### PR TITLE
fix(#279): return maskedTensor scratch buffer in FusedMatMulAddReLUBackward

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -2306,6 +2306,10 @@ internal static class BackwardFunctions<T>
                         pB[j] += rowPtr[j];
                 }
             }
+            // maskedTensor was a temporary scratch buffer — return it to the
+            // cache so the next call's [M,N] mask rental hits a warm pool.
+            // gradInput/gradWeight/gradBias are still owned by the grads dict.
+            Helpers.AutoTensorCache.Return(maskedTensor);
 
             DifferentiableOps.AccumulateGrad(grads, inputs[0], gradInput, engine);
             DifferentiableOps.AccumulateGrad(grads, inputs[1], gradWeight, engine);

--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -2308,7 +2308,8 @@ internal static class BackwardFunctions<T>
             }
             // maskedTensor was a temporary scratch buffer — return it to the
             // cache so the next call's [M,N] mask rental hits a warm pool.
-            // gradInput/gradWeight/gradBias are still owned by the grads dict.
+            // gradInput/gradWeight/gradBias will be handed off to the grads
+            // dict by the AccumulateGrad calls below; do NOT return them.
             Helpers.AutoTensorCache.Return(maskedTensor);
 
             DifferentiableOps.AccumulateGrad(grads, inputs[0], gradInput, engine);

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/BackwardBufferPoolingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/BackwardBufferPoolingTests.cs
@@ -406,54 +406,63 @@ public class BackwardBufferPoolingTests : IDisposable
     }
 
     [Fact]
-    public void FusedLinearReLU_Backward_FastPath_ReturnsScratchToCache()
+    public void FusedLinearReLU_Backward_FastPath_ProducesValidGradients()
     {
         // Exercises FusedMatMulAddReLUBackward at a shape large enough that
-        // M·K·N ≥ SimdGemm.ParallelWorkThreshold, so the success branch hits
-        // the SimdGemm fast path AND the AutoTensorCache.Return(maskedTensor)
-        // line. Without the Return, the [M,N] mask buffer would re-allocate
-        // every call instead of reusing the pool — this test verifies that
-        // running the backward N times doesn't grow the managed heap by ~M·N
-        // floats per call.
+        // M·K·N ≥ SimdGemm.ParallelWorkThreshold, so the success branch
+        // hits the SimdGemm fast path AND the AutoTensorCache.Return
+        // line for the maskedTensor scratch buffer. Existing tests in
+        // this class use 2×2 matrices that fall under the threshold and
+        // take the engine fallback path, so the fast-path success branch
+        // (which the post-PR-280 fix touches) goes uncovered.
+        //
+        // We assert behavioural correctness (gradients are populated,
+        // finite, and consistent across repeated calls) rather than
+        // heap-retention numbers — GC.GetTotalMemory deltas are
+        // unreliable on a shared CI runner where concurrent test classes
+        // allocate during the measurement window.
         const int M = 256, K = 256, N = 64; // 4.19 Mi work-elements > 2 Mi parallel gate
 
         var input = new Tensor<float>(MakeFilled(M * K, 0.01f), new[] { M, K });
         var weights = new Tensor<float>(MakeFilled(K * N, 0.005f), new[] { K, N });
         var bias = new Tensor<float>(MakeFilled(N, 0.01f), new[] { 1, N });
 
-        // Warmup: prime AutoTensorCache pools so cross-test heap state stabilizes.
-        for (int w = 0; w < 3; w++)
-        {
-            using var t = new GradientTape<float>();
-            var o = _engine.FusedLinear(input, weights, bias, FusedActivationType.ReLU);
-            var l = _engine.ReduceSum(o, null);
-            t.ComputeGradients(l, new[] { input, weights, bias });
-        }
-        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+        float[]? referenceWeightGrad = null;
 
-        long start = GC.GetTotalMemory(forceFullCollection: true);
-        const int iters = 20;
-        for (int i = 0; i < iters; i++)
+        for (int step = 0; step < 5; step++)
         {
             using var tape = new GradientTape<float>();
             var output = _engine.FusedLinear(input, weights, bias, FusedActivationType.ReLU);
             var loss = _engine.ReduceSum(output, null);
             var grads = tape.ComputeGradients(loss, new[] { input, weights, bias });
-            Assert.True(grads.ContainsKey(weights));
-        }
-        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
-        long end = GC.GetTotalMemory(forceFullCollection: true);
 
-        // If the maskedTensor isn't returned, each call leaks an [M,N] = 16384 floats
-        // = 64 KB. 20 iters × 64 KB = 1.28 MB heap growth. Cap at 200 KB/call so
-        // the test catches the regression with margin. (The test class itself
-        // doesn't run under coverage on CI, but the executed line shows up in
-        // the Test with Coverage step.)
-        long perCall = (end - start) / iters;
-        Assert.True(perCall < 200_000,
-            $"FusedLinear+ReLU fast-path backward retained {perCall} B/call " +
-            $"over {iters} iters (start={start} end={end}). Suggests the " +
-            $"maskedTensor scratch buffer isn't being returned to AutoTensorCache.");
+            Assert.True(grads.ContainsKey(weights), "weight gradient missing");
+            Assert.True(grads.ContainsKey(bias), "bias gradient missing");
+            Assert.True(grads.ContainsKey(input), "input gradient missing");
+
+            // Spot-check finiteness so a NaN/Inf from a buffer-reuse bug fails loudly.
+            for (int i = 0; i < grads[weights].Length; i += 256)
+                Assert.True(!float.IsNaN(grads[weights].GetFlat(i)) && !float.IsInfinity(grads[weights].GetFlat(i)),
+                    $"non-finite weight gradient at index {i}");
+
+            if (step == 0)
+            {
+                referenceWeightGrad = Enumerable.Range(0, grads[weights].Length)
+                    .Select(i => grads[weights].GetFlat(i)).ToArray();
+                continue;
+            }
+
+            // Gradient values must be identical across steps — if the
+            // pooled scratch buffer leaks stale data into a subsequent
+            // call, this catches it.
+            for (int i = 0; i < referenceWeightGrad!.Length; i += 256)
+            {
+                float actual = grads[weights].GetFlat(i);
+                Assert.True(Math.Abs(actual - referenceWeightGrad[i]) <= 1e-3f,
+                    $"FusedLinear+ReLU fast-path weight gradient drifted at step {step}, " +
+                    $"index {i}: expected {referenceWeightGrad[i]}, got {actual}");
+            }
+        }
     }
 
     private static float[] MakeFilled(int len, float scale)

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/BackwardBufferPoolingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/BackwardBufferPoolingTests.cs
@@ -409,19 +409,26 @@ public class BackwardBufferPoolingTests : IDisposable
     public void FusedLinearReLU_Backward_FastPath_ProducesValidGradients()
     {
         // Exercises FusedMatMulAddReLUBackward at a shape large enough that
-        // M·K·N ≥ SimdGemm.ParallelWorkThreshold, so the success branch
-        // hits the SimdGemm fast path AND the AutoTensorCache.Return
-        // line for the maskedTensor scratch buffer. Existing tests in
-        // this class use 2×2 matrices that fall under the threshold and
-        // take the engine fallback path, so the fast-path success branch
-        // (which the post-PR-280 fix touches) goes uncovered.
+        // M·K·N ≥ SimdGemm.ParallelWorkThreshold on any reasonable host,
+        // so the success branch hits the SimdGemm fast path AND the
+        // AutoTensorCache.Return line for the maskedTensor scratch buffer.
+        // Existing tests in this class use 2×2 matrices that fall under
+        // the threshold and take the engine fallback path, so the fast-
+        // path success branch (which the post-PR-280 fix touches) goes
+        // uncovered.
+        //
+        // Shape 256×512×256 ⇒ 33.5 Mi work-elements, above SimdGemm's 20 Mi
+        // upper cap (the cap is hit on hosts with ≥ 16 cores; lower cores
+        // see a smaller threshold scaled per core, so this size is safely
+        // over on every reasonable runner including the 4-core GitHub
+        // Actions Linux pool).
         //
         // We assert behavioural correctness (gradients are populated,
         // finite, and consistent across repeated calls) rather than
         // heap-retention numbers — GC.GetTotalMemory deltas are
         // unreliable on a shared CI runner where concurrent test classes
         // allocate during the measurement window.
-        const int M = 256, K = 256, N = 64; // 4.19 Mi work-elements > 2 Mi parallel gate
+        const int M = 256, K = 512, N = 256;
 
         var input = new Tensor<float>(MakeFilled(M * K, 0.01f), new[] { M, K });
         var weights = new Tensor<float>(MakeFilled(K * N, 0.005f), new[] { K, N });

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/BackwardBufferPoolingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/BackwardBufferPoolingTests.cs
@@ -432,7 +432,12 @@ public class BackwardBufferPoolingTests : IDisposable
         for (int step = 0; step < 5; step++)
         {
             using var tape = new GradientTape<float>();
-            var output = _engine.FusedLinear(input, weights, bias, FusedActivationType.ReLU);
+            // FusedLinearReLU registers FusedMatMulAddReLUBackward — the
+            // function that owns the maskedTensor scratch buffer this fix
+            // returns to the cache. _engine.FusedLinear(..., ReLU) takes a
+            // different code path (FusedLinearWithActivationBackward) that
+            // doesn't have the mask buffer at all.
+            var output = _engine.FusedLinearReLU(input, weights, bias);
             var loss = _engine.ReduceSum(output, null);
             var grads = tape.ComputeGradients(loss, new[] { input, weights, bias });
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/BackwardBufferPoolingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/BackwardBufferPoolingTests.cs
@@ -406,35 +406,46 @@ public class BackwardBufferPoolingTests : IDisposable
     }
 
     [Fact]
-    public void FusedLinearReLU_Backward_FastPath_ProducesValidGradients()
+    public void FusedLinearReLU_Backward_AboveSimdGemmThreshold_ProducesValidGradients()
     {
-        // Exercises FusedMatMulAddReLUBackward at a shape large enough that
-        // M·K·N ≥ SimdGemm.ParallelWorkThreshold on any reasonable host,
-        // so the success branch hits the SimdGemm fast path AND the
-        // AutoTensorCache.Return line for the maskedTensor scratch buffer.
+        // Exercises FusedMatMulAddReLUBackward at a shape sized DIRECTLY
+        // from SimdGemm.ParallelWorkThreshold so M·K·N is always above the
+        // gate, no matter the runner core count (the threshold scales per-
+        // core and clamps to [2 Mi, 20 Mi] work-elements). The cube-root
+        // sizing keeps the matrices as small as possible while still
+        // crossing the gate, so this test stays cheap on CI instead of
+        // using the previous 256×512×256 = 33.5 Mi shape that was much
+        // larger than necessary.
+        //
         // Existing tests in this class use 2×2 matrices that fall under
         // the threshold and take the engine fallback path, so the fast-
         // path success branch (which the post-PR-280 fix touches) goes
-        // uncovered.
-        //
-        // Shape 256×512×256 ⇒ 33.5 Mi work-elements, above SimdGemm's 20 Mi
-        // upper cap (the cap is hit on hosts with ≥ 16 cores; lower cores
-        // see a smaller threshold scaled per core, so this size is safely
-        // over on every reasonable runner including the 4-core GitHub
-        // Actions Linux pool).
+        // uncovered without this case.
         //
         // We assert behavioural correctness (gradients are populated,
         // finite, and consistent across repeated calls) rather than
         // heap-retention numbers — GC.GetTotalMemory deltas are
         // unreliable on a shared CI runner where concurrent test classes
         // allocate during the measurement window.
-        const int M = 256, K = 512, N = 256;
+        long threshold = global::AiDotNet.Tensors.Engines.Simd.SimdGemm.ParallelWorkThreshold;
+        // Cube root with 25 % headroom so we land safely above the gate
+        // even after rounding down per dimension.
+        int dim = (int)Math.Ceiling(Math.Cbrt(threshold * 1.25));
+        // Round up to the next multiple of 16 so the per-dim sizes stay
+        // friendly to the vector kernel's micro-tile (Mr=6, Nr=16) without
+        // forcing huge edges.
+        dim = ((dim + 15) / 16) * 16;
+        int M = dim, K = dim, N = dim;
+        Assert.True((long)M * K * N >= threshold,
+            $"Test sizing math regressed: M*K*N = {(long)M * K * N} < threshold = {threshold}");
 
         var input = new Tensor<float>(MakeFilled(M * K, 0.01f), new[] { M, K });
         var weights = new Tensor<float>(MakeFilled(K * N, 0.005f), new[] { K, N });
         var bias = new Tensor<float>(MakeFilled(N, 0.01f), new[] { 1, N });
 
         float[]? referenceWeightGrad = null;
+        float[]? referenceBiasGrad = null;
+        float[]? referenceInputGrad = null;
 
         for (int step = 0; step < 5; step++)
         {
@@ -452,27 +463,55 @@ public class BackwardBufferPoolingTests : IDisposable
             Assert.True(grads.ContainsKey(bias), "bias gradient missing");
             Assert.True(grads.ContainsKey(input), "input gradient missing");
 
-            // Spot-check finiteness so a NaN/Inf from a buffer-reuse bug fails loudly.
-            for (int i = 0; i < grads[weights].Length; i += 256)
+            // Validate FULL finiteness across every gradient element so a
+            // NaN/Inf from a buffer-reuse bug anywhere in the K×N / M×K /
+            // 1×N grads fails loudly. Spot-checks (every Nth entry) let
+            // contiguous corruption slip through.
+            for (int i = 0; i < grads[weights].Length; i++)
                 Assert.True(!float.IsNaN(grads[weights].GetFlat(i)) && !float.IsInfinity(grads[weights].GetFlat(i)),
                     $"non-finite weight gradient at index {i}");
+            for (int i = 0; i < grads[bias].Length; i++)
+                Assert.True(!float.IsNaN(grads[bias].GetFlat(i)) && !float.IsInfinity(grads[bias].GetFlat(i)),
+                    $"non-finite bias gradient at index {i}");
+            for (int i = 0; i < grads[input].Length; i++)
+                Assert.True(!float.IsNaN(grads[input].GetFlat(i)) && !float.IsInfinity(grads[input].GetFlat(i)),
+                    $"non-finite input gradient at index {i}");
 
             if (step == 0)
             {
                 referenceWeightGrad = Enumerable.Range(0, grads[weights].Length)
                     .Select(i => grads[weights].GetFlat(i)).ToArray();
+                referenceBiasGrad = Enumerable.Range(0, grads[bias].Length)
+                    .Select(i => grads[bias].GetFlat(i)).ToArray();
+                referenceInputGrad = Enumerable.Range(0, grads[input].Length)
+                    .Select(i => grads[input].GetFlat(i)).ToArray();
                 continue;
             }
 
             // Gradient values must be identical across steps — if the
             // pooled scratch buffer leaks stale data into a subsequent
-            // call, this catches it.
-            for (int i = 0; i < referenceWeightGrad!.Length; i += 256)
+            // call, this catches it. Validate FULL gradient content for
+            // weights AND bias AND input across steps.
+            for (int i = 0; i < referenceWeightGrad!.Length; i++)
             {
                 float actual = grads[weights].GetFlat(i);
                 Assert.True(Math.Abs(actual - referenceWeightGrad[i]) <= 1e-3f,
-                    $"FusedLinear+ReLU fast-path weight gradient drifted at step {step}, " +
+                    $"FusedLinear+ReLU weight gradient drifted at step {step}, " +
                     $"index {i}: expected {referenceWeightGrad[i]}, got {actual}");
+            }
+            for (int i = 0; i < referenceBiasGrad!.Length; i++)
+            {
+                float actual = grads[bias].GetFlat(i);
+                Assert.True(Math.Abs(actual - referenceBiasGrad[i]) <= 1e-3f,
+                    $"FusedLinear+ReLU bias gradient drifted at step {step}, " +
+                    $"index {i}: expected {referenceBiasGrad[i]}, got {actual}");
+            }
+            for (int i = 0; i < referenceInputGrad!.Length; i++)
+            {
+                float actual = grads[input].GetFlat(i);
+                Assert.True(Math.Abs(actual - referenceInputGrad[i]) <= 1e-3f,
+                    $"FusedLinear+ReLU input gradient drifted at step {step}, " +
+                    $"index {i}: expected {referenceInputGrad[i]}, got {actual}");
             }
         }
     }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/BackwardBufferPoolingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/BackwardBufferPoolingTests.cs
@@ -429,8 +429,10 @@ public class BackwardBufferPoolingTests : IDisposable
         // allocate during the measurement window.
         long threshold = global::AiDotNet.Tensors.Engines.Simd.SimdGemm.ParallelWorkThreshold;
         // Cube root with 25 % headroom so we land safely above the gate
-        // even after rounding down per dimension.
-        int dim = (int)Math.Ceiling(Math.Cbrt(threshold * 1.25));
+        // even after rounding down per dimension. Math.Cbrt isn't available
+        // on net471, so use Math.Pow(x, 1.0/3.0) which is — accurate enough
+        // for sizing a test matrix (we round up afterwards anyway).
+        int dim = (int)Math.Ceiling(Math.Pow(threshold * 1.25, 1.0 / 3.0));
         // Round up to the next multiple of 16 so the per-dim sizes stay
         // friendly to the vector kernel's micro-tile (Mr=6, Nr=16) without
         // forcing huge edges.

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/BackwardBufferPoolingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/BackwardBufferPoolingTests.cs
@@ -404,4 +404,62 @@ public class BackwardBufferPoolingTests : IDisposable
                 $"autodiff={autodiff:F4}, numerical={numerical:F4}");
         }
     }
+
+    [Fact]
+    public void FusedLinearReLU_Backward_FastPath_ReturnsScratchToCache()
+    {
+        // Exercises FusedMatMulAddReLUBackward at a shape large enough that
+        // M·K·N ≥ SimdGemm.ParallelWorkThreshold, so the success branch hits
+        // the SimdGemm fast path AND the AutoTensorCache.Return(maskedTensor)
+        // line. Without the Return, the [M,N] mask buffer would re-allocate
+        // every call instead of reusing the pool — this test verifies that
+        // running the backward N times doesn't grow the managed heap by ~M·N
+        // floats per call.
+        const int M = 256, K = 256, N = 64; // 4.19 Mi work-elements > 2 Mi parallel gate
+
+        var input = new Tensor<float>(MakeFilled(M * K, 0.01f), new[] { M, K });
+        var weights = new Tensor<float>(MakeFilled(K * N, 0.005f), new[] { K, N });
+        var bias = new Tensor<float>(MakeFilled(N, 0.01f), new[] { 1, N });
+
+        // Warmup: prime AutoTensorCache pools so cross-test heap state stabilizes.
+        for (int w = 0; w < 3; w++)
+        {
+            using var t = new GradientTape<float>();
+            var o = _engine.FusedLinear(input, weights, bias, FusedActivationType.ReLU);
+            var l = _engine.ReduceSum(o, null);
+            t.ComputeGradients(l, new[] { input, weights, bias });
+        }
+        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+
+        long start = GC.GetTotalMemory(forceFullCollection: true);
+        const int iters = 20;
+        for (int i = 0; i < iters; i++)
+        {
+            using var tape = new GradientTape<float>();
+            var output = _engine.FusedLinear(input, weights, bias, FusedActivationType.ReLU);
+            var loss = _engine.ReduceSum(output, null);
+            var grads = tape.ComputeGradients(loss, new[] { input, weights, bias });
+            Assert.True(grads.ContainsKey(weights));
+        }
+        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+        long end = GC.GetTotalMemory(forceFullCollection: true);
+
+        // If the maskedTensor isn't returned, each call leaks an [M,N] = 16384 floats
+        // = 64 KB. 20 iters × 64 KB = 1.28 MB heap growth. Cap at 200 KB/call so
+        // the test catches the regression with margin. (The test class itself
+        // doesn't run under coverage on CI, but the executed line shows up in
+        // the Test with Coverage step.)
+        long perCall = (end - start) / iters;
+        Assert.True(perCall < 200_000,
+            $"FusedLinear+ReLU fast-path backward retained {perCall} B/call " +
+            $"over {iters} iters (start={start} end={end}). Suggests the " +
+            $"maskedTensor scratch buffer isn't being returned to AutoTensorCache.");
+    }
+
+    private static float[] MakeFilled(int len, float scale)
+    {
+        var data = new float[len];
+        for (int i = 0; i < len; i++) data[i] = (float)((i * 0.017 + 0.1) * scale);
+        return data;
+    }
 }


### PR DESCRIPTION
## Summary

Returns the `maskedTensor` scratch buffer to the `AutoTensorCache` pool inside `FusedMatMulAddReLUBackward`'s SimdGemm fast path. Without this, every fused-linear+ReLU backward call leaks an `[M, N]` float buffer (= 64 KB on a typical SD-attention block) to the GC.

**Closes:** the followup tracked under #279 — masked-tensor return inside `FusedMatMulAddReLUBackward`.

## What's in this PR

### `BackwardFunctions.FusedMatMulAddReLUBackward`

- After `gradInput` / `gradWeight` / `gradBias` have been computed and BEFORE the `AccumulateGrad` calls, return the `maskedTensor` scratch buffer to `AutoTensorCache`. The grad tensors themselves are still handed off to the `grads` dict via `AccumulateGrad`, not pooled. Comment reworded to drop the misleading "still owned" phrasing per Copilot reviewer.

### Test coverage

- New `FusedLinearReLU_Backward_AboveSimdGemmThreshold_ProducesValidGradients` — sized via `SimdGemm.ParallelWorkThreshold` cube root (with 25% headroom + 16-aligned dims) so the test sits just above the SimdGemm fast-path gate on every host without burning unnecessary CI time.
- Asserts FULL weight + bias + input gradient finiteness AND step-to-step consistency across 5 successive calls — sparse spot-checks (every 256th element) would let contiguous corruption from a buffer-reuse bug slip through; full validation catches it.
- `Math.Pow(x, 1.0/3.0)` instead of `Math.Cbrt` so the test compiles on net471.

## Review-comment status

6 / 6 unresolved review threads on this PR resolved.

## Test plan

- [x] `dotnet build` — net10.0 + net471 both clean
- [x] `FusedLinearReLU_Backward_AboveSimdGemmThreshold_ProducesValidGradients` passes
- [x] CI build + publish jobs — green