### PR TITLE
feat(#216): data loading — Dataset / DataLoader / Samplers / DataPipes / CheckpointableLoader

### DIFF
--- a/src/AiDotNet.Tensors/AiDotNet.Tensors.csproj
+++ b/src/AiDotNet.Tensors/AiDotNet.Tensors.csproj
@@ -86,6 +86,9 @@
          the modern zip-format PyTorch checkpoint. -->
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
+    <!-- System.Threading.Channels is in BCL on .NET 5+; net471 needs the
+         compat package. Used by the multi-worker DataLoader (#216). -->
+    <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
   </ItemGroup>
 
   <!--

--- a/src/AiDotNet.Tensors/Data/CheckpointableLoader.cs
+++ b/src/AiDotNet.Tensors/Data/CheckpointableLoader.cs
@@ -62,6 +62,16 @@ public sealed class CheckpointableLoader<TSample, TBatch> : IEnumerable<TBatch>
     {
         if (checkpoint.Epoch < 0) throw new ArgumentOutOfRangeException(nameof(checkpoint));
         if (checkpoint.BatchIndex < 0) throw new ArgumentOutOfRangeException(nameof(checkpoint));
+        // BatchIndex == BatchCount is the legitimate end-of-epoch
+        // resume state (every batch already consumed; next call rolls
+        // to the next epoch). Anything beyond that would skip the
+        // entire next epoch by silently zeroing through every batch
+        // in the GetEnumerator skip-loop, dropping data on a corrupt
+        // or hand-edited checkpoint.
+        if (checkpoint.BatchIndex > _batchSampler.Count)
+            throw new ArgumentOutOfRangeException(
+                nameof(checkpoint),
+                $"BatchIndex {checkpoint.BatchIndex} exceeds epoch batch count {_batchSampler.Count}.");
         _epoch = checkpoint.Epoch;
         _batchIndex = checkpoint.BatchIndex;
     }

--- a/src/AiDotNet.Tensors/Data/CheckpointableLoader.cs
+++ b/src/AiDotNet.Tensors/Data/CheckpointableLoader.cs
@@ -1,0 +1,104 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using AiDotNet.Tensors.Data.Samplers;
+
+namespace AiDotNet.Tensors.Data;
+
+/// <summary>
+/// Snapshot of a <see cref="CheckpointableLoader{TSample, TBatch}"/>'s
+/// position. Save/restore so a crashed training run resumes from the same
+/// batch in the same epoch — no re-shuffling, no skipped or repeated
+/// samples. PyTorch parity: <c>torchdata.StatefulDataLoader.state_dict()</c>.
+/// </summary>
+public readonly record struct LoaderCheckpoint(int Epoch, int BatchIndex);
+
+/// <summary>
+/// Single-process DataLoader that supports mid-epoch resume. Maintains the
+/// same per-epoch ordering as the regular DataLoader (same sampler, same
+/// seed) but tracks how many batches have been emitted so far in
+/// <see cref="LoaderCheckpoint.BatchIndex"/>. After a crash, restoring the
+/// checkpoint replays the sampler and skips the already-consumed prefix —
+/// the next yielded batch is exactly the one that would have been yielded
+/// next, had the crash not happened.
+///
+/// <para>The async/multi-worker path is not used here — mid-epoch resume
+/// + parallel prefetch is genuinely incompatible (workers may have decoded
+/// past the checkpoint by the time a crash hits). For multi-worker
+/// resumption, snapshot at end-of-epoch only.</para>
+/// </summary>
+public sealed class CheckpointableLoader<TSample, TBatch> : IEnumerable<TBatch>
+{
+    private readonly IDataset<TSample> _dataset;
+    private readonly CollateFn<TSample, TBatch> _collate;
+    private readonly DataLoaderOptions _options;
+    private readonly IBatchSampler _batchSampler;
+    private int _epoch;
+    private int _batchIndex;
+
+    /// <summary>Constructs.</summary>
+    public CheckpointableLoader(IDataset<TSample> dataset,
+        CollateFn<TSample, TBatch> collate, DataLoaderOptions? options = null)
+    {
+        _dataset = dataset ?? throw new ArgumentNullException(nameof(dataset));
+        _collate = collate ?? throw new ArgumentNullException(nameof(collate));
+        _options = options ?? new DataLoaderOptions();
+        _options.Validate();
+        if (_options.NumWorkers > 0)
+            throw new ArgumentException(
+                "CheckpointableLoader does not support NumWorkers > 0. " +
+                "Use the regular DataLoader for prefetch, or snapshot at end-of-epoch.");
+        _batchSampler = ResolveBatchSampler();
+    }
+
+    /// <summary>Captures the current loader position. Pass to a future
+    /// <see cref="LoadStateDict"/> call to resume.</summary>
+    public LoaderCheckpoint StateDict() => new(_epoch, _batchIndex);
+
+    /// <summary>Restores from a checkpoint produced by an earlier
+    /// <see cref="StateDict"/> call.</summary>
+    public void LoadStateDict(LoaderCheckpoint checkpoint)
+    {
+        if (checkpoint.Epoch < 0) throw new ArgumentOutOfRangeException(nameof(checkpoint));
+        if (checkpoint.BatchIndex < 0) throw new ArgumentOutOfRangeException(nameof(checkpoint));
+        _epoch = checkpoint.Epoch;
+        _batchIndex = checkpoint.BatchIndex;
+    }
+
+    /// <summary>Number of batches per epoch.</summary>
+    public int BatchCount => _batchSampler.Count;
+
+    /// <summary>Enumerates an epoch from the current checkpoint position.</summary>
+    public IEnumerator<TBatch> GetEnumerator()
+    {
+        _batchSampler.SetEpoch(_epoch);
+        int skip = _batchIndex;
+        int seen = 0;
+        foreach (var batchIdx in _batchSampler.GetBatches())
+        {
+            if (seen < skip) { seen++; continue; }
+            var samples = new TSample[batchIdx.Count];
+            for (int i = 0; i < batchIdx.Count; i++) samples[i] = _dataset[batchIdx[i]];
+            var batch = _collate(samples);
+            _batchIndex++;
+            yield return batch;
+            seen++;
+        }
+        // Epoch finished — bump epoch and reset batch index.
+        _epoch++;
+        _batchIndex = 0;
+    }
+
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+
+    private IBatchSampler ResolveBatchSampler()
+    {
+        if (_options.BatchSampler is not null) return _options.BatchSampler;
+        ISampler inner = _options.Sampler
+            ?? (_options.Shuffle
+                ? new RandomSampler(_dataset.Count, seed: _options.Seed)
+                : new SequentialSampler(_dataset.Count));
+        return new BatchSampler(inner, _options.BatchSize, _options.DropLast);
+    }
+}

--- a/src/AiDotNet.Tensors/Data/Collation.cs
+++ b/src/AiDotNet.Tensors/Data/Collation.cs
@@ -1,0 +1,119 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Data;
+
+/// <summary>
+/// Function that turns a list of samples into a single batch. The
+/// <see cref="DataLoader{TSample, TBatch}"/> calls this with one batch worth
+/// of samples and yields the result.
+/// </summary>
+public delegate TBatch CollateFn<TSample, TBatch>(IReadOnlyList<TSample> samples);
+
+/// <summary>
+/// Default collation strategies — handle the common cases users would
+/// otherwise write by hand.
+/// </summary>
+public static class Collators
+{
+    /// <summary>
+    /// Stacks a list of <see cref="Tensor{T}"/> samples along a new leading
+    /// axis. Equivalent to <c>torch.stack</c> over the sample list. All
+    /// samples must share their shape; mismatches throw early.
+    /// </summary>
+    public static Tensor<T> Stack<T>(IReadOnlyList<Tensor<T>> samples)
+    {
+        if (samples is null) throw new ArgumentNullException(nameof(samples));
+        if (samples.Count == 0) throw new ArgumentException("Cannot stack zero samples.");
+
+        var first = samples[0];
+        var sampleShape = first._shape;
+
+        // Validate matching shapes — variadic-shape stacking would silently
+        // produce malformed batches.
+        for (int s = 1; s < samples.Count; s++)
+        {
+            var t = samples[s];
+            if (t._shape.Length != sampleShape.Length)
+                throw new ArgumentException(
+                    $"All samples must share rank. Sample 0 rank={sampleShape.Length}, sample {s} rank={t._shape.Length}.");
+            for (int d = 0; d < sampleShape.Length; d++)
+                if (t._shape[d] != sampleShape[d])
+                    throw new ArgumentException(
+                        $"Shape mismatch at sample {s} dim {d}: got {t._shape[d]}, expected {sampleShape[d]}.");
+        }
+
+        var batchShape = new int[sampleShape.Length + 1];
+        batchShape[0] = samples.Count;
+        for (int d = 0; d < sampleShape.Length; d++) batchShape[d + 1] = sampleShape[d];
+
+        var batch = new Tensor<T>(batchShape);
+        var dst = batch.AsWritableSpan();
+        int sampleLen = first.Length;
+        for (int s = 0; s < samples.Count; s++)
+        {
+            samples[s].AsSpan().CopyTo(dst.Slice(s * sampleLen, sampleLen));
+        }
+        return batch;
+    }
+
+    /// <summary>
+    /// Pads variable-length 1D sequences to the longest length, then stacks
+    /// along a new leading axis. The pad cell is filled with
+    /// <paramref name="padValue"/>. Useful for batching tokenized text where
+    /// each sample's sequence length differs.
+    /// </summary>
+    public static Tensor<T> PadAndStack1D<T>(IReadOnlyList<Tensor<T>> samples, T padValue)
+    {
+        if (samples is null) throw new ArgumentNullException(nameof(samples));
+        if (samples.Count == 0) throw new ArgumentException("Cannot stack zero samples.");
+
+        int maxLen = 0;
+        for (int s = 0; s < samples.Count; s++)
+        {
+            if (samples[s]._shape.Length != 1)
+                throw new ArgumentException(
+                    $"PadAndStack1D requires rank-1 samples. Sample {s} has rank {samples[s]._shape.Length}.");
+            if (samples[s]._shape[0] > maxLen) maxLen = samples[s]._shape[0];
+        }
+
+        var batch = new Tensor<T>(new[] { samples.Count, maxLen });
+        var dst = batch.AsWritableSpan();
+        for (int i = 0; i < dst.Length; i++) dst[i] = padValue;
+
+        for (int s = 0; s < samples.Count; s++)
+        {
+            int len = samples[s]._shape[0];
+            samples[s].AsSpan().CopyTo(dst.Slice(s * maxLen, len));
+        }
+        return batch;
+    }
+
+    /// <summary>
+    /// Default collator for <see cref="Tensor{T}"/>[] samples (the shape
+    /// emitted by <see cref="TensorDataset{T}"/>). Stacks each component
+    /// independently and returns the resulting array of stacked batches.
+    /// </summary>
+    public static Tensor<T>[] StackTuple<T>(IReadOnlyList<Tensor<T>[]> samples)
+    {
+        if (samples is null) throw new ArgumentNullException(nameof(samples));
+        if (samples.Count == 0) throw new ArgumentException("Cannot stack zero samples.");
+        int components = samples[0].Length;
+        var result = new Tensor<T>[components];
+        var componentLists = new List<Tensor<T>>[components];
+        for (int c = 0; c < components; c++) componentLists[c] = new List<Tensor<T>>(samples.Count);
+        for (int s = 0; s < samples.Count; s++)
+        {
+            var sample = samples[s];
+            if (sample.Length != components)
+                throw new ArgumentException(
+                    $"All samples must have {components} components; sample {s} has {sample.Length}.");
+            for (int c = 0; c < components; c++) componentLists[c].Add(sample[c]);
+        }
+        for (int c = 0; c < components; c++) result[c] = Stack(componentLists[c]);
+        return result;
+    }
+}

--- a/src/AiDotNet.Tensors/Data/DataLoader.cs
+++ b/src/AiDotNet.Tensors/Data/DataLoader.cs
@@ -1,0 +1,309 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using AiDotNet.Tensors.Data.Samplers;
+
+namespace AiDotNet.Tensors.Data;
+
+/// <summary>
+/// Configuration knobs for <see cref="DataLoader{TSample, TBatch}"/>.
+/// Mirrors the keyword arguments of PyTorch's
+/// <c>torch.utils.data.DataLoader</c>.
+/// </summary>
+public sealed class DataLoaderOptions
+{
+    /// <summary>Samples per batch. Required for the auto-sampler path.</summary>
+    public int BatchSize { get; set; } = 1;
+
+    /// <summary>If true, randomly shuffles indices each epoch (uses
+    /// <see cref="RandomSampler"/>). Ignored when <see cref="Sampler"/>
+    /// or <see cref="BatchSampler"/> is provided.</summary>
+    public bool Shuffle { get; set; }
+
+    /// <summary>Drops the trailing partial batch when the dataset count
+    /// isn't a multiple of <see cref="BatchSize"/>. PyTorch parity.</summary>
+    public bool DropLast { get; set; }
+
+    /// <summary>Number of background workers that prefetch batches via the
+    /// async pipeline. <c>0</c> uses the calling thread (sync); &gt; 0
+    /// spawns that many <see cref="Task"/>-pool workers writing into a
+    /// bounded <see cref="Channel{T}"/>. PyTorch parity:
+    /// <c>num_workers</c>.</summary>
+    public int NumWorkers { get; set; }
+
+    /// <summary>How many batches to keep buffered ahead of the consumer.
+    /// Also serves as the worker channel's bounded capacity. Default 2 —
+    /// matches PyTorch's <c>prefetch_factor=2</c>.</summary>
+    public int PrefetchFactor { get; set; } = 2;
+
+    /// <summary>Optional explicit per-index sampler. Overrides
+    /// <see cref="Shuffle"/> if non-null. <see cref="BatchSize"/> still
+    /// determines batch grouping.</summary>
+    public ISampler? Sampler { get; set; }
+
+    /// <summary>Optional explicit batch sampler. Overrides both
+    /// <see cref="Sampler"/> and <see cref="BatchSize"/>.</summary>
+    public IBatchSampler? BatchSampler { get; set; }
+
+    /// <summary>Seed for the default <see cref="RandomSampler"/> when
+    /// <see cref="Shuffle"/> is true and no explicit sampler is given.
+    /// <c>null</c> = unseeded (different shuffle every run).</summary>
+    public int? Seed { get; set; }
+
+    /// <summary>Throws if validation finds an inconsistent setting.</summary>
+    internal void Validate()
+    {
+        if (BatchSize < 1) throw new ArgumentOutOfRangeException(nameof(BatchSize));
+        if (NumWorkers < 0) throw new ArgumentOutOfRangeException(nameof(NumWorkers));
+        if (PrefetchFactor < 1) throw new ArgumentOutOfRangeException(nameof(PrefetchFactor));
+        if (BatchSampler is not null && (Sampler is not null || Shuffle))
+        {
+            throw new ArgumentException(
+                "BatchSampler is mutually exclusive with Sampler/Shuffle. " +
+                "When BatchSampler is set, BatchSize is ignored too.");
+        }
+    }
+}
+
+/// <summary>
+/// Drives a per-epoch iteration over an <see cref="IDataset{TSample}"/> —
+/// applies a sampler to choose indices, fetches samples, applies a collate
+/// function to assemble batches, and (optionally) prefetches batches in
+/// parallel from a worker pool. Mirrors
+/// <c>torch.utils.data.DataLoader</c>.
+/// </summary>
+/// <typeparam name="TSample">Per-sample type as exposed by the dataset.</typeparam>
+/// <typeparam name="TBatch">Per-batch type as produced by the collator.</typeparam>
+public class DataLoader<TSample, TBatch> : IEnumerable<TBatch>
+{
+    private readonly IDataset<TSample> _dataset;
+    private readonly CollateFn<TSample, TBatch> _collate;
+    private readonly DataLoaderOptions _options;
+    private readonly IBatchSampler _batchSampler;
+    private int _epoch;
+
+    /// <summary>Constructs.</summary>
+    /// <param name="dataset">Map-style dataset to iterate.</param>
+    /// <param name="collate">Function that turns a list of samples into a batch.</param>
+    /// <param name="options">Loader options. <c>null</c> uses defaults.</param>
+    public DataLoader(IDataset<TSample> dataset, CollateFn<TSample, TBatch> collate, DataLoaderOptions? options = null)
+    {
+        _dataset = dataset ?? throw new ArgumentNullException(nameof(dataset));
+        _collate = collate ?? throw new ArgumentNullException(nameof(collate));
+        _options = options ?? new DataLoaderOptions();
+        _options.Validate();
+        _batchSampler = ResolveBatchSampler();
+    }
+
+    /// <summary>The underlying dataset.</summary>
+    public IDataset<TSample> Dataset => _dataset;
+
+    /// <summary>Number of batches per epoch.</summary>
+    public int BatchCount => _batchSampler.Count;
+
+    /// <summary>Current epoch index. Bumped automatically on each fresh
+    /// enumeration, or set explicitly via <see cref="SetEpoch"/>.</summary>
+    public int Epoch => _epoch;
+
+    /// <summary>Sets the epoch — typically not needed (auto-increments per
+    /// enumeration), but exposed so distributed-training code can sync the
+    /// per-epoch shuffle seed across ranks before iteration.</summary>
+    public void SetEpoch(int epoch)
+    {
+        _epoch = epoch;
+        _batchSampler.SetEpoch(epoch);
+    }
+
+    /// <summary>Enumerates one full epoch.</summary>
+    public IEnumerator<TBatch> GetEnumerator()
+    {
+        _batchSampler.SetEpoch(_epoch);
+        try
+        {
+            return _options.NumWorkers <= 0
+                ? IterateSync().GetEnumerator()
+                : IterateAsync().GetEnumerator();
+        }
+        finally
+        {
+            // Don't auto-increment here — finally runs on enumerator dispose
+            // and the user may dispose mid-epoch (early-stop). Bump epoch at
+            // the START of the next enumeration instead.
+        }
+    }
+
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+
+    private IEnumerable<TBatch> IterateSync()
+    {
+        foreach (var batchIdx in _batchSampler.GetBatches())
+        {
+            var samples = new TSample[batchIdx.Count];
+            for (int i = 0; i < batchIdx.Count; i++) samples[i] = _dataset[batchIdx[i]];
+            yield return _collate(samples);
+        }
+        _epoch++;
+    }
+
+    private IEnumerable<TBatch> IterateAsync()
+    {
+        // Order-preserving multi-worker prefetch. Each batch carries its
+        // sampler-order sequence number through the worker pool; the
+        // consumer thread holds a small reorder buffer (capped by the
+        // prefetch factor) and yields strictly in sampler order. Matches
+        // PyTorch's DataLoader contract: batches with `num_workers>0` are
+        // returned in the same order as `num_workers=0`.
+        int capacity = Math.Max(1, _options.PrefetchFactor * Math.Max(1, _options.NumWorkers));
+        var resultChannel = Channel.CreateBounded<(int Seq, TBatch Batch)>(
+            new BoundedChannelOptions(capacity)
+            {
+                FullMode = BoundedChannelFullMode.Wait,
+                SingleReader = true,
+                SingleWriter = false,
+            });
+
+        var jobChannel = Channel.CreateBounded<(int Seq, IReadOnlyList<int> Idx)>(
+            new BoundedChannelOptions(capacity * 2)
+            {
+                FullMode = BoundedChannelFullMode.Wait,
+                SingleReader = false,
+                SingleWriter = true,
+            });
+
+        var pumpCts = new CancellationTokenSource();
+        var pumpTask = Task.Run(async () =>
+        {
+            try
+            {
+                int seq = 0;
+                foreach (var batch in _batchSampler.GetBatches())
+                {
+                    if (pumpCts.IsCancellationRequested) break;
+                    await jobChannel.Writer.WriteAsync((seq++, batch)).ConfigureAwait(false);
+                }
+            }
+            finally { jobChannel.Writer.TryComplete(); }
+        });
+
+        var workers = new Task[_options.NumWorkers];
+        int activeWorkers = _options.NumWorkers;
+        for (int w = 0; w < _options.NumWorkers; w++)
+        {
+            workers[w] = Task.Run(async () =>
+            {
+                try
+                {
+                    // Manual WaitToRead/TryRead loop instead of ReadAllAsync —
+                    // ReadAllAsync is netstandard2.1+ and we still target net471.
+                    while (await jobChannel.Reader.WaitToReadAsync().ConfigureAwait(false))
+                    {
+                        while (jobChannel.Reader.TryRead(out var job))
+                        {
+                            if (pumpCts.IsCancellationRequested) break;
+                            var samples = new TSample[job.Idx.Count];
+                            for (int i = 0; i < job.Idx.Count; i++) samples[i] = _dataset[job.Idx[i]];
+                            var batch = _collate(samples);
+                            await resultChannel.Writer.WriteAsync((job.Seq, batch)).ConfigureAwait(false);
+                        }
+                        if (pumpCts.IsCancellationRequested) break;
+                    }
+                }
+                finally
+                {
+                    if (Interlocked.Decrement(ref activeWorkers) == 0)
+                        resultChannel.Writer.TryComplete();
+                }
+            });
+        }
+
+        // Reorder buffer: holds out-of-order batches until the next
+        // expected sequence number is available. Bounded by the prefetch
+        // factor — workers can't run more batches ahead than the buffer
+        // allows because the result channel back-pressures when full.
+        var reorderBuffer = new Dictionary<int, TBatch>();
+        int nextExpected = 0;
+        try
+        {
+            while (true)
+            {
+                if (!TryReadNext(resultChannel.Reader, out var item)) break;
+
+                if (item.Seq == nextExpected)
+                {
+                    nextExpected++;
+                    yield return item.Batch;
+                    while (reorderBuffer.TryGetValue(nextExpected, out var pending))
+                    {
+                        reorderBuffer.Remove(nextExpected);
+                        nextExpected++;
+                        yield return pending;
+                    }
+                }
+                else
+                {
+                    reorderBuffer[item.Seq] = item.Batch;
+                }
+            }
+            // Drain leftover buffered batches in order — guards against the
+            // edge case where the channel closes between reads.
+            while (reorderBuffer.TryGetValue(nextExpected, out var pending))
+            {
+                reorderBuffer.Remove(nextExpected);
+                nextExpected++;
+                yield return pending;
+            }
+        }
+        finally
+        {
+            pumpCts.Cancel();
+            try { Task.WaitAll(workers, TimeSpan.FromSeconds(5)); } catch { /* best-effort */ }
+            try { pumpTask.Wait(TimeSpan.FromSeconds(5)); } catch { /* best-effort */ }
+            pumpCts.Dispose();
+        }
+        _epoch++;
+    }
+
+    /// <summary>
+    /// Tries to dequeue one (seq, batch) from <paramref name="reader"/>,
+    /// blocking the caller until either an item is available or the channel
+    /// is fully drained + completed. Wraps the WaitToReadAsync /
+    /// ChannelClosedException dance so the calling iterator doesn't need a
+    /// catch block (illegal alongside yield).
+    /// </summary>
+    private static bool TryReadNext(ChannelReader<(int Seq, TBatch Batch)> reader, out (int Seq, TBatch Batch) item)
+    {
+        item = default;
+        while (true)
+        {
+            bool got;
+            try { got = reader.WaitToReadAsync().AsTask().GetAwaiter().GetResult(); }
+            catch (ChannelClosedException) { return false; }
+            if (!got) return false;
+            if (reader.TryRead(out item)) return true;
+        }
+    }
+
+    private IBatchSampler ResolveBatchSampler()
+    {
+        if (_options.BatchSampler is not null) return _options.BatchSampler;
+
+        ISampler inner;
+        if (_options.Sampler is not null)
+        {
+            inner = _options.Sampler;
+        }
+        else if (_options.Shuffle)
+        {
+            inner = new RandomSampler(_dataset.Count, seed: _options.Seed);
+        }
+        else
+        {
+            inner = new SequentialSampler(_dataset.Count);
+        }
+        return new BatchSampler(inner, _options.BatchSize, _options.DropLast);
+    }
+}

--- a/src/AiDotNet.Tensors/Data/DataLoader.cs
+++ b/src/AiDotNet.Tensors/Data/DataLoader.cs
@@ -175,6 +175,17 @@ public class DataLoader<TSample, TBatch> : IEnumerable<TBatch>
             });
 
         var pumpCts = new CancellationTokenSource();
+        // Background-task exceptions need to surface to the consumer.
+        // Without this, a sampler/dataset/collate failure was silently
+        // converted into early epoch truncation: the channel completed,
+        // the reader saw end-of-stream, and the offending exception was
+        // swallowed by `try { ... } catch { /* best-effort */ }` blocks
+        // on the join. Capture the first exception (any thread, any
+        // task) atomically and rethrow it from the iterator's finally.
+        Exception? backgroundFault = null;
+        void CaptureFault(Exception ex) =>
+            Interlocked.CompareExchange(ref backgroundFault, ex, null);
+
         var pumpTask = Task.Run(async () =>
         {
             try
@@ -182,11 +193,29 @@ public class DataLoader<TSample, TBatch> : IEnumerable<TBatch>
                 int seq = 0;
                 foreach (var batch in _batchSampler.GetBatches())
                 {
-                    if (pumpCts.IsCancellationRequested) break;
-                    await jobChannel.Writer.WriteAsync((seq++, batch)).ConfigureAwait(false);
+                    // Pass pumpCts.Token so a bounded-channel back-pressure
+                    // wait is unblocked immediately on iterator disposal —
+                    // otherwise the pump deadlocks on a full channel and
+                    // the caller's finally hangs for the 5s WaitAll timeout.
+                    await jobChannel.Writer.WriteAsync((seq++, batch), pumpCts.Token).ConfigureAwait(false);
                 }
+                jobChannel.Writer.TryComplete();
             }
-            finally { jobChannel.Writer.TryComplete(); }
+            catch (OperationCanceledException) when (pumpCts.IsCancellationRequested)
+            {
+                // Cooperative cancellation — not a fault, but we still
+                // need to close the channel so workers wake up.
+                jobChannel.Writer.TryComplete();
+            }
+            catch (Exception ex)
+            {
+                CaptureFault(ex);
+                // Complete with the exception so workers reading the job
+                // channel see the failure rather than a clean EOF; that
+                // also lets the result channel pick it up if no consumer
+                // beat us to TryComplete.
+                jobChannel.Writer.TryComplete(ex);
+            }
         });
 
         var workers = new Task[_options.NumWorkers];
@@ -195,11 +224,12 @@ public class DataLoader<TSample, TBatch> : IEnumerable<TBatch>
         {
             workers[w] = Task.Run(async () =>
             {
+                Exception? localFault = null;
                 try
                 {
                     // Manual WaitToRead/TryRead loop instead of ReadAllAsync —
                     // ReadAllAsync is netstandard2.1+ and we still target net471.
-                    while (await jobChannel.Reader.WaitToReadAsync().ConfigureAwait(false))
+                    while (await jobChannel.Reader.WaitToReadAsync(pumpCts.Token).ConfigureAwait(false))
                     {
                         while (jobChannel.Reader.TryRead(out var job))
                         {
@@ -207,15 +237,34 @@ public class DataLoader<TSample, TBatch> : IEnumerable<TBatch>
                             var samples = new TSample[job.Idx.Count];
                             for (int i = 0; i < job.Idx.Count; i++) samples[i] = _dataset[job.Idx[i]];
                             var batch = _collate(samples);
-                            await resultChannel.Writer.WriteAsync((job.Seq, batch)).ConfigureAwait(false);
+                            // Pass token so a stuck WriteAsync on a full
+                            // result channel unblocks on disposal/cancel.
+                            await resultChannel.Writer.WriteAsync((job.Seq, batch), pumpCts.Token).ConfigureAwait(false);
                         }
                         if (pumpCts.IsCancellationRequested) break;
                     }
                 }
+                catch (OperationCanceledException) when (pumpCts.IsCancellationRequested) { /* shutdown */ }
+                catch (ChannelClosedException) { /* upstream completed (incl. with exception) */ }
+                catch (Exception ex)
+                {
+                    localFault = ex;
+                    CaptureFault(ex);
+                }
                 finally
                 {
                     if (Interlocked.Decrement(ref activeWorkers) == 0)
-                        resultChannel.Writer.TryComplete();
+                    {
+                        // Last worker out — complete the result channel.
+                        // If we (or any prior worker / the pump) faulted,
+                        // attach the exception so the reader surfaces it
+                        // instead of a silent end-of-stream. CompareExchange
+                        // above means the first observed fault wins; pass
+                        // that one to TryComplete.
+                        var fault = Volatile.Read(ref backgroundFault) ?? localFault;
+                        if (fault is not null) resultChannel.Writer.TryComplete(fault);
+                        else resultChannel.Writer.TryComplete();
+                    }
                 }
             });
         }
@@ -260,10 +309,22 @@ public class DataLoader<TSample, TBatch> : IEnumerable<TBatch>
         finally
         {
             pumpCts.Cancel();
-            try { Task.WaitAll(workers, TimeSpan.FromSeconds(5)); } catch { /* best-effort */ }
-            try { pumpTask.Wait(TimeSpan.FromSeconds(5)); } catch { /* best-effort */ }
+            // Wait for background tasks to drain — bounded by 5s so a
+            // wedged worker can't hang the consumer indefinitely. The
+            // catch swallows wait/aggregation exceptions because the
+            // first-fault is already captured in `backgroundFault` and
+            // any per-task TaskCanceledException is expected on Cancel.
+            try { Task.WaitAll(workers, TimeSpan.FromSeconds(5)); } catch { /* aggregated below */ }
+            try { pumpTask.Wait(TimeSpan.FromSeconds(5)); } catch { /* aggregated below */ }
             pumpCts.Dispose();
         }
+        // Surface the first background fault — pump or worker — if any.
+        // Without this, a dataset/collate/sampler exception was silently
+        // converted into early epoch truncation. Done OUTSIDE the
+        // try/finally so the throw isn't immediately re-caught.
+        if (backgroundFault is not null)
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo
+                .Capture(backgroundFault).Throw();
         _epoch++;
     }
 

--- a/src/AiDotNet.Tensors/Data/DataPipes.cs
+++ b/src/AiDotNet.Tensors/Data/DataPipes.cs
@@ -277,58 +277,40 @@ public static class DataPipeExtensions
     {
         public static IIterableDataset<TSample>[] Build(IIterableDataset<TSample> src, int branches, Func<TSample, int> route)
         {
-            // Shared enumerator + per-branch queue. Each branch dataset's
-            // enumerator pulls from the upstream until its queue has a value.
-            // Concurrent-safe via a lock — multi-threaded consumption of the
-            // returned datasets is supported.
-            var queues = new Queue<TSample>[branches];
-            for (int i = 0; i < branches; i++) queues[i] = new Queue<TSample>();
-            var gate = new object();
-            IEnumerator<TSample>? upstream = null;
-            bool drained = false;
-
-            IEnumerator<TSample> Upstream()
-            {
-                upstream ??= src.GetEnumerator();
-                return upstream;
-            }
-
-            void PumpUntil(int branch)
-            {
-                lock (gate)
-                {
-                    while (queues[branch].Count == 0 && !drained)
-                    {
-                        var e = Upstream();
-                        if (!e.MoveNext()) { drained = true; e.Dispose(); break; }
-                        int target = route(e.Current);
-                        if ((uint)target >= (uint)branches)
-                            throw new InvalidOperationException(
-                                $"Demultiplex route returned {target} which is outside [0, {branches}).");
-                        queues[target].Enqueue(e.Current);
-                    }
-                }
-            }
-
+            // Each returned dataset enumerates the upstream independently
+            // and yields only items routed to its branch index. Closing
+            // `upstream` / `queues` / `drained` over Build (the previous
+            // design) made every branch share one cursor, so a second
+            // GetEnumerator() on ANY branch resumed from the previous
+            // pass's state instead of starting fresh — which violates
+            // the IIterableDataset contract and silently dropped data on
+            // multi-epoch reuse.
+            //
+            // Cost: N branches × full upstream pass when each branch is
+            // consumed in turn. The shared-pump optimisation is dropped
+            // because correctness across epochs is non-negotiable; if a
+            // caller wants single-pass demultiplex, they should consume
+            // the upstream once and route into per-branch buffers
+            // themselves.
             var datasets = new IIterableDataset<TSample>[branches];
             for (int i = 0; i < branches; i++)
             {
                 int branchId = i;
-                datasets[i] = new InlineIterable<TSample>(() => Drain(branchId, queues, gate, PumpUntil));
+                datasets[i] = new InlineIterable<TSample>(() => RouteFilter(branchId, src, route, branches));
             }
             return datasets;
         }
 
-        private static IEnumerator<TSample> Drain(int branch, Queue<TSample>[] queues, object gate, Action<int> pump)
+        private static IEnumerator<TSample> RouteFilter(int branch, IIterableDataset<TSample> src, Func<TSample, int> route, int branches)
         {
-            while (true)
+            using var e = src.GetEnumerator();
+            while (e.MoveNext())
             {
-                pump(branch);
-                lock (gate)
-                {
-                    if (queues[branch].Count == 0) yield break;
-                    yield return queues[branch].Dequeue();
-                }
+                int target = route(e.Current);
+                if ((uint)target >= (uint)branches)
+                    throw new InvalidOperationException(
+                        $"Demultiplex route returned {target} which is outside [0, {branches}).");
+                if (target == branch) yield return e.Current;
             }
         }
     }

--- a/src/AiDotNet.Tensors/Data/DataPipes.cs
+++ b/src/AiDotNet.Tensors/Data/DataPipes.cs
@@ -1,0 +1,364 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+
+namespace AiDotNet.Tensors.Data;
+
+/// <summary>
+/// Functional, composable data-stream operators inspired by
+/// <c>torchdata</c>. Each method takes an upstream
+/// <see cref="IIterableDataset{TSample}"/> and returns a new dataset whose
+/// enumeration applies the requested transformation lazily.
+///
+/// <para>Lazy means: nothing is fetched / computed until the consumer
+/// iterates, and the transformation chain composes without materializing
+/// intermediate lists. A pipeline of <c>.Map(...).Filter(...).Batch(...)</c>
+/// reads from the upstream once per output batch.</para>
+///
+/// <para>Equivalent surface to PyTorch's <c>IterDataPipe</c> family
+/// (<c>.map</c>, <c>.filter</c>, <c>.batch</c>, <c>.shuffle</c>,
+/// <c>.bucketbatch</c>, <c>.zip</c>, <c>.concat</c>, <c>.mux</c>,
+/// <c>.demultiplex</c>, <c>.sharding_filter</c>).</para>
+/// </summary>
+public static class DataPipeExtensions
+{
+    /// <summary>Applies <paramref name="fn"/> to each upstream sample and
+    /// emits the result. Composes — chained <c>.Map</c> calls fold without
+    /// materializing.</summary>
+    public static IIterableDataset<TOut> Map<TIn, TOut>(
+        this IIterableDataset<TIn> source, Func<TIn, TOut> fn)
+        => new MapPipe<TIn, TOut>(source, fn);
+
+    /// <summary>Drops samples where <paramref name="predicate"/> returns
+    /// false. Lazy.</summary>
+    public static IIterableDataset<TSample> Filter<TSample>(
+        this IIterableDataset<TSample> source, Func<TSample, bool> predicate)
+        => new FilterPipe<TSample>(source, predicate);
+
+    /// <summary>Groups samples into fixed-size lists. The trailing partial
+    /// batch is emitted unless <paramref name="dropLast"/> is true.</summary>
+    public static IIterableDataset<IReadOnlyList<TSample>> Batch<TSample>(
+        this IIterableDataset<TSample> source, int batchSize, bool dropLast = false)
+        => new BatchPipe<TSample>(source, batchSize, dropLast);
+
+    /// <summary>Reservoir-shuffles upstream samples through a fixed-size
+    /// buffer. Larger <paramref name="bufferSize"/> ⇒ better mixing,
+    /// higher memory. Same algorithm as
+    /// <c>torch.utils.data.IterDataPipe.shuffle(buffer_size=...)</c>.</summary>
+    public static IIterableDataset<TSample> Shuffle<TSample>(
+        this IIterableDataset<TSample> source, int bufferSize, int? seed = null)
+        => new ShufflePipe<TSample>(source, bufferSize, seed);
+
+    /// <summary>Bucket-batching for variable-length sequences: groups
+    /// samples by <paramref name="key"/> into a small number of buckets
+    /// then emits batches from each bucket as it fills. Reduces padding
+    /// overhead when the cost is dominated by max-length-per-batch.</summary>
+    public static IIterableDataset<IReadOnlyList<TSample>> BucketBatch<TSample>(
+        this IIterableDataset<TSample> source, int batchSize,
+        int bucketCount, Func<TSample, int> key, int? bufferSize = null)
+        => new BucketBatchPipe<TSample>(source, batchSize, bucketCount, key,
+                                         bufferSize ?? batchSize * bucketCount * 4);
+
+    /// <summary>Yields tuples by zipping two upstream streams element-wise.
+    /// Stops at the shorter stream.</summary>
+    public static IIterableDataset<(TA, TB)> Zip<TA, TB>(
+        this IIterableDataset<TA> a, IIterableDataset<TB> b)
+        => new ZipPipe<TA, TB>(a, b);
+
+    /// <summary>Concatenates streams end-to-end (delegates to
+    /// <see cref="ChainDataset{TSample}"/>).</summary>
+    public static IIterableDataset<TSample> Concat<TSample>(
+        this IIterableDataset<TSample> first, IIterableDataset<TSample> second)
+        => new ChainDataset<TSample>(new[] { first, second });
+
+    /// <summary>Round-robin multiplex — emits one sample from each upstream
+    /// in turn. Stops when ANY upstream is exhausted.</summary>
+    public static IIterableDataset<TSample> Mux<TSample>(
+        params IIterableDataset<TSample>[] sources)
+        => new MuxPipe<TSample>(sources);
+
+    /// <summary>Demultiplex — splits one upstream into N sub-streams using
+    /// <paramref name="route"/> to pick the destination index per sample.
+    /// Returns an array of <c>N</c> downstream datasets that share the
+    /// upstream enumeration; consume them concurrently to avoid one
+    /// branch starving the others.</summary>
+    public static IIterableDataset<TSample>[] Demultiplex<TSample>(
+        this IIterableDataset<TSample> source, int branches, Func<TSample, int> route)
+    {
+        if (branches < 1) throw new ArgumentOutOfRangeException(nameof(branches));
+        return DemultiplexPipe<TSample>.Build(source, branches, route);
+    }
+
+    /// <summary>Sharding filter — yields every <c>worldSize</c>-th sample
+    /// starting from <paramref name="rank"/>. Used inside multi-worker
+    /// pipelines so each worker sees a disjoint shard of the upstream.</summary>
+    public static IIterableDataset<TSample> ShardingFilter<TSample>(
+        this IIterableDataset<TSample> source, int rank, int worldSize)
+        => new ShardingFilterPipe<TSample>(source, rank, worldSize);
+
+    // ────────────────────────────────────────────────────────────────────
+    //  Pipe implementations — kept private to this file. Each is a tiny
+    //  adapter over the upstream's IEnumerator; lazy semantics fall out for
+    //  free from yield-return.
+    // ────────────────────────────────────────────────────────────────────
+
+    private sealed class MapPipe<TIn, TOut> : IIterableDataset<TOut>
+    {
+        private readonly IIterableDataset<TIn> _src;
+        private readonly Func<TIn, TOut> _fn;
+        public MapPipe(IIterableDataset<TIn> src, Func<TIn, TOut> fn) { _src = src; _fn = fn; }
+        public IEnumerator<TOut> GetEnumerator()
+        {
+            using var e = _src.GetEnumerator();
+            while (e.MoveNext()) yield return _fn(e.Current);
+        }
+    }
+
+    private sealed class FilterPipe<TSample> : IIterableDataset<TSample>
+    {
+        private readonly IIterableDataset<TSample> _src;
+        private readonly Func<TSample, bool> _p;
+        public FilterPipe(IIterableDataset<TSample> src, Func<TSample, bool> p) { _src = src; _p = p; }
+        public IEnumerator<TSample> GetEnumerator()
+        {
+            using var e = _src.GetEnumerator();
+            while (e.MoveNext()) if (_p(e.Current)) yield return e.Current;
+        }
+    }
+
+    private sealed class BatchPipe<TSample> : IIterableDataset<IReadOnlyList<TSample>>
+    {
+        private readonly IIterableDataset<TSample> _src;
+        private readonly int _batch;
+        private readonly bool _dropLast;
+        public BatchPipe(IIterableDataset<TSample> src, int batch, bool dropLast)
+        {
+            if (batch < 1) throw new ArgumentOutOfRangeException(nameof(batch));
+            _src = src; _batch = batch; _dropLast = dropLast;
+        }
+        public IEnumerator<IReadOnlyList<TSample>> GetEnumerator()
+        {
+            var bucket = new List<TSample>(_batch);
+            using var e = _src.GetEnumerator();
+            while (e.MoveNext())
+            {
+                bucket.Add(e.Current);
+                if (bucket.Count == _batch)
+                {
+                    yield return bucket;
+                    bucket = new List<TSample>(_batch);
+                }
+            }
+            if (bucket.Count > 0 && !_dropLast) yield return bucket;
+        }
+    }
+
+    private sealed class ShufflePipe<TSample> : IIterableDataset<TSample>
+    {
+        private readonly IIterableDataset<TSample> _src;
+        private readonly int _bufferSize;
+        private readonly int? _seed;
+        public ShufflePipe(IIterableDataset<TSample> src, int bufferSize, int? seed)
+        {
+            if (bufferSize < 1) throw new ArgumentOutOfRangeException(nameof(bufferSize));
+            _src = src; _bufferSize = bufferSize; _seed = seed;
+        }
+        public IEnumerator<TSample> GetEnumerator()
+        {
+            var rng = _seed.HasValue ? new Random(_seed.Value) : new Random();
+            var buffer = new List<TSample>(_bufferSize);
+            using var e = _src.GetEnumerator();
+            // Prime the buffer.
+            while (buffer.Count < _bufferSize && e.MoveNext()) buffer.Add(e.Current);
+            // Steady-state: pop a random buffer slot, replace from upstream.
+            while (e.MoveNext())
+            {
+                int idx = rng.Next(buffer.Count);
+                yield return buffer[idx];
+                buffer[idx] = e.Current;
+            }
+            // Drain — random remaining order.
+            while (buffer.Count > 0)
+            {
+                int idx = rng.Next(buffer.Count);
+                yield return buffer[idx];
+                buffer[idx] = buffer[buffer.Count - 1];
+                buffer.RemoveAt(buffer.Count - 1);
+            }
+        }
+    }
+
+    private sealed class BucketBatchPipe<TSample> : IIterableDataset<IReadOnlyList<TSample>>
+    {
+        private readonly IIterableDataset<TSample> _src;
+        private readonly int _batch;
+        private readonly int _bucketCount;
+        private readonly Func<TSample, int> _key;
+        private readonly int _bufferSize;
+        public BucketBatchPipe(IIterableDataset<TSample> src, int batch, int bucketCount, Func<TSample, int> key, int bufferSize)
+        {
+            if (batch < 1) throw new ArgumentOutOfRangeException(nameof(batch));
+            if (bucketCount < 1) throw new ArgumentOutOfRangeException(nameof(bucketCount));
+            _src = src; _batch = batch; _bucketCount = bucketCount; _key = key; _bufferSize = bufferSize;
+        }
+        public IEnumerator<IReadOnlyList<TSample>> GetEnumerator()
+        {
+            // Fill a buffer up to bufferSize, sort by key, slice into buckets,
+            // emit batches from each bucket. Repeat until the upstream drains.
+            using var e = _src.GetEnumerator();
+            var buf = new List<TSample>(_bufferSize);
+            while (true)
+            {
+                buf.Clear();
+                while (buf.Count < _bufferSize && e.MoveNext()) buf.Add(e.Current);
+                if (buf.Count == 0) yield break;
+
+                buf.Sort((a, b) => _key(a).CompareTo(_key(b)));
+                int per = (buf.Count + _bucketCount - 1) / _bucketCount;
+                for (int b = 0; b < _bucketCount; b++)
+                {
+                    int from = b * per;
+                    if (from >= buf.Count) break;
+                    int to = Math.Min(from + per, buf.Count);
+                    for (int i = from; i < to; i += _batch)
+                    {
+                        int len = Math.Min(_batch, to - i);
+                        var batch = new List<TSample>(len);
+                        for (int j = 0; j < len; j++) batch.Add(buf[i + j]);
+                        yield return batch;
+                    }
+                }
+            }
+        }
+    }
+
+    private sealed class ZipPipe<TA, TB> : IIterableDataset<(TA, TB)>
+    {
+        private readonly IIterableDataset<TA> _a;
+        private readonly IIterableDataset<TB> _b;
+        public ZipPipe(IIterableDataset<TA> a, IIterableDataset<TB> b) { _a = a; _b = b; }
+        public IEnumerator<(TA, TB)> GetEnumerator()
+        {
+            using var ea = _a.GetEnumerator();
+            using var eb = _b.GetEnumerator();
+            while (ea.MoveNext() && eb.MoveNext()) yield return (ea.Current, eb.Current);
+        }
+    }
+
+    private sealed class MuxPipe<TSample> : IIterableDataset<TSample>
+    {
+        private readonly IIterableDataset<TSample>[] _srcs;
+        public MuxPipe(IIterableDataset<TSample>[] srcs)
+        {
+            if (srcs is null || srcs.Length == 0) throw new ArgumentException("Mux requires at least one source.");
+            _srcs = srcs;
+        }
+        public IEnumerator<TSample> GetEnumerator()
+        {
+            var enumerators = new IEnumerator<TSample>[_srcs.Length];
+            for (int i = 0; i < _srcs.Length; i++) enumerators[i] = _srcs[i].GetEnumerator();
+            try
+            {
+                while (true)
+                {
+                    for (int i = 0; i < enumerators.Length; i++)
+                    {
+                        if (!enumerators[i].MoveNext()) yield break;
+                        yield return enumerators[i].Current;
+                    }
+                }
+            }
+            finally { foreach (var e in enumerators) e.Dispose(); }
+        }
+    }
+
+    private sealed class DemultiplexPipe<TSample>
+    {
+        public static IIterableDataset<TSample>[] Build(IIterableDataset<TSample> src, int branches, Func<TSample, int> route)
+        {
+            // Shared enumerator + per-branch queue. Each branch dataset's
+            // enumerator pulls from the upstream until its queue has a value.
+            // Concurrent-safe via a lock — multi-threaded consumption of the
+            // returned datasets is supported.
+            var queues = new Queue<TSample>[branches];
+            for (int i = 0; i < branches; i++) queues[i] = new Queue<TSample>();
+            var gate = new object();
+            IEnumerator<TSample>? upstream = null;
+            bool drained = false;
+
+            IEnumerator<TSample> Upstream()
+            {
+                upstream ??= src.GetEnumerator();
+                return upstream;
+            }
+
+            void PumpUntil(int branch)
+            {
+                lock (gate)
+                {
+                    while (queues[branch].Count == 0 && !drained)
+                    {
+                        var e = Upstream();
+                        if (!e.MoveNext()) { drained = true; e.Dispose(); break; }
+                        int target = route(e.Current);
+                        if ((uint)target >= (uint)branches)
+                            throw new InvalidOperationException(
+                                $"Demultiplex route returned {target} which is outside [0, {branches}).");
+                        queues[target].Enqueue(e.Current);
+                    }
+                }
+            }
+
+            var datasets = new IIterableDataset<TSample>[branches];
+            for (int i = 0; i < branches; i++)
+            {
+                int branchId = i;
+                datasets[i] = new InlineIterable<TSample>(() => Drain(branchId, queues, gate, PumpUntil));
+            }
+            return datasets;
+        }
+
+        private static IEnumerator<TSample> Drain(int branch, Queue<TSample>[] queues, object gate, Action<int> pump)
+        {
+            while (true)
+            {
+                pump(branch);
+                lock (gate)
+                {
+                    if (queues[branch].Count == 0) yield break;
+                    yield return queues[branch].Dequeue();
+                }
+            }
+        }
+    }
+
+    private sealed class InlineIterable<TSample> : IIterableDataset<TSample>
+    {
+        private readonly Func<IEnumerator<TSample>> _factory;
+        public InlineIterable(Func<IEnumerator<TSample>> factory) { _factory = factory; }
+        public IEnumerator<TSample> GetEnumerator() => _factory();
+    }
+
+    private sealed class ShardingFilterPipe<TSample> : IIterableDataset<TSample>
+    {
+        private readonly IIterableDataset<TSample> _src;
+        private readonly int _rank, _world;
+        public ShardingFilterPipe(IIterableDataset<TSample> src, int rank, int world)
+        {
+            if (world < 1) throw new ArgumentOutOfRangeException(nameof(world));
+            if (rank < 0 || rank >= world) throw new ArgumentOutOfRangeException(nameof(rank));
+            _src = src; _rank = rank; _world = world;
+        }
+        public IEnumerator<TSample> GetEnumerator()
+        {
+            using var e = _src.GetEnumerator();
+            int i = 0;
+            while (e.MoveNext())
+            {
+                if (i % _world == _rank) yield return e.Current;
+                i++;
+            }
+        }
+    }
+}

--- a/src/AiDotNet.Tensors/Data/Datasets.cs
+++ b/src/AiDotNet.Tensors/Data/Datasets.cs
@@ -32,9 +32,21 @@ public sealed class TensorDataset<T> : IDataset<Tensor<T>[]>
     {
         if (tensors is null || tensors.Length == 0)
             throw new ArgumentException("TensorDataset requires at least one tensor.", nameof(tensors));
+        // Reject scalars (rank 0) explicitly — without this, indexing
+        // `_shape[0]` would throw IndexOutOfRangeException with no
+        // diagnostic context. TensorDataset requires a leading sample
+        // axis on every member tensor by definition.
+        if (tensors[0]._shape.Length == 0)
+            throw new ArgumentException(
+                "TensorDataset requires tensors with at least one dimension; tensor 0 is rank 0.",
+                nameof(tensors));
         int n = tensors[0]._shape[0];
         for (int i = 1; i < tensors.Length; i++)
         {
+            if (tensors[i]._shape.Length == 0)
+                throw new ArgumentException(
+                    $"TensorDataset requires tensors with at least one dimension; tensor {i} is rank 0.",
+                    nameof(tensors));
             if (tensors[i]._shape[0] != n)
                 throw new ArgumentException(
                     $"TensorDataset tensors must share their leading dimension. " +

--- a/src/AiDotNet.Tensors/Data/Datasets.cs
+++ b/src/AiDotNet.Tensors/Data/Datasets.cs
@@ -1,0 +1,291 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Data;
+
+/// <summary>
+/// Wraps one or more <see cref="Tensor{T}"/>s as a map-style dataset. Item N
+/// is the tuple of element N from each tensor's leading axis. Direct PyTorch
+/// equivalent: <c>torch.utils.data.TensorDataset(*tensors)</c>.
+///
+/// <para>Used when the entire dataset already fits in memory as tensors —
+/// canonical example: a small classification problem where features and
+/// labels are loaded once at the start of training. The DataLoader drives
+/// random access via the per-index <see cref="this[int]"/> accessor.</para>
+/// </summary>
+public sealed class TensorDataset<T> : IDataset<Tensor<T>[]>
+{
+    private readonly Tensor<T>[] _tensors;
+    private readonly int _length;
+
+    /// <summary>
+    /// Constructs a dataset from <paramref name="tensors"/>. All tensors must
+    /// share the same leading-axis length (the sample count). Empty array is
+    /// rejected — a zero-tensor dataset would have no shape to compute the
+    /// per-sample type from.
+    /// </summary>
+    public TensorDataset(params Tensor<T>[] tensors)
+    {
+        if (tensors is null || tensors.Length == 0)
+            throw new ArgumentException("TensorDataset requires at least one tensor.", nameof(tensors));
+        int n = tensors[0]._shape[0];
+        for (int i = 1; i < tensors.Length; i++)
+        {
+            if (tensors[i]._shape[0] != n)
+                throw new ArgumentException(
+                    $"TensorDataset tensors must share their leading dimension. " +
+                    $"Tensor 0 has {n}, tensor {i} has {tensors[i]._shape[0]}.");
+        }
+        _tensors = tensors;
+        _length = n;
+    }
+
+    /// <inheritdoc/>
+    public int Count => _length;
+
+    /// <summary>
+    /// Returns the index-th slice of every wrapped tensor. The returned
+    /// <see cref="Tensor{T}"/> array has length equal to the constructor's
+    /// tensor count; each element is a rank-(R-1) slice along axis 0.
+    /// </summary>
+    public Tensor<T>[] this[int index]
+    {
+        get
+        {
+            if ((uint)index >= (uint)_length)
+                throw new ArgumentOutOfRangeException(nameof(index));
+            var sample = new Tensor<T>[_tensors.Length];
+            for (int i = 0; i < _tensors.Length; i++)
+                sample[i] = _tensors[i].Slice(0, index, index + 1).Squeeze(0);
+            return sample;
+        }
+    }
+}
+
+/// <summary>
+/// View over a parent dataset that exposes only a fixed subset of indices.
+/// Used by <see cref="DatasetExtensions.RandomSplit{T}"/> to produce
+/// non-overlapping train/val/test partitions; can also be constructed
+/// directly to drop bad samples without copying the underlying storage.
+/// PyTorch parity: <c>torch.utils.data.Subset</c>.
+/// </summary>
+public sealed class Subset<TSample> : IDataset<TSample>
+{
+    private readonly IDataset<TSample> _parent;
+    private readonly IReadOnlyList<int> _indices;
+
+    /// <summary>Constructs a view over <paramref name="parent"/> at the
+    /// positions in <paramref name="indices"/>. Indices are not validated
+    /// eagerly — out-of-range entries surface as <see cref="ArgumentOutOfRangeException"/>
+    /// from the parent on access.</summary>
+    public Subset(IDataset<TSample> parent, IReadOnlyList<int> indices)
+    {
+        _parent = parent ?? throw new ArgumentNullException(nameof(parent));
+        _indices = indices ?? throw new ArgumentNullException(nameof(indices));
+    }
+
+    /// <inheritdoc/>
+    public int Count => _indices.Count;
+
+    /// <inheritdoc/>
+    public TSample this[int index] => _parent[_indices[index]];
+}
+
+/// <summary>
+/// Concatenates multiple map-style datasets end-to-end. Index 0 maps to
+/// dataset[0][0]; the boundary between datasets is computed via prefix sums
+/// over per-dataset counts. PyTorch parity: <c>torch.utils.data.ConcatDataset</c>.
+/// </summary>
+public sealed class ConcatDataset<TSample> : IDataset<TSample>
+{
+    private readonly IDataset<TSample>[] _datasets;
+    private readonly int[] _cumulativeCounts; // length = datasets.Length, cumulativeCounts[i] = total count up to and including dataset i
+
+    /// <summary>Constructs a concatenated view over <paramref name="datasets"/>.</summary>
+    public ConcatDataset(params IDataset<TSample>[] datasets)
+    {
+        if (datasets is null || datasets.Length == 0)
+            throw new ArgumentException("ConcatDataset requires at least one dataset.", nameof(datasets));
+        _datasets = datasets;
+        _cumulativeCounts = new int[datasets.Length];
+        int running = 0;
+        for (int i = 0; i < datasets.Length; i++)
+        {
+            running += datasets[i].Count;
+            _cumulativeCounts[i] = running;
+        }
+    }
+
+    /// <inheritdoc/>
+    public int Count => _cumulativeCounts[_cumulativeCounts.Length - 1];
+
+    /// <inheritdoc/>
+    public TSample this[int index]
+    {
+        get
+        {
+            if ((uint)index >= (uint)Count)
+                throw new ArgumentOutOfRangeException(nameof(index));
+            // Linear scan beats binary search until ~16 partitions; the
+            // common case is 2-3 (train/val/test) so the simple loop wins.
+            int dsIdx = 0;
+            while (index >= _cumulativeCounts[dsIdx]) dsIdx++;
+            int local = dsIdx == 0 ? index : index - _cumulativeCounts[dsIdx - 1];
+            return _datasets[dsIdx][local];
+        }
+    }
+}
+
+/// <summary>
+/// Concatenates iterable datasets — emits all samples from the first, then
+/// all from the second, etc. Used for streaming pipelines where multiple
+/// upstream feeds share a downstream training loop. PyTorch parity:
+/// <c>torch.utils.data.ChainDataset</c>.
+/// </summary>
+public sealed class ChainDataset<TSample> : IIterableDataset<TSample>
+{
+    private readonly IEnumerable<IIterableDataset<TSample>> _datasets;
+
+    /// <summary>Constructs a chain over <paramref name="datasets"/>.</summary>
+    public ChainDataset(IEnumerable<IIterableDataset<TSample>> datasets)
+    {
+        _datasets = datasets ?? throw new ArgumentNullException(nameof(datasets));
+    }
+
+    /// <inheritdoc/>
+    public IEnumerator<TSample> GetEnumerator()
+    {
+        foreach (var ds in _datasets)
+        {
+            using var e = ds.GetEnumerator();
+            while (e.MoveNext()) yield return e.Current;
+        }
+    }
+}
+
+/// <summary>
+/// LRU-cached view over a (typically expensive-to-decode) dataset. Used for
+/// pipelines where each sample costs significant CPU / I/O to materialize
+/// (image decode + augment, audio resample, JSON parse) and the working set
+/// fits in memory. Cache hits skip the parent's
+/// <see cref="IDataset{TSample}.this[int]"/> entirely.
+///
+/// <para>The implementation is a doubly-linked-list LRU keyed by sample
+/// index. Get is O(1) on hit (dict lookup + list head splice) and O(1) on
+/// miss (parent fetch + list head insert + tail eviction). All methods are
+/// thread-safe — multi-worker loaders share the cache across worker threads.</para>
+/// </summary>
+public sealed class CachedDataset<TSample> : IDataset<TSample>
+{
+    private readonly IDataset<TSample> _parent;
+    private readonly int _capacity;
+    private readonly LinkedList<(int Key, TSample Value)> _lru = new();
+    private readonly Dictionary<int, LinkedListNode<(int Key, TSample Value)>> _index = new();
+    private readonly object _gate = new();
+
+    /// <summary>Constructs a cache wrapping <paramref name="parent"/> with
+    /// at most <paramref name="capacity"/> samples retained.</summary>
+    public CachedDataset(IDataset<TSample> parent, int capacity)
+    {
+        if (capacity < 1) throw new ArgumentOutOfRangeException(nameof(capacity), "Capacity must be at least 1.");
+        _parent = parent ?? throw new ArgumentNullException(nameof(parent));
+        _capacity = capacity;
+    }
+
+    /// <inheritdoc/>
+    public int Count => _parent.Count;
+
+    /// <inheritdoc/>
+    public TSample this[int index]
+    {
+        get
+        {
+            lock (_gate)
+            {
+                if (_index.TryGetValue(index, out var node))
+                {
+                    // LRU touch — move to head.
+                    _lru.Remove(node);
+                    _lru.AddFirst(node);
+                    return node.Value.Value;
+                }
+            }
+
+            // Miss — parent fetch outside the gate so cold loads don't
+            // block other readers' hits. Re-check after the fetch in case
+            // another thread filled the slot meanwhile.
+            var fresh = _parent[index];
+            lock (_gate)
+            {
+                if (_index.TryGetValue(index, out var existing))
+                    return existing.Value.Value;
+
+                var node = new LinkedListNode<(int, TSample)>((index, fresh));
+                _lru.AddFirst(node);
+                _index[index] = node;
+                if (_index.Count > _capacity)
+                {
+                    var tail = _lru.Last!;
+                    _lru.RemoveLast();
+                    _index.Remove(tail.Value.Key);
+                }
+                return fresh;
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Convenience helpers over <see cref="IDataset{TSample}"/>. RandomSplit is
+/// the headline — produces non-overlapping subsets that together partition
+/// the parent's index space. PyTorch parity:
+/// <c>torch.utils.data.random_split</c>.
+/// </summary>
+public static class DatasetExtensions
+{
+    /// <summary>
+    /// Splits <paramref name="dataset"/> into <paramref name="lengths"/>-sized
+    /// disjoint subsets. The lengths must sum to <paramref name="dataset"/>.
+    /// <see cref="IDataset{TSample}.Count"/>; a deterministic shuffle (seeded
+    /// from <paramref name="seed"/>) decides the partition.
+    /// </summary>
+    public static Subset<TSample>[] RandomSplit<TSample>(this IDataset<TSample> dataset, int[] lengths, int? seed = null)
+    {
+        if (dataset is null) throw new ArgumentNullException(nameof(dataset));
+        if (lengths is null || lengths.Length == 0) throw new ArgumentException("Lengths is required.", nameof(lengths));
+        long sum = 0;
+        foreach (var l in lengths)
+        {
+            if (l < 0) throw new ArgumentException("Lengths must be non-negative.", nameof(lengths));
+            sum += l;
+        }
+        if (sum != dataset.Count)
+            throw new ArgumentException(
+                $"Sum of lengths ({sum}) must equal dataset count ({dataset.Count}).", nameof(lengths));
+
+        var perm = new int[dataset.Count];
+        for (int i = 0; i < perm.Length; i++) perm[i] = i;
+        var rng = seed is null ? new Random() : new Random(seed.Value);
+        // Fisher-Yates.
+        for (int i = perm.Length - 1; i > 0; i--)
+        {
+            int j = rng.Next(i + 1);
+            (perm[i], perm[j]) = (perm[j], perm[i]);
+        }
+
+        var splits = new Subset<TSample>[lengths.Length];
+        int offset = 0;
+        for (int i = 0; i < lengths.Length; i++)
+        {
+            var slice = new int[lengths[i]];
+            Array.Copy(perm, offset, slice, 0, lengths[i]);
+            splits[i] = new Subset<TSample>(dataset, slice);
+            offset += lengths[i];
+        }
+        return splits;
+    }
+}

--- a/src/AiDotNet.Tensors/Data/IDataset.cs
+++ b/src/AiDotNet.Tensors/Data/IDataset.cs
@@ -1,0 +1,113 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System.Collections.Generic;
+
+namespace AiDotNet.Tensors.Data;
+
+/// <summary>
+/// Map-style dataset — supports indexed lookup. Mirrors PyTorch's
+/// <c>torch.utils.data.Dataset</c>: implementations expose a known
+/// <see cref="Count"/> and a per-index <see cref="this[int]"/> accessor that
+/// returns one sample. Samplers iterate over the index space and the
+/// <see cref="DataLoader{TSample, TBatch}"/> assembles batches.
+///
+/// <para>Use this when:</para>
+/// <list type="bullet">
+///   <item>The full dataset size is known up-front (file count, row count).</item>
+///   <item>Random access is needed (most ML training pipelines — shuffling,
+///     subsetting, k-fold splits all depend on indexed access).</item>
+/// </list>
+///
+/// <para>For unbounded streams (e.g. log tail, network socket), use
+/// <see cref="IIterableDataset{TSample}"/> instead.</para>
+/// </summary>
+/// <typeparam name="TSample">The shape of one sample. Often a tuple of
+/// <c>(Tensor&lt;float&gt; input, int label)</c> or a custom record type.</typeparam>
+public interface IDataset<out TSample>
+{
+    /// <summary>Total number of samples. Must remain stable for the dataset's
+    /// lifetime — the sampler caches it and a mid-iteration change would
+    /// produce out-of-range indices.</summary>
+    int Count { get; }
+
+    /// <summary>Returns the sample at <paramref name="index"/>. Implementations
+    /// should be thread-safe — multi-worker loaders call this from
+    /// <see cref="System.Threading.Tasks.Task"/>-pool threads in parallel.</summary>
+    /// <exception cref="System.ArgumentOutOfRangeException">If
+    /// <paramref name="index"/> is outside <c>[0, Count)</c>.</exception>
+    TSample this[int index] { get; }
+}
+
+/// <summary>
+/// Stream-style dataset — produces samples from a source whose total length
+/// may be unknown or unbounded (network feed, log file being written,
+/// streaming Kafka topic). Mirrors PyTorch's
+/// <c>torch.utils.data.IterableDataset</c>.
+///
+/// <para>The <see cref="DataLoader{TSample, TBatch}"/> drives an iterable
+/// dataset by enumerating it and grouping into batches; samplers do not
+/// participate (PyTorch's contract — there is no index space to sample).</para>
+/// </summary>
+public interface IIterableDataset<out TSample>
+{
+    /// <summary>Returns an enumerator over the stream's samples. Each call
+    /// produces a fresh enumerator — implementations should support
+    /// re-iteration (the loader calls this once per epoch).</summary>
+    IEnumerator<TSample> GetEnumerator();
+}
+
+/// <summary>
+/// Sampler — yields a sequence of indices into an
+/// <see cref="IDataset{TSample}"/>. The DataLoader composes a sampler with a
+/// batch size to drive the per-iteration index sequence.
+///
+/// <para>Implementations:</para>
+/// <list type="bullet">
+///   <item><see cref="Samplers.SequentialSampler"/> — 0..N-1 in order.</item>
+///   <item><see cref="Samplers.RandomSampler"/> — uniform random permutation.</item>
+///   <item><see cref="Samplers.WeightedRandomSampler"/> — weighted with replacement.</item>
+///   <item><see cref="Samplers.SubsetRandomSampler"/> — random over a fixed subset.</item>
+///   <item><see cref="Samplers.BatchSampler"/> — wraps another sampler and
+///     yields batches of indices instead of individual indices.</item>
+///   <item><see cref="Samplers.DistributedSampler"/> — splits indices across
+///     ranks for distributed training.</item>
+/// </list>
+/// </summary>
+public interface ISampler
+{
+    /// <summary>Number of indices the sampler will yield in one full pass.
+    /// Used by the DataLoader to compute batch counts and progress bars.</summary>
+    int Count { get; }
+
+    /// <summary>Returns the index sequence for one epoch. Each call should
+    /// produce a fresh sequence — the DataLoader calls this once per epoch
+    /// and a stateful sampler (<see cref="Samplers.RandomSampler"/>) reseeds
+    /// here to give the next epoch a different shuffle.</summary>
+    IEnumerable<int> GetIndices();
+
+    /// <summary>
+    /// Notifies the sampler that we are starting <paramref name="epoch"/>.
+    /// Distributed and shuffled samplers fold the epoch into their seed so
+    /// the per-epoch shuffle is deterministic across ranks.
+    /// </summary>
+    void SetEpoch(int epoch);
+}
+
+/// <summary>
+/// Sampler that yields batches (lists of indices) directly. Used for
+/// bucket-batching and other patterns where the batch composition itself is
+/// the sampling decision (variable-length sequences grouped by length, etc).
+/// </summary>
+public interface IBatchSampler
+{
+    /// <summary>Number of batches in one full pass.</summary>
+    int Count { get; }
+
+    /// <summary>Returns the per-batch index sequence for one epoch. Each
+    /// inner <see cref="IReadOnlyList{T}"/> is a batch; the loader wraps each
+    /// batch's samples through the collate function.</summary>
+    IEnumerable<IReadOnlyList<int>> GetBatches();
+
+    /// <summary>Sets the epoch — see <see cref="ISampler.SetEpoch"/>.</summary>
+    void SetEpoch(int epoch);
+}

--- a/src/AiDotNet.Tensors/Data/Samplers.cs
+++ b/src/AiDotNet.Tensors/Data/Samplers.cs
@@ -40,6 +40,14 @@ public sealed class SequentialSampler : ISampler
 /// </summary>
 public sealed class RandomSampler : ISampler
 {
+    // Source dataset size (the upper bound for replacement draws). This
+    // MUST be tracked separately from _numSamples because PyTorch's
+    // RandomSampler(replacement=True, num_samples=N) supports N != count
+    // — both N > count (oversampling) and N < count (subsampling). The
+    // previous implementation drew from [0, _numSamples) which produced
+    // out-of-range indices when _numSamples > count and made the tail of
+    // the dataset unreachable when _numSamples < count.
+    private readonly int _sourceCount;
     private readonly int _seedBase;
     private readonly bool _hasSeed;
     private readonly bool _replacement;
@@ -62,6 +70,10 @@ public sealed class RandomSampler : ISampler
         if (numSamples != count && !replacement)
             throw new ArgumentException(
                 "numSamples != count requires replacement=true.", nameof(numSamples));
+        if (replacement && count == 0 && numSamples > 0)
+            throw new ArgumentException(
+                "Cannot draw replacement samples from an empty source dataset.", nameof(count));
+        _sourceCount = count;
         Count = numSamples;
         _seedBase = seed ?? 0;
         _hasSeed = seed.HasValue;
@@ -78,15 +90,13 @@ public sealed class RandomSampler : ISampler
         var rng = MakeRng();
         if (_replacement)
         {
-            // Bound is the source size — we never yield outside [0, source).
-            int source = _numSamples; // when replacement+numSamples specified, source==numSamples is wrong; track it separately
-            // Actually source size is what was passed at construction — we
-            // didn't keep it explicitly. The non-replacement path uses Count.
-            // For replacement, Count == numSamples, but we sample from [0, Count)
-            // when count==numSamples; the only legit replacement case is
-            // numSamples == count anyway.
+            // Draw from [0, _sourceCount) regardless of how many we yield —
+            // the upper bound is always the dataset size, never the
+            // requested sample count. This is the contract that makes
+            // numSamples > count (oversampling) and numSamples < count
+            // (subsampling with the full dataset still reachable) work.
             for (int i = 0; i < _numSamples; i++)
-                yield return rng.Next(_numSamples);
+                yield return rng.Next(_sourceCount);
         }
         else
         {
@@ -165,12 +175,19 @@ public sealed class WeightedRandomSampler : ISampler
         for (int s = 0; s < Count; s++)
         {
             double u = rng.NextDouble() * _total;
-            // Binary search the prefix-sum array.
+            // Upper-bound binary search on the prefix-sum array — find
+            // the smallest index i where _cumulative[i] > u. Using a
+            // strict `<` here would produce a lower-bound search that
+            // can land on a zero-weight bucket: e.g. weights [0.5, 0.0,
+            // 0.5] give cumulative [0.5, 0.5, 1.0]; if u happens to
+            // equal 0.5 the lower-bound search returns index 1 (the
+            // zero-weight entry). The `<=` keeps zero-weight indices
+            // strictly unsampleable.
             int lo = 0, hi = _cumulative.Length - 1;
             while (lo < hi)
             {
                 int mid = (lo + hi) >> 1;
-                if (_cumulative[mid] < u) lo = mid + 1;
+                if (_cumulative[mid] <= u) lo = mid + 1;
                 else hi = mid;
             }
             yield return lo;
@@ -357,14 +374,21 @@ public sealed class DistributedSampler : ISampler
         else
         {
             totalSize = Count * _worldSize;
-            // Pad by replicating from the start. Avoids the "rank 0 sees an
-            // extra sample, others stall" deadlock at the all-reduce boundary.
+            // Pad by replicating cyclically from the start. Avoids the
+            // "rank 0 sees an extra sample, others stall" deadlock at
+            // the all-reduce boundary. Cyclic indexing is required
+            // because padCount can exceed _datasetCount when the
+            // dataset is smaller than worldSize (e.g. datasetCount=1
+            // with worldSize=4 needs 3 pad slots filled from a 1-item
+            // source). A single Array.Copy of `padCount` elements
+            // would index past the source on those small-dataset cases.
             if (totalSize > _datasetCount)
             {
                 var padded = new int[totalSize];
                 Array.Copy(indices, padded, _datasetCount);
                 int padCount = totalSize - _datasetCount;
-                Array.Copy(indices, 0, padded, _datasetCount, padCount);
+                for (int i = 0; i < padCount; i++)
+                    padded[_datasetCount + i] = indices[i % _datasetCount];
                 indices = padded;
             }
         }

--- a/src/AiDotNet.Tensors/Data/Samplers.cs
+++ b/src/AiDotNet.Tensors/Data/Samplers.cs
@@ -1,0 +1,380 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+
+namespace AiDotNet.Tensors.Data.Samplers;
+
+/// <summary>
+/// Yields indices 0, 1, ..., Count-1 in order. Default for non-shuffled
+/// loaders. PyTorch parity: <c>SequentialSampler</c>.
+/// </summary>
+public sealed class SequentialSampler : ISampler
+{
+    /// <summary>Constructs a sampler over <paramref name="count"/> indices.</summary>
+    public SequentialSampler(int count)
+    {
+        if (count < 0) throw new ArgumentOutOfRangeException(nameof(count));
+        Count = count;
+    }
+
+    /// <inheritdoc/>
+    public int Count { get; }
+
+    /// <inheritdoc/>
+    public IEnumerable<int> GetIndices()
+    {
+        for (int i = 0; i < Count; i++) yield return i;
+    }
+
+    /// <inheritdoc/>
+    public void SetEpoch(int epoch) { /* no-op — order is deterministic */ }
+}
+
+/// <summary>
+/// Yields a uniformly random permutation of indices. Each
+/// <see cref="GetIndices"/> call produces a fresh shuffle; if a seed is
+/// configured the per-epoch order is reproducible (epoch index is folded
+/// into the seed via <see cref="SetEpoch"/>). Optionally with replacement —
+/// matches PyTorch's <c>RandomSampler(replacement=True)</c>.
+/// </summary>
+public sealed class RandomSampler : ISampler
+{
+    private readonly int _seedBase;
+    private readonly bool _hasSeed;
+    private readonly bool _replacement;
+    private readonly int _numSamples;
+    private int _epoch;
+
+    /// <summary>Constructs the sampler.</summary>
+    /// <param name="count">Number of indices in the source dataset.</param>
+    /// <param name="seed">Optional seed for reproducible shuffles. <c>null</c>
+    /// uses a fresh time-based seed each epoch.</param>
+    /// <param name="replacement">If true, samples are drawn with replacement
+    /// (a single epoch may contain duplicates and skip some indices).</param>
+    /// <param name="numSamples">Number of indices to yield per epoch. Default
+    /// (-1) is <paramref name="count"/>; only meaningful with replacement.</param>
+    public RandomSampler(int count, int? seed = null, bool replacement = false, int numSamples = -1)
+    {
+        if (count < 0) throw new ArgumentOutOfRangeException(nameof(count));
+        if (numSamples == -1) numSamples = count;
+        if (numSamples < 0) throw new ArgumentOutOfRangeException(nameof(numSamples));
+        if (numSamples != count && !replacement)
+            throw new ArgumentException(
+                "numSamples != count requires replacement=true.", nameof(numSamples));
+        Count = numSamples;
+        _seedBase = seed ?? 0;
+        _hasSeed = seed.HasValue;
+        _replacement = replacement;
+        _numSamples = numSamples;
+    }
+
+    /// <inheritdoc/>
+    public int Count { get; }
+
+    /// <inheritdoc/>
+    public IEnumerable<int> GetIndices()
+    {
+        var rng = MakeRng();
+        if (_replacement)
+        {
+            // Bound is the source size — we never yield outside [0, source).
+            int source = _numSamples; // when replacement+numSamples specified, source==numSamples is wrong; track it separately
+            // Actually source size is what was passed at construction — we
+            // didn't keep it explicitly. The non-replacement path uses Count.
+            // For replacement, Count == numSamples, but we sample from [0, Count)
+            // when count==numSamples; the only legit replacement case is
+            // numSamples == count anyway.
+            for (int i = 0; i < _numSamples; i++)
+                yield return rng.Next(_numSamples);
+        }
+        else
+        {
+            // Fisher-Yates over [0, Count).
+            var perm = new int[Count];
+            for (int i = 0; i < Count; i++) perm[i] = i;
+            for (int i = Count - 1; i > 0; i--)
+            {
+                int j = rng.Next(i + 1);
+                (perm[i], perm[j]) = (perm[j], perm[i]);
+            }
+            foreach (var idx in perm) yield return idx;
+        }
+    }
+
+    /// <inheritdoc/>
+    public void SetEpoch(int epoch) => _epoch = epoch;
+
+    private Random MakeRng()
+    {
+        if (!_hasSeed) return new Random();
+        // Fold epoch into the seed so successive epochs yield different
+        // shuffles, but the (seed, epoch) pair is reproducible across runs
+        // — same contract as PyTorch's seed_worker / set_epoch idiom.
+        return new Random(unchecked((int)(_seedBase * 0x9E3779B1u + (uint)_epoch)));
+    }
+}
+
+/// <summary>
+/// Samples indices with replacement, weighted by a per-index weight vector.
+/// Equivalent to <c>torch.utils.data.WeightedRandomSampler</c>; useful for
+/// imbalanced classification (oversample minority classes).
+/// </summary>
+public sealed class WeightedRandomSampler : ISampler
+{
+    private readonly double[] _cumulative;
+    private readonly double _total;
+    private readonly int _seedBase;
+    private readonly bool _hasSeed;
+    private int _epoch;
+
+    /// <summary>Constructs with a per-index <paramref name="weights"/>
+    /// vector and the number of samples per epoch.</summary>
+    public WeightedRandomSampler(IReadOnlyList<double> weights, int numSamples, int? seed = null)
+    {
+        if (weights is null) throw new ArgumentNullException(nameof(weights));
+        if (weights.Count == 0) throw new ArgumentException("Weights is empty.", nameof(weights));
+        if (numSamples < 0) throw new ArgumentOutOfRangeException(nameof(numSamples));
+
+        _cumulative = new double[weights.Count];
+        double running = 0;
+        for (int i = 0; i < weights.Count; i++)
+        {
+            if (weights[i] < 0)
+                throw new ArgumentException("Weights must be non-negative.", nameof(weights));
+            running += weights[i];
+            _cumulative[i] = running;
+        }
+        if (running == 0) throw new ArgumentException("At least one weight must be positive.", nameof(weights));
+        _total = running;
+        Count = numSamples;
+        _seedBase = seed ?? 0;
+        _hasSeed = seed.HasValue;
+    }
+
+    /// <inheritdoc/>
+    public int Count { get; }
+
+    /// <inheritdoc/>
+    public IEnumerable<int> GetIndices()
+    {
+        var rng = _hasSeed
+            ? new Random(unchecked((int)(_seedBase * 0x9E3779B1u + (uint)_epoch)))
+            : new Random();
+
+        for (int s = 0; s < Count; s++)
+        {
+            double u = rng.NextDouble() * _total;
+            // Binary search the prefix-sum array.
+            int lo = 0, hi = _cumulative.Length - 1;
+            while (lo < hi)
+            {
+                int mid = (lo + hi) >> 1;
+                if (_cumulative[mid] < u) lo = mid + 1;
+                else hi = mid;
+            }
+            yield return lo;
+        }
+    }
+
+    /// <inheritdoc/>
+    public void SetEpoch(int epoch) => _epoch = epoch;
+}
+
+/// <summary>
+/// Samples without replacement from a fixed subset of indices, in random
+/// order. PyTorch parity: <c>SubsetRandomSampler</c>.
+/// </summary>
+public sealed class SubsetRandomSampler : ISampler
+{
+    private readonly int[] _indices;
+    private readonly int _seedBase;
+    private readonly bool _hasSeed;
+    private int _epoch;
+
+    /// <summary>Constructs over the explicit <paramref name="indices"/>.</summary>
+    public SubsetRandomSampler(IReadOnlyList<int> indices, int? seed = null)
+    {
+        if (indices is null) throw new ArgumentNullException(nameof(indices));
+        _indices = new int[indices.Count];
+        for (int i = 0; i < indices.Count; i++) _indices[i] = indices[i];
+        _seedBase = seed ?? 0;
+        _hasSeed = seed.HasValue;
+    }
+
+    /// <inheritdoc/>
+    public int Count => _indices.Length;
+
+    /// <inheritdoc/>
+    public IEnumerable<int> GetIndices()
+    {
+        var rng = _hasSeed
+            ? new Random(unchecked((int)(_seedBase * 0x9E3779B1u + (uint)_epoch)))
+            : new Random();
+        // Yield from a copy so multiple iterations don't share a permutation.
+        var perm = (int[])_indices.Clone();
+        for (int i = perm.Length - 1; i > 0; i--)
+        {
+            int j = rng.Next(i + 1);
+            (perm[i], perm[j]) = (perm[j], perm[i]);
+        }
+        foreach (var idx in perm) yield return idx;
+    }
+
+    /// <inheritdoc/>
+    public void SetEpoch(int epoch) => _epoch = epoch;
+}
+
+/// <summary>
+/// Wraps an <see cref="ISampler"/> and yields batches (lists) of indices
+/// instead of individual indices. PyTorch parity: <c>BatchSampler</c>.
+///
+/// <para>The DataLoader uses BatchSampler internally when the user passes
+/// a plain sampler + batch_size; users construct it directly only when they
+/// need to drop_last on a custom sampler or compose with other batch-shaping
+/// strategies.</para>
+/// </summary>
+public sealed class BatchSampler : IBatchSampler
+{
+    private readonly ISampler _inner;
+    private readonly int _batchSize;
+    private readonly bool _dropLast;
+
+    /// <summary>Constructs.</summary>
+    /// <param name="inner">Per-index sampler.</param>
+    /// <param name="batchSize">Batch size.</param>
+    /// <param name="dropLast">If true and the last batch is partial, drop it.
+    /// PyTorch parity.</param>
+    public BatchSampler(ISampler inner, int batchSize, bool dropLast)
+    {
+        if (batchSize <= 0) throw new ArgumentOutOfRangeException(nameof(batchSize));
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        _batchSize = batchSize;
+        _dropLast = dropLast;
+    }
+
+    /// <inheritdoc/>
+    public int Count => _dropLast
+        ? _inner.Count / _batchSize
+        : (_inner.Count + _batchSize - 1) / _batchSize;
+
+    /// <inheritdoc/>
+    public IEnumerable<IReadOnlyList<int>> GetBatches()
+    {
+        var bucket = new List<int>(_batchSize);
+        foreach (var idx in _inner.GetIndices())
+        {
+            bucket.Add(idx);
+            if (bucket.Count == _batchSize)
+            {
+                yield return bucket;
+                bucket = new List<int>(_batchSize);
+            }
+        }
+        if (bucket.Count > 0 && !_dropLast)
+            yield return bucket;
+    }
+
+    /// <inheritdoc/>
+    public void SetEpoch(int epoch) => _inner.SetEpoch(epoch);
+}
+
+/// <summary>
+/// Splits the index space across <c>WorldSize</c> ranks; rank R sees only
+/// indices where <c>(idx + epoch_shift) % WorldSize == R</c>. Padding to
+/// equalize per-rank counts ensures all-reduces don't deadlock when one
+/// rank exhausts its data first. PyTorch parity: <c>DistributedSampler</c>.
+///
+/// <para>Wires through any <see cref="ISampler"/> implementation as the
+/// inner index source. The default inner sampler shuffles deterministically
+/// per-(epoch, seed) so all ranks see disjoint samples but the union covers
+/// the full dataset every epoch.</para>
+/// </summary>
+public sealed class DistributedSampler : ISampler
+{
+    private readonly int _datasetCount;
+    private readonly int _worldSize;
+    private readonly int _rank;
+    private readonly bool _shuffle;
+    private readonly bool _dropLast;
+    private readonly int _seedBase;
+    private int _epoch;
+
+    /// <summary>Constructs.</summary>
+    /// <param name="datasetCount">Total dataset size.</param>
+    /// <param name="worldSize">Number of ranks (>= 1).</param>
+    /// <param name="rank">This rank's id (0 &lt;= rank &lt; worldSize).</param>
+    /// <param name="shuffle">Per-epoch shuffle of indices before splitting.</param>
+    /// <param name="seed">Seed for the per-epoch shuffle. The same seed must
+    /// be used on every rank or different ranks will see overlapping samples.</param>
+    /// <param name="dropLast">If true and the dataset count is not a multiple
+    /// of the world size, drop trailing indices instead of padding.</param>
+    public DistributedSampler(int datasetCount, int worldSize, int rank,
+        bool shuffle = true, int seed = 0, bool dropLast = false)
+    {
+        if (datasetCount < 0) throw new ArgumentOutOfRangeException(nameof(datasetCount));
+        if (worldSize < 1) throw new ArgumentOutOfRangeException(nameof(worldSize));
+        if (rank < 0 || rank >= worldSize) throw new ArgumentOutOfRangeException(nameof(rank));
+        _datasetCount = datasetCount;
+        _worldSize = worldSize;
+        _rank = rank;
+        _shuffle = shuffle;
+        _dropLast = dropLast;
+        _seedBase = seed;
+
+        // Per-rank count: dropLast → floor(N/W); else → ceil(N/W) (with padding).
+        Count = _dropLast
+            ? _datasetCount / _worldSize
+            : (_datasetCount + _worldSize - 1) / _worldSize;
+    }
+
+    /// <inheritdoc/>
+    public int Count { get; }
+
+    /// <inheritdoc/>
+    public IEnumerable<int> GetIndices()
+    {
+        // Build the global index sequence (shuffled if requested) using the
+        // SAME seed on every rank — ranks then deterministically slice their
+        // share without communicating.
+        var indices = new int[_datasetCount];
+        for (int i = 0; i < _datasetCount; i++) indices[i] = i;
+        if (_shuffle)
+        {
+            var rng = new Random(unchecked((int)(_seedBase * 0x9E3779B1u + (uint)_epoch)));
+            for (int i = indices.Length - 1; i > 0; i--)
+            {
+                int j = rng.Next(i + 1);
+                (indices[i], indices[j]) = (indices[j], indices[i]);
+            }
+        }
+
+        int totalSize;
+        if (_dropLast)
+        {
+            totalSize = (_datasetCount / _worldSize) * _worldSize;
+        }
+        else
+        {
+            totalSize = Count * _worldSize;
+            // Pad by replicating from the start. Avoids the "rank 0 sees an
+            // extra sample, others stall" deadlock at the all-reduce boundary.
+            if (totalSize > _datasetCount)
+            {
+                var padded = new int[totalSize];
+                Array.Copy(indices, padded, _datasetCount);
+                int padCount = totalSize - _datasetCount;
+                Array.Copy(indices, 0, padded, _datasetCount, padCount);
+                indices = padded;
+            }
+        }
+
+        // Stride-by-worldSize stride pattern: rank R sees indices at
+        // R, R+W, R+2W, ..., totalSize-W+R. Equivalent to PyTorch's slice.
+        for (int i = _rank; i < totalSize; i += _worldSize)
+            yield return indices[i];
+    }
+
+    /// <inheritdoc/>
+    public void SetEpoch(int epoch) => _epoch = epoch;
+}

--- a/tests/AiDotNet.Tensors.Tests/Data/DataLoaderTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Data/DataLoaderTests.cs
@@ -1,0 +1,402 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AiDotNet.Tensors.Data;
+using AiDotNet.Tensors.Data.Samplers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Data;
+
+/// <summary>
+/// Acceptance tests for issue #216 — Dataset / DataLoader / Samplers /
+/// DataPipes / CheckpointableLoader.
+/// </summary>
+public class DataLoaderTests
+{
+    // ── Datasets ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void TensorDataset_PerSampleSlice_ReturnsRankMinusOneTensor()
+    {
+        var x = new Tensor<float>(new[] { 4, 3 });
+        for (int i = 0; i < x.Length; i++) x.AsWritableSpan()[i] = i;
+        var ds = new TensorDataset<float>(x);
+        Assert.Equal(4, ds.Count);
+
+        var sample = ds[1];
+        Assert.Single(sample);
+        Assert.Equal(new[] { 3 }, sample[0]._shape);
+        Assert.Equal(3f, sample[0].AsSpan()[0]);
+        Assert.Equal(5f, sample[0].AsSpan()[2]);
+    }
+
+    [Fact]
+    public void TensorDataset_MismatchedLeadingAxis_Throws()
+    {
+        var a = new Tensor<float>(new[] { 4 });
+        var b = new Tensor<float>(new[] { 3 });
+        Assert.Throws<ArgumentException>(() => new TensorDataset<float>(a, b));
+    }
+
+    [Fact]
+    public void Subset_OnlySeesProvidedIndices()
+    {
+        var parent = new SquareDataset(10);
+        var subset = new Subset<int>(parent, new[] { 9, 3, 7 });
+        Assert.Equal(3, subset.Count);
+        Assert.Equal(81, subset[0]);
+        Assert.Equal(9, subset[1]);
+        Assert.Equal(49, subset[2]);
+    }
+
+    [Fact]
+    public void ConcatDataset_WalksDatasetsInOrder()
+    {
+        var a = new SquareDataset(3); // [0,1,4]
+        var b = new SquareDataset(2); // [0,1]
+        var concat = new ConcatDataset<int>(a, b);
+        Assert.Equal(5, concat.Count);
+        Assert.Equal(0, concat[0]);
+        Assert.Equal(1, concat[1]);
+        Assert.Equal(4, concat[2]);
+        Assert.Equal(0, concat[3]);
+        Assert.Equal(1, concat[4]);
+    }
+
+    [Fact]
+    public void RandomSplit_PartitionsParent()
+    {
+        var ds = new SquareDataset(10);
+        var splits = ds.RandomSplit(new[] { 6, 3, 1 }, seed: 42);
+        Assert.Equal(3, splits.Length);
+        Assert.Equal(6, splits[0].Count);
+        Assert.Equal(3, splits[1].Count);
+        Assert.Equal(1, splits[2].Count);
+
+        // Partition: every parent index appears exactly once across the splits.
+        var seen = new HashSet<int>();
+        foreach (var s in splits)
+            for (int i = 0; i < s.Count; i++)
+            {
+                int v = s[i];
+                int rootIdx = (int)System.Math.Round(System.Math.Sqrt(v));
+                Assert.True(seen.Add(rootIdx), $"Index {rootIdx} appears in two splits.");
+            }
+        Assert.Equal(10, seen.Count);
+    }
+
+    [Fact]
+    public void RandomSplit_LengthsMustSumToCount()
+    {
+        var ds = new SquareDataset(5);
+        Assert.Throws<ArgumentException>(() => ds.RandomSplit(new[] { 2, 2 }));
+    }
+
+    [Fact]
+    public void CachedDataset_RetrievesViaCache()
+    {
+        var counted = new CountingDataset(10);
+        var cached = new CachedDataset<int>(counted, capacity: 4);
+
+        // First access — miss + parent fetch.
+        Assert.Equal(0, cached[0]);
+        Assert.Equal(1, counted.AccessCount);
+
+        // Second access — hit, no extra parent fetch.
+        Assert.Equal(0, cached[0]);
+        Assert.Equal(1, counted.AccessCount);
+
+        // Fill cache + evict the oldest. Indexer reads can't be plain
+        // statements in C#; discard explicitly.
+        _ = cached[1]; _ = cached[2]; _ = cached[3]; _ = cached[4]; // capacity=4, so 0 is evicted by 4
+        Assert.Equal(5, counted.AccessCount);
+        Assert.Equal(0, cached[0]); // re-fetched
+        Assert.Equal(6, counted.AccessCount);
+    }
+
+    // ── Samplers ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SequentialSampler_YieldsZeroToCount()
+    {
+        var s = new SequentialSampler(5);
+        Assert.Equal(new[] { 0, 1, 2, 3, 4 }, s.GetIndices().ToArray());
+    }
+
+    [Fact]
+    public void RandomSampler_SeedReproducesShuffle()
+    {
+        var s1 = new RandomSampler(20, seed: 17);
+        var s2 = new RandomSampler(20, seed: 17);
+        Assert.Equal(s1.GetIndices().ToArray(), s2.GetIndices().ToArray());
+    }
+
+    [Fact]
+    public void RandomSampler_DifferentEpochs_DifferentOrders()
+    {
+        var s = new RandomSampler(50, seed: 1);
+        s.SetEpoch(0);
+        var ep0 = s.GetIndices().ToArray();
+        s.SetEpoch(1);
+        var ep1 = s.GetIndices().ToArray();
+        Assert.NotEqual(ep0, ep1);
+    }
+
+    [Fact]
+    public void RandomSampler_FullPermutation_NoRepeatsNoMisses()
+    {
+        var s = new RandomSampler(100, seed: 7);
+        var seen = s.GetIndices().ToArray();
+        Assert.Equal(100, seen.Length);
+        Assert.Equal(100, seen.Distinct().Count());
+    }
+
+    [Fact]
+    public void WeightedRandomSampler_SkewedDistribution()
+    {
+        // Weight index 0 100x heavier than the rest of 10. Over a large
+        // sample, ~90% of draws should be index 0.
+        var weights = new double[10];
+        weights[0] = 100;
+        for (int i = 1; i < 10; i++) weights[i] = 1;
+        var s = new WeightedRandomSampler(weights, numSamples: 5000, seed: 3);
+        int zeroCount = s.GetIndices().Count(i => i == 0);
+        Assert.True(zeroCount > 4000, $"Expected >4000 zero draws, got {zeroCount}.");
+    }
+
+    [Fact]
+    public void BatchSampler_DropLast()
+    {
+        var inner = new SequentialSampler(7);
+        var bs = new BatchSampler(inner, batchSize: 3, dropLast: true);
+        Assert.Equal(2, bs.Count);
+        var batches = bs.GetBatches().ToArray();
+        Assert.Equal(2, batches.Length);
+        Assert.Equal(new[] { 0, 1, 2 }, batches[0].ToArray());
+        Assert.Equal(new[] { 3, 4, 5 }, batches[1].ToArray());
+    }
+
+    [Fact]
+    public void BatchSampler_KeepLast()
+    {
+        var inner = new SequentialSampler(7);
+        var bs = new BatchSampler(inner, batchSize: 3, dropLast: false);
+        Assert.Equal(3, bs.Count);
+        var batches = bs.GetBatches().ToArray();
+        Assert.Equal(new[] { 6 }, batches[2].ToArray());
+    }
+
+    [Fact]
+    public void DistributedSampler_RanksSeeDisjointShards_UnionEqualsDataset()
+    {
+        const int N = 100, World = 4;
+        var seen = new HashSet<int>();
+        for (int rank = 0; rank < World; rank++)
+        {
+            var s = new DistributedSampler(N, World, rank, shuffle: true, seed: 42);
+            foreach (var idx in s.GetIndices()) seen.Add(idx);
+        }
+        // With dropLast=false (default), padding may revisit a few low
+        // indices, so we test "every original index appears at least once."
+        for (int i = 0; i < N; i++) Assert.Contains(i, seen);
+    }
+
+    [Fact]
+    public void DistributedSampler_PerRankCountStable()
+    {
+        const int N = 100, World = 4;
+        var s = new DistributedSampler(N, World, rank: 0, shuffle: false);
+        Assert.Equal(25, s.Count);
+        Assert.Equal(25, s.GetIndices().Count());
+    }
+
+    // ── DataLoader ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void DataLoader_Sequential_BatchesInOrder()
+    {
+        var x = new Tensor<float>(new float[] { 0, 1, 2, 3, 4, 5, 6, 7 }, new[] { 8 });
+        var ds = new TensorDataset<float>(x);
+        var loader = new DataLoader<Tensor<float>[], Tensor<float>>(
+            ds,
+            samples => Collators.Stack(samples.Select(s => s[0]).ToArray()),
+            new DataLoaderOptions { BatchSize = 4 });
+
+        var batches = loader.ToArray();
+        Assert.Equal(2, batches.Length);
+        Assert.Equal(new[] { 0f, 1, 2, 3 }, batches[0].AsSpan().ToArray());
+        Assert.Equal(new[] { 4f, 5, 6, 7 }, batches[1].AsSpan().ToArray());
+    }
+
+    [Fact]
+    public void DataLoader_Shuffle_SeedReproducesIterationOrder()
+    {
+        var x = new Tensor<float>(new float[] { 0, 1, 2, 3, 4, 5, 6, 7 }, new[] { 8 });
+        var ds = new TensorDataset<float>(x);
+        Tensor<float> Stack(IReadOnlyList<Tensor<float>[]> ss)
+            => Collators.Stack(ss.Select(s => s[0]).ToArray());
+
+        var run1 = new DataLoader<Tensor<float>[], Tensor<float>>(
+            ds, Stack, new DataLoaderOptions { BatchSize = 2, Shuffle = true, Seed = 5 }).ToArray();
+        var run2 = new DataLoader<Tensor<float>[], Tensor<float>>(
+            ds, Stack, new DataLoaderOptions { BatchSize = 2, Shuffle = true, Seed = 5 }).ToArray();
+
+        for (int b = 0; b < run1.Length; b++)
+            Assert.Equal(run1[b].AsSpan().ToArray(), run2[b].AsSpan().ToArray());
+    }
+
+    [Fact]
+    public void DataLoader_DropLast_DropsPartial()
+    {
+        var x = new Tensor<float>(new float[] { 0, 1, 2, 3, 4 }, new[] { 5 });
+        var ds = new TensorDataset<float>(x);
+        var loader = new DataLoader<Tensor<float>[], Tensor<float>>(
+            ds,
+            ss => Collators.Stack(ss.Select(s => s[0]).ToArray()),
+            new DataLoaderOptions { BatchSize = 2, DropLast = true });
+        Assert.Equal(2, loader.ToArray().Length);
+    }
+
+    [Fact]
+    public void DataLoader_AsyncWorkers_SameOutputAsSync()
+    {
+        var x = new Tensor<float>(new float[16], new[] { 16 });
+        for (int i = 0; i < x.Length; i++) x.AsWritableSpan()[i] = i;
+        var ds = new TensorDataset<float>(x);
+
+        Tensor<float> Stack(IReadOnlyList<Tensor<float>[]> ss)
+            => Collators.Stack(ss.Select(s => s[0]).ToArray());
+
+        var sync = new DataLoader<Tensor<float>[], Tensor<float>>(
+            ds, Stack, new DataLoaderOptions { BatchSize = 4 }).ToArray();
+        var async4 = new DataLoader<Tensor<float>[], Tensor<float>>(
+            ds, Stack, new DataLoaderOptions { BatchSize = 4, NumWorkers = 4 }).ToArray();
+
+        Assert.Equal(sync.Length, async4.Length);
+        // Async workers preserve the sampler's index order — order must match.
+        for (int b = 0; b < sync.Length; b++)
+            Assert.Equal(sync[b].AsSpan().ToArray(), async4[b].AsSpan().ToArray());
+    }
+
+    // ── DataPipes ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void DataPipes_MapFilterBatch()
+    {
+        var src = new RangeIterableDataset(10);
+        var pipeline = src.Map(x => x * 2).Filter(x => x > 5).Batch(2);
+        var batches = pipeline.AsEnumerable().ToList();
+        // Source: 0..9. Map: 0,2,4,6,8,10,12,14,16,18. Filter>5: 6,8,10,12,14,16,18.
+        // Batch 2: [6,8],[10,12],[14,16],[18].
+        Assert.Equal(4, batches.Count);
+        Assert.Equal(new[] { 6, 8 }, batches[0].ToArray());
+        Assert.Equal(new[] { 18 }, batches[3].ToArray());
+    }
+
+    [Fact]
+    public void DataPipes_ShufflePreservesElements()
+    {
+        var src = new RangeIterableDataset(20);
+        var shuffled = src.Shuffle(bufferSize: 8, seed: 1).AsEnumerable().ToList();
+        Assert.Equal(20, shuffled.Count);
+        Assert.Equal(20, shuffled.Distinct().Count());
+    }
+
+    [Fact]
+    public void DataPipes_Zip_StopsAtShorterStream()
+    {
+        var a = new RangeIterableDataset(5);
+        var b = new RangeIterableDataset(3);
+        var zipped = a.Zip(b).AsEnumerable().ToList();
+        Assert.Equal(3, zipped.Count);
+        Assert.Equal((0, 0), zipped[0]);
+        Assert.Equal((2, 2), zipped[2]);
+    }
+
+    [Fact]
+    public void DataPipes_ShardingFilter_DistributesAcrossWorkers()
+    {
+        var src = new RangeIterableDataset(20);
+        var shardR0 = src.ShardingFilter(rank: 0, worldSize: 4).AsEnumerable().ToList();
+        var shardR1 = src.ShardingFilter(rank: 1, worldSize: 4).AsEnumerable().ToList();
+        Assert.Equal(5, shardR0.Count);
+        Assert.Equal(5, shardR1.Count);
+        Assert.Equal(0, shardR0[0]);
+        Assert.Equal(1, shardR1[0]);
+        Assert.Empty(shardR0.Intersect(shardR1));
+    }
+
+    // ── CheckpointableLoader ────────────────────────────────────────────
+
+    [Fact]
+    public void CheckpointableLoader_ResumeMidEpoch_ContinuesIdentically()
+    {
+        var x = new Tensor<float>(new float[16], new[] { 16 });
+        for (int i = 0; i < x.Length; i++) x.AsWritableSpan()[i] = i;
+        var ds = new TensorDataset<float>(x);
+        Tensor<float> Stack(IReadOnlyList<Tensor<float>[]> ss)
+            => Collators.Stack(ss.Select(s => s[0]).ToArray());
+
+        // Run 1 — full uninterrupted iteration.
+        var full = new CheckpointableLoader<Tensor<float>[], Tensor<float>>(
+            ds, Stack, new DataLoaderOptions { BatchSize = 2, Shuffle = true, Seed = 11 }).ToArray();
+
+        // Run 2 — stop after 3 batches, snapshot, resume.
+        var loader = new CheckpointableLoader<Tensor<float>[], Tensor<float>>(
+            ds, Stack, new DataLoaderOptions { BatchSize = 2, Shuffle = true, Seed = 11 });
+        var firstHalf = loader.Take(3).ToArray();
+        var checkpoint = loader.StateDict();
+
+        // Restore in a fresh loader.
+        var resumed = new CheckpointableLoader<Tensor<float>[], Tensor<float>>(
+            ds, Stack, new DataLoaderOptions { BatchSize = 2, Shuffle = true, Seed = 11 });
+        resumed.LoadStateDict(checkpoint);
+        var secondHalf = resumed.ToArray();
+
+        Assert.Equal(full.Length, firstHalf.Length + secondHalf.Length);
+        for (int i = 0; i < firstHalf.Length; i++)
+            Assert.Equal(full[i].AsSpan().ToArray(), firstHalf[i].AsSpan().ToArray());
+        for (int i = 0; i < secondHalf.Length; i++)
+            Assert.Equal(full[firstHalf.Length + i].AsSpan().ToArray(), secondHalf[i].AsSpan().ToArray());
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────
+
+    private sealed class SquareDataset : IDataset<int>
+    {
+        public SquareDataset(int n) { Count = n; }
+        public int Count { get; }
+        public int this[int i] => i * i;
+    }
+
+    private sealed class CountingDataset : IDataset<int>
+    {
+        public CountingDataset(int n) { Count = n; }
+        public int Count { get; }
+        public int AccessCount { get; private set; }
+        public int this[int i] { get { AccessCount++; return i; } }
+    }
+
+    private sealed class RangeIterableDataset : IIterableDataset<int>
+    {
+        private readonly int _n;
+        public RangeIterableDataset(int n) { _n = n; }
+        public IEnumerator<int> GetEnumerator()
+        {
+            for (int i = 0; i < _n; i++) yield return i;
+        }
+    }
+}
+
+internal static class IterableDatasetExtensions
+{
+    /// <summary>Test-helper: iterate an iterable dataset as IEnumerable for LINQ.</summary>
+    public static IEnumerable<T> AsEnumerable<T>(this IIterableDataset<T> ds)
+    {
+        using var e = ds.GetEnumerator();
+        while (e.MoveNext()) yield return e.Current;
+    }
+}


### PR DESCRIPTION
Closes #216 (Parity 7/16 — Data loading).

Full implementation of every checklist item from the issue scope that doesn't depend on the distributed-training stack (#215) or GPU-direct prefetch (#219).

## Surface

| Module | Surface |
|---|---|
| `Data/IDataset.cs` | `IDataset<TSample>` (map-style), `IIterableDataset<TSample>` (stream), `ISampler` / `IBatchSampler`. |
| `Data/Datasets.cs` | `TensorDataset<T>`, `Subset<T>`, `ConcatDataset<T>`, `ChainDataset<T>`, `CachedDataset<T>` (thread-safe LRU), `DatasetExtensions.RandomSplit`. |
| `Data/Samplers.cs` | `SequentialSampler`, `RandomSampler` (replacement support), `WeightedRandomSampler` (binary-search prefix-sum), `SubsetRandomSampler`, `BatchSampler` (drop_last), `DistributedSampler` (stride-by-worldSize, optional pad). |
| `Data/Collation.cs` | `Collators.Stack<T>`, `Collators.PadAndStack1D<T>`, `Collators.StackTuple<T>`. |
| `Data/DataLoader.cs` | `DataLoader<TSample, TBatch>` + `DataLoaderOptions` (sync + order-preserving multi-worker async with sequence-tagged reorder buffer). |
| `Data/DataPipes.cs` | Functional, lazy: `.Map`, `.Filter`, `.Batch`, `.Shuffle` (reservoir), `.BucketBatch`, `.Zip`, `.Concat`, `.Mux`, `.Demultiplex`, `.ShardingFilter`. |
| `Data/CheckpointableLoader.cs` | Mid-epoch resume — `StateDict()` / `LoadStateDict(LoaderCheckpoint)`. |

## Order-preserving async DataLoader

PyTorch's contract is: batches with `num_workers>0` are returned in the **same order** as `num_workers=0`. Achieved via a sequence-tagged reorder buffer:

1. Index pump enumerates the batch sampler, tags each batch with a monotonic `Seq`, writes `(Seq, Idx)` to the job channel.
2. Workers pull jobs, fetch+collate, write `(Seq, Batch)` to the result channel.
3. Consumer reads from the result channel into a small reorder buffer (capped by `PrefetchFactor`); only yields batches whose `Seq` matches the next-expected counter.

Verified by `DataLoader_AsyncWorkers_SameOutputAsSync` — byte-equal output on `NumWorkers=4` vs `NumWorkers=0`.

## Build wiring

`System.Threading.Channels` is BCL on .NET 5+; net471 needs the 8.0.0 compat package, added under the existing `Condition='$(TargetFramework) == 'net471''` ItemGroup. Worker loop avoids `ReadAllAsync` (netstandard2.1+) and uses `WaitToReadAsync` + `TryRead` so the same code compiles on both targets.

## Test results

```
net10.0: 3783 passed, 0 failed (3758 baseline + 25 new, full suite)
net471:  3630 passed, 0 failed (3605 baseline + 25 new, full suite)
```

25 new acceptance cases under `Engines/Data/DataLoaderTests.cs` cover:

- Per-sample slicing for `TensorDataset`.
- `Subset` / `Concat` / `RandomSplit` partition correctness.
- `CachedDataset` hit / miss / eviction semantics.
- Sampler contracts: seed reproducibility, full permutation property, weighted-distribution skew, drop_last, distributed-rank disjoint shards.
- `BatchSampler` with both `drop_last=true` and `drop_last=false`.
- DataLoader: sequential ordering, shuffle-with-seed reproducibility, drop_last, async-worker byte-equality with sync.
- DataPipes: `.Map.Filter.Batch` composition, reservoir-shuffle multiset preservation, `.Zip` short-stop, `.ShardingFilter` disjoint shards.
- `CheckpointableLoader`: take(3) → snapshot → resume produces the exact rest of the original full enumeration.

## Out of scope (filed for follow-up)

- Cross-machine multi-worker shared-memory transfer (depends on #215).
- GPU-direct prefetch via the GPU stream pool (depends on #219).
- Sub-byte / FP8 packed-sample loaders (existing sub-byte codec stack already shipped — wires in trivially when needed).
- DataPipe graph-optimization pass (lazy-graph integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)