### PR TITLE
feat: add ScaleParameters to PersistentTensorRole enum

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
@@ -304,6 +304,10 @@ internal static class OpRegistry
         "FusedConv3D",         // composed
         "FusedConvTranspose2D", // composed
         "FusedBatchNorm",      // composed from BatchNorm + activation
+
+        // Spectral filter ops (composed from FFT2D + NativeComplexMultiply + IFFT2DReal)
+        "NativeSpectralFilter",       // FFT2D → multiply → IFFT2D
+        "NativeSpectralFilterBatch",  // batched across [B, C, H, W]
     };
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -28179,15 +28179,19 @@ public class CpuEngine : ITensorLevelEngine
         }
         else
         {
-            // filter is [H, W], spectrum might be [..., H, W] — broadcast by tiling
+            // Broadcast filter to match spectrum shape.
+            // filter can be [H, W] (shared across all slices) or [C, H, W] (per-channel).
             int sliceSize = h * w;
-            int batchCount = spectrum.Length / sliceSize;
+            int filterSlices = filter.Length / sliceSize;
+            int spectrumSlices = spectrum.Length / sliceSize;
             broadcastedFilter = new Tensor<Complex<T>>(spectrum._shape);
-            for (int b = 0; b < batchCount; b++)
+            for (int b = 0; b < spectrumSlices; b++)
             {
-                int offset = b * sliceSize;
+                int dstOffset = b * sliceSize;
+                // Cycle through filter slices: shared (1 slice) or per-channel
+                int srcOffset = (b % filterSlices) * sliceSize;
                 for (int i = 0; i < sliceSize; i++)
-                    broadcastedFilter[offset + i] = filter[i];
+                    broadcastedFilter[dstOffset + i] = filter[srcOffset + i];
             }
         }
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -28151,6 +28151,108 @@ public class CpuEngine : ITensorLevelEngine
         return result;
     }
 
+    /// <inheritdoc />
+    public virtual Tensor<T> NativeSpectralFilter<T>(Tensor<T> input, Tensor<Complex<T>> filter)
+    {
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (filter is null) throw new ArgumentNullException(nameof(filter));
+        if (input.Rank < 2)
+            throw new ArgumentException("NativeSpectralFilter requires at least a 2D input tensor.", nameof(input));
+        if (filter.Rank < 2)
+            throw new ArgumentException("NativeSpectralFilter requires at least a 2D filter tensor.", nameof(filter));
+
+        int h = input._shape[^2];
+        int w = input._shape[^1];
+        if (filter._shape[^2] != h || filter._shape[^1] != w)
+            throw new ArgumentException(
+                $"Filter spatial dims [{filter._shape[^2]},{filter._shape[^1]}] must match input [{h},{w}].",
+                nameof(filter));
+
+        // Fused: FFT2D → pointwise multiply → IFFT2D (eliminates 2 intermediate allocations)
+        var spectrum = NativeComplexFFT2D(input);
+
+        // Broadcast filter to match spectrum shape if needed
+        Tensor<Complex<T>> broadcastedFilter;
+        if (filter.Length == spectrum.Length)
+        {
+            broadcastedFilter = filter;
+        }
+        else
+        {
+            // filter is [H, W], spectrum might be [..., H, W] — broadcast by tiling
+            int sliceSize = h * w;
+            int batchCount = spectrum.Length / sliceSize;
+            broadcastedFilter = new Tensor<Complex<T>>(spectrum._shape);
+            for (int b = 0; b < batchCount; b++)
+            {
+                int offset = b * sliceSize;
+                for (int i = 0; i < sliceSize; i++)
+                    broadcastedFilter[offset + i] = filter[i];
+            }
+        }
+
+        var filtered = NativeComplexMultiply(spectrum, broadcastedFilter);
+        return NativeComplexIFFT2DReal(filtered);
+    }
+
+    /// <inheritdoc />
+    public virtual Tensor<T> NativeSpectralFilterBatch<T>(Tensor<T> input, Tensor<Complex<T>> filter)
+    {
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (filter is null) throw new ArgumentNullException(nameof(filter));
+        if (input.Rank != 4)
+            throw new ArgumentException(
+                $"NativeSpectralFilterBatch requires 4D input [B,C,H,W]. Got rank {input.Rank}.",
+                nameof(input));
+
+        int batch = input._shape[0];
+        int channels = input._shape[1];
+        int h = input._shape[2];
+        int w = input._shape[3];
+
+        bool perChannel = filter.Rank == 3;
+        if (perChannel)
+        {
+            if (filter._shape[0] != channels || filter._shape[1] != h || filter._shape[2] != w)
+                throw new ArgumentException(
+                    $"Per-channel filter shape [{filter._shape[0]},{filter._shape[1]},{filter._shape[2]}] " +
+                    $"must match [C={channels},H={h},W={w}].", nameof(filter));
+        }
+        else if (filter.Rank == 2)
+        {
+            if (filter._shape[0] != h || filter._shape[1] != w)
+                throw new ArgumentException(
+                    $"Shared filter shape [{filter._shape[0]},{filter._shape[1]}] must match [H={h},W={w}].",
+                    nameof(filter));
+        }
+        else
+        {
+            throw new ArgumentException(
+                $"Filter must be [C,H,W] (per-channel) or [H,W] (shared). Got rank {filter.Rank}.",
+                nameof(filter));
+        }
+
+        // FFT2D the entire [B,C,H,W] input — the FFT2D already batches over leading dims
+        var spectrum = NativeComplexFFT2D(input);
+
+        // Build the full [B,C,H,W] filter by broadcasting
+        int sliceSize = h * w;
+        var fullFilter = new Tensor<Complex<T>>(spectrum._shape);
+        for (int b = 0; b < batch; b++)
+        {
+            for (int c = 0; c < channels; c++)
+            {
+                int dstOff = (b * channels + c) * sliceSize;
+                int srcOff = perChannel ? c * sliceSize : 0;
+                for (int i = 0; i < sliceSize; i++)
+                    fullFilter[dstOff + i] = filter[srcOff + i];
+            }
+        }
+
+        var filtered = NativeComplexMultiply(spectrum, fullFilter);
+        return NativeComplexIFFT2DReal(filtered);
+    }
+
     /// <summary>
     /// Transpose the last two axes of a complex tensor using a specialized nested loop.
     /// For shape [..., H, W] → [..., W, H], iterates batch × H × W with direct index

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -10050,6 +10050,67 @@ public sealed class CudaBackend : IAsyncGpuBackend
             (uint)sharedMem, IntPtr.Zero, (IntPtr)args, IntPtr.Zero);
     }
 
+    /// <inheritdoc/>
+    public void SpectralFilter(IGpuBuffer inputReal, IGpuBuffer filterReal, IGpuBuffer filterImag,
+        IGpuBuffer outputReal, int batch, int height, int width, int filterSliceCount)
+    {
+        if (!IsAvailable) throw new InvalidOperationException("CUDA backend not available");
+        if (batch <= 0 || height <= 0 || width <= 0) return;
+
+        using var _ = PushContext();
+        int sliceSize = height * width;
+        int totalSize = batch * sliceSize;
+
+        // All temp buffers live on GPU — zero CPU round-trips
+        var fftR = AllocateBuffer(totalSize);
+        var fftI = AllocateBuffer(totalSize);
+        var mulR = AllocateBuffer(totalSize);
+        var mulI = AllocateBuffer(totalSize);
+        var ifftI = AllocateBuffer(totalSize);
+        // inputImag for FFT is zero — upload zero array
+        var zeroI = AllocateBuffer(new float[totalSize]);
+        try
+        {
+
+            // Step 1: FFT2D on all slices (GPU-resident)
+            BatchedFFT2D(inputReal, zeroI, fftR, fftI, batch, height, width, inverse: false);
+
+            // Step 2: Broadcast-multiply with filter on GPU
+            // If filterSliceCount == batch, filter already matches; if 1, broadcast per-slice
+            if (filterSliceCount == batch)
+            {
+                SplitComplexMultiply(fftR, fftI, filterReal, filterImag, mulR, mulI, totalSize);
+            }
+            else
+            {
+                // Broadcast: replicate filter[0..sliceSize] for each batch slice
+                var bcastFR = AllocateBuffer(totalSize);
+                var bcastFI = AllocateBuffer(totalSize);
+                try
+                {
+                    for (int b = 0; b < batch; b++)
+                    {
+                        int srcOff = (b % filterSliceCount) * sliceSize;
+                        Copy(filterReal, srcOff, bcastFR, b * sliceSize, sliceSize);
+                        Copy(filterImag, srcOff, bcastFI, b * sliceSize, sliceSize);
+                    }
+                    SplitComplexMultiply(fftR, fftI, bcastFR, bcastFI, mulR, mulI, totalSize);
+                }
+                finally { bcastFR.Dispose(); bcastFI.Dispose(); }
+            }
+
+            // Step 3: IFFT2D on all slices (GPU-resident)
+            BatchedFFT2D(mulR, mulI, outputReal, ifftI, batch, height, width, inverse: true);
+            // outputReal now contains the real part; ifftI (imaginary) is discarded
+        }
+        finally
+        {
+            fftR.Dispose(); fftI.Dispose();
+            mulR.Dispose(); mulI.Dispose();
+            ifftI.Dispose(); zeroI.Dispose();
+        }
+    }
+
     #endregion
 
     #region Quantum Computing Operations

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -10612,6 +10612,54 @@ public sealed partial class HipBackend : IAsyncGpuBackend
     #endregion
 // Fused kernel dispatch methods    public void ReduceMean(IGpuBuffer i, IGpuBuffer o, int sz) { LaunchFusedAxis("reduce_mean", i, o, 1, sz); }    public unsafe void ClipKernel(IGpuBuffer i, IGpuBuffer o, float mn, float mx, int sz) { if(!_kernelCache.TryGetValue("clip_kernel",out var k))throw new InvalidOperationException("HIP kernel not found: clip_kernel"); using var _=PushContext(); IntPtr ip=i.Handle,op=o.Handle; void** a=stackalloc void*[5]; a[0]=&ip;a[1]=&op;a[2]=&mn;a[3]=&mx;a[4]=&sz; LaunchKernel(k,(uint)((sz+DefaultBlockSize-1)/DefaultBlockSize),DefaultBlockSize,a); }    public void PowScalar(IGpuBuffer i, IGpuBuffer o, float ex, int sz) { LaunchFusedScalar("pow_scalar", i, o, ex, sz); }    public void FracKernel(IGpuBuffer i, IGpuBuffer o, int sz) { LaunchFusedUnary("frac_kernel", i, o, sz); }    public unsafe void EyeKernel(IGpuBuffer o, int n) { if(!_kernelCache.TryGetValue("eye_kernel",out var k))throw new InvalidOperationException("HIP kernel not found: eye_kernel"); using var _=PushContext(); IntPtr op=o.Handle; void** a=stackalloc void*[2]; a[0]=&op;a[1]=&n; LaunchKernel(k,(uint)((n*n+DefaultBlockSize-1)/DefaultBlockSize),DefaultBlockSize,a); }    public unsafe void OneHotKernel(IGpuBuffer idx, IGpuBuffer o, int bs, int nc) { if(!_kernelCache.TryGetValue("one_hot_kernel",out var k))throw new InvalidOperationException("HIP kernel not found: one_hot_kernel"); using var _=PushContext(); IntPtr ip=idx.Handle,op=o.Handle; void** a=stackalloc void*[4]; a[0]=&ip;a[1]=&op;a[2]=&bs;a[3]=&nc; LaunchKernel(k,(uint)((bs*nc+DefaultBlockSize-1)/DefaultBlockSize),DefaultBlockSize,a); }    public unsafe void MaskedFillKernel(IGpuBuffer i, IGpuBuffer m, IGpuBuffer o, float fv, int sz) { if(!_kernelCache.TryGetValue("masked_fill_kernel",out var k))throw new InvalidOperationException("HIP kernel not found: masked_fill_kernel"); using var _=PushContext(); IntPtr ip=i.Handle,mp=m.Handle,op=o.Handle; void** a=stackalloc void*[5]; a[0]=&ip;a[1]=&mp;a[2]=&op;a[3]=&fv;a[4]=&sz; LaunchKernel(k,(uint)((sz+DefaultBlockSize-1)/DefaultBlockSize),DefaultBlockSize,a); }    public void EqualsKernel(IGpuBuffer a1, IGpuBuffer b1, IGpuBuffer o, int sz) { LaunchFusedBinary("equals_kernel", a1, b1, o, sz); }    public void NotEqualsKernel(IGpuBuffer a1, IGpuBuffer b1, IGpuBuffer o, int sz) { LaunchFusedBinary("not_equals_kernel", a1, b1, o, sz); }    public unsafe void OuterProduct(IGpuBuffer a1, IGpuBuffer b1, IGpuBuffer o, int M, int N) { if(!_kernelCache.TryGetValue("outer_product",out var k))throw new InvalidOperationException("HIP kernel not found: outer_product"); using var _=PushContext(); IntPtr ap=a1.Handle,bp=b1.Handle,op=o.Handle; void** a=stackalloc void*[5]; a[0]=&ap;a[1]=&bp;a[2]=&op;a[3]=&M;a[4]=&N; LaunchKernel(k,(uint)((M*N+DefaultBlockSize-1)/DefaultBlockSize),DefaultBlockSize,a); }    public unsafe void BatchDotProduct(IGpuBuffer a1, IGpuBuffer b1, IGpuBuffer o, int bs, int dim) { if(!_kernelCache.TryGetValue("batch_dot_product",out var k))throw new InvalidOperationException("HIP kernel not found: batch_dot_product"); using var _=PushContext(); IntPtr ap=a1.Handle,bp=b1.Handle,op=o.Handle; void** a=stackalloc void*[5]; a[0]=&ap;a[1]=&bp;a[2]=&op;a[3]=&bs;a[4]=&dim; LaunchKernel(k,(uint)((bs+DefaultBlockSize-1)/DefaultBlockSize),DefaultBlockSize,a); }    public void GluForward(IGpuBuffer i, IGpuBuffer o, int os, int hd) { LaunchFusedAxis("glu_forward", i, o, os, hd); }    public void GeGluForward(IGpuBuffer i, IGpuBuffer o, int os, int hd) { LaunchFusedAxis("geglu_forward", i, o, os, hd); }    public void ReGluForward(IGpuBuffer i, IGpuBuffer o, int os, int hd) { LaunchFusedAxis("reglu_forward", i, o, os, hd); }    public void SwiGluForward(IGpuBuffer i, IGpuBuffer o, int os, int hd) { LaunchFusedAxis("swiglu_forward", i, o, os, hd); }    public void BceLoss(IGpuBuffer p, IGpuBuffer t, IGpuBuffer l, int sz) { LaunchFusedBinary("bce_loss", p, t, l, sz); }
 
+    /// <inheritdoc/>
+    public void SpectralFilter(IGpuBuffer inputReal, IGpuBuffer filterReal, IGpuBuffer filterImag,
+        IGpuBuffer outputReal, int batch, int height, int width, int filterSliceCount)
+    {
+        if (batch <= 0 || height <= 0 || width <= 0) return;
+        int sliceSize = height * width;
+        int totalSize = batch * sliceSize;
+
+        var fftR = AllocateBuffer(totalSize);
+        var fftI = AllocateBuffer(totalSize);
+        var mulR = AllocateBuffer(totalSize);
+        var mulI = AllocateBuffer(totalSize);
+        var ifftI = AllocateBuffer(totalSize);
+        var zeroI = AllocateBuffer(new float[totalSize]);
+        try
+        {
+            BatchedFFT2D(inputReal, zeroI, fftR, fftI, batch, height, width, inverse: false);
+
+            if (filterSliceCount == batch)
+            {
+                SplitComplexMultiply(fftR, fftI, filterReal, filterImag, mulR, mulI, totalSize);
+            }
+            else
+            {
+                var bcastFR = AllocateBuffer(totalSize);
+                var bcastFI = AllocateBuffer(totalSize);
+                try
+                {
+                    for (int b = 0; b < batch; b++)
+                    {
+                        int srcOff = (b % filterSliceCount) * sliceSize;
+                        Copy(filterReal, srcOff, bcastFR, b * sliceSize, sliceSize);
+                        Copy(filterImag, srcOff, bcastFI, b * sliceSize, sliceSize);
+                    }
+                    SplitComplexMultiply(fftR, fftI, bcastFR, bcastFI, mulR, mulI, totalSize);
+                }
+                finally { bcastFR.Dispose(); bcastFI.Dispose(); }
+            }
+
+            BatchedFFT2D(mulR, mulI, outputReal, ifftI, batch, height, width, inverse: true);
+        }
+        finally
+        {
+            fftR.Dispose(); fftI.Dispose();
+            mulR.Dispose(); mulI.Dispose();
+            ifftI.Dispose(); zeroI.Dispose();
+        }
+    }
 
 }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
@@ -2905,7 +2905,8 @@ public interface IDirectGpuBackend : IDisposable
     /// <param name="batch">Number of 2D slices (B*C for 4D input).</param>
     /// <param name="height">Height (must be power of 2).</param>
     /// <param name="width">Width (must be power of 2).</param>
-    /// <param name="filterSliceCount">Number of filter slices: 1 = broadcast to all, batch = per-slice.</param>
+    /// <param name="filterSliceCount">Number of filter slices. Backends use (b % filterSliceCount) for
+    /// indexing, so: 1 = shared across all slices, batch = per-slice, or any divisor for repeating patterns.</param>
     void SpectralFilter(IGpuBuffer inputReal, IGpuBuffer filterReal, IGpuBuffer filterImag,
         IGpuBuffer outputReal, int batch, int height, int width, int filterSliceCount);
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
@@ -2892,6 +2892,23 @@ public interface IDirectGpuBackend : IDisposable
     /// <summary>Per-row softmax on a 2D buffer: output[r][c] = exp(input[r][c]-max) / sum(exp).</summary>
     void SoftmaxRows(IGpuBuffer input, IGpuBuffer output, int rows, int cols);
 
+    /// <summary>
+    /// Fused spectral filter: FFT2D → pointwise complex multiply → IFFT2D, entirely GPU-resident.
+    /// Input and output are real-valued split buffers. Filter is complex split (real/imag).
+    /// All intermediate FFT results stay on GPU — zero CPU round-trips.
+    /// </summary>
+    /// <param name="inputReal">Real-valued input [batch * height * width].</param>
+    /// <param name="filterReal">Filter real part. Length = filterSliceSize * filterSliceCount where
+    /// filterSliceCount is 1 for shared filter or batch for per-channel.</param>
+    /// <param name="filterImag">Filter imaginary part (same size as filterReal).</param>
+    /// <param name="outputReal">Real-valued output [batch * height * width].</param>
+    /// <param name="batch">Number of 2D slices (B*C for 4D input).</param>
+    /// <param name="height">Height (must be power of 2).</param>
+    /// <param name="width">Width (must be power of 2).</param>
+    /// <param name="filterSliceCount">Number of filter slices: 1 = broadcast to all, batch = per-slice.</param>
+    void SpectralFilter(IGpuBuffer inputReal, IGpuBuffer filterReal, IGpuBuffer filterImag,
+        IGpuBuffer outputReal, int batch, int height, int width, int filterSliceCount);
+
     #endregion
 }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Signal.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Signal.cs
@@ -623,4 +623,53 @@ public sealed partial class MetalBackend
     }
 
     #endregion
+
+    /// <inheritdoc/>
+    public void SpectralFilter(IGpuBuffer inputReal, IGpuBuffer filterReal, IGpuBuffer filterImag,
+        IGpuBuffer outputReal, int batch, int height, int width, int filterSliceCount)
+    {
+        if (batch <= 0 || height <= 0 || width <= 0) return;
+        int sliceSize = height * width;
+        int totalSize = batch * sliceSize;
+
+        var fftR = AllocateBuffer(totalSize);
+        var fftI = AllocateBuffer(totalSize);
+        var mulR = AllocateBuffer(totalSize);
+        var mulI = AllocateBuffer(totalSize);
+        var ifftI = AllocateBuffer(totalSize);
+        var zeroI = AllocateBuffer(new float[totalSize]);
+        try
+        {
+            BatchedFFT2D(inputReal, zeroI, fftR, fftI, batch, height, width, inverse: false);
+
+            if (filterSliceCount == batch)
+            {
+                SplitComplexMultiply(fftR, fftI, filterReal, filterImag, mulR, mulI, totalSize);
+            }
+            else
+            {
+                var bcastFR = AllocateBuffer(totalSize);
+                var bcastFI = AllocateBuffer(totalSize);
+                try
+                {
+                    for (int b = 0; b < batch; b++)
+                    {
+                        int srcOff = (b % filterSliceCount) * sliceSize;
+                        Copy(filterReal, srcOff, bcastFR, b * sliceSize, sliceSize);
+                        Copy(filterImag, srcOff, bcastFI, b * sliceSize, sliceSize);
+                    }
+                    SplitComplexMultiply(fftR, fftI, bcastFR, bcastFI, mulR, mulI, totalSize);
+                }
+                finally { bcastFR.Dispose(); bcastFI.Dispose(); }
+            }
+
+            BatchedFFT2D(mulR, mulI, outputReal, ifftI, batch, height, width, inverse: true);
+        }
+        finally
+        {
+            fftR.Dispose(); fftI.Dispose();
+            mulR.Dispose(); mulI.Dispose();
+            ifftI.Dispose(); zeroI.Dispose();
+        }
+    }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -10546,6 +10546,55 @@ KERNEL VARIANTS (A/B testing):
         kernel.Execute1D(rows, localSize);
     }
 
+    /// <inheritdoc/>
+    public void SpectralFilter(IGpuBuffer inputReal, IGpuBuffer filterReal, IGpuBuffer filterImag,
+        IGpuBuffer outputReal, int batch, int height, int width, int filterSliceCount)
+    {
+        if (batch <= 0 || height <= 0 || width <= 0) return;
+        int sliceSize = height * width;
+        int totalSize = batch * sliceSize;
+
+        var fftR = AllocateBuffer(totalSize);
+        var fftI = AllocateBuffer(totalSize);
+        var mulR = AllocateBuffer(totalSize);
+        var mulI = AllocateBuffer(totalSize);
+        var ifftI = AllocateBuffer(totalSize);
+        var zeroI = AllocateBuffer(new float[totalSize]);
+        try
+        {
+            BatchedFFT2D(inputReal, zeroI, fftR, fftI, batch, height, width, inverse: false);
+
+            if (filterSliceCount == batch)
+            {
+                SplitComplexMultiply(fftR, fftI, filterReal, filterImag, mulR, mulI, totalSize);
+            }
+            else
+            {
+                var bcastFR = AllocateBuffer(totalSize);
+                var bcastFI = AllocateBuffer(totalSize);
+                try
+                {
+                    for (int b = 0; b < batch; b++)
+                    {
+                        int srcOff = (b % filterSliceCount) * sliceSize;
+                        Copy(filterReal, srcOff, bcastFR, b * sliceSize, sliceSize);
+                        Copy(filterImag, srcOff, bcastFI, b * sliceSize, sliceSize);
+                    }
+                    SplitComplexMultiply(fftR, fftI, bcastFR, bcastFI, mulR, mulI, totalSize);
+                }
+                finally { bcastFR.Dispose(); bcastFI.Dispose(); }
+            }
+
+            BatchedFFT2D(mulR, mulI, outputReal, ifftI, batch, height, width, inverse: true);
+        }
+        finally
+        {
+            fftR.Dispose(); fftI.Dispose();
+            mulR.Dispose(); mulI.Dispose();
+            ifftI.Dispose(); zeroI.Dispose();
+        }
+    }
+
     #endregion
 
     #region Quantum Computing Operations

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
@@ -1740,4 +1740,53 @@ public sealed unsafe partial class VulkanBackend
         try { Copy(rb, 0, output, 0, rows * cols); }
         finally { rb.Dispose(); }
     }
+
+    /// <inheritdoc/>
+    public void SpectralFilter(IGpuBuffer inputReal, IGpuBuffer filterReal, IGpuBuffer filterImag,
+        IGpuBuffer outputReal, int batch, int height, int width, int filterSliceCount)
+    {
+        if (batch <= 0 || height <= 0 || width <= 0) return;
+        int sliceSize = height * width;
+        int totalSize = batch * sliceSize;
+
+        var fftR = AllocateBuffer(totalSize);
+        var fftI = AllocateBuffer(totalSize);
+        var mulR = AllocateBuffer(totalSize);
+        var mulI = AllocateBuffer(totalSize);
+        var ifftI = AllocateBuffer(totalSize);
+        var zeroI = AllocateBuffer(new float[totalSize]);
+        try
+        {
+            BatchedFFT2D(inputReal, zeroI, fftR, fftI, batch, height, width, inverse: false);
+
+            if (filterSliceCount == batch)
+            {
+                SplitComplexMultiply(fftR, fftI, filterReal, filterImag, mulR, mulI, totalSize);
+            }
+            else
+            {
+                var bcastFR = AllocateBuffer(totalSize);
+                var bcastFI = AllocateBuffer(totalSize);
+                try
+                {
+                    for (int b = 0; b < batch; b++)
+                    {
+                        int srcOff = (b % filterSliceCount) * sliceSize;
+                        Copy(filterReal, srcOff, bcastFR, b * sliceSize, sliceSize);
+                        Copy(filterImag, srcOff, bcastFI, b * sliceSize, sliceSize);
+                    }
+                    SplitComplexMultiply(fftR, fftI, bcastFR, bcastFI, mulR, mulI, totalSize);
+                }
+                finally { bcastFR.Dispose(); bcastFI.Dispose(); }
+            }
+
+            BatchedFFT2D(mulR, mulI, outputReal, ifftI, batch, height, width, inverse: true);
+        }
+        finally
+        {
+            fftR.Dispose(); fftI.Dispose();
+            mulR.Dispose(); mulI.Dispose();
+            ifftI.Dispose(); zeroI.Dispose();
+        }
+    }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
@@ -1464,5 +1464,54 @@ public sealed partial class WebGpuBackend
     }
 
     #endregion
+
+    /// <inheritdoc/>
+    public void SpectralFilter(IGpuBuffer inputReal, IGpuBuffer filterReal, IGpuBuffer filterImag,
+        IGpuBuffer outputReal, int batch, int height, int width, int filterSliceCount)
+    {
+        if (batch <= 0 || height <= 0 || width <= 0) return;
+        int sliceSize = height * width;
+        int totalSize = batch * sliceSize;
+
+        var fftR = AllocateBuffer(totalSize);
+        var fftI = AllocateBuffer(totalSize);
+        var mulR = AllocateBuffer(totalSize);
+        var mulI = AllocateBuffer(totalSize);
+        var ifftI = AllocateBuffer(totalSize);
+        var zeroI = AllocateBuffer(new float[totalSize]);
+        try
+        {
+            BatchedFFT2D(inputReal, zeroI, fftR, fftI, batch, height, width, inverse: false);
+
+            if (filterSliceCount == batch)
+            {
+                SplitComplexMultiply(fftR, fftI, filterReal, filterImag, mulR, mulI, totalSize);
+            }
+            else
+            {
+                var bcastFR = AllocateBuffer(totalSize);
+                var bcastFI = AllocateBuffer(totalSize);
+                try
+                {
+                    for (int b = 0; b < batch; b++)
+                    {
+                        int srcOff = (b % filterSliceCount) * sliceSize;
+                        Copy(filterReal, srcOff, bcastFR, b * sliceSize, sliceSize);
+                        Copy(filterImag, srcOff, bcastFI, b * sliceSize, sliceSize);
+                    }
+                    SplitComplexMultiply(fftR, fftI, bcastFR, bcastFI, mulR, mulI, totalSize);
+                }
+                finally { bcastFR.Dispose(); bcastFI.Dispose(); }
+            }
+
+            BatchedFFT2D(mulR, mulI, outputReal, ifftI, batch, height, width, inverse: true);
+        }
+        finally
+        {
+            fftR.Dispose(); fftI.Dispose();
+            mulR.Dispose(); mulI.Dispose();
+            ifftI.Dispose(); zeroI.Dispose();
+        }
+    }
 }
 #endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -15558,7 +15558,12 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             var inputF = new float[input.Length];
             for (int i = 0; i < input.Length; i++) inputF[i] = (float)ops.ToDouble(input[i]);
 
-            // Decompose filter to split real/imag, broadcast to match batch count
+            // Validate filter spatial dims match input
+            if (filter._shape[^2] != h || filter._shape[^1] != w)
+                return base.NativeSpectralFilter(input, filter);
+            if (filter.Length % sliceSize != 0)
+                return base.NativeSpectralFilter(input, filter);
+
             var (fR, fI) = DecomposeComplex(filter);
             int filterSliceCount = filter.Length / sliceSize;
 
@@ -15602,8 +15607,14 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             for (int i = 0; i < input.Length; i++) inputF[i] = (float)ops.ToDouble(input[i]);
 
             // Decompose filter and determine broadcast mode
-            var (fR, fI) = DecomposeComplex(filter);
+            // Validate filter shape: [H,W] shared or [C,H,W] per-channel
+            if (filter._shape[^2] != h || filter._shape[^1] != w)
+                return base.NativeSpectralFilterBatch(input, filter);
             bool perChannel = filter.Rank == 3;
+            if (perChannel && filter._shape[0] != channels)
+                return base.NativeSpectralFilterBatch(input, filter);
+
+            var (fR, fI) = DecomposeComplex(filter);
 
             // Build full [totalSlices * sliceSize] filter buffer for GPU
             // For per-channel [C,H,W]: replicate across batches

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -15534,6 +15534,118 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         catch { return base.NativeComplexIFFT2DReal(input); }
     }
 
+    public override Tensor<T> NativeSpectralFilter<T>(Tensor<T> input, Tensor<Complex<T>> filter)
+    {
+        if (input is null || filter is null || input.Rank < 2 || filter.Rank < 2)
+            return base.NativeSpectralFilter(
+                input ?? throw new ArgumentNullException(nameof(input)),
+                filter ?? throw new ArgumentNullException(nameof(filter)));
+        if (!TryGetBackend(out var backend))
+            return base.NativeSpectralFilter(input, filter);
+
+        try
+        {
+            int h = input._shape[^2];
+            int w = input._shape[^1];
+            if ((h & (h - 1)) != 0 || h <= 0 || (w & (w - 1)) != 0 || w <= 0)
+                return base.NativeSpectralFilter(input, filter);
+
+            int batchCount = input.Length / (h * w);
+            int sliceSize = h * w;
+
+            // Convert real input to float at GPU boundary
+            var ops = MathHelper.GetNumericOperations<T>();
+            var inputF = new float[input.Length];
+            for (int i = 0; i < input.Length; i++) inputF[i] = (float)ops.ToDouble(input[i]);
+
+            // Decompose filter to split real/imag, broadcast to match batch count
+            var (fR, fI) = DecomposeComplex(filter);
+            int filterSliceCount = filter.Length / sliceSize;
+
+            using var inBuf = new OwnedBuffer(backend.AllocateBuffer(inputF), true);
+            using var fRBuf = new OwnedBuffer(backend.AllocateBuffer(fR), true);
+            using var fIBuf = new OwnedBuffer(backend.AllocateBuffer(fI), true);
+            using var outBuf = new OwnedBuffer(backend.AllocateBuffer(input.Length), true);
+
+            backend.SpectralFilter(inBuf.Buffer, fRBuf.Buffer, fIBuf.Buffer,
+                outBuf.Buffer, batchCount, h, w, filterSliceCount);
+
+            return RecomposeReal<T>(backend.DownloadBuffer(outBuf.Buffer), input._shape);
+        }
+        catch { return base.NativeSpectralFilter(input, filter); }
+    }
+
+    public override Tensor<T> NativeSpectralFilterBatch<T>(Tensor<T> input, Tensor<Complex<T>> filter)
+    {
+        if (input is null || filter is null || input.Rank != 4)
+            return base.NativeSpectralFilterBatch(
+                input ?? throw new ArgumentNullException(nameof(input)),
+                filter ?? throw new ArgumentNullException(nameof(filter)));
+        if (!TryGetBackend(out var backend))
+            return base.NativeSpectralFilterBatch(input, filter);
+
+        try
+        {
+            int batch = input._shape[0];
+            int channels = input._shape[1];
+            int h = input._shape[2];
+            int w = input._shape[3];
+            if ((h & (h - 1)) != 0 || h <= 0 || (w & (w - 1)) != 0 || w <= 0)
+                return base.NativeSpectralFilterBatch(input, filter);
+
+            int totalSlices = batch * channels;
+            int sliceSize = h * w;
+
+            // Convert real input to float at GPU boundary
+            var ops = MathHelper.GetNumericOperations<T>();
+            var inputF = new float[input.Length];
+            for (int i = 0; i < input.Length; i++) inputF[i] = (float)ops.ToDouble(input[i]);
+
+            // Decompose filter and determine broadcast mode
+            var (fR, fI) = DecomposeComplex(filter);
+            bool perChannel = filter.Rank == 3;
+
+            // Build full [totalSlices * sliceSize] filter buffer for GPU
+            // For per-channel [C,H,W]: replicate across batches
+            // For shared [H,W]: single slice, filterSliceCount=1
+            float[] fullFR, fullFI;
+            int filterSliceCount;
+            if (perChannel)
+            {
+                filterSliceCount = totalSlices;
+                fullFR = new float[totalSlices * sliceSize];
+                fullFI = new float[totalSlices * sliceSize];
+                for (int b = 0; b < batch; b++)
+                {
+                    for (int c = 0; c < channels; c++)
+                    {
+                        int dstOff = (b * channels + c) * sliceSize;
+                        int srcOff = c * sliceSize;
+                        Array.Copy(fR, srcOff, fullFR, dstOff, sliceSize);
+                        Array.Copy(fI, srcOff, fullFI, dstOff, sliceSize);
+                    }
+                }
+            }
+            else
+            {
+                filterSliceCount = 1;
+                fullFR = fR;
+                fullFI = fI;
+            }
+
+            using var inBuf = new OwnedBuffer(backend.AllocateBuffer(inputF), true);
+            using var fRBuf = new OwnedBuffer(backend.AllocateBuffer(fullFR), true);
+            using var fIBuf = new OwnedBuffer(backend.AllocateBuffer(fullFI), true);
+            using var outBuf = new OwnedBuffer(backend.AllocateBuffer(input.Length), true);
+
+            backend.SpectralFilter(inBuf.Buffer, fRBuf.Buffer, fIBuf.Buffer,
+                outBuf.Buffer, totalSlices, h, w, filterSliceCount);
+
+            return RecomposeReal<T>(backend.DownloadBuffer(outBuf.Buffer), input._shape);
+        }
+        catch { return base.NativeSpectralFilterBatch(input, filter); }
+    }
+
     public override Tensor<T> TensorSoftmaxRows<T>(Tensor<T> input)
     {
         if (input.Rank != 2)

--- a/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
@@ -1761,4 +1761,9 @@ public class DelegatingGpuBackend : IDirectGpuBackend
 
     public virtual void SplitComplexTopK(IGpuBuffer inReal, IGpuBuffer inImag, IGpuBuffer outReal, IGpuBuffer outImag, int n, int k) => Inner.SplitComplexTopK(inReal, inImag, outReal, outImag, n, k);
     public virtual void SoftmaxRows(IGpuBuffer input, IGpuBuffer output, int rows, int cols) => Inner.SoftmaxRows(input, output, rows, cols);
+
+    /// <inheritdoc/>
+    public virtual void SpectralFilter(IGpuBuffer inputReal, IGpuBuffer filterReal, IGpuBuffer filterImag,
+        IGpuBuffer outputReal, int batch, int height, int width, int filterSliceCount)
+        => Inner.SpectralFilter(inputReal, filterReal, filterImag, outputReal, batch, height, width, filterSliceCount);
 }

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -7520,6 +7520,28 @@ public interface IEngine
     Tensor<T> NativeComplexIFFTNDReal<T>(Tensor<Complex<T>> input, int[] axes);
 
     /// <summary>
+    /// Fused spectral filter: FFT2D(input) ⊙ filter → IFFT2D → real output.
+    /// Single engine call that eliminates 2 intermediate tensor allocations.
+    /// Input shape: [H, W] or [..., H, W] (batches over leading dims).
+    /// Filter shape: must match or broadcast to the spatial dimensions of input.
+    /// </summary>
+    /// <param name="input">Real-valued spatial input. Last two axes must be powers of 2.</param>
+    /// <param name="filter">Complex-valued spectral filter. Shape [H, W].</param>
+    /// <returns>Real-valued filtered output of same shape as input.</returns>
+    Tensor<T> NativeSpectralFilter<T>(Tensor<T> input, Tensor<Complex<T>> filter);
+
+    /// <summary>
+    /// Batched spectral filter across samples and channels.
+    /// Input: [B, C, H, W]. Filter: [C, H, W] (per-channel) or [H, W] (shared).
+    /// Applies FFT2D → pointwise multiply → IFFT2D to every (b, c) slice in one call,
+    /// replacing the O(B×C) dispatch loop that dominates vision-model training time.
+    /// </summary>
+    /// <param name="input">Real-valued 4D tensor [B, C, H, W]. H and W must be powers of 2.</param>
+    /// <param name="filter">Complex-valued filter [C, H, W] or [H, W].</param>
+    /// <returns>Real-valued output [B, C, H, W].</returns>
+    Tensor<T> NativeSpectralFilterBatch<T>(Tensor<T> input, Tensor<Complex<T>> filter);
+
+    /// <summary>
     /// Selects the top-K elements by complex magnitude, zeroing all others.
     /// Used for spectral sparsity masking — retains the K strongest frequency components.
     /// </summary>

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -7526,7 +7526,8 @@ public interface IEngine
     /// Filter shape: must match or broadcast to the spatial dimensions of input.
     /// </summary>
     /// <param name="input">Real-valued spatial input. Last two axes must be powers of 2.</param>
-    /// <param name="filter">Complex-valued spectral filter. Shape [H, W].</param>
+    /// <param name="filter">Complex-valued spectral filter. Shape [H, W] for shared filter
+    /// or [..., H, W] matching the leading dims of input for per-channel/per-batch filtering.</param>
     /// <returns>Real-valued filtered output of same shape as input.</returns>
     Tensor<T> NativeSpectralFilter<T>(Tensor<T> input, Tensor<Complex<T>> filter);
 

--- a/src/AiDotNet.Tensors/Engines/PersistentTensorRole.cs
+++ b/src/AiDotNet.Tensors/Engines/PersistentTensorRole.cs
@@ -60,6 +60,12 @@ public enum PersistentTensorRole
     Constant,
 
     /// <summary>
+    /// Per-unit scale or width parameters (e.g., RBF kernel widths, learnable scales).
+    /// Distinct from Weights (inter-unit connection matrices) and Biases (offset terms).
+    /// </summary>
+    ScaleParameters,
+
+    /// <summary>
     /// Other persistent tensors not fitting above categories.
     /// </summary>
     Other

--- a/tests/AiDotNet.Tensors.Tests/Engines/SpectralFilterTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/SpectralFilterTests.cs
@@ -1,0 +1,455 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Tests for NativeSpectralFilter and NativeSpectralFilterBatch.
+/// Covers Issue #150: fused spectral filter ops.
+/// Verifies correctness against the manual FFT2D → multiply → IFFT2D pipeline,
+/// plus mathematical invariants (identity filter, zero filter, linearity).
+/// </summary>
+public class SpectralFilterTests
+{
+    private readonly ITestOutputHelper _output;
+    private readonly IEngine _engine = new CpuEngine();
+
+    public SpectralFilterTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    // ================================================================
+    // NativeSpectralFilter: correctness vs manual pipeline
+    // ================================================================
+
+    [Theory]
+    [InlineData(8, 8)]
+    [InlineData(16, 16)]
+    [InlineData(8, 16)]
+    public void SpectralFilter_MatchesManualPipeline(int h, int w)
+    {
+        var rng = new Random(42);
+        var input = new Tensor<double>([h, w]);
+        for (int i = 0; i < h * w; i++) input[i] = rng.NextDouble() * 2 - 1;
+
+        // Random complex filter
+        var filter = new Tensor<Complex<double>>([h, w]);
+        for (int i = 0; i < h * w; i++)
+            filter[i] = new Complex<double>(rng.NextDouble() * 2 - 1, rng.NextDouble() * 2 - 1);
+
+        // Manual pipeline: FFT2D → multiply → IFFT2D
+        var spectrum = _engine.NativeComplexFFT2D(input);
+        var filtered = _engine.NativeComplexMultiply(spectrum, filter);
+        var expected = _engine.NativeComplexIFFT2DReal(filtered);
+
+        // Fused single call
+        var actual = _engine.NativeSpectralFilter(input, filter);
+
+        Assert.Equal(expected.Shape.ToArray(), actual.Shape.ToArray());
+        for (int i = 0; i < expected.Length; i++)
+        {
+            double diff = Math.Abs(expected[i] - actual[i]);
+            Assert.True(diff < 1e-10,
+                $"SpectralFilter [{h},{w}] mismatch at [{i}]: expected={expected[i]:F10}, actual={actual[i]:F10}, diff={diff:E2}");
+        }
+    }
+
+    [Fact]
+    public void SpectralFilter_IdentityFilter_PreservesInput()
+    {
+        // All-ones filter in frequency domain should preserve the signal
+        int h = 8, w = 8;
+        var rng = new Random(123);
+        var input = new Tensor<double>([h, w]);
+        for (int i = 0; i < h * w; i++) input[i] = rng.NextDouble() * 2 - 1;
+
+        // Identity filter: (1+0i) everywhere
+        var filter = new Tensor<Complex<double>>([h, w]);
+        for (int i = 0; i < h * w; i++)
+            filter[i] = new Complex<double>(1.0, 0.0);
+
+        var result = _engine.NativeSpectralFilter(input, filter);
+
+        for (int i = 0; i < input.Length; i++)
+        {
+            double diff = Math.Abs(input[i] - result[i]);
+            Assert.True(diff < 1e-10,
+                $"Identity filter should preserve input. Mismatch at [{i}]: input={input[i]:F10}, result={result[i]:F10}");
+        }
+    }
+
+    [Fact]
+    public void SpectralFilter_ZeroFilter_ProducesZeros()
+    {
+        int h = 8, w = 8;
+        var rng = new Random(456);
+        var input = new Tensor<double>([h, w]);
+        for (int i = 0; i < h * w; i++) input[i] = rng.NextDouble() * 2 - 1;
+
+        // Zero filter
+        var filter = new Tensor<Complex<double>>([h, w]);
+
+        var result = _engine.NativeSpectralFilter(input, filter);
+
+        for (int i = 0; i < result.Length; i++)
+        {
+            Assert.True(Math.Abs(result[i]) < 1e-10,
+                $"Zero filter should produce zeros. Got {result[i]:E2} at [{i}]");
+        }
+    }
+
+    [Fact]
+    public void SpectralFilter_Linearity_ScaledFilterScalesOutput()
+    {
+        // SpectralFilter(input, 2*filter) should equal 2 * SpectralFilter(input, filter)
+        int h = 8, w = 8;
+        var rng = new Random(789);
+        var input = new Tensor<double>([h, w]);
+        for (int i = 0; i < h * w; i++) input[i] = rng.NextDouble() * 2 - 1;
+
+        var filter1 = new Tensor<Complex<double>>([h, w]);
+        for (int i = 0; i < h * w; i++)
+            filter1[i] = new Complex<double>(rng.NextDouble(), rng.NextDouble());
+
+        var filter2 = new Tensor<Complex<double>>([h, w]);
+        for (int i = 0; i < h * w; i++)
+            filter2[i] = new Complex<double>(filter1[i].Real * 2, filter1[i].Imaginary * 2);
+
+        var result1 = _engine.NativeSpectralFilter(input, filter1);
+        var result2 = _engine.NativeSpectralFilter(input, filter2);
+
+        for (int i = 0; i < result1.Length; i++)
+        {
+            double diff = Math.Abs(result1[i] * 2 - result2[i]);
+            Assert.True(diff < 1e-8,
+                $"Linearity violated at [{i}]: 2*result1={result1[i] * 2:F10}, result2={result2[i]:F10}");
+        }
+    }
+
+    [Fact]
+    public void SpectralFilter_BatchedInput_BroadcastsFilter()
+    {
+        // [B, H, W] input with [H, W] filter should work
+        int b = 3, h = 8, w = 8;
+        var rng = new Random(101);
+        var input = new Tensor<double>([b, h, w]);
+        for (int i = 0; i < b * h * w; i++) input[i] = rng.NextDouble() * 2 - 1;
+
+        var filter = new Tensor<Complex<double>>([h, w]);
+        for (int i = 0; i < h * w; i++)
+            filter[i] = new Complex<double>(rng.NextDouble(), rng.NextDouble());
+
+        var result = _engine.NativeSpectralFilter(input, filter);
+        Assert.Equal(new[] { b, h, w }, result.Shape.ToArray());
+
+        // Verify each batch slice matches single-slice result
+        for (int bi = 0; bi < b; bi++)
+        {
+            var singleSlice = new Tensor<double>([h, w]);
+            for (int i = 0; i < h * w; i++)
+                singleSlice[i] = input[bi * h * w + i];
+
+            var singleResult = _engine.NativeSpectralFilter(singleSlice, filter);
+
+            for (int i = 0; i < h * w; i++)
+            {
+                double diff = Math.Abs(result[bi * h * w + i] - singleResult[i]);
+                Assert.True(diff < 1e-8,
+                    $"Batch [{bi}] mismatch at [{i}]: batched={result[bi * h * w + i]:F10}, single={singleResult[i]:F10}");
+            }
+        }
+    }
+
+    // ================================================================
+    // NativeSpectralFilterBatch: correctness
+    // ================================================================
+
+    [Fact]
+    public void SpectralFilterBatch_SharedFilter_MatchesPerSlice()
+    {
+        // [B, C, H, W] with shared [H, W] filter
+        int batch = 2, channels = 3, h = 8, w = 8;
+        var rng = new Random(42);
+        var input = new Tensor<double>([batch, channels, h, w]);
+        for (int i = 0; i < input.Length; i++) input[i] = rng.NextDouble() * 2 - 1;
+
+        var filter = new Tensor<Complex<double>>([h, w]);
+        for (int i = 0; i < h * w; i++)
+            filter[i] = new Complex<double>(rng.NextDouble(), rng.NextDouble());
+
+        var result = _engine.NativeSpectralFilterBatch(input, filter);
+        Assert.Equal(new[] { batch, channels, h, w }, result.Shape.ToArray());
+
+        // Verify each (b,c) slice matches single-slice spectral filter
+        int sliceSize = h * w;
+        for (int b = 0; b < batch; b++)
+        {
+            for (int c = 0; c < channels; c++)
+            {
+                var singleSlice = new Tensor<double>([h, w]);
+                int srcOff = (b * channels + c) * sliceSize;
+                for (int i = 0; i < sliceSize; i++)
+                    singleSlice[i] = input[srcOff + i];
+
+                var singleResult = _engine.NativeSpectralFilter(singleSlice, filter);
+
+                for (int i = 0; i < sliceSize; i++)
+                {
+                    double diff = Math.Abs(result[srcOff + i] - singleResult[i]);
+                    Assert.True(diff < 1e-8,
+                        $"Batch shared filter (b={b},c={c}) mismatch at [{i}]: " +
+                        $"batched={result[srcOff + i]:F10}, single={singleResult[i]:F10}");
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void SpectralFilterBatch_PerChannelFilter_MatchesPerSlice()
+    {
+        // [B, C, H, W] with per-channel [C, H, W] filter
+        int batch = 2, channels = 4, h = 8, w = 8;
+        var rng = new Random(99);
+        var input = new Tensor<double>([batch, channels, h, w]);
+        for (int i = 0; i < input.Length; i++) input[i] = rng.NextDouble() * 2 - 1;
+
+        var filter = new Tensor<Complex<double>>([channels, h, w]);
+        for (int i = 0; i < filter.Length; i++)
+            filter[i] = new Complex<double>(rng.NextDouble(), rng.NextDouble());
+
+        var result = _engine.NativeSpectralFilterBatch(input, filter);
+        Assert.Equal(new[] { batch, channels, h, w }, result.Shape.ToArray());
+
+        // Verify each (b,c) slice matches single-slice spectral filter with channel-specific filter
+        int sliceSize = h * w;
+        for (int b = 0; b < batch; b++)
+        {
+            for (int c = 0; c < channels; c++)
+            {
+                var singleSlice = new Tensor<double>([h, w]);
+                int srcOff = (b * channels + c) * sliceSize;
+                for (int i = 0; i < sliceSize; i++)
+                    singleSlice[i] = input[srcOff + i];
+
+                // Extract per-channel filter
+                var channelFilter = new Tensor<Complex<double>>([h, w]);
+                int filterOff = c * sliceSize;
+                for (int i = 0; i < sliceSize; i++)
+                    channelFilter[i] = filter[filterOff + i];
+
+                var singleResult = _engine.NativeSpectralFilter(singleSlice, channelFilter);
+
+                for (int i = 0; i < sliceSize; i++)
+                {
+                    double diff = Math.Abs(result[srcOff + i] - singleResult[i]);
+                    Assert.True(diff < 1e-8,
+                        $"Batch per-channel filter (b={b},c={c}) mismatch at [{i}]: " +
+                        $"batched={result[srcOff + i]:F10}, single={singleResult[i]:F10}");
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void SpectralFilterBatch_IdentityFilter_PreservesInput()
+    {
+        int batch = 2, channels = 3, h = 8, w = 8;
+        var rng = new Random(55);
+        var input = new Tensor<double>([batch, channels, h, w]);
+        for (int i = 0; i < input.Length; i++) input[i] = rng.NextDouble() * 2 - 1;
+
+        var filter = new Tensor<Complex<double>>([h, w]);
+        for (int i = 0; i < h * w; i++)
+            filter[i] = new Complex<double>(1.0, 0.0);
+
+        var result = _engine.NativeSpectralFilterBatch(input, filter);
+
+        for (int i = 0; i < input.Length; i++)
+        {
+            double diff = Math.Abs(input[i] - result[i]);
+            Assert.True(diff < 1e-8,
+                $"Identity filter should preserve input. Mismatch at [{i}]: input={input[i]:F10}, result={result[i]:F10}");
+        }
+    }
+
+    [Fact]
+    public void SpectralFilterBatch_ZeroFilter_ProducesZeros()
+    {
+        int batch = 2, channels = 3, h = 8, w = 8;
+        var rng = new Random(77);
+        var input = new Tensor<double>([batch, channels, h, w]);
+        for (int i = 0; i < input.Length; i++) input[i] = rng.NextDouble() * 2 - 1;
+
+        var filter = new Tensor<Complex<double>>([h, w]);
+
+        var result = _engine.NativeSpectralFilterBatch(input, filter);
+
+        for (int i = 0; i < result.Length; i++)
+        {
+            Assert.True(Math.Abs(result[i]) < 1e-10,
+                $"Zero filter should produce zeros. Got {result[i]:E2} at [{i}]");
+        }
+    }
+
+    // ================================================================
+    // Validation tests
+    // ================================================================
+
+    [Fact]
+    public void SpectralFilter_ThrowsOnMismatchedFilterDims()
+    {
+        var input = new Tensor<double>([8, 8]);
+        var wrongFilter = new Tensor<Complex<double>>([4, 4]);
+
+        Assert.Throws<ArgumentException>(() => _engine.NativeSpectralFilter(input, wrongFilter));
+    }
+
+    [Fact]
+    public void SpectralFilterBatch_ThrowsOnNon4DInput()
+    {
+        var input = new Tensor<double>([8, 8]);
+        var filter = new Tensor<Complex<double>>([8, 8]);
+
+        Assert.Throws<ArgumentException>(() => _engine.NativeSpectralFilterBatch(input, filter));
+    }
+
+    [Fact]
+    public void SpectralFilterBatch_ThrowsOnWrongChannelCount()
+    {
+        var input = new Tensor<double>([2, 3, 8, 8]);
+        var wrongFilter = new Tensor<Complex<double>>([5, 8, 8]); // 5 channels != 3
+
+        Assert.Throws<ArgumentException>(() => _engine.NativeSpectralFilterBatch(input, wrongFilter));
+    }
+
+    [Fact]
+    public void SpectralFilterBatch_ThrowsOnWrongFilterRank()
+    {
+        var input = new Tensor<double>([2, 3, 8, 8]);
+        var wrongFilter = new Tensor<Complex<double>>([2, 3, 8, 8]); // rank 4 not supported
+
+        Assert.Throws<ArgumentException>(() => _engine.NativeSpectralFilterBatch(input, wrongFilter));
+    }
+
+    // ================================================================
+    // Performance: fused vs manual pipeline
+    // ================================================================
+
+    [Theory]
+    [Trait("Category", "Performance")]
+    [InlineData(16, 4, 32, 32)]
+    public void SpectralFilterBatch_FasterThanManualLoop(int batch, int channels, int h, int w)
+    {
+        var rng = new Random(42);
+        var input = new Tensor<double>([batch, channels, h, w]);
+        for (int i = 0; i < input.Length; i++) input[i] = rng.NextDouble() * 2 - 1;
+
+        var filter = new Tensor<Complex<double>>([channels, h, w]);
+        for (int i = 0; i < filter.Length; i++)
+            filter[i] = new Complex<double>(rng.NextDouble(), rng.NextDouble());
+
+        int sliceSize = h * w;
+
+        // Warmup
+        _engine.NativeSpectralFilterBatch(input, filter);
+
+        // Time fused batched path
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        int iters = 5;
+        for (int iter = 0; iter < iters; iter++)
+            _engine.NativeSpectralFilterBatch(input, filter);
+        sw.Stop();
+        double fusedMs = sw.Elapsed.TotalMilliseconds / iters;
+
+        // Time manual per-slice loop
+        sw.Restart();
+        for (int iter = 0; iter < iters; iter++)
+        {
+            var output = new Tensor<double>([batch, channels, h, w]);
+            for (int b = 0; b < batch; b++)
+            {
+                for (int c = 0; c < channels; c++)
+                {
+                    var slice = new Tensor<double>([h, w]);
+                    int off = (b * channels + c) * sliceSize;
+                    for (int i = 0; i < sliceSize; i++) slice[i] = input[off + i];
+
+                    var channelFilter = new Tensor<Complex<double>>([h, w]);
+                    int fOff = c * sliceSize;
+                    for (int i = 0; i < sliceSize; i++) channelFilter[i] = filter[fOff + i];
+
+                    var filtered = _engine.NativeSpectralFilter(slice, channelFilter);
+                    for (int i = 0; i < sliceSize; i++) output[off + i] = filtered[i];
+                }
+            }
+        }
+        sw.Stop();
+        double manualMs = sw.Elapsed.TotalMilliseconds / iters;
+
+        double speedup = manualMs / fusedMs;
+        _output.WriteLine($"SpectralFilterBatch [{batch},{channels},{h},{w}]:");
+        _output.WriteLine($"  Fused batched: {fusedMs:F2}ms");
+        _output.WriteLine($"  Manual per-slice loop: {manualMs:F2}ms");
+        _output.WriteLine($"  Speedup: {speedup:F1}x");
+
+        // The batched version eliminates per-slice allocation overhead
+        Assert.True(speedup > 1.5,
+            $"Expected at least 1.5x speedup from batched path but got {speedup:F1}x " +
+            $"(fused={fusedMs:F2}ms, manual={manualMs:F2}ms)");
+    }
+
+    // ================================================================
+    // Float type tests (verify both float and double paths work)
+    // ================================================================
+
+    [Fact]
+    public void SpectralFilter_FloatType_MatchesManualPipeline()
+    {
+        int h = 8, w = 8;
+        var rng = new Random(42);
+        var input = new Tensor<float>([h, w]);
+        for (int i = 0; i < h * w; i++) input[i] = (float)(rng.NextDouble() * 2 - 1);
+
+        var filter = new Tensor<Complex<float>>([h, w]);
+        for (int i = 0; i < h * w; i++)
+            filter[i] = new Complex<float>((float)(rng.NextDouble() * 2 - 1), (float)(rng.NextDouble() * 2 - 1));
+
+        var spectrum = _engine.NativeComplexFFT2D(input);
+        var filtered = _engine.NativeComplexMultiply(spectrum, filter);
+        var expected = _engine.NativeComplexIFFT2DReal(filtered);
+
+        var actual = _engine.NativeSpectralFilter(input, filter);
+
+        for (int i = 0; i < expected.Length; i++)
+        {
+            double diff = Math.Abs(expected[i] - actual[i]);
+            Assert.True(diff < 1e-4,
+                $"Float SpectralFilter mismatch at [{i}]: expected={expected[i]:F6}, actual={actual[i]:F6}");
+        }
+    }
+
+    [Fact]
+    public void SpectralFilterBatch_FloatType_IdentityPreservesInput()
+    {
+        int batch = 2, channels = 3, h = 8, w = 8;
+        var rng = new Random(55);
+        var input = new Tensor<float>([batch, channels, h, w]);
+        for (int i = 0; i < input.Length; i++) input[i] = (float)(rng.NextDouble() * 2 - 1);
+
+        var filter = new Tensor<Complex<float>>([h, w]);
+        for (int i = 0; i < h * w; i++)
+            filter[i] = new Complex<float>(1.0f, 0.0f);
+
+        var result = _engine.NativeSpectralFilterBatch(input, filter);
+
+        for (int i = 0; i < input.Length; i++)
+        {
+            double diff = Math.Abs(input[i] - result[i]);
+            Assert.True(diff < 1e-4,
+                $"Float identity filter mismatch at [{i}]: input={input[i]:F6}, result={result[i]:F6}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ScaleParameters` variant to `PersistentTensorRole` enum
- For per-unit scale/width parameters (RBF kernel widths, learnable scales)
- Fixes: layers registering both weights and widths under `Weights` role get silently deduped, causing parameter count mismatches

## Context
RBFLayer registers `_centers` and `_widths` as trainable parameters. Both used `PersistentTensorRole.Weights`, so `RegisterTrainableParameter` replaced `_centers` with `_widths` (same role = replace). Result: only 1 registered parameter instead of 2, causing `SetTrainableParameters` to throw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)