### PR TITLE
[Sub-F3 #374] PrefersManagedCache — per-shape measurement-driven dispatch

### DIFF
--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
@@ -43,6 +43,21 @@ public static class BlasManaged
     public static bool PreferManaged { get; set; } = false;
 
     /// <summary>
+    /// Sub-F3 (#374 follow-up): when true, <see cref="Helpers.BlasProvider.TryGemmEx"/>
+    /// consults <see cref="PrefersManagedCache"/> on each call. The cache measures
+    /// both managed and native paths once per (shape, hardware) tuple and routes
+    /// future calls to the winner.
+    ///
+    /// <para>
+    /// Defaults to <see langword="false"/> (no autotune routing).
+    /// <see cref="PreferManaged"/> takes precedence — when both are true,
+    /// every call routes managed regardless of autotune. This lets supply-chain
+    /// deployments override autotune (forcing managed dispatch unconditionally).
+    /// </para>
+    /// </summary>
+    public static bool AutotuneRouting { get; set; } = false;
+
+    /// <summary>
     /// Computes C = op(A) · op(B), where op(X) is X or X^T.
     ///
     /// <para>

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Dispatcher/PrefersManagedCache.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Dispatcher/PrefersManagedCache.cs
@@ -1,0 +1,255 @@
+using System;
+using System.Buffers;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using AiDotNet.Tensors.Helpers;
+using BlasManagedLib = AiDotNet.Tensors.Engines.BlasManaged.BlasManaged;
+
+namespace AiDotNet.Tensors.Engines.BlasManaged;
+
+/// <summary>
+/// Sub-F3 (#374 follow-up): per-shape autotune cache that picks managed vs native
+/// dispatch based on measurement.
+///
+/// <para>
+/// On cache miss: allocate matching temp buffers, run both <see cref="BlasManagedLib.Gemm{T}"/>
+/// and <see cref="BlasProvider.TryGemmEx"/> (with autotune bypass), time each, cache the winner.
+/// On cache hit: return the cached preference in O(1).
+/// </para>
+///
+/// <para>
+/// Bypass mechanism: <see cref="BypassAutotune"/> is a <see cref="ThreadStaticAttribute"/>
+/// bool that the measurement helpers flip while calling <see cref="BlasProvider.TryGemmEx"/>.
+/// This routes the measurement call past the autotune check (so native dispatch fires)
+/// without affecting concurrent threads in production code.
+/// </para>
+///
+/// <para>
+/// Memory: in-memory <see cref="ConcurrentDictionary{TKey, TValue}"/>. On-disk
+/// persistence is deferred to a follow-up — F.3 ships the measurement logic; F.4
+/// would add the file-backed cache so warmup amortizes across processes.
+/// </para>
+/// </summary>
+public static class PrefersManagedCache
+{
+    private readonly record struct ShapeKey(
+        int M, int N, int K, bool TransA, bool TransB, byte Dtype);
+
+    private static readonly ConcurrentDictionary<ShapeKey, bool> _cache = new();
+
+    /// <summary>
+    /// Thread-local bypass flag. Set to true inside the measurement helpers so
+    /// the nested <see cref="BlasProvider.TryGemmEx"/> call routes to native
+    /// without re-entering this cache.
+    /// </summary>
+    [ThreadStatic] internal static bool BypassAutotune;
+
+    /// <summary>
+    /// Number of probe iterations per backend during measurement. Small (3) keeps
+    /// first-call overhead low; the noise floor is acceptable because the goal
+    /// is to pick the better path, not to produce a precise speedup number.
+    /// </summary>
+    private const int ProbeIters = 3;
+
+    /// <summary>
+    /// Clears the cache. Used by tests to ensure measurement fires fresh.
+    /// </summary>
+    public static void Clear() => _cache.Clear();
+
+    /// <summary>Returns the current number of cached decisions.</summary>
+    public static int Count => _cache.Count;
+
+    /// <summary>
+    /// Returns true if BlasManaged is the preferred dispatch for this shape.
+    /// Measures on cache miss; returns cached result on hit.
+    /// </summary>
+    /// <param name="m">Rows of C.</param>
+    /// <param name="n">Cols of C.</param>
+    /// <param name="k">Inner dim.</param>
+    /// <param name="transA">Whether A is transposed.</param>
+    /// <param name="transB">Whether B is transposed.</param>
+    /// <param name="dtype">Element type (typeof(float) or typeof(double)).</param>
+    public static bool PrefersManaged(
+        int m, int n, int k, bool transA, bool transB, Type dtype)
+    {
+        byte dtypeKey = dtype == typeof(float) ? (byte)1
+                       : dtype == typeof(double) ? (byte)2 : (byte)0;
+        if (dtypeKey == 0) return true;  // unknown dtype — managed path is the only supported
+
+        var key = new ShapeKey(m, n, k, transA, transB, dtypeKey);
+        if (_cache.TryGetValue(key, out bool cached)) return cached;
+
+        // Cache miss — measure. If native isn't available, prefer managed.
+        if (!BlasProvider.IsAvailable)
+        {
+            _cache[key] = true;
+            return true;
+        }
+
+        bool prefersManaged = dtypeKey == 1
+            ? MeasureFp32(m, n, k, transA, transB)
+            : MeasureFp64(m, n, k, transA, transB);
+        _cache[key] = prefersManaged;
+        return prefersManaged;
+    }
+
+    private static bool MeasureFp32(int m, int n, int k, bool transA, bool transB)
+    {
+        int aRows = transA ? k : m;
+        int aCols = transA ? m : k;
+        int bRows = transB ? n : k;
+        int bCols = transB ? k : n;
+        int aLen = aRows * aCols;
+        int bLen = bRows * bCols;
+        int cLen = m * n;
+
+        var a = ArrayPool<float>.Shared.Rent(aLen);
+        var b = ArrayPool<float>.Shared.Rent(bLen);
+        var c = ArrayPool<float>.Shared.Rent(cLen);
+        try
+        {
+            var rng = new Random(42);
+            for (int i = 0; i < aLen; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+            for (int i = 0; i < bLen; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+
+            int lda = aCols, ldb = bCols, ldc = n;
+
+            // Warmup each path once.
+            BlasManagedLib.Gemm<float>(
+                new ReadOnlySpan<float>(a, 0, aLen), lda, transA,
+                new ReadOnlySpan<float>(b, 0, bLen), ldb, transB,
+                new Span<float>(c, 0, cLen), ldc,
+                m, n, k);
+
+            BypassAutotune = true;
+            try
+            {
+                BlasProvider.TryGemmEx(
+                    m, n, k,
+                    a, 0, lda, transA,
+                    b, 0, ldb, transB,
+                    c, 0, ldc);
+            }
+            finally { BypassAutotune = false; }
+
+            // Time managed.
+            var sw = Stopwatch.StartNew();
+            for (int i = 0; i < ProbeIters; i++)
+            {
+                BlasManagedLib.Gemm<float>(
+                    new ReadOnlySpan<float>(a, 0, aLen), lda, transA,
+                    new ReadOnlySpan<float>(b, 0, bLen), ldb, transB,
+                    new Span<float>(c, 0, cLen), ldc,
+                    m, n, k);
+            }
+            sw.Stop();
+            double managedMs = sw.Elapsed.TotalMilliseconds / ProbeIters;
+
+            // Time native (with autotune bypass).
+            BypassAutotune = true;
+            double nativeMs;
+            try
+            {
+                sw.Restart();
+                for (int i = 0; i < ProbeIters; i++)
+                {
+                    BlasProvider.TryGemmEx(
+                        m, n, k,
+                        a, 0, lda, transA,
+                        b, 0, ldb, transB,
+                        c, 0, ldc);
+                }
+                sw.Stop();
+                nativeMs = sw.Elapsed.TotalMilliseconds / ProbeIters;
+            }
+            finally { BypassAutotune = false; }
+
+            return managedMs <= nativeMs;
+        }
+        finally
+        {
+            ArrayPool<float>.Shared.Return(a);
+            ArrayPool<float>.Shared.Return(b);
+            ArrayPool<float>.Shared.Return(c);
+        }
+    }
+
+    private static bool MeasureFp64(int m, int n, int k, bool transA, bool transB)
+    {
+        int aRows = transA ? k : m;
+        int aCols = transA ? m : k;
+        int bRows = transB ? n : k;
+        int bCols = transB ? k : n;
+        int aLen = aRows * aCols;
+        int bLen = bRows * bCols;
+        int cLen = m * n;
+
+        var a = ArrayPool<double>.Shared.Rent(aLen);
+        var b = ArrayPool<double>.Shared.Rent(bLen);
+        var c = ArrayPool<double>.Shared.Rent(cLen);
+        try
+        {
+            var rng = new Random(42);
+            for (int i = 0; i < aLen; i++) a[i] = rng.NextDouble() * 2 - 1;
+            for (int i = 0; i < bLen; i++) b[i] = rng.NextDouble() * 2 - 1;
+
+            int lda = aCols, ldb = bCols, ldc = n;
+
+            BlasManagedLib.Gemm<double>(
+                new ReadOnlySpan<double>(a, 0, aLen), lda, transA,
+                new ReadOnlySpan<double>(b, 0, bLen), ldb, transB,
+                new Span<double>(c, 0, cLen), ldc,
+                m, n, k);
+
+            BypassAutotune = true;
+            try
+            {
+                BlasProvider.TryGemmEx(
+                    m, n, k,
+                    a, 0, lda, transA,
+                    b, 0, ldb, transB,
+                    c, 0, ldc);
+            }
+            finally { BypassAutotune = false; }
+
+            var sw = Stopwatch.StartNew();
+            for (int i = 0; i < ProbeIters; i++)
+            {
+                BlasManagedLib.Gemm<double>(
+                    new ReadOnlySpan<double>(a, 0, aLen), lda, transA,
+                    new ReadOnlySpan<double>(b, 0, bLen), ldb, transB,
+                    new Span<double>(c, 0, cLen), ldc,
+                    m, n, k);
+            }
+            sw.Stop();
+            double managedMs = sw.Elapsed.TotalMilliseconds / ProbeIters;
+
+            BypassAutotune = true;
+            double nativeMs;
+            try
+            {
+                sw.Restart();
+                for (int i = 0; i < ProbeIters; i++)
+                {
+                    BlasProvider.TryGemmEx(
+                        m, n, k,
+                        a, 0, lda, transA,
+                        b, 0, ldb, transB,
+                        c, 0, ldc);
+                }
+                sw.Stop();
+                nativeMs = sw.Elapsed.TotalMilliseconds / ProbeIters;
+            }
+            finally { BypassAutotune = false; }
+
+            return managedMs <= nativeMs;
+        }
+        finally
+        {
+            ArrayPool<double>.Shared.Return(a);
+            ArrayPool<double>.Shared.Return(b);
+            ArrayPool<double>.Shared.Return(c);
+        }
+    }
+}

--- a/src/AiDotNet.Tensors/Helpers/BlasProvider.cs
+++ b/src/AiDotNet.Tensors/Helpers/BlasProvider.cs
@@ -1103,6 +1103,20 @@ internal static class BlasProvider
                 m, n, k);
             return true;
         }
+        // Sub-F3 (#374 follow-up): per-shape autotune routing.
+        // BypassAutotune is a ThreadStatic flag the PrefersManagedCache flips
+        // during its measurement probe so the nested call goes to native.
+        if (Engines.BlasManaged.BlasManaged.AutotuneRouting
+            && !Engines.BlasManaged.PrefersManagedCache.BypassAutotune
+            && Engines.BlasManaged.PrefersManagedCache.PrefersManaged(m, n, k, transA, transB, typeof(float)))
+        {
+            Engines.BlasManaged.BlasManaged.Gemm<float>(
+                new ReadOnlySpan<float>(a, aOffset, a.Length - aOffset), lda, transA,
+                new ReadOnlySpan<float>(b, bOffset, b.Length - bOffset), ldb, transB,
+                new Span<float>(c, cOffset, c.Length - cOffset), ldc,
+                m, n, k);
+            return true;
+        }
         // Phase G.1: when AIDOTNET_BLAS_PROVIDER=mkl, the static-ctor
         // resolver redirects libopenblas → MklImports; the call below
         // then dispatches into MKL's cblas_sgemm transparently.
@@ -1139,6 +1153,17 @@ internal static class BlasProvider
     {
         ShapeLogHook?.Invoke(m, n, k, transA, transB, typeof(double));
         if (Engines.BlasManaged.BlasManaged.PreferManaged)
+        {
+            Engines.BlasManaged.BlasManaged.Gemm<double>(
+                new ReadOnlySpan<double>(a, aOffset, a.Length - aOffset), lda, transA,
+                new ReadOnlySpan<double>(b, bOffset, b.Length - bOffset), ldb, transB,
+                new Span<double>(c, cOffset, c.Length - cOffset), ldc,
+                m, n, k);
+            return true;
+        }
+        if (Engines.BlasManaged.BlasManaged.AutotuneRouting
+            && !Engines.BlasManaged.PrefersManagedCache.BypassAutotune
+            && Engines.BlasManaged.PrefersManagedCache.PrefersManaged(m, n, k, transA, transB, typeof(double)))
         {
             Engines.BlasManaged.BlasManaged.Gemm<double>(
                 new ReadOnlySpan<double>(a, aOffset, a.Length - aOffset), lda, transA,

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/PrefersManagedCacheTest.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/PrefersManagedCacheTest.cs
@@ -1,0 +1,140 @@
+using System;
+using AiDotNet.Tensors.Engines.BlasManaged;
+using AiDotNet.Tensors.Helpers;
+using Xunit;
+using BlasManagedLib = AiDotNet.Tensors.Engines.BlasManaged.BlasManaged;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+/// <summary>
+/// Sub-F3 (#374) task: verifies <see cref="PrefersManagedCache"/> measures both
+/// paths on cache miss, caches the winner, and routes <see cref="BlasProvider.TryGemmEx"/>
+/// through the cached decision when <see cref="BlasManagedLib.AutotuneRouting"/> is true.
+/// </summary>
+[Collection("BlasManaged-Stats-Serial")]
+public class PrefersManagedCacheTest
+{
+    public PrefersManagedCacheTest()
+    {
+        PrefersManagedCache.Clear();
+        BlasManagedLib.AutotuneRouting = false;
+        BlasManagedLib.PreferManaged = false;
+    }
+
+    [Fact]
+    public void Default_AutotuneRouting_Is_False()
+    {
+        Assert.False(BlasManagedLib.AutotuneRouting);
+    }
+
+    [Fact]
+    public void First_Call_Populates_Cache()
+    {
+        PrefersManagedCache.Clear();
+        Assert.Equal(0, PrefersManagedCache.Count);
+
+        // Trigger measurement.
+        bool result = PrefersManagedCache.PrefersManaged(64, 64, 64, false, false, typeof(float));
+
+        Assert.Equal(1, PrefersManagedCache.Count);
+        // Result is true or false depending on which path was faster — we don't
+        // assert direction, just that it stabilizes.
+        bool result2 = PrefersManagedCache.PrefersManaged(64, 64, 64, false, false, typeof(float));
+        Assert.Equal(result, result2);
+        Assert.Equal(1, PrefersManagedCache.Count);  // still one entry — cache hit
+    }
+
+    [Fact]
+    public void Different_Shapes_Get_Different_Cache_Entries()
+    {
+        PrefersManagedCache.Clear();
+        PrefersManagedCache.PrefersManaged(32, 32, 32, false, false, typeof(float));
+        PrefersManagedCache.PrefersManaged(64, 64, 64, false, false, typeof(float));
+        PrefersManagedCache.PrefersManaged(32, 32, 32, false, false, typeof(double));  // FP64 differs by dtype
+        Assert.Equal(3, PrefersManagedCache.Count);
+    }
+
+    [Fact]
+    public void TryGemmEx_With_AutotuneRouting_Returns_Correct_Output_FP32()
+    {
+        PrefersManagedCache.Clear();
+        BlasManagedLib.AutotuneRouting = true;
+        try
+        {
+            const int M = 64, N = 64, K = 64;
+            var rng = new Random(42);
+            var a = new float[M * K];
+            var b = new float[K * N];
+            var c = new float[M * N];
+            for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+            for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+
+            bool ok = BlasProvider.TryGemmEx(M, N, K, a, 0, K, false, b, 0, N, false, c, 0, N);
+            Assert.True(ok);
+
+            // Output is non-zero (kernel actually ran via cache-routed path).
+            bool anyNonZero = false;
+            for (int i = 0; i < c.Length; i++) if (c[i] != 0) { anyNonZero = true; break; }
+            Assert.True(anyNonZero);
+
+            // Cache was populated.
+            Assert.True(PrefersManagedCache.Count >= 1);
+        }
+        finally
+        {
+            BlasManagedLib.AutotuneRouting = false;
+        }
+    }
+
+    [Fact]
+    public void Default_Behavior_Unchanged_When_AutotuneRouting_False()
+    {
+        BlasManagedLib.AutotuneRouting = false;
+        BlasManagedLib.PreferManaged = false;
+        PrefersManagedCache.Clear();
+
+        const int M = 32, N = 32, K = 32;
+        var rng = new Random(42);
+        var a = new float[M * K];
+        var b = new float[K * N];
+        var c = new float[M * N];
+        for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+        for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+
+        bool ok = BlasProvider.TryGemmEx(M, N, K, a, 0, K, false, b, 0, N, false, c, 0, N);
+
+        // With autotune off, cache must NOT be touched.
+        Assert.Equal(0, PrefersManagedCache.Count);
+        // ok matches native availability (same as pre-F3 behavior).
+        Assert.Equal(BlasProvider.IsAvailable, ok);
+    }
+
+    [Fact]
+    public void PreferManaged_True_Bypasses_Autotune()
+    {
+        BlasManagedLib.PreferManaged = true;
+        BlasManagedLib.AutotuneRouting = true;
+        PrefersManagedCache.Clear();
+        try
+        {
+            const int M = 32, N = 32, K = 32;
+            var rng = new Random(42);
+            var a = new float[M * K];
+            var b = new float[K * N];
+            var c = new float[M * N];
+            for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+            for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+
+            bool ok = BlasProvider.TryGemmEx(M, N, K, a, 0, K, false, b, 0, N, false, c, 0, N);
+            Assert.True(ok);
+
+            // PreferManaged is checked BEFORE autotune; cache should still be empty.
+            Assert.Equal(0, PrefersManagedCache.Count);
+        }
+        finally
+        {
+            BlasManagedLib.PreferManaged = false;
+            BlasManagedLib.AutotuneRouting = false;
+        }
+    }
+}


### PR DESCRIPTION
Closes #374

**Related:** #374 (originally deferred F.3 follow-up)
**Stacks on:** PR #397 (B.5)

## Why this PR matters

After 13 PRs of microkernel + threading work, the next gains are **per-shape**:
- Some shapes win with 2D-grid (B.5), others with M-axis
- Some benefit from 8-acc Streaming (D7), others from 4-acc (D9)
- Some are AVX2-friendly aligned (D, D2), others fall to Streaming via D4 split

Every heuristic threshold I've tuned (m < 256 in B.5, M=1 detection in D9) carries D3/D7-style regression risk on shapes the heuristic doesn't help.

**F.3 fixes this** by measuring both paths per-shape and caching the winner. Future microkernel work can ship safely because the cache routes loser shapes to whichever path actually wins.

## What this PR does

```csharp
// One flag to opt all 144 production call sites into per-shape autotune:
BlasManaged.AutotuneRouting = true;

// Internally: ConcurrentDictionary<(m, n, k, transA, transB, dtype), bool>
// On cache miss: time both paths on temp buffers, cache winner.
// On cache hit: O(1) dispatch decision.
```

## Dispatch order in `BlasProvider.TryGemmEx`

```
1. ShapeLogHook (instrumentation)
2. PreferManaged → managed (unconditional override)
3. AutotuneRouting AND !BypassAutotune AND PrefersManagedCache.PrefersManaged → managed
4. Native fall-through
```

`PreferManaged` precedence ensures supply-chain-conscious deployments get unconditional managed dispatch (zero autotune overhead).

## Bypass mechanism

`PrefersManagedCache.BypassAutotune` is a `ThreadStatic` bool the measurement helpers flip while calling `BlasProvider.TryGemmEx` for the native probe. This routes past the autotune check without affecting concurrent threads in production code.

## Measurement protocol (cache miss)

```
1. Allocate temp A/B/C from ArrayPool matching the shape
2. Warmup each path once
3. Time managed: 3 iters of BlasManaged.Gemm
4. Time native: 3 iters of BlasProvider.TryGemmEx (with BypassAutotune=true)
5. Cache winner (managedMs <= nativeMs)
```

3 iters is small enough that first-call overhead is bounded, large enough that the choice is robust to single-iter noise.

## Out of F.3 scope (deferred to F.4)

- **On-disk persistence** under `~/.aidotnet/autotune/` — F.3 cache is in-memory only (warm-up cost amortizes within a process but not across processes)
- **HardwareFingerprint inclusion** in the cache key — important when caches are persisted
- **Periodic re-measurement** — currently cache-forever
- **TryGemmWithBeta autotune** — requires extending `BlasManaged.Gemm` for β≠0

## Tests (6/6 pass)

```
PrefersManagedCacheTest
  ✓ Default_AutotuneRouting_Is_False
  ✓ First_Call_Populates_Cache              (measure once, hit thereafter)
  ✓ Different_Shapes_Get_Different_Cache_Entries
  ✓ TryGemmEx_With_AutotuneRouting_Returns_Correct_Output_FP32
  ✓ Default_Behavior_Unchanged_When_AutotuneRouting_False  ← regression canary
  ✓ PreferManaged_True_Bypasses_Autotune    (precedence enforced)

Full BlasManaged set: 313/313 PASS, no regressions.
```

## Cumulative state — no change to baseline metrics

F.3 doesn't move the catalog numbers because the baseline harness measures `BlasManaged.Gemm` directly, not via the routing shim. The value of F.3 is **for production traffic going through `BlasProvider.TryGemm[Ex]`** — those 144 call sites can now opt into per-shape optimal routing with one flag flip.

Once `AutotuneRouting = true` is the default in a follow-up, the catalog metric will reflect the autotuned path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)