### PR TITLE
[Sub-F5 #374] ProbeIters 3 → 10 (catch oscillating M=1 shapes)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Dispatcher/PrefersManagedCache.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Dispatcher/PrefersManagedCache.cs
@@ -181,11 +181,18 @@ public static class PrefersManagedCache
     }
 
     /// <summary>
-    /// Number of probe iterations per backend during measurement. Small (3) keeps
-    /// first-call overhead low; the noise floor is acceptable because the goal
-    /// is to pick the better path, not to produce a precise speedup number.
+    /// Number of probe iterations per backend during measurement.
+    ///
+    /// <para>
+    /// Sub-F5: bumped from 3 → 10. The F.3/F.4 diagnostic showed sub-ms shapes
+    /// (M=1 inference) get noisy results at 3 iters — MobileNetV2_fc oscillated
+    /// between managed-routed and native-routed across runs. 10 iters reduces
+    /// variance enough that borderline shapes converge to a stable decision.
+    /// First-call cost rises to ~10× normal GEMM, but only once per (shape, host)
+    /// over the cache's lifetime.
+    /// </para>
     /// </summary>
-    private const int ProbeIters = 3;
+    private const int ProbeIters = 10;
 
     /// <summary>
     /// Clears the in-memory cache and resets the disk-loaded flag. Used by tests


### PR DESCRIPTION
Closes #374

**Related:** #374
**Stacks on:** PR #399 (F.4)

## Headline

Bumping ``PrefersManagedCache.ProbeIters`` from **3 → 10** flips one borderline shape (MobileNetV2_fc) from native-routed to managed-routed.

## Why

F.4 diagnostic on the catalog showed MobileNetV2_fc_1×1000×1280 oscillating between managed and native across consecutive autotune runs. The 3-iter probe couldn't distinguish a 1.04× ratio from 1.05× amid sub-ms timing noise.

## Result (catalog decisions on x64-amd-avx2-cpu16)

| ProbeIters | Managed-routed | Shapes |
|-----------:|---------------:|--------|
| 3 (F.3 default) | 3 | LSTM_cell ×2, GRU_cell |
| 10 (F.5) | **4** | + MobileNetV2_fc |

## Cost

First-call overhead per shape rises from ~3× normal GEMM to ~10×. Amortized:
- One-time per (shape, host) within a process
- Persisted across processes via F.4 disk cache
- Negligible against the lifetime of a long-running inference server

## Tests

```
PrefersManagedCacheTest    8/8 PASS (unchanged from F.4)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)