### PR TITLE
feat: add ScaleParameters to PersistentTensorRole enum

### DIFF
--- a/src/AiDotNet.Tensors/Engines/PersistentTensorRole.cs
+++ b/src/AiDotNet.Tensors/Engines/PersistentTensorRole.cs
@@ -60,6 +60,14 @@ public enum PersistentTensorRole
     Constant,
 
     /// <summary>
+    /// Per-unit scale or width parameters (e.g., RBF kernel widths, learnable scales).
+    /// Distinct from Weights (inter-unit connection matrices) and Biases (offset terms).
+    /// Without a dedicated role, layers registering multiple parameter types under the
+    /// same role get silently replaced by RegisterTrainableParameter's role-based dedup.
+    /// </summary>
+    ScaleParameters,
+
+    /// <summary>
     /// Other persistent tensors not fitting above categories.
     /// </summary>
     Other

--- a/src/AiDotNet.Tensors/Engines/PersistentTensorRole.cs
+++ b/src/AiDotNet.Tensors/Engines/PersistentTensorRole.cs
@@ -25,39 +25,44 @@ public enum PersistentTensorRole
     /// Layer weights that change only during training updates.
     /// These are the primary candidates for GPU persistence.
     /// </summary>
-    Weights,
+    Weights = 0,
 
     /// <summary>
     /// Layer biases that change only during training updates.
     /// </summary>
-    Biases,
+    Biases = 1,
 
     /// <summary>
     /// Normalization parameters (gamma/beta for BatchNorm, LayerNorm, etc.).
     /// </summary>
-    NormalizationParams,
+    NormalizationParams = 2,
 
     /// <summary>
     /// Embedding lookup tables.
     /// These can be very large and benefit significantly from GPU persistence.
     /// </summary>
-    Embeddings,
+    Embeddings = 3,
 
     /// <summary>
     /// Attention key/value caches for inference.
     /// Used in autoregressive generation to cache previous attention states.
     /// </summary>
-    AttentionCache,
+    AttentionCache = 4,
 
     /// <summary>
     /// Optimizer state tensors (velocity, momentum, etc.).
     /// </summary>
-    OptimizerState,
+    OptimizerState = 5,
 
     /// <summary>
     /// Constant tensors that never change (e.g., precomputed frequencies, positional encodings).
     /// </summary>
-    Constant,
+    Constant = 6,
+
+    /// <summary>
+    /// Other persistent tensors not fitting above categories.
+    /// </summary>
+    Other = 7,
 
     /// <summary>
     /// Per-unit scale or width parameters (e.g., RBF kernel widths, learnable scales).
@@ -65,10 +70,5 @@ public enum PersistentTensorRole
     /// <see cref="Biases"/> (offset terms). Consumers that register multiple persistent
     /// tensors per layer should use distinct roles to avoid role-based deduplication.
     /// </summary>
-    ScaleParameters,
-
-    /// <summary>
-    /// Other persistent tensors not fitting above categories.
-    /// </summary>
-    Other
+    ScaleParameters = 8
 }

--- a/src/AiDotNet.Tensors/Engines/PersistentTensorRole.cs
+++ b/src/AiDotNet.Tensors/Engines/PersistentTensorRole.cs
@@ -61,9 +61,9 @@ public enum PersistentTensorRole
 
     /// <summary>
     /// Per-unit scale or width parameters (e.g., RBF kernel widths, learnable scales).
-    /// Distinct from Weights (inter-unit connection matrices) and Biases (offset terms).
-    /// Without a dedicated role, layers registering multiple parameter types under the
-    /// same role get silently replaced by RegisterTrainableParameter's role-based dedup.
+    /// Distinct from <see cref="Weights"/> (inter-unit connection matrices) and
+    /// <see cref="Biases"/> (offset terms). Consumers that register multiple persistent
+    /// tensors per layer should use distinct roles to avoid role-based deduplication.
     /// </summary>
     ScaleParameters,
 


### PR DESCRIPTION
## Summary
Adds `ScaleParameters` variant to `PersistentTensorRole` enum — one file, one enum value.

## Problem
`RegisterTrainableParameter` deduplicates by role. When a layer registers multiple tensors under the same role (e.g., RBFLayer registering both `_centers` and `_widths` as `Weights`), the second registration silently replaces the first. This causes `SetTrainableParameters` to throw: "has 1 registered parameters but received 2".

## Fix
New `ScaleParameters` role for per-unit scale/width parameters, distinct from `Weights` (connection matrices) and `Biases` (offset terms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)