### PR TITLE
fix(#279): GradientTape leak + single-thread backward across all linear ops

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -377,8 +377,17 @@ internal static class BackwardFunctions<T>
         Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
         object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
     {
-        // Float32 + 2D fast path: compute transposed GEMMs into pooled buffers, then accumulate.
-        if (typeof(T) == typeof(float) && inputs[0].Rank == 2 && inputs[1].Rank == 2)
+        // Float32 + 2D fast paths (SimdGemm and BLAS): compute transposed GEMMs
+        // into pooled buffers, then accumulate. Both bypass engine recording
+        // (the kernels write directly to managed arrays without going through
+        // any tape-aware op), so they're gated on no-active-tape — when a tape
+        // is recording we want createGraph=true and Hvp-style higher-order AD
+        // to stay on the engine path so each gradient computation is itself
+        // recorded into the outer tape. Rentals also live behind the gate so
+        // the recording path doesn't pay AutoTensorCache lookups it won't use.
+        if (typeof(T) == typeof(float)
+            && inputs[0].Rank == 2 && inputs[1].Rank == 2
+            && GradientTape<T>.Current is null)
         {
             var dCArr = (gradOutput as Tensor<float>)?.GetDataArray();
             var aArr = (inputs[0] as Tensor<float>)?.GetDataArray();
@@ -396,11 +405,10 @@ internal static class BackwardFunctions<T>
                 var gradAData = (float[])(object)gradATensor.GetDataArray();
                 var gradBData = (float[])(object)gradBTensor.GetDataArray();
 
-                // Parallel SimdGemm path: bypasses single-threaded BLAS providers when
-                // no tape is recording (createGraph=true would need engine ops to wire
-                // gradients into the outer tape — that path stays on the engine below).
+                // Parallel SimdGemm path: bypasses single-threaded BLAS providers
+                // when work is large enough to amortize task spawn cost.
                 long backwardWork = (long)M * K * N;
-                if (GradientTape<T>.Current is null && backwardWork >= MatMulBackwardSimdThreshold)
+                if (backwardWork >= MatMulBackwardSimdThreshold)
                 {
                     // gradA[M,K] = dC[M,N] · Bᵀ[N,K]. B is stored row-major [K,N] (ldb=N), transB=true.
                     SimdGemm.Sgemm(dCArr, N, false, bArr, N, true, gradAData.AsSpan(0, M * K), M, N, K);

--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -359,18 +359,32 @@ internal static class BackwardFunctions<T>
     // ──────────────────────────────────────────────────────────────
 
     /// <summary>
-    /// Threshold (in FMAs ≈ 2·M·K·N flops / 2) above which the float32 backward
-    /// MatMul prefers the in-process parallel <see cref="SimdGemm"/> path over
-    /// <see cref="BlasProvider.TryGemmEx"/>. The provider may dispatch to a
-    /// single-threaded BLAS install (Microsoft.ML/CRT BLAS lacks Parallel.For
-    /// internally on some runtimes), which silently caps backward throughput
-    /// to one core during training. SimdGemm is guaranteed parallel on shapes
-    /// at or above its own internal threshold, so we use it directly when the
-    /// work is large enough to amortize task spawn cost. 4096 FMAs ≈ a 16×16×16
-    /// matmul — small enough that anything resembling a transformer FFN
-    /// (≥256×768×768 ≈ 150M FMAs) crosses it by orders of magnitude.
+    /// Work threshold (M·K·N) above which the float32 backward MatMul prefers
+    /// <see cref="SimdGemm"/> over <see cref="BlasProvider.TryGemmEx"/>. The
+    /// goal is "take SimdGemm only when it will actually run parallel" —
+    /// SimdGemm has its own internal parallel gate (≥2 Mi work-elements,
+    /// scaled up to 20 Mi by core count), so anything below that runs
+    /// sequentially inside SimdGemm and offers no advantage over BLAS.
+    ///
+    /// On installs with a parallel native BLAS, BLAS already uses many cores
+    /// and we don't need SimdGemm. On installs whose BLAS provider is
+    /// single-threaded (Microsoft.ML/CRT BLAS lacks internal Parallel.For on
+    /// some runtimes), SimdGemm overtakes BLAS — but only at shapes large
+    /// enough that SimdGemm itself parallelizes. So the threshold is mirrored
+    /// from <c>SimdGemm.ParallelWorkThreshold</c> at runtime.
     /// </summary>
-    private const long MatMulBackwardSimdThreshold = 4096L;
+    private static readonly long MatMulBackwardSimdThreshold = ComputeSimdGemmParallelThreshold();
+
+    private static long ComputeSimdGemmParallelThreshold()
+    {
+        // Mirrors SimdGemm.ComputeParallelWorkThreshold so the backward path
+        // takes SimdGemm exactly when SimdGemm itself will go parallel.
+        int cores = Math.Max(1, Environment.ProcessorCount);
+        long scaled = (20L * 1024 * 1024 / 16) * cores;
+        if (scaled < 2L * 1024 * 1024) scaled = 2L * 1024 * 1024;
+        if (scaled > 20L * 1024 * 1024) scaled = 20L * 1024 * 1024;
+        return scaled;
+    }
 
     /// <summary>d(A@B)/dA = grad @ B^T, d(A@B)/dB = A^T @ grad</summary>
     internal static void MatMulBackward(

--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -358,14 +358,27 @@ internal static class BackwardFunctions<T>
     // Matrix operations
     // ──────────────────────────────────────────────────────────────
 
+    /// <summary>
+    /// Threshold (in FMAs ≈ 2·M·K·N flops / 2) above which the float32 backward
+    /// MatMul prefers the in-process parallel <see cref="SimdGemm"/> path over
+    /// <see cref="BlasProvider.TryGemmEx"/>. The provider may dispatch to a
+    /// single-threaded BLAS install (Microsoft.ML/CRT BLAS lacks Parallel.For
+    /// internally on some runtimes), which silently caps backward throughput
+    /// to one core during training. SimdGemm is guaranteed parallel on shapes
+    /// at or above its own internal threshold, so we use it directly when the
+    /// work is large enough to amortize task spawn cost. 4096 FMAs ≈ a 16×16×16
+    /// matmul — small enough that anything resembling a transformer FFN
+    /// (≥256×768×768 ≈ 150M FMAs) crosses it by orders of magnitude.
+    /// </summary>
+    private const long MatMulBackwardSimdThreshold = 4096L;
+
     /// <summary>d(A@B)/dA = grad @ B^T, d(A@B)/dB = A^T @ grad</summary>
     internal static void MatMulBackward(
         Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
         object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
     {
-        // BLAS fast path: compute transposed GEMMs into fresh buffers, then accumulate.
-        // Allocates two float[] arrays but avoids materializing full transpose tensors.
-        if (typeof(T) == typeof(float) && inputs[0].Rank == 2 && inputs[1].Rank == 2 && BlasProvider.IsAvailable)
+        // Float32 + 2D fast path: compute transposed GEMMs into pooled buffers, then accumulate.
+        if (typeof(T) == typeof(float) && inputs[0].Rank == 2 && inputs[1].Rank == 2)
         {
             var dCArr = (gradOutput as Tensor<float>)?.GetDataArray();
             var aArr = (inputs[0] as Tensor<float>)?.GetDataArray();
@@ -373,28 +386,47 @@ internal static class BackwardFunctions<T>
 
             if (dCArr is not null && aArr is not null && bArr is not null)
             {
-                int M = gradOutput._shape[0], K = gradOutput._shape[1];
-                int N_a = inputs[1]._shape[0]; // rows of B = cols of grad_A
-                int N_b = gradOutput._shape[1]; // cols of grad_B
+                int M = inputs[0]._shape[0];     // rows of A and gradOutput
+                int K = inputs[0]._shape[1];     // inner dim (cols of A = rows of B)
+                int N = inputs[1]._shape[1];     // cols of B and gradOutput
 
                 // Pool gradient buffers via AutoTensorCache — zero allocation on steps 2+.
                 var gradATensor = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[0]._shape);
                 var gradBTensor = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[1]._shape);
                 var gradAData = (float[])(object)gradATensor.GetDataArray();
                 var gradBData = (float[])(object)gradBTensor.GetDataArray();
-                // No Array.Clear needed — TryGemmEx uses beta=0 which overwrites C entirely
 
-                bool okA = BlasProvider.TryGemmEx(M, N_a, K, dCArr, 0, K, false, bArr, 0, K, true, gradAData, 0, N_a);
-                bool okB = BlasProvider.TryGemmEx(inputs[0]._shape[1], N_b, inputs[0]._shape[0],
-                    aArr, 0, inputs[0]._shape[1], true, dCArr, 0, N_b, false, gradBData, 0, N_b);
-
-                if (okA && okB)
+                // Parallel SimdGemm path: bypasses single-threaded BLAS providers when
+                // no tape is recording (createGraph=true would need engine ops to wire
+                // gradients into the outer tape — that path stays on the engine below).
+                long backwardWork = (long)M * K * N;
+                if (GradientTape<T>.Current is null && backwardWork >= MatMulBackwardSimdThreshold)
                 {
+                    // gradA[M,K] = dC[M,N] · Bᵀ[N,K]. B is stored row-major [K,N] (ldb=N), transB=true.
+                    SimdGemm.Sgemm(dCArr, N, false, bArr, N, true, gradAData.AsSpan(0, M * K), M, N, K);
+                    // gradB[K,N] = Aᵀ[K,M] · dC[M,N]. A is stored row-major [M,K] (lda=K), transA=true.
+                    SimdGemm.Sgemm(aArr, K, true, dCArr, N, false, gradBData.AsSpan(0, K * N), K, M, N);
+
                     DifferentiableOps.AccumulateGrad(grads, inputs[0], gradATensor, engine);
                     DifferentiableOps.AccumulateGrad(grads, inputs[1], gradBTensor, engine);
                     return;
                 }
-                // Either GEMM refused — fall through to generic path
+
+                // BLAS fast path (may be single-threaded depending on provider):
+                if (BlasProvider.IsAvailable)
+                {
+                    bool okA = BlasProvider.TryGemmEx(M, K, N, dCArr, 0, N, false, bArr, 0, N, true, gradAData, 0, K);
+                    bool okB = BlasProvider.TryGemmEx(K, N, M,
+                        aArr, 0, K, true, dCArr, 0, N, false, gradBData, 0, N);
+
+                    if (okA && okB)
+                    {
+                        DifferentiableOps.AccumulateGrad(grads, inputs[0], gradATensor, engine);
+                        DifferentiableOps.AccumulateGrad(grads, inputs[1], gradBTensor, engine);
+                        return;
+                    }
+                    // Either GEMM refused — fall through to generic path
+                }
             }
         }
 

--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -362,29 +362,18 @@ internal static class BackwardFunctions<T>
     /// Work threshold (M·K·N) above which the float32 backward MatMul prefers
     /// <see cref="SimdGemm"/> over <see cref="BlasProvider.TryGemmEx"/>. The
     /// goal is "take SimdGemm only when it will actually run parallel" —
-    /// SimdGemm has its own internal parallel gate (≥2 Mi work-elements,
-    /// scaled up to 20 Mi by core count), so anything below that runs
-    /// sequentially inside SimdGemm and offers no advantage over BLAS.
+    /// SimdGemm has its own internal parallel gate, so anything below that
+    /// runs sequentially inside SimdGemm and offers no advantage over BLAS.
+    /// We reference <see cref="SimdGemm.ParallelWorkThreshold"/> directly
+    /// so the two stay in lockstep — drifting them is the dispatch bug.
     ///
     /// On installs with a parallel native BLAS, BLAS already uses many cores
     /// and we don't need SimdGemm. On installs whose BLAS provider is
     /// single-threaded (Microsoft.ML/CRT BLAS lacks internal Parallel.For on
     /// some runtimes), SimdGemm overtakes BLAS — but only at shapes large
-    /// enough that SimdGemm itself parallelizes. So the threshold is mirrored
-    /// from <c>SimdGemm.ParallelWorkThreshold</c> at runtime.
+    /// enough that SimdGemm itself parallelizes.
     /// </summary>
-    private static readonly long MatMulBackwardSimdThreshold = ComputeSimdGemmParallelThreshold();
-
-    private static long ComputeSimdGemmParallelThreshold()
-    {
-        // Mirrors SimdGemm.ComputeParallelWorkThreshold so the backward path
-        // takes SimdGemm exactly when SimdGemm itself will go parallel.
-        int cores = Math.Max(1, Environment.ProcessorCount);
-        long scaled = (20L * 1024 * 1024 / 16) * cores;
-        if (scaled < 2L * 1024 * 1024) scaled = 2L * 1024 * 1024;
-        if (scaled > 20L * 1024 * 1024) scaled = 20L * 1024 * 1024;
-        return scaled;
-    }
+    private static long MatMulBackwardSimdThreshold => SimdGemm.ParallelWorkThreshold;
 
     /// <summary>d(A@B)/dA = grad @ B^T, d(A@B)/dB = A^T @ grad</summary>
     internal static void MatMulBackward(
@@ -413,30 +402,32 @@ internal static class BackwardFunctions<T>
                 int K = inputs[0]._shape[1];     // inner dim (cols of A = rows of B)
                 int N = inputs[1]._shape[1];     // cols of B and gradOutput
 
-                // Pool gradient buffers via AutoTensorCache — zero allocation on steps 2+.
-                var gradATensor = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[0]._shape);
-                var gradBTensor = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[1]._shape);
-                var gradAData = (float[])(object)gradATensor.GetDataArray();
-                var gradBData = (float[])(object)gradBTensor.GetDataArray();
-
-                // Parallel SimdGemm path: bypasses single-threaded BLAS providers
-                // when work is large enough to amortize task spawn cost.
                 long backwardWork = (long)M * K * N;
-                if (backwardWork >= MatMulBackwardSimdThreshold)
+                bool tryBlas = backwardWork < MatMulBackwardSimdThreshold && BlasProvider.IsAvailable;
+                if (backwardWork >= MatMulBackwardSimdThreshold || tryBlas)
                 {
-                    // gradA[M,K] = dC[M,N] · Bᵀ[N,K]. B is stored row-major [K,N] (ldb=N), transB=true.
-                    SimdGemm.Sgemm(dCArr, N, false, bArr, N, true, gradAData.AsSpan(0, M * K), M, N, K);
-                    // gradB[K,N] = Aᵀ[K,M] · dC[M,N]. A is stored row-major [M,K] (lda=K), transA=true.
-                    SimdGemm.Sgemm(aArr, K, true, dCArr, N, false, gradBData.AsSpan(0, K * N), K, M, N);
+                    // Defer rentals until we know a fast path will use them — the
+                    // alternative leaks AutoTensorCache buffers if both paths
+                    // decline (BLAS not available + below SIMD threshold), since
+                    // the engine fallback below allocates its own gradient tensors.
+                    var gradATensor = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[0]._shape);
+                    var gradBTensor = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[1]._shape);
+                    var gradAData = (float[])(object)gradATensor.GetDataArray();
+                    var gradBData = (float[])(object)gradBTensor.GetDataArray();
 
-                    DifferentiableOps.AccumulateGrad(grads, inputs[0], gradATensor, engine);
-                    DifferentiableOps.AccumulateGrad(grads, inputs[1], gradBTensor, engine);
-                    return;
-                }
+                    if (backwardWork >= MatMulBackwardSimdThreshold)
+                    {
+                        // gradA[M,K] = dC[M,N] · Bᵀ[N,K]. B is stored row-major [K,N] (ldb=N), transB=true.
+                        SimdGemm.Sgemm(dCArr, N, false, bArr, N, true, gradAData.AsSpan(0, M * K), M, N, K);
+                        // gradB[K,N] = Aᵀ[K,M] · dC[M,N]. A is stored row-major [M,K] (lda=K), transA=true.
+                        SimdGemm.Sgemm(aArr, K, true, dCArr, N, false, gradBData.AsSpan(0, K * N), K, M, N);
 
-                // BLAS fast path (may be single-threaded depending on provider):
-                if (BlasProvider.IsAvailable)
-                {
+                        DifferentiableOps.AccumulateGrad(grads, inputs[0], gradATensor, engine);
+                        DifferentiableOps.AccumulateGrad(grads, inputs[1], gradBTensor, engine);
+                        return;
+                    }
+
+                    // BLAS fast path (may be single-threaded depending on provider):
                     bool okA = BlasProvider.TryGemmEx(M, K, N, dCArr, 0, N, false, bArr, 0, N, true, gradAData, 0, K);
                     bool okB = BlasProvider.TryGemmEx(K, N, M,
                         aArr, 0, K, true, dCArr, 0, N, false, gradBData, 0, N);
@@ -447,7 +438,10 @@ internal static class BackwardFunctions<T>
                         DifferentiableOps.AccumulateGrad(grads, inputs[1], gradBTensor, engine);
                         return;
                     }
-                    // Either GEMM refused — fall through to generic path
+                    // BLAS refused — return buffers to the cache before falling through
+                    // so the engine fallback's allocator hits a warm pool next call.
+                    Helpers.AutoTensorCache.Return(gradATensor);
+                    Helpers.AutoTensorCache.Return(gradBTensor);
                 }
             }
         }
@@ -494,35 +488,32 @@ internal static class BackwardFunctions<T>
                 int K = inputs[0]._shape[1];
                 int N = inputs[1]._shape[0];
 
-                var gradATensor = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[0]._shape);
-                var gradBTensor = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[1]._shape);
-                var gradAData = (float[])(object)gradATensor.GetDataArray();
-                var gradBData = (float[])(object)gradBTensor.GetDataArray();
-
-                // Parallel SimdGemm path: prefers SimdGemm over single-threaded BLAS
-                // when work crosses SimdGemm's parallel gate.
                 long backwardWork = (long)M * K * N;
-                if (backwardWork >= MatMulBackwardSimdThreshold)
+                bool tryBlas = backwardWork < MatMulBackwardSimdThreshold && BlasProvider.IsAvailable;
+                if (backwardWork >= MatMulBackwardSimdThreshold || tryBlas)
                 {
-                    // gradA[M,K] = gradC[M,N] · B[N,K]   (no transposes)
-                    SimdGemm.Sgemm(dCArr, N, false, bArr, K, false, gradAData.AsSpan(0, M * K), M, N, K);
-                    // gradB[N,K] = gradCᵀ[N,M] · A[M,K]   (transA=true)
-                    SimdGemm.Sgemm(dCArr, N, true, aArr, K, false, gradBData.AsSpan(0, N * K), N, M, K);
+                    var gradATensor = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[0]._shape);
+                    var gradBTensor = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[1]._shape);
+                    var gradAData = (float[])(object)gradATensor.GetDataArray();
+                    var gradBData = (float[])(object)gradBTensor.GetDataArray();
 
-                    DifferentiableOps.AccumulateGrad(grads, inputs[0], gradATensor, engine);
-                    DifferentiableOps.AccumulateGrad(grads, inputs[1], gradBTensor, engine);
-                    return;
-                }
+                    if (backwardWork >= MatMulBackwardSimdThreshold)
+                    {
+                        // gradA[M,K] = gradC[M,N] · B[N,K]   (no transposes)
+                        SimdGemm.Sgemm(dCArr, N, false, bArr, K, false, gradAData.AsSpan(0, M * K), M, N, K);
+                        // gradB[N,K] = gradCᵀ[N,M] · A[M,K]   (transA=true)
+                        SimdGemm.Sgemm(dCArr, N, true, aArr, K, false, gradBData.AsSpan(0, N * K), N, M, K);
 
-                // BLAS fast path (may be single-threaded depending on provider):
-                if (BlasProvider.IsAvailable)
-                {
-                    // gradA[M,K] = gradC[M,N] · B[N,K]    (no transposes)
+                        DifferentiableOps.AccumulateGrad(grads, inputs[0], gradATensor, engine);
+                        DifferentiableOps.AccumulateGrad(grads, inputs[1], gradBTensor, engine);
+                        return;
+                    }
+
+                    // BLAS fast path (may be single-threaded depending on provider):
                     bool okA = BlasProvider.TryGemmEx(M, K, N,
                         dCArr, 0, N, false,
                         bArr, 0, K, false,
                         gradAData, 0, K);
-                    // gradB[N,K] = gradCᵀ[N,M] · A[M,K]   (transpose first operand)
                     bool okB = BlasProvider.TryGemmEx(N, K, M,
                         dCArr, 0, N, true,
                         aArr, 0, K, false,
@@ -534,6 +525,9 @@ internal static class BackwardFunctions<T>
                         DifferentiableOps.AccumulateGrad(grads, inputs[1], gradBTensor, engine);
                         return;
                     }
+                    // BLAS refused — return buffers before falling through.
+                    Helpers.AutoTensorCache.Return(gradATensor);
+                    Helpers.AutoTensorCache.Return(gradBTensor);
                 }
             }
         }
@@ -2257,6 +2251,14 @@ internal static class BackwardFunctions<T>
             var inArr = (float[])(object)inputs[0].GetDataArray();
             var wArr = (float[])(object)inputs[1].GetDataArray();
 
+            // Decide which fast path will run BEFORE renting any buffers.
+            long backwardWork = (long)M * K * N;
+            bool tryBlas = backwardWork < MatMulBackwardSimdThreshold && BlasProvider.IsAvailable;
+            bool willTryFastPath = backwardWork >= MatMulBackwardSimdThreshold || tryBlas;
+
+            if (!willTryFastPath)
+                goto fusedReluFallback;
+
             // Step 1: Fused ReLU mask — pool the masked gradient buffer
             var maskedTensor = Helpers.AutoTensorCache.RentOrAllocate<float>(new[] { M, N });
             var maskedArr = maskedTensor.GetDataArray();
@@ -2271,23 +2273,24 @@ internal static class BackwardFunctions<T>
             var gradWeight = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[1]._shape);
             var gradWeightArr = (float[])(object)gradWeight.GetDataArray();
 
-            long backwardWork = (long)M * K * N;
             if (backwardWork >= MatMulBackwardSimdThreshold)
             {
                 // Parallel SimdGemm — bypass possibly-single-threaded BLAS.
                 SimdGemm.Sgemm(maskedArr, N, false, wArr, N, true, gradInputArr.AsSpan(0, M * K), M, N, K);
                 SimdGemm.Sgemm(inArr, K, true, maskedArr, N, false, gradWeightArr.AsSpan(0, K * N), K, M, N);
             }
-            else if (BlasProvider.IsAvailable)
-            {
-                if (!BlasProvider.TryGemmEx(M, K, N, maskedArr, 0, N, false, wArr, 0, N, true, gradInputArr, 0, K))
-                    goto fusedReluFallback;
-                if (!BlasProvider.TryGemmEx(K, N, M, inArr, 0, K, true, maskedArr, 0, N, false, gradWeightArr, 0, N))
-                    goto fusedReluFallback;
-            }
             else
             {
-                goto fusedReluFallback;
+                // tryBlas == true here.
+                if (!BlasProvider.TryGemmEx(M, K, N, maskedArr, 0, N, false, wArr, 0, N, true, gradInputArr, 0, K)
+                    || !BlasProvider.TryGemmEx(K, N, M, inArr, 0, K, true, maskedArr, 0, N, false, gradWeightArr, 0, N))
+                {
+                    // Return rented buffers before falling through.
+                    Helpers.AutoTensorCache.Return(maskedTensor);
+                    Helpers.AutoTensorCache.Return(gradInput);
+                    Helpers.AutoTensorCache.Return(gradWeight);
+                    goto fusedReluFallback;
+                }
             }
 
             // Step 4: gradBias = sum(maskedGrad, axis=0) — single SIMD pass, pooled buffer
@@ -2336,17 +2339,29 @@ internal static class BackwardFunctions<T>
         var inArr = (float[])(object)inputs[0].GetDataArray();
         var wArr = (float[])(object)inputs[1].GetDataArray();
 
-        // gradInput / gradWeight buffers — pooled to keep zero-alloc on steps 2+.
-        var gradInput = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[0]._shape);
-        var gradInputArr = (float[])(object)gradInput.GetDataArray();
-        var gradWeight = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[1]._shape);
-        var gradWeightArr = (float[])(object)gradWeight.GetDataArray();
-
         // Prefer parallel SimdGemm over single-threaded BLAS at large work sizes —
         // mirrors the gate in MatMulBackward / FusedLinearBackwardCore. The
         // dispatcher functions already verified GradientTape<T>.Current is null
         // before getting here (BLAS path is only taken outside higher-order AD).
         long backwardWork = (long)M * K * N;
+        bool tryBlas = backwardWork < MatMulBackwardSimdThreshold && BlasProvider.IsAvailable;
+        bool willTryFastPath = backwardWork >= MatMulBackwardSimdThreshold || tryBlas;
+
+        if (!willTryFastPath)
+        {
+            // No fast path applies — fall back to engine-based backward immediately
+            // without renting buffers we won't use.
+            var maskedTensorEarly = new Tensor<T>((T[])(object)maskedArr, new[] { M, N });
+            FusedLinearActivationBackwardFallback(maskedTensorEarly, inputs, grads, engine);
+            return;
+        }
+
+        // Defer rentals until we're committed to a fast path.
+        var gradInput = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[0]._shape);
+        var gradInputArr = (float[])(object)gradInput.GetDataArray();
+        var gradWeight = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[1]._shape);
+        var gradWeightArr = (float[])(object)gradWeight.GetDataArray();
+
         bool used = false;
 
         if (backwardWork >= MatMulBackwardSimdThreshold)
@@ -2357,8 +2372,9 @@ internal static class BackwardFunctions<T>
             SimdGemm.Sgemm(inArr, K, true, maskedArr, N, false, gradWeightArr.AsSpan(0, K * N), K, M, N);
             used = true;
         }
-        else if (BlasProvider.IsAvailable)
+        else
         {
+            // tryBlas == true here.
             bool okInput = BlasProvider.TryGemmEx(M, K, N, maskedArr, 0, N, false, wArr, 0, N, true, gradInputArr, 0, K);
             bool okWeight = BlasProvider.TryGemmEx(K, N, M, inArr, 0, K, true, maskedArr, 0, N, false, gradWeightArr, 0, N);
             used = okInput && okWeight;
@@ -2366,7 +2382,9 @@ internal static class BackwardFunctions<T>
 
         if (!used)
         {
-            // No fast path took — fall back to engine-based backward.
+            // BLAS refused — return rented buffers before falling through.
+            Helpers.AutoTensorCache.Return(gradInput);
+            Helpers.AutoTensorCache.Return(gradWeight);
             var maskedTensor = new Tensor<T>((T[])(object)maskedArr, new[] { M, N });
             FusedLinearActivationBackwardFallback(maskedTensor, inputs, grads, engine);
             return;
@@ -3783,13 +3801,21 @@ internal static class BackwardFunctions<T>
             var inArr = (float[])(object)inputs[0].GetDataArray();
             var wArr = (float[])(object)inputs[1].GetDataArray();
 
-            // Pool gradient buffers via AutoTensorCache — zero alloc on steps 2+
+            long backwardWork = (long)M * K * N;
+            bool tryBlas = backwardWork < MatMulBackwardSimdThreshold && BlasProvider.IsAvailable;
+            bool willTryFastPath = backwardWork >= MatMulBackwardSimdThreshold || tryBlas;
+
+            if (!willTryFastPath)
+                goto fusedFallback;
+
+            // Defer rentals until we're committed to a fast path so they don't leak
+            // when we fall through to the engine fallback (which allocates its own
+            // gradient tensors).
             var inputGrad = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[0]._shape);
             var weightGrad = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[1]._shape);
             var gradInputArr = (float[])(object)inputGrad.GetDataArray();
             var gradWeightArr = (float[])(object)weightGrad.GetDataArray();
 
-            long backwardWork = (long)M * K * N;
             bool used = false;
 
             if (backwardWork >= MatMulBackwardSimdThreshold)
@@ -3802,15 +3828,21 @@ internal static class BackwardFunctions<T>
                 SimdGemm.Sgemm(inArr, K, true, gArr, N, false, gradWeightArr.AsSpan(0, K * N), K, M, N);
                 used = true;
             }
-            else if (BlasProvider.IsAvailable)
+            else
             {
+                // tryBlas == true here.
                 bool okInput = BlasProvider.TryGemmEx(M, K, N, gArr, 0, N, false, wArr, 0, N, true, gradInputArr, 0, K);
                 bool okWeight = BlasProvider.TryGemmEx(K, N, M, inArr, 0, K, true, gArr, 0, N, false, gradWeightArr, 0, N);
                 used = okInput && okWeight;
             }
 
             if (!used)
-                goto fusedFallback; // No fast path took — use engine fallback
+            {
+                // Return rented buffers before falling through.
+                Helpers.AutoTensorCache.Return(inputGrad);
+                Helpers.AutoTensorCache.Return(weightGrad);
+                goto fusedFallback;
+            }
 
             DifferentiableOps.AccumulateGrad(grads, inputs[0], inputGrad, engine);
             DifferentiableOps.AccumulateGrad(grads, inputs[1], weightGrad, engine);

--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -477,8 +477,13 @@ internal static class BackwardFunctions<T>
         Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
         object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
     {
-        // BLAS fast path: A: [M,K], B: [N,K] (stored row-major), gradC: [M,N].
-        if (typeof(T) == typeof(float) && inputs[0].Rank == 2 && inputs[1].Rank == 2 && BlasProvider.IsAvailable)
+        // Float32 + 2D fast paths: A: [M,K], B: [N,K] (stored row-major), gradC: [M,N].
+        // Same gating story as MatMulBackward — both fast paths bypass engine
+        // recording, so they're behind the no-active-tape gate to preserve
+        // higher-order AD. Rentals also live inside the gate.
+        if (typeof(T) == typeof(float)
+            && inputs[0].Rank == 2 && inputs[1].Rank == 2
+            && GradientTape<T>.Current is null)
         {
             var dCArr = (gradOutput as Tensor<float>)?.GetDataArray();
             var aArr = (inputs[0] as Tensor<float>)?.GetDataArray();
@@ -494,22 +499,41 @@ internal static class BackwardFunctions<T>
                 var gradAData = (float[])(object)gradATensor.GetDataArray();
                 var gradBData = (float[])(object)gradBTensor.GetDataArray();
 
-                // gradA[M,K] = gradC[M,N] · B[N,K]    (no transposes)
-                bool okA = BlasProvider.TryGemmEx(M, K, N,
-                    dCArr, 0, N, false,
-                    bArr, 0, K, false,
-                    gradAData, 0, K);
-                // gradB[N,K] = gradCᵀ[N,M] · A[M,K]   (transpose first operand)
-                bool okB = BlasProvider.TryGemmEx(N, K, M,
-                    dCArr, 0, N, true,
-                    aArr, 0, K, false,
-                    gradBData, 0, K);
-
-                if (okA && okB)
+                // Parallel SimdGemm path: prefers SimdGemm over single-threaded BLAS
+                // when work crosses SimdGemm's parallel gate.
+                long backwardWork = (long)M * K * N;
+                if (backwardWork >= MatMulBackwardSimdThreshold)
                 {
+                    // gradA[M,K] = gradC[M,N] · B[N,K]   (no transposes)
+                    SimdGemm.Sgemm(dCArr, N, false, bArr, K, false, gradAData.AsSpan(0, M * K), M, N, K);
+                    // gradB[N,K] = gradCᵀ[N,M] · A[M,K]   (transA=true)
+                    SimdGemm.Sgemm(dCArr, N, true, aArr, K, false, gradBData.AsSpan(0, N * K), N, M, K);
+
                     DifferentiableOps.AccumulateGrad(grads, inputs[0], gradATensor, engine);
                     DifferentiableOps.AccumulateGrad(grads, inputs[1], gradBTensor, engine);
                     return;
+                }
+
+                // BLAS fast path (may be single-threaded depending on provider):
+                if (BlasProvider.IsAvailable)
+                {
+                    // gradA[M,K] = gradC[M,N] · B[N,K]    (no transposes)
+                    bool okA = BlasProvider.TryGemmEx(M, K, N,
+                        dCArr, 0, N, false,
+                        bArr, 0, K, false,
+                        gradAData, 0, K);
+                    // gradB[N,K] = gradCᵀ[N,M] · A[M,K]   (transpose first operand)
+                    bool okB = BlasProvider.TryGemmEx(N, K, M,
+                        dCArr, 0, N, true,
+                        aArr, 0, K, false,
+                        gradBData, 0, K);
+
+                    if (okA && okB)
+                    {
+                        DifferentiableOps.AccumulateGrad(grads, inputs[0], gradATensor, engine);
+                        DifferentiableOps.AccumulateGrad(grads, inputs[1], gradBTensor, engine);
+                        return;
+                    }
                 }
             }
         }
@@ -2215,9 +2239,14 @@ internal static class BackwardFunctions<T>
     {
         var preActivation = (Tensor<T>)savedState[0];
 
-        // Fused BLAS path: ReLU mask + transposed GEMM in minimal allocations
+        // Fused fast path: ReLU mask + transposed GEMM in minimal allocations.
+        // Same parallel-SimdGemm preference as the other fused-linear backward
+        // funcs — picks SimdGemm over single-threaded BLAS when work crosses
+        // SimdGemm's parallel gate. Behind the no-active-tape gate to keep
+        // higher-order AD on the engine path.
         if (typeof(T) == typeof(float) && inputs[0].Rank == 2 && inputs[1].Rank == 2
-            && BlasProvider.IsAvailable && gradOutput.IsContiguous && preActivation.IsContiguous)
+            && gradOutput.IsContiguous && preActivation.IsContiguous
+            && GradientTape<T>.Current is null)
         {
             int M = inputs[0]._shape[0]; // batch
             int K = inputs[0]._shape[1]; // in_features
@@ -2236,17 +2265,30 @@ internal static class BackwardFunctions<T>
                 SimdKernels.ReluBackwardUnsafe(pG, pPA, pM, M * N);
             }
 
-            // Step 2: gradInput = maskedGrad @ W^T  (transposed BLAS, pooled buffer)
+            // Step 2 + 3: gradInput / gradWeight via SimdGemm or BLAS
             var gradInput = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[0]._shape);
             var gradInputArr = (float[])(object)gradInput.GetDataArray();
-            if (!BlasProvider.TryGemmEx(M, K, N, maskedArr, 0, N, false, wArr, 0, N, true, gradInputArr, 0, K))
-                goto fusedReluFallback;
-
-            // Step 3: gradWeight = input^T @ maskedGrad  (transposed BLAS, pooled buffer)
             var gradWeight = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[1]._shape);
             var gradWeightArr = (float[])(object)gradWeight.GetDataArray();
-            if (!BlasProvider.TryGemmEx(K, N, M, inArr, 0, K, true, maskedArr, 0, N, false, gradWeightArr, 0, N))
+
+            long backwardWork = (long)M * K * N;
+            if (backwardWork >= MatMulBackwardSimdThreshold)
+            {
+                // Parallel SimdGemm — bypass possibly-single-threaded BLAS.
+                SimdGemm.Sgemm(maskedArr, N, false, wArr, N, true, gradInputArr.AsSpan(0, M * K), M, N, K);
+                SimdGemm.Sgemm(inArr, K, true, maskedArr, N, false, gradWeightArr.AsSpan(0, K * N), K, M, N);
+            }
+            else if (BlasProvider.IsAvailable)
+            {
+                if (!BlasProvider.TryGemmEx(M, K, N, maskedArr, 0, N, false, wArr, 0, N, true, gradInputArr, 0, K))
+                    goto fusedReluFallback;
+                if (!BlasProvider.TryGemmEx(K, N, M, inArr, 0, K, true, maskedArr, 0, N, false, gradWeightArr, 0, N))
+                    goto fusedReluFallback;
+            }
+            else
+            {
                 goto fusedReluFallback;
+            }
 
             // Step 4: gradBias = sum(maskedGrad, axis=0) — single SIMD pass, pooled buffer
             var gradBias = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[2]._shape);
@@ -2294,21 +2336,37 @@ internal static class BackwardFunctions<T>
         var inArr = (float[])(object)inputs[0].GetDataArray();
         var wArr = (float[])(object)inputs[1].GetDataArray();
 
-        // gradInput = maskedGrad @ W^T — transposed BLAS, pooled buffer
-        // No Array.Clear — TryGemmEx uses beta=0 which overwrites C entirely
+        // gradInput / gradWeight buffers — pooled to keep zero-alloc on steps 2+.
         var gradInput = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[0]._shape);
         var gradInputArr = (float[])(object)gradInput.GetDataArray();
-        bool okInput = BlasProvider.TryGemmEx(M, K, N, maskedArr, 0, N, false, wArr, 0, N, true, gradInputArr, 0, K);
-
-        // gradWeight = input^T @ maskedGrad — transposed BLAS, pooled buffer
         var gradWeight = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[1]._shape);
         var gradWeightArr = (float[])(object)gradWeight.GetDataArray();
-        bool okWeight = BlasProvider.TryGemmEx(K, N, M, inArr, 0, K, true, maskedArr, 0, N, false, gradWeightArr, 0, N);
 
-        if (!okInput || !okWeight)
+        // Prefer parallel SimdGemm over single-threaded BLAS at large work sizes —
+        // mirrors the gate in MatMulBackward / FusedLinearBackwardCore. The
+        // dispatcher functions already verified GradientTape<T>.Current is null
+        // before getting here (BLAS path is only taken outside higher-order AD).
+        long backwardWork = (long)M * K * N;
+        bool used = false;
+
+        if (backwardWork >= MatMulBackwardSimdThreshold)
         {
-            // BLAS unavailable — fall back to engine-based backward.
-            // Wrap maskedArr into a tensor for the fallback path.
+            // dInput[M,K] = masked[M,N] · Wᵀ[N,K]
+            SimdGemm.Sgemm(maskedArr, N, false, wArr, N, true, gradInputArr.AsSpan(0, M * K), M, N, K);
+            // dWeight[K,N] = inputᵀ[K,M] · masked[M,N]
+            SimdGemm.Sgemm(inArr, K, true, maskedArr, N, false, gradWeightArr.AsSpan(0, K * N), K, M, N);
+            used = true;
+        }
+        else if (BlasProvider.IsAvailable)
+        {
+            bool okInput = BlasProvider.TryGemmEx(M, K, N, maskedArr, 0, N, false, wArr, 0, N, true, gradInputArr, 0, K);
+            bool okWeight = BlasProvider.TryGemmEx(K, N, M, inArr, 0, K, true, maskedArr, 0, N, false, gradWeightArr, 0, N);
+            used = okInput && okWeight;
+        }
+
+        if (!used)
+        {
+            // No fast path took — fall back to engine-based backward.
             var maskedTensor = new Tensor<T>((T[])(object)maskedArr, new[] { M, N });
             FusedLinearActivationBackwardFallback(maskedTensor, inputs, grads, engine);
             return;
@@ -2355,7 +2413,9 @@ internal static class BackwardFunctions<T>
         object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
     {
         var maskedGrad = engine.SigmoidBackward(gradOutput, output);
-        if (typeof(T) == typeof(float) && inputs[0].Rank == 2 && BlasProvider.IsAvailable)
+        // Core handles both SimdGemm-parallel and BLAS dispatch internally; gate
+        // on no-active-tape so higher-order AD stays on the engine path.
+        if (typeof(T) == typeof(float) && inputs[0].Rank == 2 && GradientTape<T>.Current is null)
         {
             FusedLinearActivationBackwardCore(
                 (float[])(object)maskedGrad.GetDataArray(),
@@ -2371,7 +2431,9 @@ internal static class BackwardFunctions<T>
         object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
     {
         var maskedGrad = engine.TanhBackward(gradOutput, output);
-        if (typeof(T) == typeof(float) && inputs[0].Rank == 2 && BlasProvider.IsAvailable)
+        // Core handles both SimdGemm-parallel and BLAS dispatch internally; gate
+        // on no-active-tape so higher-order AD stays on the engine path.
+        if (typeof(T) == typeof(float) && inputs[0].Rank == 2 && GradientTape<T>.Current is null)
         {
             FusedLinearActivationBackwardCore(
                 (float[])(object)maskedGrad.GetDataArray(),
@@ -2388,7 +2450,9 @@ internal static class BackwardFunctions<T>
     {
         var preActivation = (Tensor<T>)savedState[0];
         var maskedGrad = engine.GeluBackward(gradOutput, preActivation);
-        if (typeof(T) == typeof(float) && inputs[0].Rank == 2 && BlasProvider.IsAvailable)
+        // Core handles both SimdGemm-parallel and BLAS dispatch internally; gate
+        // on no-active-tape so higher-order AD stays on the engine path.
+        if (typeof(T) == typeof(float) && inputs[0].Rank == 2 && GradientTape<T>.Current is null)
         {
             FusedLinearActivationBackwardCore(
                 (float[])(object)maskedGrad.GetDataArray(),
@@ -2405,7 +2469,9 @@ internal static class BackwardFunctions<T>
     {
         var preActivation = (Tensor<T>)savedState[0];
         var maskedGrad = engine.SwishBackward(gradOutput, preActivation);
-        if (typeof(T) == typeof(float) && inputs[0].Rank == 2 && BlasProvider.IsAvailable)
+        // Core handles both SimdGemm-parallel and BLAS dispatch internally; gate
+        // on no-active-tape so higher-order AD stays on the engine path.
+        if (typeof(T) == typeof(float) && inputs[0].Rank == 2 && GradientTape<T>.Current is null)
         {
             FusedLinearActivationBackwardCore(
                 (float[])(object)maskedGrad.GetDataArray(),
@@ -3701,9 +3767,13 @@ internal static class BackwardFunctions<T>
         Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
         object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
     {
-        // Fused BLAS path: transposed GEMM + inline bias sum — no transpose allocation
+        // Float32 + 2D fast paths: transposed GEMMs + inline bias sum, no transpose allocation.
+        // Same parallel-SimdGemm preference as MatMulBackward to avoid getting
+        // single-thread-trapped on installs whose BLAS provider lacks internal
+        // Parallel.For. Both fast paths bypass engine recording, so the no-
+        // active-tape gate preserves higher-order AD via the engine fallback.
         if (typeof(T) == typeof(float) && inputs[0].Rank == 2 && inputs[1].Rank == 2
-            && BlasProvider.IsAvailable && gradOutput.IsContiguous)
+            && gradOutput.IsContiguous && GradientTape<T>.Current is null)
         {
             int M = inputs[0]._shape[0]; // batch
             int K = inputs[0]._shape[1]; // in_features
@@ -3718,13 +3788,29 @@ internal static class BackwardFunctions<T>
             var weightGrad = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[1]._shape);
             var gradInputArr = (float[])(object)inputGrad.GetDataArray();
             var gradWeightArr = (float[])(object)weightGrad.GetDataArray();
-            // No Array.Clear — TryGemmEx with beta=0 overwrites C entirely
 
-            bool okInput = BlasProvider.TryGemmEx(M, K, N, gArr, 0, N, false, wArr, 0, N, true, gradInputArr, 0, K);
-            bool okWeight = BlasProvider.TryGemmEx(K, N, M, inArr, 0, K, true, gArr, 0, N, false, gradWeightArr, 0, N);
+            long backwardWork = (long)M * K * N;
+            bool used = false;
 
-            if (!okInput || !okWeight)
-                goto fusedFallback; // BLAS refused — use engine fallback for all
+            if (backwardWork >= MatMulBackwardSimdThreshold)
+            {
+                // Parallel SimdGemm path — guaranteed multi-core on shapes at/above
+                // SimdGemm's internal parallel gate.
+                // dInput[M,K] = dY[M,N] · Wᵀ[N,K]; W is stored [K,N] (ldb=N), transB=true.
+                SimdGemm.Sgemm(gArr, N, false, wArr, N, true, gradInputArr.AsSpan(0, M * K), M, N, K);
+                // dWeight[K,N] = inputᵀ[K,M] · dY[M,N]; input is stored [M,K] (lda=K), transA=true.
+                SimdGemm.Sgemm(inArr, K, true, gArr, N, false, gradWeightArr.AsSpan(0, K * N), K, M, N);
+                used = true;
+            }
+            else if (BlasProvider.IsAvailable)
+            {
+                bool okInput = BlasProvider.TryGemmEx(M, K, N, gArr, 0, N, false, wArr, 0, N, true, gradInputArr, 0, K);
+                bool okWeight = BlasProvider.TryGemmEx(K, N, M, inArr, 0, K, true, gArr, 0, N, false, gradWeightArr, 0, N);
+                used = okInput && okWeight;
+            }
+
+            if (!used)
+                goto fusedFallback; // No fast path took — use engine fallback
 
             DifferentiableOps.AccumulateGrad(grads, inputs[0], inputGrad, engine);
             DifferentiableOps.AccumulateGrad(grads, inputs[1], weightGrad, engine);

--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
@@ -628,39 +628,54 @@ public sealed class GradientTape<T> : IDisposable
         // the intermediate (a pooled output buffer, a weak-ref
         // tracker, debugging hook, …) the gradient stays live too.
         // Source tensors keep .Grad — that's the optimizer's input.
+        // Tensors registered via RetainGrad() also keep .Grad — that's the
+        // user's explicit request to retain gradients on a non-leaf tensor.
         if (!_options.Persistent)
         {
             // Build a set of source tensors for O(1) sourcehood check.
-            // Skip the set construction when no sources were specified
-            // (caller wants the full grads dict), since we can't
-            // safely null .Grad on anything in that mode.
+            // sources == null means the caller wants the full grads dict,
+            //   so we can't safely null .Grad on anything.
+            // sources != null (even if empty) means the caller specified
+            //   the protected set explicitly — clear .Grad on everything
+            //   else, including the case where the explicit set is empty.
             HashSet<Tensor<T>>? sourceSet = null;
-            if (sources is not null && sources.Count > 0)
+            if (sources is not null)
             {
                 sourceSet = new HashSet<Tensor<T>>(ReferenceEqualityComparer<Tensor<T>>.Instance);
                 foreach (var s in sources) sourceSet.Add(s);
             }
+            // Local helper: should this tensor keep its .Grad?
+            // True when sources mode is off (sourceSet null), when the tensor
+            // is a source, or when the user retained grads on it explicitly.
+            bool ShouldKeepGrad(Tensor<T> t)
+            {
+                if (sourceSet is null) return true;
+                if (sourceSet.Contains(t)) return true;
+                if (_retainGrad is not null && _retainGrad.Contains(t)) return true;
+                return false;
+            }
             foreach (var node in topoOrder)
             {
                 node.Output.GradFn = null;
-                if (sourceSet is not null && !sourceSet.Contains(node.Output))
+                if (!ShouldKeepGrad(node.Output))
                     node.Output.Grad = null;
-                if (node.Input0 is not null)
-                {
-                    node.Input0.GradFn = null;
-                    if (sourceSet is not null && !sourceSet.Contains(node.Input0))
-                        node.Input0.Grad = null;
-                }
+
+                // Input0 is non-nullable on GradNode<T>; the recorder
+                // always populates it.
+                node.Input0.GradFn = null;
+                if (!ShouldKeepGrad(node.Input0))
+                    node.Input0.Grad = null;
+
                 if (node.Input1 is not null)
                 {
                     node.Input1.GradFn = null;
-                    if (sourceSet is not null && !sourceSet.Contains(node.Input1))
+                    if (!ShouldKeepGrad(node.Input1))
                         node.Input1.Grad = null;
                 }
                 if (node.Input2 is not null)
                 {
                     node.Input2.GradFn = null;
-                    if (sourceSet is not null && !sourceSet.Contains(node.Input2))
+                    if (!ShouldKeepGrad(node.Input2))
                         node.Input2.Grad = null;
                 }
                 if (node.InputsOverflow is not null)
@@ -669,7 +684,7 @@ public sealed class GradientTape<T> : IDisposable
                     {
                         if (inp is null) continue;
                         inp.GradFn = null;
-                        if (sourceSet is not null && !sourceSet.Contains(inp))
+                        if (!ShouldKeepGrad(inp))
                             inp.Grad = null;
                     }
                 }

--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
@@ -608,14 +608,71 @@ public sealed class GradientTape<T> : IDisposable
         // Execute the chain
         var result = chain.Execute(loss, sources, engine);
 
-        // Clear GradFn to release graph memory (non-persistent tapes get new graphs each step)
+        // Clear GradFn to release graph memory (non-persistent tapes
+        // get new graphs each step). Walk inputs inline rather than
+        // via GetInputsArray() — that helper allocates a fresh
+        // Tensor<T>[] every call and we'd burn one allocation per
+        // node solely to traverse refs we already have direct field
+        // access to. Issue #279: the per-train allocation bloat
+        // compounds the leak signature.
+        //
+        // ALSO clear .Grad on intermediate tensors. AccumulateGrad
+        // sets `tensor.Grad = stored` for every tensor that receives
+        // a gradient contribution, including forward intermediates
+        // (Q, K, V, attention scores, layernorm outputs, …). Those
+        // intermediates have no caller-visible reason to keep .Grad
+        // populated after backward returns — only the `sources`
+        // (model parameters) are read by the optimizer. Leaving
+        // .Grad set chains the gradient tensor's lifetime to the
+        // intermediate's lifetime; when ANY external reference holds
+        // the intermediate (a pooled output buffer, a weak-ref
+        // tracker, debugging hook, …) the gradient stays live too.
+        // Source tensors keep .Grad — that's the optimizer's input.
         if (!_options.Persistent)
         {
+            // Build a set of source tensors for O(1) sourcehood check.
+            // Skip the set construction when no sources were specified
+            // (caller wants the full grads dict), since we can't
+            // safely null .Grad on anything in that mode.
+            HashSet<Tensor<T>>? sourceSet = null;
+            if (sources is not null && sources.Count > 0)
+            {
+                sourceSet = new HashSet<Tensor<T>>(ReferenceEqualityComparer<Tensor<T>>.Instance);
+                foreach (var s in sources) sourceSet.Add(s);
+            }
             foreach (var node in topoOrder)
             {
                 node.Output.GradFn = null;
-                foreach (var inp in node.GetInputsArray())
-                    inp.GradFn = null;
+                if (sourceSet is not null && !sourceSet.Contains(node.Output))
+                    node.Output.Grad = null;
+                if (node.Input0 is not null)
+                {
+                    node.Input0.GradFn = null;
+                    if (sourceSet is not null && !sourceSet.Contains(node.Input0))
+                        node.Input0.Grad = null;
+                }
+                if (node.Input1 is not null)
+                {
+                    node.Input1.GradFn = null;
+                    if (sourceSet is not null && !sourceSet.Contains(node.Input1))
+                        node.Input1.Grad = null;
+                }
+                if (node.Input2 is not null)
+                {
+                    node.Input2.GradFn = null;
+                    if (sourceSet is not null && !sourceSet.Contains(node.Input2))
+                        node.Input2.Grad = null;
+                }
+                if (node.InputsOverflow is not null)
+                {
+                    foreach (var inp in node.InputsOverflow)
+                    {
+                        if (inp is null) continue;
+                        inp.GradFn = null;
+                        if (sourceSet is not null && !sourceSet.Contains(inp))
+                            inp.Grad = null;
+                    }
+                }
             }
         }
 
@@ -842,6 +899,11 @@ public sealed class GradientTape<T> : IDisposable
         Compilation.AutoTrainingCompiler.ReplayMode = _savedReplayMode;
         System.Threading.Interlocked.Decrement(ref DifferentiableOps._anyTapeActive);
         SetCurrentTape(_parent);
+        // Defensively null the cached delegate chain. For non-persistent
+        // tapes it's already null; this protects against any path that
+        // sets it (e.g. a future code change that caches across a
+        // re-execute call) from leaking BackwardStep[] across Dispose.
+        _cachedDelegateChain = null;
         // Return arena to thread-local cache for reuse by next GradientTape
         _entries.Reset();
         _cachedArena = _entries;

--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
@@ -519,6 +519,39 @@ public sealed class GradientTape<T> : IDisposable
             }
         }
 
+        // Tape-walk parity for the .Grad / .GradFn cleanup that ComputeGradientsViaGraph does.
+        // AccumulateGrad sets `tensor.Grad = stored` for every tensor that receives a
+        // gradient contribution — including forward intermediates — so on a
+        // non-persistent tape we null .Grad on non-source / non-RetainGrad tensors so
+        // the gradient lifetime doesn't get chained to whatever holds the intermediate.
+        // Tape-walk-specific cases (anomaly detection, hooks) all reach this cleanup
+        // the same way the graph path does.
+        //
+        // SKIP cleanup when createGraph=true: the outer caller is computing higher-
+        // order derivatives (Hvp / Hessian / double-backward), and forward
+        // intermediates' .Grad / .GradFn fields are part of the higher-order graph
+        // that the next backward pass needs to walk.
+        if (!_options.Persistent && !createGraph && sources is not null)
+        {
+            HashSet<Tensor<T>> sourceSet = new HashSet<Tensor<T>>(ReferenceEqualityComparer<Tensor<T>>.Instance);
+            foreach (var s in sources) sourceSet.Add(s);
+            for (int i = 0; i < _entries.Count; i++)
+            {
+                ref var e = ref _entries[i];
+                CleanupTapeEntryGrad(e.Output, sourceSet);
+                if (e.Input0 != null) CleanupTapeEntryGrad(e.Input0, sourceSet);
+                if (e.InputCount >= 2 && e.Input1 != null) CleanupTapeEntryGrad(e.Input1, sourceSet);
+                if (e.InputCount >= 3 && e.Input2 != null) CleanupTapeEntryGrad(e.Input2, sourceSet);
+                if (e.InputsOverflow != null)
+                {
+                    foreach (var inp in e.InputsOverflow)
+                    {
+                        if (inp != null) CleanupTapeEntryGrad(inp, sourceSet);
+                    }
+                }
+            }
+        }
+
         // If sources specified, filter to only those
         if (sources is not null)
         {
@@ -561,6 +594,14 @@ public sealed class GradientTape<T> : IDisposable
         return grads;
     }
 
+    private void CleanupTapeEntryGrad(Tensor<T> t, HashSet<Tensor<T>> sourceSet)
+    {
+        t.GradFn = null;
+        if (sourceSet.Contains(t)) return;
+        if (_retainGrad is not null && _retainGrad.Contains(t)) return;
+        t.Grad = null;
+    }
+
     /// <summary>
     /// Graph-based backward: walks GradFn pointers on tensors instead of the tape.
     /// Eliminates tape traversal, dictionary lookups, and relevance checks.
@@ -569,6 +610,43 @@ public sealed class GradientTape<T> : IDisposable
     private CompiledDelegateChain<T>? _cachedDelegateChain;
 
     private Dictionary<Tensor<T>, Tensor<T>> ComputeGradientsViaGraph(
+        Tensor<T> loss,
+        IReadOnlyList<Tensor<T>>? sources)
+    {
+        // Suspend recording while backward runs so engine ops invoked from
+        // backward funcs don't append to *this* tape (would shift bounded
+        // tapes / corrupt persistent ones), and so backward fast paths that
+        // gate on `Current is null` (parallel SimdGemm in MatMulBackward et
+        // al.) are actually reachable on the graph path. The tape-walk path
+        // does the same just before its main loop; this is the parity fix
+        // for the graph path, which is the common case (createGraph=false,
+        // no anomaly detection, no hooks).
+        //
+        // We DON'T suspend when this graph backward is itself running inside
+        // an outer createGraph=true backward (DifferentiableOps._isBackwardCreateGraph
+        // signals that), because the outer tape wants to keep recording so
+        // each gradient computation lands in the higher-order graph for Hvp.
+        var savedCurrent = _current;
+        bool suspendTape = !DifferentiableOps._isBackwardCreateGraph;
+        if (suspendTape)
+        {
+            SetCurrentTape(null);
+        }
+
+        try
+        {
+            return ComputeGradientsViaGraphCore(loss, sources);
+        }
+        finally
+        {
+            if (suspendTape)
+            {
+                SetCurrentTape(savedCurrent);
+            }
+        }
+    }
+
+    private Dictionary<Tensor<T>, Tensor<T>> ComputeGradientsViaGraphCore(
         Tensor<T> loss,
         IReadOnlyList<Tensor<T>>? sources)
     {

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
@@ -706,7 +706,15 @@ internal static partial class SimdGemm
     //   8 cores: 10.48 Mi
     //  16 cores: 20 Mi   (iter 2 cap — unchanged)
     //  32 cores: 20 Mi   (capped)
-    private static readonly long ParallelWorkThreshold = ComputeParallelWorkThreshold();
+    /// <summary>
+    /// Work threshold (M·K·N) at and above which the SGEMM dispatch will run
+    /// the kernel in parallel via Parallel.For. Below this, the kernel runs
+    /// sequentially regardless of <see cref="UseParallelGemm"/>. Exposed
+    /// internally so callers (e.g. backward MatMul fast paths in
+    /// <c>BackwardFunctions</c>) can mirror the gate exactly instead of
+    /// hardcoding a duplicate value that drifts when this changes.
+    /// </summary>
+    internal static readonly long ParallelWorkThreshold = ComputeParallelWorkThreshold();
 
     private static long ComputeParallelWorkThreshold()
     {

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeLeakTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeLeakTests.cs
@@ -1,0 +1,143 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Issue #279 — GradientTape lifecycle leak repro.
+
+#nullable disable
+
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+/// <summary>
+/// Issue #279 leak repro. Mirrors a single transformer encoder block —
+/// QKV projections, scaled-dot-product attention, output projection,
+/// FFN — wired up with autograd recording so every saved-for-backward
+/// intermediate is exercised. The user's repro reports 3.78 MiB/call
+/// retention on a transformer of this shape; this test asserts a
+/// strict ceiling that catches both the original leak and any future
+/// regression.
+/// </summary>
+public class GradientTapeLeakTests
+{
+    private readonly ITestOutputHelper _output;
+    public GradientTapeLeakTests(ITestOutputHelper output) { _output = output; }
+
+    [Fact]
+    public void Diagnostic_FindLeakSource()
+    {
+        // Diagnostic test: track all live Tensor<float> instances
+        // via WeakReference to identify what's being retained across
+        // Train calls.
+        var engine = AiDotNetEngine.Current;
+        const int Batch = 1, Seq = 16, Dim = 64;
+        AiDotNet.Tensors.Helpers.AutoTensorCache.Clear();
+        var wq = MakeTensor(new[] { Dim, Dim }, 0.1f, 1);
+        var sources = new[] { wq };
+        var weakRefs = new System.Collections.Generic.List<System.WeakReference>();
+
+        // Warm up
+        for (int w = 0; w < 3; w++) Step();
+        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+        long start = GC.GetTotalMemory(forceFullCollection: true);
+        for (int i = 0; i < 10; i++) Step();
+        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+        long end = GC.GetTotalMemory(forceFullCollection: true);
+        _output.WriteLine($"After 10 steps: heap delta = {end - start} bytes");
+
+        int aliveCount = 0;
+        foreach (var wr in weakRefs)
+            if (wr.IsAlive) aliveCount++;
+        _output.WriteLine($"Live Tensor refs after GC: {aliveCount} of {weakRefs.Count} tracked");
+
+        void Step()
+        {
+            var x = MakeTensor(new[] { Batch * Seq, Dim }, 1.0f, 99);
+            weakRefs.Add(new System.WeakReference(x));
+            using var tape = new GradientTape<float>();
+            var q = engine.TensorMatMul(x, wq);
+            weakRefs.Add(new System.WeakReference(q));
+            var loss = engine.ReduceSum(q, null);
+            weakRefs.Add(new System.WeakReference(loss));
+            var grads = tape.ComputeGradients(loss, sources: sources);
+        }
+    }
+
+    [Fact]
+    public void TrainStep_TransformerBlock_DoesNotLeak()
+    {
+        var engine = AiDotNetEngine.Current;
+        const int Batch = 1, Seq = 16, Dim = 64, Heads = 4, FF = 128;
+        // Drain any thread-local caches left over from earlier tests
+        // (AutoTensorCache pools tensors per-thread; leftover entries
+        // from other test classes inflate the start-of-window heap and
+        // the cross-test deltas show up as a fake leak signature).
+        AiDotNet.Tensors.Helpers.AutoTensorCache.Clear();
+
+        // Parameters — survive every step like a model's trainable weights.
+        var wq = MakeTensor(new[] { Dim, Dim }, 0.1f, 1);
+        var wk = MakeTensor(new[] { Dim, Dim }, 0.1f, 2);
+        var wv = MakeTensor(new[] { Dim, Dim }, 0.1f, 3);
+        var wo = MakeTensor(new[] { Dim, Dim }, 0.1f, 4);
+        var w1 = MakeTensor(new[] { Dim, FF }, 0.1f, 5);
+        var w2 = MakeTensor(new[] { FF, Dim }, 0.1f, 6);
+        var sources = new[] { wq, wk, wv, wo, w1, w2 };
+
+        Step();
+        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+
+        long start = GC.GetTotalMemory(forceFullCollection: true);
+        const int iters = 50;
+        for (int i = 0; i < iters; i++) Step();
+        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+        long end = GC.GetTotalMemory(forceFullCollection: true);
+
+        long perCall = (end - start) / iters;
+        _output.WriteLine($"Synthetic transformer block leak: {perCall} B/call (start={start} end={end} iters={iters})");
+
+        // Threshold: 200 KB/call. The user's repro at this scale
+        // reports ~MB/call, so this catches the original leak with a
+        // generous safety factor while staying well below the
+        // sustained-training-run-out-of-memory cliff.
+        Assert.True(perCall < 200_000,
+            $"Managed-heap retention {perCall} B/call exceeds 200 KB/call budget. " +
+            $"Start={start} End={end} Iters={iters}. Issue #279 transformer-scale leak regression.");
+
+        void Step()
+        {
+            var x = MakeTensor(new[] { Batch * Seq, Dim }, 1.0f, 99);
+            using var tape = new GradientTape<float>();
+            // QKV projections.
+            var q = engine.TensorMatMul(x, wq);
+            var k = engine.TensorMatMul(x, wk);
+            var v = engine.TensorMatMul(x, wv);
+            // Reshape to [B*Seq, Heads, Dim/Heads]? Skip multi-head for
+            // the synthetic path — single-head is enough to fire the
+            // softmax + scaled-dot-product backward saved-state captures.
+            var scores = engine.TensorMatMulTransposed(q, k);
+            var attn = engine.Softmax(scores, axis: -1);
+            var ctx = engine.TensorMatMul(attn, v);
+            var proj = engine.TensorMatMul(ctx, wo);
+            // FFN with ReLU.
+            var h1 = engine.TensorMatMul(proj, w1);
+            var h2 = engine.ReLU(h1);
+            var h3 = engine.TensorMatMul(h2, w2);
+            var loss = engine.ReduceSum(h3, null);
+            var grads = tape.ComputeGradients(loss, sources: sources);
+            Assert.True(grads.ContainsKey(wq));
+        }
+    }
+
+    private static Tensor<float> MakeTensor(int[] shape, float scale, int seed)
+    {
+        var rng = new Random(seed);
+        int len = 1;
+        for (int i = 0; i < shape.Length; i++) len *= shape[i];
+        var data = new float[len];
+        for (int i = 0; i < data.Length; i++) data[i] = (float)((rng.NextDouble() * 2 - 1) * scale);
+        return new Tensor<float>(data, shape);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeLeakTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeLeakTests.cs
@@ -13,6 +13,15 @@ using Xunit.Abstractions;
 namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
 
 /// <summary>
+/// Defines the non-parallel collection for <see cref="GradientTapeLeakTests"/>.
+/// The leak ceiling assertions read process-wide <c>GC.GetTotalMemory</c>, so
+/// concurrent test allocations on other threads inflate the measured delta and
+/// can either fail the budget for unrelated reasons or hide a real regression.
+/// </summary>
+[CollectionDefinition("GradientTapeLeakTests", DisableParallelization = true)]
+public class GradientTapeLeakTestsCollection { }
+
+/// <summary>
 /// Issue #279 leak repro. Mirrors a single transformer encoder block —
 /// QKV projections, scaled-dot-product attention, output projection,
 /// FFN — wired up with autograd recording so every saved-for-backward
@@ -21,6 +30,7 @@ namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
 /// strict ceiling that catches both the original leak and any future
 /// regression.
 /// </summary>
+[Collection("GradientTapeLeakTests")]
 public class GradientTapeLeakTests
 {
     private readonly ITestOutputHelper _output;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeLeakTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeLeakTests.cs
@@ -36,7 +36,12 @@ public class GradientTapeLeakTests
     private readonly ITestOutputHelper _output;
     public GradientTapeLeakTests(ITestOutputHelper output) { _output = output; }
 
-    [Fact]
+    // Diagnostic helper retained for manual leak investigation. It writes
+    // tracking output to the test runner but asserts nothing — running it
+    // in CI just spends runtime without exercising any contract — so it's
+    // skipped by default and unskipped only when an engineer is chasing a
+    // specific leak signature.
+    [Fact(Skip = "Diagnostic-only — unskip locally when triaging a leak. No assertions, prints WeakReference live counts.")]
     public void Diagnostic_FindLeakSource()
     {
         // Diagnostic test: track all live Tensor<float> instances

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeLeakTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeLeakTests.cs
@@ -80,7 +80,7 @@ public class GradientTapeLeakTests
     public void TrainStep_TransformerBlock_DoesNotLeak()
     {
         var engine = AiDotNetEngine.Current;
-        const int Batch = 1, Seq = 16, Dim = 64, Heads = 4, FF = 128;
+        const int Batch = 1, Seq = 16, Dim = 64, FF = 128;
         // Drain any thread-local caches left over from earlier tests
         // (AutoTensorCache pools tensors per-thread; leftover entries
         // from other test classes inflate the start-of-window heap and


### PR DESCRIPTION
## Summary

Closes both halves of #279 across the **full** backward surface, not just `MatMulBackward`. Issue #279 specifically called out that the single-thread issue affects multiple backward paths (the consumer's dotnet-trace shows `FusedLinearBackwardCore` ~5×/Train alongside `MatMulBackward` ~17×/Train), so the fix lands in every 2D-float backward GEMM site.

## What this PR changes

### 1. `.Grad` cleanup on forward intermediates
`AccumulateGrad` was leaking `tensor.Grad = stored` on every forward intermediate (Q, K, V, attention scores, softmax outputs, layernorm outputs). The optimizer only reads `.Grad` on source parameters; leaving it set on intermediates chained each gradient tensor's lifetime to the intermediate's. `ComputeGradientsViaGraph` cleanup now nulls `.Grad` on every non-source tensor. Sources keep `.Grad` (optimizer contract); `RetainGrad`-registered tensors also keep `.Grad`. `Dispose` defensively nulls `_cachedDelegateChain`.

### 2. Parallel SimdGemm fast path across all 2D-float backward GEMMs
Each call site below previously routed exclusively through `BlasProvider.TryGemmEx`, which on installs whose BLAS provider lacks internal `Parallel.For` caps backward throughput to one core. Add a guarded `SimdGemm.Sgemm` dispatch ahead of the BLAS path:

- `MatMulBackward` — generic `C = A · B` backward
- `MatMulTransposedBackward` — attention `Q · Kᵀ` backward
- `FusedLinearBackwardCore` — linear + bias backward (transformer FFN, MLP)
- `FusedLinearActivationBackwardCore` — linear+bias+activation, shared by `FusedMatMulAdd{Sigmoid,Tanh,GELU,Swish}Backward`
- `FusedMatMulAddReLUBackward` — linear+bias+ReLU fused backward

Each gate:
- Prefers SimdGemm when work ≥ `MatMulBackwardSimdThreshold` (mirrored from `SimdGemm.ParallelWorkThreshold` so we only take it when SimdGemm itself will parallelize).
- Falls through to BLAS for small shapes or when SimdGemm is sequential anyway.
- Falls through to the engine path when neither fast path applies.
- Gated on `GradientTape<T>.Current is null` so `createGraph=true` higher-order AD (Hvp / double-backward) keeps recording into the outer tape.

## Regression test

`GradientTapeLeakTests.TrainStep_TransformerBlock_DoesNotLeak` fires a synthetic transformer encoder block (Q/K/V projections, scaled-dot-product attention, output projection, FFN, ReLU, ReduceSum) with a 200 KB/call managed-heap retention ceiling. Reports 0 B/call sustained over 50 iterations after the fix; user's reproducer was ~MiB/call before. The class is decorated with `[Collection("GradientTapeLeakTests")]` + `DisableParallelization=true` so its `GC.GetTotalMemory` deltas don't get corrupted by concurrent allocations on parallel test threads.

## Test plan

- [x] 617 autodiff + matmul + fused-linear + transformer tests pass on net10.0
- [x] `Hvp_QuadraticForm_GivesAv` passes (higher-order AD intact)
- [x] `TrainStep_TransformerBlock_DoesNotLeak` reports 0 B/call
- [x] No autograd or matmul correctness regressions

Closes #279.

🤖 Generated with [Claude Code](https://claude.com/claude-code)