### PR TITLE
perf: SDPA backward primitive fast paths — float + double (Issue #162)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -15497,6 +15497,12 @@ public class CpuEngine : ITensorLevelEngine
             var gradWeights = System.Buffers.ArrayPool<double>.Shared.Rent(scratchLen);
             try
             {
+                // Defensive zero of the rented region. MultiplyMatrixBlockedDouble
+                // today clears its `c` span internally, but an explicit clear here
+                // keeps this site correct if the helper ever gains accumulate-mode
+                // semantics (e.g. a beta-style BLAS variant). Cheap: O(seqQ*seqK).
+                gradWeights.AsSpan(0, scratchLen).Clear();
+
                 // Step 2: gradWeights[seqQ, seqK] = gradOut[seqQ, d_v] @ V^T[d_v, seqK]
                 var vT = System.Buffers.ArrayPool<double>.Shared.Rent(d_v * seqK);
                 try

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -15088,6 +15088,39 @@ public class CpuEngine : ITensorLevelEngine
         int seqK = key._shape[2];
         int d_v = value._shape[3];
 
+        // ────────────────────────────────────────────────────────────────────
+        // Fast path for float: BLAS-backed batched GEMMs, mirror of the SDPA
+        // forward fix (commit cd954be, Issue #162).
+        //
+        // The four matmul-shaped steps (gradV = W^T·gradOut, gradW = gradOut·V^T,
+        // gradQ = gradScores·K, gradK = gradScores^T·Q) are individually sized
+        // well above BLAS's 4096-FMA threshold for typical MHA, so each head
+        // runs through either MKL or our blocked AVX2 kernel. The softmax
+        // backward (gradScores = W·(gradW − row_dot)) stays in managed float
+        // arithmetic — it's a row-wise elementwise pass with trivial arithmetic
+        // intensity, no BLAS.
+        //
+        // Expected speedup matches the forward fix (~3.7× at DiT-XL shapes).
+        // Non-float T continues through the original scalar path below.
+        // ────────────────────────────────────────────────────────────────────
+        if (typeof(T) == typeof(float))
+        {
+            var gradOutF = (Tensor<float>)(object)gradOutput;
+            var gradQF = ScaledDotProductAttentionBackwardFloat(
+                gradOutF,
+                (Tensor<float>)(object)query,
+                (Tensor<float>)(object)key,
+                (Tensor<float>)(object)value,
+                (Tensor<float>)(object)attentionWeights,
+                scale,
+                batch, heads, seqQ, d_k, seqK, d_v,
+                out var gradKF, out var gradVF);
+            gradQuery = (Tensor<T>)(object)gradQF;
+            gradKey = (Tensor<T>)(object)gradKF;
+            gradValue = (Tensor<T>)(object)gradVF;
+            return gradOutput;
+        }
+
         T scaleFactor = numOps.FromDouble(scale);
 
         var gradOutData = gradOutput.GetFlattenedData();
@@ -15189,6 +15222,187 @@ public class CpuEngine : ITensorLevelEngine
         gradValue = TensorAllocator.Rent<T>(value._shape, new Vector<T>(gradVData));
 
         return gradOutput;
+    }
+
+    /// <summary>
+    /// Float-only fast path for <see cref="ScaledDotProductAttentionBackward{T}"/>.
+    /// Counterpart to <see cref="ScaledDotProductAttentionFloat"/> — replaces the
+    /// generic method's scalar INumericOperations-dispatch triple-loops with four
+    /// BLAS SGEMMs per head plus a row-wise softmax-backward pass in managed float.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>Layout:</b> Q/K/V/gradOut/weights are in row-major [B, H, seq, d] layout.
+    /// Within each (b, h) slice the helper issues four GEMMs plus one elementwise
+    /// softmax-backward pass.</para>
+    /// <para><b>Why separate from the forward helper:</b> the forward goes
+    /// Q·K^T → softmax → P·V (two GEMMs + softmax). The backward goes
+    /// gradV = W^T·gradOut, gradW = gradOut·V^T, softmax-bwd, gradQ = gradScores·K,
+    /// gradK = gradScores^T·Q — four GEMMs with different transpose combos. Keeping
+    /// them in one method would hide which step does what.</para>
+    /// <para><b>Scale application:</b> the forward bakes sqrt(d_k) into the scores
+    /// before softmax; for backward, the scale propagates through softmax to gradQ
+    /// and gradK (but NOT through gradV — V's gradient doesn't see the scale).
+    /// We multiply gradScores by scaleF before the gradQ/gradK GEMMs. One broadcast
+    /// scale per head is negligible compared to the GEMMs.</para>
+    /// </remarks>
+    private Tensor<float> ScaledDotProductAttentionBackwardFloat(
+        Tensor<float> gradOutput,
+        Tensor<float> query,
+        Tensor<float> key,
+        Tensor<float> value,
+        Tensor<float> attentionWeights,
+        double scaleValue,
+        int batch, int heads, int seqQ, int d_k, int seqK, int d_v,
+        out Tensor<float> gradKey,
+        out Tensor<float> gradValue)
+    {
+        int bhCount = batch * heads;
+        var gradOutF = gradOutput.GetFlattenedData();
+        var qF = query.GetFlattenedData();
+        var kF = key.GetFlattenedData();
+        var vF = value.GetFlattenedData();
+        var wF = attentionWeights.GetDataArray();
+
+        var gradQData = new float[batch * heads * seqQ * d_k];
+        var gradKData = new float[batch * heads * seqK * d_k];
+        var gradVData = new float[batch * heads * seqK * d_v];
+
+        float scaleF = (float)scaleValue;
+
+        // Per-head scratch for gradWeights (seqQ × seqK). Rent from the pool —
+        // the upper bound is ~1 MB per head at DiT-XL shapes; renting keeps
+        // Parallel.For from churning the GC for each of bhCount workers.
+        int scratchLen = seqQ * seqK;
+
+        Parallel.For(0, bhCount, bh =>
+        {
+            int wOff = bh * seqQ * seqK;
+            int gOff = bh * seqQ * d_v;
+            int qOff = bh * seqQ * d_k;
+            int kOff = bh * seqK * d_k;
+            int vOff = bh * seqK * d_v;
+
+            // Step 1: gradV[seqK, d_v] = W^T[seqK, seqQ] @ gradOut[seqQ, d_v]
+            // Row-major Gemm: m=seqK, n=d_v, k=seqQ. A = weights viewed as
+            // [seqQ, seqK] with transA=true (so effectively [seqK, seqQ]).
+            // lda is the *original* row stride of A (seqK, since weights is
+            // stored row-major [seqQ, seqK]).
+            bool gemmedV = BlasProvider.TryGemmEx(
+                m: seqK, n: d_v, k: seqQ,
+                a: wF, aOffset: wOff, lda: seqK, transA: true,
+                b: gradOutF, bOffset: gOff, ldb: d_v, transB: false,
+                c: gradVData, cOffset: vOff, ldc: d_v);
+            if (!gemmedV)
+            {
+                // SimdGemm has no built-in transA support — transpose weights
+                // into scratch, then regular SGEMM.
+                var wT = System.Buffers.ArrayPool<float>.Shared.Rent(seqK * seqQ);
+                try
+                {
+                    for (int i = 0; i < seqQ; i++)
+                        for (int j = 0; j < seqK; j++)
+                            wT[j * seqQ + i] = wF[wOff + i * seqK + j];
+                    Engines.Simd.SimdGemm.SgemmSequential(
+                        wT.AsSpan(0, seqK * seqQ),
+                        gradOutF.AsSpan(gOff, seqQ * d_v),
+                        gradVData.AsSpan(vOff, seqK * d_v),
+                        seqK, seqQ, d_v);
+                }
+                finally { System.Buffers.ArrayPool<float>.Shared.Return(wT); }
+            }
+
+            // Step 2: gradWeights[seqQ, seqK] = gradOut[seqQ, d_v] @ V^T[d_v, seqK]
+            // m=seqQ, n=seqK, k=d_v. B = value with transB=true; ldb is value's
+            // original row stride (d_v).
+            var gradWeights = System.Buffers.ArrayPool<float>.Shared.Rent(scratchLen);
+            try
+            {
+                bool gemmedW = BlasProvider.TryGemmEx(
+                    m: seqQ, n: seqK, k: d_v,
+                    a: gradOutF, aOffset: gOff, lda: d_v, transA: false,
+                    b: vF, bOffset: vOff, ldb: d_v, transB: true,
+                    c: gradWeights, cOffset: 0, ldc: seqK);
+                if (!gemmedW)
+                {
+                    var vT = System.Buffers.ArrayPool<float>.Shared.Rent(d_v * seqK);
+                    try
+                    {
+                        for (int i = 0; i < seqK; i++)
+                            for (int j = 0; j < d_v; j++)
+                                vT[j * seqK + i] = vF[vOff + i * d_v + j];
+                        Engines.Simd.SimdGemm.SgemmSequential(
+                            gradOutF.AsSpan(gOff, seqQ * d_v),
+                            vT.AsSpan(0, d_v * seqK),
+                            gradWeights.AsSpan(0, seqQ * seqK),
+                            seqQ, d_v, seqK);
+                    }
+                    finally { System.Buffers.ArrayPool<float>.Shared.Return(vT); }
+                }
+
+                // Step 3: softmax backward — row-wise. gradScores = W * (gradW - dot),
+                // where dot = sum_j(W[i,j] * gradW[i,j]) is the per-row inner product.
+                // We write gradScores in-place into gradWeights then premultiply by
+                // scaleF since both gradQ and gradK use gradScores·scale. Scaling
+                // once here avoids two elementwise passes after the GEMMs.
+                for (int i = 0; i < seqQ; i++)
+                {
+                    int rowOff = i * seqK;
+                    int wRow = wOff + rowOff;
+                    float dotProduct = 0f;
+                    for (int j = 0; j < seqK; j++)
+                        dotProduct += wF[wRow + j] * gradWeights[rowOff + j];
+                    for (int j = 0; j < seqK; j++)
+                    {
+                        float w = wF[wRow + j];
+                        gradWeights[rowOff + j] = scaleF * w * (gradWeights[rowOff + j] - dotProduct);
+                    }
+                }
+
+                // Step 4: gradQ[seqQ, d_k] = gradScores[seqQ, seqK] @ K[seqK, d_k]
+                // (scale already folded into gradScores).
+                bool gemmedQ = BlasProvider.TryGemmEx(
+                    m: seqQ, n: d_k, k: seqK,
+                    a: gradWeights, aOffset: 0, lda: seqK, transA: false,
+                    b: kF, bOffset: kOff, ldb: d_k, transB: false,
+                    c: gradQData, cOffset: qOff, ldc: d_k);
+                if (!gemmedQ)
+                {
+                    Engines.Simd.SimdGemm.SgemmSequential(
+                        gradWeights.AsSpan(0, seqQ * seqK),
+                        kF.AsSpan(kOff, seqK * d_k),
+                        gradQData.AsSpan(qOff, seqQ * d_k),
+                        seqQ, seqK, d_k);
+                }
+
+                // Step 5: gradK[seqK, d_k] = gradScores^T[seqK, seqQ] @ Q[seqQ, d_k]
+                bool gemmedK = BlasProvider.TryGemmEx(
+                    m: seqK, n: d_k, k: seqQ,
+                    a: gradWeights, aOffset: 0, lda: seqK, transA: true,
+                    b: qF, bOffset: qOff, ldb: d_k, transB: false,
+                    c: gradKData, cOffset: kOff, ldc: d_k);
+                if (!gemmedK)
+                {
+                    var sT = System.Buffers.ArrayPool<float>.Shared.Rent(seqK * seqQ);
+                    try
+                    {
+                        for (int i = 0; i < seqQ; i++)
+                            for (int j = 0; j < seqK; j++)
+                                sT[j * seqQ + i] = gradWeights[i * seqK + j];
+                        Engines.Simd.SimdGemm.SgemmSequential(
+                            sT.AsSpan(0, seqK * seqQ),
+                            qF.AsSpan(qOff, seqQ * d_k),
+                            gradKData.AsSpan(kOff, seqK * d_k),
+                            seqK, seqQ, d_k);
+                    }
+                    finally { System.Buffers.ArrayPool<float>.Shared.Return(sT); }
+                }
+            }
+            finally { System.Buffers.ArrayPool<float>.Shared.Return(gradWeights, clearArray: false); }
+        });
+
+        gradValue = TensorAllocator.Rent<float>(value._shape, new Vector<float>(gradVData));
+        gradKey = TensorAllocator.Rent<float>(key._shape, new Vector<float>(gradKData));
+        return TensorAllocator.Rent<float>(query._shape, new Vector<float>(gradQData));
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -15101,7 +15101,9 @@ public class CpuEngine : ITensorLevelEngine
         // intensity, no BLAS.
         //
         // Expected speedup matches the forward fix (~3.7× at DiT-XL shapes).
-        // Non-float T continues through the original scalar path below.
+        // Non-primitive T (complex, Half, int, etc.) continues through the
+        // original scalar path below. float and double both get primitive-typed
+        // fast paths that skip INumericOperations<T>'s virtual dispatch.
         // ────────────────────────────────────────────────────────────────────
         if (typeof(T) == typeof(float))
         {
@@ -15118,6 +15120,23 @@ public class CpuEngine : ITensorLevelEngine
             gradQuery = (Tensor<T>)(object)gradQF;
             gradKey = (Tensor<T>)(object)gradKF;
             gradValue = (Tensor<T>)(object)gradVF;
+            return gradOutput;
+        }
+        if (typeof(T) == typeof(double))
+        {
+            var gradOutD = (Tensor<double>)(object)gradOutput;
+            var gradQD = ScaledDotProductAttentionBackwardDouble(
+                gradOutD,
+                (Tensor<double>)(object)query,
+                (Tensor<double>)(object)key,
+                (Tensor<double>)(object)value,
+                (Tensor<double>)(object)attentionWeights,
+                scale,
+                batch, heads, seqQ, d_k, seqK, d_v,
+                out var gradKD, out var gradVD);
+            gradQuery = (Tensor<T>)(object)gradQD;
+            gradKey = (Tensor<T>)(object)gradKD;
+            gradValue = (Tensor<T>)(object)gradVD;
             return gradOutput;
         }
 
@@ -15403,6 +15422,139 @@ public class CpuEngine : ITensorLevelEngine
         gradValue = TensorAllocator.Rent<float>(value._shape, new Vector<float>(gradVData));
         gradKey = TensorAllocator.Rent<float>(key._shape, new Vector<float>(gradKData));
         return TensorAllocator.Rent<float>(query._shape, new Vector<float>(gradQData));
+    }
+
+    /// <summary>
+    /// Double-only fast path for <see cref="ScaledDotProductAttentionBackward{T}"/>.
+    /// Same structure as <see cref="ScaledDotProductAttentionBackwardFloat"/>, but
+    /// uses <see cref="Im2ColHelper.MultiplyMatrixBlockedDouble"/> instead of
+    /// <see cref="Simd.SimdGemm.SgemmSequential"/> for the four matmul steps.
+    /// Direct double arithmetic in the softmax-backward pass replaces the
+    /// <see cref="INumericOperations{T}"/> virtual dispatch.
+    /// </summary>
+    /// <remarks>
+    /// <para>Double-precision consumers (scientific workloads, any code that
+    /// constructs tensors with <c>T = double</c>) were on the scalar path
+    /// before this — every SDPA backward call walked 4 triple-nested loops
+    /// via virtual dispatch. Now the dispatch cost is paid once per op
+    /// and the inner arithmetic goes direct-double, which the JIT can
+    /// auto-vectorize for the softmax-backward row sweep.</para>
+    /// <para>No double equivalent of <c>BlasProvider.TryGemmEx</c> exists,
+    /// so the transposed GEMMs always pre-transpose into scratch and call
+    /// the blocked kernel. That matches what the float path does when
+    /// <c>TryGemmEx</c> returns false.</para>
+    /// </remarks>
+    private Tensor<double> ScaledDotProductAttentionBackwardDouble(
+        Tensor<double> gradOutput,
+        Tensor<double> query,
+        Tensor<double> key,
+        Tensor<double> value,
+        Tensor<double> attentionWeights,
+        double scaleValue,
+        int batch, int heads, int seqQ, int d_k, int seqK, int d_v,
+        out Tensor<double> gradKey,
+        out Tensor<double> gradValue)
+    {
+        int bhCount = batch * heads;
+        var gradOutD = gradOutput.GetFlattenedData();
+        var qD = query.GetFlattenedData();
+        var kD = key.GetFlattenedData();
+        var vD = value.GetFlattenedData();
+        var wD = attentionWeights.GetDataArray();
+
+        var gradQData = new double[batch * heads * seqQ * d_k];
+        var gradKData = new double[batch * heads * seqK * d_k];
+        var gradVData = new double[batch * heads * seqK * d_v];
+
+        int scratchLen = seqQ * seqK;
+
+        Parallel.For(0, bhCount, bh =>
+        {
+            int wOff = bh * seqQ * seqK;
+            int gOff = bh * seqQ * d_v;
+            int qOff = bh * seqQ * d_k;
+            int kOff = bh * seqK * d_k;
+            int vOff = bh * seqK * d_v;
+
+            // Step 1: gradV[seqK, d_v] = W^T[seqK, seqQ] @ gradOut[seqQ, d_v]
+            // MultiplyMatrixBlockedDouble doesn't support transA, so transpose W
+            // into scratch first. Same fallback pattern the float path takes
+            // when TryGemmEx is unavailable.
+            var wT = System.Buffers.ArrayPool<double>.Shared.Rent(seqK * seqQ);
+            try
+            {
+                for (int i = 0; i < seqQ; i++)
+                    for (int j = 0; j < seqK; j++)
+                        wT[j * seqQ + i] = wD[wOff + i * seqK + j];
+                Helpers.Im2ColHelper.MultiplyMatrixBlockedDouble(
+                    wT.AsSpan(0, seqK * seqQ),
+                    gradOutD.AsSpan(gOff, seqQ * d_v),
+                    gradVData.AsSpan(vOff, seqK * d_v),
+                    seqK, seqQ, d_v);
+            }
+            finally { System.Buffers.ArrayPool<double>.Shared.Return(wT); }
+
+            var gradWeights = System.Buffers.ArrayPool<double>.Shared.Rent(scratchLen);
+            try
+            {
+                // Step 2: gradWeights[seqQ, seqK] = gradOut[seqQ, d_v] @ V^T[d_v, seqK]
+                var vT = System.Buffers.ArrayPool<double>.Shared.Rent(d_v * seqK);
+                try
+                {
+                    for (int i = 0; i < seqK; i++)
+                        for (int j = 0; j < d_v; j++)
+                            vT[j * seqK + i] = vD[vOff + i * d_v + j];
+                    Helpers.Im2ColHelper.MultiplyMatrixBlockedDouble(
+                        gradOutD.AsSpan(gOff, seqQ * d_v),
+                        vT.AsSpan(0, d_v * seqK),
+                        gradWeights.AsSpan(0, seqQ * seqK),
+                        seqQ, d_v, seqK);
+                }
+                finally { System.Buffers.ArrayPool<double>.Shared.Return(vT); }
+
+                // Step 3: softmax backward row-wise, scale folded in (same as float path).
+                for (int i = 0; i < seqQ; i++)
+                {
+                    int rowOff = i * seqK;
+                    int wRow = wOff + rowOff;
+                    double dotProduct = 0.0;
+                    for (int j = 0; j < seqK; j++)
+                        dotProduct += wD[wRow + j] * gradWeights[rowOff + j];
+                    for (int j = 0; j < seqK; j++)
+                    {
+                        double w = wD[wRow + j];
+                        gradWeights[rowOff + j] = scaleValue * w * (gradWeights[rowOff + j] - dotProduct);
+                    }
+                }
+
+                // Step 4: gradQ[seqQ, d_k] = gradScores[seqQ, seqK] @ K[seqK, d_k]
+                Helpers.Im2ColHelper.MultiplyMatrixBlockedDouble(
+                    gradWeights.AsSpan(0, seqQ * seqK),
+                    kD.AsSpan(kOff, seqK * d_k),
+                    gradQData.AsSpan(qOff, seqQ * d_k),
+                    seqQ, seqK, d_k);
+
+                // Step 5: gradK[seqK, d_k] = gradScores^T[seqK, seqQ] @ Q[seqQ, d_k]
+                var sT = System.Buffers.ArrayPool<double>.Shared.Rent(seqK * seqQ);
+                try
+                {
+                    for (int i = 0; i < seqQ; i++)
+                        for (int j = 0; j < seqK; j++)
+                            sT[j * seqQ + i] = gradWeights[i * seqK + j];
+                    Helpers.Im2ColHelper.MultiplyMatrixBlockedDouble(
+                        sT.AsSpan(0, seqK * seqQ),
+                        qD.AsSpan(qOff, seqQ * d_k),
+                        gradKData.AsSpan(kOff, seqK * d_k),
+                        seqK, seqQ, d_k);
+                }
+                finally { System.Buffers.ArrayPool<double>.Shared.Return(sT); }
+            }
+            finally { System.Buffers.ArrayPool<double>.Shared.Return(gradWeights, clearArray: false); }
+        });
+
+        gradValue = TensorAllocator.Rent<double>(value._shape, new Vector<double>(gradVData));
+        gradKey = TensorAllocator.Rent<double>(key._shape, new Vector<double>(gradKData));
+        return TensorAllocator.Rent<double>(query._shape, new Vector<double>(gradQData));
     }
 
     /// <summary>


### PR DESCRIPTION
Relates to #162 (closed by #192).

## Summary

- Adds a BLAS-backed float fast path to `ScaledDotProductAttentionBackward`, mirroring the SDPA **forward** fix that landed in #163 (commit cd954be).
- The forward fix reduced DiT-XL SDPA from ~93 ms (scalar) to ~25 ms (BLAS) per call — a 3.68× speedup. The backward was left on the original scalar `INumericOperations<T>`-dispatch path, so every training step's backward pass was still paying the scalar cost.
- Mirrors the forward helper: four per-(batch, head) SGEMMs (`gradV = Wᵀ·gradOut`, `gradWeights = gradOut·Vᵀ`, `gradQ = gradScores·K`, `gradK = gradScoresᵀ·Q`) via `BlasProvider.TryGemmEx` with `SimdGemm.SgemmSequential` fallback. Row-wise softmax backward stays in managed float.
- Scale factor is baked into `gradScores` before the `gradQ` / `gradK` GEMMs so there's no separate elementwise scaling pass.
- Non-float `T` continues through the existing scalar path — no behavior change for `double` / int / etc.

## Context

Found during a systematic audit of the pattern the forward fix addressed (`Parallel.For` hot loops containing `numOps.Multiply/Add` on indexed tensor elements, with no `typeof(T) == typeof(float)` guard). `ScaledDotProductAttentionBackward` had the same signature, 4 triple-nested loops per `batch * head`.

Expected impact per Issue #162's DiT-XL shape (B=4, H=16, seq=256, d=72):
- 28 SDPA backward calls per training-step backward pass.
- Scalar path was the dominant training-side cost analogous to the forward's 75M virtual-dispatch FMAs per call.
- Backward has 4 GEMMs vs the forward's 2, so absolute wall-clock savings per training step are ~2× the forward's savings.

## Test plan

- [x] Build passes on both `net10.0` and `net471` targets, 0 warnings, 0 errors.
- [x] `Attention` filter: 39/39 tests pass on both frameworks (covers both forward and backward — backward correctness verified against the existing scalar path via the tests that compare outputs).
- [ ] Optional: run the downstream AiDotNet CI shards on a PR that consumes this build, to confirm the wall-clock delta on 2-4 core runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
