### PR TITLE
feat: GPU auto-detect on by default via ModuleInitializer

### DIFF
--- a/src/AiDotNet.Tensors/Engines/GpuAutoDetectModuleInit.cs
+++ b/src/AiDotNet.Tensors/Engines/GpuAutoDetectModuleInit.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace AiDotNet.Tensors.Engines;
+
+/// <summary>
+/// Module-load-time GPU auto-detection. On .NET 6+ this fires the moment
+/// the AiDotNet.Tensors assembly is loaded — before any model construction
+/// or tensor op — so consumers get GPU acceleration without an explicit
+/// <see cref="AiDotNetEngine.AutoDetectAndConfigureGpu"/> call.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Mirrors the pattern used by the consumer-side <c>BlasEnvDefault</c>
+/// initializer (which auto-sets <c>AIDOTNET_USE_BLAS=1</c>): defaults are
+/// "always on, opt-out via environment variable" so paper-canonical
+/// performance is the out-of-the-box behaviour. Previously
+/// <see cref="AiDotNetEngine.Current"/> defaulted to <see cref="CpuEngine"/>
+/// and nothing in the consumer code, test base, or model classes called
+/// <see cref="AiDotNetEngine.AutoDetectAndConfigureGpu"/>, so every
+/// <c>TryForwardGpuOptimized(...)</c> in the model layer was effectively
+/// dead code on the default path.
+/// </para>
+/// <para>
+/// <b>Opt-out:</b> set <c>AIDOTNET_DISABLE_GPU</c> to any non-empty value
+/// before the process starts (it's checked at module-init time, BEFORE
+/// the AiDotNet.Tensors assembly's static state is touched). Same pattern
+/// as the existing <c>AIDOTNET_USE_BLAS</c> env var.
+/// </para>
+/// <para>
+/// <b>Failure modes:</b> if <see cref="DirectGpuTensorEngine"/>'s ctor
+/// throws (no GPU, missing driver, missing CUDA runtime, etc.), the
+/// initializer swallows the exception and leaves <see cref="AiDotNetEngine.Current"/>
+/// on its CPU default. The initializer itself MUST NOT throw — a thrown
+/// ModuleInitializer aborts the entire AppDomain.
+/// </para>
+/// </remarks>
+internal static class GpuAutoDetectModuleInit
+{
+#if NET6_0_OR_GREATER
+#pragma warning disable CA2255 // ModuleInitializer used intentionally
+    [ModuleInitializer]
+#pragma warning restore CA2255
+    internal static void AutoDetectGpuIfNotOptedOut()
+    {
+        try
+        {
+            // Opt-out gate: AIDOTNET_DISABLE_GPU set to any non-empty
+            // value skips auto-detection. Mirrors BlasEnvDefault's
+            // env-var pattern on the consumer side. Users who explicitly
+            // want CPU (numerical reproducibility, fp64 on consumer GPUs
+            // that throttle double precision, benchmarking baselines)
+            // set this before process startup.
+            var disable = Environment.GetEnvironmentVariable("AIDOTNET_DISABLE_GPU");
+            if (!string.IsNullOrEmpty(disable))
+                return;
+
+            // AutoDetectAndConfigureGpu already wraps DirectGpuTensorEngine
+            // construction in try/catch and falls back to CPU on failure,
+            // so this call is safe at module init even without a GPU /
+            // driver / CUDA runtime present.
+            AiDotNetEngine.AutoDetectAndConfigureGpu();
+        }
+        catch
+        {
+            // Defensive belt-and-suspenders: AutoDetectAndConfigureGpu
+            // already catches its own exceptions, but a thrown
+            // ModuleInitializer takes down the entire AppDomain. Keep
+            // a final guard so module load never fails on a GPU probe.
+        }
+    }
+#endif
+}


### PR DESCRIPTION
## Summary
Part of #328 (acceleration defaults audit) — addresses the "GPU auto-detect is opt-in" finding.

`AiDotNetEngine.Current` defaulted to `CpuEngine` and nothing in the consumer code, test base, or model classes called `AutoDetectAndConfigureGpu()`. As a result, every `TryForwardGpuOptimized(...)` in the model layer was effectively dead code on the default path — even with a CUDA GPU sitting idle. PyTorch's default behaviour is "use GPU if available"; this PR brings AiDotNet.Tensors to parity.

## Implementation
- New `src/AiDotNet.Tensors/Engines/GpuAutoDetectModuleInit.cs` with a `[ModuleInitializer]` that fires at AiDotNet.Tensors assembly load time (before any model construction or tensor op).
- Mirrors the consumer-side `BlasEnvDefault` `[ModuleInitializer]` pattern (auto-sets `AIDOTNET_USE_BLAS=1` similarly).
- Opt-out: set `AIDOTNET_DISABLE_GPU=1` before process startup. Useful for numerical-reproducibility runs (CPU is bit-exact; GPU may vary across drivers / hardware), fp64 workloads on consumer GPUs that throttle double-precision, and CPU baseline benchmarking.
- `net6.0+` only — `ModuleInitializerAttribute` requires .NET 5+. `#if NET6_0_OR_GREATER` guards the attribute; on net471 the initializer is a no-op (`AutoDetectAndConfigureGpu()` remains callable explicitly).
- Failure-mode hardening — `AutoDetectAndConfigureGpu` already wraps `DirectGpuTensorEngine` construction in try/catch and falls back to CPU on failure. The initializer adds a final belt-and-suspenders `try`/`catch` so a thrown `ModuleInitializer` can never abort the AppDomain.

## Verification (locally on a CUDA GTX 1660 Ti)
Standalone diag tool exercised both paths:
- **Default run** → `AiDotNetEngine.Current` is `DirectGpuTensorEngine`; console emits `[AiDotNet] GPU acceleration enabled: Direct GPU Engine (CUDA NVIDIA GeForce GTX 1660 Ti)`.
- **`AIDOTNET_DISABLE_GPU=1` run** → `AiDotNetEngine.Current` is `CpuEngine`; no GPU probe attempted.

## Test plan
- [ ] CI: existing engine-selection tests still pass (none currently set `Current` explicitly, so they'll now run on GPU when CI runners have one — expected to be a no-op on CPU-only runners).
- [ ] Consumer (AiDotNet) — confirm that downstream `TryForwardGpuOptimized` paths actually engage on test runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)