### PR TITLE
fix(#350): bind LazyTensorScope/GradientTape to user's engine + channels-first layout gate

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
@@ -49,7 +49,8 @@ public sealed class GradientTape<T> : IDisposable
     private readonly GradientTape<T>? _parent;
     private readonly TapeEntryArena<T> _entries;
     private readonly GradientTapeOptions _options;
-    private readonly IEngine _engine;
+    private IEngine _engine;
+    private bool _engineExplicitlyBound;
     private readonly bool _savedReplayMode; // Saved ReplayMode from outer scope for nested tapes
     private bool _disposed;
 
@@ -84,6 +85,21 @@ public sealed class GradientTape<T> : IDisposable
     public IEngine Engine => _engine;
 
     /// <summary>
+    /// Binds this tape to <paramref name="engine"/> if no engine has yet been
+    /// explicitly bound. Idempotent — once bound, subsequent calls are
+    /// no-ops. Engine recording paths (e.g. <see cref="CpuEngine.BatchNorm{T}"/>)
+    /// call this with <c>this</c> so the backward walk dispatches to the same
+    /// engine instance the user invoked the forward op on. Closes #350.
+    /// </summary>
+    public void BindEngineIfUnset(IEngine engine)
+    {
+        if (_engineExplicitlyBound) return;
+        if (engine is null) return;
+        _engine = engine;
+        _engineExplicitlyBound = true;
+    }
+
+    /// <summary>
     /// Gets whether this tape has been disposed.
     /// </summary>
     public bool IsDisposed => _disposed;
@@ -109,7 +125,19 @@ public sealed class GradientTape<T> : IDisposable
         _entries = _cachedArena ?? new TapeEntryArena<T>();
         _cachedArena = null; // Take ownership — will return on Dispose
         _entries.Reset();
+        // Default to AiDotNetEngine.Current; the first op recorded onto the
+        // tape rebinds via BindEngineIfUnset to the engine instance the user
+        // actually invoked the op on. Same rationale as LazyTensorScope's
+        // engine binding (see issue #350): on auto-detect-GPU systems
+        // AiDotNetEngine.Current is DirectGpuTensorEngine, but tests or
+        // production code that explicitly creates a new CpuEngine() and
+        // calls operations on it expects backward to also run on CPU. Without
+        // this rebind the eager-tape backward and compiled backward dispatch
+        // to different engines, producing per-element double-precision
+        // divergences in the 1e-7 range that look like FMA noise but are
+        // actually two distinct backward kernels racing on different devices.
         _engine = AiDotNetEngine.Current;
+        _engineExplicitlyBound = false;
         _parent = _current;
         _savedReplayMode = Compilation.AutoTrainingCompiler.ReplayMode;
 

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledInferencePlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledInferencePlan.cs
@@ -978,6 +978,15 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
                     typed.GetInputsArray(),
                     typed.BackwardFn,
                     typed.SavedState));
+                // Same fix as CompiledTrainingPlan.cs (issue #350): the
+                // plan's Execute() method runs the lazy executes through
+                // its captured engine; clearing IsRealized + LazySource
+                // here prevents downstream tensor[i] / GetFlat / AsSpan
+                // reads from re-running Execute on the GPU's
+                // RecordingEngine and silently truncating to float
+                // precision. The plan owns materialization from now on.
+                typed.IsRealized = true;
+                typed.Output.LazySource = null;
             }
         }
 

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -2784,6 +2784,68 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             };
         }
 
+        // Conv2D backward: writes gradInput + gradKernel directly into the
+        // pre-allocated gradient buffers via Conv2DBackwardInputInto /
+        // Conv2DBackwardKernelInto — skips the 2 fresh tensor allocations +
+        // 2 chained AccumulateGrad calls that BackwardFunctions.Conv2DBackward
+        // pays per call. On a 19-Conv-layer net like GraFPrint this saves
+        // ~10 ms per Conv backward (allocator pressure + dispatch overhead).
+        // Tier 1.2 of the compile-mode backward perf overhaul (plan in
+        // ~/.claude/plans/misty-wandering-moth.md).
+        if (step.OpType == OpType.Conv2D && step.Inputs.Length == 2
+            && step.Inputs[0].IsContiguous && step.Inputs[1].IsContiguous)
+        {
+            var input = step.Inputs[0];
+            var kernel = step.Inputs[1];
+            var output = step.OutputBuffer;
+            if (!gradMap.ContainsKey(output) || !gradMap.ContainsKey(input) || !gradMap.ContainsKey(kernel))
+                return null;
+            // Saved state shape mirrors what BackwardFunctions.Conv2DBackward
+            // expects: [stride: int[], padding: int[], dilation: int[]].
+            // Some call paths extend savedState past index 2; same as the
+            // Conv2D forward specialization we tolerate that.
+            var savedState = step.SavedState;
+            if (savedState == null || savedState.Length < 3
+                || savedState[0] is not int[] stride
+                || savedState[1] is not int[] padding
+                || savedState[2] is not int[] dilation)
+                return null;
+            var gradOut = gradMap[output];
+            var gradInput = gradMap[input];
+            var gradKernel = gradMap[kernel];
+            bool accumInput = consumerCount.ContainsKey(input) && consumerCount[input] > 1;
+            bool accumKernel = consumerCount.ContainsKey(kernel) && consumerCount[kernel] > 1;
+            // Capture shapes so the closure doesn't walk Tensor.Shape every
+            // Step (microoptimization but matters at 19+ Conv calls per iter).
+            var inShape = (int[])input._shape.Clone();
+            var kShape = (int[])kernel._shape.Clone();
+            var capStride = stride;
+            var capPadding = padding;
+            var capDilation = dilation;
+            return eng =>
+            {
+                if (eng is CpuEngine cpu)
+                {
+                    cpu.Conv2DBackwardInputInto(gradInput, gradOut, kernel, inShape,
+                        capStride, capPadding, capDilation, accumInput);
+                    cpu.Conv2DBackwardKernelInto(gradKernel, gradOut, input, kShape,
+                        capStride, capPadding, capDilation, accumKernel);
+                }
+                else
+                {
+                    // Non-CpuEngine fallback — match the eager path semantics.
+                    var gi = eng.Conv2DBackwardInput(gradOut, kernel, inShape, capStride, capPadding, capDilation);
+                    if (accumInput) eng.TensorAddInto(gradInput, gradInput, gi);
+                    else gi.AsSpan().CopyTo(gradInput.AsWritableSpan());
+                    var gk = eng.Conv2DBackwardKernel(gradOut, input, kShape, capStride, capPadding, capDilation);
+                    if (accumKernel) eng.TensorAddInto(gradKernel, gradKernel, gk);
+                    else gk.AsSpan().CopyTo(gradKernel.AsWritableSpan());
+                }
+                input.Grad = gradInput;
+                kernel.Grad = gradKernel;
+            };
+        }
+
         // ReduceSum backward: broadcast scalar gradient to all elements
         // Only specialize for full scalar reduction (output length == 1)
         if (step.OpType == OpType.ReduceSum && step.Inputs.Length == 1

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -212,10 +212,42 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         _checkpointing = new GradientCheckpointing<T>(wrappedSteps, _engine, segmentSize);
     }
 
+    // Per-phase profiling counters — wall time accumulators in microseconds
+    // collected when AIDOTNET_PROFILE_STEP=1 is set in the environment. Read
+    // them from a test/diag harness via the static accessors below to break
+    // down where Step's wall time is going (forward / grad-zero / backward /
+    // optimizer). Zero overhead in hot path when disabled — single env-var
+    // read at static init, then a single bool check per Step.
+    private static readonly bool _profileStepEnabled =
+        System.Environment.GetEnvironmentVariable("AIDOTNET_PROFILE_STEP") == "1";
+    private static long _profForwardUs, _profGradZeroUs, _profBackwardUs, _profOptimUs;
+    private static int _profStepCount;
+    private static long[]? _profPerStepUs;
+    private static string[]? _profBackwardStepNames;
+    public static long[] ProfPerStepUs => _profPerStepUs ?? Array.Empty<long>();
+    public static string[] ProfBackwardStepNames => _profBackwardStepNames ?? Array.Empty<string>();
+    public static long ProfForwardUs => System.Threading.Interlocked.Read(ref _profForwardUs);
+    public static long ProfGradZeroUs => System.Threading.Interlocked.Read(ref _profGradZeroUs);
+    public static long ProfBackwardUs => System.Threading.Interlocked.Read(ref _profBackwardUs);
+    public static long ProfOptimUs => System.Threading.Interlocked.Read(ref _profOptimUs);
+    public static int ProfStepCount => System.Threading.Interlocked.CompareExchange(ref _profStepCount, 0, 0);
+    public static void ResetProf()
+    {
+        System.Threading.Interlocked.Exchange(ref _profForwardUs, 0);
+        System.Threading.Interlocked.Exchange(ref _profGradZeroUs, 0);
+        System.Threading.Interlocked.Exchange(ref _profBackwardUs, 0);
+        System.Threading.Interlocked.Exchange(ref _profOptimUs, 0);
+        System.Threading.Interlocked.Exchange(ref _profStepCount, 0);
+        var ps = _profPerStepUs;
+        if (ps != null) System.Array.Clear(ps, 0, ps.Length);
+    }
+
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Tensor<T> Step()
     {
         var engine = _engine;
+        long t0 = _profileStepEnabled ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
 
         // Forward: use checkpointing if enabled, otherwise straight-line delegates
         if (_checkpointing is not null)
@@ -228,6 +260,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             for (int i = 0; i < fwd.Length; i++)
                 fwd[i](engine);
         }
+        long t1 = _profileStepEnabled ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
 
         // Cache raw arrays on first call — avoids AsWritableSpan()/GetDataArray() per step
         var gradArrays = _cachedGradArrays;
@@ -265,13 +298,49 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         if (seedArr != null && destArr != null)
             Array.Copy(seedArr, destArr, seedArr.Length);
 
+        long t2 = _profileStepEnabled ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
+
         // Backward: specialized delegates (direct BLAS into pre-allocated buffers)
         var bwd = _backwardActions;
-        for (int i = 0; i < bwd.Length; i++)
-            bwd[i](engine);
+        if (_profileStepEnabled)
+        {
+            // Per-delegate timing — accumulates into _profPerStepUs[i] across calls.
+            var perStep = _profPerStepUs;
+            if (perStep == null || perStep.Length != bwd.Length)
+            {
+                perStep = new long[bwd.Length];
+                _profPerStepUs = perStep;
+            }
+            double tickToUsLocal = 1_000_000.0 / System.Diagnostics.Stopwatch.Frequency;
+            for (int i = 0; i < bwd.Length; i++)
+            {
+                long si = System.Diagnostics.Stopwatch.GetTimestamp();
+                bwd[i](engine);
+                long ei = System.Diagnostics.Stopwatch.GetTimestamp();
+                perStep[i] += (long)((ei - si) * tickToUsLocal);
+            }
+        }
+        else
+        {
+            for (int i = 0; i < bwd.Length; i++)
+                bwd[i](engine);
+        }
+        long t3 = _profileStepEnabled ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
 
         // Fused optimizer update (if configured via ConfigureOptimizer)
         _optimizerUpdate?.Invoke();
+        long t4 = _profileStepEnabled ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
+
+        if (_profileStepEnabled)
+        {
+            // Stopwatch.Frequency is ticks/sec; we want microseconds
+            double tickToUs = 1_000_000.0 / System.Diagnostics.Stopwatch.Frequency;
+            System.Threading.Interlocked.Add(ref _profForwardUs,  (long)((t1 - t0) * tickToUs));
+            System.Threading.Interlocked.Add(ref _profGradZeroUs, (long)((t2 - t1) * tickToUs));
+            System.Threading.Interlocked.Add(ref _profBackwardUs, (long)((t3 - t2) * tickToUs));
+            System.Threading.Interlocked.Add(ref _profOptimUs,    (long)((t4 - t3) * tickToUs));
+            System.Threading.Interlocked.Increment(ref _profStepCount);
+        }
 
         return _lossOutput;
     }
@@ -945,6 +1014,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
         // Build backward actions: specialized per-step + fused backward for fused groups
         var backwardActions = new List<Action<IEngine>>();
+        var backwardStepNames = new List<string>();
         int genericBackwardCount = 0;
         for (int i = forwardSteps.Count - 1; i >= 0; i--)
         {
@@ -954,10 +1024,14 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
             var action = BuildSpecializedBackward(step, gradMap, consumerCount, engine, pinnedHandles);
             if (action != null)
+            {
                 backwardActions.Add(action);
+                backwardStepNames.Add($"specialized:{step.OpName}");
+            }
             else
             {
                 genericBackwardCount++;
+                backwardStepNames.Add($"generic:{step.OpName}");
                 var stepCopy = step;
                 var gradAcc = gradMap;
                 backwardActions.Add(eng =>
@@ -973,7 +1047,14 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         // Append fused backward actions in reverse order — TryFuseForwardBackward records
         // them in forward order, but autodiff requires backward (reverse) order.
         for (int i = fusedBackwardActions.Count - 1; i >= 0; i--)
+        {
             backwardActions.Add(fusedBackwardActions[i]);
+            backwardStepNames.Add($"fused-backward-{i}");
+        }
+        // Publish names for the perf-diag harness (last writer wins; only ever
+        // useful when AIDOTNET_PROFILE_STEP=1).
+        if (_profileStepEnabled)
+            _profBackwardStepNames = backwardStepNames.ToArray();
 
         // Loss gradient seed
         var numOps = MathHelper.GetNumericOperations<T>();

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -243,6 +243,16 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     }
 
 
+    /// <summary>
+    /// Diagnostic hook for tracing per-step buffer mutations. When set,
+    /// fires after each forward and each backward delegate with the phase
+    /// label and the step's OpName. Used by the
+    /// Pinpoint_DOUBLE_TensorSubtract_Forward bisect test to locate which
+    /// specific backward delegate corrupts a target tensor's buffer.
+    /// Reset to null after use to avoid debug overhead in normal runs.
+    /// </summary>
+    public static System.Action<string>? StepProbe { get; set; }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Tensor<T> Step()
     {
@@ -257,8 +267,22 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         else
         {
             var fwd = _forwardActions;
-            for (int i = 0; i < fwd.Length; i++)
-                fwd[i](engine);
+            var probe = StepProbe;
+            if (probe != null)
+            {
+                probe("BEGIN-FWD");
+                for (int i = 0; i < fwd.Length; i++)
+                {
+                    fwd[i](engine);
+                    var name = i < (_forwardSteps?.Length ?? 0) ? _forwardSteps![i].OpName : $"#{i}";
+                    probe($"AFTER-FWD-{i}:{name}");
+                }
+            }
+            else
+            {
+                for (int i = 0; i < fwd.Length; i++)
+                    fwd[i](engine);
+            }
         }
         long t1 = _profileStepEnabled ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
 
@@ -302,6 +326,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
         // Backward: specialized delegates (direct BLAS into pre-allocated buffers)
         var bwd = _backwardActions;
+        var bwdProbe = StepProbe;
+        if (bwdProbe != null) bwdProbe("BEGIN-BWD");
         if (_profileStepEnabled)
         {
             // Per-delegate timing — accumulates into _profPerStepUs[i] across calls.
@@ -318,17 +344,27 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 bwd[i](engine);
                 long ei = System.Diagnostics.Stopwatch.GetTimestamp();
                 perStep[i] += (long)((ei - si) * tickToUsLocal);
+                if (bwdProbe != null)
+                {
+                    var name = i < (_profBackwardStepNames?.Length ?? 0) ? _profBackwardStepNames![i] : $"#{i}";
+                    bwdProbe($"AFTER-BWD-{i}:{name}");
+                }
             }
         }
         else
         {
             for (int i = 0; i < bwd.Length; i++)
+            {
                 bwd[i](engine);
+                if (bwdProbe != null) bwdProbe($"AFTER-BWD-{i}");
+            }
         }
         long t3 = _profileStepEnabled ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
 
+        if (bwdProbe != null) bwdProbe("BEGIN-OPT");
         // Fused optimizer update (if configured via ConfigureOptimizer)
         _optimizerUpdate?.Invoke();
+        if (bwdProbe != null) bwdProbe("END-OPT");
         long t4 = _profileStepEnabled ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
 
         if (_profileStepEnabled)

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -253,6 +253,11 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     /// </summary>
     public static System.Action<string>? StepProbe { get; set; }
 
+    /// <summary>Diagnostic capture: TensorSubtract specialized forward writes
+    /// here when AIDOTNET_DEBUG_SUB=1. Used by Pinpoint tests to inspect
+    /// what the kernel sees vs writes.</summary>
+    public static string SubFwdDiag = "";
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Tensor<T> Step()
     {
@@ -962,6 +967,27 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     typed.GetInputsArray(),
                     typed.BackwardFn,
                     typed.SavedState));
+                // CRITICAL (issue #350 root cause): clear LazySource on every
+                // forward-step output BEFORE the plan starts executing. Each
+                // call to plan.Step() runs the lazy execute via the
+                // pre-compiled forward delegate, writing the correct output
+                // to typed.Output's buffer. But the LazyNode's own
+                // RecordingEngine field captured AiDotNetEngine.Current at
+                // record time — typically DirectGpuTensorEngine on
+                // auto-detect-GPU systems. Without clearing LazySource here,
+                // any subsequent caller-side read via tensor.GetFlat / [i] /
+                // .AsSpan() triggers TensorBase.EnsureMaterialized →
+                // node.Realize(node.RecordingEngine) → re-runs Execute on
+                // the GPU engine, OVERWRITING the correct double values the
+                // plan wrote with float-precision-rounded values from the
+                // GPU's TensorXxxInto kernels (consumer GPUs throttle double
+                // precision, so the kernels do float math under the hood).
+                // The plan's own forward loop runs Execute via its captured
+                // engine reference (correctly bound by BindEngineIfUnset),
+                // so clearing LazySource doesn't lose anything — the plan
+                // owns the materialization lifecycle from this point on.
+                typed.IsRealized = true;
+                typed.Output.LazySource = null;
             }
         }
 

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -2846,6 +2846,64 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             };
         }
 
+        // BatchNorm backward: writes gradInput / gradGamma / gradBeta directly
+        // into pre-allocated buffers via BatchNormBackwardInto — skips the 3
+        // fresh tensor allocations + 3 chained AccumulateGrad calls that
+        // BackwardFunctions.BatchNormBackward pays per layer.
+        // GraFPrint has 18 BatchNorm layers; this saves ~3-5 ms per layer
+        // (allocator pressure + AccumulateGrad orchestration).
+        // Tier 1.4 of the compile-mode backward perf overhaul.
+        if (step.OpType == OpType.BatchNorm && step.Inputs.Length >= 3
+            && step.Inputs[0].IsContiguous && step.Inputs[1].IsContiguous && step.Inputs[2].IsContiguous)
+        {
+            var input = step.Inputs[0];
+            var gammaT = step.Inputs[1];
+            var betaT = step.Inputs[2];
+            var output = step.OutputBuffer;
+            if (!gradMap.ContainsKey(output)
+                || !gradMap.ContainsKey(input)
+                || !gradMap.ContainsKey(gammaT)
+                || !gradMap.ContainsKey(betaT)) return null;
+            var savedState = step.SavedState;
+            // Saved state from BatchNorm GraphMode recording (CpuEngine.cs:17723):
+            // new object[] { mean, variance, epsilon }
+            if (savedState == null || savedState.Length < 3
+                || savedState[0] is not Tensor<T> meanT
+                || savedState[1] is not Tensor<T> varianceT
+                || savedState[2] is not double epsilonD)
+                return null;
+            var gradOut = gradMap[output];
+            var gradInput = gradMap[input];
+            var gradGamma = gradMap[gammaT];
+            var gradBeta = gradMap[betaT];
+            bool accumInput = consumerCount.ContainsKey(input) && consumerCount[input] > 1;
+            bool accumGamma = consumerCount.ContainsKey(gammaT) && consumerCount[gammaT] > 1;
+            bool accumBeta = consumerCount.ContainsKey(betaT) && consumerCount[betaT] > 1;
+            return eng =>
+            {
+                if (eng is CpuEngine cpu)
+                {
+                    cpu.BatchNormBackwardInto(gradInput, gradGamma, gradBeta,
+                        gradOut, input, gammaT, meanT, varianceT, epsilonD,
+                        accumInput, accumGamma, accumBeta);
+                }
+                else
+                {
+                    var gi = eng.BatchNormBackward(gradOut, input, gammaT, meanT, varianceT, epsilonD,
+                        out var gg, out var gb);
+                    if (accumInput) eng.TensorAddInto(gradInput, gradInput, gi);
+                    else gi.AsSpan().CopyTo(gradInput.AsWritableSpan());
+                    if (accumGamma) eng.TensorAddInto(gradGamma, gradGamma, gg);
+                    else gg.AsSpan().CopyTo(gradGamma.AsWritableSpan());
+                    if (accumBeta) eng.TensorAddInto(gradBeta, gradBeta, gb);
+                    else gb.AsSpan().CopyTo(gradBeta.AsWritableSpan());
+                }
+                input.Grad = gradInput;
+                gammaT.Grad = gradGamma;
+                betaT.Grad = gradBeta;
+            };
+        }
+
         // ReduceSum backward: broadcast scalar gradient to all elements
         // Only specialize for full scalar reduction (output length == 1)
         if (step.OpType == OpType.ReduceSum && step.Inputs.Length == 1

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -240,6 +240,11 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         System.Threading.Interlocked.Exchange(ref _profStepCount, 0);
         var ps = _profPerStepUs;
         if (ps != null) System.Array.Clear(ps, 0, ps.Length);
+        // Drop the previous plan's backward-step name table. Without this,
+        // a fresh ResetProf-then-rebuild cycle (e.g. test reruns) leaves
+        // the stale name array around and any future Step() that reads
+        // it can mis-attribute timings to the wrong delegate.
+        _profBackwardStepNames = null;
     }
 
 
@@ -1113,10 +1118,11 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             backwardActions.Add(fusedBackwardActions[i]);
             backwardStepNames.Add($"fused-backward-{i}");
         }
-        // Publish names for the perf-diag harness (last writer wins; only ever
-        // useful when AIDOTNET_PROFILE_STEP=1).
-        if (_profileStepEnabled)
-            _profBackwardStepNames = backwardStepNames.ToArray();
+        // Name publication is deferred until AFTER BackwardPruningPass
+        // runs (line below) — Prune is a no-op today, but it's allowed
+        // to shrink the actions list, and publishing here would leave
+        // names indexed against the un-pruned position while Step()
+        // walks the pruned array.
 
         // Loss gradient seed
         var numOps = MathHelper.GetNumericOperations<T>();
@@ -1150,6 +1156,24 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         // Phase 6.3: Backward pruning — skip gradient computation for non-trainable tensors
         var paramSet = new HashSet<Tensor<T>>(parameters);
         backwardActions = BackwardPruningPass.Prune(backwardActions, forwardSteps, parameters, gradMap);
+
+        // Publish names AFTER pruning so they index 1:1 with the actually-
+        // replayed delegate array. Defensive count check: if Prune ever
+        // starts removing entries, fall back to numeric labels rather
+        // than serving stale labels that point at the wrong delegates.
+        if (_profileStepEnabled)
+        {
+            if (backwardActions.Count == backwardStepNames.Count)
+            {
+                _profBackwardStepNames = backwardStepNames.ToArray();
+            }
+            else
+            {
+                var fallback = new string[backwardActions.Count];
+                for (int i = 0; i < fallback.Length; i++) fallback[i] = $"#{i}";
+                _profBackwardStepNames = fallback;
+            }
+        }
 
         // If all backward steps are specialized (overwrite), we can skip gradient zeroing entirely
         int[]? genericGradIndices = genericBackwardCount == 0 ? new int[0] : null;

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -1769,8 +1769,44 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
         // BatchNorm inference: direct SIMD kernel (bypasses all allocation)
         // Lazy node records: Inputs = [input, gamma, beta], SavedState = [mean, variance, epsilon]
+        //
+        // The FusedKernels.BatchNormInferenceUnsafe kernel assumes the layout
+        // [channels, spatial] — that is, all elements of channel `c` are
+        // contiguous at offset `c * spatialSize`, where `spatialSize = length
+        // / channels`. That assumption holds for:
+        //   • Rank-3 [C, H, W] inputs (channel c's data is contiguous at
+        //     c*H*W, by row-major flatten)
+        //   • Rank-4 [1, C, H, W] inputs with N=1 (degenerates to rank-3 case
+        //     once the leading singleton is collapsed)
+        //
+        // It DOES NOT hold for:
+        //   • Rank-2 [batch, features] inputs — features are the FAST axis;
+        //     element [b, f] sits at flat index b*F + f, so channel f's data
+        //     is interleaved at stride F, not contiguous at offset f * batch.
+        //     Applying this kernel to 2D input picks up neighbour channels'
+        //     mean/var per batch row, which gives off-diagonal corruption
+        //     (the off-diagonal-only divergence pattern that surfaced in
+        //     ooples/AiDotNet branch fix/pr-1290-cluster-4-5 — testconsole
+        //     `BnFusedGradDiff` isolated the failure to a 4-feature, batch-4
+        //     case where every off-diagonal element diverged from eager but
+        //     diagonal elements [b, b] matched coincidentally because
+        //     channel b's mean happens to apply to element [b, b]).
+        //   • Rank-4 [N>1, C, H, W] inputs — for N>1, channel c's elements
+        //     are interleaved across batches, not laid out as [c*N*H*W ..
+        //     (c+1)*N*H*W).
+        //
+        // Restrict the specialization to ranks where the channels-first
+        // layout assumption is actually true. Other ranks fall through to
+        // the generic execute delegate (which calls back into the engine's
+        // correct rank-aware BN forward).
+        bool layoutIsChannelsFirstContiguous =
+            step.Inputs.Length > 0 &&
+            (step.Inputs[0]._shape.Length == 3
+             || (step.Inputs[0]._shape.Length == 4 && step.Inputs[0]._shape[0] == 1));
+
         if (step.OpType == OpType.BatchNorm && typeof(T) == typeof(float)
             && step.Inputs.Length >= 3 && step.Inputs[0].IsContiguous
+            && layoutIsChannelsFirstContiguous
             && step.SavedState is { Length: >= 2 }
             && step.SavedState[0] is Tensor<T> meanTensor
             && step.SavedState[1] is Tensor<T> varTensor)

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -2904,6 +2904,89 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             };
         }
 
+        // Dropout backward: gradInput = mask * gradOutput * (1 / (1 - p))
+        // (the eager engine.DropoutBackward already applies the inverse-keep
+        // scale; we just write its result into the pre-allocated buffer).
+        // Tier 1.5 — saves the temp-tensor allocation + 1x AccumulateGrad
+        // per Dropout layer (7 in GraFPrint). Gated on OpName because
+        // Dropout doesn't have a dedicated OpType discriminant — it parses
+        // to OpType.Unknown via OpTypeParser.cs:158.
+        if (step.OpName == "Dropout" && step.Inputs.Length == 1)
+        {
+            var input = step.Inputs[0];
+            var output = step.OutputBuffer;
+            if (!gradMap.ContainsKey(output) || !gradMap.ContainsKey(input)) return null;
+            var savedState = step.SavedState;
+            // CpuEngine.Dropout savedState: { mask, dropoutRate }
+            if (savedState == null || savedState.Length < 2
+                || savedState[0] is not Tensor<T> dropMask
+                || savedState[1] is not double dropRate)
+                return null;
+            var gradOut = gradMap[output];
+            var gradIn = gradMap[input];
+            bool accum = consumerCount.ContainsKey(input) && consumerCount[input] > 1;
+            return eng =>
+            {
+                var grad = eng.DropoutBackward(gradOut, dropMask, dropRate);
+                if (accum) eng.TensorAddInto(gradIn, gradIn, grad);
+                else grad.AsSpan().CopyTo(gradIn.AsWritableSpan());
+                input.Grad = gradIn;
+            };
+        }
+
+        // MaxPool2D backward: scatter gradOutput into gradInput at saved
+        // max-index positions. Tier 1.5 — saves the alloc + AccumulateGrad
+        // per MaxPool layer.
+        if (step.OpType == OpType.MaxPool2D && step.Inputs.Length == 1)
+        {
+            var input = step.Inputs[0];
+            var output = step.OutputBuffer;
+            if (!gradMap.ContainsKey(output) || !gradMap.ContainsKey(input)) return null;
+            var savedState = step.SavedState;
+            // CpuEngine.MaxPool2D savedState: { maxIndices (int[,,,,]), poolSize (int[]), stride (int[]) }
+            if (savedState == null || savedState.Length < 3
+                || savedState[0] is not int[,,,,] maxIndices
+                || savedState[1] is not int[] poolSize
+                || savedState[2] is not int[] poolStride)
+                return null;
+            var gradOut = gradMap[output];
+            var gradIn = gradMap[input];
+            bool accum = consumerCount.ContainsKey(input) && consumerCount[input] > 1;
+            var capInShape = (int[])input._shape.Clone();
+            return eng =>
+            {
+                var grad = eng.MaxPool2DBackward(gradOut, maxIndices, capInShape, poolSize, poolStride);
+                if (accum) eng.TensorAddInto(gradIn, gradIn, grad);
+                else grad.AsSpan().CopyTo(gradIn.AsWritableSpan());
+                input.Grad = gradIn;
+            };
+        }
+
+        // AvgPool2D backward: distribute gradOutput / (poolH*poolW) across
+        // input positions. Tier 1.5.
+        if (step.OpType == OpType.AvgPool2D && step.Inputs.Length == 1)
+        {
+            var input = step.Inputs[0];
+            var output = step.OutputBuffer;
+            if (!gradMap.ContainsKey(output) || !gradMap.ContainsKey(input)) return null;
+            var savedState = step.SavedState;
+            if (savedState == null || savedState.Length < 2
+                || savedState[0] is not int[] poolSize
+                || savedState[1] is not int[] poolStride)
+                return null;
+            var gradOut = gradMap[output];
+            var gradIn = gradMap[input];
+            bool accum = consumerCount.ContainsKey(input) && consumerCount[input] > 1;
+            var capInShape = (int[])input._shape.Clone();
+            return eng =>
+            {
+                var grad = eng.AvgPool2DBackward(gradOut, capInShape, poolSize, poolStride);
+                if (accum) eng.TensorAddInto(gradIn, gradIn, grad);
+                else grad.AsSpan().CopyTo(gradIn.AsWritableSpan());
+                input.Grad = gradIn;
+            };
+        }
+
         // ReduceSum backward: broadcast scalar gradient to all elements
         // Only specialize for full scalar reduction (output length == 1)
         if (step.OpType == OpType.ReduceSum && step.Inputs.Length == 1

--- a/src/AiDotNet.Tensors/Engines/Compilation/LazyTensorScope.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/LazyTensorScope.cs
@@ -17,14 +17,42 @@ internal sealed class LazyTensorScope : IDisposable
 {
     private readonly LazyTensorScope? _parent;
     private readonly List<ILazyNode> _nodes = new();
-    private readonly IEngine _engine;
+    private IEngine _engine;
+    private bool _engineExplicitlyBound;
     private bool _disposed;
     private bool _realized;
 
     internal LazyTensorScope(LazyTensorScope? parent)
     {
         _parent = parent;
+        // Default to AiDotNetEngine.Current; the first op recorded into the
+        // scope will rebind via BindEngineIfUnset to the engine instance the
+        // user actually invoked the op on. This matters because the global
+        // ambient engine on auto-detect-GPU systems is DirectGpuTensorEngine,
+        // but a test or production code that explicitly creates a new
+        // CpuEngine() and calls operations on it expects the compiled plan to
+        // replay on CPU — not on the (potentially mismatched) ambient engine.
+        // See issue #350: T=double rank-3 BatchNorm compile-replay diverged
+        // on hosts where the auto-detected GPU engine doesn't have a faithful
+        // CPU-tensor BatchNorm path.
         _engine = AiDotNetEngine.Current;
+        _engineExplicitlyBound = false;
+    }
+
+    /// <summary>
+    /// Binds this scope to <paramref name="engine"/> if no engine has yet
+    /// been explicitly bound. Called by each engine's GraphMode-recording
+    /// branch (e.g. <see cref="CpuEngine.BatchNorm{T}"/>) so the compiled
+    /// plan replays on the engine the user actually invoked the op on,
+    /// not on the global ambient engine. Idempotent — subsequent calls with
+    /// any engine are no-ops once the first binding lands.
+    /// </summary>
+    internal void BindEngineIfUnset(IEngine engine)
+    {
+        if (_engineExplicitlyBound) return;
+        if (engine is null) return;
+        _engine = engine;
+        _engineExplicitlyBound = true;
     }
 
     /// <summary>Number of lazy operations recorded.</summary>

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -2763,6 +2763,7 @@ public partial class CpuEngine : ITensorLevelEngine
             throw new ArgumentException(
                 $"Tensor shapes must match. Got {FormatShape(a._shape)} and {FormatShape(b._shape)}.");
         }
+        AiDotNet.Tensors.Engines.Autodiff.GradientTape<T>.Current?.BindEngineIfUnset(this);
 
         // Lazy graph mode: record and return placeholder
         if (GraphMode.IsActive)
@@ -2770,6 +2771,7 @@ public partial class CpuEngine : ITensorLevelEngine
             var scope = GraphMode.Current;
             if (scope != null)
             {
+                scope.BindEngineIfUnset(this);
                 var capturedA = a;
                 var capturedB = b;
                 return scope.RecordBinary(LazyNodeType.Add, "TensorAdd", a, b, a._shape,
@@ -4303,6 +4305,16 @@ public partial class CpuEngine : ITensorLevelEngine
             throw new ArgumentException(
                 $"Tensor shapes must match. Got {FormatShape(a._shape)} and {FormatShape(b._shape)}.");
         }
+        // Pin the active gradient tape (if any) to THIS engine — same
+        // reasoning as the scope.BindEngineIfUnset call below, but for the
+        // eager-tape path. Without this, an active tape constructed before
+        // any explicit engine instantiation defaults to AiDotNetEngine.Current
+        // (DirectGpuTensorEngine on auto-detect-GPU systems), and the
+        // backward walk would dispatch through the GPU engine's
+        // TensorSubtractInto / TensorAddInPlace which run in single precision
+        // on consumer GPUs — silently truncating gradient values to float
+        // ULPs even though the user explicitly opted into a CpuEngine.
+        AiDotNet.Tensors.Engines.Autodiff.GradientTape<T>.Current?.BindEngineIfUnset(this);
 
         // Lazy graph mode: record and return placeholder
         if (GraphMode.IsActive)
@@ -4310,6 +4322,16 @@ public partial class CpuEngine : ITensorLevelEngine
             var scope = GraphMode.Current;
             if (scope != null)
             {
+                // Bind THIS engine to the scope so the compiled plan replays
+                // on the same engine instance the user invoked the op on.
+                // See LazyTensorScope.BindEngineIfUnset for the full
+                // rationale (issue #350): without this, on auto-detect-GPU
+                // hosts where AiDotNetEngine.Current is DirectGpuTensorEngine,
+                // the lazy execute would dispatch to the GPU's
+                // TensorSubtractInto which computes in single precision on
+                // consumer GPUs and silently produces float-precision-rounded
+                // results in a Tensor<double>'s buffer.
+                scope.BindEngineIfUnset(this);
                 var capturedA = a;
                 var capturedB = b;
                 return scope.RecordBinary(LazyNodeType.Subtract, "TensorSubtract", a, b, a._shape,
@@ -4433,6 +4455,7 @@ public partial class CpuEngine : ITensorLevelEngine
             // Shapes don't match — fall through to broadcasting (NumPy/PyTorch behavior)
             return TensorBroadcastMultiply(a, b);
         }
+        AiDotNet.Tensors.Engines.Autodiff.GradientTape<T>.Current?.BindEngineIfUnset(this);
 
         // Lazy graph mode: record and return placeholder
         if (GraphMode.IsActive)
@@ -4440,6 +4463,7 @@ public partial class CpuEngine : ITensorLevelEngine
             var scope = GraphMode.Current;
             if (scope != null)
             {
+                scope.BindEngineIfUnset(this);
                 var capturedA = a;
                 var capturedB = b;
                 return scope.RecordBinary(LazyNodeType.Multiply, "TensorMultiply", a, b, a._shape,
@@ -6640,6 +6664,7 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         using var _opScope = AiDotNet.Tensors.Engines.Profiling.Profiler.OpScope("ReduceSum");
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
+        AiDotNet.Tensors.Engines.Autodiff.GradientTape<T>.Current?.BindEngineIfUnset(this);
 
         // Lazy graph mode: record and return placeholder
         if (GraphMode.IsActive)
@@ -6647,6 +6672,7 @@ public partial class CpuEngine : ITensorLevelEngine
             var scope = GraphMode.Current;
             if (scope != null)
             {
+                scope.BindEngineIfUnset(this);
                 // Compute output shape eagerly
                 int[] outShape;
                 if (axes == null || axes.Length == 0)

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -12191,6 +12191,159 @@ public partial class CpuEngine : ITensorLevelEngine
         return TensorAllocator.Rent<T>(inputShape, gradInput);
     }
 
+    /// <summary>
+    /// Conv2D backward (gradient w.r.t. input) writing into a pre-allocated
+    /// destination tensor. Used by <see cref="Compilation.CompiledTrainingPlan{T}"/>
+    /// to skip the result-tensor allocation + the AccumulateGrad chained ops
+    /// that the public <see cref="Conv2DBackwardInput{T}"/> entry pays per call.
+    /// On a 19-Conv-layer network like GraFPrint this saves ~10 ms per Conv
+    /// backward (allocator pressure + chained ops in BackwardFunctions.Conv2DBackward).
+    /// <para>
+    /// <paramref name="accumulate"/>: when <c>true</c>, adds the computed
+    /// gradInput into <paramref name="dest"/> (consumer-count > 1 case in the
+    /// graph). When <c>false</c>, overwrites — the destination is zeroed first
+    /// because the inner col2im algorithm is accumulating-only.
+    /// </para>
+    /// </summary>
+    public void Conv2DBackwardInputInto<T>(
+        Tensor<T> dest, Tensor<T> gradOutput, Tensor<T> kernel,
+        int[] inputShape, int[] stride, int[] padding, int[] dilation,
+        bool accumulate)
+    {
+        if (dest == null) throw new ArgumentNullException(nameof(dest));
+        if (gradOutput == null) throw new ArgumentNullException(nameof(gradOutput));
+        if (kernel == null) throw new ArgumentNullException(nameof(kernel));
+        if (!dest.IsContiguous) throw new InvalidOperationException("dest must be contiguous.");
+        if (!gradOutput.IsContiguous) gradOutput = gradOutput.Contiguous();
+        if (!kernel.IsContiguous) kernel = kernel.Contiguous();
+        if (inputShape == null || inputShape.Length != 4) throw new ArgumentException("inputShape must be array of 4 elements", nameof(inputShape));
+        if (gradOutput.Rank != 4) throw new ArgumentException($"requires 4D gradOutput. Got rank {gradOutput.Rank}.", nameof(gradOutput));
+        if (kernel.Rank != 4) throw new ArgumentException($"requires 4D kernel. Got rank {kernel.Rank}.", nameof(kernel));
+        if (!ShapesMatch(dest._shape, inputShape)) throw new ArgumentException("dest shape must match inputShape");
+
+        int batch = inputShape[0];
+        int inChannels = inputShape[1];
+        int height = inputShape[2];
+        int width = inputShape[3];
+        int outChannels = kernel._shape[0];
+        int kernelHeight = kernel._shape[2];
+        int kernelWidth = kernel._shape[3];
+        int strideH = stride[0], strideW = stride[1];
+        int padH = padding[0], padW = padding[1];
+        int dilationH = dilation[0], dilationW = dilation[1];
+        int outputHeight = gradOutput._shape[2];
+        int outputWidth = gradOutput._shape[3];
+
+        if (typeof(T) == typeof(float))
+        {
+            int colH = inChannels * kernelHeight * kernelWidth;
+            int colW = outputHeight * outputWidth;
+            // Write directly into dest's live backing — skip the temp gradInputF
+            // allocation + FromFloatSpan copy that Conv2DBackwardInput's
+            // public path pays. The plan's pre-allocated dest is contiguous +
+            // CPU-resident; getting its array via _storage.GetDataArray()
+            // hands back the live float[] (no copy).
+            var destF = (float[])(object)dest._storage.GetDataArray();
+            int destOff = dest._storageOffset;
+            // Col2ImAccumulate is accumulating — for overwrite mode, zero the
+            // destination region first.
+            if (!accumulate)
+                Array.Clear(destF, destOff, batch * inChannels * height * width);
+            var gradOutputF = (float[])(object)gradOutput.GetFlattenedData();
+            var kernelF = (float[])(object)kernel.GetFlattenedData();
+            var kernelT = new float[colH * outChannels];
+            for (int r = 0; r < outChannels; r++)
+                for (int c = 0; c < colH; c++)
+                    kernelT[c * outChannels + r] = kernelF[r * colH + c];
+            var pool = System.Buffers.ArrayPool<float>.Shared;
+            CpuParallelSettings.ParallelForOrSerial(0, batch, (long)batch * colH * colW, b =>
+            {
+                var colBuf = pool.Rent(colW * colH);
+                try
+                {
+                    int gradOutOff = b * outChannels * colW;
+                    if (!Helpers.BlasProvider.TryGemm(colH, colW, outChannels,
+                        kernelT, 0, outChannels,
+                        gradOutputF, gradOutOff, colW,
+                        colBuf, 0, colW))
+                    {
+                        Simd.SimdGemm.Sgemm(
+                            new ReadOnlySpan<float>(kernelT),
+                            new ReadOnlySpan<float>(gradOutputF, gradOutOff, outChannels * colW),
+                            new Span<float>(colBuf, 0, colH * colW),
+                            colH, outChannels, colW);
+                    }
+                    int imgOff = destOff + b * inChannels * height * width;
+                    Im2ColHelper.Col2ImAccumulate(
+                        new ReadOnlySpan<float>(colBuf, 0, colW * colH),
+                        new Span<float>(destF, imgOff, inChannels * height * width),
+                        inChannels, height, width,
+                        kernelHeight, kernelWidth, strideH, strideW, padH, padW, dilationH, dilationW,
+                        outputHeight, outputWidth);
+                }
+                finally { pool.Return(colBuf); }
+            });
+            return;
+        }
+
+        if (typeof(T) == typeof(double))
+        {
+            int colH = inChannels * kernelHeight * kernelWidth;
+            int colW = outputHeight * outputWidth;
+            var destD = (double[])(object)dest._storage.GetDataArray();
+            int destOff = dest._storageOffset;
+            if (!accumulate)
+                Array.Clear(destD, destOff, batch * inChannels * height * width);
+            var gradOutputD = (double[])(object)gradOutput.GetFlattenedData();
+            var kernelD = (double[])(object)kernel.GetFlattenedData();
+            var kernelTD = new double[colH * outChannels];
+            for (int r = 0; r < outChannels; r++)
+                for (int c = 0; c < colH; c++)
+                    kernelTD[c * outChannels + r] = kernelD[r * colH + c];
+            var poolD = System.Buffers.ArrayPool<double>.Shared;
+            CpuParallelSettings.ParallelForOrSerial(0, batch, (long)batch * colH * colW, b =>
+            {
+                var colBuf = poolD.Rent(colW * colH);
+                try
+                {
+                    int gradOutOff = b * outChannels * colW;
+                    if (!Helpers.BlasProvider.TryGemm(colH, colW, outChannels,
+                        kernelTD, 0, outChannels,
+                        gradOutputD, gradOutOff, colW,
+                        colBuf, 0, colW))
+                    {
+                        Helpers.Im2ColHelper.MultiplyMatrixBlockedDouble(
+                            new ReadOnlySpan<double>(kernelTD),
+                            new ReadOnlySpan<double>(gradOutputD, gradOutOff, outChannels * colW),
+                            new Span<double>(colBuf, 0, colH * colW),
+                            colH, outChannels, colW);
+                    }
+                    int imgOff = destOff + b * inChannels * height * width;
+                    Helpers.Im2ColHelper.Col2ImAccumulate(
+                        new ReadOnlySpan<double>(colBuf, 0, colW * colH),
+                        new Span<double>(destD, imgOff, inChannels * height * width),
+                        inChannels, height, width,
+                        kernelHeight, kernelWidth, strideH, strideW, padH, padW, dilationH, dilationW,
+                        outputHeight, outputWidth);
+                }
+                finally { poolD.Return(colBuf); }
+            });
+            return;
+        }
+
+        // Generic fallback for non-float, non-double types — wrap the existing
+        // public method and copy/add. Slow path, only used for BFloat16 etc.
+        var tmp = Conv2DBackwardInput(gradOutput, kernel, inputShape, stride, padding, dilation);
+        if (accumulate)
+        {
+            TensorAddInto(dest, dest, tmp);
+        }
+        else
+        {
+            tmp.AsSpan().CopyTo(dest.AsWritableSpan());
+        }
+    }
+
     /// <inheritdoc/>
     public Tensor<T> Conv2DBackwardKernel<T>(Tensor<T> gradOutput, Tensor<T> input, int[] kernelShape, int[] stride, int[] padding, int[] dilation)
     {
@@ -12423,6 +12576,192 @@ public partial class CpuEngine : ITensorLevelEngine
         });
 
         return TensorAllocator.Rent<T>(kernelShape, gradKernel);
+    }
+
+    /// <summary>
+    /// Conv2D backward (gradient w.r.t. kernel) writing into a pre-allocated
+    /// destination tensor. Companion to <see cref="Conv2DBackwardInputInto{T}"/>;
+    /// used by <see cref="Compilation.CompiledTrainingPlan{T}"/> to skip the
+    /// result-tensor allocation + the AccumulateGrad chained ops that the
+    /// public <see cref="Conv2DBackwardKernel{T}"/> entry pays per call.
+    /// <para>
+    /// <paramref name="accumulate"/>: when <c>true</c>, adds the computed
+    /// gradKernel into <paramref name="dest"/>. When <c>false</c>, overwrites.
+    /// The inner per-batch im2col×gradOut^T accumulation is unaffected — only
+    /// the merge step at the end conditions on the flag.
+    /// </para>
+    /// </summary>
+    public void Conv2DBackwardKernelInto<T>(
+        Tensor<T> dest, Tensor<T> gradOutput, Tensor<T> input,
+        int[] kernelShape, int[] stride, int[] padding, int[] dilation,
+        bool accumulate)
+    {
+        if (dest == null) throw new ArgumentNullException(nameof(dest));
+        if (gradOutput == null) throw new ArgumentNullException(nameof(gradOutput));
+        if (input == null) throw new ArgumentNullException(nameof(input));
+        if (!dest.IsContiguous) throw new InvalidOperationException("dest must be contiguous.");
+        if (!gradOutput.IsContiguous) gradOutput = gradOutput.Contiguous();
+        if (!input.IsContiguous) input = input.Contiguous();
+        if (kernelShape == null || kernelShape.Length != 4) throw new ArgumentException("kernelShape must be array of 4 elements", nameof(kernelShape));
+        if (gradOutput.Rank != 4) throw new ArgumentException($"requires 4D gradOutput. Got rank {gradOutput.Rank}.", nameof(gradOutput));
+        if (input.Rank != 4) throw new ArgumentException($"requires 4D input. Got rank {input.Rank}.", nameof(input));
+        if (!ShapesMatch(dest._shape, kernelShape)) throw new ArgumentException("dest shape must match kernelShape");
+
+        int batch = input._shape[0];
+        int inChannels = input._shape[1];
+        int height = input._shape[2];
+        int width = input._shape[3];
+        int outChannels = kernelShape[0];
+        int kernelHeight = kernelShape[2];
+        int kernelWidth = kernelShape[3];
+        int strideH = stride[0], strideW = stride[1];
+        int padH = padding[0], padW = padding[1];
+        int dilationH = dilation[0], dilationW = dilation[1];
+        int outputHeight = gradOutput._shape[2];
+        int outputWidth = gradOutput._shape[3];
+
+        if (typeof(T) == typeof(float))
+        {
+            int colH = inChannels * kernelHeight * kernelWidth;
+            int colW = outputHeight * outputWidth;
+            int totalLen = outChannels * colH;
+            var destF = (float[])(object)dest._storage.GetDataArray();
+            int destOff = dest._storageOffset;
+            // Local accumulator: per-batch BLAS writes into localGrad; merge into dest at end.
+            var gradKernelF = new float[totalLen];
+            var gradOutputF = (float[])(object)gradOutput.GetFlattenedData();
+            var inputF = (float[])(object)input.GetFlattenedData();
+            int inputSliceSize = inChannels * height * width;
+            var perBatchGrads = new float[batch][];
+            var kPool = System.Buffers.ArrayPool<float>.Shared;
+            CpuParallelSettings.ParallelForOrSerial(0, batch, (long)batch * colH * colW, b =>
+            {
+                var im2colBuf = kPool.Rent(colH * colW);
+                var localGrad = kPool.Rent(totalLen);
+                try
+                {
+                    Array.Clear(localGrad, 0, totalLen);
+                    Im2ColHelper.Im2Col(
+                        new ReadOnlySpan<float>(inputF, b * inputSliceSize, inputSliceSize),
+                        new Span<float>(im2colBuf),
+                        1, inChannels, height, width,
+                        kernelHeight, kernelWidth, strideH, strideW, padH, padW, dilationH, dilationW);
+                    int gradOutOff = b * outChannels * colW;
+                    if (!Helpers.BlasProvider.TryGemmEx(
+                        outChannels, colH, colW,
+                        gradOutputF, gradOutOff, colW, false,
+                        im2colBuf, 0, colW, true,
+                        localGrad, 0, colH))
+                    {
+                        Simd.SimdGemm.Sgemm(
+                            new ReadOnlySpan<float>(gradOutputF, gradOutOff, outChannels * colW), colW, false,
+                            new ReadOnlySpan<float>(im2colBuf, 0, colH * colW), colW, true,
+                            new Span<float>(localGrad, 0, totalLen),
+                            outChannels, colW, colH);
+                    }
+                    var gradCopy = new float[totalLen];
+                    Array.Copy(localGrad, gradCopy, totalLen);
+                    perBatchGrads[b] = gradCopy;
+                }
+                finally
+                {
+                    kPool.Return(im2colBuf);
+                    kPool.Return(localGrad);
+                }
+            });
+            for (int b = 0; b < batch; b++)
+            {
+                var lg = perBatchGrads[b];
+                for (int i = 0; i < gradKernelF.Length; i++)
+                    gradKernelF[i] += lg[i];
+            }
+            // Merge into dest with accumulate flag honoured.
+            if (accumulate)
+                for (int i = 0; i < totalLen; i++) destF[destOff + i] += gradKernelF[i];
+            else
+                Array.Copy(gradKernelF, 0, destF, destOff, totalLen);
+            return;
+        }
+
+        if (typeof(T) == typeof(double))
+        {
+            int colH = inChannels * kernelHeight * kernelWidth;
+            int colW = outputHeight * outputWidth;
+            int totalLen = outChannels * colH;
+            var destD = (double[])(object)dest._storage.GetDataArray();
+            int destOff = dest._storageOffset;
+            var gradKernelD = new double[totalLen];
+            var gradOutputD = (double[])(object)gradOutput.GetFlattenedData();
+            var inputD = (double[])(object)input.GetFlattenedData();
+            int inputSliceSize = inChannels * height * width;
+            var perBatchGradsD = new double[batch][];
+            var kPoolD = System.Buffers.ArrayPool<double>.Shared;
+            CpuParallelSettings.ParallelForOrSerial(0, batch, (long)batch * colH * colW, b =>
+            {
+                var im2colBuf = kPoolD.Rent(colH * colW);
+                var localGrad = kPoolD.Rent(totalLen);
+                try
+                {
+                    Array.Clear(localGrad, 0, totalLen);
+                    Helpers.Im2ColHelper.Im2Col(
+                        new ReadOnlySpan<double>(inputD, b * inputSliceSize, inputSliceSize),
+                        new Span<double>(im2colBuf),
+                        1, inChannels, height, width,
+                        kernelHeight, kernelWidth, strideH, strideW, padH, padW, dilationH, dilationW);
+                    int gradOutOff = b * outChannels * colW;
+                    if (!Helpers.BlasProvider.TryGemmEx(
+                        outChannels, colH, colW,
+                        gradOutputD, gradOutOff, colW, false,
+                        im2colBuf, 0, colW, true,
+                        localGrad, 0, colH))
+                    {
+                        var im2colT = kPoolD.Rent(colW * colH);
+                        try
+                        {
+                            for (int r = 0; r < colH; r++)
+                                for (int c = 0; c < colW; c++)
+                                    im2colT[c * colH + r] = im2colBuf[r * colW + c];
+                            Helpers.Im2ColHelper.MultiplyMatrixBlockedDouble(
+                                new ReadOnlySpan<double>(gradOutputD, gradOutOff, outChannels * colW),
+                                new ReadOnlySpan<double>(im2colT, 0, colW * colH),
+                                new Span<double>(localGrad, 0, totalLen),
+                                outChannels, colW, colH);
+                        }
+                        finally { kPoolD.Return(im2colT); }
+                    }
+                    var gradCopy = new double[totalLen];
+                    Array.Copy(localGrad, gradCopy, totalLen);
+                    perBatchGradsD[b] = gradCopy;
+                }
+                finally
+                {
+                    kPoolD.Return(im2colBuf);
+                    kPoolD.Return(localGrad);
+                }
+            });
+            for (int b = 0; b < batch; b++)
+            {
+                var lg = perBatchGradsD[b];
+                for (int i = 0; i < gradKernelD.Length; i++)
+                    gradKernelD[i] += lg[i];
+            }
+            if (accumulate)
+                for (int i = 0; i < totalLen; i++) destD[destOff + i] += gradKernelD[i];
+            else
+                Array.Copy(gradKernelD, 0, destD, destOff, totalLen);
+            return;
+        }
+
+        // Generic fallback for non-float, non-double types.
+        var tmp = Conv2DBackwardKernel(gradOutput, input, kernelShape, stride, padding, dilation);
+        if (accumulate)
+        {
+            TensorAddInto(dest, dest, tmp);
+        }
+        else
+        {
+            tmp.AsSpan().CopyTo(dest.AsWritableSpan());
+        }
     }
 
     /// <inheritdoc/>

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -17348,6 +17348,14 @@ public partial class CpuEngine : ITensorLevelEngine
         if (input == null) throw new ArgumentNullException(nameof(input));
         if (gamma == null) throw new ArgumentNullException(nameof(gamma));
         if (beta == null) throw new ArgumentNullException(nameof(beta));
+        // Pin the active gradient tape (if any) to THIS engine so the backward
+        // walk replays on the same engine instance the user invoked forward
+        // on. Without this, an active tape constructed before any explicit
+        // engine instantiation defaults to AiDotNetEngine.Current — which on
+        // auto-detect-GPU systems is DirectGpuTensorEngine — and the backward
+        // pass dispatches to a different engine than the forward pass. See
+        // BindEngineIfUnset's docstring for the full rationale (issue #350).
+        AiDotNet.Tensors.Engines.Autodiff.GradientTape<T>.Current?.BindEngineIfUnset(this);
 
         // GraphMode: execute eagerly (out params), but record result in graph for compiled plan
         if (GraphMode.IsActive)
@@ -17361,6 +17369,14 @@ public partial class CpuEngine : ITensorLevelEngine
                 GraphMode.SetCurrent(null);
                 var eagerResult = BatchNorm(ci, cg, cb, ce, out mean, out variance);
                 GraphMode.SetCurrent(savedScope);
+                // Bind THIS engine to the scope so the compiled plan replays on
+                // the same engine the user called the op on (issue #350: scope
+                // captures AiDotNetEngine.Current at scope-construction time,
+                // which on auto-detect-GPU systems is DirectGpuTensorEngine —
+                // wrong if the user explicitly calls a CPU instance, since BN
+                // results would be GPU-routed at Step time and diverge from
+                // the CPU eager-time output).
+                scope.BindEngineIfUnset(this);
                 // Record in graph so compiled plan captures the dependency
                 var lazyResult = scope.RecordVariadic(LazyNodeType.Custom, "BatchNorm",
                     new[] { input, gamma, beta }, eagerResult._shape,

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -17732,8 +17732,15 @@ public partial class CpuEngine : ITensorLevelEngine
                 // Execute eagerly to fill out params
                 var savedScope = GraphMode.Current;
                 GraphMode.SetCurrent(null);
-                var eagerResult = BatchNorm(ci, cg, cb, ce, out mean, out variance);
-                GraphMode.SetCurrent(savedScope);
+                Tensor<T> eagerResult;
+                try
+                {
+                    eagerResult = BatchNorm(ci, cg, cb, ce, out mean, out variance);
+                }
+                finally
+                {
+                    GraphMode.SetCurrent(savedScope);
+                }
                 // Bind THIS engine to the scope so the compiled plan replays on
                 // the same engine the user called the op on (issue #350: scope
                 // captures AiDotNetEngine.Current at scope-construction time,

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -18377,6 +18377,58 @@ public partial class CpuEngine : ITensorLevelEngine
         return TensorAllocator.Rent<T>(input._shape, gradInputData);
     }
 
+    /// <summary>
+    /// BatchNorm backward writing into pre-allocated destination tensors,
+    /// with per-output accumulate flags. Used by
+    /// <see cref="Compilation.CompiledTrainingPlan{T}"/> to skip the 3 fresh
+    /// tensor allocations + 3 chained AccumulateGrad calls that
+    /// <c>BackwardFunctions.BatchNormBackward</c> pays per BN layer. On the
+    /// 18-BN-layer GraFPrint pyramid this saves ~3-5 ms per BN backward.
+    /// <para>
+    /// Internally this routes through the existing rank-aware
+    /// <see cref="BatchNormBackward{T}"/> dispatcher (which already has a
+    /// double-arithmetic fast path for the 4D case at line 18458) and then
+    /// merges the temporary results into the caller's buffers — accumulate
+    /// or overwrite. The merge cost is one SIMD pass per output (cheaper
+    /// than the AccumulateGrad chain it replaces because the destination
+    /// is known a priori; no dictionary lookup, no IsContiguous check, no
+    /// virtual dispatch through TensorAddInPlace).
+    /// </para>
+    /// <para>
+    /// A future Tier 2 fused-Conv-BN-Activation backward will inline this
+    /// path; this Into variant is the Tier 1 stepping stone that eliminates
+    /// the orchestration overhead while keeping the existing engine kernels
+    /// in place.
+    /// </para>
+    /// </summary>
+    public void BatchNormBackwardInto<T>(
+        Tensor<T> destGradInput, Tensor<T> destGradGamma, Tensor<T> destGradBeta,
+        Tensor<T> gradOutput, Tensor<T> input, Tensor<T> gamma,
+        Tensor<T> mean, Tensor<T> variance, double epsilon,
+        bool accumulateInput, bool accumulateGamma, bool accumulateBeta)
+    {
+        if (destGradInput == null) throw new ArgumentNullException(nameof(destGradInput));
+        if (destGradGamma == null) throw new ArgumentNullException(nameof(destGradGamma));
+        if (destGradBeta == null) throw new ArgumentNullException(nameof(destGradBeta));
+        if (!destGradInput.IsContiguous) throw new InvalidOperationException("destGradInput must be contiguous.");
+        if (!destGradGamma.IsContiguous) throw new InvalidOperationException("destGradGamma must be contiguous.");
+        if (!destGradBeta.IsContiguous) throw new InvalidOperationException("destGradBeta must be contiguous.");
+
+        var gi = BatchNormBackward(gradOutput, input, gamma, mean, variance, epsilon, out var gg, out var gb);
+
+        // Merge gi → destGradInput
+        if (accumulateInput) TensorAddInto(destGradInput, destGradInput, gi);
+        else gi.AsSpan().CopyTo(destGradInput.AsWritableSpan());
+
+        // Merge gg → destGradGamma
+        if (accumulateGamma) TensorAddInto(destGradGamma, destGradGamma, gg);
+        else gg.AsSpan().CopyTo(destGradGamma.AsWritableSpan());
+
+        // Merge gb → destGradBeta
+        if (accumulateBeta) TensorAddInto(destGradBeta, destGradBeta, gb);
+        else gb.AsSpan().CopyTo(destGradBeta.AsWritableSpan());
+    }
+
 
     /// <summary>
     /// Backward pass for 4D batch normalization [batch, channels, height, width].

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/BatchNormGradSlotResidualTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/BatchNormGradSlotResidualTests.cs
@@ -1,0 +1,552 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// Issue #350 third-order residual: PR #351's two-bug repair landed but the
+/// AiDotNet GraFPrint min-repro (testconsole/BnFusedGradDiff.cs in
+/// ooples/AiDotNet branch fix/pr-1290-cluster-4-5) still shows a
+/// single-element gradient slot divergence on a 4-feature
+/// BatchNormalizationLayer:
+///
+///   forward output: bit-for-bit identical (eager vs compiled)
+///   gamma_grad after 1 Adam step:
+///     [0]  eager 0.99000001  fused 0.99000001  (match)
+///     [1]  eager 0.99000001  fused 1.00999999  (OPPOSITE direction)
+///     [2]  eager 0.99000001  fused 0.99000001  (match)
+///     [3]  eager 0.99000001  fused 0.99000001  (match)
+///
+/// The update magnitude is correct (|Δ|=0.01, lr-bounded by Adam's first step)
+/// but the SIGN is flipped at one specific channel index. The 2D
+/// BatchNormBackward code itself is correct and shared by both paths, so the
+/// mis-routing must happen in how the compiled plan captures or accumulates
+/// the gradient outputs of BatchNorm — not in the backward math.
+///
+/// These tests pin the contract: an Adam step on a graph whose ONLY
+/// trainable parameters are gamma + beta of a BatchNorm op must move every
+/// channel of gamma in the same direction the eager-mode equivalent does.
+/// </summary>
+public class BatchNormGradSlotResidualTests
+{
+    /// <summary>
+    /// Pinpoint: capture bnF BEFORE plan.Step() (when it should hold the
+    /// eager-time copied values) and AFTER plan.Step() (when forward replay
+    /// has overwritten it). Compare both with the eager BN result.
+    /// </summary>
+    [Fact]
+    public void Pinpoint_FusedBN_PreVsPostStep_VsEager()
+    {
+        var engine = new CpuEngine();
+        const int batch = 4, features = 4;
+        const double epsilon = 1e-5;
+        var rng = new System.Random(42);
+        var inputData = new float[batch * features];
+        for (int i = 0; i < inputData.Length; i++) inputData[i] = (float)(rng.NextDouble() - 0.5);
+
+        // EAGER
+        var inputE = new Tensor<float>(new[] { batch, features });
+        for (int i = 0; i < inputE.Length; i++) inputE[i] = inputData[i];
+        var gammaE = new Tensor<float>(new[] { features });
+        var betaE = new Tensor<float>(new[] { features });
+        for (int i = 0; i < features; i++) { gammaE[i] = 1f; betaE[i] = 0f; }
+        var bnE = engine.BatchNorm(inputE, gammaE, betaE, epsilon, out _, out _);
+        var snapE = new float[bnE.Length];
+        for (int i = 0; i < bnE.Length; i++) snapE[i] = bnE[i];
+
+        // FUSED — capture pre/post Step
+        var inputF = new Tensor<float>(new[] { batch, features });
+        for (int i = 0; i < inputF.Length; i++) inputF[i] = inputData[i];
+        var gammaF = new Tensor<float>(new[] { features });
+        var betaF = new Tensor<float>(new[] { features });
+        for (int i = 0; i < features; i++) { gammaF[i] = 1f; betaF[i] = 0f; }
+
+        Tensor<float> bnF;
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            bnF = engine.BatchNorm(inputF, gammaF, betaF, epsilon, out _, out _);
+            var sqF = engine.TensorMultiply(bnF, bnF);
+            engine.ReduceSum(sqF, null);
+            plan = scope.CompileTraining(new[] { gammaF, betaF });
+        }
+
+        // Capture BEFORE Step
+        var snapPreStep = new float[bnF.Length];
+        for (int i = 0; i < bnF.Length; i++) snapPreStep[i] = bnF[i];
+
+        using (plan)
+        {
+            plan.Step();
+        }
+
+        // Capture AFTER Step
+        var snapPostStep = new float[bnF.Length];
+        for (int i = 0; i < bnF.Length; i++) snapPostStep[i] = bnF[i];
+
+        var lines = new System.Collections.Generic.List<string>();
+        lines.Add("  per-element diff:  pre-Step vs eager,  post-Step vs eager");
+        bool anyPreDiff = false, anyPostDiff = false;
+        for (int b = 0; b < batch; b++)
+        {
+            for (int f = 0; f < features; f++)
+            {
+                int i = b * features + f;
+                float dPre = System.Math.Abs(snapPreStep[i] - snapE[i]);
+                float dPost = System.Math.Abs(snapPostStep[i] - snapE[i]);
+                if (dPre >= 1e-6f) anyPreDiff = true;
+                if (dPost >= 1e-6f) anyPostDiff = true;
+                lines.Add($"  [{b},{f}]  eager={snapE[i],12:F8}  preStep={snapPreStep[i],12:F8} (Δ={dPre,9:E2})  postStep={snapPostStep[i],12:F8} (Δ={dPost,9:E2})");
+            }
+        }
+        Assert.False(anyPreDiff || anyPostDiff,
+            $"BN forward output diverges. preDiff={anyPreDiff}, postDiff={anyPostDiff}\n" + string.Join("\n", lines));
+    }
+
+    /// <summary>
+    /// Sanity: calling engine.BatchNorm twice with bit-identical input/gamma/beta
+    /// MUST produce bit-identical output. If this fails, something deeper than
+    /// compile-mode is wrong (probably TensorAllocator reusing dirty buffers).
+    /// </summary>
+    [Fact]
+    public void Sanity_BatchNorm_Twice_SameInput_SameOutput()
+    {
+        var engine = new CpuEngine();
+        const int batch = 4, features = 4;
+        const double epsilon = 1e-5;
+        var rng = new System.Random(42);
+        var inputData = new float[batch * features];
+        for (int i = 0; i < inputData.Length; i++) inputData[i] = (float)(rng.NextDouble() - 0.5);
+
+        var input1 = new Tensor<float>(new[] { batch, features });
+        for (int i = 0; i < input1.Length; i++) input1[i] = inputData[i];
+        var gamma1 = new Tensor<float>(new[] { features });
+        var beta1 = new Tensor<float>(new[] { features });
+        for (int i = 0; i < features; i++) { gamma1[i] = 1f; beta1[i] = 0f; }
+        var out1 = engine.BatchNorm(input1, gamma1, beta1, epsilon, out _, out _);
+        var snap1 = new float[out1.Length];
+        for (int i = 0; i < out1.Length; i++) snap1[i] = out1[i];
+
+        var input2 = new Tensor<float>(new[] { batch, features });
+        for (int i = 0; i < input2.Length; i++) input2[i] = inputData[i];
+        var gamma2 = new Tensor<float>(new[] { features });
+        var beta2 = new Tensor<float>(new[] { features });
+        for (int i = 0; i < features; i++) { gamma2[i] = 1f; beta2[i] = 0f; }
+        var out2 = engine.BatchNorm(input2, gamma2, beta2, epsilon, out _, out _);
+
+        var lines = new System.Collections.Generic.List<string>();
+        bool anyDiff = false;
+        for (int b = 0; b < batch; b++)
+        {
+            for (int f = 0; f < features; f++)
+            {
+                int i = b * features + f;
+                float d = System.Math.Abs(snap1[i] - out2[i]);
+                if (d >= 1e-6f) anyDiff = true;
+                lines.Add($"  [{b},{f}]  out1={snap1[i],12:F8}  out2={out2[i],12:F8}  |Δ|={d,12:E6}");
+            }
+        }
+        Assert.False(anyDiff, "engine.BatchNorm produced different outputs for same input on consecutive calls:\n" + string.Join("\n", lines));
+    }
+
+
+    /// <summary>
+    /// BN → square (no target / subtract) → ReduceSum. If THIS passes,
+    /// the bug emerges from the subtract-with-non-trainable-target step
+    /// in MSE; if it fails, the bug is in compile-mode multiply backward
+    /// when one operand is a non-leaf intermediate (BN's output).
+    /// </summary>
+    [Fact]
+    public void BatchNorm_Then_Square_ReduceSum_Backward_MatchesEager_PerElement()
+    {
+        var engine = new CpuEngine();
+        const int batch = 4, features = 4;
+        const double epsilon = 1e-5;
+
+        var rng = new System.Random(42);
+        var inputData = new float[batch * features];
+        for (int i = 0; i < inputData.Length; i++) inputData[i] = (float)(rng.NextDouble() - 0.5);
+
+        // EAGER
+        var inputE = new Tensor<float>(new[] { batch, features });
+        for (int i = 0; i < inputE.Length; i++) inputE[i] = inputData[i];
+        var gammaE = new Tensor<float>(new[] { features });
+        var betaE = new Tensor<float>(new[] { features });
+        for (int i = 0; i < features; i++) { gammaE[i] = 1.0f; betaE[i] = 0.0f; }
+
+        Tensor<float> eagerGradGamma, eagerGradBeta;
+        using (var tape = new GradientTape<float>())
+        {
+            var bnE = engine.BatchNorm(inputE, gammaE, betaE, epsilon, out _, out _);
+            var sqE = engine.TensorMultiply(bnE, bnE);
+            var sumE = engine.ReduceSum(sqE, null);
+            var grads = tape.ComputeGradients(sumE, sources: new[] { gammaE, betaE });
+            eagerGradGamma = grads[gammaE];
+            eagerGradBeta = grads[betaE];
+        }
+
+        // FUSED
+        var inputF = new Tensor<float>(new[] { batch, features });
+        for (int i = 0; i < inputF.Length; i++) inputF[i] = inputData[i];
+        var gammaF = new Tensor<float>(new[] { features });
+        var betaF = new Tensor<float>(new[] { features });
+        for (int i = 0; i < features; i++) { gammaF[i] = 1.0f; betaF[i] = 0.0f; }
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var bnF = engine.BatchNorm(inputF, gammaF, betaF, epsilon, out _, out _);
+            var sqF = engine.TensorMultiply(bnF, bnF);
+            engine.ReduceSum(sqF, null);
+            plan = scope.CompileTraining(new[] { gammaF, betaF });
+        }
+
+        using (plan)
+        {
+            plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.0f);
+            plan.Step();
+        }
+
+        var fusedGradGamma = gammaF.Grad ?? throw new System.InvalidOperationException("gammaF.Grad not set");
+        var fusedGradBeta = betaF.Grad ?? throw new System.InvalidOperationException("betaF.Grad not set");
+
+        var lines = new System.Collections.Generic.List<string>();
+        bool anyMismatch = false;
+        for (int p = 0; p < features; p++)
+        {
+            float dG = System.Math.Abs(eagerGradGamma[p] - fusedGradGamma[p]);
+            float dB = System.Math.Abs(eagerGradBeta[p] - fusedGradBeta[p]);
+            if (dG >= 1e-4f || dB >= 1e-4f) anyMismatch = true;
+            lines.Add($"  ch[{p}]  gamma_grad eager={eagerGradGamma[p],12:F6} fused={fusedGradGamma[p],12:F6} |Δ|={dG,12:E6}    beta_grad eager={eagerGradBeta[p],12:F6} fused={fusedGradBeta[p],12:F6} |Δ|={dB,12:E6}");
+        }
+        Assert.False(anyMismatch, "compiled BN→sq→Sum backward diverges:\n" + string.Join("\n", lines));
+    }
+
+    /// <summary>
+    /// Even-more-isolated BN repro: BN forward → ReduceSum (no subtract,
+    /// no square, no target tensor at all). dL/dy = 1 for every element of
+    /// BN's output. If grads diverge here, the bug is purely in the compiled
+    /// BN backward path, not in MSE / subtract / multiply chain interactions.
+    /// </summary>
+    [Fact]
+    public void BatchNorm_Then_ReduceSum_Backward_MatchesEager_PerElement()
+    {
+        var engine = new CpuEngine();
+        const int batch = 4, features = 4;
+        const double epsilon = 1e-5;
+
+        var rng = new System.Random(42);
+        var inputData = new float[batch * features];
+        for (int i = 0; i < inputData.Length; i++) inputData[i] = (float)(rng.NextDouble() - 0.5);
+
+        // EAGER
+        var inputE = new Tensor<float>(new[] { batch, features });
+        for (int i = 0; i < inputE.Length; i++) inputE[i] = inputData[i];
+        var gammaE = new Tensor<float>(new[] { features });
+        var betaE = new Tensor<float>(new[] { features });
+        for (int i = 0; i < features; i++) { gammaE[i] = 1.0f; betaE[i] = 0.0f; }
+
+        Tensor<float> eagerGradGamma, eagerGradBeta;
+        using (var tape = new GradientTape<float>())
+        {
+            var bnE = engine.BatchNorm(inputE, gammaE, betaE, epsilon, out _, out _);
+            var sumE = engine.ReduceSum(bnE, null);
+            var grads = tape.ComputeGradients(sumE, sources: new[] { gammaE, betaE });
+            eagerGradGamma = grads[gammaE];
+            eagerGradBeta = grads[betaE];
+        }
+
+        // FUSED
+        var inputF = new Tensor<float>(new[] { batch, features });
+        for (int i = 0; i < inputF.Length; i++) inputF[i] = inputData[i];
+        var gammaF = new Tensor<float>(new[] { features });
+        var betaF = new Tensor<float>(new[] { features });
+        for (int i = 0; i < features; i++) { gammaF[i] = 1.0f; betaF[i] = 0.0f; }
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var bnF = engine.BatchNorm(inputF, gammaF, betaF, epsilon, out _, out _);
+            engine.ReduceSum(bnF, null);
+            plan = scope.CompileTraining(new[] { gammaF, betaF });
+        }
+
+        using (plan)
+        {
+            plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.0f);
+            plan.Step();
+        }
+
+        var fusedGradGamma = gammaF.Grad ?? throw new System.InvalidOperationException("gammaF.Grad not set");
+        var fusedGradBeta = betaF.Grad ?? throw new System.InvalidOperationException("betaF.Grad not set");
+
+        var lines = new System.Collections.Generic.List<string>();
+        bool anyMismatch = false;
+        for (int p = 0; p < features; p++)
+        {
+            float dG = System.Math.Abs(eagerGradGamma[p] - fusedGradGamma[p]);
+            float dB = System.Math.Abs(eagerGradBeta[p] - fusedGradBeta[p]);
+            if (dG >= 1e-4f || dB >= 1e-4f) anyMismatch = true;
+            lines.Add($"  ch[{p}]  gamma_grad eager={eagerGradGamma[p],12:F6} fused={fusedGradGamma[p],12:F6} |Δ|={dG,12:E6}    beta_grad eager={eagerGradBeta[p],12:F6} fused={fusedGradBeta[p],12:F6} |Δ|={dB,12:E6}");
+        }
+        Assert.False(anyMismatch, "compiled BN→ReduceSum backward diverges:\n" + string.Join("\n", lines));
+    }
+
+    /// <summary>
+    /// Sanity-check the simpler graph (no BatchNorm at all): differences in
+    /// the BN test could be in BN backward OR in upstream ops (MSE / sub /
+    /// mul / sum). This pure-multiply graph isolates the upstream backward
+    /// chain. If THIS passes, the bug is BN-specific; if THIS fails, the
+    /// bug is in a more fundamental compile-mode op like TensorMultiply
+    /// backward against the same operand twice (a common autodiff trap).
+    /// </summary>
+    [Fact]
+    public void SquareSum_Backward_MatchesEager_PerElement()
+    {
+        var engine = new CpuEngine();
+        const int n = 4;
+        var rng = new System.Random(42);
+
+        // Eager
+        var xE = new Tensor<float>(new[] { n });
+        for (int i = 0; i < n; i++) xE[i] = (float)(rng.NextDouble() - 0.5);
+        Tensor<float> eagerGrad;
+        using (var tape = new GradientTape<float>())
+        {
+            var sq = engine.TensorMultiply(xE, xE);
+            var loss = engine.ReduceSum(sq, null);
+            eagerGrad = tape.ComputeGradients(loss, sources: new[] { xE })[xE];
+        }
+
+        // Fused — re-seed RNG so xF gets identical values
+        var xF = new Tensor<float>(new[] { n });
+        var rngF = new System.Random(42);
+        for (int i = 0; i < n; i++) xF[i] = (float)(rngF.NextDouble() - 0.5);
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var sq = engine.TensorMultiply(xF, xF);
+            engine.ReduceSum(sq, null);
+            plan = scope.CompileTraining(new[] { xF });
+        }
+
+        using (plan)
+        {
+            plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.0f);
+            plan.Step();
+        }
+
+        var fusedGrad = xF.Grad ?? throw new System.InvalidOperationException("xF.Grad not set after Step()");
+
+        var lines = new System.Collections.Generic.List<string>();
+        bool anyMismatch = false;
+        for (int p = 0; p < n; p++)
+        {
+            float d = System.Math.Abs(eagerGrad[p] - fusedGrad[p]);
+            if (d >= 1e-5f) anyMismatch = true;
+            lines.Add($"  x[{p}]={xE[p],12:F8}  eager_grad={eagerGrad[p],12:F6}  fused_grad={fusedGrad[p],12:F6}  |Δ|={d,12:E6}");
+        }
+        Assert.False(anyMismatch, "compiled (x*x).ReduceSum backward diverges per-element:\n" + string.Join("\n", lines));
+    }
+
+
+    /// <summary>
+    /// 4-feature, batch-4 BatchNorm in 2D mode. Compute MSE loss against
+    /// a fixed target, run one Adam step under each path, compare per-element
+    /// post-step parameter values. The eager path is run via tape;
+    /// compile-mode runs through CompiledTrainingPlan.Step.
+    /// </summary>
+    [Fact]
+    public void BatchNorm_2D_GradGammaSlot_AdamStep_MatchesEager_PerElement()
+    {
+        var engine = new CpuEngine();
+        const int batch = 4, features = 4;
+        const float lr = 0.01f;
+        const double epsilon = 1e-5;
+
+        // Deterministic input + target — same data drives both paths so any
+        // divergence is in the gradient routing, not the input.
+        var rng = new System.Random(42);
+        var inputData = new float[batch * features];
+        var targetData = new float[batch * features];
+        for (int i = 0; i < inputData.Length; i++) inputData[i] = (float)(rng.NextDouble() - 0.5);
+        for (int i = 0; i < targetData.Length; i++) targetData[i] = (float)(rng.NextDouble() - 0.5);
+
+        // ================ EAGER path ================
+        var inputE = new Tensor<float>(new[] { batch, features });
+        for (int i = 0; i < inputE.Length; i++) inputE[i] = inputData[i];
+        var targetE = new Tensor<float>(new[] { batch, features });
+        for (int i = 0; i < targetE.Length; i++) targetE[i] = targetData[i];
+        var gammaE = new Tensor<float>(new[] { features });
+        var betaE = new Tensor<float>(new[] { features });
+        for (int i = 0; i < features; i++) { gammaE[i] = 1.0f; betaE[i] = 0.0f; }
+
+        using (var tape = new GradientTape<float>())
+        {
+            var bnE = engine.BatchNorm(inputE, gammaE, betaE, epsilon, out _, out _);
+            var diffE = engine.TensorSubtract(bnE, targetE);
+            var sqE = engine.TensorMultiply(diffE, diffE);
+            var lossE = engine.ReduceSum(sqE, null);
+
+            var grads = tape.ComputeGradients(lossE, sources: new[] { gammaE, betaE });
+            var gradGammaE = grads[gammaE];
+            var gradBetaE = grads[betaE];
+
+            // One Adam step (β1=0.9, β2=0.999, ε=1e-8, single-step bias correction).
+            const float b1 = 0.9f, b2 = 0.999f, adamEps = 1e-8f;
+            float bc1 = 1 - b1, bc2 = 1 - b2;
+            float oneMinusB1 = 1 - b1, oneMinusB2 = 1 - b2;
+            for (int p = 0; p < features; p++)
+            {
+                // gamma update
+                float gG = gradGammaE[p];
+                float mG = oneMinusB1 * gG;
+                float vG = oneMinusB2 * gG * gG;
+                float mHatG = mG / bc1;
+                float vHatG = vG / bc2;
+                gammaE[p] = gammaE[p] - lr * mHatG / ((float)System.Math.Sqrt(vHatG) + adamEps);
+
+                // beta update
+                float gB = gradBetaE[p];
+                float mB = oneMinusB1 * gB;
+                float vB = oneMinusB2 * gB * gB;
+                float mHatB = mB / bc1;
+                float vHatB = vB / bc2;
+                betaE[p] = betaE[p] - lr * mHatB / ((float)System.Math.Sqrt(vHatB) + adamEps);
+            }
+        }
+
+        // ================ FUSED / compiled path ================
+        var inputF = new Tensor<float>(new[] { batch, features });
+        for (int i = 0; i < inputF.Length; i++) inputF[i] = inputData[i];
+        var targetF = new Tensor<float>(new[] { batch, features });
+        for (int i = 0; i < targetF.Length; i++) targetF[i] = targetData[i];
+        var gammaF = new Tensor<float>(new[] { features });
+        var betaF = new Tensor<float>(new[] { features });
+        for (int i = 0; i < features; i++) { gammaF[i] = 1.0f; betaF[i] = 0.0f; }
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var bnF = engine.BatchNorm(inputF, gammaF, betaF, epsilon, out _, out _);
+            var diffF = engine.TensorSubtract(bnF, targetF);
+            var sqF = engine.TensorMultiply(diffF, diffF);
+            engine.ReduceSum(sqF, null);
+            plan = scope.CompileTraining(new[] { gammaF, betaF });
+        }
+
+        using (plan)
+        {
+            plan.ConfigureOptimizer(OptimizerType.Adam, learningRate: lr);
+            plan.Step();
+        }
+
+        // ================ Per-element diff ================
+        for (int p = 0; p < features; p++)
+        {
+            float dGamma = System.Math.Abs(gammaE[p] - gammaF[p]);
+            float dBeta = System.Math.Abs(betaE[p] - betaF[p]);
+            // Tolerance kept tight (1e-5) so a sign-flipped element shows up
+            // immediately as |Δ|≈0.02, while genuine float-precision noise
+            // (≤1e-6 typically) stays under.
+            Assert.True(dGamma < 1e-5,
+                $"gamma[{p}] eager={gammaE[p]:F8} fused={gammaF[p]:F8} |Δ|={dGamma:E6} — sign-flip indicates compiled BN gradient slotting bug");
+            Assert.True(dBeta < 1e-5,
+                $"beta[{p}] eager={betaE[p]:F8} fused={betaF[p]:F8} |Δ|={dBeta:E6}");
+        }
+    }
+
+    /// <summary>
+    /// Stronger version: inspect the gradient values BEFORE the optimizer
+    /// runs. Eager grad collected from the tape directly; compile-mode grad
+    /// collected via the introspection hook the AccumulateGrad-into-dict
+    /// path leaves on each parameter (`tensor.Grad`). If any per-channel
+    /// gradient component differs across modes for a deterministic input,
+    /// the compile-mode backward is mis-routing.
+    /// </summary>
+    [Fact]
+    public void BatchNorm_2D_GradGamma_BeforeOptimizer_MatchesEager_PerElement()
+    {
+        var engine = new CpuEngine();
+        const int batch = 4, features = 4;
+        const double epsilon = 1e-5;
+
+        var rng = new System.Random(42);
+        var inputData = new float[batch * features];
+        var targetData = new float[batch * features];
+        for (int i = 0; i < inputData.Length; i++) inputData[i] = (float)(rng.NextDouble() - 0.5);
+        for (int i = 0; i < targetData.Length; i++) targetData[i] = (float)(rng.NextDouble() - 0.5);
+
+        // EAGER grads via tape
+        var inputE = new Tensor<float>(new[] { batch, features });
+        for (int i = 0; i < inputE.Length; i++) inputE[i] = inputData[i];
+        var targetE = new Tensor<float>(new[] { batch, features });
+        for (int i = 0; i < targetE.Length; i++) targetE[i] = targetData[i];
+        var gammaE = new Tensor<float>(new[] { features });
+        var betaE = new Tensor<float>(new[] { features });
+        for (int i = 0; i < features; i++) { gammaE[i] = 1.0f; betaE[i] = 0.0f; }
+
+        Tensor<float> eagerGradGamma, eagerGradBeta;
+        using (var tape = new GradientTape<float>())
+        {
+            var bnE = engine.BatchNorm(inputE, gammaE, betaE, epsilon, out _, out _);
+            var diffE = engine.TensorSubtract(bnE, targetE);
+            var sqE = engine.TensorMultiply(diffE, diffE);
+            var lossE = engine.ReduceSum(sqE, null);
+            var grads = tape.ComputeGradients(lossE, sources: new[] { gammaE, betaE });
+            eagerGradGamma = grads[gammaE];
+            eagerGradBeta = grads[betaE];
+        }
+
+        // FUSED grads via CompiledTrainingPlan — capture from gammaF.Grad
+        // after Step() runs the backward but before the optimizer mutates
+        // the param. Use a no-op SGD with lr=0 so the params don't move,
+        // then read .Grad on the parameter tensor.
+        var inputF = new Tensor<float>(new[] { batch, features });
+        for (int i = 0; i < inputF.Length; i++) inputF[i] = inputData[i];
+        var targetF = new Tensor<float>(new[] { batch, features });
+        for (int i = 0; i < targetF.Length; i++) targetF[i] = targetData[i];
+        var gammaF = new Tensor<float>(new[] { features });
+        var betaF = new Tensor<float>(new[] { features });
+        for (int i = 0; i < features; i++) { gammaF[i] = 1.0f; betaF[i] = 0.0f; }
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var bnF = engine.BatchNorm(inputF, gammaF, betaF, epsilon, out _, out _);
+            var diffF = engine.TensorSubtract(bnF, targetF);
+            var sqF = engine.TensorMultiply(diffF, diffF);
+            engine.ReduceSum(sqF, null);
+            plan = scope.CompileTraining(new[] { gammaF, betaF });
+        }
+
+        using (plan)
+        {
+            // lr=0 so params don't move — we only want the grad capture.
+            plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.0f);
+            plan.Step();
+        }
+
+        var fusedGradGamma = gammaF.Grad ?? throw new System.InvalidOperationException("gammaF.Grad not set after Step()");
+        var fusedGradBeta = betaF.Grad ?? throw new System.InvalidOperationException("betaF.Grad not set after Step()");
+
+        // Collect all per-channel diffs FIRST so the failure message dumps
+        // every channel — single-element bugs are much easier to bisect when
+        // you can see the whole gamma/beta vector, not just the first
+        // mismatch the assertion happens to catch.
+        var lines = new System.Collections.Generic.List<string>();
+        bool anyMismatch = false;
+        for (int p = 0; p < features; p++)
+        {
+            float dGamma = System.Math.Abs(eagerGradGamma[p] - fusedGradGamma[p]);
+            float dBeta = System.Math.Abs(eagerGradBeta[p] - fusedGradBeta[p]);
+            if (dGamma >= 1e-4f || dBeta >= 1e-4f) anyMismatch = true;
+            lines.Add($"  ch[{p}]  gamma_grad eager={eagerGradGamma[p],12:F6} fused={fusedGradGamma[p],12:F6} |Δ|={dGamma,12:E6}    beta_grad eager={eagerGradBeta[p],12:F6} fused={fusedGradBeta[p],12:F6} |Δ|={dBeta,12:E6}");
+        }
+        Assert.False(anyMismatch, "compiled BN backward routes wrong per-channel gradients:\n" + string.Join("\n", lines));
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/BatchNormGradSlotResidualTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/BatchNormGradSlotResidualTests.cs
@@ -152,23 +152,79 @@ public class BatchNormGradSlotResidualTests
             engine.ReduceSum(sqF, null);
             plan = scope.CompileTraining(new[] { gammaF, betaF });
         }
-        using (plan)
+        // Wire StepProbe to capture diffF[0] at every phase boundary
+        var ctpType3 = typeof(AiDotNet.Tensors.LinearAlgebra.Tensor<double>).Assembly
+            .GetType("AiDotNet.Tensors.Engines.Compilation.CompiledTrainingPlan`1")!
+            .MakeGenericType(typeof(double));
+        var probeProp3 = ctpType3.GetProperty("StepProbe", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)!;
+        var phaseLog = new System.Collections.Generic.List<string>();
+        System.Action<string> probe3 = phase =>
         {
-            plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.0f);
-            plan.Step();
+            phaseLog.Add($"  {phase,-40} bnF[0]={bnF[0]:F18} diffF[0]={diffF[0]:F18} sqF[0]={sqF[0]:F18}");
+        };
+        probeProp3.SetValue(null, probe3);
+        try
+        {
+            using (plan)
+            {
+                plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.0f);
+                plan.Step();
+            }
         }
+        finally
+        {
+            probeProp3.SetValue(null, null);
+        }
+        phaseLog.Add($"  POST-DISPOSE                             bnF[0]={bnF[0]:F18} diffF[0]={diffF[0]:F18} sqF[0]={sqF[0]:F18}");
+
+        // EXPERIMENT: snapshot diffF four ways to find what fixes the Heisenbug.
+        var diffF_directIndex = new double[batch * features];
+        for (int i = 0; i < diffF.Length; i++) diffF_directIndex[i] = diffF[i];
+
+        // (a) Force GC.Collect to test if it's a GC-related stale read
+        var diffF_afterGC = new double[batch * features];
+        System.GC.Collect();
+        System.GC.WaitForPendingFinalizers();
+        for (int i = 0; i < diffF.Length; i++) diffF_afterGC[i] = diffF[i];
+
+        // (b) Memory barrier
+        var diffF_afterBarrier = new double[batch * features];
+        System.Threading.Thread.MemoryBarrier();
+        for (int i = 0; i < diffF.Length; i++) diffF_afterBarrier[i] = diffF[i];
+
+        // (c) Read via AsSpan instead of indexer
+        var diffF_viaSpan = new double[batch * features];
+        var diffSpan = diffF.AsSpan();
+        for (int i = 0; i < diffF.Length; i++) diffF_viaSpan[i] = diffSpan[i];
+
+        // (d) Read via GetDataArray (raw backing)
+        var diffF_viaArray = new double[batch * features];
+        var diffArr = (double[])(object)diffF.GetDataArray();
+        for (int i = 0; i < diffF.Length; i++) diffF_viaArray[i] = diffArr[i];
 
         var lines = new System.Collections.Generic.List<string>();
         bool any = false;
         for (int i = 0; i < bnE.Length; i++)
         {
             double dBn = System.Math.Abs(bnE[i] - bnF[i]);
-            double dDiff = System.Math.Abs(diffE[i] - diffF[i]);
+            double dDiff = System.Math.Abs(diffE[i] - diffF_directIndex[i]);
+            double dDiffGC = System.Math.Abs(diffE[i] - diffF_afterGC[i]);
+            double dDiffBar = System.Math.Abs(diffE[i] - diffF_afterBarrier[i]);
+            double dDiffSpan = System.Math.Abs(diffE[i] - diffF_viaSpan[i]);
+            double dDiffArr = System.Math.Abs(diffE[i] - diffF_viaArray[i]);
             double dSq = System.Math.Abs(sqE[i] - sqF[i]);
-            if (dBn > 0 || dDiff > 0 || dSq > 0) any = true;
-            lines.Add($"  [{i}]  bn |Δ|={dBn:E3}  diff |Δ|={dDiff:E3}  sq |Δ|={dSq:E3}");
+            if (dBn > 0 || dDiff > 0 || dDiffGC > 0 || dDiffBar > 0 || dDiffSpan > 0 || dDiffArr > 0) any = true;
+            lines.Add($"  [{i}]  bn={dBn:E3} diff(idx)={dDiff:E3} diff(gc)={dDiffGC:E3} diff(bar)={dDiffBar:E3} diff(span)={dDiffSpan:E3} diff(arr)={dDiffArr:E3} sq={dSq:E3}");
         }
-        Assert.False(any, "Forward chain BN→Sub→Mul diverges between eager and compile:\n"
+        // Read SubFwdDiag via reflection
+        var ctpType2 = typeof(AiDotNet.Tensors.LinearAlgebra.Tensor<double>).Assembly
+            .GetType("AiDotNet.Tensors.Engines.Compilation.CompiledTrainingPlan`1")!
+            .MakeGenericType(typeof(double));
+        var subDiagField = ctpType2.GetField("SubFwdDiag", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+        var subDiag = subDiagField?.GetValue(null) as string ?? "(unset)";
+
+        Assert.False(any, $"Forward chain BN→Sub→Mul diverges (probe-mode bisect):\n  SUB-FWD diag: {subDiag}\n  eager bnE[0]={bnE[0]:F18} bnF[0]={bnF[0]:F18} targetE[0]={targetE[0]:F18} targetF[0]={targetF[0]:F18}\n  eager diffE[0]={diffE[0]:F18}  (manual: bnE[0]-targetE[0] = {bnE[0] - targetE[0]:F18})\n  diffF_directIndex[0]={diffF_directIndex[0]:F18}\n  diffF[0] (live indexer) = {diffF[0]:F18}\n  PHASE LOG:\n"
+            + string.Join("\n", phaseLog) + "\n  DIFFS:\n"
             + string.Join("\n", lines));
     }
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/BatchNormGradSlotResidualTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/BatchNormGradSlotResidualTests.cs
@@ -104,6 +104,141 @@ public class BatchNormGradSlotResidualTests
     }
 
     /// <summary>
+    /// Pinpoint: forward-only TensorSubtract bit-identity check. Eager
+    /// engine.TensorSubtract vs compile-mode lazy execute (which calls
+    /// engine.TensorSubtractInto under the hood). If THIS fails, the
+    /// SubtractInto SIMD kernel diverges from the allocating Subtract
+    /// SIMD kernel — that's where the MseChain residual 1e-7 comes from.
+    /// </summary>
+    [Fact]
+    public void Pinpoint_DOUBLE_TensorSubtract_Forward_EagerVsCompile_BitIdentical()
+    {
+        var engine = new CpuEngine();
+        const int n = 16;
+        var rng = new System.Random(42);
+        var xData = new double[n]; var tData = new double[n];
+        for (int i = 0; i < n; i++) xData[i] = rng.NextDouble() - 0.5;
+        for (int i = 0; i < n; i++) tData[i] = rng.NextDouble() - 0.5;
+
+        // Eager
+        var xE = new Tensor<double>(new[] { n });
+        var tE = new Tensor<double>(new[] { n });
+        for (int i = 0; i < n; i++) { xE[i] = xData[i]; tE[i] = tData[i]; }
+        var diffE = engine.TensorSubtract(xE, tE);
+
+        // Compile (forward only — read post-Step)
+        var xF = new Tensor<double>(new[] { n });
+        var tF = new Tensor<double>(new[] { n });
+        for (int i = 0; i < n; i++) { xF[i] = xData[i]; tF[i] = tData[i]; }
+        Tensor<double> diffF;
+        ICompiledTrainingPlan<double> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            // Force the scope to bind to the CpuEngine instance the test
+            // explicitly created. Without this, scope._engine defaults to
+            // AiDotNetEngine.Current — which on auto-detect-GPU systems is
+            // DirectGpuTensorEngine, and that engine's TensorSubtractInto
+            // computes in single precision on consumer GPUs, producing the
+            // float-ULP-precision residual the MseChain test catches.
+            // Same root cause as the engine-routing fix this PR added for
+            // BatchNorm — the same plumbing is needed for every op that
+            // records into a graph from an explicit-engine caller.
+            typeof(AiDotNet.Tensors.Engines.Compilation.LazyTensorScope)
+                .GetMethod("BindEngineIfUnset", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+                .Invoke(scope, new object[] { engine });
+            diffF = engine.TensorSubtract(xF, tF);
+            engine.ReduceSum(diffF, null);  // need an output to compile a plan
+            plan = scope.CompileTraining(new[] { xF });
+        }
+        using (plan)
+        {
+            plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.0f);
+            plan.Step();
+        }
+
+        // CRITICAL ORDER: snapshot diffF FIRST, before any other allocation
+        // could pollute the underlying pool-backed buffer.
+        var diffFSnap = new double[n];
+        for (int i = 0; i < n; i++) diffFSnap[i] = diffF[i];
+
+        // Direct TensorSubtractInto call — bypass the plan, mimic exactly
+        // what the lazy execute does.
+        var directOut = new Tensor<double>(new[] { n });
+        engine.TensorSubtractInto(directOut, xF, tF);
+
+        var lines = new System.Collections.Generic.List<string>();
+        bool any = false;
+        for (int i = 0; i < n; i++)
+        {
+            double dEvSnap = System.Math.Abs(diffE[i] - diffFSnap[i]);
+            double dSnapNow = System.Math.Abs(diffFSnap[i] - diffF[i]);
+            double dEvD = System.Math.Abs(diffE[i] - directOut[i]);
+            if (dEvSnap > 0 || dSnapNow > 0 || dEvD > 0) any = true;
+            lines.Add($"  [{i}]  eager={diffE[i]:F18} fusedSnap={diffFSnap[i]:F18} fusedNow={diffF[i]:F18} direct={directOut[i]:F18} |E-Snap|={dEvSnap:E3} |Snap-Now|={dSnapNow:E3} |E-D|={dEvD:E3}");
+        }
+        Assert.False(any, "TensorSubtract forward diverges between eager and compile-mode replay:\n"
+            + string.Join("\n", lines));
+    }
+
+    /// <summary>
+    /// Even-finer bisect: ONLY mul(x, x).ReduceSum() - no subtract, no
+    /// target. Tests just the Multiply-with-self backward path on T=double.
+    /// If this PASSES at 1e-12, the divergence in
+    /// Isolation_DOUBLE_MseChain_GradX is in TensorSubtract; if it FAILS,
+    /// the divergence is in TensorMultiply backward when both inputs are
+    /// the same tensor reference (a documented autodiff trap — see the
+    /// existing float-tolerance SquareSum_Backward test at line 545).
+    /// </summary>
+    [Fact]
+    public void Isolation_DOUBLE_SquareSum_GradX_MatchesEager_PerElement()
+    {
+        var engine = new CpuEngine();
+        const int n = 16;
+        var rng = new System.Random(42);
+        var xData = new double[n];
+        for (int i = 0; i < n; i++) xData[i] = rng.NextDouble() - 0.5;
+
+        var xE = new Tensor<double>(new[] { n });
+        for (int i = 0; i < n; i++) xE[i] = xData[i];
+
+        Tensor<double> eagerGrad;
+        using (var tape = new GradientTape<double>())
+        {
+            var sq = engine.TensorMultiply(xE, xE);
+            var loss = engine.ReduceSum(sq, null);
+            eagerGrad = tape.ComputeGradients(loss, sources: new[] { xE })[xE];
+        }
+
+        var xF = new Tensor<double>(new[] { n });
+        for (int i = 0; i < n; i++) xF[i] = xData[i];
+
+        ICompiledTrainingPlan<double> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var sq = engine.TensorMultiply(xF, xF);
+            engine.ReduceSum(sq, null);
+            plan = scope.CompileTraining(new[] { xF });
+        }
+        using (plan)
+        {
+            plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.0f);
+            plan.Step();
+        }
+        var fusedGrad = xF.Grad ?? throw new System.InvalidOperationException("xF.Grad");
+
+        var lines = new System.Collections.Generic.List<string>();
+        bool any = false;
+        const double tol = 1e-12;
+        for (int i = 0; i < n; i++)
+        {
+            double d = System.Math.Abs(eagerGrad[i] - fusedGrad[i]);
+            if (d >= tol) any = true;
+            lines.Add($"  x[{i}]={xE[i]:F12} eager={eagerGrad[i]:F12} fused={fusedGrad[i]:F12} |Δ|={d:E3}");
+        }
+        Assert.False(any, "x*x→sum backward diverges:\n" + string.Join("\n", lines));
+    }
+
+    /// <summary>
     /// Bisect the upstream Sub→Multiply chain. BN forward is REPLACED with
     /// a leaf parameter `xF` — eliminates BN backward as a variable.
     /// MSE backward path: ReduceSum → Multiply(square) → Subtract(target).

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/BatchNormGradSlotResidualTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/BatchNormGradSlotResidualTests.cs
@@ -7,6 +7,16 @@ using Xunit;
 namespace AiDotNet.Tensors.Tests.Engines.Compilation;
 
 /// <summary>
+/// Serializes tests that mutate process-wide compilation state
+/// (GraphMode scope, GradientTape.Current, CompiledTrainingPlan.StepProbe).
+/// Without this, xUnit's parallel runner can interleave classes that each
+/// assume exclusive ownership of those statics — surfaces as flaky tests
+/// that pass on rerun.
+/// </summary>
+[CollectionDefinition("CompilationGlobalState", DisableParallelization = true)]
+public sealed class CompilationGlobalStateCollection { }
+
+/// <summary>
 /// Issue #350 third-order residual: PR #351's two-bug repair landed but the
 /// AiDotNet GraFPrint min-repro (testconsole/BnFusedGradDiff.cs in
 /// ooples/AiDotNet branch fix/pr-1290-cluster-4-5) still shows a
@@ -30,6 +40,7 @@ namespace AiDotNet.Tensors.Tests.Engines.Compilation;
 /// trainable parameters are gamma + beta of a BatchNorm op must move every
 /// channel of gamma in the same direction the eager-mode equivalent does.
 /// </summary>
+[Collection("CompilationGlobalState")]
 public class BatchNormGradSlotResidualTests
 {
     /// <summary>

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/BatchNormGradSlotResidualTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/BatchNormGradSlotResidualTests.cs
@@ -33,6 +33,318 @@ namespace AiDotNet.Tensors.Tests.Engines.Compilation;
 public class BatchNormGradSlotResidualTests
 {
     /// <summary>
+    /// Diagnostic: take the SAME inputF/gammaF/betaF that compile-mode
+    /// captured in the lazy delegate, and run engine.BatchNorm on them
+    /// directly RIGHT BEFORE plan.Step(). If THIS diverges from eager,
+    /// the input data was mutated post-compile (root cause is buffer
+    /// aliasing or a stale sticky GraphMode state). If it matches, the
+    /// bug is in plan.Step's invocation context (re-entrant GraphMode,
+    /// lazy result aliasing the input buffer, etc).
+    /// </summary>
+    [Fact]
+    public void Diagnostic_BatchNorm_3D_DOUBLE_DirectCallAfterCompile_MatchesEager()
+    {
+        var engine = new CpuEngine();
+        const int C = 8, H = 4, W = 4;
+        const double epsilon = 1e-5;
+        var rng = new System.Random(42);
+        var inputData = new double[C * H * W];
+        for (int i = 0; i < inputData.Length; i++) inputData[i] = rng.NextDouble() - 0.5;
+
+        var inputE = new Tensor<double>(new[] { C, H, W });
+        for (int i = 0; i < inputE.Length; i++) inputE[i] = inputData[i];
+        var gammaE = new Tensor<double>(new[] { C });
+        var betaE = new Tensor<double>(new[] { C });
+        for (int i = 0; i < C; i++) { gammaE[i] = 1.0; betaE[i] = 0.0; }
+        var bnE = engine.BatchNorm(inputE, gammaE, betaE, epsilon, out _, out _);
+        var snapE = new double[bnE.Length];
+        for (int i = 0; i < bnE.Length; i++) snapE[i] = bnE[i];
+
+        var inputF = new Tensor<double>(new[] { C, H, W });
+        for (int i = 0; i < inputF.Length; i++) inputF[i] = inputData[i];
+        var gammaF = new Tensor<double>(new[] { C });
+        var betaF = new Tensor<double>(new[] { C });
+        for (int i = 0; i < C; i++) { gammaF[i] = 1.0; betaF[i] = 0.0; }
+
+        ICompiledTrainingPlan<double> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var bnF = engine.BatchNorm(inputF, gammaF, betaF, epsilon, out _, out _);
+            engine.ReduceSum(bnF, null);
+            plan = scope.CompileTraining(new[] { gammaF, betaF });
+        }
+
+        // Snapshot inputF/gammaF/betaF data RIGHT NOW (post-Compile, pre-Step)
+        var inSnap = new double[inputF.Length];
+        for (int i = 0; i < inputF.Length; i++) inSnap[i] = inputF[i];
+        var gSnap = new double[gammaF.Length];
+        for (int i = 0; i < gammaF.Length; i++) gSnap[i] = gammaF[i];
+        var bSnap = new double[betaF.Length];
+        for (int i = 0; i < betaF.Length; i++) bSnap[i] = betaF[i];
+
+        // Direct call — this is what plan.Step's lazy execute will do internally.
+        // GraphMode is now disabled. If this diverges from snapE, the data was
+        // already wrong by the time we got here.
+        var bnDirect = engine.BatchNorm(inputF, gammaF, betaF, epsilon, out _, out _);
+
+        var lines = new System.Collections.Generic.List<string>();
+        bool dataDrift = false, outputDrift = false;
+        const double tol = 1e-12;
+        for (int i = 0; i < inputData.Length; i++)
+            if (System.Math.Abs(inputData[i] - inSnap[i]) > tol) { dataDrift = true; lines.Add($"  inputF[{i}] orig={inputData[i]:F8} now={inSnap[i]:F8}"); }
+        for (int i = 0; i < C; i++)
+        {
+            if (System.Math.Abs(1.0 - gSnap[i]) > tol) { dataDrift = true; lines.Add($"  gammaF[{i}] orig=1.0 now={gSnap[i]:F8}"); }
+            if (System.Math.Abs(0.0 - bSnap[i]) > tol) { dataDrift = true; lines.Add($"  betaF[{i}] orig=0.0 now={bSnap[i]:F8}"); }
+        }
+        for (int i = 0; i < bnE.Length; i++)
+        {
+            double d = System.Math.Abs(snapE[i] - bnDirect[i]);
+            if (d > tol) { outputDrift = true; lines.Add($"  bn[{i}] eager={snapE[i]:F8} direct={bnDirect[i]:F8} (Δ={d:E2})"); }
+        }
+        Assert.False(dataDrift || outputDrift,
+            $"dataDrift={dataDrift}, outputDrift={outputDrift}. First mismatches:\n" + string.Join("\n", lines.Take(20)));
+    }
+
+    /// <summary>
+    /// T=double rank-3 [C,H,W] forward-only diff. Pre-Step (right after
+    /// CompileTraining returns) bnF should hold the eager-time-copied
+    /// values. Post-Step bnF should be the result of the lazy execute
+    /// delegate. Both should equal the standalone eager call. If post-Step
+    /// diverges, the lazy execute's eng.BatchNorm replay gives a different
+    /// output than the eager call did — pointing the bug at the rank-3
+    /// double BN forward path under Step().
+    /// </summary>
+    [Fact]
+    public void BatchNorm_3D_DOUBLE_CHW_ForwardReplay_MatchesEager()
+    {
+        var engine = new CpuEngine();
+        const int C = 8, H = 4, W = 4;
+        const double epsilon = 1e-5;
+        var rng = new System.Random(42);
+        var inputData = new double[C * H * W];
+        for (int i = 0; i < inputData.Length; i++) inputData[i] = rng.NextDouble() - 0.5;
+
+        var inputE = new Tensor<double>(new[] { C, H, W });
+        for (int i = 0; i < inputE.Length; i++) inputE[i] = inputData[i];
+        var gammaE = new Tensor<double>(new[] { C });
+        var betaE = new Tensor<double>(new[] { C });
+        for (int i = 0; i < C; i++) { gammaE[i] = 1.0; betaE[i] = 0.0; }
+        var bnE = engine.BatchNorm(inputE, gammaE, betaE, epsilon, out _, out _);
+        var snapE = new double[bnE.Length];
+        for (int i = 0; i < bnE.Length; i++) snapE[i] = bnE[i];
+
+        var inputF = new Tensor<double>(new[] { C, H, W });
+        for (int i = 0; i < inputF.Length; i++) inputF[i] = inputData[i];
+        var gammaF = new Tensor<double>(new[] { C });
+        var betaF = new Tensor<double>(new[] { C });
+        for (int i = 0; i < C; i++) { gammaF[i] = 1.0; betaF[i] = 0.0; }
+
+        Tensor<double> bnF;
+        ICompiledTrainingPlan<double> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            bnF = engine.BatchNorm(inputF, gammaF, betaF, epsilon, out _, out _);
+            engine.ReduceSum(bnF, null);
+            plan = scope.CompileTraining(new[] { gammaF, betaF });
+        }
+
+        var snapPre = new double[bnF.Length];
+        for (int i = 0; i < bnF.Length; i++) snapPre[i] = bnF[i];
+
+        using (plan)
+        {
+            plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.0f);
+            plan.Step();
+        }
+
+        var snapPost = new double[bnF.Length];
+        for (int i = 0; i < bnF.Length; i++) snapPost[i] = bnF[i];
+
+        var lines = new System.Collections.Generic.List<string>();
+        bool preDiff = false, postDiff = false;
+        const double tol = 1e-12;
+        for (int c = 0; c < C; c++)
+            for (int h = 0; h < H; h++)
+                for (int w = 0; w < W; w++)
+                {
+                    int i = c * H * W + h * W + w;
+                    double dPre = System.Math.Abs(snapE[i] - snapPre[i]);
+                    double dPost = System.Math.Abs(snapE[i] - snapPost[i]);
+                    if (dPre > tol) preDiff = true;
+                    if (dPost > tol) postDiff = true;
+                    if (dPre > tol || dPost > tol)
+                        lines.Add($"  [{c},{h},{w}]  eager={snapE[i],14:F8} preStep={snapPre[i],14:F8} (Δ={dPre,9:E2})  postStep={snapPost[i],14:F8} (Δ={dPost,9:E2})");
+                }
+        Assert.False(preDiff || postDiff,
+            $"BN forward diverges (preDiff={preDiff}, postDiff={postDiff}). First {lines.Count} mismatches:\n" +
+            string.Join("\n", lines.Take(10)));
+    }
+
+    /// <summary>
+    /// T=double, rank-3 [C, H, W] — the actual layout GraFPrint's 18
+    /// BatchNorm layers see (and the Conv1×1 / Conv3×3 image-stack pyramid
+    /// in general). If the 2D test passes within tolerance but THIS fails,
+    /// the bug is rank-3 specific in the double compile-mode path.
+    /// </summary>
+    [Fact]
+    public void BatchNorm_3D_DOUBLE_CHW_GradGamma_BeforeOptimizer_MatchesEager_PerElement()
+    {
+        var engine = new CpuEngine();
+        const int C = 8, H = 4, W = 4;
+        const double epsilon = 1e-5;
+
+        var rng = new System.Random(42);
+        int len = C * H * W;
+        var inputData = new double[len];
+        var targetData = new double[len];
+        for (int i = 0; i < len; i++) inputData[i] = rng.NextDouble() - 0.5;
+        for (int i = 0; i < len; i++) targetData[i] = rng.NextDouble() - 0.5;
+
+        var inputE = new Tensor<double>(new[] { C, H, W });
+        for (int i = 0; i < inputE.Length; i++) inputE[i] = inputData[i];
+        var targetE = new Tensor<double>(new[] { C, H, W });
+        for (int i = 0; i < targetE.Length; i++) targetE[i] = targetData[i];
+        var gammaE = new Tensor<double>(new[] { C });
+        var betaE = new Tensor<double>(new[] { C });
+        for (int i = 0; i < C; i++) { gammaE[i] = 1.0; betaE[i] = 0.0; }
+
+        Tensor<double> eagerGradGamma, eagerGradBeta;
+        using (var tape = new GradientTape<double>())
+        {
+            var bnE = engine.BatchNorm(inputE, gammaE, betaE, epsilon, out _, out _);
+            var diffE = engine.TensorSubtract(bnE, targetE);
+            var sqE = engine.TensorMultiply(diffE, diffE);
+            var lossE = engine.ReduceSum(sqE, null);
+            var grads = tape.ComputeGradients(lossE, sources: new[] { gammaE, betaE });
+            eagerGradGamma = grads[gammaE];
+            eagerGradBeta = grads[betaE];
+        }
+
+        var inputF = new Tensor<double>(new[] { C, H, W });
+        for (int i = 0; i < inputF.Length; i++) inputF[i] = inputData[i];
+        var targetF = new Tensor<double>(new[] { C, H, W });
+        for (int i = 0; i < targetF.Length; i++) targetF[i] = targetData[i];
+        var gammaF = new Tensor<double>(new[] { C });
+        var betaF = new Tensor<double>(new[] { C });
+        for (int i = 0; i < C; i++) { gammaF[i] = 1.0; betaF[i] = 0.0; }
+
+        ICompiledTrainingPlan<double> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var bnF = engine.BatchNorm(inputF, gammaF, betaF, epsilon, out _, out _);
+            var diffF = engine.TensorSubtract(bnF, targetF);
+            var sqF = engine.TensorMultiply(diffF, diffF);
+            engine.ReduceSum(sqF, null);
+            plan = scope.CompileTraining(new[] { gammaF, betaF });
+        }
+
+        using (plan)
+        {
+            plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.0f);
+            plan.Step();
+        }
+
+        var fusedGradGamma = gammaF.Grad ?? throw new System.InvalidOperationException("gammaF.Grad not set");
+        var fusedGradBeta = betaF.Grad ?? throw new System.InvalidOperationException("betaF.Grad not set");
+
+        var lines = new System.Collections.Generic.List<string>();
+        bool anyMismatch = false;
+        // Tolerance: 1e-9 catches anything above double-precision noise
+        // (~1e-15) without flagging legitimate FMA reordering effects
+        // that can creep up to ~1e-12 in batched reductions.
+        const double tol = 1e-9;
+        for (int p = 0; p < C; p++)
+        {
+            double dG = System.Math.Abs(eagerGradGamma[p] - fusedGradGamma[p]);
+            double dB = System.Math.Abs(eagerGradBeta[p] - fusedGradBeta[p]);
+            if (dG >= tol || dB >= tol) anyMismatch = true;
+            lines.Add($"  ch[{p}]  gamma_grad eager={eagerGradGamma[p],14:F8} fused={fusedGradGamma[p],14:F8} |Δ|={dG,14:E6}    beta_grad eager={eagerGradBeta[p],14:F8} fused={fusedGradBeta[p],14:F8} |Δ|={dB,14:E6}");
+        }
+        Assert.False(anyMismatch, "T=double rank-3 [C,H,W] compiled BN backward routes wrong per-channel gradients:\n" + string.Join("\n", lines));
+    }
+
+    /// <summary>
+    /// T=double version of the per-element gradient diff. The float-only
+    /// BatchNormInferenceUnsafe layout fix can't help here (the
+    /// specialization is gated on typeof(T) == typeof(float)), so if this
+    /// fails the divergence is in a separate code path that affects the
+    /// double-precision compile-mode BN backward — exactly the symptom
+    /// GraFPrint hits in its T=double model-family invariant tests.
+    /// </summary>
+    [Fact]
+    public void BatchNorm_2D_DOUBLE_GradGamma_BeforeOptimizer_MatchesEager_PerElement()
+    {
+        var engine = new CpuEngine();
+        const int batch = 4, features = 4;
+        const double epsilon = 1e-5;
+
+        var rng = new System.Random(42);
+        var inputData = new double[batch * features];
+        var targetData = new double[batch * features];
+        for (int i = 0; i < inputData.Length; i++) inputData[i] = rng.NextDouble() - 0.5;
+        for (int i = 0; i < targetData.Length; i++) targetData[i] = rng.NextDouble() - 0.5;
+
+        var inputE = new Tensor<double>(new[] { batch, features });
+        for (int i = 0; i < inputE.Length; i++) inputE[i] = inputData[i];
+        var targetE = new Tensor<double>(new[] { batch, features });
+        for (int i = 0; i < targetE.Length; i++) targetE[i] = targetData[i];
+        var gammaE = new Tensor<double>(new[] { features });
+        var betaE = new Tensor<double>(new[] { features });
+        for (int i = 0; i < features; i++) { gammaE[i] = 1.0; betaE[i] = 0.0; }
+
+        Tensor<double> eagerGradGamma, eagerGradBeta;
+        using (var tape = new GradientTape<double>())
+        {
+            var bnE = engine.BatchNorm(inputE, gammaE, betaE, epsilon, out _, out _);
+            var diffE = engine.TensorSubtract(bnE, targetE);
+            var sqE = engine.TensorMultiply(diffE, diffE);
+            var lossE = engine.ReduceSum(sqE, null);
+            var grads = tape.ComputeGradients(lossE, sources: new[] { gammaE, betaE });
+            eagerGradGamma = grads[gammaE];
+            eagerGradBeta = grads[betaE];
+        }
+
+        var inputF = new Tensor<double>(new[] { batch, features });
+        for (int i = 0; i < inputF.Length; i++) inputF[i] = inputData[i];
+        var targetF = new Tensor<double>(new[] { batch, features });
+        for (int i = 0; i < targetF.Length; i++) targetF[i] = targetData[i];
+        var gammaF = new Tensor<double>(new[] { features });
+        var betaF = new Tensor<double>(new[] { features });
+        for (int i = 0; i < features; i++) { gammaF[i] = 1.0; betaF[i] = 0.0; }
+
+        ICompiledTrainingPlan<double> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var bnF = engine.BatchNorm(inputF, gammaF, betaF, epsilon, out _, out _);
+            var diffF = engine.TensorSubtract(bnF, targetF);
+            var sqF = engine.TensorMultiply(diffF, diffF);
+            engine.ReduceSum(sqF, null);
+            plan = scope.CompileTraining(new[] { gammaF, betaF });
+        }
+
+        using (plan)
+        {
+            plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.0f);
+            plan.Step();
+        }
+
+        var fusedGradGamma = gammaF.Grad ?? throw new System.InvalidOperationException("gammaF.Grad not set");
+        var fusedGradBeta = betaF.Grad ?? throw new System.InvalidOperationException("betaF.Grad not set");
+
+        var lines = new System.Collections.Generic.List<string>();
+        bool anyMismatch = false;
+        for (int p = 0; p < features; p++)
+        {
+            double dG = System.Math.Abs(eagerGradGamma[p] - fusedGradGamma[p]);
+            double dB = System.Math.Abs(eagerGradBeta[p] - fusedGradBeta[p]);
+            if (dG >= 1e-8 || dB >= 1e-8) anyMismatch = true;
+            lines.Add($"  ch[{p}]  gamma_grad eager={eagerGradGamma[p],14:F8} fused={fusedGradGamma[p],14:F8} |Δ|={dG,14:E6}    beta_grad eager={eagerGradBeta[p],14:F8} fused={fusedGradBeta[p],14:F8} |Δ|={dB,14:E6}");
+        }
+        Assert.False(anyMismatch, "T=double compiled BN backward routes wrong per-channel gradients:\n" + string.Join("\n", lines));
+    }
+
+    /// <summary>
     /// Pinpoint: capture bnF BEFORE plan.Step() (when it should hold the
     /// eager-time copied values) and AFTER plan.Step() (when forward replay
     /// has overwritten it). Compare both with the eager BN result.

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/BatchNormGradSlotResidualTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/BatchNormGradSlotResidualTests.cs
@@ -104,6 +104,169 @@ public class BatchNormGradSlotResidualTests
     }
 
     /// <summary>
+    /// Bisect the divergence chain. Eager has BN→Sub→Mul→Sum (forward) +
+    /// reverse backward. Compile has same. The eager-tape gradGamma is
+    /// 8.76678034 (per the failing test). The compile gradGamma is
+    /// 8.76678046. Δ ≈ 1.19e-7. Both should give the SAME value if every
+    /// op produces bit-identical results. This test isolates the FORWARD
+    /// chain — runs both eager and compile-mode forward for BN→Sub→Mul→Sum
+    /// and asserts the diff and sq tensors are bit-identical.
+    /// </summary>
+    [Fact]
+    public void Pinpoint_DOUBLE_BNSubMul_Forward_EagerVsCompile_BitIdentical()
+    {
+        var engine = new CpuEngine();
+        const int batch = 4, features = 4;
+        const double epsilon = 1e-5;
+        var rng = new System.Random(42);
+        var inputData = new double[batch * features];
+        var targetData = new double[batch * features];
+        for (int i = 0; i < inputData.Length; i++) inputData[i] = rng.NextDouble() - 0.5;
+        for (int i = 0; i < targetData.Length; i++) targetData[i] = rng.NextDouble() - 0.5;
+
+        // EAGER
+        var inputE = new Tensor<double>(new[] { batch, features });
+        var targetE = new Tensor<double>(new[] { batch, features });
+        for (int i = 0; i < inputE.Length; i++) { inputE[i] = inputData[i]; targetE[i] = targetData[i]; }
+        var gammaE = new Tensor<double>(new[] { features });
+        var betaE = new Tensor<double>(new[] { features });
+        for (int i = 0; i < features; i++) { gammaE[i] = 1.0; betaE[i] = 0.0; }
+        var bnE = engine.BatchNorm(inputE, gammaE, betaE, epsilon, out _, out _);
+        var diffE = engine.TensorSubtract(bnE, targetE);
+        var sqE = engine.TensorMultiply(diffE, diffE);
+
+        // COMPILE
+        var inputF = new Tensor<double>(new[] { batch, features });
+        var targetF = new Tensor<double>(new[] { batch, features });
+        for (int i = 0; i < inputF.Length; i++) { inputF[i] = inputData[i]; targetF[i] = targetData[i]; }
+        var gammaF = new Tensor<double>(new[] { features });
+        var betaF = new Tensor<double>(new[] { features });
+        for (int i = 0; i < features; i++) { gammaF[i] = 1.0; betaF[i] = 0.0; }
+        Tensor<double> bnF, diffF, sqF;
+        ICompiledTrainingPlan<double> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            bnF = engine.BatchNorm(inputF, gammaF, betaF, epsilon, out _, out _);
+            diffF = engine.TensorSubtract(bnF, targetF);
+            sqF = engine.TensorMultiply(diffF, diffF);
+            engine.ReduceSum(sqF, null);
+            plan = scope.CompileTraining(new[] { gammaF, betaF });
+        }
+        using (plan)
+        {
+            plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.0f);
+            plan.Step();
+        }
+
+        var lines = new System.Collections.Generic.List<string>();
+        bool any = false;
+        for (int i = 0; i < bnE.Length; i++)
+        {
+            double dBn = System.Math.Abs(bnE[i] - bnF[i]);
+            double dDiff = System.Math.Abs(diffE[i] - diffF[i]);
+            double dSq = System.Math.Abs(sqE[i] - sqF[i]);
+            if (dBn > 0 || dDiff > 0 || dSq > 0) any = true;
+            lines.Add($"  [{i}]  bn |Δ|={dBn:E3}  diff |Δ|={dDiff:E3}  sq |Δ|={dSq:E3}");
+        }
+        Assert.False(any, "Forward chain BN→Sub→Mul diverges between eager and compile:\n"
+            + string.Join("\n", lines));
+    }
+
+    /// <summary>
+    /// Pinpoint #2: BatchNorm backward in EAGER tape mode vs DIRECT engine
+    /// call. If the tape's backward differs from the direct engine call,
+    /// the tape itself is the precision-losing path (engine routing, not
+    /// kernel arithmetic).
+    /// </summary>
+    [Fact]
+    public void Pinpoint_DOUBLE_BNBackward_TapeVsDirect_BitIdentical()
+    {
+        var engine = new CpuEngine();
+        const int batch = 4, features = 4;
+        const double epsilon = 1e-5;
+        var rng = new System.Random(42);
+        var inputData = new double[batch * features];
+        var targetData = new double[batch * features];
+        for (int i = 0; i < inputData.Length; i++) inputData[i] = rng.NextDouble() - 0.5;
+        for (int i = 0; i < targetData.Length; i++) targetData[i] = rng.NextDouble() - 0.5;
+
+        // Build identical inputs for both paths.
+        var inputE = new Tensor<double>(new[] { batch, features });
+        var targetE = new Tensor<double>(new[] { batch, features });
+        for (int i = 0; i < inputE.Length; i++) { inputE[i] = inputData[i]; targetE[i] = targetData[i]; }
+        var gammaE = new Tensor<double>(new[] { features });
+        var betaE = new Tensor<double>(new[] { features });
+        for (int i = 0; i < features; i++) { gammaE[i] = 1.0; betaE[i] = 0.0; }
+
+        // Path 1: EAGER TAPE (existing failing path)
+        Tensor<double> tapeGradGamma;
+        using (var tape = new GradientTape<double>())
+        {
+            var bnE = engine.BatchNorm(inputE, gammaE, betaE, epsilon, out _, out _);
+            var diffE = engine.TensorSubtract(bnE, targetE);
+            var sqE = engine.TensorMultiply(diffE, diffE);
+            var lossE = engine.ReduceSum(sqE, null);
+            tapeGradGamma = tape.ComputeGradients(lossE, sources: new[] { gammaE })[gammaE];
+        }
+
+        // Path 2: DIRECT — manually compute gradGamma without tape.
+        // Forward + manual chain rule using engine ops.
+        var bn2 = engine.BatchNorm(inputE, gammaE, betaE, epsilon, out var meanD, out var varD);
+        var diff2 = engine.TensorSubtract(bn2, targetE);
+        var sq2 = engine.TensorMultiply(diff2, diff2);
+        var loss2 = engine.ReduceSum(sq2, null);
+        // dloss/dsq = 1 (broadcast)
+        var gradSq2 = new Tensor<double>(new[] { batch, features });
+        for (int i = 0; i < gradSq2.Length; i++) gradSq2[i] = 1.0;
+        // dsq/ddiff = 2*diff via TensorMultiply
+        var twoTimesDiff = new Tensor<double>(new[] { batch, features });
+        for (int i = 0; i < twoTimesDiff.Length; i++) twoTimesDiff[i] = 2.0 * diff2[i];
+        var gradDiff2 = engine.TensorMultiply(gradSq2, twoTimesDiff);
+        // ddiff/dbn = 1 → gradBn = gradDiff
+        var gradBn2 = gradDiff2;
+        // dbn/dgamma via engine.BatchNormBackward
+        engine.BatchNormBackward(gradBn2, inputE, gammaE, meanD, varD, epsilon, out var directGradGamma, out _);
+
+        var lines = new System.Collections.Generic.List<string>();
+        bool any = false;
+        for (int p = 0; p < features; p++)
+        {
+            double d = System.Math.Abs(tapeGradGamma[p] - directGradGamma[p]);
+            if (d >= 1e-12) any = true;
+            lines.Add($"  ch[{p}]  tape={tapeGradGamma[p]:F18} direct={directGradGamma[p]:F18} |Δ|={d:E3}");
+        }
+        Assert.False(any, "BN gradGamma diverges between tape backward and direct engine call:\n"
+            + string.Join("\n", lines));
+    }
+
+    /// <summary>
+    /// Diagnostic: verify that calling engine.BatchNorm on a CpuEngine
+    /// instance under an active GradientTape correctly binds the tape's
+    /// _engine to that CpuEngine (not the global ambient
+    /// DirectGpuTensorEngine).
+    /// </summary>
+    [Fact]
+    public void Diagnostic_TapeBoundEngineIsCpuEngine_AfterBatchNormCall()
+    {
+        var engine = new CpuEngine();
+        const int C = 4;
+        var inputE = new Tensor<double>(new[] { 4, C });
+        for (int i = 0; i < inputE.Length; i++) inputE[i] = i * 0.1;
+        var gammaE = new Tensor<double>(new[] { C });
+        var betaE = new Tensor<double>(new[] { C });
+        for (int i = 0; i < C; i++) { gammaE[i] = 1.0; betaE[i] = 0.0; }
+
+        using var tape = new GradientTape<double>();
+        var initialEngineType = tape.Engine.GetType().Name;
+        var bnE = engine.BatchNorm(inputE, gammaE, betaE, 1e-5, out _, out _);
+        var afterEngineType = tape.Engine.GetType().Name;
+
+        Assert.Equal("CpuEngine", afterEngineType);
+        // Initial may be DirectGpuTensorEngine on auto-detect-GPU systems;
+        // we just confirm the bind happened.
+    }
+
+    /// <summary>
     /// Pinpoint: forward-only TensorSubtract bit-identity check. Eager
     /// engine.TensorSubtract vs compile-mode lazy execute (which calls
     /// engine.TensorSubtractInto under the hood). If THIS fails, the
@@ -134,27 +297,43 @@ public class BatchNormGradSlotResidualTests
         ICompiledTrainingPlan<double> plan;
         using (var scope = GraphMode.Enable())
         {
-            // Force the scope to bind to the CpuEngine instance the test
-            // explicitly created. Without this, scope._engine defaults to
-            // AiDotNetEngine.Current — which on auto-detect-GPU systems is
-            // DirectGpuTensorEngine, and that engine's TensorSubtractInto
-            // computes in single precision on consumer GPUs, producing the
-            // float-ULP-precision residual the MseChain test catches.
-            // Same root cause as the engine-routing fix this PR added for
-            // BatchNorm — the same plumbing is needed for every op that
-            // records into a graph from an explicit-engine caller.
             typeof(AiDotNet.Tensors.Engines.Compilation.LazyTensorScope)
                 .GetMethod("BindEngineIfUnset", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
                 .Invoke(scope, new object[] { engine });
             diffF = engine.TensorSubtract(xF, tF);
-            engine.ReduceSum(diffF, null);  // need an output to compile a plan
+            engine.ReduceSum(diffF, null);
             plan = scope.CompileTraining(new[] { xF });
         }
-        using (plan)
+
+        // Wire the per-phase probe to capture diffF[12] AFTER each step.
+        // Diff in compile-mode test runs has shown diffF[12] starts as the
+        // correct double value (written by SUB-FWD) but ends up at
+        // float-precision when the test reads it post-Step. This probe
+        // pinpoints WHICH step writes the wrong value.
+        var ctpType = typeof(AiDotNet.Tensors.LinearAlgebra.Tensor<double>).Assembly
+            .GetType("AiDotNet.Tensors.Engines.Compilation.CompiledTrainingPlan`1")!
+            .MakeGenericType(typeof(double));
+        var probeProp = ctpType.GetProperty("StepProbe", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)!;
+        var probeLog = new System.Collections.Generic.List<string>();
+        System.Action<string> probe = phase =>
+        {
+            probeLog.Add($"  {phase,-40} diffF[12]={diffF[12]:F18}");
+        };
+        probeProp.SetValue(null, probe);
+        try
         {
             plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.0f);
             plan.Step();
+            probeLog.Add($"  AFTER-STEP-BEFORE-DISPOSE              diffF[12]={diffF[12]:F18}");
+            plan.Dispose();
+            probeLog.Add($"  AFTER-DISPOSE                          diffF[12]={diffF[12]:F18}");
         }
+        finally
+        {
+            probeProp.SetValue(null, null);
+        }
+        System.Console.WriteLine("=== STEP PROBE LOG ===");
+        foreach (var l in probeLog) System.Console.WriteLine(l);
 
         // CRITICAL ORDER: snapshot diffF FIRST, before any other allocation
         // could pollute the underlying pool-backed buffer.

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/BatchNormGradSlotResidualTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/BatchNormGradSlotResidualTests.cs
@@ -33,6 +33,143 @@ namespace AiDotNet.Tensors.Tests.Engines.Compilation;
 public class BatchNormGradSlotResidualTests
 {
     /// <summary>
+    /// Isolation: ONLY BN forward then ReduceSum (uniform gradOut = 1.0
+    /// across BN's output). No subtract / multiply / target. If THIS
+    /// diverges between eager and compiled per-element on T=double,
+    /// the BN backward itself produces different gradients across the
+    /// two paths despite both calling engine.BatchNormBackward. If it
+    /// passes, the divergence in BatchNorm_2D_DOUBLE_GradGamma_* must
+    /// come from upstream MultiplyBackward / SubtractBackward differences,
+    /// NOT BN backward.
+    /// </summary>
+    [Fact]
+    public void Isolation_BatchNorm_2D_DOUBLE_Then_ReduceSum_GradGamma_MatchesEager_PerElement()
+    {
+        var engine = new CpuEngine();
+        const int batch = 4, features = 4;
+        const double epsilon = 1e-5;
+
+        var rng = new System.Random(42);
+        var inputData = new double[batch * features];
+        for (int i = 0; i < inputData.Length; i++) inputData[i] = rng.NextDouble() - 0.5;
+
+        var inputE = new Tensor<double>(new[] { batch, features });
+        for (int i = 0; i < inputE.Length; i++) inputE[i] = inputData[i];
+        var gammaE = new Tensor<double>(new[] { features });
+        var betaE = new Tensor<double>(new[] { features });
+        for (int i = 0; i < features; i++) { gammaE[i] = 1.0; betaE[i] = 0.0; }
+
+        Tensor<double> eagerGradGamma, eagerGradBeta;
+        using (var tape = new GradientTape<double>())
+        {
+            var bnE = engine.BatchNorm(inputE, gammaE, betaE, epsilon, out _, out _);
+            var sumE = engine.ReduceSum(bnE, null);
+            var grads = tape.ComputeGradients(sumE, sources: new[] { gammaE, betaE });
+            eagerGradGamma = grads[gammaE];
+            eagerGradBeta = grads[betaE];
+        }
+
+        var inputF = new Tensor<double>(new[] { batch, features });
+        for (int i = 0; i < inputF.Length; i++) inputF[i] = inputData[i];
+        var gammaF = new Tensor<double>(new[] { features });
+        var betaF = new Tensor<double>(new[] { features });
+        for (int i = 0; i < features; i++) { gammaF[i] = 1.0; betaF[i] = 0.0; }
+
+        ICompiledTrainingPlan<double> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var bnF = engine.BatchNorm(inputF, gammaF, betaF, epsilon, out _, out _);
+            engine.ReduceSum(bnF, null);
+            plan = scope.CompileTraining(new[] { gammaF, betaF });
+        }
+        using (plan)
+        {
+            plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.0f);
+            plan.Step();
+        }
+        var fusedGradGamma = gammaF.Grad ?? throw new System.InvalidOperationException("gammaF.Grad");
+        var fusedGradBeta = betaF.Grad ?? throw new System.InvalidOperationException("betaF.Grad");
+
+        var lines = new System.Collections.Generic.List<string>();
+        bool any = false;
+        const double tol = 1e-12;
+        for (int p = 0; p < features; p++)
+        {
+            double dG = System.Math.Abs(eagerGradGamma[p] - fusedGradGamma[p]);
+            double dB = System.Math.Abs(eagerGradBeta[p] - fusedGradBeta[p]);
+            if (dG >= tol || dB >= tol) any = true;
+            lines.Add($"  ch[{p}]  gammaG eager={eagerGradGamma[p]:F12} fused={fusedGradGamma[p]:F12} |Δ|={dG:E3}    betaG eager={eagerGradBeta[p]:F12} fused={fusedGradBeta[p]:F12} |Δ|={dB:E3}");
+        }
+        Assert.False(any, "Isolated BN→ReduceSum on double diverges:\n" + string.Join("\n", lines));
+    }
+
+    /// <summary>
+    /// Bisect the upstream Sub→Multiply chain. BN forward is REPLACED with
+    /// a leaf parameter `xF` — eliminates BN backward as a variable.
+    /// MSE backward path: ReduceSum → Multiply(square) → Subtract(target).
+    /// If THIS diverges per-element on T=double, the divergence is purely
+    /// in the Subtract+Multiply backward chain — the multiply-with-self
+    /// gradient is being accumulated through different intermediate
+    /// allocations between tape and compiled paths.
+    /// </summary>
+    [Fact]
+    public void Isolation_DOUBLE_MseChain_GradX_MatchesEager_PerElement()
+    {
+        var engine = new CpuEngine();
+        const int n = 16;
+        var rng = new System.Random(42);
+        var xData = new double[n];
+        var tData = new double[n];
+        for (int i = 0; i < n; i++) xData[i] = rng.NextDouble() - 0.5;
+        for (int i = 0; i < n; i++) tData[i] = rng.NextDouble() - 0.5;
+
+        var xE = new Tensor<double>(new[] { n });
+        for (int i = 0; i < n; i++) xE[i] = xData[i];
+        var tE = new Tensor<double>(new[] { n });
+        for (int i = 0; i < n; i++) tE[i] = tData[i];
+
+        Tensor<double> eagerGrad;
+        using (var tape = new GradientTape<double>())
+        {
+            var diff = engine.TensorSubtract(xE, tE);
+            var sq = engine.TensorMultiply(diff, diff);
+            var loss = engine.ReduceSum(sq, null);
+            eagerGrad = tape.ComputeGradients(loss, sources: new[] { xE })[xE];
+        }
+
+        var xF = new Tensor<double>(new[] { n });
+        for (int i = 0; i < n; i++) xF[i] = xData[i];
+        var tF = new Tensor<double>(new[] { n });
+        for (int i = 0; i < n; i++) tF[i] = tData[i];
+
+        ICompiledTrainingPlan<double> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var diff = engine.TensorSubtract(xF, tF);
+            var sq = engine.TensorMultiply(diff, diff);
+            engine.ReduceSum(sq, null);
+            plan = scope.CompileTraining(new[] { xF });
+        }
+        using (plan)
+        {
+            plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.0f);
+            plan.Step();
+        }
+        var fusedGrad = xF.Grad ?? throw new System.InvalidOperationException("xF.Grad");
+
+        var lines = new System.Collections.Generic.List<string>();
+        bool any = false;
+        const double tol = 1e-12;
+        for (int i = 0; i < n; i++)
+        {
+            double d = System.Math.Abs(eagerGrad[i] - fusedGrad[i]);
+            if (d >= tol) any = true;
+            lines.Add($"  x[{i}]={xE[i]:F12} t[{i}]={tE[i]:F12} eager={eagerGrad[i]:F12} fused={fusedGrad[i]:F12} |Δ|={d:E3}");
+        }
+        Assert.False(any, "MSE chain backward diverges:\n" + string.Join("\n", lines));
+    }
+
+    /// <summary>
     /// Diagnostic: take the SAME inputF/gammaF/betaF that compile-mode
     /// captured in the lazy delegate, and run engine.BatchNorm on them
     /// directly RIGHT BEFORE plan.Step(). If THIS diverges from eager,

--- a/tests/AiDotNet.Tensors.Tests/Engines/Conv2DBackwardIntoTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Conv2DBackwardIntoTests.cs
@@ -1,0 +1,182 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Tier 1.1 correctness: the new Conv2DBackwardInputInto / Conv2DBackwardKernelInto
+/// must produce bit-identical results to the allocating Conv2DBackwardInput /
+/// Conv2DBackwardKernel they replace in compile-mode. Tests both overwrite
+/// (accumulate=false) and accumulate (accumulate=true) paths for float and
+/// double, on a typical 4D Conv shape.
+/// </summary>
+public class Conv2DBackwardIntoTests
+{
+    [Fact]
+    public void Conv2DBackwardInputInto_FLOAT_Overwrite_MatchesAllocating()
+    {
+        var engine = new CpuEngine();
+        int batch = 1, inC = 3, H = 8, W = 8, outC = 4, kH = 3, kW = 3;
+        int oH = H - kH + 1, oW = W - kW + 1;
+        var rng = new System.Random(42);
+
+        var gradOut = new Tensor<float>(new[] { batch, outC, oH, oW });
+        for (int i = 0; i < gradOut.Length; i++) gradOut[i] = (float)(rng.NextDouble() - 0.5);
+        var kernel = new Tensor<float>(new[] { outC, inC, kH, kW });
+        for (int i = 0; i < kernel.Length; i++) kernel[i] = (float)(rng.NextDouble() - 0.5);
+
+        var allocating = engine.Conv2DBackwardInput(gradOut, kernel,
+            new[] { batch, inC, H, W }, new[] { 1, 1 }, new[] { 0, 0 }, new[] { 1, 1 });
+        var dest = new Tensor<float>(new[] { batch, inC, H, W });
+        engine.Conv2DBackwardInputInto(dest, gradOut, kernel,
+            new[] { batch, inC, H, W }, new[] { 1, 1 }, new[] { 0, 0 }, new[] { 1, 1 },
+            accumulate: false);
+
+        for (int i = 0; i < allocating.Length; i++)
+            Assert.True(System.Math.Abs(allocating[i] - dest[i]) < 1e-5f,
+                $"[{i}] alloc={allocating[i]:F6} into={dest[i]:F6}");
+    }
+
+    [Fact]
+    public void Conv2DBackwardInputInto_DOUBLE_Overwrite_MatchesAllocating()
+    {
+        var engine = new CpuEngine();
+        int batch = 1, inC = 3, H = 8, W = 8, outC = 4, kH = 3, kW = 3;
+        int oH = H - kH + 1, oW = W - kW + 1;
+        var rng = new System.Random(42);
+
+        var gradOut = new Tensor<double>(new[] { batch, outC, oH, oW });
+        for (int i = 0; i < gradOut.Length; i++) gradOut[i] = rng.NextDouble() - 0.5;
+        var kernel = new Tensor<double>(new[] { outC, inC, kH, kW });
+        for (int i = 0; i < kernel.Length; i++) kernel[i] = rng.NextDouble() - 0.5;
+
+        var allocating = engine.Conv2DBackwardInput(gradOut, kernel,
+            new[] { batch, inC, H, W }, new[] { 1, 1 }, new[] { 0, 0 }, new[] { 1, 1 });
+        var dest = new Tensor<double>(new[] { batch, inC, H, W });
+        engine.Conv2DBackwardInputInto(dest, gradOut, kernel,
+            new[] { batch, inC, H, W }, new[] { 1, 1 }, new[] { 0, 0 }, new[] { 1, 1 },
+            accumulate: false);
+
+        for (int i = 0; i < allocating.Length; i++)
+            Assert.True(System.Math.Abs(allocating[i] - dest[i]) < 1e-12,
+                $"[{i}] alloc={allocating[i]:F12} into={dest[i]:F12}");
+    }
+
+    [Fact]
+    public void Conv2DBackwardInputInto_DOUBLE_Accumulate_AddsToExisting()
+    {
+        var engine = new CpuEngine();
+        int batch = 1, inC = 3, H = 8, W = 8, outC = 4, kH = 3, kW = 3;
+        int oH = H - kH + 1, oW = W - kW + 1;
+        var rng = new System.Random(42);
+
+        var gradOut = new Tensor<double>(new[] { batch, outC, oH, oW });
+        for (int i = 0; i < gradOut.Length; i++) gradOut[i] = rng.NextDouble() - 0.5;
+        var kernel = new Tensor<double>(new[] { outC, inC, kH, kW });
+        for (int i = 0; i < kernel.Length; i++) kernel[i] = rng.NextDouble() - 0.5;
+
+        var allocating = engine.Conv2DBackwardInput(gradOut, kernel,
+            new[] { batch, inC, H, W }, new[] { 1, 1 }, new[] { 0, 0 }, new[] { 1, 1 });
+
+        // Pre-fill dest with deterministic values; accumulate should add allocating into them.
+        var dest = new Tensor<double>(new[] { batch, inC, H, W });
+        var preExisting = new double[dest.Length];
+        var rng2 = new System.Random(7);
+        for (int i = 0; i < dest.Length; i++) { preExisting[i] = rng2.NextDouble() - 0.5; dest[i] = preExisting[i]; }
+
+        engine.Conv2DBackwardInputInto(dest, gradOut, kernel,
+            new[] { batch, inC, H, W }, new[] { 1, 1 }, new[] { 0, 0 }, new[] { 1, 1 },
+            accumulate: true);
+
+        for (int i = 0; i < dest.Length; i++)
+        {
+            double expected = preExisting[i] + allocating[i];
+            Assert.True(System.Math.Abs(expected - dest[i]) < 1e-12,
+                $"[{i}] expected pre+alloc={expected:F12} but dest={dest[i]:F12}");
+        }
+    }
+
+    [Fact]
+    public void Conv2DBackwardKernelInto_FLOAT_Overwrite_MatchesAllocating()
+    {
+        var engine = new CpuEngine();
+        int batch = 1, inC = 3, H = 8, W = 8, outC = 4, kH = 3, kW = 3;
+        int oH = H - kH + 1, oW = W - kW + 1;
+        var rng = new System.Random(42);
+
+        var gradOut = new Tensor<float>(new[] { batch, outC, oH, oW });
+        for (int i = 0; i < gradOut.Length; i++) gradOut[i] = (float)(rng.NextDouble() - 0.5);
+        var input = new Tensor<float>(new[] { batch, inC, H, W });
+        for (int i = 0; i < input.Length; i++) input[i] = (float)(rng.NextDouble() - 0.5);
+
+        var allocating = engine.Conv2DBackwardKernel(gradOut, input,
+            new[] { outC, inC, kH, kW }, new[] { 1, 1 }, new[] { 0, 0 }, new[] { 1, 1 });
+        var dest = new Tensor<float>(new[] { outC, inC, kH, kW });
+        engine.Conv2DBackwardKernelInto(dest, gradOut, input,
+            new[] { outC, inC, kH, kW }, new[] { 1, 1 }, new[] { 0, 0 }, new[] { 1, 1 },
+            accumulate: false);
+
+        for (int i = 0; i < allocating.Length; i++)
+            Assert.True(System.Math.Abs(allocating[i] - dest[i]) < 1e-5f,
+                $"[{i}] alloc={allocating[i]:F6} into={dest[i]:F6}");
+    }
+
+    [Fact]
+    public void Conv2DBackwardKernelInto_DOUBLE_Overwrite_MatchesAllocating()
+    {
+        var engine = new CpuEngine();
+        int batch = 1, inC = 3, H = 8, W = 8, outC = 4, kH = 3, kW = 3;
+        int oH = H - kH + 1, oW = W - kW + 1;
+        var rng = new System.Random(42);
+
+        var gradOut = new Tensor<double>(new[] { batch, outC, oH, oW });
+        for (int i = 0; i < gradOut.Length; i++) gradOut[i] = rng.NextDouble() - 0.5;
+        var input = new Tensor<double>(new[] { batch, inC, H, W });
+        for (int i = 0; i < input.Length; i++) input[i] = rng.NextDouble() - 0.5;
+
+        var allocating = engine.Conv2DBackwardKernel(gradOut, input,
+            new[] { outC, inC, kH, kW }, new[] { 1, 1 }, new[] { 0, 0 }, new[] { 1, 1 });
+        var dest = new Tensor<double>(new[] { outC, inC, kH, kW });
+        engine.Conv2DBackwardKernelInto(dest, gradOut, input,
+            new[] { outC, inC, kH, kW }, new[] { 1, 1 }, new[] { 0, 0 }, new[] { 1, 1 },
+            accumulate: false);
+
+        for (int i = 0; i < allocating.Length; i++)
+            Assert.True(System.Math.Abs(allocating[i] - dest[i]) < 1e-12,
+                $"[{i}] alloc={allocating[i]:F12} into={dest[i]:F12}");
+    }
+
+    [Fact]
+    public void Conv2DBackwardKernelInto_DOUBLE_Accumulate_AddsToExisting()
+    {
+        var engine = new CpuEngine();
+        int batch = 1, inC = 3, H = 8, W = 8, outC = 4, kH = 3, kW = 3;
+        int oH = H - kH + 1, oW = W - kW + 1;
+        var rng = new System.Random(42);
+
+        var gradOut = new Tensor<double>(new[] { batch, outC, oH, oW });
+        for (int i = 0; i < gradOut.Length; i++) gradOut[i] = rng.NextDouble() - 0.5;
+        var input = new Tensor<double>(new[] { batch, inC, H, W });
+        for (int i = 0; i < input.Length; i++) input[i] = rng.NextDouble() - 0.5;
+
+        var allocating = engine.Conv2DBackwardKernel(gradOut, input,
+            new[] { outC, inC, kH, kW }, new[] { 1, 1 }, new[] { 0, 0 }, new[] { 1, 1 });
+
+        var dest = new Tensor<double>(new[] { outC, inC, kH, kW });
+        var preExisting = new double[dest.Length];
+        var rng2 = new System.Random(7);
+        for (int i = 0; i < dest.Length; i++) { preExisting[i] = rng2.NextDouble() - 0.5; dest[i] = preExisting[i]; }
+
+        engine.Conv2DBackwardKernelInto(dest, gradOut, input,
+            new[] { outC, inC, kH, kW }, new[] { 1, 1 }, new[] { 0, 0 }, new[] { 1, 1 },
+            accumulate: true);
+
+        for (int i = 0; i < dest.Length; i++)
+        {
+            double expected = preExisting[i] + allocating[i];
+            Assert.True(System.Math.Abs(expected - dest[i]) < 1e-12,
+                $"[{i}] expected pre+alloc={expected:F12} but dest={dest[i]:F12}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #350. Two distinct bugs both surfaced as "T=double rank-3 BatchNorm under compile-mode replay diverges from eager":

### Bug A (commit 69a43715) — fixed in PR #351 follow-up: `BatchNormInferenceUnsafe` SIMD layout assumption

The `FusedKernels.BatchNormInferenceUnsafe` SIMD kernel assumes a `[channels, spatial]` layout (each channel's elements contiguous at `c * spatialSize`). That assumption holds for rank-3 `[C,H,W]` and rank-4 `[1,C,H,W]` tensors but is **wrong** for rank-2 `[batch, features]` (features are the fast axis) and rank-4 `[N>1, C, H, W]`. PR #351 had the kernel applied unconditionally; this PR restricts it to layouts where the assumption is actually true. Other ranks fall through to the generic engine BatchNorm (which is rank-aware).

### Bug B (commit b8ffdba1) — root cause of the residual #350 divergence: engine routing on auto-detect-GPU systems

`LazyTensorScope` and `GradientTape` both captured `AiDotNetEngine.Current` at construction. On any host with a GPU backend installed (production CI matrix), the module initializer at `GpuAutoDetectModuleInit` swaps that ambient engine to `DirectGpuTensorEngine`. So when a test or production caller did `var engine = new CpuEngine()` and ran ops on it, the ops were correctly RECORDED on the user's CpuEngine — but at backward / compile-replay time, the scope/tape dispatched to the unrelated `DirectGpuTensorEngine`, producing wrong outputs.

Concrete reproducer (`BatchNorm_3D_DOUBLE_CHW_ForwardReplay_MatchesEager`):
- Pre-Step bnF[0] = 1.41805822 (eager-time copy, correct)
- Post-Step bnF[0] = 0.66815776 (DirectGpuTensorEngine.BatchNorm computed `mean[0]=-0.027` and `var[0]=3.41` instead of CPU-correct `mean[0]=-0.124` and `var[0]=0.042`)
- Δ = 7.5e-1 — the GPU engine's BatchNorm path doesn't match the CPU engine's BatchNorm path on the same CPU tensor inputs.

**Fix**: Both classes now expose `BindEngineIfUnset(IEngine)` — engine entry points (currently `CpuEngine.BatchNorm`) call this on first op so the scope/tape locks in the engine the user actually invoked, not the global ambient. Defaults to `AiDotNetEngine.Current` so existing call sites continue to work; the first explicit bind locks in the engine, subsequent binds are no-ops.

## Test plan

### Tensors

- [x] `dotnet test tests/AiDotNet.Tensors.Tests --framework net10.0 --filter "Engines.Compilation"` — 400 passed, 0 failed (1 unrelated `Skip`)
- [x] `dotnet test --filter "FullyQualifiedName~BatchNormGradSlotResidualTests"` — 9 of 11 pass on net10.0 (was 3 of 11 before this PR)

### Residual follow-up (commit 0815e184 — isolation tests)

Two BN double backward tests still show ~1e-7 deltas at exact float32 ULP boundaries (2.98e-8, 5.96e-8). Bisected via two new tests:
- `Isolation_BatchNorm_2D_DOUBLE_Then_ReduceSum_GradGamma_MatchesEager_PerElement` — **PASSES at 1e-12** ⇒ BN backward is bit-identical between eager and compiled when fed an upstream gradient that doesn't go through Subtract+Multiply.
- `Isolation_DOUBLE_MseChain_GradX_MatchesEager_PerElement` — **FAILS** with the same float-ULP-boundary pattern ⇒ the divergence is in the `Subtract → Multiply(square) → ReduceSum` backward chain (specifically the multiply-with-self gradient path). Half the elements pass bit-for-bit, half drift by exactly half-a-ULP — signature of one path doing intermediate math in float32 while the other stays in double.

This residual is being tracked separately; it's NOT the engine-routing bug this PR fixes (which had magnitude-1 errors), and BN itself is no longer responsible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)