### PR TITLE
fix: net471 build errors — TensorShape vs int[] in tests and benchmarks

### DIFF
--- a/tests/AiDotNet.Tensors.Benchmarks/TorchSharpCpuComparisonBenchmarks.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/TorchSharpCpuComparisonBenchmarks.cs
@@ -220,7 +220,7 @@ public class TorchSharpCpuComparisonBenchmarks
         // Without this, the first benchmark iteration pays the cold-start, skewing the mean.
         if (_aiDoubleVectorA is not null)
         {
-            var warmupDbl = TensorAllocator.Rent<double>(_aiDoubleVectorA.Shape);
+            var warmupDbl = TensorAllocator.Rent<double>(_aiDoubleVectorA._shape);
             TensorPool.Return(_cpuEngine.TensorExp(warmupDbl));
             TensorPool.Return(_cpuEngine.TensorLog(warmupDbl));
             TensorPool.Return(_cpuEngine.TensorTanh(warmupDbl));
@@ -769,7 +769,7 @@ public class TorchSharpCpuComparisonBenchmarks
     public void AiDotNet_Softmax_ZeroAlloc()
     {
         if (_aiSoftmaxInput is null) throw new InvalidOperationException("Setup not called");
-        var output = TensorAllocator.Rent<float>(_aiSoftmaxInput.Shape);
+        var output = TensorAllocator.Rent<float>(_aiSoftmaxInput._shape);
         _cpuEngine.SoftmaxInto(output, _aiSoftmaxInput, axis: 1);
         TensorAllocator.Return(output);
     }
@@ -864,7 +864,7 @@ public class TorchSharpCpuComparisonBenchmarks
     {
         if (_aiNormInput is null || _aiNormGamma is null || _aiNormBeta is null)
             throw new InvalidOperationException("Setup not called");
-        var output = TensorAllocator.Rent<float>(_aiNormInput.Shape);
+        var output = TensorAllocator.Rent<float>(_aiNormInput._shape);
         _cpuEngine.GroupNormSwishInto(output, _aiNormInput, 32, _aiNormGamma, _aiNormBeta, 1e-5);
         TensorAllocator.Return(output);
     }

--- a/tests/AiDotNet.Tensors.Tests/Engines/BatchMatMulAndAttentionTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BatchMatMulAndAttentionTests.cs
@@ -23,7 +23,7 @@ public class BatchMatMulAndAttentionTests
         var result = _engine.TensorBatchMatMul(a, identity);
         var data = result.GetDataArray();
 
-        Assert.Equal(new[] { 2, 2, 2 }, result.Shape);
+        Assert.Equal(new[] { 2, 2, 2 }, result.Shape.ToArray());
         Assert.Equal(1f, data[0], 1e-5f);
         Assert.Equal(2f, data[1], 1e-5f);
         Assert.Equal(3f, data[2], 1e-5f);
@@ -136,7 +136,7 @@ public class BatchMatMulAndAttentionTests
         var b = new Tensor<float>(bData, new[] { 4, 2 });
         var result = _engine.TensorBatchMatMul(a, b);
 
-        Assert.Equal(new[] { 2, 3, 2 }, result.Shape);
+        Assert.Equal(new[] { 2, 3, 2 }, result.Shape.ToArray());
 
         var resultData = result.GetDataArray();
         for (int batch = 0; batch < 2; batch++)
@@ -196,9 +196,9 @@ public class BatchMatMulAndAttentionTests
         AssertNotUniform(dKData, "dK");
         AssertNotUniform(dVData, "dV");
 
-        Assert.Equal(Q.Shape, dQ.Shape);
-        Assert.Equal(K.Shape, dK.Shape);
-        Assert.Equal(V.Shape, dV.Shape);
+        Assert.Equal(Q.Shape.ToArray(), dQ.Shape.ToArray());
+        Assert.Equal(K.Shape.ToArray(), dK.Shape.ToArray());
+        Assert.Equal(V.Shape.ToArray(), dV.Shape.ToArray());
 
         Assert.True(dQData.Any(x => Math.Abs(x) > 1e-7f), "dQ is all zeros");
         Assert.True(dKData.Any(x => Math.Abs(x) > 1e-7f), "dK is all zeros");

--- a/tests/AiDotNet.Tensors.Tests/Engines/MathInvariantExtendedTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/MathInvariantExtendedTests.cs
@@ -22,7 +22,7 @@ public class MathInvariantExtendedTests
     private Tensor<float> RP(int[] s, int seed) { var r = new Random(seed); var d = new float[s.Aggregate(1, (a, b) => a * b)]; for (int i = 0; i < d.Length; i++) d[i] = (float)(r.NextDouble() * 9.9 + 0.1); return new Tensor<float>(d, s); }
     private Tensor<float> C(float v, int n) => new(Enumerable.Repeat(v, n).ToArray(), new[] { n });
     private Tensor<float> C(float v, int[] s) => new(Enumerable.Repeat(v, s.Aggregate(1, (a, b) => a * b)).ToArray(), s);
-    private void AE(Tensor<float> a, Tensor<float> b, float t = 1e-4f, string m = "") { Assert.Equal(a.Shape, b.Shape); var ad = a.GetDataArray(); var bd = b.GetDataArray(); for (int i = 0; i < a.Length; i++) Assert.True(Math.Abs(ad[i] - bd[i]) < t, $"{m} [{i}]: {ad[i]} vs {bd[i]}"); }
+    private void AE(Tensor<float> a, Tensor<float> b, float t = 1e-4f, string m = "") { Assert.Equal(a.Shape.ToArray(), b.Shape.ToArray()); var ad = a.GetDataArray(); var bd = b.GetDataArray(); for (int i = 0; i < a.Length; i++) Assert.True(Math.Abs(ad[i] - bd[i]) < t, $"{m} [{i}]: {ad[i]} vs {bd[i]}"); }
     private void AZ(Tensor<float> a, string m = "") { var d = a.GetDataArray(); for (int i = 0; i < a.Length; i++) Assert.True(Math.Abs(d[i]) < Tol, $"{m} [{i}]={d[i]}"); }
     private void AR(Tensor<float> t, float lo, float hi, string m) { var d = t.GetDataArray(); for (int i = 0; i < t.Length; i++) Assert.True(d[i] >= lo && d[i] <= hi, $"{m} [{i}]={d[i]}"); }
 
@@ -61,7 +61,7 @@ public class MathInvariantExtendedTests
     // ================================================================
     // TensorBroadcastSubtract (2)
     // ================================================================
-    [Fact] public void BroadcastSubtract_Shape() => Assert.Equal(new[] { 4, 8 }, E.TensorBroadcastSubtract(R([4, 8], 1), R([1, 8], 2)).Shape);
+    [Fact] public void BroadcastSubtract_Shape() => Assert.Equal(new[] { 4, 8 }, E.TensorBroadcastSubtract(R([4, 8], 1), R([1, 8], 2)).Shape.ToArray());
     [Fact] public void BroadcastSubtract_SameAsManualExpand() { var a = R([1, 8], 1); var b = R([1, 8], 2); float[] aRow = a.GetDataArray(); float[] bRow = b.GetDataArray(); float[] aExp = Enumerable.Concat(Enumerable.Concat(aRow, aRow), Enumerable.Concat(aRow, aRow)).ToArray(); float[] bExp = Enumerable.Concat(Enumerable.Concat(bRow, bRow), Enumerable.Concat(bRow, bRow)).ToArray(); var result = E.TensorBroadcastSubtract(new Tensor<float>(aExp, [4, 8]), new Tensor<float>(bExp, [4, 8])); var broadcast = E.TensorBroadcastSubtract(new Tensor<float>(aExp, [4, 8]), b); AE(result, broadcast, 1e-3f); }
 
     // ================================================================
@@ -87,12 +87,12 @@ public class MathInvariantExtendedTests
     // ================================================================
     // TensorConcatenate / TensorStack / TensorSplit / TensorUnstack (6)
     // ================================================================
-    [Fact] public void Concatenate_AxisZero_Shape() { var a = R([4, 8], 1); var b = R([3, 8], 2); Assert.Equal(new[] { 7, 8 }, E.TensorConcatenate(new[] { a, b }, 0).Shape); }
-    [Fact] public void Concatenate_SplitInverse() { var a = R([6, 8], 1); var c = E.TensorConcatenate(new[] { a }, 0); Assert.Equal(a.Shape, c.Shape); }
-    [Fact] public void Stack_AddsAxis() { var a = R([4, 8], 1); var b = R([4, 8], 2); Assert.Equal(new[] { 2, 4, 8 }, E.TensorStack(new[] { a, b }, 0).Shape); }
-    [Fact] public void Unstack_InverseOfStack() { var a = R([4, 8], 1); var b = R([4, 8], 2); var stacked = E.TensorStack(new[] { a, b }, 0); var unstacked = E.TensorUnstack(stacked, 0); Assert.Equal(2, unstacked.Length); Assert.Equal(new[] { 4, 8 }, unstacked[0].Shape); }
+    [Fact] public void Concatenate_AxisZero_Shape() { var a = R([4, 8], 1); var b = R([3, 8], 2); Assert.Equal(new[] { 7, 8 }, E.TensorConcatenate(new[] { a, b }, 0).Shape.ToArray()); }
+    [Fact] public void Concatenate_SplitInverse() { var a = R([6, 8], 1); var c = E.TensorConcatenate(new[] { a }, 0); Assert.Equal(a.Shape.ToArray(), c.Shape.ToArray()); }
+    [Fact] public void Stack_AddsAxis() { var a = R([4, 8], 1); var b = R([4, 8], 2); Assert.Equal(new[] { 2, 4, 8 }, E.TensorStack(new[] { a, b }, 0).Shape.ToArray()); }
+    [Fact] public void Unstack_InverseOfStack() { var a = R([4, 8], 1); var b = R([4, 8], 2); var stacked = E.TensorStack(new[] { a, b }, 0); var unstacked = E.TensorUnstack(stacked, 0); Assert.Equal(2, unstacked.Length); Assert.Equal(new[] { 4, 8 }, unstacked[0].Shape.ToArray()); }
     [Fact] public void Split_NumParts() { var x = R([6, 8], 1); var parts = E.TensorSplit(x, 3, 0); Assert.Equal(3, parts.Length); }
-    [Fact] public void Split_PartShape() { var x = R([6, 8], 1); var parts = E.TensorSplit(x, 3, 0); Assert.Equal(new[] { 2, 8 }, parts[0].Shape); }
+    [Fact] public void Split_PartShape() { var x = R([6, 8], 1); var parts = E.TensorSplit(x, 3, 0); Assert.Equal(new[] { 2, 8 }, parts[0].Shape.ToArray()); }
 
     // ================================================================
     // TensorCopy / TensorFill (3)
@@ -105,28 +105,28 @@ public class MathInvariantExtendedTests
     // TensorDiagonal (2)
     // ================================================================
     [Fact] public void Diagonal_ExtractsDiag() { var mat = new Tensor<float>(new float[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 }, [3, 3]); var d = E.TensorDiagonal(mat).GetDataArray(); Assert.Equal(1f, d[0], Tol); Assert.Equal(5f, d[1], Tol); Assert.Equal(9f, d[2], Tol); }
-    [Fact] public void Diagonal_Shape() { var mat = R([4, 4], 1); Assert.Equal(new[] { 4 }, E.TensorDiagonal(mat).Shape); }
+    [Fact] public void Diagonal_Shape() { var mat = R([4, 4], 1); Assert.Equal(new[] { 4 }, E.TensorDiagonal(mat).Shape.ToArray()); }
 
     // ================================================================
     // TensorDropoutMask (2)
     // ================================================================
-    [Fact] public void DropoutMask_ShapeCorrect() => Assert.Equal(new[] { 4, 8 }, E.TensorDropoutMask<float>(new[] { 4, 8 }, 0.3f, 1.0f / 0.7f, 42).Shape);
+    [Fact] public void DropoutMask_ShapeCorrect() => Assert.Equal(new[] { 4, 8 }, E.TensorDropoutMask<float>(new[] { 4, 8 }, 0.3f, 1.0f / 0.7f, 42).Shape.ToArray());
     [Fact] public void DropoutMask_ValuesInRange() { var t = E.TensorDropoutMask<float>(new[] { 256 }, 0.5f, 2f, 99); var m = t.GetDataArray(); for (int i = 0; i < t.Length; i++) Assert.True(m[i] == 0f || Math.Abs(m[i] - 2f) < Tol, $"mask[{i}]={m[i]}"); }
 
     // ================================================================
     // TensorExpandDims / TensorSqueeze (3)
     // ================================================================
-    [Fact] public void ExpandDims_AddsOne() { var x = R([4, 8], 1); Assert.Equal(new[] { 4, 1, 8 }, E.TensorExpandDims(x, 1).Shape); }
-    [Fact] public void Squeeze_RemovesOne() { var x = R([4, 1, 8], 1); Assert.Equal(new[] { 4, 8 }, E.TensorSqueeze(x, 1).Shape); }
+    [Fact] public void ExpandDims_AddsOne() { var x = R([4, 8], 1); Assert.Equal(new[] { 4, 1, 8 }, E.TensorExpandDims(x, 1).Shape.ToArray()); }
+    [Fact] public void Squeeze_RemovesOne() { var x = R([4, 1, 8], 1); Assert.Equal(new[] { 4, 8 }, E.TensorSqueeze(x, 1).Shape.ToArray()); }
     [Fact] public void ExpandSqueeze_Inverse() { var x = R([4, 8], 1); AE(E.TensorSqueeze(E.TensorExpandDims(x, 1), 1), x); }
 
     // ================================================================
     // TensorGather / TensorIndexSelect / TensorScatter / TensorScatterAdd (4)
     // ================================================================
-    [Fact] public void Gather_Shape() { var src = R([10, 4], 1); var idx = new Tensor<int>(new[] { 0, 2, 5 }, new[] { 3 }); Assert.Equal(new[] { 3, 4 }, E.TensorGather(src, idx, 0).Shape); }
+    [Fact] public void Gather_Shape() { var src = R([10, 4], 1); var idx = new Tensor<int>(new[] { 0, 2, 5 }, new[] { 3 }); Assert.Equal(new[] { 3, 4 }, E.TensorGather(src, idx, 0).Shape.ToArray()); }
     [Fact] public void Gather_KnownValues() { var src = new Tensor<float>(new float[] { 10, 20, 30, 40, 50, 60 }, [3, 2]); var idx = new Tensor<int>(new[] { 1, 2 }, new[] { 2 }); var r = E.TensorGather(src, idx, 0).GetDataArray(); Assert.Equal(30f, r[0], Tol); Assert.Equal(40f, r[1], Tol); Assert.Equal(50f, r[2], Tol); }
-    [Fact] public void IndexSelect_Shape() { var src = R([10, 4], 1); var idx = new Tensor<int>(new[] { 0, 2, 5 }, new[] { 3 }); Assert.Equal(new[] { 3, 4 }, E.TensorIndexSelect(src, idx, 0).Shape); }
-    [Fact] public void ScatterAdd_IncreasesDim() { var dst = C(0f, [5, 4]); var src = R([3, 4], 1); var idx = new Tensor<int>(new[] { 0, 2, 4 }, new[] { 3 }); var r = E.TensorScatterAdd(dst, idx, src, 0); Assert.Equal(new[] { 5, 4 }, r.Shape); }
+    [Fact] public void IndexSelect_Shape() { var src = R([10, 4], 1); var idx = new Tensor<int>(new[] { 0, 2, 5 }, new[] { 3 }); Assert.Equal(new[] { 3, 4 }, E.TensorIndexSelect(src, idx, 0).Shape.ToArray()); }
+    [Fact] public void ScatterAdd_IncreasesDim() { var dst = C(0f, [5, 4]); var src = R([3, 4], 1); var idx = new Tensor<int>(new[] { 0, 2, 4 }, new[] { 3 }); var r = E.TensorScatterAdd(dst, idx, src, 0); Assert.Equal(new[] { 5, 4 }, r.Shape.ToArray()); }
 
     // ================================================================
     // TensorLerp (3)
@@ -139,7 +139,7 @@ public class MathInvariantExtendedTests
     // TensorLogSumExp (2)
     // ================================================================
     [Fact] public void LogSumExp_GreaterThanMax() { var x = R([8, 16], 1); var lse = E.TensorLogSumExp(x, 1).GetDataArray(); var xd = x.GetDataArray(); for (int r = 0; r < 8; r++) { float maxVal = xd.Skip(r * 16).Take(16).Max(); Assert.True(lse[r] >= maxVal - Tol); } }
-    [Fact] public void LogSumExp_Shape() { var x = R([8, 16], 2); Assert.Equal(new[] { 8 }, E.TensorLogSumExp(x, 1, false).Shape); }
+    [Fact] public void LogSumExp_Shape() { var x = R([8, 16], 2); Assert.Equal(new[] { 8 }, E.TensorLogSumExp(x, 1, false).Shape.ToArray()); }
 
     // ================================================================
     // TensorMap (2)
@@ -156,7 +156,7 @@ public class MathInvariantExtendedTests
     // ================================================================
     // TensorMatMul (2D) (2)
     // ================================================================
-    [Fact] public void TensorMatMul_2D_Shape() { var a = R([3, 4], 1); var b = R([4, 5], 2); Assert.Equal(new[] { 3, 5 }, E.TensorMatMul(a, b).Shape); }
+    [Fact] public void TensorMatMul_2D_Shape() { var a = R([3, 4], 1); var b = R([4, 5], 2); Assert.Equal(new[] { 3, 5 }, E.TensorMatMul(a, b).Shape.ToArray()); }
     [Fact] public void TensorMatMul_KnownValue() { var a = new Tensor<float>(new float[] { 1, 2, 3, 4 }, [2, 2]); var b = new Tensor<float>(new float[] { 1, 0, 0, 1 }, [2, 2]); AE(E.TensorMatMul(a, b), a); }
 
     // ================================================================
@@ -171,25 +171,25 @@ public class MathInvariantExtendedTests
     // TensorNormalize (2)
     // ================================================================
     [Fact] public void Normalize_L2UnitNorm() { var x = R([1, 64], 1); var n = E.TensorNormalize(x, 1, 1e-8f); var d = n.GetDataArray(); float norm = (float)Math.Sqrt(d.Sum(v => v * v)); Assert.True(Math.Abs(norm - 1f) < 1e-3f); }
-    [Fact] public void Normalize_Shape() { var x = R([4, 8], 1); Assert.Equal(x.Shape, E.TensorNormalize(x, 1, 1e-8f).Shape); }
+    [Fact] public void Normalize_Shape() { var x = R([4, 8], 1); Assert.Equal(x.Shape.ToArray(), E.TensorNormalize(x, 1, 1e-8f).Shape.ToArray()); }
 
     // ================================================================
     // TensorOneHot (3)
     // ================================================================
-    [Fact] public void OneHot_Shape() { var idx = new Tensor<int>(new[] { 0, 1, 2 }, [3]); Assert.Equal(new[] { 3, 5 }, E.TensorOneHot<float>(idx, 5).Shape); }
+    [Fact] public void OneHot_Shape() { var idx = new Tensor<int>(new[] { 0, 1, 2 }, [3]); Assert.Equal(new[] { 3, 5 }, E.TensorOneHot<float>(idx, 5).Shape.ToArray()); }
     [Fact] public void OneHot_SumToOne() { var idx = new Tensor<int>(new[] { 0, 1, 2, 3 }, [4]); var r = E.TensorOneHot<float>(idx, 5).GetDataArray(); for (int i = 0; i < 4; i++) { float s = 0; for (int j = 0; j < 5; j++) s += r[i * 5 + j]; Assert.Equal(1f, s, Tol); } }
     [Fact] public void OneHot_HotIsAtIndex() { var idx = new Tensor<int>(new[] { 2 }, [1]); var r = E.TensorOneHot<float>(idx, 4).GetDataArray(); Assert.Equal(0f, r[0], Tol); Assert.Equal(0f, r[1], Tol); Assert.Equal(1f, r[2], Tol); Assert.Equal(0f, r[3], Tol); }
 
     // ================================================================
     // TensorOuterProduct (2)
     // ================================================================
-    [Fact] public void OuterProduct_Shape() { var a = R([3], 1); var b = R([4], 2); Assert.Equal(new[] { 3, 4 }, E.TensorOuterProduct(a, b).Shape); }
+    [Fact] public void OuterProduct_Shape() { var a = R([3], 1); var b = R([4], 2); Assert.Equal(new[] { 3, 4 }, E.TensorOuterProduct(a, b).Shape.ToArray()); }
     [Fact] public void OuterProduct_KnownValue() { var a = new Tensor<float>(new float[] { 1, 2 }, [2]); var b = new Tensor<float>(new float[] { 3, 4 }, [2]); var r = E.TensorOuterProduct(a, b).GetDataArray(); Assert.Equal(3f, r[0], Tol); Assert.Equal(4f, r[1], Tol); Assert.Equal(6f, r[2], Tol); Assert.Equal(8f, r[3], Tol); }
 
     // ================================================================
     // TensorPermute (2)
     // ================================================================
-    [Fact] public void Permute_SwapAxes_Shape() { var x = R([2, 3, 4], 1); Assert.Equal(new[] { 4, 2, 3 }, E.TensorPermute(x, new[] { 2, 0, 1 }).Shape); }
+    [Fact] public void Permute_SwapAxes_Shape() { var x = R([2, 3, 4], 1); Assert.Equal(new[] { 4, 2, 3 }, E.TensorPermute(x, new[] { 2, 0, 1 }).Shape.ToArray()); }
     [Fact] public void Permute_Identity_Unchanged() { var x = R([2, 3, 4], 1); AE(E.TensorPermute(x, new[] { 0, 1, 2 }), x); }
 
     // ================================================================
@@ -201,30 +201,30 @@ public class MathInvariantExtendedTests
     // ================================================================
     // TensorRandomNormal / TensorRandomUniform / TensorRandomUniformRange (4)
     // ================================================================
-    [Fact] public void RandomNormal_Shape() => Assert.Equal(new[] { 4, 8 }, E.TensorRandomNormal<float>(new[] { 4, 8 }, 0f, 1f).Shape);
+    [Fact] public void RandomNormal_Shape() => Assert.Equal(new[] { 4, 8 }, E.TensorRandomNormal<float>(new[] { 4, 8 }, 0f, 1f).Shape.ToArray());
     [Fact] public void RandomNormal_ApproxMean() { var d = E.TensorRandomNormal<float>(new[] { 1024 }, 5f, 1f).GetDataArray(); Assert.True(Math.Abs(d.Average() - 5f) < 0.2f); }
-    [Fact] public void RandomUniform_Shape() => Assert.Equal(new[] { 4, 8 }, E.TensorRandomUniform<float>(new[] { 4, 8 }).Shape);
+    [Fact] public void RandomUniform_Shape() => Assert.Equal(new[] { 4, 8 }, E.TensorRandomUniform<float>(new[] { 4, 8 }).Shape.ToArray());
     [Fact] public void RandomUniformRange_InRange() { AR(E.TensorRandomUniformRange<float>(new[] { 256 }, 2f, 5f, 42), 2f, 5f, "UniformRange"); }
 
     // ================================================================
     // TensorRepeatElements / TensorTile (3)
     // ================================================================
-    [Fact] public void RepeatElements_Shape() { var x = R([3, 4], 1); Assert.Equal(new[] { 6, 4 }, E.TensorRepeatElements(x, 2, 0).Shape); }
-    [Fact] public void Tile_Shape() { var x = R([3, 4], 1); Assert.Equal(new[] { 6, 8 }, E.TensorTile(x, new[] { 2, 2 }).Shape); }
+    [Fact] public void RepeatElements_Shape() { var x = R([3, 4], 1); Assert.Equal(new[] { 6, 4 }, E.TensorRepeatElements(x, 2, 0).Shape.ToArray()); }
+    [Fact] public void Tile_Shape() { var x = R([3, 4], 1); Assert.Equal(new[] { 6, 8 }, E.TensorTile(x, new[] { 2, 2 }).Shape.ToArray()); }
     [Fact] public void Tile_Content() { var x = new Tensor<float>(new float[] { 1, 2, 3, 4 }, [2, 2]); var t = E.TensorTile(x, new[] { 1, 2 }).GetDataArray(); Assert.Equal(1f, t[0], Tol); Assert.Equal(2f, t[1], Tol); Assert.Equal(1f, t[2], Tol); Assert.Equal(2f, t[3], Tol); }
 
     // ================================================================
     // TensorSlice / TensorSliceAxis / TensorSetSlice / TensorSetSliceAxis (4)
     // ================================================================
-    [Fact] public void Slice_Shape() { var x = R([8, 8], 1); Assert.Equal(new[] { 4, 4 }, E.TensorSlice(x, new[] { 0, 0 }, new[] { 4, 4 }).Shape); }
-    [Fact] public void SliceAxis_Shape() { var x = R([3, 4, 8], 1); Assert.Equal(new[] { 4, 8 }, E.TensorSliceAxis(x, 0, 2).Shape); }
+    [Fact] public void Slice_Shape() { var x = R([8, 8], 1); Assert.Equal(new[] { 4, 4 }, E.TensorSlice(x, new[] { 0, 0 }, new[] { 4, 4 }).Shape.ToArray()); }
+    [Fact] public void SliceAxis_Shape() { var x = R([3, 4, 8], 1); Assert.Equal(new[] { 4, 8 }, E.TensorSliceAxis(x, 0, 2).Shape.ToArray()); }
     [Fact] public void SetSlice_ModifiesDest() { var dst = C(0f, [4, 4]); var src = C(1f, [2, 2]); var r = E.TensorSetSlice(dst, src, new[] { 1, 1 }).GetDataArray(); Assert.Equal(1f, r[1 * 4 + 1], Tol); }
-    [Fact] public void SetSliceAxis_Shape() { var dst = R([3, 4, 8], 1); var src = R([4, 8], 2); E.TensorSetSliceAxis(dst, src, 0, 1); Assert.Equal(new[] { 3, 4, 8 }, dst.Shape); }
+    [Fact] public void SetSliceAxis_Shape() { var dst = R([3, 4, 8], 1); var src = R([4, 8], 2); E.TensorSetSliceAxis(dst, src, 0, 1); Assert.Equal(new[] { 3, 4, 8 }, dst.Shape.ToArray()); }
 
     // ================================================================
     // TensorSoftmaxBackward (2)
     // ================================================================
-    [Fact] public void SoftmaxBackward_Shape() { var sm = E.TensorSoftmax(R([4, 8], 1), -1); var grad = R([4, 8], 2); Assert.Equal(sm.Shape, E.TensorSoftmaxBackward(sm, grad, -1).Shape); }
+    [Fact] public void SoftmaxBackward_Shape() { var sm = E.TensorSoftmax(R([4, 8], 1), -1); var grad = R([4, 8], 2); Assert.Equal(sm.Shape.ToArray(), E.TensorSoftmaxBackward(sm, grad, -1).Shape.ToArray()); }
     [Fact] public void SoftmaxBackward_GradSumsNearZero() { var sm = E.TensorSoftmax(R([1, 8], 1), -1); var grad = C(1f, [1, 8]); var back = E.TensorSoftmaxBackward(sm, grad, -1).GetDataArray(); float s = back.Sum(); Assert.True(Math.Abs(s) < 1e-3f, $"grad sum={s}"); }
 
     // ================================================================
@@ -232,68 +232,68 @@ public class MathInvariantExtendedTests
     // ================================================================
     [Fact] public void Where_AllTrue_IsX() { var x = R([64], 1); var y = R([64], 2); var mask = new Tensor<Bit>(Enumerable.Repeat(Bit.True, 64).ToArray(), [64]); AE(E.TensorWhere(mask, x, y), x); }
     [Fact] public void Where_AllFalse_IsY() { var x = R([64], 1); var y = R([64], 2); var mask = new Tensor<Bit>(Enumerable.Repeat(Bit.False, 64).ToArray(), [64]); AE(E.TensorWhere(mask, x, y), y); }
-    [Fact] public void Where_Shape() { var x = R([4, 8], 1); var y = R([4, 8], 2); var mask = new Tensor<Bit>(Enumerable.Repeat(Bit.True, 32).ToArray(), [4, 8]); Assert.Equal(x.Shape, E.TensorWhere(mask, x, y).Shape); }
+    [Fact] public void Where_Shape() { var x = R([4, 8], 1); var y = R([4, 8], 2); var mask = new Tensor<Bit>(Enumerable.Repeat(Bit.True, 32).ToArray(), [4, 8]); Assert.Equal(x.Shape.ToArray(), E.TensorWhere(mask, x, y).Shape.ToArray()); }
 
     // ================================================================
     // TensorTopK (2)
     // ================================================================
-    [Fact] public void TopK_Shape() { var x = R([4, 8], 1); var r = E.TensorTopK(x, 3, 1, out _); Assert.Equal(new[] { 4, 3 }, r.Shape); }
-    [Fact] public void TopK_IndicesShape() { var x = R([4, 8], 1); E.TensorTopK(x, 3, 1, out var idx); Assert.Equal(new[] { 4, 3 }, idx.Shape); }
+    [Fact] public void TopK_Shape() { var x = R([4, 8], 1); var r = E.TensorTopK(x, 3, 1, out _); Assert.Equal(new[] { 4, 3 }, r.Shape.ToArray()); }
+    [Fact] public void TopK_IndicesShape() { var x = R([4, 8], 1); E.TensorTopK(x, 3, 1, out var idx); Assert.Equal(new[] { 4, 3 }, idx.Shape.ToArray()); }
 
     // ================================================================
     // SoftmaxBackward (via Softmax method) (2)
     // ================================================================
-    [Fact] public void SoftmaxBackward_Consistent() { var sm = E.Softmax(R([2, 8], 1), -1); var grad = R([2, 8], 2); Assert.Equal(sm.Shape, E.SoftmaxBackward(grad, sm, -1).Shape); }
+    [Fact] public void SoftmaxBackward_Consistent() { var sm = E.Softmax(R([2, 8], 1), -1); var grad = R([2, 8], 2); Assert.Equal(sm.Shape.ToArray(), E.SoftmaxBackward(grad, sm, -1).Shape.ToArray()); }
     [Fact] public void SoftmaxBackward_NonZero() { var sm = E.Softmax(R([2, 8], 1), -1); var grad = R([2, 8], 2); var back = E.SoftmaxBackward(grad, sm, -1); Assert.True(back.GetDataArray().Any(v => Math.Abs(v) > 1e-7f)); }
 
     // ================================================================
     // GroupNorm (3)
     // ================================================================
-    [Fact] public void GroupNorm_Shape() { var x = R([2, 4, 4, 4], 1); var gamma = C(1f, 4); var beta = C(0f, 4); Assert.Equal(x.Shape, E.GroupNorm(x, 2, gamma, beta, 1e-5, out _, out _).Shape); }
+    [Fact] public void GroupNorm_Shape() { var x = R([2, 4, 4, 4], 1); var gamma = C(1f, 4); var beta = C(0f, 4); Assert.Equal(x.Shape.ToArray(), E.GroupNorm(x, 2, gamma, beta, 1e-5, out _, out _).Shape.ToArray()); }
     [Fact] public void GroupNorm_ZeroMean() { var x = R([2, 4, 4, 4], 1); var gamma = C(1f, 4); var beta = C(0f, 4); var r = E.GroupNorm(x, 2, gamma, beta, 1e-5, out _, out _).GetDataArray(); float sum = r.Sum(); Assert.True(Math.Abs(sum / r.Length) < 0.1f); }
     [Fact] public void GroupNorm_UnitVariance() { var x = R([2, 4, 8, 8], 1); var gamma = C(1f, 4); var beta = C(0f, 4); E.GroupNorm(x, 4, gamma, beta, 1e-5, out var mean, out var variance); var vd = variance.GetDataArray(); for (int i = 0; i < vd.Length; i++) Assert.True(vd[i] > 0f, $"variance[{i}]={vd[i]}"); }
 
     // ================================================================
     // InstanceNorm (2)
     // ================================================================
-    [Fact] public void InstanceNorm_Shape() { var x = R([2, 4, 4, 4], 1); var gamma = C(1f, 4); var beta = C(0f, 4); Assert.Equal(x.Shape, E.InstanceNorm(x, gamma, beta, 1e-5, out _, out _).Shape); }
-    [Fact] public void InstanceNorm_ZeroMean() { var x = R([2, 4, 4, 4], 1); var gamma = C(1f, 4); var beta = C(0f, 4); var r = E.InstanceNorm(x, gamma, beta, 1e-5, out _, out _); E.InstanceNorm(x, gamma, beta, 1e-5, out var mean, out _); Assert.Equal(new[] { 2, 4 }, mean.Shape); }
+    [Fact] public void InstanceNorm_Shape() { var x = R([2, 4, 4, 4], 1); var gamma = C(1f, 4); var beta = C(0f, 4); Assert.Equal(x.Shape.ToArray(), E.InstanceNorm(x, gamma, beta, 1e-5, out _, out _).Shape.ToArray()); }
+    [Fact] public void InstanceNorm_ZeroMean() { var x = R([2, 4, 4, 4], 1); var gamma = C(1f, 4); var beta = C(0f, 4); var r = E.InstanceNorm(x, gamma, beta, 1e-5, out _, out _); E.InstanceNorm(x, gamma, beta, 1e-5, out var mean, out _); Assert.Equal(new[] { 2, 4 }, mean.Shape.ToArray()); }
 
     // ================================================================
     // RMSNorm (3)
     // ================================================================
-    [Fact] public void RMSNorm_Shape() { var x = R([2, 16], 1); var gamma = C(1f, 16); Assert.Equal(x.Shape, E.RMSNorm(x, gamma, 1e-8, out _).Shape); }
+    [Fact] public void RMSNorm_Shape() { var x = R([2, 16], 1); var gamma = C(1f, 16); Assert.Equal(x.Shape.ToArray(), E.RMSNorm(x, gamma, 1e-8, out _).Shape.ToArray()); }
     [Fact] public void RMSNorm_GammaTwo_ScalesOutput() { var x = R([2, 16], 1); var g1 = C(1f, 16); var g2 = C(2f, 16); var r1 = E.RMSNorm(x, g1, 1e-8, out _); var r2 = E.RMSNorm(x, g2, 1e-8, out _); AE(E.TensorMultiplyScalar(r1, 2f), r2, 1e-3f); }
     [Fact] public void RMSNorm_RmsPositive() { var x = R([2, 16], 1); var gamma = C(1f, 16); E.RMSNorm(x, gamma, 1e-8, out var rms); var rd = rms.GetDataArray(); for (int i = 0; i < rd.Length; i++) Assert.True(rd[i] > 0f); }
 
     // ================================================================
     // ReduceMax (2)
     // ================================================================
-    [Fact] public void ReduceMax_Shape() { var x = R([4, 8], 1); Assert.Equal(new[] { 4 }, E.ReduceMax(x, new[] { 1 }, false, out _).Shape); }
+    [Fact] public void ReduceMax_Shape() { var x = R([4, 8], 1); Assert.Equal(new[] { 4 }, E.ReduceMax(x, new[] { 1 }, false, out _).Shape.ToArray()); }
     [Fact] public void ReduceMax_GreaterAll() { var x = R([4, 8], 1); var maxTensor = E.ReduceMax(x, new[] { 1 }, false, out _).GetDataArray(); var xd = x.GetDataArray(); for (int r = 0; r < 4; r++) for (int c = 0; c < 8; c++) Assert.True(maxTensor[r] >= xd[r * 8 + c] - Tol); }
 
     // ================================================================
     // ReduceMean (2)
     // ================================================================
-    [Fact] public void ReduceMean_Shape() { var x = R([4, 8], 1); Assert.Equal(new[] { 4 }, E.ReduceMean(x, new[] { 1 }, false).Shape); }
+    [Fact] public void ReduceMean_Shape() { var x = R([4, 8], 1); Assert.Equal(new[] { 4 }, E.ReduceMean(x, new[] { 1 }, false).Shape.ToArray()); }
     [Fact] public void ReduceMean_CorrectValue() { var x = C(3f, [4, 8]); var m = E.ReduceMean(x, new[] { 1 }, false).GetDataArray(); for (int i = 0; i < 4; i++) Assert.Equal(3f, m[i], Tol); }
 
     // ================================================================
     // ReduceVariance (2)
     // ================================================================
-    [Fact] public void ReduceVariance_Shape() { var x = R([4, 8], 1); Assert.Equal(new[] { 4 }, E.ReduceVariance(x, new[] { 1 }, false).Shape); }
+    [Fact] public void ReduceVariance_Shape() { var x = R([4, 8], 1); Assert.Equal(new[] { 4 }, E.ReduceVariance(x, new[] { 1 }, false).Shape.ToArray()); }
     [Fact] public void ReduceVariance_Nonneg() { var x = R([4, 8], 1); var vd = E.ReduceVariance(x, new[] { 1 }, false).GetDataArray(); for (int i = 0; i < 4; i++) Assert.True(vd[i] >= 0f); }
 
     // ================================================================
     // ReduceLogVariance (2)
     // ================================================================
-    [Fact] public void ReduceLogVariance_Shape() { var x = R([4, 8], 1); Assert.Equal(new[] { 4 }, E.ReduceLogVariance(x, new[] { 1 }, false).Shape); }
+    [Fact] public void ReduceLogVariance_Shape() { var x = R([4, 8], 1); Assert.Equal(new[] { 4 }, E.ReduceLogVariance(x, new[] { 1 }, false).Shape.ToArray()); }
     [Fact] public void ReduceLogVariance_LEVariance() { var x = R([4, 8], 2); var v = E.ReduceVariance(x, new[] { 1 }, false).GetDataArray(); var lv = E.ReduceLogVariance(x, new[] { 1 }, false).GetDataArray(); for (int i = 0; i < 4; i++) Assert.True(lv[i] <= v[i] + 0.1f, $"lv[{i}]={lv[i]} v[{i}]={v[i]}"); }
 
     // ================================================================
     // ReduceStd (2)
     // ================================================================
-    [Fact] public void ReduceStd_Shape() { var x = R([4, 8], 1); Assert.Equal(new[] { 4 }, E.ReduceStd(x, new[] { 1 }, false).Shape); }
+    [Fact] public void ReduceStd_Shape() { var x = R([4, 8], 1); Assert.Equal(new[] { 4 }, E.ReduceStd(x, new[] { 1 }, false).Shape.ToArray()); }
     [Fact] public void ReduceStd_SqrtOfVariance() { var x = R([4, 8], 2); var std = E.ReduceStd(x, new[] { 1 }, false).GetDataArray(); var vr = E.ReduceVariance(x, new[] { 1 }, false).GetDataArray(); for (int i = 0; i < 4; i++) Assert.True(Math.Abs(std[i] - Math.Sqrt(vr[i])) < 1e-3f); }
 
     // ================================================================
@@ -304,15 +304,15 @@ public class MathInvariantExtendedTests
     [Fact] public void TanhBackward_InRange() { var output = E.TensorTanh(R([64], 1)); var grad = C(1f, 64); var back = E.TanhBackward(grad, output).GetDataArray(); for (int i = 0; i < back.Length; i++) Assert.True(back[i] >= 0f && back[i] <= 1.01f); }
     [Fact] public void GeluBackward_NonZeroForPositive() { var input = C(1f, [1, 4]); var grad = C(1f, [1, 4]); var back = E.GeluBackward(grad, input).GetDataArray(); Assert.True(back.All(v => v > 0f)); }
     [Fact] public void LeakyReluBackward_Negative() { var input = new Tensor<float>(new float[] { -1f, -2f, 3f, 4f }, [4]); var grad = C(1f, 4); var back = E.LeakyReluBackward(grad, input, 0.1).GetDataArray(); Assert.Equal(0.1f, back[0], 1e-3f); Assert.Equal(1f, back[2], Tol); }
-    [Fact] public void ReluBackward_Shape() { var x = R([2, 8], 1); Assert.Equal(x.Shape, E.ReluBackward(C(1f, [2, 8]), x).Shape); }
+    [Fact] public void ReluBackward_Shape() { var x = R([2, 8], 1); Assert.Equal(x.Shape.ToArray(), E.ReluBackward(C(1f, [2, 8]), x).Shape.ToArray()); }
 
     // ================================================================
     // Gated activation backward (GLUBackward, GeGLUBackward, SwiGLUBackward, ReGLUBackward) (4)
     // ================================================================
-    [Fact] public void GLUBackward_Shape() { var inp = R([4, 16], 1); var gradOut = R([4, 8], 2); Assert.Equal(inp.Shape, E.GLUBackward(gradOut, inp, -1).Shape); }
-    [Fact] public void GeGLUBackward_Shape() { var inp = R([4, 16], 1); var gradOut = R([4, 8], 2); Assert.Equal(inp.Shape, E.GeGLUBackward(gradOut, inp, -1).Shape); }
-    [Fact] public void SwiGLUBackward_Shape() { var inp = R([4, 16], 1); var gradOut = R([4, 8], 2); Assert.Equal(inp.Shape, E.SwiGLUBackward(gradOut, inp, -1).Shape); }
-    [Fact] public void ReGLUBackward_Shape() { var inp = R([4, 16], 1); var gradOut = R([4, 8], 2); Assert.Equal(inp.Shape, E.ReGLUBackward(gradOut, inp, -1).Shape); }
+    [Fact] public void GLUBackward_Shape() { var inp = R([4, 16], 1); var gradOut = R([4, 8], 2); Assert.Equal(inp.Shape.ToArray(), E.GLUBackward(gradOut, inp, -1).Shape.ToArray()); }
+    [Fact] public void GeGLUBackward_Shape() { var inp = R([4, 16], 1); var gradOut = R([4, 8], 2); Assert.Equal(inp.Shape.ToArray(), E.GeGLUBackward(gradOut, inp, -1).Shape.ToArray()); }
+    [Fact] public void SwiGLUBackward_Shape() { var inp = R([4, 16], 1); var gradOut = R([4, 8], 2); Assert.Equal(inp.Shape.ToArray(), E.SwiGLUBackward(gradOut, inp, -1).Shape.ToArray()); }
+    [Fact] public void ReGLUBackward_Shape() { var inp = R([4, 16], 1); var gradOut = R([4, 8], 2); Assert.Equal(inp.Shape.ToArray(), E.ReGLUBackward(gradOut, inp, -1).Shape.ToArray()); }
 
     // ================================================================
     // Sparsemax / TaylorSoftmax / SphericalSoftmax / GumbelSoftmax (6)
@@ -327,10 +327,10 @@ public class MathInvariantExtendedTests
     // ================================================================
     // GlobalAvgPool2D / GlobalMaxPool2D / AdaptiveAvgPool2D (4)
     // ================================================================
-    [Fact] public void GlobalAvgPool_Shape() => Assert.Equal(new[] { 2, 4, 1, 1 }, E.GlobalAvgPool2D(R([2, 4, 8, 8], 1)).Shape);
+    [Fact] public void GlobalAvgPool_Shape() => Assert.Equal(new[] { 2, 4, 1, 1 }, E.GlobalAvgPool2D(R([2, 4, 8, 8], 1)).Shape.ToArray());
     [Fact] public void GlobalAvgPool_Value() { var x = C(3f, [1, 1, 4, 4]); Assert.Equal(3f, E.GlobalAvgPool2D(x).GetDataArray()[0], Tol); }
-    [Fact] public void GlobalMaxPool_Shape() => Assert.Equal(new[] { 2, 4, 1, 1 }, E.GlobalMaxPool2D(R([2, 4, 8, 8], 1)).Shape);
-    [Fact] public void AdaptiveAvgPool_Shape() => Assert.Equal(new[] { 2, 4, 3, 3 }, E.AdaptiveAvgPool2D(R([2, 4, 8, 8], 1), 3, 3).Shape);
+    [Fact] public void GlobalMaxPool_Shape() => Assert.Equal(new[] { 2, 4, 1, 1 }, E.GlobalMaxPool2D(R([2, 4, 8, 8], 1)).Shape.ToArray());
+    [Fact] public void AdaptiveAvgPool_Shape() => Assert.Equal(new[] { 2, 4, 3, 3 }, E.AdaptiveAvgPool2D(R([2, 4, 8, 8], 1), 3, 3).Shape.ToArray());
 
     // ================================================================
     // CrossEntropyLoss / MseLoss (4)
@@ -350,7 +350,7 @@ public class MathInvariantExtendedTests
     // ================================================================
     // Upsample (2)
     // ================================================================
-    [Fact] public void Upsample_Shape() => Assert.Equal(new[] { 1, 1, 8, 8 }, E.Upsample(R([1, 1, 4, 4], 1), 2, 2).Shape);
+    [Fact] public void Upsample_Shape() => Assert.Equal(new[] { 1, 1, 8, 8 }, E.Upsample(R([1, 1, 4, 4], 1), 2, 2).Shape.ToArray());
     [Fact] public void Upsample_ValueReplicated() { var x = new Tensor<float>(new float[] { 1, 2, 3, 4 }, [1, 1, 2, 2]); var u = E.Upsample(x, 2, 2).GetDataArray(); Assert.Equal(1f, u[0], Tol); Assert.Equal(1f, u[1], Tol); Assert.Equal(2f, u[2], Tol); }
 
     // ================================================================
@@ -377,13 +377,13 @@ public class MathInvariantExtendedTests
     // MatMulInto (2)
     // ================================================================
     [Fact] public void MatMulInto_MatchesMatMul() { var a = R([3, 4], 1); var b = R([4, 5], 2); var dest = new Tensor<float>(new float[15], [3, 5]); E.MatMulInto(dest, a, b); AE(dest, E.TensorMatMul(a, b), 1e-3f); }
-    [Fact] public void MatMulInto_Shape() { var a = R([4, 8], 1); var b = R([8, 4], 2); var dest = new Tensor<float>(new float[16], [4, 4]); E.MatMulInto(dest, a, b); Assert.Equal(new[] { 4, 4 }, dest.Shape); }
+    [Fact] public void MatMulInto_Shape() { var a = R([4, 8], 1); var b = R([8, 4], 2); var dest = new Tensor<float>(new float[16], [4, 4]); E.MatMulInto(dest, a, b); Assert.Equal(new[] { 4, 4 }, dest.Shape.ToArray()); }
 
     // ================================================================
     // ConcatInto / TransposeInto / SoftmaxInto / LogSoftmaxInto (4)
     // ================================================================
     [Fact] public void ConcatInto_MatchesConcatenate() { var a = R([3, 4], 1); var b = R([3, 4], 2); var dest = new Tensor<float>(new float[24], [6, 4]); E.ConcatInto(dest, new[] { a, b }, 0); AE(dest, E.TensorConcatenate(new[] { a, b }, 0)); }
-    [Fact] public void TransposeInto_Shape() { var x = R([3, 4], 1); var dest = new Tensor<float>(new float[12], [4, 3]); E.TransposeInto(dest, x, new[] { 1, 0 }); Assert.Equal(new[] { 4, 3 }, dest.Shape); }
+    [Fact] public void TransposeInto_Shape() { var x = R([3, 4], 1); var dest = new Tensor<float>(new float[12], [4, 3]); E.TransposeInto(dest, x, new[] { 1, 0 }); Assert.Equal(new[] { 4, 3 }, dest.Shape.ToArray()); }
     [Fact] public void SoftmaxInto_SumsToOne() { var x = R([2, 8], 1); var dest = new Tensor<float>(new float[16], [2, 8]); E.SoftmaxInto(dest, x, -1); var d = dest.GetDataArray(); for (int r = 0; r < 2; r++) { float s = 0; for (int j = 0; j < 8; j++) s += d[r * 8 + j]; Assert.True(Math.Abs(s - 1f) < 1e-3f); } }
     [Fact] public void LogSoftmaxInto_Consistent() { var x = R([2, 8], 1); var dest = new Tensor<float>(new float[16], [2, 8]); E.LogSoftmaxInto(dest, x, -1); AE(dest, E.TensorLogSoftmax(x, -1), 1e-3f); }
 
@@ -391,13 +391,13 @@ public class MathInvariantExtendedTests
     // TensorCumSum extended (2)
     // ================================================================
     [Fact] public void CumSum_Monotone_ForPositive() { var x = RP([16], 1); var cs = E.TensorCumSum(x, 0).GetDataArray(); for (int i = 1; i < cs.Length; i++) Assert.True(cs[i] >= cs[i - 1] - Tol); }
-    [Fact] public void CumSum_2D_Shape() { var x = R([4, 8], 1); Assert.Equal(x.Shape, E.TensorCumSum(x, 1).Shape); }
+    [Fact] public void CumSum_2D_Shape() { var x = R([4, 8], 1); Assert.Equal(x.Shape.ToArray(), E.TensorCumSum(x, 1).Shape.ToArray()); }
 
     // ================================================================
     // TensorArgMin (2)
     // ================================================================
     [Fact] public void ArgMin_MatchesMin() { var x = R([4, 8], 1); var idx = E.TensorArgMin(x, 0); var xd = x.GetDataArray(); var id = idx.GetDataArray(); for (int j = 0; j < 8; j++) { float expectedMin = 0; for (int i = 0; i < 4; i++) expectedMin = i == 0 ? xd[i * 8 + j] : Math.Min(expectedMin, xd[i * 8 + j]); Assert.Equal(expectedMin, xd[(int)id[j] * 8 + j], Tol); } }
-    [Fact] public void ArgMin_Shape() { var x = R([4, 8], 1); Assert.Equal(new[] { 8 }, E.TensorArgMin(x, 0).Shape); }
+    [Fact] public void ArgMin_Shape() { var x = R([4, 8], 1); Assert.Equal(new[] { 8 }, E.TensorArgMin(x, 0).Shape.ToArray()); }
 
     // ================================================================
     // PositionalEncoding (2)
@@ -420,7 +420,7 @@ public class MathInvariantExtendedTests
     // ================================================================
     // TensorBinaryDE / BCEBackward (2)
     // ================================================================
-    [Fact] public void BCE_BackwardShape() { var pred = new Tensor<float>(new float[] { 0.7f, 0.3f }, [2]); var tgt = new Tensor<float>(new float[] { 1f, 0f }, [2]); Assert.Equal(pred.Shape, E.TensorBinaryCrossEntropyBackward(pred, tgt, 1e-7f).Shape); }
+    [Fact] public void BCE_BackwardShape() { var pred = new Tensor<float>(new float[] { 0.7f, 0.3f }, [2]); var tgt = new Tensor<float>(new float[] { 1f, 0f }, [2]); Assert.Equal(pred.Shape.ToArray(), E.TensorBinaryCrossEntropyBackward(pred, tgt, 1e-7f).Shape.ToArray()); }
     [Fact] public void BCE_BackwardSign() { var pred = new Tensor<float>(new float[] { 0.8f }, [1]); var tgt = new Tensor<float>(new float[] { 1f }, [1]); var g = E.TensorBinaryCrossEntropyBackward(pred, tgt, 1e-7f).GetDataArray()[0]; Assert.True(g < 0f, $"grad={g}"); }
 
     // ================================================================
@@ -428,7 +428,7 @@ public class MathInvariantExtendedTests
     // ================================================================
     [Fact] public void Dropout_Training_HasZeros() { var x = C(1f, 256); var r = E.Dropout(x, 0.5, true, out _).GetDataArray(); Assert.True(r.Count(v => v == 0f) > 0); }
     [Fact] public void Dropout_Inference_Unchanged() { var x = R([64], 1); AE(E.Dropout(x, 0.5, false, out _), x); }
-    [Fact] public void Dropout_MaskShape() { var x = R([4, 8], 1); E.Dropout(x, 0.3, true, out var mask); Assert.Equal(x.Shape, mask.Shape); }
+    [Fact] public void Dropout_MaskShape() { var x = R([4, 8], 1); E.Dropout(x, 0.3, true, out var mask); Assert.Equal(x.Shape.ToArray(), mask.Shape.ToArray()); }
 
     // ================================================================
     // LeakyReLUInPlace / LeakyReLUInto (2)
@@ -454,7 +454,7 @@ public class MathInvariantExtendedTests
         var aT = aOrig.Transpose(new[] { 0, 2, 1 }); // [2, 3, 4]
         var b = R([2, 4, 5], 201);
         var result = E.TensorBatchMatMul(aT, b);
-        Assert.Equal(new[] { 2, 3, 5 }, result.Shape);
+        Assert.Equal(new[] { 2, 3, 5 }, result.Shape.ToArray());
         // Verify against manual computation
         var ad = aT.GetDataArray(); var bd = b.GetDataArray(); var rd = result.GetDataArray();
         for (int bi = 0; bi < 2; bi++)
@@ -475,7 +475,7 @@ public class MathInvariantExtendedTests
         var a = R([2, 3, 4, 5], 202);
         var b = R([1, 1, 1, 5], 203);
         var result = E.TensorBroadcastMultiply(a, b);
-        Assert.Equal(new[] { 2, 3, 4, 5 }, result.Shape);
+        Assert.Equal(new[] { 2, 3, 4, 5 }, result.Shape.ToArray());
         // Verify values: each element a[i] should be multiplied by b[i % 5]
         var ad = a.GetDataArray(); var bd = b.GetDataArray(); var rd = result.GetDataArray();
         for (int i = 0; i < ad.Length; i++)
@@ -489,7 +489,7 @@ public class MathInvariantExtendedTests
         var a = R([4, 3, 5], 204);
         var b = R([4, 1, 5], 205);
         var result = E.TensorBroadcastMultiply(a, b);
-        Assert.Equal(new[] { 4, 3, 5 }, result.Shape);
+        Assert.Equal(new[] { 4, 3, 5 }, result.Shape.ToArray());
         var ad = a.GetDataArray(); var bd = b.GetDataArray(); var rd = result.GetDataArray();
         for (int i = 0; i < 4; i++)
             for (int j = 0; j < 3; j++)
@@ -519,7 +519,7 @@ public class MathInvariantExtendedTests
         var mat = flat.Reshape(4, 6); // [4, 6]
         var b = R([6, 3], 209);
         var result = E.TensorMatMul(mat, b);
-        Assert.Equal(new[] { 4, 3 }, result.Shape);
+        Assert.Equal(new[] { 4, 3 }, result.Shape.ToArray());
         // Verify manually
         var md = mat.GetDataArray(); var bd = b.GetDataArray(); var rd = result.GetDataArray();
         for (int i = 0; i < 4; i++)
@@ -538,7 +538,7 @@ public class MathInvariantExtendedTests
         var gradOutput = R([1, 16, 8, 8], 211);
         var kernelShape = new[] { 16, 3, 3, 3 };
         var dW = E.Conv2DBackwardKernel(gradOutput, input, kernelShape, new[] { 1, 1 }, new[] { 1, 1 }, new[] { 1, 1 });
-        Assert.Equal(kernelShape, dW.Shape);
+        Assert.Equal(kernelShape, dW.Shape.ToArray());
     }
 
     // ================================================================
@@ -550,7 +550,7 @@ public class MathInvariantExtendedTests
         var sig = E.TensorSigmoid(x);
         var grad = R([64], 221);
         var dSig = E.SigmoidBackward(sig, grad);
-        Assert.Equal(new[] { 64 }, dSig.Shape);
+        Assert.Equal(new[] { 64 }, dSig.Shape.ToArray());
         // Result should be non-zero since grad is non-zero
         Assert.True(dSig.GetDataArray().Any(v => Math.Abs(v) > 1e-7f), "SigmoidBackward all zeros");
     }
@@ -561,7 +561,7 @@ public class MathInvariantExtendedTests
         var th = E.TensorTanh(x);
         var grad = R([64], 223);
         var dTanh = E.TanhBackward(th, grad);
-        Assert.Equal(new[] { 64 }, dTanh.Shape);
+        Assert.Equal(new[] { 64 }, dTanh.Shape.ToArray());
         Assert.True(dTanh.GetDataArray().Any(v => Math.Abs(v) > 1e-7f), "TanhBackward all zeros");
     }
 
@@ -580,14 +580,14 @@ public class MathInvariantExtendedTests
         var sm = E.Softmax(x, -1);
         var grad = R([4, 16], 223);
         var dSm = E.SoftmaxBackward(sm, grad, -1);
-        Assert.Equal(new[] { 4, 16 }, dSm.Shape);
+        Assert.Equal(new[] { 4, 16 }, dSm.Shape.ToArray());
     }
 
     [Fact] public void ReduceMax_MatchesTensorMax()
     {
         var x = R([4, 8], 224);
         var rmax = E.ReduceMax(x, new[] { 1 }, false, out _);
-        Assert.Equal(new[] { 4 }, rmax.Shape);
+        Assert.Equal(new[] { 4 }, rmax.Shape.ToArray());
         var xd = x.GetDataArray(); var rd = rmax.GetDataArray();
         for (int i = 0; i < 4; i++)
         {
@@ -611,7 +611,7 @@ public class MathInvariantExtendedTests
         var x = R([2, 8, 4, 4], 226);
         var g = C(1f, 8); var b = C(0f, 8);
         var r = E.GroupNorm(x, 4, new Tensor<float>(g.GetDataArray(), [8]), new Tensor<float>(b.GetDataArray(), [8]), 1e-5, out _, out _);
-        Assert.Equal(new[] { 2, 8, 4, 4 }, r.Shape);
+        Assert.Equal(new[] { 2, 8, 4, 4 }, r.Shape.ToArray());
     }
 
     [Fact] public void InstanceNorm_ShapePreserved()
@@ -619,6 +619,6 @@ public class MathInvariantExtendedTests
         var x = R([2, 4, 8, 8], 227);
         var g = C(1f, 4); var b = C(0f, 4);
         var r = E.InstanceNorm(x, new Tensor<float>(g.GetDataArray(), [4]), new Tensor<float>(b.GetDataArray(), [4]), 1e-5, out _, out _);
-        Assert.Equal(new[] { 2, 4, 8, 8 }, r.Shape);
+        Assert.Equal(new[] { 2, 4, 8, 8 }, r.Shape.ToArray());
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/MathInvariantTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/MathInvariantTests.cs
@@ -30,7 +30,7 @@ public class MathInvariantTests
     private Tensor<float> C(float v, int n) => Const(v, n); // shorthand alias
 
     /// <summary>Asserts two tensors are element-wise close within tolerance.</summary>
-    private void AssertClose(Tensor<float> a, Tensor<float> b, float tol = 1e-4f, string msg = "") { Assert.Equal(a.Shape, b.Shape); var ad = a.GetDataArray(); var bd = b.GetDataArray(); for (int i = 0; i < a.Length; i++) Assert.True(Math.Abs(ad[i] - bd[i]) < tol, $"{msg} [{i}]: {ad[i]} vs {bd[i]}"); }
+    private void AssertClose(Tensor<float> a, Tensor<float> b, float tol = 1e-4f, string msg = "") { Assert.Equal(a.Shape.ToArray(), b.Shape.ToArray()); var ad = a.GetDataArray(); var bd = b.GetDataArray(); for (int i = 0; i < a.Length; i++) Assert.True(Math.Abs(ad[i] - bd[i]) < tol, $"{msg} [{i}]: {ad[i]} vs {bd[i]}"); }
     private void AE(Tensor<float> a, Tensor<float> b, float t = 1e-4f, string m = "") => AssertClose(a, b, t, m); // shorthand alias
 
     /// <summary>Asserts all elements are near zero.</summary>
@@ -50,7 +50,7 @@ public class MathInvariantTests
     [Fact] public void Add_Inverse() => AZ(E.TensorAdd(R([64], 1), E.TensorMultiplyScalar(R([64], 1), -1f)));
     [Fact] public void AddScalar_Correct() { var a = R([64], 1); var r = E.TensorAddScalar(a, 5f); var ad = a.GetDataArray(); var rd = r.GetDataArray(); for (int i = 0; i < 64; i++) Assert.Equal(ad[i] + 5f, rd[i], Tol); }
     [Fact] public void Add_LargeArray() => Assert.Equal(10000, E.TensorAdd(R([10000], 1), R([10000], 2)).Length);
-    [Fact] public void BroadcastAdd_Shape() => Assert.Equal(new[] { 4, 8 }, E.TensorBroadcastAdd(R([4, 8], 1), R([1, 8], 2)).Shape);
+    [Fact] public void BroadcastAdd_Shape() => Assert.Equal(new[] { 4, 8 }, E.TensorBroadcastAdd(R([4, 8], 1), R([1, 8], 2)).Shape.ToArray());
     [Fact] public void AddInPlace_Modifies() { var a = R([64], 1); var b = R([64], 2); var orig = (float[])a.GetDataArray().Clone(); E.TensorAddInPlace(a, b); var ad = a.GetDataArray(); var bd = b.GetDataArray(); for (int i = 0; i < 64; i++) Assert.Equal(orig[i] + bd[i], ad[i], Tol); }
 
     // ================================================================
@@ -69,7 +69,7 @@ public class MathInvariantTests
     [Fact] public void Multiply_Zero() => AZ(E.TensorMultiplyScalar(R([64], 1), 0f));
     [Fact] public void Multiply_Negate() => AE(E.TensorMultiplyScalar(R([64], 1), -1f), E.TensorNegate(R([64], 1)));
     [Fact] public void Distributive() { var a = R([64], 1); var b = R([64], 2); var c = R([64], 3); AE(E.TensorMultiply(a, E.TensorAdd(b, c)), E.TensorAdd(E.TensorMultiply(a, b), E.TensorMultiply(a, c)), 1e-3f); }
-    [Fact] public void BroadcastMultiply_Shape() => Assert.Equal(new[] { 4, 8 }, E.TensorBroadcastMultiply(R([4, 8], 1), R([1, 8], 2)).Shape);
+    [Fact] public void BroadcastMultiply_Shape() => Assert.Equal(new[] { 4, 8 }, E.TensorBroadcastMultiply(R([4, 8], 1), R([1, 8], 2)).Shape.ToArray());
 
     // ================================================================
     // DIVISION (4)
@@ -77,7 +77,7 @@ public class MathInvariantTests
     [Fact] public void Divide_BySelf() { var a = RP([64], 1); var r = E.TensorDivide(a, a).GetDataArray(); for (int i = 0; i < 64; i++) Assert.Equal(1f, r[i], 1e-3f); }
     [Fact] public void DivideScalar_IsMultiplyInverse() => AE(E.TensorDivideScalar(R([64], 1), 2f), E.TensorMultiplyScalar(R([64], 1), 0.5f), 1e-3f);
     [Fact] public void Divide_ByOne() => AE(E.TensorDivideScalar(R([64], 1), 1f), R([64], 1));
-    [Fact] public void BroadcastDivide_Shape() => Assert.Equal(new[] { 4, 8 }, E.TensorBroadcastDivide(R([4, 8], 1), RP([1, 8], 2)).Shape);
+    [Fact] public void BroadcastDivide_Shape() => Assert.Equal(new[] { 4, 8 }, E.TensorBroadcastDivide(R([4, 8], 1), RP([1, 8], 2)).Shape.ToArray());
 
     // ================================================================
     // UNARY MATH (12)
@@ -158,7 +158,7 @@ public class MathInvariantTests
     [Fact] public void Max_GreaterAll() { var x = R([64], 53); float mx = E.TensorMaxValue(x); var d = x.GetDataArray(); for (int i = 0; i < 64; i++) Assert.True(mx >= d[i] - Tol); }
     [Fact] public void Min_LessAll() { var x = R([64], 54); float mn = E.TensorMinValue(x); var d = x.GetDataArray(); for (int i = 0; i < 64; i++) Assert.True(mn <= d[i] + Tol); }
     [Fact] public void ArgMax_MatchesMax() { var x = R([64], 55); var idx = E.TensorArgMax(x, 0); Assert.Equal(E.TensorMaxValue(x), x.GetDataArray()[(int)idx.GetDataArray()[0]], Tol); }
-    [Fact] public void ReduceSum_Axis() { var x = R([4, 8], 56); var r = E.ReduceSum(x, new[] { 1 }, false); Assert.Equal(new[] { 4 }, r.Shape); var xd = x.GetDataArray(); var rd = r.GetDataArray(); for (int i = 0; i < 4; i++) { float s = 0; for (int j = 0; j < 8; j++) s += xd[i * 8 + j]; Assert.True(Math.Abs(rd[i] - s) < 0.01f); } }
+    [Fact] public void ReduceSum_Axis() { var x = R([4, 8], 56); var r = E.ReduceSum(x, new[] { 1 }, false); Assert.Equal(new[] { 4 }, r.Shape.ToArray()); var xd = x.GetDataArray(); var rd = r.GetDataArray(); for (int i = 0; i < 4; i++) { float s = 0; for (int j = 0; j < 8; j++) s += xd[i * 8 + j]; Assert.True(Math.Abs(rd[i] - s) < 0.01f); } }
     [Fact] public void SumOfSquares_NonNeg() => Assert.True(E.TensorSumOfSquares(R([64], 57)) >= 0f);
 
     // ================================================================
@@ -180,8 +180,8 @@ public class MathInvariantTests
     [Fact] public void Linspace_EvenSpacing() { var d = E.TensorLinspace(0f, 1f, 5).GetDataArray(); for (int i = 1; i < 5; i++) Assert.True(Math.Abs((d[i] - d[i - 1]) - 0.25f) < Tol); }
     [Fact] public void Diag_Correct() { var d = E.TensorDiag(new Tensor<float>(new float[] { 1, 2, 3 }, [3])).GetDataArray(); Assert.Equal(1f, d[0], Tol); Assert.Equal(0f, d[1], Tol); Assert.Equal(2f, d[4], Tol); Assert.Equal(3f, d[8], Tol); }
     [Fact] public void CumSum_LastEqualsSum() { var x = R([32], 91); var cs = E.TensorCumSum(x, 0).GetDataArray(); Assert.True(Math.Abs(cs[31] - E.TensorSum(x)) < 1e-2f); }
-    [Fact] public void Outer_Correct() { var r = E.TensorOuter(new Tensor<float>(new float[] { 1, 2, 3 }, [3]), new Tensor<float>(new float[] { 4, 5 }, [2])); Assert.Equal(new[] { 3, 2 }, r.Shape); Assert.Equal(4f, r.GetDataArray()[0], Tol); Assert.Equal(10f, r.GetDataArray()[3], Tol); }
-    [Fact] public void TriangularMask_Shape() => Assert.Equal(new[] { 4, 4 }, E.TensorTriangularMask<float>(4, true, 0).Shape);
+    [Fact] public void Outer_Correct() { var r = E.TensorOuter(new Tensor<float>(new float[] { 1, 2, 3 }, [3]), new Tensor<float>(new float[] { 4, 5 }, [2])); Assert.Equal(new[] { 3, 2 }, r.Shape.ToArray()); Assert.Equal(4f, r.GetDataArray()[0], Tol); Assert.Equal(10f, r.GetDataArray()[3], Tol); }
+    [Fact] public void TriangularMask_Shape() => Assert.Equal(new[] { 4, 4 }, E.TensorTriangularMask<float>(4, true, 0).Shape.ToArray());
 
     // ================================================================
     // NORMALIZATION (4)
@@ -195,9 +195,9 @@ public class MathInvariantTests
     // CONV / POOLING (4)
     // ================================================================
     [Fact] public void Conv2D_IdentityKernel() => AE(E.Conv2D(R([1, 1, 4, 4], 80), new Tensor<float>(new float[] { 1f }, [1, 1, 1, 1]), 1, 0, 1), R([1, 1, 4, 4], 80), 1e-3f);
-    [Fact] public void Conv2D_OutputShape() => Assert.Equal(new[] { 1, 16, 8, 8 }, E.Conv2D(R([1, 3, 8, 8], 81), R([16, 3, 3, 3], 82), 1, 1, 1).Shape);
-    [Fact] public void MaxPool_Shape() => Assert.Equal(new[] { 1, 1, 2, 2 }, E.MaxPool2D(R([1, 1, 4, 4], 83), 2, 2, 0).Shape);
-    [Fact] public void AvgPool_Shape() => Assert.Equal(new[] { 1, 1, 2, 2 }, E.AvgPool2D(R([1, 1, 4, 4], 84), 2, 2, 0).Shape);
+    [Fact] public void Conv2D_OutputShape() => Assert.Equal(new[] { 1, 16, 8, 8 }, E.Conv2D(R([1, 3, 8, 8], 81), R([16, 3, 3, 3], 82), 1, 1, 1).Shape.ToArray());
+    [Fact] public void MaxPool_Shape() => Assert.Equal(new[] { 1, 1, 2, 2 }, E.MaxPool2D(R([1, 1, 4, 4], 83), 2, 2, 0).Shape.ToArray());
+    [Fact] public void AvgPool_Shape() => Assert.Equal(new[] { 1, 1, 2, 2 }, E.AvgPool2D(R([1, 1, 4, 4], 84), 2, 2, 0).Shape.ToArray());
 
     // ================================================================
     // ATTENTION (4)
@@ -211,10 +211,10 @@ public class MathInvariantTests
     // ================================================================
     // GATED ACTIVATIONS (4)
     // ================================================================
-    [Fact] public void GLU_HalfDim() => Assert.Equal(new[] { 4, 8 }, E.GLU(R([4, 16], 100), -1).Shape);
-    [Fact] public void GeGLU_HalfDim() => Assert.Equal(new[] { 4, 8 }, E.GeGLU(R([4, 16], 101), -1).Shape);
-    [Fact] public void SwiGLU_HalfDim() => Assert.Equal(new[] { 4, 8 }, E.SwiGLU(R([4, 16], 102), -1).Shape);
-    [Fact] public void ReGLU_HalfDim() => Assert.Equal(new[] { 4, 8 }, E.ReGLU(R([4, 16], 103), -1).Shape);
+    [Fact] public void GLU_HalfDim() => Assert.Equal(new[] { 4, 8 }, E.GLU(R([4, 16], 100), -1).Shape.ToArray());
+    [Fact] public void GeGLU_HalfDim() => Assert.Equal(new[] { 4, 8 }, E.GeGLU(R([4, 16], 101), -1).Shape.ToArray());
+    [Fact] public void SwiGLU_HalfDim() => Assert.Equal(new[] { 4, 8 }, E.SwiGLU(R([4, 16], 102), -1).Shape.ToArray());
+    [Fact] public void ReGLU_HalfDim() => Assert.Equal(new[] { 4, 8 }, E.ReGLU(R([4, 16], 103), -1).Shape.ToArray());
 
     // ================================================================
     // LOSS / COMPARISON (4)

--- a/tests/AiDotNet.Tensors.Tests/Engines/TensorLevelOpsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/TensorLevelOpsTests.cs
@@ -556,7 +556,7 @@ public class TensorLevelOpsTests
         var output = new Tensor<double>(expected._shape);
         engine.Conv2DInto(output, input, kernel, stride: 1, padding: 1);
 
-        Assert.Equal(expected.Shape, output.Shape);
+        Assert.Equal(expected.Shape.ToArray(), output.Shape.ToArray());
         for (int i = 0; i < expected.Length; i++)
             Assert.Equal(expected[i], output[i]);
     }

--- a/tests/AiDotNet.Tensors.Tests/Engines/TensorMatMulTransposeTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/TensorMatMulTransposeTests.cs
@@ -126,7 +126,7 @@ public class TensorMatMulTransposeTests
         var doubleTransposed = engine.TensorTranspose(transposed);
 
         // Assert
-        Assert.Equal(input.Shape, doubleTransposed.Shape);
+        Assert.Equal(input.Shape.ToArray(), doubleTransposed.Shape.ToArray());
         for (int i = 0; i < 3; i++)
             for (int j = 0; j < 4; j++)
                 Assert.Equal(input[i, j], doubleTransposed[i, j], FloatTolerance);
@@ -401,7 +401,7 @@ public class TensorMatMulTransposeTests
         var btAt = engine.TensorMatMul(bTranspose, aTranspose);
 
         // Assert
-        Assert.Equal(abTranspose.Shape, btAt.Shape);
+        Assert.Equal(abTranspose.Shape.ToArray(), btAt.Shape.ToArray());
         for (int i = 0; i < abTranspose.Shape[0]; i++)
             for (int j = 0; j < abTranspose.Shape[1]; j++)
                 Assert.Equal(abTranspose[i, j], btAt[i, j], FloatTolerance);


### PR DESCRIPTION
## Summary

**Critical fix for automated release pipeline build failure.**

The release pipeline builds all TFMs including net471, where `Assert.Equal(int[], TensorShape)` fails because xUnit on .NET Framework doesn't have implicit `ReadOnlySpan<int>` conversion.

- Fix 92 test assertions across 6 test files to use `.Shape.ToArray()` for cross-TFM compatibility
- Fix 3 benchmark sites passing `TensorShape` to `TensorAllocator.Rent<T>(int[])`

## Test plan

- [x] `dotnet build -f net471` — 0 errors
- [x] `dotnet build -f net10.0` — 0 errors  
- [x] Benchmarks build — 0 errors
- [x] 300 math invariant tests pass on net10.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)