### PR TITLE
feat: add native Complex<T> IEngine operations for HRE acceleration

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -27338,6 +27338,191 @@ public class CpuEngine : ITensorLevelEngine
         return result;
     }
 
+    /// <inheritdoc />
+    public Tensor<T> TensorComplexPhase<T>(Tensor<T> a)
+    {
+        if (a.Length % 2 != 0)
+            throw new ArgumentException("Complex tensors must have even length (interleaved re/im).");
+
+        var ops = MathHelper.GetNumericOperations<T>();
+        int pairs = a.Length / 2;
+        var result = new Tensor<T>([pairs]);
+
+        for (int i = 0; i < pairs; i++)
+        {
+            var re = ops.ToDouble(a[i * 2]);
+            var im = ops.ToDouble(a[i * 2 + 1]);
+            result[i] = ops.FromDouble(Math.Atan2(im, re));
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    public Tensor<T> TensorComplexFromPolar<T>(Tensor<T> magnitudes, Tensor<T> phases)
+    {
+        if (magnitudes.Length != phases.Length)
+            throw new ArgumentException("Magnitude and phase tensors must have the same length.");
+
+        var ops = MathHelper.GetNumericOperations<T>();
+        int n = magnitudes.Length;
+        var result = new Tensor<T>([n * 2]);
+
+        for (int i = 0; i < n; i++)
+        {
+            var mag = ops.ToDouble(magnitudes[i]);
+            var phase = ops.ToDouble(phases[i]);
+            result[i * 2] = ops.FromDouble(mag * Math.Cos(phase));
+            result[i * 2 + 1] = ops.FromDouble(mag * Math.Sin(phase));
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    public Vector<Complex<T>> TensorFFTNative<T>(Vector<T> input)
+    {
+        int n = input.Length;
+        var ops = MathHelper.GetNumericOperations<T>();
+        var complexOps = MathHelper.GetNumericOperations<Complex<T>>();
+
+        // Convert real input to complex
+        var data = new Vector<Complex<T>>(n);
+        for (int i = 0; i < n; i++)
+            data[i] = new Complex<T>(input[i], ops.Zero);
+
+        return FFTIterative(data, false, ops, complexOps);
+    }
+
+    /// <inheritdoc />
+    public Vector<T> TensorIFFTNative<T>(Vector<Complex<T>> input)
+    {
+        int n = input.Length;
+        var ops = MathHelper.GetNumericOperations<T>();
+        var complexOps = MathHelper.GetNumericOperations<Complex<T>>();
+
+        var result = FFTIterative(input, true, ops, complexOps);
+
+        // Extract real parts and scale by 1/N
+        var scale = ops.FromDouble(n);
+        var output = new Vector<T>(n);
+        for (int i = 0; i < n; i++)
+            output[i] = ops.Divide(result[i].Real, scale);
+
+        return output;
+    }
+
+    /// <summary>
+    /// Iterative Cooley-Tukey FFT — better cache performance than recursive version.
+    /// </summary>
+    private static Vector<Complex<T>> FFTIterative<T>(Vector<Complex<T>> input, bool inverse,
+        INumericOperations<T> ops, INumericOperations<Complex<T>> complexOps)
+    {
+        int n = input.Length;
+        var data = new Vector<Complex<T>>(n);
+        for (int i = 0; i < n; i++) data[i] = input[i];
+
+        // Bit-reversal permutation
+        int bits = (int)(Math.Log(n) / Math.Log(2));
+        for (int i = 0; i < n; i++)
+        {
+            int j = BitReverse(i, bits);
+            if (j > i)
+            {
+                (data[i], data[j]) = (data[j], data[i]);
+            }
+        }
+
+        // Butterfly operations
+        T angleSign = inverse ? ops.One : ops.Negate(ops.One);
+
+        for (int size = 2; size <= n; size *= 2)
+        {
+            int halfSize = size / 2;
+            T angle = ops.Multiply(angleSign, ops.FromDouble(2.0 * Math.PI / size));
+
+            for (int start = 0; start < n; start += size)
+            {
+                for (int k = 0; k < halfSize; k++)
+                {
+                    T theta = ops.Multiply(angle, ops.FromDouble(k));
+                    var twiddle = Complex<T>.FromPolarCoordinates(ops.One, theta);
+                    var t = complexOps.Multiply(twiddle, data[start + k + halfSize]);
+                    var u = data[start + k];
+                    data[start + k] = complexOps.Add(u, t);
+                    data[start + k + halfSize] = complexOps.Subtract(u, t);
+                }
+            }
+        }
+
+        return data;
+    }
+
+    /// <inheritdoc />
+    public Vector<Complex<T>> VectorComplexMultiply<T>(Vector<Complex<T>> a, Vector<Complex<T>> b)
+    {
+        if (a.Length != b.Length)
+            throw new ArgumentException("Vectors must have the same length.");
+
+        var ops = MathHelper.GetNumericOperations<T>();
+        var complexOps = MathHelper.GetNumericOperations<Complex<T>>();
+        int n = a.Length;
+        var result = new Vector<Complex<T>>(n);
+
+        for (int i = 0; i < n; i++)
+        {
+            result[i] = complexOps.Multiply(a[i], b[i]);
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    public Vector<Complex<T>> VectorComplexConjugate<T>(Vector<Complex<T>> a)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        int n = a.Length;
+        var result = new Vector<Complex<T>>(n);
+
+        for (int i = 0; i < n; i++)
+        {
+            result[i] = new Complex<T>(a[i].Real, ops.Negate(a[i].Imaginary));
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    public Vector<T> VectorComplexMagnitude<T>(Vector<Complex<T>> a)
+    {
+        int n = a.Length;
+        var result = new Vector<T>(n);
+
+        for (int i = 0; i < n; i++)
+        {
+            result[i] = a[i].Magnitude;
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    public Vector<T> VectorComplexPhase<T>(Vector<Complex<T>> a)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        int n = a.Length;
+        var result = new Vector<T>(n);
+
+        for (int i = 0; i < n; i++)
+        {
+            var re = ops.ToDouble(a[i].Real);
+            var im = ops.ToDouble(a[i].Imaginary);
+            result[i] = ops.FromDouble(Math.Atan2(im, re));
+        }
+
+        return result;
+    }
+
     #endregion
 
     #region CTC Loss

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -7432,6 +7432,58 @@ public interface IEngine
     /// </summary>
     Tensor<T> TensorComplexMagnitude<T>(Tensor<T> a);
 
+    /// <summary>
+    /// Complex phase extraction on interleaved real/imaginary tensors.
+    /// Computes atan2(im, re) per complex pair.
+    /// Output length is half the input length.
+    /// </summary>
+    Tensor<T> TensorComplexPhase<T>(Tensor<T> a);
+
+    /// <summary>
+    /// Constructs an interleaved complex tensor from separate magnitude and phase tensors.
+    /// Output[2k] = magnitude[k] * cos(phase[k]), Output[2k+1] = magnitude[k] * sin(phase[k]).
+    /// Output length is double the input length.
+    /// </summary>
+    Tensor<T> TensorComplexFromPolar<T>(Tensor<T> magnitudes, Tensor<T> phases);
+
+    /// <summary>
+    /// Forward FFT on a real-valued tensor using native Complex&lt;T&gt; output.
+    /// Returns Vector&lt;Complex&lt;T&gt;&gt; directly, avoiding interleaved format conversion overhead.
+    /// </summary>
+    /// <param name="input">Real-valued input signal. Length should be power of 2.</param>
+    /// <returns>Complex-valued frequency domain representation.</returns>
+    Vector<Complex<T>> TensorFFTNative<T>(Vector<T> input);
+
+    /// <summary>
+    /// Inverse FFT returning a real-valued tensor from native Complex&lt;T&gt; input.
+    /// Avoids interleaved format conversion overhead.
+    /// </summary>
+    /// <param name="input">Complex-valued frequency domain representation.</param>
+    /// <returns>Real-valued time domain signal.</returns>
+    Vector<T> TensorIFFTNative<T>(Vector<Complex<T>> input);
+
+    /// <summary>
+    /// Element-wise multiply of two Complex&lt;T&gt; vectors (spectral filtering).
+    /// H(k) * X(k) for each frequency bin k.
+    /// </summary>
+    Vector<Complex<T>> VectorComplexMultiply<T>(Vector<Complex<T>> a, Vector<Complex<T>> b);
+
+    /// <summary>
+    /// Element-wise conjugate of a Complex&lt;T&gt; vector: (re, -im) for each element.
+    /// Used in cross-spectral density computation.
+    /// </summary>
+    Vector<Complex<T>> VectorComplexConjugate<T>(Vector<Complex<T>> a);
+
+    /// <summary>
+    /// Extract magnitudes from a Complex&lt;T&gt; vector: sqrt(re^2 + im^2) for each element.
+    /// </summary>
+    Vector<T> VectorComplexMagnitude<T>(Vector<Complex<T>> a);
+
+    /// <summary>
+    /// Extract phases from a Complex&lt;T&gt; vector: atan2(im, re) for each element.
+    /// </summary>
+    Vector<T> VectorComplexPhase<T>(Vector<Complex<T>> a);
+
     #endregion
 
     #region CTC Loss


### PR DESCRIPTION
## Summary

Adds native `Complex<T>` and `Vector<Complex<T>>` operations to IEngine, eliminating conversion overhead between `Complex<T>` and interleaved `Tensor<T>` format for spectral processing.

## New Operations

### Interleaved Tensor<T> Complex Ops
- `TensorComplexPhase<T>` — extract phase angles via atan2
- `TensorComplexFromPolar<T>` — construct complex from magnitude + phase

### Native Complex<T> Vector Ops (zero-conversion)
- `TensorFFTNative<T>` — FFT returning `Vector<Complex<T>>` directly
- `TensorIFFTNative<T>` — IFFT from `Vector<Complex<T>>` directly
- `VectorComplexMultiply<T>` — element-wise `Complex<T>` multiply
- `VectorComplexConjugate<T>` — element-wise conjugate
- `VectorComplexMagnitude<T>` — extract magnitudes
- `VectorComplexPhase<T>` — extract phases

### CpuEngine Implementation
- Iterative Cooley-Tukey FFT (better cache performance than recursive)
- All ops use `MathHelper.GetNumericOperations<Complex<T>>()`
- net471 compatible

## Motivation

The Harmonic Resonance Engine (ooples/AiDotNet#1108) performs all computation in the frequency domain using `Complex<T>`. Current interleaved-format complex ops require converting at every FFT boundary, defeating the performance gains. These native ops eliminate that overhead.

Closes #127

## Test plan

- [ ] Build succeeds for net10.0 and net471
- [ ] Existing complex tensor tests still pass
- [ ] FFT round-trip: `TensorIFFTNative(TensorFFTNative(x))` recovers `x`
- [ ] `VectorComplexMultiply(a, b)` matches manual complex multiplication

🤖 Generated with [Claude Code](https://claude.com/claude-code)