### PR TITLE
feat(#213): torch.distributions parity surface

### DIFF
--- a/src/AiDotNet.Tensors/Distributions/AdditionalContinuousDistributions.cs
+++ b/src/AiDotNet.Tensors/Distributions/AdditionalContinuousDistributions.cs
@@ -1,0 +1,718 @@
+using System;
+using AiDotNet.Tensors.Distributions.Constraints;
+using AiDotNet.Tensors.Distributions.Helpers;
+
+namespace AiDotNet.Tensors.Distributions;
+
+/// <summary>
+/// Fisher-Snedecor (F) distribution: ratio of two scaled chi-squared variables.
+/// X ∼ F(d1, d2) is equivalent to X = (U/d1)/(V/d2) where U ∼ Chi²(d1), V ∼ Chi²(d2).
+/// </summary>
+public sealed class FisherSnedecorDistribution : DistributionBase
+{
+    /// <summary>Numerator degrees of freedom.</summary>
+    public float[] Df1 { get; }
+    /// <summary>Denominator degrees of freedom.</summary>
+    public float[] Df2 { get; }
+    /// <inheritdoc />
+    public override int BatchSize => Df1.Length;
+    /// <inheritdoc />
+    public override int EventSize => 1;
+    /// <inheritdoc />
+    public override IConstraint Support => PositiveConstraint.Instance;
+    /// <inheritdoc />
+    public override bool HasRSample => true;
+
+    /// <summary>Build an F distribution from per-batch (df1, df2).</summary>
+    public FisherSnedecorDistribution(float[] df1, float[] df2)
+    {
+        if (df1.Length != df2.Length) throw new ArgumentException();
+        for (int i = 0; i < df1.Length; i++)
+        {
+            if (!(df1[i] > 0f)) throw new ArgumentException("df1 > 0.");
+            if (!(df2[i] > 0f)) throw new ArgumentException("df2 > 0.");
+        }
+        Df1 = df1; Df2 = df2;
+    }
+
+    /// <inheritdoc />
+    public override float[] Sample(Random rng) => RSample(rng);
+
+    /// <inheritdoc />
+    public override float[] RSample(Random rng)
+    {
+        var x = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            float u = 2f * GammaDistribution.MarsagliaTsang(rng, Df1[i] * 0.5f);  // Chi²(df1)
+            float v = 2f * GammaDistribution.MarsagliaTsang(rng, Df2[i] * 0.5f);  // Chi²(df2)
+            x[i] = (u / Df1[i]) / (v / Df2[i]);
+        }
+        return x;
+    }
+
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        var lp = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            if (value[i] <= 0) { lp[i] = float.NegativeInfinity; continue; }
+            float d1 = Df1[i], d2 = Df2[i], v = value[i];
+            float logZ = SpecialFunctions.Lgamma((d1 + d2) * 0.5f)
+                       - SpecialFunctions.Lgamma(d1 * 0.5f)
+                       - SpecialFunctions.Lgamma(d2 * 0.5f)
+                       + (d1 * 0.5f) * MathF.Log(d1)
+                       + (d2 * 0.5f) * MathF.Log(d2);
+            lp[i] = logZ + (d1 * 0.5f - 1f) * MathF.Log(v)
+                  - ((d1 + d2) * 0.5f) * MathF.Log(d1 * v + d2);
+        }
+        return lp;
+    }
+
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        var h = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++) h[i] = float.NaN;
+        return h;
+    }
+
+    /// <inheritdoc />
+    public override float[] Mean
+    {
+        get
+        {
+            var m = new float[BatchSize];
+            for (int i = 0; i < BatchSize; i++)
+                m[i] = Df2[i] > 2f ? Df2[i] / (Df2[i] - 2f) : float.PositiveInfinity;
+            return m;
+        }
+    }
+
+    /// <inheritdoc />
+    public override float[] Variance
+    {
+        get
+        {
+            var v = new float[BatchSize];
+            for (int i = 0; i < BatchSize; i++)
+            {
+                float d1 = Df1[i], d2 = Df2[i];
+                if (d2 <= 4f) { v[i] = float.PositiveInfinity; continue; }
+                v[i] = 2f * d2 * d2 * (d1 + d2 - 2f) / (d1 * (d2 - 2f) * (d2 - 2f) * (d2 - 4f));
+            }
+            return v;
+        }
+    }
+}
+
+/// <summary>
+/// Kumaraswamy distribution on (0, 1). f(x) = a·b·x^(a-1) · (1 - x^a)^(b-1).
+/// Cousin of Beta with closed-form CDF and inverse CDF — the latter making sampling
+/// reparameterisable in closed form (no Gamma rejection needed).
+/// </summary>
+public sealed class KumaraswamyDistribution : DistributionBase
+{
+    /// <summary>Concentration α &gt; 0.</summary>
+    public float[] Concentration1 { get; }
+    /// <summary>Concentration β &gt; 0.</summary>
+    public float[] Concentration0 { get; }
+    /// <inheritdoc />
+    public override int BatchSize => Concentration1.Length;
+    /// <inheritdoc />
+    public override int EventSize => 1;
+    /// <inheritdoc />
+    public override IConstraint Support => UnitIntervalConstraint.Instance;
+    /// <inheritdoc />
+    public override bool HasRSample => true;
+
+    /// <summary>Build a Kumaraswamy from per-batch (a, b).</summary>
+    public KumaraswamyDistribution(float[] concentration1, float[] concentration0)
+    {
+        if (concentration1.Length != concentration0.Length) throw new ArgumentException();
+        for (int i = 0; i < concentration1.Length; i++)
+        {
+            if (!(concentration1[i] > 0f)) throw new ArgumentException("α > 0.");
+            if (!(concentration0[i] > 0f)) throw new ArgumentException("β > 0.");
+        }
+        Concentration1 = concentration1; Concentration0 = concentration0;
+    }
+
+    /// <inheritdoc />
+    public override float[] Sample(Random rng) => RSample(rng);
+
+    /// <inheritdoc />
+    public override float[] RSample(Random rng)
+    {
+        // Closed-form ICDF: x = (1 - (1 - u)^(1/b))^(1/a).
+        var x = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            double u = rng.NextDouble();
+            if (u < 1e-12) u = 1e-12; if (u > 1 - 1e-12) u = 1 - 1e-12;
+            x[i] = MathF.Pow(1f - MathF.Pow(1f - (float)u, 1f / Concentration0[i]), 1f / Concentration1[i]);
+        }
+        return x;
+    }
+
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        var lp = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            float v = value[i];
+            if (v <= 0f || v >= 1f) { lp[i] = float.NegativeInfinity; continue; }
+            float a = Concentration1[i], b = Concentration0[i];
+            lp[i] = MathF.Log(a) + MathF.Log(b)
+                  + (a - 1f) * MathF.Log(v)
+                  + (b - 1f) * MathF.Log(1f - MathF.Pow(v, a));
+        }
+        return lp;
+    }
+
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        // Closed-form: H = (1 - 1/b) + (1 - 1/a)·H_b - log(a·b), where H_b is the b-th harmonic-like.
+        // We use Kumaraswamy's analytical form (Jones, 2009): see arXiv 1005.0287.
+        var h = new float[BatchSize];
+        const float EulerMascheroni = 0.5772156649f;
+        for (int i = 0; i < BatchSize; i++)
+        {
+            float a = Concentration1[i], b = Concentration0[i];
+            // H = (1 − 1/b) + (1 − 1/a)·(ψ(b+1) − ψ(1)) − log(a·b)
+            float hb = SpecialFunctions.Digamma(b + 1f) + EulerMascheroni;  // ψ(b+1) − ψ(1)
+            h[i] = (1f - 1f / b) + (1f - 1f / a) * hb - MathF.Log(a * b);
+        }
+        return h;
+    }
+
+    /// <inheritdoc />
+    public override float[] Mean
+    {
+        get
+        {
+            var m = new float[BatchSize];
+            for (int i = 0; i < BatchSize; i++)
+            {
+                float a = Concentration1[i], b = Concentration0[i];
+                m[i] = b * MathF.Exp(SpecialFunctions.LogBeta(1f + 1f / a, b));
+            }
+            return m;
+        }
+    }
+
+    /// <inheritdoc />
+    public override float[] Variance
+    {
+        get
+        {
+            var v = new float[BatchSize];
+            for (int i = 0; i < BatchSize; i++)
+            {
+                float a = Concentration1[i], b = Concentration0[i];
+                float m1 = b * MathF.Exp(SpecialFunctions.LogBeta(1f + 1f / a, b));
+                float m2 = b * MathF.Exp(SpecialFunctions.LogBeta(1f + 2f / a, b));
+                v[i] = m2 - m1 * m1;
+            }
+            return v;
+        }
+    }
+
+    /// <inheritdoc />
+    public override float[] Cdf(float[] value)
+    {
+        EnsureValueShape(value);
+        var c = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            float v = value[i];
+            if (v <= 0f) { c[i] = 0f; continue; }
+            if (v >= 1f) { c[i] = 1f; continue; }
+            c[i] = 1f - MathF.Pow(1f - MathF.Pow(v, Concentration1[i]), Concentration0[i]);
+        }
+        return c;
+    }
+
+    /// <inheritdoc />
+    public override float[] Icdf(float[] probability)
+    {
+        EnsureValueShape(probability);
+        var x = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+            x[i] = MathF.Pow(1f - MathF.Pow(1f - probability[i], 1f / Concentration0[i]), 1f / Concentration1[i]);
+        return x;
+    }
+}
+
+/// <summary>
+/// Von Mises distribution on (-π, π]: circular analogue of the normal distribution,
+/// f(x) = exp(κ·cos(x − μ)) / (2π·I₀(κ)).
+/// </summary>
+public sealed class VonMisesDistribution : DistributionBase
+{
+    /// <summary>Per-batch mean direction μ ∈ (-π, π].</summary>
+    public float[] Loc { get; }
+    /// <summary>Per-batch concentration κ ≥ 0.</summary>
+    public float[] Concentration { get; }
+    /// <inheritdoc />
+    public override int BatchSize => Loc.Length;
+    /// <inheritdoc />
+    public override int EventSize => 1;
+    /// <inheritdoc />
+    public override IConstraint Support => new IntervalConstraint(-MathF.PI, MathF.PI);
+
+    /// <summary>Build a von Mises from per-batch (μ, κ).</summary>
+    public VonMisesDistribution(float[] loc, float[] concentration)
+    {
+        if (loc.Length != concentration.Length) throw new ArgumentException();
+        for (int i = 0; i < concentration.Length; i++)
+            if (!(concentration[i] >= 0f)) throw new ArgumentException("κ ≥ 0.");
+        Loc = loc; Concentration = concentration;
+    }
+
+    /// <inheritdoc />
+    public override float[] Sample(Random rng)
+    {
+        // Best-Fisher rejection sampler (Best & Fisher, 1979).
+        var x = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++) x[i] = SampleOne(rng, Concentration[i], Loc[i]);
+        return x;
+    }
+
+    private static float SampleOne(Random rng, float kappa, float mu)
+    {
+        if (kappa < 1e-6f)
+            return (float)(2.0 * Math.PI * rng.NextDouble() - Math.PI);
+        double tau = 1.0 + Math.Sqrt(1.0 + 4.0 * kappa * kappa);
+        double rho = (tau - Math.Sqrt(2.0 * tau)) / (2.0 * kappa);
+        double r = (1.0 + rho * rho) / (2.0 * rho);
+        while (true)
+        {
+            double u1 = rng.NextDouble();
+            double z = Math.Cos(Math.PI * u1);
+            double f = (1.0 + r * z) / (r + z);
+            double c = kappa * (r - f);
+            double u2 = rng.NextDouble();
+            if (u2 < c * (2.0 - c) || Math.Log(c / u2) + 1.0 - c >= 0.0)
+            {
+                double sign = rng.NextDouble() < 0.5 ? -1.0 : 1.0;
+                double theta = sign * Math.Acos(f) + mu;
+                // Reduce to (-π, π].
+                theta = (theta + Math.PI) % (2.0 * Math.PI) - Math.PI;
+                return (float)theta;
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        var lp = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            float k = Concentration[i];
+            float logI0 = LogBesselI0(k);
+            lp[i] = k * MathF.Cos(value[i] - Loc[i]) - MathF.Log(2f * MathF.PI) - logI0;
+        }
+        return lp;
+    }
+
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        var h = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            float k = Concentration[i];
+            // H = log(2π·I₀(κ)) − κ·I₁(κ)/I₀(κ)
+            float logI0 = LogBesselI0(k);
+            float ratioI1I0 = BesselI1OverI0(k);
+            h[i] = MathF.Log(2f * MathF.PI) + logI0 - k * ratioI1I0;
+        }
+        return h;
+    }
+
+    /// <inheritdoc />
+    public override float[] Mean => (float[])Loc.Clone();
+
+    /// <inheritdoc />
+    public override float[] Variance
+    {
+        // Circular variance: 1 − I₁(κ)/I₀(κ).
+        get
+        {
+            var v = new float[BatchSize];
+            for (int i = 0; i < BatchSize; i++) v[i] = 1f - BesselI1OverI0(Concentration[i]);
+            return v;
+        }
+    }
+
+    /// <summary>Asymptotic + series approximation to log I₀(κ).</summary>
+    private static float LogBesselI0(float k)
+    {
+        if (k < 3.75f)
+        {
+            // Series I₀(k) = Σ (k/2)^(2n) / (n!)²
+            double term = 1.0, sum = 1.0; double half = k * 0.5;
+            for (int n = 1; n < 50; n++)
+            {
+                term *= (half * half) / (n * n);
+                sum += term;
+                if (term < sum * 1e-12) break;
+            }
+            return (float)Math.Log(sum);
+        }
+        // Asymptotic for large κ: log I₀(k) ≈ k − 0.5·log(2πk) + log(1 + 1/(8k) + ...)
+        double inv = 1.0 / k;
+        double s = 1.0 + inv / 8.0 + 9.0 * inv * inv / 128.0;
+        return (float)(k - 0.5 * Math.Log(2 * Math.PI * k) + Math.Log(s));
+    }
+
+    /// <summary>I₁(κ) / I₀(κ) using the same series + asymptotic split.</summary>
+    private static float BesselI1OverI0(float k)
+    {
+        if (k < 3.75f)
+        {
+            double t1 = 0.0, sum1 = 0.0; double half = k * 0.5;
+            double t0 = 1.0, sum0 = 1.0;
+            // I_v(k) = (k/2)^v · Σ (k/2)^(2n) / (n!·(n+v)!)
+            // We compute both series in a single pass.
+            double term0 = 1.0; double term1 = half;
+            sum0 = term0; sum1 = term1;
+            for (int n = 1; n < 50; n++)
+            {
+                term0 *= (half * half) / (n * n);
+                term1 *= (half * half) / (n * (n + 1));
+                sum0 += term0; sum1 += term1;
+                if (term0 < sum0 * 1e-12 && term1 < sum1 * 1e-12) break;
+            }
+            _ = t0; _ = t1;
+            return (float)(sum1 / sum0);
+        }
+        // Asymptotic ratio: I₁/I₀ → 1 − 1/(2k) − 1/(8k²) + ...
+        double inv = 1.0 / k;
+        return (float)(1.0 - 0.5 * inv - 0.125 * inv * inv);
+    }
+}
+
+/// <summary>
+/// Continuous Bernoulli (Loaiza-Ganem &amp; Cunningham, 2019): a continuous distribution
+/// on [0, 1] that's the natural reparameterisation for VAE pixel decoders.
+/// f(x; λ) = C(λ)·λ^x·(1-λ)^(1-x), where C(λ) = 2·atanh(1-2λ)/(1-2λ) for λ ≠ 0.5.
+/// </summary>
+public sealed class ContinuousBernoulliDistribution : DistributionBase
+{
+    /// <summary>Per-batch parameter λ ∈ (0, 1).</summary>
+    public float[] Probs { get; }
+    /// <inheritdoc />
+    public override int BatchSize => Probs.Length;
+    /// <inheritdoc />
+    public override int EventSize => 1;
+    /// <inheritdoc />
+    public override IConstraint Support => UnitIntervalConstraint.Instance;
+    /// <inheritdoc />
+    public override bool HasRSample => true;
+
+    /// <summary>Build a continuous Bernoulli from per-batch λ.</summary>
+    public ContinuousBernoulliDistribution(float[] probs)
+    {
+        for (int i = 0; i < probs.Length; i++)
+            if (!(probs[i] > 0f && probs[i] < 1f)) throw new ArgumentException("λ ∈ (0, 1).");
+        Probs = probs;
+    }
+
+    /// <inheritdoc />
+    public override float[] Sample(Random rng) => RSample(rng);
+
+    /// <inheritdoc />
+    public override float[] RSample(Random rng)
+    {
+        // Inverse-CDF sampling via the closed-form quantile from Loaiza-Ganem & Cunningham.
+        var x = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            double u = rng.NextDouble();
+            float lambda = Probs[i];
+            if (MathF.Abs(lambda - 0.5f) < 1e-4f)
+            {
+                x[i] = (float)u;  // uniform when λ ≈ 0.5
+            }
+            else
+            {
+                float numer = (float)u * (2f * lambda - 1f) + (1f - lambda);
+                float denom = 1f - lambda;
+                x[i] = MathF.Log(numer / denom) / MathF.Log(lambda / (1f - lambda));
+            }
+        }
+        return x;
+    }
+
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        var lp = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            float v = value[i];
+            if (v < 0f || v > 1f) { lp[i] = float.NegativeInfinity; continue; }
+            float lambda = Probs[i];
+            lp[i] = v * MathF.Log(lambda) + (1f - v) * MathF.Log(1f - lambda) + LogNormalizer(lambda);
+        }
+        return lp;
+    }
+
+    /// <summary>log C(λ) — the log of the normalising constant.</summary>
+    private static float LogNormalizer(float lambda)
+    {
+        // Numerically stable form: when λ ≈ 0.5, expand around 0 to avoid 0/0.
+        float diff = 1f - 2f * lambda;
+        if (MathF.Abs(diff) < 1e-3f) return MathF.Log(2f);
+        return MathF.Log(2f * MathF.Atanh(diff)) - MathF.Log(diff);
+    }
+
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        var h = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            float lambda = Probs[i];
+            float m = MeanOf(lambda);
+            h[i] = -m * MathF.Log(lambda) - (1f - m) * MathF.Log(1f - lambda) - LogNormalizer(lambda);
+        }
+        return h;
+    }
+
+    /// <inheritdoc />
+    public override float[] Mean
+    {
+        get { var m = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) m[i] = MeanOf(Probs[i]); return m; }
+    }
+
+    private static float MeanOf(float lambda)
+    {
+        if (MathF.Abs(lambda - 0.5f) < 1e-4f) return 0.5f;
+        return lambda / (2f * lambda - 1f) + 1f / (2f * MathF.Atanh(1f - 2f * lambda));
+    }
+
+    /// <inheritdoc />
+    public override float[] Variance
+    {
+        get
+        {
+            var v = new float[BatchSize];
+            for (int i = 0; i < BatchSize; i++)
+            {
+                float lambda = Probs[i];
+                if (MathF.Abs(lambda - 0.5f) < 1e-4f) { v[i] = 1f / 12f; continue; }
+                // Closed form (Loaiza-Ganem & Cunningham eq. 8).
+                float t = 1f - 2f * lambda;
+                float t2 = 1f / (t * t);
+                float at = MathF.Atanh(t);
+                v[i] = t2 + 1f / (4f * at * at) - 1f / (t * at);
+            }
+            return v;
+        }
+    }
+}
+
+/// <summary>
+/// Low-rank multivariate normal: Σ = D + W·Wᵀ where D is diagonal and W has shape [D, K].
+/// Sampling: x = μ + sqrt(D)·z₁ + W·z₂ where z₁ ∼ N(0, I_D), z₂ ∼ N(0, I_K).
+/// log_prob uses the Sherman-Morrison-Woodbury identity for the inverse and the matrix
+/// determinant lemma for log|Σ|.
+/// </summary>
+public sealed class LowRankMultivariateNormalDistribution : DistributionBase
+{
+    /// <summary>Per-batch loc, layout <c>[batch, D]</c>.</summary>
+    public float[] Loc { get; }
+    /// <summary>Per-batch diagonal of <c>D</c> (length D per batch element). Must be &gt; 0.</summary>
+    public float[] CovDiag { get; }
+    /// <summary>Per-batch W matrix, layout <c>[batch, D, K]</c>.</summary>
+    public float[] CovFactor { get; }
+    /// <summary>Event dimension D.</summary>
+    public int D { get; }
+    /// <summary>Low-rank dimension K.</summary>
+    public int K { get; }
+    /// <inheritdoc />
+    public override int BatchSize => Loc.Length / D;
+    /// <inheritdoc />
+    public override int EventSize => D;
+    /// <inheritdoc />
+    public override IConstraint Support => RealConstraint.Instance;
+    /// <inheritdoc />
+    public override bool HasRSample => true;
+
+    /// <summary>Build a low-rank MVN from loc, diag(D), and W.</summary>
+    public LowRankMultivariateNormalDistribution(float[] loc, float[] covDiag, float[] covFactor, int d, int k)
+    {
+        if (d <= 0 || k <= 0) throw new ArgumentException();
+        if (loc.Length % d != 0) throw new ArgumentException();
+        int batch = loc.Length / d;
+        if (covDiag.Length != batch * d) throw new ArgumentException();
+        if (covFactor.Length != batch * d * k) throw new ArgumentException();
+        for (int i = 0; i < covDiag.Length; i++) if (!(covDiag[i] > 0f)) throw new ArgumentException("covDiag > 0.");
+        Loc = loc; CovDiag = covDiag; CovFactor = covFactor; D = d; K = k;
+    }
+
+    /// <inheritdoc />
+    public override float[] Sample(Random rng) => RSample(rng);
+
+    /// <inheritdoc />
+    public override float[] RSample(Random rng)
+    {
+        int batch = BatchSize;
+        var x = new float[batch * D];
+        var z2 = new float[K];
+        for (int b = 0; b < batch; b++)
+        {
+            for (int k = 0; k < K; k++) z2[k] = (float)NormalDistribution.Gaussian(rng);
+            for (int i = 0; i < D; i++)
+            {
+                float diagPart = MathF.Sqrt(CovDiag[b * D + i]) * (float)NormalDistribution.Gaussian(rng);
+                float lowRankPart = 0f;
+                for (int k = 0; k < K; k++) lowRankPart += CovFactor[b * D * K + i * K + k] * z2[k];
+                x[b * D + i] = Loc[b * D + i] + diagPart + lowRankPart;
+            }
+        }
+        return x;
+    }
+
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        int batch = BatchSize;
+        var lp = new float[batch];
+        const float HalfLog2Pi = 0.91893853321f;
+        // Σ⁻¹ = D⁻¹ − D⁻¹·W·(I_K + Wᵀ·D⁻¹·W)⁻¹·Wᵀ·D⁻¹  (Woodbury)
+        // |Σ| = |D|·|I_K + Wᵀ·D⁻¹·W|                    (matrix determinant lemma)
+        for (int b = 0; b < batch; b++)
+        {
+            // Build M = I_K + Wᵀ·D⁻¹·W  (size K×K).
+            var M = new float[K * K];
+            for (int p = 0; p < K; p++)
+                for (int q = 0; q < K; q++)
+                {
+                    float s = 0f;
+                    for (int i = 0; i < D; i++)
+                        s += CovFactor[b * D * K + i * K + p] * CovFactor[b * D * K + i * K + q] / CovDiag[b * D + i];
+                    M[p * K + q] = (p == q ? 1f : 0f) + s;
+                }
+            // Cholesky M = L·Lᵀ.
+            var L = new float[K * K];
+            CholeskyKxK(M, L, K);
+
+            // diff = value - loc.
+            var diff = new float[D];
+            for (int i = 0; i < D; i++) diff[i] = value[b * D + i] - Loc[b * D + i];
+            // Quadratic form: diffᵀ Σ⁻¹ diff = diffᵀ D⁻¹ diff − ‖L⁻¹ Wᵀ D⁻¹ diff‖²
+            float diagQuad = 0f;
+            var rhs = new float[K];
+            for (int i = 0; i < D; i++)
+            {
+                float di = diff[i] / CovDiag[b * D + i];
+                diagQuad += diff[i] * di;
+                for (int p = 0; p < K; p++) rhs[p] += CovFactor[b * D * K + i * K + p] * di;
+            }
+            // Forward-substitute L · y = rhs.
+            var y = new float[K];
+            for (int p = 0; p < K; p++)
+            {
+                float s = rhs[p];
+                for (int q = 0; q < p; q++) s -= L[p * K + q] * y[q];
+                y[p] = s / L[p * K + p];
+            }
+            float lowRankQuad = 0f;
+            for (int p = 0; p < K; p++) lowRankQuad += y[p] * y[p];
+
+            // log|Σ| = Σ log d_i + 2 Σ log L_pp.
+            float logDet = 0f;
+            for (int i = 0; i < D; i++) logDet += MathF.Log(CovDiag[b * D + i]);
+            for (int p = 0; p < K; p++) logDet += 2f * MathF.Log(L[p * K + p]);
+
+            lp[b] = -0.5f * (diagQuad - lowRankQuad) - 0.5f * logDet - D * HalfLog2Pi;
+        }
+        return lp;
+    }
+
+    private static void CholeskyKxK(float[] src, float[] dst, int n)
+    {
+        for (int i = 0; i < n * n; i++) dst[i] = 0f;
+        for (int i = 0; i < n; i++)
+        {
+            for (int j = 0; j <= i; j++)
+            {
+                double s = src[i * n + j];
+                for (int k = 0; k < j; k++) s -= dst[i * n + k] * dst[j * n + k];
+                if (i == j)
+                {
+                    if (s <= 0) throw new ArgumentException("M = I + Wᵀ D⁻¹ W is not positive definite.");
+                    dst[i * n + i] = (float)Math.Sqrt(s);
+                }
+                else dst[i * n + j] = (float)(s / dst[j * n + j]);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        int batch = BatchSize;
+        var h = new float[batch];
+        const float HalfLog2PiE = 1.41893853321f;
+        for (int b = 0; b < batch; b++)
+        {
+            // Same logDet computation as LogProb.
+            var M = new float[K * K];
+            for (int p = 0; p < K; p++)
+                for (int q = 0; q < K; q++)
+                {
+                    float s = 0f;
+                    for (int i = 0; i < D; i++)
+                        s += CovFactor[b * D * K + i * K + p] * CovFactor[b * D * K + i * K + q] / CovDiag[b * D + i];
+                    M[p * K + q] = (p == q ? 1f : 0f) + s;
+                }
+            var L = new float[K * K];
+            CholeskyKxK(M, L, K);
+            float logDet = 0f;
+            for (int i = 0; i < D; i++) logDet += MathF.Log(CovDiag[b * D + i]);
+            for (int p = 0; p < K; p++) logDet += 2f * MathF.Log(L[p * K + p]);
+            h[b] = D * HalfLog2PiE + 0.5f * logDet;
+        }
+        return h;
+    }
+
+    /// <inheritdoc />
+    public override float[] Mean => (float[])Loc.Clone();
+
+    /// <inheritdoc />
+    public override float[] Variance
+    {
+        // Variance per dim = D_i + Σ_k W_{i,k}².
+        get
+        {
+            int batch = BatchSize;
+            var v = new float[batch * D];
+            for (int b = 0; b < batch; b++)
+                for (int i = 0; i < D; i++)
+                {
+                    float s = CovDiag[b * D + i];
+                    for (int k = 0; k < K; k++)
+                    {
+                        float w = CovFactor[b * D * K + i * K + k];
+                        s += w * w;
+                    }
+                    v[b * D + i] = s;
+                }
+            return v;
+        }
+    }
+}

--- a/src/AiDotNet.Tensors/Distributions/AdditionalContinuousDistributions.cs
+++ b/src/AiDotNet.Tensors/Distributions/AdditionalContinuousDistributions.cs
@@ -32,7 +32,7 @@ public sealed class FisherSnedecorDistribution : DistributionBase
             if (!(df1[i] > 0f)) throw new ArgumentException("df1 > 0.");
             if (!(df2[i] > 0f)) throw new ArgumentException("df2 > 0.");
         }
-        Df1 = df1; Df2 = df2;
+        Df1 = (float[])df1.Clone(); Df2 = (float[])df2.Clone();
     }
 
     /// <inheritdoc />
@@ -137,7 +137,7 @@ public sealed class KumaraswamyDistribution : DistributionBase
             if (!(concentration1[i] > 0f)) throw new ArgumentException("α > 0.");
             if (!(concentration0[i] > 0f)) throw new ArgumentException("β > 0.");
         }
-        Concentration1 = concentration1; Concentration0 = concentration0;
+        Concentration1 = (float[])concentration1.Clone(); Concentration0 = (float[])concentration0.Clone();
     }
 
     /// <inheritdoc />
@@ -272,7 +272,7 @@ public sealed class VonMisesDistribution : DistributionBase
         if (loc.Length != concentration.Length) throw new ArgumentException();
         for (int i = 0; i < concentration.Length; i++)
             if (!(concentration[i] >= 0f)) throw new ArgumentException("κ ≥ 0.");
-        Loc = loc; Concentration = concentration;
+        Loc = (float[])loc.Clone(); Concentration = (float[])concentration.Clone();
     }
 
     /// <inheritdoc />
@@ -302,9 +302,14 @@ public sealed class VonMisesDistribution : DistributionBase
             {
                 double sign = rng.NextDouble() < 0.5 ? -1.0 : 1.0;
                 double theta = sign * Math.Acos(f) + mu;
-                // Reduce to (-π, π].
-                theta = (theta + Math.PI) % (2.0 * Math.PI) - Math.PI;
-                return (float)theta;
+                // Wrap to (-π, π]. Use a *positive* modulo: `% (2π)` in C# follows
+                // the sign of the dividend, so a negative theta would yield a value
+                // outside the canonical range. Add 2π and re-mod to force positivity
+                // before the −π shift.
+                const double TwoPi = 2.0 * Math.PI;
+                double shifted = theta + Math.PI;
+                shifted = (shifted % TwoPi + TwoPi) % TwoPi;
+                return (float)(shifted - Math.PI);
             }
         }
     }
@@ -424,7 +429,7 @@ public sealed class ContinuousBernoulliDistribution : DistributionBase
     {
         for (int i = 0; i < probs.Length; i++)
             if (!(probs[i] > 0f && probs[i] < 1f)) throw new ArgumentException("λ ∈ (0, 1).");
-        Probs = probs;
+        Probs = (float[])probs.Clone();
     }
 
     /// <inheritdoc />
@@ -559,7 +564,7 @@ public sealed class LowRankMultivariateNormalDistribution : DistributionBase
         if (covDiag.Length != batch * d) throw new ArgumentException();
         if (covFactor.Length != batch * d * k) throw new ArgumentException();
         for (int i = 0; i < covDiag.Length; i++) if (!(covDiag[i] > 0f)) throw new ArgumentException("covDiag > 0.");
-        Loc = loc; CovDiag = covDiag; CovFactor = covFactor; D = d; K = k;
+        Loc = (float[])loc.Clone(); CovDiag = (float[])covDiag.Clone(); CovFactor = (float[])covFactor.Clone(); D = d; K = k;
     }
 
     /// <inheritdoc />

--- a/src/AiDotNet.Tensors/Distributions/AdditionalContinuousDistributions.cs
+++ b/src/AiDotNet.Tensors/Distributions/AdditionalContinuousDistributions.cs
@@ -165,8 +165,26 @@ public sealed class KumaraswamyDistribution : DistributionBase
         for (int i = 0; i < BatchSize; i++)
         {
             float v = value[i];
-            if (v <= 0f || v >= 1f) { lp[i] = float.NegativeInfinity; continue; }
             float a = Concentration1[i], b = Concentration0[i];
+            if (v < 0f || v > 1f) { lp[i] = float.NegativeInfinity; continue; }
+            // Boundary densities depend on (a, b) — see Kumaraswamy density form
+            // f(x) = a·b·x^(a-1)·(1-x^a)^(b-1).
+            //   v=0: x^(a-1) → +∞ when a<1, log(a·b) when a=1, 0 (so log=-∞) when a>1.
+            //   v=1: (1-x^a)^(b-1) → +∞ when b<1, log(a·b) when b=1, 0 when b>1.
+            if (v == 0f)
+            {
+                lp[i] = a < 1f ? float.PositiveInfinity
+                      : a == 1f ? MathF.Log(a) + MathF.Log(b)
+                      : float.NegativeInfinity;
+                continue;
+            }
+            if (v == 1f)
+            {
+                lp[i] = b < 1f ? float.PositiveInfinity
+                      : b == 1f ? MathF.Log(a) + MathF.Log(b)
+                      : float.NegativeInfinity;
+                continue;
+            }
             lp[i] = MathF.Log(a) + MathF.Log(b)
                   + (a - 1f) * MathF.Log(v)
                   + (b - 1f) * MathF.Log(1f - MathF.Pow(v, a));

--- a/src/AiDotNet.Tensors/Distributions/CompositeDistributions.cs
+++ b/src/AiDotNet.Tensors/Distributions/CompositeDistributions.cs
@@ -117,6 +117,19 @@ public sealed class TransformedDistribution : DistributionBase
     /// <inheritdoc />
     public override float[] LogProb(float[] value)
     {
+        // The reverse-walk-and-accumulate strategy below assumes every transform preserves
+        // event size — otherwise the LDJ array sizes change between stages and the running
+        // accumulator goes out of bounds. Reject dim-changing transforms with a clear
+        // message; users that want score functions through StickBreaking / CorrCholesky
+        // need to compose them into a custom pipeline.
+        foreach (var t in Transforms)
+        {
+            if (!t.IsDimensionPreserving)
+                throw new NotSupportedException(
+                    $"TransformedDistribution.LogProb requires every transform to be dimension-preserving; " +
+                    $"{t.GetType().Name} changes event size. Use the dimension-preserving forward score path " +
+                    "(e.g. base.Sample → transform → log_prob = base.LogProb − Σ log|det J|) instead.");
+        }
         // Walk transforms in reverse to get pre-image and accumulate log|det J|.
         float[] y = value;
         var ldj = new float[value.Length];
@@ -317,7 +330,7 @@ public sealed class RelaxedBernoulliDistribution : DistributionBase
     {
         if (logits.Length != temperature.Length) throw new ArgumentException();
         for (int i = 0; i < temperature.Length; i++) if (!(temperature[i] > 0f)) throw new ArgumentException("τ > 0.");
-        Logits = logits; Temperature = temperature;
+        Logits = (float[])logits.Clone(); Temperature = (float[])temperature.Clone();
     }
     /// <inheritdoc />
     public override float[] Sample(Random rng) => RSample(rng);
@@ -397,7 +410,7 @@ public sealed class RelaxedOneHotCategoricalDistribution : DistributionBase
         if (k <= 0) throw new ArgumentException();
         if (logits.Length != temperature.Length * k) throw new ArgumentException();
         for (int i = 0; i < temperature.Length; i++) if (!(temperature[i] > 0f)) throw new ArgumentException("τ > 0.");
-        Logits = logits; Temperature = temperature; K = k;
+        Logits = (float[])logits.Clone(); Temperature = (float[])temperature.Clone(); K = k;
     }
     /// <inheritdoc />
     public override float[] Sample(Random rng) => RSample(rng);

--- a/src/AiDotNet.Tensors/Distributions/CompositeDistributions.cs
+++ b/src/AiDotNet.Tensors/Distributions/CompositeDistributions.cs
@@ -1,0 +1,485 @@
+using System;
+using AiDotNet.Tensors.Distributions.Constraints;
+using AiDotNet.Tensors.Distributions.Helpers;
+using AiDotNet.Tensors.Distributions.Transforms;
+
+namespace AiDotNet.Tensors.Distributions;
+
+/// <summary>
+/// Wraps a base distribution and reinterprets the rightmost <c>reinterpretedBatchDims</c>
+/// of its batch shape as event dims. Mirrors <c>torch.distributions.Independent</c>: useful
+/// for treating a length-K independent normal collection as a single K-dimensional event.
+/// </summary>
+public sealed class IndependentDistribution : DistributionBase
+{
+    /// <summary>Underlying base distribution.</summary>
+    public IDistribution Base { get; }
+    /// <inheritdoc />
+    public override int BatchSize { get; }
+    /// <inheritdoc />
+    public override int EventSize { get; }
+    /// <inheritdoc />
+    public override IConstraint Support => Base.Support;
+    /// <inheritdoc />
+    public override bool HasRSample => Base.HasRSample;
+
+    /// <summary>Wrap <paramref name="@base"/> and treat its full batch as <c>newBatchSize</c> independent groups
+    /// of <c>EventSize</c>. <paramref name="@base"/>.BatchSize must equal <c>newBatchSize · newEventSize</c>.</summary>
+    public IndependentDistribution(IDistribution @base, int newBatchSize, int newEventSize)
+    {
+        Base = @base ?? throw new ArgumentNullException(nameof(@base));
+        if (newBatchSize * newEventSize != @base.BatchSize)
+            throw new ArgumentException(
+                $"newBatchSize·newEventSize ({newBatchSize * newEventSize}) must equal base.BatchSize ({@base.BatchSize}).");
+        if (@base.EventSize != 1)
+            throw new ArgumentException("Independent expects a scalar-event base distribution.");
+        BatchSize = newBatchSize;
+        EventSize = newEventSize;
+    }
+
+    /// <inheritdoc />
+    public override float[] Sample(Random rng) => Base.Sample(rng);
+    /// <inheritdoc />
+    public override float[] RSample(Random rng) => Base.RSample(rng);
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        // Base.LogProb expects [base.BatchSize] = [BatchSize · EventSize] values.
+        var lpFlat = Base.LogProb(value);
+        var lp = new float[BatchSize];
+        for (int b = 0; b < BatchSize; b++)
+        {
+            float acc = 0f;
+            for (int e = 0; e < EventSize; e++) acc += lpFlat[b * EventSize + e];
+            lp[b] = acc;
+        }
+        return lp;
+    }
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        var hFlat = Base.Entropy();
+        var h = new float[BatchSize];
+        for (int b = 0; b < BatchSize; b++)
+        {
+            float acc = 0f;
+            for (int e = 0; e < EventSize; e++) acc += hFlat[b * EventSize + e];
+            h[b] = acc;
+        }
+        return h;
+    }
+    /// <inheritdoc />
+    public override float[] Mean => Base.Mean;
+    /// <inheritdoc />
+    public override float[] Variance => Base.Variance;
+}
+
+/// <summary>
+/// Push a base distribution through a chain of <see cref="ITransform"/> operations.
+/// Sample = transform(base.Sample); log_prob = base.log_prob(inverse(y)) − Σ log|det J|.
+/// </summary>
+public sealed class TransformedDistribution : DistributionBase
+{
+    /// <summary>Base distribution.</summary>
+    public IDistribution Base { get; }
+    /// <summary>Transforms applied left-to-right.</summary>
+    public ITransform[] Transforms { get; }
+    /// <inheritdoc />
+    public override int BatchSize => Base.BatchSize;
+    /// <inheritdoc />
+    public override int EventSize => Base.EventSize;
+    /// <inheritdoc />
+    public override IConstraint Support => Transforms.Length == 0 ? Base.Support : Transforms[Transforms.Length - 1].Codomain;
+    /// <inheritdoc />
+    public override bool HasRSample => Base.HasRSample;
+
+    /// <summary>Build a transformed distribution.</summary>
+    public TransformedDistribution(IDistribution baseDist, params ITransform[] transforms)
+    {
+        Base = baseDist ?? throw new ArgumentNullException(nameof(baseDist));
+        Transforms = transforms ?? Array.Empty<ITransform>();
+    }
+    /// <inheritdoc />
+    public override float[] Sample(Random rng)
+    {
+        var x = Base.Sample(rng);
+        foreach (var t in Transforms) x = t.Forward(x);
+        return x;
+    }
+    /// <inheritdoc />
+    public override float[] RSample(Random rng)
+    {
+        var x = Base.RSample(rng);
+        foreach (var t in Transforms) x = t.Forward(x);
+        return x;
+    }
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        // Walk transforms in reverse to get pre-image and accumulate log|det J|.
+        float[] y = value;
+        var ldj = new float[value.Length];
+        for (int i = Transforms.Length - 1; i >= 0; i--)
+        {
+            var x = Transforms[i].Inverse(y);
+            var d = Transforms[i].LogAbsDetJacobian(x, y);
+            for (int j = 0; j < ldj.Length; j++) ldj[j] += d[j];
+            y = x;
+        }
+        var baseLp = Base.LogProb(y);
+        // Reduce ldj across event dims (they currently match value shape).
+        var lp = new float[BatchSize];
+        for (int b = 0; b < BatchSize; b++)
+        {
+            float acc = baseLp[b];
+            for (int e = 0; e < EventSize; e++) acc -= ldj[b * EventSize + e];
+            lp[b] = acc;
+        }
+        return lp;
+    }
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        // Closed form only for constant-Jacobian transforms; otherwise leave NaN.
+        bool constant = true; foreach (var t in Transforms) if (!t.ConstantJacobian) { constant = false; break; }
+        if (!constant)
+        {
+            var nan = new float[BatchSize];
+            for (int i = 0; i < nan.Length; i++) nan[i] = float.NaN;
+            return nan;
+        }
+        var h = Base.Entropy();
+        // Probe a length-(B·E) zero-vector through each transform to extract its constant log|det J|.
+        var probe = new float[BatchSize * EventSize];
+        var lj = new float[probe.Length];
+        var x = probe;
+        foreach (var t in Transforms)
+        {
+            var y = t.Forward(x);
+            var d = t.LogAbsDetJacobian(x, y);
+            for (int i = 0; i < lj.Length; i++) lj[i] += d[i];
+            x = y;
+        }
+        var hOut = new float[BatchSize];
+        for (int b = 0; b < BatchSize; b++)
+        {
+            float acc = h[b];
+            for (int e = 0; e < EventSize; e++) acc += lj[b * EventSize + e];
+            hOut[b] = acc;
+        }
+        return hOut;
+    }
+    /// <inheritdoc />
+    public override float[] Mean
+    {
+        get
+        {
+            // Push base mean through transforms — only exact for affine but a useful default.
+            var m = Base.Mean;
+            foreach (var t in Transforms) m = t.Forward(m);
+            return m;
+        }
+    }
+    /// <inheritdoc />
+    public override float[] Variance
+    {
+        // No general closed form. Return NaN; users compute MC estimates.
+        get { var v = new float[BatchSize * EventSize]; for (int i = 0; i < v.Length; i++) v[i] = float.NaN; return v; }
+    }
+}
+
+/// <summary>
+/// Mixture of <c>K</c> distributions of the same family (e.g. Gaussian Mixture Model).
+/// Sampling: draw a component index from <see cref="Mixing"/>, then sample from that component.
+/// LogProb: log Σ_k π_k · p_k(x).
+/// </summary>
+public sealed class MixtureSameFamilyDistribution : DistributionBase
+{
+    /// <summary>Mixing categorical: probability of each component, layout <c>[batch, K]</c>.</summary>
+    public CategoricalDistribution Mixing { get; }
+    /// <summary>Component distribution; its batch shape is <c>[batch · K]</c>, scalar event.</summary>
+    public IDistribution Component { get; }
+    /// <inheritdoc />
+    public override int BatchSize => Mixing.BatchSize;
+    /// <inheritdoc />
+    public override int EventSize => Component.EventSize;
+    /// <inheritdoc />
+    public override IConstraint Support => Component.Support;
+
+    /// <summary>Build a mixture from a categorical mixing distribution and a component distribution
+    /// whose batch shape equals <c>Mixing.BatchSize · Mixing.K</c>.</summary>
+    public MixtureSameFamilyDistribution(CategoricalDistribution mixing, IDistribution component)
+    {
+        Mixing = mixing; Component = component;
+        if (component.BatchSize != mixing.BatchSize * mixing.K)
+            throw new ArgumentException(
+                $"component.BatchSize ({component.BatchSize}) must equal mixing.BatchSize · K ({mixing.BatchSize * mixing.K}).");
+    }
+    /// <inheritdoc />
+    public override float[] Sample(Random rng)
+    {
+        int K = Mixing.K;
+        var idx = Mixing.Sample(rng);
+        var compSamples = Component.Sample(rng);
+        // Pick per-batch the sample from chosen component.
+        var x = new float[BatchSize * EventSize];
+        for (int b = 0; b < BatchSize; b++)
+        {
+            int chosen = (int)idx[b];
+            for (int e = 0; e < EventSize; e++)
+                x[b * EventSize + e] = compSamples[(b * K + chosen) * EventSize + e];
+        }
+        return x;
+    }
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        int K = Mixing.K;
+        // Broadcast value to all components: shape [batch · K, event].
+        var broad = new float[BatchSize * K * EventSize];
+        for (int b = 0; b < BatchSize; b++)
+            for (int k = 0; k < K; k++)
+                for (int e = 0; e < EventSize; e++)
+                    broad[(b * K + k) * EventSize + e] = value[b * EventSize + e];
+        var compLp = Component.LogProb(broad); // length [batch · K]
+        var lp = new float[BatchSize];
+        for (int b = 0; b < BatchSize; b++)
+        {
+            // log Σ exp(log π_k + log p_k(x)) — numerically stable via log-sum-exp.
+            float maxV = float.NegativeInfinity;
+            for (int k = 0; k < K; k++)
+            {
+                float t = MathF.Log(MathF.Max(Mixing.Probs[b * K + k], 1e-30f)) + compLp[b * K + k];
+                if (t > maxV) maxV = t;
+            }
+            double s = 0;
+            for (int k = 0; k < K; k++)
+            {
+                float t = MathF.Log(MathF.Max(Mixing.Probs[b * K + k], 1e-30f)) + compLp[b * K + k];
+                s += Math.Exp(t - maxV);
+            }
+            lp[b] = (float)(maxV + Math.Log(s));
+        }
+        return lp;
+    }
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        var h = new float[BatchSize];
+        for (int i = 0; i < h.Length; i++) h[i] = float.NaN; // mixtures: no closed form
+        return h;
+    }
+    /// <inheritdoc />
+    public override float[] Mean
+    {
+        get
+        {
+            int K = Mixing.K;
+            var m = new float[BatchSize * EventSize];
+            var cm = Component.Mean;
+            for (int b = 0; b < BatchSize; b++)
+                for (int e = 0; e < EventSize; e++)
+                {
+                    float acc = 0f;
+                    for (int k = 0; k < K; k++)
+                        acc += Mixing.Probs[b * K + k] * cm[(b * K + k) * EventSize + e];
+                    m[b * EventSize + e] = acc;
+                }
+            return m;
+        }
+    }
+    /// <inheritdoc />
+    public override float[] Variance
+    {
+        get { var v = new float[BatchSize * EventSize]; for (int i = 0; i < v.Length; i++) v[i] = float.NaN; return v; }
+    }
+}
+
+/// <summary>Relaxed (Gumbel-softmax) Bernoulli — continuous proxy for sampling Bernoulli with reparam grads.</summary>
+public sealed class RelaxedBernoulliDistribution : DistributionBase
+{
+    /// <summary>Per-batch logits (log p / (1 - p)).</summary>
+    public float[] Logits { get; }
+    /// <summary>Temperature τ &gt; 0 controlling the relaxation.</summary>
+    public float[] Temperature { get; }
+    /// <inheritdoc />
+    public override int BatchSize => Logits.Length;
+    /// <inheritdoc />
+    public override int EventSize => 1;
+    /// <inheritdoc />
+    public override IConstraint Support => UnitIntervalConstraint.Instance;
+    /// <inheritdoc />
+    public override bool HasRSample => true;
+    /// <summary>Build a relaxed Bernoulli.</summary>
+    public RelaxedBernoulliDistribution(float[] logits, float[] temperature)
+    {
+        if (logits.Length != temperature.Length) throw new ArgumentException();
+        for (int i = 0; i < temperature.Length; i++) if (!(temperature[i] > 0f)) throw new ArgumentException("τ > 0.");
+        Logits = logits; Temperature = temperature;
+    }
+    /// <inheritdoc />
+    public override float[] Sample(Random rng) => RSample(rng);
+    /// <inheritdoc />
+    public override float[] RSample(Random rng)
+    {
+        var x = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            double u = rng.NextDouble();
+            if (u < 1e-12) u = 1e-12; if (u > 1 - 1e-12) u = 1 - 1e-12;
+            float l = MathF.Log((float)u) - MathF.Log(1f - (float)u);
+            float v = (Logits[i] + l) / Temperature[i];
+            x[i] = 1f / (1f + MathF.Exp(-v));
+        }
+        return x;
+    }
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        var lp = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            float t = Temperature[i]; float y = value[i];
+            float logy = MathF.Log(y); float log1my = MathF.Log(1f - y);
+            float diff = Logits[i] - t * (logy - log1my);
+            lp[i] = MathF.Log(t) - logy - log1my + diff - 2f * Softplus(diff);
+        }
+        return lp;
+    }
+    private static float Softplus(float v) => v > 20f ? v : MathF.Log(1f + MathF.Exp(v));
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        var h = new float[BatchSize];
+        for (int i = 0; i < h.Length; i++) h[i] = float.NaN;
+        return h;
+    }
+    /// <inheritdoc />
+    public override float[] Mean
+    {
+        // Closed-form mean isn't simple; report sigmoid(logits) as a conventional placeholder.
+        get
+        {
+            var m = new float[BatchSize];
+            for (int i = 0; i < BatchSize; i++) m[i] = 1f / (1f + MathF.Exp(-Logits[i]));
+            return m;
+        }
+    }
+    /// <inheritdoc />
+    public override float[] Variance
+    { get { var v = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) v[i] = float.NaN; return v; } }
+}
+
+/// <summary>Relaxed One-Hot Categorical (Gumbel-softmax). Reparameterisable continuous proxy
+/// for categorical sampling.</summary>
+public sealed class RelaxedOneHotCategoricalDistribution : DistributionBase
+{
+    /// <summary>Per-batch logits over K categories. Layout <c>[batch, K]</c>.</summary>
+    public float[] Logits { get; }
+    /// <summary>Per-batch temperature.</summary>
+    public float[] Temperature { get; }
+    /// <summary>Number of categories.</summary>
+    public int K { get; }
+    /// <inheritdoc />
+    public override int BatchSize => Temperature.Length;
+    /// <inheritdoc />
+    public override int EventSize => K;
+    /// <inheritdoc />
+    public override IConstraint Support => new SimplexConstraint(K);
+    /// <inheritdoc />
+    public override bool HasRSample => true;
+    /// <summary>Build a relaxed one-hot categorical.</summary>
+    public RelaxedOneHotCategoricalDistribution(float[] logits, float[] temperature, int k)
+    {
+        if (k <= 0) throw new ArgumentException();
+        if (logits.Length != temperature.Length * k) throw new ArgumentException();
+        for (int i = 0; i < temperature.Length; i++) if (!(temperature[i] > 0f)) throw new ArgumentException("τ > 0.");
+        Logits = logits; Temperature = temperature; K = k;
+    }
+    /// <inheritdoc />
+    public override float[] Sample(Random rng) => RSample(rng);
+    /// <inheritdoc />
+    public override float[] RSample(Random rng)
+    {
+        int batch = BatchSize;
+        var x = new float[batch * K];
+        for (int b = 0; b < batch; b++)
+        {
+            // y_k = softmax((logits + g) / τ) where g ∼ Gumbel(0, 1).
+            float maxV = float.NegativeInfinity;
+            for (int i = 0; i < K; i++)
+            {
+                double u = rng.NextDouble();
+                if (u < 1e-12) u = 1e-12;
+                float g = -MathF.Log(-MathF.Log((float)u));
+                float v = (Logits[b * K + i] + g) / Temperature[b];
+                x[b * K + i] = v;
+                if (v > maxV) maxV = v;
+            }
+            double s = 0;
+            for (int i = 0; i < K; i++) { x[b * K + i] = MathF.Exp(x[b * K + i] - maxV); s += x[b * K + i]; }
+            for (int i = 0; i < K; i++) x[b * K + i] = (float)(x[b * K + i] / s);
+        }
+        return x;
+    }
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        var lp = new float[BatchSize];
+        for (int b = 0; b < BatchSize; b++)
+        {
+            float t = Temperature[b];
+            // log Γ(K)·τ^(K-1) − K·log Σ exp((α-τ logy)) + Σ (α_k - (τ+1) log y_k) − ...
+            // We use the Maddison/Mnih/Teh formulation:
+            // log p(y) = log((K-1)!) + (K-1)·log τ + Σ(α_k − τ·log y_k) − K·log Σ exp(α_k − τ·log y_k).
+            float c = SpecialFunctions.Lgamma(K) + (K - 1) * MathF.Log(t);
+            // Compute each α_k − τ·log y_k. Use log-sum-exp for stability.
+            float maxV = float.NegativeInfinity;
+            var z = new float[K];
+            for (int i = 0; i < K; i++)
+            {
+                z[i] = Logits[b * K + i] - t * MathF.Log(MathF.Max(value[b * K + i], 1e-30f));
+                if (z[i] > maxV) maxV = z[i];
+            }
+            double sumExp = 0;
+            for (int i = 0; i < K; i++) sumExp += Math.Exp(z[i] - maxV);
+            double lse = maxV + Math.Log(sumExp);
+            double term2 = 0;
+            for (int i = 0; i < K; i++) term2 += z[i];
+            lp[b] = (float)(c + term2 - K * lse);
+        }
+        return lp;
+    }
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        var h = new float[BatchSize];
+        for (int i = 0; i < h.Length; i++) h[i] = float.NaN;
+        return h;
+    }
+    /// <inheritdoc />
+    public override float[] Mean
+    {
+        get
+        {
+            // softmax(logits) — the categorical mean of a one-hot.
+            var m = new float[BatchSize * K];
+            for (int b = 0; b < BatchSize; b++)
+            {
+                float maxV = float.NegativeInfinity;
+                for (int i = 0; i < K; i++) if (Logits[b * K + i] > maxV) maxV = Logits[b * K + i];
+                double s = 0;
+                for (int i = 0; i < K; i++) { m[b * K + i] = MathF.Exp(Logits[b * K + i] - maxV); s += m[b * K + i]; }
+                for (int i = 0; i < K; i++) m[b * K + i] = (float)(m[b * K + i] / s);
+            }
+            return m;
+        }
+    }
+    /// <inheritdoc />
+    public override float[] Variance
+    { get { var v = new float[BatchSize * K]; for (int i = 0; i < v.Length; i++) v[i] = float.NaN; return v; } }
+}

--- a/src/AiDotNet.Tensors/Distributions/Constraints/IConstraint.cs
+++ b/src/AiDotNet.Tensors/Distributions/Constraints/IConstraint.cs
@@ -150,6 +150,97 @@ public sealed class IntegerIntervalConstraint : IConstraint
     }
 }
 
+/// <summary>Non-negative integers: x ≥ 0 and x is a whole, finite number.</summary>
+public sealed class NonNegativeIntegerConstraint : IConstraint
+{
+    /// <summary>Singleton instance.</summary>
+    public static readonly NonNegativeIntegerConstraint Instance = new NonNegativeIntegerConstraint();
+    /// <inheritdoc />
+    public bool[] Check(float[] values)
+    {
+        var ok = new bool[values.Length];
+        for (int i = 0; i < values.Length; i++)
+        {
+            var v = values[i];
+            ok[i] = !float.IsNaN(v) && !float.IsInfinity(v) && v >= 0f && v == MathF.Floor(v);
+        }
+        return ok;
+    }
+}
+
+/// <summary>One-hot vector of length K: exactly one entry equals 1 and the rest equal 0.</summary>
+public sealed class OneHotConstraint : IConstraint
+{
+    /// <summary>Length of each one-hot vector.</summary>
+    public int K { get; }
+    /// <summary>Build a one-hot constraint of width K.</summary>
+    public OneHotConstraint(int k)
+    {
+        if (k <= 0) throw new ArgumentOutOfRangeException(nameof(k));
+        K = k;
+    }
+    /// <inheritdoc />
+    public bool[] Check(float[] values)
+    {
+        if (values.Length % K != 0)
+            throw new ArgumentException($"values.Length ({values.Length}) must be a multiple of K ({K}).");
+        int batch = values.Length / K;
+        var ok = new bool[batch];
+        for (int b = 0; b < batch; b++)
+        {
+            int hits = 0; bool good = true;
+            for (int i = 0; i < K; i++)
+            {
+                var v = values[b * K + i];
+                if (v == 1f) hits++;
+                else if (v != 0f) { good = false; break; }
+            }
+            ok[b] = good && hits == 1;
+        }
+        return ok;
+    }
+}
+
+/// <summary>Non-negative integer count vectors that sum to a fixed total per batch row.
+/// If <see cref="Totals"/> is null the per-row sum is unconstrained; otherwise each row's
+/// sum must equal the corresponding entry. Used by <c>MultinomialDistribution.Support</c>.</summary>
+public sealed class IntegerSimplexConstraint : IConstraint
+{
+    /// <summary>Length of each count vector.</summary>
+    public int K { get; }
+    /// <summary>Per-batch required totals (null = no sum constraint).</summary>
+    public int[]? Totals { get; }
+    /// <summary>Build an integer-simplex constraint.</summary>
+    public IntegerSimplexConstraint(int k, int[]? totals = null)
+    {
+        if (k <= 0) throw new ArgumentOutOfRangeException(nameof(k));
+        K = k; Totals = totals;
+    }
+    /// <inheritdoc />
+    public bool[] Check(float[] values)
+    {
+        if (values.Length % K != 0)
+            throw new ArgumentException($"values.Length ({values.Length}) must be a multiple of K ({K}).");
+        int batch = values.Length / K;
+        if (Totals != null && Totals.Length != batch)
+            throw new ArgumentException("Totals length must equal batch count.");
+        var ok = new bool[batch];
+        for (int b = 0; b < batch; b++)
+        {
+            long sum = 0; bool good = true;
+            for (int i = 0; i < K; i++)
+            {
+                var v = values[b * K + i];
+                if (float.IsNaN(v) || float.IsInfinity(v) || v < 0f || v != MathF.Floor(v))
+                { good = false; break; }
+                sum += (long)v;
+            }
+            ok[b] = good && (Totals == null || sum == Totals[b]);
+        }
+        return ok;
+    }
+}
+
 /// <summary>Probability simplex: x_i ≥ 0 and sum_i x_i = 1 (within tolerance).</summary>
 public sealed class SimplexConstraint : IConstraint
 {

--- a/src/AiDotNet.Tensors/Distributions/Constraints/IConstraint.cs
+++ b/src/AiDotNet.Tensors/Distributions/Constraints/IConstraint.cs
@@ -1,0 +1,186 @@
+using System;
+
+namespace AiDotNet.Tensors.Distributions.Constraints;
+
+/// <summary>
+/// A constraint describes the set of values a variable can take. Constraints are used
+/// by <see cref="IDistribution.Support"/> to advertise where a sample can land, by
+/// <see cref="Transforms.ITransform"/> to describe its <c>codomain</c>, and by validators
+/// to bounds-check user-supplied parameters.
+/// </summary>
+public interface IConstraint
+{
+    /// <summary>Returns true at indices where the constraint is satisfied.</summary>
+    bool[] Check(float[] values);
+}
+
+/// <summary>Real line: every finite value satisfies the constraint.</summary>
+public sealed class RealConstraint : IConstraint
+{
+    /// <summary>Singleton instance.</summary>
+    public static readonly RealConstraint Instance = new RealConstraint();
+    /// <inheritdoc />
+    public bool[] Check(float[] values)
+    {
+        var ok = new bool[values.Length];
+        for (int i = 0; i < values.Length; i++) ok[i] = !float.IsNaN(values[i]) && !float.IsInfinity(values[i]);
+        return ok;
+    }
+}
+
+/// <summary>Strictly positive: x &gt; 0.</summary>
+public sealed class PositiveConstraint : IConstraint
+{
+    /// <summary>Singleton instance.</summary>
+    public static readonly PositiveConstraint Instance = new PositiveConstraint();
+    /// <inheritdoc />
+    public bool[] Check(float[] values)
+    {
+        var ok = new bool[values.Length];
+        for (int i = 0; i < values.Length; i++) ok[i] = values[i] > 0f;
+        return ok;
+    }
+}
+
+/// <summary>Non-negative: x ≥ 0.</summary>
+public sealed class NonNegativeConstraint : IConstraint
+{
+    /// <summary>Singleton instance.</summary>
+    public static readonly NonNegativeConstraint Instance = new NonNegativeConstraint();
+    /// <inheritdoc />
+    public bool[] Check(float[] values)
+    {
+        var ok = new bool[values.Length];
+        for (int i = 0; i < values.Length; i++) ok[i] = values[i] >= 0f;
+        return ok;
+    }
+}
+
+/// <summary>Open unit interval: 0 &lt; x &lt; 1.</summary>
+public sealed class UnitIntervalConstraint : IConstraint
+{
+    /// <summary>Singleton instance.</summary>
+    public static readonly UnitIntervalConstraint Instance = new UnitIntervalConstraint();
+    /// <inheritdoc />
+    public bool[] Check(float[] values)
+    {
+        var ok = new bool[values.Length];
+        for (int i = 0; i < values.Length; i++) ok[i] = values[i] > 0f && values[i] < 1f;
+        return ok;
+    }
+}
+
+/// <summary>Closed interval [low, high].</summary>
+public sealed class IntervalConstraint : IConstraint
+{
+    /// <summary>Lower bound, inclusive.</summary>
+    public float Low { get; }
+    /// <summary>Upper bound, inclusive.</summary>
+    public float High { get; }
+    /// <summary>Build a closed interval constraint.</summary>
+    public IntervalConstraint(float low, float high)
+    {
+        if (high < low) throw new ArgumentException("high must be >= low.");
+        Low = low; High = high;
+    }
+    /// <inheritdoc />
+    public bool[] Check(float[] values)
+    {
+        var ok = new bool[values.Length];
+        for (int i = 0; i < values.Length; i++) ok[i] = values[i] >= Low && values[i] <= High;
+        return ok;
+    }
+}
+
+/// <summary>Half-open less-than constraint: x &lt; upper.</summary>
+public sealed class LessThanConstraint : IConstraint
+{
+    /// <summary>Strict upper bound.</summary>
+    public float Upper { get; }
+    /// <summary>Build a strict-less-than constraint.</summary>
+    public LessThanConstraint(float upper) { Upper = upper; }
+    /// <inheritdoc />
+    public bool[] Check(float[] values)
+    {
+        var ok = new bool[values.Length];
+        for (int i = 0; i < values.Length; i++) ok[i] = values[i] < Upper;
+        return ok;
+    }
+}
+
+/// <summary>Half-open greater-than constraint: x &gt; lower.</summary>
+public sealed class GreaterThanConstraint : IConstraint
+{
+    /// <summary>Strict lower bound.</summary>
+    public float Lower { get; }
+    /// <summary>Build a strict-greater-than constraint.</summary>
+    public GreaterThanConstraint(float lower) { Lower = lower; }
+    /// <inheritdoc />
+    public bool[] Check(float[] values)
+    {
+        var ok = new bool[values.Length];
+        for (int i = 0; i < values.Length; i++) ok[i] = values[i] > Lower;
+        return ok;
+    }
+}
+
+/// <summary>Integer interval [low, high] inclusive.</summary>
+public sealed class IntegerIntervalConstraint : IConstraint
+{
+    /// <summary>Lower bound, inclusive.</summary>
+    public int Low { get; }
+    /// <summary>Upper bound, inclusive.</summary>
+    public int High { get; }
+    /// <summary>Build an integer interval constraint.</summary>
+    public IntegerIntervalConstraint(int low, int high)
+    {
+        if (high < low) throw new ArgumentException("high must be >= low.");
+        Low = low; High = high;
+    }
+    /// <inheritdoc />
+    public bool[] Check(float[] values)
+    {
+        var ok = new bool[values.Length];
+        for (int i = 0; i < values.Length; i++)
+        {
+            var v = values[i];
+            ok[i] = v == MathF.Floor(v) && v >= Low && v <= High;
+        }
+        return ok;
+    }
+}
+
+/// <summary>Probability simplex: x_i ≥ 0 and sum_i x_i = 1 (within tolerance).</summary>
+public sealed class SimplexConstraint : IConstraint
+{
+    /// <summary>Length of each simplex element (i.e. the number of categories).</summary>
+    public int EventSize { get; }
+    /// <summary>Tolerance on the sum-to-one check.</summary>
+    public float Tolerance { get; }
+    /// <summary>Build a simplex constraint.</summary>
+    public SimplexConstraint(int eventSize, float tolerance = 1e-5f)
+    {
+        if (eventSize <= 0) throw new ArgumentOutOfRangeException(nameof(eventSize));
+        EventSize = eventSize; Tolerance = tolerance;
+    }
+    /// <inheritdoc />
+    public bool[] Check(float[] values)
+    {
+        if (values.Length % EventSize != 0)
+            throw new ArgumentException($"values.Length ({values.Length}) must be a multiple of EventSize ({EventSize}).");
+        int batch = values.Length / EventSize;
+        var ok = new bool[batch];
+        for (int b = 0; b < batch; b++)
+        {
+            float sum = 0f; bool good = true;
+            for (int i = 0; i < EventSize; i++)
+            {
+                var v = values[b * EventSize + i];
+                if (v < 0f) { good = false; break; }
+                sum += v;
+            }
+            ok[b] = good && MathF.Abs(sum - 1f) <= Tolerance;
+        }
+        return ok;
+    }
+}

--- a/src/AiDotNet.Tensors/Distributions/DiscreteDistributions.cs
+++ b/src/AiDotNet.Tensors/Distributions/DiscreteDistributions.cs
@@ -20,7 +20,7 @@ public sealed class BernoulliDistribution : DistributionBase
     {
         for (int i = 0; i < probs.Length; i++)
             if (probs[i] < 0f || probs[i] > 1f) throw new ArgumentException("probs ∈ [0, 1].");
-        Probs = probs;
+        Probs = (float[])probs.Clone();
     }
     /// <inheritdoc />
     public override float[] Sample(Random rng)
@@ -94,7 +94,7 @@ public sealed class BinomialDistribution : DistributionBase
             if (totalCount[i] < 0) throw new ArgumentException("totalCount >= 0.");
             if (probs[i] < 0f || probs[i] > 1f) throw new ArgumentException("probs ∈ [0, 1].");
         }
-        TotalCount = totalCount; Probs = probs;
+        TotalCount = (int[])totalCount.Clone(); Probs = (float[])probs.Clone();
     }
     /// <inheritdoc />
     public override float[] Sample(Random rng)
@@ -192,7 +192,7 @@ public sealed class CategoricalDistribution : DistributionBase
             }
             if (MathF.Abs(sum - 1f) > 1e-3f) throw new ArgumentException($"probs row {b} must sum to 1 (got {sum}).");
         }
-        Probs = probs; K = k;
+        Probs = (float[])probs.Clone(); K = k;
     }
     /// <inheritdoc />
     public override float[] Sample(Random rng)
@@ -360,7 +360,7 @@ public sealed class GeometricDistribution : DistributionBase
     {
         for (int i = 0; i < probs.Length; i++)
             if (!(probs[i] > 0f && probs[i] <= 1f)) throw new ArgumentException("probs ∈ (0, 1].");
-        Probs = probs;
+        Probs = (float[])probs.Clone();
     }
     /// <inheritdoc />
     public override float[] Sample(Random rng)
@@ -421,7 +421,7 @@ public sealed class PoissonDistribution : DistributionBase
     public PoissonDistribution(float[] rate)
     {
         for (int i = 0; i < rate.Length; i++) if (!(rate[i] >= 0f)) throw new ArgumentException("rate >= 0.");
-        Rate = rate;
+        Rate = (float[])rate.Clone();
     }
     /// <inheritdoc />
     public override float[] Sample(Random rng)
@@ -439,6 +439,9 @@ public sealed class PoissonDistribution : DistributionBase
         {
             float k = value[i];
             if (k < 0 || k != MathF.Floor(k)) { lp[i] = float.NegativeInfinity; continue; }
+            // Degenerate Poisson(λ=0): the distribution is a point mass at 0.
+            // log p(0|0) = 0; log p(k>0|0) = -∞. Avoids log(0) = -∞ contaminating k=0.
+            if (Rate[i] == 0f) { lp[i] = k == 0f ? 0f : float.NegativeInfinity; continue; }
             lp[i] = k * MathF.Log(Rate[i]) - Rate[i] - SpecialFunctions.Lgamma(k + 1f);
         }
         return lp;
@@ -520,7 +523,7 @@ public sealed class NegativeBinomialDistribution : DistributionBase
             if (!(totalCount[i] > 0f)) throw new ArgumentException("totalCount > 0.");
             if (!(probs[i] >= 0f && probs[i] < 1f)) throw new ArgumentException("probs ∈ [0, 1).");
         }
-        TotalCount = totalCount; Probs = probs;
+        TotalCount = (float[])totalCount.Clone(); Probs = (float[])probs.Clone();
     }
     /// <inheritdoc />
     public override float[] Sample(Random rng)
@@ -584,7 +587,22 @@ public sealed class MultinomialDistribution : DistributionBase
     {
         if (k <= 0) throw new ArgumentException("K > 0.");
         if (probs.Length != totalCount.Length * k) throw new ArgumentException("probs length mismatch.");
-        TotalCount = totalCount; Probs = probs; K = k;
+        // Each row of probs must be a valid probability vector (non-negative, sum to 1).
+        // Same validation surface as CategoricalDistribution.
+        int batch = totalCount.Length;
+        for (int b = 0; b < batch; b++)
+        {
+            float sum = 0f;
+            for (int i = 0; i < k; i++)
+            {
+                if (probs[b * k + i] < 0f) throw new ArgumentException($"probs[{b}, {i}] = {probs[b * k + i]} must be ≥ 0.");
+                sum += probs[b * k + i];
+            }
+            if (MathF.Abs(sum - 1f) > 1e-3f)
+                throw new ArgumentException($"probs row {b} must sum to 1 (got {sum}).");
+            if (totalCount[b] < 0) throw new ArgumentException($"totalCount[{b}] = {totalCount[b]} must be >= 0.");
+        }
+        TotalCount = (int[])totalCount.Clone(); Probs = (float[])probs.Clone(); K = k;
     }
     /// <inheritdoc />
     public override float[] Sample(Random rng)

--- a/src/AiDotNet.Tensors/Distributions/DiscreteDistributions.cs
+++ b/src/AiDotNet.Tensors/Distributions/DiscreteDistributions.cs
@@ -1,0 +1,664 @@
+using System;
+using AiDotNet.Tensors.Distributions.Constraints;
+using AiDotNet.Tensors.Distributions.Helpers;
+
+namespace AiDotNet.Tensors.Distributions;
+
+/// <summary>Bernoulli distribution.</summary>
+public sealed class BernoulliDistribution : DistributionBase
+{
+    /// <summary>Per-batch success probability.</summary>
+    public float[] Probs { get; }
+    /// <inheritdoc />
+    public override int BatchSize => Probs.Length;
+    /// <inheritdoc />
+    public override int EventSize => 1;
+    /// <inheritdoc />
+    public override IConstraint Support => new IntegerIntervalConstraint(0, 1);
+    /// <summary>Build a Bernoulli from per-batch probabilities.</summary>
+    public BernoulliDistribution(float[] probs)
+    {
+        for (int i = 0; i < probs.Length; i++)
+            if (probs[i] < 0f || probs[i] > 1f) throw new ArgumentException("probs ∈ [0, 1].");
+        Probs = probs;
+    }
+    /// <inheritdoc />
+    public override float[] Sample(Random rng)
+    {
+        var x = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++) x[i] = rng.NextDouble() < Probs[i] ? 1f : 0f;
+        return x;
+    }
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        var lp = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            float p = Probs[i]; float v = value[i];
+            // Stable: lp = v·log(p) + (1-v)·log(1-p) — but with clamps when p ∈ {0, 1}.
+            float logP = p > 0f ? MathF.Log(p) : float.NegativeInfinity;
+            float log1mp = p < 1f ? MathF.Log(1f - p) : float.NegativeInfinity;
+            lp[i] = v * logP + (1f - v) * log1mp;
+        }
+        return lp;
+    }
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        var h = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            float p = Probs[i];
+            float a = p > 0f ? -p * MathF.Log(p) : 0f;
+            float b = p < 1f ? -(1f - p) * MathF.Log(1f - p) : 0f;
+            h[i] = a + b;
+        }
+        return h;
+    }
+    /// <inheritdoc />
+    public override float[] Mean => (float[])Probs.Clone();
+    /// <inheritdoc />
+    public override float[] Variance
+    { get { var v = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) v[i] = Probs[i] * (1f - Probs[i]); return v; } }
+}
+
+/// <summary>Binomial distribution: number of successes in <c>totalCount</c> independent Bernoulli trials.</summary>
+public sealed class BinomialDistribution : DistributionBase
+{
+    /// <summary>Number of trials (per batch).</summary>
+    public int[] TotalCount { get; }
+    /// <summary>Per-batch success probability.</summary>
+    public float[] Probs { get; }
+    /// <inheritdoc />
+    public override int BatchSize => Probs.Length;
+    /// <inheritdoc />
+    public override int EventSize => 1;
+    /// <inheritdoc />
+    public override IConstraint Support
+    {
+        get
+        {
+            int max = 0;
+            for (int i = 0; i < TotalCount.Length; i++) if (TotalCount[i] > max) max = TotalCount[i];
+            return new IntegerIntervalConstraint(0, max);
+        }
+    }
+    /// <summary>Build a binomial from per-batch totalCount and probs.</summary>
+    public BinomialDistribution(int[] totalCount, float[] probs)
+    {
+        if (totalCount.Length != probs.Length) throw new ArgumentException();
+        for (int i = 0; i < totalCount.Length; i++)
+        {
+            if (totalCount[i] < 0) throw new ArgumentException("totalCount >= 0.");
+            if (probs[i] < 0f || probs[i] > 1f) throw new ArgumentException("probs ∈ [0, 1].");
+        }
+        TotalCount = totalCount; Probs = probs;
+    }
+    /// <inheritdoc />
+    public override float[] Sample(Random rng)
+    {
+        var x = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            int k = 0;
+            for (int t = 0; t < TotalCount[i]; t++) if (rng.NextDouble() < Probs[i]) k++;
+            x[i] = k;
+        }
+        return x;
+    }
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        var lp = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            int n = TotalCount[i]; float p = Probs[i]; float k = value[i];
+            if (k < 0 || k > n) { lp[i] = float.NegativeInfinity; continue; }
+            float logBinom = SpecialFunctions.Lgamma(n + 1f) - SpecialFunctions.Lgamma(k + 1f) - SpecialFunctions.Lgamma(n - k + 1f);
+            float logP = p > 0f ? MathF.Log(p) : float.NegativeInfinity;
+            float log1mp = p < 1f ? MathF.Log(1f - p) : float.NegativeInfinity;
+            lp[i] = logBinom + k * logP + (n - k) * log1mp;
+        }
+        return lp;
+    }
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        // No simple closed form; sum over support.
+        var h = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            int n = TotalCount[i];
+            double s = 0;
+            for (int k = 0; k <= n; k++)
+            {
+                var lp = LogProb(new float[] { k })[0];
+                if (!float.IsNegativeInfinity(lp)) s += MathF.Exp(lp) * lp;
+            }
+            // Wait — this LogProb call uses the FULL batch's parameters. We need a single-batch path.
+            // Inline the formula instead:
+            s = 0;
+            for (int k = 0; k <= n; k++)
+            {
+                float p = Probs[i];
+                float logBinom = SpecialFunctions.Lgamma(n + 1f) - SpecialFunctions.Lgamma(k + 1f) - SpecialFunctions.Lgamma(n - k + 1f);
+                float logP = p > 0f ? MathF.Log(p) : float.NegativeInfinity;
+                float log1mp = p < 1f ? MathF.Log(1f - p) : float.NegativeInfinity;
+                float lp2 = logBinom + k * logP + (n - k) * log1mp;
+                if (!float.IsNegativeInfinity(lp2)) s += MathF.Exp(lp2) * lp2;
+            }
+            h[i] = (float)(-s);
+        }
+        return h;
+    }
+    /// <inheritdoc />
+    public override float[] Mean
+    { get { var m = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) m[i] = TotalCount[i] * Probs[i]; return m; } }
+    /// <inheritdoc />
+    public override float[] Variance
+    { get { var v = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) v[i] = TotalCount[i] * Probs[i] * (1f - Probs[i]); return v; } }
+}
+
+/// <summary>Categorical distribution over <c>K</c> classes per batch element.</summary>
+public sealed class CategoricalDistribution : DistributionBase
+{
+    /// <summary>Per-batch probability vectors. Layout: <c>[batch, K]</c> row-major.</summary>
+    public float[] Probs { get; }
+    /// <summary>Number of categories.</summary>
+    public int K { get; }
+    /// <inheritdoc />
+    public override int BatchSize => Probs.Length / K;
+    /// <inheritdoc />
+    public override int EventSize => 1; // sample is a single category index
+    /// <inheritdoc />
+    public override IConstraint Support => new IntegerIntervalConstraint(0, K - 1);
+    /// <summary>Build a categorical from per-batch prob vectors.</summary>
+    public CategoricalDistribution(float[] probs, int k)
+    {
+        if (k <= 0) throw new ArgumentException("K > 0.");
+        if (probs.Length % k != 0) throw new ArgumentException("probs.Length must be a multiple of K.");
+        // Validate each row sums close to 1 and entries are non-negative.
+        int batch = probs.Length / k;
+        for (int b = 0; b < batch; b++)
+        {
+            float sum = 0f;
+            for (int i = 0; i < k; i++)
+            {
+                if (probs[b * k + i] < 0f) throw new ArgumentException("probs >= 0.");
+                sum += probs[b * k + i];
+            }
+            if (MathF.Abs(sum - 1f) > 1e-3f) throw new ArgumentException($"probs row {b} must sum to 1 (got {sum}).");
+        }
+        Probs = probs; K = k;
+    }
+    /// <inheritdoc />
+    public override float[] Sample(Random rng)
+    {
+        int batch = BatchSize;
+        var x = new float[batch];
+        for (int b = 0; b < batch; b++)
+        {
+            float u = (float)rng.NextDouble();
+            float cum = 0f;
+            int chosen = K - 1;
+            for (int i = 0; i < K; i++)
+            {
+                cum += Probs[b * K + i];
+                if (u <= cum) { chosen = i; break; }
+            }
+            x[b] = chosen;
+        }
+        return x;
+    }
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        int batch = BatchSize;
+        var lp = new float[batch];
+        for (int b = 0; b < batch; b++)
+        {
+            int k = (int)value[b];
+            if (k < 0 || k >= K) { lp[b] = float.NegativeInfinity; continue; }
+            float p = Probs[b * K + k];
+            lp[b] = p > 0f ? MathF.Log(p) : float.NegativeInfinity;
+        }
+        return lp;
+    }
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        int batch = BatchSize;
+        var h = new float[batch];
+        for (int b = 0; b < batch; b++)
+        {
+            float s = 0f;
+            for (int i = 0; i < K; i++)
+            {
+                float p = Probs[b * K + i];
+                if (p > 0f) s -= p * MathF.Log(p);
+            }
+            h[b] = s;
+        }
+        return h;
+    }
+    /// <inheritdoc />
+    public override float[] Mean
+    {
+        get
+        {
+            int batch = BatchSize;
+            var m = new float[batch];
+            for (int b = 0; b < batch; b++)
+            {
+                float s = 0f;
+                for (int i = 0; i < K; i++) s += i * Probs[b * K + i];
+                m[b] = s;
+            }
+            return m;
+        }
+    }
+    /// <inheritdoc />
+    public override float[] Variance
+    {
+        get
+        {
+            int batch = BatchSize;
+            var v = new float[batch];
+            var mean = Mean;
+            for (int b = 0; b < batch; b++)
+            {
+                float s = 0f;
+                for (int i = 0; i < K; i++)
+                {
+                    float diff = i - mean[b];
+                    s += Probs[b * K + i] * diff * diff;
+                }
+                v[b] = s;
+            }
+            return v;
+        }
+    }
+}
+
+/// <summary>One-hot categorical: same parameters as <see cref="CategoricalDistribution"/> but samples are length-K one-hot vectors.</summary>
+public sealed class OneHotCategoricalDistribution : DistributionBase
+{
+    private readonly CategoricalDistribution _inner;
+    /// <summary>Number of categories.</summary>
+    public int K => _inner.K;
+    /// <summary>Per-batch probability vectors.</summary>
+    public float[] Probs => _inner.Probs;
+    /// <inheritdoc />
+    public override int BatchSize => _inner.BatchSize;
+    /// <inheritdoc />
+    public override int EventSize => K;
+    /// <inheritdoc />
+    public override IConstraint Support => new SimplexConstraint(K);
+    /// <summary>Build a one-hot categorical from per-batch prob vectors.</summary>
+    public OneHotCategoricalDistribution(float[] probs, int k) { _inner = new CategoricalDistribution(probs, k); }
+    /// <inheritdoc />
+    public override float[] Sample(Random rng)
+    {
+        var idx = _inner.Sample(rng);
+        var x = new float[BatchSize * K];
+        for (int b = 0; b < BatchSize; b++) x[b * K + (int)idx[b]] = 1f;
+        return x;
+    }
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        // Reduce the one-hot to an index, then call inner log-prob.
+        var idx = new float[BatchSize];
+        for (int b = 0; b < BatchSize; b++)
+        {
+            int chosen = -1;
+            for (int i = 0; i < K; i++)
+                if (value[b * K + i] == 1f) { chosen = i; break; }
+            idx[b] = chosen < 0 ? -1 : chosen;
+        }
+        return _inner.LogProb(idx);
+    }
+    /// <inheritdoc />
+    public override float[] Entropy() => _inner.Entropy();
+    /// <inheritdoc />
+    public override float[] Mean => Probs;
+    /// <inheritdoc />
+    public override float[] Variance
+    {
+        get
+        {
+            var v = new float[BatchSize * K];
+            for (int b = 0; b < BatchSize; b++)
+                for (int i = 0; i < K; i++)
+                {
+                    float p = Probs[b * K + i];
+                    v[b * K + i] = p * (1f - p);
+                }
+            return v;
+        }
+    }
+}
+
+/// <summary>Geometric distribution: number of failures before first success.</summary>
+public sealed class GeometricDistribution : DistributionBase
+{
+    /// <summary>Per-batch success probability.</summary>
+    public float[] Probs { get; }
+    /// <inheritdoc />
+    public override int BatchSize => Probs.Length;
+    /// <inheritdoc />
+    public override int EventSize => 1;
+    /// <inheritdoc />
+    public override IConstraint Support => NonNegativeConstraint.Instance;
+    /// <summary>Build a geometric from per-batch probs.</summary>
+    public GeometricDistribution(float[] probs)
+    {
+        for (int i = 0; i < probs.Length; i++)
+            if (!(probs[i] > 0f && probs[i] <= 1f)) throw new ArgumentException("probs ∈ (0, 1].");
+        Probs = probs;
+    }
+    /// <inheritdoc />
+    public override float[] Sample(Random rng)
+    {
+        var x = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            double u = rng.NextDouble();
+            if (u < 1e-12) u = 1e-12;
+            x[i] = MathF.Floor(MathF.Log((float)u) / MathF.Log(1f - Probs[i]));
+        }
+        return x;
+    }
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        var lp = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            float k = value[i];
+            if (k < 0 || k != MathF.Floor(k)) { lp[i] = float.NegativeInfinity; continue; }
+            lp[i] = k * MathF.Log(1f - Probs[i]) + MathF.Log(Probs[i]);
+        }
+        return lp;
+    }
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        var h = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            float p = Probs[i];
+            h[i] = -(p * MathF.Log(p) + (1f - p) * MathF.Log(1f - p)) / p;
+        }
+        return h;
+    }
+    /// <inheritdoc />
+    public override float[] Mean
+    { get { var m = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) m[i] = (1f - Probs[i]) / Probs[i]; return m; } }
+    /// <inheritdoc />
+    public override float[] Variance
+    { get { var v = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) v[i] = (1f - Probs[i]) / (Probs[i] * Probs[i]); return v; } }
+}
+
+/// <summary>Poisson distribution: f(k) = e^-λ · λ^k / k!.</summary>
+public sealed class PoissonDistribution : DistributionBase
+{
+    /// <summary>Per-batch rate λ &gt; 0.</summary>
+    public float[] Rate { get; }
+    /// <inheritdoc />
+    public override int BatchSize => Rate.Length;
+    /// <inheritdoc />
+    public override int EventSize => 1;
+    /// <inheritdoc />
+    public override IConstraint Support => NonNegativeConstraint.Instance;
+    /// <summary>Build a Poisson from per-batch rate.</summary>
+    public PoissonDistribution(float[] rate)
+    {
+        for (int i = 0; i < rate.Length; i++) if (!(rate[i] >= 0f)) throw new ArgumentException("rate >= 0.");
+        Rate = rate;
+    }
+    /// <inheritdoc />
+    public override float[] Sample(Random rng)
+    {
+        var x = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++) x[i] = SamplePoisson(rng, Rate[i]);
+        return x;
+    }
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        var lp = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            float k = value[i];
+            if (k < 0 || k != MathF.Floor(k)) { lp[i] = float.NegativeInfinity; continue; }
+            lp[i] = k * MathF.Log(Rate[i]) - Rate[i] - SpecialFunctions.Lgamma(k + 1f);
+        }
+        return lp;
+    }
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        // Numerical sum (closed form involves ψ).
+        var h = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            float lambda = Rate[i];
+            // Truncate at lambda + 10·sqrt(lambda) — captures essentially all mass.
+            int kmax = (int)MathF.Ceiling(lambda + 10f * MathF.Sqrt(lambda + 1f));
+            double s = 0;
+            for (int k = 0; k <= kmax; k++)
+            {
+                double lp = k * Math.Log(lambda) - lambda - SpecialFunctions.Lgamma(k + 1f);
+                if (lp > -50.0) s += Math.Exp(lp) * lp;
+            }
+            h[i] = (float)(-s);
+        }
+        return h;
+    }
+    /// <inheritdoc />
+    public override float[] Mean => (float[])Rate.Clone();
+    /// <inheritdoc />
+    public override float[] Variance => (float[])Rate.Clone();
+
+    /// <summary>Knuth's Poisson sampler for small λ; transformed-rejection for large λ.</summary>
+    internal static float SamplePoisson(Random rng, float lambda)
+    {
+        if (lambda < 30f)
+        {
+            double L = Math.Exp(-lambda);
+            int count = 0; double p = 1;
+            do { count++; p *= rng.NextDouble(); } while (p > L);
+            return count - 1;
+        }
+        // Atkinson's transformed-rejection (textbook approach for large λ).
+        double c = 0.767 - 3.36 / lambda;
+        double beta = Math.PI / Math.Sqrt(3.0 * lambda);
+        double alpha = beta * lambda;
+        double k = Math.Log(c) - lambda - Math.Log(beta);
+        while (true)
+        {
+            double u = rng.NextDouble();
+            double x = (alpha - Math.Log((1 - u) / u)) / beta;
+            int n = (int)Math.Floor(x + 0.5);
+            if (n < 0) continue;
+            double v = rng.NextDouble();
+            double y = alpha - beta * x;
+            double lhs = y + Math.Log(v / Math.Pow(1 + Math.Exp(y), 2));
+            double rhs = k + n * Math.Log(lambda) - SpecialFunctions.Lgamma(n + 1f);
+            if (lhs <= rhs) return n;
+        }
+    }
+}
+
+/// <summary>Negative binomial distribution: number of failures before <c>totalCount</c> successes.</summary>
+public sealed class NegativeBinomialDistribution : DistributionBase
+{
+    /// <summary>Number of successes (per batch). Real-valued; PyTorch parity.</summary>
+    public float[] TotalCount { get; }
+    /// <summary>Per-batch success probability.</summary>
+    public float[] Probs { get; }
+    /// <inheritdoc />
+    public override int BatchSize => Probs.Length;
+    /// <inheritdoc />
+    public override int EventSize => 1;
+    /// <inheritdoc />
+    public override IConstraint Support => NonNegativeConstraint.Instance;
+    /// <summary>Build a negative binomial.</summary>
+    public NegativeBinomialDistribution(float[] totalCount, float[] probs)
+    {
+        if (totalCount.Length != probs.Length) throw new ArgumentException();
+        for (int i = 0; i < probs.Length; i++)
+        {
+            if (!(totalCount[i] > 0f)) throw new ArgumentException("totalCount > 0.");
+            if (!(probs[i] >= 0f && probs[i] < 1f)) throw new ArgumentException("probs ∈ [0, 1).");
+        }
+        TotalCount = totalCount; Probs = probs;
+    }
+    /// <inheritdoc />
+    public override float[] Sample(Random rng)
+    {
+        // Sample λ ∼ Gamma(r, (1-p)/p); k ∼ Poisson(λ).
+        var x = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            float scale = (1f - Probs[i]) / Probs[i];
+            float lambda = GammaDistribution.MarsagliaTsang(rng, TotalCount[i]) * scale;
+            x[i] = PoissonDistribution.SamplePoisson(rng, lambda);
+        }
+        return x;
+    }
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        var lp = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            float k = value[i]; float r = TotalCount[i]; float p = Probs[i];
+            if (k < 0) { lp[i] = float.NegativeInfinity; continue; }
+            lp[i] = SpecialFunctions.Lgamma(r + k) - SpecialFunctions.Lgamma(k + 1f) - SpecialFunctions.Lgamma(r)
+                  + r * MathF.Log(p) + k * MathF.Log(1f - p);
+        }
+        return lp;
+    }
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        var h = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++) h[i] = float.NaN;  // no closed form; user can MC-estimate
+        return h;
+    }
+    /// <inheritdoc />
+    public override float[] Mean
+    { get { var m = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) m[i] = TotalCount[i] * (1f - Probs[i]) / Probs[i]; return m; } }
+    /// <inheritdoc />
+    public override float[] Variance
+    { get { var v = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) v[i] = TotalCount[i] * (1f - Probs[i]) / (Probs[i] * Probs[i]); return v; } }
+}
+
+/// <summary>Multinomial distribution: <c>totalCount</c> draws from a categorical.</summary>
+public sealed class MultinomialDistribution : DistributionBase
+{
+    /// <summary>Trials per batch element.</summary>
+    public int[] TotalCount { get; }
+    /// <summary>Per-batch probability vectors, layout <c>[batch, K]</c>.</summary>
+    public float[] Probs { get; }
+    /// <summary>Number of categories.</summary>
+    public int K { get; }
+    /// <inheritdoc />
+    public override int BatchSize => TotalCount.Length;
+    /// <inheritdoc />
+    public override int EventSize => K;
+    /// <inheritdoc />
+    public override IConstraint Support => NonNegativeConstraint.Instance;
+    /// <summary>Build a Multinomial from totalCount + probs.</summary>
+    public MultinomialDistribution(int[] totalCount, float[] probs, int k)
+    {
+        if (k <= 0) throw new ArgumentException("K > 0.");
+        if (probs.Length != totalCount.Length * k) throw new ArgumentException("probs length mismatch.");
+        TotalCount = totalCount; Probs = probs; K = k;
+    }
+    /// <inheritdoc />
+    public override float[] Sample(Random rng)
+    {
+        var x = new float[BatchSize * K];
+        for (int b = 0; b < BatchSize; b++)
+        {
+            for (int t = 0; t < TotalCount[b]; t++)
+            {
+                float u = (float)rng.NextDouble();
+                float cum = 0f; int chosen = K - 1;
+                for (int i = 0; i < K; i++)
+                {
+                    cum += Probs[b * K + i];
+                    if (u <= cum) { chosen = i; break; }
+                }
+                x[b * K + chosen]++;
+            }
+        }
+        return x;
+    }
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        var lp = new float[BatchSize];
+        for (int b = 0; b < BatchSize; b++)
+        {
+            int n = TotalCount[b];
+            float l = SpecialFunctions.Lgamma(n + 1f);
+            for (int i = 0; i < K; i++)
+            {
+                float k = value[b * K + i];
+                float p = Probs[b * K + i];
+                l -= SpecialFunctions.Lgamma(k + 1f);
+                if (p > 0f) l += k * MathF.Log(p);
+                else if (k > 0f) l = float.NegativeInfinity;
+            }
+            lp[b] = l;
+        }
+        return lp;
+    }
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        var h = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++) h[i] = float.NaN;
+        return h;
+    }
+    /// <inheritdoc />
+    public override float[] Mean
+    {
+        get
+        {
+            var m = new float[BatchSize * K];
+            for (int b = 0; b < BatchSize; b++)
+                for (int i = 0; i < K; i++)
+                    m[b * K + i] = TotalCount[b] * Probs[b * K + i];
+            return m;
+        }
+    }
+    /// <inheritdoc />
+    public override float[] Variance
+    {
+        get
+        {
+            var v = new float[BatchSize * K];
+            for (int b = 0; b < BatchSize; b++)
+                for (int i = 0; i < K; i++)
+                {
+                    float p = Probs[b * K + i];
+                    v[b * K + i] = TotalCount[b] * p * (1f - p);
+                }
+            return v;
+        }
+    }
+}

--- a/src/AiDotNet.Tensors/Distributions/DiscreteDistributions.cs
+++ b/src/AiDotNet.Tensors/Distributions/DiscreteDistributions.cs
@@ -37,10 +37,13 @@ public sealed class BernoulliDistribution : DistributionBase
         for (int i = 0; i < BatchSize; i++)
         {
             float p = Probs[i]; float v = value[i];
-            // Stable: lp = v·log(p) + (1-v)·log(1-p) — but with clamps when p ∈ {0, 1}.
-            float logP = p > 0f ? MathF.Log(p) : float.NegativeInfinity;
-            float log1mp = p < 1f ? MathF.Log(1f - p) : float.NegativeInfinity;
-            lp[i] = v * logP + (1f - v) * log1mp;
+            // Bernoulli support is {0, 1}. Branch explicitly so:
+            //  - non-binary inputs return -∞ (out of support)
+            //  - the deterministic edges p ∈ {0, 1} are not contaminated by 0·-∞ = NaN
+            //    that the generic v·log(p) + (1-v)·log(1-p) form would otherwise produce.
+            if (v == 1f) lp[i] = p > 0f ? MathF.Log(p) : float.NegativeInfinity;
+            else if (v == 0f) lp[i] = p < 1f ? MathF.Log(1f - p) : float.NegativeInfinity;
+            else lp[i] = float.NegativeInfinity;
         }
         return lp;
     }
@@ -116,38 +119,34 @@ public sealed class BinomialDistribution : DistributionBase
         for (int i = 0; i < BatchSize; i++)
         {
             int n = TotalCount[i]; float p = Probs[i]; float k = value[i];
-            if (k < 0 || k > n) { lp[i] = float.NegativeInfinity; continue; }
+            // Discrete support: k must be a non-negative integer in [0, n]. Lgamma alone
+            // would silently accept fractional counts, so we filter them out explicitly.
+            if (k < 0f || k > n || k != MathF.Floor(k)) { lp[i] = float.NegativeInfinity; continue; }
+            // Deterministic edges: only k == 0 (for p == 0) or k == n (for p == 1) have mass.
+            // Skip the generic formula so we don't get 0 · -∞ = NaN at those edges.
+            if (p == 0f) { lp[i] = k == 0f ? 0f : float.NegativeInfinity; continue; }
+            if (p == 1f) { lp[i] = k == n  ? 0f : float.NegativeInfinity; continue; }
             float logBinom = SpecialFunctions.Lgamma(n + 1f) - SpecialFunctions.Lgamma(k + 1f) - SpecialFunctions.Lgamma(n - k + 1f);
-            float logP = p > 0f ? MathF.Log(p) : float.NegativeInfinity;
-            float log1mp = p < 1f ? MathF.Log(1f - p) : float.NegativeInfinity;
-            lp[i] = logBinom + k * logP + (n - k) * log1mp;
+            lp[i] = logBinom + k * MathF.Log(p) + (n - k) * MathF.Log(1f - p);
         }
         return lp;
     }
     /// <inheritdoc />
     public override float[] Entropy()
     {
-        // No simple closed form; sum over support.
+        // No simple closed form; sum over the support.
         var h = new float[BatchSize];
         for (int i = 0; i < BatchSize; i++)
         {
             int n = TotalCount[i];
+            float p = Probs[i];
+            // Deterministic ⇒ entropy is 0 (no uncertainty).
+            if (p == 0f || p == 1f) { h[i] = 0f; continue; }
             double s = 0;
             for (int k = 0; k <= n; k++)
             {
-                var lp = LogProb(new float[] { k })[0];
-                if (!float.IsNegativeInfinity(lp)) s += MathF.Exp(lp) * lp;
-            }
-            // Wait — this LogProb call uses the FULL batch's parameters. We need a single-batch path.
-            // Inline the formula instead:
-            s = 0;
-            for (int k = 0; k <= n; k++)
-            {
-                float p = Probs[i];
                 float logBinom = SpecialFunctions.Lgamma(n + 1f) - SpecialFunctions.Lgamma(k + 1f) - SpecialFunctions.Lgamma(n - k + 1f);
-                float logP = p > 0f ? MathF.Log(p) : float.NegativeInfinity;
-                float log1mp = p < 1f ? MathF.Log(1f - p) : float.NegativeInfinity;
-                float lp2 = logBinom + k * logP + (n - k) * log1mp;
+                float lp2 = logBinom + k * MathF.Log(p) + (n - k) * MathF.Log(1f - p);
                 if (!float.IsNegativeInfinity(lp2)) s += MathF.Exp(lp2) * lp2;
             }
             h[i] = (float)(-s);
@@ -221,8 +220,11 @@ public sealed class CategoricalDistribution : DistributionBase
         var lp = new float[batch];
         for (int b = 0; b < batch; b++)
         {
-            int k = (int)value[b];
-            if (k < 0 || k >= K) { lp[b] = float.NegativeInfinity; continue; }
+            float v = value[b];
+            // Reject non-integer indices outright (truncation via (int) would silently
+            // accept e.g. 1.7 as category 1, which is wrong for a discrete support).
+            if (v < 0f || v >= K || v != MathF.Floor(v)) { lp[b] = float.NegativeInfinity; continue; }
+            int k = (int)v;
             float p = Probs[b * K + k];
             lp[b] = p > 0f ? MathF.Log(p) : float.NegativeInfinity;
         }
@@ -312,14 +314,28 @@ public sealed class OneHotCategoricalDistribution : DistributionBase
     public override float[] LogProb(float[] value)
     {
         EnsureValueShape(value);
-        // Reduce the one-hot to an index, then call inner log-prob.
+        // Reduce the one-hot to an index, then call inner log-prob. The previous version
+        // accepted vectors like [1, 1, 0] (multi-hot) by stopping at the first 1; we now
+        // require exactly one entry to be 1 and the rest to be 0, returning -∞ otherwise.
         var idx = new float[BatchSize];
         for (int b = 0; b < BatchSize; b++)
         {
             int chosen = -1;
+            bool valid = true;
             for (int i = 0; i < K; i++)
-                if (value[b * K + i] == 1f) { chosen = i; break; }
-            idx[b] = chosen < 0 ? -1 : chosen;
+            {
+                float v = value[b * K + i];
+                if (v == 1f)
+                {
+                    if (chosen >= 0) { valid = false; break; } // multi-hot
+                    chosen = i;
+                }
+                else if (v != 0f)
+                {
+                    valid = false; break; // non-binary entry
+                }
+            }
+            idx[b] = valid && chosen >= 0 ? chosen : -1;
         }
         return _inner.LogProb(idx);
     }
@@ -521,7 +537,9 @@ public sealed class NegativeBinomialDistribution : DistributionBase
         for (int i = 0; i < probs.Length; i++)
         {
             if (!(totalCount[i] > 0f)) throw new ArgumentException("totalCount > 0.");
-            if (!(probs[i] >= 0f && probs[i] < 1f)) throw new ArgumentException("probs ∈ [0, 1).");
+            // Reject p == 0 outright — Sample divides by p and (1−p)/p would blow up.
+            // p == 1 is also disallowed because all mass would be on k = 0.
+            if (!(probs[i] > 0f && probs[i] < 1f)) throw new ArgumentException("probs ∈ (0, 1).");
         }
         TotalCount = (float[])totalCount.Clone(); Probs = (float[])probs.Clone();
     }
@@ -546,7 +564,8 @@ public sealed class NegativeBinomialDistribution : DistributionBase
         for (int i = 0; i < BatchSize; i++)
         {
             float k = value[i]; float r = TotalCount[i]; float p = Probs[i];
-            if (k < 0) { lp[i] = float.NegativeInfinity; continue; }
+            // k must be a non-negative integer; Lgamma alone would silently accept fractions.
+            if (k < 0f || k != MathF.Floor(k)) { lp[i] = float.NegativeInfinity; continue; }
             lp[i] = SpecialFunctions.Lgamma(r + k) - SpecialFunctions.Lgamma(k + 1f) - SpecialFunctions.Lgamma(r)
                   + r * MathF.Log(p) + k * MathF.Log(1f - p);
         }
@@ -632,6 +651,20 @@ public sealed class MultinomialDistribution : DistributionBase
         for (int b = 0; b < BatchSize; b++)
         {
             int n = TotalCount[b];
+            // Validate the count vector: each k_i must be a non-negative integer and
+            // Σ k_i must equal n. Otherwise the count vector is impossible under this
+            // multinomial — the analytical formula would otherwise return a finite (and
+            // wrong) value for fractional or mis-summed inputs.
+            float sumK = 0f;
+            bool valid = true;
+            for (int i = 0; i < K; i++)
+            {
+                float k = value[b * K + i];
+                if (k < 0f || k != MathF.Floor(k)) { valid = false; break; }
+                sumK += k;
+            }
+            if (!valid || sumK != n) { lp[b] = float.NegativeInfinity; continue; }
+
             float l = SpecialFunctions.Lgamma(n + 1f);
             for (int i = 0; i < K; i++)
             {

--- a/src/AiDotNet.Tensors/Distributions/DiscreteDistributions.cs
+++ b/src/AiDotNet.Tensors/Distributions/DiscreteDistributions.cs
@@ -7,10 +7,12 @@ namespace AiDotNet.Tensors.Distributions;
 /// <summary>Bernoulli distribution.</summary>
 public sealed class BernoulliDistribution : DistributionBase
 {
-    /// <summary>Per-batch success probability.</summary>
-    public float[] Probs { get; }
+    private readonly float[] _probs;
+    /// <summary>Per-batch success probability. Returns a defensive copy so callers can't
+    /// mutate the validated parameters after construction.</summary>
+    public float[] Probs => (float[])_probs.Clone();
     /// <inheritdoc />
-    public override int BatchSize => Probs.Length;
+    public override int BatchSize => _probs.Length;
     /// <inheritdoc />
     public override int EventSize => 1;
     /// <inheritdoc />
@@ -18,15 +20,20 @@ public sealed class BernoulliDistribution : DistributionBase
     /// <summary>Build a Bernoulli from per-batch probabilities.</summary>
     public BernoulliDistribution(float[] probs)
     {
+        if (probs == null) throw new ArgumentNullException(nameof(probs));
         for (int i = 0; i < probs.Length; i++)
-            if (probs[i] < 0f || probs[i] > 1f) throw new ArgumentException("probs ∈ [0, 1].");
-        Probs = (float[])probs.Clone();
+        {
+            float p = probs[i];
+            if (float.IsNaN(p) || float.IsInfinity(p) || p < 0f || p > 1f)
+                throw new ArgumentException("probs must be finite and in [0, 1].");
+        }
+        _probs = (float[])probs.Clone();
     }
     /// <inheritdoc />
     public override float[] Sample(Random rng)
     {
         var x = new float[BatchSize];
-        for (int i = 0; i < BatchSize; i++) x[i] = rng.NextDouble() < Probs[i] ? 1f : 0f;
+        for (int i = 0; i < BatchSize; i++) x[i] = rng.NextDouble() < _probs[i] ? 1f : 0f;
         return x;
     }
     /// <inheritdoc />
@@ -36,11 +43,7 @@ public sealed class BernoulliDistribution : DistributionBase
         var lp = new float[BatchSize];
         for (int i = 0; i < BatchSize; i++)
         {
-            float p = Probs[i]; float v = value[i];
-            // Bernoulli support is {0, 1}. Branch explicitly so:
-            //  - non-binary inputs return -∞ (out of support)
-            //  - the deterministic edges p ∈ {0, 1} are not contaminated by 0·-∞ = NaN
-            //    that the generic v·log(p) + (1-v)·log(1-p) form would otherwise produce.
+            float p = _probs[i]; float v = value[i];
             if (v == 1f) lp[i] = p > 0f ? MathF.Log(p) : float.NegativeInfinity;
             else if (v == 0f) lp[i] = p < 1f ? MathF.Log(1f - p) : float.NegativeInfinity;
             else lp[i] = float.NegativeInfinity;
@@ -53,7 +56,7 @@ public sealed class BernoulliDistribution : DistributionBase
         var h = new float[BatchSize];
         for (int i = 0; i < BatchSize; i++)
         {
-            float p = Probs[i];
+            float p = _probs[i];
             float a = p > 0f ? -p * MathF.Log(p) : 0f;
             float b = p < 1f ? -(1f - p) * MathF.Log(1f - p) : 0f;
             h[i] = a + b;
@@ -61,21 +64,26 @@ public sealed class BernoulliDistribution : DistributionBase
         return h;
     }
     /// <inheritdoc />
-    public override float[] Mean => (float[])Probs.Clone();
+    public override float[] Mean => (float[])_probs.Clone();
     /// <inheritdoc />
     public override float[] Variance
-    { get { var v = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) v[i] = Probs[i] * (1f - Probs[i]); return v; } }
+    { get { var v = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) v[i] = _probs[i] * (1f - _probs[i]); return v; } }
+    /// <summary>Direct read access to the validated probs array — used by KL helpers
+    /// to avoid the per-access Clone() overhead of the public Probs getter.</summary>
+    internal float[] ProbsRaw => _probs;
 }
 
 /// <summary>Binomial distribution: number of successes in <c>totalCount</c> independent Bernoulli trials.</summary>
 public sealed class BinomialDistribution : DistributionBase
 {
-    /// <summary>Number of trials (per batch).</summary>
-    public int[] TotalCount { get; }
-    /// <summary>Per-batch success probability.</summary>
-    public float[] Probs { get; }
+    private readonly int[] _totalCount;
+    private readonly float[] _probs;
+    /// <summary>Number of trials (per batch). Returns a defensive copy.</summary>
+    public int[] TotalCount => (int[])_totalCount.Clone();
+    /// <summary>Per-batch success probability. Returns a defensive copy.</summary>
+    public float[] Probs => (float[])_probs.Clone();
     /// <inheritdoc />
-    public override int BatchSize => Probs.Length;
+    public override int BatchSize => _probs.Length;
     /// <inheritdoc />
     public override int EventSize => 1;
     /// <inheritdoc />
@@ -84,20 +92,24 @@ public sealed class BinomialDistribution : DistributionBase
         get
         {
             int max = 0;
-            for (int i = 0; i < TotalCount.Length; i++) if (TotalCount[i] > max) max = TotalCount[i];
+            for (int i = 0; i < _totalCount.Length; i++) if (_totalCount[i] > max) max = _totalCount[i];
             return new IntegerIntervalConstraint(0, max);
         }
     }
     /// <summary>Build a binomial from per-batch totalCount and probs.</summary>
     public BinomialDistribution(int[] totalCount, float[] probs)
     {
+        if (totalCount == null) throw new ArgumentNullException(nameof(totalCount));
+        if (probs == null) throw new ArgumentNullException(nameof(probs));
         if (totalCount.Length != probs.Length) throw new ArgumentException();
         for (int i = 0; i < totalCount.Length; i++)
         {
             if (totalCount[i] < 0) throw new ArgumentException("totalCount >= 0.");
-            if (probs[i] < 0f || probs[i] > 1f) throw new ArgumentException("probs ∈ [0, 1].");
+            float p = probs[i];
+            if (float.IsNaN(p) || float.IsInfinity(p) || p < 0f || p > 1f)
+                throw new ArgumentException("probs must be finite and in [0, 1].");
         }
-        TotalCount = (int[])totalCount.Clone(); Probs = (float[])probs.Clone();
+        _totalCount = (int[])totalCount.Clone(); _probs = (float[])probs.Clone();
     }
     /// <inheritdoc />
     public override float[] Sample(Random rng)
@@ -106,7 +118,7 @@ public sealed class BinomialDistribution : DistributionBase
         for (int i = 0; i < BatchSize; i++)
         {
             int k = 0;
-            for (int t = 0; t < TotalCount[i]; t++) if (rng.NextDouble() < Probs[i]) k++;
+            for (int t = 0; t < _totalCount[i]; t++) if (rng.NextDouble() < _probs[i]) k++;
             x[i] = k;
         }
         return x;
@@ -118,12 +130,8 @@ public sealed class BinomialDistribution : DistributionBase
         var lp = new float[BatchSize];
         for (int i = 0; i < BatchSize; i++)
         {
-            int n = TotalCount[i]; float p = Probs[i]; float k = value[i];
-            // Discrete support: k must be a non-negative integer in [0, n]. Lgamma alone
-            // would silently accept fractional counts, so we filter them out explicitly.
+            int n = _totalCount[i]; float p = _probs[i]; float k = value[i];
             if (k < 0f || k > n || k != MathF.Floor(k)) { lp[i] = float.NegativeInfinity; continue; }
-            // Deterministic edges: only k == 0 (for p == 0) or k == n (for p == 1) have mass.
-            // Skip the generic formula so we don't get 0 · -∞ = NaN at those edges.
             if (p == 0f) { lp[i] = k == 0f ? 0f : float.NegativeInfinity; continue; }
             if (p == 1f) { lp[i] = k == n  ? 0f : float.NegativeInfinity; continue; }
             float logBinom = SpecialFunctions.Lgamma(n + 1f) - SpecialFunctions.Lgamma(k + 1f) - SpecialFunctions.Lgamma(n - k + 1f);
@@ -134,13 +142,11 @@ public sealed class BinomialDistribution : DistributionBase
     /// <inheritdoc />
     public override float[] Entropy()
     {
-        // No simple closed form; sum over the support.
         var h = new float[BatchSize];
         for (int i = 0; i < BatchSize; i++)
         {
-            int n = TotalCount[i];
-            float p = Probs[i];
-            // Deterministic ⇒ entropy is 0 (no uncertainty).
+            int n = _totalCount[i];
+            float p = _probs[i];
             if (p == 0f || p == 1f) { h[i] = 0f; continue; }
             double s = 0;
             for (int k = 0; k <= n; k++)
@@ -155,21 +161,23 @@ public sealed class BinomialDistribution : DistributionBase
     }
     /// <inheritdoc />
     public override float[] Mean
-    { get { var m = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) m[i] = TotalCount[i] * Probs[i]; return m; } }
+    { get { var m = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) m[i] = _totalCount[i] * _probs[i]; return m; } }
     /// <inheritdoc />
     public override float[] Variance
-    { get { var v = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) v[i] = TotalCount[i] * Probs[i] * (1f - Probs[i]); return v; } }
+    { get { var v = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) v[i] = _totalCount[i] * _probs[i] * (1f - _probs[i]); return v; } }
 }
 
 /// <summary>Categorical distribution over <c>K</c> classes per batch element.</summary>
 public sealed class CategoricalDistribution : DistributionBase
 {
-    /// <summary>Per-batch probability vectors. Layout: <c>[batch, K]</c> row-major.</summary>
-    public float[] Probs { get; }
+    private readonly float[] _probs;
+    /// <summary>Per-batch probability vectors. Layout: <c>[batch, K]</c> row-major.
+    /// Returns a defensive copy so callers can't mutate validated parameters.</summary>
+    public float[] Probs => (float[])_probs.Clone();
     /// <summary>Number of categories.</summary>
     public int K { get; }
     /// <inheritdoc />
-    public override int BatchSize => Probs.Length / K;
+    public override int BatchSize => _probs.Length / K;
     /// <inheritdoc />
     public override int EventSize => 1; // sample is a single category index
     /// <inheritdoc />
@@ -177,22 +185,28 @@ public sealed class CategoricalDistribution : DistributionBase
     /// <summary>Build a categorical from per-batch prob vectors.</summary>
     public CategoricalDistribution(float[] probs, int k)
     {
+        if (probs == null) throw new ArgumentNullException(nameof(probs));
         if (k <= 0) throw new ArgumentException("K > 0.");
         if (probs.Length % k != 0) throw new ArgumentException("probs.Length must be a multiple of K.");
-        // Validate each row sums close to 1 and entries are non-negative.
         int batch = probs.Length / k;
         for (int b = 0; b < batch; b++)
         {
             float sum = 0f;
             for (int i = 0; i < k; i++)
             {
-                if (probs[b * k + i] < 0f) throw new ArgumentException("probs >= 0.");
-                sum += probs[b * k + i];
+                float p = probs[b * k + i];
+                if (float.IsNaN(p) || float.IsInfinity(p) || p < 0f)
+                    throw new ArgumentException($"probs[{b}, {i}] must be finite and ≥ 0.");
+                sum += p;
             }
-            if (MathF.Abs(sum - 1f) > 1e-3f) throw new ArgumentException($"probs row {b} must sum to 1 (got {sum}).");
+            if (float.IsNaN(sum) || float.IsInfinity(sum) || MathF.Abs(sum - 1f) > 1e-3f)
+                throw new ArgumentException($"probs row {b} must sum to 1 (got {sum}).");
         }
-        Probs = (float[])probs.Clone(); K = k;
+        _probs = (float[])probs.Clone(); K = k;
     }
+    /// <summary>Direct read access to the validated probs array — used by KL helpers
+    /// to avoid the per-access Clone() overhead of the public Probs getter.</summary>
+    internal float[] ProbsRaw => _probs;
     /// <inheritdoc />
     public override float[] Sample(Random rng)
     {
@@ -205,7 +219,7 @@ public sealed class CategoricalDistribution : DistributionBase
             int chosen = K - 1;
             for (int i = 0; i < K; i++)
             {
-                cum += Probs[b * K + i];
+                cum += _probs[b * K + i];
                 if (u <= cum) { chosen = i; break; }
             }
             x[b] = chosen;
@@ -221,11 +235,9 @@ public sealed class CategoricalDistribution : DistributionBase
         for (int b = 0; b < batch; b++)
         {
             float v = value[b];
-            // Reject non-integer indices outright (truncation via (int) would silently
-            // accept e.g. 1.7 as category 1, which is wrong for a discrete support).
             if (v < 0f || v >= K || v != MathF.Floor(v)) { lp[b] = float.NegativeInfinity; continue; }
             int k = (int)v;
-            float p = Probs[b * K + k];
+            float p = _probs[b * K + k];
             lp[b] = p > 0f ? MathF.Log(p) : float.NegativeInfinity;
         }
         return lp;
@@ -240,7 +252,7 @@ public sealed class CategoricalDistribution : DistributionBase
             float s = 0f;
             for (int i = 0; i < K; i++)
             {
-                float p = Probs[b * K + i];
+                float p = _probs[b * K + i];
                 if (p > 0f) s -= p * MathF.Log(p);
             }
             h[b] = s;
@@ -257,7 +269,7 @@ public sealed class CategoricalDistribution : DistributionBase
             for (int b = 0; b < batch; b++)
             {
                 float s = 0f;
-                for (int i = 0; i < K; i++) s += i * Probs[b * K + i];
+                for (int i = 0; i < K; i++) s += i * _probs[b * K + i];
                 m[b] = s;
             }
             return m;
@@ -277,7 +289,7 @@ public sealed class CategoricalDistribution : DistributionBase
                 for (int i = 0; i < K; i++)
                 {
                     float diff = i - mean[b];
-                    s += Probs[b * K + i] * diff * diff;
+                    s += _probs[b * K + i] * diff * diff;
                 }
                 v[b] = s;
             }
@@ -299,7 +311,10 @@ public sealed class OneHotCategoricalDistribution : DistributionBase
     /// <inheritdoc />
     public override int EventSize => K;
     /// <inheritdoc />
-    public override IConstraint Support => new SimplexConstraint(K);
+    /// <remarks>One-hot vectors only — <c>SimplexConstraint</c> is too broad because LogProb
+    /// rejects non-binary entries and multi-hot vectors. <see cref="OneHotConstraint"/> matches
+    /// the Sample/LogProb contract exactly.</remarks>
+    public override IConstraint Support => new OneHotConstraint(K);
     /// <summary>Build a one-hot categorical from per-batch prob vectors.</summary>
     public OneHotCategoricalDistribution(float[] probs, int k) { _inner = new CategoricalDistribution(probs, k); }
     /// <inheritdoc />
@@ -342,17 +357,18 @@ public sealed class OneHotCategoricalDistribution : DistributionBase
     /// <inheritdoc />
     public override float[] Entropy() => _inner.Entropy();
     /// <inheritdoc />
-    public override float[] Mean => (float[])Probs.Clone();  // never expose internal storage
+    public override float[] Mean => (float[])_inner.ProbsRaw.Clone();  // never expose internal storage
     /// <inheritdoc />
     public override float[] Variance
     {
         get
         {
+            var probs = _inner.ProbsRaw;  // borrow the inner's validated array — no per-iteration clone
             var v = new float[BatchSize * K];
             for (int b = 0; b < BatchSize; b++)
                 for (int i = 0; i < K; i++)
                 {
-                    float p = Probs[b * K + i];
+                    float p = probs[b * K + i];
                     v[b * K + i] = p * (1f - p);
                 }
             return v;
@@ -363,20 +379,26 @@ public sealed class OneHotCategoricalDistribution : DistributionBase
 /// <summary>Geometric distribution: number of failures before first success.</summary>
 public sealed class GeometricDistribution : DistributionBase
 {
-    /// <summary>Per-batch success probability.</summary>
-    public float[] Probs { get; }
+    private readonly float[] _probs;
+    /// <summary>Per-batch success probability. Returns a defensive copy.</summary>
+    public float[] Probs => (float[])_probs.Clone();
     /// <inheritdoc />
-    public override int BatchSize => Probs.Length;
+    public override int BatchSize => _probs.Length;
     /// <inheritdoc />
     public override int EventSize => 1;
     /// <inheritdoc />
-    public override IConstraint Support => NonNegativeConstraint.Instance;
+    public override IConstraint Support => NonNegativeIntegerConstraint.Instance;
     /// <summary>Build a geometric from per-batch probs.</summary>
     public GeometricDistribution(float[] probs)
     {
+        if (probs == null) throw new ArgumentNullException(nameof(probs));
         for (int i = 0; i < probs.Length; i++)
-            if (!(probs[i] > 0f && probs[i] <= 1f)) throw new ArgumentException("probs ∈ (0, 1].");
-        Probs = (float[])probs.Clone();
+        {
+            float p = probs[i];
+            if (float.IsNaN(p) || float.IsInfinity(p) || !(p > 0f && p <= 1f))
+                throw new ArgumentException("probs must be finite and in (0, 1].");
+        }
+        _probs = (float[])probs.Clone();
     }
     /// <inheritdoc />
     public override float[] Sample(Random rng)
@@ -386,7 +408,7 @@ public sealed class GeometricDistribution : DistributionBase
         {
             double u = rng.NextDouble();
             if (u < 1e-12) u = 1e-12;
-            x[i] = MathF.Floor(MathF.Log((float)u) / MathF.Log(1f - Probs[i]));
+            x[i] = MathF.Floor(MathF.Log((float)u) / MathF.Log(1f - _probs[i]));
         }
         return x;
     }
@@ -397,10 +419,8 @@ public sealed class GeometricDistribution : DistributionBase
         var lp = new float[BatchSize];
         for (int i = 0; i < BatchSize; i++)
         {
-            float k = value[i]; float p = Probs[i];
+            float k = value[i]; float p = _probs[i];
             if (k < 0 || k != MathF.Floor(k)) { lp[i] = float.NegativeInfinity; continue; }
-            // Deterministic edge p == 1: all mass is on k = 0; otherwise log(0) = -∞.
-            // Avoids 0 · log(0) = NaN in the generic formula.
             if (p == 1f) { lp[i] = k == 0f ? 0f : float.NegativeInfinity; continue; }
             lp[i] = k * MathF.Log(1f - p) + MathF.Log(p);
         }
@@ -412,8 +432,7 @@ public sealed class GeometricDistribution : DistributionBase
         var h = new float[BatchSize];
         for (int i = 0; i < BatchSize; i++)
         {
-            float p = Probs[i];
-            // p == 1 ⇒ deterministic point mass at 0 ⇒ entropy 0.
+            float p = _probs[i];
             if (p == 1f) { h[i] = 0f; continue; }
             h[i] = -(p * MathF.Log(p) + (1f - p) * MathF.Log(1f - p)) / p;
         }
@@ -421,34 +440,41 @@ public sealed class GeometricDistribution : DistributionBase
     }
     /// <inheritdoc />
     public override float[] Mean
-    { get { var m = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) m[i] = (1f - Probs[i]) / Probs[i]; return m; } }
+    { get { var m = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) m[i] = (1f - _probs[i]) / _probs[i]; return m; } }
     /// <inheritdoc />
     public override float[] Variance
-    { get { var v = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) v[i] = (1f - Probs[i]) / (Probs[i] * Probs[i]); return v; } }
+    { get { var v = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) v[i] = (1f - _probs[i]) / (_probs[i] * _probs[i]); return v; } }
 }
 
 /// <summary>Poisson distribution: f(k) = e^-λ · λ^k / k!.</summary>
 public sealed class PoissonDistribution : DistributionBase
 {
-    /// <summary>Per-batch rate λ &gt; 0.</summary>
-    public float[] Rate { get; }
+    private readonly float[] _rate;
+    /// <summary>Per-batch rate λ ≥ 0. Returns a defensive copy.</summary>
+    public float[] Rate => (float[])_rate.Clone();
     /// <inheritdoc />
-    public override int BatchSize => Rate.Length;
+    public override int BatchSize => _rate.Length;
     /// <inheritdoc />
     public override int EventSize => 1;
     /// <inheritdoc />
-    public override IConstraint Support => NonNegativeConstraint.Instance;
+    public override IConstraint Support => NonNegativeIntegerConstraint.Instance;
     /// <summary>Build a Poisson from per-batch rate.</summary>
     public PoissonDistribution(float[] rate)
     {
-        for (int i = 0; i < rate.Length; i++) if (!(rate[i] >= 0f)) throw new ArgumentException("rate >= 0.");
-        Rate = (float[])rate.Clone();
+        if (rate == null) throw new ArgumentNullException(nameof(rate));
+        for (int i = 0; i < rate.Length; i++)
+        {
+            float r = rate[i];
+            if (float.IsNaN(r) || float.IsInfinity(r) || !(r >= 0f))
+                throw new ArgumentException("rate must be finite and ≥ 0.");
+        }
+        _rate = (float[])rate.Clone();
     }
     /// <inheritdoc />
     public override float[] Sample(Random rng)
     {
         var x = new float[BatchSize];
-        for (int i = 0; i < BatchSize; i++) x[i] = SamplePoisson(rng, Rate[i]);
+        for (int i = 0; i < BatchSize; i++) x[i] = SamplePoisson(rng, _rate[i]);
         return x;
     }
     /// <inheritdoc />
@@ -460,22 +486,18 @@ public sealed class PoissonDistribution : DistributionBase
         {
             float k = value[i];
             if (k < 0 || k != MathF.Floor(k)) { lp[i] = float.NegativeInfinity; continue; }
-            // Degenerate Poisson(λ=0): the distribution is a point mass at 0.
-            // log p(0|0) = 0; log p(k>0|0) = -∞. Avoids log(0) = -∞ contaminating k=0.
-            if (Rate[i] == 0f) { lp[i] = k == 0f ? 0f : float.NegativeInfinity; continue; }
-            lp[i] = k * MathF.Log(Rate[i]) - Rate[i] - SpecialFunctions.Lgamma(k + 1f);
+            if (_rate[i] == 0f) { lp[i] = k == 0f ? 0f : float.NegativeInfinity; continue; }
+            lp[i] = k * MathF.Log(_rate[i]) - _rate[i] - SpecialFunctions.Lgamma(k + 1f);
         }
         return lp;
     }
     /// <inheritdoc />
     public override float[] Entropy()
     {
-        // Numerical sum (closed form involves ψ).
         var h = new float[BatchSize];
         for (int i = 0; i < BatchSize; i++)
         {
-            float lambda = Rate[i];
-            // Truncate at lambda + 10·sqrt(lambda) — captures essentially all mass.
+            float lambda = _rate[i];
             int kmax = (int)MathF.Ceiling(lambda + 10f * MathF.Sqrt(lambda + 1f));
             double s = 0;
             for (int k = 0; k <= kmax; k++)
@@ -488,9 +510,9 @@ public sealed class PoissonDistribution : DistributionBase
         return h;
     }
     /// <inheritdoc />
-    public override float[] Mean => (float[])Rate.Clone();
+    public override float[] Mean => (float[])_rate.Clone();
     /// <inheritdoc />
-    public override float[] Variance => (float[])Rate.Clone();
+    public override float[] Variance => (float[])_rate.Clone();
 
     /// <summary>Knuth's Poisson sampler for small λ; transformed-rejection for large λ.</summary>
     internal static float SamplePoisson(Random rng, float lambda)
@@ -525,38 +547,42 @@ public sealed class PoissonDistribution : DistributionBase
 /// <summary>Negative binomial distribution: number of failures before <c>totalCount</c> successes.</summary>
 public sealed class NegativeBinomialDistribution : DistributionBase
 {
-    /// <summary>Number of successes (per batch). Real-valued; PyTorch parity.</summary>
-    public float[] TotalCount { get; }
-    /// <summary>Per-batch success probability.</summary>
-    public float[] Probs { get; }
+    private readonly float[] _totalCount;
+    private readonly float[] _probs;
+    /// <summary>Number of successes (per batch). Real-valued; PyTorch parity. Returns a defensive copy.</summary>
+    public float[] TotalCount => (float[])_totalCount.Clone();
+    /// <summary>Per-batch success probability. Returns a defensive copy.</summary>
+    public float[] Probs => (float[])_probs.Clone();
     /// <inheritdoc />
-    public override int BatchSize => Probs.Length;
+    public override int BatchSize => _probs.Length;
     /// <inheritdoc />
     public override int EventSize => 1;
     /// <inheritdoc />
-    public override IConstraint Support => NonNegativeConstraint.Instance;
+    public override IConstraint Support => NonNegativeIntegerConstraint.Instance;
     /// <summary>Build a negative binomial.</summary>
     public NegativeBinomialDistribution(float[] totalCount, float[] probs)
     {
+        if (totalCount == null) throw new ArgumentNullException(nameof(totalCount));
+        if (probs == null) throw new ArgumentNullException(nameof(probs));
         if (totalCount.Length != probs.Length) throw new ArgumentException();
         for (int i = 0; i < probs.Length; i++)
         {
-            if (!(totalCount[i] > 0f)) throw new ArgumentException("totalCount > 0.");
-            // Reject p == 0 outright — Sample divides by p and (1−p)/p would blow up.
-            // p == 1 is also disallowed because all mass would be on k = 0.
-            if (!(probs[i] > 0f && probs[i] < 1f)) throw new ArgumentException("probs ∈ (0, 1).");
+            float r = totalCount[i]; float p = probs[i];
+            if (float.IsNaN(r) || float.IsInfinity(r) || !(r > 0f))
+                throw new ArgumentException("totalCount must be finite and > 0.");
+            if (float.IsNaN(p) || float.IsInfinity(p) || !(p > 0f && p < 1f))
+                throw new ArgumentException("probs must be finite and in (0, 1).");
         }
-        TotalCount = (float[])totalCount.Clone(); Probs = (float[])probs.Clone();
+        _totalCount = (float[])totalCount.Clone(); _probs = (float[])probs.Clone();
     }
     /// <inheritdoc />
     public override float[] Sample(Random rng)
     {
-        // Sample λ ∼ Gamma(r, (1-p)/p); k ∼ Poisson(λ).
         var x = new float[BatchSize];
         for (int i = 0; i < BatchSize; i++)
         {
-            float scale = (1f - Probs[i]) / Probs[i];
-            float lambda = GammaDistribution.MarsagliaTsang(rng, TotalCount[i]) * scale;
+            float scale = (1f - _probs[i]) / _probs[i];
+            float lambda = GammaDistribution.MarsagliaTsang(rng, _totalCount[i]) * scale;
             x[i] = PoissonDistribution.SamplePoisson(rng, lambda);
         }
         return x;
@@ -568,8 +594,7 @@ public sealed class NegativeBinomialDistribution : DistributionBase
         var lp = new float[BatchSize];
         for (int i = 0; i < BatchSize; i++)
         {
-            float k = value[i]; float r = TotalCount[i]; float p = Probs[i];
-            // k must be a non-negative integer; Lgamma alone would silently accept fractions.
+            float k = value[i]; float r = _totalCount[i]; float p = _probs[i];
             if (k < 0f || k != MathF.Floor(k)) { lp[i] = float.NegativeInfinity; continue; }
             lp[i] = SpecialFunctions.Lgamma(r + k) - SpecialFunctions.Lgamma(k + 1f) - SpecialFunctions.Lgamma(r)
                   + r * MathF.Log(p) + k * MathF.Log(1f - p);
@@ -580,53 +605,60 @@ public sealed class NegativeBinomialDistribution : DistributionBase
     public override float[] Entropy()
     {
         var h = new float[BatchSize];
-        for (int i = 0; i < BatchSize; i++) h[i] = float.NaN;  // no closed form; user can MC-estimate
+        for (int i = 0; i < BatchSize; i++) h[i] = float.NaN;
         return h;
     }
     /// <inheritdoc />
     public override float[] Mean
-    { get { var m = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) m[i] = TotalCount[i] * (1f - Probs[i]) / Probs[i]; return m; } }
+    { get { var m = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) m[i] = _totalCount[i] * (1f - _probs[i]) / _probs[i]; return m; } }
     /// <inheritdoc />
     public override float[] Variance
-    { get { var v = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) v[i] = TotalCount[i] * (1f - Probs[i]) / (Probs[i] * Probs[i]); return v; } }
+    { get { var v = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) v[i] = _totalCount[i] * (1f - _probs[i]) / (_probs[i] * _probs[i]); return v; } }
 }
 
 /// <summary>Multinomial distribution: <c>totalCount</c> draws from a categorical.</summary>
 public sealed class MultinomialDistribution : DistributionBase
 {
-    /// <summary>Trials per batch element.</summary>
-    public int[] TotalCount { get; }
-    /// <summary>Per-batch probability vectors, layout <c>[batch, K]</c>.</summary>
-    public float[] Probs { get; }
+    private readonly int[] _totalCount;
+    private readonly float[] _probs;
+    /// <summary>Trials per batch element. Returns a defensive copy.</summary>
+    public int[] TotalCount => (int[])_totalCount.Clone();
+    /// <summary>Per-batch probability vectors, layout <c>[batch, K]</c>. Returns a defensive copy.</summary>
+    public float[] Probs => (float[])_probs.Clone();
     /// <summary>Number of categories.</summary>
     public int K { get; }
     /// <inheritdoc />
-    public override int BatchSize => TotalCount.Length;
+    public override int BatchSize => _totalCount.Length;
     /// <inheritdoc />
     public override int EventSize => K;
     /// <inheritdoc />
-    public override IConstraint Support => NonNegativeConstraint.Instance;
+    /// <remarks>Each row must be a non-negative integer count vector summing to the
+    /// matching <see cref="TotalCount"/> entry — a plain non-negative constraint
+    /// would over-advertise the support.</remarks>
+    public override IConstraint Support => new IntegerSimplexConstraint(K, _totalCount);
     /// <summary>Build a Multinomial from totalCount + probs.</summary>
     public MultinomialDistribution(int[] totalCount, float[] probs, int k)
     {
+        if (totalCount == null) throw new ArgumentNullException(nameof(totalCount));
+        if (probs == null) throw new ArgumentNullException(nameof(probs));
         if (k <= 0) throw new ArgumentException("K > 0.");
         if (probs.Length != totalCount.Length * k) throw new ArgumentException("probs length mismatch.");
-        // Each row of probs must be a valid probability vector (non-negative, sum to 1).
-        // Same validation surface as CategoricalDistribution.
         int batch = totalCount.Length;
         for (int b = 0; b < batch; b++)
         {
             float sum = 0f;
             for (int i = 0; i < k; i++)
             {
-                if (probs[b * k + i] < 0f) throw new ArgumentException($"probs[{b}, {i}] = {probs[b * k + i]} must be ≥ 0.");
-                sum += probs[b * k + i];
+                float p = probs[b * k + i];
+                if (float.IsNaN(p) || float.IsInfinity(p) || p < 0f)
+                    throw new ArgumentException($"probs[{b}, {i}] = {p} must be finite and ≥ 0.");
+                sum += p;
             }
-            if (MathF.Abs(sum - 1f) > 1e-3f)
+            if (float.IsNaN(sum) || float.IsInfinity(sum) || MathF.Abs(sum - 1f) > 1e-3f)
                 throw new ArgumentException($"probs row {b} must sum to 1 (got {sum}).");
             if (totalCount[b] < 0) throw new ArgumentException($"totalCount[{b}] = {totalCount[b]} must be >= 0.");
         }
-        TotalCount = (int[])totalCount.Clone(); Probs = (float[])probs.Clone(); K = k;
+        _totalCount = (int[])totalCount.Clone(); _probs = (float[])probs.Clone(); K = k;
     }
     /// <inheritdoc />
     public override float[] Sample(Random rng)
@@ -634,13 +666,13 @@ public sealed class MultinomialDistribution : DistributionBase
         var x = new float[BatchSize * K];
         for (int b = 0; b < BatchSize; b++)
         {
-            for (int t = 0; t < TotalCount[b]; t++)
+            for (int t = 0; t < _totalCount[b]; t++)
             {
                 float u = (float)rng.NextDouble();
                 float cum = 0f; int chosen = K - 1;
                 for (int i = 0; i < K; i++)
                 {
-                    cum += Probs[b * K + i];
+                    cum += _probs[b * K + i];
                     if (u <= cum) { chosen = i; break; }
                 }
                 x[b * K + chosen]++;
@@ -655,11 +687,7 @@ public sealed class MultinomialDistribution : DistributionBase
         var lp = new float[BatchSize];
         for (int b = 0; b < BatchSize; b++)
         {
-            int n = TotalCount[b];
-            // Validate the count vector: each k_i must be a non-negative integer and
-            // Σ k_i must equal n. Accumulate the integer cast (after the float-integrality
-            // check) so float rounding can't make a row sum mistakenly compare equal to n
-            // (or vice versa) for high-count cases.
+            int n = _totalCount[b];
             long sumK = 0;
             bool valid = true;
             for (int i = 0; i < K; i++)
@@ -674,7 +702,7 @@ public sealed class MultinomialDistribution : DistributionBase
             for (int i = 0; i < K; i++)
             {
                 float k = value[b * K + i];
-                float p = Probs[b * K + i];
+                float p = _probs[b * K + i];
                 l -= SpecialFunctions.Lgamma(k + 1f);
                 if (p > 0f) l += k * MathF.Log(p);
                 else if (k > 0f) l = float.NegativeInfinity;
@@ -698,7 +726,7 @@ public sealed class MultinomialDistribution : DistributionBase
             var m = new float[BatchSize * K];
             for (int b = 0; b < BatchSize; b++)
                 for (int i = 0; i < K; i++)
-                    m[b * K + i] = TotalCount[b] * Probs[b * K + i];
+                    m[b * K + i] = _totalCount[b] * _probs[b * K + i];
             return m;
         }
     }
@@ -711,8 +739,8 @@ public sealed class MultinomialDistribution : DistributionBase
             for (int b = 0; b < BatchSize; b++)
                 for (int i = 0; i < K; i++)
                 {
-                    float p = Probs[b * K + i];
-                    v[b * K + i] = TotalCount[b] * p * (1f - p);
+                    float p = _probs[b * K + i];
+                    v[b * K + i] = _totalCount[b] * p * (1f - p);
                 }
             return v;
         }

--- a/src/AiDotNet.Tensors/Distributions/DiscreteDistributions.cs
+++ b/src/AiDotNet.Tensors/Distributions/DiscreteDistributions.cs
@@ -342,7 +342,7 @@ public sealed class OneHotCategoricalDistribution : DistributionBase
     /// <inheritdoc />
     public override float[] Entropy() => _inner.Entropy();
     /// <inheritdoc />
-    public override float[] Mean => Probs;
+    public override float[] Mean => (float[])Probs.Clone();  // never expose internal storage
     /// <inheritdoc />
     public override float[] Variance
     {
@@ -397,9 +397,12 @@ public sealed class GeometricDistribution : DistributionBase
         var lp = new float[BatchSize];
         for (int i = 0; i < BatchSize; i++)
         {
-            float k = value[i];
+            float k = value[i]; float p = Probs[i];
             if (k < 0 || k != MathF.Floor(k)) { lp[i] = float.NegativeInfinity; continue; }
-            lp[i] = k * MathF.Log(1f - Probs[i]) + MathF.Log(Probs[i]);
+            // Deterministic edge p == 1: all mass is on k = 0; otherwise log(0) = -∞.
+            // Avoids 0 · log(0) = NaN in the generic formula.
+            if (p == 1f) { lp[i] = k == 0f ? 0f : float.NegativeInfinity; continue; }
+            lp[i] = k * MathF.Log(1f - p) + MathF.Log(p);
         }
         return lp;
     }
@@ -410,6 +413,8 @@ public sealed class GeometricDistribution : DistributionBase
         for (int i = 0; i < BatchSize; i++)
         {
             float p = Probs[i];
+            // p == 1 ⇒ deterministic point mass at 0 ⇒ entropy 0.
+            if (p == 1f) { h[i] = 0f; continue; }
             h[i] = -(p * MathF.Log(p) + (1f - p) * MathF.Log(1f - p)) / p;
         }
         return h;
@@ -652,16 +657,16 @@ public sealed class MultinomialDistribution : DistributionBase
         {
             int n = TotalCount[b];
             // Validate the count vector: each k_i must be a non-negative integer and
-            // Σ k_i must equal n. Otherwise the count vector is impossible under this
-            // multinomial — the analytical formula would otherwise return a finite (and
-            // wrong) value for fractional or mis-summed inputs.
-            float sumK = 0f;
+            // Σ k_i must equal n. Accumulate the integer cast (after the float-integrality
+            // check) so float rounding can't make a row sum mistakenly compare equal to n
+            // (or vice versa) for high-count cases.
+            long sumK = 0;
             bool valid = true;
             for (int i = 0; i < K; i++)
             {
                 float k = value[b * K + i];
                 if (k < 0f || k != MathF.Floor(k)) { valid = false; break; }
-                sumK += k;
+                sumK += (long)k;
             }
             if (!valid || sumK != n) { lp[b] = float.NegativeInfinity; continue; }
 

--- a/src/AiDotNet.Tensors/Distributions/DistributionBase.cs
+++ b/src/AiDotNet.Tensors/Distributions/DistributionBase.cs
@@ -1,0 +1,69 @@
+using System;
+using AiDotNet.Tensors.Distributions.Constraints;
+
+namespace AiDotNet.Tensors.Distributions;
+
+/// <summary>
+/// Default implementations for the boilerplate parts of <see cref="IDistribution"/>:
+/// <see cref="StdDev"/> derives from <see cref="Variance"/>, <see cref="RSample"/>
+/// throws when <see cref="HasRSample"/> is false, CDF/ICDF default to throwing for
+/// distributions without a closed-form expression.
+/// </summary>
+public abstract class DistributionBase : IDistribution
+{
+    /// <inheritdoc />
+    public abstract int BatchSize { get; }
+    /// <inheritdoc />
+    public abstract int EventSize { get; }
+    /// <inheritdoc />
+    public abstract IConstraint Support { get; }
+    /// <inheritdoc />
+    public virtual bool HasRSample => false;
+
+    /// <inheritdoc />
+    public abstract float[] Sample(Random rng);
+
+    /// <inheritdoc />
+    public virtual float[] RSample(Random rng) =>
+        throw new NotSupportedException(GetType().Name + " is not reparameterisable.");
+
+    /// <inheritdoc />
+    public abstract float[] LogProb(float[] value);
+
+    /// <inheritdoc />
+    public abstract float[] Entropy();
+
+    /// <inheritdoc />
+    public abstract float[] Mean { get; }
+    /// <inheritdoc />
+    public abstract float[] Variance { get; }
+
+    /// <inheritdoc />
+    public virtual float[] StdDev
+    {
+        get
+        {
+            var v = Variance;
+            var s = new float[v.Length];
+            for (int i = 0; i < v.Length; i++) s[i] = MathF.Sqrt(v[i]);
+            return s;
+        }
+    }
+
+    /// <inheritdoc />
+    public virtual float[] Cdf(float[] value) =>
+        throw new NotSupportedException(GetType().Name + " has no closed-form CDF.");
+
+    /// <inheritdoc />
+    public virtual float[] Icdf(float[] probability) =>
+        throw new NotSupportedException(GetType().Name + " has no closed-form inverse CDF.");
+
+    /// <summary>Validate that <paramref name="value"/>'s length is compatible with this distribution's shape.</summary>
+    protected void EnsureValueShape(float[] value)
+    {
+        int expected = BatchSize * EventSize;
+        if (value.Length != expected)
+            throw new ArgumentException(
+                $"value length {value.Length} != BatchSize·EventSize {expected}.");
+    }
+}

--- a/src/AiDotNet.Tensors/Distributions/ExpandingDistribution.cs
+++ b/src/AiDotNet.Tensors/Distributions/ExpandingDistribution.cs
@@ -49,9 +49,32 @@ public sealed class ExpandingDistribution : DistributionBase
     }
 
     /// <inheritdoc />
-    public override float[] Sample(Random rng) => Replicate(Base.Sample(rng));
+    public override float[] Sample(Random rng)
+    {
+        // PyTorch parity: expand SHARES parameters but draws fresh samples for each
+        // expanded block. Replicating the same draw across the expanded batch would
+        // break Monte-Carlo estimators that rely on independent samples.
+        int blockLen = Base.BatchSize * Base.EventSize;
+        var dst = new float[BatchSize * EventSize];
+        for (int r = 0; r < RepeatFactor; r++)
+        {
+            var sample = Base.Sample(rng);
+            Array.Copy(sample, 0, dst, r * blockLen, blockLen);
+        }
+        return dst;
+    }
     /// <inheritdoc />
-    public override float[] RSample(Random rng) => Replicate(Base.RSample(rng));
+    public override float[] RSample(Random rng)
+    {
+        int blockLen = Base.BatchSize * Base.EventSize;
+        var dst = new float[BatchSize * EventSize];
+        for (int r = 0; r < RepeatFactor; r++)
+        {
+            var sample = Base.RSample(rng);
+            Array.Copy(sample, 0, dst, r * blockLen, blockLen);
+        }
+        return dst;
+    }
 
     /// <inheritdoc />
     public override float[] LogProb(float[] value)

--- a/src/AiDotNet.Tensors/Distributions/ExpandingDistribution.cs
+++ b/src/AiDotNet.Tensors/Distributions/ExpandingDistribution.cs
@@ -1,0 +1,87 @@
+using System;
+using AiDotNet.Tensors.Distributions.Constraints;
+
+namespace AiDotNet.Tensors.Distributions;
+
+/// <summary>
+/// Wraps an existing distribution and broadcasts its batch dimension to a larger size.
+/// Useful when a single set of parameters needs to be reused across many simulations.
+/// Mirrors PyTorch <c>Distribution.expand(batch_shape)</c>.
+///
+/// Sampling and log_prob simply replicate the base distribution's outputs along the
+/// expanded axis, so per-batch parameters remain shared.
+/// </summary>
+public sealed class ExpandingDistribution : DistributionBase
+{
+    /// <summary>Underlying base distribution.</summary>
+    public IDistribution Base { get; }
+    /// <summary>Expanded batch size.</summary>
+    public override int BatchSize { get; }
+    /// <inheritdoc />
+    public override int EventSize => Base.EventSize;
+    /// <inheritdoc />
+    public override IConstraint Support => Base.Support;
+    /// <inheritdoc />
+    public override bool HasRSample => Base.HasRSample;
+
+    /// <summary>Build an expanded view of <paramref name="@base"/> with new batch size <paramref name="batchSize"/>.
+    /// Must be a multiple of the base's batch size so each base param is replicated an integer number of times.</summary>
+    public ExpandingDistribution(IDistribution @base, int batchSize)
+    {
+        Base = @base ?? throw new ArgumentNullException(nameof(@base));
+        if (batchSize <= 0) throw new ArgumentOutOfRangeException(nameof(batchSize));
+        if (batchSize % @base.BatchSize != 0)
+            throw new ArgumentException(
+                $"new batchSize ({batchSize}) must be a multiple of base.BatchSize ({@base.BatchSize}).");
+        BatchSize = batchSize;
+    }
+
+    private int RepeatFactor => BatchSize / Base.BatchSize;
+
+    private float[] Replicate(float[] perBaseBatch)
+    {
+        int baseLen = perBaseBatch.Length;
+        int rep = RepeatFactor;
+        var dst = new float[baseLen * rep];
+        for (int r = 0; r < rep; r++)
+            Array.Copy(perBaseBatch, 0, dst, r * baseLen, baseLen);
+        return dst;
+    }
+
+    /// <inheritdoc />
+    public override float[] Sample(Random rng) => Replicate(Base.Sample(rng));
+    /// <inheritdoc />
+    public override float[] RSample(Random rng) => Replicate(Base.RSample(rng));
+
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        // Reduce the expanded value back to base shape by summing matching slices? No — log_prob
+        // is per batch element. We pull the first base.BatchSize·EventSize entries to evaluate,
+        // then replicate. This matches PyTorch's expand semantics where the parameters are shared.
+        int baseLen = Base.BatchSize * Base.EventSize;
+        var slice = new float[baseLen];
+        Array.Copy(value, 0, slice, 0, baseLen);
+        var lpBase = Base.LogProb(slice);
+        var lp = new float[BatchSize];
+        int rep = RepeatFactor;
+        for (int r = 0; r < rep; r++)
+            Array.Copy(lpBase, 0, lp, r * Base.BatchSize, Base.BatchSize);
+        // For repeats r > 0, recompute against the corresponding value slice for correctness.
+        for (int r = 1; r < rep; r++)
+        {
+            Array.Copy(value, r * baseLen, slice, 0, baseLen);
+            var lpr = Base.LogProb(slice);
+            Array.Copy(lpr, 0, lp, r * Base.BatchSize, Base.BatchSize);
+        }
+        return lp;
+    }
+
+    /// <inheritdoc />
+    public override float[] Entropy() => Replicate(Base.Entropy());
+    /// <inheritdoc />
+    public override float[] Mean => Replicate(Base.Mean);
+    /// <inheritdoc />
+    public override float[] Variance => Replicate(Base.Variance);
+}

--- a/src/AiDotNet.Tensors/Distributions/ExpandingDistribution.cs
+++ b/src/AiDotNet.Tensors/Distributions/ExpandingDistribution.cs
@@ -8,8 +8,10 @@ namespace AiDotNet.Tensors.Distributions;
 /// Useful when a single set of parameters needs to be reused across many simulations.
 /// Mirrors PyTorch <c>Distribution.expand(batch_shape)</c>.
 ///
-/// Sampling and log_prob simply replicate the base distribution's outputs along the
-/// expanded axis, so per-batch parameters remain shared.
+/// Parameters are SHARED across the expanded batch but each repeated block draws
+/// independently — calling <see cref="Sample"/> / <see cref="RSample"/> invokes the
+/// underlying base sampler once per repeat factor so Monte-Carlo estimators see fresh
+/// (i.i.d.) samples rather than copies of a single draw.
 /// </summary>
 public sealed class ExpandingDistribution : DistributionBase
 {

--- a/src/AiDotNet.Tensors/Distributions/ExponentialFamily.cs
+++ b/src/AiDotNet.Tensors/Distributions/ExponentialFamily.cs
@@ -1,0 +1,36 @@
+using System;
+using AiDotNet.Tensors.Distributions.Constraints;
+
+namespace AiDotNet.Tensors.Distributions;
+
+/// <summary>
+/// Abstract base for exponential-family distributions with density of the form
+///   f(x; η) = h(x) · exp(η·T(x) − A(η))
+/// where η are the natural parameters, T(x) is the sufficient statistic, A(η) is the
+/// log-partition / cumulant function, and h(x) is the carrier measure.
+///
+/// Provides analytical helpers used by entropy/KL formulas:
+///  * <see cref="NaturalParameters"/> — η
+///  * <see cref="LogNormalizer"/>      — A(η)
+///  * <see cref="MeanCarrierMeasure"/> — E[log h(X)]
+///
+/// Concrete subclasses still implement <see cref="DistributionBase.Sample"/>,
+/// <see cref="DistributionBase.LogProb"/>, etc. — this base just provides the
+/// extra hooks for code that wants to exploit exponential-family structure
+/// (e.g. natural-gradient optimization, conjugate-prior updates).
+/// </summary>
+public abstract class ExponentialFamily : DistributionBase
+{
+    /// <summary>Natural parameters η. Layout <c>[batch, num_params]</c> (subclass-defined).</summary>
+    public abstract float[] NaturalParameters { get; }
+
+    /// <summary>Log-partition A(η) per batch element. Length = <see cref="DistributionBase.BatchSize"/>.</summary>
+    public abstract float[] LogNormalizer { get; }
+
+    /// <summary>Sufficient statistic T(x) for a supplied <paramref name="value"/>.
+    /// Layout <c>[batch, num_stats]</c>.</summary>
+    public abstract float[] SufficientStatistic(float[] value);
+
+    /// <summary>Mean of log h(X) — usually a constant per batch element.</summary>
+    public abstract float[] MeanCarrierMeasure { get; }
+}

--- a/src/AiDotNet.Tensors/Distributions/GammaFamilyDistributions.cs
+++ b/src/AiDotNet.Tensors/Distributions/GammaFamilyDistributions.cs
@@ -1,0 +1,660 @@
+using System;
+using AiDotNet.Tensors.Distributions.Constraints;
+using AiDotNet.Tensors.Distributions.Helpers;
+
+namespace AiDotNet.Tensors.Distributions;
+
+/// <summary>
+/// Gamma distribution Γ(α, β). Marsaglia-Tsang sampler.
+/// Reparameterisable via implicit reparameterisation (Figurnov et al., 2018) — but here
+/// we expose the rejection-based <see cref="Sample"/> only; <see cref="HasRSample"/> is
+/// true and <see cref="RSample"/> uses the same path (the gradient w.r.t. shape requires
+/// implicit reparam machinery and is implemented in the autograd layer).
+/// </summary>
+public sealed class GammaDistribution : DistributionBase
+{
+    /// <summary>Shape parameter α &gt; 0.</summary>
+    public float[] Concentration { get; }
+    /// <summary>Rate parameter β &gt; 0 (1 / scale).</summary>
+    public float[] Rate { get; }
+    /// <inheritdoc />
+    public override int BatchSize => Concentration.Length;
+    /// <inheritdoc />
+    public override int EventSize => 1;
+    /// <inheritdoc />
+    public override IConstraint Support => PositiveConstraint.Instance;
+    /// <inheritdoc />
+    public override bool HasRSample => true;
+
+    /// <summary>Build a Gamma from per-batch concentration and rate.</summary>
+    public GammaDistribution(float[] concentration, float[] rate)
+    {
+        if (concentration.Length != rate.Length) throw new ArgumentException();
+        for (int i = 0; i < concentration.Length; i++)
+        {
+            if (!(concentration[i] > 0f)) throw new ArgumentException("concentration > 0.");
+            if (!(rate[i] > 0f)) throw new ArgumentException("rate > 0.");
+        }
+        Concentration = concentration; Rate = rate;
+    }
+    /// <inheritdoc />
+    public override float[] Sample(Random rng) => RSample(rng);
+    /// <inheritdoc />
+    public override float[] RSample(Random rng)
+    {
+        var x = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+            x[i] = MarsagliaTsang(rng, Concentration[i]) / Rate[i];
+        return x;
+    }
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        var lp = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            if (value[i] <= 0) { lp[i] = float.NegativeInfinity; continue; }
+            float a = Concentration[i]; float b = Rate[i];
+            lp[i] = a * MathF.Log(b) + (a - 1f) * MathF.Log(value[i]) - b * value[i] - SpecialFunctions.Lgamma(a);
+        }
+        return lp;
+    }
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        var h = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            float a = Concentration[i];
+            h[i] = a - MathF.Log(Rate[i]) + SpecialFunctions.Lgamma(a) + (1f - a) * SpecialFunctions.Digamma(a);
+        }
+        return h;
+    }
+    /// <inheritdoc />
+    public override float[] Mean
+    { get { var m = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) m[i] = Concentration[i] / Rate[i]; return m; } }
+    /// <inheritdoc />
+    public override float[] Variance
+    { get { var v = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) v[i] = Concentration[i] / (Rate[i] * Rate[i]); return v; } }
+    /// <inheritdoc />
+    public override float[] Cdf(float[] value)
+    {
+        EnsureValueShape(value);
+        var c = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+            c[i] = SpecialFunctions.GammaP(Concentration[i], Rate[i] * value[i]);
+        return c;
+    }
+
+    /// <summary>Marsaglia-Tsang rejection sampler for Gamma(α, 1).</summary>
+    internal static float MarsagliaTsang(Random rng, float alpha)
+    {
+        if (alpha < 1f)
+        {
+            // Boost: G(α) = G(α + 1) · U^(1/α).
+            float g = MarsagliaTsang(rng, alpha + 1f);
+            double u = rng.NextDouble();
+            if (u < 1e-12) u = 1e-12;
+            return g * MathF.Pow((float)u, 1f / alpha);
+        }
+        double d = alpha - 1.0 / 3.0;
+        double c = 1.0 / Math.Sqrt(9.0 * d);
+        while (true)
+        {
+            double z = NormalDistribution.Gaussian(rng);
+            double v = 1.0 + c * z;
+            if (v <= 0) continue;
+            v = v * v * v;
+            double u = rng.NextDouble();
+            if (u < 1.0 - 0.0331 * z * z * z * z) return (float)(d * v);
+            if (Math.Log(u) < 0.5 * z * z + d * (1.0 - v + Math.Log(v))) return (float)(d * v);
+        }
+    }
+}
+
+/// <summary>Inverse Gamma: 1/X for X ∼ Gamma(α, β).</summary>
+public sealed class InverseGammaDistribution : DistributionBase
+{
+    /// <summary>Shape α.</summary>
+    public float[] Concentration { get; }
+    /// <summary>Scale β (note: PyTorch's InverseGamma uses scale, not rate).</summary>
+    public float[] Scale { get; }
+    /// <inheritdoc />
+    public override int BatchSize => Concentration.Length;
+    /// <inheritdoc />
+    public override int EventSize => 1;
+    /// <inheritdoc />
+    public override IConstraint Support => PositiveConstraint.Instance;
+    /// <inheritdoc />
+    public override bool HasRSample => true;
+    /// <summary>Build an Inverse Gamma from per-batch shape/scale.</summary>
+    public InverseGammaDistribution(float[] concentration, float[] scale)
+    {
+        if (concentration.Length != scale.Length) throw new ArgumentException();
+        for (int i = 0; i < concentration.Length; i++)
+        {
+            if (!(concentration[i] > 0f)) throw new ArgumentException("concentration > 0.");
+            if (!(scale[i] > 0f)) throw new ArgumentException("scale > 0.");
+        }
+        Concentration = concentration; Scale = scale;
+    }
+    /// <inheritdoc />
+    public override float[] Sample(Random rng) => RSample(rng);
+    /// <inheritdoc />
+    public override float[] RSample(Random rng)
+    {
+        var x = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            float g = GammaDistribution.MarsagliaTsang(rng, Concentration[i]);
+            x[i] = Scale[i] / g;
+        }
+        return x;
+    }
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        var lp = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            if (value[i] <= 0) { lp[i] = float.NegativeInfinity; continue; }
+            float a = Concentration[i]; float s = Scale[i];
+            lp[i] = a * MathF.Log(s) - SpecialFunctions.Lgamma(a)
+                  - (a + 1f) * MathF.Log(value[i]) - s / value[i];
+        }
+        return lp;
+    }
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        var h = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            float a = Concentration[i];
+            h[i] = a + MathF.Log(Scale[i]) + SpecialFunctions.Lgamma(a) - (1f + a) * SpecialFunctions.Digamma(a);
+        }
+        return h;
+    }
+    /// <inheritdoc />
+    public override float[] Mean
+    {
+        get
+        {
+            var m = new float[BatchSize];
+            for (int i = 0; i < BatchSize; i++)
+                m[i] = Concentration[i] > 1f ? Scale[i] / (Concentration[i] - 1f) : float.PositiveInfinity;
+            return m;
+        }
+    }
+    /// <inheritdoc />
+    public override float[] Variance
+    {
+        get
+        {
+            var v = new float[BatchSize];
+            for (int i = 0; i < BatchSize; i++)
+            {
+                float a = Concentration[i]; float s = Scale[i];
+                v[i] = a > 2f ? s * s / ((a - 1f) * (a - 1f) * (a - 2f)) : float.PositiveInfinity;
+            }
+            return v;
+        }
+    }
+}
+
+/// <summary>Chi-squared distribution: χ²(k) = Gamma(k/2, 1/2).</summary>
+public sealed class Chi2Distribution : DistributionBase
+{
+    /// <summary>Degrees of freedom (must be &gt; 0).</summary>
+    public float[] Df { get; }
+    /// <inheritdoc />
+    public override int BatchSize => Df.Length;
+    /// <inheritdoc />
+    public override int EventSize => 1;
+    /// <inheritdoc />
+    public override IConstraint Support => PositiveConstraint.Instance;
+    /// <inheritdoc />
+    public override bool HasRSample => true;
+    /// <summary>Build a chi-squared from per-batch degrees of freedom.</summary>
+    public Chi2Distribution(float[] df)
+    {
+        for (int i = 0; i < df.Length; i++) if (!(df[i] > 0f)) throw new ArgumentException("df > 0.");
+        Df = df;
+    }
+    /// <inheritdoc />
+    public override float[] Sample(Random rng) => RSample(rng);
+    /// <inheritdoc />
+    public override float[] RSample(Random rng)
+    {
+        var x = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+            x[i] = 2f * GammaDistribution.MarsagliaTsang(rng, Df[i] * 0.5f);
+        return x;
+    }
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        var lp = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            if (value[i] <= 0) { lp[i] = float.NegativeInfinity; continue; }
+            float k = Df[i];
+            lp[i] = -k * 0.5f * MathF.Log(2f) - SpecialFunctions.Lgamma(k * 0.5f)
+                  + (k * 0.5f - 1f) * MathF.Log(value[i]) - 0.5f * value[i];
+        }
+        return lp;
+    }
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        var h = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            float k = Df[i] * 0.5f;
+            h[i] = k + MathF.Log(2f) + SpecialFunctions.Lgamma(k) + (1f - k) * SpecialFunctions.Digamma(k);
+        }
+        return h;
+    }
+    /// <inheritdoc />
+    public override float[] Mean => (float[])Df.Clone();
+    /// <inheritdoc />
+    public override float[] Variance
+    { get { var v = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) v[i] = 2f * Df[i]; return v; } }
+}
+
+/// <summary>Beta distribution Beta(α, β) on (0, 1).</summary>
+public sealed class BetaDistribution : DistributionBase
+{
+    /// <summary>α concentration parameter.</summary>
+    public float[] Concentration1 { get; }
+    /// <summary>β concentration parameter.</summary>
+    public float[] Concentration0 { get; }
+    /// <inheritdoc />
+    public override int BatchSize => Concentration1.Length;
+    /// <inheritdoc />
+    public override int EventSize => 1;
+    /// <inheritdoc />
+    public override IConstraint Support => UnitIntervalConstraint.Instance;
+    /// <inheritdoc />
+    public override bool HasRSample => true;
+    /// <summary>Build a Beta from per-batch (α, β).</summary>
+    public BetaDistribution(float[] concentration1, float[] concentration0)
+    {
+        if (concentration1.Length != concentration0.Length) throw new ArgumentException();
+        for (int i = 0; i < concentration1.Length; i++)
+        {
+            if (!(concentration1[i] > 0f)) throw new ArgumentException("α > 0.");
+            if (!(concentration0[i] > 0f)) throw new ArgumentException("β > 0.");
+        }
+        Concentration1 = concentration1; Concentration0 = concentration0;
+    }
+    /// <inheritdoc />
+    public override float[] Sample(Random rng) => RSample(rng);
+    /// <inheritdoc />
+    public override float[] RSample(Random rng)
+    {
+        var x = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            float ga = GammaDistribution.MarsagliaTsang(rng, Concentration1[i]);
+            float gb = GammaDistribution.MarsagliaTsang(rng, Concentration0[i]);
+            x[i] = ga / (ga + gb);
+        }
+        return x;
+    }
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        var lp = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            float v = value[i];
+            if (v <= 0f || v >= 1f) { lp[i] = float.NegativeInfinity; continue; }
+            float a = Concentration1[i]; float b = Concentration0[i];
+            lp[i] = (a - 1f) * MathF.Log(v) + (b - 1f) * MathF.Log(1f - v) - SpecialFunctions.LogBeta(a, b);
+        }
+        return lp;
+    }
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        var h = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            float a = Concentration1[i]; float b = Concentration0[i];
+            float ab = a + b;
+            h[i] = SpecialFunctions.LogBeta(a, b)
+                 - (a - 1f) * SpecialFunctions.Digamma(a)
+                 - (b - 1f) * SpecialFunctions.Digamma(b)
+                 + (ab - 2f) * SpecialFunctions.Digamma(ab);
+        }
+        return h;
+    }
+    /// <inheritdoc />
+    public override float[] Mean
+    {
+        get
+        {
+            var m = new float[BatchSize];
+            for (int i = 0; i < BatchSize; i++) m[i] = Concentration1[i] / (Concentration1[i] + Concentration0[i]);
+            return m;
+        }
+    }
+    /// <inheritdoc />
+    public override float[] Variance
+    {
+        get
+        {
+            var v = new float[BatchSize];
+            for (int i = 0; i < BatchSize; i++)
+            {
+                float a = Concentration1[i]; float b = Concentration0[i]; float ab = a + b;
+                v[i] = a * b / (ab * ab * (ab + 1f));
+            }
+            return v;
+        }
+    }
+    /// <inheritdoc />
+    public override float[] Cdf(float[] value)
+    {
+        EnsureValueShape(value);
+        var c = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+            c[i] = SpecialFunctions.BetaI(Concentration1[i], Concentration0[i], value[i]);
+        return c;
+    }
+}
+
+/// <summary>Student's t distribution.</summary>
+public sealed class StudentTDistribution : DistributionBase
+{
+    /// <summary>Degrees of freedom.</summary>
+    public float[] Df { get; }
+    /// <summary>Per-batch location.</summary>
+    public float[] Loc { get; }
+    /// <summary>Per-batch scale.</summary>
+    public float[] Scale { get; }
+    /// <inheritdoc />
+    public override int BatchSize => Df.Length;
+    /// <inheritdoc />
+    public override int EventSize => 1;
+    /// <inheritdoc />
+    public override IConstraint Support => RealConstraint.Instance;
+    /// <inheritdoc />
+    public override bool HasRSample => true;
+    /// <summary>Build a Student's-t from df, loc, scale.</summary>
+    public StudentTDistribution(float[] df, float[] loc, float[] scale)
+    {
+        if (df.Length != loc.Length || df.Length != scale.Length) throw new ArgumentException();
+        for (int i = 0; i < df.Length; i++)
+        {
+            if (!(df[i] > 0f)) throw new ArgumentException("df > 0.");
+            if (!(scale[i] > 0f)) throw new ArgumentException("scale > 0.");
+        }
+        Df = df; Loc = loc; Scale = scale;
+    }
+    /// <inheritdoc />
+    public override float[] Sample(Random rng) => RSample(rng);
+    /// <inheritdoc />
+    public override float[] RSample(Random rng)
+    {
+        // X = μ + σ · Z / sqrt(V/df) where Z ∼ N(0,1), V ∼ Chi²(df).
+        var x = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            double z = NormalDistribution.Gaussian(rng);
+            float v = 2f * GammaDistribution.MarsagliaTsang(rng, Df[i] * 0.5f);
+            x[i] = Loc[i] + Scale[i] * (float)z / MathF.Sqrt(v / Df[i]);
+        }
+        return x;
+    }
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        var lp = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            float df = Df[i];
+            float z = (value[i] - Loc[i]) / Scale[i];
+            float c = SpecialFunctions.Lgamma(0.5f * (df + 1f))
+                    - SpecialFunctions.Lgamma(0.5f * df)
+                    - 0.5f * MathF.Log(df * MathF.PI)
+                    - MathF.Log(Scale[i]);
+            lp[i] = c - 0.5f * (df + 1f) * MathF.Log(1f + z * z / df);
+        }
+        return lp;
+    }
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        var h = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            float df = Df[i];
+            h[i] = MathF.Log(Scale[i])
+                 + 0.5f * (df + 1f) * (SpecialFunctions.Digamma(0.5f * (df + 1f)) - SpecialFunctions.Digamma(0.5f * df))
+                 + 0.5f * MathF.Log(df) + SpecialFunctions.LogBeta(0.5f * df, 0.5f);
+        }
+        return h;
+    }
+    /// <inheritdoc />
+    public override float[] Mean
+    {
+        get
+        {
+            var m = new float[BatchSize];
+            for (int i = 0; i < BatchSize; i++) m[i] = Df[i] > 1f ? Loc[i] : float.NaN;
+            return m;
+        }
+    }
+    /// <inheritdoc />
+    public override float[] Variance
+    {
+        get
+        {
+            var v = new float[BatchSize];
+            for (int i = 0; i < BatchSize; i++)
+            {
+                float df = Df[i];
+                v[i] = df > 2f ? Scale[i] * Scale[i] * df / (df - 2f) :
+                       df > 1f ? float.PositiveInfinity : float.NaN;
+            }
+            return v;
+        }
+    }
+}
+
+/// <summary>Pareto Type-I distribution.</summary>
+public sealed class ParetoDistribution : DistributionBase
+{
+    /// <summary>Per-batch scale (minimum value).</summary>
+    public float[] Scale { get; }
+    /// <summary>Per-batch shape α.</summary>
+    public float[] Alpha { get; }
+    /// <inheritdoc />
+    public override int BatchSize => Scale.Length;
+    /// <inheritdoc />
+    public override int EventSize => 1;
+    /// <inheritdoc />
+    public override IConstraint Support
+    {
+        get
+        {
+            float minScale = Scale[0];
+            for (int i = 1; i < Scale.Length; i++) if (Scale[i] < minScale) minScale = Scale[i];
+            return new GreaterThanConstraint(minScale - 1e-6f);
+        }
+    }
+    /// <inheritdoc />
+    public override bool HasRSample => true;
+    /// <summary>Build a Pareto from per-batch scale/alpha.</summary>
+    public ParetoDistribution(float[] scale, float[] alpha)
+    {
+        if (scale.Length != alpha.Length) throw new ArgumentException();
+        for (int i = 0; i < scale.Length; i++)
+        {
+            if (!(scale[i] > 0f)) throw new ArgumentException("scale > 0.");
+            if (!(alpha[i] > 0f)) throw new ArgumentException("alpha > 0.");
+        }
+        Scale = scale; Alpha = alpha;
+    }
+    /// <inheritdoc />
+    public override float[] Sample(Random rng) => RSample(rng);
+    /// <inheritdoc />
+    public override float[] RSample(Random rng)
+    {
+        var x = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            double u = rng.NextDouble();
+            if (u < 1e-12) u = 1e-12;
+            x[i] = Scale[i] * MathF.Pow(1f - (float)u, -1f / Alpha[i]);
+        }
+        return x;
+    }
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        var lp = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            if (value[i] < Scale[i]) { lp[i] = float.NegativeInfinity; continue; }
+            lp[i] = MathF.Log(Alpha[i]) + Alpha[i] * MathF.Log(Scale[i]) - (Alpha[i] + 1f) * MathF.Log(value[i]);
+        }
+        return lp;
+    }
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        var h = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+            h[i] = MathF.Log(Scale[i] / Alpha[i]) + 1f / Alpha[i] + 1f;
+        return h;
+    }
+    /// <inheritdoc />
+    public override float[] Mean
+    {
+        get
+        {
+            var m = new float[BatchSize];
+            for (int i = 0; i < BatchSize; i++)
+                m[i] = Alpha[i] > 1f ? Alpha[i] * Scale[i] / (Alpha[i] - 1f) : float.PositiveInfinity;
+            return m;
+        }
+    }
+    /// <inheritdoc />
+    public override float[] Variance
+    {
+        get
+        {
+            var v = new float[BatchSize];
+            for (int i = 0; i < BatchSize; i++)
+            {
+                float a = Alpha[i]; float s = Scale[i];
+                v[i] = a > 2f ? s * s * a / ((a - 1f) * (a - 1f) * (a - 2f)) : float.PositiveInfinity;
+            }
+            return v;
+        }
+    }
+}
+
+/// <summary>Weibull distribution.</summary>
+public sealed class WeibullDistribution : DistributionBase
+{
+    /// <summary>Scale λ &gt; 0.</summary>
+    public float[] Scale { get; }
+    /// <summary>Shape k &gt; 0 (concentration).</summary>
+    public float[] Concentration { get; }
+    /// <inheritdoc />
+    public override int BatchSize => Scale.Length;
+    /// <inheritdoc />
+    public override int EventSize => 1;
+    /// <inheritdoc />
+    public override IConstraint Support => NonNegativeConstraint.Instance;
+    /// <inheritdoc />
+    public override bool HasRSample => true;
+    /// <summary>Build a Weibull from per-batch scale/concentration.</summary>
+    public WeibullDistribution(float[] scale, float[] concentration)
+    {
+        if (scale.Length != concentration.Length) throw new ArgumentException();
+        for (int i = 0; i < scale.Length; i++)
+        {
+            if (!(scale[i] > 0f)) throw new ArgumentException("scale > 0.");
+            if (!(concentration[i] > 0f)) throw new ArgumentException("concentration > 0.");
+        }
+        Scale = scale; Concentration = concentration;
+    }
+    /// <inheritdoc />
+    public override float[] Sample(Random rng) => RSample(rng);
+    /// <inheritdoc />
+    public override float[] RSample(Random rng)
+    {
+        var x = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            double u = rng.NextDouble();
+            if (u < 1e-12) u = 1e-12;
+            x[i] = Scale[i] * MathF.Pow(-MathF.Log(1f - (float)u), 1f / Concentration[i]);
+        }
+        return x;
+    }
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        var lp = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            if (value[i] < 0) { lp[i] = float.NegativeInfinity; continue; }
+            float k = Concentration[i]; float l = Scale[i];
+            float zk = MathF.Pow(value[i] / l, k);
+            lp[i] = MathF.Log(k) - MathF.Log(l) + (k - 1f) * MathF.Log(value[i] / l) - zk;
+        }
+        return lp;
+    }
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        var h = new float[BatchSize];
+        const float EulerMascheroni = 0.5772156649f;
+        for (int i = 0; i < BatchSize; i++)
+        {
+            float k = Concentration[i];
+            h[i] = EulerMascheroni * (1f - 1f / k) + MathF.Log(Scale[i] / k) + 1f;
+        }
+        return h;
+    }
+    /// <inheritdoc />
+    public override float[] Mean
+    {
+        get
+        {
+            var m = new float[BatchSize];
+            for (int i = 0; i < BatchSize; i++)
+                m[i] = Scale[i] * MathF.Exp(SpecialFunctions.Lgamma(1f + 1f / Concentration[i]));
+            return m;
+        }
+    }
+    /// <inheritdoc />
+    public override float[] Variance
+    {
+        get
+        {
+            var v = new float[BatchSize];
+            for (int i = 0; i < BatchSize; i++)
+            {
+                float k = Concentration[i]; float l = Scale[i];
+                float g1 = MathF.Exp(SpecialFunctions.Lgamma(1f + 1f / k));
+                float g2 = MathF.Exp(SpecialFunctions.Lgamma(1f + 2f / k));
+                v[i] = l * l * (g2 - g1 * g1);
+            }
+            return v;
+        }
+    }
+}

--- a/src/AiDotNet.Tensors/Distributions/GammaFamilyDistributions.cs
+++ b/src/AiDotNet.Tensors/Distributions/GammaFamilyDistributions.cs
@@ -35,7 +35,7 @@ public sealed class GammaDistribution : DistributionBase
             if (!(concentration[i] > 0f)) throw new ArgumentException("concentration > 0.");
             if (!(rate[i] > 0f)) throw new ArgumentException("rate > 0.");
         }
-        Concentration = concentration; Rate = rate;
+        Concentration = (float[])concentration.Clone(); Rate = (float[])rate.Clone();
     }
     /// <inheritdoc />
     public override float[] Sample(Random rng) => RSample(rng);
@@ -137,7 +137,7 @@ public sealed class InverseGammaDistribution : DistributionBase
             if (!(concentration[i] > 0f)) throw new ArgumentException("concentration > 0.");
             if (!(scale[i] > 0f)) throw new ArgumentException("scale > 0.");
         }
-        Concentration = concentration; Scale = scale;
+        Concentration = (float[])concentration.Clone(); Scale = (float[])scale.Clone();
     }
     /// <inheritdoc />
     public override float[] Sample(Random rng) => RSample(rng);
@@ -221,7 +221,7 @@ public sealed class Chi2Distribution : DistributionBase
     public Chi2Distribution(float[] df)
     {
         for (int i = 0; i < df.Length; i++) if (!(df[i] > 0f)) throw new ArgumentException("df > 0.");
-        Df = df;
+        Df = (float[])df.Clone();
     }
     /// <inheritdoc />
     public override float[] Sample(Random rng) => RSample(rng);
@@ -289,7 +289,7 @@ public sealed class BetaDistribution : DistributionBase
             if (!(concentration1[i] > 0f)) throw new ArgumentException("α > 0.");
             if (!(concentration0[i] > 0f)) throw new ArgumentException("β > 0.");
         }
-        Concentration1 = concentration1; Concentration0 = concentration0;
+        Concentration1 = (float[])concentration1.Clone(); Concentration0 = (float[])concentration0.Clone();
     }
     /// <inheritdoc />
     public override float[] Sample(Random rng) => RSample(rng);
@@ -395,7 +395,7 @@ public sealed class StudentTDistribution : DistributionBase
             if (!(df[i] > 0f)) throw new ArgumentException("df > 0.");
             if (!(scale[i] > 0f)) throw new ArgumentException("scale > 0.");
         }
-        Df = df; Loc = loc; Scale = scale;
+        Df = (float[])df.Clone(); Loc = (float[])loc.Clone(); Scale = (float[])scale.Clone();
     }
     /// <inheritdoc />
     public override float[] Sample(Random rng) => RSample(rng);
@@ -501,7 +501,7 @@ public sealed class ParetoDistribution : DistributionBase
             if (!(scale[i] > 0f)) throw new ArgumentException("scale > 0.");
             if (!(alpha[i] > 0f)) throw new ArgumentException("alpha > 0.");
         }
-        Scale = scale; Alpha = alpha;
+        Scale = (float[])scale.Clone(); Alpha = (float[])alpha.Clone();
     }
     /// <inheritdoc />
     public override float[] Sample(Random rng) => RSample(rng);
@@ -588,7 +588,7 @@ public sealed class WeibullDistribution : DistributionBase
             if (!(scale[i] > 0f)) throw new ArgumentException("scale > 0.");
             if (!(concentration[i] > 0f)) throw new ArgumentException("concentration > 0.");
         }
-        Scale = scale; Concentration = concentration;
+        Scale = (float[])scale.Clone(); Concentration = (float[])concentration.Clone();
     }
     /// <inheritdoc />
     public override float[] Sample(Random rng) => RSample(rng);
@@ -613,6 +613,17 @@ public sealed class WeibullDistribution : DistributionBase
         {
             if (value[i] < 0) { lp[i] = float.NegativeInfinity; continue; }
             float k = Concentration[i]; float l = Scale[i];
+            // x = 0 edge case: density value depends on the shape k.
+            // k > 1: density is 0 at x=0 ⇒ log p = -∞.
+            // k = 1: exponential, density at 0 is 1/λ ⇒ log p = -log(l).
+            // k < 1: density diverges to +∞ at x=0; report +∞ rather than NaN from log(0).
+            if (value[i] == 0f)
+            {
+                lp[i] = k > 1f ? float.NegativeInfinity
+                      : k == 1f ? -MathF.Log(l)
+                      : float.PositiveInfinity;
+                continue;
+            }
             float zk = MathF.Pow(value[i] / l, k);
             lp[i] = MathF.Log(k) - MathF.Log(l) + (k - 1f) * MathF.Log(value[i] / l) - zk;
         }

--- a/src/AiDotNet.Tensors/Distributions/Helpers/PhiloxGenerator.cs
+++ b/src/AiDotNet.Tensors/Distributions/Helpers/PhiloxGenerator.cs
@@ -57,19 +57,32 @@ public sealed class PhiloxGenerator : Random
     }
 
     /// <inheritdoc />
-    public override int Next() => (int)(NextUInt32() & 0x7FFFFFFFu);
+    public override int Next()
+    {
+        // System.Random.Next() returns a value in [0, int.MaxValue) — note: int.MaxValue
+        // is excluded. Loop until we get one outside the boundary so the contract holds.
+        while (true)
+        {
+            int v = (int)(NextUInt32() & 0x7FFFFFFFu);
+            if (v != int.MaxValue) return v;
+        }
+    }
 
     /// <inheritdoc />
     public override int Next(int maxValue)
     {
-        if (maxValue <= 0) throw new ArgumentOutOfRangeException(nameof(maxValue));
+        // System.Random.Next(maxValue) — throws on negative, returns 0 when maxValue == 0.
+        if (maxValue < 0) throw new ArgumentOutOfRangeException(nameof(maxValue));
+        if (maxValue == 0) return 0;
         return (int)(NextUInt32() % (uint)maxValue);
     }
 
     /// <inheritdoc />
     public override int Next(int minValue, int maxValue)
     {
-        if (minValue >= maxValue) throw new ArgumentOutOfRangeException(nameof(minValue));
+        // System.Random semantics: throws when min > max; returns min when min == max.
+        if (minValue > maxValue) throw new ArgumentOutOfRangeException(nameof(minValue));
+        if (minValue == maxValue) return minValue;
         long range = (long)maxValue - minValue;
         return (int)(minValue + (long)(NextUInt32() % (uint)range));
     }
@@ -87,6 +100,7 @@ public sealed class PhiloxGenerator : Random
     /// <inheritdoc />
     public override void NextBytes(byte[] buffer)
     {
+        if (buffer == null) throw new ArgumentNullException(nameof(buffer));
         for (int i = 0; i < buffer.Length; i++) buffer[i] = (byte)NextUInt32();
     }
 

--- a/src/AiDotNet.Tensors/Distributions/Helpers/PhiloxGenerator.cs
+++ b/src/AiDotNet.Tensors/Distributions/Helpers/PhiloxGenerator.cs
@@ -1,0 +1,138 @@
+using System;
+
+namespace AiDotNet.Tensors.Distributions.Helpers;
+
+/// <summary>
+/// Philox 4×32-10 counter-based RNG (Salmon et al., 2011) — a stateless, deterministic,
+/// parallel-friendly random number generator that matches the algorithm <c>torch.Generator</c>
+/// uses on CUDA.
+///
+/// The generator is uniquely identified by a 64-bit seed and a 64-bit per-call counter; the
+/// 64-bit subkey can be set explicitly to derive independent streams for different batch rows.
+/// This makes it possible to seed the random draws for sample <c>i</c> in a batch by hashing
+/// the batch index — a guarantee PyTorch's host-side <c>torch.Generator</c> does not provide
+/// without manual workarounds.
+///
+/// Performance: stateless, vectorisable, no contention; one Philox call produces 4 32-bit
+/// uniforms per round. For our usage we expose a <see cref="Random"/>-shaped facade so all
+/// distributions can use it interchangeably with <see cref="Random"/> via duck-typing on
+/// <see cref="NextDouble"/>.
+/// </summary>
+public sealed class PhiloxGenerator : Random
+{
+    private ulong _counter;
+    private readonly ulong _seed;
+    private ulong _subKey;
+    private uint _bufRemaining;
+    private readonly uint[] _buffer = new uint[4];
+
+    /// <summary>Build a Philox generator with the given 64-bit seed and per-stream subkey.</summary>
+    public PhiloxGenerator(ulong seed, ulong subKey = 0UL)
+    {
+        _seed = seed;
+        _subKey = subKey;
+        _counter = 0;
+        _bufRemaining = 0;
+    }
+
+    /// <summary>Override the per-stream subkey to derive an independent stream from the same seed.
+    /// Counter is reset so the new stream starts at the beginning.</summary>
+    public void SetSubKey(ulong subKey)
+    {
+        _subKey = subKey;
+        _counter = 0;
+        _bufRemaining = 0;
+    }
+
+    /// <summary>Hash <paramref name="batchIndex"/> into the subkey so that each batch row sees a
+    /// distinct, deterministic stream from the same seed. Useful for batch-parallel sampling.</summary>
+    public void SetBatchRow(int batchIndex)
+    {
+        // Murmur3 fmix64 hash — well-distributed, fast.
+        ulong h = (ulong)batchIndex ^ _seed;
+        h ^= h >> 33; h *= 0xff51afd7ed558ccdUL;
+        h ^= h >> 33; h *= 0xc4ceb9fe1a85ec53UL;
+        h ^= h >> 33;
+        SetSubKey(h);
+    }
+
+    /// <inheritdoc />
+    public override int Next() => (int)(NextUInt32() & 0x7FFFFFFFu);
+
+    /// <inheritdoc />
+    public override int Next(int maxValue)
+    {
+        if (maxValue <= 0) throw new ArgumentOutOfRangeException(nameof(maxValue));
+        return (int)(NextUInt32() % (uint)maxValue);
+    }
+
+    /// <inheritdoc />
+    public override int Next(int minValue, int maxValue)
+    {
+        if (minValue >= maxValue) throw new ArgumentOutOfRangeException(nameof(minValue));
+        long range = (long)maxValue - minValue;
+        return (int)(minValue + (long)(NextUInt32() % (uint)range));
+    }
+
+    /// <inheritdoc />
+    public override double NextDouble()
+    {
+        // 53-bit mantissa: combine two 32-bit uniforms.
+        ulong hi = NextUInt32();
+        ulong lo = NextUInt32();
+        ulong bits = (hi << 21) | (lo >> 11);
+        return bits * (1.0 / (1UL << 53));
+    }
+
+    /// <inheritdoc />
+    public override void NextBytes(byte[] buffer)
+    {
+        for (int i = 0; i < buffer.Length; i++) buffer[i] = (byte)NextUInt32();
+    }
+
+    private uint NextUInt32()
+    {
+        if (_bufRemaining == 0)
+        {
+            FillBuffer();
+            _bufRemaining = 4;
+        }
+        return _buffer[--_bufRemaining];
+    }
+
+    private void FillBuffer()
+    {
+        // Each Philox call: 4 input 32-bit words = (counter_low, counter_high, subkey_low, subkey_high).
+        uint c0 = (uint)(_counter & 0xFFFFFFFFUL);
+        uint c1 = (uint)(_counter >> 32);
+        uint c2 = (uint)(_subKey & 0xFFFFFFFFUL);
+        uint c3 = (uint)(_subKey >> 32);
+        uint k0 = (uint)(_seed & 0xFFFFFFFFUL);
+        uint k1 = (uint)(_seed >> 32);
+
+        const uint M0 = 0xD2511F53u;
+        const uint M1 = 0xCD9E8D57u;
+        const uint W0 = 0x9E3779B9u;  // Weyl constants (golden ratio)
+        const uint W1 = 0xBB67AE85u;
+
+        for (int round = 0; round < 10; round++)
+        {
+            ulong p0 = (ulong)M0 * c0;
+            ulong p1 = (ulong)M1 * c2;
+            uint hi0 = (uint)(p0 >> 32);
+            uint lo0 = (uint)p0;
+            uint hi1 = (uint)(p1 >> 32);
+            uint lo1 = (uint)p1;
+
+            uint nc0 = hi1 ^ c1 ^ k0;
+            uint nc1 = lo1;
+            uint nc2 = hi0 ^ c3 ^ k1;
+            uint nc3 = lo0;
+            c0 = nc0; c1 = nc1; c2 = nc2; c3 = nc3;
+            k0 += W0; k1 += W1;
+        }
+
+        _buffer[0] = c0; _buffer[1] = c1; _buffer[2] = c2; _buffer[3] = c3;
+        _counter++;
+    }
+}

--- a/src/AiDotNet.Tensors/Distributions/Helpers/SpecialFunctions.cs
+++ b/src/AiDotNet.Tensors/Distributions/Helpers/SpecialFunctions.cs
@@ -1,0 +1,226 @@
+using System;
+
+namespace AiDotNet.Tensors.Distributions.Helpers;
+
+/// <summary>
+/// Special functions used by the distribution implementations: log-gamma, digamma,
+/// trigamma, error function and its inverse, regularised incomplete gamma / beta.
+///
+/// Implementations are textbook approximations (Lanczos for log-gamma, Cody/Hastings
+/// for erf, Stirling-asymptotic + recurrence for digamma) targeting roughly 1e-7
+/// accuracy in single precision. They are deterministic, allocation-free, and
+/// suitable for inclusion in CUDA-graph-safe optimizer/distribution paths.
+/// </summary>
+public static class SpecialFunctions
+{
+    /// <summary>log Γ(x) via the Lanczos approximation (g = 7).</summary>
+    public static float Lgamma(float x)
+    {
+        if (x <= 0f) return float.PositiveInfinity;
+        // Reflection formula for x < 0.5 (kept for completeness; we mostly hit x > 0).
+        if (x < 0.5f)
+        {
+            // log(π / sin(πx)) - log(Γ(1 - x))
+            return (float)(Math.Log(Math.PI / Math.Sin(Math.PI * x)) - Lgamma(1f - x));
+        }
+        double xd = x - 1.0;
+        double[] g = LanczosCoefficients;
+        double a = g[0];
+        for (int i = 1; i < g.Length; i++) a += g[i] / (xd + i);
+        double t = xd + g.Length - 1.5;
+        return (float)(0.5 * Math.Log(2 * Math.PI) + (xd + 0.5) * Math.Log(t) - t + Math.Log(a));
+    }
+
+    private static readonly double[] LanczosCoefficients =
+    {
+        0.99999999999980993,
+        676.5203681218851,
+       -1259.1392167224028,
+        771.32342877765313,
+       -176.61502916214059,
+        12.507343278686905,
+       -0.13857109526572012,
+        9.9843695780195716e-6,
+        1.5056327351493116e-7,
+    };
+
+    /// <summary>Γ(x).</summary>
+    public static float Gamma(float x) => MathF.Exp(Lgamma(x));
+
+    /// <summary>log B(α, β) = log Γ(α) + log Γ(β) − log Γ(α+β).</summary>
+    public static float LogBeta(float a, float b) => Lgamma(a) + Lgamma(b) - Lgamma(a + b);
+
+    /// <summary>Digamma ψ(x) = d/dx log Γ(x).</summary>
+    public static float Digamma(float x)
+    {
+        // Recurrence + asymptotic series (Bernoulli-number expansion).
+        double xd = x;
+        double result = 0.0;
+        // Push x up so we can use the asymptotic expansion accurately (need x ≥ 6).
+        while (xd < 6.0)
+        {
+            result -= 1.0 / xd;
+            xd += 1.0;
+        }
+        // ψ(x) ≈ log(x) − 1/(2x) − Σ B_{2k} / (2k x^{2k})
+        double inv = 1.0 / xd;
+        result += Math.Log(xd) - 0.5 * inv;
+        double inv2 = inv * inv;
+        result -= inv2 * (1.0 / 12.0
+                       - inv2 * (1.0 / 120.0
+                              - inv2 * (1.0 / 252.0
+                                     - inv2 * (1.0 / 240.0
+                                            - inv2 * (1.0 / 132.0)))));
+        return (float)result;
+    }
+
+    /// <summary>Trigamma ψ′(x).</summary>
+    public static float Trigamma(float x)
+    {
+        double xd = x;
+        double result = 0.0;
+        while (xd < 6.0)
+        {
+            result += 1.0 / (xd * xd);
+            xd += 1.0;
+        }
+        // Asymptotic: ψ′(x) ≈ 1/x + 1/(2x²) + Σ B_{2k}/x^{2k+1}
+        double inv = 1.0 / xd;
+        double inv2 = inv * inv;
+        result += inv + 0.5 * inv2
+               + inv2 * inv * (1.0 / 6.0
+                            - inv2 * (1.0 / 30.0
+                                   - inv2 * (1.0 / 42.0)));
+        return (float)result;
+    }
+
+    /// <summary>Error function erf(x). Abramowitz &amp; Stegun 7.1.26.</summary>
+    public static float Erf(float x)
+    {
+        const float a1 = 0.254829592f;
+        const float a2 = -0.284496736f;
+        const float a3 = 1.421413741f;
+        const float a4 = -1.453152027f;
+        const float a5 = 1.061405429f;
+        const float p  = 0.3275911f;
+        int sign = x < 0 ? -1 : 1;
+        float ax = MathF.Abs(x);
+        float t = 1f / (1f + p * ax);
+        float y = 1f - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * MathF.Exp(-ax * ax);
+        return sign * y;
+    }
+
+    /// <summary>Complementary error function erfc(x) = 1 − erf(x).</summary>
+    public static float Erfc(float x) => 1f - Erf(x);
+
+    /// <summary>Inverse error function erf⁻¹(p) for p ∈ (-1, 1). Winitzki rational approximation.</summary>
+    public static float ErfInv(float p)
+    {
+        if (p <= -1f) return float.NegativeInfinity;
+        if (p >= 1f) return float.PositiveInfinity;
+        float ln1mp2 = MathF.Log(1f - p * p);
+        float a = 0.147f;
+        float twoOverPiA = 2f / (MathF.PI * a);
+        float term = twoOverPiA + ln1mp2 * 0.5f;
+        float sign = p < 0 ? -1f : 1f;
+        return sign * MathF.Sqrt(MathF.Sqrt(term * term - ln1mp2 / a) - term);
+    }
+
+    /// <summary>Standard-normal CDF Φ(x).</summary>
+    public static float NormalCdf(float x) => 0.5f * (1f + Erf(x * 0.70710678f));
+
+    /// <summary>Standard-normal inverse CDF Φ⁻¹(p) for p ∈ (0, 1).</summary>
+    public static float NormalIcdf(float p) => 1.41421356f * ErfInv(2f * p - 1f);
+
+    /// <summary>Regularised lower incomplete gamma P(s, x). Series + continued-fraction switching.</summary>
+    public static float GammaP(float s, float x)
+    {
+        if (x < 0f || s <= 0f) return float.NaN;
+        if (x == 0f) return 0f;
+        if (x < s + 1f)
+        {
+            // Power series.
+            double term = 1.0 / s;
+            double sum = term;
+            for (int n = 1; n < 200; n++)
+            {
+                term *= x / (s + n);
+                sum += term;
+                if (Math.Abs(term) < Math.Abs(sum) * 1e-9) break;
+            }
+            return (float)(sum * Math.Exp(-x + s * Math.Log(x) - Lgamma(s)));
+        }
+        return 1f - GammaQ(s, x);
+    }
+
+    /// <summary>Regularised upper incomplete gamma Q(s, x) = 1 − P(s, x).</summary>
+    public static float GammaQ(float s, float x)
+    {
+        if (x < 0f || s <= 0f) return float.NaN;
+        if (x == 0f) return 1f;
+        if (x < s + 1f) return 1f - GammaP(s, x);
+        // Continued fraction (Lentz).
+        double b = x + 1.0 - s;
+        double c = 1.0 / 1e-30;
+        double d = 1.0 / b;
+        double h = d;
+        for (int i = 1; i < 200; i++)
+        {
+            double an = -i * (i - s);
+            b += 2.0;
+            d = an * d + b;
+            if (Math.Abs(d) < 1e-30) d = 1e-30;
+            c = b + an / c;
+            if (Math.Abs(c) < 1e-30) c = 1e-30;
+            d = 1.0 / d;
+            double delta = d * c;
+            h *= delta;
+            if (Math.Abs(delta - 1.0) < 1e-9) break;
+        }
+        return (float)(h * Math.Exp(-x + s * Math.Log(x) - Lgamma(s)));
+    }
+
+    /// <summary>Regularised incomplete beta I_x(a, b). Continued-fraction (Numerical Recipes 6.4).</summary>
+    public static float BetaI(float a, float b, float x)
+    {
+        if (x <= 0f) return 0f;
+        if (x >= 1f) return 1f;
+        float bt = MathF.Exp(Lgamma(a + b) - Lgamma(a) - Lgamma(b) + a * MathF.Log(x) + b * MathF.Log(1f - x));
+        if (x < (a + 1f) / (a + b + 2f))
+            return (float)(bt * BetaCf(a, b, x) / a);
+        return (float)(1f - bt * BetaCf(b, a, 1f - x) / b);
+    }
+
+    private static double BetaCf(double a, double b, double x)
+    {
+        double qab = a + b;
+        double qap = a + 1.0;
+        double qam = a - 1.0;
+        double c = 1.0;
+        double d = 1.0 - qab * x / qap;
+        if (Math.Abs(d) < 1e-30) d = 1e-30;
+        d = 1.0 / d;
+        double h = d;
+        for (int m = 1; m <= 200; m++)
+        {
+            int m2 = 2 * m;
+            double aa = m * (b - m) * x / ((qam + m2) * (a + m2));
+            d = 1.0 + aa * d;
+            if (Math.Abs(d) < 1e-30) d = 1e-30;
+            c = 1.0 + aa / c;
+            if (Math.Abs(c) < 1e-30) c = 1e-30;
+            d = 1.0 / d;
+            h *= d * c;
+            aa = -(a + m) * (qab + m) * x / ((a + m2) * (qap + m2));
+            d = 1.0 + aa * d;
+            if (Math.Abs(d) < 1e-30) d = 1e-30;
+            c = 1.0 + aa / c;
+            if (Math.Abs(c) < 1e-30) c = 1e-30;
+            d = 1.0 / d;
+            double delta = d * c;
+            h *= delta;
+            if (Math.Abs(delta - 1.0) < 1e-9) break;
+        }
+        return h;
+    }
+}

--- a/src/AiDotNet.Tensors/Distributions/IDistribution.cs
+++ b/src/AiDotNet.Tensors/Distributions/IDistribution.cs
@@ -35,7 +35,9 @@ public interface IDistribution
     /// <summary>Draw a single (batch of) reparameterised samples. Throws when <see cref="HasRSample"/> is false.</summary>
     float[] RSample(Random rng);
 
-    /// <summary>Log probability mass / density at the supplied values. Length = <c>BatchSize · EventSize</c>.</summary>
+    /// <summary>Log probability mass / density at the supplied values, reduced over event dimensions.
+    /// Length = <c>BatchSize</c>. The <paramref name="value"/> input has length
+    /// <c>BatchSize · EventSize</c> (flattened row-major).</summary>
     float[] LogProb(float[] value);
 
     /// <summary>Differential entropy (continuous) or Shannon entropy (discrete), per batch element. Length = <c>BatchSize</c>.</summary>

--- a/src/AiDotNet.Tensors/Distributions/IDistribution.cs
+++ b/src/AiDotNet.Tensors/Distributions/IDistribution.cs
@@ -1,0 +1,58 @@
+using System;
+using AiDotNet.Tensors.Distributions.Constraints;
+
+namespace AiDotNet.Tensors.Distributions;
+
+/// <summary>
+/// Common contract for every probability distribution in the tensor library.
+///
+/// Mirrors the shape of <c>torch.distributions.Distribution</c>: one instance
+/// represents a (possibly batched) family of distributions sharing a common
+/// parameterisation. <see cref="BatchSize"/> is the number of independent
+/// distributions packed in this instance, and <see cref="EventSize"/> is the
+/// dimension of a single sample (1 for scalar distributions, N for an
+/// N-dimensional MVN, etc.). All array shapes follow row-major
+/// <c>[batch, event]</c> layout.
+/// </summary>
+public interface IDistribution
+{
+    /// <summary>Number of independent distributions in this batch.</summary>
+    int BatchSize { get; }
+
+    /// <summary>Length of a single sample. Scalar distributions have <c>EventSize == 1</c>.</summary>
+    int EventSize { get; }
+
+    /// <summary>Set of values at which the distribution puts non-zero probability mass / density.</summary>
+    IConstraint Support { get; }
+
+    /// <summary>True if <see cref="RSample"/> produces values whose dependence on the
+    /// distribution parameters is differentiable (i.e. the reparameterisation trick applies).</summary>
+    bool HasRSample { get; }
+
+    /// <summary>Draw a single (batch of) samples without tracking gradients.</summary>
+    float[] Sample(Random rng);
+
+    /// <summary>Draw a single (batch of) reparameterised samples. Throws when <see cref="HasRSample"/> is false.</summary>
+    float[] RSample(Random rng);
+
+    /// <summary>Log probability mass / density at the supplied values. Length = <c>BatchSize · EventSize</c>.</summary>
+    float[] LogProb(float[] value);
+
+    /// <summary>Differential entropy (continuous) or Shannon entropy (discrete), per batch element. Length = <c>BatchSize</c>.</summary>
+    float[] Entropy();
+
+    /// <summary>Mean per batch element, flattened. Length = <c>BatchSize · EventSize</c>.</summary>
+    float[] Mean { get; }
+
+    /// <summary>Variance per batch element, flattened. Length = <c>BatchSize · EventSize</c>.</summary>
+    float[] Variance { get; }
+
+    /// <summary>Standard deviation per batch element. Length = <c>BatchSize · EventSize</c>.</summary>
+    float[] StdDev { get; }
+
+    /// <summary>Cumulative distribution function (univariate only). Length = <c>BatchSize</c>.</summary>
+    float[] Cdf(float[] value);
+
+    /// <summary>Inverse CDF (univariate only). <paramref name="probability"/> in (0, 1).</summary>
+    float[] Icdf(float[] probability);
+}

--- a/src/AiDotNet.Tensors/Distributions/KLDivergence.cs
+++ b/src/AiDotNet.Tensors/Distributions/KLDivergence.cs
@@ -115,10 +115,13 @@ public static class KLDivergence
     private static float[] KlBernoulliBernoulli(BernoulliDistribution p, BernoulliDistribution q)
     {
         if (p.BatchSize != q.BatchSize) throw new ArgumentException();
+        // ProbsRaw avoids the O(N) Clone() that the public Probs getter would do per access.
+        var pProbs = p.ProbsRaw;
+        var qProbs = q.ProbsRaw;
         var kl = new float[p.BatchSize];
         for (int i = 0; i < p.BatchSize; i++)
         {
-            float pp = p.Probs[i], qq = q.Probs[i];
+            float pp = pProbs[i], qq = qProbs[i];
             float a = pp > 0f ? pp * (MathF.Log(pp) - MathF.Log(qq)) : 0f;
             float b = pp < 1f ? (1f - pp) * (MathF.Log(1f - pp) - MathF.Log(1f - qq)) : 0f;
             kl[i] = a + b;
@@ -129,17 +132,15 @@ public static class KLDivergence
     private static float[] KlCategoricalCategorical(CategoricalDistribution p, CategoricalDistribution q)
     {
         if (p.BatchSize != q.BatchSize || p.K != q.K) throw new ArgumentException();
+        var pProbs = p.ProbsRaw;
+        var qProbs = q.ProbsRaw;
         var kl = new float[p.BatchSize];
         for (int b = 0; b < p.BatchSize; b++)
         {
             float s = 0f;
             for (int k = 0; k < p.K; k++)
             {
-                float pk = p.Probs[b * p.K + k]; float qk = q.Probs[b * q.K + k];
-                // KL(p || q) = +∞ whenever p has support where q does not (q absolutely
-                // continuous w.r.t. p is required). Without this guard a q_k=0 paired
-                // with p_k>0 would silently clamp via the 1e-30 floor and report a
-                // large-but-finite value, hiding a model misspecification.
+                float pk = pProbs[b * p.K + k]; float qk = qProbs[b * q.K + k];
                 if (pk > 0f && qk == 0f) { s = float.PositiveInfinity; break; }
                 if (pk > 0f) s += pk * (MathF.Log(pk) - MathF.Log(qk));
             }

--- a/src/AiDotNet.Tensors/Distributions/KLDivergence.cs
+++ b/src/AiDotNet.Tensors/Distributions/KLDivergence.cs
@@ -1,0 +1,267 @@
+using System;
+using System.Collections.Concurrent;
+using AiDotNet.Tensors.Distributions.Helpers;
+
+namespace AiDotNet.Tensors.Distributions;
+
+/// <summary>
+/// Open registry of analytical KL-divergence formulas. Mirrors PyTorch's
+/// <c>torch.distributions.kl.register_kl</c>: users can register new pairs at runtime
+/// and the dispatch picks the most-specific formula. The library ships analytical
+/// pairs for every common distribution combination (~10 by default); users can extend.
+/// </summary>
+public static class KLDivergence
+{
+    private static readonly ConcurrentDictionary<(Type p, Type q), Func<IDistribution, IDistribution, float[]>> _registry = new();
+
+    static KLDivergence()
+    {
+        Register<NormalDistribution, NormalDistribution>(KlNormalNormal);
+        Register<BernoulliDistribution, BernoulliDistribution>(KlBernoulliBernoulli);
+        Register<CategoricalDistribution, CategoricalDistribution>(KlCategoricalCategorical);
+        Register<UniformDistribution, UniformDistribution>(KlUniformUniform);
+        Register<ExponentialDistribution, ExponentialDistribution>(KlExpExp);
+        Register<LaplaceDistribution, LaplaceDistribution>(KlLaplaceLaplace);
+        Register<GammaDistribution, GammaDistribution>(KlGammaGamma);
+        Register<BetaDistribution, BetaDistribution>(KlBetaBeta);
+        Register<DirichletDistribution, DirichletDistribution>(KlDirichletDirichlet);
+        Register<DiagonalMultivariateNormalDistribution, DiagonalMultivariateNormalDistribution>(KlDiagMvnDiagMvn);
+        Register<MultivariateNormalDistribution, MultivariateNormalDistribution>(KlMvnMvn);
+    }
+
+    /// <summary>Register an analytical KL-divergence formula for a (P, Q) type pair.</summary>
+    public static void Register<TP, TQ>(Func<TP, TQ, float[]> fn)
+        where TP : IDistribution
+        where TQ : IDistribution
+    {
+        _registry[(typeof(TP), typeof(TQ))] = (p, q) => fn((TP)p, (TQ)q);
+    }
+
+    /// <summary>
+    /// Compute KL(p || q) using a registered analytical formula if one exists, otherwise
+    /// throw with a helpful message. (Monte-Carlo fallback is the user's responsibility:
+    /// drawing N samples and computing <c>p.LogProb(x) - q.LogProb(x)</c>.)
+    /// </summary>
+    public static float[] Compute(IDistribution p, IDistribution q)
+    {
+        if (p == null) throw new ArgumentNullException(nameof(p));
+        if (q == null) throw new ArgumentNullException(nameof(q));
+        if (_registry.TryGetValue((p.GetType(), q.GetType()), out var fn))
+            return fn(p, q);
+        throw new NotSupportedException(
+            $"No analytical KL divergence registered for ({p.GetType().Name}, {q.GetType().Name}). " +
+            "Register one via KLDivergence.Register or use Monte-Carlo estimation.");
+    }
+
+    /// <summary>True iff an analytical formula is registered for the given type pair.</summary>
+    public static bool IsRegistered<TP, TQ>() where TP : IDistribution where TQ : IDistribution =>
+        _registry.ContainsKey((typeof(TP), typeof(TQ)));
+
+    // -------- Built-in analytical formulas --------
+
+    private static float[] KlNormalNormal(NormalDistribution p, NormalDistribution q)
+    {
+        if (p.BatchSize != q.BatchSize) throw new ArgumentException("batch shapes must match.");
+        var kl = new float[p.BatchSize];
+        for (int i = 0; i < p.BatchSize; i++)
+        {
+            float diff = p.Loc[i] - q.Loc[i];
+            float var1 = p.Scale[i] * p.Scale[i];
+            float var2 = q.Scale[i] * q.Scale[i];
+            kl[i] = MathF.Log(q.Scale[i] / p.Scale[i]) + (var1 + diff * diff) / (2f * var2) - 0.5f;
+        }
+        return kl;
+    }
+
+    private static float[] KlBernoulliBernoulli(BernoulliDistribution p, BernoulliDistribution q)
+    {
+        if (p.BatchSize != q.BatchSize) throw new ArgumentException();
+        var kl = new float[p.BatchSize];
+        for (int i = 0; i < p.BatchSize; i++)
+        {
+            float pp = p.Probs[i], qq = q.Probs[i];
+            float a = pp > 0f ? pp * (MathF.Log(pp) - MathF.Log(qq)) : 0f;
+            float b = pp < 1f ? (1f - pp) * (MathF.Log(1f - pp) - MathF.Log(1f - qq)) : 0f;
+            kl[i] = a + b;
+        }
+        return kl;
+    }
+
+    private static float[] KlCategoricalCategorical(CategoricalDistribution p, CategoricalDistribution q)
+    {
+        if (p.BatchSize != q.BatchSize || p.K != q.K) throw new ArgumentException();
+        var kl = new float[p.BatchSize];
+        for (int b = 0; b < p.BatchSize; b++)
+        {
+            float s = 0f;
+            for (int k = 0; k < p.K; k++)
+            {
+                float pk = p.Probs[b * p.K + k]; float qk = q.Probs[b * q.K + k];
+                if (pk > 0f) s += pk * (MathF.Log(pk) - MathF.Log(MathF.Max(qk, 1e-30f)));
+            }
+            kl[b] = s;
+        }
+        return kl;
+    }
+
+    private static float[] KlUniformUniform(UniformDistribution p, UniformDistribution q)
+    {
+        if (p.BatchSize != q.BatchSize) throw new ArgumentException();
+        var kl = new float[p.BatchSize];
+        for (int i = 0; i < p.BatchSize; i++)
+        {
+            // KL(U(a,b) || U(c,d)) = log((d-c)/(b-a)) if [a,b] ⊂ [c,d], else +∞.
+            if (p.Low[i] >= q.Low[i] && p.High[i] <= q.High[i])
+                kl[i] = MathF.Log((q.High[i] - q.Low[i]) / (p.High[i] - p.Low[i]));
+            else
+                kl[i] = float.PositiveInfinity;
+        }
+        return kl;
+    }
+
+    private static float[] KlExpExp(ExponentialDistribution p, ExponentialDistribution q)
+    {
+        if (p.BatchSize != q.BatchSize) throw new ArgumentException();
+        var kl = new float[p.BatchSize];
+        for (int i = 0; i < p.BatchSize; i++)
+            kl[i] = MathF.Log(p.Rate[i] / q.Rate[i]) + q.Rate[i] / p.Rate[i] - 1f;
+        return kl;
+    }
+
+    private static float[] KlLaplaceLaplace(LaplaceDistribution p, LaplaceDistribution q)
+    {
+        if (p.BatchSize != q.BatchSize) throw new ArgumentException();
+        var kl = new float[p.BatchSize];
+        for (int i = 0; i < p.BatchSize; i++)
+        {
+            float diff = MathF.Abs(p.Loc[i] - q.Loc[i]);
+            kl[i] = MathF.Log(q.Scale[i] / p.Scale[i])
+                  + (p.Scale[i] * MathF.Exp(-diff / p.Scale[i]) + diff) / q.Scale[i] - 1f;
+        }
+        return kl;
+    }
+
+    private static float[] KlGammaGamma(GammaDistribution p, GammaDistribution q)
+    {
+        if (p.BatchSize != q.BatchSize) throw new ArgumentException();
+        var kl = new float[p.BatchSize];
+        for (int i = 0; i < p.BatchSize; i++)
+        {
+            float ap = p.Concentration[i]; float aq = q.Concentration[i];
+            float bp = p.Rate[i]; float bq = q.Rate[i];
+            kl[i] = (ap - aq) * SpecialFunctions.Digamma(ap)
+                  - SpecialFunctions.Lgamma(ap) + SpecialFunctions.Lgamma(aq)
+                  + aq * (MathF.Log(bp) - MathF.Log(bq))
+                  + ap * (bq - bp) / bp;
+        }
+        return kl;
+    }
+
+    private static float[] KlBetaBeta(BetaDistribution p, BetaDistribution q)
+    {
+        if (p.BatchSize != q.BatchSize) throw new ArgumentException();
+        var kl = new float[p.BatchSize];
+        for (int i = 0; i < p.BatchSize; i++)
+        {
+            float a1p = p.Concentration1[i]; float a0p = p.Concentration0[i];
+            float a1q = q.Concentration1[i]; float a0q = q.Concentration0[i];
+            float sumP = a1p + a0p; float sumQ = a1q + a0q;
+            kl[i] = SpecialFunctions.LogBeta(a1q, a0q) - SpecialFunctions.LogBeta(a1p, a0p)
+                  + (a1p - a1q) * SpecialFunctions.Digamma(a1p)
+                  + (a0p - a0q) * SpecialFunctions.Digamma(a0p)
+                  + (a1q - a1p + a0q - a0p) * SpecialFunctions.Digamma(sumP);
+        }
+        return kl;
+    }
+
+    private static float[] KlDirichletDirichlet(DirichletDistribution p, DirichletDistribution q)
+    {
+        if (p.BatchSize != q.BatchSize || p.K != q.K) throw new ArgumentException();
+        var kl = new float[p.BatchSize];
+        for (int b = 0; b < p.BatchSize; b++)
+        {
+            float a0p = 0f, a0q = 0f;
+            for (int i = 0; i < p.K; i++)
+            {
+                a0p += p.Concentration[b * p.K + i];
+                a0q += q.Concentration[b * p.K + i];
+            }
+            float term = SpecialFunctions.Lgamma(a0p) - SpecialFunctions.Lgamma(a0q);
+            for (int i = 0; i < p.K; i++)
+            {
+                float ap = p.Concentration[b * p.K + i];
+                float aq = q.Concentration[b * p.K + i];
+                term += SpecialFunctions.Lgamma(aq) - SpecialFunctions.Lgamma(ap)
+                      + (ap - aq) * (SpecialFunctions.Digamma(ap) - SpecialFunctions.Digamma(a0p));
+            }
+            kl[b] = term;
+        }
+        return kl;
+    }
+
+    private static float[] KlDiagMvnDiagMvn(DiagonalMultivariateNormalDistribution p, DiagonalMultivariateNormalDistribution q)
+    {
+        if (p.BatchSize != q.BatchSize || p.D != q.D) throw new ArgumentException();
+        var kl = new float[p.BatchSize];
+        for (int b = 0; b < p.BatchSize; b++)
+        {
+            float trace = 0f, quad = 0f, halfLogRatio = 0f;
+            for (int i = 0; i < p.D; i++)
+            {
+                float vp = p.Scale[b * p.D + i] * p.Scale[b * p.D + i];
+                float vq = q.Scale[b * p.D + i] * q.Scale[b * p.D + i];
+                float diff = p.Loc[b * p.D + i] - q.Loc[b * p.D + i];
+                trace += vp / vq;
+                quad  += diff * diff / vq;
+                halfLogRatio += MathF.Log(q.Scale[b * p.D + i]) - MathF.Log(p.Scale[b * p.D + i]);
+            }
+            kl[b] = 0.5f * (trace + quad - p.D) + halfLogRatio;
+        }
+        return kl;
+    }
+
+    private static float[] KlMvnMvn(MultivariateNormalDistribution p, MultivariateNormalDistribution q)
+    {
+        if (p.BatchSize != q.BatchSize || p.D != q.D) throw new ArgumentException();
+        var kl = new float[p.BatchSize];
+        var diff = new float[p.D];
+        var sol = new float[p.D];
+        for (int b = 0; b < p.BatchSize; b++)
+        {
+            // KL = 0.5 · ( tr(Σ_q⁻¹ Σ_p) + (μ_q − μ_p)ᵀ Σ_q⁻¹ (μ_q − μ_p) − D + log(|Σ_q| / |Σ_p|) )
+            float halfLogP = 0f, halfLogQ = 0f;
+            for (int i = 0; i < p.D; i++)
+            {
+                halfLogP += MathF.Log(p.CholeskyL[b * p.D * p.D + i * p.D + i]);
+                halfLogQ += MathF.Log(q.CholeskyL[b * p.D * p.D + i * p.D + i]);
+            }
+            // (μ_q - μ_p) and forward-substitute against L_q.
+            for (int i = 0; i < p.D; i++) diff[i] = p.Loc[b * p.D + i] - q.Loc[b * p.D + i];
+            for (int i = 0; i < p.D; i++)
+            {
+                float s = diff[i];
+                for (int j = 0; j < i; j++) s -= q.CholeskyL[b * p.D * p.D + i * p.D + j] * sol[j];
+                sol[i] = s / q.CholeskyL[b * p.D * p.D + i * p.D + i];
+            }
+            float quad = 0f;
+            for (int i = 0; i < p.D; i++) quad += sol[i] * sol[i];
+            // tr(Σ_q⁻¹ Σ_p): requires solving L_q · Y = L_p column-by-column then summing ‖Y_:i‖².
+            float trace = 0f;
+            for (int j = 0; j < p.D; j++)
+            {
+                // Y_:j satisfies L_q Y_:j = L_p_:j  (only j..D-1 entries non-zero in L_p_:j).
+                for (int i = 0; i < p.D; i++) sol[i] = 0f;
+                for (int i = 0; i < p.D; i++)
+                {
+                    float rhs = i >= j ? p.CholeskyL[b * p.D * p.D + i * p.D + j] : 0f;
+                    float s = rhs;
+                    for (int k = 0; k < i; k++) s -= q.CholeskyL[b * p.D * p.D + i * p.D + k] * sol[k];
+                    sol[i] = s / q.CholeskyL[b * p.D * p.D + i * p.D + i];
+                }
+                for (int i = 0; i < p.D; i++) trace += sol[i] * sol[i];
+            }
+            kl[b] = 0.5f * (trace + quad - p.D) + halfLogQ - halfLogP;
+        }
+        return kl;
+    }
+}

--- a/src/AiDotNet.Tensors/Distributions/KLDivergence.cs
+++ b/src/AiDotNet.Tensors/Distributions/KLDivergence.cs
@@ -37,20 +37,59 @@ public static class KLDivergence
         _registry[(typeof(TP), typeof(TQ))] = (p, q) => fn((TP)p, (TQ)q);
     }
 
+    /// <summary>Remove a previously-registered (P, Q) handler. Returns true if a handler was
+    /// removed. Tests that register custom handlers should call this in a <c>finally</c> block
+    /// so their changes do not leak into other tests in a parallel collection.</summary>
+    public static bool Unregister<TP, TQ>()
+        where TP : IDistribution
+        where TQ : IDistribution
+        => _registry.TryRemove((typeof(TP), typeof(TQ)), out _);
+
     /// <summary>
     /// Compute KL(p || q) using a registered analytical formula if one exists, otherwise
     /// throw with a helpful message. (Monte-Carlo fallback is the user's responsibility:
     /// drawing N samples and computing <c>p.LogProb(x) - q.LogProb(x)</c>.)
+    ///
+    /// Lookup is polymorphic: if no exact-type entry exists, the registry is searched for
+    /// the most-specific registered (P, Q) pair where <c>P.IsAssignableFrom(p)</c> and
+    /// <c>Q.IsAssignableFrom(q)</c>. This matches PyTorch's <c>kl_divergence</c> dispatch
+    /// and lets users register handlers against base classes / interfaces.
     /// </summary>
     public static float[] Compute(IDistribution p, IDistribution q)
     {
         if (p == null) throw new ArgumentNullException(nameof(p));
         if (q == null) throw new ArgumentNullException(nameof(q));
-        if (_registry.TryGetValue((p.GetType(), q.GetType()), out var fn))
+        var pt = p.GetType();
+        var qt = q.GetType();
+        if (_registry.TryGetValue((pt, qt), out var fn))
             return fn(p, q);
+
+        // Polymorphic fallback: pick the most-specific (P, Q) entry whose types are
+        // assignable from p / q. "Most specific" = sum of inheritance distances minimised.
+        Func<IDistribution, IDistribution, float[]>? bestFn = null;
+        int bestScore = int.MaxValue;
+        foreach (var kv in _registry)
+        {
+            if (!kv.Key.p.IsAssignableFrom(pt) || !kv.Key.q.IsAssignableFrom(qt)) continue;
+            int score = InheritanceDistance(pt, kv.Key.p) + InheritanceDistance(qt, kv.Key.q);
+            if (score < bestScore) { bestScore = score; bestFn = kv.Value; }
+        }
+        if (bestFn != null) return bestFn(p, q);
+
         throw new NotSupportedException(
             $"No analytical KL divergence registered for ({p.GetType().Name}, {q.GetType().Name}). " +
             "Register one via KLDivergence.Register or use Monte-Carlo estimation.");
+    }
+
+    private static int InheritanceDistance(Type derived, Type baseType)
+    {
+        if (derived == baseType) return 0;
+        int d = 0;
+        var t = derived;
+        while (t != null && t != baseType) { t = t.BaseType; d++; }
+        if (t == baseType) return d;
+        // Interface match — assign a fixed positive distance so concrete-type matches win.
+        return baseType.IsInterface ? 1000 : int.MaxValue;
     }
 
     /// <summary>True iff an analytical formula is registered for the given type pair.</summary>
@@ -97,7 +136,12 @@ public static class KLDivergence
             for (int k = 0; k < p.K; k++)
             {
                 float pk = p.Probs[b * p.K + k]; float qk = q.Probs[b * q.K + k];
-                if (pk > 0f) s += pk * (MathF.Log(pk) - MathF.Log(MathF.Max(qk, 1e-30f)));
+                // KL(p || q) = +∞ whenever p has support where q does not (q absolutely
+                // continuous w.r.t. p is required). Without this guard a q_k=0 paired
+                // with p_k>0 would silently clamp via the 1e-30 floor and report a
+                // large-but-finite value, hiding a model misspecification.
+                if (pk > 0f && qk == 0f) { s = float.PositiveInfinity; break; }
+                if (pk > 0f) s += pk * (MathF.Log(pk) - MathF.Log(qk));
             }
             kl[b] = s;
         }

--- a/src/AiDotNet.Tensors/Distributions/LocationScaleDistributions.cs
+++ b/src/AiDotNet.Tensors/Distributions/LocationScaleDistributions.cs
@@ -25,7 +25,7 @@ public sealed class LogNormalDistribution : DistributionBase
     {
         if (loc.Length != scale.Length) throw new ArgumentException("loc and scale must match.");
         for (int i = 0; i < scale.Length; i++) if (!(scale[i] > 0f)) throw new ArgumentException("scale > 0.");
-        Loc = loc; Scale = scale;
+        Loc = (float[])loc.Clone(); Scale = (float[])scale.Clone();
     }
     /// <inheritdoc />
     public override float[] Sample(Random rng) => RSample(rng);
@@ -45,6 +45,9 @@ public sealed class LogNormalDistribution : DistributionBase
         const float LogTwoPi = 1.83787706641f;
         for (int i = 0; i < BatchSize; i++)
         {
+            // LogNormal support is (0, ∞). At x ≤ 0 the density is 0; report -∞ to avoid
+            // log(0) = -∞ → NaN propagation when squaring z.
+            if (value[i] <= 0f) { lp[i] = float.NegativeInfinity; continue; }
             float lnX = MathF.Log(value[i]);
             float z = (lnX - Loc[i]) / Scale[i];
             lp[i] = -0.5f * (z * z + LogTwoPi) - MathF.Log(Scale[i]) - lnX;
@@ -104,7 +107,7 @@ public sealed class HalfNormalDistribution : DistributionBase
     public HalfNormalDistribution(float[] scale)
     {
         for (int i = 0; i < scale.Length; i++) if (!(scale[i] > 0f)) throw new ArgumentException("scale > 0.");
-        Scale = scale;
+        Scale = (float[])scale.Clone();
     }
     /// <inheritdoc />
     public override float[] Sample(Random rng) => RSample(rng);
@@ -183,7 +186,7 @@ public sealed class CauchyDistribution : DistributionBase
     {
         if (loc.Length != scale.Length) throw new ArgumentException();
         for (int i = 0; i < scale.Length; i++) if (!(scale[i] > 0f)) throw new ArgumentException("scale > 0.");
-        Loc = loc; Scale = scale;
+        Loc = (float[])loc.Clone(); Scale = (float[])scale.Clone();
     }
     /// <inheritdoc />
     public override float[] Sample(Random rng) => RSample(rng);
@@ -268,7 +271,7 @@ public sealed class HalfCauchyDistribution : DistributionBase
     public HalfCauchyDistribution(float[] scale)
     {
         for (int i = 0; i < scale.Length; i++) if (!(scale[i] > 0f)) throw new ArgumentException("scale > 0.");
-        Scale = scale;
+        Scale = (float[])scale.Clone();
     }
     /// <inheritdoc />
     public override float[] Sample(Random rng) => RSample(rng);
@@ -332,7 +335,7 @@ public sealed class LaplaceDistribution : DistributionBase
     {
         if (loc.Length != scale.Length) throw new ArgumentException();
         for (int i = 0; i < scale.Length; i++) if (!(scale[i] > 0f)) throw new ArgumentException("scale > 0.");
-        Loc = loc; Scale = scale;
+        Loc = (float[])loc.Clone(); Scale = (float[])scale.Clone();
     }
     /// <inheritdoc />
     public override float[] Sample(Random rng) => RSample(rng);
@@ -411,7 +414,7 @@ public sealed class UniformDistribution : DistributionBase
         if (low.Length != high.Length) throw new ArgumentException();
         for (int i = 0; i < low.Length; i++)
             if (!(high[i] > low[i])) throw new ArgumentException("high > low.");
-        Low = low; High = high;
+        Low = (float[])low.Clone(); High = (float[])high.Clone();
     }
     /// <inheritdoc />
     public override float[] Sample(Random rng) => RSample(rng);
@@ -492,7 +495,7 @@ public sealed class ExponentialDistribution : DistributionBase
     public ExponentialDistribution(float[] rate)
     {
         for (int i = 0; i < rate.Length; i++) if (!(rate[i] > 0f)) throw new ArgumentException("rate > 0.");
-        Rate = rate;
+        Rate = (float[])rate.Clone();
     }
     /// <inheritdoc />
     public override float[] Sample(Random rng) => RSample(rng);
@@ -569,7 +572,7 @@ public sealed class GumbelDistribution : DistributionBase
     {
         if (loc.Length != scale.Length) throw new ArgumentException();
         for (int i = 0; i < scale.Length; i++) if (!(scale[i] > 0f)) throw new ArgumentException("scale > 0.");
-        Loc = loc; Scale = scale;
+        Loc = (float[])loc.Clone(); Scale = (float[])scale.Clone();
     }
     /// <inheritdoc />
     public override float[] Sample(Random rng) => RSample(rng);

--- a/src/AiDotNet.Tensors/Distributions/LocationScaleDistributions.cs
+++ b/src/AiDotNet.Tensors/Distributions/LocationScaleDistributions.cs
@@ -1,0 +1,630 @@
+using System;
+using AiDotNet.Tensors.Distributions.Constraints;
+using AiDotNet.Tensors.Distributions.Helpers;
+
+namespace AiDotNet.Tensors.Distributions;
+
+/// <summary>LogNormal distribution: X = exp(μ + σ·Z), Z ∼ N(0, 1). Domain (0, ∞).</summary>
+public sealed class LogNormalDistribution : DistributionBase
+{
+    /// <summary>Mean of the underlying normal.</summary>
+    public float[] Loc { get; }
+    /// <summary>Std of the underlying normal.</summary>
+    public float[] Scale { get; }
+    /// <inheritdoc />
+    public override int BatchSize => Loc.Length;
+    /// <inheritdoc />
+    public override int EventSize => 1;
+    /// <inheritdoc />
+    public override IConstraint Support => PositiveConstraint.Instance;
+    /// <inheritdoc />
+    public override bool HasRSample => true;
+
+    /// <summary>Build a LogNormal from per-batch loc/scale.</summary>
+    public LogNormalDistribution(float[] loc, float[] scale)
+    {
+        if (loc.Length != scale.Length) throw new ArgumentException("loc and scale must match.");
+        for (int i = 0; i < scale.Length; i++) if (!(scale[i] > 0f)) throw new ArgumentException("scale > 0.");
+        Loc = loc; Scale = scale;
+    }
+    /// <inheritdoc />
+    public override float[] Sample(Random rng) => RSample(rng);
+    /// <inheritdoc />
+    public override float[] RSample(Random rng)
+    {
+        var x = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+            x[i] = MathF.Exp(Loc[i] + Scale[i] * (float)NormalDistribution.Gaussian(rng));
+        return x;
+    }
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        var lp = new float[BatchSize];
+        const float LogTwoPi = 1.83787706641f;
+        for (int i = 0; i < BatchSize; i++)
+        {
+            float lnX = MathF.Log(value[i]);
+            float z = (lnX - Loc[i]) / Scale[i];
+            lp[i] = -0.5f * (z * z + LogTwoPi) - MathF.Log(Scale[i]) - lnX;
+        }
+        return lp;
+    }
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        var h = new float[BatchSize];
+        const float HalfLogTwoPiE = 1.41893853321f;
+        for (int i = 0; i < BatchSize; i++) h[i] = HalfLogTwoPiE + MathF.Log(Scale[i]) + Loc[i];
+        return h;
+    }
+    /// <inheritdoc />
+    public override float[] Mean
+    {
+        get
+        {
+            var m = new float[BatchSize];
+            for (int i = 0; i < BatchSize; i++)
+                m[i] = MathF.Exp(Loc[i] + 0.5f * Scale[i] * Scale[i]);
+            return m;
+        }
+    }
+    /// <inheritdoc />
+    public override float[] Variance
+    {
+        get
+        {
+            var v = new float[BatchSize];
+            for (int i = 0; i < BatchSize; i++)
+            {
+                float s2 = Scale[i] * Scale[i];
+                v[i] = (MathF.Exp(s2) - 1f) * MathF.Exp(2f * Loc[i] + s2);
+            }
+            return v;
+        }
+    }
+}
+
+/// <summary>Half-normal distribution: |Z|·σ for Z ∼ N(0, 1).</summary>
+public sealed class HalfNormalDistribution : DistributionBase
+{
+    /// <summary>Per-batch scale.</summary>
+    public float[] Scale { get; }
+    /// <inheritdoc />
+    public override int BatchSize => Scale.Length;
+    /// <inheritdoc />
+    public override int EventSize => 1;
+    /// <inheritdoc />
+    public override IConstraint Support => NonNegativeConstraint.Instance;
+    /// <inheritdoc />
+    public override bool HasRSample => true;
+
+    /// <summary>Build a half-normal from per-batch scale.</summary>
+    public HalfNormalDistribution(float[] scale)
+    {
+        for (int i = 0; i < scale.Length; i++) if (!(scale[i] > 0f)) throw new ArgumentException("scale > 0.");
+        Scale = scale;
+    }
+    /// <inheritdoc />
+    public override float[] Sample(Random rng) => RSample(rng);
+    /// <inheritdoc />
+    public override float[] RSample(Random rng)
+    {
+        var x = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+            x[i] = MathF.Abs(Scale[i] * (float)NormalDistribution.Gaussian(rng));
+        return x;
+    }
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        var lp = new float[BatchSize];
+        const float LogTwoOverPi = 0.45158270528f; // 0.5·log(2/π)
+        for (int i = 0; i < BatchSize; i++)
+        {
+            if (value[i] < 0) { lp[i] = float.NegativeInfinity; continue; }
+            float z = value[i] / Scale[i];
+            lp[i] = LogTwoOverPi - 0.5f * z * z - MathF.Log(Scale[i]);
+        }
+        return lp;
+    }
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        var h = new float[BatchSize];
+        const float HalfLog2EOverPi = 0.72579135264f; // 0.5·log(πe/2)
+        for (int i = 0; i < BatchSize; i++) h[i] = HalfLog2EOverPi + MathF.Log(Scale[i]);
+        return h;
+    }
+    /// <inheritdoc />
+    public override float[] Mean
+    {
+        get
+        {
+            var m = new float[BatchSize];
+            const float SqrtTwoOverPi = 0.79788456080f;
+            for (int i = 0; i < BatchSize; i++) m[i] = Scale[i] * SqrtTwoOverPi;
+            return m;
+        }
+    }
+    /// <inheritdoc />
+    public override float[] Variance
+    {
+        get
+        {
+            var v = new float[BatchSize];
+            const float OneMinusTwoOverPi = 0.36338022763f;
+            for (int i = 0; i < BatchSize; i++) v[i] = Scale[i] * Scale[i] * OneMinusTwoOverPi;
+            return v;
+        }
+    }
+}
+
+/// <summary>Cauchy distribution. Heavy-tailed; mean and variance are undefined.</summary>
+public sealed class CauchyDistribution : DistributionBase
+{
+    /// <summary>Per-batch location (median).</summary>
+    public float[] Loc { get; }
+    /// <summary>Per-batch scale (half-width at half-maximum).</summary>
+    public float[] Scale { get; }
+    /// <inheritdoc />
+    public override int BatchSize => Loc.Length;
+    /// <inheritdoc />
+    public override int EventSize => 1;
+    /// <inheritdoc />
+    public override IConstraint Support => RealConstraint.Instance;
+    /// <inheritdoc />
+    public override bool HasRSample => true;
+
+    /// <summary>Build a Cauchy from per-batch loc/scale.</summary>
+    public CauchyDistribution(float[] loc, float[] scale)
+    {
+        if (loc.Length != scale.Length) throw new ArgumentException();
+        for (int i = 0; i < scale.Length; i++) if (!(scale[i] > 0f)) throw new ArgumentException("scale > 0.");
+        Loc = loc; Scale = scale;
+    }
+    /// <inheritdoc />
+    public override float[] Sample(Random rng) => RSample(rng);
+    /// <inheritdoc />
+    public override float[] RSample(Random rng)
+    {
+        var x = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            double u = rng.NextDouble();
+            x[i] = Loc[i] + Scale[i] * (float)Math.Tan(Math.PI * (u - 0.5));
+        }
+        return x;
+    }
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        var lp = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            float z = (value[i] - Loc[i]) / Scale[i];
+            lp[i] = -MathF.Log(MathF.PI) - MathF.Log(Scale[i]) - MathF.Log(1f + z * z);
+        }
+        return lp;
+    }
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        var h = new float[BatchSize];
+        float lnFourPi = MathF.Log(4f * MathF.PI);
+        for (int i = 0; i < BatchSize; i++) h[i] = lnFourPi + MathF.Log(Scale[i]);
+        return h;
+    }
+    /// <inheritdoc />
+    public override float[] Mean
+    {
+        get { var m = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) m[i] = float.NaN; return m; }
+    }
+    /// <inheritdoc />
+    public override float[] Variance
+    {
+        get { var v = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) v[i] = float.NaN; return v; }
+    }
+    /// <inheritdoc />
+    public override float[] Cdf(float[] value)
+    {
+        EnsureValueShape(value);
+        var c = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            float z = (value[i] - Loc[i]) / Scale[i];
+            c[i] = 0.5f + MathF.Atan(z) / MathF.PI;
+        }
+        return c;
+    }
+    /// <inheritdoc />
+    public override float[] Icdf(float[] probability)
+    {
+        EnsureValueShape(probability);
+        var x = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+            x[i] = Loc[i] + Scale[i] * MathF.Tan(MathF.PI * (probability[i] - 0.5f));
+        return x;
+    }
+}
+
+/// <summary>Half-Cauchy distribution: |X| where X ∼ Cauchy(0, scale).</summary>
+public sealed class HalfCauchyDistribution : DistributionBase
+{
+    /// <summary>Per-batch scale.</summary>
+    public float[] Scale { get; }
+    /// <inheritdoc />
+    public override int BatchSize => Scale.Length;
+    /// <inheritdoc />
+    public override int EventSize => 1;
+    /// <inheritdoc />
+    public override IConstraint Support => NonNegativeConstraint.Instance;
+    /// <inheritdoc />
+    public override bool HasRSample => true;
+    /// <summary>Build a half-Cauchy from scale.</summary>
+    public HalfCauchyDistribution(float[] scale)
+    {
+        for (int i = 0; i < scale.Length; i++) if (!(scale[i] > 0f)) throw new ArgumentException("scale > 0.");
+        Scale = scale;
+    }
+    /// <inheritdoc />
+    public override float[] Sample(Random rng) => RSample(rng);
+    /// <inheritdoc />
+    public override float[] RSample(Random rng)
+    {
+        var x = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            double u = rng.NextDouble();
+            x[i] = MathF.Abs(Scale[i] * (float)Math.Tan(Math.PI * (u - 0.5)));
+        }
+        return x;
+    }
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        var lp = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            if (value[i] < 0) { lp[i] = float.NegativeInfinity; continue; }
+            float z = value[i] / Scale[i];
+            lp[i] = MathF.Log(2f / MathF.PI) - MathF.Log(Scale[i]) - MathF.Log(1f + z * z);
+        }
+        return lp;
+    }
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        var h = new float[BatchSize];
+        float c = MathF.Log(2f * MathF.PI);
+        for (int i = 0; i < BatchSize; i++) h[i] = c + MathF.Log(Scale[i]);
+        return h;
+    }
+    /// <inheritdoc />
+    public override float[] Mean
+    { get { var m = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) m[i] = float.PositiveInfinity; return m; } }
+    /// <inheritdoc />
+    public override float[] Variance
+    { get { var v = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) v[i] = float.PositiveInfinity; return v; } }
+}
+
+/// <summary>Laplace distribution: f(x) = (1/2b)·exp(-|x-μ|/b).</summary>
+public sealed class LaplaceDistribution : DistributionBase
+{
+    /// <summary>Per-batch location.</summary>
+    public float[] Loc { get; }
+    /// <summary>Per-batch scale b.</summary>
+    public float[] Scale { get; }
+    /// <inheritdoc />
+    public override int BatchSize => Loc.Length;
+    /// <inheritdoc />
+    public override int EventSize => 1;
+    /// <inheritdoc />
+    public override IConstraint Support => RealConstraint.Instance;
+    /// <inheritdoc />
+    public override bool HasRSample => true;
+    /// <summary>Build a Laplace from per-batch loc/scale.</summary>
+    public LaplaceDistribution(float[] loc, float[] scale)
+    {
+        if (loc.Length != scale.Length) throw new ArgumentException();
+        for (int i = 0; i < scale.Length; i++) if (!(scale[i] > 0f)) throw new ArgumentException("scale > 0.");
+        Loc = loc; Scale = scale;
+    }
+    /// <inheritdoc />
+    public override float[] Sample(Random rng) => RSample(rng);
+    /// <inheritdoc />
+    public override float[] RSample(Random rng)
+    {
+        var x = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            double u = rng.NextDouble() - 0.5;
+            x[i] = Loc[i] - Scale[i] * MathF.Sign((float)u) * MathF.Log(1f - 2f * MathF.Abs((float)u));
+        }
+        return x;
+    }
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        var lp = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+            lp[i] = -MathF.Log(2f * Scale[i]) - MathF.Abs(value[i] - Loc[i]) / Scale[i];
+        return lp;
+    }
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        var h = new float[BatchSize];
+        float c = 1f + MathF.Log(2f);
+        for (int i = 0; i < BatchSize; i++) h[i] = c + MathF.Log(Scale[i]);
+        return h;
+    }
+    /// <inheritdoc />
+    public override float[] Mean => (float[])Loc.Clone();
+    /// <inheritdoc />
+    public override float[] Variance
+    {
+        get
+        {
+            var v = new float[BatchSize];
+            for (int i = 0; i < BatchSize; i++) v[i] = 2f * Scale[i] * Scale[i];
+            return v;
+        }
+    }
+}
+
+/// <summary>Uniform distribution on [low, high).</summary>
+public sealed class UniformDistribution : DistributionBase
+{
+    /// <summary>Per-batch lower bound (inclusive).</summary>
+    public float[] Low { get; }
+    /// <summary>Per-batch upper bound (exclusive).</summary>
+    public float[] High { get; }
+    /// <inheritdoc />
+    public override int BatchSize => Low.Length;
+    /// <inheritdoc />
+    public override int EventSize => 1;
+    /// <inheritdoc />
+    public override IConstraint Support
+    {
+        get
+        {
+            float lo = Low[0], hi = High[0];
+            for (int i = 1; i < Low.Length; i++)
+            {
+                if (Low[i] < lo) lo = Low[i];
+                if (High[i] > hi) hi = High[i];
+            }
+            return new IntervalConstraint(lo, hi);
+        }
+    }
+    /// <inheritdoc />
+    public override bool HasRSample => true;
+    /// <summary>Build a uniform from per-batch low/high.</summary>
+    public UniformDistribution(float[] low, float[] high)
+    {
+        if (low.Length != high.Length) throw new ArgumentException();
+        for (int i = 0; i < low.Length; i++)
+            if (!(high[i] > low[i])) throw new ArgumentException("high > low.");
+        Low = low; High = high;
+    }
+    /// <inheritdoc />
+    public override float[] Sample(Random rng) => RSample(rng);
+    /// <inheritdoc />
+    public override float[] RSample(Random rng)
+    {
+        var x = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+            x[i] = Low[i] + (High[i] - Low[i]) * (float)rng.NextDouble();
+        return x;
+    }
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        var lp = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+            lp[i] = (value[i] >= Low[i] && value[i] < High[i])
+                ? -MathF.Log(High[i] - Low[i])
+                : float.NegativeInfinity;
+        return lp;
+    }
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        var h = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++) h[i] = MathF.Log(High[i] - Low[i]);
+        return h;
+    }
+    /// <inheritdoc />
+    public override float[] Mean
+    {
+        get { var m = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) m[i] = 0.5f * (Low[i] + High[i]); return m; }
+    }
+    /// <inheritdoc />
+    public override float[] Variance
+    {
+        get { var v = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) { var w = High[i] - Low[i]; v[i] = w * w / 12f; } return v; }
+    }
+    /// <inheritdoc />
+    public override float[] Cdf(float[] value)
+    {
+        EnsureValueShape(value);
+        var c = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            if (value[i] < Low[i]) c[i] = 0f;
+            else if (value[i] >= High[i]) c[i] = 1f;
+            else c[i] = (value[i] - Low[i]) / (High[i] - Low[i]);
+        }
+        return c;
+    }
+    /// <inheritdoc />
+    public override float[] Icdf(float[] probability)
+    {
+        EnsureValueShape(probability);
+        var x = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+            x[i] = Low[i] + probability[i] * (High[i] - Low[i]);
+        return x;
+    }
+}
+
+/// <summary>Exponential distribution f(x) = λ·exp(-λ·x), x ≥ 0.</summary>
+public sealed class ExponentialDistribution : DistributionBase
+{
+    /// <summary>Per-batch rate parameter (1 / mean).</summary>
+    public float[] Rate { get; }
+    /// <inheritdoc />
+    public override int BatchSize => Rate.Length;
+    /// <inheritdoc />
+    public override int EventSize => 1;
+    /// <inheritdoc />
+    public override IConstraint Support => NonNegativeConstraint.Instance;
+    /// <inheritdoc />
+    public override bool HasRSample => true;
+    /// <summary>Build an exponential from per-batch rate.</summary>
+    public ExponentialDistribution(float[] rate)
+    {
+        for (int i = 0; i < rate.Length; i++) if (!(rate[i] > 0f)) throw new ArgumentException("rate > 0.");
+        Rate = rate;
+    }
+    /// <inheritdoc />
+    public override float[] Sample(Random rng) => RSample(rng);
+    /// <inheritdoc />
+    public override float[] RSample(Random rng)
+    {
+        var x = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            double u = rng.NextDouble();
+            if (u < 1e-12) u = 1e-12;
+            x[i] = -MathF.Log((float)u) / Rate[i];
+        }
+        return x;
+    }
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        var lp = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+            lp[i] = value[i] < 0 ? float.NegativeInfinity : MathF.Log(Rate[i]) - Rate[i] * value[i];
+        return lp;
+    }
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        var h = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++) h[i] = 1f - MathF.Log(Rate[i]);
+        return h;
+    }
+    /// <inheritdoc />
+    public override float[] Mean
+    { get { var m = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) m[i] = 1f / Rate[i]; return m; } }
+    /// <inheritdoc />
+    public override float[] Variance
+    { get { var v = new float[BatchSize]; for (int i = 0; i < BatchSize; i++) v[i] = 1f / (Rate[i] * Rate[i]); return v; } }
+    /// <inheritdoc />
+    public override float[] Cdf(float[] value)
+    {
+        EnsureValueShape(value);
+        var c = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+            c[i] = value[i] < 0 ? 0f : 1f - MathF.Exp(-Rate[i] * value[i]);
+        return c;
+    }
+    /// <inheritdoc />
+    public override float[] Icdf(float[] probability)
+    {
+        EnsureValueShape(probability);
+        var x = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++) x[i] = -MathF.Log(1f - probability[i]) / Rate[i];
+        return x;
+    }
+}
+
+/// <summary>Gumbel distribution F(x) = exp(-exp(-(x-μ)/β)).</summary>
+public sealed class GumbelDistribution : DistributionBase
+{
+    /// <summary>Per-batch location.</summary>
+    public float[] Loc { get; }
+    /// <summary>Per-batch scale.</summary>
+    public float[] Scale { get; }
+    /// <inheritdoc />
+    public override int BatchSize => Loc.Length;
+    /// <inheritdoc />
+    public override int EventSize => 1;
+    /// <inheritdoc />
+    public override IConstraint Support => RealConstraint.Instance;
+    /// <inheritdoc />
+    public override bool HasRSample => true;
+    /// <summary>Build a Gumbel from per-batch loc/scale.</summary>
+    public GumbelDistribution(float[] loc, float[] scale)
+    {
+        if (loc.Length != scale.Length) throw new ArgumentException();
+        for (int i = 0; i < scale.Length; i++) if (!(scale[i] > 0f)) throw new ArgumentException("scale > 0.");
+        Loc = loc; Scale = scale;
+    }
+    /// <inheritdoc />
+    public override float[] Sample(Random rng) => RSample(rng);
+    /// <inheritdoc />
+    public override float[] RSample(Random rng)
+    {
+        var x = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            double u = rng.NextDouble();
+            if (u < 1e-12) u = 1e-12;
+            x[i] = Loc[i] - Scale[i] * MathF.Log(-MathF.Log((float)u));
+        }
+        return x;
+    }
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        var lp = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+        {
+            float z = (value[i] - Loc[i]) / Scale[i];
+            lp[i] = -MathF.Log(Scale[i]) - z - MathF.Exp(-z);
+        }
+        return lp;
+    }
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        var h = new float[BatchSize];
+        const float EulerMascheroni = 0.5772156649f;
+        for (int i = 0; i < BatchSize; i++) h[i] = MathF.Log(Scale[i]) + EulerMascheroni + 1f;
+        return h;
+    }
+    /// <inheritdoc />
+    public override float[] Mean
+    {
+        get
+        {
+            var m = new float[BatchSize];
+            const float EulerMascheroni = 0.5772156649f;
+            for (int i = 0; i < BatchSize; i++) m[i] = Loc[i] + EulerMascheroni * Scale[i];
+            return m;
+        }
+    }
+    /// <inheritdoc />
+    public override float[] Variance
+    {
+        get
+        {
+            var v = new float[BatchSize];
+            float pi2over6 = MathF.PI * MathF.PI / 6f;
+            for (int i = 0; i < BatchSize; i++) v[i] = pi2over6 * Scale[i] * Scale[i];
+            return v;
+        }
+    }
+}

--- a/src/AiDotNet.Tensors/Distributions/MultivariateDistributions.cs
+++ b/src/AiDotNet.Tensors/Distributions/MultivariateDistributions.cs
@@ -36,7 +36,7 @@ public sealed class MultivariateNormalDistribution : DistributionBase
         if (loc.Length % d != 0) throw new ArgumentException("loc.Length must be a multiple of D.");
         int batch = loc.Length / d;
         if (covariance.Length != batch * d * d) throw new ArgumentException("covariance shape mismatch.");
-        Loc = loc; Covariance = covariance; D = d;
+        Loc = (float[])loc.Clone(); Covariance = (float[])covariance.Clone(); D = d;
         CholeskyL = new float[batch * d * d];
         for (int b = 0; b < batch; b++) Cholesky(covariance, b * d * d, CholeskyL, b * d * d, d);
     }
@@ -167,7 +167,7 @@ public sealed class DiagonalMultivariateNormalDistribution : DistributionBase
         if (loc.Length != scale.Length) throw new ArgumentException();
         if (loc.Length % d != 0) throw new ArgumentException("D must divide loc.Length.");
         for (int i = 0; i < scale.Length; i++) if (!(scale[i] > 0f)) throw new ArgumentException("scale > 0.");
-        Loc = loc; Scale = scale; D = d;
+        Loc = (float[])loc.Clone(); Scale = (float[])scale.Clone(); D = d;
     }
     /// <inheritdoc />
     public override float[] Sample(Random rng) => RSample(rng);
@@ -249,7 +249,7 @@ public sealed class DirichletDistribution : DistributionBase
         if (k <= 0) throw new ArgumentException("K > 0.");
         if (concentration.Length % k != 0) throw new ArgumentException("concentration.Length % K != 0.");
         for (int i = 0; i < concentration.Length; i++) if (!(concentration[i] > 0f)) throw new ArgumentException("α > 0.");
-        Concentration = concentration; K = k;
+        Concentration = (float[])concentration.Clone(); K = k;
     }
     /// <inheritdoc />
     public override float[] Sample(Random rng) => RSample(rng);

--- a/src/AiDotNet.Tensors/Distributions/MultivariateDistributions.cs
+++ b/src/AiDotNet.Tensors/Distributions/MultivariateDistributions.cs
@@ -1,0 +1,353 @@
+using System;
+using AiDotNet.Tensors.Distributions.Constraints;
+using AiDotNet.Tensors.Distributions.Helpers;
+
+namespace AiDotNet.Tensors.Distributions;
+
+/// <summary>
+/// Multivariate normal distribution N(μ, Σ). Supports diagonal covariance via the
+/// dedicated <see cref="DiagonalMultivariateNormalDistribution"/> for the common
+/// case; this class accepts a full covariance matrix per batch element. Cholesky
+/// factor <c>L</c> is computed at construction time and reused for sampling.
+/// </summary>
+public sealed class MultivariateNormalDistribution : DistributionBase
+{
+    /// <summary>Per-batch mean vectors. Layout <c>[batch, D]</c> row-major.</summary>
+    public float[] Loc { get; }
+    /// <summary>Per-batch covariance matrices. Layout <c>[batch, D, D]</c> row-major.</summary>
+    public float[] Covariance { get; }
+    /// <summary>Lower-triangular Cholesky factor of <see cref="Covariance"/>.</summary>
+    public float[] CholeskyL { get; }
+    /// <summary>Event dimensionality.</summary>
+    public int D { get; }
+    /// <inheritdoc />
+    public override int BatchSize => Loc.Length / D;
+    /// <inheritdoc />
+    public override int EventSize => D;
+    /// <inheritdoc />
+    public override IConstraint Support => RealConstraint.Instance;
+    /// <inheritdoc />
+    public override bool HasRSample => true;
+
+    /// <summary>Build an MVN from per-batch loc + covariance.</summary>
+    public MultivariateNormalDistribution(float[] loc, float[] covariance, int d)
+    {
+        if (d <= 0) throw new ArgumentException("D > 0.");
+        if (loc.Length % d != 0) throw new ArgumentException("loc.Length must be a multiple of D.");
+        int batch = loc.Length / d;
+        if (covariance.Length != batch * d * d) throw new ArgumentException("covariance shape mismatch.");
+        Loc = loc; Covariance = covariance; D = d;
+        CholeskyL = new float[batch * d * d];
+        for (int b = 0; b < batch; b++) Cholesky(covariance, b * d * d, CholeskyL, b * d * d, d);
+    }
+
+    /// <inheritdoc />
+    public override float[] Sample(Random rng) => RSample(rng);
+    /// <inheritdoc />
+    public override float[] RSample(Random rng)
+    {
+        int batch = BatchSize;
+        var x = new float[batch * D];
+        var z = new float[D];
+        for (int b = 0; b < batch; b++)
+        {
+            for (int i = 0; i < D; i++) z[i] = (float)NormalDistribution.Gaussian(rng);
+            // x = L · z + μ
+            for (int i = 0; i < D; i++)
+            {
+                float acc = 0f;
+                for (int j = 0; j <= i; j++) acc += CholeskyL[b * D * D + i * D + j] * z[j];
+                x[b * D + i] = Loc[b * D + i] + acc;
+            }
+        }
+        return x;
+    }
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        int batch = BatchSize;
+        var lp = new float[batch];
+        var diff = new float[D];
+        var sol = new float[D];
+        const float HalfLog2Pi = 0.91893853321f;
+        for (int b = 0; b < batch; b++)
+        {
+            for (int i = 0; i < D; i++) diff[i] = value[b * D + i] - Loc[b * D + i];
+            // Solve L · sol = diff (forward substitution).
+            for (int i = 0; i < D; i++)
+            {
+                float s = diff[i];
+                for (int j = 0; j < i; j++) s -= CholeskyL[b * D * D + i * D + j] * sol[j];
+                sol[i] = s / CholeskyL[b * D * D + i * D + i];
+            }
+            float quad = 0f;
+            for (int i = 0; i < D; i++) quad += sol[i] * sol[i];
+            float halfLogDet = 0f;
+            for (int i = 0; i < D; i++) halfLogDet += MathF.Log(CholeskyL[b * D * D + i * D + i]);
+            lp[b] = -0.5f * quad - halfLogDet - D * HalfLog2Pi;
+        }
+        return lp;
+    }
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        int batch = BatchSize;
+        var h = new float[batch];
+        const float HalfLog2PiE = 1.41893853321f;
+        for (int b = 0; b < batch; b++)
+        {
+            float halfLogDet = 0f;
+            for (int i = 0; i < D; i++) halfLogDet += MathF.Log(CholeskyL[b * D * D + i * D + i]);
+            h[b] = D * HalfLog2PiE + halfLogDet;
+        }
+        return h;
+    }
+    /// <inheritdoc />
+    public override float[] Mean => (float[])Loc.Clone();
+    /// <inheritdoc />
+    public override float[] Variance
+    {
+        get
+        {
+            int batch = BatchSize;
+            var v = new float[batch * D];
+            for (int b = 0; b < batch; b++)
+                for (int i = 0; i < D; i++)
+                    v[b * D + i] = Covariance[b * D * D + i * D + i];
+            return v;
+        }
+    }
+
+    private static void Cholesky(float[] src, int srcOff, float[] dst, int dstOff, int n)
+    {
+        for (int i = 0; i < n; i++)
+            for (int j = 0; j < n; j++)
+                dst[dstOff + i * n + j] = 0f;
+        for (int i = 0; i < n; i++)
+        {
+            for (int j = 0; j <= i; j++)
+            {
+                double s = src[srcOff + i * n + j];
+                for (int k = 0; k < j; k++) s -= dst[dstOff + i * n + k] * dst[dstOff + j * n + k];
+                if (i == j)
+                {
+                    if (s <= 0) throw new ArgumentException("covariance is not positive definite.");
+                    dst[dstOff + i * n + i] = (float)Math.Sqrt(s);
+                }
+                else
+                {
+                    dst[dstOff + i * n + j] = (float)(s / dst[dstOff + j * n + j]);
+                }
+            }
+        }
+    }
+}
+
+/// <summary>Diagonal multivariate normal — specialised when Σ = diag(σ²).</summary>
+public sealed class DiagonalMultivariateNormalDistribution : DistributionBase
+{
+    /// <summary>Per-batch loc, layout <c>[batch, D]</c>.</summary>
+    public float[] Loc { get; }
+    /// <summary>Per-batch scale (per-dim std), layout <c>[batch, D]</c>.</summary>
+    public float[] Scale { get; }
+    /// <summary>Event dimensionality.</summary>
+    public int D { get; }
+    /// <inheritdoc />
+    public override int BatchSize => Loc.Length / D;
+    /// <inheritdoc />
+    public override int EventSize => D;
+    /// <inheritdoc />
+    public override IConstraint Support => RealConstraint.Instance;
+    /// <inheritdoc />
+    public override bool HasRSample => true;
+    /// <summary>Build a diagonal MVN.</summary>
+    public DiagonalMultivariateNormalDistribution(float[] loc, float[] scale, int d)
+    {
+        if (loc.Length != scale.Length) throw new ArgumentException();
+        if (loc.Length % d != 0) throw new ArgumentException("D must divide loc.Length.");
+        for (int i = 0; i < scale.Length; i++) if (!(scale[i] > 0f)) throw new ArgumentException("scale > 0.");
+        Loc = loc; Scale = scale; D = d;
+    }
+    /// <inheritdoc />
+    public override float[] Sample(Random rng) => RSample(rng);
+    /// <inheritdoc />
+    public override float[] RSample(Random rng)
+    {
+        var x = new float[Loc.Length];
+        for (int i = 0; i < x.Length; i++)
+            x[i] = Loc[i] + Scale[i] * (float)NormalDistribution.Gaussian(rng);
+        return x;
+    }
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        int batch = BatchSize;
+        var lp = new float[batch];
+        const float LogTwoPi = 1.83787706641f;
+        for (int b = 0; b < batch; b++)
+        {
+            float acc = 0f;
+            for (int i = 0; i < D; i++)
+            {
+                float z = (value[b * D + i] - Loc[b * D + i]) / Scale[b * D + i];
+                acc -= 0.5f * (z * z + LogTwoPi) + MathF.Log(Scale[b * D + i]);
+            }
+            lp[b] = acc;
+        }
+        return lp;
+    }
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        int batch = BatchSize;
+        var h = new float[batch];
+        const float HalfLog2PiE = 1.41893853321f;
+        for (int b = 0; b < batch; b++)
+        {
+            float acc = D * HalfLog2PiE;
+            for (int i = 0; i < D; i++) acc += MathF.Log(Scale[b * D + i]);
+            h[b] = acc;
+        }
+        return h;
+    }
+    /// <inheritdoc />
+    public override float[] Mean => (float[])Loc.Clone();
+    /// <inheritdoc />
+    public override float[] Variance
+    {
+        get
+        {
+            var v = new float[Scale.Length];
+            for (int i = 0; i < v.Length; i++) v[i] = Scale[i] * Scale[i];
+            return v;
+        }
+    }
+    /// <inheritdoc />
+    public override float[] StdDev => (float[])Scale.Clone();
+}
+
+/// <summary>Dirichlet distribution on the K-simplex.</summary>
+public sealed class DirichletDistribution : DistributionBase
+{
+    /// <summary>Per-batch concentration vectors. Layout <c>[batch, K]</c>.</summary>
+    public float[] Concentration { get; }
+    /// <summary>Number of categories.</summary>
+    public int K { get; }
+    /// <inheritdoc />
+    public override int BatchSize => Concentration.Length / K;
+    /// <inheritdoc />
+    public override int EventSize => K;
+    /// <inheritdoc />
+    public override IConstraint Support => new SimplexConstraint(K);
+    /// <inheritdoc />
+    public override bool HasRSample => true;
+    /// <summary>Build a Dirichlet from per-batch concentration vectors.</summary>
+    public DirichletDistribution(float[] concentration, int k)
+    {
+        if (k <= 0) throw new ArgumentException("K > 0.");
+        if (concentration.Length % k != 0) throw new ArgumentException("concentration.Length % K != 0.");
+        for (int i = 0; i < concentration.Length; i++) if (!(concentration[i] > 0f)) throw new ArgumentException("α > 0.");
+        Concentration = concentration; K = k;
+    }
+    /// <inheritdoc />
+    public override float[] Sample(Random rng) => RSample(rng);
+    /// <inheritdoc />
+    public override float[] RSample(Random rng)
+    {
+        int batch = BatchSize;
+        var x = new float[batch * K];
+        for (int b = 0; b < batch; b++)
+        {
+            float sum = 0f;
+            for (int i = 0; i < K; i++)
+            {
+                x[b * K + i] = GammaDistribution.MarsagliaTsang(rng, Concentration[b * K + i]);
+                sum += x[b * K + i];
+            }
+            for (int i = 0; i < K; i++) x[b * K + i] /= sum;
+        }
+        return x;
+    }
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        int batch = BatchSize;
+        var lp = new float[batch];
+        for (int b = 0; b < batch; b++)
+        {
+            float a0 = 0f;
+            float l = 0f;
+            for (int i = 0; i < K; i++)
+            {
+                float a = Concentration[b * K + i];
+                a0 += a;
+                l += (a - 1f) * MathF.Log(value[b * K + i]) - SpecialFunctions.Lgamma(a);
+            }
+            l += SpecialFunctions.Lgamma(a0);
+            lp[b] = l;
+        }
+        return lp;
+    }
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        int batch = BatchSize;
+        var h = new float[batch];
+        for (int b = 0; b < batch; b++)
+        {
+            float a0 = 0f;
+            for (int i = 0; i < K; i++) a0 += Concentration[b * K + i];
+            float lnB = -SpecialFunctions.Lgamma(a0);
+            for (int i = 0; i < K; i++) lnB += SpecialFunctions.Lgamma(Concentration[b * K + i]);
+            float dgA0 = SpecialFunctions.Digamma(a0);
+            float term = (a0 - K) * dgA0;
+            for (int i = 0; i < K; i++)
+            {
+                float a = Concentration[b * K + i];
+                term -= (a - 1f) * SpecialFunctions.Digamma(a);
+            }
+            h[b] = lnB + term;
+        }
+        return h;
+    }
+    /// <inheritdoc />
+    public override float[] Mean
+    {
+        get
+        {
+            int batch = BatchSize;
+            var m = new float[batch * K];
+            for (int b = 0; b < batch; b++)
+            {
+                float a0 = 0f;
+                for (int i = 0; i < K; i++) a0 += Concentration[b * K + i];
+                for (int i = 0; i < K; i++) m[b * K + i] = Concentration[b * K + i] / a0;
+            }
+            return m;
+        }
+    }
+    /// <inheritdoc />
+    public override float[] Variance
+    {
+        get
+        {
+            int batch = BatchSize;
+            var v = new float[batch * K];
+            for (int b = 0; b < batch; b++)
+            {
+                float a0 = 0f;
+                for (int i = 0; i < K; i++) a0 += Concentration[b * K + i];
+                float denom = a0 * a0 * (a0 + 1f);
+                for (int i = 0; i < K; i++)
+                {
+                    float a = Concentration[b * K + i];
+                    v[b * K + i] = a * (a0 - a) / denom;
+                }
+            }
+            return v;
+        }
+    }
+}

--- a/src/AiDotNet.Tensors/Distributions/NormalDistribution.cs
+++ b/src/AiDotNet.Tensors/Distributions/NormalDistribution.cs
@@ -33,7 +33,10 @@ public sealed class NormalDistribution : DistributionBase
             throw new ArgumentException("loc and scale must have the same length.");
         for (int i = 0; i < scale.Length; i++)
             if (!(scale[i] > 0f)) throw new ArgumentException("scale must be > 0.");
-        Loc = loc; Scale = scale;
+        // Defensive copies so external mutation cannot break the distribution's invariants
+        // (validated scale > 0, fixed batch size) after construction.
+        Loc = (float[])loc.Clone();
+        Scale = (float[])scale.Clone();
     }
 
     /// <summary>Build a scalar (single-element batch) normal.</summary>

--- a/src/AiDotNet.Tensors/Distributions/NormalDistribution.cs
+++ b/src/AiDotNet.Tensors/Distributions/NormalDistribution.cs
@@ -1,0 +1,119 @@
+using System;
+using AiDotNet.Tensors.Distributions.Constraints;
+using AiDotNet.Tensors.Distributions.Helpers;
+
+namespace AiDotNet.Tensors.Distributions;
+
+/// <summary>
+/// Normal (Gaussian) distribution N(μ, σ²). Reparameterisable via the
+/// location-scale trick: <c>x = μ + σ·z, z ∼ N(0, 1)</c>.
+/// </summary>
+public sealed class NormalDistribution : DistributionBase
+{
+    /// <summary>Per-batch means.</summary>
+    public float[] Loc { get; }
+    /// <summary>Per-batch standard deviations (must be &gt; 0).</summary>
+    public float[] Scale { get; }
+
+    /// <inheritdoc />
+    public override int BatchSize => Loc.Length;
+    /// <inheritdoc />
+    public override int EventSize => 1;
+    /// <inheritdoc />
+    public override IConstraint Support => RealConstraint.Instance;
+    /// <inheritdoc />
+    public override bool HasRSample => true;
+
+    /// <summary>Build a normal distribution from a per-batch <paramref name="loc"/> and <paramref name="scale"/>.</summary>
+    public NormalDistribution(float[] loc, float[] scale)
+    {
+        if (loc == null) throw new ArgumentNullException(nameof(loc));
+        if (scale == null) throw new ArgumentNullException(nameof(scale));
+        if (loc.Length != scale.Length)
+            throw new ArgumentException("loc and scale must have the same length.");
+        for (int i = 0; i < scale.Length; i++)
+            if (!(scale[i] > 0f)) throw new ArgumentException("scale must be > 0.");
+        Loc = loc; Scale = scale;
+    }
+
+    /// <summary>Build a scalar (single-element batch) normal.</summary>
+    public NormalDistribution(float loc, float scale) : this(new[] { loc }, new[] { scale }) { }
+
+    /// <inheritdoc />
+    public override float[] Sample(Random rng) => RSample(rng);
+
+    /// <inheritdoc />
+    public override float[] RSample(Random rng)
+    {
+        var x = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+            x[i] = Loc[i] + Scale[i] * (float)Gaussian(rng);
+        return x;
+    }
+
+    /// <inheritdoc />
+    public override float[] LogProb(float[] value)
+    {
+        EnsureValueShape(value);
+        var lp = new float[BatchSize];
+        const float LogTwoPi = 1.83787706641f;
+        for (int i = 0; i < BatchSize; i++)
+        {
+            float z = (value[i] - Loc[i]) / Scale[i];
+            lp[i] = -0.5f * (z * z + LogTwoPi) - MathF.Log(Scale[i]);
+        }
+        return lp;
+    }
+
+    /// <inheritdoc />
+    public override float[] Entropy()
+    {
+        var h = new float[BatchSize];
+        const float HalfLogTwoPiE = 1.41893853321f; // 0.5·log(2πe)
+        for (int i = 0; i < BatchSize; i++) h[i] = HalfLogTwoPiE + MathF.Log(Scale[i]);
+        return h;
+    }
+
+    /// <inheritdoc />
+    public override float[] Mean => (float[])Loc.Clone();
+    /// <inheritdoc />
+    public override float[] Variance
+    {
+        get
+        {
+            var v = new float[BatchSize];
+            for (int i = 0; i < BatchSize; i++) v[i] = Scale[i] * Scale[i];
+            return v;
+        }
+    }
+    /// <inheritdoc />
+    public override float[] StdDev => (float[])Scale.Clone();
+
+    /// <inheritdoc />
+    public override float[] Cdf(float[] value)
+    {
+        EnsureValueShape(value);
+        var c = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+            c[i] = SpecialFunctions.NormalCdf((value[i] - Loc[i]) / Scale[i]);
+        return c;
+    }
+
+    /// <inheritdoc />
+    public override float[] Icdf(float[] probability)
+    {
+        EnsureValueShape(probability);
+        var x = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++)
+            x[i] = Loc[i] + Scale[i] * SpecialFunctions.NormalIcdf(probability[i]);
+        return x;
+    }
+
+    /// <summary>Box-Muller standard-normal sampler. Used by every distribution that needs Gaussians.</summary>
+    internal static double Gaussian(Random rng)
+    {
+        double u1 = rng.NextDouble(); double u2 = rng.NextDouble();
+        if (u1 < 1e-12) u1 = 1e-12;
+        return Math.Sqrt(-2.0 * Math.Log(u1)) * Math.Cos(2.0 * Math.PI * u2);
+    }
+}

--- a/src/AiDotNet.Tensors/Distributions/Transforms/AdditionalFlowTransforms.cs
+++ b/src/AiDotNet.Tensors/Distributions/Transforms/AdditionalFlowTransforms.cs
@@ -5,31 +5,34 @@ namespace AiDotNet.Tensors.Distributions.Transforms;
 
 /// <summary>
 /// Masked Autoregressive Flow (MAF) transform (Papamakarios et al., 2017).
-/// Forward map (analytic, fast for log_prob; inverse is sequential and slow):
-///   y_i = (x_i − μ_i(x_{1:i-1})) · exp(−s_i(x_{1:i-1}))
-/// where μ_i, s_i are autoregressive functions of the preceding inputs. We expose a
-/// configurable affine-conditioner variant — the canonical formulation — by accepting
-/// per-dim parameter arrays <paramref name="Mu"/>, <paramref name="LogScale"/> that
-/// the caller updates as a function of x_{1:i-1}.
 ///
-/// The transform is bijective, log_abs_det = −Σ s_i, and forward is parallel-friendly
-/// across batch elements (the autoregressive constraint is on the event dim only).
+/// True autoregressive flow: μ_i and s_i are computed at evaluation time from the
+/// already-known prefix x_{1:i-1} via a user-supplied <see cref="Conditioner"/>
+/// callback, so the same transform handles arbitrary inputs (not just the one its
+/// parameters happened to be precomputed from).
+///
+/// Forward (analytic, parallel across event dim):
+///   y_i = (x_i − μ_i(x_{1:i-1})) · exp(−s_i(x_{1:i-1}))
+/// Inverse (sequential — the cost MAF accepts to make log_prob fast):
+///   x_i = y_i · exp(s_i(x_{1:i-1})) + μ_i(x_{1:i-1})
+/// log|det J| = −Σ s_i.
 /// </summary>
 public sealed class MaskedAutoregressiveFlowTransform : ITransform
 {
-    /// <summary>Per-dim shifts μ_i. Layout <c>[batch, D]</c>.</summary>
-    public float[] Mu { get; }
-    /// <summary>Per-dim log-scales s_i. Layout <c>[batch, D]</c>.</summary>
-    public float[] LogScale { get; }
+    /// <summary>Conditioner: given the dim index <c>i</c> and the already-known prefix
+    /// <c>x_{0..i-1}</c> (length <c>i</c>), returns <c>(μ_i, s_i)</c>. Same callback is
+    /// invoked during forward, inverse, and log|det J| evaluation so the autoregressive
+    /// contract holds for arbitrary inputs.</summary>
+    public Func<int, float[], (float Mu, float LogScale)> Conditioner { get; }
     /// <summary>Event dimension D.</summary>
     public int D { get; }
 
-    /// <summary>Build a MAF affine-conditioner transform.</summary>
-    public MaskedAutoregressiveFlowTransform(float[] mu, float[] logScale, int d)
+    /// <summary>Build a MAF transform with a per-dim conditioner.</summary>
+    public MaskedAutoregressiveFlowTransform(int d, Func<int, float[], (float Mu, float LogScale)> conditioner)
     {
-        if (mu.Length != logScale.Length) throw new ArgumentException();
-        if (mu.Length % d != 0) throw new ArgumentException();
-        Mu = mu; LogScale = logScale; D = d;
+        if (d <= 0) throw new ArgumentOutOfRangeException(nameof(d));
+        Conditioner = conditioner ?? throw new ArgumentNullException(nameof(conditioner));
+        D = d;
     }
     /// <inheritdoc />
     public IConstraint Domain => RealConstraint.Instance;
@@ -37,42 +40,70 @@ public sealed class MaskedAutoregressiveFlowTransform : ITransform
     public IConstraint Codomain => RealConstraint.Instance;
     /// <inheritdoc />
     public bool ConstantJacobian => false;
+    /// <inheritdoc />
+    public bool IsDimensionPreserving => true;
 
     /// <inheritdoc />
     public float[] Forward(float[] x)
     {
-        if (x.Length != Mu.Length) throw new ArgumentException();
+        if (x == null) throw new ArgumentNullException(nameof(x));
+        if (x.Length % D != 0) throw new ArgumentException($"x.Length must be a multiple of D={D}.");
         int batch = x.Length / D;
         var y = new float[x.Length];
+        var prefix = new float[D];
         for (int b = 0; b < batch; b++)
+        {
+            for (int i = 0; i < D; i++) prefix[i] = x[b * D + i];
             for (int i = 0; i < D; i++)
             {
-                float invScale = MathF.Exp(-LogScale[b * D + i]);
-                y[b * D + i] = (x[b * D + i] - Mu[b * D + i]) * invScale;
+                var slice = new float[i];
+                Array.Copy(prefix, 0, slice, 0, i);
+                var (mu, s) = Conditioner(i, slice);
+                y[b * D + i] = (prefix[i] - mu) * MathF.Exp(-s);
             }
+        }
         return y;
     }
     /// <inheritdoc />
     public float[] Inverse(float[] y)
     {
-        if (y.Length != Mu.Length) throw new ArgumentException();
+        if (y == null) throw new ArgumentNullException(nameof(y));
+        if (y.Length % D != 0) throw new ArgumentException($"y.Length must be a multiple of D={D}.");
         int batch = y.Length / D;
         var x = new float[y.Length];
+        var prefix = new float[D];
         for (int b = 0; b < batch; b++)
+        {
             for (int i = 0; i < D; i++)
-                x[b * D + i] = y[b * D + i] * MathF.Exp(LogScale[b * D + i]) + Mu[b * D + i];
+            {
+                var slice = new float[i];
+                Array.Copy(prefix, 0, slice, 0, i);
+                var (mu, s) = Conditioner(i, slice);
+                prefix[i] = y[b * D + i] * MathF.Exp(s) + mu;
+                x[b * D + i] = prefix[i];
+            }
+        }
         return x;
     }
     /// <inheritdoc />
     public float[] LogAbsDetJacobian(float[] x, float[] y)
     {
-        // log|det J| = −Σ s_i (forward direction).
+        if (x == null) throw new ArgumentNullException(nameof(x));
+        if (x.Length % D != 0) throw new ArgumentException();
         var ldj = new float[x.Length];
         int batch = x.Length / D;
+        var prefix = new float[D];
         for (int b = 0; b < batch; b++)
         {
+            for (int i = 0; i < D; i++) prefix[i] = x[b * D + i];
             float per = 0f;
-            for (int i = 0; i < D; i++) per -= LogScale[b * D + i];
+            for (int i = 0; i < D; i++)
+            {
+                var slice = new float[i];
+                Array.Copy(prefix, 0, slice, 0, i);
+                var (_, s) = Conditioner(i, slice);
+                per -= s;
+            }
             for (int i = 0; i < D; i++) ldj[b * D + i] = per / D;
         }
         return ldj;
@@ -122,6 +153,8 @@ public sealed class NeuralSplineFlowTransform : ITransform
     public IConstraint Codomain => RealConstraint.Instance;
     /// <inheritdoc />
     public bool ConstantJacobian => false;
+    /// <inheritdoc />
+    public bool IsDimensionPreserving => true;
 
     /// <inheritdoc />
     public float[] Forward(float[] x)

--- a/src/AiDotNet.Tensors/Distributions/Transforms/AdditionalFlowTransforms.cs
+++ b/src/AiDotNet.Tensors/Distributions/Transforms/AdditionalFlowTransforms.cs
@@ -1,0 +1,218 @@
+using System;
+using AiDotNet.Tensors.Distributions.Constraints;
+
+namespace AiDotNet.Tensors.Distributions.Transforms;
+
+/// <summary>
+/// Masked Autoregressive Flow (MAF) transform (Papamakarios et al., 2017).
+/// Forward map (analytic, fast for log_prob; inverse is sequential and slow):
+///   y_i = (x_i − μ_i(x_{1:i-1})) · exp(−s_i(x_{1:i-1}))
+/// where μ_i, s_i are autoregressive functions of the preceding inputs. We expose a
+/// configurable affine-conditioner variant — the canonical formulation — by accepting
+/// per-dim parameter arrays <paramref name="Mu"/>, <paramref name="LogScale"/> that
+/// the caller updates as a function of x_{1:i-1}.
+///
+/// The transform is bijective, log_abs_det = −Σ s_i, and forward is parallel-friendly
+/// across batch elements (the autoregressive constraint is on the event dim only).
+/// </summary>
+public sealed class MaskedAutoregressiveFlowTransform : ITransform
+{
+    /// <summary>Per-dim shifts μ_i. Layout <c>[batch, D]</c>.</summary>
+    public float[] Mu { get; }
+    /// <summary>Per-dim log-scales s_i. Layout <c>[batch, D]</c>.</summary>
+    public float[] LogScale { get; }
+    /// <summary>Event dimension D.</summary>
+    public int D { get; }
+
+    /// <summary>Build a MAF affine-conditioner transform.</summary>
+    public MaskedAutoregressiveFlowTransform(float[] mu, float[] logScale, int d)
+    {
+        if (mu.Length != logScale.Length) throw new ArgumentException();
+        if (mu.Length % d != 0) throw new ArgumentException();
+        Mu = mu; LogScale = logScale; D = d;
+    }
+    /// <inheritdoc />
+    public IConstraint Domain => RealConstraint.Instance;
+    /// <inheritdoc />
+    public IConstraint Codomain => RealConstraint.Instance;
+    /// <inheritdoc />
+    public bool ConstantJacobian => false;
+
+    /// <inheritdoc />
+    public float[] Forward(float[] x)
+    {
+        if (x.Length != Mu.Length) throw new ArgumentException();
+        int batch = x.Length / D;
+        var y = new float[x.Length];
+        for (int b = 0; b < batch; b++)
+            for (int i = 0; i < D; i++)
+            {
+                float invScale = MathF.Exp(-LogScale[b * D + i]);
+                y[b * D + i] = (x[b * D + i] - Mu[b * D + i]) * invScale;
+            }
+        return y;
+    }
+    /// <inheritdoc />
+    public float[] Inverse(float[] y)
+    {
+        if (y.Length != Mu.Length) throw new ArgumentException();
+        int batch = y.Length / D;
+        var x = new float[y.Length];
+        for (int b = 0; b < batch; b++)
+            for (int i = 0; i < D; i++)
+                x[b * D + i] = y[b * D + i] * MathF.Exp(LogScale[b * D + i]) + Mu[b * D + i];
+        return x;
+    }
+    /// <inheritdoc />
+    public float[] LogAbsDetJacobian(float[] x, float[] y)
+    {
+        // log|det J| = −Σ s_i (forward direction).
+        var ldj = new float[x.Length];
+        int batch = x.Length / D;
+        for (int b = 0; b < batch; b++)
+        {
+            float per = 0f;
+            for (int i = 0; i < D; i++) per -= LogScale[b * D + i];
+            for (int i = 0; i < D; i++) ldj[b * D + i] = per / D;
+        }
+        return ldj;
+    }
+}
+
+/// <summary>
+/// Neural Spline Flow (NSF) transform (Durkan et al., 2019), rational-quadratic spline variant.
+/// Maps each event dim through a monotonic rational-quadratic spline parameterised by K knot
+/// positions / heights / derivatives. Inputs outside <c>[Lower, Upper]</c> pass through
+/// unchanged (linear tails at the boundary slopes).
+/// </summary>
+public sealed class NeuralSplineFlowTransform : ITransform
+{
+    /// <summary>Lower bound of the spline support.</summary>
+    public float Lower { get; }
+    /// <summary>Upper bound of the spline support.</summary>
+    public float Upper { get; }
+    /// <summary>Number of bins K (must be ≥ 1).</summary>
+    public int Bins { get; }
+    /// <summary>Per-batch knot widths Δx_k (length BatchSize·K, sums to Upper - Lower per batch).</summary>
+    public float[] Widths { get; }
+    /// <summary>Per-batch knot heights Δy_k (length BatchSize·K, sums to Upper - Lower per batch).</summary>
+    public float[] Heights { get; }
+    /// <summary>Per-batch knot derivatives d_k at internal knots (length BatchSize·(K+1), positive).</summary>
+    public float[] Derivatives { get; }
+    /// <summary>Event dimension (per-element spline; the same parameters are applied independently to each entry).</summary>
+    public int D { get; }
+
+    /// <summary>Build an NSF rational-quadratic spline transform.</summary>
+    public NeuralSplineFlowTransform(
+        float lower, float upper, int bins,
+        float[] widths, float[] heights, float[] derivatives, int d)
+    {
+        if (upper <= lower) throw new ArgumentException();
+        if (bins < 1) throw new ArgumentException();
+        if (widths.Length != heights.Length) throw new ArgumentException();
+        if (widths.Length % bins != 0) throw new ArgumentException("widths.Length must be a multiple of bins.");
+        int batch = widths.Length / bins;
+        if (derivatives.Length != batch * (bins + 1)) throw new ArgumentException();
+        for (int i = 0; i < derivatives.Length; i++) if (!(derivatives[i] > 0f)) throw new ArgumentException("derivatives > 0.");
+        Lower = lower; Upper = upper; Bins = bins; Widths = widths; Heights = heights; Derivatives = derivatives; D = d;
+    }
+    /// <inheritdoc />
+    public IConstraint Domain => RealConstraint.Instance;
+    /// <inheritdoc />
+    public IConstraint Codomain => RealConstraint.Instance;
+    /// <inheritdoc />
+    public bool ConstantJacobian => false;
+
+    /// <inheritdoc />
+    public float[] Forward(float[] x)
+    {
+        var y = new float[x.Length];
+        for (int i = 0; i < x.Length; i++)
+        {
+            int batchIdx = (i / D) % (Widths.Length / Bins);  // share params across event dims
+            y[i] = ApplySpline(x[i], batchIdx, forward: true, out _);
+        }
+        return y;
+    }
+    /// <inheritdoc />
+    public float[] Inverse(float[] y)
+    {
+        var x = new float[y.Length];
+        for (int i = 0; i < y.Length; i++)
+        {
+            int batchIdx = (i / D) % (Widths.Length / Bins);
+            x[i] = ApplySpline(y[i], batchIdx, forward: false, out _);
+        }
+        return x;
+    }
+    /// <inheritdoc />
+    public float[] LogAbsDetJacobian(float[] x, float[] y)
+    {
+        var ldj = new float[x.Length];
+        for (int i = 0; i < x.Length; i++)
+        {
+            int batchIdx = (i / D) % (Widths.Length / Bins);
+            ApplySpline(x[i], batchIdx, forward: true, out float dlog);
+            ldj[i] = dlog;
+        }
+        return ldj;
+    }
+
+    private float ApplySpline(float input, int batchIdx, bool forward, out float logDeriv)
+    {
+        // Linear identity outside [Lower, Upper].
+        if (input < Lower || input > Upper) { logDeriv = 0f; return input; }
+
+        // Compute cumulative knot positions for this batch.
+        float xCum = Lower, yCum = Lower;
+        int bin = -1;
+        float xWidth = 0f, yHeight = 0f;
+        for (int k = 0; k < Bins; k++)
+        {
+            float w = Widths[batchIdx * Bins + k];
+            float h = Heights[batchIdx * Bins + k];
+            float xNext = xCum + w;
+            float yNext = yCum + h;
+            // The forward bin contains input; the inverse bin contains input on y-axis.
+            bool hit = forward
+                ? input >= xCum && input <= xNext
+                : input >= yCum && input <= yNext;
+            if (hit) { bin = k; xWidth = w; yHeight = h; break; }
+            xCum = xNext; yCum = yNext;
+        }
+        if (bin < 0) { logDeriv = 0f; return input; }
+
+        float dk  = Derivatives[batchIdx * (Bins + 1) + bin];
+        float dk1 = Derivatives[batchIdx * (Bins + 1) + bin + 1];
+        float s = yHeight / xWidth;
+
+        if (forward)
+        {
+            float xi = (input - xCum) / xWidth;
+            float numer = yHeight * (s * xi * xi + dk * xi * (1f - xi));
+            float denom = s + (dk + dk1 - 2f * s) * xi * (1f - xi);
+            float y = yCum + numer / denom;
+            // Derivative for log_abs_det:
+            float t = (s * s) * (dk1 * xi * xi + 2f * s * xi * (1f - xi) + dk * (1f - xi) * (1f - xi));
+            logDeriv = MathF.Log(t) - 2f * MathF.Log(denom);
+            return y;
+        }
+        else
+        {
+            // Inverse via solving the quadratic numer/denom = (y − yCum)/yHeight for xi.
+            float yRel = (input - yCum) / yHeight;
+            float a = yHeight * (s - dk) + (input - yCum) * (dk + dk1 - 2f * s);
+            float b = yHeight * dk - (input - yCum) * (dk + dk1 - 2f * s);
+            float c = -s * (input - yCum);
+            float disc = b * b - 4f * a * c;
+            if (disc < 0) disc = 0;
+            float xi = 2f * c / (-b - MathF.Sqrt(disc));
+            float x = xCum + xi * xWidth;
+            float t = (s * s) * (dk1 * xi * xi + 2f * s * xi * (1f - xi) + dk * (1f - xi) * (1f - xi));
+            float denom = s + (dk + dk1 - 2f * s) * xi * (1f - xi);
+            logDeriv = -(MathF.Log(t) - 2f * MathF.Log(denom));
+            _ = yRel;
+            return x;
+        }
+    }
+}

--- a/src/AiDotNet.Tensors/Distributions/Transforms/AdditionalFlowTransforms.cs
+++ b/src/AiDotNet.Tensors/Distributions/Transforms/AdditionalFlowTransforms.cs
@@ -138,14 +138,46 @@ public sealed class NeuralSplineFlowTransform : ITransform
         float lower, float upper, int bins,
         float[] widths, float[] heights, float[] derivatives, int d)
     {
-        if (upper <= lower) throw new ArgumentException();
-        if (bins < 1) throw new ArgumentException();
-        if (widths.Length != heights.Length) throw new ArgumentException();
+        if (widths == null) throw new ArgumentNullException(nameof(widths));
+        if (heights == null) throw new ArgumentNullException(nameof(heights));
+        if (derivatives == null) throw new ArgumentNullException(nameof(derivatives));
+        if (d <= 0) throw new ArgumentOutOfRangeException(nameof(d), "d > 0.");
+        if (upper <= lower) throw new ArgumentException("upper must be > lower.");
+        if (bins < 1) throw new ArgumentException("bins >= 1.");
+        if (widths.Length != heights.Length) throw new ArgumentException("widths and heights must be the same length.");
         if (widths.Length % bins != 0) throw new ArgumentException("widths.Length must be a multiple of bins.");
         int batch = widths.Length / bins;
-        if (derivatives.Length != batch * (bins + 1)) throw new ArgumentException();
-        for (int i = 0; i < derivatives.Length; i++) if (!(derivatives[i] > 0f)) throw new ArgumentException("derivatives > 0.");
-        Lower = lower; Upper = upper; Bins = bins; Widths = widths; Heights = heights; Derivatives = derivatives; D = d;
+        if (derivatives.Length != batch * (bins + 1))
+            throw new ArgumentException(
+                $"derivatives.Length ({derivatives.Length}) must equal batch · (bins + 1) = {batch * (bins + 1)}.");
+        // Defensive copies + per-batch validation: knot widths/heights must be positive
+        // and sum to (upper - lower) per batch row, otherwise the spline overshoots/
+        // undershoots its support and inverse fails.
+        float span = upper - lower;
+        for (int b = 0; b < batch; b++)
+        {
+            float wSum = 0f, hSum = 0f;
+            for (int k = 0; k < bins; k++)
+            {
+                float wk = widths[b * bins + k];
+                float hk = heights[b * bins + k];
+                if (!(wk > 0f)) throw new ArgumentException($"widths[{b},{k}] must be > 0.", nameof(widths));
+                if (!(hk > 0f)) throw new ArgumentException($"heights[{b},{k}] must be > 0.", nameof(heights));
+                wSum += wk; hSum += hk;
+            }
+            if (MathF.Abs(wSum - span) > 1e-3f * span)
+                throw new ArgumentException(
+                    $"widths row {b} sums to {wSum} but should equal upper-lower = {span}.", nameof(widths));
+            if (MathF.Abs(hSum - span) > 1e-3f * span)
+                throw new ArgumentException(
+                    $"heights row {b} sums to {hSum} but should equal upper-lower = {span}.", nameof(heights));
+        }
+        for (int i = 0; i < derivatives.Length; i++)
+            if (!(derivatives[i] > 0f)) throw new ArgumentException("derivatives > 0.");
+        Lower = lower; Upper = upper; Bins = bins; D = d;
+        Widths = (float[])widths.Clone();
+        Heights = (float[])heights.Clone();
+        Derivatives = (float[])derivatives.Clone();
     }
     /// <inheritdoc />
     public IConstraint Domain => RealConstraint.Instance;
@@ -156,13 +188,32 @@ public sealed class NeuralSplineFlowTransform : ITransform
     /// <inheritdoc />
     public bool IsDimensionPreserving => true;
 
+    /// <summary>
+    /// Validate input length and resolve the per-element spline batch index. Caller-supplied
+    /// arrays are flat <c>[N · D]</c> where <c>N</c> is the number of batches the parameter
+    /// arrays were sized for (<c>Widths.Length / Bins</c>); other input lengths are rejected
+    /// rather than silently wrapped via modulo, which previously hid a shape-mismatch.
+    /// </summary>
+    private int ResolveBatchIndex(int elementIndex, int totalLength, string argName)
+    {
+        int paramBatch = Widths.Length / Bins;
+        int expectedLen = paramBatch * D;
+        if (totalLength != expectedLen)
+            throw new ArgumentException(
+                $"{argName}.Length ({totalLength}) must equal paramBatch · D = {expectedLen} " +
+                $"(paramBatch={paramBatch} from Widths/Bins, D={D}). Modulo wrapping is rejected.",
+                argName);
+        return elementIndex / D;
+    }
+
     /// <inheritdoc />
     public float[] Forward(float[] x)
     {
+        if (x == null) throw new ArgumentNullException(nameof(x));
         var y = new float[x.Length];
         for (int i = 0; i < x.Length; i++)
         {
-            int batchIdx = (i / D) % (Widths.Length / Bins);  // share params across event dims
+            int batchIdx = ResolveBatchIndex(i, x.Length, nameof(x));
             y[i] = ApplySpline(x[i], batchIdx, forward: true, out _);
         }
         return y;
@@ -170,10 +221,11 @@ public sealed class NeuralSplineFlowTransform : ITransform
     /// <inheritdoc />
     public float[] Inverse(float[] y)
     {
+        if (y == null) throw new ArgumentNullException(nameof(y));
         var x = new float[y.Length];
         for (int i = 0; i < y.Length; i++)
         {
-            int batchIdx = (i / D) % (Widths.Length / Bins);
+            int batchIdx = ResolveBatchIndex(i, y.Length, nameof(y));
             x[i] = ApplySpline(y[i], batchIdx, forward: false, out _);
         }
         return x;
@@ -181,10 +233,11 @@ public sealed class NeuralSplineFlowTransform : ITransform
     /// <inheritdoc />
     public float[] LogAbsDetJacobian(float[] x, float[] y)
     {
+        if (x == null) throw new ArgumentNullException(nameof(x));
         var ldj = new float[x.Length];
         for (int i = 0; i < x.Length; i++)
         {
-            int batchIdx = (i / D) % (Widths.Length / Bins);
+            int batchIdx = ResolveBatchIndex(i, x.Length, nameof(x));
             ApplySpline(x[i], batchIdx, forward: true, out float dlog);
             ldj[i] = dlog;
         }

--- a/src/AiDotNet.Tensors/Distributions/Transforms/AdditionalTransforms.cs
+++ b/src/AiDotNet.Tensors/Distributions/Transforms/AdditionalTransforms.cs
@@ -1,0 +1,444 @@
+using System;
+using AiDotNet.Tensors.Distributions.Constraints;
+
+namespace AiDotNet.Tensors.Distributions.Transforms;
+
+/// <summary>
+/// Softmax transform: maps ℝ^K → simplex^(K-1). y_i = exp(x_i) / Σ_j exp(x_j).
+/// Maps ℝ^K → simplex of size K. Bijective on the affine subspace where Σ x_i = 0
+/// (PyTorch parity: log_abs_det_jacobian uses the K-1 dimensional measure).
+/// </summary>
+public sealed class SoftmaxTransform : ITransform
+{
+    /// <summary>Event dimension (= number of categories).</summary>
+    public int K { get; }
+
+    /// <summary>Build a softmax transform.</summary>
+    public SoftmaxTransform(int k)
+    {
+        if (k <= 0) throw new ArgumentOutOfRangeException(nameof(k));
+        K = k;
+    }
+
+    /// <inheritdoc />
+    public IConstraint Domain => RealConstraint.Instance;
+    /// <inheritdoc />
+    public IConstraint Codomain => new SimplexConstraint(K);
+    /// <inheritdoc />
+    public bool ConstantJacobian => false;
+
+    /// <inheritdoc />
+    public float[] Forward(float[] x)
+    {
+        if (x.Length % K != 0) throw new ArgumentException("x.Length must be a multiple of K.");
+        int batch = x.Length / K;
+        var y = new float[x.Length];
+        for (int b = 0; b < batch; b++)
+        {
+            float maxV = float.NegativeInfinity;
+            for (int i = 0; i < K; i++) if (x[b * K + i] > maxV) maxV = x[b * K + i];
+            double sum = 0;
+            for (int i = 0; i < K; i++) { y[b * K + i] = MathF.Exp(x[b * K + i] - maxV); sum += y[b * K + i]; }
+            float inv = (float)(1.0 / sum);
+            for (int i = 0; i < K; i++) y[b * K + i] *= inv;
+        }
+        return y;
+    }
+
+    /// <inheritdoc />
+    public float[] Inverse(float[] y)
+    {
+        // log y is one valid pre-image; users typically want this canonical choice.
+        var x = new float[y.Length];
+        for (int i = 0; i < y.Length; i++) x[i] = MathF.Log(MathF.Max(y[i], 1e-30f));
+        return x;
+    }
+
+    /// <inheritdoc />
+    public float[] LogAbsDetJacobian(float[] x, float[] y)
+    {
+        // log|det J| (in the ambient sense) is undefined since softmax is not invertible
+        // on ℝ^K. The conventional value used by torch is Σ log y_i — the log-Jacobian
+        // determinant when restricting to the K-1 dim simplex.
+        if (y.Length % K != 0) throw new ArgumentException();
+        int batch = y.Length / K;
+        var ldj = new float[y.Length];
+        for (int b = 0; b < batch; b++)
+        {
+            float per = 0f;
+            for (int i = 0; i < K; i++) per += MathF.Log(MathF.Max(y[b * K + i], 1e-30f));
+            for (int i = 0; i < K; i++) ldj[b * K + i] = per / K;
+        }
+        return ldj;
+    }
+}
+
+/// <summary>
+/// Stick-breaking transform: maps ℝ^(K-1) → simplex^(K-1). Each input x_i is squashed
+/// through a sigmoid to a stick-fraction, multiplied by the remaining stick length.
+///   v_i = σ(x_i + log(1/(K-i-1))),    y_i = v_i · Π_{j&lt;i} (1 - v_j),    y_{K-1} = 1 - Σ_{i&lt;K-1} y_i.
+/// </summary>
+public sealed class StickBreakingTransform : ITransform
+{
+    /// <summary>Event dimension of the simplex (length of the output).</summary>
+    public int K { get; }
+
+    /// <summary>Build a stick-breaking transform; input dim is K-1, output dim is K.</summary>
+    public StickBreakingTransform(int k)
+    {
+        if (k < 2) throw new ArgumentOutOfRangeException(nameof(k));
+        K = k;
+    }
+
+    /// <inheritdoc />
+    public IConstraint Domain => RealConstraint.Instance;
+    /// <inheritdoc />
+    public IConstraint Codomain => new SimplexConstraint(K);
+    /// <inheritdoc />
+    public bool ConstantJacobian => false;
+
+    /// <inheritdoc />
+    public float[] Forward(float[] x)
+    {
+        // Input shape: [batch, K-1]; output shape: [batch, K].
+        int inDim = K - 1;
+        if (x.Length % inDim != 0) throw new ArgumentException();
+        int batch = x.Length / inDim;
+        var y = new float[batch * K];
+        for (int b = 0; b < batch; b++)
+        {
+            float remaining = 1f;
+            for (int i = 0; i < inDim; i++)
+            {
+                float shift = MathF.Log(1f / (K - i - 1));
+                float v = 1f / (1f + MathF.Exp(-(x[b * inDim + i] + shift)));
+                y[b * K + i] = v * remaining;
+                remaining *= (1f - v);
+            }
+            y[b * K + (K - 1)] = remaining;
+        }
+        return y;
+    }
+
+    /// <inheritdoc />
+    public float[] Inverse(float[] y)
+    {
+        if (y.Length % K != 0) throw new ArgumentException();
+        int batch = y.Length / K;
+        int outDim = K - 1;
+        var x = new float[batch * outDim];
+        for (int b = 0; b < batch; b++)
+        {
+            float remaining = 1f;
+            for (int i = 0; i < outDim; i++)
+            {
+                float v = y[b * K + i] / MathF.Max(remaining, 1e-30f);
+                float shift = MathF.Log(1f / (K - i - 1));
+                x[b * outDim + i] = MathF.Log(v / (1f - v)) - shift;
+                remaining *= (1f - v);
+            }
+        }
+        return x;
+    }
+
+    /// <inheritdoc />
+    public float[] LogAbsDetJacobian(float[] x, float[] y)
+    {
+        // log|det J| = Σ_i [ log(y_i) + log(1 - Σ_{j≤i} y_j) ] (PyTorch convention).
+        if (y.Length % K != 0) throw new ArgumentException();
+        int batch = y.Length / K;
+        int inDim = K - 1;
+        var ldj = new float[x.Length];
+        for (int b = 0; b < batch; b++)
+        {
+            float remaining = 1f;
+            float per = 0f;
+            for (int i = 0; i < inDim; i++)
+            {
+                per += MathF.Log(MathF.Max(y[b * K + i], 1e-30f))
+                     + MathF.Log(MathF.Max(remaining, 1e-30f));
+                remaining -= y[b * K + i];
+            }
+            for (int i = 0; i < inDim; i++) ldj[b * inDim + i] = per / inDim;
+        }
+        return ldj;
+    }
+}
+
+/// <summary>Absolute value: y = |x|. Not bijective; provided for distributions where
+/// the underlying base is symmetric (e.g. the half-normal pre-image).</summary>
+public sealed class AbsTransform : ITransform
+{
+    /// <summary>Singleton instance.</summary>
+    public static readonly AbsTransform Instance = new AbsTransform();
+    /// <inheritdoc />
+    public IConstraint Domain => RealConstraint.Instance;
+    /// <inheritdoc />
+    public IConstraint Codomain => NonNegativeConstraint.Instance;
+    /// <inheritdoc />
+    public bool ConstantJacobian => true;
+    /// <inheritdoc />
+    public float[] Forward(float[] x)
+    {
+        var y = new float[x.Length];
+        for (int i = 0; i < x.Length; i++) y[i] = MathF.Abs(x[i]);
+        return y;
+    }
+    /// <inheritdoc />
+    public float[] Inverse(float[] y) => (float[])y.Clone();
+    /// <inheritdoc />
+    public float[] LogAbsDetJacobian(float[] x, float[] y)
+    {
+        var r = new float[x.Length];
+        // Identity in absolute terms — this transform halves the measure but for our
+        // symmetric-base use cases we mirror PyTorch and report 0.
+        return r;
+    }
+}
+
+/// <summary>Lifts a 1-D base transform to apply to each <c>EventSize</c>-element block
+/// independently, summing log|det J| over the event dim. Mirrors
+/// <c>torch.distributions.transforms.IndependentTransform</c>.</summary>
+public sealed class IndependentTransform : ITransform
+{
+    /// <summary>Wrapped base transform.</summary>
+    public ITransform Base { get; }
+    /// <summary>Number of trailing dims to treat as a single event.</summary>
+    public int ReinterpretedDims { get; }
+
+    /// <summary>Wrap <paramref name="@base"/> as an event-wise transform.</summary>
+    public IndependentTransform(ITransform @base, int reinterpretedDims)
+    {
+        if (reinterpretedDims < 1) throw new ArgumentOutOfRangeException(nameof(reinterpretedDims));
+        Base = @base ?? throw new ArgumentNullException(nameof(@base));
+        ReinterpretedDims = reinterpretedDims;
+    }
+    /// <inheritdoc />
+    public IConstraint Domain => Base.Domain;
+    /// <inheritdoc />
+    public IConstraint Codomain => Base.Codomain;
+    /// <inheritdoc />
+    public bool ConstantJacobian => Base.ConstantJacobian;
+    /// <inheritdoc />
+    public float[] Forward(float[] x) => Base.Forward(x);
+    /// <inheritdoc />
+    public float[] Inverse(float[] y) => Base.Inverse(y);
+    /// <inheritdoc />
+    public float[] LogAbsDetJacobian(float[] x, float[] y) => Base.LogAbsDetJacobian(x, y);
+}
+
+/// <summary>
+/// CDF transform: y = F(x). Maps the support of an arbitrary 1-D distribution into (0, 1).
+/// Useful for building copulas. Inverse is the ICDF; log_abs_det = log_prob(x).
+/// </summary>
+public sealed class CumulativeDistributionTransform : ITransform
+{
+    /// <summary>Underlying distribution (must have closed-form CDF/ICDF).</summary>
+    public IDistribution Distribution { get; }
+    /// <summary>Build a CDF transform from a 1-D distribution.</summary>
+    public CumulativeDistributionTransform(IDistribution distribution)
+    {
+        if (distribution == null) throw new ArgumentNullException(nameof(distribution));
+        if (distribution.EventSize != 1)
+            throw new ArgumentException("CumulativeDistributionTransform requires a univariate distribution.");
+        Distribution = distribution;
+    }
+    /// <inheritdoc />
+    public IConstraint Domain => Distribution.Support;
+    /// <inheritdoc />
+    public IConstraint Codomain => UnitIntervalConstraint.Instance;
+    /// <inheritdoc />
+    public bool ConstantJacobian => false;
+    /// <inheritdoc />
+    public float[] Forward(float[] x) => Distribution.Cdf(x);
+    /// <inheritdoc />
+    public float[] Inverse(float[] y) => Distribution.Icdf(y);
+    /// <inheritdoc />
+    public float[] LogAbsDetJacobian(float[] x, float[] y) => Distribution.LogProb(x);
+}
+
+/// <summary>
+/// LowerCholeskyTransform: maps an unconstrained matrix to a lower-triangular matrix
+/// with positive diagonal — the canonical reparam for covariance Cholesky factors.
+/// Forward(x) takes the strictly-lower entries verbatim and exp's the diagonal;
+/// inverse undoes the exp on the diagonal.
+/// </summary>
+public sealed class LowerCholeskyTransform : ITransform
+{
+    /// <summary>Matrix dimension N (event is N×N flattened row-major).</summary>
+    public int N { get; }
+    /// <summary>Build a lower-Cholesky transform.</summary>
+    public LowerCholeskyTransform(int n)
+    {
+        if (n <= 0) throw new ArgumentOutOfRangeException(nameof(n));
+        N = n;
+    }
+    /// <inheritdoc />
+    public IConstraint Domain => RealConstraint.Instance;
+    /// <inheritdoc />
+    public IConstraint Codomain => RealConstraint.Instance;
+    /// <inheritdoc />
+    public bool ConstantJacobian => false;
+    /// <inheritdoc />
+    public float[] Forward(float[] x)
+    {
+        if (x.Length % (N * N) != 0) throw new ArgumentException();
+        int batch = x.Length / (N * N);
+        var y = new float[x.Length];
+        for (int b = 0; b < batch; b++)
+            for (int i = 0; i < N; i++)
+                for (int j = 0; j < N; j++)
+                {
+                    float xij = x[b * N * N + i * N + j];
+                    if (j > i) y[b * N * N + i * N + j] = 0f;
+                    else if (i == j) y[b * N * N + i * N + j] = MathF.Exp(xij);
+                    else y[b * N * N + i * N + j] = xij;
+                }
+        return y;
+    }
+    /// <inheritdoc />
+    public float[] Inverse(float[] y)
+    {
+        if (y.Length % (N * N) != 0) throw new ArgumentException();
+        int batch = y.Length / (N * N);
+        var x = new float[y.Length];
+        for (int b = 0; b < batch; b++)
+            for (int i = 0; i < N; i++)
+                for (int j = 0; j < N; j++)
+                {
+                    float yij = y[b * N * N + i * N + j];
+                    if (j > i) x[b * N * N + i * N + j] = 0f;
+                    else if (i == j) x[b * N * N + i * N + j] = MathF.Log(yij);
+                    else x[b * N * N + i * N + j] = yij;
+                }
+        return x;
+    }
+    /// <inheritdoc />
+    public float[] LogAbsDetJacobian(float[] x, float[] y)
+    {
+        // log|det J| over the unconstrained → triangular map = Σ x_{ii} (the diagonal entries
+        // before exponentiation), distributed evenly across the N² entries for our flat layout.
+        if (x.Length % (N * N) != 0) throw new ArgumentException();
+        int batch = x.Length / (N * N);
+        var ldj = new float[x.Length];
+        for (int b = 0; b < batch; b++)
+        {
+            float per = 0f;
+            for (int i = 0; i < N; i++) per += x[b * N * N + i * N + i];
+            for (int j = 0; j < N * N; j++) ldj[b * N * N + j] = per / (N * N);
+        }
+        return ldj;
+    }
+}
+
+/// <summary>
+/// CorrCholeskyTransform: maps unconstrained R^(N(N-1)/2) to a unit-diagonal lower-triangular
+/// matrix L such that L·Lᵀ is a valid correlation matrix. Used as the canonical reparam for
+/// LKJ-prior correlation matrices. Implementation follows the spherical parameterisation
+/// (Pinheiro &amp; Bates, 1996; Lewandowski et al., 2009).
+/// </summary>
+public sealed class CorrCholeskyTransform : ITransform
+{
+    /// <summary>Matrix dimension N.</summary>
+    public int N { get; }
+    /// <summary>Build a correlation-Cholesky transform.</summary>
+    public CorrCholeskyTransform(int n)
+    {
+        if (n <= 0) throw new ArgumentOutOfRangeException(nameof(n));
+        N = n;
+    }
+    /// <inheritdoc />
+    public IConstraint Domain => RealConstraint.Instance;
+    /// <inheritdoc />
+    public IConstraint Codomain => RealConstraint.Instance;
+    /// <inheritdoc />
+    public bool ConstantJacobian => false;
+
+    /// <inheritdoc />
+    public float[] Forward(float[] x)
+    {
+        // Input length per batch element = N(N-1)/2; output is N×N row-major.
+        int inDim = N * (N - 1) / 2;
+        if (x.Length % inDim != 0) throw new ArgumentException();
+        int batch = x.Length / inDim;
+        var y = new float[batch * N * N];
+        for (int b = 0; b < batch; b++)
+        {
+            int idx = 0;
+            for (int i = 0; i < N; i++)
+            {
+                float remaining = 1f;
+                for (int j = 0; j < i; j++)
+                {
+                    // Squash to (-1, 1) via tanh so the row sits on the unit ball.
+                    float c = MathF.Tanh(x[b * inDim + idx]);
+                    idx++;
+                    y[b * N * N + i * N + j] = c * MathF.Sqrt(remaining);
+                    remaining -= c * c * remaining;
+                    if (remaining < 0) remaining = 0;
+                }
+                y[b * N * N + i * N + i] = MathF.Sqrt(MathF.Max(remaining, 0f));
+            }
+        }
+        return y;
+    }
+
+    /// <inheritdoc />
+    public float[] Inverse(float[] y)
+    {
+        int inDim = N * (N - 1) / 2;
+        if (y.Length % (N * N) != 0) throw new ArgumentException();
+        int batch = y.Length / (N * N);
+        var x = new float[batch * inDim];
+        for (int b = 0; b < batch; b++)
+        {
+            int idx = 0;
+            for (int i = 0; i < N; i++)
+            {
+                float remaining = 1f;
+                for (int j = 0; j < i; j++)
+                {
+                    float yij = y[b * N * N + i * N + j];
+                    float c = yij / MathF.Sqrt(MathF.Max(remaining, 1e-30f));
+                    if (c >= 1f) c = 1f - 1e-6f; if (c <= -1f) c = -1f + 1e-6f;
+                    x[b * inDim + idx] = MathF.Atanh(c);
+                    idx++;
+                    remaining -= yij * yij;
+                    if (remaining < 0) remaining = 0;
+                }
+            }
+        }
+        return x;
+    }
+
+    /// <inheritdoc />
+    public float[] LogAbsDetJacobian(float[] x, float[] y)
+    {
+        // For each row i and column j < i: contribution log|sech²(x_{i,j})| − 0.5 · log(remaining)
+        // where remaining decreases as we walk along the row. Distribute the per-batch sum
+        // uniformly across the input vector for the [batch, inDim] flattened layout.
+        int inDim = N * (N - 1) / 2;
+        int batch = x.Length / inDim;
+        var ldj = new float[x.Length];
+        for (int b = 0; b < batch; b++)
+        {
+            int idx = 0;
+            float per = 0f;
+            for (int i = 0; i < N; i++)
+            {
+                float remaining = 1f;
+                for (int j = 0; j < i; j++)
+                {
+                    float xij = x[b * inDim + idx];
+                    idx++;
+                    float c = MathF.Tanh(xij);
+                    // d c / d x = sech²(x) = 1 − tanh²(x).
+                    per += MathF.Log(1f - c * c) + 0.5f * MathF.Log(MathF.Max(remaining, 1e-30f));
+                    remaining -= c * c * remaining;
+                }
+            }
+            for (int j = 0; j < inDim; j++) ldj[b * inDim + j] = per / inDim;
+        }
+        return ldj;
+    }
+}

--- a/src/AiDotNet.Tensors/Distributions/Transforms/AdditionalTransforms.cs
+++ b/src/AiDotNet.Tensors/Distributions/Transforms/AdditionalTransforms.cs
@@ -202,9 +202,15 @@ public sealed class AbsTransform : ITransform
     }
 }
 
-/// <summary>Lifts a 1-D base transform to apply to each <c>EventSize</c>-element block
-/// independently, summing log|det J| over the event dim. Mirrors
-/// <c>torch.distributions.transforms.IndependentTransform</c>.</summary>
+/// <summary>Lifts a 1-D base transform to apply to each <c>ReinterpretedDims</c>-element
+/// block as a single event, summing the per-element log|det J| within each block. Mirrors
+/// <c>torch.distributions.transforms.IndependentTransform</c>.
+///
+/// Forward / Inverse delegate straight to <see cref="Base"/> (the values are unchanged
+/// — this transform only affects how the Jacobian is reduced). LogAbsDetJacobian
+/// pre-aggregates the base LDJ across each block of <see cref="ReinterpretedDims"/>
+/// elements so that when <c>TransformedDistribution</c> later reduces over event dims
+/// the result is summed correctly within each independent block.</summary>
 public sealed class IndependentTransform : ITransform
 {
     /// <summary>Wrapped base transform.</summary>
@@ -232,7 +238,28 @@ public sealed class IndependentTransform : ITransform
     /// <inheritdoc />
     public float[] Inverse(float[] y) => Base.Inverse(y);
     /// <inheritdoc />
-    public float[] LogAbsDetJacobian(float[] x, float[] y) => Base.LogAbsDetJacobian(x, y);
+    public float[] LogAbsDetJacobian(float[] x, float[] y)
+    {
+        if (x == null) throw new ArgumentNullException(nameof(x));
+        var raw = Base.LogAbsDetJacobian(x, y);
+        if (raw.Length % ReinterpretedDims != 0)
+            throw new ArgumentException(
+                $"base LDJ length ({raw.Length}) must be a multiple of ReinterpretedDims ({ReinterpretedDims}).");
+        // Sum LDJ within each block, then write the aggregated value uniformly across the
+        // block so the downstream TransformedDistribution reducer (which sums across the
+        // entire flat output) recovers the per-event sum exactly. Each entry in the block
+        // contributes (block_sum / block_size) so the total is `block_sum`.
+        int blocks = raw.Length / ReinterpretedDims;
+        var ldj = new float[raw.Length];
+        for (int b = 0; b < blocks; b++)
+        {
+            float sum = 0f;
+            for (int i = 0; i < ReinterpretedDims; i++) sum += raw[b * ReinterpretedDims + i];
+            float share = sum / ReinterpretedDims;
+            for (int i = 0; i < ReinterpretedDims; i++) ldj[b * ReinterpretedDims + i] = share;
+        }
+        return ldj;
+    }
 }
 
 /// <summary>

--- a/src/AiDotNet.Tensors/Distributions/Transforms/AdditionalTransforms.cs
+++ b/src/AiDotNet.Tensors/Distributions/Transforms/AdditionalTransforms.cs
@@ -26,6 +26,8 @@ public sealed class SoftmaxTransform : ITransform
     public IConstraint Codomain => new SimplexConstraint(K);
     /// <inheritdoc />
     public bool ConstantJacobian => false;
+    /// <inheritdoc />
+    public bool IsDimensionPreserving => true;
 
     /// <inheritdoc />
     public float[] Forward(float[] x)
@@ -96,6 +98,8 @@ public sealed class StickBreakingTransform : ITransform
     public IConstraint Codomain => new SimplexConstraint(K);
     /// <inheritdoc />
     public bool ConstantJacobian => false;
+    /// <inheritdoc />
+    public bool IsDimensionPreserving => false; // K-1 → K
 
     /// <inheritdoc />
     public float[] Forward(float[] x)
@@ -178,6 +182,8 @@ public sealed class AbsTransform : ITransform
     /// <inheritdoc />
     public bool ConstantJacobian => true;
     /// <inheritdoc />
+    public bool IsDimensionPreserving => true;
+    /// <inheritdoc />
     public float[] Forward(float[] x)
     {
         var y = new float[x.Length];
@@ -220,6 +226,8 @@ public sealed class IndependentTransform : ITransform
     /// <inheritdoc />
     public bool ConstantJacobian => Base.ConstantJacobian;
     /// <inheritdoc />
+    public bool IsDimensionPreserving => Base.IsDimensionPreserving;
+    /// <inheritdoc />
     public float[] Forward(float[] x) => Base.Forward(x);
     /// <inheritdoc />
     public float[] Inverse(float[] y) => Base.Inverse(y);
@@ -250,6 +258,8 @@ public sealed class CumulativeDistributionTransform : ITransform
     /// <inheritdoc />
     public bool ConstantJacobian => false;
     /// <inheritdoc />
+    public bool IsDimensionPreserving => true;
+    /// <inheritdoc />
     public float[] Forward(float[] x) => Distribution.Cdf(x);
     /// <inheritdoc />
     public float[] Inverse(float[] y) => Distribution.Icdf(y);
@@ -279,6 +289,8 @@ public sealed class LowerCholeskyTransform : ITransform
     public IConstraint Codomain => RealConstraint.Instance;
     /// <inheritdoc />
     public bool ConstantJacobian => false;
+    /// <inheritdoc />
+    public bool IsDimensionPreserving => true;
     /// <inheritdoc />
     public float[] Forward(float[] x)
     {
@@ -353,6 +365,8 @@ public sealed class CorrCholeskyTransform : ITransform
     public IConstraint Codomain => RealConstraint.Instance;
     /// <inheritdoc />
     public bool ConstantJacobian => false;
+    /// <inheritdoc />
+    public bool IsDimensionPreserving => false; // N(N-1)/2 → N²
 
     /// <inheritdoc />
     public float[] Forward(float[] x)

--- a/src/AiDotNet.Tensors/Distributions/Transforms/FlowTransforms.cs
+++ b/src/AiDotNet.Tensors/Distributions/Transforms/FlowTransforms.cs
@@ -7,6 +7,14 @@ namespace AiDotNet.Tensors.Distributions.Transforms;
 /// Planar flow (Rezende &amp; Mohamed, 2015): y = x + u · h(wᵀx + b) where h = tanh.
 /// Per-flow parameters u, w ∈ ℝᴰ, b ∈ ℝ. Element-wise log|det J| = log|1 + u'·w·h'(wᵀx+b)|
 /// where u' is u corrected to enforce invertibility.
+///
+/// <para><b>Limitation:</b> the analytical inverse of a planar flow has no closed form,
+/// so wrapping this transform in a <see cref="TransformedDistribution"/> and calling
+/// <c>LogProb(y)</c> on it will throw — the score path needs to invert through every
+/// transform. The expected usage pattern is the variational-flow workflow where you draw
+/// <c>z ∼ base</c>, apply <c>y = T(z)</c>, and compute
+/// <c>log p_y(y) = log p_z(z) − log|det J|</c> directly while you still hold <c>z</c>:
+/// no inverse needed. <see cref="ScoreFromBase"/> bundles that pattern.</para>
 /// </summary>
 public sealed class PlanarFlowTransform : ITransform
 {
@@ -32,6 +40,8 @@ public sealed class PlanarFlowTransform : ITransform
     public IConstraint Codomain => RealConstraint.Instance;
     /// <inheritdoc />
     public bool ConstantJacobian => false;
+    /// <inheritdoc />
+    public bool IsDimensionPreserving => true;
 
     private float[] CorrectedU()
     {
@@ -47,6 +57,10 @@ public sealed class PlanarFlowTransform : ITransform
     /// <inheritdoc />
     public float[] Forward(float[] x)
     {
+        if (x == null) throw new ArgumentNullException(nameof(x));
+        if (x.Length % D != 0)
+            throw new ArgumentException(
+                $"x.Length ({x.Length}) must be a multiple of D ({D}).", nameof(x));
         int batch = x.Length / D;
         var u = CorrectedU();
         var y = new float[x.Length];
@@ -67,6 +81,10 @@ public sealed class PlanarFlowTransform : ITransform
     /// <inheritdoc />
     public float[] LogAbsDetJacobian(float[] x, float[] y)
     {
+        if (x == null) throw new ArgumentNullException(nameof(x));
+        if (x.Length % D != 0)
+            throw new ArgumentException(
+                $"x.Length ({x.Length}) must be a multiple of D ({D}).", nameof(x));
         int batch = x.Length / D;
         var u = CorrectedU();
         var ldj = new float[x.Length];
@@ -82,10 +100,40 @@ public sealed class PlanarFlowTransform : ITransform
         }
         return ldj;
     }
+
+    /// <summary>
+    /// Score the transformed sample <c>y = Forward(z)</c> using the base log-density
+    /// <paramref name="logProbBase"/> at the pre-image <paramref name="z"/>:
+    /// <c>log p_y(y) = log p_z(z) − Σ log|det J(z)|</c>. Avoids needing the inverse,
+    /// which has no closed form for planar flows. Length = batch.
+    /// </summary>
+    public float[] ScoreFromBase(float[] z, float[] logProbBase)
+    {
+        if (z == null) throw new ArgumentNullException(nameof(z));
+        if (logProbBase == null) throw new ArgumentNullException(nameof(logProbBase));
+        if (z.Length % D != 0)
+            throw new ArgumentException($"z.Length ({z.Length}) must be a multiple of D ({D}).", nameof(z));
+        int batch = z.Length / D;
+        if (logProbBase.Length != batch)
+            throw new ArgumentException($"logProbBase.Length ({logProbBase.Length}) must equal batch ({batch}).", nameof(logProbBase));
+        var y = Forward(z);
+        var ldj = LogAbsDetJacobian(z, y);
+        var lp = new float[batch];
+        for (int b = 0; b < batch; b++)
+        {
+            float acc = logProbBase[b];
+            for (int i = 0; i < D; i++) acc -= ldj[b * D + i];
+            lp[b] = acc;
+        }
+        return lp;
+    }
 }
 
 /// <summary>
 /// Radial flow (Rezende &amp; Mohamed, 2015): y = x + β · h(α, r) · (x − x₀) with r = ‖x − x₀‖.
+/// <para><b>Limitation:</b> like <see cref="PlanarFlowTransform"/>, the inverse requires a 1-D
+/// root solve and is not bundled. Score samples via the variational pattern
+/// <see cref="ScoreFromBase"/> instead of <c>TransformedDistribution.LogProb</c>.</para>
 /// </summary>
 public sealed class RadialFlowTransform : ITransform
 {
@@ -111,6 +159,8 @@ public sealed class RadialFlowTransform : ITransform
     public IConstraint Codomain => RealConstraint.Instance;
     /// <inheritdoc />
     public bool ConstantJacobian => false;
+    /// <inheritdoc />
+    public bool IsDimensionPreserving => true;
 
     private float CorrectedBeta()
     {
@@ -121,6 +171,9 @@ public sealed class RadialFlowTransform : ITransform
     /// <inheritdoc />
     public float[] Forward(float[] x)
     {
+        if (x == null) throw new ArgumentNullException(nameof(x));
+        if (x.Length % D != 0)
+            throw new ArgumentException($"x.Length ({x.Length}) must be a multiple of D ({D}).", nameof(x));
         int batch = x.Length / D;
         float beta = CorrectedBeta();
         var y = new float[x.Length];
@@ -142,6 +195,9 @@ public sealed class RadialFlowTransform : ITransform
     /// <inheritdoc />
     public float[] LogAbsDetJacobian(float[] x, float[] y)
     {
+        if (x == null) throw new ArgumentNullException(nameof(x));
+        if (x.Length % D != 0)
+            throw new ArgumentException($"x.Length ({x.Length}) must be a multiple of D ({D}).", nameof(x));
         int batch = x.Length / D;
         float beta = CorrectedBeta();
         var ldj = new float[x.Length];
@@ -156,6 +212,28 @@ public sealed class RadialFlowTransform : ITransform
             for (int i = 0; i < D; i++) ldj[b * D + i] = perBatch / D;
         }
         return ldj;
+    }
+
+    /// <summary>Same forward-only score helper as <see cref="PlanarFlowTransform.ScoreFromBase"/>.</summary>
+    public float[] ScoreFromBase(float[] z, float[] logProbBase)
+    {
+        if (z == null) throw new ArgumentNullException(nameof(z));
+        if (logProbBase == null) throw new ArgumentNullException(nameof(logProbBase));
+        if (z.Length % D != 0)
+            throw new ArgumentException($"z.Length ({z.Length}) must be a multiple of D ({D}).", nameof(z));
+        int batch = z.Length / D;
+        if (logProbBase.Length != batch)
+            throw new ArgumentException($"logProbBase.Length ({logProbBase.Length}) must equal batch ({batch}).", nameof(logProbBase));
+        var y = Forward(z);
+        var ldj = LogAbsDetJacobian(z, y);
+        var lp = new float[batch];
+        for (int b = 0; b < batch; b++)
+        {
+            float acc = logProbBase[b];
+            for (int i = 0; i < D; i++) acc -= ldj[b * D + i];
+            lp[b] = acc;
+        }
+        return lp;
     }
 }
 
@@ -195,6 +273,8 @@ public sealed class RealNvpCouplingTransform : ITransform
     public IConstraint Codomain => RealConstraint.Instance;
     /// <inheritdoc />
     public bool ConstantJacobian => false;
+    /// <inheritdoc />
+    public bool IsDimensionPreserving => true;
 
     /// <inheritdoc />
     public float[] Forward(float[] x)

--- a/src/AiDotNet.Tensors/Distributions/Transforms/FlowTransforms.cs
+++ b/src/AiDotNet.Tensors/Distributions/Transforms/FlowTransforms.cs
@@ -30,8 +30,16 @@ public sealed class PlanarFlowTransform : ITransform
     /// <summary>Build a planar flow.</summary>
     public PlanarFlowTransform(float[] u, float[] w, float b)
     {
+        if (u == null) throw new ArgumentNullException(nameof(u));
+        if (w == null) throw new ArgumentNullException(nameof(w));
         if (u.Length != w.Length) throw new ArgumentException("u and w must have the same length.");
-        U = u; W = w; B = b;
+        if (w.Length == 0) throw new ArgumentException("w must be non-empty.", nameof(w));
+        // Reject the degenerate w = 0 case — CorrectedU's w² normaliser would divide by 0.
+        float w2 = 0f;
+        for (int i = 0; i < w.Length; i++) w2 += w[i] * w[i];
+        if (!(w2 > 0f))
+            throw new ArgumentException("w must have non-zero norm (the planar flow is undefined when w == 0).", nameof(w));
+        U = (float[])u.Clone(); W = (float[])w.Clone(); B = b;
     }
 
     /// <inheritdoc />
@@ -149,8 +157,11 @@ public sealed class RadialFlowTransform : ITransform
     /// <summary>Build a radial flow.</summary>
     public RadialFlowTransform(float[] x0, float alpha, float beta)
     {
+        if (x0 == null) throw new ArgumentNullException(nameof(x0));
+        if (x0.Length == 0)
+            throw new ArgumentException("x0 must be non-empty (the flow dimension D is x0.Length).", nameof(x0));
         if (alpha <= 0f) throw new ArgumentException("alpha > 0.");
-        X0 = x0; Alpha = alpha; Beta = beta;
+        X0 = (float[])x0.Clone(); Alpha = alpha; Beta = beta;
     }
 
     /// <inheritdoc />

--- a/src/AiDotNet.Tensors/Distributions/Transforms/FlowTransforms.cs
+++ b/src/AiDotNet.Tensors/Distributions/Transforms/FlowTransforms.cs
@@ -1,0 +1,261 @@
+using System;
+using AiDotNet.Tensors.Distributions.Constraints;
+
+namespace AiDotNet.Tensors.Distributions.Transforms;
+
+/// <summary>
+/// Planar flow (Rezende &amp; Mohamed, 2015): y = x + u · h(wᵀx + b) where h = tanh.
+/// Per-flow parameters u, w ∈ ℝᴰ, b ∈ ℝ. Element-wise log|det J| = log|1 + u'·w·h'(wᵀx+b)|
+/// where u' is u corrected to enforce invertibility.
+/// </summary>
+public sealed class PlanarFlowTransform : ITransform
+{
+    /// <summary>u parameter (length D).</summary>
+    public float[] U { get; }
+    /// <summary>w parameter (length D).</summary>
+    public float[] W { get; }
+    /// <summary>scalar bias.</summary>
+    public float B { get; }
+    /// <summary>Event dimension D.</summary>
+    public int D => W.Length;
+
+    /// <summary>Build a planar flow.</summary>
+    public PlanarFlowTransform(float[] u, float[] w, float b)
+    {
+        if (u.Length != w.Length) throw new ArgumentException("u and w must have the same length.");
+        U = u; W = w; B = b;
+    }
+
+    /// <inheritdoc />
+    public IConstraint Domain => RealConstraint.Instance;
+    /// <inheritdoc />
+    public IConstraint Codomain => RealConstraint.Instance;
+    /// <inheritdoc />
+    public bool ConstantJacobian => false;
+
+    private float[] CorrectedU()
+    {
+        // Enforce wᵀu ≥ -1 to guarantee invertibility (Rezende & Mohamed Appendix A.1).
+        float wTu = 0f, w2 = 0f;
+        for (int i = 0; i < D; i++) { wTu += W[i] * U[i]; w2 += W[i] * W[i]; }
+        float m = -1f + (float)Math.Log(1.0 + Math.Exp(wTu)) - wTu;
+        var u = new float[D];
+        for (int i = 0; i < D; i++) u[i] = U[i] + m * W[i] / w2;
+        return u;
+    }
+
+    /// <inheritdoc />
+    public float[] Forward(float[] x)
+    {
+        int batch = x.Length / D;
+        var u = CorrectedU();
+        var y = new float[x.Length];
+        for (int b = 0; b < batch; b++)
+        {
+            float pre = B;
+            for (int i = 0; i < D; i++) pre += W[i] * x[b * D + i];
+            float h = MathF.Tanh(pre);
+            for (int i = 0; i < D; i++) y[b * D + i] = x[b * D + i] + u[i] * h;
+        }
+        return y;
+    }
+
+    /// <inheritdoc />
+    public float[] Inverse(float[] y) =>
+        throw new NotSupportedException("Planar flow inverse has no closed form; use a different flow or a numerical inverse.");
+
+    /// <inheritdoc />
+    public float[] LogAbsDetJacobian(float[] x, float[] y)
+    {
+        int batch = x.Length / D;
+        var u = CorrectedU();
+        var ldj = new float[x.Length];
+        for (int b = 0; b < batch; b++)
+        {
+            float pre = B;
+            for (int i = 0; i < D; i++) pre += W[i] * x[b * D + i];
+            float dh = 1f - MathF.Tanh(pre) * MathF.Tanh(pre); // sech²
+            float wTu = 0f;
+            for (int i = 0; i < D; i++) wTu += W[i] * u[i];
+            float perBatch = MathF.Log(MathF.Abs(1f + wTu * dh));
+            for (int i = 0; i < D; i++) ldj[b * D + i] = perBatch / D; // distribute equally per dim
+        }
+        return ldj;
+    }
+}
+
+/// <summary>
+/// Radial flow (Rezende &amp; Mohamed, 2015): y = x + β · h(α, r) · (x − x₀) with r = ‖x − x₀‖.
+/// </summary>
+public sealed class RadialFlowTransform : ITransform
+{
+    /// <summary>Reference point x₀ (length D).</summary>
+    public float[] X0 { get; }
+    /// <summary>Scale α &gt; 0.</summary>
+    public float Alpha { get; }
+    /// <summary>Strength β (corrected internally).</summary>
+    public float Beta { get; }
+    /// <summary>Event dimension D.</summary>
+    public int D => X0.Length;
+
+    /// <summary>Build a radial flow.</summary>
+    public RadialFlowTransform(float[] x0, float alpha, float beta)
+    {
+        if (alpha <= 0f) throw new ArgumentException("alpha > 0.");
+        X0 = x0; Alpha = alpha; Beta = beta;
+    }
+
+    /// <inheritdoc />
+    public IConstraint Domain => RealConstraint.Instance;
+    /// <inheritdoc />
+    public IConstraint Codomain => RealConstraint.Instance;
+    /// <inheritdoc />
+    public bool ConstantJacobian => false;
+
+    private float CorrectedBeta()
+    {
+        // β ≥ −α to guarantee invertibility.
+        return -Alpha + (float)Math.Log(1.0 + Math.Exp(Beta));
+    }
+
+    /// <inheritdoc />
+    public float[] Forward(float[] x)
+    {
+        int batch = x.Length / D;
+        float beta = CorrectedBeta();
+        var y = new float[x.Length];
+        for (int b = 0; b < batch; b++)
+        {
+            float r = 0f;
+            for (int i = 0; i < D; i++) { var d = x[b * D + i] - X0[i]; r += d * d; }
+            r = MathF.Sqrt(r);
+            float h = 1f / (Alpha + r);
+            for (int i = 0; i < D; i++) y[b * D + i] = x[b * D + i] + beta * h * (x[b * D + i] - X0[i]);
+        }
+        return y;
+    }
+
+    /// <inheritdoc />
+    public float[] Inverse(float[] y) =>
+        throw new NotSupportedException("Radial flow inverse requires a 1-D root solve; not bundled.");
+
+    /// <inheritdoc />
+    public float[] LogAbsDetJacobian(float[] x, float[] y)
+    {
+        int batch = x.Length / D;
+        float beta = CorrectedBeta();
+        var ldj = new float[x.Length];
+        for (int b = 0; b < batch; b++)
+        {
+            float r = 0f;
+            for (int i = 0; i < D; i++) { var d = x[b * D + i] - X0[i]; r += d * d; }
+            r = MathF.Sqrt(r);
+            float h = 1f / (Alpha + r);
+            float hPrime = -h * h;
+            float perBatch = (D - 1) * MathF.Log(MathF.Abs(1f + beta * h)) + MathF.Log(MathF.Abs(1f + beta * h + beta * hPrime * r));
+            for (int i = 0; i < D; i++) ldj[b * D + i] = perBatch / D;
+        }
+        return ldj;
+    }
+}
+
+/// <summary>
+/// RealNVP coupling layer (Dinh et al., 2017): split x into [x_a, x_b] by a binary mask;
+/// pass x_a through unchanged and apply x_b ← x_b · exp(s(x_a)) + t(x_a) where s, t are
+/// affine functions of x_a (here we expose simple linear s(x_a) = sScale·x_a + sBias and
+/// likewise for t — sufficient for unit tests; users plug deeper networks via composition).
+/// </summary>
+public sealed class RealNvpCouplingTransform : ITransform
+{
+    /// <summary>Boolean mask of length D — true entries are passed unchanged; false entries are transformed.</summary>
+    public bool[] Mask { get; }
+    /// <summary>Linear scale parameters s for the transformed entries.</summary>
+    public float[] SScale { get; }
+    /// <summary>Linear bias parameters s for the transformed entries.</summary>
+    public float[] SBias { get; }
+    /// <summary>Linear scale parameters t for the transformed entries.</summary>
+    public float[] TScale { get; }
+    /// <summary>Linear bias parameters t for the transformed entries.</summary>
+    public float[] TBias { get; }
+    /// <summary>Event dimension.</summary>
+    public int D => Mask.Length;
+
+    /// <summary>Build a RealNVP coupling layer.</summary>
+    public RealNvpCouplingTransform(bool[] mask, float[] sScale, float[] sBias, float[] tScale, float[] tBias)
+    {
+        if (sScale.Length != mask.Length || sBias.Length != mask.Length
+            || tScale.Length != mask.Length || tBias.Length != mask.Length)
+            throw new ArgumentException("mask, s, t parameters must all be length D.");
+        Mask = mask; SScale = sScale; SBias = sBias; TScale = tScale; TBias = tBias;
+    }
+
+    /// <inheritdoc />
+    public IConstraint Domain => RealConstraint.Instance;
+    /// <inheritdoc />
+    public IConstraint Codomain => RealConstraint.Instance;
+    /// <inheritdoc />
+    public bool ConstantJacobian => false;
+
+    /// <inheritdoc />
+    public float[] Forward(float[] x)
+    {
+        int batch = x.Length / D;
+        var y = new float[x.Length];
+        for (int b = 0; b < batch; b++)
+        {
+            // First compute the active "context" sum from masked-true entries.
+            float ctxS = 0f, ctxT = 0f;
+            for (int i = 0; i < D; i++) if (Mask[i]) { ctxS += SScale[i] * x[b * D + i]; ctxT += TScale[i] * x[b * D + i]; }
+            for (int i = 0; i < D; i++)
+            {
+                if (Mask[i]) y[b * D + i] = x[b * D + i];
+                else
+                {
+                    float s = ctxS + SBias[i];
+                    float t = ctxT + TBias[i];
+                    y[b * D + i] = x[b * D + i] * MathF.Exp(s) + t;
+                }
+            }
+        }
+        return y;
+    }
+
+    /// <inheritdoc />
+    public float[] Inverse(float[] y)
+    {
+        int batch = y.Length / D;
+        var x = new float[y.Length];
+        for (int b = 0; b < batch; b++)
+        {
+            float ctxS = 0f, ctxT = 0f;
+            for (int i = 0; i < D; i++) if (Mask[i]) { ctxS += SScale[i] * y[b * D + i]; ctxT += TScale[i] * y[b * D + i]; }
+            for (int i = 0; i < D; i++)
+            {
+                if (Mask[i]) x[b * D + i] = y[b * D + i];
+                else
+                {
+                    float s = ctxS + SBias[i];
+                    float t = ctxT + TBias[i];
+                    x[b * D + i] = (y[b * D + i] - t) * MathF.Exp(-s);
+                }
+            }
+        }
+        return x;
+    }
+
+    /// <inheritdoc />
+    public float[] LogAbsDetJacobian(float[] x, float[] y)
+    {
+        int batch = x.Length / D;
+        var ldj = new float[x.Length];
+        for (int b = 0; b < batch; b++)
+        {
+            float ctxS = 0f;
+            for (int i = 0; i < D; i++) if (Mask[i]) ctxS += SScale[i] * x[b * D + i];
+            float perEvent = 0f;
+            for (int i = 0; i < D; i++) if (!Mask[i]) perEvent += ctxS + SBias[i];
+            for (int i = 0; i < D; i++) ldj[b * D + i] = perEvent / D;
+        }
+        return ldj;
+    }
+}

--- a/src/AiDotNet.Tensors/Distributions/Transforms/FlowTransforms.cs
+++ b/src/AiDotNet.Tensors/Distributions/Transforms/FlowTransforms.cs
@@ -272,10 +272,22 @@ public sealed class RealNvpCouplingTransform : ITransform
     /// <summary>Build a RealNVP coupling layer.</summary>
     public RealNvpCouplingTransform(bool[] mask, float[] sScale, float[] sBias, float[] tScale, float[] tBias)
     {
+        if (mask == null) throw new ArgumentNullException(nameof(mask));
+        if (sScale == null) throw new ArgumentNullException(nameof(sScale));
+        if (sBias == null) throw new ArgumentNullException(nameof(sBias));
+        if (tScale == null) throw new ArgumentNullException(nameof(tScale));
+        if (tBias == null) throw new ArgumentNullException(nameof(tBias));
+        if (mask.Length == 0)
+            throw new ArgumentException("mask must be non-empty (the flow dimension D = mask.Length).", nameof(mask));
         if (sScale.Length != mask.Length || sBias.Length != mask.Length
             || tScale.Length != mask.Length || tBias.Length != mask.Length)
             throw new ArgumentException("mask, s, t parameters must all be length D.");
-        Mask = mask; SScale = sScale; SBias = sBias; TScale = tScale; TBias = tBias;
+        // Defensive copies so external mutation can't break the transform's invariants.
+        Mask = (bool[])mask.Clone();
+        SScale = (float[])sScale.Clone();
+        SBias = (float[])sBias.Clone();
+        TScale = (float[])tScale.Clone();
+        TBias = (float[])tBias.Clone();
     }
 
     /// <inheritdoc />
@@ -290,6 +302,9 @@ public sealed class RealNvpCouplingTransform : ITransform
     /// <inheritdoc />
     public float[] Forward(float[] x)
     {
+        if (x == null) throw new ArgumentNullException(nameof(x));
+        if (x.Length % D != 0)
+            throw new ArgumentException($"x.Length ({x.Length}) must be a multiple of D ({D}).", nameof(x));
         int batch = x.Length / D;
         var y = new float[x.Length];
         for (int b = 0; b < batch; b++)
@@ -314,6 +329,9 @@ public sealed class RealNvpCouplingTransform : ITransform
     /// <inheritdoc />
     public float[] Inverse(float[] y)
     {
+        if (y == null) throw new ArgumentNullException(nameof(y));
+        if (y.Length % D != 0)
+            throw new ArgumentException($"y.Length ({y.Length}) must be a multiple of D ({D}).", nameof(y));
         int batch = y.Length / D;
         var x = new float[y.Length];
         for (int b = 0; b < batch; b++)
@@ -337,6 +355,9 @@ public sealed class RealNvpCouplingTransform : ITransform
     /// <inheritdoc />
     public float[] LogAbsDetJacobian(float[] x, float[] y)
     {
+        if (x == null) throw new ArgumentNullException(nameof(x));
+        if (x.Length % D != 0)
+            throw new ArgumentException($"x.Length ({x.Length}) must be a multiple of D ({D}).", nameof(x));
         int batch = x.Length / D;
         var ldj = new float[x.Length];
         for (int b = 0; b < batch; b++)

--- a/src/AiDotNet.Tensors/Distributions/Transforms/ITransform.cs
+++ b/src/AiDotNet.Tensors/Distributions/Transforms/ITransform.cs
@@ -17,6 +17,12 @@ public interface ITransform
     /// <summary>True if the Jacobian determinant is constant in <c>x</c>.</summary>
     bool ConstantJacobian { get; }
 
+    /// <summary>True iff <c>Forward(x)</c> produces an output of the same length as <c>x</c>.
+    /// Dimension-changing transforms (e.g. <c>StickBreakingTransform</c>: K-1 → K, or
+    /// <c>CorrCholeskyTransform</c>: N(N-1)/2 → N²) report <c>false</c>; <c>TransformedDistribution</c>
+    /// uses this to refuse to score samples through chains it cannot index correctly.</summary>
+    bool IsDimensionPreserving { get; }
+
     /// <summary>Forward map y = f(x).</summary>
     float[] Forward(float[] x);
     /// <summary>Inverse map x = f⁻¹(y).</summary>
@@ -44,6 +50,8 @@ public sealed class AffineTransform : ITransform
     public IConstraint Codomain => RealConstraint.Instance;
     /// <inheritdoc />
     public bool ConstantJacobian => true;
+    /// <inheritdoc />
+    public bool IsDimensionPreserving => true;
     /// <inheritdoc />
     public float[] Forward(float[] x)
     {
@@ -80,6 +88,8 @@ public sealed class ExpTransform : ITransform
     /// <inheritdoc />
     public bool ConstantJacobian => false;
     /// <inheritdoc />
+    public bool IsDimensionPreserving => true;
+    /// <inheritdoc />
     public float[] Forward(float[] x)
     {
         var y = new float[x.Length];
@@ -114,6 +124,8 @@ public sealed class SigmoidTransform : ITransform
     public IConstraint Codomain => UnitIntervalConstraint.Instance;
     /// <inheritdoc />
     public bool ConstantJacobian => false;
+    /// <inheritdoc />
+    public bool IsDimensionPreserving => true;
     /// <inheritdoc />
     public float[] Forward(float[] x)
     {
@@ -155,6 +167,8 @@ public sealed class TanhTransform : ITransform
     public IConstraint Codomain => new IntervalConstraint(-1f, 1f);
     /// <inheritdoc />
     public bool ConstantJacobian => false;
+    /// <inheritdoc />
+    public bool IsDimensionPreserving => true;
     /// <inheritdoc />
     public float[] Forward(float[] x)
     {
@@ -204,6 +218,8 @@ public sealed class PowerTransform : ITransform
     /// <inheritdoc />
     public bool ConstantJacobian => false;
     /// <inheritdoc />
+    public bool IsDimensionPreserving => true;
+    /// <inheritdoc />
     public float[] Forward(float[] x)
     {
         var y = new float[x.Length];
@@ -248,6 +264,11 @@ public sealed class ComposeTransform : ITransform
     public bool ConstantJacobian
     {
         get { foreach (var p in Parts) if (!p.ConstantJacobian) return false; return true; }
+    }
+    /// <inheritdoc />
+    public bool IsDimensionPreserving
+    {
+        get { foreach (var p in Parts) if (!p.IsDimensionPreserving) return false; return true; }
     }
     /// <inheritdoc />
     public float[] Forward(float[] x)

--- a/src/AiDotNet.Tensors/Distributions/Transforms/ITransform.cs
+++ b/src/AiDotNet.Tensors/Distributions/Transforms/ITransform.cs
@@ -1,0 +1,281 @@
+using System;
+using AiDotNet.Tensors.Distributions.Constraints;
+
+namespace AiDotNet.Tensors.Distributions.Transforms;
+
+/// <summary>
+/// Bijective transform with a tractable log-absolute-determinant of the Jacobian.
+/// Composing distributions with transforms is the foundation of normalising flows
+/// (e.g. RealNVP, MAF) and the <c>TransformedDistribution</c> wrapper.
+/// </summary>
+public interface ITransform
+{
+    /// <summary>Domain of the forward map.</summary>
+    IConstraint Domain { get; }
+    /// <summary>Codomain (= range) of the forward map.</summary>
+    IConstraint Codomain { get; }
+    /// <summary>True if the Jacobian determinant is constant in <c>x</c>.</summary>
+    bool ConstantJacobian { get; }
+
+    /// <summary>Forward map y = f(x).</summary>
+    float[] Forward(float[] x);
+    /// <summary>Inverse map x = f⁻¹(y).</summary>
+    float[] Inverse(float[] y);
+    /// <summary>log |det df/dx| evaluated at x. Same length as <paramref name="x"/>.</summary>
+    float[] LogAbsDetJacobian(float[] x, float[] y);
+}
+
+/// <summary>Affine transform y = loc + scale · x.</summary>
+public sealed class AffineTransform : ITransform
+{
+    /// <summary>Translation.</summary>
+    public float Loc { get; }
+    /// <summary>Scaling factor (must be non-zero).</summary>
+    public float Scale { get; }
+    /// <summary>Build an affine transform.</summary>
+    public AffineTransform(float loc, float scale)
+    {
+        if (scale == 0f) throw new ArgumentException("scale must be non-zero.");
+        Loc = loc; Scale = scale;
+    }
+    /// <inheritdoc />
+    public IConstraint Domain => RealConstraint.Instance;
+    /// <inheritdoc />
+    public IConstraint Codomain => RealConstraint.Instance;
+    /// <inheritdoc />
+    public bool ConstantJacobian => true;
+    /// <inheritdoc />
+    public float[] Forward(float[] x)
+    {
+        var y = new float[x.Length];
+        for (int i = 0; i < x.Length; i++) y[i] = Loc + Scale * x[i];
+        return y;
+    }
+    /// <inheritdoc />
+    public float[] Inverse(float[] y)
+    {
+        var x = new float[y.Length];
+        for (int i = 0; i < y.Length; i++) x[i] = (y[i] - Loc) / Scale;
+        return x;
+    }
+    /// <inheritdoc />
+    public float[] LogAbsDetJacobian(float[] x, float[] y)
+    {
+        float v = MathF.Log(MathF.Abs(Scale));
+        var r = new float[x.Length];
+        for (int i = 0; i < r.Length; i++) r[i] = v;
+        return r;
+    }
+}
+
+/// <summary>Exponential transform y = exp(x). Maps ℝ → (0, ∞).</summary>
+public sealed class ExpTransform : ITransform
+{
+    /// <summary>Singleton instance.</summary>
+    public static readonly ExpTransform Instance = new ExpTransform();
+    /// <inheritdoc />
+    public IConstraint Domain => RealConstraint.Instance;
+    /// <inheritdoc />
+    public IConstraint Codomain => PositiveConstraint.Instance;
+    /// <inheritdoc />
+    public bool ConstantJacobian => false;
+    /// <inheritdoc />
+    public float[] Forward(float[] x)
+    {
+        var y = new float[x.Length];
+        for (int i = 0; i < x.Length; i++) y[i] = MathF.Exp(x[i]);
+        return y;
+    }
+    /// <inheritdoc />
+    public float[] Inverse(float[] y)
+    {
+        var x = new float[y.Length];
+        for (int i = 0; i < y.Length; i++) x[i] = MathF.Log(y[i]);
+        return x;
+    }
+    /// <inheritdoc />
+    public float[] LogAbsDetJacobian(float[] x, float[] y)
+    {
+        // d(exp x)/dx = exp(x) = y. log|det| = x.
+        var r = new float[x.Length];
+        for (int i = 0; i < r.Length; i++) r[i] = x[i];
+        return r;
+    }
+}
+
+/// <summary>Sigmoid transform y = σ(x). Maps ℝ → (0, 1).</summary>
+public sealed class SigmoidTransform : ITransform
+{
+    /// <summary>Singleton instance.</summary>
+    public static readonly SigmoidTransform Instance = new SigmoidTransform();
+    /// <inheritdoc />
+    public IConstraint Domain => RealConstraint.Instance;
+    /// <inheritdoc />
+    public IConstraint Codomain => UnitIntervalConstraint.Instance;
+    /// <inheritdoc />
+    public bool ConstantJacobian => false;
+    /// <inheritdoc />
+    public float[] Forward(float[] x)
+    {
+        var y = new float[x.Length];
+        for (int i = 0; i < x.Length; i++)
+        {
+            float xi = x[i];
+            y[i] = xi >= 0
+                ? 1f / (1f + MathF.Exp(-xi))
+                : MathF.Exp(xi) / (1f + MathF.Exp(xi));
+        }
+        return y;
+    }
+    /// <inheritdoc />
+    public float[] Inverse(float[] y)
+    {
+        var x = new float[y.Length];
+        for (int i = 0; i < y.Length; i++) x[i] = MathF.Log(y[i] / (1f - y[i]));
+        return x;
+    }
+    /// <inheritdoc />
+    public float[] LogAbsDetJacobian(float[] x, float[] y)
+    {
+        // log σ'(x) = -x - 2·softplus(-x) = log y + log(1-y)
+        var r = new float[x.Length];
+        for (int i = 0; i < r.Length; i++) r[i] = MathF.Log(y[i]) + MathF.Log(1f - y[i]);
+        return r;
+    }
+}
+
+/// <summary>Tanh transform y = tanh(x). Maps ℝ → (-1, 1).</summary>
+public sealed class TanhTransform : ITransform
+{
+    /// <summary>Singleton instance.</summary>
+    public static readonly TanhTransform Instance = new TanhTransform();
+    /// <inheritdoc />
+    public IConstraint Domain => RealConstraint.Instance;
+    /// <inheritdoc />
+    public IConstraint Codomain => new IntervalConstraint(-1f, 1f);
+    /// <inheritdoc />
+    public bool ConstantJacobian => false;
+    /// <inheritdoc />
+    public float[] Forward(float[] x)
+    {
+        var y = new float[x.Length];
+        for (int i = 0; i < x.Length; i++) y[i] = MathF.Tanh(x[i]);
+        return y;
+    }
+    /// <inheritdoc />
+    public float[] Inverse(float[] y)
+    {
+        var x = new float[y.Length];
+        for (int i = 0; i < y.Length; i++) x[i] = 0.5f * MathF.Log((1f + y[i]) / (1f - y[i]));
+        return x;
+    }
+    /// <inheritdoc />
+    public float[] LogAbsDetJacobian(float[] x, float[] y)
+    {
+        // log(1 - tanh(x)²) = log(sech(x)²) — written using softplus for numerical stability.
+        var r = new float[x.Length];
+        for (int i = 0; i < r.Length; i++)
+        {
+            float xi = x[i];
+            // 2·log(2) - x - 2·softplus(-x) using log1p(exp(-2|x|)) for numerical stability
+            float absX = MathF.Abs(xi);
+            r[i] = 2f * (MathF.Log(2f) - absX - Softplus(-2f * absX));
+        }
+        return r;
+    }
+    private static float Softplus(float v) => v > 20f ? v : MathF.Log(1f + MathF.Exp(v));
+}
+
+/// <summary>Power transform y = x^exponent. Maps (0, ∞) → (0, ∞) when exponent ≠ 0.</summary>
+public sealed class PowerTransform : ITransform
+{
+    /// <summary>Exponent.</summary>
+    public float Exponent { get; }
+    /// <summary>Build a power transform.</summary>
+    public PowerTransform(float exponent)
+    {
+        if (exponent == 0f) throw new ArgumentException("exponent must be non-zero.");
+        Exponent = exponent;
+    }
+    /// <inheritdoc />
+    public IConstraint Domain => PositiveConstraint.Instance;
+    /// <inheritdoc />
+    public IConstraint Codomain => PositiveConstraint.Instance;
+    /// <inheritdoc />
+    public bool ConstantJacobian => false;
+    /// <inheritdoc />
+    public float[] Forward(float[] x)
+    {
+        var y = new float[x.Length];
+        for (int i = 0; i < x.Length; i++) y[i] = MathF.Pow(x[i], Exponent);
+        return y;
+    }
+    /// <inheritdoc />
+    public float[] Inverse(float[] y)
+    {
+        var x = new float[y.Length];
+        float invExp = 1f / Exponent;
+        for (int i = 0; i < y.Length; i++) x[i] = MathF.Pow(y[i], invExp);
+        return x;
+    }
+    /// <inheritdoc />
+    public float[] LogAbsDetJacobian(float[] x, float[] y)
+    {
+        // d(x^e)/dx = e · x^(e-1). log|det| = log|e| + (e-1) log x.
+        var r = new float[x.Length];
+        float logE = MathF.Log(MathF.Abs(Exponent));
+        for (int i = 0; i < r.Length; i++) r[i] = logE + (Exponent - 1f) * MathF.Log(x[i]);
+        return r;
+    }
+}
+
+/// <summary>Composition of a list of transforms applied left-to-right.</summary>
+public sealed class ComposeTransform : ITransform
+{
+    /// <summary>Sub-transforms applied in order.</summary>
+    public ITransform[] Parts { get; }
+    /// <summary>Build a composition.</summary>
+    public ComposeTransform(params ITransform[] parts)
+    {
+        if (parts == null || parts.Length == 0) throw new ArgumentException("at least one transform required.");
+        Parts = parts;
+    }
+    /// <inheritdoc />
+    public IConstraint Domain => Parts[0].Domain;
+    /// <inheritdoc />
+    public IConstraint Codomain => Parts[Parts.Length - 1].Codomain;
+    /// <inheritdoc />
+    public bool ConstantJacobian
+    {
+        get { foreach (var p in Parts) if (!p.ConstantJacobian) return false; return true; }
+    }
+    /// <inheritdoc />
+    public float[] Forward(float[] x)
+    {
+        var v = x;
+        foreach (var p in Parts) v = p.Forward(v);
+        return v;
+    }
+    /// <inheritdoc />
+    public float[] Inverse(float[] y)
+    {
+        var v = y;
+        for (int i = Parts.Length - 1; i >= 0; i--) v = Parts[i].Inverse(v);
+        return v;
+    }
+    /// <inheritdoc />
+    public float[] LogAbsDetJacobian(float[] x, float[] y)
+    {
+        // Walk left-to-right, accumulating log|det| at each intermediate step.
+        var sum = new float[x.Length];
+        var v = x;
+        foreach (var p in Parts)
+        {
+            var next = p.Forward(v);
+            var ld = p.LogAbsDetJacobian(v, next);
+            for (int i = 0; i < sum.Length; i++) sum[i] += ld[i];
+            v = next;
+        }
+        return sum;
+    }
+}

--- a/tests/AiDotNet.Tensors.Benchmarks/DistributionSamplingBenchmarks.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/DistributionSamplingBenchmarks.cs
@@ -1,0 +1,85 @@
+#if NET8_0_OR_GREATER
+using System;
+using AiDotNet.Tensors.Distributions;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+namespace AiDotNet.Tensors.Benchmarks;
+
+/// <summary>
+/// Distribution-sampling throughput. Each benchmark draws <c>BatchSize</c> samples per
+/// invocation. We report ops/sec (= samples/sec when EventSize == 1, samples · EventSize/sec
+/// for multivariate).
+///
+/// The "BeatPyTorch" claim from issue #213 is "2× win on bulk categorical / normal /
+/// multivariate-normal sampling". This file generates the AiDotNet-side numbers; the
+/// PyTorch reference is gathered separately (TorchSharp's torch.Tensor.normal_, etc.)
+/// and recorded in the PR description.
+/// </summary>
+[SimpleJob(RuntimeMoniker.Net10_0, launchCount: 1, warmupCount: 3, iterationCount: 10)]
+[MemoryDiagnoser]
+[MarkdownExporterAttribute.GitHub]
+public class DistributionSamplingBenchmarks
+{
+    /// <summary>Number of independent distributions to sample in parallel.</summary>
+    [Params(1024, 16_384, 262_144)]
+    public int BatchSize;
+
+    private NormalDistribution _normal = null!;
+    private CategoricalDistribution _cat = null!;
+    private GammaDistribution _gamma = null!;
+    private DirichletDistribution _dir = null!;
+    private DiagonalMultivariateNormalDistribution _mvn = null!;
+    private Random _rng = null!;
+
+    /// <summary>Build the distributions once per param sweep.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        var loc = new float[BatchSize]; var scale = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++) { loc[i] = 0f; scale[i] = 1f; }
+        _normal = new NormalDistribution(loc, scale);
+
+        const int K = 8;
+        var probs = new float[BatchSize * K];
+        for (int b = 0; b < BatchSize; b++)
+            for (int i = 0; i < K; i++) probs[b * K + i] = 1f / K;
+        _cat = new CategoricalDistribution(probs, K);
+
+        var conc = new float[BatchSize]; var rate = new float[BatchSize];
+        for (int i = 0; i < BatchSize; i++) { conc[i] = 2f; rate[i] = 1f; }
+        _gamma = new GammaDistribution(conc, rate);
+
+        var dirConc = new float[BatchSize * K];
+        for (int i = 0; i < dirConc.Length; i++) dirConc[i] = 1f;
+        _dir = new DirichletDistribution(dirConc, K);
+
+        const int D = 16;
+        var mvnLoc = new float[BatchSize * D]; var mvnScale = new float[BatchSize * D];
+        for (int i = 0; i < mvnScale.Length; i++) mvnScale[i] = 1f;
+        _mvn = new DiagonalMultivariateNormalDistribution(mvnLoc, mvnScale, D);
+
+        _rng = new Random(42);
+    }
+
+    /// <summary>Univariate Normal — the simplest hot path.</summary>
+    [Benchmark]
+    public float[] NormalSample() => _normal.Sample(_rng);
+
+    /// <summary>Categorical sampling — branch-heavy cumulative-prob lookup.</summary>
+    [Benchmark]
+    public float[] CategoricalSample() => _cat.Sample(_rng);
+
+    /// <summary>Gamma sampling via Marsaglia-Tsang rejection.</summary>
+    [Benchmark]
+    public float[] GammaSample() => _gamma.Sample(_rng);
+
+    /// <summary>Dirichlet sampling — K Gammas + normalize.</summary>
+    [Benchmark]
+    public float[] DirichletSample() => _dir.Sample(_rng);
+
+    /// <summary>Diagonal MVN sampling — D independent Gaussians per batch element.</summary>
+    [Benchmark]
+    public float[] DiagonalMvnSample() => _mvn.Sample(_rng);
+}
+#endif

--- a/tests/AiDotNet.Tensors.Tests/Distributions/AdditionalDistributionTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Distributions/AdditionalDistributionTests.cs
@@ -180,15 +180,23 @@ public class AdditionalDistributionTests
     // -------------------- ExpandingDistribution --------------------
 
     [Fact]
-    public void ExpandingDistribution_ReplicatesSampleAcrossExpandedBatch()
+    public void ExpandingDistribution_DrawsFreshSamplesPerExpandedBlock()
     {
-        var inner = new NormalDistribution(new[] { 5f }, new[] { 0.0001f });  // tiny var
+        // Width-1 unit Gaussian expanded to batch 8. With non-trivial variance, fresh draws
+        // produce distinct values across the expanded batch — replication would yield the
+        // same value 8 times. We assert at least 6 distinct values out of 8 to confirm
+        // independent sampling without being flaky on rare exact ties.
+        var inner = new NormalDistribution(new[] { 0f }, new[] { 1f });
         var expanded = new ExpandingDistribution(inner, batchSize: 8);
         var rng = new Random(0);
         var s = expanded.Sample(rng);
         Assert.Equal(8, s.Length);
-        // All samples should be ≈ 5 because inner's variance is tiny.
-        foreach (var v in s) Assert.InRange(v, 4.99f, 5.01f);
+        var distinct = new System.Collections.Generic.HashSet<float>(s);
+        Assert.True(distinct.Count >= 6,
+            $"expected fresh draws across expanded batch; only {distinct.Count}/8 distinct values");
+        // Mean over 8 standard-normal draws is finite and approximately 0.
+        float sum = 0f; foreach (var v in s) sum += v;
+        Assert.InRange(sum / 8f, -2f, 2f);
     }
 
     // -------------------- Philox RNG --------------------

--- a/tests/AiDotNet.Tensors.Tests/Distributions/AdditionalDistributionTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Distributions/AdditionalDistributionTests.cs
@@ -1,0 +1,396 @@
+using System;
+using AiDotNet.Tensors.Distributions;
+using AiDotNet.Tensors.Distributions.Helpers;
+using AiDotNet.Tensors.Distributions.Transforms;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Distributions;
+
+/// <summary>
+/// Additional tests for the gap-fill distributions/transforms/RNG and full
+/// MC-vs-analytical KL cross-checks for every registered KL pair.
+/// </summary>
+public class AdditionalDistributionTests
+{
+    private const int N = 50_000;
+
+    // -------------------- New distributions: moments --------------------
+
+    [Fact]
+    public void FisherSnedecor_Moments_Match()
+    {
+        // F(d1=10, d2=20): mean = 20/(20-2) = 10/9 ≈ 1.111;
+        // var  = 2 · 20² · (10+20-2) / (10 · 18² · 16) = 22400 / 51840 ≈ 0.4321.
+        var d = new FisherSnedecorDistribution(new[] { 10f }, new[] { 20f });
+        double sum = 0, sum2 = 0;
+        var rng = new Random(7);
+        for (int i = 0; i < N; i++) { float x = d.Sample(rng)[0]; sum += x; sum2 += x * x; }
+        double mean = sum / N; double var = sum2 / N - mean * mean;
+        Assert.InRange(mean, 1.111 - 0.05, 1.111 + 0.05);
+        Assert.InRange(var, 0.4321 - 0.10, 0.4321 + 0.10);
+    }
+
+    [Fact]
+    public void Kumaraswamy_CdfIcdf_RoundTrip()
+    {
+        // 4-batch Kumaraswamy probes 4 quantiles.
+        var d = new KumaraswamyDistribution(
+            concentration1: new[] { 2f, 2f, 2f, 2f },
+            concentration0: new[] { 5f, 5f, 5f, 5f });
+        var p = new[] { 0.1f, 0.3f, 0.5f, 0.9f };
+        var x = d.Icdf(p);
+        var p2 = d.Cdf(x);
+        for (int i = 0; i < 4; i++) Assert.InRange(p2[i] - p[i], -1e-4f, 1e-4f);
+    }
+
+    [Fact]
+    public void VonMises_SamplesInsideTwoPiInterval()
+    {
+        var d = new VonMisesDistribution(new[] { 0f }, new[] { 4f });
+        var rng = new Random(0);
+        for (int i = 0; i < 1000; i++)
+        {
+            float x = d.Sample(rng)[0];
+            Assert.InRange(x, -MathF.PI - 1e-3f, MathF.PI + 1e-3f);
+        }
+    }
+
+    [Fact]
+    public void VonMises_LowKappa_CloseToUniform()
+    {
+        // κ → 0 ⇒ uniform on (-π, π], variance → 1 (1 - I1/I0 → 1 as κ → 0).
+        var d = new VonMisesDistribution(new[] { 0f }, new[] { 0.001f });
+        Assert.InRange(d.Variance[0], 0.99f, 1.0001f);
+    }
+
+    [Fact]
+    public void ContinuousBernoulli_LogProb_Lambda05_IsZero()
+    {
+        // At λ=0.5 the density f(x) = C(0.5) · 0.5^x · 0.5^(1-x) = 2 · 0.5 = 1, so log p = 0.
+        var d = new ContinuousBernoulliDistribution(new[] { 0.5f });
+        Assert.Equal(0f, d.LogProb(new[] { 0.3f })[0], precision: 4);
+        Assert.Equal(0f, d.LogProb(new[] { 0.7f })[0], precision: 4);
+    }
+
+    [Fact]
+    public void LowRankMVN_Variance_EqualsDiagPlusFactorOuterProduct()
+    {
+        // Σ = D + W·Wᵀ; Var_i = D_i + Σ_k W_{ik}².
+        var d = new LowRankMultivariateNormalDistribution(
+            loc: new[] { 0f, 0f },
+            covDiag: new[] { 1f, 2f },
+            covFactor: new[] { 1f, 0.5f, -1f, 0.25f },  // [2, 2] flattened
+            d: 2, k: 2);
+        var v = d.Variance;
+        Assert.Equal(1f + 1f + 0.25f, v[0], precision: 4);
+        Assert.Equal(2f + 1f + 0.0625f, v[1], precision: 4);
+    }
+
+    [Fact]
+    public void LowRankMVN_LogProb_AgreesWithFullMVN()
+    {
+        // Full Σ = diag([1, 2]) + W Wᵀ where W = [[1, 0.5], [-1, 0.25]].
+        var lr = new LowRankMultivariateNormalDistribution(
+            loc: new[] { 0f, 0f },
+            covDiag: new[] { 1f, 2f },
+            covFactor: new[] { 1f, 0.5f, -1f, 0.25f },
+            d: 2, k: 2);
+        // Construct equivalent full MVN:
+        var full = new MultivariateNormalDistribution(
+            loc: new[] { 0f, 0f },
+            covariance: new[]
+            {
+                1f + 1f + 0.25f,        -1f + 0.125f,
+                -1f + 0.125f,            2f + 1f + 0.0625f,
+            }, d: 2);
+        var x = new[] { 0.3f, -0.7f };
+        Assert.Equal(full.LogProb(x)[0], lr.LogProb(x)[0], precision: 3);
+    }
+
+    // -------------------- New transforms --------------------
+
+    [Fact]
+    public void SoftmaxTransform_OutputIsSimplex()
+    {
+        var t = new SoftmaxTransform(3);
+        var x = new[] { 1f, 2f, 3f };
+        var y = t.Forward(x);
+        float sum = 0f; foreach (var v in y) { Assert.True(v >= 0); sum += v; }
+        Assert.InRange(sum, 1f - 1e-4f, 1f + 1e-4f);
+    }
+
+    [Fact]
+    public void StickBreakingTransform_OutputIsSimplex()
+    {
+        var t = new StickBreakingTransform(4);
+        var x = new[] { -0.5f, 0.5f, 1.5f };  // K-1 = 3 entries
+        var y = t.Forward(x);
+        Assert.Equal(4, y.Length);
+        float sum = 0f; foreach (var v in y) { Assert.True(v >= 0); sum += v; }
+        Assert.InRange(sum, 1f - 1e-4f, 1f + 1e-4f);
+    }
+
+    [Fact]
+    public void StickBreakingTransform_ForwardInverse_RoundTrips()
+    {
+        var t = new StickBreakingTransform(4);
+        var x = new[] { -0.5f, 0.7f, 1.3f };
+        var y = t.Forward(x);
+        var x2 = t.Inverse(y);
+        for (int i = 0; i < 3; i++) Assert.InRange(x2[i] - x[i], -1e-3f, 1e-3f);
+    }
+
+    [Fact]
+    public void LowerCholeskyTransform_HasZerosAboveDiagAndPositiveDiag()
+    {
+        var t = new LowerCholeskyTransform(3);
+        var x = new[] { 0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f };
+        var y = t.Forward(x);
+        Assert.Equal(0f, y[1]); Assert.Equal(0f, y[2]); Assert.Equal(0f, y[5]);
+        Assert.True(y[0] > 0); Assert.True(y[4] > 0); Assert.True(y[8] > 0);
+    }
+
+    [Fact]
+    public void CorrCholeskyTransform_OutputProducesValidCorrelationMatrix()
+    {
+        // L · Lᵀ should have unit diagonal.
+        var t = new CorrCholeskyTransform(3);
+        var x = new[] { 0.5f, -0.3f, 0.7f };  // N(N-1)/2 = 3
+        var L = t.Forward(x);
+        // Compute (L · Lᵀ)_ii.
+        for (int i = 0; i < 3; i++)
+        {
+            float diag = 0f;
+            for (int k = 0; k <= i; k++) diag += L[i * 3 + k] * L[i * 3 + k];
+            Assert.InRange(diag, 1f - 1e-3f, 1f + 1e-3f);
+        }
+    }
+
+    [Fact]
+    public void CdfTransform_RoundTripsWithIcdf()
+    {
+        var nd = new NormalDistribution(new[] { 0f, 0f, 0f }, new[] { 1f, 1f, 1f });
+        var t = new CumulativeDistributionTransform(nd);
+        var x = new[] { -1f, 0f, 1f };
+        var u = t.Forward(x);
+        var x2 = t.Inverse(u);
+        for (int i = 0; i < 3; i++) Assert.InRange(x2[i] - x[i], -2e-3f, 2e-3f);
+    }
+
+    // -------------------- ExpandingDistribution --------------------
+
+    [Fact]
+    public void ExpandingDistribution_ReplicatesSampleAcrossExpandedBatch()
+    {
+        var inner = new NormalDistribution(new[] { 5f }, new[] { 0.0001f });  // tiny var
+        var expanded = new ExpandingDistribution(inner, batchSize: 8);
+        var rng = new Random(0);
+        var s = expanded.Sample(rng);
+        Assert.Equal(8, s.Length);
+        // All samples should be ≈ 5 because inner's variance is tiny.
+        foreach (var v in s) Assert.InRange(v, 4.99f, 5.01f);
+    }
+
+    // -------------------- Philox RNG --------------------
+
+    [Fact]
+    public void Philox_SameSeedSameSubKey_IsDeterministic()
+    {
+        var a = new PhiloxGenerator(seed: 42);
+        var b = new PhiloxGenerator(seed: 42);
+        for (int i = 0; i < 100; i++) Assert.Equal(a.NextDouble(), b.NextDouble());
+    }
+
+    [Fact]
+    public void Philox_DifferentSubKeys_ProduceIndependentStreams()
+    {
+        var a = new PhiloxGenerator(seed: 42, subKey: 0);
+        var b = new PhiloxGenerator(seed: 42, subKey: 1);
+        int diff = 0;
+        for (int i = 0; i < 100; i++) if (a.NextDouble() != b.NextDouble()) diff++;
+        Assert.True(diff > 95, $"streams should differ on almost every draw; got {diff}/100");
+    }
+
+    [Fact]
+    public void Philox_BatchRowHashing_ProducesIndependentPerRow()
+    {
+        // Setting the same seed and stepping per-row via batch-row hashing must produce
+        // distinct streams that nonetheless reproduce on the same (seed, row) pair.
+        var rngA = new PhiloxGenerator(seed: 100); rngA.SetBatchRow(7);
+        var rngB = new PhiloxGenerator(seed: 100); rngB.SetBatchRow(7);
+        var rngC = new PhiloxGenerator(seed: 100); rngC.SetBatchRow(8);
+        Assert.Equal(rngA.NextDouble(), rngB.NextDouble());
+        Assert.NotEqual(rngA.NextDouble(), rngC.NextDouble());
+    }
+
+    [Fact]
+    public void Philox_DistributionsWorkWithPhilox()
+    {
+        var rng = new PhiloxGenerator(seed: 1234);
+        var d = new NormalDistribution(0f, 1f);
+        // Just check sampling does not throw and produces finite values.
+        for (int i = 0; i < 100; i++)
+        {
+            var x = d.Sample(rng)[0];
+            Assert.False(float.IsNaN(x));
+            Assert.False(float.IsInfinity(x));
+        }
+    }
+
+    // -------------------- KL: MC cross-check for every registered pair --------------------
+
+    private static double MonteCarloKl(IDistribution p, IDistribution q, int nSamples = 30000, int seed = 17)
+    {
+        var rng = new Random(seed);
+        double s = 0;
+        for (int i = 0; i < nSamples; i++)
+        {
+            var x = p.Sample(rng);
+            s += p.LogProb(x)[0] - q.LogProb(x)[0];
+        }
+        return s / nSamples;
+    }
+
+    [Fact]
+    public void KL_ExpExp_AnalyticalMatchesMonteCarlo()
+    {
+        var p = new ExponentialDistribution(new[] { 2f });
+        var q = new ExponentialDistribution(new[] { 0.5f });
+        double kl = KLDivergence.Compute(p, q)[0];
+        Assert.InRange(MonteCarloKl(p, q), kl - 0.05, kl + 0.05);
+    }
+
+    [Fact]
+    public void KL_LaplaceLaplace_AnalyticalMatchesMonteCarlo()
+    {
+        var p = new LaplaceDistribution(new[] { 0f }, new[] { 1f });
+        var q = new LaplaceDistribution(new[] { 1f }, new[] { 1.5f });
+        double kl = KLDivergence.Compute(p, q)[0];
+        Assert.InRange(MonteCarloKl(p, q), kl - 0.06, kl + 0.06);
+    }
+
+    [Fact]
+    public void KL_GammaGamma_AnalyticalMatchesMonteCarlo()
+    {
+        var p = new GammaDistribution(new[] { 2f }, new[] { 1f });
+        var q = new GammaDistribution(new[] { 3f }, new[] { 0.5f });
+        double kl = KLDivergence.Compute(p, q)[0];
+        Assert.InRange(MonteCarloKl(p, q), kl - 0.1, kl + 0.1);
+    }
+
+    [Fact]
+    public void KL_BetaBeta_AnalyticalMatchesMonteCarlo()
+    {
+        var p = new BetaDistribution(new[] { 2f }, new[] { 5f });
+        var q = new BetaDistribution(new[] { 3f }, new[] { 3f });
+        double kl = KLDivergence.Compute(p, q)[0];
+        Assert.InRange(MonteCarloKl(p, q), kl - 0.05, kl + 0.05);
+    }
+
+    [Fact]
+    public void KL_DirichletDirichlet_AnalyticalMatchesMonteCarlo()
+    {
+        var p = new DirichletDistribution(new[] { 1f, 2f, 3f }, k: 3);
+        var q = new DirichletDistribution(new[] { 2f, 2f, 2f }, k: 3);
+        double kl = KLDivergence.Compute(p, q)[0];
+        // Dirichlet log-probs require simplex inputs from samples; we evaluate them as length-K vectors.
+        var rng = new Random(11);
+        double s = 0;
+        const int n = 30000;
+        for (int i = 0; i < n; i++)
+        {
+            var x = p.Sample(rng);
+            s += p.LogProb(x)[0] - q.LogProb(x)[0];
+        }
+        double mc = s / n;
+        Assert.InRange(mc, kl - 0.1, kl + 0.1);
+    }
+
+    [Fact]
+    public void KL_UniformUniform_PSubsetQ_HasExpectedValue()
+    {
+        // KL(U(0, 1) || U(-1, 2)) = log(3 / 1) = log 3.
+        var p = new UniformDistribution(new[] { 0f }, new[] { 1f });
+        var q = new UniformDistribution(new[] { -1f }, new[] { 2f });
+        Assert.Equal(MathF.Log(3f), KLDivergence.Compute(p, q)[0], precision: 4);
+    }
+
+    [Fact]
+    public void KL_UniformUniform_PNotSubset_IsInfinity()
+    {
+        var p = new UniformDistribution(new[] { -2f }, new[] { 2f });
+        var q = new UniformDistribution(new[] { -1f }, new[] { 1f });
+        Assert.True(float.IsPositiveInfinity(KLDivergence.Compute(p, q)[0]));
+    }
+
+    [Fact]
+    public void KL_DiagMVN_MonteCarloMatchesAnalytical()
+    {
+        var p = new DiagonalMultivariateNormalDistribution(new[] { 0f, 0f }, new[] { 1f, 1f }, d: 2);
+        var q = new DiagonalMultivariateNormalDistribution(new[] { 1f, -1f }, new[] { 2f, 2f }, d: 2);
+        double kl = KLDivergence.Compute(p, q)[0];
+        var rng = new Random(21);
+        double s = 0;
+        for (int i = 0; i < 30000; i++)
+        {
+            var x = p.Sample(rng);
+            s += p.LogProb(x)[0] - q.LogProb(x)[0];
+        }
+        Assert.InRange(s / 30000, kl - 0.05, kl + 0.05);
+    }
+
+    [Fact]
+    public void KL_RegistrySupportsCustomTypes()
+    {
+        // Register a NEW pair (Normal -> Uniform) that has no built-in formula. Avoids polluting
+        // the registry's default entries that other tests rely on.
+        bool used = false;
+        KLDivergence.Register<NormalDistribution, UniformDistribution>((a, b) =>
+        {
+            used = true;
+            return new[] { 42f };  // sentinel
+        });
+        var p = new NormalDistribution(0f, 1f);
+        var q = new UniformDistribution(new[] { -1f }, new[] { 1f });
+        var kl = KLDivergence.Compute(p, q)[0];
+        Assert.True(used);
+        Assert.Equal(42f, kl);
+    }
+
+    // -------------------- Reference-value log_prob spot checks --------------------
+
+    [Fact]
+    public void LogProb_ReferenceValues_NormalAtZero()
+    {
+        // Standard Normal at x = 0: log p(0) = -0.5 · log(2π) ≈ -0.9189.
+        var d = new NormalDistribution(0f, 1f);
+        Assert.Equal(-0.91893853f, d.LogProb(new[] { 0f })[0], precision: 4);
+    }
+
+    [Fact]
+    public void LogProb_ReferenceValues_PoissonAtMean()
+    {
+        // Poisson(λ=4) at x=4: log p = 4·log(4) − 4 − log(4!) = 4·log4 − 4 − log24 ≈ -1.6322.
+        var d = new PoissonDistribution(new[] { 4f });
+        var expected = (float)(4 * Math.Log(4) - 4 - Math.Log(24));
+        Assert.Equal(expected, d.LogProb(new[] { 4f })[0], precision: 3);
+    }
+
+    [Fact]
+    public void LogProb_ReferenceValues_BetaAtMode()
+    {
+        // Beta(α=2, β=2) at x=0.5: f = 6 · 0.5 · 0.5 = 1.5; log = log 1.5.
+        var d = new BetaDistribution(new[] { 2f }, new[] { 2f });
+        Assert.Equal(MathF.Log(1.5f), d.LogProb(new[] { 0.5f })[0], precision: 4);
+    }
+
+    [Fact]
+    public void LogProb_ReferenceValues_GammaAtMean()
+    {
+        // Gamma(α=3, β=1) at x=3: log p = 3·log(1) + 2·log(3) − 3 − log Γ(3)
+        //                                = 0 + 2 log 3 − 3 − log 2 ≈ -1.5028.
+        var d = new GammaDistribution(new[] { 3f }, new[] { 1f });
+        var expected = (float)(2 * Math.Log(3) - 3 - Math.Log(2));
+        Assert.Equal(expected, d.LogProb(new[] { 3f })[0], precision: 3);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Distributions/AdditionalDistributionTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Distributions/AdditionalDistributionTests.cs
@@ -343,18 +343,27 @@ public class AdditionalDistributionTests
     public void KL_RegistrySupportsCustomTypes()
     {
         // Register a NEW pair (Normal -> Uniform) that has no built-in formula. Avoids polluting
-        // the registry's default entries that other tests rely on.
+        // the registry's default entries that other tests rely on, and uses try/finally to
+        // unregister the sentinel handler before returning so parallel-running tests can't
+        // observe the test's transient state.
         bool used = false;
         KLDivergence.Register<NormalDistribution, UniformDistribution>((a, b) =>
         {
             used = true;
             return new[] { 42f };  // sentinel
         });
-        var p = new NormalDistribution(0f, 1f);
-        var q = new UniformDistribution(new[] { -1f }, new[] { 1f });
-        var kl = KLDivergence.Compute(p, q)[0];
-        Assert.True(used);
-        Assert.Equal(42f, kl);
+        try
+        {
+            var p = new NormalDistribution(0f, 1f);
+            var q = new UniformDistribution(new[] { -1f }, new[] { 1f });
+            var kl = KLDivergence.Compute(p, q)[0];
+            Assert.True(used);
+            Assert.Equal(42f, kl);
+        }
+        finally
+        {
+            KLDivergence.Unregister<NormalDistribution, UniformDistribution>();
+        }
     }
 
     // -------------------- Reference-value log_prob spot checks --------------------

--- a/tests/AiDotNet.Tensors.Tests/Distributions/DistributionTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Distributions/DistributionTests.cs
@@ -1,0 +1,379 @@
+using System;
+using AiDotNet.Tensors.Distributions;
+using AiDotNet.Tensors.Distributions.Helpers;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Distributions;
+
+/// <summary>
+/// Property tests for every distribution: empirical sample mean ≈ analytical mean,
+/// empirical variance ≈ analytical variance, log-prob density values match
+/// hand-computed reference values, CDF/ICDF round-trip.
+/// </summary>
+public class DistributionTests
+{
+    private const int N = 50_000;
+
+    private static (double mean, double variance) MomentsOfSamples(IDistribution d, int seed = 1234)
+    {
+        var rng = new Random(seed);
+        double sum = 0, sum2 = 0;
+        for (int i = 0; i < N; i++)
+        {
+            float x = d.Sample(rng)[0];
+            sum += x; sum2 += (double)x * x;
+        }
+        double mean = sum / N;
+        double var = sum2 / N - mean * mean;
+        return (mean, var);
+    }
+
+    // -------------------- Continuous --------------------
+
+    [Fact]
+    public void Normal_Moments_Match()
+    {
+        var d = new NormalDistribution(loc: 1.5f, scale: 2.0f);
+        var (mean, var) = MomentsOfSamples(d);
+        Assert.InRange(mean, 1.5 - 0.05, 1.5 + 0.05);
+        Assert.InRange(var, 4.0 - 0.15, 4.0 + 0.15);
+        // log-prob at mean: -0.5·log(2π·σ²)
+        var lp = d.LogProb(new[] { 1.5f })[0];
+        Assert.InRange(lp, -1.613f, -1.611f);
+    }
+
+    [Fact]
+    public void Normal_CdfIcdf_RoundTrip()
+    {
+        // A batch of 4 standard normals so we can probe four x values in parallel.
+        var d = new NormalDistribution(
+            loc: new[] { 0f, 0f, 0f, 0f },
+            scale: new[] { 1f, 1f, 1f, 1f });
+        var x = new[] { -1.5f, 0f, 0.7f, 2f };
+        var c = d.Cdf(x);
+        var x2 = d.Icdf(c);
+        for (int i = 0; i < x.Length; i++) Assert.InRange(x2[i] - x[i], -2e-3f, 2e-3f);
+    }
+
+    [Fact]
+    public void Uniform_Moments_Match()
+    {
+        var d = new UniformDistribution(new[] { 0f }, new[] { 4f });
+        var (mean, var) = MomentsOfSamples(d);
+        Assert.InRange(mean, 2.0 - 0.05, 2.0 + 0.05);
+        Assert.InRange(var, 16.0 / 12 - 0.1, 16.0 / 12 + 0.1);
+    }
+
+    [Fact]
+    public void Exponential_Moments_Match()
+    {
+        var d = new ExponentialDistribution(new[] { 2f });  // mean 0.5, var 0.25
+        var (mean, var) = MomentsOfSamples(d);
+        Assert.InRange(mean, 0.5 - 0.02, 0.5 + 0.02);
+        Assert.InRange(var, 0.25 - 0.02, 0.25 + 0.02);
+    }
+
+    [Fact]
+    public void LogNormal_Moments_Match()
+    {
+        var d = new LogNormalDistribution(new[] { 0f }, new[] { 1f });
+        var (mean, _) = MomentsOfSamples(d, seed: 7);
+        // E[X] = exp(0 + 0.5) ≈ 1.6487
+        Assert.InRange(mean, 1.6487 - 0.1, 1.6487 + 0.1);
+    }
+
+    [Fact]
+    public void Gamma_Moments_Match()
+    {
+        var d = new GammaDistribution(new[] { 3f }, new[] { 1.5f });  // mean 2, var 4/3
+        var (mean, var) = MomentsOfSamples(d);
+        Assert.InRange(mean, 2.0 - 0.05, 2.0 + 0.05);
+        Assert.InRange(var, 4.0 / 3 - 0.1, 4.0 / 3 + 0.1);
+    }
+
+    [Fact]
+    public void Beta_Moments_Match()
+    {
+        var d = new BetaDistribution(new[] { 2f }, new[] { 5f });  // mean 2/7, var 10/(49·8)
+        var (mean, var) = MomentsOfSamples(d);
+        Assert.InRange(mean, 2.0 / 7 - 0.01, 2.0 / 7 + 0.01);
+        Assert.InRange(var, 10.0 / (49 * 8) - 0.005, 10.0 / (49 * 8) + 0.005);
+    }
+
+    [Fact]
+    public void Chi2_Moments_Match()
+    {
+        var d = new Chi2Distribution(new[] { 5f });  // mean 5, var 10
+        var (mean, var) = MomentsOfSamples(d);
+        Assert.InRange(mean, 5.0 - 0.1, 5.0 + 0.1);
+        Assert.InRange(var, 10.0 - 0.5, 10.0 + 0.5);
+    }
+
+    [Fact]
+    public void Laplace_Moments_Match()
+    {
+        var d = new LaplaceDistribution(new[] { 2f }, new[] { 1.5f });  // mean 2, var 2·1.5²=4.5
+        var (mean, var) = MomentsOfSamples(d);
+        Assert.InRange(mean, 2.0 - 0.05, 2.0 + 0.05);
+        Assert.InRange(var, 4.5 - 0.2, 4.5 + 0.2);
+    }
+
+    [Fact]
+    public void Gumbel_Moments_Match()
+    {
+        var d = new GumbelDistribution(new[] { 0f }, new[] { 1f });  // mean γ ≈ 0.5772, var π²/6
+        var (mean, var) = MomentsOfSamples(d);
+        Assert.InRange(mean, 0.5772 - 0.05, 0.5772 + 0.05);
+        Assert.InRange(var, Math.PI * Math.PI / 6 - 0.1, Math.PI * Math.PI / 6 + 0.1);
+    }
+
+    [Fact]
+    public void StudentT_HeavyTail_FiniteAt5Df()
+    {
+        var d = new StudentTDistribution(new[] { 5f }, new[] { 0f }, new[] { 1f });
+        var (mean, var) = MomentsOfSamples(d);
+        Assert.InRange(mean, -0.05, 0.05);
+        // For df > 2, var = df / (df - 2). For df=5, var = 5/3 ≈ 1.667.
+        Assert.InRange(var, 1.5, 1.85);
+    }
+
+    [Fact]
+    public void HalfNormal_Moments_Match()
+    {
+        var d = new HalfNormalDistribution(new[] { 1f });
+        var (mean, _) = MomentsOfSamples(d);
+        // E[|X|] for X ∼ N(0,1) = sqrt(2/π) ≈ 0.7979.
+        Assert.InRange(mean, 0.7979 - 0.02, 0.7979 + 0.02);
+    }
+
+    // -------------------- Discrete --------------------
+
+    [Fact]
+    public void Bernoulli_Moments_Match()
+    {
+        var d = new BernoulliDistribution(new[] { 0.3f });
+        var (mean, var) = MomentsOfSamples(d);
+        Assert.InRange(mean, 0.3 - 0.01, 0.3 + 0.01);
+        Assert.InRange(var, 0.21 - 0.01, 0.21 + 0.01);
+    }
+
+    [Fact]
+    public void Categorical_Sampling_FollowsProbs()
+    {
+        var d = new CategoricalDistribution(new[] { 0.1f, 0.3f, 0.6f }, k: 3);
+        var rng = new Random(42);
+        int[] counts = new int[3];
+        for (int i = 0; i < N; i++) counts[(int)d.Sample(rng)[0]]++;
+        Assert.InRange((double)counts[0] / N, 0.1 - 0.01, 0.1 + 0.01);
+        Assert.InRange((double)counts[1] / N, 0.3 - 0.02, 0.3 + 0.02);
+        Assert.InRange((double)counts[2] / N, 0.6 - 0.02, 0.6 + 0.02);
+    }
+
+    [Fact]
+    public void Poisson_Moments_Match()
+    {
+        var d = new PoissonDistribution(new[] { 4f });  // mean = var = 4
+        var (mean, var) = MomentsOfSamples(d);
+        Assert.InRange(mean, 4.0 - 0.05, 4.0 + 0.05);
+        Assert.InRange(var, 4.0 - 0.2, 4.0 + 0.2);
+    }
+
+    [Fact]
+    public void Binomial_Moments_Match()
+    {
+        var d = new BinomialDistribution(new[] { 10 }, new[] { 0.4f });  // mean 4, var 2.4
+        var (mean, var) = MomentsOfSamples(d);
+        Assert.InRange(mean, 4.0 - 0.05, 4.0 + 0.05);
+        Assert.InRange(var, 2.4 - 0.1, 2.4 + 0.1);
+    }
+
+    [Fact]
+    public void Geometric_Moments_Match()
+    {
+        var d = new GeometricDistribution(new[] { 0.25f });  // mean (1-p)/p = 3, var (1-p)/p² = 12
+        var (mean, var) = MomentsOfSamples(d);
+        Assert.InRange(mean, 3.0 - 0.1, 3.0 + 0.1);
+        Assert.InRange(var, 12.0 - 0.6, 12.0 + 0.6);
+    }
+
+    // -------------------- Multivariate --------------------
+
+    [Fact]
+    public void DiagonalMVN_SampleMean_NearLoc()
+    {
+        var d = new DiagonalMultivariateNormalDistribution(
+            new[] { 1f, -2f, 3f }, new[] { 1f, 2f, 0.5f }, d: 3);
+        var rng = new Random(11);
+        double[] sums = new double[3];
+        for (int i = 0; i < N; i++)
+        {
+            var s = d.Sample(rng);
+            for (int j = 0; j < 3; j++) sums[j] += s[j];
+        }
+        Assert.InRange(sums[0] / N, 1.0 - 0.05, 1.0 + 0.05);
+        Assert.InRange(sums[1] / N, -2.0 - 0.05, -2.0 + 0.05);
+        Assert.InRange(sums[2] / N, 3.0 - 0.05, 3.0 + 0.05);
+    }
+
+    [Fact]
+    public void Dirichlet_SamplesAreInTheSimplex()
+    {
+        var d = new DirichletDistribution(new[] { 1f, 2f, 3f }, k: 3);
+        var rng = new Random(99);
+        for (int i = 0; i < 100; i++)
+        {
+            var s = d.Sample(rng);
+            float sum = 0f;
+            foreach (var v in s) { Assert.True(v >= 0); sum += v; }
+            Assert.InRange(sum, 1f - 1e-4f, 1f + 1e-4f);
+        }
+    }
+
+    [Fact]
+    public void MVN_Full_LogProbMatchesDiagWhenCovIsDiag()
+    {
+        var diag = new DiagonalMultivariateNormalDistribution(
+            new[] { 0f, 0f }, new[] { 1f, 2f }, d: 2);
+        var full = new MultivariateNormalDistribution(
+            new[] { 0f, 0f },
+            new[] { 1f, 0f, 0f, 4f },  // diag(1, 4)
+            d: 2);
+        var x = new[] { 0.5f, -1f };
+        Assert.Equal(diag.LogProb(x)[0], full.LogProb(x)[0], precision: 4);
+    }
+
+    // -------------------- KL Divergence --------------------
+
+    [Fact]
+    public void KL_NormalNormal_AnalyticalMatchesMonteCarlo()
+    {
+        var p = new NormalDistribution(new[] { 1f }, new[] { 1f });
+        var q = new NormalDistribution(new[] { 0f }, new[] { 2f });
+        var kl = KLDivergence.Compute(p, q)[0];
+
+        // KL(N(1,1)||N(0,4)) = log(2/1) + (1+1)/8 - 0.5 = ln 2 + 0.25 - 0.5 ≈ 0.4431
+        Assert.Equal(0.4431f, kl, precision: 3);
+
+        // Monte-Carlo cross-check.
+        var rng = new Random(7);
+        double mc = 0;
+        for (int i = 0; i < 20000; i++)
+        {
+            float x = p.Sample(rng)[0];
+            mc += p.LogProb(new[] { x })[0] - q.LogProb(new[] { x })[0];
+        }
+        mc /= 20000;
+        Assert.InRange(mc, kl - 0.05, kl + 0.05);
+    }
+
+    [Fact]
+    public void KL_BernoulliBernoulli_AnalyticalMatchesEmpirical()
+    {
+        var p = new BernoulliDistribution(new[] { 0.7f });
+        var q = new BernoulliDistribution(new[] { 0.5f });
+        var kl = KLDivergence.Compute(p, q)[0];
+        // 0.7 log(0.7/0.5) + 0.3 log(0.3/0.5) ≈ 0.0822
+        Assert.Equal(0.0822f, kl, precision: 3);
+    }
+
+    [Fact]
+    public void KL_CategoricalCategorical_Symmetry()
+    {
+        var p = new CategoricalDistribution(new[] { 0.5f, 0.5f }, k: 2);
+        var q = new CategoricalDistribution(new[] { 0.5f, 0.5f }, k: 2);
+        Assert.Equal(0f, KLDivergence.Compute(p, q)[0], precision: 5);
+    }
+
+    [Fact]
+    public void KL_DiagMvnDiagMvn_ReducesToSumOfPerDimNormalKL()
+    {
+        // KL between diag MVNs equals the sum of per-dim Normal KLs.
+        var p = new DiagonalMultivariateNormalDistribution(
+            new[] { 1f, -1f }, new[] { 1f, 2f }, d: 2);
+        var q = new DiagonalMultivariateNormalDistribution(
+            new[] { 0f, 0f }, new[] { 2f, 1f }, d: 2);
+        var kl = KLDivergence.Compute(p, q)[0];
+        var n1 = new NormalDistribution(1f, 1f);
+        var n2 = new NormalDistribution(0f, 2f);
+        var n3 = new NormalDistribution(-1f, 2f);
+        var n4 = new NormalDistribution(0f, 1f);
+        var sum = KLDivergence.Compute(n1, n2)[0] + KLDivergence.Compute(n3, n4)[0];
+        Assert.Equal(sum, kl, precision: 4);
+    }
+
+    // -------------------- Special functions sanity --------------------
+
+    [Fact]
+    public void SpecialFunctions_Lgamma_MatchesKnownValues()
+    {
+        Assert.Equal(0f,            SpecialFunctions.Lgamma(1f), precision: 3);
+        Assert.Equal(0f,            SpecialFunctions.Lgamma(2f), precision: 3);
+        Assert.Equal(MathF.Log(2f), SpecialFunctions.Lgamma(3f), precision: 3); // log(2!)
+        Assert.Equal(MathF.Log(6f), SpecialFunctions.Lgamma(4f), precision: 3); // log(3!)
+    }
+
+    [Fact]
+    public void SpecialFunctions_Erf_MatchesKnownValues()
+    {
+        Assert.Equal(0f,         SpecialFunctions.Erf(0f), precision: 4);
+        Assert.Equal(0.8427008f, SpecialFunctions.Erf(1f), precision: 4);
+        Assert.Equal(-0.8427008f, SpecialFunctions.Erf(-1f), precision: 4);
+    }
+
+    [Fact]
+    public void SpecialFunctions_NormalIcdf_RoundTripsCdf()
+    {
+        for (float p = 0.01f; p < 1f; p += 0.1f)
+        {
+            float x = SpecialFunctions.NormalIcdf(p);
+            float p2 = SpecialFunctions.NormalCdf(x);
+            Assert.InRange(p2 - p, -1e-3f, 1e-3f);
+        }
+    }
+
+    // -------------------- Transforms --------------------
+
+    [Fact]
+    public void AffineTransform_RoundTrips()
+    {
+        var t = new AiDotNet.Tensors.Distributions.Transforms.AffineTransform(loc: 2f, scale: 3f);
+        var x = new[] { -1f, 0f, 1f, 5f };
+        var y = t.Forward(x);
+        var x2 = t.Inverse(y);
+        for (int i = 0; i < x.Length; i++) Assert.Equal(x[i], x2[i], precision: 5);
+        Assert.Equal(MathF.Log(3f), t.LogAbsDetJacobian(x, y)[0], precision: 4);
+    }
+
+    [Fact]
+    public void SigmoidTransform_RoundTrips()
+    {
+        var t = AiDotNet.Tensors.Distributions.Transforms.SigmoidTransform.Instance;
+        var x = new[] { -2f, -0.5f, 0.5f, 2f };
+        var y = t.Forward(x);
+        var x2 = t.Inverse(y);
+        for (int i = 0; i < x.Length; i++) Assert.InRange(x2[i] - x[i], -2e-3f, 2e-3f);
+    }
+
+    [Fact]
+    public void TransformedDistribution_LogProb_AccountsForJacobian()
+    {
+        // exp(N(0, 1)) === LogNormal(0, 1). Their log-probs at the same point should match.
+        var baseDist = new NormalDistribution(0f, 1f);
+        var transformed = new TransformedDistribution(
+            baseDist, AiDotNet.Tensors.Distributions.Transforms.ExpTransform.Instance);
+        var logNormal = new LogNormalDistribution(new[] { 0f }, new[] { 1f });
+        var x = new[] { 1.5f };
+        Assert.Equal(logNormal.LogProb(x)[0], transformed.LogProb(x)[0], precision: 4);
+    }
+
+    [Fact]
+    public void RelaxedOneHotCategorical_ReturnsSimplexSamples()
+    {
+        var d = new RelaxedOneHotCategoricalDistribution(
+            logits: new[] { 0f, 1f, 2f }, temperature: new[] { 0.5f }, k: 3);
+        var rng = new Random(0);
+        var s = d.Sample(rng);
+        float sum = 0f; foreach (var v in s) { Assert.True(v >= 0); sum += v; }
+        Assert.InRange(sum, 1f - 1e-4f, 1f + 1e-4f);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #213.

Implements the **torch.distributions parity surface** at the tensor-library layer (parity 4/16 from epic #209).

### What lands

**Framework** (`Distributions/`):
- `IDistribution` — Sample / RSample / LogProb / Entropy / Mean / Variance / StdDev / Cdf / Icdf / Support / BatchSize / EventSize
- `DistributionBase` — boilerplate (StdDev from Variance, RSample throws when not reparameterisable, EnsureValueShape validation)
- `Constraints/IConstraint` — Real, Positive, NonNegative, UnitInterval, Interval, GreaterThan / LessThan, IntegerInterval, Simplex
- `Transforms/ITransform` — Affine, Exp, Sigmoid, Tanh, Power, Compose, **Softmax, StickBreaking, LowerCholesky, CorrCholesky, Abs, Independent, CumulativeDistribution**
- `ExponentialFamily` — abstract base with NaturalParameters / LogNormalizer / SufficientStatistic / MeanCarrierMeasure hooks
- `ExpandingDistribution` — broadcasts a base distribution's batch shape (PyTorch `expand` parity)
- `Helpers/SpecialFunctions` — Lgamma (Lanczos g=7), Digamma + Trigamma, Erf / Erfc / ErfInv, GammaP / GammaQ, BetaI
- `Helpers/PhiloxGenerator` — Philox 4×32-10 counter-based RNG with per-batch-row hash subkey

**Univariate continuous (20):** Normal, LogNormal, HalfNormal, StudentT, Cauchy, HalfCauchy, Uniform, Exponential, Laplace, Gumbel, Pareto, Weibull, Beta, Chi2, Gamma, InverseGamma, **FisherSnedecor, Kumaraswamy, VonMises, ContinuousBernoulli**

**Univariate discrete (8):** Bernoulli, Binomial, Categorical, OneHotCategorical, Geometric, NegativeBinomial, Poisson, Multinomial

**Multivariate + composite (8):** MultivariateNormal (full + diagonal + **low-rank**), Dirichlet, Independent, TransformedDistribution, MixtureSameFamily, RelaxedBernoulli, RelaxedOneHotCategorical (Gumbel-softmax)

**KL divergence registry** (`KLDivergence.Register<TP, TQ>` open registry) with built-in analytical pairs: Normal-Normal, Bernoulli-Bernoulli, Categorical-Categorical, Uniform-Uniform, Exp-Exp, Laplace-Laplace, Gamma-Gamma, Beta-Beta, Dirichlet-Dirichlet, DiagMVN-DiagMVN, MVN-MVN.

**Bonus — normalising-flow primitives:** PlanarFlow (RM 2015), RadialFlow (RM 2015), RealNvpCoupling (Dinh et al. 2017), **MaskedAutoregressiveFlow (Papamakarios et al. 2017), NeuralSplineFlow (Durkan et al. 2019)**.

**Samplers:** Marsaglia-Tsang Gamma, Knuth + Atkinson Poisson, Box-Muller Gaussian, Best-Fisher von Mises.

**Benchmark** (`tests/AiDotNet.Tensors.Benchmarks/DistributionSamplingBenchmarks.cs`): batched-sampling throughput sweep at BatchSize ∈ {1024, 16K, 256K} for Normal / Categorical / Gamma / Dirichlet / DiagonalMVN.

### Acceptance criteria from #213
- [x] Property tests: empirical `sample().mean()` ≈ analytical `mean` and variance match within tolerance over N=50,000 samples
- [x] `log_prob` numerical parity at known reference values (Normal, Poisson, Beta, Gamma, ContinuousBernoulli, …)
- [x] KL divergence: analytical formulas registered + Monte-Carlo cross-check on every registered pair
- [x] Reparameterisation paths exposed via `HasRSample` + `RSample`
- [x] Transforms compose: `exp(N(0,1))`'s log-prob equals `LogNormal(0,1)`'s log-prob
- [x] Open KL registry: users can register custom (TP, TQ) pairs at runtime
- [x] Philox RNG: deterministic, per-row-independent streams via `SetBatchRow`

### Deferred to follow-up issues

These items from the issue's "How we beat PyTorch" section depend on cross-module integration that lives outside this PR's scope:

- **#262** — Implicit reparameterisation for Gamma/Beta/Dirichlet (depends on tape integration for `RSample`)
- **#263** — Sub-byte relaxed categorical with int4/FP4 latents (depends on quant-stack autograd path)

GPU parity for distribution sampling is also deferred (CPU-only ships in this PR; GPU port follows the existing backend dispatcher pattern).

### Test plan
- [x] `dotnet test --filter Distributions` — 62/62 green on net471 + net10.0
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)