### PR TITLE
fix: address post-merge PR #140 review comments

### DIFF
--- a/src/AiDotNet.Tensors/LinearAlgebra/Tensor.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/Tensor.cs
@@ -319,8 +319,8 @@ public class Tensor<T> : TensorBase<T>, IEnumerable<T>
     /// <summary>
     /// Returns a <see cref="Vector{T}"/> view of this rank-1 tensor — zero-copy
     /// when the backing data length matches, otherwise a trimmed copy.
-    /// Only valid for rank-1 tensors. For sliced views (non-zero storage offset)
-    /// or sparse tensors, throws — call <c>.Contiguous()</c> first.
+    /// Only valid for rank-1, contiguous, non-sparse tensors with zero storage
+    /// offset. For sparse tensors, use <c>SparseTensor&lt;T&gt;.ToDense()</c>.
     /// </summary>
     /// <exception cref="InvalidOperationException">If the tensor is not rank-1,
     /// not contiguous, has a non-zero storage offset, or is sparse.</exception>
@@ -333,7 +333,7 @@ public class Tensor<T> : TensorBase<T>, IEnumerable<T>
         if (IsSparse)
             throw new InvalidOperationException(
                 "AsVector does not support sparse tensors. " +
-                "Call .Contiguous() first to densify.");
+                "Use SparseTensor<T>.ToDense() first.");
         if (!IsContiguous || _storageOffset != 0)
             throw new InvalidOperationException(
                 "AsVector requires a contiguous tensor with zero storage offset. " +

--- a/src/AiDotNet.Tensors/LinearAlgebra/Vector.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/Vector.cs
@@ -1662,7 +1662,7 @@ public class Vector<T> : VectorBase<T>, IEnumerable<T>
     /// Returns a rank-1 <see cref="Tensor{T}"/> that shares the same backing
     /// memory as this vector — zero-copy. Mutations to either are visible in
     /// the other. The returned tensor has shape <c>[Length]</c>.
-    /// Forces CPU materialization for deferred vectors via AsWritableMemory().
+    /// Forces CPU materialization for deferred vectors if needed.
     /// </summary>
     public Tensor<T> AsTensor()
     {

--- a/src/AiDotNet.Tensors/LinearAlgebra/Vector.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/Vector.cs
@@ -1662,15 +1662,10 @@ public class Vector<T> : VectorBase<T>, IEnumerable<T>
     /// Returns a rank-1 <see cref="Tensor{T}"/> that shares the same backing
     /// memory as this vector — zero-copy. Mutations to either are visible in
     /// the other. The returned tensor has shape <c>[Length]</c>.
-    /// Forces CPU materialization for deferred/GPU-backed vectors.
+    /// Forces CPU materialization for deferred vectors via AsWritableMemory().
     /// </summary>
     public Tensor<T> AsTensor()
     {
-        var memory = AsWritableMemory();
-        if (memory.Length == 0 && Length > 0)
-            throw new InvalidOperationException(
-                "Cannot create a Tensor view of a GPU-resident or unmaterialized vector. " +
-                "Copy to CPU first.");
-        return Tensor<T>.FromMemory(memory, [Length]);
+        return Tensor<T>.FromMemory(AsWritableMemory(), [Length]);
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/ZeroCopyConversionTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/ZeroCopyConversionTests.cs
@@ -69,21 +69,24 @@ public class ZeroCopyConversionTests
     }
 
     [Fact]
-    public void TensorAsVector_SparseCheck()
+    public void TensorAsVector_DenseRank1_ReturnsCorrectLength()
     {
         var tensor = new Tensor<double>([4]);
         for (int i = 0; i < 4; i++) tensor[i] = i;
         var vec = tensor.AsVector();
         Assert.Equal(4, vec.Length);
+        Assert.Equal(2.0, vec[2]);
     }
 
     [Fact]
-    public void TensorAsVector_LengthMismatch_ReturnsCopy()
+    public void AsTensor_AsVector_RoundTrip_SharesMemory()
     {
         var vec = new Vector<double>([10.0, 20.0, 30.0, 40.0, 50.0]);
         var tensor = vec.AsTensor();
         var roundTrip = tensor.AsVector();
         Assert.Equal(5, roundTrip.Length);
         Assert.Equal(30.0, roundTrip[2]);
+        roundTrip[0] = 999.0;
+        Assert.Equal(999.0, vec[0]);
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to merged PR #140 addressing 6 review comments:

1. **AsVector() sparse message**: point to `SparseTensor<T>.ToDense()` instead of `.Contiguous()` (which throws for sparse)
2. **AsTensor() unreachable guard**: removed — `AsWritableMemory()` already forces materialization
3. **Test rename**: `SparseCheck` → `DenseRank1_ReturnsCorrectLength` (describes what it tests)
4. **Test fix**: `LengthMismatch_ReturnsCopy` → `RoundTrip_SharesMemory` with mutation assertion
5. **XML docs**: updated to document rank-1 requirement and sparse alternative

## Test plan

- [x] 7/7 ZeroCopy tests pass on net10.0 + net471

🤖 Generated with [Claude Code](https://claude.com/claude-code)