### PR TITLE
[Sub-F #374] BlasManaged perf sprint — routing shim (zero caller edits, makes A/B/C/D wins visible to production)

### DIFF
--- a/docs/superpowers/plans/2026-05-19-blas-perf-sub-F-routing-shim.md
+++ b/docs/superpowers/plans/2026-05-19-blas-perf-sub-F-routing-shim.md
@@ -1,0 +1,48 @@
+# Sub-issue F Implementation Plan — BlasProvider routing shim
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:executing-plans
+
+**Issue:** #374
+**Parent:** #368
+
+## Why this is the biggest lever
+
+Sub-A through Sub-D delivered real perf wins (2 outright wins, median 23.5×→21.5×, ResNet50_layer4 14×, ViT 5×). But **none of those wins are visible to production code** — every caller still goes through `BlasProvider.TryGemm` which routes to libopenblas. Sub-F is the wire that connects A/B/C/D to the 144 call sites.
+
+## Minimum viable Sub-F (this PR)
+
+**One static toggle:** `BlasManaged.PreferManaged`. When true, every `BlasProvider.TryGemm*` routes to `BlasManaged.Gemm<T>` instead of the native cblas path. When false (default), unchanged behavior.
+
+This is the simplest version that delivers value:
+- Zero changes to the 144 caller files
+- One flag flip exercises all of Sub-A/B/C/D
+- Tests can verify managed path correctness across the codebase
+- Supply-chain-conscious deployments (the original #368 motivation) just set this true at startup
+
+## Out-of-scope for Sub-F (deferred to F.2 follow-up)
+
+- **`PrefersManagedCache` autotune** — measures both paths per-shape, caches the winner. Useful when BlasManaged wins on some shapes and loses on others (current state). Can land as a follow-up PR; the `PreferManaged` global is the prerequisite.
+- **`TryGemmWithBeta` / `TryGemmExBeta`** — these have `beta != 0` (accumulating GEMM) which `BlasManaged.Gemm` doesn't support (it always does `C := AB`, not `C := αAB + βC`). Initial Sub-F only routes the `beta=0` overloads (TryGemm and TryGemmEx). The Beta variants stay native.
+- **Batched GEMM** (`TryGemmBatchSameShape*`) — different signature; stays native for now.
+
+## Tasks
+
+### F.1 — `BlasManaged.PreferManaged` static toggle + route TryGemm/TryGemmEx
+
+**Files:**
+- Modify: ``src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs`` (add static)
+- Modify: ``src/AiDotNet.Tensors/Helpers/BlasProvider.cs`` (add route check to 4 entry points)
+- Test: ``tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/RoutingShimTest.cs``
+
+**Acceptance:**
+- Setting `BlasManaged.PreferManaged = true` routes TryGemm/TryGemmEx through `BlasManaged.Gemm`
+- Output matches native dispatch bit-exact for shapes both can compute (most shapes; Streaming/PackBoth in deterministic mode)
+- Full existing test suite continues to pass with `PreferManaged = false` (the default)
+- A subset of tests with `PreferManaged = true` confirms managed path is exercised end-to-end
+
+### F.2 — Re-baseline with PreferManaged=true (verify production-visible perf)
+
+**Acceptance:**
+- Re-run baseline harness with `PreferManaged = true`
+- ResNet50_layer4 and LSTM_cell wins must be visible
+- Tied/winning shapes count must match Sub-D baseline (or better; autotune sub-F.3 could add more)

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
@@ -29,6 +29,20 @@ public static class BlasManaged
     internal const long TinyShapeWorkThreshold = 100_000;
 
     /// <summary>
+    /// Sub-issue F (#374): when true, <see cref="Helpers.BlasProvider.TryGemm"/> and
+    /// <see cref="Helpers.BlasProvider.TryGemmEx"/> route through <see cref="Gemm{T}"/>
+    /// instead of the native cblas P/Invoke. Provides a single flag to opt all 144
+    /// production call sites into managed dispatch — zero caller-side edits.
+    ///
+    /// <para>
+    /// Defaults to <see langword="false"/> (native path). Supply-chain-conscious
+    /// deployments set this to <see langword="true"/> at process startup to
+    /// eliminate the libopenblas / MKL attack surface.
+    /// </para>
+    /// </summary>
+    public static bool PreferManaged { get; set; } = false;
+
+    /// <summary>
     /// Computes C = op(A) · op(B), where op(X) is X or X^T.
     ///
     /// <para>

--- a/src/AiDotNet.Tensors/Helpers/BlasProvider.cs
+++ b/src/AiDotNet.Tensors/Helpers/BlasProvider.cs
@@ -925,6 +925,16 @@ internal static class BlasProvider
         float[] c, int cOffset, int ldc)
     {
         ShapeLogHook?.Invoke(m, n, k, false, false, typeof(float));
+        // Sub-F (#374) routing shim: caller-opt-in managed dispatch.
+        if (Engines.BlasManaged.BlasManaged.PreferManaged)
+        {
+            Engines.BlasManaged.BlasManaged.Gemm<float>(
+                new ReadOnlySpan<float>(a, aOffset, a.Length - aOffset), lda, false,
+                new ReadOnlySpan<float>(b, bOffset, b.Length - bOffset), ldb, false,
+                new Span<float>(c, cOffset, c.Length - cOffset), ldc,
+                m, n, k);
+            return true;
+        }
         if (!_nativeAvailable.Value) return false;
         try
         {
@@ -949,6 +959,15 @@ internal static class BlasProvider
         double[] c, int cOffset, int ldc)
     {
         ShapeLogHook?.Invoke(m, n, k, false, false, typeof(double));
+        if (Engines.BlasManaged.BlasManaged.PreferManaged)
+        {
+            Engines.BlasManaged.BlasManaged.Gemm<double>(
+                new ReadOnlySpan<double>(a, aOffset, a.Length - aOffset), lda, false,
+                new ReadOnlySpan<double>(b, bOffset, b.Length - bOffset), ldb, false,
+                new Span<double>(c, cOffset, c.Length - cOffset), ldc,
+                m, n, k);
+            return true;
+        }
         if (!_nativeAvailable.Value) return false;
         try
         {
@@ -971,6 +990,11 @@ internal static class BlasProvider
         ReadOnlySpan<float> a, int lda, ReadOnlySpan<float> b, int ldb, Span<float> c, int ldc)
     {
         ShapeLogHook?.Invoke(m, n, k, false, false, typeof(float));
+        if (Engines.BlasManaged.BlasManaged.PreferManaged)
+        {
+            Engines.BlasManaged.BlasManaged.Gemm<float>(a, lda, false, b, ldb, false, c, ldc, m, n, k);
+            return true;
+        }
         if (!_nativeAvailable.Value) return false;
         try
         {
@@ -993,6 +1017,11 @@ internal static class BlasProvider
         ReadOnlySpan<double> a, int lda, ReadOnlySpan<double> b, int ldb, Span<double> c, int ldc)
     {
         ShapeLogHook?.Invoke(m, n, k, false, false, typeof(double));
+        if (Engines.BlasManaged.BlasManaged.PreferManaged)
+        {
+            Engines.BlasManaged.BlasManaged.Gemm<double>(a, lda, false, b, ldb, false, c, ldc, m, n, k);
+            return true;
+        }
         if (!_nativeAvailable.Value) return false;
         try
         {
@@ -1065,6 +1094,15 @@ internal static class BlasProvider
         float[] c, int cOffset, int ldc)
     {
         ShapeLogHook?.Invoke(m, n, k, transA, transB, typeof(float));
+        if (Engines.BlasManaged.BlasManaged.PreferManaged)
+        {
+            Engines.BlasManaged.BlasManaged.Gemm<float>(
+                new ReadOnlySpan<float>(a, aOffset, a.Length - aOffset), lda, transA,
+                new ReadOnlySpan<float>(b, bOffset, b.Length - bOffset), ldb, transB,
+                new Span<float>(c, cOffset, c.Length - cOffset), ldc,
+                m, n, k);
+            return true;
+        }
         // Phase G.1: when AIDOTNET_BLAS_PROVIDER=mkl, the static-ctor
         // resolver redirects libopenblas → MklImports; the call below
         // then dispatches into MKL's cblas_sgemm transparently.
@@ -1100,6 +1138,15 @@ internal static class BlasProvider
         double[] c, int cOffset, int ldc)
     {
         ShapeLogHook?.Invoke(m, n, k, transA, transB, typeof(double));
+        if (Engines.BlasManaged.BlasManaged.PreferManaged)
+        {
+            Engines.BlasManaged.BlasManaged.Gemm<double>(
+                new ReadOnlySpan<double>(a, aOffset, a.Length - aOffset), lda, transA,
+                new ReadOnlySpan<double>(b, bOffset, b.Length - bOffset), ldb, transB,
+                new Span<double>(c, cOffset, c.Length - cOffset), ldc,
+                m, n, k);
+            return true;
+        }
         if (!_nativeAvailable.Value) return false;
         try
         {

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/RoutingShimTest.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/RoutingShimTest.cs
@@ -1,0 +1,156 @@
+using System;
+using AiDotNet.Tensors.Engines.BlasManaged;
+using AiDotNet.Tensors.Helpers;
+using Xunit;
+using BlasManagedLib = AiDotNet.Tensors.Engines.BlasManaged.BlasManaged;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+/// <summary>
+/// Sub-issue F (#374) task F.1: routing shim verification.
+///
+/// <para>
+/// When <see cref="BlasManagedLib.PreferManaged"/> is true,
+/// <see cref="BlasProvider.TryGemm"/> and <see cref="BlasProvider.TryGemmEx"/>
+/// must route to <see cref="BlasManagedLib.Gemm{T}"/> and return true. This is how
+/// the 144 production call sites across the codebase get Sub-A/B/C/D's wins
+/// without any caller-side edit.
+/// </para>
+///
+/// <para>
+/// Lives in BlasManaged-Stats-Serial collection because PreferManaged is a
+/// process-wide static; concurrent tests setting it would race.
+/// </para>
+/// </summary>
+[Collection("BlasManaged-Stats-Serial")]
+public class RoutingShimTest
+{
+    public RoutingShimTest()
+    {
+        // Each test starts with default state.
+        BlasManagedLib.PreferManaged = false;
+    }
+
+    [Fact]
+    public void Default_PreferManaged_Is_False()
+    {
+        Assert.False(BlasManagedLib.PreferManaged);
+    }
+
+    [Fact]
+    public void TryGemm_With_PreferManaged_True_Returns_True_And_Produces_Correct_Output_FP32()
+    {
+        const int M = 64, N = 64, K = 64;
+        var rng = new Random(42);
+        var a = new float[M * K];
+        var b = new float[K * N];
+        var cNative = new float[M * N];
+        var cManaged = new float[M * N];
+        for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+        for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+
+        // Native path baseline (if available). When libopenblas isn't loaded,
+        // TryGemm returns false and we skip the comparison.
+        BlasManagedLib.PreferManaged = false;
+        bool nativeOk = BlasProvider.TryGemm(M, N, K, a, 0, K, b, 0, N, cNative, 0, N);
+
+        // Routed-managed path.
+        BlasManagedLib.PreferManaged = true;
+        try
+        {
+            bool managedOk = BlasProvider.TryGemm(M, N, K, a, 0, K, b, 0, N, cManaged, 0, N);
+            Assert.True(managedOk, "TryGemm must return true when PreferManaged=true");
+
+            // Output must be non-zero (kernel actually ran).
+            bool anyNonZero = false;
+            for (int i = 0; i < cManaged.Length; i++) if (cManaged[i] != 0) { anyNonZero = true; break; }
+            Assert.True(anyNonZero, "Managed path produced all-zero output");
+
+            // If native ran, compare. Tolerance: relaxed because BlasManaged uses FMA
+            // (in Fast mode default) which differs from non-FMA scalar by 1 ULP.
+            // Actually, the default Mode is Deterministic — should be bit-exact with
+            // OpenBLAS on non-FMA paths. But OpenBLAS may use FMA too, in which case
+            // results may differ by ULPs. Use relative tolerance.
+            if (nativeOk)
+            {
+                double maxRelDelta = 0;
+                for (int i = 0; i < cNative.Length; i++)
+                {
+                    float n_ = cNative[i], m_ = cManaged[i];
+                    if (n_ == 0 && m_ == 0) continue;
+                    double rel = Math.Abs(n_ - m_) / Math.Max(Math.Abs(n_), Math.Abs(m_));
+                    if (rel > maxRelDelta) maxRelDelta = rel;
+                }
+                Assert.True(maxRelDelta < 1e-4, $"Routed managed path drift vs native: {maxRelDelta:G6}");
+            }
+        }
+        finally
+        {
+            BlasManagedLib.PreferManaged = false;
+        }
+    }
+
+    [Fact]
+    public void TryGemmEx_With_PreferManaged_True_Handles_Transposed_FP32()
+    {
+        const int M = 64, N = 32, K = 64;
+        var rng = new Random(42);
+        var a = new float[K * M];  // transA=true: A is [K, M]
+        var b = new float[K * N];
+        var cNative = new float[M * N];
+        var cManaged = new float[M * N];
+        for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+        for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+
+        BlasManagedLib.PreferManaged = false;
+        bool nativeOk = BlasProvider.TryGemmEx(M, N, K, a, 0, M, true, b, 0, N, false, cNative, 0, N);
+
+        BlasManagedLib.PreferManaged = true;
+        try
+        {
+            bool managedOk = BlasProvider.TryGemmEx(M, N, K, a, 0, M, true, b, 0, N, false, cManaged, 0, N);
+            Assert.True(managedOk);
+
+            bool anyNonZero = false;
+            for (int i = 0; i < cManaged.Length; i++) if (cManaged[i] != 0) { anyNonZero = true; break; }
+            Assert.True(anyNonZero);
+
+            if (nativeOk)
+            {
+                double maxRelDelta = 0;
+                for (int i = 0; i < cNative.Length; i++)
+                {
+                    float n_ = cNative[i], m_ = cManaged[i];
+                    if (n_ == 0 && m_ == 0) continue;
+                    double rel = Math.Abs(n_ - m_) / Math.Max(Math.Abs(n_), Math.Abs(m_));
+                    if (rel > maxRelDelta) maxRelDelta = rel;
+                }
+                Assert.True(maxRelDelta < 1e-4, $"Routed managed transposed-A drift: {maxRelDelta:G6}");
+            }
+        }
+        finally
+        {
+            BlasManagedLib.PreferManaged = false;
+        }
+    }
+
+    [Fact]
+    public void TryGemm_With_PreferManaged_False_Goes_Through_Native_Path()
+    {
+        // This is the default behavior; just confirm TryGemm still works when
+        // the toggle is off (no regression to the existing native path).
+        const int M = 32, N = 32, K = 32;
+        var rng = new Random(42);
+        var a = new float[M * K];
+        var b = new float[K * N];
+        var c = new float[M * N];
+        for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+        for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+
+        BlasManagedLib.PreferManaged = false;
+        bool ok = BlasProvider.TryGemm(M, N, K, a, 0, K, b, 0, N, c, 0, N);
+        // If native is available, ok=true; if not, ok=false. Both are acceptable —
+        // we're just confirming the default path is unchanged.
+        Assert.Equal(BlasProvider.IsAvailable, ok);
+    }
+}


### PR DESCRIPTION
**Closes:** #374 (F.1 — F.3+ in follow-up)
**Parent:** #368
**Stacks on:** PR #385 (D), #384 (C), #383 (B), #381 (A), #366.

## Why this PR is the highest-leverage of the sprint

Sub-A through Sub-D delivered measurable perf wins (2 wins, 14× on ResNet50_layer4, 5× on ViT, partial-M correctness fix). **None of those wins are visible to production code** — every BlasProvider call site still routes to libopenblas. This PR adds the wire.

## How it works

```csharp
// One static toggle:
BlasManaged.PreferManaged = true;  // Set once at process startup

// Then every BlasProvider.TryGemm/TryGemmEx call routes to BlasManaged.Gemm.
// All 144 call sites get Sub-A/B/C/D's wins. Zero caller-side edits.
```

When ``BlasManaged.PreferManaged`` is false (default), behavior is unchanged — native cblas dispatch as before. Routing shim is opt-in.

## Commits

| Commit | Task | Summary |
|--------|------|---------|
| ``9f3fbc8`` | (plan) | Sub-F plan committed |
| ``d05358f`` | F.1 | ``PreferManaged`` toggle + routing in 6 Try* entry points |

## What routes through the shim (F.1 scope)

| Entry point | Routed? | Notes |
|-------------|---------|-------|
| ``TryGemm(float[], …)`` | ✓ | NoTrans, beta=0 |
| ``TryGemm(double[], …)`` | ✓ | NoTrans, beta=0 |
| ``TryGemm(ReadOnlySpan<float>, …)`` | ✓ | NoTrans, beta=0 |
| ``TryGemm(ReadOnlySpan<double>, …)`` | ✓ | NoTrans, beta=0 |
| ``TryGemmEx(float[], …, transA, transB, …)`` | ✓ | beta=0 |
| ``TryGemmEx(double[], …, transA, transB, …)`` | ✓ | beta=0 |
| ``TryGemmWithBeta`` (FP32/FP64) | — | beta != 0; BlasManaged.Gemm doesn't yet support; native |
| ``TryGemmExBeta`` (FP32/FP64) | — | Same |
| ``TryGemmBatchSameShape*`` | — | Different signature; native |
| Raw pointer variants (``SgemmRaw`` / ``DgemmRaw`` / ``SgemmDirect``) | — | Hot-path inner callers from SIMD fast paths; native |

## Deferred to F.3+ follow-ups

- **`PrefersManagedCache` autotune** — measure both paths once per shape, cache the winner. The expected next step now that the shim is in place. Closes the "BlasManaged sometimes loses" gap.
- **TryGemmWithBeta / TryGemmExBeta routing** — requires extending ``BlasManaged.Gemm`` to support beta != 0 (accumulating GEMM). Separate spec item.
- **Batched-GEMM routing** — requires a managed batched-GEMM implementation.

## Tests (4/4 pass)

```
RoutingShimTest
  ✓ Default_PreferManaged_Is_False
  ✓ TryGemm_With_PreferManaged_True_Returns_True_And_Produces_Correct_Output_FP32
    (1e-4 relative tolerance vs native — BlasManaged may use FMA, OpenBLAS may not;
     both are within ULPs)
  ✓ TryGemmEx_With_PreferManaged_True_Handles_Transposed_FP32  (transA verified)
  ✓ TryGemm_With_PreferManaged_False_Goes_Through_Native_Path  (default path unchanged)

Full BlasManaged set: 295/295 PASS, no regressions
```

## Cumulative state (pre-B → post-F)

After this PR lands, ``PreferManaged = true`` makes the production codebase use BlasManaged. Re-measuring under PreferManaged=true will confirm Sub-A/B/C/D's wins are visible end-to-end.

## What's next

- **Sub-G** (#375 — native BLAS removal) becomes the natural next step once F.3 (PrefersManagedCache autotune) lands and proves BlasManaged is safe to use even where it's slower.
- The mega tracking issue (#368) has the perf bar codified at 80% wins / 1.20× max loss. Current state is 2/54 wins — Sub-G is gated on hitting 80%. Sub-D follow-ups (FP64 AVX2, AVX-512, prefetch, partial-M kernel) will be needed to clear that bar.

Plan: ``docs/superpowers/plans/2026-05-19-blas-perf-sub-F-routing-shim.md``

🤖 Generated with [Claude Code](https://claude.com/claude-code)