### PR TITLE
fix: cpuengine.flashattention missing graphmode branch — silently dropped grads in fused training

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -22345,6 +22345,88 @@ public partial class CpuEngine : ITensorLevelEngine
         int headDim = query._shape[3];
         int seqK = key._shape[2];
 
+        // ────────────────────────────────────────────────────────────────────
+        // Lazy graph mode: record + return placeholder. Mirror of LayerNorm's
+        // GraphMode branch (this file, line ~19498). FlashAttention was
+        // previously the ONLY tape-recorded Engine op missing this branch —
+        // the eager fast paths (FlashAttentionFloat / FlashAttentionDouble)
+        // ran at compile time and returned a materialised Tensor<T>, which
+        // downstream lazy ops captured as a frozen constant. plan.Step()
+        // replayed everything EXCEPT FlashAttention with fresh Q/K/V (so the
+        // Q/K/V projection matmuls saw updated weights and produced new
+        // tensors), but the lazy graph node for the next op consumed the
+        // compile-time FA output — gradients never flowed back to Q/K/V/O,
+        // and the output of the network stayed near the compile-time random-
+        // init result no matter how long training ran.
+        //
+        // Consumer impact (HarmonicEngine PathB at dModel=128 / L=2 /
+        // ctx=64 / 10KB WikiText-2 byte-LM): top-1 0% / top-5 100% / ppl=V
+        // uniform output + 3.76× slower than MHA (compile-time eager FA fired
+        // every plan.Step on every layer instance).
+        //
+        // savedState parity: softmaxStats from the compile-time eager call
+        // is stale once the lazy graph replays, exactly as LayerNorm's
+        // mean/variance (AiDotNet#1331). The execute callback below
+        // recomputes FA via the out-param overload and copies fresh stats
+        // into the same Tensor<T> instances the savedState slot holds, so
+        // FlashAttentionBackward reads up-to-date softmax statistics on
+        // every plan.Step.
+        // ────────────────────────────────────────────────────────────────────
+        if (GraphMode.IsActive)
+        {
+            var scope = GraphMode.Current;
+            if (scope != null)
+            {
+                // Compute eager once OUTSIDE the graph scope so the lazy graph
+                // sees a registered node, not nested record calls.
+                var savedScope = GraphMode.Current;
+                GraphMode.SetCurrent(null);
+                var eagerOutput = FlashAttention(query, key, value, scale, isCausal, out var eagerStats, attentionBias);
+                GraphMode.SetCurrent(savedScope);
+
+                softmaxStats = eagerStats; // expose to caller (savedState references this object)
+                var capturedQuery = query;
+                var capturedKey = key;
+                var capturedValue = value;
+                var capturedBias = attentionBias;
+                var capturedScale = scale;
+                var capturedIsCausal = isCausal;
+                var capturedStats = eagerStats;
+
+                var inputs = attentionBias is null
+                    ? new[] { query, key, value }
+                    : new[] { query, key, value, attentionBias };
+
+                var lazyResult = scope.RecordVariadic(
+                    LazyNodeType.Custom, "FlashAttention",
+                    inputs, eagerOutput._shape,
+                    (eng, output) =>
+                    {
+                        // Recompute FA with the latest Q/K/V coming through
+                        // the replayed graph. The out-param softmaxStats is
+                        // copied back into the SAME tensor instance the
+                        // savedState holds so the backward kernel reads fresh
+                        // log-sum-exp values.
+                        var freshOut = eng.FlashAttention(
+                            capturedQuery, capturedKey, capturedValue,
+                            capturedScale, capturedIsCausal, out var freshStats, capturedBias);
+                        freshOut.AsSpan().CopyTo(output.AsWritableSpan());
+                        freshStats.AsSpan().CopyTo(capturedStats.AsWritableSpan());
+                    },
+                    BackwardFunctions<T>.FlashAttentionBackward,
+                    capturedBias is null
+                        ? new object[] { capturedStats, capturedScale ?? 1.0 / Math.Sqrt(headDim), capturedIsCausal }
+                        : new object[] { capturedStats, capturedScale ?? 1.0 / Math.Sqrt(headDim), capturedIsCausal, capturedBias });
+
+                // Mirror eager output bytes into the lazy result so any caller
+                // that uses the returned tensor's data BEFORE plan.Step() sees
+                // the eager values (matches LayerNorm's eagerResult.AsSpan
+                // copy-into-lazy pattern).
+                eagerOutput.AsSpan().CopyTo(lazyResult.AsWritableSpan());
+                return lazyResult;
+            }
+        }
+
         // Validate bias shape *before* the float fast-path branch below. The
         // fast path (FlashAttentionFloat) trusts its caller to hand it a
         // correctly-shaped bias, so the rank/dimension check has to run here

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/FlashAttentionCompiledPlanTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/FlashAttentionCompiledPlanTests.cs
@@ -1,0 +1,334 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// Regression tests for AiDotNet#1346 — FlashAttention was missing its
+/// GraphMode.IsActive recording branch under the fused/compiled training
+/// path. Tensors PR #362 added the forward-side fix (lazy-graph
+/// recording mirroring LayerNorm); these tests pin the end-to-end
+/// behaviour: a compiled training plan that runs FA actually produces
+/// non-zero gradients on Q/K/V inputs and the plan's "loss" reduces
+/// across repeated <c>Step()</c> calls.
+///
+/// <para>Pre-fix path: <c>plan.Gradients[Q]</c> stayed all-zero
+/// because the FA lazy node was never created, so the lazy graph went
+/// straight from the upstream MatMul / Permute to the downstream
+/// Permute / Reshape with FA elided into a compile-time constant. No
+/// FA backward fired → no gradient flowed back to Q / K / V projections.</para>
+/// </summary>
+[Collection("FlashAttentionCompiledPlan")]
+public class FlashAttentionCompiledPlanTests
+{
+    /// <summary>
+    /// End-to-end: a compiled training plan whose forward includes
+    /// FlashAttention actually computes a non-zero gradient on Q, K, V
+    /// when <c>plan.Step()</c> runs. Pre-fix the gradient buffers for
+    /// Q/K/V stayed at zero regardless of input.
+    /// </summary>
+    [Fact]
+    public void FlashAttention_InCompiledPlan_ProducesNonZeroQKVGradients()
+    {
+        var engine = new CpuEngine();
+        const int batch = 1, heads = 2, seqQ = 4, headDim = 8;
+
+        // Trainable Q/K/V tensors (rank-4 [B, H, Sq, D]).
+        var Q = new Tensor<float>([batch, heads, seqQ, headDim]);
+        var K = new Tensor<float>([batch, heads, seqQ, headDim]);
+        var V = new Tensor<float>([batch, heads, seqQ, headDim]);
+        var qSpan = Q.AsWritableSpan();
+        var kSpan = K.AsWritableSpan();
+        var vSpan = V.AsWritableSpan();
+        var rng = new System.Random(42);
+        for (int i = 0; i < qSpan.Length; i++) qSpan[i] = (float)(rng.NextDouble() - 0.5);
+        for (int i = 0; i < kSpan.Length; i++) kSpan[i] = (float)(rng.NextDouble() - 0.5);
+        for (int i = 0; i < vSpan.Length; i++) vSpan[i] = (float)(rng.NextDouble() - 0.5);
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var attn = engine.FlashAttention<float>(Q, K, V, scale: null, isCausal: false, out _);
+            // Loss = sum(attn). Plan seeds dL/dOutput = ones; FA backward
+            // then walks softmax statistics + Q/K/V to produce dQ/dK/dV.
+            engine.ReduceSum(attn, null);
+            plan = scope.CompileTraining(new[] { Q, K, V });
+        }
+
+        using (plan)
+        {
+            plan.Step();
+
+            var gQ = plan.Gradients[0];
+            var gK = plan.Gradients[1];
+            var gV = plan.Gradients[2];
+
+            Assert.NotNull(gQ);
+            Assert.NotNull(gK);
+            Assert.NotNull(gV);
+
+            Assert.Equal(Q._shape, gQ._shape);
+            Assert.Equal(K._shape, gK._shape);
+            Assert.Equal(V._shape, gV._shape);
+
+            // Sum of absolute gradient values must be > 0 — pre-fix this
+            // would be exactly 0 because FA had no lazy node and so no
+            // backward delegate fired in plan.Step().
+            float absSumQ = AbsSum(gQ.AsSpan());
+            float absSumK = AbsSum(gK.AsSpan());
+            float absSumV = AbsSum(gV.AsSpan());
+
+            Assert.True(absSumQ > 1e-6f, $"dQ should be non-zero (got abs-sum={absSumQ})");
+            Assert.True(absSumK > 1e-6f, $"dK should be non-zero (got abs-sum={absSumK})");
+            Assert.True(absSumV > 1e-6f, $"dV should be non-zero (got abs-sum={absSumV})");
+        }
+    }
+
+    /// <summary>
+    /// Training convergence: a tiny 1-layer FA + linear-readout network
+    /// trained with vanilla SGD on a deterministic toy task must show
+    /// loss decreasing across multiple Step() calls. Pre-fix the loss
+    /// stayed constant because Q/K/V parameter updates were always
+    /// applied to gradients of zero.
+    /// </summary>
+    [Fact]
+    public void FlashAttention_InCompiledPlan_LossDecreasesAcrossSteps()
+    {
+        var engine = new CpuEngine();
+        const int batch = 1, heads = 2, seqQ = 4, headDim = 8;
+
+        // Trainable Q/K/V tensors. Initial values fixed for determinism.
+        var Q = new Tensor<float>([batch, heads, seqQ, headDim]);
+        var K = new Tensor<float>([batch, heads, seqQ, headDim]);
+        var V = new Tensor<float>([batch, heads, seqQ, headDim]);
+        var rng = new System.Random(1234);
+        FillRandomScaled(Q, rng, 0.1f);
+        FillRandomScaled(K, rng, 0.1f);
+        FillRandomScaled(V, rng, 0.1f);
+
+        // Target: a fixed tensor of the FA output shape. Loss = sum((attn-target)^2)
+        // is built via Subtract → Multiply (square) → ReduceSum.
+        var target = new Tensor<float>([batch, heads, seqQ, headDim]);
+        var tSpan = target.AsWritableSpan();
+        for (int i = 0; i < tSpan.Length; i++) tSpan[i] = 0.5f;
+
+        // Step 1: eager-evaluate loss BEFORE training to record initial value.
+        float initialLoss = ComputeLoss(engine, Q, K, V, target);
+
+        // Step 2: compile the same forward + loss as a training plan.
+        ICompiledTrainingPlan<float> plan;
+        Tensor<float> lossTensor;
+        using (var scope = GraphMode.Enable())
+        {
+            var attn = engine.FlashAttention<float>(Q, K, V, scale: null, isCausal: false, out _);
+            var diff = engine.TensorSubtract(attn, target);
+            var sq = engine.TensorMultiply(diff, diff);
+            lossTensor = engine.ReduceSum(sq, null);
+            plan = scope.CompileTraining(new[] { Q, K, V }, lossTensor);
+        }
+
+        // Step 3: train for a few steps with vanilla SGD (lr * grad).
+        using (plan)
+        {
+            const float lr = 0.01f;
+            for (int step = 0; step < 20; step++)
+            {
+                plan.Step();
+                ApplySgd(Q, plan.Gradients[0], lr);
+                ApplySgd(K, plan.Gradients[1], lr);
+                ApplySgd(V, plan.Gradients[2], lr);
+            }
+        }
+
+        // Step 4: re-evaluate loss eagerly with the trained Q/K/V.
+        float finalLoss = ComputeLoss(engine, Q, K, V, target);
+
+        // Loss must strictly decrease — pre-fix loss stayed constant
+        // because dQ/dK/dV were all zero.
+        Assert.True(finalLoss < initialLoss,
+            $"Loss should decrease through FA training. initial={initialLoss}, final={finalLoss}");
+    }
+
+    private static float ComputeLoss(IEngine engine, Tensor<float> Q, Tensor<float> K, Tensor<float> V, Tensor<float> target)
+    {
+        var attn = engine.FlashAttention<float>(Q, K, V, scale: null, isCausal: false, out _);
+        var diff = engine.TensorSubtract(attn, target);
+        var sq = engine.TensorMultiply(diff, diff);
+        var loss = engine.ReduceSum(sq, null);
+        return loss.AsSpan()[0];
+    }
+
+    private static void ApplySgd(Tensor<float> param, Tensor<float> grad, float lr)
+    {
+        var pSpan = param.AsWritableSpan();
+        var gSpan = grad.AsSpan();
+        for (int i = 0; i < pSpan.Length; i++)
+        {
+            pSpan[i] -= lr * gSpan[i];
+        }
+    }
+
+    private static void FillRandomScaled(Tensor<float> t, System.Random rng, float scale)
+    {
+        var s = t.AsWritableSpan();
+        for (int i = 0; i < s.Length; i++) s[i] = (float)((rng.NextDouble() - 0.5) * 2.0 * scale);
+    }
+
+    private static float AbsSum(System.ReadOnlySpan<float> span)
+    {
+        float sum = 0;
+        for (int i = 0; i < span.Length; i++) sum += System.Math.Abs(span[i]);
+        return sum;
+    }
+
+    /// <summary>
+    /// End-to-end regression mirroring the HarmonicEngine PathB consumer
+    /// failure (AiDotNet#1346): a minimal transformer block built like
+    /// FlashAttentionLayer&lt;T&gt;.Forward — Q/K/V projection via MatMul,
+    /// Reshape to [B, H, Sq, D], Permute, then FA, then Permute back +
+    /// Reshape + linear readout. Trains 30 SGD steps on a deterministic
+    /// vocab-prediction toy task and asserts: (a) loss decreases, (b)
+    /// every projection matrix actually changes its values across
+    /// training. Pre-fix #1346 the FA op was elided into a compile-time
+    /// constant, so the Q/K/V matmul gradients were zero and the
+    /// projection matrices stayed at random init forever.
+    /// </summary>
+    [Fact]
+    public void FlashAttentionLayerLikeBlock_InCompiledPlan_TrainingReducesLoss()
+    {
+        var engine = new CpuEngine();
+        const int batch = 1;
+        const int seqLen = 16;
+        const int dModel = 32;
+        const int headCount = 2;
+        const int headDim = dModel / headCount;
+
+        var input = new Tensor<float>([batch, seqLen, dModel]);
+        var rng = new System.Random(7);
+        FillRandomScaled(input, rng, 1.0f);
+
+        // Target with shape matching projected output [batch, seqLen, dModel].
+        var target = new Tensor<float>([batch, seqLen, dModel]);
+        var tSpan = target.AsWritableSpan();
+        for (int i = 0; i < tSpan.Length; i++)
+            tSpan[i] = (float)System.Math.Sin(i * 0.1);
+
+        // Projection weights (mirrors FlashAttentionLayer<T>'s Q/K/V/O).
+        var wQ = NewWeight([dModel, dModel], rng);
+        var wK = NewWeight([dModel, dModel], rng);
+        var wV = NewWeight([dModel, dModel], rng);
+        var wO = NewWeight([dModel, dModel], rng);
+
+        // Snapshot initial weights for the "weights actually changed" check.
+        var wQ0 = wQ.AsSpan().ToArray();
+        var wK0 = wK.AsSpan().ToArray();
+        var wV0 = wV.AsSpan().ToArray();
+        var wO0 = wO.AsSpan().ToArray();
+
+        // Eager initial loss.
+        float initialLoss = ComputeBlockLoss(engine, input, wQ, wK, wV, wO, target, batch, seqLen, dModel, headCount, headDim);
+
+        ICompiledTrainingPlan<float> plan;
+        Tensor<float> lossTensor;
+        using (var scope = GraphMode.Enable())
+        {
+            // Q/K/V projections
+            var q = engine.TensorMatMul(input, wQ);
+            var k = engine.TensorMatMul(input, wK);
+            var v = engine.TensorMatMul(input, wV);
+
+            // Reshape to [B, Sq, H, D] then Permute to [B, H, Sq, D]
+            q = engine.TensorPermute(engine.Reshape(q, new[] { batch, seqLen, headCount, headDim }), new[] { 0, 2, 1, 3 });
+            k = engine.TensorPermute(engine.Reshape(k, new[] { batch, seqLen, headCount, headDim }), new[] { 0, 2, 1, 3 });
+            v = engine.TensorPermute(engine.Reshape(v, new[] { batch, seqLen, headCount, headDim }), new[] { 0, 2, 1, 3 });
+
+            // Flash Attention
+            var attn = engine.FlashAttention<float>(q, k, v, scale: null, isCausal: false, out _);
+
+            // Permute back + Reshape to [B, Sq, dModel]
+            var permuted = engine.TensorPermute(attn, new[] { 0, 2, 1, 3 });
+            var reshaped = engine.Reshape(permuted, new[] { batch, seqLen, dModel });
+
+            // Output projection
+            var projected = engine.TensorMatMul(reshaped, wO);
+
+            // Loss = sum((projected - target)^2)
+            var diff = engine.TensorSubtract(projected, target);
+            var sq = engine.TensorMultiply(diff, diff);
+            lossTensor = engine.ReduceSum(sq, null);
+
+            plan = scope.CompileTraining(new[] { wQ, wK, wV, wO }, lossTensor);
+        }
+
+        using (plan)
+        {
+            const float lr = 1e-4f;
+            for (int step = 0; step < 30; step++)
+            {
+                plan.Step();
+                ApplySgd(wQ, plan.Gradients[0], lr);
+                ApplySgd(wK, plan.Gradients[1], lr);
+                ApplySgd(wV, plan.Gradients[2], lr);
+                ApplySgd(wO, plan.Gradients[3], lr);
+            }
+        }
+
+        float finalLoss = ComputeBlockLoss(engine, input, wQ, wK, wV, wO, target, batch, seqLen, dModel, headCount, headDim);
+
+        // Loss must strictly decrease.
+        Assert.True(finalLoss < initialLoss,
+            $"Loss should decrease through FA+projections training. initial={initialLoss}, final={finalLoss}");
+
+        // Every projection weight matrix must have actually changed.
+        Assert.True(MaxAbsDelta(wQ, wQ0) > 1e-6f, "wQ must change during training (was: gradient-free in #1346)");
+        Assert.True(MaxAbsDelta(wK, wK0) > 1e-6f, "wK must change during training (was: gradient-free in #1346)");
+        Assert.True(MaxAbsDelta(wV, wV0) > 1e-6f, "wV must change during training (was: gradient-free in #1346)");
+        Assert.True(MaxAbsDelta(wO, wO0) > 1e-6f, "wO must change during training");
+    }
+
+    private static float ComputeBlockLoss(
+        IEngine engine, Tensor<float> input,
+        Tensor<float> wQ, Tensor<float> wK, Tensor<float> wV, Tensor<float> wO,
+        Tensor<float> target, int batch, int seqLen, int dModel, int headCount, int headDim)
+    {
+        var q = engine.TensorMatMul(input, wQ);
+        var k = engine.TensorMatMul(input, wK);
+        var v = engine.TensorMatMul(input, wV);
+        q = engine.TensorPermute(engine.Reshape(q, new[] { batch, seqLen, headCount, headDim }), new[] { 0, 2, 1, 3 });
+        k = engine.TensorPermute(engine.Reshape(k, new[] { batch, seqLen, headCount, headDim }), new[] { 0, 2, 1, 3 });
+        v = engine.TensorPermute(engine.Reshape(v, new[] { batch, seqLen, headCount, headDim }), new[] { 0, 2, 1, 3 });
+        var attn = engine.FlashAttention<float>(q, k, v, scale: null, isCausal: false, out _);
+        var permuted = engine.TensorPermute(attn, new[] { 0, 2, 1, 3 });
+        var reshaped = engine.Reshape(permuted, new[] { batch, seqLen, dModel });
+        var projected = engine.TensorMatMul(reshaped, wO);
+        var diff = engine.TensorSubtract(projected, target);
+        var sq = engine.TensorMultiply(diff, diff);
+        var loss = engine.ReduceSum(sq, null);
+        return loss.AsSpan()[0];
+    }
+
+    private static Tensor<float> NewWeight(int[] shape, System.Random rng)
+    {
+        var t = new Tensor<float>(shape);
+        int fanIn = shape[0];
+        int fanOut = shape[1];
+        float scale = (float)System.Math.Sqrt(2.0 / (fanIn + fanOut));
+        var s = t.AsWritableSpan();
+        for (int i = 0; i < s.Length; i++) s[i] = (float)((rng.NextDouble() - 0.5) * 2.0 * scale);
+        return t;
+    }
+
+    private static float MaxAbsDelta(Tensor<float> current, float[] initial)
+    {
+        var c = current.AsSpan();
+        float max = 0;
+        for (int i = 0; i < c.Length; i++)
+        {
+            float d = System.Math.Abs(c[i] - initial[i]);
+            if (d > max) max = d;
+        }
+        return max;
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/GraphModeRecordingAuditTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/GraphModeRecordingAuditTests.cs
@@ -174,4 +174,35 @@ public class GraphModeRecordingAuditTests
 
         Assert.NotNull(output.LazySource);
     }
+
+    /// <summary>
+    /// FlashAttention — Q/K/V multi-head, out-param softmaxStats saved
+    /// into savedState for backward. Same pattern as LayerNorm
+    /// (mean/variance recomputed on replay). Pre-fix the eager fast
+    /// path produced a materialised tensor with no LazySource, and the
+    /// downstream Permute/Reshape ops in the calling FlashAttentionLayer
+    /// captured the FA output as a frozen compile-time constant —
+    /// breaking gradient flow to the upstream Q/K/V projections in the
+    /// fused compiled training path (HarmonicEngine PathB reproducer
+    /// at dModel=128 / L=2 / ctx=64 / 10KB WikiText-2 byte-LM:
+    /// top-1 0% / top-5 100% / ppl=V uniform + 3.76× slowdown vs MHA).
+    /// </summary>
+    [Fact]
+    public void FlashAttention_UnderGraphMode_RecordsLazyNode()
+    {
+        var engine = new CpuEngine();
+        const int batch = 1, heads = 2, seqQ = 4, headDim = 8;
+        var query = Tensor<float>.CreateRandom([batch, heads, seqQ, headDim]);
+        var key   = Tensor<float>.CreateRandom([batch, heads, seqQ, headDim]);
+        var value = Tensor<float>.CreateRandom([batch, heads, seqQ, headDim]);
+
+        using var scope = GraphMode.Enable();
+        var output = engine.FlashAttention<float>(
+            query, key, value,
+            scale: null,
+            isCausal: false,
+            out _);
+
+        Assert.NotNull(output.LazySource);
+    }
 }


### PR DESCRIPTION
## Summary

`CpuEngine.FlashAttention<T>` was the **only differentiable engine op** without a `GraphMode.IsActive` lazy-graph recording branch. Under the lazy-graph tracing path that `AiDotNet.CompiledTapeTrainingStep.TryStepWithFusedOptimizer` enables (float + Adam = the default fast path on most CPU training workloads), FA computed eagerly and returned a materialised tensor with no `LazySource`. Downstream lazy ops captured the FA output as a frozen compile-time constant — `plan.Step()` replayed everything upstream of FA with fresh weights but the FA node was a static literal. FA-using attention parameters never received gradients on the fused-compiled training path.

## Root cause

`Engine.FlashAttention<T>` in `src/AiDotNet.Tensors/Engines/CpuEngine.cs` lines ~22327. All 219 other differentiable ops in this file have a `if (GraphMode.IsActive) { ... }` early branch that records into `GraphMode.Current` via `scope.Record{Unary,Binary,Variadic}`. FA only had the eager-tape `RecordIfActive("FlashAttention", ...)` call, which works for the eager-tape training path (`TrainWithTape`) but is invisible to the lazy-graph compiler.

## Fix

Add a `GraphMode.IsActive` branch that mirrors `LayerNorm`'s recompute-mean-on-replay pattern (already battle-tested for `mean`/`variance` savedState — same out-param shape as FA's `softmaxStats`):

1. Save current scope, disable GraphMode, compute eager FA + softmaxStats.
2. Restore scope and call `scope.RecordVariadic(LazyNodeType.Custom, "FlashAttention", inputs, outShape, executeCallback, FlashAttentionBackward, savedState)`.
3. The `executeCallback` recomputes FA at replay time and copies fresh softmaxStats into the same `Tensor<T>` instance the savedState holds, so backward reads up-to-date log-sum-exp values.
4. Mirror eager output bytes into the lazy result for callers that read the tensor immediately (pre-`plan.Step()`).

## Backward dispatch follow-up (no separate emitter map needed)

The 2026-05-17 follow-up investigation (issue #1346) examined whether `LazyGraphCompiler` needed an explicit FA backward-emitter registration. **It does not.** Backward dispatch in `CompiledTrainingPlan` is dynamic per step (see `CompiledTrainingPlan.cs:1402-1409`): every lazy node with a non-null `BackwardFn` automatically gets a generic backward action that invokes `step.BackwardFn(gradOut, inputs, output, savedState, engine, gradAcc)`. The forward fix above already attaches `BackwardFunctions<T>.FlashAttentionBackward` to the lazy node's `BackwardFn` slot, so the generic dispatch picks it up correctly at compile time. The three new end-to-end tests below verify this.

## Test plan

- [x] `GraphModeRecordingAuditTests.FlashAttention_UnderGraphMode_RecordsLazyNode` — asserts the returned tensor has a non-null `LazySource`. Confirmed: fails pre-fix (Value is null), passes post-fix.
- [x] All 7 `GraphModeRecordingAuditTests` pass.
- [x] All 50 existing `FlashAttention*Tests` pass (no regression on the rank-N forward / float-fast-path / double-fast-path / scalar-fallback paths).
- [x] **NEW (2026-05-17)**: 3 end-to-end compiled-plan regression tests in `FlashAttentionCompiledPlanTests`:
  1. `FlashAttention_InCompiledPlan_ProducesNonZeroQKVGradients` — single FA op, asserts `plan.Gradients[Q/K/V]` abs-sum > 0 after one `Step()`.
  2. `FlashAttention_InCompiledPlan_LossDecreasesAcrossSteps` — 20-step SGD on MSE target, asserts loss strictly decreases.
  3. `FlashAttentionLayerLikeBlock_InCompiledPlan_TrainingReducesLoss` — mirrors `FlashAttentionLayer<T>.Forward` (MatMul Q/K/V → Reshape → Permute → FA → Permute → Reshape → MatMul O), 30 SGD steps, asserts loss decreases AND every projection matrix changes.
- [x] HarmonicEngine consumer reproducer (`Phase_PAPER_A_PathB_FlashAttention_Sanity`) passes shape assertions. Top-1 not yet recovered to baseline — engine-side gap closed by this PR is necessary but not sufficient; remaining issue is HE-side (likely in `FlashAttentionLayer.Forward` or its interaction with `LayerNormalizationLayer` in the transformer stack, not in Tensors). Tracked in AiDotNet#1346.

## Before / after metrics

HarmonicEngine PathB at dModel=128 / L=2 / ctx=64 / 10KB WikiText-2 byte-LM:

| arm | top-1 | top-5 | ppl | train wall |
|-----|------:|------:|----:|-----------:|
| baseline MHA       | 9.80% | 31.40% | 255.42 | 23.45s |
| FA pre-fix (#1340) |  0.00% | 100.00% | 256.00 | 59.99s (3.76x slower) |
| FA after forward fix (this PR) |  0.00% |  92.80% | 256.00 | 48.53s (2.72x slower) |
| FA after fix + new regression tests landed |  0.00% |  99.20% | 256.00 | 99.51s (4.24x; HE host load variance) |

(Top-1 not yet recovered to baseline — the engine-level gap closed by this PR is necessary but not sufficient; HE consumer-side investigation needed. Tracked in ooples/AiDotNet#1346.)

## Linked PRs

- Tracking issue: ooples/AiDotNet#1346

## Constraints honored

- No null-forgiving operator
- No test weakening (assertion is strictly stricter than pre-fix behavior)
- Lowercase commit messages
- All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)