### PR TITLE
fix: Tensor.Reshape() propagates GradFn for gradient tape (#123)

### DIFF
--- a/src/AiDotNet.Tensors/LinearAlgebra/Tensor.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/Tensor.cs
@@ -1402,16 +1402,33 @@ public class Tensor<T> : TensorBase<T>, IEnumerable<T>
             throw new ArgumentException(
                 $"Cannot reshape tensor with {Length} elements to shape [{string.Join(", ", newShape)}] ({newTotal} elements).");
 
+        Tensor<T> result;
         if (IsContiguous)
         {
             // O(1) view: same storage, new shape, row-major strides, same offset.
             // Guaranteed zero-copy for contiguous tensors (PyTorch can't always guarantee this).
             var newStrides = ComputeRowMajorStrides(newShape);
-            return new Tensor<T>(_data, newShape, newStrides, _storageOffset, _storage);
+            result = new Tensor<T>(_data, newShape, newStrides, _storageOffset, _storage);
+        }
+        else
+        {
+            // Non-contiguous view: must materialize first, then reshape the contiguous result
+            result = Contiguous().Reshape(newShape);
         }
 
-        // Non-contiguous view: must materialize first, then reshape the contiguous result
-        return Contiguous().Reshape(newShape);
+        // Propagate gradient chain: if a GradientTape is active, set GradFn on the
+        // result so gradients flow through Reshape during backward pass.
+        // Without this, any layer using tensor.Reshape() silently breaks the gradient tape.
+        if (Engines.Autodiff.GradientTape<T>.Current != null)
+        {
+            var originalShape = _shape.ToArray();
+            result.GradFn = new Engines.Autodiff.GradNode<T>(
+                Engines.Autodiff.BackwardFunctions<T>.ReshapeBackward,
+                result, this,
+                savedState: new object[] { originalShape });
+        }
+
+        return result;
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/ReshapeGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/ReshapeGradientTests.cs
@@ -1,0 +1,110 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.LinearAlgebra;
+
+/// <summary>
+/// Integration tests proving Tensor.Reshape() propagates GradFn for gradient tape.
+/// Verifies fix for issue #123.
+/// </summary>
+public class ReshapeGradientTests
+{
+    [Fact]
+    public void Reshape_SetsGradFn_WhenTapeActive()
+    {
+        using var tape = new GradientTape<float>();
+        var original = new Tensor<float>(new float[] { 1, 2, 3, 4, 5, 6 }, new[] { 2, 3 });
+        var reshaped = original.Reshape(3, 2);
+
+        Assert.NotNull(reshaped.GradFn);
+    }
+
+    [Fact]
+    public void Reshape_NoGradFn_WhenNoTape()
+    {
+        var original = new Tensor<float>(new float[] { 1, 2, 3, 4 }, new[] { 2, 2 });
+        var reshaped = original.Reshape(4);
+
+        Assert.Null(reshaped.GradFn);
+    }
+
+    [Fact]
+    public void Reshape_GradientsFlowBackward()
+    {
+        var engine = new CpuEngine();
+
+        // weight is the parameter we want gradients for
+        var weight = new Tensor<float>(new float[] { 1, 2, 3, 4 }, new[] { 2, 2 });
+        var input = new Tensor<float>(new float[] { 1, 0, 0, 1 }, new[] { 2, 2 });
+
+        using var tape = new GradientTape<float>();
+
+        // Forward: matmul -> reshape -> sum
+        var matmulResult = engine.TensorMatMul(input, weight); // [2,2]
+        var reshaped = matmulResult.Reshape(4);                // [4] — this was breaking gradients
+        var loss = engine.ReduceSum(reshaped, new[] { 0 }, false); // scalar
+
+        var grads = tape.ComputeGradients(loss);
+
+        // Gradient must flow through reshape back to weight
+        Assert.True(grads.ContainsKey(weight),
+            "Gradient for weight must exist — Reshape must not break the gradient chain");
+        Assert.True(grads[weight].Length == 4, "Gradient shape must match weight shape");
+
+        // Verify gradient is non-zero (sum of all outputs = gradient of 1 everywhere)
+        var gradData = grads[weight].GetDataArray();
+        bool anyNonZero = false;
+        for (int i = 0; i < gradData.Length; i++)
+            if (gradData[i] != 0f) anyNonZero = true;
+        Assert.True(anyNonZero, "Gradient values must be non-zero");
+    }
+
+    [Fact]
+    public void Reshape_MultipleReshapes_GradientsFlowThrough()
+    {
+        var engine = new CpuEngine();
+        var weight = new Tensor<float>(new float[] { 1, 2, 3, 4, 5, 6 }, new[] { 2, 3 });
+
+        using var tape = new GradientTape<float>();
+
+        // Multiple reshapes in sequence
+        var r1 = weight.Reshape(3, 2);    // [3,2]
+        var r2 = r1.Reshape(6);           // [6]
+        var r3 = r2.Reshape(2, 3);        // [2,3]
+        var loss = engine.ReduceSum(r3, new[] { 0, 1 }, false);
+
+        var grads = tape.ComputeGradients(loss);
+
+        Assert.True(grads.ContainsKey(weight),
+            "Gradient must flow through multiple reshapes");
+    }
+
+    [Fact]
+    public void Reshape_3DTo2D_GradientsFlowForTraining()
+    {
+        // Simulates the common pattern: batch reshape in Forward method
+        var engine = new CpuEngine();
+        var input = new Tensor<float>(
+            new float[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 },
+            new[] { 2, 2, 3 }); // [batch=2, seq=2, features=3]
+        var weight = new Tensor<float>(
+            new float[] { 1, 0, 0, 1, 0, 0 },
+            new[] { 3, 2 }); // [features=3, output=2]
+
+        using var tape = new GradientTape<float>();
+
+        // Reshape [2,2,3] -> [4,3] for matmul (common in transformer layers)
+        var flat = input.Reshape(4, 3);
+        var output = engine.TensorMatMul(flat, weight); // [4, 2]
+        var loss = engine.ReduceSum(output, new[] { 0, 1 }, false);
+
+        var grads = tape.ComputeGradients(loss);
+
+        Assert.True(grads.ContainsKey(weight),
+            "Weight gradient must exist after reshape+matmul");
+        Assert.True(grads.ContainsKey(input),
+            "Input gradient must flow through reshape");
+    }
+}


### PR DESCRIPTION
## Summary
- Tensor.Reshape() now sets GradFn when a GradientTape is active, so gradients flow through reshape operations during backward pass
- Zero overhead when no tape active (null check only)
- Uses `!= null` for net471 compatibility

## Root Cause
`Tensor<T>.Reshape()` created a view without recording to the gradient tape. Any layer using `tensor.Reshape()` in Forward silently prevented gradients from flowing to upstream parameters — affecting 1242 call sites across the codebase.

## Test plan
- [x] 5 integration tests covering GradFn presence, gradient flow through single/multiple reshapes, and 3D->2D training pattern
- [x] All 932 existing math/operator tests pass
- [x] Builds on both net10.0 and net471

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)