### PR TITLE
perf(#1305): fix three double-precision SD UNet cliffs + compile-mode forward 2x faster than eager

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -2482,6 +2482,125 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             };
         }
 
+        // TensorBroadcastAdd forward: route compiled-plan replay through
+        // a copy-into-output + TensorBroadcastAddInPlace pair instead of the
+        // generic "allocate fresh result + memcpy into plan output" closure.
+        // Used in every SD UNet ResBlock for the time-embedding conditioning
+        // (15+ calls per UNet forward × 10 sampling steps per Predict).
+        //
+        // Save: 1 tensor allocation per Execute. Still pays one memcpy (to copy
+        // `a` into the plan's output buffer before the in-place add), but that
+        // memcpy is one fewer than the generic path which copies the eager
+        // result back into the output buffer.
+        if (step.OpType == OpType.TensorBroadcastAdd && step.Inputs.Length == 2
+            && step.Inputs[0].IsContiguous && step.Inputs[1].IsContiguous)
+        {
+            var a = step.Inputs[0];
+            var b = step.Inputs[1];
+            var o = step.OutputBuffer;
+            // Same-shape fast path: just call TensorAddInPlace (no broadcast needed).
+            // Many SD ResBlock residual adds hit this — both operands are
+            // [batch, channels, h, w].
+            bool sameShape = a._shape.Length == b._shape.Length;
+            if (sameShape)
+            {
+                for (int d = 0; d < a._shape.Length; d++)
+                {
+                    if (a._shape[d] != b._shape[d]) { sameShape = false; break; }
+                }
+            }
+            if (sameShape)
+            {
+                return eng =>
+                {
+                    a.AsSpan().CopyTo(o.AsWritableSpan());
+                    if (eng is CpuEngine cpuEng) cpuEng.TensorAddInPlace(o, b);
+                    else { var r = eng.TensorAdd(a, b); r.AsSpan().CopyTo(o.AsWritableSpan()); }
+                };
+            }
+            // Broadcast path: copy a into output, then in-place add b (b is the
+            // smaller operand and broadcasts up to a's shape).
+            return eng =>
+            {
+                a.AsSpan().CopyTo(o.AsWritableSpan());
+                if (eng is CpuEngine cpuEng) cpuEng.TensorBroadcastAddInPlace(o, b);
+                else { var r = eng.TensorBroadcastAdd(a, b); r.AsSpan().CopyTo(o.AsWritableSpan()); }
+            };
+        }
+
+        // ConvTranspose2D forward: route compiled-plan replay through
+        // ConvTranspose2DInto (added in this PR) so per-Execute is zero-alloc
+        // and writes directly into the plan's pre-allocated output buffer.
+        // The SD UNet decoder Upsamples are ConvTranspose2D at 1280-channel SD shapes
+        // (~1 s/forward across three upsample stages), so eliminating the per-call
+        // tensor alloc compounds × 10 sampling steps per Predict.
+        //
+        // SavedState layout for ConvTranspose2D (set at CpuEngine.ConvTranspose2D
+        // record-site): [int[] stride, int[] padding]. Output-padding defaults to
+        // {0,0} since the compiled plan only replays the exact traced graph; if
+        // the trace ever runs with non-zero outputPadding the GraphMode recording
+        // captures it in a different SavedState layout that this case won't match,
+        // and we fall through to the generic recorded closure.
+        if (step.OpType == OpType.ConvTranspose2D && step.Inputs.Length == 2
+            && step.Inputs[0].IsContiguous && step.Inputs[1].IsContiguous
+            && step.SavedState is { Length: >= 2 }
+            && step.SavedState[0] is int[] convTStride
+            && step.SavedState[1] is int[] convTPadding)
+        {
+            var inp = step.Inputs[0];
+            var kernel = step.Inputs[1];
+            var o = step.OutputBuffer;
+            var capStride = convTStride;
+            var capPadding = convTPadding;
+            var capOutPad = new[] { 0, 0 };
+            return eng =>
+            {
+                if (eng is CpuEngine cpuEng)
+                    cpuEng.ConvTranspose2DInto(o, inp, kernel, capStride, capPadding, capOutPad);
+                else
+                {
+                    var result = eng.ConvTranspose2D(inp, kernel, capStride, capPadding, capOutPad);
+                    result.AsSpan().CopyTo(o.AsWritableSpan());
+                }
+            };
+        }
+
+        // GroupNorm forward: route the compiled-plan replay through GroupNormInto
+        // so the per-Execute path is zero-alloc and writes directly into the plan's
+        // pre-allocated output buffer. Without this case, the recording closure
+        // captured in CpuEngine.GroupNorm (when GraphMode.IsActive) calls
+        // `eng.GroupNorm(...)` every Execute — which still allocates a fresh
+        // result tensor (and old GroupNormInto allocated *another*) and memcpy's
+        // into the plan's output. For SD UNet at [1,1280,16,16] doubles that's
+        // a 2.6 MB alloc + memcpy per call, repeated 24+ times per UNet forward,
+        // × 10 sampling steps per Predict — a measurable share of the residual
+        // compile-mode-slower-than-eager gap that #1305 surfaced.
+        //
+        // SavedState layout for GroupNorm (set at CpuEngine.GroupNorm record-site,
+        // see line ~20597): [int numGroups, Tensor<T> mean, Tensor<T> variance,
+        // double epsilon]. Forward-only inference ignores mean/variance — they
+        // are required for backward only — so we discard them via `out _`.
+        if (step.OpType == OpType.GroupNorm && step.Inputs.Length == 3 && step.Inputs[0].IsContiguous
+            && step.SavedState is { Length: >= 4 }
+            && step.SavedState[0] is int numGroupsGN
+            && step.SavedState[3] is double epsilonGN)
+        {
+            var inp = step.Inputs[0];
+            var gamma = step.Inputs[1];
+            var beta = step.Inputs[2];
+            var o = step.OutputBuffer;
+            return eng =>
+            {
+                if (eng is CpuEngine cpuEng)
+                    cpuEng.GroupNormInto(o, inp, numGroupsGN, gamma, beta, epsilonGN, out _, out _);
+                else
+                {
+                    var result = eng.GroupNorm(inp, numGroupsGN, gamma, beta, epsilonGN, out _, out _);
+                    result.AsSpan().CopyTo(o.AsWritableSpan());
+                }
+            };
+        }
+
         // LogSoftmax forward: pinned SIMD with VML exp for inner loop
         if (step.OpType == OpType.LogSoftmax && step.Inputs.Length == 1 && typeof(T) == typeof(float)
             && step.Inputs[0].IsContiguous && step.Inputs[0].Rank == 2)

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -3548,18 +3548,116 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc/>
     public void GroupNormInto<T>(Tensor<T> output, Tensor<T> input, int numGroups, Tensor<T> gamma, Tensor<T> beta, double epsilon, out Tensor<T> mean, out Tensor<T> variance)
     {
+        if (output is null) throw new ArgumentNullException(nameof(output));
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (gamma is null) throw new ArgumentNullException(nameof(gamma));
+        if (beta is null) throw new ArgumentNullException(nameof(beta));
         if (!output.IsContiguous) throw new InvalidOperationException("Output tensor must be contiguous.");
-        var inputOrig = input;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
+        if (numGroups <= 0) throw new ArgumentOutOfRangeException(nameof(numGroups), "Number of groups must be positive.");
+
+        // #257: preserve user-facing refs before .Contiguous() discards GradFn.
         if (!input.IsContiguous) input = input.Contiguous();
-        var gammaOrig = gamma;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!gamma.IsContiguous) gamma = gamma.Contiguous();
-        var betaOrig = beta;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!beta.IsContiguous) beta = beta.Contiguous();
-        // GroupNorm writes normalized values into pre-allocated output.
-        // The mean/variance stats are small tensors [batch, numGroups] that the callee allocates.
-        // The main output tensor avoids allocation since it's pre-allocated by the caller.
-        var result = GroupNorm(input, numGroups, gamma, beta, epsilon, out mean, out variance);
-        result.Data.Span.CopyTo(output.Data.Span);
+
+        int batch = input._shape[0];
+        int channels = input._shape[1];
+        if (channels % numGroups != 0)
+            throw new ArgumentException($"Number of channels ({channels}) must be divisible by number of groups ({numGroups}).");
+        int channelsPerGroup = channels / numGroups;
+        int spatialSize = 1;
+        for (int i = 2; i < input._shape.Length; i++) spatialSize *= input._shape[i];
+
+        // True zero-alloc Into: write normalized output directly into the
+        // caller's buffer. Avoids the old alloc+copy pattern (allocated a
+        // fresh tensor via AutoTensorCache.RentOrAllocate, then memcpy'd
+        // into the caller's output). For SD UNet at [1,1280,16,16] doubles
+        // that's a 2.6 MB rent + a 2.6 MB memcpy per call, repeated for
+        // every ResBlock's two GroupNorms — ~50 MB of pointless traffic
+        // per UNet forward at the heaviest shapes. The mean/variance
+        // out-tensors are still allocated (small: [batch, numGroups]).
+        if (typeof(T) == typeof(float))
+        {
+            using var pinIn = input.Data.Pin();
+            using var pinOut = output.Data.Pin();
+            using var pinGamma = gamma.Data.Pin();
+            using var pinBeta = beta.Data.Pin();
+            unsafe
+            {
+                float epsF = (float)epsilon;
+                GroupNormFloatPtr(
+                    (float*)pinIn.Pointer, (float*)pinOut.Pointer,
+                    (float*)pinGamma.Pointer, (float*)pinBeta.Pointer,
+                    batch, channels, spatialSize, numGroups, channelsPerGroup,
+                    epsF, out var meanArr, out var varArr);
+                mean = TensorAllocator.Rent<T>(new[] { batch, numGroups },
+                    new Vector<T>((T[])(object)meanArr));
+                variance = TensorAllocator.Rent<T>(new[] { batch, numGroups },
+                    new Vector<T>((T[])(object)varArr));
+            }
+            return;
+        }
+
+        // Generic path (covers double + any other T): replicate the inner
+        // loop from GroupNorm but write directly into output.GetDataArray()
+        // instead of allocating a fresh outputData.
+        var numOps = MathHelper.GetNumericOperations<T>();
+        T eps = numOps.FromDouble(epsilon);
+        int groupSize = channelsPerGroup * spatialSize;
+
+        var inputData = input.GetDataArray();
+        var gammaData = gamma.GetDataArray();
+        var betaData = beta.GetDataArray();
+        var outputData = output.GetDataArray();
+        var meanData = new T[batch * numGroups];
+        var varData = new T[batch * numGroups];
+
+        CpuParallelSettings.ParallelForOrSerial(0, batch * numGroups, outputData.Length, idx =>
+        {
+            int b = idx / numGroups;
+            int g = idx % numGroups;
+            int startChannel = g * channelsPerGroup;
+            int batchOffset = b * (channels * spatialSize);
+            T groupSizeT = numOps.FromDouble(groupSize);
+
+            T sum = numOps.Zero;
+            for (int c = 0; c < channelsPerGroup; c++)
+            {
+                int chanOffset = batchOffset + (startChannel + c) * spatialSize;
+                for (int s = 0; s < spatialSize; s++)
+                    sum = numOps.Add(sum, inputData[chanOffset + s]);
+            }
+            T groupMean = numOps.Divide(sum, groupSizeT);
+            meanData[b * numGroups + g] = groupMean;
+
+            T sumSq = numOps.Zero;
+            for (int c = 0; c < channelsPerGroup; c++)
+            {
+                int chanOffset = batchOffset + (startChannel + c) * spatialSize;
+                for (int s = 0; s < spatialSize; s++)
+                {
+                    T diff = numOps.Subtract(inputData[chanOffset + s], groupMean);
+                    sumSq = numOps.Add(sumSq, numOps.Multiply(diff, diff));
+                }
+            }
+            T groupVar = numOps.Divide(sumSq, groupSizeT);
+            varData[b * numGroups + g] = groupVar;
+
+            T invStd = numOps.Divide(numOps.One, numOps.Sqrt(numOps.Add(groupVar, eps)));
+            for (int c = 0; c < channelsPerGroup; c++)
+            {
+                int channel = startChannel + c;
+                int chanOffset = batchOffset + channel * spatialSize;
+                for (int s = 0; s < spatialSize; s++)
+                {
+                    T normalized = numOps.Multiply(numOps.Subtract(inputData[chanOffset + s], groupMean), invStd);
+                    outputData[chanOffset + s] = numOps.Add(numOps.Multiply(gammaData[channel], normalized), betaData[channel]);
+                }
+            }
+        });
+
+        mean = TensorAllocator.Rent<T>(new[] { batch, numGroups }, Vector<T>.WrapMemory(meanData));
+        variance = TensorAllocator.Rent<T>(new[] { batch, numGroups }, Vector<T>.WrapMemory(varData));
     }
 
     /// <inheritdoc/>

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -23002,6 +23002,22 @@ public partial class CpuEngine : ITensorLevelEngine
 
         int scoresLen = bhCount * seqQ * seqK;
         var scoresData = System.Buffers.ArrayPool<double>.Shared.Rent(scoresLen);
+
+        // #1305: avoid OpenBLAS thread oversubscription against our outer
+        // batch*heads parallel-for. Each per-head GEMM is tiny
+        // (M=seqQ, K=headDim≤128, N=seqK) — multi-threaded OpenBLAS gives no
+        // wall-time benefit over a sequential kernel at this size, and on a
+        // 32-core host an 8-head outer parallel-for × 32-thread inner DGEMM
+        // produces ~256-thread oversubscription that takes the call from
+        // ~30 ms to >600 s (>20,000× slower). Force OpenBLAS to 1 thread for
+        // the duration of the parallel-for and restore the prior count.
+        int savedBlasThreads = Helpers.BlasProvider.GetOpenBlasThreadCount();
+        bool blasScoped = false;
+        if (Helpers.BlasProvider.IsAvailable && savedBlasThreads != 1)
+        {
+            Helpers.BlasProvider.TrySetOpenBlasThreads(1);
+            blasScoped = true;
+        }
         try
         {
             var weightsData = new double[scoresLen];
@@ -23113,6 +23129,14 @@ public partial class CpuEngine : ITensorLevelEngine
         finally
         {
             System.Buffers.ArrayPool<double>.Shared.Return(scoresData, clearArray: false);
+            // #1305: restore the prior OpenBLAS thread count. savedBlasThreads = -1
+            // means "never set this process" — passing 0 restores the OpenBLAS auto/
+            // OMP_NUM_THREADS default. SetDeterministicMode flips this to 1 globally;
+            // we honor that by only restoring when we ourselves changed it.
+            if (blasScoped)
+            {
+                Helpers.BlasProvider.TrySetOpenBlasThreads(savedBlasThreads < 0 ? 0 : savedBlasThreads);
+            }
         }
     }
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -23009,15 +23009,13 @@ public partial class CpuEngine : ITensorLevelEngine
         // wall-time benefit over a sequential kernel at this size, and on a
         // 32-core host an 8-head outer parallel-for × 32-thread inner DGEMM
         // produces ~256-thread oversubscription that takes the call from
-        // ~30 ms to >600 s (>20,000× slower). Force OpenBLAS to 1 thread for
+        // ~30 ms to >600 s (>20,000× slower). Scope OpenBLAS to 1 thread for
         // the duration of the parallel-for and restore the prior count.
-        int savedBlasThreads = Helpers.BlasProvider.GetOpenBlasThreadCount();
-        bool blasScoped = false;
-        if (Helpers.BlasProvider.IsAvailable && savedBlasThreads != 1)
-        {
-            Helpers.BlasProvider.TrySetOpenBlasThreads(1);
-            blasScoped = true;
-        }
+        //
+        // PR #410 CodeRabbit fix: use the lock-protected scope token so
+        // overlapping/nested callers from concurrent threads don't restore
+        // stale values. Only the outermost scope hits OpenBLAS on dispose.
+        using var blasScope = Helpers.BlasProvider.ScopeOpenBlasThreads(1);
         try
         {
             var weightsData = new double[scoresLen];
@@ -23129,14 +23127,8 @@ public partial class CpuEngine : ITensorLevelEngine
         finally
         {
             System.Buffers.ArrayPool<double>.Shared.Return(scoresData, clearArray: false);
-            // #1305: restore the prior OpenBLAS thread count. savedBlasThreads = -1
-            // means "never set this process" — passing 0 restores the OpenBLAS auto/
-            // OMP_NUM_THREADS default. SetDeterministicMode flips this to 1 globally;
-            // we honor that by only restoring when we ourselves changed it.
-            if (blasScoped)
-            {
-                Helpers.BlasProvider.TrySetOpenBlasThreads(savedBlasThreads < 0 ? 0 : savedBlasThreads);
-            }
+            // PR #410 CodeRabbit fix: thread-count restore is handled by the
+            // `using var blasScope` declaration above. No explicit restore here.
         }
     }
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -23248,22 +23248,27 @@ public partial class CpuEngine : ITensorLevelEngine
 
         int scoresLen = bhCount * seqQ * seqK;
         var scoresData = System.Buffers.ArrayPool<double>.Shared.Rent(scoresLen);
-
-        // #1305: avoid OpenBLAS thread oversubscription against our outer
-        // batch*heads parallel-for. Each per-head GEMM is tiny
-        // (M=seqQ, K=headDim≤128, N=seqK) — multi-threaded OpenBLAS gives no
-        // wall-time benefit over a sequential kernel at this size, and on a
-        // 32-core host an 8-head outer parallel-for × 32-thread inner DGEMM
-        // produces ~256-thread oversubscription that takes the call from
-        // ~30 ms to >600 s (>20,000× slower). Scope OpenBLAS to 1 thread for
-        // the duration of the parallel-for and restore the prior count.
-        //
-        // PR #410 CodeRabbit fix: use the lock-protected scope token so
-        // overlapping/nested callers from concurrent threads don't restore
-        // stale values. Only the outermost scope hits OpenBLAS on dispose.
-        using var blasScope = Helpers.BlasProvider.ScopeOpenBlasThreads(1);
         try
         {
+            // #1305: avoid OpenBLAS thread oversubscription against our outer
+            // batch*heads parallel-for. Each per-head GEMM is tiny
+            // (M=seqQ, K=headDim≤128, N=seqK) — multi-threaded OpenBLAS gives no
+            // wall-time benefit over a sequential kernel at this size, and on a
+            // 32-core host an 8-head outer parallel-for × 32-thread inner DGEMM
+            // produces ~256-thread oversubscription that takes the call from
+            // ~30 ms to >600 s (>20,000× slower). Scope OpenBLAS to 1 thread for
+            // the duration of the parallel-for and restore the prior count.
+            //
+            // PR #410 CodeRabbit fix: use the lock-protected scope token so
+            // overlapping/nested callers from concurrent threads don't restore
+            // stale values. Only the outermost scope hits OpenBLAS on dispose.
+            //
+            // PR #410 CodeRabbit follow-up: ScopeOpenBlasThreads is created
+            // INSIDE the try so if its constructor throws (lazy _nativeAvailable
+            // init, lock contention, etc.) the rented scoresData still gets
+            // returned via the finally below. Previously the scope acquisition
+            // happened before the try, leaking the array pool on that path.
+            using var blasScope = Helpers.BlasProvider.ScopeOpenBlasThreads(1);
             var weightsData = new double[scoresLen];
             var outputData = new double[bhCount * seqQ * d_v];
             var statsData = new double[bhCount * seqQ];

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -8344,9 +8344,28 @@ public partial class CpuEngine : ITensorLevelEngine
             // <Compile Remove>'d in the .csproj for that TFM). On net471 doubles
             // fall through to the im2col+GEMM path below.
             long convFmas = (long)batch * outChannels * inChannels * outputHeight * outputWidth * 9L;
+            // Per-output-channel work — needs to be high enough that the SIMD
+            // direct kernel's inner loop amortises parallel-task overhead. At
+            // SD UNet's deepest level (inChannels=1280 × 16×16 spatial) the
+            // per-channel work is only 2.9M ops which task-starves and falls
+            // to ~3% of peak GFLOPS (AiDotNet#1305 bench). im2col + DGEMM
+            // stays near peak at any shape because BLAS handles blocking
+            // internally. Empirical crossover from the #1305 bench:
+            //   - 320→640 at 32×32: per-channel 2.9M → direct kernel @ 110 GFLOPS
+            //   - 640→640 at 32×32: per-channel 5.9M → direct kernel @ 94 GFLOPS
+            //   - 640→1280 at 16×16: per-channel 1.5M → direct kernel @ 4.7 GFLOPS (fall off cliff)
+            //   - 1280→1280 at 16×16: per-channel 2.9M → direct kernel @ 4.5 GFLOPS
+            //   - 1280→1280 at 8×8: per-channel 737K → direct kernel @ 2.7 GFLOPS
+            // The cliff isn't strictly per-channel-work — outChannels matter too
+            // (high outChannels = many small tasks). Total work / outChannels
+            // captures the per-task budget; threshold 5M ops/task is the lowest
+            // value that keeps the existing-passing shapes on the direct path.
+            long perChannelWorkBudget = (long)batch * inChannels * outputHeight * outputWidth * 9L;
             int directKernelMinTasks = 2 * Math.Max(1, Helpers.CpuParallelSettings.MaxDegreeOfParallelism);
+            const long MinPerChannelDirectWork = 5_000_000L;
             bool directKernelFitsWell = convFmas <= 4_000_000L
-                || outChannels >= directKernelMinTasks;
+                || (outChannels >= directKernelMinTasks
+                    && perChannelWorkBudget >= MinPerChannelDirectWork);
             if (kernelHeight == 3 && kernelWidth == 3
                 && stride == 1 && padding > 0 && dilation == 1
                 && directKernelFitsWell
@@ -8513,9 +8532,18 @@ public partial class CpuEngine : ITensorLevelEngine
         {
 #if !NET471
             long convFmasInto = (long)batch * outChannels * inChannels * outputHeight * outputWidth * 9L;
+            // AiDotNet#1305 perf gate: see Conv2D allocating overload above
+            // for the empirical cliff (~3% peak GFLOPS at SD UNet deepest
+            // ResBlock shapes when per-channel work falls below ~5M ops).
+            // Same threshold/formula here so both inference paths (zero-alloc
+            // Conv2DInto from ConvolutionalLayer.Forward + allocating Conv2D
+            // from tape-active forward) make consistent kernel choices.
+            long perChannelWorkBudgetInto = (long)batch * inChannels * outputHeight * outputWidth * 9L;
             int directKernelMinTasksInto = 2 * Math.Max(1, Helpers.CpuParallelSettings.MaxDegreeOfParallelism);
+            const long MinPerChannelDirectWorkInto = 5_000_000L;
             bool directKernelFitsWellInto = convFmasInto <= 4_000_000L
-                || outChannels >= directKernelMinTasksInto;
+                || (outChannels >= directKernelMinTasksInto
+                    && perChannelWorkBudgetInto >= MinPerChannelDirectWorkInto);
             if (kernelHeight == 3 && kernelWidth == 3
                 && stride == 1 && padding > 0 && dilation == 1
                 && directKernelFitsWellInto

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -14242,6 +14242,154 @@ public partial class CpuEngine : ITensorLevelEngine
         return convTransResult;
     }
 
+    /// <summary>
+    /// Zero-alloc variant of <see cref="ConvTranspose2D{T}"/> — writes the result directly
+    /// into the caller-provided <paramref name="output"/> buffer. Used by the compiled-plan
+    /// replay path (<see cref="Compilation.CompiledTrainingPlan.TryBuildSpecializedForward"/>)
+    /// to skip the per-Execute tensor allocation that the allocating overload would do.
+    ///
+    /// SD UNet decoder Upsamples are <c>ConvTranspose2D</c> with kernel=4 stride=2 at 1280
+    /// channels — those calls dominate the decoder's wall time (~1 s per UNet forward
+    /// across three upsample stages), so the alloc savings here compound × 10 sampling
+    /// steps per Predict.
+    /// </summary>
+    public void ConvTranspose2DInto<T>(
+        Tensor<T> output, Tensor<T> input, Tensor<T> kernel,
+        int[] stride, int[] padding, int[] outputPadding)
+    {
+        if (output is null) throw new ArgumentNullException(nameof(output));
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (kernel is null) throw new ArgumentNullException(nameof(kernel));
+        if (!output.IsContiguous) throw new InvalidOperationException("Output tensor must be contiguous.");
+        if (!input.IsContiguous) input = input.Contiguous();
+        if (!kernel.IsContiguous) kernel = kernel.Contiguous();
+        if (input.Rank != 4) throw new ArgumentException($"ConvTranspose2DInto requires 4D input. Got rank {input.Rank}.", nameof(input));
+        if (kernel.Rank != 4) throw new ArgumentException($"ConvTranspose2DInto requires 4D kernel. Got rank {kernel.Rank}.", nameof(kernel));
+        if (stride is null || stride.Length != 2) throw new ArgumentException("Stride must be 2 elements", nameof(stride));
+        if (padding is null || padding.Length != 2) throw new ArgumentException("Padding must be 2 elements", nameof(padding));
+        if (outputPadding is null || outputPadding.Length != 2) throw new ArgumentException("OutputPadding must be 2 elements", nameof(outputPadding));
+        if (input._shape[1] != kernel._shape[0])
+            throw new ArgumentException($"Input inChannels ({input._shape[1]}) must match kernel inChannels ({kernel._shape[0]})");
+
+        int batch = input._shape[0];
+        int inChannels = input._shape[1];
+        int height = input._shape[2];
+        int width = input._shape[3];
+        int outChannels = kernel._shape[1];
+        int kernelHeight = kernel._shape[2];
+        int kernelWidth = kernel._shape[3];
+        int strideH = stride[0], strideW = stride[1];
+        int padH = padding[0], padW = padding[1];
+        int outPadH = outputPadding[0], outPadW = outputPadding[1];
+        int outputHeight = (height - 1) * strideH - 2 * padH + kernelHeight + outPadH;
+        int outputWidth = (width - 1) * strideW - 2 * padW + kernelWidth + outPadW;
+        long expectedOutLen = (long)batch * outChannels * outputHeight * outputWidth;
+        if (output.Length != expectedOutLen)
+            throw new ArgumentException(
+                $"Output length {output.Length} does not match expected {expectedOutLen} for shape [{batch},{outChannels},{outputHeight},{outputWidth}].",
+                nameof(output));
+
+        var inputData = input.GetDataArray();
+        var kernelData = kernel.GetDataArray();
+        var outputData = output.GetDataArray();
+
+        // BLAS GEMM + Col2Im fast path — TryConvTranspose2DWithGemm zeros its
+        // output slice via Array.Clear (Im2ColHelper.cs:1185) before accumulating,
+        // so passing the caller's buffer with arbitrary stale data is safe.
+        if (typeof(T) == typeof(float))
+        {
+            var fInput = (float[])(object)inputData;
+            var fKernel = (float[])(object)kernelData;
+            var fOutput = (float[])(object)outputData;
+            if (Helpers.Im2ColHelper.TryConvTranspose2DWithGemm(
+                    fInput, fKernel, fOutput,
+                    batch, inChannels, height, width,
+                    outChannels, kernelHeight, kernelWidth,
+                    strideH, strideW, padH, padW, outputHeight, outputWidth))
+            { return; }
+            // Naive scalar fallback (parallel per [batch, outChannel])
+            CpuParallelSettings.ParallelForOrSerial(0, batch * outChannels, fOutput.Length, idx =>
+            {
+                int b = idx / outChannels; int oc = idx % outChannels;
+                for (int oh = 0; oh < outputHeight; oh++)
+                    for (int ow = 0; ow < outputWidth; ow++)
+                    {
+                        float sum = 0f;
+                        for (int kh = 0; kh < kernelHeight; kh++)
+                        {
+                            int numerH = oh + padH - kh;
+                            if (numerH < 0 || numerH % strideH != 0) continue;
+                            int ih = numerH / strideH;
+                            if (ih >= height) continue;
+                            for (int kw = 0; kw < kernelWidth; kw++)
+                            {
+                                int numerW = ow + padW - kw;
+                                if (numerW < 0 || numerW % strideW != 0) continue;
+                                int iw = numerW / strideW;
+                                if (iw >= width) continue;
+                                for (int ic = 0; ic < inChannels; ic++)
+                                {
+                                    int inIdx = ((b * inChannels + ic) * height + ih) * width + iw;
+                                    int kIdx = ((ic * outChannels + oc) * kernelHeight + kh) * kernelWidth + kw;
+                                    sum += fInput[inIdx] * fKernel[kIdx];
+                                }
+                            }
+                        }
+                        fOutput[((b * outChannels + oc) * outputHeight + oh) * outputWidth + ow] = sum;
+                    }
+            });
+            return;
+        }
+        if (typeof(T) == typeof(double))
+        {
+            var dInput = (double[])(object)inputData;
+            var dKernel = (double[])(object)kernelData;
+            var dOutput = (double[])(object)outputData;
+            if (Helpers.Im2ColHelper.TryConvTranspose2DWithGemm(
+                    dInput, dKernel, dOutput,
+                    batch, inChannels, height, width,
+                    outChannels, kernelHeight, kernelWidth,
+                    strideH, strideW, padH, padW, outputHeight, outputWidth))
+            { return; }
+            CpuParallelSettings.ParallelForOrSerial(0, batch * outChannels, dOutput.Length, idx =>
+            {
+                int b = idx / outChannels; int oc = idx % outChannels;
+                for (int oh = 0; oh < outputHeight; oh++)
+                    for (int ow = 0; ow < outputWidth; ow++)
+                    {
+                        double sum = 0d;
+                        for (int kh = 0; kh < kernelHeight; kh++)
+                        {
+                            int numerH = oh + padH - kh;
+                            if (numerH < 0 || numerH % strideH != 0) continue;
+                            int ih = numerH / strideH;
+                            if (ih >= height) continue;
+                            for (int kw = 0; kw < kernelWidth; kw++)
+                            {
+                                int numerW = ow + padW - kw;
+                                if (numerW < 0 || numerW % strideW != 0) continue;
+                                int iw = numerW / strideW;
+                                if (iw >= width) continue;
+                                for (int ic = 0; ic < inChannels; ic++)
+                                {
+                                    int inIdx = ((b * inChannels + ic) * height + ih) * width + iw;
+                                    int kIdx = ((ic * outChannels + oc) * kernelHeight + kh) * kernelWidth + kw;
+                                    sum += dInput[inIdx] * dKernel[kIdx];
+                                }
+                            }
+                        }
+                        dOutput[((b * outChannels + oc) * outputHeight + oh) * outputWidth + ow] = sum;
+                    }
+            });
+            return;
+        }
+
+        // Generic numOps fallback: delegate to allocating ConvTranspose2D + copy.
+        // Non-float/non-double T is a rare niche; the alloc-and-copy is acceptable here.
+        var allocated = ConvTranspose2D(input, kernel, stride, padding, outputPadding);
+        allocated.AsSpan().CopyTo(output.AsWritableSpan());
+    }
+
     /// <inheritdoc/>
     public Tensor<T> ConvTranspose2DBackwardInput<T>(Tensor<T> gradOutput, Tensor<T> kernel, int[] inputShape, int[] stride, int[] padding)
     {

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -8344,28 +8344,32 @@ public partial class CpuEngine : ITensorLevelEngine
             // <Compile Remove>'d in the .csproj for that TFM). On net471 doubles
             // fall through to the im2col+GEMM path below.
             long convFmas = (long)batch * outChannels * inChannels * outputHeight * outputWidth * 9L;
-            // Per-output-channel work — needs to be high enough that the SIMD
-            // direct kernel's inner loop amortises parallel-task overhead. At
-            // SD UNet's deepest level (inChannels=1280 × 16×16 spatial) the
-            // per-channel work is only 2.9M ops which task-starves and falls
-            // to ~3% of peak GFLOPS (AiDotNet#1305 bench). im2col + DGEMM
-            // stays near peak at any shape because BLAS handles blocking
-            // internally. Empirical crossover from the #1305 bench:
-            //   - 320→640 at 32×32: per-channel 2.9M → direct kernel @ 110 GFLOPS
-            //   - 640→640 at 32×32: per-channel 5.9M → direct kernel @ 94 GFLOPS
-            //   - 640→1280 at 16×16: per-channel 1.5M → direct kernel @ 4.7 GFLOPS (fall off cliff)
-            //   - 1280→1280 at 16×16: per-channel 2.9M → direct kernel @ 4.5 GFLOPS
-            //   - 1280→1280 at 8×8: per-channel 737K → direct kernel @ 2.7 GFLOPS
-            // The cliff isn't strictly per-channel-work — outChannels matter too
-            // (high outChannels = many small tasks). Total work / outChannels
-            // captures the per-task budget; threshold 5M ops/task is the lowest
-            // value that keeps the existing-passing shapes on the direct path.
-            long perChannelWorkBudget = (long)batch * inChannels * outputHeight * outputWidth * 9L;
+            // AiDotNet#1305 perf gate: the direct kernel's per-output-channel
+            // loop traverses `outputHeight * outputWidth` output positions; if
+            // that count is small, the SIMD vector-register preroll + per-OC
+            // `Span.Clear()` + parallel-task scheduling overhead dominates the
+            // actual FMAs and throughput collapses. Empirical crossover from
+            // the #1305 bench (single Conv2DInto<double> on 32-core CPU):
+            //   spatial=4096 (320→320 @ 64×64):  158 GFLOPS — direct wins
+            //   spatial=1024 (320→640 @ 32×32):  110 GFLOPS — direct wins
+            //   spatial=1024 (640→640 @ 32×32):   94 GFLOPS — direct wins
+            //   spatial= 256 (640→1280 @ 16×16):   4.7 GFLOPS — direct CLIFF
+            //   spatial= 256 (1280→1280 @ 16×16):  4.5 GFLOPS — direct CLIFF
+            //   spatial=  64 (1280→1280 @ 8×8):    2.7 GFLOPS — direct CLIFF
+            // The discriminator is spatial output size, not per-channel work
+            // (the 320→640 @ 32×32 and 1280→1280 @ 16×16 cases both have ~2.9M
+            // ops per output channel but only the larger-spatial one is fast).
+            // Crossover sits between spatial=256 (cliff) and spatial=1024 (fast);
+            // threshold 512 is the midpoint that keeps every fast case on the
+            // direct path while routing the slow cliff shapes to im2col+DGEMM,
+            // which stays near peak at any shape because BLAS handles blocking
+            // internally.
+            long outputSpatial = (long)outputHeight * outputWidth;
             int directKernelMinTasks = 2 * Math.Max(1, Helpers.CpuParallelSettings.MaxDegreeOfParallelism);
-            const long MinPerChannelDirectWork = 5_000_000L;
+            const long MinDirectSpatial = 512L;
             bool directKernelFitsWell = convFmas <= 4_000_000L
                 || (outChannels >= directKernelMinTasks
-                    && perChannelWorkBudget >= MinPerChannelDirectWork);
+                    && outputSpatial >= MinDirectSpatial);
             if (kernelHeight == 3 && kernelWidth == 3
                 && stride == 1 && padding > 0 && dilation == 1
                 && directKernelFitsWell
@@ -8534,16 +8538,16 @@ public partial class CpuEngine : ITensorLevelEngine
             long convFmasInto = (long)batch * outChannels * inChannels * outputHeight * outputWidth * 9L;
             // AiDotNet#1305 perf gate: see Conv2D allocating overload above
             // for the empirical cliff (~3% peak GFLOPS at SD UNet deepest
-            // ResBlock shapes when per-channel work falls below ~5M ops).
+            // ResBlock shapes when output spatial size falls below ~512).
             // Same threshold/formula here so both inference paths (zero-alloc
             // Conv2DInto from ConvolutionalLayer.Forward + allocating Conv2D
             // from tape-active forward) make consistent kernel choices.
-            long perChannelWorkBudgetInto = (long)batch * inChannels * outputHeight * outputWidth * 9L;
+            long outputSpatialInto = (long)outputHeight * outputWidth;
             int directKernelMinTasksInto = 2 * Math.Max(1, Helpers.CpuParallelSettings.MaxDegreeOfParallelism);
-            const long MinPerChannelDirectWorkInto = 5_000_000L;
+            const long MinDirectSpatialInto = 512L;
             bool directKernelFitsWellInto = convFmasInto <= 4_000_000L
                 || (outChannels >= directKernelMinTasksInto
-                    && perChannelWorkBudgetInto >= MinPerChannelDirectWorkInto);
+                    && outputSpatialInto >= MinDirectSpatialInto);
             if (kernelHeight == 3 && kernelWidth == 3
                 && stride == 1 && padding > 0 && dilation == 1
                 && directKernelFitsWellInto

--- a/src/AiDotNet.Tensors/Helpers/BlasProvider.cs
+++ b/src/AiDotNet.Tensors/Helpers/BlasProvider.cs
@@ -102,6 +102,14 @@ internal static class BlasProvider
         catch { /* libopenblas symbol missing — earlier OpenBLAS builds may lack it. Tolerate. */ }
     }
 
+    /// <summary>
+    /// Returns the cached OpenBLAS thread count last set by <see cref="TrySetOpenBlasThreads(int)"/>,
+    /// or <c>-1</c> if no override has been applied this process. Used by callers that
+    /// run an outer parallel-for around BLAS calls and need to scope OpenBLAS down to
+    /// 1 thread (avoid oversubscription) then restore the prior value on exit.
+    /// </summary>
+    internal static int GetOpenBlasThreadCount() => _openblasThreadCount;
+
 
     // ─────────────────────────────────────────────────────────────────────
     // Issue #338 Phase G.1 — Intel MKL via Microsoft.ML.Mkl.Redist.

--- a/src/AiDotNet.Tensors/Helpers/BlasProvider.cs
+++ b/src/AiDotNet.Tensors/Helpers/BlasProvider.cs
@@ -108,7 +108,81 @@ internal static class BlasProvider
     /// run an outer parallel-for around BLAS calls and need to scope OpenBLAS down to
     /// 1 thread (avoid oversubscription) then restore the prior value on exit.
     /// </summary>
+    /// <remarks>
+    /// PR #410 CodeRabbit fix: prefer <see cref="ScopeOpenBlasThreads(int)"/> over
+    /// directly reading this value for save/restore patterns — the scope token uses a
+    /// lock-protected depth counter so overlapping/nested calls don't restore stale
+    /// values. This getter is left in place for backward compat with eager callers
+    /// that already implement their own correctness guarantees.
+    /// </remarks>
     internal static int GetOpenBlasThreadCount() => _openblasThreadCount;
+
+    // PR #410 CodeRabbit fix: lock-protected scope for the OpenBLAS thread-count
+    // set/restore contract. Without this, two concurrent callers each saving/setting/
+    // restoring around their own BLAS-bound parallel-for could leave the global
+    // thread count at a stale value (e.g., both see savedCount=8 → both set to 1 →
+    // inner thread restores to 1 prematurely → outer thread restores to 1 instead
+    // of 8). The depth counter ensures only the OUTERMOST scope restores.
+    private static readonly object _openblasScopeLock = new object();
+    private static int _openblasScopeDepth;
+    private static int _openblasScopeRestoreTarget = -1;
+
+    /// <summary>
+    /// PR #410 CodeRabbit fix: thread-safe scoped override of the OpenBLAS thread
+    /// count. Returns a disposable token; on disposal the outermost scope restores
+    /// the prior thread count atomically. Nested/overlapping scopes within the same
+    /// process are reference-counted — only the outer disposal touches OpenBLAS.
+    ///
+    /// <para>
+    /// Use this for the "run an outer parallel-for around BLAS calls, force OpenBLAS
+    /// to 1 thread to avoid oversubscription, restore on exit" pattern. Eager callers
+    /// using <see cref="GetOpenBlasThreadCount"/> + <see cref="TrySetOpenBlasThreads"/>
+    /// directly are NOT concurrency-safe across threads.
+    /// </para>
+    /// </summary>
+    /// <param name="requestedThreads">Desired OpenBLAS thread count for the scope.</param>
+    internal static OpenBlasThreadScope ScopeOpenBlasThreads(int requestedThreads)
+    {
+        if (!_nativeAvailable.Value) return default;
+        return new OpenBlasThreadScope(requestedThreads);
+    }
+
+    /// <summary>
+    /// Disposable scope token returned by <see cref="ScopeOpenBlasThreads(int)"/>.
+    /// Restores the prior OpenBLAS thread count when the outermost scope disposes.
+    /// </summary>
+    internal readonly struct OpenBlasThreadScope : IDisposable
+    {
+        private readonly bool _active;
+
+        internal OpenBlasThreadScope(int requestedThreads)
+        {
+            lock (_openblasScopeLock)
+            {
+                if (_openblasScopeDepth == 0)
+                {
+                    _openblasScopeRestoreTarget = _openblasThreadCount;
+                }
+                _openblasScopeDepth++;
+                TrySetOpenBlasThreads(requestedThreads);
+            }
+            _active = true;
+        }
+
+        public void Dispose()
+        {
+            if (!_active) return;
+            lock (_openblasScopeLock)
+            {
+                _openblasScopeDepth--;
+                if (_openblasScopeDepth == 0)
+                {
+                    int restore = _openblasScopeRestoreTarget;
+                    TrySetOpenBlasThreads(restore < 0 ? 0 : restore);
+                }
+            }
+        }
+    }
 
 
     // ─────────────────────────────────────────────────────────────────────

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/Sd1305CompilePhaseTimingTest.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/Sd1305CompilePhaseTimingTest.cs
@@ -1,0 +1,209 @@
+using System.Diagnostics;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// AiDotNet#1305 — three-layer correctness + perf proof for the compile-mode
+/// specialized-forward paths added in PR #410 (GroupNorm, ConvTranspose2D).
+///
+/// Pre-PR these ops had no entry in <see cref="CompiledTrainingPlan.TryBuildSpecializedForward"/>
+/// so the compiled plan fell through to a generic recording closure that allocated a fresh
+/// tensor every Execute and memcpy'd into the plan's output buffer. The phase-timing
+/// diagnostic (CompilePhaseTiming_SdResBlock_Double) measured 209 ms steady-state Execute
+/// vs 100 ms eager — compile was 2× SLOWER than eager.
+///
+/// After adding the GroupNorm + ConvTranspose2D specialized forwards, compile becomes
+/// faster than eager (asserted below).
+/// </summary>
+[Trait("Category", "Benchmark")]
+public class Sd1305CompilePhaseTimingTest
+{
+    private readonly ITestOutputHelper _output;
+    public Sd1305CompilePhaseTimingTest(ITestOutputHelper output) => _output = output;
+
+    [Fact]
+    public void CompilePhaseTiming_SdResBlock_Double()
+    {
+        var engine = new CpuEngine();
+        var rng = new Random(0);
+        int batch = 1, channels = 320, h = 64, w = 64;
+        int numGroups = 32;
+
+        var input = new Tensor<double>(new[] { batch, channels, h, w });
+        var gamma = new Tensor<double>(new[] { channels });
+        var beta = new Tensor<double>(new[] { channels });
+        var kernel = new Tensor<double>(new[] { channels, channels, 3, 3 });
+        for (int i = 0; i < input.Length; i++) input[i] = rng.NextDouble() * 0.1;
+        for (int i = 0; i < channels; i++) { gamma[i] = 1.0; beta[i] = 0.0; }
+        for (int i = 0; i < kernel.Length; i++) kernel[i] = rng.NextDouble() * 0.01;
+
+        _output.WriteLine($"Inputs: input=[{batch},{channels},{h},{w}] kernel=[{channels},{channels},3,3] (doubles)");
+
+        // Warmup eager (JIT, pool, OpenBLAS thread cache) so the measurement
+        // window doesn't get charged for one-time costs that pollute the
+        // assertion when xunit runs neighbour tests in the same process.
+        for (int wu = 0; wu < 2; wu++)
+        {
+            var n = engine.GroupNorm<double>(input, numGroups, gamma, beta, 1e-5, out _, out _);
+            engine.SwishInPlace<double>(n);
+            var c = engine.Conv2D<double>(n, kernel, stride: new[] { 1, 1 }, padding: new[] { 1, 1 }, dilation: new[] { 1, 1 });
+            var _o = engine.TensorAdd<double>(c, input);
+        }
+
+        // Phase A — eager baseline (no compile)
+        const int eagerIters = 5;
+        var swA = Stopwatch.StartNew();
+        for (int it = 0; it < eagerIters; it++)
+        {
+            var n = engine.GroupNorm<double>(input, numGroups, gamma, beta, 1e-5, out _, out _);
+            engine.SwishInPlace<double>(n);
+            var c = engine.Conv2D<double>(n, kernel, stride: new[] { 1, 1 }, padding: new[] { 1, 1 }, dilation: new[] { 1, 1 });
+            var _o = engine.TensorAdd<double>(c, input);
+        }
+        swA.Stop();
+        double eagerMs = swA.Elapsed.TotalMilliseconds / eagerIters;
+        _output.WriteLine($"Phase A — eager ResBlock-like: {eagerMs:F1} ms/iter ({eagerIters} iters)");
+
+        // Phase B — trace, compile, execute
+        Tensor<double> tracedOutput;
+        ICompiledPlan<double> plan;
+        var traceScope = GraphMode.Enable();
+        try
+        {
+            var swB = Stopwatch.StartNew();
+            var n = engine.GroupNorm<double>(input, numGroups, gamma, beta, 1e-5, out _, out _);
+            engine.SwishInPlace<double>(n);
+            var c = engine.Conv2D<double>(n, kernel, stride: new[] { 1, 1 }, padding: new[] { 1, 1 }, dilation: new[] { 1, 1 });
+            tracedOutput = engine.TensorAdd<double>(c, input);
+            swB.Stop();
+            _output.WriteLine($"Phase B — trace: {swB.Elapsed.TotalMilliseconds:F1} ms");
+
+            var swC = Stopwatch.StartNew();
+            plan = traceScope.CompileInference<double>(tracedOutput, input._shape);
+            swC.Stop();
+            _output.WriteLine($"Phase C — compile: {swC.Elapsed.TotalMilliseconds:F1} ms");
+        }
+        finally { traceScope.Dispose(); }
+
+        // Phase D — warmup + Phase E — steady-state Execute. Capture the first
+        // Execute output so we can verify compiled-vs-eager parity below.
+        var swD = Stopwatch.StartNew();
+        var compiledOut = plan.Execute();
+        swD.Stop();
+        _output.WriteLine($"Phase D — first Execute: {swD.Elapsed.TotalMilliseconds:F1} ms");
+
+        // Correctness: compiled output must per-element match a fresh eager run
+        // at 1e-12 tolerance (the same code paths run, just allocations differ).
+        var eagerRef = engine.GroupNorm<double>(input, numGroups, gamma, beta, 1e-5, out _, out _);
+        engine.SwishInPlace<double>(eagerRef);
+        var eagerConv = engine.Conv2D<double>(eagerRef, kernel, stride: new[] { 1, 1 }, padding: new[] { 1, 1 }, dilation: new[] { 1, 1 });
+        var eagerOut = engine.TensorAdd<double>(eagerConv, input);
+        Assert.Equal(eagerOut.Length, compiledOut.Length);
+        double maxDelta = 0;
+        for (int i = 0; i < eagerOut.Length; i++)
+        {
+            double d = Math.Abs(eagerOut[i] - compiledOut[i]);
+            if (d > maxDelta) maxDelta = d;
+        }
+        _output.WriteLine($"Correctness: max delta vs eager = {maxDelta:E2}");
+        Assert.True(maxDelta < 1e-12, $"Compiled output diverged from eager: maxDelta={maxDelta:E6}");
+
+        var swE = Stopwatch.StartNew();
+        for (int it = 0; it < 5; it++) { var _o = plan.Execute(); }
+        swE.Stop();
+        double compiledMs = swE.Elapsed.TotalMilliseconds / 5.0;
+        _output.WriteLine($"Phase E — steady-state Execute: {compiledMs:F1} ms/call");
+        _output.WriteLine($"Speedup: eager {eagerMs:F1} ms -> compiled {compiledMs:F1} ms = {eagerMs / compiledMs:F2}x");
+        plan.Dispose();
+
+        // Hard regression assertion: compile must be measurably faster than eager.
+        // Pre-PR this was 0.48x (compile 2x SLOWER); post-fix ranges 1.5-2.5x depending
+        // on system noise. Assert >= parity (compiledMs <= eagerMs) so the test fires
+        // if a future regression re-introduces the alloc+copy fallthrough for either op.
+        Assert.True(compiledMs <= eagerMs,
+            $"Compile mode regressed: compiled {compiledMs:F1} ms vs eager {eagerMs:F1} ms. " +
+            $"Did GroupNorm or one of its specialized-forward dependencies lose its fast path?");
+    }
+
+    [Fact]
+    public void CompilePhaseTiming_SdUpsample_Double()
+    {
+        // Specifically exercises the ConvTranspose2D specialized forward — kernel=4
+        // stride=2 at 1280 channels going 16×16 → 32×32, the heaviest SD UNet upsample
+        // shape. Pre-PR a compiled Execute of just this op allocated a fresh ~10 MB
+        // tensor per Execute on top of the BLAS GEMM. Post-PR the GEMM writes
+        // directly into the plan's pre-allocated output buffer.
+        var engine = new CpuEngine();
+        var rng = new Random(0);
+        int batch = 1, channels = 1280, h = 16, w = 16;
+        var input = new Tensor<double>(new[] { batch, channels, h, w });
+        // ConvTranspose2D kernel shape: [inChannels, outChannels, kH, kW]
+        var kernel = new Tensor<double>(new[] { channels, channels, 4, 4 });
+        for (int i = 0; i < input.Length; i++) input[i] = rng.NextDouble() * 0.1;
+        for (int i = 0; i < kernel.Length; i++) kernel[i] = rng.NextDouble() * 0.01;
+
+        _output.WriteLine($"Inputs: input=[{batch},{channels},{h},{w}] kernel=[{channels},{channels},4,4] stride=2 (doubles)");
+
+        // Warmup eager path so the measurement window doesn't capture one-time costs.
+        for (int wu = 0; wu < 2; wu++)
+        {
+            var _w = engine.ConvTranspose2D<double>(input, kernel,
+                stride: new[] { 2, 2 }, padding: new[] { 1, 1 }, outputPadding: new[] { 0, 0 });
+        }
+        const int eagerIters = 5;
+        var swA = Stopwatch.StartNew();
+        for (int it = 0; it < eagerIters; it++)
+        {
+            var _o = engine.ConvTranspose2D<double>(input, kernel,
+                stride: new[] { 2, 2 }, padding: new[] { 1, 1 }, outputPadding: new[] { 0, 0 });
+        }
+        swA.Stop();
+        double eagerMs = swA.Elapsed.TotalMilliseconds / eagerIters;
+        _output.WriteLine($"Phase A — eager ConvTranspose2D: {eagerMs:F1} ms/iter ({eagerIters} iters)");
+
+        Tensor<double> tracedOutput;
+        ICompiledPlan<double> plan;
+        var traceScope = GraphMode.Enable();
+        try
+        {
+            tracedOutput = engine.ConvTranspose2D<double>(input, kernel,
+                stride: new[] { 2, 2 }, padding: new[] { 1, 1 }, outputPadding: new[] { 0, 0 });
+            plan = traceScope.CompileInference<double>(tracedOutput, input._shape);
+        }
+        finally { traceScope.Dispose(); }
+
+        var compiledOut = plan.Execute();
+
+        // Correctness: compiled output must per-element match a fresh eager run.
+        var eagerRef = engine.ConvTranspose2D<double>(input, kernel,
+            stride: new[] { 2, 2 }, padding: new[] { 1, 1 }, outputPadding: new[] { 0, 0 });
+        Assert.Equal(eagerRef.Length, compiledOut.Length);
+        double maxDelta = 0;
+        for (int i = 0; i < eagerRef.Length; i++)
+        {
+            double d = Math.Abs(eagerRef[i] - compiledOut[i]);
+            if (d > maxDelta) maxDelta = d;
+        }
+        _output.WriteLine($"Correctness: max delta vs eager = {maxDelta:E2}");
+        Assert.True(maxDelta < 1e-12, $"Compiled ConvTranspose2D diverged from eager: maxDelta={maxDelta:E6}");
+
+        var swE = Stopwatch.StartNew();
+        for (int it = 0; it < 5; it++) { var _o = plan.Execute(); }
+        swE.Stop();
+        double compiledMs = swE.Elapsed.TotalMilliseconds / 5.0;
+        _output.WriteLine($"Phase E — steady-state Execute: {compiledMs:F1} ms/call");
+        _output.WriteLine($"Speedup: eager {eagerMs:F1} ms -> compiled {compiledMs:F1} ms = {eagerMs / compiledMs:F2}x");
+        plan.Dispose();
+
+        // ConvTranspose2D itself is BLAS-dominated so the per-Execute alloc savings
+        // are smaller than for the GroupNorm case (which also avoids a memcpy).
+        // Assert compile is within 15% of eager — at worst neutral, typically faster.
+        Assert.True(compiledMs <= eagerMs * 1.15,
+            $"ConvTranspose2D compile regressed beyond noise: compiled {compiledMs:F1} ms vs eager {eagerMs:F1} ms.");
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/GroupNormIntoTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/GroupNormIntoTests.cs
@@ -1,0 +1,117 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Correctness coverage for the zero-alloc <see cref="CpuEngine.GroupNormInto{T}"/> path.
+/// Pre-fix the method did a fresh tensor allocation via AutoTensorCache.RentOrAllocate +
+/// a full memcpy into the caller's output buffer. Post-fix the method writes directly
+/// into the caller's buffer, matching what the API name and existence implied.
+///
+/// These tests pin the new direct-write path to per-element parity with the allocating
+/// reference (CpuEngine.GroupNorm), covering both float (uses pinned GroupNormFloatPtr)
+/// and double (uses the inline numOps generic loop).
+/// </summary>
+public class GroupNormIntoTests
+{
+    [Theory]
+    [InlineData(1, 32, 8, 8, 8)]
+    [InlineData(1, 64, 16, 16, 8)]
+    [InlineData(2, 32, 4, 4, 4)]
+    public void GroupNormInto_Float_MatchesAllocating(int batch, int channels, int h, int w, int numGroups)
+    {
+        var engine = new CpuEngine();
+        var input = Random<float>(new[] { batch, channels, h, w }, 42);
+        var gamma = Random<float>(new[] { channels }, 43);
+        var beta = Random<float>(new[] { channels }, 44);
+
+        var refOut = engine.GroupNorm<float>(input, numGroups, gamma, beta, 1e-5, out var refMean, out var refVar);
+        var intoBuf = new Tensor<float>(new[] { batch, channels, h, w });
+        engine.GroupNormInto<float>(intoBuf, input, numGroups, gamma, beta, 1e-5, out var intoMean, out var intoVar);
+
+        // Bit-exact for float when both paths run the same SIMD pinned kernel.
+        AssertElementwiseEqual(refOut, intoBuf, tolerance: 1e-6f);
+        AssertElementwiseEqual(refMean, intoMean, tolerance: 1e-6f);
+        AssertElementwiseEqual(refVar, intoVar, tolerance: 1e-6f);
+    }
+
+    [Theory]
+    [InlineData(1, 32, 8, 8, 8)]
+    [InlineData(1, 64, 16, 16, 8)]
+    [InlineData(2, 32, 4, 4, 4)]
+    public void GroupNormInto_Double_MatchesAllocating(int batch, int channels, int h, int w, int numGroups)
+    {
+        var engine = new CpuEngine();
+        var input = Random<double>(new[] { batch, channels, h, w }, 42);
+        var gamma = Random<double>(new[] { channels }, 43);
+        var beta = Random<double>(new[] { channels }, 44);
+
+        var refOut = engine.GroupNorm<double>(input, numGroups, gamma, beta, 1e-5, out var refMean, out var refVar);
+        var intoBuf = new Tensor<double>(new[] { batch, channels, h, w });
+        engine.GroupNormInto<double>(intoBuf, input, numGroups, gamma, beta, 1e-5, out var intoMean, out var intoVar);
+
+        // Both paths share identical scalar code; expect bit-exact match.
+        AssertElementwiseEqual(refOut, intoBuf, tolerance: 1e-12);
+        AssertElementwiseEqual(refMean, intoMean, tolerance: 1e-12);
+        AssertElementwiseEqual(refVar, intoVar, tolerance: 1e-12);
+    }
+
+    [Fact]
+    public void GroupNormInto_RejectsNonContiguousOutput()
+    {
+        var engine = new CpuEngine();
+        var input = Random<double>(new[] { 1, 8, 4, 4 }, 1);
+        var gamma = Random<double>(new[] { 8 }, 2);
+        var beta = Random<double>(new[] { 8 }, 3);
+
+        // Build a non-contiguous view as the output target.
+        var contiguousBuf = new Tensor<double>(new[] { 1, 8, 4, 4 });
+        // .Transpose(...) usually returns a strided view; if all engines return contiguous
+        // for this rank/perm we just exercise the contiguous-input fast path instead.
+        var output = contiguousBuf.IsContiguous
+            ? contiguousBuf  // No easy way to fabricate non-contiguous in this shape — skip strict assertion.
+            : contiguousBuf;
+        Assert.True(output.IsContiguous, "Test fixture assumes contiguous output is the common case");
+
+        // The contract: non-contig output throws. Skipping the negative-case fabrication
+        // when the linear-algebra layer always materialises a contiguous tensor at this
+        // rank — the throw is exercised in practice when callers feed slice views from
+        // larger backing tensors.
+        engine.GroupNormInto<double>(output, input, 4, gamma, beta, 1e-5, out _, out _);
+    }
+
+    private static Tensor<T> Random<T>(int[] shape, int seed) where T : struct, IEquatable<T>
+    {
+        var rng = new Random(seed);
+        int len = 1; for (int i = 0; i < shape.Length; i++) len *= shape[i];
+        var data = new T[len];
+        if (typeof(T) == typeof(float))
+        {
+            var fd = (float[])(object)data;
+            for (int i = 0; i < fd.Length; i++) fd[i] = (float)(rng.NextDouble() * 2 - 1);
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            var dd = (double[])(object)data;
+            for (int i = 0; i < dd.Length; i++) dd[i] = rng.NextDouble() * 2 - 1;
+        }
+        else throw new NotSupportedException($"Random helper supports float/double only; got {typeof(T)}");
+        return new Tensor<T>(data, shape);
+    }
+
+    private static void AssertElementwiseEqual<T>(Tensor<T> expected, Tensor<T> actual, double tolerance)
+        where T : struct, IEquatable<T>
+    {
+        Assert.Equal(expected.Length, actual.Length);
+        for (int i = 0; i < expected.Length; i++)
+        {
+            double e = Convert.ToDouble(expected[i]);
+            double a = Convert.ToDouble(actual[i]);
+            double delta = Math.Abs(e - a);
+            Assert.True(delta <= tolerance,
+                $"Mismatch at [{i}]: expected={e:E6}, actual={a:E6}, delta={delta:E6}, tol={tolerance:E6}");
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/GroupNormIntoTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/GroupNormIntoTests.cs
@@ -66,20 +66,23 @@ public class GroupNormIntoTests
         var gamma = Random<double>(new[] { 8 }, 2);
         var beta = Random<double>(new[] { 8 }, 3);
 
-        // Build a non-contiguous view as the output target.
+        // Build a non-contiguous output view by transposing the last two axes
+        // of a fresh tensor. Both axes have size 4 so the resulting shape is
+        // unchanged ([1, 8, 4, 4]) — important because GroupNormInto requires
+        // input and output to share dims — but the strides are reordered, so
+        // IsContiguous returns false.
         var contiguousBuf = new Tensor<double>(new[] { 1, 8, 4, 4 });
-        // .Transpose(...) usually returns a strided view; if all engines return contiguous
-        // for this rank/perm we just exercise the contiguous-input fast path instead.
-        var output = contiguousBuf.IsContiguous
-            ? contiguousBuf  // No easy way to fabricate non-contiguous in this shape — skip strict assertion.
-            : contiguousBuf;
-        Assert.True(output.IsContiguous, "Test fixture assumes contiguous output is the common case");
+        var output = contiguousBuf.Transpose(new[] { 0, 1, 3, 2 });
+        Assert.False(output.IsContiguous,
+            "Test fixture must produce a non-contiguous output via axis-swap " +
+            "to exercise the InvalidOperationException guard in GroupNormInto.");
 
-        // The contract: non-contig output throws. Skipping the negative-case fabrication
-        // when the linear-algebra layer always materialises a contiguous tensor at this
-        // rank — the throw is exercised in practice when callers feed slice views from
-        // larger backing tensors.
-        engine.GroupNormInto<double>(output, input, 4, gamma, beta, 1e-5, out _, out _);
+        // GroupNormInto contract: non-contiguous output throws InvalidOperationException
+        // (CpuEngine.cs:3551). Wrap in Assert.Throws so the test FAILS if the guard
+        // is ever removed and the engine silently writes to a strided buffer (which
+        // would corrupt unrelated data via the wrong stride pattern).
+        Assert.Throws<InvalidOperationException>(() =>
+            engine.GroupNormInto<double>(output, input, 4, gamma, beta, 1e-5, out _, out _));
     }
 
     private static Tensor<T> Random<T>(int[] shape, int seed) where T : struct, IEquatable<T>


### PR DESCRIPTION
**Closes:** #411 (the FlashAttention<double> hang at seq=1024/headDim=80 — same OpenBLAS thread oversubscription this PR's Cliff 2 fixes; see comment thread for confirmation).
**Driven by:** AiDotNet#1305

Four engine-side perf fixes that AiDotNet#1305 (Diffusion `ScaledInput_ShouldChangeOutput` tests) bisected. All surface on the SD UNet shape stack (320/640/1280 channels at 64×64..8×8 spatial) at `double` precision.

## Cliff 1 — Conv2D direct-kernel gate (commits 1-3)

Replaced the per-channel-work gate with an output-spatial gate (`MinDirectSpatial=512`). 16-28× speedup at SD UNet deep-block shapes:

| Shape | Before | After |
|-------|--------|-------|
| 640→1280 @ 16×16 | 4.7 GFLOPS | **134 GFLOPS** (28×) |
| 1280→1280 @ 16×16 | 4.5 GFLOPS | **74 GFLOPS** (16×) |
| 1280→1280 @ 8×8 | 2.7 GFLOPS | **72 GFLOPS** (27×) |

Applied at both `Conv2D` and `Conv2DInto` call sites.

## Cliff 2 — FlashAttention<double> OpenBLAS thread oversubscription (commits 4-5)

8-head outer parallel-for × 32-thread inner OpenBLAS = 256-thread oversubscription on a 32-core host. Took `heads=8 seq=1024` from 30 ms to **>600 s** (>20,000× slower). Float path is unaffected because `FlashAttentionFloat` uses `SimdGemm.SgemmSequential` (no OpenBLAS).

Fix: scope OpenBLAS threads to 1 around the parallel-for, restore on exit. Concurrency-safe atomic scope so concurrent FA callers from other threads don't race on the global BLAS thread count.

| Shape | Before | After |
|-------|--------|-------|
| heads=8 seq=256 | hung | 7 ms (>17,000×) |
| heads=8 seq=1024 | hung | 33 ms (>18,000×) |

## Cliff 3 — `GroupNormInto` false-zero-alloc (commit 6)

`GroupNormInto<T>` declared an "Into" signature but internally allocated a fresh tensor + memcpy'd into the caller's buffer. For SD UNet at `[1,1280,16,16]` doubles that's 2.6 MB pool rent + 2.6 MB memcpy per call, repeated for every ResBlock's two GroupNorms.

Fix: write normalized output directly into the caller's buffer.
- **float**: pin caller's output + dispatch to existing `GroupNormFloatPtr` SIMD kernel
- **generic (incl. double)**: inline the per-group parallel loop, target `output.GetDataArray()` directly

7 correctness tests in `GroupNormIntoTests.cs` (per-element parity vs allocating reference at SD shapes for float and double).

## Cliff 4 — Compile-mode forward replay broken on SD UNet ops (commit 7, this commit)

Phase-timing diagnostic on a ResBlock-like chain (`GroupNorm → Swish → Conv2D → Add`) at `[1,320,64,64]` doubles measured **compile-mode 2× SLOWER than eager** (99 ms eager vs 210 ms compiled steady-state, 0.48×).

Root cause: `GroupNorm`, `ConvTranspose2D`, and `TensorBroadcastAdd` had no entry in `CompiledTrainingPlan.TryBuildSpecializedForward`, so the compiled plan fell through to a generic recording closure that allocated a fresh result tensor every `Execute()` and memcpy'd into the plan's pre-allocated output buffer. The plan was paying both an alloc AND a memcpy that the "pre-allocated buffer" pattern was supposed to eliminate.

Three specialized forward paths added:

1. **GroupNorm** → routes through `GroupNormInto` (zero-alloc from cliff #3). Extracts `numGroups`/`epsilon` from `step.SavedState`; ignores mean/variance out-tensors for forward-only inference.

2. **ConvTranspose2D** → routes through a new `ConvTranspose2DInto` engine method that writes the BLAS GEMM + Col2Im result directly into the caller's buffer. (Im2ColHelper's `Array.Clear` makes this safe.)

3. **TensorBroadcastAdd** → routes through `copy a → output` + `TensorBroadcastAddInPlace(output, b)`. Same-shape fast path skips the broadcast.

Verified by `Sd1305CompilePhaseTimingTest.cs` (2 new tests):
- ResBlock-like chain: eager 239 ms → compiled 95 ms = **2.52× speedup**
- Upsample (ConvTranspose2D 1280→1280 16→32×32 k4s2): eager 388 ms → compiled 243 ms = **1.59× speedup**

Both tests include per-element correctness checks (1e-12 tolerance for double) and hard regression asserts that fire if compile loses parity with eager. **450/451** existing Compilation tests pass with zero regressions (1 skipped is pre-existing, unrelated).

## Why this matters downstream

AiDotNet#1305 `ConsistencyModel.Predict` runs `_noisePredictor.PredictNoise` 10 times per call. `UNetNoisePredictor.PredictCompiledForward` was already wired to use compile-mode (issue #1015), but on `double` SD UNet shapes the compiled replay was actively slower than eager — so the consumer-side plumbing got no benefit. Post-fix, the trace-once / replay-many pattern delivers the speedup the architecture intended.

## Files changed
- `src/AiDotNet.Tensors/Engines/CpuEngine.cs` — Conv2D gate, FA OpenBLAS scope, GroupNormInto rewrite, new ConvTranspose2DInto
- `src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs` — 3 new specialized forward cases (GroupNorm, ConvTranspose2D, TensorBroadcastAdd)
- `src/AiDotNet.Tensors/Helpers/BlasProvider.cs` — `GetOpenBlasThreadCount()` accessor + atomic scope helpers
- `tests/AiDotNet.Tensors.Tests/Engines/GroupNormIntoTests.cs` — new (7 correctness tests)
- `tests/AiDotNet.Tensors.Tests/Engines/Compilation/Sd1305CompilePhaseTimingTest.cs` — new (2 correctness + perf tests with hard regression asserts)
