### PR TITLE
fix(#1341 [AiDotNet]): correct vjp seeding in GradientCheckpointing backward closure

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientCheckpointing.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientCheckpointing.cs
@@ -74,26 +74,80 @@ public static class GradientCheckpointing<T>
                 segmentInput,
                 (gradOutput, inputs, output, savedState, eng, grads) =>
                 {
-                    // RECOMPUTE: run the segment forward again WITH recording
-                    // so backward can flow through the ops
-                    using var recomputeTape = new GradientTape<T>();
+                    // RECOMPUTE: run the segment forward again WITH recording so
+                    // backward can flow through the ops. Use a fresh, NON-persistent
+                    // inner tape so the recomputed forward / backward do NOT
+                    // pollute the outer tape that's currently mid-backward, and so
+                    // each recompute step bypasses AutoTrainingCompiler's plan
+                    // cache (the compiler is keyed on tape-pattern signatures and
+                    // the compiled-plan replay path would otherwise try to attach
+                    // a CompiledBackwardGraph to the per-step throw-away tape,
+                    // which produces NullReferenceException in
+                    // SymbolicBackwardGraphBuilder.Analyze when the cached pattern
+                    // does not match the current tape's reachable entries).
+                    using var recomputeTape = new GradientTape<T>(
+                        new GradientTapeOptions { Persistent = false });
                     var reInput = inputs[0];
                     var reOutput = reInput;
                     for (int i = capturedStart; i < capturedEnd; i++)
                         reOutput = capturedFunctions[i](reOutput);
 
-                    // Compute gradients through the recomputed segment
-                    var segGrads = recomputeTape.ComputeGradients(reOutput, sources: new[] { reInput });
+                    // Vector-Jacobian product (VJP) seed. The previous
+                    // implementation computed gradients with the inner tape's
+                    // implicit ones-seed (treating reOutput as if it were the
+                    // scalar loss) and then attempted to "chain-rule" by
+                    // elementwise-multiplying the resulting dreOutput/dreInput
+                    // by gradOutput. That is wrong on two counts:
+                    //   (a) the inner gradient's shape matches reInput, not
+                    //       reOutput, so the elementwise multiply against
+                    //       gradOutput (shape == reOutput's shape) can fail to
+                    //       broadcast whenever the segment changes shape
+                    //       (Transformer head: [B, L, D] -> [B, D] via
+                    //       LastToken slice, or [B, D] -> [B, V] via dense
+                    //       projection) — this is the
+                    //       ArgumentException("cannot be broadcast") reported
+                    //       in AiDotNet#1341 when the head-side gradOutput
+                    //       [B, V] meets an encoder segment producing
+                    //       [B, L, D];
+                    //   (b) even when shapes happen to align (pure unary
+                    //       elementwise segment), the chain rule for non-
+                    //       elementwise ops (matmul, sum, softmax, etc.) is
+                    //       NOT pointwise multiplication, so the gradient is
+                    //       numerically wrong.
+                    //
+                    // Correct construction: define an inner scalar pseudo-loss
+                    //     pseudoLoss = sum(reOutput * gradOutput.detach())
+                    // whose gradient w.r.t. reInput is, by the chain rule,
+                    // exactly the VJP we need:
+                    //     d(pseudoLoss)/d(reInput)
+                    //         = (d(reOutput)/d(reInput))^T @ gradOutput
+                    // which is the contribution this segment owes to dL/dreInput.
+                    // ReduceSum reduces over every axis and produces a scalar
+                    // tensor — both ops are recorded on the inner tape via the
+                    // DifferentiableOps backward registry, so ComputeGradients
+                    // walks them and computes the correct VJP into reInput.
+                    var weighted = eng.TensorMultiply(reOutput, gradOutput);
+                    var pseudoLoss = eng.ReduceSum(weighted);
+
+                    var segGrads = recomputeTape.ComputeGradients(pseudoLoss, sources: new[] { reInput });
 
                     if (segGrads.TryGetValue(reInput, out var inputGrad))
                     {
-                        // Chain rule: multiply segment gradient by upstream gradient
-                        var chained = eng.TensorMultiply(gradOutput, inputGrad);
-                        DifferentiableOps.AccumulateGrad(grads, inputs[0], chained, eng);
+                        DifferentiableOps.AccumulateGrad(grads, inputs[0], inputGrad, eng);
                     }
                     else
                     {
-                        DifferentiableOps.AccumulateGrad(grads, inputs[0], gradOutput, eng);
+                        // The segment was a no-op w.r.t. its input (e.g. the
+                        // recomputed forward never touched reInput). Fall back
+                        // to passing the upstream gradient through unchanged
+                        // only when its shape matches the input — otherwise we
+                        // would re-introduce the very broadcast mismatch this
+                        // fix is intended to prevent. When shapes differ, the
+                        // gradient is zero w.r.t. this segment's input.
+                        if (ShapesEqual(gradOutput._shape, inputs[0]._shape))
+                        {
+                            DifferentiableOps.AccumulateGrad(grads, inputs[0], gradOutput, eng);
+                        }
                     }
                 });
 
@@ -101,5 +155,15 @@ public static class GradientCheckpointing<T>
         }
 
         return current2;
+    }
+
+    private static bool ShapesEqual(int[] a, int[] b)
+    {
+        if (ReferenceEquals(a, b)) return true;
+        if (a is null || b is null) return false;
+        if (a.Length != b.Length) return false;
+        for (int i = 0; i < a.Length; i++)
+            if (a[i] != b[i]) return false;
+        return true;
     }
 }

--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientCheckpointing.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientCheckpointing.cs
@@ -137,14 +137,30 @@ public static class GradientCheckpointing<T>
                     }
                     else
                     {
-                        // The segment was a no-op w.r.t. its input (e.g. the
-                        // recomputed forward never touched reInput). Fall back
-                        // to passing the upstream gradient through unchanged
-                        // only when its shape matches the input — otherwise we
-                        // would re-introduce the very broadcast mismatch this
-                        // fix is intended to prevent. When shapes differ, the
-                        // gradient is zero w.r.t. this segment's input.
-                        if (ShapesEqual(gradOutput._shape, inputs[0]._shape))
+                        // The segment was disconnected from its input — the
+                        // recomputed forward never touched reInput, so the
+                        // mathematical VJP is ZERO regardless of whether the
+                        // output happens to share a shape with the input.
+                        //
+                        // The earlier shape-equality fallback (CodeRabbit
+                        // feedback on PR #361) incorrectly turned input-
+                        // independent same-shape segments into an identity
+                        // backward by passing gradOutput through whenever the
+                        // shapes lined up. That's only correct when the
+                        // segment is literally a no-op (reOutput IS reInput
+                        // by reference), which is the only case where the
+                        // segment trivially passes gradients through. For
+                        // every other shape-equal but input-independent
+                        // segment, the correct gradient is zero, and we
+                        // achieve that by simply NOT calling
+                        // DifferentiableOps.AccumulateGrad — grads already
+                        // contains zero for inputs[0] by initialization.
+                        //
+                        // Reference-equality is the only safe alias predicate:
+                        // it covers the identity case (reInput == reOutput,
+                        // such as when the segment was empty / no-op) without
+                        // false positives on shape-coincidence.
+                        if (ReferenceEquals(reOutput, reInput))
                         {
                             DifferentiableOps.AccumulateGrad(grads, inputs[0], gradOutput, eng);
                         }


### PR DESCRIPTION
## Summary

Fixes the broadcast/shape exception reported in [AiDotNet#1341](https://github.com/ooples/AiDotNet/issues/1341) when calling \`Transformer<float>.Train()\` under \`EnableMemoryManagement(TrainingMemoryConfig.ForTransformers())\`:

\`\`\`
Tensors with shapes [1, 256] and [1, 64, 128] cannot be broadcast:
dimension 2 has sizes 256 and 128 (must be equal or one must be 1).
   at AiDotNet.Tensors.Engines.Autodiff.GradientCheckpointing\`1.Checkpoint.b__0
\`\`\`

## Root cause

\`GradientCheckpointing<T>.Checkpoint\`'s backward closure was computing the inner-tape gradient with the implicit ones-seed (treating the segment output as if it were the scalar loss) and then attempting to chain-rule via an elementwise \`TensorMultiply\` against \`gradOutput\`. That product can only succeed when the segment is a shape-preserving elementwise op; on a real Transformer the head-side gradient \`[B, V]\` meets an encoder-segment output of \`[B, L, D]\` (shape change at the \`SequenceTokenSliceLayer\` / dense head boundary) and the broadcast fails.

Two issues with the previous code:

1. **shape mismatch** — \`d(reOutput)/d(reInput)\` has \`reInput\`'s shape, not \`reOutput\`'s, so multiplying it elementwise by \`gradOutput\` (which has \`reOutput\`'s shape) only happens to work for pure elementwise segments.
2. **wrong chain rule** — even when shapes align, the chain rule for non-elementwise ops (matmul, sum, softmax) is *not* pointwise multiplication.

## Fix

Construct an inner scalar pseudo-loss
\`\`\`
pseudoLoss = sum(reOutput * gradOutput.detach())
\`\`\`
whose gradient w.r.t. \`reInput\` is, by the chain rule, exactly the vjp:
\`\`\`
d(pseudoLoss)/d(reInput) = (d(reOutput)/d(reInput))^T @ gradOutput
\`\`\`
This is the contribution the segment owes to \`dL/dreInput\`.

The inner recompute tape is also switched to \`Persistent=false\` so the per-step throwaway tape bypasses \`AutoTrainingCompiler\`'s plan cache. The cached-plan replay path was binding stale \`CompiledBackwardGraph\` state and produced a downstream \`NullReferenceException\` in \`SymbolicBackwardGraphBuilder.Analyze\` once the broadcast issue was unblocked.

## Validation

Validated against the issue's 2-encoder-layer Transformer<float> config (dModel=128, dFf=256, ctxLen=64, vocab=256, \`ForTransformers()\` preset) plus a repeated-call regression test — both pass.

The companion PR on the consumer side ([AiDotNet PR](https://github.com/ooples/AiDotNet/pull/new/fix/1341-gradient-checkpointing-shape)) adds:
\`tests/AiDotNet.Tests/IntegrationTests/Training/GradientCheckpointingTransformerIssue1341Tests.cs\`
covering both the original repro shape and a repeated-call regression.

## Test plan

- [x] Repro test passes with the patched Tensors against AiDotNet master
- [x] All 144 checkpoint-related tests in \`tests/AiDotNet.Tests\` still pass
- [x] Broader IntegrationTests/Training + UnitTests/Autodiff tests show no regression introduced by this change (one pre-existing \`SequenceClassification_ThroughFacade\` failure verified to be unrelated)
- [ ] CI green on this repo

Closes ooples/AiDotNet#1341.

🤖 Generated with [Claude Code](https://claude.com/claude-code)