### PR TITLE
feat: add SetDeterministicMode for reproducible training (Issue #131 Step 1)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/AiDotNetEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/AiDotNetEngine.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using AiDotNet.Tensors.Engines.Gpu;
+using AiDotNet.Tensors.Helpers;
 
 namespace AiDotNet.Tensors.Engines;
 
@@ -207,5 +208,55 @@ public static class AiDotNetEngine
     {
         var engine = Current;
         return $"Engine: {engine.Name}, GPU Support: {engine.SupportsGpu}";
+    }
+
+    /// <summary>
+    /// Gets whether deterministic reduction mode is currently enabled.
+    /// When true, floating-point reductions (matmul, softmax, sums) produce
+    /// bit-identical results across runs on the same hardware.
+    /// </summary>
+    public static bool DeterministicMode => BlasProvider.IsDeterministicMode;
+
+    /// <summary>
+    /// Enables or disables deterministic reduction mode for CPU tensor operations.
+    /// </summary>
+    /// <param name="deterministic">True to enable deterministic mode; false to use the default high-throughput mode.</param>
+    /// <remarks>
+    /// <para>
+    /// Multi-threaded BLAS (MKL.NET) can produce slightly different floating-point results across
+    /// runs of the same inputs because parallel reduction order is not stable — floating-point
+    /// addition is non-associative, so any variation in accumulation order produces a slightly
+    /// different final value. In long training runs, small per-step drift can compound into
+    /// observable trajectory divergence (e.g. final val-loss differences between otherwise-identical
+    /// seeded runs).
+    /// </para>
+    /// <para>
+    /// Enabling deterministic mode:
+    /// <list type="bullet">
+    ///   <item>Disables MKL.NET managed GEMM and routes matmul through the blocked fallback,
+    ///         which writes disjoint output rows per thread with fixed inner accumulation order
+    ///         (bit-exact regardless of thread count).</item>
+    ///   <item>Forces native BLAS (when loaded) to single-threaded via <c>mkl_set_num_threads(1)</c>
+    ///         and <c>mkl_set_dynamic(0)</c>.</item>
+    ///   <item>Leaves all other tensor reductions alone — <c>TensorSum</c>, <c>TensorSumOfSquares</c>,
+    ///         <c>TensorMean</c>, and <c>TensorLogSoftmax</c> are already deterministic in this engine.</item>
+    /// </list>
+    /// </para>
+    /// <para>
+    /// <b>Performance trade-off:</b> deterministic mode skips MKL's multi-threaded GEMM, which can
+    /// reduce matmul throughput for large matrices. Only enable when reproducibility is required
+    /// (tests, scientific reproducibility, paper experiments). Safe to call at any time; takes
+    /// effect on the next BLAS call.
+    /// </para>
+    /// <para>
+    /// <b>For Beginners:</b> Turn this on if you need two identical training runs to produce
+    /// identical numerical results — useful for debugging, test assertions, and research
+    /// reproducibility. Leave it off for production training where raw speed matters more than
+    /// bit-for-bit reproducibility.
+    /// </para>
+    /// </remarks>
+    public static void SetDeterministicMode(bool deterministic)
+    {
+        BlasProvider.SetDeterministicMode(deterministic);
     }
 }

--- a/src/AiDotNet.Tensors/Engines/AiDotNetEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/AiDotNetEngine.cs
@@ -233,11 +233,15 @@ public static class AiDotNetEngine
     /// <para>
     /// Enabling deterministic mode:
     /// <list type="bullet">
-    ///   <item>Disables MKL.NET managed GEMM and routes matmul through the blocked fallback,
-    ///         which writes disjoint output rows per thread with fixed inner accumulation order
-    ///         (bit-exact regardless of thread count).</item>
-    ///   <item>Forces native BLAS (when loaded) to single-threaded via <c>mkl_set_num_threads(1)</c>
-    ///         and <c>mkl_set_dynamic(0)</c>.</item>
+    ///   <item>Has <c>BlasProvider.TryGemm</c> and <c>IsMklVerified</c> short-circuit at the top,
+    ///         bypassing both MKL.NET managed GEMM and any native BLAS GEMM paths entirely.</item>
+    ///   <item>Routes matmul through the blocked C# fallback (<c>MatrixMultiplyHelper.MultiplyBlocked</c>
+    ///         for matrices, <c>CpuEngine.TensorMatMul2D</c>'s <c>Parallel.For</c> path for tensors),
+    ///         which writes disjoint output rows per thread with a fixed inner accumulation order —
+    ///         bit-exact regardless of thread count.</item>
+    ///   <item>Leaves native BLAS thread-control functions alone. Deterministic mode does <b>not</b>
+    ///         invoke <c>mkl_set_num_threads</c> or <c>mkl_set_dynamic</c>; those are only touched
+    ///         when <c>AIDOTNET_BLAS_THREADS</c> is explicitly set via env var.</item>
     ///   <item>Leaves all other tensor reductions alone — <c>TensorSum</c>, <c>TensorSumOfSquares</c>,
     ///         <c>TensorMean</c>, and <c>TensorLogSoftmax</c> are already deterministic in this engine.</item>
     /// </list>

--- a/src/AiDotNet.Tensors/Helpers/BlasProvider.cs
+++ b/src/AiDotNet.Tensors/Helpers/BlasProvider.cs
@@ -42,23 +42,36 @@ internal static class BlasProvider
     /// </summary>
     private static bool _deterministicMode;
 
+    /// <summary>
+    /// Returns whether deterministic mode is currently enabled.
+    /// </summary>
+    public static bool IsDeterministicMode => _deterministicMode;
+
+    // Saved state so that toggling deterministic mode off restores whatever MKL.NET
+    // was doing before. Null means no saved state (deterministic mode was never on
+    // or has already been turned off).
+    private static bool? _savedUseMklNet;
+
     public static void SetDeterministicMode(bool deterministic)
     {
         lock (InitLock)
         {
+            if (_deterministicMode == deterministic) return;
             _deterministicMode = deterministic;
-            ThreadCountOverride = deterministic ? 1 : ReadEnvInt("AIDOTNET_BLAS_THREADS");
+            // Deterministic mode routes all matmul through the bit-exact blocked C# fallback
+            // by having TryGemm/IsMklVerified return false at the top. We don't need to force
+            // native BLAS to single-threaded — it never gets called in deterministic mode —
+            // so we leave ThreadCountOverride alone to avoid touching native thread-control
+            // functions that can be unsafe on some platforms.
             if (deterministic)
             {
-                // Disable MKL.NET managed bindings: MKL's multi-threaded GEMM produces
-                // non-deterministic results from parallel reduction ordering, and we cannot
-                // reliably set MKL's internal thread count via the managed API.
-                // Falls back to deterministic sequential MultiplyMatrixBlocked.
+                _savedUseMklNet = _useMklNet;
                 _useMklNet = false;
             }
-            if (_initialized)
+            else if (_savedUseMklNet.HasValue)
             {
-                ApplyThreadSettings();
+                _useMklNet = _savedUseMklNet.Value;
+                _savedUseMklNet = null;
             }
         }
     }
@@ -129,6 +142,11 @@ internal static class BlasProvider
 
     internal static bool TryGemm(int m, int n, int k, float[] a, int aOffset, int lda, float[] b, int bOffset, int ldb, float[] c, int cOffset, int ldc)
     {
+        // Deterministic mode: fall through to the bit-exact blocked C# fallback in
+        // MatrixMultiplyHelper.MultiplyBlocked. Also avoids triggering native BLAS
+        // initialization, which can be unsafe on some platforms.
+        if (_deterministicMode) return false;
+
         // Hot path: after MKL is verified AND still enabled, skip all checks
         if (_mklVerified && _useMklNet)
         {
@@ -221,8 +239,10 @@ internal static class BlasProvider
     /// <summary>
     /// True after MKL has been verified working. Use IsMklVerified + MklSgemmZeroOffset
     /// to bypass TryGemm entirely when offsets are always 0 (FusedLinear hot path).
+    /// Returns false in deterministic mode so direct-MKL hot paths fall through to the
+    /// deterministic blocked matmul fallback.
     /// </summary>
-    internal static bool IsMklVerified => _mklVerified;
+    internal static bool IsMklVerified => _mklVerified && !_deterministicMode;
 
     /// <summary>
     /// Absolute fastest MKL path: zero-offset spans, no TryGemm dispatch, no validation.
@@ -291,6 +311,7 @@ internal static class BlasProvider
     /// </summary>
     internal static bool TryGemmWithBeta(int m, int n, int k, float[] a, int aOffset, int lda, float[] b, int bOffset, int ldb, float[] c, int cOffset, int ldc, float beta)
     {
+        if (_deterministicMode) return false;
         if (!EnsureInitialized()) return false;
         if (!HasEnoughData(a.Length, aOffset, m, k, lda) ||
             !HasEnoughData(b.Length, bOffset, k, n, ldb) ||
@@ -318,6 +339,7 @@ internal static class BlasProvider
     /// </summary>
     internal static bool TryGemmWithBeta(int m, int n, int k, double[] a, int aOffset, int lda, double[] b, int bOffset, int ldb, double[] c, int cOffset, int ldc, double beta)
     {
+        if (_deterministicMode) return false;
         if (!EnsureInitialized()) return false;
         if (!HasEnoughData(a.Length, aOffset, m, k, lda) ||
             !HasEnoughData(b.Length, bOffset, k, n, ldb) ||
@@ -345,6 +367,7 @@ internal static class BlasProvider
         float[] b, int bOffset, int ldb, bool transB,
         float[] c, int cOffset, int ldc)
     {
+        if (_deterministicMode) return false;
         if (!EnsureInitialized()) return false;
 
         // Bounds validation (same as TryGemm)
@@ -407,6 +430,7 @@ internal static class BlasProvider
     /// </summary>
     internal static bool TryGemm(int m, int n, int k, ReadOnlySpan<float> a, int lda, ReadOnlySpan<float> b, int ldb, Span<float> c, int ldc)
     {
+        if (_deterministicMode) return false;
         if (!EnsureInitialized())
         {
             return false;
@@ -453,6 +477,7 @@ internal static class BlasProvider
     /// </summary>
     internal static bool TryGemm(int m, int n, int k, ReadOnlySpan<double> a, int lda, ReadOnlySpan<double> b, int ldb, Span<double> c, int ldc)
     {
+        if (_deterministicMode) return false;
         if (!EnsureInitialized())
         {
             return false;
@@ -572,6 +597,9 @@ internal static class BlasProvider
     /// </summary>
     internal static bool TryGemm(int m, int n, int k, double[] a, int aOffset, int lda, double[] b, int bOffset, int ldb, double[] c, int cOffset, int ldc)
     {
+        // Deterministic mode: fall through to the bit-exact blocked C# fallback.
+        if (_deterministicMode) return false;
+
         // Hot path: skip all checks after MKL verified AND still enabled
         if (_mklVerified && _useMklNet)
         {
@@ -827,10 +855,21 @@ internal static class BlasProvider
             return;
         }
 
+        // Only invoke native thread-control functions when the caller has explicitly
+        // requested a specific thread count (env var or deterministic mode). The
+        // loaded symbols can be unsafe to call blindly on some platforms — on net10.0
+        // Windows, for example, invoking them without explicit opt-in has been seen
+        // to trigger access violations. Falling through leaves the native library at
+        // its own default thread count, which is safe.
+        if (!ThreadCountOverride.HasValue)
+        {
+            Trace("[BLAS] ApplyThreadSettings skipped — no explicit thread count requested");
+            return;
+        }
+
         try
         {
-            // Use override if specified, otherwise use all available processors
-            int threadCount = ThreadCountOverride ?? Environment.ProcessorCount;
+            int threadCount = ThreadCountOverride.Value;
             _setDynamic?.Invoke(0);
             _setNumThreads(threadCount);
             Trace($"[BLAS] Set thread count to {threadCount}");

--- a/src/AiDotNet.Tensors/Helpers/BlasProvider.cs
+++ b/src/AiDotNet.Tensors/Helpers/BlasProvider.cs
@@ -35,12 +35,14 @@ internal static class BlasProvider
     private static readonly bool TraceEnabled = ReadEnvBool("AIDOTNET_BLAS_TRACE");
 
     /// <summary>
-    /// Enables deterministic mode by forcing BLAS to single-threaded execution.
-    /// Multi-threaded BLAS (OpenBLAS, MKL) can produce slightly different FP results
-    /// across runs due to parallel reduction ordering. Single-threaded mode guarantees
-    /// bit-identical results for the same input.
+    /// When true, BLAS/MKL GEMM paths are bypassed entirely — TryGemm and
+    /// IsMklVerified return false at their top so matmul falls through to the
+    /// bit-exact blocked C# fallback. This guarantees bit-identical results
+    /// across runs regardless of thread count, since the fallback's inner
+    /// accumulation order is fixed. Volatile so that lock-free reads in the
+    /// hot TryGemm path see writes made under InitLock without stale caching.
     /// </summary>
-    private static bool _deterministicMode;
+    private static volatile bool _deterministicMode;
 
     /// <summary>
     /// Returns whether deterministic mode is currently enabled.
@@ -59,10 +61,11 @@ internal static class BlasProvider
             if (_deterministicMode == deterministic) return;
             _deterministicMode = deterministic;
             // Deterministic mode routes all matmul through the bit-exact blocked C# fallback
-            // by having TryGemm/IsMklVerified return false at the top. We don't need to force
-            // native BLAS to single-threaded — it never gets called in deterministic mode —
-            // so we leave ThreadCountOverride alone to avoid touching native thread-control
-            // functions that can be unsafe on some platforms.
+            // by having TryGemm/IsMklVerified return false at the top. It does NOT call into
+            // native thread-control functions (mkl_set_num_threads, etc.) — those paths are
+            // only triggered when AIDOTNET_BLAS_THREADS is explicitly set via env var, which
+            // drives ThreadCountOverride. ThreadCountOverride is intentionally left alone
+            // here to avoid touching native symbols that can be unsafe on some platforms.
             if (deterministic)
             {
                 _savedUseMklNet = _useMklNet;
@@ -856,11 +859,13 @@ internal static class BlasProvider
         }
 
         // Only invoke native thread-control functions when the caller has explicitly
-        // requested a specific thread count (env var or deterministic mode). The
-        // loaded symbols can be unsafe to call blindly on some platforms — on net10.0
-        // Windows, for example, invoking them without explicit opt-in has been seen
-        // to trigger access violations. Falling through leaves the native library at
-        // its own default thread count, which is safe.
+        // provided a ThreadCountOverride (set via the AIDOTNET_BLAS_THREADS env var).
+        // Deterministic mode does NOT opt in here — it bypasses BLAS entirely via
+        // the TryGemm short-circuit, so thread-control calls would be pointless.
+        // The loaded symbols can be unsafe to call blindly on some platforms — on
+        // net10.0 Windows, for example, invoking them without this explicit opt-in
+        // has been seen to trigger access violations. Falling through leaves the
+        // native library at its own default thread count, which is safe.
         if (!ThreadCountOverride.HasValue)
         {
             Trace("[BLAS] ApplyThreadSettings skipped — no explicit thread count requested");

--- a/tests/AiDotNet.Tensors.Benchmarks/DeterministicMatMulBenchmarks.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/DeterministicMatMulBenchmarks.cs
@@ -1,0 +1,158 @@
+#if NET8_0_OR_GREATER
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+namespace AiDotNet.Tensors.Benchmarks;
+
+/// <summary>
+/// A/B benchmark: MKL.NET default matmul vs the deterministic blocked C# fallback
+/// exposed by <see cref="AiDotNetEngine.SetDeterministicMode"/>.
+///
+/// Purpose: measure how competitive the bit-exact blocked path is vs MKL.NET
+/// across matmul shapes that matter for real model training — starting with the
+/// actual HRE (Harmonic Resonance Engine) hot shapes from Issue #131, and
+/// expanding out to common small/medium LLM shapes where the crossover likely
+/// sits. If the blocked path is within a reasonable margin at the shapes that
+/// matter, we can flip the deterministic default or remove MKL.NET entirely
+/// per the project's strategic direction.
+///
+/// A/B is driven by <see cref="DeterministicMode"/> (a bool param). BDN runs
+/// each benchmark twice — once with deterministic mode off (MKL.NET path) and
+/// once with it on (blocked C# fallback). Same matmul code, same tensor data,
+/// only the underlying dispatch changes.
+///
+/// Run with:
+///   dotnet run -c Release --filter DeterministicMatMul*
+/// </summary>
+[SimpleJob(RuntimeMoniker.Net10_0, launchCount: 1, warmupCount: 3, iterationCount: 10)]
+[MemoryDiagnoser]
+[MarkdownExporterAttribute.GitHub]
+public class DeterministicMatMulBenchmarks
+{
+    /// <summary>
+    /// BDN expands this to {false, true}. Each benchmark method runs twice —
+    /// once per mode — so the same shape is measured under both dispatch paths.
+    /// </summary>
+    [ParamsAllValues]
+    public bool DeterministicMode { get; set; }
+
+    private CpuEngine _engine = null!;
+
+    // ═══ HRE baseline (Issue #131 TrainingConfig defaults) ═══
+    // batch=4, seq=16, embed=32, vocab=256 → batch*seq = 64
+    // Attention-like projection: [batch*seq, embed] × [embed, embed]
+    private Tensor<float> _hre_base_attn_a = null!; // [64, 32]
+    private Tensor<float> _hre_base_attn_b = null!; // [32, 32]
+    // Output head: [batch*seq, embed] × [embed, vocab]
+    private Tensor<float> _hre_base_out_a = null!;  // [64, 32]
+    private Tensor<float> _hre_base_out_b = null!;  // [32, 256]
+
+    // ═══ HRE scaled-up (Issue #131 ScaledUp config) ═══
+    // batch=4, seq=16, embed=64, vocab=256 → batch*seq = 64
+    private Tensor<float> _hre_scaled_attn_a = null!; // [64, 64]
+    private Tensor<float> _hre_scaled_attn_b = null!; // [64, 64]
+    private Tensor<float> _hre_scaled_out_a = null!;  // [64, 64]
+    private Tensor<float> _hre_scaled_out_b = null!;  // [64, 256]
+
+    // ═══ Small LLM band: where MKL overhead may still hurt ═══
+    private Tensor<float> _small_128 = null!;  // [128, 128]
+    private Tensor<float> _small_256 = null!;  // [256, 256]
+
+    // ═══ Mid LLM band: MKL's traditional strong zone ═══
+    private Tensor<float> _mid_512 = null!;    // [512, 512]
+    private Tensor<float> _mid_1024 = null!;   // [1024, 1024]
+
+    // ═══ Large-K output head: transformer LM head over real vocab ═══
+    // batch*seq = 64, embed = 128, vocab ≈ 50257 (GPT-2)
+    private Tensor<float> _lm_head_a = null!;  // [64, 128]
+    private Tensor<float> _lm_head_b = null!;  // [128, 50257]
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new CpuEngine();
+
+        _hre_base_attn_a = Tensor<float>.CreateRandom([64, 32]);
+        _hre_base_attn_b = Tensor<float>.CreateRandom([32, 32]);
+        _hre_base_out_a  = Tensor<float>.CreateRandom([64, 32]);
+        _hre_base_out_b  = Tensor<float>.CreateRandom([32, 256]);
+
+        _hre_scaled_attn_a = Tensor<float>.CreateRandom([64, 64]);
+        _hre_scaled_attn_b = Tensor<float>.CreateRandom([64, 64]);
+        _hre_scaled_out_a  = Tensor<float>.CreateRandom([64, 64]);
+        _hre_scaled_out_b  = Tensor<float>.CreateRandom([64, 256]);
+
+        _small_128 = Tensor<float>.CreateRandom([128, 128]);
+        _small_256 = Tensor<float>.CreateRandom([256, 256]);
+
+        _mid_512  = Tensor<float>.CreateRandom([512, 512]);
+        _mid_1024 = Tensor<float>.CreateRandom([1024, 1024]);
+
+        _lm_head_a = Tensor<float>.CreateRandom([64, 128]);
+        _lm_head_b = Tensor<float>.CreateRandom([128, 50257]);
+    }
+
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        // Apply mode per iteration so BDN's {false, true} parameter split routes
+        // each benchmark through the correct dispatch path.
+        AiDotNetEngine.SetDeterministicMode(DeterministicMode);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        // Leave the engine in default mode after the benchmark run.
+        AiDotNetEngine.SetDeterministicMode(false);
+    }
+
+    // ───────────── HRE baseline (Issue #131 defaults) ─────────────
+
+    [Benchmark(Description = "HRE-base attn [64,32]×[32,32]")]
+    public Tensor<float> HRE_Baseline_Attention()
+        => _engine.TensorMatMul(_hre_base_attn_a, _hre_base_attn_b);
+
+    [Benchmark(Description = "HRE-base out-head [64,32]×[32,256]")]
+    public Tensor<float> HRE_Baseline_OutputHead()
+        => _engine.TensorMatMul(_hre_base_out_a, _hre_base_out_b);
+
+    // ───────────── HRE scaled-up ─────────────
+
+    [Benchmark(Description = "HRE-scaled attn [64,64]×[64,64]")]
+    public Tensor<float> HRE_Scaled_Attention()
+        => _engine.TensorMatMul(_hre_scaled_attn_a, _hre_scaled_attn_b);
+
+    [Benchmark(Description = "HRE-scaled out-head [64,64]×[64,256]")]
+    public Tensor<float> HRE_Scaled_OutputHead()
+        => _engine.TensorMatMul(_hre_scaled_out_a, _hre_scaled_out_b);
+
+    // ───────────── Small LLM band ─────────────
+
+    [Benchmark(Description = "Square [128,128]×[128,128]")]
+    public Tensor<float> Square_128()
+        => _engine.TensorMatMul(_small_128, _small_128);
+
+    [Benchmark(Description = "Square [256,256]×[256,256]")]
+    public Tensor<float> Square_256()
+        => _engine.TensorMatMul(_small_256, _small_256);
+
+    // ───────────── Mid LLM band ─────────────
+
+    [Benchmark(Description = "Square [512,512]×[512,512]")]
+    public Tensor<float> Square_512()
+        => _engine.TensorMatMul(_mid_512, _mid_512);
+
+    [Benchmark(Description = "Square [1024,1024]×[1024,1024]")]
+    public Tensor<float> Square_1024()
+        => _engine.TensorMatMul(_mid_1024, _mid_1024);
+
+    // ───────────── Large-K LM head (GPT-2 vocab) ─────────────
+
+    [Benchmark(Description = "LM-head [64,128]×[128,50257]")]
+    public Tensor<float> LM_Head_GPT2Vocab()
+        => _engine.TensorMatMul(_lm_head_a, _lm_head_b);
+}
+#endif

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -246,6 +246,13 @@ class Program
             return;
         }
 
+        // Run deterministic vs MKL matmul A/B benchmarks (Issue #131 Step 2, ~5-15min)
+        if (args[0] == "--vs-deterministic-matmul")
+        {
+            BenchmarkRunner.Run<DeterministicMatMulBenchmarks>(BenchConfig);
+            return;
+        }
+
         // Run TensorCodec gaps only — focused on operations still losing to PyTorch (~15min)
         if (args[0] == "--vs-tensorcodec-gaps")
         {

--- a/tests/AiDotNet.Tensors.Tests/Engines/DeterministicModeTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DeterministicModeTests.cs
@@ -1,0 +1,105 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Tests for AiDotNetEngine.SetDeterministicMode — verifies the public API surface
+/// and that enabling deterministic mode produces bit-exact reproducible results for
+/// large matmuls (the hot path that uses MKL.NET in default mode).
+/// </summary>
+public class DeterministicModeTests
+{
+    [Fact]
+    public void DeterministicMode_TogglesAndReads()
+    {
+        bool original = AiDotNetEngine.DeterministicMode;
+        try
+        {
+            AiDotNetEngine.SetDeterministicMode(true);
+            Assert.True(AiDotNetEngine.DeterministicMode);
+
+            AiDotNetEngine.SetDeterministicMode(false);
+            Assert.False(AiDotNetEngine.DeterministicMode);
+        }
+        finally
+        {
+            AiDotNetEngine.SetDeterministicMode(original);
+        }
+    }
+
+    [Fact]
+    public void DeterministicMode_MatMul_BitExactAcrossRuns()
+    {
+        bool original = AiDotNetEngine.DeterministicMode;
+        try
+        {
+            AiDotNetEngine.SetDeterministicMode(true);
+
+            // Large enough to hit the BLAS work threshold (2*128*128*128 = 4.2M, above default threshold)
+            int m = 128, k = 128, n = 128;
+            var rng = new Random(42);
+            var a = new Tensor<float>([m, k]);
+            var b = new Tensor<float>([k, n]);
+            for (int i = 0; i < m * k; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+            for (int i = 0; i < k * n; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+
+            var engine = new CpuEngine();
+            var r1 = engine.TensorMatMul(a, b);
+            var r2 = engine.TensorMatMul(a, b);
+            var r3 = engine.TensorMatMul(a, b);
+
+            // Bit-exact equality across three repeated calls
+            for (int i = 0; i < m * n; i++)
+            {
+                Assert.Equal(r1[i], r2[i]);
+                Assert.Equal(r1[i], r3[i]);
+            }
+        }
+        finally
+        {
+            AiDotNetEngine.SetDeterministicMode(original);
+        }
+    }
+
+    [Fact]
+    public void DeterministicMode_MatMul_NumericallyCloseToDefault()
+    {
+        // Sanity: deterministic and default should give the same result to reasonable FP tolerance.
+        // This catches regressions where deterministic mode accidentally computes something wrong.
+        bool original = AiDotNetEngine.DeterministicMode;
+        try
+        {
+            int m = 64, k = 64, n = 64;
+            var rng = new Random(123);
+            var a = new Tensor<float>([m, k]);
+            var b = new Tensor<float>([k, n]);
+            for (int i = 0; i < m * k; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+            for (int i = 0; i < k * n; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+
+            var engine = new CpuEngine();
+
+            AiDotNetEngine.SetDeterministicMode(false);
+            var rDefault = engine.TensorMatMul(a, b);
+
+            AiDotNetEngine.SetDeterministicMode(true);
+            var rDeterministic = engine.TensorMatMul(a, b);
+
+            for (int i = 0; i < m * n; i++)
+            {
+                // 1e-4 relative tolerance — allows for accumulation-order differences
+                // between MKL and the blocked fallback, but catches any real bugs.
+                float expected = rDefault[i];
+                float actual = rDeterministic[i];
+                float tolerance = 1e-4f * Math.Max(1f, Math.Abs(expected));
+                Assert.True(Math.Abs(expected - actual) <= tolerance,
+                    $"At index {i}: expected {expected}, got {actual}, diff {Math.Abs(expected - actual)}");
+            }
+        }
+        finally
+        {
+            AiDotNetEngine.SetDeterministicMode(original);
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/DeterministicModeTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DeterministicModeTests.cs
@@ -5,10 +5,27 @@ using Xunit;
 namespace AiDotNet.Tensors.Tests.Engines;
 
 /// <summary>
+/// Collection fixture that forces DeterministicModeTests to run sequentially and
+/// in isolation from any other test classes that share this collection. The tests
+/// mutate a process-wide static flag (AiDotNetEngine.DeterministicMode) which
+/// would otherwise race with concurrent matmul/BLAS tests under xUnit's default
+/// parallel execution. Putting all BLAS-state-mutating test classes in this
+/// collection serializes their execution with respect to each other and guarantees
+/// the flag is stable for the duration of each test method.
+/// </summary>
+[CollectionDefinition("BlasGlobalState", DisableParallelization = true)]
+public sealed class BlasGlobalStateCollection { }
+
+/// <summary>
 /// Tests for AiDotNetEngine.SetDeterministicMode — verifies the public API surface
 /// and that enabling deterministic mode produces bit-exact reproducible results for
 /// large matmuls (the hot path that uses MKL.NET in default mode).
+///
+/// Marked with [Collection("BlasGlobalState")] so these tests run serialized —
+/// they toggle a process-wide static flag that would race with concurrent BLAS
+/// calls from other parallel test classes.
 /// </summary>
+[Collection("BlasGlobalState")]
 public class DeterministicModeTests
 {
     [Fact]


### PR DESCRIPTION
Fixes #131 (Step 1 of 2).

## Summary
Exposes a public `AiDotNetEngine.SetDeterministicMode(bool)` API that toggles deterministic reduction mode for CPU tensor ops. When enabled, matmul routes through the bit-exact blocked C# fallback in `MatrixMultiplyHelper.MultiplyBlocked`, bypassing MKL.NET's multi-threaded GEMM — which the investigation in #131 identified as the only source of non-determinism in CPU reductions.

**All other float reductions are already deterministic** and need no changes:
- `TensorSum` / `TensorMean` — deterministic chunking derived from length, fixed-order accumulation
- `TensorSumOfSquares` — single-threaded SIMD
- `TensorLogSoftmax` — row-parallel, per-row work is self-contained
- `TensorAdd` / `TensorAddInPlace` — element-wise, disjoint-output chunks
- `MatMul` fallback (`Parallel.For(0, m, ...)`) and `MultiplyBlocked` — each thread writes disjoint output rows with fixed inner-loop accumulation order

## API

\`\`\`csharp
// Enable for a research/reproducibility run
AiDotNetEngine.SetDeterministicMode(true);
var loss = TrainModel(...);  // bit-identical across runs

// Check the current state
bool isDeterministic = AiDotNetEngine.DeterministicMode;

// Back to high-throughput mode
AiDotNetEngine.SetDeterministicMode(false);
\`\`\`

## Implementation
- `BlasProvider.TryGemm` (all 6 entry points) short-circuit early when `_deterministicMode` is true, which both routes matmul to the bit-exact blocked path AND prevents triggering native BLAS initialization.
- `BlasProvider.IsMklVerified` returns false in deterministic mode so the direct-MKL hot paths used by FusedLinear also fall through to the blocked fallback.
- `SetDeterministicMode` saves/restores the prior `_useMklNet` state so toggling off properly restores MKL.NET.

## Bonus fix: latent AV crash on net10.0
While writing tests I discovered an access-violation crash in `ApplyThreadSettings` on net10.0 Windows. The loaded fallback BLAS library exported symbols matching `mkl_set_num_threads` / `mkl_set_dynamic` with incompatible signatures, so calling them corrupted the stack. Normally masked because MKL.NET loads first and short-circuits the native path, but any code that disables MKL.NET could trip it.

Fix: only invoke `_setNumThreads` / `_setDynamic` when the caller has explicitly requested a thread count via `AIDOTNET_BLAS_THREADS` env var. Default path leaves the native library at its own thread count — safe on all platforms. Deterministic mode no longer forces `threads=1` either, since it routes through the pure-C# blocked path which is bit-exact regardless of thread count.

## Tests
- 3 new `DeterministicModeTests`:
  - `DeterministicMode_TogglesAndReads` — verifies the API getter/setter
  - `DeterministicMode_MatMul_BitExactAcrossRuns` — confirms bit-identical results across 3 repeated matmul calls
  - `DeterministicMode_MatMul_NumericallyCloseToDefault` — sanity check: deterministic and default paths agree to `1e-4` relative tolerance
- All 3 pass on net10.0 and net471
- Existing tests pass unchanged: `BatchMatMulAndAttentionTests` (7), `CpuEngineOperationsTests` (17), `FusedLinear` (multiple), `NativeComplexOpsTests` (28), `BackwardBufferPoolingTests`

## Step 2 (follow-up, separate PR)
Per discussion in #131, Step 2 will be proper A/B benchmarking of `MultiplyBlocked` vs MKL.NET at HRE/LLM-relevant matmul shapes, using the existing BDN harness pattern from `TensorCodecVsPyTorchBenchmarks`. If the C# blocked path is competitive at the shapes that matter, we can flip the default or remove MKL.NET entirely (per the project's strategic direction).

## Test plan
- [x] All new `DeterministicModeTests` pass on both TFMs
- [x] Bit-exactness of matmul across repeated calls verified
- [x] Numerical equivalence with default mode within 1e-4
- [x] Build clean (0 errors, 0 warnings)
- [x] BatchMatMul / CpuEngineOperations / FusedLinear / NativeComplex tests pass unchanged
- [ ] Downstream verification in HRE training run (for the original reporter to confirm val-loss becomes stable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)