### PR TITLE
feat: TensorArena two-tier pool — Pinned (weights) + Scratch (intermediates)

### DIFF
--- a/src/AiDotNet.Tensors/Helpers/TensorAllocator.cs
+++ b/src/AiDotNet.Tensors/Helpers/TensorAllocator.cs
@@ -26,6 +26,43 @@ public static class TensorAllocator
     public const int ArrayPoolThresholdValue = ArrayPoolThreshold;
 
     /// <summary>
+    /// Creates a zero-initialized tensor with the given shape that's pinned
+    /// to the current <see cref="TensorArena"/>'s long-lived tier. Pinned
+    /// allocations survive <see cref="TensorArena.Reset"/> — use this for
+    /// model weights (layer EnsureInitialized), optimizer state (Adam m / v),
+    /// running BatchNorm statistics, anything that's part of the network's
+    /// learnable state and must NOT be re-issued as scratch on the next
+    /// training iteration. Falls back to a plain <see cref="Tensor{T}"/>
+    /// allocation when no arena is active (graceful degradation —
+    /// non-arena callers get GC-tracked allocation, same as
+    /// <see cref="Rent{T}(int[])"/> with TensorPool disabled).
+    /// </summary>
+    public static Tensor<T> RentPinned<T>(int[] shape)
+    {
+        int totalSize = 1;
+        for (int i = 0; i < shape.Length; i++)
+            totalSize = checked(totalSize * shape[i]);
+        if (totalSize == 0) return new Tensor<T>(shape);
+
+        var arena = TensorArena.Current;
+        if (arena != null)
+        {
+            T[]? pinnedArray = arena.TryAllocatePinned<T>(totalSize);
+            if (pinnedArray != null)
+            {
+                var memory = new Memory<T>(pinnedArray, 0, totalSize);
+                return Tensor<T>.FromMemory(memory, shape);
+            }
+        }
+
+        // No active arena — graceful degradation to standard CLR allocation.
+        // The caller's "this lives across iterations" contract still holds
+        // because plain Tensor<T> backing arrays aren't touched by Reset
+        // (they were never in any arena pool to begin with).
+        return new Tensor<T>(shape);
+    }
+
+    /// <summary>
     /// Creates a zero-initialized tensor with the given shape.
     /// Large tensors use ArrayPool to reduce GC pressure; small-medium tensors
     /// use standard CLR allocation. All paths return zeroed memory.

--- a/src/AiDotNet.Tensors/Helpers/TensorArena.cs
+++ b/src/AiDotNet.Tensors/Helpers/TensorArena.cs
@@ -33,16 +33,32 @@ public sealed class TensorArena : IDisposable
     private static TensorArena? _current;
 
     /// <summary>
-    /// Pool of arrays allocated during warmup, keyed by (element type, element count).
-    /// Each bucket holds a list of arrays available for reuse.
+    /// SCRATCH pool: short-lived per-step intermediates. Pool of arrays allocated
+    /// during warmup, keyed by (element type, element count). Cursors rewind on
+    /// <see cref="Reset"/> so the next iteration reuses these arrays. This is
+    /// what every <see cref="TensorAllocator.Rent{T}(int[])"/> call lands in.
     /// </summary>
     private readonly Dictionary<(Type, int), List<Array>> _pool = new();
 
     /// <summary>
-    /// Tracks the reuse cursor per bucket — how many arrays of each (type, size)
-    /// have been handed out since the last Reset().
+    /// Scratch-pool reuse cursor — how many arrays of each (type, size) have
+    /// been handed out since the last <see cref="Reset"/>.
     /// </summary>
     private readonly Dictionary<(Type, int), int> _cursor = new();
+
+    /// <summary>
+    /// PINNED list: long-lived allocations that survive <see cref="Reset"/>.
+    /// Model weights (from layer EnsureInitialized), optimizer moment state
+    /// (Adam m / v), running BatchNorm statistics, positional embeddings —
+    /// anything carried across training steps lives here. Tracked so
+    /// <see cref="Dispose"/> can drop references for GC, but the cursor never
+    /// rewinds, so Reset can't accidentally hand a pinned array out as scratch
+    /// on the next iteration. This eliminates the corruption hazard that
+    /// would otherwise happen if model weights and per-step intermediates
+    /// shared one cursor: rewinding the cursor would let Rent re-issue the
+    /// weight tensor's underlying array as scratch storage.
+    /// </summary>
+    private readonly List<Array> _pinnedArrays = new();
 
     private bool _disposed;
     private readonly TensorArena? _previous;
@@ -90,6 +106,25 @@ public sealed class TensorArena : IDisposable
     internal T[]? TryAllocateUninitialized<T>(int elementCount)
     {
         return TryAllocateCore<T>(elementCount, clear: false);
+    }
+
+    /// <summary>
+    /// Allocates a long-lived array tracked in the PINNED tier. Unlike
+    /// <see cref="TryAllocate{T}"/> (scratch), pinned allocations are NOT
+    /// rewound by <see cref="Reset"/> — the caller can hold a reference
+    /// across many training iterations without risk of the arena re-issuing
+    /// the same backing array as scratch on the next iteration. Use for
+    /// model weights (layer EnsureInitialized), optimizer state (Adam m / v),
+    /// running BatchNorm statistics, anything that's part of the network's
+    /// learnable state. Returns null only when the arena is disposed.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal T[]? TryAllocatePinned<T>(int elementCount)
+    {
+        if (_disposed) return null;
+        var arr = new T[elementCount];
+        _pinnedArrays.Add(arr);
+        return arr;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -227,6 +262,7 @@ public sealed class TensorArena : IDisposable
 
         _pool.Clear();
         _cursor.Clear();
+        _pinnedArrays.Clear();
 
         // Clear tensor ring pools
         if (_tensorRing != null)
@@ -235,4 +271,13 @@ public sealed class TensorArena : IDisposable
             _tensorRingCount = 0;
         }
     }
+
+    /// <summary>
+    /// Number of arrays currently held in the PINNED tier. Diagnostic — lets
+    /// tests / benchmarks verify that long-lived allocations (weights,
+    /// optimizer state) are landing in the right tier and not bloating the
+    /// scratch pool. Pinned count grows monotonically across <see cref="Reset"/>
+    /// calls (only <see cref="Dispose"/> drops these references).
+    /// </summary>
+    public int PinnedArrayCount => _pinnedArrays.Count;
 }


### PR DESCRIPTION
## Summary
Foundational API change for arena-aware training loops. Splits `TensorArena`'s single pool into two tiers so callers can hold model state across `Reset()` boundaries without risk of the arena re-issuing the same backing array as scratch on the next iteration.

Tracks #328 (acceleration defaults audit). Unblocks the consumer-side `TrainWithTape` lifecycle fix, which can't safely "move from per-call arena to outer arena + Reset()" today because the existing single pool will recycle weight tensors back to scratch.

## Why
Profiling paper-canonical VGG16-BN (224×224×3 → 1000, fp64) showed a single Train iteration allocates **5 673 MB** — ~5× the model's weight footprint — triggering 211 Gen-0 + 4 Gen-1 + 2 Gen-2 collections. Most of that is layer EnsureInitialized + per-step intermediates allocated through `TensorAllocator.Rent`, which lands in the arena. `NeuralNetworkBase.TrainWithTape` creates and disposes its own arena every Train call (because the old single-pool design makes outer-arena reuse unsafe), so the pool is destroyed every iteration → no reuse across iterations → full alloc cost on every step.

This PR makes the consumer-side fix tractable.

## Design

| Tier | Lifetime | API | Lives here |
|---|---|---|---|
| **Pinned** | Allocate once, retained until `Dispose` | `TensorAllocator.RentPinned<T>` (new) | Model weights (`EnsureInitialized`), optimizer state (Adam m / v), BatchNorm running stats, positional embeddings — anything carried across training steps |
| **Scratch** | Allocated once, recycled on `Reset()` | `TensorAllocator.Rent<T>` (existing) | Conv2D im2col, attention scores, gradients, per-step intermediates |

`Reset()` rewinds only the Scratch cursor; Pinned is untouched. `Dispose()` clears both.

`RentPinned` falls back to plain `new Tensor<T>(shape)` when no arena is active — graceful degradation, same as `Rent` with `TensorPool.Enabled=false`.

## Implementation
- `TensorArena.cs` — adds `_pinnedArrays` list + `TryAllocatePinned<T>` + `PinnedArrayCount` diagnostic property. `Dispose` clears pinned too.
- `TensorAllocator.cs` — adds `RentPinned<T>(int[] shape)` that routes to `arena.TryAllocatePinned`.
- No changes to existing `Rent` / `Reset` semantics — fully backward compatible.

## Sanity verification (locally)
Standalone diag tool exercised:
- Pinned values written, then scratch overwritten with a different pattern → pinned **unchanged**.
- `Reset()` called, new scratch rented → scratch correctly zeroed (existing Reset contract), new scratch overwritten → pinned **still unchanged**.
- `PinnedArrayCount` increments only on `RentPinned`.

## Follow-ups (separate PRs)
- Consumer repo (`AiDotNet`): migrate `LayerBase.EnsureInitialized` → `RentPinned`, optimizer state tensors → `RentPinned`, remove inner arena from `TrainWithTape`, validate that VGG16 per-iter alloc drops below 1 GB.
- Tensors repo: same migration in any Tensors-internal allocations that survive Reset (BatchNorm running stats, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)