### PR TITLE
perf(fp64): Stage 0 — benchmark scaffolding for FP64 MKL-replacement closure

### DIFF
--- a/tests/AiDotNet.Tensors.Benchmarks/Conv2DBackwardDoubleBenchmarks.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Conv2DBackwardDoubleBenchmarks.cs
@@ -17,9 +17,13 @@ namespace AiDotNet.Tensors.Benchmarks;
 ///   - 3×3 stride=1 padding=1 (every VGG conv + ResNet50 residual block 3×3)
 ///   - 3×3 stride=2 padding=1 (ResNet50 stage-transition convs)
 ///   - 1×1 stride=1 padding=0 (ResNet50 bottleneck projections — 32 per forward)
-///   - 1×1 stride=2 padding=0 (ResNet50 stage downsamples)
-///   - 5×5 stride=1 padding=2 (various)
 ///   - 7×7 stride=2 padding=3 (ResNet50 conv1 stem)
+///
+/// Two additional shapes were considered for Stage 0 but deferred until
+/// the matching kernels land: 1×1 stride=2 padding=0 (ResNet50 stage
+/// downsamples) and 5×5 stride=1 padding=2 (various older Inception-style
+/// nets). Re-add benchmarks for those when their direct-kernel fast paths
+/// arrive — Stage 0's job is to baseline what we currently exercise.
 ///
 /// At canonical ImageNet feature-map spatial dims: 224, 112, 56, 28, 14, 7.
 ///
@@ -37,6 +41,37 @@ public class Conv2DBackwardDoubleBenchmarks
 
     [ParamsAllValues]
     public bool UseParallelGemm { get; set; }
+
+    // Cached shape/stride/padding/dilation arrays — Stage-0 baselines must
+    // measure the kernel itself, not the per-iteration int[] allocations
+    // that bypass GlobalSetup. Holding these as static-readonly leaves the
+    // benchmark methods allocation-free at call time.
+    private static readonly int[] S1 = [1, 1];
+    private static readonly int[] S2 = [2, 2];
+    private static readonly int[] P0 = [0, 0];
+    private static readonly int[] P1 = [1, 1];
+    private static readonly int[] P3 = [3, 3];
+    private static readonly int[] D1 = [1, 1];
+
+    // Kernel shapes
+    private static readonly int[] K3x3_64x64     = [64, 64, 3, 3];
+    private static readonly int[] K3x3_128x128   = [128, 128, 3, 3];
+    private static readonly int[] K3x3_256x256   = [256, 256, 3, 3];
+    private static readonly int[] K3x3_512x512   = [512, 512, 3, 3];
+    private static readonly int[] K1x1_64x256    = [64, 256, 1, 1];
+    private static readonly int[] K1x1_2048x512  = [2048, 512, 1, 1];
+    private static readonly int[] K7x7_64x3      = [64, 3, 7, 7];
+    private static readonly int[] K3x3_128x128_s2 = [128, 128, 3, 3];
+
+    // Input shapes (NCHW)
+    private static readonly int[] I_1x64_224     = [1, 64, 224, 224];
+    private static readonly int[] I_1x128_112    = [1, 128, 112, 112];
+    private static readonly int[] I_1x256_56     = [1, 256, 56, 56];
+    private static readonly int[] I_1x512_28     = [1, 512, 28, 28];
+    private static readonly int[] I_1x256_56_b   = [1, 256, 56, 56];
+    private static readonly int[] I_1x512_7      = [1, 512, 7, 7];
+    private static readonly int[] I_1x3_224      = [1, 3, 224, 224];
+    private static readonly int[] I_1x128_56     = [1, 128, 56, 56];
 
     private CpuEngine _engine = null!;
 
@@ -153,95 +188,78 @@ public class Conv2DBackwardDoubleBenchmarks
 
     [Benchmark(Description = "dW 3x3 s1 p1 [1,64,224,224]→[1,64,224,224]")]
     public Tensor<double> dW_3x3_s1p1_b64_h224()
-        => _engine.Conv2DBackwardKernel(_grad_64x224, _input_64x224,
-            new[] { 64, 64, 3, 3 }, new[] { 1, 1 }, new[] { 1, 1 }, new[] { 1, 1 });
+        => _engine.Conv2DBackwardKernel(_grad_64x224, _input_64x224, K3x3_64x64, S1, P1, D1);
 
     [Benchmark(Description = "dW 3x3 s1 p1 [1,128,112,112]→[1,128,112,112]")]
     public Tensor<double> dW_3x3_s1p1_b128_h112()
-        => _engine.Conv2DBackwardKernel(_grad_128x112, _input_128x112,
-            new[] { 128, 128, 3, 3 }, new[] { 1, 1 }, new[] { 1, 1 }, new[] { 1, 1 });
+        => _engine.Conv2DBackwardKernel(_grad_128x112, _input_128x112, K3x3_128x128, S1, P1, D1);
 
     [Benchmark(Description = "dW 3x3 s1 p1 [1,256,56,56]→[1,256,56,56]")]
     public Tensor<double> dW_3x3_s1p1_b256_h56()
-        => _engine.Conv2DBackwardKernel(_grad_256x56, _input_256x56,
-            new[] { 256, 256, 3, 3 }, new[] { 1, 1 }, new[] { 1, 1 }, new[] { 1, 1 });
+        => _engine.Conv2DBackwardKernel(_grad_256x56, _input_256x56, K3x3_256x256, S1, P1, D1);
 
     [Benchmark(Description = "dW 3x3 s1 p1 [1,512,28,28]→[1,512,28,28]")]
     public Tensor<double> dW_3x3_s1p1_b512_h28()
-        => _engine.Conv2DBackwardKernel(_grad_512x28, _input_512x28,
-            new[] { 512, 512, 3, 3 }, new[] { 1, 1 }, new[] { 1, 1 }, new[] { 1, 1 });
+        => _engine.Conv2DBackwardKernel(_grad_512x28, _input_512x28, K3x3_512x512, S1, P1, D1);
 
     [Benchmark(Description = "dW 3x3 s1 p1 [1,512,14,14]→[1,512,14,14]")]
     public Tensor<double> dW_3x3_s1p1_b512_h14()
-        => _engine.Conv2DBackwardKernel(_grad_512x14, _input_512x14,
-            new[] { 512, 512, 3, 3 }, new[] { 1, 1 }, new[] { 1, 1 }, new[] { 1, 1 });
+        => _engine.Conv2DBackwardKernel(_grad_512x14, _input_512x14, K3x3_512x512, S1, P1, D1);
 
     // ───────────── 3×3 stride=1 padding=1 dX (input gradient) ─────────────
 
     [Benchmark(Description = "dX 3x3 s1 p1 [1,64,224,224]")]
     public Tensor<double> dX_3x3_s1p1_b64_h224()
-        => _engine.Conv2DBackwardInput(_grad_64x224, _kernel_3x3_64x64,
-            new[] { 1, 64, 224, 224 }, new[] { 1, 1 }, new[] { 1, 1 }, new[] { 1, 1 });
+        => _engine.Conv2DBackwardInput(_grad_64x224, _kernel_3x3_64x64, I_1x64_224, S1, P1, D1);
 
     [Benchmark(Description = "dX 3x3 s1 p1 [1,128,112,112]")]
     public Tensor<double> dX_3x3_s1p1_b128_h112()
-        => _engine.Conv2DBackwardInput(_grad_128x112, _kernel_3x3_128x128,
-            new[] { 1, 128, 112, 112 }, new[] { 1, 1 }, new[] { 1, 1 }, new[] { 1, 1 });
+        => _engine.Conv2DBackwardInput(_grad_128x112, _kernel_3x3_128x128, I_1x128_112, S1, P1, D1);
 
     [Benchmark(Description = "dX 3x3 s1 p1 [1,256,56,56]")]
     public Tensor<double> dX_3x3_s1p1_b256_h56()
-        => _engine.Conv2DBackwardInput(_grad_256x56, _kernel_3x3_256x256,
-            new[] { 1, 256, 56, 56 }, new[] { 1, 1 }, new[] { 1, 1 }, new[] { 1, 1 });
+        => _engine.Conv2DBackwardInput(_grad_256x56, _kernel_3x3_256x256, I_1x256_56, S1, P1, D1);
 
     [Benchmark(Description = "dX 3x3 s1 p1 [1,512,28,28]")]
     public Tensor<double> dX_3x3_s1p1_b512_h28()
-        => _engine.Conv2DBackwardInput(_grad_512x28, _kernel_3x3_512x512,
-            new[] { 1, 512, 28, 28 }, new[] { 1, 1 }, new[] { 1, 1 }, new[] { 1, 1 });
+        => _engine.Conv2DBackwardInput(_grad_512x28, _kernel_3x3_512x512, I_1x512_28, S1, P1, D1);
 
     // ───────────── 1×1 stride=1 padding=0 dW + dX ─────────────
 
     [Benchmark(Description = "dW 1x1 s1 [1,64,56,56]/[1,256,56,56]")]
     public Tensor<double> dW_1x1_s1_64_256()
-        => _engine.Conv2DBackwardKernel(_grad_64x56_1x1, _input_256x56_1x1,
-            new[] { 64, 256, 1, 1 }, new[] { 1, 1 }, new[] { 0, 0 }, new[] { 1, 1 });
+        => _engine.Conv2DBackwardKernel(_grad_64x56_1x1, _input_256x56_1x1, K1x1_64x256, S1, P0, D1);
 
     [Benchmark(Description = "dW 1x1 s1 [1,2048,7,7]/[1,512,7,7]")]
     public Tensor<double> dW_1x1_s1_2048_512()
-        => _engine.Conv2DBackwardKernel(_grad_2048x7_1x1, _input_512x7_1x1,
-            new[] { 2048, 512, 1, 1 }, new[] { 1, 1 }, new[] { 0, 0 }, new[] { 1, 1 });
+        => _engine.Conv2DBackwardKernel(_grad_2048x7_1x1, _input_512x7_1x1, K1x1_2048x512, S1, P0, D1);
 
     [Benchmark(Description = "dX 1x1 s1 [1,64,56,56]/k[64,256,1,1]")]
     public Tensor<double> dX_1x1_s1_64_256()
-        => _engine.Conv2DBackwardInput(_grad_64x56_1x1, _kernel_1x1_64x256,
-            new[] { 1, 256, 56, 56 }, new[] { 1, 1 }, new[] { 0, 0 }, new[] { 1, 1 });
+        => _engine.Conv2DBackwardInput(_grad_64x56_1x1, _kernel_1x1_64x256, I_1x256_56_b, S1, P0, D1);
 
     [Benchmark(Description = "dX 1x1 s1 [1,2048,7,7]/k[2048,512,1,1]")]
     public Tensor<double> dX_1x1_s1_2048_512()
-        => _engine.Conv2DBackwardInput(_grad_2048x7_1x1, _kernel_1x1_2048x512,
-            new[] { 1, 512, 7, 7 }, new[] { 1, 1 }, new[] { 0, 0 }, new[] { 1, 1 });
+        => _engine.Conv2DBackwardInput(_grad_2048x7_1x1, _kernel_1x1_2048x512, I_1x512_7, S1, P0, D1);
 
     // ───────────── 7×7 stride=2 padding=3 (ResNet stem) ─────────────
 
     [Benchmark(Description = "dW 7x7 s2 p3 ResNet stem [1,3,224,224]→[1,64,112,112]")]
     public Tensor<double> dW_7x7_s2p3_stem()
-        => _engine.Conv2DBackwardKernel(_grad_64x112_7x7, _input_3x224,
-            new[] { 64, 3, 7, 7 }, new[] { 2, 2 }, new[] { 3, 3 }, new[] { 1, 1 });
+        => _engine.Conv2DBackwardKernel(_grad_64x112_7x7, _input_3x224, K7x7_64x3, S2, P3, D1);
 
     [Benchmark(Description = "dX 7x7 s2 p3 ResNet stem")]
     public Tensor<double> dX_7x7_s2p3_stem()
-        => _engine.Conv2DBackwardInput(_grad_64x112_7x7, _kernel_7x7_64x3,
-            new[] { 1, 3, 224, 224 }, new[] { 2, 2 }, new[] { 3, 3 }, new[] { 1, 1 });
+        => _engine.Conv2DBackwardInput(_grad_64x112_7x7, _kernel_7x7_64x3, I_1x3_224, S2, P3, D1);
 
     // ───────────── 3×3 stride=2 padding=1 (ResNet transitions) ─────────────
 
     [Benchmark(Description = "dW 3x3 s2 p1 [1,128,28,28]/[1,128,56,56]")]
     public Tensor<double> dW_3x3_s2p1()
-        => _engine.Conv2DBackwardKernel(_grad_128x28_3x3s2, _input_128x56_3x3s2,
-            new[] { 128, 128, 3, 3 }, new[] { 2, 2 }, new[] { 1, 1 }, new[] { 1, 1 });
+        => _engine.Conv2DBackwardKernel(_grad_128x28_3x3s2, _input_128x56_3x3s2, K3x3_128x128_s2, S2, P1, D1);
 
     [Benchmark(Description = "dX 3x3 s2 p1 [1,128,28,28]/k[128,128,3,3]")]
     public Tensor<double> dX_3x3_s2p1()
-        => _engine.Conv2DBackwardInput(_grad_128x28_3x3s2, _kernel_3x3_128x128_s2,
-            new[] { 1, 128, 56, 56 }, new[] { 2, 2 }, new[] { 1, 1 }, new[] { 1, 1 });
+        => _engine.Conv2DBackwardInput(_grad_128x28_3x3s2, _kernel_3x3_128x128_s2, I_1x128_56, S2, P1, D1);
 }
 #endif

--- a/tests/AiDotNet.Tensors.Benchmarks/Conv2DBackwardDoubleBenchmarks.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Conv2DBackwardDoubleBenchmarks.cs
@@ -1,0 +1,247 @@
+#if NET8_0_OR_GREATER
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Simd;
+using AiDotNet.Tensors.LinearAlgebra;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+namespace AiDotNet.Tensors.Benchmarks;
+
+/// <summary>
+/// FP64 Conv2D backward benchmarks — dW + dX across the {kernel × stride × padding}
+/// matrix that cluster #6 (VGG16/ResNet50/DenseNet) exercises at ImageNet input
+/// scale. Stage 0 of the FP64 perf-closure effort: gives us per-shape baselines
+/// to A/B Stages 1/2/5/7 against.
+///
+/// Shape catalog covers:
+///   - 3×3 stride=1 padding=1 (every VGG conv + ResNet50 residual block 3×3)
+///   - 3×3 stride=2 padding=1 (ResNet50 stage-transition convs)
+///   - 1×1 stride=1 padding=0 (ResNet50 bottleneck projections — 32 per forward)
+///   - 1×1 stride=2 padding=0 (ResNet50 stage downsamples)
+///   - 5×5 stride=1 padding=2 (various)
+///   - 7×7 stride=2 padding=3 (ResNet50 conv1 stem)
+///
+/// At canonical ImageNet feature-map spatial dims: 224, 112, 56, 28, 14, 7.
+///
+/// Run:
+///   dotnet run -c Release --project tests/AiDotNet.Tensors.Benchmarks \
+///     -- --conv2d-backward-double
+/// </summary>
+[SimpleJob(RuntimeMoniker.Net10_0, launchCount: 2, warmupCount: 3, iterationCount: 10)]
+[MemoryDiagnoser]
+[MarkdownExporterAttribute.GitHub]
+public class Conv2DBackwardDoubleBenchmarks
+{
+    [ParamsAllValues]
+    public bool DeterministicMode { get; set; }
+
+    [ParamsAllValues]
+    public bool UseParallelGemm { get; set; }
+
+    private CpuEngine _engine = null!;
+
+    // ═══ 3×3 stride=1 padding=1 at every VGG/ResNet feature-map size ═══
+    // Each tuple: (inC, outC, H, W) for input [1, inC, H, W], kernel [outC, inC, 3, 3]
+    // VGG block 1: (3→64)/64→64 at 224×224
+    // VGG block 2: 64→128/128→128 at 112×112
+    // VGG block 3: 128→256/256→256 at 56×56
+    // VGG block 4: 256→512/512→512 at 28×28
+    // VGG block 5: 512→512 at 14×14
+    private Tensor<double> _grad_64x224 = null!;       // VGG block 1 (post-conv)
+    private Tensor<double> _input_64x224 = null!;
+    private Tensor<double> _kernel_3x3_64x64 = null!;
+
+    private Tensor<double> _grad_128x112 = null!;      // VGG block 2
+    private Tensor<double> _input_128x112 = null!;
+    private Tensor<double> _kernel_3x3_128x128 = null!;
+
+    private Tensor<double> _grad_256x56 = null!;       // VGG block 3 / ResNet stage 2
+    private Tensor<double> _input_256x56 = null!;
+    private Tensor<double> _kernel_3x3_256x256 = null!;
+
+    private Tensor<double> _grad_512x28 = null!;       // VGG block 4 / ResNet stage 3
+    private Tensor<double> _input_512x28 = null!;
+    private Tensor<double> _kernel_3x3_512x512 = null!;
+
+    private Tensor<double> _grad_512x14 = null!;       // VGG block 5
+    private Tensor<double> _input_512x14 = null!;
+
+    // ═══ 1×1 stride=1 (ResNet50 bottleneck inner projections) ═══
+    // Bottleneck pattern: 1×1 reduce → 3×3 → 1×1 expand
+    // Stage 2: 256→64 (reduce) / 64→256 (expand) at 56×56
+    // Stage 3: 512→128 / 128→512 at 28×28
+    // Stage 4: 1024→256 / 256→1024 at 14×14
+    // Stage 5: 2048→512 / 512→2048 at 7×7
+    private Tensor<double> _grad_64x56_1x1 = null!;    // bottleneck reduce 256→64
+    private Tensor<double> _input_256x56_1x1 = null!;
+    private Tensor<double> _kernel_1x1_64x256 = null!;
+
+    private Tensor<double> _grad_2048x7_1x1 = null!;   // stage-5 expand
+    private Tensor<double> _input_512x7_1x1 = null!;
+    private Tensor<double> _kernel_1x1_2048x512 = null!;
+
+    // ═══ 7×7 stride=2 padding=3 (ResNet50 stem conv1) ═══
+    private Tensor<double> _grad_64x112_7x7 = null!;   // post-stem
+    private Tensor<double> _input_3x224 = null!;
+    private Tensor<double> _kernel_7x7_64x3 = null!;
+
+    // ═══ 3×3 stride=2 padding=1 (ResNet50 stage transitions) ═══
+    private Tensor<double> _grad_128x28_3x3s2 = null!;
+    private Tensor<double> _input_128x56_3x3s2 = null!;
+    private Tensor<double> _kernel_3x3_128x128_s2 = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new CpuEngine();
+
+        // 3×3 s=1 p=1
+        _grad_64x224  = Tensor<double>.CreateRandom([1, 64, 224, 224]);
+        _input_64x224 = Tensor<double>.CreateRandom([1, 64, 224, 224]);
+        _kernel_3x3_64x64 = Tensor<double>.CreateRandom([64, 64, 3, 3]);
+
+        _grad_128x112 = Tensor<double>.CreateRandom([1, 128, 112, 112]);
+        _input_128x112 = Tensor<double>.CreateRandom([1, 128, 112, 112]);
+        _kernel_3x3_128x128 = Tensor<double>.CreateRandom([128, 128, 3, 3]);
+
+        _grad_256x56  = Tensor<double>.CreateRandom([1, 256, 56, 56]);
+        _input_256x56 = Tensor<double>.CreateRandom([1, 256, 56, 56]);
+        _kernel_3x3_256x256 = Tensor<double>.CreateRandom([256, 256, 3, 3]);
+
+        _grad_512x28  = Tensor<double>.CreateRandom([1, 512, 28, 28]);
+        _input_512x28 = Tensor<double>.CreateRandom([1, 512, 28, 28]);
+        _kernel_3x3_512x512 = Tensor<double>.CreateRandom([512, 512, 3, 3]);
+
+        _grad_512x14  = Tensor<double>.CreateRandom([1, 512, 14, 14]);
+        _input_512x14 = Tensor<double>.CreateRandom([1, 512, 14, 14]);
+
+        // 1×1 s=1
+        _grad_64x56_1x1 = Tensor<double>.CreateRandom([1, 64, 56, 56]);
+        _input_256x56_1x1 = Tensor<double>.CreateRandom([1, 256, 56, 56]);
+        _kernel_1x1_64x256 = Tensor<double>.CreateRandom([64, 256, 1, 1]);
+
+        _grad_2048x7_1x1 = Tensor<double>.CreateRandom([1, 2048, 7, 7]);
+        _input_512x7_1x1 = Tensor<double>.CreateRandom([1, 512, 7, 7]);
+        _kernel_1x1_2048x512 = Tensor<double>.CreateRandom([2048, 512, 1, 1]);
+
+        // 7×7 s=2 p=3
+        _grad_64x112_7x7 = Tensor<double>.CreateRandom([1, 64, 112, 112]);
+        _input_3x224     = Tensor<double>.CreateRandom([1, 3, 224, 224]);
+        _kernel_7x7_64x3 = Tensor<double>.CreateRandom([64, 3, 7, 7]);
+
+        // 3×3 s=2 p=1
+        _grad_128x28_3x3s2  = Tensor<double>.CreateRandom([1, 128, 28, 28]);
+        _input_128x56_3x3s2 = Tensor<double>.CreateRandom([1, 128, 56, 56]);
+        _kernel_3x3_128x128_s2 = Tensor<double>.CreateRandom([128, 128, 3, 3]);
+    }
+
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        AiDotNetEngine.SetDeterministicMode(DeterministicMode);
+        SimdGemm.UseParallelGemm = UseParallelGemm;
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        AiDotNetEngine.SetDeterministicMode(false);
+        SimdGemm.UseParallelGemm = true;
+    }
+
+    // ───────────── 3×3 stride=1 padding=1 dW (kernel gradient) ─────────────
+
+    [Benchmark(Description = "dW 3x3 s1 p1 [1,64,224,224]→[1,64,224,224]")]
+    public Tensor<double> dW_3x3_s1p1_b64_h224()
+        => _engine.Conv2DBackwardKernel(_grad_64x224, _input_64x224,
+            new[] { 64, 64, 3, 3 }, new[] { 1, 1 }, new[] { 1, 1 }, new[] { 1, 1 });
+
+    [Benchmark(Description = "dW 3x3 s1 p1 [1,128,112,112]→[1,128,112,112]")]
+    public Tensor<double> dW_3x3_s1p1_b128_h112()
+        => _engine.Conv2DBackwardKernel(_grad_128x112, _input_128x112,
+            new[] { 128, 128, 3, 3 }, new[] { 1, 1 }, new[] { 1, 1 }, new[] { 1, 1 });
+
+    [Benchmark(Description = "dW 3x3 s1 p1 [1,256,56,56]→[1,256,56,56]")]
+    public Tensor<double> dW_3x3_s1p1_b256_h56()
+        => _engine.Conv2DBackwardKernel(_grad_256x56, _input_256x56,
+            new[] { 256, 256, 3, 3 }, new[] { 1, 1 }, new[] { 1, 1 }, new[] { 1, 1 });
+
+    [Benchmark(Description = "dW 3x3 s1 p1 [1,512,28,28]→[1,512,28,28]")]
+    public Tensor<double> dW_3x3_s1p1_b512_h28()
+        => _engine.Conv2DBackwardKernel(_grad_512x28, _input_512x28,
+            new[] { 512, 512, 3, 3 }, new[] { 1, 1 }, new[] { 1, 1 }, new[] { 1, 1 });
+
+    [Benchmark(Description = "dW 3x3 s1 p1 [1,512,14,14]→[1,512,14,14]")]
+    public Tensor<double> dW_3x3_s1p1_b512_h14()
+        => _engine.Conv2DBackwardKernel(_grad_512x14, _input_512x14,
+            new[] { 512, 512, 3, 3 }, new[] { 1, 1 }, new[] { 1, 1 }, new[] { 1, 1 });
+
+    // ───────────── 3×3 stride=1 padding=1 dX (input gradient) ─────────────
+
+    [Benchmark(Description = "dX 3x3 s1 p1 [1,64,224,224]")]
+    public Tensor<double> dX_3x3_s1p1_b64_h224()
+        => _engine.Conv2DBackwardInput(_grad_64x224, _kernel_3x3_64x64,
+            new[] { 1, 64, 224, 224 }, new[] { 1, 1 }, new[] { 1, 1 }, new[] { 1, 1 });
+
+    [Benchmark(Description = "dX 3x3 s1 p1 [1,128,112,112]")]
+    public Tensor<double> dX_3x3_s1p1_b128_h112()
+        => _engine.Conv2DBackwardInput(_grad_128x112, _kernel_3x3_128x128,
+            new[] { 1, 128, 112, 112 }, new[] { 1, 1 }, new[] { 1, 1 }, new[] { 1, 1 });
+
+    [Benchmark(Description = "dX 3x3 s1 p1 [1,256,56,56]")]
+    public Tensor<double> dX_3x3_s1p1_b256_h56()
+        => _engine.Conv2DBackwardInput(_grad_256x56, _kernel_3x3_256x256,
+            new[] { 1, 256, 56, 56 }, new[] { 1, 1 }, new[] { 1, 1 }, new[] { 1, 1 });
+
+    [Benchmark(Description = "dX 3x3 s1 p1 [1,512,28,28]")]
+    public Tensor<double> dX_3x3_s1p1_b512_h28()
+        => _engine.Conv2DBackwardInput(_grad_512x28, _kernel_3x3_512x512,
+            new[] { 1, 512, 28, 28 }, new[] { 1, 1 }, new[] { 1, 1 }, new[] { 1, 1 });
+
+    // ───────────── 1×1 stride=1 padding=0 dW + dX ─────────────
+
+    [Benchmark(Description = "dW 1x1 s1 [1,64,56,56]/[1,256,56,56]")]
+    public Tensor<double> dW_1x1_s1_64_256()
+        => _engine.Conv2DBackwardKernel(_grad_64x56_1x1, _input_256x56_1x1,
+            new[] { 64, 256, 1, 1 }, new[] { 1, 1 }, new[] { 0, 0 }, new[] { 1, 1 });
+
+    [Benchmark(Description = "dW 1x1 s1 [1,2048,7,7]/[1,512,7,7]")]
+    public Tensor<double> dW_1x1_s1_2048_512()
+        => _engine.Conv2DBackwardKernel(_grad_2048x7_1x1, _input_512x7_1x1,
+            new[] { 2048, 512, 1, 1 }, new[] { 1, 1 }, new[] { 0, 0 }, new[] { 1, 1 });
+
+    [Benchmark(Description = "dX 1x1 s1 [1,64,56,56]/k[64,256,1,1]")]
+    public Tensor<double> dX_1x1_s1_64_256()
+        => _engine.Conv2DBackwardInput(_grad_64x56_1x1, _kernel_1x1_64x256,
+            new[] { 1, 256, 56, 56 }, new[] { 1, 1 }, new[] { 0, 0 }, new[] { 1, 1 });
+
+    [Benchmark(Description = "dX 1x1 s1 [1,2048,7,7]/k[2048,512,1,1]")]
+    public Tensor<double> dX_1x1_s1_2048_512()
+        => _engine.Conv2DBackwardInput(_grad_2048x7_1x1, _kernel_1x1_2048x512,
+            new[] { 1, 512, 7, 7 }, new[] { 1, 1 }, new[] { 0, 0 }, new[] { 1, 1 });
+
+    // ───────────── 7×7 stride=2 padding=3 (ResNet stem) ─────────────
+
+    [Benchmark(Description = "dW 7x7 s2 p3 ResNet stem [1,3,224,224]→[1,64,112,112]")]
+    public Tensor<double> dW_7x7_s2p3_stem()
+        => _engine.Conv2DBackwardKernel(_grad_64x112_7x7, _input_3x224,
+            new[] { 64, 3, 7, 7 }, new[] { 2, 2 }, new[] { 3, 3 }, new[] { 1, 1 });
+
+    [Benchmark(Description = "dX 7x7 s2 p3 ResNet stem")]
+    public Tensor<double> dX_7x7_s2p3_stem()
+        => _engine.Conv2DBackwardInput(_grad_64x112_7x7, _kernel_7x7_64x3,
+            new[] { 1, 3, 224, 224 }, new[] { 2, 2 }, new[] { 3, 3 }, new[] { 1, 1 });
+
+    // ───────────── 3×3 stride=2 padding=1 (ResNet transitions) ─────────────
+
+    [Benchmark(Description = "dW 3x3 s2 p1 [1,128,28,28]/[1,128,56,56]")]
+    public Tensor<double> dW_3x3_s2p1()
+        => _engine.Conv2DBackwardKernel(_grad_128x28_3x3s2, _input_128x56_3x3s2,
+            new[] { 128, 128, 3, 3 }, new[] { 2, 2 }, new[] { 1, 1 }, new[] { 1, 1 });
+
+    [Benchmark(Description = "dX 3x3 s2 p1 [1,128,28,28]/k[128,128,3,3]")]
+    public Tensor<double> dX_3x3_s2p1()
+        => _engine.Conv2DBackwardInput(_grad_128x28_3x3s2, _kernel_3x3_128x128_s2,
+            new[] { 1, 128, 56, 56 }, new[] { 2, 2 }, new[] { 1, 1 }, new[] { 1, 1 });
+}
+#endif

--- a/tests/AiDotNet.Tensors.Benchmarks/DitXLMatMulDoubleBenchmarks.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/DitXLMatMulDoubleBenchmarks.cs
@@ -1,0 +1,218 @@
+#if NET8_0_OR_GREATER
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Simd;
+using AiDotNet.Tensors.LinearAlgebra;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+namespace AiDotNet.Tensors.Benchmarks;
+
+/// <summary>
+/// FP64 companion to <see cref="DitXLMatMulBenchmarks"/>. Stage 0 of the
+/// `docs/mkl-replacement/PLAN.md` Stage-0/1 FP64 closure effort: gives us a
+/// baseline to A/B every subsequent SimdGemmDouble port against (2% revert
+/// rule per `docs/mkl-replacement/baseline/iter31-35-results.md`).
+///
+/// Adds the FP64 shape coverage missing today:
+///   - VGG16 FC backward shapes (FC1 [25088,4096], FC2 [4096,4096], FC3 [4096,1000])
+///   - ResNet50 head shape [batch,2048]×[2048,1000]
+///   - ACEStep per-head MHA shapes ([seq=128, 64] × [64, seq=128], [128,128]×[128,64])
+///   - ACEStep MLP FFN shapes [128,512]×[512,2048] and [128,2048]×[2048,512]
+///   - The exact DiT-XL shapes mirrored for FP64 (so we can A/B vs FP32 iter34 numbers)
+///
+/// Run:
+///   dotnet run -c Release --project tests/AiDotNet.Tensors.Benchmarks \
+///     -- --dit-xl-matmul-double
+/// </summary>
+[SimpleJob(RuntimeMoniker.Net10_0, launchCount: 2, warmupCount: 5, iterationCount: 15)]
+[MemoryDiagnoser]
+[MarkdownExporterAttribute.GitHub]
+public class DitXLMatMulDoubleBenchmarks
+{
+    [ParamsAllValues]
+    public bool DeterministicMode { get; set; }
+
+    [ParamsAllValues]
+    public bool UseParallelGemm { get; set; }
+
+    private CpuEngine _engine = null!;
+
+    // ═══ DiT-XL FP64 shapes (mirror of float bench) ═══
+    private Tensor<double> _act_1024x1152 = null!;
+    private Tensor<double> _weight_1152x1152 = null!;
+    private Tensor<double> _weight_1152x3456 = null!;
+    private Tensor<double> _weight_1152x4608 = null!;
+    private Tensor<double> _act_1024x4608 = null!;
+    private Tensor<double> _weight_4608x1152 = null!;
+    private Tensor<double> _square_1152 = null!;
+    private Tensor<double> _square_4608 = null!;
+    private Tensor<double> _q_256x72 = null!;
+    private Tensor<double> _k_72x256 = null!;
+    private Tensor<double> _attn_256x256 = null!;
+    private Tensor<double> _v_256x72 = null!;
+    private Tensor<double> _batched_1_256_1152 = null!;
+    private Tensor<double> _batched_4_256_1152 = null!;
+
+    // ═══ Cluster #6 FP64 shapes: VGG16 FC backward ═══
+    // VGG16's three Dense layers: 25088→4096, 4096→4096, 4096→1000.
+    // Per forward+backward, each FC contributes M·K·N FMA per step.
+    // FC1 forward [1,25088]×[25088,4096] = 102.7 M FMA — most of step.
+    private Tensor<double> _vgg_fc1_act = null!;        // [1, 25088]
+    private Tensor<double> _vgg_fc1_w = null!;          // [25088, 4096]
+    private Tensor<double> _vgg_fc2_act = null!;        // [1, 4096]
+    private Tensor<double> _vgg_fc2_w = null!;          // [4096, 4096]
+    private Tensor<double> _vgg_fc3_w = null!;          // [4096, 1000]
+
+    // ═══ ResNet50 FP64 shapes: head FC + bottleneck 1×1 conv lowered to GEMM ═══
+    // Final classifier 2048→1000; bottleneck 1×1 convs lower to [H·W, C_in] × [C_in, C_out].
+    private Tensor<double> _resnet_head_act = null!;    // [1, 2048]
+    private Tensor<double> _resnet_head_w = null!;      // [2048, 1000]
+    private Tensor<double> _resnet_1x1_49x2048 = null!; // bottleneck at H·W=7×7=49
+    private Tensor<double> _resnet_1x1_w_2048x512 = null!;
+    private Tensor<double> _resnet_1x1_196x1024 = null!;// bottleneck at H·W=14×14=196
+    private Tensor<double> _resnet_1x1_w_1024x256 = null!;
+
+    // ═══ ACEStep FP64 shapes: MHA per-head + MLP FFN ═══
+    // 8 heads × dim 64; seq_len 128 (latent from diffusion step).
+    private Tensor<double> _ace_perhead_q = null!;      // [128, 64]
+    private Tensor<double> _ace_perhead_k = null!;      // [64, 128]
+    private Tensor<double> _ace_perhead_av_a = null!;   // [128, 128]
+    private Tensor<double> _ace_perhead_av_v = null!;   // [128, 64]
+    private Tensor<double> _ace_mlp_act = null!;        // [128, 512]
+    private Tensor<double> _ace_mlp_up_w = null!;       // [512, 2048]
+    private Tensor<double> _ace_mlp_hidden = null!;     // [128, 2048]
+    private Tensor<double> _ace_mlp_down_w = null!;     // [2048, 512]
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new CpuEngine();
+
+        _act_1024x1152    = Tensor<double>.CreateRandom([1024, 1152]);
+        _weight_1152x1152 = Tensor<double>.CreateRandom([1152, 1152]);
+        _weight_1152x3456 = Tensor<double>.CreateRandom([1152, 3456]);
+        _weight_1152x4608 = Tensor<double>.CreateRandom([1152, 4608]);
+        _act_1024x4608    = Tensor<double>.CreateRandom([1024, 4608]);
+        _weight_4608x1152 = Tensor<double>.CreateRandom([4608, 1152]);
+
+        _square_1152 = Tensor<double>.CreateRandom([1152, 1152]);
+        _square_4608 = Tensor<double>.CreateRandom([4608, 4608]);
+
+        _q_256x72     = Tensor<double>.CreateRandom([256, 72]);
+        _k_72x256     = Tensor<double>.CreateRandom([72, 256]);
+        _attn_256x256 = Tensor<double>.CreateRandom([256, 256]);
+        _v_256x72     = Tensor<double>.CreateRandom([256, 72]);
+
+        _batched_1_256_1152 = Tensor<double>.CreateRandom([1, 256, 1152]);
+        _batched_4_256_1152 = Tensor<double>.CreateRandom([4, 256, 1152]);
+
+        _vgg_fc1_act = Tensor<double>.CreateRandom([1, 25088]);
+        _vgg_fc1_w   = Tensor<double>.CreateRandom([25088, 4096]);
+        _vgg_fc2_act = Tensor<double>.CreateRandom([1, 4096]);
+        _vgg_fc2_w   = Tensor<double>.CreateRandom([4096, 4096]);
+        _vgg_fc3_w   = Tensor<double>.CreateRandom([4096, 1000]);
+
+        _resnet_head_act    = Tensor<double>.CreateRandom([1, 2048]);
+        _resnet_head_w      = Tensor<double>.CreateRandom([2048, 1000]);
+        _resnet_1x1_49x2048 = Tensor<double>.CreateRandom([49, 2048]);
+        _resnet_1x1_w_2048x512 = Tensor<double>.CreateRandom([2048, 512]);
+        _resnet_1x1_196x1024 = Tensor<double>.CreateRandom([196, 1024]);
+        _resnet_1x1_w_1024x256 = Tensor<double>.CreateRandom([1024, 256]);
+
+        _ace_perhead_q    = Tensor<double>.CreateRandom([128, 64]);
+        _ace_perhead_k    = Tensor<double>.CreateRandom([64, 128]);
+        _ace_perhead_av_a = Tensor<double>.CreateRandom([128, 128]);
+        _ace_perhead_av_v = Tensor<double>.CreateRandom([128, 64]);
+        _ace_mlp_act      = Tensor<double>.CreateRandom([128, 512]);
+        _ace_mlp_up_w     = Tensor<double>.CreateRandom([512, 2048]);
+        _ace_mlp_hidden   = Tensor<double>.CreateRandom([128, 2048]);
+        _ace_mlp_down_w   = Tensor<double>.CreateRandom([2048, 512]);
+    }
+
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        AiDotNetEngine.SetDeterministicMode(DeterministicMode);
+        SimdGemm.UseParallelGemm = UseParallelGemm;
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        AiDotNetEngine.SetDeterministicMode(false);
+        SimdGemm.UseParallelGemm = true;
+    }
+
+    // ───────────── DiT-XL FP64 shapes ─────────────
+
+    [Benchmark(Description = "DiT FP64 attn out [1024,1152]×[1152,1152]")]
+    public Tensor<double> DiT_AttnOutputProj_F64()
+        => _engine.TensorMatMul(_act_1024x1152, _weight_1152x1152);
+
+    [Benchmark(Description = "DiT FP64 QKV fused [1024,1152]×[1152,3456]")]
+    public Tensor<double> DiT_QKVFusedProj_F64()
+        => _engine.TensorMatMul(_act_1024x1152, _weight_1152x3456);
+
+    [Benchmark(Description = "DiT FP64 MLP up [1024,1152]×[1152,4608]")]
+    public Tensor<double> DiT_MlpUp_F64()
+        => _engine.TensorMatMul(_act_1024x1152, _weight_1152x4608);
+
+    [Benchmark(Description = "DiT FP64 MLP down [1024,4608]×[4608,1152]")]
+    public Tensor<double> DiT_MlpDown_F64()
+        => _engine.TensorMatMul(_act_1024x4608, _weight_4608x1152);
+
+    [Benchmark(Description = "Square FP64 [1152,1152]²")]
+    public Tensor<double> Square_1152_F64() => _engine.TensorMatMul(_square_1152, _square_1152);
+
+    [Benchmark(Description = "Square FP64 [4608,4608]²")]
+    public Tensor<double> Square_4608_F64() => _engine.TensorMatMul(_square_4608, _square_4608);
+
+    [Benchmark(Description = "Attn FP64 Q·K^T per-head [256,72]×[72,256]")]
+    public Tensor<double> Attn_QK_F64() => _engine.TensorMatMul(_q_256x72, _k_72x256);
+
+    [Benchmark(Description = "Attn FP64 A·V per-head [256,256]×[256,72]")]
+    public Tensor<double> Attn_AV_F64() => _engine.TensorMatMul(_attn_256x256, _v_256x72);
+
+    [Benchmark(Description = "Batched3D FP64 B=1 [1,256,1152]×[1152,4608]")]
+    public Tensor<double> Batched_B1_F64() => _engine.TensorMatMul(_batched_1_256_1152, _weight_1152x4608);
+
+    [Benchmark(Description = "Batched3D FP64 B=4 [4,256,1152]×[1152,4608]")]
+    public Tensor<double> Batched_B4_F64() => _engine.TensorMatMul(_batched_4_256_1152, _weight_1152x4608);
+
+    // ───────────── Cluster #6 VGG16 FC shapes ─────────────
+
+    [Benchmark(Description = "VGG FC1 fwd [1,25088]×[25088,4096]")]
+    public Tensor<double> VGG_FC1_Fwd() => _engine.TensorMatMul(_vgg_fc1_act, _vgg_fc1_w);
+
+    [Benchmark(Description = "VGG FC2 fwd [1,4096]×[4096,4096]")]
+    public Tensor<double> VGG_FC2_Fwd() => _engine.TensorMatMul(_vgg_fc2_act, _vgg_fc2_w);
+
+    [Benchmark(Description = "VGG FC3 fwd [1,4096]×[4096,1000]")]
+    public Tensor<double> VGG_FC3_Fwd() => _engine.TensorMatMul(_vgg_fc2_act, _vgg_fc3_w);
+
+    // ───────────── Cluster #6 ResNet50 shapes ─────────────
+
+    [Benchmark(Description = "ResNet head [1,2048]×[2048,1000]")]
+    public Tensor<double> ResNet_HeadFC() => _engine.TensorMatMul(_resnet_head_act, _resnet_head_w);
+
+    [Benchmark(Description = "ResNet bottleneck 1×1 at H·W=49 [49,2048]×[2048,512]")]
+    public Tensor<double> ResNet_Bottleneck_HW49() => _engine.TensorMatMul(_resnet_1x1_49x2048, _resnet_1x1_w_2048x512);
+
+    [Benchmark(Description = "ResNet bottleneck 1×1 at H·W=196 [196,1024]×[1024,256]")]
+    public Tensor<double> ResNet_Bottleneck_HW196() => _engine.TensorMatMul(_resnet_1x1_196x1024, _resnet_1x1_w_1024x256);
+
+    // ───────────── Cluster #6 ACEStep shapes ─────────────
+
+    [Benchmark(Description = "ACEStep MHA per-head Q·K^T [128,64]×[64,128]")]
+    public Tensor<double> ACE_QK() => _engine.TensorMatMul(_ace_perhead_q, _ace_perhead_k);
+
+    [Benchmark(Description = "ACEStep MHA per-head A·V [128,128]×[128,64]")]
+    public Tensor<double> ACE_AV() => _engine.TensorMatMul(_ace_perhead_av_a, _ace_perhead_av_v);
+
+    [Benchmark(Description = "ACEStep MLP up [128,512]×[512,2048]")]
+    public Tensor<double> ACE_MlpUp() => _engine.TensorMatMul(_ace_mlp_act, _ace_mlp_up_w);
+
+    [Benchmark(Description = "ACEStep MLP down [128,2048]×[2048,512]")]
+    public Tensor<double> ACE_MlpDown() => _engine.TensorMatMul(_ace_mlp_hidden, _ace_mlp_down_w);
+}
+#endif

--- a/tests/AiDotNet.Tensors.Benchmarks/Fp64PrimitiveBenchmarks.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Fp64PrimitiveBenchmarks.cs
@@ -110,6 +110,8 @@ public class Fp64PrimitiveBenchmarks
         _pool_256x56  = Tensor<double>.CreateRandom([1, 256, 56, 56]);
         _pool_512x28  = Tensor<double>.CreateRandom([1, 512, 28, 28]);
         _pool_512x14  = Tensor<double>.CreateRandom([1, 512, 14, 14]);
+
+        _avgpool_2048x7 = Tensor<double>.CreateRandom([1, 2048, 7, 7]);
     }
 
     // ───────────── BatchNorm forward ─────────────
@@ -193,9 +195,6 @@ public class Fp64PrimitiveBenchmarks
 
     [Benchmark(Description = "AvgPool 7x7 global [1,2048,7,7]→[1,2048,1,1] (ResNet head)")]
     public Tensor<double> AvgPool_ResNetHead()
-    {
-        _avgpool_2048x7 ??= Tensor<double>.CreateRandom([1, 2048, 7, 7]);
-        return _engine.AvgPool2D(_avgpool_2048x7, 7, 1);
-    }
+        => _engine.AvgPool2D(_avgpool_2048x7, 7, 1);
 }
 #endif

--- a/tests/AiDotNet.Tensors.Benchmarks/Fp64PrimitiveBenchmarks.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Fp64PrimitiveBenchmarks.cs
@@ -1,0 +1,201 @@
+#if NET8_0_OR_GREATER
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+namespace AiDotNet.Tensors.Benchmarks;
+
+/// <summary>
+/// FP64 primitive ops: BatchNorm, LayerNorm, Softmax, activations, pools.
+/// Stage 0 of the FP64 perf-closure effort: gives us a baseline for the
+/// ops that are CURRENTLY SCALAR in FP64 (per the audit in
+/// `docs/mkl-replacement/PLAN.md` Stage 4) so Stage 4's Vector256&lt;double&gt;
+/// SIMD ports can be A/B'd.
+///
+/// Shapes target cluster-#6 hot paths:
+///   - BN at VGG block dims (64×224, 128×112, 256×56, 512×28, 512×14)
+///     and ResNet50 BN (50 BN per step, at the same dims as the convs)
+///   - LN at ACEStep MHA hidden (128 tokens × 512 hidden)
+///   - Softmax at ACEStep MHA attention (128 × 128 attention scores)
+///   - Activations at all VGG / ResNet feature-map sizes
+///   - MaxPool / AvgPool at VGG pool dims
+///
+/// Run:
+///   dotnet run -c Release --project tests/AiDotNet.Tensors.Benchmarks \
+///     -- --fp64-primitives
+/// </summary>
+[SimpleJob(RuntimeMoniker.Net10_0, launchCount: 2, warmupCount: 3, iterationCount: 10)]
+[MemoryDiagnoser]
+[MarkdownExporterAttribute.GitHub]
+public class Fp64PrimitiveBenchmarks
+{
+    private CpuEngine _engine = null!;
+
+    // BatchNorm inputs at cluster-#6 feature-map sizes
+    private Tensor<double> _bn_64x224 = null!;
+    private Tensor<double> _bn_128x112 = null!;
+    private Tensor<double> _bn_256x56 = null!;
+    private Tensor<double> _bn_512x28 = null!;
+    private Tensor<double> _bn_512x14 = null!;
+    private Tensor<double> _bn_gamma_64 = null!;
+    private Tensor<double> _bn_beta_64 = null!;
+    private Tensor<double> _bn_gamma_128 = null!;
+    private Tensor<double> _bn_beta_128 = null!;
+    private Tensor<double> _bn_gamma_256 = null!;
+    private Tensor<double> _bn_beta_256 = null!;
+    private Tensor<double> _bn_gamma_512 = null!;
+    private Tensor<double> _bn_beta_512 = null!;
+
+    // LayerNorm inputs at ACEStep / transformer dims
+    private Tensor<double> _ln_128x512 = null!;
+    private Tensor<double> _ln_gamma_512 = null!;
+    private Tensor<double> _ln_beta_512 = null!;
+
+    // Softmax input (last-dim reduction): ACEStep attention scores
+    private Tensor<double> _softmax_128x128 = null!;
+    // Larger softmax (LM head logits, classification): 1000 classes
+    private Tensor<double> _softmax_1x1000 = null!;
+
+    // Activation inputs (1D and 4D) at VGG/ResNet shapes
+    private Tensor<double> _act_64x224 = null!;
+    private Tensor<double> _act_128x112 = null!;
+    private Tensor<double> _act_256x56 = null!;
+    private Tensor<double> _act_512x28 = null!;
+    private Tensor<double> _act_4096 = null!;       // VGG FC2 output
+    private Tensor<double> _act_25088 = null!;      // VGG FC1 input
+
+    // Pool inputs at VGG pool dims (before each pool transition)
+    private Tensor<double> _pool_64x224 = null!;    // → 64x112
+    private Tensor<double> _pool_128x112 = null!;   // → 128x56
+    private Tensor<double> _pool_256x56 = null!;    // → 256x28
+    private Tensor<double> _pool_512x28 = null!;    // → 512x14
+    private Tensor<double> _pool_512x14 = null!;    // → 512x7
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new CpuEngine();
+
+        _bn_64x224  = Tensor<double>.CreateRandom([1, 64, 224, 224]);
+        _bn_128x112 = Tensor<double>.CreateRandom([1, 128, 112, 112]);
+        _bn_256x56  = Tensor<double>.CreateRandom([1, 256, 56, 56]);
+        _bn_512x28  = Tensor<double>.CreateRandom([1, 512, 28, 28]);
+        _bn_512x14  = Tensor<double>.CreateRandom([1, 512, 14, 14]);
+        _bn_gamma_64  = Tensor<double>.CreateRandom([64]);
+        _bn_beta_64   = Tensor<double>.CreateRandom([64]);
+        _bn_gamma_128 = Tensor<double>.CreateRandom([128]);
+        _bn_beta_128  = Tensor<double>.CreateRandom([128]);
+        _bn_gamma_256 = Tensor<double>.CreateRandom([256]);
+        _bn_beta_256  = Tensor<double>.CreateRandom([256]);
+        _bn_gamma_512 = Tensor<double>.CreateRandom([512]);
+        _bn_beta_512  = Tensor<double>.CreateRandom([512]);
+
+        _ln_128x512   = Tensor<double>.CreateRandom([128, 512]);
+        _ln_gamma_512 = Tensor<double>.CreateRandom([512]);
+        _ln_beta_512  = Tensor<double>.CreateRandom([512]);
+
+        _softmax_128x128 = Tensor<double>.CreateRandom([128, 128]);
+        _softmax_1x1000  = Tensor<double>.CreateRandom([1, 1000]);
+
+        _act_64x224  = Tensor<double>.CreateRandom([1, 64, 224, 224]);
+        _act_128x112 = Tensor<double>.CreateRandom([1, 128, 112, 112]);
+        _act_256x56  = Tensor<double>.CreateRandom([1, 256, 56, 56]);
+        _act_512x28  = Tensor<double>.CreateRandom([1, 512, 28, 28]);
+        _act_4096    = Tensor<double>.CreateRandom([1, 4096]);
+        _act_25088   = Tensor<double>.CreateRandom([1, 25088]);
+
+        _pool_64x224  = Tensor<double>.CreateRandom([1, 64, 224, 224]);
+        _pool_128x112 = Tensor<double>.CreateRandom([1, 128, 112, 112]);
+        _pool_256x56  = Tensor<double>.CreateRandom([1, 256, 56, 56]);
+        _pool_512x28  = Tensor<double>.CreateRandom([1, 512, 28, 28]);
+        _pool_512x14  = Tensor<double>.CreateRandom([1, 512, 14, 14]);
+    }
+
+    // ───────────── BatchNorm forward ─────────────
+
+    [Benchmark(Description = "BN fwd [1,64,224,224]")]
+    public Tensor<double> BN_64x224()
+        => _engine.BatchNorm(_bn_64x224, _bn_gamma_64, _bn_beta_64, 1e-5, out _, out _);
+
+    [Benchmark(Description = "BN fwd [1,128,112,112]")]
+    public Tensor<double> BN_128x112()
+        => _engine.BatchNorm(_bn_128x112, _bn_gamma_128, _bn_beta_128, 1e-5, out _, out _);
+
+    [Benchmark(Description = "BN fwd [1,256,56,56]")]
+    public Tensor<double> BN_256x56()
+        => _engine.BatchNorm(_bn_256x56, _bn_gamma_256, _bn_beta_256, 1e-5, out _, out _);
+
+    [Benchmark(Description = "BN fwd [1,512,28,28]")]
+    public Tensor<double> BN_512x28()
+        => _engine.BatchNorm(_bn_512x28, _bn_gamma_512, _bn_beta_512, 1e-5, out _, out _);
+
+    [Benchmark(Description = "BN fwd [1,512,14,14]")]
+    public Tensor<double> BN_512x14()
+        => _engine.BatchNorm(_bn_512x14, _bn_gamma_512, _bn_beta_512, 1e-5, out _, out _);
+
+    // ───────────── LayerNorm forward ─────────────
+
+    [Benchmark(Description = "LN fwd [128,512] (ACEStep MHA hidden)")]
+    public Tensor<double> LN_128x512()
+        => _engine.LayerNorm(_ln_128x512, _ln_gamma_512, _ln_beta_512, 1e-5, out _, out _);
+
+    // ───────────── Softmax forward ─────────────
+
+    [Benchmark(Description = "Softmax [128,128] last-dim (ACEStep attn scores)")]
+    public Tensor<double> Softmax_128x128() => _engine.Softmax(_softmax_128x128);
+
+    [Benchmark(Description = "Softmax [1,1000] last-dim (LM head)")]
+    public Tensor<double> Softmax_1x1000() => _engine.Softmax(_softmax_1x1000);
+
+    // ───────────── Activations ─────────────
+
+    [Benchmark(Description = "ReLU [1,64,224,224]")]
+    public Tensor<double> ReLU_64x224() => _engine.ReLU(_act_64x224);
+
+    [Benchmark(Description = "ReLU [1,128,112,112]")]
+    public Tensor<double> ReLU_128x112() => _engine.ReLU(_act_128x112);
+
+    [Benchmark(Description = "ReLU [1,512,28,28]")]
+    public Tensor<double> ReLU_512x28() => _engine.ReLU(_act_512x28);
+
+    [Benchmark(Description = "ReLU [1,4096] (VGG FC mid)")]
+    public Tensor<double> ReLU_FC4096() => _engine.ReLU(_act_4096);
+
+    [Benchmark(Description = "GELU [1,4096] (transformer-style FFN)")]
+    public Tensor<double> GELU_FC4096() => _engine.GELU(_act_4096);
+
+    // ───────────── MaxPool ─────────────
+
+    [Benchmark(Description = "MaxPool 2x2 s=2 [1,64,224,224]→[1,64,112,112]")]
+    public Tensor<double> MaxPool_64x224()
+        => _engine.MaxPool2D(_pool_64x224, 2, 2);
+
+    [Benchmark(Description = "MaxPool 2x2 s=2 [1,128,112,112]→[1,128,56,56]")]
+    public Tensor<double> MaxPool_128x112()
+        => _engine.MaxPool2D(_pool_128x112, 2, 2);
+
+    [Benchmark(Description = "MaxPool 2x2 s=2 [1,256,56,56]→[1,256,28,28]")]
+    public Tensor<double> MaxPool_256x56()
+        => _engine.MaxPool2D(_pool_256x56, 2, 2);
+
+    [Benchmark(Description = "MaxPool 2x2 s=2 [1,512,28,28]→[1,512,14,14]")]
+    public Tensor<double> MaxPool_512x28()
+        => _engine.MaxPool2D(_pool_512x28, 2, 2);
+
+    [Benchmark(Description = "MaxPool 2x2 s=2 [1,512,14,14]→[1,512,7,7]")]
+    public Tensor<double> MaxPool_512x14()
+        => _engine.MaxPool2D(_pool_512x14, 2, 2);
+
+    // ───────────── AveragePool ─────────────
+
+    private Tensor<double> _avgpool_2048x7 = null!;
+
+    [Benchmark(Description = "AvgPool 7x7 global [1,2048,7,7]→[1,2048,1,1] (ResNet head)")]
+    public Tensor<double> AvgPool_ResNetHead()
+    {
+        _avgpool_2048x7 ??= Tensor<double>.CreateRandom([1, 2048, 7, 7]);
+        return _engine.AvgPool2D(_avgpool_2048x7, 7, 1);
+    }
+}
+#endif

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -399,6 +399,35 @@ class Program
             return;
         }
 
+        // FP64 companion to --dit-xl-matmul: includes DiT-XL shapes at double
+        // precision PLUS the cluster #6 cluster (VGG FC layers, ResNet head /
+        // bottleneck shapes, ACEStep MHA + MLP). Stage 0 baseline of the
+        // FP64 perf-closure effort. (~15-25min).
+        if (args[0] == "--dit-xl-matmul-double")
+        {
+            BenchmarkRunner.Run<DitXLMatMulDoubleBenchmarks>(BenchConfig);
+            return;
+        }
+
+        // FP64 Conv2D backward (dW + dX) across the {kernel × stride × padding}
+        // matrix that cluster #6 (VGG16 / ResNet50 / DenseNet) exercises at
+        // ImageNet input scale. Stage 0 baseline for Stage 1 / 5 / 7 conv work.
+        // (~15-30min).
+        if (args[0] == "--conv2d-backward-double")
+        {
+            BenchmarkRunner.Run<Conv2DBackwardDoubleBenchmarks>(BenchConfig);
+            return;
+        }
+
+        // FP64 primitive ops (BatchNorm, LayerNorm, Softmax, activations,
+        // pools). Stage 0 baseline for Stage 4 SIMD ports of currently-scalar
+        // FP64 primitives. (~10-20min).
+        if (args[0] == "--fp64-primitives")
+        {
+            BenchmarkRunner.Run<Fp64PrimitiveBenchmarks>(BenchConfig);
+            return;
+        }
+
         // DiT-XL SDPA benchmark: measures ScaledDotProductAttention at the exact
         // 4D shape DiT-XL exercises, to verify the Issue #162 BLAS-backed fast
         // path eliminates the scalar virtual-dispatch wall clock. (~1-2min).
@@ -537,6 +566,9 @@ class Program
         Console.WriteLine("  --workspace         : Run TensorWorkspace zero-allocation benchmarks");
         Console.WriteLine("  --vs-deterministic-matmul: Deterministic vs non-deterministic SimdGemm on HRE + square shapes (post-MKL-removal both paths are SimdGemm; pair with iter-17 MKL baseline for vs-MKL comparison)");
         Console.WriteLine("  --dit-xl-matmul     : SimdGemm at DiT-XL shapes; compare against docs/mkl-replacement/baseline/baseline-iter17.md for vs-MKL numbers");
+        Console.WriteLine("  --dit-xl-matmul-double : FP64 GEMM at DiT-XL + cluster-#6 shapes; Stage 0 baseline (docs/mkl-replacement/PLAN.md)");
+        Console.WriteLine("  --conv2d-backward-double : FP64 Conv2DBackward dW+dX across cluster-#6 shapes; Stage 0 baseline");
+        Console.WriteLine("  --fp64-primitives   : FP64 BN/LN/Softmax/activations/pools; Stage 0 baseline for Stage 4");
         Console.WriteLine("  --dit-xl-sdpa       : ScaledDotProductAttention at DiT-XL shape [4,16,256,72] (Issue #162 SDPA fix)");
         Console.WriteLine("  --transformer-ffn   : Small-M transformer FFN matmul (Sgemm+Dgemm+batched) — Issue #245 coverage");
         Console.WriteLine();


### PR DESCRIPTION
## Summary

Stage 0 of the FP64 perf-closure plan (`docs/mkl-replacement/PLAN.md`). Adds three benchmark suites that gate every subsequent FP64 perf iteration via the established 2% revert rule (per `docs/mkl-replacement/baseline/iter31-35-results.md`).

The motivation: after PR #163 removed MKL.NET in favor of `SimdGemm` (FP32, currently at iter 34 with 5W/1P/4L vs MKL), `SimdGemmDouble` (FP64) was left with just 2 entry points and an ~6× gap vs MKL on medium shapes (per the comment at `SimdGemmDouble.cs:8`). The cluster-#6 perf-timeout tests (3× VGG16, ResNet50, ACEStep) fail in part because of this gap, in part because BN/LN/Softmax/activations are still scalar in FP64. This PR is the measurement infrastructure to close those gaps.

## What's added

| Benchmark | Invoke | Covers |
|---|---|---|
| `DitXLMatMulDoubleBenchmarks` | `-- --dit-xl-matmul-double` | DiT-XL shapes at FP64 + VGG16 FC, ResNet50 head + bottleneck 1×1, ACEStep MHA + MLP FFN |
| `Conv2DBackwardDoubleBenchmarks` | `-- --conv2d-backward-double` | Conv2D dW + dX across 3×3/s=1/p=1, 3×3/s=2/p=1, 1×1/s=1, 7×7/s=2/p=3 × ImageNet feature-map dims |
| `Fp64PrimitiveBenchmarks` | `-- --fp64-primitives` | BatchNorm, LayerNorm, Softmax, ReLU, GELU, MaxPool, AvgPool at cluster-#6 shapes |

`Program.cs` help text + dispatch wired for all three.

## What's NOT in this PR

Zero engine code touched. Pure additive measurement infrastructure. This PR is a strict prerequisite for Stages 1–7 of the plan — no perf change can be A/B'd against an unmeasured baseline.

## Acceptance

- Build clean (0 errors, Release/net10.0).
- Each benchmark invocable via the documented `--` flag.
- Baseline numbers will be recorded in `docs/mkl-replacement/baseline/fp64-iter0-results.md` on a follow-up commit once a clean Ryzen run is available (the iter-17/31-35 baselines were all from the same Ryzen 9 3950X box; same env for parity).

## Test plan

- [x] Build clean
- [ ] Run all three new benchmarks on the same Ryzen 9 3950X used for the iter-17/31-35 baselines; commit results to `docs/mkl-replacement/baseline/fp64-iter0-results.md`

Refs ooples/AiDotNet.Tensors#415, ooples/AiDotNet#1306, ooples/AiDotNet#1314, ooples/AiDotNet#1305

🤖 Generated with [Claude Code](https://claude.com/claude-code)