### PR TITLE
perf(conv2d-double): parallel gemm + im2col-free 3x3 + b-repack for diffusion shapes

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -24633,6 +24633,41 @@ public partial class CpuEngine : ITensorLevelEngine
         if (output.Length != tensor.Length)
             throw new ArgumentException(
                 $"Output length ({output.Length}) does not match input length ({tensor.Length}).");
+
+        // Rank-0 short-circuit: a 0-d tensor permutes trivially via a single
+        // scalar copy. Without this, the contiguous-stride init below indexes
+        // srcStrides[rank - 1] which is out of bounds.
+        if (axes.Length == 0)
+        {
+            if (output.Length > 0 && tensor.Length > 0)
+                output.Data.Span[0] = tensor.Data.Span[0];
+            return;
+        }
+
+        // Validate that `axes` is a real permutation: every entry must be in
+        // [0, rank) and every axis index must appear exactly once. Without
+        // this check, a malformed array like [0, 0, 2, 3] would silently
+        // produce wrong output (axis 0 sampled twice, axis 1 dropped) and a
+        // negative or out-of-range entry would later throw
+        // IndexOutOfRangeException from `srcStrides[axes[i]]` instead of the
+        // ArgumentException callers expect.
+        int rankCheck = axes.Length;
+        Span<bool> seen = rankCheck <= 32
+            ? stackalloc bool[rankCheck]
+            : new bool[rankCheck];
+        for (int i = 0; i < rankCheck; i++)
+        {
+            int a = axes[i];
+            if (a < 0 || a >= rankCheck)
+                throw new ArgumentException(
+                    $"Axes[{i}] = {a} is out of range [0, {rankCheck}).", nameof(axes));
+            if (seen[a])
+                throw new ArgumentException(
+                    $"Axes is not a valid permutation: axis {a} appears more than once.",
+                    nameof(axes));
+            seen[a] = true;
+        }
+
         for (int i = 0; i < axes.Length; i++)
         {
             int expected = tensor._shape[axes[i]];
@@ -24640,6 +24675,25 @@ public partial class CpuEngine : ITensorLevelEngine
                 throw new ArgumentException(
                     $"Output shape mismatch at axis {i}: expected {expected}, got {output._shape[i]}.");
         }
+
+        // The dense walk below assumes both tensors are dense row-major
+        // (contiguous, zero storage offset). Strided views — created by
+        // .Slice(...) / .Transpose(...) without subsequent .Contiguous() —
+        // carry their own stride table and storage offset, and indexing
+        // tensor.Data.Span / output.Data.Span directly would read or write
+        // the wrong elements. Reject those explicitly so callers can either
+        // call .Contiguous() up front or pass dense tensors.
+        if (!(tensor.IsContiguous && tensor._storageOffset == 0))
+            throw new ArgumentException(
+                "TensorPermuteInto requires a dense row-major source tensor; " +
+                "call .Contiguous() on strided views before passing them in.",
+                nameof(tensor));
+        if (!(output.IsContiguous && output._storageOffset == 0))
+            throw new ArgumentException(
+                "TensorPermuteInto requires a dense row-major output tensor; " +
+                "non-contiguous outputs cannot be written into via the dense " +
+                "fast-path (the strided write would corrupt the underlying buffer).",
+                nameof(output));
 
         // Permute by copying strided source into row-major output. We walk
         // the OUTPUT in row-major order (linear index 0..N) and for each

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -24607,6 +24607,129 @@ public partial class CpuEngine : ITensorLevelEngine
     }
 
     /// <inheritdoc/>
+    /// <inheritdoc/>
+    public virtual void TensorPermuteInto<T>(Tensor<T> output, Tensor<T> tensor, int[] axes)
+    {
+        if (output == null) throw new ArgumentNullException(nameof(output));
+        if (tensor == null) throw new ArgumentNullException(nameof(tensor));
+        if (axes == null) throw new ArgumentNullException(nameof(axes));
+        if (axes.Length != tensor._shape.Length)
+            throw new ArgumentException("Axes length must match tensor rank");
+        if (output._shape.Length != axes.Length)
+            throw new ArgumentException("Output rank must match axes length");
+        if (output.Length != tensor.Length)
+            throw new ArgumentException(
+                $"Output length ({output.Length}) does not match input length ({tensor.Length}).");
+        for (int i = 0; i < axes.Length; i++)
+        {
+            int expected = tensor._shape[axes[i]];
+            if (output._shape[i] != expected)
+                throw new ArgumentException(
+                    $"Output shape mismatch at axis {i}: expected {expected}, got {output._shape[i]}.");
+        }
+
+        // Permute by copying strided source into row-major output. We walk
+        // the OUTPUT in row-major order (linear index 0..N) and for each
+        // output index compute the corresponding source linear index from
+        // the inverse-permutation strides. That keeps the destination
+        // write pattern stride-1 (cache-friendly) while the source read
+        // pattern follows whatever the permutation dictates — exactly the
+        // tradeoff strided-permute kernels make.
+        var srcShape = tensor._shape;
+        int rank = axes.Length;
+        var srcStrides = new int[rank];
+        // Row-major contiguous source strides
+        srcStrides[rank - 1] = 1;
+        for (int d = rank - 2; d >= 0; d--)
+            srcStrides[d] = srcStrides[d + 1] * srcShape[d + 1];
+
+        // For each output axis i, the corresponding source axis is axes[i].
+        // Walking output in row-major: increment along axis i contributes
+        // srcStrides[axes[i]] doubles to the source linear index.
+        var permutedSrcStrides = new int[rank];
+        for (int i = 0; i < rank; i++)
+            permutedSrcStrides[i] = srcStrides[axes[i]];
+
+        var dstShape = output._shape;
+        var srcSpan = tensor.Data.Span;
+        var dstSpan = output.Data.Span;
+
+        // For rank ≤ 4 (the diffusion / transformer hot path), unroll the
+        // index walk into nested loops; for higher ranks, fall back to a
+        // generic odometer loop.
+        if (rank == 4)
+        {
+            int d0 = dstShape[0], d1 = dstShape[1], d2 = dstShape[2], d3 = dstShape[3];
+            int s0 = permutedSrcStrides[0], s1 = permutedSrcStrides[1], s2 = permutedSrcStrides[2], s3 = permutedSrcStrides[3];
+            int dstIdx = 0;
+            for (int i0 = 0; i0 < d0; i0++)
+            {
+                int b0 = i0 * s0;
+                for (int i1 = 0; i1 < d1; i1++)
+                {
+                    int b1 = b0 + i1 * s1;
+                    for (int i2 = 0; i2 < d2; i2++)
+                    {
+                        int b2 = b1 + i2 * s2;
+                        for (int i3 = 0; i3 < d3; i3++)
+                        {
+                            dstSpan[dstIdx++] = srcSpan[b2 + i3 * s3];
+                        }
+                    }
+                }
+            }
+            return;
+        }
+
+        if (rank == 3)
+        {
+            int d0 = dstShape[0], d1 = dstShape[1], d2 = dstShape[2];
+            int s0 = permutedSrcStrides[0], s1 = permutedSrcStrides[1], s2 = permutedSrcStrides[2];
+            int dstIdx = 0;
+            for (int i0 = 0; i0 < d0; i0++)
+            {
+                int b0 = i0 * s0;
+                for (int i1 = 0; i1 < d1; i1++)
+                {
+                    int b1 = b0 + i1 * s1;
+                    for (int i2 = 0; i2 < d2; i2++)
+                        dstSpan[dstIdx++] = srcSpan[b1 + i2 * s2];
+                }
+            }
+            return;
+        }
+
+        if (rank == 2)
+        {
+            int d0 = dstShape[0], d1 = dstShape[1];
+            int s0 = permutedSrcStrides[0], s1 = permutedSrcStrides[1];
+            int dstIdx = 0;
+            for (int i0 = 0; i0 < d0; i0++)
+            {
+                int b0 = i0 * s0;
+                for (int i1 = 0; i1 < d1; i1++)
+                    dstSpan[dstIdx++] = srcSpan[b0 + i1 * s1];
+            }
+            return;
+        }
+
+        // Generic odometer fallback for rank ≥ 5 / rank 1.
+        var idx = new int[rank];
+        int total = output.Length;
+        for (int dstIdxG = 0; dstIdxG < total; dstIdxG++)
+        {
+            int srcIdx = 0;
+            for (int d = 0; d < rank; d++) srcIdx += idx[d] * permutedSrcStrides[d];
+            dstSpan[dstIdxG] = srcSpan[srcIdx];
+            // increment odometer
+            for (int d = rank - 1; d >= 0; d--)
+            {
+                if (++idx[d] < dstShape[d]) break;
+                idx[d] = 0;
+            }
+        }
+    }
+
     public virtual Tensor<T> TensorPermute<T>(Tensor<T> tensor, int[] axes)
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -7323,22 +7323,36 @@ public partial class CpuEngine : ITensorLevelEngine
             // Mirrors the float path's SimdConvHelper.Conv3x3Stride1 — register-
             // resident Vector256<double> inner kernel, no im2col allocation.
             //
-            // A/B-tested with --ab-conv2d-double:
+            // Original A/B-test (with serial im2col+GEMM as baseline):
             //   [1,3,32,32]→[16,3,3]  (442K FMAs):  460 → 385 µs (1.2× faster)
             //   [4,3,32,32]→[16,3,3]  (1.77M FMAs): 1632 → 1483 µs (1.1× faster)
             //   [1,16,64,64]→[32,3,3] (18.9M FMAs): 5201 → 18228 µs (3.5× SLOWER)
-            // Threshold: direct kernel for ≤4M FMAs (the BDN shape is 0.44M),
-            // im2col+GEMM for larger (where its better cache reuse dominates
-            // the lack of row-pairing in the direct kernel).
+            // The 18.9M FMA shape losing was driven by outChannels=32 — the
+            // direct kernel parallelizes per-output-channel, so 32 oc on a
+            // 32-core box gives at most 32 parallel tasks but the im2col+GEMM
+            // path's 2D-tile partition (M/64 × N/64) gives way more (and
+            // is now also parallelized on a separate path). For diffusion-
+            // class shapes (SD UNet ResBlock 320→320 @ 64×64, 3.77 GFMA)
+            // outChannels=320 gives 10× more parallelism than the original
+            // A/B baseline shape, so the direct kernel wins again.
+            //
+            // Updated gate (2026-05-02): allow the direct kernel when EITHER
+            //   (a) total FMAs are small (≤ 4 M, the BDN baseline), OR
+            //   (b) outChannels gives ≥ 2× ProcessorCount parallel tasks
+            //       so all cores have work and the no-im2col-blowup
+            //       memory-traffic win materializes.
 #if !NET471
             // SimdConvHelper.Conv3x3Stride1Double is gated on AVX2/FMA intrinsics
             // (System.Runtime.Intrinsics is unavailable on net471 — the file is
             // <Compile Remove>'d in the .csproj for that TFM). On net471 doubles
             // fall through to the im2col+GEMM path below.
             long convFmas = (long)batch * outChannels * inChannels * outputHeight * outputWidth * 9L;
+            int directKernelMinTasks = 2 * Math.Max(1, Environment.ProcessorCount);
+            bool directKernelFitsWell = convFmas <= 4_000_000L
+                || outChannels >= directKernelMinTasks;
             if (kernelHeight == 3 && kernelWidth == 3
                 && stride == 1 && padding > 0 && dilation == 1
-                && convFmas <= 4_000_000L
+                && directKernelFitsWell
                 && Helpers.SimdConvHelper.CanUseSimdConvDouble(kernelHeight, kernelWidth, stride, stride))
             {
                 var dInput  = (Tensor<double>)(object)input;
@@ -7486,9 +7500,48 @@ public partial class CpuEngine : ITensorLevelEngine
             return;
         }
 
-        // Use im2col + GEMM for double
+        // Use im2col + GEMM for double, OR — for 3×3 stride=1 with enough
+        // outChannels to saturate the cores — the register-resident
+        // SimdConvHelper.Conv3x3Stride1Double kernel that skips im2col
+        // entirely. ConvolutionalLayer's inference path calls Conv2DInto
+        // (zero-alloc), so without this branch SD UNet ResBlocks never see
+        // the direct kernel even though Conv2D (allocating overload) does.
+        // Same gating logic as Conv2D: small shapes (≤4 M FMAs) or
+        // outChannels ≥ 2× ProcessorCount — both ensure the per-oc
+        // parallelism pays off without im2col's memory blowup.
         if (typeof(T) == typeof(double))
         {
+#if !NET471
+            long convFmasInto = (long)batch * outChannels * inChannels * outputHeight * outputWidth * 9L;
+            int directKernelMinTasksInto = 2 * Math.Max(1, Environment.ProcessorCount);
+            bool directKernelFitsWellInto = convFmasInto <= 4_000_000L
+                || outChannels >= directKernelMinTasksInto;
+            if (kernelHeight == 3 && kernelWidth == 3
+                && stride == 1 && padding > 0 && dilation == 1
+                && directKernelFitsWellInto
+                && Helpers.SimdConvHelper.CanUseSimdConvDouble(kernelHeight, kernelWidth, stride, stride))
+            {
+                var dInput  = (Tensor<double>)(object)input;
+                var dKernel = (Tensor<double>)(object)kernel;
+                var dOutput = (Tensor<double>)(object)output;
+                // Caller of Conv2DInto reuses output across calls — clear
+                // before accumulating since the direct kernel does
+                // output[oh,ow] += sum_{ic,kh,kw} conv contributions.
+                dOutput.Data.Span.Clear();
+                using var pinIn = dInput.Data.Pin();
+                using var pinK  = dKernel.Data.Pin();
+                using var pinO  = dOutput.Data.Pin();
+                unsafe
+                {
+                    Helpers.SimdConvHelper.Conv3x3Stride1Double(
+                        (double*)pinIn.Pointer, (double*)pinK.Pointer, (double*)pinO.Pointer,
+                        batch, inChannels, height, width,
+                        outChannels, padding, padding, dilation, dilation);
+                }
+                return;
+            }
+#endif
+
             Conv2DWithIm2ColDouble(
                 input as Tensor<double> ?? throw new InvalidCastException(),
                 kernel as Tensor<double> ?? throw new InvalidCastException(),

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -7338,16 +7338,24 @@ public partial class CpuEngine : ITensorLevelEngine
             //
             // Updated gate (2026-05-02): allow the direct kernel when EITHER
             //   (a) total FMAs are small (≤ 4 M, the BDN baseline), OR
-            //   (b) outChannels gives ≥ 2× ProcessorCount parallel tasks
-            //       so all cores have work and the no-im2col-blowup
-            //       memory-traffic win materializes.
+            //   (b) outChannels gives ≥ 2× the parallel-task budget so all
+            //       workers have work and the no-im2col-blowup memory-traffic
+            //       win materializes.
+            // The parallel-task budget is read from CpuParallelSettings.MaxDegreeOfParallelism
+            // — Conv3x3Stride1Double's per-oc parallelism dispatches via the
+            // same setting (CpuParallelSettings.LightweightParallel), so a
+            // host that capped MaxDegreeOfParallelism (shared CI runner,
+            // deterministic-mode tests) gets a consistent gate decision.
+            // Using Environment.ProcessorCount here would over-route into
+            // the direct kernel on capped hosts where it'd actually
+            // task-starve.
 #if !NET471
             // SimdConvHelper.Conv3x3Stride1Double is gated on AVX2/FMA intrinsics
             // (System.Runtime.Intrinsics is unavailable on net471 — the file is
             // <Compile Remove>'d in the .csproj for that TFM). On net471 doubles
             // fall through to the im2col+GEMM path below.
             long convFmas = (long)batch * outChannels * inChannels * outputHeight * outputWidth * 9L;
-            int directKernelMinTasks = 2 * Math.Max(1, Environment.ProcessorCount);
+            int directKernelMinTasks = 2 * Math.Max(1, Helpers.CpuParallelSettings.MaxDegreeOfParallelism);
             bool directKernelFitsWell = convFmas <= 4_000_000L
                 || outChannels >= directKernelMinTasks;
             if (kernelHeight == 3 && kernelWidth == 3
@@ -7507,13 +7515,16 @@ public partial class CpuEngine : ITensorLevelEngine
         // (zero-alloc), so without this branch SD UNet ResBlocks never see
         // the direct kernel even though Conv2D (allocating overload) does.
         // Same gating logic as Conv2D: small shapes (≤4 M FMAs) or
-        // outChannels ≥ 2× ProcessorCount — both ensure the per-oc
-        // parallelism pays off without im2col's memory blowup.
+        // outChannels ≥ 2× CpuParallelSettings.MaxDegreeOfParallelism —
+        // both ensure the per-oc parallelism pays off without im2col's
+        // memory blowup, while honouring host-side thread caps the same
+        // way the kernel itself does (it dispatches via
+        // CpuParallelSettings.LightweightParallel internally).
         if (typeof(T) == typeof(double))
         {
 #if !NET471
             long convFmasInto = (long)batch * outChannels * inChannels * outputHeight * outputWidth * 9L;
-            int directKernelMinTasksInto = 2 * Math.Max(1, Environment.ProcessorCount);
+            int directKernelMinTasksInto = 2 * Math.Max(1, Helpers.CpuParallelSettings.MaxDegreeOfParallelism);
             bool directKernelFitsWellInto = convFmasInto <= 4_000_000L
                 || outChannels >= directKernelMinTasksInto;
             if (kernelHeight == 3 && kernelWidth == 3
@@ -7524,10 +7535,12 @@ public partial class CpuEngine : ITensorLevelEngine
                 var dInput  = (Tensor<double>)(object)input;
                 var dKernel = (Tensor<double>)(object)kernel;
                 var dOutput = (Tensor<double>)(object)output;
-                // Caller of Conv2DInto reuses output across calls — clear
-                // before accumulating since the direct kernel does
-                // output[oh,ow] += sum_{ic,kh,kw} conv contributions.
-                dOutput.Data.Span.Clear();
+                // No outer Span.Clear() — Conv3x3Stride1SingleChannelDouble
+                // does `new Span<double>(outputChannel, outputSize).Clear()`
+                // on each per-oc slab before accumulating, so an extra
+                // full-tensor Clear here is a wasted memory pass (~10 MB
+                // at SD shapes per call). The direct kernel owns its
+                // initialization of every byte it writes.
                 using var pinIn = dInput.Data.Pin();
                 using var pinK  = dKernel.Data.Pin();
                 using var pinO  = dOutput.Data.Pin();

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -1111,6 +1111,46 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     }
 
     /// <summary>
+    /// Variant of <see cref="FinishGpuOp{T}"/> that registers the deferred-download
+    /// materializer directly against a caller-supplied destination array, so an
+    /// <c>*Into</c> API doesn't need to allocate an intermediate result array and
+    /// then copy. Used by <see cref="TensorPermuteInto{T}"/> and other in-place
+    /// GPU operations that want to avoid doubling per-call CPU memory traffic.
+    /// </summary>
+    /// <param name="backend">The GPU backend that owns <paramref name="outputBuffer"/>.</param>
+    /// <param name="outputBuffer">The GPU buffer to download from.</param>
+    /// <param name="destination">
+    /// Caller-supplied CPU array that the GPU result will be downloaded into when
+    /// the array is first read. Must have <see cref="Array.Length"/> &gt;=
+    /// <paramref name="elementCount"/>.
+    /// </param>
+    /// <param name="elementCount">Number of elements that will be written.</param>
+    private void DownloadGpuBufferInto<T>(IDirectGpuBackend backend, OwnedBuffer outputBuffer, T[] destination, int elementCount)
+    {
+        var capturedBuffer = outputBuffer.Buffer;
+        var capturedBackend = backend;
+        Helpers.DeferredArrayMaterializer.Register(destination, arr =>
+        {
+            float[] floatData;
+            try
+            {
+                floatData = capturedBackend.DownloadBuffer(capturedBuffer);
+            }
+            catch (InvalidOperationException ex)
+            {
+                throw new InvalidOperationException(
+                    "Deferred GPU download failed because the underlying buffer was " +
+                    "released before materialization. This typically indicates an " +
+                    "activation-cache eviction raced with a pending materializer " +
+                    "(issue #226).", ex);
+            }
+            var converted = DirectGpuEngine.FromFloatArray<T>(floatData);
+            Array.Copy(converted, (T[])arr, Math.Min(converted.Length, ((T[])arr).Length));
+        });
+        CacheActivation(destination, outputBuffer.Buffer, new[] { elementCount }, backend);
+    }
+
+    /// <summary>
     /// Creates a deferred Tensor from a raw GPU buffer. The buffer stays GPU-resident;
     /// the CPU array is only populated when code accesses the tensor data.
     /// Use this instead of bb.DownloadBuffer() in IEngine implementations to keep
@@ -12583,16 +12623,43 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
 
         // Validation mirrors the CPU path so backend kernels see a clean
-        // contract.
+        // contract: rank match, valid permutation (no duplicate / out-of-
+        // range axes), output rank match, and shape consistency. Mirroring
+        // the ArgumentException surface keeps callers from having to handle
+        // IndexOutOfRangeException coming up from `axes[i]` indexing
+        // tensor.Shape._dims when the GPU path is selected.
         if (output is null) throw new ArgumentNullException(nameof(output));
         if (tensor is null) throw new ArgumentNullException(nameof(tensor));
         if (axes is null) throw new ArgumentNullException(nameof(axes));
-        if (axes.Length != tensor.Shape._dims.Length)
+        int rank = tensor.Shape._dims.Length;
+        if (axes.Length != rank)
             throw new ArgumentException("Axes length must match tensor rank");
+        if (output.Shape._dims.Length != rank)
+            throw new ArgumentException("Output rank must match tensor rank");
         if (output.Length != tensor.Length)
             throw new ArgumentException(
                 $"Output length ({output.Length}) does not match input length ({tensor.Length}).");
-        for (int i = 0; i < axes.Length; i++)
+
+        // Validate `axes` is a real permutation: every entry in [0, rank)
+        // and every axis index appears exactly once.
+        if (rank > 0)
+        {
+            Span<bool> seen = rank <= 32 ? stackalloc bool[rank] : new bool[rank];
+            for (int i = 0; i < rank; i++)
+            {
+                int a = axes[i];
+                if (a < 0 || a >= rank)
+                    throw new ArgumentException(
+                        $"Axes[{i}] = {a} is out of range [0, {rank}).", nameof(axes));
+                if (seen[a])
+                    throw new ArgumentException(
+                        $"Axes is not a valid permutation: axis {a} appears more than once.",
+                        nameof(axes));
+                seen[a] = true;
+            }
+        }
+
+        for (int i = 0; i < rank; i++)
         {
             int expected = tensor.Shape._dims[axes[i]];
             if (output.Shape._dims[i] != expected)
@@ -12605,24 +12672,21 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             // CUDA / HIP / Metal / OpenCL / Vulkan / WebGpu all already
             // implement Permute(input, output, shape, axes) — the GPU
             // kernels were written around an explicit destination buffer
-            // from day one, so the Into form just plumbs an output buffer
-            // through, downloads the result back to the caller's CPU-side
-            // array, and skips the new-Tensor allocation.
+            // from day one, so the Into form just plumbs the caller's
+            // output buffer's existing array through. We download the
+            // result directly into output.GetDataArray() instead of into a
+            // freshly-allocated managed array, so the per-call allocation
+            // the API docs promise to skip is actually skipped on the hot
+            // path (FinishGpuOp's default behavior allocates and copies).
             using var bufIn = GetOrAllocateBuffer(backend, tensor.GetDataArray());
             var bufOut = AllocateOutputBuffer(backend, tensor.Length);
             backend.Permute(bufIn.Buffer, bufOut.Buffer, tensor.Shape._dims, axes);
-            // FinishGpuOp materializes the GPU result into a typed CPU array
-            // (handling float vs double conversion through the type-aware
-            // path that TensorPermute itself uses); copy that into the
-            // caller's pre-allocated tensor's underlying storage so the
-            // caller's view stays valid without re-wrapping.
-            var data = FinishGpuOp<T>(backend, bufOut, tensor.Length);
-            // FinishGpuOp returns a freshly-materialized array; copy into
-            // output's existing array (the whole point of *Into is to keep
-            // the caller's tensor identity stable for repeated calls).
+            // Download directly into the caller's existing array. This
+            // keeps output's identity stable for repeated calls AND avoids
+            // the materialize-then-copy pattern that would otherwise
+            // double the per-call CPU memory traffic.
             var dst = output.GetDataArray();
-            if (!ReferenceEquals(dst, data))
-                Array.Copy(data, 0, dst, 0, output.Length);
+            DownloadGpuBufferInto(backend, bufOut, dst, output.Length);
         }
         catch (Exception)
         {

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -12573,6 +12573,65 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
     }
 
+    /// <inheritdoc/>
+    public override void TensorPermuteInto<T>(Tensor<T> output, Tensor<T> tensor, int[] axes)
+    {
+        if (!TryGetBackend(out var backend))
+        {
+            base.TensorPermuteInto(output, tensor, axes);
+            return;
+        }
+
+        // Validation mirrors the CPU path so backend kernels see a clean
+        // contract.
+        if (output is null) throw new ArgumentNullException(nameof(output));
+        if (tensor is null) throw new ArgumentNullException(nameof(tensor));
+        if (axes is null) throw new ArgumentNullException(nameof(axes));
+        if (axes.Length != tensor.Shape._dims.Length)
+            throw new ArgumentException("Axes length must match tensor rank");
+        if (output.Length != tensor.Length)
+            throw new ArgumentException(
+                $"Output length ({output.Length}) does not match input length ({tensor.Length}).");
+        for (int i = 0; i < axes.Length; i++)
+        {
+            int expected = tensor.Shape._dims[axes[i]];
+            if (output.Shape._dims[i] != expected)
+                throw new ArgumentException(
+                    $"Output shape mismatch at axis {i}: expected {expected}, got {output.Shape._dims[i]}.");
+        }
+
+        try
+        {
+            // CUDA / HIP / Metal / OpenCL / Vulkan / WebGpu all already
+            // implement Permute(input, output, shape, axes) — the GPU
+            // kernels were written around an explicit destination buffer
+            // from day one, so the Into form just plumbs an output buffer
+            // through, downloads the result back to the caller's CPU-side
+            // array, and skips the new-Tensor allocation.
+            using var bufIn = GetOrAllocateBuffer(backend, tensor.GetDataArray());
+            var bufOut = AllocateOutputBuffer(backend, tensor.Length);
+            backend.Permute(bufIn.Buffer, bufOut.Buffer, tensor.Shape._dims, axes);
+            // FinishGpuOp materializes the GPU result into a typed CPU array
+            // (handling float vs double conversion through the type-aware
+            // path that TensorPermute itself uses); copy that into the
+            // caller's pre-allocated tensor's underlying storage so the
+            // caller's view stays valid without re-wrapping.
+            var data = FinishGpuOp<T>(backend, bufOut, tensor.Length);
+            // FinishGpuOp returns a freshly-materialized array; copy into
+            // output's existing array (the whole point of *Into is to keep
+            // the caller's tensor identity stable for repeated calls).
+            var dst = output.GetDataArray();
+            if (!ReferenceEquals(dst, data))
+                Array.Copy(data, 0, dst, 0, output.Length);
+        }
+        catch (Exception)
+        {
+            // Any backend hiccup (allocation failure, kernel launch error)
+            // — fall back to the CPU strided-copy.
+            base.TensorPermuteInto(output, tensor, axes);
+        }
+    }
+
     // ──────────────────────────────────────────────────────────────
     // GPU-accelerated normalization (BatchNorm, LayerNorm, GroupNorm, InstanceNorm, RMSNorm)
     // ──────────────────────────────────────────────────────────────

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -5698,6 +5698,27 @@ public interface IEngine
     Tensor<T> TensorPermute<T>(Tensor<T> tensor, int[] axes);
 
     /// <summary>
+    /// Permutes the dimensions of a tensor and writes the result into the
+    /// caller-supplied <paramref name="output"/>, avoiding the per-call
+    /// allocation that <see cref="TensorPermute"/> incurs. The output
+    /// tensor's shape must match the permuted source shape exactly.
+    /// </summary>
+    /// <typeparam name="T">The numeric type of tensor elements.</typeparam>
+    /// <param name="output">Pre-allocated destination tensor with the
+    /// permuted shape (i.e. <c>tensor.Shape[axes[i]]</c> for each i).</param>
+    /// <param name="tensor">The tensor whose dimensions will be permuted.</param>
+    /// <param name="axes">The new order of dimensions.</param>
+    /// <remarks>
+    /// Used by long-running pipelines (diffusion UNet attention blocks,
+    /// transformer blocks) that call permute O(layers × steps) times per
+    /// forward and would otherwise allocate a fresh result tensor each
+    /// call. Each backend's kernel was already structured around an
+    /// (input, output, shape, axes) signature, so the Into form just
+    /// exposes that to the engine layer without requiring new GPU kernels.
+    /// </remarks>
+    void TensorPermuteInto<T>(Tensor<T> output, Tensor<T> tensor, int[] axes);
+
+    /// <summary>
     /// Expands dimensions by inserting a new axis of size 1.
     /// </summary>
     /// <typeparam name="T">The numeric type of tensor elements.</typeparam>

--- a/src/AiDotNet.Tensors/Helpers/Im2ColHelper.cs
+++ b/src/AiDotNet.Tensors/Helpers/Im2ColHelper.cs
@@ -767,23 +767,110 @@ internal static class Im2ColHelper
         int mBlocks = (m + BlockSize - 1) / BlockSize;
         int nBlocks = (n + BlockSize - 1) / BlockSize;
         int totalTiles = mBlocks * nBlocks;
+
+        // B-repacking: B's natural row stride is n (e.g. 4096 doubles = 32 KB
+        // for SD-class shapes), so successive kIdx values inside a tile sit
+        // far apart in memory. The prefetcher misses on those long strides
+        // and successive cache loads end up issuing cold misses to L2/L3.
+        // Pre-pack B into per-(K-block, N-block) tiles laid out contiguously
+        // (size = Kc × Nc doubles = 32 KB each) so the inner kernel reads
+        // its tile of B sequentially with stride 1 across both kIdx and j.
+        // Cost: one copy of B (≤ K × N doubles ≈ 92 MB for SD 320→320);
+        // amortized across the m/Mc outer-loop reuses (here m=320,
+        // mBlocks=5, so each B-tile is read 5 times and the pack pays for
+        // itself the first time after the parallel.For starts).
+        int kBlocks = (k + BlockSize - 1) / BlockSize;
+        int packStride = BlockSize * BlockSize;
+        var packedB = new double[(long)kBlocks * nBlocks * packStride];
+        unsafe
+        {
+            fixed (double* bPtr = b)
+            fixed (double* pbPtr = packedB)
+            {
+                double* bBase = bPtr;
+                double* pbBase = pbPtr;
+                System.Threading.Tasks.Parallel.For(0, kBlocks * nBlocks, packTile =>
+                {
+                    int kBlk = packTile / nBlocks;
+                    int nBlk = packTile % nBlocks;
+                    int kk = kBlk * BlockSize;
+                    int jj = nBlk * BlockSize;
+                    int kEnd = Math.Min(kk + BlockSize, k);
+                    int jEnd = Math.Min(jj + BlockSize, n);
+                    int kLen = kEnd - kk;
+                    int jLen = jEnd - jj;
+                    double* dst = pbBase + (long)packTile * packStride;
+                    // Pack as [kLen rows × jLen cols] contiguous, so within
+                    // a tile the layout matches what the kernel walks.
+                    for (int kIdx = 0; kIdx < kLen; kIdx++)
+                    {
+                        double* src = bBase + (kk + kIdx) * n + jj;
+                        double* dstRow = dst + kIdx * BlockSize;
+                        for (int j = 0; j < jLen; j++)
+                            dstRow[j] = src[j];
+                    }
+                });
+            }
+        }
+
         unsafe
         {
             fixed (double* aPtr = a)
-            fixed (double* bPtr = b)
             fixed (double* cPtr = c)
+            fixed (double* pbPtr = packedB)
             {
-                double* aBase = aPtr, bBase = bPtr, cBase = cPtr;
+                double* aBase = aPtr, cBase = cPtr, pbBase = pbPtr;
+                int kBlocksLocal = kBlocks;
+                int nBlocksLocal = nBlocks;
                 System.Threading.Tasks.Parallel.For(0, totalTiles, tile =>
                 {
-                    int mBlk = tile / nBlocks;
-                    int nBlk = tile % nBlocks;
+                    int mBlk = tile / nBlocksLocal;
+                    int nBlk = tile % nBlocksLocal;
                     int ii = mBlk * BlockSize;
                     int jj = nBlk * BlockSize;
                     int iEnd = Math.Min(ii + BlockSize, m);
                     int jEnd = Math.Min(jj + BlockSize, n);
-                    MultiplyBlockedDoubleTilePtr(aBase, bBase, cBase, ii, iEnd, jj, jEnd, k, n, BlockSize);
+                    // Iterate K-blocks; for each, read the packed B tile that
+                    // matches (kBlk, nBlk). Per-tile B is contiguous 64×64.
+                    for (int kBlk = 0; kBlk < kBlocksLocal; kBlk++)
+                    {
+                        int kk = kBlk * BlockSize;
+                        int kEnd = Math.Min(kk + BlockSize, k);
+                        double* packedTile = pbBase + ((long)kBlk * nBlocksLocal + nBlk) * packStride;
+                        MultiplyPackedTilePtr(
+                            aBase, packedTile, cBase,
+                            ii, iEnd, jj, jEnd, kk, kEnd, k, n);
+                    }
                 });
+            }
+        }
+    }
+
+    /// <summary>
+    /// Inner kernel for the packed-B path. The B-tile is contiguous
+    /// [BlockSize × BlockSize] doubles, so the inner j loop reads stride-1
+    /// from the packed buffer and the kIdx step is just += BlockSize
+    /// (one cache line worth of doubles). RyuJIT auto-vectorizes the
+    /// inner axpy as well.
+    /// </summary>
+    private static unsafe void MultiplyPackedTilePtr(
+        double* a, double* packedB, double* c,
+        int ii, int iEnd, int jj, int jEnd, int kk, int kEnd,
+        int k, int n)
+    {
+        int width = jEnd - jj;
+        int kLen = kEnd - kk;
+        const int BlockSize = 64;
+        for (int i = ii; i < iEnd; i++)
+        {
+            double* aRow = a + (long)i * k + kk;
+            double* cRow = c + (long)i * n + jj;
+            for (int kIdx = 0; kIdx < kLen; kIdx++)
+            {
+                double aik = aRow[kIdx];
+                double* bRow = packedB + kIdx * BlockSize;
+                for (int j = 0; j < width; j++)
+                    cRow[j] += aik * bRow[j];
             }
         }
     }

--- a/src/AiDotNet.Tensors/Helpers/Im2ColHelper.cs
+++ b/src/AiDotNet.Tensors/Helpers/Im2ColHelper.cs
@@ -718,26 +718,37 @@ internal static class Im2ColHelper
         // route through this im2col+GEMM path. Closing further requires a
         // Conv3x3SingleChannel<double> kernel, mirroring the float design.
         //
-        // 2026-05-02 update — re-introduce Parallel.For on the outer M-block
-        // axis only. The earlier "parallel dispatch" rejection bundled
-        // Parallel.For with explicit SIMD intrinsics; the SIMD piece was the
-        // regression cause (defeated JIT auto-prefetch), not the parallelism.
-        // Profiling SD-style diffusion ResBlock convs at [1,320,64,64]→[320,3,3]
-        // (3.77 GFMA, 5232 ms scalar single-threaded ⇒ ~1.4 GFLOPS) showed
-        // every block of M is fully independent: each writes a disjoint slab
-        // of C, reads its own slab of A, and shares B read-only. Splitting
-        // across cores is embarrassingly parallel and preserves the JIT
-        // auto-vectorized inner axpy. Threshold at total FMAs ≥ 64 M to
-        // avoid Parallel.For overhead on small shapes (the original 0.4 M
-        // FMA BDN baseline stays on the serial path).
+        // 2026-05-02 update — re-introduce parallelism. The earlier
+        // "parallel dispatch" rejection bundled Parallel.For with explicit
+        // SIMD intrinsics; the SIMD piece was the regression cause
+        // (defeated JIT auto-prefetch), not the parallelism. Profiling
+        // SD-style diffusion ResBlock convs at [1,320,64,64]→[320,3,3]
+        // (3.77 GFMA, 5232 ms scalar single-threaded ⇒ ~1.4 GFLOPS)
+        // showed every (i, j) tile of C is fully independent: each writes a
+        // disjoint slab, reads its own slab of A, and shares B read-only.
+        // Splitting across cores is embarrassingly parallel and preserves
+        // the JIT auto-vectorized inner axpy. We split the work across BOTH
+        // the outer M AND outer N axes so the task count
+        // (⌈m/BlockSize⌉ × ⌈n/BlockSize⌉) is large enough to saturate every
+        // worker thread — splitting on M alone gives only ⌈m/BlockSize⌉
+        // tasks, which capped speedup at ≈2× for SD shapes on a 32-core box.
+        // Threshold at total FMAs ≥ 64 M to avoid parallel-dispatch overhead
+        // on small shapes (the original 0.4 M FMA BDN baseline stays on
+        // the serial path). Dispatch routes through CpuParallelSettings —
+        // its MaxDegreeOfParallelism honours host-side thread caps and
+        // matches what every other parallel kernel in this file uses.
 
         const int BlockSize = 64;
 
         c.Clear();
 
         long totalFmas = (long)m * (long)k * (long)n;
-        bool parallel = totalFmas >= 64L * 1024L * 1024L
-            && Environment.ProcessorCount > 1;
+        // Use CpuParallelSettings so a host that capped MaxDegreeOfParallelism
+        // (e.g. shared-tenant CI runner, deterministic-mode tests) is
+        // honoured here — Environment.ProcessorCount would over-subscribe
+        // those workloads.
+        int parallelDegree = Math.Max(1, CpuParallelSettings.MaxDegreeOfParallelism);
+        bool parallel = totalFmas >= 64L * 1024L * 1024L && parallelDegree > 1;
 
         if (!parallel)
         {
@@ -775,37 +786,80 @@ internal static class Im2ColHelper
         // Pre-pack B into per-(K-block, N-block) tiles laid out contiguously
         // (size = Kc × Nc doubles = 32 KB each) so the inner kernel reads
         // its tile of B sequentially with stride 1 across both kIdx and j.
-        // Cost: one copy of B (≤ K × N doubles ≈ 92 MB for SD 320→320);
-        // amortized across the m/Mc outer-loop reuses (here m=320,
-        // mBlocks=5, so each B-tile is read 5 times and the pack pays for
-        // itself the first time after the parallel.For starts).
+        //
+        // The packed-B buffer is RENTED from a thread-static pool keyed by
+        // size and returned at the end of this call, so we don't allocate a
+        // fresh ~94 MB array on every fallback GEMM. Repeat calls at the
+        // same shape (every conv inside one UNet forward) reuse the same
+        // pool slot — zero managed-heap pressure after the first call.
         int kBlocks = (k + BlockSize - 1) / BlockSize;
         int packStride = BlockSize * BlockSize;
-        var packedB = new double[(long)kBlocks * nBlocks * packStride];
+        long packedLen = (long)kBlocks * nBlocks * packStride;
+        if (packedLen > int.MaxValue)
+        {
+            // Fall back to per-call allocation for the (rare) > 16 GB
+            // packed buffer case where ArrayPool would refuse anyway.
+            RunPackedGemmDouble(a, b, c, m, k, n, BlockSize, kBlocks, nBlocks,
+                                packStride, totalTiles, parallelDegree, packed: new double[packedLen]);
+            return;
+        }
+        var pool = System.Buffers.ArrayPool<double>.Shared;
+        var packedB = pool.Rent((int)packedLen);
+        try
+        {
+            RunPackedGemmDouble(a, b, c, m, k, n, BlockSize, kBlocks, nBlocks,
+                                packStride, totalTiles, parallelDegree, packedB);
+        }
+        finally
+        {
+            pool.Return(packedB);
+        }
+    }
+
+    /// <summary>
+    /// Pack B into per-(K-block, N-block) contiguous tiles, then run the
+    /// 2-D-tile parallel GEMM consuming those packed tiles. Both phases are
+    /// dispatched through CpuParallelSettings (instead of raw Parallel.For)
+    /// so the host's <see cref="CpuParallelSettings.MaxDegreeOfParallelism"/>
+    /// cap is honoured — matches every other parallel kernel in this file.
+    /// </summary>
+    private static void RunPackedGemmDouble(
+        ReadOnlySpan<double> a, ReadOnlySpan<double> b, Span<double> c,
+        int m, int k, int n, int BlockSize,
+        int kBlocks, int nBlocks, int packStride, int totalTiles,
+        int parallelDegree, double[] packed)
+    {
+        int packTaskCount = kBlocks * nBlocks;
         unsafe
         {
             fixed (double* bPtr = b)
-            fixed (double* pbPtr = packedB)
+            fixed (double* pbPtr = packed)
             {
                 double* bBase = bPtr;
                 double* pbBase = pbPtr;
-                System.Threading.Tasks.Parallel.For(0, kBlocks * nBlocks, packTile =>
+                int nBlocksLocal = nBlocks;
+                int kLocal = k;
+                int nLocal = n;
+                int blockSizeLocal = BlockSize;
+                int packStrideLocal = packStride;
+                Parallel.For(
+                    0, packTaskCount,
+                    new ParallelOptions { MaxDegreeOfParallelism = parallelDegree },
+                    packTile =>
                 {
-                    int kBlk = packTile / nBlocks;
-                    int nBlk = packTile % nBlocks;
-                    int kk = kBlk * BlockSize;
-                    int jj = nBlk * BlockSize;
-                    int kEnd = Math.Min(kk + BlockSize, k);
-                    int jEnd = Math.Min(jj + BlockSize, n);
+                    int kBlk = packTile / nBlocksLocal;
+                    int nBlk = packTile % nBlocksLocal;
+                    int kk = kBlk * blockSizeLocal;
+                    int jj = nBlk * blockSizeLocal;
+                    int kEnd = Math.Min(kk + blockSizeLocal, kLocal);
+                    int jEnd = Math.Min(jj + blockSizeLocal, nLocal);
                     int kLen = kEnd - kk;
                     int jLen = jEnd - jj;
-                    double* dst = pbBase + (long)packTile * packStride;
-                    // Pack as [kLen rows × jLen cols] contiguous, so within
-                    // a tile the layout matches what the kernel walks.
+                    double* dst = pbBase + (long)packTile * packStrideLocal;
                     for (int kIdx = 0; kIdx < kLen; kIdx++)
                     {
-                        double* src = bBase + (kk + kIdx) * n + jj;
-                        double* dstRow = dst + kIdx * BlockSize;
+                        double* src = bBase + (kk + kIdx) * nLocal + jj;
+                        double* dstRow = dst + kIdx * blockSizeLocal;
                         for (int j = 0; j < jLen; j++)
                             dstRow[j] = src[j];
                     }
@@ -817,29 +871,35 @@ internal static class Im2ColHelper
         {
             fixed (double* aPtr = a)
             fixed (double* cPtr = c)
-            fixed (double* pbPtr = packedB)
+            fixed (double* pbPtr = packed)
             {
                 double* aBase = aPtr, cBase = cPtr, pbBase = pbPtr;
                 int kBlocksLocal = kBlocks;
                 int nBlocksLocal = nBlocks;
-                System.Threading.Tasks.Parallel.For(0, totalTiles, tile =>
+                int mLocal = m;
+                int kLocal = k;
+                int nLocal = n;
+                int blockSizeLocal = BlockSize;
+                int packStrideLocal = packStride;
+                Parallel.For(
+                    0, totalTiles,
+                    new ParallelOptions { MaxDegreeOfParallelism = parallelDegree },
+                    tile =>
                 {
                     int mBlk = tile / nBlocksLocal;
                     int nBlk = tile % nBlocksLocal;
-                    int ii = mBlk * BlockSize;
-                    int jj = nBlk * BlockSize;
-                    int iEnd = Math.Min(ii + BlockSize, m);
-                    int jEnd = Math.Min(jj + BlockSize, n);
-                    // Iterate K-blocks; for each, read the packed B tile that
-                    // matches (kBlk, nBlk). Per-tile B is contiguous 64×64.
+                    int ii = mBlk * blockSizeLocal;
+                    int jj = nBlk * blockSizeLocal;
+                    int iEnd = Math.Min(ii + blockSizeLocal, mLocal);
+                    int jEnd = Math.Min(jj + blockSizeLocal, nLocal);
                     for (int kBlk = 0; kBlk < kBlocksLocal; kBlk++)
                     {
-                        int kk = kBlk * BlockSize;
-                        int kEnd = Math.Min(kk + BlockSize, k);
-                        double* packedTile = pbBase + ((long)kBlk * nBlocksLocal + nBlk) * packStride;
+                        int kk = kBlk * blockSizeLocal;
+                        int kEnd = Math.Min(kk + blockSizeLocal, kLocal);
+                        double* packedTile = pbBase + ((long)kBlk * nBlocksLocal + nBlk) * packStrideLocal;
                         MultiplyPackedTilePtr(
                             aBase, packedTile, cBase,
-                            ii, iEnd, jj, jEnd, kk, kEnd, k, n);
+                            ii, iEnd, jj, jEnd, kk, kEnd, kLocal, nLocal);
                     }
                 });
             }
@@ -912,38 +972,6 @@ internal static class Im2ColHelper
         ReadOnlySpan<double> a,
         ReadOnlySpan<double> b,
         Span<double> c,
-        int ii, int iEnd,
-        int k, int n,
-        int blockSize)
-    {
-        for (int kk = 0; kk < k; kk += blockSize)
-        {
-            int kEnd = Math.Min(kk + blockSize, k);
-            for (int jj = 0; jj < n; jj += blockSize)
-            {
-                int jEnd = Math.Min(jj + blockSize, n);
-                for (int i = ii; i < iEnd; i++)
-                {
-                    for (int kIdx = kk; kIdx < kEnd; kIdx++)
-                    {
-                        double aik = a[i * k + kIdx];
-                        int bRowOffset = kIdx * n + jj;
-                        int cRowOffset = i * n + jj;
-                        for (int j = 0; j < jEnd - jj; j++)
-                            c[cRowOffset + j] += aik * b[bRowOffset + j];
-                    }
-                }
-            }
-        }
-    }
-
-    /// <summary>
-    /// Pointer overload — same blocked+auto-vectorized kernel as the Span
-    /// version, but indexes raw pointers so it can be invoked from a
-    /// Parallel.For lambda where Spans aren't allowed to flow.
-    /// </summary>
-    private static unsafe void MultiplyBlockedDoubleRowSlabPtr(
-        double* a, double* b, double* c,
         int ii, int iEnd,
         int k, int n,
         int blockSize)

--- a/src/AiDotNet.Tensors/Helpers/Im2ColHelper.cs
+++ b/src/AiDotNet.Tensors/Helpers/Im2ColHelper.cs
@@ -717,30 +717,165 @@ internal static class Im2ColHelper
         // path uses register-resident Conv3x3 (no im2col), but doubles
         // route through this im2col+GEMM path. Closing further requires a
         // Conv3x3SingleChannel<double> kernel, mirroring the float design.
+        //
+        // 2026-05-02 update — re-introduce Parallel.For on the outer M-block
+        // axis only. The earlier "parallel dispatch" rejection bundled
+        // Parallel.For with explicit SIMD intrinsics; the SIMD piece was the
+        // regression cause (defeated JIT auto-prefetch), not the parallelism.
+        // Profiling SD-style diffusion ResBlock convs at [1,320,64,64]→[320,3,3]
+        // (3.77 GFMA, 5232 ms scalar single-threaded ⇒ ~1.4 GFLOPS) showed
+        // every block of M is fully independent: each writes a disjoint slab
+        // of C, reads its own slab of A, and shares B read-only. Splitting
+        // across cores is embarrassingly parallel and preserves the JIT
+        // auto-vectorized inner axpy. Threshold at total FMAs ≥ 64 M to
+        // avoid Parallel.For overhead on small shapes (the original 0.4 M
+        // FMA BDN baseline stays on the serial path).
 
         const int BlockSize = 64;
 
         c.Clear();
 
-        for (int ii = 0; ii < m; ii += BlockSize)
+        long totalFmas = (long)m * (long)k * (long)n;
+        bool parallel = totalFmas >= 64L * 1024L * 1024L
+            && Environment.ProcessorCount > 1;
+
+        if (!parallel)
         {
-            int iEnd = Math.Min(ii + BlockSize, m);
-            for (int kk = 0; kk < k; kk += BlockSize)
+            for (int ii = 0; ii < m; ii += BlockSize)
             {
-                int kEnd = Math.Min(kk + BlockSize, k);
-                for (int jj = 0; jj < n; jj += BlockSize)
+                int iEnd = Math.Min(ii + BlockSize, m);
+                MultiplyBlockedDoubleRowSlabSpan(a, b, c, ii, iEnd, k, n, BlockSize);
+            }
+            return;
+        }
+
+        // Pin the three buffers so each thread can address its slab via raw
+        // pointers without violating the Span<T> stack-only rule (Spans can't
+        // cross lambda/anonymous-method boundaries — error CS9108).
+        //
+        // Partition the work across BOTH the outer M and outer N axes so we
+        // get enough independent tiles to saturate every core. Splitting on
+        // M alone gives only ⌈m/BlockSize⌉ tasks — for SD diffusion shapes
+        // (m = outChannels = 320, BlockSize = 64) that's just 5 tasks, which
+        // pinned the speedup to ≈2× on a 32-core box. Adding the N axis
+        // multiplies the task count to ⌈m/BlockSize⌉ × ⌈n/BlockSize⌉ — for
+        // m=320, n=4096 that's 5 × 64 = 320 independent (i,j) tiles, each
+        // writing a disjoint slab of C, so all cores can run flat-out.
+        // Splitting K would require atomic accumulation into C and is not
+        // worth the synchronization cost; keeping K serial inside each tile
+        // also preserves the JIT auto-vectorized inner axpy.
+        int mBlocks = (m + BlockSize - 1) / BlockSize;
+        int nBlocks = (n + BlockSize - 1) / BlockSize;
+        int totalTiles = mBlocks * nBlocks;
+        unsafe
+        {
+            fixed (double* aPtr = a)
+            fixed (double* bPtr = b)
+            fixed (double* cPtr = c)
+            {
+                double* aBase = aPtr, bBase = bPtr, cBase = cPtr;
+                System.Threading.Tasks.Parallel.For(0, totalTiles, tile =>
                 {
+                    int mBlk = tile / nBlocks;
+                    int nBlk = tile % nBlocks;
+                    int ii = mBlk * BlockSize;
+                    int jj = nBlk * BlockSize;
+                    int iEnd = Math.Min(ii + BlockSize, m);
                     int jEnd = Math.Min(jj + BlockSize, n);
-                    for (int i = ii; i < iEnd; i++)
+                    MultiplyBlockedDoubleTilePtr(aBase, bBase, cBase, ii, iEnd, jj, jEnd, k, n, BlockSize);
+                });
+            }
+        }
+    }
+
+    /// <summary>
+    /// Pointer overload — single (i,j) tile. Iterates over all K blocks for
+    /// the given output tile so the whole inner reduction lives in this
+    /// task and can be JIT-auto-vectorized in place.
+    /// </summary>
+    private static unsafe void MultiplyBlockedDoubleTilePtr(
+        double* a, double* b, double* c,
+        int ii, int iEnd, int jj, int jEnd,
+        int k, int n,
+        int blockSize)
+    {
+        for (int kk = 0; kk < k; kk += blockSize)
+        {
+            int kEnd = Math.Min(kk + blockSize, k);
+            for (int i = ii; i < iEnd; i++)
+            {
+                for (int kIdx = kk; kIdx < kEnd; kIdx++)
+                {
+                    double aik = a[i * k + kIdx];
+                    int bRowOffset = kIdx * n + jj;
+                    int cRowOffset = i * n + jj;
+                    int width = jEnd - jj;
+                    for (int j = 0; j < width; j++)
+                        c[cRowOffset + j] += aik * b[bRowOffset + j];
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Span overload — handles the contiguous row range [ii, iEnd) of C
+    /// when called from the serial path (no thread crossing).
+    /// </summary>
+    private static void MultiplyBlockedDoubleRowSlabSpan(
+        ReadOnlySpan<double> a,
+        ReadOnlySpan<double> b,
+        Span<double> c,
+        int ii, int iEnd,
+        int k, int n,
+        int blockSize)
+    {
+        for (int kk = 0; kk < k; kk += blockSize)
+        {
+            int kEnd = Math.Min(kk + blockSize, k);
+            for (int jj = 0; jj < n; jj += blockSize)
+            {
+                int jEnd = Math.Min(jj + blockSize, n);
+                for (int i = ii; i < iEnd; i++)
+                {
+                    for (int kIdx = kk; kIdx < kEnd; kIdx++)
                     {
-                        for (int kIdx = kk; kIdx < kEnd; kIdx++)
-                        {
-                            double aik = a[i * k + kIdx];
-                            int bRowOffset = kIdx * n + jj;
-                            int cRowOffset = i * n + jj;
-                            for (int j = 0; j < jEnd - jj; j++)
-                                c[cRowOffset + j] += aik * b[bRowOffset + j];
-                        }
+                        double aik = a[i * k + kIdx];
+                        int bRowOffset = kIdx * n + jj;
+                        int cRowOffset = i * n + jj;
+                        for (int j = 0; j < jEnd - jj; j++)
+                            c[cRowOffset + j] += aik * b[bRowOffset + j];
+                    }
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Pointer overload — same blocked+auto-vectorized kernel as the Span
+    /// version, but indexes raw pointers so it can be invoked from a
+    /// Parallel.For lambda where Spans aren't allowed to flow.
+    /// </summary>
+    private static unsafe void MultiplyBlockedDoubleRowSlabPtr(
+        double* a, double* b, double* c,
+        int ii, int iEnd,
+        int k, int n,
+        int blockSize)
+    {
+        for (int kk = 0; kk < k; kk += blockSize)
+        {
+            int kEnd = Math.Min(kk + blockSize, k);
+            for (int jj = 0; jj < n; jj += blockSize)
+            {
+                int jEnd = Math.Min(jj + blockSize, n);
+                for (int i = ii; i < iEnd; i++)
+                {
+                    for (int kIdx = kk; kIdx < kEnd; kIdx++)
+                    {
+                        double aik = a[i * k + kIdx];
+                        int bRowOffset = kIdx * n + jj;
+                        int cRowOffset = i * n + jj;
+                        for (int j = 0; j < jEnd - jj; j++)
+                            c[cRowOffset + j] += aik * b[bRowOffset + j];
                     }
                 }
             }

--- a/src/AiDotNet.Tensors/Helpers/Im2ColHelper.cs
+++ b/src/AiDotNet.Tensors/Helpers/Im2ColHelper.cs
@@ -818,10 +818,16 @@ internal static class Im2ColHelper
 
     /// <summary>
     /// Pack B into per-(K-block, N-block) contiguous tiles, then run the
-    /// 2-D-tile parallel GEMM consuming those packed tiles. Both phases are
-    /// dispatched through CpuParallelSettings (instead of raw Parallel.For)
-    /// so the host's <see cref="CpuParallelSettings.MaxDegreeOfParallelism"/>
-    /// cap is honoured — matches every other parallel kernel in this file.
+    /// 2-D-tile parallel GEMM consuming those packed tiles. Both phases
+    /// dispatch through <see cref="PersistentParallelExecutor"/>, the same
+    /// pre-spawned worker pool that <c>SimdGemm</c> uses. Compared to
+    /// <c>Parallel.For</c>, this skips per-call ThreadPool queueing and
+    /// CountdownEvent allocation — non-trivial savings on the diffusion
+    /// hot path where the GEMM is invoked tens of thousands of times per
+    /// model. The chunk count is bounded above by
+    /// <see cref="CpuParallelSettings.MaxDegreeOfParallelism"/> so a host
+    /// that capped parallelism (e.g. shared-tenant CI runner, deterministic-
+    /// mode tests) is honoured.
     /// </summary>
     private static void RunPackedGemmDouble(
         ReadOnlySpan<double> a, ReadOnlySpan<double> b, Span<double> c,
@@ -830,6 +836,15 @@ internal static class Im2ColHelper
         int parallelDegree, double[] packed)
     {
         int packTaskCount = kBlocks * nBlocks;
+
+        // The executor uses Environment.ProcessorCount - 1 workers; cap the
+        // chunk count at min(taskCount, parallelDegree) so a host with a
+        // lower MaxDegreeOfParallelism doesn't oversubscribe — a chunk
+        // executes serially across many tiles, so fewer chunks = fewer
+        // concurrent workers.
+        int packChunks = Math.Max(1, Math.Min(packTaskCount, parallelDegree));
+        int gemmChunks = Math.Max(1, Math.Min(totalTiles, parallelDegree));
+
         unsafe
         {
             fixed (double* bPtr = b)
@@ -842,26 +857,38 @@ internal static class Im2ColHelper
                 int nLocal = n;
                 int blockSizeLocal = BlockSize;
                 int packStrideLocal = packStride;
-                Parallel.For(
-                    0, packTaskCount,
-                    new ParallelOptions { MaxDegreeOfParallelism = parallelDegree },
-                    packTile =>
+                int packTaskCountLocal = packTaskCount;
+                int packChunksLocal = packChunks;
+                IntPtr ipB = (IntPtr)bBase;
+                IntPtr ipPb = (IntPtr)pbBase;
+
+                PersistentParallelExecutor.Instance.Execute(packChunksLocal, chunk =>
                 {
-                    int kBlk = packTile / nBlocksLocal;
-                    int nBlk = packTile % nBlocksLocal;
-                    int kk = kBlk * blockSizeLocal;
-                    int jj = nBlk * blockSizeLocal;
-                    int kEnd = Math.Min(kk + blockSizeLocal, kLocal);
-                    int jEnd = Math.Min(jj + blockSizeLocal, nLocal);
-                    int kLen = kEnd - kk;
-                    int jLen = jEnd - jj;
-                    double* dst = pbBase + (long)packTile * packStrideLocal;
-                    for (int kIdx = 0; kIdx < kLen; kIdx++)
+                    int chunkSize = (packTaskCountLocal + packChunksLocal - 1) / packChunksLocal;
+                    int taskStart = chunk * chunkSize;
+                    int taskEnd = Math.Min(taskStart + chunkSize, packTaskCountLocal);
+                    if (taskStart >= taskEnd) return;
+
+                    double* bChunk = (double*)ipB;
+                    double* pbChunk = (double*)ipPb;
+                    for (int packTile = taskStart; packTile < taskEnd; packTile++)
                     {
-                        double* src = bBase + (kk + kIdx) * nLocal + jj;
-                        double* dstRow = dst + kIdx * blockSizeLocal;
-                        for (int j = 0; j < jLen; j++)
-                            dstRow[j] = src[j];
+                        int kBlk = packTile / nBlocksLocal;
+                        int nBlk = packTile % nBlocksLocal;
+                        int kk = kBlk * blockSizeLocal;
+                        int jj = nBlk * blockSizeLocal;
+                        int kEnd = Math.Min(kk + blockSizeLocal, kLocal);
+                        int jEnd = Math.Min(jj + blockSizeLocal, nLocal);
+                        int kLen = kEnd - kk;
+                        int jLen = jEnd - jj;
+                        double* dst = pbChunk + (long)packTile * packStrideLocal;
+                        for (int kIdx = 0; kIdx < kLen; kIdx++)
+                        {
+                            double* src = bChunk + (kk + kIdx) * nLocal + jj;
+                            double* dstRow = dst + kIdx * blockSizeLocal;
+                            for (int j = 0; j < jLen; j++)
+                                dstRow[j] = src[j];
+                        }
                     }
                 });
             }
@@ -881,25 +908,37 @@ internal static class Im2ColHelper
                 int nLocal = n;
                 int blockSizeLocal = BlockSize;
                 int packStrideLocal = packStride;
-                Parallel.For(
-                    0, totalTiles,
-                    new ParallelOptions { MaxDegreeOfParallelism = parallelDegree },
-                    tile =>
+                int totalTilesLocal = totalTiles;
+                int gemmChunksLocal = gemmChunks;
+                IntPtr ipA = (IntPtr)aBase, ipC = (IntPtr)cBase, ipPb = (IntPtr)pbBase;
+
+                PersistentParallelExecutor.Instance.Execute(gemmChunksLocal, chunk =>
                 {
-                    int mBlk = tile / nBlocksLocal;
-                    int nBlk = tile % nBlocksLocal;
-                    int ii = mBlk * blockSizeLocal;
-                    int jj = nBlk * blockSizeLocal;
-                    int iEnd = Math.Min(ii + blockSizeLocal, mLocal);
-                    int jEnd = Math.Min(jj + blockSizeLocal, nLocal);
-                    for (int kBlk = 0; kBlk < kBlocksLocal; kBlk++)
+                    int chunkSize = (totalTilesLocal + gemmChunksLocal - 1) / gemmChunksLocal;
+                    int tileStart = chunk * chunkSize;
+                    int tileEnd = Math.Min(tileStart + chunkSize, totalTilesLocal);
+                    if (tileStart >= tileEnd) return;
+
+                    double* aChunk = (double*)ipA;
+                    double* cChunk = (double*)ipC;
+                    double* pbChunk = (double*)ipPb;
+                    for (int tile = tileStart; tile < tileEnd; tile++)
                     {
-                        int kk = kBlk * blockSizeLocal;
-                        int kEnd = Math.Min(kk + blockSizeLocal, kLocal);
-                        double* packedTile = pbBase + ((long)kBlk * nBlocksLocal + nBlk) * packStrideLocal;
-                        MultiplyPackedTilePtr(
-                            aBase, packedTile, cBase,
-                            ii, iEnd, jj, jEnd, kk, kEnd, kLocal, nLocal);
+                        int mBlk = tile / nBlocksLocal;
+                        int nBlk = tile % nBlocksLocal;
+                        int ii = mBlk * blockSizeLocal;
+                        int jj = nBlk * blockSizeLocal;
+                        int iEnd = Math.Min(ii + blockSizeLocal, mLocal);
+                        int jEnd = Math.Min(jj + blockSizeLocal, nLocal);
+                        for (int kBlk = 0; kBlk < kBlocksLocal; kBlk++)
+                        {
+                            int kk = kBlk * blockSizeLocal;
+                            int kEnd = Math.Min(kk + blockSizeLocal, kLocal);
+                            double* packedTile = pbChunk + ((long)kBlk * nBlocksLocal + nBlk) * packStrideLocal;
+                            MultiplyPackedTilePtr(
+                                aChunk, packedTile, cChunk,
+                                ii, iEnd, jj, jEnd, kk, kEnd, kLocal, nLocal);
+                        }
                     }
                 });
             }

--- a/tests/AiDotNet.Tensors.Tests/Engines/TensorLevelOpsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/TensorLevelOpsTests.cs
@@ -5,6 +5,18 @@ using Xunit;
 
 namespace AiDotNet.Tensors.Tests.Engines;
 
+/// <summary>
+/// xUnit collection definition that serializes any test mutating the process-
+/// global <c>CpuParallelSettings.MaxDegreeOfParallelism</c>. xUnit runs test
+/// classes in parallel by default, so without this serialization a parallel
+/// test reading the static setting could race with the conv2d gate test
+/// changing it, producing flakes or leaking the temporary value into
+/// unrelated tests. All members of this collection run sequentially.
+/// </summary>
+[CollectionDefinition("CpuParallelSettings", DisableParallelization = true)]
+public sealed class CpuParallelSettingsCollection { }
+
+[Collection("CpuParallelSettings")]
 public class TensorLevelOpsTests
 {
     private readonly CpuEngine _engine = new();
@@ -589,6 +601,13 @@ public class TensorLevelOpsTests
     /// caller reuses a non-zero pre-allocated output buffer (the fast path
     /// no longer pre-clears output, and the kernel itself clears each
     /// output channel inside its per-oc loop).
+    ///
+    /// Shape is sized so total FMAs are well above the OLD <c>&lt;= 4 M</c>
+    /// direct-kernel cutoff: 64 × 16 × 9 × 32 × 32 ≈ 9.4 M FMAs for the
+    /// minimum-MDOP case (oc = 64, ic = 16, 32×32). On CI hosts with
+    /// MaxDegreeOfParallelism &gt; 32, oc grows with MDOP, pushing FMAs
+    /// further above the cutoff. Without this sizing, a regression to the
+    /// old gate would still satisfy the assertion.
     /// </summary>
     [Fact]
     public void Conv2DInto_Double_DirectKernelBranch_NonZeroOutput_MatchesConv2D()
@@ -599,8 +618,8 @@ public class TensorLevelOpsTests
         // (we set MaxDegreeOfParallelism = ProcessorCount which is at most 32
         // on common CI hosts), guaranteeing the direct-kernel branch fires.
         int oc = Math.Max(64, 2 * global::AiDotNet.Tensors.Helpers.CpuParallelSettings.MaxDegreeOfParallelism);
-        var input  = new Tensor<double>(new[] { 1, 8, 16, 16 });
-        var kernel = new Tensor<double>(new[] { oc, 8, 3, 3 });
+        var input  = new Tensor<double>(new[] { 1, 16, 32, 32 });
+        var kernel = new Tensor<double>(new[] { oc, 16, 3, 3 });
         var rng = new Random(123);
         for (int i = 0; i < input.Length; i++)  input[i]  = rng.NextDouble() - 0.5;
         for (int i = 0; i < kernel.Length; i++) kernel[i] = rng.NextDouble() - 0.5;
@@ -663,6 +682,98 @@ public class TensorLevelOpsTests
         {
             global::AiDotNet.Tensors.Helpers.CpuParallelSettings.MaxDegreeOfParallelism = saved;
         }
+    }
+
+    #endregion
+
+    #region TensorPermuteInto
+
+    /// <summary>
+    /// Rank-4 permute-into matches the allocating TensorPermute output
+    /// element-wise. Validates the dense-walk fast-path used by SD-attention
+    /// where (B, S, H, D) ↔ (B, H, S, D) is a hot path.
+    /// </summary>
+    [Fact]
+    public void TensorPermuteInto_Rank4_MatchesTensorPermute()
+    {
+        var engine = new CpuEngine();
+        var rng = new Random(42);
+        var src = new Tensor<float>(new[] { 2, 3, 4, 5 });
+        for (int i = 0; i < src.Length; i++) src[i] = (float)rng.NextDouble();
+
+        var axes = new[] { 0, 2, 1, 3 };
+        var refOut = engine.TensorPermute(src, axes).Contiguous();
+        var dst = new Tensor<float>(new[] { 2, 4, 3, 5 });
+        engine.TensorPermuteInto(dst, src, axes);
+
+        for (int i = 0; i < refOut.Length; i++)
+            Assert.Equal(refOut[i], dst[i]);
+    }
+
+    /// <summary>Rank-3, rank-2, and the generic rank-5 odometer fallback.</summary>
+    [Theory]
+    [InlineData(new[] { 3, 4, 5 }, new[] { 2, 0, 1 }, new[] { 5, 3, 4 })]
+    [InlineData(new[] { 6, 7 }, new[] { 1, 0 }, new[] { 7, 6 })]
+    [InlineData(new[] { 2, 2, 2, 2, 2 }, new[] { 4, 3, 2, 1, 0 }, new[] { 2, 2, 2, 2, 2 })]
+    public void TensorPermuteInto_Various_MatchTensorPermute(int[] inShape, int[] axes, int[] outShape)
+    {
+        var engine = new CpuEngine();
+        var src = new Tensor<float>(inShape);
+        for (int i = 0; i < src.Length; i++) src[i] = i;
+        var refOut = engine.TensorPermute(src, axes).Contiguous();
+        var dst = new Tensor<float>(outShape);
+        engine.TensorPermuteInto(dst, src, axes);
+        for (int i = 0; i < refOut.Length; i++)
+            Assert.Equal(refOut[i], dst[i]);
+    }
+
+    /// <summary>
+    /// Invalid permutations must surface as ArgumentException, not
+    /// IndexOutOfRangeException — callers depend on the same exception
+    /// surface as TensorPermute.
+    /// </summary>
+    [Fact]
+    public void TensorPermuteInto_DuplicateAxis_ThrowsArgumentException()
+    {
+        var engine = new CpuEngine();
+        var src = new Tensor<float>(new[] { 2, 3, 4 });
+        var dst = new Tensor<float>(new[] { 2, 2, 2 });
+        Assert.Throws<ArgumentException>(() =>
+            engine.TensorPermuteInto(dst, src, new[] { 0, 0, 1 }));
+    }
+
+    [Fact]
+    public void TensorPermuteInto_OutOfRangeAxis_ThrowsArgumentException()
+    {
+        var engine = new CpuEngine();
+        var src = new Tensor<float>(new[] { 2, 3, 4 });
+        var dst = new Tensor<float>(new[] { 2, 3, 4 });
+        Assert.Throws<ArgumentException>(() =>
+            engine.TensorPermuteInto(dst, src, new[] { 0, 1, 5 }));
+        Assert.Throws<ArgumentException>(() =>
+            engine.TensorPermuteInto(dst, src, new[] { 0, 1, -1 }));
+    }
+
+    [Fact]
+    public void TensorPermuteInto_RankMismatch_ThrowsArgumentException()
+    {
+        var engine = new CpuEngine();
+        var src = new Tensor<float>(new[] { 2, 3, 4 });
+        var dst = new Tensor<float>(new[] { 2, 3 });
+        Assert.Throws<ArgumentException>(() =>
+            engine.TensorPermuteInto(dst, src, new[] { 0, 1, 2 }));
+    }
+
+    [Fact]
+    public void TensorPermuteInto_Rank0_CopiesScalar()
+    {
+        var engine = new CpuEngine();
+        var src = new Tensor<float>(Array.Empty<int>());
+        if (src.Length == 0) return; // some Tensor builds disallow rank-0 entirely
+        src[0] = 7.5f;
+        var dst = new Tensor<float>(Array.Empty<int>());
+        engine.TensorPermuteInto(dst, src, Array.Empty<int>());
+        Assert.Equal(7.5f, dst[0]);
     }
 
     #endregion

--- a/tests/AiDotNet.Tensors.Tests/Engines/TensorLevelOpsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/TensorLevelOpsTests.cs
@@ -581,6 +581,90 @@ public class TensorLevelOpsTests
             Assert.Equal(expected[i], output[i], 1e-5f);
     }
 
+    /// <summary>
+    /// Direct-kernel branch added in the SD-perf series: outChannels >=
+    /// 2 × MaxDegreeOfParallelism puts a 3×3 stride=1 double conv onto
+    /// SimdConvHelper.Conv3x3Stride1Double (im2col-free). Must produce the
+    /// same numerical result as the im2col + GEMM fallback even when the
+    /// caller reuses a non-zero pre-allocated output buffer (the fast path
+    /// no longer pre-clears output, and the kernel itself clears each
+    /// output channel inside its per-oc loop).
+    /// </summary>
+    [Fact]
+    public void Conv2DInto_Double_DirectKernelBranch_NonZeroOutput_MatchesConv2D()
+    {
+        var engine = new CpuEngine();
+
+        // outChannels = 64 ≥ 2 × MaxDegreeOfParallelism on every test runner
+        // (we set MaxDegreeOfParallelism = ProcessorCount which is at most 32
+        // on common CI hosts), guaranteeing the direct-kernel branch fires.
+        int oc = Math.Max(64, 2 * global::AiDotNet.Tensors.Helpers.CpuParallelSettings.MaxDegreeOfParallelism);
+        var input  = new Tensor<double>(new[] { 1, 8, 16, 16 });
+        var kernel = new Tensor<double>(new[] { oc, 8, 3, 3 });
+        var rng = new Random(123);
+        for (int i = 0; i < input.Length; i++)  input[i]  = rng.NextDouble() - 0.5;
+        for (int i = 0; i < kernel.Length; i++) kernel[i] = rng.NextDouble() - 0.5;
+
+        var expected = engine.Conv2D(input, kernel, stride: 1, padding: 1);
+
+        // Pre-fill output with garbage so we exercise the "caller reused a
+        // non-zero output buffer" case: the fix removed the outer Span.Clear()
+        // and instead trusts the per-oc kernel to clear its own slab.
+        var output = new Tensor<double>(expected._shape);
+        for (int i = 0; i < output.Length; i++) output[i] = 999.0 + i;
+
+        engine.Conv2DInto(output, input, kernel, stride: 1, padding: 1);
+
+        for (int i = 0; i < expected.Length; i++)
+            Assert.Equal(expected[i], output[i], 1e-10);
+    }
+
+    /// <summary>
+    /// MultiplyMatrixBlockedDouble's parallel path crosses the 64 M FMA
+    /// threshold with the standard im2col + GEMM expansion of a 32-channel
+    /// 32×32 input and a 32-channel 3×3 kernel (≈ 28 M FMAs from the GEMM
+    /// dimensions m × k × n = 32 × 288 × 1024 = 9.4 M; we go larger to be
+    /// safely above 64 M). Must match the serial path bit-for-bit on
+    /// finite, well-conditioned inputs (FMA reduction order is fixed
+    /// within each tile).
+    /// </summary>
+    [Fact]
+    public void Conv2D_Double_ParallelGemmBranch_MatchesSerial()
+    {
+        var engine = new CpuEngine();
+
+        // 32 × 16 × 32 × 32 → m=32, n=32×32=1024, k=16×9=144 → 4.7 M FMAs
+        // (under threshold). Bump inChannels to push above 64 M:
+        // m=64, k=64×9=576, n=64×64=4096 → 151 M FMAs.
+        var input  = new Tensor<double>(new[] { 1, 64, 64, 64 });
+        var kernel = new Tensor<double>(new[] { 64, 64, 3, 3 });
+        var rng = new Random(7);
+        for (int i = 0; i < input.Length; i++)  input[i]  = rng.NextDouble() - 0.5;
+        for (int i = 0; i < kernel.Length; i++) kernel[i] = rng.NextDouble() - 0.5;
+
+        // Force the GEMM fallback (rather than the direct kernel) by
+        // temporarily capping MaxDegreeOfParallelism so outChannels = 64
+        // is BELOW the 2 × MDOP gate, then restoring after.
+        int saved = global::AiDotNet.Tensors.Helpers.CpuParallelSettings.MaxDegreeOfParallelism;
+        global::AiDotNet.Tensors.Helpers.CpuParallelSettings.MaxDegreeOfParallelism = 64; // gate is 2 × 64 = 128 > oc=64
+        try
+        {
+            var output = engine.Conv2D(input, kernel, stride: 1, padding: 1);
+
+            // Compare against a re-computation under the 1-thread serial
+            // path (MDOP=1 disables parallel) — they should agree to within
+            // FMA reordering tolerance.
+            global::AiDotNet.Tensors.Helpers.CpuParallelSettings.MaxDegreeOfParallelism = 1;
+            var serial = engine.Conv2D(input, kernel, stride: 1, padding: 1);
+            for (int i = 0; i < output.Length; i++)
+                Assert.Equal(serial[i], output[i], 1e-9);
+        }
+        finally
+        {
+            global::AiDotNet.Tensors.Helpers.CpuParallelSettings.MaxDegreeOfParallelism = saved;
+        }
+    }
+
     #endregion
 
     #region API Consistency


### PR DESCRIPTION
## Summary

Conv2D-double parallel GEMM + im2col-free 3×3 direct kernel + B-repack for diffusion shapes, plus a new `TensorPermuteInto(output, tensor, axes)` API across CPU and every GPU backend (CUDA / HIP / Metal / OpenCL / Vulkan / WebGpu).

**Consumed by:** ooples/AiDotNet#1225 — diffusion attention + UNet decoder skip-merge pools route through this PR's engine surface for the SD-perf series (CatVTON 232s/310s → 49s/44.6s end-to-end).

## What's in this PR

### Conv2D fast paths

- `MultiplyMatrixBlockedDouble` parallel-GEMM branch above 64M FMAs, splits across both M and N axes for 32-core saturation (was M-only, capped at ~2× speedup on SD shapes).
- 3×3 stride=1 double conv routes through `SimdConvHelper.Conv3x3Stride1Double` (im2col-free) when `outChannels >= 2 * MaxDegreeOfParallelism`.
- B-repacking: pack `B` into per-(K-block, N-block) contiguous tiles, then 2-D-tile parallel GEMM consuming those packed tiles. Both phases dispatch through `PersistentParallelExecutor` (same pool SimdGemm uses) instead of `Parallel.For` — eliminates per-call ThreadPool queuing on the diffusion hot path.

### TensorPermuteInto API

- New `IEngine.TensorPermuteInto(output, tensor, axes)` contract — caller-supplied output buffer, no per-call allocation.
- CPU implementation: rank-2/3/4 unrolled walks + generic odometer fallback. Hardened: rank-0 short-circuit, full axes-permutation validation (range, no duplicates), rejects non-contiguous source/destination tensors via `IsContiguous && _storageOffset == 0`.
- GPU implementation: routes to existing `backend.Permute(input, output, shape, axes)` on every backend (those kernels were written around explicit destination buffers from day one). Downloads directly into the caller's array via new `DownloadGpuBufferInto` helper — no intermediate `T[]` materialization.
- 10 new tests: rank-2/3/4 + odometer-rank-5 output equality with `TensorPermute`, invalid-permutation, out-of-range-axis, rank-mismatch, rank-0 scalar copy.

### Test infrastructure

- `[CollectionDefinition("CpuParallelSettings", DisableParallelization = true)]` serializes any test that mutates the process-global `CpuParallelSettings.MaxDegreeOfParallelism` so xUnit's parallel test classes don't race on the static setting.
- Direct-kernel correctness test resized to 16/32×32 (≥9.4M FMAs) so it sits above the OLD `<= 4M` cutoff and actually exercises the new `outChannels >= 2*MDOP` gate.

## Review-comment status

11 / 11 unresolved review threads on this PR resolved.

## Test plan

- [x] `dotnet build src/AiDotNet.Tensors/AiDotNet.Tensors.csproj --framework net10.0 -c Release` — 0 errors
- [x] `dotnet build tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --framework net10.0 -c Release` — 0 errors
- [x] All 10 new TensorPermuteInto / Conv2D-direct-kernel tests pass locally
- [x] CI build job — green