### PR TITLE
fix: add contiguous guards to TensorMatMul entry point

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -6375,6 +6375,11 @@ public class CpuEngine : ITensorLevelEngine
         if (a.Rank < 2) throw new ArgumentException($"TensorMatMul requires tensors of rank >= 2. Got rank {a.Rank} for first tensor.");
         if (b.Rank < 2) throw new ArgumentException($"TensorMatMul requires tensors of rank >= 2. Got rank {b.Rank} for second tensor.");
 
+        // Materialize non-contiguous views so downstream paths can use .Data safely.
+        // BatchMatMul already does this for rank >= 3; TensorMatMul2D did not.
+        if (!a.IsContiguous) a = a.Contiguous();
+        if (!b.IsContiguous) b = b.Contiguous();
+
         var numOps = MathHelper.GetNumericOperations<T>();
 
         // Standard 2D x 2D case


### PR DESCRIPTION
## Summary
- `TensorMatMul2D` called `.Data` unconditionally, crashing on non-contiguous tensor views from `Transpose()`
- `BatchMatMul` was already fixed with stride-aware guards (PR #60) but `TensorMatMul` was missed
- Added `IsContiguous` checks + `Contiguous()` calls at the `TensorMatMul` entry point

## Impact
Fixes ~180 SSM/attention layer Backward test failures in AiDotNet where `Transpose()` views were passed to `Engine.TensorMatMul()`.

## Test plan
- [ ] Existing stride-aware tests pass
- [ ] AiDotNet SSM layer Backward tests no longer crash with "Cannot get contiguous Memory"

🤖 Generated with [Claude Code](https://claude.com/claude-code)