### PR TITLE
fix: add AggressiveOptimization to all hot-path tensor and matrix operations

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -2066,6 +2066,9 @@ public class CpuEngine : ITensorLevelEngine
     }
 
     /// <inheritdoc/>
+    #if !NETFRAMEWORK
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
     public unsafe Tensor<T> TensorAdd<T>(Tensor<T> a, Tensor<T> b)
     {
         if (a == null) throw new ArgumentNullException(nameof(a));
@@ -2184,6 +2187,9 @@ public class CpuEngine : ITensorLevelEngine
     /// Adds tensor b to tensor a in-place (a += b). Zero allocation.
     /// Uses parallel SIMD for large float tensors.
     /// </summary>
+    #if !NETFRAMEWORK
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
     public unsafe void TensorAddInPlace<T>(Tensor<T> a, Tensor<T> b)
     {
         if (a == null) throw new ArgumentNullException(nameof(a));
@@ -2258,6 +2264,9 @@ public class CpuEngine : ITensorLevelEngine
     /// <summary>
     /// Adds tensors a and b, storing result in destination. Zero allocation.
     /// </summary>
+    #if !NETFRAMEWORK
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
     public void TensorAddInto<T>(Tensor<T> destination, Tensor<T> a, Tensor<T> b)
     {
         if (destination == null) throw new ArgumentNullException(nameof(destination));
@@ -2697,6 +2706,9 @@ public class CpuEngine : ITensorLevelEngine
     }
 
     /// <summary>Subtract into pre-allocated destination. Zero allocation.</summary>
+    #if !NETFRAMEWORK
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
     public void TensorSubtractInto<T>(Tensor<T> destination, Tensor<T> a, Tensor<T> b)
     {
         if (!destination.IsContiguous) throw new InvalidOperationException("Output tensor must be contiguous.");
@@ -2789,6 +2801,9 @@ public class CpuEngine : ITensorLevelEngine
     }
 
     /// <inheritdoc/>
+    #if !NETFRAMEWORK
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
     public unsafe Tensor<T> TensorSubtract<T>(Tensor<T> a, Tensor<T> b)
     {
         if (a == null) throw new ArgumentNullException(nameof(a));
@@ -2866,6 +2881,9 @@ public class CpuEngine : ITensorLevelEngine
     }
 
     /// <inheritdoc/>
+    #if !NETFRAMEWORK
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
     public unsafe Tensor<T> TensorMultiply<T>(Tensor<T> a, Tensor<T> b)
     {
         if (a == null) throw new ArgumentNullException(nameof(a));
@@ -2944,6 +2962,9 @@ public class CpuEngine : ITensorLevelEngine
     /// <summary>
     /// Multiplies tensor a by tensor b in-place (a *= b). Zero allocation.
     /// </summary>
+    #if !NETFRAMEWORK
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
     public unsafe void TensorMultiplyInPlace<T>(Tensor<T> a, Tensor<T> b)
     {
         if (a == null) throw new ArgumentNullException(nameof(a));
@@ -3018,6 +3039,9 @@ public class CpuEngine : ITensorLevelEngine
     /// <summary>
     /// Multiplies tensors a and b, storing result in destination. Zero allocation.
     /// </summary>
+    #if !NETFRAMEWORK
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
     public void TensorMultiplyInto<T>(Tensor<T> destination, Tensor<T> a, Tensor<T> b)
     {
         if (destination == null) throw new ArgumentNullException(nameof(destination));
@@ -3038,6 +3062,9 @@ public class CpuEngine : ITensorLevelEngine
     /// <summary>
     /// Subtracts tensor b from tensor a in-place: a[i] -= b[i]. Zero allocation.
     /// </summary>
+    #if !NETFRAMEWORK
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
     public unsafe void TensorSubtractInPlace<T>(Tensor<T> a, Tensor<T> b)
     {
         if (a == null) throw new ArgumentNullException(nameof(a));
@@ -3100,6 +3127,9 @@ public class CpuEngine : ITensorLevelEngine
     /// Multiplies all elements of tensor a by a scalar in-place: a[i] *= scalar. Zero allocation.
     /// Uses SIMD with parallel chunking for float, vectorized numOps for all types.
     /// </summary>
+    #if !NETFRAMEWORK
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
     public unsafe void TensorMultiplyScalarInPlace<T>(Tensor<T> a, T scalar)
     {
         if (a == null) throw new ArgumentNullException(nameof(a));
@@ -3172,6 +3202,9 @@ public class CpuEngine : ITensorLevelEngine
     /// Multiplies all elements of a tensor by a scalar into a pre-allocated destination. Zero allocation.
     /// Uses SIMD with parallel chunking for float, vectorized numOps for all types.
     /// </summary>
+    #if !NETFRAMEWORK
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
     public unsafe void TensorMultiplyScalarInto<T>(Tensor<T> destination, Tensor<T> a, T scalar)
     {
         if (destination == null) throw new ArgumentNullException(nameof(destination));
@@ -3307,6 +3340,9 @@ public class CpuEngine : ITensorLevelEngine
     }
 
     /// <inheritdoc/>
+    #if !NETFRAMEWORK
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
     public unsafe Tensor<T> TensorDivide<T>(Tensor<T> a, Tensor<T> b)
     {
         if (a == null) throw new ArgumentNullException(nameof(a));
@@ -4108,6 +4144,9 @@ public class CpuEngine : ITensorLevelEngine
     }
 
     /// <inheritdoc/>
+    #if !NETFRAMEWORK
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
     public unsafe T TensorSum<T>(Tensor<T> tensor)
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
@@ -6709,6 +6748,9 @@ public class CpuEngine : ITensorLevelEngine
     }
 
     /// <inheritdoc/>
+    #if !NETFRAMEWORK
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
     public Tensor<T> TensorMatMul<T>(Tensor<T> a, Tensor<T> b)
     {
         if (a == null) throw new ArgumentNullException(nameof(a));
@@ -6749,6 +6791,9 @@ public class CpuEngine : ITensorLevelEngine
     /// Standard 2D matrix multiplication: [M, N] @ [N, P] = [M, P]
     /// Uses BLAS when available for float/double, falls back to parallel loops otherwise.
     /// </summary>
+    #if !NETFRAMEWORK
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
     private Tensor<T> TensorMatMul2D<T>(Tensor<T> a, Tensor<T> b, INumericOperations<T> numOps)
     {
         int m = a._shape[0];
@@ -6791,6 +6836,9 @@ public class CpuEngine : ITensorLevelEngine
     /// Batched matmul: [..., M, N] @ [N, P] = [..., M, P]
     /// Weights (b) are broadcasted over all batch dimensions of a.
     /// </summary>
+    #if !NETFRAMEWORK
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
     private Tensor<T> TensorMatMulBatched<T>(Tensor<T> a, Tensor<T> b, INumericOperations<T> numOps)
     {
         int aRank = a.Rank;
@@ -6860,6 +6908,9 @@ public class CpuEngine : ITensorLevelEngine
     /// Full batched matmul: [..., M, N] @ [..., N, P] = [..., M, P]
     /// Batch dimensions must match.
     /// </summary>
+    #if !NETFRAMEWORK
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
     private Tensor<T> TensorMatMulFullBatched<T>(Tensor<T> a, Tensor<T> b, INumericOperations<T> numOps)
     {
         int rank = a.Rank;
@@ -18569,6 +18620,9 @@ public class CpuEngine : ITensorLevelEngine
     #region Fused Operations
 
     /// <inheritdoc/>
+    #if !NETFRAMEWORK
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
     public Tensor<T> FusedLinear<T>(Tensor<T> input, Tensor<T> weights, Tensor<T>? bias, FusedActivationType activation)
     {
         if (input == null) throw new ArgumentNullException(nameof(input));

--- a/src/AiDotNet.Tensors/LinearAlgebra/MatrixBase.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/MatrixBase.cs
@@ -645,6 +645,9 @@ public abstract class MatrixBase<T>
     /// This is also known as the Frobenius inner product of two matrices.
     /// Both matrices must have exactly the same shape (same number of rows and columns).</para>
     /// </remarks>
+    #if !NETFRAMEWORK
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
     public virtual T ElementWiseMultiplyAndSum(MatrixBase<T> other)
     {
         if (Rows != other.Rows || Columns != other.Columns)
@@ -669,6 +672,9 @@ public abstract class MatrixBase<T>
     /// The result is a new matrix of the same size where each element is the sum of the corresponding elements
     /// from the two input matrices.</para>
     /// </remarks>
+    #if !NETFRAMEWORK
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
     public virtual MatrixBase<T> Add(MatrixBase<T> other)
     {
         if (_rows != other.Rows || _cols != other.Columns)
@@ -692,6 +698,9 @@ public abstract class MatrixBase<T>
     /// the original matrix.</para>
     /// <para><b>Performance:</b> Zero-allocation SIMD-accelerated addition.</para>
     /// </remarks>
+    #if !NETFRAMEWORK
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
     public virtual void AddInPlace(MatrixBase<T> other)
     {
         if (_rows != other.Rows || _cols != other.Columns)
@@ -781,6 +790,9 @@ public abstract class MatrixBase<T>
     /// from the two input matrices.</para>
     /// <para><b>Performance:</b> Uses SIMD-accelerated operations (5-15x faster with AVX2).</para>
     /// </remarks>
+    #if !NETFRAMEWORK
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
     public virtual MatrixBase<T> Subtract(MatrixBase<T> other)
     {
         if (_rows != other.Rows || _cols != other.Columns)
@@ -799,6 +811,9 @@ public abstract class MatrixBase<T>
     /// <remarks>
     /// <para><b>Performance:</b> Zero-allocation SIMD-accelerated subtraction.</para>
     /// </remarks>
+    #if !NETFRAMEWORK
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
     public virtual void SubtractInPlace(MatrixBase<T> other)
     {
         if (_rows != other.Rows || _cols != other.Columns)
@@ -889,6 +904,9 @@ public abstract class MatrixBase<T>
     /// <para><b>Performance:</b> Uses cache-oblivious recursive divide-and-conquer algorithm.
     /// Automatically adapts to all cache levels without manual tuning. Base case uses SIMD-accelerated dot products.</para>
     /// </remarks>
+    #if !NETFRAMEWORK
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
     public virtual MatrixBase<T> Multiply(MatrixBase<T> other)
     {
         if (_cols != other.Rows)
@@ -1047,6 +1065,9 @@ public abstract class MatrixBase<T>
     /// This operation is commonly used in machine learning to apply transformations to data points.</para>
     /// <para><b>Performance:</b> Uses vectorized dot product for each row (SIMD accelerated, 8-12x faster with AVX2).</para>
     /// </remarks>
+    #if !NETFRAMEWORK
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
     public virtual VectorBase<T> Multiply(Vector<T> vector)
     {
         if (_cols != vector.Length)
@@ -1076,6 +1097,9 @@ public abstract class MatrixBase<T>
     /// This operation is useful for scaling data or adjusting the magnitude of values in a matrix.</para>
     /// <para><b>Performance:</b> Uses SIMD-accelerated operations (5-15x faster with AVX2).</para>
     /// </remarks>
+    #if !NETFRAMEWORK
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
     public virtual MatrixBase<T> Multiply(T scalar)
     {
         var result = CreateInstance(_rows, _cols);


### PR DESCRIPTION
## Summary
- Add `[MethodImpl(MethodImplOptions.AggressiveOptimization)]` to 26 hot-path methods across CpuEngine and MatrixBase
- Guarded with `#if !NETFRAMEWORK` for net471 compatibility

## Problem
.NET tiered compilation compiles methods at tier-0 (quick, unoptimized) on first call, then recompiles at tier-1 (FMA-optimized) after repeated calls. When FMA replaces separate multiply-then-add, intermediate rounding differs at ULP level. This causes non-deterministic results across calls.

PR #67 added `AggressiveOptimization` to `TensorMatMul` but the attribute was lost during squash merge. Other hot-path operations (Add, Subtract, Multiply, etc.) were never covered.

## Impact
- Fixes flaky RNN test failures in AiDotNet (GradientFlow, DifferentInputs, Training tests)
- Ensures bit-identical results for consecutive calls with identical inputs
- No performance cost (same tier-1 code, just from first call)

## Methods covered (26 total)

**CpuEngine.cs (18):** TensorAdd/Sub/Mul/Div (+ scalar/inplace/into variants), TensorSum, TensorMatMul family (4), FusedLinear

**MatrixBase.cs (8):** Add, AddInPlace, Subtract, SubtractInPlace, Multiply (matrix/vector/scalar), ElementWiseMultiplyAndSum

## Test plan
- [x] All 1209 non-GPU tests pass
- [x] Builds on net471 and net10.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)