### PR TITLE
fix: TensorAllocator dim-product uses long arithmetic with named-shape diagnostic

### DIFF
--- a/src/AiDotNet.Tensors/Helpers/TensorAllocator.cs
+++ b/src/AiDotNet.Tensors/Helpers/TensorAllocator.cs
@@ -41,14 +41,29 @@ public static class TensorAllocator
     public static Tensor<T> RentPinned<T>(int[] shape)
     {
         if (shape is null) throw new ArgumentNullException(nameof(shape));
-        int totalSize = 1;
+        // Use long arithmetic for the dim product so an intermediate
+        // multiplication can't overflow Int32 (~2.1 B). The arrays we
+        // actually allocate still cap at Array.MaxLength (slightly under
+        // Int32.MaxValue for primitive types) — fail with a clear
+        // diagnostic when the long product exceeds that, rather than
+        // letting `checked(int * int)` throw the generic
+        // OverflowException from inside the multiplication.
+        long longTotal = 1;
         for (int i = 0; i < shape.Length; i++)
         {
             if (shape[i] < 0)
                 throw new ArgumentOutOfRangeException(nameof(shape),
                     $"shape[{i}] = {shape[i]}; shape dimensions must be non-negative.");
-            totalSize = checked(totalSize * shape[i]);
+            longTotal *= shape[i];
+            if (longTotal > int.MaxValue)
+                throw new InvalidOperationException(
+                    $"Requested tensor has {longTotal} elements (shape = " +
+                    $"[{string.Join(",", shape)}]); single-array allocation caps " +
+                    $"at Array.MaxLength (~{int.MaxValue}). Use the streaming " +
+                    $"pool (WeightRegistry.AllocateStreaming) or shard the " +
+                    $"tensor across multiple sub-tensors.");
         }
+        int totalSize = (int)longTotal;
         if (totalSize == 0) return new Tensor<T>(shape);
 
         // MemoryProfiler hook — pinned tier is always a fresh allocation
@@ -214,9 +229,36 @@ public static class TensorAllocator
     /// </summary>
     public static Tensor<T> Rent<T>(int[] shape)
     {
-        int totalSize = 1;
+        if (shape is null) throw new ArgumentNullException(nameof(shape));
+        // Use long arithmetic for the dim product so an intermediate
+        // multiplication can't overflow Int32 (~2.1 B). The arrays we
+        // actually allocate still cap at Array.MaxLength (slightly under
+        // Int32.MaxValue for primitive types) — fail with a clear
+        // diagnostic when the long product exceeds that, rather than
+        // letting `checked(int * int)` throw the generic
+        // OverflowException from inside the multiplication, which was
+        // the visible failure on TimeMachine / DQN / OWLViT / DGCNN /
+        // TabTransformer / TabDPT / SlimSAM / TriaffineNER tests on
+        // PR #1408 SonarCloud run 26241806890.
+        long longTotal = 1;
         for (int i = 0; i < shape.Length; i++)
-            totalSize = checked(totalSize * shape[i]);
+        {
+            if (shape[i] < 0)
+                throw new ArgumentOutOfRangeException(nameof(shape),
+                    $"shape[{i}] = {shape[i]}; shape dimensions must be non-negative. " +
+                    $"Lazy layers should resolve their input dim from the architecture " +
+                    $"BEFORE calling Rent; the -1 sentinel suggests EnsureInitialized " +
+                    $"ran before ResolveLazyLayerShapes propagated the parent's shape.");
+            longTotal *= shape[i];
+            if (longTotal > int.MaxValue)
+                throw new InvalidOperationException(
+                    $"Requested tensor has {longTotal} elements (shape = " +
+                    $"[{string.Join(",", shape)}]); single-array allocation caps " +
+                    $"at Array.MaxLength (~{int.MaxValue}). Use the streaming " +
+                    $"pool (WeightRegistry.AllocateStreaming) or shard the " +
+                    $"tensor across multiple sub-tensors.");
+        }
+        int totalSize = (int)longTotal;
 
         // MemoryProfiler hook (#220): only record branches that actually allocate
         // new memory — arena/pool/cache reuse paths do not, and recording them

--- a/tests/AiDotNet.Tensors.Tests/Helpers/TensorAllocatorOverflowTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/TensorAllocatorOverflowTests.cs
@@ -1,0 +1,92 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Regression coverage for TensorAllocator's int→long dim-product fix.
+//
+// Before this fix `Rent` / `RentPinned` accumulated the dim product in
+// `checked(int * int)`, so any shape whose element count exceeded
+// Int32.MaxValue (~2.1 B) threw the generic `System.OverflowException`
+// from inside the multiplication itself. That surfaced upstream on
+// AiDotNet (#1408 SonarCloud run 26241806890) as opaque crashes inside
+// TimeMachine / DQN / OWLViT / DGCNN / TabTransformer / TabDPT /
+// SlimSAM / TriaffineNER — the error never named the requested shape,
+// so callers couldn't tell whether the alloc was 2 B + 1 elements (the
+// realistic case) or 2^62 elements (a real bug). Long arithmetic lets
+// the allocator name the size and point at `WeightRegistry.AllocateStreaming`
+// before throwing.
+
+using System;
+using AiDotNet.Tensors.Helpers;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Helpers;
+
+public class TensorAllocatorOverflowTests
+{
+    [Fact]
+    public void Rent_NullShape_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => TensorAllocator.Rent<float>(null!));
+    }
+
+    [Fact]
+    public void RentPinned_NullShape_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => TensorAllocator.RentPinned<float>(null!));
+    }
+
+    [Fact]
+    public void Rent_NegativeDim_ThrowsArgumentOutOfRange_NamingTheDimAndIndex()
+    {
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => TensorAllocator.Rent<float>(new[] { 4, -1, 8 }));
+        // Diagnostic must name the offending dim by index so lazy-layer
+        // sentinel-propagation bugs are debuggable upstream.
+        Assert.Contains("shape[1]", ex.Message);
+        Assert.Contains("-1", ex.Message);
+    }
+
+    [Fact]
+    public void RentPinned_NegativeDim_ThrowsArgumentOutOfRange()
+    {
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => TensorAllocator.RentPinned<float>(new[] { 2, -3 }));
+        Assert.Contains("shape[1]", ex.Message);
+    }
+
+    [Fact]
+    public void Rent_ShapeProductExceedsInt32_ThrowsInvalidOperationWithLongCount()
+    {
+        // 65537 * 65537 = 4,295,098,369 > Int32.MaxValue (2,147,483,647).
+        // Old code: `checked(int * int)` throws bare OverflowException with
+        // no shape context. New code: InvalidOperationException naming the
+        // long element count and pointing at the streaming pool.
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => TensorAllocator.Rent<float>(new[] { 65537, 65537 }));
+        Assert.Contains("4295098369", ex.Message);
+        Assert.Contains("Array.MaxLength", ex.Message);
+        Assert.Contains("WeightRegistry.AllocateStreaming", ex.Message);
+    }
+
+    [Fact]
+    public void RentPinned_ShapeProductExceedsInt32_ThrowsInvalidOperationWithLongCount()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => TensorAllocator.RentPinned<float>(new[] { 50000, 50000 }));
+        // 50000 * 50000 = 2_500_000_000 > Int32.MaxValue.
+        Assert.Contains("2500000000", ex.Message);
+        Assert.Contains("WeightRegistry.AllocateStreaming", ex.Message);
+    }
+
+    [Fact]
+    public void Rent_ZeroElementShape_ReturnsEmptyTensor_NotThrow()
+    {
+        // A zero dim short-circuits the product to 0 — pinning / arena
+        // logic shouldn't allocate, and the tensor must come back with
+        // the exact requested shape.
+        using var t = TensorAllocator.Rent<float>(new[] { 4, 0, 8 });
+        Assert.Equal(0, t.Length);
+        Assert.Equal(3, t.Shape.Length);
+        Assert.Equal(4, t.Shape[0]);
+        Assert.Equal(0, t.Shape[1]);
+        Assert.Equal(8, t.Shape[2]);
+    }
+}


### PR DESCRIPTION
## Summary
- Replace `checked(int * int)` dim-product in `TensorAllocator.Rent` and `RentPinned` with `long` accumulation
- When the long product exceeds `Int32.MaxValue` (~Array.MaxLength), throw `InvalidOperationException` naming the requested shape, the long element count, and a concrete next step (`WeightRegistry.AllocateStreaming` or shard the tensor)
- Negative dim now throws `ArgumentOutOfRangeException` naming the index and value, plus a hint about lazy-layer `-1` sentinel propagation
- Add null-shape guards and 7 regression tests

## Background
On AiDotNet PR [#1408](https://github.com/ooples/AiDotNet/pull/1408) SonarCloud run 26241806890, several models hit the silent `System.OverflowException` from inside `checked(int * int)` — TimeMachine, DQN, OWLViT, DGCNN, TabTransformer, TabDPT, SlimSAM, TriaffineNER. The stack trace named the multiplication, not the requested shape, so we couldn't tell whether the alloc was 2 B + 1 elements (a realistic large-tensor case worth routing through the streaming pool) or a real bug (e.g. a lazy layer that forgot to resolve its `-1` input-dim sentinel before calling `Rent`).

## Test plan
- [x] `tests/AiDotNet.Tensors.Tests/Helpers/TensorAllocatorOverflowTests.cs` — 7 tests, all green on `net10.0` and `net471`
- [x] Full Tensors build green on `Release` (`dotnet build src/AiDotNet.Tensors/AiDotNet.Tensors.csproj -c Release`)
- [ ] CI green on all targets

## Follow-up (not in this PR)
- Active routing through `WeightRegistry.AllocateStreaming` when an in-scope streaming context is available — currently the allocator only diagnoses the overflow and points the caller at it. Real routing requires deciding which alloc sites (training-loop arena vs weight-tier) can safely take a sharded / streaming backing tensor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)