### PR TITLE
fix: guard IsReferenceOrContainsReferences for net471 release build

### DIFF
--- a/src/AiDotNet.Tensors/Helpers/TensorAllocator.cs
+++ b/src/AiDotNet.Tensors/Helpers/TensorAllocator.cs
@@ -74,8 +74,12 @@ internal static class TensorAllocator
         if (pooledArray != null)
         {
             tensor.DetachPooledArray();
+#if NET5_0_OR_GREATER
             ArrayPool<T>.Shared.Return(pooledArray,
                 clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<T>());
+#else
+            ArrayPool<T>.Shared.Return(pooledArray, clearArray: true);
+#endif
         }
     }
 


### PR DESCRIPTION
## Summary
- Fixes automated release pipeline build failure on net471 TFM
- `RuntimeHelpers.IsReferenceOrContainsReferences<T>()` is .NET Core 2.0+ only, not available on .NET Framework 4.7.1
- Wraps the call with `#if NET5_0_OR_GREATER` preprocessor guard, falls back to `clearArray: true` on older TFMs
- The build.yml CI only builds net10.0 so this wasn't caught, but the release pipeline does a solution-level build across all TFMs

## Test plan
- [x] Verified `dotnet build --framework net471` passes locally
- [x] Verified `dotnet build --framework net10.0` passes locally
- [ ] CI build passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)