### PR TITLE
perf: GroupNormBackward primitive fast paths — float + double (Issue #162)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -14476,7 +14476,6 @@ public class CpuEngine : ITensorLevelEngine
         }
 
         int groupSize = channelsPerGroup * spatialSize;
-        T groupSizeT = numOps.FromDouble(groupSize);
 
         var gradOutputData = gradOutput.GetDataArray();
         var inputData = input.GetFlattenedData();
@@ -14488,77 +14487,181 @@ public class CpuEngine : ITensorLevelEngine
         var gradBetaData = new T[channels];
         var gradInputData = new T[input.Length];
 
-        // Initialize gradGamma and gradBeta to zero
-        for (int c = 0; c < channels; c++)
+        // ────────────────────────────────────────────────────────────────────
+        // Float fast path: direct float arithmetic, no virtual dispatch.
+        // Mirror of the GroupNorm forward's typeof(T) == typeof(float) branch.
+        // Diffusion UNet training pays this cost on every backward pass — SD15
+        // UNet has ~40 GroupNorm layers and backward runs through all of them
+        // per training step.
+        // ────────────────────────────────────────────────────────────────────
+        if (typeof(T) == typeof(float))
         {
-            gradGammaData[c] = numOps.Zero;
-            gradBetaData[c] = numOps.Zero;
-        }
+            var fGradOut = (float[])(object)gradOutputData;
+            var fInput = (float[])(object)inputData;
+            var fGamma = (float[])(object)gammaData;
+            var fMean = (float[])(object)meanData;
+            var fVar = (float[])(object)varData;
+            var fGradGamma = (float[])(object)gradGammaData;
+            var fGradBeta = (float[])(object)gradBetaData;
+            var fGradInput = (float[])(object)gradInputData;
+            float fEps = (float)epsilon;
+            float groupSizeF = groupSize;
+            float invGroupSizeF = 1f / groupSizeF;
 
-        // Compute gradGamma and gradBeta (sum across batch and spatial)
-        for (int b = 0; b < batch; b++)
+            // gradGamma / gradBeta: sum across (batch, spatial). Sequential
+            // across batches to avoid per-channel accumulator contention, but
+            // spatial inner loop runs on direct floats. We pre-compute invStd
+            // once per (b, g) to avoid recomputing inside the spatial loop.
+            for (int b = 0; b < batch; b++)
+            {
+                for (int g = 0; g < numGroups; g++)
+                {
+                    float groupMean = fMean[b * numGroups + g];
+                    float invStd = 1f / MathF.Sqrt(fVar[b * numGroups + g] + fEps);
+                    int startChannel = g * channelsPerGroup;
+                    for (int c = 0; c < channelsPerGroup; c++)
+                    {
+                        int channel = startChannel + c;
+                        int chanOffset = b * (channels * spatialSize) + channel * spatialSize;
+                        float gammaAcc = 0f;
+                        float betaAcc = 0f;
+                        for (int s = 0; s < spatialSize; s++)
+                        {
+                            float go = fGradOut[chanOffset + s];
+                            float normalized = (fInput[chanOffset + s] - groupMean) * invStd;
+                            gammaAcc += go * normalized;
+                            betaAcc += go;
+                        }
+                        fGradGamma[channel] += gammaAcc;
+                        fGradBeta[channel] += betaAcc;
+                    }
+                }
+            }
+
+            // gradInput: parallel over batch. Each batch writes a disjoint
+            // [b*channels*spatialSize, (b+1)*channels*spatialSize) slice.
+            void ProcessBatch(int b)
+            {
+                for (int g = 0; g < numGroups; g++)
+                {
+                    float groupMean = fMean[b * numGroups + g];
+                    float invStd = 1f / MathF.Sqrt(fVar[b * numGroups + g] + fEps);
+                    int startChannel = g * channelsPerGroup;
+
+                    // Pass 1: sumGrad and sumGradNorm over the group.
+                    float sumGrad = 0f;
+                    float sumGradNorm = 0f;
+                    for (int c = 0; c < channelsPerGroup; c++)
+                    {
+                        int channel = startChannel + c;
+                        int chanOffset = b * (channels * spatialSize) + channel * spatialSize;
+                        float gammaC = fGamma[channel];
+                        for (int s = 0; s < spatialSize; s++)
+                        {
+                            float scaledGrad = gammaC * fGradOut[chanOffset + s];
+                            float normalized = (fInput[chanOffset + s] - groupMean) * invStd;
+                            sumGrad += scaledGrad;
+                            sumGradNorm += scaledGrad * normalized;
+                        }
+                    }
+
+                    // Pass 2: write gradInput.
+                    float scale = invStd * invGroupSizeF;
+                    for (int c = 0; c < channelsPerGroup; c++)
+                    {
+                        int channel = startChannel + c;
+                        int chanOffset = b * (channels * spatialSize) + channel * spatialSize;
+                        float gammaC = fGamma[channel];
+                        for (int s = 0; s < spatialSize; s++)
+                        {
+                            float normalized = (fInput[chanOffset + s] - groupMean) * invStd;
+                            float gradNorm = gammaC * fGradOut[chanOffset + s];
+                            float term1 = groupSizeF * gradNorm;
+                            float term3 = normalized * sumGradNorm;
+                            fGradInput[chanOffset + s] = scale * (term1 - sumGrad - term3);
+                        }
+                    }
+                }
+            }
+
+            // Batch typically small (1–16) for diffusion training, but each
+            // batch's work is large (channels × spatialSize). Always parallel.
+            Parallel.For(0, batch, ProcessBatch);
+        }
+        else
         {
+            T groupSizeT = numOps.FromDouble(groupSize);
+
+            // Initialize gradGamma and gradBeta to zero
             for (int c = 0; c < channels; c++)
             {
-                int g = c / channelsPerGroup;
-                T groupMean = meanData[b * numGroups + g];
-                T groupVar = varData[b * numGroups + g];
-                T invStd = numOps.Divide(numOps.One, numOps.Sqrt(numOps.Add(groupVar, eps)));
-
-                for (int s = 0; s < spatialSize; s++)
-                {
-                    int idx = b * (channels * spatialSize) + c * spatialSize + s;
-                    T normalized = numOps.Multiply(numOps.Subtract(inputData[idx], groupMean), invStd);
-                    gradGammaData[c] = numOps.Add(gradGammaData[c], numOps.Multiply(gradOutputData[idx], normalized));
-                    gradBetaData[c] = numOps.Add(gradBetaData[c], gradOutputData[idx]);
-                }
+                gradGammaData[c] = numOps.Zero;
+                gradBetaData[c] = numOps.Zero;
             }
-        }
 
-        // Compute gradInput using the group norm backward formula
-        Parallel.For(0, batch, b =>
-        {
-            for (int g = 0; g < numGroups; g++)
+            // Compute gradGamma and gradBeta (sum across batch and spatial)
+            for (int b = 0; b < batch; b++)
             {
-                T groupMean = meanData[b * numGroups + g];
-                T groupVar = varData[b * numGroups + g];
-                T invStd = numOps.Divide(numOps.One, numOps.Sqrt(numOps.Add(groupVar, eps)));
-
-                // Compute sum of scaled gradients and sum of scaled gradients times normalized values for this group
-                T sumGrad = numOps.Zero;
-                T sumGradNorm = numOps.Zero;
-
-                int startChannel = g * channelsPerGroup;
-                for (int c = 0; c < channelsPerGroup; c++)
+                for (int c = 0; c < channels; c++)
                 {
-                    int channel = startChannel + c;
+                    int g = c / channelsPerGroup;
+                    T groupMean = meanData[b * numGroups + g];
+                    T groupVar = varData[b * numGroups + g];
+                    T invStd = numOps.Divide(numOps.One, numOps.Sqrt(numOps.Add(groupVar, eps)));
+
                     for (int s = 0; s < spatialSize; s++)
                     {
-                        int idx = b * (channels * spatialSize) + channel * spatialSize + s;
-                        T scaledGrad = numOps.Multiply(gammaData[channel], gradOutputData[idx]);
+                        int idx = b * (channels * spatialSize) + c * spatialSize + s;
                         T normalized = numOps.Multiply(numOps.Subtract(inputData[idx], groupMean), invStd);
-                        sumGrad = numOps.Add(sumGrad, scaledGrad);
-                        sumGradNorm = numOps.Add(sumGradNorm, numOps.Multiply(scaledGrad, normalized));
-                    }
-                }
-
-                // Compute gradient for each element in this group
-                for (int c = 0; c < channelsPerGroup; c++)
-                {
-                    int channel = startChannel + c;
-                    for (int s = 0; s < spatialSize; s++)
-                    {
-                        int idx = b * (channels * spatialSize) + channel * spatialSize + s;
-                        T normalized = numOps.Multiply(numOps.Subtract(inputData[idx], groupMean), invStd);
-                        T gradNorm = numOps.Multiply(gammaData[channel], gradOutputData[idx]);
-                        T term1 = numOps.Multiply(groupSizeT, gradNorm);
-                        T term2 = sumGrad;
-                        T term3 = numOps.Multiply(normalized, sumGradNorm);
-                        gradInputData[idx] = numOps.Multiply(numOps.Divide(invStd, groupSizeT), numOps.Subtract(numOps.Subtract(term1, term2), term3));
+                        gradGammaData[c] = numOps.Add(gradGammaData[c], numOps.Multiply(gradOutputData[idx], normalized));
+                        gradBetaData[c] = numOps.Add(gradBetaData[c], gradOutputData[idx]);
                     }
                 }
             }
-        });
+
+            // Compute gradInput using the group norm backward formula
+            Parallel.For(0, batch, b =>
+            {
+                for (int g = 0; g < numGroups; g++)
+                {
+                    T groupMean = meanData[b * numGroups + g];
+                    T groupVar = varData[b * numGroups + g];
+                    T invStd = numOps.Divide(numOps.One, numOps.Sqrt(numOps.Add(groupVar, eps)));
+
+                    T sumGrad = numOps.Zero;
+                    T sumGradNorm = numOps.Zero;
+
+                    int startChannel = g * channelsPerGroup;
+                    for (int c = 0; c < channelsPerGroup; c++)
+                    {
+                        int channel = startChannel + c;
+                        for (int s = 0; s < spatialSize; s++)
+                        {
+                            int idx = b * (channels * spatialSize) + channel * spatialSize + s;
+                            T scaledGrad = numOps.Multiply(gammaData[channel], gradOutputData[idx]);
+                            T normalized = numOps.Multiply(numOps.Subtract(inputData[idx], groupMean), invStd);
+                            sumGrad = numOps.Add(sumGrad, scaledGrad);
+                            sumGradNorm = numOps.Add(sumGradNorm, numOps.Multiply(scaledGrad, normalized));
+                        }
+                    }
+
+                    for (int c = 0; c < channelsPerGroup; c++)
+                    {
+                        int channel = startChannel + c;
+                        for (int s = 0; s < spatialSize; s++)
+                        {
+                            int idx = b * (channels * spatialSize) + channel * spatialSize + s;
+                            T normalized = numOps.Multiply(numOps.Subtract(inputData[idx], groupMean), invStd);
+                            T gradNorm = numOps.Multiply(gammaData[channel], gradOutputData[idx]);
+                            T term1 = numOps.Multiply(groupSizeT, gradNorm);
+                            T term2 = sumGrad;
+                            T term3 = numOps.Multiply(normalized, sumGradNorm);
+                            gradInputData[idx] = numOps.Multiply(numOps.Divide(invStd, groupSizeT), numOps.Subtract(numOps.Subtract(term1, term2), term3));
+                        }
+                    }
+                }
+            });
+        }
 
         gradGamma = TensorAllocator.Rent<T>([channels], new Vector<T>(gradGammaData));
         gradBeta = TensorAllocator.Rent<T>([channels], new Vector<T>(gradBetaData));

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -14488,11 +14488,13 @@ public class CpuEngine : ITensorLevelEngine
         var gradInputData = new T[input.Length];
 
         // ────────────────────────────────────────────────────────────────────
-        // Float fast path: direct float arithmetic, no virtual dispatch.
-        // Mirror of the GroupNorm forward's typeof(T) == typeof(float) branch.
+        // Primitive fast paths: direct float/double arithmetic, no
+        // INumericOperations<T> virtual dispatch. Method signature stays
+        // generic <T>; non-primitive T falls through to the scalar path.
+        //
         // Diffusion UNet training pays this cost on every backward pass — SD15
         // UNet has ~40 GroupNorm layers and backward runs through all of them
-        // per training step.
+        // per training step. Consumers using T = double get the same treatment.
         // ────────────────────────────────────────────────────────────────────
         if (typeof(T) == typeof(float))
         {
@@ -14587,6 +14589,89 @@ public class CpuEngine : ITensorLevelEngine
             // Batch typically small (1–16) for diffusion training, but each
             // batch's work is large (channels × spatialSize). Always parallel.
             Parallel.For(0, batch, ProcessBatch);
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            var dGradOut = (double[])(object)gradOutputData;
+            var dInput = (double[])(object)inputData;
+            var dGamma = (double[])(object)gammaData;
+            var dMean = (double[])(object)meanData;
+            var dVar = (double[])(object)varData;
+            var dGradGamma = (double[])(object)gradGammaData;
+            var dGradBeta = (double[])(object)gradBetaData;
+            var dGradInput = (double[])(object)gradInputData;
+            double groupSizeD = groupSize;
+            double invGroupSizeD = 1.0 / groupSizeD;
+
+            for (int b = 0; b < batch; b++)
+            {
+                for (int g = 0; g < numGroups; g++)
+                {
+                    double groupMean = dMean[b * numGroups + g];
+                    double invStd = 1.0 / Math.Sqrt(dVar[b * numGroups + g] + epsilon);
+                    int startChannel = g * channelsPerGroup;
+                    for (int c = 0; c < channelsPerGroup; c++)
+                    {
+                        int channel = startChannel + c;
+                        int chanOffset = b * (channels * spatialSize) + channel * spatialSize;
+                        double gammaAcc = 0.0;
+                        double betaAcc = 0.0;
+                        for (int s = 0; s < spatialSize; s++)
+                        {
+                            double go = dGradOut[chanOffset + s];
+                            double normalized = (dInput[chanOffset + s] - groupMean) * invStd;
+                            gammaAcc += go * normalized;
+                            betaAcc += go;
+                        }
+                        dGradGamma[channel] += gammaAcc;
+                        dGradBeta[channel] += betaAcc;
+                    }
+                }
+            }
+
+            void ProcessBatchD(int b)
+            {
+                for (int g = 0; g < numGroups; g++)
+                {
+                    double groupMean = dMean[b * numGroups + g];
+                    double invStd = 1.0 / Math.Sqrt(dVar[b * numGroups + g] + epsilon);
+                    int startChannel = g * channelsPerGroup;
+
+                    double sumGrad = 0.0;
+                    double sumGradNorm = 0.0;
+                    for (int c = 0; c < channelsPerGroup; c++)
+                    {
+                        int channel = startChannel + c;
+                        int chanOffset = b * (channels * spatialSize) + channel * spatialSize;
+                        double gammaC = dGamma[channel];
+                        for (int s = 0; s < spatialSize; s++)
+                        {
+                            double scaledGrad = gammaC * dGradOut[chanOffset + s];
+                            double normalized = (dInput[chanOffset + s] - groupMean) * invStd;
+                            sumGrad += scaledGrad;
+                            sumGradNorm += scaledGrad * normalized;
+                        }
+                    }
+
+                    double scale = invStd * invGroupSizeD;
+                    for (int c = 0; c < channelsPerGroup; c++)
+                    {
+                        int channel = startChannel + c;
+                        int chanOffset = b * (channels * spatialSize) + channel * spatialSize;
+                        double gammaC = dGamma[channel];
+                        for (int s = 0; s < spatialSize; s++)
+                        {
+                            double normalized = (dInput[chanOffset + s] - groupMean) * invStd;
+                            double gradNorm = gammaC * dGradOut[chanOffset + s];
+                            double term1 = groupSizeD * gradNorm;
+                            double term3 = normalized * sumGradNorm;
+                            dGradInput[chanOffset + s] = scale * (term1 - sumGrad - term3);
+                        }
+                    }
+                }
+            }
+
+            Parallel.For(0, batch, ProcessBatchD);
         }
         else
         {


### PR DESCRIPTION
## Summary

- Adds the float fast path to \`GroupNormBackward\`. The forward already had one; the backward was still walking every element through \`INumericOperations<T>\` virtual dispatch.
- Direct consumer: diffusion UNet training. SD15 UNet has ~40 GroupNorm layers, all hit on every backward pass of every training step.
- Non-float \`T\` continues through the existing scalar path.

## Structure

Mirrors the original scalar backward's two-phase shape:
1. \`gradGamma\` / \`gradBeta\` — sequential across (b, g) since they accumulate into the shared \`[channels]\` buffers. Inner spatial loop runs direct float. Per-(b, g) \`invStd\` is lifted out of the spatial loop to avoid redundant \`MathF.Sqrt\`.
2. \`gradInput\` — \`Parallel.For\` over batch. Each batch writes a disjoint slice so no cross-thread contention. Two-pass per batch: pass 1 computes \`sumGrad\` / \`sumGradNorm\` per group; pass 2 writes \`gradInput\`. The \`invStd * invGroupSize\` combination is hoisted into a single \`scale\` to save one multiply per element.

## Context

Part of the Issue #162 audit. Third of four Tier-1 fixes (after #189 SDPA backward and #190 LayerNormBackward). RMSNormBackward (same pattern, LLaMA-style models) is next.

## Test plan

- [x] Build passes on both \`net10.0\` and \`net471\`, 0 warnings, 0 errors.
- [x] GroupNorm tests: 32/32 pass on both frameworks.
- [ ] Downstream CI: will confirm wall-clock delta on diffusion training shards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)