### PR TITLE
perf: primitive fast paths for remaining audit ops + net471 SIMD gap (Issue #162)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -9196,31 +9196,73 @@ public class CpuEngine : ITensorLevelEngine
         var gradInputData = result.GetDataArray();
         var gradOutputData = gradOutput.GetFlattenedData();
 
-        // Initialize to zero
-        for (int i = 0; i < gradInputData.Length; i++)
-            gradInputData[i] = numOps.Zero;
-
-        // Note: Cannot parallelize across batch*channels because multiple output positions
-        // may map to the same input position within a channel. Parallelize across batches only.
-        Parallel.For(0, batch, b =>
+        // Cannot parallelize across (batch, channel) pairs because for MaxPool with
+        // overlapping windows, multiple output positions may scatter to the same
+        // input index within a channel. Parallel over batches is safe.
+        if (typeof(T) == typeof(float))
         {
-            for (int c = 0; c < channels; c++)
+            var fGradIn = (float[])(object)gradInputData;
+            var fGradOut = (float[])(object)gradOutputData;
+            Array.Clear(fGradIn, 0, fGradIn.Length);
+            Parallel.For(0, batch, b =>
             {
-                for (int oh = 0; oh < outputHeight; oh++)
+                for (int c = 0; c < channels; c++)
+                    for (int oh = 0; oh < outputHeight; oh++)
+                        for (int ow = 0; ow < outputWidth; ow++)
+                        {
+                            int maxH = maxIndices[b, c, oh, ow, 0];
+                            int maxW = maxIndices[b, c, oh, ow, 1];
+                            int gradOutIdx = ((b * channels + c) * outputHeight + oh) * outputWidth + ow;
+                            int gradInIdx = ((b * channels + c) * height + maxH) * width + maxW;
+                            fGradIn[gradInIdx] += fGradOut[gradOutIdx];
+                        }
+            });
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            var dGradIn = (double[])(object)gradInputData;
+            var dGradOut = (double[])(object)gradOutputData;
+            Array.Clear(dGradIn, 0, dGradIn.Length);
+            Parallel.For(0, batch, b =>
+            {
+                for (int c = 0; c < channels; c++)
+                    for (int oh = 0; oh < outputHeight; oh++)
+                        for (int ow = 0; ow < outputWidth; ow++)
+                        {
+                            int maxH = maxIndices[b, c, oh, ow, 0];
+                            int maxW = maxIndices[b, c, oh, ow, 1];
+                            int gradOutIdx = ((b * channels + c) * outputHeight + oh) * outputWidth + ow;
+                            int gradInIdx = ((b * channels + c) * height + maxH) * width + maxW;
+                            dGradIn[gradInIdx] += dGradOut[gradOutIdx];
+                        }
+            });
+        }
+        else
+        {
+            // Initialize to zero
+            for (int i = 0; i < gradInputData.Length; i++)
+                gradInputData[i] = numOps.Zero;
+
+            Parallel.For(0, batch, b =>
+            {
+                for (int c = 0; c < channels; c++)
                 {
-                    for (int ow = 0; ow < outputWidth; ow++)
+                    for (int oh = 0; oh < outputHeight; oh++)
                     {
-                        int maxH = maxIndices[b, c, oh, ow, 0];
-                        int maxW = maxIndices[b, c, oh, ow, 1];
+                        for (int ow = 0; ow < outputWidth; ow++)
+                        {
+                            int maxH = maxIndices[b, c, oh, ow, 0];
+                            int maxW = maxIndices[b, c, oh, ow, 1];
 
-                        int gradOutIdx = ((b * channels + c) * outputHeight + oh) * outputWidth + ow;
-                        int gradInIdx = ((b * channels + c) * height + maxH) * width + maxW;
+                            int gradOutIdx = ((b * channels + c) * outputHeight + oh) * outputWidth + ow;
+                            int gradInIdx = ((b * channels + c) * height + maxH) * width + maxW;
 
-                        gradInputData[gradInIdx] = numOps.Add(gradInputData[gradInIdx], gradOutputData[gradOutIdx]);
+                            gradInputData[gradInIdx] = numOps.Add(gradInputData[gradInIdx], gradOutputData[gradOutIdx]);
+                        }
                     }
                 }
-            }
-        });
+            });
+        }
 
         return result;
     }
@@ -9305,40 +9347,106 @@ public class CpuEngine : ITensorLevelEngine
         var result = AutoTensorCache.RentOrAllocate<T>(inputShape);
         var gradInputData = result.GetDataArray();
         var gradOutputData = gradOutput.GetFlattenedData();
-        T poolArea = numOps.FromDouble(poolH * poolW);
 
-        // Initialize to zero
-        for (int i = 0; i < gradInputData.Length; i++)
-            gradInputData[i] = numOps.Zero;
-
-        // Parallelize across batches (within a batch*channel, output positions scatter to overlapping input regions)
-        Parallel.For(0, batch, b =>
+        if (typeof(T) == typeof(float))
         {
-            for (int c = 0; c < channels; c++)
+            var fGradIn = (float[])(object)gradInputData;
+            var fGradOut = (float[])(object)gradOutputData;
+            float invPoolArea = 1f / (poolH * poolW);
+            Array.Clear(fGradIn, 0, fGradIn.Length);
+            Parallel.For(0, batch, b =>
             {
-                int inputBaseOffset = (b * channels + c) * height * width;
-                int outputBaseOffset = (b * channels + c) * outputHeight * outputWidth;
-
-                for (int oh = 0; oh < outputHeight; oh++)
+                for (int c = 0; c < channels; c++)
                 {
-                    for (int ow = 0; ow < outputWidth; ow++)
+                    int inputBaseOffset = (b * channels + c) * height * width;
+                    int outputBaseOffset = (b * channels + c) * outputHeight * outputWidth;
+                    for (int oh = 0; oh < outputHeight; oh++)
                     {
-                        T grad = numOps.Divide(gradOutputData[outputBaseOffset + oh * outputWidth + ow], poolArea);
-
-                        for (int kh = 0; kh < poolH; kh++)
+                        for (int ow = 0; ow < outputWidth; ow++)
                         {
-                            int ih = oh * strideH + kh;
-                            for (int kw = 0; kw < poolW; kw++)
+                            float grad = fGradOut[outputBaseOffset + oh * outputWidth + ow] * invPoolArea;
+                            for (int kh = 0; kh < poolH; kh++)
                             {
-                                int iw = ow * strideW + kw;
-                                int gradInIdx = inputBaseOffset + ih * width + iw;
-                                gradInputData[gradInIdx] = numOps.Add(gradInputData[gradInIdx], grad);
+                                int ih = oh * strideH + kh;
+                                for (int kw = 0; kw < poolW; kw++)
+                                {
+                                    int iw = ow * strideW + kw;
+                                    fGradIn[inputBaseOffset + ih * width + iw] += grad;
+                                }
                             }
                         }
                     }
                 }
-            }
-        });
+            });
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            var dGradIn = (double[])(object)gradInputData;
+            var dGradOut = (double[])(object)gradOutputData;
+            double invPoolArea = 1.0 / (poolH * poolW);
+            Array.Clear(dGradIn, 0, dGradIn.Length);
+            Parallel.For(0, batch, b =>
+            {
+                for (int c = 0; c < channels; c++)
+                {
+                    int inputBaseOffset = (b * channels + c) * height * width;
+                    int outputBaseOffset = (b * channels + c) * outputHeight * outputWidth;
+                    for (int oh = 0; oh < outputHeight; oh++)
+                    {
+                        for (int ow = 0; ow < outputWidth; ow++)
+                        {
+                            double grad = dGradOut[outputBaseOffset + oh * outputWidth + ow] * invPoolArea;
+                            for (int kh = 0; kh < poolH; kh++)
+                            {
+                                int ih = oh * strideH + kh;
+                                for (int kw = 0; kw < poolW; kw++)
+                                {
+                                    int iw = ow * strideW + kw;
+                                    dGradIn[inputBaseOffset + ih * width + iw] += grad;
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+        }
+        else
+        {
+            T poolArea = numOps.FromDouble(poolH * poolW);
+
+            // Initialize to zero
+            for (int i = 0; i < gradInputData.Length; i++)
+                gradInputData[i] = numOps.Zero;
+
+            // Parallelize across batches (within a batch*channel, output positions scatter to overlapping input regions)
+            Parallel.For(0, batch, b =>
+            {
+                for (int c = 0; c < channels; c++)
+                {
+                    int inputBaseOffset = (b * channels + c) * height * width;
+                    int outputBaseOffset = (b * channels + c) * outputHeight * outputWidth;
+
+                    for (int oh = 0; oh < outputHeight; oh++)
+                    {
+                        for (int ow = 0; ow < outputWidth; ow++)
+                        {
+                            T grad = numOps.Divide(gradOutputData[outputBaseOffset + oh * outputWidth + ow], poolArea);
+
+                            for (int kh = 0; kh < poolH; kh++)
+                            {
+                                int ih = oh * strideH + kh;
+                                for (int kw = 0; kw < poolW; kw++)
+                                {
+                                    int iw = ow * strideW + kw;
+                                    int gradInIdx = inputBaseOffset + ih * width + iw;
+                                    gradInputData[gradInIdx] = numOps.Add(gradInputData[gradInIdx], grad);
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+        }
 
         return result;
     }
@@ -9634,60 +9742,173 @@ public class CpuEngine : ITensorLevelEngine
         var kernelData = kernel.GetDataArray();
         var outputData = new T[batch * outChannels * outputHeight * outputWidth];
 
-        for (int i = 0; i < outputData.Length; i++)
-            outputData[i] = numOps.Zero;
+        // ────────────────────────────────────────────────────────────────────
+        // Primitive fast paths: direct float/double arithmetic, no virtual
+        // dispatch. Thread-local scatter (each input contributes to a kernel-
+        // sized output patch) with parallel body, sequential merge.
+        //
+        // VAE decoder — directly in the #162 timing-out list — plus diffusion
+        // UNet upsample decoder blocks hit this op in every forward pass.
+        // ────────────────────────────────────────────────────────────────────
+        if (typeof(T) == typeof(float))
+        {
+            var fInput = (float[])(object)inputData;
+            var fKernel = (float[])(object)kernelData;
+            var fOutput = (float[])(object)outputData;
+            int outLen = fOutput.Length;
+            var fLockObj = new object();
 
-        // Use thread-local accumulation to avoid lock contention
-        var lockObj = new object();
-        Parallel.For(0, batch * inChannels,
-            // Initialize thread-local storage
-            () => new T[batch * outChannels * outputHeight * outputWidth],
-            // Body
-            (idx, state, localOutput) =>
-            {
-                int b = idx / inChannels;
-                int ic = idx % inChannels;
-
-                for (int ih = 0; ih < height; ih++)
+            Parallel.For(0, batch * inChannels,
+                () => new float[outLen],
+                (idx, state, localOutput) =>
                 {
-                    for (int iw = 0; iw < width; iw++)
-                    {
-                        int inputIdx = ((b * inChannels + ic) * height + ih) * width + iw;
-                        T inputVal = inputData[inputIdx];
+                    int b = idx / inChannels;
+                    int ic = idx % inChannels;
 
-                        for (int oc = 0; oc < outChannels; oc++)
+                    for (int ih = 0; ih < height; ih++)
+                    {
+                        for (int iw = 0; iw < width; iw++)
                         {
-                            for (int kh = 0; kh < kernelHeight; kh++)
+                            int inputIdx = ((b * inChannels + ic) * height + ih) * width + iw;
+                            float inputVal = fInput[inputIdx];
+
+                            for (int oc = 0; oc < outChannels; oc++)
                             {
-                                for (int kw = 0; kw < kernelWidth; kw++)
+                                for (int kh = 0; kh < kernelHeight; kh++)
                                 {
                                     int oh = ih * strideH - padH + kh;
-                                    int ow = iw * strideW - padW + kw;
-
-                                    if (oh >= 0 && oh < outputHeight && ow >= 0 && ow < outputWidth)
+                                    if (oh < 0 || oh >= outputHeight) continue;
+                                    for (int kw = 0; kw < kernelWidth; kw++)
                                     {
+                                        int ow = iw * strideW - padW + kw;
+                                        if (ow < 0 || ow >= outputWidth) continue;
                                         int outputIdx = ((b * outChannels + oc) * outputHeight + oh) * outputWidth + ow;
                                         int kernelIdx = ((ic * outChannels + oc) * kernelHeight + kh) * kernelWidth + kw;
-                                        localOutput[outputIdx] = numOps.Add(localOutput[outputIdx], numOps.Multiply(inputVal, kernelData[kernelIdx]));
+                                        localOutput[outputIdx] += inputVal * fKernel[kernelIdx];
                                     }
                                 }
                             }
                         }
                     }
-                }
-                return localOutput;
-            },
-            // Merge thread-local results
-            (localOutput) =>
-            {
-                lock (lockObj)
+                    return localOutput;
+                },
+                (localOutput) =>
                 {
-                    for (int i = 0; i < outputData.Length; i++)
+                    lock (fLockObj)
                     {
-                        outputData[i] = numOps.Add(outputData[i], localOutput[i]);
+                        for (int i = 0; i < outLen; i++)
+                            fOutput[i] += localOutput[i];
                     }
-                }
-            });
+                });
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            var dInput = (double[])(object)inputData;
+            var dKernel = (double[])(object)kernelData;
+            var dOutput = (double[])(object)outputData;
+            int outLen = dOutput.Length;
+            var dLockObj = new object();
+
+            Parallel.For(0, batch * inChannels,
+                () => new double[outLen],
+                (idx, state, localOutput) =>
+                {
+                    int b = idx / inChannels;
+                    int ic = idx % inChannels;
+
+                    for (int ih = 0; ih < height; ih++)
+                    {
+                        for (int iw = 0; iw < width; iw++)
+                        {
+                            int inputIdx = ((b * inChannels + ic) * height + ih) * width + iw;
+                            double inputVal = dInput[inputIdx];
+
+                            for (int oc = 0; oc < outChannels; oc++)
+                            {
+                                for (int kh = 0; kh < kernelHeight; kh++)
+                                {
+                                    int oh = ih * strideH - padH + kh;
+                                    if (oh < 0 || oh >= outputHeight) continue;
+                                    for (int kw = 0; kw < kernelWidth; kw++)
+                                    {
+                                        int ow = iw * strideW - padW + kw;
+                                        if (ow < 0 || ow >= outputWidth) continue;
+                                        int outputIdx = ((b * outChannels + oc) * outputHeight + oh) * outputWidth + ow;
+                                        int kernelIdx = ((ic * outChannels + oc) * kernelHeight + kh) * kernelWidth + kw;
+                                        localOutput[outputIdx] += inputVal * dKernel[kernelIdx];
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    return localOutput;
+                },
+                (localOutput) =>
+                {
+                    lock (dLockObj)
+                    {
+                        for (int i = 0; i < outLen; i++)
+                            dOutput[i] += localOutput[i];
+                    }
+                });
+        }
+        else
+        {
+            for (int i = 0; i < outputData.Length; i++)
+                outputData[i] = numOps.Zero;
+
+            // Use thread-local accumulation to avoid lock contention
+            var lockObj = new object();
+            Parallel.For(0, batch * inChannels,
+                // Initialize thread-local storage
+                () => new T[batch * outChannels * outputHeight * outputWidth],
+                // Body
+                (idx, state, localOutput) =>
+                {
+                    int b = idx / inChannels;
+                    int ic = idx % inChannels;
+
+                    for (int ih = 0; ih < height; ih++)
+                    {
+                        for (int iw = 0; iw < width; iw++)
+                        {
+                            int inputIdx = ((b * inChannels + ic) * height + ih) * width + iw;
+                            T inputVal = inputData[inputIdx];
+
+                            for (int oc = 0; oc < outChannels; oc++)
+                            {
+                                for (int kh = 0; kh < kernelHeight; kh++)
+                                {
+                                    for (int kw = 0; kw < kernelWidth; kw++)
+                                    {
+                                        int oh = ih * strideH - padH + kh;
+                                        int ow = iw * strideW - padW + kw;
+
+                                        if (oh >= 0 && oh < outputHeight && ow >= 0 && ow < outputWidth)
+                                        {
+                                            int outputIdx = ((b * outChannels + oc) * outputHeight + oh) * outputWidth + ow;
+                                            int kernelIdx = ((ic * outChannels + oc) * kernelHeight + kh) * kernelWidth + kw;
+                                            localOutput[outputIdx] = numOps.Add(localOutput[outputIdx], numOps.Multiply(inputVal, kernelData[kernelIdx]));
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    return localOutput;
+                },
+                // Merge thread-local results
+                (localOutput) =>
+                {
+                    lock (lockObj)
+                    {
+                        for (int i = 0; i < outputData.Length; i++)
+                        {
+                            outputData[i] = numOps.Add(outputData[i], localOutput[i]);
+                        }
+                    }
+                });
+        }
 
         var convTransResult = TensorAllocator.Rent<T>([batch, outChannels, outputHeight, outputWidth], new Vector<T>(outputData));
         DifferentiableOps.RecordBinary("ConvTranspose2D", convTransResult, input, kernel,
@@ -9745,40 +9966,120 @@ public class CpuEngine : ITensorLevelEngine
         var gradOutputData = gradOutput.GetFlattenedData();
         var inputData = input.GetFlattenedData();
 
-        for (int i = 0; i < gradKernel.Length; i++)
-            gradKernel[i] = numOps.Zero;
+        // Parallelize over inChannels*outChannels since each (ic, oc) pair writes
+        // a disjoint [kernelHeight × kernelWidth] kernel slice. Primitive fast
+        // paths skip virtual dispatch for float/double.
+        int pairs = inChannels * outChannels;
 
-        for (int ic = 0; ic < inChannels; ic++)
+        if (typeof(T) == typeof(float))
         {
-            for (int oc = 0; oc < outChannels; oc++)
+            var fGradOut = (float[])(object)gradOutputData;
+            var fInput = (float[])(object)inputData;
+            var fGradKernel = (float[])(object)gradKernel;
+            Parallel.For(0, pairs, pair =>
             {
+                int ic = pair / outChannels;
+                int oc = pair % outChannels;
                 for (int kh = 0; kh < kernelHeight; kh++)
                 {
                     for (int kw = 0; kw < kernelWidth; kw++)
                     {
-                        T sum = numOps.Zero;
-
+                        float sum = 0f;
                         for (int b = 0; b < batch; b++)
                         {
                             for (int ih = 0; ih < height; ih++)
                             {
+                                int oh = ih * strideH - padH + kh;
+                                if (oh < 0 || oh >= outputHeight) continue;
                                 for (int iw = 0; iw < width; iw++)
                                 {
-                                    int oh = ih * strideH - padH + kh;
                                     int ow = iw * strideW - padW + kw;
-
-                                    if (oh >= 0 && oh < outputHeight && ow >= 0 && ow < outputWidth)
-                                    {
-                                        int gradOutIdx = ((b * outChannels + oc) * outputHeight + oh) * outputWidth + ow;
-                                        int inputIdx = ((b * inChannels + ic) * height + ih) * width + iw;
-                                        sum = numOps.Add(sum, numOps.Multiply(gradOutputData[gradOutIdx], inputData[inputIdx]));
-                                    }
+                                    if (ow < 0 || ow >= outputWidth) continue;
+                                    int gradOutIdx = ((b * outChannels + oc) * outputHeight + oh) * outputWidth + ow;
+                                    int inputIdx = ((b * inChannels + ic) * height + ih) * width + iw;
+                                    sum += fGradOut[gradOutIdx] * fInput[inputIdx];
                                 }
                             }
                         }
-
                         int kernelIdx = ((ic * outChannels + oc) * kernelHeight + kh) * kernelWidth + kw;
-                        gradKernel[kernelIdx] = sum;
+                        fGradKernel[kernelIdx] = sum;
+                    }
+                }
+            });
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            var dGradOut = (double[])(object)gradOutputData;
+            var dInput = (double[])(object)inputData;
+            var dGradKernel = (double[])(object)gradKernel;
+            Parallel.For(0, pairs, pair =>
+            {
+                int ic = pair / outChannels;
+                int oc = pair % outChannels;
+                for (int kh = 0; kh < kernelHeight; kh++)
+                {
+                    for (int kw = 0; kw < kernelWidth; kw++)
+                    {
+                        double sum = 0.0;
+                        for (int b = 0; b < batch; b++)
+                        {
+                            for (int ih = 0; ih < height; ih++)
+                            {
+                                int oh = ih * strideH - padH + kh;
+                                if (oh < 0 || oh >= outputHeight) continue;
+                                for (int iw = 0; iw < width; iw++)
+                                {
+                                    int ow = iw * strideW - padW + kw;
+                                    if (ow < 0 || ow >= outputWidth) continue;
+                                    int gradOutIdx = ((b * outChannels + oc) * outputHeight + oh) * outputWidth + ow;
+                                    int inputIdx = ((b * inChannels + ic) * height + ih) * width + iw;
+                                    sum += dGradOut[gradOutIdx] * dInput[inputIdx];
+                                }
+                            }
+                        }
+                        int kernelIdx = ((ic * outChannels + oc) * kernelHeight + kh) * kernelWidth + kw;
+                        dGradKernel[kernelIdx] = sum;
+                    }
+                }
+            });
+        }
+        else
+        {
+            for (int i = 0; i < gradKernel.Length; i++)
+                gradKernel[i] = numOps.Zero;
+
+            for (int ic = 0; ic < inChannels; ic++)
+            {
+                for (int oc = 0; oc < outChannels; oc++)
+                {
+                    for (int kh = 0; kh < kernelHeight; kh++)
+                    {
+                        for (int kw = 0; kw < kernelWidth; kw++)
+                        {
+                            T sum = numOps.Zero;
+
+                            for (int b = 0; b < batch; b++)
+                            {
+                                for (int ih = 0; ih < height; ih++)
+                                {
+                                    for (int iw = 0; iw < width; iw++)
+                                    {
+                                        int oh = ih * strideH - padH + kh;
+                                        int ow = iw * strideW - padW + kw;
+
+                                        if (oh >= 0 && oh < outputHeight && ow >= 0 && ow < outputWidth)
+                                        {
+                                            int gradOutIdx = ((b * outChannels + oc) * outputHeight + oh) * outputWidth + ow;
+                                            int inputIdx = ((b * inChannels + ic) * height + ih) * width + iw;
+                                            sum = numOps.Add(sum, numOps.Multiply(gradOutputData[gradOutIdx], inputData[inputIdx]));
+                                        }
+                                    }
+                                }
+                            }
+
+                            int kernelIdx = ((ic * outChannels + oc) * kernelHeight + kh) * kernelWidth + kw;
+                            gradKernel[kernelIdx] = sum;
+                        }
                     }
                 }
             }
@@ -11043,54 +11344,143 @@ public class CpuEngine : ITensorLevelEngine
         var gradOutputData = gradOutput.GetDataArray();
         var kernelData = kernel.GetDataArray();
 
-        // Initialize to zero
-        for (int i = 0; i < gradInputData.Length; i++)
-            gradInputData[i] = numOps.Zero;
-
-        // Parallel over (batch, inChannels) - each pair owns disjoint gradInput slices
-        // so direct writes are race-free without thread-local buffers
-        Parallel.For(0, batch * inChannels, idx =>
+        // Primitive fast paths for float/double. Parallel over (batch, inChannels)
+        // pairs — each pair owns a disjoint gradInput slice, so direct writes
+        // are race-free without thread-local buffers.
+        if (typeof(T) == typeof(float))
         {
-            int b = idx / inChannels;
-            int ic = idx % inChannels;
-
-            for (int oc = 0; oc < outChannels; oc++)
+            var fGradOut = (float[])(object)gradOutputData;
+            var fKernel = (float[])(object)kernelData;
+            var fGradInput = (float[])(object)gradInputData;
+            Parallel.For(0, batch * inChannels, idx =>
             {
-                for (int od = 0; od < outputDepth; od++)
+                int b = idx / inChannels;
+                int ic = idx % inChannels;
+                for (int oc = 0; oc < outChannels; oc++)
                 {
-                    for (int oh = 0; oh < outputHeight; oh++)
+                    for (int od = 0; od < outputDepth; od++)
                     {
-                        for (int ow = 0; ow < outputWidth; ow++)
+                        for (int oh = 0; oh < outputHeight; oh++)
                         {
-                            int gradOutIdx = (((b * outChannels + oc) * outputDepth + od) * outputHeight + oh) * outputWidth + ow;
-                            T gradVal = gradOutputData[gradOutIdx];
-
-                            for (int kd = 0; kd < kernelDepth; kd++)
+                            for (int ow = 0; ow < outputWidth; ow++)
                             {
-                                int id = od * strideD + kd * dilationD - padD;
-                                if (id < 0 || id >= depth) continue;
-
-                                for (int kh = 0; kh < kernelHeight; kh++)
+                                int gradOutIdx = (((b * outChannels + oc) * outputDepth + od) * outputHeight + oh) * outputWidth + ow;
+                                float gradVal = fGradOut[gradOutIdx];
+                                for (int kd = 0; kd < kernelDepth; kd++)
                                 {
-                                    int ih = oh * strideH + kh * dilationH - padH;
-                                    if (ih < 0 || ih >= height) continue;
-
-                                    for (int kw = 0; kw < kernelWidth; kw++)
+                                    int id = od * strideD + kd * dilationD - padD;
+                                    if (id < 0 || id >= depth) continue;
+                                    for (int kh = 0; kh < kernelHeight; kh++)
                                     {
-                                        int iw = ow * strideW + kw * dilationW - padW;
-                                        if (iw < 0 || iw >= width) continue;
-
-                                        int inputIdx = (((b * inChannels + ic) * depth + id) * height + ih) * width + iw;
-                                        int kernelIdx = (((oc * inChannels + ic) * kernelDepth + kd) * kernelHeight + kh) * kernelWidth + kw;
-                                        gradInputData[inputIdx] = numOps.Add(gradInputData[inputIdx], numOps.Multiply(gradVal, kernelData[kernelIdx]));
+                                        int ih = oh * strideH + kh * dilationH - padH;
+                                        if (ih < 0 || ih >= height) continue;
+                                        for (int kw = 0; kw < kernelWidth; kw++)
+                                        {
+                                            int iw = ow * strideW + kw * dilationW - padW;
+                                            if (iw < 0 || iw >= width) continue;
+                                            int inputIdx = (((b * inChannels + ic) * depth + id) * height + ih) * width + iw;
+                                            int kernelIdx = (((oc * inChannels + ic) * kernelDepth + kd) * kernelHeight + kh) * kernelWidth + kw;
+                                            fGradInput[inputIdx] += gradVal * fKernel[kernelIdx];
+                                        }
                                     }
                                 }
                             }
                         }
                     }
                 }
-            }
-        });
+            });
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            var dGradOut = (double[])(object)gradOutputData;
+            var dKernel = (double[])(object)kernelData;
+            var dGradInput = (double[])(object)gradInputData;
+            Parallel.For(0, batch * inChannels, idx =>
+            {
+                int b = idx / inChannels;
+                int ic = idx % inChannels;
+                for (int oc = 0; oc < outChannels; oc++)
+                {
+                    for (int od = 0; od < outputDepth; od++)
+                    {
+                        for (int oh = 0; oh < outputHeight; oh++)
+                        {
+                            for (int ow = 0; ow < outputWidth; ow++)
+                            {
+                                int gradOutIdx = (((b * outChannels + oc) * outputDepth + od) * outputHeight + oh) * outputWidth + ow;
+                                double gradVal = dGradOut[gradOutIdx];
+                                for (int kd = 0; kd < kernelDepth; kd++)
+                                {
+                                    int id = od * strideD + kd * dilationD - padD;
+                                    if (id < 0 || id >= depth) continue;
+                                    for (int kh = 0; kh < kernelHeight; kh++)
+                                    {
+                                        int ih = oh * strideH + kh * dilationH - padH;
+                                        if (ih < 0 || ih >= height) continue;
+                                        for (int kw = 0; kw < kernelWidth; kw++)
+                                        {
+                                            int iw = ow * strideW + kw * dilationW - padW;
+                                            if (iw < 0 || iw >= width) continue;
+                                            int inputIdx = (((b * inChannels + ic) * depth + id) * height + ih) * width + iw;
+                                            int kernelIdx = (((oc * inChannels + ic) * kernelDepth + kd) * kernelHeight + kh) * kernelWidth + kw;
+                                            dGradInput[inputIdx] += gradVal * dKernel[kernelIdx];
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+        }
+        else
+        {
+            for (int i = 0; i < gradInputData.Length; i++)
+                gradInputData[i] = numOps.Zero;
+
+            Parallel.For(0, batch * inChannels, idx =>
+            {
+                int b = idx / inChannels;
+                int ic = idx % inChannels;
+
+                for (int oc = 0; oc < outChannels; oc++)
+                {
+                    for (int od = 0; od < outputDepth; od++)
+                    {
+                        for (int oh = 0; oh < outputHeight; oh++)
+                        {
+                            for (int ow = 0; ow < outputWidth; ow++)
+                            {
+                                int gradOutIdx = (((b * outChannels + oc) * outputDepth + od) * outputHeight + oh) * outputWidth + ow;
+                                T gradVal = gradOutputData[gradOutIdx];
+
+                                for (int kd = 0; kd < kernelDepth; kd++)
+                                {
+                                    int id = od * strideD + kd * dilationD - padD;
+                                    if (id < 0 || id >= depth) continue;
+
+                                    for (int kh = 0; kh < kernelHeight; kh++)
+                                    {
+                                        int ih = oh * strideH + kh * dilationH - padH;
+                                        if (ih < 0 || ih >= height) continue;
+
+                                        for (int kw = 0; kw < kernelWidth; kw++)
+                                        {
+                                            int iw = ow * strideW + kw * dilationW - padW;
+                                            if (iw < 0 || iw >= width) continue;
+
+                                            int inputIdx = (((b * inChannels + ic) * depth + id) * height + ih) * width + iw;
+                                            int kernelIdx = (((oc * inChannels + ic) * kernelDepth + kd) * kernelHeight + kh) * kernelWidth + kw;
+                                            gradInputData[inputIdx] = numOps.Add(gradInputData[inputIdx], numOps.Multiply(gradVal, kernelData[kernelIdx]));
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+        }
 
         return TensorAllocator.Rent<T>(inputShape, new Vector<T>(gradInputData));
     }
@@ -11142,55 +11532,145 @@ public class CpuEngine : ITensorLevelEngine
         var gradOutputData = gradOutput.GetDataArray();
         var inputData = input.GetDataArray();
 
-        // Initialize to zero
-        for (int i = 0; i < gradKernelData.Length; i++)
-            gradKernelData[i] = numOps.Zero;
-
-        // Parallel over outChannels * inChannels for kernel gradient computation
-        Parallel.For(0, outChannels * inChannels, idx =>
+        // Primitive fast paths — each (oc, ic) pair owns a disjoint kernel slice.
+        if (typeof(T) == typeof(float))
         {
-            int oc = idx / inChannels;
-            int ic = idx % inChannels;
-
-            for (int kd = 0; kd < kernelDepth; kd++)
+            var fGradOut = (float[])(object)gradOutputData;
+            var fInput = (float[])(object)inputData;
+            var fGradKernel = (float[])(object)gradKernelData;
+            Parallel.For(0, outChannels * inChannels, idx =>
             {
-                for (int kh = 0; kh < kernelHeight; kh++)
+                int oc = idx / inChannels;
+                int ic = idx % inChannels;
+                for (int kd = 0; kd < kernelDepth; kd++)
                 {
-                    for (int kw = 0; kw < kernelWidth; kw++)
+                    for (int kh = 0; kh < kernelHeight; kh++)
                     {
-                        T sum = numOps.Zero;
-
-                        for (int b = 0; b < batch; b++)
+                        for (int kw = 0; kw < kernelWidth; kw++)
                         {
-                            for (int od = 0; od < outputDepth; od++)
+                            float sum = 0f;
+                            for (int b = 0; b < batch; b++)
                             {
-                                int id = od * strideD + kd * dilationD - padD;
-                                if (id < 0 || id >= depth) continue;
-
-                                for (int oh = 0; oh < outputHeight; oh++)
+                                for (int od = 0; od < outputDepth; od++)
                                 {
-                                    int ih = oh * strideH + kh * dilationH - padH;
-                                    if (ih < 0 || ih >= height) continue;
-
-                                    for (int ow = 0; ow < outputWidth; ow++)
+                                    int id = od * strideD + kd * dilationD - padD;
+                                    if (id < 0 || id >= depth) continue;
+                                    for (int oh = 0; oh < outputHeight; oh++)
                                     {
-                                        int iw = ow * strideW + kw * dilationW - padW;
-                                        if (iw < 0 || iw >= width) continue;
-
-                                        int gradOutIdx = (((b * outChannels + oc) * outputDepth + od) * outputHeight + oh) * outputWidth + ow;
-                                        int inputIdx = (((b * inChannels + ic) * depth + id) * height + ih) * width + iw;
-                                        sum = numOps.Add(sum, numOps.Multiply(gradOutputData[gradOutIdx], inputData[inputIdx]));
+                                        int ih = oh * strideH + kh * dilationH - padH;
+                                        if (ih < 0 || ih >= height) continue;
+                                        for (int ow = 0; ow < outputWidth; ow++)
+                                        {
+                                            int iw = ow * strideW + kw * dilationW - padW;
+                                            if (iw < 0 || iw >= width) continue;
+                                            int gradOutIdx = (((b * outChannels + oc) * outputDepth + od) * outputHeight + oh) * outputWidth + ow;
+                                            int inputIdx = (((b * inChannels + ic) * depth + id) * height + ih) * width + iw;
+                                            sum += fGradOut[gradOutIdx] * fInput[inputIdx];
+                                        }
                                     }
                                 }
                             }
+                            int kernelIdx = (((oc * inChannels + ic) * kernelDepth + kd) * kernelHeight + kh) * kernelWidth + kw;
+                            fGradKernel[kernelIdx] = sum;
                         }
-
-                        int kernelIdx = (((oc * inChannels + ic) * kernelDepth + kd) * kernelHeight + kh) * kernelWidth + kw;
-                        gradKernelData[kernelIdx] = sum;
                     }
                 }
-            }
-        });
+            });
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            var dGradOut = (double[])(object)gradOutputData;
+            var dInput = (double[])(object)inputData;
+            var dGradKernel = (double[])(object)gradKernelData;
+            Parallel.For(0, outChannels * inChannels, idx =>
+            {
+                int oc = idx / inChannels;
+                int ic = idx % inChannels;
+                for (int kd = 0; kd < kernelDepth; kd++)
+                {
+                    for (int kh = 0; kh < kernelHeight; kh++)
+                    {
+                        for (int kw = 0; kw < kernelWidth; kw++)
+                        {
+                            double sum = 0.0;
+                            for (int b = 0; b < batch; b++)
+                            {
+                                for (int od = 0; od < outputDepth; od++)
+                                {
+                                    int id = od * strideD + kd * dilationD - padD;
+                                    if (id < 0 || id >= depth) continue;
+                                    for (int oh = 0; oh < outputHeight; oh++)
+                                    {
+                                        int ih = oh * strideH + kh * dilationH - padH;
+                                        if (ih < 0 || ih >= height) continue;
+                                        for (int ow = 0; ow < outputWidth; ow++)
+                                        {
+                                            int iw = ow * strideW + kw * dilationW - padW;
+                                            if (iw < 0 || iw >= width) continue;
+                                            int gradOutIdx = (((b * outChannels + oc) * outputDepth + od) * outputHeight + oh) * outputWidth + ow;
+                                            int inputIdx = (((b * inChannels + ic) * depth + id) * height + ih) * width + iw;
+                                            sum += dGradOut[gradOutIdx] * dInput[inputIdx];
+                                        }
+                                    }
+                                }
+                            }
+                            int kernelIdx = (((oc * inChannels + ic) * kernelDepth + kd) * kernelHeight + kh) * kernelWidth + kw;
+                            dGradKernel[kernelIdx] = sum;
+                        }
+                    }
+                }
+            });
+        }
+        else
+        {
+            for (int i = 0; i < gradKernelData.Length; i++)
+                gradKernelData[i] = numOps.Zero;
+
+            Parallel.For(0, outChannels * inChannels, idx =>
+            {
+                int oc = idx / inChannels;
+                int ic = idx % inChannels;
+
+                for (int kd = 0; kd < kernelDepth; kd++)
+                {
+                    for (int kh = 0; kh < kernelHeight; kh++)
+                    {
+                        for (int kw = 0; kw < kernelWidth; kw++)
+                        {
+                            T sum = numOps.Zero;
+
+                            for (int b = 0; b < batch; b++)
+                            {
+                                for (int od = 0; od < outputDepth; od++)
+                                {
+                                    int id = od * strideD + kd * dilationD - padD;
+                                    if (id < 0 || id >= depth) continue;
+
+                                    for (int oh = 0; oh < outputHeight; oh++)
+                                    {
+                                        int ih = oh * strideH + kh * dilationH - padH;
+                                        if (ih < 0 || ih >= height) continue;
+
+                                        for (int ow = 0; ow < outputWidth; ow++)
+                                        {
+                                            int iw = ow * strideW + kw * dilationW - padW;
+                                            if (iw < 0 || iw >= width) continue;
+
+                                            int gradOutIdx = (((b * outChannels + oc) * outputDepth + od) * outputHeight + oh) * outputWidth + ow;
+                                            int inputIdx = (((b * inChannels + ic) * depth + id) * height + ih) * width + iw;
+                                            sum = numOps.Add(sum, numOps.Multiply(gradOutputData[gradOutIdx], inputData[inputIdx]));
+                                        }
+                                    }
+                                }
+                            }
+
+                            int kernelIdx = (((oc * inChannels + ic) * kernelDepth + kd) * kernelHeight + kh) * kernelWidth + kw;
+                            gradKernelData[kernelIdx] = sum;
+                        }
+                    }
+                }
+            });
+        }
 
         return TensorAllocator.Rent<T>(kernelShape, new Vector<T>(gradKernelData));
     }
@@ -15013,36 +15493,129 @@ public class CpuEngine : ITensorLevelEngine
         var rmsData = rms.GetDataArray();
         var gradGammaData = new T[featureSize];
         var gradInputData = new T[input.Length];
-        for (int f = 0; f < featureSize; f++) gradGammaData[f] = numOps.Zero;
 
-        for (int b = 0; b < batchSize; b++)
+        // ────────────────────────────────────────────────────────────────────
+        // Primitive fast paths — method stays generic <T>; float and double
+        // bypass INumericOperations<T> virtual dispatch. Used by LLaMA-style
+        // transformer training (every block has one RMSNorm).
+        // ────────────────────────────────────────────────────────────────────
+        if (typeof(T) == typeof(float))
         {
-            T invRms = numOps.Divide(numOps.One, rmsData[b]);
-            for (int f = 0; f < featureSize; f++)
+            var fGradOut = (float[])(object)gradOutputData;
+            var fInput = (float[])(object)inputData;
+            var fGamma = (float[])(object)gammaData;
+            var fRms = (float[])(object)rmsData;
+            var fGradGamma = (float[])(object)gradGammaData;
+            var fGradInput = (float[])(object)gradInputData;
+            int fs = featureSize;
+            float invFeatureSizeF = 1f / fs;
+
+            for (int b = 0; b < batchSize; b++)
             {
-                T normalized = numOps.Multiply(inputData[b * featureSize + f], invRms);
-                gradGammaData[f] = numOps.Add(gradGammaData[f], numOps.Multiply(gradOutputData[b * featureSize + f], normalized));
+                int off = b * fs;
+                float invRms = 1f / fRms[b];
+                for (int f = 0; f < fs; f++)
+                {
+                    float normalized = fInput[off + f] * invRms;
+                    fGradGamma[f] += fGradOut[off + f] * normalized;
+                }
             }
+
+            Parallel.For(0, batchSize, b =>
+            {
+                int off = b * fs;
+                float invRms = 1f / fRms[b];
+                float sumCorrection = 0f;
+                for (int f = 0; f < fs; f++)
+                {
+                    float scaledGrad = fGamma[f] * fGradOut[off + f];
+                    float normalized = fInput[off + f] * invRms;
+                    sumCorrection += scaledGrad * normalized;
+                }
+                float meanCorrection = sumCorrection * invFeatureSizeF;
+                for (int f = 0; f < fs; f++)
+                {
+                    float scaledGrad = fGamma[f] * fGradOut[off + f];
+                    float normalized = fInput[off + f] * invRms;
+                    fGradInput[off + f] = invRms * (scaledGrad - normalized * meanCorrection);
+                }
+            });
         }
-
-        Parallel.For(0, batchSize, b =>
+        else if (typeof(T) == typeof(double))
         {
-            T invRms = numOps.Divide(numOps.One, rmsData[b]);
-            T sumCorrection = numOps.Zero;
-            for (int f = 0; f < featureSize; f++)
+            var dGradOut = (double[])(object)gradOutputData;
+            var dInput = (double[])(object)inputData;
+            var dGamma = (double[])(object)gammaData;
+            var dRms = (double[])(object)rmsData;
+            var dGradGamma = (double[])(object)gradGammaData;
+            var dGradInput = (double[])(object)gradInputData;
+            int fs = featureSize;
+            double invFeatureSizeD = 1.0 / fs;
+
+            for (int b = 0; b < batchSize; b++)
             {
-                T scaledGrad = numOps.Multiply(gammaData[f], gradOutputData[b * featureSize + f]);
-                T normalized = numOps.Multiply(inputData[b * featureSize + f], invRms);
-                sumCorrection = numOps.Add(sumCorrection, numOps.Multiply(scaledGrad, normalized));
+                int off = b * fs;
+                double invRms = 1.0 / dRms[b];
+                for (int f = 0; f < fs; f++)
+                {
+                    double normalized = dInput[off + f] * invRms;
+                    dGradGamma[f] += dGradOut[off + f] * normalized;
+                }
             }
-            T meanCorrection = numOps.Divide(sumCorrection, numOps.FromDouble(featureSize));
-            for (int f = 0; f < featureSize; f++)
+
+            Parallel.For(0, batchSize, b =>
             {
-                T scaledGrad = numOps.Multiply(gammaData[f], gradOutputData[b * featureSize + f]);
-                T normalized = numOps.Multiply(inputData[b * featureSize + f], invRms);
-                gradInputData[b * featureSize + f] = numOps.Multiply(invRms, numOps.Subtract(scaledGrad, numOps.Multiply(normalized, meanCorrection)));
+                int off = b * fs;
+                double invRms = 1.0 / dRms[b];
+                double sumCorrection = 0.0;
+                for (int f = 0; f < fs; f++)
+                {
+                    double scaledGrad = dGamma[f] * dGradOut[off + f];
+                    double normalized = dInput[off + f] * invRms;
+                    sumCorrection += scaledGrad * normalized;
+                }
+                double meanCorrection = sumCorrection * invFeatureSizeD;
+                for (int f = 0; f < fs; f++)
+                {
+                    double scaledGrad = dGamma[f] * dGradOut[off + f];
+                    double normalized = dInput[off + f] * invRms;
+                    dGradInput[off + f] = invRms * (scaledGrad - normalized * meanCorrection);
+                }
+            });
+        }
+        else
+        {
+            for (int f = 0; f < featureSize; f++) gradGammaData[f] = numOps.Zero;
+
+            for (int b = 0; b < batchSize; b++)
+            {
+                T invRms = numOps.Divide(numOps.One, rmsData[b]);
+                for (int f = 0; f < featureSize; f++)
+                {
+                    T normalized = numOps.Multiply(inputData[b * featureSize + f], invRms);
+                    gradGammaData[f] = numOps.Add(gradGammaData[f], numOps.Multiply(gradOutputData[b * featureSize + f], normalized));
+                }
             }
-        });
+
+            Parallel.For(0, batchSize, b =>
+            {
+                T invRms = numOps.Divide(numOps.One, rmsData[b]);
+                T sumCorrection = numOps.Zero;
+                for (int f = 0; f < featureSize; f++)
+                {
+                    T scaledGrad = numOps.Multiply(gammaData[f], gradOutputData[b * featureSize + f]);
+                    T normalized = numOps.Multiply(inputData[b * featureSize + f], invRms);
+                    sumCorrection = numOps.Add(sumCorrection, numOps.Multiply(scaledGrad, normalized));
+                }
+                T meanCorrection = numOps.Divide(sumCorrection, numOps.FromDouble(featureSize));
+                for (int f = 0; f < featureSize; f++)
+                {
+                    T scaledGrad = numOps.Multiply(gammaData[f], gradOutputData[b * featureSize + f]);
+                    T normalized = numOps.Multiply(inputData[b * featureSize + f], invRms);
+                    gradInputData[b * featureSize + f] = numOps.Multiply(invRms, numOps.Subtract(scaledGrad, numOps.Multiply(normalized, meanCorrection)));
+                }
+            });
+        }
 
         gradGamma = TensorAllocator.Rent<T>(gamma._shape, new Vector<T>(gradGammaData));
         return TensorAllocator.Rent<T>(input._shape, new Vector<T>(gradInputData));
@@ -17392,10 +17965,6 @@ public class CpuEngine : ITensorLevelEngine
         var outputData = new T[outputShape.Aggregate(1, (a, b) => a * b)];
         var countData = new int[outDimSize];
 
-        // Initialize
-        for (int i = 0; i < outputData.Length; i++)
-            outputData[i] = numOps.Zero;
-
         int innerSize = 1;
         for (int i = actualDim + 1; i < source.Rank; i++)
             innerSize *= source._shape[i];
@@ -17406,37 +17975,112 @@ public class CpuEngine : ITensorLevelEngine
 
         int srcDimSize = source._shape[actualDim];
 
-        // Sum and count
-        for (int outer = 0; outer < outerSize; outer++)
+        if (typeof(T) == typeof(float))
         {
-            for (int d = 0; d < srcDimSize; d++)
+            var fSource = (float[])(object)sourceData;
+            var fOutput = (float[])(object)outputData;
+            Array.Clear(fOutput, 0, fOutput.Length);
+
+            for (int outer = 0; outer < outerSize; outer++)
             {
-                int targetIdx = indicesData[d % indicesData.Length];
-                if (targetIdx < 0 || targetIdx >= outDimSize) continue;
-
-                if (outer == 0) countData[targetIdx]++;
-
-                for (int inner = 0; inner < innerSize; inner++)
+                for (int d = 0; d < srcDimSize; d++)
                 {
-                    int srcIdx = outer * srcDimSize * innerSize + d * innerSize + inner;
-                    int dstIdx = outer * outDimSize * innerSize + targetIdx * innerSize + inner;
-                    outputData[dstIdx] = numOps.Add(outputData[dstIdx], sourceData[srcIdx]);
+                    int targetIdx = indicesData[d % indicesData.Length];
+                    if (targetIdx < 0 || targetIdx >= outDimSize) continue;
+                    if (outer == 0) countData[targetIdx]++;
+                    int srcBase = outer * srcDimSize * innerSize + d * innerSize;
+                    int dstBase = outer * outDimSize * innerSize + targetIdx * innerSize;
+                    for (int inner = 0; inner < innerSize; inner++)
+                        fOutput[dstBase + inner] += fSource[srcBase + inner];
+                }
+            }
+
+            for (int outer = 0; outer < outerSize; outer++)
+            {
+                for (int d = 0; d < outDimSize; d++)
+                {
+                    if (countData[d] > 0)
+                    {
+                        float invDivisor = 1f / countData[d];
+                        int baseIdx = outer * outDimSize * innerSize + d * innerSize;
+                        for (int inner = 0; inner < innerSize; inner++)
+                            fOutput[baseIdx + inner] *= invDivisor;
+                    }
                 }
             }
         }
-
-        // Divide by counts
-        for (int outer = 0; outer < outerSize; outer++)
+        else if (typeof(T) == typeof(double))
         {
-            for (int d = 0; d < outDimSize; d++)
+            var dSource = (double[])(object)sourceData;
+            var dOutput = (double[])(object)outputData;
+            Array.Clear(dOutput, 0, dOutput.Length);
+
+            for (int outer = 0; outer < outerSize; outer++)
             {
-                if (countData[d] > 0)
+                for (int d = 0; d < srcDimSize; d++)
                 {
-                    T divisor = numOps.FromDouble(countData[d]);
+                    int targetIdx = indicesData[d % indicesData.Length];
+                    if (targetIdx < 0 || targetIdx >= outDimSize) continue;
+                    if (outer == 0) countData[targetIdx]++;
+                    int srcBase = outer * srcDimSize * innerSize + d * innerSize;
+                    int dstBase = outer * outDimSize * innerSize + targetIdx * innerSize;
+                    for (int inner = 0; inner < innerSize; inner++)
+                        dOutput[dstBase + inner] += dSource[srcBase + inner];
+                }
+            }
+
+            for (int outer = 0; outer < outerSize; outer++)
+            {
+                for (int d = 0; d < outDimSize; d++)
+                {
+                    if (countData[d] > 0)
+                    {
+                        double invDivisor = 1.0 / countData[d];
+                        int baseIdx = outer * outDimSize * innerSize + d * innerSize;
+                        for (int inner = 0; inner < innerSize; inner++)
+                            dOutput[baseIdx + inner] *= invDivisor;
+                    }
+                }
+            }
+        }
+        else
+        {
+            // Initialize
+            for (int i = 0; i < outputData.Length; i++)
+                outputData[i] = numOps.Zero;
+
+            // Sum and count
+            for (int outer = 0; outer < outerSize; outer++)
+            {
+                for (int d = 0; d < srcDimSize; d++)
+                {
+                    int targetIdx = indicesData[d % indicesData.Length];
+                    if (targetIdx < 0 || targetIdx >= outDimSize) continue;
+
+                    if (outer == 0) countData[targetIdx]++;
+
                     for (int inner = 0; inner < innerSize; inner++)
                     {
-                        int idx = outer * outDimSize * innerSize + d * innerSize + inner;
-                        outputData[idx] = numOps.Divide(outputData[idx], divisor);
+                        int srcIdx = outer * srcDimSize * innerSize + d * innerSize + inner;
+                        int dstIdx = outer * outDimSize * innerSize + targetIdx * innerSize + inner;
+                        outputData[dstIdx] = numOps.Add(outputData[dstIdx], sourceData[srcIdx]);
+                    }
+                }
+            }
+
+            // Divide by counts
+            for (int outer = 0; outer < outerSize; outer++)
+            {
+                for (int d = 0; d < outDimSize; d++)
+                {
+                    if (countData[d] > 0)
+                    {
+                        T divisor = numOps.FromDouble(countData[d]);
+                        for (int inner = 0; inner < innerSize; inner++)
+                        {
+                            int idx = outer * outDimSize * innerSize + d * innerSize + inner;
+                            outputData[idx] = numOps.Divide(outputData[idx], divisor);
+                        }
                     }
                 }
             }

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -9744,8 +9744,10 @@ public class CpuEngine : ITensorLevelEngine
 
         // ────────────────────────────────────────────────────────────────────
         // Primitive fast paths: direct float/double arithmetic, no virtual
-        // dispatch. Thread-local scatter (each input contributes to a kernel-
-        // sized output patch) with parallel body, sequential merge.
+        // dispatch. Gather form parallelized over (batch, outChannels) — each
+        // worker owns a disjoint output slice [b, oc, :, :], eliminating
+        // thread-local full-size buffers and the merge lock. Memory usage
+        // stays O(outLen) instead of O(threads × outLen).
         //
         // VAE decoder — directly in the #162 timing-out list — plus diffusion
         // UNet upsample decoder blocks hit this op in every forward pass.
@@ -9755,102 +9757,82 @@ public class CpuEngine : ITensorLevelEngine
             var fInput = (float[])(object)inputData;
             var fKernel = (float[])(object)kernelData;
             var fOutput = (float[])(object)outputData;
-            int outLen = fOutput.Length;
-            var fLockObj = new object();
 
-            Parallel.For(0, batch * inChannels,
-                () => new float[outLen],
-                (idx, state, localOutput) =>
+            Parallel.For(0, batch * outChannels, idx =>
+            {
+                int b = idx / outChannels;
+                int oc = idx % outChannels;
+                for (int oh = 0; oh < outputHeight; oh++)
                 {
-                    int b = idx / inChannels;
-                    int ic = idx % inChannels;
-
-                    for (int ih = 0; ih < height; ih++)
+                    for (int ow = 0; ow < outputWidth; ow++)
                     {
-                        for (int iw = 0; iw < width; iw++)
+                        float sum = 0f;
+                        for (int kh = 0; kh < kernelHeight; kh++)
                         {
-                            int inputIdx = ((b * inChannels + ic) * height + ih) * width + iw;
-                            float inputVal = fInput[inputIdx];
-
-                            for (int oc = 0; oc < outChannels; oc++)
+                            int numerH = oh + padH - kh;
+                            if (numerH < 0 || numerH % strideH != 0) continue;
+                            int ih = numerH / strideH;
+                            if (ih >= height) continue;
+                            for (int kw = 0; kw < kernelWidth; kw++)
                             {
-                                for (int kh = 0; kh < kernelHeight; kh++)
+                                int numerW = ow + padW - kw;
+                                if (numerW < 0 || numerW % strideW != 0) continue;
+                                int iw = numerW / strideW;
+                                if (iw >= width) continue;
+                                for (int ic = 0; ic < inChannels; ic++)
                                 {
-                                    int oh = ih * strideH - padH + kh;
-                                    if (oh < 0 || oh >= outputHeight) continue;
-                                    for (int kw = 0; kw < kernelWidth; kw++)
-                                    {
-                                        int ow = iw * strideW - padW + kw;
-                                        if (ow < 0 || ow >= outputWidth) continue;
-                                        int outputIdx = ((b * outChannels + oc) * outputHeight + oh) * outputWidth + ow;
-                                        int kernelIdx = ((ic * outChannels + oc) * kernelHeight + kh) * kernelWidth + kw;
-                                        localOutput[outputIdx] += inputVal * fKernel[kernelIdx];
-                                    }
+                                    int inputIdx = ((b * inChannels + ic) * height + ih) * width + iw;
+                                    int kernelIdx = ((ic * outChannels + oc) * kernelHeight + kh) * kernelWidth + kw;
+                                    sum += fInput[inputIdx] * fKernel[kernelIdx];
                                 }
                             }
                         }
+                        int outputIdx = ((b * outChannels + oc) * outputHeight + oh) * outputWidth + ow;
+                        fOutput[outputIdx] = sum;
                     }
-                    return localOutput;
-                },
-                (localOutput) =>
-                {
-                    lock (fLockObj)
-                    {
-                        for (int i = 0; i < outLen; i++)
-                            fOutput[i] += localOutput[i];
-                    }
-                });
+                }
+            });
         }
         else if (typeof(T) == typeof(double))
         {
             var dInput = (double[])(object)inputData;
             var dKernel = (double[])(object)kernelData;
             var dOutput = (double[])(object)outputData;
-            int outLen = dOutput.Length;
-            var dLockObj = new object();
 
-            Parallel.For(0, batch * inChannels,
-                () => new double[outLen],
-                (idx, state, localOutput) =>
+            Parallel.For(0, batch * outChannels, idx =>
+            {
+                int b = idx / outChannels;
+                int oc = idx % outChannels;
+                for (int oh = 0; oh < outputHeight; oh++)
                 {
-                    int b = idx / inChannels;
-                    int ic = idx % inChannels;
-
-                    for (int ih = 0; ih < height; ih++)
+                    for (int ow = 0; ow < outputWidth; ow++)
                     {
-                        for (int iw = 0; iw < width; iw++)
+                        double sum = 0d;
+                        for (int kh = 0; kh < kernelHeight; kh++)
                         {
-                            int inputIdx = ((b * inChannels + ic) * height + ih) * width + iw;
-                            double inputVal = dInput[inputIdx];
-
-                            for (int oc = 0; oc < outChannels; oc++)
+                            int numerH = oh + padH - kh;
+                            if (numerH < 0 || numerH % strideH != 0) continue;
+                            int ih = numerH / strideH;
+                            if (ih >= height) continue;
+                            for (int kw = 0; kw < kernelWidth; kw++)
                             {
-                                for (int kh = 0; kh < kernelHeight; kh++)
+                                int numerW = ow + padW - kw;
+                                if (numerW < 0 || numerW % strideW != 0) continue;
+                                int iw = numerW / strideW;
+                                if (iw >= width) continue;
+                                for (int ic = 0; ic < inChannels; ic++)
                                 {
-                                    int oh = ih * strideH - padH + kh;
-                                    if (oh < 0 || oh >= outputHeight) continue;
-                                    for (int kw = 0; kw < kernelWidth; kw++)
-                                    {
-                                        int ow = iw * strideW - padW + kw;
-                                        if (ow < 0 || ow >= outputWidth) continue;
-                                        int outputIdx = ((b * outChannels + oc) * outputHeight + oh) * outputWidth + ow;
-                                        int kernelIdx = ((ic * outChannels + oc) * kernelHeight + kh) * kernelWidth + kw;
-                                        localOutput[outputIdx] += inputVal * dKernel[kernelIdx];
-                                    }
+                                    int inputIdx = ((b * inChannels + ic) * height + ih) * width + iw;
+                                    int kernelIdx = ((ic * outChannels + oc) * kernelHeight + kh) * kernelWidth + kw;
+                                    sum += dInput[inputIdx] * dKernel[kernelIdx];
                                 }
                             }
                         }
+                        int outputIdx = ((b * outChannels + oc) * outputHeight + oh) * outputWidth + ow;
+                        dOutput[outputIdx] = sum;
                     }
-                    return localOutput;
-                },
-                (localOutput) =>
-                {
-                    lock (dLockObj)
-                    {
-                        for (int i = 0; i < outLen; i++)
-                            dOutput[i] += localOutput[i];
-                    }
-                });
+                }
+            });
         }
         else
         {
@@ -11346,12 +11328,15 @@ public class CpuEngine : ITensorLevelEngine
 
         // Primitive fast paths for float/double. Parallel over (batch, inChannels)
         // pairs — each pair owns a disjoint gradInput slice, so direct writes
-        // are race-free without thread-local buffers.
+        // are race-free without thread-local buffers. Explicit Array.Clear keeps
+        // intent clear and stays correct if the buffer source ever switches from
+        // `new T[]` to TensorAllocator.RentUninitialized.
         if (typeof(T) == typeof(float))
         {
             var fGradOut = (float[])(object)gradOutputData;
             var fKernel = (float[])(object)kernelData;
             var fGradInput = (float[])(object)gradInputData;
+            Array.Clear(fGradInput, 0, fGradInput.Length);
             Parallel.For(0, batch * inChannels, idx =>
             {
                 int b = idx / inChannels;
@@ -11395,6 +11380,7 @@ public class CpuEngine : ITensorLevelEngine
             var dGradOut = (double[])(object)gradOutputData;
             var dKernel = (double[])(object)kernelData;
             var dGradInput = (double[])(object)gradInputData;
+            Array.Clear(dGradInput, 0, dGradInput.Length);
             Parallel.For(0, batch * inChannels, idx =>
             {
                 int b = idx / inChannels;

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -16967,6 +16967,179 @@ public class CpuEngine : ITensorLevelEngine
 
         T negInf = numOps.FromDouble(double.NegativeInfinity);
 
+        // ────────────────────────────────────────────────────────────────────
+        // Primitive fast paths: direct float/double arithmetic, no virtual
+        // dispatch. Method signature stays generic <T>; non-primitive T falls
+        // through to the original scalar path below.
+        //
+        // Note on locks: the generic scalar path uses `lock (gradVData)` and
+        // `lock (gradKData)` inside the ki loop. The locks are unnecessary —
+        // each Parallel.For worker (one per batch*head) writes to a disjoint
+        // [seqK*headDim]-sized slice of gradVData/gradKData selected by its
+        // unique vOffset/kOffset. The primitive paths drop the locks, which
+        // also un-serializes the nominally-parallel outer loop (the locks
+        // reference the shared array object, so all workers were contending
+        // on the same monitor — effectively sequentializing the op).
+        // ────────────────────────────────────────────────────────────────────
+        if (typeof(T) == typeof(float))
+        {
+            FlashAttentionBackwardFloat(
+                (float[])(object)queryData, (float[])(object)keyData,
+                (float[])(object)valueData, (float[])(object)outputData,
+                (float[])(object)gradOutData, (float[])(object)statsData,
+                (float[])(object)gradQData, (float[])(object)gradKData,
+                (float[])(object)gradVData,
+                biasData is null ? null : (float[])(object)biasData,
+                biasBroadcastBatch, (float)scale, isCausal,
+                batch, heads, seqQ, headDim, seqK, BLOCK_Q, BLOCK_KV);
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            FlashAttentionBackwardDouble(
+                (double[])(object)queryData, (double[])(object)keyData,
+                (double[])(object)valueData, (double[])(object)outputData,
+                (double[])(object)gradOutData, (double[])(object)statsData,
+                (double[])(object)gradQData, (double[])(object)gradKData,
+                (double[])(object)gradVData,
+                biasData is null ? null : (double[])(object)biasData,
+                biasBroadcastBatch, scale, isCausal,
+                batch, heads, seqQ, headDim, seqK, BLOCK_Q, BLOCK_KV);
+        }
+        else
+        {
+            Parallel.For(0, batch * heads, bh =>
+            {
+                int b = bh / heads;
+                int h = bh % heads;
+                int qOffset = (b * heads + h) * seqQ * headDim;
+                int kOffset = (b * heads + h) * seqK * headDim;
+                int vOffset = (b * heads + h) * seqK * headDim;
+                int oOffset = (b * heads + h) * seqQ * headDim;
+                int sOffset = (b * heads + h) * seqQ;
+
+                // Process in blocks (similar to forward, but recomputing attention)
+                for (int kvBlockStart = 0; kvBlockStart < seqK; kvBlockStart += BLOCK_KV)
+                {
+                    int kvBlockEnd = Math.Min(kvBlockStart + BLOCK_KV, seqK);
+
+                    for (int qBlockStart = 0; qBlockStart < seqQ; qBlockStart += BLOCK_Q)
+                    {
+                        int qBlockEnd = Math.Min(qBlockStart + BLOCK_Q, seqQ);
+
+                        for (int qi = qBlockStart; qi < qBlockEnd; qi++)
+                        {
+                            if (isCausal && kvBlockStart > qi)
+                                continue;
+
+                            T logsumexp = statsData[sOffset + qi];
+
+                            // Recompute attention weights for this row segment
+                            for (int ki = kvBlockStart; ki < kvBlockEnd; ki++)
+                            {
+                                if (isCausal && ki > qi)
+                                    continue;
+
+                                // Recompute score
+                                T score = numOps.Zero;
+                                for (int d = 0; d < headDim; d++)
+                                {
+                                    score = numOps.Add(score, numOps.Multiply(
+                                        queryData[qOffset + qi * headDim + d],
+                                        keyData[kOffset + ki * headDim + d]));
+                                }
+                                score = numOps.Multiply(score, scaleFactor);
+
+                                // Add attention bias if provided (must match forward pass)
+                                if (hasBias && biasData is not null)
+                                {
+                                    int biasIdx = biasBroadcastBatch
+                                        ? (h * seqQ * seqK + qi * seqK + ki)
+                                        : (b * heads * seqQ * seqK + h * seqQ * seqK + qi * seqK + ki);
+                                    score = numOps.Add(score, biasData[biasIdx]);
+                                }
+
+                                // Recompute attention weight: exp(score - logsumexp)
+                                T attnWeight = numOps.Exp(numOps.Subtract(score, logsumexp));
+
+                                // Gradient w.r.t. V: attnWeight * gradOutput
+                                for (int d = 0; d < headDim; d++)
+                                {
+                                    T gradO = gradOutData[oOffset + qi * headDim + d];
+                                    int vIdx = vOffset + ki * headDim + d;
+                                    lock (gradVData) // Thread safety for accumulation
+                                    {
+                                        gradVData[vIdx] = numOps.Add(gradVData[vIdx], numOps.Multiply(attnWeight, gradO));
+                                    }
+                                }
+
+                                // Compute dS = attnWeight * (dO @ V - sum(attnWeight * dO @ V))
+                                // First compute dO @ v for this position
+                                T doV = numOps.Zero;
+                                for (int d = 0; d < headDim; d++)
+                                {
+                                    doV = numOps.Add(doV, numOps.Multiply(
+                                        gradOutData[oOffset + qi * headDim + d],
+                                        valueData[vOffset + ki * headDim + d]));
+                                }
+
+                                // Compute dO @ O for the full row (dot product with output)
+                                T doO = numOps.Zero;
+                                for (int d = 0; d < headDim; d++)
+                                {
+                                    doO = numOps.Add(doO, numOps.Multiply(
+                                        gradOutData[oOffset + qi * headDim + d],
+                                        outputData[oOffset + qi * headDim + d]));
+                                }
+
+                                // dS = attnWeight * (doV - doO)
+                                T dS = numOps.Multiply(attnWeight, numOps.Subtract(doV, doO));
+                                dS = numOps.Multiply(dS, scaleFactor);
+
+                                // Gradient w.r.t. Q: dS * K
+                                for (int d = 0; d < headDim; d++)
+                                {
+                                    int qIdx = qOffset + qi * headDim + d;
+                                    gradQData[qIdx] = numOps.Add(gradQData[qIdx],
+                                        numOps.Multiply(dS, keyData[kOffset + ki * headDim + d]));
+                                }
+
+                                // Gradient w.r.t. K: dS * Q
+                                for (int d = 0; d < headDim; d++)
+                                {
+                                    int kIdx = kOffset + ki * headDim + d;
+                                    lock (gradKData) // Thread safety for accumulation
+                                    {
+                                        gradKData[kIdx] = numOps.Add(gradKData[kIdx],
+                                            numOps.Multiply(dS, queryData[qOffset + qi * headDim + d]));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+        }
+
+        gradQuery = TensorAllocator.Rent<T>(query._shape, new Vector<T>(gradQData));
+        gradKey = TensorAllocator.Rent<T>(key._shape, new Vector<T>(gradKData));
+        gradValue = TensorAllocator.Rent<T>(value._shape, new Vector<T>(gradVData));
+
+        return gradOutput;
+    }
+
+    /// <summary>
+    /// Float fast path for <see cref="FlashAttentionBackward{T}"/>. Direct
+    /// float arithmetic; no virtual dispatch; writes to disjoint per-(b, h)
+    /// slices so no locks are needed.
+    /// </summary>
+    private static void FlashAttentionBackwardFloat(
+        float[] queryData, float[] keyData, float[] valueData, float[] outputData,
+        float[] gradOutData, float[] statsData,
+        float[] gradQData, float[] gradKData, float[] gradVData,
+        float[]? biasData, bool biasBroadcastBatch, float scaleFactor, bool isCausal,
+        int batch, int heads, int seqQ, int headDim, int seqK,
+        int BLOCK_Q, int BLOCK_KV)
+    {
         Parallel.For(0, batch * heads, bh =>
         {
             int b = bh / heads;
@@ -16977,113 +17150,151 @@ public class CpuEngine : ITensorLevelEngine
             int oOffset = (b * heads + h) * seqQ * headDim;
             int sOffset = (b * heads + h) * seqQ;
 
-            // Process in blocks (similar to forward, but recomputing attention)
             for (int kvBlockStart = 0; kvBlockStart < seqK; kvBlockStart += BLOCK_KV)
             {
                 int kvBlockEnd = Math.Min(kvBlockStart + BLOCK_KV, seqK);
-
                 for (int qBlockStart = 0; qBlockStart < seqQ; qBlockStart += BLOCK_Q)
                 {
                     int qBlockEnd = Math.Min(qBlockStart + BLOCK_Q, seqQ);
-
                     for (int qi = qBlockStart; qi < qBlockEnd; qi++)
                     {
-                        if (isCausal && kvBlockStart > qi)
-                            continue;
+                        if (isCausal && kvBlockStart > qi) continue;
 
-                        T logsumexp = statsData[sOffset + qi];
+                        float logsumexp = statsData[sOffset + qi];
+                        int qRowOff = qOffset + qi * headDim;
+                        int oRowOff = oOffset + qi * headDim;
 
-                        // Recompute attention weights for this row segment
+                        // doO is independent of ki — hoist it out of the ki loop.
+                        // (The generic path recomputes it per ki; correctness-neutral
+                        // hoist that was already safe there too.)
+                        float doO = 0f;
+                        for (int d = 0; d < headDim; d++)
+                            doO += gradOutData[oRowOff + d] * outputData[oRowOff + d];
+
                         for (int ki = kvBlockStart; ki < kvBlockEnd; ki++)
                         {
-                            if (isCausal && ki > qi)
-                                continue;
+                            if (isCausal && ki > qi) continue;
 
-                            // Recompute score
-                            T score = numOps.Zero;
+                            int kRowOff = kOffset + ki * headDim;
+                            int vRowOff = vOffset + ki * headDim;
+
+                            float score = 0f;
                             for (int d = 0; d < headDim; d++)
-                            {
-                                score = numOps.Add(score, numOps.Multiply(
-                                    queryData[qOffset + qi * headDim + d],
-                                    keyData[kOffset + ki * headDim + d]));
-                            }
-                            score = numOps.Multiply(score, scaleFactor);
+                                score += queryData[qRowOff + d] * keyData[kRowOff + d];
+                            score *= scaleFactor;
 
-                            // Add attention bias if provided (must match forward pass)
-                            if (hasBias && biasData is not null)
+                            if (biasData is not null)
                             {
                                 int biasIdx = biasBroadcastBatch
                                     ? (h * seqQ * seqK + qi * seqK + ki)
                                     : (b * heads * seqQ * seqK + h * seqQ * seqK + qi * seqK + ki);
-                                score = numOps.Add(score, biasData[biasIdx]);
+                                score += biasData[biasIdx];
                             }
 
-                            // Recompute attention weight: exp(score - logsumexp)
-                            T attnWeight = numOps.Exp(numOps.Subtract(score, logsumexp));
+                            float attnWeight = MathF.Exp(score - logsumexp);
 
-                            // Gradient w.r.t. V: attnWeight * gradOutput
+                            float doV = 0f;
                             for (int d = 0; d < headDim; d++)
-                            {
-                                T gradO = gradOutData[oOffset + qi * headDim + d];
-                                int vIdx = vOffset + ki * headDim + d;
-                                lock (gradVData) // Thread safety for accumulation
-                                {
-                                    gradVData[vIdx] = numOps.Add(gradVData[vIdx], numOps.Multiply(attnWeight, gradO));
-                                }
-                            }
+                                doV += gradOutData[oRowOff + d] * valueData[vRowOff + d];
 
-                            // Compute dS = attnWeight * (dO @ V - sum(attnWeight * dO @ V))
-                            // First compute dO @ v for this position
-                            T doV = numOps.Zero;
+                            float dS = attnWeight * (doV - doO) * scaleFactor;
+
+                            // gradV += attnWeight * gradOutput — disjoint per (b, h), no lock.
                             for (int d = 0; d < headDim; d++)
-                            {
-                                doV = numOps.Add(doV, numOps.Multiply(
-                                    gradOutData[oOffset + qi * headDim + d],
-                                    valueData[vOffset + ki * headDim + d]));
-                            }
+                                gradVData[vRowOff + d] += attnWeight * gradOutData[oRowOff + d];
 
-                            // Compute dO @ O for the full row (dot product with output)
-                            T doO = numOps.Zero;
+                            // gradQ += dS * K (this worker owns the full gradQ slice for its qi row).
                             for (int d = 0; d < headDim; d++)
-                            {
-                                doO = numOps.Add(doO, numOps.Multiply(
-                                    gradOutData[oOffset + qi * headDim + d],
-                                    outputData[oOffset + qi * headDim + d]));
-                            }
+                                gradQData[qRowOff + d] += dS * keyData[kRowOff + d];
 
-                            // dS = attnWeight * (doV - doO)
-                            T dS = numOps.Multiply(attnWeight, numOps.Subtract(doV, doO));
-                            dS = numOps.Multiply(dS, scaleFactor);
-
-                            // Gradient w.r.t. Q: dS * K
+                            // gradK += dS * Q — also disjoint per (b, h).
                             for (int d = 0; d < headDim; d++)
-                            {
-                                int qIdx = qOffset + qi * headDim + d;
-                                gradQData[qIdx] = numOps.Add(gradQData[qIdx],
-                                    numOps.Multiply(dS, keyData[kOffset + ki * headDim + d]));
-                            }
-
-                            // Gradient w.r.t. K: dS * Q
-                            for (int d = 0; d < headDim; d++)
-                            {
-                                int kIdx = kOffset + ki * headDim + d;
-                                lock (gradKData) // Thread safety for accumulation
-                                {
-                                    gradKData[kIdx] = numOps.Add(gradKData[kIdx],
-                                        numOps.Multiply(dS, queryData[qOffset + qi * headDim + d]));
-                                }
-                            }
+                                gradKData[kRowOff + d] += dS * queryData[qRowOff + d];
                         }
                     }
                 }
             }
         });
+    }
 
-        gradQuery = TensorAllocator.Rent<T>(query._shape, new Vector<T>(gradQData));
-        gradKey = TensorAllocator.Rent<T>(key._shape, new Vector<T>(gradKData));
-        gradValue = TensorAllocator.Rent<T>(value._shape, new Vector<T>(gradVData));
+    /// <summary>Double fast path for <see cref="FlashAttentionBackward{T}"/>. Mirror of the float version.</summary>
+    private static void FlashAttentionBackwardDouble(
+        double[] queryData, double[] keyData, double[] valueData, double[] outputData,
+        double[] gradOutData, double[] statsData,
+        double[] gradQData, double[] gradKData, double[] gradVData,
+        double[]? biasData, bool biasBroadcastBatch, double scaleFactor, bool isCausal,
+        int batch, int heads, int seqQ, int headDim, int seqK,
+        int BLOCK_Q, int BLOCK_KV)
+    {
+        Parallel.For(0, batch * heads, bh =>
+        {
+            int b = bh / heads;
+            int h = bh % heads;
+            int qOffset = (b * heads + h) * seqQ * headDim;
+            int kOffset = (b * heads + h) * seqK * headDim;
+            int vOffset = (b * heads + h) * seqK * headDim;
+            int oOffset = (b * heads + h) * seqQ * headDim;
+            int sOffset = (b * heads + h) * seqQ;
 
-        return gradOutput;
+            for (int kvBlockStart = 0; kvBlockStart < seqK; kvBlockStart += BLOCK_KV)
+            {
+                int kvBlockEnd = Math.Min(kvBlockStart + BLOCK_KV, seqK);
+                for (int qBlockStart = 0; qBlockStart < seqQ; qBlockStart += BLOCK_Q)
+                {
+                    int qBlockEnd = Math.Min(qBlockStart + BLOCK_Q, seqQ);
+                    for (int qi = qBlockStart; qi < qBlockEnd; qi++)
+                    {
+                        if (isCausal && kvBlockStart > qi) continue;
+
+                        double logsumexp = statsData[sOffset + qi];
+                        int qRowOff = qOffset + qi * headDim;
+                        int oRowOff = oOffset + qi * headDim;
+
+                        double doO = 0.0;
+                        for (int d = 0; d < headDim; d++)
+                            doO += gradOutData[oRowOff + d] * outputData[oRowOff + d];
+
+                        for (int ki = kvBlockStart; ki < kvBlockEnd; ki++)
+                        {
+                            if (isCausal && ki > qi) continue;
+
+                            int kRowOff = kOffset + ki * headDim;
+                            int vRowOff = vOffset + ki * headDim;
+
+                            double score = 0.0;
+                            for (int d = 0; d < headDim; d++)
+                                score += queryData[qRowOff + d] * keyData[kRowOff + d];
+                            score *= scaleFactor;
+
+                            if (biasData is not null)
+                            {
+                                int biasIdx = biasBroadcastBatch
+                                    ? (h * seqQ * seqK + qi * seqK + ki)
+                                    : (b * heads * seqQ * seqK + h * seqQ * seqK + qi * seqK + ki);
+                                score += biasData[biasIdx];
+                            }
+
+                            double attnWeight = Math.Exp(score - logsumexp);
+
+                            double doV = 0.0;
+                            for (int d = 0; d < headDim; d++)
+                                doV += gradOutData[oRowOff + d] * valueData[vRowOff + d];
+
+                            double dS = attnWeight * (doV - doO) * scaleFactor;
+
+                            for (int d = 0; d < headDim; d++)
+                                gradVData[vRowOff + d] += attnWeight * gradOutData[oRowOff + d];
+
+                            for (int d = 0; d < headDim; d++)
+                                gradQData[qRowOff + d] += dS * keyData[kRowOff + d];
+
+                            for (int d = 0; d < headDim; d++)
+                                gradKData[kRowOff + d] += dS * queryData[qRowOff + d];
+                        }
+                    }
+                }
+            }
+        });
     }
 
     /// <summary>
@@ -19381,20 +19592,61 @@ public class CpuEngine : ITensorLevelEngine
         var inputData = input.GetFlattenedData();
         var outputData = new T[flatBatch * newHeight * newWidth];
 
-        Parallel.For(0, flatBatch, fb =>
+        // Primitive fast paths — avoid the generic T[] array covariance check
+        // and let JIT generate specialized code for float/double. Even though
+        // Upsample is a pure copy with no arithmetic, the generic path still
+        // incurs a per-element type check for the array store.
+        if (typeof(T) == typeof(float))
         {
-            for (int oh = 0; oh < newHeight; oh++)
+            var fIn = (float[])(object)inputData;
+            var fOut = (float[])(object)outputData;
+            Parallel.For(0, flatBatch, fb =>
             {
-                int ih = oh / scaleH;
-                for (int ow = 0; ow < newWidth; ow++)
+                for (int oh = 0; oh < newHeight; oh++)
                 {
-                    int iw = ow / scaleW;
-                    int inputIdx = (fb * height + ih) * width + iw;
-                    int outputIdx = (fb * newHeight + oh) * newWidth + ow;
-                    outputData[outputIdx] = inputData[inputIdx];
+                    int ih = oh / scaleH;
+                    for (int ow = 0; ow < newWidth; ow++)
+                    {
+                        int iw = ow / scaleW;
+                        fOut[(fb * newHeight + oh) * newWidth + ow] = fIn[(fb * height + ih) * width + iw];
+                    }
                 }
-            }
-        });
+            });
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            var dIn = (double[])(object)inputData;
+            var dOut = (double[])(object)outputData;
+            Parallel.For(0, flatBatch, fb =>
+            {
+                for (int oh = 0; oh < newHeight; oh++)
+                {
+                    int ih = oh / scaleH;
+                    for (int ow = 0; ow < newWidth; ow++)
+                    {
+                        int iw = ow / scaleW;
+                        dOut[(fb * newHeight + oh) * newWidth + ow] = dIn[(fb * height + ih) * width + iw];
+                    }
+                }
+            });
+        }
+        else
+        {
+            Parallel.For(0, flatBatch, fb =>
+            {
+                for (int oh = 0; oh < newHeight; oh++)
+                {
+                    int ih = oh / scaleH;
+                    for (int ow = 0; ow < newWidth; ow++)
+                    {
+                        int iw = ow / scaleW;
+                        int inputIdx = (fb * height + ih) * width + iw;
+                        int outputIdx = (fb * newHeight + oh) * newWidth + ow;
+                        outputData[outputIdx] = inputData[inputIdx];
+                    }
+                }
+            });
+        }
 
         // Create output shape preserving all leading dimensions
         var outputShape = new int[shape.Length];

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -16893,6 +16893,19 @@ public class CpuEngine : ITensorLevelEngine
         if (output == null) throw new ArgumentNullException(nameof(output));
         if (softmaxStats == null) throw new ArgumentNullException(nameof(softmaxStats));
 
+        if (query._shape.Length != 4)
+            throw new ArgumentException($"query must be rank-4 [batch, heads, seqQ, headDim], got rank {query._shape.Length}.", nameof(query));
+        if (key._shape.Length != 4)
+            throw new ArgumentException($"key must be rank-4 [batch, heads, seqK, headDim], got rank {key._shape.Length}.", nameof(key));
+        if (value._shape.Length != 4)
+            throw new ArgumentException($"value must be rank-4 [batch, heads, seqK, headDim], got rank {value._shape.Length}.", nameof(value));
+        if (output._shape.Length != 4)
+            throw new ArgumentException($"output must be rank-4 [batch, heads, seqQ, headDim], got rank {output._shape.Length}.", nameof(output));
+        if (gradOutput._shape.Length != 4)
+            throw new ArgumentException($"gradOutput must be rank-4 [batch, heads, seqQ, headDim], got rank {gradOutput._shape.Length}.", nameof(gradOutput));
+        if (softmaxStats._shape.Length != 3)
+            throw new ArgumentException($"softmaxStats must be rank-3 [batch, heads, seqQ], got rank {softmaxStats._shape.Length}.", nameof(softmaxStats));
+
         var numOps = MathHelper.GetNumericOperations<T>();
 
         int batch = query._shape[0];
@@ -16900,6 +16913,27 @@ public class CpuEngine : ITensorLevelEngine
         int seqQ = query._shape[2];
         int headDim = query._shape[3];
         int seqK = key._shape[2];
+
+        if (key._shape[0] != batch || key._shape[1] != heads || key._shape[3] != headDim)
+            throw new ArgumentException(
+                $"key shape [{string.Join(",", key._shape)}] must be [batch={batch}, heads={heads}, seqK, headDim={headDim}].",
+                nameof(key));
+        if (value._shape[0] != batch || value._shape[1] != heads || value._shape[2] != seqK || value._shape[3] != headDim)
+            throw new ArgumentException(
+                $"value shape [{string.Join(",", value._shape)}] must be [batch={batch}, heads={heads}, seqK={seqK}, headDim={headDim}].",
+                nameof(value));
+        if (output._shape[0] != batch || output._shape[1] != heads || output._shape[2] != seqQ || output._shape[3] != headDim)
+            throw new ArgumentException(
+                $"output shape [{string.Join(",", output._shape)}] must be [batch={batch}, heads={heads}, seqQ={seqQ}, headDim={headDim}].",
+                nameof(output));
+        if (gradOutput._shape[0] != batch || gradOutput._shape[1] != heads || gradOutput._shape[2] != seqQ || gradOutput._shape[3] != headDim)
+            throw new ArgumentException(
+                $"gradOutput shape [{string.Join(",", gradOutput._shape)}] must be [batch={batch}, heads={heads}, seqQ={seqQ}, headDim={headDim}].",
+                nameof(gradOutput));
+        if (softmaxStats._shape[0] != batch || softmaxStats._shape[1] != heads || softmaxStats._shape[2] != seqQ)
+            throw new ArgumentException(
+                $"softmaxStats shape [{string.Join(",", softmaxStats._shape)}] must be [batch={batch}, heads={heads}, seqQ={seqQ}].",
+                nameof(softmaxStats));
 
         T scaleFactor = numOps.FromDouble(scale);
 

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Buffers;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using AiDotNet.Tensors.Engines.CpuJit;
@@ -276,6 +277,43 @@ internal static class SimdGemm
             return;
         }
 #endif
+        // Non-intrinsics path (net471, or net5+ when Avx2/Fma unavailable).
+        // Use System.Numerics.Vector<float> — a portable SIMD primitive that
+        // the JIT lowers to SSE2 on net471, AVX2 on net5+ where available.
+        // Typical wins on net471: ~4-8× over the pure scalar triple-loop,
+        // closing most of the gap with the net5+ Avx2/Fma fast path.
+        //
+        // The Vector path does row-axpy (contiguous reads of B's p-th row
+        // into C's i-th row), so it requires transA=false and transB=false.
+        // For transB=true (common on Conv2DBackwardKernel's gradOut·im2col^T
+        // gemm), pre-transpose B into scratch and call the non-transpose path;
+        // the transpose cost is O(k*n) and amortized over the M*K work.
+        // For transA=true (less common), fall through to SgemmScalar — fixing
+        // that case is future work.
+        if (Vector.IsHardwareAccelerated && !transA && m > 0 && k > 0 && n > 0)
+        {
+            if (!transB)
+            {
+                SgemmVector(a, lda, b, ldb, c, m, k, n);
+                return;
+            }
+            // transB=true: B is laid out as [n, k] (original shape pre-transpose).
+            // b[j*ldb + p] is the logical B[p,j]. Transpose B once into scratch
+            // in [k, n] row-major, then use the regular axpy path with ldbT = n.
+            var bT = ArrayPool<float>.Shared.Rent(k * n);
+            try
+            {
+                for (int j = 0; j < n; j++)
+                    for (int p = 0; p < k; p++)
+                        bT[p * n + j] = b[j * ldb + p];
+                SgemmVector(a, lda, new ReadOnlySpan<float>(bT, 0, k * n), n, c, m, k, n);
+                return;
+            }
+            finally
+            {
+                ArrayPool<float>.Shared.Return(bT);
+            }
+        }
         SgemmScalar(a, lda, transA, b, ldb, transB, c, m, k, n);
     }
 
@@ -313,6 +351,78 @@ internal static class SimdGemm
                     c[cRowBase + j] += aip * bpj;
 #endif
                 }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Non-transpose GEMM using <see cref="Vector{T}"/> — a portable SIMD
+    /// primitive available on both .NET Framework 4.7.1 and .NET 5+. This is
+    /// the path taken when <c>System.Runtime.Intrinsics</c> (Avx2/Fma) is not
+    /// available: net471 in particular previously fell through to
+    /// <see cref="SgemmScalar"/>'s pure scalar triple-loop, leaving the
+    /// Conv2D im2col+GEMM path ~4× over naive instead of the ~10× seen on
+    /// net5+. Vector&lt;float&gt; typically reaches ~8× over scalar on AVX2
+    /// hardware and ~4× on SSE2, closing most of the gap.
+    ///
+    /// <para><b>Algorithm:</b> axpy over N — for each (i, p), broadcast
+    /// A[i, p] into a Vector&lt;float&gt; and fused-multiply-add with B[p, :]
+    /// into C[i, :]. B's p-th row and C's i-th row are both contiguous in
+    /// the non-transpose case, so <see cref="MemoryMarshal.Cast{TFrom,TTo}(Span{TFrom})"/>
+    /// gives zero-copy Vector&lt;float&gt; views over them.</para>
+    ///
+    /// <para><b>Caller contract:</b> transA and transB must both be false. The
+    /// dispatcher in <see cref="SgemmAddInternal"/> enforces this before
+    /// calling.</para>
+    /// </summary>
+    [MethodImpl(Hot)]
+    private static void SgemmVector(
+        ReadOnlySpan<float> a, int lda,
+        ReadOnlySpan<float> b, int ldb,
+        Span<float> c,
+        int m, int k, int n)
+    {
+        int vcount = Vector<float>.Count;
+        int nvec = n / vcount;
+        int nVecElems = nvec * vcount;
+        int nvecUnroll = nvec & ~3; // largest multiple of 4 ≤ nvec
+
+        for (int i = 0; i < m; i++)
+        {
+            int cRowBase = i * n;
+            int aRowBase = i * lda;
+            var cRow = c.Slice(cRowBase, n);
+            var cRowVec = MemoryMarshal.Cast<float, Vector<float>>(cRow.Slice(0, nVecElems));
+
+            for (int p = 0; p < k; p++)
+            {
+                float aip = a[aRowBase + p];
+                var aipVec = new Vector<float>(aip);
+
+                int bRowBase = p * ldb;
+                var bRow = b.Slice(bRowBase, n);
+                var bRowVec = MemoryMarshal.Cast<float, Vector<float>>(bRow.Slice(0, nVecElems));
+
+                // Unrolled x4 inner loop — exposes independent FMAs to the CPU's
+                // out-of-order pipeline. On net471 (SSE2/AVX2 via Vector<T>) the
+                // simple += form only issues one FMA per iteration, bottlenecked
+                // by the load-store dependency chain. Unrolling by 4 lets the
+                // CPU issue up to 4 independent vector loads + FMAs per cycle,
+                // roughly doubling throughput for small-k GEMMs.
+                int jv = 0;
+                for (; jv < nvecUnroll; jv += 4)
+                {
+                    cRowVec[jv]     += aipVec * bRowVec[jv];
+                    cRowVec[jv + 1] += aipVec * bRowVec[jv + 1];
+                    cRowVec[jv + 2] += aipVec * bRowVec[jv + 2];
+                    cRowVec[jv + 3] += aipVec * bRowVec[jv + 3];
+                }
+                for (; jv < nvec; jv++)
+                    cRowVec[jv] += aipVec * bRowVec[jv];
+
+                // Scalar tail for the last (n % vcount) elements.
+                for (int j = nVecElems; j < n; j++)
+                    c[cRowBase + j] += aip * b[bRowBase + j];
             }
         }
     }


### PR DESCRIPTION
Closes #162

## Summary

Final batch from the Issue #162 audit sweep — follows #189 (SDPA bwd), #190 (LayerNorm bwd), #191 (GroupNorm bwd). Method signatures stay generic `<T>`; float and double both get direct-array fast paths; the scalar `INumericOperations<T>` path is preserved for non-primitive T (complex, Half, int, etc.).

## Ops covered

| Op | Impact |
|---|---|
| `RMSNormBackward` | LLaMA-style transformer training |
| `ConvTranspose2D` forward | VAE decoder (directly on #162's timing-out list) + diffusion UNet upsample blocks |
| `ConvTranspose2DBackwardKernel` | VAE decoder training |
| `Conv3DBackwardInput` / `Conv3DBackwardKernel` | Video / medical imaging models |
| `MaxPool2DBackward` / `AvgPool2DBackward` | Classifier training backward |
| `ScatterMean` | Graph neural nets |
| `Upsample` forward | Follow-up commit (4d51dc7) added after the initial "skipped" note. |
| `FlashAttentionBackward` | Also added in 4d51dc7. |

## Bonus: fixes a net471 SIMD gap in `SimdGemm`

On .NET Framework 4.7.1, the entire `Avx2.IsSupported && Fma.IsSupported` fast-path block in `SgemmAddInternal` was `#if NET5_0_OR_GREATER`-gated, so net471 callers fell straight to `SgemmScalar` — a pure triple-loop with no SIMD at all. That's why `Conv2DBackwardPerfTests` asserted 10× speedup but only got ~4× on net471.

Added `SgemmVector` — a portable `System.Numerics.Vector<float>` axpy kernel that works on both frameworks (SSE2 on net471, AVX2 via Vector intrinsification on net5+ when Avx2 isn't available). 4×-unrolled inner loop exposes independent FMAs to the CPU pipeline. Wired `SgemmAddInternal` to dispatch to it when Vector is hardware-accelerated and the intrinsics path isn't taken.

For `transB=true` (Conv2DBackwardKernel's `gradOut·im2col^T` gemm), pre-transposes B into an ArrayPool buffer and reuses the non-transpose path. The transpose cost is O(k*n), amortized over the M*K work.

## CodeRabbit review fixes

Follow-up commit (20ae075) addressed both open threads:
- ConvTranspose2D fast paths: replaced per-thread full-size output buffer + lock-merge scatter with gather-form parallelized over `(batch, outChannels)`. Memory drops from O(threads × outLen) to O(outLen); eliminates LOH churn on VAE decoder shapes.
- Conv3DBackwardInput fast paths: added explicit `Array.Clear` on the gradInput buffer before the `Parallel.For` in float/double branches, matching the generic path. `new T[]` zero-initializes today, but the explicit clear stays correct if the buffer source ever switches to `TensorAllocator.RentUninitialized`.

## Test plan

- [x] Build: 0 warnings, 0 errors on both net10.0 and net471.
- [x] Full Conv / Pool / Norm / Scatter / Attention / Gemm / MatMul filter: **237/237 pass on net10.0, 234/234 pass on net471** (0 failures).
- [x] `Conv2DBackwardPerfTests`: 12/12 pass on both frameworks, including the 10× speedup threshold tests that previously failed on net471.
- [ ] Downstream AiDotNet CI: will confirm the wall-clock delta on the timing-out model shards (VAE, Capsule, HTM, SpikingNN, TransformerEmbedding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
