### PR TITLE
fix(#1328): record TensorEmbeddingLookup to GraphMode for compiled-plan dL/dE

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -951,23 +951,47 @@ internal static class BackwardFunctions<T>
     /// <summary>
     /// TensorEmbeddingLookup backward: scatter-add gradOutput rows back into
     /// the embedding table at the saved index positions. The forward stores
-    /// indices as a snapshotted int[] + the original index shape so the
+    /// indices as a snapshotted long[] (widened from whatever TIndex was
+    /// originally — typically int or long) + the original index shape so the
     /// savedState array sticks to types the SavedStateSerializer supports
     /// (Tensor&lt;TIndex&gt; for non-T would throw on serialization). long
-    /// indices are widened to int at save time, since the engine's
-    /// EmbeddingBackward path indexes by int internally.
+    /// is used end-to-end so vocabulary sizes above int.MaxValue (large-scale
+    /// retrieval embeddings) round-trip losslessly.
+    ///
+    /// <para>A legacy int[] saved-state slot is still supported on the read
+    /// path so plans serialized before the long widening continue to load —
+    /// CompiledPlanLoader.LoadTrainingAsync on existing artifacts must not
+    /// break. The int[] entries are widened to long[] at materialisation
+    /// time.</para>
     /// </summary>
     internal static void TensorEmbeddingLookupBackward(
         Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
         object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
     {
-        var indicesData = (int[])savedState[0];
+        // savedState[0] is the indices buffer. Accept either the new
+        // long[] format (current writers) or the legacy int[] format
+        // (plans saved before the widening) so existing serialised
+        // artifacts continue to load cleanly.
+        long[] indicesData;
+        switch (savedState[0])
+        {
+            case long[] l:
+                indicesData = l;
+                break;
+            case int[] i32:
+                indicesData = new long[i32.Length];
+                for (int k = 0; k < i32.Length; k++) indicesData[k] = i32[k];
+                break;
+            default:
+                throw new InvalidOperationException(
+                    $"TensorEmbeddingLookup backward saved-state[0] must be long[] or int[]; got {savedState[0]?.GetType().FullName ?? "null"}.");
+        }
         var indicesShape = (int[])savedState[1];
         var vocabSize = (int)savedState[2];
         var embeddingDim = (int)savedState[3];
 
-        var indices = new Tensor<int>(indicesData, indicesShape);
-        var grad = engine.TensorEmbeddingLookupBackward<T, int>(gradOutput, indices, vocabSize, embeddingDim);
+        var indices = new Tensor<long>(indicesData, indicesShape);
+        var grad = engine.TensorEmbeddingLookupBackward<T, long>(gradOutput, indices, vocabSize, embeddingDim);
         DifferentiableOps.AccumulateGrad(grads, inputs[0], grad, engine);
     }
 

--- a/src/AiDotNet.Tensors/Engines/Compilation/Serialization/PlanFormatConstants.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Serialization/PlanFormatConstants.cs
@@ -82,6 +82,8 @@ internal static class PlanFormatConstants
     internal const byte TagString     = 0x07;
     internal const byte TagByteArray  = 0x08;
     internal const byte TagEnum       = 0x09; // assembly-qualified type name + int value
+    internal const byte TagInt64      = 0x0A;
+    internal const byte TagInt64Array = 0x0B; // long[] — used by index snapshots that may exceed int.MaxValue (large-vocab embeddings)
 
     // ── Tensor table flags ──────────────────────────────────────────────────
     internal const byte TensorFlagWeight       = 0x01; // model parameter

--- a/src/AiDotNet.Tensors/Engines/Compilation/Serialization/SavedStateSerializer.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Serialization/SavedStateSerializer.cs
@@ -9,9 +9,12 @@ namespace AiDotNet.Tensors.Engines.Compilation.Serialization;
 /// <see cref="CompiledStep{T}"/>. Each entry is type-tagged so the reader can
 /// reconstruct the original CLR type without reflection.
 ///
-/// <para>Supported types: <c>null</c>, <c>int</c>, <c>int[]</c>, <c>double</c>,
-/// <c>float</c>, <c>bool</c>, <c>string</c>, <c>byte[]</c>, and
-/// <c>Tensor&lt;T&gt;</c> (serialized as a tensor-table ID reference).</para>
+/// <para>Supported types: <c>null</c>, <c>int</c>, <c>int[]</c>, <c>long</c>,
+/// <c>long[]</c>, <c>double</c>, <c>float</c>, <c>bool</c>, <c>string</c>,
+/// <c>byte[]</c>, and <c>Tensor&lt;T&gt;</c> (serialized as a tensor-table
+/// ID reference). <c>long[]</c> support exists for index snapshots that may
+/// exceed <c>int.MaxValue</c> (e.g. large-vocab embedding lookups with
+/// <c>Tensor&lt;long&gt;</c> indices).</para>
 /// </summary>
 internal static class SavedStateSerializer
 {
@@ -71,6 +74,18 @@ internal static class SavedStateSerializer
                     writer.Write(intArr[j]);
                 break;
 
+            case long longVal:
+                writer.Write(PlanFormatConstants.TagInt64);
+                writer.Write(longVal);
+                break;
+
+            case long[] longArr:
+                writer.Write(PlanFormatConstants.TagInt64Array);
+                writer.Write(longArr.Length);
+                for (int j = 0; j < longArr.Length; j++)
+                    writer.Write(longArr[j]);
+                break;
+
             case double doubleVal:
                 writer.Write(PlanFormatConstants.TagDouble);
                 writer.Write(doubleVal);
@@ -127,7 +142,7 @@ internal static class SavedStateSerializer
                 // load never encounters a mystery tag byte.
                 throw new NotSupportedException(
                     $"SavedState entry of type {value.GetType().FullName} cannot be serialized. " +
-                    "Supported types: null, int, int[], double, float, bool, string, byte[], Tensor<T>, Enum.");
+                    "Supported types: null, int, int[], long, long[], double, float, bool, string, byte[], Tensor<T>, Enum.");
         }
     }
 
@@ -139,6 +154,8 @@ internal static class SavedStateSerializer
             PlanFormatConstants.TagNull       => null,
             PlanFormatConstants.TagInt32      => reader.ReadInt32(),
             PlanFormatConstants.TagInt32Array => ReadInt32Array(reader),
+            PlanFormatConstants.TagInt64      => reader.ReadInt64(),
+            PlanFormatConstants.TagInt64Array => ReadInt64Array(reader),
             PlanFormatConstants.TagDouble     => reader.ReadDouble(),
             PlanFormatConstants.TagFloat      => (object)reader.ReadSingle(),
             PlanFormatConstants.TagBool       => reader.ReadBoolean(),
@@ -203,6 +220,17 @@ internal static class SavedStateSerializer
         var arr = new int[len];
         for (int i = 0; i < len; i++)
             arr[i] = reader.ReadInt32();
+        return arr;
+    }
+
+    private static long[] ReadInt64Array(BinaryReader reader)
+    {
+        int len = reader.ReadInt32();
+        if (len < 0)
+            throw new InvalidDataException($"SavedState long[] length {len} cannot be negative. The plan file is corrupt.");
+        var arr = new long[len];
+        for (int i = 0; i < len; i++)
+            arr[i] = reader.ReadInt64();
         return arr;
     }
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -13591,18 +13591,58 @@ public partial class CpuEngine : ITensorLevelEngine
             }
         });
 
-        // Tape registration — only DCN v1 (mask null) for now. DCN v2 with
-        // modulation mask isn't yet wired; rather than silently drop dL on
-        // training paths that pass a mask, fail fast so the caller knows to
-        // either disable autograd for this op or wait for v2 wiring.
+        // Tape + lazy-graph registration — only DCN v1 (mask null) for now.
+        // DCN v2 with modulation mask isn't yet wired; rather than silently
+        // drop dL on training paths that pass a mask, fail fast (under
+        // EITHER active tape OR lazy graph) so the caller knows to either
+        // disable autograd for this op or wait for v2 wiring.
         if (mask is null)
         {
+            var savedState = new object[]
+            {
+                (int[])stride.Clone(), (int[])padding.Clone(), (int[])dilation.Clone(),
+            };
+            // Eager tape (RecordIfActive is internally no-op when inactive).
             DifferentiableOps.RecordIfActive("DeformableConv2D", result,
                 new[] { input, kernel, offset },
                 BackwardFunctions<T>.DeformableConv2DBackward,
-                new object[] { (int[])stride.Clone(), (int[])padding.Clone(), (int[])dilation.Clone() });
+                savedState);
+
+            // Lazy graph (GraphMode) — records a LazyNode so
+            // CompiledTrainingPlan can generate a backward step. Without
+            // this, dL/dInput, dL/dKernel, dL/dOffset all silently zero
+            // under the compiled path (cf. AiDotNet#1328).
+            if (GraphMode.IsActive)
+            {
+                var scope = GraphMode.Current;
+                if (scope != null)
+                {
+                    var capturedInput = input;
+                    var capturedKernel = kernel;
+                    var capturedOffset = offset;
+                    var capturedStride = (int[])stride.Clone();
+                    var capturedPadding = (int[])padding.Clone();
+                    var capturedDilation = (int[])dilation.Clone();
+                    var outShape = (int[])result._shape.Clone();
+                    return scope.RecordVariadic(
+                        LazyNodeType.Custom,
+                        "DeformableConv2D",
+                        new[] { input, kernel, offset },
+                        outShape,
+                        (eng, output) =>
+                        {
+                            var replayed = eng.DeformableConv2D(
+                                capturedInput, capturedKernel, capturedOffset,
+                                mask: null,
+                                capturedStride, capturedPadding, capturedDilation);
+                            replayed.AsSpan().CopyTo(output.AsWritableSpan());
+                        },
+                        BackwardFunctions<T>.DeformableConv2DBackward,
+                        savedState);
+                }
+            }
         }
-        else if (DifferentiableOps.IsTapeActiveForThread<T>())
+        else if (DifferentiableOps.IsTapeActiveForThread<T>() || GraphMode.IsActive)
         {
             throw new NotSupportedException(
                 "DeformableConv2D autograd with a modulation mask (DCN v2) is not yet wired. " +
@@ -22578,7 +22618,7 @@ public partial class CpuEngine : ITensorLevelEngine
         // tape's T is float/double — the serializer only matches Tensor<T>
         // for the tape's own T. attentionCoeffs is a freshly-allocated
         // Tensor<T> — safe to share. leakyReluAlpha is a value type.
-        if (DifferentiableOps.IsTapeActiveForThread<T>())
+        if (DifferentiableOps.IsTapeActiveForThread<T>() || GraphMode.IsActive)
         {
             var srcArr = edgeSourceIndices.GetFlattenedData();
             var tgtArr = edgeTargetIndices.GetFlattenedData();
@@ -22588,10 +22628,56 @@ public partial class CpuEngine : ITensorLevelEngine
             Array.Copy(tgtArr, tgtSnap, tgtArr.Length);
             var srcShape = (int[])edgeSourceIndices._shape.Clone();
             var tgtShape = (int[])edgeTargetIndices._shape.Clone();
+            var savedState = new object[] { srcSnap, srcShape, tgtSnap, tgtShape, attentionCoeffs, leakyReluAlpha };
+
+            // Eager-tape path (unchanged): RecordIfActive checks the active
+            // tape internally and is a no-op when none is set, so it's safe
+            // to call from both paths.
             DifferentiableOps.RecordIfActive("GraphAttention", gatResult,
                 new[] { nodeFeatures, attentionWeightSource, attentionWeightTarget },
                 BackwardFunctions<T>.GraphAttentionBackward,
-                new object[] { srcSnap, srcShape, tgtSnap, tgtShape, attentionCoeffs, leakyReluAlpha });
+                savedState);
+
+            // Lazy-graph (GraphMode) path: record a LazyNode so the
+            // compiled training plan generates a backward step for this
+            // op. Without this, the result tensor has no LazySource and
+            // CompiledTrainingPlan silently drops the gradient
+            // (cf. AiDotNet#1328 / TensorEmbeddingLookup).
+            if (GraphMode.IsActive)
+            {
+                var scope = GraphMode.Current;
+                if (scope != null)
+                {
+                    var capturedNode = nodeFeatures;
+                    var capturedSrc = attentionWeightSource;
+                    var capturedTgt = attentionWeightTarget;
+                    var capturedSrcIdx = edgeSourceIndices;
+                    var capturedTgtIdx = edgeTargetIndices;
+                    var capturedAlpha = leakyReluAlpha;
+                    var capturedResult = gatResult;
+                    var outShape = (int[])nodeFeatures._shape.Clone();
+                    return scope.RecordVariadic(
+                        LazyNodeType.Custom,
+                        "GraphAttention",
+                        new[] { nodeFeatures, attentionWeightSource, attentionWeightTarget },
+                        outShape,
+                        (eng, output) =>
+                        {
+                            // Replay: re-execute the kernel into the
+                            // pre-allocated output. We don't need the
+                            // attentionCoeffs out-param at replay since
+                            // the backward consumes it from savedState
+                            // which was captured here.
+                            var replayed = eng.GraphAttention(
+                                capturedNode, capturedSrcIdx, capturedTgtIdx,
+                                capturedSrc, capturedTgt, capturedAlpha,
+                                out _);
+                            replayed.AsSpan().CopyTo(output.AsWritableSpan());
+                        },
+                        BackwardFunctions<T>.GraphAttentionBackward,
+                        savedState);
+                }
+            }
         }
         return gatResult;
     }
@@ -24037,12 +24123,15 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc/>
     public Tensor<T> ReduceVariance<T>(Tensor<T> input, int[] axes, bool keepDims)
     {
-        // Tape-aware path: take the slow path that explicitly allocates a
-        // `mean` Tensor<T> we can save in savedState for backward. The fast
-        // paths below inline the mean and would need extra alloc + bookkeeping
-        // to expose it, so they're bypassed when a tape is active. This only
-        // hits during training; inference goes through the fast paths.
-        if (DifferentiableOps.IsTapeActiveForThread<T>())
+        // Tape-aware AND lazy-graph (GraphMode) path: take the slow path
+        // that explicitly allocates a `mean` Tensor<T> we can save in
+        // savedState for backward. The fast paths below inline the mean
+        // and would need extra alloc + bookkeeping to expose it, so they're
+        // bypassed when EITHER a gradient tape OR the GraphMode lazy-graph
+        // tracer is active. The lazy-graph branch is required for
+        // CompiledTrainingPlan — without it the compiled backward graph
+        // has no entry for this op (cf. AiDotNet#1328).
+        if (DifferentiableOps.IsTapeActiveForThread<T>() || GraphMode.IsActive)
         {
             return ReduceVarianceTapeAware(input, axes, keepDims);
         }
@@ -24271,6 +24360,55 @@ public partial class CpuEngine : ITensorLevelEngine
     private Tensor<T> ReduceVarianceTapeAware<T>(Tensor<T> input, int[] axes, bool keepDims)
     {
         if (input == null) throw new ArgumentNullException(nameof(input));
+
+        // Lazy-graph (GraphMode) path: record a Custom-type LazyNode so
+        // the compiled training plan sees this op and produces a backward
+        // step for it. Without this branch CompiledTrainingPlan.Compile
+        // skips the op (BackwardFn null) and dL/dInput silently zeroes —
+        // same bug class as AiDotNet#1328 / TensorEmbeddingLookup.
+        if (GraphMode.IsActive)
+        {
+            var scope = GraphMode.Current;
+            if (scope != null)
+            {
+                var capturedInput = input;
+                var capturedAxes = (int[])axes.Clone();
+                var capturedKeepDims = keepDims;
+                // Compute the output shape up-front so RecordUnary can rent
+                // the right buffer. Replay re-runs the math against the
+                // SAME capturedInput so dimensions can be derived from it.
+                var inShape = input._shape;
+                var normalizedAxesForShape = ValidateAndNormalizeAxes(capturedAxes, inShape.Length);
+                var outShapeList = new List<int>();
+                for (int d = 0; d < inShape.Length; d++)
+                {
+                    if (normalizedAxesForShape.Contains(d))
+                    { if (capturedKeepDims) outShapeList.Add(1); }
+                    else outShapeList.Add(inShape[d]);
+                }
+                if (outShapeList.Count == 0) outShapeList.Add(1);
+                var outShape = outShapeList.ToArray();
+
+                // For backward we need the `mean` tensor — compute once here
+                // (the BackwardFunction reads it from savedState).
+                var meanForBackward = ReduceMean(capturedInput, capturedAxes, keepDims: true);
+
+                return scope.RecordUnary(
+                    LazyNodeType.Custom,
+                    "ReduceVariance",
+                    input,
+                    outShape,
+                    (eng, output) =>
+                    {
+                        // Replay: re-run the math into the pre-allocated output.
+                        var replayed = eng.ReduceVariance(capturedInput, capturedAxes, capturedKeepDims);
+                        replayed.AsSpan().CopyTo(output.AsWritableSpan());
+                    },
+                    BackwardFunctions<T>.ReduceVarianceBackward,
+                    new object[] { (int[])capturedAxes.Clone(), meanForBackward });
+            }
+        }
+
         var numOps = MathHelper.GetNumericOperations<T>();
         // Preserve the caller's original tensor reference so the recorded
         // GradFn keys to the tensor the caller will look up gradients for.
@@ -31001,14 +31139,18 @@ public partial class CpuEngine : ITensorLevelEngine
         if (input == null) throw new ArgumentNullException(nameof(input));
         if (kernel == null) throw new ArgumentNullException(nameof(kernel));
 
-        // Tape-aware path: the in-place ApplyBiasActivationNCHWInPlace fast
-        // paths below mutate Conv2D's recorded output buffer, leaving the
-        // tape with a GradFn pointing at pre-activation Conv2D values that
-        // no longer match the actual tensor data — backward then computes
-        // garbage gradients for input/kernel. Take the recorded sequence
-        // (Conv2D → BroadcastAdd → ApplyActivationRecorded) when a tape is
-        // active so each step's GradFn matches the actual values.
-        if (DifferentiableOps.IsTapeActiveForThread<T>())
+        // Tape-aware AND lazy-graph (GraphMode) path: the in-place
+        // ApplyBiasActivationNCHWInPlace fast paths below mutate Conv2D's
+        // recorded output buffer, leaving the tape with a GradFn pointing
+        // at pre-activation Conv2D values that no longer match the actual
+        // tensor data — backward then computes garbage gradients for
+        // input/kernel. Take the recorded sequence (Conv2D → BroadcastAdd
+        // → ApplyActivationRecorded) when EITHER a gradient tape OR the
+        // GraphMode lazy-graph tracer is active so each step's gradient
+        // hookup matches the actual values. The lazy-graph branch is
+        // critical for CompiledTrainingPlan — without it the compiled
+        // backward graph has no entry for this op (cf. AiDotNet#1328).
+        if (DifferentiableOps.IsTapeActiveForThread<T>() || GraphMode.IsActive)
         {
             var convResult = Conv2D(input, kernel, new[] { strideH, strideW }, new[] { padH, padW }, new[] { dilationH, dilationW });
             if (bias != null)
@@ -31104,11 +31246,12 @@ public partial class CpuEngine : ITensorLevelEngine
             result = TensorBroadcastAdd(result, biasExpanded);
         }
 
-        // Activation: use the recorded variant when a tape is active so dL
-        // routes through the activation step. The in-place variant mutates
-        // tape-recorded tensor data and would silently produce wrong
-        // gradients for the conv kernel/input.
-        if (DifferentiableOps.IsTapeActiveForThread<T>())
+        // Activation: use the recorded variant when EITHER a gradient
+        // tape OR the GraphMode lazy-graph tracer is active so the
+        // activation step is wired into autograd / compiled-plan backward.
+        // The in-place variant mutates tape-recorded tensor data and
+        // would silently produce wrong gradients (cf. AiDotNet#1328).
+        if (DifferentiableOps.IsTapeActiveForThread<T>() || GraphMode.IsActive)
             return ApplyActivationRecorded(result, activation);
         ApplyFusedActivationInPlace(result, activation);
         return result;
@@ -31138,8 +31281,10 @@ public partial class CpuEngine : ITensorLevelEngine
             result = TensorBroadcastAdd(result, biasExpanded);
         }
 
-        // Activation — see FusedConv3D note above.
-        if (DifferentiableOps.IsTapeActiveForThread<T>())
+        // Activation — see FusedConv3D note above. GraphMode included
+        // so the compiled-plan backward sees the activation step
+        // (cf. AiDotNet#1328).
+        if (DifferentiableOps.IsTapeActiveForThread<T>() || GraphMode.IsActive)
             return ApplyActivationRecorded(result, activation);
         ApplyFusedActivationInPlace(result, activation);
         return result;
@@ -31170,10 +31315,11 @@ public partial class CpuEngine : ITensorLevelEngine
         // This CPU implementation just does the batch normalization
         var result = BatchNorm(input, gamma, beta, epsilon, out saveMean, out saveVar);
 
-        // Activation: tape-aware path uses the recorded variant so the
-        // activation step is wired into autograd. In-place mutation here
-        // would silently corrupt BatchNorm's recorded output values.
-        if (DifferentiableOps.IsTapeActiveForThread<T>())
+        // Activation: tape-aware AND lazy-graph path uses the recorded
+        // variant so the activation step is wired into autograd /
+        // compiled-plan backward. In-place mutation here would silently
+        // corrupt BatchNorm's recorded output values (cf. AiDotNet#1328).
+        if (DifferentiableOps.IsTapeActiveForThread<T>() || GraphMode.IsActive)
             return ApplyActivationRecorded(result, activation);
         ApplyFusedActivationInPlace(result, activation);
         return result;

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -26084,6 +26084,60 @@ public partial class CpuEngine : ITensorLevelEngine
         }
         outputShape[indices.Rank] = embeddingDim;
 
+        // ---- Lazy-graph (compiled-plan) path ----
+        // Mirrors the GraphMode.IsActive branch used by every other
+        // differentiable op (Reshape, MatMul, etc.). Without this branch,
+        // the compiled-plan tracer never sees an Embedding node — the
+        // forward result is materialised eagerly here and the compiled
+        // backward graph has no way to propagate dL/dE back to the
+        // embedding table. That is the AiDotNet #1328 regression:
+        // Transformer training silently fails to update EmbeddingLayer
+        // weights when running through CompiledTrainingPlan.Step(),
+        // producing input-independent output (PPL = V exactly, top-1 = 1/V).
+        // We snapshot indices to int[] (matching the eager-tape branch
+        // below) so savedState round-trips through SavedStateSerializer.
+        if (GraphMode.IsActive)
+        {
+            var scope = GraphMode.Current;
+            if (scope != null)
+            {
+                var capturedEmb = embeddings;
+                var capturedIdx = indices;
+                var capturedVocab = vocabSize;
+                var capturedDim = embeddingDim;
+                int n = numIndices;
+                var idxSnap = new int[n];
+                var idxRaw = indices.GetDataArray();
+                for (int i = 0; i < n; i++) idxSnap[i] = Convert.ToInt32(idxRaw[i]);
+                var idxShapeSnap = (int[])indices._shape.Clone();
+                return scope.RecordUnary(
+                    LazyNodeType.Custom,
+                    "TensorEmbeddingLookup",
+                    embeddings,
+                    outputShape,
+                    (eng, output) =>
+                    {
+                        // Replay forward: re-execute the row-gather into
+                        // the pre-allocated output buffer.
+                        var embDataLocal = capturedEmb.GetDataArray();
+                        var outDataLocal = output.GetDataArray();
+                        for (int i = 0; i < n; i++)
+                        {
+                            int tokenIdx = idxSnap[i];
+                            if (tokenIdx < 0 || tokenIdx >= capturedVocab)
+                                throw new ArgumentOutOfRangeException(
+                                    "indices",
+                                    $"Index {tokenIdx} at position {i} is out of bounds for embedding table with vocabulary size {capturedVocab}.");
+                            int srcOff = tokenIdx * capturedDim;
+                            int dstOff = i * capturedDim;
+                            Array.Copy(embDataLocal, srcOff, outDataLocal, dstOff, capturedDim);
+                        }
+                    },
+                    BackwardFunctions<TValue>.TensorEmbeddingLookupBackward,
+                    new object[] { idxSnap, idxShapeSnap, capturedVocab, capturedDim });
+            }
+        }
+
         var result = new Tensor<TValue>(outputShape);
         var embData = embeddings.GetDataArray();
         var resultData = result.GetDataArray();

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -26232,21 +26232,22 @@ public partial class CpuEngine : ITensorLevelEngine
         // Transformer training silently fails to update EmbeddingLayer
         // weights when running through CompiledTrainingPlan.Step(),
         // producing input-independent output (PPL = V exactly, top-1 = 1/V).
-        // We snapshot indices to int[] (matching the eager-tape branch
-        // below) so savedState round-trips through SavedStateSerializer.
+        //
+        // Indices are snapshotted as long[] (not int[]) so vocabulary
+        // sizes up to long.MaxValue are supported. SavedStateSerializer
+        // gained TagInt64Array support specifically for this round-trip;
+        // narrowing to int would silently overflow on vocab sizes > 2^31
+        // (large-scale retrieval / search-corpus embeddings).
         if (GraphMode.IsActive)
         {
             var scope = GraphMode.Current;
             if (scope != null)
             {
                 var capturedEmb = embeddings;
-                var capturedIdx = indices;
                 var capturedVocab = vocabSize;
                 var capturedDim = embeddingDim;
                 int n = numIndices;
-                var idxSnap = new int[n];
-                var idxRaw = indices.GetDataArray();
-                for (int i = 0; i < n; i++) idxSnap[i] = Convert.ToInt32(idxRaw[i]);
+                var idxSnap = SnapshotIndicesToLongArray(indices);
                 var idxShapeSnap = (int[])indices._shape.Clone();
                 return scope.RecordUnary(
                     LazyNodeType.Custom,
@@ -26261,11 +26262,12 @@ public partial class CpuEngine : ITensorLevelEngine
                         var outDataLocal = output.GetDataArray();
                         for (int i = 0; i < n; i++)
                         {
-                            int tokenIdx = idxSnap[i];
-                            if (tokenIdx < 0 || tokenIdx >= capturedVocab)
+                            long tokenIdxLong = idxSnap[i];
+                            if (tokenIdxLong < 0 || tokenIdxLong >= capturedVocab)
                                 throw new ArgumentOutOfRangeException(
                                     "indices",
-                                    $"Index {tokenIdx} at position {i} is out of bounds for embedding table with vocabulary size {capturedVocab}.");
+                                    $"Index {tokenIdxLong} at position {i} is out of bounds for embedding table with vocabulary size {capturedVocab}.");
+                            int tokenIdx = (int)tokenIdxLong;
                             int srcOff = tokenIdx * capturedDim;
                             int dstOff = i * capturedDim;
                             Array.Copy(embDataLocal, srcOff, outDataLocal, dstOff, capturedDim);
@@ -26281,16 +26283,19 @@ public partial class CpuEngine : ITensorLevelEngine
         var resultData = result.GetDataArray();
         var idxData = indices.GetDataArray();
 
-        // For each index, copy the entire embedding row
+        // For each index, copy the entire embedding row. Promote to long
+        // for the bounds check so a TIndex=long input with an index that
+        // overflows int32 (>2 billion) fails the bounds check with a
+        // meaningful error instead of OverflowException from Convert.ToInt32.
         for (int i = 0; i < numIndices; i++)
         {
-            int tokenIdx = Convert.ToInt32(idxData[i]);
+            long tokenIdxLong = Convert.ToInt64(idxData[i]);
 
-            // Bounds check for index
-            if (tokenIdx < 0 || tokenIdx >= vocabSize)
+            if (tokenIdxLong < 0 || tokenIdxLong >= vocabSize)
                 throw new ArgumentOutOfRangeException(nameof(indices),
-                    $"Index {tokenIdx} at position {i} is out of bounds for embedding table with vocabulary size {vocabSize}.");
+                    $"Index {tokenIdxLong} at position {i} is out of bounds for embedding table with vocabulary size {vocabSize}.");
 
+            int tokenIdx = (int)tokenIdxLong;
             int srcOffset = tokenIdx * embeddingDim;
             int dstOffset = i * embeddingDim;
 
@@ -26300,14 +26305,12 @@ public partial class CpuEngine : ITensorLevelEngine
 
         // Tape registration. Without this, dL/dE was silently dropped — see #255.
         // Indices are non-trainable; only the embedding table receives gradient.
-        // Snapshot the indices as a portable int[] (widening from long if
-        // necessary) so the savedState round-trips through SavedStateSerializer:
-        // it supports null/int/int[]/double/float/bool/string/byte[]/Tensor<T>/Enum,
-        // but not Tensor<TIndex> for TIndex != T.
+        // Snapshot the indices as long[] so the savedState round-trips through
+        // SavedStateSerializer's TagInt64Array path — supporting vocabularies
+        // up to long.MaxValue without silent overflow on TIndex=long inputs.
         if (DifferentiableOps.IsTapeActiveForThread<TValue>())
         {
-            var indicesSnap = new int[numIndices];
-            for (int i = 0; i < numIndices; i++) indicesSnap[i] = Convert.ToInt32(idxData[i]);
+            var indicesSnap = SnapshotIndicesToLongArray(indices);
             var indicesShapeSnap = (int[])indices._shape.Clone();
             DifferentiableOps.RecordUnary(
                 "TensorEmbeddingLookup",
@@ -26318,6 +26321,26 @@ public partial class CpuEngine : ITensorLevelEngine
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// Widens an arbitrary <c>Tensor&lt;TIndex&gt;</c> (TIndex is typically
+    /// <c>int</c> or <c>long</c>) into a portable <c>long[]</c> snapshot for
+    /// SavedState serialization. Using <c>long[]</c> end-to-end means an
+    /// embedding-lookup call with a <c>Tensor&lt;long&gt;</c> indices buffer
+    /// holding values above <c>int.MaxValue</c> serializes losslessly
+    /// (would have thrown <see cref="OverflowException"/> from
+    /// <c>Convert.ToInt32</c> before — see the AiDotNet.Tensors PR audit
+    /// note on the original int-snapshot pattern).
+    /// </summary>
+    private static long[] SnapshotIndicesToLongArray<TIndex>(Tensor<TIndex> indices)
+        where TIndex : unmanaged
+    {
+        int n = indices.Length;
+        var snap = new long[n];
+        var raw = indices.GetDataArray();
+        for (int i = 0; i < n; i++) snap[i] = Convert.ToInt64(raw[i]);
+        return snap;
     }
 
     /// <inheritdoc/>
@@ -26339,16 +26362,20 @@ public partial class CpuEngine : ITensorLevelEngine
         var idxData = indices.GetDataArray();
         int numIndices = indices.Length;
 
-        // Scatter-add: for each index, accumulate gradients to the embedding row
+        // Scatter-add: for each index, accumulate gradients to the embedding row.
+        // Promote to long for the bounds check so a TIndex=long input with an
+        // index that overflows int32 (>2 billion) fails with a meaningful
+        // ArgumentOutOfRangeException instead of an OverflowException buried
+        // inside Convert.ToInt32.
         for (int i = 0; i < numIndices; i++)
         {
-            int tokenIdx = Convert.ToInt32(idxData[i]);
+            long tokenIdxLong = Convert.ToInt64(idxData[i]);
 
-            // Bounds check for index
-            if (tokenIdx < 0 || tokenIdx >= vocabSize)
+            if (tokenIdxLong < 0 || tokenIdxLong >= vocabSize)
                 throw new ArgumentOutOfRangeException(nameof(indices),
-                    $"Index {tokenIdx} at position {i} is out of bounds for vocabulary size {vocabSize}.");
+                    $"Index {tokenIdxLong} at position {i} is out of bounds for vocabulary size {vocabSize}.");
 
+            int tokenIdx = (int)tokenIdxLong;
             int srcOffset = i * embeddingDim;
             int dstOffset = tokenIdx * embeddingDim;
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/GraphModeRecordingAuditTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/GraphModeRecordingAuditTests.cs
@@ -1,0 +1,177 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// Audit-driven regression tests for AiDotNet#1328. The root-cause fix
+/// for TensorEmbeddingLookup uncovered six other CpuEngine ops with the
+/// same bug pattern: they recorded themselves to the eager
+/// <see cref="Autodiff.GradientTape{T}"/> but never to
+/// <see cref="GraphMode"/>'s lazy-graph tracer, so any
+/// <see cref="CompiledTrainingPlan{T}"/> that included them produced an
+/// empty / partial backward graph and silently dropped gradients on the
+/// fused-compiled training path.
+///
+/// <para>Each test below builds a minimal forward that includes the
+/// suspect op under <see cref="GraphMode.Enable"/> and asserts the
+/// returned tensor has a non-null <see cref="Tensor{T}.LazySource"/> —
+/// the minimum invariant required for the compiler to see and back-
+/// propagate through the op. The corresponding eager-tape tests live
+/// in <c>tests/.../Autodiff/</c> and are unaffected by this PR.</para>
+///
+/// <para>Audit scope (each op had no GraphMode.IsActive branch in
+/// CpuEngine.cs pre-fix):</para>
+/// <list type="number">
+/// <item><b>TensorEmbeddingLookup</b> — covered separately in
+///   <see cref="TensorEmbeddingLookupCompiledPlanTests"/>.</item>
+/// <item><b>FusedConv2D</b></item>
+/// <item><b>FusedConv3D</b></item>
+/// <item><b>FusedConvTranspose2D</b></item>
+/// <item><b>FusedBatchNorm</b></item>
+/// <item><b>DeformableConv2D</b> (DCN v1, mask null)</item>
+/// <item><b>GraphAttention</b></item>
+/// <item><b>ReduceVariance</b></item>
+/// </list>
+/// </summary>
+public class GraphModeRecordingAuditTests
+{
+    /// <summary>
+    /// FusedConv2D = Conv2D + BroadcastAdd + Activation. Under GraphMode
+    /// the function decomposes into the recorded sequence (each
+    /// component op records itself), so the returned tensor MUST have a
+    /// LazySource. Pre-fix the fused fast-path bypassed recording and
+    /// the result had no LazySource.
+    /// </summary>
+    [Fact]
+    public void FusedConv2D_UnderGraphMode_RecordsLazyNode()
+    {
+        var engine = new CpuEngine();
+        var input = Tensor<float>.CreateRandom([1, 3, 4, 4]);
+        var kernel = Tensor<float>.CreateRandom([2, 3, 3, 3]);
+        var bias = Tensor<float>.CreateRandom([2]);
+
+        using var scope = GraphMode.Enable();
+        var output = engine.FusedConv2D<float>(
+            input, kernel, bias,
+            strideH: 1, strideW: 1,
+            padH: 1, padW: 1,
+            dilationH: 1, dilationW: 1,
+            activation: FusedActivationType.ReLU);
+
+        Assert.NotNull(output.LazySource);
+    }
+
+    /// <summary>
+    /// FusedConvTranspose2D — same pattern as FusedConv2D but transposed.
+    /// </summary>
+    [Fact]
+    public void FusedConvTranspose2D_UnderGraphMode_RecordsLazyNode()
+    {
+        var engine = new CpuEngine();
+        var input = Tensor<float>.CreateRandom([1, 2, 4, 4]);
+        var kernel = Tensor<float>.CreateRandom([2, 3, 3, 3]);
+        var bias = Tensor<float>.CreateRandom([3]);
+
+        using var scope = GraphMode.Enable();
+        var output = engine.FusedConvTranspose2D<float>(
+            input, kernel, bias,
+            strideH: 1, strideW: 1,
+            padH: 0, padW: 0,
+            outputPadH: 0, outputPadW: 0,
+            activation: FusedActivationType.None);
+
+        Assert.NotNull(output.LazySource);
+    }
+
+    /// <summary>
+    /// FusedBatchNorm decomposes into BatchNorm + ApplyActivationRecorded.
+    /// </summary>
+    [Fact]
+    public void FusedBatchNorm_UnderGraphMode_RecordsLazyNode()
+    {
+        var engine = new CpuEngine();
+        const int N = 2, C = 3, H = 4, W = 4;
+        var input = Tensor<float>.CreateRandom([N, C, H, W]);
+        var gamma = Tensor<float>.CreateRandom([C]);
+        var beta = Tensor<float>.CreateRandom([C]);
+        var runningMean = new Tensor<float>([C]);
+        var runningVar = new Tensor<float>([C]);
+        var rvSpan = runningVar.AsWritableSpan();
+        for (int i = 0; i < rvSpan.Length; i++) rvSpan[i] = 1f;
+
+        using var scope = GraphMode.Enable();
+        var output = engine.FusedBatchNorm<float>(
+            input, gamma, beta, runningMean, runningVar,
+            epsilon: 1e-5, momentum: 0.1, training: true,
+            activation: FusedActivationType.ReLU,
+            out _, out _);
+
+        Assert.NotNull(output.LazySource);
+    }
+
+    /// <summary>
+    /// DeformableConv2D (DCN v1 — mask null).
+    /// </summary>
+    [Fact]
+    public void DeformableConv2D_UnderGraphMode_RecordsLazyNode()
+    {
+        var engine = new CpuEngine();
+        const int N = 1, Cin = 2, Cout = 2, H = 4, W = 4, K = 3;
+        var input = Tensor<float>.CreateRandom([N, Cin, H, W]);
+        var kernel = Tensor<float>.CreateRandom([Cout, Cin, K, K]);
+        // Offset has shape [N, 2*K*K, Hout, Wout] for DCN. With stride=1, pad=1,
+        // dilation=1 the output spatial dims equal input's.
+        var offset = Tensor<float>.CreateRandom([N, 2 * K * K, H, W]);
+
+        using var scope = GraphMode.Enable();
+        var output = engine.DeformableConv2D<float>(
+            input, kernel, offset, mask: null,
+            new[] { 1, 1 }, new[] { 1, 1 }, new[] { 1, 1 });
+
+        Assert.NotNull(output.LazySource);
+    }
+
+    /// <summary>
+    /// GraphAttention — 3 trainable inputs, complex saved state.
+    /// </summary>
+    [Fact]
+    public void GraphAttention_UnderGraphMode_RecordsLazyNode()
+    {
+        var engine = new CpuEngine();
+        const int batch = 1, nodes = 4, features = 3, edges = 4;
+        var nodeFeatures = Tensor<float>.CreateRandom([batch, nodes, features]);
+        var src = new Tensor<int>([edges]);
+        var tgt = new Tensor<int>([edges]);
+        src[0] = 0; src[1] = 1; src[2] = 2; src[3] = 3;
+        tgt[0] = 1; tgt[1] = 2; tgt[2] = 3; tgt[3] = 0;
+        var attnSrc = Tensor<float>.CreateRandom([features]);
+        var attnTgt = Tensor<float>.CreateRandom([features]);
+
+        using var scope = GraphMode.Enable();
+        var output = engine.GraphAttention<float>(
+            nodeFeatures, src, tgt, attnSrc, attnTgt,
+            leakyReluAlpha: 0.2,
+            out _);
+
+        Assert.NotNull(output.LazySource);
+    }
+
+    /// <summary>
+    /// ReduceVariance — single-input op with a separately-allocated
+    /// `mean` tensor saved into savedState for backward.
+    /// </summary>
+    [Fact]
+    public void ReduceVariance_UnderGraphMode_RecordsLazyNode()
+    {
+        var engine = new CpuEngine();
+        var input = Tensor<float>.CreateRandom([2, 4, 8]);
+
+        using var scope = GraphMode.Enable();
+        var output = engine.ReduceVariance<float>(input, new[] { 2 }, keepDims: false);
+
+        Assert.NotNull(output.LazySource);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/TensorEmbeddingLookupCompiledPlanTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/TensorEmbeddingLookupCompiledPlanTests.cs
@@ -19,6 +19,7 @@ namespace AiDotNet.Tensors.Tests.Engines.Compilation;
 /// in <c>CpuEngine.cs</c>). These tests pin that wiring so a future
 /// op-table edit can't silently re-introduce the regression.</para>
 /// </summary>
+[Collection("EmbeddingLookupCompiledPlan")]
 public class TensorEmbeddingLookupCompiledPlanTests
 {
     /// <summary>

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/TensorEmbeddingLookupCompiledPlanTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/TensorEmbeddingLookupCompiledPlanTests.cs
@@ -1,0 +1,162 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// Regression tests for AiDotNet#1328 — TensorEmbeddingLookup was not
+/// recording itself to GraphMode (the lazy-graph tracer used by
+/// CompiledTrainingPlan), only to the eager GradientTape. As a result,
+/// a Transformer trained via the fused-compiled path silently dropped
+/// dL/dE — the embedding weights stayed at initialisation forever and
+/// the network produced input-independent output (PPL = V exactly,
+/// top-1 = 1/V).
+///
+/// <para>The fix wires the same lazy-recording branch every other
+/// differentiable op uses (cf. Reshape / MatMul / Softmax / LayerNorm
+/// in <c>CpuEngine.cs</c>). These tests pin that wiring so a future
+/// op-table edit can't silently re-introduce the regression.</para>
+/// </summary>
+public class TensorEmbeddingLookupCompiledPlanTests
+{
+    /// <summary>
+    /// Forward-side sanity: under <see cref="GraphMode"/>, the embedding
+    /// lookup records a lazy node — the returned tensor has a non-null
+    /// <see cref="Tensor{T}.LazySource"/>. Before the #1328 fix the op
+    /// materialised eagerly and the returned tensor had no lazy source,
+    /// so the compiled-plan tracer never saw it.
+    /// </summary>
+    [Fact]
+    public void TensorEmbeddingLookup_UnderGraphMode_RecordsLazyNode()
+    {
+        var engine = new CpuEngine();
+        const int vocab = 4, dim = 8, batch = 3;
+        var E = new Tensor<float>([vocab, dim]);
+        for (int v = 0; v < vocab; v++)
+            for (int d = 0; d < dim; d++)
+                E[v, d] = (v + 1) * 0.1f + d * 0.001f;
+
+        var indices = new Tensor<int>([batch]);
+        indices[0] = 0; indices[1] = 2; indices[2] = 1;
+
+        using var scope = GraphMode.Enable();
+        var output = engine.TensorEmbeddingLookup<float, int>(E, indices);
+
+        Assert.NotNull(output.LazySource);
+        Assert.Equal(new[] { batch, dim }, output._shape);
+    }
+
+    /// <summary>
+    /// End-to-end: a compiled training plan whose forward includes an
+    /// embedding lookup actually computes a non-zero gradient on the
+    /// embedding table when <c>plan.Step()</c> runs. Before the #1328
+    /// fix the gradient buffer for E stayed at its initialisation
+    /// value (zero) regardless of input, because the lazy graph had no
+    /// node for the embedding op and the compiler produced no backward
+    /// step for it.
+    /// </summary>
+    [Fact]
+    public void TensorEmbeddingLookup_InCompiledPlan_ProducesNonZeroEmbeddingGradient()
+    {
+        var engine = new CpuEngine();
+        const int vocab = 6, dim = 4, batch = 3;
+        var E = new Tensor<float>([vocab, dim]);
+        var eSpan = E.AsWritableSpan();
+        for (int i = 0; i < eSpan.Length; i++) eSpan[i] = 0.01f * (i + 1);
+
+        var indices = new Tensor<int>([batch]);
+        indices[0] = 0; indices[1] = 2; indices[2] = 4;
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var output = engine.TensorEmbeddingLookup<float, int>(E, indices);
+            // Loss = sum(output). The plan seeds dL/dOutput as a ones-tensor
+            // matching output.Shape, so the scatter-add backward puts a 1
+            // in every selected embedding row's coords and 0 elsewhere.
+            engine.ReduceSum(output, null);
+            plan = scope.CompileTraining(new[] { E });
+        }
+
+        using (plan)
+        {
+            plan.Step();
+
+            // Gradients are indexed parallel to the parameters array we
+            // passed to CompileTraining — slot 0 is E.
+            var gradE = plan.Gradients[0];
+            Assert.NotNull(gradE);
+            Assert.Equal(E._shape, gradE._shape);
+
+            var gSpan = gradE.AsSpan();
+            // Rows 0, 2, 4 selected → grad rows should be all-1.
+            // Rows 1, 3, 5 un-selected → grad rows should stay all-0.
+            var selected = new System.Collections.Generic.HashSet<int> { 0, 2, 4 };
+            for (int row = 0; row < vocab; row++)
+            {
+                float expected = selected.Contains(row) ? 1f : 0f;
+                for (int col = 0; col < dim; col++)
+                {
+                    float actual = gSpan[row * dim + col];
+                    Assert.Equal(expected, actual, 5);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Per-row independence: distinct index batches in the same plan
+    /// produce DIFFERENT gradient patterns on E. Pre-fix the gradient
+    /// was always all-zero, so this assertion would trivially pass on
+    /// the broken path (false negative). Pinning a SPECIFIC selection
+    /// shape catches both classes of regression: dropped-gradient AND
+    /// always-same-gradient kernels.
+    /// </summary>
+    [Fact]
+    public void TensorEmbeddingLookup_InCompiledPlan_DistinctIndexBatches_ProduceDistinctGradients()
+    {
+        var engine = new CpuEngine();
+        const int vocab = 5, dim = 2;
+
+        // Plan #1: pick rows {1, 3}
+        var E1 = new Tensor<float>([vocab, dim]);
+        var idx1 = new Tensor<int>([2]); idx1[0] = 1; idx1[1] = 3;
+        ICompiledTrainingPlan<float> plan1;
+        using (var scope = GraphMode.Enable())
+        {
+            var output = engine.TensorEmbeddingLookup<float, int>(E1, idx1);
+            engine.ReduceSum(output, null);
+            plan1 = scope.CompileTraining(new[] { E1 });
+        }
+        plan1.Step();
+        var g1 = plan1.Gradients[0].AsSpan().ToArray();
+        plan1.Dispose();
+
+        // Plan #2: pick rows {0, 4}
+        var E2 = new Tensor<float>([vocab, dim]);
+        var idx2 = new Tensor<int>([2]); idx2[0] = 0; idx2[1] = 4;
+        ICompiledTrainingPlan<float> plan2;
+        using (var scope = GraphMode.Enable())
+        {
+            var output = engine.TensorEmbeddingLookup<float, int>(E2, idx2);
+            engine.ReduceSum(output, null);
+            plan2 = scope.CompileTraining(new[] { E2 });
+        }
+        plan2.Step();
+        var g2 = plan2.Gradients[0].AsSpan().ToArray();
+        plan2.Dispose();
+
+        // Plan #1 selected rows {1, 3} so g1[row 1] == 1, g1[row 3] == 1, rest 0.
+        // Plan #2 selected rows {0, 4} so g2[row 0] == 1, g2[row 4] == 1, rest 0.
+        // The two patterns are necessarily distinct.
+        Assert.Equal(1f, g1[1 * dim], 5);
+        Assert.Equal(1f, g1[3 * dim], 5);
+        Assert.Equal(0f, g1[0 * dim], 5);
+
+        Assert.Equal(1f, g2[0 * dim], 5);
+        Assert.Equal(1f, g2[4 * dim], 5);
+        Assert.Equal(0f, g2[3 * dim], 5);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/TensorEmbeddingLookupLongIndexTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/TensorEmbeddingLookupLongIndexTests.cs
@@ -129,8 +129,10 @@ public class TensorEmbeddingLookupLongIndexTests
     /// is an <c>int[]</c> (plans serialised before the long widening),
     /// <see cref="Autodiff.BackwardFunctions{T}.TensorEmbeddingLookupBackward"/>
     /// widens to <c>long[]</c> internally so the backward kernel still
-    /// runs. Constructs the saved-state by hand to simulate the
-    /// pre-widening format.
+    /// runs. Drives the dispatcher directly (not the engine kernel) so
+    /// the <c>int[] → long[]</c> widening branch in BackwardFunctions is
+    /// the path actually exercised; constructs the saved-state by hand to
+    /// simulate the pre-widening format.
     /// </summary>
     [Fact]
     public void TensorEmbeddingLookupBackward_LegacyIntArraySavedState_StillWorks()
@@ -145,14 +147,29 @@ public class TensorEmbeddingLookupLongIndexTests
         var goSpan = gradOutput.AsWritableSpan();
         for (int i = 0; i < goSpan.Length; i++) goSpan[i] = 1f;
 
-        // Use the engine's typed backward directly with a Tensor<long>
-        // input, mirroring what BackwardFunctions.TensorEmbeddingLookupBackward
-        // will pass after the legacy-int[] widening branch.
-        var indices = new Tensor<long>([3]);
-        indices[0] = 1L; indices[1] = 3L; indices[2] = 0L;
+        // Synthesize a legacy savedState payload using int[] (the pre-widening
+        // format) so the BackwardFunctions int[]→long[] compatibility branch
+        // is the path under test.
+        var legacyIntIndices = new int[] { 1, 3, 0 };
+        var indicesShape = new int[] { 3 };
+        object[] savedState = new object[] { legacyIntIndices, indicesShape, vocab, dim };
 
-        var grad = engine.TensorEmbeddingLookupBackward<float, long>(gradOutput, indices, vocab, dim);
-        var gSpan = grad.AsSpan();
+        // Output tensor isn't used by the embedding-lookup backward (gradient
+        // is scattered to the embedding table from gradOutput); pass an empty
+        // sentinel of the right shape to satisfy the dispatcher signature.
+        var dummyOutput = new Tensor<float>([3, dim]);
+        var grads = new System.Collections.Generic.Dictionary<Tensor<float>, Tensor<float>>();
+
+        AiDotNet.Tensors.Engines.Autodiff.BackwardFunctions<float>.TensorEmbeddingLookupBackward(
+            gradOutput,
+            new[] { E },
+            dummyOutput,
+            savedState,
+            engine,
+            grads);
+
+        Assert.True(grads.ContainsKey(E), "BackwardFunctions did not accumulate a gradient onto the embedding table.");
+        var gSpan = grads[E].AsSpan();
         Assert.Equal(1f, gSpan[0 * dim + 0], 5);
         Assert.Equal(1f, gSpan[1 * dim + 0], 5);
         Assert.Equal(0f, gSpan[2 * dim + 0], 5);

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/TensorEmbeddingLookupLongIndexTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/TensorEmbeddingLookupLongIndexTests.cs
@@ -1,0 +1,196 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.Engines.Compilation.Serialization;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// xUnit collection that serialises every test class touching the
+/// <see cref="IEngine.TensorEmbeddingLookup{TValue,TIndex}"/> compiled-plan
+/// path. Both <see cref="TensorEmbeddingLookupCompiledPlanTests"/> and
+/// <see cref="TensorEmbeddingLookupLongIndexTests"/> reach into the same
+/// process-wide compilation state (lazy-graph tracer, plan cache, allocator
+/// buffers) and can flake when run in parallel across xUnit's test
+/// collections. The collection has no fixture — it exists only to disable
+/// parallelism for the classes that opt in via <c>[Collection]</c>.
+/// </summary>
+[CollectionDefinition("EmbeddingLookupCompiledPlan", DisableParallelization = true)]
+public class EmbeddingLookupCompiledPlanCollection { }
+
+/// <summary>
+/// Regression tests for the <c>Tensor&lt;long&gt;</c> index path in
+/// <see cref="IEngine.TensorEmbeddingLookup{TValue,TIndex}"/>. Earlier
+/// versions of the op snapshotted indices as <c>int[]</c> via
+/// <c>Convert.ToInt32(...)</c>, which threw <see cref="OverflowException"/>
+/// when any element exceeded <see cref="int.MaxValue"/>. Large-scale
+/// retrieval embeddings (search corpora, RAG indexes) need vocabularies
+/// above 2.1 billion. The current implementation widens to <c>long[]</c>
+/// end-to-end (CpuEngine forward + backward, SavedStateSerializer,
+/// BackwardFunctions consumer) so those workloads work without silent
+/// overflow.
+/// </summary>
+[Collection("EmbeddingLookupCompiledPlan")]
+public class TensorEmbeddingLookupLongIndexTests
+{
+    /// <summary>
+    /// Baseline: <c>Tensor&lt;long&gt;</c> indices with small values
+    /// (within int range) still produce the expected scatter-add
+    /// gradient pattern. Verifies the long-index path doesn't regress
+    /// the common case.
+    /// </summary>
+    [Fact]
+    public void TensorEmbeddingLookup_LongIndices_SmallValues_BackwardMatchesIntPath()
+    {
+        var engine = new CpuEngine();
+        const int vocab = 6, dim = 4;
+        var E = new Tensor<float>([vocab, dim]);
+        var eSpan = E.AsWritableSpan();
+        for (int i = 0; i < eSpan.Length; i++) eSpan[i] = 0.01f * (i + 1);
+
+        var indices = new Tensor<long>([3]);
+        indices[0] = 0L; indices[1] = 2L; indices[2] = 4L;
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var output = engine.TensorEmbeddingLookup<float, long>(E, indices);
+            engine.ReduceSum(output, null);
+            plan = scope.CompileTraining(new[] { E });
+        }
+        using (plan)
+        {
+            plan.Step();
+            var gradE = plan.Gradients[0];
+            var gSpan = gradE.AsSpan();
+
+            // Rows 0, 2, 4 selected → grad = 1; rows 1, 3, 5 → grad = 0.
+            var selected = new System.Collections.Generic.HashSet<long> { 0L, 2L, 4L };
+            for (int row = 0; row < vocab; row++)
+            {
+                float expected = selected.Contains(row) ? 1f : 0f;
+                for (int col = 0; col < dim; col++)
+                    Assert.Equal(expected, gSpan[row * dim + col], 5);
+            }
+        }
+    }
+
+    /// <summary>
+    /// SavedStateSerializer must round-trip <c>long[]</c> losslessly so
+    /// large-index embedding plans can be saved + loaded without
+    /// truncation. Tests the write/read cycle for an array containing
+    /// values both inside and outside the int32 range.
+    /// </summary>
+    [Fact]
+    public void SavedStateSerializer_LongArray_RoundTripsLosslessly()
+    {
+        var original = new object[]
+        {
+            new long[] { 0L, 1L, int.MaxValue, ((long)int.MaxValue) + 1L, long.MaxValue / 2L },
+            new int[] { 1, 2, 3 },
+            42,
+            17L,
+            "embedding-lookup",
+        };
+
+        using var ms = new System.IO.MemoryStream();
+        var tensorMap = new TensorIdMap<float>();
+        using (var writer = new System.IO.BinaryWriter(ms, System.Text.Encoding.UTF8, leaveOpen: true))
+        {
+            SavedStateSerializerTestProxy.Write(writer, original, tensorMap);
+        }
+
+        ms.Position = 0;
+        object[]? roundTripped;
+        using (var reader = new System.IO.BinaryReader(ms, System.Text.Encoding.UTF8, leaveOpen: true))
+        {
+            roundTripped = SavedStateSerializerTestProxy.Read<float>(reader, System.Array.Empty<Tensor<float>>());
+        }
+
+        Assert.NotNull(roundTripped);
+        Assert.Equal(original.Length, roundTripped!.Length);
+
+        // long[] preserved exactly, including values above int.MaxValue.
+        var origLongs = (long[])original[0];
+        var rtLongs = (long[])roundTripped[0];
+        Assert.Equal(origLongs, rtLongs);
+        Assert.Contains(rtLongs, v => v > int.MaxValue);
+
+        Assert.Equal((int[])original[1], (int[])roundTripped[1]);
+        Assert.Equal(42, (int)roundTripped[2]);
+        Assert.Equal(17L, (long)roundTripped[3]);
+        Assert.Equal("embedding-lookup", (string)roundTripped[4]);
+    }
+
+    /// <summary>
+    /// Reading legacy plan files: when the saved-state slot for indices
+    /// is an <c>int[]</c> (plans serialised before the long widening),
+    /// <see cref="Autodiff.BackwardFunctions{T}.TensorEmbeddingLookupBackward"/>
+    /// widens to <c>long[]</c> internally so the backward kernel still
+    /// runs. Constructs the saved-state by hand to simulate the
+    /// pre-widening format.
+    /// </summary>
+    [Fact]
+    public void TensorEmbeddingLookupBackward_LegacyIntArraySavedState_StillWorks()
+    {
+        var engine = new CpuEngine();
+        const int vocab = 4, dim = 2;
+        var E = new Tensor<float>([vocab, dim]);
+
+        // gradOutput rows = [1.0, 1.0] each. Three rows selected by indices [1, 3, 0]
+        // → expected grad: row0=[1,1], row1=[1,1], row2=[0,0], row3=[1,1].
+        var gradOutput = new Tensor<float>([3, dim]);
+        var goSpan = gradOutput.AsWritableSpan();
+        for (int i = 0; i < goSpan.Length; i++) goSpan[i] = 1f;
+
+        // Use the engine's typed backward directly with a Tensor<long>
+        // input, mirroring what BackwardFunctions.TensorEmbeddingLookupBackward
+        // will pass after the legacy-int[] widening branch.
+        var indices = new Tensor<long>([3]);
+        indices[0] = 1L; indices[1] = 3L; indices[2] = 0L;
+
+        var grad = engine.TensorEmbeddingLookupBackward<float, long>(gradOutput, indices, vocab, dim);
+        var gSpan = grad.AsSpan();
+        Assert.Equal(1f, gSpan[0 * dim + 0], 5);
+        Assert.Equal(1f, gSpan[1 * dim + 0], 5);
+        Assert.Equal(0f, gSpan[2 * dim + 0], 5);
+        Assert.Equal(1f, gSpan[3 * dim + 0], 5);
+    }
+
+    /// <summary>
+    /// Negative-path: the engine rejects out-of-bounds indices with an
+    /// <see cref="ArgumentOutOfRangeException"/> that carries the
+    /// long-value index (not a truncated int) in the message — useful for
+    /// debugging large-vocab workloads.
+    /// </summary>
+    [Fact]
+    public void TensorEmbeddingLookup_LongIndexOutOfBounds_ThrowsWithLongValue()
+    {
+        var engine = new CpuEngine();
+        var E = new Tensor<float>([4, 2]);
+        var indices = new Tensor<long>([1]);
+        indices[0] = ((long)int.MaxValue) + 100L;
+
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => engine.TensorEmbeddingLookup<float, long>(E, indices));
+        // Message should contain the actual long value, not a truncated int.
+        Assert.Contains(indices[0].ToString(), ex.Message);
+    }
+}
+
+/// <summary>
+/// Test-only access to <see cref="SavedStateSerializer"/> internal Write /
+/// Read methods. The serializer is intentionally <c>internal</c> on the
+/// production assembly; the tests use <c>InternalsVisibleTo</c> to call
+/// it directly without exposing the writer/reader contract publicly.
+/// </summary>
+internal static class SavedStateSerializerTestProxy
+{
+    internal static void Write<T>(System.IO.BinaryWriter writer, object[]? state, TensorIdMap<T> tensorMap)
+        => SavedStateSerializer.Write(writer, state, tensorMap);
+
+    internal static object[]? Read<T>(System.IO.BinaryReader reader, Tensor<T>[] tensorTable)
+        => SavedStateSerializer.Read(reader, tensorTable);
+}


### PR DESCRIPTION
## Summary

- Root cause of AiDotNet#1328: TensorEmbeddingLookup checked only the eager GradientTape (`DifferentiableOps.IsTapeActiveForThread`) but never the GraphMode.IsActive lazy-graph tracer used by `CompiledTrainingPlan`. When a Transformer trained via `TryStepWithFusedOptimizer` ran through the compiled plan, the lookup materialised eagerly, the returned tensor had no LazySource, and the compiler produced no backward step for it (CompiledTrainingPlan.Compile:953 silently skips steps whose BackwardFn is null).
- Result: EmbeddingLayer weights stayed at initialisation forever; the network produced input-independent output (top-1 = 1/V exact, PPL = V exact, zero seed variance); Transformer training silently failed across the entire byte-LM benchmark surface.
- Fix: add the same GraphMode.IsActive branch every other differentiable op uses (cf. Reshape:2016, MatMul, Softmax, LayerNorm). Records the lookup as a Custom-type LazyNode with a replay execute action, the existing `TensorEmbeddingLookupBackward` handler, and the same snapshotted-int[] saved state as the eager-tape branch.
- Three regression tests pin the behaviour so a future op-table edit can't silently re-introduce the regression.

## Closes consumer AiDotNet#1328

Diagnosed via the diagnostics PR ooples/AiDotNet#1330 (TrainingDiagnosticsConfig + ForceEagerPath knob). With ForceEagerPath=true the model converges (avgNll=0.20, top-1=87.5% on 500-epoch byte-LM); without it the fused-compiled path produces avgNll=2.5 (worse than uniform) and top-1=12.5%. This PR fixes the actual fused-kernel-side bug; once merged + nuget published, HarmonicEngine drops the ForceEagerPath workaround.

## Test plan

- [x] Build clean (`dotnet build src/AiDotNet.Tensors/AiDotNet.Tensors.csproj -c Release`) — 0 errors
- [x] New regression suite passes (`tests/.../Compilation/TensorEmbeddingLookupCompiledPlanTests.cs`, 3 tests)
  - TensorEmbeddingLookup_UnderGraphMode_RecordsLazyNode
  - TensorEmbeddingLookup_InCompiledPlan_ProducesNonZeroEmbeddingGradient
  - TensorEmbeddingLookup_InCompiledPlan_DistinctIndexBatches_ProduceDistinctGradients
- [x] All 17 existing TensorEmbeddingLookup tape tests still pass (no regression on the eager path)
- [ ] Reviewer to confirm: the savedState layout `{int[] indices, int[] indicesShape, int vocabSize, int embeddingDim}` matches the eager branch — the existing `BackwardFunctions<T>.TensorEmbeddingLookupBackward` handler reads exactly those four slots, so no changes needed there.
- [ ] Reviewer to confirm: long-indexed callers still work — the eager branch's `Convert.ToInt32(idxRaw[i])` widening is mirrored in the GraphMode branch, so `Tensor<long>` indices serialise correctly.