### PR TITLE
feat(#217): vision geometry ops + IoU backward across all 6 GPU backends

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -4931,4 +4931,50 @@ internal static class BackwardFunctions<T>
         var grad = engine.TensorMultiply(gradOutput, deriv);
         DifferentiableOps.AccumulateGrad(grads, x, grad, engine);
     }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Vision Detection (Issue #217) — IoU family backward hooks. All four
+    // variants share the same binary-input signature and route to the
+    // engine's {Op}Backward method, which returns (gradA, gradB).
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>BoxIou backward: see CpuEngine.IouFamilyBackward.</summary>
+    internal static void BoxIouBackward(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
+        object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        var (gA, gB) = engine.BoxIouBackward(gradOutput, inputs[0], inputs[1]);
+        DifferentiableOps.AccumulateGrad(grads, inputs[0], gA, engine);
+        DifferentiableOps.AccumulateGrad(grads, inputs[1], gB, engine);
+    }
+
+    /// <summary>GeneralizedBoxIou backward (Rezatofighi 2019).</summary>
+    internal static void GeneralizedBoxIouBackward(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
+        object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        var (gA, gB) = engine.GeneralizedBoxIouBackward(gradOutput, inputs[0], inputs[1]);
+        DifferentiableOps.AccumulateGrad(grads, inputs[0], gA, engine);
+        DifferentiableOps.AccumulateGrad(grads, inputs[1], gB, engine);
+    }
+
+    /// <summary>DistanceBoxIou backward (Zheng 2020).</summary>
+    internal static void DistanceBoxIouBackward(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
+        object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        var (gA, gB) = engine.DistanceBoxIouBackward(gradOutput, inputs[0], inputs[1]);
+        DifferentiableOps.AccumulateGrad(grads, inputs[0], gA, engine);
+        DifferentiableOps.AccumulateGrad(grads, inputs[1], gB, engine);
+    }
+
+    /// <summary>CompleteBoxIou backward (Zheng 2020; α treated as stop-gradient).</summary>
+    internal static void CompleteBoxIouBackward(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
+        object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        var (gA, gB) = engine.CompleteBoxIouBackward(gradOutput, inputs[0], inputs[1]);
+        DifferentiableOps.AccumulateGrad(grads, inputs[0], gA, engine);
+        DifferentiableOps.AccumulateGrad(grads, inputs[1], gB, engine);
+    }
 }

--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -4977,4 +4977,716 @@ internal static class BackwardFunctions<T>
         DifferentiableOps.AccumulateGrad(grads, inputs[0], gA, engine);
         DifferentiableOps.AccumulateGrad(grads, inputs[1], gB, engine);
     }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // #217 tail — geometry / RoI / audio backward. Every op either has a
+    // closed-form CPU backward implementation below OR delegates to
+    // already-differentiable primitives (STFT / ISTFT) for compositional
+    // ops. Kept as one block here so the symmetry with the forward path
+    // is easy to audit.
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Interpolate backward. Transpose of the forward: for each output
+    /// element, scatter gradOutput·weight back to each source element
+    /// the forward read. Uses the same mode/align-corners math as forward.
+    /// </summary>
+    internal static void InterpolateBackward(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
+        object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        var input = inputs[0];
+        var mode = (InterpolateMode)savedState[0];
+        bool alignCorners = (bool)savedState[1];
+        var gradInput = InterpolateBackwardImpl(gradOutput, input, mode, alignCorners);
+        DifferentiableOps.AccumulateGrad(grads, input, gradInput, engine);
+    }
+
+    private static Tensor<T> InterpolateBackwardImpl(Tensor<T> gradOutput, Tensor<T> input,
+        InterpolateMode mode, bool alignCorners)
+    {
+        var numOps = MathHelper.GetNumericOperations<T>();
+        var gradInput = new Tensor<T>(input._shape);
+        int spatial = input.Rank - 2;
+        int N = input._shape[0], C = input._shape[1];
+        var srcDims = new int[spatial]; var dstDims = new int[spatial];
+        for (int i = 0; i < spatial; i++) { srcDims[i] = input._shape[2 + i]; dstDims[i] = gradOutput._shape[2 + i]; }
+        var srcStride = new int[spatial];
+        srcStride[spatial - 1] = 1;
+        for (int i = spatial - 2; i >= 0; i--) srcStride[i] = srcStride[i + 1] * srcDims[i + 1];
+        int srcSpatial = 1; for (int i = 0; i < spatial; i++) srcSpatial *= srcDims[i];
+        int dstSpatial = 1; for (int i = 0; i < spatial; i++) dstSpatial *= dstDims[i];
+        var gout = gradOutput.AsSpan();
+        var gin = gradInput.AsWritableSpan();
+        var dstIdx = new int[spatial];
+
+        for (int n = 0; n < N; n++)
+        for (int c = 0; c < C; c++)
+        {
+            int inBase = (n * C + c) * srcSpatial;
+            int outBase = (n * C + c) * dstSpatial;
+            for (int k = 0; k < dstSpatial; k++)
+            {
+                int tmp = k;
+                for (int i = spatial - 1; i >= 0; i--) { dstIdx[i] = tmp % dstDims[i]; tmp /= dstDims[i]; }
+                double g = numOps.ToDouble(gout[outBase + k]);
+                if (g == 0.0) continue;
+                if (mode == InterpolateMode.Nearest)
+                {
+                    int off = 0;
+                    for (int i = 0; i < spatial; i++)
+                    {
+                        double s = dstDims[i] > 1 ? (double)dstIdx[i] * srcDims[i] / dstDims[i] : 0.0;
+                        int si = (int)Math.Floor(s);
+                        if (si >= srcDims[i]) si = srcDims[i] - 1;
+                        off += si * srcStride[i];
+                    }
+                    gin[inBase + off] = numOps.Add(gin[inBase + off], numOps.FromDouble(g));
+                }
+                else if (mode == InterpolateMode.Linear || mode == InterpolateMode.Bilinear || mode == InterpolateMode.Trilinear)
+                {
+                    // Scatter g across the 2^spatial corners with multilinear weights.
+                    var lo = new int[spatial]; var hi = new int[spatial]; var frac = new double[spatial];
+                    for (int i = 0; i < spatial; i++)
+                    {
+                        double s = dstDims[i] <= 1 ? 0.0
+                                 : (alignCorners ? (double)dstIdx[i] * (srcDims[i] - 1) / (dstDims[i] - 1)
+                                                 : ((dstIdx[i] + 0.5) * srcDims[i] / dstDims[i]) - 0.5);
+                        int l = (int)Math.Floor(s); if (l < 0) l = 0;
+                        int h = l + 1; if (h >= srcDims[i]) { h = srcDims[i] - 1; l = Math.Min(l, h); }
+                        lo[i] = l; hi[i] = h;
+                        double f = s - l; if (f < 0) f = 0; if (f > 1) f = 1;
+                        frac[i] = f;
+                    }
+                    int corners = 1 << spatial;
+                    for (int corner = 0; corner < corners; corner++)
+                    {
+                        int off = 0; double w = 1.0;
+                        for (int i = 0; i < spatial; i++)
+                        {
+                            bool takeHi = ((corner >> i) & 1) == 1;
+                            off += (takeHi ? hi[i] : lo[i]) * srcStride[i];
+                            w *= takeHi ? frac[i] : (1.0 - frac[i]);
+                        }
+                        gin[inBase + off] = numOps.Add(gin[inBase + off], numOps.FromDouble(w * g));
+                    }
+                }
+                else  // Area / Bicubic fall back to a per-cell scatter over the
+                      // covered region (area weights) or clamped 4x4 (bicubic).
+                      // For Area we use overlap weights same as forward.
+                {
+                    var loI = new int[spatial]; var hiI = new int[spatial];
+                    var loF = new double[spatial]; var hiF = new double[spatial];
+                    double totalArea = 1.0;
+                    for (int i = 0; i < spatial; i++)
+                    {
+                        loF[i] = (double)dstIdx[i] * srcDims[i] / dstDims[i];
+                        hiF[i] = (double)(dstIdx[i] + 1) * srcDims[i] / dstDims[i];
+                        loI[i] = (int)Math.Floor(loF[i]);
+                        hiI[i] = Math.Max(loI[i] + 1, (int)Math.Ceiling(hiF[i]));
+                        if (hiI[i] > srcDims[i]) hiI[i] = srcDims[i];
+                        totalArea *= (hiF[i] - loF[i]);
+                    }
+                    if (totalArea > 0)
+                        ScatterAreaBackward(gin, inBase, srcStride, loI, hiI, loF, hiF, spatial,
+                            new int[spatial], 0, g / totalArea, numOps);
+                }
+            }
+        }
+        return gradInput;
+    }
+
+    private static void ScatterAreaBackward(Span<T> gin, int inBase, int[] stride,
+        int[] lo, int[] hi, double[] loF, double[] hiF, int spatial,
+        int[] coord, int axis, double scale, Interfaces.INumericOperations<T> numOps)
+    {
+        if (axis == spatial)
+        {
+            int off = 0;
+            for (int i = 0; i < spatial; i++) off += coord[i] * stride[i];
+            gin[inBase + off] = numOps.Add(gin[inBase + off], numOps.FromDouble(scale));
+            return;
+        }
+        for (int i = lo[axis]; i < hi[axis]; i++)
+        {
+            double overlap = Math.Max(0.0, Math.Min(hiF[axis], i + 1.0) - Math.Max(loF[axis], i));
+            if (overlap <= 0) continue;
+            coord[axis] = i;
+            ScatterAreaBackward(gin, inBase, stride, lo, hi, loF, hiF, spatial, coord, axis + 1,
+                scale * overlap, numOps);
+        }
+    }
+
+    /// <summary>
+    /// PadNd backward — extract the middle region of gradOutput that
+    /// corresponds to the input. For non-constant pad modes, additionally
+    /// scatter the boundary-mapped padding cells back to their source.
+    /// </summary>
+    internal static void PadNdBackward(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
+        object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        var input = inputs[0];
+        var pad = (int[])savedState[0];
+        var mode = (PadMode)savedState[1];
+
+        var numOps = MathHelper.GetNumericOperations<T>();
+        var gradInput = new Tensor<T>(input._shape);
+        int rank = input.Rank;
+        var before = new int[rank]; var after = new int[rank];
+        int padAxes = pad.Length / 2;
+        for (int i = 0; i < padAxes; i++)
+        {
+            int axis = rank - 1 - i;
+            before[axis] = pad[i * 2];
+            after[axis] = pad[i * 2 + 1];
+        }
+        var outShape = gradOutput._shape;
+        var inStride = new int[rank]; var outStride = new int[rank];
+        inStride[rank - 1] = 1; outStride[rank - 1] = 1;
+        for (int i = rank - 2; i >= 0; i--)
+        {
+            inStride[i] = inStride[i + 1] * input._shape[i + 1];
+            outStride[i] = outStride[i + 1] * outShape[i + 1];
+        }
+        var gout = gradOutput.AsSpan();
+        var gin = gradInput.AsWritableSpan();
+
+        // Walk every output element once. When the inverse coord maps to
+        // an in-range input position — either directly (middle region)
+        // or via boundary mapping (reflect/replicate/circular) — add the
+        // gradient to the source. Constant mode discards out-of-range.
+        var outIdx = new int[rank];
+        for (int k = 0; k < gout.Length; k++)
+        {
+            int tmp = k;
+            for (int i = rank - 1; i >= 0; i--) { outIdx[i] = tmp % outShape[i]; tmp /= outShape[i]; }
+            int inOff = 0;
+            bool drop = false;
+            for (int i = 0; i < rank; i++)
+            {
+                int local = outIdx[i] - before[i];
+                int extent = input._shape[i];
+                if (local < 0 || local >= extent)
+                {
+                    if (mode == PadMode.Constant) { drop = true; break; }
+                    // Same boundary map as the forward.
+                    if (extent <= 0) { drop = true; break; }
+                    switch (mode)
+                    {
+                        case PadMode.Replicate:
+                            if (local < 0) local = 0;
+                            else if (local >= extent) local = extent - 1;
+                            break;
+                        case PadMode.Reflect:
+                            if (extent == 1) local = 0;
+                            else
+                            {
+                                int period = 2 * (extent - 1);
+                                int r = ((local % period) + period) % period;
+                                local = r < extent ? r : period - r;
+                            }
+                            break;
+                        case PadMode.Circular:
+                            local = ((local % extent) + extent) % extent;
+                            break;
+                    }
+                }
+                inOff += local * inStride[i];
+            }
+            if (drop) continue;
+            gin[inOff] = numOps.Add(gin[inOff], gout[k]);
+        }
+        DifferentiableOps.AccumulateGrad(grads, input, gradInput, engine);
+    }
+
+    /// <summary>
+    /// AffineGrid3D backward — output grid is linear in theta, so
+    /// ∂grid[n,d,h,w,r] / ∂theta[n,r,k] = coord_k(d,h,w) for k ∈ {x, y, z, 1}.
+    /// Sum the product over all (d, h, w) to get gradTheta[n, r, k].
+    /// </summary>
+    internal static void AffineGrid3DBackward(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
+        object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        var theta = inputs[0];
+        int outD = (int)savedState[0];
+        int outH = (int)savedState[1];
+        int outW = (int)savedState[2];
+        bool alignCorners = (bool)savedState[3];
+        var numOps = MathHelper.GetNumericOperations<T>();
+        int N = theta._shape[0];
+        var gradTheta = new Tensor<T>(theta._shape);
+        var gOut = gradOutput.AsSpan();
+        var gTheta = gradTheta.AsWritableSpan();
+
+        for (int n = 0; n < N; n++)
+        {
+            int tBase = n * 12;
+            for (int d = 0; d < outD; d++)
+            {
+                double z = outD <= 1 ? 0.0 : (alignCorners ? -1.0 + 2.0 * d / (outD - 1) : -1.0 + (2.0 * d + 1.0) / outD);
+                for (int h = 0; h < outH; h++)
+                {
+                    double y = outH <= 1 ? 0.0 : (alignCorners ? -1.0 + 2.0 * h / (outH - 1) : -1.0 + (2.0 * h + 1.0) / outH);
+                    for (int w = 0; w < outW; w++)
+                    {
+                        double x = outW <= 1 ? 0.0 : (alignCorners ? -1.0 + 2.0 * w / (outW - 1) : -1.0 + (2.0 * w + 1.0) / outW);
+                        int gBase = (((n * outD + d) * outH + h) * outW + w) * 3;
+                        for (int row = 0; row < 3; row++)
+                        {
+                            double g = numOps.ToDouble(gOut[gBase + row]);
+                            if (g == 0) continue;
+                            gTheta[tBase + row * 4]     = numOps.Add(gTheta[tBase + row * 4],     numOps.FromDouble(g * x));
+                            gTheta[tBase + row * 4 + 1] = numOps.Add(gTheta[tBase + row * 4 + 1], numOps.FromDouble(g * y));
+                            gTheta[tBase + row * 4 + 2] = numOps.Add(gTheta[tBase + row * 4 + 2], numOps.FromDouble(g * z));
+                            gTheta[tBase + row * 4 + 3] = numOps.Add(gTheta[tBase + row * 4 + 3], numOps.FromDouble(g));
+                        }
+                    }
+                }
+            }
+        }
+        DifferentiableOps.AccumulateGrad(grads, theta, gradTheta, engine);
+    }
+
+    /// <summary>
+    /// RoIAlign backward — scatter each output cell's gradient back across
+    /// the 4 (or 2^samplingRatio²) bilinear-sampled source positions.
+    /// </summary>
+    internal static void RoIAlignBackward(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
+        object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        var input = inputs[0];
+        var boxes = inputs[1];
+        int outH = (int)savedState[0];
+        int outW = (int)savedState[1];
+        float spatialScale = (float)savedState[2];
+        int samplingRatio = (int)savedState[3];
+        bool aligned = (bool)savedState[4];
+        var gradInput = RoIAlignBackwardImpl(gradOutput, input, boxes,
+            outH, outW, spatialScale, samplingRatio, aligned);
+        var numOps = MathHelper.GetNumericOperations<T>();
+        DifferentiableOps.AccumulateGrad(grads, input, gradInput, engine);
+        // boxes gradient is 0 almost everywhere (RoIAlign is piecewise
+        // constant in box coords modulo the bilinear sub-pixel term) — we
+        // set zero to keep the tape shape consistent.
+        DifferentiableOps.AccumulateGrad(grads, boxes, new Tensor<T>(boxes._shape), engine);
+    }
+
+    private static Tensor<T> RoIAlignBackwardImpl(Tensor<T> gradOutput, Tensor<T> input, Tensor<T> boxes,
+        int outH, int outW, float spatialScale, int samplingRatio, bool aligned)
+    {
+        var numOps = MathHelper.GetNumericOperations<T>();
+        var gradInput = new Tensor<T>(input._shape);
+        int N = input._shape[0], C = input._shape[1], H = input._shape[2], W = input._shape[3];
+        int K = boxes._shape[0];
+        var go = gradOutput.AsSpan();
+        var b = boxes.AsSpan();
+        var gi = gradInput.AsWritableSpan();
+        double offset = aligned ? 0.5 : 0.0;
+
+        for (int k = 0; k < K; k++)
+        {
+            int n = (int)numOps.ToDouble(b[k * 5]);
+            if (n < 0 || n >= N) continue;
+            double x1 = numOps.ToDouble(b[k * 5 + 1]) * spatialScale - offset;
+            double y1 = numOps.ToDouble(b[k * 5 + 2]) * spatialScale - offset;
+            double x2 = numOps.ToDouble(b[k * 5 + 3]) * spatialScale - offset;
+            double y2 = numOps.ToDouble(b[k * 5 + 4]) * spatialScale - offset;
+            double roiW = aligned ? (x2 - x1) : Math.Max(x2 - x1, 1.0);
+            double roiH = aligned ? (y2 - y1) : Math.Max(y2 - y1, 1.0);
+            double binH = roiH / outH;
+            double binW = roiW / outW;
+            int ry = samplingRatio > 0 ? samplingRatio : (int)Math.Ceiling(roiH / outH);
+            int rx = samplingRatio > 0 ? samplingRatio : (int)Math.Ceiling(roiW / outW);
+            if (ry < 1) ry = 1; if (rx < 1) rx = 1;
+            double gridArea = ry * rx;
+
+            for (int c = 0; c < C; c++)
+            {
+                int planeBase = (n * C + c) * H * W;
+                for (int ph = 0; ph < outH; ph++)
+                for (int pw = 0; pw < outW; pw++)
+                {
+                    double g = numOps.ToDouble(go[((k * C + c) * outH + ph) * outW + pw]) / gridArea;
+                    if (g == 0) continue;
+                    for (int iy = 0; iy < ry; iy++)
+                    {
+                        double sy = y1 + ph * binH + (iy + 0.5) * binH / ry;
+                        for (int ix = 0; ix < rx; ix++)
+                        {
+                            double sx = x1 + pw * binW + (ix + 0.5) * binW / rx;
+                            ScatterBilinear(gi, planeBase, sy, sx, H, W, g, numOps);
+                        }
+                    }
+                }
+            }
+        }
+        return gradInput;
+    }
+
+    private static void ScatterBilinear(Span<T> dst, int planeBase,
+        double y, double x, int H, int W, double g, Interfaces.INumericOperations<T> numOps)
+    {
+        if (y < -1.0 || y > H || x < -1.0 || x > W) return;
+        if (y <= 0) y = 0; if (x <= 0) x = 0;
+        int y0 = (int)y, x0 = (int)x;
+        int y1 = y0 + 1 >= H ? H - 1 : y0 + 1;
+        int x1 = x0 + 1 >= W ? W - 1 : x0 + 1;
+        if (y0 >= H - 1) { y0 = y1 = H - 1; y = y0; }
+        if (x0 >= W - 1) { x0 = x1 = W - 1; x = x0; }
+        double ly = y - y0, lx = x - x0;
+        double hy = 1.0 - ly, hx = 1.0 - lx;
+        dst[planeBase + y0 * W + x0] = numOps.Add(dst[planeBase + y0 * W + x0], numOps.FromDouble(hy * hx * g));
+        dst[planeBase + y0 * W + x1] = numOps.Add(dst[planeBase + y0 * W + x1], numOps.FromDouble(hy * lx * g));
+        dst[planeBase + y1 * W + x0] = numOps.Add(dst[planeBase + y1 * W + x0], numOps.FromDouble(ly * hx * g));
+        dst[planeBase + y1 * W + x1] = numOps.Add(dst[planeBase + y1 * W + x1], numOps.FromDouble(ly * lx * g));
+    }
+
+    /// <summary>RoIPool backward — scatter grad to the argmax per bin.</summary>
+    internal static void RoIPoolBackward(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
+        object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        var input = inputs[0];
+        var boxes = inputs[1];
+        int outH = (int)savedState[0];
+        int outW = (int)savedState[1];
+        float spatialScale = (float)savedState[2];
+        var numOps = MathHelper.GetNumericOperations<T>();
+        var gradInput = new Tensor<T>(input._shape);
+        int N = input._shape[0], C = input._shape[1], H = input._shape[2], W = input._shape[3];
+        int K = boxes._shape[0];
+        var src = input.AsSpan();
+        var go = gradOutput.AsSpan();
+        var b = boxes.AsSpan();
+        var gi = gradInput.AsWritableSpan();
+
+        for (int k = 0; k < K; k++)
+        {
+            int n = (int)numOps.ToDouble(b[k * 5]);
+            if (n < 0 || n >= N) continue;
+            int x1 = (int)Math.Round(numOps.ToDouble(b[k * 5 + 1]) * spatialScale);
+            int y1 = (int)Math.Round(numOps.ToDouble(b[k * 5 + 2]) * spatialScale);
+            int x2 = (int)Math.Round(numOps.ToDouble(b[k * 5 + 3]) * spatialScale);
+            int y2 = (int)Math.Round(numOps.ToDouble(b[k * 5 + 4]) * spatialScale);
+            int roiW = Math.Max(x2 - x1 + 1, 1);
+            int roiH = Math.Max(y2 - y1 + 1, 1);
+            double binH = (double)roiH / outH;
+            double binW = (double)roiW / outW;
+
+            for (int c = 0; c < C; c++)
+            {
+                int planeBase = (n * C + c) * H * W;
+                for (int ph = 0; ph < outH; ph++)
+                for (int pw = 0; pw < outW; pw++)
+                {
+                    double g = numOps.ToDouble(go[((k * C + c) * outH + ph) * outW + pw]);
+                    if (g == 0) continue;
+                    int hs = Math.Max(0, Math.Min(H, (int)Math.Floor(ph * binH) + y1));
+                    int he = Math.Max(0, Math.Min(H, (int)Math.Ceiling((ph + 1) * binH) + y1));
+                    int ws = Math.Max(0, Math.Min(W, (int)Math.Floor(pw * binW) + x1));
+                    int we = Math.Max(0, Math.Min(W, (int)Math.Ceiling((pw + 1) * binW) + x1));
+                    if (hs >= he || ws >= we) continue;
+                    // Find argmax in the bin and scatter g there.
+                    double best = double.NegativeInfinity;
+                    int bestY = hs, bestX = ws;
+                    for (int yy = hs; yy < he; yy++)
+                    for (int xx = ws; xx < we; xx++)
+                    {
+                        double v = numOps.ToDouble(src[planeBase + yy * W + xx]);
+                        if (v > best) { best = v; bestY = yy; bestX = xx; }
+                    }
+                    gi[planeBase + bestY * W + bestX] =
+                        numOps.Add(gi[planeBase + bestY * W + bestX], numOps.FromDouble(g));
+                }
+            }
+        }
+        DifferentiableOps.AccumulateGrad(grads, input, gradInput, engine);
+        DifferentiableOps.AccumulateGrad(grads, boxes, new Tensor<T>(boxes._shape), engine);
+    }
+
+    /// <summary>AmplitudeToDB backward: d(20·log10(max(x,min)))/dx = 20 / (x·ln 10) where x above floor.</summary>
+    internal static void AmplitudeToDBBackward(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
+        object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        var input = inputs[0];
+        float minAmp = (float)savedState[0];
+        var numOps = MathHelper.GetNumericOperations<T>();
+        var result = new Tensor<T>(input._shape);
+        var src = input.AsSpan();
+        var gout = gradOutput.AsSpan();
+        var dst = result.AsWritableSpan();
+        double scale = 20.0 / Math.Log(10.0);
+        for (int i = 0; i < src.Length; i++)
+        {
+            double x = numOps.ToDouble(src[i]);
+            // Below floor the forward clamps to minAmp (a constant) —
+            // gradient is zero there.
+            double d = x > minAmp ? scale / x : 0.0;
+            dst[i] = numOps.FromDouble(numOps.ToDouble(gout[i]) * d);
+        }
+        DifferentiableOps.AccumulateGrad(grads, input, result, engine);
+    }
+
+    /// <summary>ComputeDeltas backward: apply the transpose Savitzky-Golay filter.</summary>
+    internal static void ComputeDeltasBackward(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
+        object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        var input = inputs[0];
+        int winLength = (int)savedState[0];
+        int n = winLength / 2;
+        double denom = 0.0;
+        for (int i = 1; i <= n; i++) denom += 2.0 * i * i;
+        var numOps = MathHelper.GetNumericOperations<T>();
+        int rank = input.Rank;
+        int tLen = input._shape[rank - 1];
+        int leading = input.Length / Math.Max(1, tLen);
+        var result = new Tensor<T>(input._shape);
+        var gout = gradOutput.AsSpan();
+        var dst = result.AsWritableSpan();
+        for (int row = 0; row < leading; row++)
+        {
+            int baseOff = row * tLen;
+            for (int t = 0; t < tLen; t++)
+            {
+                double acc = 0.0;
+                // Forward: out[t] = Σ_k k·(in[t+k] − in[t−k])/denom.
+                // Transpose (wrt in[s]): Σ_k (k/denom)·(gout[s−k] − gout[s+k]),
+                // with edge clamping identical to forward.
+                for (int k = 1; k <= n; k++)
+                {
+                    // in[s] appears as "t+k" for t = s-k (if s-k >= 0) or as
+                    // clamp target from below for indices t in [0, k); same
+                    // for "t-k" on the upper edge. The clamping is what
+                    // makes edge elements receive extra gradient.
+                    for (int t2 = 0; t2 < tLen; t2++)
+                    {
+                        int left = t2 - k < 0 ? 0 : t2 - k;
+                        int right = t2 + k >= tLen ? tLen - 1 : t2 + k;
+                        if (right == t) acc += (k / denom) * numOps.ToDouble(gout[baseOff + t2]);
+                        if (left == t) acc -= (k / denom) * numOps.ToDouble(gout[baseOff + t2]);
+                    }
+                }
+                dst[baseOff + t] = numOps.FromDouble(acc);
+            }
+        }
+        DifferentiableOps.AccumulateGrad(grads, input, result, engine);
+    }
+
+    /// <summary>
+    /// Resample backward — the polyphase Hann-sinc filter is linear, so
+    /// backward redistributes each output gradient across the taps it
+    /// originally consumed (with identical weights).
+    /// </summary>
+    internal static void ResampleBackward(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
+        object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        var input = inputs[0];
+        int origRate = (int)savedState[0];
+        int newRate = (int)savedState[1];
+        var numOps = MathHelper.GetNumericOperations<T>();
+        var result = new Tensor<T>(input._shape);
+        if (origRate == newRate)
+        {
+            // Identity forward → identity backward.
+            gradOutput.AsSpan().CopyTo(result.AsWritableSpan());
+            DifferentiableOps.AccumulateGrad(grads, input, result, engine);
+            return;
+        }
+        int gcd = GcdLocal(origRate, newRate);
+        int up = newRate / gcd;
+        int down = origRate / gcd;
+        int halfWidth = Math.Max(8, Math.Min(256, up * 8));
+        int rank = input.Rank;
+        int tIn = input._shape[rank - 1];
+        int tOut = (int)((long)tIn * up / down);
+        int leading = input.Length / Math.Max(1, tIn);
+        double cutoff = 1.0 / Math.Max(up, down);
+        var gout = gradOutput.AsSpan();
+        var dst = result.AsWritableSpan();
+
+        for (int r = 0; r < leading; r++)
+        {
+            int sBase = r * tIn, dBase = r * tOut;
+            for (int ot = 0; ot < tOut; ot++)
+            {
+                double srcIdx = (double)ot * down / up;
+                int centre = (int)Math.Floor(srcIdx);
+                // Forward per-output normalisation sums the weights; replay
+                // the same to get the denominator for this output element.
+                double wSum = 0.0;
+                for (int k = -halfWidth; k <= halfWidth; k++)
+                {
+                    int idx = centre + k;
+                    if (idx < 0 || idx >= tIn) continue;
+                    double t = (idx - srcIdx) * cutoff;
+                    double sinc = Math.Abs(t) < 1e-12 ? 1.0 : Math.Sin(Math.PI * t) / (Math.PI * t);
+                    double hann = 0.5 - 0.5 * Math.Cos(2.0 * Math.PI * (k + halfWidth) / (2.0 * halfWidth));
+                    wSum += sinc * hann;
+                }
+                if (!(wSum > 0)) continue;
+                double g = numOps.ToDouble(gout[dBase + ot]);
+                if (g == 0) continue;
+                for (int k = -halfWidth; k <= halfWidth; k++)
+                {
+                    int idx = centre + k;
+                    if (idx < 0 || idx >= tIn) continue;
+                    double t = (idx - srcIdx) * cutoff;
+                    double sinc = Math.Abs(t) < 1e-12 ? 1.0 : Math.Sin(Math.PI * t) / (Math.PI * t);
+                    double hann = 0.5 - 0.5 * Math.Cos(2.0 * Math.PI * (k + halfWidth) / (2.0 * halfWidth));
+                    double w = sinc * hann / wSum;
+                    dst[sBase + idx] = numOps.Add(dst[sBase + idx], numOps.FromDouble(w * g));
+                }
+            }
+        }
+        DifferentiableOps.AccumulateGrad(grads, input, result, engine);
+    }
+
+    private static int GcdLocal(int a, int b) { while (b != 0) { int t = b; b = a % b; a = t; } return a; }
+
+    /// <summary>
+    /// PsRoIAlign backward — same scatter pattern as RoIAlign, but the
+    /// channel index in the source plane is derived from (co, ph, pw)
+    /// (position-sensitive).
+    /// </summary>
+    internal static void PsRoIAlignBackward(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
+        object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        var input = inputs[0];
+        var boxes = inputs[1];
+        int outH = (int)savedState[0];
+        int outW = (int)savedState[1];
+        int outChans = (int)savedState[2];
+        float spatialScale = (float)savedState[3];
+        int samplingRatio = (int)savedState[4];
+        var numOps = MathHelper.GetNumericOperations<T>();
+        var gradInput = new Tensor<T>(input._shape);
+        int N = input._shape[0], C = input._shape[1], H = input._shape[2], W = input._shape[3];
+        int K = boxes._shape[0];
+        var go = gradOutput.AsSpan();
+        var b = boxes.AsSpan();
+        var gi = gradInput.AsWritableSpan();
+
+        for (int k = 0; k < K; k++)
+        {
+            int n = (int)numOps.ToDouble(b[k * 5]);
+            if (n < 0 || n >= N) continue;
+            double x1 = numOps.ToDouble(b[k * 5 + 1]) * spatialScale;
+            double y1 = numOps.ToDouble(b[k * 5 + 2]) * spatialScale;
+            double x2 = numOps.ToDouble(b[k * 5 + 3]) * spatialScale;
+            double y2 = numOps.ToDouble(b[k * 5 + 4]) * spatialScale;
+            double roiW = Math.Max(x2 - x1, 0.1);
+            double roiH = Math.Max(y2 - y1, 0.1);
+            double binH = roiH / outH;
+            double binW = roiW / outW;
+            int ry = samplingRatio > 0 ? samplingRatio : (int)Math.Ceiling(roiH / outH);
+            int rx = samplingRatio > 0 ? samplingRatio : (int)Math.Ceiling(roiW / outW);
+            if (ry < 1) ry = 1; if (rx < 1) rx = 1;
+            double gridArea = ry * rx;
+
+            for (int co = 0; co < outChans; co++)
+            for (int ph = 0; ph < outH; ph++)
+            for (int pw = 0; pw < outW; pw++)
+            {
+                int c = (co * outH + ph) * outW + pw;
+                if (c >= C) continue;
+                int planeBase = (n * C + c) * H * W;
+                double g = numOps.ToDouble(go[((k * outChans + co) * outH + ph) * outW + pw]) / gridArea;
+                if (g == 0) continue;
+                for (int iy = 0; iy < ry; iy++)
+                {
+                    double sy = y1 + ph * binH + (iy + 0.5) * binH / ry;
+                    for (int ix = 0; ix < rx; ix++)
+                    {
+                        double sx = x1 + pw * binW + (ix + 0.5) * binW / rx;
+                        ScatterBilinear(gi, planeBase, sy, sx, H, W, g, numOps);
+                    }
+                }
+            }
+        }
+        DifferentiableOps.AccumulateGrad(grads, input, gradInput, engine);
+        DifferentiableOps.AccumulateGrad(grads, boxes, new Tensor<T>(boxes._shape), engine);
+    }
+
+    /// <summary>
+    /// PsRoIPool backward — distribute each output gradient uniformly
+    /// across its bin (the forward is an average). No argmax to recover.
+    /// </summary>
+    internal static void PsRoIPoolBackward(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
+        object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        var input = inputs[0];
+        var boxes = inputs[1];
+        int outH = (int)savedState[0];
+        int outW = (int)savedState[1];
+        int outChans = (int)savedState[2];
+        float spatialScale = (float)savedState[3];
+        var numOps = MathHelper.GetNumericOperations<T>();
+        var gradInput = new Tensor<T>(input._shape);
+        int N = input._shape[0], C = input._shape[1], H = input._shape[2], W = input._shape[3];
+        int K = boxes._shape[0];
+        var go = gradOutput.AsSpan();
+        var b = boxes.AsSpan();
+        var gi = gradInput.AsWritableSpan();
+
+        for (int k = 0; k < K; k++)
+        {
+            int n = (int)numOps.ToDouble(b[k * 5]);
+            if (n < 0 || n >= N) continue;
+            double x1 = numOps.ToDouble(b[k * 5 + 1]) * spatialScale;
+            double y1 = numOps.ToDouble(b[k * 5 + 2]) * spatialScale;
+            double x2 = numOps.ToDouble(b[k * 5 + 3]) * spatialScale;
+            double y2 = numOps.ToDouble(b[k * 5 + 4]) * spatialScale;
+            double binH = Math.Max(y2 - y1, 0.1) / outH;
+            double binW = Math.Max(x2 - x1, 0.1) / outW;
+
+            for (int co = 0; co < outChans; co++)
+            for (int ph = 0; ph < outH; ph++)
+            for (int pw = 0; pw < outW; pw++)
+            {
+                int c = (co * outH + ph) * outW + pw;
+                if (c >= C) continue;
+                int planeBase = (n * C + c) * H * W;
+                int hs = Math.Max(0, (int)Math.Floor(y1 + ph * binH));
+                int he = Math.Min(H, (int)Math.Ceiling(y1 + (ph + 1) * binH));
+                int ws = Math.Max(0, (int)Math.Floor(x1 + pw * binW));
+                int we = Math.Min(W, (int)Math.Ceiling(x1 + (pw + 1) * binW));
+                int count = Math.Max(0, (he - hs) * (we - ws));
+                if (count == 0) continue;
+                double g = numOps.ToDouble(go[((k * outChans + co) * outH + ph) * outW + pw]) / count;
+                if (g == 0) continue;
+                for (int yy = hs; yy < he; yy++)
+                for (int xx = ws; xx < we; xx++)
+                    gi[planeBase + yy * W + xx] = numOps.Add(gi[planeBase + yy * W + xx], numOps.FromDouble(g));
+            }
+        }
+        DifferentiableOps.AccumulateGrad(grads, input, gradInput, engine);
+        DifferentiableOps.AccumulateGrad(grads, boxes, new Tensor<T>(boxes._shape), engine);
+    }
+
+    /// <summary>Spectrogram backward — pipes through STFT's backward.</summary>
+    internal static void SpectrogramBackward(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
+        object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        // Forward: Spectrogram = |STFT(x)|_magnitude. With magnitude-only
+        // output we lose the phase term. Proper backward requires the
+        // original phase; we save it in savedState. Grad wrt magnitude
+        // flows through ISTFT with the saved phase.
+        var waveform = inputs[0];
+        int nFft = (int)savedState[0];
+        int hopLength = (int)savedState[1];
+        var window = (Tensor<T>)savedState[2];
+        var phase = (Tensor<T>)savedState[3];
+        int origLength = (int)savedState[4];
+        var grad = engine.ISTFT(gradOutput, phase, nFft, hopLength, window, center: true, length: origLength);
+        DifferentiableOps.AccumulateGrad(grads, waveform, grad, engine);
+    }
 }

--- a/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
@@ -301,13 +301,15 @@ internal static class OpRegistry
         // separate BatchNormBackward path above)
         "BatchNormInference",
 
-        // Vision Detection — Issue #217. Forward-only in v1; backward
-        // candidates (BoxIoU family is continuous in box coords and is
-        // used as the DETR matching loss) come in a follow-up. NMS /
-        // BatchedNms / MasksToBoxes are inherently non-differentiable
-        // (discrete output / argmin).
+        // Vision Detection — Issue #217. The four IoU variants (BoxIou,
+        // GeneralizedBoxIou, DistanceBoxIou, CompleteBoxIou) ARE
+        // differentiable and have explicit backward functions registered
+        // in BackwardFunctions — they're not in this list. BoxConvert /
+        // BoxArea are linear-ish but not yet wired. NMS / BatchedNms
+        // (score-ordered discrete index selection) and MasksToBoxes
+        // (hard argmin/argmax of a boolean region) are inherently
+        // non-differentiable.
         "BoxConvert", "BoxArea",
-        "BoxIou", "GeneralizedBoxIou", "DistanceBoxIou", "CompleteBoxIou",
         "Nms", "BatchedNms",
         "MasksToBoxes",
     };

--- a/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
@@ -170,6 +170,19 @@ internal static class OpRegistry
         // DifferentiableOps.RecordBinary inside each CpuEngine.Detection.cs
         // method; backward is in BackwardFunctions<T>.*IouBackward.
         "BoxIou", "GeneralizedBoxIou", "DistanceBoxIou", "CompleteBoxIou",
+
+        // Geometry / sampling (Issue #217) — backward wired in
+        // BackwardFunctions<T>.{InterpolateBackward, PadNdBackward,
+        // AffineGrid3DBackward}. InterpolateByScale is a delegator to
+        // Interpolate.
+        "Interpolate", "PadNd", "AffineGrid3D",
+
+        // Vision RoI family (Issue #217 tail) — backward wired
+        // in BackwardFunctions<T>.{RoIAlign,RoIPool,PsRoIAlign,PsRoIPool}Backward.
+        "RoIAlign", "RoIPool", "PsRoIAlign", "PsRoIPool",
+
+        // Audio element-wise / linear ops — backward wired.
+        "Spectrogram", "AmplitudeToDB", "ComputeDeltas", "Resample",
     };
 
     /// <summary>
@@ -318,31 +331,25 @@ internal static class OpRegistry
         "Nms", "BatchedNms",
         "MasksToBoxes",
 
-        // Geometry / sampling (Issue #217) — forward only in v1. Backward
-        // for these is a substantial kernel-by-kernel follow-up
-        // (interpolate modes × align_corners × 1D/2D/3D). The existing
-        // GridSample 3-arg overload is already in DifferentiableOps above;
-        // these are the new extended overloads + Interpolate / PadNd /
-        // AffineGrid3D.
-        "Interpolate", "InterpolateByScale", "PadNd", "AffineGrid3D",
+        // PitchShift / TimeStretch: phase-vocoder compositions that
+        // manipulate mag/phase arrays outside the tape; their backward
+        // would require a non-trivial inverse phase-vocoder pass. These
+        // ops are typically used at preprocessing/augmentation time, not
+        // inside a loss, so marking them non-differentiable is
+        // operationally correct until explicit training demand appears.
+        "PitchShift", "TimeStretch",
 
-        // Vision RoI family (Issue #217 tail) — forward only in v1; backward
-        // for RoIAlign et al. is tracked as a follow-up.
-        "RoIAlign", "RoIPool", "PsRoIAlign", "PsRoIPool",
-
-        // Audio primitives (Issue #217 tail).
-        // - Spectrogram / PitchShift / TimeStretch compose the existing
-        //   differentiable STFT + ISTFT paths, but the compositions
-        //   themselves aren't currently tape-recorded end-to-end.
-        // - AmplitudeToDB / MuLawEncoding / MuLawDecoding / ComputeDeltas /
-        //   Resample are element-wise or small-window kernels without
-        //   wired backward yet.
-        "Spectrogram", "PitchShift", "TimeStretch",
-        "AmplitudeToDB", "MuLawEncoding", "MuLawDecoding",
-        "ComputeDeltas", "Resample",
+        // μ-law encode/decode — the encoded domain is discrete int codes
+        // (not floats), so gradients are meaningless across the quantiser.
+        // Use it pre-/post-training only.
+        "MuLawEncoding", "MuLawDecoding",
 
         // Image codec — byte-level I/O, not meaningfully differentiable.
         "ImageDecode",
+
+        // InterpolateByScale is a pure delegator to Interpolate (which is
+        // in DifferentiableOps) — it performs no recording of its own.
+        "InterpolateByScale",
     };
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
@@ -165,6 +165,11 @@ internal static class OpRegistry
         "TensorConstantPad",
         "TensorCosineSimilarityLoss",
         "TensorUpsampleBilinear",
+
+        // Vision Detection IoU family (Issue #217) — record through
+        // DifferentiableOps.RecordBinary inside each CpuEngine.Detection.cs
+        // method; backward is in BackwardFunctions<T>.*IouBackward.
+        "BoxIou", "GeneralizedBoxIou", "DistanceBoxIou", "CompleteBoxIou",
     };
 
     /// <summary>
@@ -312,6 +317,32 @@ internal static class OpRegistry
         "BoxConvert", "BoxArea",
         "Nms", "BatchedNms",
         "MasksToBoxes",
+
+        // Geometry / sampling (Issue #217) — forward only in v1. Backward
+        // for these is a substantial kernel-by-kernel follow-up
+        // (interpolate modes × align_corners × 1D/2D/3D). The existing
+        // GridSample 3-arg overload is already in DifferentiableOps above;
+        // these are the new extended overloads + Interpolate / PadNd /
+        // AffineGrid3D.
+        "Interpolate", "InterpolateByScale", "PadNd", "AffineGrid3D",
+
+        // Vision RoI family (Issue #217 tail) — forward only in v1; backward
+        // for RoIAlign et al. is tracked as a follow-up.
+        "RoIAlign", "RoIPool", "PsRoIAlign", "PsRoIPool",
+
+        // Audio primitives (Issue #217 tail).
+        // - Spectrogram / PitchShift / TimeStretch compose the existing
+        //   differentiable STFT + ISTFT paths, but the compositions
+        //   themselves aren't currently tape-recorded end-to-end.
+        // - AmplitudeToDB / MuLawEncoding / MuLawDecoding / ComputeDeltas /
+        //   Resample are element-wise or small-window kernels without
+        //   wired backward yet.
+        "Spectrogram", "PitchShift", "TimeStretch",
+        "AmplitudeToDB", "MuLawEncoding", "MuLawDecoding",
+        "ComputeDeltas", "Resample",
+
+        // Image codec — byte-level I/O, not meaningfully differentiable.
+        "ImageDecode",
     };
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.Detection.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.Detection.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using AiDotNet.Tensors.Engines.Autodiff;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.Interfaces;
 using AiDotNet.Tensors.LinearAlgebra;
@@ -40,6 +41,9 @@ public partial class CpuEngine
     public virtual Tensor<T> BoxConvert<T>(Tensor<T> boxes, BoxFormat from, BoxFormat to)
     {
         ValidateBoxes(boxes, nameof(boxes));
+        // CXCYWH uses ½ in element type; integral T silently truncates to 0.
+        if (from == BoxFormat.CXCYWH || to == BoxFormat.CXCYWH)
+            RequireFloatingPoint<T>(nameof(BoxConvert));
         if (from == to) return boxes.Clone();
 
         var ops = MathHelper.GetNumericOperations<T>();
@@ -137,6 +141,7 @@ public partial class CpuEngine
         if (boxesA.Rank != 2 || boxesB.Rank != 2)
             throw new ArgumentException("BoxIou requires rank-2 boxes [N, 4] and [M, 4].");
         var (iou, _, _, _) = ComputePairwiseIoU(boxesA, boxesB);
+        DifferentiableOps.RecordBinary("BoxIou", iou, boxesA, boxesB, BackwardFunctions<T>.BoxIouBackward);
         return iou;
     }
 
@@ -177,16 +182,28 @@ public partial class CpuEngine
                 }
             }
         }
+        DifferentiableOps.RecordBinary("GeneralizedBoxIou", iou, boxesA, boxesB,
+            BackwardFunctions<T>.GeneralizedBoxIouBackward);
         return iou;
     }
 
     /// <inheritdoc/>
     public virtual Tensor<T> DistanceBoxIou<T>(Tensor<T> boxesA, Tensor<T> boxesB)
-        => DiouLikeImpl(boxesA, boxesB, includeAspect: false);
+    {
+        var result = DiouLikeImpl(boxesA, boxesB, includeAspect: false);
+        DifferentiableOps.RecordBinary("DistanceBoxIou", result, boxesA, boxesB,
+            BackwardFunctions<T>.DistanceBoxIouBackward);
+        return result;
+    }
 
     /// <inheritdoc/>
     public virtual Tensor<T> CompleteBoxIou<T>(Tensor<T> boxesA, Tensor<T> boxesB)
-        => DiouLikeImpl(boxesA, boxesB, includeAspect: true);
+    {
+        var result = DiouLikeImpl(boxesA, boxesB, includeAspect: true);
+        DifferentiableOps.RecordBinary("CompleteBoxIou", result, boxesA, boxesB,
+            BackwardFunctions<T>.CompleteBoxIouBackward);
+        return result;
+    }
 
     /// <inheritdoc/>
     public virtual Tensor<int> Nms<T>(Tensor<T> boxes, Tensor<T> scores, double iouThreshold)
@@ -262,19 +279,24 @@ public partial class CpuEngine
         if (classIds.Length != n)
             throw new ArgumentException("classIds must have length N.");
 
-        // torchvision trick: offset boxes by class * (max_coord + 1) so
-        // boxes from different classes never overlap and a single global
-        // NMS effectively runs per-class.
+        // torchvision trick: offset boxes by class * offsetUnit so boxes
+        // from different classes never overlap and a single global NMS
+        // effectively runs per-class. torchvision uses (max + 1) but that
+        // breaks when coords are entirely negative (offset can be ≤ 0 or
+        // smaller than box extent). We use the full span (max − min + 1),
+        // which dominates any pairwise distance regardless of sign.
         var ops = MathHelper.GetNumericOperations<T>();
         var b = boxes.AsSpan();
-        double maxCoord = 0;
+        double maxCoord = double.NegativeInfinity;
+        double minCoord = double.PositiveInfinity;
         for (int i = 0; i < n; i++)
         {
             double x1 = ops.ToDouble(b[i * 4]), y1 = ops.ToDouble(b[i * 4 + 1]);
             double x2 = ops.ToDouble(b[i * 4 + 2]), y2 = ops.ToDouble(b[i * 4 + 3]);
             maxCoord = Math.Max(Math.Max(maxCoord, x2), Math.Max(y2, Math.Max(x1, y1)));
+            minCoord = Math.Min(Math.Min(minCoord, x1), Math.Min(y1, Math.Min(x2, y2)));
         }
-        double offsetUnit = maxCoord + 1.0;
+        double offsetUnit = (maxCoord - minCoord) + 1.0;
 
         var ids = classIds.AsSpan();
         var offsetBoxes = new Tensor<T>(boxes._shape);
@@ -291,14 +313,14 @@ public partial class CpuEngine
     }
 
     /// <inheritdoc/>
-    public virtual Tensor<T> MasksToBoxes<T>(Tensor<T> masks)
+    public virtual Tensor<int> MasksToBoxes<T>(Tensor<T> masks)
     {
         if (masks.Rank != 3)
             throw new ArgumentException("MasksToBoxes requires rank-3 masks [N, H, W].");
         var ops = MathHelper.GetNumericOperations<T>();
         int N = masks._shape[0], H = masks._shape[1], W = masks._shape[2];
         var src = masks.AsSpan();
-        var result = new Tensor<T>(new[] { N, 4 });
+        var result = new Tensor<int>(new[] { N, 4 });
         var dst = result.AsWritableSpan();
         T zero = ops.Zero;
 
@@ -324,14 +346,11 @@ public partial class CpuEngine
             if (xMax < 0)
             {
                 // Empty mask — torchvision returns [0, 0, 0, 0].
-                dst[o] = zero; dst[o + 1] = zero; dst[o + 2] = zero; dst[o + 3] = zero;
+                dst[o] = 0; dst[o + 1] = 0; dst[o + 2] = 0; dst[o + 3] = 0;
             }
             else
             {
-                dst[o] = ops.FromDouble(xMin);
-                dst[o + 1] = ops.FromDouble(yMin);
-                dst[o + 2] = ops.FromDouble(xMax);
-                dst[o + 3] = ops.FromDouble(yMax);
+                dst[o] = xMin; dst[o + 1] = yMin; dst[o + 2] = xMax; dst[o + 3] = yMax;
             }
         }
         return result;
@@ -345,6 +364,9 @@ public partial class CpuEngine
     /// </summary>
     private (Tensor<T> iou, Tensor<T> union, Tensor<T> areaA, Tensor<T> areaB) ComputePairwiseIoU<T>(Tensor<T> boxesA, Tensor<T> boxesB)
     {
+        // The IoU family divides (inter/union, enclose penalty, DIoU term,
+        // CIoU α) in element type T — integral T silently truncates to 0/1.
+        RequireFloatingPoint<T>("IoU family");
         var ops = MathHelper.GetNumericOperations<T>();
         int N = boxesA._shape[0], M = boxesB._shape[0];
         var areaA = (Tensor<T>)BoxArea(boxesA);
@@ -391,6 +413,7 @@ public partial class CpuEngine
     {
         ValidateBoxes(boxesA, nameof(boxesA));
         ValidateBoxes(boxesB, nameof(boxesB));
+        RequireFloatingPoint<T>(includeAspect ? "CompleteBoxIou" : "DistanceBoxIou");
         if (boxesA.Rank != 2 || boxesB.Rank != 2)
             throw new ArgumentException("DistanceBoxIou/CompleteBoxIou require rank-2 boxes.");
 
@@ -464,6 +487,263 @@ public partial class CpuEngine
         return iou;
     }
 
+    // ========================================================================
+    // IoU family backward (Issue #217). All four variants share the same
+    // coordinate-level chain rule for the IoU-proper path; GIoU / DIoU /
+    // CIoU each add their own gradient contributions on top. We route
+    // everything through ComputeIouBackwardCell so the derivation stays
+    // in one place.
+    // ========================================================================
+
+    /// <inheritdoc/>
+    public virtual (Tensor<T> gradA, Tensor<T> gradB) BoxIouBackward<T>(
+        Tensor<T> gradOutput, Tensor<T> boxesA, Tensor<T> boxesB)
+        => IouFamilyBackward(gradOutput, boxesA, boxesB, IouVariant.Iou);
+
+    /// <inheritdoc/>
+    public virtual (Tensor<T> gradA, Tensor<T> gradB) GeneralizedBoxIouBackward<T>(
+        Tensor<T> gradOutput, Tensor<T> boxesA, Tensor<T> boxesB)
+        => IouFamilyBackward(gradOutput, boxesA, boxesB, IouVariant.GIoU);
+
+    /// <inheritdoc/>
+    public virtual (Tensor<T> gradA, Tensor<T> gradB) DistanceBoxIouBackward<T>(
+        Tensor<T> gradOutput, Tensor<T> boxesA, Tensor<T> boxesB)
+        => IouFamilyBackward(gradOutput, boxesA, boxesB, IouVariant.DIoU);
+
+    /// <inheritdoc/>
+    public virtual (Tensor<T> gradA, Tensor<T> gradB) CompleteBoxIouBackward<T>(
+        Tensor<T> gradOutput, Tensor<T> boxesA, Tensor<T> boxesB)
+        => IouFamilyBackward(gradOutput, boxesA, boxesB, IouVariant.CIoU);
+
+    private enum IouVariant { Iou, GIoU, DIoU, CIoU }
+
+    private (Tensor<T> gradA, Tensor<T> gradB) IouFamilyBackward<T>(
+        Tensor<T> gradOutput, Tensor<T> boxesA, Tensor<T> boxesB, IouVariant variant)
+    {
+        ValidateBoxes(boxesA, nameof(boxesA));
+        ValidateBoxes(boxesB, nameof(boxesB));
+        if (boxesA.Rank != 2 || boxesB.Rank != 2)
+            throw new ArgumentException("IoU backward requires rank-2 boxes [N, 4] and [M, 4].");
+        int N = boxesA._shape[0], M = boxesB._shape[0];
+        if (gradOutput.Rank != 2 || gradOutput._shape[0] != N || gradOutput._shape[1] != M)
+            throw new ArgumentException($"gradOutput must be [N={N}, M={M}].");
+
+        var gradA = new Tensor<T>(new[] { N, 4 });
+        var gradB = new Tensor<T>(new[] { M, 4 });
+        if (N == 0 || M == 0) return (gradA, gradB);
+
+        var ops = MathHelper.GetNumericOperations<T>();
+        var a = boxesA.AsSpan();
+        var b = boxesB.AsSpan();
+        var go = gradOutput.AsSpan();
+        var gA = gradA.AsWritableSpan();
+        var gB = gradB.AsWritableSpan();
+
+        // Work in double for numerical stability — the forward converts via
+        // ops.ToDouble() for DIoU/CIoU anyway, so keeping backward in the
+        // same precision keeps finite-difference tests reproducible.
+        const double INV_PI_SQ = 4.0 / (Math.PI * Math.PI);
+
+        for (int i = 0; i < N; i++)
+        {
+            double ax1 = ops.ToDouble(a[i * 4]);
+            double ay1 = ops.ToDouble(a[i * 4 + 1]);
+            double ax2 = ops.ToDouble(a[i * 4 + 2]);
+            double ay2 = ops.ToDouble(a[i * 4 + 3]);
+
+            for (int j = 0; j < M; j++)
+            {
+                double bx1 = ops.ToDouble(b[j * 4]);
+                double by1 = ops.ToDouble(b[j * 4 + 1]);
+                double bx2 = ops.ToDouble(b[j * 4 + 2]);
+                double by2 = ops.ToDouble(b[j * 4 + 3]);
+
+                double awRaw = ax2 - ax1, ahRaw = ay2 - ay1;
+                double bwRaw = bx2 - bx1, bhRaw = by2 - by1;
+                double aw = Math.Max(awRaw, 0);
+                double ah = Math.Max(ahRaw, 0);
+                double bw = Math.Max(bwRaw, 0);
+                double bh = Math.Max(bhRaw, 0);
+                double areaA = aw * ah;
+                double areaB = bw * bh;
+
+                double ix1 = Math.Max(ax1, bx1), ix2 = Math.Min(ax2, bx2);
+                double iy1 = Math.Max(ay1, by1), iy2 = Math.Min(ay2, by2);
+                double iwRaw = ix2 - ix1, ihRaw = iy2 - iy1;
+                double iw = Math.Max(iwRaw, 0), ih = Math.Max(ihRaw, 0);
+                double inter = iw * ih;
+                double union = areaA + areaB - inter;
+                double iou = union > 0 ? inter / union : 0;
+
+                double g = ops.ToDouble(go[i * M + j]);
+                if (g == 0.0) continue;
+
+                // Accumulators per corner for this (i, j) cell.
+                double gAx1 = 0, gAy1 = 0, gAx2 = 0, gAy2 = 0;
+                double gBx1 = 0, gBy1 = 0, gBx2 = 0, gBy2 = 0;
+
+                // g_iou gets the IoU-path contribution plus anything that
+                // routes back through iou in GIoU/DIoU/CIoU. We accumulate
+                // into gIou first then propagate once.
+                double gIou = g;
+                double gInter = 0, gAreaA = 0, gAreaB = 0;
+
+                if (variant == IouVariant.GIoU)
+                {
+                    // GIoU = IoU + union/enclose − 1. The constant −1 drops out.
+                    double ex1 = Math.Min(ax1, bx1), ex2 = Math.Max(ax2, bx2);
+                    double ey1 = Math.Min(ay1, by1), ey2 = Math.Max(ay2, by2);
+                    double ewRaw = ex2 - ex1, ehRaw = ey2 - ey1;
+                    double ew = Math.Max(ewRaw, 0), eh = Math.Max(ehRaw, 0);
+                    double enclose = ew * eh;
+                    if (enclose > 0)
+                    {
+                        double gUnion = g / enclose;
+                        double gEnclose = g * (-union / (enclose * enclose));
+                        // union = areaA + areaB − inter
+                        gAreaA += gUnion; gAreaB += gUnion; gInter += -gUnion;
+                        // enclose = ew · eh
+                        double gEw = gEnclose * eh;
+                        double gEh = gEnclose * ew;
+                        // ew = max(ewRaw, 0)
+                        double gEwRaw = ewRaw > 0 ? gEw : 0;
+                        double gEhRaw = ehRaw > 0 ? gEh : 0;
+                        // ex1 = min(ax1, bx1); ex2 = max(ax2, bx2)
+                        double gEx1 = -gEwRaw, gEx2 = gEwRaw;
+                        double gEy1 = -gEhRaw, gEy2 = gEhRaw;
+                        if (ax1 <= bx1) gAx1 += gEx1; else gBx1 += gEx1;
+                        if (ay1 <= by1) gAy1 += gEy1; else gBy1 += gEy1;
+                        if (ax2 >= bx2) gAx2 += gEx2; else gBx2 += gEx2;
+                        if (ay2 >= by2) gAy2 += gEy2; else gBy2 += gEy2;
+                    }
+                }
+                else if (variant == IouVariant.DIoU || variant == IouVariant.CIoU)
+                {
+                    // DIoU = IoU − centreSq/diagSq.
+                    double acx = (ax1 + ax2) * 0.5, acy = (ay1 + ay2) * 0.5;
+                    double bcx = (bx1 + bx2) * 0.5, bcy = (by1 + by2) * 0.5;
+                    double dcx = acx - bcx, dcy = acy - bcy;
+                    double centreSq = dcx * dcx + dcy * dcy;
+                    double ex1 = Math.Min(ax1, bx1), ex2 = Math.Max(ax2, bx2);
+                    double ey1 = Math.Min(ay1, by1), ey2 = Math.Max(ay2, by2);
+                    double ew = ex2 - ex1, eh = ey2 - ey1;
+                    double diagSq = ew * ew + eh * eh;
+
+                    double gCentreSq = 0, gDiagSq = 0;
+                    if (diagSq > 0)
+                    {
+                        gCentreSq = g * (-1.0 / diagSq);
+                        gDiagSq = g * centreSq / (diagSq * diagSq);
+                    }
+
+                    // CIoU adds −α·v (α treated as stop-gradient per Zheng 2020).
+                    if (variant == IouVariant.CIoU && ah > 0 && bh > 0)
+                    {
+                        double aspectA = Math.Atan(aw / ah);
+                        double aspectB = Math.Atan(bw / bh);
+                        double diff = aspectA - aspectB;
+                        double v = INV_PI_SQ * diff * diff;
+                        double denom = (1.0 - iou) + v;
+                        double alpha = denom > 0 ? v / denom : 0;
+                        // CIoU = DIoU − α·v, so dCIoU/dv = −α (α constant).
+                        double gV = g * (-alpha);
+                        // v = INV_PI_SQ · diff². dv/dDiff = 2·INV_PI_SQ·diff.
+                        double gDiff = gV * 2.0 * INV_PI_SQ * diff;
+                        double gAspectA = gDiff, gAspectB = -gDiff;
+                        // atan(r): d/dr = 1/(1+r²). For atan(w/h), dr/dw = 1/h
+                        // and dr/dh = −w/h². Combined, d(atan(w/h))/dw = h/(w²+h²)
+                        // and d(atan(w/h))/dh = −w/(w²+h²).
+                        double aDen = aw * aw + ah * ah;
+                        double bDen = bw * bw + bh * bh;
+                        if (aDen > 0)
+                        {
+                            double gAw = gAspectA * (ah / aDen);
+                            double gAh = gAspectA * (-aw / aDen);
+                            // aw = max(awRaw, 0); ah = max(ahRaw, 0).
+                            if (awRaw > 0) { gAx2 += gAw; gAx1 += -gAw; }
+                            if (ahRaw > 0) { gAy2 += gAh; gAy1 += -gAh; }
+                        }
+                        if (bDen > 0)
+                        {
+                            double gBw = gAspectB * (bh / bDen);
+                            double gBh = gAspectB * (-bw / bDen);
+                            if (bwRaw > 0) { gBx2 += gBw; gBx1 += -gBw; }
+                            if (bhRaw > 0) { gBy2 += gBh; gBy1 += -gBh; }
+                        }
+                        // α is stop-gradient, so no contribution through gIou
+                        // from the α·v factor.
+                    }
+
+                    // Propagate gCentreSq through the centre distance.
+                    // centreSq = (acx-bcx)² + (acy-bcy)².
+                    double gAcx = gCentreSq * 2.0 * dcx;
+                    double gAcy = gCentreSq * 2.0 * dcy;
+                    // acx = (ax1+ax2)/2, bcx = (bx1+bx2)/2.
+                    gAx1 += gAcx * 0.5; gAx2 += gAcx * 0.5;
+                    gAy1 += gAcy * 0.5; gAy2 += gAcy * 0.5;
+                    gBx1 += -gAcx * 0.5; gBx2 += -gAcx * 0.5;
+                    gBy1 += -gAcy * 0.5; gBy2 += -gAcy * 0.5;
+
+                    // Propagate gDiagSq through enclose dimensions.
+                    // diagSq = ew² + eh². dew/dex1 = −1 (ew = ex2 − ex1),
+                    // dew/dex2 = +1. Same for eh.
+                    double gEw = gDiagSq * 2.0 * ew;
+                    double gEh = gDiagSq * 2.0 * eh;
+                    // ex1 = min(ax1, bx1); ex2 = max(ax2, bx2). No max(...,0)
+                    // clamp on ew/eh for DIoU — diagSq uses the raw span.
+                    double gEx1 = -gEw, gEx2 = gEw;
+                    double gEy1 = -gEh, gEy2 = gEh;
+                    if (ax1 <= bx1) gAx1 += gEx1; else gBx1 += gEx1;
+                    if (ay1 <= by1) gAy1 += gEy1; else gBy1 += gEy1;
+                    if (ax2 >= bx2) gAx2 += gEx2; else gBx2 += gEx2;
+                    if (ay2 >= by2) gAy2 += gEy2; else gBy2 += gEy2;
+                }
+
+                // IoU-proper contribution (shared across all variants).
+                if (union > 0)
+                {
+                    gInter += gIou * (union + inter) / (union * union);
+                    gAreaA += gIou * (-inter) / (union * union);
+                    gAreaB += gIou * (-inter) / (union * union);
+                }
+
+                // inter = iw · ih.
+                double gIw = gInter * ih;
+                double gIh = gInter * iw;
+                double gIwRaw = iwRaw > 0 ? gIw : 0;
+                double gIhRaw = ihRaw > 0 ? gIh : 0;
+                double gIx2 = gIwRaw, gIx1 = -gIwRaw;
+                double gIy2 = gIhRaw, gIy1 = -gIhRaw;
+                // ix1 = max(ax1, bx1); ix2 = min(ax2, bx2).
+                if (ax1 >= bx1) gAx1 += gIx1; else gBx1 += gIx1;
+                if (ay1 >= by1) gAy1 += gIy1; else gBy1 += gIy1;
+                if (ax2 <= bx2) gAx2 += gIx2; else gBx2 += gIx2;
+                if (ay2 <= by2) gAy2 += gIy2; else gBy2 += gIy2;
+
+                // areaA = aw · ah.
+                double gAw2 = gAreaA * ah;
+                double gAh2 = gAreaA * aw;
+                double gBw2 = gAreaB * bh;
+                double gBh2 = gAreaB * bw;
+                if (awRaw > 0) { gAx2 += gAw2; gAx1 += -gAw2; }
+                if (ahRaw > 0) { gAy2 += gAh2; gAy1 += -gAh2; }
+                if (bwRaw > 0) { gBx2 += gBw2; gBx1 += -gBw2; }
+                if (bhRaw > 0) { gBy2 += gBh2; gBy1 += -gBh2; }
+
+                // Accumulate into output tensors.
+                gA[i * 4] = ops.Add(gA[i * 4], ops.FromDouble(gAx1));
+                gA[i * 4 + 1] = ops.Add(gA[i * 4 + 1], ops.FromDouble(gAy1));
+                gA[i * 4 + 2] = ops.Add(gA[i * 4 + 2], ops.FromDouble(gAx2));
+                gA[i * 4 + 3] = ops.Add(gA[i * 4 + 3], ops.FromDouble(gAy2));
+                gB[j * 4] = ops.Add(gB[j * 4], ops.FromDouble(gBx1));
+                gB[j * 4 + 1] = ops.Add(gB[j * 4 + 1], ops.FromDouble(gBy1));
+                gB[j * 4 + 2] = ops.Add(gB[j * 4 + 2], ops.FromDouble(gBx2));
+                gB[j * 4 + 3] = ops.Add(gB[j * 4 + 3], ops.FromDouble(gBy2));
+            }
+        }
+        return (gradA, gradB);
+    }
+
     private static void ValidateBoxes<T>(Tensor<T> boxes, string paramName)
     {
         if (boxes is null) throw new ArgumentNullException(paramName);
@@ -471,5 +751,19 @@ public partial class CpuEngine
             throw new ArgumentException(
                 $"Box tensor's last axis must be 4; got shape [{string.Join(", ", boxes._shape)}].",
                 paramName);
+    }
+
+    /// <summary>
+    /// Detection ops use ratios (inter/union, centre²/diag², ½ in CXCYWH),
+    /// which degrade to integer 0/1 arithmetic on integral T and silently
+    /// corrupt results. Reject integral T up front rather than producing
+    /// garbage.
+    /// </summary>
+    private static void RequireFloatingPoint<T>(string op)
+    {
+        var t = typeof(T);
+        if (t == typeof(float) || t == typeof(double) || t == typeof(decimal)) return;
+        throw new NotSupportedException(
+            $"{op} requires a floating-point element type (float/double/decimal); got {t.Name}.");
     }
 }

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.Geometry.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.Geometry.cs
@@ -1,0 +1,657 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// CPU reference implementations of the geometry / sampling ops added by
+// Issue #217: Interpolate (6 modes × 1D/2D/3D), PadNd (4 modes × any rank),
+// GridSample (bilinear / nearest / bicubic × zeros / border / reflection
+// × align_corners), AffineGrid3D. The pre-existing narrow
+// GridSample(input, grid) and AffineGrid(theta, H, W) APIs stay as
+// torchvision-default shims that route through here.
+
+using System;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines;
+
+public partial class CpuEngine
+{
+    // ========================================================================
+    // Interpolate
+    // ========================================================================
+
+    /// <inheritdoc/>
+    public virtual Tensor<T> Interpolate<T>(Tensor<T> input, int[] sizes, InterpolateMode mode, bool alignCorners = false)
+    {
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (sizes is null) throw new ArgumentNullException(nameof(sizes));
+        if (input.Rank < 3)
+            throw new ArgumentException("Interpolate requires rank >= 3 ([N, C, ...] where ... is 1/2/3 spatial dims).");
+        int spatialRank = input.Rank - 2;
+        if (sizes.Length != spatialRank)
+            throw new ArgumentException($"sizes length ({sizes.Length}) must equal spatial rank ({spatialRank}).");
+        ValidateMode(mode, spatialRank);
+
+        int N = input._shape[0], C = input._shape[1];
+        var outShape = new int[input.Rank];
+        outShape[0] = N; outShape[1] = C;
+        for (int i = 0; i < spatialRank; i++)
+        {
+            if (sizes[i] <= 0) throw new ArgumentException("sizes must be positive.");
+            outShape[2 + i] = sizes[i];
+        }
+        var output = new Tensor<T>(outShape);
+        if (input.Length == 0 || output.Length == 0) return output;
+
+        var ops = MathHelper.GetNumericOperations<T>();
+        switch (mode)
+        {
+            case InterpolateMode.Nearest:
+                InterpolateNearest(input, output, alignCorners: false);
+                break;
+            case InterpolateMode.Linear:
+            case InterpolateMode.Bilinear:
+            case InterpolateMode.Trilinear:
+                InterpolateLinearFamily(input, output, alignCorners, ops);
+                break;
+            case InterpolateMode.Bicubic:
+                InterpolateBicubic2D(input, output, alignCorners, ops);
+                break;
+            case InterpolateMode.Area:
+                InterpolateArea(input, output, ops);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(mode));
+        }
+        return output;
+    }
+
+    /// <inheritdoc/>
+    public virtual Tensor<T> InterpolateByScale<T>(Tensor<T> input, double[] scaleFactors, InterpolateMode mode, bool alignCorners = false)
+    {
+        if (scaleFactors is null) throw new ArgumentNullException(nameof(scaleFactors));
+        int spatialRank = input.Rank - 2;
+        if (scaleFactors.Length != spatialRank)
+            throw new ArgumentException($"scaleFactors length ({scaleFactors.Length}) must equal spatial rank ({spatialRank}).");
+        var sizes = new int[spatialRank];
+        for (int i = 0; i < spatialRank; i++)
+        {
+            if (!(scaleFactors[i] > 0))
+                throw new ArgumentException("scaleFactors must be positive.");
+            sizes[i] = (int)Math.Floor(input._shape[2 + i] * scaleFactors[i]);
+            if (sizes[i] < 1) sizes[i] = 1;
+        }
+        return Interpolate(input, sizes, mode, alignCorners);
+    }
+
+    private static void ValidateMode(InterpolateMode mode, int spatialRank)
+    {
+        bool ok = mode switch
+        {
+            InterpolateMode.Nearest => true,
+            InterpolateMode.Area => true,
+            InterpolateMode.Linear => spatialRank == 1,
+            InterpolateMode.Bilinear => spatialRank == 2,
+            InterpolateMode.Bicubic => spatialRank == 2,
+            InterpolateMode.Trilinear => spatialRank == 3,
+            _ => false,
+        };
+        if (!ok)
+            throw new ArgumentException($"Mode {mode} is not valid for spatial rank {spatialRank}.");
+    }
+
+    /// <summary>
+    /// Nearest-neighbour interpolation — shared across 1D/2D/3D via
+    /// per-axis index rounding. Matches PyTorch's <c>mode='nearest'</c>
+    /// which uses <c>floor</c> (not rounding) of the fractional source
+    /// coordinate.
+    /// </summary>
+    private static void InterpolateNearest<T>(Tensor<T> input, Tensor<T> output, bool alignCorners)
+    {
+        int rank = input.Rank;
+        int N = input._shape[0], C = input._shape[1];
+        var src = input.AsSpan();
+        var dst = output.AsWritableSpan();
+        int spatial = rank - 2;
+
+        // Pre-compute per-axis floor-scale factors (input / output). We
+        // iterate linearly over output and compute source offset.
+        var srcDims = new int[spatial]; var dstDims = new int[spatial];
+        for (int i = 0; i < spatial; i++) { srcDims[i] = input._shape[2 + i]; dstDims[i] = output._shape[2 + i]; }
+
+        int dstSpatialCount = 1;
+        for (int i = 0; i < spatial; i++) dstSpatialCount *= dstDims[i];
+        int srcSpatialCount = 1;
+        for (int i = 0; i < spatial; i++) srcSpatialCount *= srcDims[i];
+
+        var dstIdx = new int[spatial];
+        var srcStride = new int[spatial];
+        srcStride[spatial - 1] = 1;
+        for (int i = spatial - 2; i >= 0; i--) srcStride[i] = srcStride[i + 1] * srcDims[i + 1];
+
+        for (int n = 0; n < N; n++)
+        for (int c = 0; c < C; c++)
+        {
+            int srcBase = (n * C + c) * srcSpatialCount;
+            int dstBase = (n * C + c) * dstSpatialCount;
+            // Iterate output spatial.
+            for (int k = 0; k < dstSpatialCount; k++)
+            {
+                int tmp = k;
+                for (int i = spatial - 1; i >= 0; i--)
+                {
+                    dstIdx[i] = tmp % dstDims[i];
+                    tmp /= dstDims[i];
+                }
+                int srcOff = 0;
+                for (int i = 0; i < spatial; i++)
+                {
+                    double s = dstDims[i] > 1
+                        ? (double)dstIdx[i] * srcDims[i] / dstDims[i]
+                        : 0.0;
+                    int si = (int)Math.Floor(s);
+                    if (si >= srcDims[i]) si = srcDims[i] - 1;
+                    srcOff += si * srcStride[i];
+                }
+                dst[dstBase + k] = src[srcBase + srcOff];
+            }
+        }
+    }
+
+    /// <summary>
+    /// Linear-family interpolation (linear 1D / bilinear 2D / trilinear 3D).
+    /// Shared implementation: each output sample mixes 2^spatial source
+    /// corners via multilinear weights. align_corners controls the mapping
+    /// between output and source index — align_corners=true stretches so
+    /// corners coincide; align_corners=false treats pixels as points
+    /// (torchvision default).
+    /// </summary>
+    private static void InterpolateLinearFamily<T>(Tensor<T> input, Tensor<T> output, bool alignCorners, Interfaces.INumericOperations<T> ops)
+    {
+        int spatial = input.Rank - 2;
+        int N = input._shape[0], C = input._shape[1];
+        var src = input.AsSpan();
+        var dst = output.AsWritableSpan();
+
+        var srcDims = new int[spatial]; var dstDims = new int[spatial];
+        for (int i = 0; i < spatial; i++) { srcDims[i] = input._shape[2 + i]; dstDims[i] = output._shape[2 + i]; }
+        var srcStride = new int[spatial];
+        srcStride[spatial - 1] = 1;
+        for (int i = spatial - 2; i >= 0; i--) srcStride[i] = srcStride[i + 1] * srcDims[i + 1];
+        int srcSpatial = 1; for (int i = 0; i < spatial; i++) srcSpatial *= srcDims[i];
+        int dstSpatial = 1; for (int i = 0; i < spatial; i++) dstSpatial *= dstDims[i];
+        int corners = 1 << spatial;
+
+        var lo = new int[spatial]; var hi = new int[spatial]; var frac = new double[spatial];
+        var dstIdx = new int[spatial];
+
+        for (int n = 0; n < N; n++)
+        for (int c = 0; c < C; c++)
+        {
+            int srcBase = (n * C + c) * srcSpatial;
+            int dstBase = (n * C + c) * dstSpatial;
+            for (int k = 0; k < dstSpatial; k++)
+            {
+                int tmp = k;
+                for (int i = spatial - 1; i >= 0; i--) { dstIdx[i] = tmp % dstDims[i]; tmp /= dstDims[i]; }
+                // Per-axis fractional source coord.
+                for (int i = 0; i < spatial; i++)
+                {
+                    double s = SourceCoordinate(dstIdx[i], dstDims[i], srcDims[i], alignCorners);
+                    int l = (int)Math.Floor(s);
+                    if (l < 0) l = 0;
+                    int h = l + 1;
+                    if (h >= srcDims[i]) { h = srcDims[i] - 1; l = Math.Min(l, h); }
+                    lo[i] = l; hi[i] = h; frac[i] = s - l;
+                    if (frac[i] < 0) frac[i] = 0;
+                    if (frac[i] > 1) frac[i] = 1;
+                }
+
+                double acc = 0.0;
+                for (int corner = 0; corner < corners; corner++)
+                {
+                    int srcOff = 0;
+                    double weight = 1.0;
+                    for (int i = 0; i < spatial; i++)
+                    {
+                        bool takeHi = ((corner >> i) & 1) == 1;
+                        srcOff += (takeHi ? hi[i] : lo[i]) * srcStride[i];
+                        weight *= takeHi ? frac[i] : (1.0 - frac[i]);
+                    }
+                    acc += weight * ops.ToDouble(src[srcBase + srcOff]);
+                }
+                dst[dstBase + k] = ops.FromDouble(acc);
+            }
+        }
+    }
+
+    private static double SourceCoordinate(int dstIdx, int dstSize, int srcSize, bool alignCorners)
+    {
+        if (dstSize <= 1) return 0.0;
+        return alignCorners
+            ? (double)dstIdx * (srcSize - 1) / (dstSize - 1)
+            // pixel-centre convention (torchvision default): map output centre
+            // to corresponding source centre.
+            : ((dstIdx + 0.5) * srcSize / dstSize) - 0.5;
+    }
+
+    /// <summary>
+    /// Bicubic 2D. Uses the torchvision Catmull-Rom cubic kernel
+    /// (a = -0.75), separable along H and W. Clamps out-of-range source
+    /// indices to the boundary rather than zero-padding, matching
+    /// torchvision's behaviour.
+    /// </summary>
+    private static void InterpolateBicubic2D<T>(Tensor<T> input, Tensor<T> output, bool alignCorners, Interfaces.INumericOperations<T> ops)
+    {
+        int N = input._shape[0], C = input._shape[1];
+        int H = input._shape[2], W = input._shape[3];
+        int outH = output._shape[2], outW = output._shape[3];
+        var src = input.AsSpan();
+        var dst = output.AsWritableSpan();
+
+        for (int n = 0; n < N; n++)
+        for (int c = 0; c < C; c++)
+        {
+            int srcBase = (n * C + c) * H * W;
+            int dstBase = (n * C + c) * outH * outW;
+            for (int y = 0; y < outH; y++)
+            {
+                double sy = SourceCoordinate(y, outH, H, alignCorners);
+                int y0 = (int)Math.Floor(sy);
+                double ty = sy - y0;
+                double[] wy = CubicWeights(ty);
+                for (int x = 0; x < outW; x++)
+                {
+                    double sx = SourceCoordinate(x, outW, W, alignCorners);
+                    int x0 = (int)Math.Floor(sx);
+                    double tx = sx - x0;
+                    double[] wx = CubicWeights(tx);
+                    double acc = 0.0;
+                    for (int yy = 0; yy < 4; yy++)
+                    {
+                        int yi = Math.Clamp(y0 - 1 + yy, 0, H - 1);
+                        double rowAcc = 0.0;
+                        for (int xx = 0; xx < 4; xx++)
+                        {
+                            int xi = Math.Clamp(x0 - 1 + xx, 0, W - 1);
+                            rowAcc += wx[xx] * ops.ToDouble(src[srcBase + yi * W + xi]);
+                        }
+                        acc += wy[yy] * rowAcc;
+                    }
+                    dst[dstBase + y * outW + x] = ops.FromDouble(acc);
+                }
+            }
+        }
+    }
+
+    /// <summary>Catmull-Rom cubic (a = −0.75), the torchvision default.</summary>
+    private static double[] CubicWeights(double t)
+    {
+        // Kernel evaluated at offsets {1+t, t, 1-t, 2-t}.
+        const double a = -0.75;
+        double t1 = 1.0 + t, t2 = t, t3 = 1.0 - t, t4 = 2.0 - t;
+        return new[]
+        {
+            CubicKernel(t1, a),
+            CubicKernel(t2, a),
+            CubicKernel(t3, a),
+            CubicKernel(t4, a),
+        };
+    }
+
+    private static double CubicKernel(double d, double a)
+    {
+        double ad = Math.Abs(d);
+        if (ad < 1.0) return ((a + 2.0) * ad - (a + 3.0)) * ad * ad + 1.0;
+        if (ad < 2.0) return a * ((ad - 5.0) * ad + 8.0) * ad - 4.0 * a;
+        return 0.0;
+    }
+
+    /// <summary>
+    /// Area interpolation — averages every source pixel covered by each
+    /// output cell. Handles both downsampling (multi-source-per-dst, the
+    /// common case) and upsampling (degenerate — equivalent to nearest-
+    /// neighbour when srcSize == dstSize).
+    /// </summary>
+    private static void InterpolateArea<T>(Tensor<T> input, Tensor<T> output, Interfaces.INumericOperations<T> ops)
+    {
+        int spatial = input.Rank - 2;
+        int N = input._shape[0], C = input._shape[1];
+        var src = input.AsSpan();
+        var dst = output.AsWritableSpan();
+
+        var srcDims = new int[spatial]; var dstDims = new int[spatial];
+        for (int i = 0; i < spatial; i++) { srcDims[i] = input._shape[2 + i]; dstDims[i] = output._shape[2 + i]; }
+        var srcStride = new int[spatial];
+        srcStride[spatial - 1] = 1;
+        for (int i = spatial - 2; i >= 0; i--) srcStride[i] = srcStride[i + 1] * srcDims[i + 1];
+        int srcSpatial = 1; for (int i = 0; i < spatial; i++) srcSpatial *= srcDims[i];
+        int dstSpatial = 1; for (int i = 0; i < spatial; i++) dstSpatial *= dstDims[i];
+
+        var dstIdx = new int[spatial];
+        var loI = new int[spatial]; var hiI = new int[spatial];
+
+        for (int n = 0; n < N; n++)
+        for (int c = 0; c < C; c++)
+        {
+            int srcBase = (n * C + c) * srcSpatial;
+            int dstBase = (n * C + c) * dstSpatial;
+            for (int k = 0; k < dstSpatial; k++)
+            {
+                int tmp = k;
+                for (int i = spatial - 1; i >= 0; i--) { dstIdx[i] = tmp % dstDims[i]; tmp /= dstDims[i]; }
+                int cellCount = 1;
+                for (int i = 0; i < spatial; i++)
+                {
+                    double lo = (double)dstIdx[i] * srcDims[i] / dstDims[i];
+                    double hi = (double)(dstIdx[i] + 1) * srcDims[i] / dstDims[i];
+                    loI[i] = (int)Math.Floor(lo);
+                    hiI[i] = Math.Max(loI[i] + 1, (int)Math.Ceiling(hi));
+                    if (hiI[i] > srcDims[i]) hiI[i] = srcDims[i];
+                    cellCount *= (hiI[i] - loI[i]);
+                }
+                double acc = 0.0;
+                SumRegion(src, srcBase, srcStride, loI, hiI, spatial, ops, ref acc, new int[spatial], 0);
+                dst[dstBase + k] = ops.FromDouble(acc / Math.Max(1, cellCount));
+            }
+        }
+    }
+
+    private static void SumRegion<T>(ReadOnlySpan<T> src, int srcBase, int[] stride,
+        int[] lo, int[] hi, int spatial, Interfaces.INumericOperations<T> ops,
+        ref double acc, int[] coord, int axis)
+    {
+        if (axis == spatial)
+        {
+            int off = 0;
+            for (int i = 0; i < spatial; i++) off += coord[i] * stride[i];
+            acc += ops.ToDouble(src[srcBase + off]);
+            return;
+        }
+        for (int i = lo[axis]; i < hi[axis]; i++)
+        {
+            coord[axis] = i;
+            SumRegion(src, srcBase, stride, lo, hi, spatial, ops, ref acc, coord, axis + 1);
+        }
+    }
+
+    // ========================================================================
+    // PadNd
+    // ========================================================================
+
+    /// <inheritdoc/>
+    public virtual Tensor<T> PadNd<T>(Tensor<T> input, int[] pad, PadMode mode, T value = default!)
+    {
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (pad is null) throw new ArgumentNullException(nameof(pad));
+        if ((pad.Length & 1) != 0)
+            throw new ArgumentException("pad length must be even (before/after pairs).");
+        int padAxes = pad.Length / 2;
+        if (padAxes > input.Rank)
+            throw new ArgumentException($"pad covers {padAxes} axes but input has only {input.Rank}.");
+
+        // PyTorch's pad order is innermost-first. Convert to per-axis (before, after)
+        // from axis 0 to rank-1. Axes 0..rank-padAxes-1 get (0, 0).
+        var before = new int[input.Rank];
+        var after = new int[input.Rank];
+        for (int i = 0; i < padAxes; i++)
+        {
+            int axis = input.Rank - 1 - i;
+            before[axis] = pad[i * 2];
+            after[axis] = pad[i * 2 + 1];
+            if (before[axis] < 0 || after[axis] < 0)
+                throw new ArgumentException("pad amounts must be non-negative.");
+        }
+
+        var outShape = new int[input.Rank];
+        for (int i = 0; i < input.Rank; i++)
+            outShape[i] = input._shape[i] + before[i] + after[i];
+        var output = new Tensor<T>(outShape);
+        if (output.Length == 0) return output;
+
+        var src = input.AsSpan();
+        var dst = output.AsWritableSpan();
+        var ops = MathHelper.GetNumericOperations<T>();
+        T fill = mode == PadMode.Constant ? value : ops.Zero;
+
+        // Compute strides for both src and dst in row-major order.
+        var srcStride = new int[input.Rank];
+        var dstStride = new int[input.Rank];
+        srcStride[input.Rank - 1] = 1;
+        dstStride[input.Rank - 1] = 1;
+        for (int i = input.Rank - 2; i >= 0; i--)
+        {
+            srcStride[i] = srcStride[i + 1] * input._shape[i + 1];
+            dstStride[i] = dstStride[i + 1] * outShape[i + 1];
+        }
+
+        // Iterate output linearly, map each output index back to source
+        // via the padding mode. Any axis where the mapped index is
+        // out-of-range triggers the constant fill (for Constant mode) or
+        // boundary arithmetic for the other modes.
+        var outIdx = new int[input.Rank];
+        for (int k = 0; k < output.Length; k++)
+        {
+            int tmp = k;
+            for (int i = input.Rank - 1; i >= 0; i--)
+            {
+                outIdx[i] = tmp % outShape[i];
+                tmp /= outShape[i];
+            }
+            int srcOff = 0;
+            bool inBounds = true;
+            for (int i = 0; i < input.Rank; i++)
+            {
+                int local = outIdx[i] - before[i];
+                int extent = input._shape[i];
+                if (local < 0 || local >= extent)
+                {
+                    if (mode == PadMode.Constant) { inBounds = false; break; }
+                    local = MapBoundary(local, extent, mode);
+                }
+                srcOff += local * srcStride[i];
+            }
+            dst[k] = inBounds ? src[srcOff] : fill;
+        }
+        return output;
+    }
+
+    private static int MapBoundary(int idx, int extent, PadMode mode)
+    {
+        switch (mode)
+        {
+            case PadMode.Replicate:
+                if (idx < 0) return 0;
+                if (idx >= extent) return extent - 1;
+                return idx;
+            case PadMode.Reflect:
+            {
+                // Reflect without repeating the boundary pixel (pytorch
+                // default). Period = 2*(extent-1).
+                if (extent == 1) return 0;
+                int period = 2 * (extent - 1);
+                int r = ((idx % period) + period) % period;
+                return r < extent ? r : period - r;
+            }
+            case PadMode.Circular:
+            {
+                int r = ((idx % extent) + extent) % extent;
+                return r;
+            }
+            default:
+                return 0;
+        }
+    }
+
+    // ========================================================================
+    // GridSample (extended) + AffineGrid3D
+    // ========================================================================
+
+    /// <inheritdoc/>
+    public virtual Tensor<T> GridSample<T>(Tensor<T> input, Tensor<T> grid,
+        GridSampleMode mode, GridSamplePadding padding, bool alignCorners)
+    {
+        if (input.Rank != 4) throw new ArgumentException("GridSample expects NHWC input [N, H, W, C].");
+        if (grid.Rank != 4 || grid._shape[3] != 2) throw new ArgumentException("grid must be [N, outH, outW, 2].");
+        if (input._shape[0] != grid._shape[0]) throw new ArgumentException("batch dim of input and grid must match.");
+
+        int N = input._shape[0], H = input._shape[1], W = input._shape[2], C = input._shape[3];
+        int outH = grid._shape[1], outW = grid._shape[2];
+        var output = new Tensor<T>(new[] { N, outH, outW, C });
+        if (output.Length == 0) return output;
+
+        var ops = MathHelper.GetNumericOperations<T>();
+        var src = input.AsSpan();
+        var g = grid.AsSpan();
+        var dst = output.AsWritableSpan();
+
+        for (int n = 0; n < N; n++)
+        for (int oy = 0; oy < outH; oy++)
+        for (int ox = 0; ox < outW; ox++)
+        {
+            int gOff = ((n * outH + oy) * outW + ox) * 2;
+            double gx = ops.ToDouble(g[gOff]);
+            double gy = ops.ToDouble(g[gOff + 1]);
+            // Normalised [-1, 1] -> fractional source index.
+            double sx = NormalizedToPixel(gx, W, alignCorners);
+            double sy = NormalizedToPixel(gy, H, alignCorners);
+
+            if (mode == GridSampleMode.Nearest)
+            {
+                int nx = (int)Math.Round(sx), ny = (int)Math.Round(sy);
+                for (int c = 0; c < C; c++)
+                    dst[((n * outH + oy) * outW + ox) * C + c] =
+                        SampleSafe(src, n, ny, nx, c, H, W, C, padding, ops);
+            }
+            else if (mode == GridSampleMode.Bilinear)
+            {
+                int x0 = (int)Math.Floor(sx), y0 = (int)Math.Floor(sy);
+                int x1 = x0 + 1, y1 = y0 + 1;
+                double fx = sx - x0, fy = sy - y0;
+                for (int c = 0; c < C; c++)
+                {
+                    double v00 = ops.ToDouble(SampleSafe(src, n, y0, x0, c, H, W, C, padding, ops));
+                    double v01 = ops.ToDouble(SampleSafe(src, n, y0, x1, c, H, W, C, padding, ops));
+                    double v10 = ops.ToDouble(SampleSafe(src, n, y1, x0, c, H, W, C, padding, ops));
+                    double v11 = ops.ToDouble(SampleSafe(src, n, y1, x1, c, H, W, C, padding, ops));
+                    double v =
+                        v00 * (1 - fx) * (1 - fy) +
+                        v01 * fx * (1 - fy) +
+                        v10 * (1 - fx) * fy +
+                        v11 * fx * fy;
+                    dst[((n * outH + oy) * outW + ox) * C + c] = ops.FromDouble(v);
+                }
+            }
+            else // Bicubic
+            {
+                int x0 = (int)Math.Floor(sx), y0 = (int)Math.Floor(sy);
+                double fx = sx - x0, fy = sy - y0;
+                double[] wx = CubicWeights(fx), wy = CubicWeights(fy);
+                for (int c = 0; c < C; c++)
+                {
+                    double acc = 0.0;
+                    for (int yy = 0; yy < 4; yy++)
+                    {
+                        int yi = y0 - 1 + yy;
+                        double rowAcc = 0.0;
+                        for (int xx = 0; xx < 4; xx++)
+                        {
+                            int xi = x0 - 1 + xx;
+                            rowAcc += wx[xx] * ops.ToDouble(SampleSafe(src, n, yi, xi, c, H, W, C, padding, ops));
+                        }
+                        acc += wy[yy] * rowAcc;
+                    }
+                    dst[((n * outH + oy) * outW + ox) * C + c] = ops.FromDouble(acc);
+                }
+            }
+        }
+        return output;
+    }
+
+    /// <summary>
+    /// Normalised grid coord (range [-1, 1]) → fractional source pixel
+    /// index. <paramref name="alignCorners"/> switches between the two
+    /// conventions; matches torchvision.
+    /// </summary>
+    private static double NormalizedToPixel(double coord, int size, bool alignCorners)
+    {
+        if (alignCorners) return (coord + 1.0) * 0.5 * (size - 1);
+        return ((coord + 1.0) * size - 1.0) * 0.5;
+    }
+
+    private static T SampleSafe<T>(ReadOnlySpan<T> src, int n, int y, int x, int c,
+        int H, int W, int C, GridSamplePadding padding, Interfaces.INumericOperations<T> ops)
+    {
+        switch (padding)
+        {
+            case GridSamplePadding.Zeros:
+                if ((uint)y >= H || (uint)x >= W) return ops.Zero;
+                break;
+            case GridSamplePadding.Border:
+                y = Math.Clamp(y, 0, H - 1);
+                x = Math.Clamp(x, 0, W - 1);
+                break;
+            case GridSamplePadding.Reflection:
+                y = ReflectIndex(y, H);
+                x = ReflectIndex(x, W);
+                break;
+        }
+        return src[((n * H + y) * W + x) * C + c];
+    }
+
+    private static int ReflectIndex(int i, int extent)
+    {
+        if (extent == 1) return 0;
+        int period = 2 * (extent - 1);
+        int r = ((i % period) + period) % period;
+        return r < extent ? r : period - r;
+    }
+
+    /// <inheritdoc/>
+    public virtual Tensor<T> AffineGrid3D<T>(Tensor<T> theta, int outputDepth, int outputHeight, int outputWidth, bool alignCorners = false)
+    {
+        if (theta.Rank != 3 || theta._shape[1] != 3 || theta._shape[2] != 4)
+            throw new ArgumentException("theta must be [N, 3, 4].");
+        int N = theta._shape[0];
+        var grid = new Tensor<T>(new[] { N, outputDepth, outputHeight, outputWidth, 3 });
+        if (grid.Length == 0) return grid;
+
+        var ops = MathHelper.GetNumericOperations<T>();
+        var t = theta.AsSpan();
+        var g = grid.AsWritableSpan();
+
+        for (int n = 0; n < N; n++)
+        {
+            int tBase = n * 12; // 3 × 4 affine matrix
+            for (int d = 0; d < outputDepth; d++)
+            {
+                double z = GridCoordinate(d, outputDepth, alignCorners);
+                for (int h = 0; h < outputHeight; h++)
+                {
+                    double y = GridCoordinate(h, outputHeight, alignCorners);
+                    for (int w = 0; w < outputWidth; w++)
+                    {
+                        double x = GridCoordinate(w, outputWidth, alignCorners);
+                        int gBase = (((n * outputDepth + d) * outputHeight + h) * outputWidth + w) * 3;
+                        for (int row = 0; row < 3; row++)
+                        {
+                            double v =
+                                ops.ToDouble(t[tBase + row * 4]) * x +
+                                ops.ToDouble(t[tBase + row * 4 + 1]) * y +
+                                ops.ToDouble(t[tBase + row * 4 + 2]) * z +
+                                ops.ToDouble(t[tBase + row * 4 + 3]);
+                            g[gBase + row] = ops.FromDouble(v);
+                        }
+                    }
+                }
+            }
+        }
+        return grid;
+    }
+
+    private static double GridCoordinate(int idx, int size, bool alignCorners)
+    {
+        if (size <= 1) return 0.0;
+        return alignCorners
+            ? -1.0 + 2.0 * idx / (size - 1)
+            : -1.0 + (2.0 * idx + 1.0) / size;
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.Geometry.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.Geometry.cs
@@ -267,11 +267,11 @@ public partial class CpuEngine
                     double acc = 0.0;
                     for (int yy = 0; yy < 4; yy++)
                     {
-                        int yi = Math.Clamp(y0 - 1 + yy, 0, H - 1);
+                        int yi = ClampInt(y0 - 1 + yy, 0, H - 1);
                         double rowAcc = 0.0;
                         for (int xx = 0; xx < 4; xx++)
                         {
-                            int xi = Math.Clamp(x0 - 1 + xx, 0, W - 1);
+                            int xi = ClampInt(x0 - 1 + xx, 0, W - 1);
                             rowAcc += wx[xx] * ops.ToDouble(src[srcBase + yi * W + xi]);
                         }
                         acc += wy[yy] * rowAcc;
@@ -586,8 +586,8 @@ public partial class CpuEngine
                 if ((uint)y >= H || (uint)x >= W) return ops.Zero;
                 break;
             case GridSamplePadding.Border:
-                y = Math.Clamp(y, 0, H - 1);
-                x = Math.Clamp(x, 0, W - 1);
+                y = ClampInt(y, 0, H - 1);
+                x = ClampInt(x, 0, W - 1);
                 break;
             case GridSamplePadding.Reflection:
                 y = ReflectIndex(y, H);
@@ -596,6 +596,9 @@ public partial class CpuEngine
         }
         return src[((n * H + y) * W + x) * C + c];
     }
+
+    /// <summary>Math.Clamp isn't on net471. Inline helper.</summary>
+    private static int ClampInt(int v, int lo, int hi) => v < lo ? lo : (v > hi ? hi : v);
 
     private static int ReflectIndex(int i, int extent)
     {

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.Geometry.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.Geometry.cs
@@ -21,6 +21,16 @@ public partial class CpuEngine
     /// <inheritdoc/>
     public virtual Tensor<T> Interpolate<T>(Tensor<T> input, int[] sizes, InterpolateMode mode, bool alignCorners = false)
     {
+        var result = InterpolateImpl(input, sizes, mode, alignCorners);
+        AiDotNet.Tensors.Engines.Autodiff.DifferentiableOps.RecordUnary(
+            "Interpolate", result, input,
+            AiDotNet.Tensors.Engines.Autodiff.BackwardFunctions<T>.InterpolateBackward,
+            new object[] { mode, alignCorners });
+        return result;
+    }
+
+    private Tensor<T> InterpolateImpl<T>(Tensor<T> input, int[] sizes, InterpolateMode mode, bool alignCorners)
+    {
         if (input is null) throw new ArgumentNullException(nameof(input));
         if (sizes is null) throw new ArgumentNullException(nameof(sizes));
         if (input.Rank < 3)
@@ -80,6 +90,7 @@ public partial class CpuEngine
             sizes[i] = (int)Math.Floor(input._shape[2 + i] * scaleFactors[i]);
             if (sizes[i] < 1) sizes[i] = 1;
         }
+        // Interpolate records itself; InterpolateByScale is a pure delegator.
         return Interpolate(input, sizes, mode, alignCorners);
     }
 
@@ -393,6 +404,16 @@ public partial class CpuEngine
     /// <inheritdoc/>
     public virtual Tensor<T> PadNd<T>(Tensor<T> input, int[] pad, PadMode mode, T value = default!)
     {
+        var result = PadNdImpl(input, pad, mode, value);
+        AiDotNet.Tensors.Engines.Autodiff.DifferentiableOps.RecordUnary(
+            "PadNd", result, input,
+            AiDotNet.Tensors.Engines.Autodiff.BackwardFunctions<T>.PadNdBackward,
+            new object[] { (int[])pad.Clone(), mode });
+        return result;
+    }
+
+    private Tensor<T> PadNdImpl<T>(Tensor<T> input, int[] pad, PadMode mode, T value = default!)
+    {
         if (input is null) throw new ArgumentNullException(nameof(input));
         if (pad is null) throw new ArgumentNullException(nameof(pad));
         if ((pad.Length & 1) != 0)
@@ -656,6 +677,16 @@ public partial class CpuEngine
 
     /// <inheritdoc/>
     public virtual Tensor<T> AffineGrid3D<T>(Tensor<T> theta, int outputDepth, int outputHeight, int outputWidth, bool alignCorners = false)
+    {
+        var result = AffineGrid3DImpl(theta, outputDepth, outputHeight, outputWidth, alignCorners);
+        AiDotNet.Tensors.Engines.Autodiff.DifferentiableOps.RecordUnary(
+            "AffineGrid3D", result, theta,
+            AiDotNet.Tensors.Engines.Autodiff.BackwardFunctions<T>.AffineGrid3DBackward,
+            new object[] { outputDepth, outputHeight, outputWidth, alignCorners });
+        return result;
+    }
+
+    private Tensor<T> AffineGrid3DImpl<T>(Tensor<T> theta, int outputDepth, int outputHeight, int outputWidth, bool alignCorners)
     {
         if (theta.Rank != 3 || theta._shape[1] != 3 || theta._shape[2] != 4)
             throw new ArgumentException("theta must be [N, 3, 4].");

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.Geometry.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.Geometry.cs
@@ -625,6 +625,36 @@ public partial class CpuEngine
     }
 
     /// <inheritdoc/>
+    public virtual Tensor<T> GridSampleBackwardInput<T>(Tensor<T> gradOutput, Tensor<T> grid, int[] inputShape,
+        GridSampleMode mode, GridSamplePadding padding, bool alignCorners)
+    {
+        // The existing 3-arg GridSampleBackwardInput is hard-coded to
+        // bilinear + zeros + alignCorners=false (torchvision defaults).
+        // For non-default settings, specialised GPU kernels are a
+        // follow-up; the managed impl here matches the forward default
+        // only. Guard so callers asking for non-default backward get a
+        // clear error rather than a silent mismatched gradient.
+        if (mode != GridSampleMode.Bilinear || padding != GridSamplePadding.Zeros || alignCorners)
+            throw new NotSupportedException(
+                $"GridSample backward is currently supported only for " +
+                $"Bilinear + Zeros + alignCorners=false. Requested " +
+                $"{mode}/{padding}/alignCorners={alignCorners}.");
+        return GridSampleBackwardInput(gradOutput, grid, inputShape);
+    }
+
+    /// <inheritdoc/>
+    public virtual Tensor<T> GridSampleBackwardGrid<T>(Tensor<T> gradOutput, Tensor<T> input, Tensor<T> grid,
+        GridSampleMode mode, GridSamplePadding padding, bool alignCorners)
+    {
+        if (mode != GridSampleMode.Bilinear || padding != GridSamplePadding.Zeros || alignCorners)
+            throw new NotSupportedException(
+                $"GridSample backward is currently supported only for " +
+                $"Bilinear + Zeros + alignCorners=false. Requested " +
+                $"{mode}/{padding}/alignCorners={alignCorners}.");
+        return GridSampleBackwardGrid(gradOutput, input, grid);
+    }
+
+    /// <inheritdoc/>
     public virtual Tensor<T> AffineGrid3D<T>(Tensor<T> theta, int outputDepth, int outputHeight, int outputWidth, bool alignCorners = false)
     {
         if (theta.Rank != 3 || theta._shape[1] != 3 || theta._shape[2] != 4)

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.Geometry.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.Geometry.cs
@@ -67,6 +67,7 @@ public partial class CpuEngine
     /// <inheritdoc/>
     public virtual Tensor<T> InterpolateByScale<T>(Tensor<T> input, double[] scaleFactors, InterpolateMode mode, bool alignCorners = false)
     {
+        if (input is null) throw new ArgumentNullException(nameof(input));
         if (scaleFactors is null) throw new ArgumentNullException(nameof(scaleFactors));
         int spatialRank = input.Rank - 2;
         if (scaleFactors.Length != spatialRank)
@@ -306,10 +307,10 @@ public partial class CpuEngine
     }
 
     /// <summary>
-    /// Area interpolation — averages every source pixel covered by each
-    /// output cell. Handles both downsampling (multi-source-per-dst, the
-    /// common case) and upsampling (degenerate — equivalent to nearest-
-    /// neighbour when srcSize == dstSize).
+    /// Area interpolation — each output cell is a weighted average of
+    /// every source pixel it covers, where the weight is the fractional
+    /// overlap of the output cell onto that source pixel. This matches
+    /// torchvision's adaptive_avg_pool semantics on non-integer scales.
     /// </summary>
     private static void InterpolateArea<T>(Tensor<T> input, Tensor<T> output, Interfaces.INumericOperations<T> ops)
     {
@@ -328,6 +329,7 @@ public partial class CpuEngine
 
         var dstIdx = new int[spatial];
         var loI = new int[spatial]; var hiI = new int[spatial];
+        var loF = new double[spatial]; var hiF = new double[spatial];
 
         for (int n = 0; n < N; n++)
         for (int c = 0; c < C; c++)
@@ -338,38 +340,49 @@ public partial class CpuEngine
             {
                 int tmp = k;
                 for (int i = spatial - 1; i >= 0; i--) { dstIdx[i] = tmp % dstDims[i]; tmp /= dstDims[i]; }
-                int cellCount = 1;
+                double totalArea = 1.0;
                 for (int i = 0; i < spatial; i++)
                 {
-                    double lo = (double)dstIdx[i] * srcDims[i] / dstDims[i];
-                    double hi = (double)(dstIdx[i] + 1) * srcDims[i] / dstDims[i];
-                    loI[i] = (int)Math.Floor(lo);
-                    hiI[i] = Math.Max(loI[i] + 1, (int)Math.Ceiling(hi));
+                    loF[i] = (double)dstIdx[i] * srcDims[i] / dstDims[i];
+                    hiF[i] = (double)(dstIdx[i] + 1) * srcDims[i] / dstDims[i];
+                    loI[i] = (int)Math.Floor(loF[i]);
+                    hiI[i] = Math.Max(loI[i] + 1, (int)Math.Ceiling(hiF[i]));
                     if (hiI[i] > srcDims[i]) hiI[i] = srcDims[i];
-                    cellCount *= (hiI[i] - loI[i]);
+                    totalArea *= (hiF[i] - loF[i]);
                 }
                 double acc = 0.0;
-                SumRegion(src, srcBase, srcStride, loI, hiI, spatial, ops, ref acc, new int[spatial], 0);
-                dst[dstBase + k] = ops.FromDouble(acc / Math.Max(1, cellCount));
+                WeightedRegion(src, srcBase, srcStride, loI, hiI, loF, hiF, spatial, ops,
+                    ref acc, new int[spatial], 0, 1.0);
+                dst[dstBase + k] = ops.FromDouble(totalArea > 0 ? acc / totalArea : 0);
             }
         }
     }
 
-    private static void SumRegion<T>(ReadOnlySpan<T> src, int srcBase, int[] stride,
-        int[] lo, int[] hi, int spatial, Interfaces.INumericOperations<T> ops,
-        ref double acc, int[] coord, int axis)
+    /// <summary>
+    /// Recursive overlap-weighted sum. Each source texel contributes
+    /// <c>Π overlap_i</c> where <c>overlap_i = min(hiF, i+1) − max(loF, i)</c>
+    /// along each spatial axis. Boundary texels therefore contribute
+    /// only their fractional coverage, which is what "area" interpolation
+    /// actually means.
+    /// </summary>
+    private static void WeightedRegion<T>(ReadOnlySpan<T> src, int srcBase, int[] stride,
+        int[] lo, int[] hi, double[] loF, double[] hiF, int spatial, Interfaces.INumericOperations<T> ops,
+        ref double acc, int[] coord, int axis, double weightSoFar)
     {
         if (axis == spatial)
         {
             int off = 0;
             for (int i = 0; i < spatial; i++) off += coord[i] * stride[i];
-            acc += ops.ToDouble(src[srcBase + off]);
+            acc += weightSoFar * ops.ToDouble(src[srcBase + off]);
             return;
         }
         for (int i = lo[axis]; i < hi[axis]; i++)
         {
+            double overlap = Math.Max(0.0, Math.Min(hiF[axis], i + 1.0) - Math.Max(loF[axis], i));
+            if (overlap <= 0) continue;
             coord[axis] = i;
-            SumRegion(src, srcBase, stride, lo, hi, spatial, ops, ref acc, coord, axis + 1);
+            WeightedRegion(src, srcBase, stride, lo, hi, loF, hiF, spatial, ops,
+                ref acc, coord, axis + 1, weightSoFar * overlap);
         }
     }
 
@@ -456,6 +469,9 @@ public partial class CpuEngine
 
     private static int MapBoundary(int idx, int extent, PadMode mode)
     {
+        // Zero-sized axis: every remapped index collapses to 0 (the
+        // alternative is undefined modulo-by-zero).
+        if (extent <= 0) return 0;
         switch (mode)
         {
             case PadMode.Replicate:

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.Image.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.Image.cs
@@ -41,6 +41,9 @@ public partial class CpuEngine
         if (image is null) throw new ArgumentNullException(nameof(image));
         if (image.Rank != 3)
             throw new ArgumentException("image must be rank-3 [H, W, C].");
+        if ((format == ImageFormat.Jpeg || format == ImageFormat.WebP) && (quality < 0 || quality > 100))
+            throw new ArgumentOutOfRangeException(nameof(quality),
+                $"quality must be in [0, 100] for lossy formats; got {quality}.");
         int C = image._shape[2];
         // PNG colour types 0/2/3/4/6 map to C in {1, 3, 1, 2, 4}. Accept
         // all five (2 = grey+alpha) to match what PngCodec.Encode actually
@@ -359,6 +362,8 @@ internal static class JpegBinding
         {
             int r = tjDecompressHeader3(h, data, (ulong)data.Length, out int w, out int height, out _, out _);
             if (r != 0) throw new InvalidDataException("JPEG header read failed.");
+            if (w <= 0 || height <= 0 || (long)w * height * 3 > int.MaxValue)
+                throw new InvalidDataException($"JPEG: invalid or oversized dimensions {w}×{height}.");
             var px = new byte[w * height * 3];
             r = tjDecompress2(h, data, (ulong)data.Length, px, w, 0, height, TJPF_RGB, 0);
             if (r != 0) throw new InvalidDataException("JPEG decode failed.");
@@ -424,6 +429,11 @@ internal static class WebPBinding
                 "'webp' can be loaded.", ex);
         }
         if (ptr == IntPtr.Zero) throw new InvalidDataException("WebP decode failed.");
+        if (w <= 0 || h <= 0 || (long)w * h * 4 > int.MaxValue)
+        {
+            WebPFree(ptr);
+            throw new InvalidDataException($"WebP: invalid or oversized dimensions {w}×{h}.");
+        }
         try
         {
             var bytes = new byte[w * h * 4];

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.Image.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.Image.cs
@@ -1,0 +1,446 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Image codec CPU implementations — Issue #217 tail.
+// - PNG: pure managed decoder + encoder (no native deps). Supports
+//   non-interlaced 8-bit colour types 0/2/4/6 (grey, rgb, grey+alpha,
+//   rgba). 16-bit + interlaced fall back to an explicit error — rare in
+//   practice.
+// - JPEG: native libjpeg-turbo bindings (dynamic, loaded on first use).
+// - WebP: native libwebp bindings (dynamic).
+// Native loaders throw <see cref="PlatformNotSupportedException"/> with a
+// clear message if the shared library can't be loaded so callers can
+// ship users an actionable install instruction.
+
+using System;
+using System.IO;
+using System.IO.Compression;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines;
+
+public partial class CpuEngine
+{
+    /// <inheritdoc/>
+    public virtual Tensor<byte> ImageDecode(byte[] encoded, ImageFormat? format = null)
+    {
+        if (encoded is null) throw new ArgumentNullException(nameof(encoded));
+        if (encoded.Length < 8) throw new ArgumentException("encoded image is too short.");
+
+        ImageFormat detected = format ?? DetectFormat(encoded);
+        return detected switch
+        {
+            ImageFormat.Png => PngCodec.Decode(encoded),
+            ImageFormat.Jpeg => JpegBinding.Decode(encoded),
+            ImageFormat.WebP => WebPBinding.Decode(encoded),
+            _ => throw new ArgumentOutOfRangeException(nameof(format)),
+        };
+    }
+
+    /// <inheritdoc/>
+    public virtual byte[] ImageEncode(Tensor<byte> image, ImageFormat format, int quality = 90)
+    {
+        if (image is null) throw new ArgumentNullException(nameof(image));
+        if (image.Rank != 3)
+            throw new ArgumentException("image must be rank-3 [H, W, C].");
+        int C = image._shape[2];
+        if (C != 1 && C != 3 && C != 4)
+            throw new ArgumentException("channels must be 1 (grey), 3 (RGB), or 4 (RGBA).");
+        return format switch
+        {
+            ImageFormat.Png => PngCodec.Encode(image),
+            ImageFormat.Jpeg => JpegBinding.Encode(image, quality),
+            ImageFormat.WebP => WebPBinding.Encode(image, quality),
+            _ => throw new ArgumentOutOfRangeException(nameof(format)),
+        };
+    }
+
+    /// <summary>Sniff the format from magic bytes.</summary>
+    private static ImageFormat DetectFormat(byte[] bytes)
+    {
+        if (bytes.Length >= 8
+            && bytes[0] == 137 && bytes[1] == 80 && bytes[2] == 78 && bytes[3] == 71
+            && bytes[4] == 13 && bytes[5] == 10 && bytes[6] == 26 && bytes[7] == 10)
+            return ImageFormat.Png;
+        if (bytes.Length >= 3 && bytes[0] == 0xFF && bytes[1] == 0xD8 && bytes[2] == 0xFF)
+            return ImageFormat.Jpeg;
+        if (bytes.Length >= 12 && bytes[0] == 'R' && bytes[1] == 'I' && bytes[2] == 'F' && bytes[3] == 'F'
+            && bytes[8] == 'W' && bytes[9] == 'E' && bytes[10] == 'B' && bytes[11] == 'P')
+            return ImageFormat.WebP;
+        throw new ArgumentException("unrecognised image format (PNG / JPEG / WebP supported).");
+    }
+}
+
+// ============================================================================
+// PNG — pure managed encoder + decoder.
+// ============================================================================
+internal static class PngCodec
+{
+    private static readonly byte[] Signature = { 137, 80, 78, 71, 13, 10, 26, 10 };
+
+    public static Tensor<byte> Decode(byte[] data)
+    {
+        for (int i = 0; i < 8; i++)
+            if (data[i] != Signature[i]) throw new InvalidDataException("not a PNG file.");
+
+        int pos = 8;
+        int width = 0, height = 0, bitDepth = 0, colorType = 0, interlace = 0;
+        byte[]? palette = null;
+        var idat = new MemoryStream();
+
+        while (pos < data.Length)
+        {
+            int chunkLen = ReadBE(data, pos); pos += 4;
+            string type = System.Text.Encoding.ASCII.GetString(data, pos, 4); pos += 4;
+            if (type == "IHDR")
+            {
+                width = ReadBE(data, pos); height = ReadBE(data, pos + 4);
+                bitDepth = data[pos + 8]; colorType = data[pos + 9];
+                interlace = data[pos + 12];
+            }
+            else if (type == "IDAT")
+            {
+                idat.Write(data, pos, chunkLen);
+            }
+            else if (type == "PLTE")
+            {
+                palette = new byte[chunkLen];
+                Array.Copy(data, pos, palette, 0, chunkLen);
+            }
+            pos += chunkLen + 4;  // skip data + CRC
+            if (type == "IEND") break;
+        }
+
+        if (bitDepth != 8) throw new NotSupportedException("PNG: only 8-bit depth supported.");
+        if (interlace != 0) throw new NotSupportedException("PNG: interlaced images not supported.");
+        int channels = colorType switch { 0 => 1, 2 => 3, 3 => 1, 4 => 2, 6 => 4, _ => throw new InvalidDataException("PNG: unknown colour type.") };
+        if (colorType == 3 && palette is null) throw new InvalidDataException("PNG: indexed image without PLTE.");
+
+        // zlib-wrapped DEFLATE — skip 2-byte zlib header.
+        var zlib = idat.ToArray();
+        int skip = 2;
+        byte[] raw;
+        using (var inflated = new MemoryStream())
+        using (var infl = new DeflateStream(new MemoryStream(zlib, skip, zlib.Length - skip), CompressionMode.Decompress))
+        {
+            infl.CopyTo(inflated);
+            raw = inflated.ToArray();
+        }
+
+        int bpp = channels;  // bytes per pixel at 8-bit
+        int stride = width * bpp;
+        var outBytes = new byte[width * height * (colorType == 3 ? 3 : channels)];
+        var prevRow = new byte[stride];
+        int src = 0;
+        int dstChannels = colorType == 3 ? 3 : channels;
+
+        for (int y = 0; y < height; y++)
+        {
+            if (src >= raw.Length) throw new InvalidDataException("PNG: truncated raster.");
+            byte filter = raw[src++];
+            var row = new byte[stride];
+            Array.Copy(raw, src, row, 0, stride);
+            src += stride;
+            ApplyFilter(filter, row, prevRow, bpp);
+
+            if (colorType == 3)  // indexed — expand to RGB via palette
+            {
+                for (int x = 0; x < width; x++)
+                {
+                    int idx = row[x] * 3;
+                    if (palette is null || idx + 2 >= palette.Length)
+                        throw new InvalidDataException("PNG: palette index out of range.");
+                    int off = (y * width + x) * 3;
+                    outBytes[off] = palette[idx];
+                    outBytes[off + 1] = palette[idx + 1];
+                    outBytes[off + 2] = palette[idx + 2];
+                }
+            }
+            else
+            {
+                Array.Copy(row, 0, outBytes, y * stride, stride);
+            }
+            Array.Copy(row, prevRow, stride);
+        }
+
+        return new Tensor<byte>(outBytes, new[] { height, width, dstChannels });
+    }
+
+    private static void ApplyFilter(byte filter, byte[] row, byte[] prev, int bpp)
+    {
+        switch (filter)
+        {
+            case 0: break;  // None
+            case 1:  // Sub
+                for (int i = bpp; i < row.Length; i++) row[i] = (byte)(row[i] + row[i - bpp]);
+                break;
+            case 2:  // Up
+                for (int i = 0; i < row.Length; i++) row[i] = (byte)(row[i] + prev[i]);
+                break;
+            case 3:  // Average
+                for (int i = 0; i < row.Length; i++)
+                {
+                    byte left = i < bpp ? (byte)0 : row[i - bpp];
+                    row[i] = (byte)(row[i] + (left + prev[i]) / 2);
+                }
+                break;
+            case 4:  // Paeth
+                for (int i = 0; i < row.Length; i++)
+                {
+                    byte a = i < bpp ? (byte)0 : row[i - bpp];
+                    byte b = prev[i];
+                    byte c = i < bpp ? (byte)0 : prev[i - bpp];
+                    int p = a + b - c;
+                    int pa = Math.Abs(p - a);
+                    int pb = Math.Abs(p - b);
+                    int pc = Math.Abs(p - c);
+                    byte pr = pa <= pb && pa <= pc ? a : pb <= pc ? b : c;
+                    row[i] = (byte)(row[i] + pr);
+                }
+                break;
+            default: throw new InvalidDataException($"PNG: unknown filter {filter}.");
+        }
+    }
+
+    public static byte[] Encode(Tensor<byte> image)
+    {
+        int H = image._shape[0], W = image._shape[1], C = image._shape[2];
+        byte colorType = C switch { 1 => 0, 2 => 4, 3 => 2, 4 => 6, _ => throw new ArgumentException("PNG: unsupported channel count") };
+
+        var src = image.AsSpan();
+        var raw = new byte[H * (1 + W * C)];
+        int dst = 0;
+        for (int y = 0; y < H; y++)
+        {
+            raw[dst++] = 0;  // filter type None
+            src.Slice(y * W * C, W * C).CopyTo(raw.AsSpan(dst));
+            dst += W * C;
+        }
+
+        // DEFLATE-compress, then wrap in zlib (2-byte header + adler32 footer).
+        byte[] compressed;
+        using (var ms = new MemoryStream())
+        {
+            using (var defl = new DeflateStream(ms, CompressionLevel.Optimal, leaveOpen: true))
+                defl.Write(raw, 0, raw.Length);
+            compressed = ms.ToArray();
+        }
+        var zlib = new byte[compressed.Length + 6];
+        zlib[0] = 0x78; zlib[1] = 0x9C;  // zlib header, default level
+        Array.Copy(compressed, 0, zlib, 2, compressed.Length);
+        uint adler = Adler32(raw);
+        int apos = compressed.Length + 2;
+        zlib[apos] = (byte)(adler >> 24);
+        zlib[apos + 1] = (byte)(adler >> 16);
+        zlib[apos + 2] = (byte)(adler >> 8);
+        zlib[apos + 3] = (byte)adler;
+
+        // Assemble PNG stream.
+        using var outMs = new MemoryStream();
+        outMs.Write(Signature, 0, 8);
+
+        // IHDR chunk: 13 bytes: width(4), height(4), bitDepth(1), colorType(1), compression(1), filter(1), interlace(1).
+        var ihdr = new byte[13];
+        WriteBE(ihdr, 0, W); WriteBE(ihdr, 4, H);
+        ihdr[8] = 8; ihdr[9] = colorType; ihdr[10] = 0; ihdr[11] = 0; ihdr[12] = 0;
+        WriteChunk(outMs, "IHDR", ihdr);
+        WriteChunk(outMs, "IDAT", zlib);
+        WriteChunk(outMs, "IEND", Array.Empty<byte>());
+        return outMs.ToArray();
+    }
+
+    private static void WriteChunk(Stream s, string type, byte[] data)
+    {
+        var header = new byte[4];
+        WriteBE(header, 0, data.Length);
+        s.Write(header, 0, 4);
+        var typeBytes = System.Text.Encoding.ASCII.GetBytes(type);
+        s.Write(typeBytes, 0, 4);
+        s.Write(data, 0, data.Length);
+        uint crc = Crc32(typeBytes, 0, 4, 0);
+        crc = Crc32(data, 0, data.Length, crc);
+        var crcBytes = new byte[4];
+        WriteBE(crcBytes, 0, (int)crc);
+        s.Write(crcBytes, 0, 4);
+    }
+
+    private static int ReadBE(byte[] d, int o) => (d[o] << 24) | (d[o + 1] << 16) | (d[o + 2] << 8) | d[o + 3];
+    private static void WriteBE(byte[] d, int o, int v)
+    { d[o] = (byte)(v >> 24); d[o + 1] = (byte)(v >> 16); d[o + 2] = (byte)(v >> 8); d[o + 3] = (byte)v; }
+
+    private static readonly uint[] CrcTable = BuildCrcTable();
+    private static uint[] BuildCrcTable()
+    {
+        var t = new uint[256];
+        for (uint n = 0; n < 256; n++)
+        {
+            uint c = n;
+            for (int k = 0; k < 8; k++) c = (c & 1) != 0 ? 0xEDB88320 ^ (c >> 1) : c >> 1;
+            t[n] = c;
+        }
+        return t;
+    }
+    private static uint Crc32(byte[] data, int offset, int length, uint seed)
+    {
+        uint c = seed ^ 0xFFFFFFFF;
+        for (int i = 0; i < length; i++) c = CrcTable[(c ^ data[offset + i]) & 0xFF] ^ (c >> 8);
+        return c ^ 0xFFFFFFFF;
+    }
+
+    private static uint Adler32(byte[] data)
+    {
+        uint a = 1, b = 0;
+        const uint mod = 65521;
+        for (int i = 0; i < data.Length; i++)
+        {
+            a = (a + data[i]) % mod;
+            b = (b + a) % mod;
+        }
+        return (b << 16) | a;
+    }
+}
+
+// ============================================================================
+// JPEG — P/Invoke to libjpeg-turbo (the TurboJPEG API). The library is
+// loaded on first call; a missing library raises a clear error telling
+// users how to install it. TurboJPEG's DLL name differs per platform
+// ("turbojpeg" on Win/Linux, "libturbojpeg.0" on macOS) so we try the
+// common ones in order.
+// ============================================================================
+internal static class JpegBinding
+{
+    // TurboJPEG pixel-format codes (from turbojpeg.h).
+    private const int TJPF_RGB = 0;
+    private const int TJPF_RGBA = 7;
+    private const int TJPF_GRAY = 3;
+    // TJ_SAMP_* subsampling codes.
+    private const int TJSAMP_444 = 0;
+
+    // Library tried in order on first call. Native P/Invoke will throw
+    // DllNotFoundException if the entry point can't be resolved — that's
+    // the canonical way to detect "native lib missing" in .NET.
+    [System.Runtime.InteropServices.DllImport("turbojpeg", EntryPoint = "tjInitDecompress", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl)]
+    private static extern IntPtr tjInitDecompress();
+    [System.Runtime.InteropServices.DllImport("turbojpeg", EntryPoint = "tjDecompressHeader3", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl)]
+    private static extern int tjDecompressHeader3(IntPtr handle, byte[] jpegBuf, ulong jpegSize, out int width, out int height, out int subsamp, out int colorspace);
+    [System.Runtime.InteropServices.DllImport("turbojpeg", EntryPoint = "tjDecompress2", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl)]
+    private static extern int tjDecompress2(IntPtr handle, byte[] jpegBuf, ulong jpegSize, byte[] dstBuf, int width, int pitch, int height, int pixelFormat, int flags);
+    [System.Runtime.InteropServices.DllImport("turbojpeg", EntryPoint = "tjInitCompress", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl)]
+    private static extern IntPtr tjInitCompress();
+    [System.Runtime.InteropServices.DllImport("turbojpeg", EntryPoint = "tjCompress2", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl)]
+    private static extern int tjCompress2(IntPtr handle, byte[] srcBuf, int width, int pitch, int height, int pixelFormat, ref IntPtr jpegBuf, ref ulong jpegSize, int jpegSubsamp, int jpegQual, int flags);
+    [System.Runtime.InteropServices.DllImport("turbojpeg", EntryPoint = "tjDestroy", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl)]
+    private static extern int tjDestroy(IntPtr handle);
+    [System.Runtime.InteropServices.DllImport("turbojpeg", EntryPoint = "tjFree", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl)]
+    private static extern void tjFree(IntPtr buf);
+
+    public static Tensor<byte> Decode(byte[] data)
+    {
+        IntPtr h;
+        try { h = tjInitDecompress(); }
+        catch (DllNotFoundException ex)
+        {
+            throw new PlatformNotSupportedException(
+                "JPEG decode requires libjpeg-turbo. Install it system-wide " +
+                "(apt install libturbojpeg / brew install jpeg-turbo / Windows " +
+                "MSI from libjpeg-turbo.org) so 'turbojpeg' can be loaded.", ex);
+        }
+        if (h == IntPtr.Zero) throw new InvalidOperationException("tjInitDecompress returned null.");
+        try
+        {
+            int r = tjDecompressHeader3(h, data, (ulong)data.Length, out int w, out int height, out _, out _);
+            if (r != 0) throw new InvalidDataException("JPEG header read failed.");
+            var px = new byte[w * height * 3];
+            r = tjDecompress2(h, data, (ulong)data.Length, px, w, 0, height, TJPF_RGB, 0);
+            if (r != 0) throw new InvalidDataException("JPEG decode failed.");
+            return new Tensor<byte>(px, new[] { height, w, 3 });
+        }
+        finally { tjDestroy(h); }
+    }
+
+    public static byte[] Encode(Tensor<byte> image, int quality)
+    {
+        int H = image._shape[0], W = image._shape[1], C = image._shape[2];
+        int pixFmt = C switch { 1 => TJPF_GRAY, 3 => TJPF_RGB, 4 => TJPF_RGBA, _ => -1 };
+        if (pixFmt < 0) throw new ArgumentException("JPEG: unsupported channel count.");
+        IntPtr h;
+        try { h = tjInitCompress(); }
+        catch (DllNotFoundException ex)
+        {
+            throw new PlatformNotSupportedException(
+                "JPEG encode requires libjpeg-turbo. Install it system-wide.", ex);
+        }
+        if (h == IntPtr.Zero) throw new InvalidOperationException("tjInitCompress returned null.");
+        IntPtr dst = IntPtr.Zero;
+        ulong dstLen = 0;
+        try
+        {
+            var srcBytes = image.AsSpan().ToArray();
+            int r = tjCompress2(h, srcBytes, W, 0, H, pixFmt, ref dst, ref dstLen, TJSAMP_444, quality, 0);
+            if (r != 0) throw new InvalidDataException("JPEG encode failed.");
+            var result = new byte[(int)dstLen];
+            System.Runtime.InteropServices.Marshal.Copy(dst, result, 0, (int)dstLen);
+            return result;
+        }
+        finally
+        {
+            if (dst != IntPtr.Zero) tjFree(dst);
+            tjDestroy(h);
+        }
+    }
+}
+
+// ============================================================================
+// WebP — P/Invoke to libwebp. Simple API: WebPDecodeRGBA / WebPEncodeRGBA.
+// ============================================================================
+internal static class WebPBinding
+{
+    [System.Runtime.InteropServices.DllImport("webp", EntryPoint = "WebPDecodeRGBA", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl)]
+    private static extern IntPtr WebPDecodeRGBA(byte[] data, nuint dataSize, out int width, out int height);
+    [System.Runtime.InteropServices.DllImport("webp", EntryPoint = "WebPEncodeRGBA", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl)]
+    private static extern nuint WebPEncodeRGBA(byte[] rgba, int width, int height, int stride, float quality, out IntPtr output);
+    [System.Runtime.InteropServices.DllImport("webp", EntryPoint = "WebPFree", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl)]
+    private static extern void WebPFree(IntPtr ptr);
+
+    public static Tensor<byte> Decode(byte[] data)
+    {
+        IntPtr ptr;
+        int w, h;
+        try { ptr = WebPDecodeRGBA(data, (nuint)data.Length, out w, out h); }
+        catch (DllNotFoundException ex)
+        {
+            throw new PlatformNotSupportedException(
+                "WebP decode requires libwebp. Install it system-wide (apt " +
+                "install libwebp-dev / brew install webp / Windows NuGet) so " +
+                "'webp' can be loaded.", ex);
+        }
+        if (ptr == IntPtr.Zero) throw new InvalidDataException("WebP decode failed.");
+        try
+        {
+            var bytes = new byte[w * h * 4];
+            System.Runtime.InteropServices.Marshal.Copy(ptr, bytes, 0, bytes.Length);
+            return new Tensor<byte>(bytes, new[] { h, w, 4 });
+        }
+        finally { WebPFree(ptr); }
+    }
+
+    public static byte[] Encode(Tensor<byte> image, int quality)
+    {
+        int H = image._shape[0], W = image._shape[1], C = image._shape[2];
+        if (C != 4) throw new ArgumentException("WebP encode needs 4-channel RGBA; pad if needed.");
+        IntPtr outPtr = IntPtr.Zero;
+        nuint outLen;
+        try { outLen = WebPEncodeRGBA(image.AsSpan().ToArray(), W, H, W * 4, quality, out outPtr); }
+        catch (DllNotFoundException ex)
+        {
+            throw new PlatformNotSupportedException(
+                "WebP encode requires libwebp. Install it system-wide.", ex);
+        }
+        if (outLen == 0 || outPtr == IntPtr.Zero) throw new InvalidDataException("WebP encode failed.");
+        try
+        {
+            var result = new byte[(int)outLen];
+            System.Runtime.InteropServices.Marshal.Copy(outPtr, result, 0, (int)outLen);
+            return result;
+        }
+        finally { WebPFree(outPtr); }
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.Image.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.Image.cs
@@ -42,8 +42,13 @@ public partial class CpuEngine
         if (image.Rank != 3)
             throw new ArgumentException("image must be rank-3 [H, W, C].");
         int C = image._shape[2];
-        if (C != 1 && C != 3 && C != 4)
-            throw new ArgumentException("channels must be 1 (grey), 3 (RGB), or 4 (RGBA).");
+        // PNG colour types 0/2/3/4/6 map to C in {1, 3, 1, 2, 4}. Accept
+        // all five (2 = grey+alpha) to match what PngCodec.Encode actually
+        // supports. Only JPEG is channel-restricted below.
+        if (C != 1 && C != 2 && C != 3 && C != 4)
+            throw new ArgumentException("channels must be 1 (grey), 2 (grey+alpha), 3 (RGB), or 4 (RGBA).");
+        if (format == ImageFormat.Jpeg && C == 2)
+            throw new ArgumentException("JPEG does not support 2-channel grey+alpha.");
         return format switch
         {
             ImageFormat.Png => PngCodec.Encode(image),
@@ -88,10 +93,14 @@ internal static class PngCodec
 
         while (pos < data.Length)
         {
+            if (pos + 8 > data.Length) throw new InvalidDataException("PNG: truncated chunk header.");
             int chunkLen = ReadBE(data, pos); pos += 4;
+            if (chunkLen < 0 || chunkLen > data.Length - pos - 4)
+                throw new InvalidDataException("PNG: chunk length exceeds buffer.");
             string type = System.Text.Encoding.ASCII.GetString(data, pos, 4); pos += 4;
             if (type == "IHDR")
             {
+                if (chunkLen < 13) throw new InvalidDataException("PNG: truncated IHDR.");
                 width = ReadBE(data, pos); height = ReadBE(data, pos + 4);
                 bitDepth = data[pos + 8]; colorType = data[pos + 9];
                 interlace = data[pos + 12];
@@ -109,6 +118,8 @@ internal static class PngCodec
             if (type == "IEND") break;
         }
 
+        if (width <= 0 || height <= 0 || (long)width * height > int.MaxValue / 8)
+            throw new InvalidDataException($"PNG: invalid or oversized dimensions {width}×{height}.");
         if (bitDepth != 8) throw new NotSupportedException("PNG: only 8-bit depth supported.");
         if (interlace != 0) throw new NotSupportedException("PNG: interlaced images not supported.");
         int channels = colorType switch { 0 => 1, 2 => 3, 3 => 1, 4 => 2, 6 => 4, _ => throw new InvalidDataException("PNG: unknown colour type.") };

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.RoiAudio.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.RoiAudio.cs
@@ -169,6 +169,8 @@ public partial class CpuEngine
         float spatialScale, int samplingRatio)
     {
         if (input.Rank != 4) throw new ArgumentException("PsRoIAlign input must be [N, C, H, W].");
+        if (boxes.Rank != 2 || boxes._shape[1] != 5)
+            throw new ArgumentException("PsRoIAlign boxes must be [K, 5] = (batch_idx, x1, y1, x2, y2).");
         int N = input._shape[0], C = input._shape[1], H = input._shape[2], W = input._shape[3];
         if (C != outputChannels * outputHeight * outputWidth)
             throw new ArgumentException($"PsRoIAlign requires C == outputChannels * outH * outW ({outputChannels * outputHeight * outputWidth}); got {C}.");
@@ -228,6 +230,8 @@ public partial class CpuEngine
         int outputHeight, int outputWidth, int outputChannels, float spatialScale)
     {
         if (input.Rank != 4) throw new ArgumentException("PsRoIPool input must be [N, C, H, W].");
+        if (boxes.Rank != 2 || boxes._shape[1] != 5)
+            throw new ArgumentException("PsRoIPool boxes must be [K, 5].");
         int N = input._shape[0], C = input._shape[1], H = input._shape[2], W = input._shape[3];
         if (C != outputChannels * outputHeight * outputWidth)
             throw new ArgumentException("PsRoIPool requires C == outputChannels * outH * outW.");
@@ -333,6 +337,9 @@ public partial class CpuEngine
     /// <inheritdoc/>
     public virtual Tensor<int> MuLawEncoding<T>(Tensor<T> input, int quantizationChannels = 256)
     {
+        if (quantizationChannels < 2)
+            throw new ArgumentException("quantizationChannels must be >= 2 (μ = qc − 1 must be positive).",
+                nameof(quantizationChannels));
         var ops = MathHelper.GetNumericOperations<T>();
         var src = input.AsSpan();
         var result = new Tensor<int>(input._shape);
@@ -354,6 +361,8 @@ public partial class CpuEngine
     /// <inheritdoc/>
     public virtual Tensor<T> MuLawDecoding<T>(Tensor<int> input, int quantizationChannels = 256)
     {
+        if (quantizationChannels < 2)
+            throw new ArgumentException("quantizationChannels must be >= 2.", nameof(quantizationChannels));
         var ops = MathHelper.GetNumericOperations<T>();
         var src = input.AsSpan();
         var result = new Tensor<T>(input._shape);
@@ -381,6 +390,8 @@ public partial class CpuEngine
         int rank = input.Rank;
         if (rank < 1) throw new ArgumentException("input must have at least 1 axis.");
         int tLen = input._shape[rank - 1];
+        if (tLen <= 0)
+            return new Tensor<T>((int[])input._shape.Clone());
         int leading = input.Length / tLen;
 
         var result = new Tensor<T>(input._shape);
@@ -410,6 +421,13 @@ public partial class CpuEngine
     public virtual Tensor<T> Resample<T>(Tensor<T> waveform, int origRate, int newRate)
     {
         if (origRate <= 0 || newRate <= 0) throw new ArgumentException("rates must be positive.");
+        if (waveform.Rank < 1) throw new ArgumentException("waveform must have at least 1 axis.");
+        if (waveform._shape[waveform.Rank - 1] == 0)
+        {
+            var empty = (int[])waveform._shape.Clone();
+            empty[waveform.Rank - 1] = 0;
+            return new Tensor<T>(empty);
+        }
         if (origRate == newRate) return waveform.Clone();
         int gcd = Gcd(origRate, newRate);
         int up = newRate / gcd;

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.RoiAudio.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.RoiAudio.cs
@@ -184,6 +184,8 @@ public partial class CpuEngine
         for (int k = 0; k < K; k++)
         {
             int n = (int)ops.ToDouble(b[k * 5]);
+            if (n < 0 || n >= N)
+                throw new ArgumentException($"PsRoIAlign batch idx {n} out of range [0, {N}).");
             double x1 = ops.ToDouble(b[k * 5 + 1]) * spatialScale;
             double y1 = ops.ToDouble(b[k * 5 + 2]) * spatialScale;
             double x2 = ops.ToDouble(b[k * 5 + 3]) * spatialScale;
@@ -241,6 +243,8 @@ public partial class CpuEngine
         for (int k = 0; k < K; k++)
         {
             int n = (int)ops.ToDouble(b[k * 5]);
+            if (n < 0 || n >= N)
+                throw new ArgumentException($"PsRoIPool batch idx {n} out of range [0, {N}).");
             double x1 = ops.ToDouble(b[k * 5 + 1]) * spatialScale;
             double y1 = ops.ToDouble(b[k * 5 + 2]) * spatialScale;
             double x2 = ops.ToDouble(b[k * 5 + 3]) * spatialScale;
@@ -327,11 +331,11 @@ public partial class CpuEngine
     }
 
     /// <inheritdoc/>
-    public virtual Tensor<T> MuLawEncoding<T>(Tensor<T> input, int quantizationChannels = 256)
+    public virtual Tensor<int> MuLawEncoding<T>(Tensor<T> input, int quantizationChannels = 256)
     {
         var ops = MathHelper.GetNumericOperations<T>();
         var src = input.AsSpan();
-        var result = new Tensor<T>(input._shape);
+        var result = new Tensor<int>(input._shape);
         var dst = result.AsWritableSpan();
         double mu = quantizationChannels - 1;
         double logMu = Log1pFallback(mu);
@@ -340,16 +344,15 @@ public partial class CpuEngine
             double x = ops.ToDouble(src[i]);
             if (x > 1) x = 1; else if (x < -1) x = -1;
             double y = Math.Sign(x) * Log1pFallback(mu * Math.Abs(x)) / logMu;
-            // Quantise to [0, mu] integer code (stored as float).
-            double q = Math.Floor((y + 1) * 0.5 * mu + 0.5);
-            if (q < 0) q = 0; if (q > mu) q = mu;
-            dst[i] = ops.FromDouble(q);
+            int q = (int)Math.Floor((y + 1) * 0.5 * mu + 0.5);
+            if (q < 0) q = 0; else if (q > mu) q = (int)mu;
+            dst[i] = q;
         }
         return result;
     }
 
     /// <inheritdoc/>
-    public virtual Tensor<T> MuLawDecoding<T>(Tensor<T> input, int quantizationChannels = 256)
+    public virtual Tensor<T> MuLawDecoding<T>(Tensor<int> input, int quantizationChannels = 256)
     {
         var ops = MathHelper.GetNumericOperations<T>();
         var src = input.AsSpan();
@@ -358,7 +361,7 @@ public partial class CpuEngine
         double mu = quantizationChannels - 1;
         for (int i = 0; i < src.Length; i++)
         {
-            double q = ops.ToDouble(src[i]);
+            double q = src[i];
             double y = (q / mu) * 2 - 1;
             double x = Math.Sign(y) * (Math.Pow(1 + mu, Math.Abs(y)) - 1) / mu;
             dst[i] = ops.FromDouble(x);
@@ -494,6 +497,8 @@ public partial class CpuEngine
         int nFft = 512, int hopLength = 128)
     {
         if (rate <= 0) throw new ArgumentException("rate must be positive.");
+        if (nFft < 2) throw new ArgumentException("nFft must be at least 2 (Hann window divides by nFft−1).");
+        if (hopLength <= 0) throw new ArgumentException("hopLength must be positive.");
         if (Math.Abs(rate - 1.0) < 1e-12) return waveform.Clone();
         int winLength = nFft;
         var window = new Tensor<T>(new int[] { winLength });

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.RoiAudio.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.RoiAudio.cs
@@ -1,0 +1,560 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// CPU reference implementations for the tail of Issue #217:
+//   RoI family: RoIAlign, RoIPool, PsRoIAlign, PsRoIPool
+//   Audio primitives: Spectrogram, AmplitudeToDB, MuLaw encode/decode,
+//                    ComputeDeltas, Resample, PitchShift, TimeStretch
+// Matches torchvision 0.15 / torchaudio 2.0 semantics bit-for-bit
+// where practical.
+
+using System;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines;
+
+public partial class CpuEngine
+{
+    // ========================================================================
+    // RoI family
+    // ========================================================================
+
+    /// <inheritdoc/>
+    public virtual Tensor<T> RoIAlign<T>(Tensor<T> input, Tensor<T> boxes,
+        int outputHeight, int outputWidth,
+        float spatialScale, int samplingRatio, bool aligned)
+    {
+        if (input.Rank != 4) throw new ArgumentException("RoIAlign input must be [N, C, H, W].");
+        if (boxes.Rank != 2 || boxes._shape[1] != 5)
+            throw new ArgumentException("RoIAlign boxes must be [K, 5] = (batch_idx, x1, y1, x2, y2).");
+        int N = input._shape[0], C = input._shape[1], H = input._shape[2], W = input._shape[3];
+        int K = boxes._shape[0];
+        var output = new Tensor<T>(new[] { K, C, outputHeight, outputWidth });
+        if (K == 0) return output;
+
+        var ops = MathHelper.GetNumericOperations<T>();
+        var src = input.AsSpan();
+        var b = boxes.AsSpan();
+        var dst = output.AsWritableSpan();
+        double offset = aligned ? 0.5 : 0.0;
+
+        for (int k = 0; k < K; k++)
+        {
+            int n = (int)ops.ToDouble(b[k * 5]);
+            if (n < 0 || n >= N) throw new ArgumentException($"RoIAlign batch idx {n} out of range [0, {N}).");
+            double x1 = ops.ToDouble(b[k * 5 + 1]) * spatialScale - offset;
+            double y1 = ops.ToDouble(b[k * 5 + 2]) * spatialScale - offset;
+            double x2 = ops.ToDouble(b[k * 5 + 3]) * spatialScale - offset;
+            double y2 = ops.ToDouble(b[k * 5 + 4]) * spatialScale - offset;
+
+            double roiW = aligned ? (x2 - x1) : Math.Max(x2 - x1, 1.0);
+            double roiH = aligned ? (y2 - y1) : Math.Max(y2 - y1, 1.0);
+            double binH = roiH / outputHeight;
+            double binW = roiW / outputWidth;
+
+            int ry = samplingRatio > 0 ? samplingRatio : (int)Math.Ceiling(roiH / outputHeight);
+            int rx = samplingRatio > 0 ? samplingRatio : (int)Math.Ceiling(roiW / outputWidth);
+            if (ry < 1) ry = 1;
+            if (rx < 1) rx = 1;
+            double gridArea = ry * rx;
+
+            for (int c = 0; c < C; c++)
+            {
+                int planeBase = (n * C + c) * H * W;
+                for (int ph = 0; ph < outputHeight; ph++)
+                for (int pw = 0; pw < outputWidth; pw++)
+                {
+                    double acc = 0;
+                    for (int iy = 0; iy < ry; iy++)
+                    {
+                        double sy = y1 + ph * binH + (iy + 0.5) * binH / ry;
+                        for (int ix = 0; ix < rx; ix++)
+                        {
+                            double sx = x1 + pw * binW + (ix + 0.5) * binW / rx;
+                            acc += BilinearSample(src, planeBase, sy, sx, H, W, ops);
+                        }
+                    }
+                    dst[((k * C + c) * outputHeight + ph) * outputWidth + pw] =
+                        ops.FromDouble(acc / gridArea);
+                }
+            }
+        }
+        return output;
+    }
+
+    /// <summary>Bilinear sample with zero-padding (RoIAlign convention).</summary>
+    private static double BilinearSample<T>(ReadOnlySpan<T> src, int planeBase,
+        double y, double x, int H, int W, Interfaces.INumericOperations<T> ops)
+    {
+        if (y < -1.0 || y > H || x < -1.0 || x > W) return 0.0;
+        if (y <= 0) y = 0;
+        if (x <= 0) x = 0;
+        int y0 = (int)y;
+        int x0 = (int)x;
+        int y1 = y0 + 1 >= H ? H - 1 : y0 + 1;
+        int x1 = x0 + 1 >= W ? W - 1 : x0 + 1;
+        if (y0 >= H - 1) { y0 = y1 = H - 1; y = y0; }
+        if (x0 >= W - 1) { x0 = x1 = W - 1; x = x0; }
+        double ly = y - y0, lx = x - x0;
+        double hy = 1.0 - ly, hx = 1.0 - lx;
+        double v00 = ops.ToDouble(src[planeBase + y0 * W + x0]);
+        double v01 = ops.ToDouble(src[planeBase + y0 * W + x1]);
+        double v10 = ops.ToDouble(src[planeBase + y1 * W + x0]);
+        double v11 = ops.ToDouble(src[planeBase + y1 * W + x1]);
+        return hy * hx * v00 + hy * lx * v01 + ly * hx * v10 + ly * lx * v11;
+    }
+
+    /// <inheritdoc/>
+    public virtual Tensor<T> RoIPool<T>(Tensor<T> input, Tensor<T> boxes,
+        int outputHeight, int outputWidth, float spatialScale)
+    {
+        if (input.Rank != 4) throw new ArgumentException("RoIPool input must be [N, C, H, W].");
+        if (boxes.Rank != 2 || boxes._shape[1] != 5) throw new ArgumentException("RoIPool boxes must be [K, 5].");
+        int N = input._shape[0], C = input._shape[1], H = input._shape[2], W = input._shape[3];
+        int K = boxes._shape[0];
+        var output = new Tensor<T>(new[] { K, C, outputHeight, outputWidth });
+        if (K == 0) return output;
+
+        var ops = MathHelper.GetNumericOperations<T>();
+        var src = input.AsSpan();
+        var b = boxes.AsSpan();
+        var dst = output.AsWritableSpan();
+        T negInf = ops.FromDouble(double.NegativeInfinity);
+
+        for (int k = 0; k < K; k++)
+        {
+            int n = (int)ops.ToDouble(b[k * 5]);
+            if (n < 0 || n >= N) throw new ArgumentException("RoIPool batch idx out of range.");
+            int x1 = (int)Math.Round(ops.ToDouble(b[k * 5 + 1]) * spatialScale);
+            int y1 = (int)Math.Round(ops.ToDouble(b[k * 5 + 2]) * spatialScale);
+            int x2 = (int)Math.Round(ops.ToDouble(b[k * 5 + 3]) * spatialScale);
+            int y2 = (int)Math.Round(ops.ToDouble(b[k * 5 + 4]) * spatialScale);
+            int roiW = Math.Max(x2 - x1 + 1, 1);
+            int roiH = Math.Max(y2 - y1 + 1, 1);
+            double binH = (double)roiH / outputHeight;
+            double binW = (double)roiW / outputWidth;
+
+            for (int c = 0; c < C; c++)
+            {
+                int planeBase = (n * C + c) * H * W;
+                for (int ph = 0; ph < outputHeight; ph++)
+                for (int pw = 0; pw < outputWidth; pw++)
+                {
+                    int hstart = (int)Math.Floor(ph * binH) + y1;
+                    int hend = (int)Math.Ceiling((ph + 1) * binH) + y1;
+                    int wstart = (int)Math.Floor(pw * binW) + x1;
+                    int wend = (int)Math.Ceiling((pw + 1) * binW) + x1;
+                    hstart = Math.Min(Math.Max(hstart, 0), H);
+                    hend = Math.Min(Math.Max(hend, 0), H);
+                    wstart = Math.Min(Math.Max(wstart, 0), W);
+                    wend = Math.Min(Math.Max(wend, 0), W);
+                    bool empty = hend <= hstart || wend <= wstart;
+                    double best = empty ? 0.0 : double.NegativeInfinity;
+                    for (int yy = hstart; yy < hend; yy++)
+                    for (int xx = wstart; xx < wend; xx++)
+                    {
+                        double v = ops.ToDouble(src[planeBase + yy * W + xx]);
+                        if (v > best) best = v;
+                    }
+                    dst[((k * C + c) * outputHeight + ph) * outputWidth + pw] =
+                        empty ? ops.Zero : ops.FromDouble(best);
+                }
+            }
+        }
+        return output;
+    }
+
+    /// <inheritdoc/>
+    public virtual Tensor<T> PsRoIAlign<T>(Tensor<T> input, Tensor<T> boxes,
+        int outputHeight, int outputWidth, int outputChannels,
+        float spatialScale, int samplingRatio)
+    {
+        if (input.Rank != 4) throw new ArgumentException("PsRoIAlign input must be [N, C, H, W].");
+        int N = input._shape[0], C = input._shape[1], H = input._shape[2], W = input._shape[3];
+        if (C != outputChannels * outputHeight * outputWidth)
+            throw new ArgumentException($"PsRoIAlign requires C == outputChannels * outH * outW ({outputChannels * outputHeight * outputWidth}); got {C}.");
+        int K = boxes._shape[0];
+        var output = new Tensor<T>(new[] { K, outputChannels, outputHeight, outputWidth });
+        if (K == 0) return output;
+
+        var ops = MathHelper.GetNumericOperations<T>();
+        var src = input.AsSpan();
+        var b = boxes.AsSpan();
+        var dst = output.AsWritableSpan();
+
+        for (int k = 0; k < K; k++)
+        {
+            int n = (int)ops.ToDouble(b[k * 5]);
+            double x1 = ops.ToDouble(b[k * 5 + 1]) * spatialScale;
+            double y1 = ops.ToDouble(b[k * 5 + 2]) * spatialScale;
+            double x2 = ops.ToDouble(b[k * 5 + 3]) * spatialScale;
+            double y2 = ops.ToDouble(b[k * 5 + 4]) * spatialScale;
+            double roiW = Math.Max(x2 - x1, 0.1);
+            double roiH = Math.Max(y2 - y1, 0.1);
+            double binH = roiH / outputHeight;
+            double binW = roiW / outputWidth;
+
+            int ry = samplingRatio > 0 ? samplingRatio : (int)Math.Ceiling(roiH / outputHeight);
+            int rx = samplingRatio > 0 ? samplingRatio : (int)Math.Ceiling(roiW / outputWidth);
+            if (ry < 1) ry = 1;
+            if (rx < 1) rx = 1;
+
+            for (int co = 0; co < outputChannels; co++)
+            for (int ph = 0; ph < outputHeight; ph++)
+            for (int pw = 0; pw < outputWidth; pw++)
+            {
+                int c = (co * outputHeight + ph) * outputWidth + pw;
+                int planeBase = (n * C + c) * H * W;
+                double acc = 0;
+                for (int iy = 0; iy < ry; iy++)
+                {
+                    double sy = y1 + ph * binH + (iy + 0.5) * binH / ry;
+                    for (int ix = 0; ix < rx; ix++)
+                    {
+                        double sx = x1 + pw * binW + (ix + 0.5) * binW / rx;
+                        acc += BilinearSample(src, planeBase, sy, sx, H, W, ops);
+                    }
+                }
+                dst[((k * outputChannels + co) * outputHeight + ph) * outputWidth + pw] =
+                    ops.FromDouble(acc / (ry * rx));
+            }
+        }
+        return output;
+    }
+
+    /// <inheritdoc/>
+    public virtual Tensor<T> PsRoIPool<T>(Tensor<T> input, Tensor<T> boxes,
+        int outputHeight, int outputWidth, int outputChannels, float spatialScale)
+    {
+        if (input.Rank != 4) throw new ArgumentException("PsRoIPool input must be [N, C, H, W].");
+        int N = input._shape[0], C = input._shape[1], H = input._shape[2], W = input._shape[3];
+        if (C != outputChannels * outputHeight * outputWidth)
+            throw new ArgumentException("PsRoIPool requires C == outputChannels * outH * outW.");
+        int K = boxes._shape[0];
+        var output = new Tensor<T>(new[] { K, outputChannels, outputHeight, outputWidth });
+        if (K == 0) return output;
+
+        var ops = MathHelper.GetNumericOperations<T>();
+        var src = input.AsSpan();
+        var b = boxes.AsSpan();
+        var dst = output.AsWritableSpan();
+
+        for (int k = 0; k < K; k++)
+        {
+            int n = (int)ops.ToDouble(b[k * 5]);
+            double x1 = ops.ToDouble(b[k * 5 + 1]) * spatialScale;
+            double y1 = ops.ToDouble(b[k * 5 + 2]) * spatialScale;
+            double x2 = ops.ToDouble(b[k * 5 + 3]) * spatialScale;
+            double y2 = ops.ToDouble(b[k * 5 + 4]) * spatialScale;
+            double binH = Math.Max(y2 - y1, 0.1) / outputHeight;
+            double binW = Math.Max(x2 - x1, 0.1) / outputWidth;
+
+            for (int co = 0; co < outputChannels; co++)
+            for (int ph = 0; ph < outputHeight; ph++)
+            for (int pw = 0; pw < outputWidth; pw++)
+            {
+                int c = (co * outputHeight + ph) * outputWidth + pw;
+                int planeBase = (n * C + c) * H * W;
+                int hs = Math.Max(0, (int)Math.Floor(y1 + ph * binH));
+                int he = Math.Min(H, (int)Math.Ceiling(y1 + (ph + 1) * binH));
+                int ws = Math.Max(0, (int)Math.Floor(x1 + pw * binW));
+                int we = Math.Min(W, (int)Math.Ceiling(x1 + (pw + 1) * binW));
+                double acc = 0; int count = 0;
+                for (int yy = hs; yy < he; yy++)
+                for (int xx = ws; xx < we; xx++)
+                {
+                    acc += ops.ToDouble(src[planeBase + yy * W + xx]);
+                    count++;
+                }
+                dst[((k * outputChannels + co) * outputHeight + ph) * outputWidth + pw] =
+                    count > 0 ? ops.FromDouble(acc / count) : ops.Zero;
+            }
+        }
+        return output;
+    }
+
+    // ========================================================================
+    // Audio primitives
+    // ========================================================================
+
+    /// <inheritdoc/>
+    public virtual Tensor<T> Spectrogram<T>(Tensor<T> waveform, int nFft, int hopLength, int winLength, Tensor<T>? window = null)
+    {
+        // Thin wrapper: run STFT and return only magnitude. STFT here
+        // takes (input, nFft, hop, window, center) — the winLength arg
+        // on our Spectrogram API is absorbed into the window shape.
+        var win = window ?? HannWindow<T>(winLength);
+        STFT(waveform, nFft, hopLength, win, center: true,
+            out var mag, out _);
+        return mag;
+    }
+
+    private static Tensor<T> HannWindow<T>(int n)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        var w = new Tensor<T>(new[] { n });
+        var s = w.AsWritableSpan();
+        for (int i = 0; i < n; i++)
+            s[i] = ops.FromDouble(0.5 - 0.5 * Math.Cos(2.0 * Math.PI * i / Math.Max(1, n - 1)));
+        return w;
+    }
+
+    /// <inheritdoc/>
+    public virtual Tensor<T> AmplitudeToDB<T>(Tensor<T> input, float minAmplitude = 1e-10f, float? topDb = null)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        var src = input.AsSpan();
+        var result = new Tensor<T>(input._shape);
+        var dst = result.AsWritableSpan();
+        double minAmp = Math.Max(1e-20, minAmplitude);
+        double peak = double.NegativeInfinity;
+        for (int i = 0; i < src.Length; i++)
+        {
+            double v = Math.Max(ops.ToDouble(src[i]), minAmp);
+            double db = 20.0 * Math.Log10(v);
+            if (db > peak) peak = db;
+            dst[i] = ops.FromDouble(db);
+        }
+        if (topDb.HasValue)
+        {
+            double floor = peak - topDb.Value;
+            for (int i = 0; i < dst.Length; i++)
+            {
+                double v = ops.ToDouble(dst[i]);
+                if (v < floor) dst[i] = ops.FromDouble(floor);
+            }
+        }
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public virtual Tensor<T> MuLawEncoding<T>(Tensor<T> input, int quantizationChannels = 256)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        var src = input.AsSpan();
+        var result = new Tensor<T>(input._shape);
+        var dst = result.AsWritableSpan();
+        double mu = quantizationChannels - 1;
+        double logMu = Log1pFallback(mu);
+        for (int i = 0; i < src.Length; i++)
+        {
+            double x = ops.ToDouble(src[i]);
+            if (x > 1) x = 1; else if (x < -1) x = -1;
+            double y = Math.Sign(x) * Log1pFallback(mu * Math.Abs(x)) / logMu;
+            // Quantise to [0, mu] integer code (stored as float).
+            double q = Math.Floor((y + 1) * 0.5 * mu + 0.5);
+            if (q < 0) q = 0; if (q > mu) q = mu;
+            dst[i] = ops.FromDouble(q);
+        }
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public virtual Tensor<T> MuLawDecoding<T>(Tensor<T> input, int quantizationChannels = 256)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        var src = input.AsSpan();
+        var result = new Tensor<T>(input._shape);
+        var dst = result.AsWritableSpan();
+        double mu = quantizationChannels - 1;
+        for (int i = 0; i < src.Length; i++)
+        {
+            double q = ops.ToDouble(src[i]);
+            double y = (q / mu) * 2 - 1;
+            double x = Math.Sign(y) * (Math.Pow(1 + mu, Math.Abs(y)) - 1) / mu;
+            dst[i] = ops.FromDouble(x);
+        }
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public virtual Tensor<T> ComputeDeltas<T>(Tensor<T> input, int winLength = 5)
+    {
+        if (winLength < 3 || (winLength & 1) == 0)
+            throw new ArgumentException("winLength must be an odd integer >= 3.");
+        int n = winLength / 2;
+        // torchaudio convention: denom = 2 * Σ k² for k=1..n.
+        double denom = 0.0;
+        for (int i = 1; i <= n; i++) denom += 2.0 * i * i;
+        int rank = input.Rank;
+        if (rank < 1) throw new ArgumentException("input must have at least 1 axis.");
+        int tLen = input._shape[rank - 1];
+        int leading = input.Length / tLen;
+
+        var result = new Tensor<T>(input._shape);
+        var ops = MathHelper.GetNumericOperations<T>();
+        var src = input.AsSpan();
+        var dst = result.AsWritableSpan();
+
+        for (int row = 0; row < leading; row++)
+        {
+            int base_ = row * tLen;
+            for (int t = 0; t < tLen; t++)
+            {
+                double acc = 0;
+                for (int k = 1; k <= n; k++)
+                {
+                    int left = t - k < 0 ? 0 : t - k;
+                    int right = t + k >= tLen ? tLen - 1 : t + k;
+                    acc += k * (ops.ToDouble(src[base_ + right]) - ops.ToDouble(src[base_ + left]));
+                }
+                dst[base_ + t] = ops.FromDouble(acc / denom);
+            }
+        }
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public virtual Tensor<T> Resample<T>(Tensor<T> waveform, int origRate, int newRate)
+    {
+        if (origRate <= 0 || newRate <= 0) throw new ArgumentException("rates must be positive.");
+        if (origRate == newRate) return waveform.Clone();
+        int gcd = Gcd(origRate, newRate);
+        int up = newRate / gcd;
+        int down = origRate / gcd;
+        // Simplified low-pass sinc kernel. Use a short filter (half-width =
+        // maxRate / gcd * 16) to keep CPU cost bounded.
+        int halfWidth = Math.Max(8, Math.Min(256, up * 8));
+        int tapCount = 2 * halfWidth + 1;
+        double cutoff = 1.0 / Math.Max(up, down);
+
+        // Output length for 1D or multi-axis: resample along last axis.
+        int tIn = waveform._shape[waveform.Rank - 1];
+        int tOut = (int)((long)tIn * up / down);
+        var outShape = (int[])waveform._shape.Clone();
+        outShape[waveform.Rank - 1] = tOut;
+        var result = new Tensor<T>(outShape);
+        var ops = MathHelper.GetNumericOperations<T>();
+        var src = waveform.AsSpan();
+        var dst = result.AsWritableSpan();
+        int leading = waveform.Length / tIn;
+
+        for (int row = 0; row < leading; row++)
+        {
+            int sBase = row * tIn, dBase = row * tOut;
+            for (int ot = 0; ot < tOut; ot++)
+            {
+                double srcIdx = (double)ot * down / up;
+                int centre = (int)Math.Floor(srcIdx);
+                double acc = 0;
+                double weightSum = 0;
+                for (int k = -halfWidth; k <= halfWidth; k++)
+                {
+                    int idx = centre + k;
+                    if (idx < 0 || idx >= tIn) continue;
+                    double t = (idx - srcIdx) * cutoff;
+                    double w = Sinc(t) * Hann(k, halfWidth);
+                    acc += w * ops.ToDouble(src[sBase + idx]);
+                    weightSum += w;
+                }
+                dst[dBase + ot] = ops.FromDouble(weightSum > 0 ? acc / weightSum : 0);
+            }
+        }
+        return result;
+    }
+
+    /// <summary>net471 doesn't have Math.Log1p; fall back to ln(1+x).</summary>
+    private static double Log1pFallback(double x) => Math.Log(1.0 + x);
+
+    private static double Sinc(double x)
+    {
+        if (Math.Abs(x) < 1e-12) return 1.0;
+        double px = Math.PI * x;
+        return Math.Sin(px) / px;
+    }
+
+    private static double Hann(int k, int halfWidth)
+    {
+        double n = k + halfWidth;
+        int N = 2 * halfWidth;
+        return 0.5 - 0.5 * Math.Cos(2.0 * Math.PI * n / N);
+    }
+
+    private static int Gcd(int a, int b)
+    {
+        while (b != 0) { int t = b; b = a % b; a = t; }
+        return a;
+    }
+
+    /// <inheritdoc/>
+    public virtual Tensor<T> PitchShift<T>(Tensor<T> waveform, int sampleRate, double nSteps,
+        int nFft = 512, int hopLength = 128)
+    {
+        // Semitone ratio.
+        double rate = Math.Pow(2.0, nSteps / 12.0);
+        // Time-stretch by 1/rate so pitch shifts when resampled back.
+        var stretched = TimeStretch(waveform, 1.0 / rate, nFft, hopLength);
+        // Resample by rate (back to original sample rate) — conceptually.
+        int origRate = sampleRate;
+        int newRate = (int)Math.Round(sampleRate * rate);
+        return Resample(stretched, newRate, origRate);
+    }
+
+    /// <inheritdoc/>
+    public virtual Tensor<T> TimeStretch<T>(Tensor<T> waveform, double rate,
+        int nFft = 512, int hopLength = 128)
+    {
+        if (rate <= 0) throw new ArgumentException("rate must be positive.");
+        if (Math.Abs(rate - 1.0) < 1e-12) return waveform.Clone();
+        int winLength = nFft;
+        var window = new Tensor<T>(new int[] { winLength });
+        // Hann window.
+        var ops = MathHelper.GetNumericOperations<T>();
+        var wSpan = window.AsWritableSpan();
+        for (int i = 0; i < winLength; i++)
+            wSpan[i] = ops.FromDouble(0.5 - 0.5 * Math.Cos(2.0 * Math.PI * i / (winLength - 1)));
+
+        STFT(waveform, nFft, hopLength, window, center: true, out var mag, out var phase);
+        // Phase vocoder: remap time axis with linear interpolation, update
+        // phase by accumulating the phase difference scaled by the time
+        // stretch. Operates on the (last-frame, freq) sub-axes.
+        int rank = mag.Rank;
+        int nFreq = mag._shape[rank - 1];
+        int nFrames = mag._shape[rank - 2];
+        int leading = mag.Length / (nFrames * nFreq);
+        int outFrames = (int)Math.Floor(nFrames / rate);
+
+        var newShape = (int[])mag._shape.Clone();
+        newShape[rank - 2] = outFrames;
+        var newMag = new Tensor<T>(newShape);
+        var newPhase = new Tensor<T>(newShape);
+
+        var mSpan = mag.AsSpan();
+        var pSpan = phase.AsSpan();
+        var nmSpan = newMag.AsWritableSpan();
+        var npSpan = newPhase.AsWritableSpan();
+
+        for (int b = 0; b < leading; b++)
+        {
+            int stride = nFrames * nFreq;
+            int outStride = outFrames * nFreq;
+            var accPhase = new double[nFreq];
+            for (int t = 0; t < outFrames; t++)
+            {
+                double srcT = t * rate;
+                int t0 = (int)Math.Floor(srcT);
+                int t1 = Math.Min(t0 + 1, nFrames - 1);
+                double frac = srcT - t0;
+                for (int f = 0; f < nFreq; f++)
+                {
+                    double m0 = ops.ToDouble(mSpan[b * stride + t0 * nFreq + f]);
+                    double m1 = ops.ToDouble(mSpan[b * stride + t1 * nFreq + f]);
+                    double m = (1 - frac) * m0 + frac * m1;
+                    nmSpan[b * outStride + t * nFreq + f] = ops.FromDouble(m);
+                    double dp = 0;
+                    if (t0 + 1 < nFrames)
+                    {
+                        dp = ops.ToDouble(pSpan[b * stride + (t0 + 1) * nFreq + f])
+                           - ops.ToDouble(pSpan[b * stride + t0 * nFreq + f]);
+                        // Wrap dp to [-pi, pi).
+                        dp -= 2 * Math.PI * Math.Round(dp / (2 * Math.PI));
+                    }
+                    accPhase[f] += dp;
+                    npSpan[b * outStride + t * nFreq + f] = ops.FromDouble(accPhase[f]);
+                }
+            }
+        }
+
+        int targetLen = (int)Math.Round(waveform._shape[waveform.Rank - 1] / rate);
+        return ISTFT(newMag, newPhase, nFft, hopLength, window, center: true, length: targetLen);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.RoiAudio.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.RoiAudio.cs
@@ -7,6 +7,7 @@
 // where practical.
 
 using System;
+using AiDotNet.Tensors.Engines.Autodiff;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.LinearAlgebra;
 
@@ -20,6 +21,17 @@ public partial class CpuEngine
 
     /// <inheritdoc/>
     public virtual Tensor<T> RoIAlign<T>(Tensor<T> input, Tensor<T> boxes,
+        int outputHeight, int outputWidth,
+        float spatialScale, int samplingRatio, bool aligned)
+    {
+        var result = RoIAlignImpl(input, boxes, outputHeight, outputWidth, spatialScale, samplingRatio, aligned);
+        DifferentiableOps.RecordBinary("RoIAlign", result, input, boxes,
+            BackwardFunctions<T>.RoIAlignBackward,
+            new object[] { outputHeight, outputWidth, spatialScale, samplingRatio, aligned });
+        return result;
+    }
+
+    private Tensor<T> RoIAlignImpl<T>(Tensor<T> input, Tensor<T> boxes,
         int outputHeight, int outputWidth,
         float spatialScale, int samplingRatio, bool aligned)
     {
@@ -107,6 +119,16 @@ public partial class CpuEngine
     public virtual Tensor<T> RoIPool<T>(Tensor<T> input, Tensor<T> boxes,
         int outputHeight, int outputWidth, float spatialScale)
     {
+        var result = RoIPoolImpl(input, boxes, outputHeight, outputWidth, spatialScale);
+        DifferentiableOps.RecordBinary("RoIPool", result, input, boxes,
+            BackwardFunctions<T>.RoIPoolBackward,
+            new object[] { outputHeight, outputWidth, spatialScale });
+        return result;
+    }
+
+    private Tensor<T> RoIPoolImpl<T>(Tensor<T> input, Tensor<T> boxes,
+        int outputHeight, int outputWidth, float spatialScale)
+    {
         if (input.Rank != 4) throw new ArgumentException("RoIPool input must be [N, C, H, W].");
         if (boxes.Rank != 2 || boxes._shape[1] != 5) throw new ArgumentException("RoIPool boxes must be [K, 5].");
         int N = input._shape[0], C = input._shape[1], H = input._shape[2], W = input._shape[3];
@@ -165,6 +187,17 @@ public partial class CpuEngine
 
     /// <inheritdoc/>
     public virtual Tensor<T> PsRoIAlign<T>(Tensor<T> input, Tensor<T> boxes,
+        int outputHeight, int outputWidth, int outputChannels,
+        float spatialScale, int samplingRatio)
+    {
+        var result = PsRoIAlignImpl(input, boxes, outputHeight, outputWidth, outputChannels, spatialScale, samplingRatio);
+        DifferentiableOps.RecordBinary("PsRoIAlign", result, input, boxes,
+            BackwardFunctions<T>.PsRoIAlignBackward,
+            new object[] { outputHeight, outputWidth, outputChannels, spatialScale, samplingRatio });
+        return result;
+    }
+
+    private Tensor<T> PsRoIAlignImpl<T>(Tensor<T> input, Tensor<T> boxes,
         int outputHeight, int outputWidth, int outputChannels,
         float spatialScale, int samplingRatio)
     {
@@ -229,6 +262,16 @@ public partial class CpuEngine
     public virtual Tensor<T> PsRoIPool<T>(Tensor<T> input, Tensor<T> boxes,
         int outputHeight, int outputWidth, int outputChannels, float spatialScale)
     {
+        var result = PsRoIPoolImpl(input, boxes, outputHeight, outputWidth, outputChannels, spatialScale);
+        DifferentiableOps.RecordBinary("PsRoIPool", result, input, boxes,
+            BackwardFunctions<T>.PsRoIPoolBackward,
+            new object[] { outputHeight, outputWidth, outputChannels, spatialScale });
+        return result;
+    }
+
+    private Tensor<T> PsRoIPoolImpl<T>(Tensor<T> input, Tensor<T> boxes,
+        int outputHeight, int outputWidth, int outputChannels, float spatialScale)
+    {
         if (input.Rank != 4) throw new ArgumentException("PsRoIPool input must be [N, C, H, W].");
         if (boxes.Rank != 2 || boxes._shape[1] != 5)
             throw new ArgumentException("PsRoIPool boxes must be [K, 5].");
@@ -287,12 +330,17 @@ public partial class CpuEngine
     /// <inheritdoc/>
     public virtual Tensor<T> Spectrogram<T>(Tensor<T> waveform, int nFft, int hopLength, int winLength, Tensor<T>? window = null)
     {
-        // Thin wrapper: run STFT and return only magnitude. STFT here
-        // takes (input, nFft, hop, window, center) — the winLength arg
-        // on our Spectrogram API is absorbed into the window shape.
+        // Run STFT and return only magnitude. Backward uses the saved
+        // phase to pipe the magnitude gradient through ISTFT — see
+        // BackwardFunctions<T>.SpectrogramBackward.
         var win = window ?? HannWindow<T>(winLength);
         STFT(waveform, nFft, hopLength, win, center: true,
-            out var mag, out _);
+            out var mag, out var phase);
+        int origLength = waveform._shape[waveform.Rank - 1];
+        DifferentiableOps.RecordUnary(
+            "Spectrogram", mag, waveform,
+            BackwardFunctions<T>.SpectrogramBackward,
+            new object[] { nFft, hopLength, win, phase, origLength });
         return mag;
     }
 
@@ -308,6 +356,18 @@ public partial class CpuEngine
 
     /// <inheritdoc/>
     public virtual Tensor<T> AmplitudeToDB<T>(Tensor<T> input, float minAmplitude = 1e-10f, float? topDb = null)
+    {
+        var result = AmplitudeToDBImpl(input, minAmplitude, topDb);
+        // topDb clips post-hoc against the peak — the clip mask ideally
+        // zeros gradient where clipped, but that needs a saved mask.
+        // For the common topDb=null path the backward is exact.
+        DifferentiableOps.RecordUnary("AmplitudeToDB", result, input,
+            BackwardFunctions<T>.AmplitudeToDBBackward,
+            new object[] { minAmplitude });
+        return result;
+    }
+
+    private Tensor<T> AmplitudeToDBImpl<T>(Tensor<T> input, float minAmplitude, float? topDb)
     {
         var ops = MathHelper.GetNumericOperations<T>();
         var src = input.AsSpan();
@@ -381,6 +441,15 @@ public partial class CpuEngine
     /// <inheritdoc/>
     public virtual Tensor<T> ComputeDeltas<T>(Tensor<T> input, int winLength = 5)
     {
+        var result = ComputeDeltasImpl(input, winLength);
+        DifferentiableOps.RecordUnary("ComputeDeltas", result, input,
+            BackwardFunctions<T>.ComputeDeltasBackward,
+            new object[] { winLength });
+        return result;
+    }
+
+    private Tensor<T> ComputeDeltasImpl<T>(Tensor<T> input, int winLength)
+    {
         if (winLength < 3 || (winLength & 1) == 0)
             throw new ArgumentException("winLength must be an odd integer >= 3.");
         int n = winLength / 2;
@@ -419,6 +488,15 @@ public partial class CpuEngine
 
     /// <inheritdoc/>
     public virtual Tensor<T> Resample<T>(Tensor<T> waveform, int origRate, int newRate)
+    {
+        var result = ResampleImpl(waveform, origRate, newRate);
+        DifferentiableOps.RecordUnary("Resample", result, waveform,
+            BackwardFunctions<T>.ResampleBackward,
+            new object[] { origRate, newRate });
+        return result;
+    }
+
+    private Tensor<T> ResampleImpl<T>(Tensor<T> waveform, int origRate, int newRate)
     {
         if (origRate <= 0 || newRate <= 0) throw new ArgumentException("rates must be positive.");
         if (waveform.Rank < 1) throw new ArgumentException("waveform must have at least 1 axis.");

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Audio.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Audio.cs
@@ -60,7 +60,10 @@ public sealed partial class CudaBackend : IAudioBackend
     public unsafe void ComputeDeltas(IGpuBuffer input, IGpuBuffer output,
         int leading, int timeAxis, int winLength)
     {
-        int total = leading * timeAxis;
+        long totalLong = (long)leading * timeAxis;
+        if (totalLong > int.MaxValue)
+            throw new OverflowException($"ComputeDeltas total {totalLong} exceeds Int32.MaxValue.");
+        int total = (int)totalLong;
         if (total <= 0) return;
         var kernel = ResolveAudioKernel("audio_compute_deltas");
         using var _ = PushContext();
@@ -76,7 +79,10 @@ public sealed partial class CudaBackend : IAudioBackend
     public unsafe void Resample(IGpuBuffer input, IGpuBuffer output,
         int leading, int inLen, int outLen, int up, int down, int halfWidth)
     {
-        int total = leading * outLen;
+        long totalLong = (long)leading * outLen;
+        if (totalLong > int.MaxValue)
+            throw new OverflowException($"Resample total {totalLong} exceeds Int32.MaxValue.");
+        int total = (int)totalLong;
         if (total <= 0) return;
         var kernel = ResolveAudioKernel("audio_resample");
         using var _ = PushContext();

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Audio.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Audio.cs
@@ -1,0 +1,92 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// CUDA audio launcher shims (Issue #217 tail).
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA;
+
+public sealed partial class CudaBackend : IAudioBackend
+{
+    private IntPtr ResolveAudioKernel(string name)
+    {
+        if (_audioModule == IntPtr.Zero)
+            throw new InvalidOperationException("Audio CUDA module was not compiled.");
+        if (!_kernelCache.TryGetValue(name, out var kernel))
+            throw new InvalidOperationException($"CUDA kernel not found: {name}");
+        return kernel;
+    }
+
+    public unsafe void AmplitudeToDB(IGpuBuffer input, IGpuBuffer output, int length,
+        float minAmplitude, float topDb, bool clipTopDb)
+    {
+        if (length <= 0) return;
+        var kernel = ResolveAudioKernel("audio_amplitude_to_db");
+        using var _ = PushContext();
+        uint grid = (uint)((length + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr inP = input.Handle, oP = output.Handle;
+        int len = length;
+        float minA = minAmplitude;
+        float topDbFloor = topDb;
+        int clip = clipTopDb ? 1 : 0;
+        void** args = stackalloc void*[6];
+        args[0] = &inP; args[1] = &oP;
+        args[2] = &len; args[3] = &minA; args[4] = &topDbFloor; args[5] = &clip;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    public unsafe void MuLawEncoding(IGpuBuffer input, IGpuBuffer output, int length, int qc)
+    {
+        if (length <= 0) return;
+        var kernel = ResolveAudioKernel("audio_mulaw_encoding");
+        using var _ = PushContext();
+        uint grid = (uint)((length + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr inP = input.Handle, oP = output.Handle;
+        int len = length, q = qc;
+        void** args = stackalloc void*[4];
+        args[0] = &inP; args[1] = &oP; args[2] = &len; args[3] = &q;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    public unsafe void MuLawDecoding(IGpuBuffer input, IGpuBuffer output, int length, int qc)
+    {
+        if (length <= 0) return;
+        var kernel = ResolveAudioKernel("audio_mulaw_decoding");
+        using var _ = PushContext();
+        uint grid = (uint)((length + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr inP = input.Handle, oP = output.Handle;
+        int len = length, q = qc;
+        void** args = stackalloc void*[4];
+        args[0] = &inP; args[1] = &oP; args[2] = &len; args[3] = &q;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    public unsafe void ComputeDeltas(IGpuBuffer input, IGpuBuffer output,
+        int leading, int timeAxis, int winLength)
+    {
+        int total = leading * timeAxis;
+        if (total <= 0) return;
+        var kernel = ResolveAudioKernel("audio_compute_deltas");
+        using var _ = PushContext();
+        uint grid = (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr inP = input.Handle, oP = output.Handle;
+        int ld = leading, t = timeAxis, w = winLength;
+        void** args = stackalloc void*[5];
+        args[0] = &inP; args[1] = &oP;
+        args[2] = &ld; args[3] = &t; args[4] = &w;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    public unsafe void Resample(IGpuBuffer input, IGpuBuffer output,
+        int leading, int inLen, int outLen, int up, int down, int halfWidth)
+    {
+        int total = leading * outLen;
+        if (total <= 0) return;
+        var kernel = ResolveAudioKernel("audio_resample");
+        using var _ = PushContext();
+        uint grid = (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr inP = input.Handle, oP = output.Handle;
+        int ld = leading, il = inLen, ol = outLen, u = up, d = down, hw = halfWidth;
+        void** args = stackalloc void*[8];
+        args[0] = &inP; args[1] = &oP;
+        args[2] = &ld; args[3] = &il; args[4] = &ol;
+        args[5] = &u; args[6] = &d; args[7] = &hw;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Detection.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Detection.cs
@@ -1,0 +1,101 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// CUDA launcher shims for the vision detection kernels (Issue #217).
+// Pattern matches CudaBackend.Parity210.cs: kernel resolved from
+// _kernelCache, dispatched via 256-thread block / grid-ceil.
+
+using AiDotNet.Tensors.Engines.DirectGpu.CUDA.Kernels;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA;
+
+public sealed partial class CudaBackend : IDetectionBackend
+{
+    private IntPtr ResolveDetectionKernel(string name)
+    {
+        if (_detectionModule == IntPtr.Zero)
+            throw new InvalidOperationException(
+                "Detection CUDA module was not compiled (older toolkit?). Falling back to CPU reference.");
+        if (!_kernelCache.TryGetValue(name, out var kernel))
+            throw new InvalidOperationException($"CUDA kernel not found: {name}");
+        return kernel;
+    }
+
+    private unsafe void DispatchPairwiseIou(
+        string kernelName, IGpuBuffer a, IGpuBuffer b, IGpuBuffer output, int n, int m)
+    {
+        if (n <= 0 || m <= 0) return;
+        var kernel = ResolveDetectionKernel(kernelName);
+        using var _ = PushContext();
+        int total = n * m;
+        uint grid = (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr aPtr = a.Handle, bPtr = b.Handle, oPtr = output.Handle;
+        int nn = n, mm = m;
+        void** args = stackalloc void*[5];
+        args[0] = &aPtr; args[1] = &bPtr; args[2] = &oPtr;
+        args[3] = &nn; args[4] = &mm;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    public unsafe void BoxIou(IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m)
+        => DispatchPairwiseIou("detection_box_iou", boxesA, boxesB, output, n, m);
+
+    public unsafe void GeneralizedBoxIou(IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m)
+        => DispatchPairwiseIou("detection_generalized_box_iou", boxesA, boxesB, output, n, m);
+
+    public unsafe void DistanceBoxIou(IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m)
+        => DispatchPairwiseIou("detection_distance_box_iou", boxesA, boxesB, output, n, m);
+
+    public unsafe void CompleteBoxIou(IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m)
+        => DispatchPairwiseIou("detection_complete_box_iou", boxesA, boxesB, output, n, m);
+
+    public unsafe void BoxArea(IGpuBuffer boxes, IGpuBuffer output, int n)
+    {
+        if (n <= 0) return;
+        var kernel = ResolveDetectionKernel("detection_box_area");
+        using var _ = PushContext();
+        uint grid = (uint)((n + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr bPtr = boxes.Handle, oPtr = output.Handle;
+        int nn = n;
+        void** args = stackalloc void*[3];
+        args[0] = &bPtr; args[1] = &oPtr; args[2] = &nn;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    public unsafe void BoxConvert(IGpuBuffer boxes, IGpuBuffer output, int n, int fromFormat, int toFormat)
+    {
+        if (n <= 0) return;
+        var kernel = ResolveDetectionKernel("detection_box_convert");
+        using var _ = PushContext();
+        uint grid = (uint)((n + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr bPtr = boxes.Handle, oPtr = output.Handle;
+        int nn = n, ff = fromFormat, tf = toFormat;
+        void** args = stackalloc void*[5];
+        args[0] = &bPtr; args[1] = &oPtr; args[2] = &nn; args[3] = &ff; args[4] = &tf;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    public unsafe void IouFamilyBackward(
+        IGpuBuffer gradOutput, IGpuBuffer boxesA, IGpuBuffer boxesB,
+        IGpuBuffer gradA, IGpuBuffer gradB,
+        int n, int m, int variant)
+    {
+        if (n <= 0 || m <= 0) return;
+        var kernelA = ResolveDetectionKernel("detection_iou_backward_a");
+        var kernelB = ResolveDetectionKernel("detection_iou_backward_b");
+        using var _ = PushContext();
+        IntPtr goPtr = gradOutput.Handle, aPtr = boxesA.Handle, bPtr = boxesB.Handle;
+        IntPtr gAPtr = gradA.Handle, gBPtr = gradB.Handle;
+        int nn = n, mm = m, vv = variant;
+
+        uint gridA = (uint)((n + DefaultBlockSize - 1) / DefaultBlockSize);
+        void** argsA = stackalloc void*[7];
+        argsA[0] = &goPtr; argsA[1] = &aPtr; argsA[2] = &bPtr;
+        argsA[3] = &gAPtr; argsA[4] = &nn; argsA[5] = &mm; argsA[6] = &vv;
+        LaunchKernel(kernelA, gridA, DefaultBlockSize, argsA);
+
+        uint gridB = (uint)((m + DefaultBlockSize - 1) / DefaultBlockSize);
+        void** argsB = stackalloc void*[7];
+        argsB[0] = &goPtr; argsB[1] = &aPtr; argsB[2] = &bPtr;
+        argsB[3] = &gBPtr; argsB[4] = &nn; argsB[5] = &mm; argsB[6] = &vv;
+        LaunchKernel(kernelB, gridB, DefaultBlockSize, argsB);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Detection.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Detection.cs
@@ -63,6 +63,12 @@ public sealed partial class CudaBackend : IDetectionBackend
     public unsafe void BoxConvert(IGpuBuffer boxes, IGpuBuffer output, int n, int fromFormat, int toFormat)
     {
         if (n <= 0) return;
+        // Range-check format codes so a bogus int doesn't hit an undefined
+        // case in the kernel's switch (which falls through to CXCYWH without
+        // this check).
+        if ((uint)fromFormat > 2 || (uint)toFormat > 2)
+            throw new ArgumentException(
+                $"fromFormat/toFormat must be 0 (XYXY), 1 (XYWH), or 2 (CXCYWH); got {fromFormat}, {toFormat}.");
         var kernel = ResolveDetectionKernel("detection_box_convert");
         using var _ = PushContext();
         uint grid = (uint)((n + DefaultBlockSize - 1) / DefaultBlockSize);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Detection.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Detection.cs
@@ -23,9 +23,12 @@ public sealed partial class CudaBackend : IDetectionBackend
         string kernelName, IGpuBuffer a, IGpuBuffer b, IGpuBuffer output, int n, int m)
     {
         if (n <= 0 || m <= 0) return;
+        long totalLong = (long)n * m;
+        if (totalLong > int.MaxValue)
+            throw new OverflowException($"Pairwise IoU total {totalLong} exceeds Int32.MaxValue.");
         var kernel = ResolveDetectionKernel(kernelName);
         using var _ = PushContext();
-        int total = n * m;
+        int total = (int)totalLong;
         uint grid = (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize);
         IntPtr aPtr = a.Handle, bPtr = b.Handle, oPtr = output.Handle;
         int nn = n, mm = m;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Detection.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Detection.cs
@@ -78,7 +78,11 @@ public sealed partial class CudaBackend : IDetectionBackend
         IGpuBuffer gradA, IGpuBuffer gradB,
         int n, int m, int variant)
     {
-        if (n <= 0 || m <= 0) return;
+        // Don't short-circuit on n==0 or m==0: the kernel's inner for-loop
+        // over the other dim is empty in that case and each thread writes
+        // zero, which is the correct gradient. Skipping would leak stale
+        // pooled-buffer values into autodiff.
+        if (n <= 0 && m <= 0) return;
         var kernelA = ResolveDetectionKernel("detection_iou_backward_a");
         var kernelB = ResolveDetectionKernel("detection_iou_backward_b");
         using var _ = PushContext();
@@ -86,16 +90,22 @@ public sealed partial class CudaBackend : IDetectionBackend
         IntPtr gAPtr = gradA.Handle, gBPtr = gradB.Handle;
         int nn = n, mm = m, vv = variant;
 
-        uint gridA = (uint)((n + DefaultBlockSize - 1) / DefaultBlockSize);
-        void** argsA = stackalloc void*[7];
-        argsA[0] = &goPtr; argsA[1] = &aPtr; argsA[2] = &bPtr;
-        argsA[3] = &gAPtr; argsA[4] = &nn; argsA[5] = &mm; argsA[6] = &vv;
-        LaunchKernel(kernelA, gridA, DefaultBlockSize, argsA);
+        if (n > 0)
+        {
+            uint gridA = (uint)((n + DefaultBlockSize - 1) / DefaultBlockSize);
+            void** argsA = stackalloc void*[7];
+            argsA[0] = &goPtr; argsA[1] = &aPtr; argsA[2] = &bPtr;
+            argsA[3] = &gAPtr; argsA[4] = &nn; argsA[5] = &mm; argsA[6] = &vv;
+            LaunchKernel(kernelA, gridA, DefaultBlockSize, argsA);
+        }
 
-        uint gridB = (uint)((m + DefaultBlockSize - 1) / DefaultBlockSize);
-        void** argsB = stackalloc void*[7];
-        argsB[0] = &goPtr; argsB[1] = &aPtr; argsB[2] = &bPtr;
-        argsB[3] = &gBPtr; argsB[4] = &nn; argsB[5] = &mm; argsB[6] = &vv;
-        LaunchKernel(kernelB, gridB, DefaultBlockSize, argsB);
+        if (m > 0)
+        {
+            uint gridB = (uint)((m + DefaultBlockSize - 1) / DefaultBlockSize);
+            void** argsB = stackalloc void*[7];
+            argsB[0] = &goPtr; argsB[1] = &aPtr; argsB[2] = &bPtr;
+            argsB[3] = &gBPtr; argsB[4] = &nn; argsB[5] = &mm; argsB[6] = &vv;
+            LaunchKernel(kernelB, gridB, DefaultBlockSize, argsB);
+        }
     }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Geometry.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Geometry.cs
@@ -1,0 +1,105 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// CUDA launcher shims for the geometry / sampling kernels (Issue #217).
+
+using AiDotNet.Tensors.Engines.DirectGpu.CUDA.Kernels;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA;
+
+public sealed partial class CudaBackend : IGeometryBackend
+{
+    private IntPtr ResolveGeometryKernel(string name)
+    {
+        if (_geometryModule == IntPtr.Zero)
+            throw new InvalidOperationException(
+                "Geometry CUDA module was not compiled. Falling back to CPU reference.");
+        if (!_kernelCache.TryGetValue(name, out var kernel))
+            throw new InvalidOperationException($"CUDA kernel not found: {name}");
+        return kernel;
+    }
+
+    public unsafe void Interpolate2D(IGpuBuffer input, IGpuBuffer output,
+        int N, int C, int Hin, int Win, int Hout, int Wout,
+        int mode, bool alignCorners)
+    {
+        int total = N * C * Hout * Wout;
+        if (total <= 0) return;
+        var kernel = ResolveGeometryKernel("geometry_interpolate_2d");
+        using var _ = PushContext();
+        uint grid = (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr inP = input.Handle, outP = output.Handle;
+        int ac = alignCorners ? 1 : 0;
+        int nn = N, cc = C, hi = Hin, wi = Win, ho = Hout, wo = Wout, mm = mode;
+        void** args = stackalloc void*[10];
+        args[0] = &inP; args[1] = &outP;
+        args[2] = &nn; args[3] = &cc;
+        args[4] = &hi; args[5] = &wi;
+        args[6] = &ho; args[7] = &wo;
+        args[8] = &mm; args[9] = &ac;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    public unsafe void Pad4D(IGpuBuffer input, IGpuBuffer output,
+        int N, int C, int Hin, int Win,
+        int padN0, int padN1, int padC0, int padC1,
+        int padH0, int padH1, int padW0, int padW1,
+        int mode, float padValue)
+    {
+        int Nout = N + padN0 + padN1;
+        int Cout = C + padC0 + padC1;
+        int Hout = Hin + padH0 + padH1;
+        int Wout = Win + padW0 + padW1;
+        int total = Nout * Cout * Hout * Wout;
+        if (total <= 0) return;
+        var kernel = ResolveGeometryKernel("geometry_pad_4d");
+        using var _ = PushContext();
+        uint grid = (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr inP = input.Handle, outP = output.Handle;
+        int nn = N, cc = C, hi = Hin, wi = Win;
+        int pn0 = padN0, pn1 = padN1, pc0 = padC0, pc1 = padC1;
+        int ph0 = padH0, ph1 = padH1, pw0 = padW0, pw1 = padW1;
+        int mm = mode; float pv = padValue;
+        void** args = stackalloc void*[16];
+        args[0] = &inP; args[1] = &outP;
+        args[2] = &nn; args[3] = &cc; args[4] = &hi; args[5] = &wi;
+        args[6] = &pn0; args[7] = &pn1; args[8] = &pc0; args[9] = &pc1;
+        args[10] = &ph0; args[11] = &ph1; args[12] = &pw0; args[13] = &pw1;
+        args[14] = &mm; args[15] = &pv;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    public unsafe void GridSample2D(IGpuBuffer input, IGpuBuffer grid, IGpuBuffer output,
+        int N, int H, int W, int C, int outH, int outW,
+        int mode, int padding, bool alignCorners)
+    {
+        int total = N * outH * outW;
+        if (total <= 0) return;
+        var kernel = ResolveGeometryKernel("geometry_grid_sample_2d");
+        using var _ = PushContext();
+        uint gridLaunch = (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr inP = input.Handle, grP = grid.Handle, outP = output.Handle;
+        int nn = N, hh = H, ww = W, cc = C, oh = outH, ow = outW, mm = mode, pp = padding;
+        int ac = alignCorners ? 1 : 0;
+        void** args = stackalloc void*[12];
+        args[0] = &inP; args[1] = &grP; args[2] = &outP;
+        args[3] = &nn; args[4] = &hh; args[5] = &ww; args[6] = &cc;
+        args[7] = &oh; args[8] = &ow; args[9] = &mm; args[10] = &pp; args[11] = &ac;
+        LaunchKernel(kernel, gridLaunch, DefaultBlockSize, args);
+    }
+
+    public unsafe void AffineGrid3D(IGpuBuffer theta, IGpuBuffer grid,
+        int N, int D, int H, int W, bool alignCorners)
+    {
+        int total = N * D * H * W;
+        if (total <= 0) return;
+        var kernel = ResolveGeometryKernel("geometry_affine_grid_3d");
+        using var _ = PushContext();
+        uint gridLaunch = (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr tP = theta.Handle, gP = grid.Handle;
+        int nn = N, dd = D, hh = H, ww = W;
+        int ac = alignCorners ? 1 : 0;
+        void** args = stackalloc void*[7];
+        args[0] = &tP; args[1] = &gP;
+        args[2] = &nn; args[3] = &dd; args[4] = &hh; args[5] = &ww; args[6] = &ac;
+        LaunchKernel(kernel, gridLaunch, DefaultBlockSize, args);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Roi.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Roi.cs
@@ -51,4 +51,44 @@ public sealed partial class CudaBackend : IRoiBackend
         args[7] = &kk; args[8] = &oh; args[9] = &ow; args[10] = &ss;
         LaunchKernel(kernel, grid, DefaultBlockSize, args);
     }
+
+    public unsafe void PsRoIAlign(IGpuBuffer input, IGpuBuffer boxes, IGpuBuffer output,
+        int N, int C, int H, int W, int K, int outH, int outW, int outputChannels,
+        float spatialScale, int samplingRatio)
+    {
+        int total = K * outputChannels * outH * outW;
+        if (total <= 0) return;
+        var kernel = ResolveRoiKernel("ps_roi_align");
+        using var _ = PushContext();
+        uint grid = (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr inP = input.Handle, bP = boxes.Handle, oP = output.Handle;
+        int nn = N, cc = C, hh = H, ww = W, kk = K, oh = outH, ow = outW, oc = outputChannels;
+        int sr = samplingRatio;
+        float ss = spatialScale;
+        void** args = stackalloc void*[13];
+        args[0] = &inP; args[1] = &bP; args[2] = &oP;
+        args[3] = &nn; args[4] = &cc; args[5] = &hh; args[6] = &ww;
+        args[7] = &kk; args[8] = &oh; args[9] = &ow; args[10] = &oc;
+        args[11] = &ss; args[12] = &sr;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    public unsafe void PsRoIPool(IGpuBuffer input, IGpuBuffer boxes, IGpuBuffer output,
+        int N, int C, int H, int W, int K, int outH, int outW, int outputChannels,
+        float spatialScale)
+    {
+        int total = K * outputChannels * outH * outW;
+        if (total <= 0) return;
+        var kernel = ResolveRoiKernel("ps_roi_pool");
+        using var _ = PushContext();
+        uint grid = (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr inP = input.Handle, bP = boxes.Handle, oP = output.Handle;
+        int nn = N, cc = C, hh = H, ww = W, kk = K, oh = outH, ow = outW, oc = outputChannels;
+        float ss = spatialScale;
+        void** args = stackalloc void*[12];
+        args[0] = &inP; args[1] = &bP; args[2] = &oP;
+        args[3] = &nn; args[4] = &cc; args[5] = &hh; args[6] = &ww;
+        args[7] = &kk; args[8] = &oh; args[9] = &ow; args[10] = &oc; args[11] = &ss;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Roi.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Roi.cs
@@ -1,0 +1,54 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// CUDA launcher shims for the RoI family (Issue #217 tail).
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA;
+
+public sealed partial class CudaBackend : IRoiBackend
+{
+    private IntPtr ResolveRoiKernel(string name)
+    {
+        if (_roiModule == IntPtr.Zero)
+            throw new InvalidOperationException("RoI CUDA module was not compiled.");
+        if (!_kernelCache.TryGetValue(name, out var kernel))
+            throw new InvalidOperationException($"CUDA kernel not found: {name}");
+        return kernel;
+    }
+
+    public unsafe void RoIAlign(IGpuBuffer input, IGpuBuffer boxes, IGpuBuffer output,
+        int N, int C, int H, int W, int K, int outH, int outW,
+        float spatialScale, int samplingRatio, bool aligned)
+    {
+        int total = K * C * outH * outW;
+        if (total <= 0) return;
+        var kernel = ResolveRoiKernel("roi_align");
+        using var _ = PushContext();
+        uint grid = (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr inP = input.Handle, bP = boxes.Handle, oP = output.Handle;
+        int nn = N, cc = C, hh = H, ww = W, kk = K, oh = outH, ow = outW;
+        int sr = samplingRatio, al = aligned ? 1 : 0;
+        float ss = spatialScale;
+        void** args = stackalloc void*[13];
+        args[0] = &inP; args[1] = &bP; args[2] = &oP;
+        args[3] = &nn; args[4] = &cc; args[5] = &hh; args[6] = &ww;
+        args[7] = &kk; args[8] = &oh; args[9] = &ow;
+        args[10] = &ss; args[11] = &sr; args[12] = &al;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    public unsafe void RoIPool(IGpuBuffer input, IGpuBuffer boxes, IGpuBuffer output,
+        int N, int C, int H, int W, int K, int outH, int outW, float spatialScale)
+    {
+        int total = K * C * outH * outW;
+        if (total <= 0) return;
+        var kernel = ResolveRoiKernel("roi_pool");
+        using var _ = PushContext();
+        uint grid = (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr inP = input.Handle, bP = boxes.Handle, oP = output.Handle;
+        int nn = N, cc = C, hh = H, ww = W, kk = K, oh = outH, ow = outW;
+        float ss = spatialScale;
+        void** args = stackalloc void*[11];
+        args[0] = &inP; args[1] = &bP; args[2] = &oP;
+        args[3] = &nn; args[4] = &cc; args[5] = &hh; args[6] = &ww;
+        args[7] = &kk; args[8] = &oh; args[9] = &ow; args[10] = &ss;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -11131,6 +11131,30 @@ public sealed partial class CudaBackend : IAsyncGpuBackend
             _linalgModule = IntPtr.Zero;
         }
 
+        if (_detectionModule != IntPtr.Zero)
+        {
+            CudaNativeBindings.cuModuleUnload(_detectionModule);
+            _detectionModule = IntPtr.Zero;
+        }
+
+        if (_geometryModule != IntPtr.Zero)
+        {
+            CudaNativeBindings.cuModuleUnload(_geometryModule);
+            _geometryModule = IntPtr.Zero;
+        }
+
+        if (_roiModule != IntPtr.Zero)
+        {
+            CudaNativeBindings.cuModuleUnload(_roiModule);
+            _roiModule = IntPtr.Zero;
+        }
+
+        if (_audioModule != IntPtr.Zero)
+        {
+            CudaNativeBindings.cuModuleUnload(_audioModule);
+            _audioModule = IntPtr.Zero;
+        }
+
         if (_cudaContext != IntPtr.Zero)
         {
             CuBlasNative.cuCtxDestroy(_cudaContext);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -59,6 +59,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend
     private IntPtr _parity210Module;
     private IntPtr _detectionModule;
     private IntPtr _geometryModule;
+    private IntPtr _roiModule;
     private IntPtr _linalgModule;
     private bool _disposed;
     private const int MaxPooledBufferElements = 16_777_216;
@@ -742,6 +743,19 @@ public sealed partial class CudaBackend : IAsyncGpuBackend
         catch
         {
             _geometryModule = IntPtr.Zero;
+        }
+
+        // RoI kernels (Issue #217 tail).
+        try
+        {
+            _roiModule = CompileKernelModule(device,
+                Kernels.CudaRoiKernels.GetSource(),
+                "roi_kernels",
+                Kernels.CudaRoiKernels.GetKernelNames());
+        }
+        catch
+        {
+            _roiModule = IntPtr.Zero;
         }
 
         // Linalg decomposition kernels (#211 moat #2). Same best-effort policy:

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -60,6 +60,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend
     private IntPtr _detectionModule;
     private IntPtr _geometryModule;
     private IntPtr _roiModule;
+    private IntPtr _audioModule;
     private IntPtr _linalgModule;
     private bool _disposed;
     private const int MaxPooledBufferElements = 16_777_216;
@@ -756,6 +757,19 @@ public sealed partial class CudaBackend : IAsyncGpuBackend
         catch
         {
             _roiModule = IntPtr.Zero;
+        }
+
+        // Audio kernels (Issue #217 tail).
+        try
+        {
+            _audioModule = CompileKernelModule(device,
+                Kernels.CudaAudioKernels.GetSource(),
+                "audio_kernels",
+                Kernels.CudaAudioKernels.GetKernelNames());
+        }
+        catch
+        {
+            _audioModule = IntPtr.Zero;
         }
 
         // Linalg decomposition kernels (#211 moat #2). Same best-effort policy:

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -727,8 +727,9 @@ public sealed partial class CudaBackend : IAsyncGpuBackend
                 "detection_kernels",
                 Kernels.CudaDetectionKernels.GetKernelNames());
         }
-        catch
+        catch (Exception ex)
         {
+            System.Diagnostics.Debug.WriteLine($"CUDA detection kernel compilation failed: {ex.Message}");
             _detectionModule = IntPtr.Zero;
         }
 
@@ -741,8 +742,9 @@ public sealed partial class CudaBackend : IAsyncGpuBackend
                 "geometry_kernels",
                 Kernels.CudaGeometryKernels.GetKernelNames());
         }
-        catch
+        catch (Exception ex)
         {
+            System.Diagnostics.Debug.WriteLine($"CUDA geometry kernel compilation failed: {ex.Message}");
             _geometryModule = IntPtr.Zero;
         }
 
@@ -754,8 +756,9 @@ public sealed partial class CudaBackend : IAsyncGpuBackend
                 "roi_kernels",
                 Kernels.CudaRoiKernels.GetKernelNames());
         }
-        catch
+        catch (Exception ex)
         {
+            System.Diagnostics.Debug.WriteLine($"CUDA RoI kernel compilation failed: {ex.Message}");
             _roiModule = IntPtr.Zero;
         }
 
@@ -767,8 +770,12 @@ public sealed partial class CudaBackend : IAsyncGpuBackend
                 "audio_kernels",
                 Kernels.CudaAudioKernels.GetKernelNames());
         }
-        catch
+        catch (Exception ex)
         {
+            // Preserve the compile error for post-mortem — without this
+            // log, a NVRTC failure silently degrades the audio ops to
+            // CpuEngine with no indication why.
+            System.Diagnostics.Debug.WriteLine($"CUDA audio kernel compilation failed: {ex.Message}");
             _audioModule = IntPtr.Zero;
         }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -57,6 +57,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend
     private IntPtr _snnModule;
     private IntPtr _fp16Module;
     private IntPtr _parity210Module;
+    private IntPtr _detectionModule;
     private IntPtr _linalgModule;
     private bool _disposed;
     private const int MaxPooledBufferElements = 16_777_216;
@@ -711,6 +712,21 @@ public sealed partial class CudaBackend : IAsyncGpuBackend
         catch
         {
             _parity210Module = IntPtr.Zero;
+        }
+
+        // Vision detection kernels (Issue #217). Same best-effort policy as
+        // parity-210: NVRTC failures fall through to the CpuEngine path
+        // (DirectGpuTensorEngine.Detection.cs catches and base.* delegates).
+        try
+        {
+            _detectionModule = CompileKernelModule(device,
+                Kernels.CudaDetectionKernels.GetSource(),
+                "detection_kernels",
+                Kernels.CudaDetectionKernels.GetKernelNames());
+        }
+        catch
+        {
+            _detectionModule = IntPtr.Zero;
         }
 
         // Linalg decomposition kernels (#211 moat #2). Same best-effort policy:

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -58,6 +58,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend
     private IntPtr _fp16Module;
     private IntPtr _parity210Module;
     private IntPtr _detectionModule;
+    private IntPtr _geometryModule;
     private IntPtr _linalgModule;
     private bool _disposed;
     private const int MaxPooledBufferElements = 16_777_216;
@@ -727,6 +728,20 @@ public sealed partial class CudaBackend : IAsyncGpuBackend
         catch
         {
             _detectionModule = IntPtr.Zero;
+        }
+
+        // Geometry / sampling kernels (Issue #217 second half). Same
+        // best-effort policy — NVRTC failure falls through to CpuEngine.
+        try
+        {
+            _geometryModule = CompileKernelModule(device,
+                Kernels.CudaGeometryKernels.GetSource(),
+                "geometry_kernels",
+                Kernels.CudaGeometryKernels.GetKernelNames());
+        }
+        catch
+        {
+            _geometryModule = IntPtr.Zero;
         }
 
         // Linalg decomposition kernels (#211 moat #2). Same best-effort policy:

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaAudioKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaAudioKernels.cs
@@ -102,6 +102,7 @@ extern ""C"" __global__ __launch_bounds__(256) void audio_resample(
     int gid = blockIdx.x * blockDim.x + threadIdx.x;
     int total = leading * outLen;
     if (gid >= total) return;
+    if (halfWidth < 1 || up <= 0 || down <= 0) { output[gid] = 0.0f; return; }
     int ot = gid % outLen;
     int row = gid / outLen;
     int sBase = row * inLen;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaAudioKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaAudioKernels.cs
@@ -76,6 +76,10 @@ extern ""C"" __global__ __launch_bounds__(256) void audio_compute_deltas(
     int row = gid / timeAxis;
 
     int n = winLength / 2;
+    // Defence-in-depth: winLength ≤ 1 → n = 0 → denom = 0 → output is
+    // NaN. The managed layer already rejects this, but kernels should
+    // fail closed if someone calls the raw interface directly.
+    if (n < 1) { output[gid] = 0.0f; return; }
     float denom = 0.0f;
     for (int i = 1; i <= n; i++) denom += 2.0f * i * i;
     float acc = 0.0f;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaAudioKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaAudioKernels.cs
@@ -1,0 +1,125 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// CUDA audio primitive kernels — Issue #217 tail. Spectrogram /
+// PitchShift / TimeStretch compose existing GPU STFT and stay in managed
+// code; this file holds only the element-wise and small-window kernels
+// that benefit from direct GPU execution.
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA.Kernels
+{
+    public static class CudaAudioKernels
+    {
+        public static string[] GetKernelNames() => new[]
+        {
+            "audio_amplitude_to_db",
+            "audio_mulaw_encoding",
+            "audio_mulaw_decoding",
+            "audio_compute_deltas",
+            "audio_resample",
+        };
+
+        public static string GetSource() => @"
+#include <math.h>
+
+extern ""C"" __global__ __launch_bounds__(256) void audio_amplitude_to_db(
+    const float* __restrict__ input, float* __restrict__ output,
+    int length, float minAmp, float topDbFloor, int clipTopDb)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (gid >= length) return;
+    float v = fmaxf(input[gid], minAmp);
+    float db = 20.0f * log10f(v);
+    // topDbFloor is already peak-topDb for the batch; the launcher precomputes
+    // it so we avoid a reduction here. If clipTopDb == 0, topDbFloor is ignored.
+    if (clipTopDb != 0 && db < topDbFloor) db = topDbFloor;
+    output[gid] = db;
+}
+
+extern ""C"" __global__ __launch_bounds__(256) void audio_mulaw_encoding(
+    const float* __restrict__ input, float* __restrict__ output,
+    int length, int quantizationChannels)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (gid >= length) return;
+    float mu = (float)(quantizationChannels - 1);
+    float logMu = log1pf(mu);
+    float x = input[gid];
+    if (x > 1.0f) x = 1.0f;
+    else if (x < -1.0f) x = -1.0f;
+    float y = ((x > 0.0f) - (x < 0.0f)) * log1pf(mu * fabsf(x)) / logMu;
+    float q = floorf((y + 1.0f) * 0.5f * mu + 0.5f);
+    if (q < 0.0f) q = 0.0f;
+    else if (q > mu) q = mu;
+    output[gid] = q;
+}
+
+extern ""C"" __global__ __launch_bounds__(256) void audio_mulaw_decoding(
+    const float* __restrict__ input, float* __restrict__ output,
+    int length, int quantizationChannels)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (gid >= length) return;
+    float mu = (float)(quantizationChannels - 1);
+    float q = input[gid];
+    float y = (q / mu) * 2.0f - 1.0f;
+    float x = ((y > 0.0f) - (y < 0.0f)) * (powf(1.0f + mu, fabsf(y)) - 1.0f) / mu;
+    output[gid] = x;
+}
+
+// One thread per output (row, t). Savitzky-Golay: out[t] = Σ_{k=1..n} k · (in[t+k] − in[t−k]) / (2·Σk²).
+extern ""C"" __global__ __launch_bounds__(256) void audio_compute_deltas(
+    const float* __restrict__ input, float* __restrict__ output,
+    int leading, int timeAxis, int winLength)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = leading * timeAxis;
+    if (gid >= total) return;
+    int t = gid % timeAxis;
+    int row = gid / timeAxis;
+
+    int n = winLength / 2;
+    float denom = 0.0f;
+    for (int i = 1; i <= n; i++) denom += 2.0f * i * i;
+    float acc = 0.0f;
+    int base_ = row * timeAxis;
+    for (int k = 1; k <= n; k++) {
+        int left = t - k < 0 ? 0 : t - k;
+        int right = t + k >= timeAxis ? timeAxis - 1 : t + k;
+        acc += k * (input[base_ + right] - input[base_ + left]);
+    }
+    output[gid] = acc / denom;
+}
+
+// Polyphase Hann-windowed sinc. srcIdx = ot · down / up; sum over
+// [-halfWidth, halfWidth] taps.
+extern ""C"" __global__ __launch_bounds__(256) void audio_resample(
+    const float* __restrict__ input, float* __restrict__ output,
+    int leading, int inLen, int outLen,
+    int up, int down, int halfWidth)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = leading * outLen;
+    if (gid >= total) return;
+    int ot = gid % outLen;
+    int row = gid / outLen;
+    int sBase = row * inLen;
+
+    float cutoff = 1.0f / (float)(up > down ? up : down);
+    float srcIdx = (float)ot * down / up;
+    int centre = (int)floorf(srcIdx);
+
+    float acc = 0.0f, wSum = 0.0f;
+    const float PI = 3.14159265358979323846f;
+    for (int k = -halfWidth; k <= halfWidth; k++) {
+        int idx = centre + k;
+        if (idx < 0 || idx >= inLen) continue;
+        float t = (idx - srcIdx) * cutoff;
+        float sinc = (fabsf(t) < 1e-12f) ? 1.0f : __sinf(PI * t) / (PI * t);
+        float hann = 0.5f - 0.5f * __cosf(2.0f * PI * (k + halfWidth) / (2.0f * halfWidth));
+        float w = sinc * hann;
+        acc += w * input[sBase + idx];
+        wSum += w;
+    }
+    output[gid] = wSum > 0.0f ? acc / wSum : 0.0f;
+}
+";
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaDetectionKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaDetectionKernels.cs
@@ -129,10 +129,12 @@ extern ""C"" __global__ __launch_bounds__(256) void detection_complete_box_iou(
     float ax1 = a[i * 4], ay1 = a[i * 4 + 1], ax2 = a[i * 4 + 2], ay2 = a[i * 4 + 3];
     float bx1 = b[j * 4], by1 = b[j * 4 + 1], bx2 = b[j * 4 + 2], by2 = b[j * 4 + 3];
 
-    float aw = ax2 - ax1, ah = ay2 - ay1;
-    float bw = bx2 - bx1, bh = by2 - by1;
-    float areaA = fmaxf(aw, 0.0f) * fmaxf(ah, 0.0f);
-    float areaB = fmaxf(bw, 0.0f) * fmaxf(bh, 0.0f);
+    // Clamp widths/heights to match the backward's convention; degenerate
+    // boxes (x2<x1 etc.) contribute zero to the aspect term in both passes.
+    float aw = fmaxf(ax2 - ax1, 0.0f), ah = fmaxf(ay2 - ay1, 0.0f);
+    float bw = fmaxf(bx2 - bx1, 0.0f), bh = fmaxf(by2 - by1, 0.0f);
+    float areaA = aw * ah;
+    float areaB = bw * bh;
     float ix1 = fmaxf(ax1, bx1), iy1 = fmaxf(ay1, by1);
     float ix2 = fminf(ax2, bx2), iy2 = fminf(ay2, by2);
     float inter = fmaxf(ix2 - ix1, 0.0f) * fmaxf(iy2 - iy1, 0.0f);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaDetectionKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaDetectionKernels.cs
@@ -1,0 +1,409 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// CUDA kernels for the vision detection ops added by Issue #217.
+// Each function is a single-pass kernel launched over output element count.
+// Mirrors OpenClDetectionKernels / HipDetectionKernels function-for-function.
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA.Kernels
+{
+    /// <summary>
+    /// Source bundle for the vision detection CUDA kernels (Issue #217).
+    /// Pairwise IoU family + per-box ops. fp32 only — DirectGpuTensorEngine
+    /// gates GPU dispatch on T = float, so non-float tensors fall through
+    /// to the CpuEngine path.
+    /// </summary>
+    public static class CudaDetectionKernels
+    {
+        public static string[] GetKernelNames() => new[]
+        {
+            "detection_box_iou",
+            "detection_generalized_box_iou",
+            "detection_distance_box_iou",
+            "detection_complete_box_iou",
+            "detection_box_area",
+            "detection_box_convert",
+            "detection_iou_backward_a",
+            "detection_iou_backward_b",
+        };
+
+        public static string GetSource() => @"
+#include <math.h>
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+// ----------------------------------------------------------------------------
+// Pairwise IoU family — one thread per (i, j) cell.
+// ----------------------------------------------------------------------------
+
+extern ""C"" __global__ __launch_bounds__(256) void detection_box_iou(
+    const float* __restrict__ a, const float* __restrict__ b,
+    float* __restrict__ output, int n, int m)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (gid >= n * m) return;
+    int i = gid / m;
+    int j = gid % m;
+    float ax1 = a[i * 4], ay1 = a[i * 4 + 1], ax2 = a[i * 4 + 2], ay2 = a[i * 4 + 3];
+    float bx1 = b[j * 4], by1 = b[j * 4 + 1], bx2 = b[j * 4 + 2], by2 = b[j * 4 + 3];
+
+    float aw = fmaxf(ax2 - ax1, 0.0f);
+    float ah = fmaxf(ay2 - ay1, 0.0f);
+    float bw = fmaxf(bx2 - bx1, 0.0f);
+    float bh = fmaxf(by2 - by1, 0.0f);
+    float areaA = aw * ah;
+    float areaB = bw * bh;
+
+    float ix1 = fmaxf(ax1, bx1);
+    float iy1 = fmaxf(ay1, by1);
+    float ix2 = fminf(ax2, bx2);
+    float iy2 = fminf(ay2, by2);
+    float iw = fmaxf(ix2 - ix1, 0.0f);
+    float ih = fmaxf(iy2 - iy1, 0.0f);
+    float inter = iw * ih;
+    float u = areaA + areaB - inter;
+    output[gid] = u > 0.0f ? inter / u : 0.0f;
+}
+
+extern ""C"" __global__ __launch_bounds__(256) void detection_generalized_box_iou(
+    const float* __restrict__ a, const float* __restrict__ b,
+    float* __restrict__ output, int n, int m)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (gid >= n * m) return;
+    int i = gid / m;
+    int j = gid % m;
+    float ax1 = a[i * 4], ay1 = a[i * 4 + 1], ax2 = a[i * 4 + 2], ay2 = a[i * 4 + 3];
+    float bx1 = b[j * 4], by1 = b[j * 4 + 1], bx2 = b[j * 4 + 2], by2 = b[j * 4 + 3];
+
+    float areaA = fmaxf(ax2 - ax1, 0.0f) * fmaxf(ay2 - ay1, 0.0f);
+    float areaB = fmaxf(bx2 - bx1, 0.0f) * fmaxf(by2 - by1, 0.0f);
+    float ix1 = fmaxf(ax1, bx1), iy1 = fmaxf(ay1, by1);
+    float ix2 = fminf(ax2, bx2), iy2 = fminf(ay2, by2);
+    float inter = fmaxf(ix2 - ix1, 0.0f) * fmaxf(iy2 - iy1, 0.0f);
+    float u = areaA + areaB - inter;
+    float iou = u > 0.0f ? inter / u : 0.0f;
+
+    float ex1 = fminf(ax1, bx1), ey1 = fminf(ay1, by1);
+    float ex2 = fmaxf(ax2, bx2), ey2 = fmaxf(ay2, by2);
+    float enclose = fmaxf(ex2 - ex1, 0.0f) * fmaxf(ey2 - ey1, 0.0f);
+    output[gid] = enclose > 0.0f ? iou - (enclose - u) / enclose : iou;
+}
+
+extern ""C"" __global__ __launch_bounds__(256) void detection_distance_box_iou(
+    const float* __restrict__ a, const float* __restrict__ b,
+    float* __restrict__ output, int n, int m)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (gid >= n * m) return;
+    int i = gid / m;
+    int j = gid % m;
+    float ax1 = a[i * 4], ay1 = a[i * 4 + 1], ax2 = a[i * 4 + 2], ay2 = a[i * 4 + 3];
+    float bx1 = b[j * 4], by1 = b[j * 4 + 1], bx2 = b[j * 4 + 2], by2 = b[j * 4 + 3];
+
+    float areaA = fmaxf(ax2 - ax1, 0.0f) * fmaxf(ay2 - ay1, 0.0f);
+    float areaB = fmaxf(bx2 - bx1, 0.0f) * fmaxf(by2 - by1, 0.0f);
+    float ix1 = fmaxf(ax1, bx1), iy1 = fmaxf(ay1, by1);
+    float ix2 = fminf(ax2, bx2), iy2 = fminf(ay2, by2);
+    float inter = fmaxf(ix2 - ix1, 0.0f) * fmaxf(iy2 - iy1, 0.0f);
+    float u = areaA + areaB - inter;
+    float iou = u > 0.0f ? inter / u : 0.0f;
+
+    float acx = (ax1 + ax2) * 0.5f, acy = (ay1 + ay2) * 0.5f;
+    float bcx = (bx1 + bx2) * 0.5f, bcy = (by1 + by2) * 0.5f;
+    float dx = acx - bcx, dy = acy - bcy;
+    float centreSq = dx * dx + dy * dy;
+    float ex1 = fminf(ax1, bx1), ey1 = fminf(ay1, by1);
+    float ex2 = fmaxf(ax2, bx2), ey2 = fmaxf(ay2, by2);
+    float ew = ex2 - ex1, eh = ey2 - ey1;
+    float diagSq = ew * ew + eh * eh;
+    output[gid] = diagSq > 0.0f ? iou - centreSq / diagSq : iou;
+}
+
+extern ""C"" __global__ __launch_bounds__(256) void detection_complete_box_iou(
+    const float* __restrict__ a, const float* __restrict__ b,
+    float* __restrict__ output, int n, int m)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (gid >= n * m) return;
+    int i = gid / m;
+    int j = gid % m;
+    float ax1 = a[i * 4], ay1 = a[i * 4 + 1], ax2 = a[i * 4 + 2], ay2 = a[i * 4 + 3];
+    float bx1 = b[j * 4], by1 = b[j * 4 + 1], bx2 = b[j * 4 + 2], by2 = b[j * 4 + 3];
+
+    float aw = ax2 - ax1, ah = ay2 - ay1;
+    float bw = bx2 - bx1, bh = by2 - by1;
+    float areaA = fmaxf(aw, 0.0f) * fmaxf(ah, 0.0f);
+    float areaB = fmaxf(bw, 0.0f) * fmaxf(bh, 0.0f);
+    float ix1 = fmaxf(ax1, bx1), iy1 = fmaxf(ay1, by1);
+    float ix2 = fminf(ax2, bx2), iy2 = fminf(ay2, by2);
+    float inter = fmaxf(ix2 - ix1, 0.0f) * fmaxf(iy2 - iy1, 0.0f);
+    float u = areaA + areaB - inter;
+    float iou = u > 0.0f ? inter / u : 0.0f;
+
+    float acx = (ax1 + ax2) * 0.5f, acy = (ay1 + ay2) * 0.5f;
+    float bcx = (bx1 + bx2) * 0.5f, bcy = (by1 + by2) * 0.5f;
+    float dx = acx - bcx, dy = acy - bcy;
+    float centreSq = dx * dx + dy * dy;
+    float ex1 = fminf(ax1, bx1), ey1 = fminf(ay1, by1);
+    float ex2 = fmaxf(ax2, bx2), ey2 = fmaxf(ay2, by2);
+    float ew = ex2 - ex1, eh = ey2 - ey1;
+    float diagSq = ew * ew + eh * eh;
+    float diou = diagSq > 0.0f ? iou - centreSq / diagSq : iou;
+
+    float v = 0.0f, alpha = 0.0f;
+    if (ah > 0.0f && bh > 0.0f) {
+        float aspectA = atanf(aw / ah);
+        float aspectB = atanf(bw / bh);
+        float diff = aspectA - aspectB;
+        const float invPiSq = 4.0f / ((float)M_PI * (float)M_PI);
+        v = invPiSq * diff * diff;
+        float denom = (1.0f - iou) + v;
+        alpha = denom > 0.0f ? v / denom : 0.0f;
+    }
+    output[gid] = diou - alpha * v;
+}
+
+// ----------------------------------------------------------------------------
+// BoxArea — one thread per box.
+// ----------------------------------------------------------------------------
+
+extern ""C"" __global__ __launch_bounds__(256) void detection_box_area(
+    const float* __restrict__ boxes, float* __restrict__ output, int n)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (gid >= n) return;
+    float w = fmaxf(boxes[gid * 4 + 2] - boxes[gid * 4], 0.0f);
+    float h = fmaxf(boxes[gid * 4 + 3] - boxes[gid * 4 + 1], 0.0f);
+    output[gid] = w * h;
+}
+
+// ----------------------------------------------------------------------------
+// BoxConvert — fromFormat/toFormat are int codes:
+//   0 = XYXY, 1 = XYWH, 2 = CXCYWH.
+// One thread per box.
+// ----------------------------------------------------------------------------
+
+extern ""C"" __global__ __launch_bounds__(256) void detection_box_convert(
+    const float* __restrict__ boxes, float* __restrict__ output,
+    int n, int fromFormat, int toFormat)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (gid >= n) return;
+    int o = gid * 4;
+    float v0 = boxes[o], v1 = boxes[o + 1], v2 = boxes[o + 2], v3 = boxes[o + 3];
+
+    float x1, y1, x2, y2;
+    if (fromFormat == 0) { x1 = v0; y1 = v1; x2 = v2; y2 = v3; }
+    else if (fromFormat == 1) { x1 = v0; y1 = v1; x2 = v0 + v2; y2 = v1 + v3; }
+    else { float hw = v2 * 0.5f, hh = v3 * 0.5f;
+           x1 = v0 - hw; y1 = v1 - hh; x2 = v0 + hw; y2 = v1 + hh; }
+
+    if (toFormat == 0) { output[o] = x1; output[o + 1] = y1; output[o + 2] = x2; output[o + 3] = y2; }
+    else if (toFormat == 1) {
+        output[o] = x1; output[o + 1] = y1;
+        output[o + 2] = x2 - x1; output[o + 3] = y2 - y1;
+    } else {
+        float w = x2 - x1, h = y2 - y1;
+        output[o] = x1 + w * 0.5f; output[o + 1] = y1 + h * 0.5f;
+        output[o + 2] = w; output[o + 3] = h;
+    }
+}
+
+// ----------------------------------------------------------------------------
+// IoU family backward — Issue #217.
+// Mirrors CpuEngine.IouFamilyBackward exactly. variant codes:
+//   0 = IoU, 1 = GIoU, 2 = DIoU, 3 = CIoU.
+// CIoU treats alpha as stop-gradient (Zheng 2020 / torchvision).
+//
+// Atomics-free design: two kernels. Each thread of kernel_a owns one row i
+// of A and iterates j = 0..M accumulating the four coord gradients for A[i].
+// Each thread of kernel_b owns one row j of B and iterates i = 0..N
+// accumulating the four coord gradients for B[j]. Writes happen once per
+// thread, no contention, portable to every backend.
+// ----------------------------------------------------------------------------
+
+__device__ __forceinline__ void compute_cell_grads_iou(
+    float ax1, float ay1, float ax2, float ay2,
+    float bx1, float by1, float bx2, float by2,
+    float g, int variant,
+    float* gAx1, float* gAy1, float* gAx2, float* gAy2,
+    float* gBx1, float* gBy1, float* gBx2, float* gBy2)
+{
+    *gAx1 = 0.0f; *gAy1 = 0.0f; *gAx2 = 0.0f; *gAy2 = 0.0f;
+    *gBx1 = 0.0f; *gBy1 = 0.0f; *gBx2 = 0.0f; *gBy2 = 0.0f;
+    if (g == 0.0f) return;
+
+    const float INV_PI_SQ = 4.0f / (3.14159265358979323846f * 3.14159265358979323846f);
+
+    float awRaw = ax2 - ax1, ahRaw = ay2 - ay1;
+    float bwRaw = bx2 - bx1, bhRaw = by2 - by1;
+    float aw = fmaxf(awRaw, 0.0f), ah = fmaxf(ahRaw, 0.0f);
+    float bw = fmaxf(bwRaw, 0.0f), bh = fmaxf(bhRaw, 0.0f);
+    float areaA = aw * ah, areaB = bw * bh;
+
+    float ix1 = fmaxf(ax1, bx1), ix2 = fminf(ax2, bx2);
+    float iy1 = fmaxf(ay1, by1), iy2 = fminf(ay2, by2);
+    float iwRaw = ix2 - ix1, ihRaw = iy2 - iy1;
+    float iw = fmaxf(iwRaw, 0.0f), ih = fmaxf(ihRaw, 0.0f);
+    float inter = iw * ih;
+    float u = areaA + areaB - inter;
+    float iou = u > 0.0f ? inter / u : 0.0f;
+
+    float gIou = g;
+    float gInter = 0.0f, gAreaA = 0.0f, gAreaB = 0.0f;
+
+    if (variant == 1) {
+        // GIoU
+        float ex1 = fminf(ax1, bx1), ex2 = fmaxf(ax2, bx2);
+        float ey1 = fminf(ay1, by1), ey2 = fmaxf(ay2, by2);
+        float ewRaw = ex2 - ex1, ehRaw = ey2 - ey1;
+        float ew = fmaxf(ewRaw, 0.0f), eh = fmaxf(ehRaw, 0.0f);
+        float enclose = ew * eh;
+        if (enclose > 0.0f) {
+            float gUnion = g / enclose;
+            float gEnclose = g * (-u / (enclose * enclose));
+            gAreaA += gUnion; gAreaB += gUnion; gInter += -gUnion;
+            float gEw = gEnclose * eh, gEh = gEnclose * ew;
+            float gEwRaw = ewRaw > 0.0f ? gEw : 0.0f;
+            float gEhRaw = ehRaw > 0.0f ? gEh : 0.0f;
+            float gEx1 = -gEwRaw, gEx2 = gEwRaw;
+            float gEy1 = -gEhRaw, gEy2 = gEhRaw;
+            if (ax1 <= bx1) *gAx1 += gEx1; else *gBx1 += gEx1;
+            if (ay1 <= by1) *gAy1 += gEy1; else *gBy1 += gEy1;
+            if (ax2 >= bx2) *gAx2 += gEx2; else *gBx2 += gEx2;
+            if (ay2 >= by2) *gAy2 += gEy2; else *gBy2 += gEy2;
+        }
+    } else if (variant == 2 || variant == 3) {
+        // DIoU or CIoU
+        float acx = (ax1 + ax2) * 0.5f, acy = (ay1 + ay2) * 0.5f;
+        float bcx = (bx1 + bx2) * 0.5f, bcy = (by1 + by2) * 0.5f;
+        float dcx = acx - bcx, dcy = acy - bcy;
+        float centreSq = dcx * dcx + dcy * dcy;
+        float ex1 = fminf(ax1, bx1), ex2 = fmaxf(ax2, bx2);
+        float ey1 = fminf(ay1, by1), ey2 = fmaxf(ay2, by2);
+        float ew = ex2 - ex1, eh = ey2 - ey1;
+        float diagSq = ew * ew + eh * eh;
+
+        float gCentreSq = 0.0f, gDiagSq = 0.0f;
+        if (diagSq > 0.0f) {
+            gCentreSq = g * (-1.0f / diagSq);
+            gDiagSq = g * centreSq / (diagSq * diagSq);
+        }
+
+        if (variant == 3 && ah > 0.0f && bh > 0.0f) {
+            float aspectA = atanf(aw / ah);
+            float aspectB = atanf(bw / bh);
+            float diff = aspectA - aspectB;
+            float v = INV_PI_SQ * diff * diff;
+            float denom = (1.0f - iou) + v;
+            float alpha = denom > 0.0f ? v / denom : 0.0f;
+            float gV = g * (-alpha);
+            float gDiff = gV * 2.0f * INV_PI_SQ * diff;
+            float gAspectA = gDiff, gAspectB = -gDiff;
+            float aDen = aw * aw + ah * ah;
+            float bDen = bw * bw + bh * bh;
+            if (aDen > 0.0f) {
+                float gAw = gAspectA * (ah / aDen);
+                float gAh = gAspectA * (-aw / aDen);
+                if (awRaw > 0.0f) { *gAx2 += gAw; *gAx1 += -gAw; }
+                if (ahRaw > 0.0f) { *gAy2 += gAh; *gAy1 += -gAh; }
+            }
+            if (bDen > 0.0f) {
+                float gBw = gAspectB * (bh / bDen);
+                float gBh = gAspectB * (-bw / bDen);
+                if (bwRaw > 0.0f) { *gBx2 += gBw; *gBx1 += -gBw; }
+                if (bhRaw > 0.0f) { *gBy2 += gBh; *gBy1 += -gBh; }
+            }
+        }
+
+        float gAcx = gCentreSq * 2.0f * dcx;
+        float gAcy = gCentreSq * 2.0f * dcy;
+        *gAx1 += gAcx * 0.5f; *gAx2 += gAcx * 0.5f;
+        *gAy1 += gAcy * 0.5f; *gAy2 += gAcy * 0.5f;
+        *gBx1 += -gAcx * 0.5f; *gBx2 += -gAcx * 0.5f;
+        *gBy1 += -gAcy * 0.5f; *gBy2 += -gAcy * 0.5f;
+
+        float gEw = gDiagSq * 2.0f * ew;
+        float gEh = gDiagSq * 2.0f * eh;
+        float gEx1 = -gEw, gEx2 = gEw;
+        float gEy1 = -gEh, gEy2 = gEh;
+        if (ax1 <= bx1) *gAx1 += gEx1; else *gBx1 += gEx1;
+        if (ay1 <= by1) *gAy1 += gEy1; else *gBy1 += gEy1;
+        if (ax2 >= bx2) *gAx2 += gEx2; else *gBx2 += gEx2;
+        if (ay2 >= by2) *gAy2 += gEy2; else *gBy2 += gEy2;
+    }
+
+    if (u > 0.0f) {
+        float uSq = u * u;
+        gInter += gIou * (u + inter) / uSq;
+        gAreaA += gIou * (-inter) / uSq;
+        gAreaB += gIou * (-inter) / uSq;
+    }
+
+    float gIw = gInter * ih, gIh = gInter * iw;
+    float gIwRaw = iwRaw > 0.0f ? gIw : 0.0f;
+    float gIhRaw = ihRaw > 0.0f ? gIh : 0.0f;
+    float gIx2 = gIwRaw, gIx1 = -gIwRaw;
+    float gIy2 = gIhRaw, gIy1 = -gIhRaw;
+    if (ax1 >= bx1) *gAx1 += gIx1; else *gBx1 += gIx1;
+    if (ay1 >= by1) *gAy1 += gIy1; else *gBy1 += gIy1;
+    if (ax2 <= bx2) *gAx2 += gIx2; else *gBx2 += gIx2;
+    if (ay2 <= by2) *gAy2 += gIy2; else *gBy2 += gIy2;
+
+    float gAw2 = gAreaA * ah, gAh2 = gAreaA * aw;
+    float gBw2 = gAreaB * bh, gBh2 = gAreaB * bw;
+    if (awRaw > 0.0f) { *gAx2 += gAw2; *gAx1 += -gAw2; }
+    if (ahRaw > 0.0f) { *gAy2 += gAh2; *gAy1 += -gAh2; }
+    if (bwRaw > 0.0f) { *gBx2 += gBw2; *gBx1 += -gBw2; }
+    if (bhRaw > 0.0f) { *gBy2 += gBh2; *gBy1 += -gBh2; }
+}
+
+extern ""C"" __global__ __launch_bounds__(256) void detection_iou_backward_a(
+    const float* __restrict__ gradOutput,
+    const float* __restrict__ a, const float* __restrict__ b,
+    float* __restrict__ gradA,
+    int n, int m, int variant)
+{
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= n) return;
+    float ax1 = a[i * 4], ay1 = a[i * 4 + 1], ax2 = a[i * 4 + 2], ay2 = a[i * 4 + 3];
+    float sumX1 = 0.0f, sumY1 = 0.0f, sumX2 = 0.0f, sumY2 = 0.0f;
+    for (int j = 0; j < m; j++) {
+        float bx1 = b[j * 4], by1 = b[j * 4 + 1], bx2 = b[j * 4 + 2], by2 = b[j * 4 + 3];
+        float g = gradOutput[i * m + j];
+        float gAx1, gAy1, gAx2, gAy2, gBx1, gBy1, gBx2, gBy2;
+        compute_cell_grads_iou(ax1, ay1, ax2, ay2, bx1, by1, bx2, by2, g, variant,
+            &gAx1, &gAy1, &gAx2, &gAy2, &gBx1, &gBy1, &gBx2, &gBy2);
+        sumX1 += gAx1; sumY1 += gAy1; sumX2 += gAx2; sumY2 += gAy2;
+    }
+    gradA[i * 4] = sumX1;
+    gradA[i * 4 + 1] = sumY1;
+    gradA[i * 4 + 2] = sumX2;
+    gradA[i * 4 + 3] = sumY2;
+}
+
+extern ""C"" __global__ __launch_bounds__(256) void detection_iou_backward_b(
+    const float* __restrict__ gradOutput,
+    const float* __restrict__ a, const float* __restrict__ b,
+    float* __restrict__ gradB,
+    int n, int m, int variant)
+{
+    int j = blockIdx.x * blockDim.x + threadIdx.x;
+    if (j >= m) return;
+    float bx1 = b[j * 4], by1 = b[j * 4 + 1], bx2 = b[j * 4 + 2], by2 = b[j * 4 + 3];
+    float sumX1 = 0.0f, sumY1 = 0.0f, sumX2 = 0.0f, sumY2 = 0.0f;
+    for (int i = 0; i < n; i++) {
+        float ax1 = a[i * 4], ay1 = a[i * 4 + 1], ax2 = a[i * 4 + 2], ay2 = a[i * 4 + 3];
+        float g = gradOutput[i * m + j];
+        float gAx1, gAy1, gAx2, gAy2, gBx1, gBy1, gBx2, gBy2;
+        compute_cell_grads_iou(ax1, ay1, ax2, ay2, bx1, by1, bx2, by2, g, variant,
+            &gAx1, &gAy1, &gAx2, &gAy2, &gBx1, &gBy1, &gBx2, &gBy2);
+        sumX1 += gBx1; sumY1 += gBy1; sumX2 += gBx2; sumY2 += gBy2;
+    }
+    gradB[j * 4] = sumX1;
+    gradB[j * 4 + 1] = sumY1;
+    gradB[j * 4 + 2] = sumX2;
+    gradB[j * 4 + 3] = sumY2;
+}
+";
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaGeometryKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaGeometryKernels.cs
@@ -58,14 +58,16 @@ __device__ __forceinline__ int reflect_index(int i, int extent)
 
 __device__ __forceinline__ int pad_boundary(int idx, int extent, int mode)
 {
-    // mode: 1=reflect, 2=replicate, 3=circular
+    // mode: 1=reflect, 2=replicate, 3=circular.
+    // Guard zero-sized axes: reflect/replicate/circular all collapse to
+    // index 0 so the kernel doesn't divide-by-zero or index past end.
+    if (extent <= 0) return 0;
     if (mode == 2) {
         if (idx < 0) return 0;
         if (idx >= extent) return extent - 1;
         return idx;
     }
     if (mode == 1) return reflect_index(idx, extent);
-    // Circular
     int r = ((idx % extent) + extent) % extent;
     return r;
 }
@@ -143,7 +145,7 @@ extern ""C"" __global__ __launch_bounds__(256) void geometry_interpolate_2d(
             acc += wy[yy] * rowAcc;
         }
         output[gid] = (float)acc;
-    } else {  // Area (mode == 5)
+    } else {  // Area (mode == 5) — overlap-weighted averaging
         double yLo = (double)y * Hin / Hout;
         double yHi = (double)(y + 1) * Hin / Hout;
         double xLo = (double)x * Win / Wout;
@@ -154,15 +156,18 @@ extern ""C"" __global__ __launch_bounds__(256) void geometry_interpolate_2d(
         if (xH <= xL) xH = xL + 1;
         if (yH > Hin) yH = Hin;
         if (xH > Win) xH = Win;
+        double totalArea = (yHi - yLo) * (xHi - xLo);
         double acc = 0.0;
-        int count = 0;
         for (int yy = yL; yy < yH; yy++) {
+            double oy = fmax(0.0, fmin(yHi, (double)(yy + 1)) - fmax(yLo, (double)yy));
+            if (oy <= 0.0) continue;
             for (int xx = xL; xx < xH; xx++) {
-                acc += src[yy * Win + xx];
-                count++;
+                double ox = fmax(0.0, fmin(xHi, (double)(xx + 1)) - fmax(xLo, (double)xx));
+                if (ox <= 0.0) continue;
+                acc += oy * ox * src[yy * Win + xx];
             }
         }
-        output[gid] = (float)(count > 0 ? acc / count : 0.0);
+        output[gid] = (float)(totalArea > 0.0 ? acc / totalArea : 0.0);
     }
 }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaGeometryKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaGeometryKernels.cs
@@ -1,0 +1,326 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// CUDA kernels for the geometry / sampling ops added by Issue #217.
+// Covers Interpolate (nearest/bilinear/area/bicubic on 4D NCHW),
+// Pad (4 modes on 4D NCHW), GridSample (bilinear/nearest/bicubic with
+// zeros/border/reflection padding on 4D NHWC), and AffineGrid3D.
+// Non-float tensors and rank ≠ 4 inputs fall back to CpuEngine.
+//
+// Mode ints map onto the InterpolateMode / PadMode / GridSampleMode /
+// GridSamplePadding enums in the managed layer:
+//   InterpolateMode: 0=Nearest 1=Linear 2=Bilinear 3=Bicubic 4=Trilinear 5=Area
+//   PadMode:         0=Constant 1=Reflect 2=Replicate 3=Circular
+//   GridSampleMode:  0=Bilinear 1=Nearest 2=Bicubic
+//   GridSamplePadding: 0=Zeros 1=Border 2=Reflection
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA.Kernels
+{
+    public static class CudaGeometryKernels
+    {
+        public static string[] GetKernelNames() => new[]
+        {
+            "geometry_interpolate_2d",
+            "geometry_pad_4d",
+            "geometry_grid_sample_2d",
+            "geometry_affine_grid_3d",
+        };
+
+        public static string GetSource() => @"
+#include <math.h>
+
+// ----------------------------------------------------------------------------
+// Shared device helpers.
+// ----------------------------------------------------------------------------
+
+__device__ __forceinline__ double source_coord(int dstIdx, int dstSize, int srcSize, int alignCorners)
+{
+    if (dstSize <= 1) return 0.0;
+    if (alignCorners) return (double)dstIdx * (srcSize - 1) / (dstSize - 1);
+    return ((double)dstIdx + 0.5) * srcSize / dstSize - 0.5;
+}
+
+__device__ __forceinline__ double cubic_kernel(double d, double a)
+{
+    double ad = fabs(d);
+    if (ad < 1.0) return ((a + 2.0) * ad - (a + 3.0)) * ad * ad + 1.0;
+    if (ad < 2.0) return a * ((ad - 5.0) * ad + 8.0) * ad - 4.0 * a;
+    return 0.0;
+}
+
+__device__ __forceinline__ int clamp_i(int v, int lo, int hi) { return v < lo ? lo : (v > hi ? hi : v); }
+
+__device__ __forceinline__ int reflect_index(int i, int extent)
+{
+    if (extent == 1) return 0;
+    int period = 2 * (extent - 1);
+    int r = ((i % period) + period) % period;
+    return r < extent ? r : period - r;
+}
+
+__device__ __forceinline__ int pad_boundary(int idx, int extent, int mode)
+{
+    // mode: 1=reflect, 2=replicate, 3=circular
+    if (mode == 2) {
+        if (idx < 0) return 0;
+        if (idx >= extent) return extent - 1;
+        return idx;
+    }
+    if (mode == 1) return reflect_index(idx, extent);
+    // Circular
+    int r = ((idx % extent) + extent) % extent;
+    return r;
+}
+
+// ----------------------------------------------------------------------------
+// Interpolate 2D — NCHW, modes: 0=nearest, 2=bilinear, 3=bicubic, 5=area.
+// One thread per output (n, c, y, x).
+// ----------------------------------------------------------------------------
+
+extern ""C"" __global__ __launch_bounds__(256) void geometry_interpolate_2d(
+    const float* __restrict__ input, float* __restrict__ output,
+    int N, int C, int Hin, int Win, int Hout, int Wout,
+    int mode, int alignCorners)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = N * C * Hout * Wout;
+    if (gid >= total) return;
+    int x = gid % Wout;
+    int tmp = gid / Wout;
+    int y = tmp % Hout;
+    tmp /= Hout;
+    int c = tmp % C;
+    int n = tmp / C;
+
+    const float* src = input + ((n * C + c) * Hin) * Win;
+
+    if (mode == 0) {  // Nearest
+        double sy = Hout > 1 ? (double)y * Hin / Hout : 0.0;
+        double sx = Wout > 1 ? (double)x * Win / Wout : 0.0;
+        int yi = (int)floor(sy); if (yi >= Hin) yi = Hin - 1;
+        int xi = (int)floor(sx); if (xi >= Win) xi = Win - 1;
+        output[gid] = src[yi * Win + xi];
+    } else if (mode == 2) {  // Bilinear
+        double sy = source_coord(y, Hout, Hin, alignCorners);
+        double sx = source_coord(x, Wout, Win, alignCorners);
+        int y0 = (int)floor(sy); int x0 = (int)floor(sx);
+        if (y0 < 0) y0 = 0; if (x0 < 0) x0 = 0;
+        int y1 = y0 + 1; int x1 = x0 + 1;
+        if (y1 >= Hin) { y1 = Hin - 1; if (y0 > y1) y0 = y1; }
+        if (x1 >= Win) { x1 = Win - 1; if (x0 > x1) x0 = x1; }
+        double fy = sy - y0; if (fy < 0) fy = 0; if (fy > 1) fy = 1;
+        double fx = sx - x0; if (fx < 0) fx = 0; if (fx > 1) fx = 1;
+        double v00 = src[y0 * Win + x0];
+        double v01 = src[y0 * Win + x1];
+        double v10 = src[y1 * Win + x0];
+        double v11 = src[y1 * Win + x1];
+        double v = v00 * (1 - fx) * (1 - fy) + v01 * fx * (1 - fy)
+                 + v10 * (1 - fx) * fy + v11 * fx * fy;
+        output[gid] = (float)v;
+    } else if (mode == 3) {  // Bicubic (Catmull-Rom, a = -0.75)
+        double sy = source_coord(y, Hout, Hin, alignCorners);
+        double sx = source_coord(x, Wout, Win, alignCorners);
+        int y0 = (int)floor(sy); double ty = sy - y0;
+        int x0 = (int)floor(sx); double tx = sx - x0;
+        double wy[4] = {
+            cubic_kernel(1.0 + ty, -0.75),
+            cubic_kernel(ty, -0.75),
+            cubic_kernel(1.0 - ty, -0.75),
+            cubic_kernel(2.0 - ty, -0.75),
+        };
+        double wx[4] = {
+            cubic_kernel(1.0 + tx, -0.75),
+            cubic_kernel(tx, -0.75),
+            cubic_kernel(1.0 - tx, -0.75),
+            cubic_kernel(2.0 - tx, -0.75),
+        };
+        double acc = 0.0;
+        for (int yy = 0; yy < 4; yy++) {
+            int yi = clamp_i(y0 - 1 + yy, 0, Hin - 1);
+            double rowAcc = 0.0;
+            for (int xx = 0; xx < 4; xx++) {
+                int xi = clamp_i(x0 - 1 + xx, 0, Win - 1);
+                rowAcc += wx[xx] * src[yi * Win + xi];
+            }
+            acc += wy[yy] * rowAcc;
+        }
+        output[gid] = (float)acc;
+    } else {  // Area (mode == 5)
+        double yLo = (double)y * Hin / Hout;
+        double yHi = (double)(y + 1) * Hin / Hout;
+        double xLo = (double)x * Win / Wout;
+        double xHi = (double)(x + 1) * Win / Wout;
+        int yL = (int)floor(yLo); int yH = (int)ceil(yHi);
+        int xL = (int)floor(xLo); int xH = (int)ceil(xHi);
+        if (yH <= yL) yH = yL + 1;
+        if (xH <= xL) xH = xL + 1;
+        if (yH > Hin) yH = Hin;
+        if (xH > Win) xH = Win;
+        double acc = 0.0;
+        int count = 0;
+        for (int yy = yL; yy < yH; yy++) {
+            for (int xx = xL; xx < xH; xx++) {
+                acc += src[yy * Win + xx];
+                count++;
+            }
+        }
+        output[gid] = (float)(count > 0 ? acc / count : 0.0);
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Pad 4D — NCHW, modes: 0=constant, 1=reflect, 2=replicate, 3=circular.
+// One thread per output element (n, c, h, w).
+// ----------------------------------------------------------------------------
+
+extern ""C"" __global__ __launch_bounds__(256) void geometry_pad_4d(
+    const float* __restrict__ input, float* __restrict__ output,
+    int N, int C, int Hin, int Win,
+    int padN0, int padN1, int padC0, int padC1,
+    int padH0, int padH1, int padW0, int padW1,
+    int mode, float padValue)
+{
+    int Nout = N + padN0 + padN1;
+    int Cout = C + padC0 + padC1;
+    int Hout = Hin + padH0 + padH1;
+    int Wout = Win + padW0 + padW1;
+    int total = Nout * Cout * Hout * Wout;
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (gid >= total) return;
+
+    int w = gid % Wout; int t1 = gid / Wout;
+    int h = t1 % Hout; int t2 = t1 / Hout;
+    int c = t2 % Cout; int n = t2 / Cout;
+
+    int nn = n - padN0, cc = c - padC0, hh = h - padH0, ww = w - padW0;
+
+    bool inB = nn >= 0 && nn < N && cc >= 0 && cc < C && hh >= 0 && hh < Hin && ww >= 0 && ww < Win;
+    if (!inB && mode == 0) { output[gid] = padValue; return; }
+
+    if (!inB) {
+        if (!(nn >= 0 && nn < N)) nn = pad_boundary(nn, N, mode);
+        if (!(cc >= 0 && cc < C)) cc = pad_boundary(cc, C, mode);
+        if (!(hh >= 0 && hh < Hin)) hh = pad_boundary(hh, Hin, mode);
+        if (!(ww >= 0 && ww < Win)) ww = pad_boundary(ww, Win, mode);
+    }
+    output[gid] = input[((nn * C + cc) * Hin + hh) * Win + ww];
+}
+
+// ----------------------------------------------------------------------------
+// GridSample 2D — NHWC, modes: 0=bilinear, 1=nearest, 2=bicubic.
+// padding: 0=zeros, 1=border, 2=reflection.
+// One thread per output (n, oy, ox, c) — but we loop C in-thread to
+// amortise grid-lookup work.
+// ----------------------------------------------------------------------------
+
+__device__ __forceinline__ float grid_sample_safe(const float* __restrict__ src,
+    int n, int y, int x, int c,
+    int H, int W, int C, int padding)
+{
+    if (padding == 0) {
+        if ((unsigned)y >= (unsigned)H || (unsigned)x >= (unsigned)W) return 0.0f;
+    } else if (padding == 1) {
+        y = clamp_i(y, 0, H - 1);
+        x = clamp_i(x, 0, W - 1);
+    } else {
+        y = reflect_index(y, H);
+        x = reflect_index(x, W);
+    }
+    return src[((n * H + y) * W + x) * C + c];
+}
+
+extern ""C"" __global__ __launch_bounds__(256) void geometry_grid_sample_2d(
+    const float* __restrict__ input, const float* __restrict__ grid,
+    float* __restrict__ output,
+    int N, int H, int W, int C, int outH, int outW,
+    int mode, int padding, int alignCorners)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = N * outH * outW;
+    if (gid >= total) return;
+    int ox = gid % outW; int t1 = gid / outW;
+    int oy = t1 % outH; int n = t1 / outH;
+
+    int gOff = ((n * outH + oy) * outW + ox) * 2;
+    double gx = grid[gOff];
+    double gy = grid[gOff + 1];
+    double sx = alignCorners ? (gx + 1.0) * 0.5 * (W - 1) : ((gx + 1.0) * W - 1.0) * 0.5;
+    double sy = alignCorners ? (gy + 1.0) * 0.5 * (H - 1) : ((gy + 1.0) * H - 1.0) * 0.5;
+
+    if (mode == 1) {  // Nearest
+        int nx = (int)lrint(sx), ny = (int)lrint(sy);
+        for (int c = 0; c < C; c++)
+            output[((n * outH + oy) * outW + ox) * C + c] =
+                grid_sample_safe(input, n, ny, nx, c, H, W, C, padding);
+    } else if (mode == 0) {  // Bilinear
+        int x0 = (int)floor(sx), y0 = (int)floor(sy);
+        int x1 = x0 + 1, y1 = y0 + 1;
+        double fx = sx - x0, fy = sy - y0;
+        for (int c = 0; c < C; c++) {
+            float v00 = grid_sample_safe(input, n, y0, x0, c, H, W, C, padding);
+            float v01 = grid_sample_safe(input, n, y0, x1, c, H, W, C, padding);
+            float v10 = grid_sample_safe(input, n, y1, x0, c, H, W, C, padding);
+            float v11 = grid_sample_safe(input, n, y1, x1, c, H, W, C, padding);
+            double v = v00 * (1 - fx) * (1 - fy) + v01 * fx * (1 - fy)
+                     + v10 * (1 - fx) * fy + v11 * fx * fy;
+            output[((n * outH + oy) * outW + ox) * C + c] = (float)v;
+        }
+    } else {  // Bicubic
+        int x0 = (int)floor(sx), y0 = (int)floor(sy);
+        double fx = sx - x0, fy = sy - y0;
+        double wy[4] = { cubic_kernel(1.0 + fy, -0.75), cubic_kernel(fy, -0.75),
+                         cubic_kernel(1.0 - fy, -0.75), cubic_kernel(2.0 - fy, -0.75) };
+        double wx[4] = { cubic_kernel(1.0 + fx, -0.75), cubic_kernel(fx, -0.75),
+                         cubic_kernel(1.0 - fx, -0.75), cubic_kernel(2.0 - fx, -0.75) };
+        for (int c = 0; c < C; c++) {
+            double acc = 0.0;
+            for (int yy = 0; yy < 4; yy++) {
+                int yi = y0 - 1 + yy;
+                double rowAcc = 0.0;
+                for (int xx = 0; xx < 4; xx++) {
+                    int xi = x0 - 1 + xx;
+                    rowAcc += wx[xx] * grid_sample_safe(input, n, yi, xi, c, H, W, C, padding);
+                }
+                acc += wy[yy] * rowAcc;
+            }
+            output[((n * outH + oy) * outW + ox) * C + c] = (float)acc;
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------
+// AffineGrid 3D — theta [N, 3, 4] → grid [N, D, H, W, 3].
+// One thread per output (n, d, h, w).
+// ----------------------------------------------------------------------------
+
+__device__ __forceinline__ double grid_norm_coord(int idx, int size, int alignCorners)
+{
+    if (size <= 1) return 0.0;
+    return alignCorners ? -1.0 + 2.0 * idx / (size - 1) : -1.0 + (2.0 * idx + 1.0) / size;
+}
+
+extern ""C"" __global__ __launch_bounds__(256) void geometry_affine_grid_3d(
+    const float* __restrict__ theta, float* __restrict__ grid,
+    int N, int D, int H, int W, int alignCorners)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = N * D * H * W;
+    if (gid >= total) return;
+    int w = gid % W; int t1 = gid / W;
+    int h = t1 % H; int t2 = t1 / H;
+    int d = t2 % D; int n = t2 / D;
+
+    int tBase = n * 12;
+    double x = grid_norm_coord(w, W, alignCorners);
+    double y = grid_norm_coord(h, H, alignCorners);
+    double z = grid_norm_coord(d, D, alignCorners);
+    int gBase = (((n * D + d) * H + h) * W + w) * 3;
+    for (int row = 0; row < 3; row++) {
+        double v = theta[tBase + row * 4] * x
+                 + theta[tBase + row * 4 + 1] * y
+                 + theta[tBase + row * 4 + 2] * z
+                 + theta[tBase + row * 4 + 3];
+        grid[gBase + row] = (float)v;
+    }
+}
+";
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaRoiKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaRoiKernels.cs
@@ -9,6 +9,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA.Kernels
         {
             "roi_align",
             "roi_pool",
+            "ps_roi_align",
+            "ps_roi_pool",
         };
 
         public static string GetSource() => @"
@@ -123,6 +125,91 @@ extern ""C"" __global__ __launch_bounds__(256) void roi_pool(
             if (v > best) best = v;
         }
     output[gid] = best;
+}
+
+// ----------------------------------------------------------------------------
+// Position-sensitive RoIAlign / RoIPool (R-FCN). Input channel layout:
+//   C = outputChannels * outH * outW. Per output (k, co, ph, pw), pull
+//   from channel c = (co * outH + ph) * outW + pw.
+// ----------------------------------------------------------------------------
+
+extern ""C"" __global__ __launch_bounds__(256) void ps_roi_align(
+    const float* __restrict__ input, const float* __restrict__ boxes,
+    float* __restrict__ output,
+    int N, int C, int H, int W, int K,
+    int outH, int outW, int outputChannels,
+    float spatialScale, int samplingRatio)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = K * outputChannels * outH * outW;
+    if (gid >= total) return;
+    int pw = gid % outW; int t1 = gid / outW;
+    int ph = t1 % outH; int t2 = t1 / outH;
+    int co = t2 % outputChannels; int k = t2 / outputChannels;
+
+    int n = (int)boxes[k * 5];
+    if (n < 0 || n >= N) { output[gid] = 0.0f; return; }
+    float x1 = boxes[k * 5 + 1] * spatialScale;
+    float y1 = boxes[k * 5 + 2] * spatialScale;
+    float x2 = boxes[k * 5 + 3] * spatialScale;
+    float y2 = boxes[k * 5 + 4] * spatialScale;
+    float roiW = fmaxf(x2 - x1, 0.1f);
+    float roiH = fmaxf(y2 - y1, 0.1f);
+    float binH = roiH / outH;
+    float binW = roiW / outW;
+    int ry = samplingRatio > 0 ? samplingRatio : (int)ceilf(roiH / outH);
+    int rx = samplingRatio > 0 ? samplingRatio : (int)ceilf(roiW / outW);
+    if (ry < 1) ry = 1;
+    if (rx < 1) rx = 1;
+
+    int c = (co * outH + ph) * outW + pw;
+    int planeBase = (n * C + c) * H * W;
+    float acc = 0;
+    for (int iy = 0; iy < ry; iy++) {
+        float sy = y1 + ph * binH + (iy + 0.5f) * binH / ry;
+        for (int ix = 0; ix < rx; ix++) {
+            float sx = x1 + pw * binW + (ix + 0.5f) * binW / rx;
+            acc += bilinear_sample(input, planeBase, sy, sx, H, W);
+        }
+    }
+    output[gid] = acc / (ry * rx);
+}
+
+extern ""C"" __global__ __launch_bounds__(256) void ps_roi_pool(
+    const float* __restrict__ input, const float* __restrict__ boxes,
+    float* __restrict__ output,
+    int N, int C, int H, int W, int K,
+    int outH, int outW, int outputChannels, float spatialScale)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = K * outputChannels * outH * outW;
+    if (gid >= total) return;
+    int pw = gid % outW; int t1 = gid / outW;
+    int ph = t1 % outH; int t2 = t1 / outH;
+    int co = t2 % outputChannels; int k = t2 / outputChannels;
+
+    int n = (int)boxes[k * 5];
+    if (n < 0 || n >= N) { output[gid] = 0.0f; return; }
+    float x1 = boxes[k * 5 + 1] * spatialScale;
+    float y1 = boxes[k * 5 + 2] * spatialScale;
+    float x2 = boxes[k * 5 + 3] * spatialScale;
+    float y2 = boxes[k * 5 + 4] * spatialScale;
+    float binH = fmaxf(y2 - y1, 0.1f) / outH;
+    float binW = fmaxf(x2 - x1, 0.1f) / outW;
+
+    int c = (co * outH + ph) * outW + pw;
+    int planeBase = (n * C + c) * H * W;
+    int hs = (int)fmaxf(0.0f, floorf(y1 + ph * binH));
+    int he = (int)fminf((float)H, ceilf(y1 + (ph + 1) * binH));
+    int ws = (int)fmaxf(0.0f, floorf(x1 + pw * binW));
+    int we = (int)fminf((float)W, ceilf(x1 + (pw + 1) * binW));
+    float acc = 0; int cnt = 0;
+    for (int yy = hs; yy < he; yy++)
+        for (int xx = ws; xx < we; xx++) {
+            acc += input[planeBase + yy * W + xx];
+            cnt++;
+        }
+    output[gid] = cnt > 0 ? acc / cnt : 0.0f;
 }
 ";
     }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaRoiKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaRoiKernels.cs
@@ -1,0 +1,129 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// CUDA kernels for the RoI family (torchvision roi_align / roi_pool) —
+// tail of Issue #217. One thread per output element.
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA.Kernels
+{
+    public static class CudaRoiKernels
+    {
+        public static string[] GetKernelNames() => new[]
+        {
+            "roi_align",
+            "roi_pool",
+        };
+
+        public static string GetSource() => @"
+#include <math.h>
+#include <float.h>
+
+__device__ __forceinline__ float bilinear_sample(
+    const float* __restrict__ src, int planeBase,
+    float y, float x, int H, int W)
+{
+    if (y < -1.0f || y > (float)H || x < -1.0f || x > (float)W) return 0.0f;
+    if (y <= 0) y = 0;
+    if (x <= 0) x = 0;
+    int y0 = (int)y;
+    int x0 = (int)x;
+    int y1 = y0 + 1 >= H ? H - 1 : y0 + 1;
+    int x1 = x0 + 1 >= W ? W - 1 : x0 + 1;
+    if (y0 >= H - 1) { y0 = y1 = H - 1; y = (float)y0; }
+    if (x0 >= W - 1) { x0 = x1 = W - 1; x = (float)x0; }
+    float ly = y - y0, lx = x - x0;
+    float hy = 1.0f - ly, hx = 1.0f - lx;
+    float v00 = src[planeBase + y0 * W + x0];
+    float v01 = src[planeBase + y0 * W + x1];
+    float v10 = src[planeBase + y1 * W + x0];
+    float v11 = src[planeBase + y1 * W + x1];
+    return hy * hx * v00 + hy * lx * v01 + ly * hx * v10 + ly * lx * v11;
+}
+
+extern ""C"" __global__ __launch_bounds__(256) void roi_align(
+    const float* __restrict__ input, const float* __restrict__ boxes,
+    float* __restrict__ output,
+    int N, int C, int H, int W, int K,
+    int outH, int outW,
+    float spatialScale, int samplingRatio, int aligned)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = K * C * outH * outW;
+    if (gid >= total) return;
+    int pw = gid % outW; int t1 = gid / outW;
+    int ph = t1 % outH; int t2 = t1 / outH;
+    int c = t2 % C; int k = t2 / C;
+
+    int n = (int)boxes[k * 5];
+    if (n < 0 || n >= N) { output[gid] = 0.0f; return; }
+    float offset = aligned ? 0.5f : 0.0f;
+    float x1 = boxes[k * 5 + 1] * spatialScale - offset;
+    float y1 = boxes[k * 5 + 2] * spatialScale - offset;
+    float x2 = boxes[k * 5 + 3] * spatialScale - offset;
+    float y2 = boxes[k * 5 + 4] * spatialScale - offset;
+    float roiW = aligned ? (x2 - x1) : fmaxf(x2 - x1, 1.0f);
+    float roiH = aligned ? (y2 - y1) : fmaxf(y2 - y1, 1.0f);
+    float binH = roiH / outH;
+    float binW = roiW / outW;
+
+    int ry = samplingRatio > 0 ? samplingRatio : (int)ceilf(roiH / outH);
+    int rx = samplingRatio > 0 ? samplingRatio : (int)ceilf(roiW / outW);
+    if (ry < 1) ry = 1;
+    if (rx < 1) rx = 1;
+
+    int planeBase = (n * C + c) * H * W;
+    float acc = 0;
+    for (int iy = 0; iy < ry; iy++) {
+        float sy = y1 + ph * binH + (iy + 0.5f) * binH / ry;
+        for (int ix = 0; ix < rx; ix++) {
+            float sx = x1 + pw * binW + (ix + 0.5f) * binW / rx;
+            acc += bilinear_sample(input, planeBase, sy, sx, H, W);
+        }
+    }
+    output[gid] = acc / (ry * rx);
+}
+
+extern ""C"" __global__ __launch_bounds__(256) void roi_pool(
+    const float* __restrict__ input, const float* __restrict__ boxes,
+    float* __restrict__ output,
+    int N, int C, int H, int W, int K,
+    int outH, int outW, float spatialScale)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = K * C * outH * outW;
+    if (gid >= total) return;
+    int pw = gid % outW; int t1 = gid / outW;
+    int ph = t1 % outH; int t2 = t1 / outH;
+    int c = t2 % C; int k = t2 / C;
+
+    int n = (int)boxes[k * 5];
+    if (n < 0 || n >= N) { output[gid] = 0.0f; return; }
+    int x1 = (int)roundf(boxes[k * 5 + 1] * spatialScale);
+    int y1 = (int)roundf(boxes[k * 5 + 2] * spatialScale);
+    int x2 = (int)roundf(boxes[k * 5 + 3] * spatialScale);
+    int y2 = (int)roundf(boxes[k * 5 + 4] * spatialScale);
+    int roiW = x2 - x1 + 1; if (roiW < 1) roiW = 1;
+    int roiH = y2 - y1 + 1; if (roiH < 1) roiH = 1;
+    float binH = (float)roiH / outH;
+    float binW = (float)roiW / outW;
+
+    int hstart = (int)floorf(ph * binH) + y1;
+    int hend = (int)ceilf((ph + 1) * binH) + y1;
+    int wstart = (int)floorf(pw * binW) + x1;
+    int wend = (int)ceilf((pw + 1) * binW) + x1;
+    if (hstart < 0) hstart = 0; if (hstart > H) hstart = H;
+    if (hend < 0) hend = 0; if (hend > H) hend = H;
+    if (wstart < 0) wstart = 0; if (wstart > W) wstart = W;
+    if (wend < 0) wend = 0; if (wend > W) wend = W;
+
+    int planeBase = (n * C + c) * H * W;
+    bool empty = hend <= hstart || wend <= wstart;
+    if (empty) { output[gid] = 0.0f; return; }
+    float best = -FLT_MAX;
+    for (int yy = hstart; yy < hend; yy++)
+        for (int xx = wstart; xx < wend; xx++) {
+            float v = input[planeBase + yy * W + xx];
+            if (v > best) best = v;
+        }
+    output[gid] = best;
+}
+";
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaRoiKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaRoiKernels.cs
@@ -163,6 +163,8 @@ extern ""C"" __global__ __launch_bounds__(256) void ps_roi_align(
     if (rx < 1) rx = 1;
 
     int c = (co * outH + ph) * outW + pw;
+    // Guard against malformed PS-RoI: if C doesn't match outputChannels·outH·outW, bail out cleanly.
+    if (c >= C) { output[gid] = 0.0f; return; }
     int planeBase = (n * C + c) * H * W;
     float acc = 0;
     for (int iy = 0; iy < ry; iy++) {
@@ -198,6 +200,8 @@ extern ""C"" __global__ __launch_bounds__(256) void ps_roi_pool(
     float binW = fmaxf(x2 - x1, 0.1f) / outW;
 
     int c = (co * outH + ph) * outW + pw;
+    // Guard against malformed PS-RoI: if C doesn't match outputChannels·outH·outW, bail out cleanly.
+    if (c >= C) { output[gid] = 0.0f; return; }
     int planeBase = (n * C + c) * H * W;
     int hs = (int)fmaxf(0.0f, floorf(y1 + ph * binH));
     int he = (int)fminf((float)H, ceilf(y1 + (ph + 1) * binH));

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaRoiKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaRoiKernels.cs
@@ -21,6 +21,7 @@ __device__ __forceinline__ float bilinear_sample(
     const float* __restrict__ src, int planeBase,
     float y, float x, int H, int W)
 {
+    if (H <= 0 || W <= 0) return 0.0f;
     if (y < -1.0f || y > (float)H || x < -1.0f || x > (float)W) return 0.0f;
     if (y <= 0) y = 0;
     if (x <= 0) x = 0;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.Audio.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.Audio.cs
@@ -1,0 +1,88 @@
+// Copyright (c) AiDotNet. All rights reserved.
+namespace AiDotNet.Tensors.Engines.DirectGpu.HIP;
+
+public sealed partial class HipBackend : IAudioBackend
+{
+    private IntPtr ResolveAudioKernel(string name)
+    {
+        if (_audioModule == IntPtr.Zero)
+            throw new InvalidOperationException("Audio HIP module was not compiled.");
+        if (!_kernelCache.TryGetValue(name, out var kernel))
+            throw new InvalidOperationException($"HIP kernel not found: {name}");
+        return kernel;
+    }
+
+    public unsafe void AmplitudeToDB(IGpuBuffer input, IGpuBuffer output, int length,
+        float minAmplitude, float topDb, bool clipTopDb)
+    {
+        if (length <= 0) return;
+        var kernel = ResolveAudioKernel("audio_amplitude_to_db");
+        uint grid = (uint)((length + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr inP = input.Handle, oP = output.Handle;
+        int len = length; float minA = minAmplitude; float tdb = topDb;
+        int clip = clipTopDb ? 1 : 0;
+        void** args = stackalloc void*[6];
+        args[0] = &inP; args[1] = &oP; args[2] = &len;
+        args[3] = &minA; args[4] = &tdb; args[5] = &clip;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+        Synchronize();
+    }
+
+    public unsafe void MuLawEncoding(IGpuBuffer input, IGpuBuffer output, int length, int qc)
+    {
+        if (length <= 0) return;
+        var kernel = ResolveAudioKernel("audio_mulaw_encoding");
+        uint grid = (uint)((length + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr inP = input.Handle, oP = output.Handle;
+        int len = length, q = qc;
+        void** args = stackalloc void*[4];
+        args[0] = &inP; args[1] = &oP; args[2] = &len; args[3] = &q;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+        Synchronize();
+    }
+
+    public unsafe void MuLawDecoding(IGpuBuffer input, IGpuBuffer output, int length, int qc)
+    {
+        if (length <= 0) return;
+        var kernel = ResolveAudioKernel("audio_mulaw_decoding");
+        uint grid = (uint)((length + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr inP = input.Handle, oP = output.Handle;
+        int len = length, q = qc;
+        void** args = stackalloc void*[4];
+        args[0] = &inP; args[1] = &oP; args[2] = &len; args[3] = &q;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+        Synchronize();
+    }
+
+    public unsafe void ComputeDeltas(IGpuBuffer input, IGpuBuffer output,
+        int leading, int timeAxis, int winLength)
+    {
+        int total = leading * timeAxis;
+        if (total <= 0) return;
+        var kernel = ResolveAudioKernel("audio_compute_deltas");
+        uint grid = (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr inP = input.Handle, oP = output.Handle;
+        int ld = leading, t = timeAxis, w = winLength;
+        void** args = stackalloc void*[5];
+        args[0] = &inP; args[1] = &oP; args[2] = &ld; args[3] = &t; args[4] = &w;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+        Synchronize();
+    }
+
+    public unsafe void Resample(IGpuBuffer input, IGpuBuffer output,
+        int leading, int inLen, int outLen, int up, int down, int halfWidth)
+    {
+        int total = leading * outLen;
+        if (total <= 0) return;
+        var kernel = ResolveAudioKernel("audio_resample");
+        uint grid = (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr inP = input.Handle, oP = output.Handle;
+        int ld = leading, il = inLen, ol = outLen, u = up, d = down, hw = halfWidth;
+        void** args = stackalloc void*[8];
+        args[0] = &inP; args[1] = &oP;
+        args[2] = &ld; args[3] = &il; args[4] = &ol;
+        args[5] = &u; args[6] = &d; args[7] = &hw;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+        Synchronize();
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.Detection.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.Detection.cs
@@ -10,7 +10,9 @@ public sealed partial class HipBackend : IDetectionBackend
     {
         if (_detectionModule == IntPtr.Zero)
             throw new InvalidOperationException(
-                "Detection HIP module was not compiled (hipRTC rejected source?). Falling back to CPU reference.");
+                "Detection HIP module was not compiled (hipRTC rejected source?). " +
+                "DirectGpuTensorEngine catches this and routes to the CpuEngine reference; " +
+                "direct callers to HipBackend see this exception.");
         if (!_kernelCache.TryGetValue(name, out var kernel))
             throw new InvalidOperationException($"HIP kernel not found: {name}");
         return kernel;
@@ -20,8 +22,11 @@ public sealed partial class HipBackend : IDetectionBackend
         string kernelName, IGpuBuffer a, IGpuBuffer b, IGpuBuffer output, int n, int m)
     {
         if (n <= 0 || m <= 0) return;
+        long totalLong = (long)n * m;
+        if (totalLong > int.MaxValue)
+            throw new OverflowException($"Pairwise IoU total {totalLong} exceeds Int32.MaxValue.");
         var kernel = ResolveDetectionKernel(kernelName);
-        int total = n * m;
+        int total = (int)totalLong;
         uint grid = (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize);
         IntPtr aPtr = a.Handle, bPtr = b.Handle, oPtr = output.Handle;
         int nn = n, mm = m;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.Detection.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.Detection.cs
@@ -60,6 +60,9 @@ public sealed partial class HipBackend : IDetectionBackend
     public unsafe void BoxConvert(IGpuBuffer boxes, IGpuBuffer output, int n, int fromFormat, int toFormat)
     {
         if (n <= 0) return;
+        if ((uint)fromFormat > 2 || (uint)toFormat > 2)
+            throw new ArgumentException(
+                $"fromFormat/toFormat must be 0 (XYXY), 1 (XYWH), or 2 (CXCYWH); got {fromFormat}, {toFormat}.");
         var kernel = ResolveDetectionKernel("detection_box_convert");
         uint grid = (uint)((n + DefaultBlockSize - 1) / DefaultBlockSize);
         IntPtr bPtr = boxes.Handle, oPtr = output.Handle;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.Detection.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.Detection.cs
@@ -75,24 +75,31 @@ public sealed partial class HipBackend : IDetectionBackend
         IGpuBuffer gradA, IGpuBuffer gradB,
         int n, int m, int variant)
     {
-        if (n <= 0 || m <= 0) return;
+        // See CudaBackend.Detection for the rationale on not short-circuiting n=0 XOR m=0.
+        if (n <= 0 && m <= 0) return;
         var kernelA = ResolveDetectionKernel("detection_iou_backward_a");
         var kernelB = ResolveDetectionKernel("detection_iou_backward_b");
         IntPtr goPtr = gradOutput.Handle, aPtr = boxesA.Handle, bPtr = boxesB.Handle;
         IntPtr gAPtr = gradA.Handle, gBPtr = gradB.Handle;
         int nn = n, mm = m, vv = variant;
 
-        uint gridA = (uint)((n + DefaultBlockSize - 1) / DefaultBlockSize);
-        void** argsA = stackalloc void*[7];
-        argsA[0] = &goPtr; argsA[1] = &aPtr; argsA[2] = &bPtr;
-        argsA[3] = &gAPtr; argsA[4] = &nn; argsA[5] = &mm; argsA[6] = &vv;
-        LaunchKernel(kernelA, gridA, DefaultBlockSize, argsA);
+        if (n > 0)
+        {
+            uint gridA = (uint)((n + DefaultBlockSize - 1) / DefaultBlockSize);
+            void** argsA = stackalloc void*[7];
+            argsA[0] = &goPtr; argsA[1] = &aPtr; argsA[2] = &bPtr;
+            argsA[3] = &gAPtr; argsA[4] = &nn; argsA[5] = &mm; argsA[6] = &vv;
+            LaunchKernel(kernelA, gridA, DefaultBlockSize, argsA);
+        }
 
-        uint gridB = (uint)((m + DefaultBlockSize - 1) / DefaultBlockSize);
-        void** argsB = stackalloc void*[7];
-        argsB[0] = &goPtr; argsB[1] = &aPtr; argsB[2] = &bPtr;
-        argsB[3] = &gBPtr; argsB[4] = &nn; argsB[5] = &mm; argsB[6] = &vv;
-        LaunchKernel(kernelB, gridB, DefaultBlockSize, argsB);
+        if (m > 0)
+        {
+            uint gridB = (uint)((m + DefaultBlockSize - 1) / DefaultBlockSize);
+            void** argsB = stackalloc void*[7];
+            argsB[0] = &goPtr; argsB[1] = &aPtr; argsB[2] = &bPtr;
+            argsB[3] = &gBPtr; argsB[4] = &nn; argsB[5] = &mm; argsB[6] = &vv;
+            LaunchKernel(kernelB, gridB, DefaultBlockSize, argsB);
+        }
         Synchronize();
     }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.Detection.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.Detection.cs
@@ -1,0 +1,98 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// HIP launcher shims for the vision detection kernels (Issue #217).
+// Direct port of CudaBackend.Detection.cs — kernel resolved from
+// _kernelCache, dispatched via 256-thread block / grid-ceil.
+namespace AiDotNet.Tensors.Engines.DirectGpu.HIP;
+
+public sealed partial class HipBackend : IDetectionBackend
+{
+    private IntPtr ResolveDetectionKernel(string name)
+    {
+        if (_detectionModule == IntPtr.Zero)
+            throw new InvalidOperationException(
+                "Detection HIP module was not compiled (hipRTC rejected source?). Falling back to CPU reference.");
+        if (!_kernelCache.TryGetValue(name, out var kernel))
+            throw new InvalidOperationException($"HIP kernel not found: {name}");
+        return kernel;
+    }
+
+    private unsafe void DispatchPairwiseIou(
+        string kernelName, IGpuBuffer a, IGpuBuffer b, IGpuBuffer output, int n, int m)
+    {
+        if (n <= 0 || m <= 0) return;
+        var kernel = ResolveDetectionKernel(kernelName);
+        int total = n * m;
+        uint grid = (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr aPtr = a.Handle, bPtr = b.Handle, oPtr = output.Handle;
+        int nn = n, mm = m;
+        void** args = stackalloc void*[5];
+        args[0] = &aPtr; args[1] = &bPtr; args[2] = &oPtr;
+        args[3] = &nn; args[4] = &mm;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+        Synchronize();
+    }
+
+    public unsafe void BoxIou(IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m)
+        => DispatchPairwiseIou("detection_box_iou", boxesA, boxesB, output, n, m);
+
+    public unsafe void GeneralizedBoxIou(IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m)
+        => DispatchPairwiseIou("detection_generalized_box_iou", boxesA, boxesB, output, n, m);
+
+    public unsafe void DistanceBoxIou(IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m)
+        => DispatchPairwiseIou("detection_distance_box_iou", boxesA, boxesB, output, n, m);
+
+    public unsafe void CompleteBoxIou(IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m)
+        => DispatchPairwiseIou("detection_complete_box_iou", boxesA, boxesB, output, n, m);
+
+    public unsafe void BoxArea(IGpuBuffer boxes, IGpuBuffer output, int n)
+    {
+        if (n <= 0) return;
+        var kernel = ResolveDetectionKernel("detection_box_area");
+        uint grid = (uint)((n + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr bPtr = boxes.Handle, oPtr = output.Handle;
+        int nn = n;
+        void** args = stackalloc void*[3];
+        args[0] = &bPtr; args[1] = &oPtr; args[2] = &nn;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+        Synchronize();
+    }
+
+    public unsafe void BoxConvert(IGpuBuffer boxes, IGpuBuffer output, int n, int fromFormat, int toFormat)
+    {
+        if (n <= 0) return;
+        var kernel = ResolveDetectionKernel("detection_box_convert");
+        uint grid = (uint)((n + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr bPtr = boxes.Handle, oPtr = output.Handle;
+        int nn = n, ff = fromFormat, tf = toFormat;
+        void** args = stackalloc void*[5];
+        args[0] = &bPtr; args[1] = &oPtr; args[2] = &nn; args[3] = &ff; args[4] = &tf;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+        Synchronize();
+    }
+
+    public unsafe void IouFamilyBackward(
+        IGpuBuffer gradOutput, IGpuBuffer boxesA, IGpuBuffer boxesB,
+        IGpuBuffer gradA, IGpuBuffer gradB,
+        int n, int m, int variant)
+    {
+        if (n <= 0 || m <= 0) return;
+        var kernelA = ResolveDetectionKernel("detection_iou_backward_a");
+        var kernelB = ResolveDetectionKernel("detection_iou_backward_b");
+        IntPtr goPtr = gradOutput.Handle, aPtr = boxesA.Handle, bPtr = boxesB.Handle;
+        IntPtr gAPtr = gradA.Handle, gBPtr = gradB.Handle;
+        int nn = n, mm = m, vv = variant;
+
+        uint gridA = (uint)((n + DefaultBlockSize - 1) / DefaultBlockSize);
+        void** argsA = stackalloc void*[7];
+        argsA[0] = &goPtr; argsA[1] = &aPtr; argsA[2] = &bPtr;
+        argsA[3] = &gAPtr; argsA[4] = &nn; argsA[5] = &mm; argsA[6] = &vv;
+        LaunchKernel(kernelA, gridA, DefaultBlockSize, argsA);
+
+        uint gridB = (uint)((m + DefaultBlockSize - 1) / DefaultBlockSize);
+        void** argsB = stackalloc void*[7];
+        argsB[0] = &goPtr; argsB[1] = &aPtr; argsB[2] = &bPtr;
+        argsB[3] = &gBPtr; argsB[4] = &nn; argsB[5] = &mm; argsB[6] = &vv;
+        LaunchKernel(kernelB, gridB, DefaultBlockSize, argsB);
+        Synchronize();
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.Geometry.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.Geometry.cs
@@ -1,0 +1,102 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// HIP launcher shims for the geometry / sampling kernels (Issue #217).
+// Direct port of CudaBackend.Geometry.cs.
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.HIP;
+
+public sealed partial class HipBackend : IGeometryBackend
+{
+    private IntPtr ResolveGeometryKernel(string name)
+    {
+        if (_geometryModule == IntPtr.Zero)
+            throw new InvalidOperationException(
+                "Geometry HIP module was not compiled. Falling back to CPU reference.");
+        if (!_kernelCache.TryGetValue(name, out var kernel))
+            throw new InvalidOperationException($"HIP kernel not found: {name}");
+        return kernel;
+    }
+
+    public unsafe void Interpolate2D(IGpuBuffer input, IGpuBuffer output,
+        int N, int C, int Hin, int Win, int Hout, int Wout,
+        int mode, bool alignCorners)
+    {
+        int total = N * C * Hout * Wout;
+        if (total <= 0) return;
+        var kernel = ResolveGeometryKernel("geometry_interpolate_2d");
+        uint grid = (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr inP = input.Handle, outP = output.Handle;
+        int ac = alignCorners ? 1 : 0;
+        int nn = N, cc = C, hi = Hin, wi = Win, ho = Hout, wo = Wout, mm = mode;
+        void** args = stackalloc void*[10];
+        args[0] = &inP; args[1] = &outP;
+        args[2] = &nn; args[3] = &cc; args[4] = &hi; args[5] = &wi;
+        args[6] = &ho; args[7] = &wo; args[8] = &mm; args[9] = &ac;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+        Synchronize();
+    }
+
+    public unsafe void Pad4D(IGpuBuffer input, IGpuBuffer output,
+        int N, int C, int Hin, int Win,
+        int padN0, int padN1, int padC0, int padC1,
+        int padH0, int padH1, int padW0, int padW1,
+        int mode, float padValue)
+    {
+        int Nout = N + padN0 + padN1;
+        int Cout = C + padC0 + padC1;
+        int Hout = Hin + padH0 + padH1;
+        int Wout = Win + padW0 + padW1;
+        int total = Nout * Cout * Hout * Wout;
+        if (total <= 0) return;
+        var kernel = ResolveGeometryKernel("geometry_pad_4d");
+        uint grid = (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr inP = input.Handle, outP = output.Handle;
+        int nn = N, cc = C, hi = Hin, wi = Win;
+        int pn0 = padN0, pn1 = padN1, pc0 = padC0, pc1 = padC1;
+        int ph0 = padH0, ph1 = padH1, pw0 = padW0, pw1 = padW1;
+        int mm = mode; float pv = padValue;
+        void** args = stackalloc void*[16];
+        args[0] = &inP; args[1] = &outP;
+        args[2] = &nn; args[3] = &cc; args[4] = &hi; args[5] = &wi;
+        args[6] = &pn0; args[7] = &pn1; args[8] = &pc0; args[9] = &pc1;
+        args[10] = &ph0; args[11] = &ph1; args[12] = &pw0; args[13] = &pw1;
+        args[14] = &mm; args[15] = &pv;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+        Synchronize();
+    }
+
+    public unsafe void GridSample2D(IGpuBuffer input, IGpuBuffer grid, IGpuBuffer output,
+        int N, int H, int W, int C, int outH, int outW,
+        int mode, int padding, bool alignCorners)
+    {
+        int total = N * outH * outW;
+        if (total <= 0) return;
+        var kernel = ResolveGeometryKernel("geometry_grid_sample_2d");
+        uint gridLaunch = (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr inP = input.Handle, grP = grid.Handle, outP = output.Handle;
+        int nn = N, hh = H, ww = W, cc = C, oh = outH, ow = outW, mm = mode, pp = padding;
+        int ac = alignCorners ? 1 : 0;
+        void** args = stackalloc void*[12];
+        args[0] = &inP; args[1] = &grP; args[2] = &outP;
+        args[3] = &nn; args[4] = &hh; args[5] = &ww; args[6] = &cc;
+        args[7] = &oh; args[8] = &ow; args[9] = &mm; args[10] = &pp; args[11] = &ac;
+        LaunchKernel(kernel, gridLaunch, DefaultBlockSize, args);
+        Synchronize();
+    }
+
+    public unsafe void AffineGrid3D(IGpuBuffer theta, IGpuBuffer grid,
+        int N, int D, int H, int W, bool alignCorners)
+    {
+        int total = N * D * H * W;
+        if (total <= 0) return;
+        var kernel = ResolveGeometryKernel("geometry_affine_grid_3d");
+        uint gridLaunch = (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr tP = theta.Handle, gP = grid.Handle;
+        int nn = N, dd = D, hh = H, ww = W;
+        int ac = alignCorners ? 1 : 0;
+        void** args = stackalloc void*[7];
+        args[0] = &tP; args[1] = &gP;
+        args[2] = &nn; args[3] = &dd; args[4] = &hh; args[5] = &ww; args[6] = &ac;
+        LaunchKernel(kernel, gridLaunch, DefaultBlockSize, args);
+        Synchronize();
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.Roi.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.Roi.cs
@@ -1,0 +1,55 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// HIP launcher shims for the RoI family (Issue #217 tail). Direct port of
+// CudaBackend.Roi.cs.
+namespace AiDotNet.Tensors.Engines.DirectGpu.HIP;
+
+public sealed partial class HipBackend : IRoiBackend
+{
+    private IntPtr ResolveRoiKernel(string name)
+    {
+        if (_roiModule == IntPtr.Zero)
+            throw new InvalidOperationException("RoI HIP module was not compiled.");
+        if (!_kernelCache.TryGetValue(name, out var kernel))
+            throw new InvalidOperationException($"HIP kernel not found: {name}");
+        return kernel;
+    }
+
+    public unsafe void RoIAlign(IGpuBuffer input, IGpuBuffer boxes, IGpuBuffer output,
+        int N, int C, int H, int W, int K, int outH, int outW,
+        float spatialScale, int samplingRatio, bool aligned)
+    {
+        int total = K * C * outH * outW;
+        if (total <= 0) return;
+        var kernel = ResolveRoiKernel("roi_align");
+        uint grid = (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr inP = input.Handle, bP = boxes.Handle, oP = output.Handle;
+        int nn = N, cc = C, hh = H, ww = W, kk = K, oh = outH, ow = outW;
+        int sr = samplingRatio, al = aligned ? 1 : 0;
+        float ss = spatialScale;
+        void** args = stackalloc void*[13];
+        args[0] = &inP; args[1] = &bP; args[2] = &oP;
+        args[3] = &nn; args[4] = &cc; args[5] = &hh; args[6] = &ww;
+        args[7] = &kk; args[8] = &oh; args[9] = &ow;
+        args[10] = &ss; args[11] = &sr; args[12] = &al;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+        Synchronize();
+    }
+
+    public unsafe void RoIPool(IGpuBuffer input, IGpuBuffer boxes, IGpuBuffer output,
+        int N, int C, int H, int W, int K, int outH, int outW, float spatialScale)
+    {
+        int total = K * C * outH * outW;
+        if (total <= 0) return;
+        var kernel = ResolveRoiKernel("roi_pool");
+        uint grid = (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr inP = input.Handle, bP = boxes.Handle, oP = output.Handle;
+        int nn = N, cc = C, hh = H, ww = W, kk = K, oh = outH, ow = outW;
+        float ss = spatialScale;
+        void** args = stackalloc void*[11];
+        args[0] = &inP; args[1] = &bP; args[2] = &oP;
+        args[3] = &nn; args[4] = &cc; args[5] = &hh; args[6] = &ww;
+        args[7] = &kk; args[8] = &oh; args[9] = &ow; args[10] = &ss;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+        Synchronize();
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.Roi.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.Roi.cs
@@ -52,4 +52,43 @@ public sealed partial class HipBackend : IRoiBackend
         LaunchKernel(kernel, grid, DefaultBlockSize, args);
         Synchronize();
     }
+
+    public unsafe void PsRoIAlign(IGpuBuffer input, IGpuBuffer boxes, IGpuBuffer output,
+        int N, int C, int H, int W, int K, int outH, int outW, int outputChannels,
+        float spatialScale, int samplingRatio)
+    {
+        int total = K * outputChannels * outH * outW;
+        if (total <= 0) return;
+        var kernel = ResolveRoiKernel("ps_roi_align");
+        uint grid = (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr inP = input.Handle, bP = boxes.Handle, oP = output.Handle;
+        int nn = N, cc = C, hh = H, ww = W, kk = K, oh = outH, ow = outW, oc = outputChannels;
+        int sr = samplingRatio; float ss = spatialScale;
+        void** args = stackalloc void*[13];
+        args[0] = &inP; args[1] = &bP; args[2] = &oP;
+        args[3] = &nn; args[4] = &cc; args[5] = &hh; args[6] = &ww;
+        args[7] = &kk; args[8] = &oh; args[9] = &ow; args[10] = &oc;
+        args[11] = &ss; args[12] = &sr;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+        Synchronize();
+    }
+
+    public unsafe void PsRoIPool(IGpuBuffer input, IGpuBuffer boxes, IGpuBuffer output,
+        int N, int C, int H, int W, int K, int outH, int outW, int outputChannels,
+        float spatialScale)
+    {
+        int total = K * outputChannels * outH * outW;
+        if (total <= 0) return;
+        var kernel = ResolveRoiKernel("ps_roi_pool");
+        uint grid = (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr inP = input.Handle, bP = boxes.Handle, oP = output.Handle;
+        int nn = N, cc = C, hh = H, ww = W, kk = K, oh = outH, ow = outW, oc = outputChannels;
+        float ss = spatialScale;
+        void** args = stackalloc void*[12];
+        args[0] = &inP; args[1] = &bP; args[2] = &oP;
+        args[3] = &nn; args[4] = &cc; args[5] = &hh; args[6] = &ww;
+        args[7] = &kk; args[8] = &oh; args[9] = &ow; args[10] = &oc; args[11] = &ss;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+        Synchronize();
+    }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -561,8 +561,9 @@ public sealed partial class HipBackend : IAsyncGpuBackend
                 CompileKernelModule(Kernels.HipDetectionKernels.GetSource(), "detection",
                     ref _detectionModule, Kernels.HipDetectionKernels.GetKernelNames());
             }
-            catch
+            catch (Exception ex)
             {
+                System.Diagnostics.Debug.WriteLine($"HIP detection kernel compilation failed: {ex.Message}");
                 _detectionModule = IntPtr.Zero;
             }
 
@@ -572,8 +573,9 @@ public sealed partial class HipBackend : IAsyncGpuBackend
                 CompileKernelModule(Kernels.HipGeometryKernels.GetSource(), "geometry",
                     ref _geometryModule, Kernels.HipGeometryKernels.GetKernelNames());
             }
-            catch
+            catch (Exception ex)
             {
+                System.Diagnostics.Debug.WriteLine($"HIP geometry kernel compilation failed: {ex.Message}");
                 _geometryModule = IntPtr.Zero;
             }
 
@@ -583,8 +585,9 @@ public sealed partial class HipBackend : IAsyncGpuBackend
                 CompileKernelModule(Kernels.HipRoiKernels.GetSource(), "roi",
                     ref _roiModule, Kernels.HipRoiKernels.GetKernelNames());
             }
-            catch
+            catch (Exception ex)
             {
+                System.Diagnostics.Debug.WriteLine($"HIP RoI kernel compilation failed: {ex.Message}");
                 _roiModule = IntPtr.Zero;
             }
 
@@ -594,8 +597,9 @@ public sealed partial class HipBackend : IAsyncGpuBackend
                 CompileKernelModule(Kernels.HipAudioKernels.GetSource(), "audio",
                     ref _audioModule, Kernels.HipAudioKernels.GetKernelNames());
             }
-            catch
+            catch (Exception ex)
             {
+                System.Diagnostics.Debug.WriteLine($"HIP audio kernel compilation failed: {ex.Message}");
                 _audioModule = IntPtr.Zero;
             }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -10197,6 +10197,14 @@ public sealed partial class HipBackend : IAsyncGpuBackend
             _linalgModule = IntPtr.Zero;
         }
 
+        // Unload the Issue #217 kernel modules (detection / geometry / roi / audio).
+        foreach (var modRef in new[] { _detectionModule, _geometryModule, _roiModule, _audioModule })
+        {
+            if (modRef != IntPtr.Zero)
+                HipNativeBindings.hipModuleUnload(modRef);
+        }
+        _detectionModule = _geometryModule = _roiModule = _audioModule = IntPtr.Zero;
+
         // Unload all additional kernel modules
         foreach (var modField in new[] { _dotProductModule, _reductionModule2, _broadcastModule, _gatedModule, _shapeModule, _lossModule, _softmaxVarModule, _fusedLinearModule, _iouModule, _complexModule })
         {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -84,6 +84,7 @@ public sealed partial class HipBackend : IAsyncGpuBackend
     private IntPtr _complexModule;
     private IntPtr _parity210Module;
     private IntPtr _linalgModule;
+    private IntPtr _detectionModule;
     private IntPtr _hipblasHandle;
     private bool _hipblasAvailable;
 
@@ -549,6 +550,17 @@ public sealed partial class HipBackend : IAsyncGpuBackend
             catch
             {
                 _linalgModule = IntPtr.Zero;
+            }
+
+            // Vision detection kernels (#217). IDetectionBackend dispatch.
+            try
+            {
+                CompileKernelModule(Kernels.HipDetectionKernels.GetSource(), "detection",
+                    ref _detectionModule, Kernels.HipDetectionKernels.GetKernelNames());
+            }
+            catch
+            {
+                _detectionModule = IntPtr.Zero;
             }
 
             Console.WriteLine($"[HipBackend] Kernel compilation complete. Available kernels: {_kernelCache.Count}");

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -86,6 +86,7 @@ public sealed partial class HipBackend : IAsyncGpuBackend
     private IntPtr _linalgModule;
     private IntPtr _detectionModule;
     private IntPtr _geometryModule;
+    private IntPtr _roiModule;
     private IntPtr _hipblasHandle;
     private bool _hipblasAvailable;
 
@@ -573,6 +574,17 @@ public sealed partial class HipBackend : IAsyncGpuBackend
             catch
             {
                 _geometryModule = IntPtr.Zero;
+            }
+
+            // RoI family (#217 tail). IRoiBackend dispatch.
+            try
+            {
+                CompileKernelModule(Kernels.HipRoiKernels.GetSource(), "roi",
+                    ref _roiModule, Kernels.HipRoiKernels.GetKernelNames());
+            }
+            catch
+            {
+                _roiModule = IntPtr.Zero;
             }
 
             Console.WriteLine($"[HipBackend] Kernel compilation complete. Available kernels: {_kernelCache.Count}");

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -87,6 +87,7 @@ public sealed partial class HipBackend : IAsyncGpuBackend
     private IntPtr _detectionModule;
     private IntPtr _geometryModule;
     private IntPtr _roiModule;
+    private IntPtr _audioModule;
     private IntPtr _hipblasHandle;
     private bool _hipblasAvailable;
 
@@ -585,6 +586,17 @@ public sealed partial class HipBackend : IAsyncGpuBackend
             catch
             {
                 _roiModule = IntPtr.Zero;
+            }
+
+            // Audio primitives (#217 tail). IAudioBackend dispatch.
+            try
+            {
+                CompileKernelModule(Kernels.HipAudioKernels.GetSource(), "audio",
+                    ref _audioModule, Kernels.HipAudioKernels.GetKernelNames());
+            }
+            catch
+            {
+                _audioModule = IntPtr.Zero;
             }
 
             Console.WriteLine($"[HipBackend] Kernel compilation complete. Available kernels: {_kernelCache.Count}");

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -85,6 +85,7 @@ public sealed partial class HipBackend : IAsyncGpuBackend
     private IntPtr _parity210Module;
     private IntPtr _linalgModule;
     private IntPtr _detectionModule;
+    private IntPtr _geometryModule;
     private IntPtr _hipblasHandle;
     private bool _hipblasAvailable;
 
@@ -561,6 +562,17 @@ public sealed partial class HipBackend : IAsyncGpuBackend
             catch
             {
                 _detectionModule = IntPtr.Zero;
+            }
+
+            // Geometry / sampling kernels (#217). IGeometryBackend dispatch.
+            try
+            {
+                CompileKernelModule(Kernels.HipGeometryKernels.GetSource(), "geometry",
+                    ref _geometryModule, Kernels.HipGeometryKernels.GetKernelNames());
+            }
+            catch
+            {
+                _geometryModule = IntPtr.Zero;
             }
 
             Console.WriteLine($"[HipBackend] Kernel compilation complete. Available kernels: {_kernelCache.Count}");

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipAudioKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipAudioKernels.cs
@@ -76,6 +76,7 @@ extern ""C"" __global__ __launch_bounds__(256) void audio_compute_deltas(
     int row = gid / timeAxis;
 
     int n = winLength / 2;
+    if (n < 1) { output[gid] = 0.0f; return; }
     float denom = 0.0f;
     for (int i = 1; i <= n; i++) denom += 2.0f * i * i;
     float acc = 0.0f;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipAudioKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipAudioKernels.cs
@@ -1,0 +1,125 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// CUDA audio primitive kernels — Issue #217 tail. Spectrogram /
+// PitchShift / TimeStretch compose existing GPU STFT and stay in managed
+// code; this file holds only the element-wise and small-window kernels
+// that benefit from direct GPU execution.
+namespace AiDotNet.Tensors.Engines.DirectGpu.HIP.Kernels
+{
+    public static class HipAudioKernels
+    {
+        public static string[] GetKernelNames() => new[]
+        {
+            "audio_amplitude_to_db",
+            "audio_mulaw_encoding",
+            "audio_mulaw_decoding",
+            "audio_compute_deltas",
+            "audio_resample",
+        };
+
+        public static string GetSource() => @"
+#include <math.h>
+
+extern ""C"" __global__ __launch_bounds__(256) void audio_amplitude_to_db(
+    const float* __restrict__ input, float* __restrict__ output,
+    int length, float minAmp, float topDbFloor, int clipTopDb)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (gid >= length) return;
+    float v = fmaxf(input[gid], minAmp);
+    float db = 20.0f * log10f(v);
+    // topDbFloor is already peak-topDb for the batch; the launcher precomputes
+    // it so we avoid a reduction here. If clipTopDb == 0, topDbFloor is ignored.
+    if (clipTopDb != 0 && db < topDbFloor) db = topDbFloor;
+    output[gid] = db;
+}
+
+extern ""C"" __global__ __launch_bounds__(256) void audio_mulaw_encoding(
+    const float* __restrict__ input, float* __restrict__ output,
+    int length, int quantizationChannels)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (gid >= length) return;
+    float mu = (float)(quantizationChannels - 1);
+    float logMu = log1pf(mu);
+    float x = input[gid];
+    if (x > 1.0f) x = 1.0f;
+    else if (x < -1.0f) x = -1.0f;
+    float y = ((x > 0.0f) - (x < 0.0f)) * log1pf(mu * fabsf(x)) / logMu;
+    float q = floorf((y + 1.0f) * 0.5f * mu + 0.5f);
+    if (q < 0.0f) q = 0.0f;
+    else if (q > mu) q = mu;
+    output[gid] = q;
+}
+
+extern ""C"" __global__ __launch_bounds__(256) void audio_mulaw_decoding(
+    const float* __restrict__ input, float* __restrict__ output,
+    int length, int quantizationChannels)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (gid >= length) return;
+    float mu = (float)(quantizationChannels - 1);
+    float q = input[gid];
+    float y = (q / mu) * 2.0f - 1.0f;
+    float x = ((y > 0.0f) - (y < 0.0f)) * (powf(1.0f + mu, fabsf(y)) - 1.0f) / mu;
+    output[gid] = x;
+}
+
+// One thread per output (row, t). Savitzky-Golay: out[t] = Σ_{k=1..n} k · (in[t+k] − in[t−k]) / (2·Σk²).
+extern ""C"" __global__ __launch_bounds__(256) void audio_compute_deltas(
+    const float* __restrict__ input, float* __restrict__ output,
+    int leading, int timeAxis, int winLength)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = leading * timeAxis;
+    if (gid >= total) return;
+    int t = gid % timeAxis;
+    int row = gid / timeAxis;
+
+    int n = winLength / 2;
+    float denom = 0.0f;
+    for (int i = 1; i <= n; i++) denom += 2.0f * i * i;
+    float acc = 0.0f;
+    int base_ = row * timeAxis;
+    for (int k = 1; k <= n; k++) {
+        int left = t - k < 0 ? 0 : t - k;
+        int right = t + k >= timeAxis ? timeAxis - 1 : t + k;
+        acc += k * (input[base_ + right] - input[base_ + left]);
+    }
+    output[gid] = acc / denom;
+}
+
+// Polyphase Hann-windowed sinc. srcIdx = ot · down / up; sum over
+// [-halfWidth, halfWidth] taps.
+extern ""C"" __global__ __launch_bounds__(256) void audio_resample(
+    const float* __restrict__ input, float* __restrict__ output,
+    int leading, int inLen, int outLen,
+    int up, int down, int halfWidth)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = leading * outLen;
+    if (gid >= total) return;
+    int ot = gid % outLen;
+    int row = gid / outLen;
+    int sBase = row * inLen;
+
+    float cutoff = 1.0f / (float)(up > down ? up : down);
+    float srcIdx = (float)ot * down / up;
+    int centre = (int)floorf(srcIdx);
+
+    float acc = 0.0f, wSum = 0.0f;
+    const float PI = 3.14159265358979323846f;
+    for (int k = -halfWidth; k <= halfWidth; k++) {
+        int idx = centre + k;
+        if (idx < 0 || idx >= inLen) continue;
+        float t = (idx - srcIdx) * cutoff;
+        float sinc = (fabsf(t) < 1e-12f) ? 1.0f : sinf(PI * t) / (PI * t);
+        float hann = 0.5f - 0.5f * cosf(2.0f * PI * (k + halfWidth) / (2.0f * halfWidth));
+        float w = sinc * hann;
+        acc += w * input[sBase + idx];
+        wSum += w;
+    }
+    output[gid] = wSum > 0.0f ? acc / wSum : 0.0f;
+}
+";
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipAudioKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipAudioKernels.cs
@@ -99,6 +99,9 @@ extern ""C"" __global__ __launch_bounds__(256) void audio_resample(
     int gid = blockIdx.x * blockDim.x + threadIdx.x;
     int total = leading * outLen;
     if (gid >= total) return;
+    // Defensive: halfWidth == 0 → Hann cos(2π·k/0) divides by zero.
+    // up == 0 or down == 0 are nonsense for resampling.
+    if (halfWidth < 1 || up <= 0 || down <= 0) { output[gid] = 0.0f; return; }
     int ot = gid % outLen;
     int row = gid / outLen;
     int sBase = row * inLen;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipDetectionKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipDetectionKernels.cs
@@ -129,10 +129,11 @@ extern ""C"" __global__ __launch_bounds__(256) void detection_complete_box_iou(
     float ax1 = a[i * 4], ay1 = a[i * 4 + 1], ax2 = a[i * 4 + 2], ay2 = a[i * 4 + 3];
     float bx1 = b[j * 4], by1 = b[j * 4 + 1], bx2 = b[j * 4 + 2], by2 = b[j * 4 + 3];
 
-    float aw = ax2 - ax1, ah = ay2 - ay1;
-    float bw = bx2 - bx1, bh = by2 - by1;
-    float areaA = fmaxf(aw, 0.0f) * fmaxf(ah, 0.0f);
-    float areaB = fmaxf(bw, 0.0f) * fmaxf(bh, 0.0f);
+    // Clamp to match the backward's convention.
+    float aw = fmaxf(ax2 - ax1, 0.0f), ah = fmaxf(ay2 - ay1, 0.0f);
+    float bw = fmaxf(bx2 - bx1, 0.0f), bh = fmaxf(by2 - by1, 0.0f);
+    float areaA = aw * ah;
+    float areaB = bw * bh;
     float ix1 = fmaxf(ax1, bx1), iy1 = fmaxf(ay1, by1);
     float ix2 = fminf(ax2, bx2), iy2 = fminf(ay2, by2);
     float inter = fmaxf(ix2 - ix1, 0.0f) * fmaxf(iy2 - iy1, 0.0f);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipDetectionKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipDetectionKernels.cs
@@ -1,0 +1,399 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// HIP kernels for the vision detection ops added by Issue #217.
+// Mirrors CudaDetectionKernels function-for-function — HIP's hiprtc accepts
+// the same CUDA-style source, so we keep the two files structurally identical
+// to share test harnesses and reference math.
+namespace AiDotNet.Tensors.Engines.DirectGpu.HIP.Kernels
+{
+    /// <summary>
+    /// Mirror of <c>CudaDetectionKernels</c> for HIP/ROCm. Pairwise IoU family
+    /// + per-box ops. fp32 only — DirectGpuTensorEngine gates GPU dispatch on
+    /// T = float, so non-float tensors fall through to the CpuEngine path.
+    /// </summary>
+    internal static class HipDetectionKernels
+    {
+        public static string[] GetKernelNames() => new[]
+        {
+            "detection_box_iou",
+            "detection_generalized_box_iou",
+            "detection_distance_box_iou",
+            "detection_complete_box_iou",
+            "detection_box_area",
+            "detection_box_convert",
+            "detection_iou_backward_a",
+            "detection_iou_backward_b",
+        };
+
+        public static string GetSource() => @"
+// HIP-RTC device defines — no #include needed.
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+// ----------------------------------------------------------------------------
+// Pairwise IoU family — one thread per (i, j) cell.
+// ----------------------------------------------------------------------------
+
+extern ""C"" __global__ __launch_bounds__(256) void detection_box_iou(
+    const float* __restrict__ a, const float* __restrict__ b,
+    float* __restrict__ output, int n, int m)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (gid >= n * m) return;
+    int i = gid / m;
+    int j = gid % m;
+    float ax1 = a[i * 4], ay1 = a[i * 4 + 1], ax2 = a[i * 4 + 2], ay2 = a[i * 4 + 3];
+    float bx1 = b[j * 4], by1 = b[j * 4 + 1], bx2 = b[j * 4 + 2], by2 = b[j * 4 + 3];
+
+    float aw = fmaxf(ax2 - ax1, 0.0f);
+    float ah = fmaxf(ay2 - ay1, 0.0f);
+    float bw = fmaxf(bx2 - bx1, 0.0f);
+    float bh = fmaxf(by2 - by1, 0.0f);
+    float areaA = aw * ah;
+    float areaB = bw * bh;
+
+    float ix1 = fmaxf(ax1, bx1);
+    float iy1 = fmaxf(ay1, by1);
+    float ix2 = fminf(ax2, bx2);
+    float iy2 = fminf(ay2, by2);
+    float iw = fmaxf(ix2 - ix1, 0.0f);
+    float ih = fmaxf(iy2 - iy1, 0.0f);
+    float inter = iw * ih;
+    float u = areaA + areaB - inter;
+    output[gid] = u > 0.0f ? inter / u : 0.0f;
+}
+
+extern ""C"" __global__ __launch_bounds__(256) void detection_generalized_box_iou(
+    const float* __restrict__ a, const float* __restrict__ b,
+    float* __restrict__ output, int n, int m)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (gid >= n * m) return;
+    int i = gid / m;
+    int j = gid % m;
+    float ax1 = a[i * 4], ay1 = a[i * 4 + 1], ax2 = a[i * 4 + 2], ay2 = a[i * 4 + 3];
+    float bx1 = b[j * 4], by1 = b[j * 4 + 1], bx2 = b[j * 4 + 2], by2 = b[j * 4 + 3];
+
+    float areaA = fmaxf(ax2 - ax1, 0.0f) * fmaxf(ay2 - ay1, 0.0f);
+    float areaB = fmaxf(bx2 - bx1, 0.0f) * fmaxf(by2 - by1, 0.0f);
+    float ix1 = fmaxf(ax1, bx1), iy1 = fmaxf(ay1, by1);
+    float ix2 = fminf(ax2, bx2), iy2 = fminf(ay2, by2);
+    float inter = fmaxf(ix2 - ix1, 0.0f) * fmaxf(iy2 - iy1, 0.0f);
+    float u = areaA + areaB - inter;
+    float iou = u > 0.0f ? inter / u : 0.0f;
+
+    float ex1 = fminf(ax1, bx1), ey1 = fminf(ay1, by1);
+    float ex2 = fmaxf(ax2, bx2), ey2 = fmaxf(ay2, by2);
+    float enclose = fmaxf(ex2 - ex1, 0.0f) * fmaxf(ey2 - ey1, 0.0f);
+    output[gid] = enclose > 0.0f ? iou - (enclose - u) / enclose : iou;
+}
+
+extern ""C"" __global__ __launch_bounds__(256) void detection_distance_box_iou(
+    const float* __restrict__ a, const float* __restrict__ b,
+    float* __restrict__ output, int n, int m)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (gid >= n * m) return;
+    int i = gid / m;
+    int j = gid % m;
+    float ax1 = a[i * 4], ay1 = a[i * 4 + 1], ax2 = a[i * 4 + 2], ay2 = a[i * 4 + 3];
+    float bx1 = b[j * 4], by1 = b[j * 4 + 1], bx2 = b[j * 4 + 2], by2 = b[j * 4 + 3];
+
+    float areaA = fmaxf(ax2 - ax1, 0.0f) * fmaxf(ay2 - ay1, 0.0f);
+    float areaB = fmaxf(bx2 - bx1, 0.0f) * fmaxf(by2 - by1, 0.0f);
+    float ix1 = fmaxf(ax1, bx1), iy1 = fmaxf(ay1, by1);
+    float ix2 = fminf(ax2, bx2), iy2 = fminf(ay2, by2);
+    float inter = fmaxf(ix2 - ix1, 0.0f) * fmaxf(iy2 - iy1, 0.0f);
+    float u = areaA + areaB - inter;
+    float iou = u > 0.0f ? inter / u : 0.0f;
+
+    float acx = (ax1 + ax2) * 0.5f, acy = (ay1 + ay2) * 0.5f;
+    float bcx = (bx1 + bx2) * 0.5f, bcy = (by1 + by2) * 0.5f;
+    float dx = acx - bcx, dy = acy - bcy;
+    float centreSq = dx * dx + dy * dy;
+    float ex1 = fminf(ax1, bx1), ey1 = fminf(ay1, by1);
+    float ex2 = fmaxf(ax2, bx2), ey2 = fmaxf(ay2, by2);
+    float ew = ex2 - ex1, eh = ey2 - ey1;
+    float diagSq = ew * ew + eh * eh;
+    output[gid] = diagSq > 0.0f ? iou - centreSq / diagSq : iou;
+}
+
+extern ""C"" __global__ __launch_bounds__(256) void detection_complete_box_iou(
+    const float* __restrict__ a, const float* __restrict__ b,
+    float* __restrict__ output, int n, int m)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (gid >= n * m) return;
+    int i = gid / m;
+    int j = gid % m;
+    float ax1 = a[i * 4], ay1 = a[i * 4 + 1], ax2 = a[i * 4 + 2], ay2 = a[i * 4 + 3];
+    float bx1 = b[j * 4], by1 = b[j * 4 + 1], bx2 = b[j * 4 + 2], by2 = b[j * 4 + 3];
+
+    float aw = ax2 - ax1, ah = ay2 - ay1;
+    float bw = bx2 - bx1, bh = by2 - by1;
+    float areaA = fmaxf(aw, 0.0f) * fmaxf(ah, 0.0f);
+    float areaB = fmaxf(bw, 0.0f) * fmaxf(bh, 0.0f);
+    float ix1 = fmaxf(ax1, bx1), iy1 = fmaxf(ay1, by1);
+    float ix2 = fminf(ax2, bx2), iy2 = fminf(ay2, by2);
+    float inter = fmaxf(ix2 - ix1, 0.0f) * fmaxf(iy2 - iy1, 0.0f);
+    float u = areaA + areaB - inter;
+    float iou = u > 0.0f ? inter / u : 0.0f;
+
+    float acx = (ax1 + ax2) * 0.5f, acy = (ay1 + ay2) * 0.5f;
+    float bcx = (bx1 + bx2) * 0.5f, bcy = (by1 + by2) * 0.5f;
+    float dx = acx - bcx, dy = acy - bcy;
+    float centreSq = dx * dx + dy * dy;
+    float ex1 = fminf(ax1, bx1), ey1 = fminf(ay1, by1);
+    float ex2 = fmaxf(ax2, bx2), ey2 = fmaxf(ay2, by2);
+    float ew = ex2 - ex1, eh = ey2 - ey1;
+    float diagSq = ew * ew + eh * eh;
+    float diou = diagSq > 0.0f ? iou - centreSq / diagSq : iou;
+
+    float v = 0.0f, alpha = 0.0f;
+    if (ah > 0.0f && bh > 0.0f) {
+        float aspectA = atanf(aw / ah);
+        float aspectB = atanf(bw / bh);
+        float diff = aspectA - aspectB;
+        const float invPiSq = 4.0f / ((float)M_PI * (float)M_PI);
+        v = invPiSq * diff * diff;
+        float denom = (1.0f - iou) + v;
+        alpha = denom > 0.0f ? v / denom : 0.0f;
+    }
+    output[gid] = diou - alpha * v;
+}
+
+// ----------------------------------------------------------------------------
+// BoxArea — one thread per box.
+// ----------------------------------------------------------------------------
+
+extern ""C"" __global__ __launch_bounds__(256) void detection_box_area(
+    const float* __restrict__ boxes, float* __restrict__ output, int n)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (gid >= n) return;
+    float w = fmaxf(boxes[gid * 4 + 2] - boxes[gid * 4], 0.0f);
+    float h = fmaxf(boxes[gid * 4 + 3] - boxes[gid * 4 + 1], 0.0f);
+    output[gid] = w * h;
+}
+
+// ----------------------------------------------------------------------------
+// BoxConvert — fromFormat/toFormat are int codes:
+//   0 = XYXY, 1 = XYWH, 2 = CXCYWH.
+// One thread per box.
+// ----------------------------------------------------------------------------
+
+extern ""C"" __global__ __launch_bounds__(256) void detection_box_convert(
+    const float* __restrict__ boxes, float* __restrict__ output,
+    int n, int fromFormat, int toFormat)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (gid >= n) return;
+    int o = gid * 4;
+    float v0 = boxes[o], v1 = boxes[o + 1], v2 = boxes[o + 2], v3 = boxes[o + 3];
+
+    float x1, y1, x2, y2;
+    if (fromFormat == 0) { x1 = v0; y1 = v1; x2 = v2; y2 = v3; }
+    else if (fromFormat == 1) { x1 = v0; y1 = v1; x2 = v0 + v2; y2 = v1 + v3; }
+    else { float hw = v2 * 0.5f, hh = v3 * 0.5f;
+           x1 = v0 - hw; y1 = v1 - hh; x2 = v0 + hw; y2 = v1 + hh; }
+
+    if (toFormat == 0) { output[o] = x1; output[o + 1] = y1; output[o + 2] = x2; output[o + 3] = y2; }
+    else if (toFormat == 1) {
+        output[o] = x1; output[o + 1] = y1;
+        output[o + 2] = x2 - x1; output[o + 3] = y2 - y1;
+    } else {
+        float w = x2 - x1, h = y2 - y1;
+        output[o] = x1 + w * 0.5f; output[o + 1] = y1 + h * 0.5f;
+        output[o + 2] = w; output[o + 3] = h;
+    }
+}
+
+// ----------------------------------------------------------------------------
+// IoU family backward — Issue #217. Mirrors CudaDetectionKernels (atomics-
+// free two-kernel split). See CudaDetectionKernels.cs for derivation notes.
+// ----------------------------------------------------------------------------
+
+__device__ __forceinline__ void compute_cell_grads_iou(
+    float ax1, float ay1, float ax2, float ay2,
+    float bx1, float by1, float bx2, float by2,
+    float g, int variant,
+    float* gAx1, float* gAy1, float* gAx2, float* gAy2,
+    float* gBx1, float* gBy1, float* gBx2, float* gBy2)
+{
+    *gAx1 = 0.0f; *gAy1 = 0.0f; *gAx2 = 0.0f; *gAy2 = 0.0f;
+    *gBx1 = 0.0f; *gBy1 = 0.0f; *gBx2 = 0.0f; *gBy2 = 0.0f;
+    if (g == 0.0f) return;
+
+    const float INV_PI_SQ = 4.0f / (3.14159265358979323846f * 3.14159265358979323846f);
+
+    float awRaw = ax2 - ax1, ahRaw = ay2 - ay1;
+    float bwRaw = bx2 - bx1, bhRaw = by2 - by1;
+    float aw = fmaxf(awRaw, 0.0f), ah = fmaxf(ahRaw, 0.0f);
+    float bw = fmaxf(bwRaw, 0.0f), bh = fmaxf(bhRaw, 0.0f);
+    float areaA = aw * ah, areaB = bw * bh;
+
+    float ix1 = fmaxf(ax1, bx1), ix2 = fminf(ax2, bx2);
+    float iy1 = fmaxf(ay1, by1), iy2 = fminf(ay2, by2);
+    float iwRaw = ix2 - ix1, ihRaw = iy2 - iy1;
+    float iw = fmaxf(iwRaw, 0.0f), ih = fmaxf(ihRaw, 0.0f);
+    float inter = iw * ih;
+    float u = areaA + areaB - inter;
+    float iou = u > 0.0f ? inter / u : 0.0f;
+
+    float gIou = g;
+    float gInter = 0.0f, gAreaA = 0.0f, gAreaB = 0.0f;
+
+    if (variant == 1) {
+        float ex1 = fminf(ax1, bx1), ex2 = fmaxf(ax2, bx2);
+        float ey1 = fminf(ay1, by1), ey2 = fmaxf(ay2, by2);
+        float ewRaw = ex2 - ex1, ehRaw = ey2 - ey1;
+        float ew = fmaxf(ewRaw, 0.0f), eh = fmaxf(ehRaw, 0.0f);
+        float enclose = ew * eh;
+        if (enclose > 0.0f) {
+            float gUnion = g / enclose;
+            float gEnclose = g * (-u / (enclose * enclose));
+            gAreaA += gUnion; gAreaB += gUnion; gInter += -gUnion;
+            float gEw = gEnclose * eh, gEh = gEnclose * ew;
+            float gEwRaw = ewRaw > 0.0f ? gEw : 0.0f;
+            float gEhRaw = ehRaw > 0.0f ? gEh : 0.0f;
+            float gEx1 = -gEwRaw, gEx2 = gEwRaw;
+            float gEy1 = -gEhRaw, gEy2 = gEhRaw;
+            if (ax1 <= bx1) *gAx1 += gEx1; else *gBx1 += gEx1;
+            if (ay1 <= by1) *gAy1 += gEy1; else *gBy1 += gEy1;
+            if (ax2 >= bx2) *gAx2 += gEx2; else *gBx2 += gEx2;
+            if (ay2 >= by2) *gAy2 += gEy2; else *gBy2 += gEy2;
+        }
+    } else if (variant == 2 || variant == 3) {
+        float acx = (ax1 + ax2) * 0.5f, acy = (ay1 + ay2) * 0.5f;
+        float bcx = (bx1 + bx2) * 0.5f, bcy = (by1 + by2) * 0.5f;
+        float dcx = acx - bcx, dcy = acy - bcy;
+        float centreSq = dcx * dcx + dcy * dcy;
+        float ex1 = fminf(ax1, bx1), ex2 = fmaxf(ax2, bx2);
+        float ey1 = fminf(ay1, by1), ey2 = fmaxf(ay2, by2);
+        float ew = ex2 - ex1, eh = ey2 - ey1;
+        float diagSq = ew * ew + eh * eh;
+
+        float gCentreSq = 0.0f, gDiagSq = 0.0f;
+        if (diagSq > 0.0f) {
+            gCentreSq = g * (-1.0f / diagSq);
+            gDiagSq = g * centreSq / (diagSq * diagSq);
+        }
+
+        if (variant == 3 && ah > 0.0f && bh > 0.0f) {
+            float aspectA = atanf(aw / ah);
+            float aspectB = atanf(bw / bh);
+            float diff = aspectA - aspectB;
+            float v = INV_PI_SQ * diff * diff;
+            float denom = (1.0f - iou) + v;
+            float alpha = denom > 0.0f ? v / denom : 0.0f;
+            float gV = g * (-alpha);
+            float gDiff = gV * 2.0f * INV_PI_SQ * diff;
+            float gAspectA = gDiff, gAspectB = -gDiff;
+            float aDen = aw * aw + ah * ah;
+            float bDen = bw * bw + bh * bh;
+            if (aDen > 0.0f) {
+                float gAw = gAspectA * (ah / aDen);
+                float gAh = gAspectA * (-aw / aDen);
+                if (awRaw > 0.0f) { *gAx2 += gAw; *gAx1 += -gAw; }
+                if (ahRaw > 0.0f) { *gAy2 += gAh; *gAy1 += -gAh; }
+            }
+            if (bDen > 0.0f) {
+                float gBw = gAspectB * (bh / bDen);
+                float gBh = gAspectB * (-bw / bDen);
+                if (bwRaw > 0.0f) { *gBx2 += gBw; *gBx1 += -gBw; }
+                if (bhRaw > 0.0f) { *gBy2 += gBh; *gBy1 += -gBh; }
+            }
+        }
+
+        float gAcx = gCentreSq * 2.0f * dcx;
+        float gAcy = gCentreSq * 2.0f * dcy;
+        *gAx1 += gAcx * 0.5f; *gAx2 += gAcx * 0.5f;
+        *gAy1 += gAcy * 0.5f; *gAy2 += gAcy * 0.5f;
+        *gBx1 += -gAcx * 0.5f; *gBx2 += -gAcx * 0.5f;
+        *gBy1 += -gAcy * 0.5f; *gBy2 += -gAcy * 0.5f;
+
+        float gEw = gDiagSq * 2.0f * ew;
+        float gEh = gDiagSq * 2.0f * eh;
+        float gEx1 = -gEw, gEx2 = gEw;
+        float gEy1 = -gEh, gEy2 = gEh;
+        if (ax1 <= bx1) *gAx1 += gEx1; else *gBx1 += gEx1;
+        if (ay1 <= by1) *gAy1 += gEy1; else *gBy1 += gEy1;
+        if (ax2 >= bx2) *gAx2 += gEx2; else *gBx2 += gEx2;
+        if (ay2 >= by2) *gAy2 += gEy2; else *gBy2 += gEy2;
+    }
+
+    if (u > 0.0f) {
+        float uSq = u * u;
+        gInter += gIou * (u + inter) / uSq;
+        gAreaA += gIou * (-inter) / uSq;
+        gAreaB += gIou * (-inter) / uSq;
+    }
+
+    float gIw = gInter * ih, gIh = gInter * iw;
+    float gIwRaw = iwRaw > 0.0f ? gIw : 0.0f;
+    float gIhRaw = ihRaw > 0.0f ? gIh : 0.0f;
+    float gIx2 = gIwRaw, gIx1 = -gIwRaw;
+    float gIy2 = gIhRaw, gIy1 = -gIhRaw;
+    if (ax1 >= bx1) *gAx1 += gIx1; else *gBx1 += gIx1;
+    if (ay1 >= by1) *gAy1 += gIy1; else *gBy1 += gIy1;
+    if (ax2 <= bx2) *gAx2 += gIx2; else *gBx2 += gIx2;
+    if (ay2 <= by2) *gAy2 += gIy2; else *gBy2 += gIy2;
+
+    float gAw2 = gAreaA * ah, gAh2 = gAreaA * aw;
+    float gBw2 = gAreaB * bh, gBh2 = gAreaB * bw;
+    if (awRaw > 0.0f) { *gAx2 += gAw2; *gAx1 += -gAw2; }
+    if (ahRaw > 0.0f) { *gAy2 += gAh2; *gAy1 += -gAh2; }
+    if (bwRaw > 0.0f) { *gBx2 += gBw2; *gBx1 += -gBw2; }
+    if (bhRaw > 0.0f) { *gBy2 += gBh2; *gBy1 += -gBh2; }
+}
+
+extern ""C"" __global__ __launch_bounds__(256) void detection_iou_backward_a(
+    const float* __restrict__ gradOutput,
+    const float* __restrict__ a, const float* __restrict__ b,
+    float* __restrict__ gradA,
+    int n, int m, int variant)
+{
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= n) return;
+    float ax1 = a[i * 4], ay1 = a[i * 4 + 1], ax2 = a[i * 4 + 2], ay2 = a[i * 4 + 3];
+    float sumX1 = 0.0f, sumY1 = 0.0f, sumX2 = 0.0f, sumY2 = 0.0f;
+    for (int j = 0; j < m; j++) {
+        float bx1 = b[j * 4], by1 = b[j * 4 + 1], bx2 = b[j * 4 + 2], by2 = b[j * 4 + 3];
+        float g = gradOutput[i * m + j];
+        float gAx1, gAy1, gAx2, gAy2, gBx1, gBy1, gBx2, gBy2;
+        compute_cell_grads_iou(ax1, ay1, ax2, ay2, bx1, by1, bx2, by2, g, variant,
+            &gAx1, &gAy1, &gAx2, &gAy2, &gBx1, &gBy1, &gBx2, &gBy2);
+        sumX1 += gAx1; sumY1 += gAy1; sumX2 += gAx2; sumY2 += gAy2;
+    }
+    gradA[i * 4] = sumX1;
+    gradA[i * 4 + 1] = sumY1;
+    gradA[i * 4 + 2] = sumX2;
+    gradA[i * 4 + 3] = sumY2;
+}
+
+extern ""C"" __global__ __launch_bounds__(256) void detection_iou_backward_b(
+    const float* __restrict__ gradOutput,
+    const float* __restrict__ a, const float* __restrict__ b,
+    float* __restrict__ gradB,
+    int n, int m, int variant)
+{
+    int j = blockIdx.x * blockDim.x + threadIdx.x;
+    if (j >= m) return;
+    float bx1 = b[j * 4], by1 = b[j * 4 + 1], bx2 = b[j * 4 + 2], by2 = b[j * 4 + 3];
+    float sumX1 = 0.0f, sumY1 = 0.0f, sumX2 = 0.0f, sumY2 = 0.0f;
+    for (int i = 0; i < n; i++) {
+        float ax1 = a[i * 4], ay1 = a[i * 4 + 1], ax2 = a[i * 4 + 2], ay2 = a[i * 4 + 3];
+        float g = gradOutput[i * m + j];
+        float gAx1, gAy1, gAx2, gAy2, gBx1, gBy1, gBx2, gBy2;
+        compute_cell_grads_iou(ax1, ay1, ax2, ay2, bx1, by1, bx2, by2, g, variant,
+            &gAx1, &gAy1, &gAx2, &gAy2, &gBx1, &gBy1, &gBx2, &gBy2);
+        sumX1 += gBx1; sumY1 += gBy1; sumX2 += gBx2; sumY2 += gBy2;
+    }
+    gradB[j * 4] = sumX1;
+    gradB[j * 4 + 1] = sumY1;
+    gradB[j * 4 + 2] = sumX2;
+    gradB[j * 4 + 3] = sumY2;
+}
+";
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipGeometryKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipGeometryKernels.cs
@@ -58,14 +58,13 @@ __device__ __forceinline__ int reflect_index(int i, int extent)
 
 __device__ __forceinline__ int pad_boundary(int idx, int extent, int mode)
 {
-    // mode: 1=reflect, 2=replicate, 3=circular
+    if (extent <= 0) return 0;
     if (mode == 2) {
         if (idx < 0) return 0;
         if (idx >= extent) return extent - 1;
         return idx;
     }
     if (mode == 1) return reflect_index(idx, extent);
-    // Circular
     int r = ((idx % extent) + extent) % extent;
     return r;
 }
@@ -143,7 +142,7 @@ extern ""C"" __global__ __launch_bounds__(256) void geometry_interpolate_2d(
             acc += wy[yy] * rowAcc;
         }
         output[gid] = (float)acc;
-    } else {  // Area (mode == 5)
+    } else {  // Area (mode == 5) — overlap-weighted averaging
         double yLo = (double)y * Hin / Hout;
         double yHi = (double)(y + 1) * Hin / Hout;
         double xLo = (double)x * Win / Wout;
@@ -154,15 +153,18 @@ extern ""C"" __global__ __launch_bounds__(256) void geometry_interpolate_2d(
         if (xH <= xL) xH = xL + 1;
         if (yH > Hin) yH = Hin;
         if (xH > Win) xH = Win;
+        double totalArea = (yHi - yLo) * (xHi - xLo);
         double acc = 0.0;
-        int count = 0;
         for (int yy = yL; yy < yH; yy++) {
+            double oy = fmax(0.0, fmin(yHi, (double)(yy + 1)) - fmax(yLo, (double)yy));
+            if (oy <= 0.0) continue;
             for (int xx = xL; xx < xH; xx++) {
-                acc += src[yy * Win + xx];
-                count++;
+                double ox = fmax(0.0, fmin(xHi, (double)(xx + 1)) - fmax(xLo, (double)xx));
+                if (ox <= 0.0) continue;
+                acc += oy * ox * src[yy * Win + xx];
             }
         }
-        output[gid] = (float)(count > 0 ? acc / count : 0.0);
+        output[gid] = (float)(totalArea > 0.0 ? acc / totalArea : 0.0);
     }
 }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipGeometryKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipGeometryKernels.cs
@@ -1,0 +1,326 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// HIP kernels for the geometry / sampling ops added by Issue #217.
+// Covers Interpolate (nearest/bilinear/area/bicubic on 4D NCHW),
+// Pad (4 modes on 4D NCHW), GridSample (bilinear/nearest/bicubic with
+// zeros/border/reflection padding on 4D NHWC), and AffineGrid3D.
+// Non-float tensors and rank ≠ 4 inputs fall back to CpuEngine.
+//
+// Mode ints map onto the InterpolateMode / PadMode / GridSampleMode /
+// GridSamplePadding enums in the managed layer:
+//   InterpolateMode: 0=Nearest 1=Linear 2=Bilinear 3=Bicubic 4=Trilinear 5=Area
+//   PadMode:         0=Constant 1=Reflect 2=Replicate 3=Circular
+//   GridSampleMode:  0=Bilinear 1=Nearest 2=Bicubic
+//   GridSamplePadding: 0=Zeros 1=Border 2=Reflection
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.HIP.Kernels
+{
+    public static class HipGeometryKernels
+    {
+        public static string[] GetKernelNames() => new[]
+        {
+            "geometry_interpolate_2d",
+            "geometry_pad_4d",
+            "geometry_grid_sample_2d",
+            "geometry_affine_grid_3d",
+        };
+
+        public static string GetSource() => @"
+#include <math.h>
+
+// ----------------------------------------------------------------------------
+// Shared device helpers.
+// ----------------------------------------------------------------------------
+
+__device__ __forceinline__ double source_coord(int dstIdx, int dstSize, int srcSize, int alignCorners)
+{
+    if (dstSize <= 1) return 0.0;
+    if (alignCorners) return (double)dstIdx * (srcSize - 1) / (dstSize - 1);
+    return ((double)dstIdx + 0.5) * srcSize / dstSize - 0.5;
+}
+
+__device__ __forceinline__ double cubic_kernel(double d, double a)
+{
+    double ad = fabs(d);
+    if (ad < 1.0) return ((a + 2.0) * ad - (a + 3.0)) * ad * ad + 1.0;
+    if (ad < 2.0) return a * ((ad - 5.0) * ad + 8.0) * ad - 4.0 * a;
+    return 0.0;
+}
+
+__device__ __forceinline__ int clamp_i(int v, int lo, int hi) { return v < lo ? lo : (v > hi ? hi : v); }
+
+__device__ __forceinline__ int reflect_index(int i, int extent)
+{
+    if (extent == 1) return 0;
+    int period = 2 * (extent - 1);
+    int r = ((i % period) + period) % period;
+    return r < extent ? r : period - r;
+}
+
+__device__ __forceinline__ int pad_boundary(int idx, int extent, int mode)
+{
+    // mode: 1=reflect, 2=replicate, 3=circular
+    if (mode == 2) {
+        if (idx < 0) return 0;
+        if (idx >= extent) return extent - 1;
+        return idx;
+    }
+    if (mode == 1) return reflect_index(idx, extent);
+    // Circular
+    int r = ((idx % extent) + extent) % extent;
+    return r;
+}
+
+// ----------------------------------------------------------------------------
+// Interpolate 2D — NCHW, modes: 0=nearest, 2=bilinear, 3=bicubic, 5=area.
+// One thread per output (n, c, y, x).
+// ----------------------------------------------------------------------------
+
+extern ""C"" __global__ __launch_bounds__(256) void geometry_interpolate_2d(
+    const float* __restrict__ input, float* __restrict__ output,
+    int N, int C, int Hin, int Win, int Hout, int Wout,
+    int mode, int alignCorners)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = N * C * Hout * Wout;
+    if (gid >= total) return;
+    int x = gid % Wout;
+    int tmp = gid / Wout;
+    int y = tmp % Hout;
+    tmp /= Hout;
+    int c = tmp % C;
+    int n = tmp / C;
+
+    const float* src = input + ((n * C + c) * Hin) * Win;
+
+    if (mode == 0) {  // Nearest
+        double sy = Hout > 1 ? (double)y * Hin / Hout : 0.0;
+        double sx = Wout > 1 ? (double)x * Win / Wout : 0.0;
+        int yi = (int)floor(sy); if (yi >= Hin) yi = Hin - 1;
+        int xi = (int)floor(sx); if (xi >= Win) xi = Win - 1;
+        output[gid] = src[yi * Win + xi];
+    } else if (mode == 2) {  // Bilinear
+        double sy = source_coord(y, Hout, Hin, alignCorners);
+        double sx = source_coord(x, Wout, Win, alignCorners);
+        int y0 = (int)floor(sy); int x0 = (int)floor(sx);
+        if (y0 < 0) y0 = 0; if (x0 < 0) x0 = 0;
+        int y1 = y0 + 1; int x1 = x0 + 1;
+        if (y1 >= Hin) { y1 = Hin - 1; if (y0 > y1) y0 = y1; }
+        if (x1 >= Win) { x1 = Win - 1; if (x0 > x1) x0 = x1; }
+        double fy = sy - y0; if (fy < 0) fy = 0; if (fy > 1) fy = 1;
+        double fx = sx - x0; if (fx < 0) fx = 0; if (fx > 1) fx = 1;
+        double v00 = src[y0 * Win + x0];
+        double v01 = src[y0 * Win + x1];
+        double v10 = src[y1 * Win + x0];
+        double v11 = src[y1 * Win + x1];
+        double v = v00 * (1 - fx) * (1 - fy) + v01 * fx * (1 - fy)
+                 + v10 * (1 - fx) * fy + v11 * fx * fy;
+        output[gid] = (float)v;
+    } else if (mode == 3) {  // Bicubic (Catmull-Rom, a = -0.75)
+        double sy = source_coord(y, Hout, Hin, alignCorners);
+        double sx = source_coord(x, Wout, Win, alignCorners);
+        int y0 = (int)floor(sy); double ty = sy - y0;
+        int x0 = (int)floor(sx); double tx = sx - x0;
+        double wy[4] = {
+            cubic_kernel(1.0 + ty, -0.75),
+            cubic_kernel(ty, -0.75),
+            cubic_kernel(1.0 - ty, -0.75),
+            cubic_kernel(2.0 - ty, -0.75),
+        };
+        double wx[4] = {
+            cubic_kernel(1.0 + tx, -0.75),
+            cubic_kernel(tx, -0.75),
+            cubic_kernel(1.0 - tx, -0.75),
+            cubic_kernel(2.0 - tx, -0.75),
+        };
+        double acc = 0.0;
+        for (int yy = 0; yy < 4; yy++) {
+            int yi = clamp_i(y0 - 1 + yy, 0, Hin - 1);
+            double rowAcc = 0.0;
+            for (int xx = 0; xx < 4; xx++) {
+                int xi = clamp_i(x0 - 1 + xx, 0, Win - 1);
+                rowAcc += wx[xx] * src[yi * Win + xi];
+            }
+            acc += wy[yy] * rowAcc;
+        }
+        output[gid] = (float)acc;
+    } else {  // Area (mode == 5)
+        double yLo = (double)y * Hin / Hout;
+        double yHi = (double)(y + 1) * Hin / Hout;
+        double xLo = (double)x * Win / Wout;
+        double xHi = (double)(x + 1) * Win / Wout;
+        int yL = (int)floor(yLo); int yH = (int)ceil(yHi);
+        int xL = (int)floor(xLo); int xH = (int)ceil(xHi);
+        if (yH <= yL) yH = yL + 1;
+        if (xH <= xL) xH = xL + 1;
+        if (yH > Hin) yH = Hin;
+        if (xH > Win) xH = Win;
+        double acc = 0.0;
+        int count = 0;
+        for (int yy = yL; yy < yH; yy++) {
+            for (int xx = xL; xx < xH; xx++) {
+                acc += src[yy * Win + xx];
+                count++;
+            }
+        }
+        output[gid] = (float)(count > 0 ? acc / count : 0.0);
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Pad 4D — NCHW, modes: 0=constant, 1=reflect, 2=replicate, 3=circular.
+// One thread per output element (n, c, h, w).
+// ----------------------------------------------------------------------------
+
+extern ""C"" __global__ __launch_bounds__(256) void geometry_pad_4d(
+    const float* __restrict__ input, float* __restrict__ output,
+    int N, int C, int Hin, int Win,
+    int padN0, int padN1, int padC0, int padC1,
+    int padH0, int padH1, int padW0, int padW1,
+    int mode, float padValue)
+{
+    int Nout = N + padN0 + padN1;
+    int Cout = C + padC0 + padC1;
+    int Hout = Hin + padH0 + padH1;
+    int Wout = Win + padW0 + padW1;
+    int total = Nout * Cout * Hout * Wout;
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (gid >= total) return;
+
+    int w = gid % Wout; int t1 = gid / Wout;
+    int h = t1 % Hout; int t2 = t1 / Hout;
+    int c = t2 % Cout; int n = t2 / Cout;
+
+    int nn = n - padN0, cc = c - padC0, hh = h - padH0, ww = w - padW0;
+
+    bool inB = nn >= 0 && nn < N && cc >= 0 && cc < C && hh >= 0 && hh < Hin && ww >= 0 && ww < Win;
+    if (!inB && mode == 0) { output[gid] = padValue; return; }
+
+    if (!inB) {
+        if (!(nn >= 0 && nn < N)) nn = pad_boundary(nn, N, mode);
+        if (!(cc >= 0 && cc < C)) cc = pad_boundary(cc, C, mode);
+        if (!(hh >= 0 && hh < Hin)) hh = pad_boundary(hh, Hin, mode);
+        if (!(ww >= 0 && ww < Win)) ww = pad_boundary(ww, Win, mode);
+    }
+    output[gid] = input[((nn * C + cc) * Hin + hh) * Win + ww];
+}
+
+// ----------------------------------------------------------------------------
+// GridSample 2D — NHWC, modes: 0=bilinear, 1=nearest, 2=bicubic.
+// padding: 0=zeros, 1=border, 2=reflection.
+// One thread per output (n, oy, ox, c) — but we loop C in-thread to
+// amortise grid-lookup work.
+// ----------------------------------------------------------------------------
+
+__device__ __forceinline__ float grid_sample_safe(const float* __restrict__ src,
+    int n, int y, int x, int c,
+    int H, int W, int C, int padding)
+{
+    if (padding == 0) {
+        if ((unsigned)y >= (unsigned)H || (unsigned)x >= (unsigned)W) return 0.0f;
+    } else if (padding == 1) {
+        y = clamp_i(y, 0, H - 1);
+        x = clamp_i(x, 0, W - 1);
+    } else {
+        y = reflect_index(y, H);
+        x = reflect_index(x, W);
+    }
+    return src[((n * H + y) * W + x) * C + c];
+}
+
+extern ""C"" __global__ __launch_bounds__(256) void geometry_grid_sample_2d(
+    const float* __restrict__ input, const float* __restrict__ grid,
+    float* __restrict__ output,
+    int N, int H, int W, int C, int outH, int outW,
+    int mode, int padding, int alignCorners)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = N * outH * outW;
+    if (gid >= total) return;
+    int ox = gid % outW; int t1 = gid / outW;
+    int oy = t1 % outH; int n = t1 / outH;
+
+    int gOff = ((n * outH + oy) * outW + ox) * 2;
+    double gx = grid[gOff];
+    double gy = grid[gOff + 1];
+    double sx = alignCorners ? (gx + 1.0) * 0.5 * (W - 1) : ((gx + 1.0) * W - 1.0) * 0.5;
+    double sy = alignCorners ? (gy + 1.0) * 0.5 * (H - 1) : ((gy + 1.0) * H - 1.0) * 0.5;
+
+    if (mode == 1) {  // Nearest
+        int nx = (int)lrint(sx), ny = (int)lrint(sy);
+        for (int c = 0; c < C; c++)
+            output[((n * outH + oy) * outW + ox) * C + c] =
+                grid_sample_safe(input, n, ny, nx, c, H, W, C, padding);
+    } else if (mode == 0) {  // Bilinear
+        int x0 = (int)floor(sx), y0 = (int)floor(sy);
+        int x1 = x0 + 1, y1 = y0 + 1;
+        double fx = sx - x0, fy = sy - y0;
+        for (int c = 0; c < C; c++) {
+            float v00 = grid_sample_safe(input, n, y0, x0, c, H, W, C, padding);
+            float v01 = grid_sample_safe(input, n, y0, x1, c, H, W, C, padding);
+            float v10 = grid_sample_safe(input, n, y1, x0, c, H, W, C, padding);
+            float v11 = grid_sample_safe(input, n, y1, x1, c, H, W, C, padding);
+            double v = v00 * (1 - fx) * (1 - fy) + v01 * fx * (1 - fy)
+                     + v10 * (1 - fx) * fy + v11 * fx * fy;
+            output[((n * outH + oy) * outW + ox) * C + c] = (float)v;
+        }
+    } else {  // Bicubic
+        int x0 = (int)floor(sx), y0 = (int)floor(sy);
+        double fx = sx - x0, fy = sy - y0;
+        double wy[4] = { cubic_kernel(1.0 + fy, -0.75), cubic_kernel(fy, -0.75),
+                         cubic_kernel(1.0 - fy, -0.75), cubic_kernel(2.0 - fy, -0.75) };
+        double wx[4] = { cubic_kernel(1.0 + fx, -0.75), cubic_kernel(fx, -0.75),
+                         cubic_kernel(1.0 - fx, -0.75), cubic_kernel(2.0 - fx, -0.75) };
+        for (int c = 0; c < C; c++) {
+            double acc = 0.0;
+            for (int yy = 0; yy < 4; yy++) {
+                int yi = y0 - 1 + yy;
+                double rowAcc = 0.0;
+                for (int xx = 0; xx < 4; xx++) {
+                    int xi = x0 - 1 + xx;
+                    rowAcc += wx[xx] * grid_sample_safe(input, n, yi, xi, c, H, W, C, padding);
+                }
+                acc += wy[yy] * rowAcc;
+            }
+            output[((n * outH + oy) * outW + ox) * C + c] = (float)acc;
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------
+// AffineGrid 3D — theta [N, 3, 4] → grid [N, D, H, W, 3].
+// One thread per output (n, d, h, w).
+// ----------------------------------------------------------------------------
+
+__device__ __forceinline__ double grid_norm_coord(int idx, int size, int alignCorners)
+{
+    if (size <= 1) return 0.0;
+    return alignCorners ? -1.0 + 2.0 * idx / (size - 1) : -1.0 + (2.0 * idx + 1.0) / size;
+}
+
+extern ""C"" __global__ __launch_bounds__(256) void geometry_affine_grid_3d(
+    const float* __restrict__ theta, float* __restrict__ grid,
+    int N, int D, int H, int W, int alignCorners)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = N * D * H * W;
+    if (gid >= total) return;
+    int w = gid % W; int t1 = gid / W;
+    int h = t1 % H; int t2 = t1 / H;
+    int d = t2 % D; int n = t2 / D;
+
+    int tBase = n * 12;
+    double x = grid_norm_coord(w, W, alignCorners);
+    double y = grid_norm_coord(h, H, alignCorners);
+    double z = grid_norm_coord(d, D, alignCorners);
+    int gBase = (((n * D + d) * H + h) * W + w) * 3;
+    for (int row = 0; row < 3; row++) {
+        double v = theta[tBase + row * 4] * x
+                 + theta[tBase + row * 4 + 1] * y
+                 + theta[tBase + row * 4 + 2] * z
+                 + theta[tBase + row * 4 + 3];
+        grid[gBase + row] = (float)v;
+    }
+}
+";
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipRoiKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipRoiKernels.cs
@@ -163,6 +163,7 @@ extern ""C"" __global__ __launch_bounds__(256) void ps_roi_align(
     if (rx < 1) rx = 1;
 
     int c = (co * outH + ph) * outW + pw;
+    if (c >= C) { output[gid] = 0.0f; return; }
     int planeBase = (n * C + c) * H * W;
     float acc = 0;
     for (int iy = 0; iy < ry; iy++) {
@@ -198,6 +199,7 @@ extern ""C"" __global__ __launch_bounds__(256) void ps_roi_pool(
     float binW = fmaxf(x2 - x1, 0.1f) / outW;
 
     int c = (co * outH + ph) * outW + pw;
+    if (c >= C) { output[gid] = 0.0f; return; }
     int planeBase = (n * C + c) * H * W;
     int hs = (int)fmaxf(0.0f, floorf(y1 + ph * binH));
     int he = (int)fminf((float)H, ceilf(y1 + (ph + 1) * binH));

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipRoiKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipRoiKernels.cs
@@ -1,5 +1,5 @@
 // Copyright (c) AiDotNet. All rights reserved.
-// HIP kernels for the RoI family (torchvision roi_align / roi_pool) —
+// CUDA kernels for the RoI family (torchvision roi_align / roi_pool) —
 // tail of Issue #217. One thread per output element.
 namespace AiDotNet.Tensors.Engines.DirectGpu.HIP.Kernels
 {
@@ -9,6 +9,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.HIP.Kernels
         {
             "roi_align",
             "roi_pool",
+            "ps_roi_align",
+            "ps_roi_pool",
         };
 
         public static string GetSource() => @"
@@ -123,6 +125,91 @@ extern ""C"" __global__ __launch_bounds__(256) void roi_pool(
             if (v > best) best = v;
         }
     output[gid] = best;
+}
+
+// ----------------------------------------------------------------------------
+// Position-sensitive RoIAlign / RoIPool (R-FCN). Input channel layout:
+//   C = outputChannels * outH * outW. Per output (k, co, ph, pw), pull
+//   from channel c = (co * outH + ph) * outW + pw.
+// ----------------------------------------------------------------------------
+
+extern ""C"" __global__ __launch_bounds__(256) void ps_roi_align(
+    const float* __restrict__ input, const float* __restrict__ boxes,
+    float* __restrict__ output,
+    int N, int C, int H, int W, int K,
+    int outH, int outW, int outputChannels,
+    float spatialScale, int samplingRatio)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = K * outputChannels * outH * outW;
+    if (gid >= total) return;
+    int pw = gid % outW; int t1 = gid / outW;
+    int ph = t1 % outH; int t2 = t1 / outH;
+    int co = t2 % outputChannels; int k = t2 / outputChannels;
+
+    int n = (int)boxes[k * 5];
+    if (n < 0 || n >= N) { output[gid] = 0.0f; return; }
+    float x1 = boxes[k * 5 + 1] * spatialScale;
+    float y1 = boxes[k * 5 + 2] * spatialScale;
+    float x2 = boxes[k * 5 + 3] * spatialScale;
+    float y2 = boxes[k * 5 + 4] * spatialScale;
+    float roiW = fmaxf(x2 - x1, 0.1f);
+    float roiH = fmaxf(y2 - y1, 0.1f);
+    float binH = roiH / outH;
+    float binW = roiW / outW;
+    int ry = samplingRatio > 0 ? samplingRatio : (int)ceilf(roiH / outH);
+    int rx = samplingRatio > 0 ? samplingRatio : (int)ceilf(roiW / outW);
+    if (ry < 1) ry = 1;
+    if (rx < 1) rx = 1;
+
+    int c = (co * outH + ph) * outW + pw;
+    int planeBase = (n * C + c) * H * W;
+    float acc = 0;
+    for (int iy = 0; iy < ry; iy++) {
+        float sy = y1 + ph * binH + (iy + 0.5f) * binH / ry;
+        for (int ix = 0; ix < rx; ix++) {
+            float sx = x1 + pw * binW + (ix + 0.5f) * binW / rx;
+            acc += bilinear_sample(input, planeBase, sy, sx, H, W);
+        }
+    }
+    output[gid] = acc / (ry * rx);
+}
+
+extern ""C"" __global__ __launch_bounds__(256) void ps_roi_pool(
+    const float* __restrict__ input, const float* __restrict__ boxes,
+    float* __restrict__ output,
+    int N, int C, int H, int W, int K,
+    int outH, int outW, int outputChannels, float spatialScale)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = K * outputChannels * outH * outW;
+    if (gid >= total) return;
+    int pw = gid % outW; int t1 = gid / outW;
+    int ph = t1 % outH; int t2 = t1 / outH;
+    int co = t2 % outputChannels; int k = t2 / outputChannels;
+
+    int n = (int)boxes[k * 5];
+    if (n < 0 || n >= N) { output[gid] = 0.0f; return; }
+    float x1 = boxes[k * 5 + 1] * spatialScale;
+    float y1 = boxes[k * 5 + 2] * spatialScale;
+    float x2 = boxes[k * 5 + 3] * spatialScale;
+    float y2 = boxes[k * 5 + 4] * spatialScale;
+    float binH = fmaxf(y2 - y1, 0.1f) / outH;
+    float binW = fmaxf(x2 - x1, 0.1f) / outW;
+
+    int c = (co * outH + ph) * outW + pw;
+    int planeBase = (n * C + c) * H * W;
+    int hs = (int)fmaxf(0.0f, floorf(y1 + ph * binH));
+    int he = (int)fminf((float)H, ceilf(y1 + (ph + 1) * binH));
+    int ws = (int)fmaxf(0.0f, floorf(x1 + pw * binW));
+    int we = (int)fminf((float)W, ceilf(x1 + (pw + 1) * binW));
+    float acc = 0; int cnt = 0;
+    for (int yy = hs; yy < he; yy++)
+        for (int xx = ws; xx < we; xx++) {
+            acc += input[planeBase + yy * W + xx];
+            cnt++;
+        }
+    output[gid] = cnt > 0 ? acc / cnt : 0.0f;
 }
 ";
     }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipRoiKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipRoiKernels.cs
@@ -1,0 +1,129 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// HIP kernels for the RoI family (torchvision roi_align / roi_pool) —
+// tail of Issue #217. One thread per output element.
+namespace AiDotNet.Tensors.Engines.DirectGpu.HIP.Kernels
+{
+    public static class HipRoiKernels
+    {
+        public static string[] GetKernelNames() => new[]
+        {
+            "roi_align",
+            "roi_pool",
+        };
+
+        public static string GetSource() => @"
+#include <math.h>
+#include <float.h>
+
+__device__ __forceinline__ float bilinear_sample(
+    const float* __restrict__ src, int planeBase,
+    float y, float x, int H, int W)
+{
+    if (y < -1.0f || y > (float)H || x < -1.0f || x > (float)W) return 0.0f;
+    if (y <= 0) y = 0;
+    if (x <= 0) x = 0;
+    int y0 = (int)y;
+    int x0 = (int)x;
+    int y1 = y0 + 1 >= H ? H - 1 : y0 + 1;
+    int x1 = x0 + 1 >= W ? W - 1 : x0 + 1;
+    if (y0 >= H - 1) { y0 = y1 = H - 1; y = (float)y0; }
+    if (x0 >= W - 1) { x0 = x1 = W - 1; x = (float)x0; }
+    float ly = y - y0, lx = x - x0;
+    float hy = 1.0f - ly, hx = 1.0f - lx;
+    float v00 = src[planeBase + y0 * W + x0];
+    float v01 = src[planeBase + y0 * W + x1];
+    float v10 = src[planeBase + y1 * W + x0];
+    float v11 = src[planeBase + y1 * W + x1];
+    return hy * hx * v00 + hy * lx * v01 + ly * hx * v10 + ly * lx * v11;
+}
+
+extern ""C"" __global__ __launch_bounds__(256) void roi_align(
+    const float* __restrict__ input, const float* __restrict__ boxes,
+    float* __restrict__ output,
+    int N, int C, int H, int W, int K,
+    int outH, int outW,
+    float spatialScale, int samplingRatio, int aligned)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = K * C * outH * outW;
+    if (gid >= total) return;
+    int pw = gid % outW; int t1 = gid / outW;
+    int ph = t1 % outH; int t2 = t1 / outH;
+    int c = t2 % C; int k = t2 / C;
+
+    int n = (int)boxes[k * 5];
+    if (n < 0 || n >= N) { output[gid] = 0.0f; return; }
+    float offset = aligned ? 0.5f : 0.0f;
+    float x1 = boxes[k * 5 + 1] * spatialScale - offset;
+    float y1 = boxes[k * 5 + 2] * spatialScale - offset;
+    float x2 = boxes[k * 5 + 3] * spatialScale - offset;
+    float y2 = boxes[k * 5 + 4] * spatialScale - offset;
+    float roiW = aligned ? (x2 - x1) : fmaxf(x2 - x1, 1.0f);
+    float roiH = aligned ? (y2 - y1) : fmaxf(y2 - y1, 1.0f);
+    float binH = roiH / outH;
+    float binW = roiW / outW;
+
+    int ry = samplingRatio > 0 ? samplingRatio : (int)ceilf(roiH / outH);
+    int rx = samplingRatio > 0 ? samplingRatio : (int)ceilf(roiW / outW);
+    if (ry < 1) ry = 1;
+    if (rx < 1) rx = 1;
+
+    int planeBase = (n * C + c) * H * W;
+    float acc = 0;
+    for (int iy = 0; iy < ry; iy++) {
+        float sy = y1 + ph * binH + (iy + 0.5f) * binH / ry;
+        for (int ix = 0; ix < rx; ix++) {
+            float sx = x1 + pw * binW + (ix + 0.5f) * binW / rx;
+            acc += bilinear_sample(input, planeBase, sy, sx, H, W);
+        }
+    }
+    output[gid] = acc / (ry * rx);
+}
+
+extern ""C"" __global__ __launch_bounds__(256) void roi_pool(
+    const float* __restrict__ input, const float* __restrict__ boxes,
+    float* __restrict__ output,
+    int N, int C, int H, int W, int K,
+    int outH, int outW, float spatialScale)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = K * C * outH * outW;
+    if (gid >= total) return;
+    int pw = gid % outW; int t1 = gid / outW;
+    int ph = t1 % outH; int t2 = t1 / outH;
+    int c = t2 % C; int k = t2 / C;
+
+    int n = (int)boxes[k * 5];
+    if (n < 0 || n >= N) { output[gid] = 0.0f; return; }
+    int x1 = (int)roundf(boxes[k * 5 + 1] * spatialScale);
+    int y1 = (int)roundf(boxes[k * 5 + 2] * spatialScale);
+    int x2 = (int)roundf(boxes[k * 5 + 3] * spatialScale);
+    int y2 = (int)roundf(boxes[k * 5 + 4] * spatialScale);
+    int roiW = x2 - x1 + 1; if (roiW < 1) roiW = 1;
+    int roiH = y2 - y1 + 1; if (roiH < 1) roiH = 1;
+    float binH = (float)roiH / outH;
+    float binW = (float)roiW / outW;
+
+    int hstart = (int)floorf(ph * binH) + y1;
+    int hend = (int)ceilf((ph + 1) * binH) + y1;
+    int wstart = (int)floorf(pw * binW) + x1;
+    int wend = (int)ceilf((pw + 1) * binW) + x1;
+    if (hstart < 0) hstart = 0; if (hstart > H) hstart = H;
+    if (hend < 0) hend = 0; if (hend > H) hend = H;
+    if (wstart < 0) wstart = 0; if (wstart > W) wstart = W;
+    if (wend < 0) wend = 0; if (wend > W) wend = W;
+
+    int planeBase = (n * C + c) * H * W;
+    bool empty = hend <= hstart || wend <= wstart;
+    if (empty) { output[gid] = 0.0f; return; }
+    float best = -FLT_MAX;
+    for (int yy = hstart; yy < hend; yy++)
+        for (int xx = wstart; xx < wend; xx++) {
+            float v = input[planeBase + yy * W + xx];
+            if (v > best) best = v;
+        }
+    output[gid] = best;
+}
+";
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipRoiKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipRoiKernels.cs
@@ -21,6 +21,7 @@ __device__ __forceinline__ float bilinear_sample(
     const float* __restrict__ src, int planeBase,
     float y, float x, int H, int W)
 {
+    if (H <= 0 || W <= 0) return 0.0f;
     if (y < -1.0f || y > (float)H || x < -1.0f || x > (float)W) return 0.0f;
     if (y <= 0) y = 0;
     if (x <= 0) x = 0;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/IAudioBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/IAudioBackend.cs
@@ -1,0 +1,28 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Native GPU kernels for the audio primitives in Issue #217 tail. Ops
+// that compose existing GPU-accelerated STFT (Spectrogram, PitchShift,
+// TimeStretch) stay in managed code and don't live on this interface.
+namespace AiDotNet.Tensors.Engines.DirectGpu
+{
+    public interface IAudioBackend
+    {
+        /// <summary>Element-wise 20·log10(max(x, minAmp)); optional topDb floor.</summary>
+        void AmplitudeToDB(IGpuBuffer input, IGpuBuffer output, int length, float minAmplitude, float topDb, bool clipTopDb);
+
+        /// <summary>μ-law companding encoder (torchaudio's MuLawEncoding).</summary>
+        void MuLawEncoding(IGpuBuffer input, IGpuBuffer output, int length, int quantizationChannels);
+
+        /// <summary>μ-law companding decoder.</summary>
+        void MuLawDecoding(IGpuBuffer input, IGpuBuffer output, int length, int quantizationChannels);
+
+        /// <summary>Time-axis derivative for audio features. <c>input</c>
+        /// is laid out as <c>[leading, T]</c> row-major with <c>T</c> =
+        /// audio time axis.</summary>
+        void ComputeDeltas(IGpuBuffer input, IGpuBuffer output, int leading, int timeAxis, int winLength);
+
+        /// <summary>Polyphase resampler (Hann-windowed sinc). Same layout
+        /// convention as <see cref="ComputeDeltas"/>.</summary>
+        void Resample(IGpuBuffer input, IGpuBuffer output,
+            int leading, int inLen, int outLen, int up, int down, int halfWidth);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/IDetectionBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/IDetectionBackend.cs
@@ -1,0 +1,78 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Secondary interface for backends that ship native vision-detection
+// kernels (BoxIoU family, BoxArea, BoxConvert, MasksToBoxes).
+// DirectGpuTensorEngine type-tests against this interface when
+// dispatching; backends that don't implement it transparently fall
+// through to the CpuEngine path via inheritance.
+
+namespace AiDotNet.Tensors.Engines.DirectGpu
+{
+    /// <summary>
+    /// Optional capability interface for GPU backends that ship native
+    /// kernels for the vision detection ops added by Issue #217.
+    /// </summary>
+    /// <remarks>
+    /// Each method takes raw <see cref="IGpuBuffer"/> handles so callers
+    /// (typically <see cref="DirectGpuTensorEngine"/>) can plumb their own
+    /// activation cache and uploads. Output buffers are caller-allocated.
+    /// All box buffers carry float[..., 4] data in <see cref="BoxFormat.XYXY"/>.
+    /// </remarks>
+    public interface IDetectionBackend
+    {
+        /// <summary>
+        /// Pairwise IoU between two box sets.
+        /// <para><c>boxesA</c> = N×4, <c>boxesB</c> = M×4, <c>output</c> = N×M.</para>
+        /// </summary>
+        void BoxIou(IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m);
+
+        /// <summary>
+        /// Pairwise generalized IoU (Rezatofighi 2019). Same shapes as
+        /// <see cref="BoxIou"/>; output in <c>(-1, 1]</c>.
+        /// </summary>
+        void GeneralizedBoxIou(IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m);
+
+        /// <summary>
+        /// Pairwise distance IoU (Zheng 2020). Same shapes as
+        /// <see cref="BoxIou"/>.
+        /// </summary>
+        void DistanceBoxIou(IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m);
+
+        /// <summary>
+        /// Pairwise complete IoU (Zheng 2020) — DIoU plus aspect-ratio
+        /// penalty. Same shapes as <see cref="BoxIou"/>.
+        /// </summary>
+        void CompleteBoxIou(IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m);
+
+        /// <summary>
+        /// Per-box area for a flat box buffer. <c>boxes</c> = N×4 (xyxy);
+        /// <c>output</c> = N. Negative widths/heights clamp to 0 to match
+        /// torchvision's <c>box_area</c>.
+        /// </summary>
+        void BoxArea(IGpuBuffer boxes, IGpuBuffer output, int n);
+
+        /// <summary>
+        /// Box-format conversion. Source and destination encodings are
+        /// identified by integer codes matching <see cref="BoxFormat"/>:
+        /// 0 = XYXY, 1 = XYWH, 2 = CXCYWH. <c>boxes</c> = N×4;
+        /// <c>output</c> = N×4.
+        /// </summary>
+        void BoxConvert(IGpuBuffer boxes, IGpuBuffer output, int n, int fromFormat, int toFormat);
+
+        /// <summary>
+        /// Backward kernel for the pairwise IoU family. One thread per
+        /// (i, j) cell computes its per-coordinate contributions and
+        /// accumulates into <c>gradA</c> / <c>gradB</c> via atomic adds.
+        /// <paramref name="variant"/> is an int code matching the CPU
+        /// enum: 0 = IoU, 1 = GIoU, 2 = DIoU, 3 = CIoU. The CIoU variant
+        /// treats α as stop-gradient (Zheng 2020 / torchvision).
+        /// <para>Shapes: gradOutput = N×M; boxesA = N×4; boxesB = M×4;
+        /// gradA = N×4; gradB = M×4.</para>
+        /// <para>Caller MUST zero <paramref name="gradA"/> and <paramref name="gradB"/>
+        /// before the launch — the kernel only atomically adds.</para>
+        /// </summary>
+        void IouFamilyBackward(
+            IGpuBuffer gradOutput, IGpuBuffer boxesA, IGpuBuffer boxesB,
+            IGpuBuffer gradA, IGpuBuffer gradB,
+            int n, int m, int variant);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/IDetectionBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/IDetectionBackend.cs
@@ -59,16 +59,23 @@ namespace AiDotNet.Tensors.Engines.DirectGpu
         void BoxConvert(IGpuBuffer boxes, IGpuBuffer output, int n, int fromFormat, int toFormat);
 
         /// <summary>
-        /// Backward kernel for the pairwise IoU family. One thread per
-        /// (i, j) cell computes its per-coordinate contributions and
-        /// accumulates into <c>gradA</c> / <c>gradB</c> via atomic adds.
+        /// Backward kernel for the pairwise IoU family. Implemented as
+        /// two independent passes (atomics-free, portable to WebGPU
+        /// which has no <c>atomic&lt;f32&gt;</c>):
+        /// <list type="bullet">
+        ///   <item><c>detection_iou_backward_a</c> — one thread per row
+        ///     of <c>A</c>, iterates <c>j = 0..M</c>, writes the four
+        ///     coord gradients for <c>gradA[i]</c> directly.</item>
+        ///   <item><c>detection_iou_backward_b</c> — symmetric for
+        ///     <c>gradB</c>.</item>
+        /// </list>
         /// <paramref name="variant"/> is an int code matching the CPU
         /// enum: 0 = IoU, 1 = GIoU, 2 = DIoU, 3 = CIoU. The CIoU variant
         /// treats α as stop-gradient (Zheng 2020 / torchvision).
         /// <para>Shapes: gradOutput = N×M; boxesA = N×4; boxesB = M×4;
         /// gradA = N×4; gradB = M×4.</para>
-        /// <para>Caller MUST zero <paramref name="gradA"/> and <paramref name="gradB"/>
-        /// before the launch — the kernel only atomically adds.</para>
+        /// <para>The kernel writes final gradients directly — callers do
+        /// NOT need to pre-zero <paramref name="gradA"/> or <paramref name="gradB"/>.</para>
         /// </summary>
         void IouFamilyBackward(
             IGpuBuffer gradOutput, IGpuBuffer boxesA, IGpuBuffer boxesB,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/IDetectionBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/IDetectionBackend.cs
@@ -4,6 +4,23 @@
 // DirectGpuTensorEngine type-tests against this interface when
 // dispatching; backends that don't implement it transparently fall
 // through to the CpuEngine path via inheritance.
+//
+// ── Architectural note ──────────────────────────────────────────────
+// This file intentionally follows the established repo pattern for
+// optional GPU-side capability surfaces: IParity210Backend,
+// ILinalgBackend, IFftBackend, IGeometryBackend, IRoiBackend, and
+// IAudioBackend all use the same shape. The user-facing Tensor<T>
+// contracts live on IEngine proper — these interfaces carry only the
+// low-level IGpuBuffer-based kernel launchers that are internal
+// plumbing between DirectGpuTensorEngine and a concrete backend, and
+// are not meant to be implemented by engines themselves.
+//
+// Folding them into IEngine would force every engine (CpuEngine, the
+// differentiable wrappers, tracing engines) to expose buffer-level
+// methods they have no use for, and would prevent backends from
+// shipping partial capabilities (e.g. a backend that has detection
+// kernels but hasn't yet built RoI ones). The probe-style optional
+// capability pattern is therefore preserved by design.
 
 namespace AiDotNet.Tensors.Engines.DirectGpu
 {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/IGeometryBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/IGeometryBackend.cs
@@ -1,0 +1,61 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Optional capability interface for backends that ship native kernels for
+// the geometry / sampling ops added by Issue #217 (Interpolate, PadNd,
+// GridSample, AffineGrid3D). DirectGpuTensorEngine type-tests against
+// this and falls through to the CpuEngine reference when absent or when
+// the op requires a shape/mode combination the backend doesn't support.
+
+namespace AiDotNet.Tensors.Engines.DirectGpu
+{
+    /// <summary>
+    /// Native kernels for the geometry / sampling family (Issue #217).
+    /// <para>Signatures are scoped to the most common 4D NCHW / NHWC
+    /// shapes — rank-3 1D and rank-5 3D Interpolate, or rank ≠ 4 PadNd,
+    /// fall through to the CpuEngine reference.</para>
+    /// <para>Mode and padding-mode ints map one-to-one onto
+    /// <see cref="InterpolateMode"/>, <see cref="PadMode"/>,
+    /// <see cref="GridSampleMode"/> and <see cref="GridSamplePadding"/>.</para>
+    /// </summary>
+    public interface IGeometryBackend
+    {
+        /// <summary>
+        /// 2D interpolation on NCHW float tensors. Supports
+        /// nearest / bilinear / area / bicubic (modes 0, 2, 5, 3 per the
+        /// <see cref="InterpolateMode"/> enum order). 1D / 3D variants
+        /// fall through to the CPU reference.
+        /// </summary>
+        /// <param name="input">NCHW float input.</param>
+        /// <param name="output">NCHW float output (caller-allocated).</param>
+        void Interpolate2D(IGpuBuffer input, IGpuBuffer output,
+            int N, int C, int Hin, int Win, int Hout, int Wout,
+            int mode, bool alignCorners);
+
+        /// <summary>
+        /// 4D tensor pad along all four axes simultaneously. Any of the
+        /// four <see cref="PadMode"/> options (constant / reflect /
+        /// replicate / circular). <paramref name="padValue"/> is only
+        /// consulted in constant mode.
+        /// </summary>
+        void Pad4D(IGpuBuffer input, IGpuBuffer output,
+            int N, int C, int Hin, int Win,
+            int padN0, int padN1, int padC0, int padC1,
+            int padH0, int padH1, int padW0, int padW1,
+            int mode, float padValue);
+
+        /// <summary>
+        /// 2D GridSample on NHWC float tensors. Input
+        /// <c>[N, H, W, C]</c>, grid <c>[N, outH, outW, 2]</c>, output
+        /// <c>[N, outH, outW, C]</c>.
+        /// </summary>
+        void GridSample2D(IGpuBuffer input, IGpuBuffer grid, IGpuBuffer output,
+            int N, int H, int W, int C, int outH, int outW,
+            int mode, int padding, bool alignCorners);
+
+        /// <summary>
+        /// 3D affine-grid generator — produces a <c>[N, D, H, W, 3]</c>
+        /// sampling grid from a <c>[N, 3, 4]</c> affine matrix.
+        /// </summary>
+        void AffineGrid3D(IGpuBuffer theta, IGpuBuffer grid,
+            int N, int D, int H, int W, bool alignCorners);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/IRoiBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/IRoiBackend.cs
@@ -11,5 +11,15 @@ namespace AiDotNet.Tensors.Engines.DirectGpu
         void RoIPool(IGpuBuffer input, IGpuBuffer boxes, IGpuBuffer output,
             int N, int C, int H, int W, int K, int outH, int outW,
             float spatialScale);
+
+        /// <summary>Position-sensitive RoIAlign (R-FCN).</summary>
+        void PsRoIAlign(IGpuBuffer input, IGpuBuffer boxes, IGpuBuffer output,
+            int N, int C, int H, int W, int K, int outH, int outW, int outputChannels,
+            float spatialScale, int samplingRatio);
+
+        /// <summary>Position-sensitive RoI-pool (R-FCN).</summary>
+        void PsRoIPool(IGpuBuffer input, IGpuBuffer boxes, IGpuBuffer output,
+            int N, int C, int H, int W, int K, int outH, int outW, int outputChannels,
+            float spatialScale);
     }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/IRoiBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/IRoiBackend.cs
@@ -1,0 +1,15 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Optional backend capability for the RoI family added by Issue #217.
+namespace AiDotNet.Tensors.Engines.DirectGpu
+{
+    public interface IRoiBackend
+    {
+        void RoIAlign(IGpuBuffer input, IGpuBuffer boxes, IGpuBuffer output,
+            int N, int C, int H, int W, int K, int outH, int outW,
+            float spatialScale, int samplingRatio, bool aligned);
+
+        void RoIPool(IGpuBuffer input, IGpuBuffer boxes, IGpuBuffer output,
+            int N, int C, int H, int W, int K, int outH, int outW,
+            float spatialScale);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalAudioKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalAudioKernels.cs
@@ -77,6 +77,7 @@ kernel void audio_compute_deltas(
     int t = (int)gid % timeAxis;
     int row = (int)gid / timeAxis;
     int n = winLength / 2;
+    if (n < 1) { output[gid] = 0.0; return; }
     float denom = 0.0;
     for (int i = 1; i <= n; i++) denom += 2.0 * i * i;
     float acc = 0.0;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalAudioKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalAudioKernels.cs
@@ -38,6 +38,7 @@ kernel void audio_mulaw_encoding(
     uint gid [[thread_position_in_grid]])
 {
     if ((int)gid >= length) return;
+    if (quantizationChannels < 2) { output[gid] = 0.0; return; }
     float mu = float(quantizationChannels - 1);
     float logMu = log(1.0 + mu);
     float x = input[gid];
@@ -57,6 +58,7 @@ kernel void audio_mulaw_decoding(
     uint gid [[thread_position_in_grid]])
 {
     if ((int)gid >= length) return;
+    if (quantizationChannels < 2) { output[gid] = 0.0; return; }
     float mu = float(quantizationChannels - 1);
     float q = input[gid];
     float y = (q / mu) * 2.0 - 1.0;
@@ -103,6 +105,7 @@ kernel void audio_resample(
 {
     int total = leading * outLen;
     if ((int)gid >= total) return;
+    if (halfWidth < 1 || up <= 0 || down <= 0) { output[gid] = 0.0; return; }
     int ot = (int)gid % outLen;
     int row = (int)gid / outLen;
     int sBase = row * inLen;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalAudioKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalAudioKernels.cs
@@ -1,0 +1,127 @@
+// Copyright (c) AiDotNet. All rights reserved.
+namespace AiDotNet.Tensors.Engines.DirectGpu.Metal
+{
+    public static class MetalAudioKernels
+    {
+        public static string[] GetKernelNames() => new[]
+        {
+            "audio_amplitude_to_db", "audio_mulaw_encoding", "audio_mulaw_decoding",
+            "audio_compute_deltas", "audio_resample",
+        };
+
+        public const string Source = @"
+#include <metal_stdlib>
+#include <metal_math>
+using namespace metal;
+
+kernel void audio_amplitude_to_db(
+    device const float* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    constant int& length [[buffer(2)]],
+    constant float& minAmp [[buffer(3)]],
+    constant float& topDbFloor [[buffer(4)]],
+    constant int& clipTopDb [[buffer(5)]],
+    uint gid [[thread_position_in_grid]])
+{
+    if ((int)gid >= length) return;
+    float v = max(input[gid], minAmp);
+    float db = 20.0 * log10(v);
+    if (clipTopDb != 0 && db < topDbFloor) db = topDbFloor;
+    output[gid] = db;
+}
+
+kernel void audio_mulaw_encoding(
+    device const float* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    constant int& length [[buffer(2)]],
+    constant int& quantizationChannels [[buffer(3)]],
+    uint gid [[thread_position_in_grid]])
+{
+    if ((int)gid >= length) return;
+    float mu = float(quantizationChannels - 1);
+    float logMu = log(1.0 + mu);
+    float x = input[gid];
+    if (x > 1.0) x = 1.0; else if (x < -1.0) x = -1.0;
+    float sgn = float(x > 0.0) - float(x < 0.0);
+    float y = sgn * log(1.0 + mu * fabs(x)) / logMu;
+    float q = floor((y + 1.0) * 0.5 * mu + 0.5);
+    if (q < 0.0) q = 0.0; else if (q > mu) q = mu;
+    output[gid] = q;
+}
+
+kernel void audio_mulaw_decoding(
+    device const float* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    constant int& length [[buffer(2)]],
+    constant int& quantizationChannels [[buffer(3)]],
+    uint gid [[thread_position_in_grid]])
+{
+    if ((int)gid >= length) return;
+    float mu = float(quantizationChannels - 1);
+    float q = input[gid];
+    float y = (q / mu) * 2.0 - 1.0;
+    float sgn = float(y > 0.0) - float(y < 0.0);
+    output[gid] = sgn * (pow(1.0 + mu, fabs(y)) - 1.0) / mu;
+}
+
+kernel void audio_compute_deltas(
+    device const float* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    constant int& leading [[buffer(2)]],
+    constant int& timeAxis [[buffer(3)]],
+    constant int& winLength [[buffer(4)]],
+    uint gid [[thread_position_in_grid]])
+{
+    int total = leading * timeAxis;
+    if ((int)gid >= total) return;
+    int t = (int)gid % timeAxis;
+    int row = (int)gid / timeAxis;
+    int n = winLength / 2;
+    float denom = 0.0;
+    for (int i = 1; i <= n; i++) denom += 2.0 * i * i;
+    float acc = 0.0;
+    int base_ = row * timeAxis;
+    for (int k = 1; k <= n; k++) {
+        int left = t - k < 0 ? 0 : t - k;
+        int right = t + k >= timeAxis ? timeAxis - 1 : t + k;
+        acc += k * (input[base_ + right] - input[base_ + left]);
+    }
+    output[gid] = acc / denom;
+}
+
+kernel void audio_resample(
+    device const float* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    constant int& leading [[buffer(2)]],
+    constant int& inLen [[buffer(3)]],
+    constant int& outLen [[buffer(4)]],
+    constant int& up [[buffer(5)]],
+    constant int& down [[buffer(6)]],
+    constant int& halfWidth [[buffer(7)]],
+    uint gid [[thread_position_in_grid]])
+{
+    int total = leading * outLen;
+    if ((int)gid >= total) return;
+    int ot = (int)gid % outLen;
+    int row = (int)gid / outLen;
+    int sBase = row * inLen;
+    float cutoff = 1.0 / float(up > down ? up : down);
+    float srcIdx = float(ot) * down / up;
+    int centre = int(floor(srcIdx));
+    float acc = 0.0, wSum = 0.0;
+    const float PI = 3.14159265358979323846;
+    for (int k = -halfWidth; k <= halfWidth; k++) {
+        int idx = centre + k;
+        if (idx < 0 || idx >= inLen) continue;
+        float tt = (idx - srcIdx) * cutoff;
+        float sinc = fabs(tt) < 1e-12f ? 1.0 : sin(PI * tt) / (PI * tt);
+        float hann = 0.5 - 0.5 * cos(2.0 * PI * float(k + halfWidth) / float(2 * halfWidth));
+        float w = sinc * hann;
+        acc += w * input[sBase + idx];
+        wSum += w;
+    }
+    output[gid] = wSum > 0.0 ? acc / wSum : 0.0;
+}
+";
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Audio.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Audio.cs
@@ -1,0 +1,95 @@
+// Copyright (c) AiDotNet. All rights reserved.
+namespace AiDotNet.Tensors.Engines.DirectGpu.Metal;
+
+public sealed partial class MetalBackend : IAudioBackend
+{
+    private const string AudioLibName = "Audio";
+    private MetalPipelineState GetAudioPipeline(string n)
+    {
+        if (_audioLibrary == IntPtr.Zero)
+            throw new InvalidOperationException("Metal Audio library was not compiled.");
+        return GetPipeline(AudioLibName, _audioLibrary, n);
+    }
+
+    public void AmplitudeToDB(IGpuBuffer input, IGpuBuffer output, int length,
+        float minAmplitude, float topDb, bool clipTopDb)
+    {
+        if (length <= 0) return;
+        ThrowIfDisposed();
+        if (input is not MetalGpuBuffer inBuf || output is not MetalGpuBuffer oBuf)
+            throw new ArgumentException("Buffers must be MetalGpuBuffer");
+        var pipe = GetAudioPipeline("audio_amplitude_to_db");
+        var (tgr, tpg) = pipe.Calculate1DDispatch(length);
+        using var enc = _commandQueue.CreateScopedComputeEncoder();
+        enc.SetPipelineState(pipe.Handle);
+        enc.SetBuffer(inBuf, 0); enc.SetBuffer(oBuf, 1);
+        enc.SetBytes(length, 2); enc.SetBytes(minAmplitude, 3);
+        enc.SetBytes(topDb, 4); enc.SetBytes(clipTopDb ? 1 : 0, 5);
+        enc.DispatchThreadgroups(tgr, tpg);
+    }
+
+    public void MuLawEncoding(IGpuBuffer input, IGpuBuffer output, int length, int qc)
+    {
+        if (length <= 0) return;
+        ThrowIfDisposed();
+        if (input is not MetalGpuBuffer inBuf || output is not MetalGpuBuffer oBuf)
+            throw new ArgumentException("Buffers must be MetalGpuBuffer");
+        var pipe = GetAudioPipeline("audio_mulaw_encoding");
+        var (tgr, tpg) = pipe.Calculate1DDispatch(length);
+        using var enc = _commandQueue.CreateScopedComputeEncoder();
+        enc.SetPipelineState(pipe.Handle);
+        enc.SetBuffer(inBuf, 0); enc.SetBuffer(oBuf, 1);
+        enc.SetBytes(length, 2); enc.SetBytes(qc, 3);
+        enc.DispatchThreadgroups(tgr, tpg);
+    }
+
+    public void MuLawDecoding(IGpuBuffer input, IGpuBuffer output, int length, int qc)
+    {
+        if (length <= 0) return;
+        ThrowIfDisposed();
+        if (input is not MetalGpuBuffer inBuf || output is not MetalGpuBuffer oBuf)
+            throw new ArgumentException("Buffers must be MetalGpuBuffer");
+        var pipe = GetAudioPipeline("audio_mulaw_decoding");
+        var (tgr, tpg) = pipe.Calculate1DDispatch(length);
+        using var enc = _commandQueue.CreateScopedComputeEncoder();
+        enc.SetPipelineState(pipe.Handle);
+        enc.SetBuffer(inBuf, 0); enc.SetBuffer(oBuf, 1);
+        enc.SetBytes(length, 2); enc.SetBytes(qc, 3);
+        enc.DispatchThreadgroups(tgr, tpg);
+    }
+
+    public void ComputeDeltas(IGpuBuffer input, IGpuBuffer output,
+        int leading, int timeAxis, int winLength)
+    {
+        int total = leading * timeAxis;
+        if (total <= 0) return;
+        ThrowIfDisposed();
+        if (input is not MetalGpuBuffer inBuf || output is not MetalGpuBuffer oBuf)
+            throw new ArgumentException("Buffers must be MetalGpuBuffer");
+        var pipe = GetAudioPipeline("audio_compute_deltas");
+        var (tgr, tpg) = pipe.Calculate1DDispatch(total);
+        using var enc = _commandQueue.CreateScopedComputeEncoder();
+        enc.SetPipelineState(pipe.Handle);
+        enc.SetBuffer(inBuf, 0); enc.SetBuffer(oBuf, 1);
+        enc.SetBytes(leading, 2); enc.SetBytes(timeAxis, 3); enc.SetBytes(winLength, 4);
+        enc.DispatchThreadgroups(tgr, tpg);
+    }
+
+    public void Resample(IGpuBuffer input, IGpuBuffer output,
+        int leading, int inLen, int outLen, int up, int down, int halfWidth)
+    {
+        int total = leading * outLen;
+        if (total <= 0) return;
+        ThrowIfDisposed();
+        if (input is not MetalGpuBuffer inBuf || output is not MetalGpuBuffer oBuf)
+            throw new ArgumentException("Buffers must be MetalGpuBuffer");
+        var pipe = GetAudioPipeline("audio_resample");
+        var (tgr, tpg) = pipe.Calculate1DDispatch(total);
+        using var enc = _commandQueue.CreateScopedComputeEncoder();
+        enc.SetPipelineState(pipe.Handle);
+        enc.SetBuffer(inBuf, 0); enc.SetBuffer(oBuf, 1);
+        enc.SetBytes(leading, 2); enc.SetBytes(inLen, 3); enc.SetBytes(outLen, 4);
+        enc.SetBytes(up, 5); enc.SetBytes(down, 6); enc.SetBytes(halfWidth, 7);
+        enc.DispatchThreadgroups(tgr, tpg);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Detection.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Detection.cs
@@ -1,0 +1,133 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Metal launcher shims for the vision detection kernels (Issue #217).
+// Mirrors MetalBackend.Parity210.cs — pipeline resolved via shader library
+// handle, dispatched with 1-D thread grid sized to total output cells.
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.Metal;
+
+public sealed partial class MetalBackend : IDetectionBackend
+{
+    private const string DetectionLibName = "Detection";
+
+    private MetalPipelineState GetDetectionPipeline(string kernelName)
+    {
+        if (_detectionLibrary == IntPtr.Zero)
+            throw new InvalidOperationException(
+                "Metal Detection library was not compiled. Falling back to CPU reference.");
+        return GetPipeline(DetectionLibName, _detectionLibrary, kernelName);
+    }
+
+    private void DispatchPairwiseIou(string kernelName,
+        IGpuBuffer a, IGpuBuffer b, IGpuBuffer output, int n, int m)
+    {
+        if (n <= 0 || m <= 0) return;
+        ThrowIfDisposed();
+        if (a is not MetalGpuBuffer aBuf || b is not MetalGpuBuffer bBuf
+            || output is not MetalGpuBuffer outBuf)
+            throw new ArgumentException("Buffers must be MetalGpuBuffer");
+        int total = n * m;
+        var pipeline = GetDetectionPipeline(kernelName);
+        var (threadgroups, threadsPerGroup) = pipeline.Calculate1DDispatch(total);
+        using var encoder = _commandQueue.CreateScopedComputeEncoder();
+        encoder.SetPipelineState(pipeline.Handle);
+        encoder.SetBuffer(aBuf, 0);
+        encoder.SetBuffer(bBuf, 1);
+        encoder.SetBuffer(outBuf, 2);
+        encoder.SetBytes(n, 3);
+        encoder.SetBytes(m, 4);
+        encoder.DispatchThreadgroups(threadgroups, threadsPerGroup);
+    }
+
+    public void BoxIou(IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m)
+        => DispatchPairwiseIou("detection_box_iou", boxesA, boxesB, output, n, m);
+
+    public void GeneralizedBoxIou(IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m)
+        => DispatchPairwiseIou("detection_generalized_box_iou", boxesA, boxesB, output, n, m);
+
+    public void DistanceBoxIou(IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m)
+        => DispatchPairwiseIou("detection_distance_box_iou", boxesA, boxesB, output, n, m);
+
+    public void CompleteBoxIou(IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m)
+        => DispatchPairwiseIou("detection_complete_box_iou", boxesA, boxesB, output, n, m);
+
+    public void BoxArea(IGpuBuffer boxes, IGpuBuffer output, int n)
+    {
+        if (n <= 0) return;
+        ThrowIfDisposed();
+        if (boxes is not MetalGpuBuffer inBuf || output is not MetalGpuBuffer outBuf)
+            throw new ArgumentException("Buffers must be MetalGpuBuffer");
+        var pipeline = GetDetectionPipeline("detection_box_area");
+        var (threadgroups, threadsPerGroup) = pipeline.Calculate1DDispatch(n);
+        using var encoder = _commandQueue.CreateScopedComputeEncoder();
+        encoder.SetPipelineState(pipeline.Handle);
+        encoder.SetBuffer(inBuf, 0);
+        encoder.SetBuffer(outBuf, 1);
+        encoder.SetBytes(n, 2);
+        encoder.DispatchThreadgroups(threadgroups, threadsPerGroup);
+    }
+
+    public void BoxConvert(IGpuBuffer boxes, IGpuBuffer output, int n, int fromFormat, int toFormat)
+    {
+        if (n <= 0) return;
+        ThrowIfDisposed();
+        if (boxes is not MetalGpuBuffer inBuf || output is not MetalGpuBuffer outBuf)
+            throw new ArgumentException("Buffers must be MetalGpuBuffer");
+        var pipeline = GetDetectionPipeline("detection_box_convert");
+        var (threadgroups, threadsPerGroup) = pipeline.Calculate1DDispatch(n);
+        using var encoder = _commandQueue.CreateScopedComputeEncoder();
+        encoder.SetPipelineState(pipeline.Handle);
+        encoder.SetBuffer(inBuf, 0);
+        encoder.SetBuffer(outBuf, 1);
+        encoder.SetBytes(n, 2);
+        encoder.SetBytes(fromFormat, 3);
+        encoder.SetBytes(toFormat, 4);
+        encoder.DispatchThreadgroups(threadgroups, threadsPerGroup);
+    }
+
+    public void IouFamilyBackward(
+        IGpuBuffer gradOutput, IGpuBuffer boxesA, IGpuBuffer boxesB,
+        IGpuBuffer gradA, IGpuBuffer gradB,
+        int n, int m, int variant)
+    {
+        if (n <= 0 || m <= 0) return;
+        ThrowIfDisposed();
+        if (gradOutput is not MetalGpuBuffer goBuf
+            || boxesA is not MetalGpuBuffer aBuf
+            || boxesB is not MetalGpuBuffer bBuf
+            || gradA is not MetalGpuBuffer gABuf
+            || gradB is not MetalGpuBuffer gBBuf)
+            throw new ArgumentException("Buffers must be MetalGpuBuffer");
+
+        // A-side: N threads.
+        var pipeA = GetDetectionPipeline("detection_iou_backward_a");
+        var (tgrA, tpgA) = pipeA.Calculate1DDispatch(n);
+        using (var encoder = _commandQueue.CreateScopedComputeEncoder())
+        {
+            encoder.SetPipelineState(pipeA.Handle);
+            encoder.SetBuffer(goBuf, 0);
+            encoder.SetBuffer(aBuf, 1);
+            encoder.SetBuffer(bBuf, 2);
+            encoder.SetBuffer(gABuf, 3);
+            encoder.SetBytes(n, 4);
+            encoder.SetBytes(m, 5);
+            encoder.SetBytes(variant, 6);
+            encoder.DispatchThreadgroups(tgrA, tpgA);
+        }
+
+        // B-side: M threads.
+        var pipeB = GetDetectionPipeline("detection_iou_backward_b");
+        var (tgrB, tpgB) = pipeB.Calculate1DDispatch(m);
+        using (var encoder = _commandQueue.CreateScopedComputeEncoder())
+        {
+            encoder.SetPipelineState(pipeB.Handle);
+            encoder.SetBuffer(goBuf, 0);
+            encoder.SetBuffer(aBuf, 1);
+            encoder.SetBuffer(bBuf, 2);
+            encoder.SetBuffer(gBBuf, 3);
+            encoder.SetBytes(n, 4);
+            encoder.SetBytes(m, 5);
+            encoder.SetBytes(variant, 6);
+            encoder.DispatchThreadgroups(tgrB, tpgB);
+        }
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Detection.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Detection.cs
@@ -89,7 +89,9 @@ public sealed partial class MetalBackend : IDetectionBackend
         IGpuBuffer gradA, IGpuBuffer gradB,
         int n, int m, int variant)
     {
-        if (n <= 0 || m <= 0) return;
+        // See CudaBackend.Detection for rationale — dispatch each side
+        // independently when only one dim is zero.
+        if (n <= 0 && m <= 0) return;
         ThrowIfDisposed();
         if (gradOutput is not MetalGpuBuffer goBuf
             || boxesA is not MetalGpuBuffer aBuf
@@ -99,35 +101,41 @@ public sealed partial class MetalBackend : IDetectionBackend
             throw new ArgumentException("Buffers must be MetalGpuBuffer");
 
         // A-side: N threads.
-        var pipeA = GetDetectionPipeline("detection_iou_backward_a");
-        var (tgrA, tpgA) = pipeA.Calculate1DDispatch(n);
-        using (var encoder = _commandQueue.CreateScopedComputeEncoder())
+        if (n > 0)
         {
-            encoder.SetPipelineState(pipeA.Handle);
-            encoder.SetBuffer(goBuf, 0);
-            encoder.SetBuffer(aBuf, 1);
-            encoder.SetBuffer(bBuf, 2);
-            encoder.SetBuffer(gABuf, 3);
-            encoder.SetBytes(n, 4);
-            encoder.SetBytes(m, 5);
-            encoder.SetBytes(variant, 6);
-            encoder.DispatchThreadgroups(tgrA, tpgA);
+            var pipeA = GetDetectionPipeline("detection_iou_backward_a");
+            var (tgrA, tpgA) = pipeA.Calculate1DDispatch(n);
+            using (var encoder = _commandQueue.CreateScopedComputeEncoder())
+            {
+                encoder.SetPipelineState(pipeA.Handle);
+                encoder.SetBuffer(goBuf, 0);
+                encoder.SetBuffer(aBuf, 1);
+                encoder.SetBuffer(bBuf, 2);
+                encoder.SetBuffer(gABuf, 3);
+                encoder.SetBytes(n, 4);
+                encoder.SetBytes(m, 5);
+                encoder.SetBytes(variant, 6);
+                encoder.DispatchThreadgroups(tgrA, tpgA);
+            }
         }
 
         // B-side: M threads.
-        var pipeB = GetDetectionPipeline("detection_iou_backward_b");
-        var (tgrB, tpgB) = pipeB.Calculate1DDispatch(m);
-        using (var encoder = _commandQueue.CreateScopedComputeEncoder())
+        if (m > 0)
         {
-            encoder.SetPipelineState(pipeB.Handle);
-            encoder.SetBuffer(goBuf, 0);
-            encoder.SetBuffer(aBuf, 1);
-            encoder.SetBuffer(bBuf, 2);
-            encoder.SetBuffer(gBBuf, 3);
-            encoder.SetBytes(n, 4);
-            encoder.SetBytes(m, 5);
-            encoder.SetBytes(variant, 6);
-            encoder.DispatchThreadgroups(tgrB, tpgB);
+            var pipeB = GetDetectionPipeline("detection_iou_backward_b");
+            var (tgrB, tpgB) = pipeB.Calculate1DDispatch(m);
+            using (var encoder = _commandQueue.CreateScopedComputeEncoder())
+            {
+                encoder.SetPipelineState(pipeB.Handle);
+                encoder.SetBuffer(goBuf, 0);
+                encoder.SetBuffer(aBuf, 1);
+                encoder.SetBuffer(bBuf, 2);
+                encoder.SetBuffer(gBBuf, 3);
+                encoder.SetBytes(n, 4);
+                encoder.SetBytes(m, 5);
+                encoder.SetBytes(variant, 6);
+                encoder.DispatchThreadgroups(tgrB, tpgB);
+            }
         }
     }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Detection.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Detection.cs
@@ -69,6 +69,9 @@ public sealed partial class MetalBackend : IDetectionBackend
     public void BoxConvert(IGpuBuffer boxes, IGpuBuffer output, int n, int fromFormat, int toFormat)
     {
         if (n <= 0) return;
+        if ((uint)fromFormat > 2 || (uint)toFormat > 2)
+            throw new ArgumentException(
+                $"fromFormat/toFormat must be 0/1/2; got {fromFormat}, {toFormat}.");
         ThrowIfDisposed();
         if (boxes is not MetalGpuBuffer inBuf || output is not MetalGpuBuffer outBuf)
             throw new ArgumentException("Buffers must be MetalGpuBuffer");

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Detection.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Detection.cs
@@ -25,7 +25,10 @@ public sealed partial class MetalBackend : IDetectionBackend
         if (a is not MetalGpuBuffer aBuf || b is not MetalGpuBuffer bBuf
             || output is not MetalGpuBuffer outBuf)
             throw new ArgumentException("Buffers must be MetalGpuBuffer");
-        int total = n * m;
+        long totalLong = (long)n * m;
+        if (totalLong > int.MaxValue)
+            throw new OverflowException($"Pairwise IoU total {totalLong} exceeds Int32.MaxValue.");
+        int total = (int)totalLong;
         var pipeline = GetDetectionPipeline(kernelName);
         var (threadgroups, threadsPerGroup) = pipeline.Calculate1DDispatch(total);
         using var encoder = _commandQueue.CreateScopedComputeEncoder();

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Geometry.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Geometry.cs
@@ -1,0 +1,114 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Metal launcher shims for the geometry / sampling kernels (Issue #217).
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.Metal;
+
+public sealed partial class MetalBackend : IGeometryBackend
+{
+    private const string GeometryLibName = "Geometry";
+
+    private MetalPipelineState GetGeometryPipeline(string kernelName)
+    {
+        if (_geometryLibrary == IntPtr.Zero)
+            throw new InvalidOperationException(
+                "Metal Geometry library was not compiled. Falling back to CPU reference.");
+        return GetPipeline(GeometryLibName, _geometryLibrary, kernelName);
+    }
+
+    public void Interpolate2D(IGpuBuffer input, IGpuBuffer output,
+        int N, int C, int Hin, int Win, int Hout, int Wout,
+        int mode, bool alignCorners)
+    {
+        int total = N * C * Hout * Wout;
+        if (total <= 0) return;
+        ThrowIfDisposed();
+        if (input is not MetalGpuBuffer inBuf || output is not MetalGpuBuffer outBuf)
+            throw new ArgumentException("Buffers must be MetalGpuBuffer");
+        var pipe = GetGeometryPipeline("geometry_interpolate_2d");
+        var (tgr, tpg) = pipe.Calculate1DDispatch(total);
+        using var encoder = _commandQueue.CreateScopedComputeEncoder();
+        encoder.SetPipelineState(pipe.Handle);
+        encoder.SetBuffer(inBuf, 0);
+        encoder.SetBuffer(outBuf, 1);
+        encoder.SetBytes(N, 2);
+        encoder.SetBytes(C, 3);
+        encoder.SetBytes(Hin, 4);
+        encoder.SetBytes(Win, 5);
+        encoder.SetBytes(Hout, 6);
+        encoder.SetBytes(Wout, 7);
+        encoder.SetBytes(mode, 8);
+        encoder.SetBytes(alignCorners ? 1 : 0, 9);
+        encoder.DispatchThreadgroups(tgr, tpg);
+    }
+
+    public void Pad4D(IGpuBuffer input, IGpuBuffer output,
+        int N, int C, int Hin, int Win,
+        int padN0, int padN1, int padC0, int padC1,
+        int padH0, int padH1, int padW0, int padW1,
+        int mode, float padValue)
+    {
+        int total = (N + padN0 + padN1) * (C + padC0 + padC1) * (Hin + padH0 + padH1) * (Win + padW0 + padW1);
+        if (total <= 0) return;
+        ThrowIfDisposed();
+        if (input is not MetalGpuBuffer inBuf || output is not MetalGpuBuffer outBuf)
+            throw new ArgumentException("Buffers must be MetalGpuBuffer");
+        var pipe = GetGeometryPipeline("geometry_pad_4d");
+        var (tgr, tpg) = pipe.Calculate1DDispatch(total);
+        using var encoder = _commandQueue.CreateScopedComputeEncoder();
+        encoder.SetPipelineState(pipe.Handle);
+        encoder.SetBuffer(inBuf, 0);
+        encoder.SetBuffer(outBuf, 1);
+        encoder.SetBytes(N, 2); encoder.SetBytes(C, 3);
+        encoder.SetBytes(Hin, 4); encoder.SetBytes(Win, 5);
+        encoder.SetBytes(padN0, 6); encoder.SetBytes(padN1, 7);
+        encoder.SetBytes(padC0, 8); encoder.SetBytes(padC1, 9);
+        encoder.SetBytes(padH0, 10); encoder.SetBytes(padH1, 11);
+        encoder.SetBytes(padW0, 12); encoder.SetBytes(padW1, 13);
+        encoder.SetBytes(mode, 14);
+        encoder.SetBytes(padValue, 15);
+        encoder.DispatchThreadgroups(tgr, tpg);
+    }
+
+    public void GridSample2D(IGpuBuffer input, IGpuBuffer grid, IGpuBuffer output,
+        int N, int H, int W, int C, int outH, int outW,
+        int mode, int padding, bool alignCorners)
+    {
+        int total = N * outH * outW;
+        if (total <= 0) return;
+        ThrowIfDisposed();
+        if (input is not MetalGpuBuffer inBuf || grid is not MetalGpuBuffer grBuf
+            || output is not MetalGpuBuffer outBuf)
+            throw new ArgumentException("Buffers must be MetalGpuBuffer");
+        var pipe = GetGeometryPipeline("geometry_grid_sample_2d");
+        var (tgr, tpg) = pipe.Calculate1DDispatch(total);
+        using var encoder = _commandQueue.CreateScopedComputeEncoder();
+        encoder.SetPipelineState(pipe.Handle);
+        encoder.SetBuffer(inBuf, 0);
+        encoder.SetBuffer(grBuf, 1);
+        encoder.SetBuffer(outBuf, 2);
+        encoder.SetBytes(N, 3); encoder.SetBytes(H, 4); encoder.SetBytes(W, 5); encoder.SetBytes(C, 6);
+        encoder.SetBytes(outH, 7); encoder.SetBytes(outW, 8);
+        encoder.SetBytes(mode, 9); encoder.SetBytes(padding, 10);
+        encoder.SetBytes(alignCorners ? 1 : 0, 11);
+        encoder.DispatchThreadgroups(tgr, tpg);
+    }
+
+    public void AffineGrid3D(IGpuBuffer theta, IGpuBuffer grid,
+        int N, int D, int H, int W, bool alignCorners)
+    {
+        int total = N * D * H * W;
+        if (total <= 0) return;
+        ThrowIfDisposed();
+        if (theta is not MetalGpuBuffer tBuf || grid is not MetalGpuBuffer gBuf)
+            throw new ArgumentException("Buffers must be MetalGpuBuffer");
+        var pipe = GetGeometryPipeline("geometry_affine_grid_3d");
+        var (tgr, tpg) = pipe.Calculate1DDispatch(total);
+        using var encoder = _commandQueue.CreateScopedComputeEncoder();
+        encoder.SetPipelineState(pipe.Handle);
+        encoder.SetBuffer(tBuf, 0);
+        encoder.SetBuffer(gBuf, 1);
+        encoder.SetBytes(N, 2); encoder.SetBytes(D, 3); encoder.SetBytes(H, 4); encoder.SetBytes(W, 5);
+        encoder.SetBytes(alignCorners ? 1 : 0, 6);
+        encoder.DispatchThreadgroups(tgr, tpg);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Roi.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Roi.cs
@@ -56,4 +56,47 @@ public sealed partial class MetalBackend : IRoiBackend
         enc.SetBytes(spatialScale, 10);
         enc.DispatchThreadgroups(tgr, tpg);
     }
+
+    public void PsRoIAlign(IGpuBuffer input, IGpuBuffer boxes, IGpuBuffer output,
+        int N, int C, int H, int W, int K, int outH, int outW, int outputChannels,
+        float spatialScale, int samplingRatio)
+    {
+        int total = K * outputChannels * outH * outW;
+        if (total <= 0) return;
+        ThrowIfDisposed();
+        if (input is not MetalGpuBuffer inBuf || boxes is not MetalGpuBuffer bBuf
+            || output is not MetalGpuBuffer oBuf)
+            throw new ArgumentException("Buffers must be MetalGpuBuffer");
+        var pipe = GetRoiPipeline("ps_roi_align");
+        var (tgr, tpg) = pipe.Calculate1DDispatch(total);
+        using var enc = _commandQueue.CreateScopedComputeEncoder();
+        enc.SetPipelineState(pipe.Handle);
+        enc.SetBuffer(inBuf, 0); enc.SetBuffer(bBuf, 1); enc.SetBuffer(oBuf, 2);
+        enc.SetBytes(N, 3); enc.SetBytes(C, 4); enc.SetBytes(H, 5); enc.SetBytes(W, 6);
+        enc.SetBytes(K, 7); enc.SetBytes(outH, 8); enc.SetBytes(outW, 9);
+        enc.SetBytes(outputChannels, 10);
+        enc.SetBytes(spatialScale, 11); enc.SetBytes(samplingRatio, 12);
+        enc.DispatchThreadgroups(tgr, tpg);
+    }
+
+    public void PsRoIPool(IGpuBuffer input, IGpuBuffer boxes, IGpuBuffer output,
+        int N, int C, int H, int W, int K, int outH, int outW, int outputChannels,
+        float spatialScale)
+    {
+        int total = K * outputChannels * outH * outW;
+        if (total <= 0) return;
+        ThrowIfDisposed();
+        if (input is not MetalGpuBuffer inBuf || boxes is not MetalGpuBuffer bBuf
+            || output is not MetalGpuBuffer oBuf)
+            throw new ArgumentException("Buffers must be MetalGpuBuffer");
+        var pipe = GetRoiPipeline("ps_roi_pool");
+        var (tgr, tpg) = pipe.Calculate1DDispatch(total);
+        using var enc = _commandQueue.CreateScopedComputeEncoder();
+        enc.SetPipelineState(pipe.Handle);
+        enc.SetBuffer(inBuf, 0); enc.SetBuffer(bBuf, 1); enc.SetBuffer(oBuf, 2);
+        enc.SetBytes(N, 3); enc.SetBytes(C, 4); enc.SetBytes(H, 5); enc.SetBytes(W, 6);
+        enc.SetBytes(K, 7); enc.SetBytes(outH, 8); enc.SetBytes(outW, 9);
+        enc.SetBytes(outputChannels, 10); enc.SetBytes(spatialScale, 11);
+        enc.DispatchThreadgroups(tgr, tpg);
+    }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Roi.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Roi.cs
@@ -1,0 +1,59 @@
+// Copyright (c) AiDotNet. All rights reserved.
+namespace AiDotNet.Tensors.Engines.DirectGpu.Metal;
+
+public sealed partial class MetalBackend : IRoiBackend
+{
+    private const string RoiLibName = "Roi";
+    private MetalPipelineState GetRoiPipeline(string n)
+    {
+        if (_roiLibrary == IntPtr.Zero)
+            throw new InvalidOperationException("Metal RoI library was not compiled.");
+        return GetPipeline(RoiLibName, _roiLibrary, n);
+    }
+
+    public void RoIAlign(IGpuBuffer input, IGpuBuffer boxes, IGpuBuffer output,
+        int N, int C, int H, int W, int K, int outH, int outW,
+        float spatialScale, int samplingRatio, bool aligned)
+    {
+        int total = K * C * outH * outW;
+        if (total <= 0) return;
+        ThrowIfDisposed();
+        if (input is not MetalGpuBuffer inBuf || boxes is not MetalGpuBuffer bBuf
+            || output is not MetalGpuBuffer oBuf)
+            throw new ArgumentException("Buffers must be MetalGpuBuffer");
+        var pipe = GetRoiPipeline("roi_align");
+        var (tgr, tpg) = pipe.Calculate1DDispatch(total);
+        using var enc = _commandQueue.CreateScopedComputeEncoder();
+        enc.SetPipelineState(pipe.Handle);
+        enc.SetBuffer(inBuf, 0);
+        enc.SetBuffer(bBuf, 1);
+        enc.SetBuffer(oBuf, 2);
+        enc.SetBytes(N, 3); enc.SetBytes(C, 4); enc.SetBytes(H, 5); enc.SetBytes(W, 6);
+        enc.SetBytes(K, 7); enc.SetBytes(outH, 8); enc.SetBytes(outW, 9);
+        enc.SetBytes(spatialScale, 10); enc.SetBytes(samplingRatio, 11);
+        enc.SetBytes(aligned ? 1 : 0, 12);
+        enc.DispatchThreadgroups(tgr, tpg);
+    }
+
+    public void RoIPool(IGpuBuffer input, IGpuBuffer boxes, IGpuBuffer output,
+        int N, int C, int H, int W, int K, int outH, int outW, float spatialScale)
+    {
+        int total = K * C * outH * outW;
+        if (total <= 0) return;
+        ThrowIfDisposed();
+        if (input is not MetalGpuBuffer inBuf || boxes is not MetalGpuBuffer bBuf
+            || output is not MetalGpuBuffer oBuf)
+            throw new ArgumentException("Buffers must be MetalGpuBuffer");
+        var pipe = GetRoiPipeline("roi_pool");
+        var (tgr, tpg) = pipe.Calculate1DDispatch(total);
+        using var enc = _commandQueue.CreateScopedComputeEncoder();
+        enc.SetPipelineState(pipe.Handle);
+        enc.SetBuffer(inBuf, 0);
+        enc.SetBuffer(bBuf, 1);
+        enc.SetBuffer(oBuf, 2);
+        enc.SetBytes(N, 3); enc.SetBytes(C, 4); enc.SetBytes(H, 5); enc.SetBytes(W, 6);
+        enc.SetBytes(K, 7); enc.SetBytes(outH, 8); enc.SetBytes(outW, 9);
+        enc.SetBytes(spatialScale, 10);
+        enc.DispatchThreadgroups(tgr, tpg);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
@@ -60,6 +60,7 @@ public sealed partial class MetalBackend : IDirectGpuBackend
     private IntPtr _linalgLibrary;
     private IntPtr _fftLibrary;
     private IntPtr _detectionLibrary;
+    private IntPtr _geometryLibrary;
 
     #region Properties
 
@@ -257,6 +258,18 @@ public sealed partial class MetalBackend : IDirectGpuBackend
         {
             System.Diagnostics.Debug.WriteLine($"Metal Detection pre-compilation warning: {ex.Message}");
             _detectionLibrary = IntPtr.Zero;
+        }
+
+        // Geometry / sampling kernels (#217). IGeometryBackend dispatch.
+        try
+        {
+            _geometryLibrary = _shaderLibrary.CompileLibrary("Geometry",
+                MetalGeometryKernels.Source);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Metal Geometry pre-compilation warning: {ex.Message}");
+            _geometryLibrary = IntPtr.Zero;
         }
 
         // Parity-212 FFT kernels — custom radix-2 Cooley-Tukey (no external

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
@@ -62,6 +62,7 @@ public sealed partial class MetalBackend : IDirectGpuBackend
     private IntPtr _detectionLibrary;
     private IntPtr _geometryLibrary;
     private IntPtr _roiLibrary;
+    private IntPtr _audioLibrary;
 
     #region Properties
 
@@ -282,6 +283,17 @@ public sealed partial class MetalBackend : IDirectGpuBackend
         {
             System.Diagnostics.Debug.WriteLine($"Metal RoI pre-compilation warning: {ex.Message}");
             _roiLibrary = IntPtr.Zero;
+        }
+
+        // Audio primitives (#217 tail). IAudioBackend dispatch.
+        try
+        {
+            _audioLibrary = _shaderLibrary.CompileLibrary("Audio", MetalAudioKernels.Source);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Metal Audio pre-compilation warning: {ex.Message}");
+            _audioLibrary = IntPtr.Zero;
         }
 
         // Parity-212 FFT kernels — custom radix-2 Cooley-Tukey (no external

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
@@ -61,6 +61,7 @@ public sealed partial class MetalBackend : IDirectGpuBackend
     private IntPtr _fftLibrary;
     private IntPtr _detectionLibrary;
     private IntPtr _geometryLibrary;
+    private IntPtr _roiLibrary;
 
     #region Properties
 
@@ -270,6 +271,17 @@ public sealed partial class MetalBackend : IDirectGpuBackend
         {
             System.Diagnostics.Debug.WriteLine($"Metal Geometry pre-compilation warning: {ex.Message}");
             _geometryLibrary = IntPtr.Zero;
+        }
+
+        // RoI family (#217 tail). IRoiBackend dispatch.
+        try
+        {
+            _roiLibrary = _shaderLibrary.CompileLibrary("Roi", MetalRoiKernels.Source);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Metal RoI pre-compilation warning: {ex.Message}");
+            _roiLibrary = IntPtr.Zero;
         }
 
         // Parity-212 FFT kernels — custom radix-2 Cooley-Tukey (no external

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
@@ -59,6 +59,7 @@ public sealed partial class MetalBackend : IDirectGpuBackend
     private IntPtr _parity210Library;
     private IntPtr _linalgLibrary;
     private IntPtr _fftLibrary;
+    private IntPtr _detectionLibrary;
 
     #region Properties
 
@@ -244,6 +245,18 @@ public sealed partial class MetalBackend : IDirectGpuBackend
         {
             System.Diagnostics.Debug.WriteLine($"Metal Linalg pre-compilation warning: {ex.Message}");
             _linalgLibrary = IntPtr.Zero;
+        }
+
+        // Vision detection kernels (#217). IDetectionBackend dispatch.
+        try
+        {
+            _detectionLibrary = _shaderLibrary.CompileLibrary("Detection",
+                MetalDetectionKernels.Source);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Metal Detection pre-compilation warning: {ex.Message}");
+            _detectionLibrary = IntPtr.Zero;
         }
 
         // Parity-212 FFT kernels — custom radix-2 Cooley-Tukey (no external

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalDetectionKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalDetectionKernels.cs
@@ -146,10 +146,11 @@ kernel void detection_complete_box_iou(
     float ax1 = a[i * 4], ay1 = a[i * 4 + 1], ax2 = a[i * 4 + 2], ay2 = a[i * 4 + 3];
     float bx1 = b[j * 4], by1 = b[j * 4 + 1], bx2 = b[j * 4 + 2], by2 = b[j * 4 + 3];
 
-    float aw = ax2 - ax1, ah = ay2 - ay1;
-    float bw = bx2 - bx1, bh = by2 - by1;
-    float areaA = max(aw, 0.0f) * max(ah, 0.0f);
-    float areaB = max(bw, 0.0f) * max(bh, 0.0f);
+    // Clamp to match the backward's convention.
+    float aw = max(ax2 - ax1, 0.0f), ah = max(ay2 - ay1, 0.0f);
+    float bw = max(bx2 - bx1, 0.0f), bh = max(by2 - by1, 0.0f);
+    float areaA = aw * ah;
+    float areaB = bw * bh;
     float ix1 = max(ax1, bx1), iy1 = max(ay1, by1);
     float ix2 = min(ax2, bx2), iy2 = min(ay2, by2);
     float inter = max(ix2 - ix1, 0.0f) * max(iy2 - iy1, 0.0f);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalDetectionKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalDetectionKernels.cs
@@ -1,0 +1,429 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Metal Shading Language (MSL) kernels for the vision detection ops added by
+// Issue #217. Mirrors CudaDetectionKernels / HipDetectionKernels in coverage:
+// pairwise IoU family + per-box ops. fp32 only.
+namespace AiDotNet.Tensors.Engines.DirectGpu.Metal
+{
+    /// <summary>
+    /// Metal Shading Language implementations for the detection kernels.
+    /// One thread per (i, j) for the IoU family, one thread per box for the
+    /// per-box ops. Bit-for-bit semantics with the CUDA/HIP versions so the
+    /// three GPU backends can share the parity test harness.
+    /// </summary>
+    internal static class MetalDetectionKernels
+    {
+        public static string[] GetKernelNames() => new[]
+        {
+            "detection_box_iou",
+            "detection_generalized_box_iou",
+            "detection_distance_box_iou",
+            "detection_complete_box_iou",
+            "detection_box_area",
+            "detection_box_convert",
+            "detection_iou_backward_a",
+            "detection_iou_backward_b",
+        };
+
+        public const string Source = @"
+#include <metal_stdlib>
+#include <metal_math>
+using namespace metal;
+
+constant float DETECTION_PI = 3.14159265358979323846f;
+
+// ----------------------------------------------------------------------------
+// Pairwise IoU family — one thread per (i, j) cell.
+// ----------------------------------------------------------------------------
+
+kernel void detection_box_iou(
+    device const float* a [[buffer(0)]],
+    device const float* b [[buffer(1)]],
+    device float* output  [[buffer(2)]],
+    constant int& n [[buffer(3)]],
+    constant int& m [[buffer(4)]],
+    uint gid [[thread_position_in_grid]])
+{
+    int total = n * m;
+    if ((int)gid >= total) return;
+    int i = (int)gid / m;
+    int j = (int)gid % m;
+    float ax1 = a[i * 4], ay1 = a[i * 4 + 1], ax2 = a[i * 4 + 2], ay2 = a[i * 4 + 3];
+    float bx1 = b[j * 4], by1 = b[j * 4 + 1], bx2 = b[j * 4 + 2], by2 = b[j * 4 + 3];
+
+    float aw = max(ax2 - ax1, 0.0f);
+    float ah = max(ay2 - ay1, 0.0f);
+    float bw = max(bx2 - bx1, 0.0f);
+    float bh = max(by2 - by1, 0.0f);
+    float areaA = aw * ah;
+    float areaB = bw * bh;
+
+    float ix1 = max(ax1, bx1);
+    float iy1 = max(ay1, by1);
+    float ix2 = min(ax2, bx2);
+    float iy2 = min(ay2, by2);
+    float iw = max(ix2 - ix1, 0.0f);
+    float ih = max(iy2 - iy1, 0.0f);
+    float inter = iw * ih;
+    float u = areaA + areaB - inter;
+    output[gid] = u > 0.0f ? inter / u : 0.0f;
+}
+
+kernel void detection_generalized_box_iou(
+    device const float* a [[buffer(0)]],
+    device const float* b [[buffer(1)]],
+    device float* output  [[buffer(2)]],
+    constant int& n [[buffer(3)]],
+    constant int& m [[buffer(4)]],
+    uint gid [[thread_position_in_grid]])
+{
+    int total = n * m;
+    if ((int)gid >= total) return;
+    int i = (int)gid / m;
+    int j = (int)gid % m;
+    float ax1 = a[i * 4], ay1 = a[i * 4 + 1], ax2 = a[i * 4 + 2], ay2 = a[i * 4 + 3];
+    float bx1 = b[j * 4], by1 = b[j * 4 + 1], bx2 = b[j * 4 + 2], by2 = b[j * 4 + 3];
+
+    float areaA = max(ax2 - ax1, 0.0f) * max(ay2 - ay1, 0.0f);
+    float areaB = max(bx2 - bx1, 0.0f) * max(by2 - by1, 0.0f);
+    float ix1 = max(ax1, bx1), iy1 = max(ay1, by1);
+    float ix2 = min(ax2, bx2), iy2 = min(ay2, by2);
+    float inter = max(ix2 - ix1, 0.0f) * max(iy2 - iy1, 0.0f);
+    float u = areaA + areaB - inter;
+    float iou = u > 0.0f ? inter / u : 0.0f;
+
+    float ex1 = min(ax1, bx1), ey1 = min(ay1, by1);
+    float ex2 = max(ax2, bx2), ey2 = max(ay2, by2);
+    float enclose = max(ex2 - ex1, 0.0f) * max(ey2 - ey1, 0.0f);
+    output[gid] = enclose > 0.0f ? iou - (enclose - u) / enclose : iou;
+}
+
+kernel void detection_distance_box_iou(
+    device const float* a [[buffer(0)]],
+    device const float* b [[buffer(1)]],
+    device float* output  [[buffer(2)]],
+    constant int& n [[buffer(3)]],
+    constant int& m [[buffer(4)]],
+    uint gid [[thread_position_in_grid]])
+{
+    int total = n * m;
+    if ((int)gid >= total) return;
+    int i = (int)gid / m;
+    int j = (int)gid % m;
+    float ax1 = a[i * 4], ay1 = a[i * 4 + 1], ax2 = a[i * 4 + 2], ay2 = a[i * 4 + 3];
+    float bx1 = b[j * 4], by1 = b[j * 4 + 1], bx2 = b[j * 4 + 2], by2 = b[j * 4 + 3];
+
+    float areaA = max(ax2 - ax1, 0.0f) * max(ay2 - ay1, 0.0f);
+    float areaB = max(bx2 - bx1, 0.0f) * max(by2 - by1, 0.0f);
+    float ix1 = max(ax1, bx1), iy1 = max(ay1, by1);
+    float ix2 = min(ax2, bx2), iy2 = min(ay2, by2);
+    float inter = max(ix2 - ix1, 0.0f) * max(iy2 - iy1, 0.0f);
+    float u = areaA + areaB - inter;
+    float iou = u > 0.0f ? inter / u : 0.0f;
+
+    float acx = (ax1 + ax2) * 0.5f, acy = (ay1 + ay2) * 0.5f;
+    float bcx = (bx1 + bx2) * 0.5f, bcy = (by1 + by2) * 0.5f;
+    float dx = acx - bcx, dy = acy - bcy;
+    float centreSq = dx * dx + dy * dy;
+    float ex1 = min(ax1, bx1), ey1 = min(ay1, by1);
+    float ex2 = max(ax2, bx2), ey2 = max(ay2, by2);
+    float ew = ex2 - ex1, eh = ey2 - ey1;
+    float diagSq = ew * ew + eh * eh;
+    output[gid] = diagSq > 0.0f ? iou - centreSq / diagSq : iou;
+}
+
+kernel void detection_complete_box_iou(
+    device const float* a [[buffer(0)]],
+    device const float* b [[buffer(1)]],
+    device float* output  [[buffer(2)]],
+    constant int& n [[buffer(3)]],
+    constant int& m [[buffer(4)]],
+    uint gid [[thread_position_in_grid]])
+{
+    int total = n * m;
+    if ((int)gid >= total) return;
+    int i = (int)gid / m;
+    int j = (int)gid % m;
+    float ax1 = a[i * 4], ay1 = a[i * 4 + 1], ax2 = a[i * 4 + 2], ay2 = a[i * 4 + 3];
+    float bx1 = b[j * 4], by1 = b[j * 4 + 1], bx2 = b[j * 4 + 2], by2 = b[j * 4 + 3];
+
+    float aw = ax2 - ax1, ah = ay2 - ay1;
+    float bw = bx2 - bx1, bh = by2 - by1;
+    float areaA = max(aw, 0.0f) * max(ah, 0.0f);
+    float areaB = max(bw, 0.0f) * max(bh, 0.0f);
+    float ix1 = max(ax1, bx1), iy1 = max(ay1, by1);
+    float ix2 = min(ax2, bx2), iy2 = min(ay2, by2);
+    float inter = max(ix2 - ix1, 0.0f) * max(iy2 - iy1, 0.0f);
+    float u = areaA + areaB - inter;
+    float iou = u > 0.0f ? inter / u : 0.0f;
+
+    float acx = (ax1 + ax2) * 0.5f, acy = (ay1 + ay2) * 0.5f;
+    float bcx = (bx1 + bx2) * 0.5f, bcy = (by1 + by2) * 0.5f;
+    float dx = acx - bcx, dy = acy - bcy;
+    float centreSq = dx * dx + dy * dy;
+    float ex1 = min(ax1, bx1), ey1 = min(ay1, by1);
+    float ex2 = max(ax2, bx2), ey2 = max(ay2, by2);
+    float ew = ex2 - ex1, eh = ey2 - ey1;
+    float diagSq = ew * ew + eh * eh;
+    float diou = diagSq > 0.0f ? iou - centreSq / diagSq : iou;
+
+    float v = 0.0f, alpha = 0.0f;
+    if (ah > 0.0f && bh > 0.0f) {
+        float aspectA = atan(aw / ah);
+        float aspectB = atan(bw / bh);
+        float diff = aspectA - aspectB;
+        const float invPiSq = 4.0f / (DETECTION_PI * DETECTION_PI);
+        v = invPiSq * diff * diff;
+        float denom = (1.0f - iou) + v;
+        alpha = denom > 0.0f ? v / denom : 0.0f;
+    }
+    output[gid] = diou - alpha * v;
+}
+
+// ----------------------------------------------------------------------------
+// BoxArea — one thread per box.
+// ----------------------------------------------------------------------------
+
+kernel void detection_box_area(
+    device const float* boxes [[buffer(0)]],
+    device float* output      [[buffer(1)]],
+    constant int& n [[buffer(2)]],
+    uint gid [[thread_position_in_grid]])
+{
+    if ((int)gid >= n) return;
+    float w = max(boxes[gid * 4 + 2] - boxes[gid * 4], 0.0f);
+    float h = max(boxes[gid * 4 + 3] - boxes[gid * 4 + 1], 0.0f);
+    output[gid] = w * h;
+}
+
+// ----------------------------------------------------------------------------
+// BoxConvert — fromFormat/toFormat are int codes:
+//   0 = XYXY, 1 = XYWH, 2 = CXCYWH.
+// One thread per box.
+// ----------------------------------------------------------------------------
+
+kernel void detection_box_convert(
+    device const float* boxes [[buffer(0)]],
+    device float* output      [[buffer(1)]],
+    constant int& n [[buffer(2)]],
+    constant int& fromFormat [[buffer(3)]],
+    constant int& toFormat [[buffer(4)]],
+    uint gid [[thread_position_in_grid]])
+{
+    if ((int)gid >= n) return;
+    int o = (int)gid * 4;
+    float v0 = boxes[o], v1 = boxes[o + 1], v2 = boxes[o + 2], v3 = boxes[o + 3];
+
+    float x1, y1, x2, y2;
+    if (fromFormat == 0) { x1 = v0; y1 = v1; x2 = v2; y2 = v3; }
+    else if (fromFormat == 1) { x1 = v0; y1 = v1; x2 = v0 + v2; y2 = v1 + v3; }
+    else { float hw = v2 * 0.5f, hh = v3 * 0.5f;
+           x1 = v0 - hw; y1 = v1 - hh; x2 = v0 + hw; y2 = v1 + hh; }
+
+    if (toFormat == 0) { output[o] = x1; output[o + 1] = y1; output[o + 2] = x2; output[o + 3] = y2; }
+    else if (toFormat == 1) {
+        output[o] = x1; output[o + 1] = y1;
+        output[o + 2] = x2 - x1; output[o + 3] = y2 - y1;
+    } else {
+        float w = x2 - x1, h = y2 - y1;
+        output[o] = x1 + w * 0.5f; output[o + 1] = y1 + h * 0.5f;
+        output[o + 2] = w; output[o + 3] = h;
+    }
+}
+
+// ----------------------------------------------------------------------------
+// IoU family backward — Issue #217. Atomics-free two-kernel design,
+// portable to Metal 1+ (no atomic<f32> required). Mirrors CudaDetectionKernels.
+// ----------------------------------------------------------------------------
+
+inline void compute_cell_grads_iou(
+    float ax1, float ay1, float ax2, float ay2,
+    float bx1, float by1, float bx2, float by2,
+    float g, int variant,
+    thread float* gAx1, thread float* gAy1, thread float* gAx2, thread float* gAy2,
+    thread float* gBx1, thread float* gBy1, thread float* gBx2, thread float* gBy2)
+{
+    *gAx1 = 0.0f; *gAy1 = 0.0f; *gAx2 = 0.0f; *gAy2 = 0.0f;
+    *gBx1 = 0.0f; *gBy1 = 0.0f; *gBx2 = 0.0f; *gBy2 = 0.0f;
+    if (g == 0.0f) return;
+
+    const float INV_PI_SQ = 4.0f / (DETECTION_PI * DETECTION_PI);
+
+    float awRaw = ax2 - ax1, ahRaw = ay2 - ay1;
+    float bwRaw = bx2 - bx1, bhRaw = by2 - by1;
+    float aw = max(awRaw, 0.0f), ah = max(ahRaw, 0.0f);
+    float bw = max(bwRaw, 0.0f), bh = max(bhRaw, 0.0f);
+    float areaA = aw * ah, areaB = bw * bh;
+
+    float ix1 = max(ax1, bx1), ix2 = min(ax2, bx2);
+    float iy1 = max(ay1, by1), iy2 = min(ay2, by2);
+    float iwRaw = ix2 - ix1, ihRaw = iy2 - iy1;
+    float iw = max(iwRaw, 0.0f), ih = max(ihRaw, 0.0f);
+    float inter = iw * ih;
+    float u = areaA + areaB - inter;
+    float iou = u > 0.0f ? inter / u : 0.0f;
+
+    float gIou = g;
+    float gInter = 0.0f, gAreaA = 0.0f, gAreaB = 0.0f;
+
+    if (variant == 1) {
+        float ex1 = min(ax1, bx1), ex2 = max(ax2, bx2);
+        float ey1 = min(ay1, by1), ey2 = max(ay2, by2);
+        float ewRaw = ex2 - ex1, ehRaw = ey2 - ey1;
+        float ew = max(ewRaw, 0.0f), eh = max(ehRaw, 0.0f);
+        float enclose = ew * eh;
+        if (enclose > 0.0f) {
+            float gUnion = g / enclose;
+            float gEnclose = g * (-u / (enclose * enclose));
+            gAreaA += gUnion; gAreaB += gUnion; gInter += -gUnion;
+            float gEw = gEnclose * eh, gEh = gEnclose * ew;
+            float gEwRaw = ewRaw > 0.0f ? gEw : 0.0f;
+            float gEhRaw = ehRaw > 0.0f ? gEh : 0.0f;
+            float gEx1 = -gEwRaw, gEx2 = gEwRaw;
+            float gEy1 = -gEhRaw, gEy2 = gEhRaw;
+            if (ax1 <= bx1) *gAx1 += gEx1; else *gBx1 += gEx1;
+            if (ay1 <= by1) *gAy1 += gEy1; else *gBy1 += gEy1;
+            if (ax2 >= bx2) *gAx2 += gEx2; else *gBx2 += gEx2;
+            if (ay2 >= by2) *gAy2 += gEy2; else *gBy2 += gEy2;
+        }
+    } else if (variant == 2 || variant == 3) {
+        float acx = (ax1 + ax2) * 0.5f, acy = (ay1 + ay2) * 0.5f;
+        float bcx = (bx1 + bx2) * 0.5f, bcy = (by1 + by2) * 0.5f;
+        float dcx = acx - bcx, dcy = acy - bcy;
+        float centreSq = dcx * dcx + dcy * dcy;
+        float ex1 = min(ax1, bx1), ex2 = max(ax2, bx2);
+        float ey1 = min(ay1, by1), ey2 = max(ay2, by2);
+        float ew = ex2 - ex1, eh = ey2 - ey1;
+        float diagSq = ew * ew + eh * eh;
+
+        float gCentreSq = 0.0f, gDiagSq = 0.0f;
+        if (diagSq > 0.0f) {
+            gCentreSq = g * (-1.0f / diagSq);
+            gDiagSq = g * centreSq / (diagSq * diagSq);
+        }
+
+        if (variant == 3 && ah > 0.0f && bh > 0.0f) {
+            float aspectA = atan(aw / ah);
+            float aspectB = atan(bw / bh);
+            float diff = aspectA - aspectB;
+            float v = INV_PI_SQ * diff * diff;
+            float denom = (1.0f - iou) + v;
+            float alpha = denom > 0.0f ? v / denom : 0.0f;
+            float gV = g * (-alpha);
+            float gDiff = gV * 2.0f * INV_PI_SQ * diff;
+            float gAspectA = gDiff, gAspectB = -gDiff;
+            float aDen = aw * aw + ah * ah;
+            float bDen = bw * bw + bh * bh;
+            if (aDen > 0.0f) {
+                float gAw = gAspectA * (ah / aDen);
+                float gAh = gAspectA * (-aw / aDen);
+                if (awRaw > 0.0f) { *gAx2 += gAw; *gAx1 += -gAw; }
+                if (ahRaw > 0.0f) { *gAy2 += gAh; *gAy1 += -gAh; }
+            }
+            if (bDen > 0.0f) {
+                float gBw = gAspectB * (bh / bDen);
+                float gBh = gAspectB * (-bw / bDen);
+                if (bwRaw > 0.0f) { *gBx2 += gBw; *gBx1 += -gBw; }
+                if (bhRaw > 0.0f) { *gBy2 += gBh; *gBy1 += -gBh; }
+            }
+        }
+
+        float gAcx = gCentreSq * 2.0f * dcx;
+        float gAcy = gCentreSq * 2.0f * dcy;
+        *gAx1 += gAcx * 0.5f; *gAx2 += gAcx * 0.5f;
+        *gAy1 += gAcy * 0.5f; *gAy2 += gAcy * 0.5f;
+        *gBx1 += -gAcx * 0.5f; *gBx2 += -gAcx * 0.5f;
+        *gBy1 += -gAcy * 0.5f; *gBy2 += -gAcy * 0.5f;
+
+        float gEw = gDiagSq * 2.0f * ew;
+        float gEh = gDiagSq * 2.0f * eh;
+        float gEx1 = -gEw, gEx2 = gEw;
+        float gEy1 = -gEh, gEy2 = gEh;
+        if (ax1 <= bx1) *gAx1 += gEx1; else *gBx1 += gEx1;
+        if (ay1 <= by1) *gAy1 += gEy1; else *gBy1 += gEy1;
+        if (ax2 >= bx2) *gAx2 += gEx2; else *gBx2 += gEx2;
+        if (ay2 >= by2) *gAy2 += gEy2; else *gBy2 += gEy2;
+    }
+
+    if (u > 0.0f) {
+        float uSq = u * u;
+        gInter += gIou * (u + inter) / uSq;
+        gAreaA += gIou * (-inter) / uSq;
+        gAreaB += gIou * (-inter) / uSq;
+    }
+
+    float gIw = gInter * ih, gIh = gInter * iw;
+    float gIwRaw = iwRaw > 0.0f ? gIw : 0.0f;
+    float gIhRaw = ihRaw > 0.0f ? gIh : 0.0f;
+    float gIx2 = gIwRaw, gIx1 = -gIwRaw;
+    float gIy2 = gIhRaw, gIy1 = -gIhRaw;
+    if (ax1 >= bx1) *gAx1 += gIx1; else *gBx1 += gIx1;
+    if (ay1 >= by1) *gAy1 += gIy1; else *gBy1 += gIy1;
+    if (ax2 <= bx2) *gAx2 += gIx2; else *gBx2 += gIx2;
+    if (ay2 <= by2) *gAy2 += gIy2; else *gBy2 += gIy2;
+
+    float gAw2 = gAreaA * ah, gAh2 = gAreaA * aw;
+    float gBw2 = gAreaB * bh, gBh2 = gAreaB * bw;
+    if (awRaw > 0.0f) { *gAx2 += gAw2; *gAx1 += -gAw2; }
+    if (ahRaw > 0.0f) { *gAy2 += gAh2; *gAy1 += -gAh2; }
+    if (bwRaw > 0.0f) { *gBx2 += gBw2; *gBx1 += -gBw2; }
+    if (bhRaw > 0.0f) { *gBy2 += gBh2; *gBy1 += -gBh2; }
+}
+
+kernel void detection_iou_backward_a(
+    device const float* gradOutput [[buffer(0)]],
+    device const float* a [[buffer(1)]],
+    device const float* b [[buffer(2)]],
+    device float* gradA [[buffer(3)]],
+    constant int& n [[buffer(4)]],
+    constant int& m [[buffer(5)]],
+    constant int& variant [[buffer(6)]],
+    uint gid [[thread_position_in_grid]])
+{
+    int i = (int)gid;
+    if (i >= n) return;
+    float ax1 = a[i * 4], ay1 = a[i * 4 + 1], ax2 = a[i * 4 + 2], ay2 = a[i * 4 + 3];
+    float sumX1 = 0.0f, sumY1 = 0.0f, sumX2 = 0.0f, sumY2 = 0.0f;
+    for (int j = 0; j < m; j++) {
+        float bx1 = b[j * 4], by1 = b[j * 4 + 1], bx2 = b[j * 4 + 2], by2 = b[j * 4 + 3];
+        float g = gradOutput[i * m + j];
+        float gAx1, gAy1, gAx2, gAy2, gBx1, gBy1, gBx2, gBy2;
+        compute_cell_grads_iou(ax1, ay1, ax2, ay2, bx1, by1, bx2, by2, g, variant,
+            &gAx1, &gAy1, &gAx2, &gAy2, &gBx1, &gBy1, &gBx2, &gBy2);
+        sumX1 += gAx1; sumY1 += gAy1; sumX2 += gAx2; sumY2 += gAy2;
+    }
+    gradA[i * 4] = sumX1;
+    gradA[i * 4 + 1] = sumY1;
+    gradA[i * 4 + 2] = sumX2;
+    gradA[i * 4 + 3] = sumY2;
+}
+
+kernel void detection_iou_backward_b(
+    device const float* gradOutput [[buffer(0)]],
+    device const float* a [[buffer(1)]],
+    device const float* b [[buffer(2)]],
+    device float* gradB [[buffer(3)]],
+    constant int& n [[buffer(4)]],
+    constant int& m [[buffer(5)]],
+    constant int& variant [[buffer(6)]],
+    uint gid [[thread_position_in_grid]])
+{
+    int j = (int)gid;
+    if (j >= m) return;
+    float bx1 = b[j * 4], by1 = b[j * 4 + 1], bx2 = b[j * 4 + 2], by2 = b[j * 4 + 3];
+    float sumX1 = 0.0f, sumY1 = 0.0f, sumX2 = 0.0f, sumY2 = 0.0f;
+    for (int i = 0; i < n; i++) {
+        float ax1 = a[i * 4], ay1 = a[i * 4 + 1], ax2 = a[i * 4 + 2], ay2 = a[i * 4 + 3];
+        float g = gradOutput[i * m + j];
+        float gAx1, gAy1, gAx2, gAy2, gBx1, gBy1, gBx2, gBy2;
+        compute_cell_grads_iou(ax1, ay1, ax2, ay2, bx1, by1, bx2, by2, g, variant,
+            &gAx1, &gAy1, &gAx2, &gAy2, &gBx1, &gBy1, &gBx2, &gBy2);
+        sumX1 += gBx1; sumY1 += gBy1; sumX2 += gBx2; sumY2 += gBy2;
+    }
+    gradB[j * 4] = sumX1;
+    gradB[j * 4 + 1] = sumY1;
+    gradB[j * 4 + 2] = sumX2;
+    gradB[j * 4 + 3] = sumY2;
+}
+";
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalGeometryKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalGeometryKernels.cs
@@ -47,6 +47,7 @@ inline int reflect_index(int i, int extent) {
 }
 
 inline int pad_boundary(int idx, int extent, int mode) {
+    if (extent <= 0) return 0;
     if (mode == 2) { if (idx < 0) return 0; if (idx >= extent) return extent - 1; return idx; }
     if (mode == 1) return reflect_index(idx, extent);
     int r = ((idx % extent) + extent) % extent;
@@ -113,7 +114,7 @@ kernel void geometry_interpolate_2d(
             acc += wy[yy] * rowAcc;
         }
         output[gid] = acc;
-    } else {
+    } else {  // Area — overlap-weighted averaging
         float yLo = (float)y * Hin / Hout;
         float yHi = (float)(y + 1) * Hin / Hout;
         float xLo = (float)x * Win / Wout;
@@ -124,9 +125,18 @@ kernel void geometry_interpolate_2d(
         if (xH <= xL) xH = xL + 1;
         if (yH > Hin) yH = Hin;
         if (xH > Win) xH = Win;
-        float acc = 0.0; int count = 0;
-        for (int yy = yL; yy < yH; yy++) for (int xx = xL; xx < xH; xx++) { acc += src[yy * Win + xx]; count++; }
-        output[gid] = count > 0 ? acc / count : 0.0;
+        float totalArea = (yHi - yLo) * (xHi - xLo);
+        float acc = 0.0;
+        for (int yy = yL; yy < yH; yy++) {
+            float oy = max(0.0f, min(yHi, (float)(yy + 1)) - max(yLo, (float)yy));
+            if (oy <= 0.0f) continue;
+            for (int xx = xL; xx < xH; xx++) {
+                float ox = max(0.0f, min(xHi, (float)(xx + 1)) - max(xLo, (float)xx));
+                if (ox <= 0.0f) continue;
+                acc += oy * ox * src[yy * Win + xx];
+            }
+        }
+        output[gid] = totalArea > 0.0 ? acc / totalArea : 0.0;
     }
 }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalGeometryKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalGeometryKernels.cs
@@ -1,0 +1,285 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Metal Shading Language (MSL) kernels for the geometry / sampling ops
+// added by Issue #217. Mirrors CudaGeometryKernels / OpenClGeometryKernels
+// in coverage and mode-int mapping.
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.Metal
+{
+    public static class MetalGeometryKernels
+    {
+        public static string[] GetKernelNames() => new[]
+        {
+            "geometry_interpolate_2d",
+            "geometry_pad_4d",
+            "geometry_grid_sample_2d",
+            "geometry_affine_grid_3d",
+        };
+
+        public const string Source = @"
+#include <metal_stdlib>
+#include <metal_math>
+using namespace metal;
+
+// ----------------------------------------------------------------------------
+// Shared device helpers.
+// ----------------------------------------------------------------------------
+
+inline float source_coord_f(int dstIdx, int dstSize, int srcSize, int alignCorners) {
+    if (dstSize <= 1) return 0.0;
+    if (alignCorners) return float(dstIdx) * (srcSize - 1) / (dstSize - 1);
+    return (float(dstIdx) + 0.5) * srcSize / dstSize - 0.5;
+}
+
+inline float cubic_kernel_f(float d, float a) {
+    float ad = fabs(d);
+    if (ad < 1.0) return ((a + 2.0) * ad - (a + 3.0)) * ad * ad + 1.0;
+    if (ad < 2.0) return a * ((ad - 5.0) * ad + 8.0) * ad - 4.0 * a;
+    return 0.0;
+}
+
+inline int clamp_i(int v, int lo, int hi) { return v < lo ? lo : (v > hi ? hi : v); }
+
+inline int reflect_index(int i, int extent) {
+    if (extent == 1) return 0;
+    int period = 2 * (extent - 1);
+    int r = ((i % period) + period) % period;
+    return r < extent ? r : period - r;
+}
+
+inline int pad_boundary(int idx, int extent, int mode) {
+    if (mode == 2) { if (idx < 0) return 0; if (idx >= extent) return extent - 1; return idx; }
+    if (mode == 1) return reflect_index(idx, extent);
+    int r = ((idx % extent) + extent) % extent;
+    return r;
+}
+
+// ----------------------------------------------------------------------------
+// Interpolate 2D.
+// ----------------------------------------------------------------------------
+
+kernel void geometry_interpolate_2d(
+    device const float* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    constant int& N [[buffer(2)]], constant int& C [[buffer(3)]],
+    constant int& Hin [[buffer(4)]], constant int& Win [[buffer(5)]],
+    constant int& Hout [[buffer(6)]], constant int& Wout [[buffer(7)]],
+    constant int& mode [[buffer(8)]], constant int& alignCorners [[buffer(9)]],
+    uint gid [[thread_position_in_grid]])
+{
+    int total = N * C * Hout * Wout;
+    if ((int)gid >= total) return;
+    int x = (int)gid % Wout; int t1 = (int)gid / Wout;
+    int y = t1 % Hout; int t2 = t1 / Hout;
+    int c = t2 % C; int n = t2 / C;
+    device const float* src = input + ((n * C + c) * Hin) * Win;
+
+    if (mode == 0) {
+        float sy = Hout > 1 ? (float)y * Hin / Hout : 0.0;
+        float sx = Wout > 1 ? (float)x * Win / Wout : 0.0;
+        int yi = (int)floor(sy); if (yi >= Hin) yi = Hin - 1;
+        int xi = (int)floor(sx); if (xi >= Win) xi = Win - 1;
+        output[gid] = src[yi * Win + xi];
+    } else if (mode == 2) {
+        float sy = source_coord_f(y, Hout, Hin, alignCorners);
+        float sx = source_coord_f(x, Wout, Win, alignCorners);
+        int y0 = (int)floor(sy); int x0 = (int)floor(sx);
+        if (y0 < 0) y0 = 0; if (x0 < 0) x0 = 0;
+        int y1 = y0 + 1; int x1 = x0 + 1;
+        if (y1 >= Hin) { y1 = Hin - 1; if (y0 > y1) y0 = y1; }
+        if (x1 >= Win) { x1 = Win - 1; if (x0 > x1) x0 = x1; }
+        float fy = sy - y0; if (fy < 0) fy = 0; if (fy > 1) fy = 1;
+        float fx = sx - x0; if (fx < 0) fx = 0; if (fx > 1) fx = 1;
+        float v00 = src[y0 * Win + x0], v01 = src[y0 * Win + x1];
+        float v10 = src[y1 * Win + x0], v11 = src[y1 * Win + x1];
+        output[gid] = v00 * (1 - fx) * (1 - fy) + v01 * fx * (1 - fy)
+                    + v10 * (1 - fx) * fy + v11 * fx * fy;
+    } else if (mode == 3) {
+        float sy = source_coord_f(y, Hout, Hin, alignCorners);
+        float sx = source_coord_f(x, Wout, Win, alignCorners);
+        int y0 = (int)floor(sy); float ty = sy - y0;
+        int x0 = (int)floor(sx); float tx = sx - x0;
+        float wy[4] = { cubic_kernel_f(1.0 + ty, -0.75), cubic_kernel_f(ty, -0.75),
+                        cubic_kernel_f(1.0 - ty, -0.75), cubic_kernel_f(2.0 - ty, -0.75) };
+        float wx[4] = { cubic_kernel_f(1.0 + tx, -0.75), cubic_kernel_f(tx, -0.75),
+                        cubic_kernel_f(1.0 - tx, -0.75), cubic_kernel_f(2.0 - tx, -0.75) };
+        float acc = 0.0;
+        for (int yy = 0; yy < 4; yy++) {
+            int yi = clamp_i(y0 - 1 + yy, 0, Hin - 1);
+            float rowAcc = 0.0;
+            for (int xx = 0; xx < 4; xx++) {
+                int xi = clamp_i(x0 - 1 + xx, 0, Win - 1);
+                rowAcc += wx[xx] * src[yi * Win + xi];
+            }
+            acc += wy[yy] * rowAcc;
+        }
+        output[gid] = acc;
+    } else {
+        float yLo = (float)y * Hin / Hout;
+        float yHi = (float)(y + 1) * Hin / Hout;
+        float xLo = (float)x * Win / Wout;
+        float xHi = (float)(x + 1) * Win / Wout;
+        int yL = (int)floor(yLo); int yH = (int)ceil(yHi);
+        int xL = (int)floor(xLo); int xH = (int)ceil(xHi);
+        if (yH <= yL) yH = yL + 1;
+        if (xH <= xL) xH = xL + 1;
+        if (yH > Hin) yH = Hin;
+        if (xH > Win) xH = Win;
+        float acc = 0.0; int count = 0;
+        for (int yy = yL; yy < yH; yy++) for (int xx = xL; xx < xH; xx++) { acc += src[yy * Win + xx]; count++; }
+        output[gid] = count > 0 ? acc / count : 0.0;
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Pad 4D.
+// ----------------------------------------------------------------------------
+
+kernel void geometry_pad_4d(
+    device const float* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    constant int& N [[buffer(2)]], constant int& C [[buffer(3)]],
+    constant int& Hin [[buffer(4)]], constant int& Win [[buffer(5)]],
+    constant int& padN0 [[buffer(6)]], constant int& padN1 [[buffer(7)]],
+    constant int& padC0 [[buffer(8)]], constant int& padC1 [[buffer(9)]],
+    constant int& padH0 [[buffer(10)]], constant int& padH1 [[buffer(11)]],
+    constant int& padW0 [[buffer(12)]], constant int& padW1 [[buffer(13)]],
+    constant int& mode [[buffer(14)]], constant float& padValue [[buffer(15)]],
+    uint gid [[thread_position_in_grid]])
+{
+    int Nout = N + padN0 + padN1;
+    int Cout = C + padC0 + padC1;
+    int Hout = Hin + padH0 + padH1;
+    int Wout = Win + padW0 + padW1;
+    int total = Nout * Cout * Hout * Wout;
+    if ((int)gid >= total) return;
+    int w = (int)gid % Wout; int t1 = (int)gid / Wout;
+    int h = t1 % Hout; int t2 = t1 / Hout;
+    int c = t2 % Cout; int n = t2 / Cout;
+    int nn = n - padN0, cc = c - padC0, hh = h - padH0, ww = w - padW0;
+    bool inB = nn >= 0 && nn < N && cc >= 0 && cc < C && hh >= 0 && hh < Hin && ww >= 0 && ww < Win;
+    if (!inB && mode == 0) { output[gid] = padValue; return; }
+    if (!inB) {
+        if (!(nn >= 0 && nn < N)) nn = pad_boundary(nn, N, mode);
+        if (!(cc >= 0 && cc < C)) cc = pad_boundary(cc, C, mode);
+        if (!(hh >= 0 && hh < Hin)) hh = pad_boundary(hh, Hin, mode);
+        if (!(ww >= 0 && ww < Win)) ww = pad_boundary(ww, Win, mode);
+    }
+    output[gid] = input[((nn * C + cc) * Hin + hh) * Win + ww];
+}
+
+// ----------------------------------------------------------------------------
+// GridSample 2D NHWC.
+// ----------------------------------------------------------------------------
+
+inline float grid_sample_safe_msl(device const float* src, int n, int y, int x, int c,
+    int H, int W, int C, int padding)
+{
+    if (padding == 0) {
+        if ((uint)y >= (uint)H || (uint)x >= (uint)W) return 0.0;
+    } else if (padding == 1) {
+        y = clamp_i(y, 0, H - 1); x = clamp_i(x, 0, W - 1);
+    } else {
+        y = reflect_index(y, H); x = reflect_index(x, W);
+    }
+    return src[((n * H + y) * W + x) * C + c];
+}
+
+kernel void geometry_grid_sample_2d(
+    device const float* input [[buffer(0)]],
+    device const float* grid [[buffer(1)]],
+    device float* output [[buffer(2)]],
+    constant int& N [[buffer(3)]], constant int& H [[buffer(4)]],
+    constant int& W [[buffer(5)]], constant int& C [[buffer(6)]],
+    constant int& outH [[buffer(7)]], constant int& outW [[buffer(8)]],
+    constant int& mode [[buffer(9)]], constant int& padding [[buffer(10)]],
+    constant int& alignCorners [[buffer(11)]],
+    uint gid [[thread_position_in_grid]])
+{
+    int total = N * outH * outW;
+    if ((int)gid >= total) return;
+    int ox = (int)gid % outW; int t1 = (int)gid / outW;
+    int oy = t1 % outH; int n = t1 / outH;
+    int gOff = ((n * outH + oy) * outW + ox) * 2;
+    float gx = grid[gOff];
+    float gy = grid[gOff + 1];
+    float sx = alignCorners ? (gx + 1.0) * 0.5 * (W - 1) : ((gx + 1.0) * W - 1.0) * 0.5;
+    float sy = alignCorners ? (gy + 1.0) * 0.5 * (H - 1) : ((gy + 1.0) * H - 1.0) * 0.5;
+
+    if (mode == 1) {
+        int nx = (int)round(sx), ny = (int)round(sy);
+        for (int c = 0; c < C; c++)
+            output[((n * outH + oy) * outW + ox) * C + c] =
+                grid_sample_safe_msl(input, n, ny, nx, c, H, W, C, padding);
+    } else if (mode == 0) {
+        int x0 = (int)floor(sx), y0 = (int)floor(sy);
+        int x1 = x0 + 1, y1 = y0 + 1;
+        float fx = sx - x0, fy = sy - y0;
+        for (int c = 0; c < C; c++) {
+            float v00 = grid_sample_safe_msl(input, n, y0, x0, c, H, W, C, padding);
+            float v01 = grid_sample_safe_msl(input, n, y0, x1, c, H, W, C, padding);
+            float v10 = grid_sample_safe_msl(input, n, y1, x0, c, H, W, C, padding);
+            float v11 = grid_sample_safe_msl(input, n, y1, x1, c, H, W, C, padding);
+            output[((n * outH + oy) * outW + ox) * C + c] =
+                v00 * (1 - fx) * (1 - fy) + v01 * fx * (1 - fy)
+              + v10 * (1 - fx) * fy + v11 * fx * fy;
+        }
+    } else {
+        int x0 = (int)floor(sx), y0 = (int)floor(sy);
+        float fx = sx - x0, fy = sy - y0;
+        float wy[4] = { cubic_kernel_f(1.0 + fy, -0.75), cubic_kernel_f(fy, -0.75),
+                        cubic_kernel_f(1.0 - fy, -0.75), cubic_kernel_f(2.0 - fy, -0.75) };
+        float wx[4] = { cubic_kernel_f(1.0 + fx, -0.75), cubic_kernel_f(fx, -0.75),
+                        cubic_kernel_f(1.0 - fx, -0.75), cubic_kernel_f(2.0 - fx, -0.75) };
+        for (int c = 0; c < C; c++) {
+            float acc = 0.0;
+            for (int yy = 0; yy < 4; yy++) {
+                int yi = y0 - 1 + yy;
+                float rowAcc = 0.0;
+                for (int xx = 0; xx < 4; xx++) {
+                    int xi = x0 - 1 + xx;
+                    rowAcc += wx[xx] * grid_sample_safe_msl(input, n, yi, xi, c, H, W, C, padding);
+                }
+                acc += wy[yy] * rowAcc;
+            }
+            output[((n * outH + oy) * outW + ox) * C + c] = acc;
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------
+// AffineGrid 3D.
+// ----------------------------------------------------------------------------
+
+inline float grid_norm_coord_f(int idx, int size, int alignCorners) {
+    if (size <= 1) return 0.0;
+    return alignCorners ? -1.0 + 2.0 * idx / (size - 1) : -1.0 + (2.0 * idx + 1.0) / size;
+}
+
+kernel void geometry_affine_grid_3d(
+    device const float* theta [[buffer(0)]],
+    device float* grid [[buffer(1)]],
+    constant int& N [[buffer(2)]], constant int& D [[buffer(3)]],
+    constant int& H [[buffer(4)]], constant int& W [[buffer(5)]],
+    constant int& alignCorners [[buffer(6)]],
+    uint gid [[thread_position_in_grid]])
+{
+    int total = N * D * H * W;
+    if ((int)gid >= total) return;
+    int w = (int)gid % W; int t1 = (int)gid / W;
+    int h = t1 % H; int t2 = t1 / H;
+    int d = t2 % D; int n = t2 / D;
+    int tBase = n * 12;
+    float x = grid_norm_coord_f(w, W, alignCorners);
+    float y = grid_norm_coord_f(h, H, alignCorners);
+    float z = grid_norm_coord_f(d, D, alignCorners);
+    int gBase = (((n * D + d) * H + h) * W + w) * 3;
+    for (int row = 0; row < 3; row++) {
+        grid[gBase + row] = theta[tBase + row * 4] * x
+                          + theta[tBase + row * 4 + 1] * y
+                          + theta[tBase + row * 4 + 2] * z
+                          + theta[tBase + row * 4 + 3];
+    }
+}
+";
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalRoiKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalRoiKernels.cs
@@ -16,6 +16,7 @@ using namespace metal;
 inline float bilinear_sample_msl(device const float* src, int planeBase,
     float y, float x, int H, int W)
 {
+    if (H <= 0 || W <= 0) return 0.0;
     if (y < -1.0 || y > float(H) || x < -1.0 || x > float(W)) return 0.0;
     if (y <= 0) y = 0;
     if (x <= 0) x = 0;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalRoiKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalRoiKernels.cs
@@ -3,7 +3,10 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.Metal
 {
     public static class MetalRoiKernels
     {
-        public static string[] GetKernelNames() => new[] { "roi_align", "roi_pool" };
+        public static string[] GetKernelNames() => new[]
+        {
+            "roi_align", "roi_pool", "ps_roi_align", "ps_roi_pool",
+        };
 
         public const string Source = @"
 #include <metal_stdlib>
@@ -117,6 +120,89 @@ kernel void roi_pool(
             if (v > best) best = v;
         }
     output[gid] = best;
+}
+
+kernel void ps_roi_align(
+    device const float* input [[buffer(0)]],
+    device const float* boxes [[buffer(1)]],
+    device float* output [[buffer(2)]],
+    constant int& N [[buffer(3)]], constant int& C [[buffer(4)]],
+    constant int& H [[buffer(5)]], constant int& W [[buffer(6)]],
+    constant int& K [[buffer(7)]], constant int& outH [[buffer(8)]],
+    constant int& outW [[buffer(9)]], constant int& outputChannels [[buffer(10)]],
+    constant float& spatialScale [[buffer(11)]], constant int& samplingRatio [[buffer(12)]],
+    uint gid [[thread_position_in_grid]])
+{
+    int total = K * outputChannels * outH * outW;
+    if ((int)gid >= total) return;
+    int pw = (int)gid % outW; int t1 = (int)gid / outW;
+    int ph = t1 % outH; int t2 = t1 / outH;
+    int co = t2 % outputChannels; int k = t2 / outputChannels;
+
+    int n = int(boxes[k * 5]);
+    if (n < 0 || n >= N) { output[gid] = 0.0; return; }
+    float x1 = boxes[k * 5 + 1] * spatialScale;
+    float y1 = boxes[k * 5 + 2] * spatialScale;
+    float x2 = boxes[k * 5 + 3] * spatialScale;
+    float y2 = boxes[k * 5 + 4] * spatialScale;
+    float roiW = max(x2 - x1, 0.1f);
+    float roiH = max(y2 - y1, 0.1f);
+    float binH = roiH / outH;
+    float binW = roiW / outW;
+    int ry = samplingRatio > 0 ? samplingRatio : int(ceil(roiH / outH));
+    int rx = samplingRatio > 0 ? samplingRatio : int(ceil(roiW / outW));
+    if (ry < 1) ry = 1;
+    if (rx < 1) rx = 1;
+
+    int c = (co * outH + ph) * outW + pw;
+    int planeBase = (n * C + c) * H * W;
+    float acc = 0;
+    for (int iy = 0; iy < ry; iy++) {
+        float sy = y1 + ph * binH + (iy + 0.5f) * binH / ry;
+        for (int ix = 0; ix < rx; ix++) {
+            float sx = x1 + pw * binW + (ix + 0.5f) * binW / rx;
+            acc += bilinear_sample_msl(input, planeBase, sy, sx, H, W);
+        }
+    }
+    output[gid] = acc / (ry * rx);
+}
+
+kernel void ps_roi_pool(
+    device const float* input [[buffer(0)]],
+    device const float* boxes [[buffer(1)]],
+    device float* output [[buffer(2)]],
+    constant int& N [[buffer(3)]], constant int& C [[buffer(4)]],
+    constant int& H [[buffer(5)]], constant int& W [[buffer(6)]],
+    constant int& K [[buffer(7)]], constant int& outH [[buffer(8)]],
+    constant int& outW [[buffer(9)]], constant int& outputChannels [[buffer(10)]],
+    constant float& spatialScale [[buffer(11)]],
+    uint gid [[thread_position_in_grid]])
+{
+    int total = K * outputChannels * outH * outW;
+    if ((int)gid >= total) return;
+    int pw = (int)gid % outW; int t1 = (int)gid / outW;
+    int ph = t1 % outH; int t2 = t1 / outH;
+    int co = t2 % outputChannels; int k = t2 / outputChannels;
+
+    int n = int(boxes[k * 5]);
+    if (n < 0 || n >= N) { output[gid] = 0.0; return; }
+    float x1 = boxes[k * 5 + 1] * spatialScale;
+    float y1 = boxes[k * 5 + 2] * spatialScale;
+    float x2 = boxes[k * 5 + 3] * spatialScale;
+    float y2 = boxes[k * 5 + 4] * spatialScale;
+    float binH = max(y2 - y1, 0.1f) / outH;
+    float binW = max(x2 - x1, 0.1f) / outW;
+
+    int c = (co * outH + ph) * outW + pw;
+    int planeBase = (n * C + c) * H * W;
+    int hs = (int)max(0.0f, floor(y1 + ph * binH));
+    int he = (int)min(float(H), ceil(y1 + (ph + 1) * binH));
+    int ws = (int)max(0.0f, floor(x1 + pw * binW));
+    int we = (int)min(float(W), ceil(x1 + (pw + 1) * binW));
+    float acc = 0; int cnt = 0;
+    for (int yy = hs; yy < he; yy++)
+        for (int xx = ws; xx < we; xx++) { acc += input[planeBase + yy * W + xx]; cnt++; }
+    output[gid] = cnt > 0 ? acc / cnt : 0.0;
 }
 ";
     }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalRoiKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalRoiKernels.cs
@@ -113,7 +113,7 @@ kernel void roi_pool(
     if (wend < 0) wend = 0; if (wend > W) wend = W;
     int planeBase = (n * C + c) * H * W;
     if (hend <= hstart || wend <= wstart) { output[gid] = 0.0; return; }
-    float best = -3.4e38;
+    float best = -3.402823466e+38;  // full -FLT_MAX so a region of very negative values still reports its true max
     for (int yy = hstart; yy < hend; yy++)
         for (int xx = wstart; xx < wend; xx++) {
             float v = input[planeBase + yy * W + xx];

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalRoiKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalRoiKernels.cs
@@ -155,6 +155,7 @@ kernel void ps_roi_align(
     if (rx < 1) rx = 1;
 
     int c = (co * outH + ph) * outW + pw;
+    if (c >= C) { output[gid] = 0.0; return; }
     int planeBase = (n * C + c) * H * W;
     float acc = 0;
     for (int iy = 0; iy < ry; iy++) {
@@ -194,6 +195,7 @@ kernel void ps_roi_pool(
     float binW = max(x2 - x1, 0.1f) / outW;
 
     int c = (co * outH + ph) * outW + pw;
+    if (c >= C) { output[gid] = 0.0; return; }
     int planeBase = (n * C + c) * H * W;
     int hs = (int)max(0.0f, floor(y1 + ph * binH));
     int he = (int)min(float(H), ceil(y1 + (ph + 1) * binH));

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalRoiKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalRoiKernels.cs
@@ -1,0 +1,123 @@
+// Copyright (c) AiDotNet. All rights reserved.
+namespace AiDotNet.Tensors.Engines.DirectGpu.Metal
+{
+    public static class MetalRoiKernels
+    {
+        public static string[] GetKernelNames() => new[] { "roi_align", "roi_pool" };
+
+        public const string Source = @"
+#include <metal_stdlib>
+#include <metal_math>
+using namespace metal;
+
+inline float bilinear_sample_msl(device const float* src, int planeBase,
+    float y, float x, int H, int W)
+{
+    if (y < -1.0 || y > float(H) || x < -1.0 || x > float(W)) return 0.0;
+    if (y <= 0) y = 0;
+    if (x <= 0) x = 0;
+    int y0 = int(y);
+    int x0 = int(x);
+    int y1 = y0 + 1 >= H ? H - 1 : y0 + 1;
+    int x1 = x0 + 1 >= W ? W - 1 : x0 + 1;
+    if (y0 >= H - 1) { y0 = y1 = H - 1; y = float(y0); }
+    if (x0 >= W - 1) { x0 = x1 = W - 1; x = float(x0); }
+    float ly = y - y0, lx = x - x0;
+    float hy = 1.0 - ly, hx = 1.0 - lx;
+    return hy * hx * src[planeBase + y0 * W + x0]
+         + hy * lx * src[planeBase + y0 * W + x1]
+         + ly * hx * src[planeBase + y1 * W + x0]
+         + ly * lx * src[planeBase + y1 * W + x1];
+}
+
+kernel void roi_align(
+    device const float* input [[buffer(0)]],
+    device const float* boxes [[buffer(1)]],
+    device float* output [[buffer(2)]],
+    constant int& N [[buffer(3)]], constant int& C [[buffer(4)]],
+    constant int& H [[buffer(5)]], constant int& W [[buffer(6)]],
+    constant int& K [[buffer(7)]], constant int& outH [[buffer(8)]],
+    constant int& outW [[buffer(9)]],
+    constant float& spatialScale [[buffer(10)]],
+    constant int& samplingRatio [[buffer(11)]], constant int& aligned [[buffer(12)]],
+    uint gid [[thread_position_in_grid]])
+{
+    int total = K * C * outH * outW;
+    if ((int)gid >= total) return;
+    int pw = (int)gid % outW; int t1 = (int)gid / outW;
+    int ph = t1 % outH; int t2 = t1 / outH;
+    int c = t2 % C; int k = t2 / C;
+    int n = (int)boxes[k * 5];
+    if (n < 0 || n >= N) { output[gid] = 0.0; return; }
+    float offset = aligned ? 0.5 : 0.0;
+    float x1 = boxes[k * 5 + 1] * spatialScale - offset;
+    float y1 = boxes[k * 5 + 2] * spatialScale - offset;
+    float x2 = boxes[k * 5 + 3] * spatialScale - offset;
+    float y2 = boxes[k * 5 + 4] * spatialScale - offset;
+    float roiW = aligned ? (x2 - x1) : max(x2 - x1, 1.0f);
+    float roiH = aligned ? (y2 - y1) : max(y2 - y1, 1.0f);
+    float binH = roiH / outH;
+    float binW = roiW / outW;
+    int ry = samplingRatio > 0 ? samplingRatio : int(ceil(roiH / outH));
+    int rx = samplingRatio > 0 ? samplingRatio : int(ceil(roiW / outW));
+    if (ry < 1) ry = 1;
+    if (rx < 1) rx = 1;
+    int planeBase = (n * C + c) * H * W;
+    float acc = 0;
+    for (int iy = 0; iy < ry; iy++) {
+        float sy = y1 + ph * binH + (iy + 0.5f) * binH / ry;
+        for (int ix = 0; ix < rx; ix++) {
+            float sx = x1 + pw * binW + (ix + 0.5f) * binW / rx;
+            acc += bilinear_sample_msl(input, planeBase, sy, sx, H, W);
+        }
+    }
+    output[gid] = acc / (ry * rx);
+}
+
+kernel void roi_pool(
+    device const float* input [[buffer(0)]],
+    device const float* boxes [[buffer(1)]],
+    device float* output [[buffer(2)]],
+    constant int& N [[buffer(3)]], constant int& C [[buffer(4)]],
+    constant int& H [[buffer(5)]], constant int& W [[buffer(6)]],
+    constant int& K [[buffer(7)]], constant int& outH [[buffer(8)]],
+    constant int& outW [[buffer(9)]],
+    constant float& spatialScale [[buffer(10)]],
+    uint gid [[thread_position_in_grid]])
+{
+    int total = K * C * outH * outW;
+    if ((int)gid >= total) return;
+    int pw = (int)gid % outW; int t1 = (int)gid / outW;
+    int ph = t1 % outH; int t2 = t1 / outH;
+    int c = t2 % C; int k = t2 / C;
+    int n = (int)boxes[k * 5];
+    if (n < 0 || n >= N) { output[gid] = 0.0; return; }
+    int x1 = int(round(boxes[k * 5 + 1] * spatialScale));
+    int y1 = int(round(boxes[k * 5 + 2] * spatialScale));
+    int x2 = int(round(boxes[k * 5 + 3] * spatialScale));
+    int y2 = int(round(boxes[k * 5 + 4] * spatialScale));
+    int roiW = x2 - x1 + 1; if (roiW < 1) roiW = 1;
+    int roiH = y2 - y1 + 1; if (roiH < 1) roiH = 1;
+    float binH = float(roiH) / outH;
+    float binW = float(roiW) / outW;
+    int hstart = int(floor(ph * binH)) + y1;
+    int hend = int(ceil((ph + 1) * binH)) + y1;
+    int wstart = int(floor(pw * binW)) + x1;
+    int wend = int(ceil((pw + 1) * binW)) + x1;
+    if (hstart < 0) hstart = 0; if (hstart > H) hstart = H;
+    if (hend < 0) hend = 0; if (hend > H) hend = H;
+    if (wstart < 0) wstart = 0; if (wstart > W) wstart = W;
+    if (wend < 0) wend = 0; if (wend > W) wend = W;
+    int planeBase = (n * C + c) * H * W;
+    if (hend <= hstart || wend <= wstart) { output[gid] = 0.0; return; }
+    float best = -3.4e38;
+    for (int yy = hstart; yy < hend; yy++)
+        for (int xx = wstart; xx < wend; xx++) {
+            float v = input[planeBase + yy * W + xx];
+            if (v > best) best = v;
+        }
+    output[gid] = best;
+}
+";
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClAudioKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClAudioKernels.cs
@@ -85,6 +85,7 @@ __kernel void audio_resample(
     int gid = get_global_id(0);
     int total = leading * outLen;
     if (gid >= total) return;
+    if (halfWidth < 1 || up <= 0 || down <= 0) { output[gid] = 0.0f; return; }
     int ot = gid % outLen;
     int row = gid / outLen;
     int sBase = row * inLen;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClAudioKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClAudioKernels.cs
@@ -64,6 +64,7 @@ __kernel void audio_compute_deltas(
     int t = gid % timeAxis;
     int row = gid / timeAxis;
     int n = winLength / 2;
+    if (n < 1) { output[gid] = 0.0f; return; }
     float denom = 0.0f;
     for (int i = 1; i <= n; i++) denom += 2.0f * i * i;
     float acc = 0.0f;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClAudioKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClAudioKernels.cs
@@ -1,0 +1,111 @@
+// Copyright (c) AiDotNet. All rights reserved.
+#if !NET462
+namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL;
+
+public static class OpenClAudioKernels
+{
+    public static string[] GetKernelNames() => new[]
+    {
+        "audio_amplitude_to_db", "audio_mulaw_encoding", "audio_mulaw_decoding",
+        "audio_compute_deltas", "audio_resample",
+    };
+
+    public static string GetSource() => @"
+__kernel void audio_amplitude_to_db(
+    __global const float* input, __global float* output,
+    const int length, const float minAmp, const float topDbFloor, const int clipTopDb)
+{
+    int gid = get_global_id(0);
+    if (gid >= length) return;
+    float v = fmax(input[gid], minAmp);
+    float db = 20.0f * log10(v);
+    if (clipTopDb != 0 && db < topDbFloor) db = topDbFloor;
+    output[gid] = db;
+}
+
+__kernel void audio_mulaw_encoding(
+    __global const float* input, __global float* output,
+    const int length, const int quantizationChannels)
+{
+    int gid = get_global_id(0);
+    if (gid >= length) return;
+    float mu = (float)(quantizationChannels - 1);
+    float logMu = log1p(mu);
+    float x = input[gid];
+    if (x > 1.0f) x = 1.0f; else if (x < -1.0f) x = -1.0f;
+    float sgn = (x > 0.0f) - (x < 0.0f);
+    float y = sgn * log1p(mu * fabs(x)) / logMu;
+    float q = floor((y + 1.0f) * 0.5f * mu + 0.5f);
+    if (q < 0.0f) q = 0.0f; else if (q > mu) q = mu;
+    output[gid] = q;
+}
+
+__kernel void audio_mulaw_decoding(
+    __global const float* input, __global float* output,
+    const int length, const int quantizationChannels)
+{
+    int gid = get_global_id(0);
+    if (gid >= length) return;
+    float mu = (float)(quantizationChannels - 1);
+    float q = input[gid];
+    float y = (q / mu) * 2.0f - 1.0f;
+    float sgn = (y > 0.0f) - (y < 0.0f);
+    float x = sgn * (pow(1.0f + mu, fabs(y)) - 1.0f) / mu;
+    output[gid] = x;
+}
+
+__kernel void audio_compute_deltas(
+    __global const float* input, __global float* output,
+    const int leading, const int timeAxis, const int winLength)
+{
+    int gid = get_global_id(0);
+    int total = leading * timeAxis;
+    if (gid >= total) return;
+    int t = gid % timeAxis;
+    int row = gid / timeAxis;
+    int n = winLength / 2;
+    float denom = 0.0f;
+    for (int i = 1; i <= n; i++) denom += 2.0f * i * i;
+    float acc = 0.0f;
+    int base_ = row * timeAxis;
+    for (int k = 1; k <= n; k++) {
+        int left = t - k < 0 ? 0 : t - k;
+        int right = t + k >= timeAxis ? timeAxis - 1 : t + k;
+        acc += k * (input[base_ + right] - input[base_ + left]);
+    }
+    output[gid] = acc / denom;
+}
+
+__kernel void audio_resample(
+    __global const float* input, __global float* output,
+    const int leading, const int inLen, const int outLen,
+    const int up, const int down, const int halfWidth)
+{
+    int gid = get_global_id(0);
+    int total = leading * outLen;
+    if (gid >= total) return;
+    int ot = gid % outLen;
+    int row = gid / outLen;
+    int sBase = row * inLen;
+
+    float cutoff = 1.0f / (float)(up > down ? up : down);
+    float srcIdx = (float)ot * down / up;
+    int centre = (int)floor(srcIdx);
+
+    float acc = 0.0f, wSum = 0.0f;
+    const float PI = 3.14159265358979323846f;
+    for (int k = -halfWidth; k <= halfWidth; k++) {
+        int idx = centre + k;
+        if (idx < 0 || idx >= inLen) continue;
+        float tt = (idx - srcIdx) * cutoff;
+        float sinc = fabs(tt) < 1e-12f ? 1.0f : sin(PI * tt) / (PI * tt);
+        float hann = 0.5f - 0.5f * cos(2.0f * PI * (k + halfWidth) / (2.0f * halfWidth));
+        float w = sinc * hann;
+        acc += w * input[sBase + idx];
+        wSum += w;
+    }
+    output[gid] = wSum > 0.0f ? acc / wSum : 0.0f;
+}
+";
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.Audio.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.Audio.cs
@@ -1,0 +1,75 @@
+// Copyright (c) AiDotNet. All rights reserved.
+#if !NET462
+namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
+{
+    public sealed partial class OpenClBackend : IAudioBackend
+    {
+        private const int AudioLocalSize = 256;
+        private DirectOpenClKernel GetAudioKernel(string name)
+        {
+            if (!_kernelCache.TryGetValue(name, out var k))
+                throw new InvalidOperationException($"OpenCL audio kernel not found: {name}.");
+            return k;
+        }
+        private static int RoundUpAudio(int v) => ((v + AudioLocalSize - 1) / AudioLocalSize) * AudioLocalSize;
+        private static IntPtr AudioHandle(IGpuBuffer b) => ((DirectOpenClGpuBuffer)b).Buffer.Handle;
+
+        public void AmplitudeToDB(IGpuBuffer input, IGpuBuffer output, int length,
+            float minAmplitude, float topDb, bool clipTopDb)
+        {
+            if (length <= 0) return;
+            var k = GetAudioKernel("audio_amplitude_to_db");
+            k.SetArg(0, AudioHandle(input));
+            k.SetArg(1, AudioHandle(output));
+            k.SetArg(2, length); k.SetArg(3, minAmplitude);
+            k.SetArg(4, topDb); k.SetArg(5, clipTopDb ? 1 : 0);
+            k.Execute1D(RoundUpAudio(length), AudioLocalSize);
+        }
+
+        public void MuLawEncoding(IGpuBuffer input, IGpuBuffer output, int length, int qc)
+        {
+            if (length <= 0) return;
+            var k = GetAudioKernel("audio_mulaw_encoding");
+            k.SetArg(0, AudioHandle(input));
+            k.SetArg(1, AudioHandle(output));
+            k.SetArg(2, length); k.SetArg(3, qc);
+            k.Execute1D(RoundUpAudio(length), AudioLocalSize);
+        }
+
+        public void MuLawDecoding(IGpuBuffer input, IGpuBuffer output, int length, int qc)
+        {
+            if (length <= 0) return;
+            var k = GetAudioKernel("audio_mulaw_decoding");
+            k.SetArg(0, AudioHandle(input));
+            k.SetArg(1, AudioHandle(output));
+            k.SetArg(2, length); k.SetArg(3, qc);
+            k.Execute1D(RoundUpAudio(length), AudioLocalSize);
+        }
+
+        public void ComputeDeltas(IGpuBuffer input, IGpuBuffer output,
+            int leading, int timeAxis, int winLength)
+        {
+            int total = leading * timeAxis;
+            if (total <= 0) return;
+            var k = GetAudioKernel("audio_compute_deltas");
+            k.SetArg(0, AudioHandle(input));
+            k.SetArg(1, AudioHandle(output));
+            k.SetArg(2, leading); k.SetArg(3, timeAxis); k.SetArg(4, winLength);
+            k.Execute1D(RoundUpAudio(total), AudioLocalSize);
+        }
+
+        public void Resample(IGpuBuffer input, IGpuBuffer output,
+            int leading, int inLen, int outLen, int up, int down, int halfWidth)
+        {
+            int total = leading * outLen;
+            if (total <= 0) return;
+            var k = GetAudioKernel("audio_resample");
+            k.SetArg(0, AudioHandle(input));
+            k.SetArg(1, AudioHandle(output));
+            k.SetArg(2, leading); k.SetArg(3, inLen); k.SetArg(4, outLen);
+            k.SetArg(5, up); k.SetArg(6, down); k.SetArg(7, halfWidth);
+            k.Execute1D(RoundUpAudio(total), AudioLocalSize);
+        }
+    }
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.Detection.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.Detection.cs
@@ -76,6 +76,9 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         public void BoxConvert(IGpuBuffer boxes, IGpuBuffer output, int n, int fromFormat, int toFormat)
         {
             if (n <= 0) return;
+            if ((uint)fromFormat > 2 || (uint)toFormat > 2)
+                throw new ArgumentException(
+                    $"fromFormat/toFormat must be 0/1/2; got {fromFormat}, {toFormat}.");
             var k = GetDetectionKernel("detection_box_convert");
             k.SetArg(0, DetectionBufHandle(boxes));
             k.SetArg(1, DetectionBufHandle(output));

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.Detection.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.Detection.cs
@@ -96,27 +96,35 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             IGpuBuffer gradA, IGpuBuffer gradB,
             int n, int m, int variant)
         {
-            if (n <= 0 || m <= 0) return;
+            // See CudaBackend.Detection for rationale — don't leak pooled
+            // buffer contents when one of n/m is zero.
+            if (n <= 0 && m <= 0) return;
 
-            var kA = GetDetectionKernel("detection_iou_backward_a");
-            kA.SetArg(0, DetectionBufHandle(gradOutput));
-            kA.SetArg(1, DetectionBufHandle(boxesA));
-            kA.SetArg(2, DetectionBufHandle(boxesB));
-            kA.SetArg(3, DetectionBufHandle(gradA));
-            kA.SetArg(4, n);
-            kA.SetArg(5, m);
-            kA.SetArg(6, variant);
-            kA.Execute1D(RoundUpToDetectionGroup(n), DetectionLocalSize);
+            if (n > 0)
+            {
+                var kA = GetDetectionKernel("detection_iou_backward_a");
+                kA.SetArg(0, DetectionBufHandle(gradOutput));
+                kA.SetArg(1, DetectionBufHandle(boxesA));
+                kA.SetArg(2, DetectionBufHandle(boxesB));
+                kA.SetArg(3, DetectionBufHandle(gradA));
+                kA.SetArg(4, n);
+                kA.SetArg(5, m);
+                kA.SetArg(6, variant);
+                kA.Execute1D(RoundUpToDetectionGroup(n), DetectionLocalSize);
+            }
 
-            var kB = GetDetectionKernel("detection_iou_backward_b");
-            kB.SetArg(0, DetectionBufHandle(gradOutput));
-            kB.SetArg(1, DetectionBufHandle(boxesA));
-            kB.SetArg(2, DetectionBufHandle(boxesB));
-            kB.SetArg(3, DetectionBufHandle(gradB));
-            kB.SetArg(4, n);
-            kB.SetArg(5, m);
-            kB.SetArg(6, variant);
-            kB.Execute1D(RoundUpToDetectionGroup(m), DetectionLocalSize);
+            if (m > 0)
+            {
+                var kB = GetDetectionKernel("detection_iou_backward_b");
+                kB.SetArg(0, DetectionBufHandle(gradOutput));
+                kB.SetArg(1, DetectionBufHandle(boxesA));
+                kB.SetArg(2, DetectionBufHandle(boxesB));
+                kB.SetArg(3, DetectionBufHandle(gradB));
+                kB.SetArg(4, n);
+                kB.SetArg(5, m);
+                kB.SetArg(6, variant);
+                kB.Execute1D(RoundUpToDetectionGroup(m), DetectionLocalSize);
+            }
         }
     }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.Detection.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.Detection.cs
@@ -43,7 +43,10 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         private void DispatchPairwiseIou(string kernelName,
             IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m)
         {
-            int total = n * m;
+            long totalLong = (long)n * m;
+            if (totalLong > int.MaxValue)
+                throw new OverflowException($"Pairwise IoU total {totalLong} exceeds Int32.MaxValue.");
+            int total = (int)totalLong;
             if (total <= 0) return;
             var k = GetDetectionKernel(kernelName);
             k.SetArg(0, DetectionBufHandle(boxesA));

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.Detection.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.Detection.cs
@@ -1,0 +1,123 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// OpenCL launcher shims for the vision-detection kernels (Issue #217).
+// Mirrors OpenClBackend.Parity210.cs's pattern: each method pulls the
+// compiled DirectOpenClKernel from _kernelCache and dispatches via
+// kernel.Execute1D with 256-thread workgroups.
+#if !NET462
+namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
+{
+    public sealed partial class OpenClBackend : IDetectionBackend
+    {
+        private const int DetectionLocalSize = 256;
+
+        private DirectOpenClKernel GetDetectionKernel(string name)
+        {
+            if (!_kernelCache.TryGetValue(name, out var kernel))
+                throw new InvalidOperationException(
+                    $"OpenCL detection kernel not found: {name}. Module may have failed to compile.");
+            return kernel;
+        }
+
+        private static int RoundUpToDetectionGroup(int v) =>
+            ((v + DetectionLocalSize - 1) / DetectionLocalSize) * DetectionLocalSize;
+
+        private static IntPtr DetectionBufHandle(IGpuBuffer b) =>
+            ((DirectOpenClGpuBuffer)b).Buffer.Handle;
+
+        // --------------------------------------------------------------
+        // Pairwise IoU family — one thread per (i, j).
+        // --------------------------------------------------------------
+
+        public void BoxIou(IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m)
+            => DispatchPairwiseIou("detection_box_iou", boxesA, boxesB, output, n, m);
+
+        public void GeneralizedBoxIou(IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m)
+            => DispatchPairwiseIou("detection_generalized_box_iou", boxesA, boxesB, output, n, m);
+
+        public void DistanceBoxIou(IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m)
+            => DispatchPairwiseIou("detection_distance_box_iou", boxesA, boxesB, output, n, m);
+
+        public void CompleteBoxIou(IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m)
+            => DispatchPairwiseIou("detection_complete_box_iou", boxesA, boxesB, output, n, m);
+
+        private void DispatchPairwiseIou(string kernelName,
+            IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m)
+        {
+            int total = n * m;
+            if (total <= 0) return;
+            var k = GetDetectionKernel(kernelName);
+            k.SetArg(0, DetectionBufHandle(boxesA));
+            k.SetArg(1, DetectionBufHandle(boxesB));
+            k.SetArg(2, DetectionBufHandle(output));
+            k.SetArg(3, n);
+            k.SetArg(4, m);
+            k.Execute1D(RoundUpToDetectionGroup(total), DetectionLocalSize);
+        }
+
+        // --------------------------------------------------------------
+        // BoxArea — one thread per box.
+        // --------------------------------------------------------------
+
+        public void BoxArea(IGpuBuffer boxes, IGpuBuffer output, int n)
+        {
+            if (n <= 0) return;
+            var k = GetDetectionKernel("detection_box_area");
+            k.SetArg(0, DetectionBufHandle(boxes));
+            k.SetArg(1, DetectionBufHandle(output));
+            k.SetArg(2, n);
+            k.Execute1D(RoundUpToDetectionGroup(n), DetectionLocalSize);
+        }
+
+        // --------------------------------------------------------------
+        // BoxConvert — one thread per box. Format codes match the
+        // BoxFormat enum: 0=XYXY, 1=XYWH, 2=CXCYWH.
+        // --------------------------------------------------------------
+
+        public void BoxConvert(IGpuBuffer boxes, IGpuBuffer output, int n, int fromFormat, int toFormat)
+        {
+            if (n <= 0) return;
+            var k = GetDetectionKernel("detection_box_convert");
+            k.SetArg(0, DetectionBufHandle(boxes));
+            k.SetArg(1, DetectionBufHandle(output));
+            k.SetArg(2, n);
+            k.SetArg(3, fromFormat);
+            k.SetArg(4, toFormat);
+            k.Execute1D(RoundUpToDetectionGroup(n), DetectionLocalSize);
+        }
+
+        // --------------------------------------------------------------
+        // IoU family backward — Issue #217. Two kernels: A-side owns rows
+        // of N (each thread iterates M columns), B-side owns rows of M.
+        // Atomics-free; portable.
+        // --------------------------------------------------------------
+
+        public void IouFamilyBackward(
+            IGpuBuffer gradOutput, IGpuBuffer boxesA, IGpuBuffer boxesB,
+            IGpuBuffer gradA, IGpuBuffer gradB,
+            int n, int m, int variant)
+        {
+            if (n <= 0 || m <= 0) return;
+
+            var kA = GetDetectionKernel("detection_iou_backward_a");
+            kA.SetArg(0, DetectionBufHandle(gradOutput));
+            kA.SetArg(1, DetectionBufHandle(boxesA));
+            kA.SetArg(2, DetectionBufHandle(boxesB));
+            kA.SetArg(3, DetectionBufHandle(gradA));
+            kA.SetArg(4, n);
+            kA.SetArg(5, m);
+            kA.SetArg(6, variant);
+            kA.Execute1D(RoundUpToDetectionGroup(n), DetectionLocalSize);
+
+            var kB = GetDetectionKernel("detection_iou_backward_b");
+            kB.SetArg(0, DetectionBufHandle(gradOutput));
+            kB.SetArg(1, DetectionBufHandle(boxesA));
+            kB.SetArg(2, DetectionBufHandle(boxesB));
+            kB.SetArg(3, DetectionBufHandle(gradB));
+            kB.SetArg(4, n);
+            kB.SetArg(5, m);
+            kB.SetArg(6, variant);
+            kB.Execute1D(RoundUpToDetectionGroup(m), DetectionLocalSize);
+        }
+    }
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.Geometry.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.Geometry.cs
@@ -1,0 +1,91 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// OpenCL launcher shims for the geometry / sampling kernels (Issue #217).
+#if !NET462
+namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
+{
+    public sealed partial class OpenClBackend : IGeometryBackend
+    {
+        private const int GeometryLocalSize = 256;
+
+        private DirectOpenClKernel GetGeometryKernel(string name)
+        {
+            if (!_kernelCache.TryGetValue(name, out var kernel))
+                throw new InvalidOperationException(
+                    $"OpenCL geometry kernel not found: {name}. Module may have failed to compile.");
+            return kernel;
+        }
+
+        private static int RoundUpToGeometryGroup(int v) =>
+            ((v + GeometryLocalSize - 1) / GeometryLocalSize) * GeometryLocalSize;
+
+        private static IntPtr GeometryBufHandle(IGpuBuffer b) =>
+            ((DirectOpenClGpuBuffer)b).Buffer.Handle;
+
+        public void Interpolate2D(IGpuBuffer input, IGpuBuffer output,
+            int N, int C, int Hin, int Win, int Hout, int Wout,
+            int mode, bool alignCorners)
+        {
+            int total = N * C * Hout * Wout;
+            if (total <= 0) return;
+            var k = GetGeometryKernel("geometry_interpolate_2d");
+            k.SetArg(0, GeometryBufHandle(input));
+            k.SetArg(1, GeometryBufHandle(output));
+            k.SetArg(2, N); k.SetArg(3, C);
+            k.SetArg(4, Hin); k.SetArg(5, Win);
+            k.SetArg(6, Hout); k.SetArg(7, Wout);
+            k.SetArg(8, mode); k.SetArg(9, alignCorners ? 1 : 0);
+            k.Execute1D(RoundUpToGeometryGroup(total), GeometryLocalSize);
+        }
+
+        public void Pad4D(IGpuBuffer input, IGpuBuffer output,
+            int N, int C, int Hin, int Win,
+            int padN0, int padN1, int padC0, int padC1,
+            int padH0, int padH1, int padW0, int padW1,
+            int mode, float padValue)
+        {
+            int total = (N + padN0 + padN1) * (C + padC0 + padC1) * (Hin + padH0 + padH1) * (Win + padW0 + padW1);
+            if (total <= 0) return;
+            var k = GetGeometryKernel("geometry_pad_4d");
+            k.SetArg(0, GeometryBufHandle(input));
+            k.SetArg(1, GeometryBufHandle(output));
+            k.SetArg(2, N); k.SetArg(3, C);
+            k.SetArg(4, Hin); k.SetArg(5, Win);
+            k.SetArg(6, padN0); k.SetArg(7, padN1);
+            k.SetArg(8, padC0); k.SetArg(9, padC1);
+            k.SetArg(10, padH0); k.SetArg(11, padH1);
+            k.SetArg(12, padW0); k.SetArg(13, padW1);
+            k.SetArg(14, mode); k.SetArg(15, padValue);
+            k.Execute1D(RoundUpToGeometryGroup(total), GeometryLocalSize);
+        }
+
+        public void GridSample2D(IGpuBuffer input, IGpuBuffer grid, IGpuBuffer output,
+            int N, int H, int W, int C, int outH, int outW,
+            int mode, int padding, bool alignCorners)
+        {
+            int total = N * outH * outW;
+            if (total <= 0) return;
+            var k = GetGeometryKernel("geometry_grid_sample_2d");
+            k.SetArg(0, GeometryBufHandle(input));
+            k.SetArg(1, GeometryBufHandle(grid));
+            k.SetArg(2, GeometryBufHandle(output));
+            k.SetArg(3, N); k.SetArg(4, H); k.SetArg(5, W); k.SetArg(6, C);
+            k.SetArg(7, outH); k.SetArg(8, outW);
+            k.SetArg(9, mode); k.SetArg(10, padding); k.SetArg(11, alignCorners ? 1 : 0);
+            k.Execute1D(RoundUpToGeometryGroup(total), GeometryLocalSize);
+        }
+
+        public void AffineGrid3D(IGpuBuffer theta, IGpuBuffer grid,
+            int N, int D, int H, int W, bool alignCorners)
+        {
+            int total = N * D * H * W;
+            if (total <= 0) return;
+            var k = GetGeometryKernel("geometry_affine_grid_3d");
+            k.SetArg(0, GeometryBufHandle(theta));
+            k.SetArg(1, GeometryBufHandle(grid));
+            k.SetArg(2, N); k.SetArg(3, D); k.SetArg(4, H); k.SetArg(5, W);
+            k.SetArg(6, alignCorners ? 1 : 0);
+            k.Execute1D(RoundUpToGeometryGroup(total), GeometryLocalSize);
+        }
+    }
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.Roi.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.Roi.cs
@@ -1,0 +1,51 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// OpenCL RoI launcher shims (Issue #217 tail).
+#if !NET462
+namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
+{
+    public sealed partial class OpenClBackend : IRoiBackend
+    {
+        private const int RoiLocalSize = 256;
+        private DirectOpenClKernel GetRoiKernel(string name)
+        {
+            if (!_kernelCache.TryGetValue(name, out var k))
+                throw new InvalidOperationException($"OpenCL RoI kernel not found: {name}.");
+            return k;
+        }
+        private static int RoundUpRoi(int v) => ((v + RoiLocalSize - 1) / RoiLocalSize) * RoiLocalSize;
+        private static IntPtr RoiHandle(IGpuBuffer b) => ((DirectOpenClGpuBuffer)b).Buffer.Handle;
+
+        public void RoIAlign(IGpuBuffer input, IGpuBuffer boxes, IGpuBuffer output,
+            int N, int C, int H, int W, int K, int outH, int outW,
+            float spatialScale, int samplingRatio, bool aligned)
+        {
+            int total = K * C * outH * outW;
+            if (total <= 0) return;
+            var k = GetRoiKernel("roi_align");
+            k.SetArg(0, RoiHandle(input));
+            k.SetArg(1, RoiHandle(boxes));
+            k.SetArg(2, RoiHandle(output));
+            k.SetArg(3, N); k.SetArg(4, C); k.SetArg(5, H); k.SetArg(6, W);
+            k.SetArg(7, K); k.SetArg(8, outH); k.SetArg(9, outW);
+            k.SetArg(10, spatialScale); k.SetArg(11, samplingRatio);
+            k.SetArg(12, aligned ? 1 : 0);
+            k.Execute1D(RoundUpRoi(total), RoiLocalSize);
+        }
+
+        public void RoIPool(IGpuBuffer input, IGpuBuffer boxes, IGpuBuffer output,
+            int N, int C, int H, int W, int K, int outH, int outW, float spatialScale)
+        {
+            int total = K * C * outH * outW;
+            if (total <= 0) return;
+            var k = GetRoiKernel("roi_pool");
+            k.SetArg(0, RoiHandle(input));
+            k.SetArg(1, RoiHandle(boxes));
+            k.SetArg(2, RoiHandle(output));
+            k.SetArg(3, N); k.SetArg(4, C); k.SetArg(5, H); k.SetArg(6, W);
+            k.SetArg(7, K); k.SetArg(8, outH); k.SetArg(9, outW);
+            k.SetArg(10, spatialScale);
+            k.Execute1D(RoundUpRoi(total), RoiLocalSize);
+        }
+    }
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.Roi.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.Roi.cs
@@ -46,6 +46,38 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             k.SetArg(10, spatialScale);
             k.Execute1D(RoundUpRoi(total), RoiLocalSize);
         }
+
+        public void PsRoIAlign(IGpuBuffer input, IGpuBuffer boxes, IGpuBuffer output,
+            int N, int C, int H, int W, int K, int outH, int outW, int outputChannels,
+            float spatialScale, int samplingRatio)
+        {
+            int total = K * outputChannels * outH * outW;
+            if (total <= 0) return;
+            var k = GetRoiKernel("ps_roi_align");
+            k.SetArg(0, RoiHandle(input));
+            k.SetArg(1, RoiHandle(boxes));
+            k.SetArg(2, RoiHandle(output));
+            k.SetArg(3, N); k.SetArg(4, C); k.SetArg(5, H); k.SetArg(6, W);
+            k.SetArg(7, K); k.SetArg(8, outH); k.SetArg(9, outW); k.SetArg(10, outputChannels);
+            k.SetArg(11, spatialScale); k.SetArg(12, samplingRatio);
+            k.Execute1D(RoundUpRoi(total), RoiLocalSize);
+        }
+
+        public void PsRoIPool(IGpuBuffer input, IGpuBuffer boxes, IGpuBuffer output,
+            int N, int C, int H, int W, int K, int outH, int outW, int outputChannels,
+            float spatialScale)
+        {
+            int total = K * outputChannels * outH * outW;
+            if (total <= 0) return;
+            var k = GetRoiKernel("ps_roi_pool");
+            k.SetArg(0, RoiHandle(input));
+            k.SetArg(1, RoiHandle(boxes));
+            k.SetArg(2, RoiHandle(output));
+            k.SetArg(3, N); k.SetArg(4, C); k.SetArg(5, H); k.SetArg(6, W);
+            k.SetArg(7, K); k.SetArg(8, outH); k.SetArg(9, outW); k.SetArg(10, outputChannels);
+            k.SetArg(11, spatialScale);
+            k.Execute1D(RoundUpRoi(total), RoiLocalSize);
+        }
     }
 }
 #endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -583,6 +583,24 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                     System.Diagnostics.Debug.WriteLine($"OpenCL Parity-210 compilation failed: {ex.Message}");
                 }
 
+                // Compile Vision-Detection kernels (Issue #217). Optional —
+                // same fallback pattern as Parity-210: on compile failure
+                // the kernels are simply absent from _kernelCache, the
+                // IDetectionBackend implementation throws on call, and
+                // DirectGpuTensorEngine catches that and falls through to
+                // the CpuEngine path.
+                try
+                {
+                    var detectionProgram = CompileOrLoadCached(OpenClDetectionKernels.GetSource(), optimizationFlags, "Detection kernels");
+                    _programs.Add(detectionProgram);
+                    foreach (var name in OpenClDetectionKernels.GetKernelNames())
+                        _kernelCache[name] = new DirectOpenClKernel(_context, detectionProgram, name);
+                }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Debug.WriteLine($"OpenCL Detection compilation failed: {ex.Message}");
+                }
+
                 // Linalg decomposition kernels (#211 moat #2). Compilation
                 // failure flips _linalgAvailable=false and surfaces via
                 // <see cref="LinalgAvailable"/> so callers can route to CPU

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -627,6 +627,19 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                     System.Diagnostics.Debug.WriteLine($"OpenCL RoI compilation failed: {ex.Message}");
                 }
 
+                // Compile audio kernels (Issue #217 tail).
+                try
+                {
+                    var audioProgram = CompileOrLoadCached(OpenClAudioKernels.GetSource(), optimizationFlags, "Audio kernels");
+                    _programs.Add(audioProgram);
+                    foreach (var name in OpenClAudioKernels.GetKernelNames())
+                        _kernelCache[name] = new DirectOpenClKernel(_context, audioProgram, name);
+                }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Debug.WriteLine($"OpenCL Audio compilation failed: {ex.Message}");
+                }
+
                 // Linalg decomposition kernels (#211 moat #2). Compilation
                 // failure flips _linalgAvailable=false and surfaces via
                 // <see cref="LinalgAvailable"/> so callers can route to CPU

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -614,6 +614,19 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                     System.Diagnostics.Debug.WriteLine($"OpenCL Geometry compilation failed: {ex.Message}");
                 }
 
+                // Compile RoI kernels (Issue #217 tail).
+                try
+                {
+                    var roiProgram = CompileOrLoadCached(OpenClRoiKernels.GetSource(), optimizationFlags, "RoI kernels");
+                    _programs.Add(roiProgram);
+                    foreach (var name in OpenClRoiKernels.GetKernelNames())
+                        _kernelCache[name] = new DirectOpenClKernel(_context, roiProgram, name);
+                }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Debug.WriteLine($"OpenCL RoI compilation failed: {ex.Message}");
+                }
+
                 // Linalg decomposition kernels (#211 moat #2). Compilation
                 // failure flips _linalgAvailable=false and surfaces via
                 // <see cref="LinalgAvailable"/> so callers can route to CPU

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -592,9 +592,13 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 try
                 {
                     var detectionProgram = CompileOrLoadCached(OpenClDetectionKernels.GetSource(), optimizationFlags, "Detection kernels");
-                    _programs.Add(detectionProgram);
+                    // Commit program + kernels together so a partial failure
+                    // doesn't leave _kernelCache in a half-populated state.
+                    var built = new System.Collections.Generic.List<(string, DirectOpenClKernel)>();
                     foreach (var name in OpenClDetectionKernels.GetKernelNames())
-                        _kernelCache[name] = new DirectOpenClKernel(_context, detectionProgram, name);
+                        built.Add((name, new DirectOpenClKernel(_context, detectionProgram, name)));
+                    _programs.Add(detectionProgram);
+                    foreach (var (name, kernel) in built) _kernelCache[name] = kernel;
                 }
                 catch (Exception ex)
                 {
@@ -605,9 +609,11 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 try
                 {
                     var geometryProgram = CompileOrLoadCached(OpenClGeometryKernels.GetSource(), optimizationFlags, "Geometry kernels");
-                    _programs.Add(geometryProgram);
+                    var built = new System.Collections.Generic.List<(string, DirectOpenClKernel)>();
                     foreach (var name in OpenClGeometryKernels.GetKernelNames())
-                        _kernelCache[name] = new DirectOpenClKernel(_context, geometryProgram, name);
+                        built.Add((name, new DirectOpenClKernel(_context, geometryProgram, name)));
+                    _programs.Add(geometryProgram);
+                    foreach (var (name, kernel) in built) _kernelCache[name] = kernel;
                 }
                 catch (Exception ex)
                 {
@@ -618,9 +624,11 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 try
                 {
                     var roiProgram = CompileOrLoadCached(OpenClRoiKernels.GetSource(), optimizationFlags, "RoI kernels");
-                    _programs.Add(roiProgram);
+                    var built = new System.Collections.Generic.List<(string, DirectOpenClKernel)>();
                     foreach (var name in OpenClRoiKernels.GetKernelNames())
-                        _kernelCache[name] = new DirectOpenClKernel(_context, roiProgram, name);
+                        built.Add((name, new DirectOpenClKernel(_context, roiProgram, name)));
+                    _programs.Add(roiProgram);
+                    foreach (var (name, kernel) in built) _kernelCache[name] = kernel;
                 }
                 catch (Exception ex)
                 {
@@ -631,9 +639,11 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 try
                 {
                     var audioProgram = CompileOrLoadCached(OpenClAudioKernels.GetSource(), optimizationFlags, "Audio kernels");
-                    _programs.Add(audioProgram);
+                    var built = new System.Collections.Generic.List<(string, DirectOpenClKernel)>();
                     foreach (var name in OpenClAudioKernels.GetKernelNames())
-                        _kernelCache[name] = new DirectOpenClKernel(_context, audioProgram, name);
+                        built.Add((name, new DirectOpenClKernel(_context, audioProgram, name)));
+                    _programs.Add(audioProgram);
+                    foreach (var (name, kernel) in built) _kernelCache[name] = kernel;
                 }
                 catch (Exception ex)
                 {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -601,6 +601,19 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                     System.Diagnostics.Debug.WriteLine($"OpenCL Detection compilation failed: {ex.Message}");
                 }
 
+                // Compile Geometry / sampling kernels (Issue #217 second half).
+                try
+                {
+                    var geometryProgram = CompileOrLoadCached(OpenClGeometryKernels.GetSource(), optimizationFlags, "Geometry kernels");
+                    _programs.Add(geometryProgram);
+                    foreach (var name in OpenClGeometryKernels.GetKernelNames())
+                        _kernelCache[name] = new DirectOpenClKernel(_context, geometryProgram, name);
+                }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Debug.WriteLine($"OpenCL Geometry compilation failed: {ex.Message}");
+                }
+
                 // Linalg decomposition kernels (#211 moat #2). Compilation
                 // failure flips _linalgAvailable=false and surfaces via
                 // <see cref="LinalgAvailable"/> so callers can route to CPU

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClDetectionKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClDetectionKernels.cs
@@ -128,10 +128,11 @@ __kernel void detection_complete_box_iou(
     float ax1 = a[i * 4], ay1 = a[i * 4 + 1], ax2 = a[i * 4 + 2], ay2 = a[i * 4 + 3];
     float bx1 = b[j * 4], by1 = b[j * 4 + 1], bx2 = b[j * 4 + 2], by2 = b[j * 4 + 3];
 
-    float aw = ax2 - ax1, ah = ay2 - ay1;
-    float bw = bx2 - bx1, bh = by2 - by1;
-    float areaA = max(aw, 0.0f) * max(ah, 0.0f);
-    float areaB = max(bw, 0.0f) * max(bh, 0.0f);
+    // Clamp to match the backward's convention.
+    float aw = max(ax2 - ax1, 0.0f), ah = max(ay2 - ay1, 0.0f);
+    float bw = max(bx2 - bx1, 0.0f), bh = max(by2 - by1, 0.0f);
+    float areaA = aw * ah;
+    float areaB = bw * bh;
     float ix1 = max(ax1, bx1), iy1 = max(ay1, by1);
     float ix2 = min(ax2, bx2), iy2 = min(ay2, by2);
     float inter = max(ix2 - ix1, 0.0f) * max(iy2 - iy1, 0.0f);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClDetectionKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClDetectionKernels.cs
@@ -1,0 +1,407 @@
+#if !NET462
+namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL;
+
+/// <summary>
+/// OpenCL C kernels for the vision detection ops added by Issue #217:
+/// pairwise IoU family, BoxArea, BoxConvert. One thread per output
+/// element; embarrassingly parallel.
+/// </summary>
+public static class OpenClDetectionKernels
+{
+    public static string[] GetKernelNames() => new[]
+    {
+        "detection_box_iou",
+        "detection_generalized_box_iou",
+        "detection_distance_box_iou",
+        "detection_complete_box_iou",
+        "detection_box_area",
+        "detection_box_convert",
+        "detection_iou_backward_a",
+        "detection_iou_backward_b",
+    };
+
+    public static string GetSource() => @"
+// ============================================================================
+// Vision Detection — Issue #217.
+// All boxes are float[4] in xyxy unless explicitly noted by BoxConvert.
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// Pairwise IoU family. One thread per (i, j) cell.
+// ----------------------------------------------------------------------------
+
+__kernel void detection_box_iou(
+    __global const float* a, __global const float* b,
+    __global float* output, const int n, const int m)
+{
+    int gid = get_global_id(0);
+    if (gid >= n * m) return;
+    int i = gid / m;
+    int j = gid % m;
+    float ax1 = a[i * 4], ay1 = a[i * 4 + 1], ax2 = a[i * 4 + 2], ay2 = a[i * 4 + 3];
+    float bx1 = b[j * 4], by1 = b[j * 4 + 1], bx2 = b[j * 4 + 2], by2 = b[j * 4 + 3];
+
+    float aw = max(ax2 - ax1, 0.0f);
+    float ah = max(ay2 - ay1, 0.0f);
+    float bw = max(bx2 - bx1, 0.0f);
+    float bh = max(by2 - by1, 0.0f);
+    float areaA = aw * ah;
+    float areaB = bw * bh;
+
+    float ix1 = max(ax1, bx1);
+    float iy1 = max(ay1, by1);
+    float ix2 = min(ax2, bx2);
+    float iy2 = min(ay2, by2);
+    float iw = max(ix2 - ix1, 0.0f);
+    float ih = max(iy2 - iy1, 0.0f);
+    float inter = iw * ih;
+    float u = areaA + areaB - inter;
+    output[gid] = u > 0.0f ? inter / u : 0.0f;
+}
+
+__kernel void detection_generalized_box_iou(
+    __global const float* a, __global const float* b,
+    __global float* output, const int n, const int m)
+{
+    int gid = get_global_id(0);
+    if (gid >= n * m) return;
+    int i = gid / m;
+    int j = gid % m;
+    float ax1 = a[i * 4], ay1 = a[i * 4 + 1], ax2 = a[i * 4 + 2], ay2 = a[i * 4 + 3];
+    float bx1 = b[j * 4], by1 = b[j * 4 + 1], bx2 = b[j * 4 + 2], by2 = b[j * 4 + 3];
+
+    float areaA = max(ax2 - ax1, 0.0f) * max(ay2 - ay1, 0.0f);
+    float areaB = max(bx2 - bx1, 0.0f) * max(by2 - by1, 0.0f);
+
+    float ix1 = max(ax1, bx1), iy1 = max(ay1, by1);
+    float ix2 = min(ax2, bx2), iy2 = min(ay2, by2);
+    float inter = max(ix2 - ix1, 0.0f) * max(iy2 - iy1, 0.0f);
+    float u = areaA + areaB - inter;
+    float iou = u > 0.0f ? inter / u : 0.0f;
+
+    float ex1 = min(ax1, bx1), ey1 = min(ay1, by1);
+    float ex2 = max(ax2, bx2), ey2 = max(ay2, by2);
+    float enclose = max(ex2 - ex1, 0.0f) * max(ey2 - ey1, 0.0f);
+    output[gid] = enclose > 0.0f ? iou - (enclose - u) / enclose : iou;
+}
+
+__kernel void detection_distance_box_iou(
+    __global const float* a, __global const float* b,
+    __global float* output, const int n, const int m)
+{
+    int gid = get_global_id(0);
+    if (gid >= n * m) return;
+    int i = gid / m;
+    int j = gid % m;
+    float ax1 = a[i * 4], ay1 = a[i * 4 + 1], ax2 = a[i * 4 + 2], ay2 = a[i * 4 + 3];
+    float bx1 = b[j * 4], by1 = b[j * 4 + 1], bx2 = b[j * 4 + 2], by2 = b[j * 4 + 3];
+
+    float areaA = max(ax2 - ax1, 0.0f) * max(ay2 - ay1, 0.0f);
+    float areaB = max(bx2 - bx1, 0.0f) * max(by2 - by1, 0.0f);
+    float ix1 = max(ax1, bx1), iy1 = max(ay1, by1);
+    float ix2 = min(ax2, bx2), iy2 = min(ay2, by2);
+    float inter = max(ix2 - ix1, 0.0f) * max(iy2 - iy1, 0.0f);
+    float u = areaA + areaB - inter;
+    float iou = u > 0.0f ? inter / u : 0.0f;
+
+    float acx = (ax1 + ax2) * 0.5f, acy = (ay1 + ay2) * 0.5f;
+    float bcx = (bx1 + bx2) * 0.5f, bcy = (by1 + by2) * 0.5f;
+    float dx = acx - bcx, dy = acy - bcy;
+    float centreSq = dx * dx + dy * dy;
+
+    float ex1 = min(ax1, bx1), ey1 = min(ay1, by1);
+    float ex2 = max(ax2, bx2), ey2 = max(ay2, by2);
+    float ew = ex2 - ex1, eh = ey2 - ey1;
+    float diagSq = ew * ew + eh * eh;
+
+    output[gid] = diagSq > 0.0f ? iou - centreSq / diagSq : iou;
+}
+
+__kernel void detection_complete_box_iou(
+    __global const float* a, __global const float* b,
+    __global float* output, const int n, const int m)
+{
+    int gid = get_global_id(0);
+    if (gid >= n * m) return;
+    int i = gid / m;
+    int j = gid % m;
+    float ax1 = a[i * 4], ay1 = a[i * 4 + 1], ax2 = a[i * 4 + 2], ay2 = a[i * 4 + 3];
+    float bx1 = b[j * 4], by1 = b[j * 4 + 1], bx2 = b[j * 4 + 2], by2 = b[j * 4 + 3];
+
+    float aw = ax2 - ax1, ah = ay2 - ay1;
+    float bw = bx2 - bx1, bh = by2 - by1;
+    float areaA = max(aw, 0.0f) * max(ah, 0.0f);
+    float areaB = max(bw, 0.0f) * max(bh, 0.0f);
+    float ix1 = max(ax1, bx1), iy1 = max(ay1, by1);
+    float ix2 = min(ax2, bx2), iy2 = min(ay2, by2);
+    float inter = max(ix2 - ix1, 0.0f) * max(iy2 - iy1, 0.0f);
+    float u = areaA + areaB - inter;
+    float iou = u > 0.0f ? inter / u : 0.0f;
+
+    float acx = (ax1 + ax2) * 0.5f, acy = (ay1 + ay2) * 0.5f;
+    float bcx = (bx1 + bx2) * 0.5f, bcy = (by1 + by2) * 0.5f;
+    float dx = acx - bcx, dy = acy - bcy;
+    float centreSq = dx * dx + dy * dy;
+
+    float ex1 = min(ax1, bx1), ey1 = min(ay1, by1);
+    float ex2 = max(ax2, bx2), ey2 = max(ay2, by2);
+    float ew = ex2 - ex1, eh = ey2 - ey1;
+    float diagSq = ew * ew + eh * eh;
+
+    float diou = diagSq > 0.0f ? iou - centreSq / diagSq : iou;
+
+    // Aspect-ratio penalty (CIoU): only valid when both heights > 0.
+    float v = 0.0f, alpha = 0.0f;
+    if (ah > 0.0f && bh > 0.0f) {
+        float aspectA = atan(aw / ah);
+        float aspectB = atan(bw / bh);
+        float diff = aspectA - aspectB;
+        const float invPiSq = 4.0f / (3.14159265358979323846f * 3.14159265358979323846f);
+        v = invPiSq * diff * diff;
+        float denom = (1.0f - iou) + v;
+        alpha = denom > 0.0f ? v / denom : 0.0f;
+    }
+    output[gid] = diou - alpha * v;
+}
+
+// ----------------------------------------------------------------------------
+// BoxArea — one thread per box.
+// ----------------------------------------------------------------------------
+
+__kernel void detection_box_area(
+    __global const float* boxes, __global float* output, const int n)
+{
+    int gid = get_global_id(0);
+    if (gid >= n) return;
+    float w = max(boxes[gid * 4 + 2] - boxes[gid * 4], 0.0f);
+    float h = max(boxes[gid * 4 + 3] - boxes[gid * 4 + 1], 0.0f);
+    output[gid] = w * h;
+}
+
+// ----------------------------------------------------------------------------
+// BoxConvert — fromFormat/toFormat are int codes:
+//   0 = XYXY, 1 = XYWH, 2 = CXCYWH.
+// One thread per box.
+// ----------------------------------------------------------------------------
+
+__kernel void detection_box_convert(
+    __global const float* boxes, __global float* output, const int n,
+    const int fromFormat, const int toFormat)
+{
+    int gid = get_global_id(0);
+    if (gid >= n) return;
+    int o = gid * 4;
+    float v0 = boxes[o], v1 = boxes[o + 1], v2 = boxes[o + 2], v3 = boxes[o + 3];
+
+    // Decode to xyxy.
+    float x1, y1, x2, y2;
+    if (fromFormat == 0) { x1 = v0; y1 = v1; x2 = v2; y2 = v3; }
+    else if (fromFormat == 1) { x1 = v0; y1 = v1; x2 = v0 + v2; y2 = v1 + v3; }
+    else /* CXCYWH */ {
+        float hw = v2 * 0.5f, hh = v3 * 0.5f;
+        x1 = v0 - hw; y1 = v1 - hh; x2 = v0 + hw; y2 = v1 + hh;
+    }
+
+    // Encode from xyxy.
+    if (toFormat == 0) { output[o] = x1; output[o + 1] = y1; output[o + 2] = x2; output[o + 3] = y2; }
+    else if (toFormat == 1) {
+        output[o] = x1; output[o + 1] = y1;
+        output[o + 2] = x2 - x1; output[o + 3] = y2 - y1;
+    } else /* CXCYWH */ {
+        float w = x2 - x1, h = y2 - y1;
+        output[o] = x1 + w * 0.5f; output[o + 1] = y1 + h * 0.5f;
+        output[o + 2] = w; output[o + 3] = h;
+    }
+}
+
+// ----------------------------------------------------------------------------
+// IoU family backward — Issue #217. Atomics-free two-kernel design:
+// detection_iou_backward_a launches N threads (one per A row) that each
+// iterate j=0..M and accumulate gradA[i]; detection_iou_backward_b launches
+// M threads and accumulates gradB[j]. Mirrors CudaDetectionKernels.
+// ----------------------------------------------------------------------------
+
+inline void compute_cell_grads_iou(
+    float ax1, float ay1, float ax2, float ay2,
+    float bx1, float by1, float bx2, float by2,
+    float g, int variant,
+    float* gAx1, float* gAy1, float* gAx2, float* gAy2,
+    float* gBx1, float* gBy1, float* gBx2, float* gBy2)
+{
+    *gAx1 = 0.0f; *gAy1 = 0.0f; *gAx2 = 0.0f; *gAy2 = 0.0f;
+    *gBx1 = 0.0f; *gBy1 = 0.0f; *gBx2 = 0.0f; *gBy2 = 0.0f;
+    if (g == 0.0f) return;
+
+    const float INV_PI_SQ = 4.0f / (3.14159265358979323846f * 3.14159265358979323846f);
+
+    float awRaw = ax2 - ax1, ahRaw = ay2 - ay1;
+    float bwRaw = bx2 - bx1, bhRaw = by2 - by1;
+    float aw = max(awRaw, 0.0f), ah = max(ahRaw, 0.0f);
+    float bw = max(bwRaw, 0.0f), bh = max(bhRaw, 0.0f);
+    float areaA = aw * ah, areaB = bw * bh;
+
+    float ix1 = max(ax1, bx1), ix2 = min(ax2, bx2);
+    float iy1 = max(ay1, by1), iy2 = min(ay2, by2);
+    float iwRaw = ix2 - ix1, ihRaw = iy2 - iy1;
+    float iw = max(iwRaw, 0.0f), ih = max(ihRaw, 0.0f);
+    float inter = iw * ih;
+    float u = areaA + areaB - inter;
+    float iou = u > 0.0f ? inter / u : 0.0f;
+
+    float gIou = g;
+    float gInter = 0.0f, gAreaA = 0.0f, gAreaB = 0.0f;
+
+    if (variant == 1) {
+        float ex1 = min(ax1, bx1), ex2 = max(ax2, bx2);
+        float ey1 = min(ay1, by1), ey2 = max(ay2, by2);
+        float ewRaw = ex2 - ex1, ehRaw = ey2 - ey1;
+        float ew = max(ewRaw, 0.0f), eh = max(ehRaw, 0.0f);
+        float enclose = ew * eh;
+        if (enclose > 0.0f) {
+            float gUnion = g / enclose;
+            float gEnclose = g * (-u / (enclose * enclose));
+            gAreaA += gUnion; gAreaB += gUnion; gInter += -gUnion;
+            float gEw = gEnclose * eh, gEh = gEnclose * ew;
+            float gEwRaw = ewRaw > 0.0f ? gEw : 0.0f;
+            float gEhRaw = ehRaw > 0.0f ? gEh : 0.0f;
+            float gEx1 = -gEwRaw, gEx2 = gEwRaw;
+            float gEy1 = -gEhRaw, gEy2 = gEhRaw;
+            if (ax1 <= bx1) *gAx1 += gEx1; else *gBx1 += gEx1;
+            if (ay1 <= by1) *gAy1 += gEy1; else *gBy1 += gEy1;
+            if (ax2 >= bx2) *gAx2 += gEx2; else *gBx2 += gEx2;
+            if (ay2 >= by2) *gAy2 += gEy2; else *gBy2 += gEy2;
+        }
+    } else if (variant == 2 || variant == 3) {
+        float acx = (ax1 + ax2) * 0.5f, acy = (ay1 + ay2) * 0.5f;
+        float bcx = (bx1 + bx2) * 0.5f, bcy = (by1 + by2) * 0.5f;
+        float dcx = acx - bcx, dcy = acy - bcy;
+        float centreSq = dcx * dcx + dcy * dcy;
+        float ex1 = min(ax1, bx1), ex2 = max(ax2, bx2);
+        float ey1 = min(ay1, by1), ey2 = max(ay2, by2);
+        float ew = ex2 - ex1, eh = ey2 - ey1;
+        float diagSq = ew * ew + eh * eh;
+
+        float gCentreSq = 0.0f, gDiagSq = 0.0f;
+        if (diagSq > 0.0f) {
+            gCentreSq = g * (-1.0f / diagSq);
+            gDiagSq = g * centreSq / (diagSq * diagSq);
+        }
+
+        if (variant == 3 && ah > 0.0f && bh > 0.0f) {
+            float aspectA = atan(aw / ah);
+            float aspectB = atan(bw / bh);
+            float diff = aspectA - aspectB;
+            float v = INV_PI_SQ * diff * diff;
+            float denom = (1.0f - iou) + v;
+            float alpha = denom > 0.0f ? v / denom : 0.0f;
+            float gV = g * (-alpha);
+            float gDiff = gV * 2.0f * INV_PI_SQ * diff;
+            float gAspectA = gDiff, gAspectB = -gDiff;
+            float aDen = aw * aw + ah * ah;
+            float bDen = bw * bw + bh * bh;
+            if (aDen > 0.0f) {
+                float gAw = gAspectA * (ah / aDen);
+                float gAh = gAspectA * (-aw / aDen);
+                if (awRaw > 0.0f) { *gAx2 += gAw; *gAx1 += -gAw; }
+                if (ahRaw > 0.0f) { *gAy2 += gAh; *gAy1 += -gAh; }
+            }
+            if (bDen > 0.0f) {
+                float gBw = gAspectB * (bh / bDen);
+                float gBh = gAspectB * (-bw / bDen);
+                if (bwRaw > 0.0f) { *gBx2 += gBw; *gBx1 += -gBw; }
+                if (bhRaw > 0.0f) { *gBy2 += gBh; *gBy1 += -gBh; }
+            }
+        }
+
+        float gAcx = gCentreSq * 2.0f * dcx;
+        float gAcy = gCentreSq * 2.0f * dcy;
+        *gAx1 += gAcx * 0.5f; *gAx2 += gAcx * 0.5f;
+        *gAy1 += gAcy * 0.5f; *gAy2 += gAcy * 0.5f;
+        *gBx1 += -gAcx * 0.5f; *gBx2 += -gAcx * 0.5f;
+        *gBy1 += -gAcy * 0.5f; *gBy2 += -gAcy * 0.5f;
+
+        float gEw = gDiagSq * 2.0f * ew;
+        float gEh = gDiagSq * 2.0f * eh;
+        float gEx1 = -gEw, gEx2 = gEw;
+        float gEy1 = -gEh, gEy2 = gEh;
+        if (ax1 <= bx1) *gAx1 += gEx1; else *gBx1 += gEx1;
+        if (ay1 <= by1) *gAy1 += gEy1; else *gBy1 += gEy1;
+        if (ax2 >= bx2) *gAx2 += gEx2; else *gBx2 += gEx2;
+        if (ay2 >= by2) *gAy2 += gEy2; else *gBy2 += gEy2;
+    }
+
+    if (u > 0.0f) {
+        float uSq = u * u;
+        gInter += gIou * (u + inter) / uSq;
+        gAreaA += gIou * (-inter) / uSq;
+        gAreaB += gIou * (-inter) / uSq;
+    }
+
+    float gIw = gInter * ih, gIh = gInter * iw;
+    float gIwRaw = iwRaw > 0.0f ? gIw : 0.0f;
+    float gIhRaw = ihRaw > 0.0f ? gIh : 0.0f;
+    float gIx2 = gIwRaw, gIx1 = -gIwRaw;
+    float gIy2 = gIhRaw, gIy1 = -gIhRaw;
+    if (ax1 >= bx1) *gAx1 += gIx1; else *gBx1 += gIx1;
+    if (ay1 >= by1) *gAy1 += gIy1; else *gBy1 += gIy1;
+    if (ax2 <= bx2) *gAx2 += gIx2; else *gBx2 += gIx2;
+    if (ay2 <= by2) *gAy2 += gIy2; else *gBy2 += gIy2;
+
+    float gAw2 = gAreaA * ah, gAh2 = gAreaA * aw;
+    float gBw2 = gAreaB * bh, gBh2 = gAreaB * bw;
+    if (awRaw > 0.0f) { *gAx2 += gAw2; *gAx1 += -gAw2; }
+    if (ahRaw > 0.0f) { *gAy2 += gAh2; *gAy1 += -gAh2; }
+    if (bwRaw > 0.0f) { *gBx2 += gBw2; *gBx1 += -gBw2; }
+    if (bhRaw > 0.0f) { *gBy2 += gBh2; *gBy1 += -gBh2; }
+}
+
+__kernel void detection_iou_backward_a(
+    __global const float* gradOutput,
+    __global const float* a, __global const float* b,
+    __global float* gradA,
+    const int n, const int m, const int variant)
+{
+    int i = get_global_id(0);
+    if (i >= n) return;
+    float ax1 = a[i * 4], ay1 = a[i * 4 + 1], ax2 = a[i * 4 + 2], ay2 = a[i * 4 + 3];
+    float sumX1 = 0.0f, sumY1 = 0.0f, sumX2 = 0.0f, sumY2 = 0.0f;
+    for (int j = 0; j < m; j++) {
+        float bx1 = b[j * 4], by1 = b[j * 4 + 1], bx2 = b[j * 4 + 2], by2 = b[j * 4 + 3];
+        float g = gradOutput[i * m + j];
+        float gAx1, gAy1, gAx2, gAy2, gBx1, gBy1, gBx2, gBy2;
+        compute_cell_grads_iou(ax1, ay1, ax2, ay2, bx1, by1, bx2, by2, g, variant,
+            &gAx1, &gAy1, &gAx2, &gAy2, &gBx1, &gBy1, &gBx2, &gBy2);
+        sumX1 += gAx1; sumY1 += gAy1; sumX2 += gAx2; sumY2 += gAy2;
+    }
+    gradA[i * 4] = sumX1;
+    gradA[i * 4 + 1] = sumY1;
+    gradA[i * 4 + 2] = sumX2;
+    gradA[i * 4 + 3] = sumY2;
+}
+
+__kernel void detection_iou_backward_b(
+    __global const float* gradOutput,
+    __global const float* a, __global const float* b,
+    __global float* gradB,
+    const int n, const int m, const int variant)
+{
+    int j = get_global_id(0);
+    if (j >= m) return;
+    float bx1 = b[j * 4], by1 = b[j * 4 + 1], bx2 = b[j * 4 + 2], by2 = b[j * 4 + 3];
+    float sumX1 = 0.0f, sumY1 = 0.0f, sumX2 = 0.0f, sumY2 = 0.0f;
+    for (int i = 0; i < n; i++) {
+        float ax1 = a[i * 4], ay1 = a[i * 4 + 1], ax2 = a[i * 4 + 2], ay2 = a[i * 4 + 3];
+        float g = gradOutput[i * m + j];
+        float gAx1, gAy1, gAx2, gAy2, gBx1, gBy1, gBx2, gBy2;
+        compute_cell_grads_iou(ax1, ay1, ax2, ay2, bx1, by1, bx2, by2, g, variant,
+            &gAx1, &gAy1, &gAx2, &gAy2, &gBx1, &gBy1, &gBx2, &gBy2);
+        sumX1 += gBx1; sumY1 += gBy1; sumX2 += gBx2; sumY2 += gBy2;
+    }
+    gradB[j * 4] = sumX1;
+    gradB[j * 4 + 1] = sumY1;
+    gradB[j * 4 + 2] = sumX2;
+    gradB[j * 4 + 3] = sumY2;
+}
+";
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClGeometryKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClGeometryKernels.cs
@@ -1,0 +1,290 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// OpenCL kernels for the geometry / sampling ops added by Issue #217.
+// Mirrors CudaGeometryKernels function-for-function. Same mode-int
+// mapping: InterpolateMode/PadMode/GridSampleMode/GridSamplePadding.
+
+#if !NET462
+namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL;
+
+public static class OpenClGeometryKernels
+{
+    public static string[] GetKernelNames() => new[]
+    {
+        "geometry_interpolate_2d",
+        "geometry_pad_4d",
+        "geometry_grid_sample_2d",
+        "geometry_affine_grid_3d",
+    };
+
+    public static string GetSource() => @"
+// ============================================================================
+// Shared device helpers.
+// ============================================================================
+
+inline double source_coord(int dstIdx, int dstSize, int srcSize, int alignCorners)
+{
+    if (dstSize <= 1) return 0.0;
+    if (alignCorners) return (double)dstIdx * (srcSize - 1) / (dstSize - 1);
+    return ((double)dstIdx + 0.5) * srcSize / dstSize - 0.5;
+}
+
+inline double cubic_kernel(double d, double a)
+{
+    double ad = fabs(d);
+    if (ad < 1.0) return ((a + 2.0) * ad - (a + 3.0)) * ad * ad + 1.0;
+    if (ad < 2.0) return a * ((ad - 5.0) * ad + 8.0) * ad - 4.0 * a;
+    return 0.0;
+}
+
+inline int clamp_i(int v, int lo, int hi) { return v < lo ? lo : (v > hi ? hi : v); }
+
+inline int reflect_index(int i, int extent)
+{
+    if (extent == 1) return 0;
+    int period = 2 * (extent - 1);
+    int r = ((i % period) + period) % period;
+    return r < extent ? r : period - r;
+}
+
+inline int pad_boundary(int idx, int extent, int mode)
+{
+    if (mode == 2) { if (idx < 0) return 0; if (idx >= extent) return extent - 1; return idx; }
+    if (mode == 1) return reflect_index(idx, extent);
+    int r = ((idx % extent) + extent) % extent;
+    return r;
+}
+
+// ----------------------------------------------------------------------------
+// Interpolate 2D NCHW — nearest/bilinear/bicubic/area.
+// ----------------------------------------------------------------------------
+
+__kernel void geometry_interpolate_2d(
+    __global const float* input, __global float* output,
+    const int N, const int C, const int Hin, const int Win,
+    const int Hout, const int Wout,
+    const int mode, const int alignCorners)
+{
+    int gid = get_global_id(0);
+    int total = N * C * Hout * Wout;
+    if (gid >= total) return;
+    int x = gid % Wout; int t1 = gid / Wout;
+    int y = t1 % Hout; int t2 = t1 / Hout;
+    int c = t2 % C; int n = t2 / C;
+
+    __global const float* src = input + ((n * C + c) * Hin) * Win;
+
+    if (mode == 0) {
+        double sy = Hout > 1 ? (double)y * Hin / Hout : 0.0;
+        double sx = Wout > 1 ? (double)x * Win / Wout : 0.0;
+        int yi = (int)floor(sy); if (yi >= Hin) yi = Hin - 1;
+        int xi = (int)floor(sx); if (xi >= Win) xi = Win - 1;
+        output[gid] = src[yi * Win + xi];
+    } else if (mode == 2) {
+        double sy = source_coord(y, Hout, Hin, alignCorners);
+        double sx = source_coord(x, Wout, Win, alignCorners);
+        int y0 = (int)floor(sy); int x0 = (int)floor(sx);
+        if (y0 < 0) y0 = 0; if (x0 < 0) x0 = 0;
+        int y1 = y0 + 1; int x1 = x0 + 1;
+        if (y1 >= Hin) { y1 = Hin - 1; if (y0 > y1) y0 = y1; }
+        if (x1 >= Win) { x1 = Win - 1; if (x0 > x1) x0 = x1; }
+        double fy = sy - y0; if (fy < 0) fy = 0; if (fy > 1) fy = 1;
+        double fx = sx - x0; if (fx < 0) fx = 0; if (fx > 1) fx = 1;
+        double v00 = src[y0 * Win + x0];
+        double v01 = src[y0 * Win + x1];
+        double v10 = src[y1 * Win + x0];
+        double v11 = src[y1 * Win + x1];
+        double v = v00 * (1 - fx) * (1 - fy) + v01 * fx * (1 - fy)
+                 + v10 * (1 - fx) * fy + v11 * fx * fy;
+        output[gid] = (float)v;
+    } else if (mode == 3) {
+        double sy = source_coord(y, Hout, Hin, alignCorners);
+        double sx = source_coord(x, Wout, Win, alignCorners);
+        int y0 = (int)floor(sy); double ty = sy - y0;
+        int x0 = (int)floor(sx); double tx = sx - x0;
+        double wy[4] = {
+            cubic_kernel(1.0 + ty, -0.75), cubic_kernel(ty, -0.75),
+            cubic_kernel(1.0 - ty, -0.75), cubic_kernel(2.0 - ty, -0.75),
+        };
+        double wx[4] = {
+            cubic_kernel(1.0 + tx, -0.75), cubic_kernel(tx, -0.75),
+            cubic_kernel(1.0 - tx, -0.75), cubic_kernel(2.0 - tx, -0.75),
+        };
+        double acc = 0.0;
+        for (int yy = 0; yy < 4; yy++) {
+            int yi = clamp_i(y0 - 1 + yy, 0, Hin - 1);
+            double rowAcc = 0.0;
+            for (int xx = 0; xx < 4; xx++) {
+                int xi = clamp_i(x0 - 1 + xx, 0, Win - 1);
+                rowAcc += wx[xx] * src[yi * Win + xi];
+            }
+            acc += wy[yy] * rowAcc;
+        }
+        output[gid] = (float)acc;
+    } else {
+        double yLo = (double)y * Hin / Hout;
+        double yHi = (double)(y + 1) * Hin / Hout;
+        double xLo = (double)x * Win / Wout;
+        double xHi = (double)(x + 1) * Win / Wout;
+        int yL = (int)floor(yLo); int yH = (int)ceil(yHi);
+        int xL = (int)floor(xLo); int xH = (int)ceil(xHi);
+        if (yH <= yL) yH = yL + 1;
+        if (xH <= xL) xH = xL + 1;
+        if (yH > Hin) yH = Hin;
+        if (xH > Win) xH = Win;
+        double acc = 0.0; int count = 0;
+        for (int yy = yL; yy < yH; yy++) for (int xx = xL; xx < xH; xx++) { acc += src[yy * Win + xx]; count++; }
+        output[gid] = (float)(count > 0 ? acc / count : 0.0);
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Pad 4D NCHW.
+// ----------------------------------------------------------------------------
+
+__kernel void geometry_pad_4d(
+    __global const float* input, __global float* output,
+    const int N, const int C, const int Hin, const int Win,
+    const int padN0, const int padN1, const int padC0, const int padC1,
+    const int padH0, const int padH1, const int padW0, const int padW1,
+    const int mode, const float padValue)
+{
+    int Nout = N + padN0 + padN1;
+    int Cout = C + padC0 + padC1;
+    int Hout = Hin + padH0 + padH1;
+    int Wout = Win + padW0 + padW1;
+    int total = Nout * Cout * Hout * Wout;
+    int gid = get_global_id(0);
+    if (gid >= total) return;
+
+    int w = gid % Wout; int t1 = gid / Wout;
+    int h = t1 % Hout; int t2 = t1 / Hout;
+    int c = t2 % Cout; int n = t2 / Cout;
+
+    int nn = n - padN0, cc = c - padC0, hh = h - padH0, ww = w - padW0;
+
+    bool inB = nn >= 0 && nn < N && cc >= 0 && cc < C && hh >= 0 && hh < Hin && ww >= 0 && ww < Win;
+    if (!inB && mode == 0) { output[gid] = padValue; return; }
+
+    if (!inB) {
+        if (!(nn >= 0 && nn < N)) nn = pad_boundary(nn, N, mode);
+        if (!(cc >= 0 && cc < C)) cc = pad_boundary(cc, C, mode);
+        if (!(hh >= 0 && hh < Hin)) hh = pad_boundary(hh, Hin, mode);
+        if (!(ww >= 0 && ww < Win)) ww = pad_boundary(ww, Win, mode);
+    }
+    output[gid] = input[((nn * C + cc) * Hin + hh) * Win + ww];
+}
+
+// ----------------------------------------------------------------------------
+// GridSample 2D NHWC.
+// ----------------------------------------------------------------------------
+
+inline float grid_sample_safe(__global const float* src,
+    int n, int y, int x, int c, int H, int W, int C, int padding)
+{
+    if (padding == 0) {
+        if ((uint)y >= (uint)H || (uint)x >= (uint)W) return 0.0f;
+    } else if (padding == 1) {
+        y = clamp_i(y, 0, H - 1); x = clamp_i(x, 0, W - 1);
+    } else {
+        y = reflect_index(y, H); x = reflect_index(x, W);
+    }
+    return src[((n * H + y) * W + x) * C + c];
+}
+
+__kernel void geometry_grid_sample_2d(
+    __global const float* input, __global const float* grid,
+    __global float* output,
+    const int N, const int H, const int W, const int C,
+    const int outH, const int outW,
+    const int mode, const int padding, const int alignCorners)
+{
+    int gid = get_global_id(0);
+    int total = N * outH * outW;
+    if (gid >= total) return;
+    int ox = gid % outW; int t1 = gid / outW;
+    int oy = t1 % outH; int n = t1 / outH;
+
+    int gOff = ((n * outH + oy) * outW + ox) * 2;
+    double gx = grid[gOff];
+    double gy = grid[gOff + 1];
+    double sx = alignCorners ? (gx + 1.0) * 0.5 * (W - 1) : ((gx + 1.0) * W - 1.0) * 0.5;
+    double sy = alignCorners ? (gy + 1.0) * 0.5 * (H - 1) : ((gy + 1.0) * H - 1.0) * 0.5;
+
+    if (mode == 1) {
+        int nx = (int)round(sx), ny = (int)round(sy);
+        for (int c = 0; c < C; c++)
+            output[((n * outH + oy) * outW + ox) * C + c] =
+                grid_sample_safe(input, n, ny, nx, c, H, W, C, padding);
+    } else if (mode == 0) {
+        int x0 = (int)floor(sx), y0 = (int)floor(sy);
+        int x1 = x0 + 1, y1 = y0 + 1;
+        double fx = sx - x0, fy = sy - y0;
+        for (int c = 0; c < C; c++) {
+            float v00 = grid_sample_safe(input, n, y0, x0, c, H, W, C, padding);
+            float v01 = grid_sample_safe(input, n, y0, x1, c, H, W, C, padding);
+            float v10 = grid_sample_safe(input, n, y1, x0, c, H, W, C, padding);
+            float v11 = grid_sample_safe(input, n, y1, x1, c, H, W, C, padding);
+            double v = v00 * (1 - fx) * (1 - fy) + v01 * fx * (1 - fy)
+                     + v10 * (1 - fx) * fy + v11 * fx * fy;
+            output[((n * outH + oy) * outW + ox) * C + c] = (float)v;
+        }
+    } else {
+        int x0 = (int)floor(sx), y0 = (int)floor(sy);
+        double fx = sx - x0, fy = sy - y0;
+        double wy[4] = { cubic_kernel(1.0 + fy, -0.75), cubic_kernel(fy, -0.75),
+                         cubic_kernel(1.0 - fy, -0.75), cubic_kernel(2.0 - fy, -0.75) };
+        double wx[4] = { cubic_kernel(1.0 + fx, -0.75), cubic_kernel(fx, -0.75),
+                         cubic_kernel(1.0 - fx, -0.75), cubic_kernel(2.0 - fx, -0.75) };
+        for (int c = 0; c < C; c++) {
+            double acc = 0.0;
+            for (int yy = 0; yy < 4; yy++) {
+                int yi = y0 - 1 + yy;
+                double rowAcc = 0.0;
+                for (int xx = 0; xx < 4; xx++) {
+                    int xi = x0 - 1 + xx;
+                    rowAcc += wx[xx] * grid_sample_safe(input, n, yi, xi, c, H, W, C, padding);
+                }
+                acc += wy[yy] * rowAcc;
+            }
+            output[((n * outH + oy) * outW + ox) * C + c] = (float)acc;
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------
+// AffineGrid 3D.
+// ----------------------------------------------------------------------------
+
+inline double grid_norm_coord(int idx, int size, int alignCorners)
+{
+    if (size <= 1) return 0.0;
+    return alignCorners ? -1.0 + 2.0 * idx / (size - 1) : -1.0 + (2.0 * idx + 1.0) / size;
+}
+
+__kernel void geometry_affine_grid_3d(
+    __global const float* theta, __global float* grid,
+    const int N, const int D, const int H, const int W, const int alignCorners)
+{
+    int gid = get_global_id(0);
+    int total = N * D * H * W;
+    if (gid >= total) return;
+    int w = gid % W; int t1 = gid / W;
+    int h = t1 % H; int t2 = t1 / H;
+    int d = t2 % D; int n = t2 / D;
+
+    int tBase = n * 12;
+    double x = grid_norm_coord(w, W, alignCorners);
+    double y = grid_norm_coord(h, H, alignCorners);
+    double z = grid_norm_coord(d, D, alignCorners);
+    int gBase = (((n * D + d) * H + h) * W + w) * 3;
+    for (int row = 0; row < 3; row++) {
+        double v = theta[tBase + row * 4] * x
+                 + theta[tBase + row * 4 + 1] * y
+                 + theta[tBase + row * 4 + 2] * z
+                 + theta[tBase + row * 4 + 3];
+        grid[gBase + row] = (float)v;
+    }
+}
+";
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClGeometryKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClGeometryKernels.cs
@@ -48,6 +48,7 @@ inline int reflect_index(int i, int extent)
 
 inline int pad_boundary(int idx, int extent, int mode)
 {
+    if (extent <= 0) return 0;
     if (mode == 2) { if (idx < 0) return 0; if (idx >= extent) return extent - 1; return idx; }
     if (mode == 1) return reflect_index(idx, extent);
     int r = ((idx % extent) + extent) % extent;
@@ -120,7 +121,7 @@ __kernel void geometry_interpolate_2d(
             acc += wy[yy] * rowAcc;
         }
         output[gid] = (float)acc;
-    } else {
+    } else {  // Area — overlap-weighted averaging
         double yLo = (double)y * Hin / Hout;
         double yHi = (double)(y + 1) * Hin / Hout;
         double xLo = (double)x * Win / Wout;
@@ -131,9 +132,18 @@ __kernel void geometry_interpolate_2d(
         if (xH <= xL) xH = xL + 1;
         if (yH > Hin) yH = Hin;
         if (xH > Win) xH = Win;
-        double acc = 0.0; int count = 0;
-        for (int yy = yL; yy < yH; yy++) for (int xx = xL; xx < xH; xx++) { acc += src[yy * Win + xx]; count++; }
-        output[gid] = (float)(count > 0 ? acc / count : 0.0);
+        double totalArea = (yHi - yLo) * (xHi - xLo);
+        double acc = 0.0;
+        for (int yy = yL; yy < yH; yy++) {
+            double oy = fmax(0.0, fmin(yHi, (double)(yy + 1)) - fmax(yLo, (double)yy));
+            if (oy <= 0.0) continue;
+            for (int xx = xL; xx < xH; xx++) {
+                double ox = fmax(0.0, fmin(xHi, (double)(xx + 1)) - fmax(xLo, (double)xx));
+                if (ox <= 0.0) continue;
+                acc += oy * ox * src[yy * Win + xx];
+            }
+        }
+        output[gid] = (float)(totalArea > 0.0 ? acc / totalArea : 0.0);
     }
 }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClGeometryKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClGeometryKernels.cs
@@ -17,6 +17,16 @@ public static class OpenClGeometryKernels
     };
 
     public static string GetSource() => @"
+// Geometry kernels use double for the source-coord math (torchvision
+// parity — integer-ratio resizes need 1e-16 precision to match CPU).
+// Enable fp64 explicitly; devices without fp64 support fall through to
+// the managed CpuEngine reference at the engine level.
+#ifdef cl_khr_fp64
+#pragma OPENCL EXTENSION cl_khr_fp64 : enable
+#elif defined(cl_amd_fp64)
+#pragma OPENCL EXTENSION cl_amd_fp64 : enable
+#endif
+
 // ============================================================================
 // Shared device helpers.
 // ============================================================================

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClRoiKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClRoiKernels.cs
@@ -14,6 +14,7 @@ public static class OpenClRoiKernels
 inline float bilinear_sample(__global const float* src, int planeBase,
     float y, float x, int H, int W)
 {
+    if (H <= 0 || W <= 0) return 0.0f;
     if (y < -1.0f || y > (float)H || x < -1.0f || x > (float)W) return 0.0f;
     if (y <= 0) y = 0;
     if (x <= 0) x = 0;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClRoiKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClRoiKernels.cs
@@ -1,0 +1,118 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// OpenCL RoI kernels (Issue #217 tail).
+#if !NET462
+namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL;
+
+public static class OpenClRoiKernels
+{
+    public static string[] GetKernelNames() => new[] { "roi_align", "roi_pool" };
+
+    public static string GetSource() => @"
+inline float bilinear_sample(__global const float* src, int planeBase,
+    float y, float x, int H, int W)
+{
+    if (y < -1.0f || y > (float)H || x < -1.0f || x > (float)W) return 0.0f;
+    if (y <= 0) y = 0;
+    if (x <= 0) x = 0;
+    int y0 = (int)y;
+    int x0 = (int)x;
+    int y1 = y0 + 1 >= H ? H - 1 : y0 + 1;
+    int x1 = x0 + 1 >= W ? W - 1 : x0 + 1;
+    if (y0 >= H - 1) { y0 = y1 = H - 1; y = (float)y0; }
+    if (x0 >= W - 1) { x0 = x1 = W - 1; x = (float)x0; }
+    float ly = y - y0, lx = x - x0;
+    float hy = 1.0f - ly, hx = 1.0f - lx;
+    return hy * hx * src[planeBase + y0 * W + x0]
+         + hy * lx * src[planeBase + y0 * W + x1]
+         + ly * hx * src[planeBase + y1 * W + x0]
+         + ly * lx * src[planeBase + y1 * W + x1];
+}
+
+__kernel void roi_align(
+    __global const float* input, __global const float* boxes,
+    __global float* output,
+    const int N, const int C, const int H, const int W, const int K,
+    const int outH, const int outW,
+    const float spatialScale, const int samplingRatio, const int aligned)
+{
+    int gid = get_global_id(0);
+    int total = K * C * outH * outW;
+    if (gid >= total) return;
+    int pw = gid % outW; int t1 = gid / outW;
+    int ph = t1 % outH; int t2 = t1 / outH;
+    int c = t2 % C; int k = t2 / C;
+
+    int n = (int)boxes[k * 5];
+    if (n < 0 || n >= N) { output[gid] = 0.0f; return; }
+    float offset = aligned ? 0.5f : 0.0f;
+    float x1 = boxes[k * 5 + 1] * spatialScale - offset;
+    float y1 = boxes[k * 5 + 2] * spatialScale - offset;
+    float x2 = boxes[k * 5 + 3] * spatialScale - offset;
+    float y2 = boxes[k * 5 + 4] * spatialScale - offset;
+    float roiW = aligned ? (x2 - x1) : fmax(x2 - x1, 1.0f);
+    float roiH = aligned ? (y2 - y1) : fmax(y2 - y1, 1.0f);
+    float binH = roiH / outH;
+    float binW = roiW / outW;
+    int ry = samplingRatio > 0 ? samplingRatio : (int)ceil(roiH / outH);
+    int rx = samplingRatio > 0 ? samplingRatio : (int)ceil(roiW / outW);
+    if (ry < 1) ry = 1;
+    if (rx < 1) rx = 1;
+
+    int planeBase = (n * C + c) * H * W;
+    float acc = 0;
+    for (int iy = 0; iy < ry; iy++) {
+        float sy = y1 + ph * binH + (iy + 0.5f) * binH / ry;
+        for (int ix = 0; ix < rx; ix++) {
+            float sx = x1 + pw * binW + (ix + 0.5f) * binW / rx;
+            acc += bilinear_sample(input, planeBase, sy, sx, H, W);
+        }
+    }
+    output[gid] = acc / (ry * rx);
+}
+
+__kernel void roi_pool(
+    __global const float* input, __global const float* boxes,
+    __global float* output,
+    const int N, const int C, const int H, const int W, const int K,
+    const int outH, const int outW, const float spatialScale)
+{
+    int gid = get_global_id(0);
+    int total = K * C * outH * outW;
+    if (gid >= total) return;
+    int pw = gid % outW; int t1 = gid / outW;
+    int ph = t1 % outH; int t2 = t1 / outH;
+    int c = t2 % C; int k = t2 / C;
+
+    int n = (int)boxes[k * 5];
+    if (n < 0 || n >= N) { output[gid] = 0.0f; return; }
+    int x1 = (int)round(boxes[k * 5 + 1] * spatialScale);
+    int y1 = (int)round(boxes[k * 5 + 2] * spatialScale);
+    int x2 = (int)round(boxes[k * 5 + 3] * spatialScale);
+    int y2 = (int)round(boxes[k * 5 + 4] * spatialScale);
+    int roiW = x2 - x1 + 1; if (roiW < 1) roiW = 1;
+    int roiH = y2 - y1 + 1; if (roiH < 1) roiH = 1;
+    float binH = (float)roiH / outH;
+    float binW = (float)roiW / outW;
+
+    int hstart = (int)floor(ph * binH) + y1;
+    int hend = (int)ceil((ph + 1) * binH) + y1;
+    int wstart = (int)floor(pw * binW) + x1;
+    int wend = (int)ceil((pw + 1) * binW) + x1;
+    if (hstart < 0) hstart = 0; if (hstart > H) hstart = H;
+    if (hend < 0) hend = 0; if (hend > H) hend = H;
+    if (wstart < 0) wstart = 0; if (wstart > W) wstart = W;
+    if (wend < 0) wend = 0; if (wend > W) wend = W;
+
+    int planeBase = (n * C + c) * H * W;
+    if (hend <= hstart || wend <= wstart) { output[gid] = 0.0f; return; }
+    float best = -FLT_MAX;
+    for (int yy = hstart; yy < hend; yy++)
+        for (int xx = wstart; xx < wend; xx++) {
+            float v = input[planeBase + yy * W + xx];
+            if (v > best) best = v;
+        }
+    output[gid] = best;
+}
+";
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClRoiKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClRoiKernels.cs
@@ -148,6 +148,7 @@ __kernel void ps_roi_align(
     if (rx < 1) rx = 1;
 
     int c = (co * outH + ph) * outW + pw;
+    if (c >= C) { output[gid] = 0.0f; return; }
     int planeBase = (n * C + c) * H * W;
     float acc = 0;
     for (int iy = 0; iy < ry; iy++) {
@@ -184,6 +185,7 @@ __kernel void ps_roi_pool(
     float binW = fmax(x2 - x1, 0.1f) / outW;
 
     int c = (co * outH + ph) * outW + pw;
+    if (c >= C) { output[gid] = 0.0f; return; }
     int planeBase = (n * C + c) * H * W;
     int hs = (int)fmax(0.0f, floor(y1 + ph * binH));
     int he = (int)fmin((float)H, ceil(y1 + (ph + 1) * binH));

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClRoiKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClRoiKernels.cs
@@ -5,7 +5,10 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL;
 
 public static class OpenClRoiKernels
 {
-    public static string[] GetKernelNames() => new[] { "roi_align", "roi_pool" };
+    public static string[] GetKernelNames() => new[]
+    {
+        "roi_align", "roi_pool", "ps_roi_align", "ps_roi_pool",
+    };
 
     public static string GetSource() => @"
 inline float bilinear_sample(__global const float* src, int planeBase,
@@ -112,6 +115,84 @@ __kernel void roi_pool(
             if (v > best) best = v;
         }
     output[gid] = best;
+}
+
+// Position-sensitive RoIAlign (R-FCN).
+__kernel void ps_roi_align(
+    __global const float* input, __global const float* boxes,
+    __global float* output,
+    const int N, const int C, const int H, const int W, const int K,
+    const int outH, const int outW, const int outputChannels,
+    const float spatialScale, const int samplingRatio)
+{
+    int gid = get_global_id(0);
+    int total = K * outputChannels * outH * outW;
+    if (gid >= total) return;
+    int pw = gid % outW; int t1 = gid / outW;
+    int ph = t1 % outH; int t2 = t1 / outH;
+    int co = t2 % outputChannels; int k = t2 / outputChannels;
+
+    int n = (int)boxes[k * 5];
+    if (n < 0 || n >= N) { output[gid] = 0.0f; return; }
+    float x1 = boxes[k * 5 + 1] * spatialScale;
+    float y1 = boxes[k * 5 + 2] * spatialScale;
+    float x2 = boxes[k * 5 + 3] * spatialScale;
+    float y2 = boxes[k * 5 + 4] * spatialScale;
+    float roiW = fmax(x2 - x1, 0.1f);
+    float roiH = fmax(y2 - y1, 0.1f);
+    float binH = roiH / outH;
+    float binW = roiW / outW;
+    int ry = samplingRatio > 0 ? samplingRatio : (int)ceil(roiH / outH);
+    int rx = samplingRatio > 0 ? samplingRatio : (int)ceil(roiW / outW);
+    if (ry < 1) ry = 1;
+    if (rx < 1) rx = 1;
+
+    int c = (co * outH + ph) * outW + pw;
+    int planeBase = (n * C + c) * H * W;
+    float acc = 0;
+    for (int iy = 0; iy < ry; iy++) {
+        float sy = y1 + ph * binH + (iy + 0.5f) * binH / ry;
+        for (int ix = 0; ix < rx; ix++) {
+            float sx = x1 + pw * binW + (ix + 0.5f) * binW / rx;
+            acc += bilinear_sample(input, planeBase, sy, sx, H, W);
+        }
+    }
+    output[gid] = acc / (ry * rx);
+}
+
+__kernel void ps_roi_pool(
+    __global const float* input, __global const float* boxes,
+    __global float* output,
+    const int N, const int C, const int H, const int W, const int K,
+    const int outH, const int outW, const int outputChannels,
+    const float spatialScale)
+{
+    int gid = get_global_id(0);
+    int total = K * outputChannels * outH * outW;
+    if (gid >= total) return;
+    int pw = gid % outW; int t1 = gid / outW;
+    int ph = t1 % outH; int t2 = t1 / outH;
+    int co = t2 % outputChannels; int k = t2 / outputChannels;
+
+    int n = (int)boxes[k * 5];
+    if (n < 0 || n >= N) { output[gid] = 0.0f; return; }
+    float x1 = boxes[k * 5 + 1] * spatialScale;
+    float y1 = boxes[k * 5 + 2] * spatialScale;
+    float x2 = boxes[k * 5 + 3] * spatialScale;
+    float y2 = boxes[k * 5 + 4] * spatialScale;
+    float binH = fmax(y2 - y1, 0.1f) / outH;
+    float binW = fmax(x2 - x1, 0.1f) / outW;
+
+    int c = (co * outH + ph) * outW + pw;
+    int planeBase = (n * C + c) * H * W;
+    int hs = (int)fmax(0.0f, floor(y1 + ph * binH));
+    int he = (int)fmin((float)H, ceil(y1 + (ph + 1) * binH));
+    int ws = (int)fmax(0.0f, floor(x1 + pw * binW));
+    int we = (int)fmin((float)W, ceil(x1 + (pw + 1) * binW));
+    float acc = 0; int cnt = 0;
+    for (int yy = hs; yy < he; yy++)
+        for (int xx = ws; xx < we; xx++) { acc += input[planeBase + yy * W + xx]; cnt++; }
+    output[gid] = cnt > 0 ? acc / cnt : 0.0f;
 }
 ";
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanAudioKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanAudioKernels.cs
@@ -1,0 +1,112 @@
+namespace AiDotNet.Tensors.Engines.DirectGpu.Vulkan;
+
+public static class VulkanAudioKernels
+{
+    private const string Header = @"#version 450
+layout(local_size_x = 256) in;
+";
+
+    public static string AmplitudeToDB => Header + @"
+layout(set = 0, binding = 0) readonly buffer I { float input_[]; };
+layout(set = 0, binding = 1) writeonly buffer O { float output_[]; };
+layout(push_constant) uniform P { int length; float minAmp; float topDbFloor; int clipTopDb; };
+void main() {
+    int gid = int(gl_GlobalInvocationID.x);
+    if (gid >= length) return;
+    float v = max(input_[gid], minAmp);
+    float db = 20.0 * log(v) / log(10.0);
+    if (clipTopDb != 0 && db < topDbFloor) db = topDbFloor;
+    output_[gid] = db;
+}
+";
+
+    public static string MuLawEncoding => Header + @"
+layout(set = 0, binding = 0) readonly buffer I { float input_[]; };
+layout(set = 0, binding = 1) writeonly buffer O { float output_[]; };
+layout(push_constant) uniform P { int length; int quantizationChannels; };
+void main() {
+    int gid = int(gl_GlobalInvocationID.x);
+    if (gid >= length) return;
+    float mu = float(quantizationChannels - 1);
+    float logMu = log(1.0 + mu);
+    float x = input_[gid];
+    if (x > 1.0) x = 1.0; else if (x < -1.0) x = -1.0;
+    float sgn = float(x > 0.0) - float(x < 0.0);
+    float y = sgn * log(1.0 + mu * abs(x)) / logMu;
+    float q = floor((y + 1.0) * 0.5 * mu + 0.5);
+    if (q < 0.0) q = 0.0; else if (q > mu) q = mu;
+    output_[gid] = q;
+}
+";
+
+    public static string MuLawDecoding => Header + @"
+layout(set = 0, binding = 0) readonly buffer I { float input_[]; };
+layout(set = 0, binding = 1) writeonly buffer O { float output_[]; };
+layout(push_constant) uniform P { int length; int quantizationChannels; };
+void main() {
+    int gid = int(gl_GlobalInvocationID.x);
+    if (gid >= length) return;
+    float mu = float(quantizationChannels - 1);
+    float q = input_[gid];
+    float y = (q / mu) * 2.0 - 1.0;
+    float sgn = float(y > 0.0) - float(y < 0.0);
+    output_[gid] = sgn * (pow(1.0 + mu, abs(y)) - 1.0) / mu;
+}
+";
+
+    public static string ComputeDeltas => Header + @"
+layout(set = 0, binding = 0) readonly buffer I { float input_[]; };
+layout(set = 0, binding = 1) writeonly buffer O { float output_[]; };
+layout(push_constant) uniform P { int leading; int timeAxis; int winLength; };
+void main() {
+    int gid = int(gl_GlobalInvocationID.x);
+    int total = leading * timeAxis;
+    if (gid >= total) return;
+    int t = gid % timeAxis;
+    int row = gid / timeAxis;
+    int n = winLength / 2;
+    float denom = 0.0;
+    for (int i = 1; i <= n; i++) denom += 2.0 * i * i;
+    float acc = 0.0;
+    int base_ = row * timeAxis;
+    for (int k = 1; k <= n; k++) {
+        int left = t - k < 0 ? 0 : t - k;
+        int right = t + k >= timeAxis ? timeAxis - 1 : t + k;
+        acc += k * (input_[base_ + right] - input_[base_ + left]);
+    }
+    output_[gid] = acc / denom;
+}
+";
+
+    public static string Resample => Header + @"
+layout(set = 0, binding = 0) readonly buffer I { float input_[]; };
+layout(set = 0, binding = 1) writeonly buffer O { float output_[]; };
+layout(push_constant) uniform P {
+    int leading; int inLen; int outLen; int up; int down; int halfWidth;
+};
+void main() {
+    int gid = int(gl_GlobalInvocationID.x);
+    int total = leading * outLen;
+    if (gid >= total) return;
+    int ot = gid % outLen;
+    int row = gid / outLen;
+    int sBase = row * inLen;
+    float cutoff = 1.0 / float(up > down ? up : down);
+    float srcIdx = float(ot) * float(down) / float(up);
+    int centre = int(floor(srcIdx));
+    float acc = 0.0, wSum = 0.0;
+    const float PI = 3.14159265358979323846;
+    for (int k = -halfWidth; k <= halfWidth; k++) {
+        int idx = centre + k;
+        if (idx < 0 || idx >= inLen) continue;
+        float tt = (float(idx) - srcIdx) * cutoff;
+        float sinc = abs(tt) < 1e-12 ? 1.0 : sin(PI * tt) / (PI * tt);
+        float hann = 0.5 - 0.5 * cos(2.0 * PI * float(k + halfWidth) / float(2 * halfWidth));
+        float w = sinc * hann;
+        acc += w * input_[sBase + idx];
+        wSum += w;
+    }
+    output_[gid] = wSum > 0.0 ? acc / wSum : 0.0;
+}
+";
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanAudioKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanAudioKernels.cs
@@ -65,6 +65,7 @@ void main() {
     int t = gid % timeAxis;
     int row = gid / timeAxis;
     int n = winLength / 2;
+    if (n < 1) { output_[gid] = 0.0; return; }
     float denom = 0.0;
     for (int i = 1; i <= n; i++) denom += 2.0 * i * i;
     float acc = 0.0;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanAudioKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanAudioKernels.cs
@@ -27,6 +27,7 @@ layout(push_constant) uniform P { int length; int quantizationChannels; };
 void main() {
     int gid = int(gl_GlobalInvocationID.x);
     if (gid >= length) return;
+    if (quantizationChannels < 2) { output_[gid] = 0.0; return; }
     float mu = float(quantizationChannels - 1);
     float logMu = log(1.0 + mu);
     float x = input_[gid];
@@ -46,6 +47,7 @@ layout(push_constant) uniform P { int length; int quantizationChannels; };
 void main() {
     int gid = int(gl_GlobalInvocationID.x);
     if (gid >= length) return;
+    if (quantizationChannels < 2) { output_[gid] = 0.0; return; }
     float mu = float(quantizationChannels - 1);
     float q = input_[gid];
     float y = (q / mu) * 2.0 - 1.0;
@@ -89,6 +91,7 @@ void main() {
     int gid = int(gl_GlobalInvocationID.x);
     int total = leading * outLen;
     if (gid >= total) return;
+    if (halfWidth < 1 || up <= 0 || down <= 0) { output_[gid] = 0.0; return; }
     int ot = gid % outLen;
     int row = gid / outLen;
     int sBase = row * inLen;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.Audio.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.Audio.cs
@@ -1,0 +1,49 @@
+// Copyright (c) AiDotNet. All rights reserved.
+namespace AiDotNet.Tensors.Engines.DirectGpu.Vulkan;
+
+public sealed unsafe partial class VulkanBackend : IAudioBackend
+{
+    public void AmplitudeToDB(IGpuBuffer input, IGpuBuffer output, int length,
+        float minAmplitude, float topDb, bool clipTopDb)
+    {
+        if (length <= 0) return;
+        uint mA = BitConverter.ToUInt32(BitConverter.GetBytes(minAmplitude), 0);
+        uint tD = BitConverter.ToUInt32(BitConverter.GetBytes(topDb), 0);
+        var pc = new uint[] { (uint)length, mA, tD, (uint)(clipTopDb ? 1 : 0) };
+        GlslUnaryOp(VulkanAudioKernels.AmplitudeToDB, input, output, length, pc, 16u);
+    }
+
+    public void MuLawEncoding(IGpuBuffer input, IGpuBuffer output, int length, int qc)
+    {
+        if (length <= 0) return;
+        var pc = new uint[] { (uint)length, (uint)qc };
+        GlslUnaryOp(VulkanAudioKernels.MuLawEncoding, input, output, length, pc, 8u);
+    }
+
+    public void MuLawDecoding(IGpuBuffer input, IGpuBuffer output, int length, int qc)
+    {
+        if (length <= 0) return;
+        var pc = new uint[] { (uint)length, (uint)qc };
+        GlslUnaryOp(VulkanAudioKernels.MuLawDecoding, input, output, length, pc, 8u);
+    }
+
+    public void ComputeDeltas(IGpuBuffer input, IGpuBuffer output,
+        int leading, int timeAxis, int winLength)
+    {
+        int total = leading * timeAxis;
+        if (total <= 0) return;
+        var pc = new uint[] { (uint)leading, (uint)timeAxis, (uint)winLength };
+        GlslUnaryOp(VulkanAudioKernels.ComputeDeltas, input, output, total, pc, 12u);
+    }
+
+    public void Resample(IGpuBuffer input, IGpuBuffer output,
+        int leading, int inLen, int outLen, int up, int down, int halfWidth)
+    {
+        int total = leading * outLen;
+        if (total <= 0) return;
+        var pc = new uint[] {
+            (uint)leading, (uint)inLen, (uint)outLen, (uint)up, (uint)down, (uint)halfWidth
+        };
+        GlslUnaryOp(VulkanAudioKernels.Resample, input, output, total, pc, 24u);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.Detection.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.Detection.cs
@@ -1,0 +1,68 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Vulkan launcher shims for the vision detection kernels (Issue #217).
+// Mirrors VulkanBackend.Parity210.cs — pipelines cached by GLSL source hash
+// via GetOrCreateGlslPipeline, so first call compiles SPIR-V, subsequent
+// dispatches are O(1) lookups.
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.Vulkan;
+
+public sealed unsafe partial class VulkanBackend : IDetectionBackend
+{
+    private const uint DetectionPushNm = 8u;       // 2 ints (n, m)
+    private const uint DetectionPushN = 4u;        // 1 int (n)
+    private const uint DetectionPushNFromTo = 12u; // 3 ints (n, fromFormat, toFormat)
+
+    private void DispatchPairwiseIou(string shader,
+        IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m)
+    {
+        if (n <= 0 || m <= 0) return;
+        int total = n * m;
+        var pc = new uint[] { (uint)n, (uint)m };
+        GlslBinaryOp(shader, boxesA, boxesB, output, total, pc, DetectionPushNm);
+    }
+
+    public void BoxIou(IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m)
+        => DispatchPairwiseIou(VulkanDetectionKernels.BoxIou, boxesA, boxesB, output, n, m);
+
+    public void GeneralizedBoxIou(IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m)
+        => DispatchPairwiseIou(VulkanDetectionKernels.GeneralizedBoxIou, boxesA, boxesB, output, n, m);
+
+    public void DistanceBoxIou(IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m)
+        => DispatchPairwiseIou(VulkanDetectionKernels.DistanceBoxIou, boxesA, boxesB, output, n, m);
+
+    public void CompleteBoxIou(IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m)
+        => DispatchPairwiseIou(VulkanDetectionKernels.CompleteBoxIou, boxesA, boxesB, output, n, m);
+
+    public void BoxArea(IGpuBuffer boxes, IGpuBuffer output, int n)
+    {
+        if (n <= 0) return;
+        var pc = new uint[] { (uint)n };
+        GlslUnaryOp(VulkanDetectionKernels.BoxArea, boxes, output, n, pc, DetectionPushN);
+    }
+
+    public void BoxConvert(IGpuBuffer boxes, IGpuBuffer output, int n, int fromFormat, int toFormat)
+    {
+        if (n <= 0) return;
+        var pc = new uint[] { (uint)n, (uint)fromFormat, (uint)toFormat };
+        GlslUnaryOp(VulkanDetectionKernels.BoxConvert, boxes, output, n, pc, DetectionPushNFromTo);
+    }
+
+    // -----------------------------------------------------------------------
+    // IoU family backward — 4 SSBO bindings, 3 push-constant ints.
+    // Dispatched as two separate pipelines (A-side N threads, B-side M).
+    // -----------------------------------------------------------------------
+    private const uint DetectionPushNMVariant = 12u;   // 3 ints
+
+    public void IouFamilyBackward(
+        IGpuBuffer gradOutput, IGpuBuffer boxesA, IGpuBuffer boxesB,
+        IGpuBuffer gradA, IGpuBuffer gradB,
+        int n, int m, int variant)
+    {
+        if (n <= 0 || m <= 0) return;
+        var pc = new uint[] { (uint)n, (uint)m, (uint)variant };
+        GlslQuadOp(VulkanDetectionKernels.IouBackwardA,
+            gradOutput, boxesA, boxesB, gradA, n, pc, DetectionPushNMVariant);
+        GlslQuadOp(VulkanDetectionKernels.IouBackwardB,
+            gradOutput, boxesA, boxesB, gradB, m, pc, DetectionPushNMVariant);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.Detection.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.Detection.cs
@@ -58,11 +58,19 @@ public sealed unsafe partial class VulkanBackend : IDetectionBackend
         IGpuBuffer gradA, IGpuBuffer gradB,
         int n, int m, int variant)
     {
-        if (n <= 0 || m <= 0) return;
+        // Don't short-circuit on n==0 or m==0: the kernels iterate the
+        // "other" dim with a for-loop, so when M==0 the A-side kernel
+        // writes zero sums for each of N rows (correct), and symmetric
+        // for N==0. Skipping the dispatch would leak whatever stale data
+        // was in the pooled gradA/gradB buffers into autodiff. Only bail
+        // when BOTH dims are zero (nothing to write).
+        if (n <= 0 && m <= 0) return;
         var pc = new uint[] { (uint)n, (uint)m, (uint)variant };
-        GlslQuadOp(VulkanDetectionKernels.IouBackwardA,
-            gradOutput, boxesA, boxesB, gradA, n, pc, DetectionPushNMVariant);
-        GlslQuadOp(VulkanDetectionKernels.IouBackwardB,
-            gradOutput, boxesA, boxesB, gradB, m, pc, DetectionPushNMVariant);
+        if (n > 0)
+            GlslQuadOp(VulkanDetectionKernels.IouBackwardA,
+                gradOutput, boxesA, boxesB, gradA, n, pc, DetectionPushNMVariant);
+        if (m > 0)
+            GlslQuadOp(VulkanDetectionKernels.IouBackwardB,
+                gradOutput, boxesA, boxesB, gradB, m, pc, DetectionPushNMVariant);
     }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.Detection.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.Detection.cs
@@ -43,6 +43,9 @@ public sealed unsafe partial class VulkanBackend : IDetectionBackend
     public void BoxConvert(IGpuBuffer boxes, IGpuBuffer output, int n, int fromFormat, int toFormat)
     {
         if (n <= 0) return;
+        if ((uint)fromFormat > 2 || (uint)toFormat > 2)
+            throw new ArgumentException(
+                $"fromFormat/toFormat must be 0/1/2; got {fromFormat}, {toFormat}.");
         var pc = new uint[] { (uint)n, (uint)fromFormat, (uint)toFormat };
         GlslUnaryOp(VulkanDetectionKernels.BoxConvert, boxes, output, n, pc, DetectionPushNFromTo);
     }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.Detection.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.Detection.cs
@@ -16,7 +16,10 @@ public sealed unsafe partial class VulkanBackend : IDetectionBackend
         IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m)
     {
         if (n <= 0 || m <= 0) return;
-        int total = n * m;
+        long totalLong = (long)n * m;
+        if (totalLong > int.MaxValue)
+            throw new OverflowException($"Pairwise IoU total {totalLong} exceeds Int32.MaxValue.");
+        int total = (int)totalLong;
         var pc = new uint[] { (uint)n, (uint)m };
         GlslBinaryOp(shader, boxesA, boxesB, output, total, pc, DetectionPushNm);
     }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.Geometry.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.Geometry.cs
@@ -1,0 +1,74 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Vulkan launcher shims for the geometry / sampling kernels (Issue #217).
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.Vulkan;
+
+public sealed unsafe partial class VulkanBackend : IGeometryBackend
+{
+    // Push-constant sizes (bytes):
+    //  Interpolate2D = 8 ints = 32
+    //  Pad4D         = 13 ints + 1 float = 56
+    //  GridSample2D  = 9 ints = 36
+    //  AffineGrid3D  = 5 ints = 20
+    private const uint GeometryPushInterp = 32u;
+    private const uint GeometryPushPad    = 56u;
+    private const uint GeometryPushGrid   = 36u;
+    private const uint GeometryPushAff    = 20u;
+
+    public void Interpolate2D(IGpuBuffer input, IGpuBuffer output,
+        int N, int C, int Hin, int Win, int Hout, int Wout,
+        int mode, bool alignCorners)
+    {
+        int total = N * C * Hout * Wout;
+        if (total <= 0) return;
+        var pc = new uint[] {
+            (uint)N, (uint)C, (uint)Hin, (uint)Win,
+            (uint)Hout, (uint)Wout, (uint)mode, (uint)(alignCorners ? 1 : 0)
+        };
+        GlslUnaryOp(VulkanGeometryKernels.Interpolate2D, input, output, total, pc, GeometryPushInterp);
+    }
+
+    public void Pad4D(IGpuBuffer input, IGpuBuffer output,
+        int N, int C, int Hin, int Win,
+        int padN0, int padN1, int padC0, int padC1,
+        int padH0, int padH1, int padW0, int padW1,
+        int mode, float padValue)
+    {
+        int total = (N + padN0 + padN1) * (C + padC0 + padC1) * (Hin + padH0 + padH1) * (Win + padW0 + padW1);
+        if (total <= 0) return;
+        // Pack 13 ints + 1 float = 56 bytes. Layout matches the shader's
+        // P block member order; re-interpret the float as raw bits.
+        uint packedVal = BitConverter.ToUInt32(BitConverter.GetBytes(padValue), 0);
+        var pc = new uint[] {
+            (uint)N, (uint)C, (uint)Hin, (uint)Win,
+            (uint)padN0, (uint)padN1, (uint)padC0, (uint)padC1,
+            (uint)padH0, (uint)padH1, (uint)padW0, (uint)padW1,
+            (uint)mode, packedVal
+        };
+        GlslUnaryOp(VulkanGeometryKernels.Pad4D, input, output, total, pc, GeometryPushPad);
+    }
+
+    public void GridSample2D(IGpuBuffer input, IGpuBuffer grid, IGpuBuffer output,
+        int N, int H, int W, int C, int outH, int outW,
+        int mode, int padding, bool alignCorners)
+    {
+        int total = N * outH * outW;
+        if (total <= 0) return;
+        var pc = new uint[] {
+            (uint)N, (uint)H, (uint)W, (uint)C,
+            (uint)outH, (uint)outW, (uint)mode, (uint)padding, (uint)(alignCorners ? 1 : 0)
+        };
+        GlslBinaryOp(VulkanGeometryKernels.GridSample2D, input, grid, output, total, pc, GeometryPushGrid);
+    }
+
+    public void AffineGrid3D(IGpuBuffer theta, IGpuBuffer grid,
+        int N, int D, int H, int W, bool alignCorners)
+    {
+        int total = N * D * H * W;
+        if (total <= 0) return;
+        var pc = new uint[] {
+            (uint)N, (uint)D, (uint)H, (uint)W, (uint)(alignCorners ? 1 : 0)
+        };
+        GlslUnaryOp(VulkanGeometryKernels.AffineGrid3D, theta, grid, total, pc, GeometryPushAff);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.Roi.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.Roi.cs
@@ -1,0 +1,36 @@
+// Copyright (c) AiDotNet. All rights reserved.
+namespace AiDotNet.Tensors.Engines.DirectGpu.Vulkan;
+
+public sealed unsafe partial class VulkanBackend : IRoiBackend
+{
+    // RoIAlign push: 7 ints + 1 float + 2 ints = 40 bytes
+    // RoIPool push: 7 ints + 1 float = 32 bytes
+    private const uint RoiAlignPushSize = 40u;
+    private const uint RoiPoolPushSize = 32u;
+
+    public void RoIAlign(IGpuBuffer input, IGpuBuffer boxes, IGpuBuffer output,
+        int N, int C, int H, int W, int K, int outH, int outW,
+        float spatialScale, int samplingRatio, bool aligned)
+    {
+        int total = K * C * outH * outW;
+        if (total <= 0) return;
+        uint ss = BitConverter.ToUInt32(BitConverter.GetBytes(spatialScale), 0);
+        var pc = new uint[] {
+            (uint)N, (uint)C, (uint)H, (uint)W, (uint)K, (uint)outH, (uint)outW,
+            ss, (uint)samplingRatio, (uint)(aligned ? 1 : 0)
+        };
+        GlslBinaryOp(VulkanRoiKernels.RoIAlign, input, boxes, output, total, pc, RoiAlignPushSize);
+    }
+
+    public void RoIPool(IGpuBuffer input, IGpuBuffer boxes, IGpuBuffer output,
+        int N, int C, int H, int W, int K, int outH, int outW, float spatialScale)
+    {
+        int total = K * C * outH * outW;
+        if (total <= 0) return;
+        uint ss = BitConverter.ToUInt32(BitConverter.GetBytes(spatialScale), 0);
+        var pc = new uint[] {
+            (uint)N, (uint)C, (uint)H, (uint)W, (uint)K, (uint)outH, (uint)outW, ss
+        };
+        GlslBinaryOp(VulkanRoiKernels.RoIPool, input, boxes, output, total, pc, RoiPoolPushSize);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.Roi.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.Roi.cs
@@ -33,4 +33,37 @@ public sealed unsafe partial class VulkanBackend : IRoiBackend
         };
         GlslBinaryOp(VulkanRoiKernels.RoIPool, input, boxes, output, total, pc, RoiPoolPushSize);
     }
+
+    // Push constants for PsRoI: RoIAlign = 8 ints + 1 float + 1 int = 40;
+    // RoIPool = 8 ints + 1 float = 36.
+    private const uint PsRoiAlignPushSize = 40u;
+    private const uint PsRoiPoolPushSize = 36u;
+
+    public void PsRoIAlign(IGpuBuffer input, IGpuBuffer boxes, IGpuBuffer output,
+        int N, int C, int H, int W, int K, int outH, int outW, int outputChannels,
+        float spatialScale, int samplingRatio)
+    {
+        int total = K * outputChannels * outH * outW;
+        if (total <= 0) return;
+        uint ss = BitConverter.ToUInt32(BitConverter.GetBytes(spatialScale), 0);
+        var pc = new uint[] {
+            (uint)N, (uint)C, (uint)H, (uint)W, (uint)K, (uint)outH, (uint)outW,
+            (uint)outputChannels, ss, (uint)samplingRatio
+        };
+        GlslBinaryOp(VulkanRoiKernels.PsRoIAlign, input, boxes, output, total, pc, PsRoiAlignPushSize);
+    }
+
+    public void PsRoIPool(IGpuBuffer input, IGpuBuffer boxes, IGpuBuffer output,
+        int N, int C, int H, int W, int K, int outH, int outW, int outputChannels,
+        float spatialScale)
+    {
+        int total = K * outputChannels * outH * outW;
+        if (total <= 0) return;
+        uint ss = BitConverter.ToUInt32(BitConverter.GetBytes(spatialScale), 0);
+        var pc = new uint[] {
+            (uint)N, (uint)C, (uint)H, (uint)W, (uint)K, (uint)outH, (uint)outW,
+            (uint)outputChannels, ss
+        };
+        GlslBinaryOp(VulkanRoiKernels.PsRoIPool, input, boxes, output, total, pc, PsRoiPoolPushSize);
+    }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanDetectionKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanDetectionKernels.cs
@@ -1,0 +1,398 @@
+namespace AiDotNet.Tensors.Engines.DirectGpu.Vulkan;
+
+/// <summary>
+/// GLSL compute shaders (Vulkan) for the vision detection ops added by Issue
+/// #217. Mirrors CudaDetectionKernels / HipDetectionKernels / MetalDetectionKernels
+/// function-for-function. Each shader is compiled to SPIR-V at runtime via
+/// <see cref="VulkanGlslCompiler"/> and dispatched with 1-D workgroups of
+/// local_size_x = 256.
+/// </summary>
+public static class VulkanDetectionKernels
+{
+    private const string Header = @"#version 450
+layout(local_size_x = 256) in;
+";
+
+    private const string TwoBufBoxes = @"
+layout(set = 0, binding = 0) readonly buffer Boxes { float boxes[]; };
+layout(set = 0, binding = 1) writeonly buffer Out { float o[]; };
+";
+
+    private const string ThreeBufIoU = @"
+layout(set = 0, binding = 0) readonly buffer A { float a[]; };
+layout(set = 0, binding = 1) readonly buffer B { float b[]; };
+layout(set = 0, binding = 2) writeonly buffer Out { float o[]; };
+";
+
+    // -----------------------------------------------------------------------
+    // Pairwise IoU family — 3 SSBO bindings (a, b, output) + push constants
+    // (n, m). Dispatched over n*m total cells.
+    // -----------------------------------------------------------------------
+
+    public static string BoxIou => Header + ThreeBufIoU + @"
+layout(push_constant) uniform P { int n; int m; };
+void main() {
+    int gid = int(gl_GlobalInvocationID.x);
+    int total = n * m;
+    if (gid >= total) return;
+    int i = gid / m;
+    int j = gid % m;
+    float ax1 = a[i * 4]; float ay1 = a[i * 4 + 1]; float ax2 = a[i * 4 + 2]; float ay2 = a[i * 4 + 3];
+    float bx1 = b[j * 4]; float by1 = b[j * 4 + 1]; float bx2 = b[j * 4 + 2]; float by2 = b[j * 4 + 3];
+
+    float aw = max(ax2 - ax1, 0.0); float ah = max(ay2 - ay1, 0.0);
+    float bw = max(bx2 - bx1, 0.0); float bh = max(by2 - by1, 0.0);
+    float areaA = aw * ah; float areaB = bw * bh;
+
+    float ix1 = max(ax1, bx1); float iy1 = max(ay1, by1);
+    float ix2 = min(ax2, bx2); float iy2 = min(ay2, by2);
+    float iw = max(ix2 - ix1, 0.0); float ih = max(iy2 - iy1, 0.0);
+    float inter = iw * ih;
+    float u = areaA + areaB - inter;
+    o[gid] = u > 0.0 ? inter / u : 0.0;
+}";
+
+    public static string GeneralizedBoxIou => Header + ThreeBufIoU + @"
+layout(push_constant) uniform P { int n; int m; };
+void main() {
+    int gid = int(gl_GlobalInvocationID.x);
+    int total = n * m;
+    if (gid >= total) return;
+    int i = gid / m;
+    int j = gid % m;
+    float ax1 = a[i * 4]; float ay1 = a[i * 4 + 1]; float ax2 = a[i * 4 + 2]; float ay2 = a[i * 4 + 3];
+    float bx1 = b[j * 4]; float by1 = b[j * 4 + 1]; float bx2 = b[j * 4 + 2]; float by2 = b[j * 4 + 3];
+
+    float areaA = max(ax2 - ax1, 0.0) * max(ay2 - ay1, 0.0);
+    float areaB = max(bx2 - bx1, 0.0) * max(by2 - by1, 0.0);
+    float ix1 = max(ax1, bx1); float iy1 = max(ay1, by1);
+    float ix2 = min(ax2, bx2); float iy2 = min(ay2, by2);
+    float inter = max(ix2 - ix1, 0.0) * max(iy2 - iy1, 0.0);
+    float u = areaA + areaB - inter;
+    float iou = u > 0.0 ? inter / u : 0.0;
+
+    float ex1 = min(ax1, bx1); float ey1 = min(ay1, by1);
+    float ex2 = max(ax2, bx2); float ey2 = max(ay2, by2);
+    float enclose = max(ex2 - ex1, 0.0) * max(ey2 - ey1, 0.0);
+    o[gid] = enclose > 0.0 ? iou - (enclose - u) / enclose : iou;
+}";
+
+    public static string DistanceBoxIou => Header + ThreeBufIoU + @"
+layout(push_constant) uniform P { int n; int m; };
+void main() {
+    int gid = int(gl_GlobalInvocationID.x);
+    int total = n * m;
+    if (gid >= total) return;
+    int i = gid / m;
+    int j = gid % m;
+    float ax1 = a[i * 4]; float ay1 = a[i * 4 + 1]; float ax2 = a[i * 4 + 2]; float ay2 = a[i * 4 + 3];
+    float bx1 = b[j * 4]; float by1 = b[j * 4 + 1]; float bx2 = b[j * 4 + 2]; float by2 = b[j * 4 + 3];
+
+    float areaA = max(ax2 - ax1, 0.0) * max(ay2 - ay1, 0.0);
+    float areaB = max(bx2 - bx1, 0.0) * max(by2 - by1, 0.0);
+    float ix1 = max(ax1, bx1); float iy1 = max(ay1, by1);
+    float ix2 = min(ax2, bx2); float iy2 = min(ay2, by2);
+    float inter = max(ix2 - ix1, 0.0) * max(iy2 - iy1, 0.0);
+    float u = areaA + areaB - inter;
+    float iou = u > 0.0 ? inter / u : 0.0;
+
+    float acx = (ax1 + ax2) * 0.5; float acy = (ay1 + ay2) * 0.5;
+    float bcx = (bx1 + bx2) * 0.5; float bcy = (by1 + by2) * 0.5;
+    float dx = acx - bcx; float dy = acy - bcy;
+    float centreSq = dx * dx + dy * dy;
+    float ex1 = min(ax1, bx1); float ey1 = min(ay1, by1);
+    float ex2 = max(ax2, bx2); float ey2 = max(ay2, by2);
+    float ew = ex2 - ex1; float eh = ey2 - ey1;
+    float diagSq = ew * ew + eh * eh;
+    o[gid] = diagSq > 0.0 ? iou - centreSq / diagSq : iou;
+}";
+
+    public static string CompleteBoxIou => Header + ThreeBufIoU + @"
+layout(push_constant) uniform P { int n; int m; };
+void main() {
+    int gid = int(gl_GlobalInvocationID.x);
+    int total = n * m;
+    if (gid >= total) return;
+    int i = gid / m;
+    int j = gid % m;
+    float ax1 = a[i * 4]; float ay1 = a[i * 4 + 1]; float ax2 = a[i * 4 + 2]; float ay2 = a[i * 4 + 3];
+    float bx1 = b[j * 4]; float by1 = b[j * 4 + 1]; float bx2 = b[j * 4 + 2]; float by2 = b[j * 4 + 3];
+
+    float aw = ax2 - ax1; float ah = ay2 - ay1;
+    float bw = bx2 - bx1; float bh = by2 - by1;
+    float areaA = max(aw, 0.0) * max(ah, 0.0);
+    float areaB = max(bw, 0.0) * max(bh, 0.0);
+    float ix1 = max(ax1, bx1); float iy1 = max(ay1, by1);
+    float ix2 = min(ax2, bx2); float iy2 = min(ay2, by2);
+    float inter = max(ix2 - ix1, 0.0) * max(iy2 - iy1, 0.0);
+    float u = areaA + areaB - inter;
+    float iou = u > 0.0 ? inter / u : 0.0;
+
+    float acx = (ax1 + ax2) * 0.5; float acy = (ay1 + ay2) * 0.5;
+    float bcx = (bx1 + bx2) * 0.5; float bcy = (by1 + by2) * 0.5;
+    float dx = acx - bcx; float dy = acy - bcy;
+    float centreSq = dx * dx + dy * dy;
+    float ex1 = min(ax1, bx1); float ey1 = min(ay1, by1);
+    float ex2 = max(ax2, bx2); float ey2 = max(ay2, by2);
+    float ew = ex2 - ex1; float eh = ey2 - ey1;
+    float diagSq = ew * ew + eh * eh;
+    float diou = diagSq > 0.0 ? iou - centreSq / diagSq : iou;
+
+    float v = 0.0; float alpha = 0.0;
+    if (ah > 0.0 && bh > 0.0) {
+        float aspectA = atan(aw / ah);
+        float aspectB = atan(bw / bh);
+        float diff = aspectA - aspectB;
+        const float PI = 3.14159265358979323846;
+        const float invPiSq = 4.0 / (PI * PI);
+        v = invPiSq * diff * diff;
+        float denom = (1.0 - iou) + v;
+        alpha = denom > 0.0 ? v / denom : 0.0;
+    }
+    o[gid] = diou - alpha * v;
+}";
+
+    // -----------------------------------------------------------------------
+    // Per-box ops — 2 SSBO bindings (boxes, output).
+    // -----------------------------------------------------------------------
+
+    public static string BoxArea => Header + TwoBufBoxes + @"
+layout(push_constant) uniform P { int n; };
+void main() {
+    int gid = int(gl_GlobalInvocationID.x);
+    if (gid >= n) return;
+    float w = max(boxes[gid * 4 + 2] - boxes[gid * 4], 0.0);
+    float h = max(boxes[gid * 4 + 3] - boxes[gid * 4 + 1], 0.0);
+    o[gid] = w * h;
+}";
+
+    public static string BoxConvert => Header + TwoBufBoxes + @"
+layout(push_constant) uniform P { int n; int fromFormat; int toFormat; };
+void main() {
+    int gid = int(gl_GlobalInvocationID.x);
+    if (gid >= n) return;
+    int oi = gid * 4;
+    float v0 = boxes[oi]; float v1 = boxes[oi + 1]; float v2 = boxes[oi + 2]; float v3 = boxes[oi + 3];
+
+    float x1; float y1; float x2; float y2;
+    if (fromFormat == 0) { x1 = v0; y1 = v1; x2 = v2; y2 = v3; }
+    else if (fromFormat == 1) { x1 = v0; y1 = v1; x2 = v0 + v2; y2 = v1 + v3; }
+    else { float hw = v2 * 0.5; float hh = v3 * 0.5;
+           x1 = v0 - hw; y1 = v1 - hh; x2 = v0 + hw; y2 = v1 + hh; }
+
+    if (toFormat == 0) { o[oi] = x1; o[oi + 1] = y1; o[oi + 2] = x2; o[oi + 3] = y2; }
+    else if (toFormat == 1) {
+        o[oi] = x1; o[oi + 1] = y1;
+        o[oi + 2] = x2 - x1; o[oi + 3] = y2 - y1;
+    } else {
+        float w = x2 - x1; float h = y2 - y1;
+        o[oi] = x1 + w * 0.5; o[oi + 1] = y1 + h * 0.5;
+        o[oi + 2] = w; o[oi + 3] = h;
+    }
+}";
+
+    // -----------------------------------------------------------------------
+    // IoU family backward — Issue #217. Atomics-free two-kernel split:
+    // gradA_kernel owns rows of N, gradB_kernel owns rows of M. Each kernel
+    // has 4 SSBO bindings (gradOutput, a, b, gradA|gradB) and 3 push
+    // constants (n, m, variant). GLSL here is the ASCII-safe equivalent of
+    // the CudaDetectionKernels backward — no atomics needed.
+    // -----------------------------------------------------------------------
+
+    private const string QuadBufBackwardA = @"
+layout(set = 0, binding = 0) readonly buffer GO { float gradOutput[]; };
+layout(set = 0, binding = 1) readonly buffer A { float a[]; };
+layout(set = 0, binding = 2) readonly buffer B { float b[]; };
+layout(set = 0, binding = 3) writeonly buffer GA { float gradA[]; };
+";
+
+    private const string QuadBufBackwardB = @"
+layout(set = 0, binding = 0) readonly buffer GO { float gradOutput[]; };
+layout(set = 0, binding = 1) readonly buffer A { float a[]; };
+layout(set = 0, binding = 2) readonly buffer B { float b[]; };
+layout(set = 0, binding = 3) writeonly buffer GB { float gradB[]; };
+";
+
+    // The per-cell computation is embedded inline in both kernels. We use a
+    // helper with inout out-params in GLSL. (GLSL functions can take inout
+    // parameters for pointer-like semantics.)
+    private const string IouCellFn = @"
+const float DETECTION_INV_PI_SQ = 4.0 / (3.14159265358979323846 * 3.14159265358979323846);
+
+void compute_cell_grads_iou(
+    float ax1, float ay1, float ax2, float ay2,
+    float bx1, float by1, float bx2, float by2,
+    float g, int variant,
+    out float gAx1, out float gAy1, out float gAx2, out float gAy2,
+    out float gBx1, out float gBy1, out float gBx2, out float gBy2)
+{
+    gAx1 = 0.0; gAy1 = 0.0; gAx2 = 0.0; gAy2 = 0.0;
+    gBx1 = 0.0; gBy1 = 0.0; gBx2 = 0.0; gBy2 = 0.0;
+    if (g == 0.0) return;
+
+    float awRaw = ax2 - ax1; float ahRaw = ay2 - ay1;
+    float bwRaw = bx2 - bx1; float bhRaw = by2 - by1;
+    float aw = max(awRaw, 0.0); float ah = max(ahRaw, 0.0);
+    float bw = max(bwRaw, 0.0); float bh = max(bhRaw, 0.0);
+    float areaA = aw * ah; float areaB = bw * bh;
+
+    float ix1 = max(ax1, bx1); float ix2 = min(ax2, bx2);
+    float iy1 = max(ay1, by1); float iy2 = min(ay2, by2);
+    float iwRaw = ix2 - ix1; float ihRaw = iy2 - iy1;
+    float iw = max(iwRaw, 0.0); float ih = max(ihRaw, 0.0);
+    float inter = iw * ih;
+    float u = areaA + areaB - inter;
+    float iou = u > 0.0 ? inter / u : 0.0;
+
+    float gIou = g;
+    float gInter = 0.0; float gAreaA = 0.0; float gAreaB = 0.0;
+
+    if (variant == 1) {
+        float ex1 = min(ax1, bx1); float ex2 = max(ax2, bx2);
+        float ey1 = min(ay1, by1); float ey2 = max(ay2, by2);
+        float ewRaw = ex2 - ex1; float ehRaw = ey2 - ey1;
+        float ew = max(ewRaw, 0.0); float eh = max(ehRaw, 0.0);
+        float enclose = ew * eh;
+        if (enclose > 0.0) {
+            float gUnion = g / enclose;
+            float gEnclose = g * (-u / (enclose * enclose));
+            gAreaA += gUnion; gAreaB += gUnion; gInter += -gUnion;
+            float gEw = gEnclose * eh; float gEh = gEnclose * ew;
+            float gEwRaw = ewRaw > 0.0 ? gEw : 0.0;
+            float gEhRaw = ehRaw > 0.0 ? gEh : 0.0;
+            float gEx1 = -gEwRaw; float gEx2 = gEwRaw;
+            float gEy1 = -gEhRaw; float gEy2 = gEhRaw;
+            if (ax1 <= bx1) gAx1 += gEx1; else gBx1 += gEx1;
+            if (ay1 <= by1) gAy1 += gEy1; else gBy1 += gEy1;
+            if (ax2 >= bx2) gAx2 += gEx2; else gBx2 += gEx2;
+            if (ay2 >= by2) gAy2 += gEy2; else gBy2 += gEy2;
+        }
+    } else if (variant == 2 || variant == 3) {
+        float acx = (ax1 + ax2) * 0.5; float acy = (ay1 + ay2) * 0.5;
+        float bcx = (bx1 + bx2) * 0.5; float bcy = (by1 + by2) * 0.5;
+        float dcx = acx - bcx; float dcy = acy - bcy;
+        float centreSq = dcx * dcx + dcy * dcy;
+        float ex1 = min(ax1, bx1); float ex2 = max(ax2, bx2);
+        float ey1 = min(ay1, by1); float ey2 = max(ay2, by2);
+        float ew = ex2 - ex1; float eh = ey2 - ey1;
+        float diagSq = ew * ew + eh * eh;
+
+        float gCentreSq = 0.0; float gDiagSq = 0.0;
+        if (diagSq > 0.0) {
+            gCentreSq = g * (-1.0 / diagSq);
+            gDiagSq = g * centreSq / (diagSq * diagSq);
+        }
+
+        if (variant == 3 && ah > 0.0 && bh > 0.0) {
+            float aspectA = atan(aw / ah);
+            float aspectB = atan(bw / bh);
+            float diff = aspectA - aspectB;
+            float v = DETECTION_INV_PI_SQ * diff * diff;
+            float denom = (1.0 - iou) + v;
+            float alpha = denom > 0.0 ? v / denom : 0.0;
+            float gV = g * (-alpha);
+            float gDiff = gV * 2.0 * DETECTION_INV_PI_SQ * diff;
+            float gAspectA = gDiff; float gAspectB = -gDiff;
+            float aDen = aw * aw + ah * ah;
+            float bDen = bw * bw + bh * bh;
+            if (aDen > 0.0) {
+                float gAw = gAspectA * (ah / aDen);
+                float gAh = gAspectA * (-aw / aDen);
+                if (awRaw > 0.0) { gAx2 += gAw; gAx1 += -gAw; }
+                if (ahRaw > 0.0) { gAy2 += gAh; gAy1 += -gAh; }
+            }
+            if (bDen > 0.0) {
+                float gBw = gAspectB * (bh / bDen);
+                float gBh = gAspectB * (-bw / bDen);
+                if (bwRaw > 0.0) { gBx2 += gBw; gBx1 += -gBw; }
+                if (bhRaw > 0.0) { gBy2 += gBh; gBy1 += -gBh; }
+            }
+        }
+
+        float gAcx = gCentreSq * 2.0 * dcx;
+        float gAcy = gCentreSq * 2.0 * dcy;
+        gAx1 += gAcx * 0.5; gAx2 += gAcx * 0.5;
+        gAy1 += gAcy * 0.5; gAy2 += gAcy * 0.5;
+        gBx1 += -gAcx * 0.5; gBx2 += -gAcx * 0.5;
+        gBy1 += -gAcy * 0.5; gBy2 += -gAcy * 0.5;
+
+        float gEw = gDiagSq * 2.0 * ew;
+        float gEh = gDiagSq * 2.0 * eh;
+        float gEx1 = -gEw; float gEx2 = gEw;
+        float gEy1 = -gEh; float gEy2 = gEh;
+        if (ax1 <= bx1) gAx1 += gEx1; else gBx1 += gEx1;
+        if (ay1 <= by1) gAy1 += gEy1; else gBy1 += gEy1;
+        if (ax2 >= bx2) gAx2 += gEx2; else gBx2 += gEx2;
+        if (ay2 >= by2) gAy2 += gEy2; else gBy2 += gEy2;
+    }
+
+    if (u > 0.0) {
+        float uSq = u * u;
+        gInter += gIou * (u + inter) / uSq;
+        gAreaA += gIou * (-inter) / uSq;
+        gAreaB += gIou * (-inter) / uSq;
+    }
+
+    float gIw = gInter * ih; float gIh = gInter * iw;
+    float gIwRaw = iwRaw > 0.0 ? gIw : 0.0;
+    float gIhRaw = ihRaw > 0.0 ? gIh : 0.0;
+    float gIx2 = gIwRaw; float gIx1 = -gIwRaw;
+    float gIy2 = gIhRaw; float gIy1 = -gIhRaw;
+    if (ax1 >= bx1) gAx1 += gIx1; else gBx1 += gIx1;
+    if (ay1 >= by1) gAy1 += gIy1; else gBy1 += gIy1;
+    if (ax2 <= bx2) gAx2 += gIx2; else gBx2 += gIx2;
+    if (ay2 <= by2) gAy2 += gIy2; else gBy2 += gIy2;
+
+    float gAw2 = gAreaA * ah; float gAh2 = gAreaA * aw;
+    float gBw2 = gAreaB * bh; float gBh2 = gAreaB * bw;
+    if (awRaw > 0.0) { gAx2 += gAw2; gAx1 += -gAw2; }
+    if (ahRaw > 0.0) { gAy2 += gAh2; gAy1 += -gAh2; }
+    if (bwRaw > 0.0) { gBx2 += gBw2; gBx1 += -gBw2; }
+    if (bhRaw > 0.0) { gBy2 += gBh2; gBy1 += -gBh2; }
+}
+";
+
+    public static string IouBackwardA => Header + QuadBufBackwardA + IouCellFn + @"
+layout(push_constant) uniform P { int n; int m; int variant; };
+void main() {
+    int i = int(gl_GlobalInvocationID.x);
+    if (i >= n) return;
+    float ax1 = a[i * 4]; float ay1 = a[i * 4 + 1]; float ax2 = a[i * 4 + 2]; float ay2 = a[i * 4 + 3];
+    float sumX1 = 0.0; float sumY1 = 0.0; float sumX2 = 0.0; float sumY2 = 0.0;
+    for (int j = 0; j < m; j++) {
+        float bx1 = b[j * 4]; float by1 = b[j * 4 + 1]; float bx2 = b[j * 4 + 2]; float by2 = b[j * 4 + 3];
+        float g = gradOutput[i * m + j];
+        float gAx1; float gAy1; float gAx2; float gAy2;
+        float gBx1; float gBy1; float gBx2; float gBy2;
+        compute_cell_grads_iou(ax1, ay1, ax2, ay2, bx1, by1, bx2, by2, g, variant,
+            gAx1, gAy1, gAx2, gAy2, gBx1, gBy1, gBx2, gBy2);
+        sumX1 += gAx1; sumY1 += gAy1; sumX2 += gAx2; sumY2 += gAy2;
+    }
+    gradA[i * 4]     = sumX1;
+    gradA[i * 4 + 1] = sumY1;
+    gradA[i * 4 + 2] = sumX2;
+    gradA[i * 4 + 3] = sumY2;
+}";
+
+    public static string IouBackwardB => Header + QuadBufBackwardB + IouCellFn + @"
+layout(push_constant) uniform P { int n; int m; int variant; };
+void main() {
+    int j = int(gl_GlobalInvocationID.x);
+    if (j >= m) return;
+    float bx1 = b[j * 4]; float by1 = b[j * 4 + 1]; float bx2 = b[j * 4 + 2]; float by2 = b[j * 4 + 3];
+    float sumX1 = 0.0; float sumY1 = 0.0; float sumX2 = 0.0; float sumY2 = 0.0;
+    for (int i = 0; i < n; i++) {
+        float ax1 = a[i * 4]; float ay1 = a[i * 4 + 1]; float ax2 = a[i * 4 + 2]; float ay2 = a[i * 4 + 3];
+        float g = gradOutput[i * m + j];
+        float gAx1; float gAy1; float gAx2; float gAy2;
+        float gBx1; float gBy1; float gBx2; float gBy2;
+        compute_cell_grads_iou(ax1, ay1, ax2, ay2, bx1, by1, bx2, by2, g, variant,
+            gAx1, gAy1, gAx2, gAy2, gBx1, gBy1, gBx2, gBy2);
+        sumX1 += gBx1; sumY1 += gBy1; sumX2 += gBx2; sumY2 += gBy2;
+    }
+    gradB[j * 4]     = sumX1;
+    gradB[j * 4 + 1] = sumY1;
+    gradB[j * 4 + 2] = sumX2;
+    gradB[j * 4 + 3] = sumY2;
+}";
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanDetectionKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanDetectionKernels.cs
@@ -118,10 +118,11 @@ void main() {
     float ax1 = a[i * 4]; float ay1 = a[i * 4 + 1]; float ax2 = a[i * 4 + 2]; float ay2 = a[i * 4 + 3];
     float bx1 = b[j * 4]; float by1 = b[j * 4 + 1]; float bx2 = b[j * 4 + 2]; float by2 = b[j * 4 + 3];
 
-    float aw = ax2 - ax1; float ah = ay2 - ay1;
-    float bw = bx2 - bx1; float bh = by2 - by1;
-    float areaA = max(aw, 0.0) * max(ah, 0.0);
-    float areaB = max(bw, 0.0) * max(bh, 0.0);
+    // Clamp to match the backward's convention.
+    float aw = max(ax2 - ax1, 0.0); float ah = max(ay2 - ay1, 0.0);
+    float bw = max(bx2 - bx1, 0.0); float bh = max(by2 - by1, 0.0);
+    float areaA = aw * ah;
+    float areaB = bw * bh;
     float ix1 = max(ax1, bx1); float iy1 = max(ay1, by1);
     float ix2 = min(ax2, bx2); float iy2 = min(ay2, by2);
     float inter = max(ix2 - ix1, 0.0) * max(iy2 - iy1, 0.0);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanDetectionKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanDetectionKernels.cs
@@ -9,6 +9,13 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.Vulkan;
 /// </summary>
 public static class VulkanDetectionKernels
 {
+    // Vulkan spec guarantees maxComputeWorkGroupInvocations >= 128 (spec
+    // minimum), and every consumer GPU in the last decade supports 1024.
+    // 256 is the idiomatic work-group size used across every other kernel
+    // file in this repo (Parity-210, Linalg, FFT, Detection forward).
+    // Specialization constants would require runtime device queries that
+    // existing pipelines don't use; keeping 256 matches the repo-wide
+    // convention and is safe on all conformant Vulkan implementations.
     private const string Header = @"#version 450
 layout(local_size_x = 256) in;
 ";

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanGeometryKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanGeometryKernels.cs
@@ -1,0 +1,277 @@
+namespace AiDotNet.Tensors.Engines.DirectGpu.Vulkan;
+
+/// <summary>
+/// GLSL compute shaders for the geometry / sampling ops added by Issue
+/// #217. Each entry is a self-contained compute shader; all use
+/// <c>#version 450</c> and <c>layout(local_size_x = 256)</c>.
+/// </summary>
+public static class VulkanGeometryKernels
+{
+    private const string Header = @"#version 450
+layout(local_size_x = 256) in;
+";
+
+    private const string Helpers = @"
+float source_coord(int dstIdx, int dstSize, int srcSize, int alignCorners) {
+    if (dstSize <= 1) return 0.0;
+    if (alignCorners != 0) return float(dstIdx) * (srcSize - 1) / (dstSize - 1);
+    return (float(dstIdx) + 0.5) * srcSize / dstSize - 0.5;
+}
+
+float cubic_kernel(float d, float a) {
+    float ad = abs(d);
+    if (ad < 1.0) return ((a + 2.0) * ad - (a + 3.0)) * ad * ad + 1.0;
+    if (ad < 2.0) return a * ((ad - 5.0) * ad + 8.0) * ad - 4.0 * a;
+    return 0.0;
+}
+
+int clamp_i(int v, int lo, int hi) { return v < lo ? lo : (v > hi ? hi : v); }
+
+int reflect_index(int i, int extent) {
+    if (extent == 1) return 0;
+    int period = 2 * (extent - 1);
+    int r = ((i % period) + period) % period;
+    return r < extent ? r : period - r;
+}
+
+int pad_boundary(int idx, int extent, int mode) {
+    if (mode == 2) { if (idx < 0) return 0; if (idx >= extent) return extent - 1; return idx; }
+    if (mode == 1) return reflect_index(idx, extent);
+    int r = ((idx % extent) + extent) % extent;
+    return r;
+}
+";
+
+    // -----------------------------------------------------------------------
+    // Interpolate 2D NCHW.
+    // -----------------------------------------------------------------------
+
+    public static string Interpolate2D => Header + @"
+layout(set = 0, binding = 0) readonly buffer A { float input_[]; };
+layout(set = 0, binding = 1) writeonly buffer B { float output_[]; };
+layout(push_constant) uniform P {
+    int N; int C; int Hin; int Win; int Hout; int Wout; int mode; int alignCorners;
+};
+" + Helpers + @"
+void main() {
+    int gid = int(gl_GlobalInvocationID.x);
+    int total = N * C * Hout * Wout;
+    if (gid >= total) return;
+    int x = gid % Wout; int t1 = gid / Wout;
+    int y = t1 % Hout; int t2 = t1 / Hout;
+    int c = t2 % C; int n = t2 / C;
+    int srcBase = ((n * C + c) * Hin) * Win;
+
+    if (mode == 0) {
+        float sy = Hout > 1 ? float(y) * Hin / Hout : 0.0;
+        float sx = Wout > 1 ? float(x) * Win / Wout : 0.0;
+        int yi = int(floor(sy)); if (yi >= Hin) yi = Hin - 1;
+        int xi = int(floor(sx)); if (xi >= Win) xi = Win - 1;
+        output_[gid] = input_[srcBase + yi * Win + xi];
+    } else if (mode == 2) {
+        float sy = source_coord(y, Hout, Hin, alignCorners);
+        float sx = source_coord(x, Wout, Win, alignCorners);
+        int y0 = int(floor(sy)); int x0 = int(floor(sx));
+        if (y0 < 0) y0 = 0; if (x0 < 0) x0 = 0;
+        int y1 = y0 + 1; int x1 = x0 + 1;
+        if (y1 >= Hin) { y1 = Hin - 1; if (y0 > y1) y0 = y1; }
+        if (x1 >= Win) { x1 = Win - 1; if (x0 > x1) x0 = x1; }
+        float fy = sy - y0; if (fy < 0.0) fy = 0.0; if (fy > 1.0) fy = 1.0;
+        float fx = sx - x0; if (fx < 0.0) fx = 0.0; if (fx > 1.0) fx = 1.0;
+        float v00 = input_[srcBase + y0 * Win + x0];
+        float v01 = input_[srcBase + y0 * Win + x1];
+        float v10 = input_[srcBase + y1 * Win + x0];
+        float v11 = input_[srcBase + y1 * Win + x1];
+        output_[gid] = v00 * (1.0 - fx) * (1.0 - fy) + v01 * fx * (1.0 - fy)
+                     + v10 * (1.0 - fx) * fy + v11 * fx * fy;
+    } else if (mode == 3) {
+        float sy = source_coord(y, Hout, Hin, alignCorners);
+        float sx = source_coord(x, Wout, Win, alignCorners);
+        int y0 = int(floor(sy)); float ty = sy - y0;
+        int x0 = int(floor(sx)); float tx = sx - x0;
+        float wy[4] = float[](cubic_kernel(1.0 + ty, -0.75), cubic_kernel(ty, -0.75),
+                               cubic_kernel(1.0 - ty, -0.75), cubic_kernel(2.0 - ty, -0.75));
+        float wx[4] = float[](cubic_kernel(1.0 + tx, -0.75), cubic_kernel(tx, -0.75),
+                               cubic_kernel(1.0 - tx, -0.75), cubic_kernel(2.0 - tx, -0.75));
+        float acc = 0.0;
+        for (int yy = 0; yy < 4; yy++) {
+            int yi = clamp_i(y0 - 1 + yy, 0, Hin - 1);
+            float rowAcc = 0.0;
+            for (int xx = 0; xx < 4; xx++) {
+                int xi = clamp_i(x0 - 1 + xx, 0, Win - 1);
+                rowAcc += wx[xx] * input_[srcBase + yi * Win + xi];
+            }
+            acc += wy[yy] * rowAcc;
+        }
+        output_[gid] = acc;
+    } else {
+        float yLo = float(y) * Hin / Hout;
+        float yHi = float(y + 1) * Hin / Hout;
+        float xLo = float(x) * Win / Wout;
+        float xHi = float(x + 1) * Win / Wout;
+        int yL = int(floor(yLo)); int yH = int(ceil(yHi));
+        int xL = int(floor(xLo)); int xH = int(ceil(xHi));
+        if (yH <= yL) yH = yL + 1;
+        if (xH <= xL) xH = xL + 1;
+        if (yH > Hin) yH = Hin;
+        if (xH > Win) xH = Win;
+        float acc = 0.0; int count = 0;
+        for (int yy = yL; yy < yH; yy++) for (int xx = xL; xx < xH; xx++) { acc += input_[srcBase + yy * Win + xx]; count++; }
+        output_[gid] = count > 0 ? acc / count : 0.0;
+    }
+}
+";
+
+    // -----------------------------------------------------------------------
+    // Pad 4D.
+    // -----------------------------------------------------------------------
+
+    public static string Pad4D => Header + @"
+layout(set = 0, binding = 0) readonly buffer A { float input_[]; };
+layout(set = 0, binding = 1) writeonly buffer B { float output_[]; };
+layout(push_constant) uniform P {
+    int N; int C; int Hin; int Win;
+    int padN0; int padN1; int padC0; int padC1;
+    int padH0; int padH1; int padW0; int padW1;
+    int mode; float padValue;
+};
+" + Helpers + @"
+void main() {
+    int Nout = N + padN0 + padN1;
+    int Cout = C + padC0 + padC1;
+    int Hout = Hin + padH0 + padH1;
+    int Wout = Win + padW0 + padW1;
+    int total = Nout * Cout * Hout * Wout;
+    int gid = int(gl_GlobalInvocationID.x);
+    if (gid >= total) return;
+    int w = gid % Wout; int t1 = gid / Wout;
+    int h = t1 % Hout; int t2 = t1 / Hout;
+    int c = t2 % Cout; int n = t2 / Cout;
+    int nn = n - padN0, cc = c - padC0, hh = h - padH0, ww = w - padW0;
+    bool inB = nn >= 0 && nn < N && cc >= 0 && cc < C && hh >= 0 && hh < Hin && ww >= 0 && ww < Win;
+    if (!inB && mode == 0) { output_[gid] = padValue; return; }
+    if (!inB) {
+        if (!(nn >= 0 && nn < N)) nn = pad_boundary(nn, N, mode);
+        if (!(cc >= 0 && cc < C)) cc = pad_boundary(cc, C, mode);
+        if (!(hh >= 0 && hh < Hin)) hh = pad_boundary(hh, Hin, mode);
+        if (!(ww >= 0 && ww < Win)) ww = pad_boundary(ww, Win, mode);
+    }
+    output_[gid] = input_[((nn * C + cc) * Hin + hh) * Win + ww];
+}
+";
+
+    // -----------------------------------------------------------------------
+    // GridSample 2D NHWC — 3 SSBO (input, grid, output).
+    // -----------------------------------------------------------------------
+
+    public static string GridSample2D => Header + @"
+layout(set = 0, binding = 0) readonly buffer A { float input_[]; };
+layout(set = 0, binding = 1) readonly buffer G { float grid_[]; };
+layout(set = 0, binding = 2) writeonly buffer O { float output_[]; };
+layout(push_constant) uniform P {
+    int N; int H; int W; int C;
+    int outH; int outW;
+    int mode; int padding; int alignCorners;
+};
+" + Helpers + @"
+float sample_safe(int n, int y, int x, int c) {
+    if (padding == 0) {
+        if (uint(y) >= uint(H) || uint(x) >= uint(W)) return 0.0;
+    } else if (padding == 1) {
+        y = clamp_i(y, 0, H - 1); x = clamp_i(x, 0, W - 1);
+    } else {
+        y = reflect_index(y, H); x = reflect_index(x, W);
+    }
+    return input_[((n * H + y) * W + x) * C + c];
+}
+
+void main() {
+    int gid = int(gl_GlobalInvocationID.x);
+    int total = N * outH * outW;
+    if (gid >= total) return;
+    int ox = gid % outW; int t1 = gid / outW;
+    int oy = t1 % outH; int n = t1 / outH;
+    int gOff = ((n * outH + oy) * outW + ox) * 2;
+    float gx = grid_[gOff];
+    float gy = grid_[gOff + 1];
+    float sx = alignCorners != 0 ? (gx + 1.0) * 0.5 * (W - 1) : ((gx + 1.0) * W - 1.0) * 0.5;
+    float sy = alignCorners != 0 ? (gy + 1.0) * 0.5 * (H - 1) : ((gy + 1.0) * H - 1.0) * 0.5;
+
+    if (mode == 1) {
+        int nx = int(round(sx)), ny = int(round(sy));
+        for (int c = 0; c < C; c++)
+            output_[((n * outH + oy) * outW + ox) * C + c] = sample_safe(n, ny, nx, c);
+    } else if (mode == 0) {
+        int x0 = int(floor(sx)), y0 = int(floor(sy));
+        int x1 = x0 + 1, y1 = y0 + 1;
+        float fx = sx - x0, fy = sy - y0;
+        for (int c = 0; c < C; c++) {
+            float v00 = sample_safe(n, y0, x0, c);
+            float v01 = sample_safe(n, y0, x1, c);
+            float v10 = sample_safe(n, y1, x0, c);
+            float v11 = sample_safe(n, y1, x1, c);
+            output_[((n * outH + oy) * outW + ox) * C + c] =
+                v00 * (1.0 - fx) * (1.0 - fy) + v01 * fx * (1.0 - fy)
+              + v10 * (1.0 - fx) * fy + v11 * fx * fy;
+        }
+    } else {
+        int x0 = int(floor(sx)), y0 = int(floor(sy));
+        float fx = sx - x0, fy = sy - y0;
+        float wy[4] = float[](cubic_kernel(1.0 + fy, -0.75), cubic_kernel(fy, -0.75),
+                               cubic_kernel(1.0 - fy, -0.75), cubic_kernel(2.0 - fy, -0.75));
+        float wx[4] = float[](cubic_kernel(1.0 + fx, -0.75), cubic_kernel(fx, -0.75),
+                               cubic_kernel(1.0 - fx, -0.75), cubic_kernel(2.0 - fx, -0.75));
+        for (int c = 0; c < C; c++) {
+            float acc = 0.0;
+            for (int yy = 0; yy < 4; yy++) {
+                int yi = y0 - 1 + yy;
+                float rowAcc = 0.0;
+                for (int xx = 0; xx < 4; xx++) {
+                    int xi = x0 - 1 + xx;
+                    rowAcc += wx[xx] * sample_safe(n, yi, xi, c);
+                }
+                acc += wy[yy] * rowAcc;
+            }
+            output_[((n * outH + oy) * outW + ox) * C + c] = acc;
+        }
+    }
+}
+";
+
+    // -----------------------------------------------------------------------
+    // AffineGrid 3D.
+    // -----------------------------------------------------------------------
+
+    public static string AffineGrid3D => Header + @"
+layout(set = 0, binding = 0) readonly buffer T { float theta[]; };
+layout(set = 0, binding = 1) writeonly buffer G { float grid_[]; };
+layout(push_constant) uniform P {
+    int N; int D; int H; int W; int alignCorners;
+};
+
+float grid_norm_coord(int idx, int size) {
+    if (size <= 1) return 0.0;
+    return alignCorners != 0 ? -1.0 + 2.0 * idx / (size - 1) : -1.0 + (2.0 * idx + 1.0) / size;
+}
+
+void main() {
+    int gid = int(gl_GlobalInvocationID.x);
+    int total = N * D * H * W;
+    if (gid >= total) return;
+    int w = gid % W; int t1 = gid / W;
+    int h = t1 % H; int t2 = t1 / H;
+    int d = t2 % D; int n = t2 / D;
+    int tBase = n * 12;
+    float x = grid_norm_coord(w, W);
+    float y = grid_norm_coord(h, H);
+    float z = grid_norm_coord(d, D);
+    int gBase = (((n * D + d) * H + h) * W + w) * 3;
+    for (int row = 0; row < 3; row++) {
+        grid_[gBase + row] = theta[tBase + row * 4] * x
+                           + theta[tBase + row * 4 + 1] * y
+                           + theta[tBase + row * 4 + 2] * z
+                           + theta[tBase + row * 4 + 3];
+    }
+}
+";
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanGeometryKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanGeometryKernels.cs
@@ -35,6 +35,7 @@ int reflect_index(int i, int extent) {
 }
 
 int pad_boundary(int idx, int extent, int mode) {
+    if (extent <= 0) return 0;
     if (mode == 2) { if (idx < 0) return 0; if (idx >= extent) return extent - 1; return idx; }
     if (mode == 1) return reflect_index(idx, extent);
     int r = ((idx % extent) + extent) % extent;
@@ -104,7 +105,7 @@ void main() {
             acc += wy[yy] * rowAcc;
         }
         output_[gid] = acc;
-    } else {
+    } else {  // Area — overlap-weighted averaging
         float yLo = float(y) * Hin / Hout;
         float yHi = float(y + 1) * Hin / Hout;
         float xLo = float(x) * Win / Wout;
@@ -115,9 +116,18 @@ void main() {
         if (xH <= xL) xH = xL + 1;
         if (yH > Hin) yH = Hin;
         if (xH > Win) xH = Win;
-        float acc = 0.0; int count = 0;
-        for (int yy = yL; yy < yH; yy++) for (int xx = xL; xx < xH; xx++) { acc += input_[srcBase + yy * Win + xx]; count++; }
-        output_[gid] = count > 0 ? acc / count : 0.0;
+        float totalArea = (yHi - yLo) * (xHi - xLo);
+        float acc = 0.0;
+        for (int yy = yL; yy < yH; yy++) {
+            float oy = max(0.0, min(yHi, float(yy + 1)) - max(yLo, float(yy)));
+            if (oy <= 0.0) continue;
+            for (int xx = xL; xx < xH; xx++) {
+                float ox = max(0.0, min(xHi, float(xx + 1)) - max(xLo, float(xx)));
+                if (ox <= 0.0) continue;
+                acc += oy * ox * input_[srcBase + yy * Win + xx];
+            }
+        }
+        output_[gid] = totalArea > 0.0 ? acc / totalArea : 0.0;
     }
 }
 ";

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanRoiKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanRoiKernels.cs
@@ -1,0 +1,116 @@
+namespace AiDotNet.Tensors.Engines.DirectGpu.Vulkan;
+
+public static class VulkanRoiKernels
+{
+    private const string Header = @"#version 450
+layout(local_size_x = 256) in;
+";
+
+    private const string Helper = @"
+float bilinear_sample(uint planeBase, float y, float x, int H, int W) {
+    if (y < -1.0 || y > float(H) || x < -1.0 || x > float(W)) return 0.0;
+    if (y <= 0.0) y = 0.0;
+    if (x <= 0.0) x = 0.0;
+    int y0 = int(y);
+    int x0 = int(x);
+    int y1_ = y0 + 1 >= H ? H - 1 : y0 + 1;
+    int x1_ = x0 + 1 >= W ? W - 1 : x0 + 1;
+    if (y0 >= H - 1) { y0 = y1_ = H - 1; y = float(y0); }
+    if (x0 >= W - 1) { x0 = x1_ = W - 1; x = float(x0); }
+    float ly = y - y0, lx = x - x0;
+    float hy = 1.0 - ly, hx = 1.0 - lx;
+    return hy * hx * input_[planeBase + uint(y0 * W + x0)]
+         + hy * lx * input_[planeBase + uint(y0 * W + x1_)]
+         + ly * hx * input_[planeBase + uint(y1_ * W + x0)]
+         + ly * lx * input_[planeBase + uint(y1_ * W + x1_)];
+}
+";
+
+    public static string RoIAlign => Header + @"
+layout(set = 0, binding = 0) readonly buffer I { float input_[]; };
+layout(set = 0, binding = 1) readonly buffer B { float boxes[]; };
+layout(set = 0, binding = 2) writeonly buffer O { float output_[]; };
+layout(push_constant) uniform P {
+    int N; int C; int H; int W; int K; int outH; int outW;
+    float spatialScale; int samplingRatio; int aligned;
+};
+" + Helper + @"
+void main() {
+    int gid = int(gl_GlobalInvocationID.x);
+    int total = K * C * outH * outW;
+    if (gid >= total) return;
+    int pw = gid % outW; int t1 = gid / outW;
+    int ph = t1 % outH; int t2 = t1 / outH;
+    int c = t2 % C; int k = t2 / C;
+    int n = int(boxes[k * 5]);
+    if (n < 0 || n >= N) { output_[gid] = 0.0; return; }
+    float offset = aligned != 0 ? 0.5 : 0.0;
+    float x1 = boxes[k * 5 + 1] * spatialScale - offset;
+    float y1 = boxes[k * 5 + 2] * spatialScale - offset;
+    float x2 = boxes[k * 5 + 3] * spatialScale - offset;
+    float y2 = boxes[k * 5 + 4] * spatialScale - offset;
+    float roiW = aligned != 0 ? (x2 - x1) : max(x2 - x1, 1.0);
+    float roiH = aligned != 0 ? (y2 - y1) : max(y2 - y1, 1.0);
+    float binH = roiH / outH;
+    float binW = roiW / outW;
+    int ry = samplingRatio > 0 ? samplingRatio : int(ceil(roiH / outH));
+    int rx = samplingRatio > 0 ? samplingRatio : int(ceil(roiW / outW));
+    if (ry < 1) ry = 1;
+    if (rx < 1) rx = 1;
+    uint planeBase = uint((n * C + c) * H * W);
+    float acc = 0.0;
+    for (int iy = 0; iy < ry; iy++) {
+        float sy = y1 + ph * binH + (float(iy) + 0.5) * binH / ry;
+        for (int ix = 0; ix < rx; ix++) {
+            float sx = x1 + pw * binW + (float(ix) + 0.5) * binW / rx;
+            acc += bilinear_sample(planeBase, sy, sx, H, W);
+        }
+    }
+    output_[gid] = acc / float(ry * rx);
+}
+";
+
+    public static string RoIPool => Header + @"
+layout(set = 0, binding = 0) readonly buffer I { float input_[]; };
+layout(set = 0, binding = 1) readonly buffer B { float boxes[]; };
+layout(set = 0, binding = 2) writeonly buffer O { float output_[]; };
+layout(push_constant) uniform P {
+    int N; int C; int H; int W; int K; int outH; int outW; float spatialScale;
+};
+void main() {
+    int gid = int(gl_GlobalInvocationID.x);
+    int total = K * C * outH * outW;
+    if (gid >= total) return;
+    int pw = gid % outW; int t1 = gid / outW;
+    int ph = t1 % outH; int t2 = t1 / outH;
+    int c = t2 % C; int k = t2 / C;
+    int n = int(boxes[k * 5]);
+    if (n < 0 || n >= N) { output_[gid] = 0.0; return; }
+    int x1 = int(round(boxes[k * 5 + 1] * spatialScale));
+    int y1 = int(round(boxes[k * 5 + 2] * spatialScale));
+    int x2 = int(round(boxes[k * 5 + 3] * spatialScale));
+    int y2 = int(round(boxes[k * 5 + 4] * spatialScale));
+    int roiW = x2 - x1 + 1; if (roiW < 1) roiW = 1;
+    int roiH = y2 - y1 + 1; if (roiH < 1) roiH = 1;
+    float binH = float(roiH) / outH;
+    float binW = float(roiW) / outW;
+    int hstart = int(floor(ph * binH)) + y1;
+    int hend = int(ceil((ph + 1) * binH)) + y1;
+    int wstart = int(floor(pw * binW)) + x1;
+    int wend = int(ceil((pw + 1) * binW)) + x1;
+    if (hstart < 0) hstart = 0; if (hstart > H) hstart = H;
+    if (hend < 0) hend = 0; if (hend > H) hend = H;
+    if (wstart < 0) wstart = 0; if (wstart > W) wstart = W;
+    if (wend < 0) wend = 0; if (wend > W) wend = W;
+    uint planeBase = uint((n * C + c) * H * W);
+    if (hend <= hstart || wend <= wstart) { output_[gid] = 0.0; return; }
+    float best = -3.4e38;
+    for (int yy = hstart; yy < hend; yy++)
+        for (int xx = wstart; xx < wend; xx++) {
+            float v = input_[planeBase + uint(yy * W + xx)];
+            if (v > best) best = v;
+        }
+    output_[gid] = best;
+}
+";
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanRoiKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanRoiKernels.cs
@@ -70,6 +70,85 @@ void main() {
 }
 ";
 
+    public static string PsRoIAlign => Header + @"
+layout(set = 0, binding = 0) readonly buffer I { float input_[]; };
+layout(set = 0, binding = 1) readonly buffer B { float boxes[]; };
+layout(set = 0, binding = 2) writeonly buffer O { float output_[]; };
+layout(push_constant) uniform P {
+    int N; int C; int H; int W; int K; int outH; int outW; int outputChannels;
+    float spatialScale; int samplingRatio;
+};
+" + Helper + @"
+void main() {
+    int gid = int(gl_GlobalInvocationID.x);
+    int total = K * outputChannels * outH * outW;
+    if (gid >= total) return;
+    int pw = gid % outW; int t1 = gid / outW;
+    int ph = t1 % outH; int t2 = t1 / outH;
+    int co = t2 % outputChannels; int k = t2 / outputChannels;
+    int n = int(boxes[k * 5]);
+    if (n < 0 || n >= N) { output_[gid] = 0.0; return; }
+    float x1 = boxes[k * 5 + 1] * spatialScale;
+    float y1 = boxes[k * 5 + 2] * spatialScale;
+    float x2 = boxes[k * 5 + 3] * spatialScale;
+    float y2 = boxes[k * 5 + 4] * spatialScale;
+    float roiW = max(x2 - x1, 0.1);
+    float roiH = max(y2 - y1, 0.1);
+    float binH = roiH / outH;
+    float binW = roiW / outW;
+    int ry = samplingRatio > 0 ? samplingRatio : int(ceil(roiH / outH));
+    int rx = samplingRatio > 0 ? samplingRatio : int(ceil(roiW / outW));
+    if (ry < 1) ry = 1;
+    if (rx < 1) rx = 1;
+    int c = (co * outH + ph) * outW + pw;
+    uint planeBase = uint((n * C + c) * H * W);
+    float acc = 0.0;
+    for (int iy = 0; iy < ry; iy++) {
+        float sy = y1 + ph * binH + (float(iy) + 0.5) * binH / ry;
+        for (int ix = 0; ix < rx; ix++) {
+            float sx = x1 + pw * binW + (float(ix) + 0.5) * binW / rx;
+            acc += bilinear_sample(planeBase, sy, sx, H, W);
+        }
+    }
+    output_[gid] = acc / float(ry * rx);
+}
+";
+
+    public static string PsRoIPool => Header + @"
+layout(set = 0, binding = 0) readonly buffer I { float input_[]; };
+layout(set = 0, binding = 1) readonly buffer B { float boxes[]; };
+layout(set = 0, binding = 2) writeonly buffer O { float output_[]; };
+layout(push_constant) uniform P {
+    int N; int C; int H; int W; int K; int outH; int outW; int outputChannels; float spatialScale;
+};
+void main() {
+    int gid = int(gl_GlobalInvocationID.x);
+    int total = K * outputChannels * outH * outW;
+    if (gid >= total) return;
+    int pw = gid % outW; int t1 = gid / outW;
+    int ph = t1 % outH; int t2 = t1 / outH;
+    int co = t2 % outputChannels; int k = t2 / outputChannels;
+    int n = int(boxes[k * 5]);
+    if (n < 0 || n >= N) { output_[gid] = 0.0; return; }
+    float x1 = boxes[k * 5 + 1] * spatialScale;
+    float y1 = boxes[k * 5 + 2] * spatialScale;
+    float x2 = boxes[k * 5 + 3] * spatialScale;
+    float y2 = boxes[k * 5 + 4] * spatialScale;
+    float binH = max(y2 - y1, 0.1) / outH;
+    float binW = max(x2 - x1, 0.1) / outW;
+    int c = (co * outH + ph) * outW + pw;
+    int hs = int(max(0.0, floor(y1 + ph * binH)));
+    int he = int(min(float(H), ceil(y1 + (ph + 1) * binH)));
+    int ws = int(max(0.0, floor(x1 + pw * binW)));
+    int we = int(min(float(W), ceil(x1 + (pw + 1) * binW)));
+    uint planeBase = uint((n * C + c) * H * W);
+    float acc = 0.0; int cnt = 0;
+    for (int yy = hs; yy < he; yy++)
+        for (int xx = ws; xx < we; xx++) { acc += input_[planeBase + uint(yy * W + xx)]; cnt++; }
+    output_[gid] = cnt > 0 ? acc / float(cnt) : 0.0;
+}
+";
+
     public static string RoIPool => Header + @"
 layout(set = 0, binding = 0) readonly buffer I { float input_[]; };
 layout(set = 0, binding = 1) readonly buffer B { float boxes[]; };

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanRoiKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanRoiKernels.cs
@@ -183,7 +183,7 @@ void main() {
     if (wend < 0) wend = 0; if (wend > W) wend = W;
     uint planeBase = uint((n * C + c) * H * W);
     if (hend <= hstart || wend <= wstart) { output_[gid] = 0.0; return; }
-    float best = -3.4e38;
+    float best = -3.402823466e+38;  // full -FLT_MAX
     for (int yy = hstart; yy < hend; yy++)
         for (int xx = wstart; xx < wend; xx++) {
             float v = input_[planeBase + uint(yy * W + xx)];

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanRoiKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanRoiKernels.cs
@@ -8,6 +8,7 @@ layout(local_size_x = 256) in;
 
     private const string Helper = @"
 float bilinear_sample(uint planeBase, float y, float x, int H, int W) {
+    if (H <= 0 || W <= 0) return 0.0;
     if (y < -1.0 || y > float(H) || x < -1.0 || x > float(W)) return 0.0;
     if (y <= 0.0) y = 0.0;
     if (x <= 0.0) x = 0.0;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanRoiKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanRoiKernels.cs
@@ -101,6 +101,7 @@ void main() {
     if (ry < 1) ry = 1;
     if (rx < 1) rx = 1;
     int c = (co * outH + ph) * outW + pw;
+    if (c >= C) { output_[gid] = 0.0; return; }
     uint planeBase = uint((n * C + c) * H * W);
     float acc = 0.0;
     for (int iy = 0; iy < ry; iy++) {
@@ -137,6 +138,7 @@ void main() {
     float binH = max(y2 - y1, 0.1) / outH;
     float binW = max(x2 - x1, 0.1) / outW;
     int c = (co * outH + ph) * outW + pw;
+    if (c >= C) { output_[gid] = 0.0; return; }
     int hs = int(max(0.0, floor(y1 + ph * binH)));
     int he = int(min(float(H), ceil(y1 + (ph + 1) * binH)));
     int ws = int(max(0.0, floor(x1 + pw * binW)));

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuAudioKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuAudioKernels.cs
@@ -35,6 +35,7 @@ struct P { length: i32, quantizationChannels: i32 };
 @compute @workgroup_size(256) fn main(@builtin(global_invocation_id) id : vec3<u32>) {
     let gid = i32(id.x);
     if (gid >= p.length) { return; }
+    if (p.quantizationChannels < 2) { output_[gid] = 0.0; return; }
     let mu = f32(p.quantizationChannels - 1);
     let logMu = log(1.0 + mu);
     var x = input_[gid];
@@ -56,6 +57,7 @@ struct P { length: i32, quantizationChannels: i32 };
 @compute @workgroup_size(256) fn main(@builtin(global_invocation_id) id : vec3<u32>) {
     let gid = i32(id.x);
     if (gid >= p.length) { return; }
+    if (p.quantizationChannels < 2) { output_[gid] = 0.0; return; }
     let mu = f32(p.quantizationChannels - 1);
     let q = input_[gid];
     let y = (q / mu) * 2.0 - 1.0;
@@ -101,6 +103,7 @@ struct P { leading: i32, inLen: i32, outLen: i32, up: i32, down: i32, halfWidth:
     let gid = i32(id.x);
     let total = p.leading * p.outLen;
     if (gid >= total) { return; }
+    if (p.halfWidth < 1 || p.up <= 0 || p.down <= 0) { output_[gid] = 0.0; return; }
     let ot = gid % p.outLen;
     let row = gid / p.outLen;
     let sBase = row * p.inLen;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuAudioKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuAudioKernels.cs
@@ -77,6 +77,7 @@ struct P { leading: i32, timeAxis: i32, winLength: i32 };
     let t = gid % p.timeAxis;
     let row = gid / p.timeAxis;
     let n = p.winLength / 2;
+    if (n < 1) { output_[gid] = 0.0; return; }
     var denom : f32 = 0.0;
     for (var i : i32 = 1; i <= n; i = i + 1) { denom = denom + f32(2 * i * i); }
     var acc : f32 = 0.0;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuAudioKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuAudioKernels.cs
@@ -1,0 +1,127 @@
+// Copyright (c) AiDotNet. All rights reserved.
+#if NET7_0_OR_GREATER
+namespace AiDotNet.Tensors.Engines.DirectGpu.WebGpu;
+
+public static class WebGpuAudioKernels
+{
+    public static string[] GetKernelNames() => new[]
+    {
+        "audio_amplitude_to_db", "audio_mulaw_encoding", "audio_mulaw_decoding",
+        "audio_compute_deltas", "audio_resample",
+    };
+
+    public static string AmplitudeToDB => @"
+@group(0) @binding(0) var<storage, read> input_ : array<f32>;
+@group(0) @binding(1) var<storage, read_write> output_ : array<f32>;
+struct P { length: i32, minAmp: f32, topDbFloor: f32, clipTopDb: i32 };
+@group(0) @binding(2) var<uniform> p : P;
+
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) id : vec3<u32>) {
+    let gid = i32(id.x);
+    if (gid >= p.length) { return; }
+    var v = max(input_[gid], p.minAmp);
+    var db = 20.0 * log(v) / log(10.0);
+    if (p.clipTopDb != 0 && db < p.topDbFloor) { db = p.topDbFloor; }
+    output_[gid] = db;
+}
+";
+
+    public static string MuLawEncoding => @"
+@group(0) @binding(0) var<storage, read> input_ : array<f32>;
+@group(0) @binding(1) var<storage, read_write> output_ : array<f32>;
+struct P { length: i32, quantizationChannels: i32 };
+@group(0) @binding(2) var<uniform> p : P;
+
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) id : vec3<u32>) {
+    let gid = i32(id.x);
+    if (gid >= p.length) { return; }
+    let mu = f32(p.quantizationChannels - 1);
+    let logMu = log(1.0 + mu);
+    var x = input_[gid];
+    if (x > 1.0) { x = 1.0; } else if (x < -1.0) { x = -1.0; }
+    let sgn = f32(x > 0.0) - f32(x < 0.0);
+    let y = sgn * log(1.0 + mu * abs(x)) / logMu;
+    var q = floor((y + 1.0) * 0.5 * mu + 0.5);
+    if (q < 0.0) { q = 0.0; } else if (q > mu) { q = mu; }
+    output_[gid] = q;
+}
+";
+
+    public static string MuLawDecoding => @"
+@group(0) @binding(0) var<storage, read> input_ : array<f32>;
+@group(0) @binding(1) var<storage, read_write> output_ : array<f32>;
+struct P { length: i32, quantizationChannels: i32 };
+@group(0) @binding(2) var<uniform> p : P;
+
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) id : vec3<u32>) {
+    let gid = i32(id.x);
+    if (gid >= p.length) { return; }
+    let mu = f32(p.quantizationChannels - 1);
+    let q = input_[gid];
+    let y = (q / mu) * 2.0 - 1.0;
+    let sgn = f32(y > 0.0) - f32(y < 0.0);
+    output_[gid] = sgn * (pow(1.0 + mu, abs(y)) - 1.0) / mu;
+}
+";
+
+    public static string ComputeDeltas => @"
+@group(0) @binding(0) var<storage, read> input_ : array<f32>;
+@group(0) @binding(1) var<storage, read_write> output_ : array<f32>;
+struct P { leading: i32, timeAxis: i32, winLength: i32 };
+@group(0) @binding(2) var<uniform> p : P;
+
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) id : vec3<u32>) {
+    let gid = i32(id.x);
+    let total = p.leading * p.timeAxis;
+    if (gid >= total) { return; }
+    let t = gid % p.timeAxis;
+    let row = gid / p.timeAxis;
+    let n = p.winLength / 2;
+    var denom : f32 = 0.0;
+    for (var i : i32 = 1; i <= n; i = i + 1) { denom = denom + f32(2 * i * i); }
+    var acc : f32 = 0.0;
+    let base_ = row * p.timeAxis;
+    for (var k : i32 = 1; k <= n; k = k + 1) {
+        var left = t - k; if (left < 0) { left = 0; }
+        var right = t + k; if (right >= p.timeAxis) { right = p.timeAxis - 1; }
+        acc = acc + f32(k) * (input_[base_ + right] - input_[base_ + left]);
+    }
+    output_[gid] = acc / denom;
+}
+";
+
+    public static string Resample => @"
+@group(0) @binding(0) var<storage, read> input_ : array<f32>;
+@group(0) @binding(1) var<storage, read_write> output_ : array<f32>;
+struct P { leading: i32, inLen: i32, outLen: i32, up: i32, down: i32, halfWidth: i32 };
+@group(0) @binding(2) var<uniform> p : P;
+
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) id : vec3<u32>) {
+    let gid = i32(id.x);
+    let total = p.leading * p.outLen;
+    if (gid >= total) { return; }
+    let ot = gid % p.outLen;
+    let row = gid / p.outLen;
+    let sBase = row * p.inLen;
+    var cutoff : f32;
+    if (p.up > p.down) { cutoff = 1.0 / f32(p.up); } else { cutoff = 1.0 / f32(p.down); }
+    let srcIdx = f32(ot) * f32(p.down) / f32(p.up);
+    let centre = i32(floor(srcIdx));
+    var acc : f32 = 0.0; var wSum : f32 = 0.0;
+    let PI = 3.14159265358979323846;
+    for (var k : i32 = -p.halfWidth; k <= p.halfWidth; k = k + 1) {
+        let idx = centre + k;
+        if (idx < 0 || idx >= p.inLen) { continue; }
+        let tt = (f32(idx) - srcIdx) * cutoff;
+        var sinc : f32;
+        if (abs(tt) < 1e-12) { sinc = 1.0; } else { sinc = sin(PI * tt) / (PI * tt); }
+        let hann = 0.5 - 0.5 * cos(2.0 * PI * f32(k + p.halfWidth) / f32(2 * p.halfWidth));
+        let w = sinc * hann;
+        acc = acc + w * input_[sBase + idx];
+        wSum = wSum + w;
+    }
+    if (wSum > 0.0) { output_[gid] = acc / wSum; } else { output_[gid] = 0.0; }
+}
+";
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.Audio.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.Audio.cs
@@ -54,7 +54,11 @@ public sealed partial class WebGpuBackend
     public async Task ComputeDeltasAsync(IGpuBuffer input, IGpuBuffer output,
         int leading, int timeAxis, int winLength)
     {
-        int total = leading * timeAxis;
+        // Widened arithmetic — large feature stacks can wrap in int.
+        long totalLong = (long)leading * timeAxis;
+        if (totalLong > int.MaxValue)
+            throw new OverflowException($"ComputeDeltas total {totalLong} exceeds Int32.MaxValue.");
+        int total = (int)totalLong;
         if (total <= 0) return;
         var pipe = await GetOrCreatePipelineAsync(
             AudioModuleKey + ":ComputeDeltas", WebGpuAudioKernels.ComputeDeltas, "main");
@@ -69,7 +73,10 @@ public sealed partial class WebGpuBackend
     public async Task ResampleAsync(IGpuBuffer input, IGpuBuffer output,
         int leading, int inLen, int outLen, int up, int down, int halfWidth)
     {
-        int total = leading * outLen;
+        long totalLong2 = (long)leading * outLen;
+        if (totalLong2 > int.MaxValue)
+            throw new OverflowException($"Resample total {totalLong2} exceeds Int32.MaxValue.");
+        int total = (int)totalLong2;
         if (total <= 0) return;
         var pipe = await GetOrCreatePipelineAsync(
             AudioModuleKey + ":Resample", WebGpuAudioKernels.Resample, "main");

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.Audio.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.Audio.cs
@@ -11,6 +11,10 @@ public sealed partial class WebGpuBackend
         float minAmplitude, float topDb, bool clipTopDb)
     {
         if (length <= 0) return;
+        if (!(minAmplitude > 0.0f))
+            throw new ArgumentException(
+                $"minAmplitude must be > 0 (log10 needs a positive floor); got {minAmplitude}.",
+                nameof(minAmplitude));
         var pipe = await GetOrCreatePipelineAsync(
             AudioModuleKey + ":AmplitudeToDB", WebGpuAudioKernels.AmplitudeToDB, "main");
         var u = new float[4];
@@ -28,6 +32,7 @@ public sealed partial class WebGpuBackend
     public async Task MuLawEncodingAsync(IGpuBuffer input, IGpuBuffer output, int length, int qc)
     {
         if (length <= 0) return;
+        if (qc < 2) throw new ArgumentException("qc must be >= 2.", nameof(qc));
         var pipe = await GetOrCreatePipelineAsync(
             AudioModuleKey + ":MuLawEncoding", WebGpuAudioKernels.MuLawEncoding, "main");
         using var uniforms = new WebGpuBuffer(UniformInts(length, qc),
@@ -41,6 +46,7 @@ public sealed partial class WebGpuBackend
     public async Task MuLawDecodingAsync(IGpuBuffer input, IGpuBuffer output, int length, int qc)
     {
         if (length <= 0) return;
+        if (qc < 2) throw new ArgumentException("qc must be >= 2.", nameof(qc));
         var pipe = await GetOrCreatePipelineAsync(
             AudioModuleKey + ":MuLawDecoding", WebGpuAudioKernels.MuLawDecoding, "main");
         using var uniforms = new WebGpuBuffer(UniformInts(length, qc),
@@ -73,6 +79,10 @@ public sealed partial class WebGpuBackend
     public async Task ResampleAsync(IGpuBuffer input, IGpuBuffer output,
         int leading, int inLen, int outLen, int up, int down, int halfWidth)
     {
+        if (up <= 0 || down <= 0)
+            throw new ArgumentException("up and down must both be positive.");
+        if (halfWidth < 1)
+            throw new ArgumentException("halfWidth must be >= 1 (Hann window needs at least one tap).", nameof(halfWidth));
         long totalLong2 = (long)leading * outLen;
         if (totalLong2 > int.MaxValue)
             throw new OverflowException($"Resample total {totalLong2} exceeds Int32.MaxValue.");

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.Audio.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.Audio.cs
@@ -1,0 +1,84 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// WebGPU audio launchers — async-only.
+#if NET7_0_OR_GREATER
+namespace AiDotNet.Tensors.Engines.DirectGpu.WebGpu;
+
+public sealed partial class WebGpuBackend
+{
+    private const string AudioModuleKey = "Audio";
+
+    public async Task AmplitudeToDBAsync(IGpuBuffer input, IGpuBuffer output, int length,
+        float minAmplitude, float topDb, bool clipTopDb)
+    {
+        if (length <= 0) return;
+        var pipe = await GetOrCreatePipelineAsync(
+            AudioModuleKey + ":AmplitudeToDB", WebGpuAudioKernels.AmplitudeToDB, "main");
+        var u = new float[4];
+        u[0] = System.BitConverter.Int32BitsToSingle(length);
+        u[1] = minAmplitude;
+        u[2] = topDb;
+        u[3] = System.BitConverter.Int32BitsToSingle(clipTopDb ? 1 : 0);
+        using var uniforms = new WebGpuBuffer(u, WebGpuBufferUsage.Uniform | WebGpuBufferUsage.CopyDst);
+        using var bind = new WebGpuBindGroup(pipe, AsWgpu(input), AsWgpu(output));
+        var (wg, _) = _device.CalculateWorkgroups1D(length);
+        await WebGpuNativeBindings.DispatchComputeWithUniformsAsync(pipe, bind.BindGroupId, uniforms.BufferId, wg, 1, 1);
+        await WebGpuNativeBindings.SubmitAndWaitAsync();
+    }
+
+    public async Task MuLawEncodingAsync(IGpuBuffer input, IGpuBuffer output, int length, int qc)
+    {
+        if (length <= 0) return;
+        var pipe = await GetOrCreatePipelineAsync(
+            AudioModuleKey + ":MuLawEncoding", WebGpuAudioKernels.MuLawEncoding, "main");
+        using var uniforms = new WebGpuBuffer(UniformInts(length, qc),
+            WebGpuBufferUsage.Uniform | WebGpuBufferUsage.CopyDst);
+        using var bind = new WebGpuBindGroup(pipe, AsWgpu(input), AsWgpu(output));
+        var (wg, _) = _device.CalculateWorkgroups1D(length);
+        await WebGpuNativeBindings.DispatchComputeWithUniformsAsync(pipe, bind.BindGroupId, uniforms.BufferId, wg, 1, 1);
+        await WebGpuNativeBindings.SubmitAndWaitAsync();
+    }
+
+    public async Task MuLawDecodingAsync(IGpuBuffer input, IGpuBuffer output, int length, int qc)
+    {
+        if (length <= 0) return;
+        var pipe = await GetOrCreatePipelineAsync(
+            AudioModuleKey + ":MuLawDecoding", WebGpuAudioKernels.MuLawDecoding, "main");
+        using var uniforms = new WebGpuBuffer(UniformInts(length, qc),
+            WebGpuBufferUsage.Uniform | WebGpuBufferUsage.CopyDst);
+        using var bind = new WebGpuBindGroup(pipe, AsWgpu(input), AsWgpu(output));
+        var (wg, _) = _device.CalculateWorkgroups1D(length);
+        await WebGpuNativeBindings.DispatchComputeWithUniformsAsync(pipe, bind.BindGroupId, uniforms.BufferId, wg, 1, 1);
+        await WebGpuNativeBindings.SubmitAndWaitAsync();
+    }
+
+    public async Task ComputeDeltasAsync(IGpuBuffer input, IGpuBuffer output,
+        int leading, int timeAxis, int winLength)
+    {
+        int total = leading * timeAxis;
+        if (total <= 0) return;
+        var pipe = await GetOrCreatePipelineAsync(
+            AudioModuleKey + ":ComputeDeltas", WebGpuAudioKernels.ComputeDeltas, "main");
+        using var uniforms = new WebGpuBuffer(UniformInts(leading, timeAxis, winLength),
+            WebGpuBufferUsage.Uniform | WebGpuBufferUsage.CopyDst);
+        using var bind = new WebGpuBindGroup(pipe, AsWgpu(input), AsWgpu(output));
+        var (wg, _) = _device.CalculateWorkgroups1D(total);
+        await WebGpuNativeBindings.DispatchComputeWithUniformsAsync(pipe, bind.BindGroupId, uniforms.BufferId, wg, 1, 1);
+        await WebGpuNativeBindings.SubmitAndWaitAsync();
+    }
+
+    public async Task ResampleAsync(IGpuBuffer input, IGpuBuffer output,
+        int leading, int inLen, int outLen, int up, int down, int halfWidth)
+    {
+        int total = leading * outLen;
+        if (total <= 0) return;
+        var pipe = await GetOrCreatePipelineAsync(
+            AudioModuleKey + ":Resample", WebGpuAudioKernels.Resample, "main");
+        using var uniforms = new WebGpuBuffer(UniformInts(leading, inLen, outLen, up, down, halfWidth),
+            WebGpuBufferUsage.Uniform | WebGpuBufferUsage.CopyDst);
+        using var bind = new WebGpuBindGroup(pipe, AsWgpu(input), AsWgpu(output));
+        var (wg, _) = _device.CalculateWorkgroups1D(total);
+        await WebGpuNativeBindings.DispatchComputeWithUniformsAsync(pipe, bind.BindGroupId, uniforms.BufferId, wg, 1, 1);
+        await WebGpuNativeBindings.SubmitAndWaitAsync();
+    }
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.Detection.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.Detection.cs
@@ -20,7 +20,10 @@ public sealed partial class WebGpuBackend
         IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m)
     {
         if (n <= 0 || m <= 0) return;
-        int total = n * m;
+        long totalLong = (long)n * m;
+        if (totalLong > int.MaxValue)
+            throw new OverflowException($"Pairwise IoU total {totalLong} exceeds Int32.MaxValue.");
+        int total = (int)totalLong;
         var pipelineId = await GetOrCreatePipelineAsync(
             DetectionModuleKey + ":" + tag, source, "main");
         using var uniforms = new WebGpuBuffer(

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.Detection.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.Detection.cs
@@ -65,6 +65,9 @@ public sealed partial class WebGpuBackend
         int n, int fromFormat, int toFormat)
     {
         if (n <= 0) return;
+        if ((uint)fromFormat > 2 || (uint)toFormat > 2)
+            throw new ArgumentException(
+                $"fromFormat/toFormat must be 0/1/2; got {fromFormat}, {toFormat}.");
         var pipelineId = await GetOrCreatePipelineAsync(
             DetectionModuleKey + ":BoxConvert", WebGpuDetectionKernels.BoxConvert, "main");
         using var uniforms = new WebGpuBuffer(

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.Detection.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.Detection.cs
@@ -1,0 +1,116 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// WebGPU launcher shims for the vision detection kernels (Issue #217). Each
+// WGSL source in WebGpuDetectionKernels is a self-contained compute shader
+// (one pipeline per source), dispatched 1-D over n*m (IoU) or n (per-box).
+//
+// Note: WebGPU's compute API is async, so detection ops here are exposed as
+// *Async methods. They are NOT wired through DirectGpuTensorEngine's sync
+// IDetectionBackend dispatch (same constraint as the Parity-210 surface) —
+// the engine falls through to the CpuEngine reference for WebGPU. Direct
+// callers who hold a WebGpuBackend can invoke these Async methods.
+
+#if NET7_0_OR_GREATER
+namespace AiDotNet.Tensors.Engines.DirectGpu.WebGpu;
+
+public sealed partial class WebGpuBackend
+{
+    private const string DetectionModuleKey = "Detection";
+
+    private async Task DispatchPairwiseIouAsync(string tag, string source,
+        IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m)
+    {
+        if (n <= 0 || m <= 0) return;
+        int total = n * m;
+        var pipelineId = await GetOrCreatePipelineAsync(
+            DetectionModuleKey + ":" + tag, source, "main");
+        using var uniforms = new WebGpuBuffer(
+            UniformInts(n, m),
+            WebGpuBufferUsage.Uniform | WebGpuBufferUsage.CopyDst);
+        using var bind = new WebGpuBindGroup(pipelineId,
+            AsWgpu(boxesA), AsWgpu(boxesB), AsWgpu(output));
+        var (wg, _) = _device.CalculateWorkgroups1D(total);
+        await WebGpuNativeBindings.DispatchComputeWithUniformsAsync(
+            pipelineId, bind.BindGroupId, uniforms.BufferId, wg, 1, 1);
+        await WebGpuNativeBindings.SubmitAndWaitAsync();
+    }
+
+    public Task BoxIouAsync(IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m)
+        => DispatchPairwiseIouAsync("BoxIou", WebGpuDetectionKernels.BoxIou, boxesA, boxesB, output, n, m);
+
+    public Task GeneralizedBoxIouAsync(IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m)
+        => DispatchPairwiseIouAsync("GeneralizedBoxIou", WebGpuDetectionKernels.GeneralizedBoxIou, boxesA, boxesB, output, n, m);
+
+    public Task DistanceBoxIouAsync(IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m)
+        => DispatchPairwiseIouAsync("DistanceBoxIou", WebGpuDetectionKernels.DistanceBoxIou, boxesA, boxesB, output, n, m);
+
+    public Task CompleteBoxIouAsync(IGpuBuffer boxesA, IGpuBuffer boxesB, IGpuBuffer output, int n, int m)
+        => DispatchPairwiseIouAsync("CompleteBoxIou", WebGpuDetectionKernels.CompleteBoxIou, boxesA, boxesB, output, n, m);
+
+    public async Task BoxAreaAsync(IGpuBuffer boxes, IGpuBuffer output, int n)
+    {
+        if (n <= 0) return;
+        var pipelineId = await GetOrCreatePipelineAsync(
+            DetectionModuleKey + ":BoxArea", WebGpuDetectionKernels.BoxArea, "main");
+        using var uniforms = new WebGpuBuffer(
+            UniformInts(n),
+            WebGpuBufferUsage.Uniform | WebGpuBufferUsage.CopyDst);
+        using var bind = new WebGpuBindGroup(pipelineId, AsWgpu(boxes), AsWgpu(output));
+        var (wg, _) = _device.CalculateWorkgroups1D(n);
+        await WebGpuNativeBindings.DispatchComputeWithUniformsAsync(
+            pipelineId, bind.BindGroupId, uniforms.BufferId, wg, 1, 1);
+        await WebGpuNativeBindings.SubmitAndWaitAsync();
+    }
+
+    public async Task BoxConvertAsync(IGpuBuffer boxes, IGpuBuffer output,
+        int n, int fromFormat, int toFormat)
+    {
+        if (n <= 0) return;
+        var pipelineId = await GetOrCreatePipelineAsync(
+            DetectionModuleKey + ":BoxConvert", WebGpuDetectionKernels.BoxConvert, "main");
+        using var uniforms = new WebGpuBuffer(
+            UniformInts(n, fromFormat, toFormat),
+            WebGpuBufferUsage.Uniform | WebGpuBufferUsage.CopyDst);
+        using var bind = new WebGpuBindGroup(pipelineId, AsWgpu(boxes), AsWgpu(output));
+        var (wg, _) = _device.CalculateWorkgroups1D(n);
+        await WebGpuNativeBindings.DispatchComputeWithUniformsAsync(
+            pipelineId, bind.BindGroupId, uniforms.BufferId, wg, 1, 1);
+        await WebGpuNativeBindings.SubmitAndWaitAsync();
+    }
+
+    public async Task IouFamilyBackwardAsync(
+        IGpuBuffer gradOutput, IGpuBuffer boxesA, IGpuBuffer boxesB,
+        IGpuBuffer gradA, IGpuBuffer gradB,
+        int n, int m, int variant)
+    {
+        if (n <= 0 || m <= 0) return;
+
+        var pipeA = await GetOrCreatePipelineAsync(
+            DetectionModuleKey + ":IouBackwardA", WebGpuDetectionKernels.IouBackwardA, "main");
+        using (var uniforms = new WebGpuBuffer(
+            UniformInts(n, m, variant),
+            WebGpuBufferUsage.Uniform | WebGpuBufferUsage.CopyDst))
+        using (var bind = new WebGpuBindGroup(pipeA,
+            AsWgpu(gradOutput), AsWgpu(boxesA), AsWgpu(boxesB), AsWgpu(gradA)))
+        {
+            var (wg, _) = _device.CalculateWorkgroups1D(n);
+            await WebGpuNativeBindings.DispatchComputeWithUniformsAsync(
+                pipeA, bind.BindGroupId, uniforms.BufferId, wg, 1, 1);
+            await WebGpuNativeBindings.SubmitAndWaitAsync();
+        }
+
+        var pipeB = await GetOrCreatePipelineAsync(
+            DetectionModuleKey + ":IouBackwardB", WebGpuDetectionKernels.IouBackwardB, "main");
+        using (var uniforms = new WebGpuBuffer(
+            UniformInts(n, m, variant),
+            WebGpuBufferUsage.Uniform | WebGpuBufferUsage.CopyDst))
+        using (var bind = new WebGpuBindGroup(pipeB,
+            AsWgpu(gradOutput), AsWgpu(boxesA), AsWgpu(boxesB), AsWgpu(gradB)))
+        {
+            var (wg, _) = _device.CalculateWorkgroups1D(m);
+            await WebGpuNativeBindings.DispatchComputeWithUniformsAsync(
+                pipeB, bind.BindGroupId, uniforms.BufferId, wg, 1, 1);
+            await WebGpuNativeBindings.SubmitAndWaitAsync();
+        }
+    }
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.Detection.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.Detection.cs
@@ -82,34 +82,41 @@ public sealed partial class WebGpuBackend
         IGpuBuffer gradA, IGpuBuffer gradB,
         int n, int m, int variant)
     {
-        if (n <= 0 || m <= 0) return;
+        // See CudaBackend.Detection for rationale.
+        if (n <= 0 && m <= 0) return;
 
-        var pipeA = await GetOrCreatePipelineAsync(
-            DetectionModuleKey + ":IouBackwardA", WebGpuDetectionKernels.IouBackwardA, "main");
-        using (var uniforms = new WebGpuBuffer(
-            UniformInts(n, m, variant),
-            WebGpuBufferUsage.Uniform | WebGpuBufferUsage.CopyDst))
-        using (var bind = new WebGpuBindGroup(pipeA,
-            AsWgpu(gradOutput), AsWgpu(boxesA), AsWgpu(boxesB), AsWgpu(gradA)))
+        if (n > 0)
         {
-            var (wg, _) = _device.CalculateWorkgroups1D(n);
-            await WebGpuNativeBindings.DispatchComputeWithUniformsAsync(
-                pipeA, bind.BindGroupId, uniforms.BufferId, wg, 1, 1);
-            await WebGpuNativeBindings.SubmitAndWaitAsync();
+            var pipeA = await GetOrCreatePipelineAsync(
+                DetectionModuleKey + ":IouBackwardA", WebGpuDetectionKernels.IouBackwardA, "main");
+            using (var uniforms = new WebGpuBuffer(
+                UniformInts(n, m, variant),
+                WebGpuBufferUsage.Uniform | WebGpuBufferUsage.CopyDst))
+            using (var bind = new WebGpuBindGroup(pipeA,
+                AsWgpu(gradOutput), AsWgpu(boxesA), AsWgpu(boxesB), AsWgpu(gradA)))
+            {
+                var (wg, _) = _device.CalculateWorkgroups1D(n);
+                await WebGpuNativeBindings.DispatchComputeWithUniformsAsync(
+                    pipeA, bind.BindGroupId, uniforms.BufferId, wg, 1, 1);
+                await WebGpuNativeBindings.SubmitAndWaitAsync();
+            }
         }
 
-        var pipeB = await GetOrCreatePipelineAsync(
-            DetectionModuleKey + ":IouBackwardB", WebGpuDetectionKernels.IouBackwardB, "main");
-        using (var uniforms = new WebGpuBuffer(
-            UniformInts(n, m, variant),
-            WebGpuBufferUsage.Uniform | WebGpuBufferUsage.CopyDst))
-        using (var bind = new WebGpuBindGroup(pipeB,
-            AsWgpu(gradOutput), AsWgpu(boxesA), AsWgpu(boxesB), AsWgpu(gradB)))
+        if (m > 0)
         {
-            var (wg, _) = _device.CalculateWorkgroups1D(m);
-            await WebGpuNativeBindings.DispatchComputeWithUniformsAsync(
-                pipeB, bind.BindGroupId, uniforms.BufferId, wg, 1, 1);
-            await WebGpuNativeBindings.SubmitAndWaitAsync();
+            var pipeB = await GetOrCreatePipelineAsync(
+                DetectionModuleKey + ":IouBackwardB", WebGpuDetectionKernels.IouBackwardB, "main");
+            using (var uniforms = new WebGpuBuffer(
+                UniformInts(n, m, variant),
+                WebGpuBufferUsage.Uniform | WebGpuBufferUsage.CopyDst))
+            using (var bind = new WebGpuBindGroup(pipeB,
+                AsWgpu(gradOutput), AsWgpu(boxesA), AsWgpu(boxesB), AsWgpu(gradB)))
+            {
+                var (wg, _) = _device.CalculateWorkgroups1D(m);
+                await WebGpuNativeBindings.DispatchComputeWithUniformsAsync(
+                    pipeB, bind.BindGroupId, uniforms.BufferId, wg, 1, 1);
+                await WebGpuNativeBindings.SubmitAndWaitAsync();
+            }
         }
     }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.Geometry.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.Geometry.cs
@@ -1,0 +1,109 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// WebGPU launcher shims for the geometry / sampling kernels (Issue #217).
+// WebGPU's compute API is async — these methods are exposed as *Async and
+// NOT wired through DirectGpuTensorEngine's sync IGeometryBackend dispatch
+// (same constraint as Parity-210 / Detection). Direct callers holding a
+// WebGpuBackend can invoke them.
+
+#if NET7_0_OR_GREATER
+namespace AiDotNet.Tensors.Engines.DirectGpu.WebGpu;
+
+public sealed partial class WebGpuBackend
+{
+    private const string GeometryModuleKey = "Geometry";
+
+    public async Task Interpolate2DAsync(IGpuBuffer input, IGpuBuffer output,
+        int N, int C, int Hin, int Win, int Hout, int Wout,
+        int mode, bool alignCorners)
+    {
+        int total = N * C * Hout * Wout;
+        if (total <= 0) return;
+        var pipe = await GetOrCreatePipelineAsync(
+            GeometryModuleKey + ":Interpolate2D", WebGpuGeometryKernels.Interpolate2D, "main");
+        using var uniforms = new WebGpuBuffer(
+            UniformInts(N, C, Hin, Win, Hout, Wout, mode, alignCorners ? 1 : 0),
+            WebGpuBufferUsage.Uniform | WebGpuBufferUsage.CopyDst);
+        using var bind = new WebGpuBindGroup(pipe, AsWgpu(input), AsWgpu(output));
+        var (wg, _) = _device.CalculateWorkgroups1D(total);
+        await WebGpuNativeBindings.DispatchComputeWithUniformsAsync(
+            pipe, bind.BindGroupId, uniforms.BufferId, wg, 1, 1);
+        await WebGpuNativeBindings.SubmitAndWaitAsync();
+    }
+
+    public async Task Pad4DAsync(IGpuBuffer input, IGpuBuffer output,
+        int N, int C, int Hin, int Win,
+        int padN0, int padN1, int padC0, int padC1,
+        int padH0, int padH1, int padW0, int padW1,
+        int mode, float padValue)
+    {
+        int total = (N + padN0 + padN1) * (C + padC0 + padC1) * (Hin + padH0 + padH1) * (Win + padW0 + padW1);
+        if (total <= 0) return;
+        var pipe = await GetOrCreatePipelineAsync(
+            GeometryModuleKey + ":Pad4D", WebGpuGeometryKernels.Pad4D, "main");
+        // Uniform: 13 i32 + 1 f32 = 14 × 4 bytes = 56.
+        float[] uniformBytes = new float[14];
+        uniformBytes[0] = System.BitConverter.Int32BitsToSingle(N);
+        uniformBytes[1] = System.BitConverter.Int32BitsToSingle(C);
+        uniformBytes[2] = System.BitConverter.Int32BitsToSingle(Hin);
+        uniformBytes[3] = System.BitConverter.Int32BitsToSingle(Win);
+        uniformBytes[4] = System.BitConverter.Int32BitsToSingle(padN0);
+        uniformBytes[5] = System.BitConverter.Int32BitsToSingle(padN1);
+        uniformBytes[6] = System.BitConverter.Int32BitsToSingle(padC0);
+        uniformBytes[7] = System.BitConverter.Int32BitsToSingle(padC1);
+        uniformBytes[8] = System.BitConverter.Int32BitsToSingle(padH0);
+        uniformBytes[9] = System.BitConverter.Int32BitsToSingle(padH1);
+        uniformBytes[10] = System.BitConverter.Int32BitsToSingle(padW0);
+        uniformBytes[11] = System.BitConverter.Int32BitsToSingle(padW1);
+        uniformBytes[12] = System.BitConverter.Int32BitsToSingle(mode);
+        uniformBytes[13] = padValue;
+        // Pad to multiple of 16 bytes for uniform min binding size.
+        int padded = ((uniformBytes.Length + 3) / 4) * 4;
+        var padBuf = new float[padded];
+        Array.Copy(uniformBytes, padBuf, uniformBytes.Length);
+        using var uniforms = new WebGpuBuffer(
+            padBuf,
+            WebGpuBufferUsage.Uniform | WebGpuBufferUsage.CopyDst);
+        using var bind = new WebGpuBindGroup(pipe, AsWgpu(input), AsWgpu(output));
+        var (wg, _) = _device.CalculateWorkgroups1D(total);
+        await WebGpuNativeBindings.DispatchComputeWithUniformsAsync(
+            pipe, bind.BindGroupId, uniforms.BufferId, wg, 1, 1);
+        await WebGpuNativeBindings.SubmitAndWaitAsync();
+    }
+
+    public async Task GridSample2DAsync(IGpuBuffer input, IGpuBuffer grid, IGpuBuffer output,
+        int N, int H, int W, int C, int outH, int outW,
+        int mode, int padding, bool alignCorners)
+    {
+        int total = N * outH * outW;
+        if (total <= 0) return;
+        var pipe = await GetOrCreatePipelineAsync(
+            GeometryModuleKey + ":GridSample2D", WebGpuGeometryKernels.GridSample2D, "main");
+        using var uniforms = new WebGpuBuffer(
+            UniformInts(N, H, W, C, outH, outW, mode, padding, alignCorners ? 1 : 0),
+            WebGpuBufferUsage.Uniform | WebGpuBufferUsage.CopyDst);
+        using var bind = new WebGpuBindGroup(pipe,
+            AsWgpu(input), AsWgpu(grid), AsWgpu(output));
+        var (wg, _) = _device.CalculateWorkgroups1D(total);
+        await WebGpuNativeBindings.DispatchComputeWithUniformsAsync(
+            pipe, bind.BindGroupId, uniforms.BufferId, wg, 1, 1);
+        await WebGpuNativeBindings.SubmitAndWaitAsync();
+    }
+
+    public async Task AffineGrid3DAsync(IGpuBuffer theta, IGpuBuffer grid,
+        int N, int D, int H, int W, bool alignCorners)
+    {
+        int total = N * D * H * W;
+        if (total <= 0) return;
+        var pipe = await GetOrCreatePipelineAsync(
+            GeometryModuleKey + ":AffineGrid3D", WebGpuGeometryKernels.AffineGrid3D, "main");
+        using var uniforms = new WebGpuBuffer(
+            UniformInts(N, D, H, W, alignCorners ? 1 : 0),
+            WebGpuBufferUsage.Uniform | WebGpuBufferUsage.CopyDst);
+        using var bind = new WebGpuBindGroup(pipe, AsWgpu(theta), AsWgpu(grid));
+        var (wg, _) = _device.CalculateWorkgroups1D(total);
+        await WebGpuNativeBindings.DispatchComputeWithUniformsAsync(
+            pipe, bind.BindGroupId, uniforms.BufferId, wg, 1, 1);
+        await WebGpuNativeBindings.SubmitAndWaitAsync();
+    }
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.Roi.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.Roi.cs
@@ -1,0 +1,64 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// WebGPU RoI launcher shims — async-only, same pattern as Detection/Geometry.
+#if NET7_0_OR_GREATER
+namespace AiDotNet.Tensors.Engines.DirectGpu.WebGpu;
+
+public sealed partial class WebGpuBackend
+{
+    private const string RoiModuleKey = "Roi";
+
+    public async Task RoIAlignAsync(IGpuBuffer input, IGpuBuffer boxes, IGpuBuffer output,
+        int N, int C, int H, int W, int K, int outH, int outW,
+        float spatialScale, int samplingRatio, bool aligned)
+    {
+        int total = K * C * outH * outW;
+        if (total <= 0) return;
+        var pipe = await GetOrCreatePipelineAsync(
+            RoiModuleKey + ":RoIAlign", WebGpuRoiKernels.RoIAlign, "main");
+        // Uniform: 7 i32 + 1 f32 + 2 i32 = 10 × 4 bytes = 40.
+        var uniform = new float[10];
+        uniform[0] = System.BitConverter.Int32BitsToSingle(N);
+        uniform[1] = System.BitConverter.Int32BitsToSingle(C);
+        uniform[2] = System.BitConverter.Int32BitsToSingle(H);
+        uniform[3] = System.BitConverter.Int32BitsToSingle(W);
+        uniform[4] = System.BitConverter.Int32BitsToSingle(K);
+        uniform[5] = System.BitConverter.Int32BitsToSingle(outH);
+        uniform[6] = System.BitConverter.Int32BitsToSingle(outW);
+        uniform[7] = spatialScale;
+        uniform[8] = System.BitConverter.Int32BitsToSingle(samplingRatio);
+        uniform[9] = System.BitConverter.Int32BitsToSingle(aligned ? 1 : 0);
+        // Pad to multiple of 16 bytes.
+        int padded = ((uniform.Length + 3) / 4) * 4;
+        var padBuf = new float[padded];
+        Array.Copy(uniform, padBuf, uniform.Length);
+        using var u = new WebGpuBuffer(padBuf, WebGpuBufferUsage.Uniform | WebGpuBufferUsage.CopyDst);
+        using var bind = new WebGpuBindGroup(pipe, AsWgpu(input), AsWgpu(boxes), AsWgpu(output));
+        var (wg, _) = _device.CalculateWorkgroups1D(total);
+        await WebGpuNativeBindings.DispatchComputeWithUniformsAsync(pipe, bind.BindGroupId, u.BufferId, wg, 1, 1);
+        await WebGpuNativeBindings.SubmitAndWaitAsync();
+    }
+
+    public async Task RoIPoolAsync(IGpuBuffer input, IGpuBuffer boxes, IGpuBuffer output,
+        int N, int C, int H, int W, int K, int outH, int outW, float spatialScale)
+    {
+        int total = K * C * outH * outW;
+        if (total <= 0) return;
+        var pipe = await GetOrCreatePipelineAsync(
+            RoiModuleKey + ":RoIPool", WebGpuRoiKernels.RoIPool, "main");
+        var uniform = new float[8];
+        uniform[0] = System.BitConverter.Int32BitsToSingle(N);
+        uniform[1] = System.BitConverter.Int32BitsToSingle(C);
+        uniform[2] = System.BitConverter.Int32BitsToSingle(H);
+        uniform[3] = System.BitConverter.Int32BitsToSingle(W);
+        uniform[4] = System.BitConverter.Int32BitsToSingle(K);
+        uniform[5] = System.BitConverter.Int32BitsToSingle(outH);
+        uniform[6] = System.BitConverter.Int32BitsToSingle(outW);
+        uniform[7] = spatialScale;
+        using var u = new WebGpuBuffer(uniform, WebGpuBufferUsage.Uniform | WebGpuBufferUsage.CopyDst);
+        using var bind = new WebGpuBindGroup(pipe, AsWgpu(input), AsWgpu(boxes), AsWgpu(output));
+        var (wg, _) = _device.CalculateWorkgroups1D(total);
+        await WebGpuNativeBindings.DispatchComputeWithUniformsAsync(pipe, bind.BindGroupId, u.BufferId, wg, 1, 1);
+        await WebGpuNativeBindings.SubmitAndWaitAsync();
+    }
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.Roi.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.Roi.cs
@@ -1,5 +1,16 @@
 // Copyright (c) AiDotNet. All rights reserved.
-// WebGPU RoI launcher shims — async-only, same pattern as Detection/Geometry.
+// WebGPU RoI launcher shims — ASYNC-ONLY, matching the established
+// WebGPU pattern also used by Detection, Geometry, and Parity-210.
+//
+// WebGpuBackend deliberately does NOT implement the synchronous
+// IRoiBackend interface because WebGPU's compute submission API is
+// intrinsically Task-based: every dispatch waits on queue.onSubmittedWorkDone.
+// Fabricating a sync wrapper would either deadlock (waiting on a
+// Promise resolution from the same thread the JS event loop needs) or
+// silently drop errors. DirectGpuTensorEngine therefore falls through
+// to CpuEngine when the active backend is WebGPU — the same convention
+// as the other capability surfaces. Direct callers that hold a
+// WebGpuBackend can invoke these *Async methods explicitly.
 #if NET7_0_OR_GREATER
 namespace AiDotNet.Tensors.Engines.DirectGpu.WebGpu;
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.Roi.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.Roi.cs
@@ -60,5 +60,62 @@ public sealed partial class WebGpuBackend
         await WebGpuNativeBindings.DispatchComputeWithUniformsAsync(pipe, bind.BindGroupId, u.BufferId, wg, 1, 1);
         await WebGpuNativeBindings.SubmitAndWaitAsync();
     }
+
+    public async Task PsRoIAlignAsync(IGpuBuffer input, IGpuBuffer boxes, IGpuBuffer output,
+        int N, int C, int H, int W, int K, int outH, int outW, int outputChannels,
+        float spatialScale, int samplingRatio)
+    {
+        int total = K * outputChannels * outH * outW;
+        if (total <= 0) return;
+        var pipe = await GetOrCreatePipelineAsync(
+            RoiModuleKey + ":PsRoIAlign", WebGpuRoiKernels.PsRoIAlign, "main");
+        var uniform = new float[10];
+        uniform[0] = System.BitConverter.Int32BitsToSingle(N);
+        uniform[1] = System.BitConverter.Int32BitsToSingle(C);
+        uniform[2] = System.BitConverter.Int32BitsToSingle(H);
+        uniform[3] = System.BitConverter.Int32BitsToSingle(W);
+        uniform[4] = System.BitConverter.Int32BitsToSingle(K);
+        uniform[5] = System.BitConverter.Int32BitsToSingle(outH);
+        uniform[6] = System.BitConverter.Int32BitsToSingle(outW);
+        uniform[7] = System.BitConverter.Int32BitsToSingle(outputChannels);
+        uniform[8] = spatialScale;
+        uniform[9] = System.BitConverter.Int32BitsToSingle(samplingRatio);
+        int padded = ((uniform.Length + 3) / 4) * 4;
+        var padBuf = new float[padded];
+        Array.Copy(uniform, padBuf, uniform.Length);
+        using var u = new WebGpuBuffer(padBuf, WebGpuBufferUsage.Uniform | WebGpuBufferUsage.CopyDst);
+        using var bind = new WebGpuBindGroup(pipe, AsWgpu(input), AsWgpu(boxes), AsWgpu(output));
+        var (wg, _) = _device.CalculateWorkgroups1D(total);
+        await WebGpuNativeBindings.DispatchComputeWithUniformsAsync(pipe, bind.BindGroupId, u.BufferId, wg, 1, 1);
+        await WebGpuNativeBindings.SubmitAndWaitAsync();
+    }
+
+    public async Task PsRoIPoolAsync(IGpuBuffer input, IGpuBuffer boxes, IGpuBuffer output,
+        int N, int C, int H, int W, int K, int outH, int outW, int outputChannels,
+        float spatialScale)
+    {
+        int total = K * outputChannels * outH * outW;
+        if (total <= 0) return;
+        var pipe = await GetOrCreatePipelineAsync(
+            RoiModuleKey + ":PsRoIPool", WebGpuRoiKernels.PsRoIPool, "main");
+        var uniform = new float[9];
+        uniform[0] = System.BitConverter.Int32BitsToSingle(N);
+        uniform[1] = System.BitConverter.Int32BitsToSingle(C);
+        uniform[2] = System.BitConverter.Int32BitsToSingle(H);
+        uniform[3] = System.BitConverter.Int32BitsToSingle(W);
+        uniform[4] = System.BitConverter.Int32BitsToSingle(K);
+        uniform[5] = System.BitConverter.Int32BitsToSingle(outH);
+        uniform[6] = System.BitConverter.Int32BitsToSingle(outW);
+        uniform[7] = System.BitConverter.Int32BitsToSingle(outputChannels);
+        uniform[8] = spatialScale;
+        int padded = ((uniform.Length + 3) / 4) * 4;
+        var padBuf = new float[padded];
+        Array.Copy(uniform, padBuf, uniform.Length);
+        using var u = new WebGpuBuffer(padBuf, WebGpuBufferUsage.Uniform | WebGpuBufferUsage.CopyDst);
+        using var bind = new WebGpuBindGroup(pipe, AsWgpu(input), AsWgpu(boxes), AsWgpu(output));
+        var (wg, _) = _device.CalculateWorkgroups1D(total);
+        await WebGpuNativeBindings.DispatchComputeWithUniformsAsync(pipe, bind.BindGroupId, u.BufferId, wg, 1, 1);
+        await WebGpuNativeBindings.SubmitAndWaitAsync();
+    }
 }
 #endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuDetectionKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuDetectionKernels.cs
@@ -139,10 +139,11 @@ struct P { n: i32, m: i32 };
     let ax1 = a[i * 4]; let ay1 = a[i * 4 + 1]; let ax2 = a[i * 4 + 2]; let ay2 = a[i * 4 + 3];
     let bx1 = b[j * 4]; let by1 = b[j * 4 + 1]; let bx2 = b[j * 4 + 2]; let by2 = b[j * 4 + 3];
 
-    let aw = ax2 - ax1; let ah = ay2 - ay1;
-    let bw = bx2 - bx1; let bh = by2 - by1;
-    let areaA = max(aw, 0.0) * max(ah, 0.0);
-    let areaB = max(bw, 0.0) * max(bh, 0.0);
+    // Clamp to match the backward's convention.
+    let aw = max(ax2 - ax1, 0.0); let ah = max(ay2 - ay1, 0.0);
+    let bw = max(bx2 - bx1, 0.0); let bh = max(by2 - by1, 0.0);
+    let areaA = aw * ah;
+    let areaB = bw * bh;
     let ix1 = max(ax1, bx1); let iy1 = max(ay1, by1);
     let ix2 = min(ax2, bx2); let iy2 = min(ay2, by2);
     let inter = max(ix2 - ix1, 0.0) * max(iy2 - iy1, 0.0);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuDetectionKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuDetectionKernels.cs
@@ -1,0 +1,432 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// WebGPU WGSL compute shaders for the vision detection ops added by Issue
+// #217. Mirrors CudaDetectionKernels / HipDetectionKernels /
+// MetalDetectionKernels / VulkanDetectionKernels function-for-function.
+
+#if NET7_0_OR_GREATER
+namespace AiDotNet.Tensors.Engines.DirectGpu.WebGpu;
+
+/// <summary>
+/// WGSL compute shader sources for the detection kernels. @workgroup_size(256)
+/// + 1-D dispatch shape — pairwise IoU over n*m cells, per-box ops over n
+/// cells. Bit-for-bit semantics with the CUDA / HIP / Metal / Vulkan kernels.
+/// </summary>
+public static class WebGpuDetectionKernels
+{
+    public static string[] GetKernelNames() => new[]
+    {
+        "detection_box_iou",
+        "detection_generalized_box_iou",
+        "detection_distance_box_iou",
+        "detection_complete_box_iou",
+        "detection_box_area",
+        "detection_box_convert",
+        "detection_iou_backward_a",
+        "detection_iou_backward_b",
+    };
+
+    // -----------------------------------------------------------------------
+    // Pairwise IoU family — 3 SSBO bindings (a, b, output) + uniform (n, m).
+    // -----------------------------------------------------------------------
+
+    public static string BoxIou => @"
+@group(0) @binding(0) var<storage, read> a : array<f32>;
+@group(0) @binding(1) var<storage, read> b : array<f32>;
+@group(0) @binding(2) var<storage, read_write> o : array<f32>;
+struct P { n: i32, m: i32 };
+@group(0) @binding(3) var<uniform> p : P;
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) id : vec3<u32>) {
+    let gid = i32(id.x);
+    let total = p.n * p.m;
+    if (gid >= total) { return; }
+    let i = gid / p.m;
+    let j = gid % p.m;
+    let ax1 = a[i * 4]; let ay1 = a[i * 4 + 1]; let ax2 = a[i * 4 + 2]; let ay2 = a[i * 4 + 3];
+    let bx1 = b[j * 4]; let by1 = b[j * 4 + 1]; let bx2 = b[j * 4 + 2]; let by2 = b[j * 4 + 3];
+
+    let aw = max(ax2 - ax1, 0.0); let ah = max(ay2 - ay1, 0.0);
+    let bw = max(bx2 - bx1, 0.0); let bh = max(by2 - by1, 0.0);
+    let areaA = aw * ah; let areaB = bw * bh;
+
+    let ix1 = max(ax1, bx1); let iy1 = max(ay1, by1);
+    let ix2 = min(ax2, bx2); let iy2 = min(ay2, by2);
+    let iw = max(ix2 - ix1, 0.0); let ih = max(iy2 - iy1, 0.0);
+    let inter = iw * ih;
+    let u = areaA + areaB - inter;
+    if (u > 0.0) { o[gid] = inter / u; } else { o[gid] = 0.0; }
+}
+";
+
+    public static string GeneralizedBoxIou => @"
+@group(0) @binding(0) var<storage, read> a : array<f32>;
+@group(0) @binding(1) var<storage, read> b : array<f32>;
+@group(0) @binding(2) var<storage, read_write> o : array<f32>;
+struct P { n: i32, m: i32 };
+@group(0) @binding(3) var<uniform> p : P;
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) id : vec3<u32>) {
+    let gid = i32(id.x);
+    let total = p.n * p.m;
+    if (gid >= total) { return; }
+    let i = gid / p.m;
+    let j = gid % p.m;
+    let ax1 = a[i * 4]; let ay1 = a[i * 4 + 1]; let ax2 = a[i * 4 + 2]; let ay2 = a[i * 4 + 3];
+    let bx1 = b[j * 4]; let by1 = b[j * 4 + 1]; let bx2 = b[j * 4 + 2]; let by2 = b[j * 4 + 3];
+
+    let areaA = max(ax2 - ax1, 0.0) * max(ay2 - ay1, 0.0);
+    let areaB = max(bx2 - bx1, 0.0) * max(by2 - by1, 0.0);
+    let ix1 = max(ax1, bx1); let iy1 = max(ay1, by1);
+    let ix2 = min(ax2, bx2); let iy2 = min(ay2, by2);
+    let inter = max(ix2 - ix1, 0.0) * max(iy2 - iy1, 0.0);
+    let u = areaA + areaB - inter;
+    var iou : f32 = 0.0;
+    if (u > 0.0) { iou = inter / u; }
+
+    let ex1 = min(ax1, bx1); let ey1 = min(ay1, by1);
+    let ex2 = max(ax2, bx2); let ey2 = max(ay2, by2);
+    let enclose = max(ex2 - ex1, 0.0) * max(ey2 - ey1, 0.0);
+    if (enclose > 0.0) { o[gid] = iou - (enclose - u) / enclose; } else { o[gid] = iou; }
+}
+";
+
+    public static string DistanceBoxIou => @"
+@group(0) @binding(0) var<storage, read> a : array<f32>;
+@group(0) @binding(1) var<storage, read> b : array<f32>;
+@group(0) @binding(2) var<storage, read_write> o : array<f32>;
+struct P { n: i32, m: i32 };
+@group(0) @binding(3) var<uniform> p : P;
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) id : vec3<u32>) {
+    let gid = i32(id.x);
+    let total = p.n * p.m;
+    if (gid >= total) { return; }
+    let i = gid / p.m;
+    let j = gid % p.m;
+    let ax1 = a[i * 4]; let ay1 = a[i * 4 + 1]; let ax2 = a[i * 4 + 2]; let ay2 = a[i * 4 + 3];
+    let bx1 = b[j * 4]; let by1 = b[j * 4 + 1]; let bx2 = b[j * 4 + 2]; let by2 = b[j * 4 + 3];
+
+    let areaA = max(ax2 - ax1, 0.0) * max(ay2 - ay1, 0.0);
+    let areaB = max(bx2 - bx1, 0.0) * max(by2 - by1, 0.0);
+    let ix1 = max(ax1, bx1); let iy1 = max(ay1, by1);
+    let ix2 = min(ax2, bx2); let iy2 = min(ay2, by2);
+    let inter = max(ix2 - ix1, 0.0) * max(iy2 - iy1, 0.0);
+    let u = areaA + areaB - inter;
+    var iou : f32 = 0.0;
+    if (u > 0.0) { iou = inter / u; }
+
+    let acx = (ax1 + ax2) * 0.5; let acy = (ay1 + ay2) * 0.5;
+    let bcx = (bx1 + bx2) * 0.5; let bcy = (by1 + by2) * 0.5;
+    let dx = acx - bcx; let dy = acy - bcy;
+    let centreSq = dx * dx + dy * dy;
+    let ex1 = min(ax1, bx1); let ey1 = min(ay1, by1);
+    let ex2 = max(ax2, bx2); let ey2 = max(ay2, by2);
+    let ew = ex2 - ex1; let eh = ey2 - ey1;
+    let diagSq = ew * ew + eh * eh;
+    if (diagSq > 0.0) { o[gid] = iou - centreSq / diagSq; } else { o[gid] = iou; }
+}
+";
+
+    public static string CompleteBoxIou => @"
+@group(0) @binding(0) var<storage, read> a : array<f32>;
+@group(0) @binding(1) var<storage, read> b : array<f32>;
+@group(0) @binding(2) var<storage, read_write> o : array<f32>;
+struct P { n: i32, m: i32 };
+@group(0) @binding(3) var<uniform> p : P;
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) id : vec3<u32>) {
+    let gid = i32(id.x);
+    let total = p.n * p.m;
+    if (gid >= total) { return; }
+    let i = gid / p.m;
+    let j = gid % p.m;
+    let ax1 = a[i * 4]; let ay1 = a[i * 4 + 1]; let ax2 = a[i * 4 + 2]; let ay2 = a[i * 4 + 3];
+    let bx1 = b[j * 4]; let by1 = b[j * 4 + 1]; let bx2 = b[j * 4 + 2]; let by2 = b[j * 4 + 3];
+
+    let aw = ax2 - ax1; let ah = ay2 - ay1;
+    let bw = bx2 - bx1; let bh = by2 - by1;
+    let areaA = max(aw, 0.0) * max(ah, 0.0);
+    let areaB = max(bw, 0.0) * max(bh, 0.0);
+    let ix1 = max(ax1, bx1); let iy1 = max(ay1, by1);
+    let ix2 = min(ax2, bx2); let iy2 = min(ay2, by2);
+    let inter = max(ix2 - ix1, 0.0) * max(iy2 - iy1, 0.0);
+    let u = areaA + areaB - inter;
+    var iou : f32 = 0.0;
+    if (u > 0.0) { iou = inter / u; }
+
+    let acx = (ax1 + ax2) * 0.5; let acy = (ay1 + ay2) * 0.5;
+    let bcx = (bx1 + bx2) * 0.5; let bcy = (by1 + by2) * 0.5;
+    let dx = acx - bcx; let dy = acy - bcy;
+    let centreSq = dx * dx + dy * dy;
+    let ex1 = min(ax1, bx1); let ey1 = min(ay1, by1);
+    let ex2 = max(ax2, bx2); let ey2 = max(ay2, by2);
+    let ew = ex2 - ex1; let eh = ey2 - ey1;
+    let diagSq = ew * ew + eh * eh;
+    var diou : f32 = iou;
+    if (diagSq > 0.0) { diou = iou - centreSq / diagSq; }
+
+    var v : f32 = 0.0;
+    var alpha : f32 = 0.0;
+    if (ah > 0.0 && bh > 0.0) {
+        let aspectA = atan(aw / ah);
+        let aspectB = atan(bw / bh);
+        let diff = aspectA - aspectB;
+        let PI = 3.14159265358979323846;
+        let invPiSq = 4.0 / (PI * PI);
+        v = invPiSq * diff * diff;
+        let denom = (1.0 - iou) + v;
+        if (denom > 0.0) { alpha = v / denom; }
+    }
+    o[gid] = diou - alpha * v;
+}
+";
+
+    // -----------------------------------------------------------------------
+    // Per-box ops — 2 SSBO bindings (boxes, output).
+    // -----------------------------------------------------------------------
+
+    public static string BoxArea => @"
+@group(0) @binding(0) var<storage, read> boxes : array<f32>;
+@group(0) @binding(1) var<storage, read_write> o : array<f32>;
+struct P { n: i32 };
+@group(0) @binding(2) var<uniform> p : P;
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) id : vec3<u32>) {
+    let gid = i32(id.x);
+    if (gid >= p.n) { return; }
+    let w = max(boxes[gid * 4 + 2] - boxes[gid * 4], 0.0);
+    let h = max(boxes[gid * 4 + 3] - boxes[gid * 4 + 1], 0.0);
+    o[gid] = w * h;
+}
+";
+
+    public static string BoxConvert => @"
+@group(0) @binding(0) var<storage, read> boxes : array<f32>;
+@group(0) @binding(1) var<storage, read_write> o : array<f32>;
+struct P { n: i32, fromFormat: i32, toFormat: i32 };
+@group(0) @binding(2) var<uniform> p : P;
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) id : vec3<u32>) {
+    let gid = i32(id.x);
+    if (gid >= p.n) { return; }
+    let oi = gid * 4;
+    let v0 = boxes[oi]; let v1 = boxes[oi + 1]; let v2 = boxes[oi + 2]; let v3 = boxes[oi + 3];
+
+    var x1 : f32; var y1 : f32; var x2 : f32; var y2 : f32;
+    if (p.fromFormat == 0) { x1 = v0; y1 = v1; x2 = v2; y2 = v3; }
+    else if (p.fromFormat == 1) { x1 = v0; y1 = v1; x2 = v0 + v2; y2 = v1 + v3; }
+    else { let hw = v2 * 0.5; let hh = v3 * 0.5;
+           x1 = v0 - hw; y1 = v1 - hh; x2 = v0 + hw; y2 = v1 + hh; }
+
+    if (p.toFormat == 0) { o[oi] = x1; o[oi + 1] = y1; o[oi + 2] = x2; o[oi + 3] = y2; }
+    else if (p.toFormat == 1) {
+        o[oi] = x1; o[oi + 1] = y1;
+        o[oi + 2] = x2 - x1; o[oi + 3] = y2 - y1;
+    } else {
+        let w = x2 - x1; let h = y2 - y1;
+        o[oi] = x1 + w * 0.5; o[oi + 1] = y1 + h * 0.5;
+        o[oi + 2] = w; o[oi + 3] = h;
+    }
+}
+";
+
+    // -----------------------------------------------------------------------
+    // IoU family backward — Issue #217. Atomics-free two-kernel split:
+    // *_backward_a owns rows of N, *_backward_b owns rows of M. WebGPU
+    // lacks atomic<f32> so this design is mandatory (not an optimisation).
+    // -----------------------------------------------------------------------
+
+    private const string BackwardCellFn = @"
+const DETECTION_INV_PI_SQ : f32 = 0.40528473456935109;  // 4 / pi^2
+
+fn compute_cell_grads_iou(
+    ax1: f32, ay1: f32, ax2: f32, ay2: f32,
+    bx1: f32, by1: f32, bx2: f32, by2: f32,
+    g: f32, variant: i32,
+    gA: ptr<function, vec4<f32>>, gB: ptr<function, vec4<f32>>)
+{
+    *gA = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+    *gB = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+    if (g == 0.0) { return; }
+
+    let awRaw = ax2 - ax1; let ahRaw = ay2 - ay1;
+    let bwRaw = bx2 - bx1; let bhRaw = by2 - by1;
+    let aw = max(awRaw, 0.0); let ah = max(ahRaw, 0.0);
+    let bw = max(bwRaw, 0.0); let bh = max(bhRaw, 0.0);
+    let areaA = aw * ah; let areaB = bw * bh;
+
+    let ix1 = max(ax1, bx1); let ix2 = min(ax2, bx2);
+    let iy1 = max(ay1, by1); let iy2 = min(ay2, by2);
+    let iwRaw = ix2 - ix1; let ihRaw = iy2 - iy1;
+    let iw = max(iwRaw, 0.0); let ih = max(ihRaw, 0.0);
+    let inter = iw * ih;
+    let u = areaA + areaB - inter;
+    var iou : f32 = 0.0;
+    if (u > 0.0) { iou = inter / u; }
+
+    var gInter : f32 = 0.0;
+    var gAreaA : f32 = 0.0;
+    var gAreaB : f32 = 0.0;
+
+    if (variant == 1) {
+        let ex1 = min(ax1, bx1); let ex2 = max(ax2, bx2);
+        let ey1 = min(ay1, by1); let ey2 = max(ay2, by2);
+        let ewRaw = ex2 - ex1; let ehRaw = ey2 - ey1;
+        let ew = max(ewRaw, 0.0); let eh = max(ehRaw, 0.0);
+        let enclose = ew * eh;
+        if (enclose > 0.0) {
+            let gUnion = g / enclose;
+            let gEnclose = g * (-u / (enclose * enclose));
+            gAreaA = gAreaA + gUnion;
+            gAreaB = gAreaB + gUnion;
+            gInter = gInter - gUnion;
+            let gEw = gEnclose * eh; let gEh = gEnclose * ew;
+            var gEwRaw : f32 = 0.0;
+            var gEhRaw : f32 = 0.0;
+            if (ewRaw > 0.0) { gEwRaw = gEw; }
+            if (ehRaw > 0.0) { gEhRaw = gEh; }
+            let gEx1 = -gEwRaw; let gEx2 = gEwRaw;
+            let gEy1 = -gEhRaw; let gEy2 = gEhRaw;
+            if (ax1 <= bx1) { (*gA).x = (*gA).x + gEx1; } else { (*gB).x = (*gB).x + gEx1; }
+            if (ay1 <= by1) { (*gA).y = (*gA).y + gEy1; } else { (*gB).y = (*gB).y + gEy1; }
+            if (ax2 >= bx2) { (*gA).z = (*gA).z + gEx2; } else { (*gB).z = (*gB).z + gEx2; }
+            if (ay2 >= by2) { (*gA).w = (*gA).w + gEy2; } else { (*gB).w = (*gB).w + gEy2; }
+        }
+    } else if (variant == 2 || variant == 3) {
+        let acx = (ax1 + ax2) * 0.5; let acy = (ay1 + ay2) * 0.5;
+        let bcx = (bx1 + bx2) * 0.5; let bcy = (by1 + by2) * 0.5;
+        let dcx = acx - bcx; let dcy = acy - bcy;
+        let centreSq = dcx * dcx + dcy * dcy;
+        let ex1 = min(ax1, bx1); let ex2 = max(ax2, bx2);
+        let ey1 = min(ay1, by1); let ey2 = max(ay2, by2);
+        let ew = ex2 - ex1; let eh = ey2 - ey1;
+        let diagSq = ew * ew + eh * eh;
+
+        var gCentreSq : f32 = 0.0;
+        var gDiagSq : f32 = 0.0;
+        if (diagSq > 0.0) {
+            gCentreSq = g * (-1.0 / diagSq);
+            gDiagSq = g * centreSq / (diagSq * diagSq);
+        }
+
+        if (variant == 3 && ah > 0.0 && bh > 0.0) {
+            let aspectA = atan(aw / ah);
+            let aspectB = atan(bw / bh);
+            let diff = aspectA - aspectB;
+            let v = DETECTION_INV_PI_SQ * diff * diff;
+            let denom = (1.0 - iou) + v;
+            var alpha : f32 = 0.0;
+            if (denom > 0.0) { alpha = v / denom; }
+            let gV = g * (-alpha);
+            let gDiff = gV * 2.0 * DETECTION_INV_PI_SQ * diff;
+            let gAspectA = gDiff; let gAspectB = -gDiff;
+            let aDen = aw * aw + ah * ah;
+            let bDen = bw * bw + bh * bh;
+            if (aDen > 0.0) {
+                let gAw = gAspectA * (ah / aDen);
+                let gAh = gAspectA * (-aw / aDen);
+                if (awRaw > 0.0) { (*gA).z = (*gA).z + gAw; (*gA).x = (*gA).x - gAw; }
+                if (ahRaw > 0.0) { (*gA).w = (*gA).w + gAh; (*gA).y = (*gA).y - gAh; }
+            }
+            if (bDen > 0.0) {
+                let gBw = gAspectB * (bh / bDen);
+                let gBh = gAspectB * (-bw / bDen);
+                if (bwRaw > 0.0) { (*gB).z = (*gB).z + gBw; (*gB).x = (*gB).x - gBw; }
+                if (bhRaw > 0.0) { (*gB).w = (*gB).w + gBh; (*gB).y = (*gB).y - gBh; }
+            }
+        }
+
+        let gAcx = gCentreSq * 2.0 * dcx;
+        let gAcy = gCentreSq * 2.0 * dcy;
+        (*gA).x = (*gA).x + gAcx * 0.5; (*gA).z = (*gA).z + gAcx * 0.5;
+        (*gA).y = (*gA).y + gAcy * 0.5; (*gA).w = (*gA).w + gAcy * 0.5;
+        (*gB).x = (*gB).x - gAcx * 0.5; (*gB).z = (*gB).z - gAcx * 0.5;
+        (*gB).y = (*gB).y - gAcy * 0.5; (*gB).w = (*gB).w - gAcy * 0.5;
+
+        let gEw = gDiagSq * 2.0 * ew;
+        let gEh = gDiagSq * 2.0 * eh;
+        let gEx1 = -gEw; let gEx2 = gEw;
+        let gEy1 = -gEh; let gEy2 = gEh;
+        if (ax1 <= bx1) { (*gA).x = (*gA).x + gEx1; } else { (*gB).x = (*gB).x + gEx1; }
+        if (ay1 <= by1) { (*gA).y = (*gA).y + gEy1; } else { (*gB).y = (*gB).y + gEy1; }
+        if (ax2 >= bx2) { (*gA).z = (*gA).z + gEx2; } else { (*gB).z = (*gB).z + gEx2; }
+        if (ay2 >= by2) { (*gA).w = (*gA).w + gEy2; } else { (*gB).w = (*gB).w + gEy2; }
+    }
+
+    if (u > 0.0) {
+        let uSq = u * u;
+        gInter = gInter + g * (u + inter) / uSq;
+        gAreaA = gAreaA + g * (-inter) / uSq;
+        gAreaB = gAreaB + g * (-inter) / uSq;
+    }
+
+    let gIw = gInter * ih; let gIh = gInter * iw;
+    var gIwRaw : f32 = 0.0;
+    var gIhRaw : f32 = 0.0;
+    if (iwRaw > 0.0) { gIwRaw = gIw; }
+    if (ihRaw > 0.0) { gIhRaw = gIh; }
+    let gIx2 = gIwRaw; let gIx1 = -gIwRaw;
+    let gIy2 = gIhRaw; let gIy1 = -gIhRaw;
+    if (ax1 >= bx1) { (*gA).x = (*gA).x + gIx1; } else { (*gB).x = (*gB).x + gIx1; }
+    if (ay1 >= by1) { (*gA).y = (*gA).y + gIy1; } else { (*gB).y = (*gB).y + gIy1; }
+    if (ax2 <= bx2) { (*gA).z = (*gA).z + gIx2; } else { (*gB).z = (*gB).z + gIx2; }
+    if (ay2 <= by2) { (*gA).w = (*gA).w + gIy2; } else { (*gB).w = (*gB).w + gIy2; }
+
+    let gAw2 = gAreaA * ah; let gAh2 = gAreaA * aw;
+    let gBw2 = gAreaB * bh; let gBh2 = gAreaB * bw;
+    if (awRaw > 0.0) { (*gA).z = (*gA).z + gAw2; (*gA).x = (*gA).x - gAw2; }
+    if (ahRaw > 0.0) { (*gA).w = (*gA).w + gAh2; (*gA).y = (*gA).y - gAh2; }
+    if (bwRaw > 0.0) { (*gB).z = (*gB).z + gBw2; (*gB).x = (*gB).x - gBw2; }
+    if (bhRaw > 0.0) { (*gB).w = (*gB).w + gBh2; (*gB).y = (*gB).y - gBh2; }
+}
+";
+
+    public static string IouBackwardA => @"
+@group(0) @binding(0) var<storage, read> gradOutput : array<f32>;
+@group(0) @binding(1) var<storage, read> a : array<f32>;
+@group(0) @binding(2) var<storage, read> b : array<f32>;
+@group(0) @binding(3) var<storage, read_write> gradA : array<f32>;
+struct P { n: i32, m: i32, variant: i32 };
+@group(0) @binding(4) var<uniform> p : P;
+" + BackwardCellFn + @"
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) id : vec3<u32>) {
+    let i = i32(id.x);
+    if (i >= p.n) { return; }
+    let ax1 = a[i * 4]; let ay1 = a[i * 4 + 1]; let ax2 = a[i * 4 + 2]; let ay2 = a[i * 4 + 3];
+    var sum : vec4<f32> = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+    for (var j : i32 = 0; j < p.m; j = j + 1) {
+        let bx1 = b[j * 4]; let by1 = b[j * 4 + 1]; let bx2 = b[j * 4 + 2]; let by2 = b[j * 4 + 3];
+        let g = gradOutput[i * p.m + j];
+        var gA : vec4<f32>; var gB : vec4<f32>;
+        compute_cell_grads_iou(ax1, ay1, ax2, ay2, bx1, by1, bx2, by2, g, p.variant, &gA, &gB);
+        sum = sum + gA;
+    }
+    gradA[i * 4]     = sum.x;
+    gradA[i * 4 + 1] = sum.y;
+    gradA[i * 4 + 2] = sum.z;
+    gradA[i * 4 + 3] = sum.w;
+}
+";
+
+    public static string IouBackwardB => @"
+@group(0) @binding(0) var<storage, read> gradOutput : array<f32>;
+@group(0) @binding(1) var<storage, read> a : array<f32>;
+@group(0) @binding(2) var<storage, read> b : array<f32>;
+@group(0) @binding(3) var<storage, read_write> gradB : array<f32>;
+struct P { n: i32, m: i32, variant: i32 };
+@group(0) @binding(4) var<uniform> p : P;
+" + BackwardCellFn + @"
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) id : vec3<u32>) {
+    let j = i32(id.x);
+    if (j >= p.m) { return; }
+    let bx1 = b[j * 4]; let by1 = b[j * 4 + 1]; let bx2 = b[j * 4 + 2]; let by2 = b[j * 4 + 3];
+    var sum : vec4<f32> = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+    for (var i : i32 = 0; i < p.n; i = i + 1) {
+        let ax1 = a[i * 4]; let ay1 = a[i * 4 + 1]; let ax2 = a[i * 4 + 2]; let ay2 = a[i * 4 + 3];
+        let g = gradOutput[i * p.m + j];
+        var gA : vec4<f32>; var gB : vec4<f32>;
+        compute_cell_grads_iou(ax1, ay1, ax2, ay2, bx1, by1, bx2, by2, g, p.variant, &gA, &gB);
+        sum = sum + gB;
+    }
+    gradB[j * 4]     = sum.x;
+    gradB[j * 4 + 1] = sum.y;
+    gradB[j * 4 + 2] = sum.z;
+    gradB[j * 4 + 3] = sum.w;
+}
+";
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuGeometryKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuGeometryKernels.cs
@@ -1,0 +1,314 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// WebGPU WGSL compute shaders for the geometry / sampling ops added by
+// Issue #217. Mirrors the CUDA / OpenCL / Metal / Vulkan kernels.
+
+#if NET7_0_OR_GREATER
+namespace AiDotNet.Tensors.Engines.DirectGpu.WebGpu;
+
+public static class WebGpuGeometryKernels
+{
+    public static string[] GetKernelNames() => new[]
+    {
+        "geometry_interpolate_2d",
+        "geometry_pad_4d",
+        "geometry_grid_sample_2d",
+        "geometry_affine_grid_3d",
+    };
+
+    private const string Helpers = @"
+fn source_coord(dstIdx: i32, dstSize: i32, srcSize: i32, alignCorners: i32) -> f32 {
+    if (dstSize <= 1) { return 0.0; }
+    if (alignCorners != 0) { return f32(dstIdx) * f32(srcSize - 1) / f32(dstSize - 1); }
+    return (f32(dstIdx) + 0.5) * f32(srcSize) / f32(dstSize) - 0.5;
+}
+
+fn cubic_kernel_f(d: f32, a: f32) -> f32 {
+    let ad = abs(d);
+    if (ad < 1.0) { return ((a + 2.0) * ad - (a + 3.0)) * ad * ad + 1.0; }
+    if (ad < 2.0) { return a * ((ad - 5.0) * ad + 8.0) * ad - 4.0 * a; }
+    return 0.0;
+}
+
+fn clamp_i(v: i32, lo: i32, hi: i32) -> i32 {
+    if (v < lo) { return lo; }
+    if (v > hi) { return hi; }
+    return v;
+}
+
+fn reflect_index(i: i32, extent: i32) -> i32 {
+    if (extent == 1) { return 0; }
+    let period = 2 * (extent - 1);
+    let r = ((i % period) + period) % period;
+    if (r < extent) { return r; }
+    return period - r;
+}
+
+fn pad_boundary(idx: i32, extent: i32, mode: i32) -> i32 {
+    if (mode == 2) {
+        if (idx < 0) { return 0; }
+        if (idx >= extent) { return extent - 1; }
+        return idx;
+    }
+    if (mode == 1) { return reflect_index(idx, extent); }
+    let r = ((idx % extent) + extent) % extent;
+    return r;
+}
+";
+
+    // -----------------------------------------------------------------------
+    // Interpolate 2D.
+    // -----------------------------------------------------------------------
+
+    public static string Interpolate2D => @"
+@group(0) @binding(0) var<storage, read> input_ : array<f32>;
+@group(0) @binding(1) var<storage, read_write> output_ : array<f32>;
+struct P {
+    N: i32, C: i32, Hin: i32, Win: i32,
+    Hout: i32, Wout: i32, mode: i32, alignCorners: i32
+};
+@group(0) @binding(2) var<uniform> p : P;
+" + Helpers + @"
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) id : vec3<u32>) {
+    let gid = i32(id.x);
+    let total = p.N * p.C * p.Hout * p.Wout;
+    if (gid >= total) { return; }
+    let x = gid % p.Wout; let t1 = gid / p.Wout;
+    let y = t1 % p.Hout; let t2 = t1 / p.Hout;
+    let c = t2 % p.C; let n = t2 / p.C;
+    let srcBase = ((n * p.C + c) * p.Hin) * p.Win;
+
+    if (p.mode == 0) {
+        var sy : f32 = 0.0; var sx : f32 = 0.0;
+        if (p.Hout > 1) { sy = f32(y) * f32(p.Hin) / f32(p.Hout); }
+        if (p.Wout > 1) { sx = f32(x) * f32(p.Win) / f32(p.Wout); }
+        var yi = i32(floor(sy)); if (yi >= p.Hin) { yi = p.Hin - 1; }
+        var xi = i32(floor(sx)); if (xi >= p.Win) { xi = p.Win - 1; }
+        output_[gid] = input_[srcBase + yi * p.Win + xi];
+    } else if (p.mode == 2) {
+        let sy = source_coord(y, p.Hout, p.Hin, p.alignCorners);
+        let sx = source_coord(x, p.Wout, p.Win, p.alignCorners);
+        var y0 = i32(floor(sy)); var x0 = i32(floor(sx));
+        if (y0 < 0) { y0 = 0; } if (x0 < 0) { x0 = 0; }
+        var y1 = y0 + 1; var x1 = x0 + 1;
+        if (y1 >= p.Hin) { y1 = p.Hin - 1; if (y0 > y1) { y0 = y1; } }
+        if (x1 >= p.Win) { x1 = p.Win - 1; if (x0 > x1) { x0 = x1; } }
+        var fy = sy - f32(y0); if (fy < 0.0) { fy = 0.0; } if (fy > 1.0) { fy = 1.0; }
+        var fx = sx - f32(x0); if (fx < 0.0) { fx = 0.0; } if (fx > 1.0) { fx = 1.0; }
+        let v00 = input_[srcBase + y0 * p.Win + x0];
+        let v01 = input_[srcBase + y0 * p.Win + x1];
+        let v10 = input_[srcBase + y1 * p.Win + x0];
+        let v11 = input_[srcBase + y1 * p.Win + x1];
+        output_[gid] = v00 * (1.0 - fx) * (1.0 - fy) + v01 * fx * (1.0 - fy)
+                     + v10 * (1.0 - fx) * fy + v11 * fx * fy;
+    } else if (p.mode == 3) {
+        let sy = source_coord(y, p.Hout, p.Hin, p.alignCorners);
+        let sx = source_coord(x, p.Wout, p.Win, p.alignCorners);
+        let y0 = i32(floor(sy)); let ty = sy - f32(y0);
+        let x0 = i32(floor(sx)); let tx = sx - f32(x0);
+        var wy : array<f32, 4>;
+        wy[0] = cubic_kernel_f(1.0 + ty, -0.75); wy[1] = cubic_kernel_f(ty, -0.75);
+        wy[2] = cubic_kernel_f(1.0 - ty, -0.75); wy[3] = cubic_kernel_f(2.0 - ty, -0.75);
+        var wx : array<f32, 4>;
+        wx[0] = cubic_kernel_f(1.0 + tx, -0.75); wx[1] = cubic_kernel_f(tx, -0.75);
+        wx[2] = cubic_kernel_f(1.0 - tx, -0.75); wx[3] = cubic_kernel_f(2.0 - tx, -0.75);
+        var acc : f32 = 0.0;
+        for (var yy : i32 = 0; yy < 4; yy = yy + 1) {
+            let yi = clamp_i(y0 - 1 + yy, 0, p.Hin - 1);
+            var rowAcc : f32 = 0.0;
+            for (var xx : i32 = 0; xx < 4; xx = xx + 1) {
+                let xi = clamp_i(x0 - 1 + xx, 0, p.Win - 1);
+                rowAcc = rowAcc + wx[xx] * input_[srcBase + yi * p.Win + xi];
+            }
+            acc = acc + wy[yy] * rowAcc;
+        }
+        output_[gid] = acc;
+    } else {
+        let yLo = f32(y) * f32(p.Hin) / f32(p.Hout);
+        let yHi = f32(y + 1) * f32(p.Hin) / f32(p.Hout);
+        let xLo = f32(x) * f32(p.Win) / f32(p.Wout);
+        let xHi = f32(x + 1) * f32(p.Win) / f32(p.Wout);
+        var yL = i32(floor(yLo)); var yH = i32(ceil(yHi));
+        var xL = i32(floor(xLo)); var xH = i32(ceil(xHi));
+        if (yH <= yL) { yH = yL + 1; }
+        if (xH <= xL) { xH = xL + 1; }
+        if (yH > p.Hin) { yH = p.Hin; }
+        if (xH > p.Win) { xH = p.Win; }
+        var acc : f32 = 0.0;
+        var count : i32 = 0;
+        for (var yy : i32 = yL; yy < yH; yy = yy + 1) {
+            for (var xx : i32 = xL; xx < xH; xx = xx + 1) {
+                acc = acc + input_[srcBase + yy * p.Win + xx];
+                count = count + 1;
+            }
+        }
+        if (count > 0) { output_[gid] = acc / f32(count); } else { output_[gid] = 0.0; }
+    }
+}
+";
+
+    // -----------------------------------------------------------------------
+    // Pad 4D.
+    // -----------------------------------------------------------------------
+
+    public static string Pad4D => @"
+@group(0) @binding(0) var<storage, read> input_ : array<f32>;
+@group(0) @binding(1) var<storage, read_write> output_ : array<f32>;
+struct P {
+    N: i32, C: i32, Hin: i32, Win: i32,
+    padN0: i32, padN1: i32, padC0: i32, padC1: i32,
+    padH0: i32, padH1: i32, padW0: i32, padW1: i32,
+    mode: i32, padValue: f32,
+};
+@group(0) @binding(2) var<uniform> p : P;
+" + Helpers + @"
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) id : vec3<u32>) {
+    let Nout = p.N + p.padN0 + p.padN1;
+    let Cout = p.C + p.padC0 + p.padC1;
+    let Hout = p.Hin + p.padH0 + p.padH1;
+    let Wout = p.Win + p.padW0 + p.padW1;
+    let total = Nout * Cout * Hout * Wout;
+    let gid = i32(id.x);
+    if (gid >= total) { return; }
+    let w = gid % Wout; let t1 = gid / Wout;
+    let h = t1 % Hout; let t2 = t1 / Hout;
+    let c = t2 % Cout; let n = t2 / Cout;
+    var nn = n - p.padN0; var cc = c - p.padC0;
+    var hh = h - p.padH0; var ww = w - p.padW0;
+    let inB = nn >= 0 && nn < p.N && cc >= 0 && cc < p.C && hh >= 0 && hh < p.Hin && ww >= 0 && ww < p.Win;
+    if (!inB && p.mode == 0) { output_[gid] = p.padValue; return; }
+    if (!inB) {
+        if (!(nn >= 0 && nn < p.N)) { nn = pad_boundary(nn, p.N, p.mode); }
+        if (!(cc >= 0 && cc < p.C)) { cc = pad_boundary(cc, p.C, p.mode); }
+        if (!(hh >= 0 && hh < p.Hin)) { hh = pad_boundary(hh, p.Hin, p.mode); }
+        if (!(ww >= 0 && ww < p.Win)) { ww = pad_boundary(ww, p.Win, p.mode); }
+    }
+    output_[gid] = input_[((nn * p.C + cc) * p.Hin + hh) * p.Win + ww];
+}
+";
+
+    // -----------------------------------------------------------------------
+    // GridSample 2D NHWC — 3 SSBO.
+    // -----------------------------------------------------------------------
+
+    public static string GridSample2D => @"
+@group(0) @binding(0) var<storage, read> input_ : array<f32>;
+@group(0) @binding(1) var<storage, read> grid_ : array<f32>;
+@group(0) @binding(2) var<storage, read_write> output_ : array<f32>;
+struct P {
+    N: i32, H: i32, W: i32, C: i32,
+    outH: i32, outW: i32, mode: i32, padding: i32, alignCorners: i32,
+};
+@group(0) @binding(3) var<uniform> p : P;
+" + Helpers + @"
+fn sample_safe(n: i32, y_in: i32, x_in: i32, c: i32) -> f32 {
+    var y = y_in; var x = x_in;
+    if (p.padding == 0) {
+        if (u32(y) >= u32(p.H) || u32(x) >= u32(p.W)) { return 0.0; }
+    } else if (p.padding == 1) {
+        y = clamp_i(y, 0, p.H - 1); x = clamp_i(x, 0, p.W - 1);
+    } else {
+        y = reflect_index(y, p.H); x = reflect_index(x, p.W);
+    }
+    return input_[((n * p.H + y) * p.W + x) * p.C + c];
+}
+
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) id : vec3<u32>) {
+    let gid = i32(id.x);
+    let total = p.N * p.outH * p.outW;
+    if (gid >= total) { return; }
+    let ox = gid % p.outW; let t1 = gid / p.outW;
+    let oy = t1 % p.outH; let n = t1 / p.outH;
+    let gOff = ((n * p.outH + oy) * p.outW + ox) * 2;
+    let gx = grid_[gOff];
+    let gy = grid_[gOff + 1];
+    var sx : f32; var sy : f32;
+    if (p.alignCorners != 0) {
+        sx = (gx + 1.0) * 0.5 * f32(p.W - 1);
+        sy = (gy + 1.0) * 0.5 * f32(p.H - 1);
+    } else {
+        sx = ((gx + 1.0) * f32(p.W) - 1.0) * 0.5;
+        sy = ((gy + 1.0) * f32(p.H) - 1.0) * 0.5;
+    }
+
+    if (p.mode == 1) {
+        let nx = i32(round(sx)); let ny = i32(round(sy));
+        for (var c : i32 = 0; c < p.C; c = c + 1) {
+            output_[((n * p.outH + oy) * p.outW + ox) * p.C + c] = sample_safe(n, ny, nx, c);
+        }
+    } else if (p.mode == 0) {
+        let x0 = i32(floor(sx)); let y0 = i32(floor(sy));
+        let x1 = x0 + 1; let y1 = y0 + 1;
+        let fx = sx - f32(x0); let fy = sy - f32(y0);
+        for (var c : i32 = 0; c < p.C; c = c + 1) {
+            let v00 = sample_safe(n, y0, x0, c);
+            let v01 = sample_safe(n, y0, x1, c);
+            let v10 = sample_safe(n, y1, x0, c);
+            let v11 = sample_safe(n, y1, x1, c);
+            output_[((n * p.outH + oy) * p.outW + ox) * p.C + c] =
+                v00 * (1.0 - fx) * (1.0 - fy) + v01 * fx * (1.0 - fy)
+              + v10 * (1.0 - fx) * fy + v11 * fx * fy;
+        }
+    } else {
+        let x0 = i32(floor(sx)); let y0 = i32(floor(sy));
+        let fx = sx - f32(x0); let fy = sy - f32(y0);
+        var wy : array<f32, 4>;
+        wy[0] = cubic_kernel_f(1.0 + fy, -0.75); wy[1] = cubic_kernel_f(fy, -0.75);
+        wy[2] = cubic_kernel_f(1.0 - fy, -0.75); wy[3] = cubic_kernel_f(2.0 - fy, -0.75);
+        var wx : array<f32, 4>;
+        wx[0] = cubic_kernel_f(1.0 + fx, -0.75); wx[1] = cubic_kernel_f(fx, -0.75);
+        wx[2] = cubic_kernel_f(1.0 - fx, -0.75); wx[3] = cubic_kernel_f(2.0 - fx, -0.75);
+        for (var c : i32 = 0; c < p.C; c = c + 1) {
+            var acc : f32 = 0.0;
+            for (var yy : i32 = 0; yy < 4; yy = yy + 1) {
+                let yi = y0 - 1 + yy;
+                var rowAcc : f32 = 0.0;
+                for (var xx : i32 = 0; xx < 4; xx = xx + 1) {
+                    let xi = x0 - 1 + xx;
+                    rowAcc = rowAcc + wx[xx] * sample_safe(n, yi, xi, c);
+                }
+                acc = acc + wy[yy] * rowAcc;
+            }
+            output_[((n * p.outH + oy) * p.outW + ox) * p.C + c] = acc;
+        }
+    }
+}
+";
+
+    // -----------------------------------------------------------------------
+    // AffineGrid 3D.
+    // -----------------------------------------------------------------------
+
+    public static string AffineGrid3D => @"
+@group(0) @binding(0) var<storage, read> theta : array<f32>;
+@group(0) @binding(1) var<storage, read_write> grid_ : array<f32>;
+struct P { N: i32, D: i32, H: i32, W: i32, alignCorners: i32 };
+@group(0) @binding(2) var<uniform> p : P;
+
+fn grid_norm_coord_f(idx: i32, size: i32) -> f32 {
+    if (size <= 1) { return 0.0; }
+    if (p.alignCorners != 0) { return -1.0 + 2.0 * f32(idx) / f32(size - 1); }
+    return -1.0 + (2.0 * f32(idx) + 1.0) / f32(size);
+}
+
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) id : vec3<u32>) {
+    let gid = i32(id.x);
+    let total = p.N * p.D * p.H * p.W;
+    if (gid >= total) { return; }
+    let w = gid % p.W; let t1 = gid / p.W;
+    let h = t1 % p.H; let t2 = t1 / p.H;
+    let d = t2 % p.D; let n = t2 / p.D;
+    let tBase = n * 12;
+    let x = grid_norm_coord_f(w, p.W);
+    let y = grid_norm_coord_f(h, p.H);
+    let z = grid_norm_coord_f(d, p.D);
+    let gBase = (((n * p.D + d) * p.H + h) * p.W + w) * 3;
+    for (var row : i32 = 0; row < 3; row = row + 1) {
+        grid_[gBase + row] = theta[tBase + row * 4] * x
+                           + theta[tBase + row * 4 + 1] * y
+                           + theta[tBase + row * 4 + 2] * z
+                           + theta[tBase + row * 4 + 3];
+    }
+}
+";
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuGeometryKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuGeometryKernels.cs
@@ -44,6 +44,7 @@ fn reflect_index(i: i32, extent: i32) -> i32 {
 }
 
 fn pad_boundary(idx: i32, extent: i32, mode: i32) -> i32 {
+    if (extent <= 0) { return 0; }
     if (mode == 2) {
         if (idx < 0) { return 0; }
         if (idx >= extent) { return extent - 1; }
@@ -122,7 +123,7 @@ struct P {
             acc = acc + wy[yy] * rowAcc;
         }
         output_[gid] = acc;
-    } else {
+    } else {  // Area — overlap-weighted averaging
         let yLo = f32(y) * f32(p.Hin) / f32(p.Hout);
         let yHi = f32(y + 1) * f32(p.Hin) / f32(p.Hout);
         let xLo = f32(x) * f32(p.Win) / f32(p.Wout);
@@ -133,15 +134,18 @@ struct P {
         if (xH <= xL) { xH = xL + 1; }
         if (yH > p.Hin) { yH = p.Hin; }
         if (xH > p.Win) { xH = p.Win; }
+        let totalArea = (yHi - yLo) * (xHi - xLo);
         var acc : f32 = 0.0;
-        var count : i32 = 0;
         for (var yy : i32 = yL; yy < yH; yy = yy + 1) {
+            let oy = max(0.0, min(yHi, f32(yy + 1)) - max(yLo, f32(yy)));
+            if (oy <= 0.0) { continue; }
             for (var xx : i32 = xL; xx < xH; xx = xx + 1) {
-                acc = acc + input_[srcBase + yy * p.Win + xx];
-                count = count + 1;
+                let ox = max(0.0, min(xHi, f32(xx + 1)) - max(xLo, f32(xx)));
+                if (ox <= 0.0) { continue; }
+                acc = acc + oy * ox * input_[srcBase + yy * p.Win + xx];
             }
         }
-        if (count > 0) { output_[gid] = acc / f32(count); } else { output_[gid] = 0.0; }
+        if (totalArea > 0.0) { output_[gid] = acc / totalArea; } else { output_[gid] = 0.0; }
     }
 }
 ";

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuRoiKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuRoiKernels.cs
@@ -1,0 +1,120 @@
+#if NET7_0_OR_GREATER
+namespace AiDotNet.Tensors.Engines.DirectGpu.WebGpu;
+
+public static class WebGpuRoiKernels
+{
+    public static string[] GetKernelNames() => new[] { "roi_align", "roi_pool" };
+
+    public static string RoIAlign => @"
+@group(0) @binding(0) var<storage, read> input_ : array<f32>;
+@group(0) @binding(1) var<storage, read> boxes : array<f32>;
+@group(0) @binding(2) var<storage, read_write> output_ : array<f32>;
+struct P {
+    N: i32, C: i32, H: i32, W: i32, K: i32, outH: i32, outW: i32,
+    spatialScale: f32, samplingRatio: i32, aligned: i32
+};
+@group(0) @binding(3) var<uniform> p : P;
+
+fn bilinear_sample(planeBase: i32, y_in: f32, x_in: f32) -> f32 {
+    var y = y_in; var x = x_in;
+    if (y < -1.0 || y > f32(p.H) || x < -1.0 || x > f32(p.W)) { return 0.0; }
+    if (y <= 0.0) { y = 0.0; }
+    if (x <= 0.0) { x = 0.0; }
+    var y0 = i32(y);
+    var x0 = i32(x);
+    var y1 = select(y0 + 1, p.H - 1, y0 + 1 >= p.H);
+    var x1 = select(x0 + 1, p.W - 1, x0 + 1 >= p.W);
+    if (y0 >= p.H - 1) { y0 = p.H - 1; y1 = p.H - 1; y = f32(y0); }
+    if (x0 >= p.W - 1) { x0 = p.W - 1; x1 = p.W - 1; x = f32(x0); }
+    let ly = y - f32(y0); let lx = x - f32(x0);
+    let hy = 1.0 - ly; let hx = 1.0 - lx;
+    return hy * hx * input_[planeBase + y0 * p.W + x0]
+         + hy * lx * input_[planeBase + y0 * p.W + x1]
+         + ly * hx * input_[planeBase + y1 * p.W + x0]
+         + ly * lx * input_[planeBase + y1 * p.W + x1];
+}
+
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) id : vec3<u32>) {
+    let gid = i32(id.x);
+    let total = p.K * p.C * p.outH * p.outW;
+    if (gid >= total) { return; }
+    let pw = gid % p.outW; let t1 = gid / p.outW;
+    let ph = t1 % p.outH; let t2 = t1 / p.outH;
+    let c = t2 % p.C; let k = t2 / p.C;
+    let n = i32(boxes[k * 5]);
+    if (n < 0 || n >= p.N) { output_[gid] = 0.0; return; }
+    var offset : f32 = 0.0;
+    if (p.aligned != 0) { offset = 0.5; }
+    let x1 = boxes[k * 5 + 1] * p.spatialScale - offset;
+    let y1 = boxes[k * 5 + 2] * p.spatialScale - offset;
+    let x2 = boxes[k * 5 + 3] * p.spatialScale - offset;
+    let y2 = boxes[k * 5 + 4] * p.spatialScale - offset;
+    var roiW = select(max(x2 - x1, 1.0), x2 - x1, p.aligned != 0);
+    var roiH = select(max(y2 - y1, 1.0), y2 - y1, p.aligned != 0);
+    let binH = roiH / f32(p.outH);
+    let binW = roiW / f32(p.outW);
+    var ry = select(i32(ceil(roiH / f32(p.outH))), p.samplingRatio, p.samplingRatio > 0);
+    var rx = select(i32(ceil(roiW / f32(p.outW))), p.samplingRatio, p.samplingRatio > 0);
+    if (ry < 1) { ry = 1; }
+    if (rx < 1) { rx = 1; }
+    let planeBase = (n * p.C + c) * p.H * p.W;
+    var acc : f32 = 0.0;
+    for (var iy : i32 = 0; iy < ry; iy = iy + 1) {
+        let sy = y1 + f32(ph) * binH + (f32(iy) + 0.5) * binH / f32(ry);
+        for (var ix : i32 = 0; ix < rx; ix = ix + 1) {
+            let sx = x1 + f32(pw) * binW + (f32(ix) + 0.5) * binW / f32(rx);
+            acc = acc + bilinear_sample(planeBase, sy, sx);
+        }
+    }
+    output_[gid] = acc / f32(ry * rx);
+}
+";
+
+    public static string RoIPool => @"
+@group(0) @binding(0) var<storage, read> input_ : array<f32>;
+@group(0) @binding(1) var<storage, read> boxes : array<f32>;
+@group(0) @binding(2) var<storage, read_write> output_ : array<f32>;
+struct P {
+    N: i32, C: i32, H: i32, W: i32, K: i32, outH: i32, outW: i32, spatialScale: f32
+};
+@group(0) @binding(3) var<uniform> p : P;
+
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) id : vec3<u32>) {
+    let gid = i32(id.x);
+    let total = p.K * p.C * p.outH * p.outW;
+    if (gid >= total) { return; }
+    let pw = gid % p.outW; let t1 = gid / p.outW;
+    let ph = t1 % p.outH; let t2 = t1 / p.outH;
+    let c = t2 % p.C; let k = t2 / p.C;
+    let n = i32(boxes[k * 5]);
+    if (n < 0 || n >= p.N) { output_[gid] = 0.0; return; }
+    let x1 = i32(round(boxes[k * 5 + 1] * p.spatialScale));
+    let y1 = i32(round(boxes[k * 5 + 2] * p.spatialScale));
+    let x2 = i32(round(boxes[k * 5 + 3] * p.spatialScale));
+    let y2 = i32(round(boxes[k * 5 + 4] * p.spatialScale));
+    var roiW = x2 - x1 + 1; if (roiW < 1) { roiW = 1; }
+    var roiH = y2 - y1 + 1; if (roiH < 1) { roiH = 1; }
+    let binH = f32(roiH) / f32(p.outH);
+    let binW = f32(roiW) / f32(p.outW);
+    var hstart = i32(floor(f32(ph) * binH)) + y1;
+    var hend = i32(ceil(f32(ph + 1) * binH)) + y1;
+    var wstart = i32(floor(f32(pw) * binW)) + x1;
+    var wend = i32(ceil(f32(pw + 1) * binW)) + x1;
+    if (hstart < 0) { hstart = 0; } if (hstart > p.H) { hstart = p.H; }
+    if (hend < 0) { hend = 0; } if (hend > p.H) { hend = p.H; }
+    if (wstart < 0) { wstart = 0; } if (wstart > p.W) { wstart = p.W; }
+    if (wend < 0) { wend = 0; } if (wend > p.W) { wend = p.W; }
+    let planeBase = (n * p.C + c) * p.H * p.W;
+    if (hend <= hstart || wend <= wstart) { output_[gid] = 0.0; return; }
+    var best : f32 = -3.4e38;
+    for (var yy : i32 = hstart; yy < hend; yy = yy + 1) {
+        for (var xx : i32 = wstart; xx < wend; xx = xx + 1) {
+            let v = input_[planeBase + yy * p.W + xx];
+            if (v > best) { best = v; }
+        }
+    }
+    output_[gid] = best;
+}
+";
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuRoiKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuRoiKernels.cs
@@ -109,7 +109,7 @@ struct P {
     if (wend < 0) { wend = 0; } if (wend > p.W) { wend = p.W; }
     let planeBase = (n * p.C + c) * p.H * p.W;
     if (hend <= hstart || wend <= wstart) { output_[gid] = 0.0; return; }
-    var best : f32 = -3.4e38;
+    var best : f32 = -3.402823466e+38;
     for (var yy : i32 = hstart; yy < hend; yy = yy + 1) {
         for (var xx : i32 = wstart; xx < wend; xx = xx + 1) {
             let v = input_[planeBase + yy * p.W + xx];

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuRoiKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuRoiKernels.cs
@@ -171,6 +171,7 @@ fn ps_bilinear_sample(planeBase: i32, y_in: f32, x_in: f32) -> f32 {
     if (ry < 1) { ry = 1; }
     if (rx < 1) { rx = 1; }
     let c = (co * p.outH + ph) * p.outW + pw;
+    if (c >= p.C) { output_[gid] = 0.0; return; }
     let planeBase = (n * p.C + c) * p.H * p.W;
     var acc : f32 = 0.0;
     for (var iy : i32 = 0; iy < ry; iy = iy + 1) {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuRoiKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuRoiKernels.cs
@@ -3,7 +3,10 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.WebGpu;
 
 public static class WebGpuRoiKernels
 {
-    public static string[] GetKernelNames() => new[] { "roi_align", "roi_pool" };
+    public static string[] GetKernelNames() => new[]
+    {
+        "roi_align", "roi_pool", "ps_roi_align", "ps_roi_pool",
+    };
 
     public static string RoIAlign => @"
 @group(0) @binding(0) var<storage, read> input_ : array<f32>;
@@ -114,6 +117,112 @@ struct P {
         }
     }
     output_[gid] = best;
+}
+";
+
+    public static string PsRoIAlign => @"
+@group(0) @binding(0) var<storage, read> input_ : array<f32>;
+@group(0) @binding(1) var<storage, read> boxes : array<f32>;
+@group(0) @binding(2) var<storage, read_write> output_ : array<f32>;
+struct P {
+    N: i32, C: i32, H: i32, W: i32, K: i32, outH: i32, outW: i32, outputChannels: i32,
+    spatialScale: f32, samplingRatio: i32
+};
+@group(0) @binding(3) var<uniform> p : P;
+
+fn ps_bilinear_sample(planeBase: i32, y_in: f32, x_in: f32) -> f32 {
+    var y = y_in; var x = x_in;
+    if (y < -1.0 || y > f32(p.H) || x < -1.0 || x > f32(p.W)) { return 0.0; }
+    if (y <= 0.0) { y = 0.0; }
+    if (x <= 0.0) { x = 0.0; }
+    var y0 = i32(y);
+    var x0 = i32(x);
+    var y1 = select(y0 + 1, p.H - 1, y0 + 1 >= p.H);
+    var x1 = select(x0 + 1, p.W - 1, x0 + 1 >= p.W);
+    if (y0 >= p.H - 1) { y0 = p.H - 1; y1 = p.H - 1; y = f32(y0); }
+    if (x0 >= p.W - 1) { x0 = p.W - 1; x1 = p.W - 1; x = f32(x0); }
+    let ly = y - f32(y0); let lx = x - f32(x0);
+    let hy = 1.0 - ly; let hx = 1.0 - lx;
+    return hy * hx * input_[planeBase + y0 * p.W + x0]
+         + hy * lx * input_[planeBase + y0 * p.W + x1]
+         + ly * hx * input_[planeBase + y1 * p.W + x0]
+         + ly * lx * input_[planeBase + y1 * p.W + x1];
+}
+
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) id : vec3<u32>) {
+    let gid = i32(id.x);
+    let total = p.K * p.outputChannels * p.outH * p.outW;
+    if (gid >= total) { return; }
+    let pw = gid % p.outW; let t1 = gid / p.outW;
+    let ph = t1 % p.outH; let t2 = t1 / p.outH;
+    let co = t2 % p.outputChannels; let k = t2 / p.outputChannels;
+    let n = i32(boxes[k * 5]);
+    if (n < 0 || n >= p.N) { output_[gid] = 0.0; return; }
+    let x1 = boxes[k * 5 + 1] * p.spatialScale;
+    let y1 = boxes[k * 5 + 2] * p.spatialScale;
+    let x2 = boxes[k * 5 + 3] * p.spatialScale;
+    let y2 = boxes[k * 5 + 4] * p.spatialScale;
+    let roiW = max(x2 - x1, 0.1);
+    let roiH = max(y2 - y1, 0.1);
+    let binH = roiH / f32(p.outH);
+    let binW = roiW / f32(p.outW);
+    var ry = select(i32(ceil(roiH / f32(p.outH))), p.samplingRatio, p.samplingRatio > 0);
+    var rx = select(i32(ceil(roiW / f32(p.outW))), p.samplingRatio, p.samplingRatio > 0);
+    if (ry < 1) { ry = 1; }
+    if (rx < 1) { rx = 1; }
+    let c = (co * p.outH + ph) * p.outW + pw;
+    let planeBase = (n * p.C + c) * p.H * p.W;
+    var acc : f32 = 0.0;
+    for (var iy : i32 = 0; iy < ry; iy = iy + 1) {
+        let sy = y1 + f32(ph) * binH + (f32(iy) + 0.5) * binH / f32(ry);
+        for (var ix : i32 = 0; ix < rx; ix = ix + 1) {
+            let sx = x1 + f32(pw) * binW + (f32(ix) + 0.5) * binW / f32(rx);
+            acc = acc + ps_bilinear_sample(planeBase, sy, sx);
+        }
+    }
+    output_[gid] = acc / f32(ry * rx);
+}
+";
+
+    public static string PsRoIPool => @"
+@group(0) @binding(0) var<storage, read> input_ : array<f32>;
+@group(0) @binding(1) var<storage, read> boxes : array<f32>;
+@group(0) @binding(2) var<storage, read_write> output_ : array<f32>;
+struct P {
+    N: i32, C: i32, H: i32, W: i32, K: i32, outH: i32, outW: i32, outputChannels: i32,
+    spatialScale: f32
+};
+@group(0) @binding(3) var<uniform> p : P;
+
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) id : vec3<u32>) {
+    let gid = i32(id.x);
+    let total = p.K * p.outputChannels * p.outH * p.outW;
+    if (gid >= total) { return; }
+    let pw = gid % p.outW; let t1 = gid / p.outW;
+    let ph = t1 % p.outH; let t2 = t1 / p.outH;
+    let co = t2 % p.outputChannels; let k = t2 / p.outputChannels;
+    let n = i32(boxes[k * 5]);
+    if (n < 0 || n >= p.N) { output_[gid] = 0.0; return; }
+    let x1 = boxes[k * 5 + 1] * p.spatialScale;
+    let y1 = boxes[k * 5 + 2] * p.spatialScale;
+    let x2 = boxes[k * 5 + 3] * p.spatialScale;
+    let y2 = boxes[k * 5 + 4] * p.spatialScale;
+    let binH = max(y2 - y1, 0.1) / f32(p.outH);
+    let binW = max(x2 - x1, 0.1) / f32(p.outW);
+    let c = (co * p.outH + ph) * p.outW + pw;
+    var hs = i32(max(0.0, floor(y1 + f32(ph) * binH)));
+    var he = i32(min(f32(p.H), ceil(y1 + f32(ph + 1) * binH)));
+    var ws = i32(max(0.0, floor(x1 + f32(pw) * binW)));
+    var we = i32(min(f32(p.W), ceil(x1 + f32(pw + 1) * binW)));
+    let planeBase = (n * p.C + c) * p.H * p.W;
+    var acc : f32 = 0.0; var cnt : i32 = 0;
+    for (var yy : i32 = hs; yy < he; yy = yy + 1) {
+        for (var xx : i32 = ws; xx < we; xx = xx + 1) {
+            acc = acc + input_[planeBase + yy * p.W + xx];
+            cnt = cnt + 1;
+        }
+    }
+    if (cnt > 0) { output_[gid] = acc / f32(cnt); } else { output_[gid] = 0.0; }
 }
 ";
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuRoiKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuRoiKernels.cs
@@ -20,6 +20,7 @@ struct P {
 
 fn bilinear_sample(planeBase: i32, y_in: f32, x_in: f32) -> f32 {
     var y = y_in; var x = x_in;
+    if (p.H <= 0 || p.W <= 0) { return 0.0; }
     if (y < -1.0 || y > f32(p.H) || x < -1.0 || x > f32(p.W)) { return 0.0; }
     if (y <= 0.0) { y = 0.0; }
     if (x <= 0.0) { x = 0.0; }
@@ -132,6 +133,7 @@ struct P {
 
 fn ps_bilinear_sample(planeBase: i32, y_in: f32, x_in: f32) -> f32 {
     var y = y_in; var x = x_in;
+    if (p.H <= 0 || p.W <= 0) { return 0.0; }
     if (y < -1.0 || y > f32(p.H) || x < -1.0 || x > f32(p.W)) { return 0.0; }
     if (y <= 0.0) { y = 0.0; }
     if (x <= 0.0) { x = 0.0; }

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.Audio.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.Audio.cs
@@ -47,38 +47,63 @@ public partial class DirectGpuTensorEngine
     }
 
     /// <inheritdoc/>
-    public override Tensor<T> MuLawEncoding<T>(Tensor<T> input, int quantizationChannels = 256)
-        => DispatchMuLaw(input, quantizationChannels, encoding: true)
-           ?? base.MuLawEncoding(input, quantizationChannels);
+    public override Tensor<int> MuLawEncoding<T>(Tensor<T> input, int quantizationChannels = 256)
+    {
+        // GPU kernel writes float-valued codes into a float buffer; convert
+        // to int on the CPU side so the public contract holds. For really
+        // large inputs where T=float we could add a dedicated int-writing
+        // kernel later — tracked separately; correctness first.
+        if (typeof(T) == typeof(float))
+        {
+            if (TryGetBackend(out var backend) && backend is IAudioBackend audio)
+            {
+                int len = input.Length;
+                if (len == 0) return new Tensor<int>((int[])input._shape.Clone());
+                using var inBuf = GetOrAllocateBuffer(backend, input);
+                var outBuf = AllocateOutputBuffer(backend, len);
+                try
+                {
+                    audio.MuLawEncoding(inBuf.Buffer, outBuf.Buffer, len, quantizationChannels);
+                    var arr = FinishGpuOp<float>(backend, outBuf, len);
+                    var outInt = new Tensor<int>((int[])input._shape.Clone());
+                    var dst = outInt.AsWritableSpan();
+                    for (int i = 0; i < len; i++) dst[i] = (int)arr[i];
+                    return outInt;
+                }
+                catch { outBuf.Dispose(); throw; }
+            }
+        }
+        return base.MuLawEncoding(input, quantizationChannels);
+    }
 
     /// <inheritdoc/>
-    public override Tensor<T> MuLawDecoding<T>(Tensor<T> input, int quantizationChannels = 256)
-        => DispatchMuLaw(input, quantizationChannels, encoding: false)
-           ?? base.MuLawDecoding(input, quantizationChannels);
-
-    private Tensor<T>? DispatchMuLaw<T>(Tensor<T> input, int qc, bool encoding)
+    public override Tensor<T> MuLawDecoding<T>(Tensor<int> input, int quantizationChannels = 256)
     {
-        if (typeof(T) != typeof(float)) return null;
-        try
+        // Upload the int codes as floats (kernel expects float), decode on
+        // GPU, return as T via the normal FinishGpuOp path.
+        if (typeof(T) == typeof(float))
         {
             if (TryGetBackend(out var backend) && backend is IAudioBackend audio)
             {
                 int len = input.Length;
                 if (len == 0) return new Tensor<T>((int[])input._shape.Clone());
-                using var inBuf = GetOrAllocateBuffer(backend, input);
+                var floatInput = new Tensor<float>((int[])input._shape.Clone());
+                var src = input.AsSpan();
+                var dst = floatInput.AsWritableSpan();
+                for (int i = 0; i < len; i++) dst[i] = src[i];
+
+                using var inBuf = GetOrAllocateBuffer(backend, floatInput);
                 var outBuf = AllocateOutputBuffer(backend, len);
                 try
                 {
-                    if (encoding) audio.MuLawEncoding(inBuf.Buffer, outBuf.Buffer, len, qc);
-                    else audio.MuLawDecoding(inBuf.Buffer, outBuf.Buffer, len, qc);
+                    audio.MuLawDecoding(inBuf.Buffer, outBuf.Buffer, len, quantizationChannels);
                     var arr = FinishGpuOp<T>(backend, outBuf, len);
                     return new Tensor<T>(arr, (int[])input._shape.Clone());
                 }
                 catch { outBuf.Dispose(); throw; }
             }
         }
-        catch { }
-        return null;
+        return base.MuLawDecoding<T>(input, quantizationChannels);
     }
 
     /// <inheritdoc/>

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.Audio.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.Audio.cs
@@ -14,34 +14,25 @@ public partial class DirectGpuTensorEngine
     /// <inheritdoc/>
     public override Tensor<T> AmplitudeToDB<T>(Tensor<T> input, float minAmplitude = 1e-10f, float? topDb = null)
     {
-        if (typeof(T) == typeof(float))
+        if (typeof(T) == typeof(float) && !topDb.HasValue)
         {
-            try
+            // topDb=null has no reduction dependency so the GPU path is
+            // safe. topDb path needs a global peak; we leave it to CPU.
+            if (TryGetBackend(out var backend) && backend is IAudioBackend audio)
             {
-                if (TryGetBackend(out var backend) && backend is IAudioBackend audio)
+                int len = input.Length;
+                if (len == 0) return new Tensor<T>((int[])input._shape.Clone());
+                using var inBuf = GetOrAllocateBuffer(backend, input);
+                var outBuf = AllocateOutputBuffer(backend, len);
+                try
                 {
-                    int len = input.Length;
-                    if (len == 0) return new Tensor<T>((int[])input._shape.Clone());
-                    using var inBuf = GetOrAllocateBuffer(backend, input);
-                    var outBuf = AllocateOutputBuffer(backend, len);
-                    try
-                    {
-                        // When topDb is requested, we still need the peak to set
-                        // the floor. Rather than reduce on GPU here we route
-                        // through CPU for that case (rare fast path).
-                        if (!topDb.HasValue)
-                        {
-                            audio.AmplitudeToDB(inBuf.Buffer, outBuf.Buffer, len,
-                                minAmplitude, 0.0f, clipTopDb: false);
-                            var arr = FinishGpuOp<T>(backend, outBuf, len);
-                            return new Tensor<T>(arr, (int[])input._shape.Clone());
-                        }
-                    }
-                    catch { outBuf.Dispose(); throw; }
-                    outBuf.Dispose();
+                    audio.AmplitudeToDB(inBuf.Buffer, outBuf.Buffer, len,
+                        minAmplitude, 0.0f, clipTopDb: false);
+                    var arr = FinishGpuOp<T>(backend, outBuf, len);
+                    return new Tensor<T>(arr, (int[])input._shape.Clone());
                 }
+                catch { outBuf.Dispose(); throw; }
             }
-            catch { }
         }
         return base.AmplitudeToDB(input, minAmplitude, topDb);
     }
@@ -49,10 +40,9 @@ public partial class DirectGpuTensorEngine
     /// <inheritdoc/>
     public override Tensor<int> MuLawEncoding<T>(Tensor<T> input, int quantizationChannels = 256)
     {
-        // GPU kernel writes float-valued codes into a float buffer; convert
-        // to int on the CPU side so the public contract holds. For really
-        // large inputs where T=float we could add a dedicated int-writing
-        // kernel later — tracked separately; correctness first.
+        if (quantizationChannels <= 1)
+            throw new ArgumentException("quantizationChannels must be > 1 (μ = qc − 1 must be positive).",
+                nameof(quantizationChannels));
         if (typeof(T) == typeof(float))
         {
             if (TryGetBackend(out var backend) && backend is IAudioBackend audio)
@@ -79,8 +69,8 @@ public partial class DirectGpuTensorEngine
     /// <inheritdoc/>
     public override Tensor<T> MuLawDecoding<T>(Tensor<int> input, int quantizationChannels = 256)
     {
-        // Upload the int codes as floats (kernel expects float), decode on
-        // GPU, return as T via the normal FinishGpuOp path.
+        if (quantizationChannels <= 1)
+            throw new ArgumentException("quantizationChannels must be > 1.", nameof(quantizationChannels));
         if (typeof(T) == typeof(float))
         {
             if (TryGetBackend(out var backend) && backend is IAudioBackend audio)
@@ -109,26 +99,28 @@ public partial class DirectGpuTensorEngine
     /// <inheritdoc/>
     public override Tensor<T> ComputeDeltas<T>(Tensor<T> input, int winLength = 5)
     {
+        if (winLength < 3 || (winLength & 1) == 0)
+            throw new ArgumentException(
+                "winLength must be an odd integer >= 3 (denominator 2·Σk² collapses to 0 otherwise).",
+                nameof(winLength));
         if (typeof(T) == typeof(float) && input.Rank >= 1)
         {
-            try
+            if (TryGetBackend(out var backend) && backend is IAudioBackend audio)
             {
-                if (TryGetBackend(out var backend) && backend is IAudioBackend audio)
+                int timeAxis = input._shape[input.Rank - 1];
+                if (timeAxis == 0)
+                    return new Tensor<T>((int[])input._shape.Clone());
+                int leading = input.Length / timeAxis;
+                using var inBuf = GetOrAllocateBuffer(backend, input);
+                var outBuf = AllocateOutputBuffer(backend, input.Length);
+                try
                 {
-                    int timeAxis = input._shape[input.Rank - 1];
-                    int leading = input.Length / timeAxis;
-                    using var inBuf = GetOrAllocateBuffer(backend, input);
-                    var outBuf = AllocateOutputBuffer(backend, input.Length);
-                    try
-                    {
-                        audio.ComputeDeltas(inBuf.Buffer, outBuf.Buffer, leading, timeAxis, winLength);
-                        var arr = FinishGpuOp<T>(backend, outBuf, input.Length);
-                        return new Tensor<T>(arr, (int[])input._shape.Clone());
-                    }
-                    catch { outBuf.Dispose(); throw; }
+                    audio.ComputeDeltas(inBuf.Buffer, outBuf.Buffer, leading, timeAxis, winLength);
+                    var arr = FinishGpuOp<T>(backend, outBuf, input.Length);
+                    return new Tensor<T>(arr, (int[])input._shape.Clone());
                 }
+                catch { outBuf.Dispose(); throw; }
             }
-            catch { }
         }
         return base.ComputeDeltas(input, winLength);
     }
@@ -136,42 +128,50 @@ public partial class DirectGpuTensorEngine
     /// <inheritdoc/>
     public override Tensor<T> Resample<T>(Tensor<T> waveform, int origRate, int newRate)
     {
-        if (typeof(T) == typeof(float) && waveform.Rank >= 1 && origRate > 0 && newRate > 0 && origRate != newRate)
+        if (typeof(T) == typeof(float) && waveform.Rank >= 1
+            && origRate > 0 && newRate > 0 && origRate != newRate)
         {
-            try
+            if (TryGetBackend(out var backend) && backend is IAudioBackend audio)
             {
-                if (TryGetBackend(out var backend) && backend is IAudioBackend audio)
+                int inLen = waveform._shape[waveform.Rank - 1];
+                if (inLen == 0)
                 {
-                    int gcd = Gcd(origRate, newRate);
-                    int up = newRate / gcd;
-                    int down = origRate / gcd;
-                    int halfWidth = Math.Max(8, Math.Min(256, up * 8));
-
-                    int inLen = waveform._shape[waveform.Rank - 1];
-                    int outLen = (int)((long)inLen * up / down);
-                    int leading = waveform.Length / inLen;
-                    int outTotal = leading * outLen;
-                    if (outTotal == 0)
-                    {
-                        var emptyShape = (int[])waveform._shape.Clone();
-                        emptyShape[waveform.Rank - 1] = outLen;
-                        return new Tensor<T>(emptyShape);
-                    }
-
-                    using var inBuf = GetOrAllocateBuffer(backend, waveform);
-                    var outBuf = AllocateOutputBuffer(backend, outTotal);
-                    try
-                    {
-                        audio.Resample(inBuf.Buffer, outBuf.Buffer, leading, inLen, outLen, up, down, halfWidth);
-                        var arr = FinishGpuOp<T>(backend, outBuf, outTotal);
-                        var outShape = (int[])waveform._shape.Clone();
-                        outShape[waveform.Rank - 1] = outLen;
-                        return new Tensor<T>(arr, outShape);
-                    }
-                    catch { outBuf.Dispose(); throw; }
+                    var emptyShape = (int[])waveform._shape.Clone();
+                    emptyShape[waveform.Rank - 1] = 0;
+                    return new Tensor<T>(emptyShape);
                 }
+                int gcd = Gcd(origRate, newRate);
+                int up = newRate / gcd;
+                int down = origRate / gcd;
+                int halfWidth = Math.Max(8, Math.Min(256, up * 8));
+
+                int outLen = (int)((long)inLen * up / down);
+                int leading = waveform.Length / inLen;
+                // Widened arithmetic guards int overflow on huge waveforms.
+                long outTotal64 = checked((long)leading * outLen);
+                if (outTotal64 > int.MaxValue)
+                    throw new OverflowException(
+                        $"Resample output element count {outTotal64} exceeds Int32.MaxValue.");
+                int outTotal = (int)outTotal64;
+                if (outTotal == 0)
+                {
+                    var emptyShape = (int[])waveform._shape.Clone();
+                    emptyShape[waveform.Rank - 1] = outLen;
+                    return new Tensor<T>(emptyShape);
+                }
+
+                using var inBuf = GetOrAllocateBuffer(backend, waveform);
+                var outBuf = AllocateOutputBuffer(backend, outTotal);
+                try
+                {
+                    audio.Resample(inBuf.Buffer, outBuf.Buffer, leading, inLen, outLen, up, down, halfWidth);
+                    var arr = FinishGpuOp<T>(backend, outBuf, outTotal);
+                    var outShape = (int[])waveform._shape.Clone();
+                    outShape[waveform.Rank - 1] = outLen;
+                    return new Tensor<T>(arr, outShape);
+                }
+                catch { outBuf.Dispose(); throw; }
             }
-            catch { }
         }
         return base.Resample(waveform, origRate, newRate);
     }

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.Audio.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.Audio.cs
@@ -1,0 +1,155 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// GPU dispatch for the audio primitives that have native kernels (the
+// composable ops — Spectrogram, PitchShift, TimeStretch — stay on the
+// inherited CpuEngine path since they internally call the already
+// GPU-accelerated STFT).
+
+using AiDotNet.Tensors.Engines.DirectGpu;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines;
+
+public partial class DirectGpuTensorEngine
+{
+    /// <inheritdoc/>
+    public override Tensor<T> AmplitudeToDB<T>(Tensor<T> input, float minAmplitude = 1e-10f, float? topDb = null)
+    {
+        if (typeof(T) == typeof(float))
+        {
+            try
+            {
+                if (TryGetBackend(out var backend) && backend is IAudioBackend audio)
+                {
+                    int len = input.Length;
+                    if (len == 0) return new Tensor<T>((int[])input._shape.Clone());
+                    using var inBuf = GetOrAllocateBuffer(backend, input);
+                    var outBuf = AllocateOutputBuffer(backend, len);
+                    try
+                    {
+                        // When topDb is requested, we still need the peak to set
+                        // the floor. Rather than reduce on GPU here we route
+                        // through CPU for that case (rare fast path).
+                        if (!topDb.HasValue)
+                        {
+                            audio.AmplitudeToDB(inBuf.Buffer, outBuf.Buffer, len,
+                                minAmplitude, 0.0f, clipTopDb: false);
+                            var arr = FinishGpuOp<T>(backend, outBuf, len);
+                            return new Tensor<T>(arr, (int[])input._shape.Clone());
+                        }
+                    }
+                    catch { outBuf.Dispose(); throw; }
+                    outBuf.Dispose();
+                }
+            }
+            catch { }
+        }
+        return base.AmplitudeToDB(input, minAmplitude, topDb);
+    }
+
+    /// <inheritdoc/>
+    public override Tensor<T> MuLawEncoding<T>(Tensor<T> input, int quantizationChannels = 256)
+        => DispatchMuLaw(input, quantizationChannels, encoding: true)
+           ?? base.MuLawEncoding(input, quantizationChannels);
+
+    /// <inheritdoc/>
+    public override Tensor<T> MuLawDecoding<T>(Tensor<T> input, int quantizationChannels = 256)
+        => DispatchMuLaw(input, quantizationChannels, encoding: false)
+           ?? base.MuLawDecoding(input, quantizationChannels);
+
+    private Tensor<T>? DispatchMuLaw<T>(Tensor<T> input, int qc, bool encoding)
+    {
+        if (typeof(T) != typeof(float)) return null;
+        try
+        {
+            if (TryGetBackend(out var backend) && backend is IAudioBackend audio)
+            {
+                int len = input.Length;
+                if (len == 0) return new Tensor<T>((int[])input._shape.Clone());
+                using var inBuf = GetOrAllocateBuffer(backend, input);
+                var outBuf = AllocateOutputBuffer(backend, len);
+                try
+                {
+                    if (encoding) audio.MuLawEncoding(inBuf.Buffer, outBuf.Buffer, len, qc);
+                    else audio.MuLawDecoding(inBuf.Buffer, outBuf.Buffer, len, qc);
+                    var arr = FinishGpuOp<T>(backend, outBuf, len);
+                    return new Tensor<T>(arr, (int[])input._shape.Clone());
+                }
+                catch { outBuf.Dispose(); throw; }
+            }
+        }
+        catch { }
+        return null;
+    }
+
+    /// <inheritdoc/>
+    public override Tensor<T> ComputeDeltas<T>(Tensor<T> input, int winLength = 5)
+    {
+        if (typeof(T) == typeof(float) && input.Rank >= 1)
+        {
+            try
+            {
+                if (TryGetBackend(out var backend) && backend is IAudioBackend audio)
+                {
+                    int timeAxis = input._shape[input.Rank - 1];
+                    int leading = input.Length / timeAxis;
+                    using var inBuf = GetOrAllocateBuffer(backend, input);
+                    var outBuf = AllocateOutputBuffer(backend, input.Length);
+                    try
+                    {
+                        audio.ComputeDeltas(inBuf.Buffer, outBuf.Buffer, leading, timeAxis, winLength);
+                        var arr = FinishGpuOp<T>(backend, outBuf, input.Length);
+                        return new Tensor<T>(arr, (int[])input._shape.Clone());
+                    }
+                    catch { outBuf.Dispose(); throw; }
+                }
+            }
+            catch { }
+        }
+        return base.ComputeDeltas(input, winLength);
+    }
+
+    /// <inheritdoc/>
+    public override Tensor<T> Resample<T>(Tensor<T> waveform, int origRate, int newRate)
+    {
+        if (typeof(T) == typeof(float) && waveform.Rank >= 1 && origRate > 0 && newRate > 0 && origRate != newRate)
+        {
+            try
+            {
+                if (TryGetBackend(out var backend) && backend is IAudioBackend audio)
+                {
+                    int gcd = Gcd(origRate, newRate);
+                    int up = newRate / gcd;
+                    int down = origRate / gcd;
+                    int halfWidth = Math.Max(8, Math.Min(256, up * 8));
+
+                    int inLen = waveform._shape[waveform.Rank - 1];
+                    int outLen = (int)((long)inLen * up / down);
+                    int leading = waveform.Length / inLen;
+                    int outTotal = leading * outLen;
+                    if (outTotal == 0)
+                    {
+                        var emptyShape = (int[])waveform._shape.Clone();
+                        emptyShape[waveform.Rank - 1] = outLen;
+                        return new Tensor<T>(emptyShape);
+                    }
+
+                    using var inBuf = GetOrAllocateBuffer(backend, waveform);
+                    var outBuf = AllocateOutputBuffer(backend, outTotal);
+                    try
+                    {
+                        audio.Resample(inBuf.Buffer, outBuf.Buffer, leading, inLen, outLen, up, down, halfWidth);
+                        var arr = FinishGpuOp<T>(backend, outBuf, outTotal);
+                        var outShape = (int[])waveform._shape.Clone();
+                        outShape[waveform.Rank - 1] = outLen;
+                        return new Tensor<T>(arr, outShape);
+                    }
+                    catch { outBuf.Dispose(); throw; }
+                }
+            }
+            catch { }
+        }
+        return base.Resample(waveform, origRate, newRate);
+    }
+
+    private static int Gcd(int a, int b) { while (b != 0) { int t = b; b = a % b; a = t; } return a; }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.Detection.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.Detection.cs
@@ -1,0 +1,192 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// GPU dispatch for the vision detection ops added by Issue #217.
+// Pattern matches DirectGpuTensorEngine.Parity210.cs:
+//   - if active backend implements IDetectionBackend, dispatch to its
+//     native kernel
+//   - otherwise (or on any failure) fall through to the inherited
+//     CpuEngine implementation
+// The CpuEngine fallback gives correct (slower) results on every
+// non-OpenCL backend until they ship their own kernels.
+
+using AiDotNet.Tensors.Engines.DirectGpu;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines;
+
+public partial class DirectGpuTensorEngine
+{
+    /// <inheritdoc/>
+    public override Tensor<T> BoxIou<T>(Tensor<T> boxesA, Tensor<T> boxesB)
+        => TryGpuBoxIou(boxesA, boxesB, "BoxIou", static (b, a, x, o, n, m) => b.BoxIou(a, x, o, n, m))
+           ?? base.BoxIou(boxesA, boxesB);
+
+    /// <inheritdoc/>
+    public override Tensor<T> GeneralizedBoxIou<T>(Tensor<T> boxesA, Tensor<T> boxesB)
+        => TryGpuBoxIou(boxesA, boxesB, "GeneralizedBoxIou",
+                        static (b, a, x, o, n, m) => b.GeneralizedBoxIou(a, x, o, n, m))
+           ?? base.GeneralizedBoxIou(boxesA, boxesB);
+
+    /// <inheritdoc/>
+    public override Tensor<T> DistanceBoxIou<T>(Tensor<T> boxesA, Tensor<T> boxesB)
+        => TryGpuBoxIou(boxesA, boxesB, "DistanceBoxIou",
+                        static (b, a, x, o, n, m) => b.DistanceBoxIou(a, x, o, n, m))
+           ?? base.DistanceBoxIou(boxesA, boxesB);
+
+    /// <inheritdoc/>
+    public override Tensor<T> CompleteBoxIou<T>(Tensor<T> boxesA, Tensor<T> boxesB)
+        => TryGpuBoxIou(boxesA, boxesB, "CompleteBoxIou",
+                        static (b, a, x, o, n, m) => b.CompleteBoxIou(a, x, o, n, m))
+           ?? base.CompleteBoxIou(boxesA, boxesB);
+
+    /// <inheritdoc/>
+    public override Tensor<T> BoxArea<T>(Tensor<T> boxes)
+    {
+        // Restrict GPU dispatch to float (the kernel surface) and rank-2
+        // boxes so the [N,4] → [N] reshape stays trivially correct.
+        if (typeof(T) != typeof(float) || boxes.Rank != 2 || boxes._shape[1] != 4)
+            return base.BoxArea(boxes);
+        try
+        {
+            if (TryGetBackend(out var backend) && backend is IDetectionBackend det)
+            {
+                int n = boxes._shape[0];
+                if (n == 0) return base.BoxArea(boxes);
+                using var inBuf = GetOrAllocateBuffer(backend, boxes);
+                var outBuf = AllocateOutputBuffer(backend, n);
+                try
+                {
+                    det.BoxArea(inBuf.Buffer, outBuf.Buffer, n);
+                    var arr = FinishGpuOp<T>(backend, outBuf, n);
+                    return new Tensor<T>(arr, new[] { n });
+                }
+                catch { outBuf.Dispose(); throw; }
+            }
+        }
+        catch { }
+        return base.BoxArea(boxes);
+    }
+
+    /// <inheritdoc/>
+    public override Tensor<T> BoxConvert<T>(Tensor<T> boxes, BoxFormat from, BoxFormat to)
+    {
+        if (from == to) return base.BoxConvert(boxes, from, to);
+        if (typeof(T) != typeof(float) || boxes.Rank < 1 || boxes._shape[boxes.Rank - 1] != 4)
+            return base.BoxConvert(boxes, from, to);
+        try
+        {
+            if (TryGetBackend(out var backend) && backend is IDetectionBackend det)
+            {
+                int n = boxes.Length / 4;
+                if (n == 0) return base.BoxConvert(boxes, from, to);
+                using var inBuf = GetOrAllocateBuffer(backend, boxes);
+                var outBuf = AllocateOutputBuffer(backend, boxes.Length);
+                try
+                {
+                    det.BoxConvert(inBuf.Buffer, outBuf.Buffer, n, (int)from, (int)to);
+                    var arr = FinishGpuOp<T>(backend, outBuf, boxes.Length);
+                    return new Tensor<T>(arr, (int[])boxes._shape.Clone());
+                }
+                catch { outBuf.Dispose(); throw; }
+            }
+        }
+        catch { }
+        return base.BoxConvert(boxes, from, to);
+    }
+
+    /// <inheritdoc/>
+    public override (Tensor<T> gradA, Tensor<T> gradB) BoxIouBackward<T>(
+        Tensor<T> gradOutput, Tensor<T> boxesA, Tensor<T> boxesB)
+        => TryGpuIouBackward(gradOutput, boxesA, boxesB, 0) ?? base.BoxIouBackward(gradOutput, boxesA, boxesB);
+
+    /// <inheritdoc/>
+    public override (Tensor<T> gradA, Tensor<T> gradB) GeneralizedBoxIouBackward<T>(
+        Tensor<T> gradOutput, Tensor<T> boxesA, Tensor<T> boxesB)
+        => TryGpuIouBackward(gradOutput, boxesA, boxesB, 1) ?? base.GeneralizedBoxIouBackward(gradOutput, boxesA, boxesB);
+
+    /// <inheritdoc/>
+    public override (Tensor<T> gradA, Tensor<T> gradB) DistanceBoxIouBackward<T>(
+        Tensor<T> gradOutput, Tensor<T> boxesA, Tensor<T> boxesB)
+        => TryGpuIouBackward(gradOutput, boxesA, boxesB, 2) ?? base.DistanceBoxIouBackward(gradOutput, boxesA, boxesB);
+
+    /// <inheritdoc/>
+    public override (Tensor<T> gradA, Tensor<T> gradB) CompleteBoxIouBackward<T>(
+        Tensor<T> gradOutput, Tensor<T> boxesA, Tensor<T> boxesB)
+        => TryGpuIouBackward(gradOutput, boxesA, boxesB, 3) ?? base.CompleteBoxIouBackward(gradOutput, boxesA, boxesB);
+
+    /// <summary>
+    /// GPU dispatch for the shared IouFamilyBackward kernel. <paramref name="variant"/>
+    /// matches the kernel's int code (0 IoU, 1 GIoU, 2 DIoU, 3 CIoU).
+    /// Returns null to fall through to the CPU reference on any failure
+    /// or when the backend doesn't implement <see cref="IDetectionBackend"/>.
+    /// </summary>
+    private (Tensor<T> gradA, Tensor<T> gradB)? TryGpuIouBackward<T>(
+        Tensor<T> gradOutput, Tensor<T> boxesA, Tensor<T> boxesB, int variant)
+    {
+        if (typeof(T) != typeof(float)) return null;
+        if (boxesA.Rank != 2 || boxesA._shape[1] != 4) return null;
+        if (boxesB.Rank != 2 || boxesB._shape[1] != 4) return null;
+        int n = boxesA._shape[0];
+        int m = boxesB._shape[0];
+        if (gradOutput.Rank != 2 || gradOutput._shape[0] != n || gradOutput._shape[1] != m) return null;
+        if (n == 0 || m == 0) return null;
+        try
+        {
+            if (TryGetBackend(out var backend) && backend is IDetectionBackend det)
+            {
+                using var goBuf = GetOrAllocateBuffer(backend, gradOutput);
+                using var aBuf = GetOrAllocateBuffer(backend, boxesA);
+                using var bBuf = GetOrAllocateBuffer(backend, boxesB);
+                var gABuf = AllocateOutputBuffer(backend, n * 4);
+                var gBBuf = AllocateOutputBuffer(backend, m * 4);
+                try
+                {
+                    det.IouFamilyBackward(goBuf.Buffer, aBuf.Buffer, bBuf.Buffer,
+                        gABuf.Buffer, gBBuf.Buffer, n, m, variant);
+                    var arrA = FinishGpuOp<T>(backend, gABuf, n * 4);
+                    var arrB = FinishGpuOp<T>(backend, gBBuf, m * 4);
+                    return (new Tensor<T>(arrA, new[] { n, 4 }), new Tensor<T>(arrB, new[] { m, 4 }));
+                }
+                catch { gABuf.Dispose(); gBBuf.Dispose(); throw; }
+            }
+        }
+        catch { }
+        return null;
+    }
+
+    /// <summary>
+    /// Shared dispatch for the four pairwise IoU variants — they only
+    /// differ in which IDetectionBackend method handles the kernel
+    /// launch, so factor out the buffer plumbing.
+    /// Returns null on any GPU-eligible failure so the caller can fall
+    /// back to the CPU implementation.
+    /// </summary>
+    private Tensor<T>? TryGpuBoxIou<T>(
+        Tensor<T> boxesA, Tensor<T> boxesB, string opName,
+        System.Action<IDetectionBackend, IGpuBuffer, IGpuBuffer, IGpuBuffer, int, int> kernel)
+    {
+        if (typeof(T) != typeof(float)) return null;
+        if (boxesA.Rank != 2 || boxesA._shape[1] != 4) return null;
+        if (boxesB.Rank != 2 || boxesB._shape[1] != 4) return null;
+        try
+        {
+            if (TryGetBackend(out var backend) && backend is IDetectionBackend det)
+            {
+                int n = boxesA._shape[0];
+                int m = boxesB._shape[0];
+                if (n == 0 || m == 0) return null;
+                using var aBuf = GetOrAllocateBuffer(backend, boxesA);
+                using var bBuf = GetOrAllocateBuffer(backend, boxesB);
+                var outBuf = AllocateOutputBuffer(backend, n * m);
+                try
+                {
+                    kernel(det, aBuf.Buffer, bBuf.Buffer, outBuf.Buffer, n, m);
+                    var arr = FinishGpuOp<T>(backend, outBuf, n * m);
+                    return new Tensor<T>(arr, new[] { n, m });
+                }
+                catch { outBuf.Dispose(); throw; }
+            }
+        }
+        catch { }
+        return null;
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.Geometry.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.Geometry.cs
@@ -1,0 +1,177 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// GPU dispatch for the geometry / sampling ops added by Issue #217:
+// Interpolate, PadNd, GridSample (extended), AffineGrid3D. Falls through
+// to CpuEngine via inherited base.* when the backend does not implement
+// IGeometryBackend, T != float, or the shape / mode combination isn't on
+// the GPU's supported surface (1D/3D Interpolate, rank ≠ 4 PadNd, etc.).
+
+using AiDotNet.Tensors.Engines.DirectGpu;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines;
+
+public partial class DirectGpuTensorEngine
+{
+    /// <inheritdoc/>
+    public override Tensor<T> Interpolate<T>(Tensor<T> input, int[] sizes, InterpolateMode mode, bool alignCorners = false)
+    {
+        // GPU surface: T=float, 4D NCHW, modes Nearest/Bilinear/Bicubic/Area.
+        if (typeof(T) == typeof(float)
+            && input.Rank == 4
+            && sizes.Length == 2
+            && IsGpuInterpolateMode(mode))
+        {
+            try
+            {
+                if (TryGetBackend(out var backend) && backend is IGeometryBackend geom)
+                {
+                    int N = input._shape[0], C = input._shape[1];
+                    int Hin = input._shape[2], Win = input._shape[3];
+                    int Hout = sizes[0], Wout = sizes[1];
+                    if (N * C * Hout * Wout == 0)
+                        return new Tensor<T>(new[] { N, C, Hout, Wout });
+                    using var inBuf = GetOrAllocateBuffer(backend, input);
+                    var outBuf = AllocateOutputBuffer(backend, N * C * Hout * Wout);
+                    try
+                    {
+                        geom.Interpolate2D(inBuf.Buffer, outBuf.Buffer,
+                            N, C, Hin, Win, Hout, Wout, (int)mode, alignCorners);
+                        var arr = FinishGpuOp<T>(backend, outBuf, N * C * Hout * Wout);
+                        return new Tensor<T>(arr, new[] { N, C, Hout, Wout });
+                    }
+                    catch { outBuf.Dispose(); throw; }
+                }
+            }
+            catch { }
+        }
+        return base.Interpolate(input, sizes, mode, alignCorners);
+    }
+
+    /// <inheritdoc/>
+    public override Tensor<T> InterpolateByScale<T>(Tensor<T> input, double[] scaleFactors, InterpolateMode mode, bool alignCorners = false)
+        => base.InterpolateByScale(input, scaleFactors, mode, alignCorners);
+
+    /// <inheritdoc/>
+    public override Tensor<T> PadNd<T>(Tensor<T> input, int[] pad, PadMode mode, T value = default!)
+    {
+        // GPU surface: T=float, rank 4 (NCHW), any pad pattern within the 8-int envelope.
+        if (typeof(T) == typeof(float)
+            && input.Rank == 4
+            && pad.Length <= 8)
+        {
+            try
+            {
+                if (TryGetBackend(out var backend) && backend is IGeometryBackend geom)
+                {
+                    int N = input._shape[0], C = input._shape[1];
+                    int Hin = input._shape[2], Win = input._shape[3];
+                    // Expand pad to 8 ints (innermost-first PyTorch order → per-axis pairs).
+                    int[] p = new int[8];
+                    Array.Copy(pad, p, pad.Length);
+                    int padW0 = p[0], padW1 = p[1];
+                    int padH0 = p[2], padH1 = p[3];
+                    int padC0 = p[4], padC1 = p[5];
+                    int padN0 = p[6], padN1 = p[7];
+
+                    int Nout = N + padN0 + padN1;
+                    int Cout = C + padC0 + padC1;
+                    int Hout = Hin + padH0 + padH1;
+                    int Wout = Win + padW0 + padW1;
+                    int outLen = Nout * Cout * Hout * Wout;
+                    if (outLen == 0)
+                        return new Tensor<T>(new[] { Nout, Cout, Hout, Wout });
+
+                    float padValFloat = (T)(object)value! is float f ? f : 0.0f;
+                    using var inBuf = GetOrAllocateBuffer(backend, input);
+                    var outBuf = AllocateOutputBuffer(backend, outLen);
+                    try
+                    {
+                        geom.Pad4D(inBuf.Buffer, outBuf.Buffer,
+                            N, C, Hin, Win,
+                            padN0, padN1, padC0, padC1, padH0, padH1, padW0, padW1,
+                            (int)mode, padValFloat);
+                        var arr = FinishGpuOp<T>(backend, outBuf, outLen);
+                        return new Tensor<T>(arr, new[] { Nout, Cout, Hout, Wout });
+                    }
+                    catch { outBuf.Dispose(); throw; }
+                }
+            }
+            catch { }
+        }
+        return base.PadNd(input, pad, mode, value);
+    }
+
+    /// <inheritdoc/>
+    public override Tensor<T> GridSample<T>(Tensor<T> input, Tensor<T> grid,
+        GridSampleMode mode, GridSamplePadding padding, bool alignCorners)
+    {
+        if (typeof(T) == typeof(float)
+            && input.Rank == 4 && grid.Rank == 4 && grid._shape[3] == 2)
+        {
+            try
+            {
+                if (TryGetBackend(out var backend) && backend is IGeometryBackend geom)
+                {
+                    int N = input._shape[0], H = input._shape[1], W = input._shape[2], C = input._shape[3];
+                    int outH = grid._shape[1], outW = grid._shape[2];
+                    int outLen = N * outH * outW * C;
+                    if (outLen == 0) return new Tensor<T>(new[] { N, outH, outW, C });
+                    using var inBuf = GetOrAllocateBuffer(backend, input);
+                    using var grBuf = GetOrAllocateBuffer(backend, grid);
+                    var outBuf = AllocateOutputBuffer(backend, outLen);
+                    try
+                    {
+                        geom.GridSample2D(inBuf.Buffer, grBuf.Buffer, outBuf.Buffer,
+                            N, H, W, C, outH, outW, (int)mode, (int)padding, alignCorners);
+                        var arr = FinishGpuOp<T>(backend, outBuf, outLen);
+                        return new Tensor<T>(arr, new[] { N, outH, outW, C });
+                    }
+                    catch { outBuf.Dispose(); throw; }
+                }
+            }
+            catch { }
+        }
+        return base.GridSample(input, grid, mode, padding, alignCorners);
+    }
+
+    /// <inheritdoc/>
+    public override Tensor<T> AffineGrid3D<T>(Tensor<T> theta, int outputDepth, int outputHeight, int outputWidth, bool alignCorners = false)
+    {
+        if (typeof(T) == typeof(float)
+            && theta.Rank == 3 && theta._shape[1] == 3 && theta._shape[2] == 4)
+        {
+            try
+            {
+                if (TryGetBackend(out var backend) && backend is IGeometryBackend geom)
+                {
+                    int N = theta._shape[0];
+                    int outLen = N * outputDepth * outputHeight * outputWidth * 3;
+                    if (outLen == 0) return new Tensor<T>(new[] { N, outputDepth, outputHeight, outputWidth, 3 });
+                    using var tBuf = GetOrAllocateBuffer(backend, theta);
+                    var gBuf = AllocateOutputBuffer(backend, outLen);
+                    try
+                    {
+                        geom.AffineGrid3D(tBuf.Buffer, gBuf.Buffer,
+                            N, outputDepth, outputHeight, outputWidth, alignCorners);
+                        var arr = FinishGpuOp<T>(backend, gBuf, outLen);
+                        return new Tensor<T>(arr, new[] { N, outputDepth, outputHeight, outputWidth, 3 });
+                    }
+                    catch { gBuf.Dispose(); throw; }
+                }
+            }
+            catch { }
+        }
+        return base.AffineGrid3D(theta, outputDepth, outputHeight, outputWidth, alignCorners);
+    }
+
+    /// <summary>
+    /// GPU Interpolate2D kernel supports nearest, bilinear, bicubic and
+    /// area. Linear (1D) and trilinear (3D) fall through to CPU because
+    /// they need 3D / 5D tensor handling respectively.
+    /// </summary>
+    private static bool IsGpuInterpolateMode(InterpolateMode mode)
+        => mode == InterpolateMode.Nearest
+           || mode == InterpolateMode.Bilinear
+           || mode == InterpolateMode.Bicubic
+           || mode == InterpolateMode.Area;
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.Roi.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.Roi.cs
@@ -20,32 +20,52 @@ public partial class DirectGpuTensorEngine
             && input.Rank == 4
             && boxes.Rank == 2 && boxes._shape[1] == 5)
         {
-            try
+            if (TryGetBackend(out var backend) && backend is IRoiBackend roi)
             {
-                if (TryGetBackend(out var backend) && backend is IRoiBackend roi)
+                int N = input._shape[0], C = input._shape[1];
+                int H = input._shape[2], W = input._shape[3];
+                int K = boxes._shape[0];
+                if (K == 0) return new Tensor<T>(new[] { 0, C, outputHeight, outputWidth });
+                int outLen = CheckedOutLen(K, C, outputHeight, outputWidth);
+                using var inBuf = GetOrAllocateBuffer(backend, input);
+                using var bBuf = GetOrAllocateBuffer(backend, boxes);
+                var outBuf = AllocateOutputBuffer(backend, outLen);
+                try
                 {
-                    int N = input._shape[0], C = input._shape[1];
-                    int H = input._shape[2], W = input._shape[3];
-                    int K = boxes._shape[0];
-                    if (K == 0) return new Tensor<T>(new[] { 0, C, outputHeight, outputWidth });
-                    int outLen = K * C * outputHeight * outputWidth;
-                    using var inBuf = GetOrAllocateBuffer(backend, input);
-                    using var bBuf = GetOrAllocateBuffer(backend, boxes);
-                    var outBuf = AllocateOutputBuffer(backend, outLen);
-                    try
-                    {
-                        roi.RoIAlign(inBuf.Buffer, bBuf.Buffer, outBuf.Buffer,
-                            N, C, H, W, K, outputHeight, outputWidth,
-                            spatialScale, samplingRatio, aligned);
-                        var arr = FinishGpuOp<T>(backend, outBuf, outLen);
-                        return new Tensor<T>(arr, new[] { K, C, outputHeight, outputWidth });
-                    }
-                    catch { outBuf.Dispose(); throw; }
+                    roi.RoIAlign(inBuf.Buffer, bBuf.Buffer, outBuf.Buffer,
+                        N, C, H, W, K, outputHeight, outputWidth,
+                        spatialScale, samplingRatio, aligned);
+                    var arr = FinishGpuOp<T>(backend, outBuf, outLen);
+                    return new Tensor<T>(arr, new[] { K, C, outputHeight, outputWidth });
                 }
+                catch { outBuf.Dispose(); throw; }
             }
-            catch { }
         }
         return base.RoIAlign(input, boxes, outputHeight, outputWidth, spatialScale, samplingRatio, aligned);
+    }
+
+    /// <summary>
+    /// Compute an output-element count in checked long arithmetic so a
+    /// pathologically large shape can't wrap around to a small positive
+    /// int and allocate an undersized buffer.
+    /// </summary>
+    private static int CheckedOutLen(int a, int b, int c, int d)
+    {
+        long n = checked((long)a * b * c * d);
+        if (n > int.MaxValue)
+            throw new OverflowException(
+                $"RoI output element count {n} exceeds Int32.MaxValue — " +
+                "split the K dimension or reduce output size.");
+        return (int)n;
+    }
+
+    private static int CheckedOutLen(int a, int b, int c, int d, int e)
+    {
+        long n = checked((long)a * b * c * d * e);
+        if (n > int.MaxValue)
+            throw new OverflowException(
+                $"RoI output element count {n} exceeds Int32.MaxValue.");
+        return (int)n;
     }
 
     /// <inheritdoc/>
@@ -56,30 +76,26 @@ public partial class DirectGpuTensorEngine
         if (typeof(T) == typeof(float) && input.Rank == 4
             && boxes.Rank == 2 && boxes._shape[1] == 5)
         {
-            try
+            if (TryGetBackend(out var backend) && backend is IRoiBackend roi)
             {
-                if (TryGetBackend(out var backend) && backend is IRoiBackend roi)
+                int N = input._shape[0], C = input._shape[1];
+                int H = input._shape[2], W = input._shape[3];
+                int K = boxes._shape[0];
+                if (K == 0) return new Tensor<T>(new[] { 0, outputChannels, outputHeight, outputWidth });
+                int outLen = CheckedOutLen(K, outputChannels, outputHeight, outputWidth);
+                using var inBuf = GetOrAllocateBuffer(backend, input);
+                using var bBuf = GetOrAllocateBuffer(backend, boxes);
+                var outBuf = AllocateOutputBuffer(backend, outLen);
+                try
                 {
-                    int N = input._shape[0], C = input._shape[1];
-                    int H = input._shape[2], W = input._shape[3];
-                    int K = boxes._shape[0];
-                    if (K == 0) return new Tensor<T>(new[] { 0, outputChannels, outputHeight, outputWidth });
-                    int outLen = K * outputChannels * outputHeight * outputWidth;
-                    using var inBuf = GetOrAllocateBuffer(backend, input);
-                    using var bBuf = GetOrAllocateBuffer(backend, boxes);
-                    var outBuf = AllocateOutputBuffer(backend, outLen);
-                    try
-                    {
-                        roi.PsRoIAlign(inBuf.Buffer, bBuf.Buffer, outBuf.Buffer,
-                            N, C, H, W, K, outputHeight, outputWidth, outputChannels,
-                            spatialScale, samplingRatio);
-                        var arr = FinishGpuOp<T>(backend, outBuf, outLen);
-                        return new Tensor<T>(arr, new[] { K, outputChannels, outputHeight, outputWidth });
-                    }
-                    catch { outBuf.Dispose(); throw; }
+                    roi.PsRoIAlign(inBuf.Buffer, bBuf.Buffer, outBuf.Buffer,
+                        N, C, H, W, K, outputHeight, outputWidth, outputChannels,
+                        spatialScale, samplingRatio);
+                    var arr = FinishGpuOp<T>(backend, outBuf, outLen);
+                    return new Tensor<T>(arr, new[] { K, outputChannels, outputHeight, outputWidth });
                 }
+                catch { outBuf.Dispose(); throw; }
             }
-            catch { }
         }
         return base.PsRoIAlign(input, boxes, outputHeight, outputWidth, outputChannels, spatialScale, samplingRatio);
     }
@@ -91,29 +107,25 @@ public partial class DirectGpuTensorEngine
         if (typeof(T) == typeof(float) && input.Rank == 4
             && boxes.Rank == 2 && boxes._shape[1] == 5)
         {
-            try
+            if (TryGetBackend(out var backend) && backend is IRoiBackend roi)
             {
-                if (TryGetBackend(out var backend) && backend is IRoiBackend roi)
+                int N = input._shape[0], C = input._shape[1];
+                int H = input._shape[2], W = input._shape[3];
+                int K = boxes._shape[0];
+                if (K == 0) return new Tensor<T>(new[] { 0, outputChannels, outputHeight, outputWidth });
+                int outLen = CheckedOutLen(K, outputChannels, outputHeight, outputWidth);
+                using var inBuf = GetOrAllocateBuffer(backend, input);
+                using var bBuf = GetOrAllocateBuffer(backend, boxes);
+                var outBuf = AllocateOutputBuffer(backend, outLen);
+                try
                 {
-                    int N = input._shape[0], C = input._shape[1];
-                    int H = input._shape[2], W = input._shape[3];
-                    int K = boxes._shape[0];
-                    if (K == 0) return new Tensor<T>(new[] { 0, outputChannels, outputHeight, outputWidth });
-                    int outLen = K * outputChannels * outputHeight * outputWidth;
-                    using var inBuf = GetOrAllocateBuffer(backend, input);
-                    using var bBuf = GetOrAllocateBuffer(backend, boxes);
-                    var outBuf = AllocateOutputBuffer(backend, outLen);
-                    try
-                    {
-                        roi.PsRoIPool(inBuf.Buffer, bBuf.Buffer, outBuf.Buffer,
-                            N, C, H, W, K, outputHeight, outputWidth, outputChannels, spatialScale);
-                        var arr = FinishGpuOp<T>(backend, outBuf, outLen);
-                        return new Tensor<T>(arr, new[] { K, outputChannels, outputHeight, outputWidth });
-                    }
-                    catch { outBuf.Dispose(); throw; }
+                    roi.PsRoIPool(inBuf.Buffer, bBuf.Buffer, outBuf.Buffer,
+                        N, C, H, W, K, outputHeight, outputWidth, outputChannels, spatialScale);
+                    var arr = FinishGpuOp<T>(backend, outBuf, outLen);
+                    return new Tensor<T>(arr, new[] { K, outputChannels, outputHeight, outputWidth });
                 }
+                catch { outBuf.Dispose(); throw; }
             }
-            catch { }
         }
         return base.PsRoIPool(input, boxes, outputHeight, outputWidth, outputChannels, spatialScale);
     }
@@ -126,29 +138,25 @@ public partial class DirectGpuTensorEngine
             && input.Rank == 4
             && boxes.Rank == 2 && boxes._shape[1] == 5)
         {
-            try
+            if (TryGetBackend(out var backend) && backend is IRoiBackend roi)
             {
-                if (TryGetBackend(out var backend) && backend is IRoiBackend roi)
+                int N = input._shape[0], C = input._shape[1];
+                int H = input._shape[2], W = input._shape[3];
+                int K = boxes._shape[0];
+                if (K == 0) return new Tensor<T>(new[] { 0, C, outputHeight, outputWidth });
+                int outLen = CheckedOutLen(K, C, outputHeight, outputWidth);
+                using var inBuf = GetOrAllocateBuffer(backend, input);
+                using var bBuf = GetOrAllocateBuffer(backend, boxes);
+                var outBuf = AllocateOutputBuffer(backend, outLen);
+                try
                 {
-                    int N = input._shape[0], C = input._shape[1];
-                    int H = input._shape[2], W = input._shape[3];
-                    int K = boxes._shape[0];
-                    if (K == 0) return new Tensor<T>(new[] { 0, C, outputHeight, outputWidth });
-                    int outLen = K * C * outputHeight * outputWidth;
-                    using var inBuf = GetOrAllocateBuffer(backend, input);
-                    using var bBuf = GetOrAllocateBuffer(backend, boxes);
-                    var outBuf = AllocateOutputBuffer(backend, outLen);
-                    try
-                    {
-                        roi.RoIPool(inBuf.Buffer, bBuf.Buffer, outBuf.Buffer,
-                            N, C, H, W, K, outputHeight, outputWidth, spatialScale);
-                        var arr = FinishGpuOp<T>(backend, outBuf, outLen);
-                        return new Tensor<T>(arr, new[] { K, C, outputHeight, outputWidth });
-                    }
-                    catch { outBuf.Dispose(); throw; }
+                    roi.RoIPool(inBuf.Buffer, bBuf.Buffer, outBuf.Buffer,
+                        N, C, H, W, K, outputHeight, outputWidth, spatialScale);
+                    var arr = FinishGpuOp<T>(backend, outBuf, outLen);
+                    return new Tensor<T>(arr, new[] { K, C, outputHeight, outputWidth });
                 }
+                catch { outBuf.Dispose(); throw; }
             }
-            catch { }
         }
         return base.RoIPool(input, boxes, outputHeight, outputWidth, spatialScale);
     }

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.Roi.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.Roi.cs
@@ -1,0 +1,85 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// GPU dispatch for the RoI family (Issue #217 tail). Falls through to
+// CpuEngine via inherited base.* when the backend does not implement
+// IRoiBackend, T != float, or the shape isn't on the GPU surface
+// (4D NCHW input, [K, 5] boxes).
+
+using AiDotNet.Tensors.Engines.DirectGpu;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines;
+
+public partial class DirectGpuTensorEngine
+{
+    /// <inheritdoc/>
+    public override Tensor<T> RoIAlign<T>(Tensor<T> input, Tensor<T> boxes,
+        int outputHeight, int outputWidth,
+        float spatialScale, int samplingRatio, bool aligned)
+    {
+        if (typeof(T) == typeof(float)
+            && input.Rank == 4
+            && boxes.Rank == 2 && boxes._shape[1] == 5)
+        {
+            try
+            {
+                if (TryGetBackend(out var backend) && backend is IRoiBackend roi)
+                {
+                    int N = input._shape[0], C = input._shape[1];
+                    int H = input._shape[2], W = input._shape[3];
+                    int K = boxes._shape[0];
+                    if (K == 0) return new Tensor<T>(new[] { 0, C, outputHeight, outputWidth });
+                    int outLen = K * C * outputHeight * outputWidth;
+                    using var inBuf = GetOrAllocateBuffer(backend, input);
+                    using var bBuf = GetOrAllocateBuffer(backend, boxes);
+                    var outBuf = AllocateOutputBuffer(backend, outLen);
+                    try
+                    {
+                        roi.RoIAlign(inBuf.Buffer, bBuf.Buffer, outBuf.Buffer,
+                            N, C, H, W, K, outputHeight, outputWidth,
+                            spatialScale, samplingRatio, aligned);
+                        var arr = FinishGpuOp<T>(backend, outBuf, outLen);
+                        return new Tensor<T>(arr, new[] { K, C, outputHeight, outputWidth });
+                    }
+                    catch { outBuf.Dispose(); throw; }
+                }
+            }
+            catch { }
+        }
+        return base.RoIAlign(input, boxes, outputHeight, outputWidth, spatialScale, samplingRatio, aligned);
+    }
+
+    /// <inheritdoc/>
+    public override Tensor<T> RoIPool<T>(Tensor<T> input, Tensor<T> boxes,
+        int outputHeight, int outputWidth, float spatialScale)
+    {
+        if (typeof(T) == typeof(float)
+            && input.Rank == 4
+            && boxes.Rank == 2 && boxes._shape[1] == 5)
+        {
+            try
+            {
+                if (TryGetBackend(out var backend) && backend is IRoiBackend roi)
+                {
+                    int N = input._shape[0], C = input._shape[1];
+                    int H = input._shape[2], W = input._shape[3];
+                    int K = boxes._shape[0];
+                    if (K == 0) return new Tensor<T>(new[] { 0, C, outputHeight, outputWidth });
+                    int outLen = K * C * outputHeight * outputWidth;
+                    using var inBuf = GetOrAllocateBuffer(backend, input);
+                    using var bBuf = GetOrAllocateBuffer(backend, boxes);
+                    var outBuf = AllocateOutputBuffer(backend, outLen);
+                    try
+                    {
+                        roi.RoIPool(inBuf.Buffer, bBuf.Buffer, outBuf.Buffer,
+                            N, C, H, W, K, outputHeight, outputWidth, spatialScale);
+                        var arr = FinishGpuOp<T>(backend, outBuf, outLen);
+                        return new Tensor<T>(arr, new[] { K, C, outputHeight, outputWidth });
+                    }
+                    catch { outBuf.Dispose(); throw; }
+                }
+            }
+            catch { }
+        }
+        return base.RoIPool(input, boxes, outputHeight, outputWidth, spatialScale);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.Roi.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.Roi.cs
@@ -49,6 +49,76 @@ public partial class DirectGpuTensorEngine
     }
 
     /// <inheritdoc/>
+    public override Tensor<T> PsRoIAlign<T>(Tensor<T> input, Tensor<T> boxes,
+        int outputHeight, int outputWidth, int outputChannels,
+        float spatialScale, int samplingRatio)
+    {
+        if (typeof(T) == typeof(float) && input.Rank == 4
+            && boxes.Rank == 2 && boxes._shape[1] == 5)
+        {
+            try
+            {
+                if (TryGetBackend(out var backend) && backend is IRoiBackend roi)
+                {
+                    int N = input._shape[0], C = input._shape[1];
+                    int H = input._shape[2], W = input._shape[3];
+                    int K = boxes._shape[0];
+                    if (K == 0) return new Tensor<T>(new[] { 0, outputChannels, outputHeight, outputWidth });
+                    int outLen = K * outputChannels * outputHeight * outputWidth;
+                    using var inBuf = GetOrAllocateBuffer(backend, input);
+                    using var bBuf = GetOrAllocateBuffer(backend, boxes);
+                    var outBuf = AllocateOutputBuffer(backend, outLen);
+                    try
+                    {
+                        roi.PsRoIAlign(inBuf.Buffer, bBuf.Buffer, outBuf.Buffer,
+                            N, C, H, W, K, outputHeight, outputWidth, outputChannels,
+                            spatialScale, samplingRatio);
+                        var arr = FinishGpuOp<T>(backend, outBuf, outLen);
+                        return new Tensor<T>(arr, new[] { K, outputChannels, outputHeight, outputWidth });
+                    }
+                    catch { outBuf.Dispose(); throw; }
+                }
+            }
+            catch { }
+        }
+        return base.PsRoIAlign(input, boxes, outputHeight, outputWidth, outputChannels, spatialScale, samplingRatio);
+    }
+
+    /// <inheritdoc/>
+    public override Tensor<T> PsRoIPool<T>(Tensor<T> input, Tensor<T> boxes,
+        int outputHeight, int outputWidth, int outputChannels, float spatialScale)
+    {
+        if (typeof(T) == typeof(float) && input.Rank == 4
+            && boxes.Rank == 2 && boxes._shape[1] == 5)
+        {
+            try
+            {
+                if (TryGetBackend(out var backend) && backend is IRoiBackend roi)
+                {
+                    int N = input._shape[0], C = input._shape[1];
+                    int H = input._shape[2], W = input._shape[3];
+                    int K = boxes._shape[0];
+                    if (K == 0) return new Tensor<T>(new[] { 0, outputChannels, outputHeight, outputWidth });
+                    int outLen = K * outputChannels * outputHeight * outputWidth;
+                    using var inBuf = GetOrAllocateBuffer(backend, input);
+                    using var bBuf = GetOrAllocateBuffer(backend, boxes);
+                    var outBuf = AllocateOutputBuffer(backend, outLen);
+                    try
+                    {
+                        roi.PsRoIPool(inBuf.Buffer, bBuf.Buffer, outBuf.Buffer,
+                            N, C, H, W, K, outputHeight, outputWidth, outputChannels, spatialScale);
+                        var arr = FinishGpuOp<T>(backend, outBuf, outLen);
+                        return new Tensor<T>(arr, new[] { K, outputChannels, outputHeight, outputWidth });
+                    }
+                    catch { outBuf.Dispose(); throw; }
+                }
+            }
+            catch { }
+        }
+        return base.PsRoIPool(input, boxes, outputHeight, outputWidth, outputChannels, spatialScale);
+    }
+
+    /// <inheritdoc/>
     public override Tensor<T> RoIPool<T>(Tensor<T> input, Tensor<T> boxes,
         int outputHeight, int outputWidth, float spatialScale)
     {

--- a/src/AiDotNet.Tensors/Engines/GeometryEnums.cs
+++ b/src/AiDotNet.Tensors/Engines/GeometryEnums.cs
@@ -1,0 +1,75 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Enumerations for the torchvision-style geometry / sampling ops added by
+// Issue #217: Interpolate, Pad, GridSample, AffineGrid.
+namespace AiDotNet.Tensors.Engines;
+
+/// <summary>
+/// Interpolation algorithm for <see cref="IEngine.Interpolate{T}"/> and
+/// <see cref="IEngine.InterpolateByScale{T}"/>. Maps one-to-one onto
+/// <c>torch.nn.functional.interpolate</c>'s <c>mode=</c> parameter.
+/// </summary>
+public enum InterpolateMode
+{
+    /// <summary>Nearest-neighbour (valid for 1D/2D/3D).</summary>
+    Nearest,
+    /// <summary>Linear (1D only — for 2D use <see cref="Bilinear"/>).</summary>
+    Linear,
+    /// <summary>Bilinear (2D only).</summary>
+    Bilinear,
+    /// <summary>Bicubic (2D only). Cubic Catmull-Rom kernel.</summary>
+    Bicubic,
+    /// <summary>Trilinear (3D only).</summary>
+    Trilinear,
+    /// <summary>Adaptive area averaging — equivalent to adaptive_avg_pool2d
+    /// when the scale is an integer ratio. Valid for 1D/2D/3D.</summary>
+    Area,
+}
+
+/// <summary>
+/// Padding mode for <see cref="IEngine.PadNd{T}"/>. Matches
+/// <c>torch.nn.functional.pad</c>'s <c>mode=</c> parameter.
+/// </summary>
+public enum PadMode
+{
+    /// <summary>Fill the added region with a caller-provided constant
+    /// value (torchvision's default).</summary>
+    Constant,
+    /// <summary>Reflect across the boundary, excluding the boundary pixel
+    /// itself (torch default reflect).</summary>
+    Reflect,
+    /// <summary>Repeat the boundary pixel (aka "edge" / "border" /
+    /// "replicate").</summary>
+    Replicate,
+    /// <summary>Wrap around toroidally (circular padding).</summary>
+    Circular,
+}
+
+/// <summary>
+/// Sampling algorithm for <see cref="IEngine.GridSample{T}"/>. Extends the
+/// original bilinear-only API with the full torchvision surface.
+/// </summary>
+public enum GridSampleMode
+{
+    /// <summary>Bilinear interpolation (default in torchvision).</summary>
+    Bilinear,
+    /// <summary>Nearest-neighbour.</summary>
+    Nearest,
+    /// <summary>Bicubic interpolation (2D only; matches torchvision's
+    /// convention of using a Catmull-Rom cubic kernel).</summary>
+    Bicubic,
+}
+
+/// <summary>
+/// Out-of-bounds handling for <see cref="IEngine.GridSample{T}"/>. Matches
+/// torchvision's <c>padding_mode=</c> parameter.
+/// </summary>
+public enum GridSamplePadding
+{
+    /// <summary>Out-of-bounds samples read 0.</summary>
+    Zeros,
+    /// <summary>Out-of-bounds samples clamp to the nearest boundary pixel
+    /// (aka edge / replicate).</summary>
+    Border,
+    /// <summary>Out-of-bounds samples reflect across the boundary.</summary>
+    Reflection,
+}

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -8701,6 +8701,94 @@ public interface IEngine
     Tensor<T> AffineGrid3D<T>(Tensor<T> theta, int outputDepth, int outputHeight, int outputWidth, bool alignCorners = false);
 
     #endregion
+
+    #region Vision RoI + Audio primitives (Issue #217 — tail)
+
+    /// <summary>
+    /// torchvision's <c>roi_align</c>. Input <c>[N, C, H, W]</c>, boxes
+    /// <c>[K, 5]</c> where each row is <c>(batch_idx, x1, y1, x2, y2)</c>
+    /// in image coords (before <paramref name="spatialScale"/>). Output
+    /// <c>[K, C, outH, outW]</c>. <paramref name="samplingRatio"/> ≤ 0 =
+    /// adaptive (ceil(box_size / out_size)).
+    /// <paramref name="aligned"/>=true uses the corrected
+    /// <c>(x + 0.5) · spatialScale - 0.5</c> mapping from torchvision 0.7+.
+    /// </summary>
+    Tensor<T> RoIAlign<T>(Tensor<T> input, Tensor<T> boxes,
+        int outputHeight, int outputWidth,
+        float spatialScale, int samplingRatio, bool aligned);
+
+    /// <summary>
+    /// torchvision's <c>roi_pool</c> — max-pool inside each RoI.
+    /// Signature analogous to <see cref="RoIAlign{T}"/> except no
+    /// sub-pixel sampling (uses integer ROI bounds).
+    /// </summary>
+    Tensor<T> RoIPool<T>(Tensor<T> input, Tensor<T> boxes,
+        int outputHeight, int outputWidth, float spatialScale);
+
+    /// <summary>
+    /// Position-sensitive RoIAlign (R-FCN). Input
+    /// <c>[N, outH·outW·Cout, H, W]</c> where each
+    /// <c>outH·outW</c> slice holds a position-specific score map.
+    /// Output <c>[K, Cout, outH, outW]</c>.
+    /// </summary>
+    Tensor<T> PsRoIAlign<T>(Tensor<T> input, Tensor<T> boxes,
+        int outputHeight, int outputWidth, int outputChannels,
+        float spatialScale, int samplingRatio);
+
+    /// <summary>Position-sensitive RoI-pool (R-FCN).</summary>
+    Tensor<T> PsRoIPool<T>(Tensor<T> input, Tensor<T> boxes,
+        int outputHeight, int outputWidth, int outputChannels,
+        float spatialScale);
+
+    /// <summary>Magnitude spectrogram |STFT(x)|. Thin wrapper over STFT
+    /// that returns only the magnitude half.</summary>
+    Tensor<T> Spectrogram<T>(Tensor<T> waveform, int nFft, int hopLength, int winLength, Tensor<T>? window = null);
+
+    /// <summary>
+    /// Convert amplitude to dB: <c>20 · log10(max(x, minAmplitude))</c>.
+    /// Matches torchaudio's <c>AmplitudeToDB</c> with
+    /// <c>stype='amplitude'</c>. For power input, scale the output by 0.5.
+    /// </summary>
+    Tensor<T> AmplitudeToDB<T>(Tensor<T> input, float minAmplitude = 1e-10f, float? topDb = null);
+
+    /// <summary>μ-law companding encoder (ITU-T G.711 / torchaudio).
+    /// Maps <c>[-1, 1]</c> floats to <c>[0, μ]</c> integer codes.</summary>
+    Tensor<T> MuLawEncoding<T>(Tensor<T> input, int quantizationChannels = 256);
+
+    /// <summary>μ-law companding decoder.</summary>
+    Tensor<T> MuLawDecoding<T>(Tensor<T> input, int quantizationChannels = 256);
+
+    /// <summary>
+    /// Time-axis derivative for audio feature stacks. Matches torchaudio's
+    /// <c>compute_deltas</c>: Savitzky-Golay style filter over a
+    /// <c>winLength</c> window along the time axis (last axis).
+    /// </summary>
+    Tensor<T> ComputeDeltas<T>(Tensor<T> input, int winLength = 5);
+
+    /// <summary>
+    /// Polyphase resampler. Reduces to a rational ratio
+    /// <c>newRate / origRate</c> and applies an FIR polyphase filter.
+    /// Simplified low-pass used — for production use a windowed sinc.
+    /// </summary>
+    Tensor<T> Resample<T>(Tensor<T> waveform, int origRate, int newRate);
+
+    /// <summary>
+    /// Pitch shift by <paramref name="nSteps"/> semitones via phase
+    /// vocoder on the existing STFT. Composes STFT → phase-rate
+    /// modification → ISTFT → resample.
+    /// </summary>
+    Tensor<T> PitchShift<T>(Tensor<T> waveform, int sampleRate, double nSteps,
+        int nFft = 512, int hopLength = 128);
+
+    /// <summary>
+    /// Time-stretch by <paramref name="rate"/> via phase vocoder.
+    /// <c>rate &gt; 1</c> speeds up, <c>rate &lt; 1</c> slows down;
+    /// pitch is preserved.
+    /// </summary>
+    Tensor<T> TimeStretch<T>(Tensor<T> waveform, double rate,
+        int nFft = 512, int hopLength = 128);
+
+    #endregion
 }
 
 /// <summary>

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -8752,11 +8752,15 @@ public interface IEngine
     Tensor<T> AmplitudeToDB<T>(Tensor<T> input, float minAmplitude = 1e-10f, float? topDb = null);
 
     /// <summary>μ-law companding encoder (ITU-T G.711 / torchaudio).
-    /// Maps <c>[-1, 1]</c> floats to <c>[0, μ]</c> integer codes.</summary>
-    Tensor<T> MuLawEncoding<T>(Tensor<T> input, int quantizationChannels = 256);
+    /// Maps <c>[-1, 1]</c> floats to <c>[0, μ]</c> integer codes — the
+    /// encoded domain is explicitly <c>Tensor&lt;int&gt;</c> so downstream
+    /// callers can't accidentally feed analog floats where codes are expected.</summary>
+    Tensor<int> MuLawEncoding<T>(Tensor<T> input, int quantizationChannels = 256);
 
-    /// <summary>μ-law companding decoder.</summary>
-    Tensor<T> MuLawDecoding<T>(Tensor<T> input, int quantizationChannels = 256);
+    /// <summary>μ-law companding decoder — accepts the integer codes
+    /// produced by <see cref="MuLawEncoding{T}"/> and returns analog values
+    /// of type <c>T</c> in <c>[-1, 1]</c>.</summary>
+    Tensor<T> MuLawDecoding<T>(Tensor<int> input, int quantizationChannels = 256);
 
     /// <summary>
     /// Time-axis derivative for audio feature stacks. Matches torchaudio's

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -8788,6 +8788,24 @@ public interface IEngine
     Tensor<T> TimeStretch<T>(Tensor<T> waveform, double rate,
         int nFft = 512, int hopLength = 128);
 
+    /// <summary>
+    /// Decode an encoded image byte blob into an HWC <c>Tensor&lt;byte&gt;</c>.
+    /// <para><paramref name="encoded"/> is the raw file/stream bytes.
+    /// <paramref name="format"/> may be <c>null</c> for auto-detection by
+    /// magic bytes (PNG / JPEG / WebP).</para>
+    /// <para>Output shape: <c>[H, W, channels]</c>. channels = 1 (grey),
+    /// 3 (RGB), or 4 (RGBA) — depending on source.</para>
+    /// </summary>
+    Tensor<byte> ImageDecode(byte[] encoded, ImageFormat? format = null);
+
+    /// <summary>
+    /// Encode an HWC <c>Tensor&lt;byte&gt;</c> into a byte blob.
+    /// <paramref name="image"/> shape <c>[H, W, channels]</c>; channels
+    /// 1 / 3 / 4. <paramref name="quality"/> (0-100) applies only to
+    /// lossy formats (JPEG, WebP).
+    /// </summary>
+    byte[] ImageEncode(Tensor<byte> image, ImageFormat format, int quality = 90);
+
     #endregion
 }
 

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -8577,6 +8577,36 @@ public interface IEngine
     Tensor<T> CompleteBoxIou<T>(Tensor<T> boxesA, Tensor<T> boxesB);
 
     /// <summary>
+    /// Backward pass for <see cref="BoxIou{T}"/>. Given upstream gradient
+    /// <paramref name="gradOutput"/> <c>[N, M]</c> and the forward inputs
+    /// <paramref name="boxesA"/> <c>[N, 4]</c>, <paramref name="boxesB"/>
+    /// <c>[M, 4]</c>, returns gradients with respect to both box sets.
+    /// The tie subgradient at max/min kinks is 0 (torchvision convention).
+    /// </summary>
+    (Tensor<T> gradA, Tensor<T> gradB) BoxIouBackward<T>(
+        Tensor<T> gradOutput, Tensor<T> boxesA, Tensor<T> boxesB);
+
+    /// <summary>
+    /// Backward pass for <see cref="GeneralizedBoxIou{T}"/>.
+    /// </summary>
+    (Tensor<T> gradA, Tensor<T> gradB) GeneralizedBoxIouBackward<T>(
+        Tensor<T> gradOutput, Tensor<T> boxesA, Tensor<T> boxesB);
+
+    /// <summary>
+    /// Backward pass for <see cref="DistanceBoxIou{T}"/>.
+    /// </summary>
+    (Tensor<T> gradA, Tensor<T> gradB) DistanceBoxIouBackward<T>(
+        Tensor<T> gradOutput, Tensor<T> boxesA, Tensor<T> boxesB);
+
+    /// <summary>
+    /// Backward pass for <see cref="CompleteBoxIou{T}"/>. Follows
+    /// Zheng et al. 2020 in treating α as a constant (stop-gradient) when
+    /// backpropping through the aspect-ratio term.
+    /// </summary>
+    (Tensor<T> gradA, Tensor<T> gradB) CompleteBoxIouBackward<T>(
+        Tensor<T> gradOutput, Tensor<T> boxesA, Tensor<T> boxesB);
+
+    /// <summary>
     /// Greedy non-maximum suppression. Sorts boxes by score (descending)
     /// then iteratively keeps the top-scoring box and discards every
     /// remaining box whose IoU with the kept box is &gt; <paramref name="iouThreshold"/>.
@@ -8603,12 +8633,72 @@ public interface IEngine
 
     /// <summary>
     /// Computes the tight axis-aligned bounding box of each foreground
-    /// region in a stack of binary masks. Input <c>[N, H, W]</c>;
-    /// output <c>[N, 4]</c> in <see cref="BoxFormat.XYXY"/>. Empty masks
-    /// (all zero) get <c>[0, 0, 0, 0]</c>, matching
-    /// torchvision's <c>masks_to_boxes</c>.
+    /// region in a stack of binary masks. Input <c>[N, H, W]</c> — any
+    /// numeric / bool type; foreground = any non-zero element. Output is
+    /// <c>Tensor&lt;int&gt;</c> <c>[N, 4]</c> in <see cref="BoxFormat.XYXY"/>
+    /// because box coordinates are pixel indices and must have an integer
+    /// range independent of mask storage (a <c>Tensor&lt;byte&gt;</c> mask
+    /// would cap coords at 255; a <c>Tensor&lt;bool&gt;</c> mask has no
+    /// sensible numeric coord type). Empty masks (all zero) get
+    /// <c>[0, 0, 0, 0]</c>, matching torchvision's <c>masks_to_boxes</c>.
     /// </summary>
-    Tensor<T> MasksToBoxes<T>(Tensor<T> masks);
+    Tensor<int> MasksToBoxes<T>(Tensor<T> masks);
+
+    #endregion
+
+    #region Geometry / sampling (Interpolate, Pad, GridSample, AffineGrid — Issue #217)
+
+    /// <summary>
+    /// Resamples an input tensor to the given target spatial sizes.
+    /// <para>Input layout is NCHW-family: <c>[N, C, *]</c> where <c>*</c>
+    /// is 1 (1D), 2 (2D) or 3 (3D) spatial dims.
+    /// <paramref name="sizes"/> gives the target spatial dims only
+    /// (same length as input's spatial rank).</para>
+    /// <para>Matches <c>torch.nn.functional.interpolate(..., size=, mode=,
+    /// align_corners=)</c>. Bicubic / antialias follow torchvision's
+    /// Catmull-Rom convention; area mode averages source pixels covered
+    /// by each output cell (adaptive_avg_pool equivalent).</para>
+    /// </summary>
+    Tensor<T> Interpolate<T>(Tensor<T> input, int[] sizes, InterpolateMode mode, bool alignCorners = false);
+
+    /// <summary>
+    /// Same as <see cref="Interpolate{T}"/> but sizes are derived from
+    /// per-spatial-axis <paramref name="scaleFactors"/> — each factor
+    /// multiplies the corresponding input spatial extent, floor to int.
+    /// </summary>
+    Tensor<T> InterpolateByScale<T>(Tensor<T> input, double[] scaleFactors, InterpolateMode mode, bool alignCorners = false);
+
+    /// <summary>
+    /// Pads a tensor along arbitrary trailing axes. Matches
+    /// <c>torch.nn.functional.pad(input, pad, mode, value)</c>.
+    /// <para><paramref name="pad"/> is a flat <c>[before_n, after_n,
+    /// before_{n-1}, after_{n-1}, …]</c> list (PyTorch convention:
+    /// innermost axis first). Its length must be even and ≤ 2 × input rank.</para>
+    /// <para><paramref name="value"/> is only used when
+    /// <paramref name="mode"/> = <see cref="PadMode.Constant"/>.</para>
+    /// </summary>
+    Tensor<T> PadNd<T>(Tensor<T> input, int[] pad, PadMode mode, T value = default!);
+
+    /// <summary>
+    /// Full-featured <c>GridSample</c> overload with explicit mode,
+    /// padding-mode, and <c>align_corners</c>. The legacy 3-arg
+    /// <see cref="GridSample{T}"/> delegates to this one with
+    /// mode=<see cref="GridSampleMode.Bilinear"/>,
+    /// padding=<see cref="GridSamplePadding.Zeros"/>,
+    /// alignCorners=false (torchvision defaults).
+    /// Input is NHWC <c>[N, H, W, C]</c>; grid is <c>[N, outH, outW, 2]</c>.
+    /// </summary>
+    Tensor<T> GridSample<T>(Tensor<T> input, Tensor<T> grid,
+        GridSampleMode mode, GridSamplePadding padding, bool alignCorners);
+
+    /// <summary>
+    /// 3D affine-grid generator. Given an affine matrix
+    /// <paramref name="theta"/> of shape <c>[N, 3, 4]</c>, returns a
+    /// sampling grid of shape <c>[N, outD, outH, outW, 3]</c> in
+    /// <c>[-1, 1]</c> normalised coords. The 2D overload of
+    /// <see cref="AffineGrid{T}"/> covers the common image case.
+    /// </summary>
+    Tensor<T> AffineGrid3D<T>(Tensor<T> theta, int outputDepth, int outputHeight, int outputWidth, bool alignCorners = false);
 
     #endregion
 }

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -8692,6 +8692,24 @@ public interface IEngine
         GridSampleMode mode, GridSamplePadding padding, bool alignCorners);
 
     /// <summary>
+    /// Extended <c>GridSample</c> backward with explicit mode / padding /
+    /// align-corners, matching the forward overload above. Non-default
+    /// (mode != Bilinear, padding != Zeros, alignCorners == true) paths
+    /// currently delegate through the managed CpuEngine implementation —
+    /// specialised GPU backward kernels for each mode × padding variant
+    /// are tracked as a follow-up.
+    /// </summary>
+    Tensor<T> GridSampleBackwardInput<T>(Tensor<T> gradOutput, Tensor<T> grid, int[] inputShape,
+        GridSampleMode mode, GridSamplePadding padding, bool alignCorners);
+
+    /// <summary>
+    /// Extended <c>GridSample</c> backward w.r.t. grid, symmetric to
+    /// <see cref="GridSampleBackwardInput{T}(Tensor{T}, Tensor{T}, int[], GridSampleMode, GridSamplePadding, bool)"/>.
+    /// </summary>
+    Tensor<T> GridSampleBackwardGrid<T>(Tensor<T> gradOutput, Tensor<T> input, Tensor<T> grid,
+        GridSampleMode mode, GridSamplePadding padding, bool alignCorners);
+
+    /// <summary>
     /// 3D affine-grid generator. Given an affine matrix
     /// <paramref name="theta"/> of shape <c>[N, 3, 4]</c>, returns a
     /// sampling grid of shape <c>[N, outD, outH, outW, 3]</c> in

--- a/src/AiDotNet.Tensors/Engines/ImageFormat.cs
+++ b/src/AiDotNet.Tensors/Engines/ImageFormat.cs
@@ -1,0 +1,17 @@
+// Copyright (c) AiDotNet. All rights reserved.
+namespace AiDotNet.Tensors.Engines;
+
+/// <summary>
+/// Image codec types supported by <see cref="IEngine.ImageDecode"/> and
+/// <see cref="IEngine.ImageEncode"/>. PNG is implemented in pure managed
+/// C# (no native deps). JPEG and WebP delegate to native bindings —
+/// libjpeg-turbo / libwebp — and throw a descriptive
+/// <c>PlatformNotSupportedException</c> if the native shared library
+/// isn't loadable.
+/// </summary>
+public enum ImageFormat
+{
+    Png,
+    Jpeg,
+    WebP,
+}

--- a/tests/AiDotNet.Tensors.Onnx.Tests/NchwcEndToEndRegression.cs
+++ b/tests/AiDotNet.Tensors.Onnx.Tests/NchwcEndToEndRegression.cs
@@ -130,10 +130,11 @@ public class NchwcEndToEndRegression
 
         // Pre-filter: gross breakage surfaces before the element-wise loop,
         // so a 1e-7 mismatch doesn't mask a NaN/collapsed run.
+        // float.IsFinite is net5+; inline the equivalent so net471 also builds.
         foreach (var v in packed)
-            Assert.True(float.IsFinite(v), $"Non-finite output {v} in packed pipeline");
+            Assert.True(!float.IsNaN(v) && !float.IsInfinity(v), $"Non-finite output {v} in packed pipeline");
         foreach (var v in reference)
-            Assert.True(float.IsFinite(v), $"Non-finite output {v} in NCHW reference");
+            Assert.True(!float.IsNaN(v) && !float.IsInfinity(v), $"Non-finite output {v} in NCHW reference");
         Assert.True(reference.Distinct().Count() >= 5,
             "Reference output has <5 distinct values — pipeline likely collapsed");
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/Detection/BoxIouBackwardTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Detection/BoxIouBackwardTests.cs
@@ -1,0 +1,156 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Numeric gradient check for the IoU-family backward pass (Issue #217).
+// Finite-difference each box coordinate on both input tensors and confirm
+// the analytic backward returns within 1e-3 of the numeric Jacobian
+// projection g^T · (df/dθ). Tolerance is loose because we accumulate
+// FD noise (h = 1e-3) and α-stop-gradient skews CIoU ever so slightly.
+
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Detection;
+
+public class BoxIouBackwardTests
+{
+    private static readonly CpuEngine Cpu = new();
+    private const float H = 1e-3f;     // FD step
+    private const float Tol = 5e-3f;   // tolerance per coord
+
+    private static Tensor<float> RandBoxes(int seed, int n, float range = 20f)
+    {
+        var rng = new Random(seed);
+        var data = new float[n * 4];
+        for (int i = 0; i < n; i++)
+        {
+            float x1 = (float)(rng.NextDouble() * range);
+            float y1 = (float)(rng.NextDouble() * range);
+            float w = 1f + (float)(rng.NextDouble() * range * 0.5);
+            float h = 1f + (float)(rng.NextDouble() * range * 0.5);
+            data[i * 4] = x1;
+            data[i * 4 + 1] = y1;
+            data[i * 4 + 2] = x1 + w;
+            data[i * 4 + 3] = y1 + h;
+        }
+        return new Tensor<float>(data, new[] { n, 4 });
+    }
+
+    private static Tensor<float> RandGrad(int seed, int n, int m)
+    {
+        var rng = new Random(seed ^ 0x55);
+        var data = new float[n * m];
+        for (int i = 0; i < data.Length; i++)
+            data[i] = (float)(rng.NextDouble() * 2 - 1);
+        return new Tensor<float>(data, new[] { n, m });
+    }
+
+    private static double Dot(Tensor<float> a, Tensor<float> b)
+    {
+        var sa = a.AsSpan(); var sb = b.AsSpan();
+        double s = 0;
+        for (int i = 0; i < sa.Length; i++) s += (double)sa[i] * sb[i];
+        return s;
+    }
+
+    private delegate Tensor<float> Forward(Tensor<float> a, Tensor<float> b);
+    private delegate (Tensor<float> gA, Tensor<float> gB) Backward(
+        Tensor<float> go, Tensor<float> a, Tensor<float> b);
+
+    private static void CheckGradients(Forward fwd, Backward bwd, int seedA, int seedB, int n, int m, float tolerance = Tol)
+    {
+        var boxesA = RandBoxes(seedA, n);
+        var boxesB = RandBoxes(seedB, m);
+        var go = RandGrad(seedA + seedB, n, m);
+
+        var (gA, gB) = bwd(go, boxesA, boxesB);
+
+        // FD Jacobian projection: scalar L(θ) = <go, f(θ, φ)>. dL/dθ_k should
+        // match gA[k] / gB[k] within O(h) error.
+        void CheckTensor(Tensor<float> box, Tensor<float> analytic, string label,
+            Func<Tensor<float>, Tensor<float>> perturbForward)
+        {
+            var boxData = box.AsWritableSpan();
+            var grad = analytic.AsSpan();
+            for (int k = 0; k < boxData.Length; k++)
+            {
+                float orig = boxData[k];
+                boxData[k] = orig + H;
+                double lPlus = Dot(go, perturbForward(box));
+                boxData[k] = orig - H;
+                double lMinus = Dot(go, perturbForward(box));
+                boxData[k] = orig;
+
+                double fd = (lPlus - lMinus) / (2.0 * H);
+                double diff = Math.Abs(fd - grad[k]);
+                double scale = 1.0 + Math.Abs(fd);
+                if (diff > tolerance * scale)
+                    throw new Xunit.Sdk.XunitException(
+                        $"{label}[{k}]: analytic={grad[k]:G6}, fd={fd:G6}, diff={diff:G6}");
+            }
+        }
+
+        CheckTensor(boxesA, gA, "gradA", varying => fwd(varying, boxesB));
+        CheckTensor(boxesB, gB, "gradB", varying => fwd(boxesA, varying));
+    }
+
+    [Fact]
+    public void BoxIou_MatchesFiniteDifferences()
+        => CheckGradients(Cpu.BoxIou, Cpu.BoxIouBackward, 1, 2, 4, 3);
+
+    [Fact]
+    public void GeneralizedBoxIou_MatchesFiniteDifferences()
+        => CheckGradients(Cpu.GeneralizedBoxIou, Cpu.GeneralizedBoxIouBackward, 3, 4, 3, 5);
+
+    [Fact]
+    public void DistanceBoxIou_MatchesFiniteDifferences()
+        => CheckGradients(Cpu.DistanceBoxIou, Cpu.DistanceBoxIouBackward, 5, 6, 4, 4);
+
+    [Fact]
+    public void CompleteBoxIou_MatchesFiniteDifferences()
+    {
+        // CIoU uses α-stop-gradient (Zheng et al. 2020, matching
+        // torchvision.ops.complete_box_iou_loss). FD measures the total
+        // derivative including α's dependency on IoU, so the analytic
+        // backward diverges from FD by the α-sensitivity term. Tolerance
+        // bumped to absorb that designed-in discrepancy (~1% per coord).
+        CheckGradients(Cpu.CompleteBoxIou, Cpu.CompleteBoxIouBackward, 7, 8, 3, 4, tolerance: 2e-2f);
+    }
+
+    [Fact]
+    public void BoxIouBackward_EmptyInput_ReturnsZeroShape()
+    {
+        var a = new Tensor<float>(new float[0], new[] { 0, 4 });
+        var b = new Tensor<float>(new float[0], new[] { 0, 4 });
+        var go = new Tensor<float>(new float[0], new[] { 0, 0 });
+        var (gA, gB) = Cpu.BoxIouBackward(go, a, b);
+        Assert.Equal(new[] { 0, 4 }, gA.Shape.ToArray());
+        Assert.Equal(new[] { 0, 4 }, gB.Shape.ToArray());
+    }
+
+    [Fact]
+    public void BoxIouBackward_NonOverlapping_ZeroGrad()
+    {
+        // Boxes that don't overlap have ∂iou/∂θ = 0 at every corner.
+        var a = new Tensor<float>(new float[] { 0, 0, 1, 1 }, new[] { 1, 4 });
+        var b = new Tensor<float>(new float[] { 10, 10, 11, 11 }, new[] { 1, 4 });
+        var go = new Tensor<float>(new float[] { 1 }, new[] { 1, 1 });
+        var (gA, gB) = Cpu.BoxIouBackward(go, a, b);
+        foreach (var v in gA.AsSpan()) Assert.Equal(0f, v, 5);
+        foreach (var v in gB.AsSpan()) Assert.Equal(0f, v, 5);
+    }
+
+    [Fact]
+    public void GeneralizedBoxIouBackward_NonOverlapping_NonZero()
+    {
+        // GIoU keeps a gradient even when IoU = 0, via the union/enclose
+        // term — that's the whole point of GIoU. Confirm gradA is not all
+        // zero on the non-overlap case.
+        var a = new Tensor<float>(new float[] { 0, 0, 1, 1 }, new[] { 1, 4 });
+        var b = new Tensor<float>(new float[] { 10, 10, 11, 11 }, new[] { 1, 4 });
+        var go = new Tensor<float>(new float[] { 1 }, new[] { 1, 1 });
+        var (gA, _) = Cpu.GeneralizedBoxIouBackward(go, a, b);
+        float sum = 0;
+        foreach (var v in gA.AsSpan()) sum += Math.Abs(v);
+        Assert.True(sum > 1e-4f, $"expected nonzero grad, got sum={sum}");
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/DetectionGpuParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/DetectionGpuParityTests.cs
@@ -133,8 +133,9 @@ public class DetectionGpuParityTests : IDisposable
     {
         SkipIfUnavailable();
         var boxes = RandBoxes(10, 17);
-        foreach (BoxFormat from in Enum.GetValues<BoxFormat>())
-            foreach (BoxFormat to in Enum.GetValues<BoxFormat>())
+        // Enum.GetValues<T>() is net5+; cast the non-generic form for net471.
+        foreach (BoxFormat from in (BoxFormat[])Enum.GetValues(typeof(BoxFormat)))
+            foreach (BoxFormat to in (BoxFormat[])Enum.GetValues(typeof(BoxFormat)))
             {
                 if (from == to) continue;
                 AssertClose(_gpu!.BoxConvert(boxes, from, to), _cpu.BoxConvert(boxes, from, to));

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/DetectionGpuParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/DetectionGpuParityTests.cs
@@ -22,15 +22,17 @@ public class DetectionGpuParityTests : IDisposable
 
     public DetectionGpuParityTests()
     {
+        // Only swallow PlatformNotSupportedException / DllNotFoundException
+        // (no native GPU runtime on this machine). A real kernel / module
+        // compilation regression should surface as a test failure, not a
+        // silent skip.
         try
         {
             _gpu = new DirectGpuTensorEngine();
             _gpuAvailable = _gpu.IsGpuAvailable && BackendImplementsDetection();
         }
-        catch
-        {
-            _gpuAvailable = false;
-        }
+        catch (PlatformNotSupportedException) { _gpuAvailable = false; }
+        catch (System.DllNotFoundException) { _gpuAvailable = false; }
     }
 
     private bool BackendImplementsDetection()

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/DetectionGpuParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/DetectionGpuParityTests.cs
@@ -1,0 +1,221 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.DirectGpu;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
+
+/// <summary>
+/// GPU-vs-CPU parity for the vision detection ops added by Issue #217.
+/// Skipped automatically when no GPU backend is available, or when the
+/// active backend doesn't implement <c>IDetectionBackend</c> — in that
+/// configuration <c>DirectGpuTensorEngine</c> falls through to
+/// <c>CpuEngine</c> and there's nothing GPU-side to validate.
+/// </summary>
+[Collection("VulkanGlobalState")]
+public class DetectionGpuParityTests : IDisposable
+{
+    private readonly DirectGpuTensorEngine? _gpu;
+    private readonly CpuEngine _cpu = new();
+    private readonly bool _gpuAvailable;
+    private const float Tolerance = 1e-4f;
+
+    public DetectionGpuParityTests()
+    {
+        try
+        {
+            _gpu = new DirectGpuTensorEngine();
+            _gpuAvailable = _gpu.IsGpuAvailable && BackendImplementsDetection();
+        }
+        catch
+        {
+            _gpuAvailable = false;
+        }
+    }
+
+    private bool BackendImplementsDetection()
+    {
+        var backendField = typeof(DirectGpuTensorEngine).GetField(
+            "_backend",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        var backend = backendField?.GetValue(_gpu);
+        return backend is IDetectionBackend;
+    }
+
+    public void Dispose() => (_gpu as IDisposable)?.Dispose();
+
+    private void SkipIfUnavailable() => Skip.If(!_gpuAvailable,
+        "GPU backend without IDetectionBackend support — CPU fallback is exercised by BoxOpsTests instead.");
+
+    private static Tensor<float> RandBoxes(int seed, int n, float range = 100f)
+    {
+        var rng = new Random(seed);
+        var data = new float[n * 4];
+        for (int i = 0; i < n; i++)
+        {
+            float x1 = (float)(rng.NextDouble() * range);
+            float y1 = (float)(rng.NextDouble() * range);
+            float w = (float)(rng.NextDouble() * range * 0.5);
+            float h = (float)(rng.NextDouble() * range * 0.5);
+            data[i * 4] = x1;
+            data[i * 4 + 1] = y1;
+            data[i * 4 + 2] = x1 + w;
+            data[i * 4 + 3] = y1 + h;
+        }
+        return new Tensor<float>(data, new[] { n, 4 });
+    }
+
+    private static void AssertClose(Tensor<float> g, Tensor<float> c, float tol = Tolerance)
+    {
+        Assert.Equal(c.Shape.ToArray(), g.Shape.ToArray());
+        var gs = g.AsSpan();
+        var cs = c.AsSpan();
+        for (int i = 0; i < gs.Length; i++)
+        {
+            float d = Math.Abs(gs[i] - cs[i]);
+            float scale = 1 + Math.Abs(cs[i]);
+            if (d > tol * scale)
+                throw new Xunit.Sdk.XunitException(
+                    $"GPU vs CPU mismatch at [{i}]: gpu={gs[i]}, cpu={cs[i]}, diff={d}");
+        }
+    }
+
+    [SkippableFact]
+    public void BoxIou_GpuMatchesCpu()
+    {
+        SkipIfUnavailable();
+        var a = RandBoxes(1, 16);
+        var b = RandBoxes(2, 12);
+        AssertClose(_gpu!.BoxIou(a, b), _cpu.BoxIou(a, b));
+    }
+
+    [SkippableFact]
+    public void GeneralizedBoxIou_GpuMatchesCpu()
+    {
+        SkipIfUnavailable();
+        var a = RandBoxes(3, 10);
+        var b = RandBoxes(4, 14);
+        AssertClose(_gpu!.GeneralizedBoxIou(a, b), _cpu.GeneralizedBoxIou(a, b));
+    }
+
+    [SkippableFact]
+    public void DistanceBoxIou_GpuMatchesCpu()
+    {
+        SkipIfUnavailable();
+        var a = RandBoxes(5, 8);
+        var b = RandBoxes(6, 10);
+        AssertClose(_gpu!.DistanceBoxIou(a, b), _cpu.DistanceBoxIou(a, b));
+    }
+
+    [SkippableFact]
+    public void CompleteBoxIou_GpuMatchesCpu()
+    {
+        SkipIfUnavailable();
+        var a = RandBoxes(7, 6);
+        var b = RandBoxes(8, 9);
+        // CIoU's atan term loses some FP precision on GPU vs CPU; relax
+        // tolerance very slightly to absorb 1-2 ULPs of accumulated error.
+        AssertClose(_gpu!.CompleteBoxIou(a, b), _cpu.CompleteBoxIou(a, b), tol: 5e-4f);
+    }
+
+    [SkippableFact]
+    public void BoxArea_GpuMatchesCpu()
+    {
+        SkipIfUnavailable();
+        var boxes = RandBoxes(9, 32);
+        AssertClose(_gpu!.BoxArea(boxes), _cpu.BoxArea(boxes));
+    }
+
+    [SkippableFact]
+    public void BoxConvert_AllPairs_GpuMatchesCpu()
+    {
+        SkipIfUnavailable();
+        var boxes = RandBoxes(10, 17);
+        foreach (BoxFormat from in Enum.GetValues<BoxFormat>())
+            foreach (BoxFormat to in Enum.GetValues<BoxFormat>())
+            {
+                if (from == to) continue;
+                AssertClose(_gpu!.BoxConvert(boxes, from, to), _cpu.BoxConvert(boxes, from, to));
+            }
+    }
+
+    [SkippableFact]
+    public void BoxIou_SquareN_GpuMatchesCpu_RegressionShape()
+    {
+        // Exact same input on both sides — common case for self-IoU
+        // (e.g. NMS upstream). Exercises the diagonal where IoU should be
+        // exactly 1.0 modulo FP roundoff.
+        SkipIfUnavailable();
+        var boxes = RandBoxes(11, 24);
+        AssertClose(_gpu!.BoxIou(boxes, boxes), _cpu.BoxIou(boxes, boxes));
+    }
+
+    // ========================================================================
+    // Backward parity (Issue #217). GPU backward kernel runs in fp32, CPU
+    // reference runs in fp64 internally — tolerance relaxed to 1e-3 to absorb
+    // the precision delta (especially CIoU with its atan term).
+    // ========================================================================
+
+    private static Tensor<float> RandGrad(int seed, int n, int m)
+    {
+        var rng = new Random(seed ^ 0x55);
+        var data = new float[n * m];
+        for (int i = 0; i < data.Length; i++)
+            data[i] = (float)(rng.NextDouble() * 2 - 1);
+        return new Tensor<float>(data, new[] { n, m });
+    }
+
+    [SkippableFact]
+    public void BoxIouBackward_GpuMatchesCpu()
+    {
+        SkipIfUnavailable();
+        var a = RandBoxes(21, 6);
+        var b = RandBoxes(22, 8);
+        var go = RandGrad(23, 6, 8);
+        var (gpuA, gpuB) = _gpu!.BoxIouBackward(go, a, b);
+        var (cpuA, cpuB) = _cpu.BoxIouBackward(go, a, b);
+        AssertClose(gpuA, cpuA, tol: 1e-3f);
+        AssertClose(gpuB, cpuB, tol: 1e-3f);
+    }
+
+    [SkippableFact]
+    public void GeneralizedBoxIouBackward_GpuMatchesCpu()
+    {
+        SkipIfUnavailable();
+        var a = RandBoxes(24, 5);
+        var b = RandBoxes(25, 7);
+        var go = RandGrad(26, 5, 7);
+        var (gpuA, gpuB) = _gpu!.GeneralizedBoxIouBackward(go, a, b);
+        var (cpuA, cpuB) = _cpu.GeneralizedBoxIouBackward(go, a, b);
+        AssertClose(gpuA, cpuA, tol: 1e-3f);
+        AssertClose(gpuB, cpuB, tol: 1e-3f);
+    }
+
+    [SkippableFact]
+    public void DistanceBoxIouBackward_GpuMatchesCpu()
+    {
+        SkipIfUnavailable();
+        var a = RandBoxes(27, 4);
+        var b = RandBoxes(28, 6);
+        var go = RandGrad(29, 4, 6);
+        var (gpuA, gpuB) = _gpu!.DistanceBoxIouBackward(go, a, b);
+        var (cpuA, cpuB) = _cpu.DistanceBoxIouBackward(go, a, b);
+        AssertClose(gpuA, cpuA, tol: 1e-3f);
+        AssertClose(gpuB, cpuB, tol: 1e-3f);
+    }
+
+    [SkippableFact]
+    public void CompleteBoxIouBackward_GpuMatchesCpu()
+    {
+        SkipIfUnavailable();
+        var a = RandBoxes(30, 4);
+        var b = RandBoxes(31, 5);
+        var go = RandGrad(32, 4, 5);
+        var (gpuA, gpuB) = _gpu!.CompleteBoxIouBackward(go, a, b);
+        var (cpuA, cpuB) = _cpu.CompleteBoxIouBackward(go, a, b);
+        // CIoU has an atan term — fp32 on GPU vs fp64 on CPU gives a slightly
+        // larger delta than the other variants.
+        AssertClose(gpuA, cpuA, tol: 2e-3f);
+        AssertClose(gpuB, cpuB, tol: 2e-3f);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GeometryGpuParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GeometryGpuParityTests.cs
@@ -26,7 +26,8 @@ public class GeometryGpuParityTests : IDisposable
             _gpu = new DirectGpuTensorEngine();
             _gpuAvailable = _gpu.IsGpuAvailable && BackendImplementsGeometry();
         }
-        catch { _gpuAvailable = false; }
+        catch (PlatformNotSupportedException) { _gpuAvailable = false; }
+        catch (System.DllNotFoundException) { _gpuAvailable = false; }
     }
 
     private bool BackendImplementsGeometry()

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GeometryGpuParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GeometryGpuParityTests.cs
@@ -1,0 +1,126 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.DirectGpu;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
+
+/// <summary>
+/// GPU-vs-CPU parity for the geometry / sampling ops added by Issue #217.
+/// Same skip semantics as <c>DetectionGpuParityTests</c>: without an
+/// <c>IGeometryBackend</c>-implementing backend the tests skip cleanly
+/// and the engine falls through to CpuEngine.
+/// </summary>
+[Collection("VulkanGlobalState")]
+public class GeometryGpuParityTests : IDisposable
+{
+    private readonly DirectGpuTensorEngine? _gpu;
+    private readonly CpuEngine _cpu = new();
+    private readonly bool _gpuAvailable;
+    private const float Tolerance = 1e-3f;
+
+    public GeometryGpuParityTests()
+    {
+        try
+        {
+            _gpu = new DirectGpuTensorEngine();
+            _gpuAvailable = _gpu.IsGpuAvailable && BackendImplementsGeometry();
+        }
+        catch { _gpuAvailable = false; }
+    }
+
+    private bool BackendImplementsGeometry()
+    {
+        var backendField = typeof(DirectGpuTensorEngine).GetField(
+            "_backend",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        var backend = backendField?.GetValue(_gpu);
+        return backend is IGeometryBackend;
+    }
+
+    public void Dispose() => (_gpu as IDisposable)?.Dispose();
+
+    private void SkipIfUnavailable() => Skip.If(!_gpuAvailable,
+        "GPU backend without IGeometryBackend support — CPU fallback is exercised by GeometryOpsTests instead.");
+
+    private static Tensor<float> Rand4D(int seed, int N, int C, int H, int W, float range = 1f)
+    {
+        var rng = new Random(seed);
+        var data = new float[N * C * H * W];
+        for (int i = 0; i < data.Length; i++)
+            data[i] = (float)(rng.NextDouble() * range * 2 - range);
+        return new Tensor<float>(data, new[] { N, C, H, W });
+    }
+
+    private static void AssertClose(Tensor<float> g, Tensor<float> c, float tol = Tolerance)
+    {
+        Assert.Equal(c.Shape.ToArray(), g.Shape.ToArray());
+        var gs = g.AsSpan(); var cs = c.AsSpan();
+        for (int i = 0; i < gs.Length; i++)
+        {
+            float d = Math.Abs(gs[i] - cs[i]);
+            float scale = 1 + Math.Abs(cs[i]);
+            if (d > tol * scale)
+                throw new Xunit.Sdk.XunitException(
+                    $"GPU vs CPU mismatch at [{i}]: gpu={gs[i]}, cpu={cs[i]}, diff={d}");
+        }
+    }
+
+    [SkippableTheory]
+    [InlineData(InterpolateMode.Nearest, false)]
+    [InlineData(InterpolateMode.Bilinear, false)]
+    [InlineData(InterpolateMode.Bilinear, true)]
+    [InlineData(InterpolateMode.Bicubic, false)]
+    [InlineData(InterpolateMode.Area, false)]
+    public void Interpolate2D_GpuMatchesCpu(InterpolateMode mode, bool alignCorners)
+    {
+        SkipIfUnavailable();
+        var input = Rand4D(1, 2, 3, 8, 10);
+        var g = _gpu!.Interpolate(input, new[] { 12, 15 }, mode, alignCorners);
+        var c = _cpu.Interpolate(input, new[] { 12, 15 }, mode, alignCorners);
+        AssertClose(g, c);
+    }
+
+    [SkippableTheory]
+    [InlineData(PadMode.Constant)]
+    [InlineData(PadMode.Reflect)]
+    [InlineData(PadMode.Replicate)]
+    [InlineData(PadMode.Circular)]
+    public void Pad4D_GpuMatchesCpu(PadMode mode)
+    {
+        SkipIfUnavailable();
+        var input = Rand4D(2, 1, 2, 4, 5);
+        int[] pad = { 1, 2, 1, 1, 0, 0, 0, 0 };
+        var g = _gpu!.PadNd(input, pad, mode, 0.5f);
+        var c = _cpu.PadNd(input, pad, mode, 0.5f);
+        AssertClose(g, c);
+    }
+
+    [SkippableFact]
+    public void GridSample2D_Bilinear_Zeros_GpuMatchesCpu()
+    {
+        SkipIfUnavailable();
+        var input = Rand4D(3, 1, 2, 4, 4);  // NHWC: [1, 4, 4, 2]
+        input = new Tensor<float>(input.AsSpan().ToArray(), new[] { 1, 4, 4, 2 });
+        var rng = new Random(4);
+        var gridData = new float[1 * 3 * 3 * 2];
+        for (int i = 0; i < gridData.Length; i++) gridData[i] = (float)(rng.NextDouble() * 2 - 1);
+        var grid = new Tensor<float>(gridData, new[] { 1, 3, 3, 2 });
+        var g = _gpu!.GridSample(input, grid, GridSampleMode.Bilinear, GridSamplePadding.Zeros, false);
+        var c = _cpu.GridSample(input, grid, GridSampleMode.Bilinear, GridSamplePadding.Zeros, false);
+        AssertClose(g, c);
+    }
+
+    [SkippableFact]
+    public void AffineGrid3D_GpuMatchesCpu()
+    {
+        SkipIfUnavailable();
+        var rng = new Random(5);
+        var t = new float[1 * 3 * 4];
+        for (int i = 0; i < t.Length; i++) t[i] = (float)(rng.NextDouble() * 2 - 1);
+        var theta = new Tensor<float>(t, new[] { 1, 3, 4 });
+        var g = _gpu!.AffineGrid3D(theta, 2, 3, 3, alignCorners: false);
+        var c = _cpu.AffineGrid3D(theta, 2, 3, 3, alignCorners: false);
+        AssertClose(g, c);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Geometry/GeometryOpsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Geometry/GeometryOpsTests.cs
@@ -1,0 +1,223 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// CPU reference tests for the geometry / sampling ops added by Issue #217:
+// Interpolate (6 modes), PadNd (4 modes), GridSample (mode + padding +
+// align_corners matrix), AffineGrid3D. Ground-truth values are computed
+// by hand or cross-checked against the closed-form convention used by
+// torchvision.
+
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Geometry;
+
+public class GeometryOpsTests
+{
+    private readonly CpuEngine _cpu = new();
+
+    private static Tensor<float> Arange2D(int h, int w, int start = 0)
+    {
+        var data = new float[h * w];
+        for (int i = 0; i < data.Length; i++) data[i] = start + i;
+        return new Tensor<float>(data, new[] { 1, 1, h, w });
+    }
+
+    private static void AssertClose(float[] expected, float[] actual, float tol = 1e-4f)
+    {
+        Assert.Equal(expected.Length, actual.Length);
+        for (int i = 0; i < expected.Length; i++)
+        {
+            if (Math.Abs(expected[i] - actual[i]) > tol * (1 + Math.Abs(expected[i])))
+                throw new Xunit.Sdk.XunitException($"mismatch [{i}]: exp={expected[i]}, act={actual[i]}");
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Interpolate
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Interpolate_Nearest_2D_UpsampleBy2()
+    {
+        var input = Arange2D(2, 2);        // [[0, 1], [2, 3]]
+        var output = _cpu.Interpolate(input, new[] { 4, 4 }, InterpolateMode.Nearest);
+        // Each source pixel maps to a 2×2 block.
+        var expected = new float[] {
+            0, 0, 1, 1,
+            0, 0, 1, 1,
+            2, 2, 3, 3,
+            2, 2, 3, 3,
+        };
+        AssertClose(expected, output.AsSpan().ToArray());
+    }
+
+    [Fact]
+    public void Interpolate_Bilinear_2D_UpsampleBy2_AlignCorners()
+    {
+        var input = Arange2D(2, 2);
+        var output = _cpu.Interpolate(input, new[] { 3, 3 }, InterpolateMode.Bilinear, alignCorners: true);
+        // With align_corners the corners of input and output coincide. Output
+        // is evaluated at normalized coords {0, 0.5, 1} along each axis.
+        var expected = new float[] {
+            0.0f, 0.5f, 1.0f,
+            1.0f, 1.5f, 2.0f,
+            2.0f, 2.5f, 3.0f,
+        };
+        AssertClose(expected, output.AsSpan().ToArray());
+    }
+
+    [Fact]
+    public void Interpolate_Bilinear_2D_SameSize_IsIdentity()
+    {
+        var input = Arange2D(3, 4);
+        var output = _cpu.Interpolate(input, new[] { 3, 4 }, InterpolateMode.Bilinear);
+        AssertClose(input.AsSpan().ToArray(), output.AsSpan().ToArray());
+    }
+
+    [Fact]
+    public void Interpolate_Area_2D_Downsample2x_EqualsAvgPool()
+    {
+        // 4×4 avg pool with 2×2 window.
+        var input = Arange2D(4, 4);
+        var output = _cpu.Interpolate(input, new[] { 2, 2 }, InterpolateMode.Area);
+        // Hand-compute: block means of 2x2 blocks of arange(16).
+        // Block (0,0) = mean(0,1,4,5) = 2.5; (0,1) = mean(2,3,6,7) = 4.5
+        // Block (1,0) = mean(8,9,12,13) = 10.5; (1,1) = mean(10,11,14,15) = 12.5
+        var expected = new float[] { 2.5f, 4.5f, 10.5f, 12.5f };
+        AssertClose(expected, output.AsSpan().ToArray());
+    }
+
+    [Fact]
+    public void Interpolate_Bicubic_2D_SameSize_IsIdentity()
+    {
+        var input = Arange2D(4, 4);
+        var output = _cpu.Interpolate(input, new[] { 4, 4 }, InterpolateMode.Bicubic, alignCorners: true);
+        // Bicubic with same input/output size + align_corners should be identity.
+        AssertClose(input.AsSpan().ToArray(), output.AsSpan().ToArray(), tol: 1e-3f);
+    }
+
+    [Fact]
+    public void Interpolate_1D_Linear()
+    {
+        // [N=1, C=1, W=3] -> W=5
+        var input = new Tensor<float>(new float[] { 0, 10, 20 }, new[] { 1, 1, 3 });
+        var output = _cpu.Interpolate(input, new[] { 5 }, InterpolateMode.Linear, alignCorners: true);
+        // align_corners=true: sample positions {0, 0.5, 1, 1.5, 2} in src -> {0, 5, 10, 15, 20}
+        AssertClose(new float[] { 0, 5, 10, 15, 20 }, output.AsSpan().ToArray());
+    }
+
+    [Fact]
+    public void InterpolateByScale_Factor2_MatchesInterpolate()
+    {
+        var input = Arange2D(2, 3);
+        var a = _cpu.InterpolateByScale(input, new[] { 2.0, 2.0 }, InterpolateMode.Nearest);
+        var b = _cpu.Interpolate(input, new[] { 4, 6 }, InterpolateMode.Nearest);
+        AssertClose(a.AsSpan().ToArray(), b.AsSpan().ToArray());
+    }
+
+    // ------------------------------------------------------------------
+    // PadNd
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void PadNd_Constant_2D()
+    {
+        var input = new Tensor<float>(new float[] { 1, 2, 3, 4 }, new[] { 2, 2 });
+        // pad=(1, 1, 0, 0) → 1 on each side of the innermost (width) axis.
+        var output = _cpu.PadNd(input, new[] { 1, 1, 0, 0 }, PadMode.Constant, -1f);
+        // Expected shape [2, 4] = [[−1, 1, 2, −1], [−1, 3, 4, −1]]
+        Assert.Equal(new[] { 2, 4 }, output.Shape.ToArray());
+        var expected = new float[] { -1, 1, 2, -1, -1, 3, 4, -1 };
+        AssertClose(expected, output.AsSpan().ToArray());
+    }
+
+    [Fact]
+    public void PadNd_Reflect_1D()
+    {
+        var input = new Tensor<float>(new float[] { 1, 2, 3, 4 }, new[] { 4 });
+        var output = _cpu.PadNd(input, new[] { 2, 2 }, PadMode.Reflect);
+        // Reflect (excluding boundary): [3, 2, | 1, 2, 3, 4 | 3, 2]
+        var expected = new float[] { 3, 2, 1, 2, 3, 4, 3, 2 };
+        AssertClose(expected, output.AsSpan().ToArray());
+    }
+
+    [Fact]
+    public void PadNd_Replicate_1D()
+    {
+        var input = new Tensor<float>(new float[] { 5, 6, 7 }, new[] { 3 });
+        var output = _cpu.PadNd(input, new[] { 2, 3 }, PadMode.Replicate);
+        var expected = new float[] { 5, 5, 5, 6, 7, 7, 7, 7 };
+        AssertClose(expected, output.AsSpan().ToArray());
+    }
+
+    [Fact]
+    public void PadNd_Circular_1D()
+    {
+        var input = new Tensor<float>(new float[] { 1, 2, 3 }, new[] { 3 });
+        var output = _cpu.PadNd(input, new[] { 2, 2 }, PadMode.Circular);
+        var expected = new float[] { 2, 3, 1, 2, 3, 1, 2 };
+        AssertClose(expected, output.AsSpan().ToArray());
+    }
+
+    // ------------------------------------------------------------------
+    // GridSample (extended)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void GridSample_Bilinear_Zeros_CentreSamplesInputCentre()
+    {
+        // 2×2 NHWC input, sample at centre.
+        var input = new Tensor<float>(new float[] { 1, 2, 3, 4 }, new[] { 1, 2, 2, 1 });
+        // grid at normalised (0, 0) — that's the centre, interpolates all four corners equally.
+        var grid = new Tensor<float>(new float[] { 0f, 0f }, new[] { 1, 1, 1, 2 });
+        var output = _cpu.GridSample(input, grid, GridSampleMode.Bilinear, GridSamplePadding.Zeros, alignCorners: false);
+        // align_corners=false centre maps to pixel coord (0.5, 0.5) — that's
+        // the corner between the 4 pixels — equal weights → mean(1,2,3,4) = 2.5.
+        Assert.Equal(2.5f, output.AsSpan()[0], 3);
+    }
+
+    [Fact]
+    public void GridSample_Nearest_OutOfRangeWithZerosPadding()
+    {
+        var input = new Tensor<float>(new float[] { 1, 2, 3, 4 }, new[] { 1, 2, 2, 1 });
+        // (2, 2) normalised is way outside [-1, 1], padding=Zeros → 0.
+        var grid = new Tensor<float>(new float[] { 2f, 2f }, new[] { 1, 1, 1, 2 });
+        var output = _cpu.GridSample(input, grid, GridSampleMode.Nearest, GridSamplePadding.Zeros, alignCorners: false);
+        Assert.Equal(0f, output.AsSpan()[0]);
+    }
+
+    [Fact]
+    public void GridSample_Nearest_OutOfRangeWithBorderPadding()
+    {
+        var input = new Tensor<float>(new float[] { 1, 2, 3, 4 }, new[] { 1, 2, 2, 1 });
+        var grid = new Tensor<float>(new float[] { 2f, 2f }, new[] { 1, 1, 1, 2 });
+        // padding=Border should clamp to the nearest corner — here pixel (1, 1) = 4.
+        var output = _cpu.GridSample(input, grid, GridSampleMode.Nearest, GridSamplePadding.Border, alignCorners: false);
+        Assert.Equal(4f, output.AsSpan()[0]);
+    }
+
+    // ------------------------------------------------------------------
+    // AffineGrid3D
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void AffineGrid3D_Identity_ProducesCenteredGrid()
+    {
+        // Identity affine: last row all zero, rotation part = 3x3 identity.
+        var theta = new Tensor<float>(new float[] {
+            1, 0, 0, 0,
+            0, 1, 0, 0,
+            0, 0, 1, 0,
+        }, new[] { 1, 3, 4 });
+        var grid = _cpu.AffineGrid3D(theta, 2, 2, 2, alignCorners: true);
+        // With D=H=W=2 and align_corners=true, coords hit the corners → each
+        // output location returns exactly (±1, ±1, ±1).
+        Assert.Equal(new[] { 1, 2, 2, 2, 3 }, grid.Shape.ToArray());
+        var g = grid.AsSpan();
+        // Last element (d=1, h=1, w=1) should be (1, 1, 1).
+        int tail = g.Length - 3;
+        Assert.Equal(1f, g[tail]);
+        Assert.Equal(1f, g[tail + 1]);
+        Assert.Equal(1f, g[tail + 2]);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Image/ImageCodecTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Image/ImageCodecTests.cs
@@ -1,0 +1,88 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Tests for the image codec surface (Issue #217 tail). PNG is pure
+// managed so tested here; JPEG / WebP are native-bound and their
+// decode/encode paths throw PlatformNotSupportedException when
+// libjpeg-turbo / libwebp aren't present — we only verify that the
+// error path surfaces clearly.
+
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Image;
+
+public class ImageCodecTests
+{
+    private readonly CpuEngine _cpu = new();
+
+    private static Tensor<byte> SyntheticImage(int h, int w, int c)
+    {
+        var data = new byte[h * w * c];
+        for (int y = 0; y < h; y++)
+        for (int x = 0; x < w; x++)
+        for (int k = 0; k < c; k++)
+            data[(y * w + x) * c + k] = (byte)((y * 17 + x * 31 + k * 97) & 0xFF);
+        return new Tensor<byte>(data, new[] { h, w, c });
+    }
+
+    [Theory]
+    [InlineData(1)]  // grey
+    [InlineData(3)]  // RGB
+    [InlineData(4)]  // RGBA
+    public void Png_RoundtripMatchesOriginal(int channels)
+    {
+        var original = SyntheticImage(17, 23, channels);
+        var encoded = _cpu.ImageEncode(original, ImageFormat.Png);
+        // Encoded stream must start with the PNG 8-byte signature.
+        byte[] sig = { 137, 80, 78, 71, 13, 10, 26, 10 };
+        for (int i = 0; i < sig.Length; i++) Assert.Equal(sig[i], encoded[i]);
+
+        var decoded = _cpu.ImageDecode(encoded);
+        Assert.Equal(original.Shape.ToArray(), decoded.Shape.ToArray());
+        var o = original.AsSpan();
+        var d = decoded.AsSpan();
+        Assert.Equal(o.Length, d.Length);
+        for (int i = 0; i < o.Length; i++) Assert.Equal(o[i], d[i]);
+    }
+
+    [Fact]
+    public void ImageDecode_AutoDetectsPng()
+    {
+        var img = SyntheticImage(5, 7, 3);
+        var encoded = _cpu.ImageEncode(img, ImageFormat.Png);
+        // No format argument — should auto-detect from magic bytes.
+        var decoded = _cpu.ImageDecode(encoded);
+        Assert.Equal(new[] { 5, 7, 3 }, decoded.Shape.ToArray());
+    }
+
+    [Fact]
+    public void ImageDecode_Jpeg_NativeMissingThrowsInformative()
+    {
+        // Pass enough bytes past the short-input guard so we reach the
+        // actual native decoder (either PlatformNotSupported when the
+        // library isn't installed, or InvalidDataException from a bogus
+        // stream when it is).
+        var bytes = new byte[32];
+        bytes[0] = 0xFF; bytes[1] = 0xD8; bytes[2] = 0xFF; bytes[3] = 0xE0;
+        var ex = Assert.ThrowsAny<Exception>(() => _cpu.ImageDecode(bytes));
+        // Either PlatformNotSupportedException (lib missing) or
+        // InvalidDataException (lib present, bogus bytes) is acceptable —
+        // we just need a clear, reached error.
+        Assert.True(ex is PlatformNotSupportedException || ex is System.IO.InvalidDataException
+                    || ex is InvalidOperationException,
+            $"unexpected exception type: {ex.GetType().Name}: {ex.Message}");
+    }
+
+    [Fact]
+    public void ImageEncode_RejectsUnsupportedChannelCount()
+    {
+        var weird = new Tensor<byte>(new byte[2 * 2 * 5], new[] { 2, 2, 5 });
+        Assert.Throws<ArgumentException>(() => _cpu.ImageEncode(weird, ImageFormat.Png));
+    }
+
+    [Fact]
+    public void ImageDecode_RejectsTooShortInput()
+    {
+        Assert.Throws<ArgumentException>(() => _cpu.ImageDecode(new byte[4]));
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/RoiAudio/RoiAudioOpsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/RoiAudio/RoiAudioOpsTests.cs
@@ -92,8 +92,11 @@ public class RoiAudioOpsTests
     public void MuLaw_EncodeDecodeRoundtrip()
     {
         var input = new Tensor<float>(new float[] { 0f, 0.1f, -0.1f, 0.5f, -0.5f, 0.99f, -0.99f }, new[] { 7 });
-        var enc = _cpu.MuLawEncoding(input);
-        var dec = _cpu.MuLawDecoding(enc);
+        Tensor<int> enc = _cpu.MuLawEncoding(input);
+        // Encoded codes must be int in [0, 255] — verify both type and range.
+        foreach (int code in enc.AsSpan())
+            Assert.InRange(code, 0, 255);
+        var dec = _cpu.MuLawDecoding<float>(enc);
         var orig = input.AsSpan();
         var back = dec.AsSpan();
         for (int i = 0; i < orig.Length; i++)

--- a/tests/AiDotNet.Tensors.Tests/Engines/RoiAudio/RoiAudioOpsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/RoiAudio/RoiAudioOpsTests.cs
@@ -1,0 +1,145 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// CPU reference tests for the tail of Issue #217: RoI family + audio
+// primitives. Ground-truth values computed against torchvision 0.15 /
+// torchaudio 2.0 semantics.
+
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.RoiAudio;
+
+public class RoiAudioOpsTests
+{
+    private readonly CpuEngine _cpu = new();
+
+    private static Tensor<float> Arange(int n, float start = 0f)
+    {
+        var d = new float[n];
+        for (int i = 0; i < n; i++) d[i] = start + i;
+        return new Tensor<float>(d, new[] { n });
+    }
+
+    // ------------------------------------------------------------------
+    // RoI
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void RoIAlign_FullBox_MatchesAverage()
+    {
+        // [1, 1, 4, 4] image, box covers whole image, output 1x1 must
+        // equal the whole-image average.
+        var img = Arange(16);
+        img = new Tensor<float>(img.AsSpan().ToArray(), new[] { 1, 1, 4, 4 });
+        var boxes = new Tensor<float>(new float[] { 0, 0, 0, 3, 3 }, new[] { 1, 5 });
+        var output = _cpu.RoIAlign(img, boxes, 1, 1, 1.0f, samplingRatio: 2, aligned: false);
+        // torchvision's RoIAlign(output_size=1, sampling_ratio=2, aligned=False)
+        // samples at (0.75, 0.75), (0.75, 2.25), (2.25, 0.75), (2.25, 2.25)
+        // with bilinear, then averages. Result ≈ 7.5.
+        Assert.Equal(7.5f, output.AsSpan()[0], 2);
+    }
+
+    [Fact]
+    public void RoIPool_UnitBox_ReturnsMax()
+    {
+        // [1,1,3,3] image, box that covers exactly pixel (1,1) — output 1x1 = max = 4.
+        var img = new Tensor<float>(new float[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 }, new[] { 1, 1, 3, 3 });
+        var boxes = new Tensor<float>(new float[] { 0, 1, 1, 1, 1 }, new[] { 1, 5 });
+        var output = _cpu.RoIPool(img, boxes, 1, 1, 1.0f);
+        Assert.Equal(5f, output.AsSpan()[0]);
+    }
+
+    [Fact]
+    public void RoIAlign_EmptyBoxList_ReturnsEmpty()
+    {
+        var img = new Tensor<float>(new float[4], new[] { 1, 1, 2, 2 });
+        var boxes = new Tensor<float>(new float[0], new[] { 0, 5 });
+        var output = _cpu.RoIAlign(img, boxes, 2, 2, 1.0f, 2, false);
+        Assert.Equal(new[] { 0, 1, 2, 2 }, output.Shape.ToArray());
+    }
+
+    // ------------------------------------------------------------------
+    // AmplitudeToDB
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void AmplitudeToDB_BasicFormula()
+    {
+        var input = new Tensor<float>(new float[] { 1f, 0.5f, 0.1f }, new[] { 3 });
+        var output = _cpu.AmplitudeToDB(input);
+        var o = output.AsSpan();
+        // 20 * log10(1) = 0, 20 * log10(0.5) ≈ -6.02, 20 * log10(0.1) = -20
+        Assert.Equal(0f, o[0], 2);
+        Assert.InRange(o[1], -6.1f, -5.9f);
+        Assert.Equal(-20f, o[2], 2);
+    }
+
+    [Fact]
+    public void AmplitudeToDB_TopDb_ClipsFloor()
+    {
+        var input = new Tensor<float>(new float[] { 1f, 1e-5f }, new[] { 2 });
+        var output = _cpu.AmplitudeToDB(input, topDb: 80f).AsSpan();
+        // Peak is 0 dB (from 1.0). topDb=80 → floor at -80 dB. The 1e-5 value
+        // (-100 dB) should be clipped to -80.
+        Assert.Equal(-80f, output[1], 2);
+    }
+
+    // ------------------------------------------------------------------
+    // MuLaw
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void MuLaw_EncodeDecodeRoundtrip()
+    {
+        var input = new Tensor<float>(new float[] { 0f, 0.1f, -0.1f, 0.5f, -0.5f, 0.99f, -0.99f }, new[] { 7 });
+        var enc = _cpu.MuLawEncoding(input);
+        var dec = _cpu.MuLawDecoding(enc);
+        var orig = input.AsSpan();
+        var back = dec.AsSpan();
+        for (int i = 0; i < orig.Length; i++)
+        {
+            // μ-law is quantising, not lossless. Tolerance ~1/256.
+            Assert.True(Math.Abs(orig[i] - back[i]) < 0.01f,
+                $"[{i}] orig={orig[i]}, roundtrip={back[i]}");
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // ComputeDeltas
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void ComputeDeltas_LinearRamp_ConstantSlope()
+    {
+        // For a linear ramp f[t]=t the derivative should be constant = 1 in
+        // the interior (edge effects aside).
+        var input = Arange(10);
+        input = new Tensor<float>(input.AsSpan().ToArray(), new[] { 10 });
+        var d = _cpu.ComputeDeltas(input, winLength: 5).AsSpan();
+        // Interior (index 2..7) should equal 1.
+        for (int i = 2; i <= 7; i++)
+            Assert.Equal(1f, d[i], 3);
+    }
+
+    // ------------------------------------------------------------------
+    // Resample
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Resample_SameRate_IsIdentity()
+    {
+        var input = Arange(8);
+        var output = _cpu.Resample(input, 16000, 16000);
+        var o = output.AsSpan();
+        var i = input.AsSpan();
+        for (int k = 0; k < o.Length; k++) Assert.Equal(i[k], o[k], 5);
+    }
+
+    [Fact]
+    public void Resample_Upsample2x_DoublesLength()
+    {
+        var input = Arange(8);
+        var output = _cpu.Resample(input, 8000, 16000);
+        Assert.Equal(16, output.Shape[0]);
+    }
+}


### PR DESCRIPTION
Closes #217.

Delivers the full Issue #217 scope: every op across CPU + all 6 GPU backends (CUDA, HIP, OpenCL, Metal, Vulkan, WebGPU) plus image codec I/O. Also folds in the orphaned backward-kernel + CodeRabbit fixes from PR #236 that didn't make it into the merged commit.

## Scope

### Geometry / sampling (CPU + 6 GPU backends)
- **Interpolate / InterpolateByScale** — 6 modes (Nearest, Linear, Bilinear, Bicubic, Trilinear, Area) × 1D/2D/3D. GPU covers the 4D NCHW × {Nearest, Bilinear, Bicubic, Area} surface; 1D/3D fall through to CPU.
- **PadNd** — 4 modes (Constant, Reflect, Replicate, Circular) on any rank. GPU covers 4D NCHW with all 4 modes.
- **GridSample (extended overload)** — `(input, grid, mode, padding, alignCorners)` with 3 modes × 3 padding modes × `alignCorners` flag.
- **AffineGrid3D** — `[N, 3, 4]` theta → `[N, D, H, W, 3]` grid.

### Vision RoI (CPU + 6 GPU backends)
- **RoIAlign + RoIPool** — torchvision parity including `aligned` and `samplingRatio` params.
- **PsRoIAlign + PsRoIPool** — R-FCN position-sensitive variants.

### Audio primitives (CPU + 6 GPU backends for element-wise/windowed ops)
- **AmplitudeToDB, MuLawEncoding, MuLawDecoding, ComputeDeltas, Resample** — native GPU kernels on all 6 backends.
- **Spectrogram, PitchShift, TimeStretch** — managed, composing the existing GPU-accelerated STFT from #212.

### IoU family backward (CPU + 6 GPU backends)
- BoxIou, GIoU, DIoU, CIoU backward with atomics-free two-kernel split (portable to WebGPU which has no `atomic<f32>`).
- Autodiff wired through `BackwardFunctions<T>` + `DifferentiableOps.RecordBinary`.

### Image I/O
- **PNG**: pure-managed encoder + decoder (CRC32, Adler32, zlib-wrapped DEFLATE, all 5 filter types).
- **JPEG**: P/Invoke to `libjpeg-turbo`'s TurboJPEG API (`tjInitDecompress` / `tjDecompress2` / `tjCompress2`).
- **WebP**: P/Invoke to `libwebp` (`WebPDecodeRGBA` / `WebPEncodeRGBA`).
- Magic-byte format auto-detection; missing native libs surface as `PlatformNotSupportedException` with install instructions.

### CodeRabbit fixes from #236 (folded in)
- argmin wording in `OpRegistry`
- integer-T silent-corruption guard in `BoxConvert` + IoU family
- `BatchedNms` max_coord seed bug (fixed via span = max − min + 1)
- IoU docs corrected to "Differentiable"
- `MasksToBoxes` output type decoupled from mask storage (`Tensor<int>`)

## Test plan
- [x] Multi-TFM build (net471 + net10.0), 0 warnings
- [x] 62 CPU tests pass (detection + geometry + RoI+audio + image codec + IoU backward)
- [x] 22 GPU parity tests skip cleanly without GPU hardware
- [x] Existing 23 `BoxOpsTests` still pass
- [x] PNG roundtrip exact across 1/3/4 channels
- [x] Numeric-gradient check for all 4 IoU backward variants