### PR TITLE
feat(#223): nn primitives gap — losses, functional, activations, parametrizations, pruning

### DIFF
--- a/src/AiDotNet.Tensors/NN/Activations/Activations.cs
+++ b/src/AiDotNet.Tensors/NN/Activations/Activations.cs
@@ -1,0 +1,172 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.NN.Activations;
+
+/// <summary>
+/// Activations missing from the engine surface, plus the newer GLU
+/// family that powers modern LLMs (SwiGLU, GEGLU, ReGLU). Engine
+/// already covers ReLU / Sigmoid / Tanh / GELU / Mish / Softplus /
+/// HardSwish / HardSigmoid / ELU / SELU; this file fills in the
+/// long-tail PyTorch ships under <c>torch.nn.functional</c>.
+/// </summary>
+public static class Activations
+{
+    /// <summary>Hard shrinkage: <c>x</c> when <c>|x| &gt; lambda</c>, else 0.</summary>
+    public static Tensor<T> Hardshrink<T>(Tensor<T> input, double lambda = 0.5)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        var output = new Tensor<T>((int[])input._shape.Clone());
+        var src = input.AsSpan();
+        var dst = output.AsWritableSpan();
+        for (int i = 0; i < src.Length; i++)
+        {
+            double v = ops.ToDouble(src[i]);
+            dst[i] = Math.Abs(v) > lambda ? src[i] : ops.Zero;
+        }
+        return output;
+    }
+
+    /// <summary>Soft shrinkage: <c>x − sign(x) · lambda</c> when
+    /// <c>|x| &gt; lambda</c>, else 0.</summary>
+    public static Tensor<T> Softshrink<T>(Tensor<T> input, double lambda = 0.5)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        var output = new Tensor<T>((int[])input._shape.Clone());
+        var src = input.AsSpan();
+        var dst = output.AsWritableSpan();
+        for (int i = 0; i < src.Length; i++)
+        {
+            double v = ops.ToDouble(src[i]);
+            double r = v > lambda ? v - lambda
+                     : v < -lambda ? v + lambda
+                     : 0.0;
+            dst[i] = ops.FromDouble(r);
+        }
+        return output;
+    }
+
+    /// <summary>Tanh shrinkage: <c>x − tanh(x)</c>.</summary>
+    public static Tensor<T> Tanhshrink<T>(Tensor<T> input)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        var output = new Tensor<T>((int[])input._shape.Clone());
+        var src = input.AsSpan();
+        var dst = output.AsWritableSpan();
+        for (int i = 0; i < src.Length; i++)
+        {
+            double v = ops.ToDouble(src[i]);
+            dst[i] = ops.FromDouble(v - Math.Tanh(v));
+        }
+        return output;
+    }
+
+    /// <summary>Threshold: <c>x</c> when <c>x &gt; threshold</c>, else
+    /// <paramref name="value"/>.</summary>
+    public static Tensor<T> Threshold<T>(Tensor<T> input, double threshold, double value)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        var output = new Tensor<T>((int[])input._shape.Clone());
+        var src = input.AsSpan();
+        var dst = output.AsWritableSpan();
+        T fill = ops.FromDouble(value);
+        for (int i = 0; i < src.Length; i++)
+        {
+            double v = ops.ToDouble(src[i]);
+            dst[i] = v > threshold ? src[i] : fill;
+        }
+        return output;
+    }
+
+    /// <summary>Quick GELU — <c>x · sigmoid(1.702 · x)</c>. Cheaper
+    /// than the standard GELU and used in CLIP / GPT-2.</summary>
+    public static Tensor<T> QuickGelu<T>(Tensor<T> input)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        var output = new Tensor<T>((int[])input._shape.Clone());
+        var src = input.AsSpan();
+        var dst = output.AsWritableSpan();
+        for (int i = 0; i < src.Length; i++)
+        {
+            double v = ops.ToDouble(src[i]);
+            double sig = 1.0 / (1.0 + Math.Exp(-1.702 * v));
+            dst[i] = ops.FromDouble(v * sig);
+        }
+        return output;
+    }
+
+    /// <summary>GELU with the tanh approximation —
+    /// <c>0.5 · x · (1 + tanh(sqrt(2/π) · (x + 0.044715 · x³)))</c>.
+    /// Mirrors PyTorch's <c>F.gelu(x, approximate="tanh")</c>.</summary>
+    public static Tensor<T> GeluTanh<T>(Tensor<T> input)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        var output = new Tensor<T>((int[])input._shape.Clone());
+        var src = input.AsSpan();
+        var dst = output.AsWritableSpan();
+        const double C = 0.7978845608028654; // sqrt(2/π)
+        for (int i = 0; i < src.Length; i++)
+        {
+            double v = ops.ToDouble(src[i]);
+            double inner = C * (v + 0.044715 * v * v * v);
+            dst[i] = ops.FromDouble(0.5 * v * (1.0 + Math.Tanh(inner)));
+        }
+        return output;
+    }
+
+    /// <summary>SwiGLU: <c>silu(x_a) · x_b</c> where the input's last
+    /// axis is split in half (a, b). Used in LLaMA, PaLM, Mistral.</summary>
+    public static Tensor<T> SwiGLU<T>(Tensor<T> input)
+        => GLUFamily(input, GLUKind.SwiGLU);
+
+    /// <summary>GEGLU: <c>gelu(x_a) · x_b</c>. Used in T5-v1.1,
+    /// Gemma, GLaM.</summary>
+    public static Tensor<T> GEGLU<T>(Tensor<T> input)
+        => GLUFamily(input, GLUKind.GEGLU);
+
+    /// <summary>ReGLU: <c>relu(x_a) · x_b</c>. Used in Noam
+    /// Shazeer's "GLU Variants Improve Transformer" study.</summary>
+    public static Tensor<T> ReGLU<T>(Tensor<T> input)
+        => GLUFamily(input, GLUKind.ReGLU);
+
+    private enum GLUKind { SwiGLU, GEGLU, ReGLU }
+
+    private static Tensor<T> GLUFamily<T>(Tensor<T> input, GLUKind kind)
+    {
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        int last = input._shape[input.Rank - 1];
+        if (last % 2 != 0)
+            throw new ArgumentException(
+                $"GLU family requires last dim be even; got {last}.", nameof(input));
+        var ops = MathHelper.GetNumericOperations<T>();
+        int half = last / 2;
+        var newShape = (int[])input._shape.Clone();
+        newShape[input.Rank - 1] = half;
+        var output = new Tensor<T>(newShape);
+
+        int outer = input.Length / last;
+        var src = input.AsSpan();
+        var dst = output.AsWritableSpan();
+
+        for (int o = 0; o < outer; o++)
+        {
+            for (int j = 0; j < half; j++)
+            {
+                double a = ops.ToDouble(src[o * last + j]);
+                double b = ops.ToDouble(src[o * last + half + j]);
+                double act = kind switch
+                {
+                    GLUKind.SwiGLU => a / (1.0 + Math.Exp(-a)),
+                    GLUKind.GEGLU => 0.5 * a * (1.0 + Math.Tanh(0.7978845608028654 * (a + 0.044715 * a * a * a))),
+                    GLUKind.ReGLU => Math.Max(0, a),
+                    _ => a,
+                };
+                dst[o * half + j] = ops.FromDouble(act * b);
+            }
+        }
+        return output;
+    }
+}

--- a/src/AiDotNet.Tensors/NN/Activations/Activations.cs
+++ b/src/AiDotNet.Tensors/NN/Activations/Activations.cs
@@ -143,7 +143,11 @@ public static class Activations
     private static Tensor<T> GLUFamily<T>(Tensor<T> input, GLUKind kind)
     {
         if (input is null) throw new ArgumentNullException(nameof(input));
+        if (input.Rank == 0)
+            throw new ArgumentException("GLU family requires rank ≥ 1.", nameof(input));
         int last = input._shape[input.Rank - 1];
+        if (last == 0)
+            throw new ArgumentException("GLU family requires last dim > 0.", nameof(input));
         if (last % 2 != 0)
             throw new ArgumentException(
                 $"GLU family requires last dim be even; got {last}.", nameof(input));
@@ -153,7 +157,8 @@ public static class Activations
         newShape[input.Rank - 1] = half;
         var output = new Tensor<T>(newShape);
 
-        int outer = input.Length / last;
+        int outer = 1;
+        for (int d = 0; d < input.Rank - 1; d++) outer *= input._shape[d];
         var src = input.AsSpan();
         var dst = output.AsWritableSpan();
 

--- a/src/AiDotNet.Tensors/NN/Activations/Activations.cs
+++ b/src/AiDotNet.Tensors/NN/Activations/Activations.cs
@@ -18,6 +18,7 @@ public static class Activations
     /// <summary>Hard shrinkage: <c>x</c> when <c>|x| &gt; lambda</c>, else 0.</summary>
     public static Tensor<T> Hardshrink<T>(Tensor<T> input, double lambda = 0.5)
     {
+        if (input is null) throw new ArgumentNullException(nameof(input));
         var ops = MathHelper.GetNumericOperations<T>();
         var output = new Tensor<T>((int[])input._shape.Clone());
         var src = input.AsSpan();
@@ -34,6 +35,7 @@ public static class Activations
     /// <c>|x| &gt; lambda</c>, else 0.</summary>
     public static Tensor<T> Softshrink<T>(Tensor<T> input, double lambda = 0.5)
     {
+        if (input is null) throw new ArgumentNullException(nameof(input));
         var ops = MathHelper.GetNumericOperations<T>();
         var output = new Tensor<T>((int[])input._shape.Clone());
         var src = input.AsSpan();
@@ -52,6 +54,7 @@ public static class Activations
     /// <summary>Tanh shrinkage: <c>x − tanh(x)</c>.</summary>
     public static Tensor<T> Tanhshrink<T>(Tensor<T> input)
     {
+        if (input is null) throw new ArgumentNullException(nameof(input));
         var ops = MathHelper.GetNumericOperations<T>();
         var output = new Tensor<T>((int[])input._shape.Clone());
         var src = input.AsSpan();
@@ -68,6 +71,7 @@ public static class Activations
     /// <paramref name="value"/>.</summary>
     public static Tensor<T> Threshold<T>(Tensor<T> input, double threshold, double value)
     {
+        if (input is null) throw new ArgumentNullException(nameof(input));
         var ops = MathHelper.GetNumericOperations<T>();
         var output = new Tensor<T>((int[])input._shape.Clone());
         var src = input.AsSpan();
@@ -85,6 +89,7 @@ public static class Activations
     /// than the standard GELU and used in CLIP / GPT-2.</summary>
     public static Tensor<T> QuickGelu<T>(Tensor<T> input)
     {
+        if (input is null) throw new ArgumentNullException(nameof(input));
         var ops = MathHelper.GetNumericOperations<T>();
         var output = new Tensor<T>((int[])input._shape.Clone());
         var src = input.AsSpan();
@@ -103,6 +108,7 @@ public static class Activations
     /// Mirrors PyTorch's <c>F.gelu(x, approximate="tanh")</c>.</summary>
     public static Tensor<T> GeluTanh<T>(Tensor<T> input)
     {
+        if (input is null) throw new ArgumentNullException(nameof(input));
         var ops = MathHelper.GetNumericOperations<T>();
         var output = new Tensor<T>((int[])input._shape.Clone());
         var src = input.AsSpan();

--- a/src/AiDotNet.Tensors/NN/Functional/Functional.cs
+++ b/src/AiDotNet.Tensors/NN/Functional/Functional.cs
@@ -130,6 +130,12 @@ public static class Functional
         var ops = MathHelper.GetNumericOperations<T>();
         int numEmb = weight._shape[0];
         int embDim = weight._shape[1];
+        // paddingIdx (if supplied) must be a valid row — silently
+        // zero-filling for an invalid index would mask data
+        // corruption from upstream tokenizers / vocab fixups.
+        if (paddingIdx is int pi && (uint)pi >= (uint)numEmb)
+            throw new ArgumentOutOfRangeException(nameof(paddingIdx),
+                $"paddingIdx {pi} out of range [0, {numEmb}).");
 
         // Apply max-norm clipping in-place on the weight rows that are
         // referenced. Matches PyTorch behavior — the clipped rows
@@ -142,7 +148,10 @@ public static class Functional
             for (int i = 0; i < inputSpan.Length; i++)
             {
                 int row = inputSpan[i];
-                if ((uint)row >= (uint)numEmb || visited[row]) continue;
+                if ((uint)row >= (uint)numEmb)
+                    throw new ArgumentException(
+                        $"Index {row} out of range [0, {numEmb}).", nameof(input));
+                if (visited[row]) continue;
                 visited[row] = true;
                 double normP = 0;
                 for (int e = 0; e < embDim; e++)
@@ -173,14 +182,17 @@ public static class Functional
         for (int i = 0; i < inSpan.Length; i++)
         {
             int row = inSpan[i];
+            // Validate row bounds BEFORE the paddingIdx short-circuit
+            // so an out-of-range index that happens to equal
+            // paddingIdx still raises (otherwise corruption masquerades
+            // as padding).
+            if ((uint)row >= (uint)numEmb)
+                throw new ArgumentException($"Index {row} out of range [0, {numEmb}).", nameof(input));
             if (paddingIdx.HasValue && row == paddingIdx.Value)
             {
-                // Zero-fill the embedding for the padding index.
                 for (int e = 0; e < embDim; e++) outSpan[i * embDim + e] = ops.Zero;
                 continue;
             }
-            if ((uint)row >= (uint)numEmb)
-                throw new ArgumentException($"Index {row} out of range [0, {numEmb}).", nameof(input));
             for (int e = 0; e < embDim; e++)
                 outSpan[i * embDim + e] = weightSpan[row * embDim + e];
         }
@@ -209,6 +221,8 @@ public static class Functional
     public static Tensor<T> EmbeddingBag<T>(Tensor<int> input, Tensor<T> weight, int[] offsets,
         EmbeddingBagMode mode = EmbeddingBagMode.Mean)
     {
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (weight is null) throw new ArgumentNullException(nameof(weight));
         if (offsets is null) throw new ArgumentNullException(nameof(offsets));
         if (weight.Rank != 2)
             throw new ArgumentException("weight must be rank-2 [num_embeddings, embedding_dim].", nameof(weight));
@@ -216,12 +230,28 @@ public static class Functional
             throw new ArgumentException("input must be rank-1 (flattened indices).", nameof(input));
 
         var ops = MathHelper.GetNumericOperations<T>();
+        int numEmb = weight._shape[0];
         int bagCount = offsets.Length;
         int embDim = weight._shape[1];
         var output = new Tensor<T>(new[] { bagCount, embDim });
         var inSpan = input.AsSpan();
         var weightSpan = weight.AsSpan();
         var dst = output.AsWritableSpan();
+
+        // Pre-validate offsets: non-negative, monotonic, and within
+        // input.Length. Catches malformed inputs deterministically
+        // instead of letting them surface as negative counts or
+        // IndexOutOfRangeException later.
+        int previous = 0;
+        for (int b = 0; b < bagCount; b++)
+        {
+            int off = offsets[b];
+            if ((uint)off > (uint)inSpan.Length || off < previous)
+                throw new ArgumentException(
+                    $"offsets must be non-negative, sorted, and ≤ input.Length (got {off} at bag {b}).",
+                    nameof(offsets));
+            previous = off;
+        }
 
         for (int b = 0; b < bagCount; b++)
         {
@@ -240,6 +270,9 @@ public static class Functional
                     for (int k = start; k < end; k++)
                     {
                         int row = inSpan[k];
+                        if ((uint)row >= (uint)numEmb)
+                            throw new ArgumentException(
+                                $"Index {row} out of range [0, {numEmb}).", nameof(input));
                         double v = ops.ToDouble(weightSpan[row * embDim + e]);
                         if (v > best) best = v;
                     }
@@ -251,6 +284,9 @@ public static class Functional
                 for (int k = start; k < end; k++)
                 {
                     int row = inSpan[k];
+                    if ((uint)row >= (uint)numEmb)
+                        throw new ArgumentException(
+                            $"Index {row} out of range [0, {numEmb}).", nameof(input));
                     for (int e = 0; e < embDim; e++)
                         dst[b * embDim + e] = ops.Add(dst[b * embDim + e], weightSpan[row * embDim + e]);
                 }

--- a/src/AiDotNet.Tensors/NN/Functional/Functional.cs
+++ b/src/AiDotNet.Tensors/NN/Functional/Functional.cs
@@ -1,0 +1,267 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.NN.Functional;
+
+/// <summary>
+/// <c>torch.nn.functional</c> utility surface added by #223. Engine
+/// already exposes <c>TensorPDist</c>, <c>TensorCDist</c>, and
+/// <c>TensorCosineSimilarity</c>; this file fills in the remaining
+/// utility ops PyTorch ships under <c>F.</c>.
+/// </summary>
+public static class Functional
+{
+    /// <summary>
+    /// L<paramref name="p"/>-normalize <paramref name="input"/> along
+    /// <paramref name="dim"/>. Each slice is divided by its L<paramref name="p"/>
+    /// norm (clamped at <paramref name="eps"/> to avoid division by zero).
+    /// Mirrors <c>F.normalize</c>.
+    /// </summary>
+    public static Tensor<T> Normalize<T>(Tensor<T> input, double p = 2.0, int dim = 1, double eps = 1e-12)
+    {
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        int actualDim = dim < 0 ? input.Rank + dim : dim;
+        if (actualDim < 0 || actualDim >= input.Rank)
+            throw new ArgumentOutOfRangeException(nameof(dim));
+        var ops = MathHelper.GetNumericOperations<T>();
+
+        int outer = 1, axisLen = input._shape[actualDim], inner = 1;
+        for (int i = 0; i < actualDim; i++) outer *= input._shape[i];
+        for (int i = actualDim + 1; i < input.Rank; i++) inner *= input._shape[i];
+
+        var output = new Tensor<T>((int[])input._shape.Clone());
+        var src = input.AsSpan();
+        var dst = output.AsWritableSpan();
+
+        for (int o = 0; o < outer; o++)
+        {
+            for (int i = 0; i < inner; i++)
+            {
+                double normP = 0;
+                for (int a = 0; a < axisLen; a++)
+                {
+                    double v = ops.ToDouble(src[(o * axisLen + a) * inner + i]);
+                    normP += Math.Pow(Math.Abs(v), p);
+                }
+                double norm = Math.Max(eps, Math.Pow(normP, 1.0 / p));
+                for (int a = 0; a < axisLen; a++)
+                {
+                    int idx = (o * axisLen + a) * inner + i;
+                    dst[idx] = ops.FromDouble(ops.ToDouble(src[idx]) / norm);
+                }
+            }
+        }
+        return output;
+    }
+
+    /// <summary>
+    /// One-hot encode integer indices. Output shape adds a final
+    /// <paramref name="numClasses"/> axis. Mirrors <c>F.one_hot</c>.
+    /// </summary>
+    public static Tensor<int> OneHot(Tensor<int> input, int numClasses)
+    {
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (numClasses <= 0) throw new ArgumentOutOfRangeException(nameof(numClasses));
+        var newShape = new int[input.Rank + 1];
+        Array.Copy(input._shape, newShape, input.Rank);
+        newShape[input.Rank] = numClasses;
+        var output = new Tensor<int>(newShape);
+        var src = input.AsSpan();
+        var dst = output.AsWritableSpan();
+        for (int i = 0; i < src.Length; i++)
+        {
+            int cls = src[i];
+            if ((uint)cls >= (uint)numClasses)
+                throw new ArgumentException($"Index {cls} out of range [0, {numClasses}).", nameof(input));
+            dst[i * numClasses + cls] = 1;
+        }
+        return output;
+    }
+
+    /// <summary>
+    /// Pairwise L<paramref name="p"/> distance between rows of
+    /// <paramref name="x1"/> and <paramref name="x2"/>. Both must be
+    /// rank-2 with the same shape; output is rank-1 of length
+    /// <c>batch</c>. Mirrors <c>F.pairwise_distance</c>.
+    /// </summary>
+    public static Tensor<T> PairwiseDistance<T>(Tensor<T> x1, Tensor<T> x2, double p = 2.0, double eps = 1e-6)
+    {
+        if (x1.Rank != 2 || x2.Rank != 2)
+            throw new ArgumentException("PairwiseDistance expects rank-2 inputs.", nameof(x1));
+        if (x1._shape[0] != x2._shape[0] || x1._shape[1] != x2._shape[1])
+            throw new ArgumentException("x1 and x2 must have the same shape.");
+        var ops = MathHelper.GetNumericOperations<T>();
+        int batch = x1._shape[0], features = x1._shape[1];
+        var output = new Tensor<T>(new[] { batch });
+        var s1 = x1.AsSpan();
+        var s2 = x2.AsSpan();
+        var dst = output.AsWritableSpan();
+        for (int b = 0; b < batch; b++)
+        {
+            double accum = 0;
+            for (int f = 0; f < features; f++)
+            {
+                double diff = ops.ToDouble(s1[b * features + f]) - ops.ToDouble(s2[b * features + f]) + eps;
+                accum += Math.Pow(Math.Abs(diff), p);
+            }
+            dst[b] = ops.FromDouble(Math.Pow(accum, 1.0 / p));
+        }
+        return output;
+    }
+
+    /// <summary>
+    /// Embedding lookup. Returns <c>weight[input[i]]</c> for every index
+    /// in <paramref name="input"/>. Output shape is
+    /// <c>input.shape + [embedding_dim]</c>. Optional max-norm rescaling
+    /// + scale-grad-by-freq tracking mirror PyTorch's
+    /// <c>F.embedding</c>.
+    /// </summary>
+    public static Tensor<T> Embedding<T>(Tensor<int> input, Tensor<T> weight,
+        int? paddingIdx = null, double? maxNorm = null, double normType = 2.0,
+        bool scaleGradByFreq = false)
+    {
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (weight is null) throw new ArgumentNullException(nameof(weight));
+        if (weight.Rank != 2)
+            throw new ArgumentException("weight must be rank-2 [num_embeddings, embedding_dim].", nameof(weight));
+        var ops = MathHelper.GetNumericOperations<T>();
+        int numEmb = weight._shape[0];
+        int embDim = weight._shape[1];
+
+        // Apply max-norm clipping in-place on the weight rows that are
+        // referenced. Matches PyTorch behavior — the clipped rows
+        // become the "official" representation that backward sees.
+        if (maxNorm is not null)
+        {
+            var wSpan = weight.AsWritableSpan();
+            var visited = new bool[numEmb];
+            var inputSpan = input.AsSpan();
+            for (int i = 0; i < inputSpan.Length; i++)
+            {
+                int row = inputSpan[i];
+                if ((uint)row >= (uint)numEmb || visited[row]) continue;
+                visited[row] = true;
+                double normP = 0;
+                for (int e = 0; e < embDim; e++)
+                {
+                    double v = ops.ToDouble(wSpan[row * embDim + e]);
+                    normP += Math.Pow(Math.Abs(v), normType);
+                }
+                double norm = Math.Pow(normP, 1.0 / normType);
+                if (norm > maxNorm.Value)
+                {
+                    double scale = maxNorm.Value / norm;
+                    for (int e = 0; e < embDim; e++)
+                    {
+                        var wv = wSpan[row * embDim + e];
+                        wSpan[row * embDim + e] = ops.FromDouble(ops.ToDouble(wv) * scale);
+                    }
+                }
+            }
+        }
+
+        var newShape = new int[input.Rank + 1];
+        Array.Copy(input._shape, newShape, input.Rank);
+        newShape[input.Rank] = embDim;
+        var output = new Tensor<T>(newShape);
+        var inSpan = input.AsSpan();
+        var outSpan = output.AsWritableSpan();
+        var weightSpan = weight.AsSpan();
+        for (int i = 0; i < inSpan.Length; i++)
+        {
+            int row = inSpan[i];
+            if (paddingIdx.HasValue && row == paddingIdx.Value)
+            {
+                // Zero-fill the embedding for the padding index.
+                for (int e = 0; e < embDim; e++) outSpan[i * embDim + e] = ops.Zero;
+                continue;
+            }
+            if ((uint)row >= (uint)numEmb)
+                throw new ArgumentException($"Index {row} out of range [0, {numEmb}).", nameof(input));
+            for (int e = 0; e < embDim; e++)
+                outSpan[i * embDim + e] = weightSpan[row * embDim + e];
+        }
+        _ = scaleGradByFreq; // takes effect during backward; forward path is unchanged.
+        return output;
+    }
+
+    /// <summary>Bag mode for <see cref="EmbeddingBag{T}"/>.</summary>
+    public enum EmbeddingBagMode
+    {
+        /// <summary>Sum the embeddings in each bag.</summary>
+        Sum,
+        /// <summary>Average the embeddings in each bag.</summary>
+        Mean,
+        /// <summary>Element-wise max across the bag.</summary>
+        Max,
+    }
+
+    /// <summary>
+    /// Embedding bag — fetches embeddings, then reduces (sum / mean /
+    /// max) within each bag delimited by <paramref name="offsets"/>.
+    /// Output shape is <c>[bags, embedding_dim]</c>. Mirrors
+    /// <c>F.embedding_bag</c>; sub-byte storage support is a follow-up
+    /// gated on the existing <c>PackedInt1/2/3/4</c> codecs.
+    /// </summary>
+    public static Tensor<T> EmbeddingBag<T>(Tensor<int> input, Tensor<T> weight, int[] offsets,
+        EmbeddingBagMode mode = EmbeddingBagMode.Mean)
+    {
+        if (offsets is null) throw new ArgumentNullException(nameof(offsets));
+        if (weight.Rank != 2)
+            throw new ArgumentException("weight must be rank-2 [num_embeddings, embedding_dim].", nameof(weight));
+        if (input.Rank != 1)
+            throw new ArgumentException("input must be rank-1 (flattened indices).", nameof(input));
+
+        var ops = MathHelper.GetNumericOperations<T>();
+        int bagCount = offsets.Length;
+        int embDim = weight._shape[1];
+        var output = new Tensor<T>(new[] { bagCount, embDim });
+        var inSpan = input.AsSpan();
+        var weightSpan = weight.AsSpan();
+        var dst = output.AsWritableSpan();
+
+        for (int b = 0; b < bagCount; b++)
+        {
+            int start = offsets[b];
+            int end = b + 1 < bagCount ? offsets[b + 1] : inSpan.Length;
+            int count = end - start;
+
+            for (int e = 0; e < embDim; e++) dst[b * embDim + e] = ops.Zero;
+            if (count == 0) continue;
+
+            if (mode == EmbeddingBagMode.Max)
+            {
+                for (int e = 0; e < embDim; e++)
+                {
+                    double best = double.NegativeInfinity;
+                    for (int k = start; k < end; k++)
+                    {
+                        int row = inSpan[k];
+                        double v = ops.ToDouble(weightSpan[row * embDim + e]);
+                        if (v > best) best = v;
+                    }
+                    dst[b * embDim + e] = ops.FromDouble(best);
+                }
+            }
+            else
+            {
+                for (int k = start; k < end; k++)
+                {
+                    int row = inSpan[k];
+                    for (int e = 0; e < embDim; e++)
+                        dst[b * embDim + e] = ops.Add(dst[b * embDim + e], weightSpan[row * embDim + e]);
+                }
+                if (mode == EmbeddingBagMode.Mean)
+                {
+                    T inv = ops.Divide(ops.One, ops.FromDouble(count));
+                    for (int e = 0; e < embDim; e++)
+                        dst[b * embDim + e] = ops.Multiply(dst[b * embDim + e], inv);
+                }
+            }
+        }
+        return output;
+    }
+}

--- a/src/AiDotNet.Tensors/NN/Functional/Functional.cs
+++ b/src/AiDotNet.Tensors/NN/Functional/Functional.cs
@@ -23,6 +23,10 @@ public static class Functional
     public static Tensor<T> Normalize<T>(Tensor<T> input, double p = 2.0, int dim = 1, double eps = 1e-12)
     {
         if (input is null) throw new ArgumentNullException(nameof(input));
+        if (double.IsNaN(p) || double.IsInfinity(p) || p <= 0.0)
+            throw new ArgumentOutOfRangeException(nameof(p), "p must be finite and > 0.");
+        if (double.IsNaN(eps) || double.IsInfinity(eps) || eps <= 0.0)
+            throw new ArgumentOutOfRangeException(nameof(eps), "eps must be finite and > 0.");
         int actualDim = dim < 0 ? input.Rank + dim : dim;
         if (actualDim < 0 || actualDim >= input.Rank)
             throw new ArgumentOutOfRangeException(nameof(dim));
@@ -89,6 +93,12 @@ public static class Functional
     /// </summary>
     public static Tensor<T> PairwiseDistance<T>(Tensor<T> x1, Tensor<T> x2, double p = 2.0, double eps = 1e-6)
     {
+        if (x1 is null) throw new ArgumentNullException(nameof(x1));
+        if (x2 is null) throw new ArgumentNullException(nameof(x2));
+        if (double.IsNaN(p) || double.IsInfinity(p) || p <= 0.0)
+            throw new ArgumentOutOfRangeException(nameof(p), "p must be finite and > 0.");
+        if (double.IsNaN(eps) || double.IsInfinity(eps) || eps < 0.0)
+            throw new ArgumentOutOfRangeException(nameof(eps), "eps must be finite and ≥ 0.");
         if (x1.Rank != 2 || x2.Rank != 2)
             throw new ArgumentException("PairwiseDistance expects rank-2 inputs.", nameof(x1));
         if (x1._shape[0] != x2._shape[0] || x1._shape[1] != x2._shape[1])
@@ -136,6 +146,11 @@ public static class Functional
         if (paddingIdx is int pi && (uint)pi >= (uint)numEmb)
             throw new ArgumentOutOfRangeException(nameof(paddingIdx),
                 $"paddingIdx {pi} out of range [0, {numEmb}).");
+        if (maxNorm is double mn && (double.IsNaN(mn) || double.IsInfinity(mn) || mn <= 0.0))
+            throw new ArgumentOutOfRangeException(nameof(maxNorm), "maxNorm must be finite and > 0.");
+        if (maxNorm is not null && (double.IsNaN(normType) || double.IsInfinity(normType) || normType <= 0.0))
+            throw new ArgumentOutOfRangeException(nameof(normType),
+                "normType must be finite and > 0 when maxNorm is set.");
 
         // Apply max-norm clipping in-place on the weight rows that are
         // referenced. Matches PyTorch behavior — the clipped rows
@@ -228,6 +243,8 @@ public static class Functional
             throw new ArgumentException("weight must be rank-2 [num_embeddings, embedding_dim].", nameof(weight));
         if (input.Rank != 1)
             throw new ArgumentException("input must be rank-1 (flattened indices).", nameof(input));
+        if (!Enum.IsDefined(typeof(EmbeddingBagMode), mode))
+            throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unsupported EmbeddingBagMode.");
 
         var ops = MathHelper.GetNumericOperations<T>();
         int numEmb = weight._shape[0];

--- a/src/AiDotNet.Tensors/NN/Losses/Losses.cs
+++ b/src/AiDotNet.Tensors/NN/Losses/Losses.cs
@@ -124,6 +124,9 @@ public static class Losses
             throw new ArgumentException("Target must be rank-1 with length = batch.", nameof(target));
         var ops = MathHelper.GetNumericOperations<T>();
         int batch = input._shape[0], classes = input._shape[1];
+        if (weight is not null && weight.Length != classes)
+            throw new ArgumentException(
+                $"weight length {weight.Length} must equal classes {classes}.", nameof(weight));
         var output = new Tensor<T>(new[] { batch });
         var inSpan = input.AsSpan();
         var tSpan = target.AsSpan();
@@ -132,6 +135,9 @@ public static class Losses
         for (int b = 0; b < batch; b++)
         {
             int yi = tSpan[b];
+            if ((uint)yi >= (uint)classes)
+                throw new ArgumentException(
+                    $"Target class index {yi} out of range [0, {classes}).", nameof(target));
             double loss = 0;
             double xy = ops.ToDouble(inSpan[b * classes + yi]);
             for (int j = 0; j < classes; j++)
@@ -338,6 +344,9 @@ public static class Losses
             throw new ArgumentException("CosineEmbeddingLoss expects rank-2 inputs.", nameof(x1));
         var ops = MathHelper.GetNumericOperations<T>();
         int batch = x1._shape[0], features = x1._shape[1];
+        if (y.Rank != 1 || y.Length != batch)
+            throw new ArgumentException(
+                "y must be rank-1 with one label per input row.", nameof(y));
         var output = new Tensor<T>(new[] { batch });
         var s1 = x1.AsSpan();
         var s2 = x2.AsSpan();
@@ -345,6 +354,10 @@ public static class Losses
         var dst = output.AsWritableSpan();
         for (int b = 0; b < batch; b++)
         {
+            int yi = ySpan[b];
+            if (yi != 1 && yi != -1)
+                throw new ArgumentException(
+                    $"y values must be +1 or -1; got {yi} at index {b}.", nameof(y));
             double dot = 0, n1 = 0, n2 = 0;
             for (int f = 0; f < features; f++)
             {
@@ -355,7 +368,7 @@ public static class Losses
                 n2 += bb * bb;
             }
             double cos = dot / Math.Max(1e-12, Math.Sqrt(n1 * n2));
-            double loss = ySpan[b] == 1 ? 1.0 - cos : Math.Max(0.0, cos - margin);
+            double loss = yi == 1 ? 1.0 - cos : Math.Max(0.0, cos - margin);
             dst[b] = ops.FromDouble(loss);
         }
         return Reduce(output, reduction);

--- a/src/AiDotNet.Tensors/NN/Losses/Losses.cs
+++ b/src/AiDotNet.Tensors/NN/Losses/Losses.cs
@@ -247,6 +247,8 @@ public static class Losses
     {
         EnsureSameShape(anchor, positive);
         EnsureSameShape(anchor, negative);
+        if (p <= 0)
+            throw new ArgumentOutOfRangeException(nameof(p), "p must be > 0.");
         var ops = MathHelper.GetNumericOperations<T>();
         int last = anchor._shape[anchor.Rank - 1];
         int rows = anchor.Length / last;
@@ -263,11 +265,16 @@ public static class Losses
                 double a = ops.ToDouble(aSpan[r * last + c]);
                 double pp = ops.ToDouble(pSpan[r * last + c]);
                 double n = ops.ToDouble(nSpan[r * last + c]);
-                dPos += Math.Pow(Math.Abs(a - pp) + eps, p);
-                dNeg += Math.Pow(Math.Abs(a - n) + eps, p);
+                // Standard Lp distance: sum |a-p|^p, then root.
+                // Adding eps INSIDE the |·| would inflate negative
+                // deltas — eps is a numerical-stability nudge applied
+                // AFTER the per-element power so the gradient stays
+                // finite at zero.
+                dPos += Math.Pow(Math.Abs(a - pp), p);
+                dNeg += Math.Pow(Math.Abs(a - n), p);
             }
-            double dPosNorm = Math.Pow(dPos, 1.0 / p);
-            double dNegNorm = Math.Pow(dNeg, 1.0 / p);
+            double dPosNorm = Math.Pow(dPos + eps, 1.0 / p);
+            double dNegNorm = Math.Pow(dNeg + eps, 1.0 / p);
             double loss = Math.Max(0.0, dPosNorm - dNegNorm + margin);
             outSpan[r] = ops.FromDouble(loss);
         }
@@ -285,10 +292,15 @@ public static class Losses
         if (distanceFn is null) throw new ArgumentNullException(nameof(distanceFn));
         var dPos = distanceFn(anchor, positive);
         var dNeg = distanceFn(anchor, negative);
+        // Reject scalar / mismatched-shape distance fn outputs up
+        // front instead of letting them truncate or read past spans
+        // in the swap merge / loss loop.
+        EnsureSameShape(dPos, dNeg);
         if (swap)
         {
             // PyTorch's "swap" replaces dNeg with min(dNeg, distance(positive, negative)).
             var dPosNeg = distanceFn(positive, negative);
+            EnsureSameShape(dNeg, dPosNeg);
             var ops = MathHelper.GetNumericOperations<T>();
             var swapped = new Tensor<T>((int[])dNeg._shape.Clone());
             var srcN = dNeg.AsSpan();

--- a/src/AiDotNet.Tensors/NN/Losses/Losses.cs
+++ b/src/AiDotNet.Tensors/NN/Losses/Losses.cs
@@ -1,0 +1,439 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.NN.Losses;
+
+/// <summary>
+/// The "long tail" of <c>torch.nn.functional</c> losses missing from
+/// the engine surface. Each entry mirrors PyTorch's reduction semantics:
+/// <c>"none"</c> returns the per-element loss tensor, <c>"mean"</c> averages
+/// over every element, <c>"sum"</c> sums everything to a scalar.
+/// </summary>
+public enum LossReduction
+{
+    /// <summary>Per-element loss; output has the same shape as input.</summary>
+    None,
+    /// <summary>Average over all elements; scalar output.</summary>
+    Mean,
+    /// <summary>Sum over all elements; scalar output.</summary>
+    Sum,
+}
+
+/// <summary>
+/// Functional loss surface added by #223. Engine-level losses
+/// (HuberLoss, CTCLoss, CosineSimilarityLoss) already exist on
+/// <c>IEngine</c> — this file fills in the remainder PyTorch lists in
+/// <c>torch.nn.functional</c>.
+/// </summary>
+public static class Losses
+{
+    /// <summary>SmoothL1Loss with the configurable <paramref name="beta"/>
+    /// transition point. Mirrors <c>F.smooth_l1_loss</c>; matches Huber
+    /// when <c>beta == 1</c>.</summary>
+    public static Tensor<T> SmoothL1Loss<T>(Tensor<T> input, Tensor<T> target, double beta = 1.0,
+        LossReduction reduction = LossReduction.Mean)
+    {
+        EnsureSameShape(input, target);
+        var ops = MathHelper.GetNumericOperations<T>();
+        var output = new Tensor<T>((int[])input._shape.Clone());
+        var inSpan = input.AsSpan();
+        var tgtSpan = target.AsSpan();
+        var outSpan = output.AsWritableSpan();
+        for (int i = 0; i < inSpan.Length; i++)
+        {
+            double diff = ops.ToDouble(ops.Subtract(inSpan[i], tgtSpan[i]));
+            double absDiff = Math.Abs(diff);
+            double loss = absDiff < beta
+                ? 0.5 * diff * diff / beta
+                : absDiff - 0.5 * beta;
+            outSpan[i] = ops.FromDouble(loss);
+        }
+        return Reduce(output, reduction);
+    }
+
+    /// <summary>Poisson NLL: <c>input − target · log(input + eps)</c>
+    /// when <paramref name="logInput"/> is false; <c>exp(input) − target · input</c>
+    /// when true. Matches <c>F.poisson_nll_loss</c>.</summary>
+    public static Tensor<T> PoissonNllLoss<T>(Tensor<T> input, Tensor<T> target,
+        bool logInput = true, bool full = false, double eps = 1e-8,
+        LossReduction reduction = LossReduction.Mean)
+    {
+        EnsureSameShape(input, target);
+        var ops = MathHelper.GetNumericOperations<T>();
+        var output = new Tensor<T>((int[])input._shape.Clone());
+        var inSpan = input.AsSpan();
+        var tgtSpan = target.AsSpan();
+        var outSpan = output.AsWritableSpan();
+        for (int i = 0; i < inSpan.Length; i++)
+        {
+            double xi = ops.ToDouble(inSpan[i]);
+            double ti = ops.ToDouble(tgtSpan[i]);
+            double loss = logInput
+                ? Math.Exp(xi) - ti * xi
+                : xi - ti * Math.Log(xi + eps);
+            // Stirling approximation for the full target-factorial term.
+            if (full && ti > 1)
+                loss += ti * Math.Log(ti) - ti + 0.5 * Math.Log(2.0 * Math.PI * ti);
+            outSpan[i] = ops.FromDouble(loss);
+        }
+        return Reduce(output, reduction);
+    }
+
+    /// <summary>Gaussian NLL with predicted mean and variance.
+    /// <c>0.5 · (log(var) + (target − input)² / var) [+ const]</c>.</summary>
+    public static Tensor<T> GaussianNllLoss<T>(Tensor<T> input, Tensor<T> target, Tensor<T> variance,
+        bool full = false, double eps = 1e-6,
+        LossReduction reduction = LossReduction.Mean)
+    {
+        EnsureSameShape(input, target);
+        EnsureSameShape(input, variance);
+        var ops = MathHelper.GetNumericOperations<T>();
+        var output = new Tensor<T>((int[])input._shape.Clone());
+        var inSpan = input.AsSpan();
+        var tgtSpan = target.AsSpan();
+        var varSpan = variance.AsSpan();
+        var outSpan = output.AsWritableSpan();
+        double constTerm = full ? 0.5 * Math.Log(2.0 * Math.PI) : 0.0;
+        for (int i = 0; i < inSpan.Length; i++)
+        {
+            double xi = ops.ToDouble(inSpan[i]);
+            double ti = ops.ToDouble(tgtSpan[i]);
+            double vi = Math.Max(eps, ops.ToDouble(varSpan[i]));
+            double diff = ti - xi;
+            double loss = 0.5 * (Math.Log(vi) + diff * diff / vi) + constTerm;
+            outSpan[i] = ops.FromDouble(loss);
+        }
+        return Reduce(output, reduction);
+    }
+
+    /// <summary>
+    /// MultiMarginLoss — for each row, sum over j of
+    /// <c>max(0, margin − x[y] + x[j])^p</c> for j ≠ y.
+    /// Mirrors <c>F.multi_margin_loss</c>.
+    /// </summary>
+    public static Tensor<T> MultiMarginLoss<T>(Tensor<T> input, Tensor<int> target,
+        int p = 1, double margin = 1.0, Tensor<T>? weight = null,
+        LossReduction reduction = LossReduction.Mean)
+    {
+        if (input.Rank != 2)
+            throw new ArgumentException("MultiMarginLoss expects rank-2 input [batch, classes].", nameof(input));
+        if (target.Rank != 1 || target.Length != input._shape[0])
+            throw new ArgumentException("Target must be rank-1 with length = batch.", nameof(target));
+        var ops = MathHelper.GetNumericOperations<T>();
+        int batch = input._shape[0], classes = input._shape[1];
+        var output = new Tensor<T>(new[] { batch });
+        var inSpan = input.AsSpan();
+        var tSpan = target.AsSpan();
+        var wSpan = weight is null ? ReadOnlySpan<T>.Empty : weight.AsSpan();
+        var outSpan = output.AsWritableSpan();
+        for (int b = 0; b < batch; b++)
+        {
+            int yi = tSpan[b];
+            double loss = 0;
+            double xy = ops.ToDouble(inSpan[b * classes + yi]);
+            for (int j = 0; j < classes; j++)
+            {
+                if (j == yi) continue;
+                double margin_xj = margin - xy + ops.ToDouble(inSpan[b * classes + j]);
+                if (margin_xj > 0)
+                {
+                    double term = p == 1 ? margin_xj : Math.Pow(margin_xj, p);
+                    if (weight is not null) term *= ops.ToDouble(wSpan[yi]);
+                    loss += term;
+                }
+            }
+            outSpan[b] = ops.FromDouble(loss / classes);
+        }
+        return Reduce(output, reduction);
+    }
+
+    /// <summary>MultiLabelMarginLoss — multi-label variant where the
+    /// target row contains class indices terminated by -1.
+    /// Mirrors <c>F.multi_label_margin_loss</c>.</summary>
+    public static Tensor<T> MultiLabelMarginLoss<T>(Tensor<T> input, Tensor<int> target,
+        LossReduction reduction = LossReduction.Mean)
+    {
+        if (input.Rank != 2)
+            throw new ArgumentException("MultiLabelMarginLoss expects rank-2 input.", nameof(input));
+        if (target.Rank != 2 || target._shape[0] != input._shape[0] || target._shape[1] != input._shape[1])
+            throw new ArgumentException("target shape must equal input shape.", nameof(target));
+        var ops = MathHelper.GetNumericOperations<T>();
+        int batch = input._shape[0], classes = input._shape[1];
+        var output = new Tensor<T>(new[] { batch });
+        var inSpan = input.AsSpan();
+        var tSpan = target.AsSpan();
+        var outSpan = output.AsWritableSpan();
+        var positive = new bool[classes];
+        for (int b = 0; b < batch; b++)
+        {
+            // Mark every positive class index until -1 sentinel.
+            Array.Clear(positive, 0, classes);
+            for (int k = 0; k < classes; k++)
+            {
+                int idx = tSpan[b * classes + k];
+                if (idx < 0) break;
+                if ((uint)idx >= (uint)classes)
+                    throw new ArgumentException($"Target index {idx} out of range.", nameof(target));
+                positive[idx] = true;
+            }
+
+            double loss = 0;
+            for (int pos = 0; pos < classes; pos++)
+            {
+                if (!positive[pos]) continue;
+                for (int neg = 0; neg < classes; neg++)
+                {
+                    if (positive[neg]) continue;
+                    double margin = 1.0 - ops.ToDouble(inSpan[b * classes + pos])
+                                        + ops.ToDouble(inSpan[b * classes + neg]);
+                    if (margin > 0) loss += margin;
+                }
+            }
+            outSpan[b] = ops.FromDouble(loss / classes);
+        }
+        return Reduce(output, reduction);
+    }
+
+    /// <summary>MultiLabelSoftMarginLoss — element-wise sigmoid
+    /// log-likelihood. Mirrors <c>F.multi_label_soft_margin_loss</c>.</summary>
+    public static Tensor<T> MultiLabelSoftMarginLoss<T>(Tensor<T> input, Tensor<T> target,
+        Tensor<T>? weight = null, LossReduction reduction = LossReduction.Mean)
+    {
+        EnsureSameShape(input, target);
+        var ops = MathHelper.GetNumericOperations<T>();
+        int classes = input._shape[input.Rank - 1];
+        var output = new Tensor<T>(DropLastDim(input._shape));
+        var inSpan = input.AsSpan();
+        var tSpan = target.AsSpan();
+        var wSpan = weight is null ? ReadOnlySpan<T>.Empty : weight.AsSpan();
+        var outSpan = output.AsWritableSpan();
+        int rows = output.Length;
+        for (int r = 0; r < rows; r++)
+        {
+            double rowLoss = 0;
+            for (int c = 0; c < classes; c++)
+            {
+                int idx = r * classes + c;
+                double xi = ops.ToDouble(inSpan[idx]);
+                double ti = ops.ToDouble(tSpan[idx]);
+                // log(1 + exp(x)) = softplus, numerically stable.
+                double sp = xi >= 0 ? xi + Math.Log(1 + Math.Exp(-xi))
+                                    : Math.Log(1 + Math.Exp(xi));
+                double term = ti * (xi - sp) + (1 - ti) * (-sp);
+                if (weight is not null) term *= ops.ToDouble(wSpan[c]);
+                rowLoss -= term;
+            }
+            outSpan[r] = ops.FromDouble(rowLoss / classes);
+        }
+        return Reduce(output, reduction);
+    }
+
+    /// <summary>Triplet margin loss with L2 distance —
+    /// <c>max(0, ||a − p||₂ − ||a − n||₂ + margin)</c>.
+    /// Mirrors <c>F.triplet_margin_loss</c>.</summary>
+    public static Tensor<T> TripletMarginLoss<T>(
+        Tensor<T> anchor, Tensor<T> positive, Tensor<T> negative,
+        double margin = 1.0, double p = 2.0, double eps = 1e-6,
+        LossReduction reduction = LossReduction.Mean)
+    {
+        EnsureSameShape(anchor, positive);
+        EnsureSameShape(anchor, negative);
+        var ops = MathHelper.GetNumericOperations<T>();
+        int last = anchor._shape[anchor.Rank - 1];
+        int rows = anchor.Length / last;
+        var output = new Tensor<T>(DropLastDim(anchor._shape));
+        var aSpan = anchor.AsSpan();
+        var pSpan = positive.AsSpan();
+        var nSpan = negative.AsSpan();
+        var outSpan = output.AsWritableSpan();
+        for (int r = 0; r < rows; r++)
+        {
+            double dPos = 0, dNeg = 0;
+            for (int c = 0; c < last; c++)
+            {
+                double a = ops.ToDouble(aSpan[r * last + c]);
+                double pp = ops.ToDouble(pSpan[r * last + c]);
+                double n = ops.ToDouble(nSpan[r * last + c]);
+                dPos += Math.Pow(Math.Abs(a - pp) + eps, p);
+                dNeg += Math.Pow(Math.Abs(a - n) + eps, p);
+            }
+            double dPosNorm = Math.Pow(dPos, 1.0 / p);
+            double dNegNorm = Math.Pow(dNeg, 1.0 / p);
+            double loss = Math.Max(0.0, dPosNorm - dNegNorm + margin);
+            outSpan[r] = ops.FromDouble(loss);
+        }
+        return Reduce(output, reduction);
+    }
+
+    /// <summary>Triplet margin loss with a custom distance function.
+    /// Mirrors <c>F.triplet_margin_with_distance_loss</c>.</summary>
+    public static Tensor<T> TripletMarginWithDistanceLoss<T>(
+        Tensor<T> anchor, Tensor<T> positive, Tensor<T> negative,
+        Func<Tensor<T>, Tensor<T>, Tensor<T>> distanceFn,
+        double margin = 1.0, bool swap = false,
+        LossReduction reduction = LossReduction.Mean)
+    {
+        if (distanceFn is null) throw new ArgumentNullException(nameof(distanceFn));
+        var dPos = distanceFn(anchor, positive);
+        var dNeg = distanceFn(anchor, negative);
+        if (swap)
+        {
+            // PyTorch's "swap" replaces dNeg with min(dNeg, distance(positive, negative)).
+            var dPosNeg = distanceFn(positive, negative);
+            var ops = MathHelper.GetNumericOperations<T>();
+            var swapped = new Tensor<T>((int[])dNeg._shape.Clone());
+            var srcN = dNeg.AsSpan();
+            var srcPn = dPosNeg.AsSpan();
+            var dst = swapped.AsWritableSpan();
+            for (int i = 0; i < srcN.Length; i++)
+                dst[i] = ops.LessThan(srcPn[i], srcN[i]) ? srcPn[i] : srcN[i];
+            dNeg = swapped;
+        }
+        var loss = new Tensor<T>((int[])dPos._shape.Clone());
+        var ops2 = MathHelper.GetNumericOperations<T>();
+        var dPosSpan = dPos.AsSpan();
+        var dNegSpan = dNeg.AsSpan();
+        var outSpan = loss.AsWritableSpan();
+        for (int i = 0; i < outSpan.Length; i++)
+            outSpan[i] = ops2.FromDouble(Math.Max(0.0,
+                ops2.ToDouble(dPosSpan[i]) - ops2.ToDouble(dNegSpan[i]) + margin));
+        return Reduce(loss, reduction);
+    }
+
+    /// <summary>Margin ranking loss — <c>max(0, −y · (x1 − x2) + margin)</c>
+    /// where <paramref name="y"/> is +1 or -1.
+    /// Mirrors <c>F.margin_ranking_loss</c>.</summary>
+    public static Tensor<T> MarginRankingLoss<T>(Tensor<T> input1, Tensor<T> input2, Tensor<T> y,
+        double margin = 0.0, LossReduction reduction = LossReduction.Mean)
+    {
+        EnsureSameShape(input1, input2);
+        EnsureSameShape(input1, y);
+        var ops = MathHelper.GetNumericOperations<T>();
+        var output = new Tensor<T>((int[])input1._shape.Clone());
+        var s1 = input1.AsSpan();
+        var s2 = input2.AsSpan();
+        var sy = y.AsSpan();
+        var dst = output.AsWritableSpan();
+        for (int i = 0; i < s1.Length; i++)
+        {
+            double a = ops.ToDouble(s1[i]);
+            double b = ops.ToDouble(s2[i]);
+            double yy = ops.ToDouble(sy[i]);
+            dst[i] = ops.FromDouble(Math.Max(0.0, -yy * (a - b) + margin));
+        }
+        return Reduce(output, reduction);
+    }
+
+    /// <summary>Cosine embedding loss with margin.
+    /// <c>1 − cos(x1, x2)</c> when <paramref name="y"/> = +1;
+    /// <c>max(0, cos(x1, x2) − margin)</c> when <paramref name="y"/> = -1.</summary>
+    public static Tensor<T> CosineEmbeddingLoss<T>(Tensor<T> x1, Tensor<T> x2, Tensor<int> y,
+        double margin = 0.0, LossReduction reduction = LossReduction.Mean)
+    {
+        EnsureSameShape(x1, x2);
+        if (x1.Rank != 2)
+            throw new ArgumentException("CosineEmbeddingLoss expects rank-2 inputs.", nameof(x1));
+        var ops = MathHelper.GetNumericOperations<T>();
+        int batch = x1._shape[0], features = x1._shape[1];
+        var output = new Tensor<T>(new[] { batch });
+        var s1 = x1.AsSpan();
+        var s2 = x2.AsSpan();
+        var ySpan = y.AsSpan();
+        var dst = output.AsWritableSpan();
+        for (int b = 0; b < batch; b++)
+        {
+            double dot = 0, n1 = 0, n2 = 0;
+            for (int f = 0; f < features; f++)
+            {
+                double a = ops.ToDouble(s1[b * features + f]);
+                double bb = ops.ToDouble(s2[b * features + f]);
+                dot += a * bb;
+                n1 += a * a;
+                n2 += bb * bb;
+            }
+            double cos = dot / Math.Max(1e-12, Math.Sqrt(n1 * n2));
+            double loss = ySpan[b] == 1 ? 1.0 - cos : Math.Max(0.0, cos - margin);
+            dst[b] = ops.FromDouble(loss);
+        }
+        return Reduce(output, reduction);
+    }
+
+    /// <summary>Hinge embedding loss — <c>x</c> when y=+1, otherwise
+    /// <c>max(0, margin − x)</c>. Mirrors <c>F.hinge_embedding_loss</c>.</summary>
+    public static Tensor<T> HingeEmbeddingLoss<T>(Tensor<T> input, Tensor<int> y,
+        double margin = 1.0, LossReduction reduction = LossReduction.Mean)
+    {
+        if (input.Length != y.Length)
+            throw new ArgumentException("input and y must have the same length.");
+        var ops = MathHelper.GetNumericOperations<T>();
+        var output = new Tensor<T>((int[])input._shape.Clone());
+        var src = input.AsSpan();
+        var ySpan = y.AsSpan();
+        var dst = output.AsWritableSpan();
+        for (int i = 0; i < src.Length; i++)
+        {
+            double xi = ops.ToDouble(src[i]);
+            double loss = ySpan[i] == 1 ? xi : Math.Max(0.0, margin - xi);
+            dst[i] = ops.FromDouble(loss);
+        }
+        return Reduce(output, reduction);
+    }
+
+    /// <summary>Kullback-Leibler divergence with optional <paramref name="logTarget"/>.
+    /// <c>log_target=true</c> means <paramref name="target"/> is in log-space —
+    /// the variant PyTorch added to <c>F.kl_div</c> for stable training.</summary>
+    public static Tensor<T> KLDiv<T>(Tensor<T> input, Tensor<T> target,
+        bool logTarget = false, LossReduction reduction = LossReduction.Mean)
+    {
+        EnsureSameShape(input, target);
+        var ops = MathHelper.GetNumericOperations<T>();
+        var output = new Tensor<T>((int[])input._shape.Clone());
+        var src = input.AsSpan();
+        var tgt = target.AsSpan();
+        var dst = output.AsWritableSpan();
+        for (int i = 0; i < src.Length; i++)
+        {
+            double inputI = ops.ToDouble(src[i]);
+            double targetI = ops.ToDouble(tgt[i]);
+            double term = logTarget
+                ? Math.Exp(targetI) * (targetI - inputI)
+                : targetI * (Math.Log(Math.Max(1e-30, targetI)) - inputI);
+            dst[i] = ops.FromDouble(term);
+        }
+        return Reduce(output, reduction);
+    }
+
+    private static Tensor<T> Reduce<T>(Tensor<T> input, LossReduction reduction)
+    {
+        if (reduction == LossReduction.None) return input;
+        var ops = MathHelper.GetNumericOperations<T>();
+        var src = input.AsSpan();
+        T acc = ops.Zero;
+        for (int i = 0; i < src.Length; i++) acc = ops.Add(acc, src[i]);
+        if (reduction == LossReduction.Mean)
+            acc = ops.Divide(acc, ops.FromDouble(src.Length));
+        var result = new Tensor<T>(new[] { 1 });
+        result.AsWritableSpan()[0] = acc;
+        return result;
+    }
+
+    private static int[] DropLastDim(int[] shape)
+    {
+        if (shape.Length <= 1) return new[] { 1 };
+        var result = new int[shape.Length - 1];
+        Array.Copy(shape, result, shape.Length - 1);
+        return result;
+    }
+
+    private static void EnsureSameShape<T>(Tensor<T> a, Tensor<T> b)
+    {
+        if (a.Length != b.Length || a.Rank != b.Rank)
+            throw new ArgumentException("Shape mismatch between inputs.");
+        for (int i = 0; i < a.Rank; i++)
+            if (a._shape[i] != b._shape[i])
+                throw new ArgumentException($"Shape mismatch on axis {i}: {a._shape[i]} vs {b._shape[i]}.");
+    }
+}

--- a/src/AiDotNet.Tensors/NN/Parametrizations/Parametrizations.cs
+++ b/src/AiDotNet.Tensors/NN/Parametrizations/Parametrizations.cs
@@ -1,0 +1,344 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.NN.Parametrizations;
+
+/// <summary>
+/// Parametrization framework — wrap a parameter with a reparam (e.g.
+/// "always positive" via exp, or "spectral-normalized" via power
+/// iteration) and the wrapper transparently emits the parameterized
+/// value on every forward call. Mirrors <c>torch.nn.utils.parametrize</c>.
+///
+/// <para>Lifecycle:
+/// <list type="number">
+///   <item><see cref="Parametrize{T}.Wrap"/> — bind a reparam to a parameter.</item>
+///   <item><see cref="IParametrization{T}.Forward"/> — called every time the wrapped value is needed.</item>
+///   <item><see cref="Parametrize{T}.Remove"/> — collapse the reparam into the underlying parameter; the wrapper goes away.</item>
+/// </list>
+/// </para>
+/// </summary>
+public interface IParametrization<T>
+{
+    /// <summary>Maps the underlying parameter to its reparameterized
+    /// form. Called every forward pass that touches the parameter.</summary>
+    Tensor<T> Forward(Tensor<T> raw);
+}
+
+/// <summary>Wrapper around a base parameter + a parametrization. The
+/// effective tensor is <c>parametrization.Forward(Raw)</c>.</summary>
+public sealed class ParametrizedParameter<T>
+{
+    /// <summary>The underlying raw tensor — the optimizer updates this
+    /// directly, and the parametrization runs on top.</summary>
+    public Tensor<T> Raw { get; private set; }
+
+    /// <summary>The active parametrization. Replaceable via
+    /// <see cref="Parametrize{T}.Wrap"/>.</summary>
+    public IParametrization<T> Parametrization { get; private set; }
+
+    internal ParametrizedParameter(Tensor<T> raw, IParametrization<T> parametrization)
+    {
+        Raw = raw;
+        Parametrization = parametrization;
+    }
+
+    /// <summary>Returns the parameterized tensor —
+    /// <c>parametrization.Forward(Raw)</c>.</summary>
+    public Tensor<T> Forward() => Parametrization.Forward(Raw);
+}
+
+/// <summary>Static facade over the parametrization framework.</summary>
+public static class Parametrize<T>
+{
+    /// <summary>Wrap <paramref name="raw"/> with <paramref name="parametrization"/>.
+    /// Returns a <see cref="ParametrizedParameter{T}"/> that exposes
+    /// <c>Forward()</c> for callers and keeps <c>Raw</c> available for
+    /// optimizer updates.</summary>
+    public static ParametrizedParameter<T> Wrap(Tensor<T> raw, IParametrization<T> parametrization)
+    {
+        if (raw is null) throw new ArgumentNullException(nameof(raw));
+        if (parametrization is null) throw new ArgumentNullException(nameof(parametrization));
+        return new ParametrizedParameter<T>(raw, parametrization);
+    }
+
+    /// <summary>Consolidate the parametrization into the raw tensor —
+    /// equivalent to <c>parametrize.remove_parametrizations</c>. The
+    /// wrapper becomes a plain <see cref="Tensor{T}"/> matching the
+    /// last forward output.</summary>
+    public static Tensor<T> Remove(ParametrizedParameter<T> wrapped)
+        => wrapped.Forward();
+}
+
+/// <summary>Weight normalization — factors a tensor into direction
+/// (<c>v / ||v||</c>) + magnitude <c>g</c> so the optimizer sees the
+/// magnitude as a scalar variable. Mirrors
+/// <c>torch.nn.utils.weight_norm</c>.</summary>
+public sealed class WeightNorm<T> : IParametrization<T>
+{
+    /// <summary>Per-row magnitude scale <c>g</c>; broadcast against the
+    /// direction vector at forward time.</summary>
+    public Tensor<T> G { get; }
+
+    /// <summary>Axis along which to compute the L2 norm.</summary>
+    public int Dim { get; }
+
+    /// <summary>Constructs a weight-norm parametrization. Initialises
+    /// <see cref="G"/> from the input's per-row L2 norm.</summary>
+    public WeightNorm(Tensor<T> initialV, int dim = 0)
+    {
+        Dim = dim;
+        var ops = MathHelper.GetNumericOperations<T>();
+        if (initialV.Rank != 2)
+            throw new ArgumentException("WeightNorm currently supports rank-2 inputs only.", nameof(initialV));
+
+        int outer = initialV._shape[1 - dim];
+        int inner = initialV._shape[dim];
+        G = new Tensor<T>(new[] { outer });
+        var src = initialV.AsSpan();
+        var gSpan = G.AsWritableSpan();
+        for (int o = 0; o < outer; o++)
+        {
+            double n = 0;
+            for (int i = 0; i < inner; i++)
+            {
+                double v = ops.ToDouble(dim == 0 ? src[i * outer + o] : src[o * inner + i]);
+                n += v * v;
+            }
+            gSpan[o] = ops.FromDouble(Math.Sqrt(n));
+        }
+    }
+
+    /// <inheritdoc/>
+    public Tensor<T> Forward(Tensor<T> raw)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        if (raw.Rank != 2)
+            throw new InvalidOperationException("WeightNorm forward: raw must be rank 2.");
+        int outer = raw._shape[1 - Dim];
+        int inner = raw._shape[Dim];
+        var output = new Tensor<T>((int[])raw._shape.Clone());
+        var src = raw.AsSpan();
+        var dst = output.AsWritableSpan();
+        var gSpan = G.AsSpan();
+        for (int o = 0; o < outer; o++)
+        {
+            double n = 0;
+            for (int i = 0; i < inner; i++)
+            {
+                double v = ops.ToDouble(Dim == 0 ? src[i * outer + o] : src[o * inner + i]);
+                n += v * v;
+            }
+            double normInv = 1.0 / Math.Max(1e-12, Math.Sqrt(n));
+            double g = ops.ToDouble(gSpan[o]);
+            for (int i = 0; i < inner; i++)
+            {
+                int idx = Dim == 0 ? i * outer + o : o * inner + i;
+                dst[idx] = ops.FromDouble(ops.ToDouble(src[idx]) * normInv * g);
+            }
+        }
+        return output;
+    }
+}
+
+/// <summary>Spectral normalization via power iteration. Each forward
+/// runs <paramref name="iters"/> iterations of <c>u ← Wᵀv / ||Wᵀv||</c>
+/// then divides W by its top singular value. Mirrors
+/// <c>torch.nn.utils.spectral_norm</c>.</summary>
+public sealed class SpectralNorm<T> : IParametrization<T>
+{
+    private readonly int _iters;
+    private readonly IEngine _engine;
+    private Tensor<T> _u;
+
+    /// <summary>The most-recent estimated top singular vector. Updated
+    /// in place each forward call.</summary>
+    public Tensor<T> U => _u;
+
+    /// <summary>Constructs spectral-norm with <paramref name="iters"/>
+    /// power-iteration steps per forward.</summary>
+    public SpectralNorm(int outFeatures, int iters = 1)
+    {
+        _iters = iters;
+        _engine = new CpuEngine();
+        var ops = MathHelper.GetNumericOperations<T>();
+        _u = new Tensor<T>(new[] { outFeatures });
+        var span = _u.AsWritableSpan();
+        // Init u to a fixed vector (1, 0, …, 0) — converges from any
+        // non-orthogonal start. Deterministic for tests.
+        span[0] = ops.One;
+    }
+
+    /// <inheritdoc/>
+    public Tensor<T> Forward(Tensor<T> raw)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        if (raw.Rank != 2)
+            throw new InvalidOperationException("SpectralNorm forward: raw must be rank 2.");
+        int outF = raw._shape[0];
+        int inF = raw._shape[1];
+
+        var u = _u;
+        Tensor<T> v = new Tensor<T>(new[] { inF });
+
+        for (int iter = 0; iter < _iters; iter++)
+        {
+            // v = Wᵀu / ||Wᵀu||
+            var rawT = _engine.TensorTranspose(raw);
+            v = MatVec(rawT, u, ops, inF, outF);
+            NormalizeInPlace(v, ops);
+            // u = Wv / ||Wv||
+            u = MatVec(raw, v, ops, outF, inF);
+            NormalizeInPlace(u, ops);
+        }
+        _u = u;
+
+        // Top singular value σ = uᵀWv (one inner product after the loop).
+        double sigma = 0;
+        var rawSpan = raw.AsSpan();
+        var uSpan = u.AsSpan();
+        var vSpan = v.AsSpan();
+        for (int o = 0; o < outF; o++)
+            for (int i = 0; i < inF; i++)
+                sigma += ops.ToDouble(uSpan[o]) * ops.ToDouble(rawSpan[o * inF + i]) * ops.ToDouble(vSpan[i]);
+
+        if (sigma < 1e-12) sigma = 1.0;
+        var output = new Tensor<T>((int[])raw._shape.Clone());
+        var dst = output.AsWritableSpan();
+        for (int i = 0; i < dst.Length; i++)
+            dst[i] = ops.FromDouble(ops.ToDouble(rawSpan[i]) / sigma);
+        return output;
+    }
+
+    private static Tensor<T> MatVec(Tensor<T> M, Tensor<T> v, Interfaces.INumericOperations<T> ops, int outDim, int inDim)
+    {
+        var output = new Tensor<T>(new[] { outDim });
+        var Mspan = M.AsSpan();
+        var vSpan = v.AsSpan();
+        var dst = output.AsWritableSpan();
+        for (int r = 0; r < outDim; r++)
+        {
+            double acc = 0;
+            for (int c = 0; c < inDim; c++)
+                acc += ops.ToDouble(Mspan[r * inDim + c]) * ops.ToDouble(vSpan[c]);
+            dst[r] = ops.FromDouble(acc);
+        }
+        return output;
+    }
+
+    private static void NormalizeInPlace(Tensor<T> t, Interfaces.INumericOperations<T> ops)
+    {
+        var span = t.AsWritableSpan();
+        double n = 0;
+        for (int i = 0; i < span.Length; i++)
+        {
+            double v = ops.ToDouble(span[i]);
+            n += v * v;
+        }
+        n = Math.Max(1e-12, Math.Sqrt(n));
+        for (int i = 0; i < span.Length; i++)
+            span[i] = ops.FromDouble(ops.ToDouble(span[i]) / n);
+    }
+}
+
+/// <summary>Orthogonal parametrization via the Cayley transform —
+/// <c>(I − A) · (I + A)^(-1)</c> where A is the skew-symmetrized raw.
+/// Mirrors <c>torch.nn.utils.orthogonal</c>'s default Cayley path.
+/// Matrix-exp variant is a follow-up gated on
+/// <c>matrix_exp</c> from the linalg parity issue.</summary>
+public sealed class OrthogonalParametrization<T> : IParametrization<T>
+{
+    /// <inheritdoc/>
+    public Tensor<T> Forward(Tensor<T> raw)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        if (raw.Rank != 2 || raw._shape[0] != raw._shape[1])
+            throw new InvalidOperationException("OrthogonalParametrization requires a square matrix.");
+        int n = raw._shape[0];
+
+        // Skew-symmetrize: A = (raw − rawᵀ) / 2.
+        var A = new Tensor<T>(new[] { n, n });
+        var aSpan = A.AsWritableSpan();
+        var src = raw.AsSpan();
+        for (int r = 0; r < n; r++)
+            for (int c = 0; c < n; c++)
+            {
+                double diff = (ops.ToDouble(src[r * n + c]) - ops.ToDouble(src[c * n + r])) * 0.5;
+                aSpan[r * n + c] = ops.FromDouble(diff);
+            }
+
+        // Build (I + A) and (I − A).
+        var iPlusA = new double[n * n];
+        var iMinusA = new double[n * n];
+        for (int r = 0; r < n; r++)
+        {
+            for (int c = 0; c < n; c++)
+            {
+                double a = ops.ToDouble(aSpan[r * n + c]);
+                double diag = r == c ? 1.0 : 0.0;
+                iPlusA[r * n + c] = diag + a;
+                iMinusA[r * n + c] = diag - a;
+            }
+        }
+
+        // Solve (I + A) · X = (I − A) for X via Gaussian elimination.
+        // Result X = (I + A)^(-1) · (I − A) is orthogonal.
+        var X = SolveGeneral(iPlusA, iMinusA, n);
+        var output = new Tensor<T>(new[] { n, n });
+        var dst = output.AsWritableSpan();
+        for (int i = 0; i < X.Length; i++) dst[i] = ops.FromDouble(X[i]);
+        return output;
+    }
+
+    private static double[] SolveGeneral(double[] A, double[] B, int n)
+    {
+        // Augment A | B and run partial-pivot Gaussian elimination.
+        // Returns X = A^(-1) · B as a flat row-major matrix.
+        var aug = new double[n * (2 * n)];
+        for (int r = 0; r < n; r++)
+        {
+            for (int c = 0; c < n; c++) aug[r * (2 * n) + c] = A[r * n + c];
+            for (int c = 0; c < n; c++) aug[r * (2 * n) + n + c] = B[r * n + c];
+        }
+        for (int p = 0; p < n; p++)
+        {
+            // Pivot row.
+            int pivot = p;
+            double pivotMag = Math.Abs(aug[p * (2 * n) + p]);
+            for (int r = p + 1; r < n; r++)
+            {
+                double m = Math.Abs(aug[r * (2 * n) + p]);
+                if (m > pivotMag) { pivotMag = m; pivot = r; }
+            }
+            if (pivotMag < 1e-12)
+                throw new InvalidOperationException("OrthogonalParametrization: (I + A) is singular.");
+            if (pivot != p)
+            {
+                for (int c = 0; c < 2 * n; c++)
+                {
+                    var tmp = aug[p * (2 * n) + c];
+                    aug[p * (2 * n) + c] = aug[pivot * (2 * n) + c];
+                    aug[pivot * (2 * n) + c] = tmp;
+                }
+            }
+            double inv = 1.0 / aug[p * (2 * n) + p];
+            for (int c = 0; c < 2 * n; c++) aug[p * (2 * n) + c] *= inv;
+            for (int r = 0; r < n; r++)
+            {
+                if (r == p) continue;
+                double factor = aug[r * (2 * n) + p];
+                if (factor == 0) continue;
+                for (int c = 0; c < 2 * n; c++)
+                    aug[r * (2 * n) + c] -= factor * aug[p * (2 * n) + c];
+            }
+        }
+        var result = new double[n * n];
+        for (int r = 0; r < n; r++)
+            for (int c = 0; c < n; c++)
+                result[r * n + c] = aug[r * (2 * n) + n + c];
+        return result;
+    }
+}

--- a/src/AiDotNet.Tensors/NN/Parametrizations/Parametrizations.cs
+++ b/src/AiDotNet.Tensors/NN/Parametrizations/Parametrizations.cs
@@ -90,13 +90,21 @@ public sealed class WeightNorm<T> : IParametrization<T>
     /// <see cref="G"/> from the input's per-row L2 norm.</summary>
     public WeightNorm(Tensor<T> initialV, int dim = 0)
     {
+        if ((uint)dim > 1)
+            throw new ArgumentOutOfRangeException(nameof(dim),
+                "WeightNorm dim must be 0 or 1 for the rank-2 path.");
         Dim = dim;
         var ops = MathHelper.GetNumericOperations<T>();
         if (initialV.Rank != 2)
             throw new ArgumentException("WeightNorm currently supports rank-2 inputs only.", nameof(initialV));
 
-        int outer = initialV._shape[1 - dim];
-        int inner = initialV._shape[dim];
+        // Issue: previously `outer = _shape[1 - dim]`, which made
+        // dim=0 produce one g per input column. The PyTorch
+        // convention is one g per slice along `dim` — for dim=0 on
+        // a [out, in] weight that's one g per output row. Fix to
+        // outer = _shape[dim] / inner = _shape[1 - dim].
+        int outer = initialV._shape[dim];
+        int inner = initialV._shape[1 - dim];
         G = new Tensor<T>(new[] { outer });
         var src = initialV.AsSpan();
         var gSpan = G.AsWritableSpan();
@@ -105,7 +113,8 @@ public sealed class WeightNorm<T> : IParametrization<T>
             double n = 0;
             for (int i = 0; i < inner; i++)
             {
-                double v = ops.ToDouble(dim == 0 ? src[i * outer + o] : src[o * inner + i]);
+                int idx = dim == 0 ? o * inner + i : i * outer + o;
+                double v = ops.ToDouble(src[idx]);
                 n += v * v;
             }
             gSpan[o] = ops.FromDouble(Math.Sqrt(n));
@@ -118,8 +127,11 @@ public sealed class WeightNorm<T> : IParametrization<T>
         var ops = MathHelper.GetNumericOperations<T>();
         if (raw.Rank != 2)
             throw new InvalidOperationException("WeightNorm forward: raw must be rank 2.");
-        int outer = raw._shape[1 - Dim];
-        int inner = raw._shape[Dim];
+        int outer = raw._shape[Dim];
+        int inner = raw._shape[1 - Dim];
+        if (outer != G.Length)
+            throw new InvalidOperationException(
+                $"WeightNorm: G length {G.Length} doesn't match raw axis {Dim} length {outer}.");
         var output = new Tensor<T>((int[])raw._shape.Clone());
         var src = raw.AsSpan();
         var dst = output.AsWritableSpan();
@@ -129,14 +141,15 @@ public sealed class WeightNorm<T> : IParametrization<T>
             double n = 0;
             for (int i = 0; i < inner; i++)
             {
-                double v = ops.ToDouble(Dim == 0 ? src[i * outer + o] : src[o * inner + i]);
+                int idx = Dim == 0 ? o * inner + i : i * outer + o;
+                double v = ops.ToDouble(src[idx]);
                 n += v * v;
             }
             double normInv = 1.0 / Math.Max(1e-12, Math.Sqrt(n));
             double g = ops.ToDouble(gSpan[o]);
             for (int i = 0; i < inner; i++)
             {
-                int idx = Dim == 0 ? i * outer + o : o * inner + i;
+                int idx = Dim == 0 ? o * inner + i : i * outer + o;
                 dst[idx] = ops.FromDouble(ops.ToDouble(src[idx]) * normInv * g);
             }
         }
@@ -180,6 +193,10 @@ public sealed class SpectralNorm<T> : IParametrization<T>
             throw new InvalidOperationException("SpectralNorm forward: raw must be rank 2.");
         int outF = raw._shape[0];
         int inF = raw._shape[1];
+        if (_u.Length != outF)
+            throw new InvalidOperationException(
+                $"SpectralNorm was initialised with outFeatures={_u.Length} but received a raw matrix " +
+                $"with {outF} rows. Construct a fresh SpectralNorm per parameter shape.");
 
         var u = _u;
         Tensor<T> v = new Tensor<T>(new[] { inF });

--- a/src/AiDotNet.Tensors/NN/Pruning/Pruning.cs
+++ b/src/AiDotNet.Tensors/NN/Pruning/Pruning.cs
@@ -1,0 +1,257 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.NN.Pruning;
+
+/// <summary>
+/// Pruning APIs — <c>torch.nn.utils.prune</c> equivalent. Each entry
+/// returns a <see cref="PrunedTensor{T}"/> bundling the original raw
+/// values + a binary mask. The masked product
+/// <c>raw ⊙ mask</c> is what downstream ops should consume; calling
+/// <see cref="Pruning.Remove{T}"/> consolidates the mask into the raw
+/// values.
+/// </summary>
+public static class Pruning
+{
+    /// <summary>L1-magnitude unstructured pruning — zeros out the
+    /// <paramref name="amount"/> fraction of weights with the smallest
+    /// absolute value. Mirrors <c>prune.l1_unstructured</c>.</summary>
+    public static PrunedTensor<T> L1Unstructured<T>(Tensor<T> raw, double amount)
+    {
+        if (amount < 0 || amount > 1) throw new ArgumentOutOfRangeException(nameof(amount));
+        var ops = MathHelper.GetNumericOperations<T>();
+        int total = raw.Length;
+        int toPrune = (int)Math.Round(amount * total);
+        var mask = new bool[total];
+        if (toPrune == 0)
+        {
+            for (int i = 0; i < total; i++) mask[i] = true;
+            return new PrunedTensor<T>(raw, mask);
+        }
+        if (toPrune >= total)
+            return new PrunedTensor<T>(raw, mask);
+
+        var src = raw.AsSpan();
+        // Compute |raw_i|, find the k-th smallest as the threshold.
+        var abs = new double[total];
+        for (int i = 0; i < total; i++) abs[i] = Math.Abs(ops.ToDouble(src[i]));
+        var sorted = (double[])abs.Clone();
+        Array.Sort(sorted);
+        double threshold = sorted[toPrune];
+        int actual = 0;
+        for (int i = 0; i < total; i++)
+        {
+            mask[i] = abs[i] >= threshold;
+            if (!mask[i]) actual++;
+            if (actual >= toPrune && abs[i] == threshold) mask[i] = true;
+        }
+        return new PrunedTensor<T>(raw, mask);
+    }
+
+    /// <summary>Random unstructured pruning. <paramref name="seed"/>
+    /// chooses the random subset.</summary>
+    public static PrunedTensor<T> RandomUnstructured<T>(Tensor<T> raw, double amount, int seed = 0)
+    {
+        if (amount < 0 || amount > 1) throw new ArgumentOutOfRangeException(nameof(amount));
+        int total = raw.Length;
+        int toPrune = (int)Math.Round(amount * total);
+        var mask = new bool[total];
+        for (int i = 0; i < total; i++) mask[i] = true;
+        if (toPrune == 0) return new PrunedTensor<T>(raw, mask);
+
+        var rng = new Random(seed);
+        var indices = new int[total];
+        for (int i = 0; i < total; i++) indices[i] = i;
+        // Fisher-Yates shuffle, then pick the first `toPrune` to mask out.
+        for (int i = total - 1; i > 0; i--)
+        {
+            int j = rng.Next(i + 1);
+            (indices[i], indices[j]) = (indices[j], indices[i]);
+        }
+        for (int k = 0; k < toPrune; k++) mask[indices[k]] = false;
+        return new PrunedTensor<T>(raw, mask);
+    }
+
+    /// <summary>Ln-norm structured pruning along the dimension
+    /// <paramref name="dim"/>. Slices with the smallest L<paramref name="n"/>
+    /// norm get the entire slice masked. Mirrors <c>prune.ln_structured</c>.</summary>
+    public static PrunedTensor<T> LnStructured<T>(Tensor<T> raw, double amount, int n, int dim)
+    {
+        if (amount < 0 || amount > 1) throw new ArgumentOutOfRangeException(nameof(amount));
+        if (dim < 0 || dim >= raw.Rank) throw new ArgumentOutOfRangeException(nameof(dim));
+        var ops = MathHelper.GetNumericOperations<T>();
+
+        int outer = 1, axisLen = raw._shape[dim], inner = 1;
+        for (int i = 0; i < dim; i++) outer *= raw._shape[i];
+        for (int i = dim + 1; i < raw.Rank; i++) inner *= raw._shape[i];
+
+        var sliceNorms = new double[axisLen];
+        var src = raw.AsSpan();
+        for (int a = 0; a < axisLen; a++)
+        {
+            double normN = 0;
+            for (int o = 0; o < outer; o++)
+            {
+                for (int i = 0; i < inner; i++)
+                {
+                    double v = ops.ToDouble(src[(o * axisLen + a) * inner + i]);
+                    normN += Math.Pow(Math.Abs(v), n);
+                }
+            }
+            sliceNorms[a] = Math.Pow(normN, 1.0 / n);
+        }
+
+        int toPrune = (int)Math.Round(amount * axisLen);
+        var sortedNorms = (double[])sliceNorms.Clone();
+        Array.Sort(sortedNorms);
+        double threshold = toPrune > 0 ? sortedNorms[Math.Min(toPrune, axisLen - 1)] : double.MinValue;
+
+        var mask = new bool[raw.Length];
+        for (int a = 0; a < axisLen; a++)
+        {
+            bool keep = sliceNorms[a] >= threshold;
+            for (int o = 0; o < outer; o++)
+                for (int i = 0; i < inner; i++)
+                    mask[(o * axisLen + a) * inner + i] = keep;
+        }
+        return new PrunedTensor<T>(raw, mask);
+    }
+
+    /// <summary>Random structured pruning along
+    /// <paramref name="dim"/>. Same shape as
+    /// <see cref="LnStructured{T}"/> but the slice selection is random.</summary>
+    public static PrunedTensor<T> RandomStructured<T>(Tensor<T> raw, double amount, int dim, int seed = 0)
+    {
+        if (amount < 0 || amount > 1) throw new ArgumentOutOfRangeException(nameof(amount));
+        if (dim < 0 || dim >= raw.Rank) throw new ArgumentOutOfRangeException(nameof(dim));
+
+        int outer = 1, axisLen = raw._shape[dim], inner = 1;
+        for (int i = 0; i < dim; i++) outer *= raw._shape[i];
+        for (int i = dim + 1; i < raw.Rank; i++) inner *= raw._shape[i];
+
+        int toPrune = (int)Math.Round(amount * axisLen);
+        var rng = new Random(seed);
+        var sliceIndices = new int[axisLen];
+        for (int i = 0; i < axisLen; i++) sliceIndices[i] = i;
+        for (int i = axisLen - 1; i > 0; i--)
+        {
+            int j = rng.Next(i + 1);
+            (sliceIndices[i], sliceIndices[j]) = (sliceIndices[j], sliceIndices[i]);
+        }
+        var prune = new bool[axisLen];
+        for (int k = 0; k < toPrune; k++) prune[sliceIndices[k]] = true;
+
+        var mask = new bool[raw.Length];
+        for (int a = 0; a < axisLen; a++)
+        {
+            bool keep = !prune[a];
+            for (int o = 0; o < outer; o++)
+                for (int i = 0; i < inner; i++)
+                    mask[(o * axisLen + a) * inner + i] = keep;
+        }
+        return new PrunedTensor<T>(raw, mask);
+    }
+
+    /// <summary>Global unstructured L1 pruning across multiple
+    /// tensors — picks the <paramref name="amount"/> fraction of the
+    /// smallest-magnitude weights from the combined pool. Mirrors
+    /// <c>prune.global_unstructured</c>.</summary>
+    public static PrunedTensor<T>[] GlobalUnstructured<T>(Tensor<T>[] raws, double amount)
+    {
+        if (raws is null) throw new ArgumentNullException(nameof(raws));
+        if (amount < 0 || amount > 1) throw new ArgumentOutOfRangeException(nameof(amount));
+        var ops = MathHelper.GetNumericOperations<T>();
+        int total = 0;
+        for (int t = 0; t < raws.Length; t++) total += raws[t].Length;
+        int toPrune = (int)Math.Round(amount * total);
+
+        var pool = new double[total];
+        int cursor = 0;
+        for (int t = 0; t < raws.Length; t++)
+        {
+            var span = raws[t].AsSpan();
+            for (int i = 0; i < span.Length; i++) pool[cursor++] = Math.Abs(ops.ToDouble(span[i]));
+        }
+        var sortedPool = (double[])pool.Clone();
+        Array.Sort(sortedPool);
+        double threshold = toPrune > 0 ? sortedPool[Math.Min(toPrune, total - 1)] : double.MinValue;
+
+        var result = new PrunedTensor<T>[raws.Length];
+        cursor = 0;
+        for (int t = 0; t < raws.Length; t++)
+        {
+            var mask = new bool[raws[t].Length];
+            var span = raws[t].AsSpan();
+            for (int i = 0; i < span.Length; i++)
+                mask[i] = Math.Abs(ops.ToDouble(span[i])) >= threshold;
+            result[t] = new PrunedTensor<T>(raws[t], mask);
+            cursor += raws[t].Length;
+        }
+        return result;
+    }
+
+    /// <summary>Apply a custom user-supplied mask. Mirrors
+    /// <c>prune.custom_from_mask</c>.</summary>
+    public static PrunedTensor<T> CustomFromMask<T>(Tensor<T> raw, bool[] mask)
+    {
+        if (mask is null) throw new ArgumentNullException(nameof(mask));
+        if (mask.Length != raw.Length)
+            throw new ArgumentException(
+                $"Mask length {mask.Length} doesn't match tensor length {raw.Length}.", nameof(mask));
+        return new PrunedTensor<T>(raw, (bool[])mask.Clone());
+    }
+
+    /// <summary>Consolidates the mask into the raw values — the
+    /// resulting tensor has zeros wherever the mask was false. Mirrors
+    /// <c>prune.remove</c>.</summary>
+    public static Tensor<T> Remove<T>(PrunedTensor<T> pruned)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        var output = new Tensor<T>((int[])pruned.Raw._shape.Clone());
+        var src = pruned.Raw.AsSpan();
+        var dst = output.AsWritableSpan();
+        for (int i = 0; i < src.Length; i++)
+            dst[i] = pruned.IsKept(i) ? src[i] : ops.Zero;
+        return output;
+    }
+}
+
+/// <summary>Bundle of a raw parameter + a per-element keep/prune mask.
+/// <see cref="EffectiveValue"/> returns <c>raw ⊙ mask</c>; the mask
+/// can be inspected via <see cref="IsKept"/>.</summary>
+public sealed class PrunedTensor<T>
+{
+    /// <summary>The underlying raw values — unaffected by pruning until
+    /// <see cref="Pruning.Remove{T}"/> consolidates.</summary>
+    public Tensor<T> Raw { get; }
+
+    private readonly bool[] _mask;
+
+    /// <summary>Number of un-pruned (kept) lanes.</summary>
+    public int KeptCount { get; }
+
+    /// <summary>Constructs a pruned tensor with an explicit mask.</summary>
+    public PrunedTensor(Tensor<T> raw, bool[] mask)
+    {
+        Raw = raw;
+        _mask = mask;
+        int kept = 0;
+        for (int i = 0; i < mask.Length; i++) if (mask[i]) kept++;
+        KeptCount = kept;
+    }
+
+    /// <summary>True when lane <paramref name="i"/> survived pruning.</summary>
+    public bool IsKept(int i) => _mask[i];
+
+    /// <summary>The raw tensor with masked-out lanes zeroed —
+    /// equivalent to calling <see cref="Pruning.Remove{T}"/>.</summary>
+    public Tensor<T> EffectiveValue() => Pruning.Remove(this);
+
+    /// <summary>Read-only view of the mask. Useful for serializing
+    /// or for a custom forward path.</summary>
+    public IReadOnlyList<bool> Mask => _mask;
+}

--- a/src/AiDotNet.Tensors/NN/Pruning/Pruning.cs
+++ b/src/AiDotNet.Tensors/NN/Pruning/Pruning.cs
@@ -22,6 +22,7 @@ public static class Pruning
     /// absolute value. Mirrors <c>prune.l1_unstructured</c>.</summary>
     public static PrunedTensor<T> L1Unstructured<T>(Tensor<T> raw, double amount)
     {
+        if (raw is null) throw new ArgumentNullException(nameof(raw));
         if (amount < 0 || amount > 1) throw new ArgumentOutOfRangeException(nameof(amount));
         var ops = MathHelper.GetNumericOperations<T>();
         int total = raw.Length;
@@ -35,20 +36,17 @@ public static class Pruning
         if (toPrune >= total)
             return new PrunedTensor<T>(raw, mask);
 
+        // Threshold-only pruning under-counts when values tie at the
+        // cutoff. Switch to the (score, index) sort: take the first
+        // `toPrune` indices in ascending magnitude as the prune set.
+        // Exact-count regardless of ties; matches PyTorch's
+        // prune.l1_unstructured semantics.
         var src = raw.AsSpan();
-        // Compute |raw_i|, find the k-th smallest as the threshold.
-        var abs = new double[total];
-        for (int i = 0; i < total; i++) abs[i] = Math.Abs(ops.ToDouble(src[i]));
-        var sorted = (double[])abs.Clone();
-        Array.Sort(sorted);
-        double threshold = sorted[toPrune];
-        int actual = 0;
-        for (int i = 0; i < total; i++)
-        {
-            mask[i] = abs[i] >= threshold;
-            if (!mask[i]) actual++;
-            if (actual >= toPrune && abs[i] == threshold) mask[i] = true;
-        }
+        var indexed = new (double Mag, int Idx)[total];
+        for (int i = 0; i < total; i++) indexed[i] = (Math.Abs(ops.ToDouble(src[i])), i);
+        Array.Sort(indexed, (a, b) => a.Mag.CompareTo(b.Mag));
+        for (int i = 0; i < total; i++) mask[i] = true;
+        for (int k = 0; k < toPrune; k++) mask[indexed[k].Idx] = false;
         return new PrunedTensor<T>(raw, mask);
     }
 
@@ -106,14 +104,18 @@ public static class Pruning
         }
 
         int toPrune = (int)Math.Round(amount * axisLen);
-        var sortedNorms = (double[])sliceNorms.Clone();
-        Array.Sort(sortedNorms);
-        double threshold = toPrune > 0 ? sortedNorms[Math.Min(toPrune, axisLen - 1)] : double.MinValue;
+        // (norm, slice-index) sort + take-k for exact-count pruning
+        // even when norms tie at the cutoff.
+        var indexedNorms = new (double Norm, int Idx)[axisLen];
+        for (int a = 0; a < axisLen; a++) indexedNorms[a] = (sliceNorms[a], a);
+        Array.Sort(indexedNorms, (a, b) => a.Norm.CompareTo(b.Norm));
+        var pruneSlice = new bool[axisLen];
+        for (int k = 0; k < toPrune; k++) pruneSlice[indexedNorms[k].Idx] = true;
 
         var mask = new bool[raw.Length];
         for (int a = 0; a < axisLen; a++)
         {
-            bool keep = sliceNorms[a] >= threshold;
+            bool keep = !pruneSlice[a];
             for (int o = 0; o < outer; o++)
                 for (int i = 0; i < inner; i++)
                     mask[(o * axisLen + a) * inner + i] = keep;
@@ -176,20 +178,23 @@ public static class Pruning
             var span = raws[t].AsSpan();
             for (int i = 0; i < span.Length; i++) pool[cursor++] = Math.Abs(ops.ToDouble(span[i]));
         }
-        var sortedPool = (double[])pool.Clone();
-        Array.Sort(sortedPool);
-        double threshold = toPrune > 0 ? sortedPool[Math.Min(toPrune, total - 1)] : double.MinValue;
+        // Exact-count global pruning via (score, global-index) sort
+        // + take-k. Ties at the cutoff don't bias the prune count.
+        var indexed = new (double Mag, int GlobalIdx)[total];
+        for (int i = 0; i < total; i++) indexed[i] = (pool[i], i);
+        Array.Sort(indexed, (a, b) => a.Mag.CompareTo(b.Mag));
+        var pruneSet = new bool[total];
+        for (int k = 0; k < toPrune; k++) pruneSet[indexed[k].GlobalIdx] = true;
 
         var result = new PrunedTensor<T>[raws.Length];
         cursor = 0;
         for (int t = 0; t < raws.Length; t++)
         {
-            var mask = new bool[raws[t].Length];
-            var span = raws[t].AsSpan();
-            for (int i = 0; i < span.Length; i++)
-                mask[i] = Math.Abs(ops.ToDouble(span[i])) >= threshold;
+            int len = raws[t].Length;
+            var mask = new bool[len];
+            for (int i = 0; i < len; i++) mask[i] = !pruneSet[cursor + i];
             result[t] = new PrunedTensor<T>(raws[t], mask);
-            cursor += raws[t].Length;
+            cursor += len;
         }
         return result;
     }
@@ -234,9 +239,18 @@ public sealed class PrunedTensor<T>
     /// <summary>Number of un-pruned (kept) lanes.</summary>
     public int KeptCount { get; }
 
-    /// <summary>Constructs a pruned tensor with an explicit mask.</summary>
+    /// <summary>Constructs a pruned tensor with an explicit mask.
+    /// <paramref name="mask"/> must have the same length as
+    /// <paramref name="raw"/>; mismatched masks would surface as
+    /// IndexOutOfRangeException in <see cref="IsKept"/> /
+    /// <see cref="Pruning.Remove{T}"/>.</summary>
     public PrunedTensor(Tensor<T> raw, bool[] mask)
     {
+        if (raw is null) throw new ArgumentNullException(nameof(raw));
+        if (mask is null) throw new ArgumentNullException(nameof(mask));
+        if (mask.Length != raw.Length)
+            throw new ArgumentException(
+                $"Mask length {mask.Length} doesn't match tensor length {raw.Length}.", nameof(mask));
         Raw = raw;
         _mask = mask;
         int kept = 0;

--- a/src/AiDotNet.Tensors/NN/Pruning/Pruning.cs
+++ b/src/AiDotNet.Tensors/NN/Pruning/Pruning.cs
@@ -54,6 +54,7 @@ public static class Pruning
     /// chooses the random subset.</summary>
     public static PrunedTensor<T> RandomUnstructured<T>(Tensor<T> raw, double amount, int seed = 0)
     {
+        if (raw is null) throw new ArgumentNullException(nameof(raw));
         if (amount < 0 || amount > 1) throw new ArgumentOutOfRangeException(nameof(amount));
         int total = raw.Length;
         int toPrune = (int)Math.Round(amount * total);
@@ -79,6 +80,7 @@ public static class Pruning
     /// norm get the entire slice masked. Mirrors <c>prune.ln_structured</c>.</summary>
     public static PrunedTensor<T> LnStructured<T>(Tensor<T> raw, double amount, int n, int dim)
     {
+        if (raw is null) throw new ArgumentNullException(nameof(raw));
         if (amount < 0 || amount > 1) throw new ArgumentOutOfRangeException(nameof(amount));
         if (dim < 0 || dim >= raw.Rank) throw new ArgumentOutOfRangeException(nameof(dim));
         var ops = MathHelper.GetNumericOperations<T>();
@@ -128,6 +130,7 @@ public static class Pruning
     /// <see cref="LnStructured{T}"/> but the slice selection is random.</summary>
     public static PrunedTensor<T> RandomStructured<T>(Tensor<T> raw, double amount, int dim, int seed = 0)
     {
+        if (raw is null) throw new ArgumentNullException(nameof(raw));
         if (amount < 0 || amount > 1) throw new ArgumentOutOfRangeException(nameof(amount));
         if (dim < 0 || dim >= raw.Rank) throw new ArgumentOutOfRangeException(nameof(dim));
 
@@ -165,6 +168,9 @@ public static class Pruning
     public static PrunedTensor<T>[] GlobalUnstructured<T>(Tensor<T>[] raws, double amount)
     {
         if (raws is null) throw new ArgumentNullException(nameof(raws));
+        for (int i = 0; i < raws.Length; i++)
+            if (raws[i] is null)
+                throw new ArgumentException($"raws[{i}] is null.", nameof(raws));
         if (amount < 0 || amount > 1) throw new ArgumentOutOfRangeException(nameof(amount));
         var ops = MathHelper.GetNumericOperations<T>();
         int total = 0;
@@ -203,11 +209,12 @@ public static class Pruning
     /// <c>prune.custom_from_mask</c>.</summary>
     public static PrunedTensor<T> CustomFromMask<T>(Tensor<T> raw, bool[] mask)
     {
+        if (raw is null) throw new ArgumentNullException(nameof(raw));
         if (mask is null) throw new ArgumentNullException(nameof(mask));
         if (mask.Length != raw.Length)
             throw new ArgumentException(
                 $"Mask length {mask.Length} doesn't match tensor length {raw.Length}.", nameof(mask));
-        return new PrunedTensor<T>(raw, (bool[])mask.Clone());
+        return new PrunedTensor<T>(raw, mask);
     }
 
     /// <summary>Consolidates the mask into the raw values — the
@@ -215,6 +222,7 @@ public static class Pruning
     /// <c>prune.remove</c>.</summary>
     public static Tensor<T> Remove<T>(PrunedTensor<T> pruned)
     {
+        if (pruned is null) throw new ArgumentNullException(nameof(pruned));
         var ops = MathHelper.GetNumericOperations<T>();
         var output = new Tensor<T>((int[])pruned.Raw._shape.Clone());
         var src = pruned.Raw.AsSpan();
@@ -243,7 +251,11 @@ public sealed class PrunedTensor<T>
     /// <paramref name="mask"/> must have the same length as
     /// <paramref name="raw"/>; mismatched masks would surface as
     /// IndexOutOfRangeException in <see cref="IsKept"/> /
-    /// <see cref="Pruning.Remove{T}"/>.</summary>
+    /// <see cref="Pruning.Remove{T}"/>.
+    ///
+    /// <para>The mask is cloned on entry so the caller can't mutate
+    /// it after construction (which would silently change pruning
+    /// behaviour while <see cref="KeptCount"/> stays stale).</para></summary>
     public PrunedTensor(Tensor<T> raw, bool[] mask)
     {
         if (raw is null) throw new ArgumentNullException(nameof(raw));
@@ -252,9 +264,9 @@ public sealed class PrunedTensor<T>
             throw new ArgumentException(
                 $"Mask length {mask.Length} doesn't match tensor length {raw.Length}.", nameof(mask));
         Raw = raw;
-        _mask = mask;
+        _mask = (bool[])mask.Clone();
         int kept = 0;
-        for (int i = 0; i < mask.Length; i++) if (mask[i]) kept++;
+        for (int i = 0; i < _mask.Length; i++) if (_mask[i]) kept++;
         KeptCount = kept;
     }
 
@@ -265,7 +277,10 @@ public sealed class PrunedTensor<T>
     /// equivalent to calling <see cref="Pruning.Remove{T}"/>.</summary>
     public Tensor<T> EffectiveValue() => Pruning.Remove(this);
 
-    /// <summary>Read-only view of the mask. Useful for serializing
-    /// or for a custom forward path.</summary>
-    public IReadOnlyList<bool> Mask => _mask;
+    /// <summary>Read-only view of the mask. Wrapped via
+    /// <see cref="Array.AsReadOnly{T}"/> so callers can't downcast
+    /// back to <c>bool[]</c> and mutate the internal mask
+    /// (<c>(IReadOnlyList&lt;bool&gt;)bool[]</c> is the same array
+    /// reference; the wrapper breaks that round-trip).</summary>
+    public IReadOnlyList<bool> Mask => Array.AsReadOnly(_mask);
 }

--- a/tests/AiDotNet.Tensors.Tests/NN/NnPrimitivesTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/NN/NnPrimitivesTests.cs
@@ -1,0 +1,392 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.Tensors.NN.Activations;
+using AiDotNet.Tensors.NN.Functional;
+using AiDotNet.Tensors.NN.Losses;
+using AiDotNet.Tensors.NN.Parametrizations;
+using AiDotNet.Tensors.NN.Pruning;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.NN;
+
+/// <summary>
+/// Acceptance tests for #223 (torch.nn primitives gap). Covers the
+/// new losses, functional utilities, activations, parametrizations,
+/// and pruning APIs.
+/// </summary>
+public class NnPrimitivesTests
+{
+    // ======================  LOSSES  ======================
+
+    [Fact]
+    public void SmoothL1Loss_BetaOneMatchesHuberAtAbsDiffAboveBeta()
+    {
+        var x = MakeFloats(new[] { 1f, 5f, -3f });
+        var y = MakeFloats(new[] { 0f, 0f, 0f });
+        // |diff| = [1, 5, 3]; with beta=1:
+        //   diff=1   → 0.5*1²/1 = 0.5
+        //   diff=5   → 5 - 0.5 = 4.5
+        //   diff=3   → 3 - 0.5 = 2.5
+        // sum = 7.5; mean = 2.5.
+        var loss = Losses.SmoothL1Loss(x, y, beta: 1.0, reduction: LossReduction.Mean);
+        Assert.Equal(2.5f, loss.AsSpan()[0], 4);
+    }
+
+    [Fact]
+    public void PoissonNllLoss_NonLogInputComputesXminusTLogX()
+    {
+        var x = MakeFloats(new[] { 2f, 3f });
+        var y = MakeFloats(new[] { 1f, 2f });
+        // logInput=false: x − t·log(x+eps)
+        // [2 − 1·log(2), 3 − 2·log(3)]
+        var loss = Losses.PoissonNllLoss(x, y, logInput: false, reduction: LossReduction.None);
+        Assert.Equal(2f - MathF.Log(2f), loss.AsSpan()[0], 3);
+        Assert.Equal(3f - 2f * MathF.Log(3f), loss.AsSpan()[1], 3);
+    }
+
+    [Fact]
+    public void GaussianNllLoss_PositivePredictedVarianceIsClampedAtEps()
+    {
+        var x = MakeFloats(new[] { 1f });
+        var y = MakeFloats(new[] { 0f });
+        var v = MakeFloats(new[] { -1f }); // negative — must be clamped to eps.
+        var loss = Losses.GaussianNllLoss(x, y, v, eps: 1e-3, reduction: LossReduction.None);
+        // 0.5 * (log(1e-3) + (0 − 1)² / 1e-3) = 0.5 * (-6.908 + 1000) ≈ 496.5
+        Assert.True(loss.AsSpan()[0] > 100f);
+    }
+
+    [Fact]
+    public void MultiMarginLoss_PositiveTargetMatchingHasZeroLoss()
+    {
+        // Class 0 is the target and is the largest score → loss = 0.
+        var x = new Tensor<float>(new[] { 1, 3 });
+        x[0, 0] = 5; x[0, 1] = 0; x[0, 2] = 0;
+        var t = new Tensor<int>(new[] { 1 });
+        t.AsWritableSpan()[0] = 0;
+        var loss = Losses.MultiMarginLoss(x, t, reduction: LossReduction.None);
+        // For each j ≠ 0: max(0, 1 - 5 + x[j]) — both negative → 0.
+        Assert.Equal(0f, loss.AsSpan()[0], 4);
+    }
+
+    [Fact]
+    public void TripletMarginLoss_AnchorEqualPositiveYieldsZeroBeforeMargin()
+    {
+        var a = MakeMatrix(new[,] { { 1f, 2f, 3f } });
+        var p = MakeMatrix(new[,] { { 1f, 2f, 3f } });   // distance(a,p) = 0
+        var n = MakeMatrix(new[,] { { 5f, 5f, 5f } });   // distance(a,n) > 0
+        // Loss = max(0, 0 - dNeg + margin); margin=1, dNeg ≈ 5 → loss = 0.
+        var loss = Losses.TripletMarginLoss(a, p, n, margin: 1.0, reduction: LossReduction.None);
+        Assert.Equal(0f, loss.AsSpan()[0], 3);
+    }
+
+    [Fact]
+    public void MarginRankingLoss_HigherRankedFirstWithPositiveLabelHasZeroLoss()
+    {
+        var x1 = MakeFloats(new[] { 5f });
+        var x2 = MakeFloats(new[] { 1f });
+        var y = MakeFloats(new[] { 1f });
+        var loss = Losses.MarginRankingLoss(x1, x2, y, reduction: LossReduction.None);
+        // -1 · (5 - 1) + 0 = -4 → max(0, -4) = 0.
+        Assert.Equal(0f, loss.AsSpan()[0], 4);
+    }
+
+    [Fact]
+    public void CosineEmbeddingLoss_IdenticalVectorsWithLabel1HaveZeroLoss()
+    {
+        var x = new Tensor<float>(new[] { 1, 3 });
+        x[0, 0] = 1; x[0, 1] = 2; x[0, 2] = 3;
+        var y = new Tensor<int>(new[] { 1 });
+        y.AsWritableSpan()[0] = 1;
+        var loss = Losses.CosineEmbeddingLoss(x, x, y, reduction: LossReduction.None);
+        Assert.Equal(0f, loss.AsSpan()[0], 3);
+    }
+
+    [Fact]
+    public void HingeEmbeddingLoss_PositiveLabelPassesInputThrough()
+    {
+        var x = MakeFloats(new[] { 0.5f, -0.2f });
+        var y = new Tensor<int>(new[] { 2 });
+        y.AsWritableSpan()[0] = 1;
+        y.AsWritableSpan()[1] = 1;
+        var loss = Losses.HingeEmbeddingLoss(x, y, reduction: LossReduction.None);
+        Assert.Equal(0.5f, loss.AsSpan()[0], 4);
+        Assert.Equal(-0.2f, loss.AsSpan()[1], 4);
+    }
+
+    [Fact]
+    public void KLDiv_LogTargetTrueMatchesExpFormula()
+    {
+        var input = MakeFloats(new[] { -1f }); // log p
+        var target = MakeFloats(new[] { -2f }); // log q (since log_target=true)
+        var loss = Losses.KLDiv(input, target, logTarget: true, reduction: LossReduction.None);
+        // exp(-2) * (-2 - (-1)) = exp(-2) * -1 ≈ -0.1353
+        Assert.Equal(-MathF.Exp(-2f), loss.AsSpan()[0], 4);
+    }
+
+    // ======================  FUNCTIONAL  ======================
+
+    [Fact]
+    public void Normalize_RowsHaveUnitL2Norm()
+    {
+        var x = MakeMatrix(new[,] { { 3f, 4f }, { 1f, 0f } });
+        var n = Functional.Normalize(x, p: 2.0, dim: 1);
+        // Row 0: ||(3,4)|| = 5 → (0.6, 0.8). Row 1: ||(1,0)|| = 1 → (1, 0).
+        Assert.Equal(0.6f, n[0, 0], 3);
+        Assert.Equal(0.8f, n[0, 1], 3);
+        Assert.Equal(1f, n[1, 0], 3);
+    }
+
+    [Fact]
+    public void OneHot_PlacesOneAtTheCorrectClass()
+    {
+        var idx = new Tensor<int>(new[] { 3 });
+        idx.AsWritableSpan()[0] = 0;
+        idx.AsWritableSpan()[1] = 2;
+        idx.AsWritableSpan()[2] = 1;
+        var oh = Functional.OneHot(idx, 4);
+        Assert.Equal(new[] { 3, 4 }, oh._shape);
+        Assert.Equal(1, oh[0, 0]);
+        Assert.Equal(1, oh[1, 2]);
+        Assert.Equal(1, oh[2, 1]);
+        Assert.Equal(0, oh[0, 1]);
+    }
+
+    [Fact]
+    public void PairwiseDistance_L2MatchesEuclidean()
+    {
+        var x1 = MakeMatrix(new[,] { { 0f, 0f }, { 3f, 4f } });
+        var x2 = MakeMatrix(new[,] { { 3f, 4f }, { 0f, 0f } });
+        var d = Functional.PairwiseDistance(x1, x2, p: 2.0, eps: 0.0);
+        Assert.Equal(5f, d.AsSpan()[0], 3);
+        Assert.Equal(5f, d.AsSpan()[1], 3);
+    }
+
+    [Fact]
+    public void Embedding_LooksUpRowsByIndex()
+    {
+        var idx = new Tensor<int>(new[] { 2 });
+        idx.AsWritableSpan()[0] = 1;
+        idx.AsWritableSpan()[1] = 0;
+        var w = MakeMatrix(new[,] { { 1f, 2f, 3f }, { 10f, 20f, 30f } });
+        var emb = Functional.Embedding(idx, w);
+        Assert.Equal(new[] { 2, 3 }, emb._shape);
+        Assert.Equal(10f, emb[0, 0]);
+        Assert.Equal(20f, emb[0, 1]);
+        Assert.Equal(1f, emb[1, 0]);
+    }
+
+    [Fact]
+    public void EmbeddingBag_MeanModeAveragesWithinBags()
+    {
+        // Bag 0: indices [0, 1] → mean of weights[0] + weights[1] = (5.5, 11)
+        // Bag 1: indices [1] → weights[1] = (10, 20)
+        var idx = new Tensor<int>(new[] { 3 });
+        idx.AsWritableSpan()[0] = 0;
+        idx.AsWritableSpan()[1] = 1;
+        idx.AsWritableSpan()[2] = 1;
+        var w = MakeMatrix(new[,] { { 1f, 2f }, { 10f, 20f } });
+        var bag = Functional.EmbeddingBag(idx, w, new[] { 0, 2 }, Functional.EmbeddingBagMode.Mean);
+        Assert.Equal(5.5f, bag[0, 0], 3);
+        Assert.Equal(11f, bag[0, 1], 3);
+        Assert.Equal(10f, bag[1, 0], 3);
+    }
+
+    // ======================  ACTIVATIONS  ======================
+
+    [Fact]
+    public void Hardshrink_ZeroesValuesBelowLambda()
+    {
+        var x = MakeFloats(new[] { 0.1f, 0.6f, -0.3f, -0.7f });
+        var r = Activations.Hardshrink(x, lambda: 0.5);
+        Assert.Equal(0f, r.AsSpan()[0]);
+        Assert.Equal(0.6f, r.AsSpan()[1]);
+        Assert.Equal(0f, r.AsSpan()[2]);
+        Assert.Equal(-0.7f, r.AsSpan()[3]);
+    }
+
+    [Fact]
+    public void Softshrink_ShrinksTowardZero()
+    {
+        var x = MakeFloats(new[] { 0.1f, 0.6f, -0.7f });
+        var r = Activations.Softshrink(x, lambda: 0.5);
+        Assert.Equal(0f, r.AsSpan()[0], 4);
+        Assert.Equal(0.1f, r.AsSpan()[1], 4);
+        Assert.Equal(-0.2f, r.AsSpan()[2], 4);
+    }
+
+    [Fact]
+    public void Tanhshrink_EqualsXMinusTanhX()
+    {
+        var x = MakeFloats(new[] { 1f });
+        var r = Activations.Tanhshrink(x);
+        Assert.Equal(1f - MathF.Tanh(1f), r.AsSpan()[0], 4);
+    }
+
+    [Fact]
+    public void Threshold_ReplacesValuesBelowThreshold()
+    {
+        var r = Activations.Threshold(MakeFloats(new[] { -1f, 5f, -100f }), threshold: 0.0, value: 0.0);
+        Assert.Equal(0f, r.AsSpan()[0]);   // -1 ≤ 0 → replaced with 0
+        Assert.Equal(5f, r.AsSpan()[1]);   // 5 > 0 → kept
+        Assert.Equal(0f, r.AsSpan()[2]);   // -100 ≤ 0 → replaced
+    }
+
+    [Fact]
+    public void QuickGelu_ApproximatesGeluCloselyAtZero()
+    {
+        var x = MakeFloats(new[] { 0f });
+        var r = Activations.QuickGelu(x);
+        Assert.Equal(0f, r.AsSpan()[0], 4);
+    }
+
+    [Fact]
+    public void GeluTanh_AtZeroIsZero()
+    {
+        var x = MakeFloats(new[] { 0f });
+        var r = Activations.GeluTanh(x);
+        Assert.Equal(0f, r.AsSpan()[0], 5);
+    }
+
+    [Fact]
+    public void SwiGLU_HalvesLastDim()
+    {
+        var x = MakeMatrix(new[,] { { 1f, 2f, 3f, 4f } });
+        var r = Activations.SwiGLU(x);
+        Assert.Equal(new[] { 1, 2 }, r._shape);
+        // a = (1, 2); b = (3, 4); SiLU(1) ≈ 0.7311; SiLU(2) ≈ 1.7616.
+        // r = (silu(1)*3, silu(2)*4)
+        Assert.Equal(0.7311f * 3f, r.AsSpan()[0], 2);
+        Assert.Equal(1.7616f * 4f, r.AsSpan()[1], 2);
+    }
+
+    [Fact]
+    public void ReGLU_HalvesLastDimAndAppliesReLU()
+    {
+        var x = MakeMatrix(new[,] { { 1f, -1f, 5f, 6f } });
+        var r = Activations.ReGLU(x);
+        Assert.Equal(new[] { 1, 2 }, r._shape);
+        // a=(1,-1); ReLU(a)=(1,0); b=(5,6); r=(5, 0).
+        Assert.Equal(5f, r.AsSpan()[0]);
+        Assert.Equal(0f, r.AsSpan()[1]);
+    }
+
+    // ======================  PARAMETRIZATIONS  ======================
+
+    [Fact]
+    public void WeightNorm_ForwardScalesRowsBackToOriginalNorms()
+    {
+        var w = MakeMatrix(new[,] { { 3f, 4f }, { 1f, 0f } });
+        var wn = new WeightNorm<float>(w, dim: 1);
+        var out_ = wn.Forward(w);
+        // Row 0 should still have ||row|| ≈ 5; row 1 still ≈ 1.
+        // Norm is preserved exactly when the magnitude g is initialised
+        // from the input's own per-row norms.
+        double n0 = Math.Sqrt(out_[0, 0] * out_[0, 0] + out_[0, 1] * out_[0, 1]);
+        double n1 = Math.Sqrt(out_[1, 0] * out_[1, 0] + out_[1, 1] * out_[1, 1]);
+        Assert.Equal(5.0, n0, 3);
+        Assert.Equal(1.0, n1, 3);
+    }
+
+    [Fact]
+    public void SpectralNorm_BoundsTopSingularValueToOne()
+    {
+        // 2x2 matrix with known singular values 4 and 2.
+        var w = MakeMatrix(new[,] { { 4f, 0f }, { 0f, 2f } });
+        var sn = new SpectralNorm<float>(outFeatures: 2, iters: 50);
+        var normed = sn.Forward(w);
+        // After spectral normalization the matrix's largest singular
+        // value should be approximately 1.
+        double n0 = Math.Sqrt(normed[0, 0] * normed[0, 0] + normed[0, 1] * normed[0, 1]);
+        double n1 = Math.Sqrt(normed[1, 0] * normed[1, 0] + normed[1, 1] * normed[1, 1]);
+        Assert.True(Math.Max(n0, n1) <= 1.0 + 1e-2);
+    }
+
+    [Fact]
+    public void Orthogonal_ProducesOrthogonalMatrixCayleyTransform()
+    {
+        // Skew-symmetric input → Cayley(skew) is orthogonal.
+        var w = MakeMatrix(new[,] { { 0f, 1f }, { -1f, 0f } });
+        var op = new OrthogonalParametrization<float>();
+        var Q = op.Forward(w);
+        // QQᵀ = I.
+        double q00 = Q[0, 0] * Q[0, 0] + Q[0, 1] * Q[0, 1];
+        double q11 = Q[1, 0] * Q[1, 0] + Q[1, 1] * Q[1, 1];
+        double q01 = Q[0, 0] * Q[1, 0] + Q[0, 1] * Q[1, 1];
+        Assert.Equal(1.0, q00, 3);
+        Assert.Equal(1.0, q11, 3);
+        Assert.Equal(0.0, q01, 3);
+    }
+
+    // ======================  PRUNING  ======================
+
+    [Fact]
+    public void L1Unstructured_RemovesSmallestMagnitudeFraction()
+    {
+        var w = MakeFloats(new[] { 0.1f, 0.5f, -0.05f, 1f, 2f });
+        var pruned = Pruning.L1Unstructured(w, amount: 0.4); // prune 2 of 5.
+        Assert.Equal(3, pruned.KeptCount);
+        // The two smallest magnitudes are 0.05 and 0.1 — both should be pruned.
+        Assert.False(pruned.IsKept(0));
+        Assert.False(pruned.IsKept(2));
+        Assert.True(pruned.IsKept(1));
+        Assert.True(pruned.IsKept(3));
+        Assert.True(pruned.IsKept(4));
+    }
+
+    [Fact]
+    public void RandomUnstructured_ProducesDeterministicMaskFromSeed()
+    {
+        var w = MakeFloats(new[] { 1f, 2f, 3f, 4f, 5f });
+        var p1 = Pruning.RandomUnstructured(w, amount: 0.4, seed: 42);
+        var p2 = Pruning.RandomUnstructured(w, amount: 0.4, seed: 42);
+        Assert.Equal(p1.KeptCount, p2.KeptCount);
+        for (int i = 0; i < 5; i++)
+            Assert.Equal(p1.IsKept(i), p2.IsKept(i));
+    }
+
+    [Fact]
+    public void GlobalUnstructured_PrunesSmallestAcrossPool()
+    {
+        var w1 = MakeFloats(new[] { 0.1f, 5f });
+        var w2 = MakeFloats(new[] { 0.2f, 0.05f });
+        var pruned = Pruning.GlobalUnstructured(new[] { w1, w2 }, amount: 0.5);
+        // Pool: [0.1, 5, 0.2, 0.05]; smallest 2 are 0.05 and 0.1 → mask both.
+        Assert.False(pruned[0].IsKept(0));   // 0.1
+        Assert.True(pruned[0].IsKept(1));    // 5
+        Assert.True(pruned[1].IsKept(0));    // 0.2 — kept (3rd smallest)
+        Assert.False(pruned[1].IsKept(1));   // 0.05
+    }
+
+    [Fact]
+    public void Remove_ZeroesOutPrunedLanes()
+    {
+        var w = MakeFloats(new[] { 1f, 2f, 3f, 4f });
+        var mask = new[] { true, false, true, false };
+        var pruned = Pruning.CustomFromMask(w, mask);
+        var consolidated = Pruning.Remove(pruned);
+        Assert.Equal(1f, consolidated.AsSpan()[0]);
+        Assert.Equal(0f, consolidated.AsSpan()[1]);
+        Assert.Equal(3f, consolidated.AsSpan()[2]);
+        Assert.Equal(0f, consolidated.AsSpan()[3]);
+    }
+
+    private static Tensor<float> MakeFloats(float[] data)
+    {
+        var t = new Tensor<float>(new[] { data.Length });
+        var s = t.AsWritableSpan();
+        for (int i = 0; i < data.Length; i++) s[i] = data[i];
+        return t;
+    }
+
+    private static Tensor<float> MakeMatrix(float[,] data)
+    {
+        int r = data.GetLength(0), c = data.GetLength(1);
+        var t = new Tensor<float>(new[] { r, c });
+        for (int i = 0; i < r; i++)
+            for (int j = 0; j < c; j++)
+                t[i, j] = data[i, j];
+        return t;
+    }
+}


### PR DESCRIPTION
## Summary

Fills in the `torch.nn.functional` gaps that weren't already covered by `IEngine`. Engine ships `HuberLoss` / `CTCLoss` / `CosineSimilarityLoss` / `TensorPDist` / `TensorCDist` / `TensorCosineSimilarity` / `PReLU` / `RReLU`; this PR adds the long-tail surface PyTorch lists under `torch.nn.functional` plus the new parametrization + pruning frameworks.

### `NN/Losses/Losses.cs`
- `LossReduction` enum (None / Mean / Sum) used by every entry
- `SmoothL1Loss` (configurable beta), `PoissonNllLoss` (logInput + Stirling-full), `GaussianNllLoss` (predicted variance with eps clamp)
- `MultiMarginLoss` (with class weights), `MultiLabelMarginLoss`, `MultiLabelSoftMarginLoss`
- `TripletMarginLoss` (Lp distance + eps), `TripletMarginWithDistanceLoss` (custom distance fn + swap), `MarginRankingLoss`
- `CosineEmbeddingLoss` (with margin), `HingeEmbeddingLoss`
- `KLDiv` (with `log_target` variant — the stable training mode)

### `NN/Functional/Functional.cs`
- `Normalize` (Lp normalize along a dim with eps)
- `OneHot` (integer index → one-hot int tensor)
- `PairwiseDistance` (Lp distance per row of two rank-2 inputs)
- `Embedding` (with `paddingIdx` zero-fill, `max_norm` clipping, `scale_grad_by_freq` forward path)
- `EmbeddingBag` (Sum / Mean / Max modes)

### `NN/Activations/Activations.cs`
- `Hardshrink`, `Softshrink`, `Tanhshrink`, `Threshold`
- `QuickGelu` (cheap CLIP/GPT-2 path), `GeluTanh` (PyTorch's `approximate="tanh"` GELU)
- `SwiGLU` / `GEGLU` / `ReGLU` — the GLU family that powers LLaMA / Gemma / Mistral, as first-class ops

### `NN/Parametrizations/Parametrizations.cs`
- `IParametrization<T>` + `ParametrizedParameter<T>` wrap-and-forward framework with `Wrap` / `Remove`
- `WeightNorm` parametrization (per-row direction + magnitude factor)
- `SpectralNorm` parametrization (power iteration with cached u)
- `OrthogonalParametrization` (Cayley transform — skew-symmetrize then solve (I+A)·X = (I−A) via partial-pivot Gaussian elimination)

### `NN/Pruning/Pruning.cs`
- `L1Unstructured` (magnitude-based prune)
- `RandomUnstructured` (deterministic Fisher-Yates shuffle keyed on seed)
- `LnStructured` / `RandomStructured` (slice-level pruning along a dim)
- `GlobalUnstructured` (cross-tensor magnitude pool)
- `CustomFromMask`, `Remove` (mask consolidation)
- `PrunedTensor<T>` bundle with `Raw` / `Mask` / `KeptCount` / `EffectiveValue`

### Acceptance tests (29 tests, 29 passing on net10.0 + net471)
- **Losses**: formula matches for SmoothL1, PoissonNll, GaussianNll, MultiMargin / TripletMargin / MarginRanking / CosineEmbedding / HingeEmbedding zero-loss cases, KLDiv `log_target` exp formula
- **Functional**: Normalize unit L2, OneHot placement, PairwiseDistance L2, Embedding row lookup, EmbeddingBag mean averaging
- **Activations**: Hardshrink / Softshrink / Tanhshrink / Threshold formulas, QuickGelu / GeluTanh at zero, SwiGLU / ReGLU last-dim halving
- **Parametrizations**: WeightNorm preserves row norms, SpectralNorm bounds top singular value, Orthogonal Cayley produces QQᵀ = I
- **Pruning**: L1 magnitude prune, deterministic random prune, global pool prune, mask consolidation

Closes #223.

## Test plan
- [x] `dotnet build` clean on net10.0
- [x] `dotnet build` clean on net471
- [x] 29/29 NN primitives tests pass on net10.0
- [x] 29/29 NN primitives tests pass on net471