### PR TITLE
feat(#401): SgemmWithInt8RowScaledCachedB — per-row-scaled INT8 weight-only GEMM

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.Int8RowScaled.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.Int8RowScaled.cs
@@ -1,0 +1,559 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Tensors#401 / AiDotNet#1349: per-row-scaled INT8 weight-only GEMM.
+//
+// The existing SgemmWithInt8CachedB computes a per-tensor symmetric scale
+// during pack (one float scale for all of B). AiDotNet's Int8InferenceModel
+// produces per-row scales (one per output channel) via QuantizePerRow, which
+// preserves much more SNR on weight matrices whose row magnitudes vary widely
+// (the common case in trained transformers). Routing AiDotNet's quantized
+// layers through SgemmWithInt8CachedB would require re-quantizing already-
+// quantized weights — net loss vs the current dequant+Sgemm path.
+//
+// This file adds a second cached path that:
+//   * Takes weights already as sbyte[] in [n, k] layout (matches AiDotNet's
+//     Int8WeightOnlyQuantization.QuantizePerRow output exactly — no copy or
+//     re-quantize at the entry point).
+//   * Takes per-row scales (length n, one per output column).
+//   * Packs the int8 weights into the same tile layout SgemmWithInt8CachedB
+//     uses, so MacroKernel + MicroKernel6x16 are identical to the float and
+//     per-tensor-int8 paths.
+//   * Per-tile dequant during compute folds the per-row scales into the
+//     output: the Nr scales for the current Nr-column panel are broadcast
+//     into a SIMD vector and applied to every kc-row across that panel.
+//
+// Expected perf (per Tensors#401 downstream section): the 16×64 transformer
+// canary's INT8/FP32 ratio drops from ~15-20x to ~3-5x, and BERT-class shapes
+// hit the full 4x DRAM-bandwidth saving on weight loads (the prior FP32
+// dequant scratch defeated that win).
+
+// The per-row-scaled INT8 path follows the same TFM gating as the
+// per-tensor INT8 path in SimdGemm.cs — PackA/PackB/MacroKernel and
+// their AVX2 fast paths are net5.0+ only, so the kernel + cache only
+// compile when those primitives are available. net471 consumers fall
+// back to the legacy AiDotNet.Inference dequant+Sgemm path (which
+// itself doesn't compile on net471's lower SIMD baseline either).
+#if NET5_0_OR_GREATER
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+
+namespace AiDotNet.Tensors.Engines.Simd;
+
+internal static partial class SimdGemm
+{
+    // ─────────────────────────────────────────────────────────────────────
+    // Cached pre-packed B for per-row-scaled INT8 weight-only GEMM.
+    //
+    // Mirrors Int8PrePackedB but:
+    //   * No per-tensor Scale field — scales are per-row, sized [n].
+    //   * Pack input is already sbyte[] (skip the FP32→INT8 quantize step).
+    //
+    // Cache keying is on the source sbyte[] reference (the consumer's
+    // weight array), so the cache survives across Predict calls and is
+    // reclaimed when the weight tensor goes out of scope.
+    // ─────────────────────────────────────────────────────────────────────
+    internal sealed class Int8RowScaledPrePackedB
+    {
+        internal int K;
+        internal int N;
+        internal int Kc;
+        internal int Mc;
+        internal int NumColSubBlocks;
+        internal int ColSubSize;
+        internal sbyte[][] PackedSubs = Array.Empty<sbyte[]>();
+        internal int NumPcIters;
+        // Per-row scales, length N. Defensive copy of the consumer's array
+        // so a subsequent caller mutation doesn't silently change the
+        // dequant scale of cached tiles.
+        internal float[] RowScales = Array.Empty<float>();
+    }
+
+    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<sbyte[], Int8RowScaledPrePackedB>
+        _int8RowScaledPrePackedBCache = new();
+    private static readonly object _int8RowScaledPrePackedBCacheLock = new();
+
+    /// <summary>
+    /// Compute <c>C = A · dequant(B_int8, rowScales)</c> using a cached
+    /// pre-packed form of B. Weights are already int8 with per-row scales,
+    /// avoiding the FP32 round-trip the consumer's prior dequant+Sgemm path
+    /// required. B is laid out as <c>[n, k]</c> row-major; <paramref name="rowScales"/>
+    /// has length <paramref name="n"/> and <c>rowScales[r]</c> scales row
+    /// <c>r</c> of B (= output column <c>r</c>).
+    /// </summary>
+    /// <param name="a">Activations <c>A</c> in <c>[m, k]</c> row-major.</param>
+    /// <param name="bInt8">Pre-quantized weights in <c>[n, k]</c> row-major.</param>
+    /// <param name="rowScales">Per-row scales, length <paramref name="n"/>.</param>
+    /// <param name="c">Output <c>C</c> in <c>[m, n]</c> row-major; cleared on entry.</param>
+    /// <param name="m">Output rows (batch).</param>
+    /// <param name="k">Inner dim.</param>
+    /// <param name="n">Output cols (features).</param>
+    public static void SgemmWithInt8RowScaledCachedB(
+        ReadOnlySpan<float> a,
+        sbyte[] bInt8,
+        ReadOnlySpan<float> rowScales,
+        Span<float> c,
+        int m, int k, int n)
+    {
+        if (bInt8 is null) throw new ArgumentNullException(nameof(bInt8));
+        if (rowScales.Length < n)
+            throw new ArgumentException(
+                $"rowScales.Length ({rowScales.Length}) must be >= n ({n}).",
+                nameof(rowScales));
+        if ((long)bInt8.Length < (long)n * k)
+            throw new ArgumentException(
+                $"bInt8.Length ({bInt8.Length}) must be >= n*k ({(long)n * k}) for the [n, k] layout.",
+                nameof(bInt8));
+        if (m <= 0 || n <= 0 || k <= 0) { c.Clear(); return; }
+
+        c.Clear();
+
+        // Path A: large-n / AVX-512 — fall back to a one-time on-the-fly
+        // dequant + standard SGEMM. The packed tiled path is sized for the
+        // Nc=4096 sub-block budget; once n exceeds that, the per-tile dequant
+        // overhead in the cached path equals or exceeds a single-pass FP32
+        // dequant + the existing SgemmAddInternal large-n fast path.
+        if (n > Nc || Avx512Sgemm.CanUse)
+        {
+            // Allocate a single FP32 buffer for the full dequantized B and
+            // run the standard Sgemm. This path is rare (n > 4096 is unusual
+            // for transformer FFN; or AVX-512 hosts where Sgemm dispatches
+            // straight to the 512-bit kernel and per-tile dequant isn't a
+            // win). We don't cache this path — it's the cold/edge case.
+            var dequantFull = System.Buffers.ArrayPool<float>.Shared.Rent(n * k);
+            try
+            {
+                DequantizeInt8WithRowScalesToFloat32_Reference(
+                    bInt8, dequantFull.AsSpan(0, n * k), rowScales, n, k);
+                // bInt8 is [n, k] row-major; Sgemm wants B in [k, n].
+                // Use transB:true to read the dequantized [n, k] buffer
+                // through Sgemm's transposed-B path.
+                SgemmAddInternal(
+                    a, k, false,
+                    dequantFull.AsSpan(0, n * k), k, true,
+                    c, m, k, n,
+                    allowParallel: true, clearedOutput: true);
+            }
+            finally
+            {
+                System.Buffers.ArrayPool<float>.Shared.Return(dequantFull);
+            }
+            return;
+        }
+
+        int expectedMc = ChooseAdaptiveMc(m, k, n);
+        var cached = GetOrBuildInt8RowScaledPrePackedB(bInt8, rowScales, k, n, m, expectedMc);
+
+        SgemmTiledWithInt8RowScaledCached(a, cached, c, m, k, n);
+    }
+
+    private static Int8RowScaledPrePackedB GetOrBuildInt8RowScaledPrePackedB(
+        sbyte[] bInt8, ReadOnlySpan<float> rowScales, int k, int n, int m, int expectedMc)
+    {
+        if (_int8RowScaledPrePackedBCache.TryGetValue(bInt8, out var existing)
+            && existing.K == k && existing.N == n
+            && existing.Mc == expectedMc
+            && RowScalesEqual(existing.RowScales, rowScales))
+        {
+            return existing;
+        }
+
+        lock (_int8RowScaledPrePackedBCacheLock)
+        {
+            if (_int8RowScaledPrePackedBCache.TryGetValue(bInt8, out existing))
+            {
+                if (existing.K == k && existing.N == n
+                    && existing.Mc == expectedMc
+                    && RowScalesEqual(existing.RowScales, rowScales))
+                {
+                    return existing;
+                }
+                _int8RowScaledPrePackedBCache.Remove(bInt8);
+            }
+            var built = BuildInt8RowScaledPrePackedB(bInt8, rowScales, k, n, m);
+            _int8RowScaledPrePackedBCache.Add(bInt8, built);
+            return built;
+        }
+    }
+
+    private static bool RowScalesEqual(float[] cached, ReadOnlySpan<float> current)
+    {
+        if (cached.Length != current.Length) return false;
+        // Bitwise compare — cached holds the EXACT bytes the caller passed
+        // at first build; if any rowScales[r] changed the dequant must be
+        // rebuilt. This is one read per output channel; negligible vs the
+        // pack cost it gates.
+        for (int i = 0; i < cached.Length; i++)
+            if (cached[i] != current[i]) return false;
+        return true;
+    }
+
+    /// <summary>
+    /// Pack INT8 weights laid out as <c>[n, k]</c> row-major into the
+    /// tile-friendly layout MacroKernel + MicroKernel6x16 expect. Mirrors
+    /// <see cref="BuildInt8PrePackedB"/>'s tile-grid math exactly so all
+    /// downstream kernel code is shared — the only differences are
+    /// (1) input is sbyte not float (skip quantize), (2) input is [n, k]
+    /// not [k, n] (transposed read pattern in PackBInt8FromNK).
+    /// </summary>
+    private static Int8RowScaledPrePackedB BuildInt8RowScaledPrePackedB(
+        sbyte[] bInt8, ReadOnlySpan<float> rowScales, int k, int n, int m)
+    {
+        int Mc = ChooseAdaptiveMc(m, k, n);
+        int numRowBlocks = (m + Mc - 1) / Mc;
+        int maxThreads = Helpers.CpuParallelSettings.MaxDegreeOfParallelism;
+        int numPcIters = (k + Kc - 1) / Kc;
+
+        int nc0 = Math.Min(Nc, n);
+        int desiredColSubs = Math.Max(1, maxThreads / numRowBlocks);
+        int maxColSubs = Math.Max(1, nc0 / (Nr * 4));
+        int numColSubBlocks = Math.Min(desiredColSubs, maxColSubs);
+        int colSubSize = (nc0 / numColSubBlocks / Nr) * Nr;
+        if (colSubSize < Nr)
+        {
+            colSubSize = nc0;
+            numColSubBlocks = 1;
+        }
+
+        int colSubRounded = ((colSubSize + Nr - 1) / Nr) * Nr;
+        int lastColSubWidth = nc0 - (numColSubBlocks - 1) * colSubSize;
+        int lastColSubRounded = ((lastColSubWidth + Nr - 1) / Nr) * Nr;
+        int packedBSizePerSub = Kc * Math.Max(colSubRounded, lastColSubRounded);
+
+        var packedSubs = new sbyte[numPcIters * numColSubBlocks][];
+        for (int pcIter = 0; pcIter < numPcIters; pcIter++)
+        {
+            int pc = pcIter * Kc;
+            int kc = Math.Min(Kc, k - pc);
+            for (int cs = 0; cs < numColSubBlocks; cs++)
+            {
+                int jStart = cs * colSubSize;
+                int subNc = (cs == numColSubBlocks - 1) ? (nc0 - jStart) : colSubSize;
+                var int8Buf = new sbyte[packedBSizePerSub];
+                PackBInt8FromNK(bInt8, int8Buf, k, n, pc, kc, jStart, subNc);
+                packedSubs[pcIter * numColSubBlocks + cs] = int8Buf;
+            }
+        }
+
+        // Defensive copy so the cache key (the sbyte[] reference) is
+        // honoured at lookup time — if the caller mutates rowScales
+        // in-place we must NOT silently keep using the new values with
+        // the previously-packed tiles. The lookup compares the cached
+        // copy against the caller's argument and rebuilds on mismatch.
+        var scalesCopy = new float[n];
+        rowScales.Slice(0, n).CopyTo(scalesCopy);
+
+        return new Int8RowScaledPrePackedB
+        {
+            K = k, N = n, Kc = Kc, Mc = Mc,
+            NumColSubBlocks = numColSubBlocks,
+            ColSubSize = colSubSize,
+            PackedSubs = packedSubs,
+            NumPcIters = numPcIters,
+            RowScales = scalesCopy,
+        };
+    }
+
+    /// <summary>
+    /// Pack an <c>[n, k]</c>-row-major sbyte panel into the same tile
+    /// layout PackB produces for FP32 <c>[k, n]</c>. The translation:
+    /// each PackB output position <c>(p, jj)</c> reads conceptual
+    /// <c>B[pc + p, jc + jj]</c> with B as <c>[k, n]</c>. We have
+    /// <c>bInt8</c> as <c>[n, k]</c>, so the same logical element is
+    /// at <c>bInt8[(jc + jj) * k + (pc + p)]</c>.
+    /// </summary>
+    private static void PackBInt8FromNK(
+        sbyte[] bInt8, sbyte[] packed,
+        int k, int n,
+        int pc, int kc, int jc, int subNc)
+    {
+        int pos = 0;
+        int j = 0;
+        // Full Nr-column panels first.
+        for (; j + Nr <= subNc; j += Nr)
+        {
+            for (int p = 0; p < kc; p++)
+            {
+                int rowK = pc + p;
+                for (int jj = 0; jj < Nr; jj++)
+                {
+                    int colN = jc + j + jj;
+                    packed[pos++] = bInt8[colN * k + rowK];
+                }
+            }
+        }
+        // Tail panel (subNc % Nr != 0): pad to Nr with zeros so the
+        // micro-kernel reads valid sbyte values for the zero-padded
+        // columns (zero × any-scale == 0, contributes nothing).
+        int remaining = subNc - j;
+        if (remaining > 0)
+        {
+            for (int p = 0; p < kc; p++)
+            {
+                int rowK = pc + p;
+                for (int jj = 0; jj < remaining; jj++)
+                {
+                    int colN = jc + j + jj;
+                    packed[pos++] = bInt8[colN * k + rowK];
+                }
+                for (int jj = remaining; jj < Nr; jj++)
+                    packed[pos++] = 0;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Tiled SGEMM driver mirroring <see cref="SgemmTiledWithInt8Cached"/>.
+    /// The only differences: dequant uses per-row scales (one Nr-wide
+    /// vector of scales per Nr-column panel, broadcast then applied across
+    /// the panel's kc rows), and the cache key is the consumer's
+    /// sbyte[] weight reference.
+    /// </summary>
+    private static unsafe void SgemmTiledWithInt8RowScaledCached(
+        ReadOnlySpan<float> a,
+        Int8RowScaledPrePackedB cached,
+        Span<float> c,
+        int m, int k, int n)
+    {
+        int Mc = cached.Mc;
+        int numRowBlocks = (m + Mc - 1) / Mc;
+        int maxThreads = Helpers.CpuParallelSettings.MaxDegreeOfParallelism;
+        bool canParallelize = UseParallelGemm
+            && maxThreads > 1
+            && numRowBlocks >= 1
+            && (long)m * k * n >= ParallelWorkThreshold;
+
+        int mcRounded = ((Mc + Mr - 1) / Mr) * Mr;
+        int packedASizePerRow = mcRounded * Kc;
+        int packedBSizePerSub = cached.PackedSubs.Length > 0 ? cached.PackedSubs[0].Length : 0;
+
+        var packedABufs = canParallelize ? new float[numRowBlocks][] : null;
+        if (canParallelize)
+            for (int r = 0; r < numRowBlocks; r++)
+                packedABufs![r] = System.Buffers.ArrayPool<float>.Shared.Rent(packedASizePerRow);
+        var packedABuf = canParallelize ? null : System.Buffers.ArrayPool<float>.Shared.Rent(packedASizePerRow);
+
+        var dequantBufs = canParallelize ? new float[cached.NumColSubBlocks][] : null;
+        if (canParallelize)
+            for (int cs = 0; cs < cached.NumColSubBlocks; cs++)
+                dequantBufs![cs] = System.Buffers.ArrayPool<float>.Shared.Rent(packedBSizePerSub);
+        var dequantBuf = canParallelize ? null : System.Buffers.ArrayPool<float>.Shared.Rent(packedBSizePerSub);
+
+        try
+        {
+            int jc = 0;
+            int nc = Math.Min(Nc, n);
+            float[] rowScalesArr = cached.RowScales;
+
+            for (int pcIter = 0; pcIter < cached.NumPcIters; pcIter++)
+            {
+                int pc = pcIter * Kc;
+                int kc = Math.Min(Kc, k - pc);
+                int subsBase = pcIter * cached.NumColSubBlocks;
+
+                if (canParallelize && cached.NumColSubBlocks >= 2)
+                {
+                    int localNumRowBlocks = numRowBlocks;
+                    int localMc = Mc;
+                    int localM = m;
+                    int localK = k;
+                    int localN = n;
+                    int localPc = pc;
+                    int localKc = kc;
+                    int localColSubSize = cached.ColSubSize;
+                    int localNumColSubs = cached.NumColSubBlocks;
+                    int localNc = nc;
+                    var localPackedABufs = packedABufs!;
+                    var localDequantBufs = dequantBufs!;
+                    var localCachedSubs = cached.PackedSubs;
+                    int localSubsBase = subsBase;
+                    float[] localRowScales = rowScalesArr;
+
+                    fixed (float* aPtr0 = a)
+                    fixed (float* cPtr0 = c)
+                    {
+                        float* localAPtr = aPtr0;
+                        int localALen = a.Length;
+                        float* localCPtr = cPtr0;
+                        int localCLen = c.Length;
+
+                        int numPackTasks = localNumRowBlocks + localNumColSubs;
+                        Helpers.CpuParallelSettings.LightweightParallel(numPackTasks, taskId =>
+                        {
+                            if (taskId < localNumRowBlocks)
+                            {
+                                int r = taskId;
+                                int ic = r * localMc;
+                                int mcLocal = Math.Min(localMc, localM - ic);
+                                if (mcLocal > 0)
+                                {
+                                    var aSpan = new ReadOnlySpan<float>(localAPtr, localALen);
+                                    PackA(aSpan, localPackedABufs[r], localK, ic, mcLocal, localPc, localKc);
+                                }
+                            }
+                            else
+                            {
+                                int cs = taskId - localNumRowBlocks;
+                                int jStart = cs * localColSubSize;
+                                int subNc = (cs == localNumColSubs - 1) ? (localNc - jStart) : localColSubSize;
+                                var int8Sub = localCachedSubs[localSubsBase + cs];
+                                DequantizeInt8WithRowScalesToFloat32(
+                                    int8Sub, localDequantBufs[cs],
+                                    localRowScales, jStart, localKc, subNc);
+                            }
+                        });
+
+                        int totalTiles = localNumRowBlocks * localNumColSubs;
+                        Helpers.CpuParallelSettings.LightweightParallel(totalTiles, tileId =>
+                        {
+                            int r = tileId / localNumColSubs;
+                            int cs = tileId % localNumColSubs;
+                            int ic = r * localMc;
+                            int mcLocal = Math.Min(localMc, localM - ic);
+                            int jStart = cs * localColSubSize;
+                            int subNc = (cs == localNumColSubs - 1) ? (localNc - jStart) : localColSubSize;
+                            if (mcLocal > 0 && subNc > 0)
+                            {
+                                var cSpan = new Span<float>(localCPtr, localCLen);
+                                MacroKernel(
+                                    localPackedABufs[r], localDequantBufs[cs],
+                                    cSpan, mcLocal, subNc, localKc, localN,
+                                    ic, jc + jStart);
+                            }
+                        });
+                    }
+                }
+                else
+                {
+                    // Sequential fallback. Pack-A and dequant happen inline.
+                    PackA(a, packedABuf!, k, false, ic: 0, mc: Math.Min(Mc, m), pc, kc);
+                    for (int ic = 0; ic < m; ic += Mc)
+                    {
+                        int mc = Math.Min(Mc, m - ic);
+                        if (ic > 0)
+                            PackA(a, packedABuf!, k, false, ic, mc, pc, kc);
+
+                        for (int cs = 0; cs < cached.NumColSubBlocks; cs++)
+                        {
+                            int jStart = cs * cached.ColSubSize;
+                            int subNc = (cs == cached.NumColSubBlocks - 1) ? (nc - jStart) : cached.ColSubSize;
+                            if (subNc > 0)
+                            {
+                                DequantizeInt8WithRowScalesToFloat32(
+                                    cached.PackedSubs[subsBase + cs], dequantBuf!,
+                                    rowScalesArr, jStart, kc, subNc);
+                                MacroKernel(
+                                    packedABuf!, dequantBuf!,
+                                    c, mc, subNc, kc, n,
+                                    ic, jc + jStart);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        finally
+        {
+            if (packedABuf is not null)
+                System.Buffers.ArrayPool<float>.Shared.Return(packedABuf);
+            if (dequantBuf is not null)
+                System.Buffers.ArrayPool<float>.Shared.Return(dequantBuf);
+            if (packedABufs is not null)
+                for (int r = 0; r < numRowBlocks; r++)
+                    System.Buffers.ArrayPool<float>.Shared.Return(packedABufs[r]);
+            if (dequantBufs is not null)
+                for (int cs = 0; cs < cached.NumColSubBlocks; cs++)
+                    System.Buffers.ArrayPool<float>.Shared.Return(dequantBufs[cs]);
+        }
+    }
+
+    /// <summary>
+    /// Dequantize one packed sub-block of int8 weights with per-row scales,
+    /// producing the FP32 buffer the macro-kernel reads. Within ONE Nr-wide
+    /// panel of the packed buffer, the same Nr scales apply to every kc-row,
+    /// so we broadcast them once and multiply per row — the per-row scale
+    /// lookup happens Nr times per panel (not Nr × kc times).
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static unsafe void DequantizeInt8WithRowScalesToFloat32(
+        ReadOnlySpan<sbyte> int8Sub,
+        Span<float> output,
+        ReadOnlySpan<float> rowScales,
+        int jStart,
+        int kc,
+        int subNc)
+    {
+        int numPanels = (subNc + Nr - 1) / Nr;
+
+        Span<float> panelScales = stackalloc float[Nr];
+        for (int panel = 0; panel < numPanels; panel++)
+        {
+            int panelStart = panel * Nr;
+            int panelCols = Math.Min(Nr, subNc - panelStart);
+
+            // Gather the Nr scales for this panel; pad with zero so a
+            // partial tail panel contributes zero through the
+            // (zero-padded packed weight) × (zero scale) multiply.
+            for (int jj = 0; jj < Nr; jj++)
+                panelScales[jj] = jj < panelCols ? rowScales[jStart + panelStart + jj] : 0f;
+
+            int packedRowStride = Nr;
+            int panelBase = panel * kc * Nr;
+
+#if NET5_0_OR_GREATER
+            if (Avx2.IsSupported)
+            {
+                fixed (sbyte* pIn = int8Sub)
+                fixed (float* pOut = output)
+                fixed (float* pScales = panelScales)
+                {
+                    // Two AVX2 256-bit vectors cover the 16-wide Nr.
+                    var vScale0 = Avx.LoadVector256(pScales + 0);
+                    var vScale1 = Avx.LoadVector256(pScales + 8);
+                    for (int p = 0; p < kc; p++)
+                    {
+                        int row = panelBase + p * packedRowStride;
+                        sbyte* pInRow = pIn + row;
+                        float* pOutRow = pOut + row;
+                        var v0 = Vector256.Create(
+                            (float)pInRow[0], (float)pInRow[1], (float)pInRow[2], (float)pInRow[3],
+                            (float)pInRow[4], (float)pInRow[5], (float)pInRow[6], (float)pInRow[7]);
+                        var v1 = Vector256.Create(
+                            (float)pInRow[8], (float)pInRow[9], (float)pInRow[10], (float)pInRow[11],
+                            (float)pInRow[12], (float)pInRow[13], (float)pInRow[14], (float)pInRow[15]);
+                        Avx.Store(pOutRow + 0, Avx.Multiply(v0, vScale0));
+                        Avx.Store(pOutRow + 8, Avx.Multiply(v1, vScale1));
+                    }
+                }
+                continue;
+            }
+#endif
+            // Scalar fallback — used on net471 / non-AVX2 hosts.
+            for (int p = 0; p < kc; p++)
+            {
+                int row = panelBase + p * packedRowStride;
+                for (int jj = 0; jj < Nr; jj++)
+                    output[row + jj] = (float)int8Sub[row + jj] * panelScales[jj];
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reference dequantizer for the large-n / AVX-512 fallback path. Walks
+    /// the source <c>[n, k]</c> sbyte layout directly (no pack) and writes
+    /// the same <c>[n, k]</c> layout in FP32 — the caller passes this to
+    /// SgemmAddInternal with <c>transB:true</c>.
+    /// </summary>
+    private static void DequantizeInt8WithRowScalesToFloat32_Reference(
+        sbyte[] bInt8, Span<float> output, ReadOnlySpan<float> rowScales, int n, int k)
+    {
+        for (int row = 0; row < n; row++)
+        {
+            float scale = rowScales[row];
+            int baseIdx = row * k;
+            for (int col = 0; col < k; col++)
+                output[baseIdx + col] = bInt8[baseIdx + col] * scale;
+        }
+    }
+}
+#endif // NET5_0_OR_GREATER

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.Int8RowScaled.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.Int8RowScaled.cs
@@ -327,17 +327,27 @@ internal static partial class SimdGemm
         int packedASizePerRow = mcRounded * Kc;
         int packedBSizePerSub = cached.PackedSubs.Length > 0 ? cached.PackedSubs[0].Length : 0;
 
-        var packedABufs = canParallelize ? new float[numRowBlocks][] : null;
-        if (canParallelize)
+        // The parallel path requires at least 2 column sub-blocks — pack-A and
+        // dequant are dispatched as taskId>=numRowBlocks tasks alongside the
+        // pack-A tasks, and a single column sub-block leaves nothing to
+        // parallelize on the dequant side. When canParallelize is true but
+        // NumColSubBlocks < 2, the code falls through to the sequential branch
+        // below; that branch reads packedABuf!/dequantBuf!. Pre-fix those were
+        // null in this case → NRE under low n (n < Nr*4 ≈ 64). Compute the
+        // effective branch once here and key all buffer allocations off it.
+        bool useParallelPath = canParallelize && cached.NumColSubBlocks >= 2;
+
+        var packedABufs = useParallelPath ? new float[numRowBlocks][] : null;
+        if (useParallelPath)
             for (int r = 0; r < numRowBlocks; r++)
                 packedABufs![r] = System.Buffers.ArrayPool<float>.Shared.Rent(packedASizePerRow);
-        var packedABuf = canParallelize ? null : System.Buffers.ArrayPool<float>.Shared.Rent(packedASizePerRow);
+        var packedABuf = useParallelPath ? null : System.Buffers.ArrayPool<float>.Shared.Rent(packedASizePerRow);
 
-        var dequantBufs = canParallelize ? new float[cached.NumColSubBlocks][] : null;
-        if (canParallelize)
+        var dequantBufs = useParallelPath ? new float[cached.NumColSubBlocks][] : null;
+        if (useParallelPath)
             for (int cs = 0; cs < cached.NumColSubBlocks; cs++)
                 dequantBufs![cs] = System.Buffers.ArrayPool<float>.Shared.Rent(packedBSizePerSub);
-        var dequantBuf = canParallelize ? null : System.Buffers.ArrayPool<float>.Shared.Rent(packedBSizePerSub);
+        var dequantBuf = useParallelPath ? null : System.Buffers.ArrayPool<float>.Shared.Rent(packedBSizePerSub);
 
         try
         {
@@ -351,7 +361,7 @@ internal static partial class SimdGemm
                 int kc = Math.Min(Kc, k - pc);
                 int subsBase = pcIter * cached.NumColSubBlocks;
 
-                if (canParallelize && cached.NumColSubBlocks >= 2)
+                if (useParallelPath)
                 {
                     int localNumRowBlocks = numRowBlocks;
                     int localMc = Mc;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Simd/SgemmWithInt8RowScaledCachedBTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Simd/SgemmWithInt8RowScaledCachedBTests.cs
@@ -1,0 +1,198 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Tensors#401: regression coverage for the per-row-scaled INT8 weight-only
+// GEMM. The kernel mirrors SgemmWithInt8CachedB's tile pipeline but skips
+// the FP32→INT8 quantize step (consumer hands us pre-quantized sbyte[])
+// and folds per-row scales into the per-tile dequant instead of using a
+// single per-tensor scale.
+//
+// The matmul contract:
+//   C[r, o] += A[r, i] * (B_int8[o, i] * rowScales[o])
+// where B is laid out [n, k] row-major.
+//
+// Correctness is measured as SNR (signal-to-noise ratio) vs a scalar
+// reference. INT8 quantization introduces quantization noise; we assert
+// ≥ 30 dB SNR (≈30 dB ↔ 31× signal-to-noise ratio) which matches the
+// existing per-tensor INT8 path's tolerance and is comfortable inside the
+// 35-45 dB typical for transformer weights.
+
+#if NET5_0_OR_GREATER
+
+using System;
+using AiDotNet.Tensors.Engines.Simd;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Simd;
+
+public class SgemmWithInt8RowScaledCachedBTests
+{
+    private static double SnrDb(ReadOnlySpan<float> reference, ReadOnlySpan<float> actual)
+    {
+        Assert.Equal(reference.Length, actual.Length);
+        double signal = 0, noise = 0;
+        for (int i = 0; i < reference.Length; i++)
+        {
+            signal += (double)reference[i] * reference[i];
+            double diff = reference[i] - actual[i];
+            noise += diff * diff;
+        }
+        if (noise == 0) return double.PositiveInfinity;
+        return 10.0 * Math.Log10(signal / noise);
+    }
+
+    private static void ReferenceMatMul(
+        ReadOnlySpan<float> a, sbyte[] bInt8, ReadOnlySpan<float> rowScales,
+        Span<float> c, int m, int k, int n)
+    {
+        c.Clear();
+        for (int r = 0; r < m; r++)
+        for (int o = 0; o < n; o++)
+        {
+            double acc = 0;
+            float scaleO = rowScales[o];
+            for (int i = 0; i < k; i++)
+                acc += (double)a[r * k + i] * (bInt8[o * k + i] * scaleO);
+            c[r * n + o] = (float)acc;
+        }
+    }
+
+    private static (float[] a, sbyte[] bInt8, float[] rowScales, float[] cRef, int m, int k, int n) BuildRandomCase(
+        int m, int k, int n, int seed)
+    {
+        var rng = new Random(seed);
+        var a = new float[m * k];
+        for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() - 0.5);
+
+        var bInt8 = new sbyte[n * k];
+        var rowScales = new float[n];
+        for (int o = 0; o < n; o++)
+        {
+            // Per-row scale magnitude varies across rows so a correctness
+            // regression that drops per-row scales (and falls back to one
+            // scale) would manifest as a much larger error.
+            rowScales[o] = (float)(0.01 + 0.05 * rng.NextDouble());
+            for (int i = 0; i < k; i++)
+                bInt8[o * k + i] = (sbyte)rng.Next(-127, 128);
+        }
+
+        var cRef = new float[m * n];
+        ReferenceMatMul(a, bInt8, rowScales, cRef, m, k, n);
+        return (a, bInt8, rowScales, cRef, m, k, n);
+    }
+
+    [Theory]
+    [InlineData(4, 64, 64, 1)]      // small square
+    [InlineData(16, 64, 16, 2)]     // m > Nr, n == Nr — exactly one panel
+    [InlineData(8, 32, 24, 3)]      // m and n not multiples of micro-kernel
+    [InlineData(1, 64, 32, 4)]      // gemv corner (m=1)
+    [InlineData(32, 256, 64, 5)]    // medium k inside Kc
+    [InlineData(8, 1024, 16, 6)]    // k > Kc — exercise pcIter loop
+    [InlineData(8, 600, 32, 7)]     // k % Kc != 0 — tail Kc panel
+    [InlineData(4, 32, 5000, 8)]    // n > Nc — large-n fallback path
+    public void Correctness_VsScalarReference_AtSnr30Db(int m, int k, int n, int seed)
+    {
+        var tc = BuildRandomCase(m, k, n, seed);
+        var c = new float[m * n];
+
+        SimdGemm.SgemmWithInt8RowScaledCachedB(
+            tc.a.AsSpan(), tc.bInt8, tc.rowScales.AsSpan(),
+            c.AsSpan(), m, k, n);
+
+        double snr = SnrDb(tc.cRef, c);
+        Assert.True(snr >= 30.0, $"SNR {snr:F1} dB below 30 dB threshold (m={m}, k={k}, n={n})");
+    }
+
+    [Fact]
+    public void CacheHit_SecondCallSameBReference_BitIdenticalOutput()
+    {
+        // The cache is keyed on the sbyte[] reference; if the second call
+        // hits the cache, the packed tiles + scales are reused. Output
+        // must be bit-identical to the first call (same packed layout,
+        // same kernel, same input A — only the pack step is skipped).
+        var tc = BuildRandomCase(8, 128, 32, 100);
+        var c1 = new float[8 * 32];
+        var c2 = new float[8 * 32];
+
+        SimdGemm.SgemmWithInt8RowScaledCachedB(
+            tc.a.AsSpan(), tc.bInt8, tc.rowScales.AsSpan(), c1.AsSpan(), 8, 128, 32);
+        SimdGemm.SgemmWithInt8RowScaledCachedB(
+            tc.a.AsSpan(), tc.bInt8, tc.rowScales.AsSpan(), c2.AsSpan(), 8, 128, 32);
+
+        for (int i = 0; i < c1.Length; i++)
+            Assert.Equal(c1[i], c2[i]);
+    }
+
+    [Fact]
+    public void ScaleChange_ForcesRebuild_OutputReflectsNewScales()
+    {
+        // The cache compares cached rowScales against current; if they
+        // differ, the cached pack is discarded and rebuilt. Verify that
+        // a scale change after the first call DOES change the output
+        // (i.e., we are not silently using the stale cached scales).
+        var tc = BuildRandomCase(4, 64, 16, 200);
+        var c1 = new float[4 * 16];
+        var c2 = new float[4 * 16];
+
+        SimdGemm.SgemmWithInt8RowScaledCachedB(
+            tc.a.AsSpan(), tc.bInt8, tc.rowScales.AsSpan(), c1.AsSpan(), 4, 64, 16);
+
+        var newScales = (float[])tc.rowScales.Clone();
+        for (int i = 0; i < newScales.Length; i++) newScales[i] *= 2.0f;
+        SimdGemm.SgemmWithInt8RowScaledCachedB(
+            tc.a.AsSpan(), tc.bInt8, newScales.AsSpan(), c2.AsSpan(), 4, 64, 16);
+
+        // c2 should be approximately 2x c1 (same A, same B, scales doubled).
+        // Use a relative-error check to allow for quantization-noise effects;
+        // any silent stale-cache reuse would give c2 == c1, far outside this.
+        double maxRelDiff = 0;
+        for (int i = 0; i < c1.Length; i++)
+        {
+            float expected = 2.0f * c1[i];
+            if (Math.Abs(expected) < 1e-6) continue;
+            double rel = Math.Abs(c2[i] - expected) / Math.Abs(expected);
+            if (rel > maxRelDiff) maxRelDiff = rel;
+        }
+        Assert.True(maxRelDiff < 0.01,
+            $"max relative diff {maxRelDiff:E3} too large — cache may have returned stale-scale output");
+    }
+
+    [Fact]
+    public void ZeroDims_NoThrow_ZeroedOutput()
+    {
+        // The kernel must early-return cleanly for any zero dim. Output
+        // should be zeroed (the standard GEMM contract: C is cleared on
+        // entry regardless of dims).
+        var a = new float[0];
+        var b = new sbyte[0];
+        var scales = new float[0];
+        var c = new float[0];
+        SimdGemm.SgemmWithInt8RowScaledCachedB(
+            a.AsSpan(), b, scales.AsSpan(), c.AsSpan(), 0, 0, 0);
+        // No exception is the assertion. (c.Length is 0, nothing to check.)
+    }
+
+    [Fact]
+    public void RowScalesTooShort_Throws()
+    {
+        var a = new float[4 * 8];
+        var b = new sbyte[16 * 8];
+        var scales = new float[15];  // one short of n=16
+        var c = new float[4 * 16];
+        Assert.Throws<ArgumentException>(() =>
+            SimdGemm.SgemmWithInt8RowScaledCachedB(
+                a.AsSpan(), b, scales.AsSpan(), c.AsSpan(), 4, 8, 16));
+    }
+
+    [Fact]
+    public void BInt8TooShort_Throws()
+    {
+        var a = new float[4 * 8];
+        var b = new sbyte[16 * 8 - 1];  // one short of n*k
+        var scales = new float[16];
+        var c = new float[4 * 16];
+        Assert.Throws<ArgumentException>(() =>
+            SimdGemm.SgemmWithInt8RowScaledCachedB(
+                a.AsSpan(), b, scales.AsSpan(), c.AsSpan(), 4, 8, 16));
+    }
+}
+
+#endif

--- a/tests/AiDotNet.Tensors.Tests/Engines/Simd/SgemmWithInt8RowScaledCachedBTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Simd/SgemmWithInt8RowScaledCachedBTests.cs
@@ -88,6 +88,11 @@ public class SgemmWithInt8RowScaledCachedBTests
     [InlineData(8, 1024, 16, 6)]    // k > Kc — exercise pcIter loop
     [InlineData(8, 600, 32, 7)]     // k % Kc != 0 — tail Kc panel
     [InlineData(4, 32, 5000, 8)]    // n > Nc — large-n fallback path
+    // CodeRabbit #427 review comment regression: canParallelize=true AND
+    // NumColSubBlocks=1 (n < Nr*4 ≈ 64). m*k*n = 64*1024*32 = 2 MiB hits
+    // ParallelWorkThreshold's 2 MiB floor on any core count; n=32 < 64 forces
+    // NumColSubBlocks=1. Pre-fix this NRE'd at packedABuf!.
+    [InlineData(64, 1024, 32, 9)]   // parallel-work threshold met + single col sub-block
     public void Correctness_VsScalarReference_AtSnr30Db(int m, int k, int n, int seed)
     {
         var tc = BuildRandomCase(m, k, n, seed);
@@ -117,8 +122,14 @@ public class SgemmWithInt8RowScaledCachedBTests
         SimdGemm.SgemmWithInt8RowScaledCachedB(
             tc.a.AsSpan(), tc.bInt8, tc.rowScales.AsSpan(), c2.AsSpan(), 8, 128, 32);
 
+        // Bit-identical: compare IEEE-754 bit patterns, not numeric equality.
+        // Assert.Equal(float, float) treats NaN-with-different-payloads / -0 vs +0
+        // as equal — neither should occur here, but the test's name promises
+        // bit-identity so the assertion should enforce it (CodeRabbit #427).
         for (int i = 0; i < c1.Length; i++)
-            Assert.Equal(c1[i], c2[i]);
+            Assert.Equal(
+                BitConverter.SingleToInt32Bits(c1[i]),
+                BitConverter.SingleToInt32Bits(c2[i]));
     }
 
     [Fact]
@@ -168,6 +179,27 @@ public class SgemmWithInt8RowScaledCachedBTests
         SimdGemm.SgemmWithInt8RowScaledCachedB(
             a.AsSpan(), b, scales.AsSpan(), c.AsSpan(), 0, 0, 0);
         // No exception is the assertion. (c.Length is 0, nothing to check.)
+    }
+
+    [Fact]
+    public void ZeroK_NonEmptyC_PrefilledOutputIsCleared()
+    {
+        // CodeRabbit #427: the zero-dim test above only exercises m=k=n=0
+        // (c.Length == 0), so the clear-on-entry contract is never observed.
+        // m>0 ∧ n>0 ∧ k=0 still hits the early-return branch but C is non-empty;
+        // the contract says C must be cleared regardless of dims.
+        int m = 3, k = 0, n = 4;
+        var a = new float[m * k];
+        var b = new sbyte[n * k];
+        var scales = new float[n];
+        var c = new float[m * n];
+        Array.Fill(c, 123.0f); // prefill with garbage to detect clear
+
+        SimdGemm.SgemmWithInt8RowScaledCachedB(
+            a.AsSpan(), b, scales.AsSpan(), c.AsSpan(), m, k, n);
+
+        for (int i = 0; i < c.Length; i++)
+            Assert.Equal(0f, c[i]);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes #401. New entry point `SimdGemm.SgemmWithInt8RowScaledCachedB(a, bInt8, rowScales, c, m, k, n)` for the per-row-scaled INT8 weight-only matmul. Mirrors the existing `SgemmWithInt8CachedB` tile pipeline (same `Mc/Kc/Nc/Nr` geometry, same `PackA`, same `MacroKernel + MicroKernel6x16`) but:

- Takes weights as `sbyte[]` in `[n, k]` layout — matches AiDotNet's `Int8WeightOnlyQuantization.QuantizePerRow` output exactly, so no copy or re-quantize at the entry point.
- Takes per-row scales (length `n`, one per output column).
- Per-tile dequant broadcasts the `Nr` scales for the current panel into a SIMD vector and folds them across the panel's `kc` rows. The per-row scale lookup happens `Nr` times per panel (not `Nr × kc`).
- Cache key is the consumer's `sbyte[]` reference (`ConditionalWeakTable`). Survives across `Predict` calls; reclaimed when the consumer drops the weight tensor. Scale-change forces rebuild.

## Background

AiDotNet#1349 reports INT8 inference is ~20× slower than FP32 at wall-clock today. Root cause: `AiDotNet.Inference.Quantization.Int8WeightOnlyMatMul.MultiplyAddBias` dequantizes INT8 → FP32 in scratch then runs FP32 SGEMM — the INT8 memory-bandwidth advantage is destroyed because we materialize the full FP32 weights anyway. The existing `SgemmWithInt8CachedB` would skip that scratch but requires FP32 inputs (computes a per-tensor scale internally), incompatible with AiDotNet's per-row quantized weights.

This PR is the prerequisite for the AiDotNet-side wiring change.

## Test plan

- [x] `tests/AiDotNet.Tensors.Tests/Engines/Simd/SgemmWithInt8RowScaledCachedBTests.cs` — 13 tests covering:
  - Correctness vs scalar reference at SNR ≥ 30 dB across 8 shapes (small square, exact-panel, m=1 gemv, k>Kc, k%Kc≠0 tail, n>Nc large-n fallback).
  - Cache-hit returns bit-identical output on second call with same `bInt8` reference.
  - Scale-change forces rebuild; output reflects new scales (proves no stale-cache reuse).
  - Zero-dim early-return + `ArgumentException` on too-short `rowScales`/`bInt8`.
- [x] All 13 pass on `net10.0`. `net471` excludes them by the same `#if NET5_0_OR_GREATER` gate the per-tensor INT8 path uses (`PackA`/`MacroKernel` AVX2 paths are `net5.0+` only).
- [x] Broader SIMD test sweep: 186/187 pass (the 1 skipped is an unrelated perf benchmark).

## Downstream

AiDotNet#1349 — replace `Int8WeightOnlyMatMul.MultiplyAddBias`'s tiled-dequant + Sgemm body with a single `SgemmWithInt8RowScaledCachedB` call once this NuGet publishes. Expected: 16×64 canary INT8/FP32 ratio drops from ~20× to ~3-5×; BERT-class shapes hit the full 4× DRAM-bandwidth saving on weight loads (the prior FP32 dequant scratch defeated that win).

🤖 Generated with [Claude Code](https://claude.com/claude-code)