### PR TITLE
feat(#334): GpuRoutingHelpers — Tensors-side capability surface for Train() auto-route

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Gpu/GpuRoutingHelpers.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/GpuRoutingHelpers.cs
@@ -1,0 +1,169 @@
+using System;
+using AiDotNet.Tensors.Engines.DirectGpu;
+
+namespace AiDotNet.Tensors.Engines.Gpu;
+
+/// <summary>
+/// High-level routing helpers that let consumers (e.g. AiDotNet's
+/// <c>NeuralNetworkBase.Train</c>) decide whether to dispatch a training
+/// or inference step through the GPU deferred-scope path without having
+/// to inspect engine internals at every call site.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Background — closes the Tensors-side capability surface for issue #334.
+/// Before these helpers, every consumer that wanted to auto-route to GPU
+/// had to (a) test <c>engine is DirectGpuTensorEngine</c>, (b) cast,
+/// (c) call <c>GetAsyncBackend()</c> and check for null, (d) check
+/// <c>SupportsDeferredExecution</c>. The result was that the canonical
+/// public training entry point (<c>NeuralNetworkBase.Train</c>) just
+/// always ran the CPU tape path even when <see cref="DirectGpuTensorEngine"/>
+/// was active, because nothing wired the routing-decision logic.
+/// </para>
+/// <para>
+/// These helpers answer two questions a consumer routing dispatcher needs:
+/// 1) "Is this engine actually GPU-active right now?" — engine-level only,
+/// not a per-op or per-layer eligibility check (the consumer owns that
+/// because Tensors doesn't know about layer / loss / optimizer types).
+/// 2) "How do I run my deferred GPU action with a CPU fallback in one
+/// call?" — <see cref="TryExecuteOnGpu(Action{IDeferredScope}, Action, GpuExecutionOptions?, out string)"/>.
+/// </para>
+/// <para>
+/// The per-layer / per-loss / per-optimizer eligibility checks (steps 2–4
+/// of issue #334's required behavior) stay consumer-side: they require
+/// knowledge of <c>IGpuLayer</c>, loss-function GPU paths, and optimizer
+/// types that live in the AiDotNet repo, not in AiDotNet.Tensors.
+/// </para>
+/// </remarks>
+public static class GpuRoutingHelpers
+{
+    /// <summary>
+    /// Returns true when <paramref name="engine"/> is a GPU engine with a
+    /// live async backend — i.e. dispatching a deferred-scope action via
+    /// <see cref="DirectGpuTensorEngine.BeginDeferredScope"/> or
+    /// <see cref="AsyncGpuBackendExtensions.ExecuteDeferred{TResult}"/> would
+    /// actually run on hardware rather than no-op back to a CPU path.
+    /// </summary>
+    /// <param name="engine">The engine to inspect. May be null.</param>
+    /// <returns>
+    /// True iff <paramref name="engine"/> is a <see cref="DirectGpuTensorEngine"/>
+    /// reporting <see cref="DirectGpuTensorEngine.SupportsDeferredExecution"/> ==
+    /// true. False for null, <see cref="CpuEngine"/>, and GPU engines whose
+    /// backend isn't async-capable.
+    /// </returns>
+    public static bool IsGpuActive(IEngine? engine)
+    {
+        if (engine is not DirectGpuTensorEngine gpu) return false;
+        return gpu.SupportsDeferredExecution;
+    }
+
+    /// <summary>
+    /// Same as <see cref="IsGpuActive(IEngine)"/> applied to
+    /// <see cref="AiDotNetEngine.Current"/>. Convenience for consumer code
+    /// that already routes through the process-global engine.
+    /// </summary>
+    public static bool IsGpuActiveOnCurrentEngine() => IsGpuActive(AiDotNetEngine.Current);
+
+    /// <summary>
+    /// Tries to obtain the <see cref="IAsyncGpuBackend"/> handle the
+    /// engine routes through for deferred scopes. Returns null when the
+    /// engine is CPU-only OR is a GPU engine whose underlying backend
+    /// isn't async-capable.
+    /// </summary>
+    /// <param name="engine">The engine to inspect. May be null.</param>
+    /// <returns>
+    /// The backend handle, or null when no deferred-execution-capable
+    /// backend is reachable from <paramref name="engine"/>.
+    /// </returns>
+    public static IAsyncGpuBackend? TryGetAsyncBackend(IEngine? engine)
+    {
+        if (engine is not DirectGpuTensorEngine gpu) return null;
+        return gpu.GetAsyncBackend();
+    }
+
+    /// <summary>
+    /// Convenience dispatcher: when the current engine is GPU-active,
+    /// runs <paramref name="gpuAction"/> inside a deferred scope on the
+    /// async backend; otherwise runs <paramref name="cpuFallback"/>
+    /// without entering any deferred scope.
+    /// </summary>
+    /// <param name="gpuAction">The GPU-side action to execute inside an
+    /// <see cref="IDeferredScope"/>. Called only when the GPU path is
+    /// active.</param>
+    /// <param name="cpuFallback">The CPU-side fallback action. Called
+    /// when no GPU engine is active.</param>
+    /// <param name="options">Optional execution options; defaults to
+    /// <see cref="GpuExecutionOptions.FromEnvironment"/> with
+    /// <see cref="GpuExecutionOptions.EnableGpuResidency"/> = true,
+    /// matching the issue #334 required behavior.</param>
+    /// <param name="reason">When the GPU path is skipped, a short
+    /// human-readable explanation suitable for a debug log; null when
+    /// the GPU path ran.</param>
+    /// <returns>True when the GPU action ran; false when the CPU
+    /// fallback ran.</returns>
+    /// <remarks>
+    /// <para>
+    /// Engine-level eligibility only. The caller is responsible for
+    /// per-layer / per-op eligibility checks before deciding to call
+    /// this helper at all — if the caller knows a layer's forward op
+    /// has no GPU kernel, they should call <paramref name="cpuFallback"/>
+    /// directly without going through this dispatcher.
+    /// </para>
+    /// <para>
+    /// Exceptions thrown from <paramref name="gpuAction"/> are NOT
+    /// caught — the caller decides whether a runtime GPU failure should
+    /// fall back to CPU or surface to the user. This helper is a
+    /// routing decision, not an error-recovery wrapper.
+    /// </para>
+    /// </remarks>
+    public static bool TryExecuteOnGpu(
+        Action<IDeferredScope> gpuAction,
+        Action cpuFallback,
+        GpuExecutionOptions? options,
+        out string? reason)
+    {
+        if (gpuAction is null) throw new ArgumentNullException(nameof(gpuAction));
+        if (cpuFallback is null) throw new ArgumentNullException(nameof(cpuFallback));
+
+        var engine = AiDotNetEngine.Current;
+        if (engine is null)
+        {
+            reason = "No process engine is set; CPU path runs.";
+            cpuFallback();
+            return false;
+        }
+        if (engine is not DirectGpuTensorEngine gpu)
+        {
+            reason = $"Engine '{engine.GetType().Name}' is not a GPU engine; CPU path runs.";
+            cpuFallback();
+            return false;
+        }
+        var backend = gpu.GetAsyncBackend();
+        if (backend is null)
+        {
+            reason = "DirectGpuTensorEngine has no async-capable backend; CPU path runs.";
+            cpuFallback();
+            return false;
+        }
+
+        // Default options preserve issue #334's required behavior:
+        // EnableGpuResidency = true keeps activations + weights GPU-resident
+        // across the deferred scope, avoiding the H2D/D2H round-trip that
+        // dominated the VGG11 profile. EnableGraphCompilation = true (the
+        // GpuExecutionOptions default) compiles the recorded graph for
+        // repeated training steps.
+        backend.ExecuteDeferred(gpuAction, options ?? GpuExecutionOptions.FromEnvironment());
+        reason = null;
+        return true;
+    }
+
+    /// <summary>
+    /// Overload that drops the diagnostic <c>reason</c> for callers that
+    /// don't need it. Mirrors the <c>out string?</c> overload otherwise.
+    /// </summary>
+    public static bool TryExecuteOnGpu(
+        Action<IDeferredScope> gpuAction,
+        Action cpuFallback,
+        GpuExecutionOptions? options = null)
+        => TryExecuteOnGpu(gpuAction, cpuFallback, options, out _);
+}

--- a/src/AiDotNet.Tensors/Engines/Gpu/GpuRoutingHelpers.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/GpuRoutingHelpers.cs
@@ -41,7 +41,7 @@ public static class GpuRoutingHelpers
     /// Returns true when <paramref name="engine"/> is a GPU engine with a
     /// live async backend — i.e. dispatching a deferred-scope action via
     /// <see cref="DirectGpuTensorEngine.BeginDeferredScope"/> or
-    /// <see cref="AsyncGpuBackendExtensions.ExecuteDeferred{TResult}"/> would
+    /// <see cref="DeferredScopeExtensions.ExecuteDeferred{TResult}"/> would
     /// actually run on hardware rather than no-op back to a CPU path.
     /// </summary>
     /// <param name="engine">The engine to inspect. May be null.</param>
@@ -135,6 +135,18 @@ public static class GpuRoutingHelpers
         if (engine is not DirectGpuTensorEngine gpu)
         {
             reason = $"Engine '{engine.GetType().Name}' is not a GPU engine; CPU path runs.";
+            cpuFallback();
+            return false;
+        }
+        // Align with IsGpuActive(): a GPU engine whose backend can't run
+        // a deferred scope (cuGraph-incapable driver, missing runtime
+        // library, etc.) is NOT "GPU active" — fall back to CPU even if
+        // GetAsyncBackend() returns non-null. Without this gate the
+        // dispatcher would diverge from the predicate and route work
+        // that IsGpuActive(engine) just said couldn't run.
+        if (!gpu.SupportsDeferredExecution)
+        {
+            reason = "DirectGpuTensorEngine does not support deferred execution; CPU path runs.";
             cpuFallback();
             return false;
         }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Gpu/GpuRoutingHelpersTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Gpu/GpuRoutingHelpersTests.cs
@@ -1,0 +1,126 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Gpu;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Gpu;
+
+/// <summary>
+/// Issue #334: covers the Tensors-side capability surface that
+/// <c>AiDotNet.NeuralNetworkBase.Train</c> calls when deciding whether to
+/// dispatch a training step to the GPU. The actual <c>Train()</c> dispatch
+/// fix ships in a companion AiDotNet PR; this suite validates the helpers
+/// that companion PR depends on.
+/// </summary>
+public class GpuRoutingHelpersTests
+{
+    [Fact]
+    public void IsGpuActive_NullEngine_ReturnsFalse()
+    {
+        Assert.False(GpuRoutingHelpers.IsGpuActive(null));
+    }
+
+    [Fact]
+    public void IsGpuActive_CpuEngine_ReturnsFalse()
+    {
+        var engine = new CpuEngine();
+        Assert.False(GpuRoutingHelpers.IsGpuActive(engine));
+    }
+
+    [Fact]
+    public void TryGetAsyncBackend_NullEngine_ReturnsNull()
+    {
+        Assert.Null(GpuRoutingHelpers.TryGetAsyncBackend(null));
+    }
+
+    [Fact]
+    public void TryGetAsyncBackend_CpuEngine_ReturnsNull()
+    {
+        var engine = new CpuEngine();
+        Assert.Null(GpuRoutingHelpers.TryGetAsyncBackend(engine));
+    }
+
+    [Fact]
+    public void TryExecuteOnGpu_CpuEngineActive_RunsFallback_NotGpuAction()
+    {
+        var priorEngine = AiDotNetEngine.Current;
+        AiDotNetEngine.Current = new CpuEngine();
+        try
+        {
+            bool gpuRan = false;
+            bool cpuRan = false;
+            var actualReturn = GpuRoutingHelpers.TryExecuteOnGpu(
+                gpuAction: _ => { gpuRan = true; },
+                cpuFallback: () => { cpuRan = true; },
+                options: null,
+                out var reason);
+
+            Assert.False(actualReturn, "TryExecuteOnGpu must return false on CPU engine.");
+            Assert.False(gpuRan, "GPU action must NOT run on a CpuEngine.");
+            Assert.True(cpuRan, "CPU fallback must run on a CpuEngine.");
+            Assert.NotNull(reason);
+            Assert.Contains("not a GPU engine", reason);
+        }
+        finally
+        {
+            AiDotNetEngine.Current = priorEngine;
+        }
+    }
+
+    [Fact]
+    public void TryExecuteOnGpu_NullGpuAction_Throws()
+    {
+        Assert.Throws<System.ArgumentNullException>(() =>
+            GpuRoutingHelpers.TryExecuteOnGpu(
+                gpuAction: null!,
+                cpuFallback: () => { },
+                options: null,
+                out _));
+    }
+
+    [Fact]
+    public void TryExecuteOnGpu_NullCpuFallback_Throws()
+    {
+        Assert.Throws<System.ArgumentNullException>(() =>
+            GpuRoutingHelpers.TryExecuteOnGpu(
+                gpuAction: _ => { },
+                cpuFallback: null!,
+                options: null,
+                out _));
+    }
+
+    [Fact]
+    public void TryExecuteOnGpu_ConvenienceOverload_DropsReason()
+    {
+        var priorEngine = AiDotNetEngine.Current;
+        AiDotNetEngine.Current = new CpuEngine();
+        try
+        {
+            bool cpuRan = false;
+            var ranOnGpu = GpuRoutingHelpers.TryExecuteOnGpu(
+                _ => { },
+                () => { cpuRan = true; });
+
+            Assert.False(ranOnGpu);
+            Assert.True(cpuRan);
+        }
+        finally
+        {
+            AiDotNetEngine.Current = priorEngine;
+        }
+    }
+
+    [Fact]
+    public void IsGpuActiveOnCurrentEngine_CpuEngineSet_ReturnsFalse()
+    {
+        var priorEngine = AiDotNetEngine.Current;
+        AiDotNetEngine.Current = new CpuEngine();
+        try
+        {
+            Assert.False(GpuRoutingHelpers.IsGpuActiveOnCurrentEngine());
+        }
+        finally
+        {
+            AiDotNetEngine.Current = priorEngine;
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Gpu/GpuRoutingHelpersTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Gpu/GpuRoutingHelpersTests.cs
@@ -5,12 +5,24 @@ using Xunit;
 namespace AiDotNet.Tensors.Tests.Engines.Gpu;
 
 /// <summary>
+/// xUnit collection marker that disables parallel execution for
+/// tests touching <c>AiDotNetEngine.Current</c>. Any other test class
+/// that reads or overrides the process-global engine should join this
+/// collection — same pattern as <c>BlasGlobalState</c> / <c>WeightRegistry</c>.
+/// PR #342 review: without this gate, parallel tests racing on
+/// <c>AiDotNetEngine.Current</c> produce intermittent failures.
+/// </summary>
+[CollectionDefinition("AiDotNetEngineCurrentState", DisableParallelization = true)]
+public sealed class AiDotNetEngineCurrentStateCollection { }
+
+/// <summary>
 /// Issue #334: covers the Tensors-side capability surface that
 /// <c>AiDotNet.NeuralNetworkBase.Train</c> calls when deciding whether to
 /// dispatch a training step to the GPU. The actual <c>Train()</c> dispatch
 /// fix ships in a companion AiDotNet PR; this suite validates the helpers
 /// that companion PR depends on.
 /// </summary>
+[Collection("AiDotNetEngineCurrentState")]
 public class GpuRoutingHelpersTests
 {
     [Fact]


### PR DESCRIPTION
## Summary

Partial close for #334 — provides the Tensors-side capability surface the consumer-side `NeuralNetworkBase.Train()` dispatcher needs. The actual `Train()` auto-route ships in a companion AiDotNet PR (per the issue body: *"Tensors PR provides the routing-decision capability surface; AiDotNet PR wires the entry point"*).

## What this PR adds

`AiDotNet.Tensors.Engines.Gpu.GpuRoutingHelpers`:

| API | Purpose |
|---|---|
| `IsGpuActive(engine)` | True iff engine is `DirectGpuTensorEngine` with a live async-capable backend |
| `IsGpuActiveOnCurrentEngine()` | Same applied to `AiDotNetEngine.Current` |
| `TryGetAsyncBackend(engine)` | Exposes `IAsyncGpuBackend` for callers that want `ExecuteDeferred` directly |
| `TryExecuteOnGpu(gpuAction, cpuFallback, options, out reason)` | Single-call dispatcher: runs `gpuAction` inside `ExecuteDeferred` when GPU is active, otherwise runs `cpuFallback`. Returns whether GPU path ran + human-readable reason on skip (matches issue #334's "fallback with debug log" requirement) |
| `TryExecuteOnGpu(gpuAction, cpuFallback, options)` | Convenience overload that drops the `reason` |

## What stays consumer-side (per #334)

Per-layer / per-loss / per-optimizer eligibility (steps 2–4 of the issue's required behavior) lives in AiDotNet — Tensors doesn't know about `IGpuLayer`, loss-function types, or optimizer wiring. The companion PR combines those checks with these helpers to make the final routing decision in `Train()`.

## Default options

`TryExecuteOnGpu` defaults to `GpuExecutionOptions.FromEnvironment()` which sets:
- `EnableGpuResidency = true` — keeps activations + weights GPU-resident, avoiding the H2D/D2H round-trip that dominated the VGG11 profile cited in #334
- `EnableGraphCompilation = true` — compiles the recorded graph for repeated training steps

## Test plan

- [x] 9 unit tests cover: null engine, CPU engine, async-backend acquisition, fallback invocation, reason emission, null-argument validation, convenience overload, and `IsGpuActiveOnCurrentEngine` with a CPU engine
- [x] All 9 pass
- [x] Full solution builds clean (0 errors, 0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)