### PR TITLE
fix: Engine.TensorAdd/TensorSubtract broadcast support

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -1951,8 +1951,8 @@ public class CpuEngine : ITensorLevelEngine
         if (b == null) throw new ArgumentNullException(nameof(b));
         if (!ShapesMatch(a._shape, b._shape))
         {
-            throw new ArgumentException(
-                $"Tensor shapes must match. Got {FormatShape(a._shape)} and {FormatShape(b._shape)}.");
+            // Fall back to Tensor's BroadcastAdd which handles shape broadcasting
+            return a.BroadcastAdd(b);
         }
 
         var result = TensorAllocator.Rent<T>(a._shape);
@@ -2674,8 +2674,7 @@ public class CpuEngine : ITensorLevelEngine
         if (b == null) throw new ArgumentNullException(nameof(b));
         if (!ShapesMatch(a._shape, b._shape))
         {
-            throw new ArgumentException(
-                $"Tensor shapes must match. Got {FormatShape(a._shape)} and {FormatShape(b._shape)}.");
+            return a.BroadcastSubtract(b);
         }
 
         var result = TensorAllocator.Rent<T>(a._shape);


### PR DESCRIPTION
## Summary

When tensor shapes don't match, `TensorAdd` and `TensorSubtract` now fall back to `BroadcastAdd`/`BroadcastSubtract` instead of throwing `ArgumentException`. This matches PyTorch/NumPy behavior.

## Why this matters

**Blocks ALL 244+ diffusion models in AiDotNet.** UNet ResBlocks add time embeddings `[1,C,1,1]` to feature maps `[1,C,H,W]` via `Engine.TensorAdd`. Without broadcasting, every diffusion model fails with:
```
ArgumentException: Tensor shapes must match. Got [1, 128, 32, 32] and [1, 128, 1, 1].
```

`TensorMultiply` already had this fallback (`TensorBroadcastMultiply`). This PR adds the same pattern to Add and Subtract.

## Test plan
- [x] 1203 existing tests pass, 0 regressions
- [x] Source library builds clean on both targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)