### PR TITLE
feat(autotune): WarmupCommonKernelsAsync + WarmupCategoryAsync (closes #200)

### DIFF
--- a/src/AiDotNet.Tensors/Helpers/Autotune/AutotuneCache.cs
+++ b/src/AiDotNet.Tensors/Helpers/Autotune/AutotuneCache.cs
@@ -344,6 +344,11 @@ public static class AutotuneCache
         IProgress<string>? progress = null,
         CancellationToken ct = default)
     {
+        // Lazy register built-in entries (GEMM variant select, …) the first
+        // time any warmup runs. Tests that Clear() the catalog don't get
+        // re-seeded automatically — they call BuiltInCatalog.EnsureRegistered
+        // or accept an empty catalog.
+        BuiltInCatalog.EnsureRegistered();
         return WarmupInternalAsync(
             AutotuneKernelCatalog.Entries,
             representativeInputShapes ?? DefaultRepresentativeShapes(),
@@ -365,6 +370,7 @@ public static class AutotuneCache
     {
         if (category is null) throw new ArgumentNullException(nameof(category));
         if (representativeInputShapes is null) throw new ArgumentNullException(nameof(representativeInputShapes));
+        BuiltInCatalog.EnsureRegistered();
         return WarmupInternalAsync(
             AutotuneKernelCatalog.EntriesForCategory(category),
             representativeInputShapes,

--- a/src/AiDotNet.Tensors/Helpers/Autotune/AutotuneCache.cs
+++ b/src/AiDotNet.Tensors/Helpers/Autotune/AutotuneCache.cs
@@ -326,6 +326,135 @@ public static class AutotuneCache
     }
 
     /// <summary>
+    /// One-call warmup of every kernel registered in
+    /// <see cref="AutotuneKernelCatalog"/> at the supplied representative
+    /// shapes. Callers don't need to know Tensors-internal KernelIds or
+    /// variant spaces — the catalog supplies both. For each (kernel, shape)
+    /// that isn't already cached, every registered variant is benchmarked
+    /// and the highest-GFLOPS winner is persisted.
+    /// </summary>
+    /// <param name="representativeInputShapes">Shapes to warm up each
+    /// kernel at. When null, a conservative default set covering common
+    /// MLP/transformer matmul dims is used.</param>
+    /// <param name="progress">Receives a per-entry progress line
+    /// (<c>"warmed {kernel.ToFileStem()} @ {shape} → {variant} ({gflops:F1} GFLOPS)"</c>).</param>
+    /// <param name="ct">Cancellation.</param>
+    public static Task<AutotuneWarmupReport> WarmupCommonKernelsAsync(
+        IEnumerable<int[]>? representativeInputShapes = null,
+        IProgress<string>? progress = null,
+        CancellationToken ct = default)
+    {
+        return WarmupInternalAsync(
+            AutotuneKernelCatalog.Entries,
+            representativeInputShapes ?? DefaultRepresentativeShapes(),
+            progress,
+            ct);
+    }
+
+    /// <summary>
+    /// Variant of <see cref="WarmupCommonKernelsAsync"/> that limits the
+    /// warmup to catalog entries whose <see cref="KernelId.Category"/>
+    /// matches <paramref name="category"/>. Use when you only care about
+    /// one op family (e.g. <c>"gemm"</c>) and want to skip the rest.
+    /// </summary>
+    public static Task<AutotuneWarmupReport> WarmupCategoryAsync(
+        string category,
+        IEnumerable<int[]> representativeInputShapes,
+        IProgress<string>? progress = null,
+        CancellationToken ct = default)
+    {
+        if (category is null) throw new ArgumentNullException(nameof(category));
+        if (representativeInputShapes is null) throw new ArgumentNullException(nameof(representativeInputShapes));
+        return WarmupInternalAsync(
+            AutotuneKernelCatalog.EntriesForCategory(category),
+            representativeInputShapes,
+            progress,
+            ct);
+    }
+
+    private static async Task<AutotuneWarmupReport> WarmupInternalAsync(
+        IReadOnlyList<AutotuneCatalogEntry> entries,
+        IEnumerable<int[]> shapes,
+        IProgress<string>? progress,
+        CancellationToken ct)
+    {
+        var shapeList = (shapes as IReadOnlyList<int[]>) ?? shapes.ToArray();
+        var shapeProfiles = new ShapeProfile[shapeList.Count];
+        for (int i = 0; i < shapeList.Count; i++)
+            shapeProfiles[i] = new ShapeProfile(shapeList[i]);
+
+        var best = new Dictionary<string, double>();
+        int kernelsWarmed = 0;
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+
+        // Sequential outer loop (per-variant benchmarking is already the
+        // parallel unit of work; running two distinct kernels concurrently
+        // on the same cores causes false contention and noise). If we ever
+        // want multi-GPU warmup, the catalog entry can internally parallelise
+        // across devices.
+        foreach (var entry in entries)
+        {
+            ct.ThrowIfCancellationRequested();
+            bool anyFreshBenchmark = false;
+            foreach (var shape in shapeProfiles)
+            {
+                ct.ThrowIfCancellationRequested();
+                if (Lookup(entry.Id, shape) is { } existing)
+                {
+                    best[ReportKey(entry.Id, shape)] = existing.MeasuredGflops;
+                    progress?.Report($"cached {entry.Id.ToFileStem()} @ {shape.ToFileStem()} ({existing.Variant}, {existing.MeasuredGflops:F1} GFLOPS)");
+                    continue;
+                }
+
+                // Benchmark every variant, keep the highest-GFLOPS winner.
+                string bestVariant = "";
+                double bestGflops = double.NegativeInfinity;
+                foreach (var variant in entry.Variants(shape))
+                {
+                    ct.ThrowIfCancellationRequested();
+                    double g = await entry.BenchmarkVariant(shape, variant, ct).ConfigureAwait(false);
+                    if (g > bestGflops)
+                    {
+                        bestGflops = g;
+                        bestVariant = variant;
+                    }
+                }
+
+                if (bestGflops > 0)
+                {
+                    var choice = new KernelChoice
+                    {
+                        Variant = bestVariant,
+                        MeasuredGflops = bestGflops,
+                    };
+                    TryStore(entry.Id, shape, choice);
+                    best[ReportKey(entry.Id, shape)] = bestGflops;
+                    anyFreshBenchmark = true;
+                    progress?.Report($"warmed {entry.Id.ToFileStem()} @ {shape.ToFileStem()} → {bestVariant} ({bestGflops:F1} GFLOPS)");
+                }
+            }
+            if (anyFreshBenchmark) kernelsWarmed++;
+        }
+        sw.Stop();
+        return new AutotuneWarmupReport(kernelsWarmed, shapeProfiles.Length, sw.Elapsed, best);
+    }
+
+    private static string ReportKey(KernelId id, ShapeProfile shape)
+        => $"{id.ToFileStem()}@{shape.ToFileStem()}";
+
+    private static int[][] DefaultRepresentativeShapes() => new[]
+    {
+        // Common MLP / single-token inference shapes. GEMM (M, N, K) is
+        // interpreted by each catalog entry. For 2-D input-activation
+        // shapes the entry can treat indices as (batch, features).
+        new[] { 1, 784 },
+        new[] { 32, 784 },
+        new[] { 128, 784 },
+        new[] { 1, 768 },    // BERT-base hidden dim
+        new[] { 32, 768 },
+    };
+
+    /// <summary>
     /// Deletes every cache file under the current hardware fingerprint's
     /// directory. Intended for tests and for operators who want to force a
     /// full re-tune (e.g. after a driver upgrade on the same hardware that

--- a/src/AiDotNet.Tensors/Helpers/Autotune/AutotuneKernelCatalog.cs
+++ b/src/AiDotNet.Tensors/Helpers/Autotune/AutotuneKernelCatalog.cs
@@ -1,0 +1,107 @@
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AiDotNet.Tensors.Helpers.Autotune;
+
+/// <summary>
+/// Internal registry of tunable kernels that <see cref="AutotuneCache"/>
+/// knows how to benchmark. Each entry pairs a <see cref="KernelId"/> with
+/// a variant enumerator and a benchmark function — the data the
+/// <see cref="AutotuneCache.WarmupCommonKernelsAsync"/> entry point needs
+/// to turn "warm up everything relevant" into a concrete set of
+/// benchmark jobs without the caller having to know library internals.
+///
+/// <para>Internal-only so only Tensors itself can register entries;
+/// downstream consumers can't inject kernels they don't own, which keeps
+/// the catalog semantics meaningful ("common kernels shipped with
+/// Tensors").</para>
+///
+/// <para>Populated at type-initialisation time by the modules that own
+/// each kernel family (GEMM, Conv, SDPA). An empty catalog is a valid
+/// runtime state — the warmup APIs return
+/// <see cref="AutotuneWarmupReport"/> with <c>KernelsWarmed = 0</c>.</para>
+/// </summary>
+internal static class AutotuneKernelCatalog
+{
+    // ConcurrentDictionary keyed on KernelId gives us atomic register +
+    // idempotent re-registration (duplicate keys overwrite, last-in wins).
+    // Register is called from static constructors; order across type
+    // initializers is non-deterministic, but later overwrites mean the
+    // last-registered variant-set/benchmarker is what Warmup sees. In
+    // practice each kernel id is registered once.
+    private static readonly ConcurrentDictionary<KernelId, AutotuneCatalogEntry> _entries = new();
+
+    /// <summary>Adds <paramref name="entry"/> to the registry, overwriting any
+    /// existing entry for the same <see cref="AutotuneCatalogEntry.Id"/>.</summary>
+    public static void Register(AutotuneCatalogEntry entry)
+    {
+        if (entry is null) throw new ArgumentNullException(nameof(entry));
+        _entries[entry.Id] = entry;
+    }
+
+    /// <summary>Snapshot of every registered entry. Order is unspecified.</summary>
+    public static IReadOnlyList<AutotuneCatalogEntry> Entries => _entries.Values.ToArray();
+
+    /// <summary>Entries whose <see cref="KernelId.Category"/> matches
+    /// <paramref name="category"/> (ordinal, case-sensitive).</summary>
+    public static IReadOnlyList<AutotuneCatalogEntry> EntriesForCategory(string category)
+    {
+        if (category is null) throw new ArgumentNullException(nameof(category));
+        return _entries.Values
+            .Where(e => string.Equals(e.Id.Category, category, StringComparison.Ordinal))
+            .ToArray();
+    }
+
+    /// <summary>Test-hook: erases every registered entry. Tests that need a
+    /// clean catalog call this in Arrange.</summary>
+    internal static void Clear() => _entries.Clear();
+}
+
+/// <summary>
+/// A tunable kernel family in the catalog. Variants are the candidate
+/// implementations (e.g. <c>"blas"</c>, <c>"simd"</c>); BenchmarkVariant
+/// times one variant at a shape and returns GFLOPS (higher is better).
+/// </summary>
+internal sealed class AutotuneCatalogEntry
+{
+    public KernelId Id { get; }
+
+    /// <summary>Variant names to evaluate at a given shape. Same shape may
+    /// expose different variant sets (e.g. tensor-core kernels only for
+    /// shapes divisible by 8 on Ampere+).</summary>
+    public Func<ShapeProfile, IEnumerable<string>> Variants { get; }
+
+    /// <summary>Runs the benchmark for one variant at one shape, returns
+    /// measured GFLOPS. Return 0 or negative to signal "not applicable" —
+    /// that variant is skipped for this shape.</summary>
+    public Func<ShapeProfile, string, CancellationToken, Task<double>> BenchmarkVariant { get; }
+
+    public AutotuneCatalogEntry(
+        KernelId id,
+        Func<ShapeProfile, IEnumerable<string>> variants,
+        Func<ShapeProfile, string, CancellationToken, Task<double>> benchmarkVariant)
+    {
+        Id = id;
+        Variants = variants ?? throw new ArgumentNullException(nameof(variants));
+        BenchmarkVariant = benchmarkVariant ?? throw new ArgumentNullException(nameof(benchmarkVariant));
+    }
+}
+
+/// <summary>
+/// Summary of a <see cref="AutotuneCache.WarmupCommonKernelsAsync"/> call.
+/// </summary>
+/// <param name="KernelsWarmed">Number of distinct catalog entries that
+/// ran at least one fresh benchmark during the call. Does not include
+/// entries that were already in the cache.</param>
+/// <param name="ShapesPerKernel">Number of representative shapes supplied
+/// to the warmup.</param>
+/// <param name="Duration">Wall time for the whole warmup.</param>
+/// <param name="BestGflopsByKernel">The winning variant's measured GFLOPS
+/// per (KernelId.ToFileStem, shape) pair — useful for logging and CI
+/// perf dashboards.</param>
+public sealed record AutotuneWarmupReport(
+    int KernelsWarmed,
+    int ShapesPerKernel,
+    TimeSpan Duration,
+    Dictionary<string, double> BestGflopsByKernel);

--- a/src/AiDotNet.Tensors/Helpers/Autotune/AutotuneKernelCatalog.cs
+++ b/src/AiDotNet.Tensors/Helpers/Autotune/AutotuneKernelCatalog.cs
@@ -82,6 +82,15 @@ internal sealed class AutotuneCatalogEntry
         Func<ShapeProfile, IEnumerable<string>> variants,
         Func<ShapeProfile, string, CancellationToken, Task<double>> benchmarkVariant)
     {
+        // KernelId is a readonly record struct (value type) so it can never be
+        // null — but its Category/Name strings can be. Catalog consumers build
+        // cache filenames from those strings, and a null here would corrupt
+        // the cache path. Fail fast at construction instead of handing the
+        // problem to the filesystem layer.
+        if (id.Category is null)
+            throw new ArgumentException("KernelId.Category must not be null.", nameof(id));
+        if (id.Name is null)
+            throw new ArgumentException("KernelId.Name must not be null.", nameof(id));
         Id = id;
         Variants = variants ?? throw new ArgumentNullException(nameof(variants));
         BenchmarkVariant = benchmarkVariant ?? throw new ArgumentNullException(nameof(benchmarkVariant));

--- a/src/AiDotNet.Tensors/Helpers/Autotune/BuiltInCatalog.cs
+++ b/src/AiDotNet.Tensors/Helpers/Autotune/BuiltInCatalog.cs
@@ -22,6 +22,20 @@ namespace AiDotNet.Tensors.Helpers.Autotune;
 /// shape." Empty catalog trivially satisfies this; this class makes the
 /// claim load-bearing by actually registering a kernel that benchmarks
 /// and stores.</para>
+///
+/// <para><b>Concurrency contract — run warmup BEFORE serving traffic.</b>
+/// The <c>SGEMM</c> benchmark below toggles the process-wide
+/// <see cref="SimdGemm.UseParallelGemm"/> flag to measure each variant and
+/// restores it before returning. This is safe only when no other thread is
+/// calling <c>SimdGemm.Sgemm</c> concurrently with the warmup; a concurrent
+/// GEMM caller would observe the wrong parallelism choice for the duration
+/// of the benchmark, producing correct results but degraded (or inflated)
+/// throughput attributable to the wrong variant. In practice warmup is
+/// a startup-time operation run before the application handles requests,
+/// so this window is empty. Future follow-up: introduce a scoped override
+/// on <see cref="SimdGemm"/> (e.g.
+/// <c>SimdGemm.WithParallelGemm(bool, Action)</c>) and route the benchmark
+/// through it so concurrent callers are never perturbed.</para>
 /// </summary>
 internal static class BuiltInCatalog
 {
@@ -92,11 +106,16 @@ internal static class BuiltInCatalog
         SimdGemm.Sgemm(a, b, c, m, k, n);
         ct.ThrowIfCancellationRequested();
 
-        // Measure. Toggle the parallel switch per variant — a proper
-        // scoped override wrapper would be cleaner but SimdGemm exposes
-        // only the static flag today. Temporary mutation is isolated by
-        // BenchmarkVariant being called sequentially from the warmup
-        // driver, and we restore before return.
+        // Measure. Toggle the process-wide parallel switch per variant.
+        // SimdGemm exposes only the global flag today — save/restore bounds
+        // the mutation to this benchmark. CALLER CONTRACT (see class
+        // docstring): warmup must run when no other thread is calling
+        // SimdGemm.Sgemm; a concurrent caller during this window would see
+        // the wrong parallelism choice (correct results, wrong throughput
+        // for that one call). The warmup driver calls BenchmarkVariant
+        // sequentially so variants don't fight each other; a future scoped
+        // SimdGemm.WithParallelGemm(...) helper will make this robust
+        // against concurrent application callers too.
         bool savedParallel = SimdGemm.UseParallelGemm;
         SimdGemm.UseParallelGemm = variant == "parallel";
         const int iters = 5;

--- a/src/AiDotNet.Tensors/Helpers/Autotune/BuiltInCatalog.cs
+++ b/src/AiDotNet.Tensors/Helpers/Autotune/BuiltInCatalog.cs
@@ -41,6 +41,15 @@ internal static class BuiltInCatalog
 {
     public static readonly KernelId SGEMM = new("gemm", "cpu-simd-sgemm");
 
+    // Registration latch MUST be set only AFTER Register() successfully
+    // completes. The previous Interlocked.Exchange-then-Register ordering
+    // had two failure modes: (a) a concurrent caller could observe
+    // _registered == 1 while Register() was still in flight and call
+    // AutotuneCache.Lookup before the catalog entry was installed, and
+    // (b) if Register() threw, _registered stayed at 1 forever and the
+    // registration could never be retried. Fix via double-checked locking
+    // with Volatile.Write after the successful registration completes.
+    private static readonly object _registerGate = new();
     private static int _registered;
 
     /// <summary>Idempotently registers the built-in catalog entries.
@@ -48,17 +57,24 @@ internal static class BuiltInCatalog
     /// registry is warm before any Warmup call.</summary>
     public static void EnsureRegistered()
     {
-        if (Interlocked.Exchange(ref _registered, 1) == 1) return;
-        AutotuneKernelCatalog.Register(new AutotuneCatalogEntry(
-            SGEMM,
-            variants: SgemmVariants,
-            benchmarkVariant: BenchmarkSgemmVariant));
+        if (Volatile.Read(ref _registered) == 1) return;
+        lock (_registerGate)
+        {
+            if (_registered == 1) return;
+            AutotuneKernelCatalog.Register(new AutotuneCatalogEntry(
+                SGEMM,
+                variants: SgemmVariants,
+                benchmarkVariant: BenchmarkSgemmVariant));
+            // Publish only after Register() succeeds. If Register throws,
+            // _registered stays 0 and the next caller retries.
+            Volatile.Write(ref _registered, 1);
+        }
     }
 
     /// <summary>Test hook — forces re-registration on the next EnsureRegistered
     /// call. Needed by AutotuneKernelCatalog.Clear tests so the module-init
     /// registrations don't shadow a Clear.</summary>
-    public static void ResetRegistrationForTests() => Interlocked.Exchange(ref _registered, 0);
+    public static void ResetRegistrationForTests() => Volatile.Write(ref _registered, 0);
 
     private static IEnumerable<string> SgemmVariants(ShapeProfile shape)
     {
@@ -94,9 +110,21 @@ internal static class BuiltInCatalog
         }
         if (m <= 0 || n <= 0 || k <= 0) return Task.FromResult(0.0);
 
-        var a = new float[m * k];
-        var b = new float[k * n];
-        var c = new float[m * n];
+        // Compute allocation sizes in long so we can detect int-overflow
+        // from large shapes BEFORE calling `new float[...]`. Overflowing
+        // sizes would either wrap to a small/negative allocation (wrong
+        // benchmark output) or push memory pressure into the tens of GB.
+        // Return 0.0 (the agreed "not applicable" signal) so the warmup
+        // driver skips this variant at this shape instead of throwing.
+        long aLen = (long)m * k;
+        long bLen = (long)k * n;
+        long cLen = (long)m * n;
+        if (aLen > int.MaxValue || bLen > int.MaxValue || cLen > int.MaxValue)
+            return Task.FromResult(0.0);
+
+        var a = new float[(int)aLen];
+        var b = new float[(int)bLen];
+        var c = new float[(int)cLen];
         var rng = new Random(0x515EE + variant.GetHashCode());
         for (int i = 0; i < a.Length; i++) a[i] = (float)rng.NextDouble();
         for (int i = 0; i < b.Length; i++) b[i] = (float)rng.NextDouble();

--- a/src/AiDotNet.Tensors/Helpers/Autotune/BuiltInCatalog.cs
+++ b/src/AiDotNet.Tensors/Helpers/Autotune/BuiltInCatalog.cs
@@ -1,0 +1,122 @@
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using AiDotNet.Tensors.Engines.Simd;
+
+namespace AiDotNet.Tensors.Helpers.Autotune;
+
+/// <summary>
+/// Tensors-internal kernel inventory — the catalog entries that
+/// <see cref="AutotuneCache.WarmupCommonKernelsAsync"/> populates when no
+/// external registrations are present.
+///
+/// <para>Registered at module init so consumers who only call the new
+/// public warmup API don't need to know internal KernelIds or variant
+/// spaces. Today: one GEMM family (parallel-vs-sequential). Each new
+/// tunable kernel (Conv2D variants, SDPA block sizes, …) plugs in here
+/// as its integration lands.</para>
+///
+/// <para><b>Acceptance contract (issue #200):</b> "After
+/// WarmupCommonKernelsAsync completes, <c>Lookup(id, shape)</c> returns
+/// a non-null KernelChoice for every common kernel at every supplied
+/// shape." Empty catalog trivially satisfies this; this class makes the
+/// claim load-bearing by actually registering a kernel that benchmarks
+/// and stores.</para>
+/// </summary>
+internal static class BuiltInCatalog
+{
+    public static readonly KernelId SGEMM = new("gemm", "cpu-simd-sgemm");
+
+    private static int _registered;
+
+    /// <summary>Idempotently registers the built-in catalog entries.
+    /// Called from <see cref="AutotuneCache"/>'s module init so the
+    /// registry is warm before any Warmup call.</summary>
+    public static void EnsureRegistered()
+    {
+        if (Interlocked.Exchange(ref _registered, 1) == 1) return;
+        AutotuneKernelCatalog.Register(new AutotuneCatalogEntry(
+            SGEMM,
+            variants: SgemmVariants,
+            benchmarkVariant: BenchmarkSgemmVariant));
+    }
+
+    /// <summary>Test hook — forces re-registration on the next EnsureRegistered
+    /// call. Needed by AutotuneKernelCatalog.Clear tests so the module-init
+    /// registrations don't shadow a Clear.</summary>
+    public static void ResetRegistrationForTests() => Interlocked.Exchange(ref _registered, 0);
+
+    private static IEnumerable<string> SgemmVariants(ShapeProfile shape)
+    {
+        // Shape[0]*[1]*[2] = M*N*K — effective work in FMAs. Parallel dispatch
+        // only makes sense when work justifies the thread-pool overhead; we
+        // still ENUMERATE both so the benchmark can record that sequential
+        // won at small shapes (consumers may still want that data).
+        yield return "sequential";
+        yield return "parallel";
+    }
+
+    private static Task<double> BenchmarkSgemmVariant(ShapeProfile shape, string variant, CancellationToken ct)
+    {
+        // Shape profile for GEMM is (M, N, K). Other ranks fall back to a
+        // square-ish heuristic — pick the geometric mean as the side length
+        // so the benchmark still runs something meaningful. Returning 0
+        // would make the warmup skip this variant at that shape, which is
+        // also acceptable.
+        int[] dims = shape.Dimensions;
+        int m, n, k;
+        if (dims.Length >= 3)
+        {
+            m = dims[0]; n = dims[1]; k = dims[2];
+        }
+        else if (dims.Length == 2)
+        {
+            // [M, features] — treat features as N=K for square-ish GEMM.
+            m = dims[0]; n = dims[1]; k = dims[1];
+        }
+        else
+        {
+            return Task.FromResult(0.0);
+        }
+        if (m <= 0 || n <= 0 || k <= 0) return Task.FromResult(0.0);
+
+        var a = new float[m * k];
+        var b = new float[k * n];
+        var c = new float[m * n];
+        var rng = new Random(0x515EE + variant.GetHashCode());
+        for (int i = 0; i < a.Length; i++) a[i] = (float)rng.NextDouble();
+        for (int i = 0; i < b.Length; i++) b[i] = (float)rng.NextDouble();
+
+        // Warm up — let JIT compile and L1 prime.
+        SimdGemm.Sgemm(a, b, c, m, k, n);
+        SimdGemm.Sgemm(a, b, c, m, k, n);
+        ct.ThrowIfCancellationRequested();
+
+        // Measure. Toggle the parallel switch per variant — a proper
+        // scoped override wrapper would be cleaner but SimdGemm exposes
+        // only the static flag today. Temporary mutation is isolated by
+        // BenchmarkVariant being called sequentially from the warmup
+        // driver, and we restore before return.
+        bool savedParallel = SimdGemm.UseParallelGemm;
+        SimdGemm.UseParallelGemm = variant == "parallel";
+        const int iters = 5;
+        var sw = Stopwatch.StartNew();
+        try
+        {
+            for (int i = 0; i < iters; i++)
+            {
+                ct.ThrowIfCancellationRequested();
+                SimdGemm.Sgemm(a, b, c, m, k, n);
+            }
+        }
+        finally
+        {
+            SimdGemm.UseParallelGemm = savedParallel;
+        }
+        sw.Stop();
+        double secsPerIter = sw.Elapsed.TotalSeconds / iters;
+        if (secsPerIter <= 0) return Task.FromResult(0.0);
+        double flops = 2.0 * m * k * n;
+        return Task.FromResult(flops / 1e9 / secsPerIter);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Helpers/Autotune/AutotuneWarmupTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/Autotune/AutotuneWarmupTests.cs
@@ -6,23 +6,53 @@ using Xunit;
 namespace AiDotNet.Tensors.Tests.Helpers.Autotune;
 
 /// <summary>
+/// xUnit collection that pins <see cref="AutotuneWarmupTests"/> to serial
+/// execution. Each test mutates process-wide shared state
+/// (<c>AIDOTNET_AUTOTUNE_CACHE_PATH</c> env var + the static
+/// <see cref="AutotuneKernelCatalog"/>); parallel workers would otherwise
+/// race on both. Mirrors the <see cref="AutotuneCacheTests"/> pattern.
+/// </summary>
+[CollectionDefinition("AutotuneWarmupTests", DisableParallelization = true)]
+public sealed class AutotuneWarmupTestsCollection { }
+
+/// <summary>
 /// Tests for issue #200 — <see cref="AutotuneCache.WarmupCommonKernelsAsync"/>
 /// and <see cref="AutotuneCache.WarmupCategoryAsync"/>. Uses a synthetic
 /// <see cref="AutotuneCatalogEntry"/> so tests are deterministic and don't
 /// depend on host-specific BLAS.
 /// </summary>
-public class AutotuneWarmupTests
+[Collection("AutotuneWarmupTests")]
+public sealed class AutotuneWarmupTests : IDisposable
 {
-    // Each test isolates itself by clearing the catalog up front; they also
-    // write to a sandbox autotune cache path so the host's real cache is
-    // untouched.
+    private const string EnvVar = "AIDOTNET_AUTOTUNE_CACHE_PATH";
+    private readonly string _tempRoot;
+    private readonly string? _originalEnv;
+
     public AutotuneWarmupTests()
     {
+        // Snapshot the prior env var so Dispose can restore it — otherwise a
+        // CI runner that preset the var loses its setting after the first
+        // test runs. Save-and-restore matches AutotuneCacheTests.
+        _originalEnv = Environment.GetEnvironmentVariable(EnvVar);
         AutotuneKernelCatalog.Clear();
-        // Redirect the cache to a per-test temp dir via env var. Kept for
-        // the duration of the test; another test clearing it is fine.
-        var tmp = Path.Combine(Path.GetTempPath(), "aidotnet-autotune-test-" + Guid.NewGuid().ToString("N"));
-        Environment.SetEnvironmentVariable("AIDOTNET_AUTOTUNE_CACHE_PATH", tmp);
+        _tempRoot = Path.Combine(
+            Path.GetTempPath(),
+            "aidotnet-autotune-test-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable(EnvVar, _tempRoot);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable(EnvVar, _originalEnv);
+        AutotuneKernelCatalog.Clear();
+        try
+        {
+            if (Directory.Exists(_tempRoot)) Directory.Delete(_tempRoot, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup — OS may hold a handle briefly after Dispose.
+        }
     }
 
     [Fact]

--- a/tests/AiDotNet.Tensors.Tests/Helpers/Autotune/AutotuneWarmupTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/Autotune/AutotuneWarmupTests.cs
@@ -1,0 +1,174 @@
+using System.Threading;
+using System.Threading.Tasks;
+using AiDotNet.Tensors.Helpers.Autotune;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Helpers.Autotune;
+
+/// <summary>
+/// Tests for issue #200 — <see cref="AutotuneCache.WarmupCommonKernelsAsync"/>
+/// and <see cref="AutotuneCache.WarmupCategoryAsync"/>. Uses a synthetic
+/// <see cref="AutotuneCatalogEntry"/> so tests are deterministic and don't
+/// depend on host-specific BLAS.
+/// </summary>
+public class AutotuneWarmupTests
+{
+    // Each test isolates itself by clearing the catalog up front; they also
+    // write to a sandbox autotune cache path so the host's real cache is
+    // untouched.
+    public AutotuneWarmupTests()
+    {
+        AutotuneKernelCatalog.Clear();
+        // Redirect the cache to a per-test temp dir via env var. Kept for
+        // the duration of the test; another test clearing it is fine.
+        var tmp = Path.Combine(Path.GetTempPath(), "aidotnet-autotune-test-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("AIDOTNET_AUTOTUNE_CACHE_PATH", tmp);
+    }
+
+    [Fact]
+    public async Task WarmupCommonKernels_EmptyCatalog_ReturnsNoOpReport()
+    {
+        var report = await AutotuneCache.WarmupCommonKernelsAsync();
+        Assert.Equal(0, report.KernelsWarmed);
+        Assert.True(report.ShapesPerKernel > 0, "default shape set should be non-empty");
+        Assert.Empty(report.BestGflopsByKernel);
+    }
+
+    [Fact]
+    public async Task WarmupCommonKernels_SingleEntry_PopulatesCacheForEveryShape()
+    {
+        var id = new KernelId("unit-test", "stub-gemm");
+        // Variants: "fast" (100 GFLOPS) and "slow" (50 GFLOPS) — fast must win.
+        AutotuneKernelCatalog.Register(new AutotuneCatalogEntry(
+            id,
+            variants: _ => new[] { "fast", "slow" },
+            benchmarkVariant: (shape, variant, ct) =>
+                Task.FromResult(variant == "fast" ? 100.0 : 50.0)));
+
+        var shapes = new[] { new[] { 2, 4 }, new[] { 8, 16 } };
+        var report = await AutotuneCache.WarmupCommonKernelsAsync(shapes);
+
+        Assert.Equal(1, report.KernelsWarmed);
+        Assert.Equal(2, report.ShapesPerKernel);
+
+        foreach (var s in shapes)
+        {
+            var choice = AutotuneCache.Lookup(id, new ShapeProfile(s));
+            Assert.NotNull(choice);
+            Assert.Equal("fast", choice!.Variant);
+            Assert.Equal(100.0, choice.MeasuredGflops);
+        }
+    }
+
+    [Fact]
+    public async Task WarmupCommonKernels_SecondRun_SkipsAlreadyCachedEntries()
+    {
+        int benchmarkCalls = 0;
+        var id = new KernelId("unit-test", "counted");
+        AutotuneKernelCatalog.Register(new AutotuneCatalogEntry(
+            id,
+            variants: _ => new[] { "only" },
+            benchmarkVariant: (shape, variant, ct) =>
+            {
+                Interlocked.Increment(ref benchmarkCalls);
+                return Task.FromResult(75.0);
+            }));
+
+        var shapes = new[] { new[] { 1, 1 } };
+        await AutotuneCache.WarmupCommonKernelsAsync(shapes);
+        int afterFirst = benchmarkCalls;
+        await AutotuneCache.WarmupCommonKernelsAsync(shapes);
+
+        Assert.Equal(1, afterFirst);
+        Assert.Equal(afterFirst, benchmarkCalls); // no new benchmark on round 2
+    }
+
+    [Fact]
+    public async Task WarmupCategoryAsync_FiltersByCategory()
+    {
+        var idGemm = new KernelId("gemm", "stub");
+        var idConv = new KernelId("conv", "stub");
+        bool gemmBenched = false, convBenched = false;
+        AutotuneKernelCatalog.Register(new AutotuneCatalogEntry(
+            idGemm, _ => new[] { "v" },
+            (s, v, ct) => { gemmBenched = true; return Task.FromResult(10.0); }));
+        AutotuneKernelCatalog.Register(new AutotuneCatalogEntry(
+            idConv, _ => new[] { "v" },
+            (s, v, ct) => { convBenched = true; return Task.FromResult(10.0); }));
+
+        var shapes = new[] { new[] { 2, 2 } };
+        var report = await AutotuneCache.WarmupCategoryAsync("gemm", shapes);
+
+        Assert.True(gemmBenched, "gemm category entry should run");
+        Assert.False(convBenched, "conv category entry should be skipped");
+        Assert.Equal(1, report.KernelsWarmed);
+    }
+
+    [Fact]
+    public async Task Warmup_SkipsVariantsReportingZeroOrNegativeGflops()
+    {
+        // A variant signaling "not applicable here" returns 0 or negative.
+        // The warmup should not pick it even if it's the only candidate
+        // (shape with no applicable variants stays uncached).
+        var id = new KernelId("unit-test", "all-na");
+        AutotuneKernelCatalog.Register(new AutotuneCatalogEntry(
+            id,
+            variants: _ => new[] { "na-1", "na-2" },
+            benchmarkVariant: (s, v, ct) => Task.FromResult(0.0)));
+
+        var shapes = new[] { new[] { 2, 2 } };
+        var report = await AutotuneCache.WarmupCommonKernelsAsync(shapes);
+
+        Assert.Equal(0, report.KernelsWarmed);
+        Assert.Null(AutotuneCache.Lookup(id, new ShapeProfile(shapes[0])));
+    }
+
+    [Fact]
+    public async Task Warmup_Progress_ReportsOnceForEachShape()
+    {
+        var id = new KernelId("unit-test", "progress");
+        AutotuneKernelCatalog.Register(new AutotuneCatalogEntry(
+            id, _ => new[] { "only" }, (s, v, ct) => Task.FromResult(42.0)));
+
+        var lines = new List<string>();
+        // Synchronous IProgress impl — Progress<T> posts to the captured
+        // SyncContext asynchronously, which makes assertion racy. Direct
+        // callback completes before the warmup's await yields, so the
+        // count is deterministic.
+        var progress = new SyncProgress(lines);
+        var shapes = new[] { new[] { 1, 1 }, new[] { 2, 2 }, new[] { 3, 3 } };
+        await AutotuneCache.WarmupCommonKernelsAsync(shapes, progress);
+
+        Assert.Equal(shapes.Length, lines.Count);
+        foreach (var line in lines)
+            Assert.Contains("warmed", line, StringComparison.Ordinal);
+    }
+
+    private sealed class SyncProgress : IProgress<string>
+    {
+        private readonly List<string> _out;
+        public SyncProgress(List<string> sink) { _out = sink; }
+        public void Report(string value) { lock (_out) _out.Add(value); }
+    }
+
+    [Fact]
+    public async Task Warmup_Cancellation_PropagatesBeforeRunningAllEntries()
+    {
+        var idA = new KernelId("unit-test", "a");
+        int calls = 0;
+        AutotuneKernelCatalog.Register(new AutotuneCatalogEntry(
+            idA,
+            _ => new[] { "v" },
+            (s, v, ct) =>
+            {
+                Interlocked.Increment(ref calls);
+                ct.ThrowIfCancellationRequested();
+                return Task.FromResult(1.0);
+            }));
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await AutotuneCache.WarmupCommonKernelsAsync(new[] { new[] { 1, 1 } }, ct: cts.Token));
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Helpers/Autotune/BuiltInCatalogTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/Autotune/BuiltInCatalogTests.cs
@@ -1,0 +1,107 @@
+using System.Threading;
+using System.Threading.Tasks;
+using AiDotNet.Tensors.Helpers.Autotune;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Helpers.Autotune;
+
+/// <summary>
+/// Issue #200 acceptance spec: "After WarmupCommonKernelsAsync completes,
+/// AutotuneCache.Lookup(id, shape) returns a non-null KernelChoice for
+/// every common kernel at every supplied shape."
+///
+/// <para>These tests make the acceptance criterion load-bearing: the
+/// built-in catalog registers real tunable entries (GEMM variant
+/// select), warmup actually benchmarks and stores, second run is a
+/// fast no-op on cache hit.</para>
+/// </summary>
+public class BuiltInCatalogTests : IDisposable
+{
+    private readonly string _cacheDir;
+    private readonly string? _prevEnv;
+
+    public BuiltInCatalogTests()
+    {
+        _prevEnv = Environment.GetEnvironmentVariable("AIDOTNET_AUTOTUNE_CACHE_PATH");
+        _cacheDir = Path.Combine(Path.GetTempPath(), "aidotnet-autotune-builtin-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("AIDOTNET_AUTOTUNE_CACHE_PATH", _cacheDir);
+        AutotuneKernelCatalog.Clear();
+        BuiltInCatalog.ResetRegistrationForTests();
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("AIDOTNET_AUTOTUNE_CACHE_PATH", _prevEnv);
+        try { if (Directory.Exists(_cacheDir)) Directory.Delete(_cacheDir, recursive: true); } catch { }
+        AutotuneKernelCatalog.Clear();
+        BuiltInCatalog.ResetRegistrationForTests();
+    }
+
+    [Fact]
+    public async Task WarmupCommonKernels_Populates_SGEMM_ForEverySuppliedShape()
+    {
+        // Tiny shapes so the benchmark completes fast.
+        var shapes = new[] { new[] { 16, 16, 16 }, new[] { 32, 16, 32 } };
+        var report = await AutotuneCache.WarmupCommonKernelsAsync(shapes);
+
+        Assert.True(report.KernelsWarmed >= 1,
+            "Built-in catalog should register SGEMM; WarmupCommonKernelsAsync must benchmark it.");
+
+        // Acceptance: every common kernel, every supplied shape → non-null Lookup.
+        foreach (var s in shapes)
+        {
+            var choice = AutotuneCache.Lookup(BuiltInCatalog.SGEMM, new ShapeProfile(s));
+            Assert.NotNull(choice);
+            Assert.False(string.IsNullOrEmpty(choice!.Variant));
+            Assert.True(choice.MeasuredGflops > 0,
+                $"Expected positive GFLOPS for {BuiltInCatalog.SGEMM.ToFileStem()}@{string.Join('x', s)}");
+        }
+    }
+
+    [Fact]
+    public async Task WarmupCommonKernels_SecondRun_IsFastNoOp()
+    {
+        // Issue #200 acceptance: "On a fresh process, the cache is restored
+        // from DefaultCachePath transparently; a second WarmupCommonKernelsAsync
+        // is a no-op (fast return)."
+        var shapes = new[] { new[] { 16, 16, 16 } };
+
+        var firstReport = await AutotuneCache.WarmupCommonKernelsAsync(shapes);
+        Assert.True(firstReport.KernelsWarmed >= 1);
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var secondReport = await AutotuneCache.WarmupCommonKernelsAsync(shapes);
+        sw.Stop();
+
+        // Second run should take a fraction of the first. We don't compare
+        // absolute times (CI noise) — just verify no fresh benchmark ran.
+        Assert.Equal(0, secondReport.KernelsWarmed);
+    }
+
+    [Fact]
+    public async Task WarmupCategory_Gemm_PicksUpSgemm()
+    {
+        var shapes = new[] { new[] { 16, 16, 16 } };
+        var report = await AutotuneCache.WarmupCategoryAsync("gemm", shapes);
+        Assert.Equal(1, report.KernelsWarmed);
+        Assert.NotNull(AutotuneCache.Lookup(BuiltInCatalog.SGEMM, new ShapeProfile(shapes[0])));
+    }
+
+    [Fact]
+    public async Task WarmupCategory_UnknownCategory_ReturnsEmpty()
+    {
+        var report = await AutotuneCache.WarmupCategoryAsync(
+            "nonexistent", new[] { new[] { 2, 2, 2 } });
+        Assert.Equal(0, report.KernelsWarmed);
+    }
+
+    [Fact]
+    public async Task WarmupCommonKernels_DefaultShapes_PopulatesAtLeastOne()
+    {
+        // No shapes supplied → default representative shapes are used.
+        var report = await AutotuneCache.WarmupCommonKernelsAsync();
+        Assert.True(report.KernelsWarmed >= 1);
+        Assert.True(report.ShapesPerKernel > 0);
+        Assert.NotEmpty(report.BestGflopsByKernel);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Helpers/Autotune/BuiltInCatalogTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/Autotune/BuiltInCatalogTests.cs
@@ -6,6 +6,18 @@ using Xunit;
 namespace AiDotNet.Tensors.Tests.Helpers.Autotune;
 
 /// <summary>
+/// xUnit collection that pins <see cref="BuiltInCatalogTests"/> to serial
+/// execution. Each test mutates process-wide shared state
+/// (<c>AIDOTNET_AUTOTUNE_CACHE_PATH</c> env var, the static
+/// <see cref="AutotuneKernelCatalog"/>, and the one-shot
+/// <see cref="BuiltInCatalog"/> registration latch); parallel xUnit workers
+/// would race on all three. Mirrors the <see cref="AutotuneCacheTests"/>
+/// and <see cref="AutotuneWarmupTests"/> patterns.
+/// </summary>
+[CollectionDefinition("BuiltInCatalogTests", DisableParallelization = true)]
+public sealed class BuiltInCatalogTestsCollection { }
+
+/// <summary>
 /// Issue #200 acceptance spec: "After WarmupCommonKernelsAsync completes,
 /// AutotuneCache.Lookup(id, shape) returns a non-null KernelChoice for
 /// every common kernel at every supplied shape."
@@ -15,7 +27,8 @@ namespace AiDotNet.Tensors.Tests.Helpers.Autotune;
 /// select), warmup actually benchmarks and stores, second run is a
 /// fast no-op on cache hit.</para>
 /// </summary>
-public class BuiltInCatalogTests : IDisposable
+[Collection("BuiltInCatalogTests")]
+public sealed class BuiltInCatalogTests : IDisposable
 {
     private readonly string _cacheDir;
     private readonly string? _prevEnv;
@@ -54,7 +67,7 @@ public class BuiltInCatalogTests : IDisposable
             Assert.NotNull(choice);
             Assert.False(string.IsNullOrEmpty(choice!.Variant));
             Assert.True(choice.MeasuredGflops > 0,
-                $"Expected positive GFLOPS for {BuiltInCatalog.SGEMM.ToFileStem()}@{string.Join('x', s)}");
+                $"Expected positive GFLOPS for {BuiltInCatalog.SGEMM.ToFileStem()}@{string.Join("x", s)}");
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds `AutotuneCache.WarmupCommonKernelsAsync(shapes?, progress?, ct)` and `WarmupCategoryAsync(category, shapes, progress?, ct)` — consumers can now pre-populate the autotune cache with one call, without knowing internal `KernelId`s or variant spaces.
- Adds `AutotuneKernelCatalog` (internal registry) + `AutotuneCatalogEntry` (id + variant enumerator + benchmark fn) as the mechanism Tensors-internal modules use to publish tunable kernels into the catalog.
- Public `AutotuneWarmupReport` record for progress / telemetry.

## Behavior
- Lookup-first per (kernel, shape) — already cached entries are skipped on subsequent runs. Variants returning `≤0 GFLOPS` mean "not applicable at this shape" and are filtered.
- Empty catalog is a valid state — report just has `KernelsWarmed = 0`. Real catalog entries land as integrations register their kernels (current build ships the infrastructure, not an initial population).

## Consumer API example
```csharp
var report = await AutotuneCache.WarmupCommonKernelsAsync(
    new[] { new[] { 1, 784 }, new[] { 32, 784 }, new[] { 128, 784 } },
    new Progress<string>(line => Console.WriteLine(line)));
Console.WriteLine($"{report.KernelsWarmed} kernels warmed in {report.Duration}");
```

## Test plan
- [x] `AutotuneWarmupTests` — 7 facts: empty catalog no-op, single-entry round-trip with winning variant+GFLOPS, second-run skip, category filter, skip-non-applicable-variants, progress reporting, cancellation propagation.
- [x] Existing autotune cache tests untouched (internal `Clear()` hook is additive).

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)