### PR TITLE
bench: deterministic vs MKL matmul A/B (Issue #131 Step 2)

### DIFF
--- a/tests/AiDotNet.Tensors.Benchmarks/DeterministicMatMulBenchmarks.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/DeterministicMatMulBenchmarks.cs
@@ -1,0 +1,158 @@
+#if NET8_0_OR_GREATER
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+namespace AiDotNet.Tensors.Benchmarks;
+
+/// <summary>
+/// A/B benchmark: MKL.NET default matmul vs the deterministic blocked C# fallback
+/// exposed by <see cref="AiDotNetEngine.SetDeterministicMode"/>.
+///
+/// Purpose: measure how competitive the bit-exact blocked path is vs MKL.NET
+/// across matmul shapes that matter for real model training — starting with the
+/// actual HRE (Harmonic Resonance Engine) hot shapes from Issue #131, and
+/// expanding out to common small/medium LLM shapes where the crossover likely
+/// sits. If the blocked path is within a reasonable margin at the shapes that
+/// matter, we can flip the deterministic default or remove MKL.NET entirely
+/// per the project's strategic direction.
+///
+/// A/B is driven by <see cref="DeterministicMode"/> (a bool param). BDN runs
+/// each benchmark twice — once with deterministic mode off (MKL.NET path) and
+/// once with it on (blocked C# fallback). Same matmul code, same tensor data,
+/// only the underlying dispatch changes.
+///
+/// Run with:
+///   dotnet run -c Release --filter DeterministicMatMul*
+/// </summary>
+[SimpleJob(RuntimeMoniker.Net10_0, launchCount: 1, warmupCount: 3, iterationCount: 10)]
+[MemoryDiagnoser]
+[MarkdownExporterAttribute.GitHub]
+public class DeterministicMatMulBenchmarks
+{
+    /// <summary>
+    /// BDN expands this to {false, true}. Each benchmark method runs twice —
+    /// once per mode — so the same shape is measured under both dispatch paths.
+    /// </summary>
+    [ParamsAllValues]
+    public bool DeterministicMode { get; set; }
+
+    private CpuEngine _engine = null!;
+
+    // ═══ HRE baseline (Issue #131 TrainingConfig defaults) ═══
+    // batch=4, seq=16, embed=32, vocab=256 → batch*seq = 64
+    // Attention-like projection: [batch*seq, embed] × [embed, embed]
+    private Tensor<float> _hre_base_attn_a = null!; // [64, 32]
+    private Tensor<float> _hre_base_attn_b = null!; // [32, 32]
+    // Output head: [batch*seq, embed] × [embed, vocab]
+    private Tensor<float> _hre_base_out_a = null!;  // [64, 32]
+    private Tensor<float> _hre_base_out_b = null!;  // [32, 256]
+
+    // ═══ HRE scaled-up (Issue #131 ScaledUp config) ═══
+    // batch=4, seq=16, embed=64, vocab=256 → batch*seq = 64
+    private Tensor<float> _hre_scaled_attn_a = null!; // [64, 64]
+    private Tensor<float> _hre_scaled_attn_b = null!; // [64, 64]
+    private Tensor<float> _hre_scaled_out_a = null!;  // [64, 64]
+    private Tensor<float> _hre_scaled_out_b = null!;  // [64, 256]
+
+    // ═══ Small LLM band: where MKL overhead may still hurt ═══
+    private Tensor<float> _small_128 = null!;  // [128, 128]
+    private Tensor<float> _small_256 = null!;  // [256, 256]
+
+    // ═══ Mid LLM band: MKL's traditional strong zone ═══
+    private Tensor<float> _mid_512 = null!;    // [512, 512]
+    private Tensor<float> _mid_1024 = null!;   // [1024, 1024]
+
+    // ═══ Large-K output head: transformer LM head over real vocab ═══
+    // batch*seq = 64, embed = 128, vocab ≈ 50257 (GPT-2)
+    private Tensor<float> _lm_head_a = null!;  // [64, 128]
+    private Tensor<float> _lm_head_b = null!;  // [128, 50257]
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new CpuEngine();
+
+        _hre_base_attn_a = Tensor<float>.CreateRandom([64, 32]);
+        _hre_base_attn_b = Tensor<float>.CreateRandom([32, 32]);
+        _hre_base_out_a  = Tensor<float>.CreateRandom([64, 32]);
+        _hre_base_out_b  = Tensor<float>.CreateRandom([32, 256]);
+
+        _hre_scaled_attn_a = Tensor<float>.CreateRandom([64, 64]);
+        _hre_scaled_attn_b = Tensor<float>.CreateRandom([64, 64]);
+        _hre_scaled_out_a  = Tensor<float>.CreateRandom([64, 64]);
+        _hre_scaled_out_b  = Tensor<float>.CreateRandom([64, 256]);
+
+        _small_128 = Tensor<float>.CreateRandom([128, 128]);
+        _small_256 = Tensor<float>.CreateRandom([256, 256]);
+
+        _mid_512  = Tensor<float>.CreateRandom([512, 512]);
+        _mid_1024 = Tensor<float>.CreateRandom([1024, 1024]);
+
+        _lm_head_a = Tensor<float>.CreateRandom([64, 128]);
+        _lm_head_b = Tensor<float>.CreateRandom([128, 50257]);
+    }
+
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        // Apply mode per iteration so BDN's {false, true} parameter split routes
+        // each benchmark through the correct dispatch path.
+        AiDotNetEngine.SetDeterministicMode(DeterministicMode);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        // Leave the engine in default mode after the benchmark run.
+        AiDotNetEngine.SetDeterministicMode(false);
+    }
+
+    // ───────────── HRE baseline (Issue #131 defaults) ─────────────
+
+    [Benchmark(Description = "HRE-base attn [64,32]×[32,32]")]
+    public Tensor<float> HRE_Baseline_Attention()
+        => _engine.TensorMatMul(_hre_base_attn_a, _hre_base_attn_b);
+
+    [Benchmark(Description = "HRE-base out-head [64,32]×[32,256]")]
+    public Tensor<float> HRE_Baseline_OutputHead()
+        => _engine.TensorMatMul(_hre_base_out_a, _hre_base_out_b);
+
+    // ───────────── HRE scaled-up ─────────────
+
+    [Benchmark(Description = "HRE-scaled attn [64,64]×[64,64]")]
+    public Tensor<float> HRE_Scaled_Attention()
+        => _engine.TensorMatMul(_hre_scaled_attn_a, _hre_scaled_attn_b);
+
+    [Benchmark(Description = "HRE-scaled out-head [64,64]×[64,256]")]
+    public Tensor<float> HRE_Scaled_OutputHead()
+        => _engine.TensorMatMul(_hre_scaled_out_a, _hre_scaled_out_b);
+
+    // ───────────── Small LLM band ─────────────
+
+    [Benchmark(Description = "Square [128,128]×[128,128]")]
+    public Tensor<float> Square_128()
+        => _engine.TensorMatMul(_small_128, _small_128);
+
+    [Benchmark(Description = "Square [256,256]×[256,256]")]
+    public Tensor<float> Square_256()
+        => _engine.TensorMatMul(_small_256, _small_256);
+
+    // ───────────── Mid LLM band ─────────────
+
+    [Benchmark(Description = "Square [512,512]×[512,512]")]
+    public Tensor<float> Square_512()
+        => _engine.TensorMatMul(_mid_512, _mid_512);
+
+    [Benchmark(Description = "Square [1024,1024]×[1024,1024]")]
+    public Tensor<float> Square_1024()
+        => _engine.TensorMatMul(_mid_1024, _mid_1024);
+
+    // ───────────── Large-K LM head (GPT-2 vocab) ─────────────
+
+    [Benchmark(Description = "LM-head [64,128]×[128,50257]")]
+    public Tensor<float> LM_Head_GPT2Vocab()
+        => _engine.TensorMatMul(_lm_head_a, _lm_head_b);
+}
+#endif

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -246,6 +246,13 @@ class Program
             return;
         }
 
+        // Run deterministic vs MKL matmul A/B benchmarks (Issue #131 Step 2, ~5-15min)
+        if (args[0] == "--vs-deterministic-matmul")
+        {
+            BenchmarkRunner.Run<DeterministicMatMulBenchmarks>(BenchConfig);
+            return;
+        }
+
         // Run TensorCodec gaps only — focused on operations still losing to PyTorch (~15min)
         if (args[0] == "--vs-tensorcodec-gaps")
         {


### PR DESCRIPTION
Issue #131 Step 2. Depends on #132 (Step 1) for the \`AiDotNetEngine.SetDeterministicMode\` API. PR base is set to \`fix/issue-131-deterministic-mode\` so these two can stack; re-target to \`main\` once #132 merges.

## Summary
Adds \`DeterministicMatMulBenchmarks\` — a BenchmarkDotNet A/B harness that compares MKL.NET's default GEMM against the deterministic blocked C# fallback across 9 matmul shapes chosen to cover:

- **HRE baseline and scaled-up hot paths** from Issue #131's \`SpectralTargetPropagation_TinyShakespeare_ReducesValLoss\` test (batch=4, seq=16, embed=32/64, vocab=256)
- **Small square matmul** (128², 256²) — small LLM band where MKL overhead may hurt
- **Mid square matmul** (512², 1024²) — MKL's traditional strong zone
- **GPT-2-vocab LM head** ([64,128]×[128,50257]) — real transformer output projection stress case

A/B is driven by a \`[ParamsAllValues] bool DeterministicMode\` property. BDN runs each benchmark twice, toggling the mode via \`[IterationSetup]\`. Same code, same data, only the dispatch changes.

## First-run results (Ryzen 9 3950X, net10.0, float32)

| Shape | MKL μs | Blocked μs | Blocked/MKL |
|---|---:|---:|---:|
| **HRE-base attn [64,32]×[32,32]** | 32.52 | 34.21 | **1.05×** |
| **HRE-base out-head [64,32]×[32,256]** | 70.86 | 92.16 | **1.30×** |
| **HRE-scaled attn [64,64]×[64,64]** | 40.45 | 61.34 | **1.52×** |
| HRE-scaled out-head [64,64]×[64,256] | 44.87 | 240.54 | 5.36× |
| Square [128,128]² | 55.33 | 166.40 | 3.01× |
| Square [256,256]² | 148.81 | 785.26 | 5.28× |
| Square [512,512]² | 887.84 | 5,933.33 | 6.68× |
| Square [1024,1024]² | 3,585 | 48,830 | **13.6×** |
| LM-head [64,128]×[128,50257] | 14,581 | 70,140 | 4.81× |

## Takeaways

1. **Deterministic mode is cheap for Issue #131's HRE reporter.** The baseline HRE attention — their dominant hot path — is only **~5% slower**. They can turn on \`SetDeterministicMode(true)\` and get bit-exact reproducibility without a meaningful perf hit.

2. **MKL replacement is NOT ready.** Mid-size square matmul (512² → 1024²) is **6–14× slower** in the blocked C# path. The current \`MatrixMultiplyHelper.MultiplyBlocked\` uses generic \`INumericOperations<T>.MultiplyAdd\` per-element — no AVX2/FMA register-blocked accumulation, no cache-oblivious tiling, no prefetching.

3. **Path forward for MKL removal:** write a proper AVX2/FMA register-blocked SGEMM kernel (similar to the other SIMD wins in this repo — Sqrt 188×, Transpose 744×, Abs 250×). Estimated 3–5 weeks of kernel work. Then re-run this benchmark and decide whether to deprecate MKL.NET.

## Measurement caveats
BDN warned that several small-shape iterations were <100μs, below its recommended minimum. HRE baseline numbers have ~20% error bars. Trend is reliable, but don't read individual percentages too precisely. Follow-up: bump \`InvocationCount\` or add a \`ShortRunJob\` variant for sub-100μs shapes.

## Test plan
- [x] Benchmark project builds cleanly (0 errors, 0 new warnings)
- [x] Full benchmark run completes in ~72s on Ryzen 9 3950X
- [x] Results file generated at \`tests/AiDotNet.Tensors.Benchmarks/BenchmarkDotNet.Artifacts/results/AiDotNet.Tensors.Benchmarks.DeterministicMatMulBenchmarks-report-github.md\`
- [ ] Future: re-run after a SIMD blocked GEMM kernel is written to see how far the gap closes

Run with:
\`\`\`
dotnet run -c Release --project tests/AiDotNet.Tensors.Benchmarks -- --vs-deterministic-matmul
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)