### PR TITLE
feat: relax CudaGraphScope constructor to IDirectGpuBackend (#171 option A)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Gpu/CudaGraphScope.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/CudaGraphScope.cs
@@ -20,19 +20,30 @@ namespace AiDotNet.Tensors.Engines.Gpu;
 /// // Warmup run (required by CUDA graphs)
 /// var output = model.Forward(input);
 ///
-/// // Create a CUDA stream for capture (caller owns its lifetime).
-/// IntPtr stream = backend.CreateStream();
-///
-/// // Record the graph on that stream
-/// using var graph = new CudaGraphScope(backend, stream);
-/// graph.BeginCapture();
-/// var recorded = model.Forward(input);  // Operations are recorded, not executed
-/// graph.EndCapture();
-///
-/// // Replay with zero launch overhead
-/// for (int epoch = 0; epoch &lt; 1000; epoch++)
+/// // Create a user CUDA stream for capture. The default/null stream
+/// // (IntPtr.Zero) is rejected by cuStreamBeginCapture, so a user-created
+/// // stream is required. IDirectGpuBackend does NOT define a CreateStream
+/// // API today — use the CUDA driver binding directly, and dispose via
+/// // cuStreamDestroy when finished. The scope does not take ownership of
+/// // the stream; the caller is responsible for its lifetime.
+/// CudaNativeBindings.cuStreamCreate(out IntPtr stream, flags: 0);
+/// try
 /// {
-///     graph.Replay();  // Instant replay of all recorded operations
+///     // Record the graph on that stream
+///     using var graph = new CudaGraphScope(backend, stream);
+///     graph.BeginCapture();
+///     var recorded = model.Forward(input);  // Operations are recorded while being dispatched on `stream`
+///     graph.EndCapture();
+///
+///     // Replay with zero launch overhead
+///     for (int epoch = 0; epoch &lt; 1000; epoch++)
+///     {
+///         graph.Replay();  // Instant replay of all recorded operations
+///     }
+/// }
+/// finally
+/// {
+///     CudaNativeBindings.cuStreamDestroy(stream);
 /// }
 /// </code>
 /// </remarks>

--- a/src/AiDotNet.Tensors/Engines/Gpu/CudaGraphScope.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/CudaGraphScope.cs
@@ -35,8 +35,11 @@ namespace AiDotNet.Tensors.Engines.Gpu;
 /// </remarks>
 public sealed class CudaGraphScope : IDisposable
 {
-    // Backend retained for future graph replay integration with batch execution
-    internal readonly IGpuBatchExecution Backend;
+    // Backend retained for future graph replay integration (batch execution,
+    // resource lifetime, device-memory validation). Capture/replay itself only
+    // uses _stream — the backend reference is carried for future enhancements
+    // and to tie the scope's lifetime to a specific GPU context.
+    internal readonly IDirectGpuBackend Backend;
     private readonly IntPtr _stream;
     private IntPtr _graph;
     private IntPtr _graphExec;
@@ -62,9 +65,15 @@ public sealed class CudaGraphScope : IDisposable
     /// <summary>
     /// Creates a new CUDA graph scope.
     /// </summary>
-    /// <param name="backend">The GPU backend to use for graph operations.</param>
+    /// <param name="backend">
+    /// The direct GPU backend to associate with this scope (typically a
+    /// <c>CudaBackend</c>). Any <see cref="IDirectGpuBackend"/> is accepted;
+    /// graph capture only uses the supplied CUDA <paramref name="stream"/>,
+    /// but the backend reference is retained for lifecycle management and
+    /// future batch-execution integration.
+    /// </param>
     /// <param name="stream">The CUDA stream to capture on. Must be a user-created stream, not the default/null stream (CUDA requires this for graph capture).</param>
-    public CudaGraphScope(IGpuBatchExecution backend, IntPtr stream)
+    public CudaGraphScope(IDirectGpuBackend backend, IntPtr stream)
     {
         Backend = backend ?? throw new ArgumentNullException(nameof(backend));
         if (stream == IntPtr.Zero)

--- a/src/AiDotNet.Tensors/Engines/Gpu/CudaGraphScope.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/CudaGraphScope.cs
@@ -20,8 +20,11 @@ namespace AiDotNet.Tensors.Engines.Gpu;
 /// // Warmup run (required by CUDA graphs)
 /// var output = model.Forward(input);
 ///
-/// // Record the graph
-/// using var graph = new CudaGraphScope(backend);
+/// // Create a CUDA stream for capture (caller owns its lifetime).
+/// IntPtr stream = backend.CreateStream();
+///
+/// // Record the graph on that stream
+/// using var graph = new CudaGraphScope(backend, stream);
 /// graph.BeginCapture();
 /// var recorded = model.Forward(input);  // Operations are recorded, not executed
 /// graph.EndCapture();

--- a/tests/AiDotNet.Tensors.Tests/Engines/Gpu/CudaGraphScopeConstructionTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Gpu/CudaGraphScopeConstructionTests.cs
@@ -127,7 +127,8 @@ public class CudaGraphScopeConstructionTests
             // Default stream is synchronous in the legacy mode this test uses,
             // but synchronize explicitly to be robust against per-thread-default
             // stream behaviour.
-            CudaNativeBindings.cuStreamSynchronize(IntPtr.Zero);
+            Assert.Equal(CudaResult.Success,
+                CudaNativeBindings.cuStreamSynchronize(IntPtr.Zero));
 
             // ── Captured path: construct scope with real CudaBackend ─────
             // THIS is the line the issue's acceptance criterion calls out —
@@ -140,8 +141,12 @@ public class CudaGraphScopeConstructionTests
             Assert.True(scope.IsCapturing);
 
             // Forward op recorded into the graph: async D2D memcpy on the
-            // captured stream. CUDA records this as a memcpy node; it does not
-            // execute during capture.
+            // captured stream. CUDA records this as a memcpy node AND may also
+            // dispatch it normally to the stream during capture (capture mode
+            // doesn't suppress execution — it observes and records). The re-zero
+            // step after EndCapture below makes this test robust either way by
+            // ensuring any pattern we observe post-Replay was written by Replay
+            // itself, not by a side-effect of capture.
             Assert.Equal(CudaResult.Success,
                 CudaNativeBindings.cuMemcpyDtoDAsync(
                     dstCapturedDevice, srcDevice, byteCount, stream));
@@ -177,7 +182,11 @@ public class CudaGraphScopeConstructionTests
             if (srcDevice != IntPtr.Zero) CuBlasNative.cuMemFree(srcDevice);
             if (dstEagerDevice != IntPtr.Zero) CuBlasNative.cuMemFree(dstEagerDevice);
             if (dstCapturedDevice != IntPtr.Zero) CuBlasNative.cuMemFree(dstCapturedDevice);
-            CudaNativeBindings.cuStreamDestroy(stream);
+            // Stream destroy is best-effort in a finally — fail the test loudly
+            // rather than silently if the driver reports a destroy failure, since
+            // that indicates a leaked CUDA handle that will affect later tests.
+            if (stream != IntPtr.Zero)
+                Assert.Equal(CudaResult.Success, CudaNativeBindings.cuStreamDestroy(stream));
         }
     }
 
@@ -195,7 +204,8 @@ public class CudaGraphScopeConstructionTests
             var result = CudaNativeBindings.cuMemcpyDtoHAsync(
                 hostPtr, deviceBuffer, byteCount, IntPtr.Zero);
             Assert.Equal(CudaResult.Success, result);
-            CudaNativeBindings.cuStreamSynchronize(IntPtr.Zero);
+            Assert.Equal(CudaResult.Success,
+                CudaNativeBindings.cuStreamSynchronize(IntPtr.Zero));
         }
         finally
         {

--- a/tests/AiDotNet.Tensors.Tests/Engines/Gpu/CudaGraphScopeConstructionTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Gpu/CudaGraphScopeConstructionTests.cs
@@ -52,31 +52,22 @@ public class CudaGraphScopeConstructionTests
     }
 
     /// <summary>
-    /// Integration test (per issue #171 acceptance criterion):
-    /// <c>BeginCapture</c> → <c>EndCapture</c> → <c>Replay</c> with the real
+    /// Integration test covering issue #171's full acceptance criterion:
+    /// <c>BeginCapture</c> → forward op → <c>EndCapture</c> → <c>Replay</c>
+    /// with verified output equivalence vs. eager execution, using the real
     /// <see cref="CudaBackend"/> passed to the relaxed constructor.
     ///
-    /// Skipped when CUDA is unavailable on the host (CI without GPU, non-CUDA
-    /// dev machines). When a CUDA driver with graph-capture support (10.0+) is
-    /// present, the test:
-    /// <list type="number">
-    ///   <item>Creates a user stream via <c>cuStreamCreate</c> (graph capture
-    ///         rejects the default stream).</item>
-    ///   <item>Constructs <see cref="CudaGraphScope"/> with the real
-    ///         <see cref="CudaBackend"/> — the exact call that #171 unblocks.</item>
-    ///   <item>Captures an empty graph and replays it.</item>
-    /// </list>
+    /// The "forward op" is a device-to-device async memcpy on the captured
+    /// stream — the simplest real stream-submitted operation that (a) gets
+    /// recorded into the graph during capture, and (b) has a deterministic,
+    /// bit-exact expected output that can be compared against eager execution
+    /// without depending on any floating-point-sensitive kernel.
     ///
-    /// Capturing an empty graph is an intentionally minimal integration test —
-    /// it verifies the entire capture → instantiate → replay pipeline is
-    /// reachable via the relaxed constructor without depending on specific
-    /// kernel infrastructure (covered by the broader GPU correctness suite).
-    /// Output equivalence of real forward ops vs. eager is verified in those
-    /// other tests; this test specifically proves the constructor-relaxation
-    /// lets CUDA users wire up graph capture at all.
+    /// Skipped when CUDA is unavailable on the host (CI without GPU, non-CUDA
+    /// dev machines).
     /// </summary>
     [SkippableFact]
-    public void Constructor_WithRealCudaBackend_CanCaptureAndReplay()
+    public void Constructor_WithRealCudaBackend_CaptureReplayProducesSameOutputAsEager()
     {
         Skip.IfNot(CudaNativeBindings.IsAvailable,
             "CUDA driver not available on this machine");
@@ -93,31 +84,117 @@ public class CudaGraphScopeConstructionTests
         Skip.IfNot(streamResult == CudaResult.Success,
             $"cuStreamCreate failed: {streamResult}");
 
+        // Use 16 uint32 elements (64 bytes) as the test payload — large enough
+        // to catch any per-element bugs, small enough to stay on any GPU.
+        const int elementCount = 16;
+        const ulong byteCount = elementCount * sizeof(uint);
+        const uint pattern = 0xDEADBEEFu;
+
+        IntPtr srcDevice = IntPtr.Zero;
+        IntPtr dstEagerDevice = IntPtr.Zero;
+        IntPtr dstCapturedDevice = IntPtr.Zero;
+
         try
         {
-            // The acceptance criterion: this line must compile and run with
-            // CudaBackend passed directly. Before this PR, CudaBackend did not
-            // satisfy the constructor's IGpuBatchExecution parameter.
+            // Allocate three device buffers: src (source pattern), dstEager
+            // (direct-copy reference), dstCaptured (filled via graph replay).
+            Assert.Equal(CudaResult.Success, CuBlasNative.cuMemAlloc(out srcDevice, byteCount));
+            Assert.Equal(CudaResult.Success, CuBlasNative.cuMemAlloc(out dstEagerDevice, byteCount));
+            Assert.Equal(CudaResult.Success, CuBlasNative.cuMemAlloc(out dstCapturedDevice, byteCount));
+
+            // Fill source with the known pattern (sync, pre-capture).
+            Assert.Equal(CudaResult.Success,
+                CuBlasNative.cuMemsetD32(srcDevice, pattern, elementCount));
+            // Zero both destinations so a failed copy would show as all-zeros.
+            Assert.Equal(CudaResult.Success,
+                CuBlasNative.cuMemsetD32(dstEagerDevice, 0u, elementCount));
+            Assert.Equal(CudaResult.Success,
+                CuBlasNative.cuMemsetD32(dstCapturedDevice, 0u, elementCount));
+
+            // ── Eager path: direct sync memcpy on default stream ──────────
+            // Using the sync D2H path to roundtrip: stage src -> host -> dstEager
+            // would defeat the comparison. Instead, we use cuMemcpyDtoDAsync
+            // with stream=Zero (synchronous default stream), which is the eager
+            // analogue of the captured async copy below.
+            Assert.Equal(CudaResult.Success,
+                CudaNativeBindings.cuMemcpyDtoDAsync(
+                    dstEagerDevice, srcDevice, byteCount, IntPtr.Zero));
+            // Default stream is synchronous in the legacy mode this test uses,
+            // but synchronize explicitly to be robust against per-thread-default
+            // stream behaviour.
+            CudaNativeBindings.cuStreamSynchronize(IntPtr.Zero);
+
+            // ── Captured path: construct scope with real CudaBackend ─────
+            // THIS is the line the issue's acceptance criterion calls out —
+            // passing CudaBackend (IAsyncGpuBackend : IDirectGpuBackend) where
+            // previously IGpuBatchExecution was demanded.
             using var scope = new CudaGraphScope(cudaBackend, stream);
             Assert.True(scope.IsSupported);
 
             scope.BeginCapture();
             Assert.True(scope.IsCapturing);
 
-            // Empty graph: minimal valid capture. No kernels submitted — this
-            // test exists to prove the lifecycle is reachable via the relaxed
-            // constructor, not to re-verify kernel correctness.
+            // Forward op recorded into the graph: async D2D memcpy on the
+            // captured stream. CUDA records this as a memcpy node; it does not
+            // execute during capture.
+            Assert.Equal(CudaResult.Success,
+                CudaNativeBindings.cuMemcpyDtoDAsync(
+                    dstCapturedDevice, srcDevice, byteCount, stream));
+
             scope.EndCapture();
-            Assert.False(scope.IsCapturing);
             Assert.True(scope.HasGraph);
 
+            // Re-zero the captured destination so any "pattern" we see after
+            // replay must have been written by Replay, not by a lingering
+            // side-effect of capture.
+            Assert.Equal(CudaResult.Success,
+                CuBlasNative.cuMemsetD32(dstCapturedDevice, 0u, elementCount));
+
             scope.Replay();
-            // Replay internally calls cuStreamSynchronize, so completion is
-            // implicit. The assertion is "returns without throwing".
+            // Replay() internally synchronises the captured stream.
+
+            // ── Compare outputs ──────────────────────────────────────────
+            uint[] eagerHost = new uint[elementCount];
+            uint[] capturedHost = new uint[elementCount];
+            CopyDeviceToHost(dstEagerDevice, eagerHost, byteCount);
+            CopyDeviceToHost(dstCapturedDevice, capturedHost, byteCount);
+
+            // Sanity: the eager path wrote the pattern.
+            for (int i = 0; i < elementCount; i++)
+                Assert.Equal(pattern, eagerHost[i]);
+
+            // Acceptance criterion: captured/replayed output is bit-identical
+            // to the eager reference.
+            Assert.Equal(eagerHost, capturedHost);
         }
         finally
         {
+            if (srcDevice != IntPtr.Zero) CuBlasNative.cuMemFree(srcDevice);
+            if (dstEagerDevice != IntPtr.Zero) CuBlasNative.cuMemFree(dstEagerDevice);
+            if (dstCapturedDevice != IntPtr.Zero) CuBlasNative.cuMemFree(dstCapturedDevice);
             CudaNativeBindings.cuStreamDestroy(stream);
+        }
+    }
+
+    /// <summary>
+    /// Synchronous device-to-host copy for uint32 buffers, used by the
+    /// integration test to verify bit-identical output.
+    /// </summary>
+    private static void CopyDeviceToHost(IntPtr deviceBuffer, uint[] host, ulong byteCount)
+    {
+        var handle = System.Runtime.InteropServices.GCHandle.Alloc(host,
+            System.Runtime.InteropServices.GCHandleType.Pinned);
+        try
+        {
+            var hostPtr = handle.AddrOfPinnedObject();
+            var result = CudaNativeBindings.cuMemcpyDtoHAsync(
+                hostPtr, deviceBuffer, byteCount, IntPtr.Zero);
+            Assert.Equal(CudaResult.Success, result);
+            CudaNativeBindings.cuStreamSynchronize(IntPtr.Zero);
+        }
+        finally
+        {
+            handle.Free();
         }
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Gpu/CudaGraphScopeConstructionTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Gpu/CudaGraphScopeConstructionTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.DirectGpu;
+using AiDotNet.Tensors.Engines.DirectGpu.CUDA;
+using AiDotNet.Tensors.Engines.Gpu;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Gpu;
+
+/// <summary>
+/// Verifies that <see cref="CudaGraphScope"/> is constructible with any
+/// <see cref="IDirectGpuBackend"/> — in particular the real
+/// <see cref="CudaBackend"/>, which does not implement the tighter
+/// <c>IGpuBatchExecution</c> interface.
+///
+/// Reference: Issue #171. Before this PR, <c>CudaGraphScope</c> required
+/// <c>IGpuBatchExecution</c>, which <c>CudaBackend</c> does not implement,
+/// so no caller could construct the type. Option A relaxes the constructor
+/// to <see cref="IDirectGpuBackend"/>.
+/// </summary>
+public class CudaGraphScopeConstructionTests
+{
+    /// <summary>
+    /// Metadata-level acceptance check (runs anywhere, no GPU required):
+    /// verifies the public constructor signature is <c>(IDirectGpuBackend, IntPtr)</c>.
+    /// This is the exact signature the issue calls for — without requiring a live
+    /// CUDA driver to exercise.
+    /// </summary>
+    [Fact]
+    public void Constructor_PublicSignature_TakesIDirectGpuBackend()
+    {
+        var ctor = typeof(CudaGraphScope).GetConstructors(BindingFlags.Public | BindingFlags.Instance)
+            .Single();
+
+        var parameters = ctor.GetParameters();
+        Assert.Equal(2, parameters.Length);
+        Assert.Equal(typeof(IDirectGpuBackend), parameters[0].ParameterType);
+        Assert.Equal(typeof(IntPtr), parameters[1].ParameterType);
+    }
+
+    /// <summary>
+    /// Verifies the relaxed constructor still guards against null.
+    /// No backend instance required — the null path throws before use.
+    /// </summary>
+    [Fact]
+    public void Constructor_RejectsNullBackend()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new CudaGraphScope((IDirectGpuBackend)null!, new IntPtr(1)));
+    }
+
+    /// <summary>
+    /// Integration test (per issue #171 acceptance criterion):
+    /// <c>BeginCapture</c> → <c>EndCapture</c> → <c>Replay</c> with the real
+    /// <see cref="CudaBackend"/> passed to the relaxed constructor.
+    ///
+    /// Skipped when CUDA is unavailable on the host (CI without GPU, non-CUDA
+    /// dev machines). When a CUDA driver with graph-capture support (10.0+) is
+    /// present, the test:
+    /// <list type="number">
+    ///   <item>Creates a user stream via <c>cuStreamCreate</c> (graph capture
+    ///         rejects the default stream).</item>
+    ///   <item>Constructs <see cref="CudaGraphScope"/> with the real
+    ///         <see cref="CudaBackend"/> — the exact call that #171 unblocks.</item>
+    ///   <item>Captures an empty graph and replays it.</item>
+    /// </list>
+    ///
+    /// Capturing an empty graph is an intentionally minimal integration test —
+    /// it verifies the entire capture → instantiate → replay pipeline is
+    /// reachable via the relaxed constructor without depending on specific
+    /// kernel infrastructure (covered by the broader GPU correctness suite).
+    /// Output equivalence of real forward ops vs. eager is verified in those
+    /// other tests; this test specifically proves the constructor-relaxation
+    /// lets CUDA users wire up graph capture at all.
+    /// </summary>
+    [SkippableFact]
+    public void Constructor_WithRealCudaBackend_CanCaptureAndReplay()
+    {
+        Skip.IfNot(CudaNativeBindings.IsAvailable,
+            "CUDA driver not available on this machine");
+        Skip.IfNot(CudaNativeBindings.SupportsGraphCapture,
+            "Installed CUDA driver predates graph capture (requires 10.0+)");
+
+        using var cudaBackend = new CudaBackend();
+        Skip.IfNot(cudaBackend.IsAvailable, "CudaBackend failed to initialize");
+
+        // Graph capture requires a user-created stream — the default stream
+        // (IntPtr.Zero) is rejected by cuStreamBeginCapture, which is why the
+        // constructor's stream guard exists.
+        var streamResult = CudaNativeBindings.cuStreamCreate(out IntPtr stream, 0);
+        Skip.IfNot(streamResult == CudaResult.Success,
+            $"cuStreamCreate failed: {streamResult}");
+
+        try
+        {
+            // The acceptance criterion: this line must compile and run with
+            // CudaBackend passed directly. Before this PR, CudaBackend did not
+            // satisfy the constructor's IGpuBatchExecution parameter.
+            using var scope = new CudaGraphScope(cudaBackend, stream);
+            Assert.True(scope.IsSupported);
+
+            scope.BeginCapture();
+            Assert.True(scope.IsCapturing);
+
+            // Empty graph: minimal valid capture. No kernels submitted — this
+            // test exists to prove the lifecycle is reachable via the relaxed
+            // constructor, not to re-verify kernel correctness.
+            scope.EndCapture();
+            Assert.False(scope.IsCapturing);
+            Assert.True(scope.HasGraph);
+
+            scope.Replay();
+            // Replay internally calls cuStreamSynchronize, so completion is
+            // implicit. The assertion is "returns without throwing".
+        }
+        finally
+        {
+            CudaNativeBindings.cuStreamDestroy(stream);
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Gpu/CudaGraphScopeConstructionTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Gpu/CudaGraphScopeConstructionTests.cs
@@ -31,13 +31,18 @@ public class CudaGraphScopeConstructionTests
     [Fact]
     public void Constructor_PublicSignature_TakesIDirectGpuBackend()
     {
-        var ctor = typeof(CudaGraphScope).GetConstructors(BindingFlags.Public | BindingFlags.Instance)
-            .Single();
+        // Look up the specific (IDirectGpuBackend, IntPtr) constructor by
+        // parameter types rather than asserting there is exactly one public
+        // constructor — that way a future overload (e.g. one that takes an
+        // additional options parameter) doesn't break this contract check
+        // as long as the documented signature still exists.
+        var ctor = typeof(CudaGraphScope).GetConstructor(
+            BindingFlags.Public | BindingFlags.Instance,
+            binder: null,
+            types: new[] { typeof(IDirectGpuBackend), typeof(IntPtr) },
+            modifiers: null);
 
-        var parameters = ctor.GetParameters();
-        Assert.Equal(2, parameters.Length);
-        Assert.Equal(typeof(IDirectGpuBackend), parameters[0].ParameterType);
-        Assert.Equal(typeof(IntPtr), parameters[1].ParameterType);
+        Assert.NotNull(ctor);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- Relaxes the `CudaGraphScope` constructor to accept `IDirectGpuBackend` (was `IGpuBatchExecution`)
- Unblocks CUDA Graph capture on the real `CudaBackend`, which implements `IAsyncGpuBackend : IDirectGpuBackend` but NOT `IGpuBatchExecution`
- Adds 3 unit tests: constructor-signature metadata check, null rejection, and a real CUDA capture→replay integration test that verifies **bit-exact output equivalence vs. eager execution**

## Why

Before this PR, `CudaGraphScope` was effectively dead code:
- Constructor required `IGpuBatchExecution backend`
- `CudaBackend` does not implement that interface
- No factory, no extension method, no call site — `grep -rn "new CudaGraphScope"` returned only its own docstring

Issue #171 offered two fixes; this PR takes **Option A** (relax the type), the smaller surgical unblock. **Option B** (make `CudaBackend` a full `IGpuBatchExecution` — ~20 members) remains a valid follow-up and is explicitly out of scope here.

The field's pre-existing comment already stated the batch-execution interface was *"retained for future graph replay integration with batch execution"* — i.e. not used by capture/replay today. Only `_stream` is used. Relaxing the type matches the actual current contract.

## Changes

| File | Change |
|---|---|
| `src/.../Engines/Gpu/CudaGraphScope.cs` | `Backend` field: `IGpuBatchExecution` → `IDirectGpuBackend` |
| `src/.../Engines/Gpu/CudaGraphScope.cs` | Constructor parameter: `IGpuBatchExecution` → `IDirectGpuBackend` |
| `src/.../Engines/Gpu/CudaGraphScope.cs` | Updated XML doc on the field + constructor param to describe current role (lifecycle/future integration) rather than implying batch-execution use |
| `tests/.../Engines/Gpu/CudaGraphScopeConstructionTests.cs` | New — 3 tests (see below) |

## Acceptance criteria coverage (issue #171)

| Criterion | Covered by |
|---|---|
| `new CudaGraphScope(cudaBackend, stream)` compiles and runs on a CUDA machine | `Constructor_WithRealCudaBackend_CaptureReplayProducesSameOutputAsEager` — runs on net10.0 where CUDA is available, passes on the validated dev machine |
| At least one integration test exercising `BeginCapture` → forward op → `EndCapture` → `Replay` with **verified output equivalence vs eager** | Same test. The forward op is a `cuMemcpyDtoDAsync` submitted on the captured stream. After `EndCapture`, the destination is re-zeroed; `Replay` then writes the expected pattern, and the result is compared **bit-for-bit** against a direct eager `cuMemcpyDtoDAsync` reference. Memcpy was chosen because it is deterministic and bit-exact — no floating-point tolerances. |
| After landing, AiDotNet's `CompiledModelHost<T>` can wrap `Predict` with capture-replay on 3rd+ calls | Unblocked — `new CudaGraphScope(cudaBackend, stream)` now type-checks, so the consumer-side wiring described in AiDotNet task #45 can proceed. |

## Test details

### `Constructor_PublicSignature_TakesIDirectGpuBackend`

Reflection-based metadata check — verifies the public constructor's parameter types are `(IDirectGpuBackend, IntPtr)`. Runs anywhere (no GPU required); catches any future regression that tightens the parameter back to `IGpuBatchExecution`.

### `Constructor_RejectsNullBackend`

The relaxed parameter still guards `null`. No backend instance required; the null-check path throws before dereferencing.

### `Constructor_WithRealCudaBackend_CaptureReplayProducesSameOutputAsEager`

`[SkippableFact]` — integration test. Skips on non-CUDA machines (CI without GPU, non-CUDA dev boxes). When a CUDA driver with graph-capture support (10.0+) is present:

1. Allocates three device buffers: `src`, `dstEager`, `dstCaptured` (16 × uint32 = 64 bytes each).
2. `cuMemsetD32` fills `src` with `0xDEADBEEF`; zeroes both destinations.
3. **Eager reference path**: `cuMemcpyDtoDAsync(dstEager ← src)` on the default stream, then synchronise. Host-side sanity assert that `dstEager` now holds the pattern.
4. **Captured path**: Construct `CudaGraphScope(cudaBackend, stream)` — the exact call previously blocked. `BeginCapture` → `cuMemcpyDtoDAsync(dstCaptured ← src)` on the user stream → `EndCapture`.
5. Re-zero `dstCaptured` — proves any pattern we observe after `Replay` must have been written by `Replay` itself, not as a capture side-effect.
6. `Replay()` (internally synchronises the captured stream).
7. Copy `dstCaptured` to host; **assert bit-identical to the eager reference**.

## Test plan

- [x] `Constructor_PublicSignature_TakesIDirectGpuBackend` — passes on both `net471` and `net10.0`
- [x] `Constructor_RejectsNullBackend` — passes on both targets
- [x] `Constructor_WithRealCudaBackend_CaptureReplayProducesSameOutputAsEager` — passes on net10.0 with real CUDA. Skips on net471 (CUDA interop configured for modern targets)
- [x] Source project build: 0 warnings, 0 errors
- [x] Test project build: 0 errors (only pre-existing unrelated warnings)

## Breaking change analysis

`grep -rn "new CudaGraphScope"` across `src/` and `tests/` returned zero external usages — the only match before this PR was inside the class's own XML docstring. The `Backend` field is `internal`, and `grep` confirms no consumer reads it. No internal or external code breaks.

The change is a **widening** of the accepted parameter type — any caller with an `IGpuBatchExecution` (a subtype of `IDirectGpuBackend`) still compiles. Callers with a plain `IDirectGpuBackend` now compile where they didn't before. Strictly additive at the use-site.

## Out of scope / follow-up

**Option B** from the issue — making `CudaBackend` a full `IGpuBatchExecution` implementer — would also enable the Vulkan-equivalent batch-execution path on CUDA (fused reductions, secondary streams, barriers). That's ~20 members of real work and deserves its own PR. Recommend filing a follow-up issue after this merges.

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)