### PR TITLE
fix(autodiff): clear .Grad on graph intermediates when sources=null (reopens #283, fixes consumer #1227)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/CompiledBackwardGraph.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/CompiledBackwardGraph.cs
@@ -167,6 +167,26 @@ public sealed class CompiledBackwardGraph<T>
         finally
         {
             DifferentiableOps.ClearIndexedGrads();
+
+            // Persistent-tape parity with the GradientTape.ComputeGradientsViaGraphCore
+            // cleanup: clear .Grad on forward intermediates so a consumer-side cache
+            // that retains an intermediate (e.g. a layer's `_lastInput`) doesn't pin
+            // one full backward's worth of gradient tensors across successive Execute
+            // calls. Same defense-in-depth pattern as GradientTape.cs PR for
+            // reopened-#283 / consumer-AiDotNet#1227.
+            //
+            // We DON'T clear .GradFn here — the compiled graph reuses the tape's
+            // forward graph for the next Execute, so the GradFn back-pointers must
+            // stay live. .Grad gets re-set by AccumulateGrad on the next Execute,
+            // so clearing it here only severs the per-tensor field; the data flows
+            // through the returned dictionary regardless.
+            HashSet<Tensor<T>>? sourceSet = null;
+            if (_sources is not null)
+            {
+                sourceSet = new HashSet<Tensor<T>>(ReferenceEqualityComparer<Tensor<T>>.Instance);
+                foreach (var s in _sources) sourceSet.Add(s);
+            }
+
             foreach (int i in _reachableEntryIndices)
             {
                 ref var e = ref _entries[i];
@@ -176,6 +196,15 @@ public sealed class CompiledBackwardGraph<T>
                 if (e.InputCount >= 3 && e.Input2 != null) e.Input2._gradIndex = -1;
                 if (e.InputsOverflow != null)
                     foreach (var inp in e.InputsOverflow) inp._gradIndex = -1;
+
+                // .Grad cleanup on this entry's output (every output is an
+                // intermediate — graph leaves never appear as outputs in the
+                // entries array). Inputs are NOT cleared because they may be
+                // graph leaves (parameters), and the consumer relies on
+                // `param.Grad` being populated after a sources=null Execute.
+                bool keepGrad =
+                    (sourceSet?.Contains(e.Output) == true);
+                if (!keepGrad) e.Output.Grad = null;
             }
         }
 

--- a/src/AiDotNet.Tensors/Engines/Autodiff/CompiledBackwardGraph.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/CompiledBackwardGraph.cs
@@ -111,11 +111,14 @@ public sealed class CompiledBackwardGraph<T>
     {
         var loss = currentLoss ?? _loss;
 
-        // Phase C: try optimized backward with CSE + algebraic simplification
+        // Phase C: try optimized backward with CSE + algebraic simplification.
+        // OptimizedBackwardPlan applies the same RetainGrad-aware intermediate
+        // .Grad cleanup as the non-optimized path below, so taking this branch
+        // does not bypass the leak fix.
         if (Optimization.TensorCodecOptions.Current.EnableAlgebraicBackward)
         {
             var optimized = OptimizedBackwardPlan<T>.TryCreate(
-                _entries, _reachableEntryIndices, loss, _sources, _engine);
+                _entries, _reachableEntryIndices, loss, _sources, _engine, _retainGrad);
             if (optimized is not null)
                 return optimized.Execute();
         }

--- a/src/AiDotNet.Tensors/Engines/Autodiff/CompiledBackwardGraph.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/CompiledBackwardGraph.cs
@@ -35,6 +35,16 @@ public sealed class CompiledBackwardGraph<T>
     private readonly IEngine _engine;
 
     /// <summary>
+    /// Optional reference to the owning tape's RetainGrad set. When non-null,
+    /// the cleanup phase of <see cref="Execute"/> preserves <c>.Grad</c> on any
+    /// tensor the user has explicitly marked with
+    /// <see cref="GradientTape{T}.RetainGrad"/>, matching the behavior of
+    /// <see cref="GradientTape{T}.CleanupTapeEntryGrad"/> and
+    /// <see cref="GradientTape{T}.ComputeGradientsViaGraphCore"/>.
+    /// </summary>
+    private readonly HashSet<Tensor<T>>? _retainGrad;
+
+    /// <summary>
     /// Compiles a backward graph by analyzing which tape entries are reachable
     /// from the loss tensor. Dead entries are eliminated from the execution plan.
     /// </summary>
@@ -42,7 +52,8 @@ public sealed class CompiledBackwardGraph<T>
         TapeEntryArena<T> entries,
         Tensor<T> loss,
         Tensor<T>[]? sources,
-        IEngine engine)
+        IEngine engine,
+        HashSet<Tensor<T>>? retainGrad = null)
     {
         // Arena reference is shared with the owning tape. Safe because:
         // 1. CompiledBackwardGraph is created inside ComputeGradients which holds the tape
@@ -52,6 +63,7 @@ public sealed class CompiledBackwardGraph<T>
         _loss = loss;
         _sources = sources;
         _engine = engine;
+        _retainGrad = retainGrad;
 
         // Dead node elimination: find which entries are reachable from loss
         var reachable = new HashSet<Tensor<T>>(ReferenceEqualityComparer<Tensor<T>>.Instance);
@@ -202,8 +214,15 @@ public sealed class CompiledBackwardGraph<T>
                 // entries array). Inputs are NOT cleared because they may be
                 // graph leaves (parameters), and the consumer relies on
                 // `param.Grad` being populated after a sources=null Execute.
+                //
+                // Matches the parity rule used by
+                // GradientTape.CleanupTapeEntryGrad (line 635) and
+                // ComputeGradientsViaGraphCore (line 719): a tensor explicitly
+                // marked with RetainGrad() must keep its .Grad even though it
+                // is a graph intermediate.
                 bool keepGrad =
-                    (sourceSet?.Contains(e.Output) == true);
+                    (sourceSet?.Contains(e.Output) == true)
+                    || (_retainGrad is not null && _retainGrad.Contains(e.Output));
                 if (!keepGrad) e.Output.Grad = null;
             }
         }

--- a/src/AiDotNet.Tensors/Engines/Autodiff/CompiledDelegateChain.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/CompiledDelegateChain.cs
@@ -19,6 +19,14 @@ internal sealed class CompiledDelegateChain<T>
     }
 
     /// <summary>
+    /// Exposes the underlying step array so callers (the persistent-tape cleanup
+    /// in <c>ComputeGradientsViaGraphCore</c>) can walk it to release per-step
+    /// gradient retentions without re-doing the topological traversal that
+    /// produced the chain.
+    /// </summary>
+    internal BackwardStep<T>[] Steps => _steps;
+
+    /// <summary>
     /// Executes the pre-compiled backward chain. Each step is a captured closure
     /// that calls the backward function with the right inputs and accumulates gradients.
     /// </summary>

--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
@@ -562,18 +562,34 @@ public sealed class GradientTape<T> : IDisposable
                 sourceSet = new HashSet<Tensor<T>>(ReferenceEqualityComparer<Tensor<T>>.Instance);
                 foreach (var s in sources) sourceSet.Add(s);
             }
+
+            // Pre-collect every output tensor in the arena: these are the
+            // intermediates produced by tape-recorded ops. Graph leaves
+            // (parameters / user-supplied roots) never appear as Output in
+            // an entry. We need this distinction so the BC contract
+            // "param.Grad stays populated after a sources=null backward"
+            // holds in the tape-walk path the same way it holds in
+            // ComputeGradientsViaGraphCore (line 776+). Without this,
+            // calling CleanupTapeEntryGrad on a leaf input would null
+            // param.Grad and silently break any consumer reading it.
+            var intermediates = new HashSet<Tensor<T>>(ReferenceEqualityComparer<Tensor<T>>.Instance);
+            for (int i = 0; i < _entries.Count; i++)
+            {
+                intermediates.Add(_entries[i].Output);
+            }
+
             for (int i = 0; i < _entries.Count; i++)
             {
                 ref var e = ref _entries[i];
-                CleanupTapeEntryGrad(e.Output, sourceSet);
-                if (e.Input0 != null) CleanupTapeEntryGrad(e.Input0, sourceSet);
-                if (e.InputCount >= 2 && e.Input1 != null) CleanupTapeEntryGrad(e.Input1, sourceSet);
-                if (e.InputCount >= 3 && e.Input2 != null) CleanupTapeEntryGrad(e.Input2, sourceSet);
+                CleanupTapeEntryGrad(e.Output, sourceSet, intermediates);
+                if (e.Input0 != null) CleanupTapeEntryGrad(e.Input0, sourceSet, intermediates);
+                if (e.InputCount >= 2 && e.Input1 != null) CleanupTapeEntryGrad(e.Input1, sourceSet, intermediates);
+                if (e.InputCount >= 3 && e.Input2 != null) CleanupTapeEntryGrad(e.Input2, sourceSet, intermediates);
                 if (e.InputsOverflow != null)
                 {
                     foreach (var inp in e.InputsOverflow)
                     {
-                        if (inp != null) CleanupTapeEntryGrad(inp, sourceSet);
+                        if (inp != null) CleanupTapeEntryGrad(inp, sourceSet, intermediates);
                     }
                 }
             }
@@ -621,7 +637,7 @@ public sealed class GradientTape<T> : IDisposable
         return grads;
     }
 
-    private void CleanupTapeEntryGrad(Tensor<T> t, HashSet<Tensor<T>>? sourceSet)
+    private void CleanupTapeEntryGrad(Tensor<T> t, HashSet<Tensor<T>>? sourceSet, HashSet<Tensor<T>> intermediates)
     {
         // Always clear GradFn — this is the back-pointer that chains a tensor to its
         // BackwardFunction closure, which in turn captures forward intermediates. The
@@ -633,10 +649,19 @@ public sealed class GradientTape<T> : IDisposable
         if (sourceSet?.Contains(t) == true) return;
         // Preserve .Grad on tensors the user explicitly marked with RetainGrad().
         if (_retainGrad is not null && _retainGrad.Contains(t)) return;
-        // For null-sources callers, the gradients still live in the returned
-        // Dictionary — clearing .Grad here only severs the per-tensor field, not
-        // the data itself.
-        t.Grad = null;
+        // Distinguish intermediate vs leaf when sources is null:
+        //   sourceSet != null + non-source: caller's explicit filter said
+        //     "only keep what I listed" — clear regardless of leaf-ness.
+        //   sourceSet == null + intermediate: clear (returned dict still
+        //     holds the gradient; .Grad is only the per-tensor mirror).
+        //   sourceSet == null + leaf (parameter / user-supplied root):
+        //     preserve param.Grad — that's the BC contract that
+        //     AiDotNet.NeuralNetworkBase.TrainWithTape and the graph-walk
+        //     path (ComputeGradientsViaGraphCore line 776+) both honor.
+        if (sourceSet is not null || intermediates.Contains(t))
+        {
+            t.Grad = null;
+        }
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
@@ -687,10 +687,40 @@ public sealed class GradientTape<T> : IDisposable
         Tensor<T> loss,
         IReadOnlyList<Tensor<T>>? sources)
     {
-        // If we have a cached delegate chain from a previous backward, replay it directly
+        // If we have a cached delegate chain from a previous backward, replay it directly.
+        // Apply the same per-intermediate .Grad cleanup as the fresh-walk path so a
+        // persistent tape doesn't keep one full backward's worth of gradient tensors
+        // pinned on every intermediate between successive Execute calls. We CANNOT clear
+        // GradFn on persistent-cached chains because the chain itself reuses those
+        // tensors' Output.GradFn pointers for the next Execute's graph traversal —
+        // only .Grad is safe to clear (it gets re-set by AccumulateGrad on the next
+        // forward+backward pass).
         if (_cachedDelegateChain is not null)
         {
-            return _cachedDelegateChain.Execute(loss, sources, _engine);
+            var cachedResult = _cachedDelegateChain.Execute(loss, sources, _engine);
+
+            HashSet<Tensor<T>>? cachedSourceSet = null;
+            if (sources is not null)
+            {
+                cachedSourceSet = new HashSet<Tensor<T>>(ReferenceEqualityComparer<Tensor<T>>.Instance);
+                foreach (var s in sources) cachedSourceSet.Add(s);
+            }
+
+            // Walk the chain's steps to find every intermediate (step.Output)
+            // and clear its .Grad. Inputs to a step may be parameters
+            // (graph leaves) — leave their .Grad alone for the same reason
+            // the fresh-walk path does. Intermediate-as-input cases get
+            // cleared when they appear as Output in their own step.
+            var cachedSteps = _cachedDelegateChain.Steps;
+            for (int i = 0; i < cachedSteps.Length; i++)
+            {
+                ref var step = ref cachedSteps[i];
+                if (cachedSourceSet?.Contains(step.Output) == true) continue;
+                if (_retainGrad is not null && _retainGrad.Contains(step.Output)) continue;
+                step.Output.Grad = null;
+            }
+
+            return cachedResult;
         }
 
         var engine = _engine;

--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
@@ -639,11 +639,18 @@ public sealed class GradientTape<T> : IDisposable
 
     private void CleanupTapeEntryGrad(Tensor<T> t, HashSet<Tensor<T>>? sourceSet, HashSet<Tensor<T>> intermediates)
     {
-        // Always clear GradFn — this is the back-pointer that chains a tensor to its
-        // BackwardFunction closure, which in turn captures forward intermediates. The
-        // forward graph stays alive as long as ANY tape-tracked tensor keeps its
-        // GradFn, regardless of whether the consumer asked to filter by sources.
-        t.GradFn = null;
+        // Only null GradFn on tensors THIS tape owns. A tensor whose GradFn
+        // doesn't belong to this tape's graph (e.g. an output of an outer
+        // tape, fed in as input to this tape's ops) must keep its back-
+        // pointer intact — otherwise the outer tape's later backward
+        // would see a severed graph and either crash or silently drop
+        // gradients. The ownership signal is membership in `intermediates`,
+        // which holds every Output produced by this tape's entries.
+        bool ownedByThisTape = intermediates.Contains(t);
+        if (ownedByThisTape)
+        {
+            t.GradFn = null;
+        }
         // Preserve .Grad when the caller explicitly listed this tensor as a source
         // (they're going to read `tensor.Grad` rather than the returned Dictionary).
         if (sourceSet?.Contains(t) == true) return;
@@ -651,14 +658,21 @@ public sealed class GradientTape<T> : IDisposable
         if (_retainGrad is not null && _retainGrad.Contains(t)) return;
         // Distinguish intermediate vs leaf when sources is null:
         //   sourceSet != null + non-source: caller's explicit filter said
-        //     "only keep what I listed" — clear regardless of leaf-ness.
-        //   sourceSet == null + intermediate: clear (returned dict still
-        //     holds the gradient; .Grad is only the per-tensor mirror).
-        //   sourceSet == null + leaf (parameter / user-supplied root):
-        //     preserve param.Grad — that's the BC contract that
-        //     AiDotNet.NeuralNetworkBase.TrainWithTape and the graph-walk
-        //     path (ComputeGradientsViaGraphCore line 776+) both honor.
-        if (sourceSet is not null || intermediates.Contains(t))
+        //     "only keep what I listed" — clear regardless of ownership.
+        //     Foreign-leaf .Grad wasn't populated by this backward pass
+        //     anyway (this tape only accumulates to its own reachable
+        //     graph), so clearing it is effectively a no-op on the typical
+        //     nested-tape case.
+        //   sourceSet == null + this-tape intermediate: clear (returned
+        //     dict still holds the gradient; .Grad is only the per-tensor
+        //     mirror).
+        //   sourceSet == null + leaf or foreign tensor:
+        //     preserve .Grad — for true leaves (params), the BC contract
+        //     that AiDotNet.NeuralNetworkBase.TrainWithTape and the graph-
+        //     walk path (ComputeGradientsViaGraphCore line 776+) honor;
+        //     for foreign tensors, their .Grad belongs to the outer tape
+        //     and we must not touch it.
+        if (sourceSet is not null || ownedByThisTape)
         {
             t.Grad = null;
         }
@@ -844,72 +858,74 @@ public sealed class GradientTape<T> : IDisposable
                 return false;
             }
 
+            // Build the set of nodes THIS graph owns. A tensor produced by an
+            // op on a foreign tape (an outer/parent tape, fed in as input to
+            // this tape's ops) has a non-null GradFn that doesn't belong to
+            // any node in topoOrder. We must NOT null its GradFn or touch its
+            // .Grad — those belong to the outer tape and would be corrupted
+            // by indiscriminate cleanup. `GradFn != null` is NOT a safe proxy
+            // for "intermediate of this graph" because it conflates
+            // this-graph intermediates with foreign-tape outputs.
+            var ownedIntermediates = new HashSet<Tensor<T>>(ReferenceEqualityComparer<Tensor<T>>.Instance);
+            foreach (var n in topoOrder)
+                ownedIntermediates.Add(n.Output);
+
             foreach (var node in topoOrder)
             {
-                // node.Output is always an intermediate (it has GradFn until
-                // we null it on this line). Safe to clear .Grad: parameters
-                // never appear as outputs (they're graph leaves), so we can't
-                // accidentally drop a param's gradient here.
+                // node.Output is always owned by this graph (we just put it
+                // into ownedIntermediates). Safe to null its GradFn and clear
+                // its .Grad: parameters never appear as outputs.
                 node.Output.GradFn = null;
                 if (!ShouldKeepGrad(node.Output))
                     node.Output.Grad = null;
 
-                // For Inputs: always null .GradFn (the graph traversal is
-                // over so the back-pointer is dead weight). For .Grad:
+                // For Inputs: only touch GradFn / .Grad when the input is
+                // owned by THIS graph (i.e. is the Output of some node in
+                // topoOrder). The three cases:
                 //
-                //   sourceSet != null:
-                //     The caller provided an explicit source list. Clear
-                //     .Grad on non-source inputs (matches the established
-                //     "sources specifies what to keep" contract).
-                //   sourceSet == null AND input is NOT a graph leaf:
-                //     We've cleared this input's GradFn — i.e. it WAS an
-                //     intermediate (output of an upstream op). Its .Grad
-                //     also gets cleared on the upstream op's iteration,
-                //     but the consumer-visible gradient is preserved
-                //     through the returned `grads` dictionary either way.
-                //     Clearing it here doesn't drop data.
-                //   sourceSet == null AND input IS a graph leaf:
-                //     The input has GradFn = null already (a parameter or
-                //     a user-supplied input). Preserving .Grad here keeps
-                //     `param.Grad` populated for callers that read it
-                //     directly (a small subset, but BC-relevant).
-                //
-                // We can distinguish "intermediate input" from "leaf input"
-                // by checking GradFn BEFORE this iteration nulls it. Cache
-                // the snapshot below.
-                bool input0WasIntermediate = node.Input0.GradFn is not null;
-                node.Input0.GradFn = null;
+                //   sourceSet != null + non-source: clear .Grad (caller's
+                //     explicit "keep what I listed" contract). Foreign-leaf
+                //     .Grad wasn't populated by this backward anyway, so
+                //     clearing is effectively a no-op for nested-tape inputs.
+                //   sourceSet == null + owned intermediate: clear .Grad
+                //     (returned dict still holds the gradient).
+                //   sourceSet == null + leaf or foreign tensor: preserve
+                //     .Grad — for true leaves that's the BC contract
+                //     (param.Grad), for foreign tensors that's outer-tape
+                //     state we must not touch.
+                bool input0Owned = ownedIntermediates.Contains(node.Input0);
+                if (input0Owned) node.Input0.GradFn = null;
                 if (sourceSet is not null)
                 {
                     if (!ShouldKeepGrad(node.Input0)) node.Input0.Grad = null;
                 }
-                else if (input0WasIntermediate && !ShouldKeepGrad(node.Input0))
+                else if (input0Owned && !ShouldKeepGrad(node.Input0))
                 {
                     node.Input0.Grad = null;
                 }
 
                 if (node.Input1 is not null)
                 {
-                    bool wasIntermediate = node.Input1.GradFn is not null;
-                    node.Input1.GradFn = null;
+                    bool input1Owned = ownedIntermediates.Contains(node.Input1);
+                    if (input1Owned) node.Input1.GradFn = null;
                     if (sourceSet is not null)
                     {
                         if (!ShouldKeepGrad(node.Input1)) node.Input1.Grad = null;
                     }
-                    else if (wasIntermediate && !ShouldKeepGrad(node.Input1))
+                    else if (input1Owned && !ShouldKeepGrad(node.Input1))
                     {
                         node.Input1.Grad = null;
                     }
                 }
                 if (node.Input2 is not null)
                 {
-                    bool wasIntermediate = node.Input2.GradFn is not null;
-                    node.Input2.GradFn = null;
+                    bool input2Owned = ownedIntermediates.Contains(node.Input2);
+                    if (input2Owned) node.Input2.GradFn = null;
                     if (sourceSet is not null)
                     {
                         if (!ShouldKeepGrad(node.Input2)) node.Input2.Grad = null;
                     }
-                    else if (wasIntermediate && !ShouldKeepGrad(node.Input2))
+                    else if (input2Owned && !ShouldKeepGrad(node.Input2))
                     {
                         node.Input2.Grad = null;
                     }
@@ -919,13 +935,13 @@ public sealed class GradientTape<T> : IDisposable
                     foreach (var inp in node.InputsOverflow)
                     {
                         if (inp is null) continue;
-                        bool wasIntermediate = inp.GradFn is not null;
-                        inp.GradFn = null;
+                        bool inpOwned = ownedIntermediates.Contains(inp);
+                        if (inpOwned) inp.GradFn = null;
                         if (sourceSet is not null)
                         {
                             if (!ShouldKeepGrad(inp)) inp.Grad = null;
                         }
-                        else if (wasIntermediate && !ShouldKeepGrad(inp))
+                        else if (inpOwned && !ShouldKeepGrad(inp))
                         {
                             inp.Grad = null;
                         }

--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
@@ -527,20 +527,41 @@ public sealed class GradientTape<T> : IDisposable
 
         // Tape-walk parity for the .Grad / .GradFn cleanup that ComputeGradientsViaGraph does.
         // AccumulateGrad sets `tensor.Grad = stored` for every tensor that receives a
-        // gradient contribution — including forward intermediates — so on a
-        // non-persistent tape we null .Grad on non-source / non-RetainGrad tensors so
-        // the gradient lifetime doesn't get chained to whatever holds the intermediate.
-        // Tape-walk-specific cases (anomaly detection, hooks) all reach this cleanup
-        // the same way the graph path does.
+        // gradient contribution — including forward intermediates — and each tensor's
+        // GradFn pointer chains back through the entire forward graph via captured
+        // BackwardFunction closures. Without explicit cleanup, any external code that
+        // retains even ONE forward intermediate (e.g. a layer's `_lastInput` cache)
+        // keeps the whole graph alive across Train calls, surviving Gen2 GC.
+        //
+        // The previous guard `sources is not null` skipped cleanup whenever the caller
+        // didn't specify a source filter. In practice every long-running training loop
+        // calls ComputeGradients(loss, sources: null) — including AiDotNet's
+        // NeuralNetworkBase.TrainWithTape (passes null and consumes the returned Dictionary
+        // directly) — so the cleanup never ran and the heap grew linearly at the per-call
+        // saved-for-backward footprint. ooples/AiDotNet#1227 documented this at ~1.5 MB/call
+        // on a 4-encoder-layer Transformer; the same model on the equivalent raw-tape
+        // probe in this repo measured 0 B/call because the test always passed explicit
+        // sources.
+        //
+        // Fix: run the cleanup whether or not `sources` was provided. When sources is
+        // null we still clear .GradFn on every tape-recorded tensor (breaks the graph
+        // back-pointer chain) and clear .Grad on tensors that aren't pinned via
+        // RetainGrad. The returned `grads` Dictionary already holds the gradient
+        // references the caller needs — clearing the per-tensor .Grad field doesn't
+        // drop any data the caller can still access through the dictionary.
         //
         // SKIP cleanup when createGraph=true: the outer caller is computing higher-
         // order derivatives (Hvp / Hessian / double-backward), and forward
         // intermediates' .Grad / .GradFn fields are part of the higher-order graph
         // that the next backward pass needs to walk.
-        if (!_options.Persistent && !createGraph && sources is not null)
+        if (!_options.Persistent && !createGraph)
         {
-            HashSet<Tensor<T>> sourceSet = new HashSet<Tensor<T>>(ReferenceEqualityComparer<Tensor<T>>.Instance);
-            foreach (var s in sources) sourceSet.Add(s);
+            HashSet<Tensor<T>>? sourceSet = null;
+            if (sources is not null)
+            {
+                sourceSet = new HashSet<Tensor<T>>(ReferenceEqualityComparer<Tensor<T>>.Instance);
+                foreach (var s in sources) sourceSet.Add(s);
+            }
             for (int i = 0; i < _entries.Count; i++)
             {
                 ref var e = ref _entries[i];
@@ -600,11 +621,21 @@ public sealed class GradientTape<T> : IDisposable
         return grads;
     }
 
-    private void CleanupTapeEntryGrad(Tensor<T> t, HashSet<Tensor<T>> sourceSet)
+    private void CleanupTapeEntryGrad(Tensor<T> t, HashSet<Tensor<T>>? sourceSet)
     {
+        // Always clear GradFn — this is the back-pointer that chains a tensor to its
+        // BackwardFunction closure, which in turn captures forward intermediates. The
+        // forward graph stays alive as long as ANY tape-tracked tensor keeps its
+        // GradFn, regardless of whether the consumer asked to filter by sources.
         t.GradFn = null;
-        if (sourceSet.Contains(t)) return;
+        // Preserve .Grad when the caller explicitly listed this tensor as a source
+        // (they're going to read `tensor.Grad` rather than the returned Dictionary).
+        if (sourceSet?.Contains(t) == true) return;
+        // Preserve .Grad on tensors the user explicitly marked with RetainGrad().
         if (_retainGrad is not null && _retainGrad.Contains(t)) return;
+        // For null-sources callers, the gradients still live in the returned
+        // Dictionary — clearing .Grad here only severs the per-tensor field, not
+        // the data itself.
         t.Grad = null;
     }
 
@@ -717,59 +748,132 @@ public sealed class GradientTape<T> : IDisposable
         if (!_options.Persistent)
         {
             // Build a set of source tensors for O(1) sourcehood check.
-            // sources == null means the caller wants the full grads dict,
-            //   so we can't safely null .Grad on anything.
-            // sources != null (even if empty) means the caller specified
-            //   the protected set explicitly — clear .Grad on everything
-            //   else, including the case where the explicit set is empty.
+            //   sources != null (even if empty): the caller specified the
+            //     protected set explicitly — clear .Grad on everything
+            //     else (including the case where the explicit set is empty).
+            //   sources == null: the caller is consuming gradients via the
+            //     returned dictionary (the standard pattern in
+            //     AiDotNet.NeuralNetworkBase.TrainWithTape, all auto-
+            //     differentiation-driven optimizers, etc.). We MUST still
+            //     clear .Grad on forward intermediates here — otherwise
+            //     each intermediate's gradient tensor (a fresh
+            //     ~outputSize-of-the-op backing array, NOT pooled past the
+            //     64-slot TensorPool cap) stays pinned for the lifetime of
+            //     the intermediate. When a consumer-side cache (a layer's
+            //     `_lastInput` field, a streaming-pool retention, etc.)
+            //     holds a single forward intermediate, all of that
+            //     intermediate's gradient memory bleeds across calls.
+            //     Reopened-#1227 measured this as ~1.5 MB/call retention
+            //     on a 4-encoder-layer Transformer.
+            //
+            // The dict returned to the caller keeps the gradient references
+            // by value — clearing the per-tensor .Grad field just severs
+            // the back-pointer from intermediates, not the dict's mapping.
             HashSet<Tensor<T>>? sourceSet = null;
             if (sources is not null)
             {
                 sourceSet = new HashSet<Tensor<T>>(ReferenceEqualityComparer<Tensor<T>>.Instance);
                 foreach (var s in sources) sourceSet.Add(s);
             }
-            // Local helper: should this tensor keep its .Grad?
-            // True when sources mode is off (sourceSet null), when the tensor
-            // is a source, or when the user retained grads on it explicitly.
+
+            // Should this tensor keep its .Grad after backward returns?
+            //   - Explicit source (caller asked for its grad by reference): yes
+            //   - RetainGrad-marked non-leaf: yes
+            //   - Otherwise: no — even when sources was null, because the
+            //     gradient is preserved in the returned dictionary
+            //     regardless of whether .Grad stays set on the tensor.
             bool ShouldKeepGrad(Tensor<T> t)
             {
-                if (sourceSet is null) return true;
-                if (sourceSet.Contains(t)) return true;
+                if (sourceSet?.Contains(t) == true) return true;
                 if (_retainGrad is not null && _retainGrad.Contains(t)) return true;
                 return false;
             }
+
             foreach (var node in topoOrder)
             {
+                // node.Output is always an intermediate (it has GradFn until
+                // we null it on this line). Safe to clear .Grad: parameters
+                // never appear as outputs (they're graph leaves), so we can't
+                // accidentally drop a param's gradient here.
                 node.Output.GradFn = null;
                 if (!ShouldKeepGrad(node.Output))
                     node.Output.Grad = null;
 
-                // Input0 is non-nullable on GradNode<T>; the recorder
-                // always populates it.
+                // For Inputs: always null .GradFn (the graph traversal is
+                // over so the back-pointer is dead weight). For .Grad:
+                //
+                //   sourceSet != null:
+                //     The caller provided an explicit source list. Clear
+                //     .Grad on non-source inputs (matches the established
+                //     "sources specifies what to keep" contract).
+                //   sourceSet == null AND input is NOT a graph leaf:
+                //     We've cleared this input's GradFn — i.e. it WAS an
+                //     intermediate (output of an upstream op). Its .Grad
+                //     also gets cleared on the upstream op's iteration,
+                //     but the consumer-visible gradient is preserved
+                //     through the returned `grads` dictionary either way.
+                //     Clearing it here doesn't drop data.
+                //   sourceSet == null AND input IS a graph leaf:
+                //     The input has GradFn = null already (a parameter or
+                //     a user-supplied input). Preserving .Grad here keeps
+                //     `param.Grad` populated for callers that read it
+                //     directly (a small subset, but BC-relevant).
+                //
+                // We can distinguish "intermediate input" from "leaf input"
+                // by checking GradFn BEFORE this iteration nulls it. Cache
+                // the snapshot below.
+                bool input0WasIntermediate = node.Input0.GradFn is not null;
                 node.Input0.GradFn = null;
-                if (!ShouldKeepGrad(node.Input0))
+                if (sourceSet is not null)
+                {
+                    if (!ShouldKeepGrad(node.Input0)) node.Input0.Grad = null;
+                }
+                else if (input0WasIntermediate && !ShouldKeepGrad(node.Input0))
+                {
                     node.Input0.Grad = null;
+                }
 
                 if (node.Input1 is not null)
                 {
+                    bool wasIntermediate = node.Input1.GradFn is not null;
                     node.Input1.GradFn = null;
-                    if (!ShouldKeepGrad(node.Input1))
+                    if (sourceSet is not null)
+                    {
+                        if (!ShouldKeepGrad(node.Input1)) node.Input1.Grad = null;
+                    }
+                    else if (wasIntermediate && !ShouldKeepGrad(node.Input1))
+                    {
                         node.Input1.Grad = null;
+                    }
                 }
                 if (node.Input2 is not null)
                 {
+                    bool wasIntermediate = node.Input2.GradFn is not null;
                     node.Input2.GradFn = null;
-                    if (!ShouldKeepGrad(node.Input2))
+                    if (sourceSet is not null)
+                    {
+                        if (!ShouldKeepGrad(node.Input2)) node.Input2.Grad = null;
+                    }
+                    else if (wasIntermediate && !ShouldKeepGrad(node.Input2))
+                    {
                         node.Input2.Grad = null;
+                    }
                 }
                 if (node.InputsOverflow is not null)
                 {
                     foreach (var inp in node.InputsOverflow)
                     {
                         if (inp is null) continue;
+                        bool wasIntermediate = inp.GradFn is not null;
                         inp.GradFn = null;
-                        if (!ShouldKeepGrad(inp))
+                        if (sourceSet is not null)
+                        {
+                            if (!ShouldKeepGrad(inp)) inp.Grad = null;
+                        }
+                        else if (wasIntermediate && !ShouldKeepGrad(inp))
+                        {
                             inp.Grad = null;
+                        }
                     }
                 }
             }

--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
@@ -1086,7 +1086,7 @@ public sealed class GradientTape<T> : IDisposable
         if (loss.Length != 1)
             throw new ArgumentException($"CompileBackward requires a scalar loss tensor (length 1), got length {loss.Length}.", nameof(loss));
 
-        return new CompiledBackwardGraph<T>(_entries, loss, sources, _engine);
+        return new CompiledBackwardGraph<T>(_entries, loss, sources, _engine, _retainGrad);
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/Autodiff/OptimizedBackwardPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/OptimizedBackwardPlan.cs
@@ -23,19 +23,29 @@ internal sealed class OptimizedBackwardPlan<T>
     private readonly Tensor<T>[]? _sources;
     private readonly IEngine _engine;
 
+    /// <summary>
+    /// Optional reference to the owning tape's RetainGrad set. Same parity rule
+    /// as <see cref="CompiledBackwardGraph{T}"/> — when a user marks a tensor
+    /// with <see cref="GradientTape{T}.RetainGrad"/>, its <c>.Grad</c> must
+    /// survive the cleanup phase below.
+    /// </summary>
+    private readonly HashSet<Tensor<T>>? _retainGrad;
+
     internal OptimizedBackwardPlan(
         TapeEntryArena<T> entries,
         int[] reachableIndices,
         Tensor<T> loss,
         Tensor<T>[]? sources,
         IEngine engine,
-        BackwardAnalysis analysis)
+        BackwardAnalysis analysis,
+        HashSet<Tensor<T>>? retainGrad = null)
     {
         _entries = entries;
         _reachableIndices = reachableIndices;
         _loss = loss;
         _sources = sources;
         _engine = engine;
+        _retainGrad = retainGrad;
         _ = analysis; // Retained for future backward optimization passes
     }
 
@@ -107,6 +117,22 @@ internal sealed class OptimizedBackwardPlan<T>
         {
             cse.Clear();
             DifferentiableOps.ClearIndexedGrads();
+
+            // Parity with CompiledBackwardGraph.Execute's finally block:
+            // a consumer-side cache that retains a forward intermediate
+            // (e.g. a layer's `_lastInput`) would otherwise pin one full
+            // backward's worth of gradient tensors across successive
+            // Execute calls when this optimized path is taken (the default
+            // when TensorCodecOptions.EnableAlgebraicBackward is on).
+            // Same RetainGrad / sourceSet preservation rule used by the
+            // non-optimized path so behavior is consistent.
+            HashSet<Tensor<T>>? sourceSet = null;
+            if (_sources is not null)
+            {
+                sourceSet = new HashSet<Tensor<T>>(ReferenceEqualityComparer<Tensor<T>>.Instance);
+                foreach (var s in _sources) sourceSet.Add(s);
+            }
+
             foreach (int i in _reachableIndices)
             {
                 ref var e = ref _entries[i];
@@ -116,6 +142,13 @@ internal sealed class OptimizedBackwardPlan<T>
                 if (e.InputCount >= 3 && e.Input2 != null) e.Input2._gradIndex = -1;
                 if (e.InputsOverflow != null)
                     foreach (var inp in e.InputsOverflow) inp._gradIndex = -1;
+
+                // e.Output is always a graph intermediate; inputs may be
+                // leaves (parameters) so we don't touch their .Grad here.
+                bool keepGrad =
+                    (sourceSet?.Contains(e.Output) == true)
+                    || (_retainGrad is not null && _retainGrad.Contains(e.Output));
+                if (!keepGrad) e.Output.Grad = null;
             }
         }
 
@@ -172,13 +205,14 @@ internal sealed class OptimizedBackwardPlan<T>
         int[] reachableIndices,
         Tensor<T> loss,
         Tensor<T>[]? sources,
-        IEngine engine)
+        IEngine engine,
+        HashSet<Tensor<T>>? retainGrad = null)
     {
         var analysis = SymbolicBackwardGraphBuilder.Analyze(entries, reachableIndices);
 
         if (!analysis.CanBenefit)
             return null;
 
-        return new OptimizedBackwardPlan<T>(entries, reachableIndices, loss, sources, engine, analysis);
+        return new OptimizedBackwardPlan<T>(entries, reachableIndices, loss, sources, engine, analysis, retainGrad);
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeLeakTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeLeakTests.cs
@@ -451,6 +451,411 @@ public class GradientTapeLeakTests
         }
     }
 
+    /// <summary>
+    /// Reopened-#1227 repro: AiDotNet consumer-side measurement (see
+    /// ooples/AiDotNet PR #1285) shows ~1.5 MB/call retention at
+    /// L=4 / 1000-call scale, even though the single-encoder-block
+    /// canary above asserts 0 B/call. Either the leak is in an op
+    /// the canary doesn't exercise, or it only manifests at the
+    /// chained-layers scale.
+    ///
+    /// This probe mirrors a 4-encoder-layer transformer (the
+    /// reporter's exact config: Heads=4, Dim=128, FF=512, Seq=64,
+    /// 4 encoder layers, pre-norm style with residual connections,
+    /// bias add on every dense projection, output classification
+    /// head, softmax+cross-entropy-style loss). If retention scales
+    /// linearly with layer count, we have a Tensors-side repro that
+    /// matches the consumer's symptom.
+    /// </summary>
+    [Fact]
+    public void TrainStep_FourLayerTransformer_NoLinearLeakAcrossWindows()
+    {
+        var engine = AiDotNetEngine.Current;
+        const int Batch = 1, Seq = 64, Dim = 128, FF = 512, Vocab = 256;
+        const int NumLayers = 4;
+        AiDotNet.Tensors.Helpers.AutoTensorCache.Clear();
+        AiDotNet.Tensors.Engines.Autodiff.TensorPool<float>.Clear();
+
+        // Per-layer weights (4 sets of QKV/output + FFN + LayerNorm gain/bias).
+        var perLayerW = new System.Collections.Generic.List<Tensor<float>[]>(NumLayers);
+        for (int L = 0; L < NumLayers; L++)
+        {
+            perLayerW.Add(new[]
+            {
+                MakeTensor(new[] { Dim, Dim }, 0.05f, L * 10 + 1),  // wq
+                MakeTensor(new[] { Dim, Dim }, 0.05f, L * 10 + 2),  // wk
+                MakeTensor(new[] { Dim, Dim }, 0.05f, L * 10 + 3),  // wv
+                MakeTensor(new[] { Dim, Dim }, 0.05f, L * 10 + 4),  // wo
+                MakeTensor(new[] { Dim, FF }, 0.05f, L * 10 + 5),   // w1
+                MakeTensor(new[] { FF, Dim }, 0.05f, L * 10 + 6),   // w2
+                MakeTensor(new[] { Dim }, 1.0f, L * 10 + 7),        // ln1_gamma
+                MakeTensor(new[] { Dim }, 0.0f, L * 10 + 8),        // ln1_beta
+                MakeTensor(new[] { Dim }, 1.0f, L * 10 + 9),        // ln2_gamma
+                MakeTensor(new[] { Dim }, 0.0f, L * 10 + 10),       // ln2_beta
+            });
+        }
+        var wOut = MakeTensor(new[] { Dim, Vocab }, 0.05f, 999);
+        var allSources = new System.Collections.Generic.List<Tensor<float>>();
+        foreach (var W in perLayerW) allSources.AddRange(W);
+        allSources.Add(wOut);
+        var sources = allSources.ToArray();
+
+        // Two consecutive 200-call windows with forced Gen2 GC between them.
+        // A linear leak shows equal growth in both windows; warm-up shows
+        // large window-1 and near-zero window-2.
+        const int Warmup = 25;
+        const int Measure = 200;
+        for (int i = 0; i < Warmup; i++) Step();
+        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+        long m0 = GC.GetTotalMemory(forceFullCollection: true);
+
+        for (int i = 0; i < Measure; i++) Step();
+        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+        long m1 = GC.GetTotalMemory(forceFullCollection: true);
+
+        for (int i = 0; i < Measure; i++) Step();
+        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+        long m2 = GC.GetTotalMemory(forceFullCollection: true);
+
+        long w1PerCall = (m1 - m0) / Measure;
+        long w2PerCall = (m2 - m1) / Measure;
+        _output.WriteLine(
+            $"4-layer Transformer leak probe (Dim={Dim} FF={FF} Seq={Seq} L={NumLayers}): " +
+            $"win1={w1PerCall} B/call, win2={w2PerCall} B/call " +
+            $"(m0={m0} m1={m1} m2={m2}; {Measure} iters/window)");
+
+        // Tripwire: second-window per-call retention < 100 KB. The reporter's
+        // consumer-side observation was ~360 KB/call at L=1 → ~1.5 MB at L=4,
+        // so a 100 KB ceiling on a 4-layer probe catches both the issue's
+        // signature and any future regression at this scale.
+        Assert.True(w2PerCall < 100_000,
+            $"4-layer Transformer second-window retention {w2PerCall} B/call exceeds 100 KB/call. " +
+            $"Matches AiDotNet#1227 / Tensors#283 residual-leak signature. " +
+            $"win1={w1PerCall} B/call, m0={m0} m1={m1} m2={m2}.");
+
+        void Step()
+        {
+            // Token "embedding": synthesise an input directly at [B*Seq, Dim]
+            // since the Tensors layer doesn't have an embedding op surfaced
+            // to the test, and a leak rooted in the gather would surface
+            // separately. The hot per-layer ops are what we want.
+            var x = MakeTensor(new[] { Batch * Seq, Dim }, 1.0f, 99);
+            using var tape = new GradientTape<float>();
+
+            Tensor<float> h = x;
+            for (int L = 0; L < NumLayers; L++)
+            {
+                var W = perLayerW[L];
+                Tensor<float> wq = W[0], wk = W[1], wv = W[2], wo = W[3], w1 = W[4], w2 = W[5];
+                Tensor<float> g1 = W[6], b1 = W[7], g2 = W[8], b2 = W[9];
+
+                // Pre-norm + attention
+                var xNorm = engine.TensorLayerNorm(h, g1, b1, epsilon: 1e-5);
+                var q = engine.TensorMatMul(xNorm, wq);
+                var k = engine.TensorMatMul(xNorm, wk);
+                var v = engine.TensorMatMul(xNorm, wv);
+                var scores = engine.TensorMatMulTransposed(q, k);
+                var attn = engine.Softmax(scores, axis: -1);
+                var ctx = engine.TensorMatMul(attn, v);
+                var proj = engine.TensorMatMul(ctx, wo);
+                h = engine.TensorAdd(h, proj);
+
+                // Pre-norm + FFN
+                var hNorm = engine.TensorLayerNorm(h, g2, b2, epsilon: 1e-5);
+                var ffn1 = engine.TensorMatMul(hNorm, w1);
+                var ffn1Act = engine.ReLU(ffn1);
+                var ffn2 = engine.TensorMatMul(ffn1Act, w2);
+                h = engine.TensorAdd(h, ffn2);
+            }
+
+            // Output projection: reduce per-token to vocab logits, then
+            // reduce to a scalar loss surrogate (sum-of-squared-logits is
+            // enough to exercise backward through every parameter).
+            var logits = engine.TensorMatMul(h, wOut);
+            var loss = engine.ReduceSum(logits, null);
+            var grads = tape.ComputeGradients(loss, sources: sources);
+
+            // Simulate optimizer reading .Grad on every source — that's the
+            // consumer-side pattern that exercises source-tensor pinning.
+            foreach (var s in sources)
+            {
+                Assert.True(grads.ContainsKey(s));
+                Assert.NotNull(s.Grad);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Like <see cref="TrainStep_FourLayerTransformer_NoLinearLeakAcrossWindows"/>
+    /// but with the ops AiDotNet's MultiHeadAttentionLayer actually uses
+    /// internally — Permute (for the head-split transpose) and FusedLinear
+    /// (for the output projection's matmul+bias). The simpler 4-layer probe
+    /// passes at 0 B/call, so if AiDotNet leaks at 1.5 MB/call the leak
+    /// must be in an op the simpler probe doesn't exercise. This probe
+    /// adds the candidates one by one.
+    /// </summary>
+    [Fact]
+    public void TrainStep_FourLayerTransformer_WithPermuteAndFusedLinear_NoLeak()
+    {
+        var engine = AiDotNetEngine.Current;
+        const int Batch = 1, Seq = 64, Dim = 128, FF = 512, Heads = 4, HeadDim = Dim / Heads;
+        const int NumLayers = 4;
+        AiDotNet.Tensors.Helpers.AutoTensorCache.Clear();
+        AiDotNet.Tensors.Engines.Autodiff.TensorPool<float>.Clear();
+
+        // Per-layer weights + biases (FusedLinear takes bias).
+        var perLayerW = new System.Collections.Generic.List<Tensor<float>[]>(NumLayers);
+        for (int L = 0; L < NumLayers; L++)
+        {
+            perLayerW.Add(new[]
+            {
+                MakeTensor(new[] { Dim, Dim }, 0.05f, L * 20 + 1),   // wq
+                MakeTensor(new[] { Dim, Dim }, 0.05f, L * 20 + 2),   // wk
+                MakeTensor(new[] { Dim, Dim }, 0.05f, L * 20 + 3),   // wv
+                MakeTensor(new[] { Dim, Dim }, 0.05f, L * 20 + 4),   // wo
+                MakeTensor(new[] { Dim }, 0.0f, L * 20 + 5),         // bo (bias for output proj)
+                MakeTensor(new[] { Dim, FF }, 0.05f, L * 20 + 6),    // w1
+                MakeTensor(new[] { FF }, 0.0f, L * 20 + 7),          // b1
+                MakeTensor(new[] { FF, Dim }, 0.05f, L * 20 + 8),    // w2
+                MakeTensor(new[] { Dim }, 0.0f, L * 20 + 9),         // b2
+                MakeTensor(new[] { Dim }, 1.0f, L * 20 + 10),        // ln1_gamma
+                MakeTensor(new[] { Dim }, 0.0f, L * 20 + 11),        // ln1_beta
+                MakeTensor(new[] { Dim }, 1.0f, L * 20 + 12),        // ln2_gamma
+                MakeTensor(new[] { Dim }, 0.0f, L * 20 + 13),        // ln2_beta
+            });
+        }
+        var wOut = MakeTensor(new[] { Dim, 256 }, 0.05f, 999);
+        var allSources = new System.Collections.Generic.List<Tensor<float>>();
+        foreach (var W in perLayerW) allSources.AddRange(W);
+        allSources.Add(wOut);
+        var sources = allSources.ToArray();
+
+        const int Warmup = 25;
+        const int Measure = 200;
+        for (int i = 0; i < Warmup; i++) Step();
+        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+        long m0 = GC.GetTotalMemory(forceFullCollection: true);
+
+        for (int i = 0; i < Measure; i++) Step();
+        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+        long m1 = GC.GetTotalMemory(forceFullCollection: true);
+
+        for (int i = 0; i < Measure; i++) Step();
+        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+        long m2 = GC.GetTotalMemory(forceFullCollection: true);
+
+        long w1PerCall = (m1 - m0) / Measure;
+        long w2PerCall = (m2 - m1) / Measure;
+        _output.WriteLine(
+            $"4L-Transformer + Permute + FusedLinear leak probe: " +
+            $"win1={w1PerCall} B/call, win2={w2PerCall} B/call " +
+            $"(m0={m0} m1={m1} m2={m2}; {Measure} iters/window)");
+
+        Assert.True(w2PerCall < 100_000,
+            $"4L-Transformer+Permute+FusedLinear second-window retention {w2PerCall} B/call > 100 KB. " +
+            $"win1={w1PerCall} B/call, m0={m0} m1={m1} m2={m2}.");
+
+        void Step()
+        {
+            var x = MakeTensor(new[] { Batch * Seq, Dim }, 1.0f, 99);
+            using var tape = new GradientTape<float>();
+
+            Tensor<float> h = x;
+            for (int L = 0; L < NumLayers; L++)
+            {
+                var W = perLayerW[L];
+                Tensor<float> wq = W[0], wk = W[1], wv = W[2], wo = W[3], bo = W[4];
+                Tensor<float> w1 = W[5], b1 = W[6], w2 = W[7], b2 = W[8];
+                Tensor<float> g1 = W[9], beta1 = W[10], g2 = W[11], beta2 = W[12];
+
+                // Pre-norm
+                var xNorm = engine.TensorLayerNorm(h, g1, beta1, epsilon: 1e-5);
+
+                // QKV projections [B*S, Dim] -> [B*S, Dim]
+                var Q_flat = engine.TensorMatMul(xNorm, wq);
+                var K_flat = engine.TensorMatMul(xNorm, wk);
+                var V_flat = engine.TensorMatMul(xNorm, wv);
+
+                // Reshape + Permute to [B, Heads, S, HeadDim] (mirrors MHA layer)
+                var Q4 = engine.Reshape(Q_flat, new[] { Batch, Seq, Heads, HeadDim });
+                var K4 = engine.Reshape(K_flat, new[] { Batch, Seq, Heads, HeadDim });
+                var V4 = engine.Reshape(V_flat, new[] { Batch, Seq, Heads, HeadDim });
+                var queries = engine.TensorPermute(Q4, new[] { 0, 2, 1, 3 });
+                var keys = engine.TensorPermute(K4, new[] { 0, 2, 1, 3 });
+                var values = engine.TensorPermute(V4, new[] { 0, 2, 1, 3 });
+
+                // Scaled dot-product attention
+                var ctx4 = engine.ScaledDotProductAttention(queries, keys, values,
+                    mask: null,
+                    scale: 1.0 / Math.Sqrt(HeadDim),
+                    out var attnWeights);
+
+                // [B, H, S, D] -> [B, S, H, D] -> [B*S, Dim]
+                var ctxT = engine.TensorPermute(ctx4, new[] { 0, 2, 1, 3 });
+                var ctxFlat = engine.Reshape(ctxT, new[] { Batch * Seq, Dim });
+
+                // Fused output projection (matmul+bias, no activation)
+                var attnProj = engine.FusedLinear(ctxFlat, wo, bo, FusedActivationType.None);
+                h = engine.TensorAdd(h, attnProj);
+
+                // Pre-norm + FFN with FusedLinear (matches DenseLayer pattern)
+                var hNorm = engine.TensorLayerNorm(h, g2, beta2, epsilon: 1e-5);
+                var ffn1 = engine.FusedLinear(hNorm, w1, b1, FusedActivationType.ReLU);
+                var ffn2 = engine.FusedLinear(ffn1, w2, b2, FusedActivationType.None);
+                h = engine.TensorAdd(h, ffn2);
+            }
+
+            // Output classification logits
+            var logits = engine.TensorMatMul(h, wOut);
+            var loss = engine.ReduceSum(logits, null);
+            var grads = tape.ComputeGradients(loss, sources: sources);
+            foreach (var s in sources)
+            {
+                Assert.True(grads.ContainsKey(s));
+                Assert.NotNull(s.Grad);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reopened-#1227 regression. The original cleanup at the end of
+    /// <c>ComputeGradients</c> gated on <c>sources is not null</c>, which
+    /// meant any caller passing <c>null</c> (the standard consumer pattern
+    /// when reading gradients from the returned dictionary) skipped the
+    /// cleanup entirely — every forward intermediate kept its
+    /// <c>GradFn</c> back-pointer, and any external code that retained a
+    /// single intermediate (e.g. a layer's <c>_lastInput</c> cache)
+    /// pinned the whole graph across calls. ooples/AiDotNet#1227
+    /// measured ~1.5 MB/call retention on a 4-encoder-layer Transformer
+    /// going through this exact path.
+    ///
+    /// This probe matches AiDotNet's pattern: <c>sources: null</c>, no
+    /// retain-grad, single tape per Step. It also retains an intermediate
+    /// to mimic the layer-cache pinning that triggered the consumer-side
+    /// leak. Without the fix, second-window retention runs around 100 KB/call
+    /// on this 4-layer config; with the fix it stays at 0 B/call.
+    /// </summary>
+    [Fact]
+    public void TrainStep_FourLayerTransformer_NullSources_NoLeak()
+    {
+        var engine = AiDotNetEngine.Current;
+        const int Batch = 1, Seq = 64, Dim = 128, FF = 512;
+        const int NumLayers = 4;
+        AiDotNet.Tensors.Helpers.AutoTensorCache.Clear();
+        AiDotNet.Tensors.Engines.Autodiff.TensorPool<float>.Clear();
+
+        var perLayerW = new System.Collections.Generic.List<Tensor<float>[]>(NumLayers);
+        for (int L = 0; L < NumLayers; L++)
+        {
+            perLayerW.Add(new[]
+            {
+                MakeTensor(new[] { Dim, Dim }, 0.05f, L * 10 + 1),
+                MakeTensor(new[] { Dim, Dim }, 0.05f, L * 10 + 2),
+                MakeTensor(new[] { Dim, Dim }, 0.05f, L * 10 + 3),
+                MakeTensor(new[] { Dim, Dim }, 0.05f, L * 10 + 4),
+                MakeTensor(new[] { Dim, FF }, 0.05f, L * 10 + 5),
+                MakeTensor(new[] { FF, Dim }, 0.05f, L * 10 + 6),
+                MakeTensor(new[] { Dim }, 1.0f, L * 10 + 7),
+                MakeTensor(new[] { Dim }, 0.0f, L * 10 + 8),
+                MakeTensor(new[] { Dim }, 1.0f, L * 10 + 9),
+                MakeTensor(new[] { Dim }, 0.0f, L * 10 + 10),
+            });
+        }
+        // Mimic AiDotNet's layer-cache pattern: each MultiHeadAttentionLayer
+        // and DenseLayer stores 5-10 `_last*` fields pointing at forward
+        // intermediates. Simulate that with one slot per layer × multiple
+        // intermediates per layer.
+        Tensor<float>?[,] layerCaches = new Tensor<float>?[NumLayers, 8];
+
+        const int Warmup = 25;
+        const int Measure = 200;
+        for (int i = 0; i < Warmup; i++) Step();
+        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+        long m0 = GC.GetTotalMemory(forceFullCollection: true);
+
+        for (int i = 0; i < Measure; i++) Step();
+        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+        long m1 = GC.GetTotalMemory(forceFullCollection: true);
+
+        for (int i = 0; i < Measure; i++) Step();
+        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+        long m2 = GC.GetTotalMemory(forceFullCollection: true);
+
+        long w1PerCall = (m1 - m0) / Measure;
+        long w2PerCall = (m2 - m1) / Measure;
+        _output.WriteLine(
+            $"4L-Transformer null-sources leak probe " +
+            $"(reopened-AiDotNet#1227): " +
+            $"win1={w1PerCall} B/call, win2={w2PerCall} B/call " +
+            $"(m0={m0} m1={m1} m2={m2}; {Measure} iters/window)");
+
+        // Hold the references to defeat the JIT's dead-code elimination —
+        // without this, the JIT can drop layerCaches early and we
+        // get a false-clean reading even pre-fix.
+        Assert.NotNull(layerCaches);
+
+        // 50 KB/call ceiling. Pre-fix this test produced ~100 KB/call;
+        // with the cleanup-runs-for-null-sources fix it drops to 0 B/call
+        // on net10.0. The 50 KB band accommodates legitimate per-iter
+        // warm-up costs (delegate caching, pool growth) without
+        // tolerating the original graph-retention pattern.
+        Assert.True(w2PerCall < 50_000,
+            $"Reopened-AiDotNet#1227: null-sources ComputeGradients leaked " +
+            $"{w2PerCall} B/call > 50 KB on a 4-encoder-layer Transformer with " +
+            $"a single retained forward intermediate. " +
+            $"win1={w1PerCall} B/call, m0={m0} m1={m1} m2={m2}.");
+
+        void Step()
+        {
+            var x = MakeTensor(new[] { Batch * Seq, Dim }, 1.0f, 99);
+            using var tape = new GradientTape<float>();
+
+            Tensor<float> h = x;
+            for (int L = 0; L < NumLayers; L++)
+            {
+                var W = perLayerW[L];
+                Tensor<float> wq = W[0], wk = W[1], wv = W[2], wo = W[3];
+                Tensor<float> w1 = W[4], w2 = W[5];
+                Tensor<float> g1 = W[6], beta1 = W[7], g2 = W[8], beta2 = W[9];
+
+                var xNorm = engine.TensorLayerNorm(h, g1, beta1, epsilon: 1e-5);
+                var q = engine.TensorMatMul(xNorm, wq);
+                var k = engine.TensorMatMul(xNorm, wk);
+                var v = engine.TensorMatMul(xNorm, wv);
+                var scores = engine.TensorMatMulTransposed(q, k);
+                var attn = engine.Softmax(scores, axis: -1);
+                var ctx = engine.TensorMatMul(attn, v);
+                var proj = engine.TensorMatMul(ctx, wo);
+                h = engine.TensorAdd(h, proj);
+
+                var hNorm = engine.TensorLayerNorm(h, g2, beta2, epsilon: 1e-5);
+                var ffn1 = engine.TensorMatMul(hNorm, w1);
+                var ffn1Act = engine.ReLU(ffn1);
+                var ffn2 = engine.TensorMatMul(ffn1Act, w2);
+                h = engine.TensorAdd(h, ffn2);
+
+                // Layer-cache simulation: retain forward intermediates the
+                // way AiDotNet's MultiHeadAttentionLayer does via
+                // _lastInput / _lastQueryInput / _lastKeyInput / _lastValueInput
+                // / _lastProjectedQueries / _lastAttentionScores / etc.
+                layerCaches[L, 0] = xNorm;
+                layerCaches[L, 1] = q;
+                layerCaches[L, 2] = k;
+                layerCaches[L, 3] = v;
+                layerCaches[L, 4] = attn;
+                layerCaches[L, 5] = ctx;
+                layerCaches[L, 6] = ffn1Act;
+                layerCaches[L, 7] = h;
+            }
+
+            var loss = engine.ReduceSum(h, null);
+            // Critical: pass sources=null to match AiDotNet's consumer pattern
+            // (NeuralNetworkBase.TrainWithTape reads gradients from the
+            // returned Dictionary, not from tensor.Grad).
+            var grads = tape.ComputeGradients(loss, sources: null);
+        }
+    }
+
     [Fact]
     public void TrainStep_LongRun_1000Iters_StaysUnder10KB_PerCall()
     {

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeLeakTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeLeakTests.cs
@@ -705,7 +705,7 @@ public class GradientTapeLeakTests
                 var ctx4 = engine.ScaledDotProductAttention(queries, keys, values,
                     mask: null,
                     scale: 1.0 / Math.Sqrt(HeadDim),
-                    out var attnWeights);
+                    out _);
 
                 // [B, H, S, D] -> [B, S, H, D] -> [B*S, Dim]
                 var ctxT = engine.TensorPermute(ctx4, new[] { 0, 2, 1, 3 });
@@ -808,10 +808,34 @@ public class GradientTapeLeakTests
             $"win1={w1PerCall} B/call, win2={w2PerCall} B/call " +
             $"(m0={m0} m1={m1} m2={m2}; {Measure} iters/window)");
 
-        // Hold the references to defeat the JIT's dead-code elimination —
-        // without this, the JIT can drop layerCaches early and we
-        // get a false-clean reading even pre-fix.
-        Assert.NotNull(layerCaches);
+        // Hold the references to defeat the JIT's dead-code elimination.
+        // Asserting `layerCaches != null` alone is not enough — the array
+        // identity stays live but the element-store code inside Step()
+        // (`layerCaches[L, k] = …`) can still be eliminated if no read
+        // ever observes the elements. Actually READ every slot and
+        // accumulate a checksum so the stores are provably load-bearing.
+        // A live cached intermediate is what makes this test reproduce
+        // reopened-AiDotNet#1227 — without it the autodiff arena's
+        // natural sweep masks the leak and the probe goes false-clean.
+        int liveCachedCount = 0;
+        long rankSum = 0;
+        for (int L = 0; L < NumLayers; L++)
+        {
+            for (int k = 0; k < 8; k++)
+            {
+                var cached = layerCaches[L, k];
+                if (cached is not null)
+                {
+                    liveCachedCount++;
+                    rankSum += cached.Rank;
+                }
+            }
+        }
+        GC.KeepAlive(layerCaches);
+        Assert.True(liveCachedCount > 0,
+            $"layerCaches expected at least one retained intermediate after Step() ran, " +
+            $"got {liveCachedCount}. JIT may have dead-store-eliminated the cache writes " +
+            $"(rankSum={rankSum}), which would invalidate the leak probe.");
 
         // 50 KB/call ceiling. Pre-fix this test produced ~100 KB/call;
         // with the cleanup-runs-for-null-sources fix it drops to 0 B/call

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeLeakTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeLeakTests.cs
@@ -500,22 +500,26 @@ public class GradientTapeLeakTests
         allSources.Add(wOut);
         var sources = allSources.ToArray();
 
-        // Two consecutive 200-call windows with forced Gen2 GC between them.
-        // A linear leak shows equal growth in both windows; warm-up shows
-        // large window-1 and near-zero window-2.
+        // Two consecutive 200-call windows with StableForcedGc()/LiveBytes()
+        // sampling for cross-platform stability under Server GC. A linear leak
+        // shows window-2 retention ≈ window-1 retention; a one-time warmup
+        // shows window-1 high and window-2 near-zero. The "no linear leak"
+        // claim asserts BOTH that the absolute window-2 figure is bounded AND
+        // that window-2 is not significantly larger than window-1 (so leaks
+        // can't hide behind warmup noise).
         const int Warmup = 25;
         const int Measure = 200;
         for (int i = 0; i < Warmup; i++) Step();
-        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
-        long m0 = GC.GetTotalMemory(forceFullCollection: true);
+        StableForcedGc();
+        long m0 = LiveBytes();
 
         for (int i = 0; i < Measure; i++) Step();
-        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
-        long m1 = GC.GetTotalMemory(forceFullCollection: true);
+        StableForcedGc();
+        long m1 = LiveBytes();
 
         for (int i = 0; i < Measure; i++) Step();
-        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
-        long m2 = GC.GetTotalMemory(forceFullCollection: true);
+        StableForcedGc();
+        long m2 = LiveBytes();
 
         long w1PerCall = (m1 - m0) / Measure;
         long w2PerCall = (m2 - m1) / Measure;
@@ -532,6 +536,16 @@ public class GradientTapeLeakTests
             $"4-layer Transformer second-window retention {w2PerCall} B/call exceeds 100 KB/call. " +
             $"Matches AiDotNet#1227 / Tensors#283 residual-leak signature. " +
             $"win1={w1PerCall} B/call, m0={m0} m1={m1} m2={m2}.");
+
+        // Slope check: window-2 retention should not exceed window-1 by more
+        // than 50 KB/call. A true linear leak would show w2 ≈ w1; this guard
+        // catches a regression where retention grows across windows (the
+        // signature that distinguishes a leak from one-time warmup).
+        Assert.True(w2PerCall < w1PerCall + 50_000,
+            $"4-layer Transformer leak grows across windows: " +
+            $"win1={w1PerCall} B/call → win2={w2PerCall} B/call " +
+            $"(slope > 50 KB/call). A linear leak should hold w1 ≈ w2; " +
+            $"w2 > w1 + 50KB indicates accelerating retention.");
 
         void Step()
         {
@@ -630,19 +644,22 @@ public class GradientTapeLeakTests
         allSources.Add(wOut);
         var sources = allSources.ToArray();
 
+        // StableForcedGc()/LiveBytes() per the file's standard two-window
+        // half-window methodology — see TrainStep_FourLayerTransformer_
+        // NoLinearLeakAcrossWindows for the matching pattern.
         const int Warmup = 25;
         const int Measure = 200;
         for (int i = 0; i < Warmup; i++) Step();
-        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
-        long m0 = GC.GetTotalMemory(forceFullCollection: true);
+        StableForcedGc();
+        long m0 = LiveBytes();
 
         for (int i = 0; i < Measure; i++) Step();
-        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
-        long m1 = GC.GetTotalMemory(forceFullCollection: true);
+        StableForcedGc();
+        long m1 = LiveBytes();
 
         for (int i = 0; i < Measure; i++) Step();
-        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
-        long m2 = GC.GetTotalMemory(forceFullCollection: true);
+        StableForcedGc();
+        long m2 = LiveBytes();
 
         long w1PerCall = (m1 - m0) / Measure;
         long w2PerCall = (m2 - m1) / Measure;
@@ -767,19 +784,21 @@ public class GradientTapeLeakTests
         // intermediates per layer.
         Tensor<float>?[,] layerCaches = new Tensor<float>?[NumLayers, 8];
 
+        // StableForcedGc()/LiveBytes() per the file's standard two-window
+        // half-window methodology — same as the other multi-layer probes.
         const int Warmup = 25;
         const int Measure = 200;
         for (int i = 0; i < Warmup; i++) Step();
-        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
-        long m0 = GC.GetTotalMemory(forceFullCollection: true);
+        StableForcedGc();
+        long m0 = LiveBytes();
 
         for (int i = 0; i < Measure; i++) Step();
-        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
-        long m1 = GC.GetTotalMemory(forceFullCollection: true);
+        StableForcedGc();
+        long m1 = LiveBytes();
 
         for (int i = 0; i < Measure; i++) Step();
-        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
-        long m2 = GC.GetTotalMemory(forceFullCollection: true);
+        StableForcedGc();
+        long m2 = LiveBytes();
 
         long w1PerCall = (m1 - m0) / Measure;
         long w2PerCall = (m2 - m1) / Measure;


### PR DESCRIPTION
Reopens #283. The residual leak reported there as ~400 KB/call (and which we measured as ~1.5 MB/call on a 4-encoder-layer Transformer in [AiDotNet#1227](https://github.com/ooples/AiDotNet/issues/1227)) has a different root cause than the AutoTracer recording PR #284 fixed.

## Root cause

`ComputeGradientsViaGraph`'s end-of-backward cleanup walks the topological order of `GradNode`s and decides per-tensor whether to clear `.Grad` / `.GradFn`. The deciding helper had:

```csharp
bool ShouldKeepGrad(Tensor<T> t)
{
    if (sourceSet is null) return true;   // <-- the bug
    if (sourceSet.Contains(t)) return true;
    if (_retainGrad is not null && _retainGrad.Contains(t)) return true;
    return false;
}
```

The accompanying comment said *"sources == null means the caller wants the full grads dict, so we can't safely null .Grad on anything"*. But that's wrong for the common consumer pattern: the Dictionary returned by `ComputeGradients` holds the **same gradient tensor references** as `tensor.Grad`. Clearing the per-tensor field doesn't drop the data the caller can still access through the dict.

Every long-running training loop that calls `ComputeGradients(loss, sources: null)` and consumes the returned Dictionary hits this path:

- `AiDotNet.NeuralNetworkBase.TrainWithTape` (line 4657 in the consumer repo)
- every auto-differentiation-driven optimizer wired through it

The result: every forward intermediate's `.Grad` stays populated for the lifetime of the intermediate. When any external code retains an intermediate (a layer's `_lastInput` field, a streaming-pool retention, a debugging hook, …) the whole chain of gradient tensors and their backing storage bleeds across calls.

AiDotNet#1227 measured this at **~1.5 MB/call** on a 4-encoder-layer Transformer (1000 calls = 1.5 GB managed-heap growth; projecting to ~84 GB at the reporter's 56k-sample scale, which fully explains the original OS-lockup symptom).

## Fix

`ShouldKeepGrad` now falls through to the same `RetainGrad`-only preservation that explicit-sources mode uses. Forward intermediates (the output of any op in `topoOrder`) get `.Grad` cleared; the gradient values stay live in the returned Dictionary for the caller.

To stay backward-compatible with callers that DO read `tensor.Grad` after a `sources=null` call, the input-side cleanup distinguishes input slots that **were intermediates** (had `GradFn` at the start of cleanup) from input slots that are **graph leaves** (parameters / user inputs, `GradFn == null`). Leaf inputs keep their `.Grad` — that's the parameter-side payload BC-relevant callers expect.

## Verification

| Probe | Pre-fix | Post-fix |
|---|---|---|
| `TrainStep_TransformerBlock_AtIssue283Scale_DoesNotLeak` | 0 B/call | 0 B/call (unchanged) |
| `TrainStep_FourLayerTransformer_NullSources_NoLeak` (NEW) | ~100 KB/call | **0 B/call** |
| AiDotNet#1227 L=4 stress (1000 calls) | +1513 MB heap | **+756 MB heap** (50% reduction) |
| AiDotNet#1227 granular probe (5 × 100 calls) | +151 MB/window (1.55 MB/call) | **+75 MB/window (775 KB/call)** |

All 11 existing leak tests still pass. The broader 514 autodiff-suite tests also pass.

## Caveats

The AiDotNet consumer measurement drops from 1.5 MB/call to 0.75 MB/call (50% reduction) — not all the way to 0. The remaining residual is from a separate retention path that I haven't yet localized; likely either a `[ThreadStatic]` cache I missed or gradient tensors held through a different reference. The new `TrainStep_FourLayerTransformer_NullSources_NoLeak` regression test asserts 0 B/call on the pure-Tensors path that this PR fixes; a follow-up will track the AiDotNet-side residual.

## Closes

- ooples/AiDotNet.Tensors#283 (residual ~400 KB/call after PR #284)
- significantly reduces ooples/AiDotNet#1227 (Transformer.Train OS-lockup symptom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)