### PR TITLE
perf(#403): phase a — shape catalog, dcgan step probe, alloc profile

### DIFF
--- a/src/AiDotNet.Tensors/Helpers/BlasProvider.cs
+++ b/src/AiDotNet.Tensors/Helpers/BlasProvider.cs
@@ -450,6 +450,28 @@ internal static class BlasProvider
     /// <summary>Resolved lazily on first use — probes MklImports once.</summary>
     private static readonly Lazy<bool> _mklAvailable = new(ProbeMklLibrary);
 
+    // ─────────────────────────────────────────────────────────────────────
+    // Shape-instrumentation hook (issue #403 Phase A.1).
+    //
+    // When subscribed, every successful TryGemm/TryGemmWithBeta/TryGemmEx
+    // call invokes the hook with (m, n, k, transA, transB) so a higher-level
+    // profiler can build a unique-shape catalog without modifying call
+    // sites. The hook is a single volatile delegate read on the fast path —
+    // when unset, the per-call cost is one null check.
+    //
+    // Subscribe by assigning ShapeLogHook = (m,n,k,tA,tB) => {...}.
+    // Unsubscribe by assigning null. Concurrent subscribe/unsubscribe is not
+    // supported (intended single-consumer profiler).
+    // ─────────────────────────────────────────────────────────────────────
+    internal static Action<int, int, int, bool, bool>? ShapeLogHook;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void LogShape(int m, int n, int k, bool transA = false, bool transB = false)
+    {
+        var hook = ShapeLogHook;
+        if (hook is not null) hook(m, n, k, transA, transB);
+    }
+
 #if NET5_0_OR_GREATER
     static BlasProvider()
     {
@@ -920,6 +942,7 @@ internal static class BlasProvider
                         m, n, k, 1.0f, pa, lda, pb, ldb, 0.0f, pc, ldc);
                 }
             }
+            LogShape(m, n, k);
             return true;
         }
         catch { return false; }
@@ -943,6 +966,7 @@ internal static class BlasProvider
                         m, n, k, 1.0, pa, lda, pb, ldb, 0.0, pc, ldc);
                 }
             }
+            LogShape(m, n, k);
             return true;
         }
         catch { return false; }
@@ -964,6 +988,7 @@ internal static class BlasProvider
                         m, n, k, 1.0f, pa, lda, pb, ldb, 0.0f, pc, ldc);
                 }
             }
+            LogShape(m, n, k);
             return true;
         }
         catch { return false; }
@@ -985,6 +1010,7 @@ internal static class BlasProvider
                         m, n, k, 1.0, pa, lda, pb, ldb, 0.0, pc, ldc);
                 }
             }
+            LogShape(m, n, k);
             return true;
         }
         catch { return false; }
@@ -1008,6 +1034,7 @@ internal static class BlasProvider
                         m, n, k, 1.0f, pa, lda, pb, ldb, beta, pc, ldc);
                 }
             }
+            LogShape(m, n, k);
             return true;
         }
         catch { return false; }
@@ -1031,6 +1058,7 @@ internal static class BlasProvider
                         m, n, k, 1.0, pa, lda, pb, ldb, beta, pc, ldc);
                 }
             }
+            LogShape(m, n, k);
             return true;
         }
         catch { return false; }
@@ -1059,6 +1087,7 @@ internal static class BlasProvider
                         m, n, k, 1.0f, pa, lda, pb, ldb, 0.0f, pc, ldc);
                 }
             }
+            LogShape(m, n, k, transA, transB);
             return true;
         }
         catch { return false; }
@@ -1090,6 +1119,7 @@ internal static class BlasProvider
                         m, n, k, 1.0, pa, lda, pb, ldb, 0.0, pc, ldc);
                 }
             }
+            LogShape(m, n, k, transA, transB);
             return true;
         }
         catch { return false; }
@@ -1122,6 +1152,7 @@ internal static class BlasProvider
                         m, n, k, alpha, pa, lda, pb, ldb, beta, pc, ldc);
                 }
             }
+            LogShape(m, n, k, transA, transB);
             return true;
         }
         catch { return false; }
@@ -1151,6 +1182,7 @@ internal static class BlasProvider
                         m, n, k, alpha, pa, lda, pb, ldb, beta, pc, ldc);
                 }
             }
+            LogShape(m, n, k, transA, transB);
             return true;
         }
         catch { return false; }

--- a/src/AiDotNet.Tensors/Helpers/ShapeInstrumenter.cs
+++ b/src/AiDotNet.Tensors/Helpers/ShapeInstrumenter.cs
@@ -1,0 +1,114 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace AiDotNet.Tensors.Helpers;
+
+/// <summary>
+/// Per-shape GEMM-call profiler (issue #403 Phase A.1).
+///
+/// <para>Subscribes to <see cref="BlasProvider.ShapeLogHook"/> for the
+/// duration of a scope, accumulates a unique-shape catalog keyed by
+/// (M, N, K, transA, transB), and dumps it in descending call-count order
+/// on dispose. Designed to wrap a single training step so the per-substep
+/// shape mix is visible without instrumenting every GEMM call site.</para>
+///
+/// <para>Single-consumer: BlasProvider exposes one delegate slot. Concurrent
+/// instances throw on construction to guarantee a clean snapshot. The hook
+/// is fast-path null-checked, so per-call cost is one volatile read when
+/// no instance is active.</para>
+///
+/// <para>Usage:</para>
+/// <code>
+/// using (var probe = new ShapeInstrumenter())
+/// {
+///     RunOneTrainingStep();
+///     probe.PrintCatalog(); // or probe.GetCatalog() / probe.GetSnapshot()
+/// }
+/// </code>
+/// </summary>
+internal sealed class ShapeInstrumenter : IDisposable
+{
+    private static int _activeCount;
+    private readonly Action<int, int, int, bool, bool>? _previousHook;
+    private readonly ConcurrentDictionary<ShapeKey, long> _counts = new();
+    private bool _disposed;
+
+    public ShapeInstrumenter()
+    {
+        if (System.Threading.Interlocked.Increment(ref _activeCount) != 1)
+        {
+            System.Threading.Interlocked.Decrement(ref _activeCount);
+            throw new InvalidOperationException(
+                "Another ShapeInstrumenter is already active. BlasProvider.ShapeLogHook is a single-consumer slot.");
+        }
+
+        _previousHook = BlasProvider.ShapeLogHook;
+        BlasProvider.ShapeLogHook = OnGemm;
+    }
+
+    private void OnGemm(int m, int n, int k, bool transA, bool transB)
+    {
+        var key = new ShapeKey(m, n, k, transA, transB);
+        _counts.AddOrUpdate(key, 1L, static (_, v) => v + 1L);
+    }
+
+    /// <summary>Total GEMM calls observed since construction.</summary>
+    public long TotalCalls => _counts.Values.Sum();
+
+    /// <summary>Number of unique (M,N,K,transA,transB) tuples observed.</summary>
+    public int UniqueShapes => _counts.Count;
+
+    /// <summary>
+    /// Snapshot of the catalog ordered by descending call count. Safe to call
+    /// while the probe is still active.
+    /// </summary>
+    public IReadOnlyList<ShapeEntry> GetCatalog()
+    {
+        return _counts
+            .Select(kvp => new ShapeEntry(kvp.Key.M, kvp.Key.N, kvp.Key.K, kvp.Key.TransA, kvp.Key.TransB, kvp.Value))
+            .OrderByDescending(e => e.Calls)
+            .ThenByDescending(e => (long)e.M * e.N * e.K)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Renders the catalog as a fixed-width markdown table suitable for
+    /// pasting into PR descriptions or the Phase A investigation report.
+    /// </summary>
+    public string FormatCatalog()
+    {
+        var entries = GetCatalog();
+        var sb = new StringBuilder();
+        sb.AppendLine($"Unique shapes: {entries.Count} | Total calls: {TotalCalls}");
+        sb.AppendLine();
+        sb.AppendLine("| Calls |     M |     N |     K | tA | tB |       FLOPs |");
+        sb.AppendLine("|------:|------:|------:|------:|:--:|:--:|------------:|");
+        foreach (var e in entries)
+        {
+            double flops = 2.0 * e.M * e.N * e.K * e.Calls;
+            sb.AppendLine($"| {e.Calls,5} | {e.M,5} | {e.N,5} | {e.K,5} |  {(e.TransA ? "T" : "N")} |  {(e.TransB ? "T" : "N")} | {flops,11:N0} |");
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>Convenience: prints <see cref="FormatCatalog"/> to console.</summary>
+    public void PrintCatalog() => Console.WriteLine(FormatCatalog());
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        BlasProvider.ShapeLogHook = _previousHook;
+        System.Threading.Interlocked.Decrement(ref _activeCount);
+    }
+
+    private readonly record struct ShapeKey(int M, int N, int K, bool TransA, bool TransB);
+
+    /// <summary>Public-facing catalog entry.</summary>
+    internal readonly record struct ShapeEntry(int M, int N, int K, bool TransA, bool TransB, long Calls);
+}

--- a/tests/AiDotNet.Tensors.Benchmarks/DCGANStepProbe.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/DCGANStepProbe.cs
@@ -65,6 +65,21 @@ public class DCGANStepProbe
     private const int ColH = InChannels * KernelHW * KernelHW;
     private const int ColW = SpatialOut * SpatialOut;
 
+    // PR #412 CodeRabbit fix: hoist the shape / stride / padding / dilation
+    // int[] arrays to static readonly fields so the backward probe methods
+    // don't allocate three fresh arrays per call. The allocation profile is
+    // measuring op-internal allocations; the harness overhead of allocating
+    // these argument arrays per call contaminates the per-substep ranking
+    // (especially Conv2DBackward* which fire ~1 KB of GC-heap traffic per
+    // call from just the int[] args before any engine code runs).
+    private static readonly int[] InputShape =
+        { Batch, InChannels, SpatialIn, SpatialIn };
+    private static readonly int[] KernelShape =
+        { OutChannels, InChannels, KernelHW, KernelHW };
+    private static readonly int[] StrideArr = { Stride, Stride };
+    private static readonly int[] PaddingArr = { Padding, Padding };
+    private static readonly int[] DilationArr = { 1, 1 };
+
     private CpuEngine _engine = null!;
 
     // FP64 (matches DCGANTests.MoreData_ShouldNotDegrade)
@@ -75,6 +90,12 @@ public class DCGANStepProbe
     private Tensor<double> _bnBeta64 = null!;
     private Tensor<double> _bnIn64 = null!;
     private Tensor<double> _bnGradOut64 = null!;
+    // PR #412 CodeRabbit fix: precomputed mean/var so BatchNormBackward_Fp64
+    // only measures the backward step. Pre-fix the benchmark called BatchNorm
+    // (forward) inside the measured method, so the reported "backward" time
+    // and allocation profile actually included the full forward pass.
+    private Tensor<double> _bnMean64 = null!;
+    private Tensor<double> _bnVar64 = null!;
     private Tensor<double> _addA64 = null!;
     private Tensor<double> _addB64 = null!;
 
@@ -101,6 +122,11 @@ public class DCGANStepProbe
         _bnGamma64 = Tensor<double>.CreateRandom(rng, InChannels);
         _bnBeta64 = Tensor<double>.CreateRandom(rng, InChannels);
         _bnGradOut64 = Tensor<double>.CreateRandom(rng, Batch, InChannels, SpatialIn, SpatialIn);
+
+        // PR #412 CodeRabbit fix: run BN forward ONCE during setup so the
+        // backward probe can reuse mean/var without paying forward cost on
+        // each measured iteration.
+        _ = _engine.BatchNorm(_bnIn64, _bnGamma64, _bnBeta64, 1e-5, out _bnMean64, out _bnVar64);
 
         int addLen = Batch * OutChannels * SpatialOut * SpatialOut;
         _addA64 = Tensor<double>.CreateRandom(rng, addLen);
@@ -144,14 +170,12 @@ public class DCGANStepProbe
     [Benchmark, BenchmarkCategory("Conv2DBackward")]
     public Tensor<double> Conv2DBackwardInput_Fp64()
         => _engine.Conv2DBackwardInput(_gradOutput64, _kernel64,
-            new[] { Batch, InChannels, SpatialIn, SpatialIn },
-            new[] { Stride, Stride }, new[] { Padding, Padding }, new[] { 1, 1 });
+            InputShape, StrideArr, PaddingArr, DilationArr);
 
     [Benchmark, BenchmarkCategory("Conv2DBackward")]
     public Tensor<double> Conv2DBackwardKernel_Fp64()
         => _engine.Conv2DBackwardKernel(_gradOutput64, _input64,
-            new[] { OutChannels, InChannels, KernelHW, KernelHW },
-            new[] { Stride, Stride }, new[] { Padding, Padding }, new[] { 1, 1 });
+            KernelShape, StrideArr, PaddingArr, DilationArr);
 
     // ─── RecordBinary overhead (tape inactive vs tape active) ─────────────
 
@@ -174,12 +198,10 @@ public class DCGANStepProbe
 
     [Benchmark, BenchmarkCategory("BatchNorm")]
     public Tensor<double> BatchNormBackward_Fp64()
-    {
-        var fwd = _engine.BatchNorm(_bnIn64, _bnGamma64, _bnBeta64, 1e-5, out var mean, out var var);
-        return _engine.BatchNormBackward(
-            _bnGradOut64, _bnIn64, _bnGamma64, mean, var, 1e-5,
+        // Use the precomputed mean/var from Setup so this measures backward-only.
+        => _engine.BatchNormBackward(
+            _bnGradOut64, _bnIn64, _bnGamma64, _bnMean64, _bnVar64, 1e-5,
             out _, out _);
-    }
 
     // ─── Phase A.3 allocation profile (callable outside BDN) ──────────────
 
@@ -201,8 +223,20 @@ public class DCGANStepProbe
         probe.Setup();
         var p = new AllocationProfile();
 
-        // Warm up JIT — first call dominates allocation if measured cold.
+        // Warm up every measured path once before allocation sampling.
+        // PR #412 CodeRabbit fix: pre-fix only Conv2DForward_Fp64 was warmed,
+        // so the other 8 substeps still incurred first-call/JIT-tier-up alloc
+        // overhead in their MeasureAlloc result — skewing the Phase A
+        // per-substep ranking. Warming all paths gives steady-state numbers.
+        probe.Im2Col_Fp32_DcganShape();
         _ = probe.Conv2DForward_Fp64();
+        _ = probe.Conv2DForward_Fp32();
+        _ = probe.Conv2DBackwardInput_Fp64();
+        _ = probe.Conv2DBackwardKernel_Fp64();
+        _ = probe.TensorAdd_NoTape();
+        _ = probe.TensorAdd_WithTape();
+        _ = probe.BatchNormForward_Fp64();
+        _ = probe.BatchNormBackward_Fp64();
 
         p.Im2Col_Fp32 = MeasureAlloc(() => probe.Im2Col_Fp32_DcganShape());
         p.Conv2DForward_Fp64 = MeasureAlloc(() => probe.Conv2DForward_Fp64());

--- a/tests/AiDotNet.Tensors.Benchmarks/DCGANStepProbe.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/DCGANStepProbe.cs
@@ -1,0 +1,272 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+namespace AiDotNet.Tensors.Benchmarks;
+
+/// <summary>
+/// Issue #403 Phase A — per-component microbench at DCGAN-typical shapes.
+///
+/// <para>The DCGAN training step is dominated by Conv2D / ConvTranspose2D
+/// on a small set of (batch, channels, spatial, kernel) shapes. Per the
+/// issue's profile, ~95% of wall time per step lives in this repo with
+/// the heaviest substep being the generator-adversarial gradient pass.
+/// This probe isolates the underlying tensor ops so Phase B-E can target
+/// the right hotspot.</para>
+///
+/// <para>Substeps measured (mirrors the issue's Phase A.2 list):</para>
+/// <list type="bullet">
+///   <item><b>Im2Col</b>: <see cref="Im2ColHelper.Im2Col(ReadOnlySpan{float}, Span{float}, int, int, int, int, int, int, int, int, int, int, int, int)"/>
+///         at the DCGAN-decoder shapes (batch=2, kernel 4×4, 8×8 → 16×16).</item>
+///   <item><b>Conv2D forward</b>: <see cref="CpuEngine.Conv2D{T}(Tensor{T}, Tensor{T}, int, int, int)"/>
+///         (the entry point that wraps Im2Col + GEMM).</item>
+///   <item><b>Conv2D backward input</b>: <see cref="CpuEngine.Conv2DBackwardInput{T}"/>.</item>
+///   <item><b>Conv2D backward kernel</b>: <see cref="CpuEngine.Conv2DBackwardKernel{T}"/>.</item>
+///   <item><b>RecordBinary overhead</b>: tape-recorded TensorAdd inside an
+///         active tape vs the same op with no tape.</item>
+///   <item><b>BatchNorm forward / backward</b>:
+///         <see cref="CpuEngine.BatchNorm{T}"/> and
+///         <see cref="CpuEngine.BatchNormBackward{T}"/>.</item>
+/// </list>
+///
+/// <para>Shape choice mirrors a late-DCGAN-decoder layer (batch=2,
+/// in=64, out=64, spatial=8×8, kernel=4×4 with stride/pad as appropriate).
+/// FP64 is the primary mode because the issue's failing test
+/// <c>DCGANTests.MoreData_ShouldNotDegrade</c> instantiates the model with
+/// <c>double</c> as <c>T</c>. An FP32 sibling benchmark is included for
+/// the Phase F escape-hatch comparison.</para>
+///
+/// <para>Run via <c>dotnet run -c Release --project tests/AiDotNet.Tensors.Benchmarks
+/// -- --filter *DCGANStepProbe*</c>. Pair the output with a
+/// <see cref="ShapeInstrumenter"/> scope over a real DCGAN step to identify
+/// which substep dominates wall time for the production model.</para>
+/// </summary>
+[SimpleJob(RuntimeMoniker.Net10_0, warmupCount: 3, iterationCount: 10)]
+[MemoryDiagnoser]
+public class DCGANStepProbe
+{
+    // ─── DCGAN-typical shapes (late decoder layer, batch=2) ───────────────
+    private const int Batch = 2;
+    private const int InChannels = 64;
+    private const int OutChannels = 64;
+    private const int SpatialIn = 8;
+    private const int KernelHW = 4;
+    private const int Stride = 1;
+    private const int Padding = 1;  // (8 + 2*1 - 4)/1 + 1 = 7
+    private const int SpatialOut = (SpatialIn + 2 * Padding - KernelHW) / Stride + 1;
+
+    // Im2Col working buffer dims
+    private const int ColH = InChannels * KernelHW * KernelHW;
+    private const int ColW = SpatialOut * SpatialOut;
+
+    private CpuEngine _engine = null!;
+
+    // FP64 (matches DCGANTests.MoreData_ShouldNotDegrade)
+    private Tensor<double> _input64 = null!;
+    private Tensor<double> _kernel64 = null!;
+    private Tensor<double> _gradOutput64 = null!;
+    private Tensor<double> _bnGamma64 = null!;
+    private Tensor<double> _bnBeta64 = null!;
+    private Tensor<double> _bnIn64 = null!;
+    private Tensor<double> _bnGradOut64 = null!;
+    private Tensor<double> _addA64 = null!;
+    private Tensor<double> _addB64 = null!;
+
+    // FP32 (Phase F escape-hatch — 8-lane AVX2 vs FP64's 4-lane)
+    private Tensor<float> _input32 = null!;
+    private Tensor<float> _kernel32 = null!;
+    private Tensor<float> _gradOutput32 = null!;
+
+    // Im2Col scratch (FP32, since the public helper is float-only)
+    private float[] _im2colIn = null!;
+    private float[] _im2colOut = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new CpuEngine();
+        var rng = new Random(42);
+
+        _input64 = Tensor<double>.CreateRandom(rng, Batch, InChannels, SpatialIn, SpatialIn);
+        _kernel64 = Tensor<double>.CreateRandom(rng, OutChannels, InChannels, KernelHW, KernelHW);
+        _gradOutput64 = Tensor<double>.CreateRandom(rng, Batch, OutChannels, SpatialOut, SpatialOut);
+
+        _bnIn64 = Tensor<double>.CreateRandom(rng, Batch, InChannels, SpatialIn, SpatialIn);
+        _bnGamma64 = Tensor<double>.CreateRandom(rng, InChannels);
+        _bnBeta64 = Tensor<double>.CreateRandom(rng, InChannels);
+        _bnGradOut64 = Tensor<double>.CreateRandom(rng, Batch, InChannels, SpatialIn, SpatialIn);
+
+        int addLen = Batch * OutChannels * SpatialOut * SpatialOut;
+        _addA64 = Tensor<double>.CreateRandom(rng, addLen);
+        _addB64 = Tensor<double>.CreateRandom(rng, addLen);
+
+        _input32 = Tensor<float>.CreateRandom(rng, Batch, InChannels, SpatialIn, SpatialIn);
+        _kernel32 = Tensor<float>.CreateRandom(rng, OutChannels, InChannels, KernelHW, KernelHW);
+        _gradOutput32 = Tensor<float>.CreateRandom(rng, Batch, OutChannels, SpatialOut, SpatialOut);
+
+        _im2colIn = new float[Batch * InChannels * SpatialIn * SpatialIn];
+        for (int i = 0; i < _im2colIn.Length; i++) _im2colIn[i] = (float)rng.NextDouble();
+        _im2colOut = new float[Batch * ColH * ColW];
+    }
+
+    // ─── Im2Col (raw helper, FP32 — issue lists this as a top allocator) ──
+
+    [Benchmark, BenchmarkCategory("Im2Col")]
+    public void Im2Col_Fp32_DcganShape()
+    {
+        Im2ColHelper.Im2Col(
+            _im2colIn, _im2colOut,
+            Batch, InChannels, SpatialIn, SpatialIn,
+            KernelHW, KernelHW,
+            Stride, Stride,
+            Padding, Padding,
+            1, 1);
+    }
+
+    // ─── Conv2D forward (entry point that wraps Im2Col + GEMM) ────────────
+
+    [Benchmark, BenchmarkCategory("Conv2DForward")]
+    public Tensor<double> Conv2DForward_Fp64()
+        => _engine.Conv2D(_input64, _kernel64, Stride, Padding, 1);
+
+    [Benchmark, BenchmarkCategory("Conv2DForward")]
+    public Tensor<float> Conv2DForward_Fp32()
+        => _engine.Conv2D(_input32, _kernel32, Stride, Padding, 1);
+
+    // ─── Conv2D backward (the heavier half of the per-step profile) ───────
+
+    [Benchmark, BenchmarkCategory("Conv2DBackward")]
+    public Tensor<double> Conv2DBackwardInput_Fp64()
+        => _engine.Conv2DBackwardInput(_gradOutput64, _kernel64,
+            new[] { Batch, InChannels, SpatialIn, SpatialIn },
+            new[] { Stride, Stride }, new[] { Padding, Padding }, new[] { 1, 1 });
+
+    [Benchmark, BenchmarkCategory("Conv2DBackward")]
+    public Tensor<double> Conv2DBackwardKernel_Fp64()
+        => _engine.Conv2DBackwardKernel(_gradOutput64, _input64,
+            new[] { OutChannels, InChannels, KernelHW, KernelHW },
+            new[] { Stride, Stride }, new[] { Padding, Padding }, new[] { 1, 1 });
+
+    // ─── RecordBinary overhead (tape inactive vs tape active) ─────────────
+
+    [Benchmark(Baseline = true), BenchmarkCategory("RecordBinary")]
+    public Tensor<double> TensorAdd_NoTape()
+        => _engine.TensorAdd(_addA64, _addB64);
+
+    [Benchmark, BenchmarkCategory("RecordBinary")]
+    public Tensor<double> TensorAdd_WithTape()
+    {
+        using var tape = new GradientTape<double>();
+        return _engine.TensorAdd(_addA64, _addB64);
+    }
+
+    // ─── BatchNorm forward / backward (issue Phase A.2 list item) ─────────
+
+    [Benchmark, BenchmarkCategory("BatchNorm")]
+    public Tensor<double> BatchNormForward_Fp64()
+        => _engine.BatchNorm(_bnIn64, _bnGamma64, _bnBeta64, 1e-5, out _, out _);
+
+    [Benchmark, BenchmarkCategory("BatchNorm")]
+    public Tensor<double> BatchNormBackward_Fp64()
+    {
+        var fwd = _engine.BatchNorm(_bnIn64, _bnGamma64, _bnBeta64, 1e-5, out var mean, out var var);
+        return _engine.BatchNormBackward(
+            _bnGradOut64, _bnIn64, _bnGamma64, mean, var, 1e-5,
+            out _, out _);
+    }
+
+    // ─── Phase A.3 allocation profile (callable outside BDN) ──────────────
+
+    /// <summary>
+    /// Walks every Phase A.2 substep once with <see cref="GC.GetAllocatedBytesForCurrentThread"/>
+    /// bracketing, returning bytes-allocated per substep. Independent of
+    /// BenchmarkDotNet — designed to be called from an xunit fact or the
+    /// benchmark runner's Program.cs so reviewers can compare alloc shape
+    /// against the issue's hypothesis (GradNode + closures + per-call im2col).
+    /// </summary>
+    /// <remarks>
+    /// Per-thread counter ignores cross-thread allocations from worker
+    /// pools, which is correct for serial single-call profiling. For a
+    /// process-wide view use BDN's <c>[MemoryDiagnoser]</c> output above.
+    /// </remarks>
+    public static AllocationProfile RunAllocationProfile()
+    {
+        var probe = new DCGANStepProbe();
+        probe.Setup();
+        var p = new AllocationProfile();
+
+        // Warm up JIT — first call dominates allocation if measured cold.
+        _ = probe.Conv2DForward_Fp64();
+
+        p.Im2Col_Fp32 = MeasureAlloc(() => probe.Im2Col_Fp32_DcganShape());
+        p.Conv2DForward_Fp64 = MeasureAlloc(() => probe.Conv2DForward_Fp64());
+        p.Conv2DForward_Fp32 = MeasureAlloc(() => probe.Conv2DForward_Fp32());
+        p.Conv2DBackwardInput_Fp64 = MeasureAlloc(() => probe.Conv2DBackwardInput_Fp64());
+        p.Conv2DBackwardKernel_Fp64 = MeasureAlloc(() => probe.Conv2DBackwardKernel_Fp64());
+        p.TensorAdd_NoTape = MeasureAlloc(() => probe.TensorAdd_NoTape());
+        p.TensorAdd_WithTape = MeasureAlloc(() => probe.TensorAdd_WithTape());
+        p.BatchNormForward_Fp64 = MeasureAlloc(() => probe.BatchNormForward_Fp64());
+        p.BatchNormBackward_Fp64 = MeasureAlloc(() => probe.BatchNormBackward_Fp64());
+
+        return p;
+    }
+
+    private static long MeasureAlloc(Action action)
+    {
+        // GC.Collect before the measurement to keep allocator state
+        // deterministic across substeps — without it, lazy LOH compaction
+        // and pinned-pool free-list state from earlier substeps shows up
+        // as noise in later measurements.
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        action();
+        long after = GC.GetAllocatedBytesForCurrentThread();
+        return after - before;
+    }
+
+    /// <summary>Per-substep bytes-allocated (one-call sample, current thread).</summary>
+    public sealed class AllocationProfile
+    {
+        public long Im2Col_Fp32;
+        public long Conv2DForward_Fp64;
+        public long Conv2DForward_Fp32;
+        public long Conv2DBackwardInput_Fp64;
+        public long Conv2DBackwardKernel_Fp64;
+        public long TensorAdd_NoTape;
+        public long TensorAdd_WithTape;
+        public long BatchNormForward_Fp64;
+        public long BatchNormBackward_Fp64;
+
+        public string Format()
+        {
+            var entries = new (string name, long bytes)[]
+            {
+                ("Conv2DBackwardInput_Fp64",  Conv2DBackwardInput_Fp64),
+                ("Conv2DBackwardKernel_Fp64", Conv2DBackwardKernel_Fp64),
+                ("Conv2DForward_Fp64",        Conv2DForward_Fp64),
+                ("Conv2DForward_Fp32",        Conv2DForward_Fp32),
+                ("BatchNormBackward_Fp64",    BatchNormBackward_Fp64),
+                ("BatchNormForward_Fp64",     BatchNormForward_Fp64),
+                ("Im2Col_Fp32",               Im2Col_Fp32),
+                ("TensorAdd_WithTape",        TensorAdd_WithTape),
+                ("TensorAdd_NoTape",          TensorAdd_NoTape),
+            };
+            Array.Sort(entries, (a, b) => b.bytes.CompareTo(a.bytes));
+
+            var sb = new System.Text.StringBuilder();
+            sb.AppendLine("Per-substep allocation profile (bytes, current-thread, descending):");
+            foreach (var (name, bytes) in entries)
+                sb.AppendLine($"  {bytes,12:N0}  {name}");
+            return sb.ToString();
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -67,6 +67,30 @@ class Program
             return;
         }
 
+        // Issue #403 Phase A.3: per-substep allocation profile + shape catalog
+        // for one pass through the DCGAN-step probe substeps. Cheap to run
+        // (one call per substep) so reviewers can compare alloc shape against
+        // the issue's hypothesis without spinning up a full BDN run.
+        if (args[0] == "--dcgan-probe")
+        {
+            var profile = DCGANStepProbe.RunAllocationProfile();
+            Console.WriteLine(profile.Format());
+
+            Console.WriteLine();
+            using (var shapes = new AiDotNet.Tensors.Helpers.ShapeInstrumenter())
+            {
+                var probe = new DCGANStepProbe();
+                probe.Setup();
+                probe.Conv2DForward_Fp64();
+                probe.Conv2DBackwardInput_Fp64();
+                probe.Conv2DBackwardKernel_Fp64();
+                probe.BatchNormForward_Fp64();
+                probe.BatchNormBackward_Fp64();
+                shapes.PrintCatalog();
+            }
+            return;
+        }
+
 #if NET8_0_OR_GREATER
         // Issue #294 acceptance criterion #6: PyTorch CPU parity
         // benchmark — matmul, FlashAttention, LayerNorm, BCE

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -507,6 +507,7 @@ class Program
         Console.WriteLine("  --conv      : Run GPU convolution benchmarks (Conv2D, Depthwise)");
         Console.WriteLine("  --baseline  : Capture full baseline to CSV (--baseline [phase] [csv])");
         Console.WriteLine("  --compare   : Compare baselines (--compare before.csv after.csv)");
+        Console.WriteLine("  --dcgan-probe : Run DCGAN step allocation / shape probe (#403 Phase A)");
         Console.WriteLine();
         Console.WriteLine("GPU Bottleneck Analysis:");
         Console.WriteLine("  --vulkan   : Run Vulkan backend diagnostics and bottleneck analysis");

--- a/tests/AiDotNet.Tensors.Tests/Helpers/ShapeInstrumenterTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/ShapeInstrumenterTests.cs
@@ -1,0 +1,98 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using AiDotNet.Tensors.Helpers;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Helpers;
+
+/// <summary>
+/// Issue #403 Phase A.1 — verifies ShapeInstrumenter correctly collects
+/// every GEMM call dispatched through BlasProvider.ShapeLogHook, dedupes
+/// by (M, N, K, transA, transB), and restores the prior hook on dispose.
+/// </summary>
+public class ShapeInstrumenterTests
+{
+    [Fact]
+    public void Probe_aggregates_unique_shape_calls()
+    {
+        using var probe = new ShapeInstrumenter();
+
+        // Fire the hook directly. The kernels are tested via the GEMM
+        // call sites; this test isolates the probe's aggregation logic.
+        BlasProvider.ShapeLogHook!.Invoke(32, 64, 128, false, false);
+        BlasProvider.ShapeLogHook!.Invoke(32, 64, 128, false, false);
+        BlasProvider.ShapeLogHook!.Invoke(32, 64, 128, false, false);
+        BlasProvider.ShapeLogHook!.Invoke(64, 32, 128, false, false);
+        BlasProvider.ShapeLogHook!.Invoke(32, 64, 128, true, false);
+
+        Assert.Equal(5L, probe.TotalCalls);
+        Assert.Equal(3, probe.UniqueShapes);
+
+        var catalog = probe.GetCatalog();
+        Assert.Equal(3, catalog.Count);
+
+        // Descending count order: (32,64,128,N,N)=3 first, then ties broken
+        // by descending FLOPs (both ties have identical FLOPs here, ordering
+        // among them is implementation-defined, so just check count).
+        Assert.Equal(3L, catalog[0].Calls);
+        Assert.Equal(32, catalog[0].M);
+        Assert.Equal(64, catalog[0].N);
+        Assert.Equal(128, catalog[0].K);
+        Assert.False(catalog[0].TransA);
+    }
+
+    [Fact]
+    public void Probe_restores_previous_hook_on_dispose()
+    {
+        Assert.Null(BlasProvider.ShapeLogHook);
+
+        int outerCount = 0;
+        BlasProvider.ShapeLogHook = (_, _, _, _, _) => outerCount++;
+
+        try
+        {
+            using (var probe = new ShapeInstrumenter())
+            {
+                // Inside the scope, the probe owns the hook — outer
+                // counter must not advance.
+                BlasProvider.ShapeLogHook!.Invoke(16, 16, 16, false, false);
+                Assert.Equal(1L, probe.TotalCalls);
+                Assert.Equal(0, outerCount);
+            }
+
+            // After dispose, the outer counter must take over again.
+            BlasProvider.ShapeLogHook!.Invoke(8, 8, 8, false, false);
+            Assert.Equal(1, outerCount);
+        }
+        finally
+        {
+            BlasProvider.ShapeLogHook = null;
+        }
+    }
+
+    [Fact]
+    public void Concurrent_probe_construction_throws()
+    {
+        using var first = new ShapeInstrumenter();
+        Assert.Throws<InvalidOperationException>(() => new ShapeInstrumenter());
+    }
+
+    [Fact]
+    public void Format_catalog_renders_markdown_table()
+    {
+        using var probe = new ShapeInstrumenter();
+        BlasProvider.ShapeLogHook!.Invoke(10, 20, 30, false, false);
+        BlasProvider.ShapeLogHook!.Invoke(10, 20, 30, false, false);
+        BlasProvider.ShapeLogHook!.Invoke(40, 50, 60, true, true);
+
+        string md = probe.FormatCatalog();
+
+        Assert.Contains("Unique shapes: 2", md);
+        Assert.Contains("Total calls: 3", md);
+        Assert.Contains("| Calls |", md);
+        // Spot-check that both shapes appear with their transpose flags.
+        Assert.Contains("    10 |    20 |    30 |  N |  N |", md);
+        Assert.Contains("    40 |    50 |    60 |  T |  T |", md);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Helpers/ShapeInstrumenterTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/ShapeInstrumenterTests.cs
@@ -10,7 +10,16 @@ namespace AiDotNet.Tensors.Tests.Helpers;
 /// Issue #403 Phase A.1 — verifies ShapeInstrumenter correctly collects
 /// every GEMM call dispatched through BlasProvider.ShapeLogHook, dedupes
 /// by (M, N, K, transA, transB), and restores the prior hook on dispose.
+///
+/// <para>PR #412 CodeRabbit fix: this test class mutates the process-wide
+/// static <see cref="BlasProvider.ShapeLogHook"/>. Joined to the
+/// <c>ShapeLogHookSerial</c> xunit collection so it never runs in parallel
+/// with any other class that touches the same hook — assertions like
+/// <c>Assert.Null(BlasProvider.ShapeLogHook)</c> after dispose were
+/// nondeterministic under parallel runs because a sibling test could have
+/// installed its own hook between this test's Setup and the assertion.</para>
 /// </summary>
+[Collection("ShapeLogHookSerial")]
 public class ShapeInstrumenterTests
 {
     [Fact]

--- a/tests/AiDotNet.Tensors.Tests/Helpers/ShapeLogHookSerialCollection.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/ShapeLogHookSerialCollection.cs
@@ -1,0 +1,24 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Helpers;
+
+/// <summary>
+/// xunit collection marker for tests that mutate the process-wide static
+/// <c>BlasProvider.ShapeLogHook</c>. Members of this collection run serially
+/// with respect to each other (xunit default: tests in the same collection
+/// never run in parallel). Use this to guard hook-ownership assertions
+/// like <c>Assert.Null(BlasProvider.ShapeLogHook)</c> after dispose, which
+/// would otherwise race against any sibling test class that installs its
+/// own hook.
+///
+/// <para>PR #412 CodeRabbit review fix — applied to
+/// <see cref="ShapeInstrumenterTests"/>. Add this attribute to any future
+/// test class that touches <c>BlasProvider.ShapeLogHook</c>.</para>
+/// </summary>
+[CollectionDefinition("ShapeLogHookSerial", DisableParallelization = true)]
+public sealed class ShapeLogHookSerialCollection
+{
+    // Marker only — no fixture needed.
+}


### PR DESCRIPTION
Closes part of #403 (Phase A only — subsequent phases will land as
follow-up commits on this PR).

## Summary

- `BlasProvider.ShapeLogHook`: process-wide single-slot hook fired per
  successful GEMM with `(M, N, K, transA, transB)`. Fast-path null-check
  on the hot path; one volatile read when no probe is attached.
- `ShapeInstrumenter`: scoped `IDisposable` that subscribes, dedupes by
  tuple, restores the prior hook on dispose, and renders a markdown
  catalog sorted by descending call count.
- `DCGANStepProbe`: BenchmarkDotNet class with per-substep benchmarks for
  the ops the issue's Phase A.2 lists — Im2Col, Conv2D forward, Conv2D
  backward (input + kernel grad), RecordBinary overhead, BatchNorm
  forward / backward. Shapes mirror a late-DCGAN-decoder layer (batch=2,
  in/out=64, spatial 8 with 4×4 kernel) at FP64 to match
  `DCGANTests.MoreData_ShouldNotDegrade`.
- `DCGANStepProbe.RunAllocationProfile()`: per-substep
  `GC.GetAllocatedBytesForCurrentThread` bracketing, exposed via a new
  `--dcgan-probe` CLI flag on the Benchmarks `Program.cs` which also
  prints a fresh shape catalog over the same substeps.

## Phase A→B-E sequencing

Per the issue, Phase A's output ranks the bottlenecks and Phase B-E are
sequenced based on findings. The infrastructure here makes that ranking
producible in one command; the report itself will land as a comment on
this PR before any Phase B-E commits.

## Test plan

- [x] `dotnet build` on net10.0 + net471 — both clean
- [x] `dotnet test --filter ShapeInstrumenter` — 4 tests, all pass
- [ ] Run `dotnet run -c Release --project tests/AiDotNet.Tensors.Benchmarks -- --dcgan-probe` and paste the alloc + shape catalog as a PR comment
- [ ] Run the BDN class with
      `dotnet run -c Release --project tests/AiDotNet.Tensors.Benchmarks -- --filter *DCGANStepProbe*`
      and paste the table as a PR comment
- [ ] Phase B-E commits land here based on the report's ranking

🤖 Generated with [Claude Code](https://claude.com/claude-code)