### PR TITLE
fix(#311): zero pooled-tensor padding so SIMD overhang reads can't leak garbage

### DIFF
--- a/src/AiDotNet.Tensors/Helpers/TensorAllocator.cs
+++ b/src/AiDotNet.Tensors/Helpers/TensorAllocator.cs
@@ -75,8 +75,20 @@ public static class TensorAllocator
             cached = ThreadLocalTensorCache<T>.TryRent(ArrayPoolBucketSize(totalSize));
         if (cached is not null)
         {
-            Array.Clear(cached, 0,
-                RuntimeHelpers.IsReferenceOrContainsReferences<T>() ? cached.Length : totalSize);
+            // Issue #311: clear the ENTIRE pooled array, not just the
+            // logical portion. The pooled buffer may exceed totalSize
+            // (ArrayPool buckets pad to the next power of two; a 401,408-
+            // element rent returns a 524,288-element array), and the
+            // padding region carries the previous renter's bytes.
+            // Downstream kernels that read past the logical extent via
+            // SIMD overhang then observe non-zero garbage — making two
+            // forward passes through "logically identical" tensors
+            // diverge by 3-4% after a couple of layers (DBM clone-after-
+            // train). Clearing the whole array makes the zero-init
+            // contract layout-invariant: identical logical content +
+            // identical padding (= zero) → identical SIMD reduction
+            // order across pooled and freshly-allocated tensors.
+            Array.Clear(cached, 0, cached.Length);
             var memory = new Memory<T>(cached, 0, totalSize);
             return Tensor<T>.FromPooledMemory(memory, shape, cached);
         }
@@ -89,8 +101,10 @@ public static class TensorAllocator
             AiDotNet.Tensors.Engines.Profiling.Memory.MemoryProfiler.RecordAllocation(
                 "TensorAllocator", bytesIfTracking, shape, typeof(T).Name);
             T[] pooled = ArrayPool<T>.Shared.Rent(totalSize);
-            Array.Clear(pooled, 0,
-                RuntimeHelpers.IsReferenceOrContainsReferences<T>() ? pooled.Length : totalSize);
+            // Issue #311: clear the entire array, including the padding
+            // beyond totalSize. See the matching comment on the cached
+            // path above.
+            Array.Clear(pooled, 0, pooled.Length);
             var memory = new Memory<T>(pooled, 0, totalSize);
             return Tensor<T>.FromPooledMemory(memory, shape, pooled);
         }
@@ -135,9 +149,23 @@ public static class TensorAllocator
             cached = ThreadLocalTensorCache<T>.TryRent(ArrayPoolBucketSize(totalSize));
         if (cached is not null)
         {
-            // Must clear reference types to avoid retaining stale objects
+            // Reference types: must clear EVERYTHING so we don't retain
+            // stale objects in the GC graph.
+            // Value types (issue #311): clear only the padding region
+            // (totalSize..cached.Length). The caller's contract is that
+            // it writes every element of the LOGICAL region, but
+            // downstream readers can still SIMD-overhang into padding
+            // and observe the prior renter's garbage — that produces
+            // ~3-4% drift between original (pooled-padded) and clone
+            // (freshly-allocated) Predict outputs after a few layers.
+            // Clearing only the padding preserves the "skip clear of
+            // logical region" optimization that is the whole point of
+            // RentUninitialized; the clear-padding-only cost is the
+            // ~25% bucket overhead, not the full buffer.
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
                 Array.Clear(cached, 0, cached.Length);
+            else if (cached.Length > totalSize)
+                Array.Clear(cached, totalSize, cached.Length - totalSize);
             var memory = new Memory<T>(cached, 0, totalSize);
             return Tensor<T>.FromPooledMemory(memory, shape, cached);
         }
@@ -145,9 +173,11 @@ public static class TensorAllocator
         if (totalSize >= ArrayPoolThreshold)
         {
             T[] pooled = ArrayPool<T>.Shared.Rent(totalSize);
-            // Must clear reference types to avoid retaining stale objects
+            // See matching #311 comment on the cached path above.
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
                 Array.Clear(pooled, 0, pooled.Length);
+            else if (pooled.Length > totalSize)
+                Array.Clear(pooled, totalSize, pooled.Length - totalSize);
             var memory = new Memory<T>(pooled, 0, totalSize);
             return Tensor<T>.FromPooledMemory(memory, shape, pooled);
         }

--- a/tests/AiDotNet.Tensors.Tests/Helpers/PaddedBufferDeterminismTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/PaddedBufferDeterminismTests.cs
@@ -1,0 +1,145 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Issue #311 regression — ensure pooled-padded tensors and freshly-
+// allocated tensors with identical logical content produce bit-
+// identical forward output. The original symptom was a 3-4% drift in
+// DeepBoltzmannMachine.Predict between an in-place-trained model and
+// its Clone()'d copy: identical params byte-for-byte, but padding-
+// region garbage in the trained-tensor path leaked into downstream
+// SIMD reads via overhang and biased the matmul/sigmoid chain.
+
+using System;
+using System.Buffers;
+using System.Reflection;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Helpers;
+
+public class PaddedBufferDeterminismTests
+{
+    /// <summary>
+    /// Forces an ArrayPool-backed Tensor whose padding region we then
+    /// fill with high-magnitude garbage. After the fix, padding is
+    /// always zeroed by Rent — so we have to bypass it via reflection
+    /// to reproduce the original failure mode and assert the kernel
+    /// no longer reads it.
+    /// </summary>
+    private static Tensor<float> RentWithGarbagePadding(int[] shape, float[] logicalValues, float padValue)
+    {
+        // Rent through TensorAllocator so the resulting tensor has the
+        // pooled, potentially-padded backing array.
+        var t = TensorAllocator.Rent<float>(shape);
+        var span = t.AsWritableSpan();
+        Assert.Equal(logicalValues.Length, span.Length);
+        for (int i = 0; i < logicalValues.Length; i++) span[i] = logicalValues[i];
+
+        // Reach the underlying T[] (may exceed Length) and write
+        // garbage into the padding region. If pooling didn't pad this
+        // shape we just return the tensor — the test still verifies
+        // determinism vs the fresh path.
+        var backing = t.GetDataArray();
+        if (backing.Length > t.Length)
+        {
+            for (int i = t.Length; i < backing.Length; i++)
+                backing[i] = padValue;
+        }
+        return t;
+    }
+
+    private static Tensor<float> FreshTensor(int[] shape, float[] logicalValues)
+    {
+        // Bypass TensorAllocator entirely — get a non-padded backing
+        // array so this is the canonical reference path.
+        var t = new Tensor<float>(shape);
+        var span = t.AsWritableSpan();
+        Assert.Equal(logicalValues.Length, span.Length);
+        for (int i = 0; i < logicalValues.Length; i++) span[i] = logicalValues[i];
+        return t;
+    }
+
+    /// <summary>
+    /// Full forward chain (matmul → sigmoid → matmul) with the input
+    /// allocated via ArrayPool with garbage padding vs via the fresh
+    /// CLR allocator. Same logical values; outputs must match bit-for-
+    /// bit.
+    /// </summary>
+    [Theory]
+    [InlineData(8, 64, 32)]
+    [InlineData(16, 128, 64)]
+    [InlineData(4, 256, 128)]
+    public void MatMulSigmoidChain_PooledPaddedAndFreshTensor_ProduceIdenticalOutput(
+        int batch, int hidden, int outFeat)
+    {
+        var rng = new Random(1);
+        var inputVals = new float[batch * hidden];
+        for (int i = 0; i < inputVals.Length; i++) inputVals[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+
+        var weightsVals = new float[hidden * outFeat];
+        for (int i = 0; i < weightsVals.Length; i++) weightsVals[i] = (float)(rng.NextDouble() * 0.1);
+
+        // PADDED path — input rented from pool, padding seeded with
+        // large garbage values so any overhang read is detectable.
+        var inputPad = RentWithGarbagePadding(new[] { batch, hidden }, inputVals, padValue: 999_999f);
+        var weightsPad = RentWithGarbagePadding(new[] { hidden, outFeat }, weightsVals, padValue: -999_999f);
+
+        // FRESH path — non-padded backing storage.
+        var inputFresh = FreshTensor(new[] { batch, hidden }, inputVals);
+        var weightsFresh = FreshTensor(new[] { hidden, outFeat }, weightsVals);
+
+        var engine = new CpuEngine();
+        var z1Pad = engine.TensorMatMul(inputPad, weightsPad);
+        var a1Pad = engine.Sigmoid(z1Pad);
+
+        var z1Fresh = engine.TensorMatMul(inputFresh, weightsFresh);
+        var a1Fresh = engine.Sigmoid(z1Fresh);
+
+        var padSpan = a1Pad.AsSpan();
+        var freshSpan = a1Fresh.AsSpan();
+        Assert.Equal(freshSpan.Length, padSpan.Length);
+        for (int i = 0; i < padSpan.Length; i++)
+        {
+            Assert.True(padSpan[i] == freshSpan[i],
+                $"Mismatch at idx {i}: pooled-padded={padSpan[i]} vs fresh={freshSpan[i]} — "
+                + "padding region is leaking into the matmul/sigmoid output.");
+        }
+    }
+
+    /// <summary>
+    /// Direct allocator-level invariant: a freshly-rented tensor must
+    /// have its full backing array zeroed (including the padding region)
+    /// — that's the contract issue #311 enforces.
+    /// </summary>
+    [Theory]
+    [InlineData(401_408)]
+    [InlineData(1_000_000)]
+    public void Rent_ZerosPaddingRegionForValueTypes(int totalSize)
+    {
+        // Pre-warm the pool with a large rent that we taint, then
+        // return — this gives the next Rent a recycled, dirty buffer.
+        // If padding-zeroing is missing, the next Rent's padding will
+        // hold our taint values.
+        var first = TensorAllocator.Rent<float>(new[] { totalSize });
+        var firstBacking = first.GetDataArray();
+        for (int i = 0; i < firstBacking.Length; i++) firstBacking[i] = 0xCAFEf;
+
+        // Force the buffer back into the pool via TensorPool.Return
+        // (the convention used by the engine to recycle).
+        TensorPool.Return(first);
+
+        // Re-rent at the same logical size and check the padding bytes.
+        var second = TensorAllocator.Rent<float>(new[] { totalSize });
+        var secondBacking = second.GetDataArray();
+
+        // Logical region must be zeroed (Rent contract).
+        for (int i = 0; i < second.Length; i++)
+            Assert.True(secondBacking[i] == 0f,
+                $"Logical idx {i} not zero: {secondBacking[i]}.");
+
+        // Padding region must be zeroed too (issue #311).
+        for (int i = second.Length; i < secondBacking.Length; i++)
+            Assert.True(secondBacking[i] == 0f,
+                $"Padding idx {i} not zero — leaks prior renter's garbage: {secondBacking[i]}.");
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Helpers/PaddedBufferDeterminismTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/PaddedBufferDeterminismTests.cs
@@ -60,10 +60,16 @@ public class PaddedBufferDeterminismTests
     }
 
     /// <summary>
-    /// Full forward chain (matmul → sigmoid → matmul) with the input
-    /// allocated via ArrayPool with garbage padding vs via the fresh
-    /// CLR allocator. Same logical values; outputs must match bit-for-
-    /// bit.
+    /// Full forward chain (matmul → sigmoid → matmul) with all
+    /// operands allocated via ArrayPool with garbage padding vs via
+    /// the fresh CLR allocator. Same logical values; outputs after
+    /// the SECOND matmul must match bit-for-bit.
+    ///
+    /// <para>Two matmuls (not one) so we exercise the original DBM
+    /// drift path: a sigmoid output (post-pool-allocated) is then
+    /// fed back into another matmul, and any padding-leak in the
+    /// second-stage matmul accumulates the divergence introduced
+    /// by the first stage's sigmoid output.</para>
     /// </summary>
     [Theory]
     [InlineData(8, 64, 32)]
@@ -79,30 +85,42 @@ public class PaddedBufferDeterminismTests
         var weightsVals = new float[hidden * outFeat];
         for (int i = 0; i < weightsVals.Length; i++) weightsVals[i] = (float)(rng.NextDouble() * 0.1);
 
-        // PADDED path — input rented from pool, padding seeded with
-        // large garbage values so any overhang read is detectable.
+        // Second-stage weights map [outFeat] → [hidden] so the chain
+        // has shape [batch, hidden] → [batch, outFeat] → [batch, hidden].
+        var weights2Vals = new float[outFeat * hidden];
+        for (int i = 0; i < weights2Vals.Length; i++) weights2Vals[i] = (float)(rng.NextDouble() * 0.1);
+
+        // PADDED path — every operand rented from the pool with
+        // large-magnitude garbage written into its padding region so
+        // any overhang read is detectable.
         var inputPad = RentWithGarbagePadding(new[] { batch, hidden }, inputVals, padValue: 999_999f);
         var weightsPad = RentWithGarbagePadding(new[] { hidden, outFeat }, weightsVals, padValue: -999_999f);
+        var weights2Pad = RentWithGarbagePadding(new[] { outFeat, hidden }, weights2Vals, padValue: 777_777f);
 
-        // FRESH path — non-padded backing storage.
+        // FRESH path — non-padded backing storage on every operand.
         var inputFresh = FreshTensor(new[] { batch, hidden }, inputVals);
         var weightsFresh = FreshTensor(new[] { hidden, outFeat }, weightsVals);
+        var weights2Fresh = FreshTensor(new[] { outFeat, hidden }, weights2Vals);
 
         var engine = new CpuEngine();
+        // Stage 1: matmul + sigmoid.
         var z1Pad = engine.TensorMatMul(inputPad, weightsPad);
         var a1Pad = engine.Sigmoid(z1Pad);
-
         var z1Fresh = engine.TensorMatMul(inputFresh, weightsFresh);
         var a1Fresh = engine.Sigmoid(z1Fresh);
+        // Stage 2: feed the (pool-allocated) sigmoid output back into
+        // another matmul — the part that previously produced DBM drift.
+        var z2Pad = engine.TensorMatMul(a1Pad, weights2Pad);
+        var z2Fresh = engine.TensorMatMul(a1Fresh, weights2Fresh);
 
-        var padSpan = a1Pad.AsSpan();
-        var freshSpan = a1Fresh.AsSpan();
+        var padSpan = z2Pad.AsSpan();
+        var freshSpan = z2Fresh.AsSpan();
         Assert.Equal(freshSpan.Length, padSpan.Length);
         for (int i = 0; i < padSpan.Length; i++)
         {
             Assert.True(padSpan[i] == freshSpan[i],
                 $"Mismatch at idx {i}: pooled-padded={padSpan[i]} vs fresh={freshSpan[i]} — "
-                + "padding region is leaking into the matmul/sigmoid output.");
+                + "padding region is leaking into the matmul→sigmoid→matmul output.");
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #311.

`DeepBoltzmannMachine.Predict` drifted ~3-4% between an in-place-trained model and its `Clone()`: per-layer parameters were byte-identical between the two paths, but the trained-side tensors carried backing arrays from `ArrayPool` whose **padding region** (bytes from `totalSize` to bucket size) held the **previous renter's data**. Any downstream kernel that does a SIMD load with overhang into the padding observes garbage; the freshly-allocated clone (via `SetParameters` → `new Tensor<T>(shape)`) sees zeros instead. Two-path forward runs then produce different SIMD reduction sequences and fp64 non-associativity drives the divergence to several percent after a couple of MatMul + Sigmoid layers.

The two paths in `TensorAllocator` that reuse pooled buffers previously cleared **only the logical portion** of the array for value types (the optimization being "we only hand out a `Memory<T>` slice, so the consumer never reads past `Length`"). That assumption breaks the moment any kernel uses the underlying `T[]` via `GetDataArray()` and iterates by anything other than the strict logical bound — fragile and observably wrong in the DBM forward chain.

## Fix

* `TensorAllocator.Rent<T>(int[])` — always `Array.Clear` the **entire** pooled buffer (logical region + padding) for value types. Reference types were already clearing the full array; value types now match. Zero-init was already the documented contract for this path; we just deliver on it.

* `TensorAllocator.RentUninitialized<T>(int[])` — clear **only** the padding region (`totalSize..cached.Length`) for value types. The caller's contract is that it overwrites the logical region; we keep that perf optimization but plug the padding-leak so downstream readers don't observe garbage.

## Test plan

- [x] `PaddedBufferDeterminismTests.MatMulSigmoidChain_*ProduceIdenticalOutput` — three shape combinations. Builds two tensors with identical logical content: one rented from the pool with deliberate high-magnitude garbage written into its padding region (via the underlying `GetDataArray()`), one allocated fresh. Runs MatMul + Sigmoid on both; asserts bit-identical outputs.
- [x] `PaddedBufferDeterminismTests.Rent_ZerosPaddingRegionForValueTypes` — direct allocator-level invariant. Pre-taints a buffer with a marker value, returns it to the pool, re-rents, asserts both the logical region AND the padding region are zero.
- [x] All 5 new tests pass on net10.0 and net471.
- [x] All 5 existing allocator-related tests (`TensorAllocator` / `TensorPool` / `TensorArena`) continue to pass.
- [ ] CI green on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)