### PR TITLE
Fix issue 305 destination-aware engine initialization

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -44,6 +44,8 @@ namespace AiDotNet.Tensors.Engines;
 /// </remarks>
 public partial class CpuEngine : ITensorLevelEngine
 {
+    private static int _randomNormalSeedCounter = Environment.TickCount;
+
     /// <inheritdoc/>
     public string Name => "CPU Engine";
 
@@ -25375,6 +25377,14 @@ public partial class CpuEngine : ITensorLevelEngine
         var random = RandomHelper.ThreadSafeRandom;
         double meanD = numOps.ToDouble(mean);
         double stdD = numOps.ToDouble(stddev);
+        int totalElements = destination.Length;
+
+        var liveBacking = destination.GetLiveBackingArrayOrNull();
+        if (liveBacking is not null && totalElements > ParallelThreshold)
+        {
+            FillRandomNormalArray(liveBacking, totalElements, numOps, meanD, stdD);
+            return;
+        }
 
         if (destination.IsContiguous)
         {
@@ -25383,11 +25393,11 @@ public partial class CpuEngine : ITensorLevelEngine
         }
 
         var destinationStorage = destination.RawWritableStorageSpan;
-        for (int i = 0; i < destination.Length;)
+        for (int i = 0; i < totalElements;)
         {
             NextNormalPair(random, out double z0, out double z1);
             destinationStorage[destination.LogicalToStorageIndex(i++)] = numOps.FromDouble(z0 * stdD + meanD);
-            if (i < destination.Length)
+            if (i < totalElements)
                 destinationStorage[destination.LogicalToStorageIndex(i++)] = numOps.FromDouble(z1 * stdD + meanD);
         }
     }
@@ -25476,6 +25486,197 @@ public partial class CpuEngine : ITensorLevelEngine
         }
     }
 
+    private static void FillRandomNormalArray<T>(
+        T[] destination,
+        int length,
+        INumericOperations<T> numOps,
+        double meanD,
+        double stdD)
+    {
+        int workerCount = Math.Min(MaxDegreeOfParallelism, Math.Max(1, (length + MinChunkSize - 1) / MinChunkSize));
+        if (workerCount <= 1)
+        {
+            FillRandomNormal(destination.AsSpan(0, length), numOps, RandomHelper.ThreadSafeRandom, meanD, stdD);
+            return;
+        }
+
+        int baseSeed = System.Threading.Interlocked.Add(ref _randomNormalSeedCounter, unchecked((int)0x9E3779B9));
+        int chunkSize = (length + workerCount - 1) / workerCount;
+
+        if (typeof(T) == typeof(float))
+        {
+            var typedDestination = (float[])(object)destination;
+            LightweightParallel(workerCount, chunk =>
+            {
+                int start = chunk * chunkSize;
+                int count = Math.Min(chunkSize, length - start);
+                if (count > 0)
+                    FillRandomNormalFloatChunk(typedDestination, start, count, (float)meanD, (float)stdD, baseSeed + chunk);
+            });
+            return;
+        }
+
+        if (typeof(T) == typeof(double))
+        {
+            var typedDestination = (double[])(object)destination;
+            LightweightParallel(workerCount, chunk =>
+            {
+                int start = chunk * chunkSize;
+                int count = Math.Min(chunkSize, length - start);
+                if (count > 0)
+                    FillRandomNormalDoubleChunk(typedDestination, start, count, meanD, stdD, baseSeed + chunk);
+            });
+            return;
+        }
+
+        LightweightParallel(workerCount, chunk =>
+        {
+            int start = chunk * chunkSize;
+            int count = Math.Min(chunkSize, length - start);
+            if (count > 0)
+                FillRandomNormalGenericChunk(destination, start, count, numOps, meanD, stdD, baseSeed + chunk);
+        });
+    }
+
+    private static void FillRandomNormalFloatChunk(
+        float[] destination,
+        int start,
+        int count,
+        float mean,
+        float stdDev,
+        int seed)
+    {
+        var random = new Helpers.SimdRandom(seed);
+        const int uniformChunk = 1024;
+        var uniforms = System.Buffers.ArrayPool<double>.Shared.Rent(uniformChunk);
+        try
+        {
+            int written = 0;
+            while (written < count)
+            {
+                int outputCount = Math.Min(count - written, uniformChunk);
+                int uniformCount = outputCount + (outputCount & 1);
+                random.NextDoubles(uniforms.AsSpan(0, uniformCount));
+
+                int pairs = outputCount / 2;
+                int destinationIndex = start + written;
+                for (int pair = 0; pair < pairs; pair++)
+                {
+                    int uniformIndex = pair * 2;
+                    NextNormalPair(uniforms[uniformIndex], uniforms[uniformIndex + 1], out double z0, out double z1);
+                    destination[destinationIndex++] = (float)(z0 * stdDev + mean);
+                    destination[destinationIndex++] = (float)(z1 * stdDev + mean);
+                }
+
+                if ((outputCount & 1) != 0)
+                {
+                    int uniformIndex = pairs * 2;
+                    NextNormalPair(uniforms[uniformIndex], uniforms[uniformIndex + 1], out double z0, out _);
+                    destination[destinationIndex] = (float)(z0 * stdDev + mean);
+                }
+
+                written += outputCount;
+            }
+        }
+        finally
+        {
+            System.Buffers.ArrayPool<double>.Shared.Return(uniforms);
+        }
+    }
+
+    private static void FillRandomNormalDoubleChunk(
+        double[] destination,
+        int start,
+        int count,
+        double mean,
+        double stdDev,
+        int seed)
+    {
+        var random = new Helpers.SimdRandom(seed);
+        const int uniformChunk = 1024;
+        var uniforms = System.Buffers.ArrayPool<double>.Shared.Rent(uniformChunk);
+        try
+        {
+            int written = 0;
+            while (written < count)
+            {
+                int outputCount = Math.Min(count - written, uniformChunk);
+                int uniformCount = outputCount + (outputCount & 1);
+                random.NextDoubles(uniforms.AsSpan(0, uniformCount));
+
+                int pairs = outputCount / 2;
+                int destinationIndex = start + written;
+                for (int pair = 0; pair < pairs; pair++)
+                {
+                    int uniformIndex = pair * 2;
+                    NextNormalPair(uniforms[uniformIndex], uniforms[uniformIndex + 1], out double z0, out double z1);
+                    destination[destinationIndex++] = z0 * stdDev + mean;
+                    destination[destinationIndex++] = z1 * stdDev + mean;
+                }
+
+                if ((outputCount & 1) != 0)
+                {
+                    int uniformIndex = pairs * 2;
+                    NextNormalPair(uniforms[uniformIndex], uniforms[uniformIndex + 1], out double z0, out _);
+                    destination[destinationIndex] = z0 * stdDev + mean;
+                }
+
+                written += outputCount;
+            }
+        }
+        finally
+        {
+            System.Buffers.ArrayPool<double>.Shared.Return(uniforms);
+        }
+    }
+
+    private static void FillRandomNormalGenericChunk<T>(
+        T[] destination,
+        int start,
+        int count,
+        INumericOperations<T> numOps,
+        double meanD,
+        double stdD,
+        int seed)
+    {
+        var random = new Helpers.SimdRandom(seed);
+        const int uniformChunk = 1024;
+        var uniforms = System.Buffers.ArrayPool<double>.Shared.Rent(uniformChunk);
+        try
+        {
+            int written = 0;
+            while (written < count)
+            {
+                int outputCount = Math.Min(count - written, uniformChunk);
+                int uniformCount = outputCount + (outputCount & 1);
+                random.NextDoubles(uniforms.AsSpan(0, uniformCount));
+
+                int pairs = outputCount / 2;
+                int destinationIndex = start + written;
+                for (int pair = 0; pair < pairs; pair++)
+                {
+                    int uniformIndex = pair * 2;
+                    NextNormalPair(uniforms[uniformIndex], uniforms[uniformIndex + 1], out double z0, out double z1);
+                    destination[destinationIndex++] = numOps.FromDouble(z0 * stdD + meanD);
+                    destination[destinationIndex++] = numOps.FromDouble(z1 * stdD + meanD);
+                }
+
+                if ((outputCount & 1) != 0)
+                {
+                    int uniformIndex = pairs * 2;
+                    NextNormalPair(uniforms[uniformIndex], uniforms[uniformIndex + 1], out double z0, out _);
+                    destination[destinationIndex] = numOps.FromDouble(z0 * stdD + meanD);
+                }
+
+                written += outputCount;
+            }
+        }
+        finally
+        {
+            System.Buffers.ArrayPool<double>.Shared.Return(uniforms);
+        }
+    }
+
     private static void FillUniformRange<T>(
         Span<T> destination,
         INumericOperations<T> numOps,
@@ -25493,6 +25694,15 @@ public partial class CpuEngine : ITensorLevelEngine
         double u2 = random.NextDouble();
 
         // Guard against log(0) which produces -Infinity and then NaN.
+        u1 = Math.Max(u1, double.Epsilon);
+
+        double mag = Math.Sqrt(-2.0 * Math.Log(u1));
+        z0 = mag * Math.Cos(2.0 * Math.PI * u2);
+        z1 = mag * Math.Sin(2.0 * Math.PI * u2);
+    }
+
+    private static void NextNormalPair(double u1, double u2, out double z0, out double z1)
+    {
         u1 = Math.Max(u1, double.Epsilon);
 
         double mag = Math.Sqrt(-2.0 * Math.Log(u1));

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -3661,13 +3661,34 @@ public partial class CpuEngine : ITensorLevelEngine
 #endif
     public unsafe void TensorSubtractInto<T>(Tensor<T> destination, Tensor<T> a, Tensor<T> b)
     {
-        if (!destination.IsContiguous) throw new InvalidOperationException("Output tensor must be contiguous.");
-        var aOrig = a;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
-        if (!a.IsContiguous) a = a.Contiguous();
-        var bOrig = b;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
-        if (!b.IsContiguous) b = b.Contiguous();
+        if (destination == null) throw new ArgumentNullException(nameof(destination));
+        if (a == null) throw new ArgumentNullException(nameof(a));
+        if (b == null) throw new ArgumentNullException(nameof(b));
+        if (a.Length != b.Length)
+            throw new ArgumentException($"Tensor lengths must match: {a.Length} vs {b.Length}.");
+        if (destination.Length < a.Length)
+            throw new ArgumentException($"Destination length ({destination.Length}) must be >= source length ({a.Length}).");
+        if (destination.IsSparse || a.IsSparse || b.IsSparse)
+            throw new InvalidOperationException("TensorSubtractInto does not support SparseTensor operands.");
 
         int length = a.Length;
+        if (!destination.IsContiguous || !a.IsContiguous || !b.IsContiguous)
+        {
+            var numOps = MathHelper.GetNumericOperations<T>();
+            var aStorage = a.RawStorageSpan;
+            var bStorage = b.RawStorageSpan;
+            var destinationStorage = destination.RawWritableStorageSpan;
+
+            for (int i = 0; i < length; i++)
+            {
+                destinationStorage[destination.LogicalToStorageIndex(i)] =
+                    numOps.Subtract(
+                        aStorage[a.LogicalToStorageIndex(i)],
+                        bStorage[b.LogicalToStorageIndex(i)]);
+            }
+            return;
+        }
+
         if (typeof(T) == typeof(float))
         {
             var aMem = AsFloatMemory(a.Data);
@@ -4424,13 +4445,24 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (destination == null) throw new ArgumentNullException(nameof(destination));
         if (a == null) throw new ArgumentNullException(nameof(a));
-        if (!destination.IsContiguous) throw new InvalidOperationException("Output tensor must be contiguous.");
-        var aOrig = a;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
-        if (!a.IsContiguous) a = a.Contiguous();
         if (destination.Length < a.Length)
             throw new ArgumentException($"Destination length ({destination.Length}) must be >= source length ({a.Length}).");
+        if (destination.IsSparse || a.IsSparse)
+            throw new InvalidOperationException("TensorMultiplyScalarInto does not support SparseTensor operands.");
 
         int length = a.Length;
+        if (!destination.IsContiguous || !a.IsContiguous)
+        {
+            var strideOps = MathHelper.GetNumericOperations<T>();
+            var sourceStorage = a.RawStorageSpan;
+            var destinationStorage = destination.RawWritableStorageSpan;
+            for (int i = 0; i < length; i++)
+            {
+                destinationStorage[destination.LogicalToStorageIndex(i)] =
+                    strideOps.Multiply(sourceStorage[a.LogicalToStorageIndex(i)], scalar);
+            }
+            return;
+        }
 
         // Float fast path: SIMD MultiplyScalar with parallel chunking
         if (typeof(T) == typeof(float))
@@ -25327,34 +25359,37 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (shape == null) throw new ArgumentNullException(nameof(shape));
 
+        var result = AutoTensorCache.RentOrAllocate<T>(shape);
+        TensorRandomNormalInto(result, mean, stddev);
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public void TensorRandomNormalInto<T>(Tensor<T> destination, T mean, T stddev)
+    {
+        if (destination == null) throw new ArgumentNullException(nameof(destination));
+        if (destination.IsSparse)
+            throw new InvalidOperationException("Random initialization into SparseTensor is not supported.");
+
         var numOps = MathHelper.GetNumericOperations<T>();
         var random = RandomHelper.ThreadSafeRandom;
-        var result = AutoTensorCache.RentOrAllocate<T>(shape);
-        int totalElements = shape.Aggregate(1, (a, b) => a * b);
-
-        var resultData = result.GetDataArray();
         double meanD = numOps.ToDouble(mean);
         double stdD = numOps.ToDouble(stddev);
 
-        // Box-Muller transform for normal distribution
-        for (int i = 0; i < totalElements; i += 2)
+        if (destination.IsContiguous)
         {
-            double u1 = random.NextDouble();
-            double u2 = random.NextDouble();
-
-            // Guard against log(0) which produces -Infinity and then NaN
-            u1 = Math.Max(u1, double.Epsilon);
-
-            double mag = Math.Sqrt(-2.0 * Math.Log(u1));
-            double z0 = mag * Math.Cos(2.0 * Math.PI * u2);
-            double z1 = mag * Math.Sin(2.0 * Math.PI * u2);
-
-            resultData[i] = numOps.FromDouble(z0 * stdD + meanD);
-            if (i + 1 < totalElements)
-                resultData[i + 1] = numOps.FromDouble(z1 * stdD + meanD);
+            FillRandomNormal(destination.AsWritableSpan(), numOps, random, meanD, stdD);
+            return;
         }
 
-        return result;
+        var destinationStorage = destination.RawWritableStorageSpan;
+        for (int i = 0; i < destination.Length;)
+        {
+            NextNormalPair(random, out double z0, out double z1);
+            destinationStorage[destination.LogicalToStorageIndex(i++)] = numOps.FromDouble(z0 * stdD + meanD);
+            if (i < destination.Length)
+                destinationStorage[destination.LogicalToStorageIndex(i++)] = numOps.FromDouble(z1 * stdD + meanD);
+        }
     }
 
     /// <inheritdoc/>
@@ -25362,18 +25397,28 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (shape == null) throw new ArgumentNullException(nameof(shape));
 
+        var result = AutoTensorCache.RentOrAllocate<T>(shape);
+        TensorRandomUniformRangeInto(result, min, max, seed);
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public void TensorRandomUniformRangeInto<T>(Tensor<T> destination, T min, T max, int? seed = null)
+    {
+        if (destination == null) throw new ArgumentNullException(nameof(destination));
+        if (destination.IsSparse)
+            throw new InvalidOperationException("Random initialization into SparseTensor is not supported.");
+
         var numOps = MathHelper.GetNumericOperations<T>();
         var random = seed.HasValue ? RandomHelper.CreateSeededRandom(seed.Value) : RandomHelper.ThreadSafeRandom;
-        var result = AutoTensorCache.RentOrAllocate<T>(shape);
-        int totalElements = shape.Aggregate(1, (a, b) => a * b);
 
         double minD = numOps.ToDouble(min);
         double maxD = numOps.ToDouble(max);
         double range = maxD - minD;
+        int totalElements = destination.Length;
 
-        var resultData = result.GetDataArray();
-
-        if (totalElements > 10000)
+        var liveBacking = destination.GetLiveBackingArrayOrNull();
+        if (liveBacking is not null && totalElements > 10000)
         {
             // For seeded random with parallelism, we need thread-local randoms
             if (seed.HasValue)
@@ -25386,7 +25431,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 Parallel.For(0, totalElements, () => RandomHelper.CreateSeededRandom(seeds[Thread.CurrentThread.ManagedThreadId % seeds.Length]),
                     (i, state, localRandom) =>
                     {
-                        resultData[i] = numOps.FromDouble(localRandom.NextDouble() * range + minD);
+                        liveBacking[i] = numOps.FromDouble(localRandom.NextDouble() * range + minD);
                         return localRandom;
                     },
                     _ => { });
@@ -25395,19 +25440,64 @@ public partial class CpuEngine : ITensorLevelEngine
             {
                 Parallel.For(0, totalElements, i =>
                 {
-                    resultData[i] = numOps.FromDouble(RandomHelper.ThreadSafeRandom.NextDouble() * range + minD);
+                    liveBacking[i] = numOps.FromDouble(RandomHelper.ThreadSafeRandom.NextDouble() * range + minD);
                 });
             }
-        }
-        else
-        {
-            for (int i = 0; i < totalElements; i++)
-            {
-                resultData[i] = numOps.FromDouble(random.NextDouble() * range + minD);
-            }
+            return;
         }
 
-        return result;
+        if (destination.IsContiguous)
+        {
+            FillUniformRange(destination.AsWritableSpan(), numOps, random, minD, range);
+            return;
+        }
+
+        var destinationStorage = destination.RawWritableStorageSpan;
+        for (int i = 0; i < totalElements; i++)
+        {
+            destinationStorage[destination.LogicalToStorageIndex(i)] =
+                numOps.FromDouble(random.NextDouble() * range + minD);
+        }
+    }
+
+    private static void FillRandomNormal<T>(
+        Span<T> destination,
+        INumericOperations<T> numOps,
+        Random random,
+        double meanD,
+        double stdD)
+    {
+        for (int i = 0; i < destination.Length;)
+        {
+            NextNormalPair(random, out double z0, out double z1);
+            destination[i++] = numOps.FromDouble(z0 * stdD + meanD);
+            if (i < destination.Length)
+                destination[i++] = numOps.FromDouble(z1 * stdD + meanD);
+        }
+    }
+
+    private static void FillUniformRange<T>(
+        Span<T> destination,
+        INumericOperations<T> numOps,
+        Random random,
+        double minD,
+        double range)
+    {
+        for (int i = 0; i < destination.Length; i++)
+            destination[i] = numOps.FromDouble(random.NextDouble() * range + minD);
+    }
+
+    private static void NextNormalPair(Random random, out double z0, out double z1)
+    {
+        double u1 = random.NextDouble();
+        double u2 = random.NextDouble();
+
+        // Guard against log(0) which produces -Infinity and then NaN.
+        u1 = Math.Max(u1, double.Epsilon);
+
+        double mag = Math.Sqrt(-2.0 * Math.Log(u1));
+        z0 = mag * Math.Cos(2.0 * Math.PI * u2);
+        z1 = mag * Math.Sin(2.0 * Math.PI * u2);
     }
 
     /// <inheritdoc/>
@@ -28782,8 +28872,7 @@ public partial class CpuEngine : ITensorLevelEngine
     /// </remarks>
     public void UnregisterPersistentTensor<T>(Tensor<T> tensor)
     {
-        var tensorOrig = tensor;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
-        if (!tensor.IsContiguous) tensor = tensor.Contiguous();
+        if (tensor == null) throw new ArgumentNullException(nameof(tensor));
         // No-op on CPU
     }
 
@@ -28793,8 +28882,7 @@ public partial class CpuEngine : ITensorLevelEngine
     /// </remarks>
     public void InvalidatePersistentTensor<T>(Tensor<T> tensor)
     {
-        var tensorOrig = tensor;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
-        if (!tensor.IsContiguous) tensor = tensor.Contiguous();
+        if (tensor == null) throw new ArgumentNullException(nameof(tensor));
         // No-op on CPU
     }
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -3668,8 +3668,12 @@ public partial class CpuEngine : ITensorLevelEngine
         if (b == null) throw new ArgumentNullException(nameof(b));
         if (a.Length != b.Length)
             throw new ArgumentException($"Tensor lengths must match: {a.Length} vs {b.Length}.");
-        if (destination.Length < a.Length)
-            throw new ArgumentException($"Destination length ({destination.Length}) must be >= source length ({a.Length}).");
+        // Exact-length match: destination MUST be the same size as the sources.
+        // A larger destination would leave trailing stale data and silently
+        // misalign downstream consumers that key on tensor.Length.
+        if (destination.Length != a.Length)
+            throw new ArgumentException(
+                $"Destination length ({destination.Length}) must equal source length ({a.Length}).");
         if (destination.IsSparse || a.IsSparse || b.IsSparse)
             throw new InvalidOperationException("TensorSubtractInto does not support SparseTensor operands.");
 
@@ -4447,8 +4451,9 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (destination == null) throw new ArgumentNullException(nameof(destination));
         if (a == null) throw new ArgumentNullException(nameof(a));
-        if (destination.Length < a.Length)
-            throw new ArgumentException($"Destination length ({destination.Length}) must be >= source length ({a.Length}).");
+        if (destination.Length != a.Length)
+            throw new ArgumentException(
+                $"Destination length ({destination.Length}) must equal source length ({a.Length}).");
         if (destination.IsSparse || a.IsSparse)
             throw new InvalidOperationException("TensorMultiplyScalarInto does not support SparseTensor operands.");
 
@@ -25430,29 +25435,32 @@ public partial class CpuEngine : ITensorLevelEngine
         var liveBacking = destination.GetLiveBackingArrayOrNull();
         if (liveBacking is not null && totalElements > 10000)
         {
-            // For seeded random with parallelism, we need thread-local randoms
-            if (seed.HasValue)
-            {
-                var baseRandom = RandomHelper.CreateSeededRandom(seed.Value);
-                var seeds = new int[CpuParallelSettings.MaxDegreeOfParallelism];
-                for (int i = 0; i < seeds.Length; i++)
-                    seeds[i] = baseRandom.Next();
+            // Chunk-based parallel fill. Each chunk gets a deterministic
+            // chunk-id-derived seed (from baseSeed when provided, otherwise
+            // from a process-wide monotonic counter). Avoids the
+            // ManagedThreadId-modulo collision where two workers can pick
+            // the same seed and produce identical subsequences.
+            int workerCount = Math.Min(
+                CpuParallelSettings.MaxDegreeOfParallelism,
+                Math.Max(1, (totalElements + MinChunkSize - 1) / MinChunkSize));
+            int chunkSize = (totalElements + workerCount - 1) / workerCount;
+            int baseSeed = seed.HasValue
+                ? seed.Value
+                : System.Threading.Interlocked.Add(ref _randomUniformSeedCounter, unchecked((int)0x9E3779B9));
 
-                Parallel.For(0, totalElements, () => RandomHelper.CreateSeededRandom(seeds[Thread.CurrentThread.ManagedThreadId % seeds.Length]),
-                    (i, state, localRandom) =>
-                    {
-                        liveBacking[i] = numOps.FromDouble(localRandom.NextDouble() * range + minD);
-                        return localRandom;
-                    },
-                    _ => { });
-            }
-            else
+            LightweightParallel(workerCount, chunkIdx =>
             {
-                Parallel.For(0, totalElements, i =>
-                {
-                    liveBacking[i] = numOps.FromDouble(RandomHelper.ThreadSafeRandom.NextDouble() * range + minD);
-                });
-            }
+                int start = chunkIdx * chunkSize;
+                int count = Math.Min(chunkSize, totalElements - start);
+                if (count <= 0) return;
+                // Mix base + chunkIdx through the same golden-ratio constant
+                // FillRandomNormalArray uses, so identical (baseSeed, workerCount)
+                // produces identical output across runs.
+                int chunkSeed = unchecked(baseSeed + (int)((uint)chunkIdx * 0x9E3779B9u));
+                var rand = RandomHelper.CreateSeededRandom(chunkSeed);
+                for (int i = start; i < start + count; i++)
+                    liveBacking[i] = numOps.FromDouble(rand.NextDouble() * range + minD);
+            });
             return;
         }
 
@@ -25469,6 +25477,8 @@ public partial class CpuEngine : ITensorLevelEngine
                 numOps.FromDouble(random.NextDouble() * range + minD);
         }
     }
+
+    private static int _randomUniformSeedCounter;
 
     private static void FillRandomNormal<T>(
         Span<T> destination,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClKernel.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClKernel.cs
@@ -77,6 +77,22 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             }
         }
 
+        public void SetArg(uint index, ulong value)
+        {
+            IntPtr ptr = Marshal.AllocHGlobal(sizeof(ulong));
+            try
+            {
+                Marshal.WriteInt64(ptr, unchecked((long)value));
+                int err = OpenClNativeBindings.SetKernelArg(_kernel, index, (UIntPtr)sizeof(ulong), ptr);
+                if (err != OpenClNativeBindings.CL_SUCCESS)
+                    throw new InvalidOperationException($"Failed to set kernel arg {index}: {err}");
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(ptr);
+            }
+        }
+
         /// <summary>
         /// Sets a local memory argument (for shared memory allocation).
         /// </summary>

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -1403,19 +1403,27 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         var bufferB = AllocateOutputBuffer(backend, input.Length);
         try
         {
-            // AutocastScope: convert to fp16 for compute, back to fp32 for output
-            var fp16Input = Gpu.AutocastScope.MaybeConvertInput(backend, bufferA.Buffer, input.Length);
-            if (fp16Input is not null)
+            // AutocastScope: convert to fp16 for compute, back to fp32 for output.
+            // try/finally guarantees fp16Input is released even if op() or
+            // ConvertToFp32 throws.
+            IGpuBuffer? fp16Input = null;
+            try
             {
-                using var fp16Output = AllocateOutputBuffer(backend, input.Length);
-                op(backend, fp16Input, fp16Output.Buffer, input.Length);
-                // Convert output back to fp32
-                backend.ConvertToFp32(fp16Output.Buffer, bufferB.Buffer, input.Length);
-                fp16Input.Dispose();
+                fp16Input = Gpu.AutocastScope.MaybeConvertInput(backend, bufferA.Buffer, input.Length);
+                if (fp16Input is not null)
+                {
+                    using var fp16Output = AllocateOutputBuffer(backend, input.Length);
+                    op(backend, fp16Input, fp16Output.Buffer, input.Length);
+                    backend.ConvertToFp32(fp16Output.Buffer, bufferB.Buffer, input.Length);
+                }
+                else
+                {
+                    op(backend, bufferA.Buffer, bufferB.Buffer, input.Length);
+                }
             }
-            else
+            finally
             {
-                op(backend, bufferA.Buffer, bufferB.Buffer, input.Length);
+                fp16Input?.Dispose();
             }
             return FinishGpuOp<T>(backend, bufferB, input.Length);
         }
@@ -1498,17 +1506,24 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 // to fp32 for the downloaded result. Without this the chunked
                 // fallback would silently change numeric / perf behaviour vs
                 // the normal GPU path.
-                var fp16Input = Gpu.AutocastScope.MaybeConvertInput(backend, bufferIn.Buffer, len);
-                if (fp16Input is not null)
+                IGpuBuffer? fp16Input = null;
+                try
                 {
-                    using var fp16Out = new OwnedBuffer(backend.AllocateBuffer(len), ownsBuffer: true);
-                    op(backend, fp16Input, fp16Out.Buffer, len);
-                    backend.ConvertToFp32(fp16Out.Buffer, bufferOut.Buffer, len);
-                    fp16Input.Dispose();
+                    fp16Input = Gpu.AutocastScope.MaybeConvertInput(backend, bufferIn.Buffer, len);
+                    if (fp16Input is not null)
+                    {
+                        using var fp16Out = new OwnedBuffer(backend.AllocateBuffer(len), ownsBuffer: true);
+                        op(backend, fp16Input, fp16Out.Buffer, len);
+                        backend.ConvertToFp32(fp16Out.Buffer, bufferOut.Buffer, len);
+                    }
+                    else
+                    {
+                        op(backend, bufferIn.Buffer, bufferOut.Buffer, len);
+                    }
                 }
-                else
+                finally
                 {
-                    op(backend, bufferIn.Buffer, bufferOut.Buffer, len);
+                    fp16Input?.Dispose();
                 }
                 var chunkResult = backend.DownloadBuffer(bufferOut.Buffer);
                 Array.Copy(chunkResult, 0, resultFloat, offset, len);
@@ -1571,21 +1586,30 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         var bufferC = AllocateOutputBuffer(backend, left.Length);
         try
         {
-            var fp16A = Gpu.AutocastScope.MaybeConvertInput(backend, bufferA.Buffer, left.Length);
-            var fp16B = Gpu.AutocastScope.MaybeConvertInput(backend, bufferB.Buffer, left.Length);
-            if (fp16A is not null && fp16B is not null)
+            // fp16A / fp16B are raw IGpuBuffer? (no IDisposable wrapper) so we
+            // must guarantee Dispose() runs even if op() or ConvertToFp32 throws.
+            // Previously these leaked on any exception inside the if-branch.
+            IGpuBuffer? fp16A = null;
+            IGpuBuffer? fp16B = null;
+            try
             {
-                using var fp16Out = AllocateOutputBuffer(backend, left.Length);
-                op(backend, fp16A, fp16B, fp16Out.Buffer, left.Length);
-                backend.ConvertToFp32(fp16Out.Buffer, bufferC.Buffer, left.Length);
-                fp16A.Dispose();
-                fp16B.Dispose();
+                fp16A = Gpu.AutocastScope.MaybeConvertInput(backend, bufferA.Buffer, left.Length);
+                fp16B = Gpu.AutocastScope.MaybeConvertInput(backend, bufferB.Buffer, left.Length);
+                if (fp16A is not null && fp16B is not null)
+                {
+                    using var fp16Out = AllocateOutputBuffer(backend, left.Length);
+                    op(backend, fp16A, fp16B, fp16Out.Buffer, left.Length);
+                    backend.ConvertToFp32(fp16Out.Buffer, bufferC.Buffer, left.Length);
+                }
+                else
+                {
+                    op(backend, bufferA.Buffer, bufferB.Buffer, bufferC.Buffer, left.Length);
+                }
             }
-            else
+            finally
             {
                 fp16A?.Dispose();
                 fp16B?.Dispose();
-                op(backend, bufferA.Buffer, bufferB.Buffer, bufferC.Buffer, left.Length);
             }
             return FinishGpuOp<T>(backend, bufferC, left.Length);
         }
@@ -1651,21 +1675,27 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 // Mirror the AutocastScope behaviour from TryRunBinaryGpu so the
                 // chunked fallback doesn't silently change numeric/perf behaviour
                 // when autocast is enabled.
-                var fp16A = Gpu.AutocastScope.MaybeConvertInput(backend, bA.Buffer, len);
-                var fp16B = Gpu.AutocastScope.MaybeConvertInput(backend, bB.Buffer, len);
-                if (fp16A is not null && fp16B is not null)
+                IGpuBuffer? fp16A = null;
+                IGpuBuffer? fp16B = null;
+                try
                 {
-                    using var fp16Out = new OwnedBuffer(backend.AllocateBuffer(len), ownsBuffer: true);
-                    op(backend, fp16A, fp16B, fp16Out.Buffer, len);
-                    backend.ConvertToFp32(fp16Out.Buffer, bC.Buffer, len);
-                    fp16A.Dispose();
-                    fp16B.Dispose();
+                    fp16A = Gpu.AutocastScope.MaybeConvertInput(backend, bA.Buffer, len);
+                    fp16B = Gpu.AutocastScope.MaybeConvertInput(backend, bB.Buffer, len);
+                    if (fp16A is not null && fp16B is not null)
+                    {
+                        using var fp16Out = new OwnedBuffer(backend.AllocateBuffer(len), ownsBuffer: true);
+                        op(backend, fp16A, fp16B, fp16Out.Buffer, len);
+                        backend.ConvertToFp32(fp16Out.Buffer, bC.Buffer, len);
+                    }
+                    else
+                    {
+                        op(backend, bA.Buffer, bB.Buffer, bC.Buffer, len);
+                    }
                 }
-                else
+                finally
                 {
                     fp16A?.Dispose();
                     fp16B?.Dispose();
-                    op(backend, bA.Buffer, bB.Buffer, bC.Buffer, len);
                 }
                 var chunkResult = backend.DownloadBuffer(bC.Buffer);
                 Array.Copy(chunkResult, 0, resultFloat, offset, len);
@@ -1885,21 +1915,27 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             var output = AllocateOutputBuffer(backend, left.Length);
             try
             {
-                var fp16A = Gpu.AutocastScope.MaybeConvertInput(backend, bufferA.Buffer, left.Length);
-                var fp16B = Gpu.AutocastScope.MaybeConvertInput(backend, bufferB.Buffer, left.Length);
-                if (fp16A is not null && fp16B is not null)
+                IGpuBuffer? fp16A = null;
+                IGpuBuffer? fp16B = null;
+                try
                 {
-                    using var fp16Out = AllocateOutputBuffer(backend, left.Length);
-                    op(backend, fp16A, fp16B, fp16Out.Buffer, left.Length);
-                    backend.ConvertToFp32(fp16Out.Buffer, output.Buffer, left.Length);
-                    fp16A.Dispose();
-                    fp16B.Dispose();
+                    fp16A = Gpu.AutocastScope.MaybeConvertInput(backend, bufferA.Buffer, left.Length);
+                    fp16B = Gpu.AutocastScope.MaybeConvertInput(backend, bufferB.Buffer, left.Length);
+                    if (fp16A is not null && fp16B is not null)
+                    {
+                        using var fp16Out = AllocateOutputBuffer(backend, left.Length);
+                        op(backend, fp16A, fp16B, fp16Out.Buffer, left.Length);
+                        backend.ConvertToFp32(fp16Out.Buffer, output.Buffer, left.Length);
+                    }
+                    else
+                    {
+                        op(backend, bufferA.Buffer, bufferB.Buffer, output.Buffer, left.Length);
+                    }
                 }
-                else
+                finally
                 {
                     fp16A?.Dispose();
                     fp16B?.Dispose();
-                    op(backend, bufferA.Buffer, bufferB.Buffer, output.Buffer, left.Length);
                 }
 
                 DownloadGpuBufferInto(backend, output, destinationArray, left.Length);

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -50,6 +50,8 @@ internal sealed class CsrCacheKey : IEquatable<CsrCacheKey>
     public bool Equals(CsrCacheKey? other) =>
         other is not null && ReferenceEquals(_sparse, other._sparse) && ReferenceEquals(_backend, other._backend);
 
+    public bool MatchesSparse(object sparse) => ReferenceEquals(_sparse, sparse);
+
     public override bool Equals(object? obj) => Equals(obj as CsrCacheKey);
 
     public override int GetHashCode()
@@ -884,6 +886,44 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
     }
 
+    private void RemoveActivationCacheEntry(object cacheKey)
+    {
+        ActivationCacheEntry? removed = null;
+        lock (_activationCacheLock)
+        {
+            if (_activationCache.TryRemove(cacheKey, out var entry))
+            {
+                System.Threading.Interlocked.Add(ref _currentActivationCacheBytes,
+                    -(entry.Buffer.Size * sizeof(float)));
+                removed = entry;
+            }
+        }
+
+        removed?.Dispose();
+    }
+
+    private bool TryReplacePersistentBuffer<T>(T[] data, IGpuBuffer buffer)
+    {
+        lock (_persistentBufferLock)
+        {
+            if (!_persistentBufferCache.TryGetValue(data, out var existing))
+                return false;
+
+            var nextVersion = existing.Version + 1;
+            var replacement = new GpuBufferCacheEntry(buffer, existing.Role)
+            {
+                Version = nextVersion
+            };
+
+            if (_persistentBufferCache.TryRemove(data, out var removed))
+                removed.Dispose();
+
+            _persistentBufferCache[data] = replacement;
+            _tensorVersions[data] = nextVersion;
+            return true;
+        }
+    }
+
     /// <summary>
     /// Evicts the oldest half of the activation cache entries.
     /// Must be called while holding _activationCacheLock.
@@ -1127,6 +1167,9 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// <param name="elementCount">Number of elements that will be written.</param>
     private void DownloadGpuBufferInto<T>(IDirectGpuBackend backend, OwnedBuffer outputBuffer, T[] destination, int elementCount)
     {
+        Helpers.DeferredArrayMaterializer.Remove(destination);
+        RemoveActivationCacheEntry(destination);
+
         var capturedBuffer = outputBuffer.Buffer;
         var capturedBackend = backend;
         Helpers.DeferredArrayMaterializer.Register(destination, arr =>
@@ -1147,7 +1190,9 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             var converted = DirectGpuEngine.FromFloatArray<T>(floatData);
             Array.Copy(converted, (T[])arr, Math.Min(converted.Length, ((T[])arr).Length));
         });
-        CacheActivation(destination, outputBuffer.Buffer, new[] { elementCount }, backend);
+
+        if (!TryReplacePersistentBuffer(destination, outputBuffer.Buffer))
+            CacheActivation(destination, outputBuffer.Buffer, new[] { elementCount }, backend);
     }
 
     /// <summary>
@@ -1796,6 +1841,126 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
     }
 
+    private static bool TryGetSimpleCpuDestinationArray<T>(Tensor<T> destination, int elementCount, out T[] destinationArray)
+    {
+        destinationArray = null!;
+        if (destination.IsSparse || !destination.IsContiguous || destination.Length < elementCount)
+            return false;
+
+        destinationArray = destination.GetLiveBackingArrayOrNull()!;
+        return destinationArray is not null;
+    }
+
+    private OwnedBuffer GetOrAllocateContiguousInputBuffer<T>(IDirectGpuBackend backend, Tensor<T> tensor)
+    {
+        if (tensor._gpuBuffer is not null && ReferenceEquals(tensor._gpuBackend, backend))
+            return new OwnedBuffer(tensor._gpuBuffer, ownsBuffer: false);
+
+        if (!tensor.IsContiguous || tensor.IsSparse)
+            throw new InvalidOperationException("GPU destination-aware tensor ops require contiguous dense inputs.");
+        if (tensor._storageOffset != 0 || tensor._storage.Length != tensor.Length)
+            throw new InvalidOperationException("GPU destination-aware tensor ops require simple CPU-backed inputs.");
+
+        return GetOrAllocateBuffer(backend, tensor);
+    }
+
+    private bool TryRunBinaryInto<T>(
+        Tensor<T> destination,
+        Tensor<T> left,
+        Tensor<T> right,
+        Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, IGpuBuffer, int> op,
+        [System.Runtime.CompilerServices.CallerMemberName] string callerName = "")
+    {
+        if (left.Length != right.Length)
+            return false;
+        if (!TryGetSimpleCpuDestinationArray(destination, left.Length, out var destinationArray))
+            return false;
+        if (!TryGetBackend(out var backend))
+            return false;
+
+        try
+        {
+            using var bufferA = GetOrAllocateContiguousInputBuffer(backend, left);
+            using var bufferB = GetOrAllocateContiguousInputBuffer(backend, right);
+            var output = AllocateOutputBuffer(backend, left.Length);
+            try
+            {
+                var fp16A = Gpu.AutocastScope.MaybeConvertInput(backend, bufferA.Buffer, left.Length);
+                var fp16B = Gpu.AutocastScope.MaybeConvertInput(backend, bufferB.Buffer, left.Length);
+                if (fp16A is not null && fp16B is not null)
+                {
+                    using var fp16Out = AllocateOutputBuffer(backend, left.Length);
+                    op(backend, fp16A, fp16B, fp16Out.Buffer, left.Length);
+                    backend.ConvertToFp32(fp16Out.Buffer, output.Buffer, left.Length);
+                    fp16A.Dispose();
+                    fp16B.Dispose();
+                }
+                else
+                {
+                    fp16A?.Dispose();
+                    fp16B?.Dispose();
+                    op(backend, bufferA.Buffer, bufferB.Buffer, output.Buffer, left.Length);
+                }
+
+                DownloadGpuBufferInto(backend, output, destinationArray, left.Length);
+                return true;
+            }
+            catch
+            {
+                output.Dispose();
+                throw;
+            }
+        }
+        catch (AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex)
+        {
+            HandleBufferTooLarge<T>(ex, callerName);
+            return false;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private bool TryRunScalarInto<T>(
+        Tensor<T> destination,
+        Tensor<T> input,
+        T scalar,
+        Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, float, int> op,
+        [System.Runtime.CompilerServices.CallerMemberName] string callerName = "")
+    {
+        if (!TryGetSimpleCpuDestinationArray(destination, input.Length, out var destinationArray))
+            return false;
+        if (!TryGetBackend(out var backend))
+            return false;
+
+        try
+        {
+            using var bufferA = GetOrAllocateContiguousInputBuffer(backend, input);
+            var output = AllocateOutputBuffer(backend, input.Length);
+            try
+            {
+                op(backend, bufferA.Buffer, output.Buffer, ToFloatScalar(scalar), input.Length);
+                DownloadGpuBufferInto(backend, output, destinationArray, input.Length);
+                return true;
+            }
+            catch
+            {
+                output.Dispose();
+                throw;
+            }
+        }
+        catch (AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex)
+        {
+            HandleBufferTooLarge<T>(ex, callerName);
+            return false;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     private static bool ShapesMatch(int[] left, int[] right)
     {
         return left.Length == right.Length && left.SequenceEqual(right);
@@ -2107,9 +2272,10 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     void IEngine.TensorAddInto<T>(Tensor<T> dest, Tensor<T> a, Tensor<T> b)
     {
-        // Use allocating GPU path and copy result
-        var result = ((IEngine)this).TensorAdd(a, b);
-        result.Data.Span.CopyTo(dest.Data.Span);
+        if (ShapesMatch(a.Shape._dims, b.Shape._dims) && TryRunBinaryInto(dest, a, b,
+            static (backend, left, right, output, size) => backend.Add(left, right, output, size)))
+            return;
+        base.TensorAddInto(dest, a, b);
     }
 
     void IEngine.TensorMultiplyInPlace<T>(Tensor<T> a, Tensor<T> b)
@@ -2122,8 +2288,10 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     void IEngine.TensorMultiplyInto<T>(Tensor<T> dest, Tensor<T> a, Tensor<T> b)
     {
-        var result = ((IEngine)this).TensorMultiply(a, b);
-        result.Data.Span.CopyTo(dest.Data.Span);
+        if (ShapesMatch(a.Shape._dims, b.Shape._dims) && TryRunBinaryInto(dest, a, b,
+            static (backend, left, right, output, size) => backend.Multiply(left, right, output, size)))
+            return;
+        base.TensorMultiplyInto(dest, a, b);
     }
 
     void IEngine.TensorSubtractInPlace<T>(Tensor<T> a, Tensor<T> b)
@@ -2137,10 +2305,10 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     void IEngine.TensorSubtractInto<T>(Tensor<T> dest, Tensor<T> a, Tensor<T> b)
     {
-        if (!dest.IsContiguous) { base.TensorSubtractInto(dest, a, b); return; }
-        // Compute on GPU then copy directly into dest's backing storage
-        var result = ((IEngine)this).TensorSubtract(a, b);
-        result.Data.Span.CopyTo(dest.Data.Span);
+        if (ShapesMatch(a.Shape._dims, b.Shape._dims) && TryRunBinaryInto(dest, a, b,
+            static (backend, left, right, output, size) => backend.Subtract(left, right, output, size)))
+            return;
+        base.TensorSubtractInto(dest, a, b);
     }
 
     void IEngine.TensorMultiplyScalarInPlace<T>(Tensor<T> a, T scalar)
@@ -2155,16 +2323,9 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     void IEngine.TensorMultiplyScalarInto<T>(Tensor<T> dest, Tensor<T> a, T scalar)
     {
-        if (!dest.IsContiguous) { base.TensorMultiplyScalarInto(dest, a, scalar); return; }
-        // Compute on GPU, copy result directly into dest's contiguous span
-        var scalarF = ToFloatScalar(scalar);
-        var result = TryRunScalar(a.GetDataArray(), scalar,
-            static (backend, input, output, value, size) => backend.Scale(input, output, value, size));
-        if (result != null)
-        {
-            result.AsSpan(0, Math.Min(result.Length, dest.Length)).CopyTo(dest.Data.Span);
+        if (TryRunScalarInto(dest, a, scalar,
+            static (backend, input, output, value, size) => backend.Scale(input, output, value, size)))
             return;
-        }
         base.TensorMultiplyScalarInto(dest, a, scalar);
     }
 
@@ -6398,6 +6559,10 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// </summary>
     public new void RegisterPersistentTensor<T>(Tensor<T> tensor, PersistentTensorRole role)
     {
+        if (tensor == null) throw new ArgumentNullException(nameof(tensor));
+        if (tensor.IsSparse)
+            return;
+
         base.RegisterPersistentTensor(tensor, role);
 
         if (!TryGetBackend(out var backend))
@@ -6432,15 +6597,25 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// </summary>
     public new void UnregisterPersistentTensor<T>(Tensor<T> tensor)
     {
+        if (tensor == null) throw new ArgumentNullException(nameof(tensor));
+        if (tensor.IsSparse)
+        {
+            RemoveCsrBufferCacheForSparse(tensor);
+            return;
+        }
+
         base.UnregisterPersistentTensor(tensor);
 
         object key = tensor.GetDataArray();
 
-        if (_persistentBufferCache.TryRemove(key, out var entry))
+        lock (_persistentBufferLock)
         {
-            entry.Dispose();
+            if (_persistentBufferCache.TryRemove(key, out var entry))
+            {
+                entry.Dispose();
+            }
+            _tensorVersions.TryRemove(key, out _);
         }
-        _tensorVersions.TryRemove(key, out _);
     }
 
     /// <summary>
@@ -6449,6 +6624,13 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// </summary>
     public new void InvalidatePersistentTensor<T>(Tensor<T> tensor)
     {
+        if (tensor == null) throw new ArgumentNullException(nameof(tensor));
+        if (tensor.IsSparse)
+        {
+            RemoveCsrBufferCacheForSparse(tensor);
+            return;
+        }
+
         base.InvalidatePersistentTensor(tensor);
 
         if (!TryGetBackend(out var backend))
@@ -6495,6 +6677,18 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             return entry.Buffer;
         }
         return null;
+    }
+
+    private void RemoveCsrBufferCacheForSparse(object sparse)
+    {
+        foreach (var pair in _csrBufferCache.ToArray())
+        {
+            if (!pair.Key.MatchesSparse(sparse))
+                continue;
+
+            if (_csrBufferCache.TryRemove(pair.Key, out var entry))
+                entry.Dispose();
+        }
     }
 
     /// <summary>
@@ -14681,8 +14875,64 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         return base.TensorRandomUniform<T>(shape);
     }
 
+    Tensor<T> IEngine.TensorRandomUniformRange<T>(int[] shape, T min, T max, int? seed)
+    {
+        if (shape == null) throw new ArgumentNullException(nameof(shape));
+        if (TryGetBackend(out var b))
+        {
+            try
+            {
+                int total = 1;
+                foreach (var d in shape) total *= d;
+                var go = b.AllocateBuffer(total);
+                ulong gpuSeed = seed.HasValue
+                    ? (ulong)(uint)seed.Value
+                    : (ulong)System.Threading.Interlocked.Increment(ref _gpuRngSeed);
+                b.GenerateRandomUniform(go, total, ToFloatScalar(min), ToFloatScalar(max), gpuSeed);
+                return DeferTensorResult<T>(b, go, total, shape);
+            }
+            catch { }
+        }
+        return base.TensorRandomUniformRange(shape, min, max, seed);
+    }
+
+    void IEngine.TensorRandomUniformRangeInto<T>(Tensor<T> destination, T min, T max, int? seed)
+    {
+        if (destination == null) throw new ArgumentNullException(nameof(destination));
+        if (TryGetBackend(out var b) &&
+            TryGetSimpleCpuDestinationArray(destination, destination.Length, out var destinationArray))
+        {
+            try
+            {
+                var go = AllocateOutputBuffer(b, destination.Length);
+                try
+                {
+                    ulong gpuSeed = seed.HasValue
+                        ? (ulong)(uint)seed.Value
+                        : (ulong)System.Threading.Interlocked.Increment(ref _gpuRngSeed);
+                    b.GenerateRandomUniform(go.Buffer, destination.Length, ToFloatScalar(min), ToFloatScalar(max), gpuSeed);
+                    DownloadGpuBufferInto(b, go, destinationArray, destination.Length);
+                    return;
+                }
+                catch
+                {
+                    go.Dispose();
+                    throw;
+                }
+            }
+            catch (AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex)
+            {
+                HandleBufferTooLarge<T>(ex, nameof(IEngine.TensorRandomUniformRangeInto));
+            }
+            catch { }
+        }
+
+        base.TensorRandomUniformRangeInto(destination, min, max, seed);
+    }
+
     Tensor<T> IEngine.TensorRandomNormal<T>(int[] shape, T mean, T stddev)
     {
+        if (shape == null) throw new ArgumentNullException(nameof(shape));
         if (TryGetBackend(out var b))
         {
             try
@@ -14696,6 +14946,42 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             catch { }
         }
         return base.TensorRandomNormal(shape, mean, stddev);
+    }
+
+    void IEngine.TensorRandomNormalInto<T>(Tensor<T> destination, T mean, T stddev)
+    {
+        if (destination == null) throw new ArgumentNullException(nameof(destination));
+        if (TryGetBackend(out var b) &&
+            TryGetSimpleCpuDestinationArray(destination, destination.Length, out var destinationArray))
+        {
+            try
+            {
+                var go = AllocateOutputBuffer(b, destination.Length);
+                try
+                {
+                    b.GenerateRandomNormal(
+                        go.Buffer,
+                        destination.Length,
+                        ToFloatScalar(mean),
+                        ToFloatScalar(stddev),
+                        (ulong)System.Threading.Interlocked.Increment(ref _gpuRngSeed));
+                    DownloadGpuBufferInto(b, go, destinationArray, destination.Length);
+                    return;
+                }
+                catch
+                {
+                    go.Dispose();
+                    throw;
+                }
+            }
+            catch (AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex)
+            {
+                HandleBufferTooLarge<T>(ex, nameof(IEngine.TensorRandomNormalInto));
+            }
+            catch { }
+        }
+
+        base.TensorRandomNormalInto(destination, mean, stddev);
     }
 
     Tensor<T> IEngine.ReduceSum<T>(Tensor<T> tensor, int[]? axes, bool keepDims)

--- a/src/AiDotNet.Tensors/Engines/Distributed/ElasticLauncher.cs
+++ b/src/AiDotNet.Tensors/Engines/Distributed/ElasticLauncher.cs
@@ -347,15 +347,46 @@ public sealed class ElasticLauncher
                     $"Saw {nonces.Count} of {_options.WorldSize} workers.");
             // Wait up to 250ms for the next connection so we can re-check the deadline.
             if (!WaitForConnection(listener, TimeSpan.FromMilliseconds(250))) continue;
-            var client = listener.AcceptTcpClient();
-            client.NoDelay = true;
-            var stream = client.GetStream();
-            string nonce = ReadLine(stream);
-            nonces.Add(nonce);
-            // Hold this client open until we've collected all nonces, then
-            // reply. The stream + client are explicitly disposed in the
-            // reply loop below — DO NOT use a `using` here.
-            clientReplies.Add(new TcpReply(client, stream, nonce));
+
+            // A connection arriving on the listener is NOT necessarily a real
+            // worker. Causes of stray connections we must tolerate:
+            //   - A client whose ConnectAsync.Wait deemed itself timed-out and
+            //     disposed the socket, while the OS-level handshake had
+            //     already completed — the coordinator sees connect+RST.
+            //   - Slow CI runners where a client retries after a transient
+            //     SocketException, leaving an orphan half-opened socket.
+            //   - Port scanners / health checks on shared CI loopback.
+            // A bad connection MUST NOT crash the whole rendezvous — it kills
+            // every other worker that was waiting at the barrier. Catch the
+            // I/O failure, dispose the bad client, and keep waiting. We give
+            // each accept a bounded read window via stream.ReadTimeout so a
+            // peer that connects then never writes can't stall the coordinator
+            // past the rendezvous deadline.
+            TcpClient? client = null;
+            NetworkStream? stream = null;
+            try
+            {
+                client = listener.AcceptTcpClient();
+                client.NoDelay = true;
+                stream = client.GetStream();
+                int remainingMs = (int)Math.Max(1000, (deadline - DateTime.UtcNow).TotalMilliseconds);
+                stream.ReadTimeout = remainingMs;
+                string nonce = ReadLine(stream);
+                nonces.Add(nonce);
+                // Hold this client open until we've collected all nonces, then
+                // reply. The stream + client are explicitly disposed in the
+                // reply loop below — DO NOT use a `using` here.
+                clientReplies.Add(new TcpReply(client, stream, nonce));
+                client = null; stream = null; // ownership transferred
+            }
+            catch (Exception ex) when (ex is IOException || ex is System.Net.Sockets.SocketException)
+            {
+                // Stray / aborted connection — log and resume the accept loop.
+                System.Diagnostics.Debug.WriteLine(
+                    $"[TcpCoordinator] dropping stray connection: {ex.GetType().Name}: {ex.Message}");
+                stream?.Dispose();
+                client?.Dispose();
+            }
         }
 
         // Sort + assign ranks.
@@ -392,17 +423,34 @@ public sealed class ElasticLauncher
         Exception? lastError = null;
         while (DateTime.UtcNow < deadline)
         {
+            // Don't use `using` here: when ConnectAsync.Wait deems itself
+            // timed-out, the OS-level handshake may have actually completed
+            // during the wait. A `using` Dispose on a half-connected client
+            // sends a stray FIN/RST to the coordinator that gets accepted as
+            // an orphan connection. Track ownership manually and force the
+            // socket closed *before* we drop the reference, so the
+            // coordinator's accept loop sees a hard close instead of a
+            // half-open handshake it has to read from.
+            TcpClient? client = null;
+            NetworkStream? stream = null;
             try
             {
-                using var client = new TcpClient();
+                client = new TcpClient();
                 var connectTask = client.ConnectAsync(host, port);
                 if (!connectTask.Wait((int)Math.Min(2000, (deadline - DateTime.UtcNow).TotalMilliseconds)))
                 {
+                    // Connect timed out from our perspective. If the OS-level
+                    // handshake races to completion right after we give up,
+                    // forcibly close instead of letting a half-connected
+                    // socket reach the coordinator's accept queue.
+                    try { client.Client?.Close(0); } catch { /* best-effort */ }
+                    client.Dispose();
+                    client = null;
                     Thread.Sleep(50);
                     continue;
                 }
                 client.NoDelay = true;
-                using var stream = client.GetStream();
+                stream = client.GetStream();
                 stream.ReadTimeout = (int)Math.Max(1000, (deadline - DateTime.UtcNow).TotalMilliseconds);
                 WriteLine(stream, workerNonce);
                 string reply = ReadLine(stream);
@@ -424,6 +472,16 @@ public sealed class ElasticLauncher
             }
             catch (SocketException ex) { lastError = ex; Thread.Sleep(50); }
             catch (IOException ex) { lastError = ex; Thread.Sleep(50); }
+            finally
+            {
+                // Always release the per-iteration socket — runs on the
+                // success-return path too (finally runs before the return
+                // value reaches the caller). The continue-on-timeout branch
+                // sets client to null after manual close, so this is a no-op
+                // there.
+                stream?.Dispose();
+                client?.Dispose();
+            }
         }
         throw new TimeoutException(
             $"TCP rendezvous client could not reach coordinator at {host}:{port} within " +

--- a/src/AiDotNet.Tensors/Engines/Distributed/ElasticLauncher.cs
+++ b/src/AiDotNet.Tensors/Engines/Distributed/ElasticLauncher.cs
@@ -437,7 +437,11 @@ public sealed class ElasticLauncher
             {
                 client = new TcpClient();
                 var connectTask = client.ConnectAsync(host, port);
-                if (!connectTask.Wait((int)Math.Min(2000, (deadline - DateTime.UtcNow).TotalMilliseconds)))
+                // Floor at 1ms so a deadline that elapses between the while-
+                // check and here doesn't pass a negative timeout to Wait()
+                // (which throws ArgumentOutOfRangeException for values < -1).
+                int connectWaitMs = (int)Math.Max(1, Math.Min(2000, (deadline - DateTime.UtcNow).TotalMilliseconds));
+                if (!connectTask.Wait(connectWaitMs))
                 {
                     // Connect timed out from our perspective. If the OS-level
                     // handshake races to completion right after we give up,

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -5841,6 +5841,19 @@ public interface IEngine
     Tensor<T> TensorRandomNormal<T>(int[] shape, T mean, T stddev);
 
     /// <summary>
+    /// Fills an existing tensor with random values from a normal distribution.
+    /// </summary>
+    /// <typeparam name="T">The numeric type of tensor elements.</typeparam>
+    /// <param name="destination">The tensor to fill in-place.</param>
+    /// <param name="mean">The mean of the distribution.</param>
+    /// <param name="stddev">The standard deviation of the distribution.</param>
+    /// <remarks>
+    /// Use this for weight initialization when the tensor identity must be preserved,
+    /// for example persistent/streaming weights registered before first forward.
+    /// </remarks>
+    void TensorRandomNormalInto<T>(Tensor<T> destination, T mean, T stddev);
+
+    /// <summary>
     /// Generates a tensor filled with random values from a uniform distribution within a specified range.
     /// </summary>
     /// <typeparam name="T">The numeric type of tensor elements.</typeparam>
@@ -5858,6 +5871,20 @@ public interface IEngine
     /// </para>
     /// </remarks>
     Tensor<T> TensorRandomUniformRange<T>(int[] shape, T min, T max, int? seed = null);
+
+    /// <summary>
+    /// Fills an existing tensor with random values from a uniform distribution within a specified range.
+    /// </summary>
+    /// <typeparam name="T">The numeric type of tensor elements.</typeparam>
+    /// <param name="destination">The tensor to fill in-place.</param>
+    /// <param name="min">The minimum value (inclusive).</param>
+    /// <param name="max">The maximum value (exclusive).</param>
+    /// <param name="seed">Optional random seed for reproducibility.</param>
+    /// <remarks>
+    /// Use this for weight initialization when the tensor identity must be preserved,
+    /// for example persistent/streaming weights registered before first forward.
+    /// </remarks>
+    void TensorRandomUniformRangeInto<T>(Tensor<T> destination, T min, T max, int? seed = null);
 
     /// <summary>
     /// Generates a dropout mask tensor where each element is either zero or a scale value.

--- a/tests/AiDotNet.Tensors.Benchmarks/BaselineRunners/py/issue305_pytorch_gpu_init.py
+++ b/tests/AiDotNet.Tensors.Benchmarks/BaselineRunners/py/issue305_pytorch_gpu_init.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""PyTorch GPU random-initialization benchmark for AiDotNet.Tensors issue #305.
+
+Backend selection:
+- CUDA is used when torch.cuda is available.
+- DirectML is used when torch-directml is installed, which is the expected
+  PyTorch GPU route for AMD GPUs on Windows.
+
+The benchmark measures in-place uniform_ and normal_ initialization on an
+already-allocated tensor. CUDA timings use torch.cuda.Event. DirectML does not
+expose an event/synchronize API, so the script uses a one-element CPU read to
+force completion and reports that timing as synchronized wall-clock time.
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import sys
+import time
+from typing import Callable
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="PyTorch GPU init benchmark for issue #305")
+    parser.add_argument("--elements", nargs="+", type=int, default=[1_000_000, 16_777_216])
+    parser.add_argument("--runs", type=int, default=50)
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--min", type=float, default=-0.05)
+    parser.add_argument("--max", type=float, default=0.05)
+    parser.add_argument("--stddev", type=float, default=0.02)
+    parser.add_argument("--device", choices=["auto", "cuda", "directml"], default="auto")
+    return parser.parse_args()
+
+
+def select_device(requested: str):
+    import torch
+
+    if requested in ("auto", "cuda") and torch.cuda.is_available():
+        return torch.device("cuda"), "cuda"
+
+    if requested in ("auto", "directml"):
+        try:
+            import torch_directml  # type: ignore
+        except Exception as exc:
+            if requested == "directml":
+                raise RuntimeError("torch-directml is not installed or failed to import") from exc
+        else:
+            return torch_directml.device(), "directml"
+
+    raise RuntimeError(
+        "No PyTorch GPU backend is available. Install a CUDA build of torch for NVIDIA, "
+        "or install torch-directml for AMD/Intel GPUs on Windows."
+    )
+
+
+def synchronize(backend: str, tensor) -> None:
+    if backend == "cuda":
+        import torch
+
+        torch.cuda.synchronize(tensor.device)
+        return
+
+    if backend == "directml":
+        # torch-directml currently has no public synchronize/event timer.
+        # A scalar read forces queued work to complete and keeps transfer size tiny.
+        _ = tensor[0].detach().cpu().item()
+        return
+
+    raise RuntimeError(f"Unknown backend: {backend}")
+
+
+def measure_cuda(tensor, runs: int, action: Callable[[int], None]) -> list[float]:
+    import torch
+
+    timings: list[float] = []
+    for run in range(runs):
+        start = torch.cuda.Event(enable_timing=True)
+        stop = torch.cuda.Event(enable_timing=True)
+        start.record()
+        action(run)
+        stop.record()
+        torch.cuda.synchronize(tensor.device)
+        timings.append(float(start.elapsed_time(stop)))
+    return timings
+
+
+def measure_wall_clock(backend: str, tensor, runs: int, action: Callable[[int], None]) -> list[float]:
+    timings: list[float] = []
+    for run in range(runs):
+        start = time.perf_counter()
+        action(run)
+        synchronize(backend, tensor)
+        stop = time.perf_counter()
+        timings.append((stop - start) * 1000.0)
+    return timings
+
+
+def summarize(method: str, elements: int, timings: list[float]) -> None:
+    timings = sorted(timings)
+    mean_ms = statistics.fmean(timings)
+    median_ms = statistics.median(timings)
+    gbps = elements * 4 / (mean_ms / 1000.0) / 1_000_000_000.0
+    print(
+        f"{method:<32} {elements:>12,d} {mean_ms:>10.4f} "
+        f"{median_ms:>10.4f} {timings[0]:>10.4f} {timings[-1]:>10.4f} {gbps:>10.2f}"
+    )
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        import torch
+    except Exception as exc:
+        print(f"FAILED: could not import torch: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        device, backend = select_device(args.device)
+    except Exception as exc:
+        print(f"FAILED: {exc}", file=sys.stderr)
+        print(f"torch version: {torch.__version__}", file=sys.stderr)
+        print(f"torch.cuda.is_available: {torch.cuda.is_available()}", file=sys.stderr)
+        return 3
+
+    torch.set_grad_enabled(False)
+    print("Issue #305 PyTorch GPU initialization benchmark")
+    print(f"torch:   {torch.__version__}")
+    print(f"backend: {backend}")
+    print(f"device:  {device}")
+    if backend == "cuda":
+        print(f"name:    {torch.cuda.get_device_name(device)}")
+    print("Timing is synchronized; DirectML includes a one-element readback sync.")
+    print()
+    print(f"{'Method':<32} {'Elements':>12} {'Mean ms':>10} {'Median ms':>10} {'Min ms':>10} {'Max ms':>10} {'GB/s':>10}")
+    print("-" * 98)
+
+    for elements in args.elements:
+        tensor = torch.empty((elements,), dtype=torch.float32, device=device)
+
+        for _ in range(args.warmup):
+            tensor.uniform_(args.min, args.max)
+            tensor.normal_(0.0, args.stddev)
+        synchronize(backend, tensor)
+
+        uniform_action = lambda _run: tensor.uniform_(args.min, args.max)
+        normal_action = lambda _run: tensor.normal_(0.0, args.stddev)
+
+        if backend == "cuda":
+            uniform_timings = measure_cuda(tensor, args.runs, uniform_action)
+            normal_timings = measure_cuda(tensor, args.runs, normal_action)
+        else:
+            uniform_timings = measure_wall_clock(backend, tensor, args.runs, uniform_action)
+            normal_timings = measure_wall_clock(backend, tensor, args.runs, normal_action)
+
+        summarize("PyTorch GPU uniform_", elements, uniform_timings)
+        summarize("PyTorch GPU normal_", elements, normal_timings)
+        print()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/AiDotNet.Tensors.Benchmarks/BaselineRunners/py/issue305_pytorch_gpu_init.py
+++ b/tests/AiDotNet.Tensors.Benchmarks/BaselineRunners/py/issue305_pytorch_gpu_init.py
@@ -30,7 +30,21 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--max", type=float, default=0.05)
     parser.add_argument("--stddev", type=float, default=0.02)
     parser.add_argument("--device", choices=["auto", "cuda", "directml"], default="auto")
-    return parser.parse_args()
+    args = parser.parse_args()
+
+    if args.runs <= 0:
+        parser.error("--runs must be > 0 (need at least one timed sample for median)")
+    if args.warmup < 0:
+        parser.error("--warmup must be >= 0")
+    if args.stddev < 0:
+        parser.error("--stddev must be >= 0")
+    if args.max < args.min:
+        parser.error(f"--max ({args.max}) must be >= --min ({args.min})")
+    for e in args.elements:
+        if e <= 0:
+            parser.error(f"--elements values must be > 0 (got {e})")
+
+    return args
 
 
 def select_device(requested: str):

--- a/tests/AiDotNet.Tensors.Benchmarks/Issue305FirstForwardInitBenchmarks.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Issue305FirstForwardInitBenchmarks.cs
@@ -1,0 +1,82 @@
+#if NET8_0_OR_GREATER
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Jobs;
+using TorchSharp;
+using TorchTensor = TorchSharp.torch.Tensor;
+
+namespace AiDotNet.Tensors.Benchmarks;
+
+[SimpleJob(RuntimeMoniker.Net10_0, launchCount: 1, warmupCount: 5, iterationCount: 15)]
+[MemoryDiagnoser]
+[MarkdownExporterAttribute.GitHub]
+public class Issue305FirstForwardInitBenchmarks
+{
+    private const float Min = -0.05f;
+    private const float Max = 0.05f;
+    private const float StdDev = 0.02f;
+
+    private readonly Consumer _consumer = new();
+    private CpuEngine _engine = null!;
+    private Tensor<float> _destination = null!;
+    private TorchTensor _torchDestination = null!;
+
+    [Params(1_000_000, 16_777_216)]
+    public int Elements { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new CpuEngine();
+        _destination = new Tensor<float>([Elements]);
+
+        torch.set_grad_enabled(false);
+        torch.set_num_threads(Environment.ProcessorCount);
+        _torchDestination = torch.empty([Elements], device: torch.CPU);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _torchDestination.Dispose();
+    }
+
+    [Benchmark(Baseline = true)]
+    public void AiDotNet_OldRandomUniformRangeThenCopy()
+    {
+        var random = _engine.TensorRandomUniformRange<float>([Elements], Min, Max);
+        random.AsSpan().CopyTo(_destination.AsWritableSpan());
+        _consumer.Consume(_destination);
+    }
+
+    [Benchmark]
+    public void AiDotNet_RandomUniformRangeInto()
+    {
+        _engine.TensorRandomUniformRangeInto(_destination, Min, Max);
+        _consumer.Consume(_destination);
+    }
+
+    [Benchmark]
+    public void AiDotNet_RandomNormalInto()
+    {
+        _engine.TensorRandomNormalInto(_destination, 0f, StdDev);
+        _consumer.Consume(_destination);
+    }
+
+    [Benchmark]
+    public void TorchSharp_UniformInPlace()
+    {
+        _torchDestination.uniform_(Min, Max);
+        _consumer.Consume(_torchDestination);
+    }
+
+    [Benchmark]
+    public void TorchSharp_NormalInPlace()
+    {
+        _torchDestination.normal_(0.0, StdDev);
+        _consumer.Consume(_torchDestination);
+    }
+}
+#endif

--- a/tests/AiDotNet.Tensors.Benchmarks/Issue305GpuInitBenchmark.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Issue305GpuInitBenchmark.cs
@@ -86,9 +86,17 @@ public static class Issue305GpuInitBenchmark
         foreach (double timing in timings)
             sum += timing;
 
+        // Even-N median is the average of the two middle samples; previously
+        // we used timings[length/2] (upper-middle only) which biases the
+        // median upward for even sample counts.
+        int n = timings.Length;
+        double median = (n % 2 == 1)
+            ? timings[n / 2]
+            : 0.5 * (timings[(n / 2) - 1] + timings[n / 2]);
+
         return new Stats(
-            MeanMs: sum / timings.Length,
-            MedianMs: timings[timings.Length / 2],
+            MeanMs: sum / n,
+            MedianMs: median,
             MinMs: timings[0],
             MaxMs: timings[^1]);
     }

--- a/tests/AiDotNet.Tensors.Benchmarks/Issue305GpuInitBenchmark.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Issue305GpuInitBenchmark.cs
@@ -1,0 +1,134 @@
+#if NET8_0_OR_GREATER
+using System.Diagnostics;
+using AiDotNet.Tensors.Engines.DirectGpu;
+
+namespace AiDotNet.Tensors.Benchmarks;
+
+public static class Issue305GpuInitBenchmark
+{
+    private const float Min = -0.05f;
+    private const float Max = 0.05f;
+    private const float StdDev = 0.02f;
+    private static readonly int[] ElementCounts = [1_000_000, 16_777_216];
+
+    public static void Run()
+    {
+        using var engine = new DirectGpuEngine();
+        if (!engine.IsAvailable || engine.Backend is null)
+        {
+            Console.WriteLine("DirectGPU is not available; cannot run Issue305 GPU initialization benchmark.");
+            Console.WriteLine($"Backend: {engine.BackendName}");
+            Console.WriteLine($"Device:  {engine.DeviceName}");
+            return;
+        }
+
+        var backend = engine.Backend;
+        Console.WriteLine("Issue #305 GPU initialization benchmark");
+        Console.WriteLine($"Backend: {engine.BackendName}");
+        Console.WriteLine($"Device:  {engine.DeviceName}");
+        Console.WriteLine($"Vendor:  {engine.DeviceVendor}");
+        Console.WriteLine($"Compute: {engine.ComputeUnits} CUs, {engine.GlobalMemoryGB:F2} GB global memory");
+        Console.WriteLine("Timing includes kernel dispatch plus backend.Synchronize(); it excludes allocation and host download.");
+        Console.WriteLine();
+        Console.WriteLine($"{"Method",-32} {"Elements",12} {"Mean ms",10} {"Median ms",10} {"Min ms",10} {"Max ms",10} {"GB/s",10}");
+        Console.WriteLine(new string('-', 98));
+
+        foreach (int elements in ElementCounts)
+        {
+            using var output = backend.AllocateBuffer(elements);
+
+            Warmup(backend, output, elements);
+
+            var uniform = Measure(
+                runs: 50,
+                action: run => backend.GenerateRandomUniform(output, elements, Min, Max, (ulong)(305_000 + run)),
+                synchronize: backend.Synchronize);
+            Print("AiDotNet GPU uniform", elements, uniform);
+
+            ValidateUniform(backend, output, elements);
+
+            var normal = Measure(
+                runs: 50,
+                action: run => backend.GenerateRandomNormal(output, elements, 0f, StdDev, (ulong)(405_000 + run)),
+                synchronize: backend.Synchronize);
+            Print("AiDotNet GPU normal", elements, normal);
+
+            ValidateNormal(backend, output, elements);
+            Console.WriteLine();
+        }
+    }
+
+    private static void Warmup(IDirectGpuBackend backend, IGpuBuffer output, int elements)
+    {
+        for (int i = 0; i < 10; i++)
+        {
+            backend.GenerateRandomUniform(output, elements, Min, Max, (ulong)(10_000 + i));
+            backend.GenerateRandomNormal(output, elements, 0f, StdDev, (ulong)(20_000 + i));
+        }
+
+        backend.Synchronize();
+    }
+
+    private static Stats Measure(int runs, Action<int> action, Action synchronize)
+    {
+        var timings = new double[runs];
+        for (int i = 0; i < runs; i++)
+        {
+            long start = Stopwatch.GetTimestamp();
+            action(i);
+            synchronize();
+            long stop = Stopwatch.GetTimestamp();
+            timings[i] = (stop - start) * 1000.0 / Stopwatch.Frequency;
+        }
+
+        Array.Sort(timings);
+        double sum = 0;
+        foreach (double timing in timings)
+            sum += timing;
+
+        return new Stats(
+            MeanMs: sum / timings.Length,
+            MedianMs: timings[timings.Length / 2],
+            MinMs: timings[0],
+            MaxMs: timings[^1]);
+    }
+
+    private static void Print(string method, int elements, Stats stats)
+    {
+        double bytes = elements * sizeof(float);
+        double gbPerSecond = bytes / (stats.MeanMs / 1000.0) / 1_000_000_000.0;
+        Console.WriteLine($"{method,-32} {elements,12:N0} {stats.MeanMs,10:F4} {stats.MedianMs,10:F4} {stats.MinMs,10:F4} {stats.MaxMs,10:F4} {gbPerSecond,10:F2}");
+    }
+
+    private static void ValidateUniform(IDirectGpuBackend backend, IGpuBuffer output, int elements)
+    {
+        var sample = backend.DownloadBuffer(output);
+        int checkedCount = Math.Min(elements, 4096);
+        for (int i = 0; i < checkedCount; i++)
+        {
+            float value = sample[i];
+            if (float.IsNaN(value) || value < Min || value > Max)
+                throw new InvalidOperationException($"Uniform GPU initialization produced invalid value {value} at index {i}.");
+        }
+    }
+
+    private static void ValidateNormal(IDirectGpuBackend backend, IGpuBuffer output, int elements)
+    {
+        var sample = backend.DownloadBuffer(output);
+        int checkedCount = Math.Min(elements, 4096);
+        bool sawNonZero = false;
+        for (int i = 0; i < checkedCount; i++)
+        {
+            float value = sample[i];
+            if (float.IsNaN(value) || float.IsInfinity(value))
+                throw new InvalidOperationException($"Normal GPU initialization produced invalid value {value} at index {i}.");
+            sawNonZero |= value != 0f;
+        }
+
+        if (!sawNonZero)
+            throw new InvalidOperationException("Normal GPU initialization produced only zeros in the validation sample.");
+    }
+
+    private readonly record struct Stats(double MeanMs, double MedianMs, double MinMs, double MaxMs);
+}
+#endif

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -275,6 +275,12 @@ class Program
             return;
         }
 
+        if (args[0] == "--305-init-gpu")
+        {
+            Issue305GpuInitBenchmark.Run();
+            return;
+        }
+
         // Run competitive benchmarks vs TensorFlow (GPU)
         if (args[0] == "--vs-tensorflow-gpu")
         {
@@ -485,6 +491,7 @@ class Program
         Console.WriteLine("  --296-throughput    : Multi-batch pipelined throughput vs PyTorch (NumBatches=8/32)");
         Console.WriteLine("  --296-diffusion     : 50-step denoising loop vs PyTorch nn.Sequential");
         Console.WriteLine("  --305-init          : First-forward weight-init peak benchmark vs old temp+copy and TorchSharp");
+        Console.WriteLine("  --305-init-gpu      : GPU random initialization benchmark for Issue #305");
 #endif
     }
 }

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -269,6 +269,12 @@ class Program
             return;
         }
 
+        if (args[0] == "--305-init")
+        {
+            BenchmarkRunner.Run<Issue305FirstForwardInitBenchmarks>(BenchConfig);
+            return;
+        }
+
         // Run competitive benchmarks vs TensorFlow (GPU)
         if (args[0] == "--vs-tensorflow-gpu")
         {
@@ -478,6 +484,7 @@ class Program
         Console.WriteLine("  --296-chain         : Single-batch latency vs PyTorch (BS=1/32/128, two-stage Linear→ReLU→Linear)");
         Console.WriteLine("  --296-throughput    : Multi-batch pipelined throughput vs PyTorch (NumBatches=8/32)");
         Console.WriteLine("  --296-diffusion     : 50-step denoising loop vs PyTorch nn.Sequential");
+        Console.WriteLine("  --305-init          : First-forward weight-init peak benchmark vs old temp+copy and TorchSharp");
 #endif
     }
 }

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -269,6 +269,7 @@ class Program
             return;
         }
 
+#if NET8_0_OR_GREATER
         if (args[0] == "--305-init")
         {
             BenchmarkRunner.Run<Issue305FirstForwardInitBenchmarks>(BenchConfig);
@@ -280,6 +281,7 @@ class Program
             Issue305GpuInitBenchmark.Run();
             return;
         }
+#endif
 
         // Run competitive benchmarks vs TensorFlow (GPU)
         if (args[0] == "--vs-tensorflow-gpu")
@@ -490,8 +492,10 @@ class Program
         Console.WriteLine("  --296-chain         : Single-batch latency vs PyTorch (BS=1/32/128, two-stage Linear→ReLU→Linear)");
         Console.WriteLine("  --296-throughput    : Multi-batch pipelined throughput vs PyTorch (NumBatches=8/32)");
         Console.WriteLine("  --296-diffusion     : 50-step denoising loop vs PyTorch nn.Sequential");
+#if NET8_0_OR_GREATER
         Console.WriteLine("  --305-init          : First-forward weight-init peak benchmark vs old temp+copy and TorchSharp");
         Console.WriteLine("  --305-init-gpu      : GPU random initialization benchmark for Issue #305");
+#endif
 #endif
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Issue305DestinationAwareInitTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Issue305DestinationAwareInitTests.cs
@@ -1,0 +1,101 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+public class Issue305DestinationAwareInitTests
+{
+    private readonly CpuEngine _engine = new();
+
+    [Fact]
+    public void TensorRandomUniformRangeInto_FillsExistingDestination()
+    {
+        var destination = new Tensor<float>(Enumerable.Repeat(-1f, 64).ToArray(), [64]);
+
+        _engine.TensorRandomUniformRangeInto(destination, -0.25f, 0.25f, seed: 305);
+
+        var values = destination.ToArray();
+        Assert.All(values, value => Assert.InRange(value, -0.25f, 0.25f));
+        Assert.Contains(values, value => value != -1f);
+    }
+
+    [Fact]
+    public void TensorRandomNormalInto_FillsExistingDestination()
+    {
+        var destination = new Tensor<float>(Enumerable.Repeat(float.NaN, 128).ToArray(), [128]);
+
+        _engine.TensorRandomNormalInto(destination, 0f, 1f);
+
+        var values = destination.ToArray();
+        Assert.All(values, value => Assert.False(float.IsNaN(value)));
+        Assert.Contains(values, value => value != 0f);
+    }
+
+    [Fact]
+    public void TensorRandomUniformRangeInto_UsesStrideAwareDestination()
+    {
+        var backing = new Tensor<float>(Enumerable.Repeat(-7f, 12).ToArray(), [3, 4]);
+        var destination = backing.Transpose(new[] { 1, 0 });
+        Assert.False(destination.IsContiguous);
+
+        _engine.TensorRandomUniformRangeInto(destination, 1f, 2f, seed: 305);
+
+        var values = destination.ToArray();
+        Assert.All(values, value => Assert.InRange(value, 1f, 2f));
+        Assert.DoesNotContain(-7f, backing.ToArray());
+    }
+
+    [Fact]
+    public void TensorSubtractInto_KeepsOriginalDestinationFirstSignature()
+    {
+        var destination = new Tensor<float>(new float[3], [3]);
+        var a = new Tensor<float>(new[] { 10f, 20f, 30f }, [3]);
+        var b = new Tensor<float>(new[] { 1f, 2f, 3f }, [3]);
+
+        _engine.TensorSubtractInto(destination, a, b);
+
+        Assert.Equal(new[] { 9f, 18f, 27f }, destination.ToArray());
+    }
+
+    [Fact]
+    public void TensorSubtractInto_UsesStrideAwareDestination()
+    {
+        var backing = new Tensor<float>(new float[6], [2, 3]);
+        var destination = backing.Transpose(new[] { 1, 0 });
+        var a = new Tensor<float>(new[] { 10f, 20f, 30f, 40f, 50f, 60f }, [3, 2]);
+        var b = new Tensor<float>(new[] { 1f, 2f, 3f, 4f, 5f, 6f }, [3, 2]);
+
+        _engine.TensorSubtractInto(destination, a, b);
+
+        Assert.Equal(new[] { 9f, 18f, 27f, 36f, 45f, 54f }, destination.ToArray());
+    }
+
+    [Fact]
+    public void TensorMultiplyScalarInto_UsesStrideAwareSourceAndDestination()
+    {
+        var sourceBacking = new Tensor<float>(new[] { 1f, 2f, 3f, 4f, 5f, 6f }, [2, 3]);
+        var source = sourceBacking.Transpose(new[] { 1, 0 });
+        var destinationBacking = new Tensor<float>(new float[6], [2, 3]);
+        var destination = destinationBacking.Transpose(new[] { 1, 0 });
+
+        _engine.TensorMultiplyScalarInto(destination, source, 3f);
+
+        Assert.Equal(new[] { 3f, 12f, 6f, 15f, 9f, 18f }, destination.ToArray());
+    }
+
+    [Fact]
+    public void PersistentTensorManagement_DoesNotDensifySparseTensor()
+    {
+        var sparse = new SparseTensor<float>(
+            2,
+            2,
+            new[] { 0, 1 },
+            new[] { 1, 0 },
+            new[] { 3f, 4f });
+
+        _engine.RegisterPersistentTensor(sparse, PersistentTensorRole.Weights);
+        _engine.UnregisterPersistentTensor(sparse);
+        _engine.InvalidatePersistentTensor(sparse);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Issue305DestinationAwareInitTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Issue305DestinationAwareInitTests.cs
@@ -33,6 +33,19 @@ public class Issue305DestinationAwareInitTests
     }
 
     [Fact]
+    public void TensorRandomNormalInto_FillsLargeDestinationWithoutTempTensor()
+    {
+        var destination = new Tensor<float>(Enumerable.Repeat(float.NaN, 65_536).ToArray(), [65_536]);
+
+        _engine.TensorRandomNormalInto(destination, 0f, 1f);
+
+        var values = destination.ToArray();
+        Assert.All(values, value => Assert.True(!float.IsNaN(value) && !float.IsInfinity(value)));
+        Assert.Contains(values, value => value < 0f);
+        Assert.Contains(values, value => value > 0f);
+    }
+
+    [Fact]
     public void TensorRandomUniformRangeInto_UsesStrideAwareDestination()
     {
         var backing = new Tensor<float>(Enumerable.Repeat(-7f, 12).ToArray(), [3, 4]);


### PR DESCRIPTION
Fixes #305.

## What Changed

- Added destination-aware engine initialization paths so existing tensors can be filled in place instead of allocating a full temporary and copying into the registered destination.
- Kept the implementation on the existing engine process rather than introducing a new unrelated cache/API path.
- Added optimized normal initialization and GPU/OpenCL coverage for the first-forward peak-memory scenario.
- Added CPU and GPU benchmark coverage for the issue #305 initialization workload, including a raw Python PyTorch GPU baseline script where a GPU-enabled PyTorch install is available.

## Why

Issue #305 reports that first-forward initialization can allocate a same-size temporary and then copy into a registered/lazy/streaming tensor. For large tensors this creates a 2x peak memory spike and undermines the purpose of destination-preserving allocation.

## Validation

- Issue #305 destination-aware init tests were added on the branch.
- Issue #305 CPU/GPU benchmark harnesses were added on the branch.
- Later full solution validation on the stacked #304 branch passed with these #305 commits included: `dotnet build AiDotNet.Tensors.slnx -c Release --no-restore`.

## Notes

PR #306 for issue #304 was accidentally branched on top of this #305 branch. It is now being separated so #305 is reviewed independently and #304 is stacked on top of this branch instead of hiding #305 inside the #304 PR.