### PR TITLE
fix: RBFKernel backward had swapped epsilons/output args + missing epsilon gradients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ ehthumbs.db
 # Large native binaries (too large for git, build locally for NuGet)
 # CUDA binaries (~770MB total) - download from NVIDIA CUDA Toolkit
 src/AiDotNet.Native.CUDA/runtimes/*/native/*.dll
+.claude/scheduled_tasks.lock

--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -2806,12 +2806,122 @@ internal static class BackwardFunctions<T>
         Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
         object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
     {
-        var numOps = MathHelper.GetNumericOperations<T>();
-        var gamma = numOps.FromDouble((double)savedState[0]);
-        var gammaT = new Tensor<T>(new[] { gamma }, new[] { 1 });
-        var (gradX, gradY, gradGamma) = engine.RBFKernelBackward(gradOutput, inputs[0], inputs[1], output, gammaT);
+        // inputs: [0]=input, [1]=centers, [2]=epsilons
+        // RBFKernelBackward signature: (gradOutput, input, centers, epsilons, output)
+        var (gradX, gradCenters, gradEpsilons) = engine.RBFKernelBackward(gradOutput, inputs[0], inputs[1], inputs[2], output);
         DifferentiableOps.AccumulateGrad(grads, inputs[0], gradX, engine);
-        DifferentiableOps.AccumulateGrad(grads, inputs[1], gradY, engine);
+        DifferentiableOps.AccumulateGrad(grads, inputs[1], gradCenters, engine);
+        DifferentiableOps.AccumulateGrad(grads, inputs[2], gradEpsilons, engine);
+    }
+
+    /// <summary>
+    /// OctonionMatMulTensor backward. Forward: output[b,o,:] = sum_i(weight[o,i,:] * input[b,i,:]).
+    /// Gradients use the 8x8 Jacobians of octonion multiplication (non-commutative).
+    /// For r = w * x: dR/dX = Jacobian_B(w), dR/dW = Jacobian_A(x).
+    /// gradInput[b,i,:] = sum_o (J_B(w[o,i])^T @ gradOut[b,o,:])
+    /// gradWeight[o,i,:] = sum_b (J_A(x[b,i])^T @ gradOut[b,o,:])
+    /// </summary>
+    internal static void OctonionMatMulBackward(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
+        object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        var input = inputs[0];  // [batch, inputFeatures, 8]
+        var weight = inputs[1]; // [outputFeatures, inputFeatures, 8]
+        var numOps = MathHelper.GetNumericOperations<T>();
+
+        int batch = input._shape[0];
+        int inputFeatures = input._shape[1];
+        int outputFeatures = weight._shape[0];
+
+        var gradInput = new Tensor<T>(input._shape);
+        var gradWeight = new Tensor<T>(weight._shape);
+
+        var w = new double[8];
+        var x = new double[8];
+        var g = new double[8];
+        var jac = new double[64]; // 8x8 Jacobian
+
+        for (int b = 0; b < batch; b++)
+        {
+            for (int i = 0; i < inputFeatures; i++)
+            {
+                for (int o = 0; o < outputFeatures; o++)
+                {
+                    // Load weight[o, i, :] and input[b, i, :] and gradOutput[b, o, :]
+                    for (int c = 0; c < 8; c++)
+                    {
+                        w[c] = numOps.ToDouble(weight[o, i, c]);
+                        x[c] = numOps.ToDouble(input[b, i, c]);
+                        g[c] = numOps.ToDouble(gradOutput[b, o, c]);
+                    }
+
+                    // gradInput += J_B(w)^T @ gradOut  (Jacobian of r=w*x w.r.t. x, transposed)
+                    OctonionJacobianB(w, jac);
+                    for (int ci = 0; ci < 8; ci++)
+                    {
+                        double sum = 0;
+                        for (int co = 0; co < 8; co++)
+                            sum += jac[co * 8 + ci] * g[co]; // J^T: column ci of J = row ci of J^T
+                        gradInput[b, i, ci] = numOps.Add(gradInput[b, i, ci], numOps.FromDouble(sum));
+                    }
+
+                    // gradWeight += J_A(x)^T @ gradOut  (Jacobian of r=w*x w.r.t. w, transposed)
+                    OctonionJacobianA(x, jac);
+                    for (int ci = 0; ci < 8; ci++)
+                    {
+                        double sum = 0;
+                        for (int co = 0; co < 8; co++)
+                            sum += jac[co * 8 + ci] * g[co];
+                        gradWeight[o, i, ci] = numOps.Add(gradWeight[o, i, ci], numOps.FromDouble(sum));
+                    }
+                }
+            }
+        }
+
+        DifferentiableOps.AccumulateGrad(grads, input, gradInput, engine);
+        DifferentiableOps.AccumulateGrad(grads, weight, gradWeight, engine);
+    }
+
+    /// <summary>Jacobian of r = a * b w.r.t. a (left factor). 8x8 row-major.</summary>
+    private static void OctonionJacobianA(double[] b, double[] jac)
+    {
+        // Row 0: r0 = a0*b0 - a1*b1 - a2*b2 - a3*b3 - a4*b4 - a5*b5 - a6*b6 - a7*b7
+        jac[0] = b[0]; jac[1] = -b[1]; jac[2] = -b[2]; jac[3] = -b[3]; jac[4] = -b[4]; jac[5] = -b[5]; jac[6] = -b[6]; jac[7] = -b[7];
+        // Row 1: r1 = a0*b1 + a1*b0 + a2*b3 - a3*b2 + a4*b5 - a5*b4 - a6*b7 + a7*b6
+        jac[8] = b[1]; jac[9] = b[0]; jac[10] = b[3]; jac[11] = -b[2]; jac[12] = b[5]; jac[13] = -b[4]; jac[14] = -b[7]; jac[15] = b[6];
+        // Row 2: r2 = a0*b2 - a1*b3 + a2*b0 + a3*b1 + a4*b6 + a5*b7 - a6*b4 - a7*b5
+        jac[16] = b[2]; jac[17] = -b[3]; jac[18] = b[0]; jac[19] = b[1]; jac[20] = b[6]; jac[21] = b[7]; jac[22] = -b[4]; jac[23] = -b[5];
+        // Row 3: r3 = a0*b3 + a1*b2 - a2*b1 + a3*b0 + a4*b7 - a5*b6 + a6*b5 - a7*b4
+        jac[24] = b[3]; jac[25] = b[2]; jac[26] = -b[1]; jac[27] = b[0]; jac[28] = b[7]; jac[29] = -b[6]; jac[30] = b[5]; jac[31] = -b[4];
+        // Row 4: r4 = a0*b4 - a1*b5 - a2*b6 - a3*b7 + a4*b0 + a5*b1 + a6*b2 + a7*b3
+        jac[32] = b[4]; jac[33] = -b[5]; jac[34] = -b[6]; jac[35] = -b[7]; jac[36] = b[0]; jac[37] = b[1]; jac[38] = b[2]; jac[39] = b[3];
+        // Row 5: r5 = a0*b5 + a1*b4 - a2*b7 + a3*b6 - a4*b1 + a5*b0 - a6*b3 + a7*b2
+        jac[40] = b[5]; jac[41] = b[4]; jac[42] = -b[7]; jac[43] = b[6]; jac[44] = -b[1]; jac[45] = b[0]; jac[46] = -b[3]; jac[47] = b[2];
+        // Row 6: r6 = a0*b6 + a1*b7 + a2*b4 - a3*b5 - a4*b2 + a5*b3 + a6*b0 - a7*b1
+        jac[48] = b[6]; jac[49] = b[7]; jac[50] = b[4]; jac[51] = -b[5]; jac[52] = -b[2]; jac[53] = b[3]; jac[54] = b[0]; jac[55] = -b[1];
+        // Row 7: r7 = a0*b7 - a1*b6 + a2*b5 + a3*b4 - a4*b3 - a5*b2 + a6*b1 + a7*b0
+        jac[56] = b[7]; jac[57] = -b[6]; jac[58] = b[5]; jac[59] = b[4]; jac[60] = -b[3]; jac[61] = -b[2]; jac[62] = b[1]; jac[63] = b[0];
+    }
+
+    /// <summary>Jacobian of r = a * b w.r.t. b (right factor). 8x8 row-major.</summary>
+    private static void OctonionJacobianB(double[] a, double[] jac)
+    {
+        // Row 0: r0 = a0*b0 - a1*b1 - a2*b2 - a3*b3 - a4*b4 - a5*b5 - a6*b6 - a7*b7
+        jac[0] = a[0]; jac[1] = -a[1]; jac[2] = -a[2]; jac[3] = -a[3]; jac[4] = -a[4]; jac[5] = -a[5]; jac[6] = -a[6]; jac[7] = -a[7];
+        // Row 1: r1 = a0*b1 + a1*b0 + a2*b3 - a3*b2 + a4*b5 - a5*b4 - a6*b7 + a7*b6
+        jac[8] = a[1]; jac[9] = a[0]; jac[10] = -a[3]; jac[11] = a[2]; jac[12] = -a[5]; jac[13] = a[4]; jac[14] = a[7]; jac[15] = -a[6];
+        // Row 2
+        jac[16] = a[2]; jac[17] = a[3]; jac[18] = a[0]; jac[19] = -a[1]; jac[20] = -a[6]; jac[21] = -a[7]; jac[22] = a[4]; jac[23] = a[5];
+        // Row 3
+        jac[24] = a[3]; jac[25] = -a[2]; jac[26] = a[1]; jac[27] = a[0]; jac[28] = -a[7]; jac[29] = a[6]; jac[30] = -a[5]; jac[31] = a[4];
+        // Row 4
+        jac[32] = a[4]; jac[33] = a[5]; jac[34] = a[6]; jac[35] = a[7]; jac[36] = a[0]; jac[37] = -a[1]; jac[38] = -a[2]; jac[39] = -a[3];
+        // Row 5
+        jac[40] = a[5]; jac[41] = -a[4]; jac[42] = a[7]; jac[43] = -a[6]; jac[44] = a[1]; jac[45] = a[0]; jac[46] = a[3]; jac[47] = -a[2];
+        // Row 6
+        jac[48] = a[6]; jac[49] = -a[7]; jac[50] = -a[4]; jac[51] = a[5]; jac[52] = a[2]; jac[53] = -a[3]; jac[54] = a[0]; jac[55] = a[1];
+        // Row 7
+        jac[56] = a[7]; jac[57] = a[6]; jac[58] = -a[5]; jac[59] = -a[4]; jac[60] = a[3]; jac[61] = a[2]; jac[62] = -a[1]; jac[63] = a[0];
     }
 
     /// <summary>TensorBinaryCrossEntropy backward via engine</summary>

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -18558,7 +18558,7 @@ public class CpuEngine : ITensorLevelEngine
             }
         }
 
-        DifferentiableOps.RecordIfActive("RBFKernel", output, new[] { input, centers }, BackwardFunctions<T>.RBFKernelBackward, new object[] { numOps.ToDouble(epsilonsData[0]) });
+        DifferentiableOps.RecordIfActive("RBFKernel", output, new[] { input, centers, epsilons }, BackwardFunctions<T>.RBFKernelBackward, epsilonsData.Length > 0 ? new object[] { numOps.ToDouble(epsilonsData[0]) } : Array.Empty<object>());
         { var ci = input; var cc = centers; var ce = epsilons; AutoTracer.RecordOp("RBFKernel", output, eng => eng.RBFKernel(ci, cc, ce)); }
         return output;
     }
@@ -18601,6 +18601,10 @@ public class CpuEngine : ITensorLevelEngine
         var gradInput = AutoTensorCache.RentOrAllocate<T>(input._shape);
         var gradCenters = AutoTensorCache.RentOrAllocate<T>(centers._shape);
         var gradEpsilons = AutoTensorCache.RentOrAllocate<T>(epsilons._shape);
+        // Zero pooled buffers — RentOrAllocate can return stale data from the cache
+        gradInput.AsWritableSpan().Clear();
+        gradCenters.AsWritableSpan().Clear();
+        gradEpsilons.AsWritableSpan().Clear();
 
         var inputData = input.GetFlattenedData();
         var centersData = centers.GetFlattenedData();
@@ -27082,7 +27086,7 @@ public class CpuEngine : ITensorLevelEngine
         => _algebraEngine.So3AdjointBatch(group, rotations);
 
     /// <inheritdoc />
-    public Tensor<T> OctonionMatMulTensor<T>(Tensor<T> input, Tensor<T> weight)
+    public virtual Tensor<T> OctonionMatMulTensor<T>(Tensor<T> input, Tensor<T> weight)
     {
         if (input.Rank != 3 || input._shape[2] != 8)
             throw new ArgumentException($"Input must be rank-3 with last dim 8, got shape [{string.Join(", ", input._shape)}].", nameof(input));
@@ -27090,8 +27094,9 @@ public class CpuEngine : ITensorLevelEngine
             throw new ArgumentException($"Weight must be rank-3 with last dim 8, got shape [{string.Join(", ", weight._shape)}].", nameof(weight));
         if (input._shape[1] != weight._shape[1])
             throw new ArgumentException($"Input features ({input._shape[1]}) must match weight input dimension ({weight._shape[1]}).");
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_input = input; var c_weight = weight; return scope.RecordBinary(LazyNodeType.Custom, "OctonionMatMulTensor", input, weight, input._shape, (eng, output) => { var r = eng.OctonionMatMulTensor(c_input, c_weight); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.MatMulBackward); } }
-        { var ac = AutoTracer.TryGetCompiledPlan<T>("OctonionMatMulTensor", input._shape); if (ac is not null) return ac.Execute(); }
+        var outputShape = new[] { input._shape[0], weight._shape[0], 8 };
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_input = input; var c_weight = weight; return scope.RecordBinary(LazyNodeType.Custom, "OctonionMatMulTensor", input, weight, outputShape, (eng, output) => { var r = eng.OctonionMatMulTensor(c_input, c_weight); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.OctonionMatMulBackward); } }
+        { var ac = AutoTracer.TryGetCompiledPlan<T>("OctonionMatMulTensor", outputShape); if (ac is not null) return ac.Execute(); }
 
         var numOps = MathHelper.GetNumericOperations<T>();
 
@@ -27137,7 +27142,7 @@ public class CpuEngine : ITensorLevelEngine
             }
         }
 
-        DifferentiableOps.RecordBinary("OctonionMatMulTensor", output, input, weight, BackwardFunctions<T>.MatMulBackward);
+        DifferentiableOps.RecordBinary("OctonionMatMulTensor", output, input, weight, BackwardFunctions<T>.OctonionMatMulBackward);
         { var ci = input; var cw = weight; AutoTracer.RecordOp("OctonionMatMulTensor", output, eng => eng.OctonionMatMulTensor(ci, cw)); }
         return output;
     }
@@ -27204,55 +27209,51 @@ public class CpuEngine : ITensorLevelEngine
     }
 
     /// <summary>
-    /// Zero-allocation octonion multiply that writes result into a pre-allocated destination buffer.
-    /// Uses direct multiplication table instead of Cayley-Dickson decomposition to avoid
-    /// intermediate quaternion allocations.
+    /// Zero-allocation octonion multiply using the standard Cayley-Dickson table.
+    /// Matches the CUDA kernels in CudaOctonionKernels.cs and the backward
+    /// Jacobian tables in BackwardFunctions.OctonionJacobianA/B. Uses static
+    /// sign/index lookup tables and a simple accumulation loop — no nested
+    /// ops.Add/Subtract chains that were prone to sign errors.
     /// </summary>
+    // Standard Cayley-Dickson octonion multiplication sign table.
+    // signs[component][term]: +1 or -1 for the a[term]*b[bIdx[term]] product.
+    private static readonly int[][] OctonionSigns = {
+        new[]{ 1,-1,-1,-1,-1,-1,-1,-1}, // e0
+        new[]{ 1, 1, 1,-1, 1,-1,-1, 1}, // e1
+        new[]{ 1,-1, 1, 1, 1, 1,-1,-1}, // e2
+        new[]{ 1, 1,-1, 1, 1,-1, 1,-1}, // e3
+        new[]{ 1,-1,-1,-1, 1, 1, 1, 1}, // e4
+        new[]{ 1, 1,-1, 1,-1, 1,-1, 1}, // e5
+        new[]{ 1, 1, 1,-1,-1, 1, 1,-1}, // e6
+        new[]{ 1,-1, 1, 1,-1,-1, 1, 1}, // e7
+    };
+
+    // b-index table: bIdx[component][term] gives which b[j] multiplies a[term].
+    private static readonly int[][] OctonionBIdx = {
+        new[]{0,1,2,3,4,5,6,7}, // e0
+        new[]{1,0,3,2,5,4,7,6}, // e1
+        new[]{2,3,0,1,6,7,4,5}, // e2
+        new[]{3,2,1,0,7,6,5,4}, // e3
+        new[]{4,5,6,7,0,1,2,3}, // e4
+        new[]{5,4,7,6,1,0,3,2}, // e5
+        new[]{6,7,4,5,2,3,0,1}, // e6
+        new[]{7,6,5,4,3,2,1,0}, // e7
+    };
+
     private static void OctonionMultiplyInPlace<T>(T[] a, T[] b, T[] result, INumericOperations<T> ops)
     {
-        T a0=a[0],a1=a[1],a2=a[2],a3=a[3],a4=a[4],a5=a[5],a6=a[6],a7=a[7];
-        T b0=b[0],b1=b[1],b2=b[2],b3=b[3],b4=b[4],b5=b[5],b6=b[6],b7=b[7];
-
-        // e0
-        result[0] = ops.Subtract(ops.Subtract(ops.Subtract(ops.Subtract(
-            ops.Subtract(ops.Subtract(ops.Subtract(ops.Multiply(a0,b0), ops.Multiply(a1,b1)),
-            ops.Multiply(a2,b2)), ops.Multiply(a3,b3)), ops.Multiply(a4,b4)),
-            ops.Multiply(a5,b5)), ops.Multiply(a6,b6)), ops.Multiply(a7,b7));
-        // e1
-        result[1] = ops.Add(ops.Subtract(ops.Add(ops.Add(
-            ops.Subtract(ops.Add(ops.Add(ops.Multiply(a0,b1), ops.Multiply(a1,b0)),
-            ops.Multiply(a2,b3)), ops.Multiply(a3,b2)), ops.Multiply(a4,b5)),
-            ops.Multiply(a5,b4)), ops.Multiply(a6,b7)), ops.Multiply(a7,b6));
-        // e2
-        result[2] = ops.Subtract(ops.Subtract(ops.Add(ops.Add(
-            ops.Add(ops.Subtract(ops.Add(ops.Multiply(a0,b2), ops.Multiply(a2,b0)),
-            ops.Multiply(a1,b3)), ops.Multiply(a3,b1)), ops.Multiply(a4,b6)),
-            ops.Multiply(a5,b7)), ops.Multiply(a6,b4)), ops.Multiply(a7,b5));
-        // e3
-        result[3] = ops.Subtract(ops.Add(ops.Subtract(ops.Add(
-            ops.Add(ops.Subtract(ops.Add(ops.Multiply(a0,b3), ops.Multiply(a3,b0)),
-            ops.Multiply(a2,b1)), ops.Multiply(a1,b2)), ops.Multiply(a4,b7)),
-            ops.Multiply(a5,b6)), ops.Multiply(a6,b5)), ops.Multiply(a7,b4));
-        // e4
-        result[4] = ops.Add(ops.Add(ops.Add(ops.Subtract(
-            ops.Subtract(ops.Subtract(ops.Add(ops.Multiply(a0,b4), ops.Multiply(a4,b0)),
-            ops.Multiply(a1,b5)), ops.Multiply(a2,b6)), ops.Multiply(a3,b7)),
-            ops.Multiply(a5,b1)), ops.Multiply(a6,b2)), ops.Multiply(a7,b3));
-        // e5
-        result[5] = ops.Add(ops.Subtract(ops.Subtract(ops.Add(
-            ops.Add(ops.Subtract(ops.Add(ops.Multiply(a0,b5), ops.Multiply(a5,b0)),
-            ops.Multiply(a4,b1)), ops.Multiply(a1,b4)), ops.Multiply(a3,b6)),
-            ops.Multiply(a2,b7)), ops.Multiply(a6,b3)), ops.Multiply(a7,b2));
-        // e6
-        result[6] = ops.Subtract(ops.Add(ops.Subtract(ops.Add(
-            ops.Subtract(ops.Add(ops.Add(ops.Multiply(a0,b6), ops.Multiply(a6,b0)),
-            ops.Multiply(a1,b7)), ops.Multiply(a4,b2)), ops.Multiply(a2,b4)),
-            ops.Multiply(a5,b3)), ops.Multiply(a3,b5)), ops.Multiply(a7,b1));
-        // e7
-        result[7] = ops.Add(ops.Subtract(ops.Subtract(ops.Subtract(
-            ops.Add(ops.Add(ops.Add(ops.Multiply(a0,b7), ops.Multiply(a7,b0)),
-            ops.Multiply(a2,b5)), ops.Multiply(a3,b4)), ops.Multiply(a1,b6)),
-            ops.Multiply(a4,b3)), ops.Multiply(a5,b2)), ops.Multiply(a6,b1));
+        for (int comp = 0; comp < 8; comp++)
+        {
+            T sum = ops.Zero;
+            var signs = OctonionSigns[comp];
+            var bIdx = OctonionBIdx[comp];
+            for (int term = 0; term < 8; term++)
+            {
+                T product = ops.Multiply(a[term], b[bIdx[term]]);
+                sum = signs[term] > 0 ? ops.Add(sum, product) : ops.Subtract(sum, product);
+            }
+            result[comp] = sum;
+        }
     }
 
     #endregion

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -14965,6 +14965,56 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         return base.TensorCIoULoss(predicted, target);
     }
 
+    // --- Octonion GPU overrides ---
+    // Dispatches OctonionMatMulTensor to GPU backends' OctonionLinearForward kernel.
+    // The GPU kernel expects a bias buffer; we pass zeros since OctonionMatMulTensor has no bias.
+
+    public override Tensor<T> OctonionMatMulTensor<T>(Tensor<T> input, Tensor<T> weight)
+    {
+        // Validate shapes match base implementation before indexing
+        if (input is null || weight is null
+            || input.Rank != 3 || input._shape[2] != 8
+            || weight.Rank != 3 || weight._shape[2] != 8
+            || input._shape[1] != weight._shape[1])
+            return base.OctonionMatMulTensor(input ?? throw new ArgumentNullException(nameof(input)),
+                weight ?? throw new ArgumentNullException(nameof(weight)));
+        if (typeof(T) != typeof(float))
+            return base.OctonionMatMulTensor(input, weight);
+        if (!TryGetBackend(out var backend))
+            return base.OctonionMatMulTensor(input, weight);
+
+        try
+        {
+            int batch = input._shape[0];
+            int inputFeatures = input._shape[1];
+            int outputFeatures = weight._shape[0];
+
+            // T is float — direct cast, no ToDouble round-trip
+            var inputF = (float[])(object)input.GetFlattenedData();
+            var weightF = (float[])(object)weight.GetFlattenedData();
+            var biasData = new float[outputFeatures * 8]; // zero bias
+
+            using var inputBuf = new OwnedBuffer(backend.AllocateBuffer(inputF), true);
+            using var weightBuf = new OwnedBuffer(backend.AllocateBuffer(weightF), true);
+            using var biasBuf = new OwnedBuffer(backend.AllocateBuffer(biasData), true);
+            using var outputBuf = new OwnedBuffer(backend.AllocateBuffer(batch * outputFeatures * 8), true);
+
+            backend.OctonionLinearForward(inputBuf.Buffer, weightBuf.Buffer, biasBuf.Buffer,
+                outputBuf.Buffer, batch, inputFeatures, outputFeatures);
+
+            var gpuResult = backend.DownloadBuffer(outputBuf.Buffer);
+            var result = new Tensor<T>(new[] { batch, outputFeatures, 8 });
+            var resultF = (float[])(object)result.GetDataArray();
+            Array.Copy(gpuResult, resultF, gpuResult.Length);
+
+            Autodiff.DifferentiableOps.RecordBinary("OctonionMatMulTensor", result, input, weight,
+                Autodiff.BackwardFunctions<T>.OctonionMatMulBackward);
+
+            return result;
+        }
+        catch { return base.OctonionMatMulTensor(input, weight); }
+    }
+
     // --- Native Complex<T> GPU overrides ---
     // Decomposes Tensor<Complex<T>> to split real/imag GPU buffers,
     // dispatches via IDirectGpuBackend.SplitComplex*, recomposes result.

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/BackwardBugFixTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/BackwardBugFixTests.cs
@@ -1,0 +1,215 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+/// <summary>
+/// Integration tests proving Issue #144 (OctonionMatMulTensor backward) and
+/// Issue #145 (RBFKernel backward) are fixed. Each test runs a forward pass
+/// through a GradientTape, computes backward, and verifies:
+///   1. No crash (the original bugs caused ArgumentException / shape mismatch)
+///   2. Gradient shapes match input shapes
+///   3. Gradients are non-zero (proving the backward function actually computed something)
+///   4. Numerical gradient check (finite differences) agrees with analytical gradients
+/// </summary>
+public class BackwardBugFixTests
+{
+    private readonly CpuEngine _engine = new();
+
+    // ================================================================
+    // Issue #144: OctonionMatMulTensor backward
+    // ================================================================
+
+    [Fact]
+    public void OctonionMatMulTensor_Backward_ProducesCorrectShapeGradients()
+    {
+        // Forward: output[b,o,:] = sum_i(weight[o,i,:] * input[b,i,:])
+        // input: [batch=2, inputFeatures=3, 8]
+        // weight: [outputFeatures=4, inputFeatures=3, 8]
+        var rng = new Random(42);
+        var input = new Tensor<double>([2, 3, 8]);
+        var weight = new Tensor<double>([4, 3, 8]);
+        for (int i = 0; i < input.Length; i++) input[i] = rng.NextDouble() * 2 - 1;
+        for (int i = 0; i < weight.Length; i++) weight[i] = rng.NextDouble() * 2 - 1;
+
+        using var tape = new GradientTape<double>();
+        var output = _engine.OctonionMatMulTensor(input, weight);
+
+        // Sum output to get scalar loss for backward
+        var loss = _engine.ReduceSum(output, null);
+
+        var grads = tape.ComputeGradients(loss,
+            new[] { input, weight });
+
+        Assert.True(grads.ContainsKey(input), "No gradient for input");
+        Assert.True(grads.ContainsKey(weight), "No gradient for weight");
+
+        // Shapes must match inputs
+        Assert.Equal(input.Shape.ToArray(), grads[input].Shape.ToArray());
+        Assert.Equal(weight.Shape.ToArray(), grads[weight].Shape.ToArray());
+
+        // Gradients must be non-zero
+        bool inputHasNonZero = false;
+        bool weightHasNonZero = false;
+        for (int i = 0; i < grads[input].Length; i++)
+            if (Math.Abs(grads[input][i]) > 1e-10) { inputHasNonZero = true; break; }
+        for (int i = 0; i < grads[weight].Length; i++)
+            if (Math.Abs(grads[weight][i]) > 1e-10) { weightHasNonZero = true; break; }
+
+        Assert.True(inputHasNonZero, "Input gradient is all zeros");
+        Assert.True(weightHasNonZero, "Weight gradient is all zeros");
+    }
+
+    [Fact]
+    public void OctonionMatMulTensor_Backward_NumericalGradientCheck()
+    {
+        // Numerical gradient check: perturb each input element by eps, measure
+        // change in loss, compare to analytical gradient.
+        var rng = new Random(123);
+        var input = new Tensor<double>([1, 2, 8]);
+        var weight = new Tensor<double>([2, 2, 8]);
+        for (int i = 0; i < input.Length; i++) input[i] = rng.NextDouble() * 0.5;
+        for (int i = 0; i < weight.Length; i++) weight[i] = rng.NextDouble() * 0.5;
+
+        // Analytical gradient
+        using var tape = new GradientTape<double>();
+        var output = _engine.OctonionMatMulTensor(input, weight);
+        var loss = _engine.ReduceSum(output, null);
+        var grads = tape.ComputeGradients(loss,
+            new[] { input });
+
+        var analyticalGrad = grads[input];
+
+        // Numerical gradient for input (central differences)
+        double eps = 1e-5;
+        for (int idx = 0; idx < Math.Min(8, input.Length); idx++)
+        {
+            double orig = input[idx];
+
+            input[idx] = orig + eps;
+            var outPlus = _engine.OctonionMatMulTensor(input, weight);
+            double lossPlus = _engine.TensorSum(outPlus);
+
+            input[idx] = orig - eps;
+            var outMinus = _engine.OctonionMatMulTensor(input, weight);
+            double lossMinus = _engine.TensorSum(outMinus);
+
+            input[idx] = orig;
+
+            double numericalGrad = (lossPlus - lossMinus) / (2 * eps);
+            double analyticalVal = analyticalGrad[idx];
+
+            Assert.True(Math.Abs(numericalGrad - analyticalVal) < 1e-3,
+                $"Input grad mismatch at [{idx}]: numerical={numericalGrad:F6}, analytical={analyticalVal:F6}, " +
+                $"diff={Math.Abs(numericalGrad - analyticalVal):E2}");
+        }
+    }
+
+    // ================================================================
+    // Issue #145: RBFKernel backward
+    // ================================================================
+
+    [Fact]
+    public void RBFKernel_Backward_ProducesGradientsForAllInputsIncludingEpsilons()
+    {
+        // RBFKernel: output[b,c] = exp(-epsilon[c] * ||input[b] - centers[c]||^2)
+        // input: [batch=3, features=4]
+        // centers: [numCenters=2, features=4]
+        // epsilons: [numCenters=2]
+        var rng = new Random(42);
+        var input = new Tensor<double>([3, 4]);
+        var centers = new Tensor<double>([2, 4]);
+        var epsilons = new Tensor<double>([2]);
+        for (int i = 0; i < input.Length; i++) input[i] = rng.NextDouble();
+        for (int i = 0; i < centers.Length; i++) centers[i] = rng.NextDouble();
+        epsilons[0] = 1.0;
+        epsilons[1] = 2.0;
+
+        using var tape = new GradientTape<double>();
+        var output = _engine.RBFKernel(input, centers, epsilons);
+        var loss = _engine.ReduceSum(output, null);
+
+        var grads = tape.ComputeGradients(loss,
+            new[] { input, centers, epsilons });
+
+        // All 3 inputs must have gradients
+        Assert.True(grads.ContainsKey(input), "No gradient for input");
+        Assert.True(grads.ContainsKey(centers), "No gradient for centers");
+        Assert.True(grads.ContainsKey(epsilons), "No gradient for epsilons");
+
+        // Shapes must match
+        Assert.Equal(input.Shape.ToArray(), grads[input].Shape.ToArray());
+        Assert.Equal(centers.Shape.ToArray(), grads[centers].Shape.ToArray());
+        Assert.Equal(epsilons.Shape.ToArray(), grads[epsilons].Shape.ToArray());
+
+        // Gradients must be non-zero
+        bool inputNonZero = false, centersNonZero = false, epsilonsNonZero = false;
+        for (int i = 0; i < grads[input].Length; i++)
+            if (Math.Abs(grads[input][i]) > 1e-10) { inputNonZero = true; break; }
+        for (int i = 0; i < grads[centers].Length; i++)
+            if (Math.Abs(grads[centers][i]) > 1e-10) { centersNonZero = true; break; }
+        for (int i = 0; i < grads[epsilons].Length; i++)
+            if (Math.Abs(grads[epsilons][i]) > 1e-10) { epsilonsNonZero = true; break; }
+
+        Assert.True(inputNonZero, "Input gradient is all zeros");
+        Assert.True(centersNonZero, "Centers gradient is all zeros");
+        Assert.True(epsilonsNonZero, "Epsilons gradient is all zeros — per-center widths not flowing");
+    }
+
+    [Fact]
+    public void RBFKernel_Backward_NumericalGradientCheck_Epsilons()
+    {
+        // Verify epsilon gradients match numerical (central differences).
+        // This specifically tests the fix for issue #145 where only
+        // epsilonsData[0] was saved.
+        var input = new Tensor<double>([2, 3]);
+        var centers = new Tensor<double>([2, 3]);
+        var epsilons = new Tensor<double>([2]);
+
+        input[0] = 1; input[1] = 2; input[2] = 3;
+        input[3] = 4; input[4] = 5; input[5] = 6;
+        centers[0] = 0.5; centers[1] = 1.5; centers[2] = 2.5;
+        centers[3] = 3.5; centers[4] = 4.5; centers[5] = 5.5;
+        epsilons[0] = 0.5;
+        epsilons[1] = 1.5;
+
+        // Analytical gradient
+        using var tape = new GradientTape<double>();
+        var output = _engine.RBFKernel(input, centers, epsilons);
+        var loss = _engine.ReduceSum(output, null);
+        var grads = tape.ComputeGradients(loss,
+            new[] { epsilons });
+
+        var analyticalGrad = grads[epsilons];
+
+        // Numerical gradient for epsilons
+        double eps = 1e-5;
+        for (int idx = 0; idx < epsilons.Length; idx++)
+        {
+            double orig = epsilons[idx];
+
+            epsilons[idx] = orig + eps;
+            var outPlus = _engine.RBFKernel(input, centers, epsilons);
+            double lossPlus = _engine.TensorSum(outPlus);
+
+            epsilons[idx] = orig - eps;
+            var outMinus = _engine.RBFKernel(input, centers, epsilons);
+            double lossMinus = _engine.TensorSum(outMinus);
+
+            epsilons[idx] = orig;
+
+            double numericalGrad = (lossPlus - lossMinus) / (2 * eps);
+            double analyticalVal = analyticalGrad[idx];
+
+            Assert.True(Math.Abs(numericalGrad - analyticalVal) < 1e-3,
+                $"Epsilon grad mismatch at [{idx}]: numerical={numericalGrad:F6}, analytical={analyticalVal:F6}, " +
+                $"diff={Math.Abs(numericalGrad - analyticalVal):E2}. " +
+                $"If epsilon[0] and epsilon[1] produce identical gradients, the old scalar-only bug is still present.");
+        }
+
+        // Verify the two epsilon gradients are DIFFERENT (proves per-center widths work)
+        Assert.NotEqual(analyticalGrad[0], analyticalGrad[1]);
+    }
+}


### PR DESCRIPTION
Fixes #145. Fixes #144.

## Summary
- **#145 RBFKernel backward** — three bugs: (1) epsilons tensor missing from recorded inputs, (2) output/epsilons arguments swapped in backward call to engine, (3) only scalar fallback for per-center widths, no epsilon gradient accumulation
- **#144 OctonionMatMulTensor backward** — registered generic `MatMulBackward` which crashes on 3D `[batch, features, 8]` octonion tensors. Added `OctonionMatMulBackward` with proper 8x8 Jacobian matrices matching the existing CUDA kernels

## Test plan
- [x] Build clean (0 errors, 0 warnings)
- [x] 61 non-GPU tests pass on net10.0 + net471
- [x] 34 GPU octonion test failures are pre-existing (no GPU on test machine)
- [ ] Downstream verification: AiDotNet CI tests for RadialBasisFunctionNetwork and OctonionNeuralNetwork

🤖 Generated with [Claude Code](https://claude.com/claude-code)