### PR TITLE
Add seeded CreateRandom overloads for deterministic initialization

### DIFF
--- a/src/AiDotNet.Tensors/LinearAlgebra/Matrix.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/Matrix.cs
@@ -512,6 +512,9 @@ public class Matrix<T> : MatrixBase<T>, IEnumerable<T>
     /// </remarks>
     public static Matrix<T> CreateRandom(Random random, int rows, int columns)
     {
+        if (random == null)
+            throw new ArgumentNullException(nameof(random));
+
         Matrix<T> matrix = new(rows, columns);
 
         for (int i = 0; i < rows; i++)

--- a/src/AiDotNet.Tensors/LinearAlgebra/Tensor.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/Tensor.cs
@@ -505,14 +505,15 @@ public class Tensor<T> : TensorBase<T>, IEnumerable<T>
     /// </remarks>
     public static Tensor<T> CreateRandom(Random random, params int[] dimensions)
     {
+        if (random == null)
+            throw new ArgumentNullException(nameof(random));
         if (dimensions == null || dimensions.Length == 0)
             throw new ArgumentException("Dimensions cannot be null or empty.", nameof(dimensions));
 
         var tensor = new Tensor<T>(dimensions);
         var numOps = MathHelper.GetNumericOperations<T>();
 
-        var flattenedSize = dimensions.Aggregate(1, (a, b) => a * b);
-        for (int i = 0; i < flattenedSize; i++)
+        for (int i = 0; i < tensor.Length; i++)
         {
             tensor._data[i] = numOps.FromDouble(random.NextDouble());
         }

--- a/src/AiDotNet.Tensors/LinearAlgebra/Vector.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/Vector.cs
@@ -1040,6 +1040,9 @@ public class Vector<T> : VectorBase<T>, IEnumerable<T>
     /// </remarks>
     public static Vector<T> CreateRandom(Random random, int size)
     {
+        if (random == null)
+            throw new ArgumentNullException(nameof(random));
+
         Vector<T> vector = new(size);
         for (int i = 0; i < size; i++)
         {

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/CreateRandomTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/CreateRandomTests.cs
@@ -1,0 +1,123 @@
+using System;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.LinearAlgebra;
+
+public class CreateRandomTests
+{
+    [Fact]
+    public void Vector_SameSeed_ProducesSameValues()
+    {
+        var v1 = Vector<float>.CreateRandom(new Random(42), 100);
+        var v2 = Vector<float>.CreateRandom(new Random(42), 100);
+
+        for (int i = 0; i < 100; i++)
+        {
+            Assert.Equal(v1[i], v2[i]);
+        }
+    }
+
+    [Fact]
+    public void Vector_DifferentSeeds_ProducesDifferentValues()
+    {
+        var v1 = Vector<float>.CreateRandom(new Random(42), 100);
+        var v2 = Vector<float>.CreateRandom(new Random(99), 100);
+
+        bool anyDifferent = false;
+        for (int i = 0; i < 100; i++)
+        {
+            if (v1[i] != v2[i])
+            {
+                anyDifferent = true;
+                break;
+            }
+        }
+
+        Assert.True(anyDifferent, "Vectors with different seeds should differ.");
+    }
+
+    [Fact]
+    public void Matrix_SameSeed_ProducesSameValues()
+    {
+        var m1 = Matrix<float>.CreateRandom(new Random(42), 10, 10);
+        var m2 = Matrix<float>.CreateRandom(new Random(42), 10, 10);
+
+        for (int i = 0; i < 10; i++)
+        {
+            for (int j = 0; j < 10; j++)
+            {
+                Assert.Equal(m1[i, j], m2[i, j]);
+            }
+        }
+    }
+
+    [Fact]
+    public void Matrix_DifferentSeeds_ProducesDifferentValues()
+    {
+        var m1 = Matrix<float>.CreateRandom(new Random(42), 10, 10);
+        var m2 = Matrix<float>.CreateRandom(new Random(99), 10, 10);
+
+        bool anyDifferent = false;
+        for (int i = 0; i < 10 && !anyDifferent; i++)
+        {
+            for (int j = 0; j < 10 && !anyDifferent; j++)
+            {
+                if (m1[i, j] != m2[i, j])
+                    anyDifferent = true;
+            }
+        }
+
+        Assert.True(anyDifferent, "Matrices with different seeds should differ.");
+    }
+
+    [Fact]
+    public void Tensor_SameSeed_ProducesSameValues()
+    {
+        var t1 = Tensor<float>.CreateRandom(new Random(42), 4, 5, 3);
+        var t2 = Tensor<float>.CreateRandom(new Random(42), 4, 5, 3);
+
+        for (int i = 0; i < t1.Length; i++)
+        {
+            Assert.Equal(t1[i], t2[i]);
+        }
+    }
+
+    [Fact]
+    public void Tensor_DifferentSeeds_ProducesDifferentValues()
+    {
+        var t1 = Tensor<float>.CreateRandom(new Random(42), 4, 5, 3);
+        var t2 = Tensor<float>.CreateRandom(new Random(99), 4, 5, 3);
+
+        bool anyDifferent = false;
+        for (int i = 0; i < t1.Length; i++)
+        {
+            if (t1[i] != t2[i])
+            {
+                anyDifferent = true;
+                break;
+            }
+        }
+
+        Assert.True(anyDifferent, "Tensors with different seeds should differ.");
+    }
+
+    [Fact]
+    public void Parameterless_CreateRandom_IsNonDeterministic()
+    {
+        var v1 = Vector<float>.CreateRandom(10);
+        var v2 = Vector<float>.CreateRandom(10);
+
+        bool anyDifferent = false;
+        for (int i = 0; i < 10; i++)
+        {
+            if (v1[i] != v2[i])
+            {
+                anyDifferent = true;
+                break;
+            }
+        }
+
+        Assert.True(anyDifferent, "Parameterless CreateRandom should produce different values across calls.");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `CreateRandom(Random random, ...)` overloads to `Tensor<T>`, `Matrix<T>`, and `Vector<T>`
- Existing parameterless `CreateRandom` uses cryptographic seeds (non-deterministic) — this is unchanged
- New overloads accept a `System.Random` instance so callers can pass a seeded random for reproducible results

## Motivation
Neural network weight initialization uses `Tensor<T>.CreateRandom()` which calls `RandomHelper.CreateSecureRandom()` — every call produces a unique cryptographic seed. This is correct for production but makes it impossible to create two identically-initialized networks, which is needed for:

- **Test invariants**: comparing 50 vs 200 training iterations from the same starting point
- **Reproducible experiments**: ensuring the same seed produces the same model
- **Debugging**: replaying exact weight initialization to diagnose training issues

## Usage
```csharp
// Reproducible tensor initialization
var rng = new Random(42);
var weights = Tensor<double>.CreateRandom(rng, 128, 64);
// Same seed → same values every time

// Existing behavior unchanged
var random = Tensor<double>.CreateRandom(128, 64);
// Cryptographic seed → unique every time
```

## Test plan
- [x] Build succeeds
- [ ] Existing tests still pass (no behavioral changes to existing methods)
- [ ] New overloads produce reproducible results with same seed

🤖 Generated with [Claude Code](https://claude.com/claude-code)