### PR TITLE
fix(#285): accurate profiler event tracking + actual op names in chunker fallbacks

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -1272,19 +1272,31 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     /// <summary>
     /// Records a "gpu.fallback.buffer_cap" Profiler event. Returns true
-    /// when the profiler was active and accepted the event; false when no
-    /// session was active and nothing was recorded. Callers that track
-    /// "did this dispatch already log a decision?" must use the return
-    /// value, not assume an event always lands — the de-dup logic in
-    /// HandleBufferTooLarge depends on this distinction.
+    /// when the active profiler session actually accepted and enqueued
+    /// the event; false when nothing was recorded — either because no
+    /// session is active, OR because the active session dropped the
+    /// event (CPU capture disabled via <c>ProfilerActivities.None</c>,
+    /// schedule phase in <c>Wait</c>/<c>Stopped</c>, or session disposed).
+    /// Callers that track "did this dispatch already log a decision?"
+    /// must use the return value: only suppress the outer fallback
+    /// marker when the inner event was *actually* recorded — otherwise
+    /// telemetry is silently lost for profiled-but-inactive sessions.
     /// </summary>
     private bool EmitBufferCapEvent(AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex, string opName, string decision)
     {
-        // Zero-overhead when no profiler session is active. When the user
-        // enables one via PredictionModelBuilder.ConfigureProfiling, the
-        // event lands in PredictionModelResult.ProfilingReport.
+        // Zero-overhead fast-path when no profiler session is active.
+        // RecordInstant would itself short-circuit, but checking up front
+        // avoids the dictionary allocation below for the common no-session
+        // case where the event is going to be dropped anyway.
         if (Profiling.Profiler.Current is null) return false;
-        Profiling.Profiler.RecordInstant(
+        // RecordInstant returns true only when the event landed; that
+        // means the session is active, CPU capture is enabled, and the
+        // schedule phase is Active or Warmup. False means the session
+        // existed but dropped this specific event — in which case we
+        // must NOT report success, otherwise the outer dispatcher's
+        // generic cpu_fallback marker gets suppressed and the user sees
+        // no record of the fallback at all.
+        return Profiling.Profiler.RecordInstant(
             "gpu.fallback.buffer_cap",
             category: "gpu_dispatch",
             args: new System.Collections.Generic.Dictionary<string, string>
@@ -1296,7 +1308,6 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 ["cap_bytes"] = ex.DeviceMaxAllocBytes.ToString(System.Globalization.CultureInfo.InvariantCulture),
                 ["decision"] = decision,
             });
-        return true;
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -1480,8 +1480,12 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             // OOM / kernel dispatch / download errors during the chunk loop:
             // emit a cpu_fallback event for telemetry and let the outer
-            // dispatcher route to CPU.
-            EmitBufferCapEvent(ex, opName, decision: "cpu_fallback_chunk_dispatch_error");
+            // dispatcher route to CPU. OR-into emittedEvent so that even
+            // if the earlier "chunked_N" event was dropped (e.g. session
+            // entered Wait phase between the two records) the outer
+            // dispatcher still suppresses its own marker when this one
+            // lands — otherwise we'd double-log the fallback.
+            emittedEvent |= EmitBufferCapEvent(ex, opName, decision: "cpu_fallback_chunk_dispatch_error");
             return null;
         }
     }
@@ -1631,7 +1635,11 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
         catch (Exception)
         {
-            EmitBufferCapEvent(ex, opName, decision: "cpu_fallback_chunk_dispatch_error");
+            // OR-into emittedEvent: see the matching unary catch block
+            // for the rationale — accumulating prevents a double-log
+            // when the earlier "chunked_N" event was dropped but this
+            // one landed.
+            emittedEvent |= EmitBufferCapEvent(ex, opName, decision: "cpu_fallback_chunk_dispatch_error");
             return null;
         }
     }

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -1270,12 +1270,20 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         return null; // CPU fallback
     }
 
-    private void EmitBufferCapEvent(AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex, string opName, string decision)
+    /// <summary>
+    /// Records a "gpu.fallback.buffer_cap" Profiler event. Returns true
+    /// when the profiler was active and accepted the event; false when no
+    /// session was active and nothing was recorded. Callers that track
+    /// "did this dispatch already log a decision?" must use the return
+    /// value, not assume an event always lands — the de-dup logic in
+    /// HandleBufferTooLarge depends on this distinction.
+    /// </summary>
+    private bool EmitBufferCapEvent(AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex, string opName, string decision)
     {
         // Zero-overhead when no profiler session is active. When the user
         // enables one via PredictionModelBuilder.ConfigureProfiling, the
         // event lands in PredictionModelResult.ProfilingReport.
-        if (Profiling.Profiler.Current is null) return;
+        if (Profiling.Profiler.Current is null) return false;
         Profiling.Profiler.RecordInstant(
             "gpu.fallback.buffer_cap",
             category: "gpu_dispatch",
@@ -1288,13 +1296,21 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 ["cap_bytes"] = ex.DeviceMaxAllocBytes.ToString(System.Globalization.CultureInfo.InvariantCulture),
                 ["decision"] = decision,
             });
+        return true;
     }
 
     /// <summary>
     /// Tensor-aware TryRunUnary: checks GPU activation cache BEFORE triggering CPU materialization.
     /// This is the preferred path for chained GPU operations — avoids wasteful downloads.
     /// </summary>
-    private T[]? TryRunUnary<T>(Tensor<T> input, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, int> op)
+    /// <remarks>
+    /// <paramref name="callerName"/> is captured automatically via
+    /// <see cref="System.Runtime.CompilerServices.CallerMemberNameAttribute"/>
+    /// so the Profiler events emitted on cap-miss carry the actual op
+    /// name (Relu, Gelu, Add, …) instead of the dispatcher label.
+    /// </remarks>
+    private T[]? TryRunUnary<T>(Tensor<T> input, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, int> op,
+        [System.Runtime.CompilerServices.CallerMemberName] string callerName = "")
     {
         if (!TryGetBackend(out var backend))
             return null;
@@ -1313,7 +1329,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             if (policy == AiDotNet.Tensors.Engines.DirectGpu.GpuChunkingPolicy.AutoChunk
                 || policy == AiDotNet.Tensors.Engines.DirectGpu.GpuChunkingPolicy.AlwaysChunk)
             {
-                var chunked = TryRunUnaryChunked(backend, input, op, ex, out chunkerEmittedEvent);
+                var chunked = TryRunUnaryChunked(backend, input, op, ex, out chunkerEmittedEvent, callerName);
                 if (chunked is not null) return chunked;
             }
             // Skip the generic cpu_fallback event ONLY when the chunker
@@ -1321,7 +1337,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             // can return null without emitting (cap <= 0, non-float type,
             // single-element tensor) — in that case the generic event is
             // still the right signal that work moved to CPU.
-            return HandleBufferTooLarge<T>(ex, opName: "TryRunUnary", eventAlreadyEmitted: chunkerEmittedEvent);
+            return HandleBufferTooLarge<T>(ex, opName: callerName, eventAlreadyEmitted: chunkerEmittedEvent);
         }
     }
 
@@ -1368,7 +1384,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// whether this method already recorded a Profiler fallback event so
     /// the outer dispatcher doesn't double-log.
     /// </summary>
-    internal T[]? TryRunUnaryChunked<T>(IDirectGpuBackend backend, Tensor<T> input, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, int> op, AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex, out bool emittedEvent)
+    internal T[]? TryRunUnaryChunked<T>(IDirectGpuBackend backend, Tensor<T> input, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, int> op, AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex, out bool emittedEvent, string opName = "Unary")
     {
         emittedEvent = false;
         long capBytes = ex.DeviceMaxAllocBytes;
@@ -1392,9 +1408,11 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (chunkCount > options.EffectiveMaxChunkCount)
         {
             // Too many chunks — overhead per dispatch dominates. CPU fallback.
-            EmitBufferCapEvent(ex, "TryRunUnary",
+            // emittedEvent reflects WHETHER an event was actually recorded
+            // (false when no profiler session is active) so the outer
+            // dispatcher knows whether to record its own cpu_fallback marker.
+            emittedEvent = EmitBufferCapEvent(ex, opName,
                 decision: $"cpu_fallback_chunks_{chunkCount}_exceeds_{options.EffectiveMaxChunkCount}");
-            emittedEvent = true;
             return null;
         }
 
@@ -1402,8 +1420,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (inputArray is not float[] inputFloat) return null; // only float supported by this path
 
         var resultFloat = new float[totalElements];
-        EmitBufferCapEvent(ex, "TryRunUnary", decision: $"chunked_{chunkCount}");
-        emittedEvent = true;
+        emittedEvent = EmitBufferCapEvent(ex, opName, decision: $"chunked_{chunkCount}");
         // Wrap the chunk loop so any per-chunk failure (allocation OOM,
         // kernel dispatch, download error) cleanly falls through to CPU
         // instead of propagating and crashing the user's training step.
@@ -1453,7 +1470,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             // OOM / kernel dispatch / download errors during the chunk loop:
             // emit a cpu_fallback event for telemetry and let the outer
             // dispatcher route to CPU.
-            EmitBufferCapEvent(ex, "TryRunUnary", decision: "cpu_fallback_chunk_dispatch_error");
+            EmitBufferCapEvent(ex, opName, decision: "cpu_fallback_chunk_dispatch_error");
             return null;
         }
     }
@@ -1461,7 +1478,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// <summary>
     /// Tensor-aware TryRunBinary: checks GPU activation cache BEFORE triggering CPU materialization.
     /// </summary>
-    private T[]? TryRunBinary<T>(Tensor<T> left, Tensor<T> right, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, IGpuBuffer, int> op)
+    private T[]? TryRunBinary<T>(Tensor<T> left, Tensor<T> right, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, IGpuBuffer, int> op,
+        [System.Runtime.CompilerServices.CallerMemberName] string callerName = "")
     {
         if (!TryGetBackend(out var backend))
             return null;
@@ -1479,10 +1497,10 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             if (policy == AiDotNet.Tensors.Engines.DirectGpu.GpuChunkingPolicy.AutoChunk
                 || policy == AiDotNet.Tensors.Engines.DirectGpu.GpuChunkingPolicy.AlwaysChunk)
             {
-                var chunked = TryRunBinaryChunked(backend, left, right, op, ex, out chunkerEmittedEvent);
+                var chunked = TryRunBinaryChunked(backend, left, right, op, ex, out chunkerEmittedEvent, callerName);
                 if (chunked is not null) return chunked;
             }
-            return HandleBufferTooLarge<T>(ex, opName: "TryRunBinary", eventAlreadyEmitted: chunkerEmittedEvent);
+            return HandleBufferTooLarge<T>(ex, opName: callerName, eventAlreadyEmitted: chunkerEmittedEvent);
         }
     }
 
@@ -1523,7 +1541,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// chunking strategy as <see cref="TryRunUnaryChunked"/>; works for any
     /// shape because element-wise ops have a 1:1 input-to-output mapping.
     /// </summary>
-    internal T[]? TryRunBinaryChunked<T>(IDirectGpuBackend backend, Tensor<T> left, Tensor<T> right, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, IGpuBuffer, int> op, AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex, out bool emittedEvent)
+    internal T[]? TryRunBinaryChunked<T>(IDirectGpuBackend backend, Tensor<T> left, Tensor<T> right, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, IGpuBuffer, int> op, AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex, out bool emittedEvent, string opName = "Binary")
     {
         emittedEvent = false;
         long capBytes = ex.DeviceMaxAllocBytes;
@@ -1542,9 +1560,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         var options = AiDotNet.Tensors.Engines.DirectGpu.GpuFallbackOptionsHolder.Current;
         if (chunkCount > options.EffectiveMaxChunkCount)
         {
-            EmitBufferCapEvent(ex, "TryRunBinary",
+            emittedEvent = EmitBufferCapEvent(ex, opName,
                 decision: $"cpu_fallback_chunks_{chunkCount}_exceeds_{options.EffectiveMaxChunkCount}");
-            emittedEvent = true;
             return null;
         }
 
@@ -1553,8 +1570,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (leftArr is not float[] leftFloat || rightArr is not float[] rightFloat) return null;
 
         var resultFloat = new float[totalElements];
-        EmitBufferCapEvent(ex, "TryRunBinary", decision: $"chunked_{chunkCount}");
-        emittedEvent = true;
+        emittedEvent = EmitBufferCapEvent(ex, opName, decision: $"chunked_{chunkCount}");
         // Wrap the chunk loop so any per-chunk failure cleanly falls through
         // to CPU instead of crashing the user's training step. See the same
         // pattern in TryRunUnaryChunked for the rationale.
@@ -1604,13 +1620,14 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
         catch (Exception)
         {
-            EmitBufferCapEvent(ex, "TryRunBinary", decision: "cpu_fallback_chunk_dispatch_error");
+            EmitBufferCapEvent(ex, opName, decision: "cpu_fallback_chunk_dispatch_error");
             return null;
         }
     }
 
     // Legacy T[] overloads kept for backward compatibility with IEngine explicit implementations
-    private T[]? TryRunUnary<T>(T[] input, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, int> op)
+    private T[]? TryRunUnary<T>(T[] input, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, int> op,
+        [System.Runtime.CompilerServices.CallerMemberName] string callerName = "")
     {
         if (!TryGetBackend(out var backend))
             return null;
@@ -1632,11 +1649,12 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
         catch (AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex)
         {
-            return HandleBufferTooLarge<T>(ex, "TryRunUnary[T]"); // CPU fallback (no chunking on legacy path)
+            return HandleBufferTooLarge<T>(ex, callerName); // CPU fallback (no chunking on legacy path)
         }
     }
 
-    private T[]? TryRunBinary<T>(T[] left, T[] right, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, IGpuBuffer, int> op)
+    private T[]? TryRunBinary<T>(T[] left, T[] right, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, IGpuBuffer, int> op,
+        [System.Runtime.CompilerServices.CallerMemberName] string callerName = "")
     {
         if (!TryGetBackend(out var backend))
             return null;
@@ -1661,11 +1679,12 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
         catch (AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex)
         {
-            return HandleBufferTooLarge<T>(ex, "TryRunBinary[T]");
+            return HandleBufferTooLarge<T>(ex, callerName);
         }
     }
 
-    private T[]? TryRunScalar<T>(T[] input, T scalar, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, float, int> op)
+    private T[]? TryRunScalar<T>(T[] input, T scalar, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, float, int> op,
+        [System.Runtime.CompilerServices.CallerMemberName] string callerName = "")
     {
         if (!TryGetBackend(out var backend))
             return null;
@@ -1691,14 +1710,15 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
         catch (AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex)
         {
-            return HandleBufferTooLarge<T>(ex, "TryRunScalar");
+            return HandleBufferTooLarge<T>(ex, callerName);
         }
     }
 
     /// <summary>
     /// Span-based binary operation that avoids ToArray() allocation for matrix operations.
     /// </summary>
-    private T[]? TryRunBinarySpan<T>(ReadOnlySpan<T> left, ReadOnlySpan<T> right, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, IGpuBuffer, int> op)
+    private T[]? TryRunBinarySpan<T>(ReadOnlySpan<T> left, ReadOnlySpan<T> right, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, IGpuBuffer, int> op,
+        [System.Runtime.CompilerServices.CallerMemberName] string callerName = "")
     {
         if (!TryGetBackend(out var backend))
             return null;
@@ -1723,14 +1743,15 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
         catch (AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex)
         {
-            return HandleBufferTooLarge<T>(ex, "TryRunBinarySpan");
+            return HandleBufferTooLarge<T>(ex, callerName);
         }
     }
 
     /// <summary>
     /// Span-based scalar operation that avoids ToArray() allocation for matrix operations.
     /// </summary>
-    private T[]? TryRunScalarSpan<T>(ReadOnlySpan<T> input, T scalar, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, float, int> op)
+    private T[]? TryRunScalarSpan<T>(ReadOnlySpan<T> input, T scalar, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, float, int> op,
+        [System.Runtime.CompilerServices.CallerMemberName] string callerName = "")
     {
         if (!TryGetBackend(out var backend))
             return null;
@@ -1752,7 +1773,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
         catch (AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex)
         {
-            return HandleBufferTooLarge<T>(ex, "TryRunScalarSpan");
+            return HandleBufferTooLarge<T>(ex, callerName);
         }
     }
 

--- a/src/AiDotNet.Tensors/Engines/Profiling/Profiler.cs
+++ b/src/AiDotNet.Tensors/Engines/Profiling/Profiler.cs
@@ -128,10 +128,17 @@ public static class Profiler
     }
 
     /// <summary>Records an instantaneous event on the active session.
-    /// No-op when no session is active.</summary>
-    public static void RecordInstant(string name, string category = "instant", IReadOnlyDictionary<string, string>? args = null)
+    /// Returns <c>true</c> when the event was accepted; <c>false</c> when
+    /// no session is active or the active session dropped the event
+    /// (CPU capture disabled, schedule phase Wait/Stopped, disposed).
+    /// Callers tracking de-duplication against an outer fallback need
+    /// the bool: only suppressing the outer event when the inner event
+    /// was actually recorded prevents silent telemetry loss.</summary>
+    public static bool RecordInstant(string name, string category = "instant", IReadOnlyDictionary<string, string>? args = null)
     {
-        Current?.RecordInstant(name, category, args);
+        var session = Current;
+        if (session is null) return false;
+        return session.RecordInstant(name, category, args);
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/Profiling/ProfilerSession.cs
+++ b/src/AiDotNet.Tensors/Engines/Profiling/ProfilerSession.cs
@@ -144,19 +144,27 @@ public sealed class ProfilerSession : IDisposable
     /// <summary>
     /// Records an instantaneous event (no duration). Useful for one-shot
     /// markers like "autotune cache miss" or "recompile triggered".
+    /// Returns <c>true</c> when the event was accepted and enqueued;
+    /// <c>false</c> when it was dropped because the session is disposed,
+    /// CPU capture is disabled (<see cref="ProfilerActivities.None"/>),
+    /// or the schedule phase is <see cref="ProfilerSchedulePhase.Wait"/>
+    /// or <see cref="ProfilerSchedulePhase.Stopped"/>. Callers that
+    /// dedupe against an outer fallback marker need this distinction
+    /// so a no-op record doesn't suppress the outer event.
     /// </summary>
-    public void RecordInstant(string name, string category, IReadOnlyDictionary<string, string>? args = null)
+    public bool RecordInstant(string name, string category, IReadOnlyDictionary<string, string>? args = null)
     {
-        if (_disposed) return;
-        if (!IsCpuCaptureEnabled()) return;
+        if (_disposed) return false;
+        if (!IsCpuCaptureEnabled()) return false;
         var phase = CurrentPhase;
-        if (phase != ProfilerSchedulePhase.Active && phase != ProfilerSchedulePhase.Warmup) return;
+        if (phase != ProfilerSchedulePhase.Active && phase != ProfilerSchedulePhase.Warmup) return false;
 
         long ts = TicksToMicros(Stopwatch.GetTimestamp() - _sessionStartTicks);
         EnqueueEvent(TraceEvent.Instant(
             name, category, ts,
             _processId, System.Environment.CurrentManagedThreadId,
             args));
+        return true;
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/Profiling/ProfilerSession.cs
+++ b/src/AiDotNet.Tensors/Engines/Profiling/ProfilerSession.cs
@@ -92,9 +92,19 @@ public sealed class ProfilerSession : IDisposable
     public void Step()
     {
         if (_disposed) throw new ObjectDisposedException(nameof(ProfilerSession));
-        int prev = _stepIndex;
-        int next = prev + 1;
-        _stepIndex = next;
+        int prev;
+        int next;
+        // Update _stepIndex under _bufferGate so RecordInstant's phase
+        // check (also under the lock) cannot observe a torn or stale
+        // value during the transition. Without this serialisation the
+        // accept-bool returned by RecordInstant could disagree with
+        // what actually landed in the queue.
+        lock (_bufferGate)
+        {
+            prev = _stepIndex;
+            next = prev + 1;
+            _stepIndex = next;
+        }
 
         if (_schedule is null) return;
         // Drop the warmup-window samples before the measured window opens. Without
@@ -151,20 +161,44 @@ public sealed class ProfilerSession : IDisposable
     /// or <see cref="ProfilerSchedulePhase.Stopped"/>. Callers that
     /// dedupe against an outer fallback marker need this distinction
     /// so a no-op record doesn't suppress the outer event.
+    ///
+    /// <para><b>Atomicity:</b> the schedule-phase check and the queue
+    /// enqueue happen inside the same <c>_bufferGate</c> lock as
+    /// <see cref="Step"/>'s <c>_stepIndex</c> update. A concurrent
+    /// <see cref="Step"/> cannot flip the phase between this method's
+    /// check and its enqueue, so the returned bool is consistent with
+    /// what actually landed in the queue.</para>
     /// </summary>
     public bool RecordInstant(string name, string category, IReadOnlyDictionary<string, string>? args = null)
     {
         if (_disposed) return false;
         if (!IsCpuCaptureEnabled()) return false;
-        var phase = CurrentPhase;
-        if (phase != ProfilerSchedulePhase.Active && phase != ProfilerSchedulePhase.Warmup) return false;
 
+        // Build the event timestamp/payload outside the lock to minimise
+        // lock-hold time. Phase classification and enqueue happen under
+        // _bufferGate so a concurrent Step() can't desynchronise them.
         long ts = TicksToMicros(Stopwatch.GetTimestamp() - _sessionStartTicks);
-        EnqueueEvent(TraceEvent.Instant(
-            name, category, ts,
-            _processId, System.Environment.CurrentManagedThreadId,
-            args));
-        return true;
+        int threadId = System.Environment.CurrentManagedThreadId;
+        TraceEvent ev = TraceEvent.Instant(name, category, ts, _processId, threadId, args);
+
+        lock (_bufferGate)
+        {
+            // Re-read disposal under the lock — Dispose may have raced.
+            if (_disposed) return false;
+            var phase = CurrentPhase;
+            if (phase != ProfilerSchedulePhase.Active && phase != ProfilerSchedulePhase.Warmup) return false;
+
+            // Inline the enqueue body so we don't re-enter the lock via
+            // EnqueueEvent (re-entrant locks work but inlining makes the
+            // accept/drop transaction unambiguous in one critical section).
+            if (++_eventCount > _maxEvents)
+            {
+                if (_events.TryDequeue(out _)) _eventCount--;
+                else _eventCount--;
+            }
+            _events.Enqueue(ev);
+            return true;
+        }
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/BufferSizeCapTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/BufferSizeCapTests.cs
@@ -240,11 +240,10 @@ public class BufferSizeCapTests
     }
 
     // ───────────────────────────────────────────────────────────────────
-    // Chunker decision math (the policy/cap parts that don't need a backend).
-    // The actual chunked GPU dispatch path is integration-tested with real
-    // hardware; a fake-IDirectGpuBackend mock is tracked as follow-up
-    // because the interface has 100+ members and a minimal stub would
-    // dwarf this PR's scope.
+    // Chunker decision math — pure-formula tests for the chunk-count and
+    // policy logic. End-to-end chunker behaviour (dispatch, output
+    // correctness, error paths) is covered in ChunkerWithMockBackendTests
+    // via the DispatchProxy-based MockDirectGpuBackend.
     // ───────────────────────────────────────────────────────────────────
 
     [Theory]

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/ChunkerWithMockBackendTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/ChunkerWithMockBackendTests.cs
@@ -10,6 +10,7 @@ using System;
 using System.Linq;
 using AiDotNet.Tensors.Engines;
 using AiDotNet.Tensors.Engines.DirectGpu;
+using AiDotNet.Tensors.Engines.Profiling;
 using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
 
@@ -35,6 +36,11 @@ public class ChunkerWithMockBackendTests
 
         var input = new Tensor<float>(new float[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 }, new[] { 12 });
         var ex = new GpuBufferTooLargeException("Mock", requestedBytes: 48, deviceMaxAllocBytes: 16, deviceName: "MockDevice");
+
+        // Profiler session must be active for emittedEvent to reflect a
+        // recorded event. Without it, the chunker still dispatches but
+        // emittedEvent stays false (zero-overhead-when-off contract).
+        using var session = Profiler.Profile();
 
         // Op: y[i] = x[i] * 2. The mock's MockGpuBuffer wraps the host
         // float[] directly, so we read in/write out via Data.
@@ -70,6 +76,7 @@ public class ChunkerWithMockBackendTests
         var ex = new GpuBufferTooLargeException("Mock", 400, 4, "MockDevice");
 
         var prev = GpuFallbackOptionsHolder.Current;
+        using var session = Profiler.Profile();
         try
         {
             GpuFallbackOptionsHolder.Current = new GpuFallbackOptions { MaxChunkCount = 4 };
@@ -168,6 +175,8 @@ public class ChunkerWithMockBackendTests
         var right = new Tensor<float>(new float[] { 10, 20, 30, 40, 50, 60, 70, 80 }, new[] { 8 });
         var ex = new GpuBufferTooLargeException("Mock", 32, 16, "MockDevice");
 
+        using var session = Profiler.Profile();
+
         var result = engine.TryRunBinaryChunked<float>(backend, left, right,
             (b, bA, bB, bC, len) =>
             {
@@ -200,6 +209,7 @@ public class ChunkerWithMockBackendTests
         var ex = new GpuBufferTooLargeException("Mock", 400, 4, "MockDevice");
 
         var prev = GpuFallbackOptionsHolder.Current;
+        using var session = Profiler.Profile();
         try
         {
             GpuFallbackOptionsHolder.Current = new GpuFallbackOptions { MaxChunkCount = 4 };
@@ -234,6 +244,8 @@ public class ChunkerWithMockBackendTests
         var input = new Tensor<float>(new float[] { 1, 2, 3, 4, 5, 6, 7, 8 }, new[] { 8 });
         var ex = new GpuBufferTooLargeException("Mock", 32, 16, "MockDevice");
 
+        using var session = Profiler.Profile();
+
         var result = engine.TryRunUnaryChunked<float>(backend, input,
             (b, bIn, bOut, len) =>
             {
@@ -259,6 +271,8 @@ public class ChunkerWithMockBackendTests
         var left = new Tensor<float>(new float[] { 1, 2, 3, 4, 5, 6, 7, 8 }, new[] { 8 });
         var right = new Tensor<float>(new float[] { 10, 20, 30, 40, 50, 60, 70, 80 }, new[] { 8 });
         var ex = new GpuBufferTooLargeException("Mock", 32, 16, "MockDevice");
+
+        using var session = Profiler.Profile();
 
         var result = engine.TryRunBinaryChunked<float>(backend, left, right,
             (b, bA, bB, bC, len) =>

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/ChunkerWithMockBackendTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/ChunkerWithMockBackendTests.cs
@@ -64,6 +64,46 @@ public class ChunkerWithMockBackendTests
     }
 
     [Fact]
+    public void TryRunUnaryChunked_NoProfilerSession_DispatchesAndReportsFalseEmitted()
+    {
+        // Mirror image of the above SplitsAcrossCap test: same workload,
+        // identical chunker behaviour expected, but Profiler.Current is
+        // null. Verifies the zero-overhead-when-off contract — the
+        // chunker still produces the correct result, but emittedEvent
+        // stays false so the outer dispatcher's generic cpu_fallback
+        // marker is NOT suppressed.
+        var state = new MockBackendState { MaxBufferAllocBytes = 16 };
+        var backend = MockDirectGpuBackend.Create(state);
+        var engine = new DirectGpuTensorEngine();
+
+        var input = new Tensor<float>(new float[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 }, new[] { 12 });
+        var ex = new GpuBufferTooLargeException("Mock", requestedBytes: 48, deviceMaxAllocBytes: 16, deviceName: "MockDevice");
+
+        // Sanity: no session is active. The collection-level isolation
+        // (DisableParallelization) plus the using-statements in the
+        // other tests guarantee this is true at this point.
+        Assert.Null(Profiler.Current);
+
+        var result = engine.TryRunUnaryChunked<float>(backend, input,
+            (b, bIn, bOut, len) =>
+            {
+                state.UnaryOpCalls++;
+                var bufferIn = (MockGpuBuffer)bIn;
+                var bufferOut = (MockGpuBuffer)bOut;
+                for (int i = 0; i < len; i++) bufferOut.Data[i] = bufferIn.Data[i] * 2;
+            },
+            ex,
+            out bool emitted);
+
+        Assert.NotNull(result);
+        Assert.Equal(12, result!.Length);
+        for (int i = 0; i < 12; i++)
+            Assert.Equal((i + 1) * 2f, result[i]);
+        Assert.Equal(3, state.UnaryOpCalls);
+        Assert.False(emitted, "no profiler session ⇒ no event landed ⇒ emittedEvent must be false");
+    }
+
+    [Fact]
     public void TryRunUnaryChunked_ChunkCountExceedsMax_ReturnsNullAndEmits()
     {
         // Cap = 4 bytes (1 element per chunk), 100 elements → 100 chunks.

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/ChunkerWithMockBackendTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/ChunkerWithMockBackendTests.cs
@@ -335,5 +335,116 @@ public class ChunkerWithMockBackendTests
         Assert.Null(result);
         Assert.False(emitted);
     }
+
+    // ───────────────────────────────────────────────────────────────────
+    // Profiler-active-but-event-dropped paths.
+    //
+    // Per PR #289 review: a session can be active (Profiler.Current is
+    // non-null) yet still drop a RecordInstant call because:
+    //   1. ProfilerActivities.None — CPU capture is disabled.
+    //   2. Schedule phase is Wait or Stopped — outside the recording
+    //      window.
+    //   3. Session is disposed — already torn down.
+    // The chunker must report emittedEvent = false in all three cases
+    // so the outer dispatcher's generic cpu_fallback marker is NOT
+    // suppressed; otherwise telemetry is silently lost for
+    // profiled-but-currently-inactive sessions.
+    // ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void TryRunUnaryChunked_SessionActiveButActivitiesNone_ReturnsFalseEmitted()
+    {
+        var state = new MockBackendState { MaxBufferAllocBytes = 16 };
+        var backend = MockDirectGpuBackend.Create(state);
+        var engine = new DirectGpuTensorEngine();
+
+        var input = new Tensor<float>(new float[] { 1, 2, 3, 4, 5, 6, 7, 8 }, new[] { 8 });
+        var ex = new GpuBufferTooLargeException("Mock", 32, 16, "MockDevice");
+
+        // Session exists but Activities = None means RecordInstant is
+        // a no-op even though Profiler.Current is non-null.
+        using var session = Profiler.Profile(new ProfilerOptions
+        {
+            Activities = ProfilerActivities.None,
+        });
+
+        var result = engine.TryRunUnaryChunked<float>(backend, input,
+            (b, bIn, bOut, len) =>
+            {
+                state.UnaryOpCalls++;
+                var bufferIn = (MockGpuBuffer)bIn;
+                var bufferOut = (MockGpuBuffer)bOut;
+                for (int i = 0; i < len; i++) bufferOut.Data[i] = bufferIn.Data[i];
+            },
+            ex,
+            out bool emitted);
+
+        Assert.NotNull(result);                 // chunker still dispatches
+        Assert.Equal(2, state.UnaryOpCalls);    // both chunks ran
+        Assert.False(emitted, "ProfilerActivities.None drops RecordInstant; emittedEvent must be false so the outer fallback marker is not suppressed");
+        Assert.Equal(0, session.EventCount - 1); // only the metadata prologue is in the queue
+    }
+
+    [Fact]
+    public void TryRunUnaryChunked_SessionActiveButScheduleInWait_ReturnsFalseEmitted()
+    {
+        var state = new MockBackendState { MaxBufferAllocBytes = 16 };
+        var backend = MockDirectGpuBackend.Create(state);
+        var engine = new DirectGpuTensorEngine();
+
+        var input = new Tensor<float>(new float[] { 1, 2, 3, 4, 5, 6, 7, 8 }, new[] { 8 });
+        var ex = new GpuBufferTooLargeException("Mock", 32, 16, "MockDevice");
+
+        // Schedule with wait=10 means we sit in the Wait phase for the
+        // first 10 steps; RecordInstant short-circuits in this phase
+        // even though the session is otherwise live.
+        using var session = Profiler.Profile(new ProfilerOptions
+        {
+            Activities = ProfilerActivities.Cpu,
+            Schedule = new ProfilerSchedule(wait: 10, warmup: 0, active: 1, repeat: 1),
+        });
+
+        Assert.Equal(ProfilerSchedulePhase.Wait, session.CurrentPhase);
+
+        var result = engine.TryRunUnaryChunked<float>(backend, input,
+            (b, bIn, bOut, len) => state.UnaryOpCalls++,
+            ex,
+            out bool emitted);
+
+        Assert.NotNull(result);
+        Assert.False(emitted, "schedule phase Wait drops RecordInstant; emittedEvent must be false");
+    }
+
+    [Fact]
+    public void TryRunBinaryChunked_SessionActiveButActivitiesNone_ReturnsFalseEmitted()
+    {
+        var state = new MockBackendState { MaxBufferAllocBytes = 16 };
+        var backend = MockDirectGpuBackend.Create(state);
+        var engine = new DirectGpuTensorEngine();
+
+        var left = new Tensor<float>(new float[] { 1, 2, 3, 4, 5, 6, 7, 8 }, new[] { 8 });
+        var right = new Tensor<float>(new float[] { 10, 20, 30, 40, 50, 60, 70, 80 }, new[] { 8 });
+        var ex = new GpuBufferTooLargeException("Mock", 32, 16, "MockDevice");
+
+        using var session = Profiler.Profile(new ProfilerOptions
+        {
+            Activities = ProfilerActivities.None,
+        });
+
+        var result = engine.TryRunBinaryChunked<float>(backend, left, right,
+            (b, bA, bB, bC, len) =>
+            {
+                state.BinaryOpCalls++;
+                var ba = (MockGpuBuffer)bA;
+                var bb = (MockGpuBuffer)bB;
+                var bc = (MockGpuBuffer)bC;
+                for (int i = 0; i < len; i++) bc.Data[i] = ba.Data[i] + bb.Data[i];
+            },
+            ex,
+            out bool emitted);
+
+        Assert.NotNull(result);
+        Assert.False(emitted, "ProfilerActivities.None drops RecordInstant; emittedEvent must be false");
+    }
 }
 #endif


### PR DESCRIPTION
## Summary

Follow-up to PR #288. Addresses 4 review comments that landed after the squash-merge of the original buffer-cap PR. The original PR was accidentally closed/merged before these fixes could be pushed, so opening a new PR with just the deltas.

- **Profiler emit semantics**: `EmitBufferCapEvent` now returns `bool` indicating whether the event actually landed (false when no profiler session is active). The chunker's `emittedEvent` out-parameter now reflects reality instead of always being true. This stops the outer dispatcher from suppressing its own `cpu_fallback` marker when nothing was actually logged — fixes silent telemetry loss when chunking happens with no profiler attached.
- **Op-name attribution**: Profiler events emitted from cap-miss paths now carry the actual op name (`Relu`, `Gelu`, `Add`, …) instead of the dispatcher label (`TryRunUnary`, `TryRunBinary`). Threaded via `[CallerMemberName]` into `TryRunUnary` / `TryRunBinary` / `TryRunScalar` / `TryRunBinarySpan` / `TryRunScalarSpan`, plus an explicit `string opName` parameter on `TryRunUnaryChunked` / `TryRunBinaryChunked`.
- **Test correctness**: 6 chunker mock tests that assert `Assert.True(emitted, …)` now wrap the chunker call in `using var session = Profiler.Profile()` so events actually land. Without it, the new (correct) emit semantics would leave `emittedEvent = false`. The other tests (which assert `Assert.False(emitted)`) stay unchanged because they verify silent-bail paths that should not emit regardless of session state.
- **Stale comment**: Removed an outdated `"follow-up"` reference in `BufferSizeCapTests`.

Originating review comments (PR #288): PRRT_kwDOQ-aYaM5_KHHX, PRRT_kwDOQ-aYaM5_KHHZ, PRRT_kwDOQ-aYaM5_KHHT.

## Test plan

- [x] `dotnet build src/AiDotNet.Tensors` — 0 warnings, 0 errors
- [x] `dotnet build tests/AiDotNet.Tensors.Tests` — 0 errors (only pre-existing analyzer warnings)
- [x] `ChunkerWithMockBackendTests` + `BufferSizeCapTests` — 35 / 35 pass on net10.0
- [ ] CI must run the full DirectGpu and core test suites
- [ ] codecov/patch threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)