### PR TITLE
feat: deterministic matmul for Issue #131 — API, benchmark, 17 perf iterations

### DIFF
--- a/src/AiDotNet.Tensors/Engines/AiDotNetEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/AiDotNetEngine.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using AiDotNet.Tensors.Engines.Gpu;
+using AiDotNet.Tensors.Helpers;
 
 namespace AiDotNet.Tensors.Engines;
 
@@ -207,5 +208,55 @@ public static class AiDotNetEngine
     {
         var engine = Current;
         return $"Engine: {engine.Name}, GPU Support: {engine.SupportsGpu}";
+    }
+
+    /// <summary>
+    /// Gets whether deterministic reduction mode is currently enabled.
+    /// When true, floating-point reductions (matmul, softmax, sums) produce
+    /// bit-identical results across runs on the same hardware.
+    /// </summary>
+    public static bool DeterministicMode => BlasProvider.IsDeterministicMode;
+
+    /// <summary>
+    /// Enables or disables deterministic reduction mode for CPU tensor operations.
+    /// </summary>
+    /// <param name="deterministic">True to enable deterministic mode; false to use the default high-throughput mode.</param>
+    /// <remarks>
+    /// <para>
+    /// Multi-threaded BLAS (MKL.NET) can produce slightly different floating-point results across
+    /// runs of the same inputs because parallel reduction order is not stable — floating-point
+    /// addition is non-associative, so any variation in accumulation order produces a slightly
+    /// different final value. In long training runs, small per-step drift can compound into
+    /// observable trajectory divergence (e.g. final val-loss differences between otherwise-identical
+    /// seeded runs).
+    /// </para>
+    /// <para>
+    /// Enabling deterministic mode:
+    /// <list type="bullet">
+    ///   <item>Disables MKL.NET managed GEMM and routes matmul through the blocked fallback,
+    ///         which writes disjoint output rows per thread with fixed inner accumulation order
+    ///         (bit-exact regardless of thread count).</item>
+    ///   <item>Forces native BLAS (when loaded) to single-threaded via <c>mkl_set_num_threads(1)</c>
+    ///         and <c>mkl_set_dynamic(0)</c>.</item>
+    ///   <item>Leaves all other tensor reductions alone — <c>TensorSum</c>, <c>TensorSumOfSquares</c>,
+    ///         <c>TensorMean</c>, and <c>TensorLogSoftmax</c> are already deterministic in this engine.</item>
+    /// </list>
+    /// </para>
+    /// <para>
+    /// <b>Performance trade-off:</b> deterministic mode skips MKL's multi-threaded GEMM, which can
+    /// reduce matmul throughput for large matrices. Only enable when reproducibility is required
+    /// (tests, scientific reproducibility, paper experiments). Safe to call at any time; takes
+    /// effect on the next BLAS call.
+    /// </para>
+    /// <para>
+    /// <b>For Beginners:</b> Turn this on if you need two identical training runs to produce
+    /// identical numerical results — useful for debugging, test assertions, and research
+    /// reproducibility. Leave it off for production training where raw speed matters more than
+    /// bit-for-bit reproducibility.
+    /// </para>
+    /// </remarks>
+    public static void SetDeterministicMode(bool deterministic)
+    {
+        BlasProvider.SetDeterministicMode(deterministic);
     }
 }

--- a/src/AiDotNet.Tensors/Engines/AiDotNetEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/AiDotNetEngine.cs
@@ -233,11 +233,15 @@ public static class AiDotNetEngine
     /// <para>
     /// Enabling deterministic mode:
     /// <list type="bullet">
-    ///   <item>Disables MKL.NET managed GEMM and routes matmul through the blocked fallback,
-    ///         which writes disjoint output rows per thread with fixed inner accumulation order
-    ///         (bit-exact regardless of thread count).</item>
-    ///   <item>Forces native BLAS (when loaded) to single-threaded via <c>mkl_set_num_threads(1)</c>
-    ///         and <c>mkl_set_dynamic(0)</c>.</item>
+    ///   <item>Has <c>BlasProvider.TryGemm</c> and <c>IsMklVerified</c> short-circuit at the top,
+    ///         bypassing both MKL.NET managed GEMM and any native BLAS GEMM paths entirely.</item>
+    ///   <item>Routes matmul through the blocked C# fallback (<c>MatrixMultiplyHelper.MultiplyBlocked</c>
+    ///         for matrices, <c>CpuEngine.TensorMatMul2D</c>'s <c>Parallel.For</c> path for tensors),
+    ///         which writes disjoint output rows per thread with a fixed inner accumulation order —
+    ///         bit-exact regardless of thread count.</item>
+    ///   <item>Leaves native BLAS thread-control functions alone. Deterministic mode does <b>not</b>
+    ///         invoke <c>mkl_set_num_threads</c> or <c>mkl_set_dynamic</c>; those are only touched
+    ///         when <c>AIDOTNET_BLAS_THREADS</c> is explicitly set via env var.</item>
     ///   <item>Leaves all other tensor reductions alone — <c>TensorSum</c>, <c>TensorSumOfSquares</c>,
     ///         <c>TensorMean</c>, and <c>TensorLogSoftmax</c> are already deterministic in this engine.</item>
     /// </list>

--- a/src/AiDotNet.Tensors/Engines/CpuJit/CpuJitKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuJit/CpuJitKernels.cs
@@ -509,51 +509,124 @@ internal static class CpuJitKernels
             // Save R8 (C pointer) into R10 — we'll need R8 pristine for C stores later
             e.MovRR(X86Emitter.R10, X86Emitter.R8);
 
-            // Loop counter: R9 = kc (counts down to 0)
-            int loopLabel = e.NewLabel();
-            e.BindLabel(loopLabel);
+            // Iter 17: 2x-unrolled K loop. Each loop body processes 2 K iterations
+            // back-to-back, giving the OoO engine more instruction-level parallelism
+            // and halving the loop overhead. Pointer advances: A += 48 (2*Mr*4),
+            // B += 128 (2*Nr*4), counter decrements by 2. If kc is odd, handle the
+            // last iteration after the main loop with a scalar-style single step.
+            int unrolledIters = kc / 2;
+            int tail = kc & 1;
 
-            // Load B row: 2 vectors of 8 floats from packedB (RDX)
-            e.VmovupsLoad(X86Emitter.YMM12, X86Emitter.RDX, 0);   // B[p, 0:7]
-            e.VmovupsLoad(X86Emitter.YMM13, X86Emitter.RDX, 32);  // B[p, 8:15]
+            if (unrolledIters > 0)
+            {
+                // R9 counts unrolled iterations (down from kc/2 to 0)
+                // Main loop counter was set to kc by the caller (via R9); we override below.
+                // Actually R9 starts at kc from the prologue — we need to set it to unrolledIters.
+                // The prologue sets R9 from the argument (kc) already.
+                // We need to divide R9 by 2. Shift right by 1 is simplest but X86Emitter
+                // may not expose it — use SubImm32 pattern instead.
+                // Actually, since kc is baked at JIT time (one kernel per kc value),
+                // we can just set R9 = unrolledIters directly via a MOV with the constant.
+                e.MovImm32(X86Emitter.R9, unrolledIters);
 
-            // Row 0: broadcast A[p*6+0], FMA with B
-            e.Vbroadcastss(X86Emitter.YMM14, X86Emitter.RCX, 0);
-            e.Vfmadd231ps(X86Emitter.YMM0, X86Emitter.YMM14, X86Emitter.YMM12);
-            e.Vfmadd231ps(X86Emitter.YMM1, X86Emitter.YMM14, X86Emitter.YMM13);
+                int loopLabel = e.NewLabel();
+                e.BindLabel(loopLabel);
 
-            // Row 1
-            e.Vbroadcastss(X86Emitter.YMM14, X86Emitter.RCX, 4);
-            e.Vfmadd231ps(X86Emitter.YMM2, X86Emitter.YMM14, X86Emitter.YMM12);
-            e.Vfmadd231ps(X86Emitter.YMM3, X86Emitter.YMM14, X86Emitter.YMM13);
+                // === Iteration p ===
+                e.VmovupsLoad(X86Emitter.YMM12, X86Emitter.RDX, 0);
+                e.VmovupsLoad(X86Emitter.YMM13, X86Emitter.RDX, 32);
 
-            // Row 2
-            e.Vbroadcastss(X86Emitter.YMM14, X86Emitter.RCX, 8);
-            e.Vfmadd231ps(X86Emitter.YMM4, X86Emitter.YMM14, X86Emitter.YMM12);
-            e.Vfmadd231ps(X86Emitter.YMM5, X86Emitter.YMM14, X86Emitter.YMM13);
+                e.Vbroadcastss(X86Emitter.YMM14, X86Emitter.RCX, 0);
+                e.Vfmadd231ps(X86Emitter.YMM0, X86Emitter.YMM14, X86Emitter.YMM12);
+                e.Vfmadd231ps(X86Emitter.YMM1, X86Emitter.YMM14, X86Emitter.YMM13);
 
-            // Row 3
-            e.Vbroadcastss(X86Emitter.YMM14, X86Emitter.RCX, 12);
-            e.Vfmadd231ps(X86Emitter.YMM6, X86Emitter.YMM14, X86Emitter.YMM12);
-            e.Vfmadd231ps(X86Emitter.YMM7, X86Emitter.YMM14, X86Emitter.YMM13);
+                e.Vbroadcastss(X86Emitter.YMM14, X86Emitter.RCX, 4);
+                e.Vfmadd231ps(X86Emitter.YMM2, X86Emitter.YMM14, X86Emitter.YMM12);
+                e.Vfmadd231ps(X86Emitter.YMM3, X86Emitter.YMM14, X86Emitter.YMM13);
 
-            // Row 4
-            e.Vbroadcastss(X86Emitter.YMM14, X86Emitter.RCX, 16);
-            e.Vfmadd231ps(X86Emitter.YMM8, X86Emitter.YMM14, X86Emitter.YMM12);
-            e.Vfmadd231ps(X86Emitter.YMM9, X86Emitter.YMM14, X86Emitter.YMM13);
+                e.Vbroadcastss(X86Emitter.YMM14, X86Emitter.RCX, 8);
+                e.Vfmadd231ps(X86Emitter.YMM4, X86Emitter.YMM14, X86Emitter.YMM12);
+                e.Vfmadd231ps(X86Emitter.YMM5, X86Emitter.YMM14, X86Emitter.YMM13);
 
-            // Row 5
-            e.Vbroadcastss(X86Emitter.YMM14, X86Emitter.RCX, 20);
-            e.Vfmadd231ps(X86Emitter.YMM10, X86Emitter.YMM14, X86Emitter.YMM12);
-            e.Vfmadd231ps(X86Emitter.YMM11, X86Emitter.YMM14, X86Emitter.YMM13);
+                e.Vbroadcastss(X86Emitter.YMM14, X86Emitter.RCX, 12);
+                e.Vfmadd231ps(X86Emitter.YMM6, X86Emitter.YMM14, X86Emitter.YMM12);
+                e.Vfmadd231ps(X86Emitter.YMM7, X86Emitter.YMM14, X86Emitter.YMM13);
 
-            // Advance A by Mr*4=24 bytes, B by Nr*4=64 bytes
-            e.AddImm32(X86Emitter.RCX, 24);
-            e.AddImm32(X86Emitter.RDX, 64);
+                e.Vbroadcastss(X86Emitter.YMM14, X86Emitter.RCX, 16);
+                e.Vfmadd231ps(X86Emitter.YMM8, X86Emitter.YMM14, X86Emitter.YMM12);
+                e.Vfmadd231ps(X86Emitter.YMM9, X86Emitter.YMM14, X86Emitter.YMM13);
 
-            // Decrement kc and loop
-            e.SubImm32(X86Emitter.R9, 1);
-            e.Jne(loopLabel);
+                e.Vbroadcastss(X86Emitter.YMM14, X86Emitter.RCX, 20);
+                e.Vfmadd231ps(X86Emitter.YMM10, X86Emitter.YMM14, X86Emitter.YMM12);
+                e.Vfmadd231ps(X86Emitter.YMM11, X86Emitter.YMM14, X86Emitter.YMM13);
+
+                // === Iteration p+1 ===
+                e.VmovupsLoad(X86Emitter.YMM12, X86Emitter.RDX, 64);   // B[p+1, 0:7] at +64 bytes
+                e.VmovupsLoad(X86Emitter.YMM13, X86Emitter.RDX, 96);   // B[p+1, 8:15] at +96 bytes
+
+                e.Vbroadcastss(X86Emitter.YMM14, X86Emitter.RCX, 24);  // A[(p+1)*6+0] at +24 bytes
+                e.Vfmadd231ps(X86Emitter.YMM0, X86Emitter.YMM14, X86Emitter.YMM12);
+                e.Vfmadd231ps(X86Emitter.YMM1, X86Emitter.YMM14, X86Emitter.YMM13);
+
+                e.Vbroadcastss(X86Emitter.YMM14, X86Emitter.RCX, 28);
+                e.Vfmadd231ps(X86Emitter.YMM2, X86Emitter.YMM14, X86Emitter.YMM12);
+                e.Vfmadd231ps(X86Emitter.YMM3, X86Emitter.YMM14, X86Emitter.YMM13);
+
+                e.Vbroadcastss(X86Emitter.YMM14, X86Emitter.RCX, 32);
+                e.Vfmadd231ps(X86Emitter.YMM4, X86Emitter.YMM14, X86Emitter.YMM12);
+                e.Vfmadd231ps(X86Emitter.YMM5, X86Emitter.YMM14, X86Emitter.YMM13);
+
+                e.Vbroadcastss(X86Emitter.YMM14, X86Emitter.RCX, 36);
+                e.Vfmadd231ps(X86Emitter.YMM6, X86Emitter.YMM14, X86Emitter.YMM12);
+                e.Vfmadd231ps(X86Emitter.YMM7, X86Emitter.YMM14, X86Emitter.YMM13);
+
+                e.Vbroadcastss(X86Emitter.YMM14, X86Emitter.RCX, 40);
+                e.Vfmadd231ps(X86Emitter.YMM8, X86Emitter.YMM14, X86Emitter.YMM12);
+                e.Vfmadd231ps(X86Emitter.YMM9, X86Emitter.YMM14, X86Emitter.YMM13);
+
+                e.Vbroadcastss(X86Emitter.YMM14, X86Emitter.RCX, 44);
+                e.Vfmadd231ps(X86Emitter.YMM10, X86Emitter.YMM14, X86Emitter.YMM12);
+                e.Vfmadd231ps(X86Emitter.YMM11, X86Emitter.YMM14, X86Emitter.YMM13);
+
+                // Advance A by 2*Mr*4=48 bytes, B by 2*Nr*4=128 bytes
+                e.AddImm32(X86Emitter.RCX, 48);
+                e.AddImm32(X86Emitter.RDX, 128);
+
+                // Decrement unrolled counter and loop
+                e.SubImm32(X86Emitter.R9, 1);
+                e.Jne(loopLabel);
+            }
+
+            // Tail: if kc is odd, process one more iteration
+            if (tail > 0)
+            {
+                e.VmovupsLoad(X86Emitter.YMM12, X86Emitter.RDX, 0);
+                e.VmovupsLoad(X86Emitter.YMM13, X86Emitter.RDX, 32);
+
+                e.Vbroadcastss(X86Emitter.YMM14, X86Emitter.RCX, 0);
+                e.Vfmadd231ps(X86Emitter.YMM0, X86Emitter.YMM14, X86Emitter.YMM12);
+                e.Vfmadd231ps(X86Emitter.YMM1, X86Emitter.YMM14, X86Emitter.YMM13);
+
+                e.Vbroadcastss(X86Emitter.YMM14, X86Emitter.RCX, 4);
+                e.Vfmadd231ps(X86Emitter.YMM2, X86Emitter.YMM14, X86Emitter.YMM12);
+                e.Vfmadd231ps(X86Emitter.YMM3, X86Emitter.YMM14, X86Emitter.YMM13);
+
+                e.Vbroadcastss(X86Emitter.YMM14, X86Emitter.RCX, 8);
+                e.Vfmadd231ps(X86Emitter.YMM4, X86Emitter.YMM14, X86Emitter.YMM12);
+                e.Vfmadd231ps(X86Emitter.YMM5, X86Emitter.YMM14, X86Emitter.YMM13);
+
+                e.Vbroadcastss(X86Emitter.YMM14, X86Emitter.RCX, 12);
+                e.Vfmadd231ps(X86Emitter.YMM6, X86Emitter.YMM14, X86Emitter.YMM12);
+                e.Vfmadd231ps(X86Emitter.YMM7, X86Emitter.YMM14, X86Emitter.YMM13);
+
+                e.Vbroadcastss(X86Emitter.YMM14, X86Emitter.RCX, 16);
+                e.Vfmadd231ps(X86Emitter.YMM8, X86Emitter.YMM14, X86Emitter.YMM12);
+                e.Vfmadd231ps(X86Emitter.YMM9, X86Emitter.YMM14, X86Emitter.YMM13);
+
+                e.Vbroadcastss(X86Emitter.YMM14, X86Emitter.RCX, 20);
+                e.Vfmadd231ps(X86Emitter.YMM10, X86Emitter.YMM14, X86Emitter.YMM12);
+                e.Vfmadd231ps(X86Emitter.YMM11, X86Emitter.YMM14, X86Emitter.YMM13);
+            }
 
             // === Store accumulated results back to C (load-add-store) ===
             // R10 = C pointer, ldc baked as displacement

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
@@ -27,6 +27,16 @@ internal static class SimdGemm
     private const int Mr = 6;
     private const int Nr = 16;
 
+    // A/B test toggle: set to false to force sequential SgemmTiled for baseline
+    // comparisons. Defaults to true so multi-core systems get parallel execution.
+    // Intended for benchmark A/B iteration, not production config.
+    internal static bool UseParallelGemm = true;
+
+    // Minimum problem size (2*m*n*k flops) to enable parallel dispatch. Below this
+    // threshold the thread-pool overhead outweighs the parallelism benefit and the
+    // sequential tiled path wins.
+    private const long ParallelWorkThreshold = 4L * 1024 * 1024; // ~4M flops (e.g. 128^3 * 2)
+
     /// <summary>
     /// Computes C = A * B where A is [m,k], B is [k,n], C is [m,n].
     /// All matrices are in row-major order. C is cleared before computation.
@@ -222,6 +232,17 @@ internal static class SimdGemm
         Span<float> c,
         int m, int k, int n)
     {
+        // Decide parallel vs sequential up front. Parallel dispatches per-(jc,pc) tile
+        // by having each worker own its own row-block (ic), with packed-A allocated per
+        // worker from the ArrayPool and packed-B shared read-only within the tile.
+        int maxThreads = Helpers.CpuParallelSettings.MaxDegreeOfParallelism;
+        int numRowBlocks = (m + Mc - 1) / Mc;
+        bool useParallel = UseParallelGemm
+            && maxThreads > 1
+            && numRowBlocks >= 2
+            && !transA && !transB  // Parallel path uses the no-transpose Pack overloads
+            && (long)m * k * n >= ParallelWorkThreshold;
+
         // Round up to micro-tile dimensions to avoid buffer overruns in PackA/PackB padding
         int mcRounded = ((Mc + Mr - 1) / Mr) * Mr;
         int ncRounded = ((Nc + Nr - 1) / Nr) * Nr;
@@ -240,16 +261,34 @@ internal static class SimdGemm
                 {
                     int kc = Math.Min(Kc, k - pc);
 
-                    // Sequential path (parallel paths use the same PackA/PackB with stride params)
-                    PackA(a, packedABuf, lda, transA, ic: 0, mc: Math.Min(Mc, m), pc, kc);
-                    PackB(b, packedBBuf, ldb, transB, pc, kc, jc, nc);
-
-                    for (int ic = 0; ic < m; ic += Mc)
+                    if (useParallel)
                     {
-                        int mc = Math.Min(Mc, m - ic);
-                        if (ic > 0) // first block already packed above
-                            PackA(a, packedABuf, lda, transA, ic, mc, pc, kc);
-                        MacroKernel(packedABuf, packedBBuf, c, mc, nc, kc, n, ic, jc);
+                        // Parallel ic loop: each worker gets a disjoint row block with its
+                        // own packed-A, B is packed once and shared read-only. The output
+                        // row ranges are disjoint so no synchronization is needed on C.
+                        // Determinism: each C row's accumulation order is still fixed
+                        // (pc outer loop is sequential; inner kk/kIndex ordering is fixed
+                        // in the micro-kernel), so results are bit-exact regardless of
+                        // which worker processes which row block.
+                        SgemmTiledParallelM(
+                            a, b, c,
+                            m, k, n,
+                            jc, nc, pc, kc,
+                            numRowBlocks, packedBBuf);
+                    }
+                    else
+                    {
+                        // Sequential path (original)
+                        PackA(a, packedABuf, lda, transA, ic: 0, mc: Math.Min(Mc, m), pc, kc);
+                        PackB(b, packedBBuf, ldb, transB, pc, kc, jc, nc);
+
+                        for (int ic = 0; ic < m; ic += Mc)
+                        {
+                            int mc = Math.Min(Mc, m - ic);
+                            if (ic > 0) // first block already packed above
+                                PackA(a, packedABuf, lda, transA, ic, mc, pc, kc);
+                            MacroKernel(packedABuf, packedBBuf, c, mc, nc, kc, n, ic, jc);
+                        }
                     }
                 }
             }

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
@@ -596,32 +596,41 @@ internal static class SimdGemm
                 float* localCPtr = cPtr0;
                 int localCLen = c.Length;
 
-                // Phase 1: parallel pack A for each row block. Runs PackA once per row
-                // block on independent output buffers — no contention.
-                Helpers.CpuParallelSettings.LightweightParallel(numRowBlocks, r =>
+                // Iter 12: fuse phases 1 (pack A) and 2 (pack B) into a single parallel
+                // dispatch to save one barrier per (jc, pc) iteration. Tasks 0..numRowBlocks-1
+                // pack A, tasks numRowBlocks..numRowBlocks+numColSubs-1 pack B. All
+                // independent output buffers — no contention, all can run concurrently.
+                int numPackTasks = numRowBlocks + numColSubBlocks;
+                int localNumRowBlocks = numRowBlocks;
+                Helpers.CpuParallelSettings.LightweightParallel(numPackTasks, taskId =>
                 {
-                    int ic = r * localMc;
-                    int mcLocal = Math.Min(localMc, localM - ic);
-                    if (mcLocal > 0)
+                    if (taskId < localNumRowBlocks)
                     {
-                        var aSpan = new ReadOnlySpan<float>(localAPtr, localALen);
-                        PackA(aSpan, localPackedABufs[r], localK, ic, mcLocal, localPc, localKc);
+                        // Pack A for row block r = taskId
+                        int r = taskId;
+                        int ic = r * localMc;
+                        int mcLocal = Math.Min(localMc, localM - ic);
+                        if (mcLocal > 0)
+                        {
+                            var aSpan = new ReadOnlySpan<float>(localAPtr, localALen);
+                            PackA(aSpan, localPackedABufs[r], localK, ic, mcLocal, localPc, localKc);
+                        }
+                    }
+                    else
+                    {
+                        // Pack B for col sub cs = taskId - numRowBlocks
+                        int cs = taskId - localNumRowBlocks;
+                        int jStart = cs * localColSubSize;
+                        int subNc = (cs == localNumColSubs - 1) ? (localNc - jStart) : localColSubSize;
+                        if (subNc > 0)
+                        {
+                            var bSpan = new ReadOnlySpan<float>(localBPtr, localBLen);
+                            PackB(bSpan, localPackedBBufs[cs], localN, localPc, localKc, localJc + jStart, subNc);
+                        }
                     }
                 });
 
-                // Phase 2: parallel pack B for each col sub.
-                Helpers.CpuParallelSettings.LightweightParallel(numColSubBlocks, cs =>
-                {
-                    int jStart = cs * localColSubSize;
-                    int subNc = (cs == localNumColSubs - 1) ? (localNc - jStart) : localColSubSize;
-                    if (subNc > 0)
-                    {
-                        var bSpan = new ReadOnlySpan<float>(localBPtr, localBLen);
-                        PackB(bSpan, localPackedBBufs[cs], localN, localPc, localKc, localJc + jStart, subNc);
-                    }
-                });
-
-                // Phase 3: parallel compute for all (ic, jc_sub) tiles.
+                // Phase 2 (was 3): parallel compute for all (ic, jc_sub) tiles.
                 int totalTiles = numRowBlocks * numColSubBlocks;
                 Helpers.CpuParallelSettings.LightweightParallel(totalTiles, tileId =>
                 {

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
@@ -244,13 +244,15 @@ internal static class SimdGemm
         //     to justify col-sub parallelism OR when numRowBlocks already matches the
         //     target core count.
         //   - 2D parallel (SgemmTiledParallel2D): (row block × col sub) grid, when
-        //     numRowBlocks alone doesn't saturate available cores. Breaks past the
-        //     numRowBlocks ceiling that limited iter 1-3 at 1024² on 16-core machines.
+        //     either M or N alone doesn't saturate available cores. Handles row-heavy
+        //     problems (1024²) by splitting columns too, AND col-heavy problems
+        //     (LM-head [64, 128]x[128, 50257]) by parallelizing the 1 row block across
+        //     many col subs.
         int maxThreads = Helpers.CpuParallelSettings.MaxDegreeOfParallelism;
         int numRowBlocks = (m + Mc - 1) / Mc;
         bool canParallelize = UseParallelGemm
             && maxThreads > 1
-            && numRowBlocks >= 2
+            && numRowBlocks >= 1
             && !transA && !transB  // Parallel path uses the no-transpose Pack overloads
             && (long)m * k * n >= ParallelWorkThreshold;
 
@@ -272,38 +274,38 @@ internal static class SimdGemm
                 {
                     int kc = Math.Min(Kc, k - pc);
 
-                    if (canParallelize)
-                    {
-                        // Adaptive col-sub count: we want numRowBlocks * numColSubs ≈
-                        // logical core count so the parallel dispatch fills the machine.
-                        // Iter 5 (2026-04-11): use maxThreads (logical cores) instead of
-                        // physical — at 1024² this gives 8 row blocks × 4 col subs = 32
-                        // tiles, one per logical core on the 32-core Ryzen. SMT siblings
-                        // help here because the work is load-port-limited rather than
-                        // FMA-port-limited in blocked GEMM.
-                        int desiredColSubs = Math.Max(1, maxThreads / numRowBlocks);
-                        int maxColSubs = Math.Max(1, nc / (Nr * 4));
-                        int numColSubs = Math.Min(desiredColSubs, maxColSubs);
+                    // Decide per-tile parallel dispatch. numColSubs is adaptive to
+                    // logical core count so numRowBlocks * numColSubs ≈ maxThreads.
+                    // Iter 5: logical cores, not physical — SMT siblings help because
+                    // blocked GEMM is load-port-limited not FMA-port-limited.
+                    // Iter 7: allow numRowBlocks=1 through the 2D path so col-heavy
+                    // problems like LM-head [64,128]x[128,50257] get parallelism.
+                    int desiredColSubs = canParallelize ? Math.Max(1, maxThreads / numRowBlocks) : 1;
+                    int maxColSubs = Math.Max(1, nc / (Nr * 4));
+                    int numColSubs = Math.Min(desiredColSubs, maxColSubs);
+                    int totalTiles = numRowBlocks * numColSubs;
 
-                        if (numColSubs >= 2)
-                        {
-                            SgemmTiledParallel2D(
-                                a, b, c,
-                                m, k, n,
-                                jc, nc, pc, kc,
-                                numRowBlocks, numColSubs);
-                        }
-                        else
-                        {
-                            // 1D parallel-M: each worker owns a disjoint row block with its
-                            // own packed-A, B is packed once and shared read-only. Output
-                            // row ranges are disjoint so no synchronization on C is needed.
-                            SgemmTiledParallelM(
-                                a, b, c,
-                                m, k, n,
-                                jc, nc, pc, kc,
-                                numRowBlocks, packedBBuf);
-                        }
+                    bool used2D = canParallelize && numColSubs >= 2 && totalTiles >= 2;
+                    bool used1D = canParallelize && !used2D && numRowBlocks >= 2;
+
+                    if (used2D)
+                    {
+                        SgemmTiledParallel2D(
+                            a, b, c,
+                            m, k, n,
+                            jc, nc, pc, kc,
+                            numRowBlocks, numColSubs);
+                    }
+                    else if (used1D)
+                    {
+                        // 1D parallel-M: each worker owns a disjoint row block with its
+                        // own packed-A, B is packed once and shared read-only. Output
+                        // row ranges are disjoint so no synchronization on C is needed.
+                        SgemmTiledParallelM(
+                            a, b, c,
+                            m, k, n,
+                            jc, nc, pc, kc,
+                            numRowBlocks, packedBBuf);
                     }
                     else
                     {

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
@@ -275,11 +275,13 @@ internal static class SimdGemm
                     if (canParallelize)
                     {
                         // Adaptive col-sub count: we want numRowBlocks * numColSubs ≈
-                        // target core count so the parallel dispatch fills the machine.
-                        // Clamp so each col sub has at least 4*Nr cols (else pack/compute
-                        // overhead dominates). If numColSubs <= 1, fall back to 1D.
-                        int targetCores = Math.Max(maxThreads / 2, 1); // physical cores
-                        int desiredColSubs = Math.Max(1, targetCores / numRowBlocks);
+                        // logical core count so the parallel dispatch fills the machine.
+                        // Iter 5 (2026-04-11): use maxThreads (logical cores) instead of
+                        // physical — at 1024² this gives 8 row blocks × 4 col subs = 32
+                        // tiles, one per logical core on the 32-core Ryzen. SMT siblings
+                        // help here because the work is load-port-limited rather than
+                        // FMA-port-limited in blocked GEMM.
+                        int desiredColSubs = Math.Max(1, maxThreads / numRowBlocks);
                         int maxColSubs = Math.Max(1, nc / (Nr * 4));
                         int numColSubs = Math.Min(desiredColSubs, maxColSubs);
 

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
@@ -18,7 +18,10 @@ namespace AiDotNet.Tensors.Engines.Simd;
 internal static class SimdGemm
 {
     // Cache blocking parameters (tuned for typical L1=32KB, L2=256KB, L3=8MB)
-    private const int Mc = 256;  // Panel height for A (fits in L2)
+    // Iter 2 (2026-04-11): Mc lowered 256→128 to get more row blocks per problem, which
+    // improves parallel utilization on ≥8-core machines without affecting total pack cost
+    // (same total A bytes packed, just spread across more PackA calls).
+    private const int Mc = 128;  // Panel height for A (fits in L2)
     private const int Kc = 512;  // Panel depth (fits in L1)
     private const int Nc = 4096; // Panel width for B (fits in L3)
 
@@ -32,10 +35,11 @@ internal static class SimdGemm
     // Intended for benchmark A/B iteration, not production config.
     internal static bool UseParallelGemm = true;
 
-    // Minimum problem size (2*m*n*k flops) to enable parallel dispatch. Below this
-    // threshold the thread-pool overhead outweighs the parallelism benefit and the
-    // sequential tiled path wins.
-    private const long ParallelWorkThreshold = 4L * 1024 * 1024; // ~4M flops (e.g. 128^3 * 2)
+    // Minimum problem size (m*n*k, count as flops/2) to enable parallel dispatch.
+    // Iter 2 (2026-04-11): raised 4M → 20M after measuring that 256² (16.8M) regressed
+    // with parallel on — thread-pool overhead dominates at that size. 512² (134M) and
+    // 1024² (1B) are the real winners and comfortably clear the new threshold.
+    private const long ParallelWorkThreshold = 20L * 1024 * 1024;
 
     /// <summary>
     /// Computes C = A * B where A is [m,k], B is [k,n], C is [m,n].

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
@@ -709,14 +709,45 @@ internal static class SimdGemm
     /// When transB=false: reads B[row, col] = b[row*ldb + col] (row-major).
     /// When transB=true:  reads B^T[row, col] = b[col*ldb + row] (transposed).
     /// Layout: groups of Nr columns, each stored as kc x Nr contiguous block.
+    /// Iter 11: non-transpose full-Nr path uses 2x Vector256 loads/stores per k
+    /// iteration — reads 16 contiguous floats from a B row and writes them to
+    /// the packed buffer as two 256-bit aligned writes. ~8x faster than the
+    /// scalar fallback on cached data.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void PackB(ReadOnlySpan<float> b, float[] packed, int ldb, bool transB, int pc, int kc, int jc, int nc)
+    private static unsafe void PackB(ReadOnlySpan<float> b, float[] packed, int ldb, bool transB, int pc, int kc, int jc, int nc)
     {
         int pos = 0;
         int j = 0;
 
-        // Full Nr-column panels
+#if NET5_0_OR_GREATER
+        // Fast path: non-transpose, full Nr-column panels with SIMD copy.
+        // Nr=16 floats per row → 2 Vector256<float> = 64 bytes per iter.
+        if (!transB && Avx.IsSupported)
+        {
+            fixed (float* pBBase = b)
+            fixed (float* pPackedBase = packed)
+            {
+                for (; j + Nr <= nc; j += Nr)
+                {
+                    float* pPacked = pPackedBase + pos;
+                    float* pBCol = pBBase + pc * ldb + (jc + j);
+                    for (int p = 0; p < kc; p++)
+                    {
+                        var v0 = Avx.LoadVector256(pBCol);
+                        var v1 = Avx.LoadVector256(pBCol + 8);
+                        Avx.Store(pPacked, v0);
+                        Avx.Store(pPacked + 8, v1);
+                        pBCol += ldb;
+                        pPacked += Nr;
+                    }
+                    pos += kc * Nr;
+                }
+            }
+        }
+#endif
+
+        // Remaining full panels (transpose path or older TFMs) — scalar loop.
         for (; j + Nr <= nc; j += Nr)
         {
             for (int p = 0; p < kc; p++)
@@ -776,6 +807,10 @@ internal static class SimdGemm
         CpuJitKernels.GemmMicroKernel? jitKernel =
             CpuJitSelfTest.IsVerified ? CpuJitKernels.GetGemmMicroKernel(kc, ldc) : null;
 
+        // Iter 10 (reverted): tried pinning packedA/B/C once around the whole micro-
+        // kernel loop to eliminate per-call fixed overhead. It regressed ~14% at 512².
+        // The JIT was already eliding the inner-loop fixed statements, and the outer
+        // fixed created a longer-lived GC pin that seemed to hurt. Reverted.
         for (int jr = 0; jr < nrBlocks; jr++)
         {
             int jLocal = jr * Nr;

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
@@ -665,23 +665,68 @@ internal static class SimdGemm
     /// When transA=false: reads A[row, col] = a[row*lda + col] (row-major).
     /// When transA=true:  reads A^T[row, col] = a[col*lda + row] (transposed).
     /// Layout: groups of Mr rows, each stored as Mr x kc contiguous block.
+    /// Iter 14: non-transpose full-Mr panel path uses direct pointer arithmetic with
+    /// 6 hoisted row pointers and inner-loop unroll-by-4. Eliminates the JIT's bounds
+    /// checks and repeated index calculations, cutting pack A time substantially.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void PackA(ReadOnlySpan<float> a, float[] packed, int lda, bool transA, int ic, int mc, int pc, int kc)
+    private static unsafe void PackA(ReadOnlySpan<float> a, float[] packed, int lda, bool transA, int ic, int mc, int pc, int kc)
     {
         int pos = 0;
         int i = 0;
 
-        // Full Mr-row panels
-        for (; i + Mr <= mc; i += Mr)
+#if NET5_0_OR_GREATER
+        // Fast path: non-transpose, full Mr-row panels. Hoist 6 row pointers out
+        // of the p-loop, unroll p by 4.
+        if (!transA)
         {
-            for (int p = 0; p < kc; p++)
+            fixed (float* aPtr = a)
+            fixed (float* packedPtr = packed)
             {
-                for (int ii = 0; ii < Mr; ii++)
+                for (; i + Mr <= mc; i += Mr)
                 {
-                    int row = ic + i + ii;
-                    int col = pc + p;
-                    packed[pos++] = transA ? a[col * lda + row] : a[row * lda + col];
+                    float* row0 = aPtr + (ic + i + 0) * lda + pc;
+                    float* row1 = aPtr + (ic + i + 1) * lda + pc;
+                    float* row2 = aPtr + (ic + i + 2) * lda + pc;
+                    float* row3 = aPtr + (ic + i + 3) * lda + pc;
+                    float* row4 = aPtr + (ic + i + 4) * lda + pc;
+                    float* row5 = aPtr + (ic + i + 5) * lda + pc;
+                    float* pp = packedPtr + pos;
+
+                    int p = 0;
+                    for (; p + 4 <= kc; p += 4)
+                    {
+                        pp[0]  = row0[0]; pp[1]  = row1[0]; pp[2]  = row2[0]; pp[3]  = row3[0]; pp[4]  = row4[0]; pp[5]  = row5[0];
+                        pp[6]  = row0[1]; pp[7]  = row1[1]; pp[8]  = row2[1]; pp[9]  = row3[1]; pp[10] = row4[1]; pp[11] = row5[1];
+                        pp[12] = row0[2]; pp[13] = row1[2]; pp[14] = row2[2]; pp[15] = row3[2]; pp[16] = row4[2]; pp[17] = row5[2];
+                        pp[18] = row0[3]; pp[19] = row1[3]; pp[20] = row2[3]; pp[21] = row3[3]; pp[22] = row4[3]; pp[23] = row5[3];
+                        pp += 24;
+                        row0 += 4; row1 += 4; row2 += 4; row3 += 4; row4 += 4; row5 += 4;
+                    }
+                    for (; p < kc; p++)
+                    {
+                        pp[0] = row0[0]; pp[1] = row1[0]; pp[2] = row2[0]; pp[3] = row3[0]; pp[4] = row4[0]; pp[5] = row5[0];
+                        pp += 6;
+                        row0++; row1++; row2++; row3++; row4++; row5++;
+                    }
+                    pos += Mr * kc;
+                }
+            }
+        }
+        else
+#endif
+        {
+            // Scalar fallback (transpose path or older TFMs)
+            for (; i + Mr <= mc; i += Mr)
+            {
+                for (int p = 0; p < kc; p++)
+                {
+                    for (int ii = 0; ii < Mr; ii++)
+                    {
+                        int row = ic + i + ii;
+                        int col = pc + p;
+                        packed[pos++] = transA ? a[col * lda + row] : a[row * lda + col];
+                    }
                 }
             }
         }

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
@@ -568,22 +568,8 @@ internal static class SimdGemm
         for (int cs = 0; cs < numColSubBlocks; cs++)
             packedBBufs[cs] = ArrayPool<float>.Shared.Rent(packedBSizePerSub);
 
-        // Pin A so workers can read it via ReadOnlySpan reconstruction inside the lambda.
-        float[] aArr = ArrayPool<float>.Shared.Rent(a.Length);
-        a.CopyTo(aArr);
-        var aHandle = GCHandle.Alloc(aArr, GCHandleType.Pinned);
-
-        // Pin B similarly — pack phase reads from it concurrently across workers.
-        float[] bArr = ArrayPool<float>.Shared.Rent(b.Length);
-        b.CopyTo(bArr);
-        var bHandle = GCHandle.Alloc(bArr, GCHandleType.Pinned);
-
         try
         {
-            float* localAPtr = (float*)aHandle.AddrOfPinnedObject();
-            int localALen = a.Length;
-            float* localBPtr = (float*)bHandle.AddrOfPinnedObject();
-            int localBLen = b.Length;
             var localPackedABufs = packedABufs;
             var localPackedBBufs = packedBBufs;
             int localM = m, localK = k, localN = n;
@@ -591,41 +577,50 @@ internal static class SimdGemm
             int localColSubSize = colSubSize;
             int localNumColSubs = numColSubBlocks;
             int localMc = Mc;
-            int cLen = c.Length;
 
-            // Phase 1: parallel pack A for each row block. Runs PackA once per row
-            // block on independent output buffers — no contention.
-            Helpers.CpuParallelSettings.LightweightParallel(numRowBlocks, r =>
+            // Pin A, B, C directly via the input spans — no extra copy. The fixed
+            // block outlives every LightweightParallel call below (synchronous
+            // dispatch waits for all workers before returning), so the pointers
+            // stay valid throughout. Iter 6: previous version copied A and B into
+            // rented arrays for pinning, which added 8MB of serial copy at 1024².
+            fixed (float* aPtr0 = a)
+            fixed (float* bPtr0 = b)
+            fixed (float* cPtr0 = c)
             {
-                int ic = r * localMc;
-                int mcLocal = Math.Min(localMc, localM - ic);
-                if (mcLocal > 0)
+                float* localAPtr = aPtr0;
+                int localALen = a.Length;
+                float* localBPtr = bPtr0;
+                int localBLen = b.Length;
+                float* localCPtr = cPtr0;
+                int localCLen = c.Length;
+
+                // Phase 1: parallel pack A for each row block. Runs PackA once per row
+                // block on independent output buffers — no contention.
+                Helpers.CpuParallelSettings.LightweightParallel(numRowBlocks, r =>
                 {
-                    var aSpan = new ReadOnlySpan<float>(localAPtr, localALen);
-                    PackA(aSpan, localPackedABufs[r], localK, ic, mcLocal, localPc, localKc);
-                }
-            });
+                    int ic = r * localMc;
+                    int mcLocal = Math.Min(localMc, localM - ic);
+                    if (mcLocal > 0)
+                    {
+                        var aSpan = new ReadOnlySpan<float>(localAPtr, localALen);
+                        PackA(aSpan, localPackedABufs[r], localK, ic, mcLocal, localPc, localKc);
+                    }
+                });
 
-            // Phase 2: parallel pack B for each col sub.
-            Helpers.CpuParallelSettings.LightweightParallel(numColSubBlocks, cs =>
-            {
-                int jStart = cs * localColSubSize;
-                int subNc = (cs == localNumColSubs - 1) ? (localNc - jStart) : localColSubSize;
-                if (subNc > 0)
+                // Phase 2: parallel pack B for each col sub.
+                Helpers.CpuParallelSettings.LightweightParallel(numColSubBlocks, cs =>
                 {
-                    var bSpan = new ReadOnlySpan<float>(localBPtr, localBLen);
-                    PackB(bSpan, localPackedBBufs[cs], localN, localPc, localKc, localJc + jStart, subNc);
-                }
-            });
+                    int jStart = cs * localColSubSize;
+                    int subNc = (cs == localNumColSubs - 1) ? (localNc - jStart) : localColSubSize;
+                    if (subNc > 0)
+                    {
+                        var bSpan = new ReadOnlySpan<float>(localBPtr, localBLen);
+                        PackB(bSpan, localPackedBBufs[cs], localN, localPc, localKc, localJc + jStart, subNc);
+                    }
+                });
 
-            // Phase 3: parallel compute for all (ic, jc_sub) tiles.
-            int totalTiles = numRowBlocks * numColSubBlocks;
-
-            fixed (float* cPtr = c)
-            {
-                var localCPtr = cPtr;
-                var localCLen = cLen;
-
+                // Phase 3: parallel compute for all (ic, jc_sub) tiles.
+                int totalTiles = numRowBlocks * numColSubBlocks;
                 Helpers.CpuParallelSettings.LightweightParallel(totalTiles, tileId =>
                 {
                     int r = tileId / localNumColSubs;
@@ -647,10 +642,6 @@ internal static class SimdGemm
         }
         finally
         {
-            if (aHandle.IsAllocated) aHandle.Free();
-            ArrayPool<float>.Shared.Return(aArr);
-            if (bHandle.IsAllocated) bHandle.Free();
-            ArrayPool<float>.Shared.Return(bArr);
             for (int r = 0; r < numRowBlocks; r++)
                 ArrayPool<float>.Shared.Return(packedABufs[r]);
             for (int cs = 0; cs < numColSubBlocks; cs++)

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
@@ -18,12 +18,12 @@ namespace AiDotNet.Tensors.Engines.Simd;
 internal static class SimdGemm
 {
     // Cache blocking parameters (tuned for typical L1=32KB, L2=256KB, L3=8MB)
-    // Iter 2 (2026-04-11): Mc lowered 256→128 to get more row blocks per problem, which
-    // improves parallel utilization on ≥8-core machines without affecting total pack cost.
-    // Iter 3 (2026-04-11, reverted): Mc=64 was tried and failed — regressed 1024² from
-    // 15.5ms to 17.3ms and 256² from 785us to 2.82ms. Mc=64 is too small: 16 row blocks
-    // on 16 cores gives poor cache locality and 64 is not a multiple of Mr=6 (10.67→
-    // remainder-path overhead per panel). Kept at 128.
+    // Iter 2: Mc lowered 256→128 for more row blocks (better parallel utilization).
+    // Iter 3 (reverted): Mc=64 regressed across the board — too small for cache reuse.
+    // Iter 8 (reverted): Kc=256 was tried to fit per-tile working set in L2, but the
+    // extra pc iterations (4 instead of 2) doubled the number of parallel barriers and
+    // regressed 512² by 1.5x. The L2-fit argument was wrong because packed A gets
+    // evicted by packed B during the inner loop anyway. Kept at 512.
     private const int Mc = 128;  // Panel height for A (fits in L2)
     private const int Kc = 512;  // Panel depth (fits in L1)
     private const int Nc = 4096; // Panel width for B (fits in L3)
@@ -832,7 +832,7 @@ internal static class SimdGemm
     /// Inner loop over K dimension broadcasts A elements and FMA with B row.
     /// </summary>
     [MethodImpl(HotInline)]
-    private static void MicroKernel6x16(
+    private static unsafe void MicroKernel6x16(
         float[] packedA, int aOffset,
         float[] packedB, int bOffset,
         Span<float> c, int ldc,
@@ -850,8 +850,30 @@ internal static class SimdGemm
         ref float aRef = ref MemoryMarshal.GetArrayDataReference(packedA);
         ref float bRef = ref MemoryMarshal.GetArrayDataReference(packedB);
 
+        // Prefetch distance: load B/A cache lines PrefetchDistance iterations ahead
+        // so they arrive in L1 just before they're consumed. Zen 2 L2→L1 latency is
+        // ~12 cycles and each k iteration is ~4 cycles (load-port limited), so 4
+        // iterations ahead covers the gap. Overrun past kc doesn't cause issues —
+        // prefetch instructions are hints and out-of-bounds prefetches are ignored.
+        const int PrefetchDistance = 8;
+        int prefetchLimit = kc - PrefetchDistance;
+
         for (int p = 0; p < kc; p++)
         {
+            // Prefetch B for the p+PrefetchDistance iteration (both halves of the
+            // Nr=16 row, which spans 2 cache lines on 64-byte lines / 16 floats).
+            if (p < prefetchLimit)
+            {
+                int prefBIdx = bOffset + (p + PrefetchDistance) * Nr;
+                Sse.Prefetch0(
+                    (void*)Unsafe.AsPointer(ref Unsafe.Add(ref bRef, prefBIdx)));
+                // Prefetch A's 6 floats for the p+PrefetchDistance iteration
+                // (fits in one cache line since Mr=6 floats = 24 bytes).
+                int prefAIdx = aOffset + (p + PrefetchDistance) * Mr;
+                Sse.Prefetch0(
+                    (void*)Unsafe.AsPointer(ref Unsafe.Add(ref aRef, prefAIdx)));
+            }
+
             // Load B row (Nr=16 = 2 vectors of 8). B regs are live across all 6 A
             // broadcasts, so they stay resident throughout the inner sequence.
             int bIdx = bOffset + p * Nr;

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
@@ -19,8 +19,11 @@ internal static class SimdGemm
 {
     // Cache blocking parameters (tuned for typical L1=32KB, L2=256KB, L3=8MB)
     // Iter 2 (2026-04-11): Mc lowered 256→128 to get more row blocks per problem, which
-    // improves parallel utilization on ≥8-core machines without affecting total pack cost
-    // (same total A bytes packed, just spread across more PackA calls).
+    // improves parallel utilization on ≥8-core machines without affecting total pack cost.
+    // Iter 3 (2026-04-11, reverted): Mc=64 was tried and failed — regressed 1024² from
+    // 15.5ms to 17.3ms and 256² from 785us to 2.82ms. Mc=64 is too small: 16 row blocks
+    // on 16 cores gives poor cache locality and 64 is not a multiple of Mr=6 (10.67→
+    // remainder-path overhead per panel). Kept at 128.
     private const int Mc = 128;  // Panel height for A (fits in L2)
     private const int Kc = 512;  // Panel depth (fits in L1)
     private const int Nc = 4096; // Panel width for B (fits in L3)
@@ -690,29 +693,37 @@ internal static class SimdGemm
 
         for (int p = 0; p < kc; p++)
         {
-            // Load B row (Nr=16 = 2 vectors of 8)
+            // Load B row (Nr=16 = 2 vectors of 8). B regs are live across all 6 A
+            // broadcasts, so they stay resident throughout the inner sequence.
             int bIdx = bOffset + p * Nr;
             var b0 = Unsafe.ReadUnaligned<Vector256<float>>(
                 ref Unsafe.As<float, byte>(ref Unsafe.Add(ref bRef, bIdx)));
             var b1 = Unsafe.ReadUnaligned<Vector256<float>>(
                 ref Unsafe.As<float, byte>(ref Unsafe.Add(ref bRef, bIdx + 8)));
 
-            // Load A column (Mr=6 values)
+            // A broadcasts: load each element right before its 2 FMAs and let the
+            // register die immediately. This keeps only one A reg live at a time,
+            // bringing total live ymm regs to 12 acc + 2 B + 1 A = 15, fitting in
+            // AVX2's 16 ymm without spills. Prior version loaded all 6 A elements
+            // up front, forcing the JIT to keep 20 regs live and spill to stack.
             int aIdx = aOffset + p * Mr;
-            var a0 = Vector256.Create(Unsafe.Add(ref aRef, aIdx));
-            var a1 = Vector256.Create(Unsafe.Add(ref aRef, aIdx + 1));
-            var a2 = Vector256.Create(Unsafe.Add(ref aRef, aIdx + 2));
-            var a3 = Vector256.Create(Unsafe.Add(ref aRef, aIdx + 3));
-            var a4 = Vector256.Create(Unsafe.Add(ref aRef, aIdx + 4));
-            var a5 = Vector256.Create(Unsafe.Add(ref aRef, aIdx + 5));
+            var a = Vector256.Create(Unsafe.Add(ref aRef, aIdx));
+            c00 = Fma.MultiplyAdd(a, b0, c00); c01 = Fma.MultiplyAdd(a, b1, c01);
 
-            // FMA: C[i,j] += A[i,p] * B[p,j]
-            c00 = Fma.MultiplyAdd(a0, b0, c00); c01 = Fma.MultiplyAdd(a0, b1, c01);
-            c10 = Fma.MultiplyAdd(a1, b0, c10); c11 = Fma.MultiplyAdd(a1, b1, c11);
-            c20 = Fma.MultiplyAdd(a2, b0, c20); c21 = Fma.MultiplyAdd(a2, b1, c21);
-            c30 = Fma.MultiplyAdd(a3, b0, c30); c31 = Fma.MultiplyAdd(a3, b1, c31);
-            c40 = Fma.MultiplyAdd(a4, b0, c40); c41 = Fma.MultiplyAdd(a4, b1, c41);
-            c50 = Fma.MultiplyAdd(a5, b0, c50); c51 = Fma.MultiplyAdd(a5, b1, c51);
+            a = Vector256.Create(Unsafe.Add(ref aRef, aIdx + 1));
+            c10 = Fma.MultiplyAdd(a, b0, c10); c11 = Fma.MultiplyAdd(a, b1, c11);
+
+            a = Vector256.Create(Unsafe.Add(ref aRef, aIdx + 2));
+            c20 = Fma.MultiplyAdd(a, b0, c20); c21 = Fma.MultiplyAdd(a, b1, c21);
+
+            a = Vector256.Create(Unsafe.Add(ref aRef, aIdx + 3));
+            c30 = Fma.MultiplyAdd(a, b0, c30); c31 = Fma.MultiplyAdd(a, b1, c31);
+
+            a = Vector256.Create(Unsafe.Add(ref aRef, aIdx + 4));
+            c40 = Fma.MultiplyAdd(a, b0, c40); c41 = Fma.MultiplyAdd(a, b1, c41);
+
+            a = Vector256.Create(Unsafe.Add(ref aRef, aIdx + 5));
+            c50 = Fma.MultiplyAdd(a, b0, c50); c51 = Fma.MultiplyAdd(a, b1, c51);
         }
 
         // Store results back to C (accumulate)

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
@@ -939,30 +939,13 @@ internal static class SimdGemm
         ref float aRef = ref MemoryMarshal.GetArrayDataReference(packedA);
         ref float bRef = ref MemoryMarshal.GetArrayDataReference(packedB);
 
-        // Prefetch distance: load B/A cache lines PrefetchDistance iterations ahead
-        // so they arrive in L1 just before they're consumed. Zen 2 L2→L1 latency is
-        // ~12 cycles and each k iteration is ~4 cycles (load-port limited), so 4
-        // iterations ahead covers the gap. Overrun past kc doesn't cause issues —
-        // prefetch instructions are hints and out-of-bounds prefetches are ignored.
-        const int PrefetchDistance = 8;
-        int prefetchLimit = kc - PrefetchDistance;
-
+        // Iter 16: removed software prefetch entirely. Zen 2's hardware prefetcher
+        // already handles sequential access well. Iter 9's explicit Sse.Prefetch0
+        // hints consumed load ports (10 loads per iter → 12 with 2 prefetches =
+        // 6 cycles load-limited vs 5 without), slightly slowing the critical path.
+        // The branch check (if p < prefetchLimit) also hurt loop predictability.
         for (int p = 0; p < kc; p++)
         {
-            // Prefetch B for the p+PrefetchDistance iteration (both halves of the
-            // Nr=16 row, which spans 2 cache lines on 64-byte lines / 16 floats).
-            if (p < prefetchLimit)
-            {
-                int prefBIdx = bOffset + (p + PrefetchDistance) * Nr;
-                Sse.Prefetch0(
-                    (void*)Unsafe.AsPointer(ref Unsafe.Add(ref bRef, prefBIdx)));
-                // Prefetch A's 6 floats for the p+PrefetchDistance iteration
-                // (fits in one cache line since Mr=6 floats = 24 bytes).
-                int prefAIdx = aOffset + (p + PrefetchDistance) * Mr;
-                Sse.Prefetch0(
-                    (void*)Unsafe.AsPointer(ref Unsafe.Add(ref aRef, prefAIdx)));
-            }
-
             // Load B row (Nr=16 = 2 vectors of 8). B regs are live across all 6 A
             // broadcasts, so they stay resident throughout the inner sequence.
             int bIdx = bOffset + p * Nr;

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
@@ -239,12 +239,16 @@ internal static class SimdGemm
         Span<float> c,
         int m, int k, int n)
     {
-        // Decide parallel vs sequential up front. Parallel dispatches per-(jc,pc) tile
-        // by having each worker own its own row-block (ic), with packed-A allocated per
-        // worker from the ArrayPool and packed-B shared read-only within the tile.
+        // Decide parallel vs sequential up front. Parallel dispatches either:
+        //   - 1D parallel (SgemmTiledParallelM): row blocks only, when nc is too small
+        //     to justify col-sub parallelism OR when numRowBlocks already matches the
+        //     target core count.
+        //   - 2D parallel (SgemmTiledParallel2D): (row block × col sub) grid, when
+        //     numRowBlocks alone doesn't saturate available cores. Breaks past the
+        //     numRowBlocks ceiling that limited iter 1-3 at 1024² on 16-core machines.
         int maxThreads = Helpers.CpuParallelSettings.MaxDegreeOfParallelism;
         int numRowBlocks = (m + Mc - 1) / Mc;
-        bool useParallel = UseParallelGemm
+        bool canParallelize = UseParallelGemm
             && maxThreads > 1
             && numRowBlocks >= 2
             && !transA && !transB  // Parallel path uses the no-transpose Pack overloads
@@ -268,20 +272,36 @@ internal static class SimdGemm
                 {
                     int kc = Math.Min(Kc, k - pc);
 
-                    if (useParallel)
+                    if (canParallelize)
                     {
-                        // Parallel ic loop: each worker gets a disjoint row block with its
-                        // own packed-A, B is packed once and shared read-only. The output
-                        // row ranges are disjoint so no synchronization is needed on C.
-                        // Determinism: each C row's accumulation order is still fixed
-                        // (pc outer loop is sequential; inner kk/kIndex ordering is fixed
-                        // in the micro-kernel), so results are bit-exact regardless of
-                        // which worker processes which row block.
-                        SgemmTiledParallelM(
-                            a, b, c,
-                            m, k, n,
-                            jc, nc, pc, kc,
-                            numRowBlocks, packedBBuf);
+                        // Adaptive col-sub count: we want numRowBlocks * numColSubs ≈
+                        // target core count so the parallel dispatch fills the machine.
+                        // Clamp so each col sub has at least 4*Nr cols (else pack/compute
+                        // overhead dominates). If numColSubs <= 1, fall back to 1D.
+                        int targetCores = Math.Max(maxThreads / 2, 1); // physical cores
+                        int desiredColSubs = Math.Max(1, targetCores / numRowBlocks);
+                        int maxColSubs = Math.Max(1, nc / (Nr * 4));
+                        int numColSubs = Math.Min(desiredColSubs, maxColSubs);
+
+                        if (numColSubs >= 2)
+                        {
+                            SgemmTiledParallel2D(
+                                a, b, c,
+                                m, k, n,
+                                jc, nc, pc, kc,
+                                numRowBlocks, numColSubs);
+                        }
+                        else
+                        {
+                            // 1D parallel-M: each worker owns a disjoint row block with its
+                            // own packed-A, B is packed once and shared read-only. Output
+                            // row ranges are disjoint so no synchronization on C is needed.
+                            SgemmTiledParallelM(
+                                a, b, c,
+                                m, k, n,
+                                jc, nc, pc, kc,
+                                numRowBlocks, packedBBuf);
+                        }
                     }
                     else
                     {
@@ -489,6 +509,150 @@ internal static class SimdGemm
         {
             aHandle.Free();
             ArrayPool<float>.Shared.Return(aArr);
+        }
+    }
+
+    /// <summary>
+    /// 2D parallel GEMM: dispatches a grid of (ic_block × jc_sub) tiles in parallel.
+    /// Iter 4 (2026-04-11): breaks past the numRowBlocks parallelism ceiling. On a
+    /// 16-core machine at 1024² with Mc=128, the 1D M-parallel path was limited to
+    /// 8 workers; this variant adds col-sub parallelism to fill the remaining cores.
+    ///
+    /// Layout:
+    ///   - Each row block r has its own packed-A buffer, shared across all col subs
+    ///     (so PackA runs numRowBlocks times total, not numRowBlocks * numColSubs).
+    ///   - Each col sub cs has its own packed-B buffer, shared across all row blocks
+    ///     (so PackB runs numColSubs times, not numRowBlocks * numColSubs).
+    ///   - Compute dispatches numRowBlocks * numColSubs tiles in parallel, each
+    ///     reading its row's packed-A and its col-sub's packed-B, writing to a
+    ///     disjoint (mc x subNc) region of C.
+    ///
+    /// Determinism: output regions are disjoint per tile, inner pc loop is still
+    /// sequential, and the micro-kernel's FMA order is fixed. Results are bit-exact
+    /// identical to the sequential and 1D-parallel paths.
+    /// </summary>
+    [MethodImpl(Hot)]
+    private static unsafe void SgemmTiledParallel2D(
+        ReadOnlySpan<float> a,
+        ReadOnlySpan<float> b,
+        Span<float> c,
+        int m, int k, int n,
+        int jc, int nc, int pc, int kc,
+        int numRowBlocks, int numColSubBlocks)
+    {
+        // colSubSize: number of B columns per sub-block, rounded down to a multiple
+        // of Nr so MacroKernel's Nr panel loop stays clean. The last sub absorbs the
+        // remainder. If nc < numColSubBlocks*Nr, fall back to the 1D parallel path.
+        int colSubSize = (nc / numColSubBlocks / Nr) * Nr;
+        if (colSubSize < Nr)
+        {
+            // Degenerate — not enough cols per sub. Caller should have checked,
+            // but we guard here to avoid a zero-sized sub.
+            colSubSize = nc;
+            numColSubBlocks = 1;
+        }
+
+        int mcRounded = ((Mc + Mr - 1) / Mr) * Mr;
+        int packedASizePerRow = mcRounded * Kc;
+        int colSubRounded = ((colSubSize + Nr - 1) / Nr) * Nr;
+        int lastColSubWidth = nc - (numColSubBlocks - 1) * colSubSize;
+        int lastColSubRounded = ((lastColSubWidth + Nr - 1) / Nr) * Nr;
+        int packedBSizePerSub = Kc * Math.Max(colSubRounded, lastColSubRounded);
+
+        var packedABufs = new float[numRowBlocks][];
+        var packedBBufs = new float[numColSubBlocks][];
+        for (int r = 0; r < numRowBlocks; r++)
+            packedABufs[r] = ArrayPool<float>.Shared.Rent(packedASizePerRow);
+        for (int cs = 0; cs < numColSubBlocks; cs++)
+            packedBBufs[cs] = ArrayPool<float>.Shared.Rent(packedBSizePerSub);
+
+        // Pin A so workers can read it via ReadOnlySpan reconstruction inside the lambda.
+        float[] aArr = ArrayPool<float>.Shared.Rent(a.Length);
+        a.CopyTo(aArr);
+        var aHandle = GCHandle.Alloc(aArr, GCHandleType.Pinned);
+
+        // Pin B similarly — pack phase reads from it concurrently across workers.
+        float[] bArr = ArrayPool<float>.Shared.Rent(b.Length);
+        b.CopyTo(bArr);
+        var bHandle = GCHandle.Alloc(bArr, GCHandleType.Pinned);
+
+        try
+        {
+            float* localAPtr = (float*)aHandle.AddrOfPinnedObject();
+            int localALen = a.Length;
+            float* localBPtr = (float*)bHandle.AddrOfPinnedObject();
+            int localBLen = b.Length;
+            var localPackedABufs = packedABufs;
+            var localPackedBBufs = packedBBufs;
+            int localM = m, localK = k, localN = n;
+            int localJc = jc, localNc = nc, localPc = pc, localKc = kc;
+            int localColSubSize = colSubSize;
+            int localNumColSubs = numColSubBlocks;
+            int localMc = Mc;
+            int cLen = c.Length;
+
+            // Phase 1: parallel pack A for each row block. Runs PackA once per row
+            // block on independent output buffers — no contention.
+            Helpers.CpuParallelSettings.LightweightParallel(numRowBlocks, r =>
+            {
+                int ic = r * localMc;
+                int mcLocal = Math.Min(localMc, localM - ic);
+                if (mcLocal > 0)
+                {
+                    var aSpan = new ReadOnlySpan<float>(localAPtr, localALen);
+                    PackA(aSpan, localPackedABufs[r], localK, ic, mcLocal, localPc, localKc);
+                }
+            });
+
+            // Phase 2: parallel pack B for each col sub.
+            Helpers.CpuParallelSettings.LightweightParallel(numColSubBlocks, cs =>
+            {
+                int jStart = cs * localColSubSize;
+                int subNc = (cs == localNumColSubs - 1) ? (localNc - jStart) : localColSubSize;
+                if (subNc > 0)
+                {
+                    var bSpan = new ReadOnlySpan<float>(localBPtr, localBLen);
+                    PackB(bSpan, localPackedBBufs[cs], localN, localPc, localKc, localJc + jStart, subNc);
+                }
+            });
+
+            // Phase 3: parallel compute for all (ic, jc_sub) tiles.
+            int totalTiles = numRowBlocks * numColSubBlocks;
+
+            fixed (float* cPtr = c)
+            {
+                var localCPtr = cPtr;
+                var localCLen = cLen;
+
+                Helpers.CpuParallelSettings.LightweightParallel(totalTiles, tileId =>
+                {
+                    int r = tileId / localNumColSubs;
+                    int cs = tileId % localNumColSubs;
+                    int ic = r * localMc;
+                    int mcLocal = Math.Min(localMc, localM - ic);
+                    int jStart = cs * localColSubSize;
+                    int subNc = (cs == localNumColSubs - 1) ? (localNc - jStart) : localColSubSize;
+                    if (mcLocal > 0 && subNc > 0)
+                    {
+                        var cSpan = new Span<float>(localCPtr, localCLen);
+                        MacroKernel(
+                            localPackedABufs[r], localPackedBBufs[cs],
+                            cSpan, mcLocal, subNc, localKc, localN,
+                            ic, localJc + jStart);
+                    }
+                });
+            }
+        }
+        finally
+        {
+            if (aHandle.IsAllocated) aHandle.Free();
+            ArrayPool<float>.Shared.Return(aArr);
+            if (bHandle.IsAllocated) bHandle.Free();
+            ArrayPool<float>.Shared.Return(bArr);
+            for (int r = 0; r < numRowBlocks; r++)
+                ArrayPool<float>.Shared.Return(packedABufs[r]);
+            for (int cs = 0; cs < numColSubBlocks; cs++)
+                ArrayPool<float>.Shared.Return(packedBBufs[cs]);
         }
     }
 

--- a/src/AiDotNet.Tensors/Helpers/BlasProvider.cs
+++ b/src/AiDotNet.Tensors/Helpers/BlasProvider.cs
@@ -42,23 +42,36 @@ internal static class BlasProvider
     /// </summary>
     private static bool _deterministicMode;
 
+    /// <summary>
+    /// Returns whether deterministic mode is currently enabled.
+    /// </summary>
+    public static bool IsDeterministicMode => _deterministicMode;
+
+    // Saved state so that toggling deterministic mode off restores whatever MKL.NET
+    // was doing before. Null means no saved state (deterministic mode was never on
+    // or has already been turned off).
+    private static bool? _savedUseMklNet;
+
     public static void SetDeterministicMode(bool deterministic)
     {
         lock (InitLock)
         {
+            if (_deterministicMode == deterministic) return;
             _deterministicMode = deterministic;
-            ThreadCountOverride = deterministic ? 1 : ReadEnvInt("AIDOTNET_BLAS_THREADS");
+            // Deterministic mode routes all matmul through the bit-exact blocked C# fallback
+            // by having TryGemm/IsMklVerified return false at the top. We don't need to force
+            // native BLAS to single-threaded — it never gets called in deterministic mode —
+            // so we leave ThreadCountOverride alone to avoid touching native thread-control
+            // functions that can be unsafe on some platforms.
             if (deterministic)
             {
-                // Disable MKL.NET managed bindings: MKL's multi-threaded GEMM produces
-                // non-deterministic results from parallel reduction ordering, and we cannot
-                // reliably set MKL's internal thread count via the managed API.
-                // Falls back to deterministic sequential MultiplyMatrixBlocked.
+                _savedUseMklNet = _useMklNet;
                 _useMklNet = false;
             }
-            if (_initialized)
+            else if (_savedUseMklNet.HasValue)
             {
-                ApplyThreadSettings();
+                _useMklNet = _savedUseMklNet.Value;
+                _savedUseMklNet = null;
             }
         }
     }
@@ -129,6 +142,11 @@ internal static class BlasProvider
 
     internal static bool TryGemm(int m, int n, int k, float[] a, int aOffset, int lda, float[] b, int bOffset, int ldb, float[] c, int cOffset, int ldc)
     {
+        // Deterministic mode: fall through to the bit-exact blocked C# fallback in
+        // MatrixMultiplyHelper.MultiplyBlocked. Also avoids triggering native BLAS
+        // initialization, which can be unsafe on some platforms.
+        if (_deterministicMode) return false;
+
         // Hot path: after MKL is verified AND still enabled, skip all checks
         if (_mklVerified && _useMklNet)
         {
@@ -221,8 +239,10 @@ internal static class BlasProvider
     /// <summary>
     /// True after MKL has been verified working. Use IsMklVerified + MklSgemmZeroOffset
     /// to bypass TryGemm entirely when offsets are always 0 (FusedLinear hot path).
+    /// Returns false in deterministic mode so direct-MKL hot paths fall through to the
+    /// deterministic blocked matmul fallback.
     /// </summary>
-    internal static bool IsMklVerified => _mklVerified;
+    internal static bool IsMklVerified => _mklVerified && !_deterministicMode;
 
     /// <summary>
     /// Absolute fastest MKL path: zero-offset spans, no TryGemm dispatch, no validation.
@@ -291,6 +311,7 @@ internal static class BlasProvider
     /// </summary>
     internal static bool TryGemmWithBeta(int m, int n, int k, float[] a, int aOffset, int lda, float[] b, int bOffset, int ldb, float[] c, int cOffset, int ldc, float beta)
     {
+        if (_deterministicMode) return false;
         if (!EnsureInitialized()) return false;
         if (!HasEnoughData(a.Length, aOffset, m, k, lda) ||
             !HasEnoughData(b.Length, bOffset, k, n, ldb) ||
@@ -318,6 +339,7 @@ internal static class BlasProvider
     /// </summary>
     internal static bool TryGemmWithBeta(int m, int n, int k, double[] a, int aOffset, int lda, double[] b, int bOffset, int ldb, double[] c, int cOffset, int ldc, double beta)
     {
+        if (_deterministicMode) return false;
         if (!EnsureInitialized()) return false;
         if (!HasEnoughData(a.Length, aOffset, m, k, lda) ||
             !HasEnoughData(b.Length, bOffset, k, n, ldb) ||
@@ -345,6 +367,7 @@ internal static class BlasProvider
         float[] b, int bOffset, int ldb, bool transB,
         float[] c, int cOffset, int ldc)
     {
+        if (_deterministicMode) return false;
         if (!EnsureInitialized()) return false;
 
         // Bounds validation (same as TryGemm)
@@ -407,6 +430,7 @@ internal static class BlasProvider
     /// </summary>
     internal static bool TryGemm(int m, int n, int k, ReadOnlySpan<float> a, int lda, ReadOnlySpan<float> b, int ldb, Span<float> c, int ldc)
     {
+        if (_deterministicMode) return false;
         if (!EnsureInitialized())
         {
             return false;
@@ -453,6 +477,7 @@ internal static class BlasProvider
     /// </summary>
     internal static bool TryGemm(int m, int n, int k, ReadOnlySpan<double> a, int lda, ReadOnlySpan<double> b, int ldb, Span<double> c, int ldc)
     {
+        if (_deterministicMode) return false;
         if (!EnsureInitialized())
         {
             return false;
@@ -572,6 +597,9 @@ internal static class BlasProvider
     /// </summary>
     internal static bool TryGemm(int m, int n, int k, double[] a, int aOffset, int lda, double[] b, int bOffset, int ldb, double[] c, int cOffset, int ldc)
     {
+        // Deterministic mode: fall through to the bit-exact blocked C# fallback.
+        if (_deterministicMode) return false;
+
         // Hot path: skip all checks after MKL verified AND still enabled
         if (_mklVerified && _useMklNet)
         {
@@ -827,10 +855,21 @@ internal static class BlasProvider
             return;
         }
 
+        // Only invoke native thread-control functions when the caller has explicitly
+        // requested a specific thread count (env var or deterministic mode). The
+        // loaded symbols can be unsafe to call blindly on some platforms — on net10.0
+        // Windows, for example, invoking them without explicit opt-in has been seen
+        // to trigger access violations. Falling through leaves the native library at
+        // its own default thread count, which is safe.
+        if (!ThreadCountOverride.HasValue)
+        {
+            Trace("[BLAS] ApplyThreadSettings skipped — no explicit thread count requested");
+            return;
+        }
+
         try
         {
-            // Use override if specified, otherwise use all available processors
-            int threadCount = ThreadCountOverride ?? Environment.ProcessorCount;
+            int threadCount = ThreadCountOverride.Value;
             _setDynamic?.Invoke(0);
             _setNumThreads(threadCount);
             Trace($"[BLAS] Set thread count to {threadCount}");

--- a/src/AiDotNet.Tensors/Helpers/BlasProvider.cs
+++ b/src/AiDotNet.Tensors/Helpers/BlasProvider.cs
@@ -35,12 +35,14 @@ internal static class BlasProvider
     private static readonly bool TraceEnabled = ReadEnvBool("AIDOTNET_BLAS_TRACE");
 
     /// <summary>
-    /// Enables deterministic mode by forcing BLAS to single-threaded execution.
-    /// Multi-threaded BLAS (OpenBLAS, MKL) can produce slightly different FP results
-    /// across runs due to parallel reduction ordering. Single-threaded mode guarantees
-    /// bit-identical results for the same input.
+    /// When true, BLAS/MKL GEMM paths are bypassed entirely — TryGemm and
+    /// IsMklVerified return false at their top so matmul falls through to the
+    /// bit-exact blocked C# fallback. This guarantees bit-identical results
+    /// across runs regardless of thread count, since the fallback's inner
+    /// accumulation order is fixed. Volatile so that lock-free reads in the
+    /// hot TryGemm path see writes made under InitLock without stale caching.
     /// </summary>
-    private static bool _deterministicMode;
+    private static volatile bool _deterministicMode;
 
     /// <summary>
     /// Returns whether deterministic mode is currently enabled.
@@ -59,10 +61,11 @@ internal static class BlasProvider
             if (_deterministicMode == deterministic) return;
             _deterministicMode = deterministic;
             // Deterministic mode routes all matmul through the bit-exact blocked C# fallback
-            // by having TryGemm/IsMklVerified return false at the top. We don't need to force
-            // native BLAS to single-threaded — it never gets called in deterministic mode —
-            // so we leave ThreadCountOverride alone to avoid touching native thread-control
-            // functions that can be unsafe on some platforms.
+            // by having TryGemm/IsMklVerified return false at the top. It does NOT call into
+            // native thread-control functions (mkl_set_num_threads, etc.) — those paths are
+            // only triggered when AIDOTNET_BLAS_THREADS is explicitly set via env var, which
+            // drives ThreadCountOverride. ThreadCountOverride is intentionally left alone
+            // here to avoid touching native symbols that can be unsafe on some platforms.
             if (deterministic)
             {
                 _savedUseMklNet = _useMklNet;
@@ -856,11 +859,13 @@ internal static class BlasProvider
         }
 
         // Only invoke native thread-control functions when the caller has explicitly
-        // requested a specific thread count (env var or deterministic mode). The
-        // loaded symbols can be unsafe to call blindly on some platforms — on net10.0
-        // Windows, for example, invoking them without explicit opt-in has been seen
-        // to trigger access violations. Falling through leaves the native library at
-        // its own default thread count, which is safe.
+        // provided a ThreadCountOverride (set via the AIDOTNET_BLAS_THREADS env var).
+        // Deterministic mode does NOT opt in here — it bypasses BLAS entirely via
+        // the TryGemm short-circuit, so thread-control calls would be pointless.
+        // The loaded symbols can be unsafe to call blindly on some platforms — on
+        // net10.0 Windows, for example, invoking them without this explicit opt-in
+        // has been seen to trigger access violations. Falling through leaves the
+        // native library at its own default thread count, which is safe.
         if (!ThreadCountOverride.HasValue)
         {
             Trace("[BLAS] ApplyThreadSettings skipped — no explicit thread count requested");

--- a/src/AiDotNet.Tensors/Helpers/BlasProvider.cs
+++ b/src/AiDotNet.Tensors/Helpers/BlasProvider.cs
@@ -71,10 +71,36 @@ internal static class BlasProvider
                 _savedUseMklNet = _useMklNet;
                 _useMklNet = false;
             }
-            else if (_savedUseMklNet.HasValue)
+            else
             {
-                _useMklNet = _savedUseMklNet.Value;
-                _savedUseMklNet = null;
+                // Restore saved MKL state (what _useMklNet was before deterministic was turned on).
+                if (_savedUseMklNet.HasValue)
+                {
+                    _useMklNet = _savedUseMklNet.Value;
+                    _savedUseMklNet = null;
+                }
+
+                // Second-chance MKL.NET init: if BLAS was initialized DURING deterministic mode,
+                // TryLoadLibrary deliberately skipped MKL.NET and fell through to native BLAS
+                // (or no backend at all). Now that deterministic is off, attempt the MKL.NET
+                // load once more so the non-deterministic path isn't permanently stuck on the
+                // slower native/blocked fallback. This mirrors the code in TryLoadLibrary.
+                if (_initialized && !_useMklNet)
+                {
+                    try
+                    {
+                        if (TryInitializeMklNet())
+                        {
+                            Trace("[BLAS] MKL.NET retry-init after leaving deterministic mode succeeded");
+                            _useMklNet = true;
+                            _available = true;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Trace($"[BLAS] MKL.NET retry-init failed: {ex.GetType().Name}: {ex.Message}");
+                    }
+                }
             }
         }
     }

--- a/tests/AiDotNet.Tensors.Benchmarks/DeterministicMatMulBenchmarks.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/DeterministicMatMulBenchmarks.cs
@@ -1,5 +1,6 @@
 #if NET8_0_OR_GREATER
 using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Simd;
 using AiDotNet.Tensors.LinearAlgebra;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
@@ -18,13 +19,16 @@ namespace AiDotNet.Tensors.Benchmarks;
 /// matter, we can flip the deterministic default or remove MKL.NET entirely
 /// per the project's strategic direction.
 ///
-/// A/B is driven by <see cref="DeterministicMode"/> (a bool param). BDN runs
-/// each benchmark twice — once with deterministic mode off (MKL.NET path) and
-/// once with it on (blocked C# fallback). Same matmul code, same tensor data,
-/// only the underlying dispatch changes.
+/// A/B is driven by two bool params:
+///  - <see cref="DeterministicMode"/>: off = MKL.NET GEMM, on = blocked C# fallback
+///  - <see cref="UseParallelGemm"/>: off = single-threaded SgemmTiled, on = parallel-M
+///
+/// BDN runs each benchmark under all 4 combinations, letting us isolate the
+/// parallelism win from the deterministic-dispatch overhead independently.
 ///
 /// Run with:
-///   dotnet run -c Release --filter DeterministicMatMul*
+///   dotnet run -c Release --project tests/AiDotNet.Tensors.Benchmarks \
+///     -- --vs-deterministic-matmul
 /// </summary>
 [SimpleJob(RuntimeMoniker.Net10_0, launchCount: 1, warmupCount: 3, iterationCount: 10)]
 [MemoryDiagnoser]
@@ -37,6 +41,16 @@ public class DeterministicMatMulBenchmarks
     /// </summary>
     [ParamsAllValues]
     public bool DeterministicMode { get; set; }
+
+    /// <summary>
+    /// BDN expands this to {false, true}. Controls <see cref="SimdGemm.UseParallelGemm"/>,
+    /// the toggle that routes SgemmTiled through the parallel-M variant. Only meaningful
+    /// when the blocked C# path is actually used — i.e. when DeterministicMode is true OR
+    /// when the shape falls below the BLAS work threshold. For default-mode MKL runs this
+    /// has no effect (MKL manages its own parallelism).
+    /// </summary>
+    [ParamsAllValues]
+    public bool UseParallelGemm { get; set; }
 
     private CpuEngine _engine = null!;
 
@@ -97,9 +111,10 @@ public class DeterministicMatMulBenchmarks
     [IterationSetup]
     public void IterationSetup()
     {
-        // Apply mode per iteration so BDN's {false, true} parameter split routes
-        // each benchmark through the correct dispatch path.
+        // Apply mode per iteration so BDN's parameter expansion routes each
+        // benchmark through the correct dispatch path.
         AiDotNetEngine.SetDeterministicMode(DeterministicMode);
+        SimdGemm.UseParallelGemm = UseParallelGemm;
     }
 
     [GlobalCleanup]
@@ -107,6 +122,7 @@ public class DeterministicMatMulBenchmarks
     {
         // Leave the engine in default mode after the benchmark run.
         AiDotNetEngine.SetDeterministicMode(false);
+        SimdGemm.UseParallelGemm = true;
     }
 
     // ───────────── HRE baseline (Issue #131 defaults) ─────────────

--- a/tests/AiDotNet.Tensors.Benchmarks/DeterministicMatMulBenchmarks.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/DeterministicMatMulBenchmarks.cs
@@ -21,7 +21,9 @@ namespace AiDotNet.Tensors.Benchmarks;
 ///
 /// A/B is driven by two bool params:
 ///  - <see cref="DeterministicMode"/>: off = MKL.NET GEMM, on = blocked C# fallback
-///  - <see cref="UseParallelGemm"/>: off = single-threaded SgemmTiled, on = parallel-M
+///  - <see cref="UseParallelGemm"/>: off = single-threaded SgemmTiled, on = parallel
+///    dispatch (1D parallel-M for shapes where row blocks alone saturate cores,
+///    2D (row × col-sub) grid for shapes where they don't)
 ///
 /// BDN runs each benchmark under all 4 combinations, letting us isolate the
 /// parallelism win from the deterministic-dispatch overhead independently.
@@ -44,10 +46,14 @@ public class DeterministicMatMulBenchmarks
 
     /// <summary>
     /// BDN expands this to {false, true}. Controls <see cref="SimdGemm.UseParallelGemm"/>,
-    /// the toggle that routes SgemmTiled through the parallel-M variant. Only meaningful
-    /// when the blocked C# path is actually used — i.e. when DeterministicMode is true OR
-    /// when the shape falls below the BLAS work threshold. For default-mode MKL runs this
-    /// has no effect (MKL manages its own parallelism).
+    /// the toggle that enables the parallel dispatch inside <c>SgemmTiled</c>. When true,
+    /// SgemmTiled picks between the 1D <c>SgemmTiledParallelM</c> variant (row-block-only
+    /// parallelism) and the 2D <c>SgemmTiledParallel2D</c> variant (row-block × col-sub
+    /// grid) based on shape — 2D is used for shapes where numRowBlocks alone does not
+    /// saturate logical cores. When false, SgemmTiled runs its original single-threaded
+    /// tiled path. Only meaningful when the blocked C# path is actually used — i.e. when
+    /// DeterministicMode is true OR the shape falls below the BLAS work threshold. For
+    /// default-mode MKL runs this has no effect (MKL manages its own parallelism).
     /// </summary>
     [ParamsAllValues]
     public bool UseParallelGemm { get; set; }

--- a/tests/AiDotNet.Tensors.Benchmarks/DeterministicMatMulBenchmarks.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/DeterministicMatMulBenchmarks.cs
@@ -1,0 +1,158 @@
+#if NET8_0_OR_GREATER
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+namespace AiDotNet.Tensors.Benchmarks;
+
+/// <summary>
+/// A/B benchmark: MKL.NET default matmul vs the deterministic blocked C# fallback
+/// exposed by <see cref="AiDotNetEngine.SetDeterministicMode"/>.
+///
+/// Purpose: measure how competitive the bit-exact blocked path is vs MKL.NET
+/// across matmul shapes that matter for real model training — starting with the
+/// actual HRE (Harmonic Resonance Engine) hot shapes from Issue #131, and
+/// expanding out to common small/medium LLM shapes where the crossover likely
+/// sits. If the blocked path is within a reasonable margin at the shapes that
+/// matter, we can flip the deterministic default or remove MKL.NET entirely
+/// per the project's strategic direction.
+///
+/// A/B is driven by <see cref="DeterministicMode"/> (a bool param). BDN runs
+/// each benchmark twice — once with deterministic mode off (MKL.NET path) and
+/// once with it on (blocked C# fallback). Same matmul code, same tensor data,
+/// only the underlying dispatch changes.
+///
+/// Run with:
+///   dotnet run -c Release --filter DeterministicMatMul*
+/// </summary>
+[SimpleJob(RuntimeMoniker.Net10_0, launchCount: 1, warmupCount: 3, iterationCount: 10)]
+[MemoryDiagnoser]
+[MarkdownExporterAttribute.GitHub]
+public class DeterministicMatMulBenchmarks
+{
+    /// <summary>
+    /// BDN expands this to {false, true}. Each benchmark method runs twice —
+    /// once per mode — so the same shape is measured under both dispatch paths.
+    /// </summary>
+    [ParamsAllValues]
+    public bool DeterministicMode { get; set; }
+
+    private CpuEngine _engine = null!;
+
+    // ═══ HRE baseline (Issue #131 TrainingConfig defaults) ═══
+    // batch=4, seq=16, embed=32, vocab=256 → batch*seq = 64
+    // Attention-like projection: [batch*seq, embed] × [embed, embed]
+    private Tensor<float> _hre_base_attn_a = null!; // [64, 32]
+    private Tensor<float> _hre_base_attn_b = null!; // [32, 32]
+    // Output head: [batch*seq, embed] × [embed, vocab]
+    private Tensor<float> _hre_base_out_a = null!;  // [64, 32]
+    private Tensor<float> _hre_base_out_b = null!;  // [32, 256]
+
+    // ═══ HRE scaled-up (Issue #131 ScaledUp config) ═══
+    // batch=4, seq=16, embed=64, vocab=256 → batch*seq = 64
+    private Tensor<float> _hre_scaled_attn_a = null!; // [64, 64]
+    private Tensor<float> _hre_scaled_attn_b = null!; // [64, 64]
+    private Tensor<float> _hre_scaled_out_a = null!;  // [64, 64]
+    private Tensor<float> _hre_scaled_out_b = null!;  // [64, 256]
+
+    // ═══ Small LLM band: where MKL overhead may still hurt ═══
+    private Tensor<float> _small_128 = null!;  // [128, 128]
+    private Tensor<float> _small_256 = null!;  // [256, 256]
+
+    // ═══ Mid LLM band: MKL's traditional strong zone ═══
+    private Tensor<float> _mid_512 = null!;    // [512, 512]
+    private Tensor<float> _mid_1024 = null!;   // [1024, 1024]
+
+    // ═══ Large-K output head: transformer LM head over real vocab ═══
+    // batch*seq = 64, embed = 128, vocab ≈ 50257 (GPT-2)
+    private Tensor<float> _lm_head_a = null!;  // [64, 128]
+    private Tensor<float> _lm_head_b = null!;  // [128, 50257]
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new CpuEngine();
+
+        _hre_base_attn_a = Tensor<float>.CreateRandom([64, 32]);
+        _hre_base_attn_b = Tensor<float>.CreateRandom([32, 32]);
+        _hre_base_out_a  = Tensor<float>.CreateRandom([64, 32]);
+        _hre_base_out_b  = Tensor<float>.CreateRandom([32, 256]);
+
+        _hre_scaled_attn_a = Tensor<float>.CreateRandom([64, 64]);
+        _hre_scaled_attn_b = Tensor<float>.CreateRandom([64, 64]);
+        _hre_scaled_out_a  = Tensor<float>.CreateRandom([64, 64]);
+        _hre_scaled_out_b  = Tensor<float>.CreateRandom([64, 256]);
+
+        _small_128 = Tensor<float>.CreateRandom([128, 128]);
+        _small_256 = Tensor<float>.CreateRandom([256, 256]);
+
+        _mid_512  = Tensor<float>.CreateRandom([512, 512]);
+        _mid_1024 = Tensor<float>.CreateRandom([1024, 1024]);
+
+        _lm_head_a = Tensor<float>.CreateRandom([64, 128]);
+        _lm_head_b = Tensor<float>.CreateRandom([128, 50257]);
+    }
+
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        // Apply mode per iteration so BDN's {false, true} parameter split routes
+        // each benchmark through the correct dispatch path.
+        AiDotNetEngine.SetDeterministicMode(DeterministicMode);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        // Leave the engine in default mode after the benchmark run.
+        AiDotNetEngine.SetDeterministicMode(false);
+    }
+
+    // ───────────── HRE baseline (Issue #131 defaults) ─────────────
+
+    [Benchmark(Description = "HRE-base attn [64,32]×[32,32]")]
+    public Tensor<float> HRE_Baseline_Attention()
+        => _engine.TensorMatMul(_hre_base_attn_a, _hre_base_attn_b);
+
+    [Benchmark(Description = "HRE-base out-head [64,32]×[32,256]")]
+    public Tensor<float> HRE_Baseline_OutputHead()
+        => _engine.TensorMatMul(_hre_base_out_a, _hre_base_out_b);
+
+    // ───────────── HRE scaled-up ─────────────
+
+    [Benchmark(Description = "HRE-scaled attn [64,64]×[64,64]")]
+    public Tensor<float> HRE_Scaled_Attention()
+        => _engine.TensorMatMul(_hre_scaled_attn_a, _hre_scaled_attn_b);
+
+    [Benchmark(Description = "HRE-scaled out-head [64,64]×[64,256]")]
+    public Tensor<float> HRE_Scaled_OutputHead()
+        => _engine.TensorMatMul(_hre_scaled_out_a, _hre_scaled_out_b);
+
+    // ───────────── Small LLM band ─────────────
+
+    [Benchmark(Description = "Square [128,128]×[128,128]")]
+    public Tensor<float> Square_128()
+        => _engine.TensorMatMul(_small_128, _small_128);
+
+    [Benchmark(Description = "Square [256,256]×[256,256]")]
+    public Tensor<float> Square_256()
+        => _engine.TensorMatMul(_small_256, _small_256);
+
+    // ───────────── Mid LLM band ─────────────
+
+    [Benchmark(Description = "Square [512,512]×[512,512]")]
+    public Tensor<float> Square_512()
+        => _engine.TensorMatMul(_mid_512, _mid_512);
+
+    [Benchmark(Description = "Square [1024,1024]×[1024,1024]")]
+    public Tensor<float> Square_1024()
+        => _engine.TensorMatMul(_mid_1024, _mid_1024);
+
+    // ───────────── Large-K LM head (GPT-2 vocab) ─────────────
+
+    [Benchmark(Description = "LM-head [64,128]×[128,50257]")]
+    public Tensor<float> LM_Head_GPT2Vocab()
+        => _engine.TensorMatMul(_lm_head_a, _lm_head_b);
+}
+#endif

--- a/tests/AiDotNet.Tensors.Benchmarks/DeterministicMatMulBenchmarks.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/DeterministicMatMulBenchmarks.cs
@@ -30,7 +30,7 @@ namespace AiDotNet.Tensors.Benchmarks;
 ///   dotnet run -c Release --project tests/AiDotNet.Tensors.Benchmarks \
 ///     -- --vs-deterministic-matmul
 /// </summary>
-[SimpleJob(RuntimeMoniker.Net10_0, launchCount: 1, warmupCount: 3, iterationCount: 10)]
+[SimpleJob(RuntimeMoniker.Net10_0, launchCount: 2, warmupCount: 5, iterationCount: 15)]
 [MemoryDiagnoser]
 [MarkdownExporterAttribute.GitHub]
 public class DeterministicMatMulBenchmarks

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -246,6 +246,13 @@ class Program
             return;
         }
 
+        // Run deterministic vs MKL matmul A/B benchmarks (Issue #131 Step 2, ~5-15min)
+        if (args[0] == "--vs-deterministic-matmul")
+        {
+            BenchmarkRunner.Run<DeterministicMatMulBenchmarks>(BenchConfig);
+            return;
+        }
+
         // Run TensorCodec gaps only — focused on operations still losing to PyTorch (~15min)
         if (args[0] == "--vs-tensorcodec-gaps")
         {

--- a/tests/AiDotNet.Tensors.Tests/Engines/DeterministicModeTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DeterministicModeTests.cs
@@ -1,0 +1,105 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Tests for AiDotNetEngine.SetDeterministicMode — verifies the public API surface
+/// and that enabling deterministic mode produces bit-exact reproducible results for
+/// large matmuls (the hot path that uses MKL.NET in default mode).
+/// </summary>
+public class DeterministicModeTests
+{
+    [Fact]
+    public void DeterministicMode_TogglesAndReads()
+    {
+        bool original = AiDotNetEngine.DeterministicMode;
+        try
+        {
+            AiDotNetEngine.SetDeterministicMode(true);
+            Assert.True(AiDotNetEngine.DeterministicMode);
+
+            AiDotNetEngine.SetDeterministicMode(false);
+            Assert.False(AiDotNetEngine.DeterministicMode);
+        }
+        finally
+        {
+            AiDotNetEngine.SetDeterministicMode(original);
+        }
+    }
+
+    [Fact]
+    public void DeterministicMode_MatMul_BitExactAcrossRuns()
+    {
+        bool original = AiDotNetEngine.DeterministicMode;
+        try
+        {
+            AiDotNetEngine.SetDeterministicMode(true);
+
+            // Large enough to hit the BLAS work threshold (2*128*128*128 = 4.2M, above default threshold)
+            int m = 128, k = 128, n = 128;
+            var rng = new Random(42);
+            var a = new Tensor<float>([m, k]);
+            var b = new Tensor<float>([k, n]);
+            for (int i = 0; i < m * k; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+            for (int i = 0; i < k * n; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+
+            var engine = new CpuEngine();
+            var r1 = engine.TensorMatMul(a, b);
+            var r2 = engine.TensorMatMul(a, b);
+            var r3 = engine.TensorMatMul(a, b);
+
+            // Bit-exact equality across three repeated calls
+            for (int i = 0; i < m * n; i++)
+            {
+                Assert.Equal(r1[i], r2[i]);
+                Assert.Equal(r1[i], r3[i]);
+            }
+        }
+        finally
+        {
+            AiDotNetEngine.SetDeterministicMode(original);
+        }
+    }
+
+    [Fact]
+    public void DeterministicMode_MatMul_NumericallyCloseToDefault()
+    {
+        // Sanity: deterministic and default should give the same result to reasonable FP tolerance.
+        // This catches regressions where deterministic mode accidentally computes something wrong.
+        bool original = AiDotNetEngine.DeterministicMode;
+        try
+        {
+            int m = 64, k = 64, n = 64;
+            var rng = new Random(123);
+            var a = new Tensor<float>([m, k]);
+            var b = new Tensor<float>([k, n]);
+            for (int i = 0; i < m * k; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+            for (int i = 0; i < k * n; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+
+            var engine = new CpuEngine();
+
+            AiDotNetEngine.SetDeterministicMode(false);
+            var rDefault = engine.TensorMatMul(a, b);
+
+            AiDotNetEngine.SetDeterministicMode(true);
+            var rDeterministic = engine.TensorMatMul(a, b);
+
+            for (int i = 0; i < m * n; i++)
+            {
+                // 1e-4 relative tolerance — allows for accumulation-order differences
+                // between MKL and the blocked fallback, but catches any real bugs.
+                float expected = rDefault[i];
+                float actual = rDeterministic[i];
+                float tolerance = 1e-4f * Math.Max(1f, Math.Abs(expected));
+                Assert.True(Math.Abs(expected - actual) <= tolerance,
+                    $"At index {i}: expected {expected}, got {actual}, diff {Math.Abs(expected - actual)}");
+            }
+        }
+        finally
+        {
+            AiDotNetEngine.SetDeterministicMode(original);
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/DeterministicModeTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DeterministicModeTests.cs
@@ -5,10 +5,27 @@ using Xunit;
 namespace AiDotNet.Tensors.Tests.Engines;
 
 /// <summary>
+/// Collection fixture that forces DeterministicModeTests to run sequentially and
+/// in isolation from any other test classes that share this collection. The tests
+/// mutate a process-wide static flag (AiDotNetEngine.DeterministicMode) which
+/// would otherwise race with concurrent matmul/BLAS tests under xUnit's default
+/// parallel execution. Putting all BLAS-state-mutating test classes in this
+/// collection serializes their execution with respect to each other and guarantees
+/// the flag is stable for the duration of each test method.
+/// </summary>
+[CollectionDefinition("BlasGlobalState", DisableParallelization = true)]
+public sealed class BlasGlobalStateCollection { }
+
+/// <summary>
 /// Tests for AiDotNetEngine.SetDeterministicMode — verifies the public API surface
 /// and that enabling deterministic mode produces bit-exact reproducible results for
 /// large matmuls (the hot path that uses MKL.NET in default mode).
+///
+/// Marked with [Collection("BlasGlobalState")] so these tests run serialized —
+/// they toggle a process-wide static flag that would race with concurrent BLAS
+/// calls from other parallel test classes.
 /// </summary>
+[Collection("BlasGlobalState")]
 public class DeterministicModeTests
 {
     [Fact]

--- a/tests/AiDotNet.Tensors.Tests/Engines/DeterministicModeTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DeterministicModeTests.cs
@@ -54,7 +54,8 @@ public class DeterministicModeTests
         {
             AiDotNetEngine.SetDeterministicMode(true);
 
-            // Large enough to hit the BLAS work threshold (2*128*128*128 = 4.2M, above default threshold)
+            // Large enough to clear MatrixMultiplyHelper's BLAS work threshold (work = m*k*n,
+            // DefaultBlasWorkThreshold = 4096; 128*128*128 = 2,097,152 >> 4096).
             int m = 128, k = 128, n = 128;
             var rng = new Random(42);
             var a = new Tensor<float>([m, k]);


### PR DESCRIPTION
Fixes #131. Single consolidated PR containing the full deterministic-matmul work: the public API, the A/B benchmark harness, and 17 iterations of kernel and dispatch optimizations.

## TL;DR

**Issue #131 reported non-deterministic val-loss in HRE training on Tiny Shakespeare.** Investigation identified MKL.NET's multi-threaded GEMM as the only source of non-determinism in CPU reductions (all other reductions — TensorSum, TensorSumOfSquares, TensorMean, TensorLogSoftmax — were already deterministic).

This PR:
1. Exposes a public \`AiDotNetEngine.SetDeterministicMode(bool)\` API that routes matmul through a bit-exact blocked C# fallback
2. Adds a BDN A/B benchmark harness to measure the cost
3. Closes 17 A/B-tested iterations of kernel optimizations, taking the deterministic path from **13.6× slower than MKL to 1.26× or faster**

## Final benchmark results

With tightened BDN measurements (\`launchCount=2, warmupCount=5, iterationCount=15\`) — medians on Ryzen 9 3950X:

| Shape | Sequential baseline | **Final** | Total Speedup | vs MKL |
|---|---:|---:|---:|---:|
| Square [512,512]² | 5,933 μs | **1,007 μs** | **5.89×** | **1.15×** |
| Square [1024,1024]² | 48,830 μs | **4,385 μs** | **11.13×** | **1.26×** |
| LM-head [64,128]×50257 | 70,140 μs | **9,730 μs** | **7.21×** | **0.75× (25% FASTER)** |

**94% of the 1024² gap closed. 97% of the 512² gap closed. LM-head beats MKL.**

## What's in this PR

### Public API (commits 1-2)
- \`AiDotNetEngine.SetDeterministicMode(bool)\` + \`AiDotNetEngine.DeterministicMode\` getter
- \`BlasProvider.TryGemm\` (all 6 entry points) short-circuit early in deterministic mode, routing matmul to the bit-exact blocked fallback
- \`BlasProvider.IsMklVerified\` returns false in deterministic mode, gating direct-MKL hot paths
- Saves/restores prior \`_useMklNet\` state so toggling off restores MKL cleanly
- Fixed a **latent net10.0 access-violation crash** in \`ApplyThreadSettings\` where native thread-control symbols could corrupt the stack when invoked on libraries that exported compatible names with incompatible signatures
- \`_deterministicMode\` marked \`volatile\` for correct lock-free hot-path reads

### Benchmark harness (commit 3)
- \`DeterministicMatMulBenchmarks\` — 36 benchmarks (9 shapes × 2 DeterministicMode × 2 UseParallelGemm params)
- Covers HRE baseline/scaled shapes, small/mid square matmul, GPT-2-vocab LM head
- Wired into Program.cs as \`--vs-deterministic-matmul\`

### Perf iterations (commits 4-17)

| Iter | Change | Key impact |
|---|---|---|
| 1 | Wire up \`SgemmTiledParallelM\` (existed but had zero callers) | 2.09× at 1024² |
| 2 | \`Mc\` 256→128, raise parallel threshold 4M→20M | 1.51× more |
| 3 | A-register reuse in MicroKernel6x16 (15 live ymm regs, no spills) | Small-shape wins |
| **4** | **New 2D parallel grid \`SgemmTiledParallel2D\`** | **Breaks row-block ceiling** |
| 5 | Use logical cores for col-sub heuristic (SMT helps load-port-limited GEMM) | 1.18× |
| **6** | **Skip 8MB serial A/B memcpy, pin spans via \`fixed\`** | **1.74× (biggest non-compute win)** |
| **7** | **Allow \`numRowBlocks=1\` in 2D path** | **Unlocked LM-head (7.3× that shape)** |
| 9 | Software prefetch in micro-kernel (later removed in iter 16) | Neutral |
| 11 | SIMD-vectorize PackB non-transpose full-Nr panel path | 1.10× large |
| 12 | Fuse PackA+PackB into one parallel dispatch | 1.23× (saves barrier) |
| 14 | Unroll PackA inner loop with hoisted row pointers | Small-shape wins |
| 16 | Remove iter-9 software prefetch (hw prefetcher already handles it) | Cleaner code |
| **17** | **2x-unroll the JIT GEMM K loop in CpuJitKernels** | **1.40× at 1024² — biggest inner-loop win** |

### Reverted in-session (not in PR)

Each of these was tried, benchmarked, and rolled back before commit:
- **Mc=64** — too small for cache reuse, not a multiple of Mr=6
- **Kc=256** — more pc iters = more parallel barriers
- **Pin C outside MacroKernel loop** — JIT was already eliding inner-loop fixed statements
- **pc loop inside each tile** — doubled per-tile cache working set, regressed 1024²
- **Split prefetch loop** — catastrophic regression, JIT couldn't inline enlarged method
- **4x K-loop unroll** — L1 icache pressure regressed 1024² vs the 2x sweet spot

A/B was the final gate on every change.

## Review fixes included (from the consolidated stack)

Seven review comments from copilot-pull-request-reviewer and coderabbitai were resolved in an earlier review round and are included in this branch:

1. \`_deterministicMode\` marked \`volatile\` — lock-free hot-path reads need visibility
2. \`BlasProvider._deterministicMode\` XML summary updated (was stale after iter work removed native thread-control)
3. \`AiDotNetEngine.SetDeterministicMode\` XML docs updated to reflect actual behavior (TryGemm short-circuit, not \`mkl_set_num_threads\`)
4. \`BlasProvider.ApplyThreadSettings\` comment updated — only env var triggers it, not deterministic mode
5. \`DeterministicModeTests\` placed in a \`BlasGlobalState\` xUnit collection with \`DisableParallelization=true\` to prevent racing with concurrent parallel test classes

## Test plan
- [x] Build clean (0 errors, 0 warnings)
- [x] 95+ correctness tests pass on net10.0 + net471 (DeterministicMode, BatchMatMul, CpuEngineOperations, FusedLinear, NativeComplexOps, BackwardBufferPooling)
- [x] Bit-exactness of deterministic mode preserved across all iterations (2D parallel workers write disjoint output tiles, inner pc loops run in fixed order, micro-kernel FMA order is fixed)
- [x] A/B benchmark with tightened measurements after every iteration
- [ ] Independent verification on HRE training run — reporter to confirm stable seeded val-loss with deterministic mode enabled

Run benchmarks:
\`\`\`
dotnet run -c Release --project tests/AiDotNet.Tensors.Benchmarks -- --vs-deterministic-matmul
\`\`\`

Use the API:
\`\`\`csharp
AiDotNetEngine.SetDeterministicMode(true);
// ...training runs here...
AiDotNetEngine.SetDeterministicMode(false);  // restore default MKL path
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)