### PR TITLE
fix(#396): pool-padded loss tensor silently zeroes NaN in fused-Adam path

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -1594,6 +1594,34 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
     private unsafe delegate void PointerBinaryKernel(float* a, float* b, float* r, int count);
 
+    /// <summary>
+    /// AiDotNet#396 fix: return the array suitable for pinning the tensor's storage
+    /// in a specialized-forward kernel. Prefers
+    /// <see cref="LinearAlgebra.TensorBase{T}.GetLiveBackingArrayAllowingPaddingOrNull"/>
+    /// which returns the actual pool-padded backing array, so pins point at the live
+    /// storage and writes through the pin are visible to subsequent
+    /// <c>tensor.AsSpan()</c> / <c>tensor[i]</c> reads. Falls back to
+    /// <c>GetDataArray()</c> for non-contiguous / non-zero-offset / non-CPU tensors
+    /// (where GetDataArray returns a COPY) — those are filtered out by callers'
+    /// <c>IsContiguous</c> gates, so the fallback should never fire in practice.
+    /// <para>
+    /// The bug was: <c>GetDataArray()</c> returns a COPY when the tensor is
+    /// ArrayPool-padded (logical Length=1 on a 16-slot bucket, for instance).
+    /// Pinning that copy and writing through the pin updated the COPY, not the
+    /// live tensor backing. Subsequent reads via <c>lossOutput[0]</c> →
+    /// <c>GetFlat</c> hit the live backing (still zero-initialized from the pool
+    /// rent), so the consumer saw <c>lastLoss = 0</c> even when the negate kernel
+    /// computed NaN. Surfaced by AiDotNet#1346 / Tensors#396; original
+    /// pool-padding fix pattern was established by Tensors#350.
+    /// </para>
+    /// </summary>
+    private static float[] GetPinnableFloatBacking(Tensor<float> t)
+        => t.GetLiveBackingArrayAllowingPaddingOrNull() ?? t.GetDataArray();
+
+    /// <summary>FP64 counterpart of <see cref="GetPinnableFloatBacking"/>.</summary>
+    private static double[] GetPinnableDoubleBacking(Tensor<double> t)
+        => t.GetLiveBackingArrayAllowingPaddingOrNull() ?? t.GetDataArray();
+
     internal static unsafe Action<IEngine>? TryBuildSpecializedForward(
         CompiledStep<T> step,
         List<GCHandle>? handleTracker = null,
@@ -1800,7 +1828,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             {
                 // Pinned path: GCHandle once at compile time
                 var inH = PinAndTrack(
-                    ((Tensor<float>)(object)input).GetDataArray(), handleTracker);
+                    GetPinnableFloatBacking((Tensor<float>)(object)input), handleTracker);
                 int len = input.Length;
 
                 // For large arrays, use parallel chunked reduction (matches TensorSum)
@@ -1898,7 +1926,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         {
             var input = step.Inputs[0];
             var output = step.OutputBuffer;
-            var inH = PinAndTrack(((Tensor<float>)(object)input).GetDataArray(), handleTracker);
+            var inH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)input), handleTracker);
             int len = input.Length;
             float[]? cOut = null;
 
@@ -1927,9 +1955,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             && typeof(T) == typeof(float))
         {
             var a = step.Inputs[0]; var b = step.Inputs[1]; var o = step.OutputBuffer;
-            var aH = PinAndTrack(((Tensor<float>)(object)a).GetDataArray(), handleTracker);
-            var bH = PinAndTrack(((Tensor<float>)(object)b).GetDataArray(), handleTracker);
-            var oH = PinAndTrack(((Tensor<float>)(object)o).GetDataArray(), handleTracker);
+            var aH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)a), handleTracker);
+            var bH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)b), handleTracker);
+            var oH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)o), handleTracker);
             int len = a.Length;
             return BuildParallelBinaryKernel(aH, bH, oH, len,
                 (pA, pB, pR, count) => { unsafe { SimdKernels.VectorAddUnsafe(pA, pB, pR, count); } });
@@ -1947,9 +1975,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             && typeof(T) == typeof(float))
         {
             var a = step.Inputs[0]; var b = step.Inputs[1]; var o = step.OutputBuffer;
-            var aH = PinAndTrack(((Tensor<float>)(object)a).GetDataArray(), handleTracker);
-            var bH = PinAndTrack(((Tensor<float>)(object)b).GetDataArray(), handleTracker);
-            var oH = PinAndTrack(((Tensor<float>)(object)o).GetDataArray(), handleTracker);
+            var aH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)a), handleTracker);
+            var bH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)b), handleTracker);
+            var oH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)o), handleTracker);
             int len = a.Length;
             return BuildParallelBinaryKernel(aH, bH, oH, len,
                 (pA, pB, pR, count) => { unsafe { SimdKernels.VectorSubtractUnsafe(pA, pB, pR, count); } });
@@ -1967,9 +1995,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             && typeof(T) == typeof(float))
         {
             var a = step.Inputs[0]; var b = step.Inputs[1]; var o = step.OutputBuffer;
-            var aH = PinAndTrack(((Tensor<float>)(object)a).GetDataArray(), handleTracker);
-            var bH = PinAndTrack(((Tensor<float>)(object)b).GetDataArray(), handleTracker);
-            var oH = PinAndTrack(((Tensor<float>)(object)o).GetDataArray(), handleTracker);
+            var aH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)a), handleTracker);
+            var bH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)b), handleTracker);
+            var oH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)o), handleTracker);
             int len = a.Length;
             return BuildParallelBinaryKernel(aH, bH, oH, len,
                 (pA, pB, pR, count) => { unsafe { SimdKernels.VectorMultiplyUnsafe(pA, pB, pR, count); } });
@@ -1990,9 +2018,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         {
             var inp = step.Inputs[0]; var o = step.OutputBuffer;
             var inH = PinAndTrack(
-                ((Tensor<float>)(object)inp).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)inp), handleTracker);
             var outH = PinAndTrack(
-                ((Tensor<float>)(object)o).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)o), handleTracker);
             int len = inp.Length;
             return eng =>
             {
@@ -2026,8 +2054,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             && typeof(T) == typeof(float))
         {
             var inp = step.Inputs[0]; var o = step.OutputBuffer;
-            var inH = PinAndTrack(((Tensor<float>)(object)inp).GetDataArray(), handleTracker);
-            var outH = PinAndTrack(((Tensor<float>)(object)o).GetDataArray(), handleTracker);
+            var inH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)inp), handleTracker);
+            var outH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)o), handleTracker);
             int len = inp.Length;
             return eng => { unsafe { SimdKernels.NegateUnsafe((float*)inH.AddrOfPinnedObject(), (float*)outH.AddrOfPinnedObject(), len); } };
         }
@@ -2047,9 +2075,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         {
             var inp = step.Inputs[0]; var o = step.OutputBuffer;
             var inH = PinAndTrack(
-                ((Tensor<float>)(object)inp).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)inp), handleTracker);
             var outH = PinAndTrack(
-                ((Tensor<float>)(object)o).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)o), handleTracker);
             int len = inp.Length;
             return eng =>
             {
@@ -2069,9 +2097,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             var inp = step.Inputs[0]; var o = step.OutputBuffer;
             // Pin arrays once at compile time — GCHandles survive across replays
             var inHandle = PinAndTrack(
-                ((Tensor<float>)(object)inp).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)inp), handleTracker);
             var outHandle = PinAndTrack(
-                ((Tensor<float>)(object)o).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)o), handleTracker);
             int len = inp.Length;
             return eng =>
             {
@@ -2177,9 +2205,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         {
             var inp = step.Inputs[0]; var o = step.OutputBuffer;
             var inH = PinAndTrack(
-                ((Tensor<float>)(object)inp).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)inp), handleTracker);
             var outH = PinAndTrack(
-                ((Tensor<float>)(object)o).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)o), handleTracker);
             int len = inp.Length;
             return eng =>
             {
@@ -2206,9 +2234,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             var inp = step.Inputs[0]; var o = step.OutputBuffer;
             float alphaF = step.SavedState != null && step.SavedState.Length > 0 ? (float)(double)step.SavedState[0] : 1.0f;
             var inH = PinAndTrack(
-                ((Tensor<float>)(object)inp).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)inp), handleTracker);
             var outH = PinAndTrack(
-                ((Tensor<float>)(object)o).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)o), handleTracker);
             int len = inp.Length;
             return eng =>
             {
@@ -2229,9 +2257,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         {
             var inp = step.Inputs[0]; var o = step.OutputBuffer;
             var inH = PinAndTrack(
-                ((Tensor<float>)(object)inp).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)inp), handleTracker);
             var outH = PinAndTrack(
-                ((Tensor<float>)(object)o).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)o), handleTracker);
             int len = inp.Length;
             return eng =>
             {
@@ -2251,9 +2279,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         {
             var inp = step.Inputs[0]; var o = step.OutputBuffer;
             var inH = PinAndTrack(
-                ((Tensor<float>)(object)inp).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)inp), handleTracker);
             var outH = PinAndTrack(
-                ((Tensor<float>)(object)o).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)o), handleTracker);
             int len = inp.Length;
             return eng =>
             {
@@ -2279,9 +2307,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         {
             var inp = step.Inputs[0]; var o = step.OutputBuffer;
             var inH = PinAndTrack(
-                ((Tensor<float>)(object)inp).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)inp), handleTracker);
             var outH = PinAndTrack(
-                ((Tensor<float>)(object)o).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)o), handleTracker);
             int len = inp.Length;
             return eng =>
             {
@@ -2350,12 +2378,12 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             if (step.SavedState.Length >= 3 && step.SavedState[2] is double epsD)
                 eps = (float)epsD;
 
-            var inH = PinAndTrack(((Tensor<float>)(object)input).GetDataArray(), handleTracker);
-            var outH = PinAndTrack(((Tensor<float>)(object)output).GetDataArray(), handleTracker);
-            var gammaH = PinAndTrack(((Tensor<float>)(object)gamma).GetDataArray(), handleTracker);
-            var betaH = PinAndTrack(((Tensor<float>)(object)beta).GetDataArray(), handleTracker);
-            var meanH = PinAndTrack(((Tensor<float>)(object)mean).GetDataArray(), handleTracker);
-            var varH = PinAndTrack(((Tensor<float>)(object)variance).GetDataArray(), handleTracker);
+            var inH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)input), handleTracker);
+            var outH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)output), handleTracker);
+            var gammaH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)gamma), handleTracker);
+            var betaH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)beta), handleTracker);
+            var meanH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)mean), handleTracker);
+            var varH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)variance), handleTracker);
             int length = input.Length;
             float capturedEps = eps;
 
@@ -2399,9 +2427,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             && typeof(T) == typeof(float))
         {
             var a = step.Inputs[0]; var b = step.Inputs[1]; var o = step.OutputBuffer;
-            var aH = PinAndTrack(((Tensor<float>)(object)a).GetDataArray(), handleTracker);
-            var bH = PinAndTrack(((Tensor<float>)(object)b).GetDataArray(), handleTracker);
-            var oH = PinAndTrack(((Tensor<float>)(object)o).GetDataArray(), handleTracker);
+            var aH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)a), handleTracker);
+            var bH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)b), handleTracker);
+            var oH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)o), handleTracker);
             int len = a.Length;
             return eng =>
             {
@@ -2607,9 +2635,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         {
             var inp = step.Inputs[0]; var o = step.OutputBuffer;
             var inH = PinAndTrack(
-                ((Tensor<float>)(object)inp).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)inp), handleTracker);
             var outH = PinAndTrack(
-                ((Tensor<float>)(object)o).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)o), handleTracker);
             int rows = inp._shape[0], cols = inp._shape[1];
             return eng =>
             {
@@ -2636,7 +2664,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         {
             var inp = step.Inputs[0]; var o = step.OutputBuffer;
             var inHandle = PinAndTrack(
-                ((Tensor<float>)(object)inp).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)inp), handleTracker);
             float[]? cOut = null;
             int len = inp.Length;
             return eng =>
@@ -2656,9 +2684,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         {
             var inp = step.Inputs[0]; var o = step.OutputBuffer;
             var inH = PinAndTrack(
-                ((Tensor<float>)(object)inp).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)inp), handleTracker);
             var outH = PinAndTrack(
-                ((Tensor<float>)(object)o).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)o), handleTracker);
             int len = inp.Length;
             return eng =>
             {
@@ -2693,9 +2721,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         {
             var inp = step.Inputs[0]; var o = step.OutputBuffer;
             var inH = PinAndTrack(
-                ((Tensor<float>)(object)inp).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)inp), handleTracker);
             var outH = PinAndTrack(
-                ((Tensor<float>)(object)o).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)o), handleTracker);
             int len = inp.Length;
             return eng =>
             {
@@ -2709,9 +2737,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         {
             var inp = step.Inputs[0]; var o = step.OutputBuffer;
             var inH = PinAndTrack(
-                ((Tensor<float>)(object)inp).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)inp), handleTracker);
             var outH = PinAndTrack(
-                ((Tensor<float>)(object)o).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)o), handleTracker);
             int len = inp.Length;
             return eng =>
             {
@@ -2725,9 +2753,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         {
             var inp = step.Inputs[0]; var o = step.OutputBuffer;
             var inH = PinAndTrack(
-                ((Tensor<float>)(object)inp).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)inp), handleTracker);
             var outH = PinAndTrack(
-                ((Tensor<float>)(object)o).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)o), handleTracker);
             int len = inp.Length;
             return eng =>
             {
@@ -2741,9 +2769,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         {
             var inp = step.Inputs[0]; var o = step.OutputBuffer;
             var inH = PinAndTrack(
-                ((Tensor<float>)(object)inp).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)inp), handleTracker);
             var outH = PinAndTrack(
-                ((Tensor<float>)(object)o).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)o), handleTracker);
             int len = inp.Length;
             return eng =>
             {
@@ -2757,9 +2785,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         {
             var inp = step.Inputs[0]; var o = step.OutputBuffer;
             var inH = PinAndTrack(
-                ((Tensor<float>)(object)inp).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)inp), handleTracker);
             var outH = PinAndTrack(
-                ((Tensor<float>)(object)o).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)o), handleTracker);
             int len = inp.Length;
             return eng =>
             {
@@ -2772,8 +2800,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             && typeof(T) == typeof(float))
         {
             var inp = step.Inputs[0]; var o = step.OutputBuffer;
-            var inH = PinAndTrack(((Tensor<float>)(object)inp).GetDataArray(), handleTracker);
-            var outH = PinAndTrack(((Tensor<float>)(object)o).GetDataArray(), handleTracker);
+            var inH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)inp), handleTracker);
+            var outH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)o), handleTracker);
             int len = inp.Length;
             return eng => { unsafe { SimdKernels.ReciprocalUnsafe((float*)inH.AddrOfPinnedObject(), (float*)outH.AddrOfPinnedObject(), len); } };
         }
@@ -2783,8 +2811,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             && typeof(T) == typeof(float))
         {
             var inp = step.Inputs[0]; var o = step.OutputBuffer;
-            var inH = PinAndTrack(((Tensor<float>)(object)inp).GetDataArray(), handleTracker);
-            var outH = PinAndTrack(((Tensor<float>)(object)o).GetDataArray(), handleTracker);
+            var inH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)inp), handleTracker);
+            var outH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)o), handleTracker);
             int len = inp.Length;
             return eng => { unsafe { SimdKernels.FloorUnsafe((float*)inH.AddrOfPinnedObject(), (float*)outH.AddrOfPinnedObject(), len); } };
         }
@@ -2794,8 +2822,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             && typeof(T) == typeof(float))
         {
             var inp = step.Inputs[0]; var o = step.OutputBuffer;
-            var inH = PinAndTrack(((Tensor<float>)(object)inp).GetDataArray(), handleTracker);
-            var outH = PinAndTrack(((Tensor<float>)(object)o).GetDataArray(), handleTracker);
+            var inH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)inp), handleTracker);
+            var outH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)o), handleTracker);
             int len = inp.Length;
             return eng => { unsafe { SimdKernels.CeilingUnsafe((float*)inH.AddrOfPinnedObject(), (float*)outH.AddrOfPinnedObject(), len); } };
         }
@@ -2805,8 +2833,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             && typeof(T) == typeof(float))
         {
             var inp = step.Inputs[0]; var o = step.OutputBuffer;
-            var inH = PinAndTrack(((Tensor<float>)(object)inp).GetDataArray(), handleTracker);
-            var outH = PinAndTrack(((Tensor<float>)(object)o).GetDataArray(), handleTracker);
+            var inH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)inp), handleTracker);
+            var outH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)o), handleTracker);
             int len = inp.Length;
             return eng => { unsafe { SimdKernels.RoundUnsafe((float*)inH.AddrOfPinnedObject(), (float*)outH.AddrOfPinnedObject(), len); } };
         }
@@ -2818,11 +2846,11 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         {
             var a = step.Inputs[0]; var b = step.Inputs[1]; var o = step.OutputBuffer;
             var aH = PinAndTrack(
-                ((Tensor<float>)(object)a).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)a), handleTracker);
             var bH = PinAndTrack(
-                ((Tensor<float>)(object)b).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)b), handleTracker);
             var oH = PinAndTrack(
-                ((Tensor<float>)(object)o).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)o), handleTracker);
             int len = a.Length;
             return eng =>
             {
@@ -2838,9 +2866,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             float fMin = step.SavedState != null && step.SavedState.Length >= 2 ? Convert.ToSingle(step.SavedState[0]) : float.MinValue;
             float fMax = step.SavedState != null && step.SavedState.Length >= 2 ? Convert.ToSingle(step.SavedState[1]) : float.MaxValue;
             var inH = PinAndTrack(
-                ((Tensor<float>)(object)inp).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)inp), handleTracker);
             var outH = PinAndTrack(
-                ((Tensor<float>)(object)o).GetDataArray(), handleTracker);
+                GetPinnableFloatBacking((Tensor<float>)(object)o), handleTracker);
             int len = inp.Length;
             return eng =>
             {

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/PoolPaddedLossReadoutTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/PoolPaddedLossReadoutTests.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Buffers;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// Regression for <see href="https://github.com/ooples/AiDotNet.Tensors/issues/396">AiDotNet.Tensors#396</see>:
+/// fused-Adam path silently zeroes NaN loss readout when the loss tensor's
+/// pool-rented backing is padded (logical Length=1 on a 16-slot ArrayPool bucket).
+/// <para>
+/// Root cause: specialised forward kernels in <see cref="CompiledTrainingPlan{T}.TryBuildSpecializedForward"/>
+/// pinned via <c>step.OutputBuffer.GetDataArray()</c>, which returns a COPY for
+/// ArrayPool-padded tensors. The kernel wrote NaN to the copy; subsequent
+/// <c>lossOutput[0]</c> reads via <c>AsSpan</c> hit the live backing
+/// (still zero-initialised from pool rent). Consumers saw <c>lastLoss = 0</c>
+/// and assumed training was converging while gradients were corrupted.
+/// </para>
+/// <para>
+/// The 5-experiment bisection in #396 didn't reproduce the bug in small
+/// Tensors-direct traces because the pool's Length=1 bucket wasn't padded
+/// enough to trigger COPY returns. This test deliberately pads the bucket by
+/// renting+returning multiple oversized Length=1 arrays before running the
+/// compile + step, so the loss tensor is allocated from a padded slot.
+/// </para>
+/// </summary>
+public class PoolPaddedLossReadoutTests
+{
+    private readonly ITestOutputHelper _output;
+    public PoolPaddedLossReadoutTests(ITestOutputHelper output) { _output = output; }
+
+    [Fact]
+    public void NegateForward_PoolPaddedOutput_PropagatesNaN_NotSilentZero()
+    {
+        // Pre-pad the ArrayPool<float> Length-1 bucket by renting + returning
+        // several oversized buffers. Subsequent tensor allocations for Length=1
+        // get the same bucket (rounded up to a multiple of 16 floats).
+        var prePadded = new float[8][];
+        for (int i = 0; i < prePadded.Length; i++)
+        {
+            prePadded[i] = ArrayPool<float>.Shared.Rent(1);
+            // Write a sentinel into the trailing padding so a subsequent rent
+            // observes garbage there. The fix should not depend on padding
+            // content — it should always pin the live backing.
+            for (int j = 0; j < prePadded[i].Length; j++)
+                prePadded[i][j] = float.PositiveInfinity;
+        }
+        try
+        {
+            // Tensor whose backing is now a pool-padded Length-1 slot.
+            var inp = new Tensor<float>(new float[] { float.NaN }, new[] { 1 });
+            // Force the output to be allocated from the pool too — RentUninitialized
+            // is what TryBuildSpecializedForward expects to see as step.OutputBuffer.
+            var outputTensor = TensorAllocator.RentUninitialized<float>(new[] { 1 });
+
+            // The compiled trace path's TensorNegate specialised forward pins
+            // the output's GetDataArray() pre-fix and writes through that pin.
+            // We exercise the same kernel directly via the engine to verify
+            // the pinning helper produces the right backing.
+            var engine = new CpuEngine();
+            var negated = engine.TensorNegate(inp);
+
+            // Sanity: TensorNegate of NaN must propagate NaN.
+            Assert.True(float.IsNaN(negated[0]),
+                $"Direct engine.TensorNegate didn't propagate NaN — got {negated[0]}. " +
+                "Pre-condition for the pool-padded test failed.");
+
+            // Now exercise the helper directly: GetPinnableFloatBacking should
+            // return the live backing for a contiguous pool-rented tensor, NOT
+            // a fresh copy. We verify by writing through the returned array and
+            // reading back via the tensor's indexer.
+            // (Helper is private; we verify the semantic via behaviour: writes
+            // through GetLiveBackingArrayAllowingPaddingOrNull must be visible
+            // to subsequent tensor reads.)
+            var live = outputTensor.GetLiveBackingArrayAllowingPaddingOrNull();
+            Assert.NotNull(live);
+            live![0] = float.NaN;
+            Assert.True(float.IsNaN(outputTensor[0]),
+                "Writing NaN through GetLiveBackingArrayAllowingPaddingOrNull was not " +
+                "visible to outputTensor[0] — the live backing is not what the indexer reads.");
+        }
+        finally
+        {
+            for (int i = 0; i < prePadded.Length; i++)
+                ArrayPool<float>.Shared.Return(prePadded[i]);
+        }
+    }
+
+    [Fact]
+    public void CompiledNegateChain_OnPoolPaddedLossOutput_ReadsNaN()
+    {
+        // End-to-end: build a tiny compiled training plan whose loss chain
+        // produces NaN (TensorNegate(TensorLog(0))), execute it via the
+        // engine wrapper that exercises the same TryBuildSpecializedForward
+        // path AiDotNet's fused-Adam wiring uses, and verify the loss readout
+        // is NaN, not literal 0.
+        //
+        // Pre-pad the pool first to maximise the chance the loss tensor is
+        // padded — same pattern as the test above.
+        var prePadded = new float[16][];
+        for (int i = 0; i < prePadded.Length; i++)
+            prePadded[i] = ArrayPool<float>.Shared.Rent(1);
+        try
+        {
+            var engine = new CpuEngine();
+            AiDotNetEngine.Current = engine;
+
+            // log(0) = -inf; -(-inf) = +inf — but log(-1) = NaN; -NaN = NaN.
+            // Use input = -1 to drive the chain through NaN.
+            var input = new Tensor<float>(new float[] { -1.0f }, new[] { 1 });
+            var logged = engine.TensorLog(input);
+            var negated = engine.TensorNegate(logged);
+
+            _output.WriteLine(
+                $"input={input[0]}, log(input)={logged[0]}, -log(input)={negated[0]}, " +
+                $"IsNaN(neg)={float.IsNaN(negated[0])}, IsZero(neg)={negated[0] == 0f}");
+
+            // Bug manifestation: negated[0] returns literal 0 instead of NaN.
+            Assert.False(negated[0] == 0f && !float.IsNaN(negated[0]),
+                "#396 regression: TensorNegate(TensorLog(-1)) returned literal 0 " +
+                "instead of NaN. The pool-padded output's GetDataArray() must have " +
+                "returned a copy, the kernel wrote NaN to the copy, and the read via " +
+                "tensor indexer hit the still-zero live backing.");
+            Assert.True(float.IsNaN(negated[0]),
+                $"Expected NaN from -log(-1), got {negated[0]}.");
+        }
+        finally
+        {
+            for (int i = 0; i < prePadded.Length; i++)
+                ArrayPool<float>.Shared.Return(prePadded[i]);
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/PoolPaddedLossReadoutTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/PoolPaddedLossReadoutTests.cs
@@ -94,14 +94,26 @@ public class PoolPaddedLossReadoutTests
     [Fact]
     public void CompiledNegateChain_OnPoolPaddedLossOutput_ReadsNaN()
     {
-        // End-to-end: build a tiny compiled training plan whose loss chain
-        // produces NaN (TensorNegate(TensorLog(0))), execute it via the
-        // engine wrapper that exercises the same TryBuildSpecializedForward
-        // path AiDotNet's fused-Adam wiring uses, and verify the loss readout
-        // is NaN, not literal 0.
+        // End-to-end: trace a TensorNegate(TensorLog(input)) chain inside
+        // GraphMode, COMPILE it (so the kernels go through
+        // <see cref="CompiledTrainingPlan{T}.TryBuildSpecializedForward"/>
+        // — the exact site the #396 fix patches), Execute the compiled plan,
+        // and verify the output propagates NaN instead of being silently zeroed.
         //
-        // Pre-pad the pool first to maximise the chance the loss tensor is
-        // padded — same pattern as the test above.
+        // Pre-fix, the specialized forward for TensorNegate / TensorLog pinned
+        // step.OutputBuffer via GetDataArray(). For ArrayPool-padded tensors
+        // that returned a COPY — the kernel wrote NaN to the copy, the consumer
+        // reading via the tensor indexer hit the still-zero live backing, and
+        // training silently consumed lastLoss=0 while gradients were corrupted.
+        //
+        // The previous (eager-engine) version of this test would have passed
+        // even on the pre-fix code because eager TensorLog/TensorNegate write
+        // through the live backing directly — only the compiled fast path
+        // exhibits the bug. This rewrite drives the compiled fast path so the
+        // assertion would FAIL on the pre-#419 commit.
+        //
+        // Pre-pad the pool first to maximise the chance the compiled plan's
+        // intermediate / output buffers come from a padded slot.
         var prePadded = new float[16][];
         for (int i = 0; i < prePadded.Length; i++)
             prePadded[i] = ArrayPool<float>.Shared.Rent(1);
@@ -110,24 +122,51 @@ public class PoolPaddedLossReadoutTests
             var engine = new CpuEngine();
             AiDotNetEngine.Current = engine;
 
-            // log(0) = -inf; -(-inf) = +inf — but log(-1) = NaN; -NaN = NaN.
-            // Use input = -1 to drive the chain through NaN.
+            // log(-1) = NaN; -NaN = NaN. The compiled forward must propagate
+            // both. Use a length-1 input — that's exactly the ArrayPool bucket
+            // that surfaced #396 (loss tensors are scalar).
             var input = new Tensor<float>(new float[] { -1.0f }, new[] { 1 });
-            var logged = engine.TensorLog(input);
-            var negated = engine.TensorNegate(logged);
+
+            // Phase 1 — trace under GraphMode so the engine ops record into
+            // the lazy graph rather than executing eagerly. CompileInference
+            // then walks the recorded graph and emits the specialized-forward
+            // closures from TryBuildSpecializedForward.
+            ICompiledPlan<float> plan;
+            Tensor<float> tracedOutput;
+            var traceScope = GraphMode.Enable();
+            try
+            {
+                var logged = engine.TensorLog(input);
+                tracedOutput = engine.TensorNegate(logged);
+                plan = traceScope.CompileInference<float>(tracedOutput, input._shape);
+            }
+            finally { traceScope.Dispose(); }
+
+            // Phase 2 — Execute the compiled plan. The result tensor's backing
+            // is the same step.OutputBuffer the specialized forward writes
+            // through; if the pin grabs a copy, the indexer here sees 0 (the
+            // pool's zero-initialised live backing) instead of NaN.
+            Tensor<float> compiledOut;
+            using (plan)
+            {
+                compiledOut = plan.Execute();
+            }
 
             _output.WriteLine(
-                $"input={input[0]}, log(input)={logged[0]}, -log(input)={negated[0]}, " +
-                $"IsNaN(neg)={float.IsNaN(negated[0])}, IsZero(neg)={negated[0] == 0f}");
+                $"compiledOut[0]={compiledOut[0]}, " +
+                $"IsNaN={float.IsNaN(compiledOut[0])}, " +
+                $"IsZero={compiledOut[0] == 0f}, " +
+                $"backingLen={compiledOut.GetLiveBackingArrayAllowingPaddingOrNull()?.Length ?? -1}");
 
-            // Bug manifestation: negated[0] returns literal 0 instead of NaN.
-            Assert.False(negated[0] == 0f && !float.IsNaN(negated[0]),
-                "#396 regression: TensorNegate(TensorLog(-1)) returned literal 0 " +
+            // Bug manifestation: compiledOut[0] would be literal 0 on pre-fix
+            // code because the kernel's NaN write went to the orphaned copy.
+            Assert.False(compiledOut[0] == 0f && !float.IsNaN(compiledOut[0]),
+                "#396 regression: compiled TensorNegate(TensorLog(-1)) returned literal 0 " +
                 "instead of NaN. The pool-padded output's GetDataArray() must have " +
                 "returned a copy, the kernel wrote NaN to the copy, and the read via " +
                 "tensor indexer hit the still-zero live backing.");
-            Assert.True(float.IsNaN(negated[0]),
-                $"Expected NaN from -log(-1), got {negated[0]}.");
+            Assert.True(float.IsNaN(compiledOut[0]),
+                $"Expected NaN from compiled -log(-1), got {compiledOut[0]}.");
         }
         finally
         {

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/PoolPaddedLossReadoutTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/PoolPaddedLossReadoutTests.cs
@@ -117,6 +117,12 @@ public class PoolPaddedLossReadoutTests
         var prePadded = new float[16][];
         for (int i = 0; i < prePadded.Length; i++)
             prePadded[i] = ArrayPool<float>.Shared.Rent(1);
+        // Capture the existing engine BEFORE mutating the process-global slot.
+        // GraphMode + CompileInference require AiDotNetEngine.Current to be a
+        // CpuEngine instance here, but xunit parallelises across collections
+        // and other tests assume the slot they set is the one they observe.
+        // Restore in the outer finally below.
+        var previousEngine = AiDotNetEngine.Current;
         try
         {
             var engine = new CpuEngine();
@@ -170,6 +176,7 @@ public class PoolPaddedLossReadoutTests
         }
         finally
         {
+            AiDotNetEngine.Current = previousEngine;
             for (int i = 0; i < prePadded.Length; i++)
                 ArrayPool<float>.Shared.Return(prePadded[i]);
         }


### PR DESCRIPTION
## Summary

Closes #396 (and unblocks the AiDotNet#1346 fused-Adam debuggability layer).

The fused-Adam path was silently returning `lastLoss = 0` even when the loss-chain computed NaN — masking gradient corruption with what looked like a clean convergence signal.

## Root cause

`TryBuildSpecializedForward` pinned its output buffer via:

```csharp
PinAndTrack(((Tensor<float>)(object)o).GetDataArray(), handleTracker)
```

`Tensor<T>.GetDataArray()` returns a **copy** when the tensor is ArrayPool-padded (e.g., logical `Length=1` on a 16-slot bucket — the typical loss-tensor case after a few layers of allocation pressure). The kernel wrote NaN to that copy; subsequent reads via `lossOutput[0]` went to the **live** backing (still zero-initialised from the pool rent), so consumers saw `lastLoss = 0`.

The 5-experiment bisection in #396 didn't reproduce the bug in small Tensors-direct traces because the pool's Length-1 bucket wasn't padded enough to trigger COPY returns. AiDotNet wiring with multiple trainable layers fills the pool past that threshold.

## Fix

Introduce `GetPinnableFloatBacking` / `GetPinnableDoubleBacking` helpers that prefer `GetLiveBackingArrayAllowingPaddingOrNull` (live backing, padding-tolerant — established by #350) and fall back to `GetDataArray`. Replace all **60 pin-sites** across specialized-forward kernels.

## Test plan

- [x] `dotnet build` clean
- [x] New regression tests: `PoolPaddedLossReadoutTests` (2 tests)
  - `NegateForward_PoolPaddedOutput_PropagatesNaN_NotSilentZero` — verifies writes through `GetLiveBackingArrayAllowingPaddingOrNull` are visible to indexer reads
  - `CompiledNegateChain_OnPoolPaddedLossOutput_ReadsNaN` — verifies `TensorLog(-1) -> TensorNegate` propagates NaN, not literal 0
- [x] 108 compiled-plan / fused-Adam adjacent tests still pass:
  - `CompiledTrainingPlanDoublePathTests` (9)
  - `FusedAdaptiveLrPlanTests`, `ConfigureOptimizerParamUpdateTests`, `MultiMatMulFusedAdamParamUpdateTests`, `FusedAdvancedGraphFusionTests`, `BatchNormGradSlotResidualTests` (38)
  - `ExecuteIntoTests`, `StepIntoTests`, `PlanStitchingTests`, `FlashAttentionCompiledPlanTests`, `CompiledPlanFinalOutputReproTest`, `MultiDimSymbolicShapeTests`, `CompileTracerBugfixTests` (61)

## Notes for AiDotNet consumers

After this Tensors NuGet bump lands, the AiDotNet#1346 fused-Adam test (`DenseIdentity_CCE_OnFusedAdam_DoesNotSilentlyZeroNaN`) should be unskippable and confirm the end-to-end fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)