### PR TITLE
ci: switch all jobs from windows-latest to ubuntu-latest

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   version-and-build:
     name: Version and Build
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     outputs:
       package_version: ${{ steps.version.outputs.version }}
@@ -250,7 +250,7 @@ jobs:
 
   pack:
     name: Pack NuGet
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     needs: version-and-build
     timeout-minutes: 20
     if: needs.version-and-build.outputs.should_release == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
 
   publish:
     needs: build
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
 
     steps:


### PR DESCRIPTION
## Summary
Switches all CI jobs from `windows-latest` to `ubuntu-latest` to fix slow runner provisioning.

## Why
- Windows runners are taking 30+ minutes to provision, leaving jobs stuck in `queued`
- Ubuntu runners provision in seconds
- No Windows-specific dependencies exist in any job (dotnet CLI + pwsh are cross-platform)

## Changes
- `automated-release.yml`: Version and Build + Pack NuGet jobs -> `ubuntu-latest`
- `build.yml`: publish job -> `ubuntu-latest`

## Test plan
- [x] `pwsh` is pre-installed on GitHub ubuntu-latest runners
- [x] dotnet CLI works identically on Ubuntu
- [ ] Verify release pipeline runs to completion on Ubuntu

🤖 Generated with [Claude Code](https://claude.com/claude-code)