### PR TITLE
feat: comprehensive acceleration-defaults audit fixes (closes #328)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/AiDotNetEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/AiDotNetEngine.cs
@@ -84,27 +84,6 @@ public static class AiDotNetEngine
     }
 
     /// <summary>
-    /// Automatically detects and configures GPU acceleration if available.     
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// This method attempts to initialize DirectGpu acceleration. If successful, the Current
-    /// engine is switched to DirectGpuTensorEngine. If GPU is not available or initialization fails,
-    /// the engine remains on CpuEngine.
-    /// </para>
-    /// <para><b>For Beginners:</b> Call this once at application startup for automatic optimization.
-    ///
-    /// <code>
-    /// // In your Program.cs or Main():
-    /// AiDotNetEngine.AutoDetectAndConfigureGpu();
-    ///
-    /// // Now all operations will automatically use GPU if available!
-    /// </code>
-    ///
-    /// This is safe to call even if you don't have a GPU - it will just stay on CPU mode.
-    /// </para>
-    /// </remarks>
-    /// <summary>
     /// User-configurable log sink for engine-level events (GPU auto-detect status,
     /// engine resets, etc.). When non-null, replaces the default Console.WriteLine
     /// destination — wire to your own logger (Microsoft.Extensions.Logging, Serilog,
@@ -157,17 +136,39 @@ public static class AiDotNetEngine
         catch { /* stdout transport errors are non-fatal */ }
     }
 
-    /// <returns>True if GPU was successfully configured, false otherwise.</returns>
+    /// <summary>
+    /// Automatically detects and configures GPU acceleration if available.
+    /// </summary>
     /// <remarks>
-    /// Original parameterless overload. Preserved as a separate method (not a
-    /// `verbose = true` default on the new overload) so previously-compiled
-    /// consumers that took a binary reference to <c>AutoDetectAndConfigureGpu()</c>
-    /// keep linking against the same metadata signature. Forwards to the
-    /// verbose-aware overload with the default-verbose value.
+    /// <para>
+    /// Attempts to initialize DirectGpu acceleration. If successful, the <see cref="Current"/>
+    /// engine is switched to <c>DirectGpuTensorEngine</c>. If GPU is not available or
+    /// initialization fails, the engine remains on <c>CpuEngine</c>.
+    /// </para>
+    /// <para><b>For Beginners:</b> Call this once at application startup for automatic optimization.
+    /// <code>
+    /// // In your Program.cs or Main():
+    /// AiDotNetEngine.AutoDetectAndConfigureGpu();
+    ///
+    /// // Now all operations will automatically use GPU if available!
+    /// </code>
+    /// Safe to call even without a GPU — falls back to CPU silently.</para>
+    /// <para>
+    /// Original parameterless overload. Preserved as a distinct method (not collapsed
+    /// into a <c>verbose = true</c> default on the verbose-aware overload below) so
+    /// previously-compiled consumers that took a binary reference to
+    /// <c>AutoDetectAndConfigureGpu()</c> keep linking against the same metadata signature.
+    /// Forwards to <see cref="AutoDetectAndConfigureGpu(bool)"/> with verbose enabled.</para>
     /// </remarks>
+    /// <returns>True if GPU was successfully configured, false otherwise.</returns>
     public static bool AutoDetectAndConfigureGpu()
         => AutoDetectAndConfigureGpu(verbose: true);
 
+    /// <summary>
+    /// Verbose-aware overload of <see cref="AutoDetectAndConfigureGpu()"/>. Same GPU
+    /// detection / fallback behavior; the <paramref name="verbose"/> flag gates whether
+    /// the status banner is emitted through the configured log sink.
+    /// </summary>
     /// <param name="verbose">When true, emits status via <see cref="Logger"/>
     /// if set, otherwise Console.WriteLine. Pass false for module-init or library-internal
     /// use where polluting stdout is undesirable (test runners, hosted services, anything

--- a/src/AiDotNet.Tensors/Engines/AiDotNetEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/AiDotNetEngine.cs
@@ -139,19 +139,43 @@ public static class AiDotNetEngine
         // without threading the flag through every caller.
         if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AIDOTNET_QUIET")))
             return;
+
+        // Guard sink invocation — a user-supplied Logger callback that
+        // throws (broken ILogger pipeline, disposed sink, malformed format
+        // string) must NOT break engine startup or ResetToCpu. Same logic
+        // for Console.WriteLine: a redirected/closed stdout (Windows
+        // service contexts, build hosts piping logs through a fragile
+        // wrapper) can throw IOException, and the engine has no business
+        // failing because the host's log transport is misconfigured.
         var sink = Logger;
-        if (sink is not null) sink(message);
-        else Console.WriteLine(message);
+        if (sink is not null)
+        {
+            try { sink(message); return; }
+            catch { /* sink errors are non-fatal — fall through to Console */ }
+        }
+        try { Console.WriteLine(message); }
+        catch { /* stdout transport errors are non-fatal */ }
     }
 
-    /// <param name="verbose">When true (default), emits status via <see cref="Logger"/>
+    /// <returns>True if GPU was successfully configured, false otherwise.</returns>
+    /// <remarks>
+    /// Original parameterless overload. Preserved as a separate method (not a
+    /// `verbose = true` default on the new overload) so previously-compiled
+    /// consumers that took a binary reference to <c>AutoDetectAndConfigureGpu()</c>
+    /// keep linking against the same metadata signature. Forwards to the
+    /// verbose-aware overload with the default-verbose value.
+    /// </remarks>
+    public static bool AutoDetectAndConfigureGpu()
+        => AutoDetectAndConfigureGpu(verbose: true);
+
+    /// <param name="verbose">When true, emits status via <see cref="Logger"/>
     /// if set, otherwise Console.WriteLine. Pass false for module-init or library-internal
     /// use where polluting stdout is undesirable (test runners, hosted services, anything
     /// parsing stdout). Override globally via the <c>AIDOTNET_QUIET</c> env var — when
     /// set to any non-empty value, suppresses output regardless of this parameter.
     /// Plug your own log sink via the <see cref="Logger"/> property.</param>
     /// <returns>True if GPU was successfully configured, false otherwise.</returns>
-    public static bool AutoDetectAndConfigureGpu(bool verbose = true)
+    public static bool AutoDetectAndConfigureGpu(bool verbose)
     {
         try
         {

--- a/src/AiDotNet.Tensors/Engines/AiDotNetEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/AiDotNetEngine.cs
@@ -104,8 +104,54 @@ public static class AiDotNetEngine
     /// This is safe to call even if you don't have a GPU - it will just stay on CPU mode.
     /// </para>
     /// </remarks>
+    /// <summary>
+    /// User-configurable log sink for engine-level events (GPU auto-detect status,
+    /// engine resets, etc.). When non-null, replaces the default Console.WriteLine
+    /// destination — wire to your own logger (Microsoft.Extensions.Logging, Serilog,
+    /// xUnit ITestOutputHelper, structured-event bus, etc.). Defaults to null
+    /// (Console output preserved for backwards-compat) but settable at any time;
+    /// changes take effect on the next event emission.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// // Route engine events to ILogger:
+    /// AiDotNetEngine.Logger = msg =&gt; logger.LogInformation(msg);
+    ///
+    /// // Suppress all engine output:
+    /// AiDotNetEngine.Logger = _ =&gt; { };
+    ///
+    /// // Restore default Console output:
+    /// AiDotNetEngine.Logger = null;
+    /// </code>
+    /// </example>
+    public static Action<string>? Logger { get; set; }
+
+    /// <summary>
+    /// Emits an engine log line. Honors (in order) the explicit <paramref name="verbose"/>
+    /// flag passed by the caller, the <c>AIDOTNET_QUIET</c> env var (forces silence), and
+    /// the <see cref="Logger"/> callback (overrides Console destination).
+    /// </summary>
+    private static void EmitLog(string message, bool verbose)
+    {
+        if (!verbose) return;
+        // AIDOTNET_QUIET forces silence regardless of caller's verbose flag.
+        // Lets users globally silence engine chatter from a single env var
+        // without threading the flag through every caller.
+        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AIDOTNET_QUIET")))
+            return;
+        var sink = Logger;
+        if (sink is not null) sink(message);
+        else Console.WriteLine(message);
+    }
+
+    /// <param name="verbose">When true (default), emits status via <see cref="Logger"/>
+    /// if set, otherwise Console.WriteLine. Pass false for module-init or library-internal
+    /// use where polluting stdout is undesirable (test runners, hosted services, anything
+    /// parsing stdout). Override globally via the <c>AIDOTNET_QUIET</c> env var — when
+    /// set to any non-empty value, suppresses output regardless of this parameter.
+    /// Plug your own log sink via the <see cref="Logger"/> property.</param>
     /// <returns>True if GPU was successfully configured, false otherwise.</returns>
-    public static bool AutoDetectAndConfigureGpu()
+    public static bool AutoDetectAndConfigureGpu(bool verbose = true)
     {
         try
         {
@@ -114,18 +160,18 @@ public static class AiDotNetEngine
             if (gpuEngine.SupportsGpu)
             {
                 Current = gpuEngine;
-                Console.WriteLine($"[AiDotNet] GPU acceleration enabled: {gpuEngine.Name}");
+                EmitLog($"[AiDotNet] GPU acceleration enabled: {gpuEngine.Name}", verbose);
                 return true;
             }
 
             gpuEngine.Dispose();
-            Console.WriteLine("[AiDotNet] GPU not available, using CPU");
+            EmitLog("[AiDotNet] GPU not available, using CPU", verbose);
             return false;
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"[AiDotNet] Failed to initialize DirectGpu: {ex.Message}");
-            Console.WriteLine("[AiDotNet] Falling back to CPU");
+            EmitLog($"[AiDotNet] Failed to initialize DirectGpu: {ex.Message}", verbose);
+            EmitLog("[AiDotNet] Falling back to CPU", verbose);
             return false;
         }
     }
@@ -141,7 +187,7 @@ public static class AiDotNetEngine
     public static void ResetToCpu()
     {
         Current = new CpuEngine();
-        Console.WriteLine("[AiDotNet] Reset to CPU engine");
+        EmitLog("[AiDotNet] Reset to CPU engine", verbose: true);
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/Autodiff/CompiledBackwardGraph.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/CompiledBackwardGraph.cs
@@ -18,9 +18,24 @@ public sealed class CompiledBackwardGraph<T>
     private readonly int[] _reachableEntryIndices;
 
     /// <summary>
-    /// The loss tensor this graph was compiled for.
+    /// The loss tensor this graph was compiled for. Nullable because
+    /// long-lived holders of the plan (e.g. the thread-static
+    /// <c>AutoTrainingState</c> cache) can call
+    /// <see cref="ReleaseCompilationTimeLoss"/> to drop this reference once
+    /// they're committed to always passing a current-step loss into
+    /// <see cref="Execute(Tensor{T})"/>. Strong references here pin the
+    /// compilation-time forward chain (loss.GradFn → upstream
+    /// intermediates) for the whole plan lifetime, which (combined with
+    /// tensor-arena pool reuse of <see cref="Tensor{T}"/> instances across
+    /// training iterations) causes every later step's intermediates to
+    /// appear leaked under <see cref="GradientTapeLeakTests"/> /
+    /// Issue #283. Production replay always feeds in the current-step
+    /// loss; this field exists only for the parameterless
+    /// <see cref="Execute()"/> overload used by tests that call
+    /// <c>tape.CompileBackward(loss)</c> + <c>compiled.Execute()</c>
+    /// inline (where the original loss is still in caller scope).
     /// </summary>
-    private readonly Tensor<T> _loss;
+    private Tensor<T>? _loss;
 
     /// <summary>
     /// Optional source filter — if non-null, only these tensors get gradients.
@@ -110,6 +125,13 @@ public sealed class CompiledBackwardGraph<T>
     internal Dictionary<Tensor<T>, Tensor<T>> Execute(Tensor<T>? currentLoss)
     {
         var loss = currentLoss ?? _loss;
+        if (loss is null)
+            throw new InvalidOperationException(
+                "CompiledBackwardGraph.Execute requires a current-step loss. " +
+                "The compilation-time loss was released — call Execute(loss) " +
+                "with the current step's loss tensor (this is the production " +
+                "replay path; only the inline-test usage relies on the cached " +
+                "compilation-time loss, which is still present at that call site).");
 
         // Phase C: try optimized backward with CSE + algebraic simplification.
         // OptimizedBackwardPlan applies the same RetainGrad-aware intermediate
@@ -243,6 +265,18 @@ public sealed class CompiledBackwardGraph<T>
 
         return grads;
     }
+
+    /// <summary>
+    /// Drops the strong reference to the compilation-time loss tensor.
+    /// Long-lived plan holders (the thread-static
+    /// <c>AutoTrainingCompiler</c> cache) call this immediately after
+    /// storing the plan so the compilation-time forward chain can be GCed
+    /// once user code drops it. Subsequent <see cref="Execute(Tensor{T})"/>
+    /// calls must pass a current-step loss — production replay always does.
+    /// The parameterless <see cref="Execute()"/> overload throws after this
+    /// is called, which is fine: production never uses it.
+    /// </summary>
+    internal void ReleaseCompilationTimeLoss() => _loss = null;
 
     /// <summary>
     /// Gets the number of entries that will be executed (after dead node elimination).

--- a/src/AiDotNet.Tensors/Engines/Autodiff/CompiledBackwardGraph.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/CompiledBackwardGraph.cs
@@ -206,17 +206,19 @@ public sealed class CompiledBackwardGraph<T>
             DifferentiableOps.ClearIndexedGrads();
 
             // Persistent-tape parity with the GradientTape.ComputeGradientsViaGraphCore
-            // cleanup: clear .Grad on forward intermediates so a consumer-side cache
-            // that retains an intermediate (e.g. a layer's `_lastInput`) doesn't pin
-            // one full backward's worth of gradient tensors across successive Execute
-            // calls. Same defense-in-depth pattern as GradientTape.cs PR for
-            // reopened-#283 / consumer-AiDotNet#1227.
-            //
-            // We DON'T clear .GradFn here — the compiled graph reuses the tape's
-            // forward graph for the next Execute, so the GradFn back-pointers must
-            // stay live. .Grad gets re-set by AccumulateGrad on the next Execute,
-            // so clearing it here only severs the per-tensor field; the data flows
-            // through the returned dictionary regardless.
+            // cleanup: clear .GradFn AND .Grad on forward intermediates so they don't
+            // get pinned across iterations. CompiledBackwardGraph walks the tape via
+            // the arena's entry array (`_entries[i]` for `i in _reachableEntryIndices`)
+            // — it does NOT follow GradFn pointers — so nulling GradFn here doesn't
+            // break the next Execute call's traversal. The next forward will re-set
+            // GradFn on every intermediate before the next backward runs, restoring
+            // any back-pointers a consumer of the public `tensor.GradFn` API might
+            // expect. Leaving GradFn live across Execute calls is what previously
+            // made every step's intermediates appear leaked under
+            // GradientTapeLeakTests — the GradFn back-chain kept compilation-step
+            // intermediates (which are the same Tensor instances as later iters'
+            // intermediates after tensor-arena pool reuse) reachable from any
+            // consumer that holds even one downstream tensor.
             HashSet<Tensor<T>>? sourceSet = null;
             if (_sources is not null)
             {
@@ -234,11 +236,11 @@ public sealed class CompiledBackwardGraph<T>
                 if (e.InputsOverflow != null)
                     foreach (var inp in e.InputsOverflow) inp._gradIndex = -1;
 
-                // .Grad cleanup on this entry's output (every output is an
-                // intermediate — graph leaves never appear as outputs in the
-                // entries array). Inputs are NOT cleared because they may be
-                // graph leaves (parameters), and the consumer relies on
-                // `param.Grad` being populated after a sources=null Execute.
+                // .GradFn / .Grad cleanup on this entry's output (every output is an
+                // intermediate — graph leaves never appear as outputs in the entries
+                // array). Inputs are NOT cleared because they may be graph leaves
+                // (parameters), and the consumer relies on `param.Grad` being
+                // populated after a sources=null Execute.
                 //
                 // Matches the parity rule used by
                 // GradientTape.CleanupTapeEntryGrad (line 635) and
@@ -248,6 +250,7 @@ public sealed class CompiledBackwardGraph<T>
                 bool keepGrad =
                     (sourceSet?.Contains(e.Output) == true)
                     || (_retainGrad is not null && _retainGrad.Contains(e.Output));
+                e.Output.GradFn = null;
                 if (!keepGrad) e.Output.Grad = null;
             }
         }

--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientTapeOptions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientTapeOptions.cs
@@ -22,11 +22,17 @@ public sealed class GradientTapeOptions
     /// fraction substantially.
     /// </para>
     /// <para>
-    /// Clone-then-train safety is handled inside <c>AutoTrainingCompiler.ComputePatternHash</c>
-    /// — the cache hash includes input / output tensor identities, so a
-    /// cloned model (same architecture but fresh tensor instances) hashes
-    /// differently from its source and triggers a fresh compile rather than
-    /// replaying the original's backward plan on the wrong tensors.
+    /// Clone-then-train safety is handled inside <c>AutoTrainingCompiler</c>
+    /// via two cooperating mechanisms: (1) the cache lookup key composes
+    /// <c>ComputeStructureHash</c> (op + shape + element type) with
+    /// <c>IncludeTargetIdentity</c> (<c>RuntimeHelpers.GetHashCode</c> over
+    /// <c>sources</c>) so a cloned model with fresh parameter tensors
+    /// produces a different cache key and triggers a fresh compile rather
+    /// than replaying the original's backward plan on the wrong tensors;
+    /// (2) <c>TryCompileBackward</c> refuses to store a plan when
+    /// <c>sources</c> is null, so the structure-only fallback can never be
+    /// cached and a null-sources caller cannot accidentally hit a
+    /// clone-mismatched plan.
     /// </para>
     /// </remarks>
     public static readonly GradientTapeOptions Default = new() { Persistent = true };

--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientTapeOptions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientTapeOptions.cs
@@ -7,15 +7,36 @@ namespace AiDotNet.Tensors.Engines.Autodiff;
 public sealed class GradientTapeOptions
 {
     /// <summary>
-    /// Default options: non-persistent, unlimited entries, records in-place ops.
+    /// Default options: <see cref="Persistent"/> = <c>true</c>, unlimited entries,
+    /// records in-place ops.
     /// </summary>
-    public static readonly GradientTapeOptions Default = new();
+    /// <remarks>
+    /// <para>
+    /// <c>Persistent = true</c> by default gates the <c>AutoTrainingCompiler</c>
+    /// fast path (see <see cref="AiDotNet.Tensors.Engines.Compilation.AutoTrainingCompiler"/>).
+    /// On profile data from a single VGG11 / ResNet50 Train step,
+    /// <c>ComputeGradients</c> dominated 65–73 % of wall time when
+    /// non-persistent; turning persistent on lets the compiler replay a
+    /// flat-indexed compiled backward graph instead of walking the tape
+    /// entry list + dictionary-keyed gradient lookups per op, cutting that
+    /// fraction substantially.
+    /// </para>
+    /// <para>
+    /// Clone-then-train safety is handled inside <c>AutoTrainingCompiler.ComputePatternHash</c>
+    /// — the cache hash includes input / output tensor identities, so a
+    /// cloned model (same architecture but fresh tensor instances) hashes
+    /// differently from its source and triggers a fresh compile rather than
+    /// replaying the original's backward plan on the wrong tensors.
+    /// </para>
+    /// </remarks>
+    public static readonly GradientTapeOptions Default = new() { Persistent = true };
 
     /// <summary>
     /// Whether the tape is persistent (can compute gradients multiple times).
     /// When false, <see cref="GradientTape{T}.ComputeGradients"/> clears the tape after use.
+    /// Defaults to <c>true</c> (see <see cref="Default"/> remarks).
     /// </summary>
-    public bool Persistent { get; init; }
+    public bool Persistent { get; init; } = true;
 
     /// <summary>
     /// Maximum number of tape entries. 0 means unlimited.

--- a/src/AiDotNet.Tensors/Engines/Autodiff/OptimizedBackwardPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/OptimizedBackwardPlan.cs
@@ -145,9 +145,12 @@ internal sealed class OptimizedBackwardPlan<T>
 
                 // e.Output is always a graph intermediate; inputs may be
                 // leaves (parameters) so we don't touch their .Grad here.
+                // GradFn cleanup parity with the recording path — see the
+                // matching comment in CompiledBackwardGraph.Execute.
                 bool keepGrad =
                     (sourceSet?.Contains(e.Output) == true)
                     || (_retainGrad is not null && _retainGrad.Contains(e.Output));
+                e.Output.GradFn = null;
                 if (!keepGrad) e.Output.Grad = null;
             }
         }

--- a/src/AiDotNet.Tensors/Engines/Compilation/AutoTrainingCompiler.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/AutoTrainingCompiler.cs
@@ -141,8 +141,32 @@ internal static class AutoTrainingCompiler
 
     /// <summary>
     /// Computes a hash of the training step pattern from tape entries.
-    /// Two steps with the same op sequence + shapes produce the same hash.
+    /// Two steps with the same op sequence + shapes + tensor identities
+    /// produce the same hash; differing tensor identities (e.g., a cloned
+    /// model's parameter tensors are fresh instances) produce a different
+    /// hash so the compile-cache cannot replay a backward graph keyed on
+    /// the wrong tensor references.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Why tensor identities are in the hash: the compiled backward graph
+    /// stores tensor REFERENCES (specific Tensor{T} instances used during
+    /// the original compilation). Replaying it on different tensor objects
+    /// — e.g., after <c>network.Clone()</c> creates a new model with the
+    /// same architecture but fresh parameter tensors — silently produces
+    /// wrong gradients because the cached refs no longer correspond to any
+    /// live parameter. Including <c>RuntimeHelpers.GetHashCode</c> on
+    /// inputs and outputs makes that scenario miss the cache and trigger
+    /// a fresh compile.
+    /// </para>
+    /// <para>
+    /// Cost: O(entries × inputs) reference-hash lookups per Train call.
+    /// On VGG16-BN that's roughly 500 hash ops out of a 38 s iteration —
+    /// negligible (microseconds) relative to the wins from gating
+    /// auto-compile on persistent tape, which previously cut 65–73 % of
+    /// ComputeGradients walltime on profile data.
+    /// </para>
+    /// </remarks>
     private static long ComputePatternHash<T>(TapeEntryArena<T> entries, int entryCount)
     {
         long hash = unchecked((long)0xcbf29ce484222325L);
@@ -156,9 +180,28 @@ internal static class AutoTrainingCompiler
             hash *= unchecked((long)0x100000001b3L);
             if (entry.Output is not null)
             {
+                // Identity disambiguates same-shape outputs across models
+                // (e.g., cloned network's intermediates vs original's).
+                hash ^= RuntimeHelpers.GetHashCode(entry.Output);
+                hash *= unchecked((long)0x100000001b3L);
                 foreach (int dim in entry.Output._shape)
                 {
                     hash ^= dim;
+                    hash *= unchecked((long)0x100000001b3L);
+                }
+            }
+            // Hash input tensor identities so the cached compiled backward
+            // can't be replayed on a fresh set of parameter / activation
+            // tensors (the original use case that broke clone-then-train:
+            // identical op pattern + identical shapes but different
+            // underlying Tensor{T} references).
+            var inputs = entry.GetInputsArray();
+            if (inputs is not null)
+            {
+                foreach (var inp in inputs)
+                {
+                    if (inp is null) continue;
+                    hash ^= RuntimeHelpers.GetHashCode(inp);
                     hash *= unchecked((long)0x100000001b3L);
                 }
             }

--- a/src/AiDotNet.Tensors/Engines/Compilation/AutoTrainingCompiler.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/AutoTrainingCompiler.cs
@@ -48,11 +48,21 @@ internal static class AutoTrainingCompiler
     internal static void RecordStep<T>(TapeEntryArena<T> entries, int entryCount, Tensor<T>? loss = null)
     {
         if (!Enabled) return;
-        // Repeat-detection hash: STRUCTURE ONLY (op sequence + shapes). Every
-        // forward pass creates fresh activation/loss tensors, so including
-        // their identities here would make every step produce a different hash
-        // and pattern repeats would never trigger the compile threshold.
-        long hash = ComputeStructureHash(entries, entryCount);
+        // Single full-identity hash. We considered splitting into a structure-only
+        // hash for repeat detection + identity-augmented hash for cache lookup
+        // (see PR #333 review thread), but actually splitting them exposes latent
+        // bugs in the compiled-replay path: tests in BatchNorm3DIntegrationTests,
+        // GradientTapeReplayModeTests, TensorCopyToTests, and TorchFuncPhase1Tests
+        // start failing because auto-compile fires in scenarios it didn't before,
+        // and the compiled backward graph stores tensor references that aren't
+        // valid in those scenarios (KeyNotFoundException on gradients dictionary).
+        // The TODO is to fix the compiled-replay path so it handles createGraph,
+        // gradient-dict consistency, and cross-tape replay correctly — only then
+        // can we safely split the hashes. Until then keep the full hash so compile
+        // only fires when activation / loss / parameter identities all match,
+        // which is rare in practice (every forward creates fresh intermediates)
+        // and limits the scope of replay-path bugs that can be triggered.
+        long hash = ComputePatternHash(entries, entryCount);
         State.RecordStepHash(hash);
     }
 
@@ -71,15 +81,11 @@ internal static class AutoTrainingCompiler
         // Only use compiled backward if tape is persistent (entries survive between calls)
         if (!tape.Options.Persistent) return null;
 
-        // Compiled-plan retrieval hash: structure + parameter-tensor identities.
-        // The compiled backward graph holds direct Tensor<T> references to the
-        // specific parameter tensors it was built against; replaying it on a
-        // cloned model (same architecture, fresh parameter instances) would
-        // silently produce wrong gradients. So the cache key must include
-        // SOURCE identities. Activation/loss identities are deliberately NOT
-        // included — only sources, which are the long-lived parameter tensors
-        // the caller actually wants gradients for.
-        long currentHash = ComputeStructureHash(tape.Entries, tape.EntryCount);
+        // Validate current tape pattern AND loss/sources identity match the
+        // compiled plan. Full-hash matching keeps the compile cache safe
+        // against clone-then-train (different parameter tensors) and against
+        // tape-aliasing (same op pattern, different activation/loss objects).
+        long currentHash = ComputePatternHash(tape.Entries, tape.EntryCount);
         currentHash = IncludeTargetIdentity(currentHash, loss, sources);
         if (!State.MatchesCompiledHash(currentHash))
         {
@@ -112,9 +118,10 @@ internal static class AutoTrainingCompiler
         try
         {
             var compiled = tape.CompileBackward(loss, sources);
-            // Store the cache key (structure + sources). Matches the lookup
-            // computation in TryGetCompiledBackward — both must agree.
-            long hash = ComputeStructureHash(tape.Entries, tape.EntryCount);
+            // Store the same hash TryGetCompiledBackward will compute for
+            // lookup — full identity-augmented pattern hash so cache lookup
+            // and cache store agree.
+            long hash = ComputePatternHash(tape.Entries, tape.EntryCount);
             hash = IncludeTargetIdentity(hash, loss, sources);
             State.StoreCompiledBackwardWithHash(compiled, hash);
             ReplayMode = true; // Enable replay mode now that backward is compiled
@@ -147,25 +154,37 @@ internal static class AutoTrainingCompiler
     }
 
     /// <summary>
-    /// Structure-only hash: op name sequence + output shapes + element type.
-    /// Two training steps with the same model architecture and same input
-    /// shapes produce the same hash even though their activation / loss
-    /// tensors are different object instances (which they always are —
-    /// each forward pass creates fresh intermediates).
+    /// Computes a hash of the training step pattern: op names + output identities
+    /// + output shapes + input identities + element type. Used by both
+    /// <see cref="RecordStep{T}"/> for repeat detection and by
+    /// <see cref="TryGetCompiledBackward{T}"/> / <see cref="TryCompileBackward{T}"/>
+    /// (after composition with <see cref="IncludeTargetIdentity{T}"/>) for the
+    /// compiled-plan cache key.
     /// </summary>
     /// <remarks>
-    /// <para>This is the right hash for <see cref="RecordStep{T}"/>'s repeat
-    /// detection: we want consecutive train steps of the same model to be
-    /// recognized as a repeat so the compile threshold actually fires.
-    /// Including activation / intermediate / loss identities would make
-    /// every step hash differently and pattern repeats would never trigger.</para>
-    /// <para>Per-Train cost: O(entryCount) — one hash op per tape entry. On
-    /// VGG16-BN that's ~100 hash ops out of a 38 s iteration — negligible.</para>
+    /// <para>
+    /// Output tensor identities (<c>RuntimeHelpers.GetHashCode</c>) are included
+    /// so a cloned model — same architecture, fresh parameter tensors — produces
+    /// a different hash from its source and gets a fresh compile rather than
+    /// replaying the original's backward plan against the wrong tensor refs.
+    /// </para>
+    /// <para>
+    /// <b>Repeat-detection trade-off:</b> activation / loss tensors are typically
+    /// recreated each forward pass, so the hash differs across steps and the
+    /// compile threshold rarely fires unless the consumer reuses tensor instances
+    /// (e.g. via <c>TensorArena</c>'s pooled reuse). A future refactor could split
+    /// this into a structure-only hash for repeat detection + an identity-augmented
+    /// hash for cache lookup so compile fires more aggressively, but that requires
+    /// the compiled-replay path to first correctly handle createGraph, gradient-dict
+    /// consistency, and cross-tape replay — see BatchNorm3DIntegrationTests and
+    /// GradientTapeReplayModeTests for the surface that would need to be fixed
+    /// alongside the split.
+    /// </para>
     /// </remarks>
-    private static long ComputeStructureHash<T>(TapeEntryArena<T> entries, int entryCount)
+    private static long ComputePatternHash<T>(TapeEntryArena<T> entries, int entryCount)
     {
         long hash = unchecked((long)0xcbf29ce484222325L);
-        // Include element type so float and double plans don't collide.
+        // Include element type so float and double plans don't collide
         hash ^= typeof(T).GetHashCode();
         hash *= unchecked((long)0x100000001b3L);
         for (int i = 0; i < entryCount; i++)
@@ -175,11 +194,46 @@ internal static class AutoTrainingCompiler
             hash *= unchecked((long)0x100000001b3L);
             if (entry.Output is not null)
             {
-                // Shape only — NOT identity. Two steps with the same model
-                // shape produce the same structure hash.
+                // Identity disambiguates same-shape outputs across models
+                // (e.g., cloned network's intermediates vs original's).
+                hash ^= RuntimeHelpers.GetHashCode(entry.Output);
+                hash *= unchecked((long)0x100000001b3L);
                 foreach (int dim in entry.Output._shape)
                 {
                     hash ^= dim;
+                    hash *= unchecked((long)0x100000001b3L);
+                }
+            }
+            // Hash input tensor identities directly from the inline
+            // Input0/Input1/Input2/InputsOverflow fields. GetInputsArray()
+            // allocates a Tensor<T>[1..3] on every call and this hash runs
+            // per RecordStep / TryGetCompiledBackward / TryCompileBackward,
+            // so on large graphs (BERT ~150 entries) that's 150 small-array
+            // allocs per Train call we avoid here.
+            if (entry.InputsOverflow is not null)
+            {
+                foreach (var inp in entry.InputsOverflow)
+                {
+                    if (inp is null) continue;
+                    hash ^= RuntimeHelpers.GetHashCode(inp);
+                    hash *= unchecked((long)0x100000001b3L);
+                }
+            }
+            else
+            {
+                if (entry.InputCount >= 1 && entry.Input0 is not null)
+                {
+                    hash ^= RuntimeHelpers.GetHashCode(entry.Input0);
+                    hash *= unchecked((long)0x100000001b3L);
+                }
+                if (entry.InputCount >= 2 && entry.Input1 is not null)
+                {
+                    hash ^= RuntimeHelpers.GetHashCode(entry.Input1);
+                    hash *= unchecked((long)0x100000001b3L);
+                }
+                if (entry.InputCount >= 3 && entry.Input2 is not null)
+                {
+                    hash ^= RuntimeHelpers.GetHashCode(entry.Input2);
                     hash *= unchecked((long)0x100000001b3L);
                 }
             }

--- a/src/AiDotNet.Tensors/Engines/Compilation/AutoTrainingCompiler.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/AutoTrainingCompiler.cs
@@ -48,10 +48,11 @@ internal static class AutoTrainingCompiler
     internal static void RecordStep<T>(TapeEntryArena<T> entries, int entryCount, Tensor<T>? loss = null)
     {
         if (!Enabled) return;
-        // Pattern hash is based on op sequence + shapes only — NOT loss tensor identity.
-        // Loss tensors are recreated each forward pass (different object each step),
-        // so including identity would prevent pattern detection across steps.
-        long hash = ComputePatternHash(entries, entryCount);
+        // Repeat-detection hash: STRUCTURE ONLY (op sequence + shapes). Every
+        // forward pass creates fresh activation/loss tensors, so including
+        // their identities here would make every step produce a different hash
+        // and pattern repeats would never trigger the compile threshold.
+        long hash = ComputeStructureHash(entries, entryCount);
         State.RecordStepHash(hash);
     }
 
@@ -70,10 +71,15 @@ internal static class AutoTrainingCompiler
         // Only use compiled backward if tape is persistent (entries survive between calls)
         if (!tape.Options.Persistent) return null;
 
-        // Validate current tape pattern AND loss/sources identity match the compiled plan.
-        // IncludeTargetIdentity hashes both loss tensor and source tensors so different
-        // loss functions or source sets don't reuse the wrong backward plan.
-        long currentHash = ComputePatternHash(tape.Entries, tape.EntryCount);
+        // Compiled-plan retrieval hash: structure + parameter-tensor identities.
+        // The compiled backward graph holds direct Tensor<T> references to the
+        // specific parameter tensors it was built against; replaying it on a
+        // cloned model (same architecture, fresh parameter instances) would
+        // silently produce wrong gradients. So the cache key must include
+        // SOURCE identities. Activation/loss identities are deliberately NOT
+        // included — only sources, which are the long-lived parameter tensors
+        // the caller actually wants gradients for.
+        long currentHash = ComputeStructureHash(tape.Entries, tape.EntryCount);
         currentHash = IncludeTargetIdentity(currentHash, loss, sources);
         if (!State.MatchesCompiledHash(currentHash))
         {
@@ -106,8 +112,9 @@ internal static class AutoTrainingCompiler
         try
         {
             var compiled = tape.CompileBackward(loss, sources);
-            // Store with target identity so the hash includes loss/sources
-            long hash = ComputePatternHash(tape.Entries, tape.EntryCount);
+            // Store the cache key (structure + sources). Matches the lookup
+            // computation in TryGetCompiledBackward — both must agree.
+            long hash = ComputeStructureHash(tape.Entries, tape.EntryCount);
             hash = IncludeTargetIdentity(hash, loss, sources);
             State.StoreCompiledBackwardWithHash(compiled, hash);
             ReplayMode = true; // Enable replay mode now that backward is compiled
@@ -140,37 +147,25 @@ internal static class AutoTrainingCompiler
     }
 
     /// <summary>
-    /// Computes a hash of the training step pattern from tape entries.
-    /// Two steps with the same op sequence + shapes + tensor identities
-    /// produce the same hash; differing tensor identities (e.g., a cloned
-    /// model's parameter tensors are fresh instances) produce a different
-    /// hash so the compile-cache cannot replay a backward graph keyed on
-    /// the wrong tensor references.
+    /// Structure-only hash: op name sequence + output shapes + element type.
+    /// Two training steps with the same model architecture and same input
+    /// shapes produce the same hash even though their activation / loss
+    /// tensors are different object instances (which they always are —
+    /// each forward pass creates fresh intermediates).
     /// </summary>
     /// <remarks>
-    /// <para>
-    /// Why tensor identities are in the hash: the compiled backward graph
-    /// stores tensor REFERENCES (specific Tensor{T} instances used during
-    /// the original compilation). Replaying it on different tensor objects
-    /// — e.g., after <c>network.Clone()</c> creates a new model with the
-    /// same architecture but fresh parameter tensors — silently produces
-    /// wrong gradients because the cached refs no longer correspond to any
-    /// live parameter. Including <c>RuntimeHelpers.GetHashCode</c> on
-    /// inputs and outputs makes that scenario miss the cache and trigger
-    /// a fresh compile.
-    /// </para>
-    /// <para>
-    /// Cost: O(entries × inputs) reference-hash lookups per Train call.
-    /// On VGG16-BN that's roughly 500 hash ops out of a 38 s iteration —
-    /// negligible (microseconds) relative to the wins from gating
-    /// auto-compile on persistent tape, which previously cut 65–73 % of
-    /// ComputeGradients walltime on profile data.
-    /// </para>
+    /// <para>This is the right hash for <see cref="RecordStep{T}"/>'s repeat
+    /// detection: we want consecutive train steps of the same model to be
+    /// recognized as a repeat so the compile threshold actually fires.
+    /// Including activation / intermediate / loss identities would make
+    /// every step hash differently and pattern repeats would never trigger.</para>
+    /// <para>Per-Train cost: O(entryCount) — one hash op per tape entry. On
+    /// VGG16-BN that's ~100 hash ops out of a 38 s iteration — negligible.</para>
     /// </remarks>
-    private static long ComputePatternHash<T>(TapeEntryArena<T> entries, int entryCount)
+    private static long ComputeStructureHash<T>(TapeEntryArena<T> entries, int entryCount)
     {
         long hash = unchecked((long)0xcbf29ce484222325L);
-        // Include element type so float and double plans don't collide
+        // Include element type so float and double plans don't collide.
         hash ^= typeof(T).GetHashCode();
         hash *= unchecked((long)0x100000001b3L);
         for (int i = 0; i < entryCount; i++)
@@ -180,54 +175,11 @@ internal static class AutoTrainingCompiler
             hash *= unchecked((long)0x100000001b3L);
             if (entry.Output is not null)
             {
-                // Identity disambiguates same-shape outputs across models
-                // (e.g., cloned network's intermediates vs original's).
-                hash ^= RuntimeHelpers.GetHashCode(entry.Output);
-                hash *= unchecked((long)0x100000001b3L);
+                // Shape only — NOT identity. Two steps with the same model
+                // shape produce the same structure hash.
                 foreach (int dim in entry.Output._shape)
                 {
                     hash ^= dim;
-                    hash *= unchecked((long)0x100000001b3L);
-                }
-            }
-            // Hash input tensor identities so the cached compiled backward
-            // can't be replayed on a fresh set of parameter / activation
-            // tensors (the original use case that broke clone-then-train:
-            // identical op pattern + identical shapes but different
-            // underlying Tensor{T} references).
-            //
-            // Read directly from the inline Input0/Input1/Input2/InputsOverflow
-            // fields instead of calling entry.GetInputsArray() — GetInputsArray
-            // allocates a fresh Tensor<T>[1..3] on every call, and this loop
-            // runs once per RecordStep / TryGetCompiledBackward / TryCompileBackward
-            // (every Train iteration), which adds noticeable GC churn on
-            // large graphs (BERT ~150 entries = 150 small-array allocs per
-            // Train call). The inline path also lets us skip the
-            // InputsOverflow branch entirely when InputCount ≤ 3.
-            if (entry.InputsOverflow is not null)
-            {
-                foreach (var inp in entry.InputsOverflow)
-                {
-                    if (inp is null) continue;
-                    hash ^= RuntimeHelpers.GetHashCode(inp);
-                    hash *= unchecked((long)0x100000001b3L);
-                }
-            }
-            else
-            {
-                if (entry.InputCount >= 1 && entry.Input0 is not null)
-                {
-                    hash ^= RuntimeHelpers.GetHashCode(entry.Input0);
-                    hash *= unchecked((long)0x100000001b3L);
-                }
-                if (entry.InputCount >= 2 && entry.Input1 is not null)
-                {
-                    hash ^= RuntimeHelpers.GetHashCode(entry.Input1);
-                    hash *= unchecked((long)0x100000001b3L);
-                }
-                if (entry.InputCount >= 3 && entry.Input2 is not null)
-                {
-                    hash ^= RuntimeHelpers.GetHashCode(entry.Input2);
                     hash *= unchecked((long)0x100000001b3L);
                 }
             }

--- a/src/AiDotNet.Tensors/Engines/Compilation/AutoTrainingCompiler.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/AutoTrainingCompiler.cs
@@ -195,13 +195,39 @@ internal static class AutoTrainingCompiler
             // tensors (the original use case that broke clone-then-train:
             // identical op pattern + identical shapes but different
             // underlying Tensor{T} references).
-            var inputs = entry.GetInputsArray();
-            if (inputs is not null)
+            //
+            // Read directly from the inline Input0/Input1/Input2/InputsOverflow
+            // fields instead of calling entry.GetInputsArray() — GetInputsArray
+            // allocates a fresh Tensor<T>[1..3] on every call, and this loop
+            // runs once per RecordStep / TryGetCompiledBackward / TryCompileBackward
+            // (every Train iteration), which adds noticeable GC churn on
+            // large graphs (BERT ~150 entries = 150 small-array allocs per
+            // Train call). The inline path also lets us skip the
+            // InputsOverflow branch entirely when InputCount ≤ 3.
+            if (entry.InputsOverflow is not null)
             {
-                foreach (var inp in inputs)
+                foreach (var inp in entry.InputsOverflow)
                 {
                     if (inp is null) continue;
                     hash ^= RuntimeHelpers.GetHashCode(inp);
+                    hash *= unchecked((long)0x100000001b3L);
+                }
+            }
+            else
+            {
+                if (entry.InputCount >= 1 && entry.Input0 is not null)
+                {
+                    hash ^= RuntimeHelpers.GetHashCode(entry.Input0);
+                    hash *= unchecked((long)0x100000001b3L);
+                }
+                if (entry.InputCount >= 2 && entry.Input1 is not null)
+                {
+                    hash ^= RuntimeHelpers.GetHashCode(entry.Input1);
+                    hash *= unchecked((long)0x100000001b3L);
+                }
+                if (entry.InputCount >= 3 && entry.Input2 is not null)
+                {
+                    hash ^= RuntimeHelpers.GetHashCode(entry.Input2);
                     hash *= unchecked((long)0x100000001b3L);
                 }
             }

--- a/src/AiDotNet.Tensors/Engines/Compilation/AutoTrainingCompiler.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/AutoTrainingCompiler.cs
@@ -48,21 +48,17 @@ internal static class AutoTrainingCompiler
     internal static void RecordStep<T>(TapeEntryArena<T> entries, int entryCount, Tensor<T>? loss = null)
     {
         if (!Enabled) return;
-        // Single full-identity hash. We considered splitting into a structure-only
-        // hash for repeat detection + identity-augmented hash for cache lookup
-        // (see PR #333 review thread), but actually splitting them exposes latent
-        // bugs in the compiled-replay path: tests in BatchNorm3DIntegrationTests,
-        // GradientTapeReplayModeTests, TensorCopyToTests, and TorchFuncPhase1Tests
-        // start failing because auto-compile fires in scenarios it didn't before,
-        // and the compiled backward graph stores tensor references that aren't
-        // valid in those scenarios (KeyNotFoundException on gradients dictionary).
-        // The TODO is to fix the compiled-replay path so it handles createGraph,
-        // gradient-dict consistency, and cross-tape replay correctly — only then
-        // can we safely split the hashes. Until then keep the full hash so compile
-        // only fires when activation / loss / parameter identities all match,
-        // which is rare in practice (every forward creates fresh intermediates)
-        // and limits the scope of replay-path bugs that can be triggered.
-        long hash = ComputePatternHash(entries, entryCount);
+        // Repeat-detection hash: STRUCTURE ONLY (op sequence + shapes + element
+        // type). Every forward pass creates fresh activation / loss tensors,
+        // so folding their identities in here would make every step hash
+        // differently and the compile threshold would never fire on real
+        // training loops (which is exactly what happened on PR #333's first
+        // attempt at a unified-hash design — the AutoTrainingCompilerTests
+        // PersistentTape_* assertions all failed). Cache LOOKUP uses a stricter
+        // key (structure + parameter-tensor identities, via
+        // <see cref="TryGetCompiledBackward{T}"/>) so cloned models still miss
+        // the cache and trigger a fresh compile.
+        long hash = ComputeStructureHash(entries, entryCount);
         State.RecordStepHash(hash);
     }
 
@@ -81,11 +77,15 @@ internal static class AutoTrainingCompiler
         // Only use compiled backward if tape is persistent (entries survive between calls)
         if (!tape.Options.Persistent) return null;
 
-        // Validate current tape pattern AND loss/sources identity match the
-        // compiled plan. Full-hash matching keeps the compile cache safe
-        // against clone-then-train (different parameter tensors) and against
-        // tape-aliasing (same op pattern, different activation/loss objects).
-        long currentHash = ComputePatternHash(tape.Entries, tape.EntryCount);
+        // Compiled-plan retrieval hash: structure + parameter-tensor identities.
+        // The compiled backward graph holds direct Tensor<T> references to the
+        // specific parameter tensors it was built against; replaying it on a
+        // cloned model (same architecture, fresh parameter instances) would
+        // silently produce wrong gradients. So the cache key must include
+        // SOURCE identities. Activation / loss identities are deliberately NOT
+        // included — only sources, which are the long-lived parameter tensors
+        // the caller actually wants gradients for.
+        long currentHash = ComputeStructureHash(tape.Entries, tape.EntryCount);
         currentHash = IncludeTargetIdentity(currentHash, loss, sources);
         if (!State.MatchesCompiledHash(currentHash))
         {
@@ -115,13 +115,23 @@ internal static class AutoTrainingCompiler
         if (!tape.Options.Persistent) return;
         if (!State.ShouldCompile) return;
 
+        // Clone-then-train safety: when `sources` is null the cache key
+        // collapses to structure-only, which would let a cloned model with
+        // identical architecture hit the original's compiled plan and replay
+        // gradients against the wrong parameter tensors. Refuse to compile
+        // until the caller passes an explicit sources set — they almost
+        // always do (every consumer that actually uses
+        // <c>tape.ComputeGradients(loss, parameters)</c> passes parameters),
+        // and the rare null-sources callers simply pay the recording-path
+        // cost rather than risk a wrong-gradient replay.
+        if (sources is null) return;
+
         try
         {
             var compiled = tape.CompileBackward(loss, sources);
-            // Store the same hash TryGetCompiledBackward will compute for
-            // lookup — full identity-augmented pattern hash so cache lookup
-            // and cache store agree.
-            long hash = ComputePatternHash(tape.Entries, tape.EntryCount);
+            // Store the cache key (structure + sources). Matches the lookup
+            // computation in TryGetCompiledBackward — both must agree.
+            long hash = ComputeStructureHash(tape.Entries, tape.EntryCount);
             hash = IncludeTargetIdentity(hash, loss, sources);
             State.StoreCompiledBackwardWithHash(compiled, hash);
             ReplayMode = true; // Enable replay mode now that backward is compiled
@@ -140,6 +150,12 @@ internal static class AutoTrainingCompiler
     /// each forward pass. The op structure (captured in tape entries hash) already
     /// identifies the computation pattern including the loss function type.
     /// </summary>
+    /// <remarks>
+    /// When <paramref name="sources"/> is null the function is a no-op. That
+    /// path is now closed inside <see cref="TryCompileBackward"/> via a
+    /// short-circuit return, so the cache cannot store a plan keyed on
+    /// structure-only — clone-then-train remains safe.
+    /// </remarks>
     private static long IncludeTargetIdentity<T>(long hash, Tensor<T> loss, Tensor<T>[]? sources)
     {
         if (sources is not null)
@@ -154,37 +170,25 @@ internal static class AutoTrainingCompiler
     }
 
     /// <summary>
-    /// Computes a hash of the training step pattern: op names + output identities
-    /// + output shapes + input identities + element type. Used by both
-    /// <see cref="RecordStep{T}"/> for repeat detection and by
-    /// <see cref="TryGetCompiledBackward{T}"/> / <see cref="TryCompileBackward{T}"/>
-    /// (after composition with <see cref="IncludeTargetIdentity{T}"/>) for the
-    /// compiled-plan cache key.
+    /// Structure-only hash: op name sequence + output shapes + element type.
+    /// Two training steps with the same model architecture and same input
+    /// shapes produce the same hash even though their activation / loss
+    /// tensors are different object instances (which they always are —
+    /// each forward pass creates fresh intermediates).
     /// </summary>
     /// <remarks>
-    /// <para>
-    /// Output tensor identities (<c>RuntimeHelpers.GetHashCode</c>) are included
-    /// so a cloned model — same architecture, fresh parameter tensors — produces
-    /// a different hash from its source and gets a fresh compile rather than
-    /// replaying the original's backward plan against the wrong tensor refs.
-    /// </para>
-    /// <para>
-    /// <b>Repeat-detection trade-off:</b> activation / loss tensors are typically
-    /// recreated each forward pass, so the hash differs across steps and the
-    /// compile threshold rarely fires unless the consumer reuses tensor instances
-    /// (e.g. via <c>TensorArena</c>'s pooled reuse). A future refactor could split
-    /// this into a structure-only hash for repeat detection + an identity-augmented
-    /// hash for cache lookup so compile fires more aggressively, but that requires
-    /// the compiled-replay path to first correctly handle createGraph, gradient-dict
-    /// consistency, and cross-tape replay — see BatchNorm3DIntegrationTests and
-    /// GradientTapeReplayModeTests for the surface that would need to be fixed
-    /// alongside the split.
-    /// </para>
+    /// <para>This is the right hash for <see cref="RecordStep{T}"/>'s repeat
+    /// detection: we want consecutive train steps of the same model to be
+    /// recognized as a repeat so the compile threshold actually fires.
+    /// Including activation / intermediate / loss identities would make
+    /// every step hash differently and pattern repeats would never trigger.</para>
+    /// <para>Per-Train cost: O(entryCount) — one hash op per tape entry. On
+    /// VGG16-BN that's ~100 hash ops out of a 38 s iteration — negligible.</para>
     /// </remarks>
-    private static long ComputePatternHash<T>(TapeEntryArena<T> entries, int entryCount)
+    private static long ComputeStructureHash<T>(TapeEntryArena<T> entries, int entryCount)
     {
         long hash = unchecked((long)0xcbf29ce484222325L);
-        // Include element type so float and double plans don't collide
+        // Include element type so float and double plans don't collide.
         hash ^= typeof(T).GetHashCode();
         hash *= unchecked((long)0x100000001b3L);
         for (int i = 0; i < entryCount; i++)
@@ -194,46 +198,11 @@ internal static class AutoTrainingCompiler
             hash *= unchecked((long)0x100000001b3L);
             if (entry.Output is not null)
             {
-                // Identity disambiguates same-shape outputs across models
-                // (e.g., cloned network's intermediates vs original's).
-                hash ^= RuntimeHelpers.GetHashCode(entry.Output);
-                hash *= unchecked((long)0x100000001b3L);
+                // Shape only — NOT identity. Two steps with the same model
+                // shape produce the same structure hash.
                 foreach (int dim in entry.Output._shape)
                 {
                     hash ^= dim;
-                    hash *= unchecked((long)0x100000001b3L);
-                }
-            }
-            // Hash input tensor identities directly from the inline
-            // Input0/Input1/Input2/InputsOverflow fields. GetInputsArray()
-            // allocates a Tensor<T>[1..3] on every call and this hash runs
-            // per RecordStep / TryGetCompiledBackward / TryCompileBackward,
-            // so on large graphs (BERT ~150 entries) that's 150 small-array
-            // allocs per Train call we avoid here.
-            if (entry.InputsOverflow is not null)
-            {
-                foreach (var inp in entry.InputsOverflow)
-                {
-                    if (inp is null) continue;
-                    hash ^= RuntimeHelpers.GetHashCode(inp);
-                    hash *= unchecked((long)0x100000001b3L);
-                }
-            }
-            else
-            {
-                if (entry.InputCount >= 1 && entry.Input0 is not null)
-                {
-                    hash ^= RuntimeHelpers.GetHashCode(entry.Input0);
-                    hash *= unchecked((long)0x100000001b3L);
-                }
-                if (entry.InputCount >= 2 && entry.Input1 is not null)
-                {
-                    hash ^= RuntimeHelpers.GetHashCode(entry.Input1);
-                    hash *= unchecked((long)0x100000001b3L);
-                }
-                if (entry.InputCount >= 3 && entry.Input2 is not null)
-                {
-                    hash ^= RuntimeHelpers.GetHashCode(entry.Input2);
                     hash *= unchecked((long)0x100000001b3L);
                 }
             }

--- a/src/AiDotNet.Tensors/Engines/Compilation/AutoTrainingCompiler.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/AutoTrainingCompiler.cs
@@ -134,6 +134,18 @@ internal static class AutoTrainingCompiler
             long hash = ComputeStructureHash(tape.Entries, tape.EntryCount);
             hash = IncludeTargetIdentity(hash, loss, sources);
             State.StoreCompiledBackwardWithHash(compiled, hash);
+            // Drop the plan's strong reference to the compilation-time loss
+            // tensor. The compile cache is thread-static and persists for
+            // the lifetime of the worker thread; without this release, the
+            // loss tensor (and its entire GradFn chain back through every
+            // forward intermediate) would stay reachable for the whole
+            // process, manifesting as a per-iteration leak under
+            // GradientTapeLeakTests at issue #283 scale (tensor-arena pool
+            // reuse makes early-iteration intermediates the same Tensor
+            // instances as later iterations'). Subsequent ComputeGradients
+            // calls always pass the current step's loss to Execute(loss),
+            // so the parameterless fallback isn't needed on this path.
+            compiled.ReleaseCompilationTimeLoss();
             ReplayMode = true; // Enable replay mode now that backward is compiled
         }
         catch

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -3210,14 +3210,26 @@ public partial class CpuEngine : ITensorLevelEngine
             if (cols == bCols)
             {
                 var res = AutoTensorCache.RentOrAllocate<T>(a._shape);
-                var ad = (double[])(object)a.GetDataArray();
-                var bd = (double[])(object)b.GetDataArray();
-                var rd = (double[])(object)res.GetDataArray();
+                // Use raw storage + offset rather than GetDataArray() —
+                // for contiguous slice/view tensors with a non-zero
+                // storage offset, GetDataArray() falls back to ToArray()
+                // and allocates a fresh copy on every call, defeating
+                // the allocation-free fast path. The Contiguous() call
+                // above only rebinds when IsContiguous is false, so
+                // offset-bearing contiguous views still reach this point.
+                var aStorage = a._storage.GetDataArray();
+                var bStorage = b._storage.GetDataArray();
+                var rStorage = res._storage.GetDataArray();
+                var ad = (double[])(object)aStorage;
+                var bd = (double[])(object)bStorage;
+                var rd = (double[])(object)rStorage;
+                int aOff = a._storageOffset, bOff = b._storageOffset, rOff = res._storageOffset;
                 for (int r = 0; r < rows; r++)
                 {
-                    int off = r * cols;
+                    int aRow = aOff + r * cols;
+                    int rRow = rOff + r * cols;
                     for (int c = 0; c < cols; c++)
-                        rd[off + c] = ad[off + c] - bd[c];
+                        rd[rRow + c] = ad[aRow + c] - bd[bOff + c];
                 }
                 DifferentiableOps.RecordBinary("TensorBroadcastSubtract", res, aOrig, bOrig, BackwardFunctions<T>.BroadcastSubtractBackward);
                 { var ca = a; var cb = b; AutoTracer.RecordOp("TensorBroadcastSubtract", res, eng => eng.TensorBroadcastSubtract(ca, cb)); }
@@ -6592,12 +6604,17 @@ public partial class CpuEngine : ITensorLevelEngine
 
         // Double fast path — Span-based SIMD reduction. Single-call (no
         // multi-chunk partials yet) but still 4× faster than the scalar
-        // IVectorizedOperations.Sum fallback on AVX2 hosts.
+        // IVectorizedOperations.Sum fallback on AVX2 hosts. Use the raw
+        // storage + offset rather than GetDataArray() — GetDataArray()
+        // falls back to ToArray() for contiguous views with a non-zero
+        // storage offset, which would defeat the allocation-free fast
+        // path on every slice / view caller. Same pattern as the BLAS
+        // GEMM paths above.
         if (typeof(T) == typeof(double))
         {
-            T[] arr = tensor.GetDataArray();
-            double[] dArr = Unsafe.As<T[], double[]>(ref arr);
-            double sum = SimdKernels.Sum(new ReadOnlySpan<double>(dArr, 0, tensor.Length));
+            T[] storageArr = tensor._storage.GetDataArray();
+            double[] dArr = Unsafe.As<T[], double[]>(ref storageArr);
+            double sum = SimdKernels.Sum(new ReadOnlySpan<double>(dArr, tensor._storageOffset, tensor.Length));
             return Unsafe.As<double, T>(ref sum);
         }
 
@@ -10736,23 +10753,34 @@ public partial class CpuEngine : ITensorLevelEngine
         if (!a.IsContiguous) a = a.Contiguous();
         if (!b.IsContiguous) b = b.Contiguous();
 
-        var aArr = a.GetDataArray();
-        var bArr = b.GetDataArray();
-        var oArr = output.GetDataArray();
+        // Use raw storage + _storageOffset rather than GetDataArray() —
+        // GetDataArray() falls back to ToArray() for contiguous views
+        // with a non-zero storage offset (e.g. slices into a larger
+        // tensor), allocating a fresh copy on every call. The
+        // write-through fast path exists to skip exactly that kind of
+        // hidden alloc, so we read the backing storage directly and
+        // thread the per-tensor storage offset into every BLAS / SIMD
+        // GEMM call. Same pattern as TensorMatMulTransposed's BLAS path.
+        var aArr = a._storage.GetDataArray();
+        var bArr = b._storage.GetDataArray();
+        var oArr = output._storage.GetDataArray();
+        int aOff = a._storageOffset;
+        int bOff = b._storageOffset;
+        int oOff = output._storageOffset;
 
         // 2D × 2D
         if (a.Rank == 2 && b.Rank == 2)
         {
             int m = a._shape[0], k = a._shape[1], n = b._shape[1];
             if (Helpers.BlasProvider.TryGemmEx(m, n, k,
-                aArr, 0, k, false,
-                bArr, 0, n, false,
-                oArr, 0, n))
+                aArr, aOff, k, false,
+                bArr, bOff, n, false,
+                oArr, oOff, n))
                 return;
             SimdGemm.Dgemm(
-                new ReadOnlySpan<double>(aArr, 0, m * k),
-                new ReadOnlySpan<double>(bArr, 0, k * n),
-                new Span<double>(oArr, 0, m * n),
+                new ReadOnlySpan<double>(aArr, aOff, m * k),
+                new ReadOnlySpan<double>(bArr, bOff, k * n),
+                new Span<double>(oArr, oOff, m * n),
                 m, k, n);
             return;
         }
@@ -10768,14 +10796,14 @@ public partial class CpuEngine : ITensorLevelEngine
             for (int i = 0; i < aRank - 2; i++) batchSize *= a._shape[i];
             int rows = batchSize * m;
             if (BlasProvider.TryGemmEx(rows, n, k,
-                aArr, 0, k, false,
-                bArr, 0, n, false,
-                oArr, 0, n))
+                aArr, aOff, k, false,
+                bArr, bOff, n, false,
+                oArr, oOff, n))
                 return;
             SimdGemm.Dgemm(
-                new ReadOnlySpan<double>(aArr, 0, rows * k),
-                new ReadOnlySpan<double>(bArr, 0, k * n),
-                new Span<double>(oArr, 0, rows * n),
+                new ReadOnlySpan<double>(aArr, aOff, rows * k),
+                new ReadOnlySpan<double>(bArr, bOff, k * n),
+                new Span<double>(oArr, oOff, rows * n),
                 rows, k, n);
             return;
         }
@@ -10793,14 +10821,14 @@ public partial class CpuEngine : ITensorLevelEngine
             if (batchSize == 1)
             {
                 if (BlasProvider.TryGemmEx(m, n, k,
-                    aArr, 0, k, false,
-                    bArr, 0, n, false,
-                    oArr, 0, n))
+                    aArr, aOff, k, false,
+                    bArr, bOff, n, false,
+                    oArr, oOff, n))
                     return;
                 SimdGemm.Dgemm(
-                    new ReadOnlySpan<double>(aArr, 0, sliceA),
-                    new ReadOnlySpan<double>(bArr, 0, sliceB),
-                    new Span<double>(oArr, 0, sliceC),
+                    new ReadOnlySpan<double>(aArr, aOff, sliceA),
+                    new ReadOnlySpan<double>(bArr, bOff, sliceB),
+                    new Span<double>(oArr, oOff, sliceC),
                     m, k, n);
             }
             else
@@ -10808,14 +10836,14 @@ public partial class CpuEngine : ITensorLevelEngine
                 CpuParallelSettings.ParallelForOrSerial(0, batchSize, (long)batchSize * m * n * k, batch =>
                 {
                     if (BlasProvider.TryGemmEx(m, n, k,
-                        aArr, batch * sliceA, k, false,
-                        bArr, batch * sliceB, n, false,
-                        oArr, batch * sliceC, n))
+                        aArr, aOff + batch * sliceA, k, false,
+                        bArr, bOff + batch * sliceB, n, false,
+                        oArr, oOff + batch * sliceC, n))
                         return;
                     SimdGemm.DgemmSequential(
-                        new ReadOnlySpan<double>(aArr, batch * sliceA, sliceA),
-                        new ReadOnlySpan<double>(bArr, batch * sliceB, sliceB),
-                        new Span<double>(oArr, batch * sliceC, sliceC),
+                        new ReadOnlySpan<double>(aArr, aOff + batch * sliceA, sliceA),
+                        new ReadOnlySpan<double>(bArr, bOff + batch * sliceB, sliceB),
+                        new Span<double>(oArr, oOff + batch * sliceC, sliceC),
                         m, k, n);
                 });
             }
@@ -24057,6 +24085,14 @@ public partial class CpuEngine : ITensorLevelEngine
                 var outShape = keepDims ? new[] { 1, cols } : new[] { cols };
                 var result = AutoTensorCache.RentOrAllocate<T>(outShape);
                 var fOut = (float[])(object)result.GetDataArray();
+                // AutoTensorCache.RentOrAllocate returns an UNINITIALIZED
+                // buffer (the cache reuses pooled arrays without zeroing).
+                // The variance accumulator below uses `+=` so it must start
+                // from zero — otherwise the previous renter's stale bytes
+                // get folded into the variance and the result becomes
+                // nondeterministic across runs. Clear just the logical
+                // region so we don't pay for any backing-array padding.
+                Array.Clear(fOut, 0, cols);
                 // First compute means
                 var means = new float[cols];
                 for (int r = 0; r < rows; r++)
@@ -24101,6 +24137,11 @@ public partial class CpuEngine : ITensorLevelEngine
                 var outShape = keepDims ? new[] { 1, cols } : new[] { cols };
                 var result = AutoTensorCache.RentOrAllocate<T>(outShape);
                 var dOut = (double[])(object)result.GetDataArray();
+                // Same rationale as the float axis==0 branch above —
+                // AutoTensorCache returns an uninitialized buffer and the
+                // accumulator below uses `+=`, so the logical region must
+                // start from zero.
+                Array.Clear(dOut, 0, cols);
                 var means = new double[cols];
                 for (int r = 0; r < rows; r++)
                     for (int c = 0; c < cols; c++) means[c] += dData[r * cols + c];

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -28765,6 +28765,41 @@ public partial class CpuEngine : ITensorLevelEngine
             AutoTracer.RecordOp("LogSoftmax", result, eng => result);
             return result;
         }
+        // Double primitive fast path for last-axis log-softmax. Inline 3-pass
+        // max / log-sum-exp / shift per row, parallel across rows. No
+        // INumericOperations<T> virtual dispatch and no per-element boxing.
+        // Hit by every classifier head and NLLLoss flow on fp64 networks.
+        if (typeof(T) == typeof(double) && innerSize == 1)
+        {
+            var resultD = AutoTensorCache.RentOrAllocate<T>(tensor._shape);
+            using var pinIn = tensor.Data.Pin();
+            using var pinOut = resultD.Data.Pin();
+            unsafe
+            {
+                double* pIn = (double*)pinIn.Pointer;
+                double* pOut = (double*)pinOut.Pointer;
+                int axisSz = axisSize;
+                int outerSz = outerSize;
+                bool useParallel = outerSz >= 4 && (long)outerSz * axisSz >= 32768;
+                Action<int> rowKernel = row =>
+                {
+                    double* rIn = pIn + row * axisSz;
+                    double* rOut = pOut + row * axisSz;
+                    double max = rIn[0];
+                    for (int i = 1; i < axisSz; i++) if (rIn[i] > max) max = rIn[i];
+                    double sumExp = 0.0;
+                    for (int i = 0; i < axisSz; i++) sumExp += Math.Exp(rIn[i] - max);
+                    double logSumExp = Math.Log(sumExp);
+                    for (int i = 0; i < axisSz; i++) rOut[i] = (rIn[i] - max) - logSumExp;
+                };
+                if (useParallel) Parallel.For(0, outerSz, rowKernel);
+                else for (int row = 0; row < outerSz; row++) rowKernel(row);
+            }
+            DifferentiableOps.RecordUnary("LogSoftmax", resultD, tensor,
+                BackwardFunctions<T>.LogSoftmaxBackward);
+            AutoTracer.RecordOp("LogSoftmax", resultD, eng => resultD);
+            return resultD;
+        }
 
         // Generic scalar fallback
         var numOps = MathHelper.GetNumericOperations<T>();
@@ -30005,6 +30040,13 @@ public partial class CpuEngine : ITensorLevelEngine
                 SimdKernels.CoshUnsafe((float*)pinSrc.Pointer, (float*)pinDst.Pointer, length);
             }
         }
+        else if (typeof(T) == typeof(double))
+        {
+            var dSrc = (double[])(object)tensor.GetDataArray();
+            var dDst = (double[])(object)result.GetDataArray();
+            for (int i = 0; i < length; i++)
+                dDst[i] = Math.Cosh(dSrc[i]);
+        }
         else
         {
             var numOps = MathHelper.GetNumericOperations<T>();
@@ -30051,6 +30093,13 @@ public partial class CpuEngine : ITensorLevelEngine
                 using var pinDst = dstMem.Pin();
                 SimdKernels.SinhUnsafe((float*)pinSrc.Pointer, (float*)pinDst.Pointer, length);
             }
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            var dSrc = (double[])(object)tensor.GetDataArray();
+            var dDst = (double[])(object)result.GetDataArray();
+            for (int i = 0; i < length; i++)
+                dDst[i] = Math.Sinh(dSrc[i]);
         }
         else
         {
@@ -32735,6 +32784,27 @@ public partial class CpuEngine : ITensorLevelEngine
                 }
             }
         }
+        else if (typeof(T) == typeof(double))
+        {
+            var rand = RandomHelper.CreateSeededRandom((int)(DateTime.UtcNow.Ticks % int.MaxValue));
+            double dScale = 1.0 / (1.0 - dropoutRate);
+            var inArr = (double[])(object)input.GetDataArray();
+            var outArr = (double[])(object)dropResult.GetDataArray();
+            var mArr = (double[])(object)mask.GetDataArray();
+            for (int i = 0; i < input.Length; i++)
+            {
+                if (rand.NextDouble() >= dropoutRate)
+                {
+                    mArr[i] = dScale;
+                    outArr[i] = inArr[i] * dScale;
+                }
+                else
+                {
+                    mArr[i] = 0.0;
+                    outArr[i] = 0.0;
+                }
+            }
+        }
         else
         {
             var numOps = MathHelper.GetNumericOperations<T>();
@@ -33078,6 +33148,46 @@ public partial class CpuEngine : ITensorLevelEngine
         var resultData = new T[batch * channels];
         int totalChannels = batch * channels;
 
+        // Float primitive fast path (non-Nchwc8 layouts): inline sum + divide,
+        // no INumericOperations<T> virtual dispatch. Used by every CNN classifier
+        // head that doesn't hit the Nchwc8 SIMD branch.
+        if (typeof(T) == typeof(float))
+        {
+            var inArrF = (float[])(object)inputData;
+            var outArrF = (float[])(object)resultData;
+            float invSp = 1f / spatialSize;
+            Action<int> kernel = bc =>
+            {
+                int offset = bc * spatialSize;
+                float sum = 0f;
+                for (int s = 0; s < spatialSize; s++) sum += inArrF[offset + s];
+                outArrF[bc] = sum * invSp;
+            };
+            if (totalChannels > 32)
+                CpuParallelSettings.ParallelForOrSerial(0, totalChannels, (long)totalChannels * spatialSize, kernel);
+            else
+                for (int bc = 0; bc < totalChannels; bc++) kernel(bc);
+            return TensorAllocator.Rent<T>([batch, channels, 1, 1], resultData);
+        }
+        if (typeof(T) == typeof(double))
+        {
+            var inArrD = (double[])(object)inputData;
+            var outArrD = (double[])(object)resultData;
+            double invSp = 1.0 / spatialSize;
+            Action<int> kernel = bc =>
+            {
+                int offset = bc * spatialSize;
+                double sum = 0.0;
+                for (int s = 0; s < spatialSize; s++) sum += inArrD[offset + s];
+                outArrD[bc] = sum * invSp;
+            };
+            if (totalChannels > 32)
+                CpuParallelSettings.ParallelForOrSerial(0, totalChannels, (long)totalChannels * spatialSize, kernel);
+            else
+                for (int bc = 0; bc < totalChannels; bc++) kernel(bc);
+            return TensorAllocator.Rent<T>([batch, channels, 1, 1], resultData);
+        }
+
         // Parallelize across batch*channels (each channel is independent)
         Action<int> processChannel = bc =>
         {
@@ -33111,6 +33221,46 @@ public partial class CpuEngine : ITensorLevelEngine
         var inputData = input.GetFlattenedData();
         var resultData = new T[batch * channels];
         int totalChannels = batch * channels;
+
+        // Float / double primitive fast paths: inline max-finding loop,
+        // no INumericOperations<T> dispatch. CNN classifier heads hit this
+        // per-step.
+        if (typeof(T) == typeof(float))
+        {
+            var inArrF = (float[])(object)inputData;
+            var outArrF = (float[])(object)resultData;
+            Action<int> kernel = bc =>
+            {
+                int offset = bc * spatialSize;
+                float maxVal = inArrF[offset];
+                for (int s = 1; s < spatialSize; s++)
+                    if (inArrF[offset + s] > maxVal) maxVal = inArrF[offset + s];
+                outArrF[bc] = maxVal;
+            };
+            if (totalChannels > 32)
+                CpuParallelSettings.ParallelForOrSerial(0, totalChannels, (long)totalChannels * spatialSize, kernel);
+            else
+                for (int bc = 0; bc < totalChannels; bc++) kernel(bc);
+            return TensorAllocator.Rent<T>([batch, channels, 1, 1], resultData);
+        }
+        if (typeof(T) == typeof(double))
+        {
+            var inArrD = (double[])(object)inputData;
+            var outArrD = (double[])(object)resultData;
+            Action<int> kernel = bc =>
+            {
+                int offset = bc * spatialSize;
+                double maxVal = inArrD[offset];
+                for (int s = 1; s < spatialSize; s++)
+                    if (inArrD[offset + s] > maxVal) maxVal = inArrD[offset + s];
+                outArrD[bc] = maxVal;
+            };
+            if (totalChannels > 32)
+                CpuParallelSettings.ParallelForOrSerial(0, totalChannels, (long)totalChannels * spatialSize, kernel);
+            else
+                for (int bc = 0; bc < totalChannels; bc++) kernel(bc);
+            return TensorAllocator.Rent<T>([batch, channels, 1, 1], resultData);
+        }
 
         Action<int> processChannel = bc =>
         {

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -16376,6 +16376,30 @@ public partial class CpuEngine : ITensorLevelEngine
             return (Tensor<T>)(object)TensorAllocator.Rent<T>(output._shape, (T[])(object)gInF);
         }
 #endif
+        // Double primitive fast path for last-axis softmax backward.
+        // Inline scalar arithmetic (no Vector256<double> kernel yet) but still
+        // ~4× the throughput of the generic INumericOperations<T> loop because
+        // it eliminates virtual-dispatch + Multiply/Add boxing on every element.
+        if (typeof(T) == typeof(double) && innerSize == 1
+            && gradOutput.GetFlattenedData() is double[] gOutD
+            && output.GetFlattenedData() is double[] outD)
+        {
+            var gInD = new double[outD.Length];
+            bool useParallel = outerSize >= 4 && (long)outerSize * axisSize >= 32768;
+            int axisSz = axisSize;
+            Action<int> rowKernel = row =>
+            {
+                int baseIdx = row * axisSz;
+                double dot = 0.0;
+                for (int i = 0; i < axisSz; i++) dot += gOutD[baseIdx + i] * outD[baseIdx + i];
+                for (int i = 0; i < axisSz; i++) gInD[baseIdx + i] = outD[baseIdx + i] * (gOutD[baseIdx + i] - dot);
+            };
+            if (useParallel)
+                CpuParallelSettings.ParallelForOrSerial(0, outerSize, (long)outerSize * axisSize, rowKernel);
+            else
+                for (int row = 0; row < outerSize; row++) rowKernel(row);
+            return (Tensor<T>)(object)TensorAllocator.Rent<T>(output._shape, (T[])(object)gInD);
+        }
 
         // Generic fallback
         var numOps = MathHelper.GetNumericOperations<T>();
@@ -26696,6 +26720,36 @@ public partial class CpuEngine : ITensorLevelEngine
             return result;
         }
 
+        // Double fast paths: scalar accumulation but no virtual dispatch.
+        // (PrefixSumDouble SIMD scan is a separate follow-up.) The scalar
+        // loop runs ~3-4× faster than INumericOperations<T>.Add by inlining
+        // the add and saving the v-table indirection.
+        if (typeof(T) == typeof(double) && tensor.Rank == 1)
+        {
+            var srcD = (double[])(object)tensor.GetDataArray();
+            var dstD = (double[])(object)result.GetDataArray();
+            double accD = 0.0;
+            int len = tensor.Length;
+            for (int i = 0; i < len; i++) { accD += srcD[i]; dstD[i] = accD; }
+            DifferentiableOps.RecordUnary("TensorCumSum", result, tensorOrig, BackwardFunctions<T>.CumSumBackward, new object[] { axis });
+            AutoTracer.RecordOp("TensorCumSum", result, eng => result);
+            return result;
+        }
+        if (typeof(T) == typeof(double) && innerSize == 1)
+        {
+            var srcD = (double[])(object)tensor.GetDataArray();
+            var dstD = (double[])(object)result.GetDataArray();
+            for (int outer = 0; outer < outerSize; outer++)
+            {
+                int start = outer * axisSize;
+                double accD = 0.0;
+                for (int a = 0; a < axisSize; a++) { accD += srcD[start + a]; dstD[start + a] = accD; }
+            }
+            DifferentiableOps.RecordUnary("TensorCumSum", result, tensorOrig, BackwardFunctions<T>.CumSumBackward, new object[] { axis });
+            AutoTracer.RecordOp("TensorCumSum", result, eng => result);
+            return result;
+        }
+
         var numOps = MathHelper.GetNumericOperations<T>();
         var tensorData = tensor.GetDataArray();
         var resultData = result.GetDataArray();
@@ -27684,6 +27738,50 @@ public partial class CpuEngine : ITensorLevelEngine
                 }
                 for (int c = 0; c < cols; c++)
                     fDst[c] = MathF.Sqrt(fDst[c]);
+                DifferentiableOps.RecordUnary("Norm", normResult, tensor, BackwardFunctions<T>.NormBackward, new object[] { normAxis });
+                AutoTracer.RecordOp("Norm", normResult, eng => normResult);
+                return normResult;
+            }
+        }
+
+        // Double fast path for 2D L2 norm — mirrors float branch.
+        if (typeof(T) == typeof(double) && tensor.Rank == 2 && tensor.IsContiguous)
+        {
+            int normAxis = axis < 0 ? tensor.Rank + axis : axis;
+            int rows = tensor._shape[0], cols = tensor._shape[1];
+            var dSrc = (double[])(object)tensor.GetDataArray();
+
+            if (normAxis == 1)
+            {
+                var outShape = keepDims ? new[] { rows, 1 } : new[] { rows };
+                var normResult = AutoTensorCache.RentOrAllocate<T>(outShape);
+                var dDst = (double[])(object)normResult.GetDataArray();
+                for (int r = 0; r < rows; r++)
+                {
+                    double sumSq = 0.0;
+                    int off = r * cols;
+                    for (int c = 0; c < cols; c++)
+                        sumSq += dSrc[off + c] * dSrc[off + c];
+                    dDst[r] = Math.Sqrt(sumSq);
+                }
+                DifferentiableOps.RecordUnary("Norm", normResult, tensor, BackwardFunctions<T>.NormBackward, new object[] { normAxis });
+                AutoTracer.RecordOp("Norm", normResult, eng => normResult);
+                return normResult;
+            }
+            else if (normAxis == 0)
+            {
+                var outShape = keepDims ? new[] { 1, cols } : new[] { cols };
+                var normResult = AutoTensorCache.RentOrAllocate<T>(outShape);
+                var dDst = (double[])(object)normResult.GetDataArray();
+                Array.Clear(dDst, 0, cols);
+                for (int r = 0; r < rows; r++)
+                {
+                    int off = r * cols;
+                    for (int c = 0; c < cols; c++)
+                        dDst[c] += dSrc[off + c] * dSrc[off + c];
+                }
+                for (int c = 0; c < cols; c++)
+                    dDst[c] = Math.Sqrt(dDst[c]);
                 DifferentiableOps.RecordUnary("Norm", normResult, tensor, BackwardFunctions<T>.NormBackward, new object[] { normAxis });
                 AutoTracer.RecordOp("Norm", normResult, eng => normResult);
                 return normResult;

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -6572,6 +6572,50 @@ public partial class CpuEngine : ITensorLevelEngine
             }
         }
 
+        // Fast path: single-axis sum on 2D contiguous double tensor — mirrors float branch.
+        // Heavily used by gradient accumulation paths (loss/bias sums, axis-wise reductions in
+        // attention) on double networks; eliminates INumericOperations<T> dispatch.
+        if (normalizedAxes.Length == 1 && tensor.Rank == 2 && tensor.IsContiguous && typeof(T) == typeof(double))
+        {
+            int axis = normalizedAxes[0];
+            int rows = tensor._shape[0], cols = tensor._shape[1];
+            var srcArr = (double[])(object)tensor.GetDataArray();
+
+            if (axis == 0)
+            {
+                var outShape = keepDims ? new[] { 1, cols } : new[] { cols };
+                var fastResult = AutoTensorCache.RentOrAllocate<T>(outShape);
+                var rArr = (double[])(object)fastResult.GetDataArray();
+                Array.Clear(rArr, 0, cols);
+                for (int r = 0; r < rows; r++)
+                {
+                    int offset = r * cols;
+                    for (int c = 0; c < cols; c++)
+                        rArr[c] += srcArr[offset + c];
+                }
+                DifferentiableOps.RecordUnary("ReduceSum", fastResult, tensorOrig, BackwardFunctions<T>.ReduceSumBackward,
+                    new object[] { normalizedAxes.ToArray(), keepDims });
+                return fastResult;
+            }
+            else if (axis == 1)
+            {
+                var outShape = keepDims ? new[] { rows, 1 } : new[] { rows };
+                var fastResult = AutoTensorCache.RentOrAllocate<T>(outShape);
+                var rArr = (double[])(object)fastResult.GetDataArray();
+                for (int r = 0; r < rows; r++)
+                {
+                    double sum = 0;
+                    int offset = r * cols;
+                    for (int c = 0; c < cols; c++)
+                        sum += srcArr[offset + c];
+                    rArr[r] = sum;
+                }
+                DifferentiableOps.RecordUnary("ReduceSum", fastResult, tensorOrig, BackwardFunctions<T>.ReduceSumBackward,
+                    new object[] { normalizedAxes.ToArray(), keepDims });
+                return fastResult;
+            }
+        }
+
         // Calculate output shape
         var outputShape = new List<int>();
         for (int i = 0; i < tensor.Rank; i++)
@@ -23113,6 +23157,19 @@ public partial class CpuEngine : ITensorLevelEngine
         }
         if (isFullReduction && input.IsContiguous)
         {
+            if (typeof(T) == typeof(double))
+            {
+                var dSpan = AsDoubleMemory(input.Data).Span;
+                double dSum = SimdKernels.Sum(dSpan);
+                double dMean = dSum / input.Length;
+                var scalarResult = AutoTensorCache.RentOrAllocate<T>(new[] { 1 });
+                ((double[])(object)scalarResult.GetDataArray())[0] = dMean;
+                DifferentiableOps.RecordUnary("ReduceMean", scalarResult, input,
+                    BackwardFunctions<T>.ReduceMeanBackward,
+                    savedState: new object[] { Enumerable.Range(0, input.Rank).ToArray() });
+                AutoTracer.RecordOp("ReduceMean", scalarResult, eng => scalarResult);
+                return scalarResult;
+            }
             if (typeof(T) == typeof(float))
             {
                 unsafe
@@ -23352,6 +23409,48 @@ public partial class CpuEngine : ITensorLevelEngine
                 for (int r = 0; r < rows; r++)
                     for (int c = 0; c < cols; c++) { float d = fData[r * cols + c] - means[c]; fOut[c] += d * d; }
                 for (int c = 0; c < cols; c++) fOut[c] /= rows;
+                return result;
+            }
+        }
+
+        // Double fast path for 2D single-axis variance — mirrors float branch above.
+        // Eliminates INumericOperations<T> dispatch per element for the LayerNorm /
+        // BatchNorm / Instructor mean-pool inference critical paths on double tensors.
+        if (typeof(T) == typeof(double) && input.IsContiguous && axes.Length == 1 && input.Rank == 2)
+        {
+            int axis = axes[0] < 0 ? input.Rank + axes[0] : axes[0];
+            var dData = (double[])(object)input.GetDataArray();
+            int rows = input._shape[0], cols = input._shape[1];
+
+            if (axis == 1) // variance along columns (per-row)
+            {
+                var outShape = keepDims ? new[] { rows, 1 } : new[] { rows };
+                var result = AutoTensorCache.RentOrAllocate<T>(outShape);
+                var dOut = (double[])(object)result.GetDataArray();
+                for (int r = 0; r < rows; r++)
+                {
+                    int off = r * cols;
+                    double rowSum = 0.0;
+                    for (int c = 0; c < cols; c++) rowSum += dData[off + c];
+                    double rowMean = rowSum / cols;
+                    double varSum = 0.0;
+                    for (int c = 0; c < cols; c++) { double d = dData[off + c] - rowMean; varSum += d * d; }
+                    dOut[r] = varSum / cols;
+                }
+                return result;
+            }
+            else if (axis == 0) // variance along rows (per-column)
+            {
+                var outShape = keepDims ? new[] { 1, cols } : new[] { cols };
+                var result = AutoTensorCache.RentOrAllocate<T>(outShape);
+                var dOut = (double[])(object)result.GetDataArray();
+                var means = new double[cols];
+                for (int r = 0; r < rows; r++)
+                    for (int c = 0; c < cols; c++) means[c] += dData[r * cols + c];
+                for (int c = 0; c < cols; c++) means[c] /= rows;
+                for (int r = 0; r < rows; r++)
+                    for (int c = 0; c < cols; c++) { double d = dData[r * cols + c] - means[c]; dOut[c] += d * d; }
+                for (int c = 0; c < cols; c++) dOut[c] /= rows;
                 return result;
             }
         }

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -6896,9 +6896,15 @@ public partial class CpuEngine : ITensorLevelEngine
             // SIMD reduction — no parallel-chunk wrapper yet (Min over double
             // doesn't have an unsafe-ptr overload the float ParallelReduceFloat
             // path uses), but still ~4× faster than the scalar numOps.Min
-            // fallback on AVX2 hosts.
-            var dArr = (double[])(object)tensor.GetDataArray();
-            double result = SimdKernels.Min(new ReadOnlySpan<double>(dArr, 0, tensor.Length));
+            // fallback on AVX2 hosts. Read through tensor.Data (logical view,
+            // sliced to Length) instead of GetDataArray() — the latter returns
+            // the underlying bucket-sized storage that ignores the tensor's
+            // _storageOffset, so contiguous-but-offset views would read the
+            // wrong elements. tensor was already Contiguous()-materialized
+            // above when not contiguous, so .Data is the right span here.
+            var span = AsDoubleMemory(tensor.Data).Span;
+            if (span.Length > tensor.Length) span = span[..tensor.Length];
+            double result = SimdKernels.Min(span);
             return Unsafe.As<double, T>(ref result);
         }
 
@@ -6960,11 +6966,16 @@ public partial class CpuEngine : ITensorLevelEngine
             return Unsafe.As<float, T>(ref result);
         }
 
-        // Double fast path: SIMD Sum over Span, then divide
+        // Double fast path: SIMD Sum over Span, then divide. Read through
+        // tensor.Data (logical view) so contiguous-but-offset views — and the
+        // future streaming-backed Memory<T> tensors — work correctly. The
+        // older GetDataArray() path returned bucket-sized backing storage
+        // that didn't honor _storageOffset.
         if (typeof(T) == typeof(double) && tensor.IsContiguous)
         {
-            var dArr = (double[])(object)tensor.GetDataArray();
-            double dSum = SimdKernels.Sum(new ReadOnlySpan<double>(dArr, 0, tensor.Length));
+            var span = AsDoubleMemory(tensor.Data).Span;
+            if (span.Length > tensor.Length) span = span[..tensor.Length];
+            double dSum = SimdKernels.Sum(span);
             double result = dSum / tensor.Length;
             return Unsafe.As<double, T>(ref result);
         }
@@ -23791,7 +23802,13 @@ public partial class CpuEngine : ITensorLevelEngine
                 DifferentiableOps.RecordUnary("ReduceMean", scalarResult, input,
                     BackwardFunctions<T>.ReduceMeanBackward,
                     savedState: new object[] { Enumerable.Range(0, input.Rank).ToArray() });
-                AutoTracer.RecordOp("ReduceMean", scalarResult, eng => scalarResult);
+                // Record the actual operation so AutoTracer's replay
+                // recomputes ReduceMean against the current tensor instead of
+                // baking the scalar we just produced. Replaying `eng => scalarResult`
+                // poisons compiled graphs with a stale value when the same op
+                // pattern is run on a different input tensor of identical shape.
+                { var c = input; var ca = Enumerable.Range(0, input.Rank).ToArray();
+                  AutoTracer.RecordOp("ReduceMean", scalarResult, eng => eng.ReduceMean(c, ca, keepDims: false)); }
                 return scalarResult;
             }
             if (typeof(T) == typeof(float))
@@ -23807,7 +23824,11 @@ public partial class CpuEngine : ITensorLevelEngine
                     DifferentiableOps.RecordUnary("ReduceMean", scalarResult, input,
                         BackwardFunctions<T>.ReduceMeanBackward,
                         savedState: new object[] { Enumerable.Range(0, input.Rank).ToArray() });
-                    AutoTracer.RecordOp("ReduceMean", scalarResult, eng => scalarResult);
+                    // Replay the actual operation so AutoTracer doesn't bake
+                    // this branch as a stale scalar constant — same fix as the
+                    // double branch above.
+                    { var c = input; var ca = Enumerable.Range(0, input.Rank).ToArray();
+                      AutoTracer.RecordOp("ReduceMean", scalarResult, eng => eng.ReduceMean(c, ca, keepDims: false)); }
                     return scalarResult;
                 }
             }

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -10534,6 +10534,35 @@ public partial class CpuEngine : ITensorLevelEngine
             return result;
         }
 
+        // Double fast path via BLAS cblas_dgemm with transB=true. Mirrors the
+        // float branch's "skip the transpose materialization" trick. Used by
+        // every attention layer's QKᵀ on fp64 and by linear-layer backwards
+        // through MatMulTransposedBackward. Falls through to the materialize-
+        // transpose generic path below when BLAS isn't loaded (rare — the in-
+        // house SimdGemm.Dgemm doesn't carry a transB flag, so we don't have
+        // a non-BLAS fast path here; the existing TryGemmEx route gives us
+        // PyTorch-class throughput when libopenblas is available).
+        if (typeof(T) == typeof(double) && a.Rank == 2 && b.Rank == 2 && a.IsContiguous && b.IsContiguous)
+        {
+            var aRaw = (double[])(object)a._storage.GetDataArray();
+            var bRaw = (double[])(object)b._storage.GetDataArray();
+            var result = AutoTensorCache.RentOrAllocate<T>(outShape);
+            var rRaw = (double[])(object)result._storage.GetDataArray();
+            int aOff = a._storageOffset, bOff = b._storageOffset, rOff = result._storageOffset;
+
+            if (Helpers.BlasProvider.TryGemmEx(M, N, K,
+                aRaw, aOff, K, false,
+                bRaw, bOff, K, true,
+                rRaw, rOff, N))
+            {
+                DifferentiableOps.RecordBinary("TensorMatMulTransposed", result, a, b, BackwardFunctions<T>.MatMulTransposedBackward);
+                return result;
+            }
+            // BLAS not loaded — fall through to the materialize-transpose path
+            // (still better than nothing; future work: add an in-house
+            // DgemmTransposeB so we keep the fast path even without libopenblas).
+        }
+
         // Generic fallback: materialize the transpose and call TensorMatMul.
         // Slower than the fast path but correct for all dtypes / non-2D shapes.
         var bT = TensorTranspose(b);
@@ -10571,12 +10600,19 @@ public partial class CpuEngine : ITensorLevelEngine
                     // 2D/ND×2D/ND×ND cases to write-through kernels.
                     (eng, output) =>
                     {
-                        if (typeof(T) == typeof(float) && eng is CpuEngine cpuEng)
+                        if (typeof(T) == typeof(float) && eng is CpuEngine cpuEngF)
                         {
-                            cpuEng.TensorMatMulFloatInto(
+                            cpuEngF.TensorMatMulFloatInto(
                                 (Tensor<float>)(object)capturedA,
                                 (Tensor<float>)(object)capturedB,
                                 (Tensor<float>)(object)output);
+                        }
+                        else if (typeof(T) == typeof(double) && eng is CpuEngine cpuEngD)
+                        {
+                            cpuEngD.TensorMatMulDoubleInto(
+                                (Tensor<double>)(object)capturedA,
+                                (Tensor<double>)(object)capturedB,
+                                (Tensor<double>)(object)output);
                         }
                         else
                         {
@@ -10661,6 +10697,110 @@ public partial class CpuEngine : ITensorLevelEngine
     internal void BatchMatMulFloatInto(Tensor<float> a, Tensor<float> b, Tensor<float> output)
     {
         TensorMatMulFloatInto(a, b, output);
+    }
+
+    /// <summary>
+    /// Write-through MatMul for double — parallel to <see cref="TensorMatMulFloatInto"/>.
+    /// Routes through cblas_dgemm when BLAS is available (the typical case),
+    /// otherwise the in-house <see cref="Simd.SimdGemm.Dgemm"/>. Skips the
+    /// alloc+CopyTo round-trip of the public TensorMatMul entry point: BERT-
+    /// scale fp64 models call MatMul ~72× per layer, so per-call savings
+    /// compound across the inference. Dispatches 2D×2D, ND×2D, and ND×ND
+    /// same-rank cases — same shape contracts as the float counterpart.
+    /// </summary>
+    internal void TensorMatMulDoubleInto(Tensor<double> a, Tensor<double> b, Tensor<double> output)
+    {
+        if (!a.IsContiguous) a = a.Contiguous();
+        if (!b.IsContiguous) b = b.Contiguous();
+
+        var aArr = a.GetDataArray();
+        var bArr = b.GetDataArray();
+        var oArr = output.GetDataArray();
+
+        // 2D × 2D
+        if (a.Rank == 2 && b.Rank == 2)
+        {
+            int m = a._shape[0], k = a._shape[1], n = b._shape[1];
+            if (Helpers.BlasProvider.TryGemmEx(m, n, k,
+                aArr, 0, k, false,
+                bArr, 0, n, false,
+                oArr, 0, n))
+                return;
+            Simd.SimdGemm.Dgemm(
+                new System.ReadOnlySpan<double>(aArr, 0, m * k),
+                new System.ReadOnlySpan<double>(bArr, 0, k * n),
+                new System.Span<double>(oArr, 0, m * n),
+                m, k, n);
+            return;
+        }
+
+        // ND × 2D: collapse batch dims into m
+        if (b.Rank == 2)
+        {
+            int aRank = a.Rank;
+            int m = a._shape[aRank - 2];
+            int k = a._shape[aRank - 1];
+            int n = b._shape[1];
+            int batchSize = 1;
+            for (int i = 0; i < aRank - 2; i++) batchSize *= a._shape[i];
+            int rows = batchSize * m;
+            if (Helpers.BlasProvider.TryGemmEx(rows, n, k,
+                aArr, 0, k, false,
+                bArr, 0, n, false,
+                oArr, 0, n))
+                return;
+            Simd.SimdGemm.Dgemm(
+                new System.ReadOnlySpan<double>(aArr, 0, rows * k),
+                new System.ReadOnlySpan<double>(bArr, 0, k * n),
+                new System.Span<double>(oArr, 0, rows * n),
+                rows, k, n);
+            return;
+        }
+
+        // ND × ND (same rank): per-batch GEMM
+        if (a.Rank == b.Rank)
+        {
+            int rank = a.Rank;
+            int m = a._shape[rank - 2];
+            int k = a._shape[rank - 1];
+            int n = b._shape[rank - 1];
+            int batchSize = 1;
+            for (int i = 0; i < rank - 2; i++) batchSize *= a._shape[i];
+            int sliceA = m * k, sliceB = k * n, sliceC = m * n;
+            if (batchSize == 1)
+            {
+                if (Helpers.BlasProvider.TryGemmEx(m, n, k,
+                    aArr, 0, k, false,
+                    bArr, 0, n, false,
+                    oArr, 0, n))
+                    return;
+                Simd.SimdGemm.Dgemm(
+                    new System.ReadOnlySpan<double>(aArr, 0, sliceA),
+                    new System.ReadOnlySpan<double>(bArr, 0, sliceB),
+                    new System.Span<double>(oArr, 0, sliceC),
+                    m, k, n);
+            }
+            else
+            {
+                AiDotNet.Tensors.Helpers.CpuParallelSettings.ParallelForOrSerial(0, batchSize, (long)batchSize * m * n * k, batch =>
+                {
+                    if (Helpers.BlasProvider.TryGemmEx(m, n, k,
+                        aArr, batch * sliceA, k, false,
+                        bArr, batch * sliceB, n, false,
+                        oArr, batch * sliceC, n))
+                        return;
+                    Simd.SimdGemm.DgemmSequential(
+                        new System.ReadOnlySpan<double>(aArr, batch * sliceA, sliceA),
+                        new System.ReadOnlySpan<double>(bArr, batch * sliceB, sliceB),
+                        new System.Span<double>(oArr, batch * sliceC, sliceC),
+                        m, k, n);
+                });
+            }
+            return;
+        }
+
+        throw new ArgumentException(
+            $"TensorMatMulDoubleInto: unsupported rank combination {a.Rank} and {b.Rank}");
     }
 
     internal void TensorMatMulFloatInto(Tensor<float> a, Tensor<float> b, Tensor<float> output)
@@ -11096,6 +11236,40 @@ public partial class CpuEngine : ITensorLevelEngine
                     aF.AsSpan(aOffset, matrixSizeA),
                     bF.AsSpan(bOffset, matrixSizeB),
                     rF.AsSpan(resultOffset, matrixSizeResult),
+                    m, n, p);
+            });
+
+            return result;
+        }
+
+        // Double path: same rationale as the float branch above. DgemmSequential
+        // is the right variant inside this outer Parallel.For over batch — using
+        // Dgemm (which has its own internal parallel above ~16K work) would nest
+        // workers. BLAS dgemm via TryGemm is preferred when available; we hit
+        // the in-house Dgemm tiled FMA kernel only when BLAS isn't loaded.
+        if (typeof(T) == typeof(double))
+        {
+            var aD = (double[])(object)aData;
+            var bD = (double[])(object)bData;
+            var rD = (double[])(object)rData;
+
+            AiDotNet.Tensors.Helpers.CpuParallelSettings.ParallelForOrSerial(0, batchSize, (long)result.Length, batch =>
+            {
+                int aOffset = batch * matrixSizeA;
+                int bOffset = batch * matrixSizeB;
+                int resultOffset = batch * matrixSizeResult;
+
+                // Try BLAS dgemm first — that's the absolute fastest when libopenblas
+                // is loaded. Falls through to the in-house kernel below.
+                if (MatrixMultiplyHelper.TryGemm(a.Data, aOffset, b.Data, bOffset, result.Data, resultOffset, m, n, p))
+                {
+                    return;
+                }
+
+                Simd.SimdGemm.DgemmSequential(
+                    aD.AsSpan(aOffset, matrixSizeA),
+                    bD.AsSpan(bOffset, matrixSizeB),
+                    rD.AsSpan(resultOffset, matrixSizeResult),
                     m, n, p);
             });
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -34844,6 +34844,22 @@ public partial class CpuEngine : ITensorLevelEngine
             for (int r = 0; r < srcRows; r++)
                 Array.Copy(srcArr, r * srcCols, dstArr, (r + padTop) * dstCols + padLeft, srcCols);
         }
+        else if (typeof(T) == typeof(double) && rank == 2 && padding.Length >= 4 && tensor.IsContiguous)
+        {
+            double dVal = value is not null ? (double)(object)value : 0.0;
+            var srcArr = (double[])(object)tensor.GetDataArray();
+            var dstArr = (double[])(object)result.GetDataArray();
+            int srcRows = tensor._shape[0], srcCols = tensor._shape[1];
+            int padLeft = padding[0];
+            int padTop = padding[2];
+            int dstCols = newShape[1];
+            if (dVal == 0.0)
+                Array.Clear(dstArr, 0, dstArr.Length);
+            else
+                for (int i = 0; i < dstArr.Length; i++) dstArr[i] = dVal;
+            for (int r = 0; r < srcRows; r++)
+                Array.Copy(srcArr, r * srcCols, dstArr, (r + padTop) * dstCols + padLeft, srcCols);
+        }
         else
         {
             result.Fill(value);
@@ -34928,6 +34944,41 @@ public partial class CpuEngine : ITensorLevelEngine
                                 + fh   * omfw * inArr[rowH1 + w0]
                                 + fh   * fw   * inArr[rowH1 + w1];
                         outArr[rowOut + ow] = v;
+                    }
+                }
+            };
+            if (total > 4) Parallel.For(0, total, kernel);
+            else for (int bc = 0; bc < total; bc++) kernel(bc);
+            return;
+        }
+        if (typeof(T) == typeof(double)
+            && input.GetDataArray() is double[] inArrD
+            && output.GetDataArray() is double[] outArrD)
+        {
+            int total = n * c;
+            int hh = h, ww = w, oH = outH, oW = outW;
+            Action<int> kernel = bc =>
+            {
+                int inBase = bc * hh * ww;
+                int outBase = bc * oH * oW;
+                for (int oh = 0; oh < oH; oh++)
+                {
+                    int h0 = h0Arr[oh], h1 = h1Arr[oh];
+                    double fh = fhArr[oh];
+                    double omfh = 1.0 - fh;
+                    int rowH0 = inBase + h0 * ww;
+                    int rowH1 = inBase + h1 * ww;
+                    int rowOut = outBase + oh * oW;
+                    for (int ow = 0; ow < oW; ow++)
+                    {
+                        int w0 = w0Arr[ow], w1 = w1Arr[ow];
+                        double fw = fwArr[ow];
+                        double omfw = 1.0 - fw;
+                        double v = omfh * omfw * inArrD[rowH0 + w0]
+                                 + omfh * fw   * inArrD[rowH0 + w1]
+                                 + fh   * omfw * inArrD[rowH1 + w0]
+                                 + fh   * fw   * inArrD[rowH1 + w1];
+                        outArrD[rowOut + ow] = v;
                     }
                 }
             };

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -35351,7 +35351,13 @@ public partial class CpuEngine : ITensorLevelEngine
         {
             int total = n * c;
             int hh = h, ww = w, oH = outH, oW = outW;
-            Action<int> kernel = bc =>
+            long work = (long)total * oH * oW;
+            // Route through CpuParallelSettings so MaxDegreeOfParallelism is
+            // honored and the small-shape serial cutover matches the rest of
+            // the engine's hot paths (LightweightParallel / ParallelForOrSerial
+            // are the documented entry points — raw Parallel.For bypasses both
+            // the work threshold and the global concurrency cap).
+            CpuParallelSettings.ParallelForOrSerial(0, total, work, bc =>
             {
                 int inBase = bc * hh * ww;
                 int outBase = bc * oH * oW;
@@ -35375,9 +35381,7 @@ public partial class CpuEngine : ITensorLevelEngine
                         outArrD[rowOut + ow] = v;
                     }
                 }
-            };
-            if (total > 4) Parallel.For(0, total, kernel);
-            else for (int bc = 0; bc < total; bc++) kernel(bc);
+            });
             return;
         }
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -2898,6 +2898,38 @@ public partial class CpuEngine : ITensorLevelEngine
             return;
         }
 
+        // Double fast path mirroring the float branch — same parallel-chunk
+        // VectorAddUnsafe pattern, dgemm-equivalent throughput on AVX2.
+        if (typeof(T) == typeof(double))
+        {
+            var aMem = AsDoubleMemory(a.Data);
+            var bMem = AsDoubleMemory(b.Data);
+            using var pinA = aMem.Pin();
+            using var pinB = bMem.Pin();
+            double* pA = (double*)pinA.Pointer;
+            double* pB = (double*)pinB.Pointer;
+
+            int numChunks = Math.Min(CpuParallelSettings.MaxDegreeOfParallelism, Math.Max(1, length / 2_000_000));
+            if (numChunks >= 2)
+            {
+                int chunkSize = (length + numChunks - 1) / numChunks;
+                chunkSize = (chunkSize + 31) & ~31;
+                CpuParallelSettings.ParallelForOrSerial(0, numChunks, length, chunk =>
+                {
+                    int start = chunk * chunkSize;
+                    int count = Math.Min(chunkSize, length - start);
+                    if (count > 0)
+                        SimdKernels.VectorAddUnsafe(pB + start, pA + start, pA + start, count);
+                });
+            }
+            else
+            {
+                SimdKernels.VectorAddUnsafe(pB, pA, pA, length);
+            }
+            if (savedA is not null) DifferentiableOps.RecordBinary("TensorAddInPlace", a, savedA, bOrig, BackwardFunctions<T>.AddBackward);
+            return;
+        }
+
         var numOps = MathHelper.GetNumericOperations<T>();
         numOps.Add(a.AsSpan(), b.AsSpan(), a.AsWritableSpan());
         if (savedA is not null)
@@ -4429,6 +4461,36 @@ public partial class CpuEngine : ITensorLevelEngine
             return;
         }
 
+        if (typeof(T) == typeof(double))
+        {
+            var aMem = AsDoubleMemory(a.Data);
+            var bMem = AsDoubleMemory(b.Data);
+            using var pinA = aMem.Pin();
+            using var pinB = bMem.Pin();
+            double* pA = (double*)pinA.Pointer;
+            double* pB = (double*)pinB.Pointer;
+
+            int numChunks = Math.Min(CpuParallelSettings.MaxDegreeOfParallelism, Math.Max(1, length / 2_000_000));
+            if (numChunks >= 2)
+            {
+                int chunkSize = (length + numChunks - 1) / numChunks;
+                chunkSize = (chunkSize + 31) & ~31;
+                CpuParallelSettings.ParallelForOrSerial(0, numChunks, length, chunk =>
+                {
+                    int start = chunk * chunkSize;
+                    int count = Math.Min(chunkSize, length - start);
+                    if (count > 0)
+                        SimdKernels.VectorMultiplyUnsafe(pB + start, pA + start, pA + start, count);
+                });
+            }
+            else
+            {
+                SimdKernels.VectorMultiplyUnsafe(pB, pA, pA, length);
+            }
+            if (savedA is not null) DifferentiableOps.RecordBinary("TensorMultiplyInPlace", a, savedA, bOrig, BackwardFunctions<T>.MultiplyBackward);
+            return;
+        }
+
         var numOps = MathHelper.GetNumericOperations<T>();
         numOps.Multiply(a.AsSpan(), b.AsSpan(), a.AsWritableSpan());
         if (savedA is not null)
@@ -4544,6 +4606,36 @@ public partial class CpuEngine : ITensorLevelEngine
                     {
                         SimdKernels.VectorSubtractUnsafe(pA + start, pB + start, pA + start, count);
                     }
+                });
+            }
+            else
+            {
+                SimdKernels.VectorSubtractUnsafe(pA, pB, pA, length);
+            }
+            if (savedASub is not null) DifferentiableOps.RecordBinary("TensorSubtractInPlace", a, savedASub, bOrig, BackwardFunctions<T>.SubtractBackward);
+            return;
+        }
+
+        if (typeof(T) == typeof(double))
+        {
+            var aMem = AsDoubleMemory(a.Data);
+            var bMem = AsDoubleMemory(b.Data);
+            using var pinA = aMem.Pin();
+            using var pinB = bMem.Pin();
+            double* pA = (double*)pinA.Pointer;
+            double* pB = (double*)pinB.Pointer;
+
+            int numChunks = Math.Min(CpuParallelSettings.MaxDegreeOfParallelism, Math.Max(1, length / 2_000_000));
+            if (numChunks >= 2)
+            {
+                int chunkSize = (length + numChunks - 1) / numChunks;
+                chunkSize = (chunkSize + 31) & ~31;
+                CpuParallelSettings.ParallelForOrSerial(0, numChunks, length, chunk =>
+                {
+                    int start = chunk * chunkSize;
+                    int count = Math.Min(chunkSize, length - start);
+                    if (count > 0)
+                        SimdKernels.VectorSubtractUnsafe(pA + start, pB + start, pA + start, count);
                 });
             }
             else

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -21128,6 +21128,36 @@ public partial class CpuEngine : ITensorLevelEngine
             return resultFCast;
         }
 
+        // Double fast path mirrors the float branch but uses inline double
+        // arithmetic + DgemmSequential (or BLAS dgemm when libopenblas is
+        // loaded) instead of SgemmSequential. Same materialized-softmax
+        // strategy: scores = Q · K^T (per head, with a pre-transposed K
+        // scratch buffer because SimdGemm.Dgemm has no transB flag), then
+        // fused scale + mask + bias + numerically stable softmax row-wise,
+        // then output = softmax · V.
+        if (typeof(T) == typeof(double))
+        {
+            double scaleValD = scale ?? 1.0 / Math.Sqrt(headDim);
+            var resultD = FlashAttentionDouble(
+                (Tensor<double>)(object)query,
+                (Tensor<double>)(object)key,
+                (Tensor<double>)(object)value,
+                attentionBias is null ? null : (Tensor<double>)(object)attentionBias,
+                scaleValD, isCausal,
+                batch, heads, seqQ, headDim, seqK,
+                out var statsD);
+            softmaxStats = (Tensor<T>)(object)statsD;
+            var resultDCast = (Tensor<T>)(object)resultD;
+            var savedD = attentionBias is null
+                ? new object[] { softmaxStats, scaleValD, isCausal }
+                : new object[] { softmaxStats, scaleValD, isCausal, attentionBias };
+            DifferentiableOps.RecordIfActive("FlashAttention", resultDCast,
+                new[] { query, key, value },
+                BackwardFunctions<T>.FlashAttentionBackward,
+                savedD);
+            return resultDCast;
+        }
+
         // Extract bias data for the scalar path (shape already validated above).
         T[]? biasData = null;
         bool hasBias = false;
@@ -21456,6 +21486,162 @@ public partial class CpuEngine : ITensorLevelEngine
         finally
         {
             System.Buffers.ArrayPool<float>.Shared.Return(scoresData, clearArray: false);
+        }
+    }
+
+    /// <summary>
+    /// Double-precision counterpart of <see cref="FlashAttentionFloat"/>. Same
+    /// materialized-softmax structure (per-head pre-transpose of K, fused
+    /// scale + causal/bias mask + numerically stable softmax, output = P · V).
+    /// Routes scores=Q·K^T and out=P·V through cblas_dgemm via
+    /// <see cref="Helpers.BlasProvider.TryGemmEx"/> when libopenblas is loaded;
+    /// falls back to the in-house <see cref="Simd.SimdGemm.DgemmSequential"/>
+    /// tiled Vector256&lt;double&gt; FMA kernel when BLAS is absent. The outer
+    /// <c>Parallel.For</c> across (batch * heads) demands the sequential GEMM
+    /// variant so workers don't nest.
+    /// </summary>
+    private Tensor<double> FlashAttentionDouble(
+        Tensor<double> query,
+        Tensor<double> key,
+        Tensor<double> value,
+        Tensor<double>? attentionBias,
+        double scaleValue,
+        bool isCausal,
+        int batch, int heads, int seqQ, int headDim, int seqK,
+        out Tensor<double> softmaxStats)
+    {
+        int bhCount = batch * heads;
+        int d_v = headDim;
+
+        if (!query.IsContiguous) query = query.Contiguous();
+        if (!key.IsContiguous) key = key.Contiguous();
+        if (!value.IsContiguous) value = value.Contiguous();
+
+        var qd = query.GetFlattenedData();
+        var kd = key.GetFlattenedData();
+        var vd = value.GetDataArray();
+        double[]? biasData = null;
+        bool biasBroadcastBatch = false;
+        if (attentionBias is not null)
+        {
+            if (!attentionBias.IsContiguous) attentionBias = attentionBias.Contiguous();
+            biasData = attentionBias.GetDataArray();
+            biasBroadcastBatch = attentionBias.Rank == 3;
+        }
+
+        int scoresLen = bhCount * seqQ * seqK;
+        var scoresData = System.Buffers.ArrayPool<double>.Shared.Rent(scoresLen);
+        try
+        {
+            var weightsData = new double[scoresLen];
+            var outputData = new double[bhCount * seqQ * d_v];
+            var statsData = new double[bhCount * seqQ];
+
+            double scaleD = scaleValue;
+            double negInfD = double.NegativeInfinity;
+
+            CpuParallelSettings.ParallelForOrSerial(0, bhCount, (long)bhCount * seqQ * headDim, bh =>
+            {
+                int b = bh / heads;
+                int h = bh % heads;
+
+                int qOff = bh * seqQ * headDim;
+                int kOff = bh * seqK * headDim;
+                int sOff = bh * seqQ * seqK;
+
+                // Step 1: scores = Q · K^T. Pre-transpose this head's K into a
+                // pooled scratch buffer so the GEMM doesn't need transB support.
+                var kt = System.Buffers.ArrayPool<double>.Shared.Rent(headDim * seqK);
+                try
+                {
+                    for (int i = 0; i < seqK; i++)
+                        for (int j = 0; j < headDim; j++)
+                            kt[j * seqK + i] = kd[kOff + i * headDim + j];
+
+                    if (!Helpers.BlasProvider.TryGemmEx(seqQ, seqK, headDim,
+                        qd, qOff, headDim, false,
+                        kt, 0, seqK, false,
+                        scoresData, sOff, seqK))
+                    {
+                        Engines.Simd.SimdGemm.DgemmSequential(
+                            qd.AsSpan(qOff, seqQ * headDim),
+                            kt.AsSpan(0, headDim * seqK),
+                            scoresData.AsSpan(sOff, seqQ * seqK),
+                            seqQ, headDim, seqK);
+                    }
+                }
+                finally { System.Buffers.ArrayPool<double>.Shared.Return(kt); }
+
+                // Step 2: fused scale + causal-mask + bias + stable softmax per row.
+                for (int i = 0; i < seqQ; i++)
+                {
+                    int rowOff = sOff + i * seqK;
+                    double maxVal = negInfD;
+                    for (int j = 0; j < seqK; j++)
+                    {
+                        double v = scoresData[rowOff + j] * scaleD;
+                        if (biasData is not null)
+                        {
+                            int biasIdx = biasBroadcastBatch
+                                ? (h * seqQ * seqK + i * seqK + j)
+                                : (b * heads * seqQ * seqK + h * seqQ * seqK + i * seqK + j);
+                            v += biasData[biasIdx];
+                        }
+                        if (isCausal && j > i) v = negInfD;
+                        if (v > maxVal) maxVal = v;
+                        scoresData[rowOff + j] = v;
+                    }
+
+                    // Fully-masked row guard — matches the float path.
+                    if (double.IsNegativeInfinity(maxVal))
+                    {
+                        for (int j = 0; j < seqK; j++)
+                            weightsData[rowOff + j] = 0.0;
+                        statsData[bh * seqQ + i] = negInfD;
+                        continue;
+                    }
+
+                    double sumExp = 0.0;
+                    for (int j = 0; j < seqK; j++)
+                    {
+                        double e = Math.Exp(scoresData[rowOff + j] - maxVal);
+                        weightsData[rowOff + j] = e;
+                        sumExp += e;
+                    }
+                    double inv = sumExp != 0.0 ? 1.0 / sumExp : 0.0;
+                    for (int j = 0; j < seqK; j++)
+                        weightsData[rowOff + j] *= inv;
+
+                    statsData[bh * seqQ + i] = maxVal + Math.Log(sumExp);
+                }
+
+                // Step 3: output = softmax · V. No transpose, V is row-major.
+                int wOff = bh * seqQ * seqK;
+                int vOff = bh * seqK * d_v;
+                int oOff = bh * seqQ * d_v;
+                if (!Helpers.BlasProvider.TryGemmEx(seqQ, d_v, seqK,
+                    weightsData, wOff, seqK, false,
+                    vd, vOff, d_v, false,
+                    outputData, oOff, d_v))
+                {
+                    Engines.Simd.SimdGemm.DgemmSequential(
+                        weightsData.AsSpan(wOff, seqQ * seqK),
+                        vd.AsSpan(vOff, seqK * d_v),
+                        outputData.AsSpan(oOff, seqQ * d_v),
+                        seqQ, seqK, d_v);
+                }
+            });
+
+            softmaxStats = TensorAllocator.Rent<double>(
+                new[] { batch, heads, seqQ },
+                new Vector<double>(statsData));
+            return TensorAllocator.Rent<double>(
+                new[] { batch, heads, seqQ, headDim },
+                new Vector<double>(outputData));
+        }
+        finally
+        {
+            System.Buffers.ArrayPool<double>.Shared.Return(scoresData, clearArray: false);
         }
     }
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -7255,6 +7255,45 @@ public partial class CpuEngine : ITensorLevelEngine
             return;
         }
 
+        // Double fast path: direct double arithmetic with batch×channel parallelism,
+        // bypassing the per-element numOps virtual dispatch. Mirrors the allocating
+        // MaxPool2D's double path that VGG / ResNet / DenseNet hit on every pool layer.
+        if (typeof(T) == typeof(double) && input.GetDataArray() is double[] inArrD && output.GetDataArray() is double[] outArrD)
+        {
+            int hD = height, wD = width, oHD = outputHeight, oWD = outputWidth;
+            int psD = poolSize, stD = stride, pdD = padding;
+            int bcD = batch * channels;
+            CpuParallelSettings.ParallelForOrSerial(0, bcD, (long)bcD * oHD * oWD, idx =>
+            {
+                int inBase = idx * hD * wD;
+                int outBase = idx * oHD * oWD;
+                for (int oh = 0; oh < oHD; oh++)
+                {
+                    for (int ow = 0; ow < oWD; ow++)
+                    {
+                        double maxVal = double.NegativeInfinity;
+                        int ihStart = oh * stD - pdD;
+                        int iwStart = ow * stD - pdD;
+                        int khStart = ihStart < 0 ? -ihStart : 0;
+                        int kwStart = iwStart < 0 ? -iwStart : 0;
+                        int khEnd = psD < (hD - ihStart) ? psD : (hD - ihStart);
+                        int kwEnd = psD < (wD - iwStart) ? psD : (wD - iwStart);
+                        for (int kh = khStart; kh < khEnd; kh++)
+                        {
+                            int rowOff = inBase + (ihStart + kh) * wD + iwStart;
+                            for (int kw = kwStart; kw < kwEnd; kw++)
+                            {
+                                double v = inArrD[rowOff + kw];
+                                if (v > maxVal) maxVal = v;
+                            }
+                        }
+                        outArrD[outBase + oh * oWD + ow] = maxVal;
+                    }
+                }
+            });
+            return;
+        }
+
         // Generic fallback
         var inputData = input.GetDataArray();
         var outputData = output.GetDataArray();
@@ -7352,6 +7391,47 @@ public partial class CpuEngine : ITensorLevelEngine
                             }
                         }
                         outArr[outputBase + oh * oW + ow] = count > 0 ? sum / count : 0f;
+                    }
+            };
+            if (h * w >= 1024) Parallel.For(0, bc, poolKernel);
+            else for (int idx = 0; idx < bc; idx++) poolKernel(idx);
+            return;
+        }
+
+        // Double fast path: direct double arithmetic with the same batch×channel
+        // parallel partition, but without the per-element numOps virtual dispatch.
+        // Used by ResNet's global-average-pool final step and by GAP blocks in
+        // various CV architectures running fp64.
+        if (typeof(T) == typeof(double) && input.GetDataArray() is double[] inArrD && output.GetDataArray() is double[] outArrD)
+        {
+            int bc = batch * channels;
+            int h = height, w = width, oH = outputHeight, oW = outputWidth;
+            int ps = poolSize, st = stride, pd = padding;
+            Action<int> poolKernel = idx =>
+            {
+                int inputBase = idx * h * w;
+                int outputBase = idx * oH * oW;
+                for (int oh = 0; oh < oH; oh++)
+                    for (int ow = 0; ow < oW; ow++)
+                    {
+                        double sum = 0;
+                        int count = 0;
+                        int ihStart = oh * st - pd;
+                        int iwStart = ow * st - pd;
+                        int khStart = ihStart < 0 ? -ihStart : 0;
+                        int kwStart = iwStart < 0 ? -iwStart : 0;
+                        int khEnd = Math.Min(ps, h - ihStart);
+                        int kwEnd = Math.Min(ps, w - iwStart);
+                        for (int kh = khStart; kh < khEnd; kh++)
+                        {
+                            int rowOff = inputBase + (ihStart + kh) * w + iwStart;
+                            for (int kw = kwStart; kw < kwEnd; kw++)
+                            {
+                                sum += inArrD[rowOff + kw];
+                                count++;
+                            }
+                        }
+                        outArrD[outputBase + oh * oW + ow] = count > 0 ? sum / count : 0.0;
                     }
             };
             if (h * w >= 1024) Parallel.For(0, bc, poolKernel);

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -36532,6 +36532,42 @@ public partial class CpuEngine : ITensorLevelEngine
         return result;
     }
 
+    /// <summary>Decompose Complex&lt;double&gt; tensor to split double arrays for SIMD.</summary>
+    private static (double[] real, double[] imag) DecomposeToDouble<T>(Tensor<Complex<T>> tensor)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        int n = tensor.Length;
+        var real = new double[n];
+        var imag = new double[n];
+        for (int i = 0; i < n; i++)
+        {
+            real[i] = ops.ToDouble(tensor[i].Real);
+            imag[i] = ops.ToDouble(tensor[i].Imaginary);
+        }
+        return (real, imag);
+    }
+
+    /// <summary>Recompose double split arrays back to Complex tensor.</summary>
+    private static Tensor<Complex<T>> RecomposeFromDouble<T>(double[] real, double[] imag, int[] shape)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        int n = real.Length;
+        var result = new Tensor<Complex<T>>(shape);
+        for (int i = 0; i < n; i++)
+            result[i] = new Complex<T>(ops.FromDouble(real[i]), ops.FromDouble(imag[i]));
+        return result;
+    }
+
+    /// <summary>Recompose double array to real Tensor.</summary>
+    private static Tensor<T> RecomposeRealFromDouble<T>(double[] data, int[] shape)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        int n = data.Length;
+        var result = new Tensor<T>(shape);
+        for (int i = 0; i < n; i++) result[i] = ops.FromDouble(data[i]);
+        return result;
+    }
+
     /// <summary>
     /// Computes batch count and last-axis size for batched FFT.
     /// For 1D: batch=1, fftSize=length. For multi-D: batch=product of leading dims, fftSize=last dim.
@@ -38426,6 +38462,13 @@ public partial class CpuEngine : ITensorLevelEngine
             Simd.SimdComplexKernels.ComplexConjugate(aR, aI, oR, oI);
             result = RecomposeFromFloat<T>(oR, oI, a._shape);
         }
+        else if (typeof(T) == typeof(double))
+        {
+            var (aR, aI) = DecomposeToDouble(a);
+            var oR = new double[n]; var oI = new double[n];
+            Simd.SimdComplexKernels.ComplexConjugateDouble(aR, aI, oR, oI);
+            result = RecomposeFromDouble<T>(oR, oI, a._shape);
+        }
         else
         {
             for (int i = 0; i < n; i++)
@@ -38454,6 +38497,13 @@ public partial class CpuEngine : ITensorLevelEngine
             var output = new float[n];
             Simd.SimdComplexKernels.ComplexMagnitude(aR, aI, output);
             result = RecomposeRealFromFloat<T>(output, a._shape);
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            var (aR, aI) = DecomposeToDouble(a);
+            var output = new double[n];
+            Simd.SimdComplexKernels.ComplexMagnitudeDouble(aR, aI, output);
+            result = RecomposeRealFromDouble<T>(output, a._shape);
         }
         else
         {
@@ -38487,6 +38537,13 @@ public partial class CpuEngine : ITensorLevelEngine
             var output = new float[n];
             Simd.SimdComplexKernels.ComplexMagnitudeSquared(aR, aI, output);
             result = RecomposeRealFromFloat<T>(output, a._shape);
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            var (aR, aI) = DecomposeToDouble(a);
+            var output = new double[n];
+            Simd.SimdComplexKernels.ComplexMagnitudeSquaredDouble(aR, aI, output);
+            result = RecomposeRealFromDouble<T>(output, a._shape);
         }
         else
         {
@@ -38594,6 +38651,13 @@ public partial class CpuEngine : ITensorLevelEngine
             Simd.SimdComplexKernels.ComplexScale(aR, aI, oR, oI, (float)ops.ToDouble(scalar));
             result = RecomposeFromFloat<T>(oR, oI, a._shape);
         }
+        else if (typeof(T) == typeof(double))
+        {
+            var (aR, aI) = DecomposeToDouble(a);
+            var oR = new double[n]; var oI = new double[n];
+            Simd.SimdComplexKernels.ComplexScaleDouble(aR, aI, oR, oI, ops.ToDouble(scalar));
+            result = RecomposeFromDouble<T>(oR, oI, a._shape);
+        }
         else
         {
             for (int i = 0; i < n; i++)
@@ -38628,6 +38692,14 @@ public partial class CpuEngine : ITensorLevelEngine
             var oR = new float[n]; var oI = new float[n];
             Simd.SimdComplexKernels.ComplexCrossSpectral(xR, xI, yR, yI, oR, oI);
             result = RecomposeFromFloat<T>(oR, oI, x._shape);
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            var (xR, xI) = DecomposeToDouble(x);
+            var (yR, yI) = DecomposeToDouble(y);
+            var oR = new double[n]; var oI = new double[n];
+            Simd.SimdComplexKernels.ComplexCrossSpectralDouble(xR, xI, yR, yI, oR, oI);
+            result = RecomposeFromDouble<T>(oR, oI, x._shape);
         }
         else
         {
@@ -39114,6 +39186,14 @@ public partial class CpuEngine : ITensorLevelEngine
             var oR = new float[n]; var oI = new float[n];
             Simd.SimdComplexKernels.ComplexAdd(aR, aI, bR, bI, oR, oI);
             result = RecomposeFromFloat<T>(oR, oI, a._shape);
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            var (aR, aI) = DecomposeToDouble(a);
+            var (bR, bI) = DecomposeToDouble(b);
+            var oR = new double[n]; var oI = new double[n];
+            Simd.SimdComplexKernels.ComplexAddDouble(aR, aI, bR, bI, oR, oI);
+            result = RecomposeFromDouble<T>(oR, oI, a._shape);
         }
         else
         {

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -27187,7 +27187,7 @@ public partial class CpuEngine : ITensorLevelEngine
             var dst = (float[])(object)result.GetDataArray();
             Simd.ScanKernels.PrefixSumFloat(src, dst);
             DifferentiableOps.RecordUnary("TensorCumSum", result, tensorOrig, BackwardFunctions<T>.CumSumBackward, new object[] { axis });
-            AutoTracer.RecordOp("TensorCumSum", result, eng => result);
+            { var c = tensorOrig; var ca = axis; AutoTracer.RecordOp("TensorCumSum", result, eng => eng.TensorCumSum(c, ca)); }
             return result;
         }
 
@@ -27204,7 +27204,10 @@ public partial class CpuEngine : ITensorLevelEngine
                     new Span<float>(dst, start, axisSize));
             }
             DifferentiableOps.RecordUnary("TensorCumSum", result, tensorOrig, BackwardFunctions<T>.CumSumBackward, new object[] { axis });
-            AutoTracer.RecordOp("TensorCumSum", result, eng => result);
+            // Record the actual op against captured inputs so AutoTracer's
+            // compiled-replay recomputes the cumulative sum for the live
+            // tensor instead of baking the scalar we just produced.
+            { var c = tensorOrig; var ca = axis; AutoTracer.RecordOp("TensorCumSum", result, eng => eng.TensorCumSum(c, ca)); }
             return result;
         }
 
@@ -27220,7 +27223,7 @@ public partial class CpuEngine : ITensorLevelEngine
             int len = tensor.Length;
             for (int i = 0; i < len; i++) { accD += srcD[i]; dstD[i] = accD; }
             DifferentiableOps.RecordUnary("TensorCumSum", result, tensorOrig, BackwardFunctions<T>.CumSumBackward, new object[] { axis });
-            AutoTracer.RecordOp("TensorCumSum", result, eng => result);
+            { var c = tensorOrig; var ca = axis; AutoTracer.RecordOp("TensorCumSum", result, eng => eng.TensorCumSum(c, ca)); }
             return result;
         }
         if (typeof(T) == typeof(double) && innerSize == 1)
@@ -27234,7 +27237,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 for (int a = 0; a < axisSize; a++) { accD += srcD[start + a]; dstD[start + a] = accD; }
             }
             DifferentiableOps.RecordUnary("TensorCumSum", result, tensorOrig, BackwardFunctions<T>.CumSumBackward, new object[] { axis });
-            AutoTracer.RecordOp("TensorCumSum", result, eng => result);
+            { var c = tensorOrig; var ca = axis; AutoTracer.RecordOp("TensorCumSum", result, eng => eng.TensorCumSum(c, ca)); }
             return result;
         }
 
@@ -27269,7 +27272,7 @@ public partial class CpuEngine : ITensorLevelEngine
         }
 
         DifferentiableOps.RecordUnary("TensorCumSum", result, tensorOrig, BackwardFunctions<T>.CumSumBackward, new object[] { axis });
-        AutoTracer.RecordOp("TensorCumSum", result, eng => result);
+        { var c = tensorOrig; var ca = axis; AutoTracer.RecordOp("TensorCumSum", result, eng => eng.TensorCumSum(c, ca)); }
         return result;
     }
 
@@ -28208,7 +28211,11 @@ public partial class CpuEngine : ITensorLevelEngine
                     fDst[r] = MathF.Sqrt(sumSq);
                 }
                 DifferentiableOps.RecordUnary("Norm", normResult, tensor, BackwardFunctions<T>.NormBackward, new object[] { normAxis });
-                AutoTracer.RecordOp("Norm", normResult, eng => normResult);
+                // Record the actual op against captured inputs so AutoTracer's
+                // compiled-replay recomputes the norm for the live tensor
+                // instead of baking the result tensor we just produced as a
+                // constant in the graph.
+                { var c = tensor; var ca = normAxis; var ck = keepDims; AutoTracer.RecordOp("Norm", normResult, eng => eng.TensorNorm(c, ca, ck)); }
                 return normResult;
             }
             else if (normAxis == 0)
@@ -28227,7 +28234,11 @@ public partial class CpuEngine : ITensorLevelEngine
                 for (int c = 0; c < cols; c++)
                     fDst[c] = MathF.Sqrt(fDst[c]);
                 DifferentiableOps.RecordUnary("Norm", normResult, tensor, BackwardFunctions<T>.NormBackward, new object[] { normAxis });
-                AutoTracer.RecordOp("Norm", normResult, eng => normResult);
+                // Record the actual op against captured inputs so AutoTracer's
+                // compiled-replay recomputes the norm for the live tensor
+                // instead of baking the result tensor we just produced as a
+                // constant in the graph.
+                { var c = tensor; var ca = normAxis; var ck = keepDims; AutoTracer.RecordOp("Norm", normResult, eng => eng.TensorNorm(c, ca, ck)); }
                 return normResult;
             }
         }
@@ -28253,7 +28264,11 @@ public partial class CpuEngine : ITensorLevelEngine
                     dDst[r] = Math.Sqrt(sumSq);
                 }
                 DifferentiableOps.RecordUnary("Norm", normResult, tensor, BackwardFunctions<T>.NormBackward, new object[] { normAxis });
-                AutoTracer.RecordOp("Norm", normResult, eng => normResult);
+                // Record the actual op against captured inputs so AutoTracer's
+                // compiled-replay recomputes the norm for the live tensor
+                // instead of baking the result tensor we just produced as a
+                // constant in the graph.
+                { var c = tensor; var ca = normAxis; var ck = keepDims; AutoTracer.RecordOp("Norm", normResult, eng => eng.TensorNorm(c, ca, ck)); }
                 return normResult;
             }
             else if (normAxis == 0)
@@ -28271,7 +28286,11 @@ public partial class CpuEngine : ITensorLevelEngine
                 for (int c = 0; c < cols; c++)
                     dDst[c] = Math.Sqrt(dDst[c]);
                 DifferentiableOps.RecordUnary("Norm", normResult, tensor, BackwardFunctions<T>.NormBackward, new object[] { normAxis });
-                AutoTracer.RecordOp("Norm", normResult, eng => normResult);
+                // Record the actual op against captured inputs so AutoTracer's
+                // compiled-replay recomputes the norm for the live tensor
+                // instead of baking the result tensor we just produced as a
+                // constant in the graph.
+                { var c = tensor; var ca = normAxis; var ck = keepDims; AutoTracer.RecordOp("Norm", normResult, eng => eng.TensorNorm(c, ca, ck)); }
                 return normResult;
             }
         }
@@ -29139,7 +29158,7 @@ public partial class CpuEngine : ITensorLevelEngine
             }
             DifferentiableOps.RecordUnary("LogSoftmax", result, tensor,
                 BackwardFunctions<T>.LogSoftmaxBackward);
-            AutoTracer.RecordOp("LogSoftmax", result, eng => result);
+            { var c = tensor; var ca = axis; AutoTracer.RecordOp("LogSoftmax", result, eng => eng.TensorLogSoftmax(c, ca)); }
             return result;
         }
         // Double primitive fast path for last-axis log-softmax. Inline 3-pass
@@ -29172,7 +29191,7 @@ public partial class CpuEngine : ITensorLevelEngine
             }
             DifferentiableOps.RecordUnary("LogSoftmax", resultD, tensor,
                 BackwardFunctions<T>.LogSoftmaxBackward);
-            AutoTracer.RecordOp("LogSoftmax", resultD, eng => resultD);
+            { var c = tensor; var ca = axis; AutoTracer.RecordOp("LogSoftmax", resultD, eng => eng.TensorLogSoftmax(c, ca)); }
             return resultD;
         }
 
@@ -29217,7 +29236,7 @@ public partial class CpuEngine : ITensorLevelEngine
         var logSoftmaxResult = TensorAllocator.Rent<T>(tensor._shape, outputData);
         DifferentiableOps.RecordUnary("LogSoftmax", logSoftmaxResult, tensor,
             BackwardFunctions<T>.LogSoftmaxBackward);
-        AutoTracer.RecordOp("LogSoftmax", logSoftmaxResult, eng => logSoftmaxResult);
+        { var c = tensor; var ca = axis; AutoTracer.RecordOp("LogSoftmax", logSoftmaxResult, eng => eng.TensorLogSoftmax(c, ca)); }
         return logSoftmaxResult;
     }
 
@@ -34278,7 +34297,7 @@ public partial class CpuEngine : ITensorLevelEngine
             float fMean = sumSq / len;
             var scalarResult = new Tensor<T>(new[] { Unsafe.As<float, T>(ref fMean) }, [1]);
             DifferentiableOps.RecordBinary("MSELoss", scalarResult, predictions, targets, BackwardFunctions<T>.MSELossBackward);
-            AutoTracer.RecordOp("MSELoss", scalarResult, eng => scalarResult);
+            { var cp = predictions; var ct = targets; AutoTracer.RecordOp("MSELoss", scalarResult, eng => eng.TensorMSELoss(cp, ct)); }
             return scalarResult;
         }
         // Double fast path: same fused single-pass diff² sum.
@@ -34296,7 +34315,7 @@ public partial class CpuEngine : ITensorLevelEngine
             double dMean = sumSq / len;
             var scalarResult = new Tensor<T>(new[] { Unsafe.As<double, T>(ref dMean) }, [1]);
             DifferentiableOps.RecordBinary("MSELoss", scalarResult, predictions, targets, BackwardFunctions<T>.MSELossBackward);
-            AutoTracer.RecordOp("MSELoss", scalarResult, eng => scalarResult);
+            { var cp = predictions; var ct = targets; AutoTracer.RecordOp("MSELoss", scalarResult, eng => eng.TensorMSELoss(cp, ct)); }
             return scalarResult;
         }
 
@@ -34311,7 +34330,7 @@ public partial class CpuEngine : ITensorLevelEngine
         }
         var result = new Tensor<T>(new[] { mean }, [1]);
         DifferentiableOps.RecordBinary("MSELoss", result, predictions, targets, BackwardFunctions<T>.MSELossBackward);
-        AutoTracer.RecordOp("MSELoss", result, eng => result);
+        { var cp = predictions; var ct = targets; AutoTracer.RecordOp("MSELoss", result, eng => eng.TensorMSELoss(cp, ct)); }
         return result;
     }
 
@@ -34345,7 +34364,7 @@ public partial class CpuEngine : ITensorLevelEngine
             float fMean = sumAbs / len;
             var scalarResult = new Tensor<T>(new[] { Unsafe.As<float, T>(ref fMean) }, [1]);
             DifferentiableOps.RecordBinary("L1Loss", scalarResult, predictions, targets, BackwardFunctions<T>.L1LossBackward);
-            AutoTracer.RecordOp("L1Loss", scalarResult, eng => scalarResult);
+            { var cp = predictions; var ct = targets; AutoTracer.RecordOp("L1Loss", scalarResult, eng => eng.TensorL1Loss(cp, ct)); }
             return scalarResult;
         }
         // Double fast path
@@ -34360,7 +34379,7 @@ public partial class CpuEngine : ITensorLevelEngine
             double dMean = sumAbs / len;
             var scalarResult = new Tensor<T>(new[] { Unsafe.As<double, T>(ref dMean) }, [1]);
             DifferentiableOps.RecordBinary("L1Loss", scalarResult, predictions, targets, BackwardFunctions<T>.L1LossBackward);
-            AutoTracer.RecordOp("L1Loss", scalarResult, eng => scalarResult);
+            { var cp = predictions; var ct = targets; AutoTracer.RecordOp("L1Loss", scalarResult, eng => eng.TensorL1Loss(cp, ct)); }
             return scalarResult;
         }
 
@@ -34375,7 +34394,7 @@ public partial class CpuEngine : ITensorLevelEngine
         }
         var result = new Tensor<T>(new[] { mean }, [1]);
         DifferentiableOps.RecordBinary("L1Loss", result, predictions, targets, BackwardFunctions<T>.L1LossBackward);
-        AutoTracer.RecordOp("L1Loss", result, eng => result);
+        { var cp = predictions; var ct = targets; AutoTracer.RecordOp("L1Loss", result, eng => eng.TensorL1Loss(cp, ct)); }
         return result;
     }
 
@@ -34417,7 +34436,7 @@ public partial class CpuEngine : ITensorLevelEngine
             var scalarResult = new Tensor<T>(new[] { Unsafe.As<float, T>(ref fMean) }, [1]);
             DifferentiableOps.RecordBinary("HuberLoss", scalarResult, predictions, targets,
                 BackwardFunctions<T>.HuberLossBackward, savedState: new object[] { delta });
-            AutoTracer.RecordOp("HuberLoss", scalarResult, eng => scalarResult);
+            { var cp = predictions; var ct = targets; var cd = delta; AutoTracer.RecordOp("HuberLoss", scalarResult, eng => eng.TensorHuberLoss(cp, ct, cd)); }
             return scalarResult;
         }
         // Double fast path
@@ -34438,7 +34457,7 @@ public partial class CpuEngine : ITensorLevelEngine
             var scalarResult = new Tensor<T>(new[] { Unsafe.As<double, T>(ref dMean) }, [1]);
             DifferentiableOps.RecordBinary("HuberLoss", scalarResult, predictions, targets,
                 BackwardFunctions<T>.HuberLossBackward, savedState: new object[] { delta });
-            AutoTracer.RecordOp("HuberLoss", scalarResult, eng => scalarResult);
+            { var cp = predictions; var ct = targets; var cd = delta; AutoTracer.RecordOp("HuberLoss", scalarResult, eng => eng.TensorHuberLoss(cp, ct, cd)); }
             return scalarResult;
         }
 
@@ -34457,7 +34476,7 @@ public partial class CpuEngine : ITensorLevelEngine
         var result = new Tensor<T>(new[] { mean }, [1]);
         DifferentiableOps.RecordBinary("HuberLoss", result, predictions, targets,
             BackwardFunctions<T>.HuberLossBackward, savedState: new object[] { delta });
-        AutoTracer.RecordOp("HuberLoss", result, eng => result);
+        { var cp = predictions; var ct = targets; var cd = delta; AutoTracer.RecordOp("HuberLoss", result, eng => eng.TensorHuberLoss(cp, ct, cd)); }
         return result;
     }
 
@@ -34497,7 +34516,7 @@ public partial class CpuEngine : ITensorLevelEngine
             var scalarResultF = new Tensor<T>(new[] { Unsafe.As<float, T>(ref meanF) }, [1]);
             DifferentiableOps.RecordBinary("BCEWithLogitsLoss", scalarResultF, logits, targets,
                 BackwardFunctions<T>.BCEWithLogitsLossBackward);
-            AutoTracer.RecordOp("BCEWithLogitsLoss", scalarResultF, eng => scalarResultF);
+            { var cl = logits; var ct = targets; AutoTracer.RecordOp("BCEWithLogitsLoss", scalarResultF, eng => eng.TensorBCEWithLogitsLoss(cl, ct)); }
             return scalarResultF;
         }
         // Double fast path: same numerically stable form, inline arithmetic.
@@ -34518,7 +34537,7 @@ public partial class CpuEngine : ITensorLevelEngine
             var scalarResultD = new Tensor<T>(new[] { Unsafe.As<double, T>(ref meanD) }, [1]);
             DifferentiableOps.RecordBinary("BCEWithLogitsLoss", scalarResultD, logits, targets,
                 BackwardFunctions<T>.BCEWithLogitsLossBackward);
-            AutoTracer.RecordOp("BCEWithLogitsLoss", scalarResultD, eng => scalarResultD);
+            { var cl = logits; var ct = targets; AutoTracer.RecordOp("BCEWithLogitsLoss", scalarResultD, eng => eng.TensorBCEWithLogitsLoss(cl, ct)); }
             return scalarResultD;
         }
 
@@ -34536,7 +34555,7 @@ public partial class CpuEngine : ITensorLevelEngine
         var result = new Tensor<T>(new[] { mean }, [1]);
         DifferentiableOps.RecordBinary("BCEWithLogitsLoss", result, logits, targets,
             BackwardFunctions<T>.BCEWithLogitsLossBackward);
-        AutoTracer.RecordOp("BCEWithLogitsLoss", result, eng => result);
+        { var cl = logits; var ct = targets; AutoTracer.RecordOp("BCEWithLogitsLoss", result, eng => eng.TensorBCEWithLogitsLoss(cl, ct)); }
         return result;
     }
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -2597,7 +2597,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var aSpanD = new ReadOnlySpan<double>((double[])(object)aArrD, a._storageOffset, m * k);
                 var bSpanD = new ReadOnlySpan<double>((double[])(object)bArrD, b._storageOffset, k * n);
                 var cSpanD = new Span<double>((double[])(object)rArrD, 0, m * n);
-                Simd.SimdGemm.Dgemm(aSpanD, bSpanD, cSpanD, m, k, n);
+                SimdGemm.Dgemm(aSpanD, bSpanD, cSpanD, m, k, n);
                 DifferentiableOps.RecordBinary("BatchMatMul", result, aOrig, bOrig, BackwardFunctions<T>.BatchMatMulBackward);
                 { var ca = a; var cb = b; AutoTracer.RecordOp("BatchMatMul", result, eng => eng.BatchMatMul(ca, cb)); }
                 return result;
@@ -10550,7 +10550,7 @@ public partial class CpuEngine : ITensorLevelEngine
             var rRaw = (double[])(object)result._storage.GetDataArray();
             int aOff = a._storageOffset, bOff = b._storageOffset, rOff = result._storageOffset;
 
-            if (Helpers.BlasProvider.TryGemmEx(M, N, K,
+            if (BlasProvider.TryGemmEx(M, N, K,
                 aRaw, aOff, K, false,
                 bRaw, bOff, K, true,
                 rRaw, rOff, N))
@@ -10726,10 +10726,10 @@ public partial class CpuEngine : ITensorLevelEngine
                 bArr, 0, n, false,
                 oArr, 0, n))
                 return;
-            Simd.SimdGemm.Dgemm(
-                new System.ReadOnlySpan<double>(aArr, 0, m * k),
-                new System.ReadOnlySpan<double>(bArr, 0, k * n),
-                new System.Span<double>(oArr, 0, m * n),
+            SimdGemm.Dgemm(
+                new ReadOnlySpan<double>(aArr, 0, m * k),
+                new ReadOnlySpan<double>(bArr, 0, k * n),
+                new Span<double>(oArr, 0, m * n),
                 m, k, n);
             return;
         }
@@ -10744,15 +10744,15 @@ public partial class CpuEngine : ITensorLevelEngine
             int batchSize = 1;
             for (int i = 0; i < aRank - 2; i++) batchSize *= a._shape[i];
             int rows = batchSize * m;
-            if (Helpers.BlasProvider.TryGemmEx(rows, n, k,
+            if (BlasProvider.TryGemmEx(rows, n, k,
                 aArr, 0, k, false,
                 bArr, 0, n, false,
                 oArr, 0, n))
                 return;
-            Simd.SimdGemm.Dgemm(
-                new System.ReadOnlySpan<double>(aArr, 0, rows * k),
-                new System.ReadOnlySpan<double>(bArr, 0, k * n),
-                new System.Span<double>(oArr, 0, rows * n),
+            SimdGemm.Dgemm(
+                new ReadOnlySpan<double>(aArr, 0, rows * k),
+                new ReadOnlySpan<double>(bArr, 0, k * n),
+                new Span<double>(oArr, 0, rows * n),
                 rows, k, n);
             return;
         }
@@ -10769,30 +10769,30 @@ public partial class CpuEngine : ITensorLevelEngine
             int sliceA = m * k, sliceB = k * n, sliceC = m * n;
             if (batchSize == 1)
             {
-                if (Helpers.BlasProvider.TryGemmEx(m, n, k,
+                if (BlasProvider.TryGemmEx(m, n, k,
                     aArr, 0, k, false,
                     bArr, 0, n, false,
                     oArr, 0, n))
                     return;
-                Simd.SimdGemm.Dgemm(
-                    new System.ReadOnlySpan<double>(aArr, 0, sliceA),
-                    new System.ReadOnlySpan<double>(bArr, 0, sliceB),
-                    new System.Span<double>(oArr, 0, sliceC),
+                SimdGemm.Dgemm(
+                    new ReadOnlySpan<double>(aArr, 0, sliceA),
+                    new ReadOnlySpan<double>(bArr, 0, sliceB),
+                    new Span<double>(oArr, 0, sliceC),
                     m, k, n);
             }
             else
             {
-                AiDotNet.Tensors.Helpers.CpuParallelSettings.ParallelForOrSerial(0, batchSize, (long)batchSize * m * n * k, batch =>
+                CpuParallelSettings.ParallelForOrSerial(0, batchSize, (long)batchSize * m * n * k, batch =>
                 {
-                    if (Helpers.BlasProvider.TryGemmEx(m, n, k,
+                    if (BlasProvider.TryGemmEx(m, n, k,
                         aArr, batch * sliceA, k, false,
                         bArr, batch * sliceB, n, false,
                         oArr, batch * sliceC, n))
                         return;
-                    Simd.SimdGemm.DgemmSequential(
-                        new System.ReadOnlySpan<double>(aArr, batch * sliceA, sliceA),
-                        new System.ReadOnlySpan<double>(bArr, batch * sliceB, sliceB),
-                        new System.Span<double>(oArr, batch * sliceC, sliceC),
+                    SimdGemm.DgemmSequential(
+                        new ReadOnlySpan<double>(aArr, batch * sliceA, sliceA),
+                        new ReadOnlySpan<double>(bArr, batch * sliceB, sliceB),
+                        new Span<double>(oArr, batch * sliceC, sliceC),
                         m, k, n);
                 });
             }
@@ -11253,7 +11253,7 @@ public partial class CpuEngine : ITensorLevelEngine
             var bD = (double[])(object)bData;
             var rD = (double[])(object)rData;
 
-            AiDotNet.Tensors.Helpers.CpuParallelSettings.ParallelForOrSerial(0, batchSize, (long)result.Length, batch =>
+            CpuParallelSettings.ParallelForOrSerial(0, batchSize, (long)result.Length, batch =>
             {
                 int aOffset = batch * matrixSizeA;
                 int bOffset = batch * matrixSizeB;
@@ -11266,7 +11266,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     return;
                 }
 
-                Simd.SimdGemm.DgemmSequential(
+                SimdGemm.DgemmSequential(
                     aD.AsSpan(aOffset, matrixSizeA),
                     bD.AsSpan(bOffset, matrixSizeB),
                     rD.AsSpan(resultOffset, matrixSizeResult),
@@ -21558,12 +21558,12 @@ public partial class CpuEngine : ITensorLevelEngine
                         for (int j = 0; j < headDim; j++)
                             kt[j * seqK + i] = kd[kOff + i * headDim + j];
 
-                    if (!Helpers.BlasProvider.TryGemmEx(seqQ, seqK, headDim,
+                    if (!BlasProvider.TryGemmEx(seqQ, seqK, headDim,
                         qd, qOff, headDim, false,
                         kt, 0, seqK, false,
                         scoresData, sOff, seqK))
                     {
-                        Engines.Simd.SimdGemm.DgemmSequential(
+                        SimdGemm.DgemmSequential(
                             qd.AsSpan(qOff, seqQ * headDim),
                             kt.AsSpan(0, headDim * seqK),
                             scoresData.AsSpan(sOff, seqQ * seqK),
@@ -21619,12 +21619,12 @@ public partial class CpuEngine : ITensorLevelEngine
                 int wOff = bh * seqQ * seqK;
                 int vOff = bh * seqK * d_v;
                 int oOff = bh * seqQ * d_v;
-                if (!Helpers.BlasProvider.TryGemmEx(seqQ, d_v, seqK,
+                if (!BlasProvider.TryGemmEx(seqQ, d_v, seqK,
                     weightsData, wOff, seqK, false,
                     vd, vOff, d_v, false,
                     outputData, oOff, d_v))
                 {
-                    Engines.Simd.SimdGemm.DgemmSequential(
+                    SimdGemm.DgemmSequential(
                         weightsData.AsSpan(wOff, seqQ * seqK),
                         vd.AsSpan(vOff, seqK * d_v),
                         outputData.AsSpan(oOff, seqQ * d_v),

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -33547,6 +33547,24 @@ public partial class CpuEngine : ITensorLevelEngine
             AutoTracer.RecordOp("MSELoss", scalarResult, eng => scalarResult);
             return scalarResult;
         }
+        // Double fast path: same fused single-pass diff² sum.
+        if (typeof(T) == typeof(double) && predictions.IsContiguous && targets.IsContiguous)
+        {
+            var pArr = (double[])(object)predictions.GetDataArray();
+            var tArr = (double[])(object)targets.GetDataArray();
+            int len = predictions.Length;
+            double sumSq = 0.0;
+            for (int i = 0; i < len; i++)
+            {
+                double d = pArr[i] - tArr[i];
+                sumSq += d * d;
+            }
+            double dMean = sumSq / len;
+            var scalarResult = new Tensor<T>(new[] { Unsafe.As<double, T>(ref dMean) }, [1]);
+            DifferentiableOps.RecordBinary("MSELoss", scalarResult, predictions, targets, BackwardFunctions<T>.MSELossBackward);
+            AutoTracer.RecordOp("MSELoss", scalarResult, eng => scalarResult);
+            return scalarResult;
+        }
 
         var numOps = MathHelper.GetNumericOperations<T>();
         T mean;
@@ -33596,6 +33614,21 @@ public partial class CpuEngine : ITensorLevelEngine
             AutoTracer.RecordOp("L1Loss", scalarResult, eng => scalarResult);
             return scalarResult;
         }
+        // Double fast path
+        if (typeof(T) == typeof(double) && predictions.IsContiguous && targets.IsContiguous)
+        {
+            var pArr = (double[])(object)predictions.GetDataArray();
+            var tArr = (double[])(object)targets.GetDataArray();
+            int len = predictions.Length;
+            double sumAbs = 0.0;
+            for (int i = 0; i < len; i++)
+                sumAbs += Math.Abs(pArr[i] - tArr[i]);
+            double dMean = sumAbs / len;
+            var scalarResult = new Tensor<T>(new[] { Unsafe.As<double, T>(ref dMean) }, [1]);
+            DifferentiableOps.RecordBinary("L1Loss", scalarResult, predictions, targets, BackwardFunctions<T>.L1LossBackward);
+            AutoTracer.RecordOp("L1Loss", scalarResult, eng => scalarResult);
+            return scalarResult;
+        }
 
         var numOps = MathHelper.GetNumericOperations<T>();
         T mean;
@@ -33631,18 +33664,62 @@ public partial class CpuEngine : ITensorLevelEngine
             }
         }
 
+        // Float fast path: fused Huber loss over contiguous arrays.
+        if (typeof(T) == typeof(float) && predictions.IsContiguous && targets.IsContiguous)
+        {
+            var pArr = (float[])(object)predictions.GetDataArray();
+            var tArr = (float[])(object)targets.GetDataArray();
+            int len = predictions.Length;
+            float deltaF = (float)delta;
+            float halfDelta = 0.5f * deltaF;
+            float sum = 0f;
+            for (int i = 0; i < len; i++)
+            {
+                float d = pArr[i] - tArr[i];
+                float ad = MathF.Abs(d);
+                sum += ad <= deltaF ? 0.5f * d * d : deltaF * (ad - halfDelta);
+            }
+            float fMean = sum / len;
+            var scalarResult = new Tensor<T>(new[] { Unsafe.As<float, T>(ref fMean) }, [1]);
+            DifferentiableOps.RecordBinary("HuberLoss", scalarResult, predictions, targets,
+                BackwardFunctions<T>.HuberLossBackward, savedState: new object[] { delta });
+            AutoTracer.RecordOp("HuberLoss", scalarResult, eng => scalarResult);
+            return scalarResult;
+        }
+        // Double fast path
+        if (typeof(T) == typeof(double) && predictions.IsContiguous && targets.IsContiguous)
+        {
+            var pArr = (double[])(object)predictions.GetDataArray();
+            var tArr = (double[])(object)targets.GetDataArray();
+            int len = predictions.Length;
+            double halfDelta = 0.5 * delta;
+            double sum = 0.0;
+            for (int i = 0; i < len; i++)
+            {
+                double d = pArr[i] - tArr[i];
+                double ad = Math.Abs(d);
+                sum += ad <= delta ? 0.5 * d * d : delta * (ad - halfDelta);
+            }
+            double dMean = sum / len;
+            var scalarResult = new Tensor<T>(new[] { Unsafe.As<double, T>(ref dMean) }, [1]);
+            DifferentiableOps.RecordBinary("HuberLoss", scalarResult, predictions, targets,
+                BackwardFunctions<T>.HuberLossBackward, savedState: new object[] { delta });
+            AutoTracer.RecordOp("HuberLoss", scalarResult, eng => scalarResult);
+            return scalarResult;
+        }
+
         var numOps = MathHelper.GetNumericOperations<T>();
         Tensor<T> diff;
         using (new NoGradScope<T>()) { diff = TensorSubtract(predictions, targets); }
-        T sum = numOps.Zero;
+        T sumGeneric = numOps.Zero;
         for (int i = 0; i < diff.Length; i++)
         {
             double d = numOps.ToDouble(diff[i]);
-            sum = numOps.Add(sum, Math.Abs(d) <= delta
+            sumGeneric = numOps.Add(sumGeneric, Math.Abs(d) <= delta
                 ? numOps.FromDouble(0.5 * d * d)
                 : numOps.FromDouble(delta * (Math.Abs(d) - 0.5 * delta)));
         }
-        T mean = numOps.Divide(sum, numOps.FromDouble(predictions.Length));
+        T mean = numOps.Divide(sumGeneric, numOps.FromDouble(predictions.Length));
         var result = new Tensor<T>(new[] { mean }, [1]);
         DifferentiableOps.RecordBinary("HuberLoss", result, predictions, targets,
             BackwardFunctions<T>.HuberLossBackward, savedState: new object[] { delta });
@@ -33864,6 +33941,18 @@ public partial class CpuEngine : ITensorLevelEngine
                 SimdKernels.SELUUnsafe((float*)pinSrc.Pointer, (float*)pinDst.Pointer, tensor.Length);
             }
         }
+        else if (typeof(T) == typeof(double))
+        {
+            const double alpha = 1.6732632423543772;
+            const double scale = 1.0507009873554805;
+            var dSrc = (double[])(object)tensor.GetDataArray();
+            var dDst = (double[])(object)result.GetDataArray();
+            for (int i = 0; i < tensor.Length; i++)
+            {
+                double x = dSrc[i];
+                dDst[i] = x > 0 ? scale * x : scale * alpha * (Math.Exp(x) - 1);
+            }
+        }
         else
         {
             var numOps = MathHelper.GetNumericOperations<T>();
@@ -33917,6 +34006,16 @@ public partial class CpuEngine : ITensorLevelEngine
             { var c = tensor; AutoTracer.RecordOp("HardSigmoid", result, eng => ((CpuEngine)eng).TensorHardSigmoid(c)); }
             return result;
         }
+        if (typeof(T) == typeof(double))
+        {
+            var dSrc = (double[])(object)tensor.GetDataArray();
+            var dDst = (double[])(object)result.GetDataArray();
+            for (int i = 0; i < tensor.Length; i++)
+                dDst[i] = Math.Max(0.0, Math.Min(1.0, dSrc[i] / 6.0 + 0.5));
+            DifferentiableOps.RecordUnary("HardSigmoid", result, tensorOrig, BackwardFunctions<T>.HardSigmoidBackward);
+            { var c = tensor; AutoTracer.RecordOp("HardSigmoid", result, eng => ((CpuEngine)eng).TensorHardSigmoid(c)); }
+            return result;
+        }
         var numOps = MathHelper.GetNumericOperations<T>();
         for (int i = 0; i < tensor.Length; i++)
         {
@@ -33956,6 +34055,13 @@ public partial class CpuEngine : ITensorLevelEngine
             var fDst = (float[])(object)result.GetDataArray();
             for (int i = 0; i < length; i++)
                 fDst[i] = MathF.Max(0f, MathF.Min(6f, fSrc[i]));
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            var dSrc = (double[])(object)tensor.GetDataArray();
+            var dDst = (double[])(object)result.GetDataArray();
+            for (int i = 0; i < length; i++)
+                dDst[i] = Math.Max(0.0, Math.Min(6.0, dSrc[i]));
         }
         else
         {
@@ -34018,6 +34124,25 @@ public partial class CpuEngine : ITensorLevelEngine
                 {
                     int channelIdx = channels == 1 ? 0 : (i / spatialSize) % channels;
                     fDst[i] = fSrc[i] >= 0f ? fSrc[i] : fAlpha[channelIdx] * fSrc[i];
+                }
+            }
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            var dSrc = (double[])(object)tensor.GetDataArray();
+            var dAlpha = (double[])(object)alpha.GetDataArray();
+            var dDst = (double[])(object)result.GetDataArray();
+            if (channels == tensor.Length)
+            {
+                for (int i = 0; i < dSrc.Length; i++)
+                    dDst[i] = dSrc[i] >= 0.0 ? dSrc[i] : dAlpha[i] * dSrc[i];
+            }
+            else
+            {
+                for (int i = 0; i < dSrc.Length; i++)
+                {
+                    int channelIdx = channels == 1 ? 0 : (i / spatialSize) % channels;
+                    dDst[i] = dSrc[i] >= 0.0 ? dSrc[i] : dAlpha[channelIdx] * dSrc[i];
                 }
             }
         }

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -5684,10 +5684,17 @@ public partial class CpuEngine : ITensorLevelEngine
         var numOps = MathHelper.GetNumericOperations<T>();
         var result = AutoTensorCache.RentOrAllocate<T>(tensor._shape);
 
-        // Fast SIMD path for common integer exponents (x^2 = x*x, x^3 = x*x*x)
+        // Fast SIMD path for common integer exponents (x^2 = x*x, x^3 = x*x*x).
+        // Use Unsafe.As<T, float> rather than (float)(object)exponent — the
+        // cast chain box/unboxes a value type on every TensorPower call (BERT
+        // hits this op per attention layer's loss term, so the allocation is
+        // measurable). The `exponent is not null` guard is also redundant here:
+        // we're inside `typeof(T) == typeof(float)`, so T is a value type and
+        // a non-nullable parameter cannot be null. The same fix applies to the
+        // double branch below.
         if (typeof(T) == typeof(float))
         {
-            float fExp = exponent is not null ? (float)(object)exponent : 0f;
+            float fExp = System.Runtime.CompilerServices.Unsafe.As<T, float>(ref exponent);
             if (fExp == 2.0f)
             {
                 // x^2 = x * x — use SIMD multiply
@@ -5696,15 +5703,20 @@ public partial class CpuEngine : ITensorLevelEngine
                 using var pinSrc = srcMem.Pin();
                 using var pinDst = dstMem.Pin();
                 Simd.SimdKernels.VectorMultiplyUnsafe((float*)pinSrc.Pointer, (float*)pinSrc.Pointer, (float*)pinDst.Pointer, tensor.Length);
-                if (exponent is not null)
-                    DifferentiableOps.RecordUnary("TensorPower", result, tensorOrig, BackwardFunctions<T>.PowerBackward, new object[] { exponent });
+                // T is value-type float in this branch — exponent cannot be null,
+                // so the prior `exponent is not null` gate was always true. Box
+                // the already-extracted float (not the generic T) so the
+                // compiler sees a concrete value type and the savedState slot
+                // gets the same float boxing the slow path would produce.
+                DifferentiableOps.RecordUnary("TensorPower", result, tensorOrig, BackwardFunctions<T>.PowerBackward, new object[] { (object)fExp });
                 { var c = tensor; AutoTracer.RecordOp("TensorPower", result, eng => eng.TensorPower(c, exponent)); }
                 return result;
             }
         }
         if (typeof(T) == typeof(double))
         {
-            double dExp = exponent is not null ? (double)(object)exponent : 0.0;
+            // Non-boxing conversion — see the float branch comment above.
+            double dExp = System.Runtime.CompilerServices.Unsafe.As<T, double>(ref exponent);
             if (dExp == 2.0)
             {
                 // x^2 = x * x — used by every L2 regularization / squared-error loss term.
@@ -5713,8 +5725,8 @@ public partial class CpuEngine : ITensorLevelEngine
                 using var pinSrc = srcMem.Pin();
                 using var pinDst = dstMem.Pin();
                 Simd.SimdKernels.VectorMultiplyUnsafe((double*)pinSrc.Pointer, (double*)pinSrc.Pointer, (double*)pinDst.Pointer, tensor.Length);
-                if (exponent is not null)
-                    DifferentiableOps.RecordUnary("TensorPower", result, tensorOrig, BackwardFunctions<T>.PowerBackward, new object[] { exponent });
+                // T is value-type double in this branch — same rationale as the float branch.
+                DifferentiableOps.RecordUnary("TensorPower", result, tensorOrig, BackwardFunctions<T>.PowerBackward, new object[] { (object)dExp });
                 { var c = tensor; AutoTracer.RecordOp("TensorPower", result, eng => eng.TensorPower(c, exponent)); }
                 return result;
             }

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -3890,6 +3890,15 @@ public partial class CpuEngine : ITensorLevelEngine
             ParallelComputeBound((float*)pinSrc.Pointer, (float*)pinDst.Pointer, input.Length, Simd.SimdKernels.ExpUnsafe);
             return;
         }
+        if (typeof(T) == typeof(double))
+        {
+            var srcMem = AsDoubleMemory(input.Data);
+            var dstMem = AsDoubleMemory(destination.Data);
+            using var pinSrc = srcMem.Pin();
+            using var pinDst = dstMem.Pin();
+            ParallelComputeBound((double*)pinSrc.Pointer, (double*)pinDst.Pointer, input.Length, Simd.SimdKernels.ExpUnsafe);
+            return;
+        }
         var numOps = MathHelper.GetNumericOperations<T>();
         numOps.Exp(input.AsSpan(), destination.AsWritableSpan());
     }
@@ -3907,6 +3916,15 @@ public partial class CpuEngine : ITensorLevelEngine
             using var pinSrc = srcMem.Pin();
             using var pinDst = dstMem.Pin();
             ParallelComputeBound((float*)pinSrc.Pointer, (float*)pinDst.Pointer, input.Length, Simd.SimdKernels.LogUnsafe);
+            return;
+        }
+        if (typeof(T) == typeof(double))
+        {
+            var srcMem = AsDoubleMemory(input.Data);
+            var dstMem = AsDoubleMemory(destination.Data);
+            using var pinSrc = srcMem.Pin();
+            using var pinDst = dstMem.Pin();
+            ParallelComputeBound((double*)pinSrc.Pointer, (double*)pinDst.Pointer, input.Length, Simd.SimdKernels.LogUnsafe);
             return;
         }
         var numOps = MathHelper.GetNumericOperations<T>();
@@ -3928,6 +3946,14 @@ public partial class CpuEngine : ITensorLevelEngine
             ParallelComputeBound((float*)pinSrc.Pointer, (float*)pinDst.Pointer, input.Length, SimdKernels.SqrtUnsafe);
             return;
         }
+        if (typeof(T) == typeof(double))
+        {
+            // SIMD double sqrt via Span overload (no unsafe ptr variant in SimdKernels).
+            var srcSpan = ((ReadOnlyMemory<double>)AsDoubleMemory(input.Data)).Span;
+            var dstSpan = AsDoubleMemory(destination.Data).Span;
+            SimdKernels.Sqrt(srcSpan, dstSpan);
+            return;
+        }
         var numOps = MathHelper.GetNumericOperations<T>();
         numOps.Sqrt(input.AsSpan(), destination.AsWritableSpan());
     }
@@ -3945,6 +3971,15 @@ public partial class CpuEngine : ITensorLevelEngine
             using var pinSrc = srcMem.Pin();
             using var pinDst = dstMem.Pin();
             ParallelComputeBound((float*)pinSrc.Pointer, (float*)pinDst.Pointer, input.Length, SimdKernels.AbsUnsafe);
+            return;
+        }
+        if (typeof(T) == typeof(double))
+        {
+            var srcMem = AsDoubleMemory(input.Data);
+            var dstMem = AsDoubleMemory(destination.Data);
+            using var pinSrc = srcMem.Pin();
+            using var pinDst = dstMem.Pin();
+            ParallelComputeBound((double*)pinSrc.Pointer, (double*)pinDst.Pointer, input.Length, SimdKernels.AbsUnsafe);
             return;
         }
         var numOps = MathHelper.GetNumericOperations<T>();
@@ -3971,6 +4006,13 @@ public partial class CpuEngine : ITensorLevelEngine
             }
             return;
         }
+        if (typeof(T) == typeof(double))
+        {
+            var srcSpan = ((ReadOnlyMemory<double>)AsDoubleMemory(input.Data)).Span;
+            var dstSpan = AsDoubleMemory(destination.Data).Span;
+            SimdKernels.Sin(srcSpan, dstSpan);
+            return;
+        }
         var numOps = MathHelper.GetNumericOperations<T>();
         numOps.Sin(input.AsSpan(), destination.AsWritableSpan());
     }
@@ -3993,6 +4035,13 @@ public partial class CpuEngine : ITensorLevelEngine
                 var fDst = (float[])(object)destination.GetDataArray();
                 for (int i = 0; i < fSrc.Length; i++) fDst[i] = MathF.Cos(fSrc[i]);
             }
+            return;
+        }
+        if (typeof(T) == typeof(double))
+        {
+            var srcSpan = ((ReadOnlyMemory<double>)AsDoubleMemory(input.Data)).Span;
+            var dstSpan = AsDoubleMemory(destination.Data).Span;
+            SimdKernels.Cos(srcSpan, dstSpan);
             return;
         }
         var numOps = MathHelper.GetNumericOperations<T>();
@@ -6210,6 +6259,17 @@ public partial class CpuEngine : ITensorLevelEngine
             return Unsafe.As<float, T>(ref result);
         }
 
+        // Double fast path — Span-based SIMD reduction. Single-call (no
+        // multi-chunk partials yet) but still 4× faster than the scalar
+        // IVectorizedOperations.Sum fallback on AVX2 hosts.
+        if (typeof(T) == typeof(double))
+        {
+            T[] arr = tensor.GetDataArray();
+            double[] dArr = Unsafe.As<T[], double[]>(ref arr);
+            double sum = SimdKernels.Sum(new ReadOnlySpan<double>(dArr, 0, tensor.Length));
+            return Unsafe.As<double, T>(ref sum);
+        }
+
         var numOps = MathHelper.GetNumericOperations<T>();
         // Use SIMD-optimized sum via IVectorizedOperations
         return numOps.Sum(tensor.AsSpan());
@@ -6468,6 +6528,18 @@ public partial class CpuEngine : ITensorLevelEngine
             }
         }
 
+        if (typeof(T) == typeof(double))
+        {
+            // Double Min via SimdKernels.Min(ReadOnlySpan<double>). Single-call
+            // SIMD reduction — no parallel-chunk wrapper yet (Min over double
+            // doesn't have an unsafe-ptr overload the float ParallelReduceFloat
+            // path uses), but still ~4× faster than the scalar numOps.Min
+            // fallback on AVX2 hosts.
+            var dArr = (double[])(object)tensor.GetDataArray();
+            double result = SimdKernels.Min(new ReadOnlySpan<double>(dArr, 0, tensor.Length));
+            return Unsafe.As<double, T>(ref result);
+        }
+
         var numOps = MathHelper.GetNumericOperations<T>();
         return numOps.Min(tensor.AsSpan());
     }
@@ -6524,6 +6596,15 @@ public partial class CpuEngine : ITensorLevelEngine
             float fSum = SimdKernels.SumUnsafe((float*)pin.Pointer, tensor.Length);
             float result = fSum / tensor.Length;
             return Unsafe.As<float, T>(ref result);
+        }
+
+        // Double fast path: SIMD Sum over Span, then divide
+        if (typeof(T) == typeof(double) && tensor.IsContiguous)
+        {
+            var dArr = (double[])(object)tensor.GetDataArray();
+            double dSum = SimdKernels.Sum(new ReadOnlySpan<double>(dArr, 0, tensor.Length));
+            double result = dSum / tensor.Length;
+            return Unsafe.As<double, T>(ref result);
         }
 
         // Generic path

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -2942,6 +2942,16 @@ public partial class CpuEngine : ITensorLevelEngine
             else
                 Simd.SimdKernels.VectorAddUnsafe(pA, pB, pR, length);
         }
+        else if (typeof(T) == typeof(double))
+        {
+            var aMem = AsDoubleMemory(a.Data);
+            var bMem = AsDoubleMemory(b.Data);
+            var rMem = AsDoubleMemory(destination.Data);
+            using var pinA = aMem.Pin();
+            using var pinB = bMem.Pin();
+            using var pinR = rMem.Pin();
+            Simd.SimdKernels.VectorAddUnsafe((double*)pinA.Pointer, (double*)pinB.Pointer, (double*)pinR.Pointer, length);
+        }
         else
         {
             var numOps = MathHelper.GetNumericOperations<T>();
@@ -3423,6 +3433,14 @@ public partial class CpuEngine : ITensorLevelEngine
             Simd.SimdKernels.VectorMultiplyUnsafe(pSrc, pDst, pDst, input.Length);
             return;
         }
+        if (typeof(T) == typeof(double))
+        {
+            // SIMD double Swish via Span overload.
+            var srcSpan = ((ReadOnlyMemory<double>)AsDoubleMemory(input.Data)).Span;
+            var dstSpan = AsDoubleMemory(destination.Data).Span;
+            Simd.SimdKernels.Swish(srcSpan, dstSpan);
+            return;
+        }
         var numOps = MathHelper.GetNumericOperations<T>();
         numOps.Sigmoid(input.AsSpan(), destination.AsWritableSpan());
         numOps.Multiply(input.AsSpan(), destination.AsSpan(), destination.AsWritableSpan());
@@ -3454,6 +3472,14 @@ public partial class CpuEngine : ITensorLevelEngine
             using var pinSrc = srcMem.Pin();
             using var pinDst = dstMem.Pin();
             Simd.SimdKernels.GELUUnsafe((float*)pinSrc.Pointer, (float*)pinDst.Pointer, input.Length);
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            var srcMem = AsDoubleMemory(input.Data);
+            var dstMem = AsDoubleMemory(destination.Data);
+            using var pinSrc = srcMem.Pin();
+            using var pinDst = dstMem.Pin();
+            Simd.SimdKernels.GELUUnsafe((double*)pinSrc.Pointer, (double*)pinDst.Pointer, input.Length);
         }
         else
         {
@@ -3489,6 +3515,14 @@ public partial class CpuEngine : ITensorLevelEngine
             using var pinDst = dstMem.Pin();
             Simd.SimdKernels.TanhUnsafe((float*)pinSrc.Pointer, (float*)pinDst.Pointer, length);
         }
+        else if (typeof(T) == typeof(double))
+        {
+            var srcMem = AsDoubleMemory(input.Data);
+            var dstMem = AsDoubleMemory(destination.Data);
+            using var pinSrc = srcMem.Pin();
+            using var pinDst = dstMem.Pin();
+            Simd.SimdKernels.TanhUnsafe((double*)pinSrc.Pointer, (double*)pinDst.Pointer, length);
+        }
         else
         {
             var numOps = MathHelper.GetNumericOperations<T>();
@@ -3518,6 +3552,16 @@ public partial class CpuEngine : ITensorLevelEngine
             using var pinSrc = srcMem.Pin();
             using var pinDst = dstMem.Pin();
             Simd.SimdKernels.MishUnsafe((float*)pinSrc.Pointer, (float*)pinDst.Pointer, input.Length);
+            return;
+        }
+        if (typeof(T) == typeof(double))
+        {
+            // SIMD double-precision Mish via the Span overload (no unsafe ptr
+            // variant exists for double Mish yet — same elementwise cost
+            // class either way).
+            var srcSpan = ((ReadOnlyMemory<double>)AsDoubleMemory(input.Data)).Span;
+            var dstSpan = AsDoubleMemory(destination.Data).Span;
+            Simd.SimdKernels.Mish(srcSpan, dstSpan);
             return;
         }
         var numOps = MathHelper.GetNumericOperations<T>();
@@ -3551,6 +3595,13 @@ public partial class CpuEngine : ITensorLevelEngine
             using var pinDst = dstMem.Pin();
             float alphaF = (float)MathHelper.GetNumericOperations<T>().ToDouble(alpha);
             unsafe { Simd.SimdKernels.LeakyReLUUnsafe((float*)pinSrc.Pointer, (float*)pinDst.Pointer, input.Length, alphaF); }
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            var srcSpan = ((ReadOnlyMemory<double>)AsDoubleMemory(input.Data)).Span;
+            var dstSpan = AsDoubleMemory(destination.Data).Span;
+            double alphaD = MathHelper.GetNumericOperations<T>().ToDouble(alpha);
+            Simd.SimdKernels.LeakyReLU(srcSpan, alphaD, dstSpan);
         }
         else
         {
@@ -3770,6 +3821,16 @@ public partial class CpuEngine : ITensorLevelEngine
             using var pinR = rMem.Pin();
             Simd.SimdKernels.VectorSubtractUnsafe((float*)pinA.Pointer, (float*)pinB.Pointer, (float*)pinR.Pointer, length);
         }
+        else if (typeof(T) == typeof(double))
+        {
+            var aMem = AsDoubleMemory(a.Data);
+            var bMem = AsDoubleMemory(b.Data);
+            var rMem = AsDoubleMemory(destination.Data);
+            using var pinA = aMem.Pin();
+            using var pinB = bMem.Pin();
+            using var pinR = rMem.Pin();
+            Simd.SimdKernels.VectorSubtractUnsafe((double*)pinA.Pointer, (double*)pinB.Pointer, (double*)pinR.Pointer, length);
+        }
         else
         {
             var numOps = MathHelper.GetNumericOperations<T>();
@@ -3796,6 +3857,16 @@ public partial class CpuEngine : ITensorLevelEngine
             using var pinB = bMem.Pin();
             using var pinR = rMem.Pin();
             Simd.SimdKernels.VectorDivideUnsafe((float*)pinA.Pointer, (float*)pinB.Pointer, (float*)pinR.Pointer, length);
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            var aMem = AsDoubleMemory(a.Data);
+            var bMem = AsDoubleMemory(b.Data);
+            var rMem = AsDoubleMemory(destination.Data);
+            using var pinA = aMem.Pin();
+            using var pinB = bMem.Pin();
+            using var pinR = rMem.Pin();
+            Simd.SimdKernels.VectorDivideUnsafe((double*)pinA.Pointer, (double*)pinB.Pointer, (double*)pinR.Pointer, length);
         }
         else
         {
@@ -4346,6 +4417,16 @@ public partial class CpuEngine : ITensorLevelEngine
             using var pinB = bMem.Pin();
             using var pinR = rMem.Pin();
             Simd.SimdKernels.VectorMultiplyUnsafe((float*)pinA.Pointer, (float*)pinB.Pointer, (float*)pinR.Pointer, length);
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            var aMem = AsDoubleMemory(a.Data);
+            var bMem = AsDoubleMemory(b.Data);
+            var rMem = AsDoubleMemory(destination.Data);
+            using var pinA = aMem.Pin();
+            using var pinB = bMem.Pin();
+            using var pinR = rMem.Pin();
+            Simd.SimdKernels.VectorMultiplyUnsafe((double*)pinA.Pointer, (double*)pinB.Pointer, (double*)pinR.Pointer, length);
         }
         else
         {
@@ -8569,6 +8650,36 @@ public partial class CpuEngine : ITensorLevelEngine
             return;
         }
 
+        // Double fast-path — the SIMD kernel exists, the dispatch didn't.
+        if (typeof(T) == typeof(double))
+        {
+            var mem = AsDoubleMemory(tensor.Data);
+            using var pin = mem.Pin();
+            double* p = (double*)pin.Pointer;
+
+            int sigChunks = Math.Min(CpuParallelSettings.MaxDegreeOfParallelism, Math.Max(1, length / 250_000));
+            if (sigChunks >= 2)
+            {
+                int chunkSize = (length + sigChunks - 1) / sigChunks;
+                chunkSize = (chunkSize + 31) & ~31;
+
+                CpuParallelSettings.ParallelForOrSerial(0, sigChunks, length, chunk =>
+                {
+                    int start = chunk * chunkSize;
+                    int count = Math.Min(chunkSize, length - start);
+                    if (count > 0)
+                    {
+                        SimdKernels.SigmoidUnsafe(p + start, p + start, count);
+                    }
+                });
+            }
+            else
+            {
+                SimdKernels.SigmoidUnsafe(p, p, length);
+            }
+            return;
+        }
+
         var numOps = MathHelper.GetNumericOperations<T>();
         numOps.Sigmoid(tensor.AsSpan(), tensor.AsWritableSpan());
     }
@@ -8596,6 +8707,14 @@ public partial class CpuEngine : ITensorLevelEngine
             using var pinSrc = srcMem.Pin();
             using var pinDst = dstMem.Pin();
             Simd.SimdKernels.SigmoidUnsafe((float*)pinSrc.Pointer, (float*)pinDst.Pointer, length);
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            var srcMem = AsDoubleMemory(input.Data);
+            var dstMem = AsDoubleMemory(destination.Data);
+            using var pinSrc = srcMem.Pin();
+            using var pinDst = dstMem.Pin();
+            Simd.SimdKernels.SigmoidUnsafe((double*)pinSrc.Pointer, (double*)pinDst.Pointer, length);
         }
         else
         {
@@ -8788,6 +8907,20 @@ public partial class CpuEngine : ITensorLevelEngine
             return;
         }
 
+        // Symmetric fast path for double — same SimdKernels covers both
+        // element types but the dispatching in CpuEngine wasn't routing
+        // doubles to it. Closes the float-fast / double-slow gap on the
+        // hottest activation (every Conv/Dense forward pass calls this).
+        if (typeof(T) == typeof(double))
+        {
+            var mem = AsDoubleMemory(tensor.Data);
+            using var pin = mem.Pin();
+            double* p = (double*)pin.Pointer;
+
+            SimdKernels.ReLUUnsafe(p, p, length);
+            return;
+        }
+
         var numOps = MathHelper.GetNumericOperations<T>();
         numOps.ReLU(tensor.AsSpan(), tensor.AsWritableSpan());
     }
@@ -8820,6 +8953,16 @@ public partial class CpuEngine : ITensorLevelEngine
                 JitUnaryDispatch(pSrc, pDst, length);
             else
                 Simd.SimdKernels.ReLUUnsafe(pSrc, pDst, length);
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            var srcMem = AsDoubleMemory(input.Data);
+            var dstMem = AsDoubleMemory(destination.Data);
+            using var pinSrc = srcMem.Pin();
+            using var pinDst = dstMem.Pin();
+            double* pSrc = (double*)pinSrc.Pointer;
+            double* pDst = (double*)pinDst.Pointer;
+            Simd.SimdKernels.ReLUUnsafe(pSrc, pDst, length);
         }
         else
         {
@@ -9127,6 +9270,13 @@ public partial class CpuEngine : ITensorLevelEngine
                 using var pinDst = dstMem.Pin();
                 SimdKernels.ELUUnsafe((float*)pinSrc.Pointer, (float*)pinDst.Pointer, tensor.Length, (float)alpha);
             }
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            // SIMD double ELU via the Span overload (no double unsafe-ptr variant in SimdKernels).
+            var srcSpan = ((ReadOnlyMemory<double>)AsDoubleMemory(tensor.Data)).Span;
+            var dstSpan = AsDoubleMemory(result.Data).Span;
+            SimdKernels.ELU(srcSpan, alpha, dstSpan);
         }
         else
         {

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -25043,6 +25043,28 @@ public partial class CpuEngine : ITensorLevelEngine
             else for (int bc = 0; bc < totalBC; bc++) kernel(bc);
             return;
         }
+        if (typeof(T) == typeof(double)
+            && input.GetDataArray() is double[] inArrD
+            && output.GetDataArray() is double[] outArrD)
+        {
+            int totalBC = batch * channels;
+            int iH = inputHeight, iW = inputWidth, oH = height, oW = width;
+            int t = top, l = left;
+            Action<int> kernel = bc =>
+            {
+                int inBase = bc * iH * iW + t * iW + l;
+                int outBase = bc * oH * oW;
+                for (int oh = 0; oh < oH; oh++)
+                {
+                    Buffer.BlockCopy(inArrD, (inBase + oh * iW) * sizeof(double),
+                                     outArrD, (outBase + oh * oW) * sizeof(double),
+                                     oW * sizeof(double));
+                }
+            };
+            if (totalBC > 8) Parallel.For(0, totalBC, kernel);
+            else for (int bc = 0; bc < totalBC; bc++) kernel(bc);
+            return;
+        }
 
         var inputData = input.GetFlattenedData();
         var outputData = output.GetDataArray();
@@ -25193,6 +25215,36 @@ public partial class CpuEngine : ITensorLevelEngine
                     Buffer.BlockCopy(inArr, (inBase + ih * w) * sizeof(float),
                                      outArr, (outBase + ih * nW) * sizeof(float),
                                      w * sizeof(float));
+                }
+            };
+            if (batchSize > 4) Parallel.For(0, batchSize, kernel);
+            else for (int b = 0; b < batchSize; b++) kernel(b);
+            return;
+        }
+        if (typeof(T) == typeof(double)
+            && input.GetDataArray() is double[] inArrD
+            && output.GetDataArray() is double[] outArrD)
+        {
+            double padD = padValue is double dv ? dv : 0.0;
+            if (padD == 0.0)
+            {
+                Array.Clear(outArrD, 0, outArrD.Length);
+            }
+            else
+            {
+                outArrD.AsSpan().Fill(padD);
+            }
+            int h = height, w = width, nH = newHeight, nW = newWidth;
+            int pt = padTop, pl = padLeft;
+            Action<int> kernel = b =>
+            {
+                int inBase = b * h * w;
+                int outBase = b * nH * nW + pt * nW + pl;
+                for (int ih = 0; ih < h; ih++)
+                {
+                    Buffer.BlockCopy(inArrD, (inBase + ih * w) * sizeof(double),
+                                     outArrD, (outBase + ih * nW) * sizeof(double),
+                                     w * sizeof(double));
                 }
             };
             if (batchSize > 4) Parallel.For(0, batchSize, kernel);
@@ -25445,11 +25497,70 @@ public partial class CpuEngine : ITensorLevelEngine
             }
             return Unsafe.As<float, T>(ref result);
         }
+
+        if (typeof(T) == typeof(double))
+        {
+            T[] arr = tensor.GetFlattenedData();
+            double[] dArr = Unsafe.As<T[], double[]>(ref arr);
+            int length = tensor.Length;
+            double result;
+            fixed (double* ptr = dArr)
+            {
+                result = SumOfSquaresUnsafeDouble(ptr, length);
+            }
+            return Unsafe.As<double, T>(ref result);
+        }
 #endif
 
         var numOps = MathHelper.GetNumericOperations<T>();
         return numOps.Dot(tensor.AsSpan(), tensor.AsSpan());
     }
+
+#if NET5_0_OR_GREATER
+    /// <summary>
+    /// SIMD sum of squares (double): sum(x[i] * x[i]) with 4x unrolled FMA accumulation.
+    /// Hits L2-regularization terms on Adam/SGD weight decay for fp64 networks.
+    /// </summary>
+    private static unsafe double SumOfSquaresUnsafeDouble(double* data, int length)
+    {
+        int i = 0;
+        double result = 0.0;
+
+        if (System.Runtime.Intrinsics.X86.Fma.IsSupported && length >= 16)
+        {
+            var vsum0 = System.Runtime.Intrinsics.Vector256<double>.Zero;
+            var vsum1 = vsum0; var vsum2 = vsum0; var vsum3 = vsum0;
+            int simdLen = length & ~15;
+            for (; i < simdLen; i += 16)
+            {
+                var v0 = System.Runtime.Intrinsics.X86.Avx.LoadVector256(data + i);
+                var v1 = System.Runtime.Intrinsics.X86.Avx.LoadVector256(data + i + 4);
+                var v2 = System.Runtime.Intrinsics.X86.Avx.LoadVector256(data + i + 8);
+                var v3 = System.Runtime.Intrinsics.X86.Avx.LoadVector256(data + i + 12);
+                vsum0 = System.Runtime.Intrinsics.X86.Fma.MultiplyAdd(v0, v0, vsum0);
+                vsum1 = System.Runtime.Intrinsics.X86.Fma.MultiplyAdd(v1, v1, vsum1);
+                vsum2 = System.Runtime.Intrinsics.X86.Fma.MultiplyAdd(v2, v2, vsum2);
+                vsum3 = System.Runtime.Intrinsics.X86.Fma.MultiplyAdd(v3, v3, vsum3);
+            }
+            vsum0 = System.Runtime.Intrinsics.X86.Avx.Add(
+                System.Runtime.Intrinsics.X86.Avx.Add(vsum0, vsum1),
+                System.Runtime.Intrinsics.X86.Avx.Add(vsum2, vsum3));
+            // Horizontal sum across 4 doubles
+            var hi = System.Runtime.Intrinsics.X86.Avx.ExtractVector128(vsum0, 1);
+            var lo = System.Runtime.Intrinsics.X86.Avx.ExtractVector128(vsum0, 0);
+            var s128 = System.Runtime.Intrinsics.X86.Sse2.Add(lo, hi);
+            var shuf = System.Runtime.Intrinsics.X86.Sse2.Shuffle(s128, s128, 0b_01_00_11_10);
+            s128 = System.Runtime.Intrinsics.X86.Sse2.Add(s128, shuf);
+            double tmp;
+            System.Runtime.Intrinsics.X86.Sse2.StoreScalar(&tmp, s128);
+            result = tmp;
+        }
+
+        for (; i < length; i++)
+            result += data[i] * data[i];
+        return result;
+    }
+#endif
 
 #if NET5_0_OR_GREATER
     /// <summary>
@@ -33841,6 +33952,49 @@ public partial class CpuEngine : ITensorLevelEngine
                     (eng, output) => { var r = eng.TensorBCEWithLogitsLoss(capturedLogits, capturedTargets); r.AsSpan().CopyTo(output.AsWritableSpan()); },
                     BackwardFunctions<T>.BCEWithLogitsLossBackward);
             }
+        }
+
+        // Float fast path: fused stable BCE.
+        if (typeof(T) == typeof(float) && logits.IsContiguous && targets.IsContiguous)
+        {
+            var lArr = (float[])(object)logits.GetDataArray();
+            var tArr = (float[])(object)targets.GetDataArray();
+            int len = logits.Length;
+            float sumF = 0f;
+            for (int i = 0; i < len; i++)
+            {
+                float x = lArr[i];
+                float ti = tArr[i];
+                float loss = MathF.Max(x, 0f) - x * ti + MathF.Log(1f + MathF.Exp(-MathF.Abs(x)));
+                sumF += loss;
+            }
+            float meanF = sumF / len;
+            var scalarResultF = new Tensor<T>(new[] { Unsafe.As<float, T>(ref meanF) }, [1]);
+            DifferentiableOps.RecordBinary("BCEWithLogitsLoss", scalarResultF, logits, targets,
+                BackwardFunctions<T>.BCEWithLogitsLossBackward);
+            AutoTracer.RecordOp("BCEWithLogitsLoss", scalarResultF, eng => scalarResultF);
+            return scalarResultF;
+        }
+        // Double fast path: same numerically stable form, inline arithmetic.
+        if (typeof(T) == typeof(double) && logits.IsContiguous && targets.IsContiguous)
+        {
+            var lArr = (double[])(object)logits.GetDataArray();
+            var tArr = (double[])(object)targets.GetDataArray();
+            int len = logits.Length;
+            double sumD = 0.0;
+            for (int i = 0; i < len; i++)
+            {
+                double x = lArr[i];
+                double ti = tArr[i];
+                double loss = Math.Max(x, 0.0) - x * ti + Math.Log(1.0 + Math.Exp(-Math.Abs(x)));
+                sumD += loss;
+            }
+            double meanD = sumD / len;
+            var scalarResultD = new Tensor<T>(new[] { Unsafe.As<double, T>(ref meanD) }, [1]);
+            DifferentiableOps.RecordBinary("BCEWithLogitsLoss", scalarResultD, logits, targets,
+                BackwardFunctions<T>.BCEWithLogitsLossBackward);
+            AutoTracer.RecordOp("BCEWithLogitsLoss", scalarResultD, eng => scalarResultD);
+            return scalarResultD;
         }
 
         var numOps = MathHelper.GetNumericOperations<T>();

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -455,6 +455,14 @@ public partial class CpuEngine : ITensorLevelEngine
             return Unsafe.As<float, T>(ref result);
         }
 
+        if (typeof(T) == typeof(double))
+        {
+            T[] arr = vector.GetDataArray();
+            double[] dArr = Unsafe.As<T[], double[]>(ref arr);
+            double result = SimdKernels.Sum(new ReadOnlySpan<double>(dArr, 0, vector.Length)) / vector.Length;
+            return Unsafe.As<double, T>(ref result);
+        }
+
         var numOps = MathHelper.GetNumericOperations<T>();
         T sum = Sum(vector);
         T length = numOps.FromDouble(vector.Length);
@@ -1806,6 +1814,21 @@ public partial class CpuEngine : ITensorLevelEngine
                 }
             }
         }
+        else if (typeof(T) == typeof(double) && bArray.Length >= 8)
+        {
+            var bDouble = (double[])(object)bArray;
+            var aDouble = (double[])(object)aArray;
+
+            for (int i = 0; i < aDouble.Length; i++)
+            {
+                var rowData = new double[bDouble.Length];
+                Simd.SimdKernels.MultiplyScalar(bDouble.AsSpan(), aDouble[i], rowData.AsSpan());
+                for (int j = 0; j < bDouble.Length; j++)
+                {
+                    result[i, j] = (T)(object)rowData[j];
+                }
+            }
+        }
         else
         {
             // Fallback using NumOps
@@ -2338,18 +2361,54 @@ public partial class CpuEngine : ITensorLevelEngine
             return (Tensor<T>)(object)result;
         }
 
-        // Generic scalar fallback for non-float T. Pre-combine scale/bias, then FMA.
+        // Double primitive fast path: pre-combine scale/bias then FMA, no
+        // INumericOperations<T> virtual dispatch. ResNet50 / VGG16-BN train at
+        // double precision through this op on every conv block — used by every
+        // BN inference pass in vision networks.
+        if (typeof(T) == typeof(double))
+        {
+            int cc = x._shape[1], hh = x._shape[2], ww = x._shape[3], nn = x._shape[0];
+            int spatial = hh * ww;
+            var inSpanD = ((Tensor<double>)(object)x).AsSpan();
+            var gDataD = ((Tensor<double>)(object)gamma).AsSpan();
+            var bDataD = ((Tensor<double>)(object)beta).AsSpan();
+            var mDataD = ((Tensor<double>)(object)mean).AsSpan();
+            var vDataD = ((Tensor<double>)(object)variance).AsSpan();
+            var outTD = new Tensor<double>(x._shape) { Layout = x.Layout };
+            var outSpanD = outTD.AsWritableSpan();
+            var scaleArrD = new double[cc];
+            var biasArrD = new double[cc];
+            for (int c = 0; c < cc; c++)
+            {
+                double s = gDataD[c] / Math.Sqrt(vDataD[c] + epsilon);
+                scaleArrD[c] = s;
+                biasArrD[c] = bDataD[c] - s * mDataD[c];
+            }
+            for (int ni = 0; ni < nn; ni++)
+            {
+                for (int c = 0; c < cc; c++)
+                {
+                    int baseIdx = (ni * cc + c) * spatial;
+                    double s = scaleArrD[c], b2 = biasArrD[c];
+                    for (int sp = 0; sp < spatial; sp++)
+                        outSpanD[baseIdx + sp] = inSpanD[baseIdx + sp] * s + b2;
+                }
+            }
+            return (Tensor<T>)(object)outTD;
+        }
+
+        // Generic scalar fallback for non-primitive T. Pre-combine scale/bias, then FMA.
         var numOps = MathHelper.GetNumericOperations<T>();
         T eps = numOps.FromDouble(epsilon);
-        int cc = x._shape[1], hh = x._shape[2], ww = x._shape[3], nn = x._shape[0];
-        int spatial = hh * ww;
+        int ccG = x._shape[1], hhG = x._shape[2], wwG = x._shape[3], nnG = x._shape[0];
+        int spatialG = hhG * wwG;
         var gData = gamma.GetDataArray();
         var bData = beta.GetDataArray();
         var mData = mean.GetDataArray();
         var vData = variance.GetDataArray();
-        var scaleArr = new T[cc];
-        var biasArr = new T[cc];
-        for (int c = 0; c < cc; c++)
+        var scaleArr = new T[ccG];
+        var biasArr = new T[ccG];
+        for (int c = 0; c < ccG; c++)
         {
             T s = numOps.Divide(gData[c], numOps.Sqrt(numOps.Add(vData[c], eps)));
             scaleArr[c] = s;
@@ -2358,13 +2417,13 @@ public partial class CpuEngine : ITensorLevelEngine
         var outT = new Tensor<T>(x._shape) { Layout = x.Layout };
         var inSpan = x.AsSpan();
         var outSpan = outT.AsWritableSpan();
-        for (int ni = 0; ni < nn; ni++)
+        for (int ni = 0; ni < nnG; ni++)
         {
-            for (int c = 0; c < cc; c++)
+            for (int c = 0; c < ccG; c++)
             {
-                int baseIdx = (ni * cc + c) * spatial;
+                int baseIdx = (ni * ccG + c) * spatialG;
                 T s = scaleArr[c], b2 = biasArr[c];
-                for (int sp = 0; sp < spatial; sp++)
+                for (int sp = 0; sp < spatialG; sp++)
                     outSpan[baseIdx + sp] = numOps.Add(numOps.Multiply(inSpan[baseIdx + sp], s), b2);
             }
         }
@@ -2523,6 +2582,25 @@ public partial class CpuEngine : ITensorLevelEngine
                     { var ca = a; var cb = b; AutoTracer.RecordOp("BatchMatMul", result, eng => eng.BatchMatMul(ca, cb)); }
                     return result;
                 }
+            }
+
+            // Double in-house SIMD fallback: when BLAS isn't available (TryGemm
+            // returned false above) and inputs are contiguous, use SimdGemm.Dgemm
+            // (AVX2 Vector256<double> FMA tiling) instead of falling through to
+            // the generic scalar matmul. ~10× faster on AVX2 hosts than the
+            // generic loop for moderate-size shapes.
+            if (typeof(T) == typeof(double) && a.IsContiguous && b.IsContiguous)
+            {
+                var aArrD = a._storage.GetDataArray();
+                var bArrD = b._storage.GetDataArray();
+                var rArrD = result.GetDataArray();
+                var aSpanD = new ReadOnlySpan<double>((double[])(object)aArrD, a._storageOffset, m * k);
+                var bSpanD = new ReadOnlySpan<double>((double[])(object)bArrD, b._storageOffset, k * n);
+                var cSpanD = new Span<double>((double[])(object)rArrD, 0, m * n);
+                Simd.SimdGemm.Dgemm(aSpanD, bSpanD, cSpanD, m, k, n);
+                DifferentiableOps.RecordBinary("BatchMatMul", result, aOrig, bOrig, BackwardFunctions<T>.BatchMatMulBackward);
+                { var ca = a; var cb = b; AutoTracer.RecordOp("BatchMatMul", result, eng => eng.BatchMatMul(ca, cb)); }
+                return result;
             }
 
             // Generic fallback: stride-aware scalar matmul (raw storage for stride access)
@@ -3114,6 +3192,27 @@ public partial class CpuEngine : ITensorLevelEngine
                     int off = r * cols;
                     for (int c = 0; c < cols; c++)
                         rf[off + c] = af[off + c] - bf[c];
+                }
+                DifferentiableOps.RecordBinary("TensorBroadcastSubtract", res, aOrig, bOrig, BackwardFunctions<T>.BroadcastSubtractBackward);
+                { var ca = a; var cb = b; AutoTracer.RecordOp("TensorBroadcastSubtract", res, eng => eng.TensorBroadcastSubtract(ca, cb)); }
+                return res;
+            }
+        }
+        if (typeof(T) == typeof(double) && a.Rank == 2 && (b.Rank == 1 || (b.Rank == 2 && b._shape[0] == 1)))
+        {
+            int rows = a._shape[0], cols = a._shape[1];
+            int bCols = b.Rank == 1 ? b._shape[0] : b._shape[1];
+            if (cols == bCols)
+            {
+                var res = AutoTensorCache.RentOrAllocate<T>(a._shape);
+                var ad = (double[])(object)a.GetDataArray();
+                var bd = (double[])(object)b.GetDataArray();
+                var rd = (double[])(object)res.GetDataArray();
+                for (int r = 0; r < rows; r++)
+                {
+                    int off = r * cols;
+                    for (int c = 0; c < cols; c++)
+                        rd[off + c] = ad[off + c] - bd[c];
                 }
                 DifferentiableOps.RecordBinary("TensorBroadcastSubtract", res, aOrig, bOrig, BackwardFunctions<T>.BroadcastSubtractBackward);
                 { var ca = a; var cb = b; AutoTracer.RecordOp("TensorBroadcastSubtract", res, eng => eng.TensorBroadcastSubtract(ca, cb)); }
@@ -5602,6 +5701,23 @@ public partial class CpuEngine : ITensorLevelEngine
                 return result;
             }
         }
+        if (typeof(T) == typeof(double))
+        {
+            double dExp = exponent is not null ? (double)(object)exponent : 0.0;
+            if (dExp == 2.0)
+            {
+                // x^2 = x * x — used by every L2 regularization / squared-error loss term.
+                var srcMem = AsDoubleMemory(tensor.Data);
+                var dstMem = AsDoubleMemory(result.Data);
+                using var pinSrc = srcMem.Pin();
+                using var pinDst = dstMem.Pin();
+                Simd.SimdKernels.VectorMultiplyUnsafe((double*)pinSrc.Pointer, (double*)pinSrc.Pointer, (double*)pinDst.Pointer, tensor.Length);
+                if (exponent is not null)
+                    DifferentiableOps.RecordUnary("TensorPower", result, tensorOrig, BackwardFunctions<T>.PowerBackward, new object[] { exponent });
+                { var c = tensor; AutoTracer.RecordOp("TensorPower", result, eng => eng.TensorPower(c, exponent)); }
+                return result;
+            }
+        }
 
         var src = tensor.AsSpan();
         var dest = result.AsWritableSpan();
@@ -5665,6 +5781,17 @@ public partial class CpuEngine : ITensorLevelEngine
                 SimdKernels.FloorUnsafe((float*)pinSrc.Pointer, (float*)pinDst.Pointer, tensor.Length);
             }
         }
+        else if (typeof(T) == typeof(double))
+        {
+            unsafe
+            {
+                var srcMem = AsDoubleMemory(tensor.Data);
+                var dstMem = AsDoubleMemory(result.Data);
+                using var pinSrc = srcMem.Pin();
+                using var pinDst = dstMem.Pin();
+                SimdKernels.FloorUnsafe((double*)pinSrc.Pointer, (double*)pinDst.Pointer, tensor.Length);
+            }
+        }
         else
         {
             var numOps = MathHelper.GetNumericOperations<T>();
@@ -5698,6 +5825,17 @@ public partial class CpuEngine : ITensorLevelEngine
                 using var pinSrc = srcMem.Pin();
                 using var pinDst = dstMem.Pin();
                 SimdKernels.CeilingUnsafe((float*)pinSrc.Pointer, (float*)pinDst.Pointer, tensor.Length);
+            }
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            unsafe
+            {
+                var srcMem = AsDoubleMemory(tensor.Data);
+                var dstMem = AsDoubleMemory(result.Data);
+                using var pinSrc = srcMem.Pin();
+                using var pinDst = dstMem.Pin();
+                SimdKernels.CeilingUnsafe((double*)pinSrc.Pointer, (double*)pinDst.Pointer, tensor.Length);
             }
         }
         else
@@ -5734,6 +5872,17 @@ public partial class CpuEngine : ITensorLevelEngine
                 using var pinSrc = srcMem.Pin();
                 using var pinDst = dstMem.Pin();
                 SimdKernels.RoundUnsafe((float*)pinSrc.Pointer, (float*)pinDst.Pointer, tensor.Length);
+            }
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            unsafe
+            {
+                var srcMem = AsDoubleMemory(tensor.Data);
+                var dstMem = AsDoubleMemory(result.Data);
+                using var pinSrc = srcMem.Pin();
+                using var pinDst = dstMem.Pin();
+                SimdKernels.RoundUnsafe((double*)pinSrc.Pointer, (double*)pinDst.Pointer, tensor.Length);
             }
         }
         else

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 #if NET5_0_OR_GREATER
@@ -1795,39 +1796,43 @@ public partial class CpuEngine : ITensorLevelEngine
         var aArray = a.GetDataArray();
         var bArray = b.GetDataArray();
 
-        // Use SIMD-optimized TensorPrimitives for float type
+        // Use SIMD-optimized TensorPrimitives for float type. Single rented
+        // scratch buffer reused across rows — earlier passes allocated a
+        // fresh row[] per outer-loop iteration, which dominated runtime on
+        // large vectors and produced O(rows × cols) GC churn.
         if (typeof(T) == typeof(float) && bArray.Length >= 16)
         {
             var bFloat = (float[])(object)bArray;
             var aFloat = (float[])(object)aArray;
-
-            for (int i = 0; i < aFloat.Length; i++)
+            var rowData = ArrayPool<float>.Shared.Rent(bFloat.Length);
+            try
             {
-                var rowData = new float[bFloat.Length];
-                // SIMD vectorized: multiply vector b by scalar a[i]
-                Simd.SimdKernels.MultiplyScalar(bFloat.AsSpan(), aFloat[i], rowData.AsSpan());
-
-                // Copy result to matrix
-                for (int j = 0; j < bFloat.Length; j++)
+                var rowSpan = rowData.AsSpan(0, bFloat.Length);
+                for (int i = 0; i < aFloat.Length; i++)
                 {
-                    result[i, j] = (T)(object)rowData[j];
+                    SimdKernels.MultiplyScalar(bFloat.AsSpan(), aFloat[i], rowSpan);
+                    for (int j = 0; j < bFloat.Length; j++)
+                        result[i, j] = (T)(object)rowData[j];
                 }
             }
+            finally { ArrayPool<float>.Shared.Return(rowData, clearArray: false); }
         }
         else if (typeof(T) == typeof(double) && bArray.Length >= 8)
         {
             var bDouble = (double[])(object)bArray;
             var aDouble = (double[])(object)aArray;
-
-            for (int i = 0; i < aDouble.Length; i++)
+            var rowData = ArrayPool<double>.Shared.Rent(bDouble.Length);
+            try
             {
-                var rowData = new double[bDouble.Length];
-                Simd.SimdKernels.MultiplyScalar(bDouble.AsSpan(), aDouble[i], rowData.AsSpan());
-                for (int j = 0; j < bDouble.Length; j++)
+                var rowSpan = rowData.AsSpan(0, bDouble.Length);
+                for (int i = 0; i < aDouble.Length; i++)
                 {
-                    result[i, j] = (T)(object)rowData[j];
+                    SimdKernels.MultiplyScalar(bDouble.AsSpan(), aDouble[i], rowSpan);
+                    for (int j = 0; j < bDouble.Length; j++)
+                        result[i, j] = (T)(object)rowData[j];
                 }
             }
+            finally { ArrayPool<double>.Shared.Return(rowData, clearArray: false); }
         }
         else
         {
@@ -3891,7 +3896,6 @@ public partial class CpuEngine : ITensorLevelEngine
                 double* pOut = (double*)pinOut.Pointer;
                 int axisSz = axisSize;
                 int outerSz = outerSize;
-                bool useParallel = outerSz >= 4 && (long)outerSz * axisSz >= 32768;
                 Action<int> rowKernel = row =>
                 {
                     double* rIn = pIn + row * axisSz;
@@ -3909,14 +3913,11 @@ public partial class CpuEngine : ITensorLevelEngine
                     double inv = 1.0 / sum;
                     for (int i = 0; i < axisSz; i++) rOut[i] *= inv;
                 };
-                if (useParallel)
-                {
-                    Parallel.For(0, outerSz, rowKernel);
-                }
-                else
-                {
-                    for (int row = 0; row < outerSz; row++) rowKernel(row);
-                }
+                // Route through CpuParallelSettings so the loop respects the
+                // configured MaxDegreeOfParallelism and falls back to serial
+                // for small inputs (skipping ThreadPool dispatch overhead).
+                // The totalWork estimate is outerSz*axisSz fmac operations.
+                CpuParallelSettings.ParallelForOrSerial(0, outerSz, (long)outerSz * axisSz, rowKernel);
             }
             return;
         }
@@ -7715,8 +7716,7 @@ public partial class CpuEngine : ITensorLevelEngine
                         outArrD[outputBase + oh * oW + ow] = count > 0 ? sum / count : 0.0;
                     }
             };
-            if (h * w >= 1024) Parallel.For(0, bc, poolKernel);
-            else for (int idx = 0; idx < bc; idx++) poolKernel(idx);
+            CpuParallelSettings.ParallelForOrSerial(0, bc, (long)bc * h * w, poolKernel);
             return;
         }
 
@@ -25420,8 +25420,7 @@ public partial class CpuEngine : ITensorLevelEngine
                                      oW * sizeof(float));
                 }
             };
-            if (totalBC > 8) Parallel.For(0, totalBC, kernel);
-            else for (int bc = 0; bc < totalBC; bc++) kernel(bc);
+            CpuParallelSettings.ParallelForOrSerial(0, totalBC, (long)totalBC * oH * oW, kernel);
             return;
         }
         if (typeof(T) == typeof(double)
@@ -25442,8 +25441,7 @@ public partial class CpuEngine : ITensorLevelEngine
                                      oW * sizeof(double));
                 }
             };
-            if (totalBC > 8) Parallel.For(0, totalBC, kernel);
-            else for (int bc = 0; bc < totalBC; bc++) kernel(bc);
+            CpuParallelSettings.ParallelForOrSerial(0, totalBC, (long)totalBC * oH * oW, kernel);
             return;
         }
 
@@ -25598,8 +25596,7 @@ public partial class CpuEngine : ITensorLevelEngine
                                      w * sizeof(float));
                 }
             };
-            if (batchSize > 4) Parallel.For(0, batchSize, kernel);
-            else for (int b = 0; b < batchSize; b++) kernel(b);
+            CpuParallelSettings.ParallelForOrSerial(0, batchSize, (long)batchSize * h * w, kernel);
             return;
         }
         if (typeof(T) == typeof(double)
@@ -25628,8 +25625,7 @@ public partial class CpuEngine : ITensorLevelEngine
                                      w * sizeof(double));
                 }
             };
-            if (batchSize > 4) Parallel.For(0, batchSize, kernel);
-            else for (int b = 0; b < batchSize; b++) kernel(b);
+            CpuParallelSettings.ParallelForOrSerial(0, batchSize, (long)batchSize * h * w, kernel);
             return;
         }
 
@@ -29161,7 +29157,6 @@ public partial class CpuEngine : ITensorLevelEngine
                 double* pOut = (double*)pinOut.Pointer;
                 int axisSz = axisSize;
                 int outerSz = outerSize;
-                bool useParallel = outerSz >= 4 && (long)outerSz * axisSz >= 32768;
                 Action<int> rowKernel = row =>
                 {
                     double* rIn = pIn + row * axisSz;
@@ -29173,8 +29168,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     double logSumExp = Math.Log(sumExp);
                     for (int i = 0; i < axisSz; i++) rOut[i] = (rIn[i] - max) - logSumExp;
                 };
-                if (useParallel) Parallel.For(0, outerSz, rowKernel);
-                else for (int row = 0; row < outerSz; row++) rowKernel(row);
+                CpuParallelSettings.ParallelForOrSerial(0, outerSz, (long)outerSz * axisSz, rowKernel);
             }
             DifferentiableOps.RecordUnary("LogSoftmax", resultD, tensor,
                 BackwardFunctions<T>.LogSoftmaxBackward);

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -27187,7 +27187,7 @@ public partial class CpuEngine : ITensorLevelEngine
             var dst = (float[])(object)result.GetDataArray();
             Simd.ScanKernels.PrefixSumFloat(src, dst);
             DifferentiableOps.RecordUnary("TensorCumSum", result, tensorOrig, BackwardFunctions<T>.CumSumBackward, new object[] { axis });
-            { var c = tensorOrig; var ca = axis; AutoTracer.RecordOp("TensorCumSum", result, eng => eng.TensorCumSum(c, ca)); }
+            if (AutoTracer.ShouldRecord) { var c = tensorOrig; var ca = axis; AutoTracer.RecordOp("TensorCumSum", result, eng => eng.TensorCumSum(c, ca)); }
             return result;
         }
 
@@ -27207,7 +27207,7 @@ public partial class CpuEngine : ITensorLevelEngine
             // Record the actual op against captured inputs so AutoTracer's
             // compiled-replay recomputes the cumulative sum for the live
             // tensor instead of baking the scalar we just produced.
-            { var c = tensorOrig; var ca = axis; AutoTracer.RecordOp("TensorCumSum", result, eng => eng.TensorCumSum(c, ca)); }
+            if (AutoTracer.ShouldRecord) { var c = tensorOrig; var ca = axis; AutoTracer.RecordOp("TensorCumSum", result, eng => eng.TensorCumSum(c, ca)); }
             return result;
         }
 
@@ -27223,7 +27223,7 @@ public partial class CpuEngine : ITensorLevelEngine
             int len = tensor.Length;
             for (int i = 0; i < len; i++) { accD += srcD[i]; dstD[i] = accD; }
             DifferentiableOps.RecordUnary("TensorCumSum", result, tensorOrig, BackwardFunctions<T>.CumSumBackward, new object[] { axis });
-            { var c = tensorOrig; var ca = axis; AutoTracer.RecordOp("TensorCumSum", result, eng => eng.TensorCumSum(c, ca)); }
+            if (AutoTracer.ShouldRecord) { var c = tensorOrig; var ca = axis; AutoTracer.RecordOp("TensorCumSum", result, eng => eng.TensorCumSum(c, ca)); }
             return result;
         }
         if (typeof(T) == typeof(double) && innerSize == 1)
@@ -27237,7 +27237,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 for (int a = 0; a < axisSize; a++) { accD += srcD[start + a]; dstD[start + a] = accD; }
             }
             DifferentiableOps.RecordUnary("TensorCumSum", result, tensorOrig, BackwardFunctions<T>.CumSumBackward, new object[] { axis });
-            { var c = tensorOrig; var ca = axis; AutoTracer.RecordOp("TensorCumSum", result, eng => eng.TensorCumSum(c, ca)); }
+            if (AutoTracer.ShouldRecord) { var c = tensorOrig; var ca = axis; AutoTracer.RecordOp("TensorCumSum", result, eng => eng.TensorCumSum(c, ca)); }
             return result;
         }
 
@@ -27272,7 +27272,7 @@ public partial class CpuEngine : ITensorLevelEngine
         }
 
         DifferentiableOps.RecordUnary("TensorCumSum", result, tensorOrig, BackwardFunctions<T>.CumSumBackward, new object[] { axis });
-        { var c = tensorOrig; var ca = axis; AutoTracer.RecordOp("TensorCumSum", result, eng => eng.TensorCumSum(c, ca)); }
+        if (AutoTracer.ShouldRecord) { var c = tensorOrig; var ca = axis; AutoTracer.RecordOp("TensorCumSum", result, eng => eng.TensorCumSum(c, ca)); }
         return result;
     }
 
@@ -28215,7 +28215,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 // compiled-replay recomputes the norm for the live tensor
                 // instead of baking the result tensor we just produced as a
                 // constant in the graph.
-                { var c = tensor; var ca = normAxis; var ck = keepDims; AutoTracer.RecordOp("Norm", normResult, eng => eng.TensorNorm(c, ca, ck)); }
+                if (AutoTracer.ShouldRecord) { var c = tensor; var ca = normAxis; var ck = keepDims; AutoTracer.RecordOp("Norm", normResult, eng => eng.TensorNorm(c, ca, ck)); }
                 return normResult;
             }
             else if (normAxis == 0)
@@ -28238,7 +28238,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 // compiled-replay recomputes the norm for the live tensor
                 // instead of baking the result tensor we just produced as a
                 // constant in the graph.
-                { var c = tensor; var ca = normAxis; var ck = keepDims; AutoTracer.RecordOp("Norm", normResult, eng => eng.TensorNorm(c, ca, ck)); }
+                if (AutoTracer.ShouldRecord) { var c = tensor; var ca = normAxis; var ck = keepDims; AutoTracer.RecordOp("Norm", normResult, eng => eng.TensorNorm(c, ca, ck)); }
                 return normResult;
             }
         }
@@ -28268,7 +28268,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 // compiled-replay recomputes the norm for the live tensor
                 // instead of baking the result tensor we just produced as a
                 // constant in the graph.
-                { var c = tensor; var ca = normAxis; var ck = keepDims; AutoTracer.RecordOp("Norm", normResult, eng => eng.TensorNorm(c, ca, ck)); }
+                if (AutoTracer.ShouldRecord) { var c = tensor; var ca = normAxis; var ck = keepDims; AutoTracer.RecordOp("Norm", normResult, eng => eng.TensorNorm(c, ca, ck)); }
                 return normResult;
             }
             else if (normAxis == 0)
@@ -28290,7 +28290,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 // compiled-replay recomputes the norm for the live tensor
                 // instead of baking the result tensor we just produced as a
                 // constant in the graph.
-                { var c = tensor; var ca = normAxis; var ck = keepDims; AutoTracer.RecordOp("Norm", normResult, eng => eng.TensorNorm(c, ca, ck)); }
+                if (AutoTracer.ShouldRecord) { var c = tensor; var ca = normAxis; var ck = keepDims; AutoTracer.RecordOp("Norm", normResult, eng => eng.TensorNorm(c, ca, ck)); }
                 return normResult;
             }
         }
@@ -29158,7 +29158,7 @@ public partial class CpuEngine : ITensorLevelEngine
             }
             DifferentiableOps.RecordUnary("LogSoftmax", result, tensor,
                 BackwardFunctions<T>.LogSoftmaxBackward);
-            { var c = tensor; var ca = axis; AutoTracer.RecordOp("LogSoftmax", result, eng => eng.TensorLogSoftmax(c, ca)); }
+            if (AutoTracer.ShouldRecord) { var c = tensor; var ca = axis; AutoTracer.RecordOp("LogSoftmax", result, eng => eng.TensorLogSoftmax(c, ca)); }
             return result;
         }
         // Double primitive fast path for last-axis log-softmax. Inline 3-pass
@@ -29191,7 +29191,7 @@ public partial class CpuEngine : ITensorLevelEngine
             }
             DifferentiableOps.RecordUnary("LogSoftmax", resultD, tensor,
                 BackwardFunctions<T>.LogSoftmaxBackward);
-            { var c = tensor; var ca = axis; AutoTracer.RecordOp("LogSoftmax", resultD, eng => eng.TensorLogSoftmax(c, ca)); }
+            if (AutoTracer.ShouldRecord) { var c = tensor; var ca = axis; AutoTracer.RecordOp("LogSoftmax", resultD, eng => eng.TensorLogSoftmax(c, ca)); }
             return resultD;
         }
 
@@ -29236,7 +29236,7 @@ public partial class CpuEngine : ITensorLevelEngine
         var logSoftmaxResult = TensorAllocator.Rent<T>(tensor._shape, outputData);
         DifferentiableOps.RecordUnary("LogSoftmax", logSoftmaxResult, tensor,
             BackwardFunctions<T>.LogSoftmaxBackward);
-        { var c = tensor; var ca = axis; AutoTracer.RecordOp("LogSoftmax", logSoftmaxResult, eng => eng.TensorLogSoftmax(c, ca)); }
+        if (AutoTracer.ShouldRecord) { var c = tensor; var ca = axis; AutoTracer.RecordOp("LogSoftmax", logSoftmaxResult, eng => eng.TensorLogSoftmax(c, ca)); }
         return logSoftmaxResult;
     }
 
@@ -34297,7 +34297,7 @@ public partial class CpuEngine : ITensorLevelEngine
             float fMean = sumSq / len;
             var scalarResult = new Tensor<T>(new[] { Unsafe.As<float, T>(ref fMean) }, [1]);
             DifferentiableOps.RecordBinary("MSELoss", scalarResult, predictions, targets, BackwardFunctions<T>.MSELossBackward);
-            { var cp = predictions; var ct = targets; AutoTracer.RecordOp("MSELoss", scalarResult, eng => eng.TensorMSELoss(cp, ct)); }
+            if (AutoTracer.ShouldRecord) { var cp = predictions; var ct = targets; AutoTracer.RecordOp("MSELoss", scalarResult, eng => eng.TensorMSELoss(cp, ct)); }
             return scalarResult;
         }
         // Double fast path: same fused single-pass diff² sum.
@@ -34315,7 +34315,7 @@ public partial class CpuEngine : ITensorLevelEngine
             double dMean = sumSq / len;
             var scalarResult = new Tensor<T>(new[] { Unsafe.As<double, T>(ref dMean) }, [1]);
             DifferentiableOps.RecordBinary("MSELoss", scalarResult, predictions, targets, BackwardFunctions<T>.MSELossBackward);
-            { var cp = predictions; var ct = targets; AutoTracer.RecordOp("MSELoss", scalarResult, eng => eng.TensorMSELoss(cp, ct)); }
+            if (AutoTracer.ShouldRecord) { var cp = predictions; var ct = targets; AutoTracer.RecordOp("MSELoss", scalarResult, eng => eng.TensorMSELoss(cp, ct)); }
             return scalarResult;
         }
 
@@ -34330,7 +34330,7 @@ public partial class CpuEngine : ITensorLevelEngine
         }
         var result = new Tensor<T>(new[] { mean }, [1]);
         DifferentiableOps.RecordBinary("MSELoss", result, predictions, targets, BackwardFunctions<T>.MSELossBackward);
-        { var cp = predictions; var ct = targets; AutoTracer.RecordOp("MSELoss", result, eng => eng.TensorMSELoss(cp, ct)); }
+        if (AutoTracer.ShouldRecord) { var cp = predictions; var ct = targets; AutoTracer.RecordOp("MSELoss", result, eng => eng.TensorMSELoss(cp, ct)); }
         return result;
     }
 
@@ -34364,7 +34364,7 @@ public partial class CpuEngine : ITensorLevelEngine
             float fMean = sumAbs / len;
             var scalarResult = new Tensor<T>(new[] { Unsafe.As<float, T>(ref fMean) }, [1]);
             DifferentiableOps.RecordBinary("L1Loss", scalarResult, predictions, targets, BackwardFunctions<T>.L1LossBackward);
-            { var cp = predictions; var ct = targets; AutoTracer.RecordOp("L1Loss", scalarResult, eng => eng.TensorL1Loss(cp, ct)); }
+            if (AutoTracer.ShouldRecord) { var cp = predictions; var ct = targets; AutoTracer.RecordOp("L1Loss", scalarResult, eng => eng.TensorL1Loss(cp, ct)); }
             return scalarResult;
         }
         // Double fast path
@@ -34379,7 +34379,7 @@ public partial class CpuEngine : ITensorLevelEngine
             double dMean = sumAbs / len;
             var scalarResult = new Tensor<T>(new[] { Unsafe.As<double, T>(ref dMean) }, [1]);
             DifferentiableOps.RecordBinary("L1Loss", scalarResult, predictions, targets, BackwardFunctions<T>.L1LossBackward);
-            { var cp = predictions; var ct = targets; AutoTracer.RecordOp("L1Loss", scalarResult, eng => eng.TensorL1Loss(cp, ct)); }
+            if (AutoTracer.ShouldRecord) { var cp = predictions; var ct = targets; AutoTracer.RecordOp("L1Loss", scalarResult, eng => eng.TensorL1Loss(cp, ct)); }
             return scalarResult;
         }
 
@@ -34394,7 +34394,7 @@ public partial class CpuEngine : ITensorLevelEngine
         }
         var result = new Tensor<T>(new[] { mean }, [1]);
         DifferentiableOps.RecordBinary("L1Loss", result, predictions, targets, BackwardFunctions<T>.L1LossBackward);
-        { var cp = predictions; var ct = targets; AutoTracer.RecordOp("L1Loss", result, eng => eng.TensorL1Loss(cp, ct)); }
+        if (AutoTracer.ShouldRecord) { var cp = predictions; var ct = targets; AutoTracer.RecordOp("L1Loss", result, eng => eng.TensorL1Loss(cp, ct)); }
         return result;
     }
 
@@ -34436,7 +34436,7 @@ public partial class CpuEngine : ITensorLevelEngine
             var scalarResult = new Tensor<T>(new[] { Unsafe.As<float, T>(ref fMean) }, [1]);
             DifferentiableOps.RecordBinary("HuberLoss", scalarResult, predictions, targets,
                 BackwardFunctions<T>.HuberLossBackward, savedState: new object[] { delta });
-            { var cp = predictions; var ct = targets; var cd = delta; AutoTracer.RecordOp("HuberLoss", scalarResult, eng => eng.TensorHuberLoss(cp, ct, cd)); }
+            if (AutoTracer.ShouldRecord) { var cp = predictions; var ct = targets; var cd = delta; AutoTracer.RecordOp("HuberLoss", scalarResult, eng => eng.TensorHuberLoss(cp, ct, cd)); }
             return scalarResult;
         }
         // Double fast path
@@ -34457,7 +34457,7 @@ public partial class CpuEngine : ITensorLevelEngine
             var scalarResult = new Tensor<T>(new[] { Unsafe.As<double, T>(ref dMean) }, [1]);
             DifferentiableOps.RecordBinary("HuberLoss", scalarResult, predictions, targets,
                 BackwardFunctions<T>.HuberLossBackward, savedState: new object[] { delta });
-            { var cp = predictions; var ct = targets; var cd = delta; AutoTracer.RecordOp("HuberLoss", scalarResult, eng => eng.TensorHuberLoss(cp, ct, cd)); }
+            if (AutoTracer.ShouldRecord) { var cp = predictions; var ct = targets; var cd = delta; AutoTracer.RecordOp("HuberLoss", scalarResult, eng => eng.TensorHuberLoss(cp, ct, cd)); }
             return scalarResult;
         }
 
@@ -34476,7 +34476,7 @@ public partial class CpuEngine : ITensorLevelEngine
         var result = new Tensor<T>(new[] { mean }, [1]);
         DifferentiableOps.RecordBinary("HuberLoss", result, predictions, targets,
             BackwardFunctions<T>.HuberLossBackward, savedState: new object[] { delta });
-        { var cp = predictions; var ct = targets; var cd = delta; AutoTracer.RecordOp("HuberLoss", result, eng => eng.TensorHuberLoss(cp, ct, cd)); }
+        if (AutoTracer.ShouldRecord) { var cp = predictions; var ct = targets; var cd = delta; AutoTracer.RecordOp("HuberLoss", result, eng => eng.TensorHuberLoss(cp, ct, cd)); }
         return result;
     }
 
@@ -34516,7 +34516,7 @@ public partial class CpuEngine : ITensorLevelEngine
             var scalarResultF = new Tensor<T>(new[] { Unsafe.As<float, T>(ref meanF) }, [1]);
             DifferentiableOps.RecordBinary("BCEWithLogitsLoss", scalarResultF, logits, targets,
                 BackwardFunctions<T>.BCEWithLogitsLossBackward);
-            { var cl = logits; var ct = targets; AutoTracer.RecordOp("BCEWithLogitsLoss", scalarResultF, eng => eng.TensorBCEWithLogitsLoss(cl, ct)); }
+            if (AutoTracer.ShouldRecord) { var cl = logits; var ct = targets; AutoTracer.RecordOp("BCEWithLogitsLoss", scalarResultF, eng => eng.TensorBCEWithLogitsLoss(cl, ct)); }
             return scalarResultF;
         }
         // Double fast path: same numerically stable form, inline arithmetic.
@@ -34537,7 +34537,7 @@ public partial class CpuEngine : ITensorLevelEngine
             var scalarResultD = new Tensor<T>(new[] { Unsafe.As<double, T>(ref meanD) }, [1]);
             DifferentiableOps.RecordBinary("BCEWithLogitsLoss", scalarResultD, logits, targets,
                 BackwardFunctions<T>.BCEWithLogitsLossBackward);
-            { var cl = logits; var ct = targets; AutoTracer.RecordOp("BCEWithLogitsLoss", scalarResultD, eng => eng.TensorBCEWithLogitsLoss(cl, ct)); }
+            if (AutoTracer.ShouldRecord) { var cl = logits; var ct = targets; AutoTracer.RecordOp("BCEWithLogitsLoss", scalarResultD, eng => eng.TensorBCEWithLogitsLoss(cl, ct)); }
             return scalarResultD;
         }
 
@@ -34555,7 +34555,7 @@ public partial class CpuEngine : ITensorLevelEngine
         var result = new Tensor<T>(new[] { mean }, [1]);
         DifferentiableOps.RecordBinary("BCEWithLogitsLoss", result, logits, targets,
             BackwardFunctions<T>.BCEWithLogitsLossBackward);
-        { var cl = logits; var ct = targets; AutoTracer.RecordOp("BCEWithLogitsLoss", result, eng => eng.TensorBCEWithLogitsLoss(cl, ct)); }
+        if (AutoTracer.ShouldRecord) { var cl = logits; var ct = targets; AutoTracer.RecordOp("BCEWithLogitsLoss", result, eng => eng.TensorBCEWithLogitsLoss(cl, ct)); }
         return result;
     }
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -6303,6 +6303,19 @@ public partial class CpuEngine : ITensorLevelEngine
                 SimdKernels.VectorMaxUnsafe((float*)pinA.Pointer, (float*)pinB.Pointer, (float*)pinD.Pointer, a.Length);
             }
         }
+        else if (typeof(T) == typeof(double))
+        {
+            unsafe
+            {
+                var srcMemA = AsDoubleMemory(a.Data);
+                var srcMemB = AsDoubleMemory(b.Data);
+                var dstMem = AsDoubleMemory(result.Data);
+                using var pinA = srcMemA.Pin();
+                using var pinB = srcMemB.Pin();
+                using var pinD = dstMem.Pin();
+                SimdKernels.VectorMaxUnsafe((double*)pinA.Pointer, (double*)pinB.Pointer, (double*)pinD.Pointer, a.Length);
+            }
+        }
         else
         {
             var numOps = MathHelper.GetNumericOperations<T>();
@@ -6372,11 +6385,29 @@ public partial class CpuEngine : ITensorLevelEngine
 
         if (typeof(T) == typeof(float))
         {
-            var fA = (float[])(object)a.GetDataArray();
-            var fB = (float[])(object)b.GetDataArray();
-            var fD = (float[])(object)result.GetDataArray();
-            for (int i = 0; i < fA.Length; i++)
-                fD[i] = MathF.Min(fA[i], fB[i]);
+            unsafe
+            {
+                var srcMemA = AsFloatMemory(a.Data);
+                var srcMemB = AsFloatMemory(b.Data);
+                var dstMem = AsFloatMemory(result.Data);
+                using var pinA = srcMemA.Pin();
+                using var pinB = srcMemB.Pin();
+                using var pinD = dstMem.Pin();
+                SimdKernels.VectorMinUnsafe((float*)pinA.Pointer, (float*)pinB.Pointer, (float*)pinD.Pointer, a.Length);
+            }
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            unsafe
+            {
+                var srcMemA = AsDoubleMemory(a.Data);
+                var srcMemB = AsDoubleMemory(b.Data);
+                var dstMem = AsDoubleMemory(result.Data);
+                using var pinA = srcMemA.Pin();
+                using var pinB = srcMemB.Pin();
+                using var pinD = dstMem.Pin();
+                SimdKernels.VectorMinUnsafe((double*)pinA.Pointer, (double*)pinB.Pointer, (double*)pinD.Pointer, a.Length);
+            }
         }
         else
         {

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -19369,26 +19369,86 @@ public partial class CpuEngine : ITensorLevelEngine
         var rmsData = new T[batchSize];
         var outputData = new T[batchSize * featureSize];
 
-        CpuParallelSettings.ParallelForOrSerial(0, batchSize, outputData.Length, b =>
+        // Primitive fast paths: direct float/double arithmetic, no
+        // INumericOperations<T> virtual dispatch. Used by every LLaMA-style
+        // transformer block — gets called per-token per-layer per-step.
+        // The backward (RMSNormBackward) already had these primitive branches;
+        // forward stayed generic, paying ~20× the cost per element on AVX2
+        // hosts vs the cast-to-primitive variant.
+        if (typeof(T) == typeof(float))
         {
-            int offset = b * featureSize;
-            T featureSizeT = numOps.FromDouble(featureSize);
+            var fInput = (float[])(object)inputData;
+            var fGamma = (float[])(object)gammaData;
+            var fRms = (float[])(object)rmsData;
+            var fOutput = (float[])(object)outputData;
+            float fEps = (float)epsilon;
+            int fs = featureSize;
+            float invFs = 1f / fs;
 
-            // RMS
-            T sumSq = numOps.Zero;
-            for (int f = 0; f < featureSize; f++)
+            CpuParallelSettings.ParallelForOrSerial(0, batchSize, outputData.Length, b =>
             {
-                T val = inputData[offset + f];
-                sumSq = numOps.Add(sumSq, numOps.Multiply(val, val));
-            }
-            T rmsVal = numOps.Sqrt(numOps.Add(numOps.Divide(sumSq, featureSizeT), eps));
-            rmsData[b] = rmsVal;
+                int offset = b * fs;
+                float sumSq = 0f;
+                for (int f = 0; f < fs; f++)
+                {
+                    float val = fInput[offset + f];
+                    sumSq += val * val;
+                }
+                float rmsVal = MathF.Sqrt(sumSq * invFs + fEps);
+                fRms[b] = rmsVal;
+                float invRms = 1f / rmsVal;
+                for (int f = 0; f < fs; f++)
+                    fOutput[offset + f] = fGamma[f] * (fInput[offset + f] * invRms);
+            });
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            var dInput = (double[])(object)inputData;
+            var dGamma = (double[])(object)gammaData;
+            var dRms = (double[])(object)rmsData;
+            var dOutput = (double[])(object)outputData;
+            int fs = featureSize;
+            double invFs = 1.0 / fs;
 
-            // Normalize and scale
-            T invRms = numOps.Divide(numOps.One, rmsVal);
-            for (int f = 0; f < featureSize; f++)
-                outputData[offset + f] = numOps.Multiply(gammaData[f], numOps.Multiply(inputData[offset + f], invRms));
-        });
+            CpuParallelSettings.ParallelForOrSerial(0, batchSize, outputData.Length, b =>
+            {
+                int offset = b * fs;
+                double sumSq = 0.0;
+                for (int f = 0; f < fs; f++)
+                {
+                    double val = dInput[offset + f];
+                    sumSq += val * val;
+                }
+                double rmsVal = Math.Sqrt(sumSq * invFs + epsilon);
+                dRms[b] = rmsVal;
+                double invRms = 1.0 / rmsVal;
+                for (int f = 0; f < fs; f++)
+                    dOutput[offset + f] = dGamma[f] * (dInput[offset + f] * invRms);
+            });
+        }
+        else
+        {
+            CpuParallelSettings.ParallelForOrSerial(0, batchSize, outputData.Length, b =>
+            {
+                int offset = b * featureSize;
+                T featureSizeT = numOps.FromDouble(featureSize);
+
+                // RMS
+                T sumSq = numOps.Zero;
+                for (int f = 0; f < featureSize; f++)
+                {
+                    T val = inputData[offset + f];
+                    sumSq = numOps.Add(sumSq, numOps.Multiply(val, val));
+                }
+                T rmsVal = numOps.Sqrt(numOps.Add(numOps.Divide(sumSq, featureSizeT), eps));
+                rmsData[b] = rmsVal;
+
+                // Normalize and scale
+                T invRms = numOps.Divide(numOps.One, rmsVal);
+                for (int f = 0; f < featureSize; f++)
+                    outputData[offset + f] = numOps.Multiply(gammaData[f], numOps.Multiply(inputData[offset + f], invRms));
+            });
+        }
 
         rms = TensorAllocator.Rent<T>(batchShape, rmsData);
         var rmsResult = TensorAllocator.Rent<T>(input._shape, outputData);

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -3776,6 +3776,52 @@ public partial class CpuEngine : ITensorLevelEngine
             return;
         }
 
+        // Double fast path for last-axis softmax (innerSize == 1). Used by
+        // every attention layer's QKᵀ softmax and every classifier head
+        // when running fp64. Inline 3-pass max / exp-sum / normalize per
+        // row avoids the generic Softmax() fallback's per-element numOps
+        // virtual dispatch + intermediate allocation + CopyTo. Parallel
+        // across rows for cache locality and core saturation.
+        if (typeof(T) == typeof(double) && innerSize == 1)
+        {
+            using var pinIn = input.Data.Pin();
+            using var pinOut = destination.Data.Pin();
+            unsafe
+            {
+                double* pIn = (double*)pinIn.Pointer;
+                double* pOut = (double*)pinOut.Pointer;
+                int axisSz = axisSize;
+                int outerSz = outerSize;
+                bool useParallel = outerSz >= 4 && (long)outerSz * axisSz >= 32768;
+                Action<int> rowKernel = row =>
+                {
+                    double* rIn = pIn + row * axisSz;
+                    double* rOut = pOut + row * axisSz;
+                    double max = rIn[0];
+                    for (int i = 1; i < axisSz; i++)
+                        if (rIn[i] > max) max = rIn[i];
+                    double sum = 0;
+                    for (int i = 0; i < axisSz; i++)
+                    {
+                        double e = Math.Exp(rIn[i] - max);
+                        rOut[i] = e;
+                        sum += e;
+                    }
+                    double inv = 1.0 / sum;
+                    for (int i = 0; i < axisSz; i++) rOut[i] *= inv;
+                };
+                if (useParallel)
+                {
+                    Parallel.For(0, outerSz, rowKernel);
+                }
+                else
+                {
+                    for (int row = 0; row < outerSz; row++) rowKernel(row);
+                }
+            }
+            return;
+        }
+
         // Fallback: compute and copy, return pooled tensor
         var result = Softmax(input, axis);
         try

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -241,7 +241,15 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
             int mathMode = useTF32
                 ? CuBlasNative.CUBLAS_TF32_TENSOR_OP_MATH
                 : CuBlasNative.CUBLAS_TENSOR_OP_MATH;
-            CuBlasNative.cublasSetMathMode(_cublasHandle, mathMode);
+            // Wrap in CheckCublasStatus so a math-mode set failure surfaces
+            // immediately rather than leaving the handle in an unknown state.
+            // Same pattern as cublasCreate / cublasSetStream above; a silent
+            // failure here would make every subsequent fp32 GEMM run with
+            // unspecified Tensor-Core behaviour (could be CUBLAS_DEFAULT_MATH,
+            // strict fp32 with no acceleration; could be undefined).
+            CuBlasNative.CheckCublasStatus(
+                CuBlasNative.cublasSetMathMode(_cublasHandle, mathMode),
+                "cublasSetMathMode");
 
             // Query clock rate for theoretical GFLOPS calculation
             if (CuBlasNative.cuDeviceGetAttribute(out int clockKHz, (int)CudaDeviceAttribute.ClockRate, device) == CudaResult.Success)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -219,11 +219,29 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
 
             CuBlasNative.CheckCublasStatus(CuBlasNative.cublasCreate(out _cublasHandle), "cublasCreate");
             CuBlasNative.CheckCublasStatus(CuBlasNative.cublasSetStream(_cublasHandle, _stream), "cublasSetStream");
-            CuBlasNative.cublasSetMathMode(_cublasHandle, CuBlasNative.CUBLAS_TENSOR_OP_MATH);
 
+            // Math mode dispatch:
+            //   - Ampere+ (compute capability ≥ 8.0) + AllowTF32 = true:
+            //     CUBLAS_TF32_TENSOR_OP_MATH. Fp32 GEMMs run on the Tensor
+            //     Cores with TF32 multiply + fp32 accumulate, ~5× the FLOPs
+            //     of strict fp32. Loss curves match strict fp32 to within
+            //     measurement noise on every NVIDIA-published benchmark
+            //     (BERT, ResNet-50, Mask-R-CNN, T5).
+            //   - Volta / Turing (compute capability < 8.0) OR AllowTF32 = false:
+            //     legacy CUBLAS_TENSOR_OP_MATH, which gives the V100-class
+            //     fp16 Tensor-Core path for HGEMM but leaves fp32 GEMMs at
+            //     strict fp32.
+            // Compute-capability check uses the value we just read; AllowTF32
+            // honors AIDOTNET_DISABLE_TF32 env var + runtime override.
             var cc = GetComputeCapability(device);
             _ccMajor = cc.Major;
             _ccMinor = cc.Minor;
+
+            bool useTF32 = _ccMajor >= 8 && CudaDispatchPolicy.AllowTF32;
+            int mathMode = useTF32
+                ? CuBlasNative.CUBLAS_TF32_TENSOR_OP_MATH
+                : CuBlasNative.CUBLAS_TENSOR_OP_MATH;
+            CuBlasNative.cublasSetMathMode(_cublasHandle, mathMode);
 
             // Query clock rate for theoretical GFLOPS calculation
             if (CuBlasNative.cuDeviceGetAttribute(out int clockKHz, (int)CudaDeviceAttribute.ClockRate, device) == CudaResult.Success)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaDispatchPolicy.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaDispatchPolicy.cs
@@ -51,6 +51,41 @@ internal static class CudaDispatchPolicy
         => TensorCodecOptions.Current.UseCublas;
 
     /// <summary>
+    /// Returns true when fp32 cuBLAS GEMMs should use TF32 (TensorFloat-32)
+    /// accumulation on Ampere+ (compute capability ≥ 8.0). TF32 rounds the
+    /// 23-bit fp32 mantissa to 10 bits for the multiply, accumulates at full
+    /// fp32, and runs on the Tensor Cores. The result is ~5× the throughput
+    /// of strict fp32 with bit-comparable training-loss curves on every
+    /// published benchmark (NVIDIA: BERT, ResNet-50, Mask-R-CNN, T5).
+    /// </summary>
+    /// <remarks>
+    /// <para>Default: true. Opt out by:
+    /// <list type="bullet">
+    /// <item>setting <c>AIDOTNET_DISABLE_TF32</c> to any non-empty value
+    /// before process startup (checked at <see cref="CudaBackend"/> init time), or</item>
+    /// <item>flipping the static <see cref="AllowTF32"/> property at runtime —
+    /// changes take effect on the next <see cref="CudaBackend"/> instance
+    /// (current backends keep the math mode they were initialized with).</item>
+    /// </list></para>
+    /// <para>When to disable: numerical-reproducibility runs that need bit-exact
+    /// fp32 arithmetic (regression tests pinned to a reference output), Volta or
+    /// older hardware (the property short-circuits via compute-capability check
+    /// in <see cref="CudaBackend"/>, so this is for forcing the legacy path on
+    /// Ampere+ rather than relaxing it on older hardware).</para>
+    /// </remarks>
+    public static bool AllowTF32
+    {
+        get
+        {
+            if (_allowTF32Override.HasValue) return _allowTF32Override.Value;
+            return string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AIDOTNET_DISABLE_TF32"));
+        }
+        set => _allowTF32Override = value;
+    }
+
+    private static bool? _allowTF32Override;
+
+    /// <summary>
     /// Push a <see cref="PerformanceProfiler"/> scope with a kernel-path
     /// label so downstream telemetry can distinguish vendor vs generic
     /// kernel runs.

--- a/src/AiDotNet.Tensors/Engines/Gpu/GpuStreamPool.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/GpuStreamPool.cs
@@ -60,6 +60,17 @@ public sealed class GpuStreamPool : IDisposable
     public IAsyncGpuBackend Backend => _backend;
 
     /// <summary>
+    /// Returns the upper bound on how many streams of <paramref name="streamType"/>
+    /// the pool will lazily create before <see cref="AcquireStream"/> starts
+    /// throwing. Consumers like <see cref="GpuStreamScheduler"/> use this to
+    /// pre-size their leased working set so a single dispatch call can hold
+    /// every pool stream concurrently rather than acquire-and-release on each
+    /// launch (which collapses onto one stream under <c>ConcurrentBag</c>'s
+    /// thread-local cache).
+    /// </summary>
+    public int GetMaxStreams(GpuStreamType streamType) => GetMaxStreamsForType(streamType);
+
+    /// <summary>
     /// Creates a new stream pool for the given backend.
     /// </summary>
     /// <param name="backend">The async GPU backend.</param>

--- a/src/AiDotNet.Tensors/Engines/Gpu/GpuStreamScheduler.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/GpuStreamScheduler.cs
@@ -1,0 +1,177 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// PR #333 / issue #335 — schedules independent kernel launches across the
+// streams in a GpuStreamPool. Solves the "every kernel serializes on
+// _defaultStream" perf gap by round-robining independent work across
+// pool streams. Used by BatchMatMul (per-batch-slice GEMMs), multi-head
+// attention (per-head launches), and any other consumer that has a list
+// of data-independent launches.
+
+namespace AiDotNet.Tensors.Engines.Gpu;
+
+/// <summary>
+/// Dispatches independent GPU kernel launches across the streams in a
+/// <see cref="GpuStreamPool"/> for compute-compute overlap. Each launch
+/// runs on its own stream, so the GPU's stream-multiprocessor scheduler
+/// can interleave them based on resource availability.
+///
+/// <para>This is the high-level consumer API for <see cref="GpuStreamPool"/>.
+/// Callers describe their independent work as a list of <c>Action&lt;IGpuStream&gt;</c>
+/// delegates; the scheduler picks a stream from the pool for each, runs
+/// the delegate (which is expected to call kernel-launch methods bound to
+/// the supplied stream), and returns completion events the caller can
+/// wait on or chain into downstream work.</para>
+///
+/// <para><b>Concurrency model:</b> Each launch in a single <see cref="Dispatch"/>
+/// call is independent of every other launch in that call — the caller is
+/// responsible for guaranteeing no data dependencies between them. The
+/// scheduler does NOT analyze dependencies; it just round-robins streams.
+/// For DAG-ordered dispatch (batch N depends on batch N-1), use
+/// <see cref="DispatchSequential"/>.</para>
+///
+/// <para><b>Stream count:</b> Bounded by <see cref="GpuExecutionOptions.MaxComputeStreams"/>.
+/// When the number of launches exceeds the stream count, multiple launches
+/// share each stream and serialize on it; the scheduler still spreads work
+/// across all available streams.</para>
+///
+/// <para><b>Hot-path use cases:</b>
+/// <list type="bullet">
+/// <item>BatchMatMul over independent batch slices — each slice GEMM is
+/// dispatched on a distinct stream, so cuBLAS / cuDNN can keep multiple
+/// SMs busy concurrently.</item>
+/// <item>Multi-head attention forward: scores = Q · K^T per head, then
+/// softmax, then output = scores · V per head — each head's three GEMMs
+/// run on the same stream (preserving per-head ordering) but heads run
+/// across different streams (compute-compute overlap).</item>
+/// <item>ResNet bottleneck blocks with parallel 1×1 conv branches — each
+/// branch on its own stream.</item>
+/// </list></para>
+/// </summary>
+public sealed class GpuStreamScheduler
+{
+    private readonly GpuStreamPool _pool;
+    private readonly GpuStreamType _streamType;
+    private int _nextStream;
+
+    /// <summary>
+    /// Creates a scheduler bound to a stream pool. Launches dispatched
+    /// through this scheduler will be drawn from the pool's
+    /// <paramref name="streamType"/> tier; the default is <see cref="GpuStreamType.Compute"/>
+    /// which matches the most common training/inference use case.
+    /// </summary>
+    public GpuStreamScheduler(GpuStreamPool pool, GpuStreamType streamType = GpuStreamType.Compute)
+    {
+        _pool = pool ?? throw new ArgumentNullException(nameof(pool));
+        _streamType = streamType;
+    }
+
+    /// <summary>
+    /// Dispatches a batch of independent launches across pool streams.
+    /// Returns one completion event per launch, in the same order as the
+    /// input list. Callers waiting for all to complete should call
+    /// <see cref="SynchronizeEvents"/> with the returned events or call
+    /// <see cref="GpuStreamPool.SynchronizeAll"/> on the underlying pool.
+    /// </summary>
+    /// <remarks>
+    /// The launches must be data-independent — neither reads nor writes
+    /// shared GPU memory between launches in this batch. If two launches
+    /// touch the same buffer (even if logically disjoint regions), the
+    /// underlying CUDA / HIP / Metal / OpenCL runtime may emit memory-
+    /// access warnings under racy access patterns. Use
+    /// <see cref="DispatchSequential"/> when ordering matters.
+    /// </remarks>
+    public IReadOnlyList<IGpuEvent> Dispatch(IReadOnlyList<Action<IGpuStream>> launches)
+    {
+        if (launches is null) throw new ArgumentNullException(nameof(launches));
+        if (launches.Count == 0) return Array.Empty<IGpuEvent>();
+
+        var events = new IGpuEvent[launches.Count];
+        // Acquire streams round-robin from the pool. The pool caps stream
+        // count at GpuExecutionOptions.MaxComputeStreams; when launches.Count
+        // exceeds that, we wrap and reuse streams — which serializes the
+        // wrapped launches on each stream, but still spreads work across
+        // the cap-limited stream count.
+        for (int i = 0; i < launches.Count; i++)
+        {
+            var stream = AcquireNextStream();
+            try
+            {
+                launches[i](stream);
+                events[i] = stream.RecordEvent();
+            }
+            finally
+            {
+                _pool.ReleaseStream(stream);
+            }
+        }
+        return events;
+    }
+
+    /// <summary>
+    /// Dispatches a sequence of DAG-ordered batches. Each batch in
+    /// <paramref name="batches"/> runs in parallel across streams (same
+    /// semantics as <see cref="Dispatch"/>), but batches run in order —
+    /// batch N's launches wait on completion events from batch N-1 before
+    /// they start. Use when each layer of the model is parallel internally
+    /// but downstream layers depend on upstream completion (forward pass
+    /// over per-attention-head Q · K^T → softmax → output).
+    /// </summary>
+    public void DispatchSequential(IReadOnlyList<IReadOnlyList<Action<IGpuStream>>> batches)
+    {
+        if (batches is null) throw new ArgumentNullException(nameof(batches));
+
+        IReadOnlyList<IGpuEvent>? prevEvents = null;
+        for (int b = 0; b < batches.Count; b++)
+        {
+            var batch = batches[b];
+            if (batch is null || batch.Count == 0) continue;
+
+            var thisBatchEvents = new IGpuEvent[batch.Count];
+            for (int i = 0; i < batch.Count; i++)
+            {
+                var stream = AcquireNextStream();
+                try
+                {
+                    // Block this stream on every event from the previous
+                    // batch — batch N can't start until batch N-1 is fully
+                    // done. The GPU still runs batch N's launches in
+                    // parallel across streams; it just won't start them
+                    // until the cross-stream wait is satisfied.
+                    if (prevEvents is not null)
+                        foreach (var ev in prevEvents)
+                            stream.WaitEvent(ev);
+
+                    batch[i](stream);
+                    thisBatchEvents[i] = stream.RecordEvent();
+                }
+                finally
+                {
+                    _pool.ReleaseStream(stream);
+                }
+            }
+            prevEvents = thisBatchEvents;
+        }
+    }
+
+    /// <summary>
+    /// Waits for every event in <paramref name="events"/> to complete on
+    /// the host. Cheaper than synchronizing the whole pool when you only
+    /// need a subset of dispatched launches done — e.g. waiting on the
+    /// last layer's events before reading the loss to CPU.
+    /// </summary>
+    public void SynchronizeEvents(IReadOnlyList<IGpuEvent> events)
+    {
+        if (events is null) return;
+        foreach (var ev in events)
+            ev?.Synchronize();
+    }
+
+    private IGpuStream AcquireNextStream()
+    {
+        // Round-robin across pool streams. We use AcquireStream rather than
+        // tracking our own stream pool because the GpuStreamPool already
+        // caps total streams at MaxComputeStreams and reuses them.
+        int idx = Interlocked.Increment(ref _nextStream);
+        _ = idx; // suppress unused; kept for future logging / debugging
+        return _pool.AcquireStream(_streamType);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/Gpu/GpuStreamScheduler.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/GpuStreamScheduler.cs
@@ -6,6 +6,8 @@
 // attention (per-head launches), and any other consumer that has a list
 // of data-independent launches.
 
+using System.Collections;
+
 namespace AiDotNet.Tensors.Engines.Gpu;
 
 /// <summary>
@@ -16,10 +18,11 @@ namespace AiDotNet.Tensors.Engines.Gpu;
 ///
 /// <para>This is the high-level consumer API for <see cref="GpuStreamPool"/>.
 /// Callers describe their independent work as a list of <c>Action&lt;IGpuStream&gt;</c>
-/// delegates; the scheduler picks a stream from the pool for each, runs
-/// the delegate (which is expected to call kernel-launch methods bound to
-/// the supplied stream), and returns completion events the caller can
-/// wait on or chain into downstream work.</para>
+/// delegates; the scheduler leases up to <see cref="GpuExecutionOptions.MaxComputeStreams"/>
+/// streams from the pool, round-robins the launches across the leased set,
+/// and returns a <see cref="GpuEventBatch"/> the caller can wait on or
+/// chain into downstream work. The batch owns the recorded events and
+/// disposes them when the caller disposes the batch.</para>
 ///
 /// <para><b>Concurrency model:</b> Each launch in a single <see cref="Dispatch"/>
 /// call is independent of every other launch in that call — the caller is
@@ -28,10 +31,16 @@ namespace AiDotNet.Tensors.Engines.Gpu;
 /// For DAG-ordered dispatch (batch N depends on batch N-1), use
 /// <see cref="DispatchSequential"/>.</para>
 ///
-/// <para><b>Stream count:</b> Bounded by <see cref="GpuExecutionOptions.MaxComputeStreams"/>.
-/// When the number of launches exceeds the stream count, multiple launches
-/// share each stream and serialize on it; the scheduler still spreads work
-/// across all available streams.</para>
+/// <para><b>Stream leasing model:</b> <see cref="Dispatch"/> leases
+/// <c>min(launches.Count, MaxComputeStreams)</c> streams for the entire
+/// call, indexes into the leased set with a round-robin counter, and
+/// releases all leased streams when the dispatch returns. This avoids the
+/// trap where per-launch acquire+release through <c>ConcurrentBag</c>
+/// returns the same stream to the calling thread (LIFO cache) and
+/// serializes every launch onto a single stream. If the pool is exhausted
+/// by concurrent callers and we can't lease anything, the scheduler falls
+/// back to the pool's default compute stream so the work still completes
+/// — without parallelism, but correctly.</para>
 ///
 /// <para><b>Hot-path use cases:</b>
 /// <list type="bullet">
@@ -50,6 +59,7 @@ public sealed class GpuStreamScheduler
 {
     private readonly GpuStreamPool _pool;
     private readonly GpuStreamType _streamType;
+    private readonly int _maxStreams;
     private int _nextStream;
 
     /// <summary>
@@ -62,14 +72,18 @@ public sealed class GpuStreamScheduler
     {
         _pool = pool ?? throw new ArgumentNullException(nameof(pool));
         _streamType = streamType;
+        _maxStreams = pool.GetMaxStreams(streamType);
+        if (_maxStreams < 1) _maxStreams = 1;
     }
 
     /// <summary>
     /// Dispatches a batch of independent launches across pool streams.
-    /// Returns one completion event per launch, in the same order as the
-    /// input list. Callers waiting for all to complete should call
-    /// <see cref="SynchronizeEvents"/> with the returned events or call
-    /// <see cref="GpuStreamPool.SynchronizeAll"/> on the underlying pool.
+    /// Returns a <see cref="GpuEventBatch"/> with one completion event per
+    /// launch in the same order as the input list. The returned batch owns
+    /// the events — callers SHOULD <c>using var batch = scheduler.Dispatch(...)</c>
+    /// or call <see cref="GpuEventBatch.Dispose"/> explicitly to release
+    /// the native event handles. Failing to dispose leaks native GPU event
+    /// objects.
     /// </summary>
     /// <remarks>
     /// The launches must be data-independent — neither reads nor writes
@@ -79,31 +93,45 @@ public sealed class GpuStreamScheduler
     /// access warnings under racy access patterns. Use
     /// <see cref="DispatchSequential"/> when ordering matters.
     /// </remarks>
-    public IReadOnlyList<IGpuEvent> Dispatch(IReadOnlyList<Action<IGpuStream>> launches)
+    public GpuEventBatch Dispatch(IReadOnlyList<Action<IGpuStream>> launches)
     {
         if (launches is null) throw new ArgumentNullException(nameof(launches));
-        if (launches.Count == 0) return Array.Empty<IGpuEvent>();
+        if (launches.Count == 0) return GpuEventBatch.Empty;
 
-        var events = new IGpuEvent[launches.Count];
-        // Acquire streams round-robin from the pool. The pool caps stream
-        // count at GpuExecutionOptions.MaxComputeStreams; when launches.Count
-        // exceeds that, we wrap and reuse streams — which serializes the
-        // wrapped launches on each stream, but still spreads work across
-        // the cap-limited stream count.
-        for (int i = 0; i < launches.Count; i++)
+        // Lease the streams up front so each launch lands on a distinct
+        // stream via round-robin. With per-launch acquire+release, the
+        // pool's ConcurrentBag returns the same stream to the calling
+        // thread (LIFO thread-local cache) and every launch serializes
+        // onto a single stream — the very perf gap this scheduler exists
+        // to close.
+        int target = Math.Min(launches.Count, _maxStreams);
+        var leased = LeaseStreams(target);
+        try
         {
-            var stream = AcquireNextStream();
-            try
+            int streamCount = leased.Count;
+            if (streamCount == 0)
             {
+                // Pool exhausted by concurrent callers. Fall back to the
+                // default compute stream — work still executes, just
+                // without parallelism on this call.
+                return DispatchOnSingleStream(_pool.DefaultComputeStream, launches);
+            }
+
+            var events = new IGpuEvent[launches.Count];
+            int start = (int)((uint)Interlocked.Increment(ref _nextStream)) % streamCount;
+            for (int i = 0; i < launches.Count; i++)
+            {
+                var stream = leased[(start + i) % streamCount];
                 launches[i](stream);
                 events[i] = stream.RecordEvent();
             }
-            finally
-            {
-                _pool.ReleaseStream(stream);
-            }
+            return new GpuEventBatch(events);
         }
-        return events;
+        finally
+        {
+            for (int i = 0; i < leased.Count; i++)
+                _pool.ReleaseStream(leased[i]);
+        }
     }
 
     /// <summary>
@@ -115,40 +143,88 @@ public sealed class GpuStreamScheduler
     /// but downstream layers depend on upstream completion (forward pass
     /// over per-attention-head Q · K^T → softmax → output).
     /// </summary>
-    public void DispatchSequential(IReadOnlyList<IReadOnlyList<Action<IGpuStream>>> batches)
+    /// <returns>
+    /// A <see cref="GpuEventBatch"/> covering the FINAL batch's recorded
+    /// events. Earlier batches' events are owned by the scheduler and
+    /// disposed internally once the next batch has installed waits on
+    /// them. The returned batch is the caller's responsibility — dispose
+    /// it (or wrap in <c>using</c>) to release the final batch's native
+    /// event handles. Returns <see cref="GpuEventBatch.Empty"/> when every
+    /// supplied batch is null or empty.
+    /// </returns>
+    public GpuEventBatch DispatchSequential(IReadOnlyList<IReadOnlyList<Action<IGpuStream>>> batches)
     {
         if (batches is null) throw new ArgumentNullException(nameof(batches));
+        if (batches.Count == 0) return GpuEventBatch.Empty;
 
-        IReadOnlyList<IGpuEvent>? prevEvents = null;
+        int maxBatchSize = 0;
         for (int b = 0; b < batches.Count; b++)
         {
             var batch = batches[b];
-            if (batch is null || batch.Count == 0) continue;
+            if (batch is not null && batch.Count > maxBatchSize) maxBatchSize = batch.Count;
+        }
+        if (maxBatchSize == 0) return GpuEventBatch.Empty;
 
-            var thisBatchEvents = new IGpuEvent[batch.Count];
-            for (int i = 0; i < batch.Count; i++)
+        int target = Math.Min(maxBatchSize, _maxStreams);
+        var leased = LeaseStreams(target);
+        try
+        {
+            // Build the effective stream set. If the pool was exhausted by
+            // concurrent callers and we couldn't lease anything, fall back
+            // to the default compute stream — single-stream execution still
+            // respects the DAG ordering because everything runs in submit
+            // order on one stream.
+            IGpuStream[] streams = leased.Count > 0
+                ? leased.ToArray()
+                : new[] { _pool.DefaultComputeStream };
+
+            IGpuEvent[]? prevEvents = null;
+            IGpuEvent[]? lastEvents = null;
+            int rotation = (int)((uint)Interlocked.Increment(ref _nextStream)) % streams.Length;
+
+            for (int b = 0; b < batches.Count; b++)
             {
-                var stream = AcquireNextStream();
-                try
+                var batch = batches[b];
+                if (batch is null || batch.Count == 0) continue;
+
+                var thisBatchEvents = new IGpuEvent[batch.Count];
+                for (int i = 0; i < batch.Count; i++)
                 {
-                    // Block this stream on every event from the previous
-                    // batch — batch N can't start until batch N-1 is fully
-                    // done. The GPU still runs batch N's launches in
-                    // parallel across streams; it just won't start them
-                    // until the cross-stream wait is satisfied.
+                    var stream = streams[(rotation + i) % streams.Length];
+
                     if (prevEvents is not null)
-                        foreach (var ev in prevEvents)
-                            stream.WaitEvent(ev);
+                    {
+                        for (int p = 0; p < prevEvents.Length; p++)
+                            stream.WaitEvent(prevEvents[p]);
+                    }
 
                     batch[i](stream);
                     thisBatchEvents[i] = stream.RecordEvent();
                 }
-                finally
+
+                // The previous batch's events have been consumed by every
+                // stream in the current batch that needed them. CUDA /
+                // HIP / Metal / OpenCL all capture the event state at
+                // WaitEvent submission time, so disposing the wrapper now
+                // does not break the wait that's already queued on the
+                // GPU. This is the only path that keeps DispatchSequential
+                // from leaking event handles proportional to batch count.
+                if (prevEvents is not null)
                 {
-                    _pool.ReleaseStream(stream);
+                    for (int p = 0; p < prevEvents.Length; p++)
+                        prevEvents[p]?.Dispose();
                 }
+
+                prevEvents = thisBatchEvents;
+                lastEvents = thisBatchEvents;
             }
-            prevEvents = thisBatchEvents;
+
+            return lastEvents is null ? GpuEventBatch.Empty : new GpuEventBatch(lastEvents);
+        }
+        finally
+        {
+            for (int i = 0; i < leased.Count; i++)
+                _pool.ReleaseStream(leased[i]);
         }
     }
 
@@ -156,22 +232,103 @@ public sealed class GpuStreamScheduler
     /// Waits for every event in <paramref name="events"/> to complete on
     /// the host. Cheaper than synchronizing the whole pool when you only
     /// need a subset of dispatched launches done — e.g. waiting on the
-    /// last layer's events before reading the loss to CPU.
+    /// last layer's events before reading the loss to CPU. Equivalent to
+    /// <see cref="GpuEventBatch.SynchronizeAll"/> for the batch case.
     /// </summary>
     public void SynchronizeEvents(IReadOnlyList<IGpuEvent> events)
     {
         if (events is null) return;
-        foreach (var ev in events)
-            ev?.Synchronize();
+        for (int i = 0; i < events.Count; i++)
+            events[i]?.Synchronize();
     }
 
-    private IGpuStream AcquireNextStream()
+    private GpuEventBatch DispatchOnSingleStream(IGpuStream stream, IReadOnlyList<Action<IGpuStream>> launches)
     {
-        // Round-robin across pool streams. We use AcquireStream rather than
-        // tracking our own stream pool because the GpuStreamPool already
-        // caps total streams at MaxComputeStreams and reuses them.
-        int idx = Interlocked.Increment(ref _nextStream);
-        _ = idx; // suppress unused; kept for future logging / debugging
-        return _pool.AcquireStream(_streamType);
+        var events = new IGpuEvent[launches.Count];
+        for (int i = 0; i < launches.Count; i++)
+        {
+            launches[i](stream);
+            events[i] = stream.RecordEvent();
+        }
+        return new GpuEventBatch(events);
+    }
+
+    private List<IGpuStream> LeaseStreams(int count)
+    {
+        var leased = new List<IGpuStream>(count);
+        for (int i = 0; i < count; i++)
+        {
+            try
+            {
+                leased.Add(_pool.AcquireStream(_streamType));
+            }
+            catch (InvalidOperationException)
+            {
+                // Pool exhausted by concurrent callers — break and use
+                // whatever subset we managed to lease. Caller path also
+                // tolerates Count == 0 by routing to the default stream.
+                break;
+            }
+        }
+        return leased;
+    }
+}
+
+/// <summary>
+/// Disposable list of recorded GPU events returned by
+/// <see cref="GpuStreamScheduler.Dispatch"/> and
+/// <see cref="GpuStreamScheduler.DispatchSequential"/>. Owns the underlying
+/// <see cref="IGpuEvent"/> handles — dispose the batch (e.g. via
+/// <c>using var batch = scheduler.Dispatch(...)</c>) to release the native
+/// event objects. Failing to dispose leaks GPU event handles.
+/// </summary>
+public sealed class GpuEventBatch : IReadOnlyList<IGpuEvent>, IDisposable
+{
+    /// <summary>
+    /// Shared empty batch — returned when there is nothing to dispatch.
+    /// Safe to dispose any number of times.
+    /// </summary>
+    public static readonly GpuEventBatch Empty = new GpuEventBatch(Array.Empty<IGpuEvent>());
+
+    private readonly IGpuEvent[] _events;
+    private bool _disposed;
+
+    internal GpuEventBatch(IGpuEvent[] events)
+    {
+        _events = events ?? throw new ArgumentNullException(nameof(events));
+    }
+
+    /// <inheritdoc />
+    public IGpuEvent this[int index] => _events[index];
+
+    /// <inheritdoc />
+    public int Count => _events.Length;
+
+    /// <inheritdoc />
+    public IEnumerator<IGpuEvent> GetEnumerator() => ((IEnumerable<IGpuEvent>)_events).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => _events.GetEnumerator();
+
+    /// <summary>
+    /// Blocks the calling thread until every event in this batch
+    /// completes on the device. Equivalent to calling
+    /// <see cref="IGpuEvent.Synchronize"/> on each event in order.
+    /// </summary>
+    public void SynchronizeAll()
+    {
+        for (int i = 0; i < _events.Length; i++)
+            _events[i]?.Synchronize();
+    }
+
+    /// <summary>
+    /// Disposes every event in the batch, releasing the underlying native
+    /// GPU event handles. Idempotent. The batch is unusable after disposal.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        for (int i = 0; i < _events.Length; i++)
+            _events[i]?.Dispose();
     }
 }

--- a/src/AiDotNet.Tensors/Engines/Gpu/GpuStreamScheduler.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/GpuStreamScheduler.cs
@@ -119,11 +119,26 @@ public sealed class GpuStreamScheduler
 
             var events = new IGpuEvent[launches.Count];
             int start = (int)((uint)Interlocked.Increment(ref _nextStream)) % streamCount;
-            for (int i = 0; i < launches.Count; i++)
+            int recorded = 0;
+            try
             {
-                var stream = leased[(start + i) % streamCount];
-                launches[i](stream);
-                events[i] = stream.RecordEvent();
+                for (int i = 0; i < launches.Count; i++)
+                {
+                    var stream = leased[(start + i) % streamCount];
+                    launches[i](stream);
+                    events[i] = stream.RecordEvent();
+                    recorded = i + 1;
+                }
+            }
+            catch
+            {
+                // A launch delegate threw. Dispose every event we already
+                // recorded for prior launches — otherwise the native event
+                // handles leak (the caller never gets a GpuEventBatch to
+                // dispose). Then propagate the original exception.
+                for (int j = 0; j < recorded; j++)
+                    events[j]?.Dispose();
+                throw;
             }
             return new GpuEventBatch(events);
         }
@@ -182,41 +197,71 @@ public sealed class GpuStreamScheduler
             IGpuEvent[]? lastEvents = null;
             int rotation = (int)((uint)Interlocked.Increment(ref _nextStream)) % streams.Length;
 
-            for (int b = 0; b < batches.Count; b++)
+            IGpuEvent[]? thisBatchEvents = null;
+            int thisBatchRecorded = 0;
+            try
             {
-                var batch = batches[b];
-                if (batch is null || batch.Count == 0) continue;
-
-                var thisBatchEvents = new IGpuEvent[batch.Count];
-                for (int i = 0; i < batch.Count; i++)
+                for (int b = 0; b < batches.Count; b++)
                 {
-                    var stream = streams[(rotation + i) % streams.Length];
+                    var batch = batches[b];
+                    if (batch is null || batch.Count == 0) continue;
 
+                    thisBatchEvents = new IGpuEvent[batch.Count];
+                    thisBatchRecorded = 0;
+                    for (int i = 0; i < batch.Count; i++)
+                    {
+                        var stream = streams[(rotation + i) % streams.Length];
+
+                        if (prevEvents is not null)
+                        {
+                            for (int p = 0; p < prevEvents.Length; p++)
+                                stream.WaitEvent(prevEvents[p]);
+                        }
+
+                        batch[i](stream);
+                        thisBatchEvents[i] = stream.RecordEvent();
+                        thisBatchRecorded = i + 1;
+                    }
+
+                    // The previous batch's events have been consumed by every
+                    // stream in the current batch that needed them. CUDA /
+                    // HIP / Metal / OpenCL all capture the event state at
+                    // WaitEvent submission time, so disposing the wrapper now
+                    // does not break the wait that's already queued on the
+                    // GPU. This is the only path that keeps DispatchSequential
+                    // from leaking event handles proportional to batch count.
                     if (prevEvents is not null)
                     {
                         for (int p = 0; p < prevEvents.Length; p++)
-                            stream.WaitEvent(prevEvents[p]);
+                            prevEvents[p]?.Dispose();
                     }
 
-                    batch[i](stream);
-                    thisBatchEvents[i] = stream.RecordEvent();
+                    prevEvents = thisBatchEvents;
+                    lastEvents = thisBatchEvents;
+                    thisBatchEvents = null; // ownership transferred to prevEvents/lastEvents
                 }
-
-                // The previous batch's events have been consumed by every
-                // stream in the current batch that needed them. CUDA /
-                // HIP / Metal / OpenCL all capture the event state at
-                // WaitEvent submission time, so disposing the wrapper now
-                // does not break the wait that's already queued on the
-                // GPU. This is the only path that keeps DispatchSequential
-                // from leaking event handles proportional to batch count.
+            }
+            catch
+            {
+                // A launch delegate threw mid-batch. Dispose every event we
+                // already recorded so the native event handles don't leak —
+                // the caller never gets a returned GpuEventBatch on the
+                // exception path. Cover (a) the in-progress batch up to the
+                // last successfully-recorded slot, and (b) the previous
+                // batch whose events haven't been disposed yet (the dispose
+                // happens AFTER the next batch finishes recording, so a
+                // mid-recording throw leaves prevEvents un-disposed).
+                if (thisBatchEvents is not null)
+                {
+                    for (int j = 0; j < thisBatchRecorded; j++)
+                        thisBatchEvents[j]?.Dispose();
+                }
                 if (prevEvents is not null)
                 {
                     for (int p = 0; p < prevEvents.Length; p++)
                         prevEvents[p]?.Dispose();
                 }
-
-                prevEvents = thisBatchEvents;
-                lastEvents = thisBatchEvents;
+                throw;
             }
 
             return lastEvents is null ? GpuEventBatch.Empty : new GpuEventBatch(lastEvents);
@@ -245,10 +290,24 @@ public sealed class GpuStreamScheduler
     private GpuEventBatch DispatchOnSingleStream(IGpuStream stream, IReadOnlyList<Action<IGpuStream>> launches)
     {
         var events = new IGpuEvent[launches.Count];
-        for (int i = 0; i < launches.Count; i++)
+        int recorded = 0;
+        try
         {
-            launches[i](stream);
-            events[i] = stream.RecordEvent();
+            for (int i = 0; i < launches.Count; i++)
+            {
+                launches[i](stream);
+                events[i] = stream.RecordEvent();
+                recorded = i + 1;
+            }
+        }
+        catch
+        {
+            // Same exception-safety contract as Dispatch — dispose any
+            // events we already recorded so the caller's exception path
+            // doesn't leak native event handles.
+            for (int j = 0; j < recorded; j++)
+                events[j]?.Dispose();
+            throw;
         }
         return new GpuEventBatch(events);
     }

--- a/src/AiDotNet.Tensors/Engines/GpuAutoDetectModuleInit.cs
+++ b/src/AiDotNet.Tensors/Engines/GpuAutoDetectModuleInit.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace AiDotNet.Tensors.Engines;
+
+/// <summary>
+/// Module-load-time GPU auto-detection. On .NET 6+ this fires the moment
+/// the AiDotNet.Tensors assembly is loaded — before any model construction
+/// or tensor op — so consumers get GPU acceleration without an explicit
+/// <see cref="AiDotNetEngine.AutoDetectAndConfigureGpu"/> call.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Mirrors the pattern used by the consumer-side <c>BlasEnvDefault</c>
+/// initializer (which auto-sets <c>AIDOTNET_USE_BLAS=1</c>): defaults are
+/// "always on, opt-out via environment variable" so paper-canonical
+/// performance is the out-of-the-box behaviour. Previously
+/// <see cref="AiDotNetEngine.Current"/> defaulted to <see cref="CpuEngine"/>
+/// and nothing in the consumer code, test base, or model classes called
+/// <see cref="AiDotNetEngine.AutoDetectAndConfigureGpu"/>, so every
+/// <c>TryForwardGpuOptimized(...)</c> in the model layer was effectively
+/// dead code on the default path.
+/// </para>
+/// <para>
+/// <b>Opt-out:</b> set <c>AIDOTNET_DISABLE_GPU</c> to any non-empty value
+/// before the process starts (it's checked at module-init time, BEFORE
+/// the AiDotNet.Tensors assembly's static state is touched). Same pattern
+/// as the existing <c>AIDOTNET_USE_BLAS</c> env var.
+/// </para>
+/// <para>
+/// <b>Failure modes:</b> if <see cref="DirectGpuTensorEngine"/>'s ctor
+/// throws (no GPU, missing driver, missing CUDA runtime, etc.), the
+/// initializer swallows the exception and leaves <see cref="AiDotNetEngine.Current"/>
+/// on its CPU default. The initializer itself MUST NOT throw — a thrown
+/// ModuleInitializer aborts the entire AppDomain.
+/// </para>
+/// </remarks>
+internal static class GpuAutoDetectModuleInit
+{
+#if NET6_0_OR_GREATER
+#pragma warning disable CA2255 // ModuleInitializer used intentionally
+    [ModuleInitializer]
+#pragma warning restore CA2255
+    internal static void AutoDetectGpuIfNotOptedOut()
+    {
+        try
+        {
+            // Opt-out gate: AIDOTNET_DISABLE_GPU set to any non-empty
+            // value skips auto-detection. Mirrors BlasEnvDefault's
+            // env-var pattern on the consumer side. Users who explicitly
+            // want CPU (numerical reproducibility, fp64 on consumer GPUs
+            // that throttle double precision, benchmarking baselines)
+            // set this before process startup.
+            var disable = Environment.GetEnvironmentVariable("AIDOTNET_DISABLE_GPU");
+            if (!string.IsNullOrEmpty(disable))
+                return;
+
+            // AutoDetectAndConfigureGpu already wraps DirectGpuTensorEngine
+            // construction in try/catch and falls back to CPU on failure,
+            // so this call is safe at module init even without a GPU /
+            // driver / CUDA runtime present.
+            AiDotNetEngine.AutoDetectAndConfigureGpu();
+        }
+        catch
+        {
+            // Defensive belt-and-suspenders: AutoDetectAndConfigureGpu
+            // already catches its own exceptions, but a thrown
+            // ModuleInitializer takes down the entire AppDomain. Keep
+            // a final guard so module load never fails on a GPU probe.
+        }
+    }
+#endif
+}

--- a/src/AiDotNet.Tensors/Engines/GpuAutoDetectModuleInit.cs
+++ b/src/AiDotNet.Tensors/Engines/GpuAutoDetectModuleInit.cs
@@ -59,7 +59,22 @@ internal static class GpuAutoDetectModuleInit
             // construction in try/catch and falls back to CPU on failure,
             // so this call is safe at module init even without a GPU /
             // driver / CUDA runtime present.
-            AiDotNetEngine.AutoDetectAndConfigureGpu();
+            //
+            // Module-init verbosity is OFF by default — emitting [AiDotNet]
+            // status to stdout at assembly-load time can break test runners
+            // that parse stdout (xUnit reporters, MSBuild diagnostics),
+            // hosted services that route stdout to structured loggers, and
+            // any consumer that expects clean program output. Users who
+            // WANT init-time logging can opt in via the
+            // AIDOTNET_VERBOSE_INIT env var, set their own logger via
+            // AiDotNetEngine.Logger before any tensor work, or call
+            // AutoDetectAndConfigureGpu() explicitly later with the default
+            // verbose: true. AIDOTNET_QUIET overrides everything — sets verbose=false
+            // even when AIDOTNET_VERBOSE_INIT is set, for the "I want zero
+            // noise" override.
+            var verboseInit = !string.IsNullOrEmpty(
+                Environment.GetEnvironmentVariable("AIDOTNET_VERBOSE_INIT"));
+            AiDotNetEngine.AutoDetectAndConfigureGpu(verbose: verboseInit);
         }
         catch
         {

--- a/src/AiDotNet.Tensors/Engines/GpuAutoDetectModuleInit.cs
+++ b/src/AiDotNet.Tensors/Engines/GpuAutoDetectModuleInit.cs
@@ -65,13 +65,14 @@ internal static class GpuAutoDetectModuleInit
             // that parse stdout (xUnit reporters, MSBuild diagnostics),
             // hosted services that route stdout to structured loggers, and
             // any consumer that expects clean program output. Users who
-            // WANT init-time logging can opt in via the
-            // AIDOTNET_VERBOSE_INIT env var, set their own logger via
-            // AiDotNetEngine.Logger before any tensor work, or call
-            // AutoDetectAndConfigureGpu() explicitly later with the default
-            // verbose: true. AIDOTNET_QUIET overrides everything — sets verbose=false
-            // even when AIDOTNET_VERBOSE_INIT is set, for the "I want zero
-            // noise" override.
+            // WANT init-time logging have ONE opt-in: set the
+            // AIDOTNET_VERBOSE_INIT env var BEFORE process startup. The
+            // AiDotNetEngine.Logger property is too late at this point —
+            // module initializers run at assembly load, before any consumer
+            // code can set in-assembly statics — so Logger only affects
+            // log lines emitted by AutoDetectAndConfigureGpu / ResetToCpu
+            // calls made AFTER the assembly is loaded. AIDOTNET_QUIET
+            // overrides AIDOTNET_VERBOSE_INIT for callers who want zero noise.
             var verboseInit = !string.IsNullOrEmpty(
                 Environment.GetEnvironmentVariable("AIDOTNET_VERBOSE_INIT"));
             AiDotNetEngine.AutoDetectAndConfigureGpu(verbose: verboseInit);

--- a/src/AiDotNet.Tensors/Engines/Optimization/MixedPrecisionPolicy.cs
+++ b/src/AiDotNet.Tensors/Engines/Optimization/MixedPrecisionPolicy.cs
@@ -1,0 +1,52 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// PR #333 / issue #337 — mixed-precision routing policy for compute-bound
+// GPU ops. Distinct from the TF32 path (CudaDispatchPolicy.AllowTF32) which
+// stays on fp32 but rounds the multiply on the Tensor Cores; this enum
+// controls whether to actively cast tensors down to fp16 / bf16 for the
+// compute step while keeping fp32 master weights.
+
+namespace AiDotNet.Tensors.Engines.Optimization;
+
+/// <summary>
+/// Routing policy that hot-path GPU kernels consult to decide their compute
+/// dtype. Set via <see cref="TensorCodecOptions.MixedPrecisionPolicy"/> for
+/// thread-local effect, or as a default in <see cref="TensorCodecOptions.Default"/>.
+/// </summary>
+public enum MixedPrecisionPolicy
+{
+    /// <summary>
+    /// No autocast. Kernels run in the model's declared dtype throughout.
+    /// Default. Use this for numerical-reproducibility runs, baseline
+    /// benchmarks, and platforms where the autocast paths aren't yet
+    /// kernel-supported on the loaded backend.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Autocast compute-bound ops to fp16 (System.Half) while keeping fp32
+    /// master weights, gradients, and reductions. Forward casts fp32 → fp16
+    /// at op entry; backward emits gradients in fp32 from the autocast op's
+    /// internal fp16 state. Requires loss scaling (typically ×2¹⁵..2¹⁷)
+    /// to prevent small-magnitude gradients from underflowing fp16's narrow
+    /// exponent range; the loss-scaling state lives on the optimizer.
+    /// </summary>
+    /// <remarks>
+    /// Hardware availability: Volta+, Turing+, Ampere+ for fp16 Tensor Cores.
+    /// All compute-capability 7.0+ NVIDIA GPUs.
+    /// </remarks>
+    AutoCastFP16 = 1,
+
+    /// <summary>
+    /// Autocast compute-bound ops to bfloat16 while keeping fp32 master weights.
+    /// BF16 has the same 8-bit exponent as fp32 — no loss scaling required —
+    /// but trades 7 mantissa bits (vs fp16's 10) for the dynamic range. Best
+    /// choice for transformer training when the hardware supports it.
+    /// </summary>
+    /// <remarks>
+    /// Hardware availability: Ampere (sm_80+) for full BF16 Tensor Core
+    /// support, Hopper (sm_90+) for BF16 on every op. On Volta / Turing /
+    /// pre-Ampere consumer cards (RTX 2080, RTX 3090 selected ops), BF16
+    /// kernels may emulate via fp32 — check vendor docs.
+    /// </remarks>
+    AutoCastBF16 = 2,
+}

--- a/src/AiDotNet.Tensors/Engines/Optimization/TensorCodecOptions.cs
+++ b/src/AiDotNet.Tensors/Engines/Optimization/TensorCodecOptions.cs
@@ -107,7 +107,39 @@ public sealed class TensorCodecOptions
     public bool EnableBlasBatch { get; set; } = true;
 
     /// <summary>Phase 7.3: Enable mixed precision (fp16 forward, fp32 backward). Opt-in.</summary>
+    /// <remarks>Legacy boolean — kept for backward compat. New code should use
+    /// <see cref="MixedPrecisionPolicy"/> for finer-grained control over which dtype
+    /// is used (fp16 vs bf16) and whether autocast is engaged automatically.</remarks>
     public bool EnableMixedPrecision { get; set; }
+
+    /// <summary>
+    /// Mixed-precision routing policy for compute-bound ops (MatMul, Conv2D,
+    /// Attention) under issue #337. Hot-path GPU kernels read this to decide
+    /// whether to dispatch on the standard fp32 path or to cast inputs to the
+    /// lower-precision compute dtype while keeping fp32 master weights.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>Defaults:</b> <see cref="Optimization.MixedPrecisionPolicy.None"/> —
+    /// kernels run in the model's declared dtype (typically fp32). No autocast,
+    /// no loss scaling, no behavior change vs. pre-#337 builds.</para>
+    /// <para><b>Opt-in:</b> set to <see cref="Optimization.MixedPrecisionPolicy.AutoCastBF16"/>
+    /// on Hopper/Ada/A100/Sapphire Rapids — BF16 has the same exponent range
+    /// as fp32 so no loss scaling is required and accuracy stays well within
+    /// noise for transformer training. Use <see cref="Optimization.MixedPrecisionPolicy.AutoCastFP16"/>
+    /// on Ampere or Turing where BF16 isn't natively supported by all ops;
+    /// requires loss scaling to keep small-magnitude gradients from
+    /// underflowing fp16's narrow exponent range.</para>
+    /// <para><b>Per-op opt-out:</b> ops that must preserve numerical accuracy
+    /// (running BN statistics accumulation, softmax denominator) MUST run in
+    /// the master dtype regardless of this policy — they don't honor the
+    /// autocast contract.</para>
+    /// <para>The TF32 path (Ampere+ fp32 → Tensor Cores via TF32 multiply +
+    /// fp32 accumulate) is gated separately by <see cref="DirectGpu.CUDA.CudaDispatchPolicy.AllowTF32"/>
+    /// and runs orthogonally — TF32 is the fp32-codepath speedup, autocast is
+    /// the fp16/bf16-codepath speedup.</para>
+    /// </remarks>
+    public MixedPrecisionPolicy MixedPrecisionPolicy { get; set; }
+        = MixedPrecisionPolicy.None;
 
     /// <summary>
     /// When true, tensor operations route through deterministic code paths — floating-point

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdComplexKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdComplexKernels.cs
@@ -253,6 +253,14 @@ public static class SimdComplexKernels
         Span<double> outR, Span<double> outI)
     {
         int n = inR.Length;
+        // Explicit length guards on all companion spans — ReadVector256 /
+        // WriteVector256 use unchecked Unsafe.Add so a shorter peer span
+        // would read/write past its allocation with undefined behavior.
+        // Match ComplexMultiplyDouble's contract.
+        if (inI.Length != n || outR.Length != n || outI.Length != n)
+            throw new ArgumentException(
+                "All four spans (inR, inI, outR, outI) must have identical length.");
+
         int i = 0;
 #if NET5_0_OR_GREATER
         if (Avx.IsSupported && n >= 4)
@@ -278,6 +286,10 @@ public static class SimdComplexKernels
     public static void ComplexMagnitudeDouble(ReadOnlySpan<double> inR, ReadOnlySpan<double> inI, Span<double> output)
     {
         int n = inR.Length;
+        if (inI.Length != n || output.Length != n)
+            throw new ArgumentException(
+                "All three spans (inR, inI, output) must have identical length.");
+
         int i = 0;
 #if NET5_0_OR_GREATER
         if (Avx.IsSupported && n >= 4)
@@ -301,6 +313,10 @@ public static class SimdComplexKernels
     public static void ComplexMagnitudeSquaredDouble(ReadOnlySpan<double> inR, ReadOnlySpan<double> inI, Span<double> output)
     {
         int n = inR.Length;
+        if (inI.Length != n || output.Length != n)
+            throw new ArgumentException(
+                "All three spans (inR, inI, output) must have identical length.");
+
         int i = 0;
 #if NET5_0_OR_GREATER
         if (Avx.IsSupported && n >= 4)
@@ -325,6 +341,10 @@ public static class SimdComplexKernels
         Span<double> outR, Span<double> outI)
     {
         int n = aR.Length;
+        if (aI.Length != n || bR.Length != n || bI.Length != n || outR.Length != n || outI.Length != n)
+            throw new ArgumentException(
+                "All six spans (aR, aI, bR, bI, outR, outI) must have identical length.");
+
         int i = 0;
 #if NET5_0_OR_GREATER
         if (Avx.IsSupported && n >= 4)
@@ -350,6 +370,10 @@ public static class SimdComplexKernels
         Span<double> outR, Span<double> outI, double scalar)
     {
         int n = inR.Length;
+        if (inI.Length != n || outR.Length != n || outI.Length != n)
+            throw new ArgumentException(
+                "All four spans (inR, inI, outR, outI) must have identical length.");
+
         int i = 0;
 #if NET5_0_OR_GREATER
         if (Avx.IsSupported && n >= 4)
@@ -377,6 +401,10 @@ public static class SimdComplexKernels
         Span<double> outR, Span<double> outI)
     {
         int n = xR.Length;
+        if (xI.Length != n || yR.Length != n || yI.Length != n || outR.Length != n || outI.Length != n)
+            throw new ArgumentException(
+                "All six spans (xR, xI, yR, yI, outR, outI) must have identical length.");
+
         int i = 0;
 #if NET5_0_OR_GREATER
         if (Avx.IsSupported && n >= 4)

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdComplexKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdComplexKernels.cs
@@ -247,6 +247,159 @@ public static class SimdComplexKernels
         }
     }
 
+    /// <summary>SIMD complex conjugate (double): outR = inR, outI = -inI</summary>
+    [MethodImpl(HotInline)]
+    public static void ComplexConjugateDouble(ReadOnlySpan<double> inR, ReadOnlySpan<double> inI,
+        Span<double> outR, Span<double> outI)
+    {
+        int n = inR.Length;
+        int i = 0;
+#if NET5_0_OR_GREATER
+        if (Avx.IsSupported && n >= 4)
+        {
+            var negMask = Vector256.Create(-0.0);
+            int simdLen = n & ~3;
+            for (; i < simdLen; i += 4)
+            {
+                SimdKernels.WriteVector256(outR, i, SimdKernels.ReadVector256(inR, i));
+                SimdKernels.WriteVector256(outI, i, Avx.Xor(SimdKernels.ReadVector256(inI, i), negMask));
+            }
+        }
+#endif
+        for (; i < n; i++)
+        {
+            outR[i] = inR[i];
+            outI[i] = -inI[i];
+        }
+    }
+
+    /// <summary>SIMD complex magnitude (double): out = sqrt(re² + im²)</summary>
+    [MethodImpl(HotInline)]
+    public static void ComplexMagnitudeDouble(ReadOnlySpan<double> inR, ReadOnlySpan<double> inI, Span<double> output)
+    {
+        int n = inR.Length;
+        int i = 0;
+#if NET5_0_OR_GREATER
+        if (Avx.IsSupported && n >= 4)
+        {
+            int simdLen = n & ~3;
+            for (; i < simdLen; i += 4)
+            {
+                var re = SimdKernels.ReadVector256(inR, i);
+                var im = SimdKernels.ReadVector256(inI, i);
+                var magSq = Avx.Add(Avx.Multiply(re, re), Avx.Multiply(im, im));
+                SimdKernels.WriteVector256(output, i, Avx.Sqrt(magSq));
+            }
+        }
+#endif
+        for (; i < n; i++)
+            output[i] = Math.Sqrt(inR[i] * inR[i] + inI[i] * inI[i]);
+    }
+
+    /// <summary>SIMD complex magnitude squared (double): out = re² + im²</summary>
+    [MethodImpl(HotInline)]
+    public static void ComplexMagnitudeSquaredDouble(ReadOnlySpan<double> inR, ReadOnlySpan<double> inI, Span<double> output)
+    {
+        int n = inR.Length;
+        int i = 0;
+#if NET5_0_OR_GREATER
+        if (Avx.IsSupported && n >= 4)
+        {
+            int simdLen = n & ~3;
+            for (; i < simdLen; i += 4)
+            {
+                var re = SimdKernels.ReadVector256(inR, i);
+                var im = SimdKernels.ReadVector256(inI, i);
+                SimdKernels.WriteVector256(output, i, Avx.Add(Avx.Multiply(re, re), Avx.Multiply(im, im)));
+            }
+        }
+#endif
+        for (; i < n; i++)
+            output[i] = inR[i] * inR[i] + inI[i] * inI[i];
+    }
+
+    /// <summary>SIMD complex add (double): outR = aR + bR, outI = aI + bI</summary>
+    [MethodImpl(HotInline)]
+    public static void ComplexAddDouble(ReadOnlySpan<double> aR, ReadOnlySpan<double> aI,
+        ReadOnlySpan<double> bR, ReadOnlySpan<double> bI,
+        Span<double> outR, Span<double> outI)
+    {
+        int n = aR.Length;
+        int i = 0;
+#if NET5_0_OR_GREATER
+        if (Avx.IsSupported && n >= 4)
+        {
+            int simdLen = n & ~3;
+            for (; i < simdLen; i += 4)
+            {
+                SimdKernels.WriteVector256(outR, i, Avx.Add(SimdKernels.ReadVector256(aR, i), SimdKernels.ReadVector256(bR, i)));
+                SimdKernels.WriteVector256(outI, i, Avx.Add(SimdKernels.ReadVector256(aI, i), SimdKernels.ReadVector256(bI, i)));
+            }
+        }
+#endif
+        for (; i < n; i++)
+        {
+            outR[i] = aR[i] + bR[i];
+            outI[i] = aI[i] + bI[i];
+        }
+    }
+
+    /// <summary>SIMD complex scale (double): outR = inR * s, outI = inI * s</summary>
+    [MethodImpl(HotInline)]
+    public static void ComplexScaleDouble(ReadOnlySpan<double> inR, ReadOnlySpan<double> inI,
+        Span<double> outR, Span<double> outI, double scalar)
+    {
+        int n = inR.Length;
+        int i = 0;
+#if NET5_0_OR_GREATER
+        if (Avx.IsSupported && n >= 4)
+        {
+            var s = Vector256.Create(scalar);
+            int simdLen = n & ~3;
+            for (; i < simdLen; i += 4)
+            {
+                SimdKernels.WriteVector256(outR, i, Avx.Multiply(SimdKernels.ReadVector256(inR, i), s));
+                SimdKernels.WriteVector256(outI, i, Avx.Multiply(SimdKernels.ReadVector256(inI, i), s));
+            }
+        }
+#endif
+        for (; i < n; i++)
+        {
+            outR[i] = inR[i] * scalar;
+            outI[i] = inI[i] * scalar;
+        }
+    }
+
+    /// <summary>SIMD cross-spectral density (double): X * conj(Y)</summary>
+    [MethodImpl(HotInline)]
+    public static void ComplexCrossSpectralDouble(ReadOnlySpan<double> xR, ReadOnlySpan<double> xI,
+        ReadOnlySpan<double> yR, ReadOnlySpan<double> yI,
+        Span<double> outR, Span<double> outI)
+    {
+        int n = xR.Length;
+        int i = 0;
+#if NET5_0_OR_GREATER
+        if (Avx.IsSupported && n >= 4)
+        {
+            int simdLen = n & ~3;
+            for (; i < simdLen; i += 4)
+            {
+                var xr = SimdKernels.ReadVector256(xR, i);
+                var xi = SimdKernels.ReadVector256(xI, i);
+                var yr = SimdKernels.ReadVector256(yR, i);
+                var yi = SimdKernels.ReadVector256(yI, i);
+                SimdKernels.WriteVector256(outR, i, Avx.Add(Avx.Multiply(xr, yr), Avx.Multiply(xi, yi)));
+                SimdKernels.WriteVector256(outI, i, Avx.Subtract(Avx.Multiply(xi, yr), Avx.Multiply(xr, yi)));
+            }
+        }
+#endif
+        for (; i < n; i++)
+        {
+            outR[i] = xR[i] * yR[i] + xI[i] * yI[i];
+            outI[i] = xI[i] * yR[i] - xR[i] * yI[i];
+        }
+    }
+
     /// <summary>
     /// SIMD complex conjugate: outR = inR, outI = -inI
     /// </summary>

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemmDouble.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemmDouble.cs
@@ -44,7 +44,34 @@ internal static partial class SimdGemm
 #if NET5_0_OR_GREATER
         if (Avx2.IsSupported && Fma.IsSupported)
         {
-            DgemmAvx2(a, b, c, m, k, n);
+            DgemmAvx2(a, b, c, m, k, n, allowParallel: true);
+            return;
+        }
+#endif
+        DgemmScalar(a, b, c, m, k, n);
+    }
+
+    /// <summary>
+    /// Sequential variant — same kernel as <see cref="Dgemm"/> but never
+    /// spawns inner parallelism. Use when called from inside an already-
+    /// parallel batch loop (e.g. BatchMatMul over batch slices) so the
+    /// thread pool isn't oversubscribed by nested Parallel.For dispatches.
+    /// Companion to <see cref="SgemmSequential"/>; same rationale.
+    /// </summary>
+    internal static void DgemmSequential(
+        ReadOnlySpan<double> a,
+        ReadOnlySpan<double> b,
+        Span<double> c,
+        int m, int k, int n)
+    {
+        if (m <= 0 || n <= 0) return;
+        c.Clear();
+        if (k <= 0) return;
+
+#if NET5_0_OR_GREATER
+        if (Avx2.IsSupported && Fma.IsSupported)
+        {
+            DgemmAvx2(a, b, c, m, k, n, allowParallel: false);
             return;
         }
 #endif
@@ -66,11 +93,12 @@ internal static partial class SimdGemm
         ReadOnlySpan<double> a,
         ReadOnlySpan<double> b,
         Span<double> c,
-        int m, int k, int n)
+        int m, int k, int n,
+        bool allowParallel)
     {
         int numRowBlocks = (m + DgemmBlockSize - 1) / DgemmBlockSize;
         int numColBlocks = (n + DgemmBlockSize - 1) / DgemmBlockSize;
-        bool doParallel = (long)m * n >= 16384 && Environment.ProcessorCount > 1;
+        bool doParallel = allowParallel && (long)m * n >= 16384 && Environment.ProcessorCount > 1;
 
         // Pin once at the top level so the inner kernels can do raw
         // pointer arithmetic — the Span's pointers are already pinned

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdKernels.cs
@@ -230,6 +230,99 @@ namespace AiDotNet.Tensors.Engines.Simd
         }
 
         /// <summary>
+        /// Element-wise max of two double arrays using AVX Max intrinsic (Vector256, 4 lanes).
+        /// Same NaN semantics as the float overload — hardware-defined (Avx.Max returns non-NaN
+        /// operand on collision). PyTorch parity, not IEEE 754.
+        /// </summary>
+        [MethodImpl(HotInline)]
+        public static unsafe void VectorMaxUnsafe(double* a, double* b, double* result, int length)
+        {
+            int i = 0;
+#if NET5_0_OR_GREATER
+            if (Avx.IsSupported && length >= 16)
+            {
+                int simdLength = length & ~15;
+                for (; i < simdLength; i += 16)
+                {
+                    Avx.Store(result + i, Avx.Max(Avx.LoadVector256(a + i), Avx.LoadVector256(b + i)));
+                    Avx.Store(result + i + 4, Avx.Max(Avx.LoadVector256(a + i + 4), Avx.LoadVector256(b + i + 4)));
+                    Avx.Store(result + i + 8, Avx.Max(Avx.LoadVector256(a + i + 8), Avx.LoadVector256(b + i + 8)));
+                    Avx.Store(result + i + 12, Avx.Max(Avx.LoadVector256(a + i + 12), Avx.LoadVector256(b + i + 12)));
+                }
+            }
+            if (Avx.IsSupported && length - i >= 4)
+            {
+                int simdLength = i + ((length - i) & ~3);
+                for (; i < simdLength; i += 4)
+                    Avx.Store(result + i, Avx.Max(Avx.LoadVector256(a + i), Avx.LoadVector256(b + i)));
+            }
+#endif
+            for (; i < length; i++)
+                result[i] = Math.Max(a[i], b[i]);
+        }
+
+        /// <summary>
+        /// Element-wise min of two float arrays using AVX Min intrinsic (Vector256, 8 lanes).
+        /// Same hardware NaN semantics as <see cref="VectorMaxUnsafe(float*, float*, float*, int)"/>.
+        /// </summary>
+        [MethodImpl(HotInline)]
+        public static unsafe void VectorMinUnsafe(float* a, float* b, float* result, int length)
+        {
+            int i = 0;
+#if NET5_0_OR_GREATER
+            if (Avx.IsSupported && length >= 32)
+            {
+                int simdLength = length & ~31;
+                for (; i < simdLength; i += 32)
+                {
+                    Avx.Store(result + i, Avx.Min(Avx.LoadVector256(a + i), Avx.LoadVector256(b + i)));
+                    Avx.Store(result + i + 8, Avx.Min(Avx.LoadVector256(a + i + 8), Avx.LoadVector256(b + i + 8)));
+                    Avx.Store(result + i + 16, Avx.Min(Avx.LoadVector256(a + i + 16), Avx.LoadVector256(b + i + 16)));
+                    Avx.Store(result + i + 24, Avx.Min(Avx.LoadVector256(a + i + 24), Avx.LoadVector256(b + i + 24)));
+                }
+            }
+            if (Avx.IsSupported && length - i >= 8)
+            {
+                int simdLength = i + ((length - i) & ~7);
+                for (; i < simdLength; i += 8)
+                    Avx.Store(result + i, Avx.Min(Avx.LoadVector256(a + i), Avx.LoadVector256(b + i)));
+            }
+#endif
+            for (; i < length; i++)
+                result[i] = MathF.Min(a[i], b[i]);
+        }
+
+        /// <summary>
+        /// Element-wise min of two double arrays using AVX Min intrinsic (Vector256, 4 lanes).
+        /// </summary>
+        [MethodImpl(HotInline)]
+        public static unsafe void VectorMinUnsafe(double* a, double* b, double* result, int length)
+        {
+            int i = 0;
+#if NET5_0_OR_GREATER
+            if (Avx.IsSupported && length >= 16)
+            {
+                int simdLength = length & ~15;
+                for (; i < simdLength; i += 16)
+                {
+                    Avx.Store(result + i, Avx.Min(Avx.LoadVector256(a + i), Avx.LoadVector256(b + i)));
+                    Avx.Store(result + i + 4, Avx.Min(Avx.LoadVector256(a + i + 4), Avx.LoadVector256(b + i + 4)));
+                    Avx.Store(result + i + 8, Avx.Min(Avx.LoadVector256(a + i + 8), Avx.LoadVector256(b + i + 8)));
+                    Avx.Store(result + i + 12, Avx.Min(Avx.LoadVector256(a + i + 12), Avx.LoadVector256(b + i + 12)));
+                }
+            }
+            if (Avx.IsSupported && length - i >= 4)
+            {
+                int simdLength = i + ((length - i) & ~3);
+                for (; i < simdLength; i += 4)
+                    Avx.Store(result + i, Avx.Min(Avx.LoadVector256(a + i), Avx.LoadVector256(b + i)));
+            }
+#endif
+            for (; i < length; i++)
+                result[i] = Math.Min(a[i], b[i]);
+        }
+
+        /// <summary>
         /// Pointer-based VectorSubtract — zero bounds-checking overhead for hot paths.
         /// </summary>
         [MethodImpl(HotInline)]

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdKernels.cs
@@ -922,6 +922,96 @@ namespace AiDotNet.Tensors.Engines.Simd
         }
 
         /// <summary>
+        /// SIMD Round (double) using AVX RoundToNearestInteger on 4-lane Vector256.
+        /// </summary>
+        [MethodImpl(HotInline)]
+        public static unsafe void RoundUnsafe(double* input, double* output, int length)
+        {
+            int i = 0;
+#if NET5_0_OR_GREATER
+            if (Avx.IsSupported && length >= 16)
+            {
+                int simdLength = length & ~15;
+                for (; i < simdLength; i += 16)
+                {
+                    Avx.Store(output + i, Avx.RoundToNearestInteger(Avx.LoadVector256(input + i)));
+                    Avx.Store(output + i + 4, Avx.RoundToNearestInteger(Avx.LoadVector256(input + i + 4)));
+                    Avx.Store(output + i + 8, Avx.RoundToNearestInteger(Avx.LoadVector256(input + i + 8)));
+                    Avx.Store(output + i + 12, Avx.RoundToNearestInteger(Avx.LoadVector256(input + i + 12)));
+                }
+            }
+            if (Avx.IsSupported && length - i >= 4)
+            {
+                int simdLength = i + ((length - i) & ~3);
+                for (; i < simdLength; i += 4)
+                    Avx.Store(output + i, Avx.RoundToNearestInteger(Avx.LoadVector256(input + i)));
+            }
+#endif
+            for (; i < length; i++)
+                output[i] = Math.Round(input[i]);
+        }
+
+        /// <summary>
+        /// SIMD Floor (double) using AVX Floor on 4-lane Vector256.
+        /// </summary>
+        [MethodImpl(HotInline)]
+        public static unsafe void FloorUnsafe(double* input, double* output, int length)
+        {
+            int i = 0;
+#if NET5_0_OR_GREATER
+            if (Avx.IsSupported && length >= 16)
+            {
+                int simdLength = length & ~15;
+                for (; i < simdLength; i += 16)
+                {
+                    Avx.Store(output + i, Avx.Floor(Avx.LoadVector256(input + i)));
+                    Avx.Store(output + i + 4, Avx.Floor(Avx.LoadVector256(input + i + 4)));
+                    Avx.Store(output + i + 8, Avx.Floor(Avx.LoadVector256(input + i + 8)));
+                    Avx.Store(output + i + 12, Avx.Floor(Avx.LoadVector256(input + i + 12)));
+                }
+            }
+            if (Avx.IsSupported && length - i >= 4)
+            {
+                int simdLength = i + ((length - i) & ~3);
+                for (; i < simdLength; i += 4)
+                    Avx.Store(output + i, Avx.Floor(Avx.LoadVector256(input + i)));
+            }
+#endif
+            for (; i < length; i++)
+                output[i] = Math.Floor(input[i]);
+        }
+
+        /// <summary>
+        /// SIMD Ceiling (double) using AVX Ceiling on 4-lane Vector256.
+        /// </summary>
+        [MethodImpl(HotInline)]
+        public static unsafe void CeilingUnsafe(double* input, double* output, int length)
+        {
+            int i = 0;
+#if NET5_0_OR_GREATER
+            if (Avx.IsSupported && length >= 16)
+            {
+                int simdLength = length & ~15;
+                for (; i < simdLength; i += 16)
+                {
+                    Avx.Store(output + i, Avx.Ceiling(Avx.LoadVector256(input + i)));
+                    Avx.Store(output + i + 4, Avx.Ceiling(Avx.LoadVector256(input + i + 4)));
+                    Avx.Store(output + i + 8, Avx.Ceiling(Avx.LoadVector256(input + i + 8)));
+                    Avx.Store(output + i + 12, Avx.Ceiling(Avx.LoadVector256(input + i + 12)));
+                }
+            }
+            if (Avx.IsSupported && length - i >= 4)
+            {
+                int simdLength = i + ((length - i) & ~3);
+                for (; i < simdLength; i += 4)
+                    Avx.Store(output + i, Avx.Ceiling(Avx.LoadVector256(input + i)));
+            }
+#endif
+            for (; i < length; i++)
+                output[i] = Math.Ceiling(input[i]);
+        }
+
+        /// <summary>
         /// SIMD Reciprocal: 1/x using AVX exact division (Avx.Divide).
         /// </summary>
         [MethodImpl(HotInline)]

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdKernels.cs
@@ -198,10 +198,17 @@ namespace AiDotNet.Tensors.Engines.Simd
 
         /// <summary>
         /// Element-wise max of two arrays using AVX Max intrinsic.
-        /// NaN semantics: follows hardware behavior (AVX maxps returns non-NaN operand).
-        /// This matches PyTorch torch.max behavior and is the industry standard for
-        /// performance-critical SIMD paths. Use MathF.Max for IEEE 754 NaN propagation.
         /// </summary>
+        /// <remarks>
+        /// <para><b>AVX selection semantics (per Intel SDM MAXPS):</b> when either
+        /// operand is NaN — or both are ±0 with any sign combination — the second
+        /// operand (b) is written to the result. Otherwise the larger value wins.
+        /// The scalar tail mirrors this behaviour so SIMD body and remainder
+        /// produce identical results for the same input regardless of length.</para>
+        /// <para>This matches PyTorch <c>torch.max</c> behaviour and is the industry
+        /// standard for performance-critical SIMD paths. Use <c>MathF.Max</c>
+        /// when IEEE 754 NaN propagation / signed-zero ordering is required.</para>
+        /// </remarks>
         [MethodImpl(HotInline)]
         public static unsafe void VectorMaxUnsafe(float* a, float* b, float* result, int length)
         {
@@ -225,15 +232,18 @@ namespace AiDotNet.Tensors.Engines.Simd
                     Avx.Store(result + i, Avx.Max(Avx.LoadVector256(a + i), Avx.LoadVector256(b + i)));
             }
 #endif
-            // Scalar tail mirrors AVX's NaN semantics — Avx.Max returns the
-            // SECOND operand when either input is NaN (Intel SDM MAXPS), but
-            // MathF.Max propagates NaN per IEEE 754. Using MathF.Max directly
-            // would make the kernel produce length-dependent results when NaNs
-            // are present (SIMD body picks b[i], scalar tail returns NaN).
+            // Scalar tail mirrors AVX's NaN AND signed-zero semantics — Avx.Max
+            // returns the SECOND operand both when either input is NaN AND when
+            // both are ±0 with any sign combination (Intel SDM MAXPS). MathF.Max
+            // propagates NaN per IEEE 754 and orders -0 < +0 per IEEE 754:2019,
+            // so using it directly would make the kernel produce length-dependent
+            // results for (NaN, _), (_, NaN), and (+0, -0)-style inputs (SIMD body
+            // picks b[i], scalar tail returns the IEEE 754-preferred value instead).
             for (; i < length; i++)
             {
                 float ai = a[i], bi = b[i];
-                result[i] = float.IsNaN(ai) || float.IsNaN(bi) ? bi : MathF.Max(ai, bi);
+                bool useB = float.IsNaN(ai) || float.IsNaN(bi) || (ai == 0f && bi == 0f);
+                result[i] = useB ? bi : MathF.Max(ai, bi);
             }
         }
 
@@ -265,17 +275,20 @@ namespace AiDotNet.Tensors.Engines.Simd
                     Avx.Store(result + i, Avx.Max(Avx.LoadVector256(a + i), Avx.LoadVector256(b + i)));
             }
 #endif
-            // Scalar tail mirrors AVX's NaN semantics — see float overload above.
+            // Scalar tail mirrors AVX's NaN AND signed-zero semantics — see float overload above.
             for (; i < length; i++)
             {
                 double ai = a[i], bi = b[i];
-                result[i] = double.IsNaN(ai) || double.IsNaN(bi) ? bi : Math.Max(ai, bi);
+                bool useB = double.IsNaN(ai) || double.IsNaN(bi) || (ai == 0.0 && bi == 0.0);
+                result[i] = useB ? bi : Math.Max(ai, bi);
             }
         }
 
         /// <summary>
         /// Element-wise min of two float arrays using AVX Min intrinsic (Vector256, 8 lanes).
-        /// Same hardware NaN semantics as <see cref="VectorMaxUnsafe(float*, float*, float*, int)"/>.
+        /// Same hardware NaN + signed-zero semantics as
+        /// <see cref="VectorMaxUnsafe(float*, float*, float*, int)"/>: the second
+        /// operand wins on either NaN-present or both-zero inputs.
         /// </summary>
         [MethodImpl(HotInline)]
         public static unsafe void VectorMinUnsafe(float* a, float* b, float* result, int length)
@@ -300,16 +313,18 @@ namespace AiDotNet.Tensors.Engines.Simd
                     Avx.Store(result + i, Avx.Min(Avx.LoadVector256(a + i), Avx.LoadVector256(b + i)));
             }
 #endif
-            // Scalar tail mirrors AVX's NaN semantics — see VectorMaxUnsafe(float*) above.
+            // Scalar tail mirrors AVX's NaN + signed-zero semantics — see VectorMaxUnsafe(float*) above.
             for (; i < length; i++)
             {
                 float ai = a[i], bi = b[i];
-                result[i] = float.IsNaN(ai) || float.IsNaN(bi) ? bi : MathF.Min(ai, bi);
+                bool useB = float.IsNaN(ai) || float.IsNaN(bi) || (ai == 0f && bi == 0f);
+                result[i] = useB ? bi : MathF.Min(ai, bi);
             }
         }
 
         /// <summary>
         /// Element-wise min of two double arrays using AVX Min intrinsic (Vector256, 4 lanes).
+        /// Same hardware NaN + signed-zero semantics as the float Max/Min overloads.
         /// </summary>
         [MethodImpl(HotInline)]
         public static unsafe void VectorMinUnsafe(double* a, double* b, double* result, int length)
@@ -334,11 +349,12 @@ namespace AiDotNet.Tensors.Engines.Simd
                     Avx.Store(result + i, Avx.Min(Avx.LoadVector256(a + i), Avx.LoadVector256(b + i)));
             }
 #endif
-            // Scalar tail mirrors AVX's NaN semantics — see VectorMaxUnsafe(float*) above.
+            // Scalar tail mirrors AVX's NaN + signed-zero semantics — see VectorMaxUnsafe(float*) above.
             for (; i < length; i++)
             {
                 double ai = a[i], bi = b[i];
-                result[i] = double.IsNaN(ai) || double.IsNaN(bi) ? bi : Math.Min(ai, bi);
+                bool useB = double.IsNaN(ai) || double.IsNaN(bi) || (ai == 0.0 && bi == 0.0);
+                result[i] = useB ? bi : Math.Min(ai, bi);
             }
         }
 

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdKernels.cs
@@ -225,8 +225,16 @@ namespace AiDotNet.Tensors.Engines.Simd
                     Avx.Store(result + i, Avx.Max(Avx.LoadVector256(a + i), Avx.LoadVector256(b + i)));
             }
 #endif
+            // Scalar tail mirrors AVX's NaN semantics — Avx.Max returns the
+            // SECOND operand when either input is NaN (Intel SDM MAXPS), but
+            // MathF.Max propagates NaN per IEEE 754. Using MathF.Max directly
+            // would make the kernel produce length-dependent results when NaNs
+            // are present (SIMD body picks b[i], scalar tail returns NaN).
             for (; i < length; i++)
-                result[i] = MathF.Max(a[i], b[i]);
+            {
+                float ai = a[i], bi = b[i];
+                result[i] = float.IsNaN(ai) || float.IsNaN(bi) ? bi : MathF.Max(ai, bi);
+            }
         }
 
         /// <summary>
@@ -257,8 +265,12 @@ namespace AiDotNet.Tensors.Engines.Simd
                     Avx.Store(result + i, Avx.Max(Avx.LoadVector256(a + i), Avx.LoadVector256(b + i)));
             }
 #endif
+            // Scalar tail mirrors AVX's NaN semantics — see float overload above.
             for (; i < length; i++)
-                result[i] = Math.Max(a[i], b[i]);
+            {
+                double ai = a[i], bi = b[i];
+                result[i] = double.IsNaN(ai) || double.IsNaN(bi) ? bi : Math.Max(ai, bi);
+            }
         }
 
         /// <summary>
@@ -288,8 +300,12 @@ namespace AiDotNet.Tensors.Engines.Simd
                     Avx.Store(result + i, Avx.Min(Avx.LoadVector256(a + i), Avx.LoadVector256(b + i)));
             }
 #endif
+            // Scalar tail mirrors AVX's NaN semantics — see VectorMaxUnsafe(float*) above.
             for (; i < length; i++)
-                result[i] = MathF.Min(a[i], b[i]);
+            {
+                float ai = a[i], bi = b[i];
+                result[i] = float.IsNaN(ai) || float.IsNaN(bi) ? bi : MathF.Min(ai, bi);
+            }
         }
 
         /// <summary>
@@ -318,8 +334,12 @@ namespace AiDotNet.Tensors.Engines.Simd
                     Avx.Store(result + i, Avx.Min(Avx.LoadVector256(a + i), Avx.LoadVector256(b + i)));
             }
 #endif
+            // Scalar tail mirrors AVX's NaN semantics — see VectorMaxUnsafe(float*) above.
             for (; i < length; i++)
-                result[i] = Math.Min(a[i], b[i]);
+            {
+                double ai = a[i], bi = b[i];
+                result[i] = double.IsNaN(ai) || double.IsNaN(bi) ? bi : Math.Min(ai, bi);
+            }
         }
 
         /// <summary>

--- a/src/AiDotNet.Tensors/Helpers/TensorAllocator.cs
+++ b/src/AiDotNet.Tensors/Helpers/TensorAllocator.cs
@@ -26,6 +26,43 @@ public static class TensorAllocator
     public const int ArrayPoolThresholdValue = ArrayPoolThreshold;
 
     /// <summary>
+    /// Creates a zero-initialized tensor with the given shape that's pinned
+    /// to the current <see cref="TensorArena"/>'s long-lived tier. Pinned
+    /// allocations survive <see cref="TensorArena.Reset"/> — use this for
+    /// model weights (layer EnsureInitialized), optimizer state (Adam m / v),
+    /// running BatchNorm statistics, anything that's part of the network's
+    /// learnable state and must NOT be re-issued as scratch on the next
+    /// training iteration. Falls back to a plain <see cref="Tensor{T}"/>
+    /// allocation when no arena is active (graceful degradation —
+    /// non-arena callers get GC-tracked allocation, same as
+    /// <see cref="Rent{T}(int[])"/> with TensorPool disabled).
+    /// </summary>
+    public static Tensor<T> RentPinned<T>(int[] shape)
+    {
+        int totalSize = 1;
+        for (int i = 0; i < shape.Length; i++)
+            totalSize = checked(totalSize * shape[i]);
+        if (totalSize == 0) return new Tensor<T>(shape);
+
+        var arena = TensorArena.Current;
+        if (arena != null)
+        {
+            T[]? pinnedArray = arena.TryAllocatePinned<T>(totalSize);
+            if (pinnedArray != null)
+            {
+                var memory = new Memory<T>(pinnedArray, 0, totalSize);
+                return Tensor<T>.FromMemory(memory, shape);
+            }
+        }
+
+        // No active arena — graceful degradation to standard CLR allocation.
+        // The caller's "this lives across iterations" contract still holds
+        // because plain Tensor<T> backing arrays aren't touched by Reset
+        // (they were never in any arena pool to begin with).
+        return new Tensor<T>(shape);
+    }
+
+    /// <summary>
     /// Creates a zero-initialized tensor with the given shape.
     /// Large tensors use ArrayPool to reduce GC pressure; small-medium tensors
     /// use standard CLR allocation. All paths return zeroed memory.

--- a/src/AiDotNet.Tensors/Helpers/TensorAllocator.cs
+++ b/src/AiDotNet.Tensors/Helpers/TensorAllocator.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Runtime.CompilerServices;
+using AiDotNet.Tensors.Engines.Profiling.Memory;
 using AiDotNet.Tensors.LinearAlgebra;
 
 namespace AiDotNet.Tensors.Helpers;
@@ -44,79 +45,47 @@ public static class TensorAllocator
             totalSize = checked(totalSize * shape[i]);
         if (totalSize == 0) return new Tensor<T>(shape);
 
+        // MemoryProfiler hook — pinned tier is always a fresh allocation
+        // (TensorArena's pinned list grows monotonically; the fallback is
+        // `new Tensor<T>`). Mirror Rent<T>'s pattern: record on every path
+        // that actually allocates so CurrentBytes tracks pinned weights /
+        // optimizer state alongside scratch tensors instead of silently
+        // undercounting.
+        long bytesIfTracking = (long)totalSize * Unsafe.SizeOf<T>();
+
         var arena = TensorArena.Current;
         if (arena != null)
         {
             T[]? pinnedArray = arena.TryAllocatePinned<T>(totalSize);
             if (pinnedArray != null)
             {
+                MemoryProfiler.RecordAllocation(
+                    "TensorAllocator.Pinned", bytesIfTracking, shape, typeof(T).Name);
                 var memory = new Memory<T>(pinnedArray, 0, totalSize);
                 return Tensor<T>.FromMemory(memory, shape);
             }
         }
 
-        // Streaming auto-engage for large pinned allocations. When a single
-        // tensor exceeds StreamingThresholdElements (100M elements ≈ 800 MB
-        // for double, 400 MB for float — matches the 125M-param threshold
-        // the model layer uses for ParameterBuffer skip), route through
-        // WeightRegistry.AllocateStreaming so the GPU-offload manager has
-        // a chance to evict cold weights to host RAM / disk and keep peak
-        // GC heap pressure bounded. The streaming pool itself decides
-        // whether to actually evict; this just makes the allocation visible
-        // to it. Element-type gate matches AllocateStreaming's contract
-        // (float, double, int, long, Half, BFloat16 only); other Ts skip
-        // streaming and fall through to plain `new Tensor<T>(shape)`.
-        if (totalSize >= StreamingThresholdElements && WeightRegistryAcceptsType<T>())
-        {
-            try
-            {
-                return WeightRegistry.AllocateStreaming<T>(shape);
-            }
-            catch (ObjectDisposedException)
-            {
-                // Streaming pool has been disposed — graceful fallback to plain
-                // allocation so the caller still gets a usable tensor.
-            }
-            // NOTE: deliberately do NOT catch ArgumentException /
-            // NotSupportedException / InvalidOperationException / OutOfMemoryException
-            // from AllocateStreaming. Those signal real problems (invalid shape, type
-            // not actually streamable, byteCount > int.MaxValue forcing chunking,
-            // pool budget exceeded) that the caller needs to see — silently falling
-            // back to `new Tensor<T>(shape)` would replace an actionable error with
-            // a less informative OOM on a tensor the runtime can't actually hold.
-        }
+        // NOTE: an earlier draft of this method tried to auto-engage
+        // WeightRegistry.AllocateStreaming for tensors above ~100M elements,
+        // but AllocateStreaming only RESERVES pool budget — it requires a
+        // follow-on RegisterWeight call to actually commit the bytes into
+        // the streaming pool and drop the in-memory storage. RentPinned
+        // callers (LayerBase.EnsureInitialized, Adam moments, BN running
+        // stats) hold the tensor as plain GC-managed memory and never
+        // perform that handshake, so the auto-engage stranded the
+        // reservation without buying any streaming benefit. Use the
+        // explicit WeightRegistry API instead when a caller really wants
+        // pool-backed streaming.
 
         // No active arena — graceful degradation to standard CLR allocation.
         // The caller's "this lives across iterations" contract still holds
         // because plain Tensor<T> backing arrays aren't touched by Reset
         // (they were never in any arena pool to begin with).
+        MemoryProfiler.RecordAllocation(
+            "TensorAllocator.Pinned", bytesIfTracking, shape, typeof(T).Name);
         return new Tensor<T>(shape);
     }
-
-    /// <summary>
-    /// Element-count threshold above which <see cref="RentPinned{T}"/> routes
-    /// through <see cref="WeightRegistry.AllocateStreaming{T}"/>
-    /// instead of plain CLR allocation. 100M elements is the same order as the
-    /// 125M-param ParameterBuffer-skip threshold the model layer uses — picks
-    /// up the FC layers in BERT-large / VGG16-BN / GPT-3 attention banks
-    /// without engaging streaming for small Conv kernels (~10K elements).
-    /// </summary>
-    private const int StreamingThresholdElements = 100_000_000;
-
-    /// <summary>
-    /// Delegates to <see cref="WeightRegistry.IsStreamableType{T}"/>
-    /// — the single source of truth for which element types
-    /// <see cref="WeightRegistry.AllocateStreaming{T}"/>
-    /// can serialize. Keeping the streamable-type table in one place means
-    /// adding a new supported T (e.g., when BF8 arrives) only requires
-    /// updating <c>WeightRegistry.StreamableTypeSize</c>; this gate picks
-    /// up the change automatically. Previously this lived as a hand-written
-    /// duplicate here and silently drifted out of sync (BFloat16 was
-    /// streamable in WeightRegistry but excluded here, causing fp16-like
-    /// large weights to skip streaming and OOM at <c>new Tensor&lt;T&gt;()</c>).
-    /// </summary>
-    private static bool WeightRegistryAcceptsType<T>() =>
-        WeightRegistry.IsStreamableType<T>();
 
     /// <summary>
     /// Creates a zero-initialized tensor with the given shape.
@@ -150,7 +119,7 @@ public static class TensorAllocator
         if (!TensorPool.Enabled || TensorPool.ForceFreshAllocations || totalSize == 0)
         {
             if (bytesIfTracking > 0)
-                AiDotNet.Tensors.Engines.Profiling.Memory.MemoryProfiler.RecordAllocation(
+                MemoryProfiler.RecordAllocation(
                     "TensorAllocator", bytesIfTracking, shape, typeof(T).Name);
             return new Tensor<T>(shape);
         }
@@ -198,7 +167,7 @@ public static class TensorAllocator
         // unconditionally here (RentUninitialized records on the same path).
         if (totalSize >= ArrayPoolThreshold)
         {
-            AiDotNet.Tensors.Engines.Profiling.Memory.MemoryProfiler.RecordAllocation(
+            MemoryProfiler.RecordAllocation(
                 "TensorAllocator", bytesIfTracking, shape, typeof(T).Name);
             T[] pooled = ArrayPool<T>.Shared.Rent(totalSize);
             // Issue #311: clear the entire array, including the padding
@@ -210,13 +179,13 @@ public static class TensorAllocator
         }
 
         // Tier 4: Standard managed allocation for small tensors — always a fresh alloc.
-        AiDotNet.Tensors.Engines.Profiling.Memory.MemoryProfiler.RecordAllocation(
+        MemoryProfiler.RecordAllocation(
             "TensorAllocator", bytesIfTracking, shape, typeof(T).Name);
         T[] arr = new T[totalSize];
         var mem = new Memory<T>(arr);
         return Tensor<T>.FromMemory(mem, shape);
 #else
-        AiDotNet.Tensors.Engines.Profiling.Memory.MemoryProfiler.RecordAllocation(
+        MemoryProfiler.RecordAllocation(
             "TensorAllocator", bytesIfTracking, shape, typeof(T).Name);
         return new Tensor<T>(shape);
 #endif

--- a/src/AiDotNet.Tensors/Helpers/TensorAllocator.cs
+++ b/src/AiDotNet.Tensors/Helpers/TensorAllocator.cs
@@ -88,6 +88,101 @@ public static class TensorAllocator
     }
 
     /// <summary>
+    /// Rents a tensor whose storage is registered with the active GPU
+    /// backend's offload allocator — pinned-host memory DMA-mapped to the
+    /// GPU (no per-op cudaMemcpy on read) or managed/unified memory (driver
+    /// handles migration). Use for weights, optimizer state (Adam m / v),
+    /// running BatchNorm statistics on the GPU training path: every kernel
+    /// reads/writes the pinned region directly via the DMA mapping, and
+    /// CPU code sees the updated values without an explicit download.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>Fallback behavior:</b>
+    /// <list type="bullet">
+    /// <item>No GPU offload allocator registered (CPU-only host, or GPU
+    /// engine but no backend yet) → falls back to <see cref="RentPinned{T}"/>
+    /// (CPU pinned tier). The returned tensor still survives
+    /// <see cref="TensorArena.Reset"/>, so the model can keep its weights
+    /// stable across iterations even when no GPU is available.</item>
+    /// <item>GpuOffload allocator is registered but throws (out of GPU
+    /// memory, allocator disposed) → falls back to CPU <see cref="RentPinned{T}"/>
+    /// and the caller proceeds on CPU. No silent OOM — the underlying
+    /// exception is rethrown after the fallback succeeds.</item>
+    /// </list></para>
+    /// <para><b>Initial state:</b> the returned tensor's data is zero-initialized
+    /// (same contract as <see cref="Rent{T}(int[])"/>). Host writes to the
+    /// returned tensor's <see cref="Tensor{T}.Data"/> propagate to GPU reads via
+    /// the DMA mapping (pinned scheme) or driver-managed migration
+    /// (managed scheme). GPU kernel writes are visible to CPU code on the
+    /// next access (with a host-side fence for write-after-write ordering
+    /// on the kernel-launch stream).</para>
+    /// <para><b>Lifetime:</b> registered with <see cref="WeightRegistry"/> and
+    /// pool-pinned in <see cref="TensorArena"/>. Survives Reset. The GPU
+    /// memory is freed when the tensor is collected by GC (via the registry's
+    /// finalizer-tracked handle) or when <see cref="WeightRegistry.UnregisterWeight{T}"/>
+    /// is called explicitly.</para>
+    /// </remarks>
+    public static Tensor<T> RentPinnedOnGpu<T>(int[] shape)
+    {
+        int totalSize = 1;
+        for (int i = 0; i < shape.Length; i++)
+            totalSize = checked(totalSize * shape[i]);
+        if (totalSize == 0) return new Tensor<T>(shape);
+
+        // No GPU offload allocator registered → CPU pinned fallback. Same
+        // semantics as RentPinned (survives Reset), so consumer code that
+        // unconditionally calls RentPinnedOnGpu still works on CPU-only hosts.
+        var allocator = WeightRegistry.OffloadAllocator;
+        if (allocator is null || !allocator.IsAvailable)
+            return RentPinned<T>(shape);
+
+        // Streamable-type gate matches the WeightRegistry contract — non-
+        // streamable element types (decimal, custom structs) can't be
+        // serialized to the pinned-host stage buffer that RegisterWeight uses.
+        if (!WeightRegistry.IsStreamableType<T>())
+            return RentPinned<T>(shape);
+
+        long bytesIfTracking = (long)totalSize * Unsafe.SizeOf<T>();
+
+        try
+        {
+            // Construct a zero-initialized tensor and register it under the
+            // GpuOffload lifetime. RegisterWeight handles allocator dispatch,
+            // copies the (zero-initialized) bytes into the pinned region,
+            // and persists the OffloadDevicePointer / OffloadHostPointer
+            // metadata on the tensor for later kernel launches.
+            var tensor = new Tensor<T>(shape)
+            {
+                Lifetime = WeightLifetime.GpuOffload,
+            };
+            WeightRegistry.RegisterWeight(tensor);
+
+            // After RegisterWeight, the tensor's data lives in pinned host
+            // memory DMA-mapped to the GPU. Lifetime stays GpuOffload (the
+            // registry does not flip back to Default on success — only on
+            // allocator-unavailable fallback inside the registry, which we
+            // already short-circuited above).
+            MemoryProfiler.RecordAllocation(
+                "TensorAllocator.PinnedOnGpu", bytesIfTracking, shape, typeof(T).Name);
+            return tensor;
+        }
+        catch (NotSupportedException)
+        {
+            // Per-tensor size > int.MaxValue (the offload stage byte[] limit),
+            // unsupported element type, or backend doesn't support the lifetime.
+            // Caller-side chunking is the documented remedy; the CPU pinned
+            // fallback at least lets the model run.
+            return RentPinned<T>(shape);
+        }
+        catch (InvalidOperationException)
+        {
+            // Backend in a bad state (e.g., already-disposed allocator). Falling
+            // back to CPU is non-fatal for the train step.
+            return RentPinned<T>(shape);
+        }
+    }
+
+    /// <summary>
     /// Creates a zero-initialized tensor with the given shape.
     /// Large tensors use ArrayPool to reduce GC pressure; small-medium tensors
     /// use standard CLR allocation. All paths return zeroed memory.

--- a/src/AiDotNet.Tensors/Helpers/TensorAllocator.cs
+++ b/src/AiDotNet.Tensors/Helpers/TensorAllocator.cs
@@ -40,9 +40,15 @@ public static class TensorAllocator
     /// </summary>
     public static Tensor<T> RentPinned<T>(int[] shape)
     {
+        if (shape is null) throw new ArgumentNullException(nameof(shape));
         int totalSize = 1;
         for (int i = 0; i < shape.Length; i++)
+        {
+            if (shape[i] < 0)
+                throw new ArgumentOutOfRangeException(nameof(shape),
+                    $"shape[{i}] = {shape[i]}; shape dimensions must be non-negative.");
             totalSize = checked(totalSize * shape[i]);
+        }
         if (totalSize == 0) return new Tensor<T>(shape);
 
         // MemoryProfiler hook — pinned tier is always a fresh allocation

--- a/src/AiDotNet.Tensors/Helpers/TensorAllocator.cs
+++ b/src/AiDotNet.Tensors/Helpers/TensorAllocator.cs
@@ -70,14 +70,20 @@ public static class TensorAllocator
         {
             try
             {
-                return AiDotNet.Tensors.LinearAlgebra.WeightRegistry.AllocateStreaming<T>(shape);
+                return WeightRegistry.AllocateStreaming<T>(shape);
             }
-            catch
+            catch (ObjectDisposedException)
             {
-                // Streaming pool failure (budget exceeded, pool disposed, etc.)
-                // is non-fatal — fall through to plain allocation so the
-                // caller still gets a usable tensor.
+                // Streaming pool has been disposed — graceful fallback to plain
+                // allocation so the caller still gets a usable tensor.
             }
+            // NOTE: deliberately do NOT catch ArgumentException /
+            // NotSupportedException / InvalidOperationException / OutOfMemoryException
+            // from AllocateStreaming. Those signal real problems (invalid shape, type
+            // not actually streamable, byteCount > int.MaxValue forcing chunking,
+            // pool budget exceeded) that the caller needs to see — silently falling
+            // back to `new Tensor<T>(shape)` would replace an actionable error with
+            // a less informative OOM on a tensor the runtime can't actually hold.
         }
 
         // No active arena — graceful degradation to standard CLR allocation.
@@ -89,7 +95,7 @@ public static class TensorAllocator
 
     /// <summary>
     /// Element-count threshold above which <see cref="RentPinned{T}"/> routes
-    /// through <see cref="AiDotNet.Tensors.LinearAlgebra.WeightRegistry.AllocateStreaming{T}"/>
+    /// through <see cref="WeightRegistry.AllocateStreaming{T}"/>
     /// instead of plain CLR allocation. 100M elements is the same order as the
     /// 125M-param ParameterBuffer-skip threshold the model layer uses — picks
     /// up the FC layers in BERT-large / VGG16-BN / GPT-3 attention banks
@@ -98,20 +104,19 @@ public static class TensorAllocator
     private const int StreamingThresholdElements = 100_000_000;
 
     /// <summary>
-    /// Mirrors <see cref="AiDotNet.Tensors.LinearAlgebra.WeightRegistry.AllocateStreaming{T}"/>'s
-    /// supported-type whitelist so <see cref="RentPinned{T}"/> can skip the
-    /// streaming attempt for types it would throw on. Keep in sync with the
-    /// <c>IsStreamableType</c> check inside that method.
+    /// Delegates to <see cref="WeightRegistry.IsStreamableType{T}"/>
+    /// — the single source of truth for which element types
+    /// <see cref="WeightRegistry.AllocateStreaming{T}"/>
+    /// can serialize. Keeping the streamable-type table in one place means
+    /// adding a new supported T (e.g., when BF8 arrives) only requires
+    /// updating <c>WeightRegistry.StreamableTypeSize</c>; this gate picks
+    /// up the change automatically. Previously this lived as a hand-written
+    /// duplicate here and silently drifted out of sync (BFloat16 was
+    /// streamable in WeightRegistry but excluded here, causing fp16-like
+    /// large weights to skip streaming and OOM at <c>new Tensor&lt;T&gt;()</c>).
     /// </summary>
-    private static bool WeightRegistryAcceptsType<T>()
-    {
-        var t = typeof(T);
-        return t == typeof(float) || t == typeof(double) || t == typeof(int) || t == typeof(long)
-#if NET5_0_OR_GREATER
-            || t == typeof(System.Half)
-#endif
-            ;
-    }
+    private static bool WeightRegistryAcceptsType<T>() =>
+        WeightRegistry.IsStreamableType<T>();
 
     /// <summary>
     /// Creates a zero-initialized tensor with the given shape.

--- a/src/AiDotNet.Tensors/Helpers/TensorAllocator.cs
+++ b/src/AiDotNet.Tensors/Helpers/TensorAllocator.cs
@@ -55,11 +55,62 @@ public static class TensorAllocator
             }
         }
 
+        // Streaming auto-engage for large pinned allocations. When a single
+        // tensor exceeds StreamingThresholdElements (100M elements ≈ 800 MB
+        // for double, 400 MB for float — matches the 125M-param threshold
+        // the model layer uses for ParameterBuffer skip), route through
+        // WeightRegistry.AllocateStreaming so the GPU-offload manager has
+        // a chance to evict cold weights to host RAM / disk and keep peak
+        // GC heap pressure bounded. The streaming pool itself decides
+        // whether to actually evict; this just makes the allocation visible
+        // to it. Element-type gate matches AllocateStreaming's contract
+        // (float, double, int, long, Half, BFloat16 only); other Ts skip
+        // streaming and fall through to plain `new Tensor<T>(shape)`.
+        if (totalSize >= StreamingThresholdElements && WeightRegistryAcceptsType<T>())
+        {
+            try
+            {
+                return AiDotNet.Tensors.LinearAlgebra.WeightRegistry.AllocateStreaming<T>(shape);
+            }
+            catch
+            {
+                // Streaming pool failure (budget exceeded, pool disposed, etc.)
+                // is non-fatal — fall through to plain allocation so the
+                // caller still gets a usable tensor.
+            }
+        }
+
         // No active arena — graceful degradation to standard CLR allocation.
         // The caller's "this lives across iterations" contract still holds
         // because plain Tensor<T> backing arrays aren't touched by Reset
         // (they were never in any arena pool to begin with).
         return new Tensor<T>(shape);
+    }
+
+    /// <summary>
+    /// Element-count threshold above which <see cref="RentPinned{T}"/> routes
+    /// through <see cref="AiDotNet.Tensors.LinearAlgebra.WeightRegistry.AllocateStreaming{T}"/>
+    /// instead of plain CLR allocation. 100M elements is the same order as the
+    /// 125M-param ParameterBuffer-skip threshold the model layer uses — picks
+    /// up the FC layers in BERT-large / VGG16-BN / GPT-3 attention banks
+    /// without engaging streaming for small Conv kernels (~10K elements).
+    /// </summary>
+    private const int StreamingThresholdElements = 100_000_000;
+
+    /// <summary>
+    /// Mirrors <see cref="AiDotNet.Tensors.LinearAlgebra.WeightRegistry.AllocateStreaming{T}"/>'s
+    /// supported-type whitelist so <see cref="RentPinned{T}"/> can skip the
+    /// streaming attempt for types it would throw on. Keep in sync with the
+    /// <c>IsStreamableType</c> check inside that method.
+    /// </summary>
+    private static bool WeightRegistryAcceptsType<T>()
+    {
+        var t = typeof(T);
+        return t == typeof(float) || t == typeof(double) || t == typeof(int) || t == typeof(long)
+#if NET5_0_OR_GREATER
+            || t == typeof(System.Half)
+#endif
+            ;
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Helpers/TensorAllocator.cs
+++ b/src/AiDotNet.Tensors/Helpers/TensorAllocator.cs
@@ -110,10 +110,15 @@ public static class TensorAllocator
     /// (CPU pinned tier). The returned tensor still survives
     /// <see cref="TensorArena.Reset"/>, so the model can keep its weights
     /// stable across iterations even when no GPU is available.</item>
-    /// <item>GpuOffload allocator is registered but throws (out of GPU
-    /// memory, allocator disposed) → falls back to CPU <see cref="RentPinned{T}"/>
-    /// and the caller proceeds on CPU. No silent OOM — the underlying
-    /// exception is rethrown after the fallback succeeds.</item>
+    /// <item>GpuOffload allocator is registered but throws
+    /// <see cref="NotSupportedException"/> (per-tensor size &gt;
+    /// <see cref="int.MaxValue"/>, element type not streamable, backend
+    /// doesn't support the lifetime) or <see cref="InvalidOperationException"/>
+    /// (allocator in a bad state) → caught and downgraded to CPU
+    /// <see cref="RentPinned{T}"/> fallback. The training step continues
+    /// on CPU instead of failing. Critical exceptions (<see cref="OutOfMemoryException"/>,
+    /// <see cref="System.Threading.ThreadAbortException"/>, etc.) propagate
+    /// — silent CPU drift would mask a real allocation failure.</item>
     /// </list></para>
     /// <para><b>Initial state:</b> the returned tensor's data is zero-initialized
     /// (same contract as <see cref="Rent{T}(int[])"/>). Host writes to the
@@ -122,17 +127,26 @@ public static class TensorAllocator
     /// (managed scheme). GPU kernel writes are visible to CPU code on the
     /// next access (with a host-side fence for write-after-write ordering
     /// on the kernel-launch stream).</para>
-    /// <para><b>Lifetime:</b> registered with <see cref="WeightRegistry"/> and
-    /// pool-pinned in <see cref="TensorArena"/>. Survives Reset. The GPU
-    /// memory is freed when the tensor is collected by GC (via the registry's
-    /// finalizer-tracked handle) or when <see cref="WeightRegistry.UnregisterWeight{T}"/>
-    /// is called explicitly.</para>
+    /// <para><b>Lifetime:</b> registered with <see cref="WeightRegistry"/>;
+    /// the GPU memory is freed when the tensor is collected by GC (via the
+    /// registry's finalizer-tracked handle) or when
+    /// <see cref="WeightRegistry.UnregisterWeight{T}"/> is called explicitly.
+    /// The GPU-resident path does NOT touch the <see cref="TensorArena"/>
+    /// pinned tier (the OffloadHostPointer lives outside any managed array
+    /// pool); the fallback CPU path DOES use the arena pinned tier and
+    /// survives <see cref="TensorArena.Reset"/> there.</para>
     /// </remarks>
     public static Tensor<T> RentPinnedOnGpu<T>(int[] shape)
     {
+        if (shape is null) throw new ArgumentNullException(nameof(shape));
         int totalSize = 1;
         for (int i = 0; i < shape.Length; i++)
+        {
+            if (shape[i] < 0)
+                throw new ArgumentOutOfRangeException(nameof(shape),
+                    $"shape[{i}] = {shape[i]}; shape dimensions must be non-negative.");
             totalSize = checked(totalSize * shape[i]);
+        }
         if (totalSize == 0) return new Tensor<T>(shape);
 
         // No GPU offload allocator registered → CPU pinned fallback. Same

--- a/src/AiDotNet.Tensors/Helpers/TensorArena.cs
+++ b/src/AiDotNet.Tensors/Helpers/TensorArena.cs
@@ -33,16 +33,32 @@ public sealed class TensorArena : IDisposable
     private static TensorArena? _current;
 
     /// <summary>
-    /// Pool of arrays allocated during warmup, keyed by (element type, element count).
-    /// Each bucket holds a list of arrays available for reuse.
+    /// SCRATCH pool: short-lived per-step intermediates. Pool of arrays allocated
+    /// during warmup, keyed by (element type, element count). Cursors rewind on
+    /// <see cref="Reset"/> so the next iteration reuses these arrays. This is
+    /// what every <see cref="TensorAllocator.Rent{T}(int[])"/> call lands in.
     /// </summary>
     private readonly Dictionary<(Type, int), List<Array>> _pool = new();
 
     /// <summary>
-    /// Tracks the reuse cursor per bucket — how many arrays of each (type, size)
-    /// have been handed out since the last Reset().
+    /// Scratch-pool reuse cursor — how many arrays of each (type, size) have
+    /// been handed out since the last <see cref="Reset"/>.
     /// </summary>
     private readonly Dictionary<(Type, int), int> _cursor = new();
+
+    /// <summary>
+    /// PINNED list: long-lived allocations that survive <see cref="Reset"/>.
+    /// Model weights (from layer EnsureInitialized), optimizer moment state
+    /// (Adam m / v), running BatchNorm statistics, positional embeddings —
+    /// anything carried across training steps lives here. Tracked so
+    /// <see cref="Dispose"/> can drop references for GC, but the cursor never
+    /// rewinds, so Reset can't accidentally hand a pinned array out as scratch
+    /// on the next iteration. This eliminates the corruption hazard that
+    /// would otherwise happen if model weights and per-step intermediates
+    /// shared one cursor: rewinding the cursor would let Rent re-issue the
+    /// weight tensor's underlying array as scratch storage.
+    /// </summary>
+    private readonly List<Array> _pinnedArrays = new();
 
     private bool _disposed;
     private readonly TensorArena? _previous;
@@ -90,6 +106,25 @@ public sealed class TensorArena : IDisposable
     internal T[]? TryAllocateUninitialized<T>(int elementCount)
     {
         return TryAllocateCore<T>(elementCount, clear: false);
+    }
+
+    /// <summary>
+    /// Allocates a long-lived array tracked in the PINNED tier. Unlike
+    /// <see cref="TryAllocate{T}"/> (scratch), pinned allocations are NOT
+    /// rewound by <see cref="Reset"/> — the caller can hold a reference
+    /// across many training iterations without risk of the arena re-issuing
+    /// the same backing array as scratch on the next iteration. Use for
+    /// model weights (layer EnsureInitialized), optimizer state (Adam m / v),
+    /// running BatchNorm statistics, anything that's part of the network's
+    /// learnable state. Returns null only when the arena is disposed.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal T[]? TryAllocatePinned<T>(int elementCount)
+    {
+        if (_disposed) return null;
+        var arr = new T[elementCount];
+        _pinnedArrays.Add(arr);
+        return arr;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -227,6 +262,7 @@ public sealed class TensorArena : IDisposable
 
         _pool.Clear();
         _cursor.Clear();
+        _pinnedArrays.Clear();
 
         // Clear tensor ring pools
         if (_tensorRing != null)
@@ -235,4 +271,13 @@ public sealed class TensorArena : IDisposable
             _tensorRingCount = 0;
         }
     }
+
+    /// <summary>
+    /// Number of arrays currently held in the PINNED tier. Diagnostic — lets
+    /// tests / benchmarks verify that long-lived allocations (weights,
+    /// optimizer state) are landing in the right tier and not bloating the
+    /// scratch pool. Pinned count grows monotonically across <see cref="Reset"/>
+    /// calls (only <see cref="Dispose"/> drops these references).
+    /// </summary>
+    public int PinnedArrayCount => _pinnedArrays.Count;
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeOptionsDefaultTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeOptionsDefaultTests.cs
@@ -1,0 +1,89 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// PR #333 — GradientTapeOptions.Default now ships with Persistent=true,
+// which gates the AutoTrainingCompiler fast path that cut 65-73% of
+// ComputeGradients walltime on VGG / ResNet profile data. The change
+// is silent at the type system, so a regression that flipped Default
+// back to Persistent=false would not surface in compile errors; this
+// test family is the explicit guard.
+//
+// AutoTrainingCompiler clone-then-train safety is a separate concern
+// covered by AutoTrainingCompilerHashTests — this file only verifies
+// the default-flag wiring, not the cache-key behavior.
+
+using AiDotNet.Tensors.Engines.Autodiff;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+public class GradientTapeOptionsDefaultTests
+{
+    /// <summary>
+    /// The Default singleton must report Persistent=true. This gates
+    /// AutoTrainingCompiler eligibility — when false, the compiler skips
+    /// the entire compiled-backward fast path and falls back to walking
+    /// the tape entry list per step.
+    /// </summary>
+    [Fact]
+    public void Default_IsPersistent()
+    {
+        Assert.True(GradientTapeOptions.Default.Persistent);
+    }
+
+    /// <summary>
+    /// A parameterless `new GradientTapeOptions()` must also default to
+    /// Persistent=true. Field initializer must match the Default singleton
+    /// so user code that constructs options manually (not via the singleton)
+    /// gets the same compiler-eligibility behavior.
+    /// </summary>
+    [Fact]
+    public void NewInstance_DefaultsToPersistent()
+    {
+        var options = new GradientTapeOptions();
+        Assert.True(options.Persistent);
+    }
+
+    /// <summary>
+    /// A tape constructed without explicit options must report Persistent=true
+    /// on its Options property. This is the end-to-end check that the
+    /// new-default actually reaches the tape — earlier passes flipped the
+    /// option but forgot to update the field initializer, masking the change.
+    /// </summary>
+    [Fact]
+    public void NewTape_NoOptions_ExposesPersistentDefault()
+    {
+        using var tape = new GradientTape<float>();
+        Assert.True(tape.Options.Persistent);
+    }
+
+    /// <summary>
+    /// init-only setters must still allow callers to flip Persistent off
+    /// when they explicitly want eager-disposal behavior (one-shot
+    /// gradient compute, low-memory inference scoring with periodic grad
+    /// probes). The Default singleton is not mutated by this — it's a
+    /// fresh instance each time.
+    /// </summary>
+    [Fact]
+    public void Persistent_CanBeOverriddenViaInit()
+    {
+        var options = new GradientTapeOptions { Persistent = false };
+        Assert.False(options.Persistent);
+
+        // Singleton Default is unaffected by the user's fresh instance.
+        Assert.True(GradientTapeOptions.Default.Persistent);
+    }
+
+    /// <summary>
+    /// All other defaults remain unchanged across this PR: RecordInPlace
+    /// stays true, MaxEntries stays 0 (unlimited), EnableHooks stays false.
+    /// Captures the full default surface so a future drift in any direction
+    /// is caught — not just Persistent.
+    /// </summary>
+    [Fact]
+    public void OtherDefaults_Unchanged()
+    {
+        var options = new GradientTapeOptions();
+        Assert.True(options.RecordInPlace);
+        Assert.Equal(0, options.MaxEntries);
+        Assert.False(options.EnableHooks);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeOptionsDefaultTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeOptionsDefaultTests.cs
@@ -7,8 +7,9 @@
 // test family is the explicit guard.
 //
 // AutoTrainingCompiler clone-then-train safety is a separate concern
-// covered by AutoTrainingCompilerHashTests — this file only verifies
-// the default-flag wiring, not the cache-key behavior.
+// covered by AutoTrainingCompilerTests and GradientTapeReplayModeTests —
+// this file only verifies the default-flag wiring, not the cache-key
+// behavior.
 
 using AiDotNet.Tensors.Engines.Autodiff;
 using Xunit;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeTests.cs
@@ -420,7 +420,14 @@ public class GradientTapeTests
     [Fact]
     public void Gradient_NonPersistentTape_ClearsAfterCompute()
     {
-        using var tape = new GradientTape<float>();
+        // Construct an explicitly non-persistent tape. PR #333 flipped the
+        // default GradientTapeOptions.Persistent to true (it gates the
+        // AutoTrainingCompiler fast path), so `new GradientTape<float>()`
+        // now means PERSISTENT — entries survive ComputeGradients. The
+        // non-persistent contract this test asserts (auto-clear on compute,
+        // second compute throws because tape is empty) only applies when
+        // Persistent is explicitly false.
+        using var tape = new GradientTape<float>(new GradientTapeOptions { Persistent = false });
 
         var a = new Tensor<float>(new[] { 2 }, new Vector<float>(new float[] { 1, 2 }));
         var b = new Tensor<float>(new[] { 2 }, new Vector<float>(new float[] { 3, 4 }));

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/CudaTF32PolicyTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/CudaTF32PolicyTests.cs
@@ -5,13 +5,51 @@
 // CUDA; they only validate the policy decision plumbing.
 
 using System;
+using System.Reflection;
 using AiDotNet.Tensors.Engines.DirectGpu.CUDA;
 using Xunit;
 
 namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
 
-public class CudaTF32PolicyTests
+/// <summary>
+/// Marker collection that disables xUnit parallel execution for the
+/// TF32-policy test class. The tests mutate process-wide state
+/// (AIDOTNET_DISABLE_TF32 env var + the static <c>_allowTF32Override</c>
+/// field on <see cref="CudaDispatchPolicy"/>), so running them concurrently
+/// with each other or with any other test that reads the same state would
+/// cause flaky cross-test interference.
+/// </summary>
+[CollectionDefinition(nameof(CudaTF32PolicyTests), DisableParallelization = true)]
+public sealed class CudaTF32PolicyTestsCollection { }
+
+[Collection(nameof(CudaTF32PolicyTests))]
+public class CudaTF32PolicyTests : IDisposable
 {
+    // Snapshot the inherited env var + runtime override on construction so
+    // we can restore them in Dispose. Each test runs sequentially under
+    // the no-parallel collection, but the env var still leaks into the
+    // PROCESS — a subsequent unrelated test that reads AIDOTNET_DISABLE_TF32
+    // would observe the wrong value without this save/restore.
+    private readonly string? _originalEnvVar;
+    private readonly bool? _originalOverride;
+    private static readonly FieldInfo _overrideField =
+        typeof(CudaDispatchPolicy).GetField("_allowTF32Override",
+            BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException(
+            "CudaDispatchPolicy._allowTF32Override field not found — refactor broke the test.");
+
+    public CudaTF32PolicyTests()
+    {
+        _originalEnvVar = Environment.GetEnvironmentVariable("AIDOTNET_DISABLE_TF32");
+        _originalOverride = (bool?)_overrideField.GetValue(null);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("AIDOTNET_DISABLE_TF32", _originalEnvVar);
+        _overrideField.SetValue(null, _originalOverride);
+    }
+
     /// <summary>
     /// Default state: no env var, no runtime override → AllowTF32 = true.
     /// Captures the "TF32 on by default" guarantee that the issue contract
@@ -21,20 +59,10 @@ public class CudaTF32PolicyTests
     public void AllowTF32_DefaultIsTrue()
     {
         Environment.SetEnvironmentVariable("AIDOTNET_DISABLE_TF32", null);
-        CudaDispatchPolicy.AllowTF32 = true; // explicit reset to clean state
-        try
-        {
-            // Force null override so the env-var fall-through is exercised.
-            var prop = typeof(CudaDispatchPolicy).GetField("_allowTF32Override",
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-            prop!.SetValue(null, (bool?)null);
+        // Force null override so the env-var fall-through is exercised.
+        _overrideField.SetValue(null, (bool?)null);
 
-            Assert.True(CudaDispatchPolicy.AllowTF32);
-        }
-        finally
-        {
-            CudaDispatchPolicy.AllowTF32 = true;
-        }
+        Assert.True(CudaDispatchPolicy.AllowTF32);
     }
 
     /// <summary>
@@ -45,19 +73,10 @@ public class CudaTF32PolicyTests
     [Fact]
     public void AllowTF32_EnvVarSet_ReturnsFalse()
     {
-        var prop = typeof(CudaDispatchPolicy).GetField("_allowTF32Override",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-        prop!.SetValue(null, (bool?)null);
-
+        _overrideField.SetValue(null, (bool?)null);
         Environment.SetEnvironmentVariable("AIDOTNET_DISABLE_TF32", "1");
-        try
-        {
-            Assert.False(CudaDispatchPolicy.AllowTF32);
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("AIDOTNET_DISABLE_TF32", null);
-        }
+
+        Assert.False(CudaDispatchPolicy.AllowTF32);
     }
 
     /// <summary>
@@ -68,20 +87,11 @@ public class CudaTF32PolicyTests
     public void AllowTF32_RuntimeOverride_BeatsEnvVar()
     {
         Environment.SetEnvironmentVariable("AIDOTNET_DISABLE_TF32", "1");
-        try
-        {
-            CudaDispatchPolicy.AllowTF32 = true;
-            Assert.True(CudaDispatchPolicy.AllowTF32);
 
-            CudaDispatchPolicy.AllowTF32 = false;
-            Assert.False(CudaDispatchPolicy.AllowTF32);
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("AIDOTNET_DISABLE_TF32", null);
-            var prop = typeof(CudaDispatchPolicy).GetField("_allowTF32Override",
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-            prop!.SetValue(null, (bool?)null);
-        }
+        CudaDispatchPolicy.AllowTF32 = true;
+        Assert.True(CudaDispatchPolicy.AllowTF32);
+
+        CudaDispatchPolicy.AllowTF32 = false;
+        Assert.False(CudaDispatchPolicy.AllowTF32);
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/CudaTF32PolicyTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/CudaTF32PolicyTests.cs
@@ -1,0 +1,87 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// PR #333 / issue #337 — verify the user-facing TF32 policy surface
+// (AllowTF32 property + AIDOTNET_DISABLE_TF32 env var) before the
+// hardware-dependent cuBLAS-mode wiring runs. These tests don't require
+// CUDA; they only validate the policy decision plumbing.
+
+using System;
+using AiDotNet.Tensors.Engines.DirectGpu.CUDA;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
+
+public class CudaTF32PolicyTests
+{
+    /// <summary>
+    /// Default state: no env var, no runtime override → AllowTF32 = true.
+    /// Captures the "TF32 on by default" guarantee that the issue contract
+    /// promises Ampere+ users get acceleration without any configuration.
+    /// </summary>
+    [Fact]
+    public void AllowTF32_DefaultIsTrue()
+    {
+        Environment.SetEnvironmentVariable("AIDOTNET_DISABLE_TF32", null);
+        CudaDispatchPolicy.AllowTF32 = true; // explicit reset to clean state
+        try
+        {
+            // Force null override so the env-var fall-through is exercised.
+            var prop = typeof(CudaDispatchPolicy).GetField("_allowTF32Override",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+            prop!.SetValue(null, (bool?)null);
+
+            Assert.True(CudaDispatchPolicy.AllowTF32);
+        }
+        finally
+        {
+            CudaDispatchPolicy.AllowTF32 = true;
+        }
+    }
+
+    /// <summary>
+    /// AIDOTNET_DISABLE_TF32 with any non-empty value forces AllowTF32 = false
+    /// when no runtime override is set. Lets ops / reproducibility runs disable
+    /// TF32 globally without recompiling.
+    /// </summary>
+    [Fact]
+    public void AllowTF32_EnvVarSet_ReturnsFalse()
+    {
+        var prop = typeof(CudaDispatchPolicy).GetField("_allowTF32Override",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        prop!.SetValue(null, (bool?)null);
+
+        Environment.SetEnvironmentVariable("AIDOTNET_DISABLE_TF32", "1");
+        try
+        {
+            Assert.False(CudaDispatchPolicy.AllowTF32);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("AIDOTNET_DISABLE_TF32", null);
+        }
+    }
+
+    /// <summary>
+    /// Runtime AllowTF32 setter overrides the env var so tests / hot-reload
+    /// scenarios can flip TF32 without re-launching the process.
+    /// </summary>
+    [Fact]
+    public void AllowTF32_RuntimeOverride_BeatsEnvVar()
+    {
+        Environment.SetEnvironmentVariable("AIDOTNET_DISABLE_TF32", "1");
+        try
+        {
+            CudaDispatchPolicy.AllowTF32 = true;
+            Assert.True(CudaDispatchPolicy.AllowTF32);
+
+            CudaDispatchPolicy.AllowTF32 = false;
+            Assert.False(CudaDispatchPolicy.AllowTF32);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("AIDOTNET_DISABLE_TF32", null);
+            var prop = typeof(CudaDispatchPolicy).GetField("_allowTF32Override",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+            prop!.SetValue(null, (bool?)null);
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Helpers/TensorArenaPinnedTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/TensorArenaPinnedTests.cs
@@ -14,12 +14,15 @@ namespace AiDotNet.Tensors.Tests.Helpers;
 
 /// <summary>
 /// Marker collection that disables xUnit parallel execution for the
-/// TensorArena pinned-tier tests. These tests mutate the process-wide
-/// <c>TensorArena.Current</c> static via <see cref="TensorArena.Create"/>;
-/// running them concurrently with each other or with anything else that
-/// touches the arena stack would cause cross-test interference and flaky
-/// failures (e.g. one test's arena observed by another's PinnedArrayCount
-/// assertion).
+/// TensorArena pinned-tier tests. <c>TensorArena.Current</c> is
+/// <c>[ThreadStatic]</c> rather than process-wide, but xUnit reuses test
+/// threads across collections — a worker thread that hosted one test's
+/// arena can host another's, and the new test would see the previous
+/// arena still installed on <c>Current</c> (or its <c>PinnedArrayCount</c>
+/// leaked into the new test's assertion). Disabling parallelization
+/// serializes these tests onto a single test-runner thread so each test's
+/// <see cref="TensorArena.Create"/> + <c>Dispose</c> establishes a clean
+/// arena stack, eliminating the thread-reuse interference window.
 /// </summary>
 [CollectionDefinition(nameof(TensorArenaPinnedTests), DisableParallelization = true)]
 public sealed class TensorArenaPinnedTestsCollection { }

--- a/tests/AiDotNet.Tensors.Tests/Helpers/TensorArenaPinnedTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/TensorArenaPinnedTests.cs
@@ -109,6 +109,11 @@ public class TensorArenaPinnedTests
     [Fact]
     public void RentPinned_NoActiveArena_FallsBackToCleanAllocation()
     {
+        // Precondition: no active arena on this thread. Without this assert
+        // the test would silently pass even if an outer harness was leaking
+        // arenas — the "no active arena" branch of RentPinned would never run.
+        Assert.Null(TensorArena.Current);
+
         // Outside any `using var arena = TensorArena.Create()` block.
         var pinned = TensorAllocator.RentPinned<double>(new[] { 5 });
         Assert.NotNull(pinned);

--- a/tests/AiDotNet.Tensors.Tests/Helpers/TensorArenaPinnedTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/TensorArenaPinnedTests.cs
@@ -138,4 +138,45 @@ public class TensorArenaPinnedTests
         // Zero-size short-circuit must not pollute the pinned tier counter.
         Assert.Equal(countBefore, arena.PinnedArrayCount);
     }
+
+    /// <summary>
+    /// On a CPU-only host (no GPU offload allocator registered),
+    /// RentPinnedOnGpu must gracefully fall back to RentPinned semantics.
+    /// Consumer code that unconditionally calls RentPinnedOnGpu (e.g.,
+    /// AdamOptimizer._tapeM after the AiDotNet migration) needs to keep
+    /// working when run on hosts without a GPU.
+    /// </summary>
+    [Fact]
+    public void RentPinnedOnGpu_NoGpuAllocator_FallsBackToPinned()
+    {
+        using var arena = TensorArena.Create();
+        int countBefore = arena.PinnedArrayCount;
+
+        // No `WeightRegistry.Configure(..., offloadAllocator: …)` call
+        // happens by default in the test harness, so the OffloadAllocator
+        // is null — exactly the CPU-host scenario the fallback targets.
+        var tensor = TensorAllocator.RentPinnedOnGpu<float>(new[] { 8 });
+
+        Assert.NotNull(tensor);
+        Assert.Equal(8, tensor.Length);
+        Assert.Equal(WeightLifetime.Default, tensor.Lifetime);
+        // Fallback path is RentPinned, so the pinned tier should have grown
+        // by one — verifying we actually pinned the allocation rather than
+        // routing through plain `new Tensor<T>`.
+        Assert.Equal(countBefore + 1, arena.PinnedArrayCount);
+    }
+
+    /// <summary>
+    /// Zero-size shape on RentPinnedOnGpu must short-circuit to plain
+    /// allocation without consulting any allocator (which would throw on
+    /// byteCount == 0 on most GPU runtimes). Same contract as RentPinned.
+    /// </summary>
+    [Fact]
+    public void RentPinnedOnGpu_ZeroSize_ReturnsUsableTensor()
+    {
+        using var arena = TensorArena.Create();
+        var tensor = TensorAllocator.RentPinnedOnGpu<double>(new[] { 0 });
+        Assert.NotNull(tensor);
+        Assert.Equal(0, tensor.Length);
+    }
 }

--- a/tests/AiDotNet.Tensors.Tests/Helpers/TensorArenaPinnedTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/TensorArenaPinnedTests.cs
@@ -12,6 +12,19 @@ using Xunit;
 
 namespace AiDotNet.Tensors.Tests.Helpers;
 
+/// <summary>
+/// Marker collection that disables xUnit parallel execution for the
+/// TensorArena pinned-tier tests. These tests mutate the process-wide
+/// <c>TensorArena.Current</c> static via <see cref="TensorArena.Create"/>;
+/// running them concurrently with each other or with anything else that
+/// touches the arena stack would cause cross-test interference and flaky
+/// failures (e.g. one test's arena observed by another's PinnedArrayCount
+/// assertion).
+/// </summary>
+[CollectionDefinition(nameof(TensorArenaPinnedTests), DisableParallelization = true)]
+public sealed class TensorArenaPinnedTestsCollection { }
+
+[Collection(nameof(TensorArenaPinnedTests))]
 public class TensorArenaPinnedTests
 {
     /// <summary>

--- a/tests/AiDotNet.Tensors.Tests/Helpers/TensorArenaPinnedTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/TensorArenaPinnedTests.cs
@@ -1,0 +1,141 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// PR #333 — two-tier TensorArena (Pinned + Scratch). Pinned allocations
+// (model weights, optimizer state, BatchNorm running stats) must survive
+// Reset() and NEVER get re-issued as scratch on the next iteration.
+// Without that guarantee, a Reset between training steps would let a
+// later Rent return the same backing array as the weight tensor and
+// downstream writes would corrupt the weight in place.
+
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Helpers;
+
+public class TensorArenaPinnedTests
+{
+    /// <summary>
+    /// Pinned allocations must persist across Reset() — the backing array
+    /// stays valid and its contents survive. Without this, every Train
+    /// iteration would zero out the layer weights.
+    /// </summary>
+    [Fact]
+    public void Pinned_SurvivesReset_ContentsPreserved()
+    {
+        using var arena = TensorArena.Create();
+
+        var pinned = TensorAllocator.RentPinned<float>(new[] { 4 });
+        var span = pinned.AsWritableSpan();
+        span[0] = 1f; span[1] = 2f; span[2] = 3f; span[3] = 4f;
+
+        arena.Reset();
+
+        var spanAfter = pinned.AsSpan();
+        Assert.Equal(1f, spanAfter[0]);
+        Assert.Equal(2f, spanAfter[1]);
+        Assert.Equal(3f, spanAfter[2]);
+        Assert.Equal(4f, spanAfter[3]);
+    }
+
+    /// <summary>
+    /// Reset() must NOT hand the pinned array back as scratch on the next
+    /// iteration. Verified by writing to the pinned tensor, calling Reset,
+    /// then renting a scratch tensor of the same size and writing to it —
+    /// the original pinned tensor's contents must be unchanged.
+    /// </summary>
+    [Fact]
+    public void Pinned_NotReissuedAsScratch_AfterReset()
+    {
+        using var arena = TensorArena.Create();
+
+        // Allocate a pinned tensor and stamp a signature into it.
+        var weight = TensorAllocator.RentPinned<float>(new[] { 8 });
+        var weightSpan = weight.AsWritableSpan();
+        for (int i = 0; i < 8; i++) weightSpan[i] = 100f + i;
+
+        // Mid-iteration the caller does some scratch work — both before and
+        // after Reset — and we check that the scratch allocator never picks
+        // up the pinned tensor's underlying array.
+        var scratchBefore = TensorAllocator.Rent<float>(new[] { 8 });
+        var scratchBeforeSpan = scratchBefore.AsWritableSpan();
+        for (int i = 0; i < 8; i++) scratchBeforeSpan[i] = 999f;
+
+        arena.Reset();
+
+        var scratchAfter = TensorAllocator.Rent<float>(new[] { 8 });
+        var scratchAfterSpan = scratchAfter.AsWritableSpan();
+        for (int i = 0; i < 8; i++) scratchAfterSpan[i] = -7f;
+
+        // The pinned tensor's contents must still be the signature.
+        var weightSpanAfter = weight.AsSpan();
+        for (int i = 0; i < 8; i++)
+            Assert.Equal(100f + i, weightSpanAfter[i]);
+    }
+
+    /// <summary>
+    /// PinnedArrayCount is the diagnostic that confirms pinned tier exists
+    /// and grows monotonically across allocations. Used by perf tests /
+    /// memory probes that assert weights land in the right tier.
+    /// </summary>
+    [Fact]
+    public void PinnedArrayCount_GrowsOnEachRent_AndDoesNotResetOnReset()
+    {
+        using var arena = TensorArena.Create();
+
+        Assert.Equal(0, arena.PinnedArrayCount);
+
+        _ = TensorAllocator.RentPinned<float>(new[] { 4 });
+        Assert.Equal(1, arena.PinnedArrayCount);
+
+        _ = TensorAllocator.RentPinned<float>(new[] { 16 });
+        Assert.Equal(2, arena.PinnedArrayCount);
+
+        arena.Reset();
+
+        // Reset must not drop pinned references — that would let GC reclaim
+        // weight backing arrays still held by the model.
+        Assert.Equal(2, arena.PinnedArrayCount);
+
+        _ = TensorAllocator.RentPinned<double>(new[] { 32 });
+        Assert.Equal(3, arena.PinnedArrayCount);
+    }
+
+    /// <summary>
+    /// When no arena is active, RentPinned must still return a usable
+    /// tensor (graceful degradation). The contract is "this tensor
+    /// survives across iterations" — without an arena, plain CLR allocation
+    /// satisfies that trivially because the array isn't in any pool.
+    /// </summary>
+    [Fact]
+    public void RentPinned_NoActiveArena_FallsBackToCleanAllocation()
+    {
+        // Outside any `using var arena = TensorArena.Create()` block.
+        var pinned = TensorAllocator.RentPinned<double>(new[] { 5 });
+        Assert.NotNull(pinned);
+        Assert.Equal(5, pinned.Length);
+
+        // Should be zero-initialized like a fresh new Tensor<T>(shape).
+        var span = pinned.AsSpan();
+        for (int i = 0; i < 5; i++)
+            Assert.Equal(0.0, span[i]);
+    }
+
+    /// <summary>
+    /// Edge case: zero-size shape must not throw and must return a usable
+    /// tensor. The pinned allocator should short-circuit to a plain
+    /// Tensor&lt;T&gt;(shape) without consuming the pinned tier.
+    /// </summary>
+    [Fact]
+    public void RentPinned_ZeroSize_ReturnsUsableTensor()
+    {
+        using var arena = TensorArena.Create();
+        int countBefore = arena.PinnedArrayCount;
+
+        var pinned = TensorAllocator.RentPinned<float>(new[] { 0 });
+        Assert.NotNull(pinned);
+        Assert.Equal(0, pinned.Length);
+
+        // Zero-size short-circuit must not pollute the pinned tier counter.
+        Assert.Equal(countBefore, arena.PinnedArrayCount);
+    }
+}


### PR DESCRIPTION
## Summary



Consolidates the systemic acceleration-defaults audit work into a single PR. Closes #328.







The original audit found that **every acceleration technique exists in the codebase but defaults to off** — paper-canonical models (VGG16-BN, BERT-base InstructorEmbedding, etc.) hit slow scalar code paths, GC churn, and dead `TryForwardGpuOptimized` branches because no consumer code engages any of these techniques on the default path. This PR turns them on.







(Originally filed as four separate PRs — #329, #330, #332, plus the streaming work below — but consolidated here per consumer request.)







## Changes in this PR







### 1. Two-tier `TensorArena` — Pinned + Scratch



- Adds a `_pinnedArrays` list alongside the existing `_pool` / `_cursor`.



- `TensorAllocator.RentPinned<T>` routes there; survives `Reset()`.



- `TensorAllocator.Rent<T>` keeps existing scratch semantics — recycled on `Reset()`.



- `Dispose()` clears both tiers.



- `PinnedArrayCount` diagnostic property for tests.







Unlocks the consumer-side `TrainWithTape` arena lifecycle fix: today the consumer creates + destroys an arena per Train call (because the old single-pool design made outer-arena reuse unsafe — Reset would re-issue weight tensors as scratch). With the Pinned tier, weights are stable across `Reset()` calls, so the consumer can drop the per-call arena and let the test base's outer arena pool intermediates across all 100 training iterations.







### 2. GPU auto-detect on by default



- New `GpuAutoDetectModuleInit.cs` with a `[ModuleInitializer]` (net6.0+) that fires at assembly load and calls `AutoDetectAndConfigureGpu()`.



- Mirrors the consumer-side `BlasEnvDefault` pattern (`AIDOTNET_USE_BLAS=1` env var auto-set).



- Opt-out: set `AIDOTNET_DISABLE_GPU=1` before process startup.



- Defensive try / catch — a thrown `ModuleInitializer` aborts the AppDomain, so even though `AutoDetectAndConfigureGpu` already wraps its own exceptions, an additional guard prevents any future regression from taking down the host.







Validated locally on CUDA GTX 1660 Ti: default → `DirectGpuTensorEngine`, `AIDOTNET_DISABLE_GPU=1` → `CpuEngine`.







### 3. `GradientTapeOptions.Persistent = true` by default + clone-safe compile cache



- `GradientTapeOptions.Default.Persistent = true` and `Persistent { init; } = true` (default-instance-prop initializer).



- `AutoTrainingCompiler.ComputePatternHash` now includes both input and output tensor REFERENCE identities (`RuntimeHelpers.GetHashCode`) — fixes the clone-then-train cache pollution that forced the previous attempt at this default flip to be reverted (Hope.MoreData regression).







Profile data showed `GradientTape.ComputeGradients` was 65-73 % of step wall time on VGG11 / ResNet50 with the non-persistent default. Persistent gates the `AutoTrainingCompiler` replay path, which replaces the per-op tape walk + dictionary-keyed gradient lookup with a flat-indexed compiled backward graph.







Safety in degenerate cases:



| Scenario | New behaviour |



|---|---|



| Same model, no arena reuse (current state) | Hash differs every call → no cache hit, no compile, no regression. Same effective behaviour as non-persistent. |



| Same model, with arena reuse (post-consumer migration) | Hash matches → compile after 2 repeats → replay on iter 3+. Perf win activates. |



| Cloned model (Hope.MoreData regression case) | Hash differs (input identities) → cache miss → fresh compile. No wrong-tensor replay. |







### 4. Streaming weights auto-engage on `RentPinned` — REVERTED in review
- An earlier draft of `RentPinned` routed >100M-element allocations through `WeightRegistry.AllocateStreaming`. Reviewer flagged that `AllocateStreaming` only RESERVES pool budget — it requires a follow-on `RegisterWeight` call to actually commit bytes into the streaming pool and drop in-memory storage. `RentPinned` callers (LayerBase, optimizer moments, BN running stats) hold the tensor as plain GC memory and never perform that handshake, so the auto-engage stranded the reservation without buying any streaming benefit.
- Removed in this PR — the explicit NOTE inside `RentPinned` documents why and points at the alternative.
- Streaming-pool integration belongs in the AiDotNet companion PR where the LayerBase / optimizer migration can wire both `AllocateStreaming` AND `RegisterWeight` together with explicit lifecycle handling. Callers who need pool-backed streaming today should use `WeightRegistry.AllocateStreaming` directly with a matching `RegisterWeight` / `UnregisterWeight` pair.


## Profile baseline this PR targets



VGG16-BN paper-canonical Train iteration on CPU:



- Wall time: 38 468 ms



- Allocated: **5 673 MB** (5× the model weights size)



- 211 Gen-0 + 4 Gen-1 + 2 Gen-2 collections per iteration







Expected wins as the consumer migration lands (separate PR in AiDotNet repo):



- Arena pool reuse via Pinned tier: drops most of the 5.7 GB / iter alloc churn.



- GPU auto-engage: routes Conv2D / MatMul / attention through DirectGpu paths that already exist in model code (`TryForwardGpuOptimized`).



- Persistent tape: cuts ComputeGradients share from 65-73 % to the replay-path proportion.



- Streaming for large pinned: reduces peak GC heap on > 100M-element tensors.







## Closes



- closes #328







## Verification



- Standalone diag for two-tier arena (pinned writes survive Reset + scratch overwrite + same-shape rents).



- Standalone diag for GPU auto-detect (default → DirectGpuTensorEngine, env opt-out → CpuEngine).



- Build clean on net6.0+ and net471 (ModuleInitializer guarded behind `#if NET6_0_OR_GREATER`).







🤖 Generated with [Claude Code](https://claude.com/claude-code)





---



## In-scope (added 2026-05-11): consumer-flagged perf gaps that must ship in this PR



Profile run on the consumed v0.75.3 NuGet — VGG11, paper-canonical 11.3M params — showed 1150 ms / iter, 582 MB alloc / iter, GPU idle the entire run. Audit identified four giant perf gaps. Per consumer scope decision, this PR ships the **Tensors-side API surface** for all 4; the AiDotNet companion PR (filed after PR #333 merges + NuGet bumps) wires the consumer-facing entry points (Train routing, LayerBase / Adam / BN migration, per-op kernel mixed-precision wiring).



### Issue status



- [x] **#337 mixed precision — Tensors-side surface complete.**

  - **TF32 default ON for Ampere+** (compute capability ≥ 8.0): `CudaBackend.Initialize` now selects `CUBLAS_TF32_TENSOR_OP_MATH` instead of the legacy `CUBLAS_TENSOR_OP_MATH`, gated by `CudaDispatchPolicy.AllowTF32` (honors `AIDOTNET_DISABLE_TF32` env var). ~5× the throughput of strict fp32 with bit-comparable loss curves. Effective immediately when this PR's NuGet is consumed.

  - **`MixedPrecisionPolicy` enum** (None / AutoCastFP16 / AutoCastBF16) + `TensorCodecOptions.MixedPrecisionPolicy` property. Per-op kernel wiring (cuBLAS HGEMM, cuDNN Half conv, loss-scaling on optimizer) lands incrementally — each op that gets a mixed-precision kernel checks this policy without further API churn.



- [x] **#336 GPU-resident state — Tensors-side surface complete.**

  - `TensorAllocator.RentPinnedOnGpu<T>(int[] shape)` — single-call allocator that wraps the existing `WeightLifetime.GpuOffload` pipeline. Pinned host memory DMA-mapped to the GPU; kernels read/write via the mapping; CPU access stays live without an explicit download.

  - Graceful fallback to CPU `RentPinned` when no GPU allocator is registered, when T isn't streamable, or on `NotSupportedException`/`InvalidOperationException` from the allocator.

  - Existing GPU optimizer kernels (`AdamUpdate`, `SgdUpdate`, `AdamWUpdate`, `RmspropUpdate`) on `IDirectGpuBackend` cover the optimizer-state step on GPU.



- [x] **#335 multi-stream — Tensors-side surface complete.**

  - `GpuStreamScheduler` — `Dispatch(launches)` round-robins independent launches across pool streams with per-launch event tracking; `DispatchSequential(batches)` runs batches in DAG order with cross-batch `WaitEvent` chaining.

  - Sits on the existing `GpuStreamPool` + `IGpuStream.RecordEvent`/`WaitEvent` API. Consumers wire it into BatchMatMul (per-slice GEMMs), multi-head attention (per-head launches), and any other independent-kernel batch.



- [ ] **#334 Train auto-route — AiDotNet companion PR.**

  - Pure consumer-side work: `NeuralNetworkBase.Train()` in the AiDotNet repo needs the dispatcher (check `AiDotNetEngine.Current is DirectGpuTensorEngine` + every layer is `IGpuLayer` + loss has GPU eval + optimizer can update GPU-resident params → route to `TrainStepGpu`).

  - Tensors-side already exposes the `IAsyncGpuBackend.ExecuteDeferred` entry point + `IGpuLayer` interface; AiDotNet PR adds the routing-decision dispatcher + diagnostic logging for fallback.



### Remaining per-op kernel wiring (AiDotNet companion + follow-up Tensors PRs)



The Tensors-side API surface is in place for all four. The AiDotNet companion PR consumes:



- `RentPinnedOnGpu` in `LayerBase.EnsureInitialized` / `AdamOptimizer._tapeM`/`_tapeV` / `BatchNormalizationLayer._runningMean`/`_runningVariance` / `EmbeddingLayer._embeddingTensor` / `MultiHeadAttentionLayer` weight banks.

- `MixedPrecisionPolicy` check in compute-bound ops (each Conv2D / MatMul / Attention call site picks dtype from the policy).

- `GpuStreamScheduler` in `BatchMatMul` per-slice loop and `ScaledDotProductAttention` per-head dispatch.

- `NeuralNetworkBase.Train` routing dispatcher.



These ship as the next AiDotNet PR once this Tensors PR merges + NuGet publishes.




