### PR TITLE
feat(weight-streaming): AllocateRegistered + EvictUntilFreeBytes — bound peak GC heap during PaLM-E lazy materialization

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CuRand.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CuRand.cs
@@ -109,6 +109,16 @@ public sealed class CuRand : IDeviceRng
     private bool TryDeviceUniform(Tensor<float> output, bool normal, float mean, float stddev)
     {
         if (!CuRandNative.IsAvailable) return false;
+        // Subsequence-bypass: cuRAND's Philox API has no subsequence
+        // parameter — `curandSetPseudoRandomGeneratorSeed` accepts only
+        // the seed, and offset is a per-stream counter advancement, not
+        // the subsequence dimension that managed Philox 4x32-10 supports.
+        // When the caller asks for a non-zero subsequence, the device
+        // path's bits would silently diverge from CpuPhiloxGenerator's
+        // — breaking the cross-backend determinism contract that
+        // CuRand class-doc promises. Fall back to CPU so the contract
+        // holds.
+        if (_cpuFallback.Subsequence != 0) return false;
         IntPtr dPtr = IntPtr.Zero;
         IntPtr generator = IntPtr.Zero;
         try
@@ -153,6 +163,11 @@ public sealed class CuRand : IDeviceRng
     private bool TryDeviceUniformDouble(Tensor<double> output, bool normal, double mean, double stddev)
     {
         if (!CuRandNative.IsAvailable) return false;
+        // Same subsequence-bypass as TryDeviceUniform — cuRAND's Philox
+        // doesn't accept a subsequence parameter, so a non-zero
+        // subsequence on this side must fall back to CPU to preserve
+        // bit-equivalence.
+        if (_cpuFallback.Subsequence != 0) return false;
         IntPtr dPtr = IntPtr.Zero;
         IntPtr generator = IntPtr.Zero;
         try

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaOffloadAllocator.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaOffloadAllocator.cs
@@ -17,6 +17,13 @@ public sealed class CudaOffloadAllocator : IGpuOffloadAllocator
 {
     private readonly ConcurrentDictionary<IntPtr, GpuOffloadHandle> _live = new();
     private readonly object _lifecycleLock = new();
+    // Context owned by this allocator. cuMemAllocHost / cuMemAllocManaged
+    // require a current CUDA context on the calling thread; an allocator
+    // standalone of CudaBackend (the offload-only path #1222 weight
+    // streaming hits when no GPU compute is wired up) has none, so we
+    // create + push our own. Field stays IntPtr.Zero until first
+    // Allocate; Dispose destroys it iff non-zero.
+    private IntPtr _context;
     private bool _disposed;
 
     public bool IsAvailable => CudaNativeBindings.IsAvailable;
@@ -34,29 +41,33 @@ public sealed class CudaOffloadAllocator : IGpuOffloadAllocator
                 throw new NotSupportedException("CUDA driver is not loadable on this host.");
             if (bytes <= 0) throw new ArgumentOutOfRangeException(nameof(bytes));
 
-            IntPtr ptr;
-            OffloadScheme effective = scheme == OffloadScheme.Auto ? OffloadScheme.Pinned : scheme;
-            switch (effective)
+            EnsureContext();
+            using (PushContextScope())
             {
-                case OffloadScheme.Pinned:
-                    {
-                        var rc = CuBlasNative.cuMemAllocHost(out ptr, (ulong)bytes);
-                        CuBlasNative.CheckCudaResult(rc, "cuMemAllocHost(offload)");
-                        break;
-                    }
-                case OffloadScheme.Managed:
-                    {
-                        var rc = CudaNativeBindings.cuMemAllocManaged(out ptr, (ulong)bytes, CudaNativeBindings.CU_MEM_ATTACH_GLOBAL);
-                        if (rc != CudaResult.Success)
-                            throw new InvalidOperationException($"cuMemAllocManaged returned {rc}");
-                        break;
-                    }
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(scheme), scheme, "Unknown offload scheme.");
+                IntPtr ptr;
+                OffloadScheme effective = scheme == OffloadScheme.Auto ? OffloadScheme.Pinned : scheme;
+                switch (effective)
+                {
+                    case OffloadScheme.Pinned:
+                        {
+                            var rc = CuBlasNative.cuMemAllocHost(out ptr, (ulong)bytes);
+                            CuBlasNative.CheckCudaResult(rc, "cuMemAllocHost(offload)");
+                            break;
+                        }
+                    case OffloadScheme.Managed:
+                        {
+                            var rc = CudaNativeBindings.cuMemAllocManaged(out ptr, (ulong)bytes, CudaNativeBindings.CU_MEM_ATTACH_GLOBAL);
+                            if (rc != CudaResult.Success)
+                                throw new InvalidOperationException($"cuMemAllocManaged returned {rc}");
+                            break;
+                        }
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(scheme), scheme, "Unknown offload scheme.");
+                }
+                var h = new GpuOffloadHandle(ptr, ptr, bytes, effective);
+                _live[ptr] = h;
+                return h;
             }
-            var h = new GpuOffloadHandle(ptr, ptr, bytes, effective);
-            _live[ptr] = h;
-            return h;
         }
     }
 
@@ -67,13 +78,75 @@ public sealed class CudaOffloadAllocator : IGpuOffloadAllocator
         // double-free would corrupt the heap on the second native release.
         // Lock TryRemove against Dispose's snapshot+clear so a concurrent
         // Dispose can't free the same pointer twice.
-        bool removed;
         lock (_lifecycleLock)
         {
-            removed = _live.TryRemove(handle.HostPointer, out _);
+            if (!_live.TryRemove(handle.HostPointer, out _)) return;
+            // Native free needs our context current; push before, pop
+            // after so the thread's context stack is restored to its
+            // prior state.
+            using (PushContextScope())
+            {
+                FreeNative(handle);
+            }
         }
-        if (!removed) return;
-        FreeNative(handle);
+    }
+
+    private void EnsureContext()
+    {
+        // Caller holds _lifecycleLock. Lazily creates the context on
+        // first use. cuCtxCreate makes the new context current on the
+        // calling thread AND pushes it on the thread's context stack
+        // — we immediately pop it so the stack is restored. Subsequent
+        // allocate/free calls use PushContextScope to push/pop around
+        // their native calls cleanly.
+        if (_context != IntPtr.Zero) return;
+        CuBlasNative.CheckCudaResult(CuBlasNative.cuInit(0), "cuInit(offload)");
+        CuBlasNative.CheckCudaResult(
+            CuBlasNative.cuDeviceGet(out int device, 0),
+            "cuDeviceGet(offload)");
+        CuBlasNative.CheckCudaResult(
+            CuBlasNative.cuCtxCreate(out _context, 0, device),
+            "cuCtxCreate(offload)");
+        // Pop the just-pushed context so we don't leak our context onto
+        // the caller's thread stack. If we left it pushed, a sibling
+        // CudaBackend's later cuCtxPopCurrent would pop our context
+        // instead of its own — exactly the finalizer crash mode this
+        // method exists to prevent.
+        CuBlasNative.cuCtxPopCurrent(out _);
+    }
+
+    private CudaContextPushScope PushContextScope() => new(_context);
+
+    private readonly struct CudaContextPushScope : IDisposable
+    {
+        private readonly bool _pushed;
+
+        public CudaContextPushScope(IntPtr context)
+        {
+            _pushed = false;
+            if (context == IntPtr.Zero) return;
+            // Push our context onto the thread's stack. On Dispose we
+            // pop, restoring the stack to what the caller had before.
+            // This matches CudaBackend.CudaContextScope's pattern so
+            // both can coexist without trampling each other's contexts.
+            CuBlasNative.CheckCudaResult(
+                CuBlasNative.cuCtxPushCurrent(context),
+                "cuCtxPushCurrent(offload)");
+            _pushed = true;
+        }
+
+        public void Dispose()
+        {
+            if (_pushed)
+            {
+                // Best-effort pop on failure: a throwing pop here would
+                // mask the original native error and leave the stack
+                // permanently corrupted. The CUDA driver only returns
+                // non-success here on disposed contexts, so we'd
+                // already be in a fault path.
+                CuBlasNative.cuCtxPopCurrent(out _);
+            }
+        }
     }
 
     private static void FreeNative(GpuOffloadHandle handle)
@@ -92,6 +165,7 @@ public sealed class CudaOffloadAllocator : IGpuOffloadAllocator
     public void Dispose()
     {
         GpuOffloadHandle[] snapshot;
+        IntPtr ctxToDestroy;
         lock (_lifecycleLock)
         {
             if (_disposed) return;
@@ -102,9 +176,31 @@ public sealed class CudaOffloadAllocator : IGpuOffloadAllocator
             _disposed = true;
             snapshot = _live.Values.ToArray();
             _live.Clear();
+            ctxToDestroy = _context;
+            _context = IntPtr.Zero;
+
+            if (ctxToDestroy != IntPtr.Zero)
+            {
+                // Push our context to free its allocations cleanly,
+                // then pop and destroy. Push/pop discipline matters
+                // even at dispose time: a CudaBackend running on the
+                // same thread might have its own context current, and
+                // a free issued against the wrong context would be
+                // INVALID_CONTEXT or worse.
+                using (var scope = new CudaContextPushScope(ctxToDestroy))
+                {
+                    foreach (var h in snapshot) FreeNative(h);
+                }
+                CuBlasNative.cuCtxDestroy(ctxToDestroy);
+            }
+            else
+            {
+                // No context was ever created (no Allocate ran), so
+                // _live must be empty. Defensive — free anything that
+                // somehow got registered without an alloc going
+                // through.
+                foreach (var h in snapshot) FreeNative(h);
+            }
         }
-        // Native frees outside the lock so a backend that internally locks
-        // during free can't deadlock against our lifecycle lock.
-        foreach (var h in snapshot) FreeNative(h);
     }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanOffloadAllocator.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanOffloadAllocator.cs
@@ -30,8 +30,69 @@ public sealed class VulkanOffloadAllocator : IGpuOffloadAllocator
     private uint _hostVisibleDeviceLocalMemTypeIndex = uint.MaxValue; // Pinned scheme (ReBAR)
     private readonly object _lock = new();
     private bool _disposed;
+    // IsAvailable cache. The loader-probe is necessary but not
+    // sufficient — a host can have the Vulkan ICD installed yet no
+    // physical device exposed (CI runners, VMs, headless boxes). The
+    // first call to IsAvailable does a one-shot device-enumeration
+    // probe and caches the result so subsequent calls are O(1).
+    // _availabilityProbed=false until the first IsAvailable read.
+    private static int _availabilityProbed; // 0 / 1
+    private static bool _availabilityResult;
 
-    public bool IsAvailable => VulkanLoaderProbe.IsAvailable;
+    public bool IsAvailable
+    {
+        get
+        {
+            if (System.Threading.Interlocked.CompareExchange(ref _availabilityProbed, 1, 0) == 0)
+            {
+                _availabilityResult = VulkanLoaderProbe.IsAvailable && ProbeHasPhysicalDevice();
+            }
+            return _availabilityResult;
+        }
+    }
+
+    /// <summary>
+    /// Confirms at least one Vulkan physical device is enumerable. The
+    /// loader probe (vkEnumerateInstanceVersion) only verifies the DLL is
+    /// resolvable; on hosts with the Vulkan ICD installed but no
+    /// Vulkan-capable GPU (CI, headless VMs, llvmpipe-only) the
+    /// allocator's first <see cref="EnsureDevice"/> would otherwise fail
+    /// at vkEnumeratePhysicalDevices, after the test already passed the
+    /// IsAvailable gate. This probe runs that enumeration once at
+    /// startup so IsAvailable is honest about whether Allocate can
+    /// succeed.
+    /// </summary>
+    private static bool ProbeHasPhysicalDevice()
+    {
+        IntPtr device = IntPtr.Zero;
+        IntPtr instance = IntPtr.Zero;
+        try
+        {
+            var setup = VulkanInstanceSetup.CreateMinimal();
+            device = setup.Device;
+            instance = setup.Instance;
+            return device != IntPtr.Zero;
+        }
+        catch
+        {
+            return false;
+        }
+        finally
+        {
+            // CreateMinimal allocates an instance + device on success;
+            // tear them down so the probe doesn't leak the handles for
+            // the process lifetime. The real allocator's Allocate will
+            // recreate them via its own EnsureDevice on first use.
+            if (device != IntPtr.Zero)
+            {
+                try { VulkanInstanceSetup.vkDestroyDevice(device, IntPtr.Zero); } catch { }
+            }
+            if (instance != IntPtr.Zero)
+            {
+                try { VulkanInstanceSetup.vkDestroyInstance(instance, IntPtr.Zero); } catch { }
+            }
+        }
+    }
 
     private void EnsureDevice()
     {

--- a/src/AiDotNet.Tensors/Helpers/MathHelper.cs
+++ b/src/AiDotNet.Tensors/Helpers/MathHelper.cs
@@ -116,6 +116,8 @@ public static class MathHelper
             return new UInt64Operations();
         if (typeof(T) == typeof(Bit))
             return new BitOperations();
+        if (typeof(T) == typeof(bool))
+            return new NumericOperations.BoolOperations();
         if (typeof(T) == typeof(NumericOperations.Float8E4M3))
             return new NumericOperations.Float8E4M3Operations();
         if (typeof(T) == typeof(NumericOperations.Float8E5M2))

--- a/src/AiDotNet.Tensors/LinearAlgebra/StreamingTensorPool.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/StreamingTensorPool.cs
@@ -33,6 +33,16 @@ public sealed class StreamingTensorPool : IDisposable
     private long _residentBytes;
     private long _residentBytesPeak;
     private long _nextHandleId = 1;
+    // Pre-allocated headroom the pool has promised to outstanding
+    // AllocateRegistered callers but that hasn't yet landed in
+    // _residentBytes (the caller is still initializing the GC byte[]
+    // before calling RegisterWeight). Eviction's free-bytes calculation
+    // adds this to _residentBytes so a second concurrent
+    // AllocateRegistered can't pass the same headroom-check the first
+    // one did. Decremented on RegisterWeight (or on direct
+    // ReleaseReservation when the caller bails before Register).
+    // Always written under _lock.
+    private long _reservedBytes;
     private readonly long _maxResidentBytes;
     private readonly string _backingDir;
     private readonly bool _enableCompression;
@@ -352,9 +362,10 @@ public sealed class StreamingTensorPool : IDisposable
     /// <paramref name="byteCount"/> bytes of headroom are available
     /// under <see cref="_maxResidentBytes"/> OR the LRU is empty.
     /// Best-effort: returns whether the requested headroom was secured.
-    /// Used by <see cref="WeightRegistry.AllocateRegistered{T}"/> so a
-    /// long sequence of large weight allocations bounds peak GC-heap
-    /// occupancy by the pool budget.
+    /// Used internally by <see cref="ReserveBytes"/>; external callers
+    /// (e.g., <see cref="WeightRegistry.AllocateRegistered{T}"/>) should
+    /// use <see cref="ReserveBytes"/> instead so the headroom they
+    /// secured is held against concurrent allocators.
     /// </summary>
     /// <param name="byteCount">Bytes of headroom to make available.</param>
     /// <returns>True if the pool now has at least
@@ -363,8 +374,10 @@ public sealed class StreamingTensorPool : IDisposable
     /// the pool past budget; <see cref="EvictIfOverBudget"/> on the
     /// next register will recover).</returns>
     /// <remarks>
-    /// <para>byteCount &lt;= 0 is a no-op. Invariant on entry/exit:
-    /// caller holds <see cref="_lock"/>.</para>
+    /// <para>byteCount &lt;= 0 is a no-op. The free-bytes calculation
+    /// includes <see cref="_reservedBytes"/> so a concurrent
+    /// AllocateRegistered (whose reservation hasn't yet been committed
+    /// via Register) can't double-spend the same headroom.</para>
     /// </remarks>
     public bool EvictUntilFreeBytes(long byteCount)
     {
@@ -372,21 +385,93 @@ public sealed class StreamingTensorPool : IDisposable
         lock (_lock)
         {
             ThrowIfDisposed();
-            // "Free bytes available" = budget - currently-resident.
-            // We loop until either we have at least byteCount free, OR
-            // the LRU is empty (best-effort: if the caller asked for
-            // more than the entire budget can hold, we drain the LRU
-            // and return false to signal the request can't be fully
-            // satisfied; caller's allocation will then push the pool
-            // past budget, and the next register's EvictIfOverBudget
-            // can't recover that scenario either — callers are
-            // expected to not request more than the budget itself).
-            while (_maxResidentBytes - _residentBytes < byteCount && _lruOrder.Count > 0)
-            {
-                if (!EvictOneLruEntry(protectedHandleId: null)) break;
-            }
-            return _maxResidentBytes - _residentBytes >= byteCount;
+            return EvictUntilFreeBytesUnlocked(byteCount);
         }
+    }
+
+    /// <summary>Caller already holds <see cref="_lock"/>. Same contract as
+    /// <see cref="EvictUntilFreeBytes"/>.</summary>
+    private bool EvictUntilFreeBytesUnlocked(long byteCount)
+    {
+        // "Free bytes available" = budget - resident - reserved. We loop
+        // until either we have at least byteCount free, OR the LRU is
+        // empty (best-effort: if the caller asked for more than the
+        // entire budget can hold, we drain the LRU and return false to
+        // signal the request can't be fully satisfied at this moment).
+        // Including _reservedBytes is what closes the TOCTOU race
+        // between concurrent AllocateRegistered calls — without it,
+        // both callers would observe the same headroom and overshoot.
+        while (_maxResidentBytes - _residentBytes - _reservedBytes < byteCount && _lruOrder.Count > 0)
+        {
+            if (!EvictOneLruEntry(protectedHandleId: null)) break;
+        }
+        return _maxResidentBytes - _residentBytes - _reservedBytes >= byteCount;
+    }
+
+    /// <summary>
+    /// Atomically pages out LRU entries to free at least
+    /// <paramref name="byteCount"/> bytes of headroom AND records the
+    /// reservation against <see cref="_reservedBytes"/> so a concurrent
+    /// caller can't pass the same eviction gate. The caller is expected
+    /// to either commit the reservation by calling
+    /// <see cref="WeightRegistry.RegisterWeight{T}"/> (which subtracts
+    /// from <see cref="_reservedBytes"/> then adds to
+    /// <see cref="_residentBytes"/>) or release it by calling
+    /// <see cref="ReleaseReservation"/> directly.
+    /// </summary>
+    /// <param name="byteCount">Bytes of headroom to reserve. Non-positive
+    /// is a no-op (returns true).</param>
+    /// <returns>True if the reservation was secured under budget; false
+    /// when the request exceeds the entire budget (LRU drained, can't
+    /// satisfy). False reservations are still recorded — the caller
+    /// will cause a transient overshoot until the next Register's
+    /// <see cref="EvictIfOverBudget"/> walk catches up.</returns>
+    public bool ReserveBytes(long byteCount)
+    {
+        if (byteCount <= 0) return true;
+        lock (_lock)
+        {
+            ThrowIfDisposed();
+            bool secured = EvictUntilFreeBytesUnlocked(byteCount);
+            _reservedBytes += byteCount;
+            return secured;
+        }
+    }
+
+    /// <summary>
+    /// Releases bytes previously reserved via <see cref="ReserveBytes"/>.
+    /// Called either by the matching
+    /// <see cref="WeightRegistry.RegisterWeight{T}"/> (just before the
+    /// committed bytes land in <see cref="_residentBytes"/>) or directly
+    /// when the caller bails before Register and needs to give the
+    /// headroom back to the budget.
+    /// </summary>
+    /// <param name="byteCount">Bytes to release. Non-positive is a no-op.</param>
+    public void ReleaseReservation(long byteCount)
+    {
+        if (byteCount <= 0) return;
+        lock (_lock)
+        {
+            // No ThrowIfDisposed here: a tensor that was reserved against
+            // an old pool but never registered may be released after a
+            // Configure swap. The reservation accounting is best-effort
+            // bookkeeping — it doesn't affect resident bytes once the
+            // pool is disposed.
+            if (_disposed) return;
+            _reservedBytes -= byteCount;
+            // Floor at zero — defensive against double-release. Bumping
+            // a "release without reserve" exception would turn a
+            // bookkeeping mistake into a tensor leak, which is worse.
+            if (_reservedBytes < 0) _reservedBytes = 0;
+        }
+    }
+
+    /// <summary>Outstanding reservations from in-flight
+    /// <see cref="WeightRegistry.AllocateRegistered{T}"/> calls. Exposed
+    /// for tests; production code shouldn't depend on the value.</summary>
+    public long ReservedBytes
+    {
+        get { lock (_lock) return _reservedBytes; }
     }
 
     /// <summary>
@@ -500,7 +585,13 @@ public sealed class StreamingTensorPool : IDisposable
             }
             finally
             {
-                ArrayPool<byte>.Shared.Return(encodeBuf);
+                // clearArray:true so the next renter doesn't observe the
+                // previous tenant's serialized weight bytes — these are
+                // model parameters, often proprietary, and a downstream
+                // consumer renting the same buffer would see them
+                // unzeroed. The clear cost is amortized against the
+                // disk write latency anyway.
+                ArrayPool<byte>.Shared.Return(encodeBuf, clearArray: true);
             }
         }
         else

--- a/src/AiDotNet.Tensors/LinearAlgebra/StreamingTensorPool.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/StreamingTensorPool.cs
@@ -34,11 +34,11 @@ public sealed class StreamingTensorPool : IDisposable
     private long _residentBytesPeak;
     private long _nextHandleId = 1;
     // Pre-allocated headroom the pool has promised to outstanding
-    // AllocateRegistered callers but that hasn't yet landed in
+    // AllocateStreaming callers but that hasn't yet landed in
     // _residentBytes (the caller is still initializing the GC byte[]
     // before calling RegisterWeight). Eviction's free-bytes calculation
     // adds this to _residentBytes so a second concurrent
-    // AllocateRegistered can't pass the same headroom-check the first
+    // AllocateStreaming can't pass the same headroom-check the first
     // one did. Decremented on RegisterWeight (or on direct
     // ReleaseReservation when the caller bails before Register).
     // Always written under _lock.
@@ -362,10 +362,10 @@ public sealed class StreamingTensorPool : IDisposable
     /// <paramref name="byteCount"/> bytes of headroom are available
     /// under <see cref="_maxResidentBytes"/> OR the LRU is empty.
     /// Best-effort: returns whether the requested headroom was secured.
-    /// Used internally by <see cref="ReserveBytes"/>; external callers
-    /// (e.g., <see cref="WeightRegistry.AllocateRegistered{T}"/>) should
-    /// use <see cref="ReserveBytes"/> instead so the headroom they
-    /// secured is held against concurrent allocators.
+    /// Internal plumbing for <see cref="ReserveBytes"/> and direct
+    /// test-coverage of the eviction loop; production callers should use
+    /// <see cref="ReserveBytes"/> instead so the headroom they secured
+    /// is held against concurrent allocators.
     /// </summary>
     /// <param name="byteCount">Bytes of headroom to make available.</param>
     /// <returns>True if the pool now has at least
@@ -376,10 +376,10 @@ public sealed class StreamingTensorPool : IDisposable
     /// <remarks>
     /// <para>byteCount &lt;= 0 is a no-op. The free-bytes calculation
     /// includes <see cref="_reservedBytes"/> so a concurrent
-    /// AllocateRegistered (whose reservation hasn't yet been committed
+    /// AllocateStreaming (whose reservation hasn't yet been committed
     /// via Register) can't double-spend the same headroom.</para>
     /// </remarks>
-    public bool EvictUntilFreeBytes(long byteCount)
+    internal bool EvictUntilFreeBytes(long byteCount)
     {
         if (byteCount <= 0) return true;
         lock (_lock)
@@ -393,14 +393,24 @@ public sealed class StreamingTensorPool : IDisposable
     /// <see cref="EvictUntilFreeBytes"/>.</summary>
     private bool EvictUntilFreeBytesUnlocked(long byteCount)
     {
+        // Oversize-request short-circuit: the caller is asking for more
+        // headroom than the entire pool budget. Even draining every
+        // resident entry to disk wouldn't satisfy them, so the loop
+        // below would do a full LRU flush only to return false at the
+        // end — flushing every warm weight for nothing and forcing a
+        // round of foreground rehydrates afterward. Bail out before we
+        // touch the LRU: the caller's allocation will overshoot budget
+        // by (byteCount - max), and EvictIfOverBudget on the next
+        // Register will catch up the same way it would have without
+        // this call.
+        if (byteCount > _maxResidentBytes) return false;
+
         // "Free bytes available" = budget - resident - reserved. We loop
         // until either we have at least byteCount free, OR the LRU is
-        // empty (best-effort: if the caller asked for more than the
-        // entire budget can hold, we drain the LRU and return false to
-        // signal the request can't be fully satisfied at this moment).
-        // Including _reservedBytes is what closes the TOCTOU race
-        // between concurrent AllocateRegistered calls — without it,
-        // both callers would observe the same headroom and overshoot.
+        // empty. Including _reservedBytes is what closes the TOCTOU
+        // race between concurrent AllocateStreaming calls — without
+        // it, both callers would observe the same headroom and
+        // overshoot.
         while (_maxResidentBytes - _residentBytes - _reservedBytes < byteCount && _lruOrder.Count > 0)
         {
             if (!EvictOneLruEntry(protectedHandleId: null)) break;
@@ -412,21 +422,24 @@ public sealed class StreamingTensorPool : IDisposable
     /// Atomically pages out LRU entries to free at least
     /// <paramref name="byteCount"/> bytes of headroom AND records the
     /// reservation against <see cref="_reservedBytes"/> so a concurrent
-    /// caller can't pass the same eviction gate. The caller is expected
-    /// to either commit the reservation by calling
-    /// <see cref="WeightRegistry.RegisterWeight{T}"/> (which subtracts
-    /// from <see cref="_reservedBytes"/> then adds to
-    /// <see cref="_residentBytes"/>) or release it by calling
-    /// <see cref="ReleaseReservation"/> directly.
+    /// caller can't pass the same eviction gate. Internal plumbing for
+    /// <see cref="WeightRegistry.AllocateStreaming{T}"/>; release happens
+    /// through <see cref="WeightRegistry.RegisterWeight{T}"/> (commits
+    /// reserved → resident) or <see cref="WeightRegistry.UnregisterWeight{T}"/>
+    /// (returns headroom to the budget). External code should never
+    /// call this directly: the byteCount-based release path takes no
+    /// opaque token and so can't validate that the right amount is
+    /// being released; routing all calls through WeightRegistry keeps
+    /// the bookkeeping coherent.
     /// </summary>
     /// <param name="byteCount">Bytes of headroom to reserve. Non-positive
     /// is a no-op (returns true).</param>
     /// <returns>True if the reservation was secured under budget; false
-    /// when the request exceeds the entire budget (LRU drained, can't
-    /// satisfy). False reservations are still recorded — the caller
-    /// will cause a transient overshoot until the next Register's
-    /// <see cref="EvictIfOverBudget"/> walk catches up.</returns>
-    public bool ReserveBytes(long byteCount)
+    /// when the request exceeds the entire budget. False reservations
+    /// are still recorded — the caller will cause a transient overshoot
+    /// until the next Register's <see cref="EvictIfOverBudget"/> walk
+    /// catches up.</returns>
+    internal bool ReserveBytes(long byteCount)
     {
         if (byteCount <= 0) return true;
         lock (_lock)
@@ -440,14 +453,18 @@ public sealed class StreamingTensorPool : IDisposable
 
     /// <summary>
     /// Releases bytes previously reserved via <see cref="ReserveBytes"/>.
-    /// Called either by the matching
-    /// <see cref="WeightRegistry.RegisterWeight{T}"/> (just before the
-    /// committed bytes land in <see cref="_residentBytes"/>) or directly
-    /// when the caller bails before Register and needs to give the
-    /// headroom back to the budget.
+    /// Internal plumbing — called by
+    /// <see cref="WeightRegistry.RegisterWeight{T}"/> just before the
+    /// committed bytes land in <see cref="_residentBytes"/>, or by
+    /// <see cref="WeightRegistry.UnregisterWeight{T}"/> when the caller
+    /// bails before Register. External callers must go through
+    /// UnregisterWeight rather than calling this directly: the raw
+    /// byteCount API has no opaque token to prove the release amount
+    /// matches the prior reservation, and a mismatch would silently
+    /// floor at zero (see floor logic below).
     /// </summary>
     /// <param name="byteCount">Bytes to release. Non-positive is a no-op.</param>
-    public void ReleaseReservation(long byteCount)
+    internal void ReleaseReservation(long byteCount)
     {
         if (byteCount <= 0) return;
         lock (_lock)
@@ -467,9 +484,9 @@ public sealed class StreamingTensorPool : IDisposable
     }
 
     /// <summary>Outstanding reservations from in-flight
-    /// <see cref="WeightRegistry.AllocateRegistered{T}"/> calls. Exposed
-    /// for tests; production code shouldn't depend on the value.</summary>
-    public long ReservedBytes
+    /// <see cref="WeightRegistry.AllocateStreaming{T}"/> calls. Internal
+    /// — exposed for tests via InternalsVisibleTo, not public API.</summary>
+    internal long ReservedBytes
     {
         get { lock (_lock) return _reservedBytes; }
     }

--- a/src/AiDotNet.Tensors/LinearAlgebra/StreamingTensorPool.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/StreamingTensorPool.cs
@@ -347,115 +347,185 @@ public sealed class StreamingTensorPool : IDisposable
         }
     }
 
+    /// <summary>
+    /// Pages LRU entries to disk until either the requested
+    /// <paramref name="byteCount"/> bytes of headroom are available
+    /// under <see cref="_maxResidentBytes"/> OR the LRU is empty.
+    /// Best-effort: returns whether the requested headroom was secured.
+    /// Used by <see cref="WeightRegistry.AllocateRegistered{T}"/> so a
+    /// long sequence of large weight allocations bounds peak GC-heap
+    /// occupancy by the pool budget.
+    /// </summary>
+    /// <param name="byteCount">Bytes of headroom to make available.</param>
+    /// <returns>True if the pool now has at least
+    /// <paramref name="byteCount"/> bytes of free budget; false if it
+    /// emptied its LRU and still doesn't (caller's allocation may push
+    /// the pool past budget; <see cref="EvictIfOverBudget"/> on the
+    /// next register will recover).</returns>
+    /// <remarks>
+    /// <para>byteCount &lt;= 0 is a no-op. Invariant on entry/exit:
+    /// caller holds <see cref="_lock"/>.</para>
+    /// </remarks>
+    public bool EvictUntilFreeBytes(long byteCount)
+    {
+        if (byteCount <= 0) return true;
+        lock (_lock)
+        {
+            ThrowIfDisposed();
+            // "Free bytes available" = budget - currently-resident.
+            // We loop until either we have at least byteCount free, OR
+            // the LRU is empty (best-effort: if the caller asked for
+            // more than the entire budget can hold, we drain the LRU
+            // and return false to signal the request can't be fully
+            // satisfied; caller's allocation will then push the pool
+            // past budget, and the next register's EvictIfOverBudget
+            // can't recover that scenario either — callers are
+            // expected to not request more than the budget itself).
+            while (_maxResidentBytes - _residentBytes < byteCount && _lruOrder.Count > 0)
+            {
+                if (!EvictOneLruEntry(protectedHandleId: null)) break;
+            }
+            return _maxResidentBytes - _residentBytes >= byteCount;
+        }
+    }
+
+    /// <summary>
+    /// Evicts a single LRU entry to disk. Returns true if an entry was
+    /// evicted, false if the LRU is empty (or only contains the
+    /// protected handle). Extracted so <see cref="EvictIfOverBudget"/>
+    /// and <see cref="EvictUntilFreeBytes"/> share the same eviction
+    /// machinery without duplicating the LZ4-encode + stream-write
+    /// path.
+    /// </summary>
+    /// <remarks>Caller already holds <see cref="_lock"/>.</remarks>
+    private bool EvictOneLruEntry(long? protectedHandleId)
+    {
+        // Caller already holds _lock.
+        if (_lruOrder.Count == 0) return false;
+        var oldest = _lruOrder.Last;
+        while (oldest is not null && protectedHandleId.HasValue && oldest.Value == protectedHandleId.Value)
+            oldest = oldest.Previous;
+        if (oldest is null) return false;
+        return EvictNodeInternal(oldest);
+    }
+
     private void EvictIfOverBudget(long? protectedHandleId = null)
     {
         // Caller already holds _lock.
         while (_residentBytes > _maxResidentBytes && _lruOrder.Count > 0)
         {
-            // Tail of LRU is least-recently-used. Walk forward (toward more
-            // recent) past the protected entry so a single tensor exceeding
-            // the budget doesn't page itself back out during rehydrate.
-            var oldest = _lruOrder.Last;
-            while (oldest is not null && protectedHandleId.HasValue && oldest.Value == protectedHandleId.Value)
-                oldest = oldest.Previous;
-            if (oldest is null) break; // only the protected entry remains
-            long id = oldest.Value;
+            if (!EvictOneLruEntry(protectedHandleId)) break;
+        }
+    }
 
-            if (!_entries.TryGetValue(id, out var entry) || entry.Data is null)
-            {
-                // Stale LRU node (entry already evicted/unregistered) — drop.
-                _lruOrder.Remove(oldest);
-                _lruIndex.Remove(id);
-                continue;
-            }
+    /// <summary>
+    /// Pages a single LRU entry to disk. Extracted from
+    /// <see cref="EvictIfOverBudget"/> so
+    /// <see cref="EvictUntilFreeBytes"/> can drive the same eviction
+    /// machinery via a different stop condition (free bytes vs. budget).
+    /// Returns true if an entry was evicted; false if the LRU is empty
+    /// or contains only the protected handle.
+    /// </summary>
+    /// <remarks>Caller already holds <see cref="_lock"/>.</remarks>
+    private bool EvictNodeInternal(LinkedListNode<long> oldest)
+    {
+        long id = oldest.Value;
 
-            // Page out: write to backing store, drop resident reference,
-            // remove from LRU index (Rehydrate re-adds it). When
-            // EnableCompression is true, LZ4-compress before writing —
-            // ~30-40% disk-footprint reduction on near-Gaussian fp32
-            // weights. UncompressedBytes is the rehydration target size;
-            // PagedOutBytes is what's actually on disk.
-            //
-            // Memory-peak optimisation: stream-write the encoded bytes
-            // directly from the rented LZ4 buffer (no intermediate
-            // `new byte[encoded]` copy) and null out entry.Data
-            // immediately after the write. The previous code kept
-            // entry.Data + encodeBuf + toWrite all live across the
-            // disk write — for a 268 MB tensor that peaked at ~716 MB
-            // resident during eviction, reintroducing OOMs on the
-            // memory-bound models this feature is meant to help. After
-            // this change peak is entry.Data + encodeBuf ≈ ~536 MB,
-            // and entry.Data is freed BEFORE the write returns.
-            string path = BackingPathFor(id);
-            int uncompressed = entry.Data.Length;
-            int paged;
-            bool compressed = false;
-            if (_enableCompression)
-            {
-                // LZ4 worst-case bound is uncompressed + (uncompressed/255) + 16.
-                // Rent from ArrayPool to keep the encode buffer pooled
-                // across evictions instead of allocating a fresh worst-
-                // case buffer each time.
-                int maxOut = LZ4Codec.MaximumOutputSize(uncompressed);
-                byte[] encodeBuf = ArrayPool<byte>.Shared.Rent(maxOut);
-                try
-                {
-                    int encoded = LZ4Codec.Encode(entry.Data, 0, uncompressed, encodeBuf, 0, maxOut);
-                    if (encoded > 0 && encoded < uncompressed)
-                    {
-                        // Stream-write only the encoded slice. FileStream
-                        // .Write copies (uncompressed + overhead) bytes
-                        // straight to disk — no intermediate byte[encoded]
-                        // copy. This is the dominant peak-memory win:
-                        // before this, we'd have allocated a third
-                        // copy-out buffer here.
-                        using (var fs = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None))
-                        {
-                            fs.Write(encodeBuf, 0, encoded);
-                        }
-                        paged = encoded;
-                        compressed = true;
-                    }
-                    else
-                    {
-                        // Compression didn't shrink the payload (entropy too
-                        // high or below LZ4's break-even) — write entry.Data
-                        // raw and flag IsCompressed=false so Rehydrate
-                        // doesn't try to decode. Same File.WriteAllBytes
-                        // path as the no-compression branch below.
-                        File.WriteAllBytes(path, entry.Data);
-                        paged = uncompressed;
-                        compressed = false;
-                    }
-                }
-                finally
-                {
-                    ArrayPool<byte>.Shared.Return(encodeBuf);
-                }
-            }
-            else
-            {
-                File.WriteAllBytes(path, entry.Data);
-                paged = uncompressed;
-            }
-            // Free entry.Data IMMEDIATELY now that the bytes are durably
-            // on disk. Any further work (counter updates, LRU bookkeeping)
-            // doesn't need the resident copy. Holding it alive across
-            // the rest of this method (or worse, until the next eviction)
-            // would defeat the whole eviction.
-            entry.Data = null;
-            entry.PagedOutBytes = paged;
-            entry.UncompressedBytes = uncompressed;
-            entry.IsCompressed = compressed;
-            _diskWriteBytes += paged;
-            _evictionCount++;
-            _compressedBytesTotal += paged;
-            _uncompressedBytesTotal += uncompressed;
-            Interlocked.Add(ref _residentBytes, -entry.ResidentBytes);
-            entry.ResidentBytes = 0;
+        if (!_entries.TryGetValue(id, out var entry) || entry.Data is null)
+        {
+            // Stale LRU node (entry already evicted/unregistered) — drop.
             _lruOrder.Remove(oldest);
             _lruIndex.Remove(id);
+            return true; // we did make progress — try the next iteration
         }
+
+        // Page out: write to backing store, drop resident reference,
+        // remove from LRU index (Rehydrate re-adds it). When
+        // EnableCompression is true, LZ4-compress before writing —
+        // ~30-40% disk-footprint reduction on near-Gaussian fp32
+        // weights. UncompressedBytes is the rehydration target size;
+        // PagedOutBytes is what's actually on disk.
+        //
+        // Memory-peak optimisation: stream-write the encoded bytes
+        // directly from the rented LZ4 buffer (no intermediate
+        // `new byte[encoded]` copy) and null out entry.Data
+        // immediately after the write. The previous code kept
+        // entry.Data + encodeBuf + toWrite all live across the
+        // disk write — for a 268 MB tensor that peaked at ~716 MB
+        // resident during eviction, reintroducing OOMs on the
+        // memory-bound models this feature is meant to help. After
+        // this change peak is entry.Data + encodeBuf ≈ ~536 MB,
+        // and entry.Data is freed BEFORE the write returns.
+        string path = BackingPathFor(id);
+        int uncompressed = entry.Data.Length;
+        int paged;
+        bool compressed = false;
+        if (_enableCompression)
+        {
+            // LZ4 worst-case bound is uncompressed + (uncompressed/255) + 16.
+            // Rent from ArrayPool to keep the encode buffer pooled
+            // across evictions instead of allocating a fresh worst-
+            // case buffer each time.
+            int maxOut = LZ4Codec.MaximumOutputSize(uncompressed);
+            byte[] encodeBuf = ArrayPool<byte>.Shared.Rent(maxOut);
+            try
+            {
+                int encoded = LZ4Codec.Encode(entry.Data, 0, uncompressed, encodeBuf, 0, maxOut);
+                if (encoded > 0 && encoded < uncompressed)
+                {
+                    // Stream-write only the encoded slice. FileStream
+                    // .Write copies (uncompressed + overhead) bytes
+                    // straight to disk — no intermediate byte[encoded]
+                    // copy. This is the dominant peak-memory win:
+                    // before this, we'd have allocated a third
+                    // copy-out buffer here.
+                    using (var fs = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None))
+                    {
+                        fs.Write(encodeBuf, 0, encoded);
+                    }
+                    paged = encoded;
+                    compressed = true;
+                }
+                else
+                {
+                    // Compression didn't shrink the payload (entropy too
+                    // high or below LZ4's break-even) — write entry.Data
+                    // raw and flag IsCompressed=false so Rehydrate
+                    // doesn't try to decode. Same File.WriteAllBytes
+                    // path as the no-compression branch below.
+                    File.WriteAllBytes(path, entry.Data);
+                    paged = uncompressed;
+                    compressed = false;
+                }
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(encodeBuf);
+            }
+        }
+        else
+        {
+            File.WriteAllBytes(path, entry.Data);
+            paged = uncompressed;
+        }
+        // Free entry.Data IMMEDIATELY now that the bytes are durably
+        // on disk. Any further work (counter updates, LRU bookkeeping)
+        // doesn't need the resident copy. Holding it alive across
+        // the rest of this method (or worse, until the next eviction)
+        // would defeat the whole eviction.
+        entry.Data = null;
+        entry.PagedOutBytes = paged;
+        entry.UncompressedBytes = uncompressed;
+        entry.IsCompressed = compressed;
+        _diskWriteBytes += paged;
+        _evictionCount++;
+        _compressedBytesTotal += paged;
+        _uncompressedBytesTotal += uncompressed;
+        Interlocked.Add(ref _residentBytes, -entry.ResidentBytes);
+        entry.ResidentBytes = 0;
+        _lruOrder.Remove(oldest);
+        _lruIndex.Remove(id);
+        return true;
     }
 
     // Backing files are flat raw bytes (or LZ4-compressed bytes when

--- a/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
@@ -560,7 +560,7 @@ public abstract class TensorBase<T> : IDisposable
 
     /// <summary>
     /// Bytes the streaming pool has pre-reserved against its budget on
-    /// behalf of this tensor between <c>WeightRegistry.AllocateRegistered</c>
+    /// behalf of this tensor between <c>WeightRegistry.AllocateStreaming</c>
     /// and the matching <c>WeightRegistry.RegisterWeight</c>. Used to
     /// prevent a TOCTOU race where two concurrent allocate-then-register
     /// flows both pass the pre-allocate eviction gate but together push

--- a/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
@@ -559,6 +559,18 @@ public abstract class TensorBase<T> : IDisposable
     public long StreamingPoolHandle { get; internal set; } = -1;
 
     /// <summary>
+    /// Bytes the streaming pool has pre-reserved against its budget on
+    /// behalf of this tensor between <c>WeightRegistry.AllocateRegistered</c>
+    /// and the matching <c>WeightRegistry.RegisterWeight</c>. Used to
+    /// prevent a TOCTOU race where two concurrent allocate-then-register
+    /// flows both pass the pre-allocate eviction gate but together push
+    /// resident bytes past budget before either Register lands. Owned by
+    /// <see cref="WeightRegistry"/>; setter is internal so external code
+    /// can't desync the pool's <c>_reservedBytes</c> bookkeeping.
+    /// </summary>
+    internal long StreamingReservedBytes { get; set; }
+
+    /// <summary>
     /// GPU offload allocation handle when <see cref="Lifetime"/> is
     /// <see cref="WeightLifetime.GpuOffload"/> or
     /// <see cref="WeightLifetime.GpuManaged"/>. Owned by

--- a/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
@@ -122,6 +122,21 @@ public static class WeightRegistry
                         var bytes = new byte[byteCount];
                         SerializeToBytes(weight, bytes);
                         var pool = StreamingPoolUnlocked();
+                        // If this tensor was produced by AllocateRegistered,
+                        // it carries the reservation byteCount the pool
+                        // pre-evicted on its behalf. Release the
+                        // reservation BEFORE Register so the pool's
+                        // budget check sees the same byteCount land in
+                        // _residentBytes that came out of _reservedBytes —
+                        // net-zero on the budget rather than counting
+                        // double. Tensors not produced by AllocateRegistered
+                        // have StreamingReservedBytes == 0 (no-op).
+                        long reserved = weight.StreamingReservedBytes;
+                        if (reserved > 0)
+                        {
+                            pool.ReleaseReservation(reserved);
+                            weight.StreamingReservedBytes = 0;
+                        }
                         long handle = pool.Register(bytes);
                         // Two-phase commit: drop storage FIRST (the operation
                         // that can throw — non-contiguous, view, shared
@@ -207,13 +222,20 @@ public static class WeightRegistry
     /// then calls <see cref="RegisterWeight{T}"/> as usual; the
     /// difference vs. plain <c>new Tensor&lt;T&gt;(shape)</c> is that the
     /// pool evicts LRU resident entries to disk BEFORE this method
-    /// allocates, so for a long sequence of large allocations the pool
-    /// budget bounds peak GC-heap occupancy. Without this, allocating
-    /// 64 MHA layers' worth of weights at 2.1 GB each on the lazy
+    /// allocates AND records a reservation against the pool budget so a
+    /// concurrent allocator can't pass the same eviction gate. For a
+    /// long sequence of large allocations the pool budget therefore
+    /// bounds peak GC-heap occupancy. Without this, allocating 64 MHA
+    /// layers' worth of weights at 2.1 GB each on the lazy
     /// materialization path peaks at 134 GB resident before any register
     /// runs — exactly the OOM mode #1222 / PaLM-E 562B exhibits.
     /// </summary>
-    /// <typeparam name="T">Numeric element type for the tensor.</typeparam>
+    /// <typeparam name="T">Numeric element type. Must be one of the
+    /// streamable types (float, double, int, long, Half, BFloat16); other
+    /// types throw <see cref="NotSupportedException"/> upfront so the
+    /// pool's eviction loop doesn't churn the LRU on behalf of a tensor
+    /// that <see cref="RegisterWeight{T}"/> would later refuse to
+    /// serialize anyway.</typeparam>
     /// <param name="shape">Per-axis dimensions for the new tensor. Same
     /// contract as <see cref="Tensor{T}(int[])"/>.</param>
     /// <returns>A materialized tensor with zero-initialized storage and
@@ -221,27 +243,38 @@ public static class WeightRegistry
     /// instance. Caller is expected to:
     ///   1. Initialize weights (Xavier / He / etc.).
     ///   2. Call <see cref="RegisterWeight{T}"/> to commit it to the
-    ///      pool — that's when storage is dropped + the
+    ///      pool — that's when the reservation transitions to
+    ///      resident bytes and the
     ///      <see cref="Tensor{T}.StreamingPoolHandle"/> is assigned.
+    /// If the caller bails between Allocate and Register, call
+    /// <see cref="StreamingTensorPool.ReleaseReservation"/> via the
+    /// stored <see cref="Tensor{T}.StreamingReservedBytes"/> to give
+    /// the headroom back.
     /// </returns>
     /// <remarks>
-    /// <para>No-op fallback when streaming isn't configured (i.e.
-    /// <see cref="Configure"/> hasn't run yet): falls back to a plain
-    /// <c>new Tensor&lt;T&gt;(shape)</c> with <see cref="WeightLifetime.Default"/>
-    /// — the caller's initialization + register flow becomes a regular
-    /// non-streaming registration, identical to pre-streaming behaviour.</para>
     /// <para>The eviction step is best-effort: the pool's
-    /// <see cref="StreamingTensorPool.EvictUntilFreeBytes"/> walks the
-    /// LRU until either the requested headroom is available OR the LRU
-    /// is empty (i.e. nothing more to evict). In the latter case the
-    /// allocation still proceeds — the goal is to reduce the peak,
-    /// not eliminate the possibility of OOM. Pool-budget tuning is the
-    /// caller's responsibility.</para>
+    /// <see cref="StreamingTensorPool.ReserveBytes"/> walks the LRU until
+    /// either the requested headroom is available OR the LRU is empty
+    /// (i.e. nothing more to evict). In the latter case the allocation
+    /// still proceeds — the goal is to reduce the peak, not eliminate
+    /// the possibility of OOM. Pool-budget tuning is the caller's
+    /// responsibility.</para>
     /// </remarks>
     public static Tensor<T> AllocateRegistered<T>(int[] shape)
     {
         if (shape is null) throw new ArgumentNullException(nameof(shape));
-        // Compute byte count up-front so we can evict the right amount
+        // Reject unsupported element types BEFORE we touch the pool.
+        // Without this gate, AllocateRegistered<decimal>(...) would
+        // happily evict resident weights to make room for a tensor
+        // that RegisterWeight would later refuse with
+        // NotSupportedException — turning the user's type mistake into
+        // a pool-churn DoS that pages out warm weights for no reason.
+        if (!IsStreamableType<T>())
+            throw new NotSupportedException(
+                $"WeightRegistry.AllocateRegistered: element type {typeof(T).Name} is not " +
+                "supported by the streaming pool. Supported types: float, double, int, long, " +
+                "Half, BFloat16. Use plain `new Tensor<T>(shape)` for non-streamable types.");
+        // Compute byte count up-front so we can reserve the right amount
         // BEFORE the GC heap takes the hit. CheckedStreamingByteCount
         // surfaces oversize-tensor errors as a clear NotSupportedException
         // with a chunking hint instead of OOM.
@@ -254,40 +287,43 @@ public static class WeightRegistry
             elements = checked(elements * dim);
         }
 
+        // Reservation must hold across both the eviction step and the
+        // tensor allocation: between releasing _lock and the GC byte[]
+        // landing on the heap, a concurrent AllocateRegistered would
+        // otherwise pass the same headroom check we just passed.
+        // CheckedStreamingByteCount enforces the int.MaxValue (byte[])
+        // bound; long elements > int.MaxValue rejects with a clear
+        // chunking-hint error.
+        if (elements > int.MaxValue)
+            throw new NotSupportedException(
+                $"AllocateRegistered: per-tensor element count {elements} exceeds the " +
+                $"int.MaxValue ({int.MaxValue}) bound that the streaming pool's byte[] " +
+                "buffer can represent. Chunk the tensor into smaller pool entries on " +
+                "the consumer side.");
+        int byteCount = elements > 0 ? CheckedStreamingByteCount<T>((int)elements) : 0;
+
         lock (_lock)
         {
-            // Streaming not configured — fall through to plain new Tensor.
-            // Lifetime stays Default so RegisterWeight (if the caller
-            // calls it later) is a no-op, exactly like the pre-streaming
-            // path.
-            if (_options is null) return new Tensor<T>(shape);
-
-            // Best-effort eviction. CheckedStreamingByteCount takes int
-            // length and surfaces oversize as NotSupportedException; cast
-            // long→int is safe iff elements <= int.MaxValue. Larger
-            // tensors can't be streamed at all (byte[] is itself bounded
-            // to ~2.15 GB), so reject upfront with the same chunking-
-            // hint error the post-allocate path would have surfaced.
-            if (elements > 0)
+            // _options is field-initialized to `new GpuOffloadOptions()`
+            // and never set to null (Configure rejects null; Reset
+            // assigns a fresh default), so there is no "streaming not
+            // configured" state to fall back from. Always-on contract.
+            if (byteCount > 0)
             {
-                if (elements > int.MaxValue)
-                    throw new NotSupportedException(
-                        $"AllocateRegistered: per-tensor element count {elements} exceeds the " +
-                        $"int.MaxValue ({int.MaxValue}) bound that the streaming pool's byte[] " +
-                        "buffer can represent. Chunk the tensor into smaller pool entries on " +
-                        "the consumer side.");
-                int byteCount = CheckedStreamingByteCount<T>((int)elements);
                 var pool = StreamingPoolUnlocked();
-                pool.EvictUntilFreeBytes(byteCount);
+                pool.ReserveBytes(byteCount);
             }
 
-            // Allocate AFTER eviction has paged out competitors.
-            // The tensor's storage hits the GC heap here — there's no
-            // way to skip that without a full storage-from-pool
-            // refactor — but at least competing weights have been
-            // paged to disk so we're not on top of the previous
-            // 64 layers' weights.
-            var tensor = new Tensor<T>(shape) { Lifetime = WeightLifetime.Streaming };
+            // Allocate AFTER reservation has paged out competitors AND
+            // promised headroom against concurrent allocators. The
+            // tensor's storage hits the GC heap here — there's no way
+            // to skip that without a full storage-from-pool refactor —
+            // but at least the budget invariant is enforced.
+            var tensor = new Tensor<T>(shape)
+            {
+                Lifetime = WeightLifetime.Streaming,
+                StreamingReservedBytes = byteCount,
+            };
             return tensor;
         }
     }
@@ -367,6 +403,24 @@ public static class WeightRegistry
                 $"(byte[] limit). Tensor has {length} elements × {elementSize} bytes = " +
                 $"{byteCountLong} bytes. Chunk the tensor into smaller pool entries on the consumer side.");
         return (int)byteCountLong;
+    }
+
+    /// <summary>
+    /// True when <typeparamref name="T"/> can be losslessly serialized to
+    /// the streaming pool's byte buffer. Mirrors the type set in
+    /// <see cref="SerializeToBytes{T}"/>'s fast paths — additions there
+    /// must add the type here too. Used by
+    /// <see cref="AllocateRegistered{T}"/> to fail fast before the pool's
+    /// eviction loop churns the LRU.
+    /// </summary>
+    internal static bool IsStreamableType<T>()
+    {
+        return typeof(T) == typeof(float)
+            || typeof(T) == typeof(double)
+            || typeof(T) == typeof(int)
+            || typeof(T) == typeof(long)
+            || typeof(T) == typeof(Half)
+            || typeof(T) == typeof(AiDotNet.Tensors.NumericOperations.BFloat16);
     }
 
     private static int ElementSize<T>()

--- a/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
@@ -52,6 +52,20 @@ public static class WeightRegistry
                 throw new InvalidOperationException(
                     $"WeightRegistry.Configure: existing streaming pool has {_streamingPool.RegisteredEntryCount} " +
                     "registered entries. Unregister all weights first, or call Reset() to forcibly drop them.");
+            // Same for outstanding reservations from in-flight
+            // AllocateStreaming calls that haven't yet hit RegisterWeight.
+            // Swapping the pool here would orphan those reservations: the
+            // tensor still carries StreamingReservedBytes but the pool
+            // that recorded it is gone, so RegisterWeight / UnregisterWeight
+            // would later release bytes against the WRONG pool — corrupting
+            // the new pool's _reservedBytes accounting and letting later
+            // allocators overshoot the budget.
+            if (_streamingPool is not null && _streamingPool.ReservedBytes > 0)
+                throw new InvalidOperationException(
+                    $"WeightRegistry.Configure: existing streaming pool has {_streamingPool.ReservedBytes} " +
+                    "bytes of outstanding reservations from AllocateStreaming calls that haven't yet " +
+                    "called RegisterWeight (or UnregisterWeight). Complete or abandon those allocations first, " +
+                    "or call Reset() to forcibly drop them.");
 
             // Dispose the previous allocator before swapping — otherwise its
             // outstanding pinned/managed allocations + native context are
@@ -291,27 +305,35 @@ public static class WeightRegistry
                 "supported by the streaming pool. Supported types: float, double, int, long, " +
                 "Half, BFloat16. Use plain `new Tensor<T>(shape)` for non-streamable types.");
         // Compute byte count up-front so we can reserve the right amount
-        // BEFORE the GC heap takes the hit. CheckedStreamingByteCount
-        // surfaces oversize-tensor errors as a clear NotSupportedException
-        // with a chunking hint instead of OOM.
+        // BEFORE the GC heap takes the hit. Check the int.MaxValue bound
+        // INSIDE the loop instead of relying on `checked` overflow at
+        // the end — `checked(int.MaxValue * int.MaxValue * 3)` would
+        // throw OverflowException, masking the cleaner chunking-hint
+        // error this method's contract promises. By short-circuiting on
+        // each dim multiply we surface the oversize case as
+        // NotSupportedException with the documented message regardless
+        // of how pathologically large the shape is.
         long elements = 1L;
         for (int i = 0; i < shape.Length; i++)
         {
             int dim = shape[i];
             if (dim < 0)
                 throw new ArgumentException($"shape[{i}] must be non-negative; got {dim}", nameof(shape));
-            elements = checked(elements * dim);
+            // Guard against int.MaxValue bound BEFORE the multiply so
+            // `checked` doesn't fire first. elements * dim could exceed
+            // int.MaxValue even when elements <= int.MaxValue (e.g.
+            // elements=int.MaxValue, dim=2). Compare in long arithmetic.
+            if (dim > 0 && elements > int.MaxValue / dim)
+            {
+                throw new NotSupportedException(
+                    $"AllocateStreaming: per-tensor element count exceeds the " +
+                    $"int.MaxValue ({int.MaxValue}) bound that the streaming pool's byte[] " +
+                    "buffer can represent (overflow at shape[" + i + "]). Chunk the tensor " +
+                    "into smaller pool entries on the consumer side.");
+            }
+            elements *= dim;
         }
 
-        // CheckedStreamingByteCount enforces the int.MaxValue (byte[])
-        // bound; long elements > int.MaxValue rejects with a clear
-        // chunking-hint error.
-        if (elements > int.MaxValue)
-            throw new NotSupportedException(
-                $"AllocateStreaming: per-tensor element count {elements} exceeds the " +
-                $"int.MaxValue ({int.MaxValue}) bound that the streaming pool's byte[] " +
-                "buffer can represent. Chunk the tensor into smaller pool entries on " +
-                "the consumer side.");
         int byteCount = elements > 0 ? CheckedStreamingByteCount<T>((int)elements) : 0;
 
         // Phase 1: under registry lock, take a stable reference to the

--- a/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
@@ -246,10 +246,15 @@ public static class WeightRegistry
     ///      pool — that's when the reservation transitions to
     ///      resident bytes and the
     ///      <see cref="Tensor{T}.StreamingPoolHandle"/> is assigned.
-    /// If the caller bails between Allocate and Register, call
-    /// <see cref="StreamingTensorPool.ReleaseReservation"/> via the
-    /// stored <see cref="Tensor{T}.StreamingReservedBytes"/> to give
-    /// the headroom back.
+    /// If the caller bails between Allocate and Register (e.g. an
+    /// exception during weight initialization, or the layer is torn
+    /// down before its first forward), call
+    /// <see cref="UnregisterWeight{T}"/> with the allocated tensor to
+    /// release its reservation and return the headroom to the pool
+    /// budget. <see cref="Tensor{T}.StreamingReservedBytes"/> is
+    /// internal and not directly callable from external code —
+    /// <see cref="UnregisterWeight{T}"/> is the public cancellation
+    /// path.
     /// </returns>
     /// <remarks>
     /// <para>The eviction step is best-effort: the pool's

--- a/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
@@ -122,14 +122,14 @@ public static class WeightRegistry
                         var bytes = new byte[byteCount];
                         SerializeToBytes(weight, bytes);
                         var pool = StreamingPoolUnlocked();
-                        // If this tensor was produced by AllocateRegistered,
+                        // If this tensor was produced by AllocateStreaming,
                         // it carries the reservation byteCount the pool
                         // pre-evicted on its behalf. Release the
                         // reservation BEFORE Register so the pool's
                         // budget check sees the same byteCount land in
                         // _residentBytes that came out of _reservedBytes —
                         // net-zero on the budget rather than counting
-                        // double. Tensors not produced by AllocateRegistered
+                        // double. Tensors not produced by AllocateStreaming
                         // have StreamingReservedBytes == 0 (no-op).
                         long reserved = weight.StreamingReservedBytes;
                         if (reserved > 0)
@@ -216,26 +216,28 @@ public static class WeightRegistry
     }
 
     /// <summary>
-    /// Allocates a tensor whose storage is going to be paged through the
-    /// streaming pool, reserving headroom for it in advance. Caller
-    /// initializes weights into the returned (materialized) tensor and
-    /// then calls <see cref="RegisterWeight{T}"/> as usual; the
-    /// difference vs. plain <c>new Tensor&lt;T&gt;(shape)</c> is that the
-    /// pool evicts LRU resident entries to disk BEFORE this method
-    /// allocates AND records a reservation against the pool budget so a
-    /// concurrent allocator can't pass the same eviction gate. For a
-    /// long sequence of large allocations the pool budget therefore
-    /// bounds peak GC-heap occupancy. Without this, allocating 64 MHA
-    /// layers' worth of weights at 2.1 GB each on the lazy
-    /// materialization path peaks at 134 GB resident before any register
-    /// runs — exactly the OOM mode #1222 / PaLM-E 562B exhibits.
+    /// Allocates a tensor whose storage will be paged through the
+    /// streaming pool, reserving budget headroom for it in advance.
+    /// "Streaming" not "Registered" — the returned tensor is
+    /// pre-reserved against the pool budget but NOT yet registered;
+    /// callers must still invoke <see cref="RegisterWeight{T}"/> to
+    /// commit it to the pool.
+    ///
+    /// <para>The pool evicts LRU resident entries to disk BEFORE this
+    /// method allocates AND records a reservation so a concurrent
+    /// allocator can't pass the same eviction gate. For a long sequence
+    /// of large allocations the pool budget therefore bounds peak
+    /// GC-heap occupancy. Without this, allocating 64 MHA layers' worth
+    /// of weights at 2.1 GB each on the lazy materialization path peaks
+    /// at 134 GB resident before any register runs — exactly the OOM
+    /// mode #1222 / PaLM-E 562B exhibits.</para>
     /// </summary>
     /// <typeparam name="T">Numeric element type. Must be one of the
-    /// streamable types (float, double, int, long, Half, BFloat16); other
-    /// types throw <see cref="NotSupportedException"/> upfront so the
-    /// pool's eviction loop doesn't churn the LRU on behalf of a tensor
-    /// that <see cref="RegisterWeight{T}"/> would later refuse to
-    /// serialize anyway.</typeparam>
+    /// streamable types (float, double, int, long, Half, BFloat16);
+    /// other types throw <see cref="NotSupportedException"/> upfront so
+    /// the pool's eviction loop doesn't churn the LRU on behalf of a
+    /// tensor that <see cref="RegisterWeight{T}"/> would later refuse
+    /// to serialize anyway.</typeparam>
     /// <param name="shape">Per-axis dimensions for the new tensor. Same
     /// contract as <see cref="Tensor{T}(int[])"/>.</param>
     /// <returns>A materialized tensor with zero-initialized storage and
@@ -244,7 +246,7 @@ public static class WeightRegistry
     ///   1. Initialize weights (Xavier / He / etc.).
     ///   2. Call <see cref="RegisterWeight{T}"/> to commit it to the
     ///      pool — that's when the reservation transitions to
-    ///      resident bytes and the
+    ///      resident bytes and
     ///      <see cref="Tensor{T}.StreamingPoolHandle"/> is assigned.
     /// If the caller bails between Allocate and Register (e.g. an
     /// exception during weight initialization, or the layer is torn
@@ -257,26 +259,35 @@ public static class WeightRegistry
     /// path.
     /// </returns>
     /// <remarks>
-    /// <para>The eviction step is best-effort: the pool's
-    /// <see cref="StreamingTensorPool.ReserveBytes"/> walks the LRU until
-    /// either the requested headroom is available OR the LRU is empty
-    /// (i.e. nothing more to evict). In the latter case the allocation
-    /// still proceeds — the goal is to reduce the peak, not eliminate
-    /// the possibility of OOM. Pool-budget tuning is the caller's
-    /// responsibility.</para>
+    /// <para>The eviction step is best-effort: the pool's reservation
+    /// helper walks the LRU until either the requested headroom is
+    /// available OR the LRU is empty (or the request exceeds the
+    /// entire budget — short-circuit). In any of those cases the
+    /// allocation still proceeds — the goal is to reduce the peak,
+    /// not eliminate the possibility of OOM. Pool-budget tuning is
+    /// the caller's responsibility.</para>
+    /// <para>Locking: the registry-wide <c>_lock</c> is held only long
+    /// enough to take a stable reference to the streaming pool and
+    /// reserve budget. The actual <c>new Tensor&lt;T&gt;(shape)</c>
+    /// runs OUTSIDE the lock so concurrent <see cref="RegisterWeight{T}"/>
+    /// / <see cref="UnregisterWeight{T}"/> calls aren't blocked for the
+    /// (potentially multi-hundred-MB) GC heap allocation. The pool's
+    /// own lock guarantees the reservation is atomic; releasing it on
+    /// allocation failure also goes through the pool's lock, not the
+    /// registry's.</para>
     /// </remarks>
-    public static Tensor<T> AllocateRegistered<T>(int[] shape)
+    public static Tensor<T> AllocateStreaming<T>(int[] shape)
     {
         if (shape is null) throw new ArgumentNullException(nameof(shape));
         // Reject unsupported element types BEFORE we touch the pool.
-        // Without this gate, AllocateRegistered<decimal>(...) would
+        // Without this gate, AllocateStreaming<decimal>(...) would
         // happily evict resident weights to make room for a tensor
         // that RegisterWeight would later refuse with
         // NotSupportedException — turning the user's type mistake into
         // a pool-churn DoS that pages out warm weights for no reason.
         if (!IsStreamableType<T>())
             throw new NotSupportedException(
-                $"WeightRegistry.AllocateRegistered: element type {typeof(T).Name} is not " +
+                $"WeightRegistry.AllocateStreaming: element type {typeof(T).Name} is not " +
                 "supported by the streaming pool. Supported types: float, double, int, long, " +
                 "Half, BFloat16. Use plain `new Tensor<T>(shape)` for non-streamable types.");
         // Compute byte count up-front so we can reserve the right amount
@@ -292,73 +303,80 @@ public static class WeightRegistry
             elements = checked(elements * dim);
         }
 
-        // Reservation must hold across both the eviction step and the
-        // tensor allocation: between releasing _lock and the GC byte[]
-        // landing on the heap, a concurrent AllocateRegistered would
-        // otherwise pass the same headroom check we just passed.
         // CheckedStreamingByteCount enforces the int.MaxValue (byte[])
         // bound; long elements > int.MaxValue rejects with a clear
         // chunking-hint error.
         if (elements > int.MaxValue)
             throw new NotSupportedException(
-                $"AllocateRegistered: per-tensor element count {elements} exceeds the " +
+                $"AllocateStreaming: per-tensor element count {elements} exceeds the " +
                 $"int.MaxValue ({int.MaxValue}) bound that the streaming pool's byte[] " +
                 "buffer can represent. Chunk the tensor into smaller pool entries on " +
                 "the consumer side.");
         int byteCount = elements > 0 ? CheckedStreamingByteCount<T>((int)elements) : 0;
 
+        // Phase 1: under registry lock, take a stable reference to the
+        // streaming pool. The pool's own lock will then guard the
+        // reservation atomically. We MUST NOT hold the registry lock
+        // across the GC heap allocation below — for the multi-hundred-MB
+        // tensors this API targets, that would block all unrelated
+        // RegisterWeight / UnregisterWeight calls for the full
+        // allocation duration (or the duration of an OOM throw).
+        StreamingTensorPool? pool;
         lock (_lock)
         {
             // _options is field-initialized to `new GpuOffloadOptions()`
             // and never set to null (Configure rejects null; Reset
             // assigns a fresh default), so there is no "streaming not
             // configured" state to fall back from. Always-on contract.
-            StreamingTensorPool? pool = null;
-            if (byteCount > 0)
-            {
-                pool = StreamingPoolUnlocked();
-                pool.ReserveBytes(byteCount);
-            }
+            pool = byteCount > 0 ? StreamingPoolUnlocked() : null;
+        }
 
-            // Allocate AFTER reservation has paged out competitors AND
-            // promised headroom against concurrent allocators. The
-            // tensor's storage hits the GC heap here — there's no way
-            // to skip that without a full storage-from-pool refactor —
-            // but at least the budget invariant is enforced.
-            // Roll back the reservation if the constructor or property
-            // initializer throws (e.g. OOM on the GC byte[] allocation,
-            // or a future ctor-arg validation rejecting the shape):
-            // without this catch, the reserved headroom would leak and
-            // the pool's _reservedBytes would drift up by byteCount on
-            // every failed AllocateRegistered, eventually starving the
-            // budget for legitimate allocators.
-            try
+        // Phase 2: reservation — atomic via the pool's own lock.
+        // Concurrent AllocateStreaming calls each see each other's
+        // reservation in EvictUntilFreeBytesUnlocked's free-bytes
+        // calculation, so neither overshoots budget.
+        pool?.ReserveBytes(byteCount);
+
+        // Phase 3: allocate OUTSIDE both locks. The tensor's storage
+        // hits the GC heap here — there's no way to skip that without
+        // a full storage-from-pool refactor — but the registry lock
+        // is now free for unrelated registry traffic, and the pool's
+        // budget invariant is enforced by the reservation we already
+        // recorded.
+        //
+        // Roll back the reservation if the constructor or property
+        // initializer throws (e.g. OOM on the GC byte[] allocation,
+        // or a future ctor-arg validation rejecting the shape):
+        // without this catch, the reserved headroom would leak and
+        // the pool's _reservedBytes would drift up by byteCount on
+        // every failed AllocateStreaming, eventually starving the
+        // budget for legitimate allocators.
+        try
+        {
+            return new Tensor<T>(shape)
             {
-                return new Tensor<T>(shape)
-                {
-                    Lifetime = WeightLifetime.Streaming,
-                    StreamingReservedBytes = byteCount,
-                };
-            }
-            catch
-            {
-                pool?.ReleaseReservation(byteCount);
-                throw;
-            }
+                Lifetime = WeightLifetime.Streaming,
+                StreamingReservedBytes = byteCount,
+            };
+        }
+        catch
+        {
+            pool?.ReleaseReservation(byteCount);
+            throw;
         }
     }
 
     /// <summary>
     /// Unregisters and frees backing storage. Also serves as the public
     /// cancellation path for tensors that were produced by
-    /// <see cref="AllocateRegistered{T}"/> but never went on to
+    /// <see cref="AllocateStreaming{T}"/> but never went on to
     /// <see cref="RegisterWeight{T}"/>: callers in that "allocated but
     /// abandoned" state pass the tensor to UnregisterWeight to give the
     /// pool's reserved headroom back to the budget. Without this path,
     /// <see cref="Tensor{T}.StreamingReservedBytes"/> would be inaccessible
     /// to external callers (it is internal so external code can't
     /// desync the pool's bookkeeping by mutating it directly), so the
-    /// reservation would stay stranded for the rest of the process'
+    /// reservation would stay stranded for the rest of the process's
     /// lifetime.
     /// </summary>
     public static void UnregisterWeight<T>(Tensor<T> weight)
@@ -450,35 +468,46 @@ public static class WeightRegistry
     }
 
     /// <summary>
-    /// True when <typeparamref name="T"/> can be losslessly serialized to
-    /// the streaming pool's byte buffer. Mirrors the type set in
-    /// <see cref="SerializeToBytes{T}"/>'s fast paths — additions there
-    /// must add the type here too. Used by
-    /// <see cref="AllocateRegistered{T}"/> to fail fast before the pool's
-    /// eviction loop churns the LRU.
+    /// Single source of truth for the streamable-type table. Returns the
+    /// per-element byte size when <typeparamref name="T"/> is one of
+    /// the supported types; returns 0 when <typeparamref name="T"/> is
+    /// not streamable. <see cref="IsStreamableType{T}"/>,
+    /// <see cref="ElementSize{T}"/>, and <see cref="SerializeToBytes{T}"/>
+    /// all derive from this helper so adding a new streamable type is
+    /// a single-place change.
     /// </summary>
-    internal static bool IsStreamableType<T>()
+    /// <remarks>
+    /// Marshal.SizeOf&lt;Half&gt;() is host-dependent (returns 2 on
+    /// .NET 5+, 4 on net471 polyfills), so deferring to it would
+    /// mismatch the byte layout SerializeToBytes / RestoreStorageFromBytes
+    /// expect. The hand-coded sizes here agree with those codecs.
+    /// </remarks>
+    private static int StreamableTypeSize<T>()
     {
-        return typeof(T) == typeof(float)
-            || typeof(T) == typeof(double)
-            || typeof(T) == typeof(int)
-            || typeof(T) == typeof(long)
-            || typeof(T) == typeof(Half)
-            || typeof(T) == typeof(AiDotNet.Tensors.NumericOperations.BFloat16);
-    }
-
-    private static int ElementSize<T>()
-    {
-        // Use typed fast-path sizes that agree with SerializeToBytes /
-        // TensorBase.ElementSizeForStreaming. Marshal.SizeOf<Half>() is
-        // host-dependent (returns 2 on .NET 5+, 4 on net471 polyfills),
-        // so deferring to it would mismatch the byte layout.
         if (typeof(T) == typeof(float)) return sizeof(float);
         if (typeof(T) == typeof(double)) return sizeof(double);
         if (typeof(T) == typeof(int)) return sizeof(int);
         if (typeof(T) == typeof(long)) return sizeof(long);
         if (typeof(T) == typeof(Half)) return 2;
         if (typeof(T) == typeof(AiDotNet.Tensors.NumericOperations.BFloat16)) return 2;
+        return 0; // not streamable
+    }
+
+    /// <summary>
+    /// True when <typeparamref name="T"/> can be losslessly serialized to
+    /// the streaming pool's byte buffer. Derived from
+    /// <see cref="StreamableTypeSize{T}"/> — extending the supported set
+    /// requires adding to that one method. Used by
+    /// <see cref="AllocateStreaming{T}"/> to fail fast before the pool's
+    /// eviction loop churns the LRU and by <see cref="SerializeToBytes{T}"/>
+    /// as the contract gate.
+    /// </summary>
+    internal static bool IsStreamableType<T>() => StreamableTypeSize<T>() > 0;
+
+    private static int ElementSize<T>()
+    {
+        int sz = StreamableTypeSize<T>();
+        if (sz > 0) return sz;
         // Anything else: fall through to Marshal.SizeOf — these types
         // can't actually be serialized (SerializeToBytes throws), but
         // ElementSize is also used for the GpuOffload byteCount which

--- a/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
@@ -200,6 +200,98 @@ public static class WeightRegistry
         }
     }
 
+    /// <summary>
+    /// Allocates a tensor whose storage is going to be paged through the
+    /// streaming pool, reserving headroom for it in advance. Caller
+    /// initializes weights into the returned (materialized) tensor and
+    /// then calls <see cref="RegisterWeight{T}"/> as usual; the
+    /// difference vs. plain <c>new Tensor&lt;T&gt;(shape)</c> is that the
+    /// pool evicts LRU resident entries to disk BEFORE this method
+    /// allocates, so for a long sequence of large allocations the pool
+    /// budget bounds peak GC-heap occupancy. Without this, allocating
+    /// 64 MHA layers' worth of weights at 2.1 GB each on the lazy
+    /// materialization path peaks at 134 GB resident before any register
+    /// runs — exactly the OOM mode #1222 / PaLM-E 562B exhibits.
+    /// </summary>
+    /// <typeparam name="T">Numeric element type for the tensor.</typeparam>
+    /// <param name="shape">Per-axis dimensions for the new tensor. Same
+    /// contract as <see cref="Tensor{T}(int[])"/>.</param>
+    /// <returns>A materialized tensor with zero-initialized storage and
+    /// <see cref="WeightLifetime.Streaming"/> already set on the
+    /// instance. Caller is expected to:
+    ///   1. Initialize weights (Xavier / He / etc.).
+    ///   2. Call <see cref="RegisterWeight{T}"/> to commit it to the
+    ///      pool — that's when storage is dropped + the
+    ///      <see cref="Tensor{T}.StreamingPoolHandle"/> is assigned.
+    /// </returns>
+    /// <remarks>
+    /// <para>No-op fallback when streaming isn't configured (i.e.
+    /// <see cref="Configure"/> hasn't run yet): falls back to a plain
+    /// <c>new Tensor&lt;T&gt;(shape)</c> with <see cref="WeightLifetime.Default"/>
+    /// — the caller's initialization + register flow becomes a regular
+    /// non-streaming registration, identical to pre-streaming behaviour.</para>
+    /// <para>The eviction step is best-effort: the pool's
+    /// <see cref="StreamingTensorPool.EvictUntilFreeBytes"/> walks the
+    /// LRU until either the requested headroom is available OR the LRU
+    /// is empty (i.e. nothing more to evict). In the latter case the
+    /// allocation still proceeds — the goal is to reduce the peak,
+    /// not eliminate the possibility of OOM. Pool-budget tuning is the
+    /// caller's responsibility.</para>
+    /// </remarks>
+    public static Tensor<T> AllocateRegistered<T>(int[] shape)
+    {
+        if (shape is null) throw new ArgumentNullException(nameof(shape));
+        // Compute byte count up-front so we can evict the right amount
+        // BEFORE the GC heap takes the hit. CheckedStreamingByteCount
+        // surfaces oversize-tensor errors as a clear NotSupportedException
+        // with a chunking hint instead of OOM.
+        long elements = 1L;
+        for (int i = 0; i < shape.Length; i++)
+        {
+            int dim = shape[i];
+            if (dim < 0)
+                throw new ArgumentException($"shape[{i}] must be non-negative; got {dim}", nameof(shape));
+            elements = checked(elements * dim);
+        }
+
+        lock (_lock)
+        {
+            // Streaming not configured — fall through to plain new Tensor.
+            // Lifetime stays Default so RegisterWeight (if the caller
+            // calls it later) is a no-op, exactly like the pre-streaming
+            // path.
+            if (_options is null) return new Tensor<T>(shape);
+
+            // Best-effort eviction. CheckedStreamingByteCount takes int
+            // length and surfaces oversize as NotSupportedException; cast
+            // long→int is safe iff elements <= int.MaxValue. Larger
+            // tensors can't be streamed at all (byte[] is itself bounded
+            // to ~2.15 GB), so reject upfront with the same chunking-
+            // hint error the post-allocate path would have surfaced.
+            if (elements > 0)
+            {
+                if (elements > int.MaxValue)
+                    throw new NotSupportedException(
+                        $"AllocateRegistered: per-tensor element count {elements} exceeds the " +
+                        $"int.MaxValue ({int.MaxValue}) bound that the streaming pool's byte[] " +
+                        "buffer can represent. Chunk the tensor into smaller pool entries on " +
+                        "the consumer side.");
+                int byteCount = CheckedStreamingByteCount<T>((int)elements);
+                var pool = StreamingPoolUnlocked();
+                pool.EvictUntilFreeBytes(byteCount);
+            }
+
+            // Allocate AFTER eviction has paged out competitors.
+            // The tensor's storage hits the GC heap here — there's no
+            // way to skip that without a full storage-from-pool
+            // refactor — but at least competing weights have been
+            // paged to disk so we're not on top of the previous
+            // 64 layers' weights.
+            var tensor = new Tensor<T>(shape) { Lifetime = WeightLifetime.Streaming };
+            return tensor;
+        }
+    }
+
     /// <summary>Unregisters and frees backing storage.</summary>
     public static void UnregisterWeight<T>(Tensor<T> weight)
     {

--- a/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
@@ -308,9 +308,10 @@ public static class WeightRegistry
             // and never set to null (Configure rejects null; Reset
             // assigns a fresh default), so there is no "streaming not
             // configured" state to fall back from. Always-on contract.
+            StreamingTensorPool? pool = null;
             if (byteCount > 0)
             {
-                var pool = StreamingPoolUnlocked();
+                pool = StreamingPoolUnlocked();
                 pool.ReserveBytes(byteCount);
             }
 
@@ -319,16 +320,42 @@ public static class WeightRegistry
             // tensor's storage hits the GC heap here — there's no way
             // to skip that without a full storage-from-pool refactor —
             // but at least the budget invariant is enforced.
-            var tensor = new Tensor<T>(shape)
+            // Roll back the reservation if the constructor or property
+            // initializer throws (e.g. OOM on the GC byte[] allocation,
+            // or a future ctor-arg validation rejecting the shape):
+            // without this catch, the reserved headroom would leak and
+            // the pool's _reservedBytes would drift up by byteCount on
+            // every failed AllocateRegistered, eventually starving the
+            // budget for legitimate allocators.
+            try
             {
-                Lifetime = WeightLifetime.Streaming,
-                StreamingReservedBytes = byteCount,
-            };
-            return tensor;
+                return new Tensor<T>(shape)
+                {
+                    Lifetime = WeightLifetime.Streaming,
+                    StreamingReservedBytes = byteCount,
+                };
+            }
+            catch
+            {
+                pool?.ReleaseReservation(byteCount);
+                throw;
+            }
         }
     }
 
-    /// <summary>Unregisters and frees backing storage.</summary>
+    /// <summary>
+    /// Unregisters and frees backing storage. Also serves as the public
+    /// cancellation path for tensors that were produced by
+    /// <see cref="AllocateRegistered{T}"/> but never went on to
+    /// <see cref="RegisterWeight{T}"/>: callers in that "allocated but
+    /// abandoned" state pass the tensor to UnregisterWeight to give the
+    /// pool's reserved headroom back to the budget. Without this path,
+    /// <see cref="Tensor{T}.StreamingReservedBytes"/> would be inaccessible
+    /// to external callers (it is internal so external code can't
+    /// desync the pool's bookkeeping by mutating it directly), so the
+    /// reservation would stay stranded for the rest of the process'
+    /// lifetime.
+    /// </summary>
     public static void UnregisterWeight<T>(Tensor<T> weight)
     {
         if (weight is null) throw new ArgumentNullException(nameof(weight));
@@ -337,6 +364,18 @@ public static class WeightRegistry
         // outstanding allocations.
         lock (_lock)
         {
+            // Allocated-but-never-registered tensors carry a non-zero
+            // StreamingReservedBytes and a -1 StreamingPoolHandle. Give
+            // the reservation back to the pool. Tensors that DID go
+            // through RegisterWeight already had their reservation
+            // released there (and StreamingReservedBytes cleared to 0),
+            // so this is a no-op for the normal path.
+            long reserved = weight.StreamingReservedBytes;
+            if (reserved > 0 && weight.StreamingPoolHandle < 0)
+            {
+                _streamingPool?.ReleaseReservation(reserved);
+                weight.StreamingReservedBytes = 0;
+            }
             if (weight.StreamingPoolHandle >= 0)
             {
                 _streamingPool?.Unregister(weight.StreamingPoolHandle);

--- a/src/AiDotNet.Tensors/NumericOperations/BoolOperations.cs
+++ b/src/AiDotNet.Tensors/NumericOperations/BoolOperations.cs
@@ -1,0 +1,142 @@
+using System;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.Interfaces;
+
+namespace AiDotNet.Tensors.NumericOperations;
+
+/// <summary>
+/// Provides numeric operations for the <see cref="bool"/> type, enabling
+/// <c>Tensor&lt;bool&gt;</c> for boolean mask + conditional operations.
+/// Mirrors <see cref="BitOperations"/>'s semantics — <see cref="bool"/> is
+/// the public-API surface (no special wrapper struct needed) while
+/// <see cref="Bit"/> is the Memory&lt;byte&gt;-friendly internal form.
+/// </summary>
+/// <remarks>
+/// <para>Arithmetic semantics for bool follow boolean algebra to match
+/// <see cref="BitOperations"/>: Add = OR, Multiply = AND, Subtract = XOR,
+/// Negate = NOT. Zero is <c>false</c>; One is <c>true</c>.</para>
+/// <para>Required for <see cref="LinearAlgebra.TensorBase{T}"/>'s static
+/// initializer to succeed — the static <c>_numOps = MathHelper.GetNumericOperations&lt;T&gt;()</c>
+/// runs at type init for <c>Tensor&lt;bool&gt;</c>, and would otherwise
+/// throw <c>NotSupportedException</c> the moment any test or consumer
+/// touched <c>Tensor&lt;bool&gt;</c>. That's exactly what
+/// SafetensorsRoundTripTests + TensorEmbeddingLookupTapeTests hit on
+/// net471.</para>
+/// </remarks>
+public class BoolOperations : INumericOperations<bool>
+{
+    private static readonly BoolOperations _instance = new BoolOperations();
+
+    // ---- Scalar arithmetic ----
+    public bool Add(bool a, bool b) => a | b;
+    public bool Subtract(bool a, bool b) => a ^ b;
+    public bool Multiply(bool a, bool b) => a & b;
+    public bool Divide(bool a, bool b) => !b || (a & b);
+    public bool Negate(bool a) => !a;
+    public bool Zero => false;
+    public bool One => true;
+
+    // ---- Math ----
+    public bool Sqrt(bool value) => value;
+    public bool FromDouble(double value) => value != 0.0;
+    public bool FromFloat(float value) => value != 0f;
+    public float ToFloat(bool value) => value ? 1f : 0f;
+    public double ToDouble(bool value) => value ? 1.0 : 0.0;
+    public Half ToHalf(bool value) => value ? (Half)1f : (Half)0f;
+    public bool FromHalf(Half value) => (float)value != 0f;
+    public int ToInt32(bool value) => value ? 1 : 0;
+
+    // ---- Comparison ----
+    public bool GreaterThan(bool a, bool b) => a && !b;
+    public bool LessThan(bool a, bool b) => !a && b;
+    public bool GreaterThanOrEquals(bool a, bool b) => a || !b;
+    public bool LessThanOrEquals(bool a, bool b) => !a || b;
+    public bool Equals(bool a, bool b) => a == b;
+    public int Compare(bool a, bool b) => a.CompareTo(b);
+
+    // ---- Reductions / extrema ----
+    public bool MinValue => false;
+    public bool MaxValue => true;
+    public bool Abs(bool value) => value;
+    public bool Square(bool value) => value;
+    public bool SignOrZero(bool value) => value;
+
+    // ---- Functions that don't have a clean bool semantics ----
+    public bool Exp(bool value) => true;            // e^0=1 (true), e^1≈2.7 (true)
+    public bool Log(bool value) => false;            // log(0) undefined, log(1)=0
+    public bool Power(bool b, bool e) => b & e;
+    public bool Round(bool value) => value;
+    public bool Floor(bool value) => value;
+    public bool Ceiling(bool value) => value;
+    public bool Frac(bool value) => false;
+    public bool Sin(bool value) => false;
+    public bool Cos(bool value) => false;
+
+    // ---- Special-value predicates ----
+    public bool IsNaN(bool value) => false;
+    public bool IsInfinity(bool value) => false;
+
+    // ---- Precision / acceleration ----
+    public int PrecisionBits => 1;
+    public bool SupportsCpuAcceleration => false;
+    public bool SupportsGpuAcceleration => false;
+
+    // ---- IVectorizedOperations<bool> overloads ----
+    public void Add(ReadOnlySpan<bool> x, ReadOnlySpan<bool> y, Span<bool> destination)
+    {
+        for (int i = 0; i < x.Length; i++) destination[i] = x[i] | y[i];
+    }
+    public void Subtract(ReadOnlySpan<bool> x, ReadOnlySpan<bool> y, Span<bool> destination)
+    {
+        for (int i = 0; i < x.Length; i++) destination[i] = x[i] ^ y[i];
+    }
+    public void Multiply(ReadOnlySpan<bool> x, ReadOnlySpan<bool> y, Span<bool> destination)
+    {
+        for (int i = 0; i < x.Length; i++) destination[i] = x[i] & y[i];
+    }
+    public void Divide(ReadOnlySpan<bool> x, ReadOnlySpan<bool> y, Span<bool> destination)
+    {
+        for (int i = 0; i < x.Length; i++) destination[i] = Divide(x[i], y[i]);
+    }
+    public bool Dot(ReadOnlySpan<bool> x, ReadOnlySpan<bool> y) => VectorizedOperationsFallback.Dot(_instance, x, y);
+    public bool Sum(ReadOnlySpan<bool> x) => VectorizedOperationsFallback.Sum(_instance, x);
+    public bool Max(ReadOnlySpan<bool> x) => VectorizedOperationsFallback.Max(_instance, x);
+    public bool Min(ReadOnlySpan<bool> x) => VectorizedOperationsFallback.Min(_instance, x);
+    public void Exp(ReadOnlySpan<bool> x, Span<bool> destination) => destination.Fill(true);
+    public void Log(ReadOnlySpan<bool> x, Span<bool> destination) => destination.Fill(false);
+    public void Tanh(ReadOnlySpan<bool> x, Span<bool> destination) => x.CopyTo(destination);
+    public void Sigmoid(ReadOnlySpan<bool> x, Span<bool> destination) => x.CopyTo(destination);
+    public void Log2(ReadOnlySpan<bool> x, Span<bool> destination) => destination.Fill(false);
+    public void SoftMax(ReadOnlySpan<bool> x, Span<bool> destination) => x.CopyTo(destination);
+    public bool CosineSimilarity(ReadOnlySpan<bool> x, ReadOnlySpan<bool> y) => VectorizedOperationsFallback.CosineSimilarity(_instance, x, y);
+    public void Fill(Span<bool> destination, bool value) => destination.Fill(value);
+    public void MultiplyScalar(ReadOnlySpan<bool> x, bool scalar, Span<bool> destination) => VectorizedOperationsFallback.MultiplyScalar(_instance, x, scalar, destination);
+    public void DivideScalar(ReadOnlySpan<bool> x, bool scalar, Span<bool> destination) => VectorizedOperationsFallback.DivideScalar(_instance, x, scalar, destination);
+    public void AddScalar(ReadOnlySpan<bool> x, bool scalar, Span<bool> destination) => VectorizedOperationsFallback.AddScalar(_instance, x, scalar, destination);
+    public void SubtractScalar(ReadOnlySpan<bool> x, bool scalar, Span<bool> destination) => VectorizedOperationsFallback.SubtractScalar(_instance, x, scalar, destination);
+    public void Sqrt(ReadOnlySpan<bool> x, Span<bool> destination) => x.CopyTo(destination);
+    public void Abs(ReadOnlySpan<bool> x, Span<bool> destination) => x.CopyTo(destination);
+    public void Negate(ReadOnlySpan<bool> x, Span<bool> destination)
+    {
+        for (int i = 0; i < x.Length; i++) destination[i] = !x[i];
+    }
+    public void Clip(ReadOnlySpan<bool> x, bool min, bool max, Span<bool> destination) => VectorizedOperationsFallback.Clip(_instance, x, min, max, destination);
+    public void Pow(ReadOnlySpan<bool> x, bool power, Span<bool> destination) => VectorizedOperationsFallback.Pow(_instance, x, power, destination);
+    public void Copy(ReadOnlySpan<bool> source, Span<bool> destination) => source.CopyTo(destination);
+    public void Floor(ReadOnlySpan<bool> x, Span<bool> destination) => x.CopyTo(destination);
+    public void Ceiling(ReadOnlySpan<bool> x, Span<bool> destination) => x.CopyTo(destination);
+    public void Frac(ReadOnlySpan<bool> x, Span<bool> destination) => destination.Fill(false);
+    public void Sin(ReadOnlySpan<bool> x, Span<bool> destination) => destination.Fill(false);
+    public void Cos(ReadOnlySpan<bool> x, Span<bool> destination) => destination.Fill(false);
+    public void MultiplyAdd(ReadOnlySpan<bool> x, ReadOnlySpan<bool> y, bool scalar, Span<bool> destination) => VectorizedOperationsFallback.MultiplyAdd(_instance, x, y, scalar, destination);
+    public void ToFloatSpan(ReadOnlySpan<bool> source, Span<float> destination) => VectorizedOperationsFallback.ToFloatSpan(_instance, source, destination);
+    public void FromFloatSpan(ReadOnlySpan<float> source, Span<bool> destination) => VectorizedOperationsFallback.FromFloatSpan(_instance, source, destination);
+    public void ToHalfSpan(ReadOnlySpan<bool> source, Span<Half> destination) => VectorizedOperationsFallback.ToHalfSpan(_instance, source, destination);
+    public void FromHalfSpan(ReadOnlySpan<Half> source, Span<bool> destination) => VectorizedOperationsFallback.FromHalfSpan(_instance, source, destination);
+    public void LeakyReLU(ReadOnlySpan<bool> x, bool alpha, Span<bool> destination) => x.CopyTo(destination);
+    public void GELU(ReadOnlySpan<bool> x, Span<bool> destination) => x.CopyTo(destination);
+    public void Mish(ReadOnlySpan<bool> x, Span<bool> destination) => x.CopyTo(destination);
+    public void Swish(ReadOnlySpan<bool> x, Span<bool> destination) => x.CopyTo(destination);
+    public void ELU(ReadOnlySpan<bool> x, bool alpha, Span<bool> destination) => x.CopyTo(destination);
+    public void ReLU(ReadOnlySpan<bool> x, Span<bool> destination) => x.CopyTo(destination);
+}

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightRegistryStreamingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightRegistryStreamingTests.cs
@@ -1399,6 +1399,59 @@ public class WeightRegistryStreamingTests : IDisposable
     }
 
     [Fact]
+    public void UnregisterWeight_AllocatedButNotRegistered_ReleasesReservation()
+    {
+        // Public cancellation path for the "AllocateRegistered then bail
+        // before RegisterWeight" case. StreamingReservedBytes is
+        // internal so external callers can't release it directly;
+        // UnregisterWeight is the supported escape hatch.
+        WeightRegistry.Reset();
+        WeightRegistry.Configure(new GpuOffloadOptions
+        {
+            StreamingPoolMaxResidentBytes = 64L * 1024,
+            StreamingBackingStorePath = _backingDir,
+        });
+
+        var t = WeightRegistry.AllocateRegistered<float>(new[] { 128, 32 }); // 16 KB
+        long reservedBefore = WeightRegistry.StreamingPool.ReservedBytes;
+        Assert.True(reservedBefore >= 16L * 1024);
+
+        // Caller decides not to register (e.g. exception during weight
+        // initialization, lazy layer torn down before forward, etc.)
+        WeightRegistry.UnregisterWeight(t);
+
+        long reservedAfter = WeightRegistry.StreamingPool.ReservedBytes;
+        Assert.Equal(reservedBefore - 16L * 1024, reservedAfter);
+    }
+
+    [Fact]
+    public void UnregisterWeight_RegisteredTensor_DoesNotDoubleReleaseReservation()
+    {
+        // Sanity: the normal path (Allocate → Register → Unregister)
+        // releases the reservation in RegisterWeight (clearing
+        // StreamingReservedBytes). Unregister must not then try to
+        // release zero bytes from the pool. Under the floor-at-zero
+        // contract this would be harmless, but the more surgical check
+        // is that the tensor's StreamingReservedBytes is observed at 0
+        // after Register and stays at 0 after Unregister.
+        WeightRegistry.Reset();
+        WeightRegistry.Configure(new GpuOffloadOptions
+        {
+            StreamingPoolMaxResidentBytes = 64L * 1024,
+            StreamingBackingStorePath = _backingDir,
+        });
+
+        var t = WeightRegistry.AllocateRegistered<float>(new[] { 128, 32 });
+        WeightRegistry.RegisterWeight(t);
+
+        Assert.Equal(0L, t.StreamingReservedBytes);
+        long reservedBeforeUnregister = WeightRegistry.StreamingPool.ReservedBytes;
+        WeightRegistry.UnregisterWeight(t);
+        long reservedAfterUnregister = WeightRegistry.StreamingPool.ReservedBytes;
+        Assert.Equal(reservedBeforeUnregister, reservedAfterUnregister);
+    }
+
+    [Fact]
     public void ReleaseReservation_MoreThanReserved_FloorsAtZero()
     {
         // Defensive: double-release must not turn into negative

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightRegistryStreamingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightRegistryStreamingTests.cs
@@ -1552,6 +1552,54 @@ public class WeightRegistryStreamingTests : IDisposable
     }
 
     [Fact]
+    public void Configure_WithOutstandingReservations_ThrowsCleanly()
+    {
+        // Mid-flight Configure-swap protection: if AllocateStreaming has
+        // recorded a reservation but RegisterWeight/UnregisterWeight
+        // hasn't run yet, swapping the pool would orphan that
+        // reservation's accounting on the new pool. Configure must
+        // reject this state with a clear error so callers know to
+        // complete or abandon the in-flight allocation first.
+        WeightRegistry.Reset();
+        WeightRegistry.Configure(new GpuOffloadOptions
+        {
+            StreamingPoolMaxResidentBytes = 64L * 1024,
+            StreamingBackingStorePath = _backingDir,
+        });
+
+        // Allocate but don't register: leaves an outstanding reservation
+        // on the current pool's _reservedBytes ledger.
+        var t = WeightRegistry.AllocateStreaming<float>(new[] { 128, 32 });
+        Assert.True(WeightRegistry.StreamingPool.ReservedBytes > 0);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            WeightRegistry.Configure(new GpuOffloadOptions
+            {
+                StreamingPoolMaxResidentBytes = 128L * 1024,
+                StreamingBackingStorePath = _backingDir,
+            }));
+        Assert.Contains("outstanding reservations", ex.Message, StringComparison.OrdinalIgnoreCase);
+
+        // Cleanup: cancel the reservation so subsequent tests start clean.
+        WeightRegistry.UnregisterWeight(t);
+    }
+
+    [Fact]
+    public void AllocateStreaming_OverflowingProductBeforeIntMaxCheck_ThrowsClearError()
+    {
+        // Regression: an earlier revision did `checked(elements * dim)`
+        // inside the loop and only compared against int.MaxValue
+        // afterwards. A pathologically large shape like
+        // [int.MaxValue, int.MaxValue, 3] would trip OverflowException
+        // first, masking the documented chunking-hint NotSupportedException.
+        // The fix moves the bound check INSIDE the loop so the contract
+        // surfaces correctly regardless of how large the shape is.
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            WeightRegistry.AllocateStreaming<float>(new[] { int.MaxValue, int.MaxValue, 3 }));
+        Assert.Contains("Chunk", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void ReleaseReservation_MoreThanReserved_FloorsAtZero()
     {
         // Defensive: double-release must not turn into negative

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightRegistryStreamingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightRegistryStreamingTests.cs
@@ -1134,14 +1134,14 @@ public class WeightRegistryStreamingTests : IDisposable
         finally { pool.Dispose(); }
     }
 
-    // -------- AllocateRegistered<T> + EvictUntilFreeBytes (#1222 follow-on) --------
+    // -------- AllocateStreaming<T> + EvictUntilFreeBytes (#1222 follow-on) --------
 
     [Fact]
-    public void AllocateRegistered_AfterReset_StillReturnsStreamingLifetime()
+    public void AllocateStreaming_AfterReset_StillReturnsStreamingLifetime()
     {
         // Reset() re-initializes _options to a fresh default
         // GpuOffloadOptions (it's never null — the field-initializer
-        // and Reset both assign new instances), so AllocateRegistered's
+        // and Reset both assign new instances), so AllocateStreaming's
         // contract is unconditional: it always returns a Streaming-
         // lifetime tensor with materialized storage. There is no
         // "streaming not configured" fallback to a Default-lifetime
@@ -1149,19 +1149,19 @@ public class WeightRegistryStreamingTests : IDisposable
         // "not configured".
         WeightRegistry.Reset();
 
-        var t = WeightRegistry.AllocateRegistered<float>(new[] { 16, 16 });
+        var t = WeightRegistry.AllocateStreaming<float>(new[] { 16, 16 });
 
         Assert.Equal(WeightLifetime.Streaming, t.Lifetime);
         Assert.Equal(16 * 16, t.Length);
         Assert.True(t.DataVector.Length > 0,
-            "AllocateRegistered should leave storage materialized for caller "
+            "AllocateStreaming should leave storage materialized for caller "
             + "to initialize before RegisterWeight.");
     }
 
     [Fact]
-    public void AllocateRegistered_WithStreamingConfigured_ReturnsStreamingLifetimeTensor()
+    public void AllocateStreaming_WithStreamingConfigured_ReturnsStreamingLifetimeTensor()
     {
-        var t = WeightRegistry.AllocateRegistered<float>(new[] { 8, 8 });
+        var t = WeightRegistry.AllocateStreaming<float>(new[] { 8, 8 });
 
         // Streaming-configured path: lifetime is set, storage is
         // materialized (caller has yet to RegisterWeight). The contract
@@ -1169,14 +1169,14 @@ public class WeightRegistryStreamingTests : IDisposable
         Assert.Equal(WeightLifetime.Streaming, t.Lifetime);
         Assert.Equal(64, t.Length);
         Assert.True(t.DataVector.Length > 0,
-            "AllocateRegistered should return a materialized tensor so callers "
+            "AllocateStreaming should return a materialized tensor so callers "
             + "can initialize weights into it before calling RegisterWeight.");
     }
 
     [Fact]
-    public void AllocateRegistered_LongSequence_BoundsPeakResidency()
+    public void AllocateStreaming_LongSequence_BoundsPeakResidency()
     {
-        // The whole point of AllocateRegistered: a long sequence of
+        // The whole point of AllocateStreaming: a long sequence of
         // large allocations + registers should stay bounded by the pool
         // budget instead of peaking at the cumulative weight size.
         // Simulate PaLM-E's MHA-layer pattern: 4 weights per "layer",
@@ -1186,7 +1186,7 @@ public class WeightRegistryStreamingTests : IDisposable
         // (everything alive); with it, resident should plateau near
         // the 256 KB budget.
         //
-        // Also samples ResidentBytes BETWEEN AllocateRegistered and
+        // Also samples ResidentBytes BETWEEN AllocateStreaming and
         // RegisterWeight to prove eviction-on-allocate is the load-
         // bearing step — a regression that stops calling ReserveBytes
         // before allocation would still pass the post-Register peak
@@ -1208,7 +1208,7 @@ public class WeightRegistryStreamingTests : IDisposable
             for (int matrix = 0; matrix < 4; matrix++)
             {
                 // 64 KB per matrix at fp32 = 16384 elements = 128×128.
-                var t = WeightRegistry.AllocateRegistered<float>(new[] { 128, 128 });
+                var t = WeightRegistry.AllocateStreaming<float>(new[] { 128, 128 });
 
                 // Sample BEFORE RegisterWeight: this is what a regression
                 // that stops evicting on Allocate would inflate. The
@@ -1238,7 +1238,7 @@ public class WeightRegistryStreamingTests : IDisposable
         // small slop for the most recent allocation that triggered
         // eviction. Peak shouldn't approach the cumulative 4 MB total.
         Assert.True(peakResidentBytesPostRegister <= 384L * 1024,
-            $"AllocateRegistered + RegisterWeight should bound peak resident "
+            $"AllocateStreaming + RegisterWeight should bound peak resident "
             + $"to ~budget (256 KB), but peak was {peakResidentBytesPostRegister} bytes "
             + $"({peakResidentBytesPostRegister / 1024.0:F1} KB). If this exceeds 384 KB "
             + "(budget + ~50% slop for the last register), eviction-on-allocate "
@@ -1253,23 +1253,95 @@ public class WeightRegistryStreamingTests : IDisposable
         // (full budget) as a defensive ceiling because the very first
         // few iterations may not have evicted yet.
         Assert.True(peakResidentBytesPostAllocate <= 256L * 1024,
-            $"AllocateRegistered must page out enough LRU entries to fit the "
+            $"AllocateStreaming must page out enough LRU entries to fit the "
             + $"reservation, leaving resident bytes <= budget (256 KB). Peak post-"
             + $"Allocate resident was {peakResidentBytesPostAllocate} bytes "
             + $"({peakResidentBytesPostAllocate / 1024.0:F1} KB). If this exceeds "
-            + "256 KB, AllocateRegistered isn't running its eviction-on-allocate "
+            + "256 KB, AllocateStreaming isn't running its eviction-on-allocate "
             + "step before returning the tensor — a regression #1222 was meant to "
             + "prevent.");
     }
 
     [Fact]
-    public void AllocateRegistered_UnsupportedType_ThrowsBeforeChurningPool()
+    public void AllocateStreaming_LongSequence_BoundsManagedLiveSet()
     {
-        // Type gate: AllocateRegistered<decimal> must reject upfront so
+        // Direct GC-heap measurement: ResidentBytes only counts pool-
+        // registered bytes, so a regression that stopped pre-evicting
+        // on Allocate could keep ResidentBytes flat while the LIVE
+        // managed heap (still-rooted byte[] buffers awaiting registration)
+        // grows linearly across the layer sequence. This test forces a
+        // full GC after each layer to collect dropped byte[]s, then
+        // measures the actual live working set against the pool budget.
+        //
+        // Methodology: force a full GC at the end of each layer (when
+        // the previous iteration's tensor has been registered and its
+        // GC byte[] has been dropped via DropStorageForStreaming). After
+        // the collection, GetTotalMemory reports only LIVE references
+        // — not uncollected garbage. The peak live-set is then a clean
+        // proxy for "how big can the heap get under sustained
+        // allocation".
+        WeightRegistry.Reset();
+        WeightRegistry.Configure(new GpuOffloadOptions
+        {
+            StreamingPoolMaxResidentBytes = 256L * 1024,
+            StreamingBackingStorePath = _backingDir,
+        });
+
+        // Baseline: drain pre-existing test allocator state.
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+        long heapBaseline = GC.GetTotalMemory(forceFullCollection: true);
+
+        long peakLiveSetDelta = 0;
+        for (int layer = 0; layer < 16; layer++)
+        {
+            for (int matrix = 0; matrix < 4; matrix++)
+            {
+                var t = WeightRegistry.AllocateStreaming<float>(new[] { 128, 128 });
+                var span = t.DataVector.AsWritableSpan();
+                for (int i = 0; i < span.Length; i++) span[i] = (float)((layer * 4 + matrix + i) % 7);
+                WeightRegistry.RegisterWeight(t);
+            }
+            // After each layer (4 weights), force a full collection so
+            // dropped byte[]s from the just-finished iteration are
+            // collected. Then measure: the heap size now reflects only
+            // LIVE state (pool's resident byte[]s + LRU bookkeeping +
+            // backing files' file handles) — a regression that left
+            // uncollected weights on the heap would still grow this
+            // measurement linearly because their references would still
+            // exist somewhere.
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+            long heapLive = GC.GetTotalMemory(forceFullCollection: true);
+            long delta = heapLive - heapBaseline;
+            if (delta > peakLiveSetDelta) peakLiveSetDelta = delta;
+        }
+
+        // Cumulative weight sum is 4 MB. Without AllocateStreaming the
+        // managed live-set would grow ~4 MB. With AllocateStreaming the
+        // pool drops weights to disk so live-set plateaus at ~budget
+        // (256 KB) plus per-iteration overhead. Generous ceiling: 4×
+        // budget = 1 MB, still well below the 4 MB regression case.
+        Assert.True(peakLiveSetDelta < 1024L * 1024,
+            $"Managed live-set delta should plateau near the pool budget "
+            + $"(256 KB) since AllocateStreaming pages out competing weights "
+            + $"before each new GC byte[] lands, but peak live-set was "
+            + $"{peakLiveSetDelta} bytes ({peakLiveSetDelta / 1024.0:F1} KB). "
+            + "If this exceeds 1 MB after a forced full GC, "
+            + "AllocateStreaming isn't pacing the managed heap against the "
+            + "pool budget — the OOM mode #1222 was meant to prevent.");
+    }
+
+    [Fact]
+    public void AllocateStreaming_UnsupportedType_ThrowsBeforeChurningPool()
+    {
+        // Type gate: AllocateStreaming<decimal> must reject upfront so
         // the pool's eviction loop doesn't run on behalf of a tensor
         // RegisterWeight would later refuse to serialize. Pre-fill the
         // pool to budget; assert resident doesn't change after the
-        // failed AllocateRegistered call.
+        // failed AllocateStreaming call.
         WeightRegistry.Reset();
         WeightRegistry.Configure(new GpuOffloadOptions
         {
@@ -1280,13 +1352,13 @@ public class WeightRegistryStreamingTests : IDisposable
         // Pre-fill the pool with 4 KB of registered weights.
         for (int i = 0; i < 2; i++)
         {
-            var t = WeightRegistry.AllocateRegistered<float>(new[] { 512 }); // 2 KB
+            var t = WeightRegistry.AllocateStreaming<float>(new[] { 512 }); // 2 KB
             WeightRegistry.RegisterWeight(t);
         }
         long residentBefore = WeightRegistry.GetStreamingReport().ResidentBytes;
 
         var ex = Assert.Throws<NotSupportedException>(() =>
-            WeightRegistry.AllocateRegistered<decimal>(new[] { 16 }));
+            WeightRegistry.AllocateStreaming<decimal>(new[] { 16 }));
         Assert.Contains("not supported", ex.Message, StringComparison.OrdinalIgnoreCase);
 
         long residentAfter = WeightRegistry.GetStreamingReport().ResidentBytes;
@@ -1294,10 +1366,10 @@ public class WeightRegistryStreamingTests : IDisposable
     }
 
     [Fact]
-    public void AllocateRegistered_ConcurrentCallers_RespectBudget()
+    public void AllocateStreaming_ConcurrentCallers_RespectBudget()
     {
         // Race regression: without the reservation mechanism, two
-        // concurrent AllocateRegistered calls would both pass the same
+        // concurrent AllocateStreaming calls would both pass the same
         // headroom check and overshoot the budget by the second
         // tensor's byte count. With ReserveBytes counted against the
         // budget, the second caller's eviction sees the first caller's
@@ -1314,38 +1386,61 @@ public class WeightRegistryStreamingTests : IDisposable
         // evict to make room.
         for (int i = 0; i < 4; i++)
         {
-            var t = WeightRegistry.AllocateRegistered<float>(new[] { 128, 32 }); // 16 KB
+            var t = WeightRegistry.AllocateStreaming<float>(new[] { 128, 32 }); // 16 KB
             WeightRegistry.RegisterWeight(t);
         }
         Assert.True(WeightRegistry.GetStreamingReport().ResidentBytes <= 64L * 1024);
 
-        // Race two AllocateRegistered calls. Each requests 16 KB. With
+        // Race two AllocateStreaming calls. Each requests 16 KB. With
         // a 64 KB budget already at 64 KB resident, both must trigger
         // eviction; the reservation accounting prevents them seeing the
         // same headroom.
-        var allocs = new Tensor<float>[2];
-        var threads = new System.Threading.Thread[2];
-        for (int i = 0; i < 2; i++)
+        //
+        // Synchronize the two threads on a Barrier BEFORE the actual
+        // AllocateStreaming call so they enter the reservation path
+        // concurrently — without this, one thread can complete the
+        // entire reserve+allocate path before the other ever starts,
+        // making the race the test claims to cover schedule-dependent
+        // and easy to miss in CI. The Barrier forces real overlap on
+        // the reservation gate.
+        const int threadCount = 2;
+        var allocs = new Tensor<float>[threadCount];
+        var threads = new System.Threading.Thread[threadCount];
+        var barrier = new System.Threading.Barrier(threadCount);
+        var exceptions = new Exception?[threadCount];
+        for (int i = 0; i < threadCount; i++)
         {
             int idx = i;
             threads[i] = new System.Threading.Thread(() =>
             {
-                allocs[idx] = WeightRegistry.AllocateRegistered<float>(new[] { 128, 32 });
+                try
+                {
+                    barrier.SignalAndWait();
+                    allocs[idx] = WeightRegistry.AllocateStreaming<float>(new[] { 128, 32 });
+                }
+                catch (Exception ex)
+                {
+                    exceptions[idx] = ex;
+                }
             });
         }
         foreach (var th in threads) th.Start();
         foreach (var th in threads) th.Join();
+        for (int i = 0; i < threadCount; i++)
+            if (exceptions[i] is not null)
+                throw new Xunit.Sdk.XunitException(
+                    $"Thread {i} threw during concurrent AllocateStreaming: {exceptions[i]}");
 
         long resident = WeightRegistry.GetStreamingReport().ResidentBytes;
         long reserved = WeightRegistry.StreamingPool.ReservedBytes;
         // resident already paged out to make room for the reservations;
-        // reserved should reflect the sum of both AllocateRegistered
+        // reserved should reflect the sum of both AllocateStreaming
         // requests (32 KB). Total resident + reserved must respect the
         // budget within a small slop (the budget is best-effort under
         // concurrent eviction since the LRU list is mutated under-lock
         // but the GC heap allocations happen post-lock).
         Assert.True(resident + reserved <= 64L * 1024 + 16L * 1024,
-            $"After concurrent AllocateRegistered, resident({resident}) + reserved({reserved}) "
+            $"After concurrent AllocateStreaming, resident({resident}) + reserved({reserved}) "
             + $"must respect budget ({64 * 1024}) within slop. Sum = {resident + reserved}.");
 
         // Now register both — releases reservations, commits residency.
@@ -1360,11 +1455,16 @@ public class WeightRegistryStreamingTests : IDisposable
     }
 
     [Fact]
-    public void ReserveBytes_DirectCall_BlocksConcurrentAllocators()
+    public void ReserveBytes_AccumulatesAcrossSequentialCalls_TriggersEvictionWhenBudgetFull()
     {
-        // Direct StreamingTensorPool test: ReserveBytes pages LRU
-        // entries to make room AND records the reservation so a
-        // subsequent ReserveBytes call sees it.
+        // Direct StreamingTensorPool test: ReserveBytes accumulates
+        // across sequential calls — a second reserve sees the first's
+        // _reservedBytes in the free-bytes calculation, so it must
+        // page LRU entries to make additional room. This is the
+        // single-threaded sibling of the concurrent-Allocators test
+        // above; together they validate the budget invariant under
+        // both scheduling models. Sequential cumulative accounting +
+        // concurrent overlap == correct reservation bookkeeping.
         var pool = new StreamingTensorPool(new GpuOffloadOptions
         {
             StreamingPoolMaxResidentBytes = 4096L,
@@ -1401,7 +1501,7 @@ public class WeightRegistryStreamingTests : IDisposable
     [Fact]
     public void UnregisterWeight_AllocatedButNotRegistered_ReleasesReservation()
     {
-        // Public cancellation path for the "AllocateRegistered then bail
+        // Public cancellation path for the "AllocateStreaming then bail
         // before RegisterWeight" case. StreamingReservedBytes is
         // internal so external callers can't release it directly;
         // UnregisterWeight is the supported escape hatch.
@@ -1412,7 +1512,7 @@ public class WeightRegistryStreamingTests : IDisposable
             StreamingBackingStorePath = _backingDir,
         });
 
-        var t = WeightRegistry.AllocateRegistered<float>(new[] { 128, 32 }); // 16 KB
+        var t = WeightRegistry.AllocateStreaming<float>(new[] { 128, 32 }); // 16 KB
         long reservedBefore = WeightRegistry.StreamingPool.ReservedBytes;
         Assert.True(reservedBefore >= 16L * 1024);
 
@@ -1441,7 +1541,7 @@ public class WeightRegistryStreamingTests : IDisposable
             StreamingBackingStorePath = _backingDir,
         });
 
-        var t = WeightRegistry.AllocateRegistered<float>(new[] { 128, 32 });
+        var t = WeightRegistry.AllocateStreaming<float>(new[] { 128, 32 });
         WeightRegistry.RegisterWeight(t);
 
         Assert.Equal(0L, t.StreamingReservedBytes);
@@ -1476,28 +1576,28 @@ public class WeightRegistryStreamingTests : IDisposable
     }
 
     [Fact]
-    public void AllocateRegistered_OversizeShape_ThrowsClearError()
+    public void AllocateStreaming_OversizeShape_ThrowsClearError()
     {
         // Per-tensor bytecount is bounded by int.MaxValue (the byte[]
         // limit). Asking for 2.5 GB of fp32 (~625M elements) should
         // throw NotSupportedException with a chunking hint, not OOM
         // somewhere deep in the pool.
         var ex = Assert.Throws<NotSupportedException>(() =>
-            WeightRegistry.AllocateRegistered<float>(new[] { 1_000_000_000 }));
+            WeightRegistry.AllocateStreaming<float>(new[] { 1_000_000_000 }));
         Assert.Contains("Chunk", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
-    public void AllocateRegistered_NegativeShape_Throws()
+    public void AllocateStreaming_NegativeShape_Throws()
     {
         Assert.Throws<ArgumentException>(() =>
-            WeightRegistry.AllocateRegistered<float>(new[] { -1, 16 }));
+            WeightRegistry.AllocateStreaming<float>(new[] { -1, 16 }));
     }
 
     [Fact]
     public void EvictUntilFreeBytes_DirectCall_PagesLruEntries()
     {
-        // Direct StreamingTensorPool test — no AllocateRegistered
+        // Direct StreamingTensorPool test — no AllocateStreaming
         // wrapper. Register some entries, then ask for headroom equal
         // to half the budget and verify resident drops accordingly.
         var pool = new StreamingTensorPool(new GpuOffloadOptions
@@ -1527,12 +1627,14 @@ public class WeightRegistryStreamingTests : IDisposable
     }
 
     [Fact]
-    public void EvictUntilFreeBytes_RequestExceedsBudget_BestEffortReturnsFalse()
+    public void EvictUntilFreeBytes_RequestExceedsBudget_ShortCircuitsWithoutFlushingLru()
     {
-        // Asking for more headroom than the budget itself should
-        // empty the LRU and return false — caller's allocation will
-        // push the pool past budget, but EvictIfOverBudget on the
-        // next register catches up.
+        // Asking for more headroom than the entire budget can never
+        // succeed even with a full LRU drain, so EvictUntilFreeBytes
+        // short-circuits: returns false immediately without touching
+        // the LRU. Without this, an oversize request would flush every
+        // warm weight to disk for nothing, forcing a round of
+        // foreground rehydrates afterward.
         var pool = new StreamingTensorPool(new GpuOffloadOptions
         {
             StreamingPoolMaxResidentBytes = 4096L,
@@ -1541,14 +1643,16 @@ public class WeightRegistryStreamingTests : IDisposable
         try
         {
             for (int i = 0; i < 4; i++) pool.Register(new byte[1024]);
+            long residentBefore = pool.ResidentBytes;
+            Assert.Equal(4096L, residentBefore);
 
-            // Ask for 8 KB headroom — exceeds the 4 KB budget. Even
-            // after evicting all 4 entries, can't satisfy → false.
+            // Ask for 8 KB headroom — exceeds the 4 KB budget. Pool
+            // bails immediately without evicting; resident is unchanged.
             bool secured = pool.EvictUntilFreeBytes(8192L);
             Assert.False(secured,
-                "EvictUntilFreeBytes(8192) > budget(4096) should empty the "
-                + "LRU and return false (best-effort signal).");
-            Assert.Equal(0L, pool.ResidentBytes);
+                "EvictUntilFreeBytes(8192) > budget(4096) should return false "
+                + "without touching the LRU.");
+            Assert.Equal(residentBefore, pool.ResidentBytes);
         }
         finally { pool.Dispose(); }
     }

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightRegistryStreamingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightRegistryStreamingTests.cs
@@ -1139,12 +1139,14 @@ public class WeightRegistryStreamingTests : IDisposable
     [Fact]
     public void AllocateRegistered_AfterReset_StillReturnsStreamingLifetime()
     {
-        // Reset() leaves _options at a default GpuOffloadOptions (not
-        // null), so AllocateRegistered's contract is preserved across
-        // Reset: it always returns a Streaming-lifetime tensor with
-        // materialized storage. The "fall back to Default Tensor" path
-        // exists only for the brief window before any Configure call
-        // at process startup — not normally testable from here.
+        // Reset() re-initializes _options to a fresh default
+        // GpuOffloadOptions (it's never null — the field-initializer
+        // and Reset both assign new instances), so AllocateRegistered's
+        // contract is unconditional: it always returns a Streaming-
+        // lifetime tensor with materialized storage. There is no
+        // "streaming not configured" fallback to a Default-lifetime
+        // tensor because there is no state in which the registry is
+        // "not configured".
         WeightRegistry.Reset();
 
         var t = WeightRegistry.AllocateRegistered<float>(new[] { 16, 16 });
@@ -1183,6 +1185,15 @@ public class WeightRegistryStreamingTests : IDisposable
         // Without eviction-on-allocate, peak resident would be 4 MB
         // (everything alive); with it, resident should plateau near
         // the 256 KB budget.
+        //
+        // Also samples ResidentBytes BETWEEN AllocateRegistered and
+        // RegisterWeight to prove eviction-on-allocate is the load-
+        // bearing step — a regression that stops calling ReserveBytes
+        // before allocation would still pass the post-Register peak
+        // check (because Register's own EvictIfOverBudget cleans up)
+        // but would fail the post-Allocate peak check (the GC byte[]
+        // for the new weight would have piled up on top of all 4
+        // previous layers' resident bytes).
         WeightRegistry.Reset();
         WeightRegistry.Configure(new GpuOffloadOptions
         {
@@ -1190,13 +1201,25 @@ public class WeightRegistryStreamingTests : IDisposable
             StreamingBackingStorePath = _backingDir,
         });
 
-        long peakResidentBytes = 0;
+        long peakResidentBytesPostRegister = 0;
+        long peakResidentBytesPostAllocate = 0;
         for (int layer = 0; layer < 16; layer++)
         {
             for (int matrix = 0; matrix < 4; matrix++)
             {
                 // 64 KB per matrix at fp32 = 16384 elements = 128×128.
                 var t = WeightRegistry.AllocateRegistered<float>(new[] { 128, 128 });
+
+                // Sample BEFORE RegisterWeight: this is what a regression
+                // that stops evicting on Allocate would inflate. The
+                // pool's resident bytes here exclude `t`'s storage (it
+                // hasn't been registered yet) — so this number is purely
+                // "did Allocate evict the previously-registered LRU
+                // entries".
+                long residentAfterAllocate = WeightRegistry.GetStreamingReport().ResidentBytes;
+                if (residentAfterAllocate > peakResidentBytesPostAllocate)
+                    peakResidentBytesPostAllocate = residentAfterAllocate;
+
                 // Initialize (write into materialized storage). DataVector
                 // is the underlying Vector; AsWritableSpan exposes the
                 // writable mutable view that AsSpan (read-only) does not.
@@ -1205,21 +1228,198 @@ public class WeightRegistryStreamingTests : IDisposable
                 // Register: serializes + drops + commits to pool.
                 WeightRegistry.RegisterWeight(t);
 
-                long resident = WeightRegistry.GetStreamingReport().ResidentBytes;
-                if (resident > peakResidentBytes) peakResidentBytes = resident;
+                long residentAfterRegister = WeightRegistry.GetStreamingReport().ResidentBytes;
+                if (residentAfterRegister > peakResidentBytesPostRegister)
+                    peakResidentBytesPostRegister = residentAfterRegister;
             }
         }
 
         // Pool resident should be bounded by budget (256 KB) plus a
         // small slop for the most recent allocation that triggered
         // eviction. Peak shouldn't approach the cumulative 4 MB total.
-        Assert.True(peakResidentBytes <= 384L * 1024,
+        Assert.True(peakResidentBytesPostRegister <= 384L * 1024,
             $"AllocateRegistered + RegisterWeight should bound peak resident "
-            + $"to ~budget (256 KB), but peak was {peakResidentBytes} bytes "
-            + $"({peakResidentBytes / 1024.0:F1} KB). If this exceeds 384 KB "
+            + $"to ~budget (256 KB), but peak was {peakResidentBytesPostRegister} bytes "
+            + $"({peakResidentBytesPostRegister / 1024.0:F1} KB). If this exceeds 384 KB "
             + "(budget + ~50% slop for the last register), eviction-on-allocate "
-            + "isn't running, or EvictUntilFreeBytes isn't getting the "
+            + "isn't running, or ReserveBytes isn't getting the "
             + "caller-requested headroom.");
+
+        // Tighter bound on the post-Allocate sample: the pool can't
+        // possibly hold more than budget here (Allocate's reservation +
+        // eviction must have made room before returning). The 64 KB
+        // weight that Allocate just promised is reserved, not resident,
+        // so resident <= budget - 64 KB = 192 KB. We allow 256 KB
+        // (full budget) as a defensive ceiling because the very first
+        // few iterations may not have evicted yet.
+        Assert.True(peakResidentBytesPostAllocate <= 256L * 1024,
+            $"AllocateRegistered must page out enough LRU entries to fit the "
+            + $"reservation, leaving resident bytes <= budget (256 KB). Peak post-"
+            + $"Allocate resident was {peakResidentBytesPostAllocate} bytes "
+            + $"({peakResidentBytesPostAllocate / 1024.0:F1} KB). If this exceeds "
+            + "256 KB, AllocateRegistered isn't running its eviction-on-allocate "
+            + "step before returning the tensor — a regression #1222 was meant to "
+            + "prevent.");
+    }
+
+    [Fact]
+    public void AllocateRegistered_UnsupportedType_ThrowsBeforeChurningPool()
+    {
+        // Type gate: AllocateRegistered<decimal> must reject upfront so
+        // the pool's eviction loop doesn't run on behalf of a tensor
+        // RegisterWeight would later refuse to serialize. Pre-fill the
+        // pool to budget; assert resident doesn't change after the
+        // failed AllocateRegistered call.
+        WeightRegistry.Reset();
+        WeightRegistry.Configure(new GpuOffloadOptions
+        {
+            StreamingPoolMaxResidentBytes = 8L * 1024,
+            StreamingBackingStorePath = _backingDir,
+        });
+
+        // Pre-fill the pool with 4 KB of registered weights.
+        for (int i = 0; i < 2; i++)
+        {
+            var t = WeightRegistry.AllocateRegistered<float>(new[] { 512 }); // 2 KB
+            WeightRegistry.RegisterWeight(t);
+        }
+        long residentBefore = WeightRegistry.GetStreamingReport().ResidentBytes;
+
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            WeightRegistry.AllocateRegistered<decimal>(new[] { 16 }));
+        Assert.Contains("not supported", ex.Message, StringComparison.OrdinalIgnoreCase);
+
+        long residentAfter = WeightRegistry.GetStreamingReport().ResidentBytes;
+        Assert.Equal(residentBefore, residentAfter);
+    }
+
+    [Fact]
+    public void AllocateRegistered_ConcurrentCallers_RespectBudget()
+    {
+        // Race regression: without the reservation mechanism, two
+        // concurrent AllocateRegistered calls would both pass the same
+        // headroom check and overshoot the budget by the second
+        // tensor's byte count. With ReserveBytes counted against the
+        // budget, the second caller's eviction sees the first caller's
+        // reservation and pages out an additional LRU entry to make
+        // room. Final resident + reserved must respect the budget.
+        WeightRegistry.Reset();
+        WeightRegistry.Configure(new GpuOffloadOptions
+        {
+            StreamingPoolMaxResidentBytes = 64L * 1024,
+            StreamingBackingStorePath = _backingDir,
+        });
+
+        // Pre-fill pool to budget so the parallel Allocates must each
+        // evict to make room.
+        for (int i = 0; i < 4; i++)
+        {
+            var t = WeightRegistry.AllocateRegistered<float>(new[] { 128, 32 }); // 16 KB
+            WeightRegistry.RegisterWeight(t);
+        }
+        Assert.True(WeightRegistry.GetStreamingReport().ResidentBytes <= 64L * 1024);
+
+        // Race two AllocateRegistered calls. Each requests 16 KB. With
+        // a 64 KB budget already at 64 KB resident, both must trigger
+        // eviction; the reservation accounting prevents them seeing the
+        // same headroom.
+        var allocs = new Tensor<float>[2];
+        var threads = new System.Threading.Thread[2];
+        for (int i = 0; i < 2; i++)
+        {
+            int idx = i;
+            threads[i] = new System.Threading.Thread(() =>
+            {
+                allocs[idx] = WeightRegistry.AllocateRegistered<float>(new[] { 128, 32 });
+            });
+        }
+        foreach (var th in threads) th.Start();
+        foreach (var th in threads) th.Join();
+
+        long resident = WeightRegistry.GetStreamingReport().ResidentBytes;
+        long reserved = WeightRegistry.StreamingPool.ReservedBytes;
+        // resident already paged out to make room for the reservations;
+        // reserved should reflect the sum of both AllocateRegistered
+        // requests (32 KB). Total resident + reserved must respect the
+        // budget within a small slop (the budget is best-effort under
+        // concurrent eviction since the LRU list is mutated under-lock
+        // but the GC heap allocations happen post-lock).
+        Assert.True(resident + reserved <= 64L * 1024 + 16L * 1024,
+            $"After concurrent AllocateRegistered, resident({resident}) + reserved({reserved}) "
+            + $"must respect budget ({64 * 1024}) within slop. Sum = {resident + reserved}.");
+
+        // Now register both — releases reservations, commits residency.
+        for (int i = 0; i < 2; i++)
+        {
+            var span = allocs[i].DataVector.AsWritableSpan();
+            for (int k = 0; k < span.Length; k++) span[k] = (float)i;
+            WeightRegistry.RegisterWeight(allocs[i]);
+        }
+        // After both Registers, ReservedBytes must be back to 0.
+        Assert.Equal(0L, WeightRegistry.StreamingPool.ReservedBytes);
+    }
+
+    [Fact]
+    public void ReserveBytes_DirectCall_BlocksConcurrentAllocators()
+    {
+        // Direct StreamingTensorPool test: ReserveBytes pages LRU
+        // entries to make room AND records the reservation so a
+        // subsequent ReserveBytes call sees it.
+        var pool = new StreamingTensorPool(new GpuOffloadOptions
+        {
+            StreamingPoolMaxResidentBytes = 4096L,
+            StreamingBackingStorePath = _backingDir,
+        });
+        try
+        {
+            // 2 × 1 KB entries = 2 KB resident, headroom = 2 KB.
+            for (int i = 0; i < 2; i++) pool.Register(new byte[1024]);
+            Assert.Equal(2048L, pool.ResidentBytes);
+
+            // Reserve 2 KB — fits exactly into the existing headroom.
+            // No eviction needed.
+            Assert.True(pool.ReserveBytes(2048L));
+            Assert.Equal(2048L, pool.ReservedBytes);
+            Assert.Equal(2048L, pool.ResidentBytes);
+
+            // Second reserve of 2 KB must evict an existing entry to
+            // make room (resident=2K + reserved=2K already at budget).
+            Assert.True(pool.ReserveBytes(2048L));
+            Assert.Equal(4096L, pool.ReservedBytes);
+            Assert.True(pool.ResidentBytes <= 0L,
+                $"Second ReserveBytes(2KB) should have evicted both LRU entries; got resident={pool.ResidentBytes}.");
+
+            // ReleaseReservation gives the headroom back.
+            pool.ReleaseReservation(2048L);
+            Assert.Equal(2048L, pool.ReservedBytes);
+            pool.ReleaseReservation(2048L);
+            Assert.Equal(0L, pool.ReservedBytes);
+        }
+        finally { pool.Dispose(); }
+    }
+
+    [Fact]
+    public void ReleaseReservation_MoreThanReserved_FloorsAtZero()
+    {
+        // Defensive: double-release must not turn into negative
+        // ReservedBytes (which would let future evictions skip the
+        // reservation accounting). Floor at zero.
+        var pool = new StreamingTensorPool(new GpuOffloadOptions
+        {
+            StreamingPoolMaxResidentBytes = 4096L,
+            StreamingBackingStorePath = _backingDir,
+        });
+        try
+        {
+            pool.ReserveBytes(1024L);
+            Assert.Equal(1024L, pool.ReservedBytes);
+            pool.ReleaseReservation(2048L); // double the reservation
+            Assert.Equal(0L, pool.ReservedBytes);
+            // Second release should still floor at zero, not go negative.
+            pool.ReleaseReservation(1024L);
+            Assert.Equal(0L, pool.ReservedBytes);
+        }
+        finally { pool.Dispose(); }
     }
 
     [Fact]

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightRegistryStreamingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightRegistryStreamingTests.cs
@@ -1133,4 +1133,170 @@ public class WeightRegistryStreamingTests : IDisposable
         }
         finally { pool.Dispose(); }
     }
+
+    // -------- AllocateRegistered<T> + EvictUntilFreeBytes (#1222 follow-on) --------
+
+    [Fact]
+    public void AllocateRegistered_AfterReset_StillReturnsStreamingLifetime()
+    {
+        // Reset() leaves _options at a default GpuOffloadOptions (not
+        // null), so AllocateRegistered's contract is preserved across
+        // Reset: it always returns a Streaming-lifetime tensor with
+        // materialized storage. The "fall back to Default Tensor" path
+        // exists only for the brief window before any Configure call
+        // at process startup — not normally testable from here.
+        WeightRegistry.Reset();
+
+        var t = WeightRegistry.AllocateRegistered<float>(new[] { 16, 16 });
+
+        Assert.Equal(WeightLifetime.Streaming, t.Lifetime);
+        Assert.Equal(16 * 16, t.Length);
+        Assert.True(t.DataVector.Length > 0,
+            "AllocateRegistered should leave storage materialized for caller "
+            + "to initialize before RegisterWeight.");
+    }
+
+    [Fact]
+    public void AllocateRegistered_WithStreamingConfigured_ReturnsStreamingLifetimeTensor()
+    {
+        var t = WeightRegistry.AllocateRegistered<float>(new[] { 8, 8 });
+
+        // Streaming-configured path: lifetime is set, storage is
+        // materialized (caller has yet to RegisterWeight). The contract
+        // is "ready for caller to initialize then register".
+        Assert.Equal(WeightLifetime.Streaming, t.Lifetime);
+        Assert.Equal(64, t.Length);
+        Assert.True(t.DataVector.Length > 0,
+            "AllocateRegistered should return a materialized tensor so callers "
+            + "can initialize weights into it before calling RegisterWeight.");
+    }
+
+    [Fact]
+    public void AllocateRegistered_LongSequence_BoundsPeakResidency()
+    {
+        // The whole point of AllocateRegistered: a long sequence of
+        // large allocations + registers should stay bounded by the pool
+        // budget instead of peaking at the cumulative weight size.
+        // Simulate PaLM-E's MHA-layer pattern: 4 weights per "layer",
+        // 16 "layers", each weight 64 KB. Cumulative = 64 KB × 4 × 16 =
+        // 4 MB. Pool budget set to 256 KB by the fixture override below.
+        // Without eviction-on-allocate, peak resident would be 4 MB
+        // (everything alive); with it, resident should plateau near
+        // the 256 KB budget.
+        WeightRegistry.Reset();
+        WeightRegistry.Configure(new GpuOffloadOptions
+        {
+            StreamingPoolMaxResidentBytes = 256L * 1024,
+            StreamingBackingStorePath = _backingDir,
+        });
+
+        long peakResidentBytes = 0;
+        for (int layer = 0; layer < 16; layer++)
+        {
+            for (int matrix = 0; matrix < 4; matrix++)
+            {
+                // 64 KB per matrix at fp32 = 16384 elements = 128×128.
+                var t = WeightRegistry.AllocateRegistered<float>(new[] { 128, 128 });
+                // Initialize (write into materialized storage). DataVector
+                // is the underlying Vector; AsWritableSpan exposes the
+                // writable mutable view that AsSpan (read-only) does not.
+                var span = t.DataVector.AsWritableSpan();
+                for (int i = 0; i < span.Length; i++) span[i] = (float)((layer * 4 + matrix + i) % 7);
+                // Register: serializes + drops + commits to pool.
+                WeightRegistry.RegisterWeight(t);
+
+                long resident = WeightRegistry.GetStreamingReport().ResidentBytes;
+                if (resident > peakResidentBytes) peakResidentBytes = resident;
+            }
+        }
+
+        // Pool resident should be bounded by budget (256 KB) plus a
+        // small slop for the most recent allocation that triggered
+        // eviction. Peak shouldn't approach the cumulative 4 MB total.
+        Assert.True(peakResidentBytes <= 384L * 1024,
+            $"AllocateRegistered + RegisterWeight should bound peak resident "
+            + $"to ~budget (256 KB), but peak was {peakResidentBytes} bytes "
+            + $"({peakResidentBytes / 1024.0:F1} KB). If this exceeds 384 KB "
+            + "(budget + ~50% slop for the last register), eviction-on-allocate "
+            + "isn't running, or EvictUntilFreeBytes isn't getting the "
+            + "caller-requested headroom.");
+    }
+
+    [Fact]
+    public void AllocateRegistered_OversizeShape_ThrowsClearError()
+    {
+        // Per-tensor bytecount is bounded by int.MaxValue (the byte[]
+        // limit). Asking for 2.5 GB of fp32 (~625M elements) should
+        // throw NotSupportedException with a chunking hint, not OOM
+        // somewhere deep in the pool.
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            WeightRegistry.AllocateRegistered<float>(new[] { 1_000_000_000 }));
+        Assert.Contains("Chunk", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void AllocateRegistered_NegativeShape_Throws()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            WeightRegistry.AllocateRegistered<float>(new[] { -1, 16 }));
+    }
+
+    [Fact]
+    public void EvictUntilFreeBytes_DirectCall_PagesLruEntries()
+    {
+        // Direct StreamingTensorPool test — no AllocateRegistered
+        // wrapper. Register some entries, then ask for headroom equal
+        // to half the budget and verify resident drops accordingly.
+        var pool = new StreamingTensorPool(new GpuOffloadOptions
+        {
+            StreamingPoolMaxResidentBytes = 4096L,
+            StreamingBackingStorePath = _backingDir,
+        });
+        try
+        {
+            // 4 × 1 KB entries = 4 KB resident, exactly at budget.
+            for (int i = 0; i < 4; i++)
+            {
+                var bytes = new byte[1024];
+                pool.Register(bytes);
+            }
+            Assert.Equal(4096L, pool.ResidentBytes);
+
+            // Ask for 2 KB of headroom. Pool should evict 2 LRU entries.
+            bool secured = pool.EvictUntilFreeBytes(2048L);
+            Assert.True(secured,
+                "EvictUntilFreeBytes should secure 2 KB headroom from a "
+                + "4 KB pool with 4 evictable entries.");
+            Assert.True(pool.ResidentBytes <= 2048L,
+                $"After EvictUntilFreeBytes(2048), resident should be <= 2048; got {pool.ResidentBytes}.");
+        }
+        finally { pool.Dispose(); }
+    }
+
+    [Fact]
+    public void EvictUntilFreeBytes_RequestExceedsBudget_BestEffortReturnsFalse()
+    {
+        // Asking for more headroom than the budget itself should
+        // empty the LRU and return false — caller's allocation will
+        // push the pool past budget, but EvictIfOverBudget on the
+        // next register catches up.
+        var pool = new StreamingTensorPool(new GpuOffloadOptions
+        {
+            StreamingPoolMaxResidentBytes = 4096L,
+            StreamingBackingStorePath = _backingDir,
+        });
+        try
+        {
+            for (int i = 0; i < 4; i++) pool.Register(new byte[1024]);
+
+            // Ask for 8 KB headroom — exceeds the 4 KB budget. Even
+            // after evicting all 4 entries, can't satisfy → false.
+            bool secured = pool.EvictUntilFreeBytes(8192L);
+            Assert.False(secured,
+                "EvictUntilFreeBytes(8192) > budget(4096) should empty the "
+                + "LRU and return false (best-effort signal).");
+            Assert.Equal(0L, pool.ResidentBytes);
+        }
+        finally { pool.Dispose(); }
+    }
 }


### PR DESCRIPTION
## Summary

Closes the eager-allocation gap PaLM-E 562B (and similar foundation-scale models) hit during lazy-layer weight materialization. Tracked under [ooples/AiDotNet#1222](https://github.com/ooples/AiDotNet/issues/1222).

Adds **one** new public method to `WeightRegistry`. The pool-side reservation primitives (`ReserveBytes`, `ReleaseReservation`, `ReservedBytes`, `EvictUntilFreeBytes`) are intentionally `internal` — they are plumbing that `WeightRegistry` and tests use, but exposing the byteCount-based release path publicly would let external code desync the pool's `_reservedBytes` accounting (no opaque token to validate the release amount). The supported public surface for cancellation is `WeightRegistry.UnregisterWeight`.

### `WeightRegistry.AllocateStreaming<T>(int[] shape)` (public)

Reserves pool headroom BEFORE allocating a new tensor on the GC heap. Returns a materialized tensor with `WeightLifetime.Streaming` pre-set; caller initializes weights into it and then calls `RegisterWeight` as usual to commit. If the caller bails between Allocate and Register, `UnregisterWeight` releases the reservation.

### Internal plumbing (not public — exposed via InternalsVisibleTo)

- `StreamingTensorPool.ReserveBytes(long byteCount)` — atomic reservation against pool budget.
- `StreamingTensorPool.ReleaseReservation(long byteCount)` — commit/abandon path used by `WeightRegistry.RegisterWeight` / `UnregisterWeight`.
- `StreamingTensorPool.EvictUntilFreeBytes(long byteCount)` — eviction loop; called by `ReserveBytes`. Tests cover it directly.
- `StreamingTensorPool.ReservedBytes` — telemetry; tests assert reservation accounting invariants.

> **Naming note:** an earlier revision called this `AllocateRegistered`; renamed to `AllocateStreaming` because the returned tensor is NOT yet registered with the pool — callers must still invoke `RegisterWeight`. The original name implied the registration was complete.

## Why this matters

Before this, `MultiHeadAttentionLayer.OnFirstForward` and similar lazy layers allocated weights via raw `new Tensor<T>([dim, dim])`. For PaLM-E 562B the cumulative GC-heap occupancy grew to **~134 GB** before streaming had any chance to evict — `RegisterWeight` runs AFTER the allocation, can serialize+drop but can't un-allocate. Concretely:

```csharp
// PaLM-E MHA OnFirstForward, current behavior:
_queryWeights  = new Tensor<T>([8192, 8192]);  // 537 MB GC heap
_keyWeights    = new Tensor<T>([8192, 8192]);  // 1.07 GB
_valueWeights  = new Tensor<T>([8192, 8192]);  // 1.6 GB
_outputWeights = new Tensor<T>([8192, 8192]);  // 2.1 GB
// ...64 decoder layers × 2.1 GB each = 134 GB peak before any RegisterWeight runs.
```

With `AllocateStreaming`, layers can reserve headroom first:

```csharp
_queryWeights  = WeightRegistry.AllocateStreaming<T>([8192, 8192]);
// ↑ pool evicts LRU entries to disk if needed BEFORE returning the tensor
// Peak GC heap now bounded by pool budget instead of cumulative weight size
```

## Implementation notes

- Extracted `EvictNodeInternal` from `EvictIfOverBudget` so both budget-driven and headroom-driven eviction share the same LZ4-encode + stream-write machinery. No behavior change for the existing budget-driven path.
- Reservation accounting (new `_reservedBytes` field) closes the TOCTOU race between concurrent `AllocateStreaming` callers — both would otherwise pass the same eviction gate. `ReserveBytes` evicts + records under one lock acquisition; `RegisterWeight` releases the reservation immediately before the bytes land in `_residentBytes` (net-zero on budget).
- Streamable-type table centralized in `StreamableTypeSize<T>`; `IsStreamableType<T>`, `ElementSize<T>` derive from it. Adding a new streamable type is a single-place change.
- `AllocateStreaming` upfront-rejects oversize tensors (per-tensor element count > `int.MaxValue`) with a clear chunking-hint `NotSupportedException` — overflow check runs INSIDE the shape loop so `checked` arithmetic doesn't fire first on pathological shapes. Also rejects unsupported element types (`decimal` etc.) before touching the pool.
- Reservation rollback on `Tensor<T>` ctor failure (try/catch around the ctor releases the reservation).
- `WeightRegistry.Configure` now refuses to swap pools when there are outstanding reservations, not just live entries — matching the existing safety contract.
- Tensor allocation runs OUTSIDE the registry-wide lock so a multi-hundred-MB GC heap allocation doesn't block unrelated `RegisterWeight` / `UnregisterWeight` calls.

## Test plan

- [x] `dotnet build src/AiDotNet.Tensors` — 0 errors
- [x] `dotnet test --filter "FullyQualifiedName~WeightRegistryStreaming|FullyQualifiedName~WeightLifetime"` — 55/55 pass
- [x] Full Tensors test suite (net10.0): 4303/4303 pass
- [x] Full Tensors test suite (net471): 4337/4338 pass; remaining 1 is a flaky timing-sensitive perf test (`Conv2DBackwardKernel_FloatFastPath_IsFasterThanNaiveFloatPath`) that passes in isolation
- [ ] CI green
- [ ] Consumer-side validation: `AiDotNet` PR migrating `MultiHeadAttentionLayer` etc. to `AllocateStreaming` — tracked at [ooples/AiDotNet#1271](https://github.com/ooples/AiDotNet/pull/1271).

## Followup

- Migrate AiDotNet's lazy layers (`MultiHeadAttentionLayer`, `DenseLayer`, `EmbeddingLayer`, `Conv*.OnFirstForward`) to call `AllocateStreaming` instead of `new Tensor<T>`. Gated on streaming being active so small models that fit in RAM don't pay the lookup overhead.
- Once both PRs land + 0.72.0 ships, the PaLM-E 562B canary in `PaLMEProfilerTest` should complete without OOM at paper-faithful config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)