### PR TITLE
fix(AiDotNet#1395): drop IsDeterministicMode from CompiledModelCache shape-key

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledModelCache.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledModelCache.cs
@@ -1,6 +1,5 @@
 using System.Collections.Concurrent;
 using AiDotNet.Tensors.Engines.Optimization;
-using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.LinearAlgebra;
 
 namespace AiDotNet.Tensors.Engines.Compilation;
@@ -258,14 +257,21 @@ public sealed class CompiledModelCache<T> : IDisposable
             hash *= unchecked((long)0x100000001b3L);
         }
 
-        // Issue #164: mix in the current determinism state (process-wide value or
-        // thread-local override, whichever wins) so plans compiled under one mode
-        // are not served under the other. Today this matters mainly for forward
-        // compatibility — if a future backend re-introduces determinism-divergent
-        // kernels (GPU paths, parallel SimdGemm, etc.) the segregation is already
-        // in place. The bool collapses into a single bit XORed in, then mixed.
-        hash ^= BlasProvider.IsDeterministicMode ? 1L : 0L;
-        hash *= unchecked((long)0x100000001b3L);
+        // AiDotNet#1395 fix: do NOT mix BlasProvider.IsDeterministicMode into the
+        // cache key. The previous mix-in (added in #164) was forward-compat for
+        // potential determinism-divergent backends, but it has a real cross-test
+        // failure mode under xUnit parallel runs:
+        //   - VGG.Train step 1: thread-local determinism override = X → cache key K_X.
+        //     Compile + commit fused. _fusedTrainingCommitted=true.
+        //   - Sibling test on the same pool thread sets the override to Y
+        //     (TensorCodecOptions.SetCurrent → BlasProvider.SetThreadLocalDeterministicMode).
+        //   - VGG.Train step 2: same shape but determinism override = Y → cache key K_Y ≠ K_X.
+        //     Cache miss → new plan compiled → ReferenceEquals(_configuredPlan, new) = false
+        //     → TryStepWithFusedOptimizer returns false → throws because fused has committed.
+        // No backend today actually branches on IsDeterministicMode in a way that
+        // makes compiled plans non-portable; managed SimdGemm is deterministic
+        // regardless. When a future backend reintroduces a divergent path, the
+        // correct fix is per-plan instruction selection, not cache-key segregation.
 
         return hash;
     }

--- a/tests/AiDotNet.Tensors.Tests/Engines/DeterministicByDefaultTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DeterministicByDefaultTests.cs
@@ -80,29 +80,22 @@ public class DeterministicByDefaultTests
 
     // ── Acceptance criterion #3 ──────────────────────────────────────────────
     [Fact]
-    public void CompiledModelCache_DifferentDeterminismProducesDifferentPlans()
+    public void CompiledModelCache_DeterminismChange_ReusesPlanInstance()
     {
-        // Plan compiled under deterministic=true must not be served on a subsequent
-        // call under deterministic=false (and vice versa). The cache key mixes in
-        // the current determinism state so the second call misses and recompiles.
+        // PR ooples/AiDotNet.Tensors#416 (fix(AiDotNet#1395)): determinism is
+        // INTENTIONALLY no longer part of the CompiledModelCache shape key.
+        // The pre-PR keying behaviour caused cross-test cache-key drift under
+        // xUnit's pool-recycled thread model whenever
+        // BlasProvider._threadLocalDeterministicOverride drifted between
+        // tests on the same worker thread. This test now pins the new
+        // behaviour: switching the process-wide determinism flag between two
+        // compile calls on the same shape+dtype MUST hit the cache and reuse
+        // the SAME plan instance.
         //
-        // BlasProvider.IsDeterministicMode resolves as
-        //   `_threadLocalDeterministicOverride ?? _deterministicMode`.
-        // SetDeterministicMode only writes the process-wide field. If a prior
-        // test in this collection (or upstream framework code) installed a
-        // thread-local override on the xUnit worker thread and the override
-        // is still pinned, both `Set(true)` and `Set(false)` calls in this
-        // test will be ignored by the override-first read — both compiles
-        // see the same key and the cache hands back the same plan instance.
-        // Capture and restore BOTH layers, and explicitly clear the
-        // thread-local override at the top so the process-wide toggle is
-        // observable for the duration of the test.
-        // Order matters: capture the thread-local override first, then
-        // CLEAR it before reading the process-wide flag. AiDotNetEngine
-        // .DeterministicMode returns the *merged effective* state (override
-        // wins), so reading it before the clear can stash the wrong value
-        // and the finally-block restore would then leak that override into
-        // the global flag.
+        // Determinism still affects EXECUTION (BlasProvider.IsDeterministicMode
+        // is read inside the kernel dispatch), so the same compiled plan runs
+        // correctly in both modes — what's removed is the cache-miss-and-
+        // recompile-on-mode-switch that produced #1395.
         bool? originalThreadLocal = BlasProvider.GetThreadLocalDeterministicMode();
         BlasProvider.SetThreadLocalDeterministicMode(null);
         bool originalProcess = AiDotNetEngine.DeterministicMode;
@@ -136,11 +129,9 @@ public class DeterministicByDefaultTests
                     return engine.ReduceSum(output, null);
                 });
 
-            // The two plans must be distinct instances — the cache is keyed on
-            // (shape, elementType, deterministicMode), so switching determinism
-            // forces a miss and recompile even though the shape and type are
-            // identical.
-            Assert.NotSame(planDeterministic, planNonDeterministic);
+            // Post-PR #416: the cache key is (shape, elementType) only — the
+            // second call MUST hit the cache and hand back the same instance.
+            Assert.Same(planDeterministic, planNonDeterministic);
         }
         finally
         {
@@ -408,11 +399,19 @@ public class DeterministicByDefaultTests
     }
 
     [Fact]
-    public void SetCurrent_ThreadLocalOverride_ReflectsInCompiledModelCacheKey()
+    public void SetCurrent_ThreadLocalOverride_DoesNotInvalidateCompiledModelCachePlan()
     {
-        // The cache key already mixes in BlasProvider.IsDeterministicMode, so the
-        // thread-local override should automatically produce distinct plans when a
-        // single thread toggles its own override between two compile calls.
+        // PR ooples/AiDotNet.Tensors#416 (fix(AiDotNet#1395)): the
+        // [ThreadStatic] determinism override is INTENTIONALLY no longer part
+        // of the CompiledModelCache shape key. The pre-PR behaviour produced
+        // false cache misses whenever xUnit pool-recycled a thread that
+        // happened to carry a stale TensorCodecOptions override, causing the
+        // "fused training has already run but the current step cannot engage
+        // the fused path" failure documented in AiDotNet#1395.
+        //
+        // This test pins the new behaviour: toggling the thread-local
+        // determinism override between two compile calls on the same shape
+        // must NOT force a recompile — the plan is shared across modes.
         bool originalProcess = AiDotNetEngine.DeterministicMode;
         var originalOptions  = TensorCodecOptions.Current;
         try
@@ -445,7 +444,9 @@ public class DeterministicByDefaultTests
                     return engine.ReduceSum(output, null);
                 });
 
-            Assert.NotSame(planInherited, planOverridden);
+            // Post-PR #416: cache key no longer mixes determinism, so the
+            // second call hits the cache. Same instance expected.
+            Assert.Same(planInherited, planOverridden);
         }
         finally
         {


### PR DESCRIPTION
**Closes:** AiDotNet#1395 (root-cause fix)
**Paired with:** AiDotNet#fix/1395-surface-catch-exception (debuggability fix on the AiDotNet side)

## TL;DR

Drop `BlasProvider.IsDeterministicMode` from `CompiledModelCache.ComputeShapeKey`. This eliminates the cross-test cache-key drift that produces AiDotNet#1395's "Fused compiled training has already run successfully, but the current step cannot engage the fused path" failure under xUnit parallel test runs.

## The bug

`CompiledModelCache.ComputeShapeKey` mixed `BlasProvider.IsDeterministicMode` into the cache hash so plans compiled under one mode would not be served under the other. The mix-in was added in issue #164 for **forward compatibility** against a hypothetical future backend with determinism-divergent compiled kernels.

But `IsDeterministicMode` reads `_threadLocalDeterministicOverride ?? _deterministicMode`. The override is `[ThreadStatic]` and is mutated by `TensorCodecOptions.SetCurrent`, which is called from `TensorCodec.CompileTraining` and from `AiModelBuilder`'s inference trace.

xUnit pool-recycles threads across test cases. Concrete failure mode for VGG.Training_ShouldReduceLoss in #1395:

1. `VGG.Train` step 1 runs on pool thread T with `override = X`. Cache key = `K_X`. Compile + commit fused. `_fusedTrainingCommitted = true`.
2. Sibling test runs on the same pool thread T, sets `override = Y` inside `TensorCodec.CompileTraining` or `AiModelBuilder`.
3. `VGG.Train` step 2 runs on thread T again with `override = Y`. Cache key = `K_Y ≠ K_X`. Cache **miss** → new plan compiled → `ReferenceEquals(_configuredPlan, newPlan) = false` → plan-switch path returns false → `NeuralNetworkBase` throws "Fused compiled training has already run successfully, but the current step cannot engage the fused path."

The thread-local override is the only path causing key drift in practice — Sub-E/F/etc. don't compile non-portable plans against the deterministic flag.

## The fix

Stop mixing the flag into the cache key. No backend today produces plans whose correctness depends on `IsDeterministicMode`; the managed `SimdGemm` path is deterministic regardless. If a future backend re-introduces a divergent path, the correct fix is per-plan instruction selection (e.g., set a flag on the plan at compile time), **NOT** cache-key segregation that is sensitive to mutable thread-local state.

Removed the now-unused `AiDotNet.Tensors.Helpers` `using`.

## Evidence

Trace instrumentation on `TryStepWithFusedOptimizer` across parallel `Training_ShouldReduceLoss` test runs confirmed:
- Compiled plan reference is stable across consecutive same-shape calls on a single thread when `IsDeterministicMode` is stable.
- Compiled plan reference flips when `IsDeterministicMode` flips between calls — exactly the cache-key drift this commit removes.

## Test results

Full Compilation suite (net10.0): **440/440 pass** (1 skipped, pre-existing).
