### PR TITLE
fix: add InternalsVisibleTo for AiDotNetTests assembly

### DIFF
--- a/src/AiDotNet.Tensors/AiDotNet.Tensors.csproj
+++ b/src/AiDotNet.Tensors/AiDotNet.Tensors.csproj
@@ -37,6 +37,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="AiDotNet" />
+    <InternalsVisibleTo Include="AiDotNetTests" />
     <InternalsVisibleTo Include="AiDotNet.Tensors.Tests" />
     <InternalsVisibleTo Include="AiDotNet.Tensors.Benchmarks" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- Adds `<InternalsVisibleTo Include="AiDotNetTests" />` to `AiDotNet.Tensors.csproj`
- The AiDotNet test project (assembly name `AiDotNetTests`) uses `Tensor<T>.Data.Span` in `CompiledTapeTrainingStepTests`, which is internal
- Without this attribute, the AiDotNet CI build fails with CS1061 on both net10.0 and net471 (see [AiDotNet PR #1107](https://github.com/ooples/AiDotNet/pull/1107))

## Test plan
- [ ] Verify this NuGet builds and publishes successfully
- [ ] Update AiDotNet `Directory.Packages.props` to reference the new Tensors version
- [ ] Confirm AiDotNet CI build passes on both net10.0 and net471

🤖 Generated with [Claude Code](https://claude.com/claude-code)