### PR TITLE
fix: wire GraphMode recording on 5 ops with silent gradient-drop bugs (closes #365)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -9041,7 +9041,7 @@ public partial class CpuEngine : ITensorLevelEngine
         return result;
     }
 
-    public unsafe Tensor<T> Tanh<T>(Tensor<T> tensor)
+    public virtual unsafe Tensor<T> Tanh<T>(Tensor<T> tensor)
     {
         if (tensor == null)
             throw new ArgumentNullException(nameof(tensor));
@@ -9052,6 +9052,7 @@ public partial class CpuEngine : ITensorLevelEngine
             var scope = GraphMode.Current;
             if (scope != null)
             {
+                scope.BindEngineIfUnset(this);
                 var captured = tensor;
                 return scope.RecordUnary(LazyNodeType.Tanh, "Tanh", tensor, tensor._shape,
                     (eng, output) => eng.TanhInto(output, captured),
@@ -10793,6 +10794,32 @@ public partial class CpuEngine : ITensorLevelEngine
         for (int d = 0; d < a.Rank - 2; d++) outShape[d] = a._shape[d];
         outShape[a.Rank - 2] = M;
         outShape[a.Rank - 1] = N;
+
+        // Lazy graph mode: record and return placeholder. MUST be checked
+        // BEFORE the float/double fast paths below — they execute eagerly
+        // and would silently bypass the compiled training plan, leaving the
+        // result as a frozen compile-time constant with no LazySource. The
+        // generic fallback (TensorTranspose + TensorMatMul) is composed of
+        // GraphMode-aware primitives so it would be safe, but the fast paths
+        // are not. Same failure mode the FlashAttention forward had before
+        // PR #362 — fixed here for #365.
+        if (GraphMode.IsActive)
+        {
+            var scope = GraphMode.Current;
+            if (scope != null)
+            {
+                scope.BindEngineIfUnset(this);
+                var capturedA = a;
+                var capturedB = b;
+                return scope.RecordBinary(LazyNodeType.MatMul, "TensorMatMulTransposed", a, b, outShape,
+                    (eng, output) =>
+                    {
+                        var eager = eng.TensorMatMulTransposed(capturedA, capturedB);
+                        eager.AsSpan().CopyTo(output.AsWritableSpan());
+                    },
+                    BackwardFunctions<T>.MatMulTransposedBackward);
+            }
+        }
 
         // Float fast path via SimdGemm.Sgemm with transB=true. Skips the
         // ~70%-of-the-time-spent-on-the-transpose materialization that the
@@ -13336,6 +13363,10 @@ public partial class CpuEngine : ITensorLevelEngine
     public virtual Tensor<T> AvgPool2D<T>(Tensor<T> input, int[] poolSize, int[] stride)
     {
         if (input == null) throw new ArgumentNullException(nameof(input));
+        if (poolSize == null || poolSize.Length != 2) throw new ArgumentException("poolSize must be array of 2 elements", nameof(poolSize));
+        if (stride == null || stride.Length != 2) throw new ArgumentException("stride must be array of 2 elements", nameof(stride));
+        if (input.Rank != 4)
+            throw new ArgumentException($"AvgPool2D requires a 4D tensor [batch, channels, height, width]. Got rank {input.Rank}.");
 
         var numOps = MathHelper.GetNumericOperations<T>();
 
@@ -13355,6 +13386,37 @@ public partial class CpuEngine : ITensorLevelEngine
 
         if (outputHeight <= 0 || outputWidth <= 0)
             throw new ArgumentException($"Invalid output dimensions ({outputHeight}x{outputWidth}). Check pool size and stride.");
+
+        // Lazy graph mode: record and return placeholder. Without this branch,
+        // compiled training plans that route through this int[] overload would
+        // execute eagerly and the result would have no LazySource — downstream
+        // ops would capture it as a frozen compile-time constant and gradients
+        // would silently drop through this op. The sibling int-scalar overload
+        // at line ~7980 already has this recording; this overload was the gap
+        // identified in #365.
+        if (GraphMode.IsActive)
+        {
+            var scope = GraphMode.Current;
+            if (scope != null)
+            {
+                scope.BindEngineIfUnset(this);
+                var outShape = new[] { batch, channels, outputHeight, outputWidth };
+                var capturedInput = input;
+                var capturedPool = (int[])poolSize.Clone();
+                var capturedStride = (int[])stride.Clone();
+                return scope.RecordUnary(LazyNodeType.Custom, "AvgPool2D", input, outShape,
+                    (eng, output) =>
+                    {
+                        // poolH == poolW and strideH == strideW is the common case;
+                        // when they differ this overload's semantics are kernel-rect,
+                        // which the int-scalar AvgPool2D doesn't support. Compute
+                        // via the int[] path on replay to preserve rect semantics.
+                        var r = eng.AvgPool2D(capturedInput, capturedPool, capturedStride);
+                        r.AsSpan().CopyTo(output.AsWritableSpan());
+                    },
+                    BackwardFunctions<T>.AvgPool2DBackward, new object[] { capturedPool, capturedStride });
+            }
+        }
 
         var inputData = input.GetFlattenedData();
         var outputData = new T[batch * channels * outputHeight * outputWidth];
@@ -28313,6 +28375,32 @@ public partial class CpuEngine : ITensorLevelEngine
             throw new ArgumentException(
                 $"Output length ({output.Length}) does not match input length ({tensor.Length}).");
 
+        // Lazy graph mode: record the write-into as an in-place op. Without
+        // this, the eager dense-walk below runs at trace time and the lazy
+        // graph never sees the permute — downstream ops that consume `output`
+        // would resolve to whatever uninitialized rented buffer it carries.
+        // Mirrors the TensorPermute (non-Into) recording at line ~28486.
+        // See #365 — this is the "void Into method, no GraphMode handling"
+        // entry in the owner's audit.
+        if (GraphMode.IsActive)
+        {
+            var scope = GraphMode.Current;
+            if (scope != null)
+            {
+                scope.BindEngineIfUnset(this);
+                var capturedSrc = tensor;
+                var capturedAxes = (int[])axes.Clone();
+                scope.RecordInPlace(LazyNodeType.Custom, "TensorPermuteInto", output, new[] { tensor },
+                    (eng, dst) =>
+                    {
+                        if (eng is CpuEngine cpuEng) cpuEng.TensorPermuteInto(dst, capturedSrc, capturedAxes);
+                        else { var r = eng.TensorPermute(capturedSrc, capturedAxes).Contiguous(); r.AsSpan().CopyTo(dst.AsWritableSpan()); }
+                    },
+                    BackwardFunctions<T>.PermuteBackward, new object[] { capturedAxes });
+                return;
+            }
+        }
+
         // Rank-0 short-circuit: a 0-d tensor permutes trivially via a single
         // scalar copy. Without this, the contiguous-stride init below indexes
         // srcStrides[rank - 1] which is out of bounds.
@@ -31294,6 +31382,24 @@ public partial class CpuEngine : ITensorLevelEngine
             throw new ArgumentException(
                 $"MaskedSelect requires mask shape [{string.Join(", ", mask._shape)}] " +
                 $"to match tensor shape [{string.Join(", ", tensor._shape)}].");
+
+        // MaskedSelect's output shape is data-dependent (= count of true bits
+        // in the mask), so it cannot be recorded as a static-shape lazy node:
+        // the placeholder allocation in RecordUnary needs the output shape at
+        // trace time, which is impossible without materializing the mask.
+        // PyTorch fences this off the same way for torch.compile / TorchScript.
+        // Fail loudly here rather than silently returning a frozen eager copy
+        // that downstream ops would capture as a compile-time constant — the
+        // failure mode #365 was filed to fix.
+        if (GraphMode.IsActive && GraphMode.Current is not null)
+        {
+            throw new NotSupportedException(
+                "TensorMaskedSelect has a data-dependent output shape (the count " +
+                "of true bits in the mask is not known at trace time), so it cannot " +
+                "be recorded inside a compiled training plan / GraphMode trace. " +
+                "Materialize the result outside the trace, or restructure the model " +
+                "to use TensorWhere (static-shape masking) instead.");
+        }
 
         // Preserve the original tensor/mask for autograd binding so gradients
         // flow back to the caller's input, not to transient contiguous copies.

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/GraphModeRecordingAuditTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/GraphModeRecordingAuditTests.cs
@@ -1,3 +1,4 @@
+using System;
 using AiDotNet.Tensors.Engines;
 using AiDotNet.Tensors.Engines.Compilation;
 using AiDotNet.Tensors.LinearAlgebra;
@@ -204,5 +205,183 @@ public class GraphModeRecordingAuditTests
             out _);
 
         Assert.NotNull(output.LazySource);
+    }
+
+    // ====================================================================
+    // Issue #365: ops with silent gradient-drop on the compiled training
+    // plan path. Each op below was verified to lack a GraphMode.IsActive
+    // recording branch in CpuEngine.cs at the time #365 was filed. The
+    // tests assert (a) LazySource is non-null (minimum recording invariant)
+    // and (b) for numerical ops, the materialized result equals the
+    // eager-mode reference — proving the recorded execute delegate
+    // actually computes the right values on replay, not just registers
+    // a placeholder.
+    // ====================================================================
+
+    /// <summary>
+    /// TensorMatMulTransposed — the float and double fast paths (SimdGemm
+    /// with transB=true / BLAS cblas_dgemm with transB=true) bypassed the
+    /// GraphMode guard and computed eagerly, returning a tensor with no
+    /// LazySource. Every transformer attention's Q·Kᵀ runs through this op,
+    /// so the bug silently froze attention gradients across the entire
+    /// compiled training plan.
+    /// </summary>
+    [Fact]
+    public void TensorMatMulTransposed_UnderGraphMode_RecordsLazyNode()
+    {
+        var engine = new CpuEngine();
+        var a = Tensor<float>.CreateRandom([4, 8]);   // [M, K]
+        var b = Tensor<float>.CreateRandom([6, 8]);   // [N, K] (transposed-storage)
+
+        using var scope = GraphMode.Enable();
+        var output = engine.TensorMatMulTransposed<float>(a, b);
+
+        Assert.NotNull(output.LazySource);
+    }
+
+    /// <summary>
+    /// TensorMatMulTransposed numerical equivalence — proves the recorded
+    /// execute delegate computes the right matmul-transposed when realized,
+    /// not just registers a placeholder. The eager reference is computed
+    /// outside any GraphMode scope.
+    /// </summary>
+    [Fact]
+    public void TensorMatMulTransposed_GraphMode_MaterializesToSameValuesAsEager()
+    {
+        var engine = new CpuEngine();
+        var a = Tensor<float>.CreateRandom([4, 8]);
+        var b = Tensor<float>.CreateRandom([6, 8]);
+
+        // Eager reference, no GraphMode active.
+        var eager = engine.TensorMatMulTransposed<float>(a, b);
+
+        Tensor<float> lazyOutput;
+        using (var scope = GraphMode.Enable())
+        {
+            lazyOutput = engine.TensorMatMulTransposed<float>(a, b);
+            Assert.NotNull(lazyOutput.LazySource);
+        }
+
+        // Force materialization by reading the data. The lazy graph's
+        // Realize runs the recorded execute delegate.
+        var eagerSpan = eager.AsSpan();
+        var lazySpan = lazyOutput.AsSpan();
+        Assert.Equal(eagerSpan.Length, lazySpan.Length);
+        for (int i = 0; i < eagerSpan.Length; i++)
+            Assert.Equal(eagerSpan[i], lazySpan[i], precision: 3);
+    }
+
+    /// <summary>
+    /// AvgPool2D (int[] poolSize, int[] stride) overload — the int-scalar
+    /// sibling already had GraphMode recording; this overload was a gap.
+    /// Public virtual method that consumers can hit directly.
+    /// </summary>
+    [Fact]
+    public void AvgPool2DIntArray_UnderGraphMode_RecordsLazyNode()
+    {
+        var engine = new CpuEngine();
+        var input = Tensor<float>.CreateRandom([2, 3, 8, 8]);
+
+        using var scope = GraphMode.Enable();
+        var output = engine.AvgPool2D<float>(input, new[] { 2, 2 }, new[] { 2, 2 });
+
+        Assert.NotNull(output.LazySource);
+    }
+
+    /// <summary>
+    /// AvgPool2D int[] overload numerical equivalence.
+    /// </summary>
+    [Fact]
+    public void AvgPool2DIntArray_GraphMode_MaterializesToSameValuesAsEager()
+    {
+        var engine = new CpuEngine();
+        var input = Tensor<float>.CreateRandom([2, 3, 8, 8]);
+
+        var eager = engine.AvgPool2D<float>(input, new[] { 2, 2 }, new[] { 2, 2 });
+
+        Tensor<float> lazyOutput;
+        using (var scope = GraphMode.Enable())
+        {
+            lazyOutput = engine.AvgPool2D<float>(input, new[] { 2, 2 }, new[] { 2, 2 });
+            Assert.NotNull(lazyOutput.LazySource);
+        }
+
+        var eagerSpan = eager.AsSpan();
+        var lazySpan = lazyOutput.AsSpan();
+        Assert.Equal(eagerSpan.Length, lazySpan.Length);
+        for (int i = 0; i < eagerSpan.Length; i++)
+            Assert.Equal(eagerSpan[i], lazySpan[i], precision: 4);
+    }
+
+    /// <summary>
+    /// TensorPermuteInto — void Into method that wrote directly into the
+    /// caller's pre-allocated output with no lazy recording. Under
+    /// GraphMode the write happened eagerly and downstream consumers of
+    /// output captured whatever uninitialized rented buffer it carried.
+    /// The fix records via scope.RecordInPlace so output gets a LazySource
+    /// pointing at the permute op.
+    /// </summary>
+    [Fact]
+    public void TensorPermuteInto_UnderGraphMode_RecordsOutputLazySource()
+    {
+        var engine = new CpuEngine();
+        var input = Tensor<float>.CreateRandom([2, 3, 4, 5]);
+        // Permute (0,1,2,3) -> (0,2,1,3): [2,3,4,5] -> [2,4,3,5]
+        var output = new Tensor<float>(new[] { 2, 4, 3, 5 });
+
+        using var scope = GraphMode.Enable();
+        engine.TensorPermuteInto<float>(output, input, new[] { 0, 2, 1, 3 });
+
+        Assert.NotNull(output.LazySource);
+    }
+
+    /// <summary>
+    /// TensorPermuteInto numerical equivalence on replay.
+    /// </summary>
+    [Fact]
+    public void TensorPermuteInto_GraphMode_MaterializesToSameValuesAsEager()
+    {
+        var engine = new CpuEngine();
+        var input = Tensor<float>.CreateRandom([2, 3, 4, 5]);
+        var axes = new[] { 0, 2, 1, 3 };
+
+        // Eager reference.
+        var eagerOut = new Tensor<float>(new[] { 2, 4, 3, 5 });
+        engine.TensorPermuteInto<float>(eagerOut, input, axes);
+
+        // Lazy path.
+        var lazyOut = new Tensor<float>(new[] { 2, 4, 3, 5 });
+        using (var scope = GraphMode.Enable())
+        {
+            engine.TensorPermuteInto<float>(lazyOut, input, axes);
+            Assert.NotNull(lazyOut.LazySource);
+        }
+
+        var eagerSpan = eagerOut.AsSpan();
+        var lazySpan = lazyOut.AsSpan();
+        Assert.Equal(eagerSpan.Length, lazySpan.Length);
+        for (int i = 0; i < eagerSpan.Length; i++)
+            Assert.Equal(eagerSpan[i], lazySpan[i], precision: 5);
+    }
+
+    /// <summary>
+    /// TensorMaskedSelect has a data-dependent output shape (count of true
+    /// bits in mask), so it cannot be recorded as a static-shape lazy node.
+    /// Under GraphMode the op MUST throw NotSupportedException rather than
+    /// silently producing a frozen eager copy (the failure mode #365 was
+    /// filed to fix). Callers must materialize outside the trace or use
+    /// TensorWhere (static-shape) instead.
+    /// </summary>
+    [Fact]
+    public void TensorMaskedSelect_UnderGraphMode_ThrowsNotSupportedException()
+    {
+        var engine = new CpuEngine();
+        var input = Tensor<float>.CreateRandom([8]);
+        var mask = new Tensor<Bit>(new[] { 8 });
+        var maskSpan = mask.AsWritableSpan();
+        for (int i = 0; i < maskSpan.Length; i++) maskSpan[i] = i % 2 == 0;
+
+        using var scope = GraphMode.Enable();
+        Assert.Throws<NotSupportedException>(() => engine.TensorMaskedSelect<float>(input, mask));
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/GraphModeRecordingAuditTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/GraphModeRecordingAuditTests.cs
@@ -384,4 +384,50 @@ public class GraphModeRecordingAuditTests
         using var scope = GraphMode.Enable();
         Assert.Throws<NotSupportedException>(() => engine.TensorMaskedSelect<float>(input, mask));
     }
+
+    /// <summary>
+    /// PR #367 copilot review: the per-op equivalence tests above all force
+    /// materialization AFTER leaving the GraphMode scope. The recording
+    /// delegates call back into GraphMode-aware public APIs on replay, so a
+    /// realistic regression case is forcing materialization WHILE GraphMode
+    /// is still active — that catches re-entry / re-recording bugs and any
+    /// in-place output that the lazy node failed to actually write. We use
+    /// TensorMatMulTransposed since it's the highest-impact fix in this PR
+    /// (every attention QKᵀ goes through it).
+    ///
+    /// On Realize, LazyTensorScope flips GraphMode to null around each
+    /// node's execute delegate so the eager path runs (see
+    /// LazyTensorScope.Realize). Accessing .AsSpan() inside the using block
+    /// must therefore still produce correct values without recursive
+    /// re-recording.
+    /// </summary>
+    [Fact]
+    public void TensorMatMulTransposed_GraphMode_MaterializesCorrectlyInsideActiveScope()
+    {
+        var engine = new CpuEngine();
+        var a = Tensor<float>.CreateRandom([4, 8]);
+        var b = Tensor<float>.CreateRandom([6, 8]);
+
+        // Eager reference (no GraphMode active).
+        var eager = engine.TensorMatMulTransposed<float>(a, b);
+        var eagerSnapshot = eager.AsSpan().ToArray();
+
+        // Materialize INSIDE the active scope — this is the regression case
+        // the per-op equivalence tests above don't cover.
+        float[] insideSnapshot;
+        using (var scope = GraphMode.Enable())
+        {
+            var lazyOutput = engine.TensorMatMulTransposed<float>(a, b);
+            Assert.NotNull(lazyOutput.LazySource);
+            // Force materialization while the scope is still active. If the
+            // execute delegate tries to re-record into the live scope or
+            // leaves the output buffer unwritten, this read either throws or
+            // returns garbage that fails the equality check below.
+            insideSnapshot = lazyOutput.AsSpan().ToArray();
+        }
+
+        Assert.Equal(eagerSnapshot.Length, insideSnapshot.Length);
+        for (int i = 0; i < eagerSnapshot.Length; i++)
+            Assert.Equal(eagerSnapshot[i], insideSnapshot[i], precision: 3);
+    }
 }


### PR DESCRIPTION
## Summary

Closes #365. Wires the `GraphMode.IsActive` lazy-graph recording branch onto 5 ops that PR #362's FlashAttention audit left as a follow-up. Each fixed op silently dropped gradients when invoked under a compiled training plan — the result materialized eagerly with no `LazySource`, so downstream ops captured it as a frozen compile-time constant.

## Fix scope

The owner's two-round audit on issue #365 reduced the initially-flagged 16-op surface to a verified 5-op shortlist (12 false positives forwarded to GraphMode-aware primitives via composition). This PR fixes the 5 genuine gaps + one consistency nit:

| Op | Severity | Fix |
|---|---|---|
| `TensorMatMulTransposed<T>` | High (used by every attention QKᵀ) | Add GraphMode guard at TOP of method — was after the float/double fast paths, which silently bypassed it |
| `AvgPool2D<T>(int[], int[])` overload | High (CNN pooling) | Add full GraphMode recording (was missing entirely; sibling `int`-scalar overload already had it) |
| `TensorPermuteInto<T>` | Medium (MHA permute pipeline) | Use `scope.RecordInPlace` (PR #359 pattern) since it's a void Into method writing to caller's buffer |
| `TensorMaskedSelect<T>` | Medium | Throw `NotSupportedException` under GraphMode — output shape is data-dependent (count of mask true bits), can't be statically traced. PyTorch fences this the same way for `torch.compile` |
| `Tanh<T>(Tensor<T>)` | Consistency | Add `virtual` modifier + `BindEngineIfUnset` to match the other activation primitives |

## What was NOT changed

Verified-OK ops (already wire GraphMode either directly or via GraphMode-aware composition):
- All activation wrappers: `TensorReLU/Sigmoid/GELU/SiLU/Tanh/Mish/HardSwish/LeakyReLU` (forward to primitives that have recording)
- CNN primitives: `MaxPool2D`, `AvgPool2D(int,int,int)`, `Conv2D(int,int,int)`, `Conv2D(int[],int[],int[])`, `Conv2D(...,MemoryFormat)` — all have GraphMode recording
- `TensorBroadcastTo` (composes Reshape + TensorBroadcastAdd, both recorded)
- `TensorLerp` (composes TensorSubtract + TensorMultiplyScalar + TensorAdd, all recorded)
- `TensorMatMulTransposed` generic fallback path (composes TensorTranspose + TensorMatMul, both recorded)

## Tests

Extended `GraphModeRecordingAuditTests` with 7 new tests covering each fix:
- Per numerical op: `LazySource`-invariant check + materialization-equivalence check (proves the recorded execute delegate computes the right values on replay, not just registers a placeholder)
- For `TensorMaskedSelect`: asserts `NotSupportedException` under GraphMode

**All 14/14 GraphModeRecordingAuditTests pass** on both net10.0 and net471.

## Test plan

- [x] Build clean on net10.0 + net471
- [x] All 14 GraphModeRecordingAuditTests pass on both TFMs
- [ ] CI: full Compilation + Autodiff suites green
- [ ] CI: full test suite green (no unrelated regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)