### PR TITLE
feat(licensing): tensor-layer PersistenceGuard with capability-scoped license validation

### DIFF
--- a/src/AiDotNet.Tensors/Licensing/AiDotNetTensorsLicenseKey.cs
+++ b/src/AiDotNet.Tensors/Licensing/AiDotNetTensorsLicenseKey.cs
@@ -1,0 +1,91 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+namespace AiDotNet.Tensors.Licensing;
+
+/// <summary>
+/// Represents a license key for AiDotNet.Tensors persistence operations
+/// (safetensors / GGUF / pickle / sharded checkpoint readers and writers).
+/// The same key string used by the upstream <c>AiDotNet</c> package works
+/// here — the licensing server returns a per-key set of capabilities and
+/// the tensor layer accepts the key when those capabilities include
+/// <c>tensors:save</c> or <c>tensors:load</c>.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> When you purchase a license for AiDotNet you
+/// receive one key string. That same string activates persistence in
+/// every package that reads/writes model data — the tensor library
+/// (this package) and the upstream model library both consult the same
+/// licensing server. Buying the "Tensors-only" tier still produces a
+/// key that works here; buying "Pro" or "Enterprise" produces a key
+/// that works here AND in upstream <c>AiDotNet</c>.</para>
+///
+/// <para><b>Default server:</b> the validation endpoint defaults to the
+/// shared AiDotNet license server. Override
+/// <see cref="ServerUrl"/> only when running an offline-only validation
+/// against a self-signed key.</para>
+///
+/// <para>This type intentionally has the same shape as the upstream
+/// <c>AiDotNet.Models.AiDotNetLicenseKey</c> so the upstream
+/// <c>AiModelBuilder</c> can copy fields field-by-field and flow a
+/// single user-provided key into both layers without round-tripping
+/// through serialization.</para>
+/// </remarks>
+public sealed class AiDotNetTensorsLicenseKey
+{
+    /// <summary>
+    /// Gets the license key string (e.g., <c>aidn.{id}.{secret}</c> for
+    /// signed offline-eligible keys, or <c>AIDN-*-{hex}</c> for
+    /// server-validated community/CI keys).
+    /// </summary>
+    public string Key { get; }
+
+    /// <summary>
+    /// Gets or sets the URL of the license validation server.
+    /// <para>
+    /// <list type="bullet">
+    /// <item><c>null</c> (default) — uses the built-in AiDotNet license
+    /// server.</item>
+    /// <item>Empty string — explicit offline-only mode; only signed
+    /// <c>aidn.{id}.{sig}</c> keys are accepted.</item>
+    /// <item>Custom URL — point at a self-hosted validation endpoint
+    /// implementing the same Edge-Function contract.</item>
+    /// </list>
+    /// </para>
+    /// </summary>
+    public string? ServerUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets the environment label sent during validation
+    /// (e.g., <c>production</c>, <c>staging</c>, <c>development</c>).
+    /// </summary>
+    public string? Environment { get; set; }
+
+    /// <summary>
+    /// Gets or sets the duration that a cached validation result is
+    /// trusted when the server is unreachable. Defaults to 7 days.
+    /// </summary>
+    public TimeSpan OfflineGracePeriod { get; set; } = TimeSpan.FromDays(7);
+
+    /// <summary>
+    /// Gets or sets whether advisory machine-ID telemetry is sent to
+    /// the license server during validation. Defaults to <c>true</c>.
+    /// </summary>
+    public bool EnableTelemetry { get; set; } = true;
+
+    /// <summary>
+    /// Creates a new license key with the supplied string.
+    /// </summary>
+    /// <param name="key">The license key string. Must not be null,
+    /// empty, or whitespace.</param>
+    /// <exception cref="ArgumentNullException">Thrown when
+    /// <paramref name="key"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when
+    /// <paramref name="key"/> is empty or whitespace.</exception>
+    public AiDotNetTensorsLicenseKey(string key)
+    {
+        if (key is null) throw new ArgumentNullException(nameof(key));
+        if (string.IsNullOrWhiteSpace(key))
+            throw new ArgumentException("License key must not be empty or whitespace.", nameof(key));
+        Key = key;
+    }
+}

--- a/src/AiDotNet.Tensors/Licensing/LicenseKeyStatus.cs
+++ b/src/AiDotNet.Tensors/Licensing/LicenseKeyStatus.cs
@@ -1,0 +1,43 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+namespace AiDotNet.Tensors.Licensing;
+
+/// <summary>
+/// Outcome of validating an <see cref="AiDotNetTensorsLicenseKey"/>.
+/// Mirrors the upstream <c>AiDotNet.Enums.LicenseKeyStatus</c> enum so
+/// a result returned by either layer's validator carries a stable
+/// meaning across the package boundary.
+/// </summary>
+public enum LicenseKeyStatus
+{
+    /// <summary>The key is valid and active.</summary>
+    Active,
+
+    /// <summary>The key has expired.</summary>
+    Expired,
+
+    /// <summary>The key has been revoked by an administrator.</summary>
+    Revoked,
+
+    /// <summary>The key has reached its activation/seat limit.</summary>
+    SeatLimitReached,
+
+    /// <summary>
+    /// The key string is malformed or unknown to the validation server.
+    /// </summary>
+    Invalid,
+
+    /// <summary>
+    /// The server was unreachable; the validator is operating against a
+    /// cached result inside its offline grace window.
+    /// </summary>
+    ValidationPending,
+
+    /// <summary>
+    /// The key authenticates but does not include the capability the
+    /// caller asked for. E.g. a tier that grants <c>model:save</c>
+    /// won't satisfy a <c>tensors:save</c> request unless its tier
+    /// also includes the tensors capability set.
+    /// </summary>
+    CapabilityMissing,
+}

--- a/src/AiDotNet.Tensors/Licensing/LicenseRequiredException.cs
+++ b/src/AiDotNet.Tensors/Licensing/LicenseRequiredException.cs
@@ -1,0 +1,84 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+namespace AiDotNet.Tensors.Licensing;
+
+/// <summary>
+/// Thrown when a tensor-layer persistence operation (save / load /
+/// serialize / deserialize) is attempted without an active license
+/// covering the operation, and the free-trial budget has been
+/// exhausted.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Training and inference are never gated — only persistence I/O is.
+/// Use one of the following to resolve:
+/// <list type="bullet">
+///   <item><description>Set the license key via environment variable
+///   <c>AIDOTNET_LICENSE_KEY=your-key</c> (the same variable upstream
+///   <c>AiDotNet</c> reads — one key, both packages).</description></item>
+///   <item><description>Save the key to <c>~/.aidotnet/license.key</c>.</description></item>
+///   <item><description>Pass a key to
+///   <see cref="PersistenceGuard.SetActiveLicenseKey"/> at startup.</description></item>
+/// </list>
+/// </para>
+/// </remarks>
+public sealed class LicenseRequiredException : Exception
+{
+    /// <summary>
+    /// Days the trial was active before the cap fired, or <c>null</c>
+    /// when expiration was driven by operation-count rather than time.
+    /// </summary>
+    public int? TrialDaysElapsed { get; }
+
+    /// <summary>
+    /// Number of save+load operations performed during the trial, or
+    /// <c>null</c> when expiration was driven by elapsed time.
+    /// </summary>
+    public int? OperationsPerformed { get; }
+
+    /// <summary>
+    /// Reason a license was required at the call site — surfaces the
+    /// server's validation status for diagnostic purposes.
+    /// </summary>
+    public LicenseKeyStatus? KeyStatus { get; }
+
+    /// <summary>
+    /// The capability the operation needed (e.g. <c>tensors:save</c>),
+    /// when the failure mode is <see cref="LicenseKeyStatus.CapabilityMissing"/>.
+    /// </summary>
+    public string? RequiredCapability { get; }
+
+    /// <summary>Creates an exception with a default message.</summary>
+    public LicenseRequiredException()
+        : base(DefaultMessage)
+    { }
+
+    /// <summary>Creates an exception with a custom message.</summary>
+    public LicenseRequiredException(string message) : base(message) { }
+
+    /// <summary>Creates an exception with a message and inner exception.</summary>
+    public LicenseRequiredException(string message, Exception inner) : base(message, inner) { }
+
+    /// <summary>
+    /// Creates a fully-specified exception. Used by
+    /// <see cref="PersistenceGuard"/> so callers can switch on the
+    /// individual properties to render a tailored message.
+    /// </summary>
+    public LicenseRequiredException(
+        string message,
+        int? trialDaysElapsed,
+        int? operationsPerformed,
+        LicenseKeyStatus? keyStatus,
+        string? requiredCapability) : base(message)
+    {
+        TrialDaysElapsed = trialDaysElapsed;
+        OperationsPerformed = operationsPerformed;
+        KeyStatus = keyStatus;
+        RequiredCapability = requiredCapability;
+    }
+
+    private const string DefaultMessage =
+        "AiDotNet.Tensors persistence operations require a license. The free trial has expired or no license is configured. " +
+        "Set AIDOTNET_LICENSE_KEY, save your key to ~/.aidotnet/license.key, or call " +
+        "PersistenceGuard.SetActiveLicenseKey at startup. See https://aidotnet.dev/license for details.";
+}

--- a/src/AiDotNet.Tensors/Licensing/LicenseValidationResult.cs
+++ b/src/AiDotNet.Tensors/Licensing/LicenseValidationResult.cs
@@ -1,0 +1,94 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System.Collections.Generic;
+
+namespace AiDotNet.Tensors.Licensing;
+
+/// <summary>
+/// Result of a single <see cref="LicenseValidator.Validate"/> call.
+/// Mirrors the upstream <c>AiDotNet.Models.LicenseValidationResult</c>
+/// shape, with one extension — a server-returned set of
+/// <see cref="Capabilities"/> strings used by
+/// <see cref="PersistenceGuard"/> to decide whether the key is
+/// authorised for the specific operation being attempted.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The capability convention is namespace-prefixed strings — e.g.
+/// <c>tensors:save</c>, <c>tensors:load</c>, <c>model:save</c>,
+/// <c>model:load</c>. The validation server attaches the set
+/// corresponding to the purchased tier; a missing capability surfaces
+/// as <see cref="LicenseKeyStatus.CapabilityMissing"/> rather than
+/// as a generic <see cref="LicenseKeyStatus.Invalid"/>, so the user
+/// gets a clear "your tier doesn't include this operation" error
+/// instead of the misleading "key invalid".
+/// </para>
+/// </remarks>
+public sealed class LicenseValidationResult
+{
+    /// <summary>The validation status of the license key.</summary>
+    public LicenseKeyStatus Status { get; }
+
+    /// <summary>
+    /// The subscription tier associated with this key (e.g.
+    /// <c>tensors-only</c>, <c>community</c>, <c>pro</c>,
+    /// <c>enterprise</c>), or <c>null</c> if unknown.
+    /// </summary>
+    public string? Tier { get; }
+
+    /// <summary>The expiry of this license, or <c>null</c> if perpetual.</summary>
+    public DateTimeOffset? ExpiresAt { get; }
+
+    /// <summary>UTC timestamp this validation completed.</summary>
+    public DateTimeOffset ValidatedAt { get; }
+
+    /// <summary>An optional human-readable message from the server.</summary>
+    public string? Message { get; }
+
+    /// <summary>
+    /// Set of capability strings this key authorises. The
+    /// <see cref="PersistenceGuard"/> compares the operation it's about
+    /// to authorise (e.g. <c>tensors:save</c>) against this set; if the
+    /// capability is missing, <see cref="HasCapability"/> returns
+    /// <c>false</c> and the guard throws.
+    /// </summary>
+    /// <remarks>
+    /// Typed as <see cref="IReadOnlyCollection{T}"/> rather than
+    /// <c>IReadOnlySet&lt;string&gt;</c> for net471 compatibility — the
+    /// latter type is only available on .NET 6+. Membership is checked
+    /// through <see cref="HasCapability"/>, which uses the underlying
+    /// hash set so lookup stays O(1).
+    /// </remarks>
+    public IReadOnlyCollection<string> Capabilities => _capabilities;
+
+    private readonly HashSet<string> _capabilities;
+
+    /// <summary>
+    /// True iff <paramref name="capability"/> is present in
+    /// <see cref="Capabilities"/>. Comparison is ordinal
+    /// case-sensitive — capability strings are server-defined and
+    /// must round-trip exactly.
+    /// </summary>
+    public bool HasCapability(string capability) => _capabilities.Contains(capability);
+
+    /// <summary>
+    /// Creates a new validation result.
+    /// </summary>
+    public LicenseValidationResult(
+        LicenseKeyStatus status,
+        string? tier,
+        DateTimeOffset? expiresAt,
+        DateTimeOffset validatedAt,
+        string? message,
+        IEnumerable<string>? capabilities)
+    {
+        Status = status;
+        Tier = tier;
+        ExpiresAt = expiresAt;
+        ValidatedAt = validatedAt;
+        Message = message;
+        _capabilities = capabilities is null
+            ? new HashSet<string>(StringComparer.Ordinal)
+            : new HashSet<string>(capabilities, StringComparer.Ordinal);
+    }
+}

--- a/src/AiDotNet.Tensors/Licensing/LicenseValidator.cs
+++ b/src/AiDotNet.Tensors/Licensing/LicenseValidator.cs
@@ -196,7 +196,20 @@ public sealed class LicenseValidator
             return false;
         for (int i = 0; i < parts[1].Length; i++)
             if (!char.IsLetterOrDigit(parts[1][i])) return false;
-        // Signature is base64url — accept '+', '/', '-', '_', '=' too.
+        // Signature is base64url — letters, digits, plus the URL-safe
+        // sigil set ('-', '_') and the legacy non-URL-safe ('+', '/')
+        // pair, plus any '=' padding chars at the end. Reject anything
+        // outside that set so a malformed key fails offline rather than
+        // round-tripping to the server.
+        for (int i = 0; i < parts[2].Length; i++)
+        {
+            char c = parts[2][i];
+            bool ok = char.IsLetterOrDigit(c)
+                   || c == '-' || c == '_'
+                   || c == '+' || c == '/'
+                   || c == '=';
+            if (!ok) return false;
+        }
         return true;
     }
 

--- a/src/AiDotNet.Tensors/Licensing/LicenseValidator.cs
+++ b/src/AiDotNet.Tensors/Licensing/LicenseValidator.cs
@@ -1,0 +1,350 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+#if !NET471
+using System.Net.Http;
+#endif
+
+namespace AiDotNet.Tensors.Licensing;
+
+/// <summary>
+/// Tensor-layer license validator. Hits the same Supabase Edge Function
+/// the upstream <c>AiDotNet</c> validator uses, sends a
+/// <c>package=AiDotNet.Tensors</c> hint so the server attaches the
+/// right per-tier capability set, and caches the result with an
+/// offline grace window.
+/// </summary>
+/// <remarks>
+/// <para><b>Why a validator in the tensor layer:</b></para>
+/// <para>
+/// The user explicitly asked for the tensor layer to participate in
+/// license enforcement so reading a <c>.gguf</c> / <c>.safetensors</c>
+/// file via the public API requires a valid license. The same key
+/// works in upstream <c>AiDotNet</c> — both layers hit the same server
+/// — but the tensor layer can also stand alone for users who only
+/// pull the <c>AiDotNet.Tensors</c> NuGet.
+/// </para>
+/// <para><b>What this validator does NOT do (delegated to upstream):</b></para>
+/// <list type="bullet">
+///   <item><description>Offline HMAC verification against an embedded
+///   build key. The tensor layer doesn't ship a build secret —
+///   offline-only validation always returns
+///   <see cref="LicenseKeyStatus.ValidationPending"/> until the server
+///   is reachable, then caches per <c>OfflineGracePeriod</c>.</description></item>
+///   <item><description>Trial-counter management. That lives in
+///   <see cref="TrialState"/> and is consulted by
+///   <see cref="PersistenceGuard"/> when no key is configured.</description></item>
+/// </list>
+/// </remarks>
+public sealed class LicenseValidator
+{
+    /// <summary>
+    /// Default endpoint — same Supabase Edge Function the upstream
+    /// validator uses so a single key works in both packages.
+    /// </summary>
+    public const string DefaultServerUrl =
+        "https://yfkqwpgjahoamlgckjib.supabase.co/functions/v1/validate-license";
+
+    private readonly AiDotNetTensorsLicenseKey _licenseKey;
+    private LicenseValidationResult? _cached;
+    private readonly object _cacheLock = new();
+
+#if !NET471
+    private static readonly HttpClient SharedHttpClient = new()
+    {
+        Timeout = TimeSpan.FromSeconds(15)
+    };
+#endif
+
+    /// <summary>The most recent cached validation result, or null.</summary>
+    public LicenseValidationResult? CachedResult
+    {
+        get { lock (_cacheLock) return _cached; }
+    }
+
+    /// <summary>Creates a validator for the given key.</summary>
+    public LicenseValidator(AiDotNetTensorsLicenseKey licenseKey)
+    {
+        _licenseKey = licenseKey ?? throw new ArgumentNullException(nameof(licenseKey));
+    }
+
+    /// <summary>
+    /// Validates the configured license key. Uses the shared default
+    /// server unless <see cref="AiDotNetTensorsLicenseKey.ServerUrl"/>
+    /// is set. Caches the result for the configured offline grace
+    /// window so subsequent calls don't re-hit the network.
+    /// </summary>
+    public LicenseValidationResult Validate()
+    {
+        if (string.IsNullOrWhiteSpace(_licenseKey.Key))
+        {
+            return Cache(new LicenseValidationResult(
+                LicenseKeyStatus.Invalid,
+                tier: null, expiresAt: null, validatedAt: DateTimeOffset.UtcNow,
+                message: "License key is empty.",
+                capabilities: null));
+        }
+
+        if (!ValidateKeyFormat(_licenseKey.Key))
+        {
+            return Cache(new LicenseValidationResult(
+                LicenseKeyStatus.Invalid,
+                tier: null, expiresAt: null, validatedAt: DateTimeOffset.UtcNow,
+                message: "License key format is invalid. Expected aidn.{id}.{signature} or AIDN-*-{hex}.",
+                capabilities: null));
+        }
+
+        // Explicit offline-only mode (ServerUrl == "")
+        bool explicitOfflineOnly =
+            _licenseKey.ServerUrl is not null && _licenseKey.ServerUrl.Trim().Length == 0;
+
+        if (explicitOfflineOnly)
+        {
+            // No build key in the tensor layer → can't HMAC-verify
+            // signed keys offline. Surface as ValidationPending so the
+            // guard can decide based on its own policy (today: deny).
+            return Cache(new LicenseValidationResult(
+                LicenseKeyStatus.ValidationPending,
+                tier: null, expiresAt: null, validatedAt: DateTimeOffset.UtcNow,
+                message: "Tensor-layer offline-only mode is not supported (no embedded build key). " +
+                         "Allow online validation or use upstream AiDotNet for offline verification.",
+                capabilities: null));
+        }
+
+        // Cache hit within grace window — return without hitting the network.
+        lock (_cacheLock)
+        {
+            if (_cached is not null
+                && _cached.Status == LicenseKeyStatus.Active
+                && _cached.ValidatedAt + _licenseKey.OfflineGracePeriod > DateTimeOffset.UtcNow)
+            {
+                return _cached;
+            }
+        }
+
+        try
+        {
+            var result = ValidateOnline();
+            return Cache(result);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceWarning(
+                "AiDotNet.Tensors LicenseValidator: online validation failed: "
+                + ex.GetType().Name + ": " + ex.Message);
+
+            // Fall back to cached result if still in grace.
+            lock (_cacheLock)
+            {
+                if (_cached is not null
+                    && _cached.ValidatedAt + _licenseKey.OfflineGracePeriod > DateTimeOffset.UtcNow)
+                {
+                    return _cached;
+                }
+            }
+
+            // Stale cache → expired. No cache → pending.
+            lock (_cacheLock)
+            {
+                if (_cached is not null)
+                {
+                    var expired = new LicenseValidationResult(
+                        LicenseKeyStatus.Expired,
+                        tier: _cached.Tier,
+                        expiresAt: _cached.ExpiresAt,
+                        validatedAt: DateTimeOffset.UtcNow,
+                        message: "License server unreachable and grace period exceeded.",
+                        capabilities: null);
+                    _cached = expired;
+                    return expired;
+                }
+            }
+
+            return Cache(new LicenseValidationResult(
+                LicenseKeyStatus.ValidationPending,
+                tier: null, expiresAt: null, validatedAt: DateTimeOffset.UtcNow,
+                message: "License server unreachable. Initial validation pending.",
+                capabilities: null));
+        }
+    }
+
+    private LicenseValidationResult Cache(LicenseValidationResult r)
+    {
+        lock (_cacheLock) _cached = r;
+        return r;
+    }
+
+    /// <summary>
+    /// True iff <paramref name="key"/> is in <c>aidn.{id}.{sig}</c>
+    /// format (signed offline-eligible) or <c>AIDN-*-{hex}</c> format
+    /// (server-validated). Mirrors the upstream check so the same key
+    /// strings work in both packages.
+    /// </summary>
+    public static bool ValidateKeyFormat(string key)
+        => IsSignedKeyFormat(key) || IsServerValidatedKeyFormat(key);
+
+    internal static bool IsSignedKeyFormat(string key)
+    {
+        var parts = key.Split('.');
+        if (parts.Length != 3 || parts[0] != "aidn"
+            || parts[1].Length == 0 || parts[2].Length == 0)
+            return false;
+        for (int i = 0; i < parts[1].Length; i++)
+            if (!char.IsLetterOrDigit(parts[1][i])) return false;
+        // Signature is base64url — accept '+', '/', '-', '_', '=' too.
+        return true;
+    }
+
+    internal static bool IsServerValidatedKeyFormat(string key)
+    {
+        var parts = key.Split('-');
+        if (parts.Length < 4
+            || !parts[0].Equals("AIDN", StringComparison.OrdinalIgnoreCase))
+            return false;
+        string last = parts[parts.Length - 1];
+        if (last.Length < 8) return false;
+        for (int i = 0; i < last.Length; i++)
+        {
+            char c = last[i];
+            bool isHex = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+            if (!isHex) return false;
+        }
+        return true;
+    }
+
+    private LicenseValidationResult ValidateOnline()
+    {
+        string url = _licenseKey.ServerUrl ?? DefaultServerUrl;
+
+        // Build minimal request body. Mirrors upstream's body keys plus
+        // a `package` hint so the server can attach the right capability
+        // set for the calling library — `AiDotNet.Tensors` gets the
+        // tensors:* capabilities, `AiDotNet` gets the model:* set, and
+        // higher tiers get both.
+        var body = new Dictionary<string, string?>
+        {
+            ["license_key"] = _licenseKey.Key,
+            ["package"] = "AiDotNet.Tensors",
+        };
+        if (_licenseKey.Environment is not null)
+            body["environment"] = _licenseKey.Environment;
+        if (_licenseKey.EnableTelemetry)
+        {
+            try { body["hostname"] = Environment.MachineName; } catch { }
+            try { body["os_description"] = System.Runtime.InteropServices.RuntimeInformation.OSDescription; } catch { }
+        }
+
+        string json = JsonSerializer.Serialize(body);
+
+#if NET471
+        return PostNet471(url, json);
+#else
+        return PostModern(url, json);
+#endif
+    }
+
+#if NET471
+    private LicenseValidationResult PostNet471(string url, string json)
+    {
+        var req = (HttpWebRequest)WebRequest.Create(url);
+        req.Method = "POST";
+        req.ContentType = "application/json";
+        req.Timeout = 15_000;
+        var bodyBytes = Encoding.UTF8.GetBytes(json);
+        req.ContentLength = bodyBytes.Length;
+        using (var rs = req.GetRequestStream()) rs.Write(bodyBytes, 0, bodyBytes.Length);
+
+        using var resp = (HttpWebResponse)req.GetResponse();
+        using var stream = resp.GetResponseStream() ?? Stream.Null;
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        string responseJson = reader.ReadToEnd();
+        return ParseResponse(responseJson, (int)resp.StatusCode);
+    }
+#else
+    private LicenseValidationResult PostModern(string url, string json)
+    {
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+        var response = SharedHttpClient.PostAsync(url, content).GetAwaiter().GetResult();
+        string responseJson = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+        return ParseResponse(responseJson, (int)response.StatusCode);
+    }
+#endif
+
+    /// <summary>
+    /// Parses the server response into a <see cref="LicenseValidationResult"/>.
+    /// Visible to tests so the parser can be exercised without a live
+    /// server.
+    /// </summary>
+    internal static LicenseValidationResult ParseResponse(string responseJson, int statusCode)
+    {
+        // Network non-2xx → invalid. The Edge Function returns 200
+        // for both valid and invalid keys with status in the body, so
+        // a non-2xx is a transport failure rather than a key rejection.
+        if (statusCode < 200 || statusCode >= 300)
+        {
+            return new LicenseValidationResult(
+                LicenseKeyStatus.Invalid,
+                tier: null, expiresAt: null, validatedAt: DateTimeOffset.UtcNow,
+                message: $"License server returned HTTP {statusCode}.",
+                capabilities: null);
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(responseJson);
+            var root = doc.RootElement;
+
+            string? statusStr = root.TryGetProperty("status", out var s) ? s.GetString() : null;
+            var status = statusStr switch
+            {
+                "active" => LicenseKeyStatus.Active,
+                "expired" => LicenseKeyStatus.Expired,
+                "revoked" => LicenseKeyStatus.Revoked,
+                "seat_limit_reached" => LicenseKeyStatus.SeatLimitReached,
+                "invalid" => LicenseKeyStatus.Invalid,
+                _ => LicenseKeyStatus.Invalid,
+            };
+
+            string? tier = root.TryGetProperty("tier", out var t) ? t.GetString() : null;
+            DateTimeOffset? expiresAt = null;
+            if (root.TryGetProperty("expires_at", out var exp) && exp.ValueKind == JsonValueKind.String)
+            {
+                if (DateTimeOffset.TryParse(exp.GetString(), out var parsed)) expiresAt = parsed;
+            }
+            string? message = root.TryGetProperty("message", out var m) ? m.GetString() : null;
+
+            var caps = new List<string>();
+            if (root.TryGetProperty("capabilities", out var capsEl)
+                && capsEl.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var cap in capsEl.EnumerateArray())
+                {
+                    if (cap.ValueKind == JsonValueKind.String)
+                    {
+                        var v = cap.GetString();
+                        if (!string.IsNullOrEmpty(v)) caps.Add(v!);
+                    }
+                }
+            }
+
+            return new LicenseValidationResult(
+                status, tier, expiresAt,
+                validatedAt: DateTimeOffset.UtcNow,
+                message: message,
+                capabilities: caps);
+        }
+        catch (Exception ex)
+        {
+            return new LicenseValidationResult(
+                LicenseKeyStatus.Invalid,
+                tier: null, expiresAt: null, validatedAt: DateTimeOffset.UtcNow,
+                message: "Failed to parse license server response: " + ex.Message,
+                capabilities: null);
+        }
+    }
+}

--- a/src/AiDotNet.Tensors/Licensing/PersistenceGuard.cs
+++ b/src/AiDotNet.Tensors/Licensing/PersistenceGuard.cs
@@ -1,0 +1,279 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System.IO;
+using System.Threading;
+
+namespace AiDotNet.Tensors.Licensing;
+
+/// <summary>
+/// Centralised enforcement point for AiDotNet.Tensors persistence
+/// operations. Every public read/write of a tensor file format
+/// (<c>GgufReader</c>, <c>SafetensorsReader/Writer</c>, pickle / .pt
+/// reader, sharded checkpoint loader) must call through one of the
+/// <c>EnforceBefore*</c> methods so the same gate covers every entry
+/// point.
+/// </summary>
+/// <remarks>
+/// <para><b>How licensing flows:</b></para>
+/// <list type="number">
+///   <item><description>The user provides a key string via env var
+///   <c>AIDOTNET_LICENSE_KEY</c>, the file
+///   <c>~/.aidotnet/license.key</c>, or
+///   <see cref="SetActiveLicenseKey"/>.</description></item>
+///   <item><description>On the first persistence op, the guard
+///   resolves the key, hits the licensing server (cached for the
+///   offline-grace window), and checks the returned capability set
+///   includes <c>tensors:save</c> / <c>tensors:load</c>.</description></item>
+///   <item><description>If no key is configured, the guard falls back
+///   to <see cref="TrialState"/> — the user gets the default trial
+///   budget (50 ops or 30 days). After the budget is exhausted, the
+///   guard throws <see cref="LicenseRequiredException"/>.</description></item>
+///   <item><description>Upstream <c>AiDotNet</c> wraps its own
+///   persistence calls in <see cref="InternalOperation"/> so the
+///   tensor guard's counter doesn't double-tick when both layers are
+///   in the same call stack.</description></item>
+/// </list>
+/// <para><b>Thread safety:</b></para>
+/// <para>
+/// Every mutable piece of state — the active key, the
+/// internal-operation depth, the test trial-file override — is held
+/// in <see cref="AsyncLocal{T}"/> rather than <c>[ThreadStatic]</c>.
+/// An <c>await</c> inside a guarded scope frequently resumes on a
+/// different thread-pool thread; thread-static state would fall away
+/// on the continuation, so the guard would either fire on a call
+/// that should have been suppressed or miss a call that should have
+/// been counted. <see cref="AsyncLocal{T}"/> flows with the logical
+/// call context.
+/// </para>
+/// </remarks>
+public static class PersistenceGuard
+{
+    // Capability strings used by the guard. The licensing server is
+    // expected to attach these to a key when the user's tier covers
+    // them.
+    public const string CapabilitySave = "tensors:save";
+    public const string CapabilityLoad = "tensors:load";
+    public const string CapabilitySerialize = "tensors:save";
+    public const string CapabilityDeserialize = "tensors:load";
+
+    // ─── Active license key ────────────────────────────────────────
+
+    private static readonly AsyncLocal<AiDotNetTensorsLicenseKey?> _activeKey = new();
+
+    /// <summary>
+    /// Sets the active license key for the current logical call
+    /// context. Returns an <see cref="IDisposable"/> that restores
+    /// the prior key on disposal, so nested scopes compose cleanly.
+    /// Upstream <c>AiDotNet</c>'s <c>AiModelBuilder</c> calls this at
+    /// the start of <c>BuildAsync</c> to flow its license into the
+    /// tensor layer; standalone tensor users call it once at startup
+    /// (or rely on the env-var/file fallback).
+    /// </summary>
+    public static IDisposable SetActiveLicenseKey(AiDotNetTensorsLicenseKey? key)
+    {
+        var prev = _activeKey.Value;
+        _activeKey.Value = key;
+        return new ActiveKeyScope(prev);
+    }
+
+    private sealed class ActiveKeyScope : IDisposable
+    {
+        private readonly AiDotNetTensorsLicenseKey? _previous;
+        public ActiveKeyScope(AiDotNetTensorsLicenseKey? prev) { _previous = prev; }
+        public void Dispose() => _activeKey.Value = _previous;
+    }
+
+    // ─── Internal-operation suppression ────────────────────────────
+
+    private static readonly AsyncLocal<int> _internalDepth = new();
+
+    /// <summary>
+    /// Increments the internal-operation counter for the current
+    /// logical call context. While the returned scope is active,
+    /// every <c>EnforceBefore*</c> call is a no-op — used by upstream
+    /// <c>AiDotNet</c> when its own <c>ModelPersistenceGuard</c> has
+    /// already enforced and the tensor guard would otherwise
+    /// double-count. Supports nesting; only the outermost dispose
+    /// re-enables enforcement.
+    /// </summary>
+    public static IDisposable InternalOperation()
+    {
+        _internalDepth.Value++;
+        return new InternalOperationScope();
+    }
+
+    private sealed class InternalOperationScope : IDisposable
+    {
+        private bool _disposed;
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _internalDepth.Value = Math.Max(0, _internalDepth.Value - 1);
+        }
+    }
+
+    // ─── Test-only trial file override ─────────────────────────────
+
+    private static readonly AsyncLocal<string?> _trialFilePathOverride = new();
+
+    /// <summary>
+    /// Test hook — overrides the trial-state file path for the
+    /// current logical call context so test runs don't mutate the
+    /// developer's <c>~/.aidotnet/tensors-trial.json</c>. Pass
+    /// <c>null</c> to clear an existing override.
+    /// </summary>
+    public static IDisposable SetTestTrialFilePathOverride(string? path)
+    {
+        var prev = _trialFilePathOverride.Value;
+        _trialFilePathOverride.Value = path;
+        return new TrialPathScope(prev);
+    }
+
+    private sealed class TrialPathScope : IDisposable
+    {
+        private readonly string? _previous;
+        public TrialPathScope(string? prev) { _previous = prev; }
+        public void Dispose() => _trialFilePathOverride.Value = _previous;
+    }
+
+    // ─── Shared validator cache ────────────────────────────────────
+    //
+    // Validating the key on every persistence op would re-run online
+    // checks (or at minimum re-parse env-var / disk on every call).
+    // Cache by key string so repeated saves with the same key reuse
+    // the validator instance — which itself caches the network result
+    // for the offline-grace window.
+
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, LicenseValidator> _validators = new();
+    private static LicenseValidator GetValidator(AiDotNetTensorsLicenseKey key)
+        => _validators.GetOrAdd(key.Key, _ => new LicenseValidator(key));
+
+    // ─── Enforcement entry points ──────────────────────────────────
+
+    /// <summary>
+    /// Enforces licensing before a save operation (write a tensor or
+    /// state-dict to a file).
+    /// </summary>
+    public static void EnforceBeforeSave() => EnforceCore(CapabilitySave, "save");
+
+    /// <summary>
+    /// Enforces licensing before a load operation (read a tensor or
+    /// state-dict from a file).
+    /// </summary>
+    public static void EnforceBeforeLoad() => EnforceCore(CapabilityLoad, "load");
+
+    /// <summary>
+    /// Enforces licensing before a Serialize call. Same gate as
+    /// <see cref="EnforceBeforeSave"/> — kept as a separate method so
+    /// callers express intent.
+    /// </summary>
+    public static void EnforceBeforeSerialize() => EnforceCore(CapabilitySerialize, "serialize");
+
+    /// <summary>
+    /// Enforces licensing before a Deserialize call. Same gate as
+    /// <see cref="EnforceBeforeLoad"/>.
+    /// </summary>
+    public static void EnforceBeforeDeserialize() => EnforceCore(CapabilityDeserialize, "deserialize");
+
+    private static void EnforceCore(string requiredCapability, string operationLabel)
+    {
+        // Suppressed under InternalOperation — upstream AiDotNet
+        // already enforced before delegating to us.
+        if (_internalDepth.Value > 0) return;
+
+        // Resolve key: AsyncLocal > env var > file. None present →
+        // fall through to the trial path.
+        var key = ResolveActiveKey();
+        if (key is not null)
+        {
+            var validator = GetValidator(key);
+            var result = validator.Validate();
+
+            if (result.Status == LicenseKeyStatus.Active && result.HasCapability(requiredCapability))
+                return;
+            if (result.Status == LicenseKeyStatus.Active && !result.HasCapability(requiredCapability))
+                throw new LicenseRequiredException(
+                    $"License is active but does not include the '{requiredCapability}' capability " +
+                    $"required for tensor {operationLabel}. Tier: {result.Tier ?? "(unknown)"}.",
+                    trialDaysElapsed: null,
+                    operationsPerformed: null,
+                    keyStatus: LicenseKeyStatus.CapabilityMissing,
+                    requiredCapability: requiredCapability);
+
+            // Pending (transport failure on first call) → allow within
+            // the offline grace window. The validator already returned
+            // ValidationPending, which means we have no cached prior;
+            // accept it once so users on flaky networks aren't blocked
+            // on every call.
+            if (result.Status == LicenseKeyStatus.ValidationPending)
+                return;
+
+            // Anything else (Expired / Revoked / Invalid / SeatLimit) → throw.
+            throw new LicenseRequiredException(
+                $"License key validation failed (status={result.Status}): {result.Message ?? "(no message)"}.",
+                trialDaysElapsed: null,
+                operationsPerformed: null,
+                keyStatus: result.Status,
+                requiredCapability: requiredCapability);
+        }
+
+        // No key configured → consult the trial state.
+        string trialPath = _trialFilePathOverride.Value ?? TrialState.DefaultPath;
+        var trial = TrialState.Load(trialPath);
+        var now = DateTimeOffset.UtcNow;
+        if (trial.IsExpired(now))
+        {
+            int daysElapsed = (int)(now - trial.StartedAt).TotalDays;
+            throw new LicenseRequiredException(
+                $"Free trial for AiDotNet.Tensors has expired ({trial.OperationsConsumed} operations / {daysElapsed} days). " +
+                "Set AIDOTNET_LICENSE_KEY or call PersistenceGuard.SetActiveLicenseKey to continue.",
+                trialDaysElapsed: daysElapsed,
+                operationsPerformed: trial.OperationsConsumed,
+                keyStatus: null,
+                requiredCapability: requiredCapability);
+        }
+
+        // Tick the counter and persist.
+        trial.OperationsConsumed++;
+        trial.Save(trialPath);
+    }
+
+    private static AiDotNetTensorsLicenseKey? ResolveActiveKey()
+    {
+        if (_activeKey.Value is { } explicitKey) return explicitKey;
+
+        // Env var: AIDOTNET_LICENSE_KEY (same name upstream uses, so
+        // setting it once configures both packages).
+        try
+        {
+            string? envKey = Environment.GetEnvironmentVariable("AIDOTNET_LICENSE_KEY");
+            if (!string.IsNullOrWhiteSpace(envKey))
+                return new AiDotNetTensorsLicenseKey(envKey!);
+        }
+        catch { /* SecurityException etc. — fall through */ }
+
+        // File: ~/.aidotnet/license.key (also matches upstream).
+        try
+        {
+            string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            string path = Path.Combine(home, ".aidotnet", "license.key");
+            if (File.Exists(path))
+            {
+                string content = File.ReadAllText(path).Trim();
+                if (!string.IsNullOrWhiteSpace(content))
+                    return new AiDotNetTensorsLicenseKey(content);
+            }
+        }
+        catch { /* IOException / SecurityException — fall through */ }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Test hook — clears the validator cache so a test can configure
+    /// a new key and have the next call hit the validator fresh
+    /// rather than seeing the previous test's cached result.
+    /// </summary>
+    internal static void ClearValidatorCacheForTesting() => _validators.Clear();
+}

--- a/src/AiDotNet.Tensors/Licensing/PersistenceGuard.cs
+++ b/src/AiDotNet.Tensors/Licensing/PersistenceGuard.cs
@@ -123,7 +123,14 @@ public static class PersistenceGuard
     /// developer's <c>~/.aidotnet/tensors-trial.json</c>. Pass
     /// <c>null</c> to clear an existing override.
     /// </summary>
-    public static IDisposable SetTestTrialFilePathOverride(string? path)
+    /// <remarks>
+    /// <c>internal</c> on purpose — exposed only via the test project's
+    /// <c>InternalsVisibleTo</c> entry. Making this <c>public</c> would
+    /// hand every consumer a one-line trial-tracking bypass: redirect
+    /// the override to a fresh temp file before each operation and the
+    /// counter never accumulates against the real trial.json.
+    /// </remarks>
+    internal static IDisposable SetTestTrialFilePathOverride(string? path)
     {
         var prev = _trialFilePathOverride.Value;
         _trialFilePathOverride.Value = path;
@@ -148,6 +155,33 @@ public static class PersistenceGuard
     private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, LicenseValidator> _validators = new();
     private static LicenseValidator GetValidator(AiDotNetTensorsLicenseKey key)
         => _validators.GetOrAdd(key.Key, _ => new LicenseValidator(key));
+
+    // Per-key "pending allowance consumed" set. The first
+    // ValidationPending result for a key is allowed (lets users on a
+    // flaky network bootstrap into the offline-grace window), but
+    // subsequent pending results are rejected — the validator caches
+    // a pending result for the full grace period, so without this cap
+    // a user with persistent network failure would get unlimited free
+    // operations for the entire grace window.
+    //
+    // Cleared whenever validation transitions to Active, so a transient
+    // network blip followed by a successful re-check restores the
+    // single-allowance budget for the next outage.
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, byte> _pendingConsumed = new();
+
+    // Single-process gate around the trial state's read-check-increment-
+    // write sequence. Without this, two concurrent EnforceCore calls can
+    // each load the same on-disk operationsConsumed value, both see the
+    // pre-tick count, both write back count+1, and the second write
+    // silently overwrites the first — losing increments and letting
+    // users exceed the operation cap.
+    //
+    // This is process-local. Multi-process safety would need
+    // OS-level file locking inside TrialState.Load/Save; persistence
+    // I/O is intentionally low-frequency (Save / Load / Serialize /
+    // Deserialize entry points) so a per-process lock is the right
+    // grain — matches upstream's ModelPersistenceGuard pattern.
+    private static readonly object _trialStateGate = new();
 
     // ─── Enforcement entry points ──────────────────────────────────
 
@@ -191,7 +225,14 @@ public static class PersistenceGuard
             var result = validator.Validate();
 
             if (result.Status == LicenseKeyStatus.Active && result.HasCapability(requiredCapability))
+            {
+                // Active validation clears any prior pending-consumed
+                // marker for this key — a transient outage that
+                // recovers should restore the single-pending allowance
+                // for the next outage.
+                _pendingConsumed.TryRemove(key.Key, out _);
                 return;
+            }
             if (result.Status == LicenseKeyStatus.Active && !result.HasCapability(requiredCapability))
                 throw new LicenseRequiredException(
                     $"License is active but does not include the '{requiredCapability}' capability " +
@@ -201,13 +242,28 @@ public static class PersistenceGuard
                     keyStatus: LicenseKeyStatus.CapabilityMissing,
                     requiredCapability: requiredCapability);
 
-            // Pending (transport failure on first call) → allow within
-            // the offline grace window. The validator already returned
-            // ValidationPending, which means we have no cached prior;
-            // accept it once so users on flaky networks aren't blocked
-            // on every call.
             if (result.Status == LicenseKeyStatus.ValidationPending)
-                return;
+            {
+                // First pending result per key is allowed (bootstraps
+                // users on a flaky network). Subsequent pending
+                // results — which the validator returns from its
+                // cached pending throughout the offline grace window
+                // — are rejected, so a user with persistent network
+                // failure can't loop through unlimited operations.
+                // TryAdd returns false if the key was already
+                // present, i.e. we've already consumed the allowance.
+                if (_pendingConsumed.TryAdd(key.Key, 0))
+                    return;
+
+                throw new LicenseRequiredException(
+                    "License server unreachable and the one-call validation-pending allowance " +
+                    "has already been consumed for this key. Restore network connectivity to " +
+                    "re-validate, or fall back to upstream AiDotNet for offline HMAC verification.",
+                    trialDaysElapsed: null,
+                    operationsPerformed: null,
+                    keyStatus: LicenseKeyStatus.ValidationPending,
+                    requiredCapability: requiredCapability);
+            }
 
             // Anything else (Expired / Revoked / Invalid / SeatLimit) → throw.
             throw new LicenseRequiredException(
@@ -218,25 +274,31 @@ public static class PersistenceGuard
                 requiredCapability: requiredCapability);
         }
 
-        // No key configured → consult the trial state.
+        // No key configured → consult the trial state. The
+        // load → IsExpired → increment → save sequence runs under
+        // _trialStateGate so concurrent EnforceCore calls can't race
+        // and lose increments; see _trialStateGate's comment.
         string trialPath = _trialFilePathOverride.Value ?? TrialState.DefaultPath;
-        var trial = TrialState.Load(trialPath);
-        var now = DateTimeOffset.UtcNow;
-        if (trial.IsExpired(now))
+        lock (_trialStateGate)
         {
-            int daysElapsed = (int)(now - trial.StartedAt).TotalDays;
-            throw new LicenseRequiredException(
-                $"Free trial for AiDotNet.Tensors has expired ({trial.OperationsConsumed} operations / {daysElapsed} days). " +
-                "Set AIDOTNET_LICENSE_KEY or call PersistenceGuard.SetActiveLicenseKey to continue.",
-                trialDaysElapsed: daysElapsed,
-                operationsPerformed: trial.OperationsConsumed,
-                keyStatus: null,
-                requiredCapability: requiredCapability);
-        }
+            var trial = TrialState.Load(trialPath);
+            var now = DateTimeOffset.UtcNow;
+            if (trial.IsExpired(now))
+            {
+                int daysElapsed = (int)(now - trial.StartedAt).TotalDays;
+                throw new LicenseRequiredException(
+                    $"Free trial for AiDotNet.Tensors has expired ({trial.OperationsConsumed} operations / {daysElapsed} days). " +
+                    "Set AIDOTNET_LICENSE_KEY or call PersistenceGuard.SetActiveLicenseKey to continue.",
+                    trialDaysElapsed: daysElapsed,
+                    operationsPerformed: trial.OperationsConsumed,
+                    keyStatus: null,
+                    requiredCapability: requiredCapability);
+            }
 
-        // Tick the counter and persist.
-        trial.OperationsConsumed++;
-        trial.Save(trialPath);
+            // Tick the counter and persist.
+            trial.OperationsConsumed++;
+            trial.Save(trialPath);
+        }
     }
 
     private static AiDotNetTensorsLicenseKey? ResolveActiveKey()
@@ -271,9 +333,15 @@ public static class PersistenceGuard
     }
 
     /// <summary>
-    /// Test hook — clears the validator cache so a test can configure
-    /// a new key and have the next call hit the validator fresh
-    /// rather than seeing the previous test's cached result.
+    /// Test hook — clears the validator cache and per-key
+    /// pending-consumed markers so a test can configure a new key
+    /// and have the next call hit the validator fresh rather than
+    /// seeing the previous test's cached result or its consumed
+    /// pending allowance.
     /// </summary>
-    internal static void ClearValidatorCacheForTesting() => _validators.Clear();
+    internal static void ClearValidatorCacheForTesting()
+    {
+        _validators.Clear();
+        _pendingConsumed.Clear();
+    }
 }

--- a/src/AiDotNet.Tensors/Licensing/TrialState.cs
+++ b/src/AiDotNet.Tensors/Licensing/TrialState.cs
@@ -1,0 +1,136 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System.IO;
+using System.Text.Json;
+
+namespace AiDotNet.Tensors.Licensing;
+
+/// <summary>
+/// Persistent state for the AiDotNet.Tensors free-trial mechanism.
+/// Persisted to <c>~/.aidotnet/tensors-trial.json</c> by default;
+/// tests can override the path via
+/// <see cref="PersistenceGuard.SetTestTrialFilePathOverride"/>.
+/// </summary>
+/// <remarks>
+/// <para><b>Why a separate trial file from upstream:</b></para>
+/// <para>
+/// Upstream <c>AiDotNet</c> writes <c>~/.aidotnet/trial.json</c> for
+/// model-level operations. The tensor layer uses a sibling file so
+/// the two trials are independently tracked — a user who just
+/// installed <c>AiDotNet.Tensors</c> for safetensors I/O gets a fresh
+/// trial budget rather than inheriting whatever counter upstream
+/// previously decremented. When upstream is also installed, the
+/// upstream guard suppresses the tensor guard via
+/// <see cref="PersistenceGuard.InternalOperation"/>, so only the
+/// upstream counter ticks for save/load issued through the upstream
+/// API surface.
+/// </para>
+/// </remarks>
+public sealed class TrialState
+{
+    /// <summary>
+    /// Default budget — 30 days OR 50 persistence operations,
+    /// whichever expires first. Matches upstream's "generous trial
+    /// for evaluation" pattern.
+    /// </summary>
+    public const int DefaultMaxOperations = 50;
+
+    /// <summary>Default trial window in days.</summary>
+    public const int DefaultMaxDays = 30;
+
+    /// <summary>UTC timestamp the trial first started.</summary>
+    public DateTimeOffset StartedAt { get; set; }
+
+    /// <summary>Number of save+load+serialize+deserialize ops counted
+    /// against the trial.</summary>
+    public int OperationsConsumed { get; set; }
+
+    /// <summary>
+    /// Returns <c>true</c> if the trial budget is exhausted — either
+    /// the time window is past or the operation count is hit.
+    /// </summary>
+    public bool IsExpired(DateTimeOffset now)
+    {
+        if (now - StartedAt >= TimeSpan.FromDays(DefaultMaxDays)) return true;
+        if (OperationsConsumed >= DefaultMaxOperations) return true;
+        return false;
+    }
+
+    /// <summary>
+    /// Default location: <c>%USERPROFILE%/.aidotnet/tensors-trial.json</c>
+    /// on Windows, <c>~/.aidotnet/tensors-trial.json</c> on Unix.
+    /// </summary>
+    public static string DefaultPath
+    {
+        get
+        {
+            string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            return Path.Combine(home, ".aidotnet", "tensors-trial.json");
+        }
+    }
+
+    /// <summary>
+    /// Reads the trial state from <paramref name="path"/>, or returns
+    /// a fresh state initialised to "started now, zero operations" if
+    /// the file does not exist or fails to parse. The fresh state is
+    /// not written to disk by this method — call <see cref="Save"/>
+    /// after consuming an operation.
+    /// </summary>
+    public static TrialState Load(string path)
+    {
+        try
+        {
+            if (!File.Exists(path))
+                return new TrialState { StartedAt = DateTimeOffset.UtcNow, OperationsConsumed = 0 };
+            string json = File.ReadAllText(path);
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            var state = new TrialState
+            {
+                StartedAt = root.TryGetProperty("startedAt", out var s)
+                    && DateTimeOffset.TryParse(s.GetString(), out var parsed)
+                    ? parsed
+                    : DateTimeOffset.UtcNow,
+                OperationsConsumed = root.TryGetProperty("operationsConsumed", out var o)
+                    && o.ValueKind == JsonValueKind.Number
+                    ? o.GetInt32()
+                    : 0,
+            };
+            return state;
+        }
+        catch
+        {
+            // Corrupt file → start fresh rather than block the user.
+            return new TrialState { StartedAt = DateTimeOffset.UtcNow, OperationsConsumed = 0 };
+        }
+    }
+
+    /// <summary>
+    /// Persists this state to <paramref name="path"/>, creating any
+    /// missing parent directories. Failures are swallowed (with a
+    /// trace warning) so a user with a read-only home directory can
+    /// still use the library — the trial just won't persist between
+    /// runs.
+    /// </summary>
+    public void Save(string path)
+    {
+        try
+        {
+            string? dir = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                Directory.CreateDirectory(dir!);
+            string json = JsonSerializer.Serialize(new
+            {
+                startedAt = StartedAt.ToString("o"),
+                operationsConsumed = OperationsConsumed,
+            });
+            File.WriteAllText(path, json);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Trace.TraceWarning(
+                "AiDotNet.Tensors trial state could not be persisted: "
+                + ex.GetType().Name + ": " + ex.Message);
+        }
+    }
+}

--- a/src/AiDotNet.Tensors/NumericOperations/GgufReader.cs
+++ b/src/AiDotNet.Tensors/NumericOperations/GgufReader.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Text;
+using AiDotNet.Tensors.Licensing;
 
 namespace AiDotNet.Tensors.NumericOperations;
 
@@ -35,8 +36,23 @@ public static class GgufReader
     /// <summary>Parse the full header, metadata, and tensor index from
     /// <paramref name="stream"/>. Leaves the stream positioned at the
     /// first byte of tensor data.</summary>
+    /// <exception cref="LicenseRequiredException">
+    /// Thrown when no license is configured AND the free-trial budget
+    /// is exhausted, OR when the configured license does not include
+    /// the <c>tensors:load</c> capability. See
+    /// <see cref="PersistenceGuard"/> for resolution paths.
+    /// </exception>
     public static GgufFile Read(Stream stream)
     {
+        // Gate every public read entry point through the persistence
+        // guard so the licensing check fires uniformly across every
+        // tensor-format reader (GGUF today, Safetensors / pickle / .pt
+        // / sharded checkpoints in #218). Upstream AiDotNet wraps its
+        // own load call in PersistenceGuard.InternalOperation() so
+        // this enforce is suppressed when the upstream guard has
+        // already counted the operation.
+        PersistenceGuard.EnforceBeforeLoad();
+
         if (stream is null) throw new ArgumentNullException(nameof(stream));
         if (!stream.CanRead) throw new ArgumentException("Stream must be readable.", nameof(stream));
 

--- a/tests/AiDotNet.Tensors.Tests/Licensing/PersistenceGuardTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Licensing/PersistenceGuardTests.cs
@@ -210,6 +210,72 @@ public class PersistenceGuardTests
     }
 
     [Fact]
+    public void TrialCounter_ConcurrentCallsDontLoseIncrements()
+    {
+        // Without a lock, a read-check-increment-write race can let
+        // N concurrent calls all read the same baseline and write
+        // back baseline+1, losing N-1 increments. Hammer the guard
+        // from 16 threads doing 4 ops each — the on-disk counter
+        // must end up at exactly 64.
+        using var trial = IsolatedTrial(out var path);
+
+        // Total ops must stay under TrialState.DefaultMaxOperations
+        // (50) — the test asserts the counter is exact, but if the
+        // total exceeds the cap the guard throws midway.
+        const int threads = 12;
+        const int opsPerThread = 4;
+        var barrier = new System.Threading.Barrier(threads);
+        var tasks = new System.Threading.Tasks.Task[threads];
+        for (int t = 0; t < threads; t++)
+        {
+            tasks[t] = System.Threading.Tasks.Task.Run(() =>
+            {
+                barrier.SignalAndWait();
+                for (int i = 0; i < opsPerThread; i++)
+                    PersistenceGuard.EnforceBeforeLoad();
+            });
+        }
+        System.Threading.Tasks.Task.WaitAll(tasks);
+
+        var state = TrialState.Load(path);
+        Assert.Equal(threads * opsPerThread, state.OperationsConsumed);
+    }
+
+    [Fact]
+    public void ValidationPending_FirstCall_Allowed_SubsequentCalls_Throw()
+    {
+        // The validator caches a ValidationPending result for the full
+        // offline-grace window. Without a per-key cap the guard would
+        // accept every pending call → unlimited operations on a key
+        // that never validated. The cap allows ONE pending call per
+        // key, then rejects.
+        PersistenceGuard.ClearValidatorCacheForTesting();
+        // Use a syntactically-valid key whose server URL is unreachable
+        // → the validator's online attempt fails with no cache → first
+        // result is ValidationPending.
+        var unreachableKey = new AiDotNetTensorsLicenseKey("aidn.test123.signaturePARTabc")
+        {
+            // Pointing at a dead host forces the network attempt to
+            // fail, which flows into the ValidationPending branch.
+            ServerUrl = "https://0.0.0.0:1/never-resolves",
+            OfflineGracePeriod = TimeSpan.FromMinutes(5),
+        };
+
+        using (PersistenceGuard.SetActiveLicenseKey(unreachableKey))
+        {
+            // First call: pending allowance consumed, no throw.
+            PersistenceGuard.EnforceBeforeLoad();
+
+            // Second call within the grace window: cached pending
+            // returns again, but the per-key cap rejects it.
+            var ex = Assert.Throws<LicenseRequiredException>(
+                () => PersistenceGuard.EnforceBeforeLoad());
+            Assert.Equal(LicenseKeyStatus.ValidationPending, ex.KeyStatus);
+        }
+        PersistenceGuard.ClearValidatorCacheForTesting();
+    }
+
+    [Fact]
     public void Capabilities_TensorsLoad_AcceptedBy_HasCapability()
     {
         // Direct test of the capability convention — server returns

--- a/tests/AiDotNet.Tensors.Tests/Licensing/PersistenceGuardTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Licensing/PersistenceGuardTests.cs
@@ -1,0 +1,283 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Tests for tensor-layer license enforcement.
+
+#nullable disable
+
+using System;
+using System.IO;
+using AiDotNet.Tensors.Licensing;
+using AiDotNet.Tensors.NumericOperations;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Licensing;
+
+/// <summary>
+/// Tests run serially via xUnit's collection mechanism — the guard
+/// uses process-wide AsyncLocal/static state and parallel test
+/// execution would interleave key/trial-path overrides.
+/// </summary>
+[Collection("PersistenceGuard")]
+public class PersistenceGuardTests
+{
+    /// <summary>
+    /// Test fixture that provides an isolated trial-file path per
+    /// test, ensuring no test leaks into <c>~/.aidotnet/tensors-trial.json</c>
+    /// or affects another test's counter.
+    /// </summary>
+    private static IDisposable IsolatedTrial(out string path)
+    {
+        path = Path.Combine(Path.GetTempPath(), "aidotnet-test-trial-" + Guid.NewGuid().ToString("N") + ".json");
+        var override_ = PersistenceGuard.SetTestTrialFilePathOverride(path);
+        return new TrialPathCleanup(override_, path);
+    }
+
+    private sealed class TrialPathCleanup : IDisposable
+    {
+        private readonly IDisposable _scope;
+        private readonly string _path;
+        public TrialPathCleanup(IDisposable scope, string path) { _scope = scope; _path = path; }
+        public void Dispose()
+        {
+            _scope.Dispose();
+            try { if (File.Exists(_path)) File.Delete(_path); } catch { }
+        }
+    }
+
+    [Fact]
+    public void EnforceBeforeLoad_NoKey_FreshTrial_Allows()
+    {
+        using var trial = IsolatedTrial(out _);
+        // No exception — fresh trial budget allows the call.
+        PersistenceGuard.EnforceBeforeLoad();
+    }
+
+    [Fact]
+    public void EnforceBeforeLoad_NoKey_TrialPersistsAcrossCalls()
+    {
+        // After 3 calls, the on-disk trial file should reflect 3
+        // operations consumed.
+        using var trial = IsolatedTrial(out var path);
+        PersistenceGuard.EnforceBeforeLoad();
+        PersistenceGuard.EnforceBeforeLoad();
+        PersistenceGuard.EnforceBeforeLoad();
+        var state = TrialState.Load(path);
+        Assert.Equal(3, state.OperationsConsumed);
+    }
+
+    [Fact]
+    public void EnforceBeforeLoad_NoKey_TrialBudgetExhausted_Throws()
+    {
+        // Pre-populate trial state with the operation cap reached.
+        using var trial = IsolatedTrial(out var path);
+        var preExhausted = new TrialState
+        {
+            StartedAt = DateTimeOffset.UtcNow,
+            OperationsConsumed = TrialState.DefaultMaxOperations,
+        };
+        preExhausted.Save(path);
+
+        var ex = Assert.Throws<LicenseRequiredException>(() => PersistenceGuard.EnforceBeforeLoad());
+        Assert.NotNull(ex.OperationsPerformed);
+        Assert.Equal(TrialState.DefaultMaxOperations, ex.OperationsPerformed);
+    }
+
+    [Fact]
+    public void EnforceBeforeLoad_NoKey_TrialDaysExhausted_Throws()
+    {
+        // Pre-populate trial state with start time 31 days ago (over
+        // the 30-day window).
+        using var trial = IsolatedTrial(out var path);
+        var preExhausted = new TrialState
+        {
+            StartedAt = DateTimeOffset.UtcNow - TimeSpan.FromDays(31),
+            OperationsConsumed = 1,
+        };
+        preExhausted.Save(path);
+
+        var ex = Assert.Throws<LicenseRequiredException>(() => PersistenceGuard.EnforceBeforeLoad());
+        Assert.NotNull(ex.TrialDaysElapsed);
+        Assert.True(ex.TrialDaysElapsed >= 30);
+    }
+
+    [Fact]
+    public void InternalOperation_SuppressesEnforcement()
+    {
+        // Force trial expiration so a top-level call would throw.
+        // The InternalOperation scope must suppress the throw and the
+        // counter must NOT tick for the suppressed call.
+        using var trial = IsolatedTrial(out var path);
+        var preExhausted = new TrialState
+        {
+            StartedAt = DateTimeOffset.UtcNow,
+            OperationsConsumed = TrialState.DefaultMaxOperations,
+        };
+        preExhausted.Save(path);
+
+        using (PersistenceGuard.InternalOperation())
+        {
+            // No throw despite the trial being exhausted.
+            PersistenceGuard.EnforceBeforeLoad();
+            PersistenceGuard.EnforceBeforeSave();
+        }
+
+        // Counter unchanged — InternalOperation didn't tick it.
+        var state = TrialState.Load(path);
+        Assert.Equal(TrialState.DefaultMaxOperations, state.OperationsConsumed);
+
+        // Outside the scope, enforcement fires again.
+        Assert.Throws<LicenseRequiredException>(() => PersistenceGuard.EnforceBeforeLoad());
+    }
+
+    [Fact]
+    public void InternalOperation_Nested_OnlyOutermostReEnables()
+    {
+        using var trial = IsolatedTrial(out var path);
+        var preExhausted = new TrialState
+        {
+            StartedAt = DateTimeOffset.UtcNow,
+            OperationsConsumed = TrialState.DefaultMaxOperations,
+        };
+        preExhausted.Save(path);
+
+        using (PersistenceGuard.InternalOperation())
+        {
+            using (PersistenceGuard.InternalOperation())
+            {
+                PersistenceGuard.EnforceBeforeLoad(); // suppressed
+            }
+            // Still inside the outer scope — still suppressed.
+            PersistenceGuard.EnforceBeforeLoad();
+        }
+        // Outermost disposed → enforcement re-enabled.
+        Assert.Throws<LicenseRequiredException>(() => PersistenceGuard.EnforceBeforeLoad());
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task InternalOperation_FlowsAcrossAwait()
+    {
+        // AsyncLocal must carry the suppression across an await boundary
+        // so a continuation on a different thread-pool thread still sees
+        // the scope.
+        using var trial = IsolatedTrial(out var path);
+        var preExhausted = new TrialState
+        {
+            StartedAt = DateTimeOffset.UtcNow,
+            OperationsConsumed = TrialState.DefaultMaxOperations,
+        };
+        preExhausted.Save(path);
+
+        using (PersistenceGuard.InternalOperation())
+        {
+            await System.Threading.Tasks.Task.Yield();
+            // Same logical context after the yield — must still be suppressed.
+            PersistenceGuard.EnforceBeforeLoad();
+        }
+    }
+
+    [Fact]
+    public void GgufReader_Read_FiresEnforcement()
+    {
+        // End-to-end: GgufReader.Read calls into the guard. Trial
+        // exhausted → reading throws LicenseRequiredException
+        // BEFORE the stream is consumed, so a corrupt-stream-vs-
+        // license-error test ordering can't mask the gate.
+        using var trial = IsolatedTrial(out var path);
+        var preExhausted = new TrialState
+        {
+            StartedAt = DateTimeOffset.UtcNow,
+            OperationsConsumed = TrialState.DefaultMaxOperations,
+        };
+        preExhausted.Save(path);
+
+        using var ms = new MemoryStream(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF });
+        Assert.Throws<LicenseRequiredException>(() => GgufReader.Read(ms));
+    }
+
+    [Fact]
+    public void SetActiveLicenseKey_ScopeRestoresPriorKey()
+    {
+        var inner = new AiDotNetTensorsLicenseKey("aidn.test.scope.AAAAAAAA");
+        using (PersistenceGuard.SetActiveLicenseKey(inner))
+        {
+            // Inner key active.
+            // We can't easily verify externally without a server stub,
+            // but the scope-restore semantic is the contract under test.
+        }
+        // After dispose, the previous (null) key is restored — a fresh
+        // EnforceBeforeLoad should now hit the trial path.
+        using var trial = IsolatedTrial(out _);
+        PersistenceGuard.EnforceBeforeLoad();  // no exception, trial allowed
+    }
+
+    [Fact]
+    public void Capabilities_TensorsLoad_AcceptedBy_HasCapability()
+    {
+        // Direct test of the capability convention — server returns
+        // "tensors:load" and "tensors:save" for a Tensors-tier key.
+        var result = new LicenseValidationResult(
+            LicenseKeyStatus.Active,
+            tier: "tensors-only",
+            expiresAt: null,
+            validatedAt: DateTimeOffset.UtcNow,
+            message: null,
+            capabilities: new[] { "tensors:save", "tensors:load" });
+        Assert.True(result.HasCapability("tensors:save"));
+        Assert.True(result.HasCapability("tensors:load"));
+        Assert.False(result.HasCapability("model:save"));
+    }
+
+    [Fact]
+    public void LicenseValidator_KeyFormatValidation()
+    {
+        // Signed format
+        Assert.True(LicenseValidator.ValidateKeyFormat("aidn.abc123.def456"));
+        // Server-validated format (4+ segments, hex tail >= 8 chars)
+        Assert.True(LicenseValidator.ValidateKeyFormat("AIDN-FOO-BAR-deadbeef12"));
+        // Garbage
+        Assert.False(LicenseValidator.ValidateKeyFormat("not-a-valid-key"));
+        Assert.False(LicenseValidator.ValidateKeyFormat(""));
+        Assert.False(LicenseValidator.ValidateKeyFormat("aidn..."));  // empty id+sig
+    }
+
+    [Fact]
+    public void LicenseValidator_ParseResponse_HandlesActiveWithCapabilities()
+    {
+        string json = """
+        {
+          "status": "active",
+          "tier": "pro",
+          "capabilities": ["tensors:save", "tensors:load", "model:save", "model:load"],
+          "message": "OK"
+        }
+        """;
+        var r = LicenseValidator.ParseResponse(json, 200);
+        Assert.Equal(LicenseKeyStatus.Active, r.Status);
+        Assert.Equal("pro", r.Tier);
+        Assert.True(r.HasCapability("tensors:save"));
+        Assert.True(r.HasCapability("model:save"));
+    }
+
+    [Fact]
+    public void LicenseValidator_ParseResponse_HandlesNon2xx()
+    {
+        var r = LicenseValidator.ParseResponse("{}", 500);
+        Assert.Equal(LicenseKeyStatus.Invalid, r.Status);
+        Assert.Contains("HTTP 500", r.Message);
+    }
+
+    [Fact]
+    public void LicenseValidator_ParseResponse_HandlesMalformedJson()
+    {
+        var r = LicenseValidator.ParseResponse("not json", 200);
+        Assert.Equal(LicenseKeyStatus.Invalid, r.Status);
+    }
+}
+
+/// <summary>
+/// xUnit test collection — forces all tests in
+/// <see cref="PersistenceGuardTests"/> to run sequentially. Each test
+/// configures process-wide AsyncLocal / static state, and parallel
+/// execution would interleave overrides and produce flaky failures.
+/// </summary>
+[CollectionDefinition("PersistenceGuard", DisableParallelization = true)]
+public class PersistenceGuardCollection { }


### PR DESCRIPTION
## Summary

Adds a license-enforcement boundary inside `AiDotNet.Tensors` so public read/write entry points (`GgufReader.Read` today; `SafetensorsReader/Writer`, pickle `.pt`, sharded checkpoints under #218) require either a valid license OR an unexpired free-trial budget.

Per the user-confirmed design — **one license key, server-returned capabilities** — the same `aidn.{id}.{sig}` / `AIDN-*-{hex}` key string used by upstream `AiDotNet` works here. The validator sends `package=AiDotNet.Tensors` so the server attaches the right per-tier capability set (`tensors:save`, `tensors:load`, `model:save`, `model:load`); the guard accepts the key when its capability list includes the operation being attempted.

## What lands

### Licensing infrastructure (`src/AiDotNet.Tensors/Licensing/`)

- **`AiDotNetTensorsLicenseKey`** — same shape as upstream's `AiDotNetLicenseKey` so a single user key flows into both layers field-by-field at `AiModelBuilder.BuildAsync`.
- **`LicenseValidator`** — HTTP client hitting the same Supabase Edge Function endpoint as upstream; offline grace cache; net471 + net10.0 paths.
- **`LicenseValidationResult`** — extended with a `Capabilities` set (and `HasCapability` lookup) on top of the upstream shape.
- **`LicenseKeyStatus`** — adds `CapabilityMissing` so a tier mismatch surfaces a clear error instead of generic `Invalid`.
- **`LicenseRequiredException`** — thrown on trial exhaustion or capability mismatch.
- **`TrialState`** — `~/.aidotnet/tensors-trial.json` fallback (50 ops or 30 days, whichever expires first). Sibling file to upstream's `trial.json` so the two budgets are independent.
- **`PersistenceGuard`** — central gate:
  - `EnforceBeforeSave/Load/Serialize/Deserialize` — call from every public read/write entry.
  - `InternalOperation()` — upstream wraps its enforcement to suppress double-counting in the tensor layer (counter goes once per user-facing op, not twice).
  - `SetActiveLicenseKey()` — upstream flows its key in at builder init.
  - `AsyncLocal`-backed state so awaits inside guarded scopes don't drop the suppression.
  - Env var `AIDOTNET_LICENSE_KEY` and file `~/.aidotnet/license.key` resolution paths (same names upstream uses — set once, both packages see it).

### Wiring

- `GgufReader.Read` calls `PersistenceGuard.EnforceBeforeLoad()` as the first line. Existing 6 `GgufReaderTests` still pass under the fresh trial budget.

## Test plan

- [x] `PersistenceGuardTests` — 14 new tests:
  - Trial allows fresh; persists across calls; throws on op-count cap; throws on day cap.
  - `InternalOperation` suppresses; nests correctly; flows across `await`.
  - `GgufReader.Read` end-to-end gated.
  - `SetActiveLicenseKey` scope-restore semantics.
  - Capability check (active+capability accepted; active+missing rejected).
  - `LicenseValidator` key-format gates and `ParseResponse` for active / non-2xx / malformed JSON.
- [x] All 6 existing `GgufReaderTests` pass under the new gate (trial budget covers the test calls).
- [x] Full regression — 257/260 tensor + autograd tests pass on net10.0 (3 skipped require CUDA).

## Coordinated rollout

This PR's enforcement only fires fully once the licensing server returns the new `capabilities` field. Upstream changes filed as **ooples/AiDotNet#1195**:

1. **Server** rolls out first (additive — old clients ignore the new fields).
2. **Upstream `AiDotNet`** adds `package=AiDotNet` validator tag, flows the key into `PersistenceGuard.SetActiveLicenseKey`, wraps its tensor-format calls in `PersistenceGuard.InternalOperation()`.
3. **This PR** merges last — until #1195's server change is live, real keys would be rejected by the tensor guard. Trial-fallback users (`~/.aidotnet/tensors-trial.json`) work in any order.

## References

- Tracking issue: ooples/AiDotNet#1195 (server + upstream wiring).
- Design discussion: PR #250 conversation (one-key + capability-scopes + same-branch rollout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
