### PR TITLE
feat: span-based FFT, NativeAnalyticSignal, NativeNormalizeRows (Issue #160 P0)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
@@ -204,7 +204,7 @@ internal static class OpRegistry
         "NativeComplexFFTND", "NativeComplexIFFTNDReal",
         "NativeAnalyticSignal",
         "NativeNormalizeRows",
-        "NativeComplexFFTSpan", "NativeComplexIFFTSpan", "NativeComplexFFTComplexSpan",
+        "NativeComplexFFTSpan", "NativeComplexIFFTSpan", "NativeComplexFFTComplexSpan", "NativeComplexIFFTRealSpan",
         "NativeTanh", "NativeExp", "NativeAtan2", "NativeMagnitudeAndPhase",
         "NativeBispectrum", "NativeTrispectrum",
         "NativeBatchedCavityForward",

--- a/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
@@ -205,6 +205,10 @@ internal static class OpRegistry
         "NativeAnalyticSignal",
         "NativeNormalizeRows",
         "NativeComplexFFTSpan", "NativeComplexIFFTSpan", "NativeComplexFFTComplexSpan",
+        "NativeTanh", "NativeExp", "NativeAtan2", "NativeMagnitudeAndPhase",
+        "NativeBispectrum", "NativeTrispectrum",
+        "NativeBatchedCavityForward",
+        "NativeMfccFeatures", "NativeWidebandFeatures", "NativePacFeatures",
         "TensorSoftmaxRows",
 
         // Rounding (non-differentiable, STE would need explicit annotation)

--- a/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
@@ -202,6 +202,9 @@ internal static class OpRegistry
         "NativeComplexCrossSpectral",
         "NativeComplexFFT2D", "NativeComplexIFFT2DReal",
         "NativeComplexFFTND", "NativeComplexIFFTNDReal",
+        "NativeAnalyticSignal",
+        "NativeNormalizeRows",
+        "NativeComplexFFTSpan", "NativeComplexIFFTSpan", "NativeComplexFFTComplexSpan",
         "TensorSoftmaxRows",
 
         // Rounding (non-differentiable, STE would need explicit annotation)

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -28258,7 +28258,17 @@ public class CpuEngine : ITensorLevelEngine
     {
         if (imag is null) throw new ArgumentNullException(nameof(imag));
         if (real is null) throw new ArgumentNullException(nameof(real));
-        if (imag.Length != real.Length) throw new ArgumentException("imag and real must have same length.");
+        // Require matching shape, not just length. Equal-length tensors with different shapes
+        // would silently pair values by flat index which is almost never what the caller wants.
+        if (imag.Rank != real.Rank)
+            throw new ArgumentException($"imag rank ({imag.Rank}) must equal real rank ({real.Rank}).", nameof(real));
+        for (int d = 0; d < imag.Rank; d++)
+        {
+            if (imag._shape[d] != real._shape[d])
+                throw new ArgumentException(
+                    $"imag and real must have the same shape; differ at axis {d}: imag={imag._shape[d]}, real={real._shape[d]}.",
+                    nameof(real));
+        }
         var result = new Tensor<T>(imag._shape);
         int n = imag.Length;
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -27566,6 +27566,38 @@ public class CpuEngine : ITensorLevelEngine
         ValidatePowerOfTwo(input.Length, nameof(input));
 
         int n = input.Length;
+#if NET5_0_OR_GREATER
+        if (typeof(T) == typeof(double))
+        {
+            // Reinterpret caller's output span as Span<Complex<double>> (layout-identical when T=double).
+            // Fill output directly with (input[i], 0), then run the in-place butterflies on it.
+            // Zero extra allocations, single write pass before FFT.
+            ref Complex<T> outHead = ref System.Runtime.InteropServices.MemoryMarshal.GetReference(output);
+            var outD = System.Runtime.InteropServices.MemoryMarshal.CreateSpan(
+                ref System.Runtime.CompilerServices.Unsafe.As<Complex<T>, Complex<double>>(ref outHead), n);
+            for (int i = 0; i < n; i++)
+            {
+                ref T src = ref System.Runtime.CompilerServices.Unsafe.AsRef(in input[i]);
+                outD[i] = new Complex<double>(System.Runtime.CompilerServices.Unsafe.As<T, double>(ref src), 0.0);
+            }
+            NativeFFTInPlaceDoubleSpan(outD, inverse: false);
+            return;
+        }
+        if (typeof(T) == typeof(float))
+        {
+            ref Complex<T> outHead = ref System.Runtime.InteropServices.MemoryMarshal.GetReference(output);
+            var outF = System.Runtime.InteropServices.MemoryMarshal.CreateSpan(
+                ref System.Runtime.CompilerServices.Unsafe.As<Complex<T>, Complex<float>>(ref outHead), n);
+            for (int i = 0; i < n; i++)
+            {
+                ref T src = ref System.Runtime.CompilerServices.Unsafe.AsRef(in input[i]);
+                outF[i] = new Complex<float>(System.Runtime.CompilerServices.Unsafe.As<T, float>(ref src), 0f);
+            }
+            NativeFFTInPlaceFloatSpan(outF, inverse: false);
+            return;
+        }
+#else
+        // net471 fallback: no MemoryMarshal.CreateSpan — use a scratch buffer.
         if (typeof(T) == typeof(double))
         {
             var buf = new Complex<double>[n];
@@ -27592,6 +27624,7 @@ public class CpuEngine : ITensorLevelEngine
                 output[i] = System.Runtime.CompilerServices.Unsafe.As<Complex<float>, Complex<T>>(ref buf[i]);
             return;
         }
+#endif
 
         // Generic fallback
         var ops = MathHelper.GetNumericOperations<T>();
@@ -27609,6 +27642,41 @@ public class CpuEngine : ITensorLevelEngine
         ValidatePowerOfTwo(input.Length, nameof(input));
 
         int n = input.Length;
+#if NET5_0_OR_GREATER
+        if (typeof(T) == typeof(double))
+        {
+            // Copy input into output (reinterpret as Complex<double>) then IFFT + scale in place.
+            ref Complex<T> head = ref System.Runtime.InteropServices.MemoryMarshal.GetReference(output);
+            var outD = System.Runtime.InteropServices.MemoryMarshal.CreateSpan(
+                ref System.Runtime.CompilerServices.Unsafe.As<Complex<T>, Complex<double>>(ref head), n);
+            for (int i = 0; i < n; i++)
+            {
+                ref Complex<T> src = ref System.Runtime.CompilerServices.Unsafe.AsRef(in input[i]);
+                outD[i] = System.Runtime.CompilerServices.Unsafe.As<Complex<T>, Complex<double>>(ref src);
+            }
+            NativeFFTInPlaceDoubleSpan(outD, inverse: true);
+            double scale = 1.0 / n;
+            for (int i = 0; i < n; i++)
+                outD[i] = new Complex<double>(outD[i].Real * scale, outD[i].Imaginary * scale);
+            return;
+        }
+        if (typeof(T) == typeof(float))
+        {
+            ref Complex<T> head = ref System.Runtime.InteropServices.MemoryMarshal.GetReference(output);
+            var outF = System.Runtime.InteropServices.MemoryMarshal.CreateSpan(
+                ref System.Runtime.CompilerServices.Unsafe.As<Complex<T>, Complex<float>>(ref head), n);
+            for (int i = 0; i < n; i++)
+            {
+                ref Complex<T> src = ref System.Runtime.CompilerServices.Unsafe.AsRef(in input[i]);
+                outF[i] = System.Runtime.CompilerServices.Unsafe.As<Complex<T>, Complex<float>>(ref src);
+            }
+            NativeFFTInPlaceFloatSpan(outF, inverse: true);
+            float scale = 1f / n;
+            for (int i = 0; i < n; i++)
+                outF[i] = new Complex<float>(outF[i].Real * scale, outF[i].Imaginary * scale);
+            return;
+        }
+#else
         if (typeof(T) == typeof(double))
         {
             var buf = new Complex<double>[n];
@@ -27643,6 +27711,7 @@ public class CpuEngine : ITensorLevelEngine
             }
             return;
         }
+#endif
 
         var ops = MathHelper.GetNumericOperations<T>();
         var arr = new Complex<T>[n];
@@ -27661,6 +27730,34 @@ public class CpuEngine : ITensorLevelEngine
         ValidatePowerOfTwo(input.Length, nameof(input));
 
         int n = input.Length;
+#if NET5_0_OR_GREATER
+        if (typeof(T) == typeof(double))
+        {
+            ref Complex<T> head = ref System.Runtime.InteropServices.MemoryMarshal.GetReference(output);
+            var outD = System.Runtime.InteropServices.MemoryMarshal.CreateSpan(
+                ref System.Runtime.CompilerServices.Unsafe.As<Complex<T>, Complex<double>>(ref head), n);
+            for (int i = 0; i < n; i++)
+            {
+                ref Complex<T> src = ref System.Runtime.CompilerServices.Unsafe.AsRef(in input[i]);
+                outD[i] = System.Runtime.CompilerServices.Unsafe.As<Complex<T>, Complex<double>>(ref src);
+            }
+            NativeFFTInPlaceDoubleSpan(outD, inverse: false);
+            return;
+        }
+        if (typeof(T) == typeof(float))
+        {
+            ref Complex<T> head = ref System.Runtime.InteropServices.MemoryMarshal.GetReference(output);
+            var outF = System.Runtime.InteropServices.MemoryMarshal.CreateSpan(
+                ref System.Runtime.CompilerServices.Unsafe.As<Complex<T>, Complex<float>>(ref head), n);
+            for (int i = 0; i < n; i++)
+            {
+                ref Complex<T> src = ref System.Runtime.CompilerServices.Unsafe.AsRef(in input[i]);
+                outF[i] = System.Runtime.CompilerServices.Unsafe.As<Complex<T>, Complex<float>>(ref src);
+            }
+            NativeFFTInPlaceFloatSpan(outF, inverse: false);
+            return;
+        }
+#else
         if (typeof(T) == typeof(double))
         {
             var buf = new Complex<double>[n];
@@ -27687,6 +27784,7 @@ public class CpuEngine : ITensorLevelEngine
                 output[i] = System.Runtime.CompilerServices.Unsafe.As<Complex<float>, Complex<T>>(ref buf[i]);
             return;
         }
+#endif
 
         var ops = MathHelper.GetNumericOperations<T>();
         var arr = new Complex<T>[n];
@@ -27751,6 +27849,14 @@ public class CpuEngine : ITensorLevelEngine
     public virtual Tensor<Complex<T>> NativeAnalyticSignal<T>(Tensor<T> input, double freqLow = 0.0, double freqHigh = double.MaxValue, double sampleRate = 1.0)
     {
         if (input is null) throw new ArgumentNullException(nameof(input));
+        if (!(sampleRate > 0.0) || double.IsNaN(sampleRate) || double.IsInfinity(sampleRate))
+            throw new ArgumentException($"sampleRate must be a positive finite value. Got {sampleRate}.", nameof(sampleRate));
+        if (double.IsNaN(freqLow) || freqLow < 0.0)
+            throw new ArgumentException($"freqLow must be a non-negative finite value. Got {freqLow}.", nameof(freqLow));
+        if (double.IsNaN(freqHigh))
+            throw new ArgumentException("freqHigh must not be NaN.", nameof(freqHigh));
+        if (freqHigh < freqLow)
+            throw new ArgumentException($"freqHigh ({freqHigh}) must be >= freqLow ({freqLow}).", nameof(freqHigh));
         var (batchCount, fftSize) = GetBatchedFFTDims(input._shape);
         ValidatePowerOfTwo(fftSize, nameof(input));
 
@@ -27831,9 +27937,41 @@ public class CpuEngine : ITensorLevelEngine
         int cols = input._shape[1];
         var result = inPlace ? input : new Tensor<T>(input._shape);
 
+#if NET5_0_OR_GREATER
         if (typeof(T) == typeof(double))
         {
-            // Reinterpret via Unsafe.As on each element — typeof check guarantees T=double
+            // Reinterpret the underlying DataVector spans as double spans (layout-identical when T=double).
+            // Zero allocations, zero copy passes — SIMD kernel reads/writes the tensor memory directly.
+            int n = rows * cols;
+            var srcData = input.DataVector.AsSpan();
+            var dstData = result.DataVector.AsWritableSpan();
+            ref T srcHead = ref System.Runtime.InteropServices.MemoryMarshal.GetReference(srcData);
+            ref T dstHead = ref System.Runtime.InteropServices.MemoryMarshal.GetReference(dstData);
+            var srcD = System.Runtime.InteropServices.MemoryMarshal.CreateReadOnlySpan(
+                ref System.Runtime.CompilerServices.Unsafe.As<T, double>(ref srcHead), n);
+            var dstD = System.Runtime.InteropServices.MemoryMarshal.CreateSpan(
+                ref System.Runtime.CompilerServices.Unsafe.As<T, double>(ref dstHead), n);
+            NormalizeRowsDouble(srcD, dstD, rows, cols);
+            return result;
+        }
+        if (typeof(T) == typeof(float))
+        {
+            int n = rows * cols;
+            var srcData = input.DataVector.AsSpan();
+            var dstData = result.DataVector.AsWritableSpan();
+            ref T srcHead = ref System.Runtime.InteropServices.MemoryMarshal.GetReference(srcData);
+            ref T dstHead = ref System.Runtime.InteropServices.MemoryMarshal.GetReference(dstData);
+            var srcF = System.Runtime.InteropServices.MemoryMarshal.CreateReadOnlySpan(
+                ref System.Runtime.CompilerServices.Unsafe.As<T, float>(ref srcHead), n);
+            var dstF = System.Runtime.InteropServices.MemoryMarshal.CreateSpan(
+                ref System.Runtime.CompilerServices.Unsafe.As<T, float>(ref dstHead), n);
+            NormalizeRowsFloat(srcF, dstF, rows, cols);
+            return result;
+        }
+#else
+        if (typeof(T) == typeof(double))
+        {
+            // net471 fallback: no MemoryMarshal.CreateSpan. Use temp buffer path.
             int n = rows * cols;
             var srcData = input.DataVector.AsSpan();
             var dstData = result.DataVector.AsWritableSpan();
@@ -27866,6 +28004,7 @@ public class CpuEngine : ITensorLevelEngine
                 dstData[i] = System.Runtime.CompilerServices.Unsafe.As<float, T>(ref dstF[i]);
             return result;
         }
+#endif
 
         // Generic fallback
         var ops = MathHelper.GetNumericOperations<T>();
@@ -28097,7 +28236,11 @@ public class CpuEngine : ITensorLevelEngine
                 ref T s = ref System.Runtime.CompilerServices.Unsafe.AsRef(in srcSpan[i]);
                 srcD[i] = System.Runtime.CompilerServices.Unsafe.As<T, double>(ref s);
             }
-            for (int i = 0; i < n; i++) dstD[i] = Math.Exp(srcD[i]);
+            unsafe
+            {
+                fixed (double* ip = srcD) fixed (double* op = dstD)
+                    Engines.Simd.SimdKernels.ExpUnsafe(ip, op, n);
+            }
             var dstSpan = result.DataVector.AsWritableSpan();
             for (int i = 0; i < n; i++)
                 dstSpan[i] = System.Runtime.CompilerServices.Unsafe.As<double, T>(ref dstD[i]);
@@ -28326,14 +28469,20 @@ public class CpuEngine : ITensorLevelEngine
     public virtual Tensor<T> NativeMfccFeatures<T>(Tensor<T> waveforms, int numSegments, int numMfcc, int paddedDim)
     {
         if (waveforms is null) throw new ArgumentNullException(nameof(waveforms));
-        if (numSegments <= 0) throw new ArgumentException("numSegments must be positive.");
-        if (numMfcc <= 0) throw new ArgumentException("numMfcc must be positive.");
+        if (waveforms.Rank != 1 && waveforms.Rank != 2)
+            throw new ArgumentException($"waveforms must be 1D [N] or 2D [batch, N]. Got rank {waveforms.Rank}.", nameof(waveforms));
+        if (numSegments <= 0) throw new ArgumentException("numSegments must be positive.", nameof(numSegments));
+        if (numMfcc <= 0) throw new ArgumentException("numMfcc must be positive.", nameof(numMfcc));
         ValidatePowerOfTwo(paddedDim, nameof(paddedDim));
 
         bool batched = waveforms.Rank == 2;
         int batch = batched ? waveforms._shape[0] : 1;
         int numSamples = batched ? waveforms._shape[1] : waveforms._shape[0];
         int segmentLen = numSamples / numSegments;
+        if (segmentLen <= 0)
+            throw new ArgumentException($"numSegments ({numSegments}) must not exceed signal length ({numSamples}).", nameof(numSegments));
+        if (paddedDim < segmentLen)
+            throw new ArgumentException($"paddedDim ({paddedDim}) must be >= segmentLen ({segmentLen}).", nameof(paddedDim));
 
         var outShape = batched ? new[] { batch, numSegments * numMfcc } : new[] { numSegments * numMfcc };
         var result = new Tensor<T>(outShape);
@@ -28394,12 +28543,17 @@ public class CpuEngine : ITensorLevelEngine
     public virtual Tensor<T> NativeWidebandFeatures<T>(Tensor<T> waveforms, int numSegments, int numBins)
     {
         if (waveforms is null) throw new ArgumentNullException(nameof(waveforms));
-        if (numSegments <= 0 || numBins <= 0) throw new ArgumentException("numSegments and numBins must be positive.");
+        if (waveforms.Rank != 1 && waveforms.Rank != 2)
+            throw new ArgumentException($"waveforms must be 1D [N] or 2D [batch, N]. Got rank {waveforms.Rank}.", nameof(waveforms));
+        if (numSegments <= 0) throw new ArgumentException("numSegments must be positive.", nameof(numSegments));
+        if (numBins <= 0) throw new ArgumentException("numBins must be positive.", nameof(numBins));
 
         bool batched = waveforms.Rank == 2;
         int batch = batched ? waveforms._shape[0] : 1;
         int numSamples = batched ? waveforms._shape[1] : waveforms._shape[0];
         int segmentLen = numSamples / numSegments;
+        if (segmentLen <= 1)
+            throw new ArgumentException($"numSegments ({numSegments}) produces segmentLen ({segmentLen}); must yield >= 2 samples per segment for a usable spectrum.", nameof(numSegments));
 
         // Pick FFT size as next power of 2 >= segmentLen
         int fftSize = 1;
@@ -28461,7 +28615,19 @@ public class CpuEngine : ITensorLevelEngine
         double thetaLow, double thetaHigh, (double low, double high)[] gammaBands)
     {
         if (waveforms is null) throw new ArgumentNullException(nameof(waveforms));
-        if (gammaBands is null || gammaBands.Length == 0) throw new ArgumentException("gammaBands must be non-empty.");
+        if (waveforms.Rank != 1 && waveforms.Rank != 2)
+            throw new ArgumentException($"waveforms must be 1D [N] or 2D [batch, N]. Got rank {waveforms.Rank}.", nameof(waveforms));
+        if (sampleRate <= 0) throw new ArgumentException("sampleRate must be positive.", nameof(sampleRate));
+        if (envelopeRate <= 0) throw new ArgumentException("envelopeRate must be positive.", nameof(envelopeRate));
+        if (gammaBands is null || gammaBands.Length == 0) throw new ArgumentException("gammaBands must be non-empty.", nameof(gammaBands));
+        if (!(thetaHigh > thetaLow) || thetaLow < 0.0 || double.IsNaN(thetaLow) || double.IsNaN(thetaHigh))
+            throw new ArgumentException($"theta band must satisfy 0 <= thetaLow < thetaHigh. Got [{thetaLow}, {thetaHigh}].");
+        for (int g = 0; g < gammaBands.Length; g++)
+        {
+            var (lo, hi) = gammaBands[g];
+            if (!(hi > lo) || lo < 0.0 || double.IsNaN(lo) || double.IsNaN(hi))
+                throw new ArgumentException($"gammaBands[{g}] must satisfy 0 <= low < high. Got [{lo}, {hi}].", nameof(gammaBands));
+        }
 
         bool batched = waveforms.Rank == 2;
         int batch = batched ? waveforms._shape[0] : 1;

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -27696,6 +27696,58 @@ public class CpuEngine : ITensorLevelEngine
     }
 
     /// <inheritdoc />
+    public virtual void NativeComplexIFFTRealSpan<T>(ReadOnlySpan<Complex<T>> input, Span<T> output)
+    {
+        if (input.Length != output.Length)
+            throw new ArgumentException($"Input length ({input.Length}) must equal output length ({output.Length}).");
+        ValidatePowerOfTwo(input.Length, nameof(input));
+
+        int n = input.Length;
+        if (typeof(T) == typeof(double))
+        {
+            var buf = new Complex<double>[n];
+            for (int i = 0; i < n; i++)
+            {
+                ref Complex<T> src = ref System.Runtime.CompilerServices.Unsafe.AsRef(in input[i]);
+                buf[i] = System.Runtime.CompilerServices.Unsafe.As<Complex<T>, Complex<double>>(ref src);
+            }
+            NativeFFTInPlaceDoubleSpan(buf, inverse: true);
+            double scale = 1.0 / n;
+            for (int i = 0; i < n; i++)
+            {
+                double r = buf[i].Real * scale;
+                output[i] = System.Runtime.CompilerServices.Unsafe.As<double, T>(ref r);
+            }
+            return;
+        }
+        if (typeof(T) == typeof(float))
+        {
+            var buf = new Complex<float>[n];
+            for (int i = 0; i < n; i++)
+            {
+                ref Complex<T> src = ref System.Runtime.CompilerServices.Unsafe.AsRef(in input[i]);
+                buf[i] = System.Runtime.CompilerServices.Unsafe.As<Complex<T>, Complex<float>>(ref src);
+            }
+            NativeFFTInPlaceFloatSpan(buf, inverse: true);
+            float scale = 1f / n;
+            for (int i = 0; i < n; i++)
+            {
+                float r = buf[i].Real * scale;
+                output[i] = System.Runtime.CompilerServices.Unsafe.As<float, T>(ref r);
+            }
+            return;
+        }
+
+        var opsG = MathHelper.GetNumericOperations<T>();
+        var arrG = new Complex<T>[n];
+        for (int i = 0; i < n; i++) arrG[i] = input[i];
+        NativeFFTInPlace(arrG, true, opsG);
+        var scaleT = opsG.FromDouble(n);
+        for (int i = 0; i < n; i++)
+            output[i] = opsG.Divide(arrG[i].Real, scaleT);
+    }
+
+    /// <inheritdoc />
     public virtual Tensor<Complex<T>> NativeAnalyticSignal<T>(Tensor<T> input, double freqLow = 0.0, double freqHigh = double.MaxValue, double sampleRate = 1.0)
     {
         if (input is null) throw new ArgumentNullException(nameof(input));
@@ -27770,14 +27822,14 @@ public class CpuEngine : ITensorLevelEngine
     }
 
     /// <inheritdoc />
-    public virtual Tensor<T> NativeNormalizeRows<T>(Tensor<T> input)
+    public virtual Tensor<T> NativeNormalizeRows<T>(Tensor<T> input, bool inPlace = false)
     {
         if (input is null) throw new ArgumentNullException(nameof(input));
         if (input.Rank != 2) throw new ArgumentException($"NativeNormalizeRows requires a 2D tensor. Got rank {input.Rank}.", nameof(input));
 
         int rows = input._shape[0];
         int cols = input._shape[1];
-        var result = new Tensor<T>(input._shape);
+        var result = inPlace ? input : new Tensor<T>(input._shape);
 
         if (typeof(T) == typeof(double))
         {

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -27963,6 +27963,609 @@ public class CpuEngine : ITensorLevelEngine
     }
 
     /// <inheritdoc />
+    public virtual Tensor<T> NativeTanh<T>(Tensor<T> input)
+    {
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        var result = new Tensor<T>(input._shape);
+        int n = input.Length;
+
+        if (typeof(T) == typeof(double))
+        {
+            var srcD = new double[n];
+            var dstD = new double[n];
+            var srcSpan = input.DataVector.AsSpan();
+            for (int i = 0; i < n; i++)
+            {
+                ref T s = ref System.Runtime.CompilerServices.Unsafe.AsRef(in srcSpan[i]);
+                srcD[i] = System.Runtime.CompilerServices.Unsafe.As<T, double>(ref s);
+            }
+            Engines.Simd.SimdKernels.Tanh(srcD, dstD);
+            var dstSpan = result.DataVector.AsWritableSpan();
+            for (int i = 0; i < n; i++)
+                dstSpan[i] = System.Runtime.CompilerServices.Unsafe.As<double, T>(ref dstD[i]);
+            return result;
+        }
+        if (typeof(T) == typeof(float))
+        {
+            var srcF = new float[n];
+            var dstF = new float[n];
+            var srcSpan = input.DataVector.AsSpan();
+            for (int i = 0; i < n; i++)
+            {
+                ref T s = ref System.Runtime.CompilerServices.Unsafe.AsRef(in srcSpan[i]);
+                srcF[i] = System.Runtime.CompilerServices.Unsafe.As<T, float>(ref s);
+            }
+            Engines.Simd.SimdKernels.Tanh(srcF, dstF);
+            var dstSpan = result.DataVector.AsWritableSpan();
+            for (int i = 0; i < n; i++)
+                dstSpan[i] = System.Runtime.CompilerServices.Unsafe.As<float, T>(ref dstF[i]);
+            return result;
+        }
+
+        var ops = MathHelper.GetNumericOperations<T>();
+        for (int i = 0; i < n; i++)
+            result[i] = ops.FromDouble(Math.Tanh(ops.ToDouble(input[i])));
+        return result;
+    }
+
+    /// <inheritdoc />
+    public virtual Tensor<T> NativeExp<T>(Tensor<T> input)
+    {
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        var result = new Tensor<T>(input._shape);
+        int n = input.Length;
+
+        if (typeof(T) == typeof(float))
+        {
+            var srcF = new float[n];
+            var dstF = new float[n];
+            var srcSpan = input.DataVector.AsSpan();
+            for (int i = 0; i < n; i++)
+            {
+                ref T s = ref System.Runtime.CompilerServices.Unsafe.AsRef(in srcSpan[i]);
+                srcF[i] = System.Runtime.CompilerServices.Unsafe.As<T, float>(ref s);
+            }
+            unsafe
+            {
+                fixed (float* ip = srcF) fixed (float* op = dstF)
+                    Engines.Simd.SimdKernels.ExpUnsafe(ip, op, n);
+            }
+            var dstSpan = result.DataVector.AsWritableSpan();
+            for (int i = 0; i < n; i++)
+                dstSpan[i] = System.Runtime.CompilerServices.Unsafe.As<float, T>(ref dstF[i]);
+            return result;
+        }
+        if (typeof(T) == typeof(double))
+        {
+            var srcD = new double[n];
+            var dstD = new double[n];
+            var srcSpan = input.DataVector.AsSpan();
+            for (int i = 0; i < n; i++)
+            {
+                ref T s = ref System.Runtime.CompilerServices.Unsafe.AsRef(in srcSpan[i]);
+                srcD[i] = System.Runtime.CompilerServices.Unsafe.As<T, double>(ref s);
+            }
+            for (int i = 0; i < n; i++) dstD[i] = Math.Exp(srcD[i]);
+            var dstSpan = result.DataVector.AsWritableSpan();
+            for (int i = 0; i < n; i++)
+                dstSpan[i] = System.Runtime.CompilerServices.Unsafe.As<double, T>(ref dstD[i]);
+            return result;
+        }
+
+        var ops = MathHelper.GetNumericOperations<T>();
+        for (int i = 0; i < n; i++)
+            result[i] = ops.FromDouble(Math.Exp(ops.ToDouble(input[i])));
+        return result;
+    }
+
+    /// <inheritdoc />
+    public virtual Tensor<T> NativeAtan2<T>(Tensor<T> imag, Tensor<T> real)
+    {
+        if (imag is null) throw new ArgumentNullException(nameof(imag));
+        if (real is null) throw new ArgumentNullException(nameof(real));
+        if (imag.Length != real.Length) throw new ArgumentException("imag and real must have same length.");
+        var result = new Tensor<T>(imag._shape);
+        int n = imag.Length;
+
+        if (typeof(T) == typeof(double))
+        {
+            var iSpan = imag.DataVector.AsSpan();
+            var rSpan = real.DataVector.AsSpan();
+            var dstSpan = result.DataVector.AsWritableSpan();
+            for (int i = 0; i < n; i++)
+            {
+                ref T iRef = ref System.Runtime.CompilerServices.Unsafe.AsRef(in iSpan[i]);
+                ref T rRef = ref System.Runtime.CompilerServices.Unsafe.AsRef(in rSpan[i]);
+                double iv = System.Runtime.CompilerServices.Unsafe.As<T, double>(ref iRef);
+                double rv = System.Runtime.CompilerServices.Unsafe.As<T, double>(ref rRef);
+                double atan = Math.Atan2(iv, rv);
+                dstSpan[i] = System.Runtime.CompilerServices.Unsafe.As<double, T>(ref atan);
+            }
+            return result;
+        }
+        if (typeof(T) == typeof(float))
+        {
+            var iSpan = imag.DataVector.AsSpan();
+            var rSpan = real.DataVector.AsSpan();
+            var dstSpan = result.DataVector.AsWritableSpan();
+            for (int i = 0; i < n; i++)
+            {
+                ref T iRef = ref System.Runtime.CompilerServices.Unsafe.AsRef(in iSpan[i]);
+                ref T rRef = ref System.Runtime.CompilerServices.Unsafe.AsRef(in rSpan[i]);
+                float iv = System.Runtime.CompilerServices.Unsafe.As<T, float>(ref iRef);
+                float rv = System.Runtime.CompilerServices.Unsafe.As<T, float>(ref rRef);
+                float atan = MathF.Atan2(iv, rv);
+                dstSpan[i] = System.Runtime.CompilerServices.Unsafe.As<float, T>(ref atan);
+            }
+            return result;
+        }
+
+        var ops = MathHelper.GetNumericOperations<T>();
+        for (int i = 0; i < n; i++)
+            result[i] = ops.FromDouble(Math.Atan2(ops.ToDouble(imag[i]), ops.ToDouble(real[i])));
+        return result;
+    }
+
+    /// <inheritdoc />
+    public virtual Tensor<T> NativeMagnitudeAndPhase<T>(Tensor<Complex<T>> input, out Tensor<T> phase)
+    {
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        var magnitude = new Tensor<T>(input._shape);
+        phase = new Tensor<T>(input._shape);
+        int n = input.Length;
+        var ops = MathHelper.GetNumericOperations<T>();
+        for (int i = 0; i < n; i++)
+        {
+            var c = input[i];
+            magnitude[i] = ops.Sqrt(ops.Add(ops.Multiply(c.Real, c.Real), ops.Multiply(c.Imaginary, c.Imaginary)));
+            phase[i] = ops.FromDouble(Math.Atan2(ops.ToDouble(c.Imaginary), ops.ToDouble(c.Real)));
+        }
+        return magnitude;
+    }
+
+    /// <inheritdoc />
+    public virtual Tensor<Complex<T>> NativeBispectrum<T>(Tensor<Complex<T>> spectrum, int maxF1, int maxF2)
+    {
+        if (spectrum is null) throw new ArgumentNullException(nameof(spectrum));
+        if (spectrum.Rank != 1) throw new ArgumentException("Spectrum must be 1D.", nameof(spectrum));
+        int n = spectrum.Length;
+        if (maxF1 <= 0 || maxF2 <= 0) throw new ArgumentException("maxF1 and maxF2 must be positive.");
+        if (maxF1 + maxF2 > n) throw new ArgumentException("maxF1 + maxF2 must not exceed spectrum length.");
+
+        var result = new Tensor<Complex<T>>([maxF1, maxF2]);
+        var ops = MathHelper.GetNumericOperations<T>();
+
+        // B(f1, f2) = X(f1) * X(f2) * conj(X(f1+f2))
+        System.Threading.Tasks.Parallel.For(0, maxF1, f1 =>
+        {
+            for (int f2 = 0; f2 < maxF2; f2++)
+            {
+                var xf1 = spectrum[f1];
+                var xf2 = spectrum[f2];
+                var xf1f2 = spectrum[f1 + f2];
+                var xf1f2conj = new Complex<T>(xf1f2.Real, ops.Negate(xf1f2.Imaginary));
+
+                // X(f1) * X(f2)
+                var t1Re = ops.Subtract(ops.Multiply(xf1.Real, xf2.Real), ops.Multiply(xf1.Imaginary, xf2.Imaginary));
+                var t1Im = ops.Add(ops.Multiply(xf1.Real, xf2.Imaginary), ops.Multiply(xf1.Imaginary, xf2.Real));
+
+                // * conj(X(f1+f2))
+                var bRe = ops.Subtract(ops.Multiply(t1Re, xf1f2conj.Real), ops.Multiply(t1Im, xf1f2conj.Imaginary));
+                var bIm = ops.Add(ops.Multiply(t1Re, xf1f2conj.Imaginary), ops.Multiply(t1Im, xf1f2conj.Real));
+
+                result[f1 * maxF2 + f2] = new Complex<T>(bRe, bIm);
+            }
+        });
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    public virtual Tensor<Complex<T>> NativeTrispectrum<T>(Tensor<Complex<T>> spectrum, int maxF1, int maxF2, int maxF3)
+    {
+        if (spectrum is null) throw new ArgumentNullException(nameof(spectrum));
+        if (spectrum.Rank != 1) throw new ArgumentException("Spectrum must be 1D.", nameof(spectrum));
+        int n = spectrum.Length;
+        if (maxF1 <= 0 || maxF2 <= 0 || maxF3 <= 0) throw new ArgumentException("All maxF values must be positive.");
+        if (maxF1 + maxF2 + maxF3 > n) throw new ArgumentException("maxF1+maxF2+maxF3 must not exceed spectrum length.");
+
+        var result = new Tensor<Complex<T>>([maxF1, maxF2, maxF3]);
+        var ops = MathHelper.GetNumericOperations<T>();
+
+        System.Threading.Tasks.Parallel.For(0, maxF1, f1 =>
+        {
+            for (int f2 = 0; f2 < maxF2; f2++)
+            {
+                for (int f3 = 0; f3 < maxF3; f3++)
+                {
+                    var xf1 = spectrum[f1];
+                    var xf2 = spectrum[f2];
+                    var xf3 = spectrum[f3];
+                    var xsum = spectrum[f1 + f2 + f3];
+                    var xsumConj = new Complex<T>(xsum.Real, ops.Negate(xsum.Imaginary));
+
+                    // X(f1)*X(f2)
+                    var t1Re = ops.Subtract(ops.Multiply(xf1.Real, xf2.Real), ops.Multiply(xf1.Imaginary, xf2.Imaginary));
+                    var t1Im = ops.Add(ops.Multiply(xf1.Real, xf2.Imaginary), ops.Multiply(xf1.Imaginary, xf2.Real));
+                    // *X(f3)
+                    var t2Re = ops.Subtract(ops.Multiply(t1Re, xf3.Real), ops.Multiply(t1Im, xf3.Imaginary));
+                    var t2Im = ops.Add(ops.Multiply(t1Re, xf3.Imaginary), ops.Multiply(t1Im, xf3.Real));
+                    // *conj(X(f1+f2+f3))
+                    var tRe = ops.Subtract(ops.Multiply(t2Re, xsumConj.Real), ops.Multiply(t2Im, xsumConj.Imaginary));
+                    var tIm = ops.Add(ops.Multiply(t2Re, xsumConj.Imaginary), ops.Multiply(t2Im, xsumConj.Real));
+
+                    result[(f1 * maxF2 + f2) * maxF3 + f3] = new Complex<T>(tRe, tIm);
+                }
+            }
+        });
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    public virtual Tensor<T> NativeBatchedCavityForward<T>(Tensor<T> input, Tensor<Complex<T>> cavityFilters, int numBounces)
+    {
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (cavityFilters is null) throw new ArgumentNullException(nameof(cavityFilters));
+        if (input.Rank != 2) throw new ArgumentException("input must be [batch, N].", nameof(input));
+        if (cavityFilters.Rank != 2) throw new ArgumentException("cavityFilters must be [numCavities, N].", nameof(cavityFilters));
+        if (numBounces < 1) throw new ArgumentException("numBounces must be >= 1.");
+
+        int batch = input._shape[0];
+        int n = input._shape[1];
+        int numCavities = cavityFilters._shape[0];
+        if (cavityFilters._shape[1] != n) throw new ArgumentException("cavityFilters last dim must match input N.");
+        ValidatePowerOfTwo(n, nameof(input));
+
+        var result = new Tensor<T>([batch, numCavities, n]);
+        var ops = MathHelper.GetNumericOperations<T>();
+
+        // Per batch: FFT once, then per cavity, per bounce: multiply in freq domain → IFFT → tanh → FFT again
+        System.Threading.Tasks.Parallel.For(0, batch, b =>
+        {
+            var inSlice = new T[n];
+            for (int i = 0; i < n; i++) inSlice[i] = input[b * n + i];
+
+            // Compute the initial spectrum of this waveform
+            var spectrum0 = new Complex<T>[n];
+            for (int i = 0; i < n; i++) spectrum0[i] = new Complex<T>(inSlice[i], ops.Zero);
+            NativeFFTInPlace(spectrum0, false, ops);
+
+            var work = new Complex<T>[n];
+            for (int c = 0; c < numCavities; c++)
+            {
+                // Reset working spectrum from initial
+                Array.Copy(spectrum0, work, n);
+                for (int bounce = 0; bounce < numBounces; bounce++)
+                {
+                    // Multiply by cavity filter in frequency domain
+                    for (int i = 0; i < n; i++)
+                    {
+                        var f = cavityFilters[c * n + i];
+                        var aRe = work[i].Real; var aIm = work[i].Imaginary;
+                        var bRe = f.Real; var bIm = f.Imaginary;
+                        work[i] = new Complex<T>(
+                            ops.Subtract(ops.Multiply(aRe, bRe), ops.Multiply(aIm, bIm)),
+                            ops.Add(ops.Multiply(aRe, bIm), ops.Multiply(aIm, bRe)));
+                    }
+                    // IFFT → tanh → FFT for next bounce (if any)
+                    NativeFFTInPlace(work, true, ops);
+                    var scale = ops.FromDouble(n);
+                    for (int i = 0; i < n; i++)
+                    {
+                        double rv = ops.ToDouble(ops.Divide(work[i].Real, scale));
+                        work[i] = new Complex<T>(ops.FromDouble(Math.Tanh(rv)), ops.Zero);
+                    }
+                    if (bounce < numBounces - 1)
+                        NativeFFTInPlace(work, false, ops);
+                }
+
+                // Final output = real part of the time-domain result (already time-domain after tanh)
+                int outOff = (b * numCavities + c) * n;
+                for (int i = 0; i < n; i++)
+                    result[outOff + i] = work[i].Real;
+            }
+        });
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    public virtual Tensor<T> NativeMfccFeatures<T>(Tensor<T> waveforms, int numSegments, int numMfcc, int paddedDim)
+    {
+        if (waveforms is null) throw new ArgumentNullException(nameof(waveforms));
+        if (numSegments <= 0) throw new ArgumentException("numSegments must be positive.");
+        if (numMfcc <= 0) throw new ArgumentException("numMfcc must be positive.");
+        ValidatePowerOfTwo(paddedDim, nameof(paddedDim));
+
+        bool batched = waveforms.Rank == 2;
+        int batch = batched ? waveforms._shape[0] : 1;
+        int numSamples = batched ? waveforms._shape[1] : waveforms._shape[0];
+        int segmentLen = numSamples / numSegments;
+
+        var outShape = batched ? new[] { batch, numSegments * numMfcc } : new[] { numSegments * numMfcc };
+        var result = new Tensor<T>(outShape);
+        var ops = MathHelper.GetNumericOperations<T>();
+
+        System.Threading.Tasks.Parallel.For(0, batch, b =>
+        {
+            int melBins = Math.Max(numMfcc * 2, 16);
+            var dctBasis = BuildDctBasis<T>(numMfcc, melBins);
+            var melFilters = BuildMelFilterbank<T>(melBins, paddedDim / 2 + 1);
+
+            var seg = new Complex<T>[paddedDim];
+            var powerSpec = new T[paddedDim / 2 + 1];
+            var melEnergy = new T[melBins];
+
+            for (int s = 0; s < numSegments; s++)
+            {
+                int start = s * segmentLen;
+                // Zero-pad into FFT buffer
+                for (int i = 0; i < paddedDim; i++)
+                {
+                    if (i < segmentLen && start + i < numSamples)
+                    {
+                        int idx = batched ? (b * numSamples + start + i) : (start + i);
+                        seg[i] = new Complex<T>(waveforms[idx], ops.Zero);
+                    }
+                    else seg[i] = new Complex<T>(ops.Zero, ops.Zero);
+                }
+                NativeFFTInPlace(seg, false, ops);
+                // Power spectrum (only first half)
+                for (int i = 0; i < paddedDim / 2 + 1; i++)
+                    powerSpec[i] = ops.Add(ops.Multiply(seg[i].Real, seg[i].Real), ops.Multiply(seg[i].Imaginary, seg[i].Imaginary));
+                // Mel filterbank
+                for (int m = 0; m < melBins; m++)
+                {
+                    var e = ops.Zero;
+                    for (int i = 0; i < paddedDim / 2 + 1; i++)
+                        e = ops.Add(e, ops.Multiply(melFilters[m * (paddedDim / 2 + 1) + i], powerSpec[i]));
+                    // Log-compression (log(1 + e))
+                    melEnergy[m] = ops.FromDouble(Math.Log(1.0 + ops.ToDouble(e)));
+                }
+                // DCT
+                for (int k = 0; k < numMfcc; k++)
+                {
+                    var sum = ops.Zero;
+                    for (int m = 0; m < melBins; m++)
+                        sum = ops.Add(sum, ops.Multiply(dctBasis[k * melBins + m], melEnergy[m]));
+                    int outOff = batched ? (b * numSegments * numMfcc + s * numMfcc + k) : (s * numMfcc + k);
+                    result[outOff] = sum;
+                }
+            }
+        });
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    public virtual Tensor<T> NativeWidebandFeatures<T>(Tensor<T> waveforms, int numSegments, int numBins)
+    {
+        if (waveforms is null) throw new ArgumentNullException(nameof(waveforms));
+        if (numSegments <= 0 || numBins <= 0) throw new ArgumentException("numSegments and numBins must be positive.");
+
+        bool batched = waveforms.Rank == 2;
+        int batch = batched ? waveforms._shape[0] : 1;
+        int numSamples = batched ? waveforms._shape[1] : waveforms._shape[0];
+        int segmentLen = numSamples / numSegments;
+
+        // Pick FFT size as next power of 2 >= segmentLen
+        int fftSize = 1;
+        while (fftSize < segmentLen) fftSize <<= 1;
+
+        var outShape = batched ? new[] { batch, numSegments * numBins } : new[] { numSegments * numBins };
+        var result = new Tensor<T>(outShape);
+        var ops = MathHelper.GetNumericOperations<T>();
+
+        System.Threading.Tasks.Parallel.For(0, batch, b =>
+        {
+            var buf = new Complex<T>[fftSize];
+            for (int s = 0; s < numSegments; s++)
+            {
+                int start = s * segmentLen;
+                for (int i = 0; i < fftSize; i++)
+                {
+                    if (i < segmentLen && start + i < numSamples)
+                    {
+                        int idx = batched ? (b * numSamples + start + i) : (start + i);
+                        buf[i] = new Complex<T>(waveforms[idx], ops.Zero);
+                    }
+                    else buf[i] = new Complex<T>(ops.Zero, ops.Zero);
+                }
+                NativeFFTInPlace(buf, false, ops);
+
+                // Average magnitudes into numBins logarithmically-spaced bins over [1, fftSize/2]
+                int usable = fftSize / 2;
+                for (int k = 0; k < numBins; k++)
+                {
+                    int binStart = 1 + (int)(Math.Pow((double)k / numBins, 2) * (usable - 1));
+                    int binEnd = 1 + (int)(Math.Pow((double)(k + 1) / numBins, 2) * (usable - 1));
+                    if (binEnd <= binStart) binEnd = binStart + 1;
+                    if (binEnd > usable) binEnd = usable;
+
+                    var sum = ops.Zero;
+                    int count = 0;
+                    for (int i = binStart; i < binEnd; i++)
+                    {
+                        var mag = ops.Sqrt(ops.Add(ops.Multiply(buf[i].Real, buf[i].Real), ops.Multiply(buf[i].Imaginary, buf[i].Imaginary)));
+                        sum = ops.Add(sum, mag);
+                        count++;
+                    }
+                    var avg = count > 0 ? ops.Divide(sum, ops.FromDouble(count)) : ops.Zero;
+                    // log-compress
+                    var logVal = ops.FromDouble(Math.Log(1.0 + ops.ToDouble(avg)));
+
+                    int outOff = batched ? (b * numSegments * numBins + s * numBins + k) : (s * numBins + k);
+                    result[outOff] = logVal;
+                }
+            }
+        });
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    public virtual Tensor<T> NativePacFeatures<T>(Tensor<T> waveforms, int sampleRate, int envelopeRate,
+        double thetaLow, double thetaHigh, (double low, double high)[] gammaBands)
+    {
+        if (waveforms is null) throw new ArgumentNullException(nameof(waveforms));
+        if (gammaBands is null || gammaBands.Length == 0) throw new ArgumentException("gammaBands must be non-empty.");
+
+        bool batched = waveforms.Rank == 2;
+        int batch = batched ? waveforms._shape[0] : 1;
+        int numSamples = batched ? waveforms._shape[1] : waveforms._shape[0];
+
+        // FFT size = next power of 2 >= numSamples
+        int fftSize = 1;
+        while (fftSize < numSamples) fftSize <<= 1;
+
+        int numBands = gammaBands.Length;
+        var outShape = batched ? new[] { batch, numBands } : new[] { numBands };
+        var result = new Tensor<T>(outShape);
+        var ops = MathHelper.GetNumericOperations<T>();
+
+        System.Threading.Tasks.Parallel.For(0, batch, b =>
+        {
+            // Compute theta phase via analytic signal on theta band
+            var wave = new T[fftSize];
+            for (int i = 0; i < numSamples; i++)
+            {
+                int idx = batched ? (b * numSamples + i) : i;
+                wave[i] = waveforms[idx];
+            }
+            for (int i = numSamples; i < fftSize; i++) wave[i] = ops.Zero;
+
+            var thetaAnalytic = AnalyticSignalSpan(wave, thetaLow, thetaHigh, sampleRate, fftSize, ops);
+            var thetaPhase = new double[numSamples];
+            for (int i = 0; i < numSamples; i++)
+                thetaPhase[i] = Math.Atan2(ops.ToDouble(thetaAnalytic[i].Imaginary), ops.ToDouble(thetaAnalytic[i].Real));
+
+            for (int g = 0; g < numBands; g++)
+            {
+                var gammaAnalytic = AnalyticSignalSpan(wave, gammaBands[g].low, gammaBands[g].high, sampleRate, fftSize, ops);
+                // Gamma envelope (magnitude)
+                var gammaAmp = new double[numSamples];
+                for (int i = 0; i < numSamples; i++)
+                {
+                    double re = ops.ToDouble(gammaAnalytic[i].Real);
+                    double im = ops.ToDouble(gammaAnalytic[i].Imaginary);
+                    gammaAmp[i] = Math.Sqrt(re * re + im * im);
+                }
+
+                // PAC modulation index via phase-binned amplitude distribution
+                const int numPhaseBins = 18;
+                double[] binSum = new double[numPhaseBins];
+                int[] binCount = new int[numPhaseBins];
+                for (int i = 0; i < numSamples; i++)
+                {
+                    int binIdx = (int)((thetaPhase[i] + Math.PI) / (2 * Math.PI) * numPhaseBins);
+                    if (binIdx < 0) binIdx = 0;
+                    if (binIdx >= numPhaseBins) binIdx = numPhaseBins - 1;
+                    binSum[binIdx] += gammaAmp[i];
+                    binCount[binIdx]++;
+                }
+                double totalAmp = 0;
+                for (int k = 0; k < numPhaseBins; k++)
+                    totalAmp += binCount[k] > 0 ? binSum[k] / binCount[k] : 0;
+
+                // Kullback-Leibler MI
+                double mi = 0;
+                if (totalAmp > 0)
+                {
+                    double entropy = 0;
+                    for (int k = 0; k < numPhaseBins; k++)
+                    {
+                        double p = binCount[k] > 0 ? (binSum[k] / binCount[k]) / totalAmp : 0;
+                        if (p > 1e-12) entropy -= p * Math.Log(p);
+                    }
+                    mi = (Math.Log(numPhaseBins) - entropy) / Math.Log(numPhaseBins);
+                }
+
+                int outOff = batched ? (b * numBands + g) : g;
+                result[outOff] = ops.FromDouble(mi);
+            }
+        });
+
+        return result;
+    }
+
+    // Internal helper: analytic signal on a raw array (used by PAC pipeline)
+    private static Complex<T>[] AnalyticSignalSpan<T>(T[] wave, double freqLow, double freqHigh, double sampleRate, int fftSize, INumericOperations<T> ops)
+    {
+        var buf = new Complex<T>[fftSize];
+        for (int i = 0; i < fftSize; i++) buf[i] = new Complex<T>(i < wave.Length ? wave[i] : ops.Zero, ops.Zero);
+        NativeFFTInPlace(buf, false, ops);
+
+        int halfN = fftSize / 2;
+        int binLow = freqLow <= 0 ? 0 : (int)Math.Ceiling(freqLow * fftSize / sampleRate);
+        int binHigh = double.IsPositiveInfinity(freqHigh) || freqHigh >= sampleRate * 0.5
+            ? halfN + 1 : Math.Min(halfN + 1, (int)Math.Ceiling(freqHigh * fftSize / sampleRate));
+
+        var two = ops.FromDouble(2.0);
+        for (int k = 0; k < fftSize; k++)
+        {
+            if (k == 0 || k == halfN)
+            {
+                if (k < binLow || k >= binHigh) buf[k] = new Complex<T>(ops.Zero, ops.Zero);
+            }
+            else if (k < halfN)
+            {
+                if (k < binLow || k >= binHigh)
+                    buf[k] = new Complex<T>(ops.Zero, ops.Zero);
+                else
+                    buf[k] = new Complex<T>(ops.Multiply(buf[k].Real, two), ops.Multiply(buf[k].Imaginary, two));
+            }
+            else
+            {
+                buf[k] = new Complex<T>(ops.Zero, ops.Zero);
+            }
+        }
+        NativeFFTInPlace(buf, true, ops);
+        var scale = ops.FromDouble(fftSize);
+        for (int i = 0; i < fftSize; i++)
+            buf[i] = new Complex<T>(ops.Divide(buf[i].Real, scale), ops.Divide(buf[i].Imaginary, scale));
+        return buf;
+    }
+
+    // Build a simple triangular mel filterbank — numFilters x numFftBins
+    private static T[] BuildMelFilterbank<T>(int numFilters, int numFftBins)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        var result = new T[numFilters * numFftBins];
+        // Uniform triangular bins (placeholder — full mel scaling would need sample rate)
+        double step = (double)numFftBins / (numFilters + 1);
+        for (int m = 0; m < numFilters; m++)
+        {
+            int center = (int)((m + 1) * step);
+            int left = (int)(m * step);
+            int right = (int)((m + 2) * step);
+            if (right > numFftBins) right = numFftBins;
+            for (int i = left; i < center; i++)
+                result[m * numFftBins + i] = ops.FromDouble((double)(i - left) / Math.Max(1, center - left));
+            for (int i = center; i < right; i++)
+                result[m * numFftBins + i] = ops.FromDouble((double)(right - i) / Math.Max(1, right - center));
+        }
+        return result;
+    }
+
+    // Build DCT-II basis: numCoeffs x numInputs
+    private static T[] BuildDctBasis<T>(int numCoeffs, int numInputs)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        var result = new T[numCoeffs * numInputs];
+        double norm = Math.Sqrt(2.0 / numInputs);
+        for (int k = 0; k < numCoeffs; k++)
+        {
+            for (int n = 0; n < numInputs; n++)
+            {
+                double val = norm * Math.Cos(Math.PI * k * (2 * n + 1) / (2 * numInputs));
+                result[k * numInputs + n] = ops.FromDouble(val);
+            }
+        }
+        return result;
+    }
+
+    /// <inheritdoc />
     public virtual Tensor<T> NativeComplexIFFTReal<T>(Tensor<Complex<T>> input)
     {
         if (input is null) throw new ArgumentNullException(nameof(input));

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -28325,7 +28325,9 @@ public class CpuEngine : ITensorLevelEngine
         if (spectrum.Rank != 1) throw new ArgumentException("Spectrum must be 1D.", nameof(spectrum));
         int n = spectrum.Length;
         if (maxF1 <= 0 || maxF2 <= 0) throw new ArgumentException("maxF1 and maxF2 must be positive.");
-        if (maxF1 + maxF2 > n) throw new ArgumentException("maxF1 + maxF2 must not exceed spectrum length.");
+        // The bispectrum indexes spectrum[f1 + f2] with f1 in [0, maxF1), f2 in [0, maxF2);
+        // the maximum accessed index is (maxF1 - 1) + (maxF2 - 1), which must be < n.
+        if (maxF1 + maxF2 - 1 > n) throw new ArgumentException($"maxF1 ({maxF1}) + maxF2 ({maxF2}) - 1 must not exceed spectrum length ({n}).");
 
         var result = new Tensor<Complex<T>>([maxF1, maxF2]);
         var ops = MathHelper.GetNumericOperations<T>();
@@ -28362,7 +28364,9 @@ public class CpuEngine : ITensorLevelEngine
         if (spectrum.Rank != 1) throw new ArgumentException("Spectrum must be 1D.", nameof(spectrum));
         int n = spectrum.Length;
         if (maxF1 <= 0 || maxF2 <= 0 || maxF3 <= 0) throw new ArgumentException("All maxF values must be positive.");
-        if (maxF1 + maxF2 + maxF3 > n) throw new ArgumentException("maxF1+maxF2+maxF3 must not exceed spectrum length.");
+        // The trispectrum indexes spectrum[f1 + f2 + f3] with f_i in [0, maxF_i);
+        // the maximum accessed index is (maxF1 - 1) + (maxF2 - 1) + (maxF3 - 1), which must be < n.
+        if (maxF1 + maxF2 + maxF3 - 2 > n) throw new ArgumentException($"maxF1 ({maxF1}) + maxF2 ({maxF2}) + maxF3 ({maxF3}) - 2 must not exceed spectrum length ({n}).");
 
         var result = new Tensor<Complex<T>>([maxF1, maxF2, maxF3]);
         var ops = MathHelper.GetNumericOperations<T>();

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -27559,6 +27559,410 @@ public class CpuEngine : ITensorLevelEngine
     }
 
     /// <inheritdoc />
+    public virtual void NativeComplexFFTSpan<T>(ReadOnlySpan<T> input, Span<Complex<T>> output)
+    {
+        if (input.Length != output.Length)
+            throw new ArgumentException($"Input length ({input.Length}) must equal output length ({output.Length}).");
+        ValidatePowerOfTwo(input.Length, nameof(input));
+
+        int n = input.Length;
+        if (typeof(T) == typeof(double))
+        {
+            var buf = new Complex<double>[n];
+            for (int i = 0; i < n; i++)
+            {
+                ref T src = ref System.Runtime.CompilerServices.Unsafe.AsRef(in input[i]);
+                buf[i] = new Complex<double>(System.Runtime.CompilerServices.Unsafe.As<T, double>(ref src), 0.0);
+            }
+            NativeFFTInPlaceDoubleSpan(buf, inverse: false);
+            for (int i = 0; i < n; i++)
+                output[i] = System.Runtime.CompilerServices.Unsafe.As<Complex<double>, Complex<T>>(ref buf[i]);
+            return;
+        }
+        if (typeof(T) == typeof(float))
+        {
+            var buf = new Complex<float>[n];
+            for (int i = 0; i < n; i++)
+            {
+                ref T src = ref System.Runtime.CompilerServices.Unsafe.AsRef(in input[i]);
+                buf[i] = new Complex<float>(System.Runtime.CompilerServices.Unsafe.As<T, float>(ref src), 0f);
+            }
+            NativeFFTInPlaceFloatSpan(buf, inverse: false);
+            for (int i = 0; i < n; i++)
+                output[i] = System.Runtime.CompilerServices.Unsafe.As<Complex<float>, Complex<T>>(ref buf[i]);
+            return;
+        }
+
+        // Generic fallback
+        var ops = MathHelper.GetNumericOperations<T>();
+        var arr = new Complex<T>[n];
+        for (int i = 0; i < n; i++) arr[i] = new Complex<T>(input[i], ops.Zero);
+        NativeFFTInPlace(arr, false, ops);
+        for (int i = 0; i < n; i++) output[i] = arr[i];
+    }
+
+    /// <inheritdoc />
+    public virtual void NativeComplexIFFTSpan<T>(ReadOnlySpan<Complex<T>> input, Span<Complex<T>> output)
+    {
+        if (input.Length != output.Length)
+            throw new ArgumentException($"Input length ({input.Length}) must equal output length ({output.Length}).");
+        ValidatePowerOfTwo(input.Length, nameof(input));
+
+        int n = input.Length;
+        if (typeof(T) == typeof(double))
+        {
+            var buf = new Complex<double>[n];
+            for (int i = 0; i < n; i++)
+            {
+                ref Complex<T> src = ref System.Runtime.CompilerServices.Unsafe.AsRef(in input[i]);
+                buf[i] = System.Runtime.CompilerServices.Unsafe.As<Complex<T>, Complex<double>>(ref src);
+            }
+            NativeFFTInPlaceDoubleSpan(buf, inverse: true);
+            double scale = 1.0 / n;
+            for (int i = 0; i < n; i++)
+            {
+                var scaled = new Complex<double>(buf[i].Real * scale, buf[i].Imaginary * scale);
+                output[i] = System.Runtime.CompilerServices.Unsafe.As<Complex<double>, Complex<T>>(ref scaled);
+            }
+            return;
+        }
+        if (typeof(T) == typeof(float))
+        {
+            var buf = new Complex<float>[n];
+            for (int i = 0; i < n; i++)
+            {
+                ref Complex<T> src = ref System.Runtime.CompilerServices.Unsafe.AsRef(in input[i]);
+                buf[i] = System.Runtime.CompilerServices.Unsafe.As<Complex<T>, Complex<float>>(ref src);
+            }
+            NativeFFTInPlaceFloatSpan(buf, inverse: true);
+            float scale = 1f / n;
+            for (int i = 0; i < n; i++)
+            {
+                var scaled = new Complex<float>(buf[i].Real * scale, buf[i].Imaginary * scale);
+                output[i] = System.Runtime.CompilerServices.Unsafe.As<Complex<float>, Complex<T>>(ref scaled);
+            }
+            return;
+        }
+
+        var ops = MathHelper.GetNumericOperations<T>();
+        var arr = new Complex<T>[n];
+        for (int i = 0; i < n; i++) arr[i] = input[i];
+        NativeFFTInPlace(arr, true, ops);
+        var scaleT = ops.FromDouble(n);
+        for (int i = 0; i < n; i++)
+            output[i] = new Complex<T>(ops.Divide(arr[i].Real, scaleT), ops.Divide(arr[i].Imaginary, scaleT));
+    }
+
+    /// <inheritdoc />
+    public virtual void NativeComplexFFTComplexSpan<T>(ReadOnlySpan<Complex<T>> input, Span<Complex<T>> output)
+    {
+        if (input.Length != output.Length)
+            throw new ArgumentException($"Input length ({input.Length}) must equal output length ({output.Length}).");
+        ValidatePowerOfTwo(input.Length, nameof(input));
+
+        int n = input.Length;
+        if (typeof(T) == typeof(double))
+        {
+            var buf = new Complex<double>[n];
+            for (int i = 0; i < n; i++)
+            {
+                ref Complex<T> src = ref System.Runtime.CompilerServices.Unsafe.AsRef(in input[i]);
+                buf[i] = System.Runtime.CompilerServices.Unsafe.As<Complex<T>, Complex<double>>(ref src);
+            }
+            NativeFFTInPlaceDoubleSpan(buf, inverse: false);
+            for (int i = 0; i < n; i++)
+                output[i] = System.Runtime.CompilerServices.Unsafe.As<Complex<double>, Complex<T>>(ref buf[i]);
+            return;
+        }
+        if (typeof(T) == typeof(float))
+        {
+            var buf = new Complex<float>[n];
+            for (int i = 0; i < n; i++)
+            {
+                ref Complex<T> src = ref System.Runtime.CompilerServices.Unsafe.AsRef(in input[i]);
+                buf[i] = System.Runtime.CompilerServices.Unsafe.As<Complex<T>, Complex<float>>(ref src);
+            }
+            NativeFFTInPlaceFloatSpan(buf, inverse: false);
+            for (int i = 0; i < n; i++)
+                output[i] = System.Runtime.CompilerServices.Unsafe.As<Complex<float>, Complex<T>>(ref buf[i]);
+            return;
+        }
+
+        var ops = MathHelper.GetNumericOperations<T>();
+        var arr = new Complex<T>[n];
+        for (int i = 0; i < n; i++) arr[i] = input[i];
+        NativeFFTInPlace(arr, false, ops);
+        for (int i = 0; i < n; i++) output[i] = arr[i];
+    }
+
+    /// <inheritdoc />
+    public virtual Tensor<Complex<T>> NativeAnalyticSignal<T>(Tensor<T> input, double freqLow = 0.0, double freqHigh = double.MaxValue, double sampleRate = 1.0)
+    {
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        var (batchCount, fftSize) = GetBatchedFFTDims(input._shape);
+        ValidatePowerOfTwo(fftSize, nameof(input));
+
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ci = input; var fL = freqLow; var fH = freqHigh; var sr = sampleRate; return scope.RecordCrossType<T, Complex<T>>(LazyNodeType.Custom, "NativeAnalyticSignal", input, input._shape, (eng, output) => { var r = eng.NativeAnalyticSignal(ci, fL, fH, sr); r.AsSpan().CopyTo(output.AsWritableSpan()); }); } }
+
+        var ops = MathHelper.GetNumericOperations<T>();
+        var result = new Tensor<Complex<T>>(input._shape);
+
+        // Map frequency cutoffs to bin indices. freqLow/freqHigh are in Hz; each bin k
+        // represents frequency k * (sampleRate / fftSize). For positive-frequency bins
+        // in [0, fftSize/2], we keep bins k with: (k * sampleRate / fftSize) in [freqLow, freqHigh).
+        // binLow = ceil(freqLow * fftSize / sampleRate) — inclusive lower bin
+        // binHigh = floor(freqHigh * fftSize / sampleRate) — exclusive upper bin (clamp to fftSize/2+1)
+        int halfN = fftSize / 2;
+        int binLow = freqLow <= 0.0 ? 0 : (int)Math.Ceiling(freqLow * fftSize / sampleRate);
+        int binHigh;
+        if (double.IsPositiveInfinity(freqHigh) || freqHigh >= sampleRate * 0.5)
+            binHigh = halfN + 1;
+        else
+            binHigh = Math.Min(halfN + 1, (int)Math.Ceiling(freqHigh * fftSize / sampleRate));
+        if (binLow < 0) binLow = 0;
+        if (binHigh > halfN + 1) binHigh = halfN + 1;
+
+        // Fused: forward FFT → zero negative bins + band-mask positive bins + double (except DC/Nyquist) → inverse FFT
+        // Allocate a single working buffer per batch slice (shared across batches)
+        var slice = new Complex<T>[fftSize];
+        for (int b = 0; b < batchCount; b++)
+        {
+            int offset = b * fftSize;
+            for (int i = 0; i < fftSize; i++) slice[i] = new Complex<T>(input[offset + i], ops.Zero);
+
+            NativeFFTInPlace(slice, false, ops);
+
+            // Apply Hilbert-in-frequency filter:
+            //   bin 0 and bin N/2 (Nyquist): unchanged if in [binLow, binHigh), else 0
+            //   bins 1..N/2-1: doubled if in [binLow, binHigh), else 0
+            //   bins N/2+1..N-1 (negative freq mirror): always 0
+            var two = ops.FromDouble(2.0);
+            for (int k = 0; k < fftSize; k++)
+            {
+                if (k == 0 || k == halfN)
+                {
+                    if (k < binLow || k >= binHigh) slice[k] = new Complex<T>(ops.Zero, ops.Zero);
+                    // else leave as-is
+                }
+                else if (k < halfN)
+                {
+                    if (k < binLow || k >= binHigh)
+                        slice[k] = new Complex<T>(ops.Zero, ops.Zero);
+                    else
+                        slice[k] = new Complex<T>(ops.Multiply(slice[k].Real, two), ops.Multiply(slice[k].Imaginary, two));
+                }
+                else
+                {
+                    slice[k] = new Complex<T>(ops.Zero, ops.Zero);
+                }
+            }
+
+            NativeFFTInPlace(slice, true, ops);
+
+            // IFFT normalization: divide by N
+            var scale = ops.FromDouble(fftSize);
+            for (int i = 0; i < fftSize; i++)
+                result[offset + i] = new Complex<T>(ops.Divide(slice[i].Real, scale), ops.Divide(slice[i].Imaginary, scale));
+        }
+
+        { var ci = input; var fL = freqLow; var fH = freqHigh; var sr = sampleRate; AutoTracer.RecordOp("NativeAnalyticSignal", result, eng => eng.NativeAnalyticSignal(ci, fL, fH, sr)); }
+        return result;
+    }
+
+    /// <inheritdoc />
+    public virtual Tensor<T> NativeNormalizeRows<T>(Tensor<T> input)
+    {
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (input.Rank != 2) throw new ArgumentException($"NativeNormalizeRows requires a 2D tensor. Got rank {input.Rank}.", nameof(input));
+
+        int rows = input._shape[0];
+        int cols = input._shape[1];
+        var result = new Tensor<T>(input._shape);
+
+        if (typeof(T) == typeof(double))
+        {
+            // Reinterpret via Unsafe.As on each element — typeof check guarantees T=double
+            int n = rows * cols;
+            var srcData = input.DataVector.AsSpan();
+            var dstData = result.DataVector.AsWritableSpan();
+            var srcD = new double[n];
+            var dstD = new double[n];
+            for (int i = 0; i < n; i++)
+            {
+                ref T s = ref System.Runtime.CompilerServices.Unsafe.AsRef(in srcData[i]);
+                srcD[i] = System.Runtime.CompilerServices.Unsafe.As<T, double>(ref s);
+            }
+            NormalizeRowsDouble(srcD, dstD, rows, cols);
+            for (int i = 0; i < n; i++)
+                dstData[i] = System.Runtime.CompilerServices.Unsafe.As<double, T>(ref dstD[i]);
+            return result;
+        }
+        if (typeof(T) == typeof(float))
+        {
+            int n = rows * cols;
+            var srcData = input.DataVector.AsSpan();
+            var dstData = result.DataVector.AsWritableSpan();
+            var srcF = new float[n];
+            var dstF = new float[n];
+            for (int i = 0; i < n; i++)
+            {
+                ref T s = ref System.Runtime.CompilerServices.Unsafe.AsRef(in srcData[i]);
+                srcF[i] = System.Runtime.CompilerServices.Unsafe.As<T, float>(ref s);
+            }
+            NormalizeRowsFloat(srcF, dstF, rows, cols);
+            for (int i = 0; i < n; i++)
+                dstData[i] = System.Runtime.CompilerServices.Unsafe.As<float, T>(ref dstF[i]);
+            return result;
+        }
+
+        // Generic fallback
+        var ops = MathHelper.GetNumericOperations<T>();
+        for (int r = 0; r < rows; r++)
+        {
+            int off = r * cols;
+            var sumSq = ops.Zero;
+            for (int c = 0; c < cols; c++)
+            {
+                var v = input[off + c];
+                sumSq = ops.Add(sumSq, ops.Multiply(v, v));
+            }
+            if (ops.GreaterThan(sumSq, ops.Zero))
+            {
+                var invNorm = ops.Divide(ops.One, ops.Sqrt(sumSq));
+                for (int c = 0; c < cols; c++)
+                    result[off + c] = ops.Multiply(input[off + c], invNorm);
+            }
+            else
+            {
+                for (int c = 0; c < cols; c++) result[off + c] = ops.Zero;
+            }
+        }
+        return result;
+    }
+
+    // Type-specialized SIMD helpers for NativeNormalizeRows (double/float).
+    // Private — the public NativeNormalizeRows<T> entry point dispatches to these.
+    private static void NormalizeRowsDouble(ReadOnlySpan<double> src, Span<double> dst, int rows, int cols)
+    {
+        Span<double> lanes = stackalloc double[4];
+        for (int r = 0; r < rows; r++)
+        {
+            int off = r * cols;
+            double sumSq = 0.0;
+            int i = 0;
+#if NET5_0_OR_GREATER
+            if (System.Runtime.Intrinsics.X86.Avx.IsSupported && cols >= 4)
+            {
+                var acc = System.Runtime.Intrinsics.Vector256<double>.Zero;
+                int simdLen = cols & ~3;
+                for (; i < simdLen; i += 4)
+                {
+                    var v = System.Runtime.CompilerServices.Unsafe.ReadUnaligned<System.Runtime.Intrinsics.Vector256<double>>(
+                        ref System.Runtime.CompilerServices.Unsafe.As<double, byte>(
+                            ref System.Runtime.InteropServices.MemoryMarshal.GetReference(src.Slice(off + i))));
+                    acc = System.Runtime.Intrinsics.X86.Avx.Add(acc, System.Runtime.Intrinsics.X86.Avx.Multiply(v, v));
+                }
+                System.Runtime.CompilerServices.Unsafe.WriteUnaligned(
+                    ref System.Runtime.CompilerServices.Unsafe.As<double, byte>(
+                        ref System.Runtime.InteropServices.MemoryMarshal.GetReference(lanes)),
+                    acc);
+                sumSq = lanes[0] + lanes[1] + lanes[2] + lanes[3];
+            }
+#endif
+            for (; i < cols; i++) { double v = src[off + i]; sumSq += v * v; }
+
+            if (sumSq > 0.0)
+            {
+                double invNorm = 1.0 / Math.Sqrt(sumSq);
+                i = 0;
+#if NET5_0_OR_GREATER
+                if (System.Runtime.Intrinsics.X86.Avx.IsSupported && cols >= 4)
+                {
+                    var vinv = System.Runtime.Intrinsics.Vector256.Create(invNorm);
+                    int simdLen = cols & ~3;
+                    for (; i < simdLen; i += 4)
+                    {
+                        var v = System.Runtime.CompilerServices.Unsafe.ReadUnaligned<System.Runtime.Intrinsics.Vector256<double>>(
+                            ref System.Runtime.CompilerServices.Unsafe.As<double, byte>(
+                                ref System.Runtime.InteropServices.MemoryMarshal.GetReference(src.Slice(off + i))));
+                        var m = System.Runtime.Intrinsics.X86.Avx.Multiply(v, vinv);
+                        System.Runtime.CompilerServices.Unsafe.WriteUnaligned(
+                            ref System.Runtime.CompilerServices.Unsafe.As<double, byte>(
+                                ref System.Runtime.InteropServices.MemoryMarshal.GetReference(dst.Slice(off + i))),
+                            m);
+                    }
+                }
+#endif
+                for (; i < cols; i++) dst[off + i] = src[off + i] * invNorm;
+            }
+            else
+            {
+                dst.Slice(off, cols).Clear();
+            }
+        }
+    }
+
+    private static void NormalizeRowsFloat(ReadOnlySpan<float> src, Span<float> dst, int rows, int cols)
+    {
+        Span<float> lanes = stackalloc float[8];
+        for (int r = 0; r < rows; r++)
+        {
+            int off = r * cols;
+            float sumSq = 0f;
+            int i = 0;
+#if NET5_0_OR_GREATER
+            if (System.Runtime.Intrinsics.X86.Avx.IsSupported && cols >= 8)
+            {
+                var acc = System.Runtime.Intrinsics.Vector256<float>.Zero;
+                int simdLen = cols & ~7;
+                for (; i < simdLen; i += 8)
+                {
+                    var v = System.Runtime.CompilerServices.Unsafe.ReadUnaligned<System.Runtime.Intrinsics.Vector256<float>>(
+                        ref System.Runtime.CompilerServices.Unsafe.As<float, byte>(
+                            ref System.Runtime.InteropServices.MemoryMarshal.GetReference(src.Slice(off + i))));
+                    acc = System.Runtime.Intrinsics.X86.Avx.Add(acc, System.Runtime.Intrinsics.X86.Avx.Multiply(v, v));
+                }
+                System.Runtime.CompilerServices.Unsafe.WriteUnaligned(
+                    ref System.Runtime.CompilerServices.Unsafe.As<float, byte>(
+                        ref System.Runtime.InteropServices.MemoryMarshal.GetReference(lanes)),
+                    acc);
+                for (int lane = 0; lane < 8; lane++) sumSq += lanes[lane];
+            }
+#endif
+            for (; i < cols; i++) { float v = src[off + i]; sumSq += v * v; }
+
+            if (sumSq > 0f)
+            {
+                float invNorm = 1f / MathF.Sqrt(sumSq);
+                i = 0;
+#if NET5_0_OR_GREATER
+                if (System.Runtime.Intrinsics.X86.Avx.IsSupported && cols >= 8)
+                {
+                    var vinv = System.Runtime.Intrinsics.Vector256.Create(invNorm);
+                    int simdLen = cols & ~7;
+                    for (; i < simdLen; i += 8)
+                    {
+                        var v = System.Runtime.CompilerServices.Unsafe.ReadUnaligned<System.Runtime.Intrinsics.Vector256<float>>(
+                            ref System.Runtime.CompilerServices.Unsafe.As<float, byte>(
+                                ref System.Runtime.InteropServices.MemoryMarshal.GetReference(src.Slice(off + i))));
+                        var m = System.Runtime.Intrinsics.X86.Avx.Multiply(v, vinv);
+                        System.Runtime.CompilerServices.Unsafe.WriteUnaligned(
+                            ref System.Runtime.CompilerServices.Unsafe.As<float, byte>(
+                                ref System.Runtime.InteropServices.MemoryMarshal.GetReference(dst.Slice(off + i))),
+                            m);
+                    }
+                }
+#endif
+                for (; i < cols; i++) dst[off + i] = src[off + i] * invNorm;
+            }
+            else
+            {
+                dst.Slice(off, cols).Clear();
+            }
+        }
+    }
+
+    /// <inheritdoc />
     public virtual Tensor<T> NativeComplexIFFTReal<T>(Tensor<Complex<T>> input)
     {
         if (input is null) throw new ArgumentNullException(nameof(input));
@@ -28507,7 +28911,7 @@ public class CpuEngine : ITensorLevelEngine
     {
         if (typeof(T) == typeof(float))
         {
-            NativeFFTInPlaceFloat(
+            NativeFFTInPlaceFloatSpan(
                 System.Runtime.CompilerServices.Unsafe.As<Complex<T>[], Complex<float>[]>(ref data),
                 inverse);
             return;
@@ -28515,7 +28919,7 @@ public class CpuEngine : ITensorLevelEngine
 
         if (typeof(T) == typeof(double))
         {
-            NativeFFTInPlaceDouble(
+            NativeFFTInPlaceDoubleSpan(
                 System.Runtime.CompilerServices.Unsafe.As<Complex<T>[], Complex<double>[]>(ref data),
                 inverse);
             return;
@@ -28579,7 +28983,8 @@ public class CpuEngine : ITensorLevelEngine
         }
     }
 
-    private static void NativeFFTInPlaceDouble(Complex<double>[] data, bool inverse)
+    // Span-based overload — zero-copy entry point used by NativeComplexFFTSpan hot paths.
+    private static void NativeFFTInPlaceDoubleSpan(Span<Complex<double>> data, bool inverse)
     {
         int n = data.Length;
         int bits = 0;
@@ -28634,7 +29039,7 @@ public class CpuEngine : ITensorLevelEngine
 
     [ThreadStatic] private static Dictionary<(int n, bool inverse), Complex<float>[]>? _twiddleCacheFloat;
 
-    private static void NativeFFTInPlaceFloat(Complex<float>[] data, bool inverse)
+    private static void NativeFFTInPlaceFloatSpan(Span<Complex<float>> data, bool inverse)
     {
         int n = data.Length;
         int bits = 0;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -10130,7 +10130,7 @@ public sealed class CudaBackend : IAsyncGpuBackend
     }
 
     /// <inheritdoc/>
-    public unsafe void Atan2Elementwise(IGpuBuffer imag, IGpuBuffer real, IGpuBuffer output, int n)
+    public unsafe void Atan2Elementwise(IGpuBuffer real, IGpuBuffer imag, IGpuBuffer output, int n)
     {
         if (n <= 0) return;
         if (!_kernelCache.TryGetValue("atan2_elementwise", out var kernel))
@@ -10154,7 +10154,10 @@ public sealed class CudaBackend : IAsyncGpuBackend
         void** args = stackalloc void*[4];
         args[0] = &ip; args[1] = &op; args[2] = &rows; args[3] = &cols;
         uint grid = (uint)rows;
-        uint block = (uint)Math.Min(256, Math.Max(32, cols));
+        // Tree reduction requires a power-of-two block size.
+        uint block = 32;
+        uint cap = (uint)Math.Min(256, cols);
+        while (block * 2 <= cap) block *= 2;
         uint sharedMem = block * sizeof(float);
         CudaNativeBindings.cuLaunchKernel(kernel, grid, 1, 1, block, 1, 1,
             sharedMem, IntPtr.Zero, (IntPtr)args, IntPtr.Zero);
@@ -10165,11 +10168,13 @@ public sealed class CudaBackend : IAsyncGpuBackend
         IGpuBuffer outReal, IGpuBuffer outImag, int batch, int fftSize, int binLow, int binHigh)
     {
         if (batch <= 0 || fftSize <= 0) return;
+        long totalL = (long)batch * fftSize;
+        if (totalL <= 0 || totalL > int.MaxValue) return;
+        int total = (int)totalL;
         if (!_kernelCache.TryGetValue("analytic_signal_mask", out var kernel))
             throw new InvalidOperationException("CUDA kernel not found: analytic_signal_mask");
         using var _ = PushContext();
         IntPtr srP = specReal.Handle, siP = specImag.Handle, orP = outReal.Handle, oiP = outImag.Handle;
-        int total = batch * fftSize;
         void** args = stackalloc void*[8];
         args[0] = &srP; args[1] = &siP; args[2] = &orP; args[3] = &oiP;
         args[4] = &batch; args[5] = &fftSize; args[6] = &binLow; args[7] = &binHigh;
@@ -10181,8 +10186,10 @@ public sealed class CudaBackend : IAsyncGpuBackend
     public unsafe void BispectrumGather(IGpuBuffer specReal, IGpuBuffer specImag,
         IGpuBuffer outReal, IGpuBuffer outImag, int maxF1, int maxF2)
     {
-        int total = maxF1 * maxF2;
-        if (total <= 0) return;
+        if (maxF1 <= 0 || maxF2 <= 0) return;
+        long totalL = (long)maxF1 * maxF2;
+        if (totalL <= 0 || totalL > int.MaxValue) return;
+        int total = (int)totalL;
         if (!_kernelCache.TryGetValue("bispectrum_gather", out var kernel))
             throw new InvalidOperationException("CUDA kernel not found: bispectrum_gather");
         using var _ = PushContext();
@@ -10198,8 +10205,10 @@ public sealed class CudaBackend : IAsyncGpuBackend
     public unsafe void TrispectrumGather(IGpuBuffer specReal, IGpuBuffer specImag,
         IGpuBuffer outReal, IGpuBuffer outImag, int maxF1, int maxF2, int maxF3)
     {
-        int total = maxF1 * maxF2 * maxF3;
-        if (total <= 0) return;
+        if (maxF1 <= 0 || maxF2 <= 0 || maxF3 <= 0) return;
+        long totalL = (long)maxF1 * maxF2 * maxF3;
+        if (totalL <= 0 || totalL > int.MaxValue) return;
+        int total = (int)totalL;
         if (!_kernelCache.TryGetValue("trispectrum_gather", out var kernel))
             throw new InvalidOperationException("CUDA kernel not found: trispectrum_gather");
         using var _ = PushContext();
@@ -10229,8 +10238,10 @@ public sealed class CudaBackend : IAsyncGpuBackend
     public unsafe void WidebandLogBinPool(IGpuBuffer magBuf, IGpuBuffer output,
         int totalSegBatch, int fftSize, int numBins, int usable)
     {
-        int total = totalSegBatch * numBins;
-        if (total <= 0) return;
+        if (totalSegBatch <= 0 || fftSize <= 0 || numBins <= 0 || usable <= 0) return;
+        long totalL = (long)totalSegBatch * numBins;
+        if (totalL <= 0 || totalL > int.MaxValue) return;
+        int total = (int)totalL;
         if (!_kernelCache.TryGetValue("wideband_log_bin_pool", out var kernel))
             throw new InvalidOperationException("CUDA kernel not found: wideband_log_bin_pool");
         using var _ = PushContext();
@@ -10246,8 +10257,10 @@ public sealed class CudaBackend : IAsyncGpuBackend
     public unsafe void MelFilterbankApply(IGpuBuffer powerSpec, IGpuBuffer melFilters, IGpuBuffer melEnergy,
         int totalSegBatch, int specBins, int melBins)
     {
-        int total = totalSegBatch * melBins;
-        if (total <= 0) return;
+        if (totalSegBatch <= 0 || specBins <= 0 || melBins <= 0) return;
+        long totalL = (long)totalSegBatch * melBins;
+        if (totalL <= 0 || totalL > int.MaxValue) return;
+        int total = (int)totalL;
         if (!_kernelCache.TryGetValue("mel_filterbank_apply", out var kernel))
             throw new InvalidOperationException("CUDA kernel not found: mel_filterbank_apply");
         using var _ = PushContext();
@@ -10278,6 +10291,12 @@ public sealed class CudaBackend : IAsyncGpuBackend
         int batch, int numSamples, int numGammaBands, int gammaIdx)
     {
         if (batch <= 0) return;
+        if (numSamples <= 0)
+            throw new ArgumentOutOfRangeException(nameof(numSamples), "numSamples must be positive.");
+        if (numGammaBands <= 0)
+            throw new ArgumentOutOfRangeException(nameof(numGammaBands), "numGammaBands must be positive.");
+        if (gammaIdx < 0 || gammaIdx >= numGammaBands)
+            throw new ArgumentOutOfRangeException(nameof(gammaIdx), $"gammaIdx must be in [0, {numGammaBands}).");
         if (!_kernelCache.TryGetValue("pac_phase_bin_mi", out var kernel))
             throw new InvalidOperationException("CUDA kernel not found: pac_phase_bin_mi");
         using var _ = PushContext();

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -33,6 +33,7 @@ public sealed class CudaBackend : IAsyncGpuBackend
     private IntPtr _fusedModule;
     private IntPtr _attentionModule;
     private IntPtr _fftModule;
+    private IntPtr _spectralPerfModule;
     private IntPtr _spatialTransformerModule;
     private IntPtr _sparseModule;
     private IntPtr _locallyConnectedModule;
@@ -578,6 +579,7 @@ public sealed class CudaBackend : IAsyncGpuBackend
         _fusedModule = CompileKernelModule(device, CudaFusedKernels.GetSource(), "fused_kernels", CudaFusedKernels.GetKernelNames());
         _attentionModule = CompileKernelModule(device, CudaAttentionKernels.GetSource(), "attention_kernels", CudaAttentionKernels.GetKernelNames());
         _fftModule = CompileKernelModule(device, Kernels.CudaFFTKernels.GetSource(), "fft_kernels", Kernels.CudaFFTKernels.GetKernelNames());
+        _spectralPerfModule = CompileKernelModule(device, Kernels.CudaSpectralPerfKernels.GetSource(), "spectral_perf_kernels", Kernels.CudaSpectralPerfKernels.GetKernelNames());
         _sparseModule = CompileKernelModule(device, CudaSparseKernels.GetSource(), "sparse_kernels", CudaSparseKernels.GetKernelNames());
         _spatialTransformerModule = CompileKernelModule(device, CudaSpatialTransformerKernels.GetSource(), "spatial_transformer_kernels", CudaSpatialTransformerKernels.GetKernelNames());
 
@@ -10127,6 +10129,169 @@ public sealed class CudaBackend : IAsyncGpuBackend
         }
     }
 
+    /// <inheritdoc/>
+    public unsafe void Atan2Elementwise(IGpuBuffer imag, IGpuBuffer real, IGpuBuffer output, int n)
+    {
+        if (n <= 0) return;
+        if (!_kernelCache.TryGetValue("atan2_elementwise", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: atan2_elementwise");
+        using var _ = PushContext();
+        IntPtr ip = imag.Handle, rp = real.Handle, op = output.Handle;
+        void** args = stackalloc void*[4];
+        args[0] = &ip; args[1] = &rp; args[2] = &op; args[3] = &n;
+        uint grid = (uint)((n + DefaultBlockSize - 1) / DefaultBlockSize);
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    /// <inheritdoc/>
+    public unsafe void NormalizeRowsFused(IGpuBuffer input, IGpuBuffer output, int rows, int cols)
+    {
+        if (rows <= 0 || cols <= 0) return;
+        if (!_kernelCache.TryGetValue("normalize_rows_fused", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: normalize_rows_fused");
+        using var _ = PushContext();
+        IntPtr ip = input.Handle, op = output.Handle;
+        void** args = stackalloc void*[4];
+        args[0] = &ip; args[1] = &op; args[2] = &rows; args[3] = &cols;
+        uint grid = (uint)rows;
+        uint block = (uint)Math.Min(256, Math.Max(32, cols));
+        uint sharedMem = block * sizeof(float);
+        CudaNativeBindings.cuLaunchKernel(kernel, grid, 1, 1, block, 1, 1,
+            sharedMem, IntPtr.Zero, (IntPtr)args, IntPtr.Zero);
+    }
+
+    /// <inheritdoc/>
+    public unsafe void AnalyticSignalMask(IGpuBuffer specReal, IGpuBuffer specImag,
+        IGpuBuffer outReal, IGpuBuffer outImag, int batch, int fftSize, int binLow, int binHigh)
+    {
+        if (batch <= 0 || fftSize <= 0) return;
+        if (!_kernelCache.TryGetValue("analytic_signal_mask", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: analytic_signal_mask");
+        using var _ = PushContext();
+        IntPtr srP = specReal.Handle, siP = specImag.Handle, orP = outReal.Handle, oiP = outImag.Handle;
+        int total = batch * fftSize;
+        void** args = stackalloc void*[8];
+        args[0] = &srP; args[1] = &siP; args[2] = &orP; args[3] = &oiP;
+        args[4] = &batch; args[5] = &fftSize; args[6] = &binLow; args[7] = &binHigh;
+        uint grid = (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize);
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    /// <inheritdoc/>
+    public unsafe void BispectrumGather(IGpuBuffer specReal, IGpuBuffer specImag,
+        IGpuBuffer outReal, IGpuBuffer outImag, int maxF1, int maxF2)
+    {
+        int total = maxF1 * maxF2;
+        if (total <= 0) return;
+        if (!_kernelCache.TryGetValue("bispectrum_gather", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: bispectrum_gather");
+        using var _ = PushContext();
+        IntPtr srP = specReal.Handle, siP = specImag.Handle, orP = outReal.Handle, oiP = outImag.Handle;
+        void** args = stackalloc void*[6];
+        args[0] = &srP; args[1] = &siP; args[2] = &orP; args[3] = &oiP;
+        args[4] = &maxF1; args[5] = &maxF2;
+        uint grid = (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize);
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    /// <inheritdoc/>
+    public unsafe void TrispectrumGather(IGpuBuffer specReal, IGpuBuffer specImag,
+        IGpuBuffer outReal, IGpuBuffer outImag, int maxF1, int maxF2, int maxF3)
+    {
+        int total = maxF1 * maxF2 * maxF3;
+        if (total <= 0) return;
+        if (!_kernelCache.TryGetValue("trispectrum_gather", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: trispectrum_gather");
+        using var _ = PushContext();
+        IntPtr srP = specReal.Handle, siP = specImag.Handle, orP = outReal.Handle, oiP = outImag.Handle;
+        void** args = stackalloc void*[7];
+        args[0] = &srP; args[1] = &siP; args[2] = &orP; args[3] = &oiP;
+        args[4] = &maxF1; args[5] = &maxF2; args[6] = &maxF3;
+        uint grid = (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize);
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    /// <inheritdoc/>
+    public unsafe void CavityBounceInplace(IGpuBuffer workReal, IGpuBuffer workImag, int total, float invN)
+    {
+        if (total <= 0) return;
+        if (!_kernelCache.TryGetValue("cavity_bounce_inplace", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: cavity_bounce_inplace");
+        using var _ = PushContext();
+        IntPtr wr = workReal.Handle, wi = workImag.Handle;
+        void** args = stackalloc void*[4];
+        args[0] = &wr; args[1] = &wi; args[2] = &total; args[3] = &invN;
+        uint grid = (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize);
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    /// <inheritdoc/>
+    public unsafe void WidebandLogBinPool(IGpuBuffer magBuf, IGpuBuffer output,
+        int totalSegBatch, int fftSize, int numBins, int usable)
+    {
+        int total = totalSegBatch * numBins;
+        if (total <= 0) return;
+        if (!_kernelCache.TryGetValue("wideband_log_bin_pool", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: wideband_log_bin_pool");
+        using var _ = PushContext();
+        IntPtr mp = magBuf.Handle, op = output.Handle;
+        void** args = stackalloc void*[6];
+        args[0] = &mp; args[1] = &op;
+        args[2] = &totalSegBatch; args[3] = &fftSize; args[4] = &numBins; args[5] = &usable;
+        uint grid = (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize);
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    /// <inheritdoc/>
+    public unsafe void MelFilterbankApply(IGpuBuffer powerSpec, IGpuBuffer melFilters, IGpuBuffer melEnergy,
+        int totalSegBatch, int specBins, int melBins)
+    {
+        int total = totalSegBatch * melBins;
+        if (total <= 0) return;
+        if (!_kernelCache.TryGetValue("mel_filterbank_apply", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: mel_filterbank_apply");
+        using var _ = PushContext();
+        IntPtr ps = powerSpec.Handle, mf = melFilters.Handle, me = melEnergy.Handle;
+        void** args = stackalloc void*[6];
+        args[0] = &ps; args[1] = &mf; args[2] = &me;
+        args[3] = &totalSegBatch; args[4] = &specBins; args[5] = &melBins;
+        uint grid = (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize);
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    /// <inheritdoc/>
+    public unsafe void MfccLog1p(IGpuBuffer input, IGpuBuffer output, int n)
+    {
+        if (n <= 0) return;
+        if (!_kernelCache.TryGetValue("mfcc_log1p", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: mfcc_log1p");
+        using var _ = PushContext();
+        IntPtr ip = input.Handle, op = output.Handle;
+        void** args = stackalloc void*[3];
+        args[0] = &ip; args[1] = &op; args[2] = &n;
+        uint grid = (uint)((n + DefaultBlockSize - 1) / DefaultBlockSize);
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    /// <inheritdoc/>
+    public unsafe void PacPhaseBinMi(IGpuBuffer thetaPhase, IGpuBuffer gammaAmp, IGpuBuffer output,
+        int batch, int numSamples, int numGammaBands, int gammaIdx)
+    {
+        if (batch <= 0) return;
+        if (!_kernelCache.TryGetValue("pac_phase_bin_mi", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: pac_phase_bin_mi");
+        using var _ = PushContext();
+        IntPtr tp = thetaPhase.Handle, ga = gammaAmp.Handle, op = output.Handle;
+        void** args = stackalloc void*[7];
+        args[0] = &tp; args[1] = &ga; args[2] = &op;
+        args[3] = &batch; args[4] = &numSamples; args[5] = &numGammaBands; args[6] = &gammaIdx;
+        uint grid = (uint)batch;
+        uint block = 256;
+        uint sharedMem = (uint)(2 * 18 * sizeof(float));
+        CudaNativeBindings.cuLaunchKernel(kernel, grid, 1, 1, block, 1, 1,
+            sharedMem, IntPtr.Zero, (IntPtr)args, IntPtr.Zero);
+    }
+
     #endregion
 
     #region Quantum Computing Operations
@@ -10657,6 +10822,12 @@ public sealed class CudaBackend : IAsyncGpuBackend
         {
             CudaNativeBindings.cuModuleUnload(_fftModule);
             _fftModule = IntPtr.Zero;
+        }
+
+        if (_spectralPerfModule != IntPtr.Zero)
+        {
+            CudaNativeBindings.cuModuleUnload(_spectralPerfModule);
+            _spectralPerfModule = IntPtr.Zero;
         }
 
         if (_spatialTransformerModule != IntPtr.Zero)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaSpectralPerfKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaSpectralPerfKernels.cs
@@ -1,0 +1,332 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Dedicated CUDA kernels for Issue #160 spectral/audio perf operations.
+// All kernels are fully GPU-resident — no host-side loops.
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA.Kernels
+{
+    internal static class CudaSpectralPerfKernels
+    {
+        public static string[] GetKernelNames() => new[]
+        {
+            "atan2_elementwise",
+            "analytic_signal_mask",
+            "normalize_rows_fused",
+            "bispectrum_gather",
+            "trispectrum_gather",
+            "cavity_bounce_inplace",
+            "wideband_log_bin_pool",
+            "pac_phase_bin_mi",
+            "mel_filterbank_apply",
+            "mfcc_log1p",
+        };
+
+        public static string GetSource()
+        {
+            return @"
+#include <math.h>
+
+// =================================================================
+// Atan2 element-wise: output[i] = atan2(imag[i], real[i])
+// =================================================================
+extern ""C"" __global__ __launch_bounds__(256)
+void atan2_elementwise(const float* __restrict__ imag,
+                       const float* __restrict__ real,
+                       float* __restrict__ output,
+                       int n)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= n) return;
+    output[idx] = atan2f(imag[idx], real[idx]);
+}
+
+// =================================================================
+// Analytic signal Hilbert mask: apply gain (0, 1, or 2) per frequency bin.
+// Bins are organized as [batch, fftSize] flat. For each bin k:
+//   k == 0 or k == fftSize/2: gain = (k in [binLow, binHigh)) ? 1 : 0
+//   k < fftSize/2:            gain = (k in [binLow, binHigh)) ? 2 : 0
+//   k > fftSize/2:            gain = 0
+// Multiplies (specReal, specImag) by gain in-place into (outReal, outImag).
+// =================================================================
+extern ""C"" __global__ __launch_bounds__(256)
+void analytic_signal_mask(const float* __restrict__ specReal,
+                          const float* __restrict__ specImag,
+                          float* __restrict__ outReal,
+                          float* __restrict__ outImag,
+                          int batch, int fftSize, int binLow, int binHigh)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = batch * fftSize;
+    if (idx >= total) return;
+    int k = idx % fftSize;
+    int halfN = fftSize >> 1;
+    float gain;
+    if (k == 0 || k == halfN) {
+        gain = (k < binLow || k >= binHigh) ? 0.0f : 1.0f;
+    } else if (k < halfN) {
+        gain = (k < binLow || k >= binHigh) ? 0.0f : 2.0f;
+    } else {
+        gain = 0.0f;
+    }
+    outReal[idx] = specReal[idx] * gain;
+    outImag[idx] = specImag[idx] * gain;
+}
+
+// =================================================================
+// Per-row L2 normalize. One block per row; threads cooperate on
+// sum-of-squares reduction, then divide all elements by sqrt(sumSq).
+// =================================================================
+extern ""C"" __global__ __launch_bounds__(256)
+void normalize_rows_fused(const float* __restrict__ input,
+                          float* __restrict__ output,
+                          int rows, int cols)
+{
+    extern __shared__ float sdata[];
+    int row = blockIdx.x;
+    if (row >= rows) return;
+    int tid = threadIdx.x;
+    int rowOff = row * cols;
+
+    // Phase 1: sum of squares
+    float local = 0.0f;
+    for (int c = tid; c < cols; c += blockDim.x) {
+        float v = input[rowOff + c];
+        local += v * v;
+    }
+    sdata[tid] = local;
+    __syncthreads();
+
+    // Reduction
+    for (int s = blockDim.x >> 1; s > 0; s >>= 1) {
+        if (tid < s) sdata[tid] += sdata[tid + s];
+        __syncthreads();
+    }
+
+    float invNorm = 0.0f;
+    if (sdata[0] > 0.0f) invNorm = rsqrtf(sdata[0]);
+
+    // Phase 2: write normalized output
+    for (int c = tid; c < cols; c += blockDim.x) {
+        output[rowOff + c] = input[rowOff + c] * invNorm;
+    }
+}
+
+// =================================================================
+// Bispectrum gather: B(f1, f2) = X(f1) * X(f2) * conj(X(f1+f2))
+// One thread per output element. Output shape [maxF1, maxF2] complex.
+// =================================================================
+extern ""C"" __global__ __launch_bounds__(256)
+void bispectrum_gather(const float* __restrict__ specReal,
+                       const float* __restrict__ specImag,
+                       float* __restrict__ outReal,
+                       float* __restrict__ outImag,
+                       int maxF1, int maxF2)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = maxF1 * maxF2;
+    if (idx >= total) return;
+    int f1 = idx / maxF2;
+    int f2 = idx % maxF2;
+    int sumIdx = f1 + f2;
+
+    float ar = specReal[f1], ai = specImag[f1];
+    float br = specReal[f2], bi = specImag[f2];
+    float cr = specReal[sumIdx], ci = -specImag[sumIdx]; // conjugate
+
+    // (ar+i*ai) * (br+i*bi) = (ar*br - ai*bi) + i*(ar*bi + ai*br)
+    float abr = ar * br - ai * bi;
+    float abi = ar * bi + ai * br;
+    // (abr+i*abi) * (cr+i*ci)
+    outReal[idx] = abr * cr - abi * ci;
+    outImag[idx] = abr * ci + abi * cr;
+}
+
+// =================================================================
+// Trispectrum gather: T(f1,f2,f3) = X(f1)*X(f2)*X(f3)*conj(X(f1+f2+f3))
+// =================================================================
+extern ""C"" __global__ __launch_bounds__(256)
+void trispectrum_gather(const float* __restrict__ specReal,
+                        const float* __restrict__ specImag,
+                        float* __restrict__ outReal,
+                        float* __restrict__ outImag,
+                        int maxF1, int maxF2, int maxF3)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = maxF1 * maxF2 * maxF3;
+    if (idx >= total) return;
+    int f1 = idx / (maxF2 * maxF3);
+    int rem = idx - f1 * maxF2 * maxF3;
+    int f2 = rem / maxF3;
+    int f3 = rem - f2 * maxF3;
+    int sumIdx = f1 + f2 + f3;
+
+    float ar = specReal[f1], ai = specImag[f1];
+    float br = specReal[f2], bi = specImag[f2];
+    float cr = specReal[f3], ci = specImag[f3];
+    float dr = specReal[sumIdx], di = -specImag[sumIdx];
+
+    float t1r = ar * br - ai * bi;
+    float t1i = ar * bi + ai * br;
+    float t2r = t1r * cr - t1i * ci;
+    float t2i = t1r * ci + t1i * cr;
+    outReal[idx] = t2r * dr - t2i * di;
+    outImag[idx] = t2r * di + t2i * dr;
+}
+
+// =================================================================
+// Cavity bounce in-place: applies the per-bounce nonlinearity to a
+// time-domain signal that was just IFFT'd. Computes tanh(real / N) for
+// real part, zeros imag part. N is fftSize for IFFT normalization.
+// Designed to fuse the post-IFFT scale + tanh + imag-zero work.
+// =================================================================
+extern ""C"" __global__ __launch_bounds__(256)
+void cavity_bounce_inplace(float* __restrict__ workReal,
+                           float* __restrict__ workImag,
+                           int total, float invN)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= total) return;
+    float r = workReal[idx] * invN;
+    // Clamp to avoid NaN on extreme inputs
+    r = fminf(fmaxf(r, -20.0f), 20.0f);
+    workReal[idx] = tanhf(r);
+    workImag[idx] = 0.0f;
+}
+
+// =================================================================
+// Wideband log-bin pool: per (batch, segment), pool magnitudes into
+// numBins logarithmically-spaced bins, take log(1+avg).
+// magBuf shape: [totalSegBatch, fftSize]; output: [totalSegBatch, numBins].
+// =================================================================
+extern ""C"" __global__ __launch_bounds__(256)
+void wideband_log_bin_pool(const float* __restrict__ magBuf,
+                           float* __restrict__ output,
+                           int totalSegBatch, int fftSize, int numBins, int usable)
+{
+    int outIdx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = totalSegBatch * numBins;
+    if (outIdx >= total) return;
+    int seg = outIdx / numBins;
+    int k = outIdx % numBins;
+
+    // Logarithmic bin layout: binStart = 1 + (k/numBins)^2 * (usable-1)
+    float r0 = (float)k / (float)numBins;
+    float r1 = (float)(k + 1) / (float)numBins;
+    int binStart = 1 + (int)(r0 * r0 * (float)(usable - 1));
+    int binEnd = 1 + (int)(r1 * r1 * (float)(usable - 1));
+    if (binEnd <= binStart) binEnd = binStart + 1;
+    if (binEnd > usable) binEnd = usable;
+
+    int magOff = seg * fftSize;
+    float sum = 0.0f; int cnt = 0;
+    for (int i = binStart; i < binEnd; i++) {
+        sum += magBuf[magOff + i];
+        cnt++;
+    }
+    float avg = (cnt > 0) ? (sum / (float)cnt) : 0.0f;
+    output[outIdx] = log1pf(avg);
+}
+
+// =================================================================
+// PAC phase-binned modulation index. For each (batch, gammaBand):
+// uses 18 phase bins; computes KL-divergence of amplitude distribution
+// from uniform, normalized by log(numBins).
+// thetaPhase: [batch, numSamples], gammaAmp: [batch, numSamples]
+// output: [batch, numGammaBands], one MI value per (batch, band).
+// One block per (batch, gammaBand) pair; threads cooperate on histogram + reduction.
+// =================================================================
+extern ""C"" __global__ __launch_bounds__(256)
+void pac_phase_bin_mi(const float* __restrict__ thetaPhase,
+                      const float* __restrict__ gammaAmp,
+                      float* __restrict__ output,
+                      int batch, int numSamples, int numGammaBands, int gammaIdx)
+{
+    extern __shared__ float sdata[];
+    const int NUM_PHASE_BINS = 18;
+    int b = blockIdx.x;
+    if (b >= batch) return;
+    int tid = threadIdx.x;
+
+    // sdata layout: [NUM_PHASE_BINS sums | NUM_PHASE_BINS counts]
+    if (tid < NUM_PHASE_BINS) {
+        sdata[tid] = 0.0f;
+        sdata[NUM_PHASE_BINS + tid] = 0.0f;
+    }
+    __syncthreads();
+
+    // Histogram: each thread accumulates partial sums into shared memory via atomicAdd
+    int sampleOff = b * numSamples;
+    int gammaOff = (gammaIdx * batch + b) * numSamples;
+    for (int i = tid; i < numSamples; i += blockDim.x) {
+        float phase = thetaPhase[sampleOff + i];
+        float amp = gammaAmp[gammaOff + i];
+        float fbin = (phase + 3.14159265358979f) / (2.0f * 3.14159265358979f) * (float)NUM_PHASE_BINS;
+        int bin = (int)fbin;
+        if (bin < 0) bin = 0;
+        if (bin >= NUM_PHASE_BINS) bin = NUM_PHASE_BINS - 1;
+        atomicAdd(&sdata[bin], amp);
+        atomicAdd(&sdata[NUM_PHASE_BINS + bin], 1.0f);
+    }
+    __syncthreads();
+
+    // Compute MI on thread 0
+    if (tid == 0) {
+        float totalAmp = 0.0f;
+        for (int k = 0; k < NUM_PHASE_BINS; k++) {
+            float c = sdata[NUM_PHASE_BINS + k];
+            float avg = (c > 0.0f) ? (sdata[k] / c) : 0.0f;
+            totalAmp += avg;
+        }
+        float mi = 0.0f;
+        if (totalAmp > 0.0f) {
+            float entropy = 0.0f;
+            for (int k = 0; k < NUM_PHASE_BINS; k++) {
+                float c = sdata[NUM_PHASE_BINS + k];
+                float avg = (c > 0.0f) ? (sdata[k] / c) : 0.0f;
+                float p = avg / totalAmp;
+                if (p > 1e-12f) entropy -= p * logf(p);
+            }
+            mi = (logf((float)NUM_PHASE_BINS) - entropy) / logf((float)NUM_PHASE_BINS);
+        }
+        output[b * numGammaBands + gammaIdx] = mi;
+    }
+}
+
+// =================================================================
+// Mel filterbank apply: for each (segment, melBin), sum power[i] * melFilter[melBin*specBins + i].
+// powerSpec: [totalSegBatch, specBins], melFilters: [melBins, specBins], output: [totalSegBatch, melBins].
+// =================================================================
+extern ""C"" __global__ __launch_bounds__(256)
+void mel_filterbank_apply(const float* __restrict__ powerSpec,
+                          const float* __restrict__ melFilters,
+                          float* __restrict__ melEnergy,
+                          int totalSegBatch, int specBins, int melBins)
+{
+    int outIdx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = totalSegBatch * melBins;
+    if (outIdx >= total) return;
+    int seg = outIdx / melBins;
+    int m = outIdx % melBins;
+    int powerOff = seg * specBins;
+    int filtOff = m * specBins;
+    float sum = 0.0f;
+    for (int i = 0; i < specBins; i++)
+        sum += powerSpec[powerOff + i] * melFilters[filtOff + i];
+    melEnergy[outIdx] = sum;
+}
+
+// =================================================================
+// MFCC log1p: log(1 + e) compression
+// =================================================================
+extern ""C"" __global__ __launch_bounds__(256)
+void mfcc_log1p(const float* __restrict__ input,
+                float* __restrict__ output,
+                int n)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= n) return;
+    output[idx] = log1pf(input[idx]);
+}
+";
+        }
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -10689,7 +10689,7 @@ public sealed partial class HipBackend : IAsyncGpuBackend
     }
 
     /// <inheritdoc/>
-    public unsafe void Atan2Elementwise(IGpuBuffer imag, IGpuBuffer real, IGpuBuffer output, int n)
+    public unsafe void Atan2Elementwise(IGpuBuffer real, IGpuBuffer imag, IGpuBuffer output, int n)
     {
         if (n <= 0) return;
         if (!_kernelCache.TryGetValue("atan2_elementwise", out var kernel))
@@ -10709,7 +10709,10 @@ public sealed partial class HipBackend : IAsyncGpuBackend
         IntPtr ip = input.Handle, op = output.Handle;
         void** args = stackalloc void*[4];
         args[0] = &ip; args[1] = &op; args[2] = &rows; args[3] = &cols;
-        uint block = (uint)Math.Min(256, Math.Max(32, cols));
+        // The kernel uses a tree reduction that requires a power-of-two threadgroup size.
+        uint block = 32;
+        uint cap = (uint)Math.Min(256, cols);
+        while (block * 2 <= cap) block *= 2;
         LaunchKernelWithSharedMem(kernel, (uint)rows, block, block * sizeof(float),
             new IntPtr[] { (IntPtr)args[0], (IntPtr)args[1], (IntPtr)args[2], (IntPtr)args[3] });
     }
@@ -10718,8 +10721,10 @@ public sealed partial class HipBackend : IAsyncGpuBackend
     public unsafe void AnalyticSignalMask(IGpuBuffer specReal, IGpuBuffer specImag,
         IGpuBuffer outReal, IGpuBuffer outImag, int batch, int fftSize, int binLow, int binHigh)
     {
-        int total = batch * fftSize;
-        if (total <= 0) return;
+        if (batch <= 0 || fftSize <= 0) return;
+        long totalL = (long)batch * fftSize;
+        if (totalL <= 0 || totalL > int.MaxValue) return;
+        int total = (int)totalL;
         if (!_kernelCache.TryGetValue("analytic_signal_mask", out var kernel))
             throw new InvalidOperationException("HIP kernel not found: analytic_signal_mask");
         IntPtr srP = specReal.Handle, siP = specImag.Handle, orP = outReal.Handle, oiP = outImag.Handle;
@@ -10733,8 +10738,10 @@ public sealed partial class HipBackend : IAsyncGpuBackend
     public unsafe void BispectrumGather(IGpuBuffer specReal, IGpuBuffer specImag,
         IGpuBuffer outReal, IGpuBuffer outImag, int maxF1, int maxF2)
     {
-        int total = maxF1 * maxF2;
-        if (total <= 0) return;
+        if (maxF1 <= 0 || maxF2 <= 0) return;
+        long totalL = (long)maxF1 * maxF2;
+        if (totalL <= 0 || totalL > int.MaxValue) return;
+        int total = (int)totalL;
         if (!_kernelCache.TryGetValue("bispectrum_gather", out var kernel))
             throw new InvalidOperationException("HIP kernel not found: bispectrum_gather");
         IntPtr srP = specReal.Handle, siP = specImag.Handle, orP = outReal.Handle, oiP = outImag.Handle;
@@ -10748,8 +10755,10 @@ public sealed partial class HipBackend : IAsyncGpuBackend
     public unsafe void TrispectrumGather(IGpuBuffer specReal, IGpuBuffer specImag,
         IGpuBuffer outReal, IGpuBuffer outImag, int maxF1, int maxF2, int maxF3)
     {
-        int total = maxF1 * maxF2 * maxF3;
-        if (total <= 0) return;
+        if (maxF1 <= 0 || maxF2 <= 0 || maxF3 <= 0) return;
+        long totalL = (long)maxF1 * maxF2 * maxF3;
+        if (totalL <= 0 || totalL > int.MaxValue) return;
+        int total = (int)totalL;
         if (!_kernelCache.TryGetValue("trispectrum_gather", out var kernel))
             throw new InvalidOperationException("HIP kernel not found: trispectrum_gather");
         IntPtr srP = specReal.Handle, siP = specImag.Handle, orP = outReal.Handle, oiP = outImag.Handle;
@@ -10775,8 +10784,10 @@ public sealed partial class HipBackend : IAsyncGpuBackend
     public unsafe void WidebandLogBinPool(IGpuBuffer magBuf, IGpuBuffer output,
         int totalSegBatch, int fftSize, int numBins, int usable)
     {
-        int total = totalSegBatch * numBins;
-        if (total <= 0) return;
+        if (totalSegBatch <= 0 || fftSize <= 0 || numBins <= 0 || usable <= 0) return;
+        long totalL = (long)totalSegBatch * numBins;
+        if (totalL <= 0 || totalL > int.MaxValue) return;
+        int total = (int)totalL;
         if (!_kernelCache.TryGetValue("wideband_log_bin_pool", out var kernel))
             throw new InvalidOperationException("HIP kernel not found: wideband_log_bin_pool");
         IntPtr mp = magBuf.Handle, op = output.Handle;
@@ -10790,8 +10801,10 @@ public sealed partial class HipBackend : IAsyncGpuBackend
     public unsafe void MelFilterbankApply(IGpuBuffer powerSpec, IGpuBuffer melFilters, IGpuBuffer melEnergy,
         int totalSegBatch, int specBins, int melBins)
     {
-        int total = totalSegBatch * melBins;
-        if (total <= 0) return;
+        if (totalSegBatch <= 0 || specBins <= 0 || melBins <= 0) return;
+        long totalL = (long)totalSegBatch * melBins;
+        if (totalL <= 0 || totalL > int.MaxValue) return;
+        int total = (int)totalL;
         if (!_kernelCache.TryGetValue("mel_filterbank_apply", out var kernel))
             throw new InvalidOperationException("HIP kernel not found: mel_filterbank_apply");
         IntPtr ps = powerSpec.Handle, mf = melFilters.Handle, me = melEnergy.Handle;
@@ -10818,6 +10831,12 @@ public sealed partial class HipBackend : IAsyncGpuBackend
         int batch, int numSamples, int numGammaBands, int gammaIdx)
     {
         if (batch <= 0) return;
+        if (numSamples <= 0)
+            throw new ArgumentOutOfRangeException(nameof(numSamples), "numSamples must be positive.");
+        if (numGammaBands <= 0)
+            throw new ArgumentOutOfRangeException(nameof(numGammaBands), "numGammaBands must be positive.");
+        if (gammaIdx < 0 || gammaIdx >= numGammaBands)
+            throw new ArgumentOutOfRangeException(nameof(gammaIdx), $"gammaIdx must be in [0, {numGammaBands}).");
         if (!_kernelCache.TryGetValue("pac_phase_bin_mi", out var kernel))
             throw new InvalidOperationException("HIP kernel not found: pac_phase_bin_mi");
         IntPtr tp = thetaPhase.Handle, ga = gammaAmp.Handle, op = output.Handle;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -60,6 +60,7 @@ public sealed partial class HipBackend : IAsyncGpuBackend
     private IntPtr _fusedModule;
     private IntPtr _attentionModule;
     private IntPtr _fftModule;
+    private IntPtr _spectralPerfModule;
     private IntPtr _sparseModule;
     private IntPtr _locallyConnectedModule;
     private IntPtr _deformableConvModule;
@@ -458,6 +459,8 @@ public sealed partial class HipBackend : IAsyncGpuBackend
             // Compile FFT kernels (Cooley-Tukey radix-2 FFT, STFT, Mel spectrogram)
             CompileKernelModule(HipFFTKernels.GetSource(), "fft", ref _fftModule,
                 HipFFTKernels.GetKernelNames());
+            CompileKernelModule(Kernels.HipSpectralPerfKernels.GetSource(), "spectral_perf", ref _spectralPerfModule,
+                Kernels.HipSpectralPerfKernels.GetKernelNames());
 
             // Compile Sparse kernels (CSR SpMM, GNN message passing)
             CompileKernelModule(HipSparseKernels.GetSource(), "sparse", ref _sparseModule,
@@ -10050,6 +10053,11 @@ public sealed partial class HipBackend : IAsyncGpuBackend
             HipNativeBindings.hipModuleUnload(_fftModule);
             _fftModule = IntPtr.Zero;
         }
+        if (_spectralPerfModule != IntPtr.Zero)
+        {
+            HipNativeBindings.hipModuleUnload(_spectralPerfModule);
+            _spectralPerfModule = IntPtr.Zero;
+        }
         if (_locallyConnectedModule != IntPtr.Zero)
         {
             HipNativeBindings.hipModuleUnload(_locallyConnectedModule);
@@ -10680,6 +10688,145 @@ public sealed partial class HipBackend : IAsyncGpuBackend
         }
     }
 
+    /// <inheritdoc/>
+    public unsafe void Atan2Elementwise(IGpuBuffer imag, IGpuBuffer real, IGpuBuffer output, int n)
+    {
+        if (n <= 0) return;
+        if (!_kernelCache.TryGetValue("atan2_elementwise", out var kernel))
+            throw new InvalidOperationException("HIP kernel not found: atan2_elementwise");
+        IntPtr ip = imag.Handle, rp = real.Handle, op = output.Handle;
+        void** args = stackalloc void*[4];
+        args[0] = &ip; args[1] = &rp; args[2] = &op; args[3] = &n;
+        LaunchKernel(kernel, (uint)((n + DefaultBlockSize - 1) / DefaultBlockSize), DefaultBlockSize, args);
+    }
+
+    /// <inheritdoc/>
+    public unsafe void NormalizeRowsFused(IGpuBuffer input, IGpuBuffer output, int rows, int cols)
+    {
+        if (rows <= 0 || cols <= 0) return;
+        if (!_kernelCache.TryGetValue("normalize_rows_fused", out var kernel))
+            throw new InvalidOperationException("HIP kernel not found: normalize_rows_fused");
+        IntPtr ip = input.Handle, op = output.Handle;
+        void** args = stackalloc void*[4];
+        args[0] = &ip; args[1] = &op; args[2] = &rows; args[3] = &cols;
+        uint block = (uint)Math.Min(256, Math.Max(32, cols));
+        LaunchKernelWithSharedMem(kernel, (uint)rows, block, block * sizeof(float),
+            new IntPtr[] { (IntPtr)args[0], (IntPtr)args[1], (IntPtr)args[2], (IntPtr)args[3] });
+    }
+
+    /// <inheritdoc/>
+    public unsafe void AnalyticSignalMask(IGpuBuffer specReal, IGpuBuffer specImag,
+        IGpuBuffer outReal, IGpuBuffer outImag, int batch, int fftSize, int binLow, int binHigh)
+    {
+        int total = batch * fftSize;
+        if (total <= 0) return;
+        if (!_kernelCache.TryGetValue("analytic_signal_mask", out var kernel))
+            throw new InvalidOperationException("HIP kernel not found: analytic_signal_mask");
+        IntPtr srP = specReal.Handle, siP = specImag.Handle, orP = outReal.Handle, oiP = outImag.Handle;
+        void** args = stackalloc void*[8];
+        args[0] = &srP; args[1] = &siP; args[2] = &orP; args[3] = &oiP;
+        args[4] = &batch; args[5] = &fftSize; args[6] = &binLow; args[7] = &binHigh;
+        LaunchKernel(kernel, (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize), DefaultBlockSize, args);
+    }
+
+    /// <inheritdoc/>
+    public unsafe void BispectrumGather(IGpuBuffer specReal, IGpuBuffer specImag,
+        IGpuBuffer outReal, IGpuBuffer outImag, int maxF1, int maxF2)
+    {
+        int total = maxF1 * maxF2;
+        if (total <= 0) return;
+        if (!_kernelCache.TryGetValue("bispectrum_gather", out var kernel))
+            throw new InvalidOperationException("HIP kernel not found: bispectrum_gather");
+        IntPtr srP = specReal.Handle, siP = specImag.Handle, orP = outReal.Handle, oiP = outImag.Handle;
+        void** args = stackalloc void*[6];
+        args[0] = &srP; args[1] = &siP; args[2] = &orP; args[3] = &oiP;
+        args[4] = &maxF1; args[5] = &maxF2;
+        LaunchKernel(kernel, (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize), DefaultBlockSize, args);
+    }
+
+    /// <inheritdoc/>
+    public unsafe void TrispectrumGather(IGpuBuffer specReal, IGpuBuffer specImag,
+        IGpuBuffer outReal, IGpuBuffer outImag, int maxF1, int maxF2, int maxF3)
+    {
+        int total = maxF1 * maxF2 * maxF3;
+        if (total <= 0) return;
+        if (!_kernelCache.TryGetValue("trispectrum_gather", out var kernel))
+            throw new InvalidOperationException("HIP kernel not found: trispectrum_gather");
+        IntPtr srP = specReal.Handle, siP = specImag.Handle, orP = outReal.Handle, oiP = outImag.Handle;
+        void** args = stackalloc void*[7];
+        args[0] = &srP; args[1] = &siP; args[2] = &orP; args[3] = &oiP;
+        args[4] = &maxF1; args[5] = &maxF2; args[6] = &maxF3;
+        LaunchKernel(kernel, (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize), DefaultBlockSize, args);
+    }
+
+    /// <inheritdoc/>
+    public unsafe void CavityBounceInplace(IGpuBuffer workReal, IGpuBuffer workImag, int total, float invN)
+    {
+        if (total <= 0) return;
+        if (!_kernelCache.TryGetValue("cavity_bounce_inplace", out var kernel))
+            throw new InvalidOperationException("HIP kernel not found: cavity_bounce_inplace");
+        IntPtr wr = workReal.Handle, wi = workImag.Handle;
+        void** args = stackalloc void*[4];
+        args[0] = &wr; args[1] = &wi; args[2] = &total; args[3] = &invN;
+        LaunchKernel(kernel, (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize), DefaultBlockSize, args);
+    }
+
+    /// <inheritdoc/>
+    public unsafe void WidebandLogBinPool(IGpuBuffer magBuf, IGpuBuffer output,
+        int totalSegBatch, int fftSize, int numBins, int usable)
+    {
+        int total = totalSegBatch * numBins;
+        if (total <= 0) return;
+        if (!_kernelCache.TryGetValue("wideband_log_bin_pool", out var kernel))
+            throw new InvalidOperationException("HIP kernel not found: wideband_log_bin_pool");
+        IntPtr mp = magBuf.Handle, op = output.Handle;
+        void** args = stackalloc void*[6];
+        args[0] = &mp; args[1] = &op;
+        args[2] = &totalSegBatch; args[3] = &fftSize; args[4] = &numBins; args[5] = &usable;
+        LaunchKernel(kernel, (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize), DefaultBlockSize, args);
+    }
+
+    /// <inheritdoc/>
+    public unsafe void MelFilterbankApply(IGpuBuffer powerSpec, IGpuBuffer melFilters, IGpuBuffer melEnergy,
+        int totalSegBatch, int specBins, int melBins)
+    {
+        int total = totalSegBatch * melBins;
+        if (total <= 0) return;
+        if (!_kernelCache.TryGetValue("mel_filterbank_apply", out var kernel))
+            throw new InvalidOperationException("HIP kernel not found: mel_filterbank_apply");
+        IntPtr ps = powerSpec.Handle, mf = melFilters.Handle, me = melEnergy.Handle;
+        void** args = stackalloc void*[6];
+        args[0] = &ps; args[1] = &mf; args[2] = &me;
+        args[3] = &totalSegBatch; args[4] = &specBins; args[5] = &melBins;
+        LaunchKernel(kernel, (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize), DefaultBlockSize, args);
+    }
+
+    /// <inheritdoc/>
+    public unsafe void MfccLog1p(IGpuBuffer input, IGpuBuffer output, int n)
+    {
+        if (n <= 0) return;
+        if (!_kernelCache.TryGetValue("mfcc_log1p", out var kernel))
+            throw new InvalidOperationException("HIP kernel not found: mfcc_log1p");
+        IntPtr ip = input.Handle, op = output.Handle;
+        void** args = stackalloc void*[3];
+        args[0] = &ip; args[1] = &op; args[2] = &n;
+        LaunchKernel(kernel, (uint)((n + DefaultBlockSize - 1) / DefaultBlockSize), DefaultBlockSize, args);
+    }
+
+    /// <inheritdoc/>
+    public unsafe void PacPhaseBinMi(IGpuBuffer thetaPhase, IGpuBuffer gammaAmp, IGpuBuffer output,
+        int batch, int numSamples, int numGammaBands, int gammaIdx)
+    {
+        if (batch <= 0) return;
+        if (!_kernelCache.TryGetValue("pac_phase_bin_mi", out var kernel))
+            throw new InvalidOperationException("HIP kernel not found: pac_phase_bin_mi");
+        IntPtr tp = thetaPhase.Handle, ga = gammaAmp.Handle, op = output.Handle;
+        void** args = stackalloc void*[7];
+        args[0] = &tp; args[1] = &ga; args[2] = &op;
+        args[3] = &batch; args[4] = &numSamples; args[5] = &numGammaBands; args[6] = &gammaIdx;
+        LaunchKernelWithSharedMem(kernel, (uint)batch, 256, (uint)(2 * 18 * sizeof(float)),
+            new IntPtr[] { (IntPtr)args[0], (IntPtr)args[1], (IntPtr)args[2], (IntPtr)args[3], (IntPtr)args[4], (IntPtr)args[5], (IntPtr)args[6] });
+    }
 }
 
 /// <summary>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipSpectralPerfKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipSpectralPerfKernels.cs
@@ -1,0 +1,332 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Dedicated HIP kernels (HCC, identical syntax to CUDA) for Issue #160 spectral/audio perf operations.
+// All kernels are fully GPU-resident — no host-side loops.
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.HIP.Kernels
+{
+    internal static class HipSpectralPerfKernels
+    {
+        public static string[] GetKernelNames() => new[]
+        {
+            "atan2_elementwise",
+            "analytic_signal_mask",
+            "normalize_rows_fused",
+            "bispectrum_gather",
+            "trispectrum_gather",
+            "cavity_bounce_inplace",
+            "wideband_log_bin_pool",
+            "pac_phase_bin_mi",
+            "mel_filterbank_apply",
+            "mfcc_log1p",
+        };
+
+        public static string GetSource()
+        {
+            return @"
+#include <math.h>
+
+// =================================================================
+// Atan2 element-wise: output[i] = atan2(imag[i], real[i])
+// =================================================================
+extern ""C"" __global__ __launch_bounds__(256)
+void atan2_elementwise(const float* __restrict__ imag,
+                       const float* __restrict__ real,
+                       float* __restrict__ output,
+                       int n)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= n) return;
+    output[idx] = atan2f(imag[idx], real[idx]);
+}
+
+// =================================================================
+// Analytic signal Hilbert mask: apply gain (0, 1, or 2) per frequency bin.
+// Bins are organized as [batch, fftSize] flat. For each bin k:
+//   k == 0 or k == fftSize/2: gain = (k in [binLow, binHigh)) ? 1 : 0
+//   k < fftSize/2:            gain = (k in [binLow, binHigh)) ? 2 : 0
+//   k > fftSize/2:            gain = 0
+// Multiplies (specReal, specImag) by gain in-place into (outReal, outImag).
+// =================================================================
+extern ""C"" __global__ __launch_bounds__(256)
+void analytic_signal_mask(const float* __restrict__ specReal,
+                          const float* __restrict__ specImag,
+                          float* __restrict__ outReal,
+                          float* __restrict__ outImag,
+                          int batch, int fftSize, int binLow, int binHigh)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = batch * fftSize;
+    if (idx >= total) return;
+    int k = idx % fftSize;
+    int halfN = fftSize >> 1;
+    float gain;
+    if (k == 0 || k == halfN) {
+        gain = (k < binLow || k >= binHigh) ? 0.0f : 1.0f;
+    } else if (k < halfN) {
+        gain = (k < binLow || k >= binHigh) ? 0.0f : 2.0f;
+    } else {
+        gain = 0.0f;
+    }
+    outReal[idx] = specReal[idx] * gain;
+    outImag[idx] = specImag[idx] * gain;
+}
+
+// =================================================================
+// Per-row L2 normalize. One block per row; threads cooperate on
+// sum-of-squares reduction, then divide all elements by sqrt(sumSq).
+// =================================================================
+extern ""C"" __global__ __launch_bounds__(256)
+void normalize_rows_fused(const float* __restrict__ input,
+                          float* __restrict__ output,
+                          int rows, int cols)
+{
+    extern __shared__ float sdata[];
+    int row = blockIdx.x;
+    if (row >= rows) return;
+    int tid = threadIdx.x;
+    int rowOff = row * cols;
+
+    // Phase 1: sum of squares
+    float local = 0.0f;
+    for (int c = tid; c < cols; c += blockDim.x) {
+        float v = input[rowOff + c];
+        local += v * v;
+    }
+    sdata[tid] = local;
+    __syncthreads();
+
+    // Reduction
+    for (int s = blockDim.x >> 1; s > 0; s >>= 1) {
+        if (tid < s) sdata[tid] += sdata[tid + s];
+        __syncthreads();
+    }
+
+    float invNorm = 0.0f;
+    if (sdata[0] > 0.0f) invNorm = rsqrtf(sdata[0]);
+
+    // Phase 2: write normalized output
+    for (int c = tid; c < cols; c += blockDim.x) {
+        output[rowOff + c] = input[rowOff + c] * invNorm;
+    }
+}
+
+// =================================================================
+// Bispectrum gather: B(f1, f2) = X(f1) * X(f2) * conj(X(f1+f2))
+// One thread per output element. Output shape [maxF1, maxF2] complex.
+// =================================================================
+extern ""C"" __global__ __launch_bounds__(256)
+void bispectrum_gather(const float* __restrict__ specReal,
+                       const float* __restrict__ specImag,
+                       float* __restrict__ outReal,
+                       float* __restrict__ outImag,
+                       int maxF1, int maxF2)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = maxF1 * maxF2;
+    if (idx >= total) return;
+    int f1 = idx / maxF2;
+    int f2 = idx % maxF2;
+    int sumIdx = f1 + f2;
+
+    float ar = specReal[f1], ai = specImag[f1];
+    float br = specReal[f2], bi = specImag[f2];
+    float cr = specReal[sumIdx], ci = -specImag[sumIdx]; // conjugate
+
+    // (ar+i*ai) * (br+i*bi) = (ar*br - ai*bi) + i*(ar*bi + ai*br)
+    float abr = ar * br - ai * bi;
+    float abi = ar * bi + ai * br;
+    // (abr+i*abi) * (cr+i*ci)
+    outReal[idx] = abr * cr - abi * ci;
+    outImag[idx] = abr * ci + abi * cr;
+}
+
+// =================================================================
+// Trispectrum gather: T(f1,f2,f3) = X(f1)*X(f2)*X(f3)*conj(X(f1+f2+f3))
+// =================================================================
+extern ""C"" __global__ __launch_bounds__(256)
+void trispectrum_gather(const float* __restrict__ specReal,
+                        const float* __restrict__ specImag,
+                        float* __restrict__ outReal,
+                        float* __restrict__ outImag,
+                        int maxF1, int maxF2, int maxF3)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = maxF1 * maxF2 * maxF3;
+    if (idx >= total) return;
+    int f1 = idx / (maxF2 * maxF3);
+    int rem = idx - f1 * maxF2 * maxF3;
+    int f2 = rem / maxF3;
+    int f3 = rem - f2 * maxF3;
+    int sumIdx = f1 + f2 + f3;
+
+    float ar = specReal[f1], ai = specImag[f1];
+    float br = specReal[f2], bi = specImag[f2];
+    float cr = specReal[f3], ci = specImag[f3];
+    float dr = specReal[sumIdx], di = -specImag[sumIdx];
+
+    float t1r = ar * br - ai * bi;
+    float t1i = ar * bi + ai * br;
+    float t2r = t1r * cr - t1i * ci;
+    float t2i = t1r * ci + t1i * cr;
+    outReal[idx] = t2r * dr - t2i * di;
+    outImag[idx] = t2r * di + t2i * dr;
+}
+
+// =================================================================
+// Cavity bounce in-place: applies the per-bounce nonlinearity to a
+// time-domain signal that was just IFFT'd. Computes tanh(real / N) for
+// real part, zeros imag part. N is fftSize for IFFT normalization.
+// Designed to fuse the post-IFFT scale + tanh + imag-zero work.
+// =================================================================
+extern ""C"" __global__ __launch_bounds__(256)
+void cavity_bounce_inplace(float* __restrict__ workReal,
+                           float* __restrict__ workImag,
+                           int total, float invN)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= total) return;
+    float r = workReal[idx] * invN;
+    // Clamp to avoid NaN on extreme inputs
+    r = fminf(fmaxf(r, -20.0f), 20.0f);
+    workReal[idx] = tanhf(r);
+    workImag[idx] = 0.0f;
+}
+
+// =================================================================
+// Wideband log-bin pool: per (batch, segment), pool magnitudes into
+// numBins logarithmically-spaced bins, take log(1+avg).
+// magBuf shape: [totalSegBatch, fftSize]; output: [totalSegBatch, numBins].
+// =================================================================
+extern ""C"" __global__ __launch_bounds__(256)
+void wideband_log_bin_pool(const float* __restrict__ magBuf,
+                           float* __restrict__ output,
+                           int totalSegBatch, int fftSize, int numBins, int usable)
+{
+    int outIdx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = totalSegBatch * numBins;
+    if (outIdx >= total) return;
+    int seg = outIdx / numBins;
+    int k = outIdx % numBins;
+
+    // Logarithmic bin layout: binStart = 1 + (k/numBins)^2 * (usable-1)
+    float r0 = (float)k / (float)numBins;
+    float r1 = (float)(k + 1) / (float)numBins;
+    int binStart = 1 + (int)(r0 * r0 * (float)(usable - 1));
+    int binEnd = 1 + (int)(r1 * r1 * (float)(usable - 1));
+    if (binEnd <= binStart) binEnd = binStart + 1;
+    if (binEnd > usable) binEnd = usable;
+
+    int magOff = seg * fftSize;
+    float sum = 0.0f; int cnt = 0;
+    for (int i = binStart; i < binEnd; i++) {
+        sum += magBuf[magOff + i];
+        cnt++;
+    }
+    float avg = (cnt > 0) ? (sum / (float)cnt) : 0.0f;
+    output[outIdx] = log1pf(avg);
+}
+
+// =================================================================
+// PAC phase-binned modulation index. For each (batch, gammaBand):
+// uses 18 phase bins; computes KL-divergence of amplitude distribution
+// from uniform, normalized by log(numBins).
+// thetaPhase: [batch, numSamples], gammaAmp: [batch, numSamples]
+// output: [batch, numGammaBands], one MI value per (batch, band).
+// One block per (batch, gammaBand) pair; threads cooperate on histogram + reduction.
+// =================================================================
+extern ""C"" __global__ __launch_bounds__(256)
+void pac_phase_bin_mi(const float* __restrict__ thetaPhase,
+                      const float* __restrict__ gammaAmp,
+                      float* __restrict__ output,
+                      int batch, int numSamples, int numGammaBands, int gammaIdx)
+{
+    extern __shared__ float sdata[];
+    const int NUM_PHASE_BINS = 18;
+    int b = blockIdx.x;
+    if (b >= batch) return;
+    int tid = threadIdx.x;
+
+    // sdata layout: [NUM_PHASE_BINS sums | NUM_PHASE_BINS counts]
+    if (tid < NUM_PHASE_BINS) {
+        sdata[tid] = 0.0f;
+        sdata[NUM_PHASE_BINS + tid] = 0.0f;
+    }
+    __syncthreads();
+
+    // Histogram: each thread accumulates partial sums into shared memory via atomicAdd
+    int sampleOff = b * numSamples;
+    int gammaOff = (gammaIdx * batch + b) * numSamples;
+    for (int i = tid; i < numSamples; i += blockDim.x) {
+        float phase = thetaPhase[sampleOff + i];
+        float amp = gammaAmp[gammaOff + i];
+        float fbin = (phase + 3.14159265358979f) / (2.0f * 3.14159265358979f) * (float)NUM_PHASE_BINS;
+        int bin = (int)fbin;
+        if (bin < 0) bin = 0;
+        if (bin >= NUM_PHASE_BINS) bin = NUM_PHASE_BINS - 1;
+        atomicAdd(&sdata[bin], amp);
+        atomicAdd(&sdata[NUM_PHASE_BINS + bin], 1.0f);
+    }
+    __syncthreads();
+
+    // Compute MI on thread 0
+    if (tid == 0) {
+        float totalAmp = 0.0f;
+        for (int k = 0; k < NUM_PHASE_BINS; k++) {
+            float c = sdata[NUM_PHASE_BINS + k];
+            float avg = (c > 0.0f) ? (sdata[k] / c) : 0.0f;
+            totalAmp += avg;
+        }
+        float mi = 0.0f;
+        if (totalAmp > 0.0f) {
+            float entropy = 0.0f;
+            for (int k = 0; k < NUM_PHASE_BINS; k++) {
+                float c = sdata[NUM_PHASE_BINS + k];
+                float avg = (c > 0.0f) ? (sdata[k] / c) : 0.0f;
+                float p = avg / totalAmp;
+                if (p > 1e-12f) entropy -= p * logf(p);
+            }
+            mi = (logf((float)NUM_PHASE_BINS) - entropy) / logf((float)NUM_PHASE_BINS);
+        }
+        output[b * numGammaBands + gammaIdx] = mi;
+    }
+}
+
+// =================================================================
+// Mel filterbank apply: for each (segment, melBin), sum power[i] * melFilter[melBin*specBins + i].
+// powerSpec: [totalSegBatch, specBins], melFilters: [melBins, specBins], output: [totalSegBatch, melBins].
+// =================================================================
+extern ""C"" __global__ __launch_bounds__(256)
+void mel_filterbank_apply(const float* __restrict__ powerSpec,
+                          const float* __restrict__ melFilters,
+                          float* __restrict__ melEnergy,
+                          int totalSegBatch, int specBins, int melBins)
+{
+    int outIdx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = totalSegBatch * melBins;
+    if (outIdx >= total) return;
+    int seg = outIdx / melBins;
+    int m = outIdx % melBins;
+    int powerOff = seg * specBins;
+    int filtOff = m * specBins;
+    float sum = 0.0f;
+    for (int i = 0; i < specBins; i++)
+        sum += powerSpec[powerOff + i] * melFilters[filtOff + i];
+    melEnergy[outIdx] = sum;
+}
+
+// =================================================================
+// MFCC log1p: log(1 + e) compression
+// =================================================================
+extern ""C"" __global__ __launch_bounds__(256)
+void mfcc_log1p(const float* __restrict__ input,
+                float* __restrict__ output,
+                int n)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= n) return;
+    output[idx] = log1pf(input[idx]);
+}
+";
+        }
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
@@ -2923,6 +2923,46 @@ public interface IDirectGpuBackend : IDisposable
     void SpectralFilter(IGpuBuffer inputReal, IGpuBuffer filterReal, IGpuBuffer filterImag,
         IGpuBuffer outputReal, int batch, int height, int width, int filterSliceCount);
 
+    /// <summary>Element-wise atan2(imag, real). All buffers length n.</summary>
+    void Atan2Elementwise(IGpuBuffer imag, IGpuBuffer real, IGpuBuffer output, int n);
+
+    /// <summary>Per-row L2 normalize. Single fused kernel: per-row sum-of-squares + rsqrt + multiply.
+    /// One block per row, threads cooperate on shared-memory reduction.</summary>
+    void NormalizeRowsFused(IGpuBuffer input, IGpuBuffer output, int rows, int cols);
+
+    /// <summary>Apply Hilbert mask (analytic-signal frequency-domain weights) to a complex spectrum.
+    /// One thread per (batch, bin) pair. Mask gain is 0/1/2 based on bin index and band limits.</summary>
+    void AnalyticSignalMask(IGpuBuffer specReal, IGpuBuffer specImag,
+        IGpuBuffer outReal, IGpuBuffer outImag,
+        int batch, int fftSize, int binLow, int binHigh);
+
+    /// <summary>Bispectrum gather kernel: B(f1,f2) = X(f1)*X(f2)*conj(X(f1+f2)). One thread per output.</summary>
+    void BispectrumGather(IGpuBuffer specReal, IGpuBuffer specImag,
+        IGpuBuffer outReal, IGpuBuffer outImag, int maxF1, int maxF2);
+
+    /// <summary>Trispectrum gather kernel: T(f1,f2,f3) = X(f1)*X(f2)*X(f3)*conj(X(f1+f2+f3)).</summary>
+    void TrispectrumGather(IGpuBuffer specReal, IGpuBuffer specImag,
+        IGpuBuffer outReal, IGpuBuffer outImag, int maxF1, int maxF2, int maxF3);
+
+    /// <summary>In-place cavity bounce: scale real by 1/N, apply tanh, zero imaginary.</summary>
+    void CavityBounceInplace(IGpuBuffer workReal, IGpuBuffer workImag, int total, float invN);
+
+    /// <summary>Wideband log-bin pooling: per (batch,segment), pool magnitudes into numBins
+    /// logarithmically-spaced bins, take log(1+avg).</summary>
+    void WidebandLogBinPool(IGpuBuffer magBuf, IGpuBuffer output,
+        int totalSegBatch, int fftSize, int numBins, int usable);
+
+    /// <summary>Mel filterbank apply: melEnergy[seg,m] = sum_i powerSpec[seg,i] * melFilters[m,i].</summary>
+    void MelFilterbankApply(IGpuBuffer powerSpec, IGpuBuffer melFilters, IGpuBuffer melEnergy,
+        int totalSegBatch, int specBins, int melBins);
+
+    /// <summary>log(1 + e) compression for MFCC mel-energy.</summary>
+    void MfccLog1p(IGpuBuffer input, IGpuBuffer output, int n);
+
+    /// <summary>PAC phase-binned KL modulation index. One block per batch sample.</summary>
+    void PacPhaseBinMi(IGpuBuffer thetaPhase, IGpuBuffer gammaAmp, IGpuBuffer output,
+        int batch, int numSamples, int numGammaBands, int gammaIdx);
+
     #endregion
 }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
@@ -2923,8 +2923,9 @@ public interface IDirectGpuBackend : IDisposable
     void SpectralFilter(IGpuBuffer inputReal, IGpuBuffer filterReal, IGpuBuffer filterImag,
         IGpuBuffer outputReal, int batch, int height, int width, int filterSliceCount);
 
-    /// <summary>Element-wise atan2(imag, real). All buffers length n.</summary>
-    void Atan2Elementwise(IGpuBuffer imag, IGpuBuffer real, IGpuBuffer output, int n);
+    /// <summary>Element-wise atan2: output[i] = atan2(imag[i], real[i]). Parameter order matches
+    /// <see cref="ComplexPhase"/> / <see cref="SplitComplexPhase"/> (real, imag). All buffers length n.</summary>
+    void Atan2Elementwise(IGpuBuffer real, IGpuBuffer imag, IGpuBuffer output, int n);
 
     /// <summary>Per-row L2 normalize. Single fused kernel: per-row sum-of-squares + rsqrt + multiply.
     /// One block per row, threads cooperate on shared-memory reduction.</summary>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Signal.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Signal.cs
@@ -742,8 +742,15 @@ public sealed partial class MetalBackend
     {
         ThrowIfDisposed();
         if (batch <= 0 || fftSize <= 0) return;
-        int total = batch * fftSize;
-        if (total <= 0) return;
+        // Validate signed bin indices before casting to uint (negative values would wrap to
+        // very large unsigned values and corrupt kernel indexing).
+        if (binLow < 0 || binHigh < binLow || binHigh > fftSize)
+            throw new ArgumentOutOfRangeException(nameof(binHigh),
+                $"Require 0 <= binLow ({binLow}) <= binHigh ({binHigh}) <= fftSize ({fftSize}).");
+        // Guard batch*fftSize against int overflow.
+        long totalL = (long)batch * fftSize;
+        if (totalL <= 0 || totalL > int.MaxValue) return;
+        int total = (int)totalL;
         var pipeline = GetPipeline("SpectralPerf", _spectralPerfLibrary, "analytic_signal_mask");
         var (groups, threads) = pipeline.Calculate1DDispatch(total);
         using var encoder = _commandQueue.CreateScopedComputeEncoder();

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Signal.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Signal.cs
@@ -2,6 +2,7 @@
 // Metal GPU backend - FFT, Signal Processing, and RNG operations.
 
 using AiDotNet.Tensors.Helpers;
+using static AiDotNet.Tensors.Engines.DirectGpu.Metal.MetalNativeBindings;
 
 namespace AiDotNet.Tensors.Engines.DirectGpu.Metal;
 
@@ -695,5 +696,182 @@ public sealed partial class MetalBackend
             mulR?.Dispose(); mulI?.Dispose();
             ifftI?.Dispose(); zeroI?.Dispose();
         }
+    }
+
+    /// <inheritdoc/>
+    public void Atan2Elementwise(IGpuBuffer imag, IGpuBuffer real, IGpuBuffer output, int n)
+    {
+        if (n <= 0) return;
+        var pipeline = GetPipeline("SpectralPerf", _spectralPerfLibrary, "atan2_elementwise");
+        var (groups, threads) = pipeline.Calculate1DDispatch(n);
+        using var encoder = _commandQueue.CreateScopedComputeEncoder();
+        encoder.SetPipelineState(pipeline.Handle);
+        encoder.SetBuffer((MetalGpuBuffer)imag, 0);
+        encoder.SetBuffer((MetalGpuBuffer)real, 1);
+        encoder.SetBuffer((MetalGpuBuffer)output, 2);
+        encoder.SetBytes((uint)n, 3);
+        encoder.DispatchThreadgroups(groups, threads);
+    }
+
+    /// <inheritdoc/>
+    public void NormalizeRowsFused(IGpuBuffer input, IGpuBuffer output, int rows, int cols)
+    {
+        if (rows <= 0 || cols <= 0) return;
+        var pipeline = GetPipeline("SpectralPerf", _spectralPerfLibrary, "normalize_rows_fused");
+        uint block = (uint)Math.Min(256, Math.Max(32, cols));
+        using var encoder = _commandQueue.CreateScopedComputeEncoder();
+        encoder.SetPipelineState(pipeline.Handle);
+        encoder.SetBuffer((MetalGpuBuffer)input, 0);
+        encoder.SetBuffer((MetalGpuBuffer)output, 1);
+        encoder.SetBytes((uint)rows, 2);
+        encoder.SetBytes((uint)cols, 3);
+        encoder.SetThreadgroupMemoryLength(block * sizeof(float), 0);
+        encoder.DispatchThreadgroups(new MTLSize((uint)rows, 1, 1), new MTLSize(block, 1, 1));
+    }
+
+    /// <inheritdoc/>
+    public void AnalyticSignalMask(IGpuBuffer specReal, IGpuBuffer specImag,
+        IGpuBuffer outReal, IGpuBuffer outImag, int batch, int fftSize, int binLow, int binHigh)
+    {
+        int total = batch * fftSize;
+        if (total <= 0) return;
+        var pipeline = GetPipeline("SpectralPerf", _spectralPerfLibrary, "analytic_signal_mask");
+        var (groups, threads) = pipeline.Calculate1DDispatch(total);
+        using var encoder = _commandQueue.CreateScopedComputeEncoder();
+        encoder.SetPipelineState(pipeline.Handle);
+        encoder.SetBuffer((MetalGpuBuffer)specReal, 0);
+        encoder.SetBuffer((MetalGpuBuffer)specImag, 1);
+        encoder.SetBuffer((MetalGpuBuffer)outReal, 2);
+        encoder.SetBuffer((MetalGpuBuffer)outImag, 3);
+        encoder.SetBytes((uint)batch, 4);
+        encoder.SetBytes((uint)fftSize, 5);
+        encoder.SetBytes((uint)binLow, 6);
+        encoder.SetBytes((uint)binHigh, 7);
+        encoder.DispatchThreadgroups(groups, threads);
+    }
+
+    /// <inheritdoc/>
+    public void BispectrumGather(IGpuBuffer specReal, IGpuBuffer specImag,
+        IGpuBuffer outReal, IGpuBuffer outImag, int maxF1, int maxF2)
+    {
+        int total = maxF1 * maxF2;
+        if (total <= 0) return;
+        var pipeline = GetPipeline("SpectralPerf", _spectralPerfLibrary, "bispectrum_gather");
+        var (groups, threads) = pipeline.Calculate1DDispatch(total);
+        using var encoder = _commandQueue.CreateScopedComputeEncoder();
+        encoder.SetPipelineState(pipeline.Handle);
+        encoder.SetBuffer((MetalGpuBuffer)specReal, 0);
+        encoder.SetBuffer((MetalGpuBuffer)specImag, 1);
+        encoder.SetBuffer((MetalGpuBuffer)outReal, 2);
+        encoder.SetBuffer((MetalGpuBuffer)outImag, 3);
+        encoder.SetBytes((uint)maxF1, 4);
+        encoder.SetBytes((uint)maxF2, 5);
+        encoder.DispatchThreadgroups(groups, threads);
+    }
+
+    /// <inheritdoc/>
+    public void TrispectrumGather(IGpuBuffer specReal, IGpuBuffer specImag,
+        IGpuBuffer outReal, IGpuBuffer outImag, int maxF1, int maxF2, int maxF3)
+    {
+        int total = maxF1 * maxF2 * maxF3;
+        if (total <= 0) return;
+        var pipeline = GetPipeline("SpectralPerf", _spectralPerfLibrary, "trispectrum_gather");
+        var (groups, threads) = pipeline.Calculate1DDispatch(total);
+        using var encoder = _commandQueue.CreateScopedComputeEncoder();
+        encoder.SetPipelineState(pipeline.Handle);
+        encoder.SetBuffer((MetalGpuBuffer)specReal, 0);
+        encoder.SetBuffer((MetalGpuBuffer)specImag, 1);
+        encoder.SetBuffer((MetalGpuBuffer)outReal, 2);
+        encoder.SetBuffer((MetalGpuBuffer)outImag, 3);
+        encoder.SetBytes((uint)maxF1, 4);
+        encoder.SetBytes((uint)maxF2, 5);
+        encoder.SetBytes((uint)maxF3, 6);
+        encoder.DispatchThreadgroups(groups, threads);
+    }
+
+    /// <inheritdoc/>
+    public void CavityBounceInplace(IGpuBuffer workReal, IGpuBuffer workImag, int total, float invN)
+    {
+        if (total <= 0) return;
+        var pipeline = GetPipeline("SpectralPerf", _spectralPerfLibrary, "cavity_bounce_inplace");
+        var (groups, threads) = pipeline.Calculate1DDispatch(total);
+        using var encoder = _commandQueue.CreateScopedComputeEncoder();
+        encoder.SetPipelineState(pipeline.Handle);
+        encoder.SetBuffer((MetalGpuBuffer)workReal, 0);
+        encoder.SetBuffer((MetalGpuBuffer)workImag, 1);
+        encoder.SetBytes((uint)total, 2);
+        encoder.SetBytes(invN, 3);
+        encoder.DispatchThreadgroups(groups, threads);
+    }
+
+    /// <inheritdoc/>
+    public void WidebandLogBinPool(IGpuBuffer magBuf, IGpuBuffer output,
+        int totalSegBatch, int fftSize, int numBins, int usable)
+    {
+        int total = totalSegBatch * numBins;
+        if (total <= 0) return;
+        var pipeline = GetPipeline("SpectralPerf", _spectralPerfLibrary, "wideband_log_bin_pool");
+        var (groups, threads) = pipeline.Calculate1DDispatch(total);
+        using var encoder = _commandQueue.CreateScopedComputeEncoder();
+        encoder.SetPipelineState(pipeline.Handle);
+        encoder.SetBuffer((MetalGpuBuffer)magBuf, 0);
+        encoder.SetBuffer((MetalGpuBuffer)output, 1);
+        encoder.SetBytes((uint)totalSegBatch, 2);
+        encoder.SetBytes((uint)fftSize, 3);
+        encoder.SetBytes((uint)numBins, 4);
+        encoder.SetBytes((uint)usable, 5);
+        encoder.DispatchThreadgroups(groups, threads);
+    }
+
+    /// <inheritdoc/>
+    public void MelFilterbankApply(IGpuBuffer powerSpec, IGpuBuffer melFilters, IGpuBuffer melEnergy,
+        int totalSegBatch, int specBins, int melBins)
+    {
+        int total = totalSegBatch * melBins;
+        if (total <= 0) return;
+        var pipeline = GetPipeline("SpectralPerf", _spectralPerfLibrary, "mel_filterbank_apply");
+        var (groups, threads) = pipeline.Calculate1DDispatch(total);
+        using var encoder = _commandQueue.CreateScopedComputeEncoder();
+        encoder.SetPipelineState(pipeline.Handle);
+        encoder.SetBuffer((MetalGpuBuffer)powerSpec, 0);
+        encoder.SetBuffer((MetalGpuBuffer)melFilters, 1);
+        encoder.SetBuffer((MetalGpuBuffer)melEnergy, 2);
+        encoder.SetBytes((uint)totalSegBatch, 3);
+        encoder.SetBytes((uint)specBins, 4);
+        encoder.SetBytes((uint)melBins, 5);
+        encoder.DispatchThreadgroups(groups, threads);
+    }
+
+    /// <inheritdoc/>
+    public void MfccLog1p(IGpuBuffer input, IGpuBuffer output, int n)
+    {
+        if (n <= 0) return;
+        var pipeline = GetPipeline("SpectralPerf", _spectralPerfLibrary, "mfcc_log1p");
+        var (groups, threads) = pipeline.Calculate1DDispatch(n);
+        using var encoder = _commandQueue.CreateScopedComputeEncoder();
+        encoder.SetPipelineState(pipeline.Handle);
+        encoder.SetBuffer((MetalGpuBuffer)input, 0);
+        encoder.SetBuffer((MetalGpuBuffer)output, 1);
+        encoder.SetBytes((uint)n, 2);
+        encoder.DispatchThreadgroups(groups, threads);
+    }
+
+    /// <inheritdoc/>
+    public void PacPhaseBinMi(IGpuBuffer thetaPhase, IGpuBuffer gammaAmp, IGpuBuffer output,
+        int batch, int numSamples, int numGammaBands, int gammaIdx)
+    {
+        if (batch <= 0) return;
+        var pipeline = GetPipeline("SpectralPerf", _spectralPerfLibrary, "pac_phase_bin_mi");
+        var (groups, threads) = pipeline.Calculate1DDispatch(batch);
+        using var encoder = _commandQueue.CreateScopedComputeEncoder();
+        encoder.SetPipelineState(pipeline.Handle);
+        encoder.SetBuffer((MetalGpuBuffer)thetaPhase, 0);
+        encoder.SetBuffer((MetalGpuBuffer)gammaAmp, 1);
+        encoder.SetBuffer((MetalGpuBuffer)output, 2);
+        encoder.SetBytes((uint)batch, 3);
+        encoder.SetBytes((uint)numSamples, 4);
+        encoder.SetBytes((uint)numGammaBands, 5);
+        encoder.SetBytes((uint)gammaIdx, 6);
+        encoder.DispatchThreadgroups(groups, threads);
     }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Signal.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Signal.cs
@@ -699,13 +699,15 @@ public sealed partial class MetalBackend
     }
 
     /// <inheritdoc/>
-    public void Atan2Elementwise(IGpuBuffer imag, IGpuBuffer real, IGpuBuffer output, int n)
+    public void Atan2Elementwise(IGpuBuffer real, IGpuBuffer imag, IGpuBuffer output, int n)
     {
+        ThrowIfDisposed();
         if (n <= 0) return;
         var pipeline = GetPipeline("SpectralPerf", _spectralPerfLibrary, "atan2_elementwise");
         var (groups, threads) = pipeline.Calculate1DDispatch(n);
         using var encoder = _commandQueue.CreateScopedComputeEncoder();
         encoder.SetPipelineState(pipeline.Handle);
+        // Kernel signature is atan2_elementwise(imag, real, ...), keep binding order unchanged.
         encoder.SetBuffer((MetalGpuBuffer)imag, 0);
         encoder.SetBuffer((MetalGpuBuffer)real, 1);
         encoder.SetBuffer((MetalGpuBuffer)output, 2);
@@ -716,9 +718,14 @@ public sealed partial class MetalBackend
     /// <inheritdoc/>
     public void NormalizeRowsFused(IGpuBuffer input, IGpuBuffer output, int rows, int cols)
     {
+        ThrowIfDisposed();
         if (rows <= 0 || cols <= 0) return;
         var pipeline = GetPipeline("SpectralPerf", _spectralPerfLibrary, "normalize_rows_fused");
-        uint block = (uint)Math.Min(256, Math.Max(32, cols));
+        // The normalize_rows_fused kernel uses a tree reduction that requires a power-of-two threadgroup size.
+        // Pick the largest power-of-two <= min(256, cols), then clamp to a minimum of 32.
+        uint block = 32;
+        uint cap = (uint)Math.Min(256, cols);
+        while (block * 2 <= cap) block *= 2;
         using var encoder = _commandQueue.CreateScopedComputeEncoder();
         encoder.SetPipelineState(pipeline.Handle);
         encoder.SetBuffer((MetalGpuBuffer)input, 0);
@@ -733,6 +740,8 @@ public sealed partial class MetalBackend
     public void AnalyticSignalMask(IGpuBuffer specReal, IGpuBuffer specImag,
         IGpuBuffer outReal, IGpuBuffer outImag, int batch, int fftSize, int binLow, int binHigh)
     {
+        ThrowIfDisposed();
+        if (batch <= 0 || fftSize <= 0) return;
         int total = batch * fftSize;
         if (total <= 0) return;
         var pipeline = GetPipeline("SpectralPerf", _spectralPerfLibrary, "analytic_signal_mask");
@@ -754,8 +763,11 @@ public sealed partial class MetalBackend
     public void BispectrumGather(IGpuBuffer specReal, IGpuBuffer specImag,
         IGpuBuffer outReal, IGpuBuffer outImag, int maxF1, int maxF2)
     {
-        int total = maxF1 * maxF2;
-        if (total <= 0) return;
+        ThrowIfDisposed();
+        if (maxF1 <= 0 || maxF2 <= 0) return;
+        long totalL = (long)maxF1 * maxF2;
+        if (totalL <= 0 || totalL > int.MaxValue) return;
+        int total = (int)totalL;
         var pipeline = GetPipeline("SpectralPerf", _spectralPerfLibrary, "bispectrum_gather");
         var (groups, threads) = pipeline.Calculate1DDispatch(total);
         using var encoder = _commandQueue.CreateScopedComputeEncoder();
@@ -773,8 +785,11 @@ public sealed partial class MetalBackend
     public void TrispectrumGather(IGpuBuffer specReal, IGpuBuffer specImag,
         IGpuBuffer outReal, IGpuBuffer outImag, int maxF1, int maxF2, int maxF3)
     {
-        int total = maxF1 * maxF2 * maxF3;
-        if (total <= 0) return;
+        ThrowIfDisposed();
+        if (maxF1 <= 0 || maxF2 <= 0 || maxF3 <= 0) return;
+        long totalL = (long)maxF1 * maxF2 * maxF3;
+        if (totalL <= 0 || totalL > int.MaxValue) return;
+        int total = (int)totalL;
         var pipeline = GetPipeline("SpectralPerf", _spectralPerfLibrary, "trispectrum_gather");
         var (groups, threads) = pipeline.Calculate1DDispatch(total);
         using var encoder = _commandQueue.CreateScopedComputeEncoder();
@@ -792,6 +807,7 @@ public sealed partial class MetalBackend
     /// <inheritdoc/>
     public void CavityBounceInplace(IGpuBuffer workReal, IGpuBuffer workImag, int total, float invN)
     {
+        ThrowIfDisposed();
         if (total <= 0) return;
         var pipeline = GetPipeline("SpectralPerf", _spectralPerfLibrary, "cavity_bounce_inplace");
         var (groups, threads) = pipeline.Calculate1DDispatch(total);
@@ -808,8 +824,11 @@ public sealed partial class MetalBackend
     public void WidebandLogBinPool(IGpuBuffer magBuf, IGpuBuffer output,
         int totalSegBatch, int fftSize, int numBins, int usable)
     {
-        int total = totalSegBatch * numBins;
-        if (total <= 0) return;
+        ThrowIfDisposed();
+        if (totalSegBatch <= 0 || fftSize <= 0 || numBins <= 0 || usable <= 0) return;
+        long totalL = (long)totalSegBatch * numBins;
+        if (totalL <= 0 || totalL > int.MaxValue) return;
+        int total = (int)totalL;
         var pipeline = GetPipeline("SpectralPerf", _spectralPerfLibrary, "wideband_log_bin_pool");
         var (groups, threads) = pipeline.Calculate1DDispatch(total);
         using var encoder = _commandQueue.CreateScopedComputeEncoder();
@@ -827,8 +846,11 @@ public sealed partial class MetalBackend
     public void MelFilterbankApply(IGpuBuffer powerSpec, IGpuBuffer melFilters, IGpuBuffer melEnergy,
         int totalSegBatch, int specBins, int melBins)
     {
-        int total = totalSegBatch * melBins;
-        if (total <= 0) return;
+        ThrowIfDisposed();
+        if (totalSegBatch <= 0 || specBins <= 0 || melBins <= 0) return;
+        long totalL = (long)totalSegBatch * melBins;
+        if (totalL <= 0 || totalL > int.MaxValue) return;
+        int total = (int)totalL;
         var pipeline = GetPipeline("SpectralPerf", _spectralPerfLibrary, "mel_filterbank_apply");
         var (groups, threads) = pipeline.Calculate1DDispatch(total);
         using var encoder = _commandQueue.CreateScopedComputeEncoder();
@@ -845,6 +867,7 @@ public sealed partial class MetalBackend
     /// <inheritdoc/>
     public void MfccLog1p(IGpuBuffer input, IGpuBuffer output, int n)
     {
+        ThrowIfDisposed();
         if (n <= 0) return;
         var pipeline = GetPipeline("SpectralPerf", _spectralPerfLibrary, "mfcc_log1p");
         var (groups, threads) = pipeline.Calculate1DDispatch(n);
@@ -860,7 +883,14 @@ public sealed partial class MetalBackend
     public void PacPhaseBinMi(IGpuBuffer thetaPhase, IGpuBuffer gammaAmp, IGpuBuffer output,
         int batch, int numSamples, int numGammaBands, int gammaIdx)
     {
+        ThrowIfDisposed();
         if (batch <= 0) return;
+        if (numSamples <= 0)
+            throw new ArgumentOutOfRangeException(nameof(numSamples), "numSamples must be positive.");
+        if (numGammaBands <= 0)
+            throw new ArgumentOutOfRangeException(nameof(numGammaBands), "numGammaBands must be positive.");
+        if (gammaIdx < 0 || gammaIdx >= numGammaBands)
+            throw new ArgumentOutOfRangeException(nameof(gammaIdx), $"gammaIdx must be in [0, {numGammaBands}).");
         var pipeline = GetPipeline("SpectralPerf", _spectralPerfLibrary, "pac_phase_bin_mi");
         var (groups, threads) = pipeline.Calculate1DDispatch(batch);
         using var encoder = _commandQueue.CreateScopedComputeEncoder();

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
@@ -55,6 +55,7 @@ public sealed partial class MetalBackend : IDirectGpuBackend
     private IntPtr _iouLibrary;
     private IntPtr _hyperbolicLibrary;
     private IntPtr _octonionLibrary;
+    private IntPtr _spectralPerfLibrary;
 
     #region Properties
 
@@ -181,6 +182,9 @@ public sealed partial class MetalBackend : IDirectGpuBackend
 
             // Compile octonion algebra operations
             _octonionLibrary = _shaderLibrary.CompileLibrary("Octonion", MetalKernels.OctonionKernels);
+
+            // Compile Issue #160 spectral perf kernels
+            _spectralPerfLibrary = _shaderLibrary.CompileLibrary("SpectralPerf", MetalKernels.SpectralPerfKernels);
 
             _fusedLinearLibrary = _shaderLibrary.CompileLibrary("FusedLinear", MetalKernels.FusedLinearKernels);
             _iouLibrary = _shaderLibrary.CompileLibrary("IoULoss", MetalKernels.IoULossKernels);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
@@ -182,17 +182,40 @@ public sealed partial class MetalBackend : IDirectGpuBackend
 
             // Compile octonion algebra operations
             _octonionLibrary = _shaderLibrary.CompileLibrary("Octonion", MetalKernels.OctonionKernels);
-
-            // Compile Issue #160 spectral perf kernels
-            _spectralPerfLibrary = _shaderLibrary.CompileLibrary("SpectralPerf", MetalKernels.SpectralPerfKernels);
-
-            _fusedLinearLibrary = _shaderLibrary.CompileLibrary("FusedLinear", MetalKernels.FusedLinearKernels);
-            _iouLibrary = _shaderLibrary.CompileLibrary("IoULoss", MetalKernels.IoULossKernels);
         }
         catch (Exception ex)
         {
             // Log but don't fail - kernels will be compiled on-demand
             System.Diagnostics.Debug.WriteLine($"Metal kernel pre-compilation warning: {ex.Message}");
+        }
+
+        // Compile Issue #160 spectral perf kernels independently so a failure here does not
+        // prevent the following (unrelated) libraries from being compiled.
+        try
+        {
+            _spectralPerfLibrary = _shaderLibrary.CompileLibrary("SpectralPerf", MetalKernels.SpectralPerfKernels);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Metal SpectralPerf pre-compilation warning: {ex.Message}");
+        }
+
+        try
+        {
+            _fusedLinearLibrary = _shaderLibrary.CompileLibrary("FusedLinear", MetalKernels.FusedLinearKernels);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Metal FusedLinear pre-compilation warning: {ex.Message}");
+        }
+
+        try
+        {
+            _iouLibrary = _shaderLibrary.CompileLibrary("IoULoss", MetalKernels.IoULossKernels);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Metal IoULoss pre-compilation warning: {ex.Message}");
         }
     }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalKernels.cs
@@ -4154,5 +4154,238 @@ kernel void ciou_loss_backward(device const float* goB [[buffer(0)]], device con
 }
 ";
 
+    public const string SpectralPerfKernels = CommonHeader + @"
+kernel void atan2_elementwise(
+    device const float* imag [[buffer(0)]],
+    device const float* real [[buffer(1)]],
+    device float* output [[buffer(2)]],
+    constant int& n [[buffer(3)]],
+    uint idx [[thread_position_in_grid]])
+{
+    if ((int)idx >= n) return;
+    output[idx] = atan2(imag[idx], real[idx]);
+}
+
+kernel void analytic_signal_mask(
+    device const float* specReal [[buffer(0)]],
+    device const float* specImag [[buffer(1)]],
+    device float* outReal [[buffer(2)]],
+    device float* outImag [[buffer(3)]],
+    constant int& batch [[buffer(4)]],
+    constant int& fftSize [[buffer(5)]],
+    constant int& binLow [[buffer(6)]],
+    constant int& binHigh [[buffer(7)]],
+    uint idx [[thread_position_in_grid]])
+{
+    int total = batch * fftSize;
+    if ((int)idx >= total) return;
+    int k = (int)idx % fftSize;
+    int halfN = fftSize >> 1;
+    float gain;
+    if (k == 0 || k == halfN) gain = (k < binLow || k >= binHigh) ? 0.0f : 1.0f;
+    else if (k < halfN)        gain = (k < binLow || k >= binHigh) ? 0.0f : 2.0f;
+    else                       gain = 0.0f;
+    outReal[idx] = specReal[idx] * gain;
+    outImag[idx] = specImag[idx] * gain;
+}
+
+kernel void normalize_rows_fused(
+    device const float* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    constant int& rows [[buffer(2)]],
+    constant int& cols [[buffer(3)]],
+    threadgroup float* sdata [[threadgroup(0)]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint blockDim [[threads_per_threadgroup]],
+    uint row [[threadgroup_position_in_grid]])
+{
+    if ((int)row >= rows) return;
+    int rowOff = (int)row * cols;
+    float local_acc = 0.0f;
+    for (int c = (int)tid; c < cols; c += (int)blockDim) {
+        float v = input[rowOff + c];
+        local_acc += v * v;
+    }
+    sdata[tid] = local_acc;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (uint s = blockDim >> 1; s > 0; s >>= 1) {
+        if (tid < s) sdata[tid] += sdata[tid + s];
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    float invNorm = 0.0f;
+    if (sdata[0] > 0.0f) invNorm = rsqrt(sdata[0]);
+    for (int c = (int)tid; c < cols; c += (int)blockDim) {
+        output[rowOff + c] = input[rowOff + c] * invNorm;
+    }
+}
+
+kernel void bispectrum_gather(
+    device const float* specReal [[buffer(0)]],
+    device const float* specImag [[buffer(1)]],
+    device float* outReal [[buffer(2)]],
+    device float* outImag [[buffer(3)]],
+    constant int& maxF1 [[buffer(4)]],
+    constant int& maxF2 [[buffer(5)]],
+    uint idx [[thread_position_in_grid]])
+{
+    int total = maxF1 * maxF2;
+    if ((int)idx >= total) return;
+    int f1 = (int)idx / maxF2;
+    int f2 = (int)idx % maxF2;
+    int sumIdx = f1 + f2;
+    float ar = specReal[f1], ai = specImag[f1];
+    float br = specReal[f2], bi = specImag[f2];
+    float cr = specReal[sumIdx], ci = -specImag[sumIdx];
+    float abr = ar * br - ai * bi;
+    float abi = ar * bi + ai * br;
+    outReal[idx] = abr * cr - abi * ci;
+    outImag[idx] = abr * ci + abi * cr;
+}
+
+kernel void trispectrum_gather(
+    device const float* specReal [[buffer(0)]],
+    device const float* specImag [[buffer(1)]],
+    device float* outReal [[buffer(2)]],
+    device float* outImag [[buffer(3)]],
+    constant int& maxF1 [[buffer(4)]],
+    constant int& maxF2 [[buffer(5)]],
+    constant int& maxF3 [[buffer(6)]],
+    uint idx [[thread_position_in_grid]])
+{
+    int total = maxF1 * maxF2 * maxF3;
+    if ((int)idx >= total) return;
+    int f1 = (int)idx / (maxF2 * maxF3);
+    int rem = (int)idx - f1 * maxF2 * maxF3;
+    int f2 = rem / maxF3;
+    int f3 = rem - f2 * maxF3;
+    int sumIdx = f1 + f2 + f3;
+    float ar = specReal[f1], ai = specImag[f1];
+    float br = specReal[f2], bi = specImag[f2];
+    float cr = specReal[f3], ci = specImag[f3];
+    float dr = specReal[sumIdx], di = -specImag[sumIdx];
+    float t1r = ar * br - ai * bi;
+    float t1i = ar * bi + ai * br;
+    float t2r = t1r * cr - t1i * ci;
+    float t2i = t1r * ci + t1i * cr;
+    outReal[idx] = t2r * dr - t2i * di;
+    outImag[idx] = t2r * di + t2i * dr;
+}
+
+kernel void cavity_bounce_inplace(
+    device float* workReal [[buffer(0)]],
+    device float* workImag [[buffer(1)]],
+    constant int& total [[buffer(2)]],
+    constant float& invN [[buffer(3)]],
+    uint idx [[thread_position_in_grid]])
+{
+    if ((int)idx >= total) return;
+    float r = workReal[idx] * invN;
+    r = clamp(r, -20.0f, 20.0f);
+    workReal[idx] = tanh(r);
+    workImag[idx] = 0.0f;
+}
+
+kernel void wideband_log_bin_pool(
+    device const float* magBuf [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    constant int& totalSegBatch [[buffer(2)]],
+    constant int& fftSize [[buffer(3)]],
+    constant int& numBins [[buffer(4)]],
+    constant int& usable [[buffer(5)]],
+    uint outIdx [[thread_position_in_grid]])
+{
+    int total = totalSegBatch * numBins;
+    if ((int)outIdx >= total) return;
+    int seg = (int)outIdx / numBins;
+    int k = (int)outIdx % numBins;
+    float r0 = (float)k / (float)numBins;
+    float r1 = (float)(k + 1) / (float)numBins;
+    int binStart = 1 + (int)(r0 * r0 * (float)(usable - 1));
+    int binEnd = 1 + (int)(r1 * r1 * (float)(usable - 1));
+    if (binEnd <= binStart) binEnd = binStart + 1;
+    if (binEnd > usable) binEnd = usable;
+    int magOff = seg * fftSize;
+    float sum = 0.0f; int cnt = 0;
+    for (int i = binStart; i < binEnd; i++) { sum += magBuf[magOff + i]; cnt++; }
+    float avg = (cnt > 0) ? (sum / (float)cnt) : 0.0f;
+    output[outIdx] = log(1.0f + avg);
+}
+
+kernel void mel_filterbank_apply(
+    device const float* powerSpec [[buffer(0)]],
+    device const float* melFilters [[buffer(1)]],
+    device float* melEnergy [[buffer(2)]],
+    constant int& totalSegBatch [[buffer(3)]],
+    constant int& specBins [[buffer(4)]],
+    constant int& melBins [[buffer(5)]],
+    uint outIdx [[thread_position_in_grid]])
+{
+    int total = totalSegBatch * melBins;
+    if ((int)outIdx >= total) return;
+    int seg = (int)outIdx / melBins;
+    int m = (int)outIdx % melBins;
+    int powerOff = seg * specBins;
+    int filtOff = m * specBins;
+    float sum = 0.0f;
+    for (int i = 0; i < specBins; i++)
+        sum += powerSpec[powerOff + i] * melFilters[filtOff + i];
+    melEnergy[outIdx] = sum;
+}
+
+kernel void mfcc_log1p(
+    device const float* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    constant int& n [[buffer(2)]],
+    uint idx [[thread_position_in_grid]])
+{
+    if ((int)idx >= n) return;
+    output[idx] = log(1.0f + input[idx]);
+}
+
+kernel void pac_phase_bin_mi(
+    device const float* thetaPhase [[buffer(0)]],
+    device const float* gammaAmp [[buffer(1)]],
+    device float* output [[buffer(2)]],
+    constant int& batch [[buffer(3)]],
+    constant int& numSamples [[buffer(4)]],
+    constant int& numGammaBands [[buffer(5)]],
+    constant int& gammaIdx [[buffer(6)]],
+    uint b [[thread_position_in_grid]])
+{
+    if ((int)b >= batch) return;
+    const int NUM_PHASE_BINS = 18;
+    float binSum[18]; float binCount[18];
+    for (int k = 0; k < NUM_PHASE_BINS; k++) { binSum[k] = 0.0f; binCount[k] = 0.0f; }
+    int sampleOff = (int)b * numSamples;
+    int gammaOff = (gammaIdx * batch + (int)b) * numSamples;
+    for (int i = 0; i < numSamples; i++) {
+        float phase = thetaPhase[sampleOff + i];
+        float amp = gammaAmp[gammaOff + i];
+        float fbin = (phase + 3.14159265358979f) / (2.0f * 3.14159265358979f) * (float)NUM_PHASE_BINS;
+        int bin = (int)fbin;
+        if (bin < 0) bin = 0;
+        if (bin >= NUM_PHASE_BINS) bin = NUM_PHASE_BINS - 1;
+        binSum[bin] += amp;
+        binCount[bin] += 1.0f;
+    }
+    float totalAmp = 0.0f;
+    for (int k = 0; k < NUM_PHASE_BINS; k++) {
+        float avg = (binCount[k] > 0.0f) ? (binSum[k] / binCount[k]) : 0.0f;
+        totalAmp += avg;
+    }
+    float mi = 0.0f;
+    if (totalAmp > 0.0f) {
+        float entropy = 0.0f;
+        for (int k = 0; k < NUM_PHASE_BINS; k++) {
+            float avg = (binCount[k] > 0.0f) ? (binSum[k] / binCount[k]) : 0.0f;
+            float p = avg / totalAmp;
+            if (p > 1e-12f) entropy -= p * log(p);
+        }
+        mi = (log((float)NUM_PHASE_BINS) - entropy) / log((float)NUM_PHASE_BINS);
+    }
+    output[(int)b * numGammaBands + gammaIdx] = mi;
+}
+";
+
     #endregion
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/SpectralPerfKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/SpectralPerfKernels.cs
@@ -1,0 +1,246 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Dedicated OpenCL kernels for Issue #160 spectral/audio perf operations.
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL.Kernels
+{
+    internal static class SpectralPerfKernels
+    {
+        public static string[] GetKernelNames() => new[]
+        {
+            "atan2_elementwise",
+            "analytic_signal_mask",
+            "normalize_rows_fused",
+            "bispectrum_gather",
+            "trispectrum_gather",
+            "cavity_bounce_inplace",
+            "wideband_log_bin_pool",
+            "pac_phase_bin_mi",
+            "mel_filterbank_apply",
+            "mfcc_log1p",
+        };
+
+        public static string GetSource()
+        {
+            return @"
+__kernel void atan2_elementwise(__global const float* imag,
+                                __global const float* real,
+                                __global float* output,
+                                int n)
+{
+    int idx = get_global_id(0);
+    if (idx >= n) return;
+    output[idx] = atan2(imag[idx], real[idx]);
+}
+
+__kernel void analytic_signal_mask(__global const float* specReal,
+                                   __global const float* specImag,
+                                   __global float* outReal,
+                                   __global float* outImag,
+                                   int batch, int fftSize, int binLow, int binHigh)
+{
+    int idx = get_global_id(0);
+    int total = batch * fftSize;
+    if (idx >= total) return;
+    int k = idx % fftSize;
+    int halfN = fftSize >> 1;
+    float gain;
+    if (k == 0 || k == halfN) {
+        gain = (k < binLow || k >= binHigh) ? 0.0f : 1.0f;
+    } else if (k < halfN) {
+        gain = (k < binLow || k >= binHigh) ? 0.0f : 2.0f;
+    } else {
+        gain = 0.0f;
+    }
+    outReal[idx] = specReal[idx] * gain;
+    outImag[idx] = specImag[idx] * gain;
+}
+
+__kernel void normalize_rows_fused(__global const float* input,
+                                   __global float* output,
+                                   __local float* sdata,
+                                   int rows, int cols)
+{
+    int row = get_group_id(0);
+    if (row >= rows) return;
+    int tid = get_local_id(0);
+    int blockDim = get_local_size(0);
+    int rowOff = row * cols;
+
+    float local_acc = 0.0f;
+    for (int c = tid; c < cols; c += blockDim) {
+        float v = input[rowOff + c];
+        local_acc += v * v;
+    }
+    sdata[tid] = local_acc;
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    for (int s = blockDim >> 1; s > 0; s >>= 1) {
+        if (tid < s) sdata[tid] += sdata[tid + s];
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    float invNorm = 0.0f;
+    if (sdata[0] > 0.0f) invNorm = rsqrt(sdata[0]);
+
+    for (int c = tid; c < cols; c += blockDim) {
+        output[rowOff + c] = input[rowOff + c] * invNorm;
+    }
+}
+
+__kernel void bispectrum_gather(__global const float* specReal,
+                                __global const float* specImag,
+                                __global float* outReal,
+                                __global float* outImag,
+                                int maxF1, int maxF2)
+{
+    int idx = get_global_id(0);
+    int total = maxF1 * maxF2;
+    if (idx >= total) return;
+    int f1 = idx / maxF2;
+    int f2 = idx % maxF2;
+    int sumIdx = f1 + f2;
+    float ar = specReal[f1], ai = specImag[f1];
+    float br = specReal[f2], bi = specImag[f2];
+    float cr = specReal[sumIdx], ci = -specImag[sumIdx];
+    float abr = ar * br - ai * bi;
+    float abi = ar * bi + ai * br;
+    outReal[idx] = abr * cr - abi * ci;
+    outImag[idx] = abr * ci + abi * cr;
+}
+
+__kernel void trispectrum_gather(__global const float* specReal,
+                                 __global const float* specImag,
+                                 __global float* outReal,
+                                 __global float* outImag,
+                                 int maxF1, int maxF2, int maxF3)
+{
+    int idx = get_global_id(0);
+    int total = maxF1 * maxF2 * maxF3;
+    if (idx >= total) return;
+    int f1 = idx / (maxF2 * maxF3);
+    int rem = idx - f1 * maxF2 * maxF3;
+    int f2 = rem / maxF3;
+    int f3 = rem - f2 * maxF3;
+    int sumIdx = f1 + f2 + f3;
+    float ar = specReal[f1], ai = specImag[f1];
+    float br = specReal[f2], bi = specImag[f2];
+    float cr = specReal[f3], ci = specImag[f3];
+    float dr = specReal[sumIdx], di = -specImag[sumIdx];
+    float t1r = ar * br - ai * bi;
+    float t1i = ar * bi + ai * br;
+    float t2r = t1r * cr - t1i * ci;
+    float t2i = t1r * ci + t1i * cr;
+    outReal[idx] = t2r * dr - t2i * di;
+    outImag[idx] = t2r * di + t2i * dr;
+}
+
+__kernel void cavity_bounce_inplace(__global float* workReal,
+                                    __global float* workImag,
+                                    int total, float invN)
+{
+    int idx = get_global_id(0);
+    if (idx >= total) return;
+    float r = workReal[idx] * invN;
+    r = fmin(fmax(r, -20.0f), 20.0f);
+    workReal[idx] = tanh(r);
+    workImag[idx] = 0.0f;
+}
+
+__kernel void wideband_log_bin_pool(__global const float* magBuf,
+                                    __global float* output,
+                                    int totalSegBatch, int fftSize, int numBins, int usable)
+{
+    int outIdx = get_global_id(0);
+    int total = totalSegBatch * numBins;
+    if (outIdx >= total) return;
+    int seg = outIdx / numBins;
+    int k = outIdx % numBins;
+    float r0 = (float)k / (float)numBins;
+    float r1 = (float)(k + 1) / (float)numBins;
+    int binStart = 1 + (int)(r0 * r0 * (float)(usable - 1));
+    int binEnd = 1 + (int)(r1 * r1 * (float)(usable - 1));
+    if (binEnd <= binStart) binEnd = binStart + 1;
+    if (binEnd > usable) binEnd = usable;
+    int magOff = seg * fftSize;
+    float sum = 0.0f; int cnt = 0;
+    for (int i = binStart; i < binEnd; i++) {
+        sum += magBuf[magOff + i];
+        cnt++;
+    }
+    float avg = (cnt > 0) ? (sum / (float)cnt) : 0.0f;
+    output[outIdx] = log1p(avg);
+}
+
+// PAC: one work-group per batch, single-thread histogram + reduction.
+// Avoids float atomics (not portable in OpenCL 1.x).
+__kernel void pac_phase_bin_mi(__global const float* thetaPhase,
+                               __global const float* gammaAmp,
+                               __global float* output,
+                               int batch, int numSamples, int numGammaBands, int gammaIdx)
+{
+    int b = get_global_id(0);
+    if (b >= batch) return;
+    const int NUM_PHASE_BINS = 18;
+    float binSum[18];
+    float binCount[18];
+    for (int k = 0; k < NUM_PHASE_BINS; k++) { binSum[k] = 0.0f; binCount[k] = 0.0f; }
+    int sampleOff = b * numSamples;
+    int gammaOff = (gammaIdx * batch + b) * numSamples;
+    for (int i = 0; i < numSamples; i++) {
+        float phase = thetaPhase[sampleOff + i];
+        float amp = gammaAmp[gammaOff + i];
+        float fbin = (phase + 3.14159265358979f) / (2.0f * 3.14159265358979f) * (float)NUM_PHASE_BINS;
+        int bin = (int)fbin;
+        if (bin < 0) bin = 0;
+        if (bin >= NUM_PHASE_BINS) bin = NUM_PHASE_BINS - 1;
+        binSum[bin] += amp;
+        binCount[bin] += 1.0f;
+    }
+    float totalAmp = 0.0f;
+    for (int k = 0; k < NUM_PHASE_BINS; k++) {
+        float avg = (binCount[k] > 0.0f) ? (binSum[k] / binCount[k]) : 0.0f;
+        totalAmp += avg;
+    }
+    float mi = 0.0f;
+    if (totalAmp > 0.0f) {
+        float entropy = 0.0f;
+        for (int k = 0; k < NUM_PHASE_BINS; k++) {
+            float avg = (binCount[k] > 0.0f) ? (binSum[k] / binCount[k]) : 0.0f;
+            float p = avg / totalAmp;
+            if (p > 1e-12f) entropy -= p * log(p);
+        }
+        mi = (log((float)NUM_PHASE_BINS) - entropy) / log((float)NUM_PHASE_BINS);
+    }
+    output[b * numGammaBands + gammaIdx] = mi;
+}
+
+__kernel void mel_filterbank_apply(__global const float* powerSpec,
+                                   __global const float* melFilters,
+                                   __global float* melEnergy,
+                                   int totalSegBatch, int specBins, int melBins)
+{
+    int outIdx = get_global_id(0);
+    int total = totalSegBatch * melBins;
+    if (outIdx >= total) return;
+    int seg = outIdx / melBins;
+    int m = outIdx % melBins;
+    int powerOff = seg * specBins;
+    int filtOff = m * specBins;
+    float sum = 0.0f;
+    for (int i = 0; i < specBins; i++)
+        sum += powerSpec[powerOff + i] * melFilters[filtOff + i];
+    melEnergy[outIdx] = sum;
+}
+
+__kernel void mfcc_log1p(__global const float* input,
+                         __global float* output,
+                         int n)
+{
+    int idx = get_global_id(0);
+    if (idx >= n) return;
+    output[idx] = log1p(input[idx]);
+}
+";
+        }
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -417,6 +417,14 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                     _kernelCache[name] = new DirectOpenClKernel(_context, fftProgram, name);
                 }
 
+                // Compile spectral perf kernels (Issue #160)
+                var spectralPerfProgram = CompileOrLoadCached(SpectralPerfKernels.GetSource(), optimizationFlags, "Spectral perf kernels");
+                _programs.Add(spectralPerfProgram);
+                foreach (var name in SpectralPerfKernels.GetKernelNames())
+                {
+                    _kernelCache[name] = new DirectOpenClKernel(_context, spectralPerfProgram, name);
+                }
+
                 // Compile spatial transformer kernels (TopK, AffineGrid, GridSample)
                 var stProgram = CompileOrLoadCached(SpatialTransformerKernels.GetSource(), optimizationFlags, "Spatial transformer kernels");
                 _programs.Add(stProgram);
@@ -10652,6 +10660,164 @@ KERNEL VARIANTS (A/B testing):
             mulR?.Dispose(); mulI?.Dispose();
             ifftI?.Dispose(); zeroI?.Dispose();
         }
+    }
+
+    /// <inheritdoc/>
+    public void Atan2Elementwise(IGpuBuffer imag, IGpuBuffer real, IGpuBuffer output, int n)
+    {
+        if (n <= 0) return;
+        if (!_kernelCache.TryGetValue("atan2_elementwise", out var kernel))
+            throw new InvalidOperationException("OpenCL kernel not found: atan2_elementwise");
+        kernel.SetArg(0u, ((DirectOpenClGpuBuffer)imag).Buffer.Handle);
+        kernel.SetArg(1u, ((DirectOpenClGpuBuffer)real).Buffer.Handle);
+        kernel.SetArg(2u, ((DirectOpenClGpuBuffer)output).Buffer.Handle);
+        kernel.SetArg(3u, n);
+        kernel.Execute1D(n, Math.Min(256, n));
+    }
+
+    /// <inheritdoc/>
+    public void NormalizeRowsFused(IGpuBuffer input, IGpuBuffer output, int rows, int cols)
+    {
+        if (rows <= 0 || cols <= 0) return;
+        if (!_kernelCache.TryGetValue("normalize_rows_fused", out var kernel))
+            throw new InvalidOperationException("OpenCL kernel not found: normalize_rows_fused");
+        int block = Math.Min(256, Math.Max(32, cols));
+        kernel.SetArg(0u, ((DirectOpenClGpuBuffer)input).Buffer.Handle);
+        kernel.SetArg(1u, ((DirectOpenClGpuBuffer)output).Buffer.Handle);
+        kernel.SetLocalArg(2u, block * sizeof(float));
+        kernel.SetArg(3u, rows);
+        kernel.SetArg(4u, cols);
+        kernel.Execute1D(rows * block, block);
+    }
+
+    /// <inheritdoc/>
+    public void AnalyticSignalMask(IGpuBuffer specReal, IGpuBuffer specImag,
+        IGpuBuffer outReal, IGpuBuffer outImag, int batch, int fftSize, int binLow, int binHigh)
+    {
+        int total = batch * fftSize;
+        if (total <= 0) return;
+        if (!_kernelCache.TryGetValue("analytic_signal_mask", out var kernel))
+            throw new InvalidOperationException("OpenCL kernel not found: analytic_signal_mask");
+        kernel.SetArg(0u, ((DirectOpenClGpuBuffer)specReal).Buffer.Handle);
+        kernel.SetArg(1u, ((DirectOpenClGpuBuffer)specImag).Buffer.Handle);
+        kernel.SetArg(2u, ((DirectOpenClGpuBuffer)outReal).Buffer.Handle);
+        kernel.SetArg(3u, ((DirectOpenClGpuBuffer)outImag).Buffer.Handle);
+        kernel.SetArg(4u, batch);
+        kernel.SetArg(5u, fftSize);
+        kernel.SetArg(6u, binLow);
+        kernel.SetArg(7u, binHigh);
+        kernel.Execute1D(total, Math.Min(256, total));
+    }
+
+    /// <inheritdoc/>
+    public void BispectrumGather(IGpuBuffer specReal, IGpuBuffer specImag,
+        IGpuBuffer outReal, IGpuBuffer outImag, int maxF1, int maxF2)
+    {
+        int total = maxF1 * maxF2;
+        if (total <= 0) return;
+        if (!_kernelCache.TryGetValue("bispectrum_gather", out var kernel))
+            throw new InvalidOperationException("OpenCL kernel not found: bispectrum_gather");
+        kernel.SetArg(0u, ((DirectOpenClGpuBuffer)specReal).Buffer.Handle);
+        kernel.SetArg(1u, ((DirectOpenClGpuBuffer)specImag).Buffer.Handle);
+        kernel.SetArg(2u, ((DirectOpenClGpuBuffer)outReal).Buffer.Handle);
+        kernel.SetArg(3u, ((DirectOpenClGpuBuffer)outImag).Buffer.Handle);
+        kernel.SetArg(4u, maxF1);
+        kernel.SetArg(5u, maxF2);
+        kernel.Execute1D(total, Math.Min(256, total));
+    }
+
+    /// <inheritdoc/>
+    public void TrispectrumGather(IGpuBuffer specReal, IGpuBuffer specImag,
+        IGpuBuffer outReal, IGpuBuffer outImag, int maxF1, int maxF2, int maxF3)
+    {
+        int total = maxF1 * maxF2 * maxF3;
+        if (total <= 0) return;
+        if (!_kernelCache.TryGetValue("trispectrum_gather", out var kernel))
+            throw new InvalidOperationException("OpenCL kernel not found: trispectrum_gather");
+        kernel.SetArg(0u, ((DirectOpenClGpuBuffer)specReal).Buffer.Handle);
+        kernel.SetArg(1u, ((DirectOpenClGpuBuffer)specImag).Buffer.Handle);
+        kernel.SetArg(2u, ((DirectOpenClGpuBuffer)outReal).Buffer.Handle);
+        kernel.SetArg(3u, ((DirectOpenClGpuBuffer)outImag).Buffer.Handle);
+        kernel.SetArg(4u, maxF1);
+        kernel.SetArg(5u, maxF2);
+        kernel.SetArg(6u, maxF3);
+        kernel.Execute1D(total, Math.Min(256, total));
+    }
+
+    /// <inheritdoc/>
+    public void CavityBounceInplace(IGpuBuffer workReal, IGpuBuffer workImag, int total, float invN)
+    {
+        if (total <= 0) return;
+        if (!_kernelCache.TryGetValue("cavity_bounce_inplace", out var kernel))
+            throw new InvalidOperationException("OpenCL kernel not found: cavity_bounce_inplace");
+        kernel.SetArg(0u, ((DirectOpenClGpuBuffer)workReal).Buffer.Handle);
+        kernel.SetArg(1u, ((DirectOpenClGpuBuffer)workImag).Buffer.Handle);
+        kernel.SetArg(2u, total);
+        kernel.SetArg(3u, invN);
+        kernel.Execute1D(total, Math.Min(256, total));
+    }
+
+    /// <inheritdoc/>
+    public void WidebandLogBinPool(IGpuBuffer magBuf, IGpuBuffer output,
+        int totalSegBatch, int fftSize, int numBins, int usable)
+    {
+        int total = totalSegBatch * numBins;
+        if (total <= 0) return;
+        if (!_kernelCache.TryGetValue("wideband_log_bin_pool", out var kernel))
+            throw new InvalidOperationException("OpenCL kernel not found: wideband_log_bin_pool");
+        kernel.SetArg(0u, ((DirectOpenClGpuBuffer)magBuf).Buffer.Handle);
+        kernel.SetArg(1u, ((DirectOpenClGpuBuffer)output).Buffer.Handle);
+        kernel.SetArg(2u, totalSegBatch);
+        kernel.SetArg(3u, fftSize);
+        kernel.SetArg(4u, numBins);
+        kernel.SetArg(5u, usable);
+        kernel.Execute1D(total, Math.Min(256, total));
+    }
+
+    /// <inheritdoc/>
+    public void MelFilterbankApply(IGpuBuffer powerSpec, IGpuBuffer melFilters, IGpuBuffer melEnergy,
+        int totalSegBatch, int specBins, int melBins)
+    {
+        int total = totalSegBatch * melBins;
+        if (total <= 0) return;
+        if (!_kernelCache.TryGetValue("mel_filterbank_apply", out var kernel))
+            throw new InvalidOperationException("OpenCL kernel not found: mel_filterbank_apply");
+        kernel.SetArg(0u, ((DirectOpenClGpuBuffer)powerSpec).Buffer.Handle);
+        kernel.SetArg(1u, ((DirectOpenClGpuBuffer)melFilters).Buffer.Handle);
+        kernel.SetArg(2u, ((DirectOpenClGpuBuffer)melEnergy).Buffer.Handle);
+        kernel.SetArg(3u, totalSegBatch);
+        kernel.SetArg(4u, specBins);
+        kernel.SetArg(5u, melBins);
+        kernel.Execute1D(total, Math.Min(256, total));
+    }
+
+    /// <inheritdoc/>
+    public void MfccLog1p(IGpuBuffer input, IGpuBuffer output, int n)
+    {
+        if (n <= 0) return;
+        if (!_kernelCache.TryGetValue("mfcc_log1p", out var kernel))
+            throw new InvalidOperationException("OpenCL kernel not found: mfcc_log1p");
+        kernel.SetArg(0u, ((DirectOpenClGpuBuffer)input).Buffer.Handle);
+        kernel.SetArg(1u, ((DirectOpenClGpuBuffer)output).Buffer.Handle);
+        kernel.SetArg(2u, n);
+        kernel.Execute1D(n, Math.Min(256, n));
+    }
+
+    /// <inheritdoc/>
+    public void PacPhaseBinMi(IGpuBuffer thetaPhase, IGpuBuffer gammaAmp, IGpuBuffer output,
+        int batch, int numSamples, int numGammaBands, int gammaIdx)
+    {
+        if (batch <= 0) return;
+        if (!_kernelCache.TryGetValue("pac_phase_bin_mi", out var kernel))
+            throw new InvalidOperationException("OpenCL kernel not found: pac_phase_bin_mi");
+        kernel.SetArg(0u, ((DirectOpenClGpuBuffer)thetaPhase).Buffer.Handle);
+        kernel.SetArg(1u, ((DirectOpenClGpuBuffer)gammaAmp).Buffer.Handle);
+        kernel.SetArg(2u, ((DirectOpenClGpuBuffer)output).Buffer.Handle);
+        kernel.SetArg(3u, batch);
+        kernel.SetArg(4u, numSamples);
+        kernel.SetArg(5u, numGammaBands);
+        kernel.SetArg(6u, gammaIdx);
+        kernel.Execute1D(batch, Math.Min(256, batch));
     }
 
     #endregion

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -10663,7 +10663,7 @@ KERNEL VARIANTS (A/B testing):
     }
 
     /// <inheritdoc/>
-    public void Atan2Elementwise(IGpuBuffer imag, IGpuBuffer real, IGpuBuffer output, int n)
+    public void Atan2Elementwise(IGpuBuffer real, IGpuBuffer imag, IGpuBuffer output, int n)
     {
         if (n <= 0) return;
         if (!_kernelCache.TryGetValue("atan2_elementwise", out var kernel))
@@ -10681,7 +10681,10 @@ KERNEL VARIANTS (A/B testing):
         if (rows <= 0 || cols <= 0) return;
         if (!_kernelCache.TryGetValue("normalize_rows_fused", out var kernel))
             throw new InvalidOperationException("OpenCL kernel not found: normalize_rows_fused");
-        int block = Math.Min(256, Math.Max(32, cols));
+        // Tree reduction requires a power-of-two local work-group size.
+        int block = 32;
+        int cap = Math.Min(256, cols);
+        while (block * 2 <= cap) block *= 2;
         kernel.SetArg(0u, ((DirectOpenClGpuBuffer)input).Buffer.Handle);
         kernel.SetArg(1u, ((DirectOpenClGpuBuffer)output).Buffer.Handle);
         kernel.SetLocalArg(2u, block * sizeof(float));
@@ -10694,8 +10697,10 @@ KERNEL VARIANTS (A/B testing):
     public void AnalyticSignalMask(IGpuBuffer specReal, IGpuBuffer specImag,
         IGpuBuffer outReal, IGpuBuffer outImag, int batch, int fftSize, int binLow, int binHigh)
     {
-        int total = batch * fftSize;
-        if (total <= 0) return;
+        if (batch <= 0 || fftSize <= 0) return;
+        long totalL = (long)batch * fftSize;
+        if (totalL <= 0 || totalL > int.MaxValue) return;
+        int total = (int)totalL;
         if (!_kernelCache.TryGetValue("analytic_signal_mask", out var kernel))
             throw new InvalidOperationException("OpenCL kernel not found: analytic_signal_mask");
         kernel.SetArg(0u, ((DirectOpenClGpuBuffer)specReal).Buffer.Handle);
@@ -10713,8 +10718,10 @@ KERNEL VARIANTS (A/B testing):
     public void BispectrumGather(IGpuBuffer specReal, IGpuBuffer specImag,
         IGpuBuffer outReal, IGpuBuffer outImag, int maxF1, int maxF2)
     {
-        int total = maxF1 * maxF2;
-        if (total <= 0) return;
+        if (maxF1 <= 0 || maxF2 <= 0) return;
+        long totalL = (long)maxF1 * maxF2;
+        if (totalL <= 0 || totalL > int.MaxValue) return;
+        int total = (int)totalL;
         if (!_kernelCache.TryGetValue("bispectrum_gather", out var kernel))
             throw new InvalidOperationException("OpenCL kernel not found: bispectrum_gather");
         kernel.SetArg(0u, ((DirectOpenClGpuBuffer)specReal).Buffer.Handle);
@@ -10730,8 +10737,10 @@ KERNEL VARIANTS (A/B testing):
     public void TrispectrumGather(IGpuBuffer specReal, IGpuBuffer specImag,
         IGpuBuffer outReal, IGpuBuffer outImag, int maxF1, int maxF2, int maxF3)
     {
-        int total = maxF1 * maxF2 * maxF3;
-        if (total <= 0) return;
+        if (maxF1 <= 0 || maxF2 <= 0 || maxF3 <= 0) return;
+        long totalL = (long)maxF1 * maxF2 * maxF3;
+        if (totalL <= 0 || totalL > int.MaxValue) return;
+        int total = (int)totalL;
         if (!_kernelCache.TryGetValue("trispectrum_gather", out var kernel))
             throw new InvalidOperationException("OpenCL kernel not found: trispectrum_gather");
         kernel.SetArg(0u, ((DirectOpenClGpuBuffer)specReal).Buffer.Handle);
@@ -10761,8 +10770,10 @@ KERNEL VARIANTS (A/B testing):
     public void WidebandLogBinPool(IGpuBuffer magBuf, IGpuBuffer output,
         int totalSegBatch, int fftSize, int numBins, int usable)
     {
-        int total = totalSegBatch * numBins;
-        if (total <= 0) return;
+        if (totalSegBatch <= 0 || fftSize <= 0 || numBins <= 0 || usable <= 0) return;
+        long totalL = (long)totalSegBatch * numBins;
+        if (totalL <= 0 || totalL > int.MaxValue) return;
+        int total = (int)totalL;
         if (!_kernelCache.TryGetValue("wideband_log_bin_pool", out var kernel))
             throw new InvalidOperationException("OpenCL kernel not found: wideband_log_bin_pool");
         kernel.SetArg(0u, ((DirectOpenClGpuBuffer)magBuf).Buffer.Handle);
@@ -10778,8 +10789,10 @@ KERNEL VARIANTS (A/B testing):
     public void MelFilterbankApply(IGpuBuffer powerSpec, IGpuBuffer melFilters, IGpuBuffer melEnergy,
         int totalSegBatch, int specBins, int melBins)
     {
-        int total = totalSegBatch * melBins;
-        if (total <= 0) return;
+        if (totalSegBatch <= 0 || specBins <= 0 || melBins <= 0) return;
+        long totalL = (long)totalSegBatch * melBins;
+        if (totalL <= 0 || totalL > int.MaxValue) return;
+        int total = (int)totalL;
         if (!_kernelCache.TryGetValue("mel_filterbank_apply", out var kernel))
             throw new InvalidOperationException("OpenCL kernel not found: mel_filterbank_apply");
         kernel.SetArg(0u, ((DirectOpenClGpuBuffer)powerSpec).Buffer.Handle);
@@ -10808,6 +10821,12 @@ KERNEL VARIANTS (A/B testing):
         int batch, int numSamples, int numGammaBands, int gammaIdx)
     {
         if (batch <= 0) return;
+        if (numSamples <= 0)
+            throw new ArgumentOutOfRangeException(nameof(numSamples), "numSamples must be positive.");
+        if (numGammaBands <= 0)
+            throw new ArgumentOutOfRangeException(nameof(numGammaBands), "numGammaBands must be positive.");
+        if (gammaIdx < 0 || gammaIdx >= numGammaBands)
+            throw new ArgumentOutOfRangeException(nameof(gammaIdx), $"gammaIdx must be in [0, {numGammaBands}).");
         if (!_kernelCache.TryGetValue("pac_phase_bin_mi", out var kernel))
             throw new InvalidOperationException("OpenCL kernel not found: pac_phase_bin_mi");
         kernel.SetArg(0u, ((DirectOpenClGpuBuffer)thetaPhase).Buffer.Handle);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -9880,7 +9880,7 @@ KERNEL VARIANTS (A/B testing):
             kernel.SetArg(1, winBuf.Handle);
             kernel.SetArg(2, outBuf.Handle);
             kernel.SetArg(3, n);
-            kernel.Execute1D(n, Math.Min(256, n));
+            kernel.Execute1D(n, CalculateOptimalWorkGroupSize1D(n));
         }
 
         /// <inheritdoc/>
@@ -9897,7 +9897,7 @@ KERNEL VARIANTS (A/B testing):
             kernel.SetArg(1, imagBuf.Handle);
             kernel.SetArg(2, magBuf.Handle);
             kernel.SetArg(3, n);
-            kernel.Execute1D(n, Math.Min(256, n));
+            kernel.Execute1D(n, CalculateOptimalWorkGroupSize1D(n));
         }
 
         /// <inheritdoc/>
@@ -9914,7 +9914,7 @@ KERNEL VARIANTS (A/B testing):
             kernel.SetArg(1, imagBuf.Handle);
             kernel.SetArg(2, phaseBuf.Handle);
             kernel.SetArg(3, n);
-            kernel.Execute1D(n, Math.Min(256, n));
+            kernel.Execute1D(n, CalculateOptimalWorkGroupSize1D(n));
         }
 
         /// <inheritdoc/>
@@ -9933,7 +9933,7 @@ KERNEL VARIANTS (A/B testing):
             kernel.SetArg(2, realBuf.Handle);
             kernel.SetArg(3, imagBuf.Handle);
             kernel.SetArg(4, n);
-            kernel.Execute1D(n, Math.Min(256, n));
+            kernel.Execute1D(n, CalculateOptimalWorkGroupSize1D(n));
         }
 
         /// <inheritdoc/>
@@ -9969,7 +9969,7 @@ KERNEL VARIANTS (A/B testing):
             kernel.SetArg(2, n);
             kernel.SetArg(3, refValue);
             kernel.SetArg(4, minDb);
-            kernel.Execute1D(n, Math.Min(256, n));
+            kernel.Execute1D(n, CalculateOptimalWorkGroupSize1D(n));
         }
 
         /// <inheritdoc/>
@@ -9985,7 +9985,7 @@ KERNEL VARIANTS (A/B testing):
             kernel.SetArg(1, powerBuf.Handle);
             kernel.SetArg(2, n);
             kernel.SetArg(3, refValue);
-            kernel.Execute1D(n, Math.Min(256, n));
+            kernel.Execute1D(n, CalculateOptimalWorkGroupSize1D(n));
         }
 
         public void ConvertToFp16(IGpuBuffer input, IGpuBuffer output, int size)
@@ -10672,7 +10672,7 @@ KERNEL VARIANTS (A/B testing):
         kernel.SetArg(1u, ((DirectOpenClGpuBuffer)real).Buffer.Handle);
         kernel.SetArg(2u, ((DirectOpenClGpuBuffer)output).Buffer.Handle);
         kernel.SetArg(3u, n);
-        kernel.Execute1D(n, Math.Min(256, n));
+        kernel.Execute1D(n, CalculateOptimalWorkGroupSize1D(n));
     }
 
     /// <inheritdoc/>
@@ -10681,9 +10681,11 @@ KERNEL VARIANTS (A/B testing):
         if (rows <= 0 || cols <= 0) return;
         if (!_kernelCache.TryGetValue("normalize_rows_fused", out var kernel))
             throw new InvalidOperationException("OpenCL kernel not found: normalize_rows_fused");
-        // Tree reduction requires a power-of-two local work-group size.
+        // Tree reduction requires a power-of-two local work-group size. Clamp to the
+        // device's max work-group size via the backend's sizing helper.
+        int ideal = CalculateOptimalWorkGroupSize1D(cols);
         int block = 32;
-        int cap = Math.Min(256, cols);
+        int cap = Math.Min(ideal, cols);
         while (block * 2 <= cap) block *= 2;
         kernel.SetArg(0u, ((DirectOpenClGpuBuffer)input).Buffer.Handle);
         kernel.SetArg(1u, ((DirectOpenClGpuBuffer)output).Buffer.Handle);
@@ -10711,7 +10713,7 @@ KERNEL VARIANTS (A/B testing):
         kernel.SetArg(5u, fftSize);
         kernel.SetArg(6u, binLow);
         kernel.SetArg(7u, binHigh);
-        kernel.Execute1D(total, Math.Min(256, total));
+        kernel.Execute1D(total, CalculateOptimalWorkGroupSize1D(total));
     }
 
     /// <inheritdoc/>
@@ -10730,7 +10732,7 @@ KERNEL VARIANTS (A/B testing):
         kernel.SetArg(3u, ((DirectOpenClGpuBuffer)outImag).Buffer.Handle);
         kernel.SetArg(4u, maxF1);
         kernel.SetArg(5u, maxF2);
-        kernel.Execute1D(total, Math.Min(256, total));
+        kernel.Execute1D(total, CalculateOptimalWorkGroupSize1D(total));
     }
 
     /// <inheritdoc/>
@@ -10750,7 +10752,7 @@ KERNEL VARIANTS (A/B testing):
         kernel.SetArg(4u, maxF1);
         kernel.SetArg(5u, maxF2);
         kernel.SetArg(6u, maxF3);
-        kernel.Execute1D(total, Math.Min(256, total));
+        kernel.Execute1D(total, CalculateOptimalWorkGroupSize1D(total));
     }
 
     /// <inheritdoc/>
@@ -10763,7 +10765,7 @@ KERNEL VARIANTS (A/B testing):
         kernel.SetArg(1u, ((DirectOpenClGpuBuffer)workImag).Buffer.Handle);
         kernel.SetArg(2u, total);
         kernel.SetArg(3u, invN);
-        kernel.Execute1D(total, Math.Min(256, total));
+        kernel.Execute1D(total, CalculateOptimalWorkGroupSize1D(total));
     }
 
     /// <inheritdoc/>
@@ -10782,7 +10784,7 @@ KERNEL VARIANTS (A/B testing):
         kernel.SetArg(3u, fftSize);
         kernel.SetArg(4u, numBins);
         kernel.SetArg(5u, usable);
-        kernel.Execute1D(total, Math.Min(256, total));
+        kernel.Execute1D(total, CalculateOptimalWorkGroupSize1D(total));
     }
 
     /// <inheritdoc/>
@@ -10801,7 +10803,7 @@ KERNEL VARIANTS (A/B testing):
         kernel.SetArg(3u, totalSegBatch);
         kernel.SetArg(4u, specBins);
         kernel.SetArg(5u, melBins);
-        kernel.Execute1D(total, Math.Min(256, total));
+        kernel.Execute1D(total, CalculateOptimalWorkGroupSize1D(total));
     }
 
     /// <inheritdoc/>
@@ -10813,7 +10815,7 @@ KERNEL VARIANTS (A/B testing):
         kernel.SetArg(0u, ((DirectOpenClGpuBuffer)input).Buffer.Handle);
         kernel.SetArg(1u, ((DirectOpenClGpuBuffer)output).Buffer.Handle);
         kernel.SetArg(2u, n);
-        kernel.Execute1D(n, Math.Min(256, n));
+        kernel.Execute1D(n, CalculateOptimalWorkGroupSize1D(n));
     }
 
     /// <inheritdoc/>
@@ -10836,7 +10838,7 @@ KERNEL VARIANTS (A/B testing):
         kernel.SetArg(4u, numSamples);
         kernel.SetArg(5u, numGammaBands);
         kernel.SetArg(6u, gammaIdx);
-        kernel.Execute1D(batch, Math.Min(256, batch));
+        kernel.Execute1D(batch, CalculateOptimalWorkGroupSize1D(batch));
     }
 
     #endregion

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
@@ -1794,4 +1794,96 @@ public sealed unsafe partial class VulkanBackend
             ifftI?.Dispose(); zeroI?.Dispose();
         }
     }
+
+    // Issue #160 spectral perf kernels — Vulkan implementations.
+    public void Atan2Elementwise(IGpuBuffer imag, IGpuBuffer real, IGpuBuffer output, int n)
+    {
+        if (n <= 0) return;
+        GlslBinaryOp(VulkanGlslSpectralPerfKernels.Atan2Elementwise, imag, real, output, n,
+            new uint[] { (uint)n }, sizeof(uint));
+    }
+
+    public void NormalizeRowsFused(IGpuBuffer input, IGpuBuffer output, int rows, int cols)
+    {
+        if (rows <= 0 || cols <= 0) return;
+        GlslUnaryOp(VulkanGlslSpectralPerfKernels.NormalizeRowsFused, input, output, rows,
+            new uint[] { (uint)rows, (uint)cols }, 2 * sizeof(uint));
+    }
+
+    public void AnalyticSignalMask(IGpuBuffer specReal, IGpuBuffer specImag,
+        IGpuBuffer outReal, IGpuBuffer outImag, int batch, int fftSize, int binLow, int binHigh)
+    {
+        int total = batch * fftSize;
+        if (total <= 0) return;
+        // Apply mask to real and imag with single-buffer dispatches each
+        GlslUnaryOp(VulkanGlslSpectralPerfKernels.AnalyticSignalMaskScalar, specReal, outReal, total,
+            new uint[] { (uint)batch, (uint)fftSize, (uint)binLow, (uint)binHigh }, 4 * sizeof(uint));
+        GlslUnaryOp(VulkanGlslSpectralPerfKernels.AnalyticSignalMaskScalar, specImag, outImag, total,
+            new uint[] { (uint)batch, (uint)fftSize, (uint)binLow, (uint)binHigh }, 4 * sizeof(uint));
+    }
+
+    public void BispectrumGather(IGpuBuffer specReal, IGpuBuffer specImag,
+        IGpuBuffer outReal, IGpuBuffer outImag, int maxF1, int maxF2)
+    {
+        int total = maxF1 * maxF2;
+        if (total <= 0) return;
+        GlslBinaryOp(VulkanGlslSpectralPerfKernels.BispectrumReal, specReal, specImag, outReal, total,
+            new uint[] { (uint)maxF1, (uint)maxF2 }, 2 * sizeof(uint));
+        GlslBinaryOp(VulkanGlslSpectralPerfKernels.BispectrumImag, specReal, specImag, outImag, total,
+            new uint[] { (uint)maxF1, (uint)maxF2 }, 2 * sizeof(uint));
+    }
+
+    public void TrispectrumGather(IGpuBuffer specReal, IGpuBuffer specImag,
+        IGpuBuffer outReal, IGpuBuffer outImag, int maxF1, int maxF2, int maxF3)
+    {
+        int total = maxF1 * maxF2 * maxF3;
+        if (total <= 0) return;
+        GlslBinaryOp(VulkanGlslSpectralPerfKernels.TrispectrumReal, specReal, specImag, outReal, total,
+            new uint[] { (uint)maxF1, (uint)maxF2, (uint)maxF3 }, 3 * sizeof(uint));
+        GlslBinaryOp(VulkanGlslSpectralPerfKernels.TrispectrumImag, specReal, specImag, outImag, total,
+            new uint[] { (uint)maxF1, (uint)maxF2, (uint)maxF3 }, 3 * sizeof(uint));
+    }
+
+    public void CavityBounceInplace(IGpuBuffer workReal, IGpuBuffer workImag, int total, float invN)
+    {
+        if (total <= 0) return;
+        uint invNbits = BitConverter.ToUInt32(BitConverter.GetBytes(invN), 0);
+        GlslUnaryOp(VulkanGlslSpectralPerfKernels.CavityBounceReal, workReal, workReal, total,
+            new uint[] { (uint)total, invNbits }, 2 * sizeof(uint));
+        GlslUnaryOp(VulkanGlslSpectralPerfKernels.ZeroBuffer, workImag, workImag, total,
+            new uint[] { (uint)total }, sizeof(uint));
+    }
+
+    public void WidebandLogBinPool(IGpuBuffer magBuf, IGpuBuffer output,
+        int totalSegBatch, int fftSize, int numBins, int usable)
+    {
+        int total = totalSegBatch * numBins;
+        if (total <= 0) return;
+        GlslUnaryOp(VulkanGlslSpectralPerfKernels.WidebandLogBinPool, magBuf, output, total,
+            new uint[] { (uint)totalSegBatch, (uint)fftSize, (uint)numBins, (uint)usable }, 4 * sizeof(uint));
+    }
+
+    public void MelFilterbankApply(IGpuBuffer powerSpec, IGpuBuffer melFilters, IGpuBuffer melEnergy,
+        int totalSegBatch, int specBins, int melBins)
+    {
+        int total = totalSegBatch * melBins;
+        if (total <= 0) return;
+        GlslBinaryOp(VulkanGlslSpectralPerfKernels.MelFilterbankApply, powerSpec, melFilters, melEnergy, total,
+            new uint[] { (uint)totalSegBatch, (uint)specBins, (uint)melBins }, 3 * sizeof(uint));
+    }
+
+    public void MfccLog1p(IGpuBuffer input, IGpuBuffer output, int n)
+    {
+        if (n <= 0) return;
+        GlslUnaryOp(VulkanGlslSpectralPerfKernels.MfccLog1p, input, output, n,
+            new uint[] { (uint)n }, sizeof(uint));
+    }
+
+    public void PacPhaseBinMi(IGpuBuffer thetaPhase, IGpuBuffer gammaAmp, IGpuBuffer output,
+        int batch, int numSamples, int numGammaBands, int gammaIdx)
+    {
+        if (batch <= 0) return;
+        GlslBinaryOp(VulkanGlslSpectralPerfKernels.PacPhaseBinMi, thetaPhase, gammaAmp, output, batch,
+            new uint[] { (uint)batch, (uint)numSamples, (uint)numGammaBands, (uint)gammaIdx }, 4 * sizeof(uint));
+    }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
@@ -1796,9 +1796,10 @@ public sealed unsafe partial class VulkanBackend
     }
 
     // Issue #160 spectral perf kernels — Vulkan implementations.
-    public void Atan2Elementwise(IGpuBuffer imag, IGpuBuffer real, IGpuBuffer output, int n)
+    public void Atan2Elementwise(IGpuBuffer real, IGpuBuffer imag, IGpuBuffer output, int n)
     {
         if (n <= 0) return;
+        // Kernel binding order is (imag, real, output); keep it stable and pass accordingly.
         GlslBinaryOp(VulkanGlslSpectralPerfKernels.Atan2Elementwise, imag, real, output, n,
             new uint[] { (uint)n }, sizeof(uint));
     }
@@ -1813,8 +1814,10 @@ public sealed unsafe partial class VulkanBackend
     public void AnalyticSignalMask(IGpuBuffer specReal, IGpuBuffer specImag,
         IGpuBuffer outReal, IGpuBuffer outImag, int batch, int fftSize, int binLow, int binHigh)
     {
-        int total = batch * fftSize;
-        if (total <= 0) return;
+        if (batch <= 0 || fftSize <= 0) return;
+        long totalL = (long)batch * fftSize;
+        if (totalL <= 0 || totalL > int.MaxValue) return;
+        int total = (int)totalL;
         // Apply mask to real and imag with single-buffer dispatches each
         GlslUnaryOp(VulkanGlslSpectralPerfKernels.AnalyticSignalMaskScalar, specReal, outReal, total,
             new uint[] { (uint)batch, (uint)fftSize, (uint)binLow, (uint)binHigh }, 4 * sizeof(uint));
@@ -1825,8 +1828,10 @@ public sealed unsafe partial class VulkanBackend
     public void BispectrumGather(IGpuBuffer specReal, IGpuBuffer specImag,
         IGpuBuffer outReal, IGpuBuffer outImag, int maxF1, int maxF2)
     {
-        int total = maxF1 * maxF2;
-        if (total <= 0) return;
+        if (maxF1 <= 0 || maxF2 <= 0) return;
+        long totalL = (long)maxF1 * maxF2;
+        if (totalL <= 0 || totalL > int.MaxValue) return;
+        int total = (int)totalL;
         GlslBinaryOp(VulkanGlslSpectralPerfKernels.BispectrumReal, specReal, specImag, outReal, total,
             new uint[] { (uint)maxF1, (uint)maxF2 }, 2 * sizeof(uint));
         GlslBinaryOp(VulkanGlslSpectralPerfKernels.BispectrumImag, specReal, specImag, outImag, total,
@@ -1836,8 +1841,10 @@ public sealed unsafe partial class VulkanBackend
     public void TrispectrumGather(IGpuBuffer specReal, IGpuBuffer specImag,
         IGpuBuffer outReal, IGpuBuffer outImag, int maxF1, int maxF2, int maxF3)
     {
-        int total = maxF1 * maxF2 * maxF3;
-        if (total <= 0) return;
+        if (maxF1 <= 0 || maxF2 <= 0 || maxF3 <= 0) return;
+        long totalL = (long)maxF1 * maxF2 * maxF3;
+        if (totalL <= 0 || totalL > int.MaxValue) return;
+        int total = (int)totalL;
         GlslBinaryOp(VulkanGlslSpectralPerfKernels.TrispectrumReal, specReal, specImag, outReal, total,
             new uint[] { (uint)maxF1, (uint)maxF2, (uint)maxF3 }, 3 * sizeof(uint));
         GlslBinaryOp(VulkanGlslSpectralPerfKernels.TrispectrumImag, specReal, specImag, outImag, total,
@@ -1857,8 +1864,10 @@ public sealed unsafe partial class VulkanBackend
     public void WidebandLogBinPool(IGpuBuffer magBuf, IGpuBuffer output,
         int totalSegBatch, int fftSize, int numBins, int usable)
     {
-        int total = totalSegBatch * numBins;
-        if (total <= 0) return;
+        if (totalSegBatch <= 0 || fftSize <= 0 || numBins <= 0 || usable <= 0) return;
+        long totalL = (long)totalSegBatch * numBins;
+        if (totalL <= 0 || totalL > int.MaxValue) return;
+        int total = (int)totalL;
         GlslUnaryOp(VulkanGlslSpectralPerfKernels.WidebandLogBinPool, magBuf, output, total,
             new uint[] { (uint)totalSegBatch, (uint)fftSize, (uint)numBins, (uint)usable }, 4 * sizeof(uint));
     }
@@ -1866,8 +1875,10 @@ public sealed unsafe partial class VulkanBackend
     public void MelFilterbankApply(IGpuBuffer powerSpec, IGpuBuffer melFilters, IGpuBuffer melEnergy,
         int totalSegBatch, int specBins, int melBins)
     {
-        int total = totalSegBatch * melBins;
-        if (total <= 0) return;
+        if (totalSegBatch <= 0 || specBins <= 0 || melBins <= 0) return;
+        long totalL = (long)totalSegBatch * melBins;
+        if (totalL <= 0 || totalL > int.MaxValue) return;
+        int total = (int)totalL;
         GlslBinaryOp(VulkanGlslSpectralPerfKernels.MelFilterbankApply, powerSpec, melFilters, melEnergy, total,
             new uint[] { (uint)totalSegBatch, (uint)specBins, (uint)melBins }, 3 * sizeof(uint));
     }
@@ -1883,6 +1894,12 @@ public sealed unsafe partial class VulkanBackend
         int batch, int numSamples, int numGammaBands, int gammaIdx)
     {
         if (batch <= 0) return;
+        if (numSamples <= 0)
+            throw new ArgumentOutOfRangeException(nameof(numSamples), "numSamples must be positive.");
+        if (numGammaBands <= 0)
+            throw new ArgumentOutOfRangeException(nameof(numGammaBands), "numGammaBands must be positive.");
+        if (gammaIdx < 0 || gammaIdx >= numGammaBands)
+            throw new ArgumentOutOfRangeException(nameof(gammaIdx), $"gammaIdx must be in [0, {numGammaBands}).");
         GlslBinaryOp(VulkanGlslSpectralPerfKernels.PacPhaseBinMi, thetaPhase, gammaAmp, output, batch,
             new uint[] { (uint)batch, (uint)numSamples, (uint)numGammaBands, (uint)gammaIdx }, 4 * sizeof(uint));
     }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanGlslSpectralPerfKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanGlslSpectralPerfKernels.cs
@@ -1,0 +1,240 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// GLSL compute shader sources for Issue #160 spectral perf kernels.
+// Compiled at runtime to SPIR-V via shaderc.
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.Vulkan
+{
+    internal static class VulkanGlslSpectralPerfKernels
+    {
+        private const string Header = @"#version 450
+layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+";
+        private const string TwoBufferLayout = @"
+layout(set = 0, binding = 0) readonly buffer InputA { float a[]; };
+layout(set = 0, binding = 1) writeonly buffer OutputB { float b[]; };
+";
+        private const string ThreeBufferLayout = @"
+layout(set = 0, binding = 0) readonly buffer InputA { float a[]; };
+layout(set = 0, binding = 1) readonly buffer InputB { float b[]; };
+layout(set = 0, binding = 2) writeonly buffer OutputC { float c[]; };
+";
+
+        public static string Atan2Elementwise => Header + ThreeBufferLayout + @"
+layout(push_constant) uniform Params { uint n; };
+void main() {
+    uint idx = gl_GlobalInvocationID.x;
+    if (idx >= n) return;
+    c[idx] = atan(a[idx], b[idx]);
+}";
+
+        public static string NormalizeRowsFused => Header + TwoBufferLayout + @"
+layout(push_constant) uniform Params { uint rows; uint cols; };
+void main() {
+    uint row = gl_GlobalInvocationID.x;
+    if (row >= rows) return;
+    uint rowOff = row * cols;
+    float sumSq = 0.0;
+    for (uint c = 0; c < cols; c++) { float v = a[rowOff + c]; sumSq += v * v; }
+    float invNorm = (sumSq > 0.0) ? inversesqrt(sumSq) : 0.0;
+    for (uint c = 0; c < cols; c++) b[rowOff + c] = a[rowOff + c] * invNorm;
+}";
+
+        // Single-buffer variant: writes b[idx] = a[idx] * gain.
+        // Used twice (once for real, once for imag) to implement the analytic-signal mask
+        // since the GLSL helper is constrained to two buffers.
+        public static string AnalyticSignalMaskScalar => Header + TwoBufferLayout + @"
+layout(push_constant) uniform Params { uint batch; uint fftSize; uint binLow; uint binHigh; };
+void main() {
+    uint idx = gl_GlobalInvocationID.x;
+    uint total = batch * fftSize;
+    if (idx >= total) return;
+    uint k = idx % fftSize;
+    uint halfN = fftSize >> 1;
+    float gain;
+    if (k == 0u || k == halfN) gain = (k < binLow || k >= binHigh) ? 0.0 : 1.0;
+    else if (k < halfN)        gain = (k < binLow || k >= binHigh) ? 0.0 : 2.0;
+    else                       gain = 0.0;
+    b[idx] = a[idx] * gain;
+}";
+
+        public static string BispectrumReal => Header + ThreeBufferLayout + @"
+layout(push_constant) uniform Params { uint maxF1; uint maxF2; };
+void main() {
+    uint idx = gl_GlobalInvocationID.x;
+    uint total = maxF1 * maxF2;
+    if (idx >= total) return;
+    uint f1 = idx / maxF2;
+    uint f2 = idx % maxF2;
+    uint sumIdx = f1 + f2;
+    float ar = a[f1], ai = b[f1];
+    float br = a[f2], bi = b[f2];
+    float cr = a[sumIdx], ci = -b[sumIdx];
+    float abr = ar * br - ai * bi;
+    float abi = ar * bi + ai * br;
+    c[idx] = abr * cr - abi * ci;
+}";
+
+        public static string BispectrumImag => Header + ThreeBufferLayout + @"
+layout(push_constant) uniform Params { uint maxF1; uint maxF2; };
+void main() {
+    uint idx = gl_GlobalInvocationID.x;
+    uint total = maxF1 * maxF2;
+    if (idx >= total) return;
+    uint f1 = idx / maxF2;
+    uint f2 = idx % maxF2;
+    uint sumIdx = f1 + f2;
+    float ar = a[f1], ai = b[f1];
+    float br = a[f2], bi = b[f2];
+    float cr = a[sumIdx], ci = -b[sumIdx];
+    float abr = ar * br - ai * bi;
+    float abi = ar * bi + ai * br;
+    c[idx] = abr * ci + abi * cr;
+}";
+
+        public static string TrispectrumReal => Header + ThreeBufferLayout + @"
+layout(push_constant) uniform Params { uint maxF1; uint maxF2; uint maxF3; };
+void main() {
+    uint idx = gl_GlobalInvocationID.x;
+    uint total = maxF1 * maxF2 * maxF3;
+    if (idx >= total) return;
+    uint f1 = idx / (maxF2 * maxF3);
+    uint rem = idx - f1 * maxF2 * maxF3;
+    uint f2 = rem / maxF3;
+    uint f3 = rem - f2 * maxF3;
+    uint sumIdx = f1 + f2 + f3;
+    float ar = a[f1], ai = b[f1];
+    float br = a[f2], bi = b[f2];
+    float cr = a[f3], ci = b[f3];
+    float dr = a[sumIdx], di = -b[sumIdx];
+    float t1r = ar * br - ai * bi;
+    float t1i = ar * bi + ai * br;
+    float t2r = t1r * cr - t1i * ci;
+    float t2i = t1r * ci + t1i * cr;
+    c[idx] = t2r * dr - t2i * di;
+}";
+
+        public static string TrispectrumImag => Header + ThreeBufferLayout + @"
+layout(push_constant) uniform Params { uint maxF1; uint maxF2; uint maxF3; };
+void main() {
+    uint idx = gl_GlobalInvocationID.x;
+    uint total = maxF1 * maxF2 * maxF3;
+    if (idx >= total) return;
+    uint f1 = idx / (maxF2 * maxF3);
+    uint rem = idx - f1 * maxF2 * maxF3;
+    uint f2 = rem / maxF3;
+    uint f3 = rem - f2 * maxF3;
+    uint sumIdx = f1 + f2 + f3;
+    float ar = a[f1], ai = b[f1];
+    float br = a[f2], bi = b[f2];
+    float cr = a[f3], ci = b[f3];
+    float dr = a[sumIdx], di = -b[sumIdx];
+    float t1r = ar * br - ai * bi;
+    float t1i = ar * bi + ai * br;
+    float t2r = t1r * cr - t1i * ci;
+    float t2i = t1r * ci + t1i * cr;
+    c[idx] = t2r * di + t2i * dr;
+}";
+
+        public static string CavityBounceReal => Header + TwoBufferLayout + @"
+layout(push_constant) uniform Params { uint total; uint invNBits; };
+void main() {
+    uint idx = gl_GlobalInvocationID.x;
+    if (idx >= total) return;
+    float invN = uintBitsToFloat(invNBits);
+    float r = a[idx] * invN;
+    r = clamp(r, -20.0, 20.0);
+    b[idx] = tanh(r);
+}";
+
+        public static string ZeroBuffer => Header + TwoBufferLayout + @"
+layout(push_constant) uniform Params { uint total; };
+void main() {
+    uint idx = gl_GlobalInvocationID.x;
+    if (idx >= total) return;
+    b[idx] = 0.0;
+}";
+
+        public static string WidebandLogBinPool => Header + TwoBufferLayout + @"
+layout(push_constant) uniform Params { uint totalSegBatch; uint fftSize; uint numBins; uint usable; };
+void main() {
+    uint outIdx = gl_GlobalInvocationID.x;
+    uint total = totalSegBatch * numBins;
+    if (outIdx >= total) return;
+    uint seg = outIdx / numBins;
+    uint k = outIdx % numBins;
+    float r0 = float(k) / float(numBins);
+    float r1 = float(k + 1u) / float(numBins);
+    int binStart = 1 + int(r0 * r0 * float(usable - 1u));
+    int binEnd = 1 + int(r1 * r1 * float(usable - 1u));
+    if (binEnd <= binStart) binEnd = binStart + 1;
+    if (binEnd > int(usable)) binEnd = int(usable);
+    uint magOff = seg * fftSize;
+    float sum = 0.0; int cnt = 0;
+    for (int i = binStart; i < binEnd; i++) { sum += a[magOff + uint(i)]; cnt++; }
+    float avg = (cnt > 0) ? (sum / float(cnt)) : 0.0;
+    b[outIdx] = log(1.0 + avg);
+}";
+
+        public static string MelFilterbankApply => Header + ThreeBufferLayout + @"
+layout(push_constant) uniform Params { uint totalSegBatch; uint specBins; uint melBins; };
+void main() {
+    uint outIdx = gl_GlobalInvocationID.x;
+    uint total = totalSegBatch * melBins;
+    if (outIdx >= total) return;
+    uint seg = outIdx / melBins;
+    uint m = outIdx % melBins;
+    uint powerOff = seg * specBins;
+    uint filtOff = m * specBins;
+    float sum = 0.0;
+    for (uint i = 0u; i < specBins; i++) sum += a[powerOff + i] * b[filtOff + i];
+    c[outIdx] = sum;
+}";
+
+        public static string MfccLog1p => Header + TwoBufferLayout + @"
+layout(push_constant) uniform Params { uint n; };
+void main() {
+    uint idx = gl_GlobalInvocationID.x;
+    if (idx >= n) return;
+    b[idx] = log(1.0 + a[idx]);
+}";
+
+        public static string PacPhaseBinMi => Header + ThreeBufferLayout + @"
+layout(push_constant) uniform Params { uint batch; uint numSamples; uint numGammaBands; uint gammaIdx; };
+void main() {
+    uint b_idx = gl_GlobalInvocationID.x;
+    if (b_idx >= batch) return;
+    const uint NUM_PHASE_BINS = 18u;
+    float binSum[18];
+    float binCount[18];
+    for (uint k = 0u; k < NUM_PHASE_BINS; k++) { binSum[k] = 0.0; binCount[k] = 0.0; }
+    uint sampleOff = b_idx * numSamples;
+    uint gammaOff = (gammaIdx * batch + b_idx) * numSamples;
+    for (uint i = 0u; i < numSamples; i++) {
+        float phase = a[sampleOff + i];
+        float amp = b[gammaOff + i];
+        float fbin = (phase + 3.14159265358979) / (2.0 * 3.14159265358979) * float(NUM_PHASE_BINS);
+        int bin = int(fbin);
+        if (bin < 0) bin = 0;
+        if (bin >= int(NUM_PHASE_BINS)) bin = int(NUM_PHASE_BINS) - 1;
+        binSum[bin] += amp;
+        binCount[bin] += 1.0;
+    }
+    float totalAmp = 0.0;
+    for (uint k = 0u; k < NUM_PHASE_BINS; k++) {
+        float avg = (binCount[k] > 0.0) ? (binSum[k] / binCount[k]) : 0.0;
+        totalAmp += avg;
+    }
+    float mi = 0.0;
+    if (totalAmp > 0.0) {
+        float entropy = 0.0;
+        for (uint k = 0u; k < NUM_PHASE_BINS; k++) {
+            float avg = (binCount[k] > 0.0) ? (binSum[k] / binCount[k]) : 0.0;
+            float p = avg / totalAmp;
+            if (p > 1e-12) entropy -= p * log(p);
+        }
+        mi = (log(float(NUM_PHASE_BINS)) - entropy) / log(float(NUM_PHASE_BINS));
+    }
+    c[b_idx * numGammaBands + gammaIdx] = mi;
+}";
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
@@ -1521,5 +1521,115 @@ public sealed partial class WebGpuBackend
             ifftI?.Dispose(); zeroI?.Dispose();
         }
     }
+
+    // ============================================================================
+    // Issue #160 spectral perf kernels — WebGPU implementations.
+    // ============================================================================
+
+    public void Atan2Elementwise(IGpuBuffer imag, IGpuBuffer real, IGpuBuffer output, int n)
+    {
+        if (n <= 0) return;
+        Dispatch3BufferAsync("SpectralPerf", WebGpuSpectralPerfKernels.Atan2Source,
+            "atan2_elementwise", imag, real, output,
+            new float[] { BitConverter.Int32BitsToSingle(n) }, n).GetAwaiter().GetResult();
+    }
+
+    public void NormalizeRowsFused(IGpuBuffer input, IGpuBuffer output, int rows, int cols)
+    {
+        if (rows <= 0 || cols <= 0) return;
+        Dispatch2BufferAsync("SpectralPerf", WebGpuSpectralPerfKernels.NormalizeRowsSource,
+            "normalize_rows_fused", input, output,
+            new float[] { BitConverter.Int32BitsToSingle(rows), BitConverter.Int32BitsToSingle(cols) }, rows).GetAwaiter().GetResult();
+    }
+
+    public void AnalyticSignalMask(IGpuBuffer specReal, IGpuBuffer specImag,
+        IGpuBuffer outReal, IGpuBuffer outImag, int batch, int fftSize, int binLow, int binHigh)
+    {
+        int total = batch * fftSize;
+        if (total <= 0) return;
+        var pc = new float[] { BitConverter.Int32BitsToSingle(batch), BitConverter.Int32BitsToSingle(fftSize),
+            BitConverter.Int32BitsToSingle(binLow), BitConverter.Int32BitsToSingle(binHigh) };
+        Dispatch2BufferAsync("SpectralPerf", WebGpuSpectralPerfKernels.AnalyticSignalMaskSource,
+            "analytic_signal_mask", specReal, outReal, pc, total).GetAwaiter().GetResult();
+        Dispatch2BufferAsync("SpectralPerf", WebGpuSpectralPerfKernels.AnalyticSignalMaskSource,
+            "analytic_signal_mask", specImag, outImag, pc, total).GetAwaiter().GetResult();
+    }
+
+    public void BispectrumGather(IGpuBuffer specReal, IGpuBuffer specImag,
+        IGpuBuffer outReal, IGpuBuffer outImag, int maxF1, int maxF2)
+    {
+        int total = maxF1 * maxF2;
+        if (total <= 0) return;
+        var pcReal = new float[] { BitConverter.Int32BitsToSingle(maxF1), BitConverter.Int32BitsToSingle(maxF2), BitConverter.Int32BitsToSingle(0) };
+        var pcImag = new float[] { BitConverter.Int32BitsToSingle(maxF1), BitConverter.Int32BitsToSingle(maxF2), BitConverter.Int32BitsToSingle(1) };
+        Dispatch3BufferAsync("SpectralPerf", WebGpuSpectralPerfKernels.BispectrumSource,
+            "bispectrum_gather", specReal, specImag, outReal, pcReal, total).GetAwaiter().GetResult();
+        Dispatch3BufferAsync("SpectralPerf", WebGpuSpectralPerfKernels.BispectrumSource,
+            "bispectrum_gather", specReal, specImag, outImag, pcImag, total).GetAwaiter().GetResult();
+    }
+
+    public void TrispectrumGather(IGpuBuffer specReal, IGpuBuffer specImag,
+        IGpuBuffer outReal, IGpuBuffer outImag, int maxF1, int maxF2, int maxF3)
+    {
+        int total = maxF1 * maxF2 * maxF3;
+        if (total <= 0) return;
+        var pcReal = new float[] { BitConverter.Int32BitsToSingle(maxF1), BitConverter.Int32BitsToSingle(maxF2), BitConverter.Int32BitsToSingle(maxF3), BitConverter.Int32BitsToSingle(0) };
+        var pcImag = new float[] { BitConverter.Int32BitsToSingle(maxF1), BitConverter.Int32BitsToSingle(maxF2), BitConverter.Int32BitsToSingle(maxF3), BitConverter.Int32BitsToSingle(1) };
+        Dispatch3BufferAsync("SpectralPerf", WebGpuSpectralPerfKernels.TrispectrumSource,
+            "trispectrum_gather", specReal, specImag, outReal, pcReal, total).GetAwaiter().GetResult();
+        Dispatch3BufferAsync("SpectralPerf", WebGpuSpectralPerfKernels.TrispectrumSource,
+            "trispectrum_gather", specReal, specImag, outImag, pcImag, total).GetAwaiter().GetResult();
+    }
+
+    public void CavityBounceInplace(IGpuBuffer workReal, IGpuBuffer workImag, int total, float invN)
+    {
+        if (total <= 0) return;
+        Dispatch2BufferAsync("SpectralPerf", WebGpuSpectralPerfKernels.CavityBounceSource,
+            "cavity_bounce_real", workReal, workReal,
+            new float[] { BitConverter.Int32BitsToSingle(total), invN }, total).GetAwaiter().GetResult();
+        Dispatch2BufferAsync("SpectralPerf", WebGpuSpectralPerfKernels.ZeroBufferSource,
+            "zero_buffer", workImag, workImag,
+            new float[] { BitConverter.Int32BitsToSingle(total) }, total).GetAwaiter().GetResult();
+    }
+
+    public void WidebandLogBinPool(IGpuBuffer magBuf, IGpuBuffer output,
+        int totalSegBatch, int fftSize, int numBins, int usable)
+    {
+        int total = totalSegBatch * numBins;
+        if (total <= 0) return;
+        Dispatch2BufferAsync("SpectralPerf", WebGpuSpectralPerfKernels.WidebandLogBinPoolSource,
+            "wideband_log_bin_pool", magBuf, output,
+            new float[] { BitConverter.Int32BitsToSingle(totalSegBatch), BitConverter.Int32BitsToSingle(fftSize),
+                BitConverter.Int32BitsToSingle(numBins), BitConverter.Int32BitsToSingle(usable) }, total).GetAwaiter().GetResult();
+    }
+
+    public void MelFilterbankApply(IGpuBuffer powerSpec, IGpuBuffer melFilters, IGpuBuffer melEnergy,
+        int totalSegBatch, int specBins, int melBins)
+    {
+        int total = totalSegBatch * melBins;
+        if (total <= 0) return;
+        Dispatch3BufferAsync("SpectralPerf", WebGpuSpectralPerfKernels.MelFilterbankSource,
+            "mel_filterbank_apply", powerSpec, melFilters, melEnergy,
+            new float[] { BitConverter.Int32BitsToSingle(totalSegBatch), BitConverter.Int32BitsToSingle(specBins),
+                BitConverter.Int32BitsToSingle(melBins) }, total).GetAwaiter().GetResult();
+    }
+
+    public void MfccLog1p(IGpuBuffer input, IGpuBuffer output, int n)
+    {
+        if (n <= 0) return;
+        Dispatch2BufferAsync("SpectralPerf", WebGpuSpectralPerfKernels.MfccLog1pSource,
+            "mfcc_log1p", input, output,
+            new float[] { BitConverter.Int32BitsToSingle(n) }, n).GetAwaiter().GetResult();
+    }
+
+    public void PacPhaseBinMi(IGpuBuffer thetaPhase, IGpuBuffer gammaAmp, IGpuBuffer output,
+        int batch, int numSamples, int numGammaBands, int gammaIdx)
+    {
+        if (batch <= 0) return;
+        Dispatch3BufferAsync("SpectralPerf", WebGpuSpectralPerfKernels.PacPhaseBinMiSource,
+            "pac_phase_bin_mi", thetaPhase, gammaAmp, output,
+            new float[] { BitConverter.Int32BitsToSingle(batch), BitConverter.Int32BitsToSingle(numSamples),
+                BitConverter.Int32BitsToSingle(numGammaBands), BitConverter.Int32BitsToSingle(gammaIdx) }, batch).GetAwaiter().GetResult();
+    }
 }
 #endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
@@ -1526,9 +1526,10 @@ public sealed partial class WebGpuBackend
     // Issue #160 spectral perf kernels — WebGPU implementations.
     // ============================================================================
 
-    public void Atan2Elementwise(IGpuBuffer imag, IGpuBuffer real, IGpuBuffer output, int n)
+    public void Atan2Elementwise(IGpuBuffer real, IGpuBuffer imag, IGpuBuffer output, int n)
     {
         if (n <= 0) return;
+        // Kernel binding order is (imag, real, output) internally; keep it and pass accordingly.
         Dispatch3BufferAsync("SpectralPerf", WebGpuSpectralPerfKernels.Atan2Source,
             "atan2_elementwise", imag, real, output,
             new float[] { BitConverter.Int32BitsToSingle(n) }, n).GetAwaiter().GetResult();
@@ -1545,8 +1546,12 @@ public sealed partial class WebGpuBackend
     public void AnalyticSignalMask(IGpuBuffer specReal, IGpuBuffer specImag,
         IGpuBuffer outReal, IGpuBuffer outImag, int batch, int fftSize, int binLow, int binHigh)
     {
-        int total = batch * fftSize;
-        if (total <= 0) return;
+        if (batch <= 0 || fftSize <= 0) return;
+        if (binLow < 0 || binHigh < binLow || binHigh > fftSize)
+            throw new ArgumentOutOfRangeException(nameof(binHigh), $"Require 0 <= binLow ({binLow}) <= binHigh ({binHigh}) <= fftSize ({fftSize}).");
+        long totalL = (long)batch * fftSize;
+        if (totalL <= 0 || totalL > int.MaxValue) return;
+        int total = (int)totalL;
         var pc = new float[] { BitConverter.Int32BitsToSingle(batch), BitConverter.Int32BitsToSingle(fftSize),
             BitConverter.Int32BitsToSingle(binLow), BitConverter.Int32BitsToSingle(binHigh) };
         Dispatch2BufferAsync("SpectralPerf", WebGpuSpectralPerfKernels.AnalyticSignalMaskSource,
@@ -1558,8 +1563,10 @@ public sealed partial class WebGpuBackend
     public void BispectrumGather(IGpuBuffer specReal, IGpuBuffer specImag,
         IGpuBuffer outReal, IGpuBuffer outImag, int maxF1, int maxF2)
     {
-        int total = maxF1 * maxF2;
-        if (total <= 0) return;
+        if (maxF1 <= 0 || maxF2 <= 0) return;
+        long totalL = (long)maxF1 * maxF2;
+        if (totalL <= 0 || totalL > int.MaxValue) return;
+        int total = (int)totalL;
         var pcReal = new float[] { BitConverter.Int32BitsToSingle(maxF1), BitConverter.Int32BitsToSingle(maxF2), BitConverter.Int32BitsToSingle(0) };
         var pcImag = new float[] { BitConverter.Int32BitsToSingle(maxF1), BitConverter.Int32BitsToSingle(maxF2), BitConverter.Int32BitsToSingle(1) };
         Dispatch3BufferAsync("SpectralPerf", WebGpuSpectralPerfKernels.BispectrumSource,
@@ -1571,8 +1578,10 @@ public sealed partial class WebGpuBackend
     public void TrispectrumGather(IGpuBuffer specReal, IGpuBuffer specImag,
         IGpuBuffer outReal, IGpuBuffer outImag, int maxF1, int maxF2, int maxF3)
     {
-        int total = maxF1 * maxF2 * maxF3;
-        if (total <= 0) return;
+        if (maxF1 <= 0 || maxF2 <= 0 || maxF3 <= 0) return;
+        long totalL = (long)maxF1 * maxF2 * maxF3;
+        if (totalL <= 0 || totalL > int.MaxValue) return;
+        int total = (int)totalL;
         var pcReal = new float[] { BitConverter.Int32BitsToSingle(maxF1), BitConverter.Int32BitsToSingle(maxF2), BitConverter.Int32BitsToSingle(maxF3), BitConverter.Int32BitsToSingle(0) };
         var pcImag = new float[] { BitConverter.Int32BitsToSingle(maxF1), BitConverter.Int32BitsToSingle(maxF2), BitConverter.Int32BitsToSingle(maxF3), BitConverter.Int32BitsToSingle(1) };
         Dispatch3BufferAsync("SpectralPerf", WebGpuSpectralPerfKernels.TrispectrumSource,
@@ -1595,8 +1604,10 @@ public sealed partial class WebGpuBackend
     public void WidebandLogBinPool(IGpuBuffer magBuf, IGpuBuffer output,
         int totalSegBatch, int fftSize, int numBins, int usable)
     {
-        int total = totalSegBatch * numBins;
-        if (total <= 0) return;
+        if (totalSegBatch <= 0 || fftSize <= 0 || numBins <= 0 || usable <= 0) return;
+        long totalL = (long)totalSegBatch * numBins;
+        if (totalL <= 0 || totalL > int.MaxValue) return;
+        int total = (int)totalL;
         Dispatch2BufferAsync("SpectralPerf", WebGpuSpectralPerfKernels.WidebandLogBinPoolSource,
             "wideband_log_bin_pool", magBuf, output,
             new float[] { BitConverter.Int32BitsToSingle(totalSegBatch), BitConverter.Int32BitsToSingle(fftSize),
@@ -1606,8 +1617,10 @@ public sealed partial class WebGpuBackend
     public void MelFilterbankApply(IGpuBuffer powerSpec, IGpuBuffer melFilters, IGpuBuffer melEnergy,
         int totalSegBatch, int specBins, int melBins)
     {
-        int total = totalSegBatch * melBins;
-        if (total <= 0) return;
+        if (totalSegBatch <= 0 || specBins <= 0 || melBins <= 0) return;
+        long totalL = (long)totalSegBatch * melBins;
+        if (totalL <= 0 || totalL > int.MaxValue) return;
+        int total = (int)totalL;
         Dispatch3BufferAsync("SpectralPerf", WebGpuSpectralPerfKernels.MelFilterbankSource,
             "mel_filterbank_apply", powerSpec, melFilters, melEnergy,
             new float[] { BitConverter.Int32BitsToSingle(totalSegBatch), BitConverter.Int32BitsToSingle(specBins),
@@ -1626,6 +1639,12 @@ public sealed partial class WebGpuBackend
         int batch, int numSamples, int numGammaBands, int gammaIdx)
     {
         if (batch <= 0) return;
+        if (numSamples <= 0)
+            throw new ArgumentOutOfRangeException(nameof(numSamples), "numSamples must be positive.");
+        if (numGammaBands <= 0)
+            throw new ArgumentOutOfRangeException(nameof(numGammaBands), "numGammaBands must be positive.");
+        if (gammaIdx < 0 || gammaIdx >= numGammaBands)
+            throw new ArgumentOutOfRangeException(nameof(gammaIdx), $"gammaIdx must be in [0, {numGammaBands}).");
         Dispatch3BufferAsync("SpectralPerf", WebGpuSpectralPerfKernels.PacPhaseBinMiSource,
             "pac_phase_bin_mi", thetaPhase, gammaAmp, output,
             new float[] { BitConverter.Int32BitsToSingle(batch), BitConverter.Int32BitsToSingle(numSamples),

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuSpectralPerfKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuSpectralPerfKernels.cs
@@ -1,0 +1,250 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// WGSL compute shaders for Issue #160 spectral perf kernels.
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.WebGpu
+{
+    internal static class WebGpuSpectralPerfKernels
+    {
+        public const string Atan2Source = @"
+@group(0) @binding(0) var<storage, read> imag: array<f32>;
+@group(0) @binding(1) var<storage, read> real: array<f32>;
+@group(0) @binding(2) var<storage, read_write> output: array<f32>;
+struct Params { n: u32 }
+@group(0) @binding(3) var<uniform> p: Params;
+@compute @workgroup_size(256)
+fn atan2_elementwise(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let idx = gid.x;
+    if (idx < p.n) { output[idx] = atan2(imag[idx], real[idx]); }
+}";
+
+        public const string NormalizeRowsSource = @"
+@group(0) @binding(0) var<storage, read> input: array<f32>;
+@group(0) @binding(1) var<storage, read_write> output: array<f32>;
+struct Params { rows: u32, cols: u32 }
+@group(0) @binding(2) var<uniform> p: Params;
+@compute @workgroup_size(64)
+fn normalize_rows_fused(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let row = gid.x;
+    if (row >= p.rows) { return; }
+    let rowOff = row * p.cols;
+    var sumSq: f32 = 0.0;
+    for (var c: u32 = 0u; c < p.cols; c = c + 1u) {
+        let v = input[rowOff + c];
+        sumSq = sumSq + v * v;
+    }
+    var invNorm: f32 = 0.0;
+    if (sumSq > 0.0) { invNorm = inverseSqrt(sumSq); }
+    for (var c: u32 = 0u; c < p.cols; c = c + 1u) {
+        output[rowOff + c] = input[rowOff + c] * invNorm;
+    }
+}";
+
+        public const string AnalyticSignalMaskSource = @"
+@group(0) @binding(0) var<storage, read> specReal: array<f32>;
+@group(0) @binding(1) var<storage, read_write> outReal: array<f32>;
+struct Params { batch: u32, fftSize: u32, binLow: u32, binHigh: u32 }
+@group(0) @binding(2) var<uniform> p: Params;
+@compute @workgroup_size(256)
+fn analytic_signal_mask(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let idx = gid.x;
+    let total = p.batch * p.fftSize;
+    if (idx >= total) { return; }
+    let k = idx % p.fftSize;
+    let halfN = p.fftSize >> 1u;
+    var gain: f32;
+    if (k == 0u || k == halfN) {
+        if (k < p.binLow || k >= p.binHigh) { gain = 0.0; } else { gain = 1.0; }
+    } else if (k < halfN) {
+        if (k < p.binLow || k >= p.binHigh) { gain = 0.0; } else { gain = 2.0; }
+    } else {
+        gain = 0.0;
+    }
+    outReal[idx] = specReal[idx] * gain;
+}";
+
+        public const string BispectrumSource = @"
+@group(0) @binding(0) var<storage, read> specReal: array<f32>;
+@group(0) @binding(1) var<storage, read> specImag: array<f32>;
+@group(0) @binding(2) var<storage, read_write> outBuf: array<f32>;
+struct Params { maxF1: u32, maxF2: u32, mode: u32 }
+@group(0) @binding(3) var<uniform> p: Params;
+@compute @workgroup_size(256)
+fn bispectrum_gather(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let idx = gid.x;
+    let total = p.maxF1 * p.maxF2;
+    if (idx >= total) { return; }
+    let f1 = idx / p.maxF2;
+    let f2 = idx % p.maxF2;
+    let sumIdx = f1 + f2;
+    let ar = specReal[f1]; let ai = specImag[f1];
+    let br = specReal[f2]; let bi = specImag[f2];
+    let cr = specReal[sumIdx]; let ci = -specImag[sumIdx];
+    let abr = ar * br - ai * bi;
+    let abi = ar * bi + ai * br;
+    if (p.mode == 0u) { outBuf[idx] = abr * cr - abi * ci; }
+    else { outBuf[idx] = abr * ci + abi * cr; }
+}";
+
+        public const string TrispectrumSource = @"
+@group(0) @binding(0) var<storage, read> specReal: array<f32>;
+@group(0) @binding(1) var<storage, read> specImag: array<f32>;
+@group(0) @binding(2) var<storage, read_write> outBuf: array<f32>;
+struct Params { maxF1: u32, maxF2: u32, maxF3: u32, mode: u32 }
+@group(0) @binding(3) var<uniform> p: Params;
+@compute @workgroup_size(256)
+fn trispectrum_gather(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let idx = gid.x;
+    let total = p.maxF1 * p.maxF2 * p.maxF3;
+    if (idx >= total) { return; }
+    let f1 = idx / (p.maxF2 * p.maxF3);
+    let rem = idx - f1 * p.maxF2 * p.maxF3;
+    let f2 = rem / p.maxF3;
+    let f3 = rem - f2 * p.maxF3;
+    let sumIdx = f1 + f2 + f3;
+    let ar = specReal[f1]; let ai = specImag[f1];
+    let br = specReal[f2]; let bi = specImag[f2];
+    let cr = specReal[f3]; let ci = specImag[f3];
+    let dr = specReal[sumIdx]; let di = -specImag[sumIdx];
+    let t1r = ar * br - ai * bi;
+    let t1i = ar * bi + ai * br;
+    let t2r = t1r * cr - t1i * ci;
+    let t2i = t1r * ci + t1i * cr;
+    if (p.mode == 0u) { outBuf[idx] = t2r * dr - t2i * di; }
+    else { outBuf[idx] = t2r * di + t2i * dr; }
+}";
+
+        public const string CavityBounceSource = @"
+@group(0) @binding(0) var<storage, read> input: array<f32>;
+@group(0) @binding(1) var<storage, read_write> output: array<f32>;
+struct Params { total: u32, invN: f32 }
+@group(0) @binding(2) var<uniform> p: Params;
+@compute @workgroup_size(256)
+fn cavity_bounce_real(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let idx = gid.x;
+    if (idx >= p.total) { return; }
+    var r = input[idx] * p.invN;
+    r = clamp(r, -20.0, 20.0);
+    output[idx] = tanh(r);
+}";
+
+        public const string ZeroBufferSource = @"
+@group(0) @binding(0) var<storage, read> input: array<f32>;
+@group(0) @binding(1) var<storage, read_write> output: array<f32>;
+struct Params { total: u32 }
+@group(0) @binding(2) var<uniform> p: Params;
+@compute @workgroup_size(256)
+fn zero_buffer(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let idx = gid.x;
+    if (idx >= p.total) { return; }
+    output[idx] = 0.0;
+}";
+
+        public const string WidebandLogBinPoolSource = @"
+@group(0) @binding(0) var<storage, read> magBuf: array<f32>;
+@group(0) @binding(1) var<storage, read_write> output: array<f32>;
+struct Params { totalSegBatch: u32, fftSize: u32, numBins: u32, usable: u32 }
+@group(0) @binding(2) var<uniform> p: Params;
+@compute @workgroup_size(256)
+fn wideband_log_bin_pool(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let outIdx = gid.x;
+    let total = p.totalSegBatch * p.numBins;
+    if (outIdx >= total) { return; }
+    let seg = outIdx / p.numBins;
+    let k = outIdx % p.numBins;
+    let r0 = f32(k) / f32(p.numBins);
+    let r1 = f32(k + 1u) / f32(p.numBins);
+    var binStart = 1 + i32(r0 * r0 * f32(p.usable - 1u));
+    var binEnd = 1 + i32(r1 * r1 * f32(p.usable - 1u));
+    if (binEnd <= binStart) { binEnd = binStart + 1; }
+    if (binEnd > i32(p.usable)) { binEnd = i32(p.usable); }
+    let magOff = seg * p.fftSize;
+    var sum: f32 = 0.0; var cnt: i32 = 0;
+    for (var i = binStart; i < binEnd; i = i + 1) {
+        sum = sum + magBuf[magOff + u32(i)];
+        cnt = cnt + 1;
+    }
+    var avg: f32 = 0.0;
+    if (cnt > 0) { avg = sum / f32(cnt); }
+    output[outIdx] = log(1.0 + avg);
+}";
+
+        public const string MelFilterbankSource = @"
+@group(0) @binding(0) var<storage, read> powerSpec: array<f32>;
+@group(0) @binding(1) var<storage, read> melFilters: array<f32>;
+@group(0) @binding(2) var<storage, read_write> melEnergy: array<f32>;
+struct Params { totalSegBatch: u32, specBins: u32, melBins: u32 }
+@group(0) @binding(3) var<uniform> p: Params;
+@compute @workgroup_size(256)
+fn mel_filterbank_apply(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let outIdx = gid.x;
+    let total = p.totalSegBatch * p.melBins;
+    if (outIdx >= total) { return; }
+    let seg = outIdx / p.melBins;
+    let m = outIdx % p.melBins;
+    let powerOff = seg * p.specBins;
+    let filtOff = m * p.specBins;
+    var sum: f32 = 0.0;
+    for (var i: u32 = 0u; i < p.specBins; i = i + 1u) {
+        sum = sum + powerSpec[powerOff + i] * melFilters[filtOff + i];
+    }
+    melEnergy[outIdx] = sum;
+}";
+
+        public const string MfccLog1pSource = @"
+@group(0) @binding(0) var<storage, read> input: array<f32>;
+@group(0) @binding(1) var<storage, read_write> output: array<f32>;
+struct Params { n: u32 }
+@group(0) @binding(2) var<uniform> p: Params;
+@compute @workgroup_size(256)
+fn mfcc_log1p(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let idx = gid.x;
+    if (idx >= p.n) { return; }
+    output[idx] = log(1.0 + input[idx]);
+}";
+
+        public const string PacPhaseBinMiSource = @"
+@group(0) @binding(0) var<storage, read> thetaPhase: array<f32>;
+@group(0) @binding(1) var<storage, read> gammaAmp: array<f32>;
+@group(0) @binding(2) var<storage, read_write> output: array<f32>;
+struct Params { batch: u32, numSamples: u32, numGammaBands: u32, gammaIdx: u32 }
+@group(0) @binding(3) var<uniform> p: Params;
+@compute @workgroup_size(64)
+fn pac_phase_bin_mi(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let b = gid.x;
+    if (b >= p.batch) { return; }
+    var binSum: array<f32, 18>;
+    var binCount: array<f32, 18>;
+    for (var k: u32 = 0u; k < 18u; k = k + 1u) { binSum[k] = 0.0; binCount[k] = 0.0; }
+    let sampleOff = b * p.numSamples;
+    let gammaOff = (p.gammaIdx * p.batch + b) * p.numSamples;
+    for (var i: u32 = 0u; i < p.numSamples; i = i + 1u) {
+        let phase = thetaPhase[sampleOff + i];
+        let amp = gammaAmp[gammaOff + i];
+        var fbin = (phase + 3.14159265358979) / (2.0 * 3.14159265358979) * 18.0;
+        var bin = i32(fbin);
+        if (bin < 0) { bin = 0; }
+        if (bin >= 18) { bin = 17; }
+        binSum[bin] = binSum[bin] + amp;
+        binCount[bin] = binCount[bin] + 1.0;
+    }
+    var totalAmp: f32 = 0.0;
+    for (var k: u32 = 0u; k < 18u; k = k + 1u) {
+        var avg: f32 = 0.0;
+        if (binCount[k] > 0.0) { avg = binSum[k] / binCount[k]; }
+        totalAmp = totalAmp + avg;
+    }
+    var mi: f32 = 0.0;
+    if (totalAmp > 0.0) {
+        var entropy: f32 = 0.0;
+        for (var k: u32 = 0u; k < 18u; k = k + 1u) {
+            var avg: f32 = 0.0;
+            if (binCount[k] > 0.0) { avg = binSum[k] / binCount[k]; }
+            let pp = avg / totalAmp;
+            if (pp > 1e-12) { entropy = entropy - pp * log(pp); }
+        }
+        mi = (log(18.0) - entropy) / log(18.0);
+    }
+    output[b * p.numGammaBands + p.gammaIdx] = mi;
+}";
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -15691,4 +15691,345 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
         catch { return base.TensorSoftmaxRows(input); }
     }
+
+    // ============================================================================
+    // Issue #160 spectral perf op overrides — dispatch to backend.* GPU kernels.
+    // Each op converts T to float at GPU boundary (matches existing engine pattern).
+    // ============================================================================
+
+    public override Tensor<T> NativeTanh<T>(Tensor<T> input)
+    {
+        if (!TryGetBackend(out var backend)) return base.NativeTanh(input);
+        try
+        {
+            int n = input.Length;
+            var ops = MathHelper.GetNumericOperations<T>();
+            var inputF = new float[n];
+            for (int i = 0; i < n; i++) inputF[i] = (float)ops.ToDouble(input[i]);
+            using var inBuf = new OwnedBuffer(backend.AllocateBuffer(inputF), true);
+            using var outBuf = new OwnedBuffer(backend.AllocateBuffer(n), true);
+            backend.Tanh(inBuf.Buffer, outBuf.Buffer, n);
+            return RecomposeReal<T>(backend.DownloadBuffer(outBuf.Buffer), input._shape);
+        }
+        catch { return base.NativeTanh(input); }
+    }
+
+    public override Tensor<T> NativeExp<T>(Tensor<T> input)
+    {
+        if (!TryGetBackend(out var backend)) return base.NativeExp(input);
+        try
+        {
+            int n = input.Length;
+            var ops = MathHelper.GetNumericOperations<T>();
+            var inputF = new float[n];
+            for (int i = 0; i < n; i++) inputF[i] = (float)ops.ToDouble(input[i]);
+            using var inBuf = new OwnedBuffer(backend.AllocateBuffer(inputF), true);
+            using var outBuf = new OwnedBuffer(backend.AllocateBuffer(n), true);
+            backend.Exp(inBuf.Buffer, outBuf.Buffer, n);
+            return RecomposeReal<T>(backend.DownloadBuffer(outBuf.Buffer), input._shape);
+        }
+        catch { return base.NativeExp(input); }
+    }
+
+    public override Tensor<T> NativeAtan2<T>(Tensor<T> imag, Tensor<T> real)
+    {
+        if (imag is null) throw new ArgumentNullException(nameof(imag));
+        if (real is null) throw new ArgumentNullException(nameof(real));
+        if (imag.Length != real.Length) return base.NativeAtan2(imag, real);
+        if (!TryGetBackend(out var backend)) return base.NativeAtan2(imag, real);
+        try
+        {
+            int n = imag.Length;
+            var ops = MathHelper.GetNumericOperations<T>();
+            var iF = new float[n];
+            var rF = new float[n];
+            for (int i = 0; i < n; i++) { iF[i] = (float)ops.ToDouble(imag[i]); rF[i] = (float)ops.ToDouble(real[i]); }
+            using var iBuf = new OwnedBuffer(backend.AllocateBuffer(iF), true);
+            using var rBuf = new OwnedBuffer(backend.AllocateBuffer(rF), true);
+            using var outBuf = new OwnedBuffer(backend.AllocateBuffer(n), true);
+            backend.Atan2Elementwise(iBuf.Buffer, rBuf.Buffer, outBuf.Buffer, n);
+            return RecomposeReal<T>(backend.DownloadBuffer(outBuf.Buffer), imag._shape);
+        }
+        catch { return base.NativeAtan2(imag, real); }
+    }
+
+    public override Tensor<T> NativeMagnitudeAndPhase<T>(Tensor<Complex<T>> input, out Tensor<T> phase)
+    {
+        if (!TryGetBackend(out var backend)) return base.NativeMagnitudeAndPhase(input, out phase);
+        try
+        {
+            int n = input.Length;
+            var (rF, iF) = DecomposeComplex(input);
+            using var rBuf = new OwnedBuffer(backend.AllocateBuffer(rF), true);
+            using var iBuf = new OwnedBuffer(backend.AllocateBuffer(iF), true);
+            using var magBuf = new OwnedBuffer(backend.AllocateBuffer(n), true);
+            using var phaseBuf = new OwnedBuffer(backend.AllocateBuffer(n), true);
+            backend.SplitComplexMagnitude(rBuf.Buffer, iBuf.Buffer, magBuf.Buffer, n);
+            backend.SplitComplexPhase(rBuf.Buffer, iBuf.Buffer, phaseBuf.Buffer, n);
+            phase = RecomposeReal<T>(backend.DownloadBuffer(phaseBuf.Buffer), input._shape);
+            return RecomposeReal<T>(backend.DownloadBuffer(magBuf.Buffer), input._shape);
+        }
+        catch { return base.NativeMagnitudeAndPhase(input, out phase); }
+    }
+
+    public override Tensor<Complex<T>> NativeAnalyticSignal<T>(Tensor<T> input, double freqLow = 0.0, double freqHigh = double.MaxValue, double sampleRate = 1.0)
+    {
+        if (!TryGetBackend(out var backend)) return base.NativeAnalyticSignal(input, freqLow, freqHigh, sampleRate);
+        try
+        {
+            int fftSize = input._shape[^1];
+            int batchCount = input.Length / fftSize;
+            if (fftSize <= 0 || (fftSize & (fftSize - 1)) != 0)
+                return base.NativeAnalyticSignal(input, freqLow, freqHigh, sampleRate);
+
+            int total = input.Length;
+            var ops = MathHelper.GetNumericOperations<T>();
+            var inputF = new float[total];
+            for (int i = 0; i < total; i++) inputF[i] = (float)ops.ToDouble(input[i]);
+            var zerosF = new float[total];
+
+            int halfN = fftSize / 2;
+            int binLow = freqLow <= 0 ? 0 : (int)Math.Ceiling(freqLow * fftSize / sampleRate);
+            int binHigh = double.IsPositiveInfinity(freqHigh) || freqHigh >= sampleRate * 0.5
+                ? halfN + 1 : Math.Min(halfN + 1, (int)Math.Ceiling(freqHigh * fftSize / sampleRate));
+
+            using var inRBuf = new OwnedBuffer(backend.AllocateBuffer(inputF), true);
+            using var inIBuf = new OwnedBuffer(backend.AllocateBuffer(zerosF), true);
+            using var specRBuf = new OwnedBuffer(backend.AllocateBuffer(total), true);
+            using var specIBuf = new OwnedBuffer(backend.AllocateBuffer(total), true);
+            using var maskedRBuf = new OwnedBuffer(backend.AllocateBuffer(total), true);
+            using var maskedIBuf = new OwnedBuffer(backend.AllocateBuffer(total), true);
+            using var outRBuf = new OwnedBuffer(backend.AllocateBuffer(total), true);
+            using var outIBuf = new OwnedBuffer(backend.AllocateBuffer(total), true);
+
+            // Forward FFT
+            if (batchCount > 1)
+                backend.BatchedFFT(inRBuf.Buffer, inIBuf.Buffer, specRBuf.Buffer, specIBuf.Buffer, batchCount, fftSize, inverse: false);
+            else
+                backend.FFT(inRBuf.Buffer, inIBuf.Buffer, specRBuf.Buffer, specIBuf.Buffer, fftSize, inverse: false);
+
+            // Apply Hilbert mask via dedicated kernel
+            backend.AnalyticSignalMask(specRBuf.Buffer, specIBuf.Buffer, maskedRBuf.Buffer, maskedIBuf.Buffer,
+                batchCount, fftSize, binLow, binHigh);
+
+            // Inverse FFT
+            if (batchCount > 1)
+                backend.BatchedFFT(maskedRBuf.Buffer, maskedIBuf.Buffer, outRBuf.Buffer, outIBuf.Buffer, batchCount, fftSize, inverse: true);
+            else
+                backend.FFT(maskedRBuf.Buffer, maskedIBuf.Buffer, outRBuf.Buffer, outIBuf.Buffer, fftSize, inverse: true);
+
+            return RecomposeComplex<T>(backend.DownloadBuffer(outRBuf.Buffer),
+                backend.DownloadBuffer(outIBuf.Buffer), input._shape);
+        }
+        catch { return base.NativeAnalyticSignal(input, freqLow, freqHigh, sampleRate); }
+    }
+
+    public override Tensor<T> NativeNormalizeRows<T>(Tensor<T> input, bool inPlace = false)
+    {
+        if (!TryGetBackend(out var backend)) return base.NativeNormalizeRows(input, inPlace);
+        if (input.Rank != 2) return base.NativeNormalizeRows(input, inPlace);
+        try
+        {
+            int rows = input._shape[0];
+            int cols = input._shape[1];
+            int total = rows * cols;
+            var ops = MathHelper.GetNumericOperations<T>();
+            var inputF = new float[total];
+            for (int i = 0; i < total; i++) inputF[i] = (float)ops.ToDouble(input[i]);
+            using var inBuf = new OwnedBuffer(backend.AllocateBuffer(inputF), true);
+            using var outBuf = new OwnedBuffer(backend.AllocateBuffer(total), true);
+            backend.NormalizeRowsFused(inBuf.Buffer, outBuf.Buffer, rows, cols);
+            var result = RecomposeReal<T>(backend.DownloadBuffer(outBuf.Buffer), input._shape);
+            if (inPlace)
+            {
+                // Copy result data back into the input tensor's buffer for in-place semantics
+                var src = result.DataVector.AsSpan();
+                var dst = input.DataVector.AsWritableSpan();
+                src.CopyTo(dst);
+                return input;
+            }
+            return result;
+        }
+        catch { return base.NativeNormalizeRows(input, inPlace); }
+    }
+
+    public override Tensor<Complex<T>> NativeBispectrum<T>(Tensor<Complex<T>> spectrum, int maxF1, int maxF2)
+    {
+        if (!TryGetBackend(out var backend)) return base.NativeBispectrum(spectrum, maxF1, maxF2);
+        if (spectrum.Rank != 1 || maxF1 <= 0 || maxF2 <= 0 || maxF1 + maxF2 > spectrum.Length)
+            return base.NativeBispectrum(spectrum, maxF1, maxF2);
+        try
+        {
+            int total = maxF1 * maxF2;
+            var (rF, iF) = DecomposeComplex(spectrum);
+            using var sRBuf = new OwnedBuffer(backend.AllocateBuffer(rF), true);
+            using var sIBuf = new OwnedBuffer(backend.AllocateBuffer(iF), true);
+            using var oRBuf = new OwnedBuffer(backend.AllocateBuffer(total), true);
+            using var oIBuf = new OwnedBuffer(backend.AllocateBuffer(total), true);
+            backend.BispectrumGather(sRBuf.Buffer, sIBuf.Buffer, oRBuf.Buffer, oIBuf.Buffer, maxF1, maxF2);
+            return RecomposeComplex<T>(backend.DownloadBuffer(oRBuf.Buffer),
+                backend.DownloadBuffer(oIBuf.Buffer), new[] { maxF1, maxF2 });
+        }
+        catch { return base.NativeBispectrum(spectrum, maxF1, maxF2); }
+    }
+
+    public override Tensor<Complex<T>> NativeTrispectrum<T>(Tensor<Complex<T>> spectrum, int maxF1, int maxF2, int maxF3)
+    {
+        if (!TryGetBackend(out var backend)) return base.NativeTrispectrum(spectrum, maxF1, maxF2, maxF3);
+        if (spectrum.Rank != 1 || maxF1 <= 0 || maxF2 <= 0 || maxF3 <= 0 || maxF1 + maxF2 + maxF3 > spectrum.Length)
+            return base.NativeTrispectrum(spectrum, maxF1, maxF2, maxF3);
+        try
+        {
+            int total = maxF1 * maxF2 * maxF3;
+            var (rF, iF) = DecomposeComplex(spectrum);
+            using var sRBuf = new OwnedBuffer(backend.AllocateBuffer(rF), true);
+            using var sIBuf = new OwnedBuffer(backend.AllocateBuffer(iF), true);
+            using var oRBuf = new OwnedBuffer(backend.AllocateBuffer(total), true);
+            using var oIBuf = new OwnedBuffer(backend.AllocateBuffer(total), true);
+            backend.TrispectrumGather(sRBuf.Buffer, sIBuf.Buffer, oRBuf.Buffer, oIBuf.Buffer, maxF1, maxF2, maxF3);
+            return RecomposeComplex<T>(backend.DownloadBuffer(oRBuf.Buffer),
+                backend.DownloadBuffer(oIBuf.Buffer), new[] { maxF1, maxF2, maxF3 });
+        }
+        catch { return base.NativeTrispectrum(spectrum, maxF1, maxF2, maxF3); }
+    }
+
+    public override Tensor<T> NativeBatchedCavityForward<T>(Tensor<T> input, Tensor<Complex<T>> cavityFilters, int numBounces)
+    {
+        if (!TryGetBackend(out var backend)) return base.NativeBatchedCavityForward(input, cavityFilters, numBounces);
+        if (input.Rank != 2 || cavityFilters.Rank != 2 || numBounces < 1)
+            return base.NativeBatchedCavityForward(input, cavityFilters, numBounces);
+        try
+        {
+            int batch = input._shape[0];
+            int n = input._shape[1];
+            int numCavities = cavityFilters._shape[0];
+            if (cavityFilters._shape[1] != n || (n & (n - 1)) != 0)
+                return base.NativeBatchedCavityForward(input, cavityFilters, numBounces);
+
+            var ops = MathHelper.GetNumericOperations<T>();
+            int total = batch * n;
+            var inputF = new float[total];
+            for (int i = 0; i < total; i++) inputF[i] = (float)ops.ToDouble(input[i]);
+            var (filtRF, filtIF) = DecomposeComplex(cavityFilters);
+
+            // Compose on GPU: initial FFT → per cavity (multiply + IFFT + tanh + FFT for next bounce).
+            // Uses existing backend primitives + the new CavityBounceInplace kernel.
+            using var inBuf = new OwnedBuffer(backend.AllocateBuffer(inputF), true);
+            using var zerosBuf = new OwnedBuffer(backend.AllocateBuffer(new float[total]), true);
+            using var specRBuf = new OwnedBuffer(backend.AllocateBuffer(total), true);
+            using var specIBuf = new OwnedBuffer(backend.AllocateBuffer(total), true);
+            using var workRBuf = new OwnedBuffer(backend.AllocateBuffer(total), true);
+            using var workIBuf = new OwnedBuffer(backend.AllocateBuffer(total), true);
+            using var tmpRBuf = new OwnedBuffer(backend.AllocateBuffer(total), true);
+            using var tmpIBuf = new OwnedBuffer(backend.AllocateBuffer(total), true);
+            using var tiledRBuf = new OwnedBuffer(backend.AllocateBuffer(total), true);
+            using var tiledIBuf = new OwnedBuffer(backend.AllocateBuffer(total), true);
+            using var outBuf = new OwnedBuffer(backend.AllocateBuffer(batch * numCavities * n), true);
+
+            // Initial batched FFT of input waveforms
+            backend.BatchedFFT(inBuf.Buffer, zerosBuf.Buffer, specRBuf.Buffer, specIBuf.Buffer, batch, n, inverse: false);
+
+            for (int c = 0; c < numCavities; c++)
+            {
+                // Tile this cavity's filter across batch
+                for (int b = 0; b < batch; b++)
+                {
+                    backend.Copy(backend.AllocateBuffer(new ReadOnlySpan<float>(filtRF, c * n, n).ToArray()),
+                        0, tiledRBuf.Buffer, b * n, n);
+                    backend.Copy(backend.AllocateBuffer(new ReadOnlySpan<float>(filtIF, c * n, n).ToArray()),
+                        0, tiledIBuf.Buffer, b * n, n);
+                }
+                // Reset working spectrum
+                backend.Copy(specRBuf.Buffer, 0, workRBuf.Buffer, 0, total);
+                backend.Copy(specIBuf.Buffer, 0, workIBuf.Buffer, 0, total);
+
+                for (int bounce = 0; bounce < numBounces; bounce++)
+                {
+                    backend.SplitComplexMultiply(workRBuf.Buffer, workIBuf.Buffer,
+                        tiledRBuf.Buffer, tiledIBuf.Buffer,
+                        tmpRBuf.Buffer, tmpIBuf.Buffer, total);
+                    backend.BatchedFFT(tmpRBuf.Buffer, tmpIBuf.Buffer,
+                        workRBuf.Buffer, workIBuf.Buffer, batch, n, inverse: true);
+                    // Apply 1/N scale + tanh + zero imag in single fused kernel
+                    backend.CavityBounceInplace(workRBuf.Buffer, workIBuf.Buffer, total, 1f / n);
+                    if (bounce < numBounces - 1)
+                    {
+                        backend.BatchedFFT(workRBuf.Buffer, workIBuf.Buffer,
+                            tmpRBuf.Buffer, tmpIBuf.Buffer, batch, n, inverse: false);
+                        backend.Copy(tmpRBuf.Buffer, 0, workRBuf.Buffer, 0, total);
+                        backend.Copy(tmpIBuf.Buffer, 0, workIBuf.Buffer, 0, total);
+                    }
+                }
+
+                // Copy this cavity's output for all batches into output buffer
+                for (int b = 0; b < batch; b++)
+                    backend.Copy(workRBuf.Buffer, b * n, outBuf.Buffer, (b * numCavities + c) * n, n);
+            }
+
+            return RecomposeReal<T>(backend.DownloadBuffer(outBuf.Buffer), new[] { batch, numCavities, n });
+        }
+        catch { return base.NativeBatchedCavityForward(input, cavityFilters, numBounces); }
+    }
+
+    public override Tensor<T> NativeMfccFeatures<T>(Tensor<T> waveforms, int numSegments, int numMfcc, int paddedDim)
+    {
+        // Pipeline composes from backend.FFT + backend.MelFilterbankApply + backend.MfccLog1p + backend.MatMul (DCT).
+        // For now use base CPU implementation; full GPU pipeline would require precomputed mel/DCT bases.
+        return base.NativeMfccFeatures(waveforms, numSegments, numMfcc, paddedDim);
+    }
+
+    public override Tensor<T> NativeWidebandFeatures<T>(Tensor<T> waveforms, int numSegments, int numBins)
+    {
+        if (!TryGetBackend(out var backend)) return base.NativeWidebandFeatures(waveforms, numSegments, numBins);
+        if (numSegments <= 0 || numBins <= 0) return base.NativeWidebandFeatures(waveforms, numSegments, numBins);
+        try
+        {
+            bool batched = waveforms.Rank == 2;
+            int batch = batched ? waveforms._shape[0] : 1;
+            int numSamples = batched ? waveforms._shape[1] : waveforms._shape[0];
+            int segmentLen = numSamples / numSegments;
+            int fftSize = 1; while (fftSize < segmentLen) fftSize <<= 1;
+            int totalSegBatch = batch * numSegments;
+            int totalSegFFT = totalSegBatch * fftSize;
+
+            var ops = MathHelper.GetNumericOperations<T>();
+            var segRF = new float[totalSegFFT];
+            for (int b = 0; b < batch; b++)
+                for (int s = 0; s < numSegments; s++)
+                {
+                    int srcOff = b * numSamples + s * segmentLen;
+                    int dstOff = (b * numSegments + s) * fftSize;
+                    for (int i = 0; i < segmentLen && srcOff + i < (batched ? batch * numSamples : numSamples); i++)
+                        segRF[dstOff + i] = (float)ops.ToDouble(waveforms[srcOff + i]);
+                }
+
+            using var segRBuf = new OwnedBuffer(backend.AllocateBuffer(segRF), true);
+            using var segIBuf = new OwnedBuffer(backend.AllocateBuffer(new float[totalSegFFT]), true);
+            using var fftRBuf = new OwnedBuffer(backend.AllocateBuffer(totalSegFFT), true);
+            using var fftIBuf = new OwnedBuffer(backend.AllocateBuffer(totalSegFFT), true);
+            using var magBuf = new OwnedBuffer(backend.AllocateBuffer(totalSegFFT), true);
+            using var outBuf = new OwnedBuffer(backend.AllocateBuffer(batch * numSegments * numBins), true);
+
+            backend.BatchedFFT(segRBuf.Buffer, segIBuf.Buffer, fftRBuf.Buffer, fftIBuf.Buffer, totalSegBatch, fftSize, inverse: false);
+            backend.SplitComplexMagnitude(fftRBuf.Buffer, fftIBuf.Buffer, magBuf.Buffer, totalSegFFT);
+            backend.WidebandLogBinPool(magBuf.Buffer, outBuf.Buffer, totalSegBatch, fftSize, numBins, fftSize / 2);
+
+            var outShape = batched ? new[] { batch, numSegments * numBins } : new[] { numSegments * numBins };
+            return RecomposeReal<T>(backend.DownloadBuffer(outBuf.Buffer), outShape);
+        }
+        catch { return base.NativeWidebandFeatures(waveforms, numSegments, numBins); }
+    }
+
+    public override Tensor<T> NativePacFeatures<T>(Tensor<T> waveforms, int sampleRate, int envelopeRate,
+        double thetaLow, double thetaHigh, (double low, double high)[] gammaBands)
+    {
+        // Pipeline composes from backend.AnalyticSignal + backend.SplitComplexMagnitude/Phase + backend.PacPhaseBinMi
+        // Full GPU pipeline requires multi-stage orchestration; defer to CPU base for correctness.
+        return base.NativePacFeatures(waveforms, sampleRate, envelopeRate, thetaLow, thetaHigh, gammaBands);
+    }
+
+    // Span-based FFT entry points: GPU backends already have FFT/BatchedFFT; the span entry points
+    // are CPU-side optimizations that bypass tensor wrapping. On a GPU engine, the CPU base is
+    // still the right path because there's no benefit to round-tripping span data through GPU
+    // for a single FFT call (the buffer transfer dominates). Fall-through to base is correct.
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -15747,7 +15747,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             using var iBuf = new OwnedBuffer(backend.AllocateBuffer(iF), true);
             using var rBuf = new OwnedBuffer(backend.AllocateBuffer(rF), true);
             using var outBuf = new OwnedBuffer(backend.AllocateBuffer(n), true);
-            backend.Atan2Elementwise(iBuf.Buffer, rBuf.Buffer, outBuf.Buffer, n);
+            // Interface order: Atan2Elementwise(real, imag, output) matches ComplexPhase/SplitComplexPhase.
+            backend.Atan2Elementwise(rBuf.Buffer, iBuf.Buffer, outBuf.Buffer, n);
             return RecomposeReal<T>(backend.DownloadBuffer(outBuf.Buffer), imag._shape);
         }
         catch { return base.NativeAtan2(imag, real); }
@@ -15929,15 +15930,20 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             // Initial batched FFT of input waveforms
             backend.BatchedFFT(inBuf.Buffer, zerosBuf.Buffer, specRBuf.Buffer, specIBuf.Buffer, batch, n, inverse: false);
 
+            var cavRSlice = new float[n];
+            var cavISlice = new float[n];
             for (int c = 0; c < numCavities; c++)
             {
-                // Tile this cavity's filter across batch
+                // Upload this cavity's filter once (shared across all batches), then tile via Copy.
+                // Using OwnedBuffer ensures the GPU buffer is disposed when this cavity is done.
+                Array.Copy(filtRF, c * n, cavRSlice, 0, n);
+                Array.Copy(filtIF, c * n, cavISlice, 0, n);
+                using var cavRBuf = new OwnedBuffer(backend.AllocateBuffer(cavRSlice), true);
+                using var cavIBuf = new OwnedBuffer(backend.AllocateBuffer(cavISlice), true);
                 for (int b = 0; b < batch; b++)
                 {
-                    backend.Copy(backend.AllocateBuffer(new ReadOnlySpan<float>(filtRF, c * n, n).ToArray()),
-                        0, tiledRBuf.Buffer, b * n, n);
-                    backend.Copy(backend.AllocateBuffer(new ReadOnlySpan<float>(filtIF, c * n, n).ToArray()),
-                        0, tiledIBuf.Buffer, b * n, n);
+                    backend.Copy(cavRBuf.Buffer, 0, tiledRBuf.Buffer, b * n, n);
+                    backend.Copy(cavIBuf.Buffer, 0, tiledIBuf.Buffer, b * n, n);
                 }
                 // Reset working spectrum
                 backend.Copy(specRBuf.Buffer, 0, workRBuf.Buffer, 0, total);

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -15813,14 +15813,18 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             backend.AnalyticSignalMask(specRBuf.Buffer, specIBuf.Buffer, maskedRBuf.Buffer, maskedIBuf.Buffer,
                 batchCount, fftSize, binLow, binHigh);
 
-            // Inverse FFT
+            // Inverse FFT (backend IFFT is unnormalized — scale by 1/fftSize afterward to match CPU semantics).
             if (batchCount > 1)
                 backend.BatchedFFT(maskedRBuf.Buffer, maskedIBuf.Buffer, outRBuf.Buffer, outIBuf.Buffer, batchCount, fftSize, inverse: true);
             else
                 backend.FFT(maskedRBuf.Buffer, maskedIBuf.Buffer, outRBuf.Buffer, outIBuf.Buffer, fftSize, inverse: true);
 
-            return RecomposeComplex<T>(backend.DownloadBuffer(outRBuf.Buffer),
-                backend.DownloadBuffer(outIBuf.Buffer), input._shape);
+            // Apply IFFT 1/N normalization on the downloaded real+imag arrays.
+            var outReal = backend.DownloadBuffer(outRBuf.Buffer);
+            var outImag = backend.DownloadBuffer(outIBuf.Buffer);
+            float invN = 1f / fftSize;
+            for (int i = 0; i < outReal.Length; i++) { outReal[i] *= invN; outImag[i] *= invN; }
+            return RecomposeComplex<T>(outReal, outImag, input._shape);
         }
         catch { return base.NativeAnalyticSignal(input, freqLow, freqHigh, sampleRate); }
     }
@@ -15857,7 +15861,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     public override Tensor<Complex<T>> NativeBispectrum<T>(Tensor<Complex<T>> spectrum, int maxF1, int maxF2)
     {
         if (!TryGetBackend(out var backend)) return base.NativeBispectrum(spectrum, maxF1, maxF2);
-        if (spectrum.Rank != 1 || maxF1 <= 0 || maxF2 <= 0 || maxF1 + maxF2 > spectrum.Length)
+        if (spectrum.Rank != 1 || maxF1 <= 0 || maxF2 <= 0 || maxF1 + maxF2 - 1 > spectrum.Length)
             return base.NativeBispectrum(spectrum, maxF1, maxF2);
         try
         {
@@ -15877,7 +15881,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     public override Tensor<Complex<T>> NativeTrispectrum<T>(Tensor<Complex<T>> spectrum, int maxF1, int maxF2, int maxF3)
     {
         if (!TryGetBackend(out var backend)) return base.NativeTrispectrum(spectrum, maxF1, maxF2, maxF3);
-        if (spectrum.Rank != 1 || maxF1 <= 0 || maxF2 <= 0 || maxF3 <= 0 || maxF1 + maxF2 + maxF3 > spectrum.Length)
+        if (spectrum.Rank != 1 || maxF1 <= 0 || maxF2 <= 0 || maxF3 <= 0 || maxF1 + maxF2 + maxF3 - 2 > spectrum.Length)
             return base.NativeTrispectrum(spectrum, maxF1, maxF2, maxF3);
         try
         {
@@ -15987,13 +15991,17 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     public override Tensor<T> NativeWidebandFeatures<T>(Tensor<T> waveforms, int numSegments, int numBins)
     {
         if (!TryGetBackend(out var backend)) return base.NativeWidebandFeatures(waveforms, numSegments, numBins);
+        // Mirror the base CPU preconditions so invalid inputs take the base path (which throws
+        // a clear ArgumentException) instead of silently producing truncated GPU output.
         if (numSegments <= 0 || numBins <= 0) return base.NativeWidebandFeatures(waveforms, numSegments, numBins);
+        if (waveforms.Rank != 1 && waveforms.Rank != 2) return base.NativeWidebandFeatures(waveforms, numSegments, numBins);
         try
         {
             bool batched = waveforms.Rank == 2;
             int batch = batched ? waveforms._shape[0] : 1;
             int numSamples = batched ? waveforms._shape[1] : waveforms._shape[0];
             int segmentLen = numSamples / numSegments;
+            if (segmentLen <= 1) return base.NativeWidebandFeatures(waveforms, numSegments, numBins);
             int fftSize = 1; while (fftSize < segmentLen) fftSize <<= 1;
             int totalSegBatch = batch * numSegments;
             int totalSegFFT = totalSegBatch * fftSize;

--- a/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
@@ -1771,8 +1771,8 @@ public class DelegatingGpuBackend : IDirectGpuBackend
         IGpuBuffer outputReal, int batch, int height, int width, int filterSliceCount)
         => Inner.SpectralFilter(inputReal, filterReal, filterImag, outputReal, batch, height, width, filterSliceCount);
 
-    public virtual void Atan2Elementwise(IGpuBuffer imag, IGpuBuffer real, IGpuBuffer output, int n)
-        => Inner.Atan2Elementwise(imag, real, output, n);
+    public virtual void Atan2Elementwise(IGpuBuffer real, IGpuBuffer imag, IGpuBuffer output, int n)
+        => Inner.Atan2Elementwise(real, imag, output, n);
 
     public virtual void NormalizeRowsFused(IGpuBuffer input, IGpuBuffer output, int rows, int cols)
         => Inner.NormalizeRowsFused(input, output, rows, cols);

--- a/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
@@ -1770,4 +1770,40 @@ public class DelegatingGpuBackend : IDirectGpuBackend
     public virtual void SpectralFilter(IGpuBuffer inputReal, IGpuBuffer filterReal, IGpuBuffer filterImag,
         IGpuBuffer outputReal, int batch, int height, int width, int filterSliceCount)
         => Inner.SpectralFilter(inputReal, filterReal, filterImag, outputReal, batch, height, width, filterSliceCount);
+
+    public virtual void Atan2Elementwise(IGpuBuffer imag, IGpuBuffer real, IGpuBuffer output, int n)
+        => Inner.Atan2Elementwise(imag, real, output, n);
+
+    public virtual void NormalizeRowsFused(IGpuBuffer input, IGpuBuffer output, int rows, int cols)
+        => Inner.NormalizeRowsFused(input, output, rows, cols);
+
+    public virtual void AnalyticSignalMask(IGpuBuffer specReal, IGpuBuffer specImag,
+        IGpuBuffer outReal, IGpuBuffer outImag, int batch, int fftSize, int binLow, int binHigh)
+        => Inner.AnalyticSignalMask(specReal, specImag, outReal, outImag, batch, fftSize, binLow, binHigh);
+
+    public virtual void BispectrumGather(IGpuBuffer specReal, IGpuBuffer specImag,
+        IGpuBuffer outReal, IGpuBuffer outImag, int maxF1, int maxF2)
+        => Inner.BispectrumGather(specReal, specImag, outReal, outImag, maxF1, maxF2);
+
+    public virtual void TrispectrumGather(IGpuBuffer specReal, IGpuBuffer specImag,
+        IGpuBuffer outReal, IGpuBuffer outImag, int maxF1, int maxF2, int maxF3)
+        => Inner.TrispectrumGather(specReal, specImag, outReal, outImag, maxF1, maxF2, maxF3);
+
+    public virtual void CavityBounceInplace(IGpuBuffer workReal, IGpuBuffer workImag, int total, float invN)
+        => Inner.CavityBounceInplace(workReal, workImag, total, invN);
+
+    public virtual void WidebandLogBinPool(IGpuBuffer magBuf, IGpuBuffer output,
+        int totalSegBatch, int fftSize, int numBins, int usable)
+        => Inner.WidebandLogBinPool(magBuf, output, totalSegBatch, fftSize, numBins, usable);
+
+    public virtual void MelFilterbankApply(IGpuBuffer powerSpec, IGpuBuffer melFilters, IGpuBuffer melEnergy,
+        int totalSegBatch, int specBins, int melBins)
+        => Inner.MelFilterbankApply(powerSpec, melFilters, melEnergy, totalSegBatch, specBins, melBins);
+
+    public virtual void MfccLog1p(IGpuBuffer input, IGpuBuffer output, int n)
+        => Inner.MfccLog1p(input, output, n);
+
+    public virtual void PacPhaseBinMi(IGpuBuffer thetaPhase, IGpuBuffer gammaAmp, IGpuBuffer output,
+        int batch, int numSamples, int numGammaBands, int gammaIdx)
+        => Inner.PacPhaseBinMi(thetaPhase, gammaAmp, output, batch, numSamples, numGammaBands, gammaIdx);
 }

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -7524,22 +7524,42 @@ public interface IEngine
     /// <summary>
     /// Element-wise hyperbolic tangent with SIMD acceleration on float/double.
     /// </summary>
+    /// <remarks>
+    /// <b>Non-differentiable:</b> this op is registered as non-differentiable in the autograd
+    /// <c>OpRegistry</c> and does not record a backward. Use the differentiable equivalent
+    /// <c>Tanh&lt;T&gt;</c> in training graphs; use <c>NativeTanh</c> only for inference or
+    /// post-training pipelines (e.g. HRE spectral/audio ops) that need SIMD throughput.
+    /// </remarks>
     Tensor<T> NativeTanh<T>(Tensor<T> input);
 
     /// <summary>
     /// Element-wise exponential (e^x) with SIMD acceleration on float/double.
     /// </summary>
+    /// <remarks>
+    /// <b>Non-differentiable:</b> this op is registered as non-differentiable in the autograd
+    /// <c>OpRegistry</c> and does not record a backward. Use the differentiable equivalent
+    /// <c>TensorExp&lt;T&gt;</c> in training graphs; use <c>NativeExp</c> only for inference or
+    /// post-training pipelines that need SIMD throughput.
+    /// </remarks>
     Tensor<T> NativeExp<T>(Tensor<T> input);
 
     /// <summary>
     /// Element-wise atan2(imag, real) with SIMD acceleration. Both tensors must have the same shape.
     /// </summary>
+    /// <remarks>
+    /// <b>Non-differentiable:</b> no backward is recorded. Intended for phase extraction in
+    /// signal-processing pipelines, not for training graphs.
+    /// </remarks>
     Tensor<T> NativeAtan2<T>(Tensor<T> imag, Tensor<T> real);
 
     /// <summary>
     /// Computes magnitude and phase of a complex tensor in a single pass.
     /// Returns magnitude; writes phase into the out parameter.
     /// </summary>
+    /// <remarks>
+    /// <b>Non-differentiable:</b> no backward is recorded. Intended for spectral feature
+    /// extraction, not for training graphs.
+    /// </remarks>
     Tensor<T> NativeMagnitudeAndPhase<T>(Tensor<Complex<T>> input, out Tensor<T> phase);
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -7500,6 +7500,86 @@ public interface IEngine
     Tensor<T> NativeNormalizeRows<T>(Tensor<T> input);
 
     /// <summary>
+    /// Element-wise hyperbolic tangent with SIMD acceleration on float/double.
+    /// </summary>
+    Tensor<T> NativeTanh<T>(Tensor<T> input);
+
+    /// <summary>
+    /// Element-wise exponential (e^x) with SIMD acceleration on float/double.
+    /// </summary>
+    Tensor<T> NativeExp<T>(Tensor<T> input);
+
+    /// <summary>
+    /// Element-wise atan2(imag, real) with SIMD acceleration. Both tensors must have the same shape.
+    /// </summary>
+    Tensor<T> NativeAtan2<T>(Tensor<T> imag, Tensor<T> real);
+
+    /// <summary>
+    /// Computes magnitude and phase of a complex tensor in a single pass.
+    /// Returns magnitude; writes phase into the out parameter.
+    /// </summary>
+    Tensor<T> NativeMagnitudeAndPhase<T>(Tensor<Complex<T>> input, out Tensor<T> phase);
+
+    /// <summary>
+    /// Third-order bispectrum: B(f1, f2) = X(f1) · X(f2) · conj(X(f1+f2)).
+    /// Input is a 1D complex spectrum of length N (must be a power of 2 for FFT-derived spectra).
+    /// Output shape is [maxF1, maxF2]. Used for higher-order phase-coupling features.
+    /// </summary>
+    /// <param name="spectrum">1D complex spectrum.</param>
+    /// <param name="maxF1">Maximum f1 frequency bin (exclusive).</param>
+    /// <param name="maxF2">Maximum f2 frequency bin (exclusive).</param>
+    Tensor<Complex<T>> NativeBispectrum<T>(Tensor<Complex<T>> spectrum, int maxF1, int maxF2);
+
+    /// <summary>
+    /// Fourth-order trispectrum: T(f1, f2, f3) = X(f1) · X(f2) · X(f3) · conj(X(f1+f2+f3)).
+    /// </summary>
+    Tensor<Complex<T>> NativeTrispectrum<T>(Tensor<Complex<T>> spectrum, int maxF1, int maxF2, int maxF3);
+
+    /// <summary>
+    /// Batched forward pass for resonant-cavity style operators.
+    /// Applies a per-cavity transfer function (set of complex filter responses) to a batch of inputs.
+    /// Input: [batch, N]. Filters: [numCavities, N] complex. Output: [batch, numCavities, N] real.
+    /// Fuses FFT → per-cavity multiply → IFFT → nonlinear bounce (tanh) across all cavities in one call.
+    /// </summary>
+    /// <param name="input">Real-valued [batch, N] input waveforms.</param>
+    /// <param name="cavityFilters">Complex [numCavities, N] frequency-domain filter responses.</param>
+    /// <param name="numBounces">Number of recursive nonlinear bounces per cavity.</param>
+    /// <returns>[batch, numCavities, N] real-valued output.</returns>
+    Tensor<T> NativeBatchedCavityForward<T>(Tensor<T> input, Tensor<Complex<T>> cavityFilters, int numBounces);
+
+    /// <summary>
+    /// End-to-end MFCC feature extraction pipeline for a batch of waveforms.
+    /// Fuses STFT → power spectrum → mel filterbank → log → DCT → per-segment pooling.
+    /// </summary>
+    /// <param name="waveforms">[batch, numSamples] or [numSamples] real waveforms.</param>
+    /// <param name="numSegments">Number of non-overlapping time segments.</param>
+    /// <param name="numMfcc">Number of MFCC coefficients per segment.</param>
+    /// <param name="paddedDim">Padded dimension (power of 2) used for FFT.</param>
+    /// <returns>[batch, numSegments * numMfcc] or [numSegments * numMfcc] feature tensor.</returns>
+    Tensor<T> NativeMfccFeatures<T>(Tensor<T> waveforms, int numSegments, int numMfcc, int paddedDim);
+
+    /// <summary>
+    /// End-to-end wideband spectral feature extraction pipeline.
+    /// Fuses segmentation → FFT → log-magnitude binning → pooling.
+    /// </summary>
+    Tensor<T> NativeWidebandFeatures<T>(Tensor<T> waveforms, int numSegments, int numBins);
+
+    /// <summary>
+    /// End-to-end phase-amplitude coupling (PAC) feature extraction pipeline.
+    /// For each gamma band: analytic signal on theta → phase, analytic signal on gamma → amplitude,
+    /// compute modulation index. Fuses Hilbert + envelope + PAC MI in one call.
+    /// </summary>
+    /// <param name="waveforms">[batch, numSamples] or [numSamples] real waveforms.</param>
+    /// <param name="sampleRate">Sample rate in Hz.</param>
+    /// <param name="envelopeRate">Target envelope sample rate in Hz for decimation.</param>
+    /// <param name="thetaLow">Theta band low-frequency (Hz).</param>
+    /// <param name="thetaHigh">Theta band high-frequency (Hz).</param>
+    /// <param name="gammaBands">Array of (lowHz, highHz) gamma band tuples.</param>
+    /// <returns>[batch, gammaBands.Length] PAC modulation index tensor.</returns>
+    Tensor<T> NativePacFeatures<T>(Tensor<T> waveforms, int sampleRate, int envelopeRate,
+        double thetaLow, double thetaHigh, (double low, double high)[] gammaBands);
+
+    /// <summary>
     /// Inverse 1D FFT from Complex&lt;T&gt; tensor, returning real-valued tensor.
     /// Extracts only the real component of the inverse transform. Use this when the original
     /// signal was real-valued (Hermitian symmetry assumed). Applies 1/N normalization.

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -7469,11 +7469,17 @@ public interface IEngine
     /// <summary>
     /// Span-based inverse 1D FFT (complex-to-complex) with 1/N normalization.
     /// </summary>
+    /// <param name="input">Complex input spectrum. Length must be a power of 2.</param>
+    /// <param name="output">Preallocated complex output buffer. Length must equal input length.</param>
+    /// <exception cref="ArgumentException">Thrown if lengths mismatch or input is not a power of 2.</exception>
     void NativeComplexIFFTSpan<T>(ReadOnlySpan<Complex<T>> input, Span<Complex<T>> output);
 
     /// <summary>
     /// Span-based complex-to-complex forward 1D FFT.
     /// </summary>
+    /// <param name="input">Complex input samples. Length must be a power of 2.</param>
+    /// <param name="output">Preallocated complex output buffer. Length must equal input length.</param>
+    /// <exception cref="ArgumentException">Thrown if lengths mismatch or input is not a power of 2.</exception>
     void NativeComplexFFTComplexSpan<T>(ReadOnlySpan<Complex<T>> input, Span<Complex<T>> output);
 
     /// <summary>
@@ -7481,6 +7487,9 @@ public interface IEngine
     /// Most important variant for Hilbert/PAC/MFCC pipelines that need to return to time-domain real.
     /// Applies 1/N normalization, discards imaginary part.
     /// </summary>
+    /// <param name="input">Complex input spectrum (should satisfy Hermitian symmetry for meaningful output). Length must be a power of 2.</param>
+    /// <param name="output">Preallocated real output buffer. Length must equal input length.</param>
+    /// <exception cref="ArgumentException">Thrown if lengths mismatch or input is not a power of 2.</exception>
     void NativeComplexIFFTRealSpan<T>(ReadOnlySpan<Complex<T>> input, Span<T> output);
 
     /// <summary>
@@ -7493,8 +7502,13 @@ public interface IEngine
     /// <param name="input">Real-valued time-domain input. Last axis length must be power of 2.</param>
     /// <param name="freqLow">Optional low-frequency cutoff in Hz (inclusive). Bins below are zeroed.</param>
     /// <param name="freqHigh">Optional high-frequency cutoff in Hz (exclusive). Bins at/above are zeroed.</param>
-    /// <param name="sampleRate">Sample rate in Hz for interpreting freqLow/freqHigh. Default 1.0 means no band-limiting.</param>
+    /// <param name="sampleRate">Sample rate in Hz for interpreting freqLow/freqHigh. Must be positive and finite.
+    /// Band-limiting is effectively disabled when the defaults <paramref name="freqLow"/>=0 and
+    /// <paramref name="freqHigh"/>=<see cref="double.MaxValue"/> are used; sampleRate then has no effect on the output.</param>
     /// <returns>Complex-valued analytic signal tensor of same shape as input.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if input is null.</exception>
+    /// <exception cref="ArgumentException">Thrown if sampleRate is non-positive/non-finite,
+    /// if freqLow is negative or NaN, or if freqHigh &lt; freqLow.</exception>
     Tensor<Complex<T>> NativeAnalyticSignal<T>(Tensor<T> input, double freqLow = 0.0, double freqHigh = double.MaxValue, double sampleRate = 1.0);
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -7477,6 +7477,13 @@ public interface IEngine
     void NativeComplexFFTComplexSpan<T>(ReadOnlySpan<Complex<T>> input, Span<Complex<T>> output);
 
     /// <summary>
+    /// Span-based inverse 1D FFT returning real output (Hermitian symmetry assumed).
+    /// Most important variant for Hilbert/PAC/MFCC pipelines that need to return to time-domain real.
+    /// Applies 1/N normalization, discards imaginary part.
+    /// </summary>
+    void NativeComplexIFFTRealSpan<T>(ReadOnlySpan<Complex<T>> input, Span<T> output);
+
+    /// <summary>
     /// Fused analytic-signal kernel (Hilbert transform via FFT).
     /// Computes analytic signal z(t) = x(t) + i·H{x}(t) in one fused call:
     /// forward FFT → zero negative frequencies (and optionally zero outside [freqLow, freqHigh])
@@ -7496,8 +7503,9 @@ public interface IEngine
     /// are left as zeros (no division).
     /// </summary>
     /// <param name="input">2D input tensor [rows, cols].</param>
+    /// <param name="inPlace">If true, writes back into the input buffer (no allocation). Default false.</param>
     /// <returns>2D output tensor of same shape with each row having unit L2 norm.</returns>
-    Tensor<T> NativeNormalizeRows<T>(Tensor<T> input);
+    Tensor<T> NativeNormalizeRows<T>(Tensor<T> input, bool inPlace = false);
 
     /// <summary>
     /// Element-wise hyperbolic tangent with SIMD acceleration on float/double.

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -7453,6 +7453,53 @@ public interface IEngine
     Tensor<Complex<T>> NativeComplexFFT<T>(Tensor<T> input);
 
     /// <summary>
+    /// Span-based forward 1D FFT on a real-valued signal.
+    /// Writes complex frequency bins directly into the caller-provided output span,
+    /// eliminating per-call wrapping overhead (virtual indexer, tensor allocation) for
+    /// hot paths that call FFT tens of thousands of times.
+    /// Internally dispatches to type-specialized float/double kernels via reinterpret;
+    /// the generic signature is uniform with the rest of the engine API.
+    /// </summary>
+    /// <typeparam name="T">Element type (float or double recommended for fast path).</typeparam>
+    /// <param name="input">Real-valued input samples. Length must be a power of 2.</param>
+    /// <param name="output">Preallocated complex output buffer. Length must equal input length.</param>
+    /// <exception cref="ArgumentException">Thrown if lengths mismatch or input is not a power of 2.</exception>
+    void NativeComplexFFTSpan<T>(ReadOnlySpan<T> input, Span<Complex<T>> output);
+
+    /// <summary>
+    /// Span-based inverse 1D FFT (complex-to-complex) with 1/N normalization.
+    /// </summary>
+    void NativeComplexIFFTSpan<T>(ReadOnlySpan<Complex<T>> input, Span<Complex<T>> output);
+
+    /// <summary>
+    /// Span-based complex-to-complex forward 1D FFT.
+    /// </summary>
+    void NativeComplexFFTComplexSpan<T>(ReadOnlySpan<Complex<T>> input, Span<Complex<T>> output);
+
+    /// <summary>
+    /// Fused analytic-signal kernel (Hilbert transform via FFT).
+    /// Computes analytic signal z(t) = x(t) + i·H{x}(t) in one fused call:
+    /// forward FFT → zero negative frequencies (and optionally zero outside [freqLow, freqHigh])
+    /// → double positive bins → inverse FFT. Collapses what is otherwise 3 separate engine
+    /// calls (FFT, bin masking, IFFT) into a single kernel.
+    /// </summary>
+    /// <param name="input">Real-valued time-domain input. Last axis length must be power of 2.</param>
+    /// <param name="freqLow">Optional low-frequency cutoff in Hz (inclusive). Bins below are zeroed.</param>
+    /// <param name="freqHigh">Optional high-frequency cutoff in Hz (exclusive). Bins at/above are zeroed.</param>
+    /// <param name="sampleRate">Sample rate in Hz for interpreting freqLow/freqHigh. Default 1.0 means no band-limiting.</param>
+    /// <returns>Complex-valued analytic signal tensor of same shape as input.</returns>
+    Tensor<Complex<T>> NativeAnalyticSignal<T>(Tensor<T> input, double freqLow = 0.0, double freqHigh = double.MaxValue, double sampleRate = 1.0);
+
+    /// <summary>
+    /// Per-row L2 normalization. For each row of a 2D tensor, divides by its L2 norm.
+    /// Uses SIMD for the sum-of-squares accumulation and multiplication. Rows with zero norm
+    /// are left as zeros (no division).
+    /// </summary>
+    /// <param name="input">2D input tensor [rows, cols].</param>
+    /// <returns>2D output tensor of same shape with each row having unit L2 norm.</returns>
+    Tensor<T> NativeNormalizeRows<T>(Tensor<T> input);
+
+    /// <summary>
     /// Inverse 1D FFT from Complex&lt;T&gt; tensor, returning real-valued tensor.
     /// Extracts only the real component of the inverse transform. Use this when the original
     /// signal was real-valued (Hermitian symmetry assumed). Applies 1/N normalization.

--- a/tests/AiDotNet.Tensors.Tests/Engines/SpectralPerfOpsExtendedTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/SpectralPerfOpsExtendedTests.cs
@@ -271,27 +271,36 @@ public class SpectralPerfOpsExtendedTests
     [Fact]
     public void NativePacFeatures_StructuredSignal_HasHigherPac()
     {
-        // A signal that actually has theta-gamma coupling should have higher PAC than random noise
+        // A signal that actually has theta-gamma coupling should have higher PAC than an
+        // uncoupled control — not just > 0, which any signal with nonzero gamma amplitude
+        // would satisfy.
         int numSamples = 2048;
         int sampleRate = 1000;
         double thetaFreq = 6.0;  // Hz
         double gammaFreq = 80.0; // Hz
 
         var coupled = new Tensor<double>([numSamples]);
+        var uncoupled = new Tensor<double>([numSamples]);
+        var rng = new Random(42);
         for (int i = 0; i < numSamples; i++)
         {
             double t = i / (double)sampleRate;
             double theta = Math.Cos(2 * Math.PI * thetaFreq * t);
-            // Gamma amplitude modulated by theta phase
-            double gammaAmp = 0.5 + 0.5 * theta;
-            coupled[i] = theta + gammaAmp * Math.Cos(2 * Math.PI * gammaFreq * t);
+            // Coupled: gamma amplitude modulated by theta phase
+            double gammaAmpCoupled = 0.5 + 0.5 * theta;
+            coupled[i] = theta + gammaAmpCoupled * Math.Cos(2 * Math.PI * gammaFreq * t);
+            // Uncoupled control: gamma with constant amplitude (no phase coupling) + same theta
+            uncoupled[i] = theta + Math.Cos(2 * Math.PI * gammaFreq * t) + 0.05 * (rng.NextDouble() - 0.5);
         }
 
         var gammaBands = new[] { (60.0, 100.0) };
-        var result = _engine.NativePacFeatures(coupled, sampleRate, envelopeRate: 200,
+        var resCoupled = _engine.NativePacFeatures(coupled, sampleRate, envelopeRate: 200,
+            thetaLow: 4.0, thetaHigh: 8.0, gammaBands: gammaBands);
+        var resUncoupled = _engine.NativePacFeatures(uncoupled, sampleRate, envelopeRate: 200,
             thetaLow: 4.0, thetaHigh: 8.0, gammaBands: gammaBands);
 
-        // Coupled signal should produce some PAC MI (not zero)
-        Assert.True(result[0] > 0.0);
+        // Coupled signal must have strictly higher PAC MI than the uncoupled control.
+        Assert.True(resCoupled[0] > resUncoupled[0],
+            $"Expected coupled PAC > uncoupled PAC, but got coupled={resCoupled[0]}, uncoupled={resUncoupled[0]}");
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/SpectralPerfOpsExtendedTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/SpectralPerfOpsExtendedTests.cs
@@ -1,0 +1,297 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Tests for P1-P3 spectral/audio perf ops: transcendentals, bispectrum/trispectrum,
+/// batched cavity forward, and fused MFCC/Wideband/PAC feature pipelines.
+/// Covers Issue #160 P1-P3 items.
+/// </summary>
+public class SpectralPerfOpsExtendedTests
+{
+    private readonly IEngine _engine = new CpuEngine();
+
+    // ================================================================
+    // NativeTanh / NativeExp / NativeAtan2 / NativeMagnitudeAndPhase
+    // ================================================================
+
+    [Fact]
+    public void NativeTanh_Double_MatchesMathTanh()
+    {
+        var input = new Tensor<double>([16]);
+        for (int i = 0; i < 16; i++) input[i] = i * 0.1 - 0.8;
+
+        var result = _engine.NativeTanh(input);
+
+        for (int i = 0; i < 16; i++)
+            Assert.Equal(Math.Tanh(input[i]), result[i], 5);
+    }
+
+    [Fact]
+    public void NativeTanh_Float_MatchesMathTanh()
+    {
+        var input = new Tensor<float>([16]);
+        for (int i = 0; i < 16; i++) input[i] = i * 0.1f - 0.8f;
+
+        var result = _engine.NativeTanh(input);
+
+        for (int i = 0; i < 16; i++)
+            Assert.Equal(MathF.Tanh(input[i]), result[i], 3);
+    }
+
+    [Fact]
+    public void NativeExp_Double_MatchesMathExp()
+    {
+        var input = new Tensor<double>([16]);
+        for (int i = 0; i < 16; i++) input[i] = i * 0.1 - 0.8;
+
+        var result = _engine.NativeExp(input);
+
+        for (int i = 0; i < 16; i++)
+            Assert.Equal(Math.Exp(input[i]), result[i], 5);
+    }
+
+    [Fact]
+    public void NativeAtan2_Double_MatchesMathAtan2()
+    {
+        int n = 16;
+        var imag = new Tensor<double>([n]);
+        var real = new Tensor<double>([n]);
+        for (int i = 0; i < n; i++)
+        {
+            imag[i] = Math.Sin(i * 0.3);
+            real[i] = Math.Cos(i * 0.3);
+        }
+
+        var result = _engine.NativeAtan2(imag, real);
+
+        for (int i = 0; i < n; i++)
+            Assert.Equal(Math.Atan2(imag[i], real[i]), result[i], 10);
+    }
+
+    [Fact]
+    public void NativeMagnitudeAndPhase_DecomposesComplex()
+    {
+        int n = 8;
+        var input = new Tensor<Complex<double>>([n]);
+        var rng = new Random(42);
+        for (int i = 0; i < n; i++)
+            input[i] = new Complex<double>(rng.NextDouble() * 2 - 1, rng.NextDouble() * 2 - 1);
+
+        var mag = _engine.NativeMagnitudeAndPhase(input, out var phase);
+
+        for (int i = 0; i < n; i++)
+        {
+            double expectedMag = Math.Sqrt(input[i].Real * input[i].Real + input[i].Imaginary * input[i].Imaginary);
+            double expectedPhase = Math.Atan2(input[i].Imaginary, input[i].Real);
+            Assert.Equal(expectedMag, mag[i], 10);
+            Assert.Equal(expectedPhase, phase[i], 10);
+        }
+    }
+
+    // ================================================================
+    // NativeBispectrum / NativeTrispectrum
+    // ================================================================
+
+    [Fact]
+    public void NativeBispectrum_Shape_IsCorrect()
+    {
+        int n = 32;
+        var spec = new Tensor<Complex<double>>([n]);
+        var rng = new Random(42);
+        for (int i = 0; i < n; i++)
+            spec[i] = new Complex<double>(rng.NextDouble(), rng.NextDouble());
+
+        int maxF1 = 8, maxF2 = 8;
+        var result = _engine.NativeBispectrum(spec, maxF1, maxF2);
+
+        Assert.Equal(new[] { maxF1, maxF2 }, result.Shape.ToArray());
+    }
+
+    [Fact]
+    public void NativeBispectrum_MatchesManualFormula()
+    {
+        int n = 16;
+        var spec = new Tensor<Complex<double>>([n]);
+        var rng = new Random(77);
+        for (int i = 0; i < n; i++)
+            spec[i] = new Complex<double>(rng.NextDouble(), rng.NextDouble());
+
+        int maxF1 = 4, maxF2 = 4;
+        var result = _engine.NativeBispectrum(spec, maxF1, maxF2);
+
+        // Verify a few entries against the formula B(f1,f2) = X(f1) * X(f2) * conj(X(f1+f2))
+        for (int f1 = 0; f1 < maxF1; f1++)
+        {
+            for (int f2 = 0; f2 < maxF2; f2++)
+            {
+                var x1 = spec[f1];
+                var x2 = spec[f2];
+                var x12 = spec[f1 + f2];
+                // x1 * x2
+                double t1r = x1.Real * x2.Real - x1.Imaginary * x2.Imaginary;
+                double t1i = x1.Real * x2.Imaginary + x1.Imaginary * x2.Real;
+                // * conj(x12)
+                double br = t1r * x12.Real + t1i * x12.Imaginary;
+                double bi = -t1r * x12.Imaginary + t1i * x12.Real;
+
+                var b = result[f1 * maxF2 + f2];
+                Assert.Equal(br, b.Real, 10);
+                Assert.Equal(bi, b.Imaginary, 10);
+            }
+        }
+    }
+
+    [Fact]
+    public void NativeTrispectrum_Shape_IsCorrect()
+    {
+        int n = 32;
+        var spec = new Tensor<Complex<double>>([n]);
+        var rng = new Random(55);
+        for (int i = 0; i < n; i++)
+            spec[i] = new Complex<double>(rng.NextDouble(), rng.NextDouble());
+
+        int maxF1 = 4, maxF2 = 4, maxF3 = 4;
+        var result = _engine.NativeTrispectrum(spec, maxF1, maxF2, maxF3);
+        Assert.Equal(new[] { maxF1, maxF2, maxF3 }, result.Shape.ToArray());
+    }
+
+    [Fact]
+    public void NativeBispectrum_ThrowsOnOutOfRange()
+    {
+        int n = 16;
+        var spec = new Tensor<Complex<double>>([n]);
+        Assert.Throws<ArgumentException>(() => _engine.NativeBispectrum(spec, 10, 10));
+    }
+
+    // ================================================================
+    // NativeBatchedCavityForward
+    // ================================================================
+
+    [Fact]
+    public void NativeBatchedCavityForward_Shape_IsCorrect()
+    {
+        int batch = 2, n = 16, numCavities = 3, numBounces = 2;
+        var input = new Tensor<double>([batch, n]);
+        var filters = new Tensor<Complex<double>>([numCavities, n]);
+        var rng = new Random(42);
+        for (int i = 0; i < batch * n; i++) input[i] = rng.NextDouble() * 2 - 1;
+        for (int i = 0; i < numCavities * n; i++)
+            filters[i] = new Complex<double>(rng.NextDouble(), rng.NextDouble());
+
+        var result = _engine.NativeBatchedCavityForward(input, filters, numBounces);
+
+        Assert.Equal(new[] { batch, numCavities, n }, result.Shape.ToArray());
+        // Sanity check output values are finite
+        for (int i = 0; i < result.Length; i++)
+            Assert.True(!double.IsNaN(result[i]) && !double.IsInfinity(result[i]));
+    }
+
+    [Fact]
+    public void NativeBatchedCavityForward_ThrowsOnInvalidInput()
+    {
+        var input1D = new Tensor<double>([16]);
+        var filters = new Tensor<Complex<double>>([2, 16]);
+        Assert.Throws<ArgumentException>(() => _engine.NativeBatchedCavityForward(input1D, filters, 1));
+
+        var input = new Tensor<double>([1, 16]);
+        Assert.Throws<ArgumentException>(() => _engine.NativeBatchedCavityForward(input, filters, 0));
+    }
+
+    // ================================================================
+    // NativeMfccFeatures / NativeWidebandFeatures / NativePacFeatures
+    // ================================================================
+
+    [Fact]
+    public void NativeMfccFeatures_Shape_Batched()
+    {
+        int batch = 2, numSamples = 512, numSegments = 4, numMfcc = 13, paddedDim = 256;
+        var waveforms = new Tensor<double>([batch, numSamples]);
+        var rng = new Random(42);
+        for (int i = 0; i < batch * numSamples; i++) waveforms[i] = rng.NextDouble() * 2 - 1;
+
+        var result = _engine.NativeMfccFeatures(waveforms, numSegments, numMfcc, paddedDim);
+
+        Assert.Equal(new[] { batch, numSegments * numMfcc }, result.Shape.ToArray());
+        // Check output contains finite values
+        for (int i = 0; i < result.Length; i++)
+            Assert.True(!double.IsNaN(result[i]) && !double.IsInfinity(result[i]));
+    }
+
+    [Fact]
+    public void NativeMfccFeatures_Shape_Single()
+    {
+        int numSamples = 256, numSegments = 2, numMfcc = 8, paddedDim = 128;
+        var waveform = new Tensor<double>([numSamples]);
+        for (int i = 0; i < numSamples; i++) waveform[i] = Math.Sin(i * 0.1);
+
+        var result = _engine.NativeMfccFeatures(waveform, numSegments, numMfcc, paddedDim);
+
+        Assert.Equal(new[] { numSegments * numMfcc }, result.Shape.ToArray());
+    }
+
+    [Fact]
+    public void NativeWidebandFeatures_Shape_Batched()
+    {
+        int batch = 2, numSamples = 512, numSegments = 4, numBins = 20;
+        var waveforms = new Tensor<double>([batch, numSamples]);
+        var rng = new Random(123);
+        for (int i = 0; i < batch * numSamples; i++) waveforms[i] = rng.NextDouble() * 2 - 1;
+
+        var result = _engine.NativeWidebandFeatures(waveforms, numSegments, numBins);
+
+        Assert.Equal(new[] { batch, numSegments * numBins }, result.Shape.ToArray());
+        for (int i = 0; i < result.Length; i++)
+            Assert.True(!double.IsNaN(result[i]) && !double.IsInfinity(result[i]));
+    }
+
+    [Fact]
+    public void NativePacFeatures_Shape_IsCorrect()
+    {
+        int batch = 2, numSamples = 512;
+        var waveforms = new Tensor<double>([batch, numSamples]);
+        var rng = new Random(77);
+        for (int i = 0; i < batch * numSamples; i++) waveforms[i] = rng.NextDouble() * 2 - 1;
+
+        var gammaBands = new[] { (30.0, 60.0), (60.0, 100.0), (100.0, 150.0) };
+        var result = _engine.NativePacFeatures(waveforms, sampleRate: 500, envelopeRate: 100,
+            thetaLow: 4.0, thetaHigh: 8.0, gammaBands: gammaBands);
+
+        Assert.Equal(new[] { batch, gammaBands.Length }, result.Shape.ToArray());
+        for (int i = 0; i < result.Length; i++)
+        {
+            Assert.True(!double.IsNaN(result[i]) && !double.IsInfinity(result[i]));
+            // PAC MI is in [0, 1]
+            Assert.InRange(result[i], 0.0, 1.0);
+        }
+    }
+
+    [Fact]
+    public void NativePacFeatures_StructuredSignal_HasHigherPac()
+    {
+        // A signal that actually has theta-gamma coupling should have higher PAC than random noise
+        int numSamples = 2048;
+        int sampleRate = 1000;
+        double thetaFreq = 6.0;  // Hz
+        double gammaFreq = 80.0; // Hz
+
+        var coupled = new Tensor<double>([numSamples]);
+        for (int i = 0; i < numSamples; i++)
+        {
+            double t = i / (double)sampleRate;
+            double theta = Math.Cos(2 * Math.PI * thetaFreq * t);
+            // Gamma amplitude modulated by theta phase
+            double gammaAmp = 0.5 + 0.5 * theta;
+            coupled[i] = theta + gammaAmp * Math.Cos(2 * Math.PI * gammaFreq * t);
+        }
+
+        var gammaBands = new[] { (60.0, 100.0) };
+        var result = _engine.NativePacFeatures(coupled, sampleRate, envelopeRate: 200,
+            thetaLow: 4.0, thetaHigh: 8.0, gammaBands: gammaBands);
+
+        // Coupled signal should produce some PAC MI (not zero)
+        Assert.True(result[0] > 0.0);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/SpectralPerfOpsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/SpectralPerfOpsTests.cs
@@ -127,6 +127,42 @@ public class SpectralPerfOpsTests
         Assert.Throws<ArgumentException>(() => _engine.NativeComplexFFTSpan<double>(input, output));
     }
 
+    [Fact]
+    public void IFFTRealSpan_RecoversOriginal()
+    {
+        int n = 256;
+        var rng = new Random(42);
+        var input = new double[n];
+        for (int i = 0; i < n; i++) input[i] = rng.NextDouble();
+
+        var spectrum = new Complex<double>[n];
+        _engine.NativeComplexFFTSpan<double>(input, spectrum);
+
+        var recovered = new double[n];
+        _engine.NativeComplexIFFTRealSpan<double>(spectrum, recovered);
+
+        for (int i = 0; i < n; i++)
+            Assert.Equal(input[i], recovered[i], 10);
+    }
+
+    [Fact]
+    public void IFFTRealSpan_Float_RecoversOriginal()
+    {
+        int n = 64;
+        var rng = new Random(99);
+        var input = new float[n];
+        for (int i = 0; i < n; i++) input[i] = (float)rng.NextDouble();
+
+        var spectrum = new Complex<float>[n];
+        _engine.NativeComplexFFTSpan<float>(input, spectrum);
+
+        var recovered = new float[n];
+        _engine.NativeComplexIFFTRealSpan<float>(spectrum, recovered);
+
+        for (int i = 0; i < n; i++)
+            Assert.Equal(input[i], recovered[i], 3);
+    }
+
     // ================================================================
     // NativeAnalyticSignal (Hilbert transform)
     // ================================================================
@@ -265,6 +301,33 @@ public class SpectralPerfOpsTests
     {
         var input = new Tensor<double>([8]);
         Assert.Throws<ArgumentException>(() => _engine.NativeNormalizeRows(input));
+    }
+
+    [Fact]
+    public void NormalizeRows_InPlace_MutatesInputAndReturnsIt()
+    {
+        int rows = 4, cols = 16;
+        var input = new Tensor<double>([rows, cols]);
+        var rng = new Random(123);
+        for (int i = 0; i < rows * cols; i++) input[i] = rng.NextDouble() * 5 - 2.5;
+
+        // Save original first row for comparison
+        double origFirstSum = 0;
+        for (int c = 0; c < cols; c++) origFirstSum += input[c] * input[c];
+        Assert.NotEqual(1.0, origFirstSum, 5);
+
+        var result = _engine.NativeNormalizeRows(input, inPlace: true);
+
+        // Result should be the same tensor reference
+        Assert.Same(input, result);
+
+        // Each row should now have unit L2 norm in the input itself
+        for (int r = 0; r < rows; r++)
+        {
+            double sumSq = 0;
+            for (int c = 0; c < cols; c++) sumSq += input[r * cols + c] * input[r * cols + c];
+            Assert.Equal(1.0, sumSq, 10);
+        }
     }
 
     [Fact]

--- a/tests/AiDotNet.Tensors.Tests/Engines/SpectralPerfOpsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/SpectralPerfOpsTests.cs
@@ -205,18 +205,33 @@ public class SpectralPerfOpsTests
     [Fact]
     public void AnalyticSignal_BandLimited_ZerosOutsideBand()
     {
-        // Pass a two-frequency cosine and keep only one of them — verify magnitude drops at other freq
+        // Use FFT-bin-aligned frequencies so tones do not leak across bins — this makes the
+        // test sensitive to a broken band mask (an unfiltered two-tone signal has mean
+        // envelope magnitude well above 1.0 even with some bin leakage).
         int n = 512;
-        double sr = 1000.0; // 1 kHz
+        double sr = 512.0;             // Hz — chosen so one bin == 1 Hz
+        // bin k <-> freq k * sr / n = k Hz. Pick bin 50 (50 Hz) and bin 200 (200 Hz).
         double f1 = 50.0, f2 = 200.0;
         var input = new Tensor<double>([n]);
         for (int i = 0; i < n; i++)
             input[i] = Math.Cos(2.0 * Math.PI * f1 * i / sr) + Math.Cos(2.0 * Math.PI * f2 * i / sr);
 
-        // Keep only f1 band
-        var analytic = _engine.NativeAnalyticSignal(input, freqLow: 30.0, freqHigh: 100.0, sampleRate: sr);
+        // Unfiltered analytic signal of cos(f1) + cos(f2) has magnitude that oscillates in
+        // ~[0, 2], with mean well above 1.0. Verify that first.
+        var unfiltered = _engine.NativeAnalyticSignal(input);
+        double meanMagUnfiltered = 0.0;
+        int count = 0;
+        for (int i = 100; i < n - 100; i += 10)
+        {
+            double m = Math.Sqrt(unfiltered[i].Real * unfiltered[i].Real + unfiltered[i].Imaginary * unfiltered[i].Imaginary);
+            meanMagUnfiltered += m; count++;
+        }
+        meanMagUnfiltered /= count;
+        Assert.True(meanMagUnfiltered > 1.2,
+            $"Unfiltered two-tone envelope mean should be clearly > 1; got {meanMagUnfiltered}");
 
-        // Envelope magnitude should be roughly 1 (for a single cosine at f1) at interior points
+        // Keep only the f1 band (30..100 Hz) — covers bin 50 but excludes bin 200.
+        var analytic = _engine.NativeAnalyticSignal(input, freqLow: 30.0, freqHigh: 100.0, sampleRate: sr);
         double meanMag = 0.0;
         int sampleCount = 0;
         for (int i = 100; i < n - 100; i += 10)
@@ -226,8 +241,8 @@ public class SpectralPerfOpsTests
             sampleCount++;
         }
         meanMag /= sampleCount;
-        // Should be near 1.0 — only f1 survives
-        Assert.InRange(meanMag, 0.5, 1.5);
+        // After masking out f2, envelope should be tightly concentrated around 1.0.
+        Assert.InRange(meanMag, 0.9, 1.1);
     }
 
     // ================================================================

--- a/tests/AiDotNet.Tensors.Tests/Engines/SpectralPerfOpsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/SpectralPerfOpsTests.cs
@@ -1,0 +1,291 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Tests for new spectral/audio perf ops: span-based FFT entry points,
+/// NativeAnalyticSignal (Hilbert transform), and NativeNormalizeRows.
+/// Covers Issue #160 P0 items.
+/// </summary>
+public class SpectralPerfOpsTests
+{
+    private readonly IEngine _engine = new CpuEngine();
+
+    // ================================================================
+    // Span-based FFT entry points
+    // ================================================================
+
+    [Theory]
+    [InlineData(8)]
+    [InlineData(256)]
+    [InlineData(1024)]
+    public void FFTSpan_Double_MatchesTensorFFT(int n)
+    {
+        var rng = new Random(42);
+        var input = new double[n];
+        for (int i = 0; i < n; i++) input[i] = rng.NextDouble() * 2 - 1;
+
+        // Span-based path
+        var spanOutput = new Complex<double>[n];
+        _engine.NativeComplexFFTSpan<double>(input, spanOutput);
+
+        // Tensor-based path
+        var inputTensor = new Tensor<double>([n]);
+        for (int i = 0; i < n; i++) inputTensor[i] = input[i];
+        var tensorOutput = _engine.NativeComplexFFT(inputTensor);
+
+        for (int i = 0; i < n; i++)
+        {
+            Assert.Equal(tensorOutput[i].Real, spanOutput[i].Real, 10);
+            Assert.Equal(tensorOutput[i].Imaginary, spanOutput[i].Imaginary, 10);
+        }
+    }
+
+    [Theory]
+    [InlineData(8)]
+    [InlineData(256)]
+    public void FFTSpan_Float_MatchesTensorFFT(int n)
+    {
+        var rng = new Random(123);
+        var input = new float[n];
+        for (int i = 0; i < n; i++) input[i] = (float)(rng.NextDouble() * 2 - 1);
+
+        var spanOutput = new Complex<float>[n];
+        _engine.NativeComplexFFTSpan<float>(input, spanOutput);
+
+        var inputTensor = new Tensor<float>([n]);
+        for (int i = 0; i < n; i++) inputTensor[i] = input[i];
+        var tensorOutput = _engine.NativeComplexFFT(inputTensor);
+
+        for (int i = 0; i < n; i++)
+        {
+            Assert.Equal(tensorOutput[i].Real, spanOutput[i].Real, 3);
+            Assert.Equal(tensorOutput[i].Imaginary, spanOutput[i].Imaginary, 3);
+        }
+    }
+
+    [Fact]
+    public void FFTSpan_IFFT_RoundTripRecoversOriginal()
+    {
+        int n = 256;
+        var rng = new Random(77);
+        var input = new double[n];
+        for (int i = 0; i < n; i++) input[i] = rng.NextDouble();
+
+        var spectrum = new Complex<double>[n];
+        _engine.NativeComplexFFTSpan<double>(input, spectrum);
+
+        var recovered = new Complex<double>[n];
+        _engine.NativeComplexIFFTSpan<double>(spectrum, recovered);
+
+        for (int i = 0; i < n; i++)
+        {
+            Assert.Equal(input[i], recovered[i].Real, 10);
+            Assert.Equal(0.0, recovered[i].Imaginary, 10);
+        }
+    }
+
+    [Fact]
+    public void FFTSpan_ComplexToComplexFFT_MatchesExpected()
+    {
+        int n = 32;
+        var rng = new Random(55);
+        var input = new Complex<double>[n];
+        for (int i = 0; i < n; i++)
+            input[i] = new Complex<double>(rng.NextDouble(), rng.NextDouble());
+
+        var output = new Complex<double>[n];
+        _engine.NativeComplexFFTComplexSpan<double>(input, output);
+
+        // Compare to tensor-based complex FFT
+        var inputTensor = new Tensor<Complex<double>>([n]);
+        for (int i = 0; i < n; i++) inputTensor[i] = input[i];
+        var tensorOutput = _engine.NativeComplexFFTComplex(inputTensor);
+
+        for (int i = 0; i < n; i++)
+        {
+            Assert.Equal(tensorOutput[i].Real, output[i].Real, 10);
+            Assert.Equal(tensorOutput[i].Imaginary, output[i].Imaginary, 10);
+        }
+    }
+
+    [Fact]
+    public void FFTSpan_NonPowerOfTwo_Throws()
+    {
+        var input = new double[15];
+        var output = new Complex<double>[15];
+        Assert.Throws<ArgumentException>(() => _engine.NativeComplexFFTSpan<double>(input, output));
+    }
+
+    [Fact]
+    public void FFTSpan_LengthMismatch_Throws()
+    {
+        var input = new double[8];
+        var output = new Complex<double>[16];
+        Assert.Throws<ArgumentException>(() => _engine.NativeComplexFFTSpan<double>(input, output));
+    }
+
+    // ================================================================
+    // NativeAnalyticSignal (Hilbert transform)
+    // ================================================================
+
+    [Fact]
+    public void AnalyticSignal_RealPart_MatchesInput()
+    {
+        // The analytic signal z(t) = x(t) + iH{x}(t) has Re{z} = x
+        int n = 128;
+        var input = new Tensor<double>([n]);
+        var rng = new Random(42);
+        for (int i = 0; i < n; i++) input[i] = rng.NextDouble() * 2 - 1;
+
+        var analytic = _engine.NativeAnalyticSignal(input);
+
+        for (int i = 0; i < n; i++)
+            Assert.Equal(input[i], analytic[i].Real, 8);
+    }
+
+    [Fact]
+    public void AnalyticSignal_Cosine_ProducesSineInImag()
+    {
+        // Hilbert transform of cos(ω t) is sin(ω t) — so analytic of cos is cos + i*sin
+        int n = 256;
+        double freq = 4; // cycles per period
+        var input = new Tensor<double>([n]);
+        for (int i = 0; i < n; i++)
+            input[i] = Math.Cos(2.0 * Math.PI * freq * i / n);
+
+        var analytic = _engine.NativeAnalyticSignal(input);
+
+        // Check a few interior points (avoid edge effects from discrete FFT)
+        for (int i = 32; i < n - 32; i += 8)
+        {
+            double expectedSin = Math.Sin(2.0 * Math.PI * freq * i / n);
+            Assert.Equal(expectedSin, analytic[i].Imaginary, 8);
+        }
+    }
+
+    [Fact]
+    public void AnalyticSignal_BandLimited_ZerosOutsideBand()
+    {
+        // Pass a two-frequency cosine and keep only one of them — verify magnitude drops at other freq
+        int n = 512;
+        double sr = 1000.0; // 1 kHz
+        double f1 = 50.0, f2 = 200.0;
+        var input = new Tensor<double>([n]);
+        for (int i = 0; i < n; i++)
+            input[i] = Math.Cos(2.0 * Math.PI * f1 * i / sr) + Math.Cos(2.0 * Math.PI * f2 * i / sr);
+
+        // Keep only f1 band
+        var analytic = _engine.NativeAnalyticSignal(input, freqLow: 30.0, freqHigh: 100.0, sampleRate: sr);
+
+        // Envelope magnitude should be roughly 1 (for a single cosine at f1) at interior points
+        double meanMag = 0.0;
+        int sampleCount = 0;
+        for (int i = 100; i < n - 100; i += 10)
+        {
+            double mag = Math.Sqrt(analytic[i].Real * analytic[i].Real + analytic[i].Imaginary * analytic[i].Imaginary);
+            meanMag += mag;
+            sampleCount++;
+        }
+        meanMag /= sampleCount;
+        // Should be near 1.0 — only f1 survives
+        Assert.InRange(meanMag, 0.5, 1.5);
+    }
+
+    // ================================================================
+    // NativeNormalizeRows
+    // ================================================================
+
+    [Fact]
+    public void NormalizeRows_Double_EachRowHasUnitNorm()
+    {
+        int rows = 8, cols = 32;
+        var input = new Tensor<double>([rows, cols]);
+        var rng = new Random(42);
+        for (int i = 0; i < rows * cols; i++) input[i] = rng.NextDouble() * 10 - 5;
+
+        var result = _engine.NativeNormalizeRows(input);
+
+        for (int r = 0; r < rows; r++)
+        {
+            double sumSq = 0.0;
+            for (int c = 0; c < cols; c++)
+            {
+                double v = result[r * cols + c];
+                sumSq += v * v;
+            }
+            Assert.Equal(1.0, sumSq, 10);
+        }
+    }
+
+    [Fact]
+    public void NormalizeRows_Float_EachRowHasUnitNorm()
+    {
+        int rows = 4, cols = 64;
+        var input = new Tensor<float>([rows, cols]);
+        var rng = new Random(123);
+        for (int i = 0; i < rows * cols; i++) input[i] = (float)(rng.NextDouble() * 10 - 5);
+
+        var result = _engine.NativeNormalizeRows(input);
+
+        for (int r = 0; r < rows; r++)
+        {
+            float sumSq = 0f;
+            for (int c = 0; c < cols; c++)
+            {
+                float v = result[r * cols + c];
+                sumSq += v * v;
+            }
+            Assert.Equal(1f, sumSq, 5);
+        }
+    }
+
+    [Fact]
+    public void NormalizeRows_ZeroRow_StaysZero()
+    {
+        int rows = 3, cols = 16;
+        var input = new Tensor<double>([rows, cols]);
+        // Row 0 is all zeros, rows 1 and 2 have values
+        for (int c = 0; c < cols; c++)
+        {
+            input[cols + c] = c + 1;       // row 1
+            input[2 * cols + c] = c + 10;  // row 2
+        }
+
+        var result = _engine.NativeNormalizeRows(input);
+
+        for (int c = 0; c < cols; c++)
+            Assert.Equal(0.0, result[c]);
+    }
+
+    [Fact]
+    public void NormalizeRows_ThrowsOnNon2D()
+    {
+        var input = new Tensor<double>([8]);
+        Assert.Throws<ArgumentException>(() => _engine.NativeNormalizeRows(input));
+    }
+
+    [Fact]
+    public void NormalizeRows_PreservesDirection()
+    {
+        // A vector scaled by any positive constant has the same direction after normalization
+        int cols = 32;
+        var input1 = new Tensor<double>([1, cols]);
+        var input2 = new Tensor<double>([1, cols]);
+        var rng = new Random(77);
+        for (int c = 0; c < cols; c++)
+        {
+            double v = rng.NextDouble();
+            input1[c] = v;
+            input2[c] = v * 5.0;  // scaled
+        }
+
+        var r1 = _engine.NativeNormalizeRows(input1);
+        var r2 = _engine.NativeNormalizeRows(input2);
+
+        for (int c = 0; c < cols; c++)
+            Assert.Equal(r1[c], r2[c], 10);
+    }
+}


### PR DESCRIPTION
## Summary

Implements the **complete plan** from Issue #160 — all P0-P3 items in one PR.

All public APIs are **fully generic on `T`**. Internal kernels are type-specialized for `double`/`float` where SIMD intrinsics require concrete types; dispatch is via `typeof(T)` check + `Unsafe.As` reinterpret — no new hardcoded-type public API.

## P0 — Span-based FFT + Hilbert + L2 normalize

- `NativeComplexFFTSpan<T>` / `NativeComplexIFFTSpan<T>` / `NativeComplexFFTComplexSpan<T>` — zero-allocation span-based FFT entry points
- `NativeAnalyticSignal<T>(Tensor<T>, freqLow, freqHigh, sampleRate)` — fused Hilbert transform (FFT → band-mask → IFFT in one call)
- `NativeNormalizeRows<T>` — per-row L2 normalization with AVX2 SIMD (4 doubles or 8 floats per iteration)

## P1 — Element-wise transcendentals + higher-order spectral

- `NativeTanh<T>` — SIMD via SimdKernels.Tanh
- `NativeExp<T>` — SIMD via SimdKernels.ExpUnsafe (float), Math.Exp (double)
- `NativeAtan2<T>(imag, real)` — scalar fast path
- `NativeMagnitudeAndPhase<T>` — single-pass decomposition
- `NativeBispectrum<T>` — 3rd-order B(f1,f2) = X(f1)·X(f2)·conj(X(f1+f2)), parallel over f1
- `NativeTrispectrum<T>` — 4th-order analogue

## P2 — Batched cavity operator

- `NativeBatchedCavityForward<T>(input, cavityFilters, numBounces)` — FFT→per-cavity multiply→IFFT→tanh bounce, fused across batch×cavities

## P3 — End-to-end feature pipelines

- `NativeMfccFeatures<T>` — segmentation → FFT → mel filterbank → log → DCT
- `NativeWidebandFeatures<T>` — segmentation → FFT → log-binned magnitude pool
- `NativePacFeatures<T>` — theta/gamma analytic signals → phase-binned amplitude distribution → KL modulation index

## Architecture note

Public `<T>` generic API is uniform with the rest of IEngine. Internally, `typeof(T) == typeof(double)` / `typeof(T) == typeof(float)` branches use `System.Runtime.CompilerServices.Unsafe.As<T, double>` to reinterpret refs, then call private type-specialized kernels. JIT elides the typeof check for generic specialization; at runtime there's no boxing, no virtual dispatch, no allocation beyond working buffers. Same pattern as `SimdRandom.FillUniform<T>`.

## Test plan

- [x] 35 new tests pass across SpectralPerfOpsTests + SpectralPerfOpsExtendedTests
- [x] Span FFT correctness vs tensor FFT (double & float), round-trip, complex-to-complex, validation errors
- [x] Analytic signal: real part equals input, Hilbert of cos = sin, band-limiting isolates single frequency
- [x] NormalizeRows: unit norm per row, zero-row preservation, direction preservation
- [x] Transcendentals match Math.Tanh / Math.Exp / Math.Atan2 within precision
- [x] Bispectrum matches manual formula B(f1,f2) = X(f1)·X(f2)·conj(X(f1+f2))
- [x] Bispectrum/Trispectrum shape validation
- [x] Batched cavity forward produces correct shape and finite values
- [x] MFCC/Wideband/PAC pipelines: correct shape (batched and single), finite values
- [x] PAC MI in [0,1], structured coupled signal produces non-zero MI
- [x] All 56 existing FFT tests still pass
- [x] TapeCompleteness test passes (all new ops registered)
- [x] Build passes on net10.0 and net471

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)