### PR TITLE
fix(#285): GPU buffer cap validation + chunked fallback across all backends

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -90,8 +90,9 @@ public sealed partial class CudaBackend : IAsyncGpuBackend
     /// <summary>
     /// CUDA does not expose a fixed per-allocation cap as a device attribute —
     /// in practice individual <c>cudaMalloc</c> calls are limited by the
-    /// largest contiguous free VRAM block. We use total free memory at init
-    /// as a conservative upper bound. Issue #285.
+    /// largest contiguous free VRAM block. We use the device's TOTAL VRAM
+    /// (from <c>cuDeviceTotalMem</c>) as a conservative upper bound — a
+    /// hard ceiling rather than a "current free memory" tracker. Issue #285.
     /// </summary>
     public long MaxBufferAllocBytes { get; }
     public double TheoreticalGflops { get; private set; }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -198,9 +198,13 @@ public sealed partial class CudaBackend : IAsyncGpuBackend
             GlobalMemoryBytes = (long)totalMem;
             // Issue #285: per-allocation cap. CUDA has no formal cap attribute;
             // practical limit is the largest contiguous free block. We use
-            // total VRAM as the upper bound and let the chunker fall back if
-            // a specific allocation fails (cudaErrorOutOfMemory propagates as
-            // GpuBufferTooLargeException via the buffer ctor guard).
+            // total VRAM as the upper bound. NOTE: this means the cap guard
+            // only catches obviously-impossible requests (> total VRAM). If
+            // a smaller-than-VRAM allocation hits cudaErrorOutOfMemory due
+            // to fragmentation, the existing CheckCudaResult path surfaces
+            // it as a generic CUDA error — the chunker won't catch that.
+            // Translating cuMemAlloc OOM → GpuBufferTooLargeException is
+            // tracked as follow-up work.
             MaxBufferAllocBytes = (long)totalMem;
 
             CuBlasNative.CheckCudaResult(CuBlasNative.cuCtxCreate(out _cudaContext, 0, device), "cuCtxCreate");

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -5192,6 +5192,8 @@ public sealed partial class CudaBackend : IAsyncGpuBackend
 
         if (size <= 0)
             throw new ArgumentOutOfRangeException(nameof(size), "Buffer size must be positive.");
+        // Issue #285: per-allocation cap check before cuMemAlloc.
+        GpuBufferSizeGuard.EnsureFits("CUDA", (long)size * sizeof(int), MaxBufferAllocBytes, DeviceName);
 
         using var _ = PushContext();
         ulong byteSize = (ulong)size * sizeof(int);
@@ -5204,12 +5206,16 @@ public sealed partial class CudaBackend : IAsyncGpuBackend
     {
         if (!IsAvailable)
             throw new InvalidOperationException("CUDA backend is not available.");
+        if (data is null)
+            throw new ArgumentNullException(nameof(data));
 
         using var _ = PushContext();
         int size = data.Length;
         if (size <= 0)
             throw new ArgumentOutOfRangeException(nameof(data), "Buffer size must be positive.");
         ulong byteSize = (ulong)size * sizeof(int);
+        // Issue #285: per-allocation cap check before cuMemAlloc.
+        GpuBufferSizeGuard.EnsureFits("CUDA", (long)byteSize, MaxBufferAllocBytes, DeviceName);
 
         CuBlasNative.CheckCudaResult(CuBlasNative.cuMemAlloc(out IntPtr devicePtr, byteSize), "cuMemAlloc(int)");
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -87,6 +87,13 @@ public sealed partial class CudaBackend : IAsyncGpuBackend
     public int ComputeUnits { get; }
     public long GlobalMemoryBytes { get; }
     public long LocalMemoryBytes { get; }
+    /// <summary>
+    /// CUDA does not expose a fixed per-allocation cap as a device attribute —
+    /// in practice individual <c>cudaMalloc</c> calls are limited by the
+    /// largest contiguous free VRAM block. We use total free memory at init
+    /// as a conservative upper bound. Issue #285.
+    /// </summary>
+    public long MaxBufferAllocBytes { get; }
     public double TheoreticalGflops { get; private set; }
 
     // IAsyncGpuBackend properties
@@ -189,6 +196,12 @@ public sealed partial class CudaBackend : IAsyncGpuBackend
 
             CuBlasNative.CheckCudaResult(CudaNativeBindings.cuDeviceTotalMem(out ulong totalMem, device), "cuDeviceTotalMem");
             GlobalMemoryBytes = (long)totalMem;
+            // Issue #285: per-allocation cap. CUDA has no formal cap attribute;
+            // practical limit is the largest contiguous free block. We use
+            // total VRAM as the upper bound and let the chunker fall back if
+            // a specific allocation fails (cudaErrorOutOfMemory propagates as
+            // GpuBufferTooLargeException via the buffer ctor guard).
+            MaxBufferAllocBytes = (long)totalMem;
 
             CuBlasNative.CheckCudaResult(CuBlasNative.cuCtxCreate(out _cudaContext, 0, device), "cuCtxCreate");
             CuBlasNative.CheckCudaResult(CudaNativeBindings.cuStreamCreate(out _stream, 0), "cuStreamCreate");
@@ -817,6 +830,8 @@ public sealed partial class CudaBackend : IAsyncGpuBackend
         if (size <= 0)
             throw new ArgumentOutOfRangeException(nameof(data), "Buffer size must be positive.");
         ulong byteSize = (ulong)size * sizeof(float);
+        // Issue #285: per-allocation cap check before cuMemAlloc.
+        GpuBufferSizeGuard.EnsureFits("CUDA", (long)byteSize, MaxBufferAllocBytes, DeviceName);
 
         // CUDA driver API calls are required for device memory operations.
         using var _ = PushContext();
@@ -864,6 +879,8 @@ public sealed partial class CudaBackend : IAsyncGpuBackend
 
         if (size <= 0)
             throw new ArgumentOutOfRangeException(nameof(size), "Buffer size must be positive.");
+        // Issue #285: per-allocation cap check before cuMemAlloc.
+        GpuBufferSizeGuard.EnsureFits("CUDA", (long)size * sizeof(float), MaxBufferAllocBytes, DeviceName);
 
         // CUDA driver API calls are required for device memory operations.
         using var _ = PushContext();
@@ -888,6 +905,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend
 
         if (size <= 0)
             throw new ArgumentOutOfRangeException(nameof(size), "Buffer size must be positive.");
+        GpuBufferSizeGuard.EnsureFits("CUDA", size, MaxBufferAllocBytes, DeviceName);
 
         using var _ = PushContext();
         CuBlasNative.CheckCudaResult(

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/GpuBufferSizeGuard.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/GpuBufferSizeGuard.cs
@@ -16,32 +16,40 @@ internal static class GpuBufferSizeGuard
 {
     /// <summary>
     /// Validates that a requested allocation in bytes fits under the
-    /// device's per-allocation cap.
+    /// device's per-allocation cap, AFTER applying any user override from
+    /// <see cref="GpuFallbackOptionsHolder.Current"/>.
     /// </summary>
     /// <param name="backend">Backend identifier ("OpenCL", "CUDA", …) for diagnostics.</param>
     /// <param name="requestedBytes">Size of the allocation in bytes.</param>
-    /// <param name="cap">
-    /// Per-allocation cap in bytes. Pass 0 when the cap is unknown / not
-    /// queryable; the guard then skips validation and the native call's
-    /// error (if any) propagates naturally.
+    /// <param name="deviceCap">
+    /// Device-reported per-allocation cap in bytes (from
+    /// <see cref="IDirectGpuBackend.MaxBufferAllocBytes"/>). Pass 0 when the
+    /// cap is unknown / not queryable; the guard then defers to the user
+    /// override (<see cref="GpuFallbackOptions.MaxBufferBytes"/>) if any,
+    /// or skips validation when no override is set.
     /// </param>
     /// <param name="deviceName">Human-readable device name for diagnostics.</param>
     /// <exception cref="GpuBufferTooLargeException">
-    /// Thrown when <paramref name="requestedBytes"/> exceeds <paramref name="cap"/>.
+    /// Thrown when <paramref name="requestedBytes"/> exceeds the effective cap
+    /// (the lower of <paramref name="deviceCap"/> and the user override).
     /// </exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void EnsureFits(
         string backend,
         long requestedBytes,
-        long cap,
+        long deviceCap,
         string deviceName)
     {
-        if (cap > 0 && requestedBytes > 0 && requestedBytes > cap)
+        // Apply user override (GpuFallbackOptions.MaxBufferBytes). At runtime
+        // the override is typically null, so EffectiveMaxBufferBytes returns
+        // deviceCap unchanged — single null-coalesce, no allocations.
+        long effectiveCap = GpuFallbackOptionsHolder.Current.EffectiveMaxBufferBytes(deviceCap);
+        if (effectiveCap > 0 && requestedBytes > 0 && requestedBytes > effectiveCap)
         {
             throw new GpuBufferTooLargeException(
                 backend: backend,
                 requestedBytes: requestedBytes,
-                deviceMaxAllocBytes: cap,
+                deviceMaxAllocBytes: effectiveCap,
                 deviceName: deviceName);
         }
     }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/GpuBufferSizeGuard.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/GpuBufferSizeGuard.cs
@@ -1,0 +1,48 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System.Runtime.CompilerServices;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu;
+
+/// <summary>
+/// Issue #285: cross-backend pre-allocation size check. Each backend's
+/// buffer wrapper calls this from its constructor to fail fast with a
+/// typed <see cref="GpuBufferTooLargeException"/> when the requested
+/// allocation exceeds the device's per-allocation cap. The dispatch
+/// shim in <see cref="DirectGpuTensorEngine"/> catches this and falls
+/// through to chunked or CPU execution.
+/// </summary>
+internal static class GpuBufferSizeGuard
+{
+    /// <summary>
+    /// Validates that a requested allocation in bytes fits under the
+    /// device's per-allocation cap.
+    /// </summary>
+    /// <param name="backend">Backend identifier ("OpenCL", "CUDA", …) for diagnostics.</param>
+    /// <param name="requestedBytes">Size of the allocation in bytes.</param>
+    /// <param name="cap">
+    /// Per-allocation cap in bytes. Pass 0 when the cap is unknown / not
+    /// queryable; the guard then skips validation and the native call's
+    /// error (if any) propagates naturally.
+    /// </param>
+    /// <param name="deviceName">Human-readable device name for diagnostics.</param>
+    /// <exception cref="GpuBufferTooLargeException">
+    /// Thrown when <paramref name="requestedBytes"/> exceeds <paramref name="cap"/>.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void EnsureFits(
+        string backend,
+        long requestedBytes,
+        long cap,
+        string deviceName)
+    {
+        if (cap > 0 && requestedBytes > 0 && requestedBytes > cap)
+        {
+            throw new GpuBufferTooLargeException(
+                backend: backend,
+                requestedBytes: requestedBytes,
+                deviceMaxAllocBytes: cap,
+                deviceName: deviceName);
+        }
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/GpuBufferTooLargeException.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/GpuBufferTooLargeException.cs
@@ -76,9 +76,12 @@ public sealed class GpuBufferTooLargeException : InvalidOperationException
 
     private static string BytesToHuman(long bytes)
     {
-        if (bytes < 1024) return bytes + " B";
-        if (bytes < 1024L * 1024) return (bytes / 1024.0).ToString("F1") + " KiB";
-        if (bytes < 1024L * 1024 * 1024) return (bytes / (1024.0 * 1024)).ToString("F1") + " MiB";
-        return (bytes / (1024.0 * 1024 * 1024)).ToString("F2") + " GiB";
+        // Culture-invariant formatting — log files and structured tooling
+        // depend on stable decimal separators across locales.
+        var inv = System.Globalization.CultureInfo.InvariantCulture;
+        if (bytes < 1024) return bytes.ToString(inv) + " B";
+        if (bytes < 1024L * 1024) return (bytes / 1024.0).ToString("F1", inv) + " KiB";
+        if (bytes < 1024L * 1024 * 1024) return (bytes / (1024.0 * 1024)).ToString("F1", inv) + " MiB";
+        return (bytes / (1024.0 * 1024 * 1024)).ToString("F2", inv) + " GiB";
     }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/GpuBufferTooLargeException.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/GpuBufferTooLargeException.cs
@@ -1,0 +1,84 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu;
+
+/// <summary>
+/// Thrown when a single GPU buffer allocation would exceed the device's
+/// per-allocation cap (OpenCL's <c>CL_DEVICE_MAX_MEM_ALLOC_SIZE</c>, CUDA's
+/// per-allocation virtual address window, …). Distinct from a general
+/// out-of-memory: the device may have plenty of total memory free but
+/// refuse a single buffer larger than the cap.
+/// </summary>
+/// <remarks>
+/// Catch this in dispatch shims (e.g. <see cref="DirectGpuTensorEngine"/>)
+/// to fall through to a CPU path or chunked-GPU path instead of crashing
+/// the user's training run. The thrown exception carries the requested and
+/// device-cap byte counts so logs / telemetry can show the user a concrete
+/// "reduce batch size from X to Y" hint.
+/// </remarks>
+public sealed class GpuBufferTooLargeException : InvalidOperationException
+{
+    /// <summary>
+    /// Bytes the caller asked the backend to allocate as a single buffer.
+    /// </summary>
+    public long RequestedBytes { get; }
+
+    /// <summary>
+    /// Maximum bytes the device allows in a single allocation
+    /// (<c>CL_DEVICE_MAX_MEM_ALLOC_SIZE</c> on OpenCL, equivalent on other
+    /// backends). Zero when unknown / not queried.
+    /// </summary>
+    public long DeviceMaxAllocBytes { get; }
+
+    /// <summary>
+    /// Human-readable device name (e.g. "AMD Radeon RX 5500 XT") for use
+    /// in error messages and telemetry. Empty when unknown.
+    /// </summary>
+    public string DeviceName { get; }
+
+    /// <summary>
+    /// Backend identifier (e.g. "OpenCL", "CUDA"). Useful for logs that
+    /// span multiple backends.
+    /// </summary>
+    public string Backend { get; }
+
+    public GpuBufferTooLargeException(
+        string backend,
+        long requestedBytes,
+        long deviceMaxAllocBytes,
+        string deviceName)
+        : base(BuildMessage(backend, requestedBytes, deviceMaxAllocBytes, deviceName))
+    {
+        Backend = backend ?? string.Empty;
+        RequestedBytes = requestedBytes;
+        DeviceMaxAllocBytes = deviceMaxAllocBytes;
+        DeviceName = deviceName ?? string.Empty;
+    }
+
+    private static string BuildMessage(string backend, long requested, long cap, string deviceName)
+    {
+        string b = string.IsNullOrEmpty(backend) ? "GPU" : backend;
+        string device = string.IsNullOrEmpty(deviceName) ? "device" : deviceName;
+        if (cap > 0)
+        {
+            return $"{b} buffer allocation of {requested} bytes ({BytesToHuman(requested)}) " +
+                   $"exceeds {device}'s per-allocation cap of {cap} bytes ({BytesToHuman(cap)}). " +
+                   $"Reduce batch size or split the tensor — typical fixes: lower " +
+                   $"`maxSequenceLength`, `batchSize`, or model dimension; or call " +
+                   $"`ConfigureGpuAcceleration(new GpuAccelerationConfig {{ UsageLevel = GpuUsageLevel.AlwaysCpu }})` " +
+                   $"to disable GPU for this run.";
+        }
+        return $"{b} buffer allocation of {requested} bytes ({BytesToHuman(requested)}) " +
+               $"refused by {device} (per-allocation cap unknown).";
+    }
+
+    private static string BytesToHuman(long bytes)
+    {
+        if (bytes < 1024) return bytes + " B";
+        if (bytes < 1024L * 1024) return (bytes / 1024.0).ToString("F1") + " KiB";
+        if (bytes < 1024L * 1024 * 1024) return (bytes / (1024.0 * 1024)).ToString("F1") + " MiB";
+        return (bytes / (1024.0 * 1024 * 1024)).ToString("F2") + " GiB";
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/GpuFallbackOptions.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/GpuFallbackOptions.cs
@@ -90,8 +90,22 @@ public sealed class GpuFallbackOptions
 
     // ── Internal accessors that apply the industry-standard defaults ──
 
+    /// <summary>
+    /// Resolves the effective per-allocation cap. When a user-supplied
+    /// override (<see cref="MaxBufferBytes"/>) is set and is lower than
+    /// the device's reported cap, the override wins; when it's greater
+    /// than the device cap, the device cap wins (the device's actual
+    /// rejection is the hard limit and we can't allocate past it).
+    /// When no override is set, returns the device cap unchanged.
+    /// </summary>
     internal long EffectiveMaxBufferBytes(long deviceCap)
-        => MaxBufferBytes ?? deviceCap;
+    {
+        if (!MaxBufferBytes.HasValue) return deviceCap;
+        long userCap = MaxBufferBytes.Value;
+        // If device cap is unknown (deviceCap == 0) trust the user value.
+        if (deviceCap <= 0) return userCap;
+        return Math.Min(userCap, deviceCap);
+    }
 
     internal GpuChunkingPolicy EffectiveChunkingPolicy
         => ChunkingPolicy ?? GpuChunkingPolicy.AutoChunk;
@@ -119,12 +133,15 @@ public static class GpuFallbackOptionsHolder
     private static GpuFallbackOptions _current = GpuFallbackOptions.Default;
 
     /// <summary>
-    /// The currently-active fallback options. Reading is cheap (one volatile
-    /// read on the static reference); never null.
+    /// The currently-active fallback options. Reading and writing both go
+    /// through <see cref="System.Threading.Volatile"/> so a writer thread's
+    /// update is visible to other threads without explicit
+    /// synchronisation. Never returns null — assigning null resets to
+    /// <see cref="GpuFallbackOptions.Default"/>.
     /// </summary>
     public static GpuFallbackOptions Current
     {
-        get => _current;
-        set => _current = value ?? GpuFallbackOptions.Default;
+        get => System.Threading.Volatile.Read(ref _current);
+        set => System.Threading.Volatile.Write(ref _current, value ?? GpuFallbackOptions.Default);
     }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/GpuFallbackOptions.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/GpuFallbackOptions.cs
@@ -100,9 +100,12 @@ public sealed class GpuFallbackOptions
     /// </summary>
     internal long EffectiveMaxBufferBytes(long deviceCap)
     {
-        if (!MaxBufferBytes.HasValue) return deviceCap;
+        // Treat non-positive overrides as "unset" — silently ignore the
+        // value rather than collapsing the effective cap to 0 (which would
+        // reject every allocation).
+        if (!MaxBufferBytes.HasValue || MaxBufferBytes.Value <= 0) return deviceCap;
         long userCap = MaxBufferBytes.Value;
-        // If device cap is unknown (deviceCap == 0) trust the user value.
+        // If device cap is unknown (deviceCap <= 0) trust the user value.
         if (deviceCap <= 0) return userCap;
         return Math.Min(userCap, deviceCap);
     }
@@ -111,7 +114,17 @@ public sealed class GpuFallbackOptions
         => ChunkingPolicy ?? GpuChunkingPolicy.AutoChunk;
 
     internal int EffectiveMaxChunkCount
-        => MaxChunkCount ?? 64;
+    {
+        get
+        {
+            // Treat non-positive values as "unset" — falling back to the
+            // documented default of 64 — rather than allowing 0 or negative
+            // values to either disable chunking entirely or trigger
+            // pathological negative-bound loops in the chunker.
+            if (!MaxChunkCount.HasValue || MaxChunkCount.Value <= 0) return 64;
+            return MaxChunkCount.Value;
+        }
+    }
 }
 
 /// <summary>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/GpuFallbackOptions.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/GpuFallbackOptions.cs
@@ -1,0 +1,130 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+namespace AiDotNet.Tensors.Engines.DirectGpu;
+
+/// <summary>
+/// Policy that controls how <see cref="DirectGpuTensorEngine"/> handles
+/// allocations that exceed the device's per-allocation cap (issue #285).
+/// </summary>
+public enum GpuChunkingPolicy
+{
+    /// <summary>
+    /// Default. The engine first tries to chunk the operation across
+    /// multiple smaller allocations; if chunking fails (op cannot decompose,
+    /// or chunk count exceeds <see cref="GpuFallbackOptions.MaxChunkCount"/>),
+    /// it falls through to the CPU path.
+    /// </summary>
+    AutoChunk = 0,
+
+    /// <summary>
+    /// Always chunk operations whose buffers exceed the cap. If chunking
+    /// cannot decompose the op, the engine falls through to CPU. Equivalent
+    /// to <see cref="AutoChunk"/> in current behaviour but reserved for a
+    /// future "force chunk even under cap" debugging mode.
+    /// </summary>
+    AlwaysChunk = 1,
+
+    /// <summary>
+    /// Never chunk. If a buffer exceeds the cap, the
+    /// <see cref="GpuBufferTooLargeException"/> propagates to the caller.
+    /// Use this when you want the user to see the failure and reduce model
+    /// size manually (matches pre-#285 behaviour, but with the typed
+    /// exception in place of an opaque <c>InvalidOperationException</c>).
+    /// </summary>
+    NeverChunk_FailFast = 2,
+
+    /// <summary>
+    /// Never chunk. If a buffer exceeds the cap, fall through to CPU
+    /// silently — same as <see cref="AutoChunk"/> but skip the chunking
+    /// attempt. Useful when you don't trust the chunker's correctness for
+    /// a specific op and prefer the slower-but-known CPU path.
+    /// </summary>
+    NeverChunk_FallbackToCpu = 3,
+}
+
+/// <summary>
+/// User-tunable GPU fallback / chunking knobs for issue #285. Set via the
+/// AiDotNet facade's <c>PredictionModelBuilder.ConfigureGpuAcceleration(...)</c>;
+/// the facade maps its <c>GpuAccelerationConfig</c> onto these. Defaults
+/// (apply when a property is null) are picked to do the right thing for
+/// users who don't know about the cap.
+/// </summary>
+/// <remarks>
+/// <para><b>Industry-standard defaults (applied when null):</b></para>
+/// <list type="bullet">
+/// <item><see cref="MaxBufferBytes"/>: device's <c>MaxBufferAllocBytes</c>
+/// (queried at backend init).</item>
+/// <item><see cref="ChunkingPolicy"/>: <see cref="GpuChunkingPolicy.AutoChunk"/>.</item>
+/// <item><see cref="MaxChunkCount"/>: 64.</item>
+/// </list>
+/// </remarks>
+public sealed class GpuFallbackOptions
+{
+    /// <summary>
+    /// Override the auto-detected per-allocation cap. Useful for testing
+    /// (force a low cap to exercise the chunker) or for devices that
+    /// misreport. When null, the engine uses
+    /// <see cref="IDirectGpuBackend.MaxBufferAllocBytes"/>.
+    /// </summary>
+    public long? MaxBufferBytes { get; init; }
+
+    /// <summary>
+    /// How the engine handles over-cap allocations. When null, defaults to
+    /// <see cref="GpuChunkingPolicy.AutoChunk"/>.
+    /// </summary>
+    public GpuChunkingPolicy? ChunkingPolicy { get; init; }
+
+    /// <summary>
+    /// Maximum number of chunks an op can be split into before bailing to
+    /// CPU. Prevents pathological cases (e.g. a 100 GiB allocation on a
+    /// device with 256 MiB cap would otherwise want 400 chunks). When null,
+    /// defaults to 64.
+    /// </summary>
+    public int? MaxChunkCount { get; init; }
+
+    /// <summary>
+    /// Conservative defaults — what the engine uses when no
+    /// <see cref="GpuFallbackOptions"/> is explicitly configured.
+    /// </summary>
+    public static GpuFallbackOptions Default { get; } = new GpuFallbackOptions();
+
+    // ── Internal accessors that apply the industry-standard defaults ──
+
+    internal long EffectiveMaxBufferBytes(long deviceCap)
+        => MaxBufferBytes ?? deviceCap;
+
+    internal GpuChunkingPolicy EffectiveChunkingPolicy
+        => ChunkingPolicy ?? GpuChunkingPolicy.AutoChunk;
+
+    internal int EffectiveMaxChunkCount
+        => MaxChunkCount ?? 64;
+}
+
+/// <summary>
+/// Process-wide ambient instance of <see cref="GpuFallbackOptions"/>. The
+/// AiDotNet facade sets this from the user-configured
+/// <c>GpuAccelerationConfig</c>; everything in AiDotNet.Tensors that needs
+/// to consult the policy reads <see cref="Current"/>.
+/// </summary>
+/// <remarks>
+/// Process-wide rather than thread-local because GPU buffer caps are a
+/// device property — they don't change per-thread, and the same training
+/// run typically uses one engine for all worker threads. If a future
+/// scenario needs per-thread overrides (e.g. one thread testing chunking
+/// while others run normally), this can be promoted to thread-local
+/// without breaking callers.
+/// </remarks>
+public static class GpuFallbackOptionsHolder
+{
+    private static GpuFallbackOptions _current = GpuFallbackOptions.Default;
+
+    /// <summary>
+    /// The currently-active fallback options. Reading is cheap (one volatile
+    /// read on the static reference); never null.
+    /// </summary>
+    public static GpuFallbackOptions Current
+    {
+        get => _current;
+        set => _current = value ?? GpuFallbackOptions.Default;
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -117,6 +117,12 @@ public sealed partial class HipBackend : IAsyncGpuBackend
     public int ComputeUnits { get; }
     public long GlobalMemoryBytes { get; }
     public long LocalMemoryBytes { get; }
+    /// <summary>
+    /// HIP / ROCm exposes no formal per-allocation cap — same story as CUDA.
+    /// We use total VRAM as the upper bound and let the chunker handle
+    /// hipErrorOutOfMemory on a per-call basis. Issue #285.
+    /// </summary>
+    public long MaxBufferAllocBytes { get; }
     public double TheoreticalGflops { get; }
 
     private void ReturnBufferToPool(HipGpuBuffer buffer)
@@ -233,6 +239,9 @@ public sealed partial class HipBackend : IAsyncGpuBackend
             ComputeUnits = _deviceProps.MultiProcessorCount;
             GlobalMemoryBytes = (long)(ulong)_deviceProps.TotalGlobalMem;
             LocalMemoryBytes = (long)(ulong)_deviceProps.SharedMemPerBlock;
+            // Issue #285: same approach as CUDA — total VRAM as conservative
+            // upper bound; per-call OOM surfaces as GpuBufferTooLargeException.
+            MaxBufferAllocBytes = (long)(ulong)_deviceProps.TotalGlobalMem;
 
             // Detect architecture from GCN arch name
             _architecture = DetectArchitecture(_deviceProps.GcnArchName, 0);
@@ -908,6 +917,8 @@ public sealed partial class HipBackend : IAsyncGpuBackend
     {
         IntPtr devicePtr = IntPtr.Zero;
         var size = (UIntPtr)(data.Length * sizeof(float));
+        // Issue #285: per-allocation cap check before hipMalloc.
+        GpuBufferSizeGuard.EnsureFits("HIP", (long)data.Length * sizeof(float), MaxBufferAllocBytes, DeviceName);
 
         if (_bufferPool.TryRent(data.Length, out var pooled) && pooled != null)
         {
@@ -945,6 +956,8 @@ public sealed partial class HipBackend : IAsyncGpuBackend
     {
         IntPtr devicePtr = IntPtr.Zero;
         var sizeBytes = (UIntPtr)(size * sizeof(float));
+        // Issue #285: per-allocation cap check before hipMalloc.
+        GpuBufferSizeGuard.EnsureFits("HIP", (long)size * sizeof(float), MaxBufferAllocBytes, DeviceName);
 
         if (_bufferPool.TryRent(size, out var pooled) && pooled != null)
         {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -2867,6 +2867,8 @@ public sealed partial class HipBackend : IAsyncGpuBackend
     {
         IntPtr devicePtr = IntPtr.Zero;
         var sizeBytes = (UIntPtr)size;
+        // Issue #285: per-allocation cap check before hipMalloc.
+        GpuBufferSizeGuard.EnsureFits("HIP", size, MaxBufferAllocBytes, DeviceName);
 
         var result = HipNativeBindings.hipMalloc(ref devicePtr, sizeBytes);
         HipNativeBindings.CheckError(result, "hipMalloc (byte buffer)");
@@ -5192,6 +5194,8 @@ public sealed partial class HipBackend : IAsyncGpuBackend
     {
         IntPtr devicePtr = IntPtr.Zero;
         var sizeBytes = (UIntPtr)(size * sizeof(int));
+        // Issue #285: per-allocation cap check before hipMalloc.
+        GpuBufferSizeGuard.EnsureFits("HIP", (long)size * sizeof(int), MaxBufferAllocBytes, DeviceName);
 
         var result = HipNativeBindings.hipMalloc(ref devicePtr, sizeBytes);
         HipNativeBindings.CheckError(result, "hipMalloc(int)");
@@ -5207,6 +5211,8 @@ public sealed partial class HipBackend : IAsyncGpuBackend
         IntPtr devicePtr = IntPtr.Zero;
         var size = data.Length;
         var sizeBytes = (UIntPtr)(size * sizeof(int));
+        // Issue #285: per-allocation cap check before hipMalloc.
+        GpuBufferSizeGuard.EnsureFits("HIP", (long)size * sizeof(int), MaxBufferAllocBytes, DeviceName);
 
         var result = HipNativeBindings.hipMalloc(ref devicePtr, sizeBytes);
         HipNativeBindings.CheckError(result, "hipMalloc(int)");

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -240,7 +240,11 @@ public sealed partial class HipBackend : IAsyncGpuBackend
             GlobalMemoryBytes = (long)(ulong)_deviceProps.TotalGlobalMem;
             LocalMemoryBytes = (long)(ulong)_deviceProps.SharedMemPerBlock;
             // Issue #285: same approach as CUDA — total VRAM as conservative
-            // upper bound; per-call OOM surfaces as GpuBufferTooLargeException.
+            // upper bound. The guard only catches requests > total VRAM;
+            // mid-size allocations that fail due to fragmentation surface
+            // as a generic HIP error via CheckError, NOT as
+            // GpuBufferTooLargeException. Translating hipErrorOutOfMemory
+            // into the typed exception is tracked as follow-up work.
             MaxBufferAllocBytes = (long)(ulong)_deviceProps.TotalGlobalMem;
 
             // Detect architecture from GCN arch name

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
@@ -61,6 +61,25 @@ public interface IDirectGpuBackend : IDisposable
     long LocalMemoryBytes { get; }
 
     /// <summary>
+    /// Gets the maximum size in bytes of a SINGLE buffer allocation on this
+    /// device. This is independent of <see cref="GlobalMemoryBytes"/> — even
+    /// when total VRAM is large, GPU drivers cap individual allocations
+    /// (OpenCL's <c>CL_DEVICE_MAX_MEM_ALLOC_SIZE</c>, CUDA's per-allocation
+    /// virtual address window, Metal's <c>maxBufferLength</c>, Vulkan's
+    /// <c>maxStorageBufferRange</c>, WebGPU's <c>maxBufferSize</c>).
+    /// </summary>
+    /// <remarks>
+    /// <para>Issue #285: blindly requesting an allocation above this cap
+    /// produces an opaque driver error (e.g. <c>CL_INVALID_BUFFER_SIZE = -61</c>).
+    /// Engine dispatch shims should validate against this value and fall
+    /// through to a chunked or CPU path instead of crashing.</para>
+    /// <para>Returns 0 when the cap is unknown / not queryable; callers
+    /// should treat 0 as "skip the validation, let the native call fail
+    /// with its own error if any."</para>
+    /// </remarks>
+    long MaxBufferAllocBytes { get; }
+
+    /// <summary>
     /// Gets the estimated theoretical peak FP32 GFLOPS for this GPU.
     /// Computed from clock rate, compute units, and FP32 cores per compute unit.
     /// </summary>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
@@ -106,9 +106,12 @@ public sealed partial class MetalBackend : IDirectGpuBackend
     /// Issue #285: Metal exposes <c>MTLDevice.maxBufferLength</c> as the
     /// per-allocation cap, but our current wrapper doesn't surface it.
     /// Use <c>RecommendedMaxWorkingSetSize</c> as a conservative upper bound
-    /// for now — per-call OOM (Metal returns nil from <c>newBufferWithLength:</c>)
-    /// surfaces as <see cref="GpuBufferTooLargeException"/> via the buffer
-    /// ctor guard.
+    /// for now — the guard catches requests > total working-set size only.
+    /// A smaller-than-WSS allocation that fails (Metal returns nil from
+    /// <c>newBufferWithLength:</c>) currently surfaces as a generic
+    /// <c>NullReferenceException</c>, NOT as <see cref="GpuBufferTooLargeException"/>.
+    /// Querying the real <c>maxBufferLength</c> attribute and translating
+    /// nil-buffer returns into the typed exception is tracked as follow-up.
     /// </summary>
     public long MaxBufferAllocBytes => (long)(_device?.RecommendedMaxWorkingSetSize ?? 0);
 
@@ -462,11 +465,13 @@ public sealed partial class MetalBackend : IDirectGpuBackend
         {
             throw new ArgumentOutOfRangeException(nameof(size), "Size must be positive");
         }
-        GpuBufferSizeGuard.EnsureFits("Metal", size, MaxBufferAllocBytes, DeviceName);
 
-        // For byte buffers, we allocate as floats and use size/4
-        // This is a simplification - proper implementation would use separate byte buffers
+        // For byte buffers, we allocate as floats and use size/4. Validate
+        // against the cap using the rounded-up actual byte count, not the
+        // requested logical byte count.
         var floatSize = (size + 3) / 4;
+        long actualBytes = (long)floatSize * sizeof(float);
+        GpuBufferSizeGuard.EnsureFits("Metal", actualBytes, MaxBufferAllocBytes, DeviceName);
         return new MetalGpuBuffer(_device, floatSize);
     }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
@@ -103,17 +103,18 @@ public sealed partial class MetalBackend : IDirectGpuBackend
     public long LocalMemoryBytes => (long)(_device?.MaxThreadgroupMemoryLength ?? 32768);
 
     /// <summary>
-    /// Issue #285: Metal exposes <c>MTLDevice.maxBufferLength</c> as the
-    /// per-allocation cap, but our current wrapper doesn't surface it.
-    /// Use <c>RecommendedMaxWorkingSetSize</c> as a conservative upper bound
-    /// for now — the guard catches requests > total working-set size only.
-    /// A smaller-than-WSS allocation that fails (Metal returns nil from
-    /// <c>newBufferWithLength:</c>) currently surfaces as a generic
-    /// <c>NullReferenceException</c>, NOT as <see cref="GpuBufferTooLargeException"/>.
-    /// Querying the real <c>maxBufferLength</c> attribute and translating
-    /// nil-buffer returns into the typed exception is tracked as follow-up.
+    /// Issue #285: per-allocation cap from <c>MTLDevice.maxBufferLength</c>.
+    /// This is the hard limit Metal enforces on a single
+    /// <c>newBufferWithLength:</c> call; it can be substantially smaller
+    /// than <see cref="GlobalMemoryBytes"/> (recommendedMaxWorkingSetSize)
+    /// on Apple Silicon and discrete-GPU Macs alike. NOTE: a request
+    /// smaller than this cap that still fails (e.g. due to fragmentation
+    /// or transient memory pressure) returns nil from
+    /// <c>newBufferWithLength:</c>, which our wrapper surfaces as a
+    /// generic <c>NullReferenceException</c> — translating that into
+    /// <see cref="GpuBufferTooLargeException"/> is follow-up work.
     /// </summary>
-    public long MaxBufferAllocBytes => (long)(_device?.RecommendedMaxWorkingSetSize ?? 0);
+    public long MaxBufferAllocBytes => (long)(_device?.MaxBufferLength ?? 0);
 
     public double TheoreticalGflops { get; }
 
@@ -466,13 +467,17 @@ public sealed partial class MetalBackend : IDirectGpuBackend
             throw new ArgumentOutOfRangeException(nameof(size), "Size must be positive");
         }
 
-        // For byte buffers, we allocate as floats and use size/4. Validate
-        // against the cap using the rounded-up actual byte count, not the
-        // requested logical byte count.
-        var floatSize = (size + 3) / 4;
-        long actualBytes = (long)floatSize * sizeof(float);
+        // For byte buffers, we allocate as floats and use size/4. Round up
+        // in long-space first (size could be near int.MaxValue and `size + 3`
+        // would overflow if done in int), then check the actual allocation
+        // bytes against the cap.
+        long floatSizeLong = ((long)size + 3) / 4;
+        long actualBytes = floatSizeLong * sizeof(float);
         GpuBufferSizeGuard.EnsureFits("Metal", actualBytes, MaxBufferAllocBytes, DeviceName);
-        return new MetalGpuBuffer(_device, floatSize);
+        // After the cap check, the float-count is guaranteed to fit in int
+        // (because actualBytes <= MaxBufferAllocBytes <= long.MaxValue and
+        // floatSizeLong * 4 <= int.MaxValue when actualBytes is reasonable).
+        return new MetalGpuBuffer(_device, checked((int)floatSizeLong));
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
@@ -102,6 +102,16 @@ public sealed partial class MetalBackend : IDirectGpuBackend
     /// </summary>
     public long LocalMemoryBytes => (long)(_device?.MaxThreadgroupMemoryLength ?? 32768);
 
+    /// <summary>
+    /// Issue #285: Metal exposes <c>MTLDevice.maxBufferLength</c> as the
+    /// per-allocation cap, but our current wrapper doesn't surface it.
+    /// Use <c>RecommendedMaxWorkingSetSize</c> as a conservative upper bound
+    /// for now — per-call OOM (Metal returns nil from <c>newBufferWithLength:</c>)
+    /// surfaces as <see cref="GpuBufferTooLargeException"/> via the buffer
+    /// ctor guard.
+    /// </summary>
+    public long MaxBufferAllocBytes => (long)(_device?.RecommendedMaxWorkingSetSize ?? 0);
+
     public double TheoreticalGflops { get; }
 
     #endregion
@@ -347,6 +357,8 @@ public sealed partial class MetalBackend : IDirectGpuBackend
         {
             throw new ArgumentException("Data cannot be null or empty", nameof(data));
         }
+        // Issue #285: per-allocation cap check.
+        GpuBufferSizeGuard.EnsureFits("Metal", (long)data.Length * sizeof(float), MaxBufferAllocBytes, DeviceName);
 
         return new MetalGpuBuffer(_device, data);
     }
@@ -362,6 +374,8 @@ public sealed partial class MetalBackend : IDirectGpuBackend
         {
             throw new ArgumentOutOfRangeException(nameof(size), "Size must be positive");
         }
+        // Issue #285: per-allocation cap check.
+        GpuBufferSizeGuard.EnsureFits("Metal", (long)size * sizeof(float), MaxBufferAllocBytes, DeviceName);
 
         return new MetalGpuBuffer(_device, size);
     }
@@ -448,6 +462,7 @@ public sealed partial class MetalBackend : IDirectGpuBackend
         {
             throw new ArgumentOutOfRangeException(nameof(size), "Size must be positive");
         }
+        GpuBufferSizeGuard.EnsureFits("Metal", size, MaxBufferAllocBytes, DeviceName);
 
         // For byte buffers, we allocate as floats and use size/4
         // This is a simplification - proper implementation would use separate byte buffers
@@ -466,6 +481,7 @@ public sealed partial class MetalBackend : IDirectGpuBackend
         {
             throw new ArgumentOutOfRangeException(nameof(size), "Size must be positive");
         }
+        GpuBufferSizeGuard.EnsureFits("Metal", (long)size * sizeof(int), MaxBufferAllocBytes, DeviceName);
 
         // Metal can store int32 in the same buffer format as float32
         return new MetalGpuBuffer(_device, size);
@@ -482,6 +498,7 @@ public sealed partial class MetalBackend : IDirectGpuBackend
         {
             throw new ArgumentException("Data cannot be null or empty", nameof(data));
         }
+        GpuBufferSizeGuard.EnsureFits("Metal", (long)data.Length * sizeof(int), MaxBufferAllocBytes, DeviceName);
 
         // Convert int array to float array for buffer allocation
         var floatData = new float[data.Length];

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalDevice.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalDevice.cs
@@ -90,6 +90,15 @@ public sealed class MetalDevice : IDisposable
     public ulong RecommendedMaxWorkingSetSize { get; }
 
     /// <summary>
+    /// Gets the maximum size in bytes of a SINGLE Metal buffer
+    /// (<c>MTLDevice.maxBufferLength</c>). This is the per-allocation cap
+    /// for <c>newBufferWithLength:</c>; it can be substantially smaller
+    /// than <see cref="RecommendedMaxWorkingSetSize"/> on consumer Macs.
+    /// Issue #285.
+    /// </summary>
+    public ulong MaxBufferLength { get; }
+
+    /// <summary>
     /// Gets the current allocated memory size in bytes.
     /// </summary>
     public ulong CurrentAllocatedSize
@@ -195,6 +204,7 @@ public sealed class MetalDevice : IDisposable
 
             // Get recommended working set size
             RecommendedMaxWorkingSetSize = SendMessageULongReturn(_device, Selectors.RecommendedMaxWorkingSetSize);
+            MaxBufferLength = SendMessageULongReturn(_device, Selectors.MaxBufferLength);
 
             // Get registry ID
             RegistryID = SendMessageULongReturn(_device, Selectors.RegistryID);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalNativeBindings.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalNativeBindings.cs
@@ -405,6 +405,7 @@ public static class MetalNativeBindings
         public static readonly IntPtr MaxThreadsPerThreadgroup = RegisterSelector("maxThreadsPerThreadgroup");
         public static readonly IntPtr MaxThreadgroupMemoryLength = RegisterSelector("maxThreadgroupMemoryLength");
         public static readonly IntPtr RecommendedMaxWorkingSetSize = RegisterSelector("recommendedMaxWorkingSetSize");
+        public static readonly IntPtr MaxBufferLength = RegisterSelector("maxBufferLength");
         public static readonly IntPtr CurrentAllocatedSize = RegisterSelector("currentAllocatedSize");
         public static readonly IntPtr SupportsFamily = RegisterSelector("supportsFamily:");
         public static readonly IntPtr RegistryID = RegisterSelector("registryID");

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClBuffer.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClBuffer.cs
@@ -8,6 +8,32 @@ using System.Runtime.InteropServices;
 namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 {
     /// <summary>
+    /// Helper for issue #285 — validates a requested allocation size against
+    /// the device's <c>CL_DEVICE_MAX_MEM_ALLOC_SIZE</c> before calling
+    /// <c>clCreateBuffer</c>. Allocations above the cap return
+    /// <c>CL_INVALID_BUFFER_SIZE (-61)</c> with no further information; this
+    /// throws a typed <see cref="GpuBufferTooLargeException"/> so dispatch
+    /// shims can catch it and fall back to a CPU path or chunked execution.
+    /// </summary>
+    internal static class DirectOpenClBufferGuards
+    {
+        internal static void EnsureFits(DirectOpenClContext context, long requestedBytes)
+        {
+            ulong cap = context.MaxMemAllocSize;
+            // MaxMemAllocSize == 0 means the query failed at context init —
+            // skip the guard rather than wrongly reject every allocation. The
+            // underlying clCreateBuffer call will still surface any error.
+            GpuBufferSizeGuard.EnsureFits(
+                backend: "OpenCL",
+                requestedBytes: requestedBytes,
+                cap: cap > 0 ? (long)cap : 0,
+                deviceName: !string.IsNullOrEmpty(context.DeviceBoardName)
+                    ? context.DeviceBoardName
+                    : context.DeviceName);
+        }
+    }
+
+    /// <summary>
     /// OpenCL buffer wrapper using pure P/Invoke. No managed GPU runtime dependency.
     /// </summary>
     internal sealed class DirectOpenClBuffer : IDisposable
@@ -27,6 +53,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         {
             _context = context;
             _length = data.Length;
+            DirectOpenClBufferGuards.EnsureFits(context, (long)data.Length * sizeof(float));
 
             GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
             try
@@ -54,6 +81,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         {
             _context = context;
             _length = size;
+            DirectOpenClBufferGuards.EnsureFits(context, (long)size * sizeof(float));
 
             _buffer = OpenClNativeBindings.CreateBuffer(
                 context.Context,
@@ -173,6 +201,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         {
             _context = context;
             _length = data.Length;
+            DirectOpenClBufferGuards.EnsureFits(context, data.Length);
 
             GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
             try
@@ -200,6 +229,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         {
             _context = context;
             _length = size;
+            DirectOpenClBufferGuards.EnsureFits(context, size);
 
             _buffer = OpenClNativeBindings.CreateBuffer(
                 context.Context,
@@ -288,6 +318,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         {
             _context = context;
             _length = data.Length;
+            DirectOpenClBufferGuards.EnsureFits(context, (long)data.Length * sizeof(int));
 
             GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
             try
@@ -315,6 +346,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         {
             _context = context;
             _length = size;
+            DirectOpenClBufferGuards.EnsureFits(context, (long)size * sizeof(int));
 
             _buffer = OpenClNativeBindings.CreateBuffer(
                 context.Context,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClBuffer.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClBuffer.cs
@@ -26,7 +26,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             GpuBufferSizeGuard.EnsureFits(
                 backend: "OpenCL",
                 requestedBytes: requestedBytes,
-                cap: cap > 0 ? (long)cap : 0,
+                deviceCap: cap > 0 ? (long)cap : 0,
                 deviceName: !string.IsNullOrEmpty(context.DeviceBoardName)
                     ? context.DeviceBoardName
                     : context.DeviceName);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClContext.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClContext.cs
@@ -46,6 +46,18 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         public ulong LocalMemSize { get; private set; }
 
         /// <summary>
+        /// Maximum bytes the device allows in a single buffer allocation
+        /// (<c>CL_DEVICE_MAX_MEM_ALLOC_SIZE</c>). The OpenCL spec guarantees
+        /// this is at least <c>max(GlobalMemSize / 4, 128 MiB)</c>, but the
+        /// real cap on consumer GPUs is often substantially lower than the
+        /// total VRAM. Issue #285: blindly calling clCreateBuffer with a
+        /// size above this returns <c>CL_INVALID_BUFFER_SIZE (-61)</c>;
+        /// this value lets callers validate ahead of time and fall back
+        /// gracefully to CPU or chunked execution.
+        /// </summary>
+        public ulong MaxMemAllocSize { get; private set; }
+
+        /// <summary>
         /// GPU memory bandwidth in bytes/second (approximate).
         /// </summary>
         public ulong MemoryBandwidth { get; private set; }
@@ -181,6 +193,10 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             MaxComputeUnits = OpenClNativeBindings.GetDeviceInfoUInt(_device, OpenClNativeBindings.CL_DEVICE_MAX_COMPUTE_UNITS);
             GlobalMemSize = OpenClNativeBindings.GetDeviceInfoULong(_device, OpenClNativeBindings.CL_DEVICE_GLOBAL_MEM_SIZE);
             LocalMemSize = OpenClNativeBindings.GetDeviceInfoULong(_device, OpenClNativeBindings.CL_DEVICE_LOCAL_MEM_SIZE);
+            // Per-allocation cap (issue #285) — query at context init so the
+            // hot allocation path (DirectOpenClBuffer ctor) can guard against
+            // CL_INVALID_BUFFER_SIZE (-61) without a syscall per allocation.
+            MaxMemAllocSize = OpenClNativeBindings.GetDeviceInfoULong(_device, OpenClNativeBindings.CL_DEVICE_MAX_MEM_ALLOC_SIZE);
 
             // Get work group capabilities
             MaxWorkGroupSize = (ulong)OpenClNativeBindings.GetDeviceInfoSizeT(_device, OpenClNativeBindings.CL_DEVICE_MAX_WORK_GROUP_SIZE);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -105,6 +105,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         public int ComputeUnits { get; }
         public long GlobalMemoryBytes { get; }
         public long LocalMemoryBytes { get; }
+        public long MaxBufferAllocBytes { get; }
         public double TheoreticalGflops { get; private set; }
 
         // IAsyncGpuBackend properties
@@ -185,6 +186,9 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
                 GlobalMemoryBytes = (long)_context.GlobalMemSize;
                 LocalMemoryBytes = (long)_context.LocalMemSize;
+                // Issue #285: per-allocation cap. Drivers cap individual buffers
+                // well below total VRAM (typical ~1 GB on consumer AMD/Intel).
+                MaxBufferAllocBytes = (long)_context.MaxMemAllocSize;
                 TheoreticalGflops = EstimateTheoreticalGflops();
 
                 // Store GPU capabilities for dynamic work group sizing

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClNativeBindings.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClNativeBindings.cs
@@ -89,6 +89,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         public const uint CL_DEVICE_VENDOR = 0x102C;
         public const uint CL_DEVICE_MAX_COMPUTE_UNITS = 0x1002;
         public const uint CL_DEVICE_GLOBAL_MEM_SIZE = 0x101F;
+        public const uint CL_DEVICE_MAX_MEM_ALLOC_SIZE = 0x1010;
         public const uint CL_DEVICE_LOCAL_MEM_SIZE = 0x1023;
         public const uint CL_DEVICE_MAX_WORK_GROUP_SIZE = 0x1004;
         public const uint CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS = 0x1003;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend.cs
@@ -198,6 +198,8 @@ public sealed unsafe partial class VulkanBackend
     public IGpuBuffer AllocateBuffer(float[] data)
     {
         EnsureInitialized();
+        if (data is null)
+            throw new ArgumentNullException(nameof(data));
         if (_transfer is null)
             throw new InvalidOperationException("Vulkan buffer transfer not initialized.");
         // Issue #285: per-allocation cap check before VkBuffer creation.
@@ -282,6 +284,8 @@ public sealed unsafe partial class VulkanBackend
     public IGpuBuffer AllocateIntBuffer(int[] data)
     {
         EnsureInitialized();
+        if (data is null)
+            throw new ArgumentNullException(nameof(data));
         GpuBufferSizeGuard.EnsureFits("Vulkan", (long)data.Length * sizeof(int), MaxBufferAllocBytes, DeviceName);
         var floatData = new float[data.Length];
         for (int i = 0; i < data.Length; i++)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend.cs
@@ -309,8 +309,13 @@ public sealed unsafe partial class VulkanBackend
         EnsureInitialized();
         if (size <= 0)
             throw new ArgumentOutOfRangeException(nameof(size), "Byte buffer size must be positive.");
-        GpuBufferSizeGuard.EnsureFits("Vulkan", size, MaxBufferAllocBytes, DeviceName);
+        // Vulkan storage buffers are float32-typed, so the actual allocation
+        // is `floatCount * sizeof(float)` bytes — round up `size` to a float
+        // boundary BEFORE checking the cap so the guard sees the bytes that
+        // will really be allocated.
         int floatCount = (size + sizeof(float) - 1) / sizeof(float);
+        long actualBytes = (long)floatCount * sizeof(float);
+        GpuBufferSizeGuard.EnsureFits("Vulkan", actualBytes, MaxBufferAllocBytes, DeviceName);
         return VulkanGpuBuffer.Create(floatCount);
     }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend.cs
@@ -200,6 +200,8 @@ public sealed unsafe partial class VulkanBackend
         EnsureInitialized();
         if (_transfer is null)
             throw new InvalidOperationException("Vulkan buffer transfer not initialized.");
+        // Issue #285: per-allocation cap check before VkBuffer creation.
+        GpuBufferSizeGuard.EnsureFits("Vulkan", (long)data.Length * sizeof(float), MaxBufferAllocBytes, DeviceName);
         return VulkanGpuBuffer.Create(data, _transfer);
     }
 
@@ -208,6 +210,7 @@ public sealed unsafe partial class VulkanBackend
         EnsureInitialized();
         if (size <= 0)
             throw new ArgumentOutOfRangeException(nameof(size), "Buffer size must be positive.");
+        GpuBufferSizeGuard.EnsureFits("Vulkan", (long)size * sizeof(float), MaxBufferAllocBytes, DeviceName);
         return VulkanGpuBuffer.Create(size);
     }
 
@@ -270,12 +273,14 @@ public sealed unsafe partial class VulkanBackend
     public IGpuBuffer AllocateIntBuffer(int size)
     {
         EnsureInitialized();
+        GpuBufferSizeGuard.EnsureFits("Vulkan", (long)size * sizeof(int), MaxBufferAllocBytes, DeviceName);
         return VulkanGpuBuffer.Create(size);
     }
 
     public IGpuBuffer AllocateIntBuffer(int[] data)
     {
         EnsureInitialized();
+        GpuBufferSizeGuard.EnsureFits("Vulkan", (long)data.Length * sizeof(int), MaxBufferAllocBytes, DeviceName);
         var floatData = new float[data.Length];
         for (int i = 0; i < data.Length; i++)
             floatData[i] = Int32BitsToSingleCompat(data[i]);
@@ -304,6 +309,7 @@ public sealed unsafe partial class VulkanBackend
         EnsureInitialized();
         if (size <= 0)
             throw new ArgumentOutOfRangeException(nameof(size), "Byte buffer size must be positive.");
+        GpuBufferSizeGuard.EnsureFits("Vulkan", size, MaxBufferAllocBytes, DeviceName);
         int floatCount = (size + sizeof(float) - 1) / sizeof(float);
         return VulkanGpuBuffer.Create(floatCount);
     }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend.cs
@@ -273,6 +273,8 @@ public sealed unsafe partial class VulkanBackend
     public IGpuBuffer AllocateIntBuffer(int size)
     {
         EnsureInitialized();
+        if (size <= 0)
+            throw new ArgumentOutOfRangeException(nameof(size), "Int buffer size must be positive.");
         GpuBufferSizeGuard.EnsureFits("Vulkan", (long)size * sizeof(int), MaxBufferAllocBytes, DeviceName);
         return VulkanGpuBuffer.Create(size);
     }
@@ -310,13 +312,13 @@ public sealed unsafe partial class VulkanBackend
         if (size <= 0)
             throw new ArgumentOutOfRangeException(nameof(size), "Byte buffer size must be positive.");
         // Vulkan storage buffers are float32-typed, so the actual allocation
-        // is `floatCount * sizeof(float)` bytes — round up `size` to a float
-        // boundary BEFORE checking the cap so the guard sees the bytes that
-        // will really be allocated.
-        int floatCount = (size + sizeof(float) - 1) / sizeof(float);
-        long actualBytes = (long)floatCount * sizeof(float);
+        // is `floatCount * sizeof(float)` bytes. Round up in long-space
+        // first to avoid overflow when `size` is near int.MaxValue, then
+        // check the actual byte count against the cap.
+        long floatCountLong = ((long)size + sizeof(float) - 1) / sizeof(float);
+        long actualBytes = floatCountLong * sizeof(float);
         GpuBufferSizeGuard.EnsureFits("Vulkan", actualBytes, MaxBufferAllocBytes, DeviceName);
-        return VulkanGpuBuffer.Create(floatCount);
+        return VulkanGpuBuffer.Create(checked((int)floatCountLong));
     }
 
     #endregion

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.cs
@@ -120,6 +120,13 @@ public sealed unsafe partial class VulkanBackend : IDirectGpuBackend, IGpuBatchE
     /// </summary>
     public long LocalMemoryBytes => _device.MaxSharedMemorySize;
 
+    /// <summary>
+    /// Issue #285: Vulkan's <c>VkPhysicalDeviceLimits.maxStorageBufferRange</c>
+    /// is the per-allocation (per-binding) cap. The spec guarantees at least
+    /// 128 MiB; modern desktop GPUs typically expose 2 GiB or more.
+    /// </summary>
+    public long MaxBufferAllocBytes => _device.MaxStorageBufferRange;
+
     public double TheoreticalGflops { get; }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend.cs
@@ -82,10 +82,12 @@ public sealed partial class WebGpuBackend
     public IGpuBuffer AllocateByteBuffer(int size)
     {
         EnsureInitialized();
-        GpuBufferSizeGuard.EnsureFits("WebGPU", size, MaxBufferAllocBytes, DeviceName);
-        // WebGPU buffers are float32-addressed. Allocate enough floats to hold the byte count.
-        // Callers using byte-level access must account for the 4:1 byte-to-float ratio.
+        // WebGPU buffers are float32-addressed. Round up to floats and check
+        // the cap against the actual allocation, not the requested byte count.
         int floatCount = (size + sizeof(float) - 1) / sizeof(float);
+        long actualBytes = (long)floatCount * sizeof(float);
+        GpuBufferSizeGuard.EnsureFits("WebGPU", actualBytes, MaxBufferAllocBytes, DeviceName);
+        // Callers using byte-level access must account for the 4:1 byte-to-float ratio.
         return new WebGpuBuffer(floatCount);
     }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend.cs
@@ -82,13 +82,16 @@ public sealed partial class WebGpuBackend
     public IGpuBuffer AllocateByteBuffer(int size)
     {
         EnsureInitialized();
-        // WebGPU buffers are float32-addressed. Round up to floats and check
-        // the cap against the actual allocation, not the requested byte count.
-        int floatCount = (size + sizeof(float) - 1) / sizeof(float);
-        long actualBytes = (long)floatCount * sizeof(float);
+        if (size <= 0)
+            throw new ArgumentOutOfRangeException(nameof(size), "Byte buffer size must be positive.");
+        // WebGPU buffers are float32-addressed. Round up in long-space first
+        // to avoid overflow when `size` is near int.MaxValue, then check the
+        // actual allocation byte count against the cap.
+        long floatCountLong = ((long)size + sizeof(float) - 1) / sizeof(float);
+        long actualBytes = floatCountLong * sizeof(float);
         GpuBufferSizeGuard.EnsureFits("WebGPU", actualBytes, MaxBufferAllocBytes, DeviceName);
         // Callers using byte-level access must account for the 4:1 byte-to-float ratio.
-        return new WebGpuBuffer(floatCount);
+        return new WebGpuBuffer(checked((int)floatCountLong));
     }
 
     public IGpuBuffer AllocateIntBuffer(int size)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend.cs
@@ -97,6 +97,8 @@ public sealed partial class WebGpuBackend
     public IGpuBuffer AllocateIntBuffer(int size)
     {
         EnsureInitialized();
+        if (size <= 0)
+            throw new ArgumentOutOfRangeException(nameof(size), "Int buffer size must be positive.");
         GpuBufferSizeGuard.EnsureFits("WebGPU", (long)size * sizeof(int), MaxBufferAllocBytes, DeviceName);
         return new WebGpuBuffer(size);
     }
@@ -104,6 +106,8 @@ public sealed partial class WebGpuBackend
     public IGpuBuffer AllocateIntBuffer(int[] data)
     {
         EnsureInitialized();
+        if (data is null)
+            throw new ArgumentNullException(nameof(data));
         GpuBufferSizeGuard.EnsureFits("WebGPU", (long)data.Length * sizeof(int), MaxBufferAllocBytes, DeviceName);
         var floatData = new float[data.Length];
         for (int i = 0; i < data.Length; i++)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend.cs
@@ -82,6 +82,7 @@ public sealed partial class WebGpuBackend
     public IGpuBuffer AllocateByteBuffer(int size)
     {
         EnsureInitialized();
+        GpuBufferSizeGuard.EnsureFits("WebGPU", size, MaxBufferAllocBytes, DeviceName);
         // WebGPU buffers are float32-addressed. Allocate enough floats to hold the byte count.
         // Callers using byte-level access must account for the 4:1 byte-to-float ratio.
         int floatCount = (size + sizeof(float) - 1) / sizeof(float);
@@ -91,12 +92,14 @@ public sealed partial class WebGpuBackend
     public IGpuBuffer AllocateIntBuffer(int size)
     {
         EnsureInitialized();
+        GpuBufferSizeGuard.EnsureFits("WebGPU", (long)size * sizeof(int), MaxBufferAllocBytes, DeviceName);
         return new WebGpuBuffer(size);
     }
 
     public IGpuBuffer AllocateIntBuffer(int[] data)
     {
         EnsureInitialized();
+        GpuBufferSizeGuard.EnsureFits("WebGPU", (long)data.Length * sizeof(int), MaxBufferAllocBytes, DeviceName);
         var floatData = new float[data.Length];
         for (int i = 0; i < data.Length; i++)
             floatData[i] = BitConverter.Int32BitsToSingle(data[i]);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.cs
@@ -91,11 +91,15 @@ public sealed partial class WebGpuBackend : IDirectGpuBackend, IDisposable
     public long LocalMemoryBytes => 16384L;
 
     /// <summary>
-    /// Issue #285: WebGPU's <c>GPUSupportedLimits.maxBufferSize</c> is the
-    /// per-allocation cap. Default minimum is 256 MiB per the spec; modern
-    /// browsers expose substantially more.
+    /// Issue #285: practical per-allocation cap for WebGPU storage buffers
+    /// (the kind compute pipelines bind). The cap is the minimum of two
+    /// limits because a buffer over either limit fails downstream:
+    /// <c>maxBufferSize</c> caps allocation, and
+    /// <c>maxStorageBufferBindingSize</c> caps the size that can be bound
+    /// to a compute pipeline. Reporting the lesser of the two means the
+    /// guard catches both failure modes ahead of allocation.
     /// </summary>
-    public long MaxBufferAllocBytes => _device.MaxBufferSize;
+    public long MaxBufferAllocBytes => System.Math.Min(_device.MaxBufferSize, _device.MaxStorageBufferBindingSize);
 
     public double TheoreticalGflops { get; }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.cs
@@ -90,6 +90,13 @@ public sealed partial class WebGpuBackend : IDirectGpuBackend, IDisposable
     /// </summary>
     public long LocalMemoryBytes => 16384L;
 
+    /// <summary>
+    /// Issue #285: WebGPU's <c>GPUSupportedLimits.maxBufferSize</c> is the
+    /// per-allocation cap. Default minimum is 256 MiB per the spec; modern
+    /// browsers expose substantially more.
+    /// </summary>
+    public long MaxBufferAllocBytes => _device.MaxBufferSize;
+
     public double TheoreticalGflops { get; }
 
     /// <summary>
@@ -150,6 +157,8 @@ public sealed partial class WebGpuBackend : IDirectGpuBackend, IDisposable
     public IGpuBuffer AllocateBuffer(int elementCount)
     {
         ThrowIfNotInitialized();
+        // Issue #285: per-allocation cap check.
+        GpuBufferSizeGuard.EnsureFits("WebGPU", (long)elementCount * sizeof(float), MaxBufferAllocBytes, DeviceName);
         return new WebGpuBuffer(elementCount);
     }
 
@@ -161,6 +170,8 @@ public sealed partial class WebGpuBackend : IDirectGpuBackend, IDisposable
     public IGpuBuffer AllocateBuffer(float[] data)
     {
         ThrowIfNotInitialized();
+        // Issue #285: per-allocation cap check.
+        GpuBufferSizeGuard.EnsureFits("WebGPU", (long)data.Length * sizeof(float), MaxBufferAllocBytes, DeviceName);
         return new WebGpuBuffer(data);
     }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuDevice.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuDevice.cs
@@ -81,6 +81,15 @@ public sealed class WebGpuDevice : IDisposable
     public long MaxBufferSize => _limits?.MaxBufferSize ?? 256 * 1024 * 1024; // 256MB default
 
     /// <summary>
+    /// Gets the maximum size in bytes that can be bound to a storage
+    /// buffer binding (<c>maxStorageBufferBindingSize</c>). For compute
+    /// storage buffers the practical per-buffer cap is the minimum of
+    /// <see cref="MaxBufferSize"/> and this value — a buffer larger than
+    /// this can be allocated but cannot be bound to a compute pipeline.
+    /// </summary>
+    public long MaxStorageBufferBindingSize => _limits?.MaxStorageBufferBindingSize ?? 128 * 1024 * 1024; // 128MB default
+
+    /// <summary>
     /// Gets the maximum workgroup size.
     /// </summary>
     public int MaxWorkgroupSize => _limits?.MaxComputeInvocationsPerWorkgroup ?? 256;

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -1361,12 +1361,12 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (totalElements <= 1) return null; // can't chunk a scalar
 
         long bytesPerElement = sizeof(float);
-        long maxElementsPerChunk = capBytes / bytesPerElement;
-        if (maxElementsPerChunk < 1) return null;
-        // Account for both input AND output buffers fitting under the cap
-        // simultaneously. Conservative: each chunk allocates two buffers, so
-        // we halve the per-chunk element budget to leave headroom.
-        long chunkElements = Math.Max(1, maxElementsPerChunk / 2);
+        // The cap is per single allocation, not across simultaneously-live
+        // buffers. Each chunk's input and output buffers are separate
+        // allocations and can each be up to the cap; what matters is that
+        // either single buffer fits.
+        long chunkElements = Math.Max(1, capBytes / bytesPerElement);
+        if (chunkElements < 1) return null;
         int chunkCount = (int)((totalElements + chunkElements - 1) / chunkElements);
 
         var options = AiDotNet.Tensors.Engines.DirectGpu.GpuFallbackOptionsHolder.Current;
@@ -1392,7 +1392,23 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
             using var bufferIn = new OwnedBuffer(backend.AllocateBuffer(slice), ownsBuffer: true);
             using var bufferOut = new OwnedBuffer(backend.AllocateBuffer(len), ownsBuffer: true);
-            op(backend, bufferIn.Buffer, bufferOut.Buffer, len);
+            // Mirror the AutocastScope behaviour from TryRunUnaryGpu: when
+            // autocast is enabled, run the kernel on fp16 and convert back
+            // to fp32 for the downloaded result. Without this the chunked
+            // fallback would silently change numeric / perf behaviour vs
+            // the normal GPU path.
+            var fp16Input = Gpu.AutocastScope.MaybeConvertInput(backend, bufferIn.Buffer, len);
+            if (fp16Input is not null)
+            {
+                using var fp16Out = new OwnedBuffer(backend.AllocateBuffer(len), ownsBuffer: true);
+                op(backend, fp16Input, fp16Out.Buffer, len);
+                backend.ConvertToFp32(fp16Out.Buffer, bufferOut.Buffer, len);
+                fp16Input.Dispose();
+            }
+            else
+            {
+                op(backend, bufferIn.Buffer, bufferOut.Buffer, len);
+            }
             var chunkResult = backend.DownloadBuffer(bufferOut.Buffer);
             Array.Copy(chunkResult, 0, resultFloat, offset, len);
         }
@@ -1468,10 +1484,12 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int totalElements = left.Length;
         if (totalElements <= 1) return null;
 
-        // Three buffers per chunk (A, B, C). Conservatively divide by 3.
-        long maxElementsPerChunk = capBytes / sizeof(float) / 3;
-        if (maxElementsPerChunk < 1) return null;
-        long chunkElements = Math.Max(1, maxElementsPerChunk);
+        // Cap is per single allocation, not across all three live buffers.
+        // Each of A, B, C is a separate allocation and can each be up to the
+        // cap independently — what matters is that the largest single buffer
+        // fits.
+        long chunkElements = Math.Max(1, capBytes / sizeof(float));
+        if (chunkElements < 1) return null;
         int chunkCount = (int)((totalElements + chunkElements - 1) / chunkElements);
 
         var options = AiDotNet.Tensors.Engines.DirectGpu.GpuFallbackOptionsHolder.Current;
@@ -1500,7 +1518,25 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             using var bA = new OwnedBuffer(backend.AllocateBuffer(sliceL), ownsBuffer: true);
             using var bB = new OwnedBuffer(backend.AllocateBuffer(sliceR), ownsBuffer: true);
             using var bC = new OwnedBuffer(backend.AllocateBuffer(len), ownsBuffer: true);
-            op(backend, bA.Buffer, bB.Buffer, bC.Buffer, len);
+            // Mirror the AutocastScope behaviour from TryRunBinaryGpu so the
+            // chunked fallback doesn't silently change numeric/perf behaviour
+            // when autocast is enabled.
+            var fp16A = Gpu.AutocastScope.MaybeConvertInput(backend, bA.Buffer, len);
+            var fp16B = Gpu.AutocastScope.MaybeConvertInput(backend, bB.Buffer, len);
+            if (fp16A is not null && fp16B is not null)
+            {
+                using var fp16Out = new OwnedBuffer(backend.AllocateBuffer(len), ownsBuffer: true);
+                op(backend, fp16A, fp16B, fp16Out.Buffer, len);
+                backend.ConvertToFp32(fp16Out.Buffer, bC.Buffer, len);
+                fp16A.Dispose();
+                fp16B.Dispose();
+            }
+            else
+            {
+                fp16A?.Dispose();
+                fp16B?.Dispose();
+                op(backend, bA.Buffer, bB.Buffer, bC.Buffer, len);
+            }
             var chunkResult = backend.DownloadBuffer(bC.Buffer);
             Array.Copy(chunkResult, 0, resultFloat, offset, len);
         }

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -1404,36 +1404,58 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         var resultFloat = new float[totalElements];
         EmitBufferCapEvent(ex, "TryRunUnary", decision: $"chunked_{chunkCount}");
         emittedEvent = true;
-        for (int c = 0; c < chunkCount; c++)
+        // Wrap the chunk loop so any per-chunk failure (allocation OOM,
+        // kernel dispatch, download error) cleanly falls through to CPU
+        // instead of propagating and crashing the user's training step.
+        // Re-throw GpuBufferTooLargeException specifically so the outer
+        // dispatcher's policy (NeverChunk_FailFast) still works.
+        try
         {
-            int offset = c * (int)chunkElements;
-            int len = (int)Math.Min(chunkElements, totalElements - offset);
-            var slice = new float[len];
-            Array.Copy(inputFloat, offset, slice, 0, len);
+            for (int c = 0; c < chunkCount; c++)
+            {
+                int offset = c * (int)chunkElements;
+                int len = (int)Math.Min(chunkElements, totalElements - offset);
+                var slice = new float[len];
+                Array.Copy(inputFloat, offset, slice, 0, len);
 
-            using var bufferIn = new OwnedBuffer(backend.AllocateBuffer(slice), ownsBuffer: true);
-            using var bufferOut = new OwnedBuffer(backend.AllocateBuffer(len), ownsBuffer: true);
-            // Mirror the AutocastScope behaviour from TryRunUnaryGpu: when
-            // autocast is enabled, run the kernel on fp16 and convert back
-            // to fp32 for the downloaded result. Without this the chunked
-            // fallback would silently change numeric / perf behaviour vs
-            // the normal GPU path.
-            var fp16Input = Gpu.AutocastScope.MaybeConvertInput(backend, bufferIn.Buffer, len);
-            if (fp16Input is not null)
-            {
-                using var fp16Out = new OwnedBuffer(backend.AllocateBuffer(len), ownsBuffer: true);
-                op(backend, fp16Input, fp16Out.Buffer, len);
-                backend.ConvertToFp32(fp16Out.Buffer, bufferOut.Buffer, len);
-                fp16Input.Dispose();
+                using var bufferIn = new OwnedBuffer(backend.AllocateBuffer(slice), ownsBuffer: true);
+                using var bufferOut = new OwnedBuffer(backend.AllocateBuffer(len), ownsBuffer: true);
+                // Mirror the AutocastScope behaviour from TryRunUnaryGpu: when
+                // autocast is enabled, run the kernel on fp16 and convert back
+                // to fp32 for the downloaded result. Without this the chunked
+                // fallback would silently change numeric / perf behaviour vs
+                // the normal GPU path.
+                var fp16Input = Gpu.AutocastScope.MaybeConvertInput(backend, bufferIn.Buffer, len);
+                if (fp16Input is not null)
+                {
+                    using var fp16Out = new OwnedBuffer(backend.AllocateBuffer(len), ownsBuffer: true);
+                    op(backend, fp16Input, fp16Out.Buffer, len);
+                    backend.ConvertToFp32(fp16Out.Buffer, bufferOut.Buffer, len);
+                    fp16Input.Dispose();
+                }
+                else
+                {
+                    op(backend, bufferIn.Buffer, bufferOut.Buffer, len);
+                }
+                var chunkResult = backend.DownloadBuffer(bufferOut.Buffer);
+                Array.Copy(chunkResult, 0, resultFloat, offset, len);
             }
-            else
-            {
-                op(backend, bufferIn.Buffer, bufferOut.Buffer, len);
-            }
-            var chunkResult = backend.DownloadBuffer(bufferOut.Buffer);
-            Array.Copy(chunkResult, 0, resultFloat, offset, len);
+            return (T[])(object)resultFloat;
         }
-        return (T[])(object)resultFloat;
+        catch (AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException)
+        {
+            // Sub-chunk also too large — let the outer dispatcher decide
+            // policy (rethrow under NeverChunk_FailFast, CPU otherwise).
+            throw;
+        }
+        catch (Exception)
+        {
+            // OOM / kernel dispatch / download errors during the chunk loop:
+            // emit a cpu_fallback event for telemetry and let the outer
+            // dispatcher route to CPU.
+            EmitBufferCapEvent(ex, "TryRunUnary", decision: "cpu_fallback_chunk_dispatch_error");
+            return null;
+        }
     }
 
     /// <summary>
@@ -1533,41 +1555,58 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         var resultFloat = new float[totalElements];
         EmitBufferCapEvent(ex, "TryRunBinary", decision: $"chunked_{chunkCount}");
         emittedEvent = true;
-        for (int c = 0; c < chunkCount; c++)
+        // Wrap the chunk loop so any per-chunk failure cleanly falls through
+        // to CPU instead of crashing the user's training step. See the same
+        // pattern in TryRunUnaryChunked for the rationale.
+        try
         {
-            int offset = c * (int)chunkElements;
-            int len = (int)Math.Min(chunkElements, totalElements - offset);
-            var sliceL = new float[len];
-            var sliceR = new float[len];
-            Array.Copy(leftFloat, offset, sliceL, 0, len);
-            Array.Copy(rightFloat, offset, sliceR, 0, len);
+            for (int c = 0; c < chunkCount; c++)
+            {
+                int offset = c * (int)chunkElements;
+                int len = (int)Math.Min(chunkElements, totalElements - offset);
+                var sliceL = new float[len];
+                var sliceR = new float[len];
+                Array.Copy(leftFloat, offset, sliceL, 0, len);
+                Array.Copy(rightFloat, offset, sliceR, 0, len);
 
-            using var bA = new OwnedBuffer(backend.AllocateBuffer(sliceL), ownsBuffer: true);
-            using var bB = new OwnedBuffer(backend.AllocateBuffer(sliceR), ownsBuffer: true);
-            using var bC = new OwnedBuffer(backend.AllocateBuffer(len), ownsBuffer: true);
-            // Mirror the AutocastScope behaviour from TryRunBinaryGpu so the
-            // chunked fallback doesn't silently change numeric/perf behaviour
-            // when autocast is enabled.
-            var fp16A = Gpu.AutocastScope.MaybeConvertInput(backend, bA.Buffer, len);
-            var fp16B = Gpu.AutocastScope.MaybeConvertInput(backend, bB.Buffer, len);
-            if (fp16A is not null && fp16B is not null)
-            {
-                using var fp16Out = new OwnedBuffer(backend.AllocateBuffer(len), ownsBuffer: true);
-                op(backend, fp16A, fp16B, fp16Out.Buffer, len);
-                backend.ConvertToFp32(fp16Out.Buffer, bC.Buffer, len);
-                fp16A.Dispose();
-                fp16B.Dispose();
+                using var bA = new OwnedBuffer(backend.AllocateBuffer(sliceL), ownsBuffer: true);
+                using var bB = new OwnedBuffer(backend.AllocateBuffer(sliceR), ownsBuffer: true);
+                using var bC = new OwnedBuffer(backend.AllocateBuffer(len), ownsBuffer: true);
+                // Mirror the AutocastScope behaviour from TryRunBinaryGpu so the
+                // chunked fallback doesn't silently change numeric/perf behaviour
+                // when autocast is enabled.
+                var fp16A = Gpu.AutocastScope.MaybeConvertInput(backend, bA.Buffer, len);
+                var fp16B = Gpu.AutocastScope.MaybeConvertInput(backend, bB.Buffer, len);
+                if (fp16A is not null && fp16B is not null)
+                {
+                    using var fp16Out = new OwnedBuffer(backend.AllocateBuffer(len), ownsBuffer: true);
+                    op(backend, fp16A, fp16B, fp16Out.Buffer, len);
+                    backend.ConvertToFp32(fp16Out.Buffer, bC.Buffer, len);
+                    fp16A.Dispose();
+                    fp16B.Dispose();
+                }
+                else
+                {
+                    fp16A?.Dispose();
+                    fp16B?.Dispose();
+                    op(backend, bA.Buffer, bB.Buffer, bC.Buffer, len);
+                }
+                var chunkResult = backend.DownloadBuffer(bC.Buffer);
+                Array.Copy(chunkResult, 0, resultFloat, offset, len);
             }
-            else
-            {
-                fp16A?.Dispose();
-                fp16B?.Dispose();
-                op(backend, bA.Buffer, bB.Buffer, bC.Buffer, len);
-            }
-            var chunkResult = backend.DownloadBuffer(bC.Buffer);
-            Array.Copy(chunkResult, 0, resultFloat, offset, len);
+            return (T[])(object)resultFloat;
         }
-        return (T[])(object)resultFloat;
+        catch (AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException)
+        {
+            // Sub-chunk also too large — let the outer dispatcher decide
+            // policy (rethrow under NeverChunk_FailFast, CPU otherwise).
+            throw;
+        }
+        catch (Exception)
+        {
+            EmitBufferCapEvent(ex, "TryRunBinary", decision: "cpu_fallback_chunk_dispatch_error");
+            return null;
+        }
     }
 
     // Legacy T[] overloads kept for backward compatibility with IEngine explicit implementations
@@ -1631,17 +1670,28 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (!TryGetBackend(out var backend))
             return null;
 
-        using var bufferA = GetOrAllocateBuffer(backend, input);
-        var bufferB = AllocateOutputBuffer(backend, input.Length);
+        // Issue #285: scalar ops are element-wise, so an over-cap allocation
+        // here should also fall through to CPU per the configured policy
+        // (no chunked path for scalar ops yet — chunking would need to be
+        // added to TryRunScalarChunked; tracked as follow-up).
         try
         {
-            op(backend, bufferA.Buffer, bufferB.Buffer, ToFloatScalar(scalar), input.Length);
-            return FinishGpuOp<T>(backend, bufferB, input.Length);
+            using var bufferA = GetOrAllocateBuffer(backend, input);
+            var bufferB = AllocateOutputBuffer(backend, input.Length);
+            try
+            {
+                op(backend, bufferA.Buffer, bufferB.Buffer, ToFloatScalar(scalar), input.Length);
+                return FinishGpuOp<T>(backend, bufferB, input.Length);
+            }
+            catch
+            {
+                bufferB.Dispose();
+                throw;
+            }
         }
-        catch
+        catch (AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex)
         {
-            bufferB.Dispose();
-            throw;
+            return HandleBufferTooLarge<T>(ex, "TryRunScalar");
         }
     }
 
@@ -1655,18 +1705,25 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (left.Length != right.Length)
             return null;
 
-        using var bufferA = AllocateBufferFromSpan(backend, left);
-        using var bufferB = AllocateBufferFromSpan(backend, right);
-        var bufferC = AllocateOutputBuffer(backend, left.Length);
         try
         {
-            op(backend, bufferA.Buffer, bufferB.Buffer, bufferC.Buffer, left.Length);
-            return FinishGpuOp<T>(backend, bufferC, left.Length);
+            using var bufferA = AllocateBufferFromSpan(backend, left);
+            using var bufferB = AllocateBufferFromSpan(backend, right);
+            var bufferC = AllocateOutputBuffer(backend, left.Length);
+            try
+            {
+                op(backend, bufferA.Buffer, bufferB.Buffer, bufferC.Buffer, left.Length);
+                return FinishGpuOp<T>(backend, bufferC, left.Length);
+            }
+            catch
+            {
+                bufferC.Dispose();
+                throw;
+            }
         }
-        catch
+        catch (AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex)
         {
-            bufferC.Dispose();
-            throw;
+            return HandleBufferTooLarge<T>(ex, "TryRunBinarySpan");
         }
     }
 
@@ -1678,17 +1735,24 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (!TryGetBackend(out var backend))
             return null;
 
-        using var bufferA = AllocateBufferFromSpan(backend, input);
-        var bufferB = AllocateOutputBuffer(backend, input.Length);
         try
         {
-            op(backend, bufferA.Buffer, bufferB.Buffer, ToFloatScalar(scalar), input.Length);
-            return FinishGpuOp<T>(backend, bufferB, input.Length);
+            using var bufferA = AllocateBufferFromSpan(backend, input);
+            var bufferB = AllocateOutputBuffer(backend, input.Length);
+            try
+            {
+                op(backend, bufferA.Buffer, bufferB.Buffer, ToFloatScalar(scalar), input.Length);
+                return FinishGpuOp<T>(backend, bufferB, input.Length);
+            }
+            catch
+            {
+                bufferB.Dispose();
+                throw;
+            }
         }
-        catch
+        catch (AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex)
         {
-            bufferB.Dispose();
-            throw;
+            return HandleBufferTooLarge<T>(ex, "TryRunScalarSpan");
         }
     }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -1252,15 +1252,18 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// exception when <see cref="AiDotNet.Tensors.Engines.DirectGpu.GpuChunkingPolicy.NeverChunk_FailFast"/>
     /// is configured.
     /// </summary>
-    private T[]? HandleBufferTooLarge<T>(AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex, string opName)
+    private T[]? HandleBufferTooLarge<T>(AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex, string opName, bool eventAlreadyEmitted = false)
     {
         var options = AiDotNet.Tensors.Engines.DirectGpu.GpuFallbackOptionsHolder.Current;
         var policy = options.EffectiveChunkingPolicy;
         if (policy == AiDotNet.Tensors.Engines.DirectGpu.GpuChunkingPolicy.NeverChunk_FailFast)
             throw ex;
         // Issue #285 — emit a structured event so users / tooling see the
-        // fallback (configurable via PredictionModelBuilder.ConfigureProfiling).
-        EmitBufferCapEvent(ex, opName, decision: "cpu_fallback");
+        // fallback. Skip when the chunker already recorded its own
+        // reason-specific event (e.g. cpu_fallback_chunks_N_exceeds_M) to
+        // avoid double-counting one logical fallback as two events.
+        if (!eventAlreadyEmitted)
+            EmitBufferCapEvent(ex, opName, decision: "cpu_fallback");
         return null; // CPU fallback
     }
 
@@ -1303,13 +1306,18 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             // (element-wise ops decompose trivially via leading-dim split);
             // fall through to CPU if the chunker bails or policy disallows.
             var policy = AiDotNet.Tensors.Engines.DirectGpu.GpuFallbackOptionsHolder.Current.EffectiveChunkingPolicy;
+            bool chunkerRan = false;
             if (policy == AiDotNet.Tensors.Engines.DirectGpu.GpuChunkingPolicy.AutoChunk
                 || policy == AiDotNet.Tensors.Engines.DirectGpu.GpuChunkingPolicy.AlwaysChunk)
             {
+                chunkerRan = true;
                 var chunked = TryRunUnaryChunked(backend, input, op, ex);
                 if (chunked is not null) return chunked;
             }
-            return HandleBufferTooLarge<T>(ex, opName: "TryRunUnary");
+            // The chunker emits its own reason-specific event when it bails
+            // (cpu_fallback_chunks_N_exceeds_M); don't double-log the generic
+            // cpu_fallback event in that case.
+            return HandleBufferTooLarge<T>(ex, opName: "TryRunUnary", eventAlreadyEmitted: chunkerRan);
         }
     }
 
@@ -1361,12 +1369,15 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (totalElements <= 1) return null; // can't chunk a scalar
 
         long bytesPerElement = sizeof(float);
+        // If the cap can't even fit a single float, chunking is impossible —
+        // bail straight to CPU instead of retrying allocations that will
+        // throw GpuBufferTooLargeException again from inside the chunk loop.
+        if (capBytes < bytesPerElement) return null;
         // The cap is per single allocation, not across simultaneously-live
         // buffers. Each chunk's input and output buffers are separate
         // allocations and can each be up to the cap; what matters is that
         // either single buffer fits.
-        long chunkElements = Math.Max(1, capBytes / bytesPerElement);
-        if (chunkElements < 1) return null;
+        long chunkElements = capBytes / bytesPerElement;
         int chunkCount = (int)((totalElements + chunkElements - 1) / chunkElements);
 
         var options = AiDotNet.Tensors.Engines.DirectGpu.GpuFallbackOptionsHolder.Current;
@@ -1432,13 +1443,15 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         catch (AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex)
         {
             var policy = AiDotNet.Tensors.Engines.DirectGpu.GpuFallbackOptionsHolder.Current.EffectiveChunkingPolicy;
+            bool chunkerRan = false;
             if (policy == AiDotNet.Tensors.Engines.DirectGpu.GpuChunkingPolicy.AutoChunk
                 || policy == AiDotNet.Tensors.Engines.DirectGpu.GpuChunkingPolicy.AlwaysChunk)
             {
+                chunkerRan = true;
                 var chunked = TryRunBinaryChunked(backend, left, right, op, ex);
                 if (chunked is not null) return chunked;
             }
-            return HandleBufferTooLarge<T>(ex, opName: "TryRunBinary");
+            return HandleBufferTooLarge<T>(ex, opName: "TryRunBinary", eventAlreadyEmitted: chunkerRan);
         }
     }
 
@@ -1487,9 +1500,9 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // Cap is per single allocation, not across all three live buffers.
         // Each of A, B, C is a separate allocation and can each be up to the
         // cap independently — what matters is that the largest single buffer
-        // fits.
-        long chunkElements = Math.Max(1, capBytes / sizeof(float));
-        if (chunkElements < 1) return null;
+        // fits. Bail straight to CPU when the cap can't fit a single float.
+        if (capBytes < sizeof(float)) return null;
+        long chunkElements = capBytes / sizeof(float);
         int chunkCount = (int)((totalElements + chunkElements - 1) / chunkElements);
 
         var options = AiDotNet.Tensors.Engines.DirectGpu.GpuFallbackOptionsHolder.Current;

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -1246,6 +1246,45 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     }
 
     /// <summary>
+    /// Issue #285: applies the active <see cref="AiDotNet.Tensors.Engines.DirectGpu.GpuChunkingPolicy"/> to a
+    /// caught <see cref="AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException"/>. Returns
+    /// <c>null</c> when the engine should fall through to CPU; rethrows the
+    /// exception when <see cref="AiDotNet.Tensors.Engines.DirectGpu.GpuChunkingPolicy.NeverChunk_FailFast"/>
+    /// is configured.
+    /// </summary>
+    private T[]? HandleBufferTooLarge<T>(AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex, string opName)
+    {
+        var options = AiDotNet.Tensors.Engines.DirectGpu.GpuFallbackOptionsHolder.Current;
+        var policy = options.EffectiveChunkingPolicy;
+        if (policy == AiDotNet.Tensors.Engines.DirectGpu.GpuChunkingPolicy.NeverChunk_FailFast)
+            throw ex;
+        // Issue #285 — emit a structured event so users / tooling see the
+        // fallback (configurable via PredictionModelBuilder.ConfigureProfiling).
+        EmitBufferCapEvent(ex, opName, decision: "cpu_fallback");
+        return null; // CPU fallback
+    }
+
+    private void EmitBufferCapEvent(AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex, string opName, string decision)
+    {
+        // Zero-overhead when no profiler session is active. When the user
+        // enables one via PredictionModelBuilder.ConfigureProfiling, the
+        // event lands in PredictionModelResult.ProfilingReport.
+        if (Profiling.Profiler.Current is null) return;
+        Profiling.Profiler.RecordInstant(
+            "gpu.fallback.buffer_cap",
+            category: "gpu_dispatch",
+            args: new System.Collections.Generic.Dictionary<string, string>
+            {
+                ["backend"] = ex.Backend,
+                ["op"] = opName,
+                ["device"] = ex.DeviceName,
+                ["requested_bytes"] = ex.RequestedBytes.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                ["cap_bytes"] = ex.DeviceMaxAllocBytes.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                ["decision"] = decision,
+            });
+    }
+
+    /// <summary>
     /// Tensor-aware TryRunUnary: checks GPU activation cache BEFORE triggering CPU materialization.
     /// This is the preferred path for chained GPU operations — avoids wasteful downloads.
     /// </summary>
@@ -1254,6 +1293,28 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (!TryGetBackend(out var backend))
             return null;
 
+        try
+        {
+            return TryRunUnaryGpu(backend, input, op);
+        }
+        catch (AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex)
+        {
+            // Issue #285 — over-cap allocation. Try chunked GPU path first
+            // (element-wise ops decompose trivially via leading-dim split);
+            // fall through to CPU if the chunker bails or policy disallows.
+            var policy = AiDotNet.Tensors.Engines.DirectGpu.GpuFallbackOptionsHolder.Current.EffectiveChunkingPolicy;
+            if (policy == AiDotNet.Tensors.Engines.DirectGpu.GpuChunkingPolicy.AutoChunk
+                || policy == AiDotNet.Tensors.Engines.DirectGpu.GpuChunkingPolicy.AlwaysChunk)
+            {
+                var chunked = TryRunUnaryChunked(backend, input, op, ex);
+                if (chunked is not null) return chunked;
+            }
+            return HandleBufferTooLarge<T>(ex, opName: "TryRunUnary");
+        }
+    }
+
+    private T[]? TryRunUnaryGpu<T>(IDirectGpuBackend backend, Tensor<T> input, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, int> op)
+    {
         using var bufferA = GetOrAllocateBuffer(backend, input);
         var bufferB = AllocateOutputBuffer(backend, input.Length);
         try
@@ -1282,6 +1343,63 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     }
 
     /// <summary>
+    /// Issue #285: chunked element-wise GPU dispatch when a single allocation
+    /// would exceed the per-allocation cap. Splits the tensor's leading dim
+    /// into K chunks so each chunk's buffer fits, runs the op K times, and
+    /// concatenates the result. Returns null when the op cannot be chunked
+    /// (chunk count > MaxChunkCount, scalar input, or per-chunk allocation
+    /// still too large), in which case the caller falls through to CPU.
+    /// </summary>
+    private T[]? TryRunUnaryChunked<T>(IDirectGpuBackend backend, Tensor<T> input, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, int> op, AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex)
+    {
+        // Element-wise ops are 1:1 between input and output elements — every
+        // contiguous slice of the input maps to the same slice of the output.
+        // We split along the largest unit-stride contiguous chunk that fits.
+        long capBytes = ex.DeviceMaxAllocBytes;
+        if (capBytes <= 0) return null;
+        int totalElements = input.Length;
+        if (totalElements <= 1) return null; // can't chunk a scalar
+
+        long bytesPerElement = sizeof(float);
+        long maxElementsPerChunk = capBytes / bytesPerElement;
+        if (maxElementsPerChunk < 1) return null;
+        // Account for both input AND output buffers fitting under the cap
+        // simultaneously. Conservative: each chunk allocates two buffers, so
+        // we halve the per-chunk element budget to leave headroom.
+        long chunkElements = Math.Max(1, maxElementsPerChunk / 2);
+        int chunkCount = (int)((totalElements + chunkElements - 1) / chunkElements);
+
+        var options = AiDotNet.Tensors.Engines.DirectGpu.GpuFallbackOptionsHolder.Current;
+        if (chunkCount > options.EffectiveMaxChunkCount)
+        {
+            // Too many chunks — overhead per dispatch dominates. CPU fallback.
+            EmitBufferCapEvent(ex, "TryRunUnary",
+                decision: $"cpu_fallback_chunks_{chunkCount}_exceeds_{options.EffectiveMaxChunkCount}");
+            return null;
+        }
+
+        var inputArray = input.GetDataArray();
+        if (inputArray is not float[] inputFloat) return null; // only float supported by this path
+
+        var resultFloat = new float[totalElements];
+        EmitBufferCapEvent(ex, "TryRunUnary", decision: $"chunked_{chunkCount}");
+        for (int c = 0; c < chunkCount; c++)
+        {
+            int offset = c * (int)chunkElements;
+            int len = (int)Math.Min(chunkElements, totalElements - offset);
+            var slice = new float[len];
+            Array.Copy(inputFloat, offset, slice, 0, len);
+
+            using var bufferIn = new OwnedBuffer(backend.AllocateBuffer(slice), ownsBuffer: true);
+            using var bufferOut = new OwnedBuffer(backend.AllocateBuffer(len), ownsBuffer: true);
+            op(backend, bufferIn.Buffer, bufferOut.Buffer, len);
+            var chunkResult = backend.DownloadBuffer(bufferOut.Buffer);
+            Array.Copy(chunkResult, 0, resultFloat, offset, len);
+        }
+        return (T[])(object)resultFloat;
+    }
+
+    /// <summary>
     /// Tensor-aware TryRunBinary: checks GPU activation cache BEFORE triggering CPU materialization.
     /// </summary>
     private T[]? TryRunBinary<T>(Tensor<T> left, Tensor<T> right, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, IGpuBuffer, int> op)
@@ -1291,6 +1409,25 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (left.Length != right.Length)
             return null;
 
+        try
+        {
+            return TryRunBinaryGpu(backend, left, right, op);
+        }
+        catch (AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex)
+        {
+            var policy = AiDotNet.Tensors.Engines.DirectGpu.GpuFallbackOptionsHolder.Current.EffectiveChunkingPolicy;
+            if (policy == AiDotNet.Tensors.Engines.DirectGpu.GpuChunkingPolicy.AutoChunk
+                || policy == AiDotNet.Tensors.Engines.DirectGpu.GpuChunkingPolicy.AlwaysChunk)
+            {
+                var chunked = TryRunBinaryChunked(backend, left, right, op, ex);
+                if (chunked is not null) return chunked;
+            }
+            return HandleBufferTooLarge<T>(ex, opName: "TryRunBinary");
+        }
+    }
+
+    private T[]? TryRunBinaryGpu<T>(IDirectGpuBackend backend, Tensor<T> left, Tensor<T> right, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, IGpuBuffer, int> op)
+    {
         using var bufferA = GetOrAllocateBuffer(backend, left);
         using var bufferB = GetOrAllocateBuffer(backend, right);
         var bufferC = AllocateOutputBuffer(backend, left.Length);
@@ -1321,23 +1458,79 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
     }
 
+    /// <summary>
+    /// Issue #285: chunked binary element-wise dispatch.
+    /// </summary>
+    private T[]? TryRunBinaryChunked<T>(IDirectGpuBackend backend, Tensor<T> left, Tensor<T> right, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, IGpuBuffer, int> op, AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex)
+    {
+        long capBytes = ex.DeviceMaxAllocBytes;
+        if (capBytes <= 0) return null;
+        int totalElements = left.Length;
+        if (totalElements <= 1) return null;
+
+        // Three buffers per chunk (A, B, C). Conservatively divide by 3.
+        long maxElementsPerChunk = capBytes / sizeof(float) / 3;
+        if (maxElementsPerChunk < 1) return null;
+        long chunkElements = Math.Max(1, maxElementsPerChunk);
+        int chunkCount = (int)((totalElements + chunkElements - 1) / chunkElements);
+
+        var options = AiDotNet.Tensors.Engines.DirectGpu.GpuFallbackOptionsHolder.Current;
+        if (chunkCount > options.EffectiveMaxChunkCount)
+        {
+            EmitBufferCapEvent(ex, "TryRunBinary",
+                decision: $"cpu_fallback_chunks_{chunkCount}_exceeds_{options.EffectiveMaxChunkCount}");
+            return null;
+        }
+
+        var leftArr = left.GetDataArray();
+        var rightArr = right.GetDataArray();
+        if (leftArr is not float[] leftFloat || rightArr is not float[] rightFloat) return null;
+
+        var resultFloat = new float[totalElements];
+        EmitBufferCapEvent(ex, "TryRunBinary", decision: $"chunked_{chunkCount}");
+        for (int c = 0; c < chunkCount; c++)
+        {
+            int offset = c * (int)chunkElements;
+            int len = (int)Math.Min(chunkElements, totalElements - offset);
+            var sliceL = new float[len];
+            var sliceR = new float[len];
+            Array.Copy(leftFloat, offset, sliceL, 0, len);
+            Array.Copy(rightFloat, offset, sliceR, 0, len);
+
+            using var bA = new OwnedBuffer(backend.AllocateBuffer(sliceL), ownsBuffer: true);
+            using var bB = new OwnedBuffer(backend.AllocateBuffer(sliceR), ownsBuffer: true);
+            using var bC = new OwnedBuffer(backend.AllocateBuffer(len), ownsBuffer: true);
+            op(backend, bA.Buffer, bB.Buffer, bC.Buffer, len);
+            var chunkResult = backend.DownloadBuffer(bC.Buffer);
+            Array.Copy(chunkResult, 0, resultFloat, offset, len);
+        }
+        return (T[])(object)resultFloat;
+    }
+
     // Legacy T[] overloads kept for backward compatibility with IEngine explicit implementations
     private T[]? TryRunUnary<T>(T[] input, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, int> op)
     {
         if (!TryGetBackend(out var backend))
             return null;
 
-        using var bufferA = GetOrAllocateBuffer(backend, input);
-        var bufferB = AllocateOutputBuffer(backend, input.Length);
         try
         {
-            op(backend, bufferA.Buffer, bufferB.Buffer, input.Length);
-            return FinishGpuOp<T>(backend, bufferB, input.Length);
+            using var bufferA = GetOrAllocateBuffer(backend, input);
+            var bufferB = AllocateOutputBuffer(backend, input.Length);
+            try
+            {
+                op(backend, bufferA.Buffer, bufferB.Buffer, input.Length);
+                return FinishGpuOp<T>(backend, bufferB, input.Length);
+            }
+            catch
+            {
+                bufferB.Dispose();
+                throw;
+            }
         }
-        catch
+        catch (AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex)
         {
-            bufferB.Dispose();
-            throw;
+            return HandleBufferTooLarge<T>(ex, "TryRunUnary[T]"); // CPU fallback (no chunking on legacy path)
         }
     }
 
@@ -1348,18 +1541,25 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (left.Length != right.Length)
             return null;
 
-        using var bufferA = GetOrAllocateBuffer(backend, left);
-        using var bufferB = GetOrAllocateBuffer(backend, right);
-        var bufferC = AllocateOutputBuffer(backend, left.Length);
         try
         {
-            op(backend, bufferA.Buffer, bufferB.Buffer, bufferC.Buffer, left.Length);
-            return FinishGpuOp<T>(backend, bufferC, left.Length);
+            using var bufferA = GetOrAllocateBuffer(backend, left);
+            using var bufferB = GetOrAllocateBuffer(backend, right);
+            var bufferC = AllocateOutputBuffer(backend, left.Length);
+            try
+            {
+                op(backend, bufferA.Buffer, bufferB.Buffer, bufferC.Buffer, left.Length);
+                return FinishGpuOp<T>(backend, bufferC, left.Length);
+            }
+            catch
+            {
+                bufferC.Dispose();
+                throw;
+            }
         }
-        catch
+        catch (AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex)
         {
-            bufferC.Dispose();
-            throw;
+            return HandleBufferTooLarge<T>(ex, "TryRunBinary[T]");
         }
     }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -1257,7 +1257,10 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         var options = AiDotNet.Tensors.Engines.DirectGpu.GpuFallbackOptionsHolder.Current;
         var policy = options.EffectiveChunkingPolicy;
         if (policy == AiDotNet.Tensors.Engines.DirectGpu.GpuChunkingPolicy.NeverChunk_FailFast)
-            throw ex;
+            // Preserve original stack trace via ExceptionDispatchInfo (this
+            // method received the exception across a stack frame, so a bare
+            // `throw;` isn't available — `throw ex;` would reset the trace).
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(ex).Throw();
         // Issue #285 — emit a structured event so users / tooling see the
         // fallback. Skip when the chunker already recorded its own
         // reason-specific event (e.g. cpu_fallback_chunks_N_exceeds_M) to
@@ -1306,18 +1309,19 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             // (element-wise ops decompose trivially via leading-dim split);
             // fall through to CPU if the chunker bails or policy disallows.
             var policy = AiDotNet.Tensors.Engines.DirectGpu.GpuFallbackOptionsHolder.Current.EffectiveChunkingPolicy;
-            bool chunkerRan = false;
+            bool chunkerEmittedEvent = false;
             if (policy == AiDotNet.Tensors.Engines.DirectGpu.GpuChunkingPolicy.AutoChunk
                 || policy == AiDotNet.Tensors.Engines.DirectGpu.GpuChunkingPolicy.AlwaysChunk)
             {
-                chunkerRan = true;
-                var chunked = TryRunUnaryChunked(backend, input, op, ex);
+                var chunked = TryRunUnaryChunked(backend, input, op, ex, out chunkerEmittedEvent);
                 if (chunked is not null) return chunked;
             }
-            // The chunker emits its own reason-specific event when it bails
-            // (cpu_fallback_chunks_N_exceeds_M); don't double-log the generic
-            // cpu_fallback event in that case.
-            return HandleBufferTooLarge<T>(ex, opName: "TryRunUnary", eventAlreadyEmitted: chunkerRan);
+            // Skip the generic cpu_fallback event ONLY when the chunker
+            // actually emitted its own reason-specific event. The chunker
+            // can return null without emitting (cap <= 0, non-float type,
+            // single-element tensor) — in that case the generic event is
+            // still the right signal that work moved to CPU.
+            return HandleBufferTooLarge<T>(ex, opName: "TryRunUnary", eventAlreadyEmitted: chunkerEmittedEvent);
         }
     }
 
@@ -1352,17 +1356,21 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     /// <summary>
     /// Issue #285: chunked element-wise GPU dispatch when a single allocation
-    /// would exceed the per-allocation cap. Splits the tensor's leading dim
-    /// into K chunks so each chunk's buffer fits, runs the op K times, and
-    /// concatenates the result. Returns null when the op cannot be chunked
-    /// (chunk count > MaxChunkCount, scalar input, or per-chunk allocation
-    /// still too large), in which case the caller falls through to CPU.
+    /// would exceed the per-allocation cap. Splits the flattened contiguous
+    /// buffer by element count into K chunks so each chunk's buffer fits,
+    /// runs the op K times, and concatenates the result. This works for any
+    /// shape because element-wise ops have a 1:1 map between input and
+    /// output elements — preserving the flat layout preserves correctness.
+    /// Returns null when the op cannot be chunked (chunk count >
+    /// MaxChunkCount, scalar input, non-float element type, or per-element
+    /// cap below sizeof(float)), in which case the caller falls through to
+    /// CPU. The <paramref name="emittedEvent"/> out flag tells the caller
+    /// whether this method already recorded a Profiler fallback event so
+    /// the outer dispatcher doesn't double-log.
     /// </summary>
-    private T[]? TryRunUnaryChunked<T>(IDirectGpuBackend backend, Tensor<T> input, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, int> op, AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex)
+    private T[]? TryRunUnaryChunked<T>(IDirectGpuBackend backend, Tensor<T> input, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, int> op, AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex, out bool emittedEvent)
     {
-        // Element-wise ops are 1:1 between input and output elements — every
-        // contiguous slice of the input maps to the same slice of the output.
-        // We split along the largest unit-stride contiguous chunk that fits.
+        emittedEvent = false;
         long capBytes = ex.DeviceMaxAllocBytes;
         if (capBytes <= 0) return null;
         int totalElements = input.Length;
@@ -1386,6 +1394,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             // Too many chunks — overhead per dispatch dominates. CPU fallback.
             EmitBufferCapEvent(ex, "TryRunUnary",
                 decision: $"cpu_fallback_chunks_{chunkCount}_exceeds_{options.EffectiveMaxChunkCount}");
+            emittedEvent = true;
             return null;
         }
 
@@ -1394,6 +1403,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
         var resultFloat = new float[totalElements];
         EmitBufferCapEvent(ex, "TryRunUnary", decision: $"chunked_{chunkCount}");
+        emittedEvent = true;
         for (int c = 0; c < chunkCount; c++)
         {
             int offset = c * (int)chunkElements;
@@ -1443,15 +1453,14 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         catch (AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex)
         {
             var policy = AiDotNet.Tensors.Engines.DirectGpu.GpuFallbackOptionsHolder.Current.EffectiveChunkingPolicy;
-            bool chunkerRan = false;
+            bool chunkerEmittedEvent = false;
             if (policy == AiDotNet.Tensors.Engines.DirectGpu.GpuChunkingPolicy.AutoChunk
                 || policy == AiDotNet.Tensors.Engines.DirectGpu.GpuChunkingPolicy.AlwaysChunk)
             {
-                chunkerRan = true;
-                var chunked = TryRunBinaryChunked(backend, left, right, op, ex);
+                var chunked = TryRunBinaryChunked(backend, left, right, op, ex, out chunkerEmittedEvent);
                 if (chunked is not null) return chunked;
             }
-            return HandleBufferTooLarge<T>(ex, opName: "TryRunBinary", eventAlreadyEmitted: chunkerRan);
+            return HandleBufferTooLarge<T>(ex, opName: "TryRunBinary", eventAlreadyEmitted: chunkerEmittedEvent);
         }
     }
 
@@ -1488,10 +1497,13 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     }
 
     /// <summary>
-    /// Issue #285: chunked binary element-wise dispatch.
+    /// Issue #285: chunked binary element-wise dispatch. Same flat-element
+    /// chunking strategy as <see cref="TryRunUnaryChunked"/>; works for any
+    /// shape because element-wise ops have a 1:1 input-to-output mapping.
     /// </summary>
-    private T[]? TryRunBinaryChunked<T>(IDirectGpuBackend backend, Tensor<T> left, Tensor<T> right, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, IGpuBuffer, int> op, AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex)
+    private T[]? TryRunBinaryChunked<T>(IDirectGpuBackend backend, Tensor<T> left, Tensor<T> right, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, IGpuBuffer, int> op, AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex, out bool emittedEvent)
     {
+        emittedEvent = false;
         long capBytes = ex.DeviceMaxAllocBytes;
         if (capBytes <= 0) return null;
         int totalElements = left.Length;
@@ -1510,6 +1522,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             EmitBufferCapEvent(ex, "TryRunBinary",
                 decision: $"cpu_fallback_chunks_{chunkCount}_exceeds_{options.EffectiveMaxChunkCount}");
+            emittedEvent = true;
             return null;
         }
 
@@ -1519,6 +1532,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
         var resultFloat = new float[totalElements];
         EmitBufferCapEvent(ex, "TryRunBinary", decision: $"chunked_{chunkCount}");
+        emittedEvent = true;
         for (int c = 0; c < chunkCount; c++)
         {
             int offset = c * (int)chunkElements;

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -1368,7 +1368,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// whether this method already recorded a Profiler fallback event so
     /// the outer dispatcher doesn't double-log.
     /// </summary>
-    private T[]? TryRunUnaryChunked<T>(IDirectGpuBackend backend, Tensor<T> input, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, int> op, AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex, out bool emittedEvent)
+    internal T[]? TryRunUnaryChunked<T>(IDirectGpuBackend backend, Tensor<T> input, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, int> op, AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex, out bool emittedEvent)
     {
         emittedEvent = false;
         long capBytes = ex.DeviceMaxAllocBytes;
@@ -1501,7 +1501,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// chunking strategy as <see cref="TryRunUnaryChunked"/>; works for any
     /// shape because element-wise ops have a 1:1 input-to-output mapping.
     /// </summary>
-    private T[]? TryRunBinaryChunked<T>(IDirectGpuBackend backend, Tensor<T> left, Tensor<T> right, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, IGpuBuffer, int> op, AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex, out bool emittedEvent)
+    internal T[]? TryRunBinaryChunked<T>(IDirectGpuBackend backend, Tensor<T> left, Tensor<T> right, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, IGpuBuffer, int> op, AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex, out bool emittedEvent)
     {
         emittedEvent = false;
         long capBytes = ex.DeviceMaxAllocBytes;

--- a/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
@@ -52,6 +52,9 @@ public class DelegatingGpuBackend : IDirectGpuBackend
     public virtual long LocalMemoryBytes => Inner.LocalMemoryBytes;
 
     /// <inheritdoc/>
+    public virtual long MaxBufferAllocBytes => Inner.MaxBufferAllocBytes;
+
+    /// <inheritdoc/>
     public virtual double TheoreticalGflops => Inner.TheoreticalGflops;
 
     #endregion

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/BufferSizeCapTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/BufferSizeCapTests.cs
@@ -1,0 +1,247 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Issue #285 — buffer size cap + chunked fallback test coverage.
+// Pure-logic tests; integration tests gated on real GPU availability live elsewhere.
+
+#nullable disable
+
+using System;
+using System.Linq;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.DirectGpu;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
+
+public class BufferSizeCapTests
+{
+    // ───────────────────────────────────────────────────────────────────
+    // GpuBufferTooLargeException
+    // ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Exception_PopulatesAllFields()
+    {
+        var ex = new GpuBufferTooLargeException(
+            backend: "OpenCL",
+            requestedBytes: 2_000_000_000,
+            deviceMaxAllocBytes: 1_073_741_824,
+            deviceName: "AMD Radeon RX 5500 XT");
+
+        Assert.Equal("OpenCL", ex.Backend);
+        Assert.Equal(2_000_000_000, ex.RequestedBytes);
+        Assert.Equal(1_073_741_824, ex.DeviceMaxAllocBytes);
+        Assert.Equal("AMD Radeon RX 5500 XT", ex.DeviceName);
+        Assert.IsAssignableFrom<InvalidOperationException>(ex);
+    }
+
+    [Fact]
+    public void Exception_MessageIsHelpful()
+    {
+        var ex = new GpuBufferTooLargeException("OpenCL", 2_000_000_000, 1_073_741_824, "TestGpu");
+        // Message must mention the backend, the bytes (in human form), and a fix hint.
+        Assert.Contains("OpenCL", ex.Message);
+        Assert.Contains("TestGpu", ex.Message);
+        Assert.Contains("Reduce batch size", ex.Message);
+        Assert.Contains("ConfigureGpuAcceleration", ex.Message);
+    }
+
+    [Fact]
+    public void Exception_HandlesNullBackendAndDevice()
+    {
+        var ex = new GpuBufferTooLargeException(null, 1024, 512, null);
+        Assert.NotNull(ex.Message);
+        Assert.NotEmpty(ex.Message);
+    }
+
+    [Fact]
+    public void Exception_HandlesUnknownCap()
+    {
+        // cap == 0 means "device cap unknown / not queried"
+        var ex = new GpuBufferTooLargeException("CUDA", 1024, 0, "CudaDevice");
+        Assert.Contains("unknown", ex.Message);
+    }
+
+    // ───────────────────────────────────────────────────────────────────
+    // GpuBufferSizeGuard.EnsureFits
+    // ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void EnsureFits_ThrowsWhenOverCap()
+    {
+        var ex = Assert.Throws<GpuBufferTooLargeException>(() =>
+            InvokeEnsureFits("OpenCL", requestedBytes: 2048, cap: 1024, deviceName: "X"));
+        Assert.Equal(2048, ex.RequestedBytes);
+        Assert.Equal(1024, ex.DeviceMaxAllocBytes);
+    }
+
+    [Fact]
+    public void EnsureFits_AllowsAtCap()
+    {
+        // Boundary: requestedBytes == cap is allowed (only > throws).
+        InvokeEnsureFits("OpenCL", requestedBytes: 1024, cap: 1024, deviceName: "X");
+    }
+
+    [Fact]
+    public void EnsureFits_AllowsUnderCap()
+    {
+        InvokeEnsureFits("OpenCL", requestedBytes: 512, cap: 1024, deviceName: "X");
+    }
+
+    [Fact]
+    public void EnsureFits_SkipsWhenCapIsZero()
+    {
+        // cap == 0 → skip validation (used when device cap query fails).
+        InvokeEnsureFits("OpenCL", requestedBytes: long.MaxValue, cap: 0, deviceName: "X");
+    }
+
+    [Fact]
+    public void EnsureFits_SkipsWhenRequestedIsZero()
+    {
+        // requestedBytes <= 0 is non-sensical; guard skips and lets the
+        // backend's native call surface its own error if any.
+        InvokeEnsureFits("OpenCL", requestedBytes: 0, cap: 1024, deviceName: "X");
+        InvokeEnsureFits("OpenCL", requestedBytes: -1, cap: 1024, deviceName: "X");
+    }
+
+    private static void InvokeEnsureFits(string backend, long requestedBytes, long cap, string deviceName)
+    {
+        // GpuBufferSizeGuard is internal; access via reflection to test from
+        // the test assembly without needing a public surface.
+        var type = typeof(GpuBufferTooLargeException).Assembly
+            .GetType("AiDotNet.Tensors.Engines.DirectGpu.GpuBufferSizeGuard")!;
+        var method = type.GetMethod("EnsureFits",
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)!;
+        try
+        {
+            method.Invoke(null, new object[] { backend, requestedBytes, cap, deviceName });
+        }
+        catch (System.Reflection.TargetInvocationException tie)
+            when (tie.InnerException is not null)
+        {
+            // Unwrap so callers see the original exception.
+            throw tie.InnerException;
+        }
+    }
+
+    // ───────────────────────────────────────────────────────────────────
+    // GpuFallbackOptions defaults
+    // ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Options_Default_UsesIndustryStandardDefaults()
+    {
+        var opts = GpuFallbackOptions.Default;
+        // All three knobs null on the bare default instance.
+        Assert.Null(opts.MaxBufferBytes);
+        Assert.Null(opts.ChunkingPolicy);
+        Assert.Null(opts.MaxChunkCount);
+
+        // Effective values resolve to the documented defaults.
+        Assert.Equal(2048L, InvokeEffectiveMaxBufferBytes(opts, deviceCap: 2048));
+        Assert.Equal(GpuChunkingPolicy.AutoChunk, InvokeEffectiveChunkingPolicy(opts));
+        Assert.Equal(64, InvokeEffectiveMaxChunkCount(opts));
+    }
+
+    [Fact]
+    public void Options_OverrideOnePropertyAtATime()
+    {
+        var opts = new GpuFallbackOptions
+        {
+            MaxBufferBytes = 512_000_000,
+            ChunkingPolicy = GpuChunkingPolicy.NeverChunk_FailFast,
+            MaxChunkCount = 8,
+        };
+        Assert.Equal(512_000_000, InvokeEffectiveMaxBufferBytes(opts, deviceCap: 1_000_000_000));
+        Assert.Equal(GpuChunkingPolicy.NeverChunk_FailFast, InvokeEffectiveChunkingPolicy(opts));
+        Assert.Equal(8, InvokeEffectiveMaxChunkCount(opts));
+    }
+
+    [Fact]
+    public void Holder_DefaultIsNeverNull()
+    {
+        var prev = GpuFallbackOptionsHolder.Current;
+        try
+        {
+            GpuFallbackOptionsHolder.Current = null!; // forced null assignment
+            Assert.NotNull(GpuFallbackOptionsHolder.Current);
+            Assert.Same(GpuFallbackOptions.Default, GpuFallbackOptionsHolder.Current);
+        }
+        finally
+        {
+            GpuFallbackOptionsHolder.Current = prev;
+        }
+    }
+
+    [Fact]
+    public void Holder_RoundTripsCustomOptions()
+    {
+        var prev = GpuFallbackOptionsHolder.Current;
+        try
+        {
+            var custom = new GpuFallbackOptions { MaxChunkCount = 16 };
+            GpuFallbackOptionsHolder.Current = custom;
+            Assert.Same(custom, GpuFallbackOptionsHolder.Current);
+        }
+        finally
+        {
+            GpuFallbackOptionsHolder.Current = prev;
+        }
+    }
+
+    private static long InvokeEffectiveMaxBufferBytes(GpuFallbackOptions opts, long deviceCap)
+    {
+        var m = typeof(GpuFallbackOptions).GetMethod("EffectiveMaxBufferBytes",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        return (long)m.Invoke(opts, new object[] { deviceCap })!;
+    }
+
+    private static GpuChunkingPolicy InvokeEffectiveChunkingPolicy(GpuFallbackOptions opts)
+    {
+        var p = typeof(GpuFallbackOptions).GetProperty("EffectiveChunkingPolicy",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        return (GpuChunkingPolicy)p.GetValue(opts)!;
+    }
+
+    private static int InvokeEffectiveMaxChunkCount(GpuFallbackOptions opts)
+    {
+        var p = typeof(GpuFallbackOptions).GetProperty("EffectiveMaxChunkCount",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        return (int)p.GetValue(opts)!;
+    }
+
+    // ───────────────────────────────────────────────────────────────────
+    // Smoke test: every backend now exposes MaxBufferAllocBytes via the
+    // IDirectGpuBackend interface (issue #285 pattern propagation).
+    // ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void IDirectGpuBackend_ExposesMaxBufferAllocBytes()
+    {
+        var prop = typeof(IDirectGpuBackend).GetProperty("MaxBufferAllocBytes");
+        Assert.NotNull(prop);
+        Assert.Equal(typeof(long), prop!.PropertyType);
+        Assert.True(prop.CanRead);
+    }
+
+    [Fact]
+    public void AllBackendImplementations_OverrideMaxBufferAllocBytes()
+    {
+        // Every concrete IDirectGpuBackend in the assembly must implement
+        // MaxBufferAllocBytes (issue #285 — without it, the size guard can't
+        // tell what's safe to allocate). Reflection sweep ensures the
+        // property is present on every backend, including ones added later.
+        var assembly = typeof(IDirectGpuBackend).Assembly;
+        var concreteBackends = assembly.GetTypes()
+            .Where(t => !t.IsAbstract && !t.IsInterface
+                        && typeof(IDirectGpuBackend).IsAssignableFrom(t))
+            .ToList();
+        Assert.NotEmpty(concreteBackends);
+        foreach (var backendType in concreteBackends)
+        {
+            var prop = backendType.GetProperty("MaxBufferAllocBytes",
+                System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+            Assert.True(prop is not null,
+                $"{backendType.FullName} does not expose MaxBufferAllocBytes (issue #285).");
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/BufferSizeCapTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/BufferSizeCapTests.cs
@@ -81,7 +81,7 @@ public class BufferSizeCapTests
     public void EnsureFits_ThrowsWhenOverCap()
     {
         var ex = Assert.Throws<GpuBufferTooLargeException>(() =>
-            InvokeEnsureFits("OpenCL", requestedBytes: 2048, cap: 1024, deviceName: "X"));
+            GpuBufferSizeGuard.EnsureFits("OpenCL", requestedBytes: 2048, deviceCap:1024, deviceName: "X"));
         Assert.Equal(2048, ex.RequestedBytes);
         Assert.Equal(1024, ex.DeviceMaxAllocBytes);
     }
@@ -90,20 +90,20 @@ public class BufferSizeCapTests
     public void EnsureFits_AllowsAtCap()
     {
         // Boundary: requestedBytes == cap is allowed (only > throws).
-        InvokeEnsureFits("OpenCL", requestedBytes: 1024, cap: 1024, deviceName: "X");
+        GpuBufferSizeGuard.EnsureFits("OpenCL", requestedBytes: 1024, deviceCap:1024, deviceName: "X");
     }
 
     [Fact]
     public void EnsureFits_AllowsUnderCap()
     {
-        InvokeEnsureFits("OpenCL", requestedBytes: 512, cap: 1024, deviceName: "X");
+        GpuBufferSizeGuard.EnsureFits("OpenCL", requestedBytes: 512, deviceCap:1024, deviceName: "X");
     }
 
     [Fact]
     public void EnsureFits_SkipsWhenCapIsZero()
     {
         // cap == 0 → skip validation (used when device cap query fails).
-        InvokeEnsureFits("OpenCL", requestedBytes: long.MaxValue, cap: 0, deviceName: "X");
+        GpuBufferSizeGuard.EnsureFits("OpenCL", requestedBytes: long.MaxValue, deviceCap:0, deviceName: "X");
     }
 
     [Fact]
@@ -111,28 +111,8 @@ public class BufferSizeCapTests
     {
         // requestedBytes <= 0 is non-sensical; guard skips and lets the
         // backend's native call surface its own error if any.
-        InvokeEnsureFits("OpenCL", requestedBytes: 0, cap: 1024, deviceName: "X");
-        InvokeEnsureFits("OpenCL", requestedBytes: -1, cap: 1024, deviceName: "X");
-    }
-
-    private static void InvokeEnsureFits(string backend, long requestedBytes, long cap, string deviceName)
-    {
-        // GpuBufferSizeGuard is internal; access via reflection to test from
-        // the test assembly without needing a public surface.
-        var type = typeof(GpuBufferTooLargeException).Assembly
-            .GetType("AiDotNet.Tensors.Engines.DirectGpu.GpuBufferSizeGuard")!;
-        var method = type.GetMethod("EnsureFits",
-            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)!;
-        try
-        {
-            method.Invoke(null, new object[] { backend, requestedBytes, cap, deviceName });
-        }
-        catch (System.Reflection.TargetInvocationException tie)
-            when (tie.InnerException is not null)
-        {
-            // Unwrap so callers see the original exception.
-            throw tie.InnerException;
-        }
+        GpuBufferSizeGuard.EnsureFits("OpenCL", requestedBytes: 0, deviceCap:1024, deviceName: "X");
+        GpuBufferSizeGuard.EnsureFits("OpenCL", requestedBytes: -1, deviceCap:1024, deviceName: "X");
     }
 
     // ───────────────────────────────────────────────────────────────────
@@ -201,12 +181,12 @@ public class BufferSizeCapTests
             // Device cap = 4096 (large), user override = 1024 → effective cap = 1024.
             // Request 2048 → should throw.
             var ex = Assert.Throws<GpuBufferTooLargeException>(() =>
-                InvokeEnsureFits("OpenCL", requestedBytes: 2048, cap: 4096, deviceName: "X"));
+                GpuBufferSizeGuard.EnsureFits("OpenCL", requestedBytes: 2048, deviceCap:4096, deviceName: "X"));
             Assert.Equal(1024, ex.DeviceMaxAllocBytes); // exception reports the EFFECTIVE cap
             Assert.Equal(2048, ex.RequestedBytes);
 
             // Same device cap, request 512 → fits under user override.
-            InvokeEnsureFits("OpenCL", requestedBytes: 512, cap: 4096, deviceName: "X");
+            GpuBufferSizeGuard.EnsureFits("OpenCL", requestedBytes: 512, deviceCap:4096, deviceName: "X");
         }
         finally
         {
@@ -228,7 +208,7 @@ public class BufferSizeCapTests
             };
             // Device cap = 1024 wins.
             var ex = Assert.Throws<GpuBufferTooLargeException>(() =>
-                InvokeEnsureFits("OpenCL", requestedBytes: 2048, cap: 1024, deviceName: "X"));
+                GpuBufferSizeGuard.EnsureFits("OpenCL", requestedBytes: 2048, deviceCap:1024, deviceName: "X"));
             Assert.Equal(1024, ex.DeviceMaxAllocBytes);
         }
         finally
@@ -250,7 +230,7 @@ public class BufferSizeCapTests
                 MaxBufferBytes = 256,
             };
             var ex = Assert.Throws<GpuBufferTooLargeException>(() =>
-                InvokeEnsureFits("OpenCL", requestedBytes: 1024, cap: 0, deviceName: "X"));
+                GpuBufferSizeGuard.EnsureFits("OpenCL", requestedBytes: 1024, deviceCap:0, deviceName: "X"));
             Assert.Equal(256, ex.DeviceMaxAllocBytes);
         }
         finally
@@ -275,26 +255,17 @@ public class BufferSizeCapTests
         }
     }
 
+    // Thin wrappers around the internal accessors so the call sites read
+    // naturally. The test assembly has InternalsVisibleTo so we can call
+    // these directly — no reflection (and no coverage-blind spots).
     private static long InvokeEffectiveMaxBufferBytes(GpuFallbackOptions opts, long deviceCap)
-    {
-        var m = typeof(GpuFallbackOptions).GetMethod("EffectiveMaxBufferBytes",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
-        return (long)m.Invoke(opts, new object[] { deviceCap })!;
-    }
+        => opts.EffectiveMaxBufferBytes(deviceCap);
 
     private static GpuChunkingPolicy InvokeEffectiveChunkingPolicy(GpuFallbackOptions opts)
-    {
-        var p = typeof(GpuFallbackOptions).GetProperty("EffectiveChunkingPolicy",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
-        return (GpuChunkingPolicy)p.GetValue(opts)!;
-    }
+        => opts.EffectiveChunkingPolicy;
 
     private static int InvokeEffectiveMaxChunkCount(GpuFallbackOptions opts)
-    {
-        var p = typeof(GpuFallbackOptions).GetProperty("EffectiveMaxChunkCount",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
-        return (int)p.GetValue(opts)!;
-    }
+        => opts.EffectiveMaxChunkCount;
 
     // ───────────────────────────────────────────────────────────────────
     // Smoke test: every backend now exposes MaxBufferAllocBytes via the

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/BufferSizeCapTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/BufferSizeCapTests.cs
@@ -239,6 +239,80 @@ public class BufferSizeCapTests
         }
     }
 
+    // ───────────────────────────────────────────────────────────────────
+    // Chunker decision math (the policy/cap parts that don't need a backend).
+    // The actual chunked GPU dispatch path is integration-tested with real
+    // hardware; a fake-IDirectGpuBackend mock is tracked as follow-up
+    // because the interface has 100+ members and a minimal stub would
+    // dwarf this PR's scope.
+    // ───────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(/*capBytes*/ 16,        /*totalElements*/ 100,       /*expectedChunkCount*/ 25)]
+    [InlineData(/*capBytes*/ 1024,      /*totalElements*/ 256,       /*expectedChunkCount*/ 1)]
+    [InlineData(/*capBytes*/ 4,         /*totalElements*/ 10,        /*expectedChunkCount*/ 10)]
+    [InlineData(/*capBytes*/ 1_000_000, /*totalElements*/ 1_000_000, /*expectedChunkCount*/ 4)]
+    public void ChunkCount_ComputedFromCapAndElements(long capBytes, int totalElements, int expectedChunkCount)
+    {
+        // Mirror the chunker's math: chunkElements = capBytes / sizeof(float),
+        // chunkCount = ceil(totalElements / chunkElements). Asserting the
+        // formula here catches any future change to the chunk-sizing rule
+        // (e.g. if someone reintroduces a divide-by-2 conservative bound).
+        const int BytesPerFloat = sizeof(float);
+        Assert.True(capBytes >= BytesPerFloat,
+            "test scenario must have cap >= one float — chunker bails earlier otherwise");
+        long chunkElements = capBytes / BytesPerFloat;
+        int chunkCount = (int)((totalElements + chunkElements - 1) / chunkElements);
+        Assert.Equal(expectedChunkCount, chunkCount);
+    }
+
+    [Fact]
+    public void ChunkCount_ExceedingMaxChunkCount_TriggersFallback()
+    {
+        // When chunker would need more chunks than EffectiveMaxChunkCount,
+        // the policy is to bail to CPU (chunk-spawn overhead dominates).
+        var prev = GpuFallbackOptionsHolder.Current;
+        try
+        {
+            GpuFallbackOptionsHolder.Current = new GpuFallbackOptions { MaxChunkCount = 4 };
+            Assert.Equal(4, GpuFallbackOptionsHolder.Current.EffectiveMaxChunkCount);
+
+            // 100 elements with cap = 4 bytes → 100 chunks > 4 cap → fallback.
+            const long CapBytes = 4;
+            const int TotalElements = 100;
+            long chunkElements = CapBytes / sizeof(float);
+            int chunkCount = (int)((TotalElements + chunkElements - 1) / chunkElements);
+            Assert.True(chunkCount > GpuFallbackOptionsHolder.Current.EffectiveMaxChunkCount,
+                "test scenario must be designed to exceed the configured MaxChunkCount");
+        }
+        finally
+        {
+            GpuFallbackOptionsHolder.Current = prev;
+        }
+    }
+
+    [Fact]
+    public void ChunkerPolicy_NeverChunkFailFast_RethrowsException()
+    {
+        // GpuChunkingPolicy.NeverChunk_FailFast → engine rethrows the
+        // GpuBufferTooLargeException instead of falling back. Confirm the
+        // policy enum value is wired into EffectiveChunkingPolicy.
+        var prev = GpuFallbackOptionsHolder.Current;
+        try
+        {
+            GpuFallbackOptionsHolder.Current = new GpuFallbackOptions
+            {
+                ChunkingPolicy = GpuChunkingPolicy.NeverChunk_FailFast,
+            };
+            Assert.Equal(GpuChunkingPolicy.NeverChunk_FailFast,
+                GpuFallbackOptionsHolder.Current.EffectiveChunkingPolicy);
+        }
+        finally
+        {
+            GpuFallbackOptionsHolder.Current = prev;
+        }
+    }
+
     [Fact]
     public void Holder_RoundTripsCustomOptions()
     {

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/BufferSizeCapTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/BufferSizeCapTests.cs
@@ -12,6 +12,18 @@ using Xunit;
 
 namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
 
+/// <summary>
+/// Several tests in this class mutate
+/// <see cref="GpuFallbackOptionsHolder.Current"/>, which is process-wide.
+/// Without the non-parallel collection an unrelated test running on
+/// another thread could observe the mutated value, producing flaky
+/// failures. The xUnit collection definition below disables parallel
+/// execution for this class so the holder mutation is safe.
+/// </summary>
+[CollectionDefinition("BufferSizeCapTests", DisableParallelization = true)]
+public class BufferSizeCapTestsCollection { }
+
+[Collection("BufferSizeCapTests")]
 public class BufferSizeCapTests
 {
     // ───────────────────────────────────────────────────────────────────

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/BufferSizeCapTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/BufferSizeCapTests.cs
@@ -173,6 +173,81 @@ public class BufferSizeCapTests
     }
 
     [Fact]
+    public void EnsureFits_AppliesUserOverride_LowerCapWins()
+    {
+        // Regression for review-comment #9: GpuFallbackOptions.MaxBufferBytes
+        // override must actually be applied by the size guard. Set the user
+        // override to a value LOWER than the device cap and confirm the guard
+        // throws when requestedBytes > userOverride but <= deviceCap.
+        var prev = GpuFallbackOptionsHolder.Current;
+        try
+        {
+            GpuFallbackOptionsHolder.Current = new GpuFallbackOptions
+            {
+                MaxBufferBytes = 1024, // user-override cap
+            };
+            // Device cap = 4096 (large), user override = 1024 → effective cap = 1024.
+            // Request 2048 → should throw.
+            var ex = Assert.Throws<GpuBufferTooLargeException>(() =>
+                InvokeEnsureFits("OpenCL", requestedBytes: 2048, cap: 4096, deviceName: "X"));
+            Assert.Equal(1024, ex.DeviceMaxAllocBytes); // exception reports the EFFECTIVE cap
+            Assert.Equal(2048, ex.RequestedBytes);
+
+            // Same device cap, request 512 → fits under user override.
+            InvokeEnsureFits("OpenCL", requestedBytes: 512, cap: 4096, deviceName: "X");
+        }
+        finally
+        {
+            GpuFallbackOptionsHolder.Current = prev;
+        }
+    }
+
+    [Fact]
+    public void EnsureFits_DeviceCapLowerThanUserOverride_DeviceWins()
+    {
+        // When user override > device cap, the device cap is the hard limit
+        // (we can't allocate past it). Effective cap = min(device, user).
+        var prev = GpuFallbackOptionsHolder.Current;
+        try
+        {
+            GpuFallbackOptionsHolder.Current = new GpuFallbackOptions
+            {
+                MaxBufferBytes = 100_000_000_000, // user wants huge cap
+            };
+            // Device cap = 1024 wins.
+            var ex = Assert.Throws<GpuBufferTooLargeException>(() =>
+                InvokeEnsureFits("OpenCL", requestedBytes: 2048, cap: 1024, deviceName: "X"));
+            Assert.Equal(1024, ex.DeviceMaxAllocBytes);
+        }
+        finally
+        {
+            GpuFallbackOptionsHolder.Current = prev;
+        }
+    }
+
+    [Fact]
+    public void EnsureFits_UserOverride_TrustedWhenDeviceCapUnknown()
+    {
+        // When the device cap query failed (cap == 0) but user supplied an
+        // override, the user value is used as the cap.
+        var prev = GpuFallbackOptionsHolder.Current;
+        try
+        {
+            GpuFallbackOptionsHolder.Current = new GpuFallbackOptions
+            {
+                MaxBufferBytes = 256,
+            };
+            var ex = Assert.Throws<GpuBufferTooLargeException>(() =>
+                InvokeEnsureFits("OpenCL", requestedBytes: 1024, cap: 0, deviceName: "X"));
+            Assert.Equal(256, ex.DeviceMaxAllocBytes);
+        }
+        finally
+        {
+            GpuFallbackOptionsHolder.Current = prev;
+        }
+    }
+
+    [Fact]
     public void Holder_RoundTripsCustomOptions()
     {
         var prev = GpuFallbackOptionsHolder.Current;

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/ChunkerWithMockBackendTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/ChunkerWithMockBackendTests.cs
@@ -1,0 +1,242 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Issue #285 — chunker integration tests using DispatchProxy mock.
+// Gated to non-Framework targets: DispatchProxy (.NET Core 5+) isn't
+// on .NET Framework, and the mock backend depends on it.
+
+#if !NETFRAMEWORK
+#nullable disable
+
+using System;
+using System.Linq;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.DirectGpu;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
+
+[Collection("BufferSizeCapTests")] // shares isolation with the cap tests
+public class ChunkerWithMockBackendTests
+{
+    // ───────────────────────────────────────────────────────────────────
+    // TryRunUnaryChunked
+    // ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void TryRunUnaryChunked_SplitsAcrossCap_ProducesCorrectResult()
+    {
+        // Cap = 16 bytes (4 floats per chunk). Tensor of 12 elements →
+        // 3 chunks. Op: y = x * 2. Verify the chunker dispatches 3 times
+        // and the concatenated output equals the elementwise op applied
+        // to the whole input.
+        var state = new MockBackendState { MaxBufferAllocBytes = 16 };
+        var backend = MockDirectGpuBackend.Create(state);
+        var engine = new DirectGpuTensorEngine(); // backend not used for chunker — we pass mock directly
+
+        var input = new Tensor<float>(new float[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 }, new[] { 12 });
+        var ex = new GpuBufferTooLargeException("Mock", requestedBytes: 48, deviceMaxAllocBytes: 16, deviceName: "MockDevice");
+
+        // Op: y[i] = x[i] * 2. The mock's MockGpuBuffer wraps the host
+        // float[] directly, so we read in/write out via Data.
+        var result = engine.TryRunUnaryChunked<float>(backend, input,
+            (b, bIn, bOut, len) =>
+            {
+                state.UnaryOpCalls++;
+                var bufferIn = (MockGpuBuffer)bIn;
+                var bufferOut = (MockGpuBuffer)bOut;
+                for (int i = 0; i < len; i++) bufferOut.Data[i] = bufferIn.Data[i] * 2;
+            },
+            ex,
+            out bool emitted);
+
+        Assert.NotNull(result);
+        Assert.Equal(12, result!.Length);
+        for (int i = 0; i < 12; i++)
+            Assert.Equal((i + 1) * 2f, result[i]);
+        Assert.Equal(3, state.UnaryOpCalls); // 12 elements / 4 per chunk
+        Assert.True(emitted, "chunker should emit a chunked_N event when it dispatches");
+    }
+
+    [Fact]
+    public void TryRunUnaryChunked_ChunkCountExceedsMax_ReturnsNullAndEmits()
+    {
+        // Cap = 4 bytes (1 element per chunk), 100 elements → 100 chunks.
+        // EffectiveMaxChunkCount = 4 → chunker bails to CPU.
+        var state = new MockBackendState { MaxBufferAllocBytes = 4 };
+        var backend = MockDirectGpuBackend.Create(state);
+        var engine = new DirectGpuTensorEngine();
+
+        var input = new Tensor<float>(new float[100], new[] { 100 });
+        var ex = new GpuBufferTooLargeException("Mock", 400, 4, "MockDevice");
+
+        var prev = GpuFallbackOptionsHolder.Current;
+        try
+        {
+            GpuFallbackOptionsHolder.Current = new GpuFallbackOptions { MaxChunkCount = 4 };
+
+            var result = engine.TryRunUnaryChunked<float>(backend, input,
+                (b, bIn, bOut, len) => state.UnaryOpCalls++,
+                ex,
+                out bool emitted);
+
+            Assert.Null(result);                        // CPU fallback
+            Assert.Equal(0, state.UnaryOpCalls);        // op never dispatched
+            Assert.True(emitted, "chunker emits a cpu_fallback_chunks_N_exceeds_M event before bailing");
+        }
+        finally
+        {
+            GpuFallbackOptionsHolder.Current = prev;
+        }
+    }
+
+    [Fact]
+    public void TryRunUnaryChunked_ScalarTensor_ReturnsNullWithoutEmitting()
+    {
+        // 1-element tensors can't be chunked — bail to CPU silently.
+        var state = new MockBackendState { MaxBufferAllocBytes = 4 };
+        var backend = MockDirectGpuBackend.Create(state);
+        var engine = new DirectGpuTensorEngine();
+
+        var input = new Tensor<float>(new float[] { 42 }, new[] { 1 });
+        var ex = new GpuBufferTooLargeException("Mock", 4, 4, "MockDevice");
+
+        var result = engine.TryRunUnaryChunked<float>(backend, input,
+            (b, bIn, bOut, len) => state.UnaryOpCalls++,
+            ex,
+            out bool emitted);
+
+        Assert.Null(result);
+        Assert.False(emitted, "scalar input bails before any event is recorded");
+    }
+
+    [Fact]
+    public void TryRunUnaryChunked_CapBelowSingleFloat_ReturnsNullWithoutEmitting()
+    {
+        // Cap < sizeof(float) → can't even fit a single element. Don't
+        // retry chunking; bail to CPU silently.
+        var state = new MockBackendState { MaxBufferAllocBytes = 3 };
+        var backend = MockDirectGpuBackend.Create(state);
+        var engine = new DirectGpuTensorEngine();
+
+        var input = new Tensor<float>(new float[] { 1, 2, 3, 4 }, new[] { 4 });
+        var ex = new GpuBufferTooLargeException("Mock", 16, 3, "MockDevice");
+
+        var result = engine.TryRunUnaryChunked<float>(backend, input,
+            (b, bIn, bOut, len) => state.UnaryOpCalls++,
+            ex,
+            out bool emitted);
+
+        Assert.Null(result);
+        Assert.False(emitted);
+    }
+
+    [Fact]
+    public void TryRunUnaryChunked_CapZero_ReturnsNullWithoutEmitting()
+    {
+        // capBytes <= 0 means the device cap is unknown; chunker can't
+        // make a sizing decision and bails.
+        var state = new MockBackendState { MaxBufferAllocBytes = 0 };
+        var backend = MockDirectGpuBackend.Create(state);
+        var engine = new DirectGpuTensorEngine();
+
+        var input = new Tensor<float>(new float[] { 1, 2, 3, 4 }, new[] { 4 });
+        var ex = new GpuBufferTooLargeException("Mock", 16, 0, "MockDevice");
+
+        var result = engine.TryRunUnaryChunked<float>(backend, input,
+            (b, bIn, bOut, len) => state.UnaryOpCalls++,
+            ex,
+            out bool emitted);
+
+        Assert.Null(result);
+        Assert.False(emitted);
+    }
+
+    // ───────────────────────────────────────────────────────────────────
+    // TryRunBinaryChunked
+    // ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void TryRunBinaryChunked_SplitsAcrossCap_ProducesCorrectResult()
+    {
+        // Cap = 16 bytes (4 floats per chunk). Two 8-element tensors →
+        // 2 chunks. Op: c = a + b.
+        var state = new MockBackendState { MaxBufferAllocBytes = 16 };
+        var backend = MockDirectGpuBackend.Create(state);
+        var engine = new DirectGpuTensorEngine();
+
+        var left = new Tensor<float>(new float[] { 1, 2, 3, 4, 5, 6, 7, 8 }, new[] { 8 });
+        var right = new Tensor<float>(new float[] { 10, 20, 30, 40, 50, 60, 70, 80 }, new[] { 8 });
+        var ex = new GpuBufferTooLargeException("Mock", 32, 16, "MockDevice");
+
+        var result = engine.TryRunBinaryChunked<float>(backend, left, right,
+            (b, bA, bB, bC, len) =>
+            {
+                state.BinaryOpCalls++;
+                var ba = (MockGpuBuffer)bA;
+                var bb = (MockGpuBuffer)bB;
+                var bc = (MockGpuBuffer)bC;
+                for (int i = 0; i < len; i++) bc.Data[i] = ba.Data[i] + bb.Data[i];
+            },
+            ex,
+            out bool emitted);
+
+        Assert.NotNull(result);
+        Assert.Equal(8, result!.Length);
+        for (int i = 0; i < 8; i++)
+            Assert.Equal(left.GetFlat(i) + right.GetFlat(i), result[i]);
+        Assert.Equal(2, state.BinaryOpCalls);
+        Assert.True(emitted);
+    }
+
+    [Fact]
+    public void TryRunBinaryChunked_ChunkCountExceedsMax_ReturnsNullAndEmits()
+    {
+        var state = new MockBackendState { MaxBufferAllocBytes = 4 };
+        var backend = MockDirectGpuBackend.Create(state);
+        var engine = new DirectGpuTensorEngine();
+
+        var left = new Tensor<float>(new float[100], new[] { 100 });
+        var right = new Tensor<float>(new float[100], new[] { 100 });
+        var ex = new GpuBufferTooLargeException("Mock", 400, 4, "MockDevice");
+
+        var prev = GpuFallbackOptionsHolder.Current;
+        try
+        {
+            GpuFallbackOptionsHolder.Current = new GpuFallbackOptions { MaxChunkCount = 4 };
+
+            var result = engine.TryRunBinaryChunked<float>(backend, left, right,
+                (b, bA, bB, bC, len) => state.BinaryOpCalls++,
+                ex,
+                out bool emitted);
+
+            Assert.Null(result);
+            Assert.Equal(0, state.BinaryOpCalls);
+            Assert.True(emitted);
+        }
+        finally
+        {
+            GpuFallbackOptionsHolder.Current = prev;
+        }
+    }
+
+    [Fact]
+    public void TryRunBinaryChunked_ScalarTensor_ReturnsNullWithoutEmitting()
+    {
+        var state = new MockBackendState { MaxBufferAllocBytes = 4 };
+        var backend = MockDirectGpuBackend.Create(state);
+        var engine = new DirectGpuTensorEngine();
+
+        var left = new Tensor<float>(new float[] { 1 }, new[] { 1 });
+        var right = new Tensor<float>(new float[] { 2 }, new[] { 1 });
+        var ex = new GpuBufferTooLargeException("Mock", 4, 4, "MockDevice");
+
+        var result = engine.TryRunBinaryChunked<float>(backend, left, right,
+            (b, bA, bB, bC, len) => state.BinaryOpCalls++,
+            ex,
+            out bool emitted);
+
+        Assert.Null(result);
+        Assert.False(emitted);
+    }
+}
+#endif

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/ChunkerWithMockBackendTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/ChunkerWithMockBackendTests.cs
@@ -220,6 +220,89 @@ public class ChunkerWithMockBackendTests
     }
 
     [Fact]
+    public void TryRunUnaryChunked_OpThrows_FallsThroughToCpu()
+    {
+        // Per PR #288 review: a per-chunk dispatch failure (kernel error,
+        // download error, OOM-during-loop, etc.) should fall through to
+        // CPU rather than propagate and crash the training step. The op
+        // delegate throws on the second chunk; the chunker catches and
+        // returns null + emits a cpu_fallback_chunk_dispatch_error event.
+        var state = new MockBackendState { MaxBufferAllocBytes = 16 };
+        var backend = MockDirectGpuBackend.Create(state);
+        var engine = new DirectGpuTensorEngine();
+
+        var input = new Tensor<float>(new float[] { 1, 2, 3, 4, 5, 6, 7, 8 }, new[] { 8 });
+        var ex = new GpuBufferTooLargeException("Mock", 32, 16, "MockDevice");
+
+        var result = engine.TryRunUnaryChunked<float>(backend, input,
+            (b, bIn, bOut, len) =>
+            {
+                state.UnaryOpCalls++;
+                if (state.UnaryOpCalls == 2)
+                    throw new InvalidOperationException("simulated kernel dispatch error");
+            },
+            ex,
+            out bool emitted);
+
+        Assert.Null(result);
+        Assert.Equal(2, state.UnaryOpCalls); // first chunk ran, second threw
+        Assert.True(emitted, "chunker emits an event before+after the failure");
+    }
+
+    [Fact]
+    public void TryRunBinaryChunked_OpThrows_FallsThroughToCpu()
+    {
+        var state = new MockBackendState { MaxBufferAllocBytes = 16 };
+        var backend = MockDirectGpuBackend.Create(state);
+        var engine = new DirectGpuTensorEngine();
+
+        var left = new Tensor<float>(new float[] { 1, 2, 3, 4, 5, 6, 7, 8 }, new[] { 8 });
+        var right = new Tensor<float>(new float[] { 10, 20, 30, 40, 50, 60, 70, 80 }, new[] { 8 });
+        var ex = new GpuBufferTooLargeException("Mock", 32, 16, "MockDevice");
+
+        var result = engine.TryRunBinaryChunked<float>(backend, left, right,
+            (b, bA, bB, bC, len) =>
+            {
+                state.BinaryOpCalls++;
+                if (state.BinaryOpCalls == 1)
+                    throw new InvalidOperationException("simulated dispatch error");
+            },
+            ex,
+            out bool emitted);
+
+        Assert.Null(result);
+        Assert.True(emitted);
+    }
+
+    [Fact]
+    public void TryRunUnaryChunked_FailFastPolicy_RethrowsSubChunkException()
+    {
+        // Edge case: with NeverChunk_FailFast, a sub-chunk that ALSO can't
+        // fit (GpuBufferTooLargeException raised during the chunk loop)
+        // should re-throw rather than be swallowed. Verifies the catch
+        // separates "buffer too large" (rethrow) from "dispatch error"
+        // (swallow → CPU).
+        var state = new MockBackendState { MaxBufferAllocBytes = 16 };
+        var backend = MockDirectGpuBackend.Create(state);
+        var engine = new DirectGpuTensorEngine();
+
+        var input = new Tensor<float>(new float[] { 1, 2, 3, 4, 5, 6, 7, 8 }, new[] { 8 });
+        var ex = new GpuBufferTooLargeException("Mock", 32, 16, "MockDevice");
+
+        // Op delegate throws GpuBufferTooLargeException on first chunk —
+        // simulating a sub-allocation that's still too big somehow.
+        Assert.Throws<GpuBufferTooLargeException>(() =>
+            engine.TryRunUnaryChunked<float>(backend, input,
+                (b, bIn, bOut, len) =>
+                {
+                    state.UnaryOpCalls++;
+                    throw new GpuBufferTooLargeException("Mock", 999, 16, "MockDevice");
+                },
+                ex,
+                out bool _));
+    }
+
+    [Fact]
     public void TryRunBinaryChunked_ScalarTensor_ReturnsNullWithoutEmitting()
     {
         var state = new MockBackendState { MaxBufferAllocBytes = 4 };

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/MockDirectGpuBackend.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/MockDirectGpuBackend.cs
@@ -52,6 +52,14 @@ internal sealed class MockGpuBuffer : IGpuBuffer
 internal sealed class MockBackendState
 {
     public long MaxBufferAllocBytes { get; set; } = long.MaxValue;
+    /// <summary>
+    /// Total device memory — semantically separate from the per-allocation
+    /// cap. Tests that care about the distinction (e.g. activation-cache
+    /// sizing logic that uses VRAM, not per-allocation cap) can override
+    /// this independently. Defaults to long.MaxValue — same as the cap —
+    /// so existing tests don't have to set both.
+    /// </summary>
+    public long GlobalMemoryBytes { get; set; } = long.MaxValue;
     public string DeviceName { get; set; } = "MockDevice";
     public string DeviceVendor { get; set; } = "Mock";
     public List<int> AllocationSizes { get; } = new();
@@ -89,7 +97,7 @@ public class MockDirectGpuBackend : DispatchProxy
             case "get_DeviceName": return _state.DeviceName;
             case "get_DeviceVendor": return _state.DeviceVendor;
             case "get_ComputeUnits": return 1;
-            case "get_GlobalMemoryBytes": return _state.MaxBufferAllocBytes;
+            case "get_GlobalMemoryBytes": return _state.GlobalMemoryBytes;
             case "get_LocalMemoryBytes": return 0L;
             case "get_MaxBufferAllocBytes": return _state.MaxBufferAllocBytes;
             case "get_TheoreticalGflops": return 0.0;

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/MockDirectGpuBackend.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/MockDirectGpuBackend.cs
@@ -1,0 +1,138 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Issue #285 — DispatchProxy-based mock IDirectGpuBackend for chunker tests.
+// Implements a tiny set of methods (the ones the chunker actually calls)
+// and throws NotImplementedException for everything else. Sidesteps the
+// 470-member interface surface that would require a hand-written stub.
+//
+// DispatchProxy lives in System.Reflection from .NET Core 5+; it is NOT
+// available on .NET Framework, so the whole mock + its tests are gated
+// to non-Framework targets. Coverage on net10.0 is the meaningful one
+// for codecov.
+
+#if !NETFRAMEWORK
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.DirectGpu;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
+
+/// <summary>
+/// Minimal IGpuBuffer wrapping a host float[] — the mock backend's
+/// "device buffer" is just the array itself.
+/// </summary>
+internal sealed class MockGpuBuffer : IGpuBuffer
+{
+    public float[] Data { get; }
+    public int Size => Data.Length;
+    public long SizeInBytes => (long)Data.Length * sizeof(float);
+    public IntPtr Handle { get; }
+
+    public MockGpuBuffer(float[] data)
+    {
+        Data = data;
+        // Use a synthetic handle (allocation counter) so distinct buffers
+        // get distinct handles; tests don't dereference these pointers.
+        Handle = (IntPtr)System.Threading.Interlocked.Increment(ref _handleCounter);
+    }
+
+    private static int _handleCounter;
+    public void Dispose() { }
+}
+
+/// <summary>
+/// State shared between the mock backend and tests. Captures every
+/// allocation request and configures the per-allocation cap that the
+/// mock reports via <see cref="IDirectGpuBackend.MaxBufferAllocBytes"/>.
+/// </summary>
+internal sealed class MockBackendState
+{
+    public long MaxBufferAllocBytes { get; set; } = long.MaxValue;
+    public string DeviceName { get; set; } = "MockDevice";
+    public string DeviceVendor { get; set; } = "Mock";
+    public List<int> AllocationSizes { get; } = new();
+    public int DownloadBufferCalls { get; set; }
+    public int UnaryOpCalls { get; set; }
+    public int BinaryOpCalls { get; set; }
+}
+
+/// <summary>
+/// DispatchProxy implementation that backs <see cref="MockDirectGpuBackend"/>.
+/// Implements only the methods the chunker actually calls; everything else
+/// throws <see cref="NotImplementedException"/>. The 470-method
+/// IDirectGpuBackend surface is too large to stub by hand — this lets us
+/// pretend to be a backend cheaply.
+/// </summary>
+public class MockDirectGpuBackend : DispatchProxy
+{
+    private MockBackendState _state;
+
+    internal static IDirectGpuBackend Create(MockBackendState state)
+    {
+        var proxy = (MockDirectGpuBackend)Create<IDirectGpuBackend, MockDirectGpuBackend>();
+        proxy._state = state;
+        return (IDirectGpuBackend)(object)proxy;
+    }
+
+    protected override object Invoke(MethodInfo targetMethod, object[] args)
+    {
+        switch (targetMethod.Name)
+        {
+            // ── Identity / device info — implemented ──
+            case "get_IsAvailable": return true;
+            case "get_BackendName": return "Mock";
+            case "get_DeviceType": return TensorDevice.OpenCL; // any value works
+            case "get_DeviceName": return _state.DeviceName;
+            case "get_DeviceVendor": return _state.DeviceVendor;
+            case "get_ComputeUnits": return 1;
+            case "get_GlobalMemoryBytes": return _state.MaxBufferAllocBytes;
+            case "get_LocalMemoryBytes": return 0L;
+            case "get_MaxBufferAllocBytes": return _state.MaxBufferAllocBytes;
+            case "get_TheoreticalGflops": return 0.0;
+            case "Dispose": return null!;
+
+            // ── Buffer allocation + download — what the chunker uses ──
+            case "AllocateBuffer" when args.Length == 1 && args[0] is float[] arr:
+            {
+                long bytes = (long)arr.Length * sizeof(float);
+                GpuBufferSizeGuard.EnsureFits("Mock", bytes, _state.MaxBufferAllocBytes, _state.DeviceName);
+                _state.AllocationSizes.Add(arr.Length);
+                // Copy so subsequent host writes don't affect the buffer.
+                var copy = new float[arr.Length];
+                Array.Copy(arr, copy, arr.Length);
+                return new MockGpuBuffer(copy);
+            }
+            case "AllocateBuffer" when args.Length == 1 && args[0] is int size:
+            {
+                long bytes = (long)size * sizeof(float);
+                GpuBufferSizeGuard.EnsureFits("Mock", bytes, _state.MaxBufferAllocBytes, _state.DeviceName);
+                _state.AllocationSizes.Add(size);
+                return new MockGpuBuffer(new float[size]);
+            }
+            case "DownloadBuffer" when args.Length == 1:
+            {
+                _state.DownloadBufferCalls++;
+                var b = (MockGpuBuffer)args[0]!;
+                var copy = new float[b.Size];
+                Array.Copy(b.Data, copy, b.Size);
+                return copy;
+            }
+            case "DownloadBuffer" when args.Length == 2:
+            {
+                _state.DownloadBufferCalls++;
+                var b = (MockGpuBuffer)args[0]!;
+                var dest = (float[])args[1]!;
+                Array.Copy(b.Data, dest, b.Size);
+                return null!;
+            }
+        }
+        throw new NotImplementedException(
+            $"MockDirectGpuBackend does not implement {targetMethod.Name}. " +
+            "Add a case in MockDirectGpuBackend.Invoke if your test exercises this op.");
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

Closes #285. The OpenCL allocation crash (`CL_INVALID_BUFFER_SIZE = -61`) reported in the issue was a missing per-allocation cap check. The same pattern exists across all 5 other GPU backends, so the fix rolls out repository-wide.

## What this PR adds

1. **`GpuBufferTooLargeException`** (public). Typed exception with `Backend`, `RequestedBytes`, `DeviceMaxAllocBytes`, `DeviceName`. Message points users at concrete fixes ("Reduce batch size or split the tensor; … or call ConfigureGpuAcceleration AlwaysCpu").
2. **`GpuBufferSizeGuard.EnsureFits`** (internal). Cross-backend size validator called from every buffer ctor before the native allocation.
3. **`MaxBufferAllocBytes` on `IDirectGpuBackend`** + implementations on all 6 backends:
    - OpenCL: `CL_DEVICE_MAX_MEM_ALLOC_SIZE`
    - CUDA / HIP: `cuDeviceTotalMem` / `hipDeviceProp.totalGlobalMem`
    - Metal: `MTLDevice.recommendedMaxWorkingSetSize`
    - Vulkan: `VkPhysicalDeviceLimits.maxStorageBufferRange`
    - WebGPU: `GPUSupportedLimits.maxBufferSize`
4. **Engine-level chunked fallback** in `DirectGpuTensorEngine.TryRunUnary` / `TryRunBinary`. On `GpuBufferTooLargeException`:
    - Element-wise chunking — split leading dim into K chunks so each chunk's buffer fits, dispatch K times, concatenate.
    - Returns null on chunk count > `MaxChunkCount` (default 64) → routes to CPU.
5. **`GpuFallbackOptions`** (public) with three nullable knobs:
    - `MaxBufferBytes` — override the device cap (testing / misreports)
    - `ChunkingPolicy` — `AutoChunk` (default) / `AlwaysChunk` / `NeverChunk_FailFast` / `NeverChunk_FallbackToCpu`
    - `MaxChunkCount` — bail to CPU when chunks exceed this (default 64)
   Process-wide ambient via `GpuFallbackOptionsHolder.Current`. The AiDotNet facade's `ConfigureGpuAcceleration` maps user config onto this.
6. **Profiler diagnostic events**. `gpu.fallback.buffer_cap` events emit on each chunking / CPU-fallback decision with backend / op / device / requested / cap tags. Zero overhead when profiler inactive; visible in `PredictionModelResult.ProfilingReport` when the user calls `ConfigureProfiling`.

## Tests

15 passing in `BufferSizeCapTests`:
- Exception field + message correctness (incl. unknown-cap and null-args)
- Guard boundary (at-cap allowed, just-over throws, cap=0 skipped, requested<=0 skipped)
- Options default + override + holder round-trip
- `IDirectGpuBackend` exposes `MaxBufferAllocBytes`
- Reflection sweep: every concrete backend implementation overrides it (catches future backends added without the property)

## Test plan

- [x] All backends compile (net10.0 + net471)
- [x] 15 logic tests pass
- [x] No regressions in existing GPU test suites (158 passed; 1 pre-existing CUDA hardware failure unrelated to this PR)
- [ ] Real-hardware OpenCL integration test (gated on CI runner availability) — file follow-up issue

## Remaining work (follow-up issues)

This PR closes the immediate "training crashes on over-cap allocation" bug across all 6 backends. **Not in this PR (filed as separate follow-ups):**

- Native chunked dispatch for MatMul / Conv2D / Attention via `cuBLAS strided batched GEMM` / `cuDNN`. Currently these ops fall through to CPU when over cap; chunking unlocks GPU performance for very large training shapes.
- Auto-detected `MTLDevice.maxBufferLength` for Metal (currently uses `recommendedMaxWorkingSetSize` as a conservative upper bound).
- Real-hardware integration tests on GitHub OpenCL runner.

Closes #285.

🤖 Generated with [Claude Code](https://claude.com/claude-code)