### PR TITLE
feat: SimdRandom CreateRandom, Vector.FromSpan, OpenCL quiet mode

### DIFF
--- a/src/AiDotNet.Tensors/AiDotNet.Tensors.csproj
+++ b/src/AiDotNet.Tensors/AiDotNet.Tensors.csproj
@@ -40,6 +40,8 @@
     <InternalsVisibleTo Include="AiDotNetTests" />
     <InternalsVisibleTo Include="AiDotNet.Tensors.Tests" />
     <InternalsVisibleTo Include="AiDotNet.Tensors.Benchmarks" />
+    <InternalsVisibleTo Include="HarmonicEngine" />
+    <InternalsVisibleTo Include="HarmonicEngine.Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -19595,7 +19595,10 @@ public class CpuEngine : ITensorLevelEngine
     public Tensor<T> TensorRandomUniform<T>(int[] shape)
     {
         if (shape == null) throw new ArgumentNullException(nameof(shape));
-        return Tensor<T>.CreateRandom(shape);
+        var tensor = new Tensor<T>(shape);
+        var rng = new Helpers.SimdRandom();
+        rng.FillUniform(tensor.DataVector.AsWritableSpan());
+        return tensor;
     }
 
     /// <inheritdoc/>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -9369,19 +9369,21 @@ public sealed class CudaBackend : IAsyncGpuBackend
         LaunchKernel(kernel, grid, DefaultBlockSize, args);
     }
 
-    public void GenerateSecureRandomUniform(IGpuBuffer output, int size, float min, float max)
+    public unsafe void GenerateSecureRandomUniform(IGpuBuffer output, int size, float min, float max)
     {
-        var hostBuf = System.Buffers.ArrayPool<float>.Shared.Rent(size);
-        try
+        if (size <= 0) return;
+        using var _ = PushContext();
+        var data = new float[size];
+        Helpers.SimdRandom.SecureFillFloats(data.AsSpan());
+        float range = max - min;
+        for (int i = 0; i < size; i++) data[i] = data[i] * range + min;
+        fixed (float* ptr = data)
         {
-            Helpers.SimdRandom.SecureFillFloats(hostBuf.AsSpan(0, size));
-            float range = max - min;
-            for (int i = 0; i < size; i++) hostBuf[i] = hostBuf[i] * range + min;
-            var temp = AllocateBuffer(hostBuf.AsSpan(0, size).ToArray());
-            try { Copy(temp, 0, output, 0, size); }
-            finally { temp.Dispose(); }
+            CuBlasNative.CheckCudaResult(
+                CuBlasNative.cuMemcpyHtoD(output.Handle, (IntPtr)ptr, (ulong)(size * sizeof(float))),
+                "cuMemcpyHtoD (GenerateSecureRandomUniform)");
         }
-        finally { System.Buffers.ArrayPool<float>.Shared.Return(hostBuf); }
+        Array.Clear(data, 0, size);
     }
 
     public unsafe void RbfForward(IGpuBuffer input, IGpuBuffer centers, IGpuBuffer epsilons, IGpuBuffer output, int batchSize, int numCenters, int inputDim)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -9369,6 +9369,21 @@ public sealed class CudaBackend : IAsyncGpuBackend
         LaunchKernel(kernel, grid, DefaultBlockSize, args);
     }
 
+    public void GenerateSecureRandomUniform(IGpuBuffer output, int size, float min, float max)
+    {
+        var hostBuf = System.Buffers.ArrayPool<float>.Shared.Rent(size);
+        try
+        {
+            Helpers.SimdRandom.SecureFillFloats(hostBuf.AsSpan(0, size));
+            float range = max - min;
+            for (int i = 0; i < size; i++) hostBuf[i] = hostBuf[i] * range + min;
+            var temp = AllocateBuffer(hostBuf.AsSpan(0, size).ToArray());
+            try { Copy(temp, 0, output, 0, size); }
+            finally { temp.Dispose(); }
+        }
+        finally { System.Buffers.ArrayPool<float>.Shared.Return(hostBuf); }
+    }
+
     public unsafe void RbfForward(IGpuBuffer input, IGpuBuffer centers, IGpuBuffer epsilons, IGpuBuffer output, int batchSize, int numCenters, int inputDim)
     {
         if (!_kernelCache.TryGetValue("rbf_forward", out var kernel))

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -9374,16 +9374,19 @@ public sealed class CudaBackend : IAsyncGpuBackend
         if (size <= 0) return;
         using var _ = PushContext();
         var data = new float[size];
-        Helpers.SimdRandom.SecureFillFloats(data.AsSpan());
-        float range = max - min;
-        for (int i = 0; i < size; i++) data[i] = data[i] * range + min;
-        fixed (float* ptr = data)
+        try
         {
-            CuBlasNative.CheckCudaResult(
-                CuBlasNative.cuMemcpyHtoD(output.Handle, (IntPtr)ptr, (ulong)(size * sizeof(float))),
-                "cuMemcpyHtoD (GenerateSecureRandomUniform)");
+            Helpers.SimdRandom.SecureFillFloats(data.AsSpan());
+            float range = max - min;
+            for (int i = 0; i < size; i++) data[i] = data[i] * range + min;
+            fixed (float* ptr = data)
+            {
+                CuBlasNative.CheckCudaResult(
+                    CuBlasNative.cuMemcpyHtoD(output.Handle, (IntPtr)ptr, (ulong)(size * sizeof(float))),
+                    "cuMemcpyHtoD (GenerateSecureRandomUniform)");
+            }
         }
-        Array.Clear(data, 0, size);
+        finally { Array.Clear(data, 0, size); }
     }
 
     public unsafe void RbfForward(IGpuBuffer input, IGpuBuffer centers, IGpuBuffer epsilons, IGpuBuffer output, int batchSize, int numCenters, int inputDim)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -8972,11 +8972,14 @@ public sealed partial class HipBackend : IAsyncGpuBackend
     {
         if (size <= 0) return;
         var data = new float[size];
-        Helpers.SimdRandom.SecureFillFloats(data.AsSpan());
-        float range = max - min;
-        for (int i = 0; i < size; i++) data[i] = data[i] * range + min;
-        UploadToBuffer(output, data);
-        Array.Clear(data, 0, size);
+        try
+        {
+            Helpers.SimdRandom.SecureFillFloats(data.AsSpan());
+            float range = max - min;
+            for (int i = 0; i < size; i++) data[i] = data[i] * range + min;
+            UploadToBuffer(output, data);
+        }
+        finally { Array.Clear(data, 0, size); }
     }
 
     public unsafe void RbfForward(IGpuBuffer input, IGpuBuffer centers, IGpuBuffer epsilons, IGpuBuffer output, int batchSize, int numCenters, int inputDim)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -8970,17 +8970,13 @@ public sealed partial class HipBackend : IAsyncGpuBackend
 
     public void GenerateSecureRandomUniform(IGpuBuffer output, int size, float min, float max)
     {
-        var hostBuf = System.Buffers.ArrayPool<float>.Shared.Rent(size);
-        try
-        {
-            Helpers.SimdRandom.SecureFillFloats(hostBuf.AsSpan(0, size));
-            float range = max - min;
-            for (int i = 0; i < size; i++) hostBuf[i] = hostBuf[i] * range + min;
-            var temp = AllocateBuffer(hostBuf.AsSpan(0, size).ToArray());
-            try { Copy(temp, 0, output, 0, size); }
-            finally { temp.Dispose(); }
-        }
-        finally { System.Buffers.ArrayPool<float>.Shared.Return(hostBuf); }
+        if (size <= 0) return;
+        var data = new float[size];
+        Helpers.SimdRandom.SecureFillFloats(data.AsSpan());
+        float range = max - min;
+        for (int i = 0; i < size; i++) data[i] = data[i] * range + min;
+        UploadToBuffer(output, data);
+        Array.Clear(data, 0, size);
     }
 
     public unsafe void RbfForward(IGpuBuffer input, IGpuBuffer centers, IGpuBuffer epsilons, IGpuBuffer output, int batchSize, int numCenters, int inputDim)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -8968,6 +8968,21 @@ public sealed partial class HipBackend : IAsyncGpuBackend
         LaunchKernel(kernel, grid, DefaultBlockSize, args);
     }
 
+    public void GenerateSecureRandomUniform(IGpuBuffer output, int size, float min, float max)
+    {
+        var hostBuf = System.Buffers.ArrayPool<float>.Shared.Rent(size);
+        try
+        {
+            Helpers.SimdRandom.SecureFillFloats(hostBuf.AsSpan(0, size));
+            float range = max - min;
+            for (int i = 0; i < size; i++) hostBuf[i] = hostBuf[i] * range + min;
+            var temp = AllocateBuffer(hostBuf.AsSpan(0, size).ToArray());
+            try { Copy(temp, 0, output, 0, size); }
+            finally { temp.Dispose(); }
+        }
+        finally { System.Buffers.ArrayPool<float>.Shared.Return(hostBuf); }
+    }
+
     public unsafe void RbfForward(IGpuBuffer input, IGpuBuffer centers, IGpuBuffer epsilons, IGpuBuffer output, int batchSize, int numCenters, int inputDim)
     {
         if (!_kernelCache.TryGetValue("rbf_forward", out var kernel))

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
@@ -2246,6 +2246,18 @@ public interface IDirectGpuBackend : IDisposable
     /// <param name="seed">Random seed.</param>
     void GenerateRandomNormal(IGpuBuffer output, int size, float mean, float stdDev, ulong seed);
 
+    /// <summary>
+    /// Generates cryptographically secure uniform random numbers.
+    /// Entropy is generated on the host via RandomNumberGenerator, uploaded to GPU,
+    /// then converted to [min, max) floats on-device. Provides crypto-quality randomness
+    /// with GPU-resident output (no download needed).
+    /// </summary>
+    /// <param name="output">Output buffer [size].</param>
+    /// <param name="size">Number of elements.</param>
+    /// <param name="min">Minimum value (inclusive).</param>
+    /// <param name="max">Maximum value (exclusive).</param>
+    void GenerateSecureRandomUniform(IGpuBuffer output, int size, float min, float max);
+
     #endregion
 
     #region Specialized Layer Operations

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
@@ -2247,10 +2247,10 @@ public interface IDirectGpuBackend : IDisposable
     void GenerateRandomNormal(IGpuBuffer output, int size, float mean, float stdDev, ulong seed);
 
     /// <summary>
-    /// Generates cryptographically secure uniform random numbers.
-    /// Entropy is generated on the host via RandomNumberGenerator, uploaded to GPU,
-    /// then converted to [min, max) floats on-device. Provides crypto-quality randomness
-    /// with GPU-resident output (no download needed).
+    /// Generates cryptographically secure uniform random floats in [min, max).
+    /// Entropy is generated on the host via RandomNumberGenerator + SIMD conversion,
+    /// scaled to [min, max) on the host, then uploaded to the GPU output buffer.
+    /// Output is GPU-resident after the call (no download needed).
     /// </summary>
     /// <param name="output">Output buffer [size].</param>
     /// <param name="size">Number of elements.</param>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Signal.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Signal.cs
@@ -510,15 +510,13 @@ public sealed partial class MetalBackend
     public void GenerateSecureRandomUniform(IGpuBuffer output, int size, float min, float max)
     {
         ThrowIfDisposed();
-        var hostBuf = System.Buffers.ArrayPool<float>.Shared.Rent(size);
-        try
-        {
-            Helpers.SimdRandom.SecureFillFloats(hostBuf.AsSpan(0, size));
-            float range = max - min;
-            for (int i = 0; i < size; i++) hostBuf[i] = hostBuf[i] * range + min;
-            UploadToBuffer(output, hostBuf.AsSpan(0, size).ToArray());
-        }
-        finally { System.Buffers.ArrayPool<float>.Shared.Return(hostBuf); }
+        if (size <= 0) return;
+        var data = new float[size];
+        Helpers.SimdRandom.SecureFillFloats(data.AsSpan());
+        float range = max - min;
+        for (int i = 0; i < size; i++) data[i] = data[i] * range + min;
+        UploadToBuffer(output, data);
+        Array.Clear(data, 0, size);
     }
 
     #endregion

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Signal.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Signal.cs
@@ -512,11 +512,14 @@ public sealed partial class MetalBackend
         ThrowIfDisposed();
         if (size <= 0) return;
         var data = new float[size];
-        Helpers.SimdRandom.SecureFillFloats(data.AsSpan());
-        float range = max - min;
-        for (int i = 0; i < size; i++) data[i] = data[i] * range + min;
-        UploadToBuffer(output, data);
-        Array.Clear(data, 0, size);
+        try
+        {
+            Helpers.SimdRandom.SecureFillFloats(data.AsSpan());
+            float range = max - min;
+            for (int i = 0; i < size; i++) data[i] = data[i] * range + min;
+            UploadToBuffer(output, data);
+        }
+        finally { Array.Clear(data, 0, size); }
     }
 
     #endregion

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Signal.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Signal.cs
@@ -507,6 +507,20 @@ public sealed partial class MetalBackend
         UploadToBuffer(output, data);
     }
 
+    public void GenerateSecureRandomUniform(IGpuBuffer output, int size, float min, float max)
+    {
+        ThrowIfDisposed();
+        var hostBuf = System.Buffers.ArrayPool<float>.Shared.Rent(size);
+        try
+        {
+            Helpers.SimdRandom.SecureFillFloats(hostBuf.AsSpan(0, size));
+            float range = max - min;
+            for (int i = 0; i < size; i++) hostBuf[i] = hostBuf[i] * range + min;
+            UploadToBuffer(output, hostBuf.AsSpan(0, size).ToArray());
+        }
+        finally { System.Buffers.ArrayPool<float>.Shared.Return(hostBuf); }
+    }
+
     #endregion
 
     #region Specialized Layer Operations

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -56,7 +56,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
         private static void WriteDiag(string message)
         {
-            WriteDiag(message);
+            if (DiagnosticOutput) Console.WriteLine(message);
         }
 
         private DirectOpenClContext? _context;
@@ -10095,20 +10095,28 @@ KERNEL VARIANTS (A/B testing):
             kernel.Execute1D(numThreads, Math.Min(256, numThreads));
         }
 
-        public void GenerateSecureRandomUniform(IGpuBuffer output, int size, float min, float max)
+        public unsafe void GenerateSecureRandomUniform(IGpuBuffer output, int size, float min, float max)
         {
             if (_context == null) throw new InvalidOperationException("OpenCL context not available");
-            var hostBuf = System.Buffers.ArrayPool<float>.Shared.Rent(size);
-            try
+            if (size <= 0) return;
+            var data = new float[size];
+            Helpers.SimdRandom.SecureFillFloats(data.AsSpan());
+            float range = max - min;
+            for (int i = 0; i < size; i++) data[i] = data[i] * range + min;
+            var openClBuffer = (DirectOpenClGpuBuffer)output;
+            fixed (float* ptr = data)
             {
-                Helpers.SimdRandom.SecureFillFloats(hostBuf.AsSpan(0, size));
-                float range = max - min;
-                for (int i = 0; i < size; i++) hostBuf[i] = hostBuf[i] * range + min;
-                var temp = AllocateBuffer(hostBuf.AsSpan(0, size).ToArray());
-                try { Copy(temp, 0, output, 0, size); }
-                finally { temp.Dispose(); }
+                int err = OpenClNativeBindings.EnqueueWriteBuffer(
+                    _defaultStream?.Handle ?? _context.CommandQueue,
+                    openClBuffer.Buffer.Handle,
+                    1, // blocking
+                    UIntPtr.Zero,
+                    (UIntPtr)(size * sizeof(float)),
+                    (IntPtr)ptr, 0, IntPtr.Zero, IntPtr.Zero);
+                if (err != OpenClNativeBindings.CL_SUCCESS)
+                    throw new InvalidOperationException($"clEnqueueWriteBuffer failed: {err}");
             }
-            finally { System.Buffers.ArrayPool<float>.Shared.Return(hostBuf); }
+            Array.Clear(data, 0, size);
         }
 
         #endregion

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -35,10 +35,20 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         /// <summary>
         /// Controls whether initialization and diagnostic output is written to Console.
         /// Set to false to suppress GPU diagnostics for rich terminal UI or batch processing.
-        /// Can also be controlled via AIDOTNET_GPU_VERBOSE environment variable ("false" to disable).
+        /// Controlled via AIDOTNET_GPU_VERBOSE environment variable (accepts true/false/1/0/yes/no/on/off).
+        /// Defaults to true (verbose) when the env var is unset.
         /// </summary>
-        public static bool DiagnosticOutput { get; set; } =
-            !string.Equals(Environment.GetEnvironmentVariable("AIDOTNET_GPU_VERBOSE"), "false", StringComparison.OrdinalIgnoreCase);
+        public static bool DiagnosticOutput { get; set; } = InitDiagnosticOutput();
+
+        private static bool InitDiagnosticOutput()
+        {
+            var val = Environment.GetEnvironmentVariable("AIDOTNET_GPU_VERBOSE");
+            if (string.IsNullOrWhiteSpace(val)) return true;
+            return val.Equals("1", StringComparison.OrdinalIgnoreCase) ||
+                   val.Equals("true", StringComparison.OrdinalIgnoreCase) ||
+                   val.Equals("yes", StringComparison.OrdinalIgnoreCase) ||
+                   val.Equals("on", StringComparison.OrdinalIgnoreCase);
+        }
 
         private DirectOpenClContext? _context;
         private readonly Dictionary<string, DirectOpenClKernel> _kernelCache;
@@ -4318,7 +4328,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             if (EnableTuningDiagnostics)
             {
                 if (DiagnosticOutput) Console.WriteLine("[GPU Capabilities]");
-                Console.Write(capabilities.GetDiagnosticString());
+                if (DiagnosticOutput) Console.Write(capabilities.GetDiagnosticString());
             }
 
             var dataA = new float[M * K];

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -10100,23 +10100,26 @@ KERNEL VARIANTS (A/B testing):
             if (_context == null) throw new InvalidOperationException("OpenCL context not available");
             if (size <= 0) return;
             var data = new float[size];
-            Helpers.SimdRandom.SecureFillFloats(data.AsSpan());
-            float range = max - min;
-            for (int i = 0; i < size; i++) data[i] = data[i] * range + min;
-            var openClBuffer = (DirectOpenClGpuBuffer)output;
-            fixed (float* ptr = data)
+            try
             {
-                int err = OpenClNativeBindings.EnqueueWriteBuffer(
-                    _defaultStream?.Handle ?? _context.CommandQueue,
-                    openClBuffer.Buffer.Handle,
-                    1, // blocking
-                    UIntPtr.Zero,
-                    (UIntPtr)(size * sizeof(float)),
-                    (IntPtr)ptr, 0, IntPtr.Zero, IntPtr.Zero);
-                if (err != OpenClNativeBindings.CL_SUCCESS)
-                    throw new InvalidOperationException($"clEnqueueWriteBuffer failed: {err}");
+                Helpers.SimdRandom.SecureFillFloats(data.AsSpan());
+                float range = max - min;
+                for (int i = 0; i < size; i++) data[i] = data[i] * range + min;
+                var openClBuffer = (DirectOpenClGpuBuffer)output;
+                fixed (float* ptr = data)
+                {
+                    int err = OpenClNativeBindings.EnqueueWriteBuffer(
+                        _defaultStream?.Handle ?? _context.CommandQueue,
+                        openClBuffer.Buffer.Handle,
+                        1, // blocking
+                        UIntPtr.Zero,
+                        (UIntPtr)(size * sizeof(float)),
+                        (IntPtr)ptr, 0, IntPtr.Zero, IntPtr.Zero);
+                    if (err != OpenClNativeBindings.CL_SUCCESS)
+                        throw new InvalidOperationException($"clEnqueueWriteBuffer failed: {err}");
+                }
             }
-            Array.Clear(data, 0, size);
+            finally { Array.Clear(data, 0, size); }
         }
 
         #endregion

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -43,11 +43,20 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         private static bool InitDiagnosticOutput()
         {
             var val = Environment.GetEnvironmentVariable("AIDOTNET_GPU_VERBOSE");
-            if (string.IsNullOrWhiteSpace(val)) return true;
-            return val.Equals("1", StringComparison.OrdinalIgnoreCase) ||
-                   val.Equals("true", StringComparison.OrdinalIgnoreCase) ||
-                   val.Equals("yes", StringComparison.OrdinalIgnoreCase) ||
-                   val.Equals("on", StringComparison.OrdinalIgnoreCase);
+            if (string.IsNullOrWhiteSpace(val)) return true; // default: verbose
+            // Explicitly disabled
+            if (val.Equals("0", StringComparison.OrdinalIgnoreCase) ||
+                val.Equals("false", StringComparison.OrdinalIgnoreCase) ||
+                val.Equals("no", StringComparison.OrdinalIgnoreCase) ||
+                val.Equals("off", StringComparison.OrdinalIgnoreCase))
+                return false;
+            // Unknown value — default to verbose to avoid silent suppression
+            return true;
+        }
+
+        private static void WriteDiag(string message)
+        {
+            WriteDiag(message);
         }
 
         private DirectOpenClContext? _context;
@@ -139,9 +148,9 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
             try
             {
-                if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend] Creating DirectOpenClContext for device {deviceIndex}...");
+                WriteDiag($"[OpenClBackend] Creating DirectOpenClContext for device {deviceIndex}...");
                 _context = new DirectOpenClContext(deviceIndex);
-                if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend] Context created: Device={_context.DeviceName}, Vendor={_context.DeviceVendor}");
+                WriteDiag($"[OpenClBackend] Context created: Device={_context.DeviceName}, Vendor={_context.DeviceVendor}");
 
                 IsAvailable = true;
                 DeviceName = _context.DeviceName;
@@ -152,7 +161,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 string? envCUs = Environment.GetEnvironmentVariable("AIDOTNET_GPU_COMPUTE_UNITS");
                 if (int.TryParse(envCUs, out int overrideCUs) && overrideCUs > 0 && overrideCUs <= 256)
                 {
-                    if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend] CU override: {detectedCUs} -> {overrideCUs} (via AIDOTNET_GPU_COMPUTE_UNITS)");
+                    WriteDiag($"[OpenClBackend] CU override: {detectedCUs} -> {overrideCUs} (via AIDOTNET_GPU_COMPUTE_UNITS)");
                     ComputeUnits = overrideCUs;
                 }
                 else
@@ -171,35 +180,35 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 _supportsSubgroups = _context.SupportsSubgroups;
 
                 // Print GPU capabilities for diagnostics
-                if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend] GPU Capabilities:");
-                if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend]   Compute Units: {ComputeUnits}");
-                if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend]   Max Work Group Size: {_maxWorkGroupSize}");
+                WriteDiag($"[OpenClBackend] GPU Capabilities:");
+                WriteDiag($"[OpenClBackend]   Compute Units: {ComputeUnits}");
+                WriteDiag($"[OpenClBackend]   Max Work Group Size: {_maxWorkGroupSize}");
                 if (_maxWorkItemSizes.Length >= 2)
                 {
-                    if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend]   Max Work Item Sizes: [{string.Join(", ", _maxWorkItemSizes)}]");
+                    WriteDiag($"[OpenClBackend]   Max Work Item Sizes: [{string.Join(", ", _maxWorkItemSizes)}]");
                 }
-                if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend]   Local Memory: {LocalMemoryBytes / 1024} KB");
-                if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend]   Supports FP16: {_supportsFp16}");
-                if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend]   Supports Subgroups: {_supportsSubgroups}");
+                WriteDiag($"[OpenClBackend]   Local Memory: {LocalMemoryBytes / 1024} KB");
+                WriteDiag($"[OpenClBackend]   Supports FP16: {_supportsFp16}");
+                WriteDiag($"[OpenClBackend]   Supports Subgroups: {_supportsSubgroups}");
 
                 // Initialize default stream wrapper
                 _defaultStream = new OpenClCommandQueue(this, _context.CommandQueue, _context.Context, _context.Device,
                     GpuStreamType.Default, _context.IsProfilingEnabled, ownsHandle: false);
-                if (DiagnosticOutput) Console.WriteLine("[OpenClBackend] Default command queue wrapper initialized.");
+                WriteDiag("[OpenClBackend] Default command queue wrapper initialized.");
 
-                if (DiagnosticOutput) Console.WriteLine("[OpenClBackend] Compiling kernels...");
+                WriteDiag("[OpenClBackend] Compiling kernels...");
                 CompileKernels();
-                if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend] Kernels compiled successfully. Total: {_kernelCache.Count}");
+                WriteDiag($"[OpenClBackend] Kernels compiled successfully. Total: {_kernelCache.Count}");
 
                 // Initialize dynamic kernel generator for Bayesian-optimized GEMM
                 _dynamicGemm = new DynamicGemmKernel(_context);
-                if (DiagnosticOutput) Console.WriteLine("[OpenClBackend] Dynamic GEMM kernel generator initialized.");
+                WriteDiag("[OpenClBackend] Dynamic GEMM kernel generator initialized.");
             }
             catch (Exception ex)
             {
-                if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend] Initialization FAILED: {ex.GetType().Name}: {ex.Message}");
+                WriteDiag($"[OpenClBackend] Initialization FAILED: {ex.GetType().Name}: {ex.Message}");
                 if (ex.InnerException != null)
-                    if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend] Inner: {ex.InnerException.Message}");
+                    WriteDiag($"[OpenClBackend] Inner: {ex.InnerException.Message}");
                 System.Diagnostics.Debug.WriteLine($"OpenClBackend initialization failed: {ex.Message}");
                 IsAvailable = false;
                 DeviceName = "None";
@@ -217,7 +226,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             var cached = DirectOpenClProgram.TryCreateFromCache(_context, source, buildOptions);
             if (cached != null)
             {
-                if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend] {label}: loaded from cache");
+                WriteDiag($"[OpenClBackend] {label}: loaded from cache");
                 return cached;
             }
 
@@ -226,7 +235,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             try
             {
                 program.Build(buildOptions);
-                if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend] {label}: compiled from source");
+                WriteDiag($"[OpenClBackend] {label}: compiled from source");
                 return program;
             }
             catch
@@ -251,14 +260,14 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             try
             {
                 // Compile GEMM kernels with aggressive optimizations
-                if (DiagnosticOutput) Console.WriteLine("[OpenClBackend] Compiling GEMM kernels...");
+                WriteDiag("[OpenClBackend] Compiling GEMM kernels...");
                 var gemmProgram = CompileOrLoadCached(GemmKernel.GetSource(), optimizationFlags, "GEMM kernels");
                 _programs.Add(gemmProgram);
                 foreach (var name in GemmKernel.GetKernelNames())
                 {
                     _kernelCache[name] = new DirectOpenClKernel(_context, gemmProgram, name);
                 }
-                if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend] GEMM kernels: {string.Join(", ", GemmKernel.GetKernelNames())}");
+                WriteDiag($"[OpenClBackend] GEMM kernels: {string.Join(", ", GemmKernel.GetKernelNames())}");
 
                 // Compile activation kernels
                 var activationProgram = CompileOrLoadCached(ActivationKernels.GetSource(), optimizationFlags, "Activation kernels");
@@ -377,19 +386,19 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                         _kernelCache["mixed_precision_backward"] = new DirectOpenClKernel(_context, mpProgram, "mixed_precision_backward");
                         _kernelCache["accumulate_gradient_fp32"] = new DirectOpenClKernel(_context, mpProgram, "accumulate_gradient_fp32");
                         _mixedPrecisionKernelsAvailable = true;
-                        if (DiagnosticOutput) Console.WriteLine("[OpenClBackend] Mixed precision kernels compiled: 5 kernels");
+                        WriteDiag("[OpenClBackend] Mixed precision kernels compiled: 5 kernels");
                     }
                     catch (Exception ex)
                     {
                         // Mixed precision compilation failed - this is non-fatal
                         // Device may report FP16 support but have driver issues with these kernels
-                        if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend] Warning: Mixed precision kernel compilation failed (non-fatal): {ex.Message}");
-                        if (DiagnosticOutput) Console.WriteLine("[OpenClBackend] Continuing without mixed precision support.");
+                        WriteDiag($"[OpenClBackend] Warning: Mixed precision kernel compilation failed (non-fatal): {ex.Message}");
+                        WriteDiag("[OpenClBackend] Continuing without mixed precision support.");
                     }
                 }
                 else
                 {
-                    if (DiagnosticOutput) Console.WriteLine("[OpenClBackend] Skipping mixed precision kernels (FP16 not supported on this device).");
+                    WriteDiag("[OpenClBackend] Skipping mixed precision kernels (FP16 not supported on this device).");
                 }
 
                 // Compile attention kernels (FlashAttention, GQA, ScaledDotProduct)
@@ -415,7 +424,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 {
                     _kernelCache[name] = new DirectOpenClKernel(_context, stProgram, name);
                 }
-                if (DiagnosticOutput) Console.WriteLine("[OpenClBackend] Spatial transformer kernels compiled: 4 kernels");
+                WriteDiag("[OpenClBackend] Spatial transformer kernels compiled: 4 kernels");
 
                 // Compile locally connected convolution kernels
                 var locallyConnectedProgram = CompileOrLoadCached(LocallyConnectedKernels.GetSource(), optimizationFlags, "Locally connected kernels");
@@ -810,12 +819,12 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 {
                     var previous = Console.ForegroundColor;
                     Console.ForegroundColor = color.Value;
-                    if (DiagnosticOutput) Console.WriteLine(message);
+                    WriteDiag(message);
                     Console.ForegroundColor = previous;
                 }
                 else
                 {
-                    if (DiagnosticOutput) Console.WriteLine(message);
+                    WriteDiag(message);
                 }
             }
 
@@ -962,7 +971,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
                     if (EnableTuningDiagnostics)
                     {
-                        if (DiagnosticOutput) Console.WriteLine($"[GEMM] Cached config invalid: {validationError}");
+                        WriteDiag($"[GEMM] Cached config invalid: {validationError}");
                     }
                 }
 
@@ -1027,7 +1036,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             {
                 if (EnableTuningDiagnostics)
                 {
-                    if (DiagnosticOutput) Console.WriteLine($"[GEMM] Tuning lookup failed: {ex.Message}");
+                    WriteDiag($"[GEMM] Tuning lookup failed: {ex.Message}");
                 }
 
                 return false;
@@ -1061,7 +1070,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 _clblastTransposeParams = ClBlastTransposeDatabase.GetParameters(deviceInfo);
                 _clblastDirectParams = ClBlastXgemmDirectDatabase.GetParameters(deviceInfo);
                 _clblastMinIndirectSize = ClBlastGemmRoutineDatabase.GetXgemmMinIndirectSize(deviceInfo);
-                if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend] CLBlast MinIndirectSize threshold: {_clblastMinIndirectSize} (use INDIRECT for M/N >= {_clblastMinIndirectSize})");
+                WriteDiag($"[OpenClBackend] CLBlast MinIndirectSize threshold: {_clblastMinIndirectSize} (use INDIRECT for M/N >= {_clblastMinIndirectSize})");
 
                 if (ClBlastXgemmDatabase.TryGetConfig(deviceInfo, out var baseline))
                 {
@@ -1421,19 +1430,19 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             if (!useIndirectPath || forceDirect)
             {
                 if (traceEnabled)
-                    if (DiagnosticOutput) Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] Trying DIRECT path (M/N < {_clblastMinIndirectSize} or forceDirect={forceDirect})");
+                    WriteDiag($"[GEMM-TRACE {M}x{N}x{K}] Trying DIRECT path (M/N < {_clblastMinIndirectSize} or forceDirect={forceDirect})");
                 if (TryExecuteClBlastDirectGemm(A, B, C, M, N, K, alpha, beta))
                 {
                     if (traceEnabled)
-                        if (DiagnosticOutput) Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] SUCCESS: DIRECT path executed");
+                        WriteDiag($"[GEMM-TRACE {M}x{N}x{K}] SUCCESS: DIRECT path executed");
                     return true;
                 }
                 if (traceEnabled)
-                    if (DiagnosticOutput) Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] DIRECT path failed, trying INDIRECT");
+                    WriteDiag($"[GEMM-TRACE {M}x{N}x{K}] DIRECT path failed, trying INDIRECT");
             }
             else if (traceEnabled)
             {
-                if (DiagnosticOutput) Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] Skipping DIRECT path (M/N >= {_clblastMinIndirectSize}), using INDIRECT");
+                WriteDiag($"[GEMM-TRACE {M}x{N}x{K}] Skipping DIRECT path (M/N >= {_clblastMinIndirectSize}), using INDIRECT");
             }
 
             if (_dynamicGemm == null)
@@ -1575,7 +1584,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                         var total = allocTime + packATime + packBTime + packCTime + gemmTime + unpackCTime;
                         double flops = 2.0 * M * N * K;
                         double gflops = flops / (total / ticksPerMs) / 1e6;
-                        if (DiagnosticOutput) Console.WriteLine($"[TIMING-SWAP {M}x{N}x{K}] Alloc={allocTime / ticksPerMs:F2}ms PackA={packATime / ticksPerMs:F2}ms PackB={packBTime / ticksPerMs:F2}ms GEMM={gemmTime / ticksPerMs:F2}ms UnpackC={unpackCTime / ticksPerMs:F2}ms Total={total / ticksPerMs:F2}ms ({gflops:F0} GFLOPS)");
+                        WriteDiag($"[TIMING-SWAP {M}x{N}x{K}] Alloc={allocTime / ticksPerMs:F2}ms PackA={packATime / ticksPerMs:F2}ms PackB={packBTime / ticksPerMs:F2}ms GEMM={gemmTime / ticksPerMs:F2}ms UnpackC={unpackCTime / ticksPerMs:F2}ms Total={total / ticksPerMs:F2}ms ({gflops:F0} GFLOPS)");
                     }
 
                     return true;
@@ -1676,7 +1685,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                     {
                         double ticksPerMs = System.Diagnostics.Stopwatch.Frequency / 1000.0;
                         var total = allocTime + packATime + packBTime + packCTime + gemmTime + unpackCTime;
-                        if (DiagnosticOutput) Console.WriteLine($"[TIMING {M}x{N}x{K}] Alloc={allocTime / ticksPerMs:F2}ms PackA={packATime / ticksPerMs:F2}ms PackB={packBTime / ticksPerMs:F2}ms GEMM={gemmTime / ticksPerMs:F2}ms UnpackC={unpackCTime / ticksPerMs:F2}ms Total={total / ticksPerMs:F2}ms");
+                        WriteDiag($"[TIMING {M}x{N}x{K}] Alloc={allocTime / ticksPerMs:F2}ms PackA={packATime / ticksPerMs:F2}ms PackB={packBTime / ticksPerMs:F2}ms GEMM={gemmTime / ticksPerMs:F2}ms UnpackC={unpackCTime / ticksPerMs:F2}ms Total={total / ticksPerMs:F2}ms");
                     }
 
                     return true;
@@ -1779,7 +1788,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
             if (EnableTuningDiagnostics)
             {
-                if (DiagnosticOutput) Console.WriteLine($"[GEMM] Packed GEMM: {M}x{N}x{K} -> {mPad}x{nPad}x{kPad}");
+                WriteDiag($"[GEMM] Packed GEMM: {M}x{N}x{K} -> {mPad}x{nPad}x{kPad}");
             }
 
             using var aPad = AllocateBuffer(mPad * kPad);
@@ -1843,7 +1852,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             {
                 if (EnableTuningDiagnostics)
                 {
-                    if (DiagnosticOutput) Console.WriteLine($"[GEMM] Dynamic config invalid: {validationError}");
+                    WriteDiag($"[GEMM] Dynamic config invalid: {validationError}");
                 }
                 return false;
             }
@@ -1859,7 +1868,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             {
                 if (EnableTuningDiagnostics)
                 {
-                    if (DiagnosticOutput) Console.WriteLine($"[GEMM] Dynamic kernel failed ({config.KernelName}): {ex.Message}");
+                    WriteDiag($"[GEMM] Dynamic kernel failed ({config.KernelName}): {ex.Message}");
                 }
                 return false;
             }
@@ -1882,61 +1891,61 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             if (ClBlastNative.IsAvailable && ShouldUseVendorGemm(M, N, K, offlineEnabled))
             {
                 if (traceEnabled)
-                    if (DiagnosticOutput) Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] Trying CLBlast library");
+                    WriteDiag($"[GEMM-TRACE {M}x{N}x{K}] Trying CLBlast library");
 
                 if (TryExecuteClBlastLibraryGemm(A, B, C, M, N, K, alpha, beta))
                 {
                     if (traceEnabled)
-                        if (DiagnosticOutput) Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] SUCCESS: CLBlast library executed");
+                        WriteDiag($"[GEMM-TRACE {M}x{N}x{K}] SUCCESS: CLBlast library executed");
                     return;
                 }
 
                 if (traceEnabled)
-                    if (DiagnosticOutput) Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] FALLBACK: CLBlast library FAILED");
+                    WriteDiag($"[GEMM-TRACE {M}x{N}x{K}] FALLBACK: CLBlast library FAILED");
             }
             else if (traceEnabled && !ClBlastNative.IsAvailable)
             {
-                if (DiagnosticOutput) Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] SKIP: CLBlast library not available");
+                WriteDiag($"[GEMM-TRACE {M}x{N}x{K}] SKIP: CLBlast library not available");
             }
 
             if (!offlineEnabled && TryGetClBlastBaselineConfig(out var baselineConfig))
             {
                 if (traceEnabled)
-                    if (DiagnosticOutput) Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] Trying CLBlast baseline (TileM={baselineConfig.TileM}, TileN={baselineConfig.TileN}, TileK={baselineConfig.TileK})");
+                    WriteDiag($"[GEMM-TRACE {M}x{N}x{K}] Trying CLBlast baseline (TileM={baselineConfig.TileM}, TileN={baselineConfig.TileN}, TileK={baselineConfig.TileK})");
 
                 if (TryExecuteClBlastBaselineGemm(A, B, C, M, N, K, alpha, beta, baselineConfig))
                 {
                     if (traceEnabled)
-                        if (DiagnosticOutput) Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] SUCCESS: CLBlast baseline executed");
+                        WriteDiag($"[GEMM-TRACE {M}x{N}x{K}] SUCCESS: CLBlast baseline executed");
                     return;
                 }
                 if (traceEnabled)
-                    if (DiagnosticOutput) Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] FALLBACK: CLBlast baseline FAILED");
+                    WriteDiag($"[GEMM-TRACE {M}x{N}x{K}] FALLBACK: CLBlast baseline FAILED");
             }
             else
             {
                 if (traceEnabled)
-                    if (DiagnosticOutput) Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] SKIP: CLBlast baseline not available (offline={offlineEnabled})");
+                    WriteDiag($"[GEMM-TRACE {M}x{N}x{K}] SKIP: CLBlast baseline not available (offline={offlineEnabled})");
             }
 
             if (_dynamicGemm != null && M >= 128 && N >= 128 && K >= 64 &&
                 TryGetTunedConfig(M, N, K, out var tunedConfig))
             {
                 if (traceEnabled)
-                    if (DiagnosticOutput) Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] Trying dynamic GEMM");
+                    WriteDiag($"[GEMM-TRACE {M}x{N}x{K}] Trying dynamic GEMM");
                 if (TryExecutePackedDynamicGemm(A, B, C, M, N, K, alpha, beta, tunedConfig))
                 {
                     if (traceEnabled)
-                        if (DiagnosticOutput) Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] SUCCESS: Dynamic GEMM executed");
+                        WriteDiag($"[GEMM-TRACE {M}x{N}x{K}] SUCCESS: Dynamic GEMM executed");
                     return;
                 }
                 if (traceEnabled)
-                    if (DiagnosticOutput) Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] FALLBACK: Dynamic GEMM FAILED");
+                    WriteDiag($"[GEMM-TRACE {M}x{N}x{K}] FALLBACK: Dynamic GEMM FAILED");
             }
 
             // FALLBACK: Using our own kernels (NOT CLBlast identical!)
             if (traceEnabled)
-                if (DiagnosticOutput) Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] FALLBACK: Using built-in kernel (NOT CLBlast!)");
+                WriteDiag($"[GEMM-TRACE {M}x{N}x{K}] FALLBACK: Using built-in kernel (NOT CLBlast!)");
 
             // Choose kernel based on matrix size
             // Use optimized kernel for matrices >= 128 in any dimension
@@ -1991,7 +2000,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
         public IGpuBuffer MatMul(IGpuBuffer A, IGpuBuffer B, int M, int N, int K)
         {
-            if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend.MatMul] Called: {M}x{N}x{K}");
+            WriteDiag($"[OpenClBackend.MatMul] Called: {M}x{N}x{K}");
             var C = AllocateBuffer(M * N);
             Gemm(A, B, C, M, N, K, 1.0f, 0.0f);
             // Sync only when returning buffer that might be immediately read
@@ -4113,65 +4122,65 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             {
                 if (Console.IsOutputRedirected)
                 {
-                    if (DiagnosticOutput) Console.WriteLine(message);
+                    WriteDiag(message);
                     return;
                 }
 
                 var previous = Console.ForegroundColor;
                 Console.ForegroundColor = color;
-                if (DiagnosticOutput) Console.WriteLine(message);
+                WriteDiag(message);
                 Console.ForegroundColor = previous;
             }
 
             if (DiagnosticOutput) Console.WriteLine();
-            if (DiagnosticOutput) Console.WriteLine("=== OpenCL GEMM Diagnostics ===");
-            if (DiagnosticOutput) Console.WriteLine($"Matrix dimensions: M={diagnostics.M}, N={diagnostics.N}, K={diagnostics.K}");
-            if (DiagnosticOutput) Console.WriteLine($"Kernel: {diagnostics.KernelName}");
-            if (DiagnosticOutput) Console.WriteLine($"Work configuration: Global({diagnostics.GlobalSizeX}x{diagnostics.GlobalSizeY}), Local({diagnostics.LocalSizeX}x{diagnostics.LocalSizeY})");
-            if (DiagnosticOutput) Console.WriteLine($"Work items launched: {diagnostics.WorkItemsLaunched:N0}");
-            if (DiagnosticOutput) Console.WriteLine($"Work groups launched: {diagnostics.WorkGroupsLaunched:N0}");
+            WriteDiag("=== OpenCL GEMM Diagnostics ===");
+            WriteDiag($"Matrix dimensions: M={diagnostics.M}, N={diagnostics.N}, K={diagnostics.K}");
+            WriteDiag($"Kernel: {diagnostics.KernelName}");
+            WriteDiag($"Work configuration: Global({diagnostics.GlobalSizeX}x{diagnostics.GlobalSizeY}), Local({diagnostics.LocalSizeX}x{diagnostics.LocalSizeY})");
+            WriteDiag($"Work items launched: {diagnostics.WorkItemsLaunched:N0}");
+            WriteDiag($"Work groups launched: {diagnostics.WorkGroupsLaunched:N0}");
             if (DiagnosticOutput) Console.WriteLine();
 
             if (diagnostics.IsProfilingAvailable && diagnostics.KernelExecutionNs > 0)
             {
-                if (DiagnosticOutput) Console.WriteLine("--- GPU Timing (from OpenCL events) ---");
-                if (DiagnosticOutput) Console.WriteLine($"Queue to Submit: {diagnostics.QueueToSubmitNs / 1e6:F3} ms");
-                if (DiagnosticOutput) Console.WriteLine($"Submit to Start (launch overhead): {diagnostics.SubmitToStartNs / 1e6:F3} ms");
-                if (DiagnosticOutput) Console.WriteLine($"Kernel Execution: {diagnostics.KernelExecutionNs / 1e6:F3} ms");
-                if (DiagnosticOutput) Console.WriteLine($"Total GPU Time: {diagnostics.TotalGpuTimeNs / 1e6:F3} ms");
+                WriteDiag("--- GPU Timing (from OpenCL events) ---");
+                WriteDiag($"Queue to Submit: {diagnostics.QueueToSubmitNs / 1e6:F3} ms");
+                WriteDiag($"Submit to Start (launch overhead): {diagnostics.SubmitToStartNs / 1e6:F3} ms");
+                WriteDiag($"Kernel Execution: {diagnostics.KernelExecutionNs / 1e6:F3} ms");
+                WriteDiag($"Total GPU Time: {diagnostics.TotalGpuTimeNs / 1e6:F3} ms");
             }
             else if (!string.IsNullOrEmpty(diagnostics.ProfilingError))
             {
-                if (DiagnosticOutput) Console.WriteLine($"Profiling error: {diagnostics.ProfilingError}");
+                WriteDiag($"Profiling error: {diagnostics.ProfilingError}");
             }
 
-            if (DiagnosticOutput) Console.WriteLine($"Wall clock time: {diagnostics.WallClockMs:F3} ms");
+            WriteDiag($"Wall clock time: {diagnostics.WallClockMs:F3} ms");
             if (DiagnosticOutput) Console.WriteLine();
 
-            if (DiagnosticOutput) Console.WriteLine("--- Performance Metrics ---");
-            if (DiagnosticOutput) Console.WriteLine($"FLOPS required: {diagnostics.FlopsRequired:N0} ({diagnostics.FlopsRequired / 1e9:F2} GFLOP)");
-            if (DiagnosticOutput) Console.WriteLine($"Bytes transferred: {diagnostics.BytesTransferred:N0} ({diagnostics.BytesTransferred / 1e6:F2} MB)");
-            if (DiagnosticOutput) Console.WriteLine($"Arithmetic intensity: {diagnostics.ArithmeticIntensity:F2} FLOP/byte");
-            if (DiagnosticOutput) Console.WriteLine($"Achieved GFLOPS: {diagnostics.AchievedGflops:F2}");
-            if (DiagnosticOutput) Console.WriteLine($"Achieved bandwidth: {diagnostics.AchievedBandwidthGBps:F2} GB/s");
-            if (DiagnosticOutput) Console.WriteLine($"Compute efficiency: {diagnostics.ComputeEfficiency:F1}% of theoretical peak");
+            WriteDiag("--- Performance Metrics ---");
+            WriteDiag($"FLOPS required: {diagnostics.FlopsRequired:N0} ({diagnostics.FlopsRequired / 1e9:F2} GFLOP)");
+            WriteDiag($"Bytes transferred: {diagnostics.BytesTransferred:N0} ({diagnostics.BytesTransferred / 1e6:F2} MB)");
+            WriteDiag($"Arithmetic intensity: {diagnostics.ArithmeticIntensity:F2} FLOP/byte");
+            WriteDiag($"Achieved GFLOPS: {diagnostics.AchievedGflops:F2}");
+            WriteDiag($"Achieved bandwidth: {diagnostics.AchievedBandwidthGBps:F2} GB/s");
+            WriteDiag($"Compute efficiency: {diagnostics.ComputeEfficiency:F1}% of theoretical peak");
             if (DiagnosticOutput) Console.WriteLine();
 
-            if (DiagnosticOutput) Console.WriteLine("--- Bottleneck Analysis ---");
+            WriteDiag("--- Bottleneck Analysis ---");
             if (diagnostics.SubmitToStartNs > diagnostics.KernelExecutionNs * 0.5 && diagnostics.KernelExecutionNs > 0)
             {
                 WriteColored("WARNING: High launch overhead detected (>50% of kernel time)", ConsoleColor.Yellow);
-                if (DiagnosticOutput) Console.WriteLine("  -> Consider batching multiple small operations");
+                WriteDiag("  -> Consider batching multiple small operations");
             }
             if (diagnostics.IsLikelyMemoryBound)
             {
                 WriteColored("LIKELY MEMORY BOUND: Achieved GFLOPS limited by memory bandwidth", ConsoleColor.Yellow);
-                if (DiagnosticOutput) Console.WriteLine("  -> Consider using data tiling, caching, or reducing data movement");
+                WriteDiag("  -> Consider using data tiling, caching, or reducing data movement");
             }
             else if (diagnostics.ComputeEfficiency < 50)
             {
                 WriteColored("LIKELY COMPUTE BOUND with low efficiency:", ConsoleColor.Red);
-                if (DiagnosticOutput) Console.WriteLine("  -> Check for bank conflicts, divergent warps, or suboptimal work group size");
+                WriteDiag("  -> Check for bank conflicts, divergent warps, or suboptimal work group size");
             }
             else if (diagnostics.ComputeEfficiency < 80)
             {
@@ -4191,18 +4200,18 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         {
             if (_context == null)
             {
-                if (DiagnosticOutput) Console.WriteLine("OpenCL context not available");
+                WriteDiag("OpenCL context not available");
                 return;
             }
 
             var deviceInfo = GetDeviceInfo();
-            if (DiagnosticOutput) Console.WriteLine("=== OpenCL GEMM Benchmark ===");
-            if (DiagnosticOutput) Console.WriteLine($"Device: {deviceInfo.DeviceName}");
-            if (DiagnosticOutput) Console.WriteLine($"Vendor: {deviceInfo.DeviceVendor}");
-            if (DiagnosticOutput) Console.WriteLine($"Compute Units: {deviceInfo.ComputeUnits}");
-            if (DiagnosticOutput) Console.WriteLine($"Clock: {deviceInfo.ClockFrequencyMHz} MHz");
-            if (DiagnosticOutput) Console.WriteLine($"Theoretical Peak: {deviceInfo.TheoreticalPeakGflops:F0} GFLOPS");
-            if (DiagnosticOutput) Console.WriteLine($"Profiling enabled: {IsProfilingEnabled}");
+            WriteDiag("=== OpenCL GEMM Benchmark ===");
+            WriteDiag($"Device: {deviceInfo.DeviceName}");
+            WriteDiag($"Vendor: {deviceInfo.DeviceVendor}");
+            WriteDiag($"Compute Units: {deviceInfo.ComputeUnits}");
+            WriteDiag($"Clock: {deviceInfo.ClockFrequencyMHz} MHz");
+            WriteDiag($"Theoretical Peak: {deviceInfo.TheoreticalPeakGflops:F0} GFLOPS");
+            WriteDiag($"Profiling enabled: {IsProfilingEnabled}");
             if (DiagnosticOutput) Console.WriteLine();
 
             int sizeIndex = 0;
@@ -4210,8 +4219,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             {
                 sizeIndex++;
                 int M = size, N = size, K = size;
-                if (DiagnosticOutput) Console.WriteLine($"[Progress] {sizeIndex}/{sizes.Length} size {size}x{size}x{size}");
-                if (DiagnosticOutput) Console.WriteLine($"--- Matrix size: {size}x{size}x{size} ---");
+                WriteDiag($"[Progress] {sizeIndex}/{sizes.Length} size {size}x{size}x{size}");
+                WriteDiag($"--- Matrix size: {size}x{size}x{size} ---");
 
                 // Allocate buffers
                 var dataA = new float[M * K];
@@ -4264,15 +4273,15 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 avgBandwidth /= benchmarkIterations;
                 avgLaunchOverhead /= benchmarkIterations;
 
-                if (DiagnosticOutput) Console.WriteLine($"  Kernel: {allDiagnostics[0].KernelName}");
-                if (DiagnosticOutput) Console.WriteLine($"  Avg kernel time: {avgKernelTimeMs:F3} ms");
+                WriteDiag($"  Kernel: {allDiagnostics[0].KernelName}");
+                WriteDiag($"  Avg kernel time: {avgKernelTimeMs:F3} ms");
                 if (avgLaunchOverhead > 0)
                 {
-                    if (DiagnosticOutput) Console.WriteLine($"  Avg launch overhead: {avgLaunchOverhead:F3} ms");
+                    WriteDiag($"  Avg launch overhead: {avgLaunchOverhead:F3} ms");
                 }
-                if (DiagnosticOutput) Console.WriteLine($"  Avg GFLOPS: {avgGflops:F2}");
-                if (DiagnosticOutput) Console.WriteLine($"  Avg bandwidth: {avgBandwidth:F2} GB/s");
-                if (DiagnosticOutput) Console.WriteLine($"  Efficiency: {avgGflops / deviceInfo.TheoreticalPeakGflops * 100:F1}%");
+                WriteDiag($"  Avg GFLOPS: {avgGflops:F2}");
+                WriteDiag($"  Avg bandwidth: {avgBandwidth:F2} GB/s");
+                WriteDiag($"  Efficiency: {avgGflops / deviceInfo.TheoreticalPeakGflops * 100:F1}%");
                 if (DiagnosticOutput) Console.WriteLine();
             }
         }
@@ -4321,14 +4330,14 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             var capabilities = GpuCapabilities.Detect(ComputeUnits, GlobalMemoryBytes, (int)LocalMemoryBytes,
                 (int)_maxWorkGroupSize, DeviceVendor, DeviceName, _context.Extensions);
 
-            if (DiagnosticOutput) Console.WriteLine("=== Bayesian GEMM Optimization ===");
-            if (DiagnosticOutput) Console.WriteLine($"Matrix: {M}x{N}x{K}, Device: {DeviceName}, Max trials: {maxTrials}");
+            WriteDiag("=== Bayesian GEMM Optimization ===");
+            WriteDiag($"Matrix: {M}x{N}x{K}, Device: {DeviceName}, Max trials: {maxTrials}");
 
             // Print GPU capabilities if diagnostics enabled
             if (EnableTuningDiagnostics)
             {
-                if (DiagnosticOutput) Console.WriteLine("[GPU Capabilities]");
-                if (DiagnosticOutput) Console.Write(capabilities.GetDiagnosticString());
+                WriteDiag("[GPU Capabilities]");
+                WriteDiag(capabilities.GetDiagnosticString());
             }
 
             var dataA = new float[M * K];
@@ -4368,7 +4377,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                     benchmarkFailures++;
                     if (EnableTuningDiagnostics)
                     {
-                        if (DiagnosticOutput) Console.WriteLine($"  [Validation] {config.KernelName}: {validationError}");
+                        WriteDiag($"  [Validation] {config.KernelName}: {validationError}");
                     }
                     database.MarkAsTested(M, N, K, config, 0);
                     return double.NaN;
@@ -4381,7 +4390,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                     {
                         if (EnableTuningDiagnostics)
                         {
-                            if (DiagnosticOutput) Console.WriteLine($"  [Cache] {config.KernelName}: {cachedGflops.Value:F2} GFLOPS");
+                            WriteDiag($"  [Cache] {config.KernelName}: {cachedGflops.Value:F2} GFLOPS");
                         }
 
                         return ops / (cachedGflops.Value * 1e6);
@@ -4415,12 +4424,12 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 catch (Exception ex)
                 {
                     benchmarkFailures++;
-                    if (DiagnosticOutput) Console.WriteLine($"  Config {config} failed: {ex.Message}");
+                    WriteDiag($"  Config {config} failed: {ex.Message}");
 
                     // Print kernel stats on failure
                     if (EnableTuningDiagnostics && _dynamicGemm != null)
                     {
-                        if (DiagnosticOutput) Console.WriteLine($"  [DynamicGemm Stats] {_dynamicGemm.GetDiagnosticStats()}");
+                        WriteDiag($"  [DynamicGemm Stats] {_dynamicGemm.GetDiagnosticStats()}");
                     }
 
                     database.MarkAsTested(M, N, K, config, 0);
@@ -4440,8 +4449,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             {
                 var cachedConfig = cachedEntry.Value.Config;
                 databaseGflops = cachedEntry.Value.GFlops;  // Use stored GFLOPS as baseline
-                if (DiagnosticOutput) Console.WriteLine($"Using cached configuration: {cachedConfig}");
-                if (DiagnosticOutput) Console.WriteLine($"Database best: {databaseGflops:F2} GFLOPS (threshold to beat)");
+                WriteDiag($"Using cached configuration: {cachedConfig}");
+                WriteDiag($"Database best: {databaseGflops:F2} GFLOPS (threshold to beat)");
 
                 // Re-benchmark to validate config works and add to result set
                 var cachedTimeMs = BenchmarkConfigNoCache(cachedConfig);
@@ -4455,7 +4464,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                         GFlops = revalidatedGflops,
                         IsValid = true
                     };
-                    if (DiagnosticOutput) Console.WriteLine($"Revalidated: {revalidatedGflops:F2} GFLOPS");
+                    WriteDiag($"Revalidated: {revalidatedGflops:F2} GFLOPS");
                 }
             }
 
@@ -4466,10 +4475,10 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             // Print final statistics
             if (EnableTuningDiagnostics)
             {
-                if (DiagnosticOutput) Console.WriteLine($"\n[Benchmark Stats] Attempts: {benchmarkAttempts}, Failures: {benchmarkFailures}");
+                WriteDiag($"\n[Benchmark Stats] Attempts: {benchmarkAttempts}, Failures: {benchmarkFailures}");
                 if (_dynamicGemm != null)
                 {
-                    if (DiagnosticOutput) Console.WriteLine($"[DynamicGemm Stats] {_dynamicGemm.GetDiagnosticStats()}");
+                    WriteDiag($"[DynamicGemm Stats] {_dynamicGemm.GetDiagnosticStats()}");
                 }
             }
 
@@ -4486,18 +4495,18 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             if (allResults.Count > 0 && allResults[0].IsValid)
             {
                 var best = allResults[0];
-                if (DiagnosticOutput) Console.WriteLine($"Best: {best.Config} - {best.GFlops:F2} GFLOPS");
+                WriteDiag($"Best: {best.Config} - {best.GFlops:F2} GFLOPS");
 
                 // Only update database if we found something better than the DATABASE best
                 // Note: We compare against databaseGflops (historical best), NOT re-benchmarked value
                 if (best.GFlops > databaseGflops)
                 {
-                    if (DiagnosticOutput) Console.WriteLine($"NEW GLOBAL BEST! {best.GFlops:F2} > {databaseGflops:F2} GFLOPS (previous best)");
+                    WriteDiag($"NEW GLOBAL BEST! {best.GFlops:F2} > {databaseGflops:F2} GFLOPS (previous best)");
                     database.StoreResult(M, N, K, best.Config, best.GFlops);
                 }
                 else
                 {
-                    if (DiagnosticOutput) Console.WriteLine($"No improvement: {best.GFlops:F2} <= {databaseGflops:F2} GFLOPS (database best)");
+                    WriteDiag($"No improvement: {best.GFlops:F2} <= {databaseGflops:F2} GFLOPS (database best)");
                 }
             }
 
@@ -4518,8 +4527,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             var capabilities = GpuCapabilities.Detect(ComputeUnits, GlobalMemoryBytes, (int)LocalMemoryBytes,
                 (int)_maxWorkGroupSize, DeviceVendor, DeviceName, _context.Extensions);
 
-            if (DiagnosticOutput) Console.WriteLine("=== EXHAUSTIVE GEMM Optimization (CLBlast-style) ===");
-            if (DiagnosticOutput) Console.WriteLine($"Matrix: {M}x{N}x{K}, Device: {DeviceName}");
+            WriteDiag("=== EXHAUSTIVE GEMM Optimization (CLBlast-style) ===");
+            WriteDiag($"Matrix: {M}x{N}x{K}, Device: {DeviceName}");
 
             var dataA = new float[M * K];
             var dataB = new float[K * N];
@@ -4552,7 +4561,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 {
                     if (EnableTuningDiagnostics)
                     {
-                        if (DiagnosticOutput) Console.WriteLine($"  [Validation] {config.KernelName}: {validationError}");
+                        WriteDiag($"  [Validation] {config.KernelName}: {validationError}");
                     }
                     database.MarkAsTested(M, N, K, config, 0);
                     return double.NaN;
@@ -4565,7 +4574,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                     {
                         if (EnableTuningDiagnostics)
                         {
-                            if (DiagnosticOutput) Console.WriteLine($"  [Cache] {config.KernelName}: {cachedGflops.Value:F2} GFLOPS");
+                            WriteDiag($"  [Cache] {config.KernelName}: {cachedGflops.Value:F2} GFLOPS");
                         }
 
                         return ops / (cachedGflops.Value * 1e6);
@@ -4596,7 +4605,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 }
                 catch (Exception ex)
                 {
-                    if (DiagnosticOutput) Console.WriteLine($"  Config {config} failed: {ex.Message}");
+                    WriteDiag($"  Config {config} failed: {ex.Message}");
                     database.MarkAsTested(M, N, K, config, 0);
                     return double.NaN;
                 }
@@ -4610,7 +4619,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             if (results.Length > 0 && results[0].IsValid)
             {
                 var best = results[0];
-                if (DiagnosticOutput) Console.WriteLine($"EXHAUSTIVE Best: {best.Config} - {best.GFlops:F2} GFLOPS");
+                WriteDiag($"EXHAUSTIVE Best: {best.Config} - {best.GFlops:F2} GFLOPS");
 
                 database.StoreResult(M, N, K, best.Config, best.GFlops);
             }
@@ -4650,7 +4659,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             {
                 if (EnableTuningDiagnostics)
                 {
-                    if (DiagnosticOutput) Console.WriteLine($"CLBlast SGEMM failed with status: {status}");
+                    WriteDiag($"CLBlast SGEMM failed with status: {status}");
                 }
                 return false;
             }
@@ -4912,7 +4921,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             // Auto-print if profiling is enabled
             if (GetEnvBool(GemmProfileEnvVar))
             {
-                if (DiagnosticOutput) Console.WriteLine(result);
+                WriteDiag(result.ToString());
             }
 
             return result;
@@ -10084,6 +10093,22 @@ KERNEL VARIANTS (A/B testing):
             // Each thread generates 2 numbers
             int numThreads = (size + 1) / 2;
             kernel.Execute1D(numThreads, Math.Min(256, numThreads));
+        }
+
+        public void GenerateSecureRandomUniform(IGpuBuffer output, int size, float min, float max)
+        {
+            if (_context == null) throw new InvalidOperationException("OpenCL context not available");
+            var hostBuf = System.Buffers.ArrayPool<float>.Shared.Rent(size);
+            try
+            {
+                Helpers.SimdRandom.SecureFillFloats(hostBuf.AsSpan(0, size));
+                float range = max - min;
+                for (int i = 0; i < size; i++) hostBuf[i] = hostBuf[i] * range + min;
+                var temp = AllocateBuffer(hostBuf.AsSpan(0, size).ToArray());
+                try { Copy(temp, 0, output, 0, size); }
+                finally { temp.Dispose(); }
+            }
+            finally { System.Buffers.ArrayPool<float>.Shared.Return(hostBuf); }
         }
 
         #endregion

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -32,6 +32,14 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
     /// </remarks>
     public sealed class OpenClBackend : IAsyncGpuBackend
     {
+        /// <summary>
+        /// Controls whether initialization and diagnostic output is written to Console.
+        /// Set to false to suppress GPU diagnostics for rich terminal UI or batch processing.
+        /// Can also be controlled via AIDOTNET_GPU_VERBOSE environment variable ("false" to disable).
+        /// </summary>
+        public static bool DiagnosticOutput { get; set; } =
+            !string.Equals(Environment.GetEnvironmentVariable("AIDOTNET_GPU_VERBOSE"), "false", StringComparison.OrdinalIgnoreCase);
+
         private DirectOpenClContext? _context;
         private readonly Dictionary<string, DirectOpenClKernel> _kernelCache;
         private readonly List<DirectOpenClProgram> _programs;
@@ -121,9 +129,9 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
             try
             {
-                Console.WriteLine($"[OpenClBackend] Creating DirectOpenClContext for device {deviceIndex}...");
+                if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend] Creating DirectOpenClContext for device {deviceIndex}...");
                 _context = new DirectOpenClContext(deviceIndex);
-                Console.WriteLine($"[OpenClBackend] Context created: Device={_context.DeviceName}, Vendor={_context.DeviceVendor}");
+                if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend] Context created: Device={_context.DeviceName}, Vendor={_context.DeviceVendor}");
 
                 IsAvailable = true;
                 DeviceName = _context.DeviceName;
@@ -134,7 +142,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 string? envCUs = Environment.GetEnvironmentVariable("AIDOTNET_GPU_COMPUTE_UNITS");
                 if (int.TryParse(envCUs, out int overrideCUs) && overrideCUs > 0 && overrideCUs <= 256)
                 {
-                    Console.WriteLine($"[OpenClBackend] CU override: {detectedCUs} -> {overrideCUs} (via AIDOTNET_GPU_COMPUTE_UNITS)");
+                    if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend] CU override: {detectedCUs} -> {overrideCUs} (via AIDOTNET_GPU_COMPUTE_UNITS)");
                     ComputeUnits = overrideCUs;
                 }
                 else
@@ -153,35 +161,35 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 _supportsSubgroups = _context.SupportsSubgroups;
 
                 // Print GPU capabilities for diagnostics
-                Console.WriteLine($"[OpenClBackend] GPU Capabilities:");
-                Console.WriteLine($"[OpenClBackend]   Compute Units: {ComputeUnits}");
-                Console.WriteLine($"[OpenClBackend]   Max Work Group Size: {_maxWorkGroupSize}");
+                if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend] GPU Capabilities:");
+                if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend]   Compute Units: {ComputeUnits}");
+                if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend]   Max Work Group Size: {_maxWorkGroupSize}");
                 if (_maxWorkItemSizes.Length >= 2)
                 {
-                    Console.WriteLine($"[OpenClBackend]   Max Work Item Sizes: [{string.Join(", ", _maxWorkItemSizes)}]");
+                    if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend]   Max Work Item Sizes: [{string.Join(", ", _maxWorkItemSizes)}]");
                 }
-                Console.WriteLine($"[OpenClBackend]   Local Memory: {LocalMemoryBytes / 1024} KB");
-                Console.WriteLine($"[OpenClBackend]   Supports FP16: {_supportsFp16}");
-                Console.WriteLine($"[OpenClBackend]   Supports Subgroups: {_supportsSubgroups}");
+                if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend]   Local Memory: {LocalMemoryBytes / 1024} KB");
+                if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend]   Supports FP16: {_supportsFp16}");
+                if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend]   Supports Subgroups: {_supportsSubgroups}");
 
                 // Initialize default stream wrapper
                 _defaultStream = new OpenClCommandQueue(this, _context.CommandQueue, _context.Context, _context.Device,
                     GpuStreamType.Default, _context.IsProfilingEnabled, ownsHandle: false);
-                Console.WriteLine("[OpenClBackend] Default command queue wrapper initialized.");
+                if (DiagnosticOutput) Console.WriteLine("[OpenClBackend] Default command queue wrapper initialized.");
 
-                Console.WriteLine("[OpenClBackend] Compiling kernels...");
+                if (DiagnosticOutput) Console.WriteLine("[OpenClBackend] Compiling kernels...");
                 CompileKernels();
-                Console.WriteLine($"[OpenClBackend] Kernels compiled successfully. Total: {_kernelCache.Count}");
+                if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend] Kernels compiled successfully. Total: {_kernelCache.Count}");
 
                 // Initialize dynamic kernel generator for Bayesian-optimized GEMM
                 _dynamicGemm = new DynamicGemmKernel(_context);
-                Console.WriteLine("[OpenClBackend] Dynamic GEMM kernel generator initialized.");
+                if (DiagnosticOutput) Console.WriteLine("[OpenClBackend] Dynamic GEMM kernel generator initialized.");
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[OpenClBackend] Initialization FAILED: {ex.GetType().Name}: {ex.Message}");
+                if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend] Initialization FAILED: {ex.GetType().Name}: {ex.Message}");
                 if (ex.InnerException != null)
-                    Console.WriteLine($"[OpenClBackend] Inner: {ex.InnerException.Message}");
+                    if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend] Inner: {ex.InnerException.Message}");
                 System.Diagnostics.Debug.WriteLine($"OpenClBackend initialization failed: {ex.Message}");
                 IsAvailable = false;
                 DeviceName = "None";
@@ -199,7 +207,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             var cached = DirectOpenClProgram.TryCreateFromCache(_context, source, buildOptions);
             if (cached != null)
             {
-                Console.WriteLine($"[OpenClBackend] {label}: loaded from cache");
+                if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend] {label}: loaded from cache");
                 return cached;
             }
 
@@ -208,7 +216,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             try
             {
                 program.Build(buildOptions);
-                Console.WriteLine($"[OpenClBackend] {label}: compiled from source");
+                if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend] {label}: compiled from source");
                 return program;
             }
             catch
@@ -233,14 +241,14 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             try
             {
                 // Compile GEMM kernels with aggressive optimizations
-                Console.WriteLine("[OpenClBackend] Compiling GEMM kernels...");
+                if (DiagnosticOutput) Console.WriteLine("[OpenClBackend] Compiling GEMM kernels...");
                 var gemmProgram = CompileOrLoadCached(GemmKernel.GetSource(), optimizationFlags, "GEMM kernels");
                 _programs.Add(gemmProgram);
                 foreach (var name in GemmKernel.GetKernelNames())
                 {
                     _kernelCache[name] = new DirectOpenClKernel(_context, gemmProgram, name);
                 }
-                Console.WriteLine($"[OpenClBackend] GEMM kernels: {string.Join(", ", GemmKernel.GetKernelNames())}");
+                if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend] GEMM kernels: {string.Join(", ", GemmKernel.GetKernelNames())}");
 
                 // Compile activation kernels
                 var activationProgram = CompileOrLoadCached(ActivationKernels.GetSource(), optimizationFlags, "Activation kernels");
@@ -359,19 +367,19 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                         _kernelCache["mixed_precision_backward"] = new DirectOpenClKernel(_context, mpProgram, "mixed_precision_backward");
                         _kernelCache["accumulate_gradient_fp32"] = new DirectOpenClKernel(_context, mpProgram, "accumulate_gradient_fp32");
                         _mixedPrecisionKernelsAvailable = true;
-                        Console.WriteLine("[OpenClBackend] Mixed precision kernels compiled: 5 kernels");
+                        if (DiagnosticOutput) Console.WriteLine("[OpenClBackend] Mixed precision kernels compiled: 5 kernels");
                     }
                     catch (Exception ex)
                     {
                         // Mixed precision compilation failed - this is non-fatal
                         // Device may report FP16 support but have driver issues with these kernels
-                        Console.WriteLine($"[OpenClBackend] Warning: Mixed precision kernel compilation failed (non-fatal): {ex.Message}");
-                        Console.WriteLine("[OpenClBackend] Continuing without mixed precision support.");
+                        if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend] Warning: Mixed precision kernel compilation failed (non-fatal): {ex.Message}");
+                        if (DiagnosticOutput) Console.WriteLine("[OpenClBackend] Continuing without mixed precision support.");
                     }
                 }
                 else
                 {
-                    Console.WriteLine("[OpenClBackend] Skipping mixed precision kernels (FP16 not supported on this device).");
+                    if (DiagnosticOutput) Console.WriteLine("[OpenClBackend] Skipping mixed precision kernels (FP16 not supported on this device).");
                 }
 
                 // Compile attention kernels (FlashAttention, GQA, ScaledDotProduct)
@@ -397,7 +405,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 {
                     _kernelCache[name] = new DirectOpenClKernel(_context, stProgram, name);
                 }
-                Console.WriteLine("[OpenClBackend] Spatial transformer kernels compiled: 4 kernels");
+                if (DiagnosticOutput) Console.WriteLine("[OpenClBackend] Spatial transformer kernels compiled: 4 kernels");
 
                 // Compile locally connected convolution kernels
                 var locallyConnectedProgram = CompileOrLoadCached(LocallyConnectedKernels.GetSource(), optimizationFlags, "Locally connected kernels");
@@ -792,12 +800,12 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 {
                     var previous = Console.ForegroundColor;
                     Console.ForegroundColor = color.Value;
-                    Console.WriteLine(message);
+                    if (DiagnosticOutput) Console.WriteLine(message);
                     Console.ForegroundColor = previous;
                 }
                 else
                 {
-                    Console.WriteLine(message);
+                    if (DiagnosticOutput) Console.WriteLine(message);
                 }
             }
 
@@ -944,7 +952,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
                     if (EnableTuningDiagnostics)
                     {
-                        Console.WriteLine($"[GEMM] Cached config invalid: {validationError}");
+                        if (DiagnosticOutput) Console.WriteLine($"[GEMM] Cached config invalid: {validationError}");
                     }
                 }
 
@@ -1009,7 +1017,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             {
                 if (EnableTuningDiagnostics)
                 {
-                    Console.WriteLine($"[GEMM] Tuning lookup failed: {ex.Message}");
+                    if (DiagnosticOutput) Console.WriteLine($"[GEMM] Tuning lookup failed: {ex.Message}");
                 }
 
                 return false;
@@ -1043,7 +1051,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 _clblastTransposeParams = ClBlastTransposeDatabase.GetParameters(deviceInfo);
                 _clblastDirectParams = ClBlastXgemmDirectDatabase.GetParameters(deviceInfo);
                 _clblastMinIndirectSize = ClBlastGemmRoutineDatabase.GetXgemmMinIndirectSize(deviceInfo);
-                Console.WriteLine($"[OpenClBackend] CLBlast MinIndirectSize threshold: {_clblastMinIndirectSize} (use INDIRECT for M/N >= {_clblastMinIndirectSize})");
+                if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend] CLBlast MinIndirectSize threshold: {_clblastMinIndirectSize} (use INDIRECT for M/N >= {_clblastMinIndirectSize})");
 
                 if (ClBlastXgemmDatabase.TryGetConfig(deviceInfo, out var baseline))
                 {
@@ -1403,19 +1411,19 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             if (!useIndirectPath || forceDirect)
             {
                 if (traceEnabled)
-                    Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] Trying DIRECT path (M/N < {_clblastMinIndirectSize} or forceDirect={forceDirect})");
+                    if (DiagnosticOutput) Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] Trying DIRECT path (M/N < {_clblastMinIndirectSize} or forceDirect={forceDirect})");
                 if (TryExecuteClBlastDirectGemm(A, B, C, M, N, K, alpha, beta))
                 {
                     if (traceEnabled)
-                        Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] SUCCESS: DIRECT path executed");
+                        if (DiagnosticOutput) Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] SUCCESS: DIRECT path executed");
                     return true;
                 }
                 if (traceEnabled)
-                    Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] DIRECT path failed, trying INDIRECT");
+                    if (DiagnosticOutput) Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] DIRECT path failed, trying INDIRECT");
             }
             else if (traceEnabled)
             {
-                Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] Skipping DIRECT path (M/N >= {_clblastMinIndirectSize}), using INDIRECT");
+                if (DiagnosticOutput) Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] Skipping DIRECT path (M/N >= {_clblastMinIndirectSize}), using INDIRECT");
             }
 
             if (_dynamicGemm == null)
@@ -1557,7 +1565,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                         var total = allocTime + packATime + packBTime + packCTime + gemmTime + unpackCTime;
                         double flops = 2.0 * M * N * K;
                         double gflops = flops / (total / ticksPerMs) / 1e6;
-                        Console.WriteLine($"[TIMING-SWAP {M}x{N}x{K}] Alloc={allocTime / ticksPerMs:F2}ms PackA={packATime / ticksPerMs:F2}ms PackB={packBTime / ticksPerMs:F2}ms GEMM={gemmTime / ticksPerMs:F2}ms UnpackC={unpackCTime / ticksPerMs:F2}ms Total={total / ticksPerMs:F2}ms ({gflops:F0} GFLOPS)");
+                        if (DiagnosticOutput) Console.WriteLine($"[TIMING-SWAP {M}x{N}x{K}] Alloc={allocTime / ticksPerMs:F2}ms PackA={packATime / ticksPerMs:F2}ms PackB={packBTime / ticksPerMs:F2}ms GEMM={gemmTime / ticksPerMs:F2}ms UnpackC={unpackCTime / ticksPerMs:F2}ms Total={total / ticksPerMs:F2}ms ({gflops:F0} GFLOPS)");
                     }
 
                     return true;
@@ -1658,7 +1666,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                     {
                         double ticksPerMs = System.Diagnostics.Stopwatch.Frequency / 1000.0;
                         var total = allocTime + packATime + packBTime + packCTime + gemmTime + unpackCTime;
-                        Console.WriteLine($"[TIMING {M}x{N}x{K}] Alloc={allocTime / ticksPerMs:F2}ms PackA={packATime / ticksPerMs:F2}ms PackB={packBTime / ticksPerMs:F2}ms GEMM={gemmTime / ticksPerMs:F2}ms UnpackC={unpackCTime / ticksPerMs:F2}ms Total={total / ticksPerMs:F2}ms");
+                        if (DiagnosticOutput) Console.WriteLine($"[TIMING {M}x{N}x{K}] Alloc={allocTime / ticksPerMs:F2}ms PackA={packATime / ticksPerMs:F2}ms PackB={packBTime / ticksPerMs:F2}ms GEMM={gemmTime / ticksPerMs:F2}ms UnpackC={unpackCTime / ticksPerMs:F2}ms Total={total / ticksPerMs:F2}ms");
                     }
 
                     return true;
@@ -1761,7 +1769,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
             if (EnableTuningDiagnostics)
             {
-                Console.WriteLine($"[GEMM] Packed GEMM: {M}x{N}x{K} -> {mPad}x{nPad}x{kPad}");
+                if (DiagnosticOutput) Console.WriteLine($"[GEMM] Packed GEMM: {M}x{N}x{K} -> {mPad}x{nPad}x{kPad}");
             }
 
             using var aPad = AllocateBuffer(mPad * kPad);
@@ -1825,7 +1833,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             {
                 if (EnableTuningDiagnostics)
                 {
-                    Console.WriteLine($"[GEMM] Dynamic config invalid: {validationError}");
+                    if (DiagnosticOutput) Console.WriteLine($"[GEMM] Dynamic config invalid: {validationError}");
                 }
                 return false;
             }
@@ -1841,7 +1849,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             {
                 if (EnableTuningDiagnostics)
                 {
-                    Console.WriteLine($"[GEMM] Dynamic kernel failed ({config.KernelName}): {ex.Message}");
+                    if (DiagnosticOutput) Console.WriteLine($"[GEMM] Dynamic kernel failed ({config.KernelName}): {ex.Message}");
                 }
                 return false;
             }
@@ -1864,61 +1872,61 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             if (ClBlastNative.IsAvailable && ShouldUseVendorGemm(M, N, K, offlineEnabled))
             {
                 if (traceEnabled)
-                    Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] Trying CLBlast library");
+                    if (DiagnosticOutput) Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] Trying CLBlast library");
 
                 if (TryExecuteClBlastLibraryGemm(A, B, C, M, N, K, alpha, beta))
                 {
                     if (traceEnabled)
-                        Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] SUCCESS: CLBlast library executed");
+                        if (DiagnosticOutput) Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] SUCCESS: CLBlast library executed");
                     return;
                 }
 
                 if (traceEnabled)
-                    Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] FALLBACK: CLBlast library FAILED");
+                    if (DiagnosticOutput) Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] FALLBACK: CLBlast library FAILED");
             }
             else if (traceEnabled && !ClBlastNative.IsAvailable)
             {
-                Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] SKIP: CLBlast library not available");
+                if (DiagnosticOutput) Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] SKIP: CLBlast library not available");
             }
 
             if (!offlineEnabled && TryGetClBlastBaselineConfig(out var baselineConfig))
             {
                 if (traceEnabled)
-                    Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] Trying CLBlast baseline (TileM={baselineConfig.TileM}, TileN={baselineConfig.TileN}, TileK={baselineConfig.TileK})");
+                    if (DiagnosticOutput) Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] Trying CLBlast baseline (TileM={baselineConfig.TileM}, TileN={baselineConfig.TileN}, TileK={baselineConfig.TileK})");
 
                 if (TryExecuteClBlastBaselineGemm(A, B, C, M, N, K, alpha, beta, baselineConfig))
                 {
                     if (traceEnabled)
-                        Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] SUCCESS: CLBlast baseline executed");
+                        if (DiagnosticOutput) Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] SUCCESS: CLBlast baseline executed");
                     return;
                 }
                 if (traceEnabled)
-                    Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] FALLBACK: CLBlast baseline FAILED");
+                    if (DiagnosticOutput) Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] FALLBACK: CLBlast baseline FAILED");
             }
             else
             {
                 if (traceEnabled)
-                    Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] SKIP: CLBlast baseline not available (offline={offlineEnabled})");
+                    if (DiagnosticOutput) Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] SKIP: CLBlast baseline not available (offline={offlineEnabled})");
             }
 
             if (_dynamicGemm != null && M >= 128 && N >= 128 && K >= 64 &&
                 TryGetTunedConfig(M, N, K, out var tunedConfig))
             {
                 if (traceEnabled)
-                    Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] Trying dynamic GEMM");
+                    if (DiagnosticOutput) Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] Trying dynamic GEMM");
                 if (TryExecutePackedDynamicGemm(A, B, C, M, N, K, alpha, beta, tunedConfig))
                 {
                     if (traceEnabled)
-                        Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] SUCCESS: Dynamic GEMM executed");
+                        if (DiagnosticOutput) Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] SUCCESS: Dynamic GEMM executed");
                     return;
                 }
                 if (traceEnabled)
-                    Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] FALLBACK: Dynamic GEMM FAILED");
+                    if (DiagnosticOutput) Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] FALLBACK: Dynamic GEMM FAILED");
             }
 
             // FALLBACK: Using our own kernels (NOT CLBlast identical!)
             if (traceEnabled)
-                Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] FALLBACK: Using built-in kernel (NOT CLBlast!)");
+                if (DiagnosticOutput) Console.WriteLine($"[GEMM-TRACE {M}x{N}x{K}] FALLBACK: Using built-in kernel (NOT CLBlast!)");
 
             // Choose kernel based on matrix size
             // Use optimized kernel for matrices >= 128 in any dimension
@@ -1973,7 +1981,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
         public IGpuBuffer MatMul(IGpuBuffer A, IGpuBuffer B, int M, int N, int K)
         {
-            Console.WriteLine($"[OpenClBackend.MatMul] Called: {M}x{N}x{K}");
+            if (DiagnosticOutput) Console.WriteLine($"[OpenClBackend.MatMul] Called: {M}x{N}x{K}");
             var C = AllocateBuffer(M * N);
             Gemm(A, B, C, M, N, K, 1.0f, 0.0f);
             // Sync only when returning buffer that might be immediately read
@@ -4095,65 +4103,65 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             {
                 if (Console.IsOutputRedirected)
                 {
-                    Console.WriteLine(message);
+                    if (DiagnosticOutput) Console.WriteLine(message);
                     return;
                 }
 
                 var previous = Console.ForegroundColor;
                 Console.ForegroundColor = color;
-                Console.WriteLine(message);
+                if (DiagnosticOutput) Console.WriteLine(message);
                 Console.ForegroundColor = previous;
             }
 
-            Console.WriteLine();
-            Console.WriteLine("=== OpenCL GEMM Diagnostics ===");
-            Console.WriteLine($"Matrix dimensions: M={diagnostics.M}, N={diagnostics.N}, K={diagnostics.K}");
-            Console.WriteLine($"Kernel: {diagnostics.KernelName}");
-            Console.WriteLine($"Work configuration: Global({diagnostics.GlobalSizeX}x{diagnostics.GlobalSizeY}), Local({diagnostics.LocalSizeX}x{diagnostics.LocalSizeY})");
-            Console.WriteLine($"Work items launched: {diagnostics.WorkItemsLaunched:N0}");
-            Console.WriteLine($"Work groups launched: {diagnostics.WorkGroupsLaunched:N0}");
-            Console.WriteLine();
+            if (DiagnosticOutput) Console.WriteLine();
+            if (DiagnosticOutput) Console.WriteLine("=== OpenCL GEMM Diagnostics ===");
+            if (DiagnosticOutput) Console.WriteLine($"Matrix dimensions: M={diagnostics.M}, N={diagnostics.N}, K={diagnostics.K}");
+            if (DiagnosticOutput) Console.WriteLine($"Kernel: {diagnostics.KernelName}");
+            if (DiagnosticOutput) Console.WriteLine($"Work configuration: Global({diagnostics.GlobalSizeX}x{diagnostics.GlobalSizeY}), Local({diagnostics.LocalSizeX}x{diagnostics.LocalSizeY})");
+            if (DiagnosticOutput) Console.WriteLine($"Work items launched: {diagnostics.WorkItemsLaunched:N0}");
+            if (DiagnosticOutput) Console.WriteLine($"Work groups launched: {diagnostics.WorkGroupsLaunched:N0}");
+            if (DiagnosticOutput) Console.WriteLine();
 
             if (diagnostics.IsProfilingAvailable && diagnostics.KernelExecutionNs > 0)
             {
-                Console.WriteLine("--- GPU Timing (from OpenCL events) ---");
-                Console.WriteLine($"Queue to Submit: {diagnostics.QueueToSubmitNs / 1e6:F3} ms");
-                Console.WriteLine($"Submit to Start (launch overhead): {diagnostics.SubmitToStartNs / 1e6:F3} ms");
-                Console.WriteLine($"Kernel Execution: {diagnostics.KernelExecutionNs / 1e6:F3} ms");
-                Console.WriteLine($"Total GPU Time: {diagnostics.TotalGpuTimeNs / 1e6:F3} ms");
+                if (DiagnosticOutput) Console.WriteLine("--- GPU Timing (from OpenCL events) ---");
+                if (DiagnosticOutput) Console.WriteLine($"Queue to Submit: {diagnostics.QueueToSubmitNs / 1e6:F3} ms");
+                if (DiagnosticOutput) Console.WriteLine($"Submit to Start (launch overhead): {diagnostics.SubmitToStartNs / 1e6:F3} ms");
+                if (DiagnosticOutput) Console.WriteLine($"Kernel Execution: {diagnostics.KernelExecutionNs / 1e6:F3} ms");
+                if (DiagnosticOutput) Console.WriteLine($"Total GPU Time: {diagnostics.TotalGpuTimeNs / 1e6:F3} ms");
             }
             else if (!string.IsNullOrEmpty(diagnostics.ProfilingError))
             {
-                Console.WriteLine($"Profiling error: {diagnostics.ProfilingError}");
+                if (DiagnosticOutput) Console.WriteLine($"Profiling error: {diagnostics.ProfilingError}");
             }
 
-            Console.WriteLine($"Wall clock time: {diagnostics.WallClockMs:F3} ms");
-            Console.WriteLine();
+            if (DiagnosticOutput) Console.WriteLine($"Wall clock time: {diagnostics.WallClockMs:F3} ms");
+            if (DiagnosticOutput) Console.WriteLine();
 
-            Console.WriteLine("--- Performance Metrics ---");
-            Console.WriteLine($"FLOPS required: {diagnostics.FlopsRequired:N0} ({diagnostics.FlopsRequired / 1e9:F2} GFLOP)");
-            Console.WriteLine($"Bytes transferred: {diagnostics.BytesTransferred:N0} ({diagnostics.BytesTransferred / 1e6:F2} MB)");
-            Console.WriteLine($"Arithmetic intensity: {diagnostics.ArithmeticIntensity:F2} FLOP/byte");
-            Console.WriteLine($"Achieved GFLOPS: {diagnostics.AchievedGflops:F2}");
-            Console.WriteLine($"Achieved bandwidth: {diagnostics.AchievedBandwidthGBps:F2} GB/s");
-            Console.WriteLine($"Compute efficiency: {diagnostics.ComputeEfficiency:F1}% of theoretical peak");
-            Console.WriteLine();
+            if (DiagnosticOutput) Console.WriteLine("--- Performance Metrics ---");
+            if (DiagnosticOutput) Console.WriteLine($"FLOPS required: {diagnostics.FlopsRequired:N0} ({diagnostics.FlopsRequired / 1e9:F2} GFLOP)");
+            if (DiagnosticOutput) Console.WriteLine($"Bytes transferred: {diagnostics.BytesTransferred:N0} ({diagnostics.BytesTransferred / 1e6:F2} MB)");
+            if (DiagnosticOutput) Console.WriteLine($"Arithmetic intensity: {diagnostics.ArithmeticIntensity:F2} FLOP/byte");
+            if (DiagnosticOutput) Console.WriteLine($"Achieved GFLOPS: {diagnostics.AchievedGflops:F2}");
+            if (DiagnosticOutput) Console.WriteLine($"Achieved bandwidth: {diagnostics.AchievedBandwidthGBps:F2} GB/s");
+            if (DiagnosticOutput) Console.WriteLine($"Compute efficiency: {diagnostics.ComputeEfficiency:F1}% of theoretical peak");
+            if (DiagnosticOutput) Console.WriteLine();
 
-            Console.WriteLine("--- Bottleneck Analysis ---");
+            if (DiagnosticOutput) Console.WriteLine("--- Bottleneck Analysis ---");
             if (diagnostics.SubmitToStartNs > diagnostics.KernelExecutionNs * 0.5 && diagnostics.KernelExecutionNs > 0)
             {
                 WriteColored("WARNING: High launch overhead detected (>50% of kernel time)", ConsoleColor.Yellow);
-                Console.WriteLine("  -> Consider batching multiple small operations");
+                if (DiagnosticOutput) Console.WriteLine("  -> Consider batching multiple small operations");
             }
             if (diagnostics.IsLikelyMemoryBound)
             {
                 WriteColored("LIKELY MEMORY BOUND: Achieved GFLOPS limited by memory bandwidth", ConsoleColor.Yellow);
-                Console.WriteLine("  -> Consider using data tiling, caching, or reducing data movement");
+                if (DiagnosticOutput) Console.WriteLine("  -> Consider using data tiling, caching, or reducing data movement");
             }
             else if (diagnostics.ComputeEfficiency < 50)
             {
                 WriteColored("LIKELY COMPUTE BOUND with low efficiency:", ConsoleColor.Red);
-                Console.WriteLine("  -> Check for bank conflicts, divergent warps, or suboptimal work group size");
+                if (DiagnosticOutput) Console.WriteLine("  -> Check for bank conflicts, divergent warps, or suboptimal work group size");
             }
             else if (diagnostics.ComputeEfficiency < 80)
             {
@@ -4163,7 +4171,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             {
                 WriteColored("GOOD EFFICIENCY: Kernel is well-optimized", ConsoleColor.Green);
             }
-            Console.WriteLine();
+            if (DiagnosticOutput) Console.WriteLine();
         }
 
         /// <summary>
@@ -4173,27 +4181,27 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         {
             if (_context == null)
             {
-                Console.WriteLine("OpenCL context not available");
+                if (DiagnosticOutput) Console.WriteLine("OpenCL context not available");
                 return;
             }
 
             var deviceInfo = GetDeviceInfo();
-            Console.WriteLine("=== OpenCL GEMM Benchmark ===");
-            Console.WriteLine($"Device: {deviceInfo.DeviceName}");
-            Console.WriteLine($"Vendor: {deviceInfo.DeviceVendor}");
-            Console.WriteLine($"Compute Units: {deviceInfo.ComputeUnits}");
-            Console.WriteLine($"Clock: {deviceInfo.ClockFrequencyMHz} MHz");
-            Console.WriteLine($"Theoretical Peak: {deviceInfo.TheoreticalPeakGflops:F0} GFLOPS");
-            Console.WriteLine($"Profiling enabled: {IsProfilingEnabled}");
-            Console.WriteLine();
+            if (DiagnosticOutput) Console.WriteLine("=== OpenCL GEMM Benchmark ===");
+            if (DiagnosticOutput) Console.WriteLine($"Device: {deviceInfo.DeviceName}");
+            if (DiagnosticOutput) Console.WriteLine($"Vendor: {deviceInfo.DeviceVendor}");
+            if (DiagnosticOutput) Console.WriteLine($"Compute Units: {deviceInfo.ComputeUnits}");
+            if (DiagnosticOutput) Console.WriteLine($"Clock: {deviceInfo.ClockFrequencyMHz} MHz");
+            if (DiagnosticOutput) Console.WriteLine($"Theoretical Peak: {deviceInfo.TheoreticalPeakGflops:F0} GFLOPS");
+            if (DiagnosticOutput) Console.WriteLine($"Profiling enabled: {IsProfilingEnabled}");
+            if (DiagnosticOutput) Console.WriteLine();
 
             int sizeIndex = 0;
             foreach (int size in sizes)
             {
                 sizeIndex++;
                 int M = size, N = size, K = size;
-                Console.WriteLine($"[Progress] {sizeIndex}/{sizes.Length} size {size}x{size}x{size}");
-                Console.WriteLine($"--- Matrix size: {size}x{size}x{size} ---");
+                if (DiagnosticOutput) Console.WriteLine($"[Progress] {sizeIndex}/{sizes.Length} size {size}x{size}x{size}");
+                if (DiagnosticOutput) Console.WriteLine($"--- Matrix size: {size}x{size}x{size} ---");
 
                 // Allocate buffers
                 var dataA = new float[M * K];
@@ -4246,16 +4254,16 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 avgBandwidth /= benchmarkIterations;
                 avgLaunchOverhead /= benchmarkIterations;
 
-                Console.WriteLine($"  Kernel: {allDiagnostics[0].KernelName}");
-                Console.WriteLine($"  Avg kernel time: {avgKernelTimeMs:F3} ms");
+                if (DiagnosticOutput) Console.WriteLine($"  Kernel: {allDiagnostics[0].KernelName}");
+                if (DiagnosticOutput) Console.WriteLine($"  Avg kernel time: {avgKernelTimeMs:F3} ms");
                 if (avgLaunchOverhead > 0)
                 {
-                    Console.WriteLine($"  Avg launch overhead: {avgLaunchOverhead:F3} ms");
+                    if (DiagnosticOutput) Console.WriteLine($"  Avg launch overhead: {avgLaunchOverhead:F3} ms");
                 }
-                Console.WriteLine($"  Avg GFLOPS: {avgGflops:F2}");
-                Console.WriteLine($"  Avg bandwidth: {avgBandwidth:F2} GB/s");
-                Console.WriteLine($"  Efficiency: {avgGflops / deviceInfo.TheoreticalPeakGflops * 100:F1}%");
-                Console.WriteLine();
+                if (DiagnosticOutput) Console.WriteLine($"  Avg GFLOPS: {avgGflops:F2}");
+                if (DiagnosticOutput) Console.WriteLine($"  Avg bandwidth: {avgBandwidth:F2} GB/s");
+                if (DiagnosticOutput) Console.WriteLine($"  Efficiency: {avgGflops / deviceInfo.TheoreticalPeakGflops * 100:F1}%");
+                if (DiagnosticOutput) Console.WriteLine();
             }
         }
 
@@ -4303,13 +4311,13 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             var capabilities = GpuCapabilities.Detect(ComputeUnits, GlobalMemoryBytes, (int)LocalMemoryBytes,
                 (int)_maxWorkGroupSize, DeviceVendor, DeviceName, _context.Extensions);
 
-            Console.WriteLine("=== Bayesian GEMM Optimization ===");
-            Console.WriteLine($"Matrix: {M}x{N}x{K}, Device: {DeviceName}, Max trials: {maxTrials}");
+            if (DiagnosticOutput) Console.WriteLine("=== Bayesian GEMM Optimization ===");
+            if (DiagnosticOutput) Console.WriteLine($"Matrix: {M}x{N}x{K}, Device: {DeviceName}, Max trials: {maxTrials}");
 
             // Print GPU capabilities if diagnostics enabled
             if (EnableTuningDiagnostics)
             {
-                Console.WriteLine("[GPU Capabilities]");
+                if (DiagnosticOutput) Console.WriteLine("[GPU Capabilities]");
                 Console.Write(capabilities.GetDiagnosticString());
             }
 
@@ -4350,7 +4358,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                     benchmarkFailures++;
                     if (EnableTuningDiagnostics)
                     {
-                        Console.WriteLine($"  [Validation] {config.KernelName}: {validationError}");
+                        if (DiagnosticOutput) Console.WriteLine($"  [Validation] {config.KernelName}: {validationError}");
                     }
                     database.MarkAsTested(M, N, K, config, 0);
                     return double.NaN;
@@ -4363,7 +4371,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                     {
                         if (EnableTuningDiagnostics)
                         {
-                            Console.WriteLine($"  [Cache] {config.KernelName}: {cachedGflops.Value:F2} GFLOPS");
+                            if (DiagnosticOutput) Console.WriteLine($"  [Cache] {config.KernelName}: {cachedGflops.Value:F2} GFLOPS");
                         }
 
                         return ops / (cachedGflops.Value * 1e6);
@@ -4397,12 +4405,12 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 catch (Exception ex)
                 {
                     benchmarkFailures++;
-                    Console.WriteLine($"  Config {config} failed: {ex.Message}");
+                    if (DiagnosticOutput) Console.WriteLine($"  Config {config} failed: {ex.Message}");
 
                     // Print kernel stats on failure
                     if (EnableTuningDiagnostics && _dynamicGemm != null)
                     {
-                        Console.WriteLine($"  [DynamicGemm Stats] {_dynamicGemm.GetDiagnosticStats()}");
+                        if (DiagnosticOutput) Console.WriteLine($"  [DynamicGemm Stats] {_dynamicGemm.GetDiagnosticStats()}");
                     }
 
                     database.MarkAsTested(M, N, K, config, 0);
@@ -4422,8 +4430,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             {
                 var cachedConfig = cachedEntry.Value.Config;
                 databaseGflops = cachedEntry.Value.GFlops;  // Use stored GFLOPS as baseline
-                Console.WriteLine($"Using cached configuration: {cachedConfig}");
-                Console.WriteLine($"Database best: {databaseGflops:F2} GFLOPS (threshold to beat)");
+                if (DiagnosticOutput) Console.WriteLine($"Using cached configuration: {cachedConfig}");
+                if (DiagnosticOutput) Console.WriteLine($"Database best: {databaseGflops:F2} GFLOPS (threshold to beat)");
 
                 // Re-benchmark to validate config works and add to result set
                 var cachedTimeMs = BenchmarkConfigNoCache(cachedConfig);
@@ -4437,7 +4445,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                         GFlops = revalidatedGflops,
                         IsValid = true
                     };
-                    Console.WriteLine($"Revalidated: {revalidatedGflops:F2} GFLOPS");
+                    if (DiagnosticOutput) Console.WriteLine($"Revalidated: {revalidatedGflops:F2} GFLOPS");
                 }
             }
 
@@ -4448,10 +4456,10 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             // Print final statistics
             if (EnableTuningDiagnostics)
             {
-                Console.WriteLine($"\n[Benchmark Stats] Attempts: {benchmarkAttempts}, Failures: {benchmarkFailures}");
+                if (DiagnosticOutput) Console.WriteLine($"\n[Benchmark Stats] Attempts: {benchmarkAttempts}, Failures: {benchmarkFailures}");
                 if (_dynamicGemm != null)
                 {
-                    Console.WriteLine($"[DynamicGemm Stats] {_dynamicGemm.GetDiagnosticStats()}");
+                    if (DiagnosticOutput) Console.WriteLine($"[DynamicGemm Stats] {_dynamicGemm.GetDiagnosticStats()}");
                 }
             }
 
@@ -4468,18 +4476,18 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             if (allResults.Count > 0 && allResults[0].IsValid)
             {
                 var best = allResults[0];
-                Console.WriteLine($"Best: {best.Config} - {best.GFlops:F2} GFLOPS");
+                if (DiagnosticOutput) Console.WriteLine($"Best: {best.Config} - {best.GFlops:F2} GFLOPS");
 
                 // Only update database if we found something better than the DATABASE best
                 // Note: We compare against databaseGflops (historical best), NOT re-benchmarked value
                 if (best.GFlops > databaseGflops)
                 {
-                    Console.WriteLine($"NEW GLOBAL BEST! {best.GFlops:F2} > {databaseGflops:F2} GFLOPS (previous best)");
+                    if (DiagnosticOutput) Console.WriteLine($"NEW GLOBAL BEST! {best.GFlops:F2} > {databaseGflops:F2} GFLOPS (previous best)");
                     database.StoreResult(M, N, K, best.Config, best.GFlops);
                 }
                 else
                 {
-                    Console.WriteLine($"No improvement: {best.GFlops:F2} <= {databaseGflops:F2} GFLOPS (database best)");
+                    if (DiagnosticOutput) Console.WriteLine($"No improvement: {best.GFlops:F2} <= {databaseGflops:F2} GFLOPS (database best)");
                 }
             }
 
@@ -4500,8 +4508,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             var capabilities = GpuCapabilities.Detect(ComputeUnits, GlobalMemoryBytes, (int)LocalMemoryBytes,
                 (int)_maxWorkGroupSize, DeviceVendor, DeviceName, _context.Extensions);
 
-            Console.WriteLine("=== EXHAUSTIVE GEMM Optimization (CLBlast-style) ===");
-            Console.WriteLine($"Matrix: {M}x{N}x{K}, Device: {DeviceName}");
+            if (DiagnosticOutput) Console.WriteLine("=== EXHAUSTIVE GEMM Optimization (CLBlast-style) ===");
+            if (DiagnosticOutput) Console.WriteLine($"Matrix: {M}x{N}x{K}, Device: {DeviceName}");
 
             var dataA = new float[M * K];
             var dataB = new float[K * N];
@@ -4534,7 +4542,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 {
                     if (EnableTuningDiagnostics)
                     {
-                        Console.WriteLine($"  [Validation] {config.KernelName}: {validationError}");
+                        if (DiagnosticOutput) Console.WriteLine($"  [Validation] {config.KernelName}: {validationError}");
                     }
                     database.MarkAsTested(M, N, K, config, 0);
                     return double.NaN;
@@ -4547,7 +4555,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                     {
                         if (EnableTuningDiagnostics)
                         {
-                            Console.WriteLine($"  [Cache] {config.KernelName}: {cachedGflops.Value:F2} GFLOPS");
+                            if (DiagnosticOutput) Console.WriteLine($"  [Cache] {config.KernelName}: {cachedGflops.Value:F2} GFLOPS");
                         }
 
                         return ops / (cachedGflops.Value * 1e6);
@@ -4578,7 +4586,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"  Config {config} failed: {ex.Message}");
+                    if (DiagnosticOutput) Console.WriteLine($"  Config {config} failed: {ex.Message}");
                     database.MarkAsTested(M, N, K, config, 0);
                     return double.NaN;
                 }
@@ -4592,7 +4600,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             if (results.Length > 0 && results[0].IsValid)
             {
                 var best = results[0];
-                Console.WriteLine($"EXHAUSTIVE Best: {best.Config} - {best.GFlops:F2} GFLOPS");
+                if (DiagnosticOutput) Console.WriteLine($"EXHAUSTIVE Best: {best.Config} - {best.GFlops:F2} GFLOPS");
 
                 database.StoreResult(M, N, K, best.Config, best.GFlops);
             }
@@ -4632,7 +4640,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             {
                 if (EnableTuningDiagnostics)
                 {
-                    Console.WriteLine($"CLBlast SGEMM failed with status: {status}");
+                    if (DiagnosticOutput) Console.WriteLine($"CLBlast SGEMM failed with status: {status}");
                 }
                 return false;
             }
@@ -4894,7 +4902,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             // Auto-print if profiling is enabled
             if (GetEnvBool(GemmProfileEnvVar))
             {
-                Console.WriteLine(result);
+                if (DiagnosticOutput) Console.WriteLine(result);
             }
 
             return result;
@@ -4998,7 +5006,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         /// </summary>
         public static void PrintDiagnosticHelp()
         {
-            Console.WriteLine(@"
+            if (DiagnosticOutput) Console.WriteLine(@"
 === AiDotNet GPU Diagnostic Environment Variables ===
 
 TIMING & TRACING:

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend.cs
@@ -1168,5 +1168,19 @@ void main() {
         UploadToBuffer(data, output);
     }
 
+    public void GenerateSecureRandomUniform(IGpuBuffer output, int size, float min, float max)
+    {
+        EnsureInitialized();
+        var hostBuf = System.Buffers.ArrayPool<float>.Shared.Rent(size);
+        try
+        {
+            Helpers.SimdRandom.SecureFillFloats(hostBuf.AsSpan(0, size));
+            float range = max - min;
+            for (int i = 0; i < size; i++) hostBuf[i] = hostBuf[i] * range + min;
+            UploadToBuffer(hostBuf.AsSpan(0, size).ToArray(), output);
+        }
+        finally { System.Buffers.ArrayPool<float>.Shared.Return(hostBuf); }
+    }
+
     #endregion
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend.cs
@@ -1171,15 +1171,13 @@ void main() {
     public void GenerateSecureRandomUniform(IGpuBuffer output, int size, float min, float max)
     {
         EnsureInitialized();
-        var hostBuf = System.Buffers.ArrayPool<float>.Shared.Rent(size);
-        try
-        {
-            Helpers.SimdRandom.SecureFillFloats(hostBuf.AsSpan(0, size));
-            float range = max - min;
-            for (int i = 0; i < size; i++) hostBuf[i] = hostBuf[i] * range + min;
-            UploadToBuffer(hostBuf.AsSpan(0, size).ToArray(), output);
-        }
-        finally { System.Buffers.ArrayPool<float>.Shared.Return(hostBuf); }
+        if (size <= 0) return;
+        var data = new float[size];
+        Helpers.SimdRandom.SecureFillFloats(data.AsSpan());
+        float range = max - min;
+        for (int i = 0; i < size; i++) data[i] = data[i] * range + min;
+        UploadToBuffer(data, output);
+        Array.Clear(data, 0, size);
     }
 
     #endregion

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend.cs
@@ -1173,11 +1173,14 @@ void main() {
         EnsureInitialized();
         if (size <= 0) return;
         var data = new float[size];
-        Helpers.SimdRandom.SecureFillFloats(data.AsSpan());
-        float range = max - min;
-        for (int i = 0; i < size; i++) data[i] = data[i] * range + min;
-        UploadToBuffer(data, output);
-        Array.Clear(data, 0, size);
+        try
+        {
+            Helpers.SimdRandom.SecureFillFloats(data.AsSpan());
+            float range = max - min;
+            for (int i = 0; i < size; i++) data[i] = data[i] * range + min;
+            UploadToBuffer(data, output);
+        }
+        finally { Array.Clear(data, 0, size); }
     }
 
     #endregion

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend.cs
@@ -836,17 +836,13 @@ public sealed partial class WebGpuBackend
 
     public void GenerateSecureRandomUniform(IGpuBuffer output, int size, float min, float max)
     {
-        var hostBuf = System.Buffers.ArrayPool<float>.Shared.Rent(size);
-        try
-        {
-            Helpers.SimdRandom.SecureFillFloats(hostBuf.AsSpan(0, size));
-            float range = max - min;
-            for (int i = 0; i < size; i++) hostBuf[i] = hostBuf[i] * range + min;
-            var temp = AllocateBuffer(hostBuf.AsSpan(0, size).ToArray());
-            try { Copy(temp, 0, output, 0, size); }
-            finally { temp.Dispose(); }
-        }
-        finally { System.Buffers.ArrayPool<float>.Shared.Return(hostBuf); }
+        if (size <= 0) return;
+        var data = new float[size];
+        Helpers.SimdRandom.SecureFillFloats(data.AsSpan());
+        float range = max - min;
+        for (int i = 0; i < size; i++) data[i] = data[i] * range + min;
+        UploadToBuffer(data, output);
+        Array.Clear(data, 0, size);
     }
 
     #endregion

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend.cs
@@ -834,6 +834,21 @@ public sealed partial class WebGpuBackend
             output, uniforms, size).GetAwaiter().GetResult();
     }
 
+    public void GenerateSecureRandomUniform(IGpuBuffer output, int size, float min, float max)
+    {
+        var hostBuf = System.Buffers.ArrayPool<float>.Shared.Rent(size);
+        try
+        {
+            Helpers.SimdRandom.SecureFillFloats(hostBuf.AsSpan(0, size));
+            float range = max - min;
+            for (int i = 0; i < size; i++) hostBuf[i] = hostBuf[i] * range + min;
+            var temp = AllocateBuffer(hostBuf.AsSpan(0, size).ToArray());
+            try { Copy(temp, 0, output, 0, size); }
+            finally { temp.Dispose(); }
+        }
+        finally { System.Buffers.ArrayPool<float>.Shared.Return(hostBuf); }
+    }
+
     #endregion
 }
 #endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend.cs
@@ -838,11 +838,14 @@ public sealed partial class WebGpuBackend
     {
         if (size <= 0) return;
         var data = new float[size];
-        Helpers.SimdRandom.SecureFillFloats(data.AsSpan());
-        float range = max - min;
-        for (int i = 0; i < size; i++) data[i] = data[i] * range + min;
-        UploadToBuffer(data, output);
-        Array.Clear(data, 0, size);
+        try
+        {
+            Helpers.SimdRandom.SecureFillFloats(data.AsSpan());
+            float range = max - min;
+            for (int i = 0; i < size; i++) data[i] = data[i] * range + min;
+            UploadToBuffer(data, output);
+        }
+        finally { Array.Clear(data, 0, size); }
     }
 
     #endregion

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -210,6 +210,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 {
     private readonly DirectGpuEngine? _directGpu;
     private readonly bool _ownsDirectGpu;
+    private static int _gpuRngSeed = Environment.TickCount;
 
     // GPU buffer cache for persistent tensors - keyed by tensor data array reference
     // Thread-safety: ConcurrentDictionary provides atomic operations. Invalidation uses
@@ -13950,7 +13951,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 int total = 1;
                 foreach (var d in shape) total *= d;
                 var go = b.AllocateBuffer(total);
-                b.GenerateRandomUniform(go, total, 0f, 1f, (ulong)Environment.TickCount);
+                b.GenerateRandomUniform(go, total, 0f, 1f, (ulong)System.Threading.Interlocked.Increment(ref _gpuRngSeed));
                 return DeferTensorResult<T>(b, go, total, shape);
             }
             catch { }
@@ -13967,7 +13968,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 int total = 1;
                 foreach (var d in shape) total *= d;
                 var go = b.AllocateBuffer(total);
-                b.GenerateRandomNormal(go, total, Convert.ToSingle(mean), Convert.ToSingle(stddev), (ulong)Environment.TickCount);
+                b.GenerateRandomNormal(go, total, Convert.ToSingle(mean), Convert.ToSingle(stddev), (ulong)System.Threading.Interlocked.Increment(ref _gpuRngSeed));
                 return DeferTensorResult<T>(b, go, total, shape);
             }
             catch { }

--- a/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
@@ -928,6 +928,10 @@ public class DelegatingGpuBackend : IDirectGpuBackend
     public virtual void GenerateRandomNormal(IGpuBuffer output, int size, float mean, float stdDev, ulong seed)
         => Inner.GenerateRandomNormal(output, size, mean, stdDev, seed);
 
+    /// <inheritdoc/>
+    public virtual void GenerateSecureRandomUniform(IGpuBuffer output, int size, float min, float max)
+        => Inner.GenerateSecureRandomUniform(output, size, min, max);
+
     #endregion
 
     #region Specialized Layer Operations

--- a/src/AiDotNet.Tensors/Helpers/SimdRandom.cs
+++ b/src/AiDotNet.Tensors/Helpers/SimdRandom.cs
@@ -218,46 +218,57 @@ public sealed class SimdRandom
     {
         if (typeof(T) == typeof(double))
         {
-            // Chunk-fill doubles directly via Unsafe.As — no full-size temp array
             const int chunk = 256;
-            var buf = new double[chunk];
-            int i = 0;
-            while (i < destination.Length)
+            var buf = System.Buffers.ArrayPool<double>.Shared.Rent(chunk);
+            try
             {
-                int n = Math.Min(chunk, destination.Length - i);
-                NextDoubles(buf.AsSpan(0, n));
-                for (int j = 0; j < n; j++)
-                    destination[i + j] = Unsafe.As<double, T>(ref buf[j]);
-                i += n;
+                int i = 0;
+                while (i < destination.Length)
+                {
+                    int n = Math.Min(chunk, destination.Length - i);
+                    NextDoubles(buf.AsSpan(0, n));
+                    for (int j = 0; j < n; j++)
+                        destination[i + j] = Unsafe.As<double, T>(ref buf[j]);
+                    i += n;
+                }
             }
+            finally { System.Buffers.ArrayPool<double>.Shared.Return(buf); }
         }
         else if (typeof(T) == typeof(float))
         {
             const int chunk = 256;
-            var buf = new float[chunk];
-            int i = 0;
-            while (i < destination.Length)
+            var buf = System.Buffers.ArrayPool<float>.Shared.Rent(chunk);
+            try
             {
-                int n = Math.Min(chunk, destination.Length - i);
-                NextFloats(buf.AsSpan(0, n));
-                for (int j = 0; j < n; j++)
-                    destination[i + j] = Unsafe.As<float, T>(ref buf[j]);
-                i += n;
+                int i = 0;
+                while (i < destination.Length)
+                {
+                    int n = Math.Min(chunk, destination.Length - i);
+                    NextFloats(buf.AsSpan(0, n));
+                    for (int j = 0; j < n; j++)
+                        destination[i + j] = Unsafe.As<float, T>(ref buf[j]);
+                    i += n;
+                }
             }
+            finally { System.Buffers.ArrayPool<float>.Shared.Return(buf); }
         }
         else
         {
             var numOps = MathHelper.GetNumericOperations<T>();
-            var temp = new double[Math.Min(256, destination.Length)];
-            int i = 0;
-            while (i < destination.Length)
+            var temp = System.Buffers.ArrayPool<double>.Shared.Rent(Math.Min(256, destination.Length));
+            try
             {
-                int n = Math.Min(temp.Length, destination.Length - i);
-                NextDoubles(temp.AsSpan(0, n));
-                for (int j = 0; j < n; j++)
-                    destination[i + j] = numOps.FromDouble(temp[j]);
-                i += n;
+                int i = 0;
+                while (i < destination.Length)
+                {
+                    int n = Math.Min(256, destination.Length - i);
+                    NextDoubles(temp.AsSpan(0, n));
+                    for (int j = 0; j < n; j++)
+                        destination[i + j] = numOps.FromDouble(temp[j]);
+                    i += n;
+                }
             }
+            finally { System.Buffers.ArrayPool<double>.Shared.Return(temp); }
         }
     }
 
@@ -271,50 +282,203 @@ public sealed class SimdRandom
         if (typeof(T) == typeof(double))
         {
             const int chunk = 256;
-            var buf = new double[chunk];
-            int i = 0;
-            while (i < destination.Length)
+            var buf = System.Buffers.ArrayPool<double>.Shared.Rent(chunk);
+            try
             {
-                int n = Math.Min(chunk, destination.Length - i);
-                NextDoubles(buf.AsSpan(0, n));
-                for (int j = 0; j < n; j++)
+                int i = 0;
+                while (i < destination.Length)
                 {
-                    double val = buf[j] * range + min;
-                    destination[i + j] = Unsafe.As<double, T>(ref val);
+                    int n = Math.Min(chunk, destination.Length - i);
+                    NextDoubles(buf.AsSpan(0, n));
+                    for (int j = 0; j < n; j++)
+                    {
+                        double val = buf[j] * range + min;
+                        destination[i + j] = Unsafe.As<double, T>(ref val);
+                    }
+                    i += n;
                 }
-                i += n;
             }
+            finally { System.Buffers.ArrayPool<double>.Shared.Return(buf); }
         }
         else if (typeof(T) == typeof(float))
         {
             const int chunk = 256;
-            var buf = new float[chunk];
-            int i = 0;
-            while (i < destination.Length)
+            var buf = System.Buffers.ArrayPool<float>.Shared.Rent(chunk);
+            try
             {
-                int n = Math.Min(chunk, destination.Length - i);
-                NextFloats(buf.AsSpan(0, n));
-                for (int j = 0; j < n; j++)
+                int i = 0;
+                while (i < destination.Length)
                 {
-                    float val = buf[j] * (float)range + (float)min;
-                    destination[i + j] = Unsafe.As<float, T>(ref val);
+                    int n = Math.Min(chunk, destination.Length - i);
+                    NextFloats(buf.AsSpan(0, n));
+                    for (int j = 0; j < n; j++)
+                    {
+                        float val = buf[j] * (float)range + (float)min;
+                        destination[i + j] = Unsafe.As<float, T>(ref val);
+                    }
+                    i += n;
                 }
-                i += n;
             }
+            finally { System.Buffers.ArrayPool<float>.Shared.Return(buf); }
         }
         else
         {
             var numOps = MathHelper.GetNumericOperations<T>();
-            var temp = new double[Math.Min(256, destination.Length)];
-            int i = 0;
-            while (i < destination.Length)
+            var temp = System.Buffers.ArrayPool<double>.Shared.Rent(Math.Min(256, destination.Length));
+            try
             {
-                int n = Math.Min(temp.Length, destination.Length - i);
-                NextDoubles(temp.AsSpan(0, n));
-                for (int j = 0; j < n; j++)
-                    destination[i + j] = numOps.FromDouble(temp[j] * range + min);
-                i += n;
+                int i = 0;
+                while (i < destination.Length)
+                {
+                    int n = Math.Min(256, destination.Length - i);
+                    NextDoubles(temp.AsSpan(0, n));
+                    for (int j = 0; j < n; j++)
+                        destination[i + j] = numOps.FromDouble(temp[j] * range + min);
+                    i += n;
+                }
             }
+            finally { System.Buffers.ArrayPool<double>.Shared.Return(temp); }
+        }
+    }
+
+    /// <summary>
+    /// Fills a span with cryptographically secure random doubles in [0, 1).
+    /// Uses RandomNumberGenerator.Fill for bulk byte generation, then SIMD-converts
+    /// to doubles. Much faster than per-element LockedRandom.NextDouble() for large fills.
+    /// </summary>
+    public static void SecureFillDoubles(Span<double> destination)
+    {
+        int byteCount = destination.Length * 8;
+        var bytes = System.Buffers.ArrayPool<byte>.Shared.Rent(byteCount);
+        try
+        {
+#if NET8_0_OR_GREATER
+            System.Security.Cryptography.RandomNumberGenerator.Fill(bytes.AsSpan(0, byteCount));
+#else
+            using var rng = System.Security.Cryptography.RandomNumberGenerator.Create();
+            rng.GetBytes(bytes, 0, byteCount);
+#endif
+            int i = 0;
+#if NET5_0_OR_GREATER
+            if (Avx2.IsSupported && destination.Length >= 4)
+            {
+                var one = Vector256.Create(1.0);
+                var exponentMask = Vector256.Create(0x3FF0000000000000UL);
+                var mantissaMask = Vector256.Create(0x000FFFFFFFFFFFFFUL);
+
+                int simdLen = destination.Length & ~3;
+                for (; i < simdLen; i += 4)
+                {
+                    // Load 4 x 8 bytes as 4 ulongs
+                    var raw = Unsafe.ReadUnaligned<Vector256<ulong>>(
+                        ref bytes[i * 8]);
+                    var shifted = Avx2.ShiftRightLogical(raw, 12);
+                    var bits = Avx2.Or(Avx2.And(shifted, mantissaMask), exponentMask);
+                    var doubles = Avx.Subtract(bits.AsDouble(), one);
+                    Unsafe.WriteUnaligned(
+                        ref Unsafe.As<double, byte>(ref destination[i]),
+                        doubles);
+                }
+            }
+#endif
+            // Scalar tail
+            for (; i < destination.Length; i++)
+            {
+                ulong raw = BitConverter.ToUInt64(bytes, i * 8);
+                destination[i] = BitConverter.Int64BitsToDouble(
+                    (long)((raw >> 12) | 0x3FF0000000000000UL)) - 1.0;
+            }
+        }
+        finally { System.Buffers.ArrayPool<byte>.Shared.Return(bytes); }
+    }
+
+    /// <summary>
+    /// Fills a span with cryptographically secure random floats in [0, 1).
+    /// </summary>
+    public static void SecureFillFloats(Span<float> destination)
+    {
+        int byteCount = destination.Length * 4;
+        var bytes = System.Buffers.ArrayPool<byte>.Shared.Rent(byteCount);
+        try
+        {
+#if NET8_0_OR_GREATER
+            System.Security.Cryptography.RandomNumberGenerator.Fill(bytes.AsSpan(0, byteCount));
+#else
+            using var rng = System.Security.Cryptography.RandomNumberGenerator.Create();
+            rng.GetBytes(bytes, 0, byteCount);
+#endif
+            for (int i = 0; i < destination.Length; i++)
+            {
+                uint raw = BitConverter.ToUInt32(bytes, i * 4);
+                // Use upper 23 bits mapped to [1.0f, 2.0f) then subtract 1.0f
+                int bits = (int)((raw >> 9) | 0x3F800000U);
+                destination[i] = Unsafe.As<int, float>(ref bits) - 1.0f;
+            }
+        }
+        finally { System.Buffers.ArrayPool<byte>.Shared.Return(bytes); }
+    }
+
+    /// <summary>
+    /// Fills a span with cryptographically secure uniform random values in [0, 1).
+    /// Type-specialized: float/double use bulk crypto RNG + SIMD conversion.
+    /// Other types use batched crypto doubles + NumOps.FromDouble.
+    /// </summary>
+    public static void SecureFillUniform<T>(Span<T> destination)
+    {
+        if (typeof(T) == typeof(double))
+        {
+            const int chunk = 4096;
+            var buf = System.Buffers.ArrayPool<double>.Shared.Rent(Math.Min(chunk, destination.Length));
+            try
+            {
+                int i = 0;
+                while (i < destination.Length)
+                {
+                    int n = Math.Min(buf.Length, destination.Length - i);
+                    SecureFillDoubles(buf.AsSpan(0, n));
+                    for (int j = 0; j < n; j++)
+                        destination[i + j] = Unsafe.As<double, T>(ref buf[j]);
+                    i += n;
+                }
+            }
+            finally { System.Buffers.ArrayPool<double>.Shared.Return(buf); }
+        }
+        else if (typeof(T) == typeof(float))
+        {
+            const int chunk = 4096;
+            var buf = System.Buffers.ArrayPool<float>.Shared.Rent(Math.Min(chunk, destination.Length));
+            try
+            {
+                int i = 0;
+                while (i < destination.Length)
+                {
+                    int n = Math.Min(buf.Length, destination.Length - i);
+                    SecureFillFloats(buf.AsSpan(0, n));
+                    for (int j = 0; j < n; j++)
+                        destination[i + j] = Unsafe.As<float, T>(ref buf[j]);
+                    i += n;
+                }
+            }
+            finally { System.Buffers.ArrayPool<float>.Shared.Return(buf); }
+        }
+        else
+        {
+            var numOps = MathHelper.GetNumericOperations<T>();
+            const int chunk = 256;
+            var buf = System.Buffers.ArrayPool<double>.Shared.Rent(chunk);
+            try
+            {
+                int i = 0;
+                while (i < destination.Length)
+                {
+                    int n = Math.Min(chunk, destination.Length - i);
+                    SecureFillDoubles(buf.AsSpan(0, n));
+                    for (int j = 0; j < n; j++)
+                        destination[i + j] = numOps.FromDouble(buf[j]);
+                    i += n;
+                }
+            }
+            finally { System.Buffers.ArrayPool<double>.Shared.Return(buf); }
         }
     }
 

--- a/src/AiDotNet.Tensors/Helpers/SimdRandom.cs
+++ b/src/AiDotNet.Tensors/Helpers/SimdRandom.cs
@@ -212,41 +212,108 @@ public sealed class SimdRandom
     /// <summary>
     /// Fills a span with uniform random values in [0, 1), using type-specialized
     /// direct writes for float/double to avoid per-element NumOps.FromDouble overhead.
-    /// </summary>
-    /// <summary>
-    /// Fills a span with uniform random values in [0, 1), using type-specialized
-    /// direct writes for float/double to avoid per-element NumOps.FromDouble overhead.
+    /// Not cryptographically secure — uses xoshiro256** PRNG suitable for ML workloads.
     /// </summary>
     public void FillUniform<T>(Span<T> destination)
     {
         if (typeof(T) == typeof(double))
         {
-            // Direct write for double — reinterpret via pinned array
-            var arr = new double[destination.Length];
-            NextDoubles(arr.AsSpan());
-            for (int i2 = 0; i2 < destination.Length; i2++)
-                destination[i2] = Unsafe.As<double, T>(ref arr[i2]);
+            // Chunk-fill doubles directly via Unsafe.As — no full-size temp array
+            const int chunk = 256;
+            var buf = new double[chunk];
+            int i = 0;
+            while (i < destination.Length)
+            {
+                int n = Math.Min(chunk, destination.Length - i);
+                NextDoubles(buf.AsSpan(0, n));
+                for (int j = 0; j < n; j++)
+                    destination[i + j] = Unsafe.As<double, T>(ref buf[j]);
+                i += n;
+            }
         }
         else if (typeof(T) == typeof(float))
         {
-            var arr = new float[destination.Length];
-            NextFloats(arr.AsSpan());
-            for (int i2 = 0; i2 < destination.Length; i2++)
-                destination[i2] = Unsafe.As<float, T>(ref arr[i2]);
+            const int chunk = 256;
+            var buf = new float[chunk];
+            int i = 0;
+            while (i < destination.Length)
+            {
+                int n = Math.Min(chunk, destination.Length - i);
+                NextFloats(buf.AsSpan(0, n));
+                for (int j = 0; j < n; j++)
+                    destination[i + j] = Unsafe.As<float, T>(ref buf[j]);
+                i += n;
+            }
         }
         else
         {
-            // Fallback: batch-generate doubles then convert via NumOps
             var numOps = MathHelper.GetNumericOperations<T>();
             var temp = new double[Math.Min(256, destination.Length)];
             int i = 0;
             while (i < destination.Length)
             {
-                int chunk = Math.Min(temp.Length, destination.Length - i);
-                NextDoubles(temp.AsSpan(0, chunk));
-                for (int j = 0; j < chunk; j++)
+                int n = Math.Min(temp.Length, destination.Length - i);
+                NextDoubles(temp.AsSpan(0, n));
+                for (int j = 0; j < n; j++)
                     destination[i + j] = numOps.FromDouble(temp[j]);
-                i += chunk;
+                i += n;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Fills a span with uniform random values in [min, max), with type-specialized
+    /// fast paths for float/double that avoid per-element NumOps virtual dispatch.
+    /// </summary>
+    public void FillUniformRange<T>(Span<T> destination, double min, double max)
+    {
+        double range = max - min;
+        if (typeof(T) == typeof(double))
+        {
+            const int chunk = 256;
+            var buf = new double[chunk];
+            int i = 0;
+            while (i < destination.Length)
+            {
+                int n = Math.Min(chunk, destination.Length - i);
+                NextDoubles(buf.AsSpan(0, n));
+                for (int j = 0; j < n; j++)
+                {
+                    double val = buf[j] * range + min;
+                    destination[i + j] = Unsafe.As<double, T>(ref val);
+                }
+                i += n;
+            }
+        }
+        else if (typeof(T) == typeof(float))
+        {
+            const int chunk = 256;
+            var buf = new float[chunk];
+            int i = 0;
+            while (i < destination.Length)
+            {
+                int n = Math.Min(chunk, destination.Length - i);
+                NextFloats(buf.AsSpan(0, n));
+                for (int j = 0; j < n; j++)
+                {
+                    float val = buf[j] * (float)range + (float)min;
+                    destination[i + j] = Unsafe.As<float, T>(ref val);
+                }
+                i += n;
+            }
+        }
+        else
+        {
+            var numOps = MathHelper.GetNumericOperations<T>();
+            var temp = new double[Math.Min(256, destination.Length)];
+            int i = 0;
+            while (i < destination.Length)
+            {
+                int n = Math.Min(temp.Length, destination.Length - i);
+                NextDoubles(temp.AsSpan(0, n));
+                for (int j = 0; j < n; j++)
+                    destination[i + j] = numOps.FromDouble(temp[j] * range + min);
+                i += n;
             }
         }
     }

--- a/src/AiDotNet.Tensors/Helpers/SimdRandom.cs
+++ b/src/AiDotNet.Tensors/Helpers/SimdRandom.cs
@@ -46,10 +46,13 @@ public sealed class SimdRandom
         }
     }
 
+    private static int _seedCounter = Environment.TickCount;
+
     /// <summary>
-    /// Creates a new SIMD random generator with a random seed.
+    /// Creates a new SIMD random generator with a unique random seed.
+    /// Each call produces a different seed via atomic increment.
     /// </summary>
-    public SimdRandom() : this(Environment.TickCount) { }
+    public SimdRandom() : this(System.Threading.Interlocked.Increment(ref _seedCounter)) { }
 
     /// <summary>
     /// Fills a span with uniform random doubles in [0, 1).
@@ -204,6 +207,48 @@ public sealed class SimdRandom
         _s3[0] = RotateLeft64(_s3[0], 45);
 
         return d;
+    }
+
+    /// <summary>
+    /// Fills a span with uniform random values in [0, 1), using type-specialized
+    /// direct writes for float/double to avoid per-element NumOps.FromDouble overhead.
+    /// </summary>
+    /// <summary>
+    /// Fills a span with uniform random values in [0, 1), using type-specialized
+    /// direct writes for float/double to avoid per-element NumOps.FromDouble overhead.
+    /// </summary>
+    public void FillUniform<T>(Span<T> destination)
+    {
+        if (typeof(T) == typeof(double))
+        {
+            // Direct write for double — reinterpret via pinned array
+            var arr = new double[destination.Length];
+            NextDoubles(arr.AsSpan());
+            for (int i2 = 0; i2 < destination.Length; i2++)
+                destination[i2] = Unsafe.As<double, T>(ref arr[i2]);
+        }
+        else if (typeof(T) == typeof(float))
+        {
+            var arr = new float[destination.Length];
+            NextFloats(arr.AsSpan());
+            for (int i2 = 0; i2 < destination.Length; i2++)
+                destination[i2] = Unsafe.As<float, T>(ref arr[i2]);
+        }
+        else
+        {
+            // Fallback: batch-generate doubles then convert via NumOps
+            var numOps = MathHelper.GetNumericOperations<T>();
+            var temp = new double[Math.Min(256, destination.Length)];
+            int i = 0;
+            while (i < destination.Length)
+            {
+                int chunk = Math.Min(temp.Length, destination.Length - i);
+                NextDoubles(temp.AsSpan(0, chunk));
+                for (int j = 0; j < chunk; j++)
+                    destination[i + j] = numOps.FromDouble(temp[j]);
+                i += chunk;
+            }
+        }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/AiDotNet.Tensors/Helpers/SimdRandom.cs
+++ b/src/AiDotNet.Tensors/Helpers/SimdRandom.cs
@@ -348,48 +348,53 @@ public sealed class SimdRandom
     /// </summary>
     public static void SecureFillDoubles(Span<double> destination)
     {
-        int byteCount = destination.Length * 8;
-        var bytes = System.Buffers.ArrayPool<byte>.Shared.Rent(byteCount);
-        try
+        // Process in chunks to avoid int overflow on byteCount for large spans
+        const int maxChunk = 32768; // 32K doubles = 256KB bytes, safe from overflow
+        int offset = 0;
+        while (offset < destination.Length)
         {
-#if NET8_0_OR_GREATER
-            System.Security.Cryptography.RandomNumberGenerator.Fill(bytes.AsSpan(0, byteCount));
-#else
-            using var rng = System.Security.Cryptography.RandomNumberGenerator.Create();
-            rng.GetBytes(bytes, 0, byteCount);
-#endif
-            int i = 0;
-#if NET5_0_OR_GREATER
-            if (Avx2.IsSupported && destination.Length >= 4)
+            int chunk = Math.Min(maxChunk, destination.Length - offset);
+            int byteCount = chunk * 8;
+            var bytes = System.Buffers.ArrayPool<byte>.Shared.Rent(byteCount);
+            try
             {
-                var one = Vector256.Create(1.0);
-                var exponentMask = Vector256.Create(0x3FF0000000000000UL);
-                var mantissaMask = Vector256.Create(0x000FFFFFFFFFFFFFUL);
-
-                int simdLen = destination.Length & ~3;
-                for (; i < simdLen; i += 4)
+#if NET8_0_OR_GREATER
+                System.Security.Cryptography.RandomNumberGenerator.Fill(bytes.AsSpan(0, byteCount));
+#else
+                using var rng = System.Security.Cryptography.RandomNumberGenerator.Create();
+                rng.GetBytes(bytes, 0, byteCount);
+#endif
+                int i = 0;
+#if NET5_0_OR_GREATER
+                if (Avx2.IsSupported && chunk >= 4)
                 {
-                    // Load 4 x 8 bytes as 4 ulongs
-                    var raw = Unsafe.ReadUnaligned<Vector256<ulong>>(
-                        ref bytes[i * 8]);
-                    var shifted = Avx2.ShiftRightLogical(raw, 12);
-                    var bits = Avx2.Or(Avx2.And(shifted, mantissaMask), exponentMask);
-                    var doubles = Avx.Subtract(bits.AsDouble(), one);
-                    Unsafe.WriteUnaligned(
-                        ref Unsafe.As<double, byte>(ref destination[i]),
-                        doubles);
+                    var one = Vector256.Create(1.0);
+                    var exponentMask = Vector256.Create(0x3FF0000000000000UL);
+                    var mantissaMask = Vector256.Create(0x000FFFFFFFFFFFFFUL);
+
+                    int simdLen = chunk & ~3;
+                    for (; i < simdLen; i += 4)
+                    {
+                        var raw = Unsafe.ReadUnaligned<Vector256<ulong>>(ref bytes[i * 8]);
+                        var shifted = Avx2.ShiftRightLogical(raw, 12);
+                        var bits = Avx2.Or(Avx2.And(shifted, mantissaMask), exponentMask);
+                        var doubles = Avx.Subtract(bits.AsDouble(), one);
+                        Unsafe.WriteUnaligned(
+                            ref Unsafe.As<double, byte>(ref destination[offset + i]),
+                            doubles);
+                    }
+                }
+#endif
+                for (; i < chunk; i++)
+                {
+                    ulong raw = BitConverter.ToUInt64(bytes, i * 8);
+                    destination[offset + i] = BitConverter.Int64BitsToDouble(
+                        (long)((raw >> 12) | 0x3FF0000000000000UL)) - 1.0;
                 }
             }
-#endif
-            // Scalar tail
-            for (; i < destination.Length; i++)
-            {
-                ulong raw = BitConverter.ToUInt64(bytes, i * 8);
-                destination[i] = BitConverter.Int64BitsToDouble(
-                    (long)((raw >> 12) | 0x3FF0000000000000UL)) - 1.0;
-            }
+            finally { System.Buffers.ArrayPool<byte>.Shared.Return(bytes, clearArray: true); }
+            offset += chunk;
         }
-        finally { System.Buffers.ArrayPool<byte>.Shared.Return(bytes, clearArray: true); }
     }
 
     /// <summary>
@@ -397,25 +402,31 @@ public sealed class SimdRandom
     /// </summary>
     public static void SecureFillFloats(Span<float> destination)
     {
-        int byteCount = destination.Length * 4;
-        var bytes = System.Buffers.ArrayPool<byte>.Shared.Rent(byteCount);
-        try
+        const int maxChunk = 65536; // 64K floats = 256KB bytes
+        int offset = 0;
+        while (offset < destination.Length)
         {
-#if NET8_0_OR_GREATER
-            System.Security.Cryptography.RandomNumberGenerator.Fill(bytes.AsSpan(0, byteCount));
-#else
-            using var rng = System.Security.Cryptography.RandomNumberGenerator.Create();
-            rng.GetBytes(bytes, 0, byteCount);
-#endif
-            for (int i = 0; i < destination.Length; i++)
+            int chunk = Math.Min(maxChunk, destination.Length - offset);
+            int byteCount = chunk * 4;
+            var bytes = System.Buffers.ArrayPool<byte>.Shared.Rent(byteCount);
+            try
             {
-                uint raw = BitConverter.ToUInt32(bytes, i * 4);
-                // Use upper 23 bits mapped to [1.0f, 2.0f) then subtract 1.0f
-                int bits = (int)((raw >> 9) | 0x3F800000U);
-                destination[i] = Unsafe.As<int, float>(ref bits) - 1.0f;
+#if NET8_0_OR_GREATER
+                System.Security.Cryptography.RandomNumberGenerator.Fill(bytes.AsSpan(0, byteCount));
+#else
+                using var rng = System.Security.Cryptography.RandomNumberGenerator.Create();
+                rng.GetBytes(bytes, 0, byteCount);
+#endif
+                for (int i = 0; i < chunk; i++)
+                {
+                    uint raw = BitConverter.ToUInt32(bytes, i * 4);
+                    int bits = (int)((raw >> 9) | 0x3F800000U);
+                    destination[offset + i] = Unsafe.As<int, float>(ref bits) - 1.0f;
+                }
             }
+            finally { System.Buffers.ArrayPool<byte>.Shared.Return(bytes, clearArray: true); }
+            offset += chunk;
         }
-        finally { System.Buffers.ArrayPool<byte>.Shared.Return(bytes, clearArray: true); }
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Helpers/SimdRandom.cs
+++ b/src/AiDotNet.Tensors/Helpers/SimdRandom.cs
@@ -389,7 +389,7 @@ public sealed class SimdRandom
                     (long)((raw >> 12) | 0x3FF0000000000000UL)) - 1.0;
             }
         }
-        finally { System.Buffers.ArrayPool<byte>.Shared.Return(bytes); }
+        finally { System.Buffers.ArrayPool<byte>.Shared.Return(bytes, clearArray: true); }
     }
 
     /// <summary>
@@ -415,7 +415,7 @@ public sealed class SimdRandom
                 destination[i] = Unsafe.As<int, float>(ref bits) - 1.0f;
             }
         }
-        finally { System.Buffers.ArrayPool<byte>.Shared.Return(bytes); }
+        finally { System.Buffers.ArrayPool<byte>.Shared.Return(bytes, clearArray: true); }
     }
 
     /// <summary>
@@ -441,7 +441,7 @@ public sealed class SimdRandom
                     i += n;
                 }
             }
-            finally { System.Buffers.ArrayPool<double>.Shared.Return(buf); }
+            finally { System.Buffers.ArrayPool<double>.Shared.Return(buf, clearArray: true); }
         }
         else if (typeof(T) == typeof(float))
         {
@@ -459,7 +459,7 @@ public sealed class SimdRandom
                     i += n;
                 }
             }
-            finally { System.Buffers.ArrayPool<float>.Shared.Return(buf); }
+            finally { System.Buffers.ArrayPool<float>.Shared.Return(buf, clearArray: true); }
         }
         else
         {
@@ -478,7 +478,7 @@ public sealed class SimdRandom
                     i += n;
                 }
             }
-            finally { System.Buffers.ArrayPool<double>.Shared.Return(buf); }
+            finally { System.Buffers.ArrayPool<double>.Shared.Return(buf, clearArray: true); }
         }
     }
 

--- a/src/AiDotNet.Tensors/LinearAlgebra/Matrix.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/Matrix.cs
@@ -522,16 +522,9 @@ public class Matrix<T> : MatrixBase<T>, IEnumerable<T>
     /// </remarks>
     public static Matrix<T> CreateRandom(int rows, int columns)
     {
-        Matrix<T> matrix = new(rows, columns);
-        var random = RandomHelper.CreateSecureRandom();
-
-        for (int i = 0; i < rows; i++)
-        {
-            for (int j = 0; j < columns; j++)
-            {
-                matrix[i, j] = _numOps.FromDouble(random.NextDouble());
-            }
-        }
+        var matrix = new Matrix<T>(rows, columns);
+        var rng = new Helpers.SimdRandom();
+        rng.FillUniform(matrix.AsWritableSpan());
 
         return matrix;
     }
@@ -603,18 +596,14 @@ public class Matrix<T> : MatrixBase<T>, IEnumerable<T>
         if (min >= max)
             throw new ArgumentException("Minimum value must be less than maximum value");
 
-        var random = RandomHelper.CreateSecureRandom();
         var matrix = new Matrix<T>(rows, columns);
-
-        for (int i = 0; i < rows; i++)
-        {
-            for (int j = 0; j < columns; j++)
-            {
-                // Generate random value between min and max
-                double randomValue = random.NextDouble() * (max - min) + min;
-                matrix[i, j] = _numOps.FromDouble(randomValue);
-            }
-        }
+        var rng = new Helpers.SimdRandom();
+        rng.FillUniform(matrix.AsWritableSpan());
+        double range = max - min;
+        var span = matrix.AsWritableSpan();
+        int total = rows * columns;
+        for (int i = 0; i < total; i++)
+            span[i] = _numOps.FromDouble(_numOps.ToDouble(span[i]) * range + min);
 
         return matrix;
     }

--- a/src/AiDotNet.Tensors/LinearAlgebra/Matrix.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/Matrix.cs
@@ -598,12 +598,7 @@ public class Matrix<T> : MatrixBase<T>, IEnumerable<T>
 
         var matrix = new Matrix<T>(rows, columns);
         var rng = new Helpers.SimdRandom();
-        rng.FillUniform(matrix.AsWritableSpan());
-        double range = max - min;
-        var span = matrix.AsWritableSpan();
-        int total = rows * columns;
-        for (int i = 0; i < total; i++)
-            span[i] = _numOps.FromDouble(_numOps.ToDouble(span[i]) * range + min);
+        rng.FillUniformRange(matrix.AsWritableSpan(), min, max);
 
         return matrix;
     }

--- a/src/AiDotNet.Tensors/LinearAlgebra/Tensor.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/Tensor.cs
@@ -679,16 +679,8 @@ public class Tensor<T> : TensorBase<T>, IEnumerable<T>
             throw new ArgumentException("Dimensions cannot be null or empty.", nameof(dimensions));
 
         var tensor = new Tensor<T>(dimensions);
-        var random = RandomHelper.CreateSecureRandom();
-        var numOps = MathHelper.GetNumericOperations<T>();
-
-        // Use flat indexing for better performance (avoids multi-dimensional index calculation overhead)
-        var flattenedSize = dimensions.Aggregate(1, (a, b) => a * b);
-        for (int i = 0; i < flattenedSize; i++)
-        {
-            // Generate a random value between 0 and 1
-            tensor._data[i] = numOps.FromDouble(random.NextDouble());
-        }
+        var rng = new Helpers.SimdRandom();
+        rng.FillUniform(tensor._data.AsWritableSpan());
 
         return tensor;
     }

--- a/src/AiDotNet.Tensors/LinearAlgebra/Tensor.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/Tensor.cs
@@ -678,11 +678,8 @@ public class Tensor<T> : TensorBase<T>, IEnumerable<T>
         if (dimensions == null || dimensions.Length == 0)
             throw new ArgumentException("Dimensions cannot be null or empty.", nameof(dimensions));
 
-        var tensor = new Tensor<T>(dimensions);
-        var rng = new Helpers.SimdRandom();
-        rng.FillUniform(tensor._data.AsWritableSpan());
-
-        return tensor;
+        // Route through the engine which has GPU dispatch when a GPU engine is active
+        return Engines.AiDotNetEngine.Current.TensorRandomUniform<T>(dimensions);
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/LinearAlgebra/Vector.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/Vector.cs
@@ -1053,6 +1053,8 @@ public class Vector<T> : VectorBase<T>, IEnumerable<T>
 
     /// <summary>
     /// Creates a new vector of the specified size filled with random values between 0 and 1.
+    /// Uses SimdRandom (xoshiro256** PRNG) for high-throughput ML initialization.
+    /// Not cryptographically secure — use System.Security.Cryptography for security-sensitive applications.
     /// </summary>
     /// <param name="size">The size of the vector to create.</param>
     /// <returns>A new vector filled with random values.</returns>
@@ -1113,12 +1115,7 @@ public class Vector<T> : VectorBase<T>, IEnumerable<T>
 
         var vector = new Vector<T>(size);
         var rng = new Helpers.SimdRandom();
-        // Fill with [0, 1) then scale to [min, max)
-        rng.FillUniform(vector.AsWritableSpan());
-        double range = max - min;
-        var span = vector.AsWritableSpan();
-        for (int i = 0; i < size; i++)
-            span[i] = _numOps.FromDouble(_numOps.ToDouble(span[i]) * range + min);
+        rng.FillUniformRange(vector.AsWritableSpan(), min, max);
 
         return vector;
     }

--- a/src/AiDotNet.Tensors/LinearAlgebra/Vector.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/Vector.cs
@@ -147,6 +147,18 @@ public class Vector<T> : VectorBase<T>, IEnumerable<T>
     }
 
     /// <summary>
+    /// Creates a vector by copying data from a span, avoiding the intermediate .ToArray() allocation.
+    /// </summary>
+    /// <param name="span">The span of data to copy into the new vector.</param>
+    /// <returns>A new vector containing a copy of the span data.</returns>
+    public static Vector<T> FromSpan(ReadOnlySpan<T> span)
+    {
+        var vec = new Vector<T>(span.Length, skipZeroInit: true);
+        span.CopyTo(vec.AsWritableSpan());
+        return vec;
+    }
+
+    /// <summary>
     /// Creates a GPU-resident vector with zero CPU allocation.
     /// The backing array is allocated lazily when CPU code first accesses data.
     /// </summary>
@@ -1050,12 +1062,9 @@ public class Vector<T> : VectorBase<T>, IEnumerable<T>
     /// </remarks>
     public static Vector<T> CreateRandom(int size)
     {
-        Vector<T> vector = new(size);
-        var random = RandomHelper.CreateSecureRandom();
-        for (int i = 0; i < size; i++)
-        {
-            vector[i] = _numOps.FromDouble(random.NextDouble());
-        }
+        var vector = new Vector<T>(size);
+        var rng = new Helpers.SimdRandom();
+        rng.FillUniform(vector.AsWritableSpan());
 
         return vector;
     }
@@ -1102,15 +1111,14 @@ public class Vector<T> : VectorBase<T>, IEnumerable<T>
         if (min >= max)
             throw new ArgumentException("Minimum value must be less than maximum value");
 
-        var random = RandomHelper.CreateSecureRandom();
         var vector = new Vector<T>(size);
-
+        var rng = new Helpers.SimdRandom();
+        // Fill with [0, 1) then scale to [min, max)
+        rng.FillUniform(vector.AsWritableSpan());
+        double range = max - min;
+        var span = vector.AsWritableSpan();
         for (int i = 0; i < size; i++)
-        {
-            // Generate random value between min and max
-            double randomValue = random.NextDouble() * (max - min) + min;
-            vector[i] = _numOps.FromDouble(randomValue);
-        }
+            span[i] = _numOps.FromDouble(_numOps.ToDouble(span[i]) * range + min);
 
         return vector;
     }

--- a/src/AiDotNet.Tensors/LinearAlgebra/Vector.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/Vector.cs
@@ -1052,17 +1052,32 @@ public class Vector<T> : VectorBase<T>, IEnumerable<T>
     }
 
     /// <summary>
-    /// Creates a new vector of the specified size filled with random values between 0 and 1.
-    /// Uses SimdRandom (xoshiro256** PRNG) for high-throughput ML initialization.
-    /// Not cryptographically secure — use System.Security.Cryptography for security-sensitive applications.
+    /// Creates a new vector of the specified size filled with cryptographically secure random values between 0 and 1.
+    /// Uses SIMD-accelerated bulk crypto RNG for high throughput.
     /// </summary>
     /// <param name="size">The size of the vector to create.</param>
     /// <returns>A new vector filled with random values.</returns>
     /// <remarks>
     /// <para><b>For Beginners:</b> This method creates a vector of a specific size where each element
     /// is a random number between 0 and 1. This is useful for initializing vectors for machine learning algorithms.</para>
+    /// <para>For maximum speed without crypto guarantees, use <see cref="CreateFastRandom(int)"/>.</para>
     /// </remarks>
     public static Vector<T> CreateRandom(int size)
+    {
+        var vector = new Vector<T>(size);
+        Helpers.SimdRandom.SecureFillUniform(vector.AsWritableSpan());
+
+        return vector;
+    }
+
+    /// <summary>
+    /// Creates a new vector filled with non-cryptographic random values between 0 and 1.
+    /// Uses SimdRandom (xoshiro256** PRNG) for maximum throughput on ML hot paths.
+    /// Not cryptographically secure — use <see cref="CreateRandom(int)"/> for security-sensitive applications.
+    /// </summary>
+    /// <param name="size">The size of the vector to create.</param>
+    /// <returns>A new vector filled with random values.</returns>
+    public static Vector<T> CreateFastRandom(int size)
     {
         var vector = new Vector<T>(size);
         var rng = new Helpers.SimdRandom();

--- a/src/AiDotNet.Tensors/LinearAlgebra/Vector.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/Vector.cs
@@ -1072,6 +1072,21 @@ public class Vector<T> : VectorBase<T>, IEnumerable<T>
     }
 
     /// <summary>
+    /// Creates a new vector filled with cryptographically secure random values between 0 and 1.
+    /// Use this when security guarantees are required (tokens, keys, salts).
+    /// For ML weight initialization, prefer <see cref="CreateRandom(int)"/> which is faster.
+    /// </summary>
+    /// <param name="size">The size of the vector to create.</param>
+    /// <returns>A new vector filled with cryptographically secure random values.</returns>
+    public static Vector<T> CreateSecureRandom(int size)
+    {
+        var vector = new Vector<T>(size);
+        Helpers.SimdRandom.SecureFillUniform(vector.AsWritableSpan());
+
+        return vector;
+    }
+
+    /// <summary>
     /// Creates a new vector of the specified size filled with random values using the specified random number generator.
     /// </summary>
     /// <param name="random">The random number generator to use. Pass a seeded Random for reproducible results.</param>

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/VectorFromSpanTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/VectorFromSpanTests.cs
@@ -1,0 +1,65 @@
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.LinearAlgebra;
+
+public class VectorFromSpanTests
+{
+    [Fact]
+    public void FromSpan_Float_CopiesCorrectly()
+    {
+        float[] source = [1.5f, 2.5f, 3.5f, 4.5f, 5.5f];
+        var vec = Vector<float>.FromSpan(source.AsSpan());
+
+        Assert.Equal(5, vec.Length);
+        for (int i = 0; i < source.Length; i++)
+            Assert.Equal(source[i], vec[i]);
+    }
+
+    [Fact]
+    public void FromSpan_Double_CopiesCorrectly()
+    {
+        double[] source = [1.1, 2.2, 3.3];
+        var vec = Vector<double>.FromSpan(source.AsSpan());
+
+        Assert.Equal(3, vec.Length);
+        for (int i = 0; i < source.Length; i++)
+            Assert.Equal(source[i], vec[i]);
+    }
+
+    [Fact]
+    public void FromSpan_EmptySpan_CreatesEmptyVector()
+    {
+        var vec = Vector<float>.FromSpan(ReadOnlySpan<float>.Empty);
+        Assert.Equal(0, vec.Length);
+    }
+
+    [Fact]
+    public void FromSpan_IsDeepCopy_SourceMutationDoesNotAffectVector()
+    {
+        float[] source = [10f, 20f, 30f];
+        var vec = Vector<float>.FromSpan(source.AsSpan());
+
+        // Mutate source after creating vector
+        source[0] = 999f;
+        source[1] = 888f;
+
+        // Vector should be unaffected
+        Assert.Equal(10f, vec[0]);
+        Assert.Equal(20f, vec[1]);
+        Assert.Equal(30f, vec[2]);
+    }
+
+    [Fact]
+    public void FromSpan_LargeSpan_WorksCorrectly()
+    {
+        var source = new double[10000];
+        for (int i = 0; i < source.Length; i++) source[i] = i * 0.001;
+
+        var vec = Vector<double>.FromSpan(source.AsSpan());
+
+        Assert.Equal(10000, vec.Length);
+        Assert.Equal(0.0, vec[0]);
+        Assert.Equal(9.999, vec[9999], 6);
+    }
+}


### PR DESCRIPTION
## Summary

- **Issue #154**: Add `OpenClBackend.DiagnosticOutput` static property + `AIDOTNET_GPU_VERBOSE` env var. All 125 `Console.WriteLine` calls gated by the flag — suppresses GPU diagnostics for rich terminal UI and batch processing.
- **Issue #155**: Add `Vector<T>.FromSpan(ReadOnlySpan<T>)` factory that copies span data into a new vector without the intermediate `.ToArray()` allocation.
- **Issue #156**: Replace scalar `LockedRandom` loops in `CreateRandom` with `SimdRandom` (AVX2 xoshiro256**, 4 doubles/iter) for Tensor, Vector, and Matrix.
- **Issue #157**: Add `SimdRandom.FillUniform<T>` with type-specialized direct writes for float/double — eliminates per-element `NumOps.FromDouble` virtual dispatch for 110M+ element model initialization.

Closes #154, Closes #155, Closes #156, Closes #157

## Test plan

- [x] All 7 CreateRandom tests pass (including non-determinism test)
- [x] TapeCompleteness tests pass
- [x] Build passes on both net10.0 and net471
- [x] SimdRandom atomic seed increment ensures unique seeds across rapid sequential calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)