### PR TITLE
fix(#415): 8 follow-up bug fixes after PR #423 (GPU kernels, FP64 fallbacks, view contract, AVX-512 recursion)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -38,6 +38,14 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     private readonly Tensor<T>[] _preAllocatedGrads;
     private readonly Tensor<T> _lossGradSeed;
     private readonly List<GCHandle> _pinnedHandles = new();
+    // CodeRabbit #425 review: GPU optimizer state (gpuM/gpuV) is owned by the
+    // plan once allocated via paramBackend.AllocateBuffer in
+    // ConfigureOptimizerFloat / ConfigureOptimizerFloatGrouped, but pre-fix
+    // Dispose() only freed _pinnedHandles. Tracking the per-parameter
+    // optimizer-state buffers here so Dispose() (and reconfigure) can free
+    // them — otherwise device memory leaks for every gpuM/gpuV across the
+    // plan's lifetime, which is unbounded for long-running training.
+    private readonly List<Engines.DirectGpu.IGpuBuffer> _gpuOptimizerBuffers = new();
     private bool _disposed;
 
     // Phase G.4: rebuild state captured at compile time so
@@ -112,6 +120,13 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 handle.Free();
         }
         _pinnedHandles.Clear();
+        // CodeRabbit #425: release GPU optimizer state. Buffers are added in
+        // ConfigureOptimizerFloat / ConfigureOptimizerFloatGrouped after the
+        // paramBackend.AllocateBuffer calls; reconfiguring also disposes
+        // these via the same list before re-allocating.
+        foreach (var buf in _gpuOptimizerBuffers)
+            buf.Dispose();
+        _gpuOptimizerBuffers.Clear();
     }
 
     public Tensor<T>[] Gradients => _gradients;
@@ -650,6 +665,14 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     private unsafe void ConfigureOptimizerFloat(
         OptimizerType optimizerType, LrSchedule schedule, float beta1, float beta2, float eps, float weightDecay)
     {
+        // CodeRabbit #425: reconfigure releases any prior GPU optimizer-state
+        // buffers. Without this the device memory grows every time the user
+        // calls ConfigureOptimizer (e.g., to switch from SGD to Adam mid-run
+        // or to retune lr via re-configure with a fresh schedule).
+        foreach (var buf in _gpuOptimizerBuffers)
+            buf.Dispose();
+        _gpuOptimizerBuffers.Clear();
+
         // Pre-allocate optimizer state buffers for each parameter
         int paramCount = _parameters.Length;
         var paramArrays = new float[paramCount][];
@@ -734,8 +757,16 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 {
                     gradArrays[p] = Array.Empty<float>();
                 }
-                if (needsMomentum) gpuM[p] = paramBackend.AllocateBuffer(lengths[p]);
-                if (needsSecondMoment) gpuV[p] = paramBackend.AllocateBuffer(lengths[p]);
+                if (needsMomentum)
+                {
+                    gpuM[p] = paramBackend.AllocateBuffer(lengths[p]);
+                    _gpuOptimizerBuffers.Add(gpuM[p]!);
+                }
+                if (needsSecondMoment)
+                {
+                    gpuV[p] = paramBackend.AllocateBuffer(lengths[p]);
+                    _gpuOptimizerBuffers.Add(gpuV[p]!);
+                }
                 // Skip the CPU live-backing check entirely — we're on GPU.
                 m[p] = Array.Empty<float>();
                 v[p] = Array.Empty<float>();
@@ -847,9 +878,22 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     switch (optType)
                     {
                         case OptimizerType.SGD:
+                            // CodeRabbit #425: GPU SgdUpdate folds in wd via L2
+                            // regularization (grad += wd*param). Apply the same
+                            // semantics on CPU so ConfigureOptimizer(..., weightDecay)
+                            // behaves identically across CPU and GPU. PyTorch's
+                            // torch.optim.SGD(weight_decay=...) uses this convention.
+                            if (wd != 0f)
+                                for (int i = 0; i < len; i++) pGrad[i] += wd * pParam[i];
                             FusedOptimizer.SgdUpdateSimd(pParam, pGrad, len, lr);
                             break;
                         case OptimizerType.Adam:
+                            // CodeRabbit #425: same L2-regularization wd application
+                            // as SGD above so CPU/GPU Adam stay consistent.
+                            // (AdamW uses decoupled weight decay, handled below
+                            // by the dedicated AdamWUpdateSimd kernel.)
+                            if (wd != 0f)
+                                for (int i = 0; i < len; i++) pGrad[i] += wd * pParam[i];
                             FusedOptimizer.AdamUpdateSimd(pParam, pGrad, pM, pV, len,
                                 lr, b1, b2, epsVal, _optimizerStep);
                             break;
@@ -873,6 +917,12 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         System.Collections.Generic.IReadOnlyList<int> paramToGroup,
         float beta1, float beta2, float eps, float weightDecay)
     {
+        // CodeRabbit #425: reconfigure releases prior GPU optimizer-state.
+        // See ConfigureOptimizerFloat for the rationale.
+        foreach (var buf in _gpuOptimizerBuffers)
+            buf.Dispose();
+        _gpuOptimizerBuffers.Clear();
+
         int paramCount = _parameters.Length;
         int groupCount = groupSchedules.Count;
         var paramArrays = new float[paramCount][];
@@ -931,8 +981,16 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 {
                     gradArrays[p] = Array.Empty<float>();
                 }
-                if (needsMomentum) gpuM[p] = paramBackend.AllocateBuffer(lengths[p]);
-                if (needsSecondMoment) gpuV[p] = paramBackend.AllocateBuffer(lengths[p]);
+                if (needsMomentum)
+                {
+                    gpuM[p] = paramBackend.AllocateBuffer(lengths[p]);
+                    _gpuOptimizerBuffers.Add(gpuM[p]!);
+                }
+                if (needsSecondMoment)
+                {
+                    gpuV[p] = paramBackend.AllocateBuffer(lengths[p]);
+                    _gpuOptimizerBuffers.Add(gpuV[p]!);
+                }
                 m[p] = Array.Empty<float>();
                 v[p] = Array.Empty<float>();
                 paramArrays[p] = Array.Empty<float>();
@@ -1034,9 +1092,16 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     switch (optType)
                     {
                         case OptimizerType.SGD:
+                            // CodeRabbit #425: see ConfigureOptimizerFloat for
+                            // L2-regularization weight-decay rationale (same
+                            // semantics as gpuBe.SgdUpdate's wd parameter).
+                            if (wd != 0f)
+                                for (int i = 0; i < len; i++) pGrad[i] += wd * pParam[i];
                             FusedOptimizer.SgdUpdateSimd(pParam, pGrad, len, lr);
                             break;
                         case OptimizerType.Adam:
+                            if (wd != 0f)
+                                for (int i = 0; i < len; i++) pGrad[i] += wd * pParam[i];
                             FusedOptimizer.AdamUpdateSimd(pParam, pGrad, pM, pV, len,
                                 lr, b1, b2, epsVal, _optimizerStep);
                             break;
@@ -3118,6 +3183,40 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     private static void ClipGradientsGlobalL2(Tensor<T>[] gradients, double maxNorm)
     {
         if (gradients.Length == 0) return;
+
+        // CodeRabbit #425 review: detect GPU-resident gradients before the CPU
+        // clip loop. Pre-fix the CPU pass would compute the L2 norm over a
+        // stale CPU backing (a GPU-resident tensor's host array is empty /
+        // uninitialised; the live data lives in backend memory). The norm
+        // came out as zero (or garbage), the scale was applied to the stale
+        // CPU buffer that the optimizer's GPU fast path never reads, and the
+        // optimizer step consumed the un-clipped GPU buffer — silently
+        // defeating SetMaxGradNorm whenever any parameter sat on GPU.
+        //
+        // Implementing the clip natively on GPU would require an in-place
+        // host→device upload primitive on IGpuBuffer (only OpenCL has it
+        // today; HIP/CUDA/WebGpu/Vulkan/Metal would all need new code) plus
+        // a scaled-axpy kernel on each backend — that's a feature, not a
+        // bug fix, and out of scope for the #415 follow-up cluster. For now
+        // we fail fast with an actionable message so the user knows their
+        // clip setting is unenforceable in the current configuration rather
+        // than training with silently bad behaviour.
+        for (int p = 0; p < gradients.Length; p++)
+        {
+            var tensor = gradients[p];
+            if (tensor == null) continue;
+            if (tensor.TryGetGpuBuffer() is not null)
+            {
+                throw new NotSupportedException(
+                    $"SetMaxGradNorm(maxNorm={maxNorm}) is not yet supported when any parameter " +
+                    $"gradient is GPU-resident (parameter {p}, shape [{string.Join(",", tensor.Shape)}] " +
+                    $"lives on backend '{tensor._gpuBackend?.BackendName}'). Native GPU clipping " +
+                    $"requires an in-place host→device upload primitive on IGpuBuffer that's not yet " +
+                    $"in the interface. Workarounds: (a) call SetMaxGradNorm(0) to disable clipping, " +
+                    $"(b) move the model to CPU for training, or (c) file a Tensors issue to track " +
+                    $"native GPU clip implementation. This guard replaces the prior silent no-op.");
+            }
+        }
 
         // Step 1: total L2 norm across all parameter gradients. Reads through
         // the `T` element type so float and double both work without per-type

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -661,6 +661,19 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         // Second moment buffers (Adam, RMSprop, etc.)
         var v = new float[paramCount][];
 
+        // GPU path state (parallel arrays to paramArrays etc.). For each
+        // parameter that's GPU-resident, gpuParam[p] / gpuGrad[p] hold the
+        // live IGpuBuffer and the per-step closure dispatches to the
+        // backend's fused SGD/Adam kernels instead of pinning a CPU array.
+        // CPU-resident params keep paramArrays[p] / gradArrays[p] non-null
+        // and the GPU slots stay null — single branch per parameter at
+        // step time picks the right path.
+        var gpuParam = new Engines.DirectGpu.IGpuBuffer?[paramCount];
+        var gpuGrad = new Engines.DirectGpu.IGpuBuffer?[paramCount];
+        var gpuM = new Engines.DirectGpu.IGpuBuffer?[paramCount];
+        var gpuV = new Engines.DirectGpu.IGpuBuffer?[paramCount];
+        var gpuBackends = new Engines.DirectGpu.IDirectGpuBackend?[paramCount];
+
         // Issue #350: GetDataArray() returns a COPY when the parameter tensor's
         // backing storage is pool-padded (e.g. logical length 6 on a 16-slot
         // ArrayPool bucket — common on net8+ where pool rent rounds up to
@@ -669,52 +682,95 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         // success and the parameter never actually moves. The live-backing
         // accessor below is "allowing padding" because the fused kernel reads
         // exactly `lengths[p]` elements (the logical tensor size), never
-        // touching the pool-padding tail. For non-trivial layouts (views,
-        // non-zero offset, GPU-resident) the live-backing accessor returns
-        // null and we throw — that's a "should never happen for params
-        // registered with CompileTraining" condition and a silent fallback to
-        // a copy would just resurrect this bug.
+        // touching the pool-padding tail.
         for (int p = 0; p < paramCount; p++)
         {
-            var liveParam = _parameters[p].GetLiveBackingArrayAllowingPaddingOrNull();
-            if (liveParam is null)
-                throw new InvalidOperationException(
-                    $"Parameter {p} (shape [{string.Join(",", _parameters[p].Shape)}]) has a layout that does not expose " +
-                    $"a live CPU backing array (non-contiguous view, non-zero storageOffset, or non-CPU device). " +
-                    $"ConfigureOptimizer requires every registered parameter to be a contiguous CPU tensor so " +
-                    $"the fused optimizer step can mutate the caller's tensor in place. Call .Contiguous() / " +
-                    $"copy the parameter to CPU before registering it with CompileTraining.");
-            paramArrays[p] = (float[])(object)liveParam;
-            if (_gradients[p] is not null)
-            {
-                // Mirror the parameter contract: gradients also have to expose
-                // a live CPU backing array. A copy-fallback here would let
-                // _optimizerUpdate's `fixed (T* pGrad = gradArrays[p])` read
-                // a snapshot taken at compile time while backward writes to a
-                // different storage — the same stale-buffer bug the parameter
-                // fix above is fixing, but on the gradient side. Fail fast so
-                // the bug cannot resurrect through the gradient path.
-                var liveGrad = _gradients[p].GetLiveBackingArrayAllowingPaddingOrNull();
-                if (liveGrad is null)
-                    throw new InvalidOperationException(
-                        $"Gradient {p} (shape [{string.Join(",", _gradients[p].Shape)}]) has a layout that does not expose " +
-                        $"a live CPU backing array (non-contiguous view, non-zero storageOffset, or non-CPU device). " +
-                        $"ConfigureOptimizer requires live gradient storage so the fused optimizer step reads the " +
-                        $"current gradient values produced by each plan.Step()'s backward pass.");
-                gradArrays[p] = (float[])(object)liveGrad;
-            }
-            else
-            {
-                gradArrays[p] = Array.Empty<float>();
-            }
             lengths[p] = _parameters[p].Length;
-
             bool needsMomentum = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
                 or OptimizerType.SGDMomentum or OptimizerType.Lion or OptimizerType.Nadam
                 or OptimizerType.AdaMax or OptimizerType.AMSGrad;
             bool needsSecondMoment = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
                 or OptimizerType.RMSprop or OptimizerType.Nadam or OptimizerType.AMSGrad
                 or OptimizerType.Adagrad;
+
+            // GPU fast path: param is GPU-resident → allocate matching GPU
+            // state buffers and dispatch to backend kernels. Backends ship
+            // SgdUpdate / AdamUpdate / AdamWUpdate for every supported
+            // device (CUDA / HIP / OpenCL / Metal) so the fused kernel runs
+            // on-device with no CPU round-trip.
+            var paramGpuBuf = _parameters[p].TryGetGpuBuffer();
+            var paramBackend = _parameters[p]._gpuBackend;
+            if (paramGpuBuf is not null && paramBackend is not null
+                && typeof(T) == typeof(float))
+            {
+                gpuParam[p] = paramGpuBuf;
+                gpuBackends[p] = paramBackend;
+                // Gradient may be CPU or GPU. If CPU (the common case where
+                // backward ran on the engine the tape was bound to, which
+                // for a GPU-resident param SHOULD also be GPU but isn't
+                // guaranteed), upload to a transient GPU buffer each step
+                // — but our common case is gradient is GPU because tape
+                // backward routes through the same engine as forward.
+                if (_gradients[p] is not null)
+                {
+                    var gradGpuBuf = _gradients[p].TryGetGpuBuffer();
+                    if (gradGpuBuf is not null)
+                    {
+                        gpuGrad[p] = gradGpuBuf;
+                    }
+                    else
+                    {
+                        // Gradient is CPU-resident — bind its live CPU
+                        // backing as gradArrays[p]; the per-step closure
+                        // will upload it to a GPU staging buffer.
+                        var liveGrad = _gradients[p].GetLiveBackingArrayAllowingPaddingOrNull();
+                        if (liveGrad is not null)
+                            gradArrays[p] = (float[])(object)liveGrad;
+                        else
+                            gradArrays[p] = Array.Empty<float>();
+                    }
+                }
+                else
+                {
+                    gradArrays[p] = Array.Empty<float>();
+                }
+                if (needsMomentum) gpuM[p] = paramBackend.AllocateBuffer(lengths[p]);
+                if (needsSecondMoment) gpuV[p] = paramBackend.AllocateBuffer(lengths[p]);
+                // Skip the CPU live-backing check entirely — we're on GPU.
+                m[p] = Array.Empty<float>();
+                v[p] = Array.Empty<float>();
+                paramArrays[p] = Array.Empty<float>();
+                continue;
+            }
+
+            // CPU path. For non-trivial layouts (views, non-zero offset)
+            // the live-backing accessor returns null and we throw — that's
+            // a "should never happen for params registered with
+            // CompileTraining" condition and a silent fallback to a copy
+            // would just resurrect the Issue #350 stale-buffer bug.
+            var liveParam = _parameters[p].GetLiveBackingArrayAllowingPaddingOrNull();
+            if (liveParam is null)
+                throw new InvalidOperationException(
+                    $"Parameter {p} (shape [{string.Join(",", _parameters[p].Shape)}]) has a layout that does not expose " +
+                    $"a live CPU backing array (non-contiguous view, non-zero storageOffset). " +
+                    $"ConfigureOptimizer requires either a contiguous CPU tensor or a GPU-resident tensor with " +
+                    $"a backend-attached buffer (TryGetGpuBuffer() returns non-null). For non-contiguous views, " +
+                    $"call .Contiguous() before registering with CompileTraining.");
+            paramArrays[p] = (float[])(object)liveParam;
+            if (_gradients[p] is not null)
+            {
+                var liveGrad = _gradients[p].GetLiveBackingArrayAllowingPaddingOrNull();
+                if (liveGrad is null)
+                    throw new InvalidOperationException(
+                        $"Gradient {p} (shape [{string.Join(",", _gradients[p].Shape)}]) has a layout that does not expose " +
+                        $"a live CPU backing array. ConfigureOptimizer requires live gradient storage so the fused " +
+                        $"optimizer step reads the current gradient values produced by each plan.Step()'s backward pass.");
+                gradArrays[p] = (float[])(object)liveGrad;
+            }
+            else
+            {
+                gradArrays[p] = Array.Empty<float>();
+            }
 
             m[p] = needsMomentum ? new float[lengths[p]] : Array.Empty<float>();
             v[p] = needsSecondMoment ? new float[lengths[p]] : Array.Empty<float>();
@@ -737,8 +793,53 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             float lr = (float)lrSchedule.GetLr(_optimizerStep);
             for (int p = 0; p < paramCount; p++)
             {
-                if (gradArrays[p].Length == 0) continue;
                 int len = lengths[p];
+
+                // GPU path: dispatch to backend-native fused optimizer kernel.
+                // Backends own Sgd/Adam/AdamW kernel implementations
+                // (CUDA / HIP / OpenCL / Metal); we just translate the
+                // optimizer enum to the right call. Gradient may be CPU
+                // (uploaded transiently) or GPU (passed through directly).
+                if (gpuParam[p] is { } gpuP && gpuBackends[p] is { } gpuBe)
+                {
+                    Engines.DirectGpu.IGpuBuffer? gradBuf = gpuGrad[p];
+                    bool gradTransient = false;
+                    if (gradBuf is null)
+                    {
+                        if (gradArrays[p].Length == 0) continue; // no grad recorded
+                        gradBuf = gpuBe.AllocateBuffer(gradArrays[p]);
+                        gradTransient = true;
+                    }
+                    try
+                    {
+                        switch (optType)
+                        {
+                            case OptimizerType.SGD:
+                                gpuBe.SgdUpdate(gpuP, gradBuf, lr, wd, len);
+                                break;
+                            case OptimizerType.Adam:
+                                gpuBe.AdamUpdate(gpuP, gradBuf, gpuM[p]!, gpuV[p]!,
+                                    lr, b1, b2, epsVal, wd, _optimizerStep, len);
+                                break;
+                            case OptimizerType.AdamW:
+                                gpuBe.AdamWUpdate(gpuP, gradBuf, gpuM[p]!, gpuV[p]!,
+                                    lr, b1, b2, epsVal, wd, _optimizerStep, len);
+                                break;
+                            default:
+                                throw new NotSupportedException(
+                                    $"Optimizer type {optType} is not yet supported by ConfigureOptimizer on GPU. " +
+                                    $"Supported: SGD, Adam, AdamW.");
+                        }
+                    }
+                    finally
+                    {
+                        if (gradTransient) gradBuf.Dispose();
+                    }
+                    continue;
+                }
+
+                // CPU path: pin live backing + SIMD kernel.
+                if (gradArrays[p].Length == 0) continue;
 
                 fixed (float* pParam = paramArrays[p], pGrad = gradArrays[p],
                        pM = m[p], pV = v[p])
@@ -786,19 +887,68 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         for (int g = 0; g < groupCount; g++) schedules[g] = groupSchedules[g];
         for (int p = 0; p < paramCount; p++) paramGroup[p] = paramToGroup[p];
 
+        // GPU path state (parallel arrays — same scheme as ConfigureOptimizerFloat).
+        var gpuParam = new Engines.DirectGpu.IGpuBuffer?[paramCount];
+        var gpuGrad = new Engines.DirectGpu.IGpuBuffer?[paramCount];
+        var gpuM = new Engines.DirectGpu.IGpuBuffer?[paramCount];
+        var gpuV = new Engines.DirectGpu.IGpuBuffer?[paramCount];
+        var gpuBackends = new Engines.DirectGpu.IDirectGpuBackend?[paramCount];
+
         // Issue #350: live-backing binding (see ConfigureOptimizerFloat).
         for (int p = 0; p < paramCount; p++)
         {
+            lengths[p] = _parameters[p].Length;
+            bool needsMomentum = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
+                or OptimizerType.SGDMomentum or OptimizerType.Lion or OptimizerType.Nadam
+                or OptimizerType.AdaMax or OptimizerType.AMSGrad;
+            bool needsSecondMoment = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
+                or OptimizerType.RMSprop or OptimizerType.Nadam or OptimizerType.AMSGrad
+                or OptimizerType.Adagrad;
+
+            // GPU fast path — same logic as ConfigureOptimizerFloat. See
+            // there for the full rationale on per-param GPU/CPU dispatch.
+            var paramGpuBuf = _parameters[p].TryGetGpuBuffer();
+            var paramBackend = _parameters[p]._gpuBackend;
+            if (paramGpuBuf is not null && paramBackend is not null
+                && typeof(T) == typeof(float))
+            {
+                gpuParam[p] = paramGpuBuf;
+                gpuBackends[p] = paramBackend;
+                if (_gradients[p] is not null)
+                {
+                    var gradGpuBuf = _gradients[p].TryGetGpuBuffer();
+                    if (gradGpuBuf is not null)
+                    {
+                        gpuGrad[p] = gradGpuBuf;
+                    }
+                    else
+                    {
+                        var liveGrad = _gradients[p].GetLiveBackingArrayAllowingPaddingOrNull();
+                        gradArrays[p] = liveGrad is not null ? (float[])(object)liveGrad : Array.Empty<float>();
+                    }
+                }
+                else
+                {
+                    gradArrays[p] = Array.Empty<float>();
+                }
+                if (needsMomentum) gpuM[p] = paramBackend.AllocateBuffer(lengths[p]);
+                if (needsSecondMoment) gpuV[p] = paramBackend.AllocateBuffer(lengths[p]);
+                m[p] = Array.Empty<float>();
+                v[p] = Array.Empty<float>();
+                paramArrays[p] = Array.Empty<float>();
+                continue;
+            }
+
             var liveParam = _parameters[p].GetLiveBackingArrayAllowingPaddingOrNull();
             if (liveParam is null)
                 throw new InvalidOperationException(
                     $"Parameter {p} (shape [{string.Join(",", _parameters[p].Shape)}]) has a layout that does not expose " +
-                    $"a live CPU backing array (non-contiguous view, non-zero storageOffset, or non-CPU device). " +
-                    $"ConfigureOptimizerGrouped requires every registered parameter to be a contiguous CPU tensor.");
+                    $"a live CPU backing array (non-contiguous view, non-zero storageOffset). " +
+                    $"ConfigureOptimizerGrouped requires either a contiguous CPU tensor or a GPU-resident tensor with " +
+                    $"a backend-attached buffer (TryGetGpuBuffer() returns non-null).");
             paramArrays[p] = (float[])(object)liveParam;
             if (_gradients[p] is not null)
             {
-                // Fail fast on copy-fallback (see ConfigureOptimizerFloat for full rationale).
                 var liveGrad = _gradients[p].GetLiveBackingArrayAllowingPaddingOrNull();
                 if (liveGrad is null)
                     throw new InvalidOperationException(
@@ -810,14 +960,6 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             {
                 gradArrays[p] = Array.Empty<float>();
             }
-            lengths[p] = _parameters[p].Length;
-
-            bool needsMomentum = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
-                or OptimizerType.SGDMomentum or OptimizerType.Lion or OptimizerType.Nadam
-                or OptimizerType.AdaMax or OptimizerType.AMSGrad;
-            bool needsSecondMoment = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
-                or OptimizerType.RMSprop or OptimizerType.Nadam or OptimizerType.AMSGrad
-                or OptimizerType.Adagrad;
 
             m[p] = needsMomentum ? new float[lengths[p]] : Array.Empty<float>();
             v[p] = needsSecondMoment ? new float[lengths[p]] : Array.Empty<float>();
@@ -842,9 +984,49 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
             for (int p = 0; p < paramCount; p++)
             {
-                if (gradArrays[p].Length == 0) continue;
                 int len = lengths[p];
                 float lr = groupLrs[paramGroup[p]];
+
+                // GPU path (mirrors ConfigureOptimizerFloat).
+                if (gpuParam[p] is { } gpuP && gpuBackends[p] is { } gpuBe)
+                {
+                    Engines.DirectGpu.IGpuBuffer? gradBuf = gpuGrad[p];
+                    bool gradTransient = false;
+                    if (gradBuf is null)
+                    {
+                        if (gradArrays[p].Length == 0) continue;
+                        gradBuf = gpuBe.AllocateBuffer(gradArrays[p]);
+                        gradTransient = true;
+                    }
+                    try
+                    {
+                        switch (optType)
+                        {
+                            case OptimizerType.SGD:
+                                gpuBe.SgdUpdate(gpuP, gradBuf, lr, wd, len);
+                                break;
+                            case OptimizerType.Adam:
+                                gpuBe.AdamUpdate(gpuP, gradBuf, gpuM[p]!, gpuV[p]!,
+                                    lr, b1, b2, epsVal, wd, _optimizerStep, len);
+                                break;
+                            case OptimizerType.AdamW:
+                                gpuBe.AdamWUpdate(gpuP, gradBuf, gpuM[p]!, gpuV[p]!,
+                                    lr, b1, b2, epsVal, wd, _optimizerStep, len);
+                                break;
+                            default:
+                                throw new NotSupportedException(
+                                    $"Optimizer type {optType} is not yet supported by ConfigureOptimizerGrouped on GPU. " +
+                                    $"Supported: SGD, Adam, AdamW.");
+                        }
+                    }
+                    finally
+                    {
+                        if (gradTransient) gradBuf.Dispose();
+                    }
+                    continue;
+                }
+
+                if (gradArrays[p].Length == 0) continue;
 
                 fixed (float* pParam = paramArrays[p], pGrad = gradArrays[p],
                        pM = m[p], pV = v[p])

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/ActivationKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/ActivationKernels.cs
@@ -66,7 +66,10 @@ inline float fast_exp1(float x) {
 // ACTIVATION KERNELS
 // ===========================================================================
 
-// ReLU: max(0, x)
+// ReLU: max(0, x) — NaN-preserving.
+// fmax(0, NaN) returns 0 in OpenCL because NaN compares as less-than,
+// silently zeroing incoming NaN values. CPU ReluNaNSafe* preserves NaN
+// as a debugging signal — match that contract here too.
 __kernel void relu(
     __global const float* input,
     __global float* output,
@@ -76,9 +79,18 @@ __kernel void relu(
     const int idx4 = idx * 4;
     if (idx4 + 3 < size) {
         float4 x = vload4(idx, input);
-        vstore4(fmax((float4)(0.0f), x), idx, output);
+        // isnan returns int4 mask (all-ones per NaN lane); select() returns
+        // the NaN where the mask is set, fmax otherwise. The fmax branch is
+        // safe for non-NaN inputs.
+        float4 zero = (float4)(0.0f);
+        float4 m = fmax(zero, x);
+        int4 nanMask = isnan(x);
+        vstore4(select(m, x, nanMask), idx, output);
     } else {
-        for (int i = idx4; i < size; i++) output[i] = fmax(0.0f, input[i]);
+        for (int i = idx4; i < size; i++) {
+            float v = input[i];
+            output[i] = isnan(v) ? v : fmax(0.0f, v);
+        }
     }
 }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/FFTKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/FFTKernels.cs
@@ -74,17 +74,18 @@ __kernel void batched_bit_reverse(
     }
 }
 
-// Cooley-Tukey FFT butterfly operation for a single stage
+// Cooley-Tukey FFT butterfly operation for a single stage.
+// `fullSize` is the butterfly span at this stage (2, 4, 8, ..., n) — the host
+// loops `for (size = 2; size <= n; size *= 2)` and passes that directly.
 __kernel void fft_butterfly(
     __global float* real,
     __global float* imag,
     const int n,
-    const int stage,
+    const int fullSize,
     const int inverse)
 {
     int tid = get_global_id(0);
-    int halfSize = 1 << stage;
-    int fullSize = halfSize << 1;
+    int halfSize = fullSize >> 1;
     int numGroups = n / fullSize;
 
     int groupIdx = tid / halfSize;
@@ -114,13 +115,13 @@ __kernel void fft_butterfly(
     imag[j] = uImag - tImag;
 }
 
-// Batched FFT butterfly for multiple signals
+// Batched FFT butterfly for multiple signals (`fullSize` semantics — see fft_butterfly)
 __kernel void batched_fft_butterfly(
     __global float* real,
     __global float* imag,
     const int batch,
     const int n,
-    const int stage,
+    const int fullSize,
     const int inverse)
 {
     int tid = get_global_id(0);
@@ -131,8 +132,7 @@ __kernel void batched_fft_butterfly(
     int batchIdx = tid / (n / 2);
     int localTid = tid % (n / 2);
 
-    int halfSize = 1 << stage;
-    int fullSize = halfSize << 1;
+    int halfSize = fullSize >> 1;
     int numGroups = n / fullSize;
 
     int groupIdx = localTid / halfSize;
@@ -440,7 +440,7 @@ __kernel void fft_rows_butterfly(
     __global float* imag,
     const int height,
     const int width,
-    const int stage,
+    const int fullSize,
     const int inverse)
 {
     int tid = get_global_id(0);
@@ -449,8 +449,7 @@ __kernel void fft_rows_butterfly(
 
     if (row >= height) return;
 
-    int halfSize = 1 << stage;
-    int fullSize = halfSize << 1;
+    int halfSize = fullSize >> 1;
     int numGroups = width / fullSize;
 
     int groupIdx = localTid / halfSize;
@@ -484,7 +483,7 @@ __kernel void fft_cols_butterfly(
     __global float* imag,
     const int height,
     const int width,
-    const int stage,
+    const int fullSize,
     const int inverse)
 {
     int tid = get_global_id(0);
@@ -493,8 +492,7 @@ __kernel void fft_cols_butterfly(
 
     if (col >= width) return;
 
-    int halfSize = 1 << stage;
-    int fullSize = halfSize << 1;
+    int halfSize = fullSize >> 1;
     int numGroups = height / fullSize;
 
     int groupIdx = localTid / halfSize;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -3074,7 +3074,31 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
         private void ExecuteUnary(string kernelName, IGpuBuffer A, IGpuBuffer B, int size)
         {
-            ExecuteActivation(kernelName, A, B, size);
+            // The kernels routed through ExecuteUnary (negate_vector, floor_vector,
+            // ceil_vector, round_vector, trunc_vector) are SCALAR — one element per
+            // work item with an `if (idx >= size) return` early-out. Activation
+            // kernels (relu, sigmoid, etc) routed directly through ExecuteActivation
+            // are float4-vectorized. ExecuteActivation launches `(size+3)/4` work
+            // items assuming the float4 layout — that's correct for activations but
+            // catastrophically wrong for scalar kernels: only the first
+            // ceil(size/4) elements get a work item, so for size=3 only B[0] is
+            // written and B[1..2] stay at their pre-launch (post-allocation,
+            // device-default-zero) values. Manifests as TensorNegate returning
+            // [-1, 0, 0] for input [1, 1, 1] on the backward path. Fix: launch
+            // exactly `size` work items so every element gets one.
+            if (_context == null)
+                throw new InvalidOperationException("OpenCL context not available");
+
+            var bufferA = ((DirectOpenClGpuBuffer)A).Buffer;
+            var bufferB = ((DirectOpenClGpuBuffer)B).Buffer;
+
+            var kernel = _kernelCache[kernelName];
+            kernel.SetArg(0, bufferA.Handle);
+            kernel.SetArg(1, bufferB.Handle);
+            kernel.SetArg(2, size);
+
+            int localSize = CalculateOptimalWorkGroupSize1D(size);
+            kernel.Execute1D(size, localSize);
         }
 
         public void Relu(IGpuBuffer A, IGpuBuffer B, int size)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClKernelSources.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClKernelSources.cs
@@ -277,7 +277,11 @@ internal static class OpenClKernelSources
         __kernel void relu(__global const float* input, __global float* output, const int size) {
             int idx = get_global_id(0);
             if (idx >= size) return;
-            output[idx] = fmax(0.0f, input[idx]);
+            // NaN-preserving: fmax(0, NaN) returns 0 in OpenCL (NaN compares
+            // as "less than"), silently zeroing NaN. CPU ReluNaNSafe* preserves
+            // NaN as a numerical-blowup signal — match that contract.
+            float v = input[idx];
+            output[idx] = isnan(v) ? v : fmax(0.0f, v);
         }
 
         __kernel void sigmoid(__global const float* input, __global float* output, const int size) {

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -16174,6 +16174,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             return base.NativeComplexMultiply(a ?? throw new ArgumentNullException(nameof(a)), b ?? throw new ArgumentNullException(nameof(b)));
         if (!TryGetBackend(out var backend))
             return base.NativeComplexMultiply(a, b);
+        if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
+            return base.NativeComplexMultiply(a, b);
 
         try
         {
@@ -16481,6 +16483,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     {
         if (!TryGetBackend(out var backend))
             return base.NativeComplexConjugate(a);
+        if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
+            return base.NativeComplexConjugate(a);
 
         try
         {
@@ -16504,6 +16508,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     {
         if (!TryGetBackend(out var backend))
             return base.NativeComplexMagnitude(a);
+        if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
+            return base.NativeComplexMagnitude(a);
 
         try
         {
@@ -16524,6 +16530,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     public override Tensor<T> NativeComplexMagnitudeSquared<T>(Tensor<Complex<T>> a)
     {
         if (!TryGetBackend(out var backend))
+            return base.NativeComplexMagnitudeSquared(a);
+        if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
             return base.NativeComplexMagnitudeSquared(a);
 
         try
@@ -16546,6 +16554,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     {
         if (!TryGetBackend(out var backend))
             return base.NativeComplexPhase(a);
+        if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
+            return base.NativeComplexPhase(a);
 
         try
         {
@@ -16566,6 +16576,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     public override Tensor<Complex<T>> NativeComplexFromPolar<T>(Tensor<T> magnitudes, Tensor<T> phases)
     {
         if (!TryGetBackend(out var backend))
+            return base.NativeComplexFromPolar(magnitudes, phases);
+        if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
             return base.NativeComplexFromPolar(magnitudes, phases);
 
         try
@@ -16597,6 +16609,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     {
         if (!TryGetBackend(out var backend))
             return base.NativeComplexScale(a, scalar);
+        if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
+            return base.NativeComplexScale(a, scalar);
 
         try
         {
@@ -16624,6 +16638,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             return base.NativeComplexAdd(a ?? throw new ArgumentNullException(nameof(a)), b ?? throw new ArgumentNullException(nameof(b)));
         if (!TryGetBackend(out var backend))
             return base.NativeComplexAdd(a, b);
+        if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
+            return base.NativeComplexAdd(a, b);
 
         try
         {
@@ -16650,6 +16666,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     public override Tensor<Complex<T>> NativeComplexFFTComplex<T>(Tensor<Complex<T>> input)
     {
         if (!TryGetBackend(out var backend))
+            return base.NativeComplexFFTComplex(input);
+        if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
             return base.NativeComplexFFTComplex(input);
 
         try
@@ -16685,6 +16703,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (k <= 0)
             throw new ArgumentException("k must be positive.", nameof(k));
         if (!TryGetBackend(out var backend))
+            return base.NativeComplexTopK(input, k);
+        if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
             return base.NativeComplexTopK(input, k);
 
         try
@@ -16739,6 +16759,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             return base.NativeComplexCrossSpectral(x ?? throw new ArgumentNullException(nameof(x)), y ?? throw new ArgumentNullException(nameof(y)));
         if (!TryGetBackend(out var backend))
             return base.NativeComplexCrossSpectral(x, y);
+        if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
+            return base.NativeComplexCrossSpectral(x, y);
 
         try
         {
@@ -16765,6 +16787,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     public override Tensor<Complex<T>> NativeComplexFFT<T>(Tensor<T> input)
     {
         if (!TryGetBackend(out var backend))
+            return base.NativeComplexFFT(input);
+        if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
             return base.NativeComplexFFT(input);
 
         try
@@ -16801,6 +16825,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     {
         if (!TryGetBackend(out var backend))
             return base.NativeComplexIFFTReal(input);
+        if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
+            return base.NativeComplexIFFTReal(input);
 
         try
         {
@@ -16830,6 +16856,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     public override Tensor<Complex<T>> NativeComplexIFFT<T>(Tensor<Complex<T>> input)
     {
         if (!TryGetBackend(out var backend))
+            return base.NativeComplexIFFT(input);
+        if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
             return base.NativeComplexIFFT(input);
 
         try
@@ -16862,6 +16890,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (input is null || input.Rank < 2)
             return base.NativeComplexFFT2D(input ?? throw new ArgumentNullException(nameof(input)));
         if (!TryGetBackend(out var backend))
+            return base.NativeComplexFFT2D(input);
+        if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
             return base.NativeComplexFFT2D(input);
 
         try
@@ -16900,6 +16930,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             return base.NativeComplexIFFT2DReal(input ?? throw new ArgumentNullException(nameof(input)));
         if (!TryGetBackend(out var backend))
             return base.NativeComplexIFFT2DReal(input);
+        if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
+            return base.NativeComplexIFFT2DReal(input);
 
         try
         {
@@ -16934,6 +16966,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 input ?? throw new ArgumentNullException(nameof(input)),
                 filter ?? throw new ArgumentNullException(nameof(filter)));
         if (!TryGetBackend(out var backend))
+            return base.NativeSpectralFilter(input, filter);
+        if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
             return base.NativeSpectralFilter(input, filter);
 
         try
@@ -16997,6 +17031,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 input ?? throw new ArgumentNullException(nameof(input)),
                 filter ?? throw new ArgumentNullException(nameof(filter)));
         if (!TryGetBackend(out var backend))
+            return base.NativeSpectralFilterBatch(input, filter);
+        if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
             return base.NativeSpectralFilterBatch(input, filter);
 
         try

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -14391,6 +14391,16 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     public override Tensor<T> ReLU<T>(Tensor<T> tensor)
     {
+        // Stage 8 precision-fallback gate. TryRunUnary upload converts T→float
+        // inside GetOrAllocateBuffer and the download converts float→T. For
+        // T=double the round-trip silently loses ~7 mantissa bits per element,
+        // showing up as a 2.2e-9 drift in FusedConv2DDoublePerfTests.
+        // FusedConv2D_Double_ReLU_MatchesConvPlusBroadcastAddPlusReLU (Path A
+        // = Conv2D + BroadcastAdd + ReLU was being fp32-quantised through this
+        // ReLU even after my fallbacks fixed Conv2D + BroadcastAdd).
+        if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
+            return base.ReLU(tensor);
+
         try
         {
             var result = TryRunUnary(tensor, static (backend, input, output, size) => backend.Relu(input, output, size));
@@ -14408,6 +14418,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     public override Tensor<T> GELU<T>(Tensor<T> tensor)
     {
+        if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
+            return base.GELU(tensor);
         try
         {
             var result = TryRunUnary(tensor, static (backend, input, output, size) => backend.Gelu(input, output, size));
@@ -14425,6 +14437,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     public override Tensor<T> Mish<T>(Tensor<T> tensor)
     {
+        if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
+            return base.Mish(tensor);
         try
         {
             var result = TryRunUnary(tensor, static (backend, input, output, size) => backend.Mish(input, output, size));
@@ -14443,6 +14457,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     public override Tensor<T> LeakyReLU<T>(Tensor<T> tensor, T alpha)
     {
         if (!TryGetBackend(out var backend))
+            return base.LeakyReLU(tensor, alpha);
+        if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
             return base.LeakyReLU(tensor, alpha);
 
         try
@@ -14466,6 +14482,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     public override Tensor<T> HardSwish<T>(Tensor<T> input)
     {
+        if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
+            return base.HardSwish(input);
         try
         {
             var result = TryRunUnary(input, static (backend, inp, output, size) => backend.Hardswish(inp, output, size));

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -4082,6 +4082,14 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (!TryGetBackend(out var backend))
             return base.FusedConv2D(input, kernel, bias, strideH, strideW, padH, padW, dilationH, dilationW, activation);
 
+        // Stage 8 precision-fallback gate: this GPU path materialises T into
+        // float[] buffers (see outputFloat / biasFloat below) — for T=double
+        // that silently loses ~7 mantissa bits, which shows up immediately
+        // in FusedConv2DDoublePerfTests at ulp ≤ 1e-9. Route fp64 to the
+        // contract-compliant CPU FusedConv2D direct kernel.
+        if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
+            return base.FusedConv2D(input, kernel, bias, strideH, strideW, padH, padW, dilationH, dilationW, activation);
+
         // Expected input shape: [batch, inChannels, height, width]
         // Expected kernel shape: [outChannels, inChannels, kernelH, kernelW]
         if (input.Rank != 4 || kernel.Rank != 4)
@@ -14482,6 +14490,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     public override Tensor<T> TensorBroadcastAdd<T>(Tensor<T> a, Tensor<T> b)
     {
+        if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
+            return base.TensorBroadcastAdd(a, b);
         if (TryGetBackend(out var backend) && a.Length > b.Length && a.Length % b.Length == 0)
         {
             try
@@ -14504,6 +14514,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     public override Tensor<T> TensorBroadcastSubtract<T>(Tensor<T> a, Tensor<T> b)
     {
+        if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
+            return base.TensorBroadcastSubtract(a, b);
         if (TryGetBackend(out var backend) && a.Length > b.Length && a.Length % b.Length == 0)
         {
             try
@@ -14526,6 +14538,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     public override Tensor<T> TensorBroadcastDivide<T>(Tensor<T> a, Tensor<T> b)
     {
+        if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
+            return base.TensorBroadcastDivide(a, b);
         if (TryGetBackend(out var backend) && a.Length > b.Length && a.Length % b.Length == 0)
         {
             try

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -13236,35 +13236,21 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     public override Tensor<T> TensorPermute<T>(Tensor<T> tensor, int[] axes)
     {
-        // Previously routed through CpuEngine because the CUDA Permute
-        // kernel "is off for non-trivial axes mixes". Root cause for the
-        // 2×D permute fast path was the transpose_2d launch bug above
-        // (CudaBackend.Permute delegates rank-2 permutation [1,0] to
-        // Transpose, and rank-3 [0,2,1] to BatchedTranspose). The
-        // permute_general kernel formula itself is correct
-        // (see verification in CudaNeuralNetKernels.permute_general).
-        // Routing back to GPU now that the underlying transpose dispatch
-        // is fixed.
-        if (IsTapeActive<T>())
-            return base.TensorPermute(tensor, axes);
-        if (!TryGetBackend(out var backend))
-            return base.TensorPermute(tensor, axes);
-
-        try
-        {
-            using var bufIn = GetOrAllocateBuffer(backend, tensor.GetDataArray());
-            var bufOut = AllocateOutputBuffer(backend, tensor.Length);
-            backend.Permute(bufIn.Buffer, bufOut.Buffer, tensor.Shape._dims, axes);
-            var result = FinishGpuOp<T>(backend, bufOut, tensor.Length);
-            int[] outShape = new int[axes.Length];
-            for (int i = 0; i < axes.Length; i++)
-                outShape[i] = tensor.Shape._dims[axes[i]];
-            return new Tensor<T>(result, outShape);
-        }
-        catch (Exception)
-        {
-            return base.TensorPermute(tensor, axes);
-        }
+        // Permute is a view operation by contract — `tensor.Transpose(axes)`
+        // returns a strided view with permuted strides and zero data move.
+        // The GPU path here used to eagerly materialise into a new
+        // contiguous buffer via `backend.Permute(...)`, which violated the
+        // view contract: callers got back IsContiguous == true after a
+        // permute (TensorCopyToTests.StridedAfterPermute_*,
+        // StridedAfterTranspose_*, FloatTensor_CopyTo_WorksSymmetrically
+        // all asserted IsContiguous == false). Worse, it wasted a host→device→
+        // permute→device→host round-trip every time even though the result
+        // was indistinguishable from a metadata-only stride permute.
+        //
+        // Delegate to the CPU/base path which returns the strided view.
+        // Downstream GPU ops that genuinely need contiguous layout call
+        // `.Contiguous()` themselves at the point they need it.
+        return base.TensorPermute(tensor, axes);
     }
 
     /// <inheritdoc/>

--- a/src/AiDotNet.Tensors/Engines/Simd/Avx512SgemmDouble.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/Avx512SgemmDouble.cs
@@ -69,8 +69,14 @@ internal static class Avx512SgemmDouble
             return;
         }
 #endif
-        // AVX2 fallback — Dgemm clears C and runs the existing AVX2 path.
-        SimdGemm.Dgemm(a, b, c, m, k, n);
+        // AVX2/scalar fallback for small or non-aligned shapes. Must use the
+        // non-dispatching helper (DgemmAvx2OrScalar) — calling SimdGemm.Dgemm
+        // would re-check Avx512SgemmDouble.CanUse and recurse back into this
+        // method on AVX-512 hosts for the same misaligned input. Note: the
+        // caller (SimdGemm.Dgemm) has already cleared C before dispatch, so
+        // the AVX2/scalar paths' accumulation against zero produces the same
+        // result they would compute from a fresh C buffer.
+        SimdGemm.DgemmAvx2OrScalar(a, b, c, m, k, n, allowParallel);
     }
 
 #if NET8_0_OR_GREATER

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemmDouble.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemmDouble.cs
@@ -50,10 +50,28 @@ internal static partial class SimdGemm
             return;
         }
 #endif
+        DgemmAvx2OrScalar(a, b, c, m, k, n, allowParallel: true);
+    }
+
+    /// <summary>
+    /// AVX2-or-scalar dispatch with NO AVX-512 re-check. The AVX-512 path
+    /// (Avx512SgemmDouble.DgemmBlocked) calls this from its
+    /// small-or-misaligned fallback; routing back through <see cref="Dgemm"/>
+    /// would re-dispatch into Avx512SgemmDouble.DgemmBlocked on capable
+    /// hosts and recurse forever for any shape that fails the 8×16-aligned
+    /// gate. C must already be cleared by the caller.
+    /// </summary>
+    internal static void DgemmAvx2OrScalar(
+        ReadOnlySpan<double> a,
+        ReadOnlySpan<double> b,
+        Span<double> c,
+        int m, int k, int n,
+        bool allowParallel)
+    {
 #if NET5_0_OR_GREATER
         if (Avx2.IsSupported && Fma.IsSupported)
         {
-            DgemmAvx2(a, b, c, m, k, n, allowParallel: true);
+            DgemmAvx2(a, b, c, m, k, n, allowParallel);
             return;
         }
 #endif
@@ -84,14 +102,7 @@ internal static partial class SimdGemm
             return;
         }
 #endif
-#if NET5_0_OR_GREATER
-        if (Avx2.IsSupported && Fma.IsSupported)
-        {
-            DgemmAvx2(a, b, c, m, k, n, allowParallel: false);
-            return;
-        }
-#endif
-        DgemmScalar(a, b, c, m, k, n);
+        DgemmAvx2OrScalar(a, b, c, m, k, n, allowParallel: false);
     }
 
     // ─────────────────────────────────────────────────────────────────────

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/BackwardBufferPoolingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/BackwardBufferPoolingTests.cs
@@ -19,13 +19,33 @@ namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
 /// 3. All paths must produce numerically identical gradients across repeated steps
 ///    (regression: if a buffer is not cleared/overwritten, step 2+ would return wrong values).
 /// </summary>
+// Serialize with other tests that mutate AiDotNetEngine.Current (the
+// same shared collection used by CompiledBackwardWalkTests etc.) — the
+// constructor swaps the process-wide engine for fixture isolation, so
+// concurrent execution against another fixture that does the same thing
+// would race and corrupt either side's state.
+[Collection("EngineCurrentGlobalState")]
 public class BackwardBufferPoolingTests : IDisposable
 {
     private readonly IEngine _engine;
+    private readonly IEngine _savedEngine;
+    private readonly bool _savedAutoTrainingCompilerEnabled;
+    private readonly bool _savedAutoTrainingCompilerReplayMode;
     private const float Tolerance = 1e-4f;
 
     public BackwardBufferPoolingTests()
     {
+        // Snapshot prior global state so we can restore it in Dispose —
+        // overwriting AiDotNetEngine.Current without restore lets the
+        // fresh CpuEngine leak past the fixture's lifetime and break any
+        // sibling test class that expected its own engine (e.g. tests
+        // that ran with the process default DirectGpuTensorEngine and
+        // assert GPU dispatch). Same rationale for the
+        // AutoTrainingCompiler flags below — they're process-wide.
+        _savedEngine = AiDotNetEngine.Current;
+        _savedAutoTrainingCompilerEnabled = AutoTrainingCompiler.Enabled;
+        _savedAutoTrainingCompilerReplayMode = AutoTrainingCompiler.ReplayMode;
+
         // Reset AiDotNetEngine.Current to a fresh CpuEngine so the tests
         // see a clean singleton state — the long-lived process-wide
         // singleton accumulates cached AutoTracer plans, ReplayMode bits,
@@ -44,9 +64,12 @@ public class BackwardBufferPoolingTests : IDisposable
 
     public void Dispose()
     {
-        AutoTrainingCompiler.Enabled = true;
-        AutoTrainingCompiler.ReplayMode = false;
+        // Restore process-wide state captured in ctor so we don't leak the
+        // fixture's CpuEngine / compiler flag tweaks past the test class.
         AutoTrainingCompiler.ResetState();
+        AutoTrainingCompiler.ReplayMode = _savedAutoTrainingCompilerReplayMode;
+        AutoTrainingCompiler.Enabled = _savedAutoTrainingCompilerEnabled;
+        AiDotNetEngine.Current = _savedEngine;
     }
 
     // ──────────────────────────────────────────────────────────────

--- a/tests/AiDotNet.Tensors.Tests/Engines/GpuFftKernelTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/GpuFftKernelTests.cs
@@ -1,0 +1,53 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Verifies the GPU FFT kernel at FP32 (the precision the kernel actually
+/// implements) produces correct results vs the CPU reference. Regression
+/// guard for an OpenCL bug where the host loop passed `stride` (2,4,8,…,n)
+/// but the kernel reinterpreted it via `halfSize = 1 &lt;&lt; stage`, yielding
+/// completely garbage spectra.
+/// </summary>
+public class GpuFftKernelTests
+{
+    [Fact]
+    public void GpuFft_Fp32_CosWave_MatchesExpectedSpectrum()
+    {
+        int n = 32;
+        var input = new Tensor<float>([n]);
+        for (int i = 0; i < n; i++)
+            input[i] = MathF.Cos(2f * MathF.PI * 3f * i / n);
+
+        var spectrum = AiDotNetEngine.Current.NativeComplexFFT(input);
+
+        // For cos(2π·3·n/32), expect peaks at k=3 and k=29 each with magnitude n/2 = 16.
+        for (int k = 0; k < n; k++)
+        {
+            float mag = MathF.Sqrt(spectrum[k].Real * spectrum[k].Real
+                                 + spectrum[k].Imaginary * spectrum[k].Imaginary);
+            float expected = (k == 3 || k == 29) ? 16f : 0f;
+            Assert.True(MathF.Abs(mag - expected) < 1e-3f,
+                $"spectrum[{k}] magnitude={mag}, expected {expected}");
+        }
+    }
+
+    [Fact]
+    public void GpuFft_Fp32_RoundTrip_RecoverOriginalSignal()
+    {
+        int n = 64;
+        var input = new Tensor<float>([n]);
+        for (int i = 0; i < n; i++)
+            input[i] = MathF.Sin(2f * MathF.PI * 5f * i / n);
+
+        var spectrum = AiDotNetEngine.Current.NativeComplexFFT(input);
+        var recovered = AiDotNetEngine.Current.NativeComplexIFFTReal(spectrum);
+
+        for (int i = 0; i < n; i++)
+            Assert.True(MathF.Abs(input[i] - recovered[i]) < 1e-4f,
+                $"i={i}: input={input[i]}, recovered={recovered[i]}");
+    }
+}


### PR DESCRIPTION
## Summary

PR #423 was squash-merged before these 8 follow-up fixes landed. Each one is a real bug found while addressing review feedback and hunting pre-existing failures on the FP64 perf branch — opening as a separate PR so they reach `main`.

## Commits (oldest first)

1. **`795bbb31` GPU fast path in `ConfigureOptimizer` (FP32 + grouped variants)** — pure-CPU optimizer step on GPU-resident parameters was throwing `"Parameter has a layout that does not expose a live CPU backing array"`. Adds per-parameter GPU dispatch via `TryGetGpuBuffer()` so fused SGD/Adam/AdamW run on the backend.

2. **`2ad564f6` OpenCL `ExecuteUnary` dispatched scalar kernels at float4 work-item count** — `negate_vector`, `floor_vector`, `ceil_vector`, `round_vector`, `trunc_vector` are scalar kernels but were launched with `workItems = (size + 3) / 4`, so e.g. size=3 only fired 1 work item → `Gradient_Negate` returned `[-1, 0, 0]` instead of `[-1, -1, -1]`. Inlined dispatcher launches exactly `size` work items.

3. **`1a03a4b5` FP64 fallback gate on `NativeComplex` FFT/IFFT/spectral overrides** — 17 GPU overrides materialised T→`float[]` at the boundary. For T=double, silent ~7-mantissa-bit loss + (on the OpenCL backend) mathematically wrong FFT output. Extends the Stage 8 `ShouldFallbackForPrecision<T>()` gate. `NativeComplexOpsTests` 26/28 → 28/28.

4. **`b2e9ff5e` OpenCL FFT kernels misinterpreted host's `stride` loop as `log2(halfSize)`** — host loops `for (stride = 2; stride <= n; stride *= 2)` and passes `stride` directly, but the kernel parameter was named `stage` and computed `halfSize = 1 << stage` → every butterfly stage operated on the wrong span. FFT of cos(2π·3·n/32) at bin 3 returned `(0.21, -1.95)` instead of `(16, 0)`. Renamed kernel parameter to `fullSize` (matches CUDA/HIP convention). Adds `GpuFftKernelTests` regression suite.

5. **`1e0b054c` GPU `TensorPermute` violated CPU view contract** — eagerly materialised through a kernel + host→device→host round-trip and returned `IsContiguous == true`. CPU contract is `tensor.Transpose(axes)` — a metadata-only strided view. Fixed 3 `TensorCopyToTests` failures, no regression in 116 permute/transpose tests.

6. **`83ef0a6a` OpenCL ReLU silently zeroed NaN + FP64 fallback for FusedConv2D / broadcast ops** — `fmax(0, NaN)` returns 0 in OpenCL spec (NaN compares as less-than); CPU `ReluNaNSafe*` preserves NaN as a numerical-blowup signal. Fix uses `isnan(v) ? v : fmax(0, v)`. Also gates fp64 on FusedConv2D/Conv2D/TensorBroadcastAdd/Subtract/Divide — same silent fp32 round-trip. `FusedConv2DDoublePerfTests` 1/9 → 4/9.

7. **`ccd131db` GPU ReLU/GELU/Mish/LeakyReLU/HardSwish FP64 fallback** — Stage 8 added the precision gate to 7 generic-T entry points but missed these standalone activation overrides. The `TryRunUnary` upload converts T→float, download converts back → ~7 mantissa bits lost per call. Diagnosed via `refAdd[0]=0.244348125896` → `refOut[0]=0.244348123669` (positive input modified by ReLU — should be identity). `FusedConv2DDoublePerfTests` 4/9 → 9/9.

8. **`d906bd42` AVX-512 fallback recursion + BackwardBufferPoolingTests isolation** — addresses the 2 unresolved CodeRabbit comments on the merged PR #423:
   - `Avx512SgemmDouble.DgemmBlocked`'s small/misaligned fallback called `SimdGemm.Dgemm`, which gates on `Avx512SgemmDouble.CanUse` and re-dispatches into `DgemmBlocked` → infinite recursion on AVX-512 hosts. Fix: extract `SimdGemm.DgemmAvx2OrScalar` non-dispatching helper.
   - `BackwardBufferPoolingTests` overwrote process-wide `AiDotNetEngine.Current` without restoring in `Dispose`, and had no `[Collection]` attribute. Fix: snapshot/restore engine + `AutoTrainingCompiler.{Enabled,ReplayMode}`, add `[Collection("EngineCurrentGlobalState")]`.

## Test plan

- [x] Build clean on net10.0
- [x] `NativeComplexOpsTests`: 28/28 pass (was 26/28)
- [x] `GpuFftKernelTests`: 2/2 pass (new regression suite)
- [x] `LinearAlgebra.TensorCopyToTests`: 13/13 pass (was 10/13)
- [x] `FusedConv2DDoublePerfTests`: 9/9 pass (was 1/9 — diagnosed via per-step ReLU value trace)
- [x] `BackwardBufferPoolingTests`: 9/9 pass
- [x] `TensorMatMul*` matmul fallback tests: 30/30 pass on AVX2-only host (AVX-512 recursion would manifest as stack overflow under small-shape cases)
- [x] `CompileTracerBugfixTests.Issue238` + `SpectralPerfOpsTests`: 22/22 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)