### PR TITLE
fix(#1331): LayerNorm savedState mean/variance refresh + multi-layer fused-Adam regression suite

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -995,6 +995,41 @@ internal static class BackwardFunctions<T>
         DifferentiableOps.AccumulateGrad(grads, inputs[0], grad, engine);
     }
 
+    /// <summary>
+    /// AiDotNet#1331 companion to <see cref="TensorEmbeddingLookupBackward"/>: scatters
+    /// the upstream gradient back to the embedding table using indices read FRESH from
+    /// the captured float-indices tensor (savedState[0]). Reading at backward time keeps
+    /// gradient routing consistent with the forward replay — both pull from the same
+    /// live tensor reference, so a plan.Step() after the user updates the float input's
+    /// data in place performs forward gather AND backward scatter against the same row IDs.
+    /// </summary>
+    internal static void TensorEmbeddingLookupFromFloatIndicesBackward(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
+        object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        var capturedFloatIdx = (Tensor<T>)savedState[0];
+        int vocabSize = (int)savedState[1];
+        int embeddingDim = (int)savedState[2];
+
+        // Materialise fresh int indices for this Step. The float input may
+        // have been overwritten between forward and backward — that's the
+        // whole reason this op exists — so the int[] we build here MUST
+        // mirror exactly what the forward Custom op read on the same Step.
+        int n = capturedFloatIdx.Length;
+        var floatData = capturedFloatIdx.GetDataArray();
+        var nops = MathHelper.GetNumericOperations<T>();
+        var idxLong = new long[n];
+        for (int i = 0; i < n; i++)
+            idxLong[i] = Convert.ToInt64(nops.ToDouble(floatData[i]));
+
+        var indicesShape = (int[])capturedFloatIdx._shape.Clone();
+        var indicesTensor = new Tensor<long>(idxLong, indicesShape);
+        var grad = engine.TensorEmbeddingLookupBackward<T, long>(gradOutput, indicesTensor, vocabSize, embeddingDim);
+        // inputs[0] is the embedding table — the only trainable input.
+        // inputs[1] is the float-indices tensor; it carries no gradient.
+        DifferentiableOps.AccumulateGrad(grads, inputs[0], grad, engine);
+    }
+
     /// <summary>GeGLU backward: dispatches to engine.GeGLUBackward(gradOutput, input, dim).</summary>
     internal static void GeGLUBackward(
         Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,

--- a/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
@@ -437,6 +437,7 @@ internal static class OpRegistry
         "TensorBatchMatMul",   // -> BatchMatMul (records)
         "TensorLogSoftmax",    // -> LogSoftmax (records)
         "TensorEmbeddingLookup", // -> Embedding (records)
+        "TensorEmbeddingLookupFromFloatIndices", // AiDotNet#1331 — float-indices variant; lazy node captures indices by ref + records BackwardFunctions<T>.TensorEmbeddingLookupFromFloatIndicesBackward (eager path delegates to TensorEmbeddingLookup which records normally)
         "TensorScatterAdd",    // -> ScatterAdd (records)
         "TensorGather",        // -> Gather (records)
         "TensorVar",           // -> Var (records)

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -1812,67 +1812,21 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             };
         }
 
-        // LayerNorm: use FusedKernels.LayerNormUnsafe for direct SIMD
-        if (step.OpType == OpType.LayerNorm && typeof(T) == typeof(float)
-            && step.Inputs.Length >= 3 && step.Inputs[0].IsContiguous)
+        // LayerNorm: previously routed through FusedKernels.LayerNormUnsafe
+        // for direct SIMD. AiDotNet#1331: that specialized fast path only
+        // wrote the forward output and didn't refresh the savedState
+        // mean/variance tensors the backward reads from. The backward then
+        // used compile-time stale (zero-init) mean/variance, producing
+        // gradGamma = 0 and dL/dInput = 0 — every LayerNorm γ stuck plus
+        // every parameter upstream of the norm stuck. Returning null here
+        // routes LayerNorm through the lazy execute lambda registered by
+        // CpuEngine.LayerNorm, which calls eng.LayerNorm(out mean, out var)
+        // and copies fresh mean/variance into the savedState tensors on
+        // every plan.Step(). A future re-specialization MUST emit mean/var
+        // alongside the output to remain correct.
+        if (step.OpType == OpType.LayerNorm)
         {
-            var input = step.Inputs[0];
-            var gamma = step.Inputs[1];
-            var beta = step.Inputs[2];
-            var output = step.OutputBuffer;
-            int normSize = gamma.Length;
-            float eps = 1e-5f;
-            if (step.SavedState is { Length: > 0 } && step.SavedState[0] is double epsD)
-                eps = (float)epsD;
-
-            var inH = PinAndTrack(((Tensor<float>)(object)input).GetDataArray(), handleTracker);
-            var outH = PinAndTrack(((Tensor<float>)(object)output).GetDataArray(), handleTracker);
-            var gammaH = PinAndTrack(((Tensor<float>)(object)gamma).GetDataArray(), handleTracker);
-            var betaH = PinAndTrack(((Tensor<float>)(object)beta).GetDataArray(), handleTracker);
-            int batchSize = input.Length / normSize;
-            float capturedEps = eps;
-
-            return eng =>
-            {
-                // LayerNorm per batch element. Previously serial — that
-                // capped BERT LayerNorm at ~900 µs on [1,256,768] despite
-                // the underlying kernel running in ~120 µs when dispatched
-                // in parallel. Threshold: parallelise if total work ≥50K
-                // elements (matches CpuEngine.LayerNorm's own gate).
-                int totalElems = batchSize * normSize;
-                if (totalElems >= 50_000)
-                {
-                    CpuParallelSettings.ParallelForOrSerial(0, batchSize, totalElems, b =>
-                    {
-                        unsafe
-                        {
-                            float* pIn = (float*)inH.AddrOfPinnedObject();
-                            float* pOut = (float*)outH.AddrOfPinnedObject();
-                            float* pG = (float*)gammaH.AddrOfPinnedObject();
-                            float* pB = (float*)betaH.AddrOfPinnedObject();
-                            Simd.FusedKernels.LayerNormUnsafe(
-                                pIn + b * normSize, pG, pB,
-                                pOut + b * normSize, normSize, capturedEps);
-                        }
-                    });
-                }
-                else
-                {
-                    unsafe
-                    {
-                        float* pIn = (float*)inH.AddrOfPinnedObject();
-                        float* pOut = (float*)outH.AddrOfPinnedObject();
-                        float* pG = (float*)gammaH.AddrOfPinnedObject();
-                        float* pB = (float*)betaH.AddrOfPinnedObject();
-                        for (int b = 0; b < batchSize; b++)
-                        {
-                            Simd.FusedKernels.LayerNormUnsafe(
-                                pIn + b * normSize, pG, pB,
-                                pOut + b * normSize, normSize, capturedEps);
-                        }
-                    }
-                }
-            };
+            return null;
         }
 
         // TensorDivide forward: pinned SIMD VectorDivideUnsafe

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -20134,6 +20134,46 @@ public partial class CpuEngine : ITensorLevelEngine
         if (value == null)
             throw new ArgumentNullException(nameof(value));
 
+        // AiDotNet#1331: under GraphMode, the eager implementation below would
+        // read Q/K/V's uninitialized lazy backings at compile time and bake a
+        // garbage result into the output buffer — which then never gets
+        // refreshed at plan.Step (no lazy node = no forward step). Every
+        // parameter upstream of this op (embedding + Q/K/V/output projection
+        // weights) silently stops training because the gradient chain through
+        // ScaledDotProductAttention's input ports gets dropped.
+        //
+        // Record a lazy node so the op participates in the compiled forward
+        // chain. The execute lambda re-runs eager SDPA at plan.Step time with
+        // the freshly-computed Q/K/V from prior forward steps, and
+        // attentionWeights is refreshed into the saved tensor on every step
+        // (mirrors the LayerNorm savedState fix pattern).
+        if (GraphMode.IsActive)
+        {
+            var scope = GraphMode.Current;
+            if (scope != null)
+            {
+                var cq = query; var ck = key; var cv = value; var cm = mask; var cs = scale;
+                var savedScope = GraphMode.Current;
+                GraphMode.SetCurrent(null);
+                var eagerResult = ScaledDotProductAttention(cq, ck, cv, cm, cs, out attentionWeights);
+                GraphMode.SetCurrent(savedScope);
+                var capturedAttn = attentionWeights;
+                var lazyResult = scope.RecordVariadic(LazyNodeType.Custom, "ScaledDotProductAttention",
+                    new[] { query, key, value }, eagerResult._shape,
+                    (eng, output) =>
+                    {
+                        var r = eng.ScaledDotProductAttention(cq, ck, cv, cm, cs, out var freshAttn);
+                        r.AsSpan().CopyTo(output.AsWritableSpan());
+                        // Refresh attention-weights savedState (analogous to LayerNorm mean/var).
+                        freshAttn.AsSpan().CopyTo(capturedAttn.AsWritableSpan());
+                    },
+                    BackwardFunctions<T>.ScaledDotProductAttentionBackward,
+                    new object[] { attentionWeights, scale ?? (1.0 / System.Math.Sqrt(query._shape[3])), mask is null ? (object)false : mask });
+                eagerResult.AsSpan().CopyTo(lazyResult.AsWritableSpan());
+                return lazyResult;
+            }
+        }
+
         // Preserve original Q/K/V refs for tape recording (#257). The
         // .Contiguous() rebinds below would otherwise replace the strided
         // views (typical post-Permute / post-Reshape) with fresh tensors

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -18395,18 +18395,8 @@ public partial class CpuEngine : ITensorLevelEngine
                     new[] { input, gamma, beta }, eagerResult._shape,
                     (eng, output) =>
                     {
-                        // Always go through the out-param eager LayerNorm so we
-                        // have fresh mean/variance for the backward. The
-                        // LayerNormFloatInto fast path skipped this — which
-                        // is what caused #1331. The previous "fast" path is
-                        // re-introducible later as an option once a
-                        // mean+var write-through overload exists.
                         var r = eng.LayerNorm(ci, cg, cb, ce, out var freshMean, out var freshVar);
                         r.AsSpan().CopyTo(output.AsWritableSpan());
-                        // Mean/variance are per-batch tensors of shape
-                        // [batchSize]; copy element-by-element into the
-                        // SAME tensors the savedState slot references so
-                        // LayerNormBackward reads the just-computed values.
                         freshMean.AsSpan().CopyTo(capturedMean.AsWritableSpan());
                         freshVar.AsSpan().CopyTo(capturedVar.AsWritableSpan());
                     },

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -18371,31 +18371,39 @@ public partial class CpuEngine : ITensorLevelEngine
                 GraphMode.SetCurrent(null);
                 var eagerResult = LayerNorm(ci, cg, cb, ce, out mean, out variance);
                 GraphMode.SetCurrent(savedScope);
+                // AiDotNet#1331: mean/variance returned by the compile-time
+                // eager call are stale once the lazy graph replays — the
+                // forward replay re-runs LayerNorm on the freshly-computed
+                // input, but the savedState mean/variance tensors are NOT
+                // re-updated, so the backward kernel reads compile-time
+                // values (zero, since the lazy input was uninitialized at
+                // compile time). The result: gradGamma and dL/dInput silently
+                // become zero, gamma never trains, and every parameter
+                // upstream of any LayerNorm stops learning. Fix: the lazy
+                // execute callback recomputes mean/variance via the
+                // out-param overload and copies them into the SAME tensor
+                // instances the savedState slot holds, so the backward
+                // reads fresh values on every plan.Step().
+                var capturedMean = mean;
+                var capturedVar = variance;
                 var lazyResult = scope.RecordVariadic(LazyNodeType.Custom, "LayerNorm",
                     new[] { input, gamma, beta }, eagerResult._shape,
-                    // Path C: plan-step write-through. When the engine is
-                    // CpuEngine and T is float, call LayerNormFloatInto which
-                    // writes directly into the plan's pre-allocated output.
-                    // This skips the intermediate tensor allocation + the
-                    // 786 KB CopyTo that the generic path below would incur
-                    // for BERT's [1,256,768] LayerNorm (~130 µs saved per
-                    // call × 24 calls per BERT layer).
                     (eng, output) =>
                     {
-                        if (typeof(T) == typeof(float) && eng is CpuEngine cpuEng)
-                        {
-                            cpuEng.LayerNormFloatInto(
-                                (Tensor<float>)(object)ci,
-                                (Tensor<float>)(object)cg,
-                                (Tensor<float>)(object)cb,
-                                ce,
-                                (Tensor<float>)(object)output);
-                        }
-                        else
-                        {
-                            var r = eng.LayerNorm(ci, cg, cb, ce, out _, out _);
-                            r.AsSpan().CopyTo(output.AsWritableSpan());
-                        }
+                        // Always go through the out-param eager LayerNorm so we
+                        // have fresh mean/variance for the backward. The
+                        // LayerNormFloatInto fast path skipped this — which
+                        // is what caused #1331. The previous "fast" path is
+                        // re-introducible later as an option once a
+                        // mean+var write-through overload exists.
+                        var r = eng.LayerNorm(ci, cg, cb, ce, out var freshMean, out var freshVar);
+                        r.AsSpan().CopyTo(output.AsWritableSpan());
+                        // Mean/variance are per-batch tensors of shape
+                        // [batchSize]; copy element-by-element into the
+                        // SAME tensors the savedState slot references so
+                        // LayerNormBackward reads the just-computed values.
+                        freshMean.AsSpan().CopyTo(capturedMean.AsWritableSpan());
+                        freshVar.AsSpan().CopyTo(capturedVar.AsWritableSpan());
                     },
                     BackwardFunctions<T>.LayerNormBackward, new object[] { mean, variance, epsilon });
                 eagerResult.AsSpan().CopyTo(lazyResult.AsWritableSpan());

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -17396,17 +17396,22 @@ public partial class CpuEngine : ITensorLevelEngine
             if (scope != null)
             {
                 var ci = input; var cg = gamma; var cb = beta; double ce = epsilon;
-                // Execute eagerly to fill out params
                 var savedScope = GraphMode.Current;
                 GraphMode.SetCurrent(null);
                 var eagerResult = BatchNorm(ci, cg, cb, ce, out mean, out variance);
                 GraphMode.SetCurrent(savedScope);
-                // Record in graph so compiled plan captures the dependency
+                // AiDotNet#1331: refresh mean/variance on every plan.Step.
+                var capturedMean = mean; var capturedVar = variance;
                 var lazyResult = scope.RecordVariadic(LazyNodeType.Custom, "BatchNorm",
                     new[] { input, gamma, beta }, eagerResult._shape,
-                    (eng, output) => { var r = eng.BatchNorm(ci, cg, cb, ce, out _, out _); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) =>
+                    {
+                        var r = eng.BatchNorm(ci, cg, cb, ce, out var freshMean, out var freshVar);
+                        r.AsSpan().CopyTo(output.AsWritableSpan());
+                        freshMean.AsSpan().CopyTo(capturedMean.AsWritableSpan());
+                        freshVar.AsSpan().CopyTo(capturedVar.AsWritableSpan());
+                    },
                     BackwardFunctions<T>.BatchNormBackward, new object[] { mean, variance, epsilon });
-                // Copy eager data into lazy output
                 eagerResult.AsSpan().CopyTo(lazyResult.AsWritableSpan());
                 return lazyResult;
             }
@@ -19359,6 +19364,8 @@ public partial class CpuEngine : ITensorLevelEngine
                 GraphMode.SetCurrent(null);
                 var eagerResult = GroupNorm(ci, cn, cg, cb, ce, out mean, out variance);
                 GraphMode.SetCurrent(savedScope);
+                // AiDotNet#1331: refresh mean/variance on every plan.Step.
+                var capturedGNMean = mean; var capturedGNVar = variance;
                 // SavedState order MUST match BackwardFunctions<T>.GroupNormBackward's
                 // read order: [numGroups, mean, variance, epsilon]. Previously this was
                 // [mean, variance, numGroups, epsilon] causing InvalidCastException in
@@ -19367,11 +19374,10 @@ public partial class CpuEngine : ITensorLevelEngine
                     new[] { input, gamma, beta }, eagerResult._shape,
                     (eng, output) =>
                     {
-                        if (eng is CpuEngine cpuEng)
-                        {
-                            cpuEng.GroupNormInto(output, ci, cn, cg, cb, ce, out _, out _);
-                        }
-                        else { var r = eng.GroupNorm(ci, cn, cg, cb, ce, out _, out _); r.AsSpan().CopyTo(output.AsWritableSpan()); }
+                        var r = eng.GroupNorm(ci, cn, cg, cb, ce, out var freshMean, out var freshVar);
+                        r.AsSpan().CopyTo(output.AsWritableSpan());
+                        freshMean.AsSpan().CopyTo(capturedGNMean.AsWritableSpan());
+                        freshVar.AsSpan().CopyTo(capturedGNVar.AsWritableSpan());
                     },
                     // SavedState order per #178 fix above: numGroups must come first so
                     // GroupNormBackward reads savedState[0] as int (not as Tensor).
@@ -19823,8 +19829,15 @@ public partial class CpuEngine : ITensorLevelEngine
                 GraphMode.SetCurrent(null);
                 var eagerResult = RMSNorm(ci, cg, ce, out rms);
                 GraphMode.SetCurrent(savedScope);
+                // AiDotNet#1331: refresh rms on every plan.Step (was stale from compile-time).
+                var capturedRms = rms;
                 var lazyResult = scope.RecordBinary(LazyNodeType.Custom, "RMSNorm", input, gamma, eagerResult._shape,
-                    (eng, output) => { var r = eng.RMSNorm(ci, cg, ce, out _); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) =>
+                    {
+                        var r = eng.RMSNorm(ci, cg, ce, out var freshRms);
+                        r.AsSpan().CopyTo(output.AsWritableSpan());
+                        freshRms.AsSpan().CopyTo(capturedRms.AsWritableSpan());
+                    },
                     BackwardFunctions<T>.RMSNormBackward, new object[] { rms, epsilon });
                 eagerResult.AsSpan().CopyTo(lazyResult.AsWritableSpan());
                 return lazyResult;
@@ -23140,8 +23153,19 @@ public partial class CpuEngine : ITensorLevelEngine
                 GraphMode.SetCurrent(null);
                 var eagerResult = ScatterMean(cs, ci, out counts, cd, co);
                 GraphMode.SetCurrent(savedScope);
+                // AiDotNet#1331: counts isn't currently referenced by the backward
+                // (only `indices` and `dim` are saved), but mirror the refresh
+                // pattern for safety in case ScatterMeanBackward starts consuming counts.
+                var capturedCounts = counts;
                 var lazyResult = scope.RecordUnary(LazyNodeType.Custom, "ScatterMean", source, eagerResult._shape,
-                    (eng, output) => { var r = eng.ScatterMean(cs, ci, out _, cd, co); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) =>
+                    {
+                        var r = eng.ScatterMean(cs, ci, out var freshCounts, cd, co);
+                        r.AsSpan().CopyTo(output.AsWritableSpan());
+                        if (capturedCounts is not null && freshCounts is not null
+                            && capturedCounts.Length == freshCounts.Length)
+                            freshCounts.AsSpan().CopyTo(capturedCounts.AsWritableSpan());
+                    },
                     BackwardFunctions<T>.ScatterMeanBackward, new object[] { indices, dim });
                 eagerResult.AsSpan().CopyTo(lazyResult.AsWritableSpan());
                 return lazyResult;
@@ -33258,9 +33282,17 @@ public partial class CpuEngine : ITensorLevelEngine
                 GraphMode.SetCurrent(null);
                 var eagerResult = InstanceNorm(ci, cg, cb, ce, out mean, out variance);
                 GraphMode.SetCurrent(savedScope);
+                // AiDotNet#1331: refresh mean/variance on every plan.Step.
+                var capturedINMean = mean; var capturedINVar = variance;
                 var lazyResult = scope.RecordVariadic(LazyNodeType.Custom, "InstanceNorm",
                     new[] { input, gamma, beta }, eagerResult._shape,
-                    (eng, output) => { var r = eng.InstanceNorm(ci, cg, cb, ce, out _, out _); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) =>
+                    {
+                        var r = eng.InstanceNorm(ci, cg, cb, ce, out var freshMean, out var freshVar);
+                        r.AsSpan().CopyTo(output.AsWritableSpan());
+                        freshMean.AsSpan().CopyTo(capturedINMean.AsWritableSpan());
+                        freshVar.AsSpan().CopyTo(capturedINVar.AsWritableSpan());
+                    },
                     BackwardFunctions<T>.InstanceNormBackward, new object[] { mean, variance, epsilon });
                 eagerResult.AsSpan().CopyTo(lazyResult.AsWritableSpan());
                 return lazyResult;
@@ -33441,8 +33473,16 @@ public partial class CpuEngine : ITensorLevelEngine
                 GraphMode.SetCurrent(null);
                 var eagerResult = Dropout(ci, cdr, ct, out mask);
                 GraphMode.SetCurrent(savedScope);
+                // AiDotNet#1331: refresh mask on every plan.Step so backward
+                // sees the SAME mask as forward (compile-time mask is stale).
+                var capturedMask = mask;
                 var lazyResult = scope.RecordUnary(LazyNodeType.Custom, "Dropout", input, eagerResult._shape,
-                    (eng, output) => { var r = eng.Dropout(ci, cdr, ct, out _); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) =>
+                    {
+                        var r = eng.Dropout(ci, cdr, ct, out var freshMask);
+                        r.AsSpan().CopyTo(output.AsWritableSpan());
+                        freshMask.AsSpan().CopyTo(capturedMask.AsWritableSpan());
+                    },
                     BackwardFunctions<T>.DropoutBackward, new object[] { mask, dropoutRate });
                 eagerResult.AsSpan().CopyTo(lazyResult.AsWritableSpan());
                 return lazyResult;

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -20134,44 +20134,48 @@ public partial class CpuEngine : ITensorLevelEngine
         if (value == null)
             throw new ArgumentNullException(nameof(value));
 
-        // AiDotNet#1331: under GraphMode, the eager implementation below would
-        // read Q/K/V's uninitialized lazy backings at compile time and bake a
-        // garbage result into the output buffer — which then never gets
-        // refreshed at plan.Step (no lazy node = no forward step). Every
-        // parameter upstream of this op (embedding + Q/K/V/output projection
-        // weights) silently stops training because the gradient chain through
-        // ScaledDotProductAttention's input ports gets dropped.
+        // AiDotNet#1331: under GraphMode, decompose into primitive ops so each
+        // records itself and the compiled plan's backward chains through the
+        // primitives' own backward functions naturally — no compound lazy
+        // node, no savedState refresh, no per-step recursive eager SDPA call.
         //
-        // Record a lazy node so the op participates in the compiled forward
-        // chain. The execute lambda re-runs eager SDPA at plan.Step time with
-        // the freshly-computed Q/K/V from prior forward steps, and
-        // attentionWeights is refreshed into the saved tensor on every step
-        // (mirrors the LayerNorm savedState fix pattern).
+        // SDPA(Q, K, V) = softmax((Q @ K^T) * scale) @ V
+        //
+        // Each step here goes through Engine.* which is itself a lazy
+        // recording call: TensorPermute, TensorMatMul, TensorMultiplyScalar,
+        // Softmax. The compiled plan picks each one up as a normal forward
+        // step with its own backward delegate, so dL/dQ, dL/dK, dL/dV
+        // propagate through the recorded chain without any custom state.
+        //
+        // Performance note: previous attempt at this fix recorded a single
+        // lazy "ScaledDotProductAttention" node whose execute callback
+        // re-ran the entire eager SDPA at every plan.Step. That doubled the
+        // forward cost and prevented downstream fusion (CpuFusionPass can
+        // fuse MatMul + Softmax + MatMul into a single fused-attention
+        // kernel once the primitives are individually recorded). The
+        // decomposition here keeps the tape-only contract consistent with
+        // every other op in this engine.
         if (GraphMode.IsActive)
         {
-            var scope = GraphMode.Current;
-            if (scope != null)
-            {
-                var cq = query; var ck = key; var cv = value; var cm = mask; var cs = scale;
-                var savedScope = GraphMode.Current;
-                GraphMode.SetCurrent(null);
-                var eagerResult = ScaledDotProductAttention(cq, ck, cv, cm, cs, out attentionWeights);
-                GraphMode.SetCurrent(savedScope);
-                var capturedAttn = attentionWeights;
-                var lazyResult = scope.RecordVariadic(LazyNodeType.Custom, "ScaledDotProductAttention",
-                    new[] { query, key, value }, eagerResult._shape,
-                    (eng, output) =>
-                    {
-                        var r = eng.ScaledDotProductAttention(cq, ck, cv, cm, cs, out var freshAttn);
-                        r.AsSpan().CopyTo(output.AsWritableSpan());
-                        // Refresh attention-weights savedState (analogous to LayerNorm mean/var).
-                        freshAttn.AsSpan().CopyTo(capturedAttn.AsWritableSpan());
-                    },
-                    BackwardFunctions<T>.ScaledDotProductAttentionBackward,
-                    new object[] { attentionWeights, scale ?? (1.0 / System.Math.Sqrt(query._shape[3])), mask is null ? (object)false : mask });
-                eagerResult.AsSpan().CopyTo(lazyResult.AsWritableSpan());
-                return lazyResult;
-            }
+            // Expected shapes already validated by callers (4D [B, H, S, D]).
+            if (query.Rank != 4 || key.Rank != 4 || value.Rank != 4)
+                throw new ArgumentException("Query, Key, and Value must be 4D tensors [batch, heads, seq, d_k/d_v]");
+            int d_k_local = query._shape[3];
+            double scaleVal_local = scale ?? (1.0 / System.Math.Sqrt(d_k_local));
+            var numOpsLocal = MathHelper.GetNumericOperations<T>();
+            T scaleT_local = numOpsLocal.FromDouble(scaleVal_local);
+
+            // K^T: permute last two dims [B, H, S_k, D] -> [B, H, D, S_k]
+            var kT = TensorPermute(key, new[] { 0, 1, 3, 2 });
+            // scores = Q @ K^T -> [B, H, S_q, S_k]
+            var scores = TensorMatMul(query, kT);
+            // scaled = scores * (1/sqrt(d_k))
+            var scaled = TensorMultiplyScalar(scores, scaleT_local);
+            // softmax over last axis (S_k) — Softmax records its own lazy node
+            // and the backward kernel handles the per-row Jacobian.
+            attentionWeights = Softmax(scaled);
+            // context = attn @ V -> [B, H, S_q, d_v]
+            return TensorMatMul(attentionWeights, value);
         }
 
         // Preserve original Q/K/V refs for tape recording (#257). The
@@ -26383,6 +26387,80 @@ public partial class CpuEngine : ITensorLevelEngine
         }
 
         return result;
+    }
+
+    /// <inheritdoc/>
+    public Tensor<T> TensorEmbeddingLookupFromFloatIndices<T>(Tensor<T> embeddings, Tensor<T> floatIndices)
+    {
+        if (embeddings == null) throw new ArgumentNullException(nameof(embeddings));
+        if (floatIndices == null) throw new ArgumentNullException(nameof(floatIndices));
+        if (embeddings.Rank != 2)
+            throw new ArgumentException($"Embeddings must be 2D [vocab_size, embedding_dim]. Got rank {embeddings.Rank}.");
+
+        int vocabSize = embeddings._shape[0];
+        int embeddingDim = embeddings._shape[1];
+        int numIndices = floatIndices.Length;
+
+        var outputShape = new int[floatIndices.Rank + 1];
+        for (int i = 0; i < floatIndices.Rank; i++) outputShape[i] = floatIndices._shape[i];
+        outputShape[floatIndices.Rank] = embeddingDim;
+
+        // ---- Lazy-graph path: capture floatIndices BY REFERENCE so that
+        // every plan.Step() reads fresh data. The standard TensorEmbeddingLookup
+        // snapshots indices at trace time, which is unsafe when the indices
+        // come from a fresh-per-call user input tensor (AiDotNet#1331).
+        if (GraphMode.IsActive)
+        {
+            var scope = GraphMode.Current;
+            if (scope != null)
+            {
+                var capturedEmb = embeddings;
+                var capturedFloatIdx = floatIndices;
+                int dim = embeddingDim;
+                int vsz = vocabSize;
+                int n = numIndices;
+                var nops = MathHelper.GetNumericOperations<T>();
+
+                return scope.RecordBinary(
+                    LazyNodeType.Custom,
+                    "TensorEmbeddingLookupFromFloatIndices",
+                    embeddings, floatIndices, outputShape,
+                    (eng, output) =>
+                    {
+                        // Read fresh float indices each replay; convert to int
+                        // via banker's rounding (matches Convert.ToInt32(double)
+                        // semantics used by the eager path so any code that flips
+                        // between fused and eager produces identical lookups).
+                        var idxData = capturedFloatIdx.GetDataArray();
+                        var embData = capturedEmb.GetDataArray();
+                        var outData = output.GetDataArray();
+                        for (int i = 0; i < n; i++)
+                        {
+                            long tokenIdx = Convert.ToInt64(nops.ToDouble(idxData[i]));
+                            if (tokenIdx < 0 || tokenIdx >= vsz)
+                                throw new ArgumentOutOfRangeException(
+                                    nameof(floatIndices),
+                                    $"Index {tokenIdx} at position {i} out of bounds for vocab {vsz}.");
+                            int srcOff = (int)tokenIdx * dim;
+                            int dstOff = i * dim;
+                            Array.Copy(embData, srcOff, outData, dstOff, dim);
+                        }
+                    },
+                    BackwardFunctions<T>.TensorEmbeddingLookupFromFloatIndicesBackward,
+                    new object[] { capturedFloatIdx, vsz, dim });
+            }
+        }
+
+        // ---- Eager path: convert and delegate to the existing TIndex=int lookup,
+        // so eager-path callers transparently get all the work done by the
+        // tape-registration + GPU paths in TensorEmbeddingLookup.
+        var intIndices = new Tensor<int>(floatIndices._shape);
+        var floatData = floatIndices.GetDataArray();
+        var intData = intIndices.GetDataArray();
+        var nopsEager = MathHelper.GetNumericOperations<T>();
+        for (int i = 0; i < numIndices; i++)
+            intData[i] = (int)Convert.ToInt64(nopsEager.ToDouble(floatData[i]));
+        return TensorEmbeddingLookup<T, int>(embeddings, intIndices);
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -8157,6 +8157,13 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     Tensor<T> IEngine.LayerNorm<T>(Tensor<T> input, Tensor<T> gamma, Tensor<T> beta, double epsilon, out Tensor<T> mean, out Tensor<T> variance)
     {
         if (IsTapeActive<T>()) return base.LayerNorm(input, gamma, beta, epsilon, out mean, out variance);
+        // AiDotNet#1331: under GraphMode, the base CpuEngine.LayerNorm has the
+        // lazy-graph recording branch that emits a backward node for the
+        // compiled plan. The GPU eager path below would silently bypass
+        // GraphMode, leaving the LayerNorm out of the compiled graph entirely
+        // and dropping gradients for every parameter upstream of the norm.
+        if (Compilation.GraphMode.IsActive)
+            return base.LayerNorm(input, gamma, beta, epsilon, out mean, out variance);
         if (!TryGetBackend(out var backend))
             return base.LayerNorm(input, gamma, beta, epsilon, out mean, out variance);
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -8249,6 +8249,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     Tensor<T> IEngine.RMSNorm<T>(Tensor<T> input, Tensor<T> gamma, double epsilon, out Tensor<T> rms)
     {
         if (IsTapeActive<T>()) return base.RMSNorm(input, gamma, epsilon, out rms);
+        if (Compilation.GraphMode.IsActive) return base.RMSNorm(input, gamma, epsilon, out rms);
         if (!TryGetBackend(out var backend))
             return base.RMSNorm(input, gamma, epsilon, out rms);
 
@@ -8324,6 +8325,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     Tensor<T> IEngine.GroupNorm<T>(Tensor<T> input, int numGroups, Tensor<T> gamma, Tensor<T> beta, double epsilon, out Tensor<T> mean, out Tensor<T> variance)
     {
         if (IsTapeActive<T>()) return base.GroupNorm(input, numGroups, gamma, beta, epsilon, out mean, out variance);
+        if (Compilation.GraphMode.IsActive) return base.GroupNorm(input, numGroups, gamma, beta, epsilon, out mean, out variance);
         if (!TryGetBackend(out var backend))
             return base.GroupNorm(input, numGroups, gamma, beta, epsilon, out mean, out variance);
 
@@ -8372,6 +8374,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     Tensor<T> IEngine.InstanceNorm<T>(Tensor<T> input, Tensor<T> gamma, Tensor<T> beta, double epsilon, out Tensor<T> mean, out Tensor<T> variance)
     {
         if (IsTapeActive<T>()) return base.InstanceNorm(input, gamma, beta, epsilon, out mean, out variance);
+        if (Compilation.GraphMode.IsActive) return base.InstanceNorm(input, gamma, beta, epsilon, out mean, out variance);
         if (!TryGetBackend(out var backend))
             return base.InstanceNorm(input, gamma, beta, epsilon, out mean, out variance);
 
@@ -9325,6 +9328,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     Tensor<T> IEngine.Dropout<T>(Tensor<T> input, double dropoutRate, bool training, out Tensor<T> mask)
     {
         if (IsTapeActive<T>()) return base.Dropout(input, dropoutRate, training, out mask);
+        if (Compilation.GraphMode.IsActive) return base.Dropout(input, dropoutRate, training, out mask);
         if (!TryGetBackend(out var backend) || !training)
             return base.Dropout(input, dropoutRate, training, out mask);
 

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -5472,6 +5472,26 @@ public interface IEngine
         where TIndex : unmanaged;
 
     /// <summary>
+    /// AiDotNet#1331 variant of <see cref="TensorEmbeddingLookup{TValue, TIndex}"/> that takes
+    /// indices as a <see cref="Tensor{T}"/> of the SAME numeric type as <paramref name="embeddings"/>.
+    /// Indices are converted to integers (via rounding) at the moment of read — under
+    /// <see cref="Compilation.GraphMode"/> this happens on every <c>plan.Step()</c> replay, so a
+    /// compiled training plan that updates the captured float-input tensor's data in place
+    /// (the canonical multi-batch <c>Train(input_k, target_k)</c> pattern) will see fresh
+    /// integer indices on every step. The standard <c>TensorEmbeddingLookup&lt;TValue, TIndex&gt;</c>
+    /// snapshots indices at trace time and is therefore unsafe for that pattern when the
+    /// indices tensor itself isn't a graph-tracked leaf.
+    /// </summary>
+    /// <typeparam name="T">Numeric type of embeddings and float-indices.</typeparam>
+    /// <param name="embeddings">Embedding table of shape [vocab_size, embedding_dim].</param>
+    /// <param name="floatIndices">Index tensor whose values are interpreted as integers
+    /// after rounding. Captured by reference under GraphMode; the caller must keep the
+    /// tensor alive and update its data in place between plan.Step calls if dynamic
+    /// indices are required.</param>
+    /// <returns>Tensor of shape [*floatIndices.shape, embedding_dim] holding the gathered rows.</returns>
+    Tensor<T> TensorEmbeddingLookupFromFloatIndices<T>(Tensor<T> embeddings, Tensor<T> floatIndices);
+
+    /// <summary>
     /// Performs embedding lookup backward pass - scatters gradients back to embedding table.
     /// </summary>
     /// <typeparam name="TValue">The numeric type of gradient and embedding values.</typeparam>

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiMatMulFusedAdamParamUpdateTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiMatMulFusedAdamParamUpdateTests.cs
@@ -197,6 +197,234 @@ public class MultiMatMulFusedAdamParamUpdateTests
     }
 
     /// <summary>
+    /// AiDotNet#1331 buffer-aliasing repro: mirrors the EXACT compiled-plan
+    /// forward-step chain observed in the Transformer trace —
+    /// FusedLinear [4,32] → Reshape [1,4,32] → Reshape [1,4,32] (etc.) →
+    /// LayerNorm. Reads back the LayerNorm's INPUT tensor data immediately
+    /// before the LayerNorm forward step runs and asserts it's NON-ZERO
+    /// (i.e. the upstream FusedLinear's compiled forward DID write to the
+    /// backing array LayerNorm reads from). If the buffer-aliasing bug is
+    /// in Tensors, this test reproduces the L2=0 fingerprint from the
+    /// Transformer trace in isolation.
+    /// </summary>
+    [Fact]
+    public void FusedLinear_Reshape_Reshape_LayerNorm_InputBufferMustPropagate()
+    {
+        var engine = new CpuEngine();
+        const int batch = 1, seqLen = 4, dIn = 8, dHidden = 32;
+
+        var input = FilledRand(new[] { batch, seqLen, dIn }, seed: 101);
+        var W = FilledRand(new[] { dIn, dHidden }, seed: 102);
+        var b = FilledRand(new[] { dHidden }, seed: 103);
+        var gamma = FilledRand(new[] { dHidden }, seed: 104);
+        var beta  = FilledRand(new[] { dHidden }, seed: 105);
+        for (int i = 0; i < gamma.Length; i++) gamma[i] = gamma[i] + 1f;
+
+        // Track the LayerNorm's input ref and its observed L2 at forward time.
+        // The probe lambda runs INSIDE the lazy execute callback chain — it
+        // observes the tensor that the LayerNorm's forward step sees.
+        Tensor<float>? layerNormInputRef = null;
+        double layerNormInputL2AtForwardTime = -1;
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            // Flatten rank-3 → rank-2 for FusedLinear (DenseLayer's pattern).
+            var flat = engine.Reshape(input, new[] { batch * seqLen, dIn });
+            var z = engine.FusedLinear(flat, W, b, FusedActivationType.None);
+            // Reshape back to rank-3 (DenseLayer's pattern again).
+            var rank3 = engine.Reshape(z, new[] { batch, seqLen, dHidden });
+            // Second reshape: identity reshape (no-op) to mimic the Transformer
+            // chain having multiple consecutive reshapes between FusedLinear
+            // and LayerNorm (the FWDSTEP dump showed 4 reshape ops between
+            // FusedLinear and LayerNorm).
+            var rank3b = engine.Reshape(rank3, new[] { batch, seqLen, dHidden });
+            layerNormInputRef = rank3b;
+
+            var normed = engine.LayerNorm(rank3b, gamma, beta, 1e-5, out _, out _);
+            engine.ReduceSum(normed, null);
+            plan = scope.CompileTraining(new[] { W, b, gamma, beta });
+        }
+
+        using (plan)
+        {
+            plan.Step();
+            // After forward replay, read the LayerNorm-input tensor's data.
+            double s = 0;
+            var sp = layerNormInputRef!.AsSpan();
+            for (int i = 0; i < sp.Length; i++) s += sp[i] * sp[i];
+            layerNormInputL2AtForwardTime = System.Math.Sqrt(s);
+            _output.WriteLine($"After plan.Step(): layerNormInput.L2 = {layerNormInputL2AtForwardTime:E6}");
+
+            // Sanity: input tensor data should be non-zero (FusedLinear+bias of
+            // random W,b on random input is overwhelmingly likely non-zero).
+            Assert.True(
+                layerNormInputL2AtForwardTime > 1e-6,
+                $"layerNormInputRef.AsSpan() L2 = {layerNormInputL2AtForwardTime:E6} after plan.Step(). " +
+                "The upstream FusedLinear's compiled forward did not write to the backing array " +
+                "that LayerNorm's input tensor reference reads from. This is AiDotNet#1331's deeper " +
+                "buffer-aliasing root cause: producer's step.OutputBuffer.GetDataArray() ≠ " +
+                "consumer's step.Inputs[i].GetDataArray() backing array.");
+        }
+    }
+
+    /// <summary>
+    /// Larger Transformer-shaped chain: embedding → multi-head projection
+    /// pattern (Reshape + Permute) → attention-like matmul + softmax →
+    /// Reshape back → LayerNorm. Tries to reproduce the buffer-aliasing
+    /// observed in the Transformer trace where LayerNorm's input ends up
+    /// L2=0 at plan.Step forward time.
+    /// </summary>
+    [Fact]
+    public void Embedding_MultiHeadShape_LayerNorm_InputBufferMustPropagate()
+    {
+        var engine = new CpuEngine();
+        const int batch = 1, seqLen = 4, vocab = 8, dModel = 32, numHeads = 4, dHead = 8;
+
+        var indices = new Tensor<int>(new[] { batch, seqLen });
+        indices[0, 0] = 0; indices[0, 1] = 2; indices[0, 2] = 4; indices[0, 3] = 6;
+
+        var E = FilledRand(new[] { vocab, dModel }, seed: 201);
+        var Wq = FilledRand(new[] { dModel, dModel }, seed: 202);
+        var Wk = FilledRand(new[] { dModel, dModel }, seed: 203);
+        var Wv = FilledRand(new[] { dModel, dModel }, seed: 204);
+        var Wo = FilledRand(new[] { dModel, dModel }, seed: 205);
+        var attBias = FilledRand(new[] { dModel }, seed: 206);
+        var gamma = FilledRand(new[] { dModel }, seed: 207);
+        var beta  = FilledRand(new[] { dModel }, seed: 208);
+        for (int i = 0; i < gamma.Length; i++) gamma[i] = gamma[i] + 1f;
+
+        Tensor<float>? layerNormInputRef = null;
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            // Embedding lookup → [batch, seqLen, dModel]
+            var emb = engine.TensorEmbeddingLookup<float, int>(E, indices);
+            // Flatten for projections
+            var flat = engine.Reshape(emb, new[] { batch * seqLen, dModel });
+            // Q, K, V projections
+            var q = engine.FusedLinear(flat, Wq, attBias, FusedActivationType.None);
+            var k = engine.FusedLinear(flat, Wk, attBias, FusedActivationType.None);
+            var v = engine.FusedLinear(flat, Wv, attBias, FusedActivationType.None);
+            // Reshape for multi-head: [batch*seqLen, dModel] -> [batch, seqLen, numHeads, dHead]
+            var qHeads = engine.Reshape(q, new[] { batch, seqLen, numHeads, dHead });
+            var kHeads = engine.Reshape(k, new[] { batch, seqLen, numHeads, dHead });
+            var vHeads = engine.Reshape(v, new[] { batch, seqLen, numHeads, dHead });
+            // Permute to [batch, numHeads, seqLen, dHead]
+            var qPerm = engine.TensorPermute(qHeads, new[] { 0, 2, 1, 3 });
+            var kPerm = engine.TensorPermute(kHeads, new[] { 0, 2, 1, 3 });
+            var vPerm = engine.TensorPermute(vHeads, new[] { 0, 2, 1, 3 });
+            // Reshape Q,K,V to [batch*numHeads, seqLen, dHead] for batched matmul
+            var qFlat = engine.Reshape(qPerm, new[] { batch * numHeads, seqLen, dHead });
+            var kFlat = engine.Reshape(kPerm, new[] { batch * numHeads, seqLen, dHead });
+            var vFlat = engine.Reshape(vPerm, new[] { batch * numHeads, seqLen, dHead });
+            // Attention scores: Q @ K^T  →  [batch*numHeads, seqLen, seqLen]
+            var kT = engine.TensorPermute(kFlat, new[] { 0, 2, 1 });
+            var scores = engine.TensorMatMul(qFlat, kT);
+            // Softmax over last axis
+            var attn = engine.Softmax(scores);
+            // Attended values: scores @ V  →  [batch*numHeads, seqLen, dHead]
+            var attended = engine.TensorMatMul(attn, vFlat);
+            // Reshape back to [batch, numHeads, seqLen, dHead]
+            var attendedShaped = engine.Reshape(attended, new[] { batch, numHeads, seqLen, dHead });
+            // Permute back to [batch, seqLen, numHeads, dHead]
+            var attendedPerm = engine.TensorPermute(attendedShaped, new[] { 0, 2, 1, 3 });
+            // Flatten multi-head: [batch, seqLen, dModel]
+            var attendedFlat = engine.Reshape(attendedPerm, new[] { batch, seqLen, dModel });
+            // Output projection: flatten → FusedLinear → reshape
+            var attendedFlat2D = engine.Reshape(attendedFlat, new[] { batch * seqLen, dModel });
+            var attnOut2D = engine.FusedLinear(attendedFlat2D, Wo, attBias, FusedActivationType.None);
+            var attnOut = engine.Reshape(attnOut2D, new[] { batch, seqLen, dModel });
+            layerNormInputRef = attnOut;
+
+            var normed = engine.LayerNorm(attnOut, gamma, beta, 1e-5, out _, out _);
+            engine.ReduceSum(normed, null);
+            plan = scope.CompileTraining(new[] { E, Wq, Wk, Wv, Wo, attBias, gamma, beta });
+        }
+
+        using (plan)
+        {
+            plan.Step();
+            double s = 0;
+            var sp = layerNormInputRef!.AsSpan();
+            for (int i = 0; i < sp.Length; i++) s += sp[i] * sp[i];
+            double l2 = System.Math.Sqrt(s);
+            _output.WriteLine($"After plan.Step(): layerNormInput.L2 = {l2:E6}");
+
+            Assert.True(
+                l2 > 1e-6,
+                $"layerNormInputRef.AsSpan() L2 = {l2:E6} after plan.Step(). " +
+                "Upstream attention chain didn't propagate data to the LayerNorm input tensor. " +
+                "Buffer-aliasing bug in compiled-plan forward.");
+        }
+    }
+
+    /// <summary>
+    /// Direct repro of the Transformer trace pattern:
+    /// FusedLinear [4,32] → Reshape [1,4,32] x 2 → LayerNorm.
+    /// Plus a Multiply downstream (which the trace showed at FWDSTEP 13,14
+    /// after LayerNorm — residual or scale). Try inserting an Add between
+    /// FusedLinear and LayerNorm — the residual connection — that uses
+    /// TensorBroadcastAdd or TensorAdd, since the Transformer's residual
+    /// path goes: MHA_out + input → LayerNorm.
+    /// </summary>
+    [Fact]
+    public void Embedding_FusedLinear_Residual_LayerNorm_InputBufferMustPropagate()
+    {
+        var engine = new CpuEngine();
+        const int batch = 1, seqLen = 4, vocab = 8, dModel = 32;
+
+        var indices = new Tensor<int>(new[] { batch, seqLen });
+        indices[0, 0] = 0; indices[0, 1] = 2; indices[0, 2] = 4; indices[0, 3] = 6;
+
+        var E = FilledRand(new[] { vocab, dModel }, seed: 301);
+        var W = FilledRand(new[] { dModel, dModel }, seed: 302);
+        var b = FilledRand(new[] { dModel }, seed: 303);
+        var gamma = FilledRand(new[] { dModel }, seed: 304);
+        var beta  = FilledRand(new[] { dModel }, seed: 305);
+        for (int i = 0; i < gamma.Length; i++) gamma[i] = gamma[i] + 1f;
+
+        Tensor<float>? layerNormInputRef = null;
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var emb = engine.TensorEmbeddingLookup<float, int>(E, indices);
+            // Reshape rank-3 → rank-2 for FusedLinear
+            var emb2D = engine.Reshape(emb, new[] { batch * seqLen, dModel });
+            // FusedLinear (simulates MHA's output projection)
+            var attn2D = engine.FusedLinear(emb2D, W, b, FusedActivationType.None);
+            // Reshape back to rank-3
+            var attn3D = engine.Reshape(attn2D, new[] { batch, seqLen, dModel });
+            // Reshape original embedding back too (residual branch)
+            var emb3D = engine.Reshape(emb2D, new[] { batch, seqLen, dModel });
+            // Residual add (RANK-3 + RANK-3)
+            var residual = engine.TensorAdd(attn3D, emb3D);
+            layerNormInputRef = residual;
+
+            var normed = engine.LayerNorm(residual, gamma, beta, 1e-5, out _, out _);
+            engine.ReduceSum(normed, null);
+            plan = scope.CompileTraining(new[] { E, W, b, gamma, beta });
+        }
+
+        using (plan)
+        {
+            plan.Step();
+            double s = 0;
+            var sp = layerNormInputRef!.AsSpan();
+            for (int i = 0; i < sp.Length; i++) s += sp[i] * sp[i];
+            double l2 = System.Math.Sqrt(s);
+            _output.WriteLine($"After plan.Step(): residual.L2 = {l2:E6}");
+
+            Assert.True(
+                l2 > 1e-6,
+                $"residual.AsSpan() L2 = {l2:E6} after plan.Step(). " +
+                "The TensorAdd (residual) didn't write to LayerNorm's input backing array.");
+        }
+    }
+
+    /// <summary>
     /// Mirrors what AiDotNet's <c>DenseLayer.Forward</c> does on a rank-3
     /// [batch, seq, features] input: flatten via Reshape, FusedLinear,
     /// Reshape back. Two stacked DenseLayer-style passes. If the Reshape

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiMatMulFusedAdamParamUpdateTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiMatMulFusedAdamParamUpdateTests.cs
@@ -1,0 +1,417 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// Reproduces the AiDotNet#1331 bug isolated to Tensors: in a multi-MatMul
+/// graph (e.g. two stacked Dense layers, which is what every Transformer
+/// FFN block boils down to) <c>plan.ConfigureOptimizer(Adam) + plan.Step()</c>
+/// updates ONLY the additive bias parameters near the output. The 2D weight
+/// matrices remain bit-identical after Step, even when the same forward+loss
+/// graph trained through the eager <c>TapeTrainingStep</c> pulls non-zero
+/// gradients out of all of them.
+///
+/// <para>The bug surfaces when there is more than one MatMul in the graph
+/// AND the upstream MatMul's W is a leaf parameter. The downstream MatMul's
+/// backward writes dL/dY_downstream into the leaf bias correctly (since
+/// bias backward = sum(dY)), but dL/dW_upstream needs to flow back through
+/// the downstream MatMul's input-side backward to materialise dL/dY_upstream,
+/// and that chain dies inside the compiled-plan backward construction.</para>
+///
+/// <para>These tests pin the contract: every leaf parameter registered with
+/// <c>CompileTraining</c> must have a non-zero L2(Δ) after one Adam step on
+/// a graph whose eager backward produces non-zero gradients for all of them.</para>
+/// </summary>
+public class MultiMatMulFusedAdamParamUpdateTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public MultiMatMulFusedAdamParamUpdateTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    private static Tensor<float> FilledRand(int[] shape, int seed)
+    {
+        var t = new Tensor<float>(shape);
+        var rng = new System.Random(seed);
+        for (int i = 0; i < t.Length; i++) t[i] = (float)((rng.NextDouble() - 0.5) * 0.2);
+        return t;
+    }
+
+    private static double L2Delta(float[] before, float[] after)
+    {
+        double ss = 0;
+        for (int i = 0; i < before.Length; i++)
+        {
+            double d = after[i] - before[i];
+            ss += d * d;
+        }
+        return System.Math.Sqrt(ss);
+    }
+
+    /// <summary>
+    /// Two stacked MatMuls (the Dense → ReLU → Dense pattern) with bias adds
+    /// at each layer. After ConfigureOptimizer(Adam) + Step, both weight
+    /// matrices AND both biases must show non-zero updates. The pre-existing
+    /// single-MatMul test <c>ConfigureOptimizer_AdamFloat_…</c> only exercises
+    /// the bias side; this one isolates the multi-matmul backward chain.
+    /// </summary>
+    [Fact]
+    public void TwoMatMulChain_AdamStep_AllFourParamsMustMove()
+    {
+        var engine = new CpuEngine();
+
+        const int batch = 4, dIn = 8, dHidden = 6, dOut = 3;
+        var input = FilledRand(new[] { batch, dIn }, seed: 11);
+        var W1 = FilledRand(new[] { dIn, dHidden }, seed: 12);
+        var b1 = FilledRand(new[] { dHidden }, seed: 13);
+        var W2 = FilledRand(new[] { dHidden, dOut }, seed: 14);
+        var b2 = FilledRand(new[] { dOut }, seed: 15);
+
+        var beforeW1 = W1.GetDataArray().AsSpan().ToArray();
+        var beforeB1 = b1.GetDataArray().AsSpan().ToArray();
+        var beforeW2 = W2.GetDataArray().AsSpan().ToArray();
+        var beforeB2 = b2.GetDataArray().AsSpan().ToArray();
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            // Layer 1: hidden = input @ W1 + b1   (bias broadcast over batch)
+            var z1 = engine.TensorMatMul(input, W1);
+            var h1 = engine.TensorBroadcastAdd(z1, b1);
+            // Layer 2: logits = h1 @ W2 + b2
+            var z2 = engine.TensorMatMul(h1, W2);
+            var logits = engine.TensorBroadcastAdd(z2, b2);
+            // Loss = sum(logits) — gradient flow check; not a real loss but
+            // produces non-zero dL/dY everywhere, which is all the backward
+            // chain needs to test parameter updates.
+            engine.ReduceSum(logits, null);
+            plan = scope.CompileTraining(new[] { W1, b1, W2, b2 });
+        }
+
+        using (plan)
+        {
+            plan.ConfigureOptimizer(
+                OptimizerType.Adam,
+                learningRate: 0.01f,
+                beta1: 0.9f,
+                beta2: 0.999f,
+                eps: 1e-8f,
+                weightDecay: 0f);
+            plan.Step();
+
+            double dW1 = L2Delta(beforeW1, W1.GetDataArray().AsSpan().ToArray());
+            double dB1 = L2Delta(beforeB1, b1.GetDataArray().AsSpan().ToArray());
+            double dW2 = L2Delta(beforeW2, W2.GetDataArray().AsSpan().ToArray());
+            double dB2 = L2Delta(beforeB2, b2.GetDataArray().AsSpan().ToArray());
+
+            _output.WriteLine($"L2(ΔW1)={dW1:E6}  L2(Δb1)={dB1:E6}  L2(ΔW2)={dW2:E6}  L2(Δb2)={dB2:E6}");
+
+            // dY/db = ones for every output position → bias gradient is always
+            // non-zero. If b1 or b2 didn't move, the backward chain is broken
+            // even for the easiest case.
+            Assert.True(dB1 > 1e-7, $"b1 did not move (L2(Δ)={dB1:E6}). Bias backward path is broken.");
+            Assert.True(dB2 > 1e-7, $"b2 did not move (L2(Δ)={dB2:E6}). Output bias backward path is broken.");
+
+            // dY/dW2 = h1ᵀ @ dY = non-zero because h1 is non-zero. The downstream
+            // weight matrix should always update.
+            Assert.True(dW2 > 1e-7, $"W2 did not move (L2(Δ)={dW2:E6}). Downstream MatMul weight backward is broken.");
+
+            // The bug fingerprint: dW1 should also be non-zero because
+            // dY/dW1 = inputᵀ @ dL/dh1, where dL/dh1 = dL/dY_logits @ W2ᵀ.
+            // Pre-fix this stayed at zero — the chain stopped at the
+            // downstream MatMul's input-side backward.
+            Assert.True(
+                dW1 > 1e-7,
+                $"W1 did not move (L2(Δ)={dW1:E6}). The upstream MatMul's weight gradient was dropped " +
+                "by the compiled-plan backward chain — this is AiDotNet#1331's root cause: " +
+                "MatMul backward's dL/dX propagation dies for non-leaf X, so the second-from-last " +
+                "weight matrix never gets dW = Xᵀ @ dY because dY (passed back from downstream) is zero.");
+        }
+    }
+
+    /// <summary>
+    /// Two stacked <see cref="IEngine.FusedLinear"/> ops (no activation) —
+    /// the exact code path AiDotNet's <c>DenseLayer.Forward</c> takes when
+    /// it routes through the fused-linear kernel. Same shapes as the
+    /// two-MatMul-chain test; the only difference is the op selection.
+    /// If MatMul+BroadcastAdd works but FusedLinear stacking doesn't, the
+    /// bug is in <c>FusedLinearWithActivationBackward</c>'s graph plumbing.
+    /// </summary>
+    [Fact]
+    public void TwoFusedLinearChain_AdamStep_AllFourParamsMustMove()
+    {
+        var engine = new CpuEngine();
+
+        const int batch = 4, dIn = 8, dHidden = 6, dOut = 3;
+        var input = FilledRand(new[] { batch, dIn }, seed: 31);
+        var W1 = FilledRand(new[] { dIn, dHidden }, seed: 32);
+        var b1 = FilledRand(new[] { dHidden }, seed: 33);
+        var W2 = FilledRand(new[] { dHidden, dOut }, seed: 34);
+        var b2 = FilledRand(new[] { dOut }, seed: 35);
+
+        var beforeW1 = W1.GetDataArray().AsSpan().ToArray();
+        var beforeB1 = b1.GetDataArray().AsSpan().ToArray();
+        var beforeW2 = W2.GetDataArray().AsSpan().ToArray();
+        var beforeB2 = b2.GetDataArray().AsSpan().ToArray();
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var h1 = engine.FusedLinear(input, W1, b1, FusedActivationType.None);
+            var logits = engine.FusedLinear(h1, W2, b2, FusedActivationType.None);
+            engine.ReduceSum(logits, null);
+            plan = scope.CompileTraining(new[] { W1, b1, W2, b2 });
+        }
+
+        using (plan)
+        {
+            plan.ConfigureOptimizer(
+                OptimizerType.Adam,
+                learningRate: 0.01f,
+                beta1: 0.9f,
+                beta2: 0.999f,
+                eps: 1e-8f,
+                weightDecay: 0f);
+            plan.Step();
+
+            double dW1 = L2Delta(beforeW1, W1.GetDataArray().AsSpan().ToArray());
+            double dB1 = L2Delta(beforeB1, b1.GetDataArray().AsSpan().ToArray());
+            double dW2 = L2Delta(beforeW2, W2.GetDataArray().AsSpan().ToArray());
+            double dB2 = L2Delta(beforeB2, b2.GetDataArray().AsSpan().ToArray());
+
+            _output.WriteLine($"L2(ΔW1)={dW1:E6}  L2(Δb1)={dB1:E6}  L2(ΔW2)={dW2:E6}  L2(Δb2)={dB2:E6}");
+
+            Assert.True(dB2 > 1e-7, $"b2 stuck (L2={dB2:E6}) — output bias backward broken.");
+            Assert.True(dW2 > 1e-7, $"W2 stuck (L2={dW2:E6}) — output weight backward broken.");
+            Assert.True(dB1 > 1e-7, $"b1 stuck (L2={dB1:E6}) — first-layer bias backward broken.");
+            Assert.True(dW1 > 1e-7,
+                $"W1 stuck (L2={dW1:E6}) — first-layer weight backward broken. This is the AiDotNet#1331 " +
+                "fingerprint: FusedLinear's compiled backward chain dies at the upstream weight matrix.");
+        }
+    }
+
+    /// <summary>
+    /// Mirrors what AiDotNet's <c>DenseLayer.Forward</c> does on a rank-3
+    /// [batch, seq, features] input: flatten via Reshape, FusedLinear,
+    /// Reshape back. Two stacked DenseLayer-style passes. If the Reshape
+    /// op around FusedLinear corrupts the compiled-plan backward chain,
+    /// upstream parameters stay stuck.
+    /// </summary>
+    [Fact]
+    public void TwoFusedLinearChain_WithReshapeFlatten_AllFourParamsMustMove()
+    {
+        var engine = new CpuEngine();
+
+        const int batch = 1, seqLen = 4, dIn = 8, dHidden = 6, dOut = 3;
+        var input = FilledRand(new[] { batch, seqLen, dIn }, seed: 41);
+        var W1 = FilledRand(new[] { dIn, dHidden }, seed: 42);
+        var b1 = FilledRand(new[] { dHidden }, seed: 43);
+        var W2 = FilledRand(new[] { dHidden, dOut }, seed: 44);
+        var b2 = FilledRand(new[] { dOut }, seed: 45);
+
+        var beforeW1 = W1.GetDataArray().AsSpan().ToArray();
+        var beforeB1 = b1.GetDataArray().AsSpan().ToArray();
+        var beforeW2 = W2.GetDataArray().AsSpan().ToArray();
+        var beforeB2 = b2.GetDataArray().AsSpan().ToArray();
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            // Dense #1: flatten → FusedLinear → reshape back
+            var flat1 = engine.Reshape(input, new[] { batch * seqLen, dIn });
+            var z1 = engine.FusedLinear(flat1, W1, b1, FusedActivationType.None);
+            var h1 = engine.Reshape(z1, new[] { batch, seqLen, dHidden });
+
+            // Dense #2: flatten → FusedLinear → reshape back
+            var flat2 = engine.Reshape(h1, new[] { batch * seqLen, dHidden });
+            var z2 = engine.FusedLinear(flat2, W2, b2, FusedActivationType.None);
+            var logits = engine.Reshape(z2, new[] { batch, seqLen, dOut });
+
+            engine.ReduceSum(logits, null);
+            plan = scope.CompileTraining(new[] { W1, b1, W2, b2 });
+        }
+
+        using (plan)
+        {
+            plan.ConfigureOptimizer(
+                OptimizerType.Adam,
+                learningRate: 0.01f,
+                beta1: 0.9f,
+                beta2: 0.999f,
+                eps: 1e-8f,
+                weightDecay: 0f);
+            plan.Step();
+
+            double dW1 = L2Delta(beforeW1, W1.GetDataArray().AsSpan().ToArray());
+            double dB1 = L2Delta(beforeB1, b1.GetDataArray().AsSpan().ToArray());
+            double dW2 = L2Delta(beforeW2, W2.GetDataArray().AsSpan().ToArray());
+            double dB2 = L2Delta(beforeB2, b2.GetDataArray().AsSpan().ToArray());
+
+            _output.WriteLine($"L2(ΔW1)={dW1:E6}  L2(Δb1)={dB1:E6}  L2(ΔW2)={dW2:E6}  L2(Δb2)={dB2:E6}");
+
+            Assert.True(dB2 > 1e-7, $"b2 stuck (L2={dB2:E6})");
+            Assert.True(dW2 > 1e-7, $"W2 stuck (L2={dW2:E6})");
+            Assert.True(dB1 > 1e-7, $"b1 stuck (L2={dB1:E6})");
+            Assert.True(dW1 > 1e-7,
+                $"W1 stuck (L2={dW1:E6}) — Reshape around FusedLinear is corrupting the backward chain.");
+        }
+    }
+
+    /// <summary>
+    /// AiDotNet#1331 reproduction: mirrors the Transformer-byte-LM forward
+    /// path from EmbeddingLookup through two FusedLinear layers (with
+    /// reshape-flatten + reshape-back wrappers, as DenseLayer does) to
+    /// ReduceSum loss. All six leaf params (embedding + 2× (W, b)) must
+    /// move after a single Adam step. The AiDotNet Transformer diagnostic
+    /// shows W params stuck and embedding stuck under this same op pattern;
+    /// if this Tensors-only test passes, the bug is something else (likely
+    /// process-shared state from a preceding inference call).
+    /// </summary>
+    [Fact]
+    public void EmbeddingLookup_TwoFusedLinear_Chain_AllParamsMustMove()
+    {
+        var engine = new CpuEngine();
+
+        const int batch = 1, seqLen = 4, vocab = 8, embDim = 32, dHidden = 24, dOut = 8;
+
+        var indices = new Tensor<int>(new[] { batch, seqLen });
+        indices[0, 0] = 0; indices[0, 1] = 2; indices[0, 2] = 4; indices[0, 3] = 6;
+
+        var E = FilledRand(new[] { vocab, embDim }, seed: 51);
+        var W1 = FilledRand(new[] { embDim, dHidden }, seed: 52);
+        var b1 = FilledRand(new[] { dHidden }, seed: 53);
+        var W2 = FilledRand(new[] { dHidden, dOut }, seed: 54);
+        var b2 = FilledRand(new[] { dOut }, seed: 55);
+
+        var beforeE = E.GetDataArray().AsSpan().ToArray();
+        var beforeW1 = W1.GetDataArray().AsSpan().ToArray();
+        var beforeB1 = b1.GetDataArray().AsSpan().ToArray();
+        var beforeW2 = W2.GetDataArray().AsSpan().ToArray();
+        var beforeB2 = b2.GetDataArray().AsSpan().ToArray();
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            // EmbeddingLookup → [batch, seqLen, embDim]
+            var emb = engine.TensorEmbeddingLookup<float, int>(E, indices);
+            var emb3D = engine.Reshape(emb, new[] { batch, seqLen, embDim });
+
+            // Dense #1: flatten → FusedLinear → reshape back
+            var flat1 = engine.Reshape(emb3D, new[] { batch * seqLen, embDim });
+            var z1 = engine.FusedLinear(flat1, W1, b1, FusedActivationType.None);
+            var h1 = engine.Reshape(z1, new[] { batch, seqLen, dHidden });
+
+            // Dense #2: flatten → FusedLinear → reshape back (the "head")
+            var flat2 = engine.Reshape(h1, new[] { batch * seqLen, dHidden });
+            var z2 = engine.FusedLinear(flat2, W2, b2, FusedActivationType.None);
+            var logits = engine.Reshape(z2, new[] { batch, seqLen, dOut });
+
+            engine.ReduceSum(logits, null);
+            plan = scope.CompileTraining(new[] { E, W1, b1, W2, b2 });
+        }
+
+        using (plan)
+        {
+            plan.ConfigureOptimizer(
+                OptimizerType.Adam,
+                learningRate: 0.01f,
+                beta1: 0.9f,
+                beta2: 0.999f,
+                eps: 1e-8f,
+                weightDecay: 0f);
+            plan.Step();
+
+            double dE = L2Delta(beforeE, E.GetDataArray().AsSpan().ToArray());
+            double dW1 = L2Delta(beforeW1, W1.GetDataArray().AsSpan().ToArray());
+            double dB1 = L2Delta(beforeB1, b1.GetDataArray().AsSpan().ToArray());
+            double dW2 = L2Delta(beforeW2, W2.GetDataArray().AsSpan().ToArray());
+            double dB2 = L2Delta(beforeB2, b2.GetDataArray().AsSpan().ToArray());
+
+            _output.WriteLine(
+                $"L2(ΔE)={dE:E6}  L2(ΔW1)={dW1:E6}  L2(Δb1)={dB1:E6}  " +
+                $"L2(ΔW2)={dW2:E6}  L2(Δb2)={dB2:E6}");
+
+            Assert.True(dB2 > 1e-7, $"b2 stuck (L2={dB2:E6})");
+            Assert.True(dW2 > 1e-7, $"W2 stuck (L2={dW2:E6})");
+            Assert.True(dB1 > 1e-7, $"b1 stuck (L2={dB1:E6})");
+            Assert.True(dW1 > 1e-7, $"W1 stuck (L2={dW1:E6})");
+            Assert.True(dE > 1e-7,  $"E stuck (L2={dE:E6}) — embedding gradient dropped despite v0.80.2 fix.");
+        }
+    }
+
+    /// <summary>
+    /// Three-MatMul chain (Dense → Dense → Dense head). All six leaf params
+    /// (three Ws, three bs) must move. Pre-fix only the last layer's bias
+    /// (and possibly the last weight) moves; everything upstream stays stuck.
+    /// </summary>
+    [Fact]
+    public void ThreeMatMulChain_AdamStep_AllSixParamsMustMove()
+    {
+        var engine = new CpuEngine();
+
+        const int batch = 4, dIn = 8, d1 = 6, d2 = 5, dOut = 3;
+        var input = FilledRand(new[] { batch, dIn }, seed: 21);
+        var W1 = FilledRand(new[] { dIn, d1 }, seed: 22);
+        var b1 = FilledRand(new[] { d1 }, seed: 23);
+        var W2 = FilledRand(new[] { d1, d2 }, seed: 24);
+        var b2 = FilledRand(new[] { d2 }, seed: 25);
+        var W3 = FilledRand(new[] { d2, dOut }, seed: 26);
+        var b3 = FilledRand(new[] { dOut }, seed: 27);
+
+        var beforeW1 = W1.GetDataArray().AsSpan().ToArray();
+        var beforeB1 = b1.GetDataArray().AsSpan().ToArray();
+        var beforeW2 = W2.GetDataArray().AsSpan().ToArray();
+        var beforeB2 = b2.GetDataArray().AsSpan().ToArray();
+        var beforeW3 = W3.GetDataArray().AsSpan().ToArray();
+        var beforeB3 = b3.GetDataArray().AsSpan().ToArray();
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var h1 = engine.TensorBroadcastAdd(engine.TensorMatMul(input, W1), b1);
+            var h2 = engine.TensorBroadcastAdd(engine.TensorMatMul(h1, W2), b2);
+            var logits = engine.TensorBroadcastAdd(engine.TensorMatMul(h2, W3), b3);
+            engine.ReduceSum(logits, null);
+            plan = scope.CompileTraining(new[] { W1, b1, W2, b2, W3, b3 });
+        }
+
+        using (plan)
+        {
+            plan.ConfigureOptimizer(
+                OptimizerType.Adam,
+                learningRate: 0.01f,
+                beta1: 0.9f,
+                beta2: 0.999f,
+                eps: 1e-8f,
+                weightDecay: 0f);
+            plan.Step();
+
+            var deltas = new (string name, double l2)[]
+            {
+                ("W1", L2Delta(beforeW1, W1.GetDataArray().AsSpan().ToArray())),
+                ("b1", L2Delta(beforeB1, b1.GetDataArray().AsSpan().ToArray())),
+                ("W2", L2Delta(beforeW2, W2.GetDataArray().AsSpan().ToArray())),
+                ("b2", L2Delta(beforeB2, b2.GetDataArray().AsSpan().ToArray())),
+                ("W3", L2Delta(beforeW3, W3.GetDataArray().AsSpan().ToArray())),
+                ("b3", L2Delta(beforeB3, b3.GetDataArray().AsSpan().ToArray())),
+            };
+            foreach (var (name, l2) in deltas)
+            {
+                string verdict = l2 > 1e-7 ? "MOVED" : "STUCK";
+                _output.WriteLine($"  [{verdict}] {name}  L2(Δ)={l2:E6}");
+            }
+
+            foreach (var (name, l2) in deltas)
+            {
+                Assert.True(l2 > 1e-7, $"{name} did not move (L2(Δ)={l2:E6}). " +
+                    "Compiled-plan backward dropped this parameter's gradient.");
+            }
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiMatMulFusedAdamParamUpdateTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiMatMulFusedAdamParamUpdateTests.cs
@@ -269,6 +269,172 @@ public class MultiMatMulFusedAdamParamUpdateTests
     }
 
     /// <summary>
+    /// Multi-step regression: confirms the fused-Adam path produces gradients
+    /// that monotonically decrease loss across multiple plan.Step calls when
+    /// the graph contains ScaledDotProductAttention. A single-step test is
+    /// not enough — staleness in the saved attention-weights tensor or
+    /// reuse-after-Return on TensorAllocator-rented buffers manifest only on
+    /// step 2 and onwards, with loss drifting upward.
+    /// </summary>
+    [Fact]
+    public void SDPA_MultiStep_LossMustDecreaseMonotonically()
+    {
+        var engine = new CpuEngine();
+        const int batch = 1, seqLen = 4, dModel = 8, heads = 2, dHead = 4;
+
+        var input = FilledRand(new[] { batch, seqLen, dModel }, seed: 401);
+        var Wq = FilledRand(new[] { dModel, dModel }, seed: 402);
+        var Wk = FilledRand(new[] { dModel, dModel }, seed: 403);
+        var Wv = FilledRand(new[] { dModel, dModel }, seed: 404);
+        var bq = FilledRand(new[] { dModel }, seed: 405);
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var flat = engine.Reshape(input, new[] { batch * seqLen, dModel });
+            var q = engine.FusedLinear(flat, Wq, bq, FusedActivationType.None);
+            var k = engine.FusedLinear(flat, Wk, bq, FusedActivationType.None);
+            var v = engine.FusedLinear(flat, Wv, bq, FusedActivationType.None);
+            var qH = engine.Reshape(q, new[] { batch, seqLen, heads, dHead });
+            var kH = engine.Reshape(k, new[] { batch, seqLen, heads, dHead });
+            var vH = engine.Reshape(v, new[] { batch, seqLen, heads, dHead });
+            var qP = engine.TensorPermute(qH, new[] { 0, 2, 1, 3 });
+            var kP = engine.TensorPermute(kH, new[] { 0, 2, 1, 3 });
+            var vP = engine.TensorPermute(vH, new[] { 0, 2, 1, 3 });
+            var ctx = engine.ScaledDotProductAttention(qP, kP, vP, null, 1.0 / System.Math.Sqrt(dHead), out _);
+            engine.ReduceSum(ctx, null);
+            plan = scope.CompileTraining(new[] { Wq, Wk, Wv, bq });
+        }
+
+        using (plan)
+        {
+            plan.ConfigureOptimizer(
+                OptimizerType.Adam,
+                learningRate: 0.001f,
+                beta1: 0.9f,
+                beta2: 0.999f,
+                eps: 1e-8f,
+                weightDecay: 0f);
+
+            var losses = new System.Collections.Generic.List<float>();
+            for (int step = 0; step < 10; step++)
+            {
+                var lossOut = plan.Step();
+                float lossVal = lossOut.AsSpan()[0];
+                losses.Add(lossVal);
+            }
+
+            for (int i = 0; i < losses.Count; i++)
+                _output.WriteLine($"  step {i}: loss = {losses[i]:F6}");
+
+            // Loss should not explode upward — sum is unbounded above so the
+            // sign-of-direction is what matters. With LR=0.001 + Adam, the
+            // attention-output sum should monotonically decrease (or oscillate
+            // within a small band). A persistent upward drift indicates the
+            // SDPA savedState attention weights are stale or the gradient
+            // direction is consistently wrong.
+            float maxLoss = losses.Max();
+            float lastLoss = losses[^1];
+            float firstLoss = losses[0];
+            Assert.True(
+                lastLoss <= firstLoss + System.Math.Abs(firstLoss) * 0.1f,
+                $"Loss diverged upward: start={firstLoss:F4} end={lastLoss:F4} max={maxLoss:F4}. " +
+                "SDPA savedState attention-weights tensor likely has stale or reused backing across plan.Step calls.");
+        }
+    }
+
+    /// <summary>
+    /// AiDotNet#1331 root-cause repro: when the user-facing training loop
+    /// passes a DIFFERENT input tensor instance on each call (the canonical
+    /// PyTorch-style `model.Train(input_batch_k, target_batch_k)` pattern),
+    /// the cached compiled training plan must see the new data on every
+    /// plan.Step() — not the data from the first traced call.
+    ///
+    /// The bug class: <c>CompiledModelCache.GetOrCompileTraining</c> returns
+    /// the cached plan on shape-match WITHOUT calling <c>plan.SetInputs()</c>,
+    /// so the plan's captured input tensor (a reference to the FIRST input
+    /// it was traced with) is replayed forever. This is the diagnostic that
+    /// proves the Transformer #1331 divergence is INPUT-STALENESS, not
+    /// gradient-flow.
+    ///
+    /// Forward: y = sum(W @ x). With W constant and x changing in-place,
+    /// the loss value MUST change. If the plan ignores x updates, loss is
+    /// frozen at the first call's value.
+    /// </summary>
+    [Fact]
+    public void InputDataMustRefreshAcrossStep_NotFrozenAtCompileTime()
+    {
+        var engine = new CpuEngine();
+        const int batch = 1, dIn = 4, dOut = 2;
+
+        // SAME tensor reference reused across calls; only the data inside changes.
+        // This is the contract the Tensors compiled-plan API supports today —
+        // user must update the captured tensor's data in-place. The AiDotNet
+        // bug is that the higher-level Train() API creates a fresh Tensor<T>
+        // every call, so this contract is silently violated by the test
+        // pattern but observed only through wildly divergent loss.
+        var input = new Tensor<float>(new[] { batch, dIn });
+        for (int i = 0; i < input.Length; i++) input[i] = 1.0f;
+        var W = FilledRand(new[] { dIn, dOut }, seed: 501);
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var y = engine.FusedLinear(input, W, null, FusedActivationType.None);
+            engine.ReduceSum(y, null);
+            plan = scope.CompileTraining(new[] { W });
+        }
+
+        using (plan)
+        {
+            plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.0f);
+
+            // Step 1: input is all 1s. Loss = sum(1 @ W).
+            var loss1 = plan.Step().AsSpan()[0];
+            _output.WriteLine($"  step1 (input=1) loss = {loss1:F6}");
+
+            // Update input data IN-PLACE to all 2s. Plan should see new data.
+            for (int i = 0; i < input.Length; i++) input[i] = 2.0f;
+
+            var loss2 = plan.Step().AsSpan()[0];
+            _output.WriteLine($"  step2 (input=2) loss = {loss2:F6}");
+
+            // With LR=0, W doesn't change. So loss2 = 2 * loss1 (linear in input).
+            // If plan replays with stale input=1, loss2 == loss1 (BUG).
+            Assert.True(
+                System.Math.Abs(loss2 - 2 * loss1) < 1e-4,
+                $"In-place input update was NOT seen by plan.Step(): loss1={loss1:F4} loss2={loss2:F4}. " +
+                $"Expected loss2 ≈ 2 × loss1 ≈ {2*loss1:F4} (since LR=0 keeps W constant). " +
+                "Plan is replaying with frozen input data — AiDotNet#1331 root cause.");
+
+            // Now use a DIFFERENT Tensor<T> with same shape — the captured
+            // reference is still the original `input`, so the plan should
+            // NOT see this new tensor's data unless SetInputs is called.
+            var freshInput = new Tensor<float>(new[] { batch, dIn });
+            for (int i = 0; i < freshInput.Length; i++) freshInput[i] = 3.0f;
+
+            // Without SetInputs: plan still sees the original `input` (which holds 2s).
+            var lossWithoutSetInputs = plan.Step().AsSpan()[0];
+            _output.WriteLine($"  step3a (freshInput=3, NO SetInputs) loss = {lossWithoutSetInputs:F6}");
+
+            Assert.True(
+                System.Math.Abs(lossWithoutSetInputs - loss2) < 1e-4,
+                "Without SetInputs(), a fresh Tensor<T> instance is invisible to plan.Step — " +
+                "the plan's captured ref still points at the original input tensor.");
+
+            // With SetInputs: plan now sees freshInput's data (3s).
+            plan.SetInputs(new[] { freshInput });
+            var lossWithSetInputs = plan.Step().AsSpan()[0];
+            _output.WriteLine($"  step3b (freshInput=3, WITH SetInputs) loss = {lossWithSetInputs:F6}");
+
+            Assert.True(
+                System.Math.Abs(lossWithSetInputs - 3 * loss1) < 1e-4,
+                $"After SetInputs(freshInput): loss should be 3 × loss1 ≈ {3*loss1:F4}, got {lossWithSetInputs:F4}. " +
+                "SetInputs() must copy fresh data into the plan's captured input tensor.");
+        }
+    }
+
+    /// <summary>
     /// Larger Transformer-shaped chain: embedding → multi-head projection
     /// pattern (Reshape + Permute) → attention-like matmul + softmax →
     /// Reshape back → LayerNorm. Tries to reproduce the buffer-aliasing

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiMatMulFusedAdamParamUpdateTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiMatMulFusedAdamParamUpdateTests.cs
@@ -345,6 +345,150 @@ public class MultiMatMulFusedAdamParamUpdateTests
         }
     }
 
+    [Fact]
+    public void FusedLinearThenLayerNorm_GammaMustMove()
+    {
+        var engine = new CpuEngine();
+        const int batch = 4, dIn = 8, feat = 6;
+        var input = FilledRand(new[] { batch, dIn }, seed: 81);
+        var W = FilledRand(new[] { dIn, feat }, seed: 82);
+        var b = FilledRand(new[] { feat }, seed: 83);
+        var gamma = FilledRand(new[] { feat }, seed: 84);
+        var beta  = FilledRand(new[] { feat }, seed: 85);
+        for (int i = 0; i < gamma.Length; i++) gamma[i] = gamma[i] + 1f;
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var z = engine.FusedLinear(input, W, b, FusedActivationType.None);
+            var normed = engine.LayerNorm(z, gamma, beta, 1e-5, out _, out _);
+            engine.ReduceSum(normed, null);
+            plan = scope.CompileTraining(new[] { W, b, gamma, beta });
+        }
+
+        using (plan)
+        {
+            plan.Step();
+            string[] names = { "W", "b", "gamma", "beta" };
+            for (int i = 0; i < plan.Gradients.Length; i++)
+            {
+                var g = plan.Gradients[i];
+                if (g is null) { _output.WriteLine($"  gradient[{i}] {names[i]} = NULL"); continue; }
+                double gL2 = 0; var gSpan = g.AsSpan();
+                for (int k = 0; k < gSpan.Length; k++) gL2 += gSpan[k] * gSpan[k];
+                gL2 = System.Math.Sqrt(gL2);
+                _output.WriteLine($"  gradient[{i}] {names[i]} L2={gL2:E6}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Minimal isolation: a single LayerNorm op with gamma + beta as
+    /// trainable params. If the bug reproduces here, the entire LayerNorm
+    /// compiled-plan backward is the suspect, not the surrounding chain.
+    /// </summary>
+    [Fact]
+    public void LayerNormOnly_BothGammaAndBetaMustMove()
+    {
+        var engine = new CpuEngine();
+        const int batch = 4, feat = 6;
+        var input = FilledRand(new[] { batch, feat }, seed: 71);
+        var gamma = FilledRand(new[] { feat }, seed: 72);
+        var beta  = FilledRand(new[] { feat }, seed: 73);
+        for (int i = 0; i < gamma.Length; i++) gamma[i] = gamma[i] + 1f;
+
+        var beforeGamma = gamma.GetDataArray().AsSpan().ToArray();
+        var beforeBeta  = beta .GetDataArray().AsSpan().ToArray();
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var normed = engine.LayerNorm(input, gamma, beta, 1e-5, out _, out _);
+            engine.ReduceSum(normed, null);
+            plan = scope.CompileTraining(new[] { gamma, beta });
+        }
+
+        using (plan)
+        {
+            plan.Step();
+            for (int i = 0; i < plan.Gradients.Length; i++)
+            {
+                var g = plan.Gradients[i];
+                if (g is null) { _output.WriteLine($"  gradient[{i}] = NULL"); continue; }
+                double gL2 = 0; var gSpan = g.AsSpan();
+                for (int k = 0; k < gSpan.Length; k++) gL2 += gSpan[k] * gSpan[k];
+                gL2 = System.Math.Sqrt(gL2);
+                _output.WriteLine($"  gradient[{i}] L2={gL2:E6}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// AiDotNet#1331 root-cause test: mirrors a transformer FFN block —
+    /// FusedLinear → LayerNorm → FusedLinear → ReduceSum. In the original
+    /// transformer diagnostic, every LayerNorm gain (γ) was stuck and
+    /// everything upstream of the last LayerNorm was stuck. If LayerNorm's
+    /// compiled backward drops dL/dγ or dL/dInput, this test will reproduce
+    /// the bug: upstream W1/b1 + gamma all stuck while only the LN beta
+    /// and downstream W2/b2 move.
+    /// </summary>
+    [Fact]
+    public void LayerNormBetweenFusedLinears_AllParamsMustMove()
+    {
+        var engine = new CpuEngine();
+
+        const int batch = 4, dIn = 8, dHidden = 6, dOut = 3;
+        var input = FilledRand(new[] { batch, dIn }, seed: 61);
+        var W1 = FilledRand(new[] { dIn, dHidden }, seed: 62);
+        var b1 = FilledRand(new[] { dHidden }, seed: 63);
+        var gamma = FilledRand(new[] { dHidden }, seed: 64);
+        var beta = FilledRand(new[] { dHidden }, seed: 65);
+        var W2 = FilledRand(new[] { dHidden, dOut }, seed: 66);
+        var b2 = FilledRand(new[] { dOut }, seed: 67);
+
+        // Bias gamma above zero so the layer is well-conditioned for normalization.
+        for (int i = 0; i < gamma.Length; i++) gamma[i] = gamma[i] + 1f;
+
+        var beforeW1 = W1.GetDataArray().AsSpan().ToArray();
+        var beforeB1 = b1.GetDataArray().AsSpan().ToArray();
+        var beforeGamma = gamma.GetDataArray().AsSpan().ToArray();
+        var beforeBeta = beta.GetDataArray().AsSpan().ToArray();
+        var beforeW2 = W2.GetDataArray().AsSpan().ToArray();
+        var beforeB2 = b2.GetDataArray().AsSpan().ToArray();
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var z1 = engine.FusedLinear(input, W1, b1, FusedActivationType.None);
+            var normed = engine.LayerNorm(z1, gamma, beta, 1e-5, out _, out _);
+            var z2 = engine.FusedLinear(normed, W2, b2, FusedActivationType.None);
+            engine.ReduceSum(z2, null);
+            plan = scope.CompileTraining(new[] { W1, b1, gamma, beta, W2, b2 });
+        }
+
+        using (plan)
+        {
+            // Probe: call plan.Step() WITHOUT configuring the optimizer so we
+            // can inspect plan.Gradients directly. Then re-step with the optimizer.
+            plan.Step();
+            string[] names = { "W1", "b1", "gamma", "beta", "W2", "b2" };
+            for (int i = 0; i < plan.Gradients.Length; i++)
+            {
+                var g = plan.Gradients[i];
+                if (g is null)
+                {
+                    _output.WriteLine($"  gradient[{i}] {names[i]} = NULL");
+                    continue;
+                }
+                double gL2 = 0;
+                var gSpan = g.AsSpan();
+                for (int k = 0; k < gSpan.Length; k++) gL2 += gSpan[k] * gSpan[k];
+                gL2 = System.Math.Sqrt(gL2);
+                _output.WriteLine($"  gradient[{i}] {names[i]}  shape=[{string.Join(",", g.Shape.ToArray())}]  L2={gL2:E6}");
+            }
+        }
+    }
+
     /// <summary>
     /// Three-MatMul chain (Dense → Dense → Dense head). All six leaf params
     /// (three Ws, three bs) must move. Pre-fix only the last layer's bias

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiMatMulFusedAdamParamUpdateTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiMatMulFusedAdamParamUpdateTests.cs
@@ -585,6 +585,11 @@ public class MultiMatMulFusedAdamParamUpdateTests
         var beta  = FilledRand(new[] { feat }, seed: 85);
         for (int i = 0; i < gamma.Length; i++) gamma[i] = gamma[i] + 1f;
 
+        var beforeW     = W    .GetDataArray().AsSpan().ToArray();
+        var beforeB     = b    .GetDataArray().AsSpan().ToArray();
+        var beforeGamma = gamma.GetDataArray().AsSpan().ToArray();
+        var beforeBeta  = beta .GetDataArray().AsSpan().ToArray();
+
         ICompiledTrainingPlan<float> plan;
         using (var scope = GraphMode.Enable())
         {
@@ -596,17 +601,30 @@ public class MultiMatMulFusedAdamParamUpdateTests
 
         using (plan)
         {
+            plan.ConfigureOptimizer(
+                OptimizerType.Adam,
+                learningRate: 0.01f,
+                beta1: 0.9f,
+                beta2: 0.999f,
+                eps: 1e-8f,
+                weightDecay: 0f);
             plan.Step();
-            string[] names = { "W", "b", "gamma", "beta" };
-            for (int i = 0; i < plan.Gradients.Length; i++)
-            {
-                var g = plan.Gradients[i];
-                if (g is null) { _output.WriteLine($"  gradient[{i}] {names[i]} = NULL"); continue; }
-                double gL2 = 0; var gSpan = g.AsSpan();
-                for (int k = 0; k < gSpan.Length; k++) gL2 += gSpan[k] * gSpan[k];
-                gL2 = System.Math.Sqrt(gL2);
-                _output.WriteLine($"  gradient[{i}] {names[i]} L2={gL2:E6}");
-            }
+
+            double dW     = L2Delta(beforeW    , W    .GetDataArray().AsSpan().ToArray());
+            double dB     = L2Delta(beforeB    , b    .GetDataArray().AsSpan().ToArray());
+            double dGamma = L2Delta(beforeGamma, gamma.GetDataArray().AsSpan().ToArray());
+            double dBeta  = L2Delta(beforeBeta , beta .GetDataArray().AsSpan().ToArray());
+            _output.WriteLine($"L2(ΔW)={dW:E6}  L2(Δb)={dB:E6}  L2(Δγ)={dGamma:E6}  L2(Δβ)={dBeta:E6}");
+
+            // gamma is the canary for the AiDotNet#1331 fingerprint: pre-fix
+            // gradGamma was 0 because the LayerNorm savedState mean/variance
+            // were stale-from-compile-time zeros. Asserting γ moves is the
+            // direct regression check; W/b/β must also move because the loss
+            // routes through them.
+            Assert.True(dGamma > 1e-7, $"γ stuck (L2={dGamma:E6}) — LayerNorm savedState mean/variance is not being refreshed at plan.Step.");
+            Assert.True(dBeta  > 1e-7, $"β stuck (L2={dBeta:E6})");
+            Assert.True(dW     > 1e-7, $"W stuck (L2={dW:E6}) — gradient chain through LayerNorm's dL/dInput is broken.");
+            Assert.True(dB     > 1e-7, $"b stuck (L2={dB:E6})");
         }
     }
 
@@ -638,16 +656,24 @@ public class MultiMatMulFusedAdamParamUpdateTests
 
         using (plan)
         {
+            plan.ConfigureOptimizer(
+                OptimizerType.Adam,
+                learningRate: 0.01f,
+                beta1: 0.9f,
+                beta2: 0.999f,
+                eps: 1e-8f,
+                weightDecay: 0f);
             plan.Step();
-            for (int i = 0; i < plan.Gradients.Length; i++)
-            {
-                var g = plan.Gradients[i];
-                if (g is null) { _output.WriteLine($"  gradient[{i}] = NULL"); continue; }
-                double gL2 = 0; var gSpan = g.AsSpan();
-                for (int k = 0; k < gSpan.Length; k++) gL2 += gSpan[k] * gSpan[k];
-                gL2 = System.Math.Sqrt(gL2);
-                _output.WriteLine($"  gradient[{i}] L2={gL2:E6}");
-            }
+
+            double dGamma = L2Delta(beforeGamma, gamma.GetDataArray().AsSpan().ToArray());
+            double dBeta  = L2Delta(beforeBeta , beta .GetDataArray().AsSpan().ToArray());
+            _output.WriteLine($"L2(Δγ)={dGamma:E6}  L2(Δβ)={dBeta:E6}");
+
+            // Single-op LayerNorm baseline: both γ and β must update on the
+            // first Adam step. If γ doesn't move here, the AiDotNet#1331
+            // mean/variance refresh fix is broken even in the simplest case.
+            Assert.True(dGamma > 1e-7, $"γ stuck (L2={dGamma:E6})");
+            Assert.True(dBeta  > 1e-7, $"β stuck (L2={dBeta:E6})");
         }
     }
 
@@ -696,24 +722,35 @@ public class MultiMatMulFusedAdamParamUpdateTests
 
         using (plan)
         {
-            // Probe: call plan.Step() WITHOUT configuring the optimizer so we
-            // can inspect plan.Gradients directly. Then re-step with the optimizer.
+            plan.ConfigureOptimizer(
+                OptimizerType.Adam,
+                learningRate: 0.01f,
+                beta1: 0.9f,
+                beta2: 0.999f,
+                eps: 1e-8f,
+                weightDecay: 0f);
             plan.Step();
-            string[] names = { "W1", "b1", "gamma", "beta", "W2", "b2" };
-            for (int i = 0; i < plan.Gradients.Length; i++)
+
+            var deltas = new (string name, double l2)[]
             {
-                var g = plan.Gradients[i];
-                if (g is null)
-                {
-                    _output.WriteLine($"  gradient[{i}] {names[i]} = NULL");
-                    continue;
-                }
-                double gL2 = 0;
-                var gSpan = g.AsSpan();
-                for (int k = 0; k < gSpan.Length; k++) gL2 += gSpan[k] * gSpan[k];
-                gL2 = System.Math.Sqrt(gL2);
-                _output.WriteLine($"  gradient[{i}] {names[i]}  shape=[{string.Join(",", g.Shape.ToArray())}]  L2={gL2:E6}");
-            }
+                ("W1",    L2Delta(beforeW1   , W1   .GetDataArray().AsSpan().ToArray())),
+                ("b1",    L2Delta(beforeB1   , b1   .GetDataArray().AsSpan().ToArray())),
+                ("gamma", L2Delta(beforeGamma, gamma.GetDataArray().AsSpan().ToArray())),
+                ("beta",  L2Delta(beforeBeta , beta .GetDataArray().AsSpan().ToArray())),
+                ("W2",    L2Delta(beforeW2   , W2   .GetDataArray().AsSpan().ToArray())),
+                ("b2",    L2Delta(beforeB2   , b2   .GetDataArray().AsSpan().ToArray())),
+            };
+            foreach (var (name, l2) in deltas)
+                _output.WriteLine($"  [{(l2 > 1e-7 ? "MOVED" : "STUCK")}] {name}  L2(Δ)={l2:E6}");
+
+            // The exact AiDotNet#1331 fingerprint at the LayerNorm-sandwich
+            // pattern: pre-fix gradGamma=0 plus broken dL/dInput propagation
+            // froze W1, b1, γ AND left β/W2/b2 looking deceptively healthy.
+            // Every single leaf parameter MUST move on the first Adam step.
+            foreach (var (name, l2) in deltas)
+                Assert.True(l2 > 1e-7,
+                    $"{name} stuck (L2={l2:E6}). The LayerNorm savedState mean/variance " +
+                    "refresh fix (or its dL/dInput chain) regressed.");
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes the root cause of [ooples/AiDotNet#1331](https://github.com/ooples/AiDotNet/issues/1331) — \"Fused-compiled training plan drops gradients for 26/29 trainable params in standard Transformer\".

## Root cause

`engine.LayerNorm`'s GraphMode branch (CpuEngine.cs `LayerNorm`) temporarily disabled GraphMode and ran an eager `LayerNorm` to obtain mean/variance for the lazy node's `savedState`. **But the lazy input is uninitialized at compile time** — its data only gets written when the plan replays forward. So the compile-time eager call computed mean/variance from zero-init garbage, and those zero values stayed in `savedState` for the lifetime of the compiled plan. The lazy `execute` callback (`LayerNormFloatInto`) wrote only the forward output, never refreshing mean/variance.

At backward time, `engine.LayerNormBackward` (CPU or GPU) read the stale zero mean/variance against the real (fresh) input. The result was gradGamma = 0 and dL/dInput = 0 exactly. gradBeta survived because it depends only on grad_output (`db = sum(dY)`).

In a 2-encoder Transformer, that fingerprinted as: every LayerNorm γ stuck, β moved; every parameter upstream of any LayerNorm (embedding table, MHA W matrices, earlier Dense weights) stuck.

## Fix

The lazy `execute` callback now calls the out-param eager `LayerNorm` (returns fresh mean/variance) and copies them into the **same tensor instances** the `savedState` slot references. Backward reads the just-computed values for the current step's input. The previous `LayerNormFloatInto` fast-path is dropped here — it can be re-introduced once a write-through-to-output-AND-mean-AND-variance CPU overload exists. Correctness first.

## Regression tests

New file `tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiMatMulFusedAdamParamUpdateTests.cs` with 8 cases:

| Test | Purpose |
|---|---|
| TwoMatMulChain_AdamStep_AllFourParamsMustMove | Multi-MatMul + bias |
| ThreeMatMulChain_AdamStep_AllSixParamsMustMove | Deeper multi-MatMul chain |
| TwoFusedLinearChain_AdamStep_AllFourParamsMustMove | Stacked FusedLinear |
| TwoFusedLinearChain_WithReshapeFlatten_AllFourParamsMustMove | DenseLayer rank-3↔rank-2 pattern |
| EmbeddingLookup_TwoFusedLinear_Chain_AllParamsMustMove | EmbeddingLookup + FFN |
| LayerNormOnly_BothGammaAndBetaMustMove | Single-op LayerNorm baseline |
| FusedLinearThenLayerNorm_GammaMustMove | **Reproduces #1331 — failed before fix** |
| LayerNormBetweenFusedLinears_AllParamsMustMove | **Full sandwich shape — failed before fix** |

All 8 pass with this fix.

## No regressions

Broader Compilation + LayerNorm test scope (431 tests in those filters): 430 passed, 1 skipped (pre-existing), 0 failed.

## Closes
- ooples/AiDotNet#1331

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>