### PR TITLE
fix(#310): BatchNorm4D — size output buffer to logical extent, not padded

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -16250,10 +16250,22 @@ public partial class CpuEngine : ITensorLevelEngine
             float epsF = numOps.ToDouble(eps) is double d ? (float)d : 1e-5f;
             var meanF = new float[channels];
             var varF = new float[channels];
+            // Allocate the output buffer to the LOGICAL extent
+            // (batch * channels * H * W = input.Length), NOT to inF.Length.
+            // The underlying float[] returned by GetDataArray() is allowed
+            // to be SIMD-padded — e.g. for [1, 32, 112, 112] the logical
+            // extent is 401,408 but the padded buffer can be 524,288 (the
+            // next multiple of 32 spatial / 128 channel for AVX-friendly
+            // layouts). The inner BatchNorm4DFloat kernel iterates strictly
+            // in logical-index space (offset = n * channels * spatialSize
+            // + c * spatialSize), so the output only needs to hold the
+            // logical extent — and TensorAllocator.Rent(shape, data) below
+            // hard-asserts data.Length == product(shape). Issue #310.
+            int logicalLength = input.Length;
 #if NET5_0_OR_GREATER
-            var outF = GC.AllocateUninitializedArray<float>(inF.Length);
+            var outF = GC.AllocateUninitializedArray<float>(logicalLength);
 #else
-            var outF = new float[inF.Length];
+            var outF = new float[logicalLength];
 #endif
             BatchNorm4DFloat(inF, gamF, betF, epsF, batch, channels, spatialSize, meanF, varF, outF);
             mean = (Tensor<T>)(object)TensorAllocator.Rent<T>(new[] { channels }, (Vector<T>)(object)Vector<float>.FromMemory(meanF));

--- a/tests/AiDotNet.Tensors.Tests/Engines/BatchNorm4DPaddedDataTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BatchNorm4DPaddedDataTests.cs
@@ -1,0 +1,122 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Issue #310 regression — BatchNorm4D must accept input tensors whose
+// underlying data buffer is SIMD-padded beyond the logical extent (i.e.
+// every non-power-of-2 spatial chain in EfficientNet / MobileNetV2 /
+// MobileNetV3 224x224 inference).
+
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+public class BatchNorm4DPaddedDataTests
+{
+    private static (Tensor<float> input, Tensor<float> gamma, Tensor<float> beta) MakeInputs(
+        int batch, int channels, int height, int width, int seed)
+    {
+        var rng = new Random(seed);
+        var x = new Tensor<float>(new[] { batch, channels, height, width });
+        var span = x.AsWritableSpan();
+        for (int i = 0; i < span.Length; i++) span[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+        var gamma = new Tensor<float>(new[] { channels });
+        var beta = new Tensor<float>(new[] { channels });
+        var g = gamma.AsWritableSpan();
+        var b = beta.AsWritableSpan();
+        for (int c = 0; c < channels; c++) { g[c] = 1f; b[c] = 0f; }
+        return (x, gamma, beta);
+    }
+
+    /// <summary>
+    /// Issue #310 — every non-power-of-2 spatial chain in the canonical
+    /// 224 → 112 → 56 → 28 → 14 → 7 EfficientNet / MobileNet sequence
+    /// previously threw <c>ArgumentException: Data length (X) must match
+    /// shape total (Y)</c> from <c>TensorAllocator.Rent</c> because the
+    /// SIMD-padded data buffer (e.g. 524,288 elements for a [1, 32, 112, 112]
+    /// tensor) was being wrapped in a tensor whose logical shape totalled
+    /// only 401,408. The fix sized the output buffer to the logical
+    /// extent — these shapes must now run cleanly.
+    /// </summary>
+    [Theory]
+    [InlineData(1, 32, 112, 112)]
+    [InlineData(2, 32, 112, 112)]
+    [InlineData(4, 96, 112, 112)]
+    [InlineData(1, 16, 56, 56)]
+    [InlineData(2, 24, 28, 28)]
+    [InlineData(1, 40, 14, 14)]
+    [InlineData(1, 320, 7, 7)]
+    public void BatchNorm_RunsOnNonPowerOfTwoSpatialDims(int batch, int channels, int H, int W)
+    {
+        var engine = new CpuEngine();
+        var (x, gamma, beta) = MakeInputs(batch, channels, H, W, seed: 42);
+
+        var output = engine.BatchNorm(x, gamma, beta, 1e-5, out var mean, out var variance);
+
+        Assert.Equal(new[] { batch, channels, H, W }, output._shape);
+        Assert.Equal(new[] { channels }, mean._shape);
+        Assert.Equal(new[] { channels }, variance._shape);
+        Assert.Equal(batch * channels * H * W, output.Length);
+    }
+
+    /// <summary>
+    /// With gamma=1, beta=0 the BatchNorm output of each channel must
+    /// have mean ≈ 0 and variance ≈ 1 (modulo eps). This is the
+    /// definitional guarantee — it has to hold on padded-data inputs
+    /// just like everywhere else.
+    /// </summary>
+    [Theory]
+    [InlineData(1, 32, 112, 112)]
+    [InlineData(2, 96, 56, 56)]
+    public void BatchNorm_NormalizesEachChannelOnPaddedInputs(int batch, int channels, int H, int W)
+    {
+        var engine = new CpuEngine();
+        var (x, gamma, beta) = MakeInputs(batch, channels, H, W, seed: 7);
+
+        var output = engine.BatchNorm(x, gamma, beta, 1e-5, out _, out _);
+
+        var outSpan = output.AsSpan();
+        int spatialSize = H * W;
+        for (int c = 0; c < channels; c++)
+        {
+            double sum = 0, sumSq = 0;
+            int count = 0;
+            for (int n = 0; n < batch; n++)
+            {
+                int chBase = (n * channels + c) * spatialSize;
+                for (int s = 0; s < spatialSize; s++)
+                {
+                    double v = outSpan[chBase + s];
+                    sum += v;
+                    sumSq += v * v;
+                    count++;
+                }
+            }
+            double mean = sum / count;
+            double var = (sumSq / count) - mean * mean;
+            Assert.InRange(mean, -1e-3, 1e-3);
+            // Variance ≈ 1 modulo the epsilon-shifted invStd (allow 5% slop).
+            Assert.InRange(var, 1.0 - 5e-2, 1.0 + 5e-2);
+        }
+    }
+
+    /// <summary>
+    /// Make sure we didn't accidentally break the power-of-2 spatial
+    /// path with the padded-buffer fix.
+    /// </summary>
+    [Theory]
+    [InlineData(1, 32, 16, 16)]
+    [InlineData(2, 64, 32, 32)]
+    public void BatchNorm_StillWorksOnPowerOfTwoSpatialDims(int batch, int channels, int H, int W)
+    {
+        var engine = new CpuEngine();
+        var (x, gamma, beta) = MakeInputs(batch, channels, H, W, seed: 13);
+
+        var output = engine.BatchNorm(x, gamma, beta, 1e-5, out var mean, out var variance);
+
+        Assert.Equal(new[] { batch, channels, H, W }, output._shape);
+        Assert.Equal(new[] { channels }, mean._shape);
+        Assert.Equal(new[] { channels }, variance._shape);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #310.

`CpuEngine.BatchNorm4D`'s float fast path was allocating its output buffer to `inF.Length` — the SIMD-padded length of the input data array — rather than to `input.Length`, the logical element count (product of shape). For tensors whose underlying `GetDataArray()` returns a padded buffer (every non-power-of-2 spatial chain in EfficientNet / MobileNetV2 / MobileNetV3 224x224 inference: 112, 56, 28, 14, 7), the output buffer was too long and the downstream `TensorAllocator.Rent(shape, data)` hard-asserted `data.Length == product(shape)`, throwing:

```
ArgumentException: Data length (524288) must match shape total (401408)
  at TensorAllocator.Rent[T](int[], Vector<T>)
  at CpuEngine.BatchNorm4D[T]
  at CpuEngine.BatchNorm[T]
```

The inner `BatchNorm4DFloat` kernel iterates strictly in logical-index space (`offset = n * channels * spatialSize + c * spatialSize`), so the output buffer only ever needs the logical extent. Fixed by using `input.Length` (logical extent) instead of `inF.Length` (padded buffer length). The corresponding backward path already uses `input.Length` correctly, so this is forward-only.

## Test plan

- [x] New `BatchNorm4DPaddedDataTests` — 7 EfficientNet / MobileNet shape combinations that previously threw, plus 2 power-of-2 shapes to catch regression on the previously-working path. Asserts shape correctness and the channel-wise mean ≈ 0 / variance ≈ 1 invariant on `[1, 32, 112, 112]` and `[2, 96, 56, 56]`. 11 tests total.
- [x] All 11 new tests pass on net10.0 and net471.
- [x] All 38 existing `BatchNorm` tests continue to pass on both targets.
- [ ] CI green on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)