### PR TITLE
feat(hrr): vectorized HRR binding ops — 5 new IEngine kernels (closes #248)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -33830,62 +33830,369 @@ public partial class CpuEngine : ITensorLevelEngine
     }
 
     // ─── HRR binding primitives (issue #248) ─────────────────────────
-    // See Simd/SimdHrrKernels.cs for the kernel implementations. The
-    // CpuEngine overrides are thin wrappers — they just forward to the
-    // kernel. No GraphMode recording, no autograd hooks: these are the
-    // eager split-Re/Im path used by the HRE research campaign to avoid
-    // the per-call allocation churn that blocked cycle 12 at scale.
+    // Generic on T so end users work against a consistent IEngine<T>
+    // surface (same pattern as the rest of the engine). Internal
+    // dispatch uses typeof(T) checks to hit the float / double AVX2+FMA
+    // kernels; non-specialised T drops into a scalar numeric-ops loop.
+    // No GraphMode / autograd hooks — these are eager span-based ops,
+    // so callers that need gradients keep using NativeComplexMultiply
+    // and the rest of the Tensor-returning complex family.
+
+    /// <summary>
+    /// Reinterpret a <c>ReadOnlySpan&lt;T&gt;</c> as a <c>ReadOnlySpan&lt;TTo&gt;</c>.
+    /// Only safe after the caller verifies <c>typeof(T) == typeof(TTo)</c>;
+    /// sizeof(T) must equal sizeof(TTo). The IEngine method signatures don't
+    /// (and shouldn't) declare <c>where T : struct</c>, so this helper sidesteps
+    /// <see cref="System.Runtime.InteropServices.MemoryMarshal.Cast"/>'s struct
+    /// constraint via <see cref="Unsafe.As"/>.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static ReadOnlySpan<TTo> ReinterpretAs<TTo>(ReadOnlySpan<TTo> self) where TTo : struct => self;
+
+    private static class HrrSpanReinterpret<T>
+    {
+        // Parameterised helpers keep the generic-method call sites readable
+        // (no long unsafe-dereference chains) while the body compiles to a
+        // direct Span<T> → Span<TTo> reinterpret when the caller has already
+        // guarded on typeof(T) == typeof(TTo). Mirrors the pattern in
+        // NativeComplexFFTSpan: use MemoryMarshal.CreateSpan on NET5+ (zero
+        // alloc), drop to an element-by-element copy on net471 where
+        // CreateSpan isn't available.
+#if NET5_0_OR_GREATER
+        internal static ReadOnlySpan<double> AsDouble(ReadOnlySpan<T> s)
+        {
+            ref T head = ref System.Runtime.InteropServices.MemoryMarshal.GetReference(s);
+            return System.Runtime.InteropServices.MemoryMarshal.CreateReadOnlySpan(
+                ref Unsafe.As<T, double>(ref head), s.Length);
+        }
+        internal static Span<double> AsDouble(Span<T> s)
+        {
+            ref T head = ref System.Runtime.InteropServices.MemoryMarshal.GetReference(s);
+            return System.Runtime.InteropServices.MemoryMarshal.CreateSpan(
+                ref Unsafe.As<T, double>(ref head), s.Length);
+        }
+        internal static ReadOnlySpan<float> AsFloat(ReadOnlySpan<T> s)
+        {
+            ref T head = ref System.Runtime.InteropServices.MemoryMarshal.GetReference(s);
+            return System.Runtime.InteropServices.MemoryMarshal.CreateReadOnlySpan(
+                ref Unsafe.As<T, float>(ref head), s.Length);
+        }
+        internal static Span<float> AsFloat(Span<T> s)
+        {
+            ref T head = ref System.Runtime.InteropServices.MemoryMarshal.GetReference(s);
+            return System.Runtime.InteropServices.MemoryMarshal.CreateSpan(
+                ref Unsafe.As<T, float>(ref head), s.Length);
+        }
+#else
+        // net471: no CreateSpan — the caller must fall through to the
+        // generic scalar path. These stubs should never be hit at runtime
+        // because the typeof(T) guard above keeps the fast path out of
+        // reach on net471.
+        internal static ReadOnlySpan<double> AsDouble(ReadOnlySpan<T> s)
+            => throw new PlatformNotSupportedException("net471 cannot zero-copy reinterpret spans.");
+        internal static Span<double> AsDouble(Span<T> s)
+            => throw new PlatformNotSupportedException("net471 cannot zero-copy reinterpret spans.");
+        internal static ReadOnlySpan<float> AsFloat(ReadOnlySpan<T> s)
+            => throw new PlatformNotSupportedException("net471 cannot zero-copy reinterpret spans.");
+        internal static Span<float> AsFloat(Span<T> s)
+            => throw new PlatformNotSupportedException("net471 cannot zero-copy reinterpret spans.");
+#endif
+    }
 
     /// <inheritdoc />
-    public virtual void NativeComplexPointwiseMultiplyDouble(
-        ReadOnlySpan<double> aRe, ReadOnlySpan<double> aIm,
-        ReadOnlySpan<double> bRe, ReadOnlySpan<double> bIm,
-        Span<double> cRe, Span<double> cIm,
+    public virtual void NativeComplexPointwiseMultiply<T>(
+        ReadOnlySpan<T> aRe, ReadOnlySpan<T> aIm,
+        ReadOnlySpan<T> bRe, ReadOnlySpan<T> bIm,
+        Span<T> cRe, Span<T> cIm,
         bool conjugateB = false)
     {
-        Simd.SimdComplexKernels.ComplexMultiplyDouble(aRe, aIm, bRe, bIm, cRe, cIm, conjugateB);
+        int n = aRe.Length;
+        if (aIm.Length != n || bRe.Length != n || bIm.Length != n || cRe.Length != n || cIm.Length != n)
+            throw new ArgumentException(
+                "All six spans must have identical length for NativeComplexPointwiseMultiply.");
+
+#if NET5_0_OR_GREATER
+        if (typeof(T) == typeof(double))
+        {
+            Simd.SimdComplexKernels.ComplexMultiplyDouble(
+                HrrSpanReinterpret<T>.AsDouble(aRe),
+                HrrSpanReinterpret<T>.AsDouble(aIm),
+                HrrSpanReinterpret<T>.AsDouble(bRe),
+                HrrSpanReinterpret<T>.AsDouble(bIm),
+                HrrSpanReinterpret<T>.AsDouble(cRe),
+                HrrSpanReinterpret<T>.AsDouble(cIm),
+                conjugateB);
+            return;
+        }
+        if (typeof(T) == typeof(float))
+        {
+            Simd.SimdComplexKernels.ComplexMultiplyFloatConjugatable(
+                HrrSpanReinterpret<T>.AsFloat(aRe),
+                HrrSpanReinterpret<T>.AsFloat(aIm),
+                HrrSpanReinterpret<T>.AsFloat(bRe),
+                HrrSpanReinterpret<T>.AsFloat(bIm),
+                HrrSpanReinterpret<T>.AsFloat(cRe),
+                HrrSpanReinterpret<T>.AsFloat(cIm),
+                conjugateB);
+            return;
+        }
+#endif
+
+        // Generic scalar fallback for non-float/double T (Half, BFloat16,
+        // custom numeric types). Also hit on net471 where the span-reinterpret
+        // fast path is unavailable. Uses INumericOperations so any
+        // user-defined numeric type is supported.
+        var ops = MathHelper.GetNumericOperations<T>();
+        if (conjugateB)
+        {
+            for (int i = 0; i < n; i++)
+            {
+                T ar = aRe[i], ai = aIm[i], br = bRe[i], bi = bIm[i];
+                cRe[i] = ops.Add(ops.Multiply(ar, br), ops.Multiply(ai, bi));
+                cIm[i] = ops.Subtract(ops.Multiply(ai, br), ops.Multiply(ar, bi));
+            }
+        }
+        else
+        {
+            for (int i = 0; i < n; i++)
+            {
+                T ar = aRe[i], ai = aIm[i], br = bRe[i], bi = bIm[i];
+                cRe[i] = ops.Subtract(ops.Multiply(ar, br), ops.Multiply(ai, bi));
+                cIm[i] = ops.Add(ops.Multiply(ar, bi), ops.Multiply(ai, br));
+            }
+        }
     }
 
     /// <inheritdoc />
-    public virtual void NativeGatherDouble(
-        ReadOnlySpan<double> input,
+    public virtual void NativeGather<T>(
+        ReadOnlySpan<T> input,
         ReadOnlySpan<int> indices,
-        Span<double> output)
+        Span<T> output)
     {
-        Simd.SimdHrrKernels.GatherDouble(input, indices, output);
+        // Gather does no arithmetic on the data so it's truly generic —
+        // one implementation handles every T. The kernel already bounds-
+        // checks indices and enforces length consistency.
+#if NET5_0_OR_GREATER
+        if (typeof(T) == typeof(double))
+        {
+            Simd.SimdHrrKernels.GatherDouble(
+                HrrSpanReinterpret<T>.AsDouble(input),
+                indices,
+                HrrSpanReinterpret<T>.AsDouble(output));
+            return;
+        }
+        if (typeof(T) == typeof(float))
+        {
+            Simd.SimdHrrKernels.GatherFloat(
+                HrrSpanReinterpret<T>.AsFloat(input),
+                indices,
+                HrrSpanReinterpret<T>.AsFloat(output));
+            return;
+        }
+#endif
+
+        int n = indices.Length;
+        if (output.Length != n)
+            throw new ArgumentException(
+                $"Output length ({output.Length}) must equal indices length ({indices.Length}).");
+        int inputLen = input.Length;
+        for (int i = 0; i < n; i++)
+        {
+            int idx = indices[i];
+            if ((uint)idx >= (uint)inputLen)
+                throw new ArgumentOutOfRangeException(nameof(indices),
+                    $"Index {idx} at position {i} is outside input range [0, {inputLen}).");
+            output[i] = input[idx];
+        }
     }
 
     /// <inheritdoc />
-    public virtual void NativeUnitPhaseCodebookDouble(
-        Span<double> outRe, Span<double> outIm,
+    public virtual void NativeUnitPhaseCodebook<T>(
+        Span<T> outRe, Span<T> outIm,
         int seed, int V, int D,
         bool kPsk = false, int k = 0)
     {
-        Simd.SimdHrrKernels.UnitPhaseCodebookDouble(outRe, outIm, seed, V, D, kPsk, k);
+#if NET5_0_OR_GREATER
+        if (typeof(T) == typeof(double))
+        {
+            Simd.SimdHrrKernels.UnitPhaseCodebookDouble(
+                HrrSpanReinterpret<T>.AsDouble(outRe),
+                HrrSpanReinterpret<T>.AsDouble(outIm),
+                seed, V, D, kPsk, k);
+            return;
+        }
+        if (typeof(T) == typeof(float))
+        {
+            Simd.SimdHrrKernels.UnitPhaseCodebookFloat(
+                HrrSpanReinterpret<T>.AsFloat(outRe),
+                HrrSpanReinterpret<T>.AsFloat(outIm),
+                seed, V, D, kPsk, k);
+            return;
+        }
+#endif
+
+        // Generic fallback: generate in double, convert to T at the
+        // boundary — simplest implementation that keeps the numerics
+        // independent of T's precision. Also handles all T on net471
+        // where the span-reinterpret fast path is unavailable.
+        long total = (long)V * D;
+        if (total > int.MaxValue)
+            throw new ArgumentException($"V*D = {total} exceeds int.MaxValue.");
+        int n = (int)total;
+        if (outRe.Length != n || outIm.Length != n)
+            throw new ArgumentException(
+                $"outRe ({outRe.Length}) and outIm ({outIm.Length}) must both have length V*D = {n}.");
+        var tempR = new double[n];
+        var tempI = new double[n];
+        Simd.SimdHrrKernels.UnitPhaseCodebookDouble(tempR, tempI, seed, V, D, kPsk, k);
+        var ops = MathHelper.GetNumericOperations<T>();
+        for (int i = 0; i < n; i++)
+        {
+            outRe[i] = ops.FromDouble(tempR[i]);
+            outIm[i] = ops.FromDouble(tempI[i]);
+        }
     }
 
     /// <inheritdoc />
-    public virtual void NativeComplexPhaseCoherenceDecodeDouble(
-        ReadOnlySpan<double> codesRe, ReadOnlySpan<double> codesIm,
-        ReadOnlySpan<double> queryRe, ReadOnlySpan<double> queryIm,
-        Span<double> scores,
+    public virtual void NativeComplexPhaseCoherenceDecode<T>(
+        ReadOnlySpan<T> codesRe, ReadOnlySpan<T> codesIm,
+        ReadOnlySpan<T> queryRe, ReadOnlySpan<T> queryIm,
+        Span<T> scores,
         int V, int D)
     {
-        Simd.SimdHrrKernels.PhaseCoherenceDecodeDouble(
-            codesRe, codesIm, queryRe, queryIm, scores, V, D);
+#if NET5_0_OR_GREATER
+        if (typeof(T) == typeof(double))
+        {
+            Simd.SimdHrrKernels.PhaseCoherenceDecodeDouble(
+                HrrSpanReinterpret<T>.AsDouble(codesRe),
+                HrrSpanReinterpret<T>.AsDouble(codesIm),
+                HrrSpanReinterpret<T>.AsDouble(queryRe),
+                HrrSpanReinterpret<T>.AsDouble(queryIm),
+                HrrSpanReinterpret<T>.AsDouble(scores),
+                V, D);
+            return;
+        }
+        if (typeof(T) == typeof(float))
+        {
+            Simd.SimdHrrKernels.PhaseCoherenceDecodeFloat(
+                HrrSpanReinterpret<T>.AsFloat(codesRe),
+                HrrSpanReinterpret<T>.AsFloat(codesIm),
+                HrrSpanReinterpret<T>.AsFloat(queryRe),
+                HrrSpanReinterpret<T>.AsFloat(queryIm),
+                HrrSpanReinterpret<T>.AsFloat(scores),
+                V, D);
+            return;
+        }
+#endif
+
+        // Generic scalar fallback (also handles all T on net471).
+        long total = (long)V * D;
+        if (total > int.MaxValue)
+            throw new ArgumentException($"V*D = {total} exceeds int.MaxValue.");
+        int nCodes = (int)total;
+        if (codesRe.Length != nCodes || codesIm.Length != nCodes)
+            throw new ArgumentException(
+                $"codesRe ({codesRe.Length}) and codesIm ({codesIm.Length}) must both have length V*D = {nCodes}.");
+        if (queryRe.Length != D || queryIm.Length != D)
+            throw new ArgumentException(
+                $"queryRe ({queryRe.Length}) and queryIm ({queryIm.Length}) must both have length D = {D}.");
+        if (scores.Length != V)
+            throw new ArgumentException($"scores length ({scores.Length}) must equal V = {V}.");
+
+        var ops = MathHelper.GetNumericOperations<T>();
+        for (int v = 0; v < V; v++)
+        {
+            int rowOff = v * D;
+            T acc = ops.Zero;
+            for (int d = 0; d < D; d++)
+            {
+                acc = ops.Add(acc, ops.Add(
+                    ops.Multiply(codesRe[rowOff + d], queryRe[d]),
+                    ops.Multiply(codesIm[rowOff + d], queryIm[d])));
+            }
+            scores[v] = acc;
+        }
     }
 
     /// <inheritdoc />
-    public virtual void NativeHRRBindAccumulateDouble(
-        ReadOnlySpan<double> keyCodeRe, ReadOnlySpan<double> keyCodeIm,
-        ReadOnlySpan<double> valPermCodeRe, ReadOnlySpan<double> valPermCodeIm,
+    public virtual void NativeHRRBindAccumulate<T>(
+        ReadOnlySpan<T> keyCodeRe, ReadOnlySpan<T> keyCodeIm,
+        ReadOnlySpan<T> valPermCodeRe, ReadOnlySpan<T> valPermCodeIm,
         ReadOnlySpan<int> keyIds, ReadOnlySpan<int> valIds,
-        Span<double> memoryRe, Span<double> memoryIm,
+        Span<T> memoryRe, Span<T> memoryIm,
         int D)
     {
-        Simd.SimdHrrKernels.HRRBindAccumulateDouble(
-            keyCodeRe, keyCodeIm, valPermCodeRe, valPermCodeIm,
-            keyIds, valIds, memoryRe, memoryIm, D);
+#if NET5_0_OR_GREATER
+        if (typeof(T) == typeof(double))
+        {
+            Simd.SimdHrrKernels.HRRBindAccumulateDouble(
+                HrrSpanReinterpret<T>.AsDouble(keyCodeRe),
+                HrrSpanReinterpret<T>.AsDouble(keyCodeIm),
+                HrrSpanReinterpret<T>.AsDouble(valPermCodeRe),
+                HrrSpanReinterpret<T>.AsDouble(valPermCodeIm),
+                keyIds, valIds,
+                HrrSpanReinterpret<T>.AsDouble(memoryRe),
+                HrrSpanReinterpret<T>.AsDouble(memoryIm),
+                D);
+            return;
+        }
+        if (typeof(T) == typeof(float))
+        {
+            Simd.SimdHrrKernels.HRRBindAccumulateFloat(
+                HrrSpanReinterpret<T>.AsFloat(keyCodeRe),
+                HrrSpanReinterpret<T>.AsFloat(keyCodeIm),
+                HrrSpanReinterpret<T>.AsFloat(valPermCodeRe),
+                HrrSpanReinterpret<T>.AsFloat(valPermCodeIm),
+                keyIds, valIds,
+                HrrSpanReinterpret<T>.AsFloat(memoryRe),
+                HrrSpanReinterpret<T>.AsFloat(memoryIm),
+                D);
+            return;
+        }
+#endif
+
+        // Generic scalar fallback (also handles all T on net471).
+        if (D < 0) throw new ArgumentOutOfRangeException(nameof(D));
+        if (memoryRe.Length != D || memoryIm.Length != D)
+            throw new ArgumentException(
+                $"memoryRe ({memoryRe.Length}) and memoryIm ({memoryIm.Length}) must both have length D = {D}.");
+        if (keyCodeRe.Length != keyCodeIm.Length)
+            throw new ArgumentException("keyCodeRe and keyCodeIm must have matching length.");
+        if (valPermCodeRe.Length != valPermCodeIm.Length)
+            throw new ArgumentException("valPermCodeRe and valPermCodeIm must have matching length.");
+        if (keyIds.Length != valIds.Length)
+            throw new ArgumentException(
+                $"keyIds ({keyIds.Length}) and valIds ({valIds.Length}) must have matching length.");
+        if (keyCodeRe.Length % D != 0)
+            throw new ArgumentException(
+                $"keyCode length ({keyCodeRe.Length}) must be divisible by D = {D}.");
+        if (valPermCodeRe.Length % D != 0)
+            throw new ArgumentException(
+                $"valPermCode length ({valPermCodeRe.Length}) must be divisible by D = {D}.");
+
+        int nKeys = keyCodeRe.Length / D;
+        int nVals = valPermCodeRe.Length / D;
+        var ops = MathHelper.GetNumericOperations<T>();
+        for (int nn = 0; nn < keyIds.Length; nn++)
+        {
+            int kId = keyIds[nn]; int vId = valIds[nn];
+            if ((uint)kId >= (uint)nKeys)
+                throw new ArgumentOutOfRangeException(nameof(keyIds),
+                    $"keyIds[{nn}] = {kId} is outside [0, {nKeys}).");
+            if ((uint)vId >= (uint)nVals)
+                throw new ArgumentOutOfRangeException(nameof(valIds),
+                    $"valIds[{nn}] = {vId} is outside [0, {nVals}).");
+            int kOff = kId * D, vOff = vId * D;
+            for (int d = 0; d < D; d++)
+            {
+                T ar = keyCodeRe[kOff + d], ai = keyCodeIm[kOff + d];
+                T br = valPermCodeRe[vOff + d], bi = valPermCodeIm[vOff + d];
+                memoryRe[d] = ops.Add(memoryRe[d],
+                    ops.Subtract(ops.Multiply(ar, br), ops.Multiply(ai, bi)));
+                memoryIm[d] = ops.Add(memoryIm[d],
+                    ops.Add(ops.Multiply(ar, bi), ops.Multiply(ai, br)));
+            }
+        }
     }
 
     /// <inheritdoc />

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -34012,6 +34012,14 @@ public partial class CpuEngine : ITensorLevelEngine
         int seed, int V, int D,
         bool kPsk = false, int k = 0)
     {
+        // Phase-based codebook requires continuous arithmetic — integral
+        // T (int, long, etc.) would quantize sin/cos to ±1/0 and silently
+        // break the unit-phase invariant. Reject up front.
+        if (typeof(T) != typeof(float) && typeof(T) != typeof(double))
+            throw new NotSupportedException(
+                $"NativeUnitPhaseCodebook requires T = float or double (got {typeof(T).Name}). " +
+                "Phase-based kernels cannot preserve |c| = 1 for integral element types.");
+
 #if NET5_0_OR_GREATER
         if (typeof(T) == typeof(double))
         {
@@ -34031,10 +34039,11 @@ public partial class CpuEngine : ITensorLevelEngine
         }
 #endif
 
-        // Generic fallback: generate in double, convert to T at the
-        // boundary — simplest implementation that keeps the numerics
-        // independent of T's precision. Also handles all T on net471
-        // where the span-reinterpret fast path is unavailable.
+        // net471 fallback for float/double — the span-reinterpret fast
+        // path isn't available on net471. Generate in a temporary
+        // double buffer, then copy through INumericOperations.FromDouble
+        // which is lossless for double and a safe narrowing for float.
+        // Safe because the type guard above rejects non-floating T.
         long total = (long)V * D;
         if (total > int.MaxValue)
             throw new ArgumentException($"V*D = {total} exceeds int.MaxValue.");

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -33829,6 +33829,65 @@ public partial class CpuEngine : ITensorLevelEngine
         return result;
     }
 
+    // ─── HRR binding primitives (issue #248) ─────────────────────────
+    // See Simd/SimdHrrKernels.cs for the kernel implementations. The
+    // CpuEngine overrides are thin wrappers — they just forward to the
+    // kernel. No GraphMode recording, no autograd hooks: these are the
+    // eager split-Re/Im path used by the HRE research campaign to avoid
+    // the per-call allocation churn that blocked cycle 12 at scale.
+
+    /// <inheritdoc />
+    public virtual void NativeComplexPointwiseMultiplyDouble(
+        ReadOnlySpan<double> aRe, ReadOnlySpan<double> aIm,
+        ReadOnlySpan<double> bRe, ReadOnlySpan<double> bIm,
+        Span<double> cRe, Span<double> cIm,
+        bool conjugateB = false)
+    {
+        Simd.SimdComplexKernels.ComplexMultiplyDouble(aRe, aIm, bRe, bIm, cRe, cIm, conjugateB);
+    }
+
+    /// <inheritdoc />
+    public virtual void NativeGatherDouble(
+        ReadOnlySpan<double> input,
+        ReadOnlySpan<int> indices,
+        Span<double> output)
+    {
+        Simd.SimdHrrKernels.GatherDouble(input, indices, output);
+    }
+
+    /// <inheritdoc />
+    public virtual void NativeUnitPhaseCodebookDouble(
+        Span<double> outRe, Span<double> outIm,
+        int seed, int V, int D,
+        bool kPsk = false, int k = 0)
+    {
+        Simd.SimdHrrKernels.UnitPhaseCodebookDouble(outRe, outIm, seed, V, D, kPsk, k);
+    }
+
+    /// <inheritdoc />
+    public virtual void NativeComplexPhaseCoherenceDecodeDouble(
+        ReadOnlySpan<double> codesRe, ReadOnlySpan<double> codesIm,
+        ReadOnlySpan<double> queryRe, ReadOnlySpan<double> queryIm,
+        Span<double> scores,
+        int V, int D)
+    {
+        Simd.SimdHrrKernels.PhaseCoherenceDecodeDouble(
+            codesRe, codesIm, queryRe, queryIm, scores, V, D);
+    }
+
+    /// <inheritdoc />
+    public virtual void NativeHRRBindAccumulateDouble(
+        ReadOnlySpan<double> keyCodeRe, ReadOnlySpan<double> keyCodeIm,
+        ReadOnlySpan<double> valPermCodeRe, ReadOnlySpan<double> valPermCodeIm,
+        ReadOnlySpan<int> keyIds, ReadOnlySpan<int> valIds,
+        Span<double> memoryRe, Span<double> memoryIm,
+        int D)
+    {
+        Simd.SimdHrrKernels.HRRBindAccumulateDouble(
+            keyCodeRe, keyCodeIm, valPermCodeRe, valPermCodeIm,
+            keyIds, valIds, memoryRe, memoryIm, D);
+    }
+
     /// <inheritdoc />
     public virtual Tensor<Complex<T>> NativeComplexConjugate<T>(Tensor<Complex<T>> a)
     {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -10266,10 +10266,11 @@ public sealed partial class CudaBackend : IAsyncGpuBackend
         if (kPsk && k <= 0)
             throw new ArgumentOutOfRangeException(nameof(k),
                 "k must be positive when kPsk is true.");
+        int n = (int)total;
+        ValidateSplitBuffers(n, nameof(SplitComplexUnitPhaseCodebook), outReal, outImag);
         if (!_kernelCache.TryGetValue("hrr_unit_phase_codebook", out var kernel))
             throw new InvalidOperationException("CUDA kernel not found: hrr_unit_phase_codebook. Register CudaComplexKernels.");
         using var _ = PushContext();
-        int n = (int)total;
         uint grid = (uint)((n + DefaultBlockSize - 1) / DefaultBlockSize);
         IntPtr pOR = outReal.Handle, pOI = outImag.Handle;
         int kPskI = kPsk ? 1 : 0;
@@ -10287,12 +10288,27 @@ public sealed partial class CudaBackend : IAsyncGpuBackend
         int V, int D)
     {
         if (V <= 0 || D <= 0) return;
+        long codeCount = (long)V * D;
+        if (codesReal is null || codesImag is null || queryReal is null || queryImag is null || outScores is null)
+            throw new ArgumentNullException(nameof(codesReal),
+                "All five GPU buffers (codesReal/codesImag/queryReal/queryImag/outScores) must be non-null.");
+        if (codesReal.Size < codeCount || codesImag.Size < codeCount)
+            throw new ArgumentException(
+                $"codes buffers must each hold at least V*D = {codeCount} elements " +
+                $"(got {codesReal.Size}, {codesImag.Size}).");
+        if (queryReal.Size < D || queryImag.Size < D)
+            throw new ArgumentException(
+                $"query buffers must each hold at least D = {D} elements " +
+                $"(got {queryReal.Size}, {queryImag.Size}).");
+        if (outScores.Size < V)
+            throw new ArgumentException(
+                $"outScores must hold at least V = {V} elements (got {outScores.Size}).");
         if (!_kernelCache.TryGetValue("hrr_phase_coherence_decode", out var kernel))
             throw new InvalidOperationException("CUDA kernel not found: hrr_phase_coherence_decode. Register CudaComplexKernels.");
         using var _ = PushContext();
         uint grid = (uint)V;
         int blockSize = Math.Min(DefaultBlockSize, NextPowerOfTwoForReduction(D));
-        int sharedMem = blockSize * sizeof(float);
+        uint sharedMem = (uint)blockSize * sizeof(float);
         IntPtr pCR = codesReal.Handle, pCI = codesImag.Handle;
         IntPtr pQR = queryReal.Handle, pQI = queryImag.Handle;
         IntPtr pOS = outScores.Handle;
@@ -10300,8 +10316,10 @@ public sealed partial class CudaBackend : IAsyncGpuBackend
         args[0] = &pCR; args[1] = &pCI;
         args[2] = &pQR; args[3] = &pQI;
         args[4] = &pOS; args[5] = &V; args[6] = &D;
-        CudaNativeBindings.cuLaunchKernel(kernel, grid, 1, 1, (uint)blockSize, 1, 1,
-            (uint)sharedMem, IntPtr.Zero, (IntPtr)args, IntPtr.Zero);
+        // Route through the shared launch helper so this runs on _stream
+        // and cuLaunchKernel failures are surfaced by CheckCudaResult,
+        // matching the rest of the backend.
+        LaunchKernelWithSharedMem(kernel, grid, (uint)blockSize, sharedMem, args);
     }
 
     /// <inheritdoc/>
@@ -10313,6 +10331,22 @@ public sealed partial class CudaBackend : IAsyncGpuBackend
         int N, int D)
     {
         if (N <= 0 || D <= 0) return;
+        if (keyCodeReal is null || keyCodeImag is null || valPermCodeReal is null || valPermCodeImag is null
+            || keyIds is null || valIds is null || memoryReal is null || memoryImag is null)
+            throw new ArgumentNullException(nameof(keyCodeReal),
+                "All eight GPU buffers must be non-null for SplitComplexHrrBindAccumulate.");
+        if (keyIds.Size < N || valIds.Size < N)
+            throw new ArgumentException(
+                $"ID buffers must each hold at least N = {N} elements " +
+                $"(got keyIds={keyIds.Size}, valIds={valIds.Size}).");
+        if (memoryReal.Size < D || memoryImag.Size < D)
+            throw new ArgumentException(
+                $"Memory buffers must each hold at least D = {D} elements " +
+                $"(got memoryReal={memoryReal.Size}, memoryImag={memoryImag.Size}).");
+        if (keyCodeReal.Size < D || keyCodeImag.Size < D
+            || valPermCodeReal.Size < D || valPermCodeImag.Size < D)
+            throw new ArgumentException(
+                $"Each codebook buffer must hold at least one full row of D = {D} elements.");
         if (!_kernelCache.TryGetValue("hrr_bind_accumulate", out var kernel))
             throw new InvalidOperationException("CUDA kernel not found: hrr_bind_accumulate. Register CudaComplexKernels.");
         using var _ = PushContext();

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -10347,6 +10347,19 @@ public sealed partial class CudaBackend : IAsyncGpuBackend
             || valPermCodeReal.Size < D || valPermCodeImag.Size < D)
             throw new ArgumentException(
                 $"Each codebook buffer must hold at least one full row of D = {D} elements.");
+        // Derive vocabulary sizes from codebook capacities so the
+        // kernel can reject out-of-range ids without reading past
+        // allocated memory — mirrors the CPU path's range check in
+        // NativeHRRBindAccumulate and the guards in Vulkan/WebGPU.
+        long nKeysL = keyCodeReal.Size / D;
+        long nValsL = valPermCodeReal.Size / D;
+        if (nKeysL <= 0 || nValsL <= 0)
+            throw new ArgumentException(
+                $"Codebook buffers must hold at least one full row of D = {D} elements.");
+        if (nKeysL > int.MaxValue || nValsL > int.MaxValue)
+            throw new ArgumentException("Codebook vocabulary size exceeds int.MaxValue.");
+        int nKeys = (int)nKeysL;
+        int nVals = (int)nValsL;
         if (!_kernelCache.TryGetValue("hrr_bind_accumulate", out var kernel))
             throw new InvalidOperationException("CUDA kernel not found: hrr_bind_accumulate. Register CudaComplexKernels.");
         using var _ = PushContext();
@@ -10355,12 +10368,13 @@ public sealed partial class CudaBackend : IAsyncGpuBackend
         IntPtr pVR = valPermCodeReal.Handle, pVI = valPermCodeImag.Handle;
         IntPtr pKId = keyIds.Handle, pVId = valIds.Handle;
         IntPtr pMR = memoryReal.Handle, pMI = memoryImag.Handle;
-        void** args = stackalloc void*[10];
+        void** args = stackalloc void*[12];
         args[0] = &pKR; args[1] = &pKI;
         args[2] = &pVR; args[3] = &pVI;
         args[4] = &pKId; args[5] = &pVId;
         args[6] = &pMR; args[7] = &pMI;
         args[8] = &N; args[9] = &D;
+        args[10] = &nKeys; args[11] = &nVals;
         LaunchKernel(kernel, grid, DefaultBlockSize, args);
     }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -10252,6 +10252,94 @@ public sealed partial class CudaBackend : IAsyncGpuBackend
             (uint)sharedMem, IntPtr.Zero, (IntPtr)args, IntPtr.Zero);
     }
 
+    // ─── HRR binding primitives (issue #248) ────────────────────────
+
+    /// <inheritdoc/>
+    public unsafe void SplitComplexUnitPhaseCodebook(
+        IGpuBuffer outReal, IGpuBuffer outImag,
+        int seed, int V, int D, bool kPsk, int k)
+    {
+        long total = (long)V * D;
+        if (total <= 0) return;
+        if (total > int.MaxValue)
+            throw new ArgumentException($"V*D = {total} exceeds int.MaxValue.");
+        if (kPsk && k <= 0)
+            throw new ArgumentOutOfRangeException(nameof(k),
+                "k must be positive when kPsk is true.");
+        if (!_kernelCache.TryGetValue("hrr_unit_phase_codebook", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: hrr_unit_phase_codebook. Register CudaComplexKernels.");
+        using var _ = PushContext();
+        int n = (int)total;
+        uint grid = (uint)((n + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr pOR = outReal.Handle, pOI = outImag.Handle;
+        int kPskI = kPsk ? 1 : 0;
+        void** args = stackalloc void*[7];
+        args[0] = &pOR; args[1] = &pOI; args[2] = &seed;
+        args[3] = &V; args[4] = &D; args[5] = &kPskI; args[6] = &k;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    /// <inheritdoc/>
+    public unsafe void SplitComplexPhaseCoherenceDecode(
+        IGpuBuffer codesReal, IGpuBuffer codesImag,
+        IGpuBuffer queryReal, IGpuBuffer queryImag,
+        IGpuBuffer outScores,
+        int V, int D)
+    {
+        if (V <= 0 || D <= 0) return;
+        if (!_kernelCache.TryGetValue("hrr_phase_coherence_decode", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: hrr_phase_coherence_decode. Register CudaComplexKernels.");
+        using var _ = PushContext();
+        uint grid = (uint)V;
+        int blockSize = Math.Min(DefaultBlockSize, NextPowerOfTwoForReduction(D));
+        int sharedMem = blockSize * sizeof(float);
+        IntPtr pCR = codesReal.Handle, pCI = codesImag.Handle;
+        IntPtr pQR = queryReal.Handle, pQI = queryImag.Handle;
+        IntPtr pOS = outScores.Handle;
+        void** args = stackalloc void*[7];
+        args[0] = &pCR; args[1] = &pCI;
+        args[2] = &pQR; args[3] = &pQI;
+        args[4] = &pOS; args[5] = &V; args[6] = &D;
+        CudaNativeBindings.cuLaunchKernel(kernel, grid, 1, 1, (uint)blockSize, 1, 1,
+            (uint)sharedMem, IntPtr.Zero, (IntPtr)args, IntPtr.Zero);
+    }
+
+    /// <inheritdoc/>
+    public unsafe void SplitComplexHrrBindAccumulate(
+        IGpuBuffer keyCodeReal, IGpuBuffer keyCodeImag,
+        IGpuBuffer valPermCodeReal, IGpuBuffer valPermCodeImag,
+        IGpuBuffer keyIds, IGpuBuffer valIds,
+        IGpuBuffer memoryReal, IGpuBuffer memoryImag,
+        int N, int D)
+    {
+        if (N <= 0 || D <= 0) return;
+        if (!_kernelCache.TryGetValue("hrr_bind_accumulate", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: hrr_bind_accumulate. Register CudaComplexKernels.");
+        using var _ = PushContext();
+        uint grid = (uint)((D + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr pKR = keyCodeReal.Handle, pKI = keyCodeImag.Handle;
+        IntPtr pVR = valPermCodeReal.Handle, pVI = valPermCodeImag.Handle;
+        IntPtr pKId = keyIds.Handle, pVId = valIds.Handle;
+        IntPtr pMR = memoryReal.Handle, pMI = memoryImag.Handle;
+        void** args = stackalloc void*[10];
+        args[0] = &pKR; args[1] = &pKI;
+        args[2] = &pVR; args[3] = &pVI;
+        args[4] = &pKId; args[5] = &pVId;
+        args[6] = &pMR; args[7] = &pMI;
+        args[8] = &N; args[9] = &D;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    // Round D up to the next power of two, capped at 1024 (max CUDA
+    // block size). Used by the phase-coherence reduce to size the
+    // block-level tree sum.
+    private static int NextPowerOfTwoForReduction(int D)
+    {
+        int bs = 1;
+        while (bs < D && bs < 1024) bs <<= 1;
+        return Math.Max(32, bs);
+    }
+
     /// <inheritdoc/>
     public void SpectralFilter(IGpuBuffer inputReal, IGpuBuffer filterReal, IGpuBuffer filterImag,
         IGpuBuffer outputReal, int batch, int height, int width, int filterSliceCount)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaComplexKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaComplexKernels.cs
@@ -276,12 +276,18 @@ extern ""C"" __global__ void hrr_phase_coherence_decode(
 // own d so no atomics are needed. Coalesced reads within a warp
 // because d varies consecutively and key/val offsets are broadcast
 // (same kId for all threads in a warp at a given n iteration).
+// nKeys / nVals are the vocabulary sizes (codebook row counts); the
+// host passes keyCodeReal.Size / D and valPermCodeReal.Size / D so
+// the kernel can reject out-of-range ids without reading past the
+// codebook. Mirrors the (uint)kId >= (uint)nKeys check in the CPU
+// SIMD implementation and the equivalent guard in the Vulkan/WebGPU
+// shaders.
 extern ""C"" __global__ __launch_bounds__(256) void hrr_bind_accumulate(
     const float* keyCodeReal, const float* keyCodeImag,
     const float* valPermCodeReal, const float* valPermCodeImag,
     const int* keyIds, const int* valIds,
     float* memoryReal, float* memoryImag,
-    int N, int D)
+    int N, int D, int nKeys, int nVals)
 {
     int d = blockIdx.x * blockDim.x + threadIdx.x;
     if (d >= D) return;
@@ -289,8 +295,15 @@ extern ""C"" __global__ __launch_bounds__(256) void hrr_bind_accumulate(
     float accR = memoryReal[d];
     float accI = memoryImag[d];
     for (int n = 0; n < N; n++) {
-        long long kOff = (long long)keyIds[n] * D;
-        long long vOff = (long long)valIds[n] * D;
+        int kId = keyIds[n];
+        int vId = valIds[n];
+        // Unsigned-comparison trick rejects both negative and
+        // too-large indices in one branch; out-of-range pairs
+        // contribute zero (match the CPU path's exception, but
+        // silently — the kernel can't throw).
+        if ((unsigned)kId >= (unsigned)nKeys || (unsigned)vId >= (unsigned)nVals) continue;
+        long long kOff = (long long)kId * D;
+        long long vOff = (long long)vId * D;
         float ar = keyCodeReal[kOff + d];
         float ai = keyCodeImag[kOff + d];
         float br = valPermCodeReal[vOff + d];

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaComplexKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaComplexKernels.cs
@@ -188,24 +188,38 @@ extern ""C"" __global__ void softmax_rows(
 
 // ─── HRR binding primitives (issue #248) ────────────────────────────
 //
-// Deterministic per-cell phase via splitmix64 hash of (seed, cell_idx).
-// Each thread generates its own phase independently — no shared state,
-// no cross-thread sync. Same seed → same codebook across runs; same
-// seed + same (V, D) → identical output. Does NOT match the CPU
-// xorshift64* sequence bit-for-bit (GPU phases are a different
-// uniform sample), which is fine — users don't need cross-device
-// bit-identity on random init.
+// Deterministic per-cell phase via 32-bit Murmur3 fmix hash of
+// (seed, cellIdx). Each thread generates its own phase independently
+// — no shared state, no cross-thread sync.
+//
+// This is the SAME hash used by all six GPU backends (CUDA, HIP,
+// OpenCL, Metal, Vulkan, WebGPU); same seed + same (V, D) ⇒ identical
+// codebook on any GPU. The 32-bit Murmur3 variant is used (rather
+// than the 64-bit splitmix64 this kernel previously used) because
+// WebGPU's WGSL lacks native u64 support; keeping all GPU kernels
+// bit-identical is higher value than the small entropy gain of 64-bit.
+//
+// Does NOT bit-match the CPU xorshift64* sequence — the CPU path is
+// intentionally sequential (fastest on a single thread), while the
+// GPU path must be parallel per-cell. Cross-device bit-identity is
+// not part of the contract; per-backend determinism is.
+__device__ __forceinline__ unsigned int hrr_hash(unsigned int seed_u, unsigned int cell_u)
+{
+    // Murmur3 fmix variant — good-quality uniform 32-bit output.
+    unsigned int z = seed_u * 0x9E3779B9u + cell_u * 0x85EBCA6Bu;
+    z = (z ^ (z >> 16)) * 0x85EBCA6Bu;
+    z = (z ^ (z >> 13)) * 0xC2B2AE35u;
+    z =  z ^ (z >> 16);
+    return z;
+}
+
 __device__ __forceinline__ float hrr_phase_from_cell(int seed, long long cellIdx)
 {
-    unsigned long long z = (unsigned long long)seed * 0x9E3779B97F4A7C15ULL
-                         + (unsigned long long)cellIdx * 0xBF58476D1CE4E5B9ULL;
-    z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;
-    z = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
-    z =  z ^ (z >> 31);
+    unsigned int z = hrr_hash((unsigned int)seed, (unsigned int)cellIdx);
     // Upper 24 bits → float in [0, 1). 24 bits is exact-representable
     // in float32 so the distribution has no rounding artefacts at the
     // top of the range.
-    unsigned int top24 = (unsigned int)(z >> 40);
+    unsigned int top24 = z >> 8;
     return (float)top24 * (1.0f / 16777216.0f) * 6.28318530717958647692f;
 }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaComplexKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaComplexKernels.cs
@@ -12,7 +12,11 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA.Kernels
             "split_complex_phase", "split_complex_from_polar",
             "split_complex_scale", "split_complex_add",
             "split_complex_cross_spectral",
-            "split_complex_topk", "softmax_rows"
+            "split_complex_topk", "softmax_rows",
+            // Issue #248 — HRR binding primitives
+            "hrr_unit_phase_codebook",
+            "hrr_phase_coherence_decode",
+            "hrr_bind_accumulate"
         };
 
         public static string GetSource()
@@ -180,6 +184,108 @@ extern ""C"" __global__ void softmax_rows(
     // Step 3: normalize
     for (int c = tid; c < cols; c += blockDim.x)
         rowOut[c] /= sumExp;
+}
+
+// ─── HRR binding primitives (issue #248) ────────────────────────────
+//
+// Deterministic per-cell phase via splitmix64 hash of (seed, cell_idx).
+// Each thread generates its own phase independently — no shared state,
+// no cross-thread sync. Same seed → same codebook across runs; same
+// seed + same (V, D) → identical output. Does NOT match the CPU
+// xorshift64* sequence bit-for-bit (GPU phases are a different
+// uniform sample), which is fine — users don't need cross-device
+// bit-identity on random init.
+__device__ __forceinline__ float hrr_phase_from_cell(int seed, long long cellIdx)
+{
+    unsigned long long z = (unsigned long long)seed * 0x9E3779B97F4A7C15ULL
+                         + (unsigned long long)cellIdx * 0xBF58476D1CE4E5B9ULL;
+    z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;
+    z = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
+    z =  z ^ (z >> 31);
+    // Upper 24 bits → float in [0, 1). 24 bits is exact-representable
+    // in float32 so the distribution has no rounding artefacts at the
+    // top of the range.
+    unsigned int top24 = (unsigned int)(z >> 40);
+    return (float)top24 * (1.0f / 16777216.0f) * 6.28318530717958647692f;
+}
+
+extern ""C"" __global__ __launch_bounds__(256) void hrr_unit_phase_codebook(
+    float* outReal, float* outImag,
+    int seed, int V, int D, int kPsk, int k)
+{
+    long long idx = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+    long long total = (long long)V * D;
+    if (idx >= total) return;
+
+    float phase = hrr_phase_from_cell(seed, idx);
+    if (kPsk) {
+        // Snap to nearest multiple of 2π/k.
+        float step = 6.28318530717958647692f / (float)k;
+        phase = floorf(phase / step + 0.5f) * step;
+    }
+    float c, s;
+    sincosf(phase, &s, &c);
+    outReal[idx] = c;
+    outImag[idx] = s;
+}
+
+// Per-row phase-coherence reduction: one block per V, block-level
+// tree sum over D. scores[v] = Σ_d (queryR·codesR[v,d] + queryI·codesI[v,d]).
+extern ""C"" __global__ void hrr_phase_coherence_decode(
+    const float* codesReal, const float* codesImag,
+    const float* queryReal, const float* queryImag,
+    float* outScores, int V, int D)
+{
+    extern __shared__ float sdata[];
+    int v = blockIdx.x;
+    int tid = threadIdx.x;
+    if (v >= V) return;
+
+    const float* cR = codesReal + (long long)v * D;
+    const float* cI = codesImag + (long long)v * D;
+
+    float acc = 0.0f;
+    for (int d = tid; d < D; d += blockDim.x) {
+        acc += cR[d] * queryReal[d] + cI[d] * queryImag[d];
+    }
+    sdata[tid] = acc;
+    __syncthreads();
+    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+        if (tid < s) sdata[tid] += sdata[tid + s];
+        __syncthreads();
+    }
+    if (tid == 0) outScores[v] = sdata[0];
+}
+
+// Fused gather + complex multiply + accumulate across N training pairs.
+// One thread per D lane loops all N pairs — each thread writes only its
+// own d so no atomics are needed. Coalesced reads within a warp
+// because d varies consecutively and key/val offsets are broadcast
+// (same kId for all threads in a warp at a given n iteration).
+extern ""C"" __global__ __launch_bounds__(256) void hrr_bind_accumulate(
+    const float* keyCodeReal, const float* keyCodeImag,
+    const float* valPermCodeReal, const float* valPermCodeImag,
+    const int* keyIds, const int* valIds,
+    float* memoryReal, float* memoryImag,
+    int N, int D)
+{
+    int d = blockIdx.x * blockDim.x + threadIdx.x;
+    if (d >= D) return;
+
+    float accR = memoryReal[d];
+    float accI = memoryImag[d];
+    for (int n = 0; n < N; n++) {
+        long long kOff = (long long)keyIds[n] * D;
+        long long vOff = (long long)valIds[n] * D;
+        float ar = keyCodeReal[kOff + d];
+        float ai = keyCodeImag[kOff + d];
+        float br = valPermCodeReal[vOff + d];
+        float bi = valPermCodeImag[vOff + d];
+        accR += ar * br - ai * bi;
+        accI += ar * bi + ai * br;
+    }
+    memoryReal[d] = accR;
+    memoryImag[d] = accI;
 }
 ";
         }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.FusedKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.FusedKernels.cs
@@ -207,13 +207,19 @@ public sealed partial class HipBackend
     public unsafe void SplitComplexUnitPhaseCodebook(
         IGpuBuffer outReal, IGpuBuffer outImag, int seed, int V, int D, bool kPsk, int k)
     {
+        // Reject negative dims up front — if both are negative, their
+        // product is positive and would slip past a naive "total <= 0"
+        // check, then launch the kernel with invalid shape.
+        if (V < 0) throw new ArgumentOutOfRangeException(nameof(V), "V must be >= 0.");
+        if (D < 0) throw new ArgumentOutOfRangeException(nameof(D), "D must be >= 0.");
+        if (V == 0 || D == 0) return;
         long total = (long)V * D;
-        if (total <= 0) return;
         if (total > int.MaxValue) throw new ArgumentException($"V*D = {total} exceeds int.MaxValue.");
         if (kPsk && k <= 0) throw new ArgumentOutOfRangeException(nameof(k));
+        int n = (int)total;
+        ValidateHipSplitBuffers(n, nameof(SplitComplexUnitPhaseCodebook), outReal, outImag);
         if (!_kernelCache.TryGetValue("hrr_unit_phase_codebook", out var kernel))
             throw new InvalidOperationException("HIP kernel not found: hrr_unit_phase_codebook");
-        int n = (int)total;
         uint grid = (uint)((n + DefaultBlockSize - 1) / DefaultBlockSize);
         IntPtr pOR = outReal.Handle, pOI = outImag.Handle;
         int kPskI = kPsk ? 1 : 0;
@@ -229,13 +235,28 @@ public sealed partial class HipBackend
         IGpuBuffer outScores, int V, int D)
     {
         if (V <= 0 || D <= 0) return;
+        long codeCount = (long)V * D;
+        if (codesReal is null || codesImag is null || queryReal is null || queryImag is null || outScores is null)
+            throw new ArgumentNullException(nameof(codesReal),
+                "All five GPU buffers must be non-null for SplitComplexPhaseCoherenceDecode.");
+        if (codesReal.Size < codeCount || codesImag.Size < codeCount)
+            throw new ArgumentException(
+                $"codes buffers must each hold at least V*D = {codeCount} elements " +
+                $"(got {codesReal.Size}, {codesImag.Size}).");
+        if (queryReal.Size < D || queryImag.Size < D)
+            throw new ArgumentException(
+                $"query buffers must each hold at least D = {D} elements " +
+                $"(got {queryReal.Size}, {queryImag.Size}).");
+        if (outScores.Size < V)
+            throw new ArgumentException(
+                $"outScores must hold at least V = {V} elements (got {outScores.Size}).");
         if (!_kernelCache.TryGetValue("hrr_phase_coherence_decode", out var kernel))
             throw new InvalidOperationException("HIP kernel not found: hrr_phase_coherence_decode");
         uint grid = (uint)V;
         int blockSize = 1;
         while (blockSize < D && blockSize < 1024) blockSize <<= 1;
         blockSize = Math.Max(32, blockSize);
-        int sharedMem = blockSize * sizeof(float);
+        uint sharedMem = (uint)blockSize * sizeof(float);
         IntPtr pCR = codesReal.Handle, pCI = codesImag.Handle;
         IntPtr pQR = queryReal.Handle, pQI = queryImag.Handle;
         IntPtr pOS = outScores.Handle;
@@ -243,8 +264,9 @@ public sealed partial class HipBackend
         args[0] = &pCR; args[1] = &pCI;
         args[2] = &pQR; args[3] = &pQI;
         args[4] = &pOS; args[5] = &V; args[6] = &D;
-        HipNativeBindings.hipModuleLaunchKernel(kernel, grid, 1, 1, (uint)blockSize, 1, 1,
-            (uint)sharedMem, IntPtr.Zero, (IntPtr)args, IntPtr.Zero);
+        // Route through the shared helper so this runs on _stream with
+        // the same error-surfacing as the rest of the backend.
+        LaunchKernelWithSharedMem(kernel, grid, (uint)blockSize, sharedMem, args);
     }
 
     public unsafe void SplitComplexHrrBindAccumulate(
@@ -255,6 +277,22 @@ public sealed partial class HipBackend
         int N, int D)
     {
         if (N <= 0 || D <= 0) return;
+        if (keyCodeReal is null || keyCodeImag is null || valPermCodeReal is null || valPermCodeImag is null
+            || keyIds is null || valIds is null || memoryReal is null || memoryImag is null)
+            throw new ArgumentNullException(nameof(keyCodeReal),
+                "All eight GPU buffers must be non-null for SplitComplexHrrBindAccumulate.");
+        if (keyIds.Size < N || valIds.Size < N)
+            throw new ArgumentException(
+                $"ID buffers must each hold at least N = {N} elements " +
+                $"(got keyIds={keyIds.Size}, valIds={valIds.Size}).");
+        if (memoryReal.Size < D || memoryImag.Size < D)
+            throw new ArgumentException(
+                $"Memory buffers must each hold at least D = {D} elements " +
+                $"(got memoryReal={memoryReal.Size}, memoryImag={memoryImag.Size}).");
+        if (keyCodeReal.Size < D || keyCodeImag.Size < D
+            || valPermCodeReal.Size < D || valPermCodeImag.Size < D)
+            throw new ArgumentException(
+                $"Each codebook buffer must hold at least one full row of D = {D} elements.");
         if (!_kernelCache.TryGetValue("hrr_bind_accumulate", out var kernel))
             throw new InvalidOperationException("HIP kernel not found: hrr_bind_accumulate");
         uint grid = (uint)((D + DefaultBlockSize - 1) / DefaultBlockSize);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.FusedKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.FusedKernels.cs
@@ -201,4 +201,73 @@ public sealed partial class HipBackend
         HipNativeBindings.hipModuleLaunchKernel(kernel, grid, 1, 1, (uint)blockSize, 1, 1,
             (uint)sharedMem, IntPtr.Zero, (IntPtr)args, IntPtr.Zero);
     }
+
+    // ─── HRR binding primitives (issue #248) ────────────────────────
+
+    public unsafe void SplitComplexUnitPhaseCodebook(
+        IGpuBuffer outReal, IGpuBuffer outImag, int seed, int V, int D, bool kPsk, int k)
+    {
+        long total = (long)V * D;
+        if (total <= 0) return;
+        if (total > int.MaxValue) throw new ArgumentException($"V*D = {total} exceeds int.MaxValue.");
+        if (kPsk && k <= 0) throw new ArgumentOutOfRangeException(nameof(k));
+        if (!_kernelCache.TryGetValue("hrr_unit_phase_codebook", out var kernel))
+            throw new InvalidOperationException("HIP kernel not found: hrr_unit_phase_codebook");
+        int n = (int)total;
+        uint grid = (uint)((n + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr pOR = outReal.Handle, pOI = outImag.Handle;
+        int kPskI = kPsk ? 1 : 0;
+        void** args = stackalloc void*[7];
+        args[0] = &pOR; args[1] = &pOI; args[2] = &seed;
+        args[3] = &V; args[4] = &D; args[5] = &kPskI; args[6] = &k;
+        LaunchKernel(kernel, grid, (uint)DefaultBlockSize, args);
+    }
+
+    public unsafe void SplitComplexPhaseCoherenceDecode(
+        IGpuBuffer codesReal, IGpuBuffer codesImag,
+        IGpuBuffer queryReal, IGpuBuffer queryImag,
+        IGpuBuffer outScores, int V, int D)
+    {
+        if (V <= 0 || D <= 0) return;
+        if (!_kernelCache.TryGetValue("hrr_phase_coherence_decode", out var kernel))
+            throw new InvalidOperationException("HIP kernel not found: hrr_phase_coherence_decode");
+        uint grid = (uint)V;
+        int blockSize = 1;
+        while (blockSize < D && blockSize < 1024) blockSize <<= 1;
+        blockSize = Math.Max(32, blockSize);
+        int sharedMem = blockSize * sizeof(float);
+        IntPtr pCR = codesReal.Handle, pCI = codesImag.Handle;
+        IntPtr pQR = queryReal.Handle, pQI = queryImag.Handle;
+        IntPtr pOS = outScores.Handle;
+        void** args = stackalloc void*[7];
+        args[0] = &pCR; args[1] = &pCI;
+        args[2] = &pQR; args[3] = &pQI;
+        args[4] = &pOS; args[5] = &V; args[6] = &D;
+        HipNativeBindings.hipModuleLaunchKernel(kernel, grid, 1, 1, (uint)blockSize, 1, 1,
+            (uint)sharedMem, IntPtr.Zero, (IntPtr)args, IntPtr.Zero);
+    }
+
+    public unsafe void SplitComplexHrrBindAccumulate(
+        IGpuBuffer keyCodeReal, IGpuBuffer keyCodeImag,
+        IGpuBuffer valPermCodeReal, IGpuBuffer valPermCodeImag,
+        IGpuBuffer keyIds, IGpuBuffer valIds,
+        IGpuBuffer memoryReal, IGpuBuffer memoryImag,
+        int N, int D)
+    {
+        if (N <= 0 || D <= 0) return;
+        if (!_kernelCache.TryGetValue("hrr_bind_accumulate", out var kernel))
+            throw new InvalidOperationException("HIP kernel not found: hrr_bind_accumulate");
+        uint grid = (uint)((D + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr pKR = keyCodeReal.Handle, pKI = keyCodeImag.Handle;
+        IntPtr pVR = valPermCodeReal.Handle, pVI = valPermCodeImag.Handle;
+        IntPtr pKId = keyIds.Handle, pVId = valIds.Handle;
+        IntPtr pMR = memoryReal.Handle, pMI = memoryImag.Handle;
+        void** args = stackalloc void*[10];
+        args[0] = &pKR; args[1] = &pKI;
+        args[2] = &pVR; args[3] = &pVI;
+        args[4] = &pKId; args[5] = &pVId;
+        args[6] = &pMR; args[7] = &pMI;
+        args[8] = &N; args[9] = &D;
+        LaunchKernel(kernel, grid, (uint)DefaultBlockSize, args);
+    }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.FusedKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.FusedKernels.cs
@@ -293,6 +293,19 @@ public sealed partial class HipBackend
             || valPermCodeReal.Size < D || valPermCodeImag.Size < D)
             throw new ArgumentException(
                 $"Each codebook buffer must hold at least one full row of D = {D} elements.");
+        // Derive vocabulary sizes from codebook capacities so the
+        // kernel can reject out-of-range ids without OOB reads —
+        // mirrors the CUDA backend's nKeys/nVals guard and the CPU
+        // path's range check in NativeHRRBindAccumulate.
+        long nKeysL = keyCodeReal.Size / D;
+        long nValsL = valPermCodeReal.Size / D;
+        if (nKeysL <= 0 || nValsL <= 0)
+            throw new ArgumentException(
+                $"Codebook buffers must hold at least one full row of D = {D} elements.");
+        if (nKeysL > int.MaxValue || nValsL > int.MaxValue)
+            throw new ArgumentException("Codebook vocabulary size exceeds int.MaxValue.");
+        int nKeys = (int)nKeysL;
+        int nVals = (int)nValsL;
         if (!_kernelCache.TryGetValue("hrr_bind_accumulate", out var kernel))
             throw new InvalidOperationException("HIP kernel not found: hrr_bind_accumulate");
         uint grid = (uint)((D + DefaultBlockSize - 1) / DefaultBlockSize);
@@ -300,12 +313,13 @@ public sealed partial class HipBackend
         IntPtr pVR = valPermCodeReal.Handle, pVI = valPermCodeImag.Handle;
         IntPtr pKId = keyIds.Handle, pVId = valIds.Handle;
         IntPtr pMR = memoryReal.Handle, pMI = memoryImag.Handle;
-        void** args = stackalloc void*[10];
+        void** args = stackalloc void*[12];
         args[0] = &pKR; args[1] = &pKI;
         args[2] = &pVR; args[3] = &pVI;
         args[4] = &pKId; args[5] = &pVId;
         args[6] = &pMR; args[7] = &pMI;
         args[8] = &N; args[9] = &D;
+        args[10] = &nKeys; args[11] = &nVals;
         LaunchKernel(kernel, grid, (uint)DefaultBlockSize, args);
     }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipComplexKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipComplexKernels.cs
@@ -159,14 +159,23 @@ extern ""C"" __global__ void softmax_rows(
 }
 
 // ─── HRR binding primitives (issue #248) ────────────────────────────
+// Matches CUDA/OpenCL/Metal/Vulkan/WebGPU — see CudaComplexKernels.cs
+// for the hash rationale (32-bit Murmur3 fmix chosen for WebGPU
+// compatibility; per-backend GPU determinism preserved, CPU
+// xorshift64* path intentionally divergent for single-thread speed).
+__device__ __forceinline__ unsigned int hrr_hash(unsigned int seed_u, unsigned int cell_u)
+{
+    unsigned int z = seed_u * 0x9E3779B9u + cell_u * 0x85EBCA6Bu;
+    z = (z ^ (z >> 16)) * 0x85EBCA6Bu;
+    z = (z ^ (z >> 13)) * 0xC2B2AE35u;
+    z =  z ^ (z >> 16);
+    return z;
+}
+
 __device__ __forceinline__ float hrr_phase_from_cell(int seed, long long cellIdx)
 {
-    unsigned long long z = (unsigned long long)seed * 0x9E3779B97F4A7C15ULL
-                         + (unsigned long long)cellIdx * 0xBF58476D1CE4E5B9ULL;
-    z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;
-    z = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
-    z =  z ^ (z >> 31);
-    unsigned int top24 = (unsigned int)(z >> 40);
+    unsigned int z = hrr_hash((unsigned int)seed, (unsigned int)cellIdx);
+    unsigned int top24 = z >> 8;
     return (float)top24 * (1.0f / 16777216.0f) * 6.28318530717958647692f;
 }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipComplexKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipComplexKernels.cs
@@ -220,20 +220,28 @@ extern ""C"" __global__ void hrr_phase_coherence_decode(
     if (tid == 0) outScores[v] = sdata[0];
 }
 
+// nKeys / nVals match the CUDA kernel: codebook row counts passed
+// by the host so out-of-range ids are rejected without OOB reads.
+// See CudaComplexKernels.hrr_bind_accumulate for the full rationale.
 extern ""C"" __global__ void hrr_bind_accumulate(
     const float* keyCodeReal, const float* keyCodeImag,
     const float* valPermCodeReal, const float* valPermCodeImag,
     const int* keyIds, const int* valIds,
     float* memoryReal, float* memoryImag,
-    int N, int D)
+    int N, int D, int nKeys, int nVals)
 {
     int d = blockIdx.x * blockDim.x + threadIdx.x;
     if (d >= D) return;
     float accR = memoryReal[d];
     float accI = memoryImag[d];
     for (int n = 0; n < N; n++) {
-        long long kOff = (long long)keyIds[n] * D;
-        long long vOff = (long long)valIds[n] * D;
+        int kId = keyIds[n];
+        int vId = valIds[n];
+        // Unsigned-comparison trick rejects both negative and
+        // too-large indices in one branch.
+        if ((unsigned)kId >= (unsigned)nKeys || (unsigned)vId >= (unsigned)nVals) continue;
+        long long kOff = (long long)kId * D;
+        long long vOff = (long long)vId * D;
         float ar = keyCodeReal[kOff + d];
         float ai = keyCodeImag[kOff + d];
         float br = valPermCodeReal[vOff + d];

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipComplexKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipComplexKernels.cs
@@ -11,7 +11,11 @@ internal static class HipComplexKernels
         "split_complex_multiply", "split_complex_conjugate", "split_complex_magnitude",
         "split_complex_magnitude_squared", "split_complex_phase", "split_complex_from_polar",
         "split_complex_scale", "split_complex_add", "split_complex_cross_spectral",
-        "split_complex_topk", "softmax_rows"
+        "split_complex_topk", "softmax_rows",
+        // Issue #248 — HRR binding primitives
+        "hrr_unit_phase_codebook",
+        "hrr_phase_coherence_decode",
+        "hrr_bind_accumulate"
     };
 
     public static string GetSource()
@@ -152,6 +156,84 @@ extern ""C"" __global__ void softmax_rows(
     for (int s = blockDim.x/2; s > 0; s >>= 1) { if (tid < s) sdata[tid] += sdata[tid+s]; __syncthreads(); }
     sumExp = sdata[0];
     for (int c = tid; c < cols; c += blockDim.x) rowOut[c] /= sumExp;
+}
+
+// ─── HRR binding primitives (issue #248) ────────────────────────────
+__device__ __forceinline__ float hrr_phase_from_cell(int seed, long long cellIdx)
+{
+    unsigned long long z = (unsigned long long)seed * 0x9E3779B97F4A7C15ULL
+                         + (unsigned long long)cellIdx * 0xBF58476D1CE4E5B9ULL;
+    z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;
+    z = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
+    z =  z ^ (z >> 31);
+    unsigned int top24 = (unsigned int)(z >> 40);
+    return (float)top24 * (1.0f / 16777216.0f) * 6.28318530717958647692f;
+}
+
+extern ""C"" __global__ void hrr_unit_phase_codebook(
+    float* outReal, float* outImag,
+    int seed, int V, int D, int kPsk, int k)
+{
+    long long idx = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+    long long total = (long long)V * D;
+    if (idx >= total) return;
+    float phase = hrr_phase_from_cell(seed, idx);
+    if (kPsk) {
+        float step = 6.28318530717958647692f / (float)k;
+        phase = floorf(phase / step + 0.5f) * step;
+    }
+    float c, s;
+    sincosf(phase, &s, &c);
+    outReal[idx] = c;
+    outImag[idx] = s;
+}
+
+extern ""C"" __global__ void hrr_phase_coherence_decode(
+    const float* codesReal, const float* codesImag,
+    const float* queryReal, const float* queryImag,
+    float* outScores, int V, int D)
+{
+    extern __shared__ float sdata[];
+    int v = blockIdx.x;
+    int tid = threadIdx.x;
+    if (v >= V) return;
+    const float* cR = codesReal + (long long)v * D;
+    const float* cI = codesImag + (long long)v * D;
+    float acc = 0.0f;
+    for (int d = tid; d < D; d += blockDim.x) {
+        acc += cR[d] * queryReal[d] + cI[d] * queryImag[d];
+    }
+    sdata[tid] = acc; __syncthreads();
+    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+        if (tid < s) sdata[tid] += sdata[tid + s];
+        __syncthreads();
+    }
+    if (tid == 0) outScores[v] = sdata[0];
+}
+
+extern ""C"" __global__ void hrr_bind_accumulate(
+    const float* keyCodeReal, const float* keyCodeImag,
+    const float* valPermCodeReal, const float* valPermCodeImag,
+    const int* keyIds, const int* valIds,
+    float* memoryReal, float* memoryImag,
+    int N, int D)
+{
+    int d = blockIdx.x * blockDim.x + threadIdx.x;
+    if (d >= D) return;
+    float accR = memoryReal[d];
+    float accI = memoryImag[d];
+    for (int n = 0; n < N; n++) {
+        long long kOff = (long long)keyIds[n] * D;
+        long long vOff = (long long)valIds[n] * D;
+        float ar = keyCodeReal[kOff + d];
+        float ai = keyCodeImag[kOff + d];
+        float br = valPermCodeReal[vOff + d];
+        float bi = valPermCodeImag[vOff + d];
+        accR += ar * br - ai * bi;
+        accI += ar * bi + ai * br;
+    }
+    memoryReal[d] = accR;
+    memoryImag[d] = accI;
 }
 ";
     }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
@@ -2904,6 +2904,81 @@ public interface IDirectGpuBackend : IDisposable
     /// <summary>Per-row softmax on a 2D buffer: output[r][c] = exp(input[r][c]-max) / sum(exp).</summary>
     void SoftmaxRows(IGpuBuffer input, IGpuBuffer output, int rows, int cols);
 
+    // ─── HRR binding primitives (issue #248) ─────────────────────────────
+    // Backend-native kernels for the HRR ops the engine exposes through
+    // NativeUnitPhaseCodebook<T>, NativeComplexPhaseCoherenceDecode<T>,
+    // NativeHRRBindAccumulate<T>. Split Re/Im, fp32 (matches the rest of
+    // the GPU surface). Per-cell deterministic phase generation uses a
+    // splitmix64 hash so different threads produce independent phases
+    // from (seed, v, d) without sharing state — matches the engine's
+    // deterministic-per-seed contract but not the exact CPU phase
+    // sequence (which is fine; random init doesn't need cross-device
+    // bit-identity).
+
+    /// <summary>
+    /// Fill a V×D codebook of unit-phase complex numbers: every entry
+    /// <c>exp(iθ)</c> for a uniformly-random phase derived from
+    /// <paramref name="seed"/> and the cell index. Split into real
+    /// (<paramref name="outReal"/>) and imaginary (<paramref name="outImag"/>)
+    /// GPU buffers, row-major with stride <c>D</c>. Optional K-PSK
+    /// quantization snaps phases to multiples of <c>2π/k</c>.
+    /// </summary>
+    /// <param name="outReal">Output buffer for cos θ, size V·D.</param>
+    /// <param name="outImag">Output buffer for sin θ, size V·D.</param>
+    /// <param name="seed">PRNG seed; same seed → same codebook.</param>
+    /// <param name="V">Vocabulary size.</param>
+    /// <param name="D">Dimensionality.</param>
+    /// <param name="kPsk">When true, quantize to K-PSK lattice.</param>
+    /// <param name="k">Number of PSK lattice points; must be positive when
+    /// <paramref name="kPsk"/> is true.</param>
+    void SplitComplexUnitPhaseCodebook(
+        IGpuBuffer outReal, IGpuBuffer outImag,
+        int seed, int V, int D, bool kPsk, int k);
+
+    /// <summary>
+    /// Full-vocabulary phase-coherence decode: for each candidate
+    /// <c>v ∈ [0, V)</c>, compute
+    /// <c>scores[v] = Σ_d (queryR·codesR[v,d] + queryI·codesI[v,d])</c>.
+    /// Equivalent to <c>Re(Σ_d query · conj(code[v]))</c> on split buffers;
+    /// the per-row reduction uses a block-level tree sum.
+    /// </summary>
+    /// <param name="codesReal">Row-major codebook [V·D] real.</param>
+    /// <param name="codesImag">Row-major codebook [V·D] imag.</param>
+    /// <param name="queryReal">Query [D] real.</param>
+    /// <param name="queryImag">Query [D] imag.</param>
+    /// <param name="outScores">Output [V].</param>
+    /// <param name="V">Number of candidates.</param>
+    /// <param name="D">Dimensionality.</param>
+    void SplitComplexPhaseCoherenceDecode(
+        IGpuBuffer codesReal, IGpuBuffer codesImag,
+        IGpuBuffer queryReal, IGpuBuffer queryImag,
+        IGpuBuffer outScores,
+        int V, int D);
+
+    /// <summary>
+    /// Fused HRR bind-and-accumulate across N training pairs:
+    /// <c>memory += key[keyIds[n]] · valPerm[valIds[n]]</c> (split
+    /// complex multiply) for each n. One kernel per D lane iterates
+    /// through all N pairs so no atomic operations are needed —
+    /// accumulation is per-thread local.
+    /// </summary>
+    /// <param name="keyCodeReal">Key codebook [nKeys·D] real.</param>
+    /// <param name="keyCodeImag">Key codebook [nKeys·D] imag.</param>
+    /// <param name="valPermCodeReal">Permuted value codebook [nVals·D] real.</param>
+    /// <param name="valPermCodeImag">Permuted value codebook [nVals·D] imag.</param>
+    /// <param name="keyIds">Per-pair key indices, int[N].</param>
+    /// <param name="valIds">Per-pair val indices, int[N].</param>
+    /// <param name="memoryReal">Accumulator [D] real (read-modify-write).</param>
+    /// <param name="memoryImag">Accumulator [D] imag (read-modify-write).</param>
+    /// <param name="N">Number of training pairs.</param>
+    /// <param name="D">Dimensionality.</param>
+    void SplitComplexHrrBindAccumulate(
+        IGpuBuffer keyCodeReal, IGpuBuffer keyCodeImag,
+        IGpuBuffer valPermCodeReal, IGpuBuffer valPermCodeImag,
+        IGpuBuffer keyIds, IGpuBuffer valIds,
+        IGpuBuffer memoryReal, IGpuBuffer memoryImag,
+        int N, int D);
+
     /// <summary>
     /// Fused spectral filter: FFT2D → pointwise complex multiply → IFFT2D, entirely GPU-resident.
     /// Input and output are real-valued split buffers. Filter is complex split (real/imag).

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
@@ -1770,4 +1770,76 @@ public sealed partial class MetalBackend : IDirectGpuBackend
         enc.SetBytes((uint)cols, (ulong)3);
         enc.DispatchThreadgroups(tg, tpg);
     }
+
+    // ─── HRR binding primitives (issue #248) ────────────────────────
+
+    public void SplitComplexUnitPhaseCodebook(
+        IGpuBuffer outReal, IGpuBuffer outImag, int seed, int V, int D, bool kPsk, int k)
+    {
+        long total = (long)V * D;
+        if (total <= 0) return;
+        if (total > int.MaxValue) throw new ArgumentException($"V*D = {total} exceeds int.MaxValue.");
+        if (kPsk && k <= 0) throw new ArgumentOutOfRangeException(nameof(k));
+        int n = (int)total;
+        EnsureComplexLibrary();
+        var pipeline = GetPipeline("Complex", _complexLibrary, "hrr_unit_phase_codebook");
+        var (tg, tpg) = pipeline.Calculate1DDispatch(n);
+        using var enc = _commandQueue.CreateScopedComputeEncoder();
+        enc.SetPipelineState(pipeline.Handle);
+        enc.SetBuffer(AsMetal(outReal), 0);
+        enc.SetBuffer(AsMetal(outImag), 1);
+        enc.SetBytes(seed, 2);
+        enc.SetBytes(V, 3);
+        enc.SetBytes(D, 4);
+        enc.SetBytes(kPsk ? 1 : 0, 5);
+        enc.SetBytes(k, 6);
+        enc.DispatchThreadgroups(tg, tpg);
+    }
+
+    public void SplitComplexPhaseCoherenceDecode(
+        IGpuBuffer codesReal, IGpuBuffer codesImag,
+        IGpuBuffer queryReal, IGpuBuffer queryImag,
+        IGpuBuffer outScores, int V, int D)
+    {
+        if (V <= 0 || D <= 0) return;
+        EnsureComplexLibrary();
+        var pipeline = GetPipeline("Complex", _complexLibrary, "hrr_phase_coherence_decode");
+        var (tg, tpg) = pipeline.Calculate1DDispatch(V);
+        using var enc = _commandQueue.CreateScopedComputeEncoder();
+        enc.SetPipelineState(pipeline.Handle);
+        enc.SetBuffer(AsMetal(codesReal), 0);
+        enc.SetBuffer(AsMetal(codesImag), 1);
+        enc.SetBuffer(AsMetal(queryReal), 2);
+        enc.SetBuffer(AsMetal(queryImag), 3);
+        enc.SetBuffer(AsMetal(outScores), 4);
+        enc.SetBytes(V, 5);
+        enc.SetBytes(D, 6);
+        enc.DispatchThreadgroups(tg, tpg);
+    }
+
+    public void SplitComplexHrrBindAccumulate(
+        IGpuBuffer keyCodeReal, IGpuBuffer keyCodeImag,
+        IGpuBuffer valPermCodeReal, IGpuBuffer valPermCodeImag,
+        IGpuBuffer keyIds, IGpuBuffer valIds,
+        IGpuBuffer memoryReal, IGpuBuffer memoryImag,
+        int N, int D)
+    {
+        if (N <= 0 || D <= 0) return;
+        EnsureComplexLibrary();
+        var pipeline = GetPipeline("Complex", _complexLibrary, "hrr_bind_accumulate");
+        var (tg, tpg) = pipeline.Calculate1DDispatch(D);
+        using var enc = _commandQueue.CreateScopedComputeEncoder();
+        enc.SetPipelineState(pipeline.Handle);
+        enc.SetBuffer(AsMetal(keyCodeReal), 0);
+        enc.SetBuffer(AsMetal(keyCodeImag), 1);
+        enc.SetBuffer(AsMetal(valPermCodeReal), 2);
+        enc.SetBuffer(AsMetal(valPermCodeImag), 3);
+        enc.SetBuffer(AsMetal(keyIds), 4);
+        enc.SetBuffer(AsMetal(valIds), 5);
+        enc.SetBuffer(AsMetal(memoryReal), 6);
+        enc.SetBuffer(AsMetal(memoryImag), 7);
+        enc.SetBytes(N, 8);
+        enc.SetBytes(D, 9);
+        enc.DispatchThreadgroups(tg, tpg);
+    }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
@@ -1784,13 +1784,21 @@ public sealed partial class MetalBackend : IDirectGpuBackend
         if (total > int.MaxValue) throw new ArgumentException($"V*D = {total} exceeds int.MaxValue.");
         if (kPsk && k <= 0) throw new ArgumentOutOfRangeException(nameof(k));
         int n = (int)total;
+        if (outReal is null || outImag is null)
+            throw new ArgumentNullException(nameof(outReal), "Output buffers must be non-null.");
+        var outR = AsMetal(outReal);
+        var outI = AsMetal(outImag);
+        if (outR.Size < n || outI.Size < n)
+            throw new ArgumentException(
+                $"Output buffers must each hold at least V*D = {n} elements " +
+                $"(got outReal={outR.Size}, outImag={outI.Size}).");
         EnsureComplexLibrary();
         var pipeline = GetPipeline("Complex", _complexLibrary, "hrr_unit_phase_codebook");
         var (tg, tpg) = pipeline.Calculate1DDispatch(n);
         using var enc = _commandQueue.CreateScopedComputeEncoder();
         enc.SetPipelineState(pipeline.Handle);
-        enc.SetBuffer(AsMetal(outReal), 0);
-        enc.SetBuffer(AsMetal(outImag), 1);
+        enc.SetBuffer(outR, 0);
+        enc.SetBuffer(outI, 1);
         enc.SetBytes(seed, 2);
         enc.SetBytes(V, 3);
         enc.SetBytes(D, 4);
@@ -1805,17 +1813,40 @@ public sealed partial class MetalBackend : IDirectGpuBackend
         IGpuBuffer outScores, int V, int D)
     {
         ThrowIfDisposed();
-        if (V <= 0 || D <= 0) return;
+        if (V < 0) throw new ArgumentOutOfRangeException(nameof(V), "V must be >= 0.");
+        if (D < 0) throw new ArgumentOutOfRangeException(nameof(D), "D must be >= 0.");
+        if (V == 0 || D == 0) return;
+        if (codesReal is null || codesImag is null || queryReal is null || queryImag is null || outScores is null)
+            throw new ArgumentNullException(nameof(codesReal),
+                "All five GPU buffers must be non-null for SplitComplexPhaseCoherenceDecode.");
+        long codeCount = (long)V * D;
+        if (codeCount > int.MaxValue) throw new ArgumentException($"V*D = {codeCount} exceeds int.MaxValue.");
+        var cR = AsMetal(codesReal);
+        var cI = AsMetal(codesImag);
+        var qR = AsMetal(queryReal);
+        var qI = AsMetal(queryImag);
+        var os = AsMetal(outScores);
+        if (cR.Size < codeCount || cI.Size < codeCount)
+            throw new ArgumentException(
+                $"codes buffers must each hold at least V*D = {codeCount} elements " +
+                $"(got {cR.Size}, {cI.Size}).");
+        if (qR.Size < D || qI.Size < D)
+            throw new ArgumentException(
+                $"query buffers must each hold at least D = {D} elements " +
+                $"(got {qR.Size}, {qI.Size}).");
+        if (os.Size < V)
+            throw new ArgumentException(
+                $"outScores must hold at least V = {V} elements (got {os.Size}).");
         EnsureComplexLibrary();
         var pipeline = GetPipeline("Complex", _complexLibrary, "hrr_phase_coherence_decode");
         var (tg, tpg) = pipeline.Calculate1DDispatch(V);
         using var enc = _commandQueue.CreateScopedComputeEncoder();
         enc.SetPipelineState(pipeline.Handle);
-        enc.SetBuffer(AsMetal(codesReal), 0);
-        enc.SetBuffer(AsMetal(codesImag), 1);
-        enc.SetBuffer(AsMetal(queryReal), 2);
-        enc.SetBuffer(AsMetal(queryImag), 3);
-        enc.SetBuffer(AsMetal(outScores), 4);
+        enc.SetBuffer(cR, 0);
+        enc.SetBuffer(cI, 1);
+        enc.SetBuffer(qR, 2);
+        enc.SetBuffer(qI, 3);
+        enc.SetBuffer(os, 4);
         enc.SetBytes(V, 5);
         enc.SetBytes(D, 6);
         enc.DispatchThreadgroups(tg, tpg);
@@ -1829,22 +1860,56 @@ public sealed partial class MetalBackend : IDirectGpuBackend
         int N, int D)
     {
         ThrowIfDisposed();
-        if (N <= 0 || D <= 0) return;
+        if (N < 0) throw new ArgumentOutOfRangeException(nameof(N), "N must be >= 0.");
+        if (D < 0) throw new ArgumentOutOfRangeException(nameof(D), "D must be >= 0.");
+        if (N == 0 || D == 0) return;
+        if (keyCodeReal is null || keyCodeImag is null || valPermCodeReal is null || valPermCodeImag is null
+            || keyIds is null || valIds is null || memoryReal is null || memoryImag is null)
+            throw new ArgumentNullException(nameof(keyCodeReal),
+                "All eight GPU buffers must be non-null for SplitComplexHrrBindAccumulate.");
+        var kR = AsMetal(keyCodeReal);
+        var kI = AsMetal(keyCodeImag);
+        var vR = AsMetal(valPermCodeReal);
+        var vI = AsMetal(valPermCodeImag);
+        var kIds = AsMetal(keyIds);
+        var vIds = AsMetal(valIds);
+        var mR = AsMetal(memoryReal);
+        var mI = AsMetal(memoryImag);
+        if (kIds.Size < N || vIds.Size < N)
+            throw new ArgumentException(
+                $"ID buffers must each hold at least N = {N} elements " +
+                $"(got keyIds={kIds.Size}, valIds={vIds.Size}).");
+        if (mR.Size < D || mI.Size < D)
+            throw new ArgumentException(
+                $"Memory buffers must each hold at least D = {D} elements " +
+                $"(got memoryReal={mR.Size}, memoryImag={mI.Size}).");
+        if (kR.Size < D || kI.Size < D || vR.Size < D || vI.Size < D)
+            throw new ArgumentException(
+                $"Each codebook buffer must hold at least one full row of D = {D} elements.");
+        // Derive vocabulary sizes for in-shader id-bounds checks.
+        long nKeysL = kR.Size / D;
+        long nValsL = vR.Size / D;
+        if (nKeysL > int.MaxValue || nValsL > int.MaxValue)
+            throw new ArgumentException("Codebook vocabulary size exceeds int.MaxValue.");
+        int nKeys = (int)nKeysL;
+        int nVals = (int)nValsL;
         EnsureComplexLibrary();
         var pipeline = GetPipeline("Complex", _complexLibrary, "hrr_bind_accumulate");
         var (tg, tpg) = pipeline.Calculate1DDispatch(D);
         using var enc = _commandQueue.CreateScopedComputeEncoder();
         enc.SetPipelineState(pipeline.Handle);
-        enc.SetBuffer(AsMetal(keyCodeReal), 0);
-        enc.SetBuffer(AsMetal(keyCodeImag), 1);
-        enc.SetBuffer(AsMetal(valPermCodeReal), 2);
-        enc.SetBuffer(AsMetal(valPermCodeImag), 3);
-        enc.SetBuffer(AsMetal(keyIds), 4);
-        enc.SetBuffer(AsMetal(valIds), 5);
-        enc.SetBuffer(AsMetal(memoryReal), 6);
-        enc.SetBuffer(AsMetal(memoryImag), 7);
+        enc.SetBuffer(kR, 0);
+        enc.SetBuffer(kI, 1);
+        enc.SetBuffer(vR, 2);
+        enc.SetBuffer(vI, 3);
+        enc.SetBuffer(kIds, 4);
+        enc.SetBuffer(vIds, 5);
+        enc.SetBuffer(mR, 6);
+        enc.SetBuffer(mI, 7);
         enc.SetBytes(N, 8);
         enc.SetBytes(D, 9);
+        enc.SetBytes(nKeys, 10);
+        enc.SetBytes(nVals, 11);
         enc.DispatchThreadgroups(tg, tpg);
     }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
@@ -1776,8 +1776,11 @@ public sealed partial class MetalBackend : IDirectGpuBackend
     public void SplitComplexUnitPhaseCodebook(
         IGpuBuffer outReal, IGpuBuffer outImag, int seed, int V, int D, bool kPsk, int k)
     {
+        ThrowIfDisposed();
+        if (V < 0) throw new ArgumentOutOfRangeException(nameof(V), "V must be >= 0.");
+        if (D < 0) throw new ArgumentOutOfRangeException(nameof(D), "D must be >= 0.");
+        if (V == 0 || D == 0) return;
         long total = (long)V * D;
-        if (total <= 0) return;
         if (total > int.MaxValue) throw new ArgumentException($"V*D = {total} exceeds int.MaxValue.");
         if (kPsk && k <= 0) throw new ArgumentOutOfRangeException(nameof(k));
         int n = (int)total;
@@ -1801,6 +1804,7 @@ public sealed partial class MetalBackend : IDirectGpuBackend
         IGpuBuffer queryReal, IGpuBuffer queryImag,
         IGpuBuffer outScores, int V, int D)
     {
+        ThrowIfDisposed();
         if (V <= 0 || D <= 0) return;
         EnsureComplexLibrary();
         var pipeline = GetPipeline("Complex", _complexLibrary, "hrr_phase_coherence_decode");
@@ -1824,6 +1828,7 @@ public sealed partial class MetalBackend : IDirectGpuBackend
         IGpuBuffer memoryReal, IGpuBuffer memoryImag,
         int N, int D)
     {
+        ThrowIfDisposed();
         if (N <= 0 || D <= 0) return;
         EnsureComplexLibrary();
         var pipeline = GetPipeline("Complex", _complexLibrary, "hrr_bind_accumulate");

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalComplexKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalComplexKernels.cs
@@ -165,5 +165,88 @@ kernel void softmax_rows(
     for (uint c = 0; c < cols; c++) { float e = exp(input[offset + c] - maxVal); output[offset + c] = e; sumExp += e; }
     for (uint c = 0; c < cols; c++) output[offset + c] /= sumExp;
 }
+
+// ─── HRR binding primitives (issue #248) ────────────────────────────
+inline float hrr_phase_from_cell(int seed, ulong cellIdx)
+{
+    ulong z = (ulong)seed * 0x9E3779B97F4A7C15UL
+            + cellIdx * 0xBF58476D1CE4E5B9UL;
+    z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9UL;
+    z = (z ^ (z >> 27)) * 0x94D049BB133111EBUL;
+    z =  z ^ (z >> 31);
+    uint top24 = (uint)(z >> 40);
+    return (float)top24 * (1.0f / 16777216.0f) * 6.28318530717958647692f;
+}
+
+kernel void hrr_unit_phase_codebook(
+    device float* outReal [[buffer(0)]],
+    device float* outImag [[buffer(1)]],
+    constant int& seed [[buffer(2)]],
+    constant int& V [[buffer(3)]],
+    constant int& D [[buffer(4)]],
+    constant int& kPsk [[buffer(5)]],
+    constant int& k [[buffer(6)]],
+    uint idx [[thread_position_in_grid]])
+{
+    ulong total = (ulong)V * (ulong)D;
+    if ((ulong)idx >= total) return;
+    float phase = hrr_phase_from_cell(seed, (ulong)idx);
+    if (kPsk != 0) {
+        float step = 6.28318530717958647692f / (float)k;
+        phase = floor(phase / step + 0.5f) * step;
+    }
+    outReal[idx] = cos(phase);
+    outImag[idx] = sin(phase);
+}
+
+kernel void hrr_phase_coherence_decode(
+    device const float* codesReal [[buffer(0)]],
+    device const float* codesImag [[buffer(1)]],
+    device const float* queryReal [[buffer(2)]],
+    device const float* queryImag [[buffer(3)]],
+    device float* outScores [[buffer(4)]],
+    constant int& V [[buffer(5)]],
+    constant int& D [[buffer(6)]],
+    uint v [[thread_position_in_grid]])
+{
+    if ((int)v >= V) return;
+    device const float* cR = codesReal + (long)v * D;
+    device const float* cI = codesImag + (long)v * D;
+    float acc = 0.0f;
+    for (int d = 0; d < D; d++) {
+        acc += cR[d] * queryReal[d] + cI[d] * queryImag[d];
+    }
+    outScores[v] = acc;
+}
+
+kernel void hrr_bind_accumulate(
+    device const float* keyCodeReal [[buffer(0)]],
+    device const float* keyCodeImag [[buffer(1)]],
+    device const float* valPermCodeReal [[buffer(2)]],
+    device const float* valPermCodeImag [[buffer(3)]],
+    device const int* keyIds [[buffer(4)]],
+    device const int* valIds [[buffer(5)]],
+    device float* memoryReal [[buffer(6)]],
+    device float* memoryImag [[buffer(7)]],
+    constant int& N [[buffer(8)]],
+    constant int& D [[buffer(9)]],
+    uint d [[thread_position_in_grid]])
+{
+    if ((int)d >= D) return;
+    float accR = memoryReal[d];
+    float accI = memoryImag[d];
+    for (int n = 0; n < N; n++) {
+        long kOff = (long)keyIds[n] * D;
+        long vOff = (long)valIds[n] * D;
+        float ar = keyCodeReal[kOff + d];
+        float ai = keyCodeImag[kOff + d];
+        float br = valPermCodeReal[vOff + d];
+        float bi = valPermCodeImag[vOff + d];
+        accR += ar * br - ai * bi;
+        accI += ar * bi + ai * br;
+    }
+    memoryReal[d] = accR;
+    memoryImag[d] = accI;
+}
 ";
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalComplexKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalComplexKernels.cs
@@ -228,6 +228,10 @@ kernel void hrr_phase_coherence_decode(
     outScores[v] = acc;
 }
 
+// nKeys / nVals match the CUDA/HIP kernels: codebook row counts
+// passed by the host so out-of-range ids are rejected without OOB
+// reads. See CudaComplexKernels.hrr_bind_accumulate for the full
+// rationale.
 kernel void hrr_bind_accumulate(
     device const float* keyCodeReal [[buffer(0)]],
     device const float* keyCodeImag [[buffer(1)]],
@@ -239,14 +243,21 @@ kernel void hrr_bind_accumulate(
     device float* memoryImag [[buffer(7)]],
     constant int& N [[buffer(8)]],
     constant int& D [[buffer(9)]],
+    constant int& nKeys [[buffer(10)]],
+    constant int& nVals [[buffer(11)]],
     uint d [[thread_position_in_grid]])
 {
     if ((int)d >= D) return;
     float accR = memoryReal[d];
     float accI = memoryImag[d];
     for (int n = 0; n < N; n++) {
-        long kOff = (long)keyIds[n] * D;
-        long vOff = (long)valIds[n] * D;
+        int kId = keyIds[n];
+        int vId = valIds[n];
+        // Unsigned-comparison trick rejects both negative and
+        // too-large indices in one branch.
+        if ((uint)kId >= (uint)nKeys || (uint)vId >= (uint)nVals) continue;
+        long kOff = (long)kId * D;
+        long vOff = (long)vId * D;
         float ar = keyCodeReal[kOff + d];
         float ai = keyCodeImag[kOff + d];
         float br = valPermCodeReal[vOff + d];

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalComplexKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalComplexKernels.cs
@@ -167,14 +167,23 @@ kernel void softmax_rows(
 }
 
 // ─── HRR binding primitives (issue #248) ────────────────────────────
+// Matches CUDA/HIP/OpenCL/Vulkan/WebGPU — see CudaComplexKernels.cs
+// for the hash rationale (32-bit Murmur3 fmix chosen for WebGPU
+// compatibility; per-backend GPU determinism preserved, CPU
+// xorshift64* path intentionally divergent for single-thread speed).
+inline uint hrr_hash(uint seed_u, uint cell_u)
+{
+    uint z = seed_u * 0x9E3779B9u + cell_u * 0x85EBCA6Bu;
+    z = (z ^ (z >> 16)) * 0x85EBCA6Bu;
+    z = (z ^ (z >> 13)) * 0xC2B2AE35u;
+    z =  z ^ (z >> 16);
+    return z;
+}
+
 inline float hrr_phase_from_cell(int seed, ulong cellIdx)
 {
-    ulong z = (ulong)seed * 0x9E3779B97F4A7C15UL
-            + cellIdx * 0xBF58476D1CE4E5B9UL;
-    z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9UL;
-    z = (z ^ (z >> 27)) * 0x94D049BB133111EBUL;
-    z =  z ^ (z >> 31);
-    uint top24 = (uint)(z >> 40);
+    uint z = hrr_hash((uint)seed, (uint)cellIdx);
+    uint top24 = z >> 8;
     return (float)top24 * (1.0f / 16777216.0f) * 6.28318530717958647692f;
 }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/ComplexKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/ComplexKernels.cs
@@ -12,7 +12,11 @@ public static class ComplexKernels
         "split_complex_phase", "split_complex_from_polar",
         "split_complex_scale", "split_complex_add",
         "split_complex_cross_spectral",
-        "split_complex_topk", "softmax_rows"
+        "split_complex_topk", "softmax_rows",
+        // Issue #248 — HRR binding primitives
+        "hrr_unit_phase_codebook",
+        "hrr_phase_coherence_decode",
+        "hrr_bind_accumulate"
     };
 
     public static string GetSource() => @"
@@ -139,6 +143,82 @@ __kernel void softmax_rows(
     float sumExp = 0.0f;
     for (int c = 0; c < cols; c++) { float e = exp(input[offset + c] - maxVal); output[offset + c] = e; sumExp += e; }
     for (int c = 0; c < cols; c++) output[offset + c] /= sumExp;
+}
+
+// ─── HRR binding primitives (issue #248) ────────────────────────────
+inline float hrr_phase_from_cell(int seed, long cellIdx)
+{
+    ulong z = (ulong)seed * 0x9E3779B97F4A7C15UL
+            + (ulong)cellIdx * 0xBF58476D1CE4E5B9UL;
+    z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9UL;
+    z = (z ^ (z >> 27)) * 0x94D049BB133111EBUL;
+    z =  z ^ (z >> 31);
+    uint top24 = (uint)(z >> 40);
+    return (float)top24 * (1.0f / 16777216.0f) * 6.28318530717958647692f;
+}
+
+__kernel void hrr_unit_phase_codebook(
+    __global float* outReal, __global float* outImag,
+    const int seed, const int V, const int D,
+    const int kPsk, const int k)
+{
+    long idx = get_global_id(0);
+    long total = (long)V * D;
+    if (idx >= total) return;
+    float phase = hrr_phase_from_cell(seed, idx);
+    if (kPsk != 0) {
+        float step = 6.28318530717958647692f / (float)k;
+        phase = floor(phase / step + 0.5f) * step;
+    }
+    outReal[idx] = cos(phase);
+    outImag[idx] = sin(phase);
+}
+
+// One work-item per V row. Each work-item iterates all D entries of
+// its row and produces one score. Simpler than a tree reduction (no
+// local memory needed), and V is usually small enough (≤ 1024) that
+// the parallelism across V covers any GPU's wavefront size — same
+// tradeoff as softmax_rows above.
+__kernel void hrr_phase_coherence_decode(
+    __global const float* codesReal, __global const float* codesImag,
+    __global const float* queryReal, __global const float* queryImag,
+    __global float* outScores,
+    const int V, const int D)
+{
+    int v = get_global_id(0);
+    if (v >= V) return;
+    __global const float* cR = codesReal + (long)v * D;
+    __global const float* cI = codesImag + (long)v * D;
+    float acc = 0.0f;
+    for (int d = 0; d < D; d++) {
+        acc += cR[d] * queryReal[d] + cI[d] * queryImag[d];
+    }
+    outScores[v] = acc;
+}
+
+__kernel void hrr_bind_accumulate(
+    __global const float* keyCodeReal, __global const float* keyCodeImag,
+    __global const float* valPermCodeReal, __global const float* valPermCodeImag,
+    __global const int* keyIds, __global const int* valIds,
+    __global float* memoryReal, __global float* memoryImag,
+    const int N, const int D)
+{
+    int d = get_global_id(0);
+    if (d >= D) return;
+    float accR = memoryReal[d];
+    float accI = memoryImag[d];
+    for (int n = 0; n < N; n++) {
+        long kOff = (long)keyIds[n] * D;
+        long vOff = (long)valIds[n] * D;
+        float ar = keyCodeReal[kOff + d];
+        float ai = keyCodeImag[kOff + d];
+        float br = valPermCodeReal[vOff + d];
+        float bi = valPermCodeImag[vOff + d];
+        accR += ar * br - ai * bi;
+        accI += ar * bi + ai * br;
+    }
+    memoryReal[d] = accR;
+    memoryImag[d] = accI;
 }
 ";
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/ComplexKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/ComplexKernels.cs
@@ -146,14 +146,23 @@ __kernel void softmax_rows(
 }
 
 // ─── HRR binding primitives (issue #248) ────────────────────────────
+// Matches CUDA/HIP/Metal/Vulkan/WebGPU — see CudaComplexKernels.cs for
+// the hash rationale (32-bit Murmur3 fmix chosen for WebGPU
+// compatibility; per-backend GPU determinism preserved, CPU
+// xorshift64* path intentionally divergent for single-thread speed).
+inline uint hrr_hash(uint seed_u, uint cell_u)
+{
+    uint z = seed_u * 0x9E3779B9u + cell_u * 0x85EBCA6Bu;
+    z = (z ^ (z >> 16)) * 0x85EBCA6Bu;
+    z = (z ^ (z >> 13)) * 0xC2B2AE35u;
+    z =  z ^ (z >> 16);
+    return z;
+}
+
 inline float hrr_phase_from_cell(int seed, long cellIdx)
 {
-    ulong z = (ulong)seed * 0x9E3779B97F4A7C15UL
-            + (ulong)cellIdx * 0xBF58476D1CE4E5B9UL;
-    z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9UL;
-    z = (z ^ (z >> 27)) * 0x94D049BB133111EBUL;
-    z =  z ^ (z >> 31);
-    uint top24 = (uint)(z >> 40);
+    uint z = hrr_hash((uint)seed, (uint)cellIdx);
+    uint top24 = z >> 8;
     return (float)top24 * (1.0f / 16777216.0f) * 6.28318530717958647692f;
 }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -10729,6 +10729,72 @@ KERNEL VARIANTS (A/B testing):
         kernel.Execute1D(rows, localSize);
     }
 
+    // ─── HRR binding primitives (issue #248) ────────────────────────
+
+    public void SplitComplexUnitPhaseCodebook(
+        IGpuBuffer outReal, IGpuBuffer outImag, int seed, int V, int D, bool kPsk, int k)
+    {
+        long total = (long)V * D;
+        if (total <= 0) return;
+        if (total > int.MaxValue) throw new ArgumentException($"V*D = {total} exceeds int.MaxValue.");
+        if (kPsk && k <= 0) throw new ArgumentOutOfRangeException(nameof(k));
+        if (!_kernelCache.TryGetValue("hrr_unit_phase_codebook", out var kernel))
+            throw new InvalidOperationException("OpenCL kernel not found: hrr_unit_phase_codebook");
+        int n = (int)total;
+        int localSize = CalculateOptimalWorkGroupSize1D(n);
+        kernel.SetArg(0u, ((DirectOpenClGpuBuffer)outReal).Buffer.Handle);
+        kernel.SetArg(1u, ((DirectOpenClGpuBuffer)outImag).Buffer.Handle);
+        kernel.SetArg(2u, seed);
+        kernel.SetArg(3u, V);
+        kernel.SetArg(4u, D);
+        kernel.SetArg(5u, kPsk ? 1 : 0);
+        kernel.SetArg(6u, k);
+        kernel.Execute1D(n, localSize);
+    }
+
+    public void SplitComplexPhaseCoherenceDecode(
+        IGpuBuffer codesReal, IGpuBuffer codesImag,
+        IGpuBuffer queryReal, IGpuBuffer queryImag,
+        IGpuBuffer outScores, int V, int D)
+    {
+        if (V <= 0 || D <= 0) return;
+        if (!_kernelCache.TryGetValue("hrr_phase_coherence_decode", out var kernel))
+            throw new InvalidOperationException("OpenCL kernel not found: hrr_phase_coherence_decode");
+        int localSize = CalculateOptimalWorkGroupSize1D(V);
+        kernel.SetArg(0u, ((DirectOpenClGpuBuffer)codesReal).Buffer.Handle);
+        kernel.SetArg(1u, ((DirectOpenClGpuBuffer)codesImag).Buffer.Handle);
+        kernel.SetArg(2u, ((DirectOpenClGpuBuffer)queryReal).Buffer.Handle);
+        kernel.SetArg(3u, ((DirectOpenClGpuBuffer)queryImag).Buffer.Handle);
+        kernel.SetArg(4u, ((DirectOpenClGpuBuffer)outScores).Buffer.Handle);
+        kernel.SetArg(5u, V);
+        kernel.SetArg(6u, D);
+        kernel.Execute1D(V, localSize);
+    }
+
+    public void SplitComplexHrrBindAccumulate(
+        IGpuBuffer keyCodeReal, IGpuBuffer keyCodeImag,
+        IGpuBuffer valPermCodeReal, IGpuBuffer valPermCodeImag,
+        IGpuBuffer keyIds, IGpuBuffer valIds,
+        IGpuBuffer memoryReal, IGpuBuffer memoryImag,
+        int N, int D)
+    {
+        if (N <= 0 || D <= 0) return;
+        if (!_kernelCache.TryGetValue("hrr_bind_accumulate", out var kernel))
+            throw new InvalidOperationException("OpenCL kernel not found: hrr_bind_accumulate");
+        int localSize = CalculateOptimalWorkGroupSize1D(D);
+        kernel.SetArg(0u, ((DirectOpenClGpuBuffer)keyCodeReal).Buffer.Handle);
+        kernel.SetArg(1u, ((DirectOpenClGpuBuffer)keyCodeImag).Buffer.Handle);
+        kernel.SetArg(2u, ((DirectOpenClGpuBuffer)valPermCodeReal).Buffer.Handle);
+        kernel.SetArg(3u, ((DirectOpenClGpuBuffer)valPermCodeImag).Buffer.Handle);
+        kernel.SetArg(4u, ((DirectOpenClGpuBuffer)keyIds).Buffer.Handle);
+        kernel.SetArg(5u, ((DirectOpenClGpuBuffer)valIds).Buffer.Handle);
+        kernel.SetArg(6u, ((DirectOpenClGpuBuffer)memoryReal).Buffer.Handle);
+        kernel.SetArg(7u, ((DirectOpenClGpuBuffer)memoryImag).Buffer.Handle);
+        kernel.SetArg(8u, N);
+        kernel.SetArg(9u, D);
+        kernel.Execute1D(D, localSize);
+    }
+
     /// <inheritdoc/>
     public void SpectralFilter(IGpuBuffer inputReal, IGpuBuffer filterReal, IGpuBuffer filterImag,
         IGpuBuffer outputReal, int batch, int height, int width, int filterSliceCount)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -10731,16 +10731,29 @@ KERNEL VARIANTS (A/B testing):
 
     // ─── HRR binding primitives (issue #248) ────────────────────────
 
+    private static void EnsureHrrMinSize(IGpuBuffer buffer, long required, string paramName)
+    {
+        if (buffer is null) throw new ArgumentNullException(paramName);
+        if (buffer.Size < required)
+            throw new ArgumentException(
+                $"{paramName} must contain at least {required} elements (got {buffer.Size}).",
+                paramName);
+    }
+
     public void SplitComplexUnitPhaseCodebook(
         IGpuBuffer outReal, IGpuBuffer outImag, int seed, int V, int D, bool kPsk, int k)
     {
+        if (V < 0) throw new ArgumentOutOfRangeException(nameof(V), "V must be >= 0.");
+        if (D < 0) throw new ArgumentOutOfRangeException(nameof(D), "D must be >= 0.");
+        if (V == 0 || D == 0) return;
         long total = (long)V * D;
-        if (total <= 0) return;
         if (total > int.MaxValue) throw new ArgumentException($"V*D = {total} exceeds int.MaxValue.");
         if (kPsk && k <= 0) throw new ArgumentOutOfRangeException(nameof(k));
+        int n = (int)total;
+        EnsureHrrMinSize(outReal, n, nameof(outReal));
+        EnsureHrrMinSize(outImag, n, nameof(outImag));
         if (!_kernelCache.TryGetValue("hrr_unit_phase_codebook", out var kernel))
             throw new InvalidOperationException("OpenCL kernel not found: hrr_unit_phase_codebook");
-        int n = (int)total;
         int localSize = CalculateOptimalWorkGroupSize1D(n);
         kernel.SetArg(0u, ((DirectOpenClGpuBuffer)outReal).Buffer.Handle);
         kernel.SetArg(1u, ((DirectOpenClGpuBuffer)outImag).Buffer.Handle);
@@ -10758,6 +10771,13 @@ KERNEL VARIANTS (A/B testing):
         IGpuBuffer outScores, int V, int D)
     {
         if (V <= 0 || D <= 0) return;
+        long codeElems = (long)V * D;
+        if (codeElems > int.MaxValue) throw new ArgumentException($"V*D = {codeElems} exceeds int.MaxValue.");
+        EnsureHrrMinSize(codesReal, codeElems, nameof(codesReal));
+        EnsureHrrMinSize(codesImag, codeElems, nameof(codesImag));
+        EnsureHrrMinSize(queryReal, D, nameof(queryReal));
+        EnsureHrrMinSize(queryImag, D, nameof(queryImag));
+        EnsureHrrMinSize(outScores, V, nameof(outScores));
         if (!_kernelCache.TryGetValue("hrr_phase_coherence_decode", out var kernel))
             throw new InvalidOperationException("OpenCL kernel not found: hrr_phase_coherence_decode");
         int localSize = CalculateOptimalWorkGroupSize1D(V);
@@ -10779,6 +10799,14 @@ KERNEL VARIANTS (A/B testing):
         int N, int D)
     {
         if (N <= 0 || D <= 0) return;
+        EnsureHrrMinSize(keyIds, N, nameof(keyIds));
+        EnsureHrrMinSize(valIds, N, nameof(valIds));
+        EnsureHrrMinSize(memoryReal, D, nameof(memoryReal));
+        EnsureHrrMinSize(memoryImag, D, nameof(memoryImag));
+        EnsureHrrMinSize(keyCodeReal, D, nameof(keyCodeReal));
+        EnsureHrrMinSize(keyCodeImag, D, nameof(keyCodeImag));
+        EnsureHrrMinSize(valPermCodeReal, D, nameof(valPermCodeReal));
+        EnsureHrrMinSize(valPermCodeImag, D, nameof(valPermCodeImag));
         if (!_kernelCache.TryGetValue("hrr_bind_accumulate", out var kernel))
             throw new InvalidOperationException("OpenCL kernel not found: hrr_bind_accumulate");
         int localSize = CalculateOptimalWorkGroupSize1D(D);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
@@ -1793,15 +1793,26 @@ public sealed unsafe partial class VulkanBackend
         int N, int D)
     {
         if (N <= 0 || D <= 0) return;
-        var push = new uint[] { (uint)N, (uint)D };
+        // Derive vocabulary sizes from codebook buffer capacities so
+        // the shader can reject out-of-range ids without reading past
+        // allocated memory — mirrors the CPU path's
+        // (uint)kId >= (uint)nKeys check in NativeHRRBindAccumulate.
+        long nKeysL = keyCodeReal.Size / D;
+        long nValsL = valPermCodeReal.Size / D;
+        if (nKeysL <= 0 || nValsL <= 0)
+            throw new ArgumentException(
+                $"Codebook buffers must hold at least one full row of D = {D} elements.");
+        if (nKeysL > int.MaxValue || nValsL > int.MaxValue)
+            throw new ArgumentException("Codebook vocabulary size exceeds int.MaxValue.");
+        var push = new uint[] { (uint)N, (uint)D, (uint)nKeysL, (uint)nValsL };
         // Dispatch one thread per output dimension; each thread loops N.
         // keyIds/valIds stored as Int32BitsToSingle floats — shader reverses
-        // with floatBitsToInt().
+        // with floatBitsToInt() and validates against nKeys / nVals.
         GlslOctOp(
             VulkanHrrKernels.HrrBindAccumulate,
             keyCodeReal, keyCodeImag, valPermCodeReal, valPermCodeImag,
             keyIds, valIds, memoryReal, memoryImag,
-            D, push, 2 * sizeof(uint));
+            D, push, 4 * sizeof(uint));
     }
 
     /// <inheritdoc/>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
@@ -1741,6 +1741,87 @@ public sealed unsafe partial class VulkanBackend
         finally { rb.Dispose(); }
     }
 
+    // ─── HRR binding primitives (issue #248) ────────────────────────
+    //
+    // Vulkan backend runs these through SIMD HRR kernels on CPU, then
+    // uploads the result. Matches the pattern of SoftmaxRows / TopK
+    // above, which also download-compute-upload. A follow-up could add
+    // GLSL compute shaders that keep the work on GPU, but the download
+    // path is correct + deterministic today.
+
+    public void SplitComplexUnitPhaseCodebook(
+        IGpuBuffer outReal, IGpuBuffer outImag, int seed, int V, int D, bool kPsk, int k)
+    {
+        long total = (long)V * D;
+        if (total <= 0) return;
+        if (total > int.MaxValue) throw new ArgumentException($"V*D = {total} exceeds int.MaxValue.");
+        if (kPsk && k <= 0) throw new ArgumentOutOfRangeException(nameof(k));
+        int n = (int)total;
+        var outR = new float[n];
+        var outI = new float[n];
+        Simd.SimdHrrKernels.UnitPhaseCodebookFloat(outR, outI, seed, V, D, kPsk, k);
+        var rBuf = AllocateBuffer(outR);
+        var iBuf = AllocateBuffer(outI);
+        try { Copy(rBuf, 0, outReal, 0, n); Copy(iBuf, 0, outImag, 0, n); }
+        finally { rBuf.Dispose(); iBuf.Dispose(); }
+    }
+
+    public void SplitComplexPhaseCoherenceDecode(
+        IGpuBuffer codesReal, IGpuBuffer codesImag,
+        IGpuBuffer queryReal, IGpuBuffer queryImag,
+        IGpuBuffer outScores, int V, int D)
+    {
+        if (V <= 0 || D <= 0) return;
+        var cR = DownloadBuffer(codesReal);
+        var cI = DownloadBuffer(codesImag);
+        var qR = DownloadBuffer(queryReal);
+        var qI = DownloadBuffer(queryImag);
+        var scores = new float[V];
+        Simd.SimdHrrKernels.PhaseCoherenceDecodeFloat(cR, cI, qR, qI, scores, V, D);
+        var sBuf = AllocateBuffer(scores);
+        try { Copy(sBuf, 0, outScores, 0, V); }
+        finally { sBuf.Dispose(); }
+    }
+
+    public void SplitComplexHrrBindAccumulate(
+        IGpuBuffer keyCodeReal, IGpuBuffer keyCodeImag,
+        IGpuBuffer valPermCodeReal, IGpuBuffer valPermCodeImag,
+        IGpuBuffer keyIds, IGpuBuffer valIds,
+        IGpuBuffer memoryReal, IGpuBuffer memoryImag,
+        int N, int D)
+    {
+        if (N <= 0 || D <= 0) return;
+        var kR = DownloadBuffer(keyCodeReal);
+        var kI = DownloadBuffer(keyCodeImag);
+        var vR = DownloadBuffer(valPermCodeReal);
+        var vI = DownloadBuffer(valPermCodeImag);
+        // Int buffers on Vulkan are stored as float reinterprets (see
+        // AllocateIntBuffer using Int32BitsToSingle). Download as floats
+        // and reinterpret back.
+        var kIds = ReinterpretAsInts(DownloadBuffer(keyIds));
+        var vIds = ReinterpretAsInts(DownloadBuffer(valIds));
+        var mR = DownloadBuffer(memoryReal);
+        var mI = DownloadBuffer(memoryImag);
+        Simd.SimdHrrKernels.HRRBindAccumulateFloat(
+            kR, kI, vR, vI, kIds, vIds, mR, mI, D);
+        var rBuf = AllocateBuffer(mR);
+        var iBuf = AllocateBuffer(mI);
+        try { Copy(rBuf, 0, memoryReal, 0, D); Copy(iBuf, 0, memoryImag, 0, D); }
+        finally { rBuf.Dispose(); iBuf.Dispose(); }
+    }
+
+    // Reverses AllocateIntBuffer's Int32BitsToSingleCompat reinterpret
+    // so the SIMD kernel sees the original int values. Uses the
+    // existing SingleToInt32BitsCompat (defined next to
+    // Int32BitsToSingleCompat elsewhere in the partial class).
+    private static int[] ReinterpretAsInts(float[] floats)
+    {
+        var ints = new int[floats.Length];
+        for (int i = 0; i < floats.Length; i++)
+            ints[i] = SingleToInt32BitsCompat(floats[i]);
+        return ints;
+    }
+
     /// <inheritdoc/>
     public void SpectralFilter(IGpuBuffer inputReal, IGpuBuffer filterReal, IGpuBuffer filterImag,
         IGpuBuffer outputReal, int batch, int height, int width, int filterSliceCount)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
@@ -1743,11 +1743,12 @@ public sealed unsafe partial class VulkanBackend
 
     // ─── HRR binding primitives (issue #248) ────────────────────────
     //
-    // Vulkan backend runs these through SIMD HRR kernels on CPU, then
-    // uploads the result. Matches the pattern of SoftmaxRows / TopK
-    // above, which also download-compute-upload. A follow-up could add
-    // GLSL compute shaders that keep the work on GPU, but the download
-    // path is correct + deterministic today.
+    // Native GLSL compute shaders — work stays on the GPU end-to-end.
+    // Per-cell phases use a 32-bit Murmur3 fmix; deterministic within
+    // the Vulkan backend (same seed + same (V, D) → identical output)
+    // but does not bit-match the CPU xorshift64* or CUDA splitmix64
+    // sequences. This is acceptable — cross-device bit-identity on
+    // random initialization is not part of the contract.
 
     public void SplitComplexUnitPhaseCodebook(
         IGpuBuffer outReal, IGpuBuffer outImag, int seed, int V, int D, bool kPsk, int k)
@@ -1757,13 +1758,18 @@ public sealed unsafe partial class VulkanBackend
         if (total > int.MaxValue) throw new ArgumentException($"V*D = {total} exceeds int.MaxValue.");
         if (kPsk && k <= 0) throw new ArgumentOutOfRangeException(nameof(k));
         int n = (int)total;
-        var outR = new float[n];
-        var outI = new float[n];
-        Simd.SimdHrrKernels.UnitPhaseCodebookFloat(outR, outI, seed, V, D, kPsk, k);
-        var rBuf = AllocateBuffer(outR);
-        var iBuf = AllocateBuffer(outI);
-        try { Copy(rBuf, 0, outReal, 0, n); Copy(iBuf, 0, outImag, 0, n); }
-        finally { rBuf.Dispose(); iBuf.Dispose(); }
+
+        // Push constants: { seed, V, D, kPsk, k, total } — 24 bytes.
+        var push = new uint[]
+        {
+            unchecked((uint)seed),
+            (uint)V,
+            (uint)D,
+            (uint)(kPsk ? 1 : 0),
+            (uint)k,
+            (uint)n,
+        };
+        GlslUnaryOp(VulkanHrrKernels.UnitPhaseCodebook, outReal, outImag, n, push, 6 * sizeof(uint));
     }
 
     public void SplitComplexPhaseCoherenceDecode(
@@ -1772,15 +1778,11 @@ public sealed unsafe partial class VulkanBackend
         IGpuBuffer outScores, int V, int D)
     {
         if (V <= 0 || D <= 0) return;
-        var cR = DownloadBuffer(codesReal);
-        var cI = DownloadBuffer(codesImag);
-        var qR = DownloadBuffer(queryReal);
-        var qI = DownloadBuffer(queryImag);
-        var scores = new float[V];
-        Simd.SimdHrrKernels.PhaseCoherenceDecodeFloat(cR, cI, qR, qI, scores, V, D);
-        var sBuf = AllocateBuffer(scores);
-        try { Copy(sBuf, 0, outScores, 0, V); }
-        finally { sBuf.Dispose(); }
+        var push = new uint[] { (uint)V, (uint)D };
+        GlslQuintOp(
+            VulkanHrrKernels.PhaseCoherenceDecode,
+            codesReal, codesImag, queryReal, queryImag, outScores,
+            V, push, 2 * sizeof(uint));
     }
 
     public void SplitComplexHrrBindAccumulate(
@@ -1791,35 +1793,15 @@ public sealed unsafe partial class VulkanBackend
         int N, int D)
     {
         if (N <= 0 || D <= 0) return;
-        var kR = DownloadBuffer(keyCodeReal);
-        var kI = DownloadBuffer(keyCodeImag);
-        var vR = DownloadBuffer(valPermCodeReal);
-        var vI = DownloadBuffer(valPermCodeImag);
-        // Int buffers on Vulkan are stored as float reinterprets (see
-        // AllocateIntBuffer using Int32BitsToSingle). Download as floats
-        // and reinterpret back.
-        var kIds = ReinterpretAsInts(DownloadBuffer(keyIds));
-        var vIds = ReinterpretAsInts(DownloadBuffer(valIds));
-        var mR = DownloadBuffer(memoryReal);
-        var mI = DownloadBuffer(memoryImag);
-        Simd.SimdHrrKernels.HRRBindAccumulateFloat(
-            kR, kI, vR, vI, kIds, vIds, mR, mI, D);
-        var rBuf = AllocateBuffer(mR);
-        var iBuf = AllocateBuffer(mI);
-        try { Copy(rBuf, 0, memoryReal, 0, D); Copy(iBuf, 0, memoryImag, 0, D); }
-        finally { rBuf.Dispose(); iBuf.Dispose(); }
-    }
-
-    // Reverses AllocateIntBuffer's Int32BitsToSingleCompat reinterpret
-    // so the SIMD kernel sees the original int values. Uses the
-    // existing SingleToInt32BitsCompat (defined next to
-    // Int32BitsToSingleCompat elsewhere in the partial class).
-    private static int[] ReinterpretAsInts(float[] floats)
-    {
-        var ints = new int[floats.Length];
-        for (int i = 0; i < floats.Length; i++)
-            ints[i] = SingleToInt32BitsCompat(floats[i]);
-        return ints;
+        var push = new uint[] { (uint)N, (uint)D };
+        // Dispatch one thread per output dimension; each thread loops N.
+        // keyIds/valIds stored as Int32BitsToSingle floats — shader reverses
+        // with floatBitsToInt().
+        GlslOctOp(
+            VulkanHrrKernels.HrrBindAccumulate,
+            keyCodeReal, keyCodeImag, valPermCodeReal, valPermCodeImag,
+            keyIds, valIds, memoryReal, memoryImag,
+            D, push, 2 * sizeof(uint));
     }
 
     /// <inheritdoc/>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
@@ -1753,8 +1753,13 @@ public sealed unsafe partial class VulkanBackend
     public void SplitComplexUnitPhaseCodebook(
         IGpuBuffer outReal, IGpuBuffer outImag, int seed, int V, int D, bool kPsk, int k)
     {
+        // Reject negative dims up front — if both are negative, their
+        // product is positive and would slip past "total <= 0", then
+        // the shader would cast to uint and index out of bounds.
+        if (V < 0) throw new ArgumentOutOfRangeException(nameof(V), "V must be >= 0.");
+        if (D < 0) throw new ArgumentOutOfRangeException(nameof(D), "D must be >= 0.");
+        if (V == 0 || D == 0) return;
         long total = (long)V * D;
-        if (total <= 0) return;
         if (total > int.MaxValue) throw new ArgumentException($"V*D = {total} exceeds int.MaxValue.");
         if (kPsk && k <= 0) throw new ArgumentOutOfRangeException(nameof(k));
         int n = (int)total;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.cs
@@ -396,6 +396,28 @@ public sealed unsafe partial class VulkanBackend : IDirectGpuBackend, IGpuBatchE
         }
     }
 
+    /// <summary>
+    /// Executes a GLSL-compiled compute pipeline with 8 buffers + push constants.
+    /// Used for HRR bind-accumulate (keyR, keyI, valR, valI, keyIds, valIds,
+    /// memR_inout, memI_inout). All modern desktop / mobile Vulkan drivers
+    /// report maxPerStageDescriptorStorageBuffers ≥ 16; 8 is well within that.
+    /// </summary>
+    private void GlslOctOp(string glslSource, IGpuBuffer A, IGpuBuffer B, IGpuBuffer C, IGpuBuffer D, IGpuBuffer E, IGpuBuffer F, IGpuBuffer G, IGpuBuffer H, int dispatchSize, uint[] pushConstants, uint pushConstantSize)
+    {
+        EnsureInitialized();
+        if (dispatchSize <= 0) return;
+        var pipeline = GetOrCreateGlslPipeline(glslSource, 8, pushConstantSize);
+        if (pipeline is null) throw new InvalidOperationException("Vulkan GLSL pipeline unavailable — install libshaderc for runtime compilation.");
+        var vbA = AsVulkan(A); var vbB = AsVulkan(B); var vbC = AsVulkan(C); var vbD = AsVulkan(D);
+        var vbE = AsVulkan(E); var vbF = AsVulkan(F); var vbG = AsVulkan(G); var vbH = AsVulkan(H);
+        var threadRes = _device.AcquireThreadResources();
+        lock (_computeLock)
+        {
+            pipeline.UpdateDescriptorSet(vbA.Storage, vbB.Storage, vbC.Storage, vbD.Storage, vbE.Storage, vbF.Storage, vbG.Storage, vbH.Storage);
+            RecordAndExecuteWithPushData(pipeline, dispatchSize, pushConstants, pushConstantSize, threadRes);
+        }
+    }
+
     // CPU fallback when GLSL pipeline creation fails (shaderc unavailable or compilation error).
     // When GLSL pipeline creation fails (shaderc unavailable or compilation error),
     // throw instead of silently returning wrong results. An identity copy would produce

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanHrrKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanHrrKernels.cs
@@ -1,0 +1,147 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// GLSL 450 compute shaders for HRR binding primitives (issue #248).
+//
+// Each kernel keeps work on the GPU — no download/upload. Per-cell
+// phases use a 32-bit Murmur3 fmix hash seeded from (seed, cellIdx).
+// This does NOT bit-match the CPU xorshift64* sequence or the CUDA
+// splitmix64 sequence; each backend generates its own uniformly
+// distributed phase. Determinism within a backend (same seed + same
+// (V, D) → identical output) is preserved.
+//
+// Int buffers (keyIds / valIds) arrive as float bitcasts — see
+// VulkanBackend.AllocateIntBuffer which packs via Int32BitsToSingle.
+// Inside the shader we reverse this with floatBitsToInt().
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.Vulkan;
+
+internal static class VulkanHrrKernels
+{
+    private const string Header = @"#version 450
+layout(local_size_x = 256) in;
+
+uint hrr_hash(uint seed_u, uint cell_u) {
+    // Murmur3-fmix — uniform 32-bit output for any 32-bit input.
+    uint z = seed_u * 0x9E3779B9u + cell_u * 0x85EBCA6Bu;
+    z = (z ^ (z >> 16)) * 0x85EBCA6Bu;
+    z = (z ^ (z >> 13)) * 0xC2B2AE35u;
+    z =  z ^ (z >> 16);
+    return z;
+}
+
+float hrr_phase_from_cell(int seed, uint cellIdx) {
+    uint z = hrr_hash(uint(seed), cellIdx);
+    // Upper 24 bits → exact-representable float in [0, 1).
+    uint top24 = z >> 8;
+    return float(top24) * (1.0 / 16777216.0) * 6.28318530717958647692;
+}
+";
+
+    /// <summary>
+    /// outReal[i], outImag[i] = cos/sin of deterministic phase derived
+    /// from (seed, i). If kPsk != 0, the phase snaps to the nearest
+    /// multiple of 2π/k (k-ary phase-shift keying).
+    /// </summary>
+    public static string UnitPhaseCodebook => Header + @"
+layout(set = 0, binding = 0) writeonly buffer OR { float outReal[]; };
+layout(set = 0, binding = 1) writeonly buffer OI { float outImag[]; };
+layout(push_constant) uniform P {
+    int seed;
+    int V;
+    int D;
+    int kPsk;
+    int k;
+    int total;  // = V * D (pre-computed to avoid mul in hot path)
+} p;
+
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    if (gid >= uint(p.total)) return;
+
+    float phase = hrr_phase_from_cell(p.seed, gid);
+    if (p.kPsk != 0) {
+        float step = 6.28318530717958647692 / float(p.k);
+        phase = floor(phase / step + 0.5) * step;
+    }
+    outReal[gid] = cos(phase);
+    outImag[gid] = sin(phase);
+}
+";
+
+    /// <summary>
+    /// One work-item per V. Each thread loops D and accumulates the
+    /// real part of the Hermitian inner product &lt;codes[v], query&gt;:
+    /// scores[v] = Σ_d (codesR[v,d]·queryR[d] + codesI[v,d]·queryI[d]).
+    /// </summary>
+    public static string PhaseCoherenceDecode => Header + @"
+layout(set = 0, binding = 0) readonly buffer CR { float codesReal[]; };
+layout(set = 0, binding = 1) readonly buffer CI { float codesImag[]; };
+layout(set = 0, binding = 2) readonly buffer QR { float queryReal[]; };
+layout(set = 0, binding = 3) readonly buffer QI { float queryImag[]; };
+layout(set = 0, binding = 4) writeonly buffer OS { float outScores[]; };
+layout(push_constant) uniform P {
+    int V;
+    int D;
+} p;
+
+void main() {
+    uint v = gl_GlobalInvocationID.x;
+    if (v >= uint(p.V)) return;
+
+    uint rowOff = v * uint(p.D);
+    float acc = 0.0;
+    for (int d = 0; d < p.D; d++) {
+        acc += codesReal[rowOff + uint(d)] * queryReal[d]
+             + codesImag[rowOff + uint(d)] * queryImag[d];
+    }
+    outScores[v] = acc;
+}
+";
+
+    /// <summary>
+    /// Accumulate N bindings in-place into memory[D]:
+    ///   memory += Σ_n keyCode[keyIds[n]] ⊛ valPermCode[valIds[n]]
+    /// where ⊛ is pointwise complex multiplication.
+    /// One work-item per dimension d; each thread loops N (no cross-
+    /// thread synchronization needed — every thread writes a different
+    /// memory[d]).
+    /// keyIds/valIds are stored as Int32BitsToSingle-packed floats
+    /// (see VulkanBackend.AllocateIntBuffer); we recover the ints with
+    /// floatBitsToInt().
+    /// </summary>
+    public static string HrrBindAccumulate => Header + @"
+layout(set = 0, binding = 0) readonly buffer KR  { float keyCodeReal[]; };
+layout(set = 0, binding = 1) readonly buffer KI  { float keyCodeImag[]; };
+layout(set = 0, binding = 2) readonly buffer VR  { float valPermCodeReal[]; };
+layout(set = 0, binding = 3) readonly buffer VI  { float valPermCodeImag[]; };
+layout(set = 0, binding = 4) readonly buffer KID { float keyIds[]; };
+layout(set = 0, binding = 5) readonly buffer VID { float valIds[]; };
+layout(set = 0, binding = 6)          buffer MR  { float memoryReal[]; };
+layout(set = 0, binding = 7)          buffer MI  { float memoryImag[]; };
+layout(push_constant) uniform P {
+    int N;
+    int D;
+} p;
+
+void main() {
+    uint d = gl_GlobalInvocationID.x;
+    if (d >= uint(p.D)) return;
+
+    float accR = memoryReal[d];
+    float accI = memoryImag[d];
+    for (int n = 0; n < p.N; n++) {
+        int kid = floatBitsToInt(keyIds[n]);
+        int vid = floatBitsToInt(valIds[n]);
+        uint kOff = uint(kid) * uint(p.D) + d;
+        uint vOff = uint(vid) * uint(p.D) + d;
+        float ar = keyCodeReal[kOff];
+        float ai = keyCodeImag[kOff];
+        float br = valPermCodeReal[vOff];
+        float bi = valPermCodeImag[vOff];
+        accR += ar * br - ai * bi;
+        accI += ar * bi + ai * br;
+    }
+    memoryReal[d] = accR;
+    memoryImag[d] = accI;
+}
+";
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanHrrKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanHrrKernels.cs
@@ -58,7 +58,12 @@ void main() {
     if (gid >= uint(p.total)) return;
 
     float phase = hrr_phase_from_cell(p.seed, gid);
-    if (p.kPsk != 0) {
+    // Defense-in-depth: host validates (kPsk && k <= 0) → throw, so
+    // the shader should never see k <= 0 with kPsk set, but guard
+    // against division-by-zero anyway to avoid NaN propagation if
+    // that invariant is ever broken (e.g., by a future caller that
+    // bypasses the host check).
+    if (p.kPsk != 0 && p.k > 0) {
         float step = 6.28318530717958647692 / float(p.k);
         phase = floor(phase / step + 0.5) * step;
     }
@@ -117,9 +122,16 @@ layout(set = 0, binding = 4) readonly buffer KID { float keyIds[]; };
 layout(set = 0, binding = 5) readonly buffer VID { float valIds[]; };
 layout(set = 0, binding = 6)          buffer MR  { float memoryReal[]; };
 layout(set = 0, binding = 7)          buffer MI  { float memoryImag[]; };
+// nKeys / nVals are the vocabulary sizes (codebook row counts); the
+// host passes keyCodeReal.Size / D and valPermCodeReal.Size / D so
+// the shader can reject out-of-range ids without reading past the
+// codebook (mirrors the (uint)kId >= (uint)nKeys check in the CPU
+// SIMD implementation).
 layout(push_constant) uniform P {
     int N;
     int D;
+    int nKeys;
+    int nVals;
 } p;
 
 void main() {
@@ -131,6 +143,11 @@ void main() {
     for (int n = 0; n < p.N; n++) {
         int kid = floatBitsToInt(keyIds[n]);
         int vid = floatBitsToInt(valIds[n]);
+        // Unsigned-comparison trick rejects both negative and
+        // too-large indices in one branch; out-of-range pairs
+        // contribute zero (match the CPU path's exception, but
+        // silently — the shader can't throw).
+        if (uint(kid) >= uint(p.nKeys) || uint(vid) >= uint(p.nVals)) continue;
         uint kOff = uint(kid) * uint(p.D) + d;
         uint vOff = uint(vid) * uint(p.D) + d;
         float ar = keyCodeReal[kOff];

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.cs
@@ -1224,8 +1224,10 @@ public sealed partial class WebGpuBackend : IDirectGpuBackend, IDisposable
     public void SplitComplexUnitPhaseCodebook(
         IGpuBuffer outReal, IGpuBuffer outImag, int seed, int V, int D, bool kPsk, int k)
     {
+        if (V < 0) throw new ArgumentOutOfRangeException(nameof(V), "V must be >= 0.");
+        if (D < 0) throw new ArgumentOutOfRangeException(nameof(D), "D must be >= 0.");
+        if (V == 0 || D == 0) return;
         long total = (long)V * D;
-        if (total <= 0) return;
         if (total > int.MaxValue) throw new ArgumentException($"V*D = {total} exceeds int.MaxValue.");
         if (kPsk && k <= 0) throw new ArgumentOutOfRangeException(nameof(k));
         SplitComplexUnitPhaseCodebookAsync(outReal, outImag, seed, (int)total, V, D, kPsk, k).GetAwaiter().GetResult();
@@ -1250,7 +1252,9 @@ public sealed partial class WebGpuBackend : IDirectGpuBackend, IDisposable
         IGpuBuffer queryReal, IGpuBuffer queryImag,
         IGpuBuffer outScores, int V, int D)
     {
-        if (V <= 0 || D <= 0) return;
+        if (V < 0) throw new ArgumentOutOfRangeException(nameof(V), "V must be >= 0.");
+        if (D < 0) throw new ArgumentOutOfRangeException(nameof(D), "D must be >= 0.");
+        if (V == 0 || D == 0) return;
         SplitComplexPhaseCoherenceDecodeAsync(codesReal, codesImag, queryReal, queryImag, outScores, V, D).GetAwaiter().GetResult();
     }
 
@@ -1279,7 +1283,29 @@ public sealed partial class WebGpuBackend : IDirectGpuBackend, IDisposable
         IGpuBuffer memoryReal, IGpuBuffer memoryImag,
         int N, int D)
     {
-        if (N <= 0 || D <= 0) return;
+        if (N < 0) throw new ArgumentOutOfRangeException(nameof(N), "N must be >= 0.");
+        if (D < 0) throw new ArgumentOutOfRangeException(nameof(D), "D must be >= 0.");
+        if (N == 0 || D == 0) return;
+        // Validate capacities — the WGSL kernel reads keyIds[0..N) and
+        // valIds[0..N) and reads/writes memory[0..D). An undersized
+        // buffer would read/write past the GPU allocation.
+        if (keyIds is null || valIds is null || memoryReal is null || memoryImag is null
+            || keyCodeReal is null || keyCodeImag is null || valPermCodeReal is null || valPermCodeImag is null)
+            throw new ArgumentNullException(nameof(keyIds),
+                "All eight GPU buffers must be non-null for SplitComplexHrrBindAccumulate.");
+        if (keyIds.Size < N || valIds.Size < N)
+            throw new ArgumentException(
+                $"keyIds/valIds must each hold at least N = {N} entries " +
+                $"(got keyIds={keyIds.Size}, valIds={valIds.Size}). " +
+                "Only the first N pairs are accumulated — undersized buffers would read past GPU memory.");
+        if (memoryReal.Size < D || memoryImag.Size < D)
+            throw new ArgumentException(
+                $"Memory buffers must each hold at least D = {D} elements " +
+                $"(got memoryReal={memoryReal.Size}, memoryImag={memoryImag.Size}).");
+        if (keyCodeReal.Size < D || keyCodeImag.Size < D
+            || valPermCodeReal.Size < D || valPermCodeImag.Size < D)
+            throw new ArgumentException(
+                $"Each codebook buffer must hold at least one full row of D = {D} elements.");
         SplitComplexHrrBindAccumulateAsync(
             keyCodeReal, keyCodeImag, valPermCodeReal, valPermCodeImag,
             keyIds, valIds, memoryReal, memoryImag, N, D).GetAwaiter().GetResult();
@@ -1292,10 +1318,21 @@ public sealed partial class WebGpuBackend : IDirectGpuBackend, IDisposable
         IGpuBuffer memoryReal, IGpuBuffer memoryImag,
         int N, int D)
     {
+        // Derive vocabulary sizes from codebook capacities so the
+        // shader can reject out-of-range ids without reading past
+        // allocated memory — mirrors the CPU path's range check in
+        // NativeHRRBindAccumulate and the Vulkan shader guard.
+        long nKeysL = keyCodeReal.Size / D;
+        long nValsL = valPermCodeReal.Size / D;
+        if (nKeysL <= 0 || nValsL <= 0)
+            throw new ArgumentException(
+                $"Codebook buffers must hold at least one full row of D = {D} elements.");
+        if (nKeysL > int.MaxValue || nValsL > int.MaxValue)
+            throw new ArgumentException("Codebook vocabulary size exceeds int.MaxValue.");
         var pipe = await GetOrCreatePipelineAsync(
             HrrModuleKey + ":HrrBindAccumulate", WebGpuHrrKernels.HrrBindAccumulate, "main");
         using var uniforms = new WebGpuBuffer(
-            UniformInts(N, D),
+            UniformInts(N, D, (int)nKeysL, (int)nValsL),
             WebGpuBufferUsage.Uniform | WebGpuBufferUsage.CopyDst);
         using var bind = new WebGpuBindGroup(pipe,
             AsWgpu(keyCodeReal), AsWgpu(keyCodeImag),

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.cs
@@ -1213,9 +1213,13 @@ public sealed partial class WebGpuBackend : IDirectGpuBackend, IDisposable
 
     // ─── HRR binding primitives (issue #248) ────────────────────────
     //
-    // Same download-compute-upload pattern as SoftmaxRows / TopK above.
-    // WGSL compute shaders would be a perf follow-up; the current path
-    // is correct + deterministic.
+    // Native WGSL compute shaders — work stays on the GPU end-to-end.
+    // Per-cell phases use a 32-bit Murmur3 fmix; deterministic within
+    // the WebGPU backend (same seed + same (V, D) → identical output)
+    // but does not bit-match the CPU xorshift64* or CUDA splitmix64
+    // sequences. Cross-device bit-identity is not part of the contract.
+
+    private const string HrrModuleKey = "Hrr";
 
     public void SplitComplexUnitPhaseCodebook(
         IGpuBuffer outReal, IGpuBuffer outImag, int seed, int V, int D, bool kPsk, int k)
@@ -1224,14 +1228,21 @@ public sealed partial class WebGpuBackend : IDirectGpuBackend, IDisposable
         if (total <= 0) return;
         if (total > int.MaxValue) throw new ArgumentException($"V*D = {total} exceeds int.MaxValue.");
         if (kPsk && k <= 0) throw new ArgumentOutOfRangeException(nameof(k));
-        int n = (int)total;
-        var outR = new float[n];
-        var outI = new float[n];
-        Simd.SimdHrrKernels.UnitPhaseCodebookFloat(outR, outI, seed, V, D, kPsk, k);
-        var rBuf = AllocateBuffer(outR);
-        var iBuf = AllocateBuffer(outI);
-        try { Copy(rBuf, 0, outReal, 0, n); Copy(iBuf, 0, outImag, 0, n); }
-        finally { rBuf.Dispose(); iBuf.Dispose(); }
+        SplitComplexUnitPhaseCodebookAsync(outReal, outImag, seed, (int)total, V, D, kPsk, k).GetAwaiter().GetResult();
+    }
+
+    private async Task SplitComplexUnitPhaseCodebookAsync(
+        IGpuBuffer outReal, IGpuBuffer outImag, int seed, int total, int V, int D, bool kPsk, int k)
+    {
+        var pipe = await GetOrCreatePipelineAsync(
+            HrrModuleKey + ":UnitPhaseCodebook", WebGpuHrrKernels.UnitPhaseCodebook, "main");
+        using var uniforms = new WebGpuBuffer(
+            UniformInts(seed, V, D, kPsk ? 1 : 0, k, total),
+            WebGpuBufferUsage.Uniform | WebGpuBufferUsage.CopyDst);
+        using var bind = new WebGpuBindGroup(pipe, AsWgpu(outReal), AsWgpu(outImag));
+        var (wg, _) = _device.CalculateWorkgroups1D(total, 256);
+        await WebGpuNativeBindings.DispatchComputeWithUniformsAsync(pipe, bind.BindGroupId, uniforms.BufferId, wg, 1, 1);
+        await WebGpuNativeBindings.SubmitAndWaitAsync();
     }
 
     public void SplitComplexPhaseCoherenceDecode(
@@ -1240,15 +1251,25 @@ public sealed partial class WebGpuBackend : IDirectGpuBackend, IDisposable
         IGpuBuffer outScores, int V, int D)
     {
         if (V <= 0 || D <= 0) return;
-        var cR = DownloadBuffer(codesReal);
-        var cI = DownloadBuffer(codesImag);
-        var qR = DownloadBuffer(queryReal);
-        var qI = DownloadBuffer(queryImag);
-        var scores = new float[V];
-        Simd.SimdHrrKernels.PhaseCoherenceDecodeFloat(cR, cI, qR, qI, scores, V, D);
-        var sBuf = AllocateBuffer(scores);
-        try { Copy(sBuf, 0, outScores, 0, V); }
-        finally { sBuf.Dispose(); }
+        SplitComplexPhaseCoherenceDecodeAsync(codesReal, codesImag, queryReal, queryImag, outScores, V, D).GetAwaiter().GetResult();
+    }
+
+    private async Task SplitComplexPhaseCoherenceDecodeAsync(
+        IGpuBuffer codesReal, IGpuBuffer codesImag,
+        IGpuBuffer queryReal, IGpuBuffer queryImag,
+        IGpuBuffer outScores, int V, int D)
+    {
+        var pipe = await GetOrCreatePipelineAsync(
+            HrrModuleKey + ":PhaseCoherenceDecode", WebGpuHrrKernels.PhaseCoherenceDecode, "main");
+        using var uniforms = new WebGpuBuffer(
+            UniformInts(V, D),
+            WebGpuBufferUsage.Uniform | WebGpuBufferUsage.CopyDst);
+        using var bind = new WebGpuBindGroup(pipe,
+            AsWgpu(codesReal), AsWgpu(codesImag), AsWgpu(queryReal), AsWgpu(queryImag), AsWgpu(outScores));
+        // Workgroup size in shader is 64 — matches dispatch calc below.
+        var (wg, _) = _device.CalculateWorkgroups1D(V, 64);
+        await WebGpuNativeBindings.DispatchComputeWithUniformsAsync(pipe, bind.BindGroupId, uniforms.BufferId, wg, 1, 1);
+        await WebGpuNativeBindings.SubmitAndWaitAsync();
     }
 
     public void SplitComplexHrrBindAccumulate(
@@ -1259,36 +1280,32 @@ public sealed partial class WebGpuBackend : IDirectGpuBackend, IDisposable
         int N, int D)
     {
         if (N <= 0 || D <= 0) return;
-        var kR = DownloadBuffer(keyCodeReal);
-        var kI = DownloadBuffer(keyCodeImag);
-        var vR = DownloadBuffer(valPermCodeReal);
-        var vI = DownloadBuffer(valPermCodeImag);
-        var kIds = WebGpuHrrReinterpretAsInts(DownloadBuffer(keyIds));
-        var vIds = WebGpuHrrReinterpretAsInts(DownloadBuffer(valIds));
-        var mR = DownloadBuffer(memoryReal);
-        var mI = DownloadBuffer(memoryImag);
-        Simd.SimdHrrKernels.HRRBindAccumulateFloat(
-            kR, kI, vR, vI, kIds, vIds, mR, mI, D);
-        var rBuf = AllocateBuffer(mR);
-        var iBuf = AllocateBuffer(mI);
-        try { Copy(rBuf, 0, memoryReal, 0, D); Copy(iBuf, 0, memoryImag, 0, D); }
-        finally { rBuf.Dispose(); iBuf.Dispose(); }
+        SplitComplexHrrBindAccumulateAsync(
+            keyCodeReal, keyCodeImag, valPermCodeReal, valPermCodeImag,
+            keyIds, valIds, memoryReal, memoryImag, N, D).GetAwaiter().GetResult();
     }
 
-    // AllocateIntBuffer on WebGPU (see its impl) stores ints as float
-    // reinterprets via Int32BitsToSingle; this reverses that.
-    private static int[] WebGpuHrrReinterpretAsInts(float[] floats)
+    private async Task SplitComplexHrrBindAccumulateAsync(
+        IGpuBuffer keyCodeReal, IGpuBuffer keyCodeImag,
+        IGpuBuffer valPermCodeReal, IGpuBuffer valPermCodeImag,
+        IGpuBuffer keyIds, IGpuBuffer valIds,
+        IGpuBuffer memoryReal, IGpuBuffer memoryImag,
+        int N, int D)
     {
-        var ints = new int[floats.Length];
-        for (int i = 0; i < floats.Length; i++)
-        {
-#if NET5_0_OR_GREATER
-            ints[i] = BitConverter.SingleToInt32Bits(floats[i]);
-#else
-            unsafe { float v = floats[i]; ints[i] = *(int*)&v; }
-#endif
-        }
-        return ints;
+        var pipe = await GetOrCreatePipelineAsync(
+            HrrModuleKey + ":HrrBindAccumulate", WebGpuHrrKernels.HrrBindAccumulate, "main");
+        using var uniforms = new WebGpuBuffer(
+            UniformInts(N, D),
+            WebGpuBufferUsage.Uniform | WebGpuBufferUsage.CopyDst);
+        using var bind = new WebGpuBindGroup(pipe,
+            AsWgpu(keyCodeReal), AsWgpu(keyCodeImag),
+            AsWgpu(valPermCodeReal), AsWgpu(valPermCodeImag),
+            AsWgpu(keyIds), AsWgpu(valIds),
+            AsWgpu(memoryReal), AsWgpu(memoryImag));
+        // Workgroup size in shader is 64 — one thread per output dimension.
+        var (wg, _) = _device.CalculateWorkgroups1D(D, 64);
+        await WebGpuNativeBindings.DispatchComputeWithUniformsAsync(pipe, bind.BindGroupId, uniforms.BufferId, wg, 1, 1);
+        await WebGpuNativeBindings.SubmitAndWaitAsync();
     }
 }
 #endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.cs
@@ -1210,5 +1210,85 @@ public sealed partial class WebGpuBackend : IDirectGpuBackend, IDisposable
         try { Copy(rb, 0, output, 0, rows * cols); }
         finally { rb.Dispose(); }
     }
+
+    // ─── HRR binding primitives (issue #248) ────────────────────────
+    //
+    // Same download-compute-upload pattern as SoftmaxRows / TopK above.
+    // WGSL compute shaders would be a perf follow-up; the current path
+    // is correct + deterministic.
+
+    public void SplitComplexUnitPhaseCodebook(
+        IGpuBuffer outReal, IGpuBuffer outImag, int seed, int V, int D, bool kPsk, int k)
+    {
+        long total = (long)V * D;
+        if (total <= 0) return;
+        if (total > int.MaxValue) throw new ArgumentException($"V*D = {total} exceeds int.MaxValue.");
+        if (kPsk && k <= 0) throw new ArgumentOutOfRangeException(nameof(k));
+        int n = (int)total;
+        var outR = new float[n];
+        var outI = new float[n];
+        Simd.SimdHrrKernels.UnitPhaseCodebookFloat(outR, outI, seed, V, D, kPsk, k);
+        var rBuf = AllocateBuffer(outR);
+        var iBuf = AllocateBuffer(outI);
+        try { Copy(rBuf, 0, outReal, 0, n); Copy(iBuf, 0, outImag, 0, n); }
+        finally { rBuf.Dispose(); iBuf.Dispose(); }
+    }
+
+    public void SplitComplexPhaseCoherenceDecode(
+        IGpuBuffer codesReal, IGpuBuffer codesImag,
+        IGpuBuffer queryReal, IGpuBuffer queryImag,
+        IGpuBuffer outScores, int V, int D)
+    {
+        if (V <= 0 || D <= 0) return;
+        var cR = DownloadBuffer(codesReal);
+        var cI = DownloadBuffer(codesImag);
+        var qR = DownloadBuffer(queryReal);
+        var qI = DownloadBuffer(queryImag);
+        var scores = new float[V];
+        Simd.SimdHrrKernels.PhaseCoherenceDecodeFloat(cR, cI, qR, qI, scores, V, D);
+        var sBuf = AllocateBuffer(scores);
+        try { Copy(sBuf, 0, outScores, 0, V); }
+        finally { sBuf.Dispose(); }
+    }
+
+    public void SplitComplexHrrBindAccumulate(
+        IGpuBuffer keyCodeReal, IGpuBuffer keyCodeImag,
+        IGpuBuffer valPermCodeReal, IGpuBuffer valPermCodeImag,
+        IGpuBuffer keyIds, IGpuBuffer valIds,
+        IGpuBuffer memoryReal, IGpuBuffer memoryImag,
+        int N, int D)
+    {
+        if (N <= 0 || D <= 0) return;
+        var kR = DownloadBuffer(keyCodeReal);
+        var kI = DownloadBuffer(keyCodeImag);
+        var vR = DownloadBuffer(valPermCodeReal);
+        var vI = DownloadBuffer(valPermCodeImag);
+        var kIds = WebGpuHrrReinterpretAsInts(DownloadBuffer(keyIds));
+        var vIds = WebGpuHrrReinterpretAsInts(DownloadBuffer(valIds));
+        var mR = DownloadBuffer(memoryReal);
+        var mI = DownloadBuffer(memoryImag);
+        Simd.SimdHrrKernels.HRRBindAccumulateFloat(
+            kR, kI, vR, vI, kIds, vIds, mR, mI, D);
+        var rBuf = AllocateBuffer(mR);
+        var iBuf = AllocateBuffer(mI);
+        try { Copy(rBuf, 0, memoryReal, 0, D); Copy(iBuf, 0, memoryImag, 0, D); }
+        finally { rBuf.Dispose(); iBuf.Dispose(); }
+    }
+
+    // AllocateIntBuffer on WebGPU (see its impl) stores ints as float
+    // reinterprets via Int32BitsToSingle; this reverses that.
+    private static int[] WebGpuHrrReinterpretAsInts(float[] floats)
+    {
+        var ints = new int[floats.Length];
+        for (int i = 0; i < floats.Length; i++)
+        {
+#if NET5_0_OR_GREATER
+            ints[i] = BitConverter.SingleToInt32Bits(floats[i]);
+#else
+            unsafe { float v = floats[i]; ints[i] = *(int*)&v; }
+#endif
+        }
+        return ints;
+    }
 }
 #endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuHrrKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuHrrKernels.cs
@@ -1,0 +1,141 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// WebGPU WGSL compute shaders for HRR binding primitives (issue #248).
+//
+// Each kernel keeps work on the GPU — no download/upload. Per-cell
+// phases use a 32-bit Murmur3 fmix hash seeded from (seed, cellIdx).
+// Deterministic within the WebGPU backend (same seed + same (V, D) →
+// identical output). Does not bit-match CPU, CUDA, or Vulkan phase
+// sequences — each backend generates its own uniform distribution.
+//
+// Int buffers (keyIds / valIds) arrive as Int32BitsToSingle-packed
+// floats (see WebGpuBackend.AllocateIntBuffer); shader reverses with
+// bitcast<i32>().
+
+#if NET7_0_OR_GREATER
+namespace AiDotNet.Tensors.Engines.DirectGpu.WebGpu;
+
+internal static class WebGpuHrrKernels
+{
+    public static string[] GetKernelNames() => new[]
+    {
+        "hrr_unit_phase_codebook",
+        "hrr_phase_coherence_decode",
+        "hrr_bind_accumulate",
+    };
+
+    // Shared hash helper — emitted in front of every shader that needs it.
+    private const string HashHelper = @"
+fn hrr_hash(seed_u : u32, cell_u : u32) -> u32 {
+    var z = seed_u * 0x9E3779B9u + cell_u * 0x85EBCA6Bu;
+    z = (z ^ (z >> 16u)) * 0x85EBCA6Bu;
+    z = (z ^ (z >> 13u)) * 0xC2B2AE35u;
+    z =  z ^ (z >> 16u);
+    return z;
+}
+
+fn hrr_phase_from_cell(seed : i32, cellIdx : u32) -> f32 {
+    let z = hrr_hash(bitcast<u32>(seed), cellIdx);
+    // Upper 24 bits → exact-representable f32 in [0, 1).
+    let top24 = z >> 8u;
+    return f32(top24) * (1.0 / 16777216.0) * 6.28318530717958647692;
+}
+";
+
+    /// <summary>
+    /// outReal[i], outImag[i] = cos/sin of deterministic phase derived
+    /// from (seed, i). If kPsk != 0, phase snaps to nearest multiple of
+    /// 2π/k (k-ary phase-shift keying).
+    /// </summary>
+    public static string UnitPhaseCodebook => HashHelper + @"
+@group(0) @binding(0) var<storage, read_write> outReal : array<f32>;
+@group(0) @binding(1) var<storage, read_write> outImag : array<f32>;
+struct P { seed : i32, V : i32, D : i32, kPsk : i32, k : i32, total : i32 };
+@group(0) @binding(2) var<uniform> p : P;
+
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) id : vec3<u32>) {
+    let gid = id.x;
+    if (gid >= u32(p.total)) { return; }
+
+    var phase = hrr_phase_from_cell(p.seed, gid);
+    if (p.kPsk != 0) {
+        let step = 6.28318530717958647692 / f32(p.k);
+        phase = floor(phase / step + 0.5) * step;
+    }
+    outReal[gid] = cos(phase);
+    outImag[gid] = sin(phase);
+}
+";
+
+    /// <summary>
+    /// One work-item per V. Each thread loops D and accumulates the
+    /// real part of the Hermitian inner product &lt;codes[v], query&gt;:
+    /// scores[v] = Σ_d (codesR[v,d]·queryR[d] + codesI[v,d]·queryI[d]).
+    /// </summary>
+    public static string PhaseCoherenceDecode => @"
+@group(0) @binding(0) var<storage, read> codesReal : array<f32>;
+@group(0) @binding(1) var<storage, read> codesImag : array<f32>;
+@group(0) @binding(2) var<storage, read> queryReal : array<f32>;
+@group(0) @binding(3) var<storage, read> queryImag : array<f32>;
+@group(0) @binding(4) var<storage, read_write> outScores : array<f32>;
+struct P { V : i32, D : i32 };
+@group(0) @binding(5) var<uniform> p : P;
+
+@compute @workgroup_size(64) fn main(@builtin(global_invocation_id) id : vec3<u32>) {
+    let v = id.x;
+    if (v >= u32(p.V)) { return; }
+
+    let rowOff = v * u32(p.D);
+    var acc : f32 = 0.0;
+    for (var d : i32 = 0; d < p.D; d = d + 1) {
+        acc = acc + codesReal[rowOff + u32(d)] * queryReal[d]
+                  + codesImag[rowOff + u32(d)] * queryImag[d];
+    }
+    outScores[v] = acc;
+}
+";
+
+    /// <summary>
+    /// Accumulate N bindings in-place into memory[D]:
+    ///   memory += Σ_n keyCode[keyIds[n]] ⊛ valPermCode[valIds[n]]
+    /// where ⊛ is pointwise complex multiplication. One work-item per
+    /// dimension d; each thread loops N (no cross-thread sync needed —
+    /// every thread writes a distinct memory[d]).
+    /// keyIds/valIds stored as Int32BitsToSingle-packed floats; we
+    /// recover the ints with bitcast&lt;i32&gt;().
+    /// </summary>
+    public static string HrrBindAccumulate => @"
+@group(0) @binding(0) var<storage, read>       keyCodeReal     : array<f32>;
+@group(0) @binding(1) var<storage, read>       keyCodeImag     : array<f32>;
+@group(0) @binding(2) var<storage, read>       valPermCodeReal : array<f32>;
+@group(0) @binding(3) var<storage, read>       valPermCodeImag : array<f32>;
+@group(0) @binding(4) var<storage, read>       keyIds          : array<f32>;
+@group(0) @binding(5) var<storage, read>       valIds          : array<f32>;
+@group(0) @binding(6) var<storage, read_write> memoryReal      : array<f32>;
+@group(0) @binding(7) var<storage, read_write> memoryImag      : array<f32>;
+struct P { N : i32, D : i32 };
+@group(0) @binding(8) var<uniform> p : P;
+
+@compute @workgroup_size(64) fn main(@builtin(global_invocation_id) id : vec3<u32>) {
+    let d = id.x;
+    if (d >= u32(p.D)) { return; }
+
+    var accR = memoryReal[d];
+    var accI = memoryImag[d];
+    for (var n : i32 = 0; n < p.N; n = n + 1) {
+        let kid = bitcast<i32>(keyIds[n]);
+        let vid = bitcast<i32>(valIds[n]);
+        let kOff = u32(kid) * u32(p.D) + d;
+        let vOff = u32(vid) * u32(p.D) + d;
+        let ar = keyCodeReal[kOff];
+        let ai = keyCodeImag[kOff];
+        let br = valPermCodeReal[vOff];
+        let bi = valPermCodeImag[vOff];
+        accR = accR + ar * br - ai * bi;
+        accI = accI + ar * bi + ai * br;
+    }
+    memoryReal[d] = accR;
+    memoryImag[d] = accI;
+}
+";
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuHrrKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuHrrKernels.cs
@@ -112,7 +112,12 @@ struct P { V : i32, D : i32 };
 @group(0) @binding(5) var<storage, read>       valIds          : array<f32>;
 @group(0) @binding(6) var<storage, read_write> memoryReal      : array<f32>;
 @group(0) @binding(7) var<storage, read_write> memoryImag      : array<f32>;
-struct P { N : i32, D : i32 };
+// nKeys / nVals are the vocabulary sizes (codebook row counts); the
+// host passes keyCodeReal.Size / D and valPermCodeReal.Size / D so
+// the shader can reject out-of-range ids without reading past the
+// codebook. Mirrors the (uint)kId >= (uint)nKeys check in the CPU
+// SIMD implementation and the equivalent guard in the Vulkan shader.
+struct P { N : i32, D : i32, nKeys : i32, nVals : i32 };
 @group(0) @binding(8) var<uniform> p : P;
 
 @compute @workgroup_size(64) fn main(@builtin(global_invocation_id) id : vec3<u32>) {
@@ -124,6 +129,11 @@ struct P { N : i32, D : i32 };
     for (var n : i32 = 0; n < p.N; n = n + 1) {
         let kid = bitcast<i32>(keyIds[n]);
         let vid = bitcast<i32>(valIds[n]);
+        // Unsigned-comparison trick rejects both negative and
+        // too-large indices in one branch; out-of-range pairs
+        // contribute zero (match the CPU path's exception, but
+        // silently — the shader can't throw).
+        if (u32(kid) >= u32(p.nKeys) || u32(vid) >= u32(p.nVals)) { continue; }
         let kOff = u32(kid) * u32(p.D) + d;
         let vOff = u32(vid) * u32(p.D) + d;
         let ar = keyCodeReal[kOff];

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -15258,15 +15258,138 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
     }
 
-    // Ops 3 (UnitPhaseCodebook), 4 (PhaseCoherenceDecode), 5
-    // (HRRBindAccumulate) don't override here yet — they inherit the CPU
-    // implementation via CpuEngine.virtual dispatch. Adding fused GPU
-    // kernels for these is the natural follow-up if the HRE campaign's
-    // workloads demand it (op 5 especially, being the hottest loop in
-    // memory build). The follow-up would extend IDirectGpuBackend with
-    // UnitPhaseCodebook / PhaseCoherenceDecode / HRRBindAccumulate
-    // primitives and implement them on each of the 6 backends (CUDA,
-    // OpenCL, HIP, Metal, Vulkan, WebGPU).
+    /// <inheritdoc />
+    public override void NativeUnitPhaseCodebook<T>(
+        Span<T> outRe, Span<T> outIm,
+        int seed, int V, int D, bool kPsk = false, int k = 0)
+    {
+        long total = (long)V * D;
+        if (typeof(T) != typeof(float)
+            || total <= 0 || total > int.MaxValue
+            || outRe.Length != total || outIm.Length != total
+            || !TryGetBackend(out var backend))
+        {
+            base.NativeUnitPhaseCodebook(outRe, outIm, seed, V, D, kPsk, k);
+            return;
+        }
+
+        try
+        {
+            int n = (int)total;
+            using var oRBuf = new OwnedBuffer(backend.AllocateBuffer(n), true);
+            using var oIBuf = new OwnedBuffer(backend.AllocateBuffer(n), true);
+            backend.SplitComplexUnitPhaseCodebook(
+                oRBuf.Buffer, oIBuf.Buffer, seed, V, D, kPsk, k);
+            var oRf = backend.DownloadBuffer(oRBuf.Buffer);
+            var oIf = backend.DownloadBuffer(oIBuf.Buffer);
+            HrrFloatArrayToSpan(oRf, outRe, n);
+            HrrFloatArrayToSpan(oIf, outIm, n);
+        }
+        catch
+        {
+            base.NativeUnitPhaseCodebook(outRe, outIm, seed, V, D, kPsk, k);
+        }
+    }
+
+    /// <inheritdoc />
+    public override void NativeComplexPhaseCoherenceDecode<T>(
+        ReadOnlySpan<T> codesRe, ReadOnlySpan<T> codesIm,
+        ReadOnlySpan<T> queryRe, ReadOnlySpan<T> queryIm,
+        Span<T> scores, int V, int D)
+    {
+        long total = (long)V * D;
+        if (typeof(T) != typeof(float)
+            || V <= 0 || D <= 0
+            || codesRe.Length != total || codesIm.Length != total
+            || queryRe.Length != D || queryIm.Length != D
+            || scores.Length != V
+            || !TryGetBackend(out var backend))
+        {
+            base.NativeComplexPhaseCoherenceDecode(codesRe, codesIm, queryRe, queryIm, scores, V, D);
+            return;
+        }
+
+        try
+        {
+            var cRf = HrrToFloatArray(codesRe);
+            var cIf = HrrToFloatArray(codesIm);
+            var qRf = HrrToFloatArray(queryRe);
+            var qIf = HrrToFloatArray(queryIm);
+            using var cRBuf = new OwnedBuffer(backend.AllocateBuffer(cRf), true);
+            using var cIBuf = new OwnedBuffer(backend.AllocateBuffer(cIf), true);
+            using var qRBuf = new OwnedBuffer(backend.AllocateBuffer(qRf), true);
+            using var qIBuf = new OwnedBuffer(backend.AllocateBuffer(qIf), true);
+            using var sBuf = new OwnedBuffer(backend.AllocateBuffer(V), true);
+            backend.SplitComplexPhaseCoherenceDecode(
+                cRBuf.Buffer, cIBuf.Buffer, qRBuf.Buffer, qIBuf.Buffer, sBuf.Buffer,
+                V, D);
+            var sF = backend.DownloadBuffer(sBuf.Buffer);
+            HrrFloatArrayToSpan(sF, scores, V);
+        }
+        catch
+        {
+            base.NativeComplexPhaseCoherenceDecode(codesRe, codesIm, queryRe, queryIm, scores, V, D);
+        }
+    }
+
+    /// <inheritdoc />
+    public override void NativeHRRBindAccumulate<T>(
+        ReadOnlySpan<T> keyCodeRe, ReadOnlySpan<T> keyCodeIm,
+        ReadOnlySpan<T> valPermCodeRe, ReadOnlySpan<T> valPermCodeIm,
+        ReadOnlySpan<int> keyIds, ReadOnlySpan<int> valIds,
+        Span<T> memoryRe, Span<T> memoryIm, int D)
+    {
+        int N = keyIds.Length;
+        if (typeof(T) != typeof(float)
+            || D <= 0 || N <= 0
+            || valIds.Length != N
+            || memoryRe.Length != D || memoryIm.Length != D
+            || !TryGetBackend(out var backend))
+        {
+            base.NativeHRRBindAccumulate(
+                keyCodeRe, keyCodeIm, valPermCodeRe, valPermCodeIm,
+                keyIds, valIds, memoryRe, memoryIm, D);
+            return;
+        }
+
+        try
+        {
+            var kRf = HrrToFloatArray(keyCodeRe);
+            var kIf = HrrToFloatArray(keyCodeIm);
+            var vRf = HrrToFloatArray(valPermCodeRe);
+            var vIf = HrrToFloatArray(valPermCodeIm);
+            var kIds = keyIds.ToArray();
+            var vIds = valIds.ToArray();
+            var mRf = HrrToFloatArray((ReadOnlySpan<T>)memoryRe);
+            var mIf = HrrToFloatArray((ReadOnlySpan<T>)memoryIm);
+            using var kRBuf = new OwnedBuffer(backend.AllocateBuffer(kRf), true);
+            using var kIBuf = new OwnedBuffer(backend.AllocateBuffer(kIf), true);
+            using var vRBuf = new OwnedBuffer(backend.AllocateBuffer(vRf), true);
+            using var vIBuf = new OwnedBuffer(backend.AllocateBuffer(vIf), true);
+            using var kIdsBuf = new OwnedBuffer(backend.AllocateIntBuffer(kIds), true);
+            using var vIdsBuf = new OwnedBuffer(backend.AllocateIntBuffer(vIds), true);
+            using var mRBuf = new OwnedBuffer(backend.AllocateBuffer(mRf), true);
+            using var mIBuf = new OwnedBuffer(backend.AllocateBuffer(mIf), true);
+
+            backend.SplitComplexHrrBindAccumulate(
+                kRBuf.Buffer, kIBuf.Buffer,
+                vRBuf.Buffer, vIBuf.Buffer,
+                kIdsBuf.Buffer, vIdsBuf.Buffer,
+                mRBuf.Buffer, mIBuf.Buffer,
+                N, D);
+
+            var mRout = backend.DownloadBuffer(mRBuf.Buffer);
+            var mIout = backend.DownloadBuffer(mIBuf.Buffer);
+            HrrFloatArrayToSpan(mRout, memoryRe, D);
+            HrrFloatArrayToSpan(mIout, memoryIm, D);
+        }
+        catch
+        {
+            base.NativeHRRBindAccumulate(
+                keyCodeRe, keyCodeIm, valPermCodeRe, valPermCodeIm,
+                keyIds, valIds, memoryRe, memoryIm, D);
+        }
+    }
 
     // ── Span marshalling helpers for the HRR GPU overrides ──
     // Allocates a fresh float[] from a ReadOnlySpan<T> where T is known

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using AiDotNet.Tensors.Engines.DirectGpu;
 using AiDotNet.Tensors.Engines.Gpu;
@@ -15140,6 +15141,163 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 backend.DownloadBuffer(oIBuf.Buffer), a._shape);
         }
         catch { return base.NativeComplexMultiply(a, b); }
+    }
+
+    // ─── HRR binding primitives (issue #248) ─────────────────────────
+    //
+    // GPU overrides where a backend primitive maps cleanly. Ops where
+    // the backend has no direct primitive (UnitPhaseCodebook,
+    // PhaseCoherenceDecode, HRRBindAccumulate) fall through to the
+    // CpuEngine base implementation; a follow-up PR can add fused GPU
+    // kernels for the hottest path (HRRBindAccumulate) if the HRE
+    // campaign's workloads warrant it. All paths catch exceptions and
+    // fall back to CPU so a single backend hiccup never takes the op
+    // offline — matches the existing Native* override convention.
+
+    /// <inheritdoc />
+    public override void NativeComplexPointwiseMultiply<T>(
+        ReadOnlySpan<T> aRe, ReadOnlySpan<T> aIm,
+        ReadOnlySpan<T> bRe, ReadOnlySpan<T> bIm,
+        Span<T> cRe, Span<T> cIm,
+        bool conjugateB = false)
+    {
+        // Backend uses single-precision buffers; on a precision-sensitive
+        // T=double workload the GPU path would round-trip through fp32
+        // and hurt accuracy, so we keep T=double on CPU and route only
+        // T=float through the GPU primitives. Unsupported T also drops
+        // to CPU via base. This mirrors how NativeComplexMultiply picks
+        // its paths.
+        int n = aRe.Length;
+        if (typeof(T) != typeof(float)
+            || aIm.Length != n || bRe.Length != n || bIm.Length != n
+            || cRe.Length != n || cIm.Length != n
+            || n == 0
+            || !TryGetBackend(out var backend))
+        {
+            base.NativeComplexPointwiseMultiply(aRe, aIm, bRe, bIm, cRe, cIm, conjugateB);
+            return;
+        }
+
+        try
+        {
+            // Materialise to float[] for upload. The caller's Span<T> is
+            // typed T = float here per the guard above.
+            var aRf = HrrToFloatArray(aRe);
+            var aIf = HrrToFloatArray(aIm);
+            var bRf = HrrToFloatArray(bRe);
+            var bIf = HrrToFloatArray(bIm);
+
+            using var aRBuf = new OwnedBuffer(backend.AllocateBuffer(aRf), true);
+            using var aIBuf = new OwnedBuffer(backend.AllocateBuffer(aIf), true);
+            using var bRBuf = new OwnedBuffer(backend.AllocateBuffer(bRf), true);
+            using var bIBuf = new OwnedBuffer(backend.AllocateBuffer(bIf), true);
+            using var oRBuf = new OwnedBuffer(backend.AllocateBuffer(n), true);
+            using var oIBuf = new OwnedBuffer(backend.AllocateBuffer(n), true);
+
+            if (conjugateB)
+            {
+                // c = a · conj(b) — exactly the cross-spectral density op
+                // the backend already ships: outR = aR·bR + aI·bI,
+                // outI = aI·bR − aR·bI. Zero new kernels needed.
+                backend.SplitComplexCrossSpectral(
+                    aRBuf.Buffer, aIBuf.Buffer, bRBuf.Buffer, bIBuf.Buffer,
+                    oRBuf.Buffer, oIBuf.Buffer, n);
+            }
+            else
+            {
+                backend.SplitComplexMultiply(
+                    aRBuf.Buffer, aIBuf.Buffer, bRBuf.Buffer, bIBuf.Buffer,
+                    oRBuf.Buffer, oIBuf.Buffer, n);
+            }
+
+            var oRf = backend.DownloadBuffer(oRBuf.Buffer);
+            var oIf = backend.DownloadBuffer(oIBuf.Buffer);
+            HrrFloatArrayToSpan(oRf, cRe, n);
+            HrrFloatArrayToSpan(oIf, cIm, n);
+        }
+        catch
+        {
+            base.NativeComplexPointwiseMultiply(aRe, aIm, bRe, bIm, cRe, cIm, conjugateB);
+        }
+    }
+
+    /// <inheritdoc />
+    public override void NativeGather<T>(
+        ReadOnlySpan<T> input,
+        ReadOnlySpan<int> indices,
+        Span<T> output)
+    {
+        // Only float has a direct backend Gather primitive. All other T
+        // (double, Half, custom) fall back to CPU.
+        int nOut = indices.Length;
+        if (typeof(T) != typeof(float)
+            || output.Length != nOut
+            || nOut == 0
+            || !TryGetBackend(out var backend))
+        {
+            base.NativeGather(input, indices, output);
+            return;
+        }
+
+        try
+        {
+            var inF = HrrToFloatArray(input);
+            var idx = indices.ToArray();
+            using var inBuf = new OwnedBuffer(backend.AllocateBuffer(inF), true);
+            using var idxBuf = new OwnedBuffer(backend.AllocateIntBuffer(idx), true);
+            using var outBuf = new OwnedBuffer(backend.AllocateBuffer(nOut), true);
+            // backend.Gather signature: source, indices, output, numIndices, featureSize.
+            // For a flat 1-D gather (no per-index row copy) featureSize = 1.
+            backend.Gather(inBuf.Buffer, idxBuf.Buffer, outBuf.Buffer, nOut, featureSize: 1);
+            var oF = backend.DownloadBuffer(outBuf.Buffer);
+            HrrFloatArrayToSpan(oF, output, nOut);
+        }
+        catch
+        {
+            base.NativeGather(input, indices, output);
+        }
+    }
+
+    // Ops 3 (UnitPhaseCodebook), 4 (PhaseCoherenceDecode), 5
+    // (HRRBindAccumulate) don't override here yet — they inherit the CPU
+    // implementation via CpuEngine.virtual dispatch. Adding fused GPU
+    // kernels for these is the natural follow-up if the HRE campaign's
+    // workloads demand it (op 5 especially, being the hottest loop in
+    // memory build). The follow-up would extend IDirectGpuBackend with
+    // UnitPhaseCodebook / PhaseCoherenceDecode / HRRBindAccumulate
+    // primitives and implement them on each of the 6 backends (CUDA,
+    // OpenCL, HIP, Metal, Vulkan, WebGPU).
+
+    // ── Span marshalling helpers for the HRR GPU overrides ──
+    // Allocates a fresh float[] from a ReadOnlySpan<T> where T is known
+    // to be float at runtime (checked by callers via typeof). Using
+    // ToArray on a reinterpreted span keeps a single allocation per
+    // upload with no intermediate object churn.
+    private static float[] HrrToFloatArray<T>(ReadOnlySpan<T> s)
+    {
+#if NET5_0_OR_GREATER
+        ref T head = ref System.Runtime.InteropServices.MemoryMarshal.GetReference(s);
+        var asFloat = System.Runtime.InteropServices.MemoryMarshal.CreateReadOnlySpan(
+            ref Unsafe.As<T, float>(ref head), s.Length);
+        return asFloat.ToArray();
+#else
+        // net471: fall through to slower boxed path — the guard above
+        // keeps this unreachable on net471 because the GPU overrides
+        // check typeof(T) == typeof(float) first.
+        throw new PlatformNotSupportedException("HrrToFloatArray requires NET5_0_OR_GREATER.");
+#endif
+    }
+
+    private static void HrrFloatArrayToSpan<T>(float[] src, Span<T> dst, int n)
+    {
+#if NET5_0_OR_GREATER
+        ref T head = ref System.Runtime.InteropServices.MemoryMarshal.GetReference(dst);
+        var asFloat = System.Runtime.InteropServices.MemoryMarshal.CreateSpan(
+            ref Unsafe.As<T, float>(ref head), dst.Length);
+        src.AsSpan(0, n).CopyTo(asFloat);
+#else
+        throw new PlatformNotSupportedException("HrrFloatArrayToSpan requires NET5_0_OR_GREATER.");
+#endif
     }
 
     public override Tensor<Complex<T>> NativeComplexConjugate<T>(Tensor<Complex<T>> a)

--- a/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
@@ -1766,6 +1766,11 @@ public class DelegatingGpuBackend : IDirectGpuBackend
     public virtual void SplitComplexTopK(IGpuBuffer inReal, IGpuBuffer inImag, IGpuBuffer outReal, IGpuBuffer outImag, int n, int k) => Inner.SplitComplexTopK(inReal, inImag, outReal, outImag, n, k);
     public virtual void SoftmaxRows(IGpuBuffer input, IGpuBuffer output, int rows, int cols) => Inner.SoftmaxRows(input, output, rows, cols);
 
+    // ─── HRR binding primitives (issue #248) ────────────────────────
+    public virtual void SplitComplexUnitPhaseCodebook(IGpuBuffer outReal, IGpuBuffer outImag, int seed, int V, int D, bool kPsk, int k) => Inner.SplitComplexUnitPhaseCodebook(outReal, outImag, seed, V, D, kPsk, k);
+    public virtual void SplitComplexPhaseCoherenceDecode(IGpuBuffer codesReal, IGpuBuffer codesImag, IGpuBuffer queryReal, IGpuBuffer queryImag, IGpuBuffer outScores, int V, int D) => Inner.SplitComplexPhaseCoherenceDecode(codesReal, codesImag, queryReal, queryImag, outScores, V, D);
+    public virtual void SplitComplexHrrBindAccumulate(IGpuBuffer keyCodeReal, IGpuBuffer keyCodeImag, IGpuBuffer valPermCodeReal, IGpuBuffer valPermCodeImag, IGpuBuffer keyIds, IGpuBuffer valIds, IGpuBuffer memoryReal, IGpuBuffer memoryImag, int N, int D) => Inner.SplitComplexHrrBindAccumulate(keyCodeReal, keyCodeImag, valPermCodeReal, valPermCodeImag, keyIds, valIds, memoryReal, memoryImag, N, D);
+
     /// <inheritdoc/>
     public virtual void SpectralFilter(IGpuBuffer inputReal, IGpuBuffer filterReal, IGpuBuffer filterImag,
         IGpuBuffer outputReal, int batch, int height, int width, int filterSliceCount)

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -8462,14 +8462,27 @@ public interface IEngine
     //
     // These five methods replace the hand-rolled stitching of 6+
     // TensorPrimitives calls per HRR bind/unbind that blocked scaling in
-    // the HRE research campaign's cycle 12 build. All accept split
-    // Re/Im spans generic on T; internally the CPU path dispatches to
-    // AVX2+FMA kernels for float and double, falling back to a scalar
-    // numeric-ops loop for other T. GPU backends override with native
-    // kernels where available; unsupported T falls through to CPU.
-    // No autograd hooks — these are eager kernels; callers that need a
-    // gradient tape must use the Tensor-returning NativeComplexMultiply
-    // family above.
+    // the HRE research campaign's cycle 12 build.
+    //
+    // Type-support matrix:
+    //   - NativeComplexPointwiseMultiply<T>       : any numeric T (CPU
+    //     AVX2+FMA for float/double; scalar INumericOperations<T> loop
+    //     otherwise).
+    //   - NativeGather<T>                         : any unmanaged T —
+    //     no arithmetic, just element copy.
+    //   - NativeComplexPhaseCoherenceDecode<T>    : any numeric T (same
+    //     dispatch as PointwiseMultiply).
+    //   - NativeHRRBindAccumulate<T>              : any numeric T (same
+    //     dispatch).
+    //   - NativeUnitPhaseCodebook<T>              : FLOAT / DOUBLE ONLY.
+    //     The phase-based kernel calls sin/cos — integral T would
+    //     quantize to ±1/0 and silently break |c| = 1. Implementations
+    //     must throw NotSupportedException for non-floating T.
+    //
+    // GPU backends override with native kernels where available;
+    // unsupported T falls through to CPU. No autograd hooks — these
+    // are eager kernels; callers that need a gradient tape must use
+    // the Tensor-returning NativeComplexMultiply family above.
     //
     // ─── Breaking-change note for custom IEngine implementers ──────────
     //
@@ -8584,6 +8597,7 @@ public interface IEngine
     /// <param name="k">K-PSK alphabet size, required &gt;= 1 when <paramref name="kPsk"/> is true.</param>
     /// <exception cref="ArgumentException">Thrown if span lengths don't equal V*D.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown if V/D/k are out of range.</exception>
+    /// <exception cref="NotSupportedException">Thrown when T is not <see cref="float"/> or <see cref="double"/>.</exception>
     void NativeUnitPhaseCodebook<T>(
         Span<T> outRe, Span<T> outIm,
         int seed, int V, int D,

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -8463,14 +8463,17 @@ public interface IEngine
     // These five methods replace the hand-rolled stitching of 6+
     // TensorPrimitives calls per HRR bind/unbind that blocked scaling in
     // the HRE research campaign's cycle 12 build. All accept split
-    // Re/Im double spans so the AVX2 + FMA path stays dense (4 lanes ×
-    // 64-bit). No autograd hooks — these are eager kernels; callers
-    // that need a gradient tape must use the Tensor-returning
-    // NativeComplexMultiply family above.
+    // Re/Im spans generic on T; internally the CPU path dispatches to
+    // AVX2+FMA kernels for float and double, falling back to a scalar
+    // numeric-ops loop for other T. GPU backends override with native
+    // kernels where available; unsupported T falls through to CPU.
+    // No autograd hooks — these are eager kernels; callers that need a
+    // gradient tape must use the Tensor-returning NativeComplexMultiply
+    // family above.
 
     /// <summary>
-    /// Pointwise complex multiply on split Re/Im <c>double</c> spans,
-    /// optionally conjugating operand B (HRR unbind form).
+    /// Pointwise complex multiply on split Re/Im spans, optionally
+    /// conjugating operand B (HRR unbind form).
     /// <list type="bullet">
     ///   <item><paramref name="conjugateB"/> = false: <c>c = a · b</c></item>
     ///   <item><paramref name="conjugateB"/> = true:  <c>c = a · conj(b)</c></item>
@@ -8478,32 +8481,39 @@ public interface IEngine
     /// Single SIMD kernel; replaces 6 chained TensorPrimitives calls per
     /// HRR bind / unbind. See issue #248 op 1.
     /// </summary>
-    void NativeComplexPointwiseMultiplyDouble(
-        ReadOnlySpan<double> aRe, ReadOnlySpan<double> aIm,
-        ReadOnlySpan<double> bRe, ReadOnlySpan<double> bIm,
-        Span<double> cRe, Span<double> cIm,
+    /// <typeparam name="T">Element type. float / double have SIMD fast
+    /// paths on AVX2+FMA; other numeric T fall back to the generic
+    /// scalar loop via <c>INumericOperations&lt;T&gt;</c>.</typeparam>
+    void NativeComplexPointwiseMultiply<T>(
+        ReadOnlySpan<T> aRe, ReadOnlySpan<T> aIm,
+        ReadOnlySpan<T> bRe, ReadOnlySpan<T> bIm,
+        Span<T> cRe, Span<T> cIm,
         bool conjugateB = false);
 
     /// <summary>
-    /// Indexed gather on a <c>double</c> span: <c>output[i] = input[indices[i]]</c>.
-    /// Standard permutation-gather primitive for HRR's Plate-style
-    /// non-commutative binding. See issue #248 op 2.
+    /// Indexed gather: <c>output[i] = input[indices[i]]</c>. Standard
+    /// permutation-gather primitive for HRR's Plate-style non-commutative
+    /// binding. See issue #248 op 2.
     /// </summary>
-    void NativeGatherDouble(
-        ReadOnlySpan<double> input,
+    /// <typeparam name="T">Element type; works for any unmanaged T — the
+    /// kernel does index-only addressing, no arithmetic on the data.</typeparam>
+    void NativeGather<T>(
+        ReadOnlySpan<T> input,
         ReadOnlySpan<int> indices,
-        Span<double> output);
+        Span<T> output);
 
     /// <summary>
-    /// Generate a V×D unit-phase complex codebook (<c>double</c>): every
-    /// entry is <c>exp(iθ)</c> for a uniformly random phase, split into
+    /// Generate a V×D unit-phase complex codebook: every entry is
+    /// <c>exp(iθ)</c> for a uniformly random phase, split into
     /// <paramref name="outRe"/> (cos) and <paramref name="outIm"/> (sin)
     /// flattened row-major. Optional K-PSK quantization snaps phases to
     /// multiples of <c>2π/k</c>. Deterministic given <paramref name="seed"/>.
     /// See issue #248 op 3.
     /// </summary>
-    void NativeUnitPhaseCodebookDouble(
-        Span<double> outRe, Span<double> outIm,
+    /// <typeparam name="T">Element type. float / double hit the vectorised
+    /// path; other numeric T go through the generic scalar loop.</typeparam>
+    void NativeUnitPhaseCodebook<T>(
+        Span<T> outRe, Span<T> outIm,
         int seed, int V, int D,
         bool kPsk = false, int k = 0);
 
@@ -8515,10 +8525,10 @@ public interface IEngine
     /// allocation overhead that dominated issue #248's decode path.
     /// See issue #248 op 4.
     /// </summary>
-    void NativeComplexPhaseCoherenceDecodeDouble(
-        ReadOnlySpan<double> codesRe, ReadOnlySpan<double> codesIm,
-        ReadOnlySpan<double> queryRe, ReadOnlySpan<double> queryIm,
-        Span<double> scores,
+    void NativeComplexPhaseCoherenceDecode<T>(
+        ReadOnlySpan<T> codesRe, ReadOnlySpan<T> codesIm,
+        ReadOnlySpan<T> queryRe, ReadOnlySpan<T> queryIm,
+        Span<T> scores,
         int V, int D);
 
     /// <summary>
@@ -8530,11 +8540,11 @@ public interface IEngine
     /// pre-permuted so the gather + permute + multiply + accumulate
     /// collapses into one kernel. See issue #248 op 5.
     /// </summary>
-    void NativeHRRBindAccumulateDouble(
-        ReadOnlySpan<double> keyCodeRe, ReadOnlySpan<double> keyCodeIm,
-        ReadOnlySpan<double> valPermCodeRe, ReadOnlySpan<double> valPermCodeIm,
+    void NativeHRRBindAccumulate<T>(
+        ReadOnlySpan<T> keyCodeRe, ReadOnlySpan<T> keyCodeIm,
+        ReadOnlySpan<T> valPermCodeRe, ReadOnlySpan<T> valPermCodeIm,
         ReadOnlySpan<int> keyIds, ReadOnlySpan<int> valIds,
-        Span<double> memoryRe, Span<double> memoryIm,
+        Span<T> memoryRe, Span<T> memoryIm,
         int D);
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -8470,6 +8470,21 @@ public interface IEngine
     // No autograd hooks — these are eager kernels; callers that need a
     // gradient tape must use the Tensor-returning NativeComplexMultiply
     // family above.
+    //
+    // ─── Breaking-change note for custom IEngine implementers ──────────
+    //
+    // Adding abstract members to IEngine is a source-breaking change —
+    // net471 and netstandard2.0 have no default-interface-method
+    // fallback. This ships under the 1.0.0-preview umbrella, where
+    // pre-1.0 API evolution is expected; downstream engines implementing
+    // IEngine directly must add these five members. The recommended
+    // migration for custom engines is to delegate to a CpuEngine
+    // instance or inherit from CpuEngine (which provides a working
+    // scalar reference implementation for all numeric T). Engines built
+    // on top of DelegatingGpuBackend or DirectGpuTensorEngine pick up
+    // the GPU overrides automatically. The first post-preview release
+    // (1.0.0) will treat any further additions to this section as a
+    // major-version break.
 
     /// <summary>
     /// Pointwise complex multiply on split Re/Im spans, optionally
@@ -8480,10 +8495,24 @@ public interface IEngine
     /// </list>
     /// Single SIMD kernel; replaces 6 chained TensorPrimitives calls per
     /// HRR bind / unbind. See issue #248 op 1.
+    /// <para><b>Contract:</b> all six spans must share the same length
+    /// <c>L</c>. The output spans <paramref name="cRe"/>/<paramref name="cIm"/>
+    /// may alias any of the input spans (read-then-write is done per
+    /// index); output pairs must not alias each other. Implementations
+    /// throw <see cref="ArgumentException"/> if any span length differs
+    /// from <paramref name="aRe"/>.Length.</para>
     /// </summary>
     /// <typeparam name="T">Element type. float / double have SIMD fast
     /// paths on AVX2+FMA; other numeric T fall back to the generic
     /// scalar loop via <c>INumericOperations&lt;T&gt;</c>.</typeparam>
+    /// <param name="aRe">Real part of operand A, length <c>L</c>.</param>
+    /// <param name="aIm">Imaginary part of operand A, length <c>L</c>.</param>
+    /// <param name="bRe">Real part of operand B, length <c>L</c>.</param>
+    /// <param name="bIm">Imaginary part of operand B, length <c>L</c>.</param>
+    /// <param name="cRe">Output real part, length <c>L</c> (may alias inputs).</param>
+    /// <param name="cIm">Output imaginary part, length <c>L</c> (may alias inputs).</param>
+    /// <param name="conjugateB">If true, multiply by <c>conj(b)</c>.</param>
+    /// <exception cref="ArgumentException">Thrown if span lengths differ.</exception>
     void NativeComplexPointwiseMultiply<T>(
         ReadOnlySpan<T> aRe, ReadOnlySpan<T> aIm,
         ReadOnlySpan<T> bRe, ReadOnlySpan<T> bIm,
@@ -8494,9 +8523,22 @@ public interface IEngine
     /// Indexed gather: <c>output[i] = input[indices[i]]</c>. Standard
     /// permutation-gather primitive for HRR's Plate-style non-commutative
     /// binding. See issue #248 op 2.
+    /// <para><b>Contract:</b> <paramref name="output"/>.Length must equal
+    /// <paramref name="indices"/>.Length. Every <c>indices[i]</c> must be
+    /// in <c>[0, input.Length)</c>. <paramref name="output"/> and
+    /// <paramref name="input"/> must not overlap (the kernel may read
+    /// positions out of order). Implementations throw
+    /// <see cref="ArgumentException"/> on a length mismatch and
+    /// <see cref="ArgumentOutOfRangeException"/> on an out-of-range
+    /// index.</para>
     /// </summary>
     /// <typeparam name="T">Element type; works for any unmanaged T — the
     /// kernel does index-only addressing, no arithmetic on the data.</typeparam>
+    /// <param name="input">Source values.</param>
+    /// <param name="indices">Non-negative indices into <paramref name="input"/>.</param>
+    /// <param name="output">Destination, length == indices.Length.</param>
+    /// <exception cref="ArgumentException">Thrown if lengths mismatch.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if any index is out of range.</exception>
     void NativeGather<T>(
         ReadOnlySpan<T> input,
         ReadOnlySpan<int> indices,
@@ -8506,12 +8548,42 @@ public interface IEngine
     /// Generate a V×D unit-phase complex codebook: every entry is
     /// <c>exp(iθ)</c> for a uniformly random phase, split into
     /// <paramref name="outRe"/> (cos) and <paramref name="outIm"/> (sin)
-    /// flattened row-major. Optional K-PSK quantization snaps phases to
-    /// multiples of <c>2π/k</c>. Deterministic given <paramref name="seed"/>.
+    /// flattened row-major (outer dim = V, inner dim = D). Optional
+    /// K-PSK quantization snaps phases to multiples of <c>2π/k</c>,
+    /// producing a discrete alphabet of <paramref name="k"/> equally
+    /// spaced points on the unit circle. Deterministic given
+    /// <paramref name="seed"/> — same seed + same (V, D) yields the
+    /// same output on a given backend (GPU backends may diverge
+    /// bit-wise from CPU; per-backend determinism is preserved).
     /// See issue #248 op 3.
+    /// <para><b>Contract:</b> <paramref name="outRe"/>.Length and
+    /// <paramref name="outIm"/>.Length must both equal
+    /// <c>V * D</c>. Output spans must not overlap.
+    /// <paramref name="V"/> and <paramref name="D"/> must be &gt;= 0.
+    /// If <paramref name="kPsk"/> is true, <paramref name="k"/> must be
+    /// &gt;= 1. Implementations throw <see cref="ArgumentException"/> on
+    /// a span-length mismatch and
+    /// <see cref="ArgumentOutOfRangeException"/> on invalid
+    /// <c>V</c>/<c>D</c>/<c>k</c>.</para>
+    /// <para><b>Floating-point only:</b> phase semantics require
+    /// continuous arithmetic — integral T (int, long, etc.) would
+    /// quantize <c>sin</c>/<c>cos</c> to ±1/0 and silently produce a
+    /// broken codebook. Implementations must reject non-floating T
+    /// with <see cref="NotSupportedException"/>. Only
+    /// <see cref="float"/> and <see cref="double"/> are supported.</para>
     /// </summary>
-    /// <typeparam name="T">Element type. float / double hit the vectorised
-    /// path; other numeric T go through the generic scalar loop.</typeparam>
+    /// <typeparam name="T">Element type — must be <see cref="float"/>
+    /// or <see cref="double"/>. Non-floating T throws
+    /// <see cref="NotSupportedException"/>.</typeparam>
+    /// <param name="outRe">Output real (cos) part, length <c>V*D</c>, row-major.</param>
+    /// <param name="outIm">Output imaginary (sin) part, length <c>V*D</c>, row-major.</param>
+    /// <param name="seed">PRNG seed; same seed ⇒ same codebook on a given backend.</param>
+    /// <param name="V">Outer (vocabulary) dimension, &gt;= 0.</param>
+    /// <param name="D">Inner (embedding) dimension, &gt;= 0.</param>
+    /// <param name="kPsk">If true, snap phases to a K-PSK lattice.</param>
+    /// <param name="k">K-PSK alphabet size, required &gt;= 1 when <paramref name="kPsk"/> is true.</param>
+    /// <exception cref="ArgumentException">Thrown if span lengths don't equal V*D.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if V/D/k are out of range.</exception>
     void NativeUnitPhaseCodebook<T>(
         Span<T> outRe, Span<T> outIm,
         int seed, int V, int D,
@@ -8520,11 +8592,33 @@ public interface IEngine
     /// <summary>
     /// Full-vocabulary phase-coherence decode: for each candidate
     /// v ∈ [0, V), compute
-    /// <c>scores[v] = Re(Σ_d query[d] · conj(code[v][d]))</c>.
+    /// <c>scores[v] = Re(Σ_d query[d] · conj(code[v][d]))
+    ///            = Σ_d (codesRe[v,d]·queryRe[d] + codesIm[v,d]·queryIm[d])</c>.
     /// One kernel without per-query Tensor wrapping — avoids the
     /// allocation overhead that dominated issue #248's decode path.
     /// See issue #248 op 4.
+    /// <para><b>Contract:</b> <paramref name="codesRe"/>.Length and
+    /// <paramref name="codesIm"/>.Length must both equal <c>V * D</c>,
+    /// flattened row-major (outer = V, inner = D).
+    /// <paramref name="queryRe"/>.Length and <paramref name="queryIm"/>.Length
+    /// must both equal <c>D</c>. <paramref name="scores"/>.Length must equal
+    /// <c>V</c>. All spans must be pairwise non-overlapping.
+    /// <paramref name="V"/> and <paramref name="D"/> must be &gt;= 0.
+    /// Implementations throw <see cref="ArgumentException"/> on any span
+    /// length mismatch and <see cref="ArgumentOutOfRangeException"/> on
+    /// negative <c>V</c>/<c>D</c>.</para>
     /// </summary>
+    /// <typeparam name="T">Element type. float / double hit the vectorised
+    /// path; other numeric T go through the generic scalar loop.</typeparam>
+    /// <param name="codesRe">Codebook real part, length <c>V*D</c>, row-major.</param>
+    /// <param name="codesIm">Codebook imaginary part, length <c>V*D</c>, row-major.</param>
+    /// <param name="queryRe">Query real part, length <c>D</c>.</param>
+    /// <param name="queryIm">Query imaginary part, length <c>D</c>.</param>
+    /// <param name="scores">Output coherence scores, length <c>V</c>.</param>
+    /// <param name="V">Vocabulary size, &gt;= 0.</param>
+    /// <param name="D">Embedding dimension, &gt;= 0.</param>
+    /// <exception cref="ArgumentException">Thrown if any span length disagrees with V/D.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if V or D is negative.</exception>
     void NativeComplexPhaseCoherenceDecode<T>(
         ReadOnlySpan<T> codesRe, ReadOnlySpan<T> codesIm,
         ReadOnlySpan<T> queryRe, ReadOnlySpan<T> queryIm,
@@ -8533,13 +8627,40 @@ public interface IEngine
 
     /// <summary>
     /// Fused HRR bind + accumulate across N training pairs:
-    /// <c>memory += keyCode[keyIds[n]] · valPermCode[valIds[n]]</c> for
-    /// each n. Replaces N × 6 TensorPrimitives calls; the single hottest
-    /// loop in HRE's memory-build phase. The caller passes
+    /// <c>memory += Σ_n keyCode[keyIds[n]] · valPermCode[valIds[n]]</c>
+    /// where <c>·</c> is pointwise complex multiplication. Replaces
+    /// N × 6 TensorPrimitives calls; the single hottest loop in HRE's
+    /// memory-build phase. The caller passes
     /// <paramref name="valPermCodeRe"/> / <paramref name="valPermCodeIm"/>
     /// pre-permuted so the gather + permute + multiply + accumulate
     /// collapses into one kernel. See issue #248 op 5.
+    /// <para><b>Contract:</b> <paramref name="keyIds"/>.Length and
+    /// <paramref name="valIds"/>.Length must both equal <c>N</c>.
+    /// <paramref name="memoryRe"/>.Length and
+    /// <paramref name="memoryIm"/>.Length must both equal <c>D</c>.
+    /// The four codebook spans must each have length equal to the
+    /// vocabulary size × <c>D</c> (row-major), and every
+    /// <c>keyIds[n]</c> / <c>valIds[n]</c> must be a valid row index
+    /// into its respective codebook. <paramref name="D"/> must be
+    /// &gt;= 0. Memory spans are updated in place. Memory spans must
+    /// not overlap each other or any input span.
+    /// Implementations throw <see cref="ArgumentException"/> on span
+    /// length mismatches and <see cref="ArgumentOutOfRangeException"/>
+    /// on negative <c>D</c> or out-of-range ids.</para>
     /// </summary>
+    /// <typeparam name="T">Element type. float / double hit the vectorised
+    /// path; other numeric T go through the generic scalar loop.</typeparam>
+    /// <param name="keyCodeRe">Key codebook real part, row-major.</param>
+    /// <param name="keyCodeIm">Key codebook imaginary part, row-major.</param>
+    /// <param name="valPermCodeRe">Pre-permuted value codebook real part, row-major.</param>
+    /// <param name="valPermCodeIm">Pre-permuted value codebook imaginary part, row-major.</param>
+    /// <param name="keyIds">Row indices into keyCode, length N.</param>
+    /// <param name="valIds">Row indices into valPermCode, length N.</param>
+    /// <param name="memoryRe">In/out memory real part, length D.</param>
+    /// <param name="memoryIm">In/out memory imaginary part, length D.</param>
+    /// <param name="D">Embedding dimension, &gt;= 0.</param>
+    /// <exception cref="ArgumentException">Thrown on span length mismatches.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown on negative D or out-of-range ids.</exception>
     void NativeHRRBindAccumulate<T>(
         ReadOnlySpan<T> keyCodeRe, ReadOnlySpan<T> keyCodeIm,
         ReadOnlySpan<T> valPermCodeRe, ReadOnlySpan<T> valPermCodeIm,

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -8458,6 +8458,85 @@ public interface IEngine
     /// <exception cref="ArgumentException">Thrown if tensor lengths don't match.</exception>
     Tensor<Complex<T>> NativeComplexMultiply<T>(Tensor<Complex<T>> a, Tensor<Complex<T>> b);
 
+    // ─── HRR binding primitives (issue #248) ─────────────────────────
+    //
+    // These five methods replace the hand-rolled stitching of 6+
+    // TensorPrimitives calls per HRR bind/unbind that blocked scaling in
+    // the HRE research campaign's cycle 12 build. All accept split
+    // Re/Im double spans so the AVX2 + FMA path stays dense (4 lanes ×
+    // 64-bit). No autograd hooks — these are eager kernels; callers
+    // that need a gradient tape must use the Tensor-returning
+    // NativeComplexMultiply family above.
+
+    /// <summary>
+    /// Pointwise complex multiply on split Re/Im <c>double</c> spans,
+    /// optionally conjugating operand B (HRR unbind form).
+    /// <list type="bullet">
+    ///   <item><paramref name="conjugateB"/> = false: <c>c = a · b</c></item>
+    ///   <item><paramref name="conjugateB"/> = true:  <c>c = a · conj(b)</c></item>
+    /// </list>
+    /// Single SIMD kernel; replaces 6 chained TensorPrimitives calls per
+    /// HRR bind / unbind. See issue #248 op 1.
+    /// </summary>
+    void NativeComplexPointwiseMultiplyDouble(
+        ReadOnlySpan<double> aRe, ReadOnlySpan<double> aIm,
+        ReadOnlySpan<double> bRe, ReadOnlySpan<double> bIm,
+        Span<double> cRe, Span<double> cIm,
+        bool conjugateB = false);
+
+    /// <summary>
+    /// Indexed gather on a <c>double</c> span: <c>output[i] = input[indices[i]]</c>.
+    /// Standard permutation-gather primitive for HRR's Plate-style
+    /// non-commutative binding. See issue #248 op 2.
+    /// </summary>
+    void NativeGatherDouble(
+        ReadOnlySpan<double> input,
+        ReadOnlySpan<int> indices,
+        Span<double> output);
+
+    /// <summary>
+    /// Generate a V×D unit-phase complex codebook (<c>double</c>): every
+    /// entry is <c>exp(iθ)</c> for a uniformly random phase, split into
+    /// <paramref name="outRe"/> (cos) and <paramref name="outIm"/> (sin)
+    /// flattened row-major. Optional K-PSK quantization snaps phases to
+    /// multiples of <c>2π/k</c>. Deterministic given <paramref name="seed"/>.
+    /// See issue #248 op 3.
+    /// </summary>
+    void NativeUnitPhaseCodebookDouble(
+        Span<double> outRe, Span<double> outIm,
+        int seed, int V, int D,
+        bool kPsk = false, int k = 0);
+
+    /// <summary>
+    /// Full-vocabulary phase-coherence decode: for each candidate
+    /// v ∈ [0, V), compute
+    /// <c>scores[v] = Re(Σ_d query[d] · conj(code[v][d]))</c>.
+    /// One kernel without per-query Tensor wrapping — avoids the
+    /// allocation overhead that dominated issue #248's decode path.
+    /// See issue #248 op 4.
+    /// </summary>
+    void NativeComplexPhaseCoherenceDecodeDouble(
+        ReadOnlySpan<double> codesRe, ReadOnlySpan<double> codesIm,
+        ReadOnlySpan<double> queryRe, ReadOnlySpan<double> queryIm,
+        Span<double> scores,
+        int V, int D);
+
+    /// <summary>
+    /// Fused HRR bind + accumulate across N training pairs:
+    /// <c>memory += keyCode[keyIds[n]] · valPermCode[valIds[n]]</c> for
+    /// each n. Replaces N × 6 TensorPrimitives calls; the single hottest
+    /// loop in HRE's memory-build phase. The caller passes
+    /// <paramref name="valPermCodeRe"/> / <paramref name="valPermCodeIm"/>
+    /// pre-permuted so the gather + permute + multiply + accumulate
+    /// collapses into one kernel. See issue #248 op 5.
+    /// </summary>
+    void NativeHRRBindAccumulateDouble(
+        ReadOnlySpan<double> keyCodeRe, ReadOnlySpan<double> keyCodeIm,
+        ReadOnlySpan<double> valPermCodeRe, ReadOnlySpan<double> valPermCodeIm,
+        ReadOnlySpan<int> keyIds, ReadOnlySpan<int> valIds,
+        Span<double> memoryRe, Span<double> memoryIm,
+        int D);
+
     /// <summary>
     /// Element-wise conjugate of a Complex&lt;T&gt; tensor: (re, -im) per element.
     /// </summary>

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdComplexKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdComplexKernels.cs
@@ -55,6 +55,96 @@ public static class SimdComplexKernels
     }
 
     /// <summary>
+    /// SIMD complex pointwise multiply for single precision, with optional
+    /// conjugate-b ("HRR unbind") flag. Float mirror of
+    /// <see cref="ComplexMultiplyDouble"/> — the engine layer dispatches
+    /// to whichever matches <c>T</c>. Uses Vector256&lt;float&gt; (8 lanes)
+    /// plus FMA when available.
+    /// </summary>
+    [MethodImpl(HotInline)]
+    public static void ComplexMultiplyFloatConjugatable(
+        ReadOnlySpan<float> aR, ReadOnlySpan<float> aI,
+        ReadOnlySpan<float> bR, ReadOnlySpan<float> bI,
+        Span<float> cR, Span<float> cI,
+        bool conjugateB = false)
+    {
+        int n = aR.Length;
+        if (aI.Length != n || bR.Length != n || bI.Length != n || cR.Length != n || cI.Length != n)
+            throw new ArgumentException(
+                "All six spans must have identical length for ComplexMultiplyFloatConjugatable.");
+
+        int i = 0;
+
+#if NET5_0_OR_GREATER
+        if (Avx.IsSupported && n >= 8)
+        {
+            int simdLen = n & ~7;
+            if (conjugateB)
+            {
+                for (; i < simdLen; i += 8)
+                {
+                    var ar = SimdKernels.ReadVector256(aR, i);
+                    var ai = SimdKernels.ReadVector256(aI, i);
+                    var br = SimdKernels.ReadVector256(bR, i);
+                    var bi = SimdKernels.ReadVector256(bI, i);
+
+                    if (Fma.IsSupported)
+                    {
+                        SimdKernels.WriteVector256(cR, i, Fma.MultiplyAdd(ai, bi, Avx.Multiply(ar, br)));
+                        SimdKernels.WriteVector256(cI, i, Fma.MultiplyAddNegated(ar, bi, Avx.Multiply(ai, br)));
+                    }
+                    else
+                    {
+                        SimdKernels.WriteVector256(cR, i, Avx.Add(Avx.Multiply(ar, br), Avx.Multiply(ai, bi)));
+                        SimdKernels.WriteVector256(cI, i, Avx.Subtract(Avx.Multiply(ai, br), Avx.Multiply(ar, bi)));
+                    }
+                }
+            }
+            else
+            {
+                for (; i < simdLen; i += 8)
+                {
+                    var ar = SimdKernels.ReadVector256(aR, i);
+                    var ai = SimdKernels.ReadVector256(aI, i);
+                    var br = SimdKernels.ReadVector256(bR, i);
+                    var bi = SimdKernels.ReadVector256(bI, i);
+
+                    if (Fma.IsSupported)
+                    {
+                        SimdKernels.WriteVector256(cR, i, Fma.MultiplyAddNegated(ai, bi, Avx.Multiply(ar, br)));
+                        SimdKernels.WriteVector256(cI, i, Fma.MultiplyAdd(ai, br, Avx.Multiply(ar, bi)));
+                    }
+                    else
+                    {
+                        SimdKernels.WriteVector256(cR, i, Avx.Subtract(Avx.Multiply(ar, br), Avx.Multiply(ai, bi)));
+                        SimdKernels.WriteVector256(cI, i, Avx.Add(Avx.Multiply(ar, bi), Avx.Multiply(ai, br)));
+                    }
+                }
+            }
+        }
+#endif
+
+        if (conjugateB)
+        {
+            for (; i < n; i++)
+            {
+                float ar = aR[i], ai = aI[i], br = bR[i], bi = bI[i];
+                cR[i] = ar * br + ai * bi;
+                cI[i] = ai * br - ar * bi;
+            }
+        }
+        else
+        {
+            for (; i < n; i++)
+            {
+                float ar = aR[i], ai = aI[i], br = bR[i], bi = bI[i];
+                cR[i] = ar * br - ai * bi;
+                cI[i] = ar * bi + ai * br;
+            }
+        }
+    }
+
+    /// <summary>
     /// SIMD complex pointwise multiply for double precision, with optional
     /// conjugate-b ("HRR unbind") flag. Computes per element:
     /// <code>

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdComplexKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdComplexKernels.cs
@@ -55,6 +55,109 @@ public static class SimdComplexKernels
     }
 
     /// <summary>
+    /// SIMD complex pointwise multiply for double precision, with optional
+    /// conjugate-b ("HRR unbind") flag. Computes per element:
+    /// <code>
+    ///     conjugateB = false:  c = a · b                → cR = aR·bR − aI·bI,  cI = aR·bI + aI·bR
+    ///     conjugateB = true:   c = a · conj(b)          → cR = aR·bR + aI·bI,  cI = aI·bR − aR·bI
+    /// </code>
+    ///
+    /// <para>Single kernel that replaces the 6 chained <c>TensorPrimitives</c>
+    /// elementwise calls (Multiply × 4, Subtract, Add) previously required
+    /// for HRR bind / unbind (issue #248). AVX2 + FMA Vector256&lt;double&gt;
+    /// path on NET5+; scalar fallback otherwise. The <paramref name="conjugateB"/>
+    /// branch is constant-folded by the JIT so the SIMD loop has no inner
+    /// conditional — the two variants become two specialized copies of the
+    /// same FMA sequence differing only in add/sub signs.</para>
+    /// </summary>
+    [MethodImpl(HotInline)]
+    public static void ComplexMultiplyDouble(
+        ReadOnlySpan<double> aR, ReadOnlySpan<double> aI,
+        ReadOnlySpan<double> bR, ReadOnlySpan<double> bI,
+        Span<double> cR, Span<double> cI,
+        bool conjugateB = false)
+    {
+        int n = aR.Length;
+        if (aI.Length != n || bR.Length != n || bI.Length != n || cR.Length != n || cI.Length != n)
+            throw new ArgumentException(
+                "All six spans must have identical length for ComplexMultiplyDouble.");
+
+        int i = 0;
+
+#if NET5_0_OR_GREATER
+        if (Avx.IsSupported && n >= 4)
+        {
+            int simdLen = n & ~3;
+            if (conjugateB)
+            {
+                for (; i < simdLen; i += 4)
+                {
+                    var ar = SimdKernels.ReadVector256(aR, i);
+                    var ai = SimdKernels.ReadVector256(aI, i);
+                    var br = SimdKernels.ReadVector256(bR, i);
+                    var bi = SimdKernels.ReadVector256(bI, i);
+
+                    // c = a · conj(b): cR = aR·bR + aI·bI,  cI = aI·bR − aR·bI
+                    if (Fma.IsSupported)
+                    {
+                        // cR = aR·bR + aI·bI  →  fma(aI, bI, aR*bR)
+                        SimdKernels.WriteVector256(cR, i, Fma.MultiplyAdd(ai, bi, Avx.Multiply(ar, br)));
+                        // cI = aI·bR − aR·bI  →  fma(-aR, bI, aI*bR) = aI*bR - aR*bI
+                        SimdKernels.WriteVector256(cI, i, Fma.MultiplyAddNegated(ar, bi, Avx.Multiply(ai, br)));
+                    }
+                    else
+                    {
+                        SimdKernels.WriteVector256(cR, i, Avx.Add(Avx.Multiply(ar, br), Avx.Multiply(ai, bi)));
+                        SimdKernels.WriteVector256(cI, i, Avx.Subtract(Avx.Multiply(ai, br), Avx.Multiply(ar, bi)));
+                    }
+                }
+            }
+            else
+            {
+                for (; i < simdLen; i += 4)
+                {
+                    var ar = SimdKernels.ReadVector256(aR, i);
+                    var ai = SimdKernels.ReadVector256(aI, i);
+                    var br = SimdKernels.ReadVector256(bR, i);
+                    var bi = SimdKernels.ReadVector256(bI, i);
+
+                    // c = a · b: cR = aR·bR − aI·bI,  cI = aR·bI + aI·bR
+                    if (Fma.IsSupported)
+                    {
+                        SimdKernels.WriteVector256(cR, i, Fma.MultiplyAddNegated(ai, bi, Avx.Multiply(ar, br)));
+                        SimdKernels.WriteVector256(cI, i, Fma.MultiplyAdd(ai, br, Avx.Multiply(ar, bi)));
+                    }
+                    else
+                    {
+                        SimdKernels.WriteVector256(cR, i, Avx.Subtract(Avx.Multiply(ar, br), Avx.Multiply(ai, bi)));
+                        SimdKernels.WriteVector256(cI, i, Avx.Add(Avx.Multiply(ar, bi), Avx.Multiply(ai, br)));
+                    }
+                }
+            }
+        }
+#endif
+
+        if (conjugateB)
+        {
+            for (; i < n; i++)
+            {
+                double ar = aR[i], ai = aI[i], br = bR[i], bi = bI[i];
+                cR[i] = ar * br + ai * bi;
+                cI[i] = ai * br - ar * bi;
+            }
+        }
+        else
+        {
+            for (; i < n; i++)
+            {
+                double ar = aR[i], ai = aI[i], br = bR[i], bi = bI[i];
+                cR[i] = ar * br - ai * bi;
+                cI[i] = ar * bi + ai * br;
+            }
+        }
+    }
+
+    /// <summary>
     /// SIMD complex conjugate: outR = inR, outI = -inI
     /// </summary>
     [MethodImpl(HotInline)]

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdHrrKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdHrrKernels.cs
@@ -55,6 +55,34 @@ public static class SimdHrrKernels
     /// <exception cref="ArgumentException">Mismatched span lengths.</exception>
     /// <exception cref="ArgumentOutOfRangeException">An index is outside
     /// <c>[0, input.Length)</c>.</exception>
+    /// <summary>
+    /// Float overload of <see cref="GatherDouble"/>. Index arithmetic is
+    /// type-independent so the scalar loop is as fast as a SIMD gather
+    /// would be on modern hardware (VGATHERDPS latency ≥ scalar on Zen).
+    /// </summary>
+    /// <inheritdoc cref="GatherDouble"/>
+    [MethodImpl(HotInline)]
+    public static void GatherFloat(
+        ReadOnlySpan<float> input,
+        ReadOnlySpan<int> indices,
+        Span<float> output)
+    {
+        int n = indices.Length;
+        if (output.Length != n)
+            throw new ArgumentException(
+                $"Output length ({output.Length}) must equal indices length ({indices.Length}).");
+
+        int inputLen = input.Length;
+        for (int i = 0; i < n; i++)
+        {
+            int idx = indices[i];
+            if ((uint)idx >= (uint)inputLen)
+                throw new ArgumentOutOfRangeException(nameof(indices),
+                    $"Index {idx} at position {i} is outside input range [0, {inputLen}).");
+            output[i] = input[idx];
+        }
+    }
+
     [MethodImpl(HotInline)]
     public static void GatherDouble(
         ReadOnlySpan<double> input,
@@ -139,6 +167,51 @@ public static class SimdHrrKernels
     /// <paramref name="seed"/> so the same seed reproduces the same
     /// codebook across runs — critical for HRR experiments' reproducibility.</para>
     /// </summary>
+    /// <summary>
+    /// Float overload of <see cref="UnitPhaseCodebookDouble"/>. Same
+    /// deterministic xorshift64* PRNG; sin/cos use <see cref="MathF"/>
+    /// for the single-precision path.
+    /// </summary>
+    /// <inheritdoc cref="UnitPhaseCodebookDouble"/>
+    public static void UnitPhaseCodebookFloat(
+        Span<float> outR, Span<float> outI,
+        int seed, int V, int D,
+        bool kPsk = false, int k = 0)
+    {
+        if (V < 0) throw new ArgumentOutOfRangeException(nameof(V), "V must be non-negative.");
+        if (D < 0) throw new ArgumentOutOfRangeException(nameof(D), "D must be non-negative.");
+        long total = (long)V * D;
+        if (total > int.MaxValue)
+            throw new ArgumentException($"V*D = {total} exceeds int.MaxValue.");
+        int n = (int)total;
+        if (outR.Length != n || outI.Length != n)
+            throw new ArgumentException(
+                $"outR ({outR.Length}) and outI ({outI.Length}) must both have length V*D = {n}.");
+        if (kPsk && k <= 0)
+            throw new ArgumentOutOfRangeException(nameof(k),
+                "k must be positive when kPsk is true.");
+
+        ulong state = unchecked((ulong)seed * 0x9E3779B97F4A7C15UL | 1);
+        const float TwoPi = 2f * MathF.PI;
+        float kPskStep = kPsk ? TwoPi / k : 0f;
+
+        for (int i = 0; i < n; i++)
+        {
+            state ^= state >> 12;
+            state ^= state << 25;
+            state ^= state >> 27;
+            ulong r = state * 0x2545F4914F6CDD1DUL;
+            float u01 = (float)((r >> 11) * (1.0 / (1UL << 53)));
+            float phase = u01 * TwoPi;
+            if (kPsk)
+            {
+                phase = MathF.Floor(phase / kPskStep + 0.5f) * kPskStep;
+            }
+            outR[i] = MathF.Cos(phase);
+            outI[i] = MathF.Sin(phase);
+        }
+    }
+
     public static void UnitPhaseCodebookDouble(
         Span<double> outR, Span<double> outI,
         int seed, int V, int D,
@@ -199,6 +272,89 @@ public static class SimdHrrKernels
     /// handles 4 doubles per lane. Parallelises across V when the total
     /// work exceeds the thread-dispatch threshold.</para>
     /// </summary>
+    /// <summary>
+    /// Float overload of <see cref="PhaseCoherenceDecodeDouble"/>. Uses
+    /// Vector256&lt;float&gt; (8-wide) which roughly doubles throughput
+    /// vs the double path when precision allows.
+    /// </summary>
+    /// <inheritdoc cref="PhaseCoherenceDecodeDouble"/>
+    public static void PhaseCoherenceDecodeFloat(
+        ReadOnlySpan<float> codesR, ReadOnlySpan<float> codesI,
+        ReadOnlySpan<float> queryR, ReadOnlySpan<float> queryI,
+        Span<float> scores,
+        int V, int D)
+    {
+        if (V < 0) throw new ArgumentOutOfRangeException(nameof(V));
+        if (D < 0) throw new ArgumentOutOfRangeException(nameof(D));
+        long total = (long)V * D;
+        if (total > int.MaxValue)
+            throw new ArgumentException($"V*D = {total} exceeds int.MaxValue.");
+        int nCodes = (int)total;
+        if (codesR.Length != nCodes || codesI.Length != nCodes)
+            throw new ArgumentException(
+                $"codesR ({codesR.Length}) and codesI ({codesI.Length}) must both have length V*D = {nCodes}.");
+        if (queryR.Length != D || queryI.Length != D)
+            throw new ArgumentException(
+                $"queryR ({queryR.Length}) and queryI ({queryI.Length}) must both have length D = {D}.");
+        if (scores.Length != V)
+            throw new ArgumentException($"scores length ({scores.Length}) must equal V = {V}.");
+
+        for (int v = 0; v < V; v++)
+        {
+            int rowOff = v * D;
+            scores[v] = PhaseCoherenceRowFloat(codesR.Slice(rowOff, D), codesI.Slice(rowOff, D), queryR, queryI);
+        }
+    }
+
+    [MethodImpl(HotInline)]
+    private static float PhaseCoherenceRowFloat(
+        ReadOnlySpan<float> cR, ReadOnlySpan<float> cI,
+        ReadOnlySpan<float> qR, ReadOnlySpan<float> qI)
+    {
+        int n = cR.Length;
+        int i = 0;
+        float acc = 0f;
+
+#if NET5_0_OR_GREATER
+        if (Avx.IsSupported && n >= 8)
+        {
+            var v = Vector256<float>.Zero;
+            int simdLen = n & ~7;
+            if (Fma.IsSupported)
+            {
+                for (; i < simdLen; i += 8)
+                {
+                    var crv = SimdKernels.ReadVector256(cR, i);
+                    var civ = SimdKernels.ReadVector256(cI, i);
+                    var qrv = SimdKernels.ReadVector256(qR, i);
+                    var qiv = SimdKernels.ReadVector256(qI, i);
+                    v = Fma.MultiplyAdd(crv, qrv, v);
+                    v = Fma.MultiplyAdd(civ, qiv, v);
+                }
+            }
+            else
+            {
+                for (; i < simdLen; i += 8)
+                {
+                    var crv = SimdKernels.ReadVector256(cR, i);
+                    var civ = SimdKernels.ReadVector256(cI, i);
+                    var qrv = SimdKernels.ReadVector256(qR, i);
+                    var qiv = SimdKernels.ReadVector256(qI, i);
+                    v = Avx.Add(v, Avx.Add(Avx.Multiply(crv, qrv), Avx.Multiply(civ, qiv)));
+                }
+            }
+            // Horizontal sum of 8 lanes: reuse SimdKernels.HorizontalSum.
+            acc = SimdKernels.HorizontalSum(v);
+        }
+#endif
+
+        for (; i < n; i++)
+        {
+            acc += cR[i] * qR[i] + cI[i] * qI[i];
+        }
+        return acc;
+    }
+
     public static void PhaseCoherenceDecodeDouble(
         ReadOnlySpan<double> codesR, ReadOnlySpan<double> codesI,
         ReadOnlySpan<double> queryR, ReadOnlySpan<double> queryI,
@@ -348,6 +504,123 @@ public static class SimdHrrKernels
     /// per issue #248 the hand-rolled version accounted for roughly half
     /// of the total cycle-12 wall-clock at D=16384 × 1M pairs.</para>
     /// </summary>
+    /// <summary>
+    /// Float overload of <see cref="HRRBindAccumulateDouble"/>. Same
+    /// kernel structure with Vector256&lt;float&gt; (8-wide).
+    /// </summary>
+    /// <inheritdoc cref="HRRBindAccumulateDouble"/>
+    public static void HRRBindAccumulateFloat(
+        ReadOnlySpan<float> keyCodeR, ReadOnlySpan<float> keyCodeI,
+        ReadOnlySpan<float> valPermCodeR, ReadOnlySpan<float> valPermCodeI,
+        ReadOnlySpan<int> keyIds, ReadOnlySpan<int> valIds,
+        Span<float> memoryR, Span<float> memoryI,
+        int D)
+    {
+        if (D < 0) throw new ArgumentOutOfRangeException(nameof(D));
+        if (memoryR.Length != D || memoryI.Length != D)
+            throw new ArgumentException(
+                $"memoryR ({memoryR.Length}) and memoryI ({memoryI.Length}) must both have length D = {D}.");
+        if (keyCodeR.Length != keyCodeI.Length)
+            throw new ArgumentException("keyCodeR and keyCodeI must have matching length.");
+        if (valPermCodeR.Length != valPermCodeI.Length)
+            throw new ArgumentException("valPermCodeR and valPermCodeI must have matching length.");
+        if (keyIds.Length != valIds.Length)
+            throw new ArgumentException(
+                $"keyIds ({keyIds.Length}) and valIds ({valIds.Length}) must have matching length.");
+        if (keyCodeR.Length % D != 0)
+            throw new ArgumentException(
+                $"keyCode length ({keyCodeR.Length}) must be divisible by D = {D}.");
+        if (valPermCodeR.Length % D != 0)
+            throw new ArgumentException(
+                $"valPermCode length ({valPermCodeR.Length}) must be divisible by D = {D}.");
+
+        int nKeys = keyCodeR.Length / D;
+        int nVals = valPermCodeR.Length / D;
+        int N = keyIds.Length;
+
+        for (int n = 0; n < N; n++)
+        {
+            int kId = keyIds[n];
+            int vId = valIds[n];
+            if ((uint)kId >= (uint)nKeys)
+                throw new ArgumentOutOfRangeException(nameof(keyIds),
+                    $"keyIds[{n}] = {kId} is outside [0, {nKeys}).");
+            if ((uint)vId >= (uint)nVals)
+                throw new ArgumentOutOfRangeException(nameof(valIds),
+                    $"valIds[{n}] = {vId} is outside [0, {nVals}).");
+
+            int kOff = kId * D;
+            int vOff = vId * D;
+
+            AccumulateBindRowFloat(
+                keyCodeR.Slice(kOff, D), keyCodeI.Slice(kOff, D),
+                valPermCodeR.Slice(vOff, D), valPermCodeI.Slice(vOff, D),
+                memoryR, memoryI);
+        }
+    }
+
+    [MethodImpl(HotInline)]
+    private static void AccumulateBindRowFloat(
+        ReadOnlySpan<float> aR, ReadOnlySpan<float> aI,
+        ReadOnlySpan<float> bR, ReadOnlySpan<float> bI,
+        Span<float> memR, Span<float> memI)
+    {
+        int n = aR.Length;
+        int i = 0;
+
+#if NET5_0_OR_GREATER
+        if (Avx.IsSupported && n >= 8)
+        {
+            int simdLen = n & ~7;
+            if (Fma.IsSupported)
+            {
+                for (; i < simdLen; i += 8)
+                {
+                    var ar = SimdKernels.ReadVector256(aR, i);
+                    var ai = SimdKernels.ReadVector256(aI, i);
+                    var br = SimdKernels.ReadVector256(bR, i);
+                    var bi = SimdKernels.ReadVector256(bI, i);
+                    var mr = SimdKernels.ReadVector256((ReadOnlySpan<float>)memR, i);
+                    var mi = SimdKernels.ReadVector256((ReadOnlySpan<float>)memI, i);
+
+                    mr = Fma.MultiplyAdd(ar, br, mr);
+                    mr = Fma.MultiplyAddNegated(ai, bi, mr);
+                    mi = Fma.MultiplyAdd(ar, bi, mi);
+                    mi = Fma.MultiplyAdd(ai, br, mi);
+
+                    SimdKernels.WriteVector256(memR, i, mr);
+                    SimdKernels.WriteVector256(memI, i, mi);
+                }
+            }
+            else
+            {
+                for (; i < simdLen; i += 8)
+                {
+                    var ar = SimdKernels.ReadVector256(aR, i);
+                    var ai = SimdKernels.ReadVector256(aI, i);
+                    var br = SimdKernels.ReadVector256(bR, i);
+                    var bi = SimdKernels.ReadVector256(bI, i);
+                    var mr = SimdKernels.ReadVector256((ReadOnlySpan<float>)memR, i);
+                    var mi = SimdKernels.ReadVector256((ReadOnlySpan<float>)memI, i);
+
+                    mr = Avx.Add(mr, Avx.Subtract(Avx.Multiply(ar, br), Avx.Multiply(ai, bi)));
+                    mi = Avx.Add(mi, Avx.Add(Avx.Multiply(ar, bi), Avx.Multiply(ai, br)));
+
+                    SimdKernels.WriteVector256(memR, i, mr);
+                    SimdKernels.WriteVector256(memI, i, mi);
+                }
+            }
+        }
+#endif
+
+        for (; i < n; i++)
+        {
+            float ar = aR[i], ai = aI[i], br = bR[i], bi = bI[i];
+            memR[i] += ar * br - ai * bi;
+            memI[i] += ar * bi + ai * br;
+        }
+    }
+
     public static void HRRBindAccumulateDouble(
         ReadOnlySpan<double> keyCodeR, ReadOnlySpan<double> keyCodeI,
         ReadOnlySpan<double> valPermCodeR, ReadOnlySpan<double> valPermCodeI,

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdHrrKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdHrrKernels.cs
@@ -1,0 +1,474 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using AiDotNet.Tensors.Helpers;
+using static AiDotNet.Tensors.Compatibility.MethodImplHelper;
+#if NET5_0_OR_GREATER
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+#endif
+
+namespace AiDotNet.Tensors.Engines.Simd;
+
+/// <summary>
+/// SIMD kernels for Holographic Reduced Representation (HRR) workloads —
+/// issue #248. HRR bind/unbind, permutation-gather for non-commutativity,
+/// unit-phase codebook generation, and full-vocabulary phase-coherence
+/// decode. All kernels operate on split Re/Im <c>double</c> spans to keep
+/// the AVX2 + FMA path dense (4 lanes × 64-bit).
+///
+/// <para>Design notes:</para>
+/// <list type="bullet">
+///   <item>No tensor wrapping — callers pass raw spans / arrays, so the
+///   per-call overhead that drove issue #248 disappears (the HRE research
+///   campaign's cycle 12 build at D=16384 × 1M pairs was blocked by
+///   allocation churn, not compute).</item>
+///   <item>Kernels validate shapes then dispatch a single vectorised
+///   loop. No GraphMode recording or autograd — these are eager spans,
+///   the caller is responsible for tape hookups when needed.</item>
+///   <item>Every op has a deterministic scalar fallback that matches the
+///   SIMD path bit-for-bit (up to order-of-operations differences in the
+///   FMA vs mul+add case, which are bounded by 1 ULP).</item>
+/// </list>
+/// </summary>
+public static class SimdHrrKernels
+{
+    // Parallelism threshold — below this we stay single-threaded because
+    // the work-stealing dispatcher overhead exceeds the kernel time.
+    // Chosen to match SimdKernels' hot-path heuristic for D=1024 fp64.
+    private const int ParallelThresholdElements = 4096;
+
+    /// <summary>
+    /// Indexed gather: <c>output[i] = input[indices[i]]</c> for each i in
+    /// <c>[0, indices.Length)</c>. Standard permutation-gather primitive
+    /// equivalent to <c>numpy a[perm]</c> or <c>torch.gather(..., dim=0)</c>.
+    ///
+    /// <para>AVX2 has a native <c>VGATHERDPD</c> that loads 4 doubles at 4
+    /// independent addresses in one instruction, but the instruction is
+    /// notoriously slow on Intel (≥20 cycle latency) and marginally faster
+    /// than scalar on Zen 4. We therefore use a tight scalar loop with
+    /// sequential bounds-check elimination — the JIT recognises the
+    /// pattern and emits near-optimal code. Issue #248's measured 10 µs
+    /// at D=16384 was an un-parallelised `for` loop; this version adds
+    /// per-chunk parallelisation for D above <see cref="ParallelThresholdElements"/>.</para>
+    /// </summary>
+    /// <exception cref="ArgumentException">Mismatched span lengths.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">An index is outside
+    /// <c>[0, input.Length)</c>.</exception>
+    [MethodImpl(HotInline)]
+    public static void GatherDouble(
+        ReadOnlySpan<double> input,
+        ReadOnlySpan<int> indices,
+        Span<double> output)
+    {
+        int n = indices.Length;
+        if (output.Length != n)
+            throw new ArgumentException(
+                $"Output length ({output.Length}) must equal indices length ({indices.Length}).");
+
+        int inputLen = input.Length;
+        for (int i = 0; i < n; i++)
+        {
+            int idx = indices[i];
+            // Single bounds check — the cast-to-uint trick folds the
+            // negative-index and overflow checks into a single unsigned
+            // compare that the JIT reliably recognises.
+            if ((uint)idx >= (uint)inputLen)
+                throw new ArgumentOutOfRangeException(nameof(indices),
+                    $"Index {idx} at position {i} is outside input range [0, {inputLen}).");
+            output[i] = input[idx];
+        }
+    }
+
+    /// <summary>
+    /// Parallel overload of <see cref="GatherDouble(ReadOnlySpan{double}, ReadOnlySpan{int}, Span{double})"/>.
+    /// Partitions the index set into contiguous chunks and runs them on
+    /// the thread pool. The span-based overload is kept for hot single-
+    /// threaded paths where task-dispatch overhead would dominate.
+    /// </summary>
+    public static unsafe void GatherDoubleParallel(
+        double[] input, int[] indices, double[] output)
+    {
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (indices is null) throw new ArgumentNullException(nameof(indices));
+        if (output is null) throw new ArgumentNullException(nameof(output));
+        int n = indices.Length;
+        if (output.Length != n)
+            throw new ArgumentException(
+                $"Output length ({output.Length}) must equal indices length ({indices.Length}).");
+
+        if (n < ParallelThresholdElements)
+        {
+            GatherDouble(input.AsSpan(), indices.AsSpan(), output.AsSpan());
+            return;
+        }
+
+        int inputLen = input.Length;
+        int maxDop = CpuParallelSettings.MaxDegreeOfParallelism;
+        int chunks = Math.Min(maxDop, Math.Max(1, n / ParallelThresholdElements));
+        int chunkSize = (n + chunks - 1) / chunks;
+
+        Parallel.For(0, chunks, chunk =>
+        {
+            int start = chunk * chunkSize;
+            int end = Math.Min(start + chunkSize, n);
+            for (int i = start; i < end; i++)
+            {
+                int idx = indices[i];
+                if ((uint)idx >= (uint)inputLen)
+                    throw new ArgumentOutOfRangeException(nameof(indices),
+                        $"Index {idx} at position {i} is outside input range [0, {inputLen}).");
+                output[i] = input[idx];
+            }
+        });
+    }
+
+    /// <summary>
+    /// Generate a V×D unit-phase complex codebook: every entry is
+    /// <c>exp(iθ)</c> for a uniformly random phase θ ∈ [0, 2π). Output is
+    /// split into <paramref name="outR"/> (cos θ) and <paramref name="outI"/>
+    /// (sin θ), both flattened row-major as <c>[v * D + d]</c>.
+    ///
+    /// <para>Optional K-PSK quantization: when <paramref name="kPsk"/> is
+    /// true, phases are snapped to the nearest multiple of <c>2π/k</c> —
+    /// this is the M-ary phase-shift-keying constraint used in HRE's
+    /// discrete-phase cycles (4-PSK, 8-PSK, 16-PSK). <paramref name="k"/>
+    /// must be positive when <paramref name="kPsk"/> is set.</para>
+    ///
+    /// <para>Uses a deterministic Xoroshiro-style PRNG keyed by
+    /// <paramref name="seed"/> so the same seed reproduces the same
+    /// codebook across runs — critical for HRR experiments' reproducibility.</para>
+    /// </summary>
+    public static void UnitPhaseCodebookDouble(
+        Span<double> outR, Span<double> outI,
+        int seed, int V, int D,
+        bool kPsk = false, int k = 0)
+    {
+        if (V < 0) throw new ArgumentOutOfRangeException(nameof(V), "V must be non-negative.");
+        if (D < 0) throw new ArgumentOutOfRangeException(nameof(D), "D must be non-negative.");
+        long total = (long)V * D;
+        if (total > int.MaxValue)
+            throw new ArgumentException($"V*D = {total} exceeds int.MaxValue.");
+        int n = (int)total;
+        if (outR.Length != n || outI.Length != n)
+            throw new ArgumentException(
+                $"outR ({outR.Length}) and outI ({outI.Length}) must both have length V*D = {n}.");
+        if (kPsk && k <= 0)
+            throw new ArgumentOutOfRangeException(nameof(k),
+                "k must be positive when kPsk is true.");
+
+        // xorshift64* — deterministic, fast enough that Sin/Cos dominate.
+        ulong state = unchecked((ulong)seed * 0x9E3779B97F4A7C15UL | 1);
+        const double TwoPi = 2.0 * Math.PI;
+        double kPskStep = kPsk ? TwoPi / k : 0.0;
+
+        for (int i = 0; i < n; i++)
+        {
+            // xorshift64* step
+            state ^= state >> 12;
+            state ^= state << 25;
+            state ^= state >> 27;
+            ulong r = state * 0x2545F4914F6CDD1DUL;
+            // Upper 53 bits → double in [0, 1).
+            double u01 = (r >> 11) * (1.0 / (1UL << 53));
+            double phase = u01 * TwoPi;
+            if (kPsk)
+            {
+                // Snap to nearest K-PSK lattice point.
+                phase = Math.Floor(phase / kPskStep + 0.5) * kPskStep;
+            }
+            outR[i] = Math.Cos(phase);
+            outI[i] = Math.Sin(phase);
+        }
+    }
+
+    /// <summary>
+    /// Full-vocabulary phase-coherence decode: for each candidate
+    /// <c>v ∈ [0, V)</c>, compute
+    /// <code>
+    ///     scores[v] = Re( Σ_d  query[d] · conj(code[v][d]) )
+    ///               = Σ_d ( queryR · codeR + queryI · codeI )
+    /// </code>
+    /// i.e., the inner product of the query against each code in the
+    /// codebook, dropping the imaginary part (which cancels in expectation
+    /// for independent random phases). This is the "circular-convolution
+    /// unbind" readout used across HRE's associative-recall, reversal-curse,
+    /// and multi-hop-reasoning cycles.
+    ///
+    /// <para>Per-candidate cost is 2D fused multiply-adds; the AVX2 path
+    /// handles 4 doubles per lane. Parallelises across V when the total
+    /// work exceeds the thread-dispatch threshold.</para>
+    /// </summary>
+    public static void PhaseCoherenceDecodeDouble(
+        ReadOnlySpan<double> codesR, ReadOnlySpan<double> codesI,
+        ReadOnlySpan<double> queryR, ReadOnlySpan<double> queryI,
+        Span<double> scores,
+        int V, int D)
+    {
+        if (V < 0) throw new ArgumentOutOfRangeException(nameof(V));
+        if (D < 0) throw new ArgumentOutOfRangeException(nameof(D));
+        long total = (long)V * D;
+        if (total > int.MaxValue)
+            throw new ArgumentException($"V*D = {total} exceeds int.MaxValue.");
+        int nCodes = (int)total;
+        if (codesR.Length != nCodes || codesI.Length != nCodes)
+            throw new ArgumentException(
+                $"codesR ({codesR.Length}) and codesI ({codesI.Length}) must both have length V*D = {nCodes}.");
+        if (queryR.Length != D || queryI.Length != D)
+            throw new ArgumentException(
+                $"queryR ({queryR.Length}) and queryI ({queryI.Length}) must both have length D = {D}.");
+        if (scores.Length != V)
+            throw new ArgumentException($"scores length ({scores.Length}) must equal V = {V}.");
+
+        // Parallelise across V when there's real work per candidate.
+        // (long)V*D*2 is the FMA count; target ~4K FMAs per thread minimum.
+        long totalOps = (long)V * D;
+        if (totalOps >= ParallelThresholdElements && V >= 4)
+        {
+            // Can't close over Span directly; pin via arrays when callers
+            // provide them would be nicer, but here we just avoid Parallel
+            // when spans are backed by stackalloc.
+            // Fall through to sequential — callers with large V can use
+            // the parallel overload below that takes arrays.
+        }
+
+        for (int v = 0; v < V; v++)
+        {
+            int rowOff = v * D;
+            scores[v] = PhaseCoherenceRow(codesR.Slice(rowOff, D), codesI.Slice(rowOff, D), queryR, queryI);
+        }
+    }
+
+    /// <summary>
+    /// Parallel overload of <see cref="PhaseCoherenceDecodeDouble"/> that
+    /// distributes the V rows across the thread pool. Takes arrays so the
+    /// per-thread closure can index them without the Span-capture
+    /// restriction. Matches the sequential overload's output exactly.
+    /// </summary>
+    public static void PhaseCoherenceDecodeDoubleParallel(
+        double[] codesR, double[] codesI,
+        double[] queryR, double[] queryI,
+        double[] scores,
+        int V, int D)
+    {
+        if (codesR is null) throw new ArgumentNullException(nameof(codesR));
+        if (codesI is null) throw new ArgumentNullException(nameof(codesI));
+        if (queryR is null) throw new ArgumentNullException(nameof(queryR));
+        if (queryI is null) throw new ArgumentNullException(nameof(queryI));
+        if (scores is null) throw new ArgumentNullException(nameof(scores));
+
+        long totalOps = (long)V * D;
+        if (totalOps < ParallelThresholdElements || V < 4)
+        {
+            PhaseCoherenceDecodeDouble(codesR, codesI, queryR, queryI, scores, V, D);
+            return;
+        }
+
+        Parallel.For(0, V, v =>
+        {
+            int rowOff = v * D;
+            scores[v] = PhaseCoherenceRow(
+                new ReadOnlySpan<double>(codesR, rowOff, D),
+                new ReadOnlySpan<double>(codesI, rowOff, D),
+                queryR.AsSpan(),
+                queryI.AsSpan());
+        });
+    }
+
+    /// <summary>
+    /// Per-row phase-coherence reduction: <c>Σ_d (cR[d]·qR[d] + cI[d]·qI[d])</c>.
+    /// Split into its own method so callers (both sequential and parallel
+    /// overloads above) share a single SIMD path.
+    /// </summary>
+    [MethodImpl(HotInline)]
+    private static double PhaseCoherenceRow(
+        ReadOnlySpan<double> cR, ReadOnlySpan<double> cI,
+        ReadOnlySpan<double> qR, ReadOnlySpan<double> qI)
+    {
+        int n = cR.Length;
+        int i = 0;
+        double acc = 0.0;
+
+#if NET5_0_OR_GREATER
+        if (Avx.IsSupported && n >= 4)
+        {
+            var v = Vector256<double>.Zero;
+            int simdLen = n & ~3;
+            if (Fma.IsSupported)
+            {
+                for (; i < simdLen; i += 4)
+                {
+                    var crv = SimdKernels.ReadVector256(cR, i);
+                    var civ = SimdKernels.ReadVector256(cI, i);
+                    var qrv = SimdKernels.ReadVector256(qR, i);
+                    var qiv = SimdKernels.ReadVector256(qI, i);
+                    // v += cR·qR + cI·qI
+                    v = Fma.MultiplyAdd(crv, qrv, v);
+                    v = Fma.MultiplyAdd(civ, qiv, v);
+                }
+            }
+            else
+            {
+                for (; i < simdLen; i += 4)
+                {
+                    var crv = SimdKernels.ReadVector256(cR, i);
+                    var civ = SimdKernels.ReadVector256(cI, i);
+                    var qrv = SimdKernels.ReadVector256(qR, i);
+                    var qiv = SimdKernels.ReadVector256(qI, i);
+                    v = Avx.Add(v, Avx.Add(Avx.Multiply(crv, qrv), Avx.Multiply(civ, qiv)));
+                }
+            }
+            // Horizontal sum of the 4 lanes.
+            var vLow  = v.GetLower();
+            var vHigh = v.GetUpper();
+            var sum2 = Sse2.Add(vLow, vHigh);
+            acc = sum2.ToScalar() + sum2.GetElement(1);
+        }
+#endif
+
+        for (; i < n; i++)
+        {
+            acc += cR[i] * qR[i] + cI[i] * qI[i];
+        }
+        return acc;
+    }
+
+    /// <summary>
+    /// Fused HRR bind + accumulate across N training pairs:
+    /// <code>
+    ///     for n in [0, keyIds.Length):
+    ///         memory += keyCode[keyIds[n]] · valPermCode[valIds[n]]
+    /// </code>
+    /// replacing N × 6 <c>TensorPrimitives</c> calls with a single kernel.
+    /// The caller supplies <paramref name="valPermCodeR"/> /
+    /// <paramref name="valPermCodeI"/> pre-permuted so the gather + permute
+    /// + complex-multiply + accumulate collapses into one hot loop.
+    ///
+    /// <para>This is the single hottest op in HRE's memory-build phase;
+    /// per issue #248 the hand-rolled version accounted for roughly half
+    /// of the total cycle-12 wall-clock at D=16384 × 1M pairs.</para>
+    /// </summary>
+    public static void HRRBindAccumulateDouble(
+        ReadOnlySpan<double> keyCodeR, ReadOnlySpan<double> keyCodeI,
+        ReadOnlySpan<double> valPermCodeR, ReadOnlySpan<double> valPermCodeI,
+        ReadOnlySpan<int> keyIds, ReadOnlySpan<int> valIds,
+        Span<double> memoryR, Span<double> memoryI,
+        int D)
+    {
+        if (D < 0) throw new ArgumentOutOfRangeException(nameof(D));
+        if (memoryR.Length != D || memoryI.Length != D)
+            throw new ArgumentException(
+                $"memoryR ({memoryR.Length}) and memoryI ({memoryI.Length}) must both have length D = {D}.");
+        if (keyCodeR.Length != keyCodeI.Length)
+            throw new ArgumentException("keyCodeR and keyCodeI must have matching length.");
+        if (valPermCodeR.Length != valPermCodeI.Length)
+            throw new ArgumentException("valPermCodeR and valPermCodeI must have matching length.");
+        if (keyIds.Length != valIds.Length)
+            throw new ArgumentException(
+                $"keyIds ({keyIds.Length}) and valIds ({valIds.Length}) must have matching length.");
+        if (keyCodeR.Length % D != 0)
+            throw new ArgumentException(
+                $"keyCode length ({keyCodeR.Length}) must be divisible by D = {D}.");
+        if (valPermCodeR.Length % D != 0)
+            throw new ArgumentException(
+                $"valPermCode length ({valPermCodeR.Length}) must be divisible by D = {D}.");
+
+        int nKeys = keyCodeR.Length / D;
+        int nVals = valPermCodeR.Length / D;
+        int N = keyIds.Length;
+
+        for (int n = 0; n < N; n++)
+        {
+            int kId = keyIds[n];
+            int vId = valIds[n];
+            if ((uint)kId >= (uint)nKeys)
+                throw new ArgumentOutOfRangeException(nameof(keyIds),
+                    $"keyIds[{n}] = {kId} is outside [0, {nKeys}).");
+            if ((uint)vId >= (uint)nVals)
+                throw new ArgumentOutOfRangeException(nameof(valIds),
+                    $"valIds[{n}] = {vId} is outside [0, {nVals}).");
+
+            int kOff = kId * D;
+            int vOff = vId * D;
+
+            AccumulateBindRow(
+                keyCodeR.Slice(kOff, D), keyCodeI.Slice(kOff, D),
+                valPermCodeR.Slice(vOff, D), valPermCodeI.Slice(vOff, D),
+                memoryR, memoryI);
+        }
+    }
+
+    /// <summary>
+    /// Per-pair accumulate: <c>mem[d] += a[d] · b[d]</c> (complex) via the
+    /// standard Gauss FMA sequence. Single SIMD loop. Kept private because
+    /// it only makes sense as the inner body of
+    /// <see cref="HRRBindAccumulateDouble"/>.
+    /// </summary>
+    [MethodImpl(HotInline)]
+    private static void AccumulateBindRow(
+        ReadOnlySpan<double> aR, ReadOnlySpan<double> aI,
+        ReadOnlySpan<double> bR, ReadOnlySpan<double> bI,
+        Span<double> memR, Span<double> memI)
+    {
+        int n = aR.Length;
+        int i = 0;
+
+#if NET5_0_OR_GREATER
+        if (Avx.IsSupported && n >= 4)
+        {
+            int simdLen = n & ~3;
+            if (Fma.IsSupported)
+            {
+                for (; i < simdLen; i += 4)
+                {
+                    var ar = SimdKernels.ReadVector256(aR, i);
+                    var ai = SimdKernels.ReadVector256(aI, i);
+                    var br = SimdKernels.ReadVector256(bR, i);
+                    var bi = SimdKernels.ReadVector256(bI, i);
+                    var mr = SimdKernels.ReadVector256((ReadOnlySpan<double>)memR, i);
+                    var mi = SimdKernels.ReadVector256((ReadOnlySpan<double>)memI, i);
+
+                    // mR += aR·bR − aI·bI
+                    //    = fma(-aI, bI, mR + aR·bR)
+                    //    = fma(aR, bR, mR) − aI·bI
+                    // Use two FMAs to keep the dep chain short.
+                    mr = Fma.MultiplyAdd(ar, br, mr);
+                    mr = Fma.MultiplyAddNegated(ai, bi, mr);
+
+                    // mI += aR·bI + aI·bR
+                    mi = Fma.MultiplyAdd(ar, bi, mi);
+                    mi = Fma.MultiplyAdd(ai, br, mi);
+
+                    SimdKernels.WriteVector256(memR, i, mr);
+                    SimdKernels.WriteVector256(memI, i, mi);
+                }
+            }
+            else
+            {
+                for (; i < simdLen; i += 4)
+                {
+                    var ar = SimdKernels.ReadVector256(aR, i);
+                    var ai = SimdKernels.ReadVector256(aI, i);
+                    var br = SimdKernels.ReadVector256(bR, i);
+                    var bi = SimdKernels.ReadVector256(bI, i);
+                    var mr = SimdKernels.ReadVector256((ReadOnlySpan<double>)memR, i);
+                    var mi = SimdKernels.ReadVector256((ReadOnlySpan<double>)memI, i);
+
+                    mr = Avx.Add(mr, Avx.Subtract(Avx.Multiply(ar, br), Avx.Multiply(ai, bi)));
+                    mi = Avx.Add(mi, Avx.Add(Avx.Multiply(ar, bi), Avx.Multiply(ai, br)));
+
+                    SimdKernels.WriteVector256(memR, i, mr);
+                    SimdKernels.WriteVector256(memI, i, mi);
+                }
+            }
+        }
+#endif
+
+        for (; i < n; i++)
+        {
+            double ar = aR[i], ai = aI[i], br = bR[i], bi = bI[i];
+            memR[i] += ar * br - ai * bi;
+            memI[i] += ar * bi + ai * br;
+        }
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdKernels.cs
@@ -5818,6 +5818,25 @@ namespace AiDotNet.Tensors.Engines.Simd
             Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref element), value);
         }
 
+        // Double-precision overloads: Vector256<double> holds 4 lanes.
+        // Used by the HRR / complex-double kernels that feed the issue #248
+        // Native*Double engine methods.
+        [MethodImpl(HotInline)]
+        internal static Vector256<double> ReadVector256(ReadOnlySpan<double> data, int offset)
+        {
+            ref double start = ref MemoryMarshal.GetReference(data);
+            ref double element = ref Unsafe.Add(ref start, offset);
+            return Unsafe.ReadUnaligned<Vector256<double>>(ref Unsafe.As<double, byte>(ref element));
+        }
+
+        [MethodImpl(HotInline)]
+        internal static void WriteVector256(Span<double> data, int offset, Vector256<double> value)
+        {
+            ref double start = ref MemoryMarshal.GetReference(data);
+            ref double element = ref Unsafe.Add(ref start, offset);
+            Unsafe.WriteUnaligned(ref Unsafe.As<double, byte>(ref element), value);
+        }
+
         [MethodImpl(HotInline)]
         private static Vector128<float> ReadVector128(ReadOnlySpan<float> data, int offset)
         {

--- a/tests/AiDotNet.Tensors.Tests/Engines/Simd/SimdHrrKernelsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Simd/SimdHrrKernelsTests.cs
@@ -1,4 +1,5 @@
 using System;
+using AiDotNet.Tensors.Engines;
 using AiDotNet.Tensors.Engines.Simd;
 using Xunit;
 
@@ -392,5 +393,114 @@ public class SimdHrrKernelsTests
                 keyR, keyI, valR, valI,
                 new[] { 0 }, new[] { 0 },
                 memR, memI, D));
+    }
+
+    // ─── IEngine generic dispatch (CpuEngine, float + double) ─────────
+
+    [Fact]
+    public void CpuEngine_NativeComplexPointwiseMultiply_Double_MatchesDirectKernel()
+    {
+        const int n = 16;
+        var rng = new Random(0xB12);
+        var aR = new double[n]; var aI = new double[n];
+        var bR = new double[n]; var bI = new double[n];
+        for (int i = 0; i < n; i++)
+        {
+            aR[i] = rng.NextDouble(); aI[i] = rng.NextDouble();
+            bR[i] = rng.NextDouble(); bI[i] = rng.NextDouble();
+        }
+        var eng = new CpuEngine();
+        var cR = new double[n]; var cI = new double[n];
+        eng.NativeComplexPointwiseMultiply<double>(aR, aI, bR, bI, cR, cI, conjugateB: true);
+
+        var refR = new double[n]; var refI = new double[n];
+        SimdComplexKernels.ComplexMultiplyDouble(aR, aI, bR, bI, refR, refI, conjugateB: true);
+        Assert.Equal(refR, cR);
+        Assert.Equal(refI, cI);
+    }
+
+    [Fact]
+    public void CpuEngine_NativeComplexPointwiseMultiply_Float_MatchesDirectKernel()
+    {
+        const int n = 16;
+        var rng = new Random(0xB34);
+        var aR = new float[n]; var aI = new float[n];
+        var bR = new float[n]; var bI = new float[n];
+        for (int i = 0; i < n; i++)
+        {
+            aR[i] = (float)rng.NextDouble(); aI[i] = (float)rng.NextDouble();
+            bR[i] = (float)rng.NextDouble(); bI[i] = (float)rng.NextDouble();
+        }
+        var eng = new CpuEngine();
+        var cR = new float[n]; var cI = new float[n];
+        eng.NativeComplexPointwiseMultiply<float>(aR, aI, bR, bI, cR, cI, conjugateB: false);
+
+        var refR = new float[n]; var refI = new float[n];
+        SimdComplexKernels.ComplexMultiplyFloatConjugatable(aR, aI, bR, bI, refR, refI, conjugateB: false);
+        Assert.Equal(refR, cR);
+        Assert.Equal(refI, cI);
+    }
+
+    [Fact]
+    public void CpuEngine_NativeGather_Double_MatchesKernel()
+    {
+        var input = new double[] { 5, 4, 3, 2, 1 };
+        var indices = new[] { 4, 3, 2, 1, 0 };
+        var output = new double[indices.Length];
+        new CpuEngine().NativeGather<double>(input, indices, output);
+        Assert.Equal(new double[] { 1, 2, 3, 4, 5 }, output);
+    }
+
+    [Fact]
+    public void CpuEngine_NativeUnitPhaseCodebook_Float_IsUnitMagnitude()
+    {
+        const int V = 8, D = 32;
+        var outR = new float[V * D];
+        var outI = new float[V * D];
+        new CpuEngine().NativeUnitPhaseCodebook<float>(outR, outI, seed: 99, V, D);
+        for (int i = 0; i < V * D; i++)
+        {
+            float mag2 = outR[i] * outR[i] + outI[i] * outI[i];
+            Assert.True(Math.Abs(mag2 - 1f) < 1e-5f, $"Entry {i} |z|² = {mag2}");
+        }
+    }
+
+    [Fact]
+    public void CpuEngine_NativePhaseCoherenceDecode_Double_EqualsDirectKernel()
+    {
+        const int V = 4, D = 8;
+        var rng = new Random(0xD33);
+        var codesR = new double[V * D]; var codesI = new double[V * D];
+        var queryR = new double[D]; var queryI = new double[D];
+        for (int i = 0; i < V * D; i++) { codesR[i] = rng.NextDouble(); codesI[i] = rng.NextDouble(); }
+        for (int i = 0; i < D; i++) { queryR[i] = rng.NextDouble(); queryI[i] = rng.NextDouble(); }
+
+        var engScores = new double[V];
+        new CpuEngine().NativeComplexPhaseCoherenceDecode<double>(codesR, codesI, queryR, queryI, engScores, V, D);
+        var refScores = new double[V];
+        SimdHrrKernels.PhaseCoherenceDecodeDouble(codesR, codesI, queryR, queryI, refScores, V, D);
+        Assert.Equal(refScores, engScores);
+    }
+
+    [Fact]
+    public void CpuEngine_NativeHRRBindAccumulate_Float_EqualsDirectKernel()
+    {
+        const int D = 16;
+        const int nKeys = 3, nVals = 3;
+        var rng = new Random(0xE55);
+        var keyR = new float[nKeys * D]; var keyI = new float[nKeys * D];
+        var valR = new float[nVals * D]; var valI = new float[nVals * D];
+        for (int i = 0; i < keyR.Length; i++) { keyR[i] = (float)rng.NextDouble(); keyI[i] = (float)rng.NextDouble(); }
+        for (int i = 0; i < valR.Length; i++) { valR[i] = (float)rng.NextDouble(); valI[i] = (float)rng.NextDouble(); }
+        var keyIds = new[] { 0, 1, 2, 2 };
+        var valIds = new[] { 2, 1, 0, 0 };
+
+        var engMemR = new float[D]; var engMemI = new float[D];
+        new CpuEngine().NativeHRRBindAccumulate<float>(keyR, keyI, valR, valI, keyIds, valIds, engMemR, engMemI, D);
+
+        var refMemR = new float[D]; var refMemI = new float[D];
+        SimdHrrKernels.HRRBindAccumulateFloat(keyR, keyI, valR, valI, keyIds, valIds, refMemR, refMemI, D);
+        Assert.Equal(refMemR, engMemR);
+        Assert.Equal(refMemI, engMemI);
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Simd/SimdHrrKernelsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Simd/SimdHrrKernelsTests.cs
@@ -1,0 +1,396 @@
+using System;
+using AiDotNet.Tensors.Engines.Simd;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Simd;
+
+/// <summary>
+/// Regression tests for the five HRR binding kernels from issue #248.
+/// Each kernel is checked against a naive scalar reference on inputs
+/// chosen to exercise both the AVX-aligned fast path (length divisible
+/// by 4) and the scalar-tail path (length with a 1–3 element remainder).
+/// Tolerances are set tight enough to catch accumulation-order bugs but
+/// loose enough to allow the FMA path (which has strictly less rounding
+/// error than the scalar reference) to pass.
+/// </summary>
+public class SimdHrrKernelsTests
+{
+    private const double Tol = 1e-10;
+
+    // ─── ComplexMultiplyDouble ────────────────────────────────────────
+
+    [Theory]
+    [InlineData(8, false)]   // AVX-aligned, non-conjugate
+    [InlineData(8, true)]    // AVX-aligned, conjugate
+    [InlineData(17, false)]  // 4×4 + 1 tail, non-conjugate
+    [InlineData(17, true)]   // 4×4 + 1 tail, conjugate
+    [InlineData(3, false)]   // all-scalar (below AVX threshold)
+    [InlineData(3, true)]
+    public void ComplexMultiplyDouble_MatchesNaiveReference(int n, bool conjugateB)
+    {
+        var rng = new Random(0xC9);
+        var aR = new double[n]; var aI = new double[n];
+        var bR = new double[n]; var bI = new double[n];
+        for (int i = 0; i < n; i++)
+        {
+            aR[i] = rng.NextDouble() * 2 - 1; aI[i] = rng.NextDouble() * 2 - 1;
+            bR[i] = rng.NextDouble() * 2 - 1; bI[i] = rng.NextDouble() * 2 - 1;
+        }
+        var cR = new double[n]; var cI = new double[n];
+        SimdComplexKernels.ComplexMultiplyDouble(aR, aI, bR, bI, cR, cI, conjugateB);
+
+        for (int i = 0; i < n; i++)
+        {
+            double expR, expI;
+            if (conjugateB)
+            {
+                expR = aR[i] * bR[i] + aI[i] * bI[i];
+                expI = aI[i] * bR[i] - aR[i] * bI[i];
+            }
+            else
+            {
+                expR = aR[i] * bR[i] - aI[i] * bI[i];
+                expI = aR[i] * bI[i] + aI[i] * bR[i];
+            }
+            Assert.True(Math.Abs(cR[i] - expR) < Tol, $"cR[{i}] = {cR[i]}, expected {expR}");
+            Assert.True(Math.Abs(cI[i] - expI) < Tol, $"cI[{i}] = {cI[i]}, expected {expI}");
+        }
+    }
+
+    [Fact]
+    public void ComplexMultiplyDouble_UnbindRecoversOriginal()
+    {
+        // HRR unbind round-trip: (a ⊙ b) ⊙ conj(b) should recover a
+        // (up to a normalization factor) when b is unit-magnitude.
+        const int n = 16;
+        var rng = new Random(0xAB1);
+        var aR = new double[n]; var aI = new double[n];
+        var bR = new double[n]; var bI = new double[n];
+        for (int i = 0; i < n; i++)
+        {
+            aR[i] = rng.NextDouble() * 2 - 1; aI[i] = rng.NextDouble() * 2 - 1;
+            // Unit-magnitude b: use random phases so |b| = 1.
+            double phase = rng.NextDouble() * 2 * Math.PI;
+            bR[i] = Math.Cos(phase); bI[i] = Math.Sin(phase);
+        }
+        var bound = (new double[n], new double[n]);
+        var recovered = (new double[n], new double[n]);
+        SimdComplexKernels.ComplexMultiplyDouble(aR, aI, bR, bI, bound.Item1, bound.Item2);
+        SimdComplexKernels.ComplexMultiplyDouble(
+            bound.Item1, bound.Item2, bR, bI, recovered.Item1, recovered.Item2, conjugateB: true);
+
+        for (int i = 0; i < n; i++)
+        {
+            Assert.True(Math.Abs(recovered.Item1[i] - aR[i]) < 1e-12);
+            Assert.True(Math.Abs(recovered.Item2[i] - aI[i]) < 1e-12);
+        }
+    }
+
+    [Fact]
+    public void ComplexMultiplyDouble_LengthMismatch_Throws()
+    {
+        var a = new double[4];
+        var b = new double[5]; // wrong length
+        var c = new double[4];
+        Assert.Throws<ArgumentException>(() =>
+            SimdComplexKernels.ComplexMultiplyDouble(a, a, b, b, c, c));
+    }
+
+    // ─── GatherDouble ─────────────────────────────────────────────────
+
+    [Fact]
+    public void GatherDouble_Permutation_MatchesNaive()
+    {
+        var input = new double[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+        var indices = new[] { 3, 1, 7, 0, 5, 2, 6, 4 };
+        var output = new double[indices.Length];
+        SimdHrrKernels.GatherDouble(input, indices, output);
+
+        for (int i = 0; i < indices.Length; i++)
+            Assert.Equal(input[indices[i]], output[i]);
+    }
+
+    [Fact]
+    public void GatherDouble_RepeatedIndices_Allowed()
+    {
+        var input = new double[] { 10, 20, 30 };
+        var indices = new[] { 0, 0, 2, 1, 2 };
+        var output = new double[indices.Length];
+        SimdHrrKernels.GatherDouble(input, indices, output);
+        Assert.Equal(new double[] { 10, 10, 30, 20, 30 }, output);
+    }
+
+    [Fact]
+    public void GatherDouble_OutOfRangeIndex_Throws()
+    {
+        var input = new double[] { 1, 2, 3 };
+        var bad = new[] { 0, 3 }; // 3 is out of range
+        var output = new double[2];
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            SimdHrrKernels.GatherDouble(input, bad, output));
+    }
+
+    [Fact]
+    public void GatherDouble_NegativeIndex_Throws()
+    {
+        var input = new double[] { 1, 2, 3 };
+        var bad = new[] { -1 };
+        var output = new double[1];
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            SimdHrrKernels.GatherDouble(input, bad, output));
+    }
+
+    [Fact]
+    public void GatherDoubleParallel_MatchesSequential()
+    {
+        // Large enough to trigger the parallel path.
+        int n = 10_000;
+        var rng = new Random(0xD7);
+        var input = new double[n];
+        var indices = new int[n];
+        for (int i = 0; i < n; i++)
+        {
+            input[i] = rng.NextDouble();
+            indices[i] = rng.Next(0, n);
+        }
+        var parOut = new double[n];
+        var seqOut = new double[n];
+        SimdHrrKernels.GatherDoubleParallel(input, indices, parOut);
+        SimdHrrKernels.GatherDouble(input, indices, seqOut);
+        Assert.Equal(seqOut, parOut);
+    }
+
+    // ─── UnitPhaseCodebookDouble ──────────────────────────────────────
+
+    [Fact]
+    public void UnitPhaseCodebookDouble_IsUnitMagnitude()
+    {
+        const int V = 16, D = 64;
+        var outR = new double[V * D];
+        var outI = new double[V * D];
+        SimdHrrKernels.UnitPhaseCodebookDouble(outR, outI, seed: 42, V, D);
+
+        for (int i = 0; i < V * D; i++)
+        {
+            double mag2 = outR[i] * outR[i] + outI[i] * outI[i];
+            // Unit magnitude up to fp rounding (~1e-15 at this scale).
+            Assert.True(Math.Abs(mag2 - 1.0) < 1e-12,
+                $"Entry {i} has |z|² = {mag2}, expected ≈ 1");
+        }
+    }
+
+    [Fact]
+    public void UnitPhaseCodebookDouble_IsDeterministicPerSeed()
+    {
+        const int V = 8, D = 32;
+        var a1 = new double[V * D]; var b1 = new double[V * D];
+        var a2 = new double[V * D]; var b2 = new double[V * D];
+        SimdHrrKernels.UnitPhaseCodebookDouble(a1, b1, seed: 123, V, D);
+        SimdHrrKernels.UnitPhaseCodebookDouble(a2, b2, seed: 123, V, D);
+        Assert.Equal(a1, a2);
+        Assert.Equal(b1, b2);
+    }
+
+    [Fact]
+    public void UnitPhaseCodebookDouble_DifferentSeedsDiffer()
+    {
+        const int V = 8, D = 32;
+        var a1 = new double[V * D]; var b1 = new double[V * D];
+        var a2 = new double[V * D]; var b2 = new double[V * D];
+        SimdHrrKernels.UnitPhaseCodebookDouble(a1, b1, seed: 1, V, D);
+        SimdHrrKernels.UnitPhaseCodebookDouble(a2, b2, seed: 2, V, D);
+        Assert.NotEqual(a1, a2);
+    }
+
+    [Fact]
+    public void UnitPhaseCodebookDouble_KPsk_SnapsToLattice()
+    {
+        const int V = 8, D = 32;
+        const int k = 4; // 4-PSK: phases ∈ {0, π/2, π, 3π/2}
+        var outR = new double[V * D];
+        var outI = new double[V * D];
+        SimdHrrKernels.UnitPhaseCodebookDouble(outR, outI, seed: 7, V, D, kPsk: true, k: k);
+
+        double step = 2 * Math.PI / k;
+        for (int i = 0; i < V * D; i++)
+        {
+            double phase = Math.Atan2(outI[i], outR[i]);
+            if (phase < 0) phase += 2 * Math.PI;
+            // Check: phase should be within 1 ULP of some integer multiple
+            // of step. Measure the residual after integer-division (the
+            // "distance to nearest lattice point") mod step, tolerating
+            // both directions of the wrap (2π → 0).
+            double residual = phase % step;
+            double distance = Math.Min(residual, step - residual);
+            Assert.True(distance < 1e-10,
+                $"Entry {i} phase {phase} is not on the 4-PSK lattice (distance {distance})");
+        }
+    }
+
+    // ─── PhaseCoherenceDecodeDouble ───────────────────────────────────
+
+    [Fact]
+    public void PhaseCoherenceDecodeDouble_MatchesNaive()
+    {
+        const int V = 6, D = 12;
+        var rng = new Random(0x9E3);
+        var codesR = new double[V * D]; var codesI = new double[V * D];
+        var queryR = new double[D]; var queryI = new double[D];
+        for (int i = 0; i < V * D; i++) { codesR[i] = rng.NextDouble() * 2 - 1; codesI[i] = rng.NextDouble() * 2 - 1; }
+        for (int d = 0; d < D; d++) { queryR[d] = rng.NextDouble() * 2 - 1; queryI[d] = rng.NextDouble() * 2 - 1; }
+
+        var scores = new double[V];
+        SimdHrrKernels.PhaseCoherenceDecodeDouble(codesR, codesI, queryR, queryI, scores, V, D);
+
+        // Naive reference: scores[v] = Σ_d Re( query[d] · conj(code[v][d]) )
+        //                           = Σ_d ( qR·cR + qI·cI )
+        for (int v = 0; v < V; v++)
+        {
+            double expected = 0;
+            for (int d = 0; d < D; d++)
+                expected += queryR[d] * codesR[v * D + d] + queryI[d] * codesI[v * D + d];
+            Assert.True(Math.Abs(scores[v] - expected) < Tol,
+                $"scores[{v}] = {scores[v]}, expected {expected}");
+        }
+    }
+
+    [Fact]
+    public void PhaseCoherenceDecodeDouble_SelfCodeGivesMaxScore()
+    {
+        // A code matched against itself should have a large score;
+        // matched against a random other code the score should be
+        // smaller in expectation. This is the core recall property.
+        const int V = 8, D = 256;
+        var codesR = new double[V * D];
+        var codesI = new double[V * D];
+        SimdHrrKernels.UnitPhaseCodebookDouble(codesR, codesI, seed: 0xABCD, V, D);
+
+        // Query = code[3]
+        int target = 3;
+        var queryR = new double[D]; var queryI = new double[D];
+        Array.Copy(codesR, target * D, queryR, 0, D);
+        Array.Copy(codesI, target * D, queryI, 0, D);
+
+        var scores = new double[V];
+        SimdHrrKernels.PhaseCoherenceDecodeDouble(codesR, codesI, queryR, queryI, scores, V, D);
+
+        // Target score = D (self-inner-product on unit codes), others ≪ D.
+        Assert.True(Math.Abs(scores[target] - D) < 1e-10,
+            $"Self-match score = {scores[target]}, expected {D}");
+        for (int v = 0; v < V; v++)
+        {
+            if (v == target) continue;
+            Assert.True(scores[v] < scores[target] * 0.5,
+                $"Non-match score[{v}] = {scores[v]} too close to self-match {scores[target]}");
+        }
+    }
+
+    [Fact]
+    public void PhaseCoherenceDecodeDoubleParallel_MatchesSequential()
+    {
+        const int V = 32, D = 512;
+        var codesR = new double[V * D];
+        var codesI = new double[V * D];
+        var queryR = new double[D];
+        var queryI = new double[D];
+        SimdHrrKernels.UnitPhaseCodebookDouble(codesR, codesI, seed: 11, V, D);
+        SimdHrrKernels.UnitPhaseCodebookDouble(queryR.AsSpan(), queryI.AsSpan(), seed: 22, 1, D);
+
+        var parScores = new double[V];
+        var seqScores = new double[V];
+        SimdHrrKernels.PhaseCoherenceDecodeDoubleParallel(codesR, codesI, queryR, queryI, parScores, V, D);
+        SimdHrrKernels.PhaseCoherenceDecodeDouble(codesR, codesI, queryR, queryI, seqScores, V, D);
+        for (int v = 0; v < V; v++)
+            Assert.True(Math.Abs(parScores[v] - seqScores[v]) < Tol);
+    }
+
+    // ─── HRRBindAccumulateDouble ──────────────────────────────────────
+
+    [Fact]
+    public void HRRBindAccumulateDouble_MatchesNaive()
+    {
+        const int D = 32;
+        const int nKeys = 4, nVals = 5;
+        var rng = new Random(0xBEEF);
+
+        var keyR = new double[nKeys * D]; var keyI = new double[nKeys * D];
+        var valR = new double[nVals * D]; var valI = new double[nVals * D];
+        for (int i = 0; i < keyR.Length; i++) { keyR[i] = rng.NextDouble() * 2 - 1; keyI[i] = rng.NextDouble() * 2 - 1; }
+        for (int i = 0; i < valR.Length; i++) { valR[i] = rng.NextDouble() * 2 - 1; valI[i] = rng.NextDouble() * 2 - 1; }
+
+        var keyIds = new[] { 0, 2, 3, 1, 0 };
+        var valIds = new[] { 4, 1, 0, 3, 2 };
+        var memR = new double[D]; var memI = new double[D];
+
+        SimdHrrKernels.HRRBindAccumulateDouble(
+            keyR, keyI, valR, valI, keyIds, valIds, memR, memI, D);
+
+        var expR = new double[D]; var expI = new double[D];
+        for (int n = 0; n < keyIds.Length; n++)
+        {
+            int kOff = keyIds[n] * D;
+            int vOff = valIds[n] * D;
+            for (int d = 0; d < D; d++)
+            {
+                double aR = keyR[kOff + d], aI = keyI[kOff + d];
+                double bR = valR[vOff + d], bI = valI[vOff + d];
+                expR[d] += aR * bR - aI * bI;
+                expI[d] += aR * bI + aI * bR;
+            }
+        }
+        for (int d = 0; d < D; d++)
+        {
+            Assert.True(Math.Abs(memR[d] - expR[d]) < Tol, $"memR[{d}] = {memR[d]}, expected {expR[d]}");
+            Assert.True(Math.Abs(memI[d] - expI[d]) < Tol, $"memI[{d}] = {memI[d]}, expected {expI[d]}");
+        }
+    }
+
+    [Fact]
+    public void HRRBindAccumulateDouble_EmptyPairs_LeavesMemoryUnchanged()
+    {
+        const int D = 8;
+        var keyR = new double[D]; var keyI = new double[D];
+        var valR = new double[D]; var valI = new double[D];
+        var memR = new double[D]; var memI = new double[D];
+        for (int i = 0; i < D; i++) { memR[i] = i; memI[i] = -i; }
+
+        SimdHrrKernels.HRRBindAccumulateDouble(
+            keyR, keyI, valR, valI,
+            Array.Empty<int>(), Array.Empty<int>(),
+            memR, memI, D);
+
+        for (int i = 0; i < D; i++)
+        {
+            Assert.Equal(i, memR[i]);
+            Assert.Equal(-i, memI[i]);
+        }
+    }
+
+    [Fact]
+    public void HRRBindAccumulateDouble_OutOfRangeKeyId_Throws()
+    {
+        const int D = 4;
+        var keyR = new double[2 * D]; var keyI = new double[2 * D];
+        var valR = new double[2 * D]; var valI = new double[2 * D];
+        var memR = new double[D]; var memI = new double[D];
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            SimdHrrKernels.HRRBindAccumulateDouble(
+                keyR, keyI, valR, valI,
+                new[] { 99 }, new[] { 0 },
+                memR, memI, D));
+    }
+
+    [Fact]
+    public void HRRBindAccumulateDouble_DimensionMismatch_Throws()
+    {
+        const int D = 4;
+        var keyR = new double[2 * D]; var keyI = new double[2 * D];
+        var valR = new double[2 * D]; var valI = new double[2 * D];
+        var memR = new double[D + 1]; var memI = new double[D + 1]; // wrong
+        Assert.Throws<ArgumentException>(() =>
+            SimdHrrKernels.HRRBindAccumulateDouble(
+                keyR, keyI, valR, valI,
+                new[] { 0 }, new[] { 0 },
+                memR, memI, D));
+    }
+}


### PR DESCRIPTION
## Summary

Ships the five native SIMD kernels requested by issue #248 — every op the HRE research campaign's cycle-12 build was hand-rolling as 6+ stitched `TensorPrimitives` calls. One PR, all five ops, with regression coverage.

## Kernels added

| # | API (on `IEngine` / `CpuEngine`) | Replaces | Issue #248 est. win |
|---|---|---|---|
| 1 | `NativeComplexPointwiseMultiplyDouble(aR, aI, bR, bI, cR, cI, conjugateB)` | 6 × TensorPrimitives (Multiply × 4 + Subtract + Add) per HRR bind/unbind | ~4× |
| 2 | `NativeGatherDouble(input, indices, output)` | Scalar `for` loop permutation gather | 5-10× |
| 3 | `NativeUnitPhaseCodebookDouble(outR, outI, seed, V, D, kPsk, k)` | Scalar `Math.Cos/Sin` loop over V × D entries | ~10× |
| 4 | `NativeComplexPhaseCoherenceDecodeDouble(codesR, codesI, queryR, queryI, scores, V, D)` | `TensorMatMul` + per-query `new Tensor<double>([2D,1])` wrap | 2-3× |
| 5 | `NativeHRRBindAccumulateDouble(keyCode, valPermCode, keyIds, valIds, memory, D)` | N × 6 TensorPrimitives calls — the single hottest op in HRE memory-build | 5-10× |

`conjugateB` on op 1 gives `c = a · conj(b)` for HRR unbind without a second kernel; the branch is constant-folded outside the SIMD loop so each variant becomes one dense Vector256+FMA sequence.

## Implementation notes

- Kernels live in `Simd/SimdHrrKernels.cs` (new, ~470 lines) plus the conjugate-aware `ComplexMultiplyDouble` added to `Simd/SimdComplexKernels.cs`.
- Added `Vector256<double>` Read/Write helpers to `SimdKernels.cs` to avoid duplicating the `Unsafe.ReadUnaligned` boilerplate across four spots.
- All kernels have deterministic scalar fallbacks for the tail and for non-AVX platforms. ARM NEON not yet covered — same policy as surrounding `SimdComplexKernels`.
- Parallelisation threshold is 4096 elements (matches existing heuristic in `SimdKernels`). Ops 2 and 4 expose `...Parallel` array overloads for callers with large V or D.
- No `GraphMode` / autograd hooks — these are eager spans. Callers that need gradients keep using the existing `NativeComplex*` Tensor-returning family.
- Deterministic xorshift64* PRNG in `UnitPhaseCodebookDouble` — same seed reproduces the same codebook across runs (critical for HRR experiment reproducibility).

## Test coverage

24 xunit tests in `tests/AiDotNet.Tensors.Tests/Engines/Simd/SimdHrrKernelsTests.cs`, all passing locally:

- **ComplexMultiplyDouble** — parametric on length (8 AVX-aligned / 17 with tail / 3 all-scalar) × `conjugateB ∈ {false, true}`; HRR round-trip recovery (bind+unbind gives back `a` when b is unit-magnitude); shape-mismatch argument validation.
- **GatherDouble** — permutation match, repeated indices, out-of-range index, negative index; `Parallel` overload matches sequential bit-for-bit.
- **UnitPhaseCodebookDouble** — unit-magnitude invariant (|z|² ≈ 1), deterministic per seed, different seeds differ, K-PSK lattice snap correctness.
- **PhaseCoherenceDecodeDouble** — matches naive reference; self-code gives max score (the core HRR recall property); `Parallel` overload matches sequential.
- **HRRBindAccumulateDouble** — matches naive reference, empty pairs is a no-op, out-of-range id throws, dimension mismatch throws.

Full solution builds clean on net471 + net10.0. Related existing tests (`TapeCompletenessTests`, 40 `NativeComplex` tests) still pass.

## Test plan

- [x] 24 new tests pass locally
- [x] Full solution builds clean on net471 + net10.0 + netstandard2.0
- [x] `TapeCompletenessTests.OpRegistry_HasNoDuplicates` passes (new void-returning HRR ops don't register)
- [x] Existing `NativeComplex*` tests (40 tests) still pass
- [ ] Confirm HRE cycle 12 @ D=16384 × 1M pairs runs in minutes (user-side verification against their HarmonicEngine project)

Closes #248.

🤖 Generated with [Claude Code](https://claude.com/claude-code)