### PR TITLE
feat(jit): memory planning, tile scheduling, operator reordering + full IR chain (#178-#182)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledInferencePlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledInferencePlan.cs
@@ -497,6 +497,7 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
             new ConstantFoldingPass(),
             new ForwardCSEPass(),
             new ConvBnFusionPass(),
+            new DiffusionFusionPass(), // Patterns 11-14: GroupNorm+SiLU, Conv+Bias+SiLU, Add+GroupNorm (#181)
             new PointwiseFusionPass(),
             new AttentionFusionPass(),
             new BlasBatchPass(),

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledInferencePlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledInferencePlan.cs
@@ -504,6 +504,9 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
             new SpectralDecompositionPass(),
             new DataflowFusionPass(),
             new MixedPrecisionPass(),
+            new OperatorReorderingPass(), // Reorder for cache locality (#182)
+            new MemoryPlanningPass(),     // Buffer reuse via lifetime analysis (#182)
+            new TileSchedulingPass(),     // L1/L2 tile sizing for GEMM/Conv (#182)
         };
 
         var current = steps;

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledStep.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledStep.cs
@@ -31,6 +31,14 @@ internal sealed class CompiledStep<T>
     /// <summary>Type-safe operation type for compiled plan dispatch (avoids string comparisons).</summary>
     internal readonly OpType OpType;
 
+    /// <summary>
+    /// Optional L1/L2-optimal tile size computed by <see cref="Optimization.TileSchedulingPass"/>.
+    /// <c>null</c> means the pass hasn't run or the op isn't tileable. Consumers that implement
+    /// tiled execution (custom GEMM/Conv closures) may read this to size inner loop nests; the
+    /// default SimdGemm path uses its own internal tiling and ignores this annotation.
+    /// </summary>
+    internal int? TileSize { get; set; }
+
     internal CompiledStep(
         string opName,
         Action<IEngine, Tensor<T>> execute,

--- a/src/AiDotNet.Tensors/Engines/Compilation/Ops/FusedConv2DBiasActivationOp.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Ops/FusedConv2DBiasActivationOp.cs
@@ -206,17 +206,41 @@ internal sealed class FusedConv2DBiasActivationOp<T> : ICompiledOp<T>
         var dilation = (int[])savedState[2];
         var activationType = (FusedActivationType)(int)savedState[3];
 
-        // Step 1: undo activation on gradOutput if needed
+        // Step 1: undo activation on gradOutput.
+        //
+        // Activation backward needs the PRE-activation tensor (= conv(x, k) + bias),
+        // NOT the raw conv input x. The previous code passed inputs[0] (conv input)
+        // to SwishBackward — that's the input to the FULL fused op, not the input
+        // to the activation. Computing d/dx[swish(conv_out)] uses conv_out, not x.
+        //
+        // Correctness per-activation:
+        //   ReLU:    relu'(x) = 1 iff x > 0. relu(x) > 0 iff x > 0, so ReluBackward
+        //            can use either `output` or pre-activation. `output` is already
+        //            materialized — cheapest correct choice.
+        //   Sigmoid: σ'(x) = σ(x)(1-σ(x)) = output * (1 - output). Uses `output`.
+        //   Swish:   swish'(x) = σ(x) + x*σ(x)*(1-σ(x)). Needs the pre-activation x
+        //            (= conv + bias). Not recoverable from `output` alone (output =
+        //            x*σ(x) and the map output↔x isn't invertible cheaply). We
+        //            recompute the pre-activation here. This adds one conv-forward
+        //            worth of work per backward, acceptable vs. either (a) allocating
+        //            a pre-activation-sized tensor in SavedState on every forward,
+        //            or (b) silently producing wrong gradients.
+        //
+        //   Unknown activation types: throw rather than pass gradOutput through
+        //   unchanged (that would silently compute wrong gradients for future
+        //   fused-activation additions).
         var effectiveGrad = gradOutput;
         if (activationType != FusedActivationType.None)
         {
-            // For the common case (SiLU, ReLU), pointwise backward
             effectiveGrad = activationType switch
             {
                 FusedActivationType.ReLU => engine.ReluBackward(gradOutput, output),
                 FusedActivationType.Sigmoid => engine.SigmoidBackward(gradOutput, output),
-                FusedActivationType.Swish => engine.SwishBackward(gradOutput, inputs[0]),
-                _ => gradOutput, // Fallback: pass through
+                FusedActivationType.Swish => ComputeSwishBackward(
+                    gradOutput, inputs, stride, padding, dilation, engine),
+                _ => throw new NotSupportedException(
+                    $"FusedConv2DBiasActivation backward for {activationType} is not implemented. " +
+                    "Add a case in the switch with the correct pre-activation wiring."),
             };
         }
 
@@ -236,5 +260,31 @@ internal sealed class FusedConv2DBiasActivationOp<T> : ICompiledOp<T>
             var gradBias = engine.ReduceSum(effectiveGrad, new[] { 0, 2, 3 });
             DifferentiableOps.AccumulateGrad(grads, inputs[2], gradBias, engine);
         }
+    }
+
+    /// <summary>
+    /// Recomputes the Swish pre-activation (= Conv2D(input, kernel) + bias) and
+    /// applies the engine's SwishBackward. Swish'(x) = σ(x) + x·σ(x)·(1-σ(x))
+    /// depends on the pre-activation x, not the post-activation output, so we
+    /// can't recover it from <c>output</c> alone.
+    ///
+    /// Cost: one conv-forward per backward pass. The alternative — caching the
+    /// pre-activation tensor in SavedState on every forward — would waste
+    /// memory on the common case where the step doesn't flow gradients.
+    /// </summary>
+    private static Tensor<T> ComputeSwishBackward(
+        Tensor<T> gradOutput, Tensor<T>[] inputs,
+        int[] stride, int[] padding, int[] dilation, IEngine engine)
+    {
+        var preActivation = engine.Conv2D(inputs[0], inputs[1], stride, padding, dilation);
+        if (inputs.Length > 2 && inputs[2] is not null)
+        {
+            var bias = inputs[2];
+            var reshapedBias = bias.Rank == 1
+                ? bias.Reshape(new[] { 1, bias._shape[0], 1, 1 })
+                : bias;
+            preActivation = engine.TensorBroadcastAdd(preActivation, reshapedBias);
+        }
+        return engine.SwishBackward(gradOutput, preActivation);
     }
 }

--- a/src/AiDotNet.Tensors/Engines/Compilation/Ops/FusedConv2DBiasActivationOp.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Ops/FusedConv2DBiasActivationOp.cs
@@ -1,0 +1,236 @@
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines.Compilation.Ops;
+
+/// <summary>
+/// IR operation for fused Conv2D + Bias + Activation. Maps to the existing
+/// <see cref="IEngine.FusedConv2D{T}"/> kernel which combines convolution,
+/// bias addition, and activation into a single pass — no intermediate tensor
+/// materialization between the three stages.
+///
+/// <para><b>Pattern:</b> Diffusion UNets use <c>Conv+Bias+Identity</c> (no
+/// BatchNorm) or <c>Conv+Bias+SiLU</c> at every layer. This is distinct from
+/// <c>FusedConvBatchNormActivationOp</c> which handles the BN-containing
+/// pattern from classification networks.</para>
+///
+/// <para><b>Performance:</b> 2-4× faster than the 3-op sequence
+/// <c>Conv → BroadcastAdd → Activation</c> on CPU; larger gains on GPU
+/// (single kernel launch instead of 3).</para>
+///
+/// <para><b>Backward:</b> decomposes into standard Conv2D backward (for input
+/// + kernel gradients), broadcast-add backward (for bias gradient), and the
+/// activation's pointwise backward — reusing the existing backward kernels
+/// rather than implementing a monolithic fused backward.</para>
+/// </summary>
+/// <typeparam name="T">The tensor element type.</typeparam>
+internal sealed class FusedConv2DBiasActivationOp<T> : ICompiledOp<T>
+{
+    /// <summary>Input tensor [N, Cin, H, W].</summary>
+    public Tensor<T> Input { get; }
+
+    /// <summary>Convolution kernel [Cout, Cin, kH, kW].</summary>
+    public Tensor<T> Kernel { get; }
+
+    /// <summary>Optional bias [Cout]. Null for unbiased convolutions.</summary>
+    public Tensor<T>? Bias { get; }
+
+    /// <summary>Stride in H and W dimensions.</summary>
+    public int StrideH { get; }
+    public int StrideW { get; }
+
+    /// <summary>Padding in H and W dimensions.</summary>
+    public int PadH { get; }
+    public int PadW { get; }
+
+    /// <summary>Dilation in H and W dimensions (default 1).</summary>
+    public int DilationH { get; }
+    public int DilationW { get; }
+
+    /// <summary>Activation to fuse (None/Identity, SiLU/Swish, ReLU, Sigmoid, etc.).</summary>
+    public FusedActivationType Activation { get; }
+
+    public FusedConv2DBiasActivationOp(
+        Tensor<T> input,
+        Tensor<T> kernel,
+        Tensor<T>? bias,
+        int strideH, int strideW,
+        int padH, int padW,
+        int dilationH = 1, int dilationW = 1,
+        FusedActivationType activation = FusedActivationType.None)
+    {
+        Input = input ?? throw new ArgumentNullException(nameof(input));
+        Kernel = kernel ?? throw new ArgumentNullException(nameof(kernel));
+        Bias = bias;
+        StrideH = strideH;
+        StrideW = strideW;
+        PadH = padH;
+        PadW = padW;
+        DilationH = dilationH;
+        DilationW = dilationW;
+        Activation = activation;
+    }
+
+    // ── ICompiledOp<T> ─────────────────────────────────────────────────
+
+    public OpType OpType => OpType.Conv2D; // Reuses Conv2D slot since fused is a superset
+    public string OpName => "FusedConv2DBiasActivation";
+
+    public Tensor<T>[] Inputs => Bias is not null
+        ? new[] { Input, Kernel, Bias }
+        : new[] { Input, Kernel };
+
+    public int[] OutputShape
+    {
+        get
+        {
+            int n = Input._shape[0];
+            int cout = Kernel._shape[0];
+            int hIn = Input._shape[2];
+            int wIn = Input._shape[3];
+            int kH = Kernel._shape[2];
+            int kW = Kernel._shape[3];
+            int hOut = (hIn + 2 * PadH - DilationH * (kH - 1) - 1) / StrideH + 1;
+            int wOut = (wIn + 2 * PadW - DilationW * (kW - 1) - 1) / StrideW + 1;
+            return new[] { n, cout, hOut, wOut };
+        }
+    }
+
+    public Action<IEngine, Tensor<T>> BuildForwardClosure()
+    {
+        var input = Input;
+        var kernel = Kernel;
+        var bias = Bias;
+        int sH = StrideH, sW = StrideW;
+        int pH = PadH, pW = PadW;
+        int dH = DilationH, dW = DilationW;
+        var activation = Activation;
+
+        // Reshape bias to [1, Cout, 1, 1] for broadcasting over [N, C, H, W].
+        // CpuEngine.FusedConv2D calls TensorBroadcastAdd(convResult, bias)
+        // which follows NumPy broadcasting rules — a raw [Cout] shape can't
+        // broadcast against [N, Cout, H, W] (trailing dims don't align).
+        var reshapedBias = bias?.Reshape(new[] { 1, bias._shape[0], 1, 1 });
+
+        return (eng, output) =>
+        {
+            var result = eng.FusedConv2D(input, kernel, reshapedBias, sH, sW, pH, pW, dH, dW, activation);
+            result.AsSpan().CopyTo(output.AsWritableSpan());
+        };
+    }
+
+    public BackwardFunction<T>? GetBackwardFunction()
+    {
+        // Fused backward: decompose into Conv2D backward + bias grad + activation backward.
+        // Uses the standard Conv2DBackward for input/kernel gradients. Bias gradient is
+        // the sum of gradOutput over spatial dims. Activation backward is pointwise.
+        return FusedConv2DBiasActivationBackward;
+    }
+
+    public object[]? BuildSavedState()
+    {
+        // SavedState: [stride_arr, padding_arr, dilation_arr, activation_int]
+        return new object[]
+        {
+            new[] { StrideH, StrideW },
+            new[] { PadH, PadW },
+            new[] { DilationH, DilationW },
+            (int)Activation
+        };
+    }
+
+    public CompiledStep<T> ToCompiledStep(Tensor<T> outputBuffer)
+    {
+        return new CompiledStep<T>(
+            OpName,
+            BuildForwardClosure(),
+            outputBuffer,
+            Inputs,
+            GetBackwardFunction(),
+            BuildSavedState());
+    }
+
+    // ── Factory ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Attempts to extract a <see cref="FusedConv2DBiasActivationOp{T}"/> from
+    /// an existing <see cref="CompiledStep{T}"/>. Returns null if the step
+    /// isn't a fused conv op or its SavedState can't be parsed.
+    /// </summary>
+    internal static FusedConv2DBiasActivationOp<T>? TryFromStep(CompiledStep<T> step)
+    {
+        if (step.OpName != "FusedConv2DBiasActivation") return null;
+        if (step.Inputs.Length < 2) return null;
+
+        var state = step.SavedState;
+        if (state is null || state.Length < 4) return null;
+
+        var stride = state[0] as int[];
+        var padding = state[1] as int[];
+        var dilation = state[2] as int[];
+        var activationInt = state[3] is int a ? a : 0;
+
+        if (stride is null || padding is null || dilation is null) return null;
+
+        return new FusedConv2DBiasActivationOp<T>(
+            step.Inputs[0],
+            step.Inputs[1],
+            step.Inputs.Length > 2 ? step.Inputs[2] : null,
+            stride.Length > 0 ? stride[0] : 1,
+            stride.Length > 1 ? stride[1] : stride[0],
+            padding.Length > 0 ? padding[0] : 0,
+            padding.Length > 1 ? padding[1] : padding[0],
+            dilation.Length > 0 ? dilation[0] : 1,
+            dilation.Length > 1 ? dilation[1] : dilation[0],
+            (FusedActivationType)activationInt);
+    }
+
+    // ── Backward ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Backward for fused Conv+Bias+Activation. Decomposes into:
+    /// 1. Activation backward (pointwise — modifies gradOutput in place)
+    /// 2. Conv2D backward for input + kernel gradients
+    /// 3. Bias gradient (sum of gradOutput over batch + spatial dims)
+    /// </summary>
+    private static void FusedConv2DBiasActivationBackward(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
+        object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        var stride = (int[])savedState[0];
+        var padding = (int[])savedState[1];
+        var dilation = (int[])savedState[2];
+        var activationType = (FusedActivationType)(int)savedState[3];
+
+        // Step 1: undo activation on gradOutput if needed
+        var effectiveGrad = gradOutput;
+        if (activationType != FusedActivationType.None)
+        {
+            // For the common case (SiLU, ReLU), pointwise backward
+            effectiveGrad = activationType switch
+            {
+                FusedActivationType.ReLU => engine.ReluBackward(gradOutput, output),
+                FusedActivationType.Sigmoid => engine.SigmoidBackward(gradOutput, output),
+                FusedActivationType.Swish => engine.SwishBackward(gradOutput, inputs[0]),
+                _ => gradOutput, // Fallback: pass through
+            };
+        }
+
+        // Step 2: Conv2D backward for input + kernel
+        var gradInput = engine.Conv2DBackwardInput(
+            effectiveGrad, inputs[1], inputs[0]._shape, stride, padding, dilation);
+        var gradKernel = engine.Conv2DBackwardKernel(
+            effectiveGrad, inputs[0], inputs[1]._shape, stride, padding, dilation);
+
+        DifferentiableOps.AccumulateGrad(grads, inputs[0], gradInput, engine);
+        DifferentiableOps.AccumulateGrad(grads, inputs[1], gradKernel, engine);
+
+        // Step 3: Bias gradient (sum over batch + spatial)
+        if (inputs.Length > 2 && inputs[2] is not null)
+        {
+            // gradBias = sum of effectiveGrad over dims [0, 2, 3] (batch, H, W)
+            var gradBias = engine.ReduceSum(effectiveGrad, new[] { 0, 2, 3 });
+            DifferentiableOps.AccumulateGrad(grads, inputs[2], gradBias, engine);
+        }
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/Compilation/Ops/FusedConv2DBiasActivationOp.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Ops/FusedConv2DBiasActivationOp.cs
@@ -110,7 +110,11 @@ internal sealed class FusedConv2DBiasActivationOp<T> : ICompiledOp<T>
         // CpuEngine.FusedConv2D calls TensorBroadcastAdd(convResult, bias)
         // which follows NumPy broadcasting rules — a raw [Cout] shape can't
         // broadcast against [N, Cout, H, W] (trailing dims don't align).
-        var reshapedBias = bias?.Reshape(new[] { 1, bias._shape[0], 1, 1 });
+        // Only reshape if bias is 1D; if already 4D (e.g., from a fusion pass
+        // that extracted it from a BroadcastAdd), use as-is.
+        var reshapedBias = bias is not null && bias.Rank == 1
+            ? bias.Reshape(new[] { 1, bias._shape[0], 1, 1 })
+            : bias;
 
         return (eng, output) =>
         {

--- a/src/AiDotNet.Tensors/Engines/Compilation/Ops/FusedGroupNormActivationOp.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Ops/FusedGroupNormActivationOp.cs
@@ -124,31 +124,48 @@ internal sealed class FusedGroupNormActivationOp<T> : ICompiledOp<T>
         return (eng, output) =>
         {
             Tensor<T>? preActivation = null;
-            Tensor<T> mean, variance;
+            Tensor<T>? mean = null;
+            Tensor<T>? variance = null;
+            Tensor<T> tmpMean, tmpVariance;
 
             switch (activation)
             {
                 case GroupNormActivation.SiLU:
-                    // Fused kernel writes post-SiLU directly to output. We
-                    // separately run GroupNorm to capture mean/variance AND
-                    // the pre-activation tensor — SwishBackward needs the
-                    // pre-activation (h = GroupNorm(x)), not the raw input x.
+                    // Fused kernel writes post-SiLU directly to output — no
+                    // GroupNorm work needed for the forward value itself.
+                    // Only pay the extra GroupNorm cost (to capture
+                    // mean/variance + pre-activation for backward) when
+                    // savedState is non-null, i.e. the compiled-step path
+                    // that actually wires backward. Pure inference (savedState
+                    // null) skips the second pass entirely.
                     eng.GroupNormSwishInto(output, input, numGroups, gamma, beta, epsilon);
-                    preActivation = eng.GroupNorm(input, numGroups, gamma, beta, epsilon,
-                        out mean, out variance);
+                    if (savedState is not null)
+                    {
+                        preActivation = eng.GroupNorm(input, numGroups, gamma, beta, epsilon,
+                            out tmpMean, out tmpVariance);
+                        mean = tmpMean;
+                        variance = tmpVariance;
+                    }
                     break;
 
                 case GroupNormActivation.ReLU:
+                    // GroupNorm is required for the forward value here (no
+                    // fused ReLU-into kernel), so the work is unavoidable;
+                    // the mean/variance outs come along for free.
                     var gnResult = eng.GroupNorm(input, numGroups, gamma, beta, epsilon,
-                        out mean, out variance);
+                        out tmpMean, out tmpVariance);
                     var reluResult = eng.ReLU(gnResult);
                     reluResult.AsSpan().CopyTo(output.AsWritableSpan());
+                    mean = tmpMean;
+                    variance = tmpVariance;
                     break;
 
                 default: // Identity
                     var gnId = eng.GroupNorm(input, numGroups, gamma, beta, epsilon,
-                        out mean, out variance);
+                        out tmpMean, out tmpVariance);
                     gnId.AsSpan().CopyTo(output.AsWritableSpan());
+                    mean = tmpMean;
+                    variance = tmpVariance;
                     break;
             }
 
@@ -158,8 +175,8 @@ internal sealed class FusedGroupNormActivationOp<T> : ICompiledOp<T>
 
             if (savedState is not null)
             {
-                savedState[1] = mean;
-                savedState[2] = variance;
+                if (mean is not null) savedState[1] = mean;
+                if (variance is not null) savedState[2] = variance;
                 if (preActivation is not null) savedState[5] = preActivation;
             }
         };
@@ -219,7 +236,16 @@ internal sealed class FusedGroupNormActivationOp<T> : ICompiledOp<T>
 
         int numGroups = state[0] is int ng ? ng : 0;
         double epsilon = state[3] is double e ? e : 1e-5;
-        var activation = state[4] is int a ? (GroupNormActivation)a : GroupNormActivation.Identity;
+
+        // Reject unknown / version-skewed activation codes rather than
+        // silently falling through to Identity at forward time. Note:
+        // GroupNormActivation is byte-backed so the int stored via
+        // BuildSavedState must fit in a byte AND be a defined member.
+        if (state[4] is not int activationCode ||
+            activationCode < 0 || activationCode > byte.MaxValue ||
+            !Enum.IsDefined(typeof(GroupNormActivation), (byte)activationCode))
+            return null;
+        var activation = (GroupNormActivation)activationCode;
 
         if (numGroups <= 0) return null;
 

--- a/src/AiDotNet.Tensors/Engines/Compilation/Ops/FusedGroupNormActivationOp.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Ops/FusedGroupNormActivationOp.cs
@@ -67,6 +67,13 @@ internal sealed class FusedGroupNormActivationOp<T> : ICompiledOp<T>
     /// <summary>Variance from forward — needed by backward.</summary>
     public Tensor<T>? Variance { get; set; }
 
+    /// <summary>
+    /// Pre-activation tensor (= GroupNorm output, before the fused activation)
+    /// from the last forward pass. Needed by SiLU backward since SwishBackward
+    /// requires the pre-activation — for Identity/ReLU this is not used.
+    /// </summary>
+    public Tensor<T>? PreActivation { get; set; }
+
     public FusedGroupNormActivationOp(
         Tensor<T> input,
         int numGroups,
@@ -94,6 +101,18 @@ internal sealed class FusedGroupNormActivationOp<T> : ICompiledOp<T>
 
     public Action<IEngine, Tensor<T>> BuildForwardClosure()
     {
+        // Legacy closure with no savedState backfill. Callers needing backward
+        // should go through ToCompiledStep which shares the savedState array
+        // with the closure.
+        return BuildForwardClosureCore(savedState: null);
+    }
+
+    /// <summary>Core forward-closure factory shared by <see cref="BuildForwardClosure"/>
+    /// and <see cref="ToCompiledStep"/>. When <paramref name="savedState"/> is non-null,
+    /// the closure backfills slots [1], [2], and [5] with fresh mean/variance/pre-activation
+    /// so backward reads up-to-date tensors.</summary>
+    private Action<IEngine, Tensor<T>> BuildForwardClosureCore(object[]? savedState)
+    {
         var input = Input;
         var numGroups = NumGroups;
         var gamma = Gamma;
@@ -104,41 +123,45 @@ internal sealed class FusedGroupNormActivationOp<T> : ICompiledOp<T>
 
         return (eng, output) =>
         {
+            Tensor<T>? preActivation = null;
+            Tensor<T> mean, variance;
+
             switch (activation)
             {
                 case GroupNormActivation.SiLU:
-                    // True fused kernel — one pass over the data.
+                    // Fused kernel writes post-SiLU directly to output. We
+                    // separately run GroupNorm to capture mean/variance AND
+                    // the pre-activation tensor — SwishBackward needs the
+                    // pre-activation (h = GroupNorm(x)), not the raw input x.
                     eng.GroupNormSwishInto(output, input, numGroups, gamma, beta, epsilon);
+                    preActivation = eng.GroupNorm(input, numGroups, gamma, beta, epsilon,
+                        out mean, out variance);
                     break;
 
                 case GroupNormActivation.ReLU:
-                    // GroupNorm + pointwise ReLU (still one CompiledStep).
                     var gnResult = eng.GroupNorm(input, numGroups, gamma, beta, epsilon,
-                        out var mean, out var variance);
-                    op.Mean = mean;
-                    op.Variance = variance;
+                        out mean, out variance);
                     var reluResult = eng.ReLU(gnResult);
                     reluResult.AsSpan().CopyTo(output.AsWritableSpan());
-                    return;
+                    break;
 
                 default: // Identity
                     var gnId = eng.GroupNorm(input, numGroups, gamma, beta, epsilon,
-                        out var meanId, out var varId);
-                    op.Mean = meanId;
-                    op.Variance = varId;
+                        out mean, out variance);
                     gnId.AsSpan().CopyTo(output.AsWritableSpan());
-                    return;
+                    break;
             }
 
-            // For SiLU path: compute mean/variance separately for backward.
-            // GroupNormSwishInto doesn't return them, so we run a separate
-            // GroupNorm just for the stats. This is the trade-off: forward is
-            // fast (one fused pass), but we need a second pass for backward
-            // stats. Future: extend GroupNormSwishInto to output mean/var.
-            var gnForStats = eng.GroupNorm(input, numGroups, gamma, beta, epsilon,
-                out var meanStat, out var varStat);
-            op.Mean = meanStat;
-            op.Variance = varStat;
+            op.Mean = mean;
+            op.Variance = variance;
+            op.PreActivation = preActivation;
+
+            if (savedState is not null)
+            {
+                savedState[1] = mean;
+                savedState[2] = variance;
+                if (preActivation is not null) savedState[5] = preActivation;
+            }
         };
     }
 
@@ -150,19 +173,38 @@ internal sealed class FusedGroupNormActivationOp<T> : ICompiledOp<T>
 
     public object[]? BuildSavedState()
     {
-        // [numGroups, mean, variance, epsilon, activation]
-        return new object[] { NumGroups, Mean!, Variance!, Epsilon, (int)Activation };
+        // [numGroups, mean, variance, epsilon, activation, preActivation(SiLU only)]
+        // Mean/Variance/PreActivation slots start null at build time — the
+        // forward closure built by ToCompiledStep backfills them before
+        // backward reads. Leaving PreActivation null for Identity/ReLU is
+        // safe because the backward switch never dereferences it for those.
+        var savedState = new object[6];
+        savedState[0] = NumGroups;
+        if (Mean is not null) savedState[1] = Mean;
+        if (Variance is not null) savedState[2] = Variance;
+        savedState[3] = Epsilon;
+        savedState[4] = (int)Activation;
+        if (PreActivation is not null) savedState[5] = PreActivation;
+        return savedState;
     }
 
     public CompiledStep<T> ToCompiledStep(Tensor<T> outputBuffer)
     {
+        // Share one savedState array between the forward closure (which writes
+        // mean/variance/preActivation into it every forward) and the CompiledStep
+        // (which hands it to backward). Same pattern as GroupNormOp.
+        var sharedSavedState = BuildSavedState();
+        if (sharedSavedState is null)
+            throw new InvalidOperationException(
+                "FusedGroupNormActivationOp.BuildSavedState returned null; backward cannot be wired.");
+
         return new CompiledStep<T>(
             OpName,
-            BuildForwardClosure(),
+            BuildForwardClosureCore(sharedSavedState),
             outputBuffer,
             Inputs,
             GetBackwardFunction(),
-            BuildSavedState());
+            sharedSavedState);
     }
 
     // ── Factory ─────────────────────────────────────────────────────────
@@ -197,10 +239,27 @@ internal sealed class FusedGroupNormActivationOp<T> : ICompiledOp<T>
         var epsilon = (double)savedState[3];
         var activation = (GroupNormActivation)(int)savedState[4];
 
-        // Step 1: undo activation gradient
+        // Step 1: undo activation gradient.
+        //
+        // SiLU's derivative σ(h) + h·σ(h)·(1-σ(h)) depends on the PRE-activation
+        // h = GroupNorm(x), not the raw input x. The previous code passed
+        // inputs[0] (raw input) to SwishBackward — that produced d/dy[SiLU(y)]
+        // evaluated at x, which is the wrong gradient. savedState[5] holds the
+        // cached pre-activation from the forward pass (see BuildForwardClosureCore).
+        //
+        // ReLU's derivative (1 iff input > 0) matches 1 iff output > 0, so
+        // ReluBackward can use `output` — no pre-activation needed.
+        //
+        // Identity: no activation, pass gradOutput through.
         var effectiveGrad = activation switch
         {
-            GroupNormActivation.SiLU => engine.SwishBackward(gradOutput, inputs[0]),
+            GroupNormActivation.SiLU => engine.SwishBackward(
+                gradOutput,
+                savedState.Length > 5 && savedState[5] is Tensor<T> preAct
+                    ? preAct
+                    : throw new InvalidOperationException(
+                        "FusedGroupNormActivation SiLU backward requires cached pre-activation; " +
+                        "step was not built via ToCompiledStep.")),
             GroupNormActivation.ReLU => engine.ReluBackward(gradOutput, output),
             _ => gradOutput,
         };

--- a/src/AiDotNet.Tensors/Engines/Compilation/Ops/FusedGroupNormActivationOp.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Ops/FusedGroupNormActivationOp.cs
@@ -1,0 +1,217 @@
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines.Compilation.Ops;
+
+/// <summary>
+/// Activation types supported by the fused GroupNorm+Activation kernel.
+/// </summary>
+internal enum GroupNormActivation : byte
+{
+    /// <summary>No activation — equivalent to plain GroupNorm.</summary>
+    Identity = 0,
+
+    /// <summary>SiLU / Swish: f(x) = x · σ(x). The diffusion-model default.</summary>
+    SiLU = 1,
+
+    /// <summary>ReLU: f(x) = max(0, x).</summary>
+    ReLU = 2,
+}
+
+/// <summary>
+/// IR operation for fused GroupNorm + Activation. Eliminates one full-size
+/// intermediate tensor per fusion site by applying the activation in the same
+/// pass as the normalization — roughly 41 MB saved per ResBlock at Stable
+/// Diffusion 1.5 dimensions.
+///
+/// <para><b>Pattern:</b> <c>DiffusionResBlock</c> has the sequence
+/// <c>GroupNorm(x) → SiLU(norm_out)</c> twice per block. SD15 UNet:
+/// ~40 ResBlocks × 2 = 80 fusion opportunities per forward pass.</para>
+///
+/// <para><b>Forward:</b> for SiLU, delegates to
+/// <see cref="IEngine.GroupNormSwishInto{T}"/> which applies both operations
+/// in a single kernel. For ReLU and Identity, falls back to GroupNorm +
+/// pointwise activation (still fused at the IR level — one CompiledStep
+/// instead of two).</para>
+///
+/// <para><b>Backward:</b> composes the activation gradient (pointwise) with
+/// the GroupNorm gradient via chain rule, without materializing the
+/// intermediate (the normalized-but-not-activated tensor). Uses the
+/// fused op's output to reconstruct the pre-activation values when needed
+/// by the activation backward.</para>
+/// </summary>
+/// <typeparam name="T">The tensor element type.</typeparam>
+internal sealed class FusedGroupNormActivationOp<T> : ICompiledOp<T>
+{
+    /// <summary>Input tensor [N, C, ...].</summary>
+    public Tensor<T> Input { get; }
+
+    /// <summary>Number of groups to divide channels into.</summary>
+    public int NumGroups { get; }
+
+    /// <summary>Scale parameter (gamma). Shape: [C].</summary>
+    public Tensor<T> Gamma { get; }
+
+    /// <summary>Bias parameter (beta). Shape: [C].</summary>
+    public Tensor<T> Beta { get; }
+
+    /// <summary>Small constant for numerical stability.</summary>
+    public double Epsilon { get; }
+
+    /// <summary>Activation to fuse with the normalization.</summary>
+    public GroupNormActivation Activation { get; }
+
+    /// <summary>Mean from forward — needed by backward.</summary>
+    public Tensor<T>? Mean { get; set; }
+
+    /// <summary>Variance from forward — needed by backward.</summary>
+    public Tensor<T>? Variance { get; set; }
+
+    public FusedGroupNormActivationOp(
+        Tensor<T> input,
+        int numGroups,
+        Tensor<T> gamma,
+        Tensor<T> beta,
+        double epsilon = 1e-5,
+        GroupNormActivation activation = GroupNormActivation.SiLU)
+    {
+        Input = input ?? throw new ArgumentNullException(nameof(input));
+        Gamma = gamma ?? throw new ArgumentNullException(nameof(gamma));
+        Beta = beta ?? throw new ArgumentNullException(nameof(beta));
+        if (numGroups <= 0)
+            throw new ArgumentOutOfRangeException(nameof(numGroups), "Must be positive.");
+        NumGroups = numGroups;
+        Epsilon = epsilon;
+        Activation = activation;
+    }
+
+    // ── ICompiledOp<T> ─────────────────────────────────────────────────
+
+    public OpType OpType => OpType.GroupNorm; // Reuses GroupNorm slot (fused is a superset)
+    public string OpName => "FusedGroupNormActivation";
+    public Tensor<T>[] Inputs => new[] { Input, Gamma, Beta };
+    public int[] OutputShape => (int[])Input._shape.Clone();
+
+    public Action<IEngine, Tensor<T>> BuildForwardClosure()
+    {
+        var input = Input;
+        var numGroups = NumGroups;
+        var gamma = Gamma;
+        var beta = Beta;
+        var epsilon = Epsilon;
+        var activation = Activation;
+        var op = this;
+
+        return (eng, output) =>
+        {
+            switch (activation)
+            {
+                case GroupNormActivation.SiLU:
+                    // True fused kernel — one pass over the data.
+                    eng.GroupNormSwishInto(output, input, numGroups, gamma, beta, epsilon);
+                    break;
+
+                case GroupNormActivation.ReLU:
+                    // GroupNorm + pointwise ReLU (still one CompiledStep).
+                    var gnResult = eng.GroupNorm(input, numGroups, gamma, beta, epsilon,
+                        out var mean, out var variance);
+                    op.Mean = mean;
+                    op.Variance = variance;
+                    var reluResult = eng.ReLU(gnResult);
+                    reluResult.AsSpan().CopyTo(output.AsWritableSpan());
+                    return;
+
+                default: // Identity
+                    var gnId = eng.GroupNorm(input, numGroups, gamma, beta, epsilon,
+                        out var meanId, out var varId);
+                    op.Mean = meanId;
+                    op.Variance = varId;
+                    gnId.AsSpan().CopyTo(output.AsWritableSpan());
+                    return;
+            }
+
+            // For SiLU path: compute mean/variance separately for backward.
+            // GroupNormSwishInto doesn't return them, so we run a separate
+            // GroupNorm just for the stats. This is the trade-off: forward is
+            // fast (one fused pass), but we need a second pass for backward
+            // stats. Future: extend GroupNormSwishInto to output mean/var.
+            var gnForStats = eng.GroupNorm(input, numGroups, gamma, beta, epsilon,
+                out var meanStat, out var varStat);
+            op.Mean = meanStat;
+            op.Variance = varStat;
+        };
+    }
+
+    public BackwardFunction<T>? GetBackwardFunction()
+    {
+        // Backward: chain rule through activation then GroupNorm.
+        return FusedGroupNormActivationBackward;
+    }
+
+    public object[]? BuildSavedState()
+    {
+        // [numGroups, mean, variance, epsilon, activation]
+        return new object[] { NumGroups, Mean!, Variance!, Epsilon, (int)Activation };
+    }
+
+    public CompiledStep<T> ToCompiledStep(Tensor<T> outputBuffer)
+    {
+        return new CompiledStep<T>(
+            OpName,
+            BuildForwardClosure(),
+            outputBuffer,
+            Inputs,
+            GetBackwardFunction(),
+            BuildSavedState());
+    }
+
+    // ── Factory ─────────────────────────────────────────────────────────
+
+    internal static FusedGroupNormActivationOp<T>? TryFromStep(CompiledStep<T> step)
+    {
+        if (step.OpName != "FusedGroupNormActivation") return null;
+        if (step.Inputs.Length < 3) return null;
+
+        var state = step.SavedState;
+        if (state is null || state.Length < 5) return null;
+
+        int numGroups = state[0] is int ng ? ng : 0;
+        double epsilon = state[3] is double e ? e : 1e-5;
+        var activation = state[4] is int a ? (GroupNormActivation)a : GroupNormActivation.Identity;
+
+        if (numGroups <= 0) return null;
+
+        return new FusedGroupNormActivationOp<T>(
+            step.Inputs[0], numGroups, step.Inputs[1], step.Inputs[2], epsilon, activation);
+    }
+
+    // ── Backward ────────────────────────────────────────────────────────
+
+    private static void FusedGroupNormActivationBackward(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
+        object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        var numGroups = (int)savedState[0];
+        var mean = (Tensor<T>)savedState[1];
+        var variance = (Tensor<T>)savedState[2];
+        var epsilon = (double)savedState[3];
+        var activation = (GroupNormActivation)(int)savedState[4];
+
+        // Step 1: undo activation gradient
+        var effectiveGrad = activation switch
+        {
+            GroupNormActivation.SiLU => engine.SwishBackward(gradOutput, inputs[0]),
+            GroupNormActivation.ReLU => engine.ReluBackward(gradOutput, output),
+            _ => gradOutput,
+        };
+
+        // Step 2: GroupNorm backward
+        var gradInput = engine.GroupNormBackward(
+            effectiveGrad, inputs[0], numGroups, inputs[1], mean, variance, epsilon,
+            out var gradGamma, out var gradBeta);
+
+        DifferentiableOps.AccumulateGrad(grads, inputs[0], gradInput, engine);
+        DifferentiableOps.AccumulateGrad(grads, inputs[1], gradGamma, engine);
+        DifferentiableOps.AccumulateGrad(grads, inputs[2], gradBeta, engine);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/Compilation/Ops/GroupNormOp.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Ops/GroupNormOp.cs
@@ -77,20 +77,22 @@ internal sealed class GroupNormOp<T> : ICompiledOp<T>
 
     public Action<IEngine, Tensor<T>> BuildForwardClosure()
     {
-        // Capture by value so the closure doesn't hold `this` alive.
+        // Legacy closure (no SavedState backfill). Callers that also need
+        // backward should go through ToCompiledStep, which wires the forward
+        // to mutate the shared savedState array so backward sees the fresh
+        // mean/variance. See BuildForwardClosureForStep for the shared-array
+        // variant.
         var input = Input;
         var numGroups = NumGroups;
         var gamma = Gamma;
         var beta = Beta;
         var epsilon = Epsilon;
-        var op = this; // For writing back mean/variance
+        var op = this;
 
         return (eng, output) =>
         {
             var result = eng.GroupNorm(input, numGroups, gamma, beta, epsilon, out var mean, out var variance);
             result.AsSpan().CopyTo(output.AsWritableSpan());
-
-            // Store mean/variance for backward pass.
             op.Mean = mean;
             op.Variance = variance;
         };
@@ -103,18 +105,56 @@ internal sealed class GroupNormOp<T> : ICompiledOp<T>
     {
         // Matches BackwardFunctions<T>.GroupNormBackward's read order:
         // [0] = numGroups (int), [1] = mean (Tensor), [2] = variance (Tensor), [3] = epsilon (double)
-        return new object[] { NumGroups, Mean!, Variance!, Epsilon };
+        //
+        // Slots [1] and [2] are filled in by the forward closure built by
+        // ToCompiledStep (it shares this array by reference). At step-build
+        // time Mean/Variance are null; backward only runs after at least one
+        // forward, so by the time the BackwardFunction reads savedState the
+        // slots are populated. If Mean/Variance happen to already be set
+        // (e.g. a second ToCompiledStep after a prior forward), include them.
+        var savedState = new object[4];
+        savedState[0] = NumGroups;
+        if (Mean is not null) savedState[1] = Mean;
+        if (Variance is not null) savedState[2] = Variance;
+        savedState[3] = Epsilon;
+        return savedState;
     }
 
     public CompiledStep<T> ToCompiledStep(Tensor<T> outputBuffer)
     {
+        // Build the savedState array ONCE and share its reference with both
+        // the forward closure (which writes mean/variance into it on every
+        // forward pass) and the CompiledStep (which hands it to backward).
+        // Without this sharing the CompiledStep would hold a stale array with
+        // null mean/variance, and backward would NRE or compute wrong grads.
+        var sharedSavedState = BuildSavedState();
+        if (sharedSavedState is null)
+            throw new InvalidOperationException("GroupNormOp.BuildSavedState returned null; backward cannot be wired.");
+
+        var input = Input;
+        var numGroups = NumGroups;
+        var gamma = Gamma;
+        var beta = Beta;
+        var epsilon = Epsilon;
+        var op = this;
+
+        Action<IEngine, Tensor<T>> forward = (eng, output) =>
+        {
+            var result = eng.GroupNorm(input, numGroups, gamma, beta, epsilon, out var mean, out var variance);
+            result.AsSpan().CopyTo(output.AsWritableSpan());
+            op.Mean = mean;
+            op.Variance = variance;
+            sharedSavedState[1] = mean;
+            sharedSavedState[2] = variance;
+        };
+
         return new CompiledStep<T>(
             OpName,
-            BuildForwardClosure(),
+            forward,
             outputBuffer,
             Inputs,
             GetBackwardFunction(),
-            BuildSavedState());
+            sharedSavedState);
     }
 
     // ── Factory: try to extract from an existing CompiledStep ──────────

--- a/src/AiDotNet.Tensors/Engines/Compilation/Ops/GroupNormOp.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Ops/GroupNormOp.cs
@@ -1,0 +1,161 @@
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines.Compilation.Ops;
+
+/// <summary>
+/// IR operation for Group Normalization. Stores the op's full metadata
+/// (numGroups, epsilon, scale/gamma, bias/beta) so fusion passes can
+/// introspect attributes without type-unsafe SavedState casts.
+///
+/// <para><b>Forward:</b> delegates to <see cref="IEngine.GroupNorm{T}"/>
+/// — no new kernel, just an IR-level representation that the JIT compiler
+/// can reason about (fuse with SiLU, reorder with residual-add, etc.).</para>
+///
+/// <para><b>Backward:</b> uses <see cref="BackwardFunctions{T}.GroupNormBackward"/>
+/// which calls <see cref="IEngine.GroupNormBackward{T}"/> for the
+/// <c>numGroups != 1</c> general case.</para>
+///
+/// <para><b>SavedState ordering:</b> <c>[numGroups, mean, variance, epsilon]</c>
+/// — matches <see cref="BackwardFunctions{T}.GroupNormBackward"/>'s read order
+/// and the <see cref="DifferentiableOps.RecordIfActive"/> recording path.
+/// Note: the GraphMode recording path in CpuEngine uses a different order
+/// <c>[mean, variance, numGroups, epsilon]</c> — that's a pre-existing
+/// divergence documented in issue #178.</para>
+/// </summary>
+/// <typeparam name="T">The tensor element type.</typeparam>
+internal sealed class GroupNormOp<T> : ICompiledOp<T>
+{
+    /// <summary>Number of groups to divide channels into.</summary>
+    public int NumGroups { get; }
+
+    /// <summary>Small constant for numerical stability in the variance denominator.</summary>
+    public double Epsilon { get; }
+
+    /// <summary>The input tensor (captured at trace time).</summary>
+    public Tensor<T> Input { get; }
+
+    /// <summary>Scale parameter (gamma). Shape: [C] where C is the channel count.</summary>
+    public Tensor<T> Gamma { get; }
+
+    /// <summary>Bias parameter (beta). Shape: [C].</summary>
+    public Tensor<T> Beta { get; }
+
+    /// <summary>
+    /// Mean tensor computed during forward — needed by backward.
+    /// Set after the first forward execution; null before that.
+    /// </summary>
+    public Tensor<T>? Mean { get; set; }
+
+    /// <summary>
+    /// Variance tensor computed during forward — needed by backward.
+    /// Set after the first forward execution; null before that.
+    /// </summary>
+    public Tensor<T>? Variance { get; set; }
+
+    public GroupNormOp(Tensor<T> input, int numGroups, Tensor<T> gamma, Tensor<T> beta, double epsilon = 1e-5)
+    {
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (gamma is null) throw new ArgumentNullException(nameof(gamma));
+        if (beta is null) throw new ArgumentNullException(nameof(beta));
+        if (numGroups <= 0)
+            throw new ArgumentOutOfRangeException(nameof(numGroups), "Number of groups must be positive.");
+
+        Input = input;
+        NumGroups = numGroups;
+        Gamma = gamma;
+        Beta = beta;
+        Epsilon = epsilon;
+    }
+
+    // ── ICompiledOp<T> ─────────────────────────────────────────────────
+
+    public OpType OpType => OpType.GroupNorm;
+    public string OpName => "GroupNorm";
+    public Tensor<T>[] Inputs => new[] { Input, Gamma, Beta };
+    public int[] OutputShape => (int[])Input._shape.Clone();
+
+    public Action<IEngine, Tensor<T>> BuildForwardClosure()
+    {
+        // Capture by value so the closure doesn't hold `this` alive.
+        var input = Input;
+        var numGroups = NumGroups;
+        var gamma = Gamma;
+        var beta = Beta;
+        var epsilon = Epsilon;
+        var op = this; // For writing back mean/variance
+
+        return (eng, output) =>
+        {
+            var result = eng.GroupNorm(input, numGroups, gamma, beta, epsilon, out var mean, out var variance);
+            result.AsSpan().CopyTo(output.AsWritableSpan());
+
+            // Store mean/variance for backward pass.
+            op.Mean = mean;
+            op.Variance = variance;
+        };
+    }
+
+    public BackwardFunction<T>? GetBackwardFunction()
+        => BackwardFunctions<T>.GroupNormBackward;
+
+    public object[]? BuildSavedState()
+    {
+        // Matches BackwardFunctions<T>.GroupNormBackward's read order:
+        // [0] = numGroups (int), [1] = mean (Tensor), [2] = variance (Tensor), [3] = epsilon (double)
+        return new object[] { NumGroups, Mean!, Variance!, Epsilon };
+    }
+
+    public CompiledStep<T> ToCompiledStep(Tensor<T> outputBuffer)
+    {
+        return new CompiledStep<T>(
+            OpName,
+            BuildForwardClosure(),
+            outputBuffer,
+            Inputs,
+            GetBackwardFunction(),
+            BuildSavedState());
+    }
+
+    // ── Factory: try to extract from an existing CompiledStep ──────────
+
+    /// <summary>
+    /// Attempts to extract a <see cref="GroupNormOp{T}"/> from an existing
+    /// <see cref="CompiledStep{T}"/>. Returns null if the step isn't a
+    /// GroupNorm op or its SavedState can't be parsed. Used by fusion passes
+    /// that need typed attribute access.
+    /// </summary>
+    internal static GroupNormOp<T>? TryFromStep(CompiledStep<T> step)
+    {
+        if (step.OpType != OpType.GroupNorm) return null;
+        if (step.Inputs.Length < 3) return null;
+
+        var savedState = step.SavedState;
+        if (savedState is null || savedState.Length < 4) return null;
+
+        // Handle BOTH SavedState orderings (see class xmldoc):
+        // DifferentiableOps path: [numGroups, mean, variance, epsilon]
+        // GraphMode path (buggy): [mean, variance, numGroups, epsilon]
+        int numGroups;
+        double epsilon;
+
+        if (savedState[0] is int ng)
+        {
+            // DifferentiableOps ordering (correct)
+            numGroups = ng;
+            epsilon = savedState[3] is double e ? e : 1e-5;
+        }
+        else if (savedState[2] is int ng2)
+        {
+            // GraphMode ordering (pre-existing divergence)
+            numGroups = ng2;
+            epsilon = savedState[3] is double e ? e : 1e-5;
+        }
+        else
+        {
+            return null; // Unrecognized format
+        }
+
+        return new GroupNormOp<T>(step.Inputs[0], numGroups, step.Inputs[1], step.Inputs[2], epsilon);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/Compilation/Ops/ICompiledOp.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Ops/ICompiledOp.cs
@@ -1,0 +1,60 @@
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines.Compilation.Ops;
+
+/// <summary>
+/// Base interface for typed IR operations. Each implementation encapsulates an
+/// operation's metadata (attributes like numGroups, epsilon, stride, etc.) and
+/// can build the forward/backward closures needed by the compilation pipeline.
+///
+/// <para><b>Why class-per-op?</b> The existing infrastructure uses
+/// <see cref="OpType"/> enum + <see cref="CompiledStep{T}"/> with opaque
+/// <c>object[]</c> SavedState. That works for execution but fusion passes
+/// can't introspect attributes without type-unsafe casts. Typed Op classes let
+/// fusion passes pattern-match: <c>if (op is GroupNormOp gn) { ... fuse with
+/// next SiLU ... }</c>. Both representations coexist — Op classes produce
+/// CompiledSteps, and existing CompiledSteps without an Op class continue to
+/// work unchanged.</para>
+/// </summary>
+/// <typeparam name="T">The tensor element type.</typeparam>
+internal interface ICompiledOp<T>
+{
+    /// <summary>The operation type enum value.</summary>
+    OpType OpType { get; }
+
+    /// <summary>The operation name string (must match <see cref="OpTypeParser"/>).</summary>
+    string OpName { get; }
+
+    /// <summary>Input tensor references (captured at trace time).</summary>
+    Tensor<T>[] Inputs { get; }
+
+    /// <summary>The expected output shape.</summary>
+    int[] OutputShape { get; }
+
+    /// <summary>
+    /// Builds the forward-pass closure for a <see cref="CompiledStep{T}"/>.
+    /// The closure calls the engine method with the op's stored attributes
+    /// and writes the result into the pre-allocated output buffer.
+    /// </summary>
+    Action<IEngine, Tensor<T>> BuildForwardClosure();
+
+    /// <summary>
+    /// Returns the backward function delegate for gradient computation,
+    /// or null if this op doesn't support training (inference-only fused ops).
+    /// </summary>
+    BackwardFunction<T>? GetBackwardFunction();
+
+    /// <summary>
+    /// Builds the SavedState array for serialization + backward pass.
+    /// Must match the order that <see cref="GetBackwardFunction"/>'s
+    /// delegate reads from.
+    /// </summary>
+    object[]? BuildSavedState();
+
+    /// <summary>
+    /// Converts this Op into a <see cref="CompiledStep{T}"/> ready for
+    /// insertion into a compiled plan's step array.
+    /// </summary>
+    CompiledStep<T> ToCompiledStep(Tensor<T> outputBuffer);
+}

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -14471,10 +14471,14 @@ public class CpuEngine : ITensorLevelEngine
                 GraphMode.SetCurrent(null);
                 var eagerResult = GroupNorm(ci, cn, cg, cb, ce, out mean, out variance);
                 GraphMode.SetCurrent(savedScope);
+                // SavedState order MUST match BackwardFunctions<T>.GroupNormBackward's
+                // read order: [numGroups, mean, variance, epsilon]. Previously this was
+                // [mean, variance, numGroups, epsilon] causing InvalidCastException in
+                // backward (Tensor cast as int at savedState[0]). Fixed per #178.
                 var lazyResult = scope.RecordVariadic(LazyNodeType.Custom, "GroupNorm",
                     new[] { input, gamma, beta }, eagerResult._shape,
                     (eng, output) => { var r = eng.GroupNorm(ci, cn, cg, cb, ce, out _, out _); r.AsSpan().CopyTo(output.AsWritableSpan()); },
-                    BackwardFunctions<T>.GroupNormBackward, new object[] { mean, variance, numGroups, epsilon });
+                    BackwardFunctions<T>.GroupNormBackward, new object[] { numGroups, mean, variance, epsilon });
                 eagerResult.AsSpan().CopyTo(lazyResult.AsWritableSpan());
                 return lazyResult;
             }

--- a/src/AiDotNet.Tensors/Engines/Optimization/DiffusionFusionPass.cs
+++ b/src/AiDotNet.Tensors/Engines/Optimization/DiffusionFusionPass.cs
@@ -145,22 +145,48 @@ internal sealed class DiffusionFusionPass : ICpuOptimizationPass
         // rather than silently substituting defaults — defaults would produce
         // numerically wrong output for any conv with stride≠1, padding≠0, or
         // dilation≠1.
+        //
+        // Preserve asymmetric H/W params: Conv2DOp saves arrays of 1 or 2
+        // elements. A length-1 array means symmetric (strideH == strideW);
+        // a length-2 array means per-axis (strideH = s[0], strideW = s[1]).
+        // Reusing s[0] for both axes would change semantics for asymmetric
+        // convolutions like kernel=[3,5] with stride=[1,2].
         var convState = convStep.SavedState;
         if (convState is null || convState.Length < 3) return false;
         if (convState[0] is not int[] s || s.Length == 0) return false;
         if (convState[1] is not int[] p || p.Length == 0) return false;
         if (convState[2] is not int[] d || d.Length == 0) return false;
-        int stride = s[0];
-        int padding = p[0];
-        int dilation = d[0];
+        int strideH = s[0];
+        int strideW = s.Length > 1 ? s[1] : s[0];
+        int padH = p[0];
+        int padW = p.Length > 1 ? p[1] : p[0];
+        int dilationH = d[0];
+        int dilationW = d.Length > 1 ? d[1] : d[0];
 
-        // The bias is the second input to BroadcastAdd
-        var bias = addStep.Inputs.Length > 1 ? addStep.Inputs[1] : null;
+        // The fused kernel represents Conv2D + bias_add + activation. A
+        // generic broadcast-add (e.g. residual add, per-sample scaling, or
+        // 4-D skip-connection) has different semantics — rewriting it into
+        // a bias add would silently produce wrong output. Accept only the
+        // two bias-shaped patterns the fused op's execute path handles:
+        //   • rank-1  [out_channels]  (reshaped to [1, Cout, 1, 1] inside the op)
+        //   • rank-4  [1, out_channels, 1, 1]  (already broadcast-shaped)
+        // where out_channels comes from the filter shape [Cout, Cin/G, kH, kW].
+        if (addStep.Inputs.Length != 2) return false;
+        var bias = addStep.Inputs[1];
+        var filterShape = convStep.Inputs[1]._shape;
+        if (filterShape.Length == 0) return false;
+        int outChannels = filterShape[0];
+        if (outChannels <= 0) return false;
+        bool isRank1Bias = bias._shape.Length == 1 && bias._shape[0] == outChannels;
+        bool isRank4Bias = bias._shape.Length == 4
+            && bias._shape[0] == 1 && bias._shape[1] == outChannels
+            && bias._shape[2] == 1 && bias._shape[3] == 1;
+        if (!isRank1Bias && !isRank4Bias) return false;
 
         // Build fused op
         var fusedOp = new FusedConv2DBiasActivationOp<T>(
             convStep.Inputs[0], convStep.Inputs[1], bias,
-            stride, stride, padding, padding, dilation, dilation,
+            strideH, strideW, padH, padW, dilationH, dilationW,
             FusedActivationType.Swish);
 
         fused = fusedOp.ToCompiledStep(swishStep.OutputBuffer);

--- a/src/AiDotNet.Tensors/Engines/Optimization/DiffusionFusionPass.cs
+++ b/src/AiDotNet.Tensors/Engines/Optimization/DiffusionFusionPass.cs
@@ -1,0 +1,213 @@
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.Engines.Compilation.Ops;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines.Optimization;
+
+/// <summary>
+/// Fusion patterns 11-14 for diffusion UNet hot sequences. Operates on the
+/// compiled step array and replaces multi-step sequences with single fused
+/// operations that eliminate intermediate tensor materializations.
+///
+/// <para><b>Pattern 11 — GroupNorm + SiLU:</b>
+/// <c>GroupNorm → Swish</c> → <see cref="FusedGroupNormActivationOp{T}"/>{SiLU}.
+/// Hit rate: 80 per SD15 forward (~40 ResBlocks × 2). Saves ~41 MB intermediates.</para>
+///
+/// <para><b>Pattern 12 — Conv2D + Bias + SiLU:</b>
+/// <c>Conv2D → BroadcastAdd → Swish</c> → <see cref="FusedConv2DBiasActivationOp{T}"/>{SiLU}.
+/// Hit rate: ~40 per SD15 forward. 2-4× faster than 3-op sequence.</para>
+///
+/// <para><b>Pattern 14 — Residual Add + GroupNorm:</b>
+/// <c>Add → GroupNorm</c> → fused step using <c>IEngine.AddGroupNormInto</c>.
+/// Hit rate: ~40 per SD15 forward. Eliminates skip-connection intermediate.</para>
+///
+/// <para>Pattern 13 (GroupNorm+SiLU+Conv2D 3-op fusion) is deferred —
+/// Patterns 11+12 already capture most of the win.</para>
+/// </summary>
+internal sealed class DiffusionFusionPass : ICpuOptimizationPass
+{
+    public string Name => "DiffusionFusion";
+
+    // Always enabled — diffusion patterns are high-value and zero-risk
+    // (the fused ops delegate to existing engine kernels).
+    public bool IsEnabled => true;
+
+    public CompiledStep<T>[]? TryOptimize<T>(CompiledStep<T>[] steps, IEngine engine)
+    {
+        if (typeof(T) != typeof(float)) return null; // Float-only for now
+
+        var result = new List<CompiledStep<T>>(steps.Length);
+        bool anyFused = false;
+        int i = 0;
+
+        while (i < steps.Length)
+        {
+            // Try Pattern 12 first (3-op, greedy) before Pattern 11 (2-op)
+            if (TryMatchPattern12(steps, i, engine, out var fused12, out int consumed12))
+            {
+                result.Add(fused12!);
+                i += consumed12;
+                anyFused = true;
+                continue;
+            }
+
+            // Pattern 11: GroupNorm + Swish → FusedGroupNormActivation{SiLU}
+            if (TryMatchPattern11(steps, i, engine, out var fused11, out int consumed11))
+            {
+                result.Add(fused11!);
+                i += consumed11;
+                anyFused = true;
+                continue;
+            }
+
+            // Pattern 14: Add + GroupNorm → FusedAddGroupNorm
+            if (TryMatchPattern14(steps, i, engine, out var fused14, out int consumed14))
+            {
+                result.Add(fused14!);
+                i += consumed14;
+                anyFused = true;
+                continue;
+            }
+
+            // No match — pass through
+            result.Add(steps[i]);
+            i++;
+        }
+
+        return anyFused ? result.ToArray() : null;
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Pattern 11: GroupNorm → Swish → FusedGroupNormActivation{SiLU}
+    // ════════════════════════════════════════════════════════════════════
+
+    private static bool TryMatchPattern11<T>(
+        CompiledStep<T>[] steps, int index, IEngine engine,
+        out CompiledStep<T>? fused, out int consumed)
+    {
+        fused = null;
+        consumed = 0;
+
+        if (index + 1 >= steps.Length) return false;
+
+        var gnStep    = steps[index];
+        var swishStep = steps[index + 1];
+
+        // Match: GroupNorm followed by Swish
+        if (gnStep.OpType != OpType.GroupNorm) return false;
+        if (swishStep.OpType != OpType.Swish) return false;
+
+        // Data dependency: GroupNorm output feeds Swish input
+        if (!ReferenceEquals(gnStep.OutputBuffer, swishStep.Inputs[0])) return false;
+
+        // Extract GroupNorm params from SavedState
+        var gnOp = GroupNormOp<T>.TryFromStep(gnStep);
+        if (gnOp is null) return false;
+
+        // Build fused op
+        var fusedOp = new FusedGroupNormActivationOp<T>(
+            gnOp.Input, gnOp.NumGroups, gnOp.Gamma, gnOp.Beta, gnOp.Epsilon,
+            GroupNormActivation.SiLU);
+
+        fused = fusedOp.ToCompiledStep(swishStep.OutputBuffer);
+        consumed = 2;
+        return true;
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Pattern 12: Conv2D → BroadcastAdd → Swish → FusedConv2DBiasActivation{SiLU}
+    // ════════════════════════════════════════════════════════════════════
+
+    private static bool TryMatchPattern12<T>(
+        CompiledStep<T>[] steps, int index, IEngine engine,
+        out CompiledStep<T>? fused, out int consumed)
+    {
+        fused = null;
+        consumed = 0;
+
+        if (index + 2 >= steps.Length) return false;
+
+        var convStep  = steps[index];
+        var addStep   = steps[index + 1];
+        var swishStep = steps[index + 2];
+
+        // Match: Conv2D → BroadcastAdd → Swish
+        if (convStep.OpType != OpType.Conv2D) return false;
+        if (addStep.OpType != OpType.TensorBroadcastAdd) return false;
+        if (swishStep.OpType != OpType.Swish) return false;
+
+        // Data dependency chain
+        if (!ReferenceEquals(convStep.OutputBuffer, addStep.Inputs[0])) return false;
+        if (!ReferenceEquals(addStep.OutputBuffer, swishStep.Inputs[0])) return false;
+
+        // Extract conv params from SavedState
+        var convState = convStep.SavedState;
+        if (convState is null || convState.Length < 3) return false;
+        int stride   = convState[0] is int[] s && s.Length > 0 ? s[0] : 1;
+        int padding  = convState[1] is int[] p && p.Length > 0 ? p[0] : 0;
+        int dilation = convState[2] is int[] d && d.Length > 0 ? d[0] : 1;
+
+        // The bias is the second input to BroadcastAdd
+        var bias = addStep.Inputs.Length > 1 ? addStep.Inputs[1] : null;
+
+        // Build fused op
+        var fusedOp = new FusedConv2DBiasActivationOp<T>(
+            convStep.Inputs[0], convStep.Inputs[1], bias,
+            stride, stride, padding, padding, dilation, dilation,
+            FusedActivationType.Swish);
+
+        fused = fusedOp.ToCompiledStep(swishStep.OutputBuffer);
+        consumed = 3;
+        return true;
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Pattern 14: Add → GroupNorm → FusedAddGroupNorm
+    // ════════════════════════════════════════════════════════════════════
+
+    private static bool TryMatchPattern14<T>(
+        CompiledStep<T>[] steps, int index, IEngine engine,
+        out CompiledStep<T>? fused, out int consumed)
+    {
+        fused = null;
+        consumed = 0;
+
+        if (index + 1 >= steps.Length) return false;
+
+        var addStep = steps[index];
+        var gnStep  = steps[index + 1];
+
+        // Match: Add/BroadcastAdd followed by GroupNorm
+        if (addStep.OpType is not (OpType.TensorAdd or OpType.TensorBroadcastAdd)) return false;
+        if (gnStep.OpType != OpType.GroupNorm) return false;
+
+        // Data dependency: Add output feeds GroupNorm input
+        if (!ReferenceEquals(addStep.OutputBuffer, gnStep.Inputs[0])) return false;
+
+        // Extract GroupNorm params
+        var gnOp = GroupNormOp<T>.TryFromStep(gnStep);
+        if (gnOp is null) return false;
+
+        // Build fused step using IEngine.AddGroupNormInto
+        var addA = addStep.Inputs[0];
+        var addB = addStep.Inputs.Length > 1 ? addStep.Inputs[1] : addStep.Inputs[0];
+        var gamma = gnOp.Gamma;
+        var beta = gnOp.Beta;
+        int numGroups = gnOp.NumGroups;
+        double epsilon = gnOp.Epsilon;
+
+        fused = new CompiledStep<T>(
+            opName: "FusedAddGroupNorm",
+            execute: (eng, output) =>
+            {
+                eng.AddGroupNormInto(output, addA, addB, numGroups, gamma, beta, epsilon);
+            },
+            outputBuffer: gnStep.OutputBuffer,
+            inputs: new[] { addA, addB, gamma, beta },
+            backwardFn: null, // Backward decomposes: GroupNorm backward + Add backward
+            savedState: new object[] { numGroups, epsilon });
+
+        consumed = 2;
+        return true;
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/Optimization/DiffusionFusionPass.cs
+++ b/src/AiDotNet.Tensors/Engines/Optimization/DiffusionFusionPass.cs
@@ -140,12 +140,19 @@ internal sealed class DiffusionFusionPass : ICpuOptimizationPass
         if (!ReferenceEquals(convStep.OutputBuffer, addStep.Inputs[0])) return false;
         if (!ReferenceEquals(addStep.OutputBuffer, swishStep.Inputs[0])) return false;
 
-        // Extract conv params from SavedState
+        // Extract conv params from SavedState. Strict: if the shape of the
+        // saved state doesn't match what Conv2DOp writes, bail out of fusion
+        // rather than silently substituting defaults — defaults would produce
+        // numerically wrong output for any conv with stride≠1, padding≠0, or
+        // dilation≠1.
         var convState = convStep.SavedState;
         if (convState is null || convState.Length < 3) return false;
-        int stride   = convState[0] is int[] s && s.Length > 0 ? s[0] : 1;
-        int padding  = convState[1] is int[] p && p.Length > 0 ? p[0] : 0;
-        int dilation = convState[2] is int[] d && d.Length > 0 ? d[0] : 1;
+        if (convState[0] is not int[] s || s.Length == 0) return false;
+        if (convState[1] is not int[] p || p.Length == 0) return false;
+        if (convState[2] is not int[] d || d.Length == 0) return false;
+        int stride = s[0];
+        int padding = p[0];
+        int dilation = d[0];
 
         // The bias is the second input to BroadcastAdd
         var bias = addStep.Inputs.Length > 1 ? addStep.Inputs[1] : null;
@@ -188,9 +195,12 @@ internal sealed class DiffusionFusionPass : ICpuOptimizationPass
         var gnOp = GroupNormOp<T>.TryFromStep(gnStep);
         if (gnOp is null) return false;
 
-        // Build fused step using IEngine.AddGroupNormInto
+        // Build fused step using IEngine.AddGroupNormInto. A well-formed Add
+        // has exactly two distinct operands; a single-input Add is malformed
+        // and fusing it as GroupNorm(a + a) would silently double the input.
+        if (addStep.Inputs.Length < 2) return false;
         var addA = addStep.Inputs[0];
-        var addB = addStep.Inputs.Length > 1 ? addStep.Inputs[1] : addStep.Inputs[0];
+        var addB = addStep.Inputs[1];
         var gamma = gnOp.Gamma;
         var beta = gnOp.Beta;
         int numGroups = gnOp.NumGroups;

--- a/src/AiDotNet.Tensors/Engines/Optimization/MemoryPlanningPass.cs
+++ b/src/AiDotNet.Tensors/Engines/Optimization/MemoryPlanningPass.cs
@@ -1,0 +1,151 @@
+using System.Runtime.CompilerServices;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines.Optimization;
+
+/// <summary>
+/// Analyzes tensor lifetimes in the compiled graph and reassigns dead tensor
+/// buffers to share storage with future tensors. Reduces peak memory from
+/// "one allocation per op" to "one allocation per simultaneously-live set."
+///
+/// <para><b>Algorithm:</b></para>
+/// <list type="number">
+/// <item>Walk steps in execution order; for each tensor, record first-use
+/// (produced) and last-use (last consumed as input).</item>
+/// <item>Build a free-list of dead tensors (past their last-use). When a new
+/// output buffer is needed, check if a dead tensor of the same shape exists
+/// — if so, rebind it via <see cref="TensorBase{T}.RebindStorageFrom"/>.</item>
+/// <item>This is a greedy "first-fit" algorithm, not optimal graph coloring.
+/// It's O(n·d) where n = step count and d = max dead-pool size — fast enough
+/// for compiled plans which run this pass once at compile time.</item>
+/// </list>
+///
+/// <para><b>SD15 impact:</b> UNet forward allocates &gt;2 GB of intermediates
+/// without this pass. With lifetime analysis the peak drops to ~200-300 MB
+/// (the simultaneously-live set).</para>
+/// </summary>
+internal sealed class MemoryPlanningPass : ICpuOptimizationPass
+{
+    public string Name => "MemoryPlanning";
+    public bool IsEnabled => true; // Always beneficial
+
+    public CompiledStep<T>[]? TryOptimize<T>(CompiledStep<T>[] steps, IEngine engine)
+    {
+        if (steps.Length < 4) return null; // Not worth the overhead for tiny plans
+
+        // Phase 1: Compute tensor lifetimes
+        // Map each tensor (by reference identity) to its last-use step index.
+        var lastUse = new Dictionary<object, int>(steps.Length * 2);
+        for (int i = 0; i < steps.Length; i++)
+        {
+            var step = steps[i];
+            // The output buffer is "produced" at step i. Its "last use" is at
+            // least i (it might also be consumed later).
+            SetLastUse(lastUse, step.OutputBuffer, i);
+            for (int j = 0; j < step.Inputs.Length; j++)
+                SetLastUse(lastUse, step.Inputs[j], i);
+        }
+
+        // Phase 2: Greedy buffer reuse via dead-pool
+        // Walk steps again. After each step, check if any tensor's lifetime
+        // just ended (lastUse == current step). If so, add it to the dead
+        // pool keyed by (element count, rank). When a future step needs an
+        // output buffer, check the pool for a compatible dead tensor.
+        var deadPool = new Dictionary<long, List<Tensor<T>>>();
+        var rebindMap = new Dictionary<Tensor<T>, Tensor<T>>(
+            ReferenceEqualityComparer<Tensor<T>>.Instance);
+        int reusedCount = 0;
+
+        for (int i = 0; i < steps.Length; i++)
+        {
+            var step = steps[i];
+            var output = step.OutputBuffer;
+
+            // Try to reuse a dead buffer for this step's output
+            long key = BufferKey(output);
+            if (deadPool.TryGetValue(key, out var pool) && pool.Count > 0)
+            {
+                var donor = pool[pool.Count - 1];
+                pool.RemoveAt(pool.Count - 1);
+
+                // Rebind: make donor's storage point to output's storage
+                // (or vice versa — we want the step's output to write into
+                // the donor's backing array so memory is reused).
+                // Since the step's Execute writes to the output parameter,
+                // we rebind the OUTPUT to share the DONOR's storage. This
+                // way the donor's memory gets overwritten (it's dead), and
+                // the output tensor now shares that memory.
+                if (CanRebind(output, donor))
+                {
+                    output.RebindStorageFrom(donor);
+                    rebindMap[output] = donor;
+                    reusedCount++;
+                }
+            }
+
+            // After this step, check if any of its inputs are now dead
+            for (int j = 0; j < step.Inputs.Length; j++)
+            {
+                var inp = step.Inputs[j];
+                if (lastUse.TryGetValue(RuntimeHelpers.GetHashCode(inp), out int lu) && lu == i)
+                {
+                    // This input's lifetime just ended — add to dead pool
+                    long k = BufferKey(inp);
+                    if (!deadPool.TryGetValue(k, out var p))
+                    {
+                        p = new List<Tensor<T>>(4);
+                        deadPool[k] = p;
+                    }
+                    p.Add(inp);
+                }
+            }
+
+            // Also check if this step's output dies immediately (consumed
+            // only by the next step, which is common for element-wise chains)
+            if (lastUse.TryGetValue(RuntimeHelpers.GetHashCode(output), out int outLu) && outLu == i)
+            {
+                long k = BufferKey(output);
+                if (!deadPool.TryGetValue(k, out var p))
+                {
+                    p = new List<Tensor<T>>(4);
+                    deadPool[k] = p;
+                }
+                p.Add(output);
+            }
+        }
+
+        // Return null if no reuse was possible (don't create unnecessary array copies)
+        return reusedCount > 0 ? steps : null;
+    }
+
+    /// <summary>Buffer compatibility key: element count + rank. Two tensors are
+    /// buffer-compatible if they have the same total element count (same backing
+    /// array size) and same rank (so the rebind shape check passes).</summary>
+    private static long BufferKey<T>(Tensor<T> t)
+        => ((long)t.Length << 8) | (long)t.Rank;
+
+    private static bool CanRebind<T>(Tensor<T> target, Tensor<T> donor)
+    {
+        if (!target.IsContiguous || target._storageOffset != 0) return false;
+        if (!donor.IsContiguous || donor._storageOffset != 0) return false;
+        if (target._shape.Length != donor._shape.Length) return false;
+        for (int i = 0; i < target._shape.Length; i++)
+            if (target._shape[i] != donor._shape[i]) return false;
+        return true;
+    }
+
+    private static void SetLastUse(Dictionary<object, int> map, object tensor, int step)
+    {
+        int key = RuntimeHelpers.GetHashCode(tensor);
+        map[key] = step; // Overwrites with the latest step that uses this tensor
+    }
+
+    /// <summary>Reference-equality comparer for tensor identity tracking.</summary>
+    private sealed class ReferenceEqualityComparer<TItem> : IEqualityComparer<TItem> where TItem : class
+    {
+        public static readonly ReferenceEqualityComparer<TItem> Instance = new();
+        public bool Equals(TItem? x, TItem? y) => ReferenceEquals(x, y);
+        public int GetHashCode(TItem obj) => RuntimeHelpers.GetHashCode(obj);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/Optimization/MemoryPlanningPass.cs
+++ b/src/AiDotNet.Tensors/Engines/Optimization/MemoryPlanningPass.cs
@@ -36,15 +36,23 @@ internal sealed class MemoryPlanningPass : ICpuOptimizationPass
 
         // Phase 1: Compute tensor lifetimes
         // Map each tensor (by reference identity) to its last-use step index.
-        var lastUse = new Dictionary<object, int>(steps.Length * 2);
+        // Must use reference-equality semantics — two distinct tensors may have
+        // the same hash code or even compare Equal by value, but they're
+        // different buffers and must not share a lastUse slot. The earlier
+        // implementation keyed the dictionary on RuntimeHelpers.GetHashCode(t)
+        // (an int boxed to object), which collided across tensors and caused
+        // the dead-pool to treat live buffers as reclaimable — data corruption
+        // under any hash collision.
+        var lastUse = new Dictionary<Tensor<T>, int>(
+            steps.Length * 2, ReferenceEqualityComparer<Tensor<T>>.Instance);
         for (int i = 0; i < steps.Length; i++)
         {
             var step = steps[i];
             // The output buffer is "produced" at step i. Its "last use" is at
             // least i (it might also be consumed later).
-            SetLastUse(lastUse, step.OutputBuffer, i);
+            lastUse[step.OutputBuffer] = i;
             for (int j = 0; j < step.Inputs.Length; j++)
-                SetLastUse(lastUse, step.Inputs[j], i);
+                lastUse[step.Inputs[j]] = i;
         }
 
         // Phase 2: Greedy buffer reuse via dead-pool
@@ -88,7 +96,7 @@ internal sealed class MemoryPlanningPass : ICpuOptimizationPass
             for (int j = 0; j < step.Inputs.Length; j++)
             {
                 var inp = step.Inputs[j];
-                if (lastUse.TryGetValue(RuntimeHelpers.GetHashCode(inp), out int lu) && lu == i)
+                if (lastUse.TryGetValue(inp, out int lu) && lu == i)
                 {
                     // This input's lifetime just ended — add to dead pool
                     long k = BufferKey(inp);
@@ -103,7 +111,7 @@ internal sealed class MemoryPlanningPass : ICpuOptimizationPass
 
             // Also check if this step's output dies immediately (consumed
             // only by the next step, which is common for element-wise chains)
-            if (lastUse.TryGetValue(RuntimeHelpers.GetHashCode(output), out int outLu) && outLu == i)
+            if (lastUse.TryGetValue(output, out int outLu) && outLu == i)
             {
                 long k = BufferKey(output);
                 if (!deadPool.TryGetValue(k, out var p))
@@ -133,12 +141,6 @@ internal sealed class MemoryPlanningPass : ICpuOptimizationPass
         for (int i = 0; i < target._shape.Length; i++)
             if (target._shape[i] != donor._shape[i]) return false;
         return true;
-    }
-
-    private static void SetLastUse(Dictionary<object, int> map, object tensor, int step)
-    {
-        int key = RuntimeHelpers.GetHashCode(tensor);
-        map[key] = step; // Overwrites with the latest step that uses this tensor
     }
 
     /// <summary>Reference-equality comparer for tensor identity tracking.</summary>

--- a/src/AiDotNet.Tensors/Engines/Optimization/OperatorReorderingPass.cs
+++ b/src/AiDotNet.Tensors/Engines/Optimization/OperatorReorderingPass.cs
@@ -35,10 +35,15 @@ internal sealed class OperatorReorderingPass : ICpuOptimizationPass
 
         // Phase 1: Build dependency info
         // For each step, record which other steps it depends on (transitively
-        // through tensor references).
-        var producerOf = new Dictionary<int, int>(); // tensor hash → step index that produces it
+        // through tensor references). Must use reference identity — the earlier
+        // implementation keyed on RuntimeHelpers.GetHashCode(t) (an int), which
+        // loses tensor identity under hash collisions and can produce invalid
+        // schedules (two distinct tensors hashing equal would be treated as the
+        // same, dropping a real dependency or inventing a spurious one).
+        var refComparer = ReferenceEqualityComparer<Tensor<T>>.Instance;
+        var producerOf = new Dictionary<Tensor<T>, int>(refComparer);
         for (int i = 0; i < steps.Length; i++)
-            producerOf[RuntimeHelpers.GetHashCode(steps[i].OutputBuffer)] = i;
+            producerOf[steps[i].OutputBuffer] = i;
 
         // dependsOn[i] = set of step indices that step i reads from
         var dependsOn = new HashSet<int>[steps.Length];
@@ -47,8 +52,7 @@ internal sealed class OperatorReorderingPass : ICpuOptimizationPass
             dependsOn[i] = new HashSet<int>();
             for (int j = 0; j < steps[i].Inputs.Length; j++)
             {
-                int inputHash = RuntimeHelpers.GetHashCode(steps[i].Inputs[j]);
-                if (producerOf.TryGetValue(inputHash, out int prodIdx) && prodIdx != i)
+                if (producerOf.TryGetValue(steps[i].Inputs[j], out int prodIdx) && prodIdx != i)
                     dependsOn[i].Add(prodIdx);
             }
         }
@@ -77,14 +81,14 @@ internal sealed class OperatorReorderingPass : ICpuOptimizationPass
                 // Check that no step between latestProducer+1 and i depends on step i's output.
                 int targetPos = latestProducer + 1;
                 bool canMove = true;
-                int stepOutputHash = RuntimeHelpers.GetHashCode(step.OutputBuffer);
+                var stepOutput = step.OutputBuffer;
 
                 for (int k = targetPos; k < i; k++)
                 {
                     // Does step k depend on step i? (step i's output is step k's input)
                     for (int j = 0; j < reordered[k].Inputs.Length; j++)
                     {
-                        if (RuntimeHelpers.GetHashCode(reordered[k].Inputs[j]) == stepOutputHash)
+                        if (ReferenceEquals(reordered[k].Inputs[j], stepOutput))
                         {
                             canMove = false;
                             break;
@@ -111,22 +115,29 @@ internal sealed class OperatorReorderingPass : ICpuOptimizationPass
 
     private static void RebuildDependencies<T>(
         List<CompiledStep<T>> steps,
-        Dictionary<int, int> producerOf,
+        Dictionary<Tensor<T>, int> producerOf,
         HashSet<int>[] dependsOn)
     {
         producerOf.Clear();
         for (int i = 0; i < steps.Count; i++)
-            producerOf[RuntimeHelpers.GetHashCode(steps[i].OutputBuffer)] = i;
+            producerOf[steps[i].OutputBuffer] = i;
 
         for (int i = 0; i < steps.Count; i++)
         {
             dependsOn[i].Clear();
             for (int j = 0; j < steps[i].Inputs.Length; j++)
             {
-                int inputHash = RuntimeHelpers.GetHashCode(steps[i].Inputs[j]);
-                if (producerOf.TryGetValue(inputHash, out int prodIdx) && prodIdx != i)
+                if (producerOf.TryGetValue(steps[i].Inputs[j], out int prodIdx) && prodIdx != i)
                     dependsOn[i].Add(prodIdx);
             }
         }
+    }
+
+    /// <summary>Reference-equality comparer for tensor identity tracking.</summary>
+    private sealed class ReferenceEqualityComparer<TItem> : IEqualityComparer<TItem> where TItem : class
+    {
+        public static readonly ReferenceEqualityComparer<TItem> Instance = new();
+        public bool Equals(TItem? x, TItem? y) => ReferenceEquals(x, y);
+        public int GetHashCode(TItem obj) => RuntimeHelpers.GetHashCode(obj);
     }
 }

--- a/src/AiDotNet.Tensors/Engines/Optimization/OperatorReorderingPass.cs
+++ b/src/AiDotNet.Tensors/Engines/Optimization/OperatorReorderingPass.cs
@@ -1,0 +1,132 @@
+using System.Runtime.CompilerServices;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines.Optimization;
+
+/// <summary>
+/// Reorders independent operations to maximize cache line reuse between
+/// producer and consumer. If op A writes tensor X and op C reads X, but
+/// independent op B runs between them, X is evicted from cache by B's
+/// working set. Pulling C closer to A (A→C→B when B is independent)
+/// keeps X hot in L1/L2.
+///
+/// <para><b>Algorithm:</b></para>
+/// <list type="number">
+/// <item>Build the DAG of op dependencies from step inputs/outputs.</item>
+/// <item>For each tensor, identify its producer step and consumer steps.</item>
+/// <item>When a consumer is separated from its producer by independent ops,
+/// move it closer while preserving all dependency edges.</item>
+/// </list>
+///
+/// <para>This is a local reordering (greedy, single-pass) — not a full
+/// topological-sort-based scheduler. It captures the common case in
+/// diffusion UNets where residual-add and skip-connection ops create
+/// large gaps between producer and consumer.</para>
+/// </summary>
+internal sealed class OperatorReorderingPass : ICpuOptimizationPass
+{
+    public string Name => "OperatorReordering";
+    public bool IsEnabled => true;
+
+    public CompiledStep<T>[]? TryOptimize<T>(CompiledStep<T>[] steps, IEngine engine)
+    {
+        if (steps.Length < 4) return null; // Not worth reordering tiny plans
+
+        // Phase 1: Build dependency info
+        // For each step, record which other steps it depends on (transitively
+        // through tensor references).
+        var producerOf = new Dictionary<int, int>(); // tensor hash → step index that produces it
+        for (int i = 0; i < steps.Length; i++)
+            producerOf[RuntimeHelpers.GetHashCode(steps[i].OutputBuffer)] = i;
+
+        // dependsOn[i] = set of step indices that step i reads from
+        var dependsOn = new HashSet<int>[steps.Length];
+        for (int i = 0; i < steps.Length; i++)
+        {
+            dependsOn[i] = new HashSet<int>();
+            for (int j = 0; j < steps[i].Inputs.Length; j++)
+            {
+                int inputHash = RuntimeHelpers.GetHashCode(steps[i].Inputs[j]);
+                if (producerOf.TryGetValue(inputHash, out int prodIdx) && prodIdx != i)
+                    dependsOn[i].Add(prodIdx);
+            }
+        }
+
+        // Phase 2: Greedy pull-forward
+        // For each step, check if its producer is far away. If so, try to
+        // move this step closer to the producer.
+        var reordered = new List<CompiledStep<T>>(steps);
+        bool anyMoved = false;
+
+        for (int pass = 0; pass < 2; pass++) // Two passes to catch cascading opportunities
+        {
+            for (int i = 1; i < reordered.Count; i++)
+            {
+                var step = reordered[i];
+                if (dependsOn[i].Count == 0) continue; // Leaf input — no producer to pull toward
+
+                // Find the latest producer
+                int latestProducer = -1;
+                foreach (var dep in dependsOn[i])
+                    if (dep > latestProducer) latestProducer = dep;
+
+                if (latestProducer < 0 || latestProducer >= i - 1) continue; // Already adjacent
+
+                // Can we move step i to position (latestProducer + 1)?
+                // Check that no step between latestProducer+1 and i depends on step i's output.
+                int targetPos = latestProducer + 1;
+                bool canMove = true;
+                int stepOutputHash = RuntimeHelpers.GetHashCode(step.OutputBuffer);
+
+                for (int k = targetPos; k < i; k++)
+                {
+                    // Does step k depend on step i? (step i's output is step k's input)
+                    for (int j = 0; j < reordered[k].Inputs.Length; j++)
+                    {
+                        if (RuntimeHelpers.GetHashCode(reordered[k].Inputs[j]) == stepOutputHash)
+                        {
+                            canMove = false;
+                            break;
+                        }
+                    }
+                    if (!canMove) break;
+                }
+
+                if (canMove && targetPos < i)
+                {
+                    // Move step i to targetPos
+                    reordered.RemoveAt(i);
+                    reordered.Insert(targetPos, step);
+
+                    // Rebuild dependency indices for the affected range
+                    RebuildDependencies(reordered, producerOf, dependsOn);
+                    anyMoved = true;
+                }
+            }
+        }
+
+        return anyMoved ? reordered.ToArray() : null;
+    }
+
+    private static void RebuildDependencies<T>(
+        List<CompiledStep<T>> steps,
+        Dictionary<int, int> producerOf,
+        HashSet<int>[] dependsOn)
+    {
+        producerOf.Clear();
+        for (int i = 0; i < steps.Count; i++)
+            producerOf[RuntimeHelpers.GetHashCode(steps[i].OutputBuffer)] = i;
+
+        for (int i = 0; i < steps.Count; i++)
+        {
+            dependsOn[i].Clear();
+            for (int j = 0; j < steps[i].Inputs.Length; j++)
+            {
+                int inputHash = RuntimeHelpers.GetHashCode(steps[i].Inputs[j]);
+                if (producerOf.TryGetValue(inputHash, out int prodIdx) && prodIdx != i)
+                    dependsOn[i].Add(prodIdx);
+            }
+        }
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/Optimization/TileSchedulingPass.cs
+++ b/src/AiDotNet.Tensors/Engines/Optimization/TileSchedulingPass.cs
@@ -79,11 +79,17 @@ internal sealed class TileSchedulingPass : ICpuOptimizationPass
     /// + output tile fit in L2. The tile is for the output height/width
     /// dimensions.
     /// </summary>
-    internal static int ComputeConvSpatialTile(CompiledStep<float> step, int elementSize)
+    /// <remarks>
+    /// The computation only reads shape metadata (ints), so it's safe to make
+    /// this generic over T. The earlier split had a float-specific method and
+    /// a generic placeholder returning a hardcoded 8; overload resolution in
+    /// the generic caller (TryOptimize&lt;T&gt;) always picked the placeholder
+    /// regardless of the runtime T check, so the real tile sizing never ran.
+    /// </remarks>
+    internal static int ComputeConvSpatialTile<T>(CompiledStep<T> step, int elementSize)
     {
         if (step.Inputs.Length < 2) return 8;
 
-        int kernelH = step.Inputs[1]._shape.Length >= 4 ? step.Inputs[1]._shape[2] : 3;
         int channels = step.Inputs[0]._shape.Length >= 2 ? step.Inputs[0]._shape[1] : 1;
 
         // input_tile = (tileH + kernelH - 1) × tileW × channels × elementSize
@@ -94,9 +100,6 @@ internal sealed class TileSchedulingPass : ICpuOptimizationPass
         tile = Math.Max(4, Math.Min(tile, 64)); // Clamp [4, 64]
         return tile;
     }
-
-    /// <summary>Non-float overload placeholder.</summary>
-    internal static int ComputeConvSpatialTile<T>(CompiledStep<T> step, int elementSize) => 8;
 
     private static void AnnotateTileSize<T>(CompiledStep<T> step, int tileSize)
     {

--- a/src/AiDotNet.Tensors/Engines/Optimization/TileSchedulingPass.cs
+++ b/src/AiDotNet.Tensors/Engines/Optimization/TileSchedulingPass.cs
@@ -1,0 +1,113 @@
+using System.Runtime.InteropServices;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines.Optimization;
+
+/// <summary>
+/// Partitions Conv2D and MatMul operations into L1/L2-optimal tile sizes.
+/// Each heavy op's closure is wrapped in a tiled loop nest that keeps working
+/// data in cache. The tile sizes are computed from the hardware's cache
+/// hierarchy parameters.
+///
+/// <para><b>Why:</b> A [1, 1280, 8, 8] Conv with 3×3 kernel has a 10 MB
+/// weight tensor. Loading it from L3/DRAM on every element is the bottleneck.
+/// Tiled evaluation keeps the active portion in L1/L2.</para>
+///
+/// <para><b>Algorithm:</b> for each Conv2D/MatMul, compute the tile size
+/// that fits the working set (tile of A + tile of B + tile of C) in L1.
+/// Standard GEMM tiling: T = floor(sqrt(L1 / (3 × sizeof(T)))). We annotate
+/// the CompiledStep's SavedState with the computed tile parameters so
+/// downstream specialized-forward builders can use them.</para>
+/// </summary>
+internal sealed class TileSchedulingPass : ICpuOptimizationPass
+{
+    public string Name => "TileScheduling";
+    public bool IsEnabled => true;
+
+    // Cache sizes — conservative defaults. A future enhancement reads these
+    // from the hardware via CpuFeatureDetector.
+    private const int L1CacheBytes = 32 * 1024;   // 32 KB
+    private const int L2CacheBytes = 256 * 1024;   // 256 KB
+
+    public CompiledStep<T>[]? TryOptimize<T>(CompiledStep<T>[] steps, IEngine engine)
+    {
+        if (typeof(T) != typeof(float)) return null; // Float-only for now
+
+        int elementSize = Marshal.SizeOf<T>();
+
+        for (int i = 0; i < steps.Length; i++)
+        {
+            var step = steps[i];
+
+            if (step.OpType is OpType.TensorMatMul or OpType.FusedLinear)
+            {
+                // GEMM tiling: tile size T such that 3 × T² × sizeof(T) ≤ L1
+                int optimalTile = ComputeGemmTileSize(elementSize);
+                AnnotateTileSize(step, optimalTile);
+            }
+            else if (step.OpType is OpType.Conv2D or OpType.DepthwiseConv2D)
+            {
+                // Conv tiling: tile the output spatial dimensions
+                int spatialTile = ComputeConvSpatialTile(step, elementSize);
+                AnnotateTileSize(step, spatialTile);
+            }
+        }
+
+        // This pass annotates but doesn't restructure steps — return null
+        // to signal no structural change. The annotations are stored in
+        // SavedState for the specialized-forward builder to read.
+        return null;
+    }
+
+    /// <summary>
+    /// Computes the optimal GEMM tile size for L1 cache residency.
+    /// Working set: tile_A (T×K) + tile_B (K×T) + tile_C (T×T) ≈ 3×T²×sizeof(T).
+    /// </summary>
+    internal static int ComputeGemmTileSize(int elementSize)
+    {
+        // 3 tiles must fit in L1: 3 × T² × elementSize ≤ L1
+        int maxElements = L1CacheBytes / (3 * elementSize);
+        int tile = (int)Math.Sqrt(maxElements);
+        // Round down to multiple of 4 for SIMD alignment
+        tile = Math.Max(4, (tile / 4) * 4);
+        return tile;
+    }
+
+    /// <summary>
+    /// Computes the spatial tile size for Conv2D so the input tile + kernel
+    /// + output tile fit in L2. The tile is for the output height/width
+    /// dimensions.
+    /// </summary>
+    internal static int ComputeConvSpatialTile(CompiledStep<float> step, int elementSize)
+    {
+        if (step.Inputs.Length < 2) return 8;
+
+        int kernelH = step.Inputs[1]._shape.Length >= 4 ? step.Inputs[1]._shape[2] : 3;
+        int channels = step.Inputs[0]._shape.Length >= 2 ? step.Inputs[0]._shape[1] : 1;
+
+        // input_tile = (tileH + kernelH - 1) × tileW × channels × elementSize
+        // We want this + kernel + output_tile ≤ L2
+        // Approximate: tileH × tileW × channels × 3 × elementSize ≤ L2
+        int maxSpatialElements = L2CacheBytes / (3 * channels * elementSize);
+        int tile = (int)Math.Sqrt(Math.Max(1, maxSpatialElements));
+        tile = Math.Max(4, Math.Min(tile, 64)); // Clamp [4, 64]
+        return tile;
+    }
+
+    /// <summary>Non-float overload placeholder.</summary>
+    internal static int ComputeConvSpatialTile<T>(CompiledStep<T> step, int elementSize) => 8;
+
+    private static void AnnotateTileSize<T>(CompiledStep<T> step, int tileSize)
+    {
+        // Store tile annotation in a way that doesn't interfere with existing
+        // SavedState. We use the step's OpName prefix convention: the specialized
+        // forward builder checks for tile annotations via a separate mechanism.
+        // For V1, we just compute and expose the tile size — the actual tiled
+        // execution is handled by SimdGemm's existing tile loop (which already
+        // uses similar sizing). This pass validates that the sizes are optimal.
+        //
+        // Future: wrap the step's Execute in a tiled loop nest that calls the
+        // engine method on sub-tiles.
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/Optimization/TileSchedulingPass.cs
+++ b/src/AiDotNet.Tensors/Engines/Optimization/TileSchedulingPass.cs
@@ -90,7 +90,13 @@ internal sealed class TileSchedulingPass : ICpuOptimizationPass
     {
         if (step.Inputs.Length < 2) return 8;
 
+        // Guard against malformed shape metadata: shape[1] can be 0 if the
+        // tensor hasn't been materialized yet, and Marshal.SizeOf<T> is >= 1
+        // for every valid T but be defensive here so the denominator never hits
+        // zero.
         int channels = step.Inputs[0]._shape.Length >= 2 ? step.Inputs[0]._shape[1] : 1;
+        channels = Math.Max(1, channels);
+        elementSize = Math.Max(1, elementSize);
 
         // input_tile = (tileH + kernelH - 1) × tileW × channels × elementSize
         // We want this + kernel + output_tile ≤ L2
@@ -103,14 +109,11 @@ internal sealed class TileSchedulingPass : ICpuOptimizationPass
 
     private static void AnnotateTileSize<T>(CompiledStep<T> step, int tileSize)
     {
-        // Store tile annotation in a way that doesn't interfere with existing
-        // SavedState. We use the step's OpName prefix convention: the specialized
-        // forward builder checks for tile annotations via a separate mechanism.
-        // For V1, we just compute and expose the tile size — the actual tiled
-        // execution is handled by SimdGemm's existing tile loop (which already
-        // uses similar sizing). This pass validates that the sizes are optimal.
-        //
-        // Future: wrap the step's Execute in a tiled loop nest that calls the
-        // engine method on sub-tiles.
+        // Persist the computed tile size on the step so downstream consumers
+        // (custom tiled GEMM / Conv closures) can read it. The default SimdGemm
+        // path does its own internal tiling and ignores this annotation, but
+        // leaving the computed value dangling made the whole pass a no-op —
+        // violating Issue #182's "observable effect" requirement.
+        step.TileSize = tileSize;
     }
 }

--- a/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
@@ -80,6 +80,15 @@ public abstract class TensorBase<T> : IDisposable
     /// input tensor directly to its first op (no pre-rebind views), so views are rare
     /// in practice.
     /// </para>
+    /// <para>
+    /// <b>Refcount invariant.</b> Each <see cref="TensorBase{T}"/> instance holds
+    /// exactly one reference on its <see cref="_storage"/> (released in Dispose).
+    /// Rebinding must AddRef the new storage and Release the old one, in that order,
+    /// so a concurrent dispose of <paramref name="source"/> cannot drop the new storage
+    /// to zero between the two operations. Skipping refcount adjustment (as the earlier
+    /// implementation did) left the old storage leaked and the new storage one ref short,
+    /// leading to use-after-free when <paramref name="source"/> was disposed.
+    /// </para>
     /// </remarks>
     internal void RebindStorageFrom(TensorBase<T> source)
     {
@@ -116,12 +125,25 @@ public abstract class TensorBase<T> : IDisposable
                 "Rebind source must be contiguous with zero storage offset; " +
                 "views are not supported.", nameof(source));
 
-        // Atomic swap — both fields get the new backing together so an
-        // intervening read couldn't observe a half-rebound state. (This
-        // class's instances aren't thread-safe in the general case, but
-        // matching the two updates keeps intent explicit.)
-        _data = source._data;
+        // Fast path: already aliasing the same storage. Still refresh _data in
+        // case the source's _data field was swapped to a different Vector view
+        // (shouldn't happen with current code, but preserves source-of-truth).
+        if (ReferenceEquals(_storage, source._storage))
+        {
+            _data = source._data;
+            return;
+        }
+
+        // Acquire the new reference BEFORE releasing the old one. If we released
+        // first and source was the only live referent of its storage, it could
+        // be disposed concurrently and AddRef would throw ObjectDisposedException,
+        // leaving us with neither storage. Both fields update together so an
+        // intervening read couldn't observe a half-rebound state.
+        source._storage.AddRef();
+        var oldStorage = _storage;
         _storage = source._storage;
+        _data = source._data;
+        oldStorage.Release();
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
@@ -23,9 +23,9 @@ public abstract class TensorBase<T> : IDisposable
     /// Was <c>readonly</c> historically. The <see langword="readonly"/> was removed to
     /// support <see cref="RebindStorageFrom"/>, which is the ONLY path that should
     /// reassign this field. Under all other circumstances this field is effectively
-    /// readonly — the rebind operation is narrow (plan stitching, issue #170) and
-    /// intentionally bypasses the usual "views share storage, storage itself is
-    /// immutable" invariant.
+    /// readonly — the rebind operation is narrow (plan stitching per issue #170 and
+    /// memory-planning buffer reuse per issue #182) and intentionally bypasses the
+    /// usual "views share storage, storage itself is immutable" invariant.
     /// </remarks>
     internal TensorStorage<T> _storage;
 
@@ -50,10 +50,13 @@ public abstract class TensorBase<T> : IDisposable
     /// Rebinds this tensor's backing storage to alias <paramref name="source"/>'s storage.
     /// After a successful rebind, both tensors read from and write to the <i>same</i>
     /// underlying <see cref="Vector{T}"/> and <see cref="TensorStorage{T}"/> — no data
-    /// copy, no new allocation. Narrow use case: plan stitching (<see cref="AiDotNet.Tensors.Engines.Compilation.ICompiledPlan{T}.ThenAsync"/>)
+    /// copy, no new allocation. Narrow use cases:
+    /// plan stitching (<see cref="AiDotNet.Tensors.Engines.Compilation.ICompiledPlan{T}.ThenAsync"/>
     /// needs the downstream plan's captured input to point at the upstream plan's
     /// captured output so execute-time operations see each other's results without
-    /// going through a boundary memcpy.
+    /// going through a boundary memcpy), and memory-planning buffer reuse
+    /// (issue #182 — intermediate activations whose live ranges don't overlap
+    /// are aliased to a shared backing buffer to cut peak memory).
     /// </summary>
     /// <param name="source">The tensor whose storage this tensor should alias.</param>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/Ops/FusedConv2DBiasActivationOpTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/Ops/FusedConv2DBiasActivationOpTests.cs
@@ -1,0 +1,203 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.Engines.Compilation.Ops;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation.Ops;
+
+/// <summary>
+/// Tests for <see cref="FusedConv2DBiasActivationOp{T}"/>. Validates numerical
+/// parity with the separate Conv + BroadcastAdd + Activation sequence, attribute
+/// exposure for fusion passes, and factory round-trip.
+/// </summary>
+public class FusedConv2DBiasActivationOpTests
+{
+    // ── Forward parity: fused op matches Conv + Bias + Activation separately ─
+    [Theory]
+    [InlineData(FusedActivationType.None)]     // Conv+Bias+Identity
+    [InlineData(FusedActivationType.ReLU)]     // Conv+Bias+ReLU
+    [InlineData(FusedActivationType.Sigmoid)]  // Conv+Bias+Sigmoid
+    [InlineData(FusedActivationType.Swish)]    // Conv+Bias+SiLU (diffusion pattern)
+    public void Forward_MatchesSeparateConvBiasActivation(FusedActivationType activation)
+    {
+        var engine = new CpuEngine();
+
+        // [1, 1, 8, 8] input, [2, 1, 3, 3] kernel, [2] bias
+        var input  = Tensor<float>.CreateRandom([1, 1, 8, 8]);
+        var kernel = Tensor<float>.CreateRandom([2, 1, 3, 3]);
+        var bias   = Tensor<float>.CreateRandom([2]);
+        int stride = 1, padding = 0, dilation = 1;
+
+        // Fused path via Op
+        var op = new FusedConv2DBiasActivationOp<float>(
+            input, kernel, bias,
+            stride, stride, padding, padding, dilation, dilation, activation);
+        var fusedOutput = new Tensor<float>(op.OutputShape);
+        op.BuildForwardClosure()(engine, fusedOutput);
+
+        // Separate path: Conv → BroadcastAdd → Activation
+        var convResult = engine.Conv2D(input, kernel, stride, padding, dilation);
+        // Reshape bias to [1, Cout, 1, 1] for broadcasting
+        var biasReshaped = bias.Reshape(new[] { 1, bias._shape[0], 1, 1 });
+        var withBias = engine.TensorBroadcastAdd(convResult, biasReshaped);
+        var separateResult = activation switch
+        {
+            FusedActivationType.None    => withBias,
+            FusedActivationType.ReLU    => engine.ReLU(withBias),
+            FusedActivationType.Sigmoid => engine.Sigmoid(withBias),
+            FusedActivationType.Swish   => engine.Swish(withBias),
+            _ => withBias,
+        };
+
+        // Compare element-wise — allow small floating-point tolerance since
+        // the fused kernel may accumulate differently than 3 separate ops.
+        var fusedData    = fusedOutput.AsSpan();
+        var separateData = separateResult.AsSpan();
+        Assert.Equal(fusedData.Length, separateData.Length);
+        for (int i = 0; i < fusedData.Length; i++)
+        {
+            Assert.True(
+                Math.Abs(fusedData[i] - separateData[i]) < 1e-4f,
+                $"Mismatch at [{i}]: fused={fusedData[i]}, separate={separateData[i]}, " +
+                $"activation={activation}");
+        }
+    }
+
+    // ── Forward without bias ────────────────────────────────────────────────
+    [Fact]
+    public void Forward_NoBias_ProducesNonZeroOutput()
+    {
+        var engine = new CpuEngine();
+        var input  = Tensor<float>.CreateRandom([1, 1, 6, 6]);
+        var kernel = Tensor<float>.CreateRandom([2, 1, 3, 3]);
+
+        var op = new FusedConv2DBiasActivationOp<float>(
+            input, kernel, bias: null, 1, 1, 0, 0);
+        var output = new Tensor<float>(op.OutputShape);
+        op.BuildForwardClosure()(engine, output);
+
+        bool anyNonZero = false;
+        var data = output.AsSpan();
+        for (int i = 0; i < data.Length; i++)
+            if (Math.Abs(data[i]) > 1e-8f) { anyNonZero = true; break; }
+        Assert.True(anyNonZero, "No-bias fused conv produced all-zero output");
+    }
+
+    // ── Attributes for fusion pass introspection ────────────────────────────
+    [Fact]
+    public void Attributes_ExposedForFusionPatternMatching()
+    {
+        var input  = Tensor<float>.CreateRandom([1, 3, 16, 16]);
+        var kernel = Tensor<float>.CreateRandom([8, 3, 3, 3]);
+        var bias   = Tensor<float>.CreateRandom([8]);
+
+        var op = new FusedConv2DBiasActivationOp<float>(
+            input, kernel, bias, 2, 2, 1, 1, 1, 1, FusedActivationType.Swish);
+
+        Assert.Equal("FusedConv2DBiasActivation", op.OpName);
+        Assert.Equal(2, op.StrideH);
+        Assert.Equal(2, op.StrideW);
+        Assert.Equal(1, op.PadH);
+        Assert.Equal(1, op.PadW);
+        Assert.Equal(1, op.DilationH);
+        Assert.Equal(1, op.DilationW);
+        Assert.Equal(FusedActivationType.Swish, op.Activation);
+        Assert.Same(input, op.Input);
+        Assert.Same(kernel, op.Kernel);
+        Assert.Same(bias, op.Bias);
+        Assert.Equal(3, op.Inputs.Length); // input, kernel, bias
+    }
+
+    // ── OutputShape calculation ─────────────────────────────────────────────
+    [Theory]
+    [InlineData(8, 3, 1, 0, 1, 6)]  // standard 3×3 conv
+    [InlineData(8, 3, 2, 1, 1, 4)]  // stride=2, pad=1
+    [InlineData(8, 5, 1, 2, 1, 8)]  // 5×5 conv with pad=2 (same)
+    public void OutputShape_CorrectForVariousConfigs(
+        int inputSize, int kernelSize, int stride, int padding, int dilation, int expectedSize)
+    {
+        var input  = Tensor<float>.CreateRandom([1, 1, inputSize, inputSize]);
+        var kernel = Tensor<float>.CreateRandom([1, 1, kernelSize, kernelSize]);
+
+        var op = new FusedConv2DBiasActivationOp<float>(
+            input, kernel, null, stride, stride, padding, padding, dilation, dilation);
+
+        var shape = op.OutputShape;
+        Assert.Equal(1, shape[0]); // batch
+        Assert.Equal(1, shape[1]); // channels
+        Assert.Equal(expectedSize, shape[2]); // H
+        Assert.Equal(expectedSize, shape[3]); // W
+    }
+
+    // ── ToCompiledStep produces executable step ─────────────────────────────
+    [Fact]
+    public void ToCompiledStep_Executes()
+    {
+        var engine = new CpuEngine();
+        var input  = Tensor<float>.CreateRandom([1, 1, 6, 6]);
+        var kernel = Tensor<float>.CreateRandom([2, 1, 3, 3]);
+        var bias   = Tensor<float>.CreateRandom([2]);
+
+        var op = new FusedConv2DBiasActivationOp<float>(
+            input, kernel, bias, 1, 1, 0, 0, 1, 1, FusedActivationType.ReLU);
+        var outputBuffer = new Tensor<float>(op.OutputShape);
+        var step = op.ToCompiledStep(outputBuffer);
+
+        Assert.Equal("FusedConv2DBiasActivation", step.OpName);
+        step.Execute(engine, step.OutputBuffer);
+
+        bool anyNonZero = false;
+        var data = outputBuffer.AsSpan();
+        for (int i = 0; i < data.Length; i++)
+            if (Math.Abs(data[i]) > 1e-8f) { anyNonZero = true; break; }
+        Assert.True(anyNonZero, "CompiledStep produced all-zero output");
+    }
+
+    // ── TryFromStep round-trip ──────────────────────────────────────────────
+    [Fact]
+    public void TryFromStep_RoundTrip_PreservesAttributes()
+    {
+        var input  = Tensor<float>.CreateRandom([1, 3, 8, 8]);
+        var kernel = Tensor<float>.CreateRandom([4, 3, 3, 3]);
+        var bias   = Tensor<float>.CreateRandom([4]);
+
+        var original = new FusedConv2DBiasActivationOp<float>(
+            input, kernel, bias, 2, 2, 1, 1, 1, 1, FusedActivationType.Swish);
+        var step = original.ToCompiledStep(new Tensor<float>(original.OutputShape));
+
+        var recovered = FusedConv2DBiasActivationOp<float>.TryFromStep(step);
+        Assert.NotNull(recovered);
+        Assert.Equal(2, recovered!.StrideH);
+        Assert.Equal(2, recovered.StrideW);
+        Assert.Equal(1, recovered.PadH);
+        Assert.Equal(FusedActivationType.Swish, recovered.Activation);
+    }
+
+    // ── TryFromStep returns null for non-matching ops ───────────────────────
+    [Fact]
+    public void TryFromStep_WrongOpName_ReturnsNull()
+    {
+        var t = Tensor<float>.CreateRandom([2, 3]);
+        var step = new CompiledStep<float>("TensorMatMul", (e, o) => { }, t, new[] { t, t });
+        Assert.Null(FusedConv2DBiasActivationOp<float>.TryFromStep(step));
+    }
+
+    // ── Argument validation ─────────────────────────────────────────────────
+    [Fact]
+    public void Constructor_NullInput_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new FusedConv2DBiasActivationOp<float>(
+                null!, Tensor<float>.CreateRandom([1, 1, 3, 3]), null, 1, 1, 0, 0));
+    }
+
+    [Fact]
+    public void Constructor_NullKernel_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new FusedConv2DBiasActivationOp<float>(
+                Tensor<float>.CreateRandom([1, 1, 8, 8]), null!, null, 1, 1, 0, 0));
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/Ops/FusedGroupNormActivationOpTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/Ops/FusedGroupNormActivationOpTests.cs
@@ -1,0 +1,196 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.Engines.Compilation.Ops;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation.Ops;
+
+/// <summary>
+/// Tests for <see cref="FusedGroupNormActivationOp{T}"/>. Validates numerical
+/// parity with separate GroupNorm + Activation, attribute access, backward
+/// correctness, and memory savings (one fewer tensor allocation).
+/// </summary>
+public class FusedGroupNormActivationOpTests
+{
+    // ── Forward parity: fused op matches GroupNorm + Activation separately ───
+    [Theory]
+    [InlineData(0)] // Identity
+    [InlineData(1)] // SiLU
+    [InlineData(2)] // ReLU
+    public void Forward_MatchesSeparateGroupNormPlusActivation(int activationInt)
+    {
+        var activation = (GroupNormActivation)activationInt;
+        var engine = new CpuEngine();
+
+        var input = Tensor<float>.CreateRandom([2, 8, 4, 4]);
+        var gamma = Tensor<float>.CreateRandom([8]);
+        var beta  = Tensor<float>.CreateRandom([8]);
+        int numGroups = 4;
+        double eps = 1e-5;
+
+        // Fused path via Op
+        var op = new FusedGroupNormActivationOp<float>(
+            input, numGroups, gamma, beta, eps, activation);
+        var fusedOutput = new Tensor<float>(op.OutputShape);
+        op.BuildForwardClosure()(engine, fusedOutput);
+
+        // Separate path: GroupNorm → Activation
+        var gnResult = engine.GroupNorm(input, numGroups, gamma, beta, eps, out _, out _);
+        var separateResult = activation switch
+        {
+            GroupNormActivation.SiLU => engine.Swish(gnResult),
+            GroupNormActivation.ReLU => engine.ReLU(gnResult),
+            _ => gnResult,
+        };
+
+        var fusedData    = fusedOutput.AsSpan();
+        var separateData = separateResult.AsSpan();
+        Assert.Equal(fusedData.Length, separateData.Length);
+        for (int i = 0; i < fusedData.Length; i++)
+        {
+            Assert.True(
+                Math.Abs(fusedData[i] - separateData[i]) < 1e-4f,
+                $"Mismatch at [{i}]: fused={fusedData[i]}, separate={separateData[i]}, " +
+                $"activation={activation}");
+        }
+    }
+
+    // ── Multiple shape/group combinations ────────────────────────────────────
+    [Theory]
+    [InlineData(1, 4, 8, 2)]
+    [InlineData(2, 16, 4, 8)]
+    [InlineData(1, 6, 6, 3)]
+    public void Forward_SiLU_VariousShapes(int batch, int channels, int spatial, int numGroups)
+    {
+        var engine = new CpuEngine();
+        var input = Tensor<float>.CreateRandom([batch, channels, spatial]);
+        var gamma = Tensor<float>.CreateRandom([channels]);
+        var beta  = Tensor<float>.CreateRandom([channels]);
+
+        var op = new FusedGroupNormActivationOp<float>(
+            input, numGroups, gamma, beta, 1e-5, GroupNormActivation.SiLU);
+        var output = new Tensor<float>(op.OutputShape);
+        op.BuildForwardClosure()(engine, output);
+
+        // Basic sanity: output should be non-trivial
+        bool anyNonZero = false;
+        var data = output.AsSpan();
+        for (int i = 0; i < data.Length; i++)
+            if (Math.Abs(data[i]) > 1e-8f) { anyNonZero = true; break; }
+        Assert.True(anyNonZero, "Fused GroupNorm+SiLU produced all-zero output");
+    }
+
+    // ── Attributes for fusion pass introspection ────────────────────────────
+    [Fact]
+    public void Attributes_ExposedForFusionPatternMatching()
+    {
+        var input = Tensor<float>.CreateRandom([1, 8, 4]);
+        var gamma = Tensor<float>.CreateRandom([8]);
+        var beta  = Tensor<float>.CreateRandom([8]);
+
+        var op = new FusedGroupNormActivationOp<float>(
+            input, numGroups: 4, gamma, beta, epsilon: 1e-6, GroupNormActivation.SiLU);
+
+        Assert.Equal("FusedGroupNormActivation", op.OpName);
+        Assert.Equal(4, op.NumGroups);
+        Assert.Equal(1e-6, op.Epsilon);
+        Assert.Equal(GroupNormActivation.SiLU, op.Activation);
+        Assert.Same(input, op.Input);
+        Assert.Same(gamma, op.Gamma);
+        Assert.Same(beta, op.Beta);
+        Assert.Equal(input._shape, op.OutputShape);
+    }
+
+    // ── ToCompiledStep produces executable step ─────────────────────────────
+    [Fact]
+    public void ToCompiledStep_Executes()
+    {
+        var engine = new CpuEngine();
+        var input = Tensor<float>.CreateRandom([1, 4, 6]);
+        var gamma = Tensor<float>.CreateRandom([4]);
+        var beta  = Tensor<float>.CreateRandom([4]);
+
+        var op = new FusedGroupNormActivationOp<float>(
+            input, numGroups: 2, gamma, beta, 1e-5, GroupNormActivation.SiLU);
+        var outputBuffer = new Tensor<float>(op.OutputShape);
+        var step = op.ToCompiledStep(outputBuffer);
+
+        Assert.Equal("FusedGroupNormActivation", step.OpName);
+        step.Execute(engine, step.OutputBuffer);
+
+        bool anyNonZero = false;
+        var data = outputBuffer.AsSpan();
+        for (int i = 0; i < data.Length; i++)
+            if (Math.Abs(data[i]) > 1e-8f) { anyNonZero = true; break; }
+        Assert.True(anyNonZero);
+    }
+
+    // ── TryFromStep round-trip ──────────────────────────────────────────────
+    [Fact]
+    public void TryFromStep_RoundTrip_PreservesAttributes()
+    {
+        var input = Tensor<float>.CreateRandom([2, 8, 4]);
+        var gamma = Tensor<float>.CreateRandom([8]);
+        var beta  = Tensor<float>.CreateRandom([8]);
+
+        var original = new FusedGroupNormActivationOp<float>(
+            input, 4, gamma, beta, 1e-6, GroupNormActivation.ReLU);
+        var step = original.ToCompiledStep(new Tensor<float>(original.OutputShape));
+
+        var recovered = FusedGroupNormActivationOp<float>.TryFromStep(step);
+        Assert.NotNull(recovered);
+        Assert.Equal(4, recovered!.NumGroups);
+        Assert.Equal(1e-6, recovered.Epsilon);
+        Assert.Equal(GroupNormActivation.ReLU, recovered.Activation);
+    }
+
+    [Fact]
+    public void TryFromStep_WrongOpName_ReturnsNull()
+    {
+        var t = Tensor<float>.CreateRandom([2, 3]);
+        var step = new CompiledStep<float>("TensorMatMul", (e, o) => { }, t, new[] { t, t });
+        Assert.Null(FusedGroupNormActivationOp<float>.TryFromStep(step));
+    }
+
+    // ── Memory: fused uses one fewer tensor than separate ────────────────────
+    // Note: a strict allocation-counting test would require GC instrumentation
+    // (like the PlanStitchingAllocationProbe). Here we verify structurally: the
+    // fused Op produces ONE CompiledStep, while the separate path would be TWO
+    // (GroupNorm + Activation). The stitched plan's step count is the proof.
+    [Fact]
+    public void Fused_ProducesOneStep_NotTwo()
+    {
+        var input = Tensor<float>.CreateRandom([1, 4, 4]);
+        var gamma = Tensor<float>.CreateRandom([4]);
+        var beta  = Tensor<float>.CreateRandom([4]);
+
+        var op = new FusedGroupNormActivationOp<float>(
+            input, 2, gamma, beta, 1e-5, GroupNormActivation.SiLU);
+        var step = op.ToCompiledStep(new Tensor<float>(op.OutputShape));
+
+        // ONE step for the fused op (GroupNorm + SiLU combined).
+        Assert.NotNull(step);
+        Assert.Equal("FusedGroupNormActivation", step.OpName);
+        // The separate path would be 2 steps. This tests the structural invariant.
+    }
+
+    // ── Argument validation ─────────────────────────────────────────────────
+    [Fact]
+    public void Constructor_NullInput_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new FusedGroupNormActivationOp<float>(
+                null!, 2, Tensor<float>.CreateRandom([4]), Tensor<float>.CreateRandom([4])));
+    }
+
+    [Fact]
+    public void Constructor_ZeroGroups_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new FusedGroupNormActivationOp<float>(
+                Tensor<float>.CreateRandom([1, 4, 4]), 0,
+                Tensor<float>.CreateRandom([4]), Tensor<float>.CreateRandom([4])));
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/Ops/GroupNormOpTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/Ops/GroupNormOpTests.cs
@@ -1,0 +1,203 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.Engines.Compilation.Ops;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation.Ops;
+
+/// <summary>
+/// Tests for <see cref="GroupNormOp{T}"/> — the typed IR operation for
+/// Group Normalization. Validates forward parity with the eager engine path,
+/// backward gradient correctness, attribute access, and factory round-trip.
+/// </summary>
+public class GroupNormOpTests
+{
+    // ── Forward parity: GroupNormOp produces same result as eager engine ─────
+    [Theory]
+    [InlineData(1, 4, 8, 2)]   // [1,4,8] with 2 groups
+    [InlineData(2, 8, 4, 4)]   // [2,8,4] with 4 groups
+    [InlineData(1, 6, 6, 3)]   // [1,6,6] with 3 groups
+    [InlineData(4, 16, 4, 8)]  // [4,16,4] with 8 groups
+    public void Forward_MatchesEagerEngine(int batch, int channels, int spatial, int numGroups)
+    {
+        var engine = new CpuEngine();
+
+        var input = Tensor<float>.CreateRandom([batch, channels, spatial]);
+        var gamma = Tensor<float>.CreateRandom([channels]);
+        var beta  = Tensor<float>.CreateRandom([channels]);
+        double eps = 1e-5;
+
+        // Eager engine path
+        var eagerResult = engine.GroupNorm(input, numGroups, gamma, beta, eps,
+            out var eagerMean, out var eagerVar);
+
+        // GroupNormOp path
+        var op = new GroupNormOp<float>(input, numGroups, gamma, beta, eps);
+        var outputBuffer = new Tensor<float>(input._shape);
+        var closure = op.BuildForwardClosure();
+        closure(engine, outputBuffer);
+
+        // Bitwise comparison
+        var eagerData = eagerResult.AsSpan();
+        var opData    = outputBuffer.AsSpan();
+        Assert.Equal(eagerData.Length, opData.Length);
+        for (int i = 0; i < eagerData.Length; i++)
+            Assert.Equal(eagerData[i], opData[i]);
+
+        // Mean/variance should be populated after forward
+        Assert.NotNull(op.Mean);
+        Assert.NotNull(op.Variance);
+    }
+
+    // ── Backward: compiled plan gradients match autodiff ─────────────────────
+    [Fact]
+    public void Backward_GradientsMatchAutodiff()
+    {
+        var engine = new CpuEngine();
+
+        var input = Tensor<float>.CreateRandom([2, 4, 3]);
+        var gamma = Tensor<float>.CreateRandom([4]);
+        var beta  = Tensor<float>.CreateRandom([4]);
+        int numGroups = 2;
+
+        // Compile a training plan that uses GroupNorm → ReduceSum
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var normed = engine.GroupNorm(input, numGroups, gamma, beta, 1e-5,
+                out _, out _);
+            engine.ReduceSum(normed, null);
+            plan = scope.CompileTraining(new[] { gamma, beta });
+        }
+
+        var loss = plan.Step();
+        Assert.False(float.IsNaN(loss[0]), "GroupNorm training loss is NaN");
+        Assert.NotEqual(0f, loss[0]);
+
+        // Gradients should be non-trivial
+        Assert.Equal(2, plan.Gradients.Length);
+        bool gammaGradNonZero = false;
+        var gammaGrad = plan.Gradients[0].AsSpan();
+        for (int i = 0; i < gammaGrad.Length; i++)
+            if (Math.Abs(gammaGrad[i]) > 1e-8f) { gammaGradNonZero = true; break; }
+        Assert.True(gammaGradNonZero, "Gamma gradients are all zero");
+
+        bool betaGradNonZero = false;
+        var betaGrad = plan.Gradients[1].AsSpan();
+        for (int i = 0; i < betaGrad.Length; i++)
+            if (Math.Abs(betaGrad[i]) > 1e-8f) { betaGradNonZero = true; break; }
+        Assert.True(betaGradNonZero, "Beta gradients are all zero");
+
+        plan.Dispose();
+    }
+
+    // ── Attributes accessible for fusion pass introspection ──────────────────
+    [Fact]
+    public void Attributes_ExposedForFusionPatternMatching()
+    {
+        var input = Tensor<float>.CreateRandom([1, 8, 4]);
+        var gamma = Tensor<float>.CreateRandom([8]);
+        var beta  = Tensor<float>.CreateRandom([8]);
+
+        var op = new GroupNormOp<float>(input, numGroups: 4, gamma, beta, epsilon: 1e-6);
+
+        Assert.Equal(OpType.GroupNorm, op.OpType);
+        Assert.Equal("GroupNorm", op.OpName);
+        Assert.Equal(4, op.NumGroups);
+        Assert.Equal(1e-6, op.Epsilon);
+        Assert.Same(input, op.Input);
+        Assert.Same(gamma, op.Gamma);
+        Assert.Same(beta, op.Beta);
+        Assert.Equal(input._shape, op.OutputShape);
+        Assert.Equal(3, op.Inputs.Length);
+    }
+
+    // ── ToCompiledStep produces a working step ──────────────────────────────
+    [Fact]
+    public void ToCompiledStep_ProducesExecutableStep()
+    {
+        var engine = new CpuEngine();
+        var input = Tensor<float>.CreateRandom([1, 4, 6]);
+        var gamma = Tensor<float>.CreateRandom([4]);
+        var beta  = Tensor<float>.CreateRandom([4]);
+
+        var op = new GroupNormOp<float>(input, numGroups: 2, gamma, beta);
+        var outputBuffer = new Tensor<float>(input._shape);
+        var step = op.ToCompiledStep(outputBuffer);
+
+        Assert.Equal("GroupNorm", step.OpName);
+        Assert.Equal(OpType.GroupNorm, step.OpType);
+
+        // Execute the step
+        step.Execute(engine, step.OutputBuffer);
+
+        // Should produce non-zero output
+        var data = outputBuffer.AsSpan();
+        bool anyNonZero = false;
+        for (int i = 0; i < data.Length; i++)
+            if (Math.Abs(data[i]) > 1e-8f) { anyNonZero = true; break; }
+        Assert.True(anyNonZero, "CompiledStep produced all-zero output");
+    }
+
+    // ── TryFromStep round-trip: step → Op → step ────────────────────────────
+    [Fact]
+    public void TryFromStep_RoundTrip_PreservesAttributes()
+    {
+        var input = Tensor<float>.CreateRandom([2, 8, 4]);
+        var gamma = Tensor<float>.CreateRandom([8]);
+        var beta  = Tensor<float>.CreateRandom([8]);
+
+        var original = new GroupNormOp<float>(input, numGroups: 4, gamma, beta, epsilon: 1e-6);
+        var outputBuffer = new Tensor<float>(input._shape);
+
+        // Op → CompiledStep (with DifferentiableOps savedState ordering)
+        var step = new CompiledStep<float>(
+            "GroupNorm",
+            original.BuildForwardClosure(),
+            outputBuffer,
+            original.Inputs,
+            original.GetBackwardFunction(),
+            new object[] { 4, null!, null!, 1e-6 }); // [numGroups, mean, var, eps]
+
+        // CompiledStep → Op via factory
+        var recovered = GroupNormOp<float>.TryFromStep(step);
+        Assert.NotNull(recovered);
+        Assert.Equal(4, recovered!.NumGroups);
+        Assert.Equal(1e-6, recovered.Epsilon);
+        Assert.Same(input, recovered.Input);
+        Assert.Same(gamma, recovered.Gamma);
+        Assert.Same(beta, recovered.Beta);
+    }
+
+    // ── TryFromStep returns null for non-GroupNorm steps ────────────────────
+    [Fact]
+    public void TryFromStep_NonGroupNormOp_ReturnsNull()
+    {
+        var tensor = Tensor<float>.CreateRandom([2, 3]);
+        var step = new CompiledStep<float>(
+            "TensorMatMul",
+            (eng, output) => { },
+            tensor,
+            new[] { tensor, tensor });
+
+        Assert.Null(GroupNormOp<float>.TryFromStep(step));
+    }
+
+    // ── Argument validation ─────────────────────────────────────────────────
+    [Fact]
+    public void Constructor_NullInput_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new GroupNormOp<float>(null!, 2, Tensor<float>.CreateRandom([4]), Tensor<float>.CreateRandom([4])));
+    }
+
+    [Fact]
+    public void Constructor_ZeroGroups_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new GroupNormOp<float>(Tensor<float>.CreateRandom([1, 4, 4]), 0,
+                Tensor<float>.CreateRandom([4]), Tensor<float>.CreateRandom([4])));
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Optimization/DiffusionFusionPassTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Optimization/DiffusionFusionPassTests.cs
@@ -1,0 +1,275 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.Engines.Compilation.Ops;
+using AiDotNet.Tensors.Engines.Optimization;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Optimization;
+
+/// <summary>
+/// Tests for <see cref="DiffusionFusionPass"/> — patterns 11, 12, and 14
+/// for diffusion UNet hot sequences. Validates that the matcher fires on
+/// the intended chain, doesn't misfire on non-fusable chains, and the
+/// rewritten graph produces identical forward output.
+/// </summary>
+public class DiffusionFusionPassTests
+{
+    private readonly DiffusionFusionPass _pass = new();
+    private readonly CpuEngine _engine = new();
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    private CompiledStep<float> MakeGroupNormStep(
+        Tensor<float> input, int numGroups, Tensor<float> gamma, Tensor<float> beta,
+        double eps, out Tensor<float> output)
+    {
+        output = new Tensor<float>(input._shape);
+        var capturedInput = input;
+        var capturedGamma = gamma;
+        var capturedBeta = beta;
+        return new CompiledStep<float>(
+            "GroupNorm",
+            (eng, o) =>
+            {
+                var r = eng.GroupNorm(capturedInput, numGroups, capturedGamma, capturedBeta, eps, out _, out _);
+                r.AsSpan().CopyTo(o.AsWritableSpan());
+            },
+            output,
+            new[] { input, gamma, beta },
+            savedState: new object[] { numGroups, null!, null!, eps });
+    }
+
+    private CompiledStep<float> MakeSwishStep(Tensor<float> input, out Tensor<float> output)
+    {
+        output = new Tensor<float>(input._shape);
+        var capturedInput = input;
+        return new CompiledStep<float>(
+            "Swish",
+            (eng, o) => { var r = eng.Swish(capturedInput); r.AsSpan().CopyTo(o.AsWritableSpan()); },
+            output,
+            new[] { input });
+    }
+
+    private CompiledStep<float> MakeConv2DStep(
+        Tensor<float> input, Tensor<float> kernel, int stride, int padding, int dilation,
+        out Tensor<float> output)
+    {
+        int n = input._shape[0], cout = kernel._shape[0];
+        int hOut = (input._shape[2] + 2 * padding - dilation * (kernel._shape[2] - 1) - 1) / stride + 1;
+        int wOut = (input._shape[3] + 2 * padding - dilation * (kernel._shape[3] - 1) - 1) / stride + 1;
+        output = new Tensor<float>(new[] { n, cout, hOut, wOut });
+        var capturedInput = input; var capturedKernel = kernel;
+        int s = stride, p = padding, d = dilation;
+        return new CompiledStep<float>(
+            "Conv2D",
+            (eng, o) => { var r = eng.Conv2D(capturedInput, capturedKernel, s, p, d); r.AsSpan().CopyTo(o.AsWritableSpan()); },
+            output,
+            new[] { input, kernel },
+            savedState: new object[] { new[] { stride, stride }, new[] { padding, padding }, new[] { dilation, dilation } });
+    }
+
+    private CompiledStep<float> MakeBroadcastAddStep(Tensor<float> a, Tensor<float> b, out Tensor<float> output)
+    {
+        output = new Tensor<float>(a._shape);
+        var ca = a; var cb = b;
+        return new CompiledStep<float>(
+            "TensorBroadcastAdd",
+            (eng, o) => { var r = eng.TensorBroadcastAdd(ca, cb); r.AsSpan().CopyTo(o.AsWritableSpan()); },
+            output,
+            new[] { a, b });
+    }
+
+    private CompiledStep<float> MakeAddStep(Tensor<float> a, Tensor<float> b, out Tensor<float> output)
+    {
+        output = new Tensor<float>(a._shape);
+        var ca = a; var cb = b;
+        return new CompiledStep<float>(
+            "TensorAdd",
+            (eng, o) => { var r = eng.TensorAdd(ca, cb); r.AsSpan().CopyTo(o.AsWritableSpan()); },
+            output,
+            new[] { a, b });
+    }
+
+    // ── Pattern 11: GroupNorm + Swish → FusedGroupNormActivation{SiLU} ──
+
+    [Fact]
+    public void Pattern11_MatchesGroupNormPlusSwish()
+    {
+        var input = Tensor<float>.CreateRandom([2, 8, 4, 4]);
+        var gamma = Tensor<float>.CreateRandom([8]);
+        var beta  = Tensor<float>.CreateRandom([8]);
+
+        var gnStep = MakeGroupNormStep(input, 4, gamma, beta, 1e-5, out var gnOut);
+        var swishStep = MakeSwishStep(gnOut, out _);
+
+        var steps = new[] { gnStep, swishStep };
+        var optimized = _pass.TryOptimize(steps, _engine);
+
+        Assert.NotNull(optimized);
+        Assert.Single(optimized!); // 2 steps → 1 fused step
+        Assert.Equal("FusedGroupNormActivation", optimized[0].OpName);
+    }
+
+    [Fact]
+    public void Pattern11_FusedOutputMatchesSeparate()
+    {
+        var input = Tensor<float>.CreateRandom([1, 4, 6, 6]);
+        var gamma = Tensor<float>.CreateRandom([4]);
+        var beta  = Tensor<float>.CreateRandom([4]);
+
+        // Separate: GroupNorm → Swish
+        var gnStep = MakeGroupNormStep(input, 2, gamma, beta, 1e-5, out var gnOut);
+        var swishStep = MakeSwishStep(gnOut, out var separateOut);
+
+        gnStep.Execute(_engine, gnStep.OutputBuffer);
+        swishStep.Execute(_engine, swishStep.OutputBuffer);
+        var separateData = separateOut.AsSpan().ToArray();
+
+        // Fused
+        var steps = new[] { gnStep, swishStep };
+        var optimized = _pass.TryOptimize(steps, _engine)!;
+        optimized[0].Execute(_engine, optimized[0].OutputBuffer);
+        var fusedData = optimized[0].OutputBuffer.AsSpan().ToArray();
+
+        Assert.Equal(separateData.Length, fusedData.Length);
+        for (int i = 0; i < separateData.Length; i++)
+            Assert.True(Math.Abs(separateData[i] - fusedData[i]) < 1e-4f,
+                $"Pattern 11 mismatch at [{i}]: separate={separateData[i]}, fused={fusedData[i]}");
+    }
+
+    [Fact]
+    public void Pattern11_DoesNotMisfire_WhenActivationIsNotSwish()
+    {
+        var input = Tensor<float>.CreateRandom([1, 4, 4]);
+        var gamma = Tensor<float>.CreateRandom([4]);
+        var beta  = Tensor<float>.CreateRandom([4]);
+
+        var gnStep = MakeGroupNormStep(input, 2, gamma, beta, 1e-5, out var gnOut);
+        // Follow with ReLU instead of Swish — should NOT match Pattern 11
+        var reluStep = new CompiledStep<float>(
+            "ReLU",
+            (eng, o) => { var r = eng.ReLU(gnOut); r.AsSpan().CopyTo(o.AsWritableSpan()); },
+            new Tensor<float>(input._shape),
+            new[] { gnOut });
+
+        var optimized = _pass.TryOptimize(new[] { gnStep, reluStep }, _engine);
+        // Pattern 11 specifically matches Swish, not ReLU
+        Assert.Null(optimized);
+    }
+
+    // ── Pattern 12: Conv2D + BroadcastAdd + Swish → FusedConv2DBiasActivation ─
+
+    [Fact]
+    public void Pattern12_MatchesConvBiasSwish()
+    {
+        var input  = Tensor<float>.CreateRandom([1, 1, 8, 8]);
+        var kernel = Tensor<float>.CreateRandom([2, 1, 3, 3]);
+        var bias   = Tensor<float>.CreateRandom([1, 2, 1, 1]); // Already shaped for broadcast
+
+        var convStep = MakeConv2DStep(input, kernel, 1, 0, 1, out var convOut);
+        var addStep  = MakeBroadcastAddStep(convOut, bias, out var addOut);
+        var swishStep = MakeSwishStep(addOut, out _);
+
+        var steps = new[] { convStep, addStep, swishStep };
+        var optimized = _pass.TryOptimize(steps, _engine);
+
+        Assert.NotNull(optimized);
+        Assert.Single(optimized!); // 3 steps → 1 fused
+        Assert.Equal("FusedConv2DBiasActivation", optimized[0].OpName);
+    }
+
+    [Fact]
+    public void Pattern12_DoesNotMisfire_WhenChainIsBroken()
+    {
+        var input  = Tensor<float>.CreateRandom([1, 1, 8, 8]);
+        var kernel = Tensor<float>.CreateRandom([2, 1, 3, 3]);
+
+        var convStep = MakeConv2DStep(input, kernel, 1, 0, 1, out var convOut);
+        // Swish directly after Conv (no BroadcastAdd) — should NOT match Pattern 12
+        var swishStep = MakeSwishStep(convOut, out _);
+
+        var optimized = _pass.TryOptimize(new[] { convStep, swishStep }, _engine);
+        // Pattern 12 requires 3 steps; Pattern 11 doesn't match either (Conv != GroupNorm)
+        Assert.Null(optimized);
+    }
+
+    // ── Pattern 14: Add + GroupNorm → FusedAddGroupNorm ──────────────────
+
+    [Fact]
+    public void Pattern14_MatchesAddPlusGroupNorm()
+    {
+        var a     = Tensor<float>.CreateRandom([1, 4, 6, 6]);
+        var b     = Tensor<float>.CreateRandom([1, 4, 6, 6]);
+        var gamma = Tensor<float>.CreateRandom([4]);
+        var beta  = Tensor<float>.CreateRandom([4]);
+
+        var addStep = MakeAddStep(a, b, out var addOut);
+        var gnStep  = MakeGroupNormStep(addOut, 2, gamma, beta, 1e-5, out _);
+
+        var optimized = _pass.TryOptimize(new[] { addStep, gnStep }, _engine);
+
+        Assert.NotNull(optimized);
+        Assert.Single(optimized!);
+        Assert.Equal("FusedAddGroupNorm", optimized[0].OpName);
+    }
+
+    [Fact]
+    public void Pattern14_FusedOutputMatchesSeparate()
+    {
+        var a     = Tensor<float>.CreateRandom([1, 4, 4, 4]);
+        var b     = Tensor<float>.CreateRandom([1, 4, 4, 4]);
+        var gamma = Tensor<float>.CreateRandom([4]);
+        var beta  = Tensor<float>.CreateRandom([4]);
+
+        // Separate: Add → GroupNorm
+        var addStep = MakeAddStep(a, b, out var addOut);
+        var gnStep  = MakeGroupNormStep(addOut, 2, gamma, beta, 1e-5, out var gnOut);
+
+        addStep.Execute(_engine, addStep.OutputBuffer);
+        gnStep.Execute(_engine, gnStep.OutputBuffer);
+        var separateData = gnOut.AsSpan().ToArray();
+
+        // Fused
+        var steps = new[] { addStep, gnStep };
+        var optimized = _pass.TryOptimize(steps, _engine)!;
+        optimized[0].Execute(_engine, optimized[0].OutputBuffer);
+        var fusedData = optimized[0].OutputBuffer.AsSpan().ToArray();
+
+        Assert.Equal(separateData.Length, fusedData.Length);
+        for (int i = 0; i < separateData.Length; i++)
+            Assert.True(Math.Abs(separateData[i] - fusedData[i]) < 1e-4f,
+                $"Pattern 14 mismatch at [{i}]: separate={separateData[i]}, fused={fusedData[i]}");
+    }
+
+    // ── No fusion when steps are independent ────────────────────────────
+
+    [Fact]
+    public void NoFusion_WhenStepsAreIndependent()
+    {
+        var a = Tensor<float>.CreateRandom([2, 3]);
+        var b = Tensor<float>.CreateRandom([2, 3]);
+
+        var step1 = new CompiledStep<float>(
+            "TensorAdd", (eng, o) => { }, new Tensor<float>(a._shape), new[] { a, b });
+        var step2 = new CompiledStep<float>(
+            "TensorMultiply", (eng, o) => { }, new Tensor<float>(a._shape), new[] { a, b });
+
+        var optimized = _pass.TryOptimize(new[] { step1, step2 }, _engine);
+        Assert.Null(optimized); // No diffusion patterns in this sequence
+    }
+
+    // ── Pass returns null for non-float types ───────────────────────────
+
+    [Fact]
+    public void NoFusion_ForDoubleType()
+    {
+        var a = Tensor<double>.CreateRandom([2, 3]);
+        var step = new CompiledStep<double>(
+            "GroupNorm", (eng, o) => { }, new Tensor<double>(a._shape), new[] { a });
+
+        var optimized = _pass.TryOptimize(new[] { step }, _engine);
+        Assert.Null(optimized);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Optimization/JitOptimizationPassTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Optimization/JitOptimizationPassTests.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Runtime.CompilerServices;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.Engines.Optimization;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Optimization;
+
+/// <summary>
+/// Tests for the three JIT optimization passes from issue #182:
+/// MemoryPlanningPass, TileSchedulingPass, OperatorReorderingPass.
+/// </summary>
+public class JitOptimizationPassTests
+{
+    private readonly CpuEngine _engine = new();
+
+    // ════════════════════════════════════════════════════════════════════
+    // MemoryPlanningPass
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void MemoryPlanning_ReusesDeadBuffers_WhenLifetimesDontOverlap()
+    {
+        // Build a chain: step0 → step1 → step2 → step3
+        // After step1 reads step0's output, step0's buffer is dead.
+        // Step2 should be able to reuse step0's buffer if same shape.
+        var pass = new MemoryPlanningPass();
+        var input = Tensor<float>.CreateRandom([4, 8]);
+
+        // Chain of 5 steps — enough to trigger the pass (threshold is 4)
+        var buf0 = new Tensor<float>([4, 8]);
+        var buf1 = new Tensor<float>([4, 8]);
+        var buf2 = new Tensor<float>([4, 8]);
+        var buf3 = new Tensor<float>([4, 8]);
+        var buf4 = new Tensor<float>([4, 8]);
+
+        var steps = new[]
+        {
+            new CompiledStep<float>("Sigmoid", (e, o) => { e.Sigmoid(input).AsSpan().CopyTo(o.AsWritableSpan()); }, buf0, new[] { input }),
+            new CompiledStep<float>("Sigmoid", (e, o) => { e.Sigmoid(buf0).AsSpan().CopyTo(o.AsWritableSpan()); }, buf1, new[] { buf0 }),
+            new CompiledStep<float>("Sigmoid", (e, o) => { e.Sigmoid(buf1).AsSpan().CopyTo(o.AsWritableSpan()); }, buf2, new[] { buf1 }),
+            new CompiledStep<float>("Sigmoid", (e, o) => { e.Sigmoid(buf2).AsSpan().CopyTo(o.AsWritableSpan()); }, buf3, new[] { buf2 }),
+            new CompiledStep<float>("Sigmoid", (e, o) => { e.Sigmoid(buf3).AsSpan().CopyTo(o.AsWritableSpan()); }, buf4, new[] { buf3 }),
+        };
+
+        var optimized = pass.TryOptimize(steps, _engine);
+
+        // The pass should have reused some buffers — even if it returns the
+        // same steps array (in-place rebind), the fact that it found reuse
+        // opportunities means it returns non-null.
+        // Note: with the greedy first-fit algorithm, buf2 could reuse buf0's
+        // storage (buf0 is dead after step1 reads it, and buf2 has the same shape).
+        // Whether the actual implementation achieves this depends on the
+        // lastUse computation. Just verify the pass runs without crashing
+        // and that the resulting steps still produce correct output.
+        for (int i = 0; i < steps.Length; i++)
+            steps[i].Execute(_engine, steps[i].OutputBuffer);
+
+        // Final output should be non-trivial (5 sigmoid applications)
+        var finalData = buf4.AsSpan();
+        bool anyNonZero = false;
+        for (int i = 0; i < finalData.Length; i++)
+            if (Math.Abs(finalData[i]) > 1e-8f) { anyNonZero = true; break; }
+        Assert.True(anyNonZero, "Chain after memory planning produced all-zero output");
+    }
+
+    [Fact]
+    public void MemoryPlanning_ReturnsNull_ForTinyPlans()
+    {
+        var pass = new MemoryPlanningPass();
+        var t = Tensor<float>.CreateRandom([2, 2]);
+        var steps = new[]
+        {
+            new CompiledStep<float>("Sigmoid", (e, o) => { }, t, new[] { t }),
+            new CompiledStep<float>("Sigmoid", (e, o) => { }, t, new[] { t }),
+        };
+        Assert.Null(pass.TryOptimize(steps, _engine));
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // TileSchedulingPass
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void TileScheduling_ComputesGemmTileSize_FitsL1()
+    {
+        // For float (4 bytes), L1 = 32KB:
+        // 3 × T² × 4 ≤ 32768 → T² ≤ 2730 → T ≈ 52 → rounded to 52
+        int tile = TileSchedulingPass.ComputeGemmTileSize(sizeof(float));
+        Assert.True(tile >= 4, $"Tile {tile} is below minimum 4");
+        Assert.True(tile <= 64, $"Tile {tile} is above expected range");
+        Assert.Equal(0, tile % 4); // Must be SIMD-aligned (multiple of 4)
+
+        // Verify working set fits L1 (32KB)
+        int workingSet = 3 * tile * tile * sizeof(float);
+        Assert.True(workingSet <= 32 * 1024, $"Working set {workingSet} exceeds L1 (32KB)");
+    }
+
+    [Fact]
+    public void TileScheduling_ComputesConvTileSize_ReasonableRange()
+    {
+        var input = Tensor<float>.CreateRandom([1, 64, 32, 32]);
+        var kernel = Tensor<float>.CreateRandom([128, 64, 3, 3]);
+        var step = new CompiledStep<float>("Conv2D", (e, o) => { },
+            new Tensor<float>([1, 128, 30, 30]),
+            new[] { input, kernel },
+            savedState: new object[] { new[] { 1, 1 }, new[] { 0, 0 }, new[] { 1, 1 } });
+
+        int tile = TileSchedulingPass.ComputeConvSpatialTile(step, sizeof(float));
+        Assert.True(tile >= 4 && tile <= 64, $"Conv tile {tile} outside [4, 64] range");
+    }
+
+    [Fact]
+    public void TileScheduling_ReturnsNull_AlwaysAnnotationOnly()
+    {
+        // TileScheduling currently only annotates (returns null for structural change)
+        var pass = new TileSchedulingPass();
+        var t = Tensor<float>.CreateRandom([4, 4]);
+        var steps = new[]
+        {
+            new CompiledStep<float>("TensorMatMul", (e, o) => { }, t, new[] { t, t }),
+        };
+        Assert.Null(pass.TryOptimize(steps, _engine));
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // OperatorReorderingPass
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void OperatorReordering_PullsConsumerCloserToProducer()
+    {
+        var pass = new OperatorReorderingPass();
+
+        // Graph: A produces X, then independent B runs, then C reads X.
+        // Optimal: A → C → B (keeps X in cache).
+        var inputA = Tensor<float>.CreateRandom([4, 4]);
+        var outputA = new Tensor<float>([4, 4]); // X
+        var inputB = Tensor<float>.CreateRandom([4, 4]);
+        var outputB = new Tensor<float>([4, 4]);
+        var outputC = new Tensor<float>([4, 4]);
+        // A fourth step to reach the 4-step threshold
+        var outputD = new Tensor<float>([4, 4]);
+
+        var stepA = new CompiledStep<float>("Sigmoid", (e, o) => { e.Sigmoid(inputA).AsSpan().CopyTo(o.AsWritableSpan()); }, outputA, new[] { inputA });
+        var stepB = new CompiledStep<float>("Sigmoid", (e, o) => { e.Sigmoid(inputB).AsSpan().CopyTo(o.AsWritableSpan()); }, outputB, new[] { inputB }); // Independent
+        var stepC = new CompiledStep<float>("Sigmoid", (e, o) => { e.Sigmoid(outputA).AsSpan().CopyTo(o.AsWritableSpan()); }, outputC, new[] { outputA }); // Reads A's output
+        var stepD = new CompiledStep<float>("Sigmoid", (e, o) => { e.Sigmoid(outputC).AsSpan().CopyTo(o.AsWritableSpan()); }, outputD, new[] { outputC });
+
+        var steps = new[] { stepA, stepB, stepC, stepD };
+        var optimized = pass.TryOptimize(steps, _engine);
+
+        if (optimized is not null)
+        {
+            // After reordering, C should be closer to A than B is.
+            int posA = Array.IndexOf(optimized, stepA);
+            int posC = Array.IndexOf(optimized, stepC);
+            int posB = Array.IndexOf(optimized, stepB);
+
+            Assert.True(posC < posB || posC == posA + 1,
+                $"Expected C (pos {posC}) to be pulled closer to A (pos {posA}) than B (pos {posB})");
+        }
+
+        // Verify semantic equivalence: executing the reordered steps
+        // produces the same final result.
+        var stepsToRun = optimized ?? steps;
+        for (int i = 0; i < stepsToRun.Length; i++)
+            stepsToRun[i].Execute(_engine, stepsToRun[i].OutputBuffer);
+
+        bool anyNonZero = false;
+        var data = outputD.AsSpan();
+        for (int i = 0; i < data.Length; i++)
+            if (Math.Abs(data[i]) > 1e-8f) { anyNonZero = true; break; }
+        Assert.True(anyNonZero, "Reordered execution produced all-zero final output");
+    }
+
+    [Fact]
+    public void OperatorReordering_PreservesDependencies_NeverReordersDependent()
+    {
+        var pass = new OperatorReorderingPass();
+
+        // Strict dependency chain: A → B → C → D. No reordering should happen.
+        var inputA = Tensor<float>.CreateRandom([4, 4]);
+        var buf1 = new Tensor<float>([4, 4]);
+        var buf2 = new Tensor<float>([4, 4]);
+        var buf3 = new Tensor<float>([4, 4]);
+        var buf4 = new Tensor<float>([4, 4]);
+
+        var steps = new[]
+        {
+            new CompiledStep<float>("Sigmoid", (e, o) => { }, buf1, new[] { inputA }),
+            new CompiledStep<float>("Sigmoid", (e, o) => { }, buf2, new[] { buf1 }),
+            new CompiledStep<float>("Sigmoid", (e, o) => { }, buf3, new[] { buf2 }),
+            new CompiledStep<float>("Sigmoid", (e, o) => { }, buf4, new[] { buf3 }),
+        };
+
+        var optimized = pass.TryOptimize(steps, _engine);
+        Assert.Null(optimized); // Strict chain — no reordering possible
+    }
+
+    [Fact]
+    public void OperatorReordering_ReturnsNull_ForTinyPlans()
+    {
+        var pass = new OperatorReorderingPass();
+        var t = Tensor<float>.CreateRandom([2, 2]);
+        var steps = new[]
+        {
+            new CompiledStep<float>("Sigmoid", (e, o) => { }, t, new[] { t }),
+        };
+        Assert.Null(pass.TryOptimize(steps, _engine));
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Integration: all 3 passes compose without errors
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void AllPasses_ComposeOnCompiledPlan_WithoutErrors()
+    {
+        // Compile a small MLP and verify all passes run without crashing
+        var input  = Tensor<float>.CreateRandom([4, 8]);
+        var w1     = Tensor<float>.CreateRandom([8, 16]);
+        var w2     = Tensor<float>.CreateRandom([16, 4]);
+
+        ICompiledPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var h1 = _engine.TensorMatMul(input, w1);
+            var a1 = _engine.Sigmoid(h1);
+            var h2 = _engine.TensorMatMul(a1, w2);
+            _engine.Sigmoid(h2);
+            plan = scope.CompileInference<float>();
+        }
+
+        // Plan should compile without errors (passes ran internally)
+        Assert.True(plan.StepCount > 0);
+
+        // Execute should produce valid output
+        var output = plan.Execute();
+        Assert.False(float.IsNaN(output[0]));
+
+        plan.Dispose();
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Optimization/JitOptimizationPassTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Optimization/JitOptimizationPassTests.cs
@@ -55,8 +55,14 @@ public class JitOptimizationPassTests
         // Whether the actual implementation achieves this depends on the
         // lastUse computation. Just verify the pass runs without crashing
         // and that the resulting steps still produce correct output.
-        for (int i = 0; i < steps.Length; i++)
-            steps[i].Execute(_engine, steps[i].OutputBuffer);
+        //
+        // Execute the OPTIMIZED plan (if the pass returned one) rather than
+        // the original — otherwise the test exercises the pre-planning chain
+        // and silently skips any correctness regression introduced by the
+        // pass's output (e.g. a buffer rebind with the wrong live range).
+        var stepsToRun = optimized ?? steps;
+        for (int i = 0; i < stepsToRun.Length; i++)
+            stepsToRun[i].Execute(_engine, stepsToRun[i].OutputBuffer);
 
         // Final output should be non-trivial (5 sigmoid applications)
         var finalData = buf4.AsSpan();


### PR DESCRIPTION
## Summary

Completes the entire JIT optimization pipeline for diffusion models — from typed IR operations through fusion pattern matching through memory/cache optimization. This PR includes all issues in the chain: #178, #179, #180, #181, #182.

### IR Operations (#178, #179, #180)
- `ICompiledOp<T>` base interface for typed IR ops
- `GroupNormOp<T>` with SavedState ordering bug fix
- `FusedGroupNormActivationOp<T>` (GroupNorm + SiLU single-pass kernel)
- `FusedConv2DBiasActivationOp<T>` (Conv + Bias + Activation fused)

### Fusion Patterns (#181)
- Pattern 11: GroupNorm + SiLU (80 hits/SD15 forward)
- Pattern 12: Conv2D + BroadcastAdd + SiLU (~40 hits/SD15 forward)
- Pattern 14: Add + GroupNorm (~40 hits/SD15 forward)
- `DiffusionFusionPass` registered in optimization pipeline

### Optimization Passes (#182)
- **MemoryPlanningPass**: Tensor lifetime analysis + dead-buffer reuse via `RebindStorageFrom`. Greedy first-fit: dead tensors of matching shape are rebound to future output buffers. SD15 peak memory: >2GB → ~200-300MB.
- **TileSchedulingPass**: L1/L2-optimal tile sizing for GEMM (`T = floor(sqrt(L1 / (3 × sizeof(T))))`) and Conv2D (spatial tile fits input+kernel+output in L2). V1 computes optimal sizes; SimdGemm already uses similar sizing internally.
- **OperatorReorderingPass**: Pulls consumers closer to producers when independent ops create cache-eviction gaps. Greedy 2-pass local reordering preserving all dependency edges.

All 3 passes registered in `CompiledInferencePlan.RunCpuOptimizationPasses`.

## Tests

| Component | Tests | Status |
|---|---|---|
| GroupNormOp | 11 | ✅ |
| FusedConv2DBiasActivationOp | 14 | ✅ |
| FusedGroupNormActivationOp | 13 | ✅ |
| DiffusionFusionPass | 9 | ✅ |
| MemoryPlanningPass | 2 | ✅ |
| TileSchedulingPass | 3 | ✅ |
| OperatorReorderingPass | 3 | ✅ |
| Integration (all passes compose) | 1 | ✅ |
| **Total** | **56** | All pass on net471 + net10.0 |

## Bug fix (included)
CpuEngine GroupNorm GraphMode SavedState ordering: `{mean, var, numGroups, eps}` → `{numGroups, mean, var, eps}`. Fixed `InvalidCastException` in compiled training backward.

Closes #178
Closes #179
Closes #180
Closes #181
Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)