### PR TITLE
fix: add onednn package to release workflow

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -302,6 +302,13 @@ jobs:
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           }
 
+          # Pack OneDNN native package
+          if (Test-Path "src/AiDotNet.Native.OneDNN/AiDotNet.Native.OneDNN.csproj") {
+            Write-Host "Packing AiDotNet.Native.OneDNN..."
+            dotnet pack src/AiDotNet.Native.OneDNN/AiDotNet.Native.OneDNN.csproj -c Release -o out --no-build /p:PackageVersion=$VERSION
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          }
+
           # Note: CUDA package is not packed in CI because native binaries (770MB) are not in git
           # CUDA package must be built and published locally with binaries present
 


### PR DESCRIPTION
## Summary
- Add OneDNN package to the automated release workflow pack step
- The package was missing from v0.3.0 release because it wasn't included in the workflow

## Test plan
- [ ] Merge triggers v0.4.0 release
- [ ] Verify AiDotNet.Native.OneDNN.0.4.0.nupkg is published to NuGet