### PR TITLE
ci: add concurrency groups to prevent queued run pileup

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -15,7 +15,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false  # Don't cancel release in progress
+  cancel-in-progress: true  # Cancel stale release when new push to master arrives
 
 permissions:
   contents: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ master, main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true


### PR DESCRIPTION
## Summary
- Adds `concurrency` groups to both CI workflows to prevent runs from piling up in the queue
- Cancelled 48 stuck runs on ooples/AiDotNet that were blocking the user-level GitHub Actions queue

## Changes

**build.yml**: Add concurrency group with `cancel-in-progress: true`
- New pushes/PR updates automatically cancel stale queued runs for the same ref
- Prevents multiple Build and Test runs from queuing for the same PR

**automated-release.yml**: Change `cancel-in-progress` from `false` to `true`
- Only the latest push to master needs a release — intermediate versions get superseded
- Prevents stale release pipeline runs from blocking the entire queue

## Root cause
48+ workflow runs across ooples/AiDotNet and ooples/AiDotNet.Tensors were stuck in `queued` status because:
1. `build.yml` had no concurrency group — every push queued independently
2. `automated-release.yml` had `cancel-in-progress: false` — stale releases blocked new ones
3. Multiple dependabot PRs + manual PRs + master pushes all piled up simultaneously

## Test plan
- [x] Workflow YAML is valid
- [x] Concurrency group uses `workflow-ref` pattern (standard GitHub Actions pattern)
- [ ] Verify next PR push cancels the previous queued run

🤖 Generated with [Claude Code](https://claude.com/claude-code)