### PR TITLE
fix(engine): TensorCopy must use source.Length, not sourceArray.Length

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -21139,9 +21139,17 @@ public class CpuEngine : ITensorLevelEngine
         if (source.Length != destination.Length)
             throw new ArgumentException($"Tensor lengths must match. Got {source.Length} and {destination.Length}");
 
+        // Copy exactly source.Length elements — NOT sourceArray.Length.
+        // GetFlattenedData / GetDataArray can return the underlying storage
+        // array directly when the tensor is contiguous (zero-copy fast
+        // path), and that array may be over-allocated past the logical
+        // Length (e.g. arrays grown for capacity headroom). Copying
+        // sourceArray.Length would then attempt to write past
+        // destination's logical length and throw "Destination array was
+        // not long enough", even though the logical Length values agree.
         var sourceArray = source.GetFlattenedData();
         var destArray = destination.GetDataArray();
-        Array.Copy(sourceArray, destArray, sourceArray.Length);
+        Array.Copy(sourceArray, destArray, source.Length);
     }
 
     /// <inheritdoc/>

--- a/tests/AiDotNet.Tensors.Tests/Engines/MathInvariantExtendedTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/MathInvariantExtendedTests.cs
@@ -100,6 +100,56 @@ public class MathInvariantExtendedTests
     // ================================================================
     [Fact] public void Copy_ContentEqual() { var src = R([64], 1); var dst = new Tensor<float>(new float[64], [64]); E.TensorCopy(src, dst); AE(dst, src); }
     [Fact] public void Copy_Independent() { var src = R([64], 1); var dst = new Tensor<float>(new float[64], [64]); E.TensorCopy(src, dst); var sd = src.GetDataArray(); sd[0] += 100f; Assert.NotEqual(100f + dst.GetDataArray()[0], dst.GetDataArray()[0]); }
+
+    /// <summary>
+    /// Regression: TensorCopy must respect the source's logical Length, not
+    /// the underlying GetDataArray() length. ArrayPool / TensorAllocator can
+    /// return a backing array larger than the tensor's Length (per
+    /// VectorBase.GetDataArray docstring: "may be larger than Length when
+    /// backed by ArrayPool. Callers MUST index by Length."). The previous
+    /// implementation used <c>Array.Copy(src, dst, sourceArray.Length)</c>,
+    /// which would attempt to copy the full backing-array length and throw
+    /// "Destination array was not long enough" whenever the source was
+    /// over-allocated and destination was tightly sized. This test allocates
+    /// the source via TensorAllocator.Rent (which goes through the pool
+    /// path and may return an over-allocated buffer) and writes into a
+    /// tightly-sized destination.
+    /// </summary>
+    [Fact]
+    public void Copy_RentedSource_TightlySizedDestination_DoesNotOverrun()
+    {
+        // Pick a size that the ArrayPool typically rounds up to a larger
+        // bucket on net5+. 17 is small enough to live well below the
+        // 1024-element pool threshold, but the construction below uses
+        // TensorAllocator.Rent whose ArrayPool path triggers at >= the
+        // configured threshold; force a larger shape so the pool actually
+        // hands back an oversized array.
+        const int N = 1024;
+        var src = TensorAllocator.Rent<float>(new[] { N });
+        try
+        {
+            // Fill source with a known pattern.
+            var srcWritable = src.AsWritableSpan();
+            for (int i = 0; i < N; i++) srcWritable[i] = i + 0.5f;
+
+            // Destination is a plain new Tensor<T> with exactly N elements.
+            var dst = new Tensor<float>(new float[N], new[] { N });
+
+            // Pre-fix this throws ArgumentException("Destination array was
+            // not long enough...") on every CI runner where the pooled
+            // backing array exceeds N. Post-fix it copies exactly N
+            // elements.
+            E.TensorCopy(src, dst);
+
+            var dstSpan = dst.AsSpan();
+            for (int i = 0; i < N; i++)
+                Assert.True(System.Math.Abs(dstSpan[i] - (i + 0.5f)) < Tol, $"[{i}] expected {i + 0.5f} got {dstSpan[i]}");
+        }
+        finally
+        {
+            TensorAllocator.Return(src);
+        }
+    }
     [Fact] public void Fill_AllSameValue() { var t = new Tensor<float>(new float[64], [64]); E.TensorFill(t, 3.14f); var d = t.GetDataArray(); for (int i = 0; i < d.Length; i++) Assert.Equal(3.14f, d[i], Tol); }
 
     // ================================================================

--- a/tests/AiDotNet.Tensors.Tests/Engines/MathInvariantExtendedTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/MathInvariantExtendedTests.cs
@@ -118,16 +118,23 @@ public class MathInvariantExtendedTests
     [Fact]
     public void Copy_RentedSource_TightlySizedDestination_DoesNotOverrun()
     {
-        // Pick a size that the ArrayPool typically rounds up to a larger
-        // bucket on net5+. 17 is small enough to live well below the
-        // 1024-element pool threshold, but the construction below uses
-        // TensorAllocator.Rent whose ArrayPool path triggers at >= the
-        // configured threshold; force a larger shape so the pool actually
-        // hands back an oversized array.
-        const int N = 1024;
+        // TensorAllocator.Rent only routes through ArrayPool at or above
+        // ArrayPoolThresholdValue elements. Below that, Rent returns an
+        // exactly-sized backing array and the test passes even on the
+        // pre-fix (buggy) implementation — making the regression check
+        // toothless. Force a size past the threshold so the pool actually
+        // hands back an over-allocated bucket, then hard-assert that
+        // over-allocation occurred before proceeding.
+        int N = Math.Max(TensorAllocator.ArrayPoolThresholdValue + 1, 1025);
         var src = TensorAllocator.Rent<float>(new[] { N });
         try
         {
+            int backingLength = src.GetDataArray().Length;
+            Assert.True(
+                backingLength > src.Length,
+                $"Test precondition failed: backing length {backingLength} must exceed logical length {src.Length}. " +
+                $"ArrayPool did not over-allocate at N={N}; this run would pass even on the buggy pre-fix impl.");
+
             // Fill source with a known pattern.
             var srcWritable = src.AsWritableSpan();
             for (int i = 0; i < N; i++) srcWritable[i] = i + 0.5f;
@@ -136,9 +143,8 @@ public class MathInvariantExtendedTests
             var dst = new Tensor<float>(new float[N], new[] { N });
 
             // Pre-fix this throws ArgumentException("Destination array was
-            // not long enough...") on every CI runner where the pooled
-            // backing array exceeds N. Post-fix it copies exactly N
-            // elements.
+            // not long enough...") because the impl indexed by backing-array
+            // length. Post-fix it copies exactly src.Length elements.
             E.TensorCopy(src, dst);
 
             var dstSpan = dst.AsSpan();


### PR DESCRIPTION
## Summary

``CpuEngine.TensorCopy`` copies the wrong element count whenever the source tensor's backing array is over-allocated past its logical ``Length`` (the standard ``ArrayPool`` / ``TensorAllocator`` case). It calls

\`\`\`csharp
Array.Copy(sourceArray, destArray, sourceArray.Length);
\`\`\`

where ``sourceArray = source.GetFlattenedData()`` returns the underlying storage array directly on the contiguous fast path. The documented contract on ``VectorBase.GetDataArray`` is:

> The returned array may be larger than ``Length`` when backed by ``ArrayPool``.
> Callers MUST index by ``Length``, not ``array.Length``.

``TensorCopy`` was violating that contract — copying ``sourceArray.Length`` elements writes past the destination's logical end and throws

\`\`\`
ArgumentException("Destination array was not long enough. Check the destination index,
                   length, and the array's lower bounds. (Parameter 'destinationArray')")
\`\`\`

even though ``source.Length == destination.Length`` (the explicit length check above already passed).

## Discovered via

CI failure on consumer repo ``ooples/AiDotNet`` PR #1154 / master, in ``MobileNetV3_Train_CompletesWithoutError``:

\`\`\`
AdamOptimizer.Step
  -> Engine.TensorAdd(mScaled, gradScaled)   // mNew is backed by a pooled, over-allocated buffer
  -> Engine.TensorCopy(mNew, m)              // m is tightly sized; throws
\`\`\`

The optimizer correctly sized ``m`` to ``param._shape``, but the intermediate ``mNew`` came from ``Engine.TensorAdd`` which allocates via ``TensorAllocator.Rent`` → ``ArrayPool<T>.Shared.Rent(totalSize)``. The pool returns a buffer of ``Length >= totalSize``, and ``TensorCopy`` then tries to copy that whole buffer into ``m``.

## Fix

\`\`\`diff
- Array.Copy(sourceArray, destArray, sourceArray.Length);
+ Array.Copy(sourceArray, destArray, source.Length);
\`\`\`

The explicit ``source.Length != destination.Length`` check earlier in the method guarantees the new copy count fits in destination.

## Tests

``tests/AiDotNet.Tensors.Tests/Engines/MathInvariantExtendedTests.cs``:

- ``Copy_RentedSource_TightlySizedDestination_DoesNotOverrun`` — new regression. Allocates source via ``TensorAllocator.Rent<float>`` (which goes through the ArrayPool path on net5+ and may return an over-allocated buffer), creates a tightly-sized destination, calls ``TensorCopy``, asserts every element transferred correctly. Pre-fix throws ``ArgumentException``; post-fix passes.
- Existing ``Copy_ContentEqual`` and ``Copy_Independent`` unaffected.

## Test results

\`\`\`
Passed! - Failed: 0, Passed: 3, Skipped: 0, Total: 3
\`\`\`

(Net10.0 only run; same TensorCopy code path on net471 — the regression test's ``TensorAllocator.Rent`` path is net5+-gated by a ``#if NET5_0_OR_GREATER``.)

## Followup

Consumer repo ``ooples/AiDotNet`` will bump its ``AiDotNet.Tensors`` package reference to the version containing this fix and verify ``MobileNetV3_Train_CompletesWithoutError`` (and any other test hitting the same Adam path) goes green.

## Test plan
- [x] Pre-fix: regression test throws ``ArgumentException``
- [x] Post-fix: regression test passes
- [x] Existing TensorCopy tests still pass
- [x] No other call sites assume ``Array.Copy(src, dst, src.Length)`` semantics — grepped repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)