### PR TITLE
fix(#414): per-thread OpenCL command queues to unblock parallel IEngine work

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClContext.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClContext.cs
@@ -4,34 +4,82 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 {
     /// <summary>
     /// OpenCL context wrapper using pure P/Invoke. No managed GPU runtime dependency.
+    ///
+    /// <para><b>Threading model</b> (issue #414): the OpenCL context is shared across
+    /// all host threads (one per device), but each host thread that touches
+    /// <see cref="CommandQueue"/> or <see cref="ProfilingCommandQueue"/> gets its
+    /// own per-thread <c>cl_command_queue</c> lazily created on first access. This
+    /// eliminates the host-side enqueue serialization point that previously made
+    /// <c>Parallel.ForEach(... IEngine work ...)</c> slower than serial.</para>
+    ///
+    /// <para>Per-thread queues share the same OpenCL context and device, so device
+    /// buffers / programs / kernels are interchangeable across them — but each
+    /// thread's enqueues no longer block on another thread's clEnqueue*. The GPU
+    /// driver schedules across queues independently; on small consumer devices the
+    /// hardware may still serialize kernel execution, but the host-side enqueue
+    /// path becomes truly parallel.</para>
     /// </summary>
     internal sealed class DirectOpenClContext : IDisposable
     {
         private IntPtr _context;
-        private IntPtr _commandQueue;
-        private IntPtr _profilingCommandQueue;
+        private ThreadLocal<IntPtr>? _threadCommandQueue;
+        private ThreadLocal<IntPtr>? _threadProfilingCommandQueue;
         private IntPtr _device;
         private IntPtr _platform;
+        private bool _profilingSupported;
         private bool _disposed;
 
         public IntPtr Context => _context;
-        public IntPtr CommandQueue => _commandQueue;
+
+        /// <summary>
+        /// Gets the OpenCL command queue for the <b>current host thread</b>. Each
+        /// thread that touches this property gets its own lazily-created
+        /// <c>cl_command_queue</c> on the shared <see cref="Context"/> + <see cref="Device"/>
+        /// (issue #414). The returned <c>IntPtr</c> is valid only on the thread that
+        /// fetched it; do not store and use it from another thread — fetch fresh
+        /// per thread.
+        /// </summary>
+        public IntPtr CommandQueue
+        {
+            get
+            {
+                if (_disposed) throw new ObjectDisposedException(nameof(DirectOpenClContext));
+                var tl = _threadCommandQueue
+                    ?? throw new InvalidOperationException("DirectOpenClContext not initialized.");
+                return tl.Value;
+            }
+        }
 
         /// <summary>
         /// Gets a profiling-enabled command queue for performance measurements.
         /// Uses CL_QUEUE_PROFILING_ENABLE to allow clGetEventProfilingInfo.
+        /// Per-thread (issue #414): each host thread that touches this property gets
+        /// its own lazily-created profiling queue, mirroring <see cref="CommandQueue"/>.
+        /// Returns <see cref="IntPtr.Zero"/> if the device or driver refused to
+        /// create a profiling queue at init time.
         /// </summary>
-        public IntPtr ProfilingCommandQueue => _profilingCommandQueue;
+        public IntPtr ProfilingCommandQueue
+        {
+            get
+            {
+                if (_disposed) throw new ObjectDisposedException(nameof(DirectOpenClContext));
+                if (!_profilingSupported) return IntPtr.Zero;
+                var tl = _threadProfilingCommandQueue
+                    ?? throw new InvalidOperationException("DirectOpenClContext not initialized.");
+                return tl.Value;
+            }
+        }
 
         /// <summary>
         /// Gets whether profiling is enabled on this context.
         /// </summary>
-        public bool IsProfilingEnabled => _profilingCommandQueue != IntPtr.Zero;
+        public bool IsProfilingEnabled => _profilingSupported;
 
         public IntPtr Device => _device;
 
@@ -232,61 +280,136 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             if (err != OpenClNativeBindings.CL_SUCCESS || _context == IntPtr.Zero)
                 throw new InvalidOperationException($"Failed to create OpenCL context: {err}");
 
-            // Create command queue (without profiling for normal operations)
-            _commandQueue = OpenClNativeBindings.CreateCommandQueue(_context, _device, 0, out err);
-            if (err != OpenClNativeBindings.CL_SUCCESS || _commandQueue == IntPtr.Zero)
-            {
-                OpenClNativeBindings.ReleaseContext(_context);
-                throw new InvalidOperationException($"Failed to create command queue: {err}");
-            }
+            // Per-thread command queues (issue #414). The original design used a
+            // single shared queue here, which made Parallel.ForEach(... IEngine
+            // work ...) serialize on host-side clEnqueue* calls — observed
+            // 26× slower than 1× serial. Now each host thread that touches
+            // CommandQueue gets its own clCreateCommandQueue on the same context;
+            // ThreadLocal.Values lets Dispose release every queue created across
+            // every thread.
+            _threadCommandQueue = new ThreadLocal<IntPtr>(
+                () => CreateCommandQueueForCurrentThread(profilingEnabled: false),
+                trackAllValues: true);
 
-            // Create profiling-enabled command queue for diagnostics
-            // This queue has overhead but provides accurate GPU timestamps
-            _profilingCommandQueue = OpenClNativeBindings.CreateCommandQueue(
+            // Probe profiling-queue support once on the ctor thread so callers can
+            // ask IsProfilingEnabled without paying a per-thread create + roll-back.
+            IntPtr probeProfilingQueue = OpenClNativeBindings.CreateCommandQueue(
                 _context, _device, OpenClNativeBindings.CL_QUEUE_PROFILING_ENABLE, out err);
-            if (err != OpenClNativeBindings.CL_SUCCESS)
+            if (err == OpenClNativeBindings.CL_SUCCESS && probeProfilingQueue != IntPtr.Zero)
             {
-                // Profiling queue is optional - continue without it
-                _profilingCommandQueue = IntPtr.Zero;
+                // Probe succeeded — release the probe queue and lazy-create per-thread
+                // profiling queues on demand via the ThreadLocal factory.
+                OpenClNativeBindings.ReleaseCommandQueue(probeProfilingQueue);
+                _profilingSupported = true;
+                _threadProfilingCommandQueue = new ThreadLocal<IntPtr>(
+                    () => CreateCommandQueueForCurrentThread(profilingEnabled: true),
+                    trackAllValues: true);
+            }
+            else
+            {
+                _profilingSupported = false;
+                _threadProfilingCommandQueue = null;
             }
         }
 
+        private IntPtr CreateCommandQueueForCurrentThread(bool profilingEnabled)
+        {
+            // Disposal can race with a thread that's lazy-fetching CommandQueue;
+            // returning IntPtr.Zero in that case lets callers fail fast via the
+            // null-check ladder rather than calling a released cl_command_queue.
+            if (_disposed) return IntPtr.Zero;
+            ulong properties = profilingEnabled
+                ? OpenClNativeBindings.CL_QUEUE_PROFILING_ENABLE
+                : 0;
+            IntPtr q = OpenClNativeBindings.CreateCommandQueue(_context, _device, properties, out int err);
+            if (err != OpenClNativeBindings.CL_SUCCESS || q == IntPtr.Zero)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to create per-thread OpenCL command queue (profiling={profilingEnabled}): err={err}");
+            }
+            return q;
+        }
+
         /// <summary>
-        /// Waits for all enqueued commands to complete.
+        /// Waits for all enqueued commands on the <b>current thread's</b> command
+        /// queue to complete. After issue #414, each host thread has its own
+        /// command queue, so callers that need a true cross-thread barrier should
+        /// call <see cref="FinishAll"/> instead.
         /// </summary>
         public void Finish()
         {
-            if (_commandQueue != IntPtr.Zero)
+            if (_disposed) return;
+            var tl = _threadCommandQueue;
+            if (tl is null) return;
+            // Only finish the queue if this thread has already materialized one;
+            // touching tl.Value would lazy-create a queue just to finish nothing.
+            if (tl.IsValueCreated)
             {
-                OpenClNativeBindings.Finish(_commandQueue);
+                IntPtr q = tl.Value;
+                if (q != IntPtr.Zero) OpenClNativeBindings.Finish(q);
             }
         }
 
         /// <summary>
-        /// Waits for all commands on the profiling queue to complete.
+        /// Cross-thread barrier: finishes every per-thread command queue created
+        /// across the lifetime of this context. Use sparingly — typically only at
+        /// the end of a Parallel.ForEach block before reading device buffers from
+        /// the orchestrating thread.
+        /// </summary>
+        public void FinishAll()
+        {
+            if (_disposed) return;
+            var tl = _threadCommandQueue;
+            if (tl is null) return;
+            foreach (IntPtr q in tl.Values)
+            {
+                if (q != IntPtr.Zero) OpenClNativeBindings.Finish(q);
+            }
+        }
+
+        /// <summary>
+        /// Waits for all commands on the current thread's profiling queue to complete.
         /// </summary>
         public void FinishProfiling()
         {
-            if (_profilingCommandQueue != IntPtr.Zero)
+            if (_disposed) return;
+            var tl = _threadProfilingCommandQueue;
+            if (tl is null) return;
+            if (tl.IsValueCreated)
             {
-                OpenClNativeBindings.Finish(_profilingCommandQueue);
+                IntPtr q = tl.Value;
+                if (q != IntPtr.Zero) OpenClNativeBindings.Finish(q);
             }
         }
 
         public void Dispose()
         {
             if (_disposed) return;
+            // Mark disposed FIRST so any concurrent lazy-init from a worker thread
+            // sees the flag and returns IntPtr.Zero instead of creating a new queue
+            // that would leak past disposal.
+            _disposed = true;
 
-            if (_profilingCommandQueue != IntPtr.Zero)
+            var profiling = _threadProfilingCommandQueue;
+            _threadProfilingCommandQueue = null;
+            if (profiling is not null)
             {
-                OpenClNativeBindings.ReleaseCommandQueue(_profilingCommandQueue);
-                _profilingCommandQueue = IntPtr.Zero;
+                foreach (IntPtr q in profiling.Values)
+                {
+                    if (q != IntPtr.Zero) OpenClNativeBindings.ReleaseCommandQueue(q);
+                }
+                profiling.Dispose();
             }
 
-            if (_commandQueue != IntPtr.Zero)
+            var regular = _threadCommandQueue;
+            _threadCommandQueue = null;
+            if (regular is not null)
             {
-                OpenClNativeBindings.ReleaseCommandQueue(_commandQueue);
-                _commandQueue = IntPtr.Zero;
+                foreach (IntPtr q in regular.Values)
+                {
+                    if (q != IntPtr.Zero) OpenClNativeBindings.ReleaseCommandQueue(q);
+                }
+                regular.Dispose();
             }
 
             if (_context != IntPtr.Zero)
@@ -294,8 +417,6 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 OpenClNativeBindings.ReleaseContext(_context);
                 _context = IntPtr.Zero;
             }
-
-            _disposed = true;
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #414.

Before this change, `DirectOpenClContext` exposed a single shared `cl_command_queue` across all host threads. When callers used `Parallel.ForEach` with `IEngine` work (e.g. 4 parallel `AiModelBuilder.BuildAsync` calls each running Adam over a Transformer), every `clEnqueue*` call serialized on this one queue. Observed downstream: 4-way parallel ran **~26× slower than 1× serial** and did not finish a 100 KB byte-LM training cell within 6 hours.

This change replaces the shared queue with a `ThreadLocal<IntPtr>` of per-thread queues. Each host thread that touches `CommandQueue` gets its own `clCreateCommandQueue` on the same shared `Context` + `Device`, and `ThreadLocal.Values` lets `Dispose()` release every queue created across every thread.

## API impact

- **`CommandQueue` and `ProfilingCommandQueue` properties** now lazy-create per-thread queues. Callers that capture the value once and reuse it on another thread **must refetch** — but kernel-launch / buffer-IO patterns already fetch the queue at each call site (verified all 19 `.CommandQueue` usages across 5 files in the codebase — all use it on the same thread that fetched it).

- **`Finish()`** now finishes the current thread's queue only. For a true cross-thread barrier callers should use the new **`FinishAll()`** method (finishes every queue created across every thread).

- **`ProfilingCommandQueue`** continues to return `IntPtr.Zero` when the device refused to create a profiling queue at init time — we probe once on the ctor thread and gate the per-thread factory on `_profilingSupported` rather than paying create-and-release per worker thread.

- **`Dispose()`** marks the context disposed first (so a concurrent lazy-init from a worker thread returns `IntPtr.Zero` instead of creating a queue past disposal), then enumerates `ThreadLocal.Values` to release every per-thread queue.

## What this unblocks

The HE PathB Pareto sweep (`Phase_PAPER_A_PathB_RetrievalLM_vs_Transformer_Pareto_8seed.PAPER_A_PathB_Pareto_Sweep_WT2`), which trains 4-8 Transformer seeds in parallel for paper-grade head-to-head, was previously timing out at 6 h with zero cells completing. With this change the host-side enqueue parallelism is restored; the GPU driver decides whether to actually parallelize kernel execution across queues (on a small consumer GPU the hardware may still serialize, but the host-side enqueue contention layer is eliminated).

## Validation

- ✅ Debug build clean (`dotnet build src/AiDotNet.Tensors`)
- ✅ Release build clean
- ⚠️ No unit tests added — Tensors repo has no xUnit test project, only `tests/AiDotNet.Tensors.Benchmarks` (BenchmarkDotNet). Integration validation will happen via the downstream HE `PathB` Pareto sweep once this lands and HE bumps Tensors.

## Reproducer (downstream)

```csharp
// HE PathB Pareto — was the workload that surfaced #414
Parallel.ForEach(seeds, new ParallelOptions { MaxDegreeOfParallelism = 4 }, seed =>
{
    var pred = new AiDotNetFacadeTransformerLMPredictor(
        vocabSize: 256, dModel: 128, dFf: 256, ctxLen: 64,
        epochs: 2, trainStride: 8, learningRate: 1e-3,
        heads: 2, layers: 2, seed: seed);
    pred.Build(train /* 100KB byte-LM corpus */, seed, new DiagnosticsCollector());
});
```

Before this PR: timed out at 6 h, 0 cells completed.
Expected after this PR: each cell completes in tens of minutes (limited by serial wall ÷ ~real GPU parallelism, not host-side contention).

## Caveats

- The OpenCL context itself (`_context`) is still shared. Kernel cache (`OpenClBackend._kernelCache`) and program cache (`_programs`) are also still shared. Any plan-cache / autotuner state inside the broader engine that uses `lock()` on a shared object could still produce contention beyond the command queue — but the queue was the primary suspect per the #414 analysis. Follow-up profiling under `dotnet-trace` can identify any remaining serialization points.
- On NVIDIA hosts where cuDNN provides truly parallel kernel scheduling, this change is a strict win. On AMD consumer hardware (the original reproducer used RX 5500), hardware-level serialization may limit the wall-time improvement even though host-side parallelism is fixed.