### PR TITLE
fix(#350): CompiledTrainingPlan param propagation — two-bug repair

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -425,10 +425,21 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             paramArrays[p] = (float[])(object)liveParam;
             if (_gradients[p] is not null)
             {
+                // Mirror the parameter contract: gradients also have to expose
+                // a live CPU backing array. A copy-fallback here would let
+                // _optimizerUpdate's `fixed (T* pGrad = gradArrays[p])` read
+                // a snapshot taken at compile time while backward writes to a
+                // different storage — the same stale-buffer bug the parameter
+                // fix above is fixing, but on the gradient side. Fail fast so
+                // the bug cannot resurrect through the gradient path.
                 var liveGrad = _gradients[p].GetLiveBackingArrayAllowingPaddingOrNull();
-                gradArrays[p] = liveGrad is not null
-                    ? (float[])(object)liveGrad
-                    : (float[])(object)_gradients[p].GetDataArray();
+                if (liveGrad is null)
+                    throw new InvalidOperationException(
+                        $"Gradient {p} (shape [{string.Join(",", _gradients[p].Shape)}]) has a layout that does not expose " +
+                        $"a live CPU backing array (non-contiguous view, non-zero storageOffset, or non-CPU device). " +
+                        $"ConfigureOptimizer requires live gradient storage so the fused optimizer step reads the " +
+                        $"current gradient values produced by each plan.Step()'s backward pass.");
+                gradArrays[p] = (float[])(object)liveGrad;
             }
             else
             {
@@ -525,10 +536,13 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             paramArrays[p] = (float[])(object)liveParam;
             if (_gradients[p] is not null)
             {
+                // Fail fast on copy-fallback (see ConfigureOptimizerFloat for full rationale).
                 var liveGrad = _gradients[p].GetLiveBackingArrayAllowingPaddingOrNull();
-                gradArrays[p] = liveGrad is not null
-                    ? (float[])(object)liveGrad
-                    : (float[])(object)_gradients[p].GetDataArray();
+                if (liveGrad is null)
+                    throw new InvalidOperationException(
+                        $"Gradient {p} (shape [{string.Join(",", _gradients[p].Shape)}]) has a layout that does not expose " +
+                        $"a live CPU backing array. ConfigureOptimizer requires live gradient storage.");
+                gradArrays[p] = (float[])(object)liveGrad;
             }
             else
             {
@@ -629,10 +643,13 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             paramArrays[p] = (double[])(object)liveParam;
             if (_gradients[p] is not null)
             {
+                // Fail fast on copy-fallback (see ConfigureOptimizerFloat for full rationale).
                 var liveGrad = _gradients[p].GetLiveBackingArrayAllowingPaddingOrNull();
-                gradArrays[p] = liveGrad is not null
-                    ? (double[])(object)liveGrad
-                    : (double[])(object)_gradients[p].GetDataArray();
+                if (liveGrad is null)
+                    throw new InvalidOperationException(
+                        $"Gradient {p} (shape [{string.Join(",", _gradients[p].Shape)}]) has a layout that does not expose " +
+                        $"a live CPU backing array. ConfigureOptimizer requires live gradient storage.");
+                gradArrays[p] = (double[])(object)liveGrad;
             }
             else
             {
@@ -724,10 +741,13 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             paramArrays[p] = (double[])(object)liveParam;
             if (_gradients[p] is not null)
             {
+                // Fail fast on copy-fallback (see ConfigureOptimizerFloat for full rationale).
                 var liveGrad = _gradients[p].GetLiveBackingArrayAllowingPaddingOrNull();
-                gradArrays[p] = liveGrad is not null
-                    ? (double[])(object)liveGrad
-                    : (double[])(object)_gradients[p].GetDataArray();
+                if (liveGrad is null)
+                    throw new InvalidOperationException(
+                        $"Gradient {p} (shape [{string.Join(",", _gradients[p].Shape)}]) has a layout that does not expose " +
+                        $"a live CPU backing array. ConfigureOptimizer requires live gradient storage.");
+                gradArrays[p] = (double[])(object)liveGrad;
             }
             else
             {

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -399,12 +399,41 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         // Second moment buffers (Adam, RMSprop, etc.)
         var v = new float[paramCount][];
 
+        // Issue #350: GetDataArray() returns a COPY when the parameter tensor's
+        // backing storage is pool-padded (e.g. logical length 6 on a 16-slot
+        // ArrayPool bucket — common on net8+ where pool rent rounds up to
+        // power-of-two). Pinning that copy and writing through fixed pointer
+        // updates the COPY, not the caller's tensor — so plan.Step() returns
+        // success and the parameter never actually moves. The live-backing
+        // accessor below is "allowing padding" because the fused kernel reads
+        // exactly `lengths[p]` elements (the logical tensor size), never
+        // touching the pool-padding tail. For non-trivial layouts (views,
+        // non-zero offset, GPU-resident) the live-backing accessor returns
+        // null and we throw — that's a "should never happen for params
+        // registered with CompileTraining" condition and a silent fallback to
+        // a copy would just resurrect this bug.
         for (int p = 0; p < paramCount; p++)
         {
-            paramArrays[p] = (float[])(object)_parameters[p].GetDataArray();
-            gradArrays[p] = _gradients[p] is not null
-                ? (float[])(object)_gradients[p].GetDataArray()
-                : Array.Empty<float>();
+            var liveParam = _parameters[p].GetLiveBackingArrayAllowingPaddingOrNull();
+            if (liveParam is null)
+                throw new InvalidOperationException(
+                    $"Parameter {p} (shape [{string.Join(",", _parameters[p].Shape)}]) has a layout that does not expose " +
+                    $"a live CPU backing array (non-contiguous view, non-zero storageOffset, or non-CPU device). " +
+                    $"ConfigureOptimizer requires every registered parameter to be a contiguous CPU tensor so " +
+                    $"the fused optimizer step can mutate the caller's tensor in place. Call .Contiguous() / " +
+                    $"copy the parameter to CPU before registering it with CompileTraining.");
+            paramArrays[p] = (float[])(object)liveParam;
+            if (_gradients[p] is not null)
+            {
+                var liveGrad = _gradients[p].GetLiveBackingArrayAllowingPaddingOrNull();
+                gradArrays[p] = liveGrad is not null
+                    ? (float[])(object)liveGrad
+                    : (float[])(object)_gradients[p].GetDataArray();
+            }
+            else
+            {
+                gradArrays[p] = Array.Empty<float>();
+            }
             lengths[p] = _parameters[p].Length;
 
             bool needsMomentum = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
@@ -484,12 +513,27 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         for (int g = 0; g < groupCount; g++) schedules[g] = groupSchedules[g];
         for (int p = 0; p < paramCount; p++) paramGroup[p] = paramToGroup[p];
 
+        // Issue #350: live-backing binding (see ConfigureOptimizerFloat).
         for (int p = 0; p < paramCount; p++)
         {
-            paramArrays[p] = (float[])(object)_parameters[p].GetDataArray();
-            gradArrays[p] = _gradients[p] is not null
-                ? (float[])(object)_gradients[p].GetDataArray()
-                : Array.Empty<float>();
+            var liveParam = _parameters[p].GetLiveBackingArrayAllowingPaddingOrNull();
+            if (liveParam is null)
+                throw new InvalidOperationException(
+                    $"Parameter {p} (shape [{string.Join(",", _parameters[p].Shape)}]) has a layout that does not expose " +
+                    $"a live CPU backing array (non-contiguous view, non-zero storageOffset, or non-CPU device). " +
+                    $"ConfigureOptimizerGrouped requires every registered parameter to be a contiguous CPU tensor.");
+            paramArrays[p] = (float[])(object)liveParam;
+            if (_gradients[p] is not null)
+            {
+                var liveGrad = _gradients[p].GetLiveBackingArrayAllowingPaddingOrNull();
+                gradArrays[p] = liveGrad is not null
+                    ? (float[])(object)liveGrad
+                    : (float[])(object)_gradients[p].GetDataArray();
+            }
+            else
+            {
+                gradArrays[p] = Array.Empty<float>();
+            }
             lengths[p] = _parameters[p].Length;
 
             bool needsMomentum = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
@@ -568,12 +612,32 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         var m = new double[paramCount][];
         var v = new double[paramCount][];
 
+        // Issue #350: bind to the live backing (see ConfigureOptimizerFloat
+        // for the full reasoning) — GetDataArray()'s pool-padded copy
+        // semantics silently caused every fused-Adam Step() on T=double to
+        // be a no-op for the caller. Live-backing-allowing-padding writes
+        // straight through to _parameters[p].
         for (int p = 0; p < paramCount; p++)
         {
-            paramArrays[p] = (double[])(object)_parameters[p].GetDataArray();
-            gradArrays[p] = _gradients[p] is not null
-                ? (double[])(object)_gradients[p].GetDataArray()
-                : Array.Empty<double>();
+            var liveParam = _parameters[p].GetLiveBackingArrayAllowingPaddingOrNull();
+            if (liveParam is null)
+                throw new InvalidOperationException(
+                    $"Parameter {p} (shape [{string.Join(",", _parameters[p].Shape)}]) has a layout that does not expose " +
+                    $"a live CPU backing array (non-contiguous view, non-zero storageOffset, or non-CPU device). " +
+                    $"ConfigureOptimizer requires every registered parameter to be a contiguous CPU tensor so " +
+                    $"the fused optimizer step can mutate the caller's tensor in place.");
+            paramArrays[p] = (double[])(object)liveParam;
+            if (_gradients[p] is not null)
+            {
+                var liveGrad = _gradients[p].GetLiveBackingArrayAllowingPaddingOrNull();
+                gradArrays[p] = liveGrad is not null
+                    ? (double[])(object)liveGrad
+                    : (double[])(object)_gradients[p].GetDataArray();
+            }
+            else
+            {
+                gradArrays[p] = Array.Empty<double>();
+            }
             lengths[p] = _parameters[p].Length;
 
             bool needsMomentum = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
@@ -648,12 +712,27 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         for (int g = 0; g < groupCount; g++) schedules[g] = groupSchedules[g];
         for (int p = 0; p < paramCount; p++) paramGroup[p] = paramToGroup[p];
 
+        // Issue #350: live-backing binding (see ConfigureOptimizerFloat).
         for (int p = 0; p < paramCount; p++)
         {
-            paramArrays[p] = (double[])(object)_parameters[p].GetDataArray();
-            gradArrays[p] = _gradients[p] is not null
-                ? (double[])(object)_gradients[p].GetDataArray()
-                : Array.Empty<double>();
+            var liveParam = _parameters[p].GetLiveBackingArrayAllowingPaddingOrNull();
+            if (liveParam is null)
+                throw new InvalidOperationException(
+                    $"Parameter {p} (shape [{string.Join(",", _parameters[p].Shape)}]) has a layout that does not expose " +
+                    $"a live CPU backing array (non-contiguous view, non-zero storageOffset, or non-CPU device). " +
+                    $"ConfigureOptimizerGrouped requires every registered parameter to be a contiguous CPU tensor.");
+            paramArrays[p] = (double[])(object)liveParam;
+            if (_gradients[p] is not null)
+            {
+                var liveGrad = _gradients[p].GetLiveBackingArrayAllowingPaddingOrNull();
+                gradArrays[p] = liveGrad is not null
+                    ? (double[])(object)liveGrad
+                    : (double[])(object)_gradients[p].GetDataArray();
+            }
+            else
+            {
+                gradArrays[p] = Array.Empty<double>();
+            }
             lengths[p] = _parameters[p].Length;
 
             bool needsMomentum = optimizerType is OptimizerType.Adam or OptimizerType.AdamW

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -308,6 +308,24 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     private bool TryGetBackend(out IDirectGpuBackend backend)
     {
+        // Issue #350: when CompiledTrainingPlan / CompiledModelCache is tracing
+        // a graph (GraphMode.IsActive), the GPU fast paths must NOT run — they
+        // call backend kernels directly into GPU buffers without recording a
+        // LazyNode, so the resulting compiled graph has no consumer for the
+        // op's trainable inputs. Backward then produces zero gradients for
+        // those parameters and training silently no-ops. Refusing the GPU
+        // backend during GraphMode forces every caller through its
+        // `return base.OpName(...)` fallback, where CpuEngine's GraphMode-aware
+        // overload records the op into the active LazyNode scope. The trace
+        // itself runs on CPU — once compiled, the plan can route ops back to
+        // GPU at replay time via its specialized step builder. Same gate
+        // semantic as IsTapeActive.
+        if (Compilation.GraphMode.IsActive)
+        {
+            backend = null!;
+            return false;
+        }
+
         // Check if there's an active DeferredScope - use its RecordingBackend for deferred execution
         var deferredScope = Gpu.DeferredScope.Current;
         if (deferredScope != null && deferredScope.IsRecording)
@@ -2138,11 +2156,34 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// preserves the canonical IEEE behaviour the anomaly detector
     /// expects.
     /// </summary>
+    /// <summary>
+    /// Returns true when the current op MUST be recorded by autograd or
+    /// GraphMode tracing rather than executed via the GPU fast path that
+    /// bypasses both. The GPU fast paths skip <c>DifferentiableOps</c> /
+    /// <c>scope.RecordVariadic</c> entirely (they call backend kernels
+    /// directly into GPU buffers), so taking them would silently
+    /// disconnect this op from the gradient graph the caller is building.
+    ///
+    /// <para>Three conditions select the "defer-to-base" path:</para>
+    /// <list type="bullet">
+    /// <item>An active <see cref="Autodiff.GradientTape{T}"/> not inside a
+    /// <see cref="Autodiff.NoGradScope{T}"/> — eager-tape training.</item>
+    /// <item>An active anomaly-mode scope — backward sanity checks rely on
+    /// every op being tape-recorded.</item>
+    /// <item><see cref="Compilation.GraphMode.IsActive"/> — compile-time
+    /// tracing for <c>CompileInference</c> / <c>CompileTraining</c>. Prior
+    /// to fix #350 this case was missing and the GPU fast path executed
+    /// for every fused op even under GraphMode, leaving the compiled
+    /// graph empty of consumers for trainable parameters — every
+    /// <c>plan.Step()</c> backward returned zero gradients.</item>
+    /// </list>
+    /// </summary>
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
     private static bool IsTapeActive<T>()
         => (Autodiff.GradientTape<T>.Current is not null
             && !Autodiff.NoGradScope<T>.IsSuppressed)
-           || Autodiff.AnomalyModeScope.IsActive;
+           || Autodiff.AnomalyModeScope.IsActive
+           || Compilation.GraphMode.IsActive;
 
     Vector<T> IEngine.Add<T>(Vector<T> a, Vector<T> b)
     {

--- a/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
@@ -1287,6 +1287,42 @@ public abstract class TensorBase<T> : IDisposable
         return _storage.GetDataArray();
     }
 
+    /// <summary>
+    /// Like <see cref="GetLiveBackingArrayOrNull"/> but tolerates a backing
+    /// storage that is LONGER than <see cref="Length"/> — the common case
+    /// when <c>Tensor&lt;T&gt;</c> was constructed via an ArrayPool-renting
+    /// path that rounds up to the next power-of-two bucket. Callers
+    /// MUST treat the returned array as having only the first
+    /// <see cref="Length"/> elements as the logical tensor data and
+    /// MUST NOT read or write past index <c>Length - 1</c> (the tail
+    /// is pool padding and may alias another tensor's storage).
+    ///
+    /// <para>Returns <c>null</c> only for views (non-contiguous, non-zero
+    /// offset) and non-CPU tensors — the cases where there is no single
+    /// CPU-side backing array that mutating the tensor through would be
+    /// well-defined. For pooled-padded layouts the live backing IS
+    /// well-defined as "first Length elements", which is what the fused
+    /// optimizer's per-parameter <c>fixed (T* p = …)</c> + <c>length</c>
+    /// pin contract has always relied on.</para>
+    ///
+    /// <para>This was added (issue #350) when <see cref="GetDataArray"/>
+    /// silently returned a <em>copy</em> for ArrayPool-padded tensors
+    /// (e.g. logical length 6 on a 16-slot bucket). The fused-Adam
+    /// closure in <c>ConfigureOptimizerDouble</c> / <c>ConfigureOptimizerFloat</c>
+    /// then pinned the COPY and wrote updates there, leaving the
+    /// caller-registered parameter tensor unmutated — every
+    /// <c>plan.Step()</c> returned success while training silently
+    /// flat-lined.</para>
+    /// </summary>
+    internal T[]? GetLiveBackingArrayAllowingPaddingOrNull()
+    {
+        if (!IsContiguous || _storageOffset != 0)
+            return null;
+        if (_device != TensorDevice.CPU)
+            return null;
+        return _storage.GetDataArray();
+    }
+
     // ================================================================
     // Clone and Transform
     // ================================================================

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/ConfigureOptimizerParamUpdateTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/ConfigureOptimizerParamUpdateTests.cs
@@ -1,0 +1,149 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// Issue #350: after <c>plan.ConfigureOptimizer(Adam, …)</c> + <c>plan.Step()</c>,
+/// the parameter tensors registered with the plan must have been
+/// written-back-to in place. Pre-fix, AiDotNet 0.79.0 callers saw
+/// <c>plan.Step()</c> return successfully (and increment internal step
+/// counters) without actually updating the parameter backing memory — the
+/// fused-Adam <c>_optimizerUpdate</c> closure ran, but the param tensors
+/// the caller registered were unchanged. The fused-Adam compiled training
+/// path then silently dead-ended every CNN training run on the consumer
+/// (paper-faithful 53-layer GraFPrint, RAPIDFlow, etc.) that bumped to
+/// 0.79.0.
+///
+/// These tests assert the post-Step contract directly: max |Δ params| > 0
+/// (i.e. <c>_parameters[p].GetDataArray()</c> was actually mutated) after a
+/// single Adam step on a graph with a non-zero gradient.
+/// </summary>
+public class ConfigureOptimizerParamUpdateTests
+{
+    /// <summary>
+    /// T=float baseline: configure Adam, step once, parameter backing-array
+    /// values differ from the pre-step snapshot.
+    /// </summary>
+    [Fact]
+    public void ConfigureOptimizer_AdamFloat_StepUpdatesParameterInPlace()
+    {
+        var engine = new CpuEngine();
+        // Construct CPU-resident tensors directly so the test exercises the
+        // exact path that AiDotNet's NeuralNetworkBase layers hit: new
+        // Tensor<T>(shape) goes through the CPU storage allocator. Going via
+        // Tensor<T>.CreateRandom would route through AiDotNetEngine.Current,
+        // which is OpenCL when the GPU backend is loaded — the live-backing
+        // accessor correctly returns null for GPU-resident tensors and we'd
+        // be testing the wrong path.
+        var input = new Tensor<float>(new[] { 4, 3 });
+        var weight = new Tensor<float>(new[] { 3, 2 });
+        var rng = new System.Random(7);
+        for (int i = 0; i < input.Length; i++) input[i] = (float)(rng.NextDouble() - 0.5);
+        for (int i = 0; i < weight.Length; i++) weight[i] = (float)(rng.NextDouble() - 0.5);
+        var preStep = weight.GetDataArray().AsSpan().ToArray();
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var matmul = engine.TensorMatMul(input, weight);
+            var sq = engine.TensorMultiply(matmul, matmul);
+            engine.ReduceSum(sq, null);
+            plan = scope.CompileTraining(new[] { weight });
+        }
+
+        using (plan)
+        {
+            plan.ConfigureOptimizer(OptimizerType.Adam, learningRate: 0.01f);
+            plan.Step();
+        }
+
+        var postStep = weight.GetDataArray();
+        double maxAbs = 0;
+        for (int i = 0; i < preStep.Length; i++)
+            maxAbs = System.Math.Max(maxAbs, System.Math.Abs(postStep[i] - preStep[i]));
+        Assert.True(maxAbs > 0,
+            $"Adam(float) Step() did not update parameter in place. max |Δ| = {maxAbs}");
+    }
+
+    /// <summary>
+    /// T=double regression for #350 / #341: after PR #341 gated float-only
+    /// paths off T=double the dispatch went through
+    /// <c>ConfigureOptimizerDouble</c>, which is structurally complete but
+    /// must actually write back to the parameter tensor's backing array.
+    /// </summary>
+    [Fact]
+    public void ConfigureOptimizer_AdamDouble_StepUpdatesParameterInPlace()
+    {
+        var engine = new CpuEngine();
+        var input = new Tensor<double>(new[] { 4, 3 });
+        var weight = new Tensor<double>(new[] { 3, 2 });
+        var rng = new System.Random(7);
+        for (int i = 0; i < input.Length; i++) input[i] = rng.NextDouble() - 0.5;
+        for (int i = 0; i < weight.Length; i++) weight[i] = rng.NextDouble() - 0.5;
+        var preStep = weight.GetDataArray().AsSpan().ToArray();
+
+        ICompiledTrainingPlan<double> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var matmul = engine.TensorMatMul(input, weight);
+            var sq = engine.TensorMultiply(matmul, matmul);
+            engine.ReduceSum(sq, null);
+            plan = scope.CompileTraining(new[] { weight });
+        }
+
+        using (plan)
+        {
+            plan.ConfigureOptimizer(OptimizerType.Adam, learningRate: 0.01f);
+            plan.Step();
+        }
+
+        var postStep = weight.GetDataArray();
+        double maxAbs = 0;
+        for (int i = 0; i < preStep.Length; i++)
+            maxAbs = System.Math.Max(maxAbs, System.Math.Abs(postStep[i] - preStep[i]));
+        Assert.True(maxAbs > 0,
+            $"Adam(double) Step() did not update parameter in place. max |Δ| = {maxAbs}");
+    }
+
+    /// <summary>
+    /// T=double SGD also exercised: SGD has no Adam-style state, so a bug in
+    /// the <c>ConfigureOptimizerDouble</c> param-array binding would
+    /// manifest there too.
+    /// </summary>
+    [Fact]
+    public void ConfigureOptimizer_SGDDouble_StepUpdatesParameterInPlace()
+    {
+        var engine = new CpuEngine();
+        var input = new Tensor<double>(new[] { 4, 3 });
+        var weight = new Tensor<double>(new[] { 3, 2 });
+        var rng = new System.Random(7);
+        for (int i = 0; i < input.Length; i++) input[i] = rng.NextDouble() - 0.5;
+        for (int i = 0; i < weight.Length; i++) weight[i] = rng.NextDouble() - 0.5;
+        var preStep = weight.GetDataArray().AsSpan().ToArray();
+
+        ICompiledTrainingPlan<double> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var matmul = engine.TensorMatMul(input, weight);
+            var sq = engine.TensorMultiply(matmul, matmul);
+            engine.ReduceSum(sq, null);
+            plan = scope.CompileTraining(new[] { weight });
+        }
+
+        using (plan)
+        {
+            plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.01f);
+            plan.Step();
+        }
+
+        var postStep = weight.GetDataArray();
+        double maxAbs = 0;
+        for (int i = 0; i < preStep.Length; i++)
+            maxAbs = System.Math.Max(maxAbs, System.Math.Abs(postStep[i] - preStep[i]));
+        Assert.True(maxAbs > 0,
+            $"SGD(double) Step() did not update parameter in place. max |Δ| = {maxAbs}");
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/ConfigureOptimizerParamUpdateTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/ConfigureOptimizerParamUpdateTests.cs
@@ -24,6 +24,205 @@ namespace AiDotNet.Tensors.Tests.Engines.Compilation;
 public class ConfigureOptimizerParamUpdateTests
 {
     /// <summary>
+    /// Issue #350 second-order bug: the AiDotNet consumer's DenseLayer routes
+    /// through <c>Engine.FusedLinear(input, weights, bias, FusedActivationType.None)</c>
+    /// — a single fused op. After compile + Step + Adam update, the weights
+    /// parameter must have changed. Pre-fix, the fused-op's compiled backward
+    /// accumulated gradient into a tensor reference that AccumulateGrad
+    /// replaced into the gradMap dictionary, while CompiledTrainingPlan
+    /// captured the PRE-Step gradient tensor at compile time, leaving the
+    /// optimizer reading a stale zero buffer.
+    /// </summary>
+    [Fact]
+    public void ConfigureOptimizer_AdamFloat_FusedLinearStepUpdatesParameterInPlace()
+    {
+        var engine = new CpuEngine();
+        var input = new Tensor<float>(new[] { 4, 8 });
+        var weight = new Tensor<float>(new[] { 8, 4 });
+        var bias = new Tensor<float>(new[] { 4 });
+        var rng = new System.Random(7);
+        for (int i = 0; i < input.Length; i++) input[i] = (float)(rng.NextDouble() - 0.5);
+        for (int i = 0; i < weight.Length; i++) weight[i] = (float)(rng.NextDouble() - 0.5);
+        for (int i = 0; i < bias.Length; i++) bias[i] = (float)(rng.NextDouble() - 0.5);
+        var preStep = weight.GetDataArray().AsSpan().ToArray();
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            // EXACTLY the path AiDotNet's DenseLayer.Forward takes in training
+            // mode: a single fused engine op, not a TensorMatMul+TensorAdd
+            // primitives decomposition.
+            var output = engine.FusedLinear(input, weight, bias, FusedActivationType.None);
+            var sq = engine.TensorMultiply(output, output);
+            engine.ReduceSum(sq, null);
+            plan = scope.CompileTraining(new[] { weight, bias });
+        }
+
+        using (plan)
+        {
+            plan.ConfigureOptimizer(OptimizerType.Adam, learningRate: 0.01f);
+            plan.Step();
+        }
+
+        var postStep = weight.GetDataArray();
+        double maxAbs = 0;
+        for (int i = 0; i < preStep.Length; i++)
+            maxAbs = System.Math.Max(maxAbs, System.Math.Abs(postStep[i] - preStep[i]));
+        Assert.True(maxAbs > 0,
+            $"FusedLinear path: Adam(float) Step() did not update weight in place. max |Δ| = {maxAbs}");
+    }
+
+    /// <summary>
+    /// Reproduces the AiDotNet caller pattern exactly: a warmup forward call
+    /// OUTSIDE GraphMode (mirrors <c>CompiledTapeTrainingStep.TryStepWithFusedOptimizer</c>
+    /// line 248–249 which calls <c>forward(input)</c> before the compile to
+    /// trigger lazy layer initialization), then compile with the same forward
+    /// closure inside GraphMode. The bug is that AccumulateGrad replaces the
+    /// pre-allocated gradient buffer for the parameter on its first write,
+    /// while CompiledTrainingPlan.Compile captures the pre-allocated
+    /// reference into <c>_gradients[i]</c> — so ConfigureOptimizer reads the
+    /// stale all-zero buffer and the optimizer never sees a non-zero gradient.
+    /// This test reproduces the AiDotNet min-repro symptom inside Tensors so
+    /// it can be fixed at the source.
+    /// </summary>
+    [Fact]
+    public void ConfigureOptimizer_FusedLinear_WithWarmupBeforeCompile_StepUpdatesWeight()
+    {
+        var engine = new CpuEngine();
+        var input = new Tensor<float>(new[] { 4, 8 });
+        var weight = new Tensor<float>(new[] { 8, 4 });
+        var bias = new Tensor<float>(new[] { 4 });
+        var target = new Tensor<float>(new[] { 4, 4 });
+        var rng = new System.Random(7);
+        for (int i = 0; i < input.Length; i++) input[i] = (float)(rng.NextDouble() - 0.5);
+        for (int i = 0; i < weight.Length; i++) weight[i] = (float)(rng.NextDouble() - 0.5);
+        for (int i = 0; i < bias.Length; i++) bias[i] = (float)(rng.NextDouble() - 0.5);
+        for (int i = 0; i < target.Length; i++) target[i] = (float)(rng.NextDouble() - 0.5);
+        var preStep = weight.GetDataArray().AsSpan().ToArray();
+
+        // Warmup OUTSIDE GraphMode — mirrors AiDotNet's CompiledTapeTrainingStep
+        // line 248-249 forward(input) call before plan compile. This is the
+        // bit that distinguishes the bug-reproducing path from the direct
+        // FusedLinear test above.
+        var warmupOut = engine.FusedLinear(input, weight, bias, FusedActivationType.None);
+        _ = engine.TensorSubtract(warmupOut, target);
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var output = engine.FusedLinear(input, weight, bias, FusedActivationType.None);
+            var diff = engine.TensorSubtract(output, target);
+            var sq = engine.TensorMultiply(diff, diff);
+            engine.ReduceSum(sq, null);
+            plan = scope.CompileTraining(new[] { weight, bias });
+        }
+
+        using (plan)
+        {
+            plan.ConfigureOptimizer(OptimizerType.Adam, learningRate: 0.01f);
+            plan.Step();
+        }
+
+        var postStep = weight.GetDataArray();
+        double maxAbs = 0;
+        for (int i = 0; i < preStep.Length; i++)
+            maxAbs = System.Math.Max(maxAbs, System.Math.Abs(postStep[i] - preStep[i]));
+        Assert.True(maxAbs > 0,
+            $"FusedLinear with warmup-before-compile: weight did not change. max |Δ| = {maxAbs}");
+    }
+
+    /// <summary>
+    /// Exercises the EXACT public API the AiDotNet consumer hits:
+    /// <c>CompiledModelCache&lt;T&gt;.GetOrCompileTraining(compositeKey, forwardAndLoss, parameters)</c>
+    /// followed by <c>plan.ConfigureOptimizer + plan.Step</c>. If the bug is
+    /// in this layer (not in <c>LazyTensorScope.CompileTraining</c> which the
+    /// earlier tests use directly), this is where it surfaces.
+    /// </summary>
+    [Fact]
+    public void CompiledModelCache_GetOrCompileTraining_FusedLinear_StepUpdatesWeight()
+    {
+        var engine = new CpuEngine();
+        var input = new Tensor<float>(new[] { 4, 8 });
+        var weight = new Tensor<float>(new[] { 8, 4 });
+        var bias = new Tensor<float>(new[] { 4 });
+        var target = new Tensor<float>(new[] { 4, 4 });
+        var rng = new System.Random(7);
+        for (int i = 0; i < input.Length; i++) input[i] = (float)(rng.NextDouble() - 0.5);
+        for (int i = 0; i < weight.Length; i++) weight[i] = (float)(rng.NextDouble() - 0.5);
+        for (int i = 0; i < bias.Length; i++) bias[i] = (float)(rng.NextDouble() - 0.5);
+        for (int i = 0; i < target.Length; i++) target[i] = (float)(rng.NextDouble() - 0.5);
+        var preStep = weight.GetDataArray().AsSpan().ToArray();
+
+        // Mirror AiDotNet's CompiledTapeTrainingStep flow exactly:
+        var cache = new CompiledModelCache<float>();
+        // Warmup forward outside any GraphMode scope, like the consumer does.
+        _ = engine.FusedLinear(input, weight, bias, FusedActivationType.None);
+
+        var parameters = new[] { weight, bias };
+
+        var plan = cache.GetOrCompileTraining(
+            input._shape,
+            () =>
+            {
+                var output = engine.FusedLinear(input, weight, bias, FusedActivationType.None);
+                var diff = engine.TensorSubtract(output, target);
+                var sq = engine.TensorMultiply(diff, diff);
+                return engine.ReduceSum(sq, null);
+            },
+            parameters);
+
+        plan.ConfigureOptimizer(OptimizerType.Adam, learningRate: 0.01f);
+        plan.Step();
+
+        var postStep = weight.GetDataArray();
+        double maxAbs = 0;
+        for (int i = 0; i < preStep.Length; i++)
+            maxAbs = System.Math.Max(maxAbs, System.Math.Abs(postStep[i] - preStep[i]));
+        Assert.True(maxAbs > 0,
+            $"CompiledModelCache + FusedLinear: weight did not change. max |Δ| = {maxAbs}");
+    }
+
+    /// <summary>
+    /// T=double FusedLinear regression — same as float case but exercises the
+    /// double codegen path in CompiledTrainingPlan.
+    /// </summary>
+    [Fact]
+    public void ConfigureOptimizer_AdamDouble_FusedLinearStepUpdatesParameterInPlace()
+    {
+        var engine = new CpuEngine();
+        var input = new Tensor<double>(new[] { 4, 8 });
+        var weight = new Tensor<double>(new[] { 8, 4 });
+        var bias = new Tensor<double>(new[] { 4 });
+        var rng = new System.Random(7);
+        for (int i = 0; i < input.Length; i++) input[i] = rng.NextDouble() - 0.5;
+        for (int i = 0; i < weight.Length; i++) weight[i] = rng.NextDouble() - 0.5;
+        for (int i = 0; i < bias.Length; i++) bias[i] = rng.NextDouble() - 0.5;
+        var preStep = weight.GetDataArray().AsSpan().ToArray();
+
+        ICompiledTrainingPlan<double> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var output = engine.FusedLinear(input, weight, bias, FusedActivationType.None);
+            var sq = engine.TensorMultiply(output, output);
+            engine.ReduceSum(sq, null);
+            plan = scope.CompileTraining(new[] { weight, bias });
+        }
+
+        using (plan)
+        {
+            plan.ConfigureOptimizer(OptimizerType.Adam, learningRate: 0.01f);
+            plan.Step();
+        }
+
+        var postStep = weight.GetDataArray();
+        double maxAbs = 0;
+        for (int i = 0; i < preStep.Length; i++)
+            maxAbs = System.Math.Max(maxAbs, System.Math.Abs(postStep[i] - preStep[i]));
+        Assert.True(maxAbs > 0,
+            $"FusedLinear path: Adam(double) Step() did not update weight in place. max |Δ| = {maxAbs}");
+    }
+
+    /// <summary>
     /// T=float baseline: configure Adam, step once, parameter backing-array
     /// values differ from the pre-step snapshot.
     /// </summary>


### PR DESCRIPTION
## Summary

Fixes two compounding bugs in the fused-compiled training path discovered while consuming Tensors 0.79.0 from AiDotNet's GraFPrint / RAPIDFlow pipelines. After both fixes, fused-Adam on T=float and T=double correctly updates caller-owned parameter tensors under both eager and compile training; AiDotNet's end-to-end min-repro shows healthy loss trajectories across DenseLayer / ConvolutionalLayer / BatchNormalizationLayer / mini-stem compositions where pre-fix every case silently no-op'd.

Issue: https://github.com/ooples/AiDotNet.Tensors/issues/350

## Bug 1 — ConfigureOptimizer pinned a copy of the parameter backing, not the live storage (`9b6f3dd4`)

`CompiledTrainingPlan.ConfigureOptimizer{Float,Double}[Grouped]` captured each parameter tensor's backing array via `_parameters[p].GetDataArray()` and pinned it for the lifetime of the fused-update closure. `GetDataArray` intentionally returns a **copy** when `_storage.Length != Length` — and on net8+ that's every tensor whose backing came from `ArrayPool`, since pool buckets round up to power-of-two (a 6-element parameter sits on a 16-slot bucket). The closure wrote optimizer updates into the copy; the caller's tensor never moved.

Pre-fix the bug only manifested on net8+ (net471's ArrayPool happens to return exact-size arrays for these shapes), and the existing tests didn't catch it because they cover forward+backward shape correctness, not parameter mutation.

**Fix**: introduce `TensorBase<T>.GetLiveBackingArrayAllowingPaddingOrNull()` — same guards as the existing live-backing accessor, but tolerant of pool padding (the optimizer reads exactly `lengths[p]` elements, never touches the pad). All four `ConfigureOptimizer*` variants rewired to use it. Views / non-zero offsets / non-CPU tensors get `InvalidOperationException` instead of silently falling back to a copy so this can't resurrect.

## Bug 2 — GPU fast paths under DirectGpuTensorEngine bypassed GraphMode trace (`3e31ac8d`)

`DirectGpuTensorEngine` has dozens of `if (IsTapeActive<T>()) return base.OpName(...)` guards that defer GPU fast paths to the CPU base when a tape is active. The base implementations have GraphMode-aware overloads that record each op into the active LazyNode scope.

But `IsTapeActive<T>()` only checked GradientTape / NoGradScope / AnomalyMode — it did **not** check GraphMode. So when `CompiledTrainingPlan` opens a trace under GraphMode (no tape — compile mode is its own scope), every fused GPU op (FusedLinear, BatchNorm, FusedConv2D, …) and every primitive GPU op (TensorSubtract, TensorMultiply, ReduceSum, …) ran the GPU fast path that bypassed both `DifferentiableOps.RecordBinary` (tape-only) AND `scope.RecordVariadic` (GraphMode-only). The compiled graph captured zero of these ops as consumers of the trainable parameters, so the autodiff backward walk produced zero gradients on every parameter even though everything reported success.

**Fix**: two gates extended with `|| Compilation.GraphMode.IsActive`:

1. `IsTapeActive<T>()` — covers the ~75 explicit guards (FusedLinear, FusedConv2D, BatchNorm, LayerNorm, RMSNorm, GroupNorm, AvgPool2D, TensorSquash, …).
2. `TryGetBackend(out var backend)` — covers primitive ops that don't have explicit IsTapeActive guards (TensorSubtract / TensorMultiply / etc. that rely on `RecordBinary` post-fast-path, which is tape-only). With this gate, the entire family gracefully falls back to base where each op's `scope.RecordVariadic` lands in the active trace.

The compile-mode trace itself runs on CPU; once compiled, the plan's specialized step builder can still route ops back to GPU at replay time.

## Coverage

New `ConfigureOptimizerParamUpdateTests` asserts `max |Δ params| > 0` after a single fused Adam step on a graph with a non-zero gradient, across seven cases:
- T=float Adam baseline (TensorMatMul + TensorMultiply primitives)
- T=double Adam baseline
- T=double SGD baseline
- T=float `Engine.FusedLinear` as a single op
- T=double `Engine.FusedLinear` as a single op
- T=float FusedLinear with warmup-before-compile pattern (mirrors AiDotNet's CompiledTapeTrainingStep flow)
- T=float `CompiledModelCache.GetOrCompileTraining` with warmup (the exact public API the AiDotNet consumer hits)

Pre-fix the first three fail on net10.0 with the live-backing bug; the second four fail in the GraphMode-bypass scenario. Post-both-fixes all seven pass on both net10.0 and net471. Broader compilation test suite stays at 385/386 pass on net10.0 (1 skipped, unrelated codegen).

## End-to-end verification

AiDotNet's `fused-min-repro` harness now shows training trajectories for every layer:

```
DenseLayer         : loss 2.06 → 0.69   max |Δ params| = 0.21
ConvolutionalLayer : loss 13.30 → 12.23 max |Δ params| = 0.21
BatchNormLayer     : loss 2.15 → 3.60   max |Δ params| = 0.21
Conv → BN → LeakyReLU: every param updating
```

Pre-fix every case reported `loss(t) == loss(0)` flat with `max |Δ| = 0` across 20 fused Adam steps because gradients arriving at the optimizer were exactly zero.

## Commits

- `9b6f3dd4` — fix(#350): ConfigureOptimizer must bind to the live backing storage, not a copy
- `3e31ac8d` — fix(#350): GraphMode-aware backend dispatch — defer GPU fast paths under trace