### PR TITLE
feat(autograd): sparse-aware ParameterBuffer + pattern-preserving sparse matmul

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/ParameterBuffer.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/ParameterBuffer.cs
@@ -61,6 +61,7 @@ public sealed class ParameterBuffer<T>
     private readonly Vector<T> _data;
     private readonly int[] _offsets;
     private readonly int[][] _shapes;
+    private readonly SparsityLayout?[] _sparseLayouts;
     private readonly int _totalSize;
 
     // Held by callers that need to atomically swap, observe, and restore
@@ -84,15 +85,51 @@ public sealed class ParameterBuffer<T>
     /// </summary>
     /// <param name="parameterShapes">The shapes of each parameter tensor, in order.</param>
     public ParameterBuffer(IReadOnlyList<int[]> parameterShapes)
+        : this(WrapAsDenseLayouts(parameterShapes))
     {
-        _shapes = new int[parameterShapes.Count][];
-        _offsets = new int[parameterShapes.Count];
+    }
+
+    /// <summary>
+    /// Creates a parameter buffer that supports BOTH dense and sparse
+    /// trainable parameters. Each <see cref="ParameterLayout"/> describes
+    /// either a dense leaf (full-shape slab) or a sparse leaf (only the
+    /// pattern's non-zero values are stored).
+    /// </summary>
+    /// <remarks>
+    /// <para>Sparse leaves are the production-ready path for training
+    /// <c>SparseLinearLayer&lt;T&gt;</c> and similar pattern-fixed layers
+    /// without paying the memory cost of a dense shadow. The buffer slot
+    /// for a sparse leaf is sized at <c>NonZeroCount</c> (the pattern's
+    /// non-zero count) instead of <c>rows × columns</c>; views over the
+    /// slot reconstruct a <see cref="SparseTensor{T}"/> using the
+    /// pattern's row/column indices and the sliced values vector.</para>
+    ///
+    /// <para>The dense ctor (<see cref="ParameterBuffer(IReadOnlyList{int[]})"/>)
+    /// remains for backward compatibility and delegates here with
+    /// all-dense layouts.</para>
+    /// </remarks>
+    /// <param name="layouts">Per-parameter layout descriptors.</param>
+    public ParameterBuffer(IReadOnlyList<ParameterLayout> layouts)
+    {
+        if (layouts is null) throw new ArgumentNullException(nameof(layouts));
+        _shapes = new int[layouts.Count][];
+        _offsets = new int[layouts.Count];
+        _sparseLayouts = new SparsityLayout?[layouts.Count];
 
         int offset = 0;
-        for (int i = 0; i < parameterShapes.Count; i++)
+        for (int i = 0; i < layouts.Count; i++)
         {
-            _shapes[i] = (int[])parameterShapes[i].Clone();
+            var layout = layouts[i] ?? throw new ArgumentNullException(
+                nameof(layouts), $"layouts[{i}] is null.");
+            _shapes[i] = (int[])layout.DenseShape.Clone();
+            _sparseLayouts[i] = layout.Sparse;
             _offsets[i] = offset;
+
+            // Dense slot size = product of dense shape; sparse slot size =
+            // pattern's NonZeroCount. The dense-shape validation still runs
+            // for sparse leaves (we want a sane semantic shape recorded for
+            // shape-inference and serialization paths) but the buffer
+            // allocation uses the cheaper sparse count.
             long size = 1;
             foreach (int dim in _shapes[i])
             {
@@ -101,15 +138,29 @@ public sealed class ParameterBuffer<T>
                 size *= dim;
                 if (size > int.MaxValue)
                     throw new OverflowException(
-                        $"Parameter {i} shape produces more than {int.MaxValue} elements. " +
+                        $"Parameter {i} dense shape produces more than {int.MaxValue} elements. " +
                         "ParameterBuffer uses int indexing; reduce parameter sizes or use multiple buffers.");
             }
-            offset = checked(offset + (int)size);
+
+            long bufferElements = layout.BufferElementCount;
+            if (bufferElements > int.MaxValue)
+                throw new OverflowException(
+                    $"Parameter {i} buffer size ({bufferElements}) exceeds int.MaxValue.");
+            offset = checked(offset + (int)bufferElements);
         }
 
         _totalSize = offset;
         _data = new Vector<T>(_totalSize);
         _storage = new TensorStorage<T>(_data);
+    }
+
+    private static IReadOnlyList<ParameterLayout> WrapAsDenseLayouts(IReadOnlyList<int[]> shapes)
+    {
+        if (shapes is null) throw new ArgumentNullException(nameof(shapes));
+        var wrapped = new ParameterLayout[shapes.Count];
+        for (int i = 0; i < shapes.Count; i++)
+            wrapped[i] = new ParameterLayout(shapes[i]);
+        return wrapped;
     }
 
     /// <summary>
@@ -148,16 +199,78 @@ public sealed class ParameterBuffer<T>
     public int[] GetShape(int index) => (int[])_shapes[index].Clone();
 
     /// <summary>
-    /// Creates a tensor view into this buffer at the specified parameter index.
-    /// The returned tensor shares storage with the buffer — mutations are bidirectional.
+    /// Returns the sparsity layout for the i-th parameter when it is
+    /// sparse; <c>null</c> otherwise. Use <see cref="IsSparse"/> for a
+    /// quick boolean test before reading.
     /// </summary>
-    /// <param name="index">The parameter index (0-based, in the order shapes were provided).</param>
+    public SparsityLayout? GetSparseLayout(int index) => _sparseLayouts[index];
+
+    /// <summary>
+    /// Whether the i-th parameter is stored as a sparse-pattern values vector.
+    /// </summary>
+    public bool IsSparse(int index) => _sparseLayouts[index] is not null;
+
+    /// <summary>
+    /// Creates a tensor view into this buffer at the specified parameter index.
+    /// Dense parameters return a <see cref="Tensor{T}"/> view sharing storage
+    /// with the buffer. Sparse parameters return a <see cref="SparseTensor{T}"/>
+    /// whose <c>Values</c> share storage with the buffer slice and whose
+    /// row/column indices come from the layout — mutations to the buffer
+    /// flow into the sparse tensor's values automatically.
+    /// </summary>
+    /// <param name="index">The parameter index (0-based, in the order layouts were provided).</param>
     /// <returns>A tensor view backed by this buffer's storage.</returns>
     public Tensor<T> CreateView(int index)
     {
         var shape = _shapes[index];
-        var strides = ComputeRowMajorStrides(shape);
-        return new Tensor<T>(_data, shape, strides, _offsets[index], _storage);
+        var sparse = _sparseLayouts[index];
+        if (sparse is null)
+        {
+            var strides = ComputeRowMajorStrides(shape);
+            return new Tensor<T>(_data, shape, strides, _offsets[index], _storage);
+        }
+
+        // Sparse leaf: build a SparseTensor whose Values array is a
+        // dedicated copy of the buffer slice. The SparseTensor ctor wraps
+        // the values via Vector<T>.Wrap, which takes the array reference —
+        // we deliberately copy here so the SparseTensor's storage isn't
+        // aliased to the buffer's TensorStorage (which would let two
+        // different storage objects view the same memory and break
+        // tape-side identity comparisons). Updates flow back to the buffer
+        // through CopyFrom(IReadOnlyList<Tensor<T>>) at end-of-step or
+        // through the explicit values-vector accessors below.
+        var values = new T[sparse.NonZeroCount];
+        var bufferSpan = _data.AsSpan().Slice(_offsets[index], sparse.NonZeroCount);
+        bufferSpan.CopyTo(values);
+        return new SparseTensor<T>(sparse.Rows, sparse.Columns,
+            sparse.RowIndices, sparse.ColumnIndices, values);
+    }
+
+    /// <summary>
+    /// Returns a writable span over the i-th sparse parameter's non-zero
+    /// values directly inside the buffer. Mutations flow into the buffer
+    /// in-place. Used by sparse-aware autograd ops and optimizers to
+    /// push values updates back without rebuilding the SparseTensor.
+    /// Throws if the i-th parameter is dense.
+    /// </summary>
+    public Span<T> GetSparseValuesSpan(int index)
+    {
+        var sparse = _sparseLayouts[index]
+            ?? throw new InvalidOperationException(
+                $"Parameter {index} is dense; use CreateView instead.");
+        return _data.AsWritableSpan().Slice(_offsets[index], sparse.NonZeroCount);
+    }
+
+    /// <summary>
+    /// Read-only counterpart of <see cref="GetSparseValuesSpan"/> for
+    /// inspecting a sparse leaf's current values without copying.
+    /// </summary>
+    public ReadOnlySpan<T> GetSparseValuesReadOnlySpan(int index)
+    {
+        var sparse = _sparseLayouts[index]
+            ?? throw new InvalidOperationException(
+                $"Parameter {index} is dense; use CreateView instead.");
+        return _data.AsSpan().Slice(_offsets[index], sparse.NonZeroCount);
     }
 
     /// <summary>
@@ -188,12 +301,70 @@ public sealed class ParameterBuffer<T>
         for (int i = 0; i < parameters.Count; i++)
         {
             var param = parameters[i];
-            // Densify sparse tensors before copying (sparse storage isn't contiguous)
+            var sparseLayout = _sparseLayouts[i];
+
+            if (sparseLayout is not null)
+            {
+                // Sparse leaf: source must be a SparseTensor<T> with the
+                // same pattern. Copy only the Values vector into the slot
+                // — the buffer slot was sized at NonZeroCount, not the
+                // full dense shape.
+                if (param is not SparseTensor<T> sparseParam)
+                    throw new ArgumentException(
+                        $"Parameter {i} is registered as sparse but the source tensor is dense. " +
+                        "Convert to SparseTensor with the matching COO pattern before copying.",
+                        nameof(parameters));
+                if (sparseParam.Rows != sparseLayout.Rows || sparseParam.Columns != sparseLayout.Columns)
+                    throw new ArgumentException(
+                        $"Parameter {i} sparse shape [{sparseParam.Rows}, {sparseParam.Columns}] " +
+                        $"does not match layout [{sparseLayout.Rows}, {sparseLayout.Columns}].",
+                        nameof(parameters));
+                // Validate the source's COO pattern matches our layout.
+                // Pattern is fixed at layer init; a mismatch here means the
+                // caller passed a different sparse tensor than the layer
+                // registered — fail loudly rather than silently copying
+                // values into wrong-pattern positions.
+                var coo = sparseParam.ToCoo();
+                if (coo.RowIndices.Length != sparseLayout.NonZeroCount)
+                    throw new ArgumentException(
+                        $"Parameter {i} non-zero count ({coo.RowIndices.Length}) does not match " +
+                        $"layout NonZeroCount ({sparseLayout.NonZeroCount}). The sparsity pattern " +
+                        "is fixed at construction time.",
+                        nameof(parameters));
+                for (int k = 0; k < sparseLayout.NonZeroCount; k++)
+                {
+                    if (coo.RowIndices[k] != sparseLayout.RowIndices[k]
+                        || coo.ColumnIndices[k] != sparseLayout.ColumnIndices[k])
+                    {
+                        throw new ArgumentException(
+                            $"Parameter {i} COO pattern at index {k} differs from layout " +
+                            $"(source [{coo.RowIndices[k]}, {coo.ColumnIndices[k]}] vs layout " +
+                            $"[{sparseLayout.RowIndices[k]}, {sparseLayout.ColumnIndices[k]}]). " +
+                            "Sparsity pattern is fixed.",
+                            nameof(parameters));
+                    }
+                }
+
+                // Copy Values into the buffer slot.
+                var valuesSrc = coo.DataVector.AsSpan()
+                    .Slice(coo._storageOffset, sparseLayout.NonZeroCount);
+                var dst = bufferSpan.Slice(_offsets[i], sparseLayout.NonZeroCount);
+                valuesSrc.CopyTo(dst);
+                continue;
+            }
+
+            // Dense leaf — original path.
             Tensor<T> contiguous;
             if (param.IsSparse)
+            {
+                // Caller registered this leaf as dense but is passing a
+                // sparse tensor. Densify so the dense slot fills correctly.
                 contiguous = ((SparseTensor<T>)param).ToDense();
+            }
             else
+            {
                 contiguous = param.IsContiguous ? param : param.Contiguous();
+            }
             var srcData = contiguous.DataVector;
             var src = srcData.AsSpan().Slice(contiguous._storageOffset, contiguous.Length);
             int expectedSize = 1;
@@ -202,8 +373,8 @@ public sealed class ParameterBuffer<T>
                 throw new ArgumentException(
                     $"Parameter {i} length ({src.Length}) does not match expected shape size. " +
                     "Ensure parameter tensors match the shapes provided at buffer construction.");
-            var dst = bufferSpan.Slice(_offsets[i], contiguous.Length);
-            src.CopyTo(dst);
+            var denseDst = bufferSpan.Slice(_offsets[i], contiguous.Length);
+            src.CopyTo(denseDst);
         }
     }
 
@@ -244,22 +415,81 @@ public sealed class ParameterBuffer<T>
 
         for (int i = 0; i < parameters.Count; i++)
         {
-            if (gradients.TryGetValue(parameters[i], out var grad))
+            if (!gradients.TryGetValue(parameters[i], out var grad)) continue;
+
+            var sparseLayout = _sparseLayouts[i];
+            if (sparseLayout is not null)
             {
-                Tensor<T> contiguous;
-                if (grad.IsSparse)
-                    contiguous = ((SparseTensor<T>)grad).ToDense();
+                // Sparse leaf — the gradient slot is sized at
+                // NonZeroCount. Two source forms to handle:
+                //   (a) sparse gradient with matching pattern: copy Values
+                //       directly (zero allocation).
+                //   (b) dense gradient (the standard PyTorch return form):
+                //       gather only the values at the pattern's positions.
+                //       Densifying then copying would overflow the slot.
+                var dst = gradSpan.Slice(_offsets[i], sparseLayout.NonZeroCount);
+
+                if (grad is SparseTensor<T> sparseGrad
+                    && sparseGrad.Rows == sparseLayout.Rows
+                    && sparseGrad.Columns == sparseLayout.Columns
+                    && PatternsMatch(sparseGrad.ToCoo(), sparseLayout))
+                {
+                    var coo = sparseGrad.ToCoo();
+                    var valuesSrc = coo.DataVector.AsSpan()
+                        .Slice(coo._storageOffset, sparseLayout.NonZeroCount);
+                    valuesSrc.CopyTo(dst);
+                }
                 else
-                    contiguous = grad.IsContiguous ? grad : grad.Contiguous();
-                var srcData = contiguous.DataVector;
-                var src = srcData.AsSpan().Slice(contiguous._storageOffset, contiguous.Length);
-                int copyLen = Math.Min(src.Length, parameters[i].Length);
-                var dst = gradSpan.Slice(_offsets[i], copyLen);
-                src.Slice(0, copyLen).CopyTo(dst);
+                {
+                    // Dense gradient: gather at pattern positions. Use the
+                    // multi-dim indexer so strided / view tensors work.
+                    Tensor<T> denseGrad = grad.IsSparse
+                        ? ((SparseTensor<T>)grad).ToDense()
+                        : grad;
+                    if (denseGrad.Rank != 2)
+                        throw new ArgumentException(
+                            $"Sparse leaf {i} expects a rank-2 dense gradient or a matching sparse " +
+                            $"gradient; got rank {denseGrad.Rank}.");
+                    if (denseGrad.Shape[0] != sparseLayout.Rows
+                        || denseGrad.Shape[1] != sparseLayout.Columns)
+                        throw new ArgumentException(
+                            $"Sparse leaf {i} dense gradient shape " +
+                            $"[{denseGrad.Shape[0]}, {denseGrad.Shape[1]}] does not match layout " +
+                            $"[{sparseLayout.Rows}, {sparseLayout.Columns}].");
+                    for (int k = 0; k < sparseLayout.NonZeroCount; k++)
+                    {
+                        dst[k] = denseGrad[sparseLayout.RowIndices[k], sparseLayout.ColumnIndices[k]];
+                    }
+                }
+                continue;
             }
+
+            // Dense leaf — original path.
+            Tensor<T> contiguous;
+            if (grad.IsSparse)
+                contiguous = ((SparseTensor<T>)grad).ToDense();
+            else
+                contiguous = grad.IsContiguous ? grad : grad.Contiguous();
+            var denseSrcData = contiguous.DataVector;
+            var denseSrc = denseSrcData.AsSpan().Slice(contiguous._storageOffset, contiguous.Length);
+            int copyLen = Math.Min(denseSrc.Length, parameters[i].Length);
+            var denseDst = gradSpan.Slice(_offsets[i], copyLen);
+            denseSrc.Slice(0, copyLen).CopyTo(denseDst);
         }
 
         return flatGrad;
+    }
+
+    private static bool PatternsMatch(SparseTensor<T> coo, SparsityLayout layout)
+    {
+        if (coo.RowIndices.Length != layout.NonZeroCount) return false;
+        for (int k = 0; k < layout.NonZeroCount; k++)
+        {
+            if (coo.RowIndices[k] != layout.RowIndices[k]
+                || coo.ColumnIndices[k] != layout.ColumnIndices[k])
+                return false;
+        }
+        return true;
     }
 
     private static int[] ComputeRowMajorStrides(int[] shape)

--- a/src/AiDotNet.Tensors/Engines/Autodiff/ParameterBuffer.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/ParameterBuffer.cs
@@ -57,12 +57,17 @@ namespace AiDotNet.Tensors.Engines.Autodiff;
 /// </remarks>
 public sealed class ParameterBuffer<T>
 {
-    private readonly TensorStorage<T> _storage;
-    private readonly Vector<T> _data;
+    // Most fields are immutable post-construction in the original API.
+    // ResizeSparseLeaf is the one operation that can replace _data /
+    // _storage / _totalSize (when a sparse leaf's NonZeroCount changes
+    // and the buffer must grow/shrink). All other code paths treat
+    // these as readonly-after-ctor.
+    private TensorStorage<T> _storage;
+    private Vector<T> _data;
     private readonly int[] _offsets;
     private readonly int[][] _shapes;
     private readonly SparsityLayout?[] _sparseLayouts;
-    private readonly int _totalSize;
+    private int _totalSize;
 
     // Held by callers that need to atomically swap, observe, and restore
     // the buffer's contents — most importantly TensorFunc.FunctionalCall.
@@ -271,6 +276,146 @@ public sealed class ParameterBuffer<T>
             ?? throw new InvalidOperationException(
                 $"Parameter {index} is dense; use CreateView instead.");
         return _data.AsSpan().Slice(_offsets[index], sparse.NonZeroCount);
+    }
+
+    /// <summary>
+    /// Replaces a sparse leaf's pattern in place when the new pattern
+    /// has the SAME <c>NonZeroCount</c> as the current one. Use this for
+    /// dynamic-sparsity training where the sparsity ratio is fixed but
+    /// the active positions move between optimizer steps (rigid pruning,
+    /// SET / RigL / threshold-based dynamic-sparse training).
+    /// </summary>
+    /// <remarks>
+    /// <para>The buffer slot is unchanged in size and offset, so other
+    /// leaves' offsets are unaffected. <paramref name="newValues"/> is
+    /// optional — if omitted the existing values stay in place at their
+    /// new pattern positions, which the caller must understand (the
+    /// position–value association is now relative to the new indices).
+    /// </para>
+    /// <para>For pattern changes that also alter the count, use
+    /// <see cref="ResizeSparseLeaf"/> which reallocates the buffer.</para>
+    /// </remarks>
+    public void RebuildSparsePattern(int index, SparsityLayout newLayout, ReadOnlySpan<T> newValues = default)
+    {
+        if (newLayout is null) throw new ArgumentNullException(nameof(newLayout));
+        var current = _sparseLayouts[index]
+            ?? throw new InvalidOperationException(
+                $"Parameter {index} is dense; cannot replace its sparsity pattern.");
+
+        if (newLayout.Rows != current.Rows || newLayout.Columns != current.Columns)
+            throw new ArgumentException(
+                $"New pattern dense shape [{newLayout.Rows}, {newLayout.Columns}] must match " +
+                $"existing [{current.Rows}, {current.Columns}]; use ResizeSparseLeaf for shape changes.",
+                nameof(newLayout));
+        if (newLayout.NonZeroCount != current.NonZeroCount)
+            throw new ArgumentException(
+                $"RebuildSparsePattern requires the new NonZeroCount ({newLayout.NonZeroCount}) " +
+                $"to match the existing ({current.NonZeroCount}). Use ResizeSparseLeaf for size changes.",
+                nameof(newLayout));
+
+        _sparseLayouts[index] = newLayout;
+
+        if (!newValues.IsEmpty)
+        {
+            if (newValues.Length != newLayout.NonZeroCount)
+                throw new ArgumentException(
+                    $"newValues length ({newValues.Length}) must equal NonZeroCount " +
+                    $"({newLayout.NonZeroCount}).",
+                    nameof(newValues));
+            var dst = _data.AsWritableSpan().Slice(_offsets[index], newLayout.NonZeroCount);
+            newValues.CopyTo(dst);
+        }
+    }
+
+    /// <summary>
+    /// Replaces a sparse leaf's layout AND reallocates the buffer to
+    /// accommodate the new <c>NonZeroCount</c>. Other leaves' values
+    /// are preserved; their offsets shift to reflect the new sparse
+    /// slot size. Use this for fully variable-pattern training (positions
+    /// AND count both change) — e.g. when a model dynamically prunes /
+    /// regrows connections.
+    /// </summary>
+    /// <remarks>
+    /// <para>Cost: <see cref="O(TotalSize)"/> for the buffer copy and
+    /// <see cref="O(Count)"/> for the offset rebuild. Tensor views
+    /// returned by previous <see cref="CreateView"/> calls are
+    /// invalidated — re-create them after this method returns.</para>
+    /// </remarks>
+    public void ResizeSparseLeaf(int index, SparsityLayout newLayout, ReadOnlySpan<T> newValues = default)
+    {
+        if (newLayout is null) throw new ArgumentNullException(nameof(newLayout));
+        var current = _sparseLayouts[index]
+            ?? throw new InvalidOperationException(
+                $"Parameter {index} is dense; cannot resize a dense slot via this API.");
+
+        if (newLayout.Rows != current.Rows || newLayout.Columns != current.Columns)
+            throw new ArgumentException(
+                $"New pattern dense shape [{newLayout.Rows}, {newLayout.Columns}] must match " +
+                $"existing [{current.Rows}, {current.Columns}].",
+                nameof(newLayout));
+
+        if (!newValues.IsEmpty && newValues.Length != newLayout.NonZeroCount)
+            throw new ArgumentException(
+                $"newValues length ({newValues.Length}) must equal NonZeroCount " +
+                $"({newLayout.NonZeroCount}).",
+                nameof(newValues));
+
+        int oldNnz = current.NonZeroCount;
+        int newNnz = newLayout.NonZeroCount;
+        int delta = newNnz - oldNnz;
+
+        if (delta == 0)
+        {
+            // No size change — fall through to the in-place rebuild path.
+            RebuildSparsePattern(index, newLayout, newValues);
+            return;
+        }
+
+        // Reallocate the underlying vector with the new total size.
+        // Preserve every other leaf's contents at their (possibly shifted)
+        // new offsets. The new sparse leaf's slot lives at the SAME
+        // offset as before; subsequent leaves shift by `delta`.
+        int newTotal = checked(_totalSize + delta);
+        var newData = new Vector<T>(newTotal);
+        var oldSpan = _data.AsSpan();
+        var newSpan = newData.AsWritableSpan();
+
+        // Copy everything before the resized slot (unchanged).
+        int prefixLen = _offsets[index];
+        if (prefixLen > 0)
+            oldSpan.Slice(0, prefixLen).CopyTo(newSpan.Slice(0, prefixLen));
+
+        // Fill the resized slot with newValues if provided, else zeros.
+        if (!newValues.IsEmpty)
+        {
+            newValues.CopyTo(newSpan.Slice(_offsets[index], newNnz));
+        }
+        // (Default case: leave zeros — Vector<T> allocates zero-initialized.)
+
+        // Copy the suffix (everything after the resized slot) to its new
+        // offset. The sparse leaf's slot grew/shrunk by `delta`, so the
+        // suffix starts `delta` positions later in the new buffer.
+        int oldSuffixStart = _offsets[index] + oldNnz;
+        int newSuffixStart = _offsets[index] + newNnz;
+        int suffixLen = _totalSize - oldSuffixStart;
+        if (suffixLen > 0)
+            oldSpan.Slice(oldSuffixStart, suffixLen).CopyTo(newSpan.Slice(newSuffixStart, suffixLen));
+
+        // Replace the storage. Existing tensor views obtained via
+        // CreateView before this Resize point at the OLD vector and are
+        // now stale — callers must re-create views after a Resize. The
+        // buffer's own read paths (CreateView, GetSparseValuesSpan, ...)
+        // use _data which we update here.
+        _data = newData;
+        _storage = new TensorStorage<T>(newData);
+        _totalSize = newTotal;
+
+        _sparseLayouts[index] = newLayout;
+        // Shift subsequent offsets by delta.
+        for (int i = index + 1; i < _offsets.Length; i++)
+        {
+            _offsets[i] += delta;
+        }
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/Autodiff/ParameterBuffer.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/ParameterBuffer.cs
@@ -130,21 +130,31 @@ public sealed class ParameterBuffer<T>
             _sparseLayouts[i] = layout.Sparse;
             _offsets[i] = offset;
 
-            // Dense slot size = product of dense shape; sparse slot size =
-            // pattern's NonZeroCount. The dense-shape validation still runs
-            // for sparse leaves (we want a sane semantic shape recorded for
-            // shape-inference and serialization paths) but the buffer
-            // allocation uses the cheaper sparse count.
-            long size = 1;
+            // Dense leaves: validate shape dimensions are non-negative AND
+            // the dense product fits in int (since the buffer slot is
+            // sized by that product).
+            // Sparse leaves: the buffer slot is sized by NonZeroCount, NOT
+            // the dense product. Only validate non-negativity of each dim
+            // (so callers can declare e.g. a 1M × 1M sparse parameter with
+            // 100 non-zeros without tripping the dense int.MaxValue
+            // overflow check that would otherwise defeat the entire
+            // memory-efficiency promise of sparse leaves).
             foreach (int dim in _shapes[i])
             {
                 if (dim < 0)
                     throw new ArgumentException($"Shape dimension must be non-negative, got {dim} in parameter {i}.");
-                size *= dim;
-                if (size > int.MaxValue)
-                    throw new OverflowException(
-                        $"Parameter {i} dense shape produces more than {int.MaxValue} elements. " +
-                        "ParameterBuffer uses int indexing; reduce parameter sizes or use multiple buffers.");
+            }
+            if (!layout.IsSparse)
+            {
+                long denseSize = 1;
+                foreach (int dim in _shapes[i])
+                {
+                    denseSize *= dim;
+                    if (denseSize > int.MaxValue)
+                        throw new OverflowException(
+                            $"Parameter {i} dense shape produces more than {int.MaxValue} elements. " +
+                            "ParameterBuffer uses int indexing; reduce parameter sizes or use multiple buffers.");
+                }
             }
 
             long bufferElements = layout.BufferElementCount;
@@ -235,20 +245,16 @@ public sealed class ParameterBuffer<T>
             return new Tensor<T>(_data, shape, strides, _offsets[index], _storage);
         }
 
-        // Sparse leaf: build a SparseTensor whose Values array is a
-        // dedicated copy of the buffer slice. The SparseTensor ctor wraps
-        // the values via Vector<T>.Wrap, which takes the array reference —
-        // we deliberately copy here so the SparseTensor's storage isn't
-        // aliased to the buffer's TensorStorage (which would let two
-        // different storage objects view the same memory and break
-        // tape-side identity comparisons). Updates flow back to the buffer
-        // through CopyFrom(IReadOnlyList<Tensor<T>>) at end-of-step or
-        // through the explicit values-vector accessors below.
-        var values = new T[sparse.NonZeroCount];
-        var bufferSpan = _data.AsSpan().Slice(_offsets[index], sparse.NonZeroCount);
-        bufferSpan.CopyTo(values);
+        // Sparse leaf: zero-copy view. Vector<T>.CreateSlice wraps a
+        // window of the buffer's underlying memory (no allocation, no
+        // copy), and the SparseTensor(Vector<T>) ctor takes that vector
+        // directly without re-wrapping. Mutations to the buffer flow
+        // into the returned SparseTensor's Values, and vice versa —
+        // matches the dense-leaf contract where CreateView returns a
+        // live view of the buffer.
+        var valuesVector = _data.CreateSlice(_offsets[index], sparse.NonZeroCount);
         return new SparseTensor<T>(sparse.Rows, sparse.Columns,
-            sparse.RowIndices, sparse.ColumnIndices, values);
+            sparse.RowIndices, sparse.ColumnIndices, valuesVector);
     }
 
     /// <summary>
@@ -576,18 +582,26 @@ public sealed class ParameterBuffer<T>
 
                 if (grad is SparseTensor<T> sparseGrad
                     && sparseGrad.Rows == sparseLayout.Rows
-                    && sparseGrad.Columns == sparseLayout.Columns
-                    && PatternsMatch(sparseGrad.ToCoo(), sparseLayout))
+                    && sparseGrad.Columns == sparseLayout.Columns)
                 {
+                    // ToCoo can allocate / canonicalize ordering, so call
+                    // it ONCE and reuse the result for both pattern check
+                    // and value copy. Hot path on every backward step.
                     var coo = sparseGrad.ToCoo();
-                    var valuesSrc = coo.DataVector.AsSpan()
-                        .Slice(coo._storageOffset, sparseLayout.NonZeroCount);
-                    valuesSrc.CopyTo(dst);
+                    if (PatternsMatch(coo, sparseLayout))
+                    {
+                        var valuesSrc = coo.DataVector.AsSpan()
+                            .Slice(coo._storageOffset, sparseLayout.NonZeroCount);
+                        valuesSrc.CopyTo(dst);
+                        continue;
+                    }
+                    // Pattern mismatch — fall through to dense projection.
                 }
-                else
                 {
-                    // Dense gradient: gather at pattern positions. Use the
-                    // multi-dim indexer so strided / view tensors work.
+                    // Dense gradient (or pattern-mismatched sparse that
+                    // fell through above): gather at pattern positions.
+                    // Use the multi-dim indexer so strided / view tensors
+                    // work.
                     Tensor<T> denseGrad = grad.IsSparse
                         ? ((SparseTensor<T>)grad).ToDense()
                         : grad;

--- a/src/AiDotNet.Tensors/Engines/Autodiff/ParameterBuffer.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/ParameterBuffer.cs
@@ -298,6 +298,17 @@ public sealed class ParameterBuffer<T>
     /// new pattern positions, which the caller must understand (the
     /// position–value association is now relative to the new indices).
     /// </para>
+    /// <para>
+    /// <b>View invalidation:</b> any <see cref="SparseTensor{T}"/>
+    /// instances obtained via <see cref="CreateView"/> before this call
+    /// were constructed with the old pattern's RowIndices /
+    /// ColumnIndices baked in — they will continue to interpret the
+    /// (now-shared) values slot using the OLD coordinates. Callers
+    /// MUST re-fetch views via <see cref="CreateView"/> after rebuilding
+    /// the pattern. (The same contract applies to
+    /// <see cref="ResizeSparseLeaf"/>, where the buffer reallocation
+    /// makes view invalidation even more obvious.)
+    /// </para>
     /// <para>For pattern changes that also alter the count, use
     /// <see cref="ResizeSparseLeaf"/> which reallocates the buffer.</para>
     /// </remarks>

--- a/src/AiDotNet.Tensors/Engines/Autodiff/ParameterLayout.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/ParameterLayout.cs
@@ -101,8 +101,10 @@ public sealed class ParameterLayout
 
 /// <summary>
 /// Captures a sparse parameter's fixed pattern: COO row/column indices.
-/// Indices are captured by reference at construction; the caller must
-/// not mutate them while the owning buffer is live.
+/// The constructor takes its OWN COPIES of the supplied index arrays
+/// (via <see cref="System.Array.Clone"/>), so subsequent mutations to
+/// the caller's arrays do not affect this layout. The fixed-pattern
+/// contract is enforced by ownership, not by caller discipline.
 /// </summary>
 public sealed class SparsityLayout
 {
@@ -114,13 +116,17 @@ public sealed class SparsityLayout
 
     /// <summary>
     /// Row indices of the non-zero positions, in COO order. Length =
-    /// <see cref="NonZeroCount"/>. Captured by reference; do not mutate.
+    /// <see cref="NonZeroCount"/>. This is the layout's own copy, taken
+    /// at construction; mutating the caller's source array after
+    /// construction has no effect here.
     /// </summary>
     public int[] RowIndices { get; }
 
     /// <summary>
     /// Column indices of the non-zero positions, in COO order. Length =
-    /// <see cref="NonZeroCount"/>. Captured by reference; do not mutate.
+    /// <see cref="NonZeroCount"/>. This is the layout's own copy, taken
+    /// at construction; mutating the caller's source array after
+    /// construction has no effect here.
     /// </summary>
     public int[] ColumnIndices { get; }
 

--- a/src/AiDotNet.Tensors/Engines/Autodiff/ParameterLayout.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/ParameterLayout.cs
@@ -1,0 +1,176 @@
+using System;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines.Autodiff;
+
+/// <summary>
+/// Describes the storage layout of a single trainable parameter inside a
+/// <see cref="ParameterBuffer{T}"/>. A layout is either dense (the
+/// historical case — the entire <see cref="DenseShape"/> participates in
+/// training) or sparse, in which case only the non-zero positions of a
+/// <see cref="LinearAlgebra.SparseTensor{T}"/> are stored and trained.
+/// Sparsity pattern is fixed at construction; only values move during
+/// training (this matches PyTorch's <c>torch.sparse.Parameter</c>
+/// contract — pattern is metadata, not a learnable quantity).
+/// </summary>
+/// <remarks>
+/// <para><b>Why a per-leaf layout instead of just a shape:</b>
+/// Sparse leaves like <c>SparseLinearLayer&lt;T&gt;</c>'s weight matrix
+/// have a dense semantic shape (e.g. <c>[outFeatures, inFeatures]</c>)
+/// but only allocate <c>NonZeroCount</c> trainable slots. The older
+/// <c>IReadOnlyList&lt;int[]&gt;</c> ctor sized the buffer slot off the
+/// dense shape and would have wasted <c>O(rows × columns)</c> memory
+/// per sparse leaf — defeating the entire memory-efficiency promise of
+/// sparse layers. <see cref="ParameterLayout"/> lets callers describe
+/// which leaves should occupy only their pattern's worth of buffer space
+/// while still preserving the dense shape for shape inference and
+/// serialization.</para>
+///
+/// <para><b>Sparsity pattern immutability:</b> The pattern's row and
+/// column index arrays are captured by reference at layout creation and
+/// must not be mutated afterwards. Mutating them while the buffer is
+/// live would desynchronize <see cref="ParameterBuffer{T}.CreateView"/>
+/// from the actual storage layout.</para>
+/// </remarks>
+public sealed class ParameterLayout
+{
+    /// <summary>
+    /// The dense semantic shape of the parameter. For sparse leaves this
+    /// is the shape of the underlying dense matrix the sparse pattern
+    /// projects onto (e.g. <c>[rows, columns]</c>); for dense leaves it
+    /// is the actual storage shape.
+    /// </summary>
+    public int[] DenseShape { get; }
+
+    /// <summary>
+    /// Sparsity layout when the parameter is sparse, or <c>null</c> for
+    /// a dense parameter.
+    /// </summary>
+    public SparsityLayout? Sparse { get; }
+
+    /// <summary>
+    /// True when this parameter is sparse (only its pattern's non-zero
+    /// values are stored in the buffer).
+    /// </summary>
+    public bool IsSparse => Sparse is not null;
+
+    /// <summary>
+    /// Creates a dense layout from a shape array.
+    /// </summary>
+    public ParameterLayout(int[] denseShape)
+    {
+        DenseShape = denseShape ?? throw new ArgumentNullException(nameof(denseShape));
+        Sparse = null;
+    }
+
+    /// <summary>
+    /// Creates a sparse layout. <paramref name="denseShape"/> must match
+    /// <c>[sparse.Rows, sparse.Columns]</c>.
+    /// </summary>
+    public ParameterLayout(int[] denseShape, SparsityLayout sparse)
+    {
+        DenseShape = denseShape ?? throw new ArgumentNullException(nameof(denseShape));
+        Sparse = sparse ?? throw new ArgumentNullException(nameof(sparse));
+        if (denseShape.Length != 2)
+            throw new ArgumentException(
+                $"Sparse parameter dense shape must be rank-2 [rows, columns]; got rank {denseShape.Length}.",
+                nameof(denseShape));
+        if (denseShape[0] != sparse.Rows || denseShape[1] != sparse.Columns)
+            throw new ArgumentException(
+                $"Dense shape [{denseShape[0]}, {denseShape[1]}] does not match sparse pattern " +
+                $"[{sparse.Rows}, {sparse.Columns}].",
+                nameof(denseShape));
+    }
+
+    /// <summary>
+    /// Number of trainable scalars in this parameter's buffer slot.
+    /// Dense: product of <see cref="DenseShape"/>. Sparse: pattern's
+    /// non-zero count.
+    /// </summary>
+    internal long BufferElementCount
+    {
+        get
+        {
+            if (Sparse is { } s) return s.NonZeroCount;
+            long product = 1;
+            foreach (int d in DenseShape) product *= d;
+            return product;
+        }
+    }
+}
+
+/// <summary>
+/// Captures a sparse parameter's fixed pattern: COO row/column indices.
+/// Indices are captured by reference at construction; the caller must
+/// not mutate them while the owning buffer is live.
+/// </summary>
+public sealed class SparsityLayout
+{
+    /// <summary>Dense matrix row count.</summary>
+    public int Rows { get; }
+
+    /// <summary>Dense matrix column count.</summary>
+    public int Columns { get; }
+
+    /// <summary>
+    /// Row indices of the non-zero positions, in COO order. Length =
+    /// <see cref="NonZeroCount"/>. Captured by reference; do not mutate.
+    /// </summary>
+    public int[] RowIndices { get; }
+
+    /// <summary>
+    /// Column indices of the non-zero positions, in COO order. Length =
+    /// <see cref="NonZeroCount"/>. Captured by reference; do not mutate.
+    /// </summary>
+    public int[] ColumnIndices { get; }
+
+    /// <summary>Number of non-zero values stored.</summary>
+    public int NonZeroCount => RowIndices.Length;
+
+    /// <summary>
+    /// Builds a layout from explicit row/column index arrays. The arrays
+    /// must have equal length; out-of-range indices throw
+    /// <see cref="ArgumentOutOfRangeException"/>.
+    /// </summary>
+    public SparsityLayout(int rows, int columns, int[] rowIndices, int[] columnIndices)
+    {
+        if (rows < 0) throw new ArgumentOutOfRangeException(nameof(rows));
+        if (columns < 0) throw new ArgumentOutOfRangeException(nameof(columns));
+        if (rowIndices is null) throw new ArgumentNullException(nameof(rowIndices));
+        if (columnIndices is null) throw new ArgumentNullException(nameof(columnIndices));
+        if (rowIndices.Length != columnIndices.Length)
+            throw new ArgumentException(
+                $"Row index length ({rowIndices.Length}) must equal column index length " +
+                $"({columnIndices.Length}).");
+        for (int i = 0; i < rowIndices.Length; i++)
+        {
+            if (rowIndices[i] < 0 || rowIndices[i] >= rows)
+                throw new ArgumentOutOfRangeException(
+                    nameof(rowIndices),
+                    $"rowIndices[{i}] = {rowIndices[i]} out of range [0, {rows}).");
+            if (columnIndices[i] < 0 || columnIndices[i] >= columns)
+                throw new ArgumentOutOfRangeException(
+                    nameof(columnIndices),
+                    $"columnIndices[{i}] = {columnIndices[i]} out of range [0, {columns}).");
+        }
+
+        Rows = rows;
+        Columns = columns;
+        RowIndices = rowIndices;
+        ColumnIndices = columnIndices;
+    }
+
+    /// <summary>
+    /// Builds a layout from an existing <see cref="SparseTensor{T}"/>'s
+    /// COO pattern. The layout shares index arrays with the source
+    /// tensor — do not mutate them through either reference.
+    /// </summary>
+    public static SparsityLayout FromSparseTensor<T>(SparseTensor<T> source)
+    {
+        if (source is null) throw new ArgumentNullException(nameof(source));
+        // ToCoo() guarantees RowIndices / ColumnIndices are populated
+        // regardless of the source's underlying storage format.
+        var coo = source.ToCoo();
+        return new SparsityLayout(coo.Rows, coo.Columns, coo.RowIndices, coo.ColumnIndices);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/Autodiff/ParameterLayout.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/ParameterLayout.cs
@@ -156,20 +156,27 @@ public sealed class SparsityLayout
 
         Rows = rows;
         Columns = columns;
-        RowIndices = rowIndices;
-        ColumnIndices = columnIndices;
+        // Clone caller-owned arrays so the fixed-pattern contract is
+        // enforced even if the caller mutates their copy after
+        // construction. Without the clones, an external mutation would
+        // silently desynchronise SparsityLayout from the buffer slots
+        // that depend on these indices being immutable.
+        RowIndices = (int[])rowIndices.Clone();
+        ColumnIndices = (int[])columnIndices.Clone();
     }
 
     /// <summary>
     /// Builds a layout from an existing <see cref="SparseTensor{T}"/>'s
-    /// COO pattern. The layout shares index arrays with the source
-    /// tensor — do not mutate them through either reference.
+    /// COO pattern. The layout takes its own COPY of the index arrays
+    /// (via the regular ctor) so subsequent mutations to the source
+    /// tensor's pattern don't desynchronise this layout.
     /// </summary>
     public static SparsityLayout FromSparseTensor<T>(SparseTensor<T> source)
     {
         if (source is null) throw new ArgumentNullException(nameof(source));
         // ToCoo() guarantees RowIndices / ColumnIndices are populated
-        // regardless of the source's underlying storage format.
+        // regardless of the source's underlying storage format. The
+        // SparsityLayout ctor will clone them for us.
         var coo = source.ToCoo();
         return new SparsityLayout(coo.Rows, coo.Columns, coo.RowIndices, coo.ColumnIndices);
     }

--- a/src/AiDotNet.Tensors/Engines/Autodiff/SparseAutograd.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/SparseAutograd.cs
@@ -135,7 +135,17 @@ public static class SparseAutograd
         // order; snapshot the values once via ToArray() (single copy)
         // so the rest is allocation-free at backward time.
         var coo = a.ToCoo();
-        var aValuesSnapshot = coo.DataVector.ToArray();
+        // Snapshot exactly the values aligned with the COO indices, not the
+        // full backing buffer. DataVector.ToArray() returns the whole
+        // memory the Vector wraps; if the sparse tensor were ever a view
+        // into a larger storage (current code paths don't do this, but a
+        // future Slice() / View() helper might), a full ToArray would
+        // include unrelated regions and backward would consume misaligned
+        // values when iterating COO indices. AsSpan().Slice(offset, count)
+        // keeps the snapshot strictly aligned with the saved RowIndices.
+        var aValuesSnapshot = coo.DataVector.AsSpan()
+            .Slice(coo._storageOffset, coo.RowIndices.Length)
+            .ToArray();
         DifferentiableOps.RecordBinary(
             "SparsePatternPreservingMatMul",
             output,
@@ -442,8 +452,16 @@ public static class SparseAutograd
         // ToArray().Clone() was a redundant second copy.
         var aCoo = a.ToCoo();
         var bCoo = b.ToCoo();
-        var aValuesSnapshot = aCoo.DataVector.ToArray();
-        var bValuesSnapshot = bCoo.DataVector.ToArray();
+        // See note on the matching pattern in SparsePatternPreservingMatMulRecord
+        // — slice strictly to the COO non-zero count via _storageOffset so any
+        // future SparseTensor view path can't leak unrelated buffer regions
+        // into the snapshot.
+        var aValuesSnapshot = aCoo.DataVector.AsSpan()
+            .Slice(aCoo._storageOffset, aCoo.RowIndices.Length)
+            .ToArray();
+        var bValuesSnapshot = bCoo.DataVector.AsSpan()
+            .Slice(bCoo._storageOffset, bCoo.RowIndices.Length)
+            .ToArray();
 
         DifferentiableOps.RecordBinary(
             "SparsePatternPreservingSpGeMM",

--- a/src/AiDotNet.Tensors/Engines/Autodiff/SparseAutograd.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/SparseAutograd.cs
@@ -379,6 +379,145 @@ public static class SparseAutograd
     /// materialisation of the CSR product so downstream tape ops compose;
     /// backward routes through the dense matmul Jacobian and is keyed on
     /// the dense views supplied by the caller.</summary>
+    /// <summary>Pattern-preserving sparse · sparse matmul. Backward
+    /// produces SPARSE gradients on both sides — values computed only at
+    /// each operand's own non-zero pattern, not as a full dense matrix.
+    /// Use this when both A and B are registered trainable parameters
+    /// (typical: a sparse-sparse projection chain). The output is
+    /// densified for downstream tape composition (matches the dense-grad
+    /// SpGeMM variant); the gradient flowing back into A and B is
+    /// pattern-preserving sparse and integrates with sparse-aware
+    /// <see cref="ParameterBuffer{T}"/> slots without densification.
+    /// </summary>
+    /// <param name="a">Sparse left operand (also the gradient target —
+    /// must be the same SparseTensor instance the caller registered).</param>
+    /// <param name="b">Sparse right operand (same identity rule).</param>
+    public static Tensor<T> SparsePatternPreservingSpGeMMRecord<T>(
+        SparseTensor<T> a, SparseTensor<T> b)
+    {
+        if (a is null) throw new ArgumentNullException(nameof(a));
+        if (b is null) throw new ArgumentNullException(nameof(b));
+        var sparseOut = SparseOps.SparseSpGeMM(a, b);
+        var output = sparseOut.ToDense();
+        if (DifferentiableOps._anyTapeActive == 0) return output;
+
+        // Snapshot patterns AND values for both operands at forward time.
+        // The sparse-aware backward needs B's values to compute dA and
+        // A's values to compute dB. Snapshot prevents in-place weight
+        // updates between forward + backward from corrupting gradients.
+        var aCoo = a.ToCoo();
+        var bCoo = b.ToCoo();
+        var aValuesSnapshot = (T[])aCoo.DataVector.ToArray().Clone();
+        var bValuesSnapshot = (T[])bCoo.DataVector.ToArray().Clone();
+
+        DifferentiableOps.RecordBinary(
+            "SparsePatternPreservingSpGeMM",
+            output,
+            a,
+            b,
+            SparsePatternPreservingSpGeMMBackward,
+            savedState: new object[]
+            {
+                aCoo.RowIndices, aCoo.ColumnIndices, a.Rows, a.Columns, aValuesSnapshot,
+                bCoo.RowIndices, bCoo.ColumnIndices, b.Rows, b.Columns, bValuesSnapshot,
+            });
+        return output;
+    }
+
+    private static void SparsePatternPreservingSpGeMMBackward<T>(
+        Tensor<T> gradOutput,
+        Tensor<T>[] inputs,
+        Tensor<T> output,
+        object[] savedState,
+        IEngine engine,
+        System.Collections.Generic.Dictionary<Tensor<T>, Tensor<T>> gradAccumulator)
+    {
+        // Y_dense = A_sparse · B_sparse  (then densified for tape composition)
+        // dA at non-zero (i,j) ∈ pattern_A:
+        //     dA[i,j] = sum_k B[j,k] · gradOut[i,k]
+        //   where B[j,k] is read via the sparse indexer (zero for
+        //   structural zeros, snapshot value for non-zero positions).
+        //   Equivalently: gather only over the k positions where (j,k) is
+        //   in pattern_B, then sum sparse_B(j,k) · gradOut(i,k).
+        // dB at non-zero (j,k) ∈ pattern_B:
+        //     dB[j,k] = sum_i A[i,j] · gradOut[i,k]
+        var aSparse = (SparseTensor<T>)inputs[0];
+        var bSparse = (SparseTensor<T>)inputs[1];
+        var aRowIdx = (int[])savedState[0];
+        var aColIdx = (int[])savedState[1];
+        int aRows = (int)savedState[2];
+        int aCols = (int)savedState[3];
+        var aValues = (T[])savedState[4];
+        var bRowIdx = (int[])savedState[5];
+        var bColIdx = (int[])savedState[6];
+        int bRows = (int)savedState[7];
+        int bCols = (int)savedState[8];
+        var bValues = (T[])savedState[9];
+
+        var ops = MathHelper.GetNumericOperations<T>();
+
+        // Build a B-row → list-of-(col, value) lookup so dA's per-(i,j)
+        // sum only scans the actual non-zeros in row j of B (not the
+        // structural zeros). O(nnz_B) total work to build.
+        var bByRow = new System.Collections.Generic.List<(int col, T val)>[bRows];
+        for (int idx = 0; idx < bRowIdx.Length; idx++)
+        {
+            int row = bRowIdx[idx];
+            (bByRow[row] ??= new System.Collections.Generic.List<(int, T)>())
+                .Add((bColIdx[idx], bValues[idx]));
+        }
+
+        int nnzA = aRowIdx.Length;
+        var gradAValues = new T[nnzA];
+        for (int idx = 0; idx < nnzA; idx++)
+        {
+            int i = aRowIdx[idx];
+            int j = aColIdx[idx];
+            T sum = ops.Zero;
+            var bRow = bByRow[j];
+            if (bRow is not null)
+            {
+                foreach (var (k, bVal) in bRow)
+                {
+                    sum = ops.Add(sum, ops.Multiply(bVal, gradOutput[i, k]));
+                }
+            }
+            gradAValues[idx] = sum;
+        }
+        var sparseGradA = new SparseTensor<T>(aRows, aCols, aRowIdx, aColIdx, gradAValues);
+        AccumulateGrad(aSparse, sparseGradA, gradAccumulator, engine);
+
+        // dB symmetric: build A-col → list-of-(row, value).
+        var aByCol = new System.Collections.Generic.List<(int row, T val)>[aCols];
+        for (int idx = 0; idx < aRowIdx.Length; idx++)
+        {
+            int col = aColIdx[idx];
+            (aByCol[col] ??= new System.Collections.Generic.List<(int, T)>())
+                .Add((aRowIdx[idx], aValues[idx]));
+        }
+
+        int nnzB = bRowIdx.Length;
+        var gradBValues = new T[nnzB];
+        for (int idx = 0; idx < nnzB; idx++)
+        {
+            int j = bRowIdx[idx];
+            int k = bColIdx[idx];
+            T sum = ops.Zero;
+            var aCol = aByCol[j];
+            if (aCol is not null)
+            {
+                foreach (var (i, aVal) in aCol)
+                {
+                    sum = ops.Add(sum, ops.Multiply(aVal, gradOutput[i, k]));
+                }
+            }
+            gradBValues[idx] = sum;
+        }
+        var sparseGradB = new SparseTensor<T>(bRows, bCols, bRowIdx, bColIdx, gradBValues);
+        AccumulateGrad(bSparse, sparseGradB, gradAccumulator, engine);
+        _ = output;
+    }
+
     public static Tensor<T> SparseSpGeMMRecord<T>(SparseTensor<T> a, SparseTensor<T> b,
         Tensor<T> aDense, Tensor<T> bDense)
     {

--- a/src/AiDotNet.Tensors/Engines/Autodiff/SparseAutograd.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/SparseAutograd.cs
@@ -127,9 +127,15 @@ public static class SparseAutograd
         var output = SparseOps.SparseMatMul(a, b);
         if (DifferentiableOps._anyTapeActive == 0) return output;
 
-        // Snapshot the COO pattern so backward can construct the sparse
-        // gradient with the same row/column indices as A.
+        // Snapshot BOTH the COO pattern AND the values aligned with that
+        // pattern. Backward computes dB by iterating non-zeros of A, and
+        // the values must match the index order — but if A is stored in
+        // CSR/BSR/etc. its DataVector ordering is NOT aligned with the
+        // COO indices we save. ToCoo() materialises both in the right
+        // order; snapshot the values once via ToArray() (single copy)
+        // so the rest is allocation-free at backward time.
         var coo = a.ToCoo();
+        var aValuesSnapshot = coo.DataVector.ToArray();
         DifferentiableOps.RecordBinary(
             "SparsePatternPreservingMatMul",
             output,
@@ -142,6 +148,7 @@ public static class SparseAutograd
                 coo.ColumnIndices,
                 a.Rows,
                 a.Columns,
+                aValuesSnapshot,
             });
         return output;
     }
@@ -165,6 +172,7 @@ public static class SparseAutograd
         var colIndices = (int[])savedState[1];
         int rows = (int)savedState[2];
         int columns = (int)savedState[3];
+        var aValues = (T[])savedState[4];
 
         var ops = MathHelper.GetNumericOperations<T>();
         int nnz = rowIndices.Length;
@@ -192,16 +200,17 @@ public static class SparseAutograd
         // dense [columns × innerK] gradient. This avoids the O(rows × columns)
         // densification that materialising A and transposing it would
         // incur — the whole memory-efficiency point of the
-        // pattern-preserving op. Pulls A's values from saved state? — no,
-        // A is the trainable parameter, so its current values
-        // (which the user hasn't yet updated this step) are still the
-        // ones used in forward. Read them via the sparse indexer.
+        // pattern-preserving op. The values used here MUST be the
+        // forward-time snapshot (`aValues`, captured during record in
+        // COO order matching `rowIndices` / `colIndices`); reading
+        // aSparse.DataVector directly would assume COO ordering, but
+        // CSR/BSR-stored sparse tensors return values in a different
+        // order. The snapshot fixes that misalignment.
         var gradB = new Tensor<T>(new[] { columns, innerK });
         var gradBSpan = gradB.AsWritableSpan();
         // gradB starts zero (Tensor ctor zero-fills); accumulate
         //   gradB[j, k] += A_value[idx] · dY[i, k]    where (i, j) ∈ pattern_A
         // Equivalent to A^T · dY without materialising the dense A.
-        var aValues = aSparse.DataVector.AsSpan().Slice(aSparse._storageOffset, nnz);
         for (int idx = 0; idx < nnz; idx++)
         {
             int i = rowIndices[idx];
@@ -429,10 +438,12 @@ public static class SparseAutograd
         // The sparse-aware backward needs B's values to compute dA and
         // A's values to compute dB. Snapshot prevents in-place weight
         // updates between forward + backward from corrupting gradients.
+        // ToArray() already allocates a fresh copy — the previous
+        // ToArray().Clone() was a redundant second copy.
         var aCoo = a.ToCoo();
         var bCoo = b.ToCoo();
-        var aValuesSnapshot = (T[])aCoo.DataVector.ToArray().Clone();
-        var bValuesSnapshot = (T[])bCoo.DataVector.ToArray().Clone();
+        var aValuesSnapshot = aCoo.DataVector.ToArray();
+        var bValuesSnapshot = bCoo.DataVector.ToArray();
 
         DifferentiableOps.RecordBinary(
             "SparsePatternPreservingSpGeMM",

--- a/src/AiDotNet.Tensors/Engines/Autodiff/SparseAutograd.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/SparseAutograd.cs
@@ -103,6 +103,98 @@ public static class SparseAutograd
         return output;
     }
 
+    /// <summary>Tape-aware sparse · dense matmul that produces a
+    /// PATTERN-PRESERVING sparse gradient on the sparse side. Use this
+    /// when the sparse tensor is a registered trainable parameter
+    /// (typical: <c>SparseLinearLayer&lt;T&gt;</c> + sparse-aware
+    /// <see cref="ParameterBuffer{T}"/>) — the produced gradient's
+    /// <see cref="SparseTensor{T}.Values"/> length matches the original
+    /// pattern's <c>NonZeroCount</c>, so the parameter buffer can store
+    /// it as a flat values vector without materialising the dense matrix.
+    /// Avoids the O(rows·columns) memory allocation that
+    /// <see cref="SparseMatMulRecord{T}"/> incurs in its backward.
+    /// </summary>
+    /// <param name="a">Sparse left operand. Must be the registered
+    /// trainable-parameter SparseTensor — the gradient is keyed against
+    /// this exact instance, so reusing a different SparseTensor with the
+    /// same pattern won't accumulate gradients correctly.</param>
+    /// <param name="b">Dense right operand.</param>
+    public static Tensor<T> SparsePatternPreservingMatMulRecord<T>(
+        SparseTensor<T> a, Tensor<T> b)
+    {
+        if (a is null) throw new ArgumentNullException(nameof(a));
+        if (b is null) throw new ArgumentNullException(nameof(b));
+        var output = SparseOps.SparseMatMul(a, b);
+        if (DifferentiableOps._anyTapeActive == 0) return output;
+
+        // Snapshot the COO pattern so backward can construct the sparse
+        // gradient with the same row/column indices as A.
+        var coo = a.ToCoo();
+        DifferentiableOps.RecordBinary(
+            "SparsePatternPreservingMatMul",
+            output,
+            a,    // sparse parameter — gradient accumulator keyed here
+            b,
+            SparsePatternPreservingMatMulBackward,
+            savedState: new object[]
+            {
+                coo.RowIndices,
+                coo.ColumnIndices,
+                a.Rows,
+                a.Columns,
+            });
+        return output;
+    }
+
+    private static void SparsePatternPreservingMatMulBackward<T>(
+        Tensor<T> gradOutput,
+        Tensor<T>[] inputs,
+        Tensor<T> output,
+        object[] savedState,
+        IEngine engine,
+        System.Collections.Generic.Dictionary<Tensor<T>, Tensor<T>> gradAccumulator)
+    {
+        // Y = A_sparse · B (pattern P fixed)
+        // dB = A^T · dY  (dense form: standard SpMM with transposed A)
+        // dA[i,j] for non-zero (i,j) ∈ P:
+        //     dA[i,j] = sum_k B[j,k] · dY[i,k]
+        // Pack the dA values in COO order matching the saved pattern.
+        var aSparse = (SparseTensor<T>)inputs[0];
+        var b = inputs[1];
+        var rowIndices = (int[])savedState[0];
+        var colIndices = (int[])savedState[1];
+        int rows = (int)savedState[2];
+        int columns = (int)savedState[3];
+
+        var ops = MathHelper.GetNumericOperations<T>();
+        int nnz = rowIndices.Length;
+        int innerK = b._shape[1];
+
+        // Compute dA over the pattern only — never materialises the
+        // dense O(rows × columns) gradient.
+        var gradValues = new T[nnz];
+        for (int idx = 0; idx < nnz; idx++)
+        {
+            int i = rowIndices[idx];
+            int j = colIndices[idx];
+            T sum = ops.Zero;
+            for (int k = 0; k < innerK; k++)
+            {
+                sum = ops.Add(sum, ops.Multiply(b[j, k], gradOutput[i, k]));
+            }
+            gradValues[idx] = sum;
+        }
+        var sparseGradA = new SparseTensor<T>(rows, columns, rowIndices, colIndices, gradValues);
+        AccumulateGrad(aSparse, sparseGradA, gradAccumulator, engine);
+
+        // dB is dense (full out × in); same as the standard SparseMatMul backward.
+        var aT = aSparse.ToDense();
+        aT = engine.TensorTranspose(aT);
+        var gradB = engine.TensorMatMul(aT, gradOutput);
+        AccumulateGrad(b, gradB, gradAccumulator, engine);
+        _ = output;
+    }
+
     private static void SparseMatMulBackward<T>(
         Tensor<T> gradOutput,
         Tensor<T>[] inputs,

--- a/src/AiDotNet.Tensors/Engines/Autodiff/SparseAutograd.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/SparseAutograd.cs
@@ -168,7 +168,7 @@ public static class SparseAutograd
 
         var ops = MathHelper.GetNumericOperations<T>();
         int nnz = rowIndices.Length;
-        int innerK = b._shape[1];
+        int innerK = b.Shape[1];
 
         // Compute dA over the pattern only — never materialises the
         // dense O(rows × columns) gradient.
@@ -187,10 +187,34 @@ public static class SparseAutograd
         var sparseGradA = new SparseTensor<T>(rows, columns, rowIndices, colIndices, gradValues);
         AccumulateGrad(aSparse, sparseGradA, gradAccumulator, engine);
 
-        // dB is dense (full out × in); same as the standard SparseMatMul backward.
-        var aT = aSparse.ToDense();
-        aT = engine.TensorTranspose(aT);
-        var gradB = engine.TensorMatMul(aT, gradOutput);
+        // dB = A^T · dY computed as a sparse-transpose · dense matmul,
+        // i.e. iterate the sparse pattern of A and accumulate into a
+        // dense [columns × innerK] gradient. This avoids the O(rows × columns)
+        // densification that materialising A and transposing it would
+        // incur — the whole memory-efficiency point of the
+        // pattern-preserving op. Pulls A's values from saved state? — no,
+        // A is the trainable parameter, so its current values
+        // (which the user hasn't yet updated this step) are still the
+        // ones used in forward. Read them via the sparse indexer.
+        var gradB = new Tensor<T>(new[] { columns, innerK });
+        var gradBSpan = gradB.AsWritableSpan();
+        // gradB starts zero (Tensor ctor zero-fills); accumulate
+        //   gradB[j, k] += A_value[idx] · dY[i, k]    where (i, j) ∈ pattern_A
+        // Equivalent to A^T · dY without materialising the dense A.
+        var aValues = aSparse.DataVector.AsSpan().Slice(aSparse._storageOffset, nnz);
+        for (int idx = 0; idx < nnz; idx++)
+        {
+            int i = rowIndices[idx];
+            int j = colIndices[idx];
+            T aVal = aValues[idx];
+            int rowStart = j * innerK;
+            for (int k = 0; k < innerK; k++)
+            {
+                gradBSpan[rowStart + k] = ops.Add(
+                    gradBSpan[rowStart + k],
+                    ops.Multiply(aVal, gradOutput[i, k]));
+            }
+        }
         AccumulateGrad(b, gradB, gradAccumulator, engine);
         _ = output;
     }

--- a/src/AiDotNet.Tensors/LinearAlgebra/SparseTensor.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/SparseTensor.cs
@@ -131,6 +131,45 @@ public class SparseTensor<T> : Tensor<T>
         BlockColSize = 0;
     }
 
+    /// <summary>
+    /// Creates a COO-format sparse tensor whose <c>Values</c> backing
+    /// vector is a caller-supplied <see cref="Vector{T}"/>. Use this
+    /// (paired with <see cref="Vector{T}.CreateSlice"/>) to construct
+    /// a sparse tensor that shares value storage with another vector —
+    /// the contract <see cref="ParameterBuffer{T}.CreateView"/> relies
+    /// on for live, zero-copy sparse views over the parameter buffer.
+    /// </summary>
+    /// <remarks>
+    /// Unlike the <c>T[]</c> overload, this ctor does NOT wrap-then-copy:
+    /// mutations to the supplied vector are reflected in the sparse
+    /// tensor and vice versa. <paramref name="valuesVector"/> must have
+    /// length equal to <paramref name="rowIndices"/>.Length.
+    /// </remarks>
+    public SparseTensor(int rows, int columns, int[] rowIndices, int[] columnIndices, Vector<T> valuesVector)
+        : base(valuesVector ?? throw new ArgumentNullException(nameof(valuesVector)),
+               new[] { rows, columns }, isSparse: true)
+    {
+        if (rowIndices is null)
+            throw new ArgumentNullException(nameof(rowIndices));
+        if (columnIndices is null)
+            throw new ArgumentNullException(nameof(columnIndices));
+        if (rowIndices.Length != columnIndices.Length || rowIndices.Length != valuesVector.Length)
+            throw new ArgumentException(
+                "COO indices and values vector must have the same length: " +
+                $"rowIndices.Length={rowIndices.Length}, columnIndices.Length={columnIndices.Length}, " +
+                $"valuesVector.Length={valuesVector.Length}.");
+
+        Rows = rows;
+        Columns = columns;
+        RowIndices = rowIndices;
+        ColumnIndices = columnIndices;
+        RowPointers = Array.Empty<int>();
+        ColumnPointers = Array.Empty<int>();
+        Format = SparseStorageFormat.Coo;
+        BlockRowSize = 0;
+        BlockColSize = 0;
+    }
+
     private SparseTensor(int rows, int columns, SparseStorageFormat format,
         int[] rowIndices, int[] columnIndices, int[] rowPointers, int[] columnPointers, T[] values,
         int blockRowSize = 0, int blockColSize = 0)

--- a/src/AiDotNet.Tensors/LinearAlgebra/Vector.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/Vector.cs
@@ -241,7 +241,13 @@ public class Vector<T> : VectorBase<T>, IEnumerable<T>
         if (offset + length > Length)
             throw new ArgumentOutOfRangeException(nameof(length),
                 $"Slice [{offset}, {offset + length}) extends beyond vector length {Length}.");
-        return new Vector<T>(_memory.Slice(offset, length), false);
+        // GPU-resident / lazy vectors leave _memory empty until CPU
+        // access. Slicing _memory directly would silently slice
+        // Memory<T>.Empty and throw on subsequent reads. Force
+        // materialisation through AsWritableMemory() so the slice is
+        // backed by real CPU storage. Mirrors the behaviour AsSpan() /
+        // AsMemory() use on the same lazy-allocation path.
+        return new Vector<T>(AsWritableMemory().Slice(offset, length), false);
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/LinearAlgebra/Vector.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/Vector.cs
@@ -218,6 +218,33 @@ public class Vector<T> : VectorBase<T>, IEnumerable<T>
     }
 
     /// <summary>
+    /// Returns a new <see cref="Vector{T}"/> that shares storage with this
+    /// vector over the slice <c>[offset, offset + length)</c>. Mutations
+    /// to the returned vector are visible through the original vector and
+    /// vice versa — true zero-copy view, not a copy. Used by
+    /// <see cref="ParameterBuffer{T}"/>'s sparse-leaf <c>CreateView</c>
+    /// to hand out a <see cref="SparseTensor{T}"/> whose <c>Values</c>
+    /// stay live with the buffer.
+    /// </summary>
+    /// <param name="offset">First element index of the slice.</param>
+    /// <param name="length">Length of the slice.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="offset"/> or <paramref name="length"/>
+    /// is negative, or when the slice extends beyond this vector.
+    /// </exception>
+    public Vector<T> CreateSlice(int offset, int length)
+    {
+        if (offset < 0)
+            throw new ArgumentOutOfRangeException(nameof(offset), "Offset must be non-negative.");
+        if (length < 0)
+            throw new ArgumentOutOfRangeException(nameof(length), "Length must be non-negative.");
+        if (offset + length > Length)
+            throw new ArgumentOutOfRangeException(nameof(length),
+                $"Slice [{offset}, {offset + length}) extends beyond vector length {Length}.");
+        return new Vector<T>(_memory.Slice(offset, length), false);
+    }
+
+    /// <summary>
     /// Creates a vector from pooled memory. The pooled array is tracked for return to the pool.
     /// </summary>
     /// <param name="memory">The sliced memory (exact size) to use as backing store.</param>

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/SparseAwareParameterBufferTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/SparseAwareParameterBufferTests.cs
@@ -284,6 +284,190 @@ public class SparseAwareParameterBufferTests
     /// SparseLinearLayer can train via TrainWithTape with a sparse-aware
     /// ParameterBuffer.
     /// </summary>
+    /// <summary>
+    /// Pattern-preserving SpGeMM (sparse · sparse) backward: produces
+    /// SPARSE gradients on BOTH sides matching their respective patterns.
+    /// Verifies dA and dB values against the analytic formulas.
+    ///
+    /// A is 2×3 with pattern (0,0), (0,1), (1,2); values 1, 2, 3.
+    /// B is 3×2 with pattern (0,0), (1,0), (2,1); values 4, 5, 6.
+    /// Forward dense Y = A·B at (0,0) = 1·4 + 2·5 = 14, etc.
+    /// </summary>
+    [Fact]
+    public void SparsePatternPreservingSpGeMMRecord_BothSidesGetPatternMatchingSparseGrads()
+    {
+        var a = new SparseTensor<float>(2, 3,
+            new[] { 0, 0, 1 }, new[] { 0, 1, 2 }, new[] { 1f, 2f, 3f });
+        var b = new SparseTensor<float>(3, 2,
+            new[] { 0, 1, 2 }, new[] { 0, 0, 1 }, new[] { 4f, 5f, 6f });
+
+        using var tape = new GradientTape<float>();
+        var output = SparseAutograd.SparsePatternPreservingSpGeMMRecord(a, b);
+        var loss = _engine.ReduceSum(output, axes: null, keepDims: false);
+        var grads = tape.ComputeGradients(loss, new Tensor<float>[] { a, b });
+
+        Assert.True(grads.ContainsKey(a));
+        Assert.True(grads.ContainsKey(b));
+        var gradA = (SparseTensor<float>)grads[a];
+        var gradB = (SparseTensor<float>)grads[b];
+
+        Assert.Equal(3, gradA.NonZeroCount);
+        Assert.Equal(3, gradB.NonZeroCount);
+
+        // gradOut is all-ones; dA[i,j] = sum_k B[j,k] · 1 = sum_k B[j,k].
+        //   pattern (0,0): row 0 of B has only B[0,0]=4 → dA = 4
+        //   pattern (0,1): row 1 of B has only B[1,0]=5 → dA = 5
+        //   pattern (1,2): row 2 of B has only B[2,1]=6 → dA = 6
+        Assert.Equal(4f, gradA[0, 0], 5);
+        Assert.Equal(5f, gradA[0, 1], 5);
+        Assert.Equal(6f, gradA[1, 2], 5);
+
+        // dB[j,k] = sum_i A[i,j] · 1 = sum over i where (i,j) ∈ A.
+        //   pattern (0,0): col 0 of A has only A[0,0]=1 → dB = 1
+        //   pattern (1,0): col 1 of A has only A[0,1]=2 → dB = 2
+        //   pattern (2,1): col 2 of A has only A[1,2]=3 → dB = 3
+        Assert.Equal(1f, gradB[0, 0], 5);
+        Assert.Equal(2f, gradB[1, 0], 5);
+        Assert.Equal(3f, gradB[2, 1], 5);
+    }
+
+    /// <summary>
+    /// Variable-sparsity-pattern in-place rebuild: same NonZeroCount,
+    /// new positions. Mirrors dynamic-sparse training (SET / RigL /
+    /// RigL+ / threshold pruning) where the sparsity ratio stays fixed
+    /// but the active connections move between optimizer steps.
+    /// </summary>
+    [Fact]
+    public void RebuildSparsePattern_SameNonZeroCount_InPlaceUpdate()
+    {
+        var oldPattern = new SparsityLayout(3, 3, new[] { 0, 1, 2 }, new[] { 0, 1, 2 });
+        var buffer = new ParameterBuffer<float>(new[]
+        {
+            new ParameterLayout(new[] { 3, 3 }, oldPattern),
+        });
+
+        var span = buffer.GetSparseValuesSpan(0);
+        span[0] = 1f; span[1] = 2f; span[2] = 3f;
+
+        // Rebuild pattern: same nnz=3 but different positions.
+        var newPattern = new SparsityLayout(3, 3, new[] { 0, 1, 2 }, new[] { 2, 0, 1 });
+        buffer.RebuildSparsePattern(0, newPattern, new float[] { 7f, 8f, 9f });
+
+        Assert.Equal(3, buffer.GetSparseLayout(0)!.NonZeroCount);
+        var view = (SparseTensor<float>)buffer.CreateView(0);
+        Assert.Equal(7f, view[0, 2]);
+        Assert.Equal(8f, view[1, 0]);
+        Assert.Equal(9f, view[2, 1]);
+        // Old positions are now structural zero.
+        Assert.Equal(0f, view[0, 0]);
+    }
+
+    /// <summary>
+    /// RebuildSparsePattern rejects a new pattern whose NonZeroCount
+    /// differs — caller must use ResizeSparseLeaf for that.
+    /// </summary>
+    [Fact]
+    public void RebuildSparsePattern_NonZeroCountMismatch_Throws()
+    {
+        var oldPattern = new SparsityLayout(3, 3, new[] { 0, 1, 2 }, new[] { 0, 1, 2 });
+        var buffer = new ParameterBuffer<float>(new[]
+        {
+            new ParameterLayout(new[] { 3, 3 }, oldPattern),
+        });
+
+        var biggerPattern = new SparsityLayout(3, 3,
+            new[] { 0, 1, 2, 0 }, new[] { 0, 1, 2, 1 });
+        Assert.Throws<ArgumentException>(() =>
+            buffer.RebuildSparsePattern(0, biggerPattern));
+    }
+
+    /// <summary>
+    /// ResizeSparseLeaf — full variable-pattern support: NonZeroCount
+    /// can grow or shrink. Buffer is reallocated; subsequent leaves'
+    /// offsets shift by the delta. Other leaves' values preserved.
+    /// </summary>
+    [Fact]
+    public void ResizeSparseLeaf_GrowSlot_PreservesOtherLeavesAndShiftsOffsets()
+    {
+        var pattern0 = new SparsityLayout(3, 3, new[] { 0, 1 }, new[] { 0, 1 });   // nnz=2
+        var buffer = new ParameterBuffer<float>(new[]
+        {
+            new ParameterLayout(new[] { 3, 3 }, pattern0),     // sparse, nnz=2
+            new ParameterLayout(new[] { 4 }),                  // dense, size=4
+        });
+
+        // Seed: sparse leaf 0 with [1, 2], dense leaf 1 with [10, 20, 30, 40].
+        var s0 = buffer.GetSparseValuesSpan(0);
+        s0[0] = 1f; s0[1] = 2f;
+        var d1 = buffer.CreateView(1);
+        d1[0] = 10f; d1[1] = 20f; d1[2] = 30f; d1[3] = 40f;
+
+        Assert.Equal(0, buffer.GetOffset(0));   // first leaf always at offset 0
+        Assert.Equal(2, buffer.GetOffset(1));   // dense leaf starts after sparse nnz=2
+
+        // Grow the sparse leaf to nnz=5.
+        var newPattern = new SparsityLayout(3, 3,
+            new[] { 0, 0, 1, 1, 2 }, new[] { 0, 1, 0, 2, 2 });
+        buffer.ResizeSparseLeaf(0, newPattern,
+            new float[] { 100f, 200f, 300f, 400f, 500f });
+
+        // Leaf 0 now has nnz=5; leaf 1's offset shifts by +3.
+        Assert.Equal(5, buffer.GetSparseLayout(0)!.NonZeroCount);
+        Assert.Equal(0, buffer.GetOffset(0));
+        Assert.Equal(5, buffer.GetOffset(1));
+
+        // Sparse values updated.
+        var view0 = (SparseTensor<float>)buffer.CreateView(0);
+        Assert.Equal(100f, view0[0, 0]);
+        Assert.Equal(200f, view0[0, 1]);
+        Assert.Equal(300f, view0[1, 0]);
+        Assert.Equal(400f, view0[1, 2]);
+        Assert.Equal(500f, view0[2, 2]);
+
+        // Dense leaf preserved across resize.
+        var view1 = buffer.CreateView(1);
+        Assert.Equal(10f, view1[0]);
+        Assert.Equal(20f, view1[1]);
+        Assert.Equal(30f, view1[2]);
+        Assert.Equal(40f, view1[3]);
+
+        // Total size grew by delta.
+        Assert.Equal(9, buffer.TotalSize); // 5 (sparse new) + 4 (dense)
+    }
+
+    /// <summary>
+    /// ResizeSparseLeaf shrinking case (NonZeroCount decreases).
+    /// </summary>
+    [Fact]
+    public void ResizeSparseLeaf_ShrinkSlot_ShiftsOffsetsBack()
+    {
+        var pattern0 = new SparsityLayout(3, 3,
+            new[] { 0, 0, 1, 2 }, new[] { 0, 1, 1, 2 });   // nnz=4
+        var buffer = new ParameterBuffer<float>(new[]
+        {
+            new ParameterLayout(new[] { 3, 3 }, pattern0),     // sparse, nnz=4
+            new ParameterLayout(new[] { 2 }),                  // dense, size=2
+        });
+
+        var d1 = buffer.CreateView(1);
+        d1[0] = 7f; d1[1] = 9f;
+
+        var newPattern = new SparsityLayout(3, 3, new[] { 0, 2 }, new[] { 0, 2 }); // nnz=2
+        buffer.ResizeSparseLeaf(0, newPattern, new float[] { 11f, 22f });
+
+        Assert.Equal(2, buffer.GetSparseLayout(0)!.NonZeroCount);
+        Assert.Equal(2, buffer.GetOffset(1)); // shifted back from 4 to 2
+        Assert.Equal(4, buffer.TotalSize);    // 2 sparse + 2 dense
+
+        var view0 = (SparseTensor<float>)buffer.CreateView(0);
+        Assert.Equal(11f, view0[0, 0]);
+        Assert.Equal(22f, view0[2, 2]);
+
+        var view1 = buffer.CreateView(1);
+        Assert.Equal(7f, view1[0]);
+        Assert.Equal(9f, view1[1]);
+    }
+
     [Fact]
     public void SparsePatternPreservingMatMul_IntegratesWithSparseAwareBuffer()
     {

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/SparseAwareParameterBufferTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/SparseAwareParameterBufferTests.cs
@@ -83,6 +83,82 @@ public class SparseAwareParameterBufferTests
     }
 
     /// <summary>
+    /// True zero-copy contract for sparse leaves: writes to the buffer
+    /// flow through to a previously-obtained CreateView, AND writes to
+    /// the SparseTensor's underlying values vector flow back to the
+    /// buffer. Mirrors the dense-leaf contract that callers depend on.
+    /// </summary>
+    [Fact]
+    public void CreateView_SparseLeaf_IsLiveZeroCopyView()
+    {
+        var pattern = new SparsityLayout(3, 3,
+            new[] { 0, 1, 2 }, new[] { 0, 1, 2 });
+        var buffer = new ParameterBuffer<float>(new[]
+        {
+            new ParameterLayout(new[] { 3, 3 }, pattern),
+        });
+
+        // Get a view, then mutate the buffer.
+        var view = (SparseTensor<float>)buffer.CreateView(0);
+        var bufferSpan = buffer.GetSparseValuesSpan(0);
+        bufferSpan[0] = 11f;
+        bufferSpan[1] = 22f;
+        bufferSpan[2] = 33f;
+
+        // The view sees the new values WITHOUT being re-fetched.
+        Assert.Equal(11f, view[0, 0]);
+        Assert.Equal(22f, view[1, 1]);
+        Assert.Equal(33f, view[2, 2]);
+
+        // Writes through the view's underlying values vector flow back
+        // into the buffer.
+        view.DataVector.AsWritableSpan()[0] = 100f;
+        Assert.Equal(100f, buffer.GetSparseValuesReadOnlySpan(0)[0]);
+    }
+
+    /// <summary>
+    /// SparsityLayout clones index arrays so external mutations to the
+    /// caller's array don't desynchronise the layout from buffer slots
+    /// that depend on its indices being immutable.
+    /// </summary>
+    [Fact]
+    public void SparsityLayout_Ctor_ClonesIndexArrays()
+    {
+        var rowIdx = new[] { 0, 1, 2 };
+        var colIdx = new[] { 0, 1, 2 };
+        var layout = new SparsityLayout(3, 3, rowIdx, colIdx);
+
+        // Mutate the caller's arrays — must not affect the layout.
+        rowIdx[0] = 99;
+        colIdx[0] = 99;
+
+        Assert.Equal(0, layout.RowIndices[0]);
+        Assert.Equal(0, layout.ColumnIndices[0]);
+    }
+
+    /// <summary>
+    /// Sparse-only buffer with a very large dense semantic shape: the
+    /// dense product would exceed int.MaxValue but the buffer should
+    /// allocate based on NonZeroCount only. The whole point of sparse
+    /// leaves is to express huge sparse matrices without paying dense
+    /// memory cost.
+    /// </summary>
+    [Fact]
+    public void Ctor_SparseLeaf_LargeDenseShape_DoesNotOverflowOnDenseProduct()
+    {
+        // 50,000 × 50,000 = 2.5e9 (overflows int) — but only 4 non-zeros.
+        var pattern = new SparsityLayout(50_000, 50_000,
+            new[] { 0, 1, 2, 3 }, new[] { 0, 1, 2, 3 });
+        var buffer = new ParameterBuffer<float>(new[]
+        {
+            new ParameterLayout(new[] { 50_000, 50_000 }, pattern),
+        });
+
+        Assert.Equal(4, buffer.TotalSize);
+        Assert.True(buffer.IsSparse(0));
+    }
+
+    /// <summary>
     /// CreateView for a sparse leaf returns a SparseTensor whose Values
     /// reflect the buffer's current contents at the layout's pattern
     /// positions, with the recorded RowIndices / ColumnIndices.

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/SparseAwareParameterBufferTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/SparseAwareParameterBufferTests.cs
@@ -1,0 +1,318 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+/// <summary>
+/// Issue #286 — sparse-aware <see cref="ParameterBuffer{T}"/> +
+/// pattern-preserving sparse·dense matmul autograd op.
+///
+/// Together these unblock <c>SparseLinearLayer</c> integration with
+/// <c>TrainWithTape</c> in the AiDotNet repo without paying the
+/// O(rows × columns) memory cost of a dense parameter shadow.
+/// </summary>
+public class SparseAwareParameterBufferTests
+{
+    private readonly IEngine _engine = AiDotNetEngine.Current;
+
+    private static SparsityLayout PatternFor(SparseTensor<float> source) =>
+        SparsityLayout.FromSparseTensor(source);
+
+    /// <summary>
+    /// Buffer-slot sizing for sparse leaves: a 4×4 sparse identity matrix
+    /// (NonZeroCount = 4) should occupy 4 buffer slots, NOT 16. The whole
+    /// point of the new ctor is to skip the dense O(rows × columns)
+    /// allocation that the original API forced for sparse leaves.
+    /// </summary>
+    [Fact]
+    public void Ctor_SparseLeaf_AllocatesNonZeroCountSlotsOnly()
+    {
+        var pattern = new SparsityLayout(4, 4,
+            new[] { 0, 1, 2, 3 }, new[] { 0, 1, 2, 3 });
+        var layouts = new[]
+        {
+            new ParameterLayout(new[] { 4, 4 }, pattern),
+        };
+        var buffer = new ParameterBuffer<float>(layouts);
+
+        Assert.Equal(4, buffer.TotalSize);
+        Assert.True(buffer.IsSparse(0));
+        Assert.Equal(4, buffer.GetSparseLayout(0)!.NonZeroCount);
+    }
+
+    /// <summary>
+    /// Mixed dense + sparse layouts: each occupies its own slot at the
+    /// correct buffer offset. Catches an off-by-one in offset arithmetic
+    /// when the slot size depends on the layout type.
+    /// </summary>
+    [Fact]
+    public void Ctor_MixedDenseAndSparse_OffsetsAreContiguous()
+    {
+        var pattern = new SparsityLayout(3, 3,
+            new[] { 0, 1, 2 }, new[] { 0, 1, 2 });
+        var layouts = new[]
+        {
+            new ParameterLayout(new[] { 2, 5 }),                    // dense slot: 10
+            new ParameterLayout(new[] { 3, 3 }, pattern),           // sparse slot: 3
+            new ParameterLayout(new[] { 4 }),                       // dense slot: 4
+        };
+        var buffer = new ParameterBuffer<float>(layouts);
+
+        Assert.Equal(17, buffer.TotalSize); // 10 + 3 + 4
+        Assert.Equal(0, buffer.GetOffset(0));
+        Assert.Equal(10, buffer.GetOffset(1));
+        Assert.Equal(13, buffer.GetOffset(2));
+        Assert.False(buffer.IsSparse(0));
+        Assert.True(buffer.IsSparse(1));
+        Assert.False(buffer.IsSparse(2));
+    }
+
+    /// <summary>
+    /// Ctor must reject a sparse layout whose dense shape mismatches the
+    /// pattern's (rows, columns).
+    /// </summary>
+    [Fact]
+    public void Ctor_SparseShapeMismatch_Throws()
+    {
+        var pattern = new SparsityLayout(3, 3, new[] { 0 }, new[] { 0 });
+        Assert.Throws<ArgumentException>(() =>
+            new ParameterLayout(new[] { 4, 4 }, pattern));
+    }
+
+    /// <summary>
+    /// CreateView for a sparse leaf returns a SparseTensor whose Values
+    /// reflect the buffer's current contents at the layout's pattern
+    /// positions, with the recorded RowIndices / ColumnIndices.
+    /// </summary>
+    [Fact]
+    public void CreateView_SparseLeaf_ReturnsSparseTensorWithLayoutPattern()
+    {
+        var rowIdx = new[] { 0, 1, 2 };
+        var colIdx = new[] { 1, 2, 0 };
+        var pattern = new SparsityLayout(3, 3, rowIdx, colIdx);
+        var buffer = new ParameterBuffer<float>(new[]
+        {
+            new ParameterLayout(new[] { 3, 3 }, pattern),
+        });
+
+        // Seed the buffer slot directly via the values span.
+        var slot = buffer.GetSparseValuesSpan(0);
+        slot[0] = 7f;
+        slot[1] = 8f;
+        slot[2] = 9f;
+
+        var view = (SparseTensor<float>)buffer.CreateView(0);
+        Assert.Equal(3, view.Rows);
+        Assert.Equal(3, view.Columns);
+        Assert.Equal(3, view.NonZeroCount);
+        Assert.Equal(7f, view[0, 1]);
+        Assert.Equal(8f, view[1, 2]);
+        Assert.Equal(9f, view[2, 0]);
+        Assert.Equal(0f, view[0, 0]); // structural zero
+    }
+
+    /// <summary>
+    /// CopyFrom(IReadOnlyList&lt;Tensor&lt;T&gt;&gt;) for a sparse leaf
+    /// must reject inputs whose pattern differs from the layout — the
+    /// sparsity pattern is fixed at construction.
+    /// </summary>
+    [Fact]
+    public void CopyFrom_SparseLeaf_RejectsPatternMismatch()
+    {
+        var pattern = new SparsityLayout(3, 3, new[] { 0, 1 }, new[] { 0, 1 });
+        var buffer = new ParameterBuffer<float>(new[]
+        {
+            new ParameterLayout(new[] { 3, 3 }, pattern),
+        });
+
+        // Different pattern — should throw.
+        var differentPattern = new SparseTensor<float>(3, 3,
+            new[] { 0, 2 }, new[] { 0, 2 }, new[] { 1f, 2f });
+        Assert.Throws<ArgumentException>(() =>
+            buffer.CopyFrom(new Tensor<float>[] { differentPattern }));
+    }
+
+    /// <summary>
+    /// CopyFrom for a sparse leaf with matching pattern copies the
+    /// Values into the buffer. Round-trip via CreateView.
+    /// </summary>
+    [Fact]
+    public void CopyFrom_SparseLeaf_PatternMatch_CopiesValues()
+    {
+        var pattern = new SparsityLayout(3, 3, new[] { 0, 1, 2 }, new[] { 0, 1, 2 });
+        var buffer = new ParameterBuffer<float>(new[]
+        {
+            new ParameterLayout(new[] { 3, 3 }, pattern),
+        });
+
+        var src = new SparseTensor<float>(3, 3,
+            new[] { 0, 1, 2 }, new[] { 0, 1, 2 }, new[] { 10f, 20f, 30f });
+        buffer.CopyFrom(new Tensor<float>[] { src });
+
+        var view = (SparseTensor<float>)buffer.CreateView(0);
+        Assert.Equal(10f, view[0, 0]);
+        Assert.Equal(20f, view[1, 1]);
+        Assert.Equal(30f, view[2, 2]);
+    }
+
+    /// <summary>
+    /// FlattenGradients for a sparse leaf with a matching-pattern sparse
+    /// gradient: pulls Values directly into the slot.
+    /// </summary>
+    [Fact]
+    public void FlattenGradients_SparseLeaf_SparseGradMatchingPattern_CopiesValues()
+    {
+        var pattern = new SparsityLayout(3, 3, new[] { 0, 1, 2 }, new[] { 0, 1, 2 });
+        var buffer = new ParameterBuffer<float>(new[]
+        {
+            new ParameterLayout(new[] { 3, 3 }, pattern),
+        });
+
+        // The "parameter" we pass in is the SparseTensor used as the
+        // gradient-dictionary key.
+        var paramTensor = new SparseTensor<float>(3, 3,
+            new[] { 0, 1, 2 }, new[] { 0, 1, 2 }, new[] { 0f, 0f, 0f });
+        var gradTensor = new SparseTensor<float>(3, 3,
+            new[] { 0, 1, 2 }, new[] { 0, 1, 2 }, new[] { 0.1f, 0.2f, 0.3f });
+
+        var grads = new System.Collections.Generic.Dictionary<Tensor<float>, Tensor<float>>
+        {
+            { paramTensor, gradTensor },
+        };
+
+        var flat = buffer.FlattenGradients(new Tensor<float>[] { paramTensor }, grads);
+        Assert.Equal(3, flat.Length);
+        Assert.Equal(0.1f, flat[0]);
+        Assert.Equal(0.2f, flat[1]);
+        Assert.Equal(0.3f, flat[2]);
+    }
+
+    /// <summary>
+    /// FlattenGradients for a sparse leaf with a DENSE gradient (the
+    /// PyTorch-default backward form) projects only the values at the
+    /// pattern's positions. Values at structural-zero positions are
+    /// silently dropped — the layer only trains pattern positions.
+    /// </summary>
+    [Fact]
+    public void FlattenGradients_SparseLeaf_DenseGrad_ProjectsToPattern()
+    {
+        var pattern = new SparsityLayout(3, 3, new[] { 0, 1, 2 }, new[] { 0, 1, 2 });
+        var buffer = new ParameterBuffer<float>(new[]
+        {
+            new ParameterLayout(new[] { 3, 3 }, pattern),
+        });
+
+        var paramTensor = new SparseTensor<float>(3, 3,
+            new[] { 0, 1, 2 }, new[] { 0, 1, 2 }, new[] { 0f, 0f, 0f });
+        var denseGrad = new Tensor<float>(new[] { 3, 3 });
+        // Fill with a known pattern: G[i,j] = i*3 + j + 1
+        for (int i = 0; i < 3; i++)
+            for (int j = 0; j < 3; j++)
+                denseGrad[i, j] = i * 3 + j + 1;
+
+        var grads = new System.Collections.Generic.Dictionary<Tensor<float>, Tensor<float>>
+        {
+            { paramTensor, denseGrad },
+        };
+
+        var flat = buffer.FlattenGradients(new Tensor<float>[] { paramTensor }, grads);
+        // Pattern positions: (0,0), (1,1), (2,2) → 1, 5, 9
+        Assert.Equal(1f, flat[0]);
+        Assert.Equal(5f, flat[1]);
+        Assert.Equal(9f, flat[2]);
+    }
+
+    /// <summary>
+    /// End-to-end: pattern-preserving sparse·dense matmul forward +
+    /// backward via SparseAutograd.SparsePatternPreservingMatMulRecord.
+    /// The sparse gradient produced has matching pattern and Values
+    /// that ParameterBuffer.FlattenGradients copies into the buffer
+    /// slot. Verifies dY/dA[i,j] = sum_k B[j,k] · gradOut[i,k] over
+    /// pattern positions only.
+    /// </summary>
+    [Fact]
+    public void SparsePatternPreservingMatMulRecord_BackwardProducesPatternMatchingSparseGrad()
+    {
+        // A: 2×3 sparse with pattern at (0,0), (1,1), (1,2).
+        var aPattern = new SparseTensor<float>(2, 3,
+            new[] { 0, 1, 1 }, new[] { 0, 1, 2 }, new[] { 1f, 2f, 3f });
+
+        // B: 3×2 dense
+        var b = new Tensor<float>(new[] { 3, 2 });
+        b[0, 0] = 0.5f; b[0, 1] = 0.7f;
+        b[1, 0] = 1.0f; b[1, 1] = 1.5f;
+        b[2, 0] = 2.0f; b[2, 1] = 2.5f;
+
+        using var tape = new GradientTape<float>();
+        var output = SparseAutograd.SparsePatternPreservingMatMulRecord(aPattern, b);
+
+        // Force a non-trivial gradient by reducing over output.
+        // Here we just feed an explicit gradOut of all-ones to keep the
+        // expected math simple to reason about.
+        Assert.Equal(2, output.Shape[0]);
+        Assert.Equal(2, output.Shape[1]);
+
+        // Reduce: sum(output) → scalar. Backward propagates 1.0 to every
+        // output position.
+        var loss = _engine.ReduceSum(output, axes: null, keepDims: false);
+        var grads = tape.ComputeGradients(loss, new Tensor<float>[] { aPattern, b });
+
+        // gradA against aPattern should be a SparseTensor with same pattern.
+        Assert.True(grads.ContainsKey(aPattern));
+        var gradA = grads[aPattern];
+        Assert.True(gradA is SparseTensor<float>, "Expected pattern-preserving sparse gradient.");
+        var sparseGradA = (SparseTensor<float>)gradA;
+        Assert.Equal(3, sparseGradA.NonZeroCount);
+
+        // For gradOut = 1s everywhere: gradA[i,j] = sum_k B[j,k] · 1 = B[j,0] + B[j,1]
+        //   pattern (0,0): B[0,0] + B[0,1] = 0.5 + 0.7 = 1.2
+        //   pattern (1,1): B[1,0] + B[1,1] = 1.0 + 1.5 = 2.5
+        //   pattern (1,2): B[2,0] + B[2,1] = 2.0 + 2.5 = 4.5
+        Assert.Equal(1.2f, sparseGradA[0, 0], 5);
+        Assert.Equal(2.5f, sparseGradA[1, 1], 5);
+        Assert.Equal(4.5f, sparseGradA[1, 2], 5);
+    }
+
+    /// <summary>
+    /// End-to-end + ParameterBuffer integration: the sparse gradient
+    /// produced by SparsePatternPreservingMatMulRecord flows through
+    /// ParameterBuffer.FlattenGradients and lands in the right slot
+    /// without densification. This is the load-bearing test proving
+    /// SparseLinearLayer can train via TrainWithTape with a sparse-aware
+    /// ParameterBuffer.
+    /// </summary>
+    [Fact]
+    public void SparsePatternPreservingMatMul_IntegratesWithSparseAwareBuffer()
+    {
+        var rowIdx = new[] { 0, 1, 1 };
+        var colIdx = new[] { 0, 1, 2 };
+        var aValues = new[] { 1f, 2f, 3f };
+        var aPattern = new SparseTensor<float>(2, 3, rowIdx, colIdx, aValues);
+
+        var buffer = new ParameterBuffer<float>(new[]
+        {
+            new ParameterLayout(new[] { 2, 3 }, SparsityLayout.FromSparseTensor(aPattern)),
+        });
+        buffer.CopyFrom(new Tensor<float>[] { aPattern });
+
+        var b = new Tensor<float>(new[] { 3, 2 });
+        b[0, 0] = 0.5f; b[0, 1] = 0.7f;
+        b[1, 0] = 1.0f; b[1, 1] = 1.5f;
+        b[2, 0] = 2.0f; b[2, 1] = 2.5f;
+
+        using var tape = new GradientTape<float>();
+        var output = SparseAutograd.SparsePatternPreservingMatMulRecord(aPattern, b);
+        var loss = _engine.ReduceSum(output, axes: null, keepDims: false);
+        var grads = tape.ComputeGradients(loss, new Tensor<float>[] { aPattern, b });
+
+        var flat = buffer.FlattenGradients(new Tensor<float>[] { aPattern }, grads);
+        Assert.Equal(3, flat.Length);
+        // Same expected values as the previous test.
+        Assert.Equal(1.2f, flat[0], 5);
+        Assert.Equal(2.5f, flat[1], 5);
+        Assert.Equal(4.5f, flat[2], 5);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/SparseAwareParameterBufferTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/SparseAwareParameterBufferTests.cs
@@ -353,14 +353,6 @@ public class SparseAwareParameterBufferTests
     }
 
     /// <summary>
-    /// End-to-end + ParameterBuffer integration: the sparse gradient
-    /// produced by SparsePatternPreservingMatMulRecord flows through
-    /// ParameterBuffer.FlattenGradients and lands in the right slot
-    /// without densification. This is the load-bearing test proving
-    /// SparseLinearLayer can train via TrainWithTape with a sparse-aware
-    /// ParameterBuffer.
-    /// </summary>
-    /// <summary>
     /// Pattern-preserving SpGeMM (sparse · sparse) backward: produces
     /// SPARSE gradients on BOTH sides matching their respective patterns.
     /// Verifies dA and dB values against the analytic formulas.


### PR DESCRIPTION
Closes #286.

## Summary

Unblocks `SparseLinearLayer<T>` tape-based training in [ooples/AiDotNet#1231](https://github.com/ooples/AiDotNet/pull/1231) without paying the `O(rows × columns)` memory cost of a dense parameter shadow. Three coordinated changes:

### 1. `ParameterBuffer<T>` sparse-aware storage

New `ParameterLayout` / `SparsityLayout` types describe per-leaf storage. Dense leaves use the historical full-shape slot; sparse leaves allocate only `NonZeroCount` worth of buffer space.

- New ctor `ParameterBuffer(IReadOnlyList<ParameterLayout>)`. Original shape-only ctor preserved for backward compatibility (delegates with all-dense layouts).
- `CreateView` returns `SparseTensor<T>` for sparse leaves, `Tensor<T>` for dense leaves. `GetSparseValuesSpan` / `-ReadOnlySpan` give zero-copy access to the buffer slot.
- `CopyFrom(IReadOnlyList<Tensor<T>>)` validates sparsity pattern at the leaf level (caller can opt out by using `RebuildSparsePattern` / `ResizeSparseLeaf` if intentional).
- `FlattenGradients` handles both sparse-form and dense-form gradients for sparse leaves.

### 2. Pattern-preserving sparse matmul autograd ops

**`SparsePatternPreservingMatMulRecord`** — sparse · dense. Backward produces a `SparseTensor<T>` gradient with the same pattern as `a` (values computed at `O(NonZeroCount)` pattern positions instead of materializing the full `O(rows × columns)` dense gradient).

**`SparsePatternPreservingSpGeMMRecord`** — sparse · sparse. Backward produces a `SparseTensor<T>` gradient on **each** operand, matching that operand's own pattern. Uses precomputed B-row / A-column lookups so per-(i,j) sums scan only the actual non-zeros along the relevant axis.

Existing dense-grad variants (`SparseMatMulRecord`, `SparseSpGeMMRecord`) are untouched — kept for callers who don't have a sparse-aware buffer.

### 3. Variable-sparsity-pattern support

For dynamic-sparse training (SET / RigL / threshold pruning) where active positions move between optimizer steps:

- **`RebuildSparsePattern(index, newLayout, newValues)`** — in-place pattern swap when `NonZeroCount` is unchanged. Other leaves' offsets unaffected.
- **`ResizeSparseLeaf(index, newLayout, newValues)`** — full variable-pattern support. `NonZeroCount` can grow or shrink; buffer reallocates and subsequent leaves' offsets shift by the delta. Other leaves' values preserved.

`_data` / `_storage` / `_totalSize` lose the `readonly` modifier (commented inline) so `Resize` can mutate them without reflection. All other paths still treat them as immutable post-construction.

## Memory comparison (4096×4096 sparse linear, sparsity 0.99)

| Storage | Old API | This PR |
|---|---|---|
| Trainable parameter slot | 16,777,216 floats (dense slab) | 167,772 floats (NonZeroCount only) |
| Backward gradient allocation | 16,777,216 floats (dense) per step | 167,772 floats (sparse Values) per step |
| Total trainable+grad steady-state | 134 MB at fp64 | 1.34 MB at fp64 |

The 100× reduction matches the sparsity ratio.

## Tests (15 in `SparseAwareParameterBufferTests`)

- Ctor buffer-slot sizing for sparse leaves (allocates NonZeroCount, not rows×columns)
- Mixed dense+sparse layouts with contiguous offsets
- Ctor shape-mismatch rejection
- `CreateView` round-trip via the buffer
- `CopyFrom` pattern-mismatch rejection
- `CopyFrom` matching-pattern Values copy
- `FlattenGradients` matching-pattern sparse grad (Values copy)
- `FlattenGradients` dense grad → pattern projection
- `SparsePatternPreservingMatMulRecord` backward correctness vs analytic gradient
- ParameterBuffer integration with sparse-grad fast path
- `SparsePatternPreservingSpGeMMRecord` — both operands get pattern-matching sparse gradients
- `RebuildSparsePattern` in-place same-NNZ swap
- `RebuildSparsePattern` rejects NNZ mismatch
- `ResizeSparseLeaf` grow case (offset shift + value preservation)
- `ResizeSparseLeaf` shrink case

Verified: full `Engines.Autodiff` suite — 492 passed, 23 skipped, 0 failed.

## Cross-references

- Blocks: [ooples/AiDotNet#1231](https://github.com/ooples/AiDotNet/pull/1231) — `SparseNeuralNetwork.TrainWithTape` conversion lands once a Tensors release with this PR is wired in `Directory.Packages.props`.
- Pattern reference: PyTorch `torch.sparse` autograd (https://pytorch.org/docs/stable/sparse.html).

🤖 Generated with [Claude Code](https://claude.com/claude-code)