### PR TITLE
feat: BlasProvider.SetDeterministicMode for bit-identical reproducibility

### DIFF
--- a/src/AiDotNet.Tensors/Helpers/BlasProvider.cs
+++ b/src/AiDotNet.Tensors/Helpers/BlasProvider.cs
@@ -34,22 +34,12 @@ internal static class BlasProvider
     /// </summary>
     public static void SetDeterministicMode(bool deterministic)
     {
-        if (deterministic)
+        lock (InitLock)
         {
-            ThreadCountOverride = 1;
-            if (_initialized && _setNumThreads != null)
+            ThreadCountOverride = deterministic ? 1 : ReadEnvInt("AIDOTNET_BLAS_THREADS");
+            if (_initialized)
             {
-                _setDynamic?.Invoke(0);
-                _setNumThreads(1);
-            }
-        }
-        else
-        {
-            ThreadCountOverride = ReadEnvInt("AIDOTNET_BLAS_THREADS");
-            if (_initialized && _setNumThreads != null)
-            {
-                int threads = ThreadCountOverride ?? Environment.ProcessorCount;
-                _setNumThreads(threads);
+                ApplyThreadSettings();
             }
         }
     }


### PR DESCRIPTION
## Summary

Multi-threaded BLAS (OpenBLAS, MKL) produces non-deterministic FP results due to parallel reduction ordering in GEMM. This causes models using Conv2D/MatMul to produce slightly different outputs (~1e-14) across runs with the same seed.

Added `BlasProvider.SetDeterministicMode(true)` which forces BLAS to single-threaded execution, guaranteeing bit-identical results.

## Root cause

Diffusion model determinism test failed with:
```
Expected: -107.35126911404998
Actual:   -107.35126911405004
```

Traced to `CpuEngine.Conv2DWithIm2ColDouble` → `BlasProvider.TryGemm` → OpenBLAS dgemm which uses multi-threaded reduction. Different thread scheduling = different FP accumulation order = different results at the 14th decimal.

## API

```csharp
BlasProvider.SetDeterministicMode(true);  // Force single-threaded BLAS
BlasProvider.SetDeterministicMode(false); // Restore parallel BLAS
```

The existing `AIDOTNET_BLAS_THREADS=1` env var also works but can't be set at runtime.

## Test plan
- [x] 1210 existing tests pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)