### PR TITLE
fix(ci): restore moltenvk separately and correct semver bump types

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -102,8 +102,8 @@ jobs:
 
           # Check for fixes/refactor/perf/docs (conventional format with colon)
           if [ "$BUMP_TYPE" = "none" ] && echo "$COMMITS" | grep -iE "^[a-f0-9]+ (fix|refactor|perf|docs)(\(.*\))?:" > /dev/null; then
-            BUMP_TYPE="minor"
-            echo "Found fix:/refactor:/perf:/docs: commits - will bump MINOR version"
+            BUMP_TYPE="patch"
+            echo "Found fix:/refactor:/perf:/docs: commits - will bump PATCH version"
           fi
 
           # FALLBACK: Check for common non-conventional patterns (without colon)
@@ -113,8 +113,8 @@ jobs:
           fi
 
           if [ "$BUMP_TYPE" = "none" ] && echo "$COMMITS" | grep -iE "^[a-f0-9]+ (fix|update|improve|enhance|resolve|patch|correct|repair) " > /dev/null; then
-            BUMP_TYPE="minor"
-            echo "Found Fix/Update/Improve commits - will bump MINOR version"
+            BUMP_TYPE="patch"
+            echo "Found Fix/Update/Improve commits - will bump PATCH version"
           fi
 
           case $BUMP_TYPE in
@@ -128,6 +128,10 @@ jobs:
               MINOR=$((MINOR + 1))
               PATCH=0
               echo "Bumping MINOR: $CURRENT_VERSION -> $MAJOR.$MINOR.$PATCH"
+              ;;
+            patch)
+              PATCH=$((PATCH + 1))
+              echo "Bumping PATCH: $CURRENT_VERSION -> $MAJOR.$MINOR.$PATCH"
               ;;
             none)
               echo "No conventional commits found, no version bump"
@@ -311,6 +315,8 @@ jobs:
 
           # Pack MoltenVK native package (Vulkan on macOS via Metal translation)
           # Only pack if all required native binaries are present for both architectures
+          # Note: MoltenVK is not in the solution file, so dotnet restore/build above skips it.
+          # We must restore and build it separately before packing.
           $moltenVKProj = "src/AiDotNet.Native.MoltenVK/AiDotNet.Native.MoltenVK.csproj"
           $moltenVKFiles = @(
             "src/AiDotNet.Native.MoltenVK/runtimes/osx-arm64/native/libMoltenVK.dylib",
@@ -322,6 +328,11 @@ jobs:
           )
           $allPresent = (Test-Path $moltenVKProj) -and ($moltenVKFiles | ForEach-Object { Test-Path $_ }) -notcontains $false
           if ($allPresent) {
+            Write-Host "Restoring and building AiDotNet.Native.MoltenVK..."
+            dotnet restore $moltenVKProj
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+            dotnet build $moltenVKProj -c Release --no-restore
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
             Write-Host "Packing AiDotNet.Native.MoltenVK..."
             dotnet pack $moltenVKProj -c Release -o out --no-build /p:PackageVersion=$VERSION
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,6 +146,8 @@ jobs:
         }
 
         # MoltenVK: only pack if all required native binaries are present for both architectures
+        # Note: MoltenVK is not in the solution file, so dotnet restore/build above skips it.
+        # We must restore and build it separately before packing.
         $moltenVKProj = "src/AiDotNet.Native.MoltenVK/AiDotNet.Native.MoltenVK.csproj"
         $moltenVKFiles = @(
           "src/AiDotNet.Native.MoltenVK/runtimes/osx-arm64/native/libMoltenVK.dylib",
@@ -157,6 +159,11 @@ jobs:
         )
         $allPresent = (Test-Path $moltenVKProj) -and ($moltenVKFiles | ForEach-Object { Test-Path $_ }) -notcontains $false
         if ($allPresent) {
+          Write-Host "Restoring and building AiDotNet.Native.MoltenVK..."
+          dotnet restore $moltenVKProj
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          dotnet build $moltenVKProj --configuration Release --no-restore
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           Write-Host "Packing AiDotNet.Native.MoltenVK..."
           dotnet pack $moltenVKProj --configuration Release --no-build --output ./artifacts
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }


### PR DESCRIPTION
## Summary

- **Fix MoltenVK pack failure (NETSDK1004)**: MoltenVK is not in the solution file (`AiDotNet.Tensors.slnx`), so `dotnet restore` skips it. The `$allPresent` check passes because the `.csproj` and native binary files exist, but `dotnet pack --no-build` fails because `project.assets.json` was never generated. Fix: add explicit `dotnet restore` and `dotnet build` for MoltenVK before packing in both `build.yml` and `automated-release.yml`.
- **Fix semver version bumping**: `fix:`, `refactor:`, `perf:`, `docs:` commits were incorrectly bumping MINOR version instead of PATCH. Per semver convention, only `feat:` should bump MINOR. Added missing `patch` case to the version bump switch statement.

## Test plan

- [ ] Verify `Automated Release Pipeline` no longer fails at "Pack NuGet packages" step
- [ ] Verify `fix:` commits produce a PATCH version bump (e.g., `0.8.0` → `0.8.1`) instead of MINOR
- [ ] Verify `feat:` commits still produce a MINOR version bump
- [ ] Verify `build.yml` publish job correctly handles MoltenVK packing

🤖 Generated with [Claude Code](https://claude.com/claude-code)