### PR TITLE
fix(#363): bridge Profiler.OpScope to PerformanceProfiler.Instance for CPU op rollup

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Profiling/Profiler.cs
+++ b/src/AiDotNet.Tensors/Engines/Profiling/Profiler.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using AiDotNet.Tensors.Engines.Optimization;
 
 namespace AiDotNet.Tensors.Engines.Profiling;
 
@@ -105,8 +106,9 @@ public static class Profiler
     public static IDisposable Range(string name, string category)
     {
         var session = Current;
-        if (session is null) return NoOpScope.Instance;
-        return new RangeScope(session, name, category, args: null);
+        bool legacyEnabled = PerformanceProfiler.Instance.Enabled;
+        if (session is null && !legacyEnabled) return NoOpScope.Instance;
+        return new RangeScope(session, name, category, args: null, legacyEnabled);
     }
 
     /// <summary>
@@ -123,8 +125,9 @@ public static class Profiler
     public static IDisposable Range(string name, string category, IReadOnlyDictionary<string, string> args)
     {
         var session = Current;
-        if (session is null) return NoOpScope.Instance;
-        return new RangeScope(session, name, category, args);
+        bool legacyEnabled = PerformanceProfiler.Instance.Enabled;
+        if (session is null && !legacyEnabled) return NoOpScope.Instance;
+        return new RangeScope(session, name, category, args, legacyEnabled);
     }
 
     /// <summary>Records an instantaneous event on the active session.
@@ -149,20 +152,31 @@ public static class Profiler
     /// <c>CpuEngine</c> so a profiler turned on by the user at runtime
     /// gets per-op timings without engine code paying any cost when the
     /// profiler is off.
+    /// <para>
+    /// Issue #363 bridge: when <see cref="PerformanceProfiler.Instance"/>'s
+    /// <see cref="PerformanceProfiler.Enabled"/> flag is set (the legacy
+    /// per-op aggregator surface consumed by AiDotNet's
+    /// <c>TensorsOperationProfile.Capture</c>), this scope also records to
+    /// it on dispose — so users who flip the documented knob get the CPU
+    /// op rollup they expect, without needing to additionally start a
+    /// modern <see cref="ProfilerSession"/>.
+    /// </para>
     /// </summary>
     public static IDisposable OpScope(string opName)
     {
         var session = Current;
-        if (session is null) return NoOpScope.Instance;
-        return new RangeScope(session, opName, category: "cpu_op", args: null);
+        bool legacyEnabled = PerformanceProfiler.Instance.Enabled;
+        if (session is null && !legacyEnabled) return NoOpScope.Instance;
+        return new RangeScope(session, opName, category: "cpu_op", args: null, legacyEnabled);
     }
 
     /// <summary>Op scope with structured args (typical: shape, dtype, dispatch tier).</summary>
     public static IDisposable OpScope(string opName, IReadOnlyDictionary<string, string> args)
     {
         var session = Current;
-        if (session is null) return NoOpScope.Instance;
-        return new RangeScope(session, opName, category: "cpu_op", args);
+        bool legacyEnabled = PerformanceProfiler.Instance.Enabled;
+        if (session is null && !legacyEnabled) return NoOpScope.Instance;
+        return new RangeScope(session, opName, category: "cpu_op", args, legacyEnabled);
     }
 
     /// <summary>
@@ -173,8 +187,9 @@ public static class Profiler
     public static IDisposable CompilePassScope(string passName)
     {
         var session = Current;
-        if (session is null) return NoOpScope.Instance;
-        return new RangeScope(session, passName, category: "compile_pass", args: null);
+        bool legacyEnabled = PerformanceProfiler.Instance.Enabled;
+        if (session is null && !legacyEnabled) return NoOpScope.Instance;
+        return new RangeScope(session, passName, category: "compile_pass", args: null, legacyEnabled);
     }
 
     /// <summary>
@@ -187,13 +202,14 @@ public static class Profiler
     public static IDisposable FusedOpScope(string fusedName, IReadOnlyList<string> originalOpNames)
     {
         var session = Current;
-        if (session is null) return NoOpScope.Instance;
+        bool legacyEnabled = PerformanceProfiler.Instance.Enabled;
+        if (session is null && !legacyEnabled) return NoOpScope.Instance;
         var args = new Dictionary<string, string>(2)
         {
             ["subops"] = string.Join(",", originalOpNames),
             ["fused"]  = "true",
         };
-        return new RangeScope(session, fusedName, category: "cpu_op", args);
+        return new RangeScope(session, fusedName, category: "cpu_op", args, legacyEnabled);
     }
 
     /// <summary>
@@ -221,33 +237,47 @@ public static class Profiler
 
     private sealed class RangeScope : IDisposable
     {
-        private readonly ProfilerSession _session;
+        // Session is nullable in the #363 bridge path: the user enabled the
+        // legacy PerformanceProfiler without starting a modern session, so
+        // the scope still ticks the legacy aggregator but has no session
+        // events to emit.
+        private readonly ProfilerSession? _session;
         private readonly string _name;
         private readonly string _category;
         private readonly IReadOnlyDictionary<string, string>? _args;
         private readonly long _startTicks;
         private readonly bool _emitNvtx;
         private readonly bool _emitItt;
+        private readonly bool _recordToLegacy;
         private bool _disposed;
 
-        public RangeScope(ProfilerSession session, string name, string category, IReadOnlyDictionary<string, string>? args)
+        public RangeScope(
+            ProfilerSession? session,
+            string name,
+            string category,
+            IReadOnlyDictionary<string, string>? args,
+            bool recordToLegacy = false)
         {
             _session = session;
             _name = name;
             _category = category;
             _args = args;
+            _recordToLegacy = recordToLegacy;
             _startTicks = Stopwatch.GetTimestamp();
 
-            // Bridge to the native profilers when the session opted in. We
-            // gate on the session's Activities so a CPU-only session doesn't
-            // pay the marshalling cost. The bridge classes themselves probed
-            // for the native libs at startup, so the call is a single bool
-            // check + p/invoke when present, no-op when absent.
-            var activities = session.Options.Activities;
-            _emitNvtx = (activities & ProfilerActivities.Gpu) != 0 && Native.NvtxBridge.IsAvailable;
-            _emitItt  = (activities & ProfilerActivities.Cpu) != 0 && Native.IttBridge.IsAvailable;
-            if (_emitNvtx) Native.NvtxBridge.PushRange(name);
-            if (_emitItt)  Native.IttBridge.PushTask(name);
+            if (session is not null)
+            {
+                // Bridge to the native profilers when the session opted in. We
+                // gate on the session's Activities so a CPU-only session doesn't
+                // pay the marshalling cost. The bridge classes themselves probed
+                // for the native libs at startup, so the call is a single bool
+                // check + p/invoke when present, no-op when absent.
+                var activities = session.Options.Activities;
+                _emitNvtx = (activities & ProfilerActivities.Gpu) != 0 && Native.NvtxBridge.IsAvailable;
+                _emitItt  = (activities & ProfilerActivities.Cpu) != 0 && Native.IttBridge.IsAvailable;
+                if (_emitNvtx) Native.NvtxBridge.PushRange(name);
+                if (_emitItt)  Native.IttBridge.PushTask(name);
+            }
         }
 
         public void Dispose()
@@ -257,7 +287,20 @@ public static class Profiler
             if (_emitItt)  Native.IttBridge.PopTask();
             if (_emitNvtx) Native.NvtxBridge.PopRange();
             long endTicks = Stopwatch.GetTimestamp();
-            _session.RecordCompleteInternal(_name, _category, _startTicks, endTicks, _args);
+            _session?.RecordCompleteInternal(_name, _category, _startTicks, endTicks, _args);
+            if (_recordToLegacy)
+            {
+                // Issue #363: tick the legacy PerformanceProfiler.Instance so the
+                // documented `PerformanceProfiler.Instance.Enabled = true` knob
+                // produces CPU-side stats. Memory delta is left at 0 here —
+                // RangeScope doesn't capture per-thread allocation deltas and
+                // the legacy memory column is rarely the consumer's question
+                // (TensorsOperationProfile.Capture surfaces wall-clock timings,
+                // not allocations). Profile() callers who explicitly want
+                // allocation tracking continue to use the legacy Profile() API
+                // directly — that path's ProfileScope still captures it.
+                PerformanceProfiler.Instance.RecordOperation(_name, endTicks - _startTicks, memoryBytes: 0);
+            }
         }
     }
 

--- a/src/AiDotNet.Tensors/Engines/Profiling/Profiler.cs
+++ b/src/AiDotNet.Tensors/Engines/Profiling/Profiler.cs
@@ -102,13 +102,22 @@ public static class Profiler
     /// Opens a categorized range. <paramref name="category"/> appears in
     /// chrome-trace UIs as the event's tag — typical values are
     /// <c>"cpu_op"</c>, <c>"compile_pass"</c>, <c>"autograd"</c>.
+    /// <para>
+    /// CodeRabbit #428 review: this entry point is user-annotation territory
+    /// — events here are not CPU kernel timings and must NOT feed
+    /// <see cref="PerformanceProfiler.Instance"/>, which backs the per-op
+    /// rollup <c>TensorsOperationProfile.Capture</c> exposes (mixing user
+    /// annotations and arbitrary categories into that flat name→ticks map
+    /// would break the rollup contract and collide on names across
+    /// categories). Only <see cref="OpScope(string)"/> and
+    /// <see cref="FusedOpScope"/> bridge to the legacy aggregator.
+    /// </para>
     /// </summary>
     public static IDisposable Range(string name, string category)
     {
         var session = Current;
-        bool legacyEnabled = PerformanceProfiler.Instance.Enabled;
-        if (session is null && !legacyEnabled) return NoOpScope.Instance;
-        return new RangeScope(session, name, category, args: null, legacyEnabled);
+        if (session is null) return NoOpScope.Instance;
+        return new RangeScope(session, name, category, args: null, recordToLegacy: false);
     }
 
     /// <summary>
@@ -124,10 +133,11 @@ public static class Profiler
     /// </summary>
     public static IDisposable Range(string name, string category, IReadOnlyDictionary<string, string> args)
     {
+        // CodeRabbit #428: user-annotation overload — never bridges to the
+        // legacy per-op aggregator. See no-args Range(string, string).
         var session = Current;
-        bool legacyEnabled = PerformanceProfiler.Instance.Enabled;
-        if (session is null && !legacyEnabled) return NoOpScope.Instance;
-        return new RangeScope(session, name, category, args, legacyEnabled);
+        if (session is null) return NoOpScope.Instance;
+        return new RangeScope(session, name, category, args, recordToLegacy: false);
     }
 
     /// <summary>Records an instantaneous event on the active session.
@@ -183,13 +193,20 @@ public static class Profiler
     /// Compile-pass scope — a categorized variant for the optimization
     /// pipeline so chrome-trace UIs can filter pass timings out of the
     /// per-op category.
+    /// <para>
+    /// CodeRabbit #428 review: compile-pass timings are build-time, not
+    /// CPU kernel timings — they must NOT feed
+    /// <see cref="PerformanceProfiler.Instance"/> (which backs the per-op
+    /// rollup <c>TensorsOperationProfile.Capture</c> exposes). Only the
+    /// engine hot-path ops (<see cref="OpScope(string)"/>,
+    /// <see cref="FusedOpScope"/>) bridge to the legacy aggregator.
+    /// </para>
     /// </summary>
     public static IDisposable CompilePassScope(string passName)
     {
         var session = Current;
-        bool legacyEnabled = PerformanceProfiler.Instance.Enabled;
-        if (session is null && !legacyEnabled) return NoOpScope.Instance;
-        return new RangeScope(session, passName, category: "compile_pass", args: null, legacyEnabled);
+        if (session is null) return NoOpScope.Instance;
+        return new RangeScope(session, passName, category: "compile_pass", args: null, recordToLegacy: false);
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tensors.Tests/Engines/Optimization/PerformanceProfilerTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Optimization/PerformanceProfilerTests.cs
@@ -1,8 +1,12 @@
+using AiDotNet.Tensors.Engines;
 using AiDotNet.Tensors.Engines.Optimization;
+using AiDotNet.Tensors.Engines.Profiling;
+using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
 
 namespace AiDotNet.Tensors.Tests.Engines.Optimization;
 
+[Collection("PerformanceProfilerInstance")]
 public class PerformanceProfilerTests
 {
     [Fact]
@@ -60,4 +64,82 @@ public class PerformanceProfilerTests
             profiler.Clear();
         }
     }
+
+    [Fact]
+    public void CpuMatMul_RecordsStats_WhenLegacyProfilerEnabled()
+    {
+        // Issue #363 regression: setting PerformanceProfiler.Instance.Enabled = true
+        // must surface CPU op timings (the documented contract for
+        // AiDotNet.Diagnostics.TensorsOperationProfile.Capture). Pre-fix the
+        // CPU engine emitted ops only through Profiler.OpScope's ambient
+        // ProfilerSession; the legacy singleton stayed empty no matter how
+        // many CPU forward passes ran. The bridge in Profiler.OpScope routes
+        // op timings into both surfaces when the legacy flag is on.
+        var profiler = PerformanceProfiler.Instance;
+        bool wasEnabled = profiler.Enabled;
+        profiler.Clear();
+        profiler.Enabled = true;
+
+        try
+        {
+            var engine = new CpuEngine();
+            var a = new Tensor<float>(new float[] { 1, 2, 3, 4 }, new[] { 2, 2 });
+            var b = new Tensor<float>(new float[] { 5, 6, 7, 8 }, new[] { 2, 2 });
+
+            // Run a small batch of CPU MatMul calls. Each one goes through
+            // CpuEngine.TensorMatMul -> Profiler.OpScope("TensorMatMul"),
+            // which post-#363 also feeds PerformanceProfiler.Instance.
+            for (int i = 0; i < 5; i++)
+                _ = engine.TensorMatMul(a, b);
+
+            var stats = profiler.GetStats("TensorMatMul");
+            Assert.NotNull(stats);
+            Assert.Equal(5, stats!.CallCount);
+            Assert.True(stats.TotalTicks > 0, "TotalTicks must be positive after 5 MatMul calls.");
+        }
+        finally
+        {
+            profiler.Enabled = wasEnabled;
+            profiler.Clear();
+        }
+    }
+
+    [Fact]
+    public void CpuMatMul_StaysEmpty_WhenLegacyProfilerDisabled()
+    {
+        // Counterpart: when Enabled is false (default), CPU MatMul must NOT
+        // tick the legacy aggregator. Confirms the bridge is gated, not
+        // unconditional — overhead on the disabled hot path must stay zero.
+        var profiler = PerformanceProfiler.Instance;
+        bool wasEnabled = profiler.Enabled;
+        profiler.Clear();
+        profiler.Enabled = false;
+
+        try
+        {
+            var engine = new CpuEngine();
+            var a = new Tensor<float>(new float[] { 1, 2, 3, 4 }, new[] { 2, 2 });
+            var b = new Tensor<float>(new float[] { 5, 6, 7, 8 }, new[] { 2, 2 });
+            for (int i = 0; i < 5; i++)
+                _ = engine.TensorMatMul(a, b);
+
+            Assert.Null(profiler.GetStats("TensorMatMul"));
+        }
+        finally
+        {
+            profiler.Enabled = wasEnabled;
+            profiler.Clear();
+        }
+    }
 }
+
+/// <summary>
+/// xunit collection that serializes tests touching the global
+/// <see cref="PerformanceProfiler.Instance"/> singleton's Enabled flag /
+/// stats. Without this, two tests flipping <c>Enabled</c> in parallel
+/// would race: one's "set true / run / assert" interleaves with another's
+/// "set false / run / assert null" and both see the wrong state. The
+/// fixture itself holds no state — it's just a serialization tag.
+/// </summary>
+[CollectionDefinition("PerformanceProfilerInstance", DisableParallelization = true)]
+public sealed class PerformanceProfilerCollection { }


### PR DESCRIPTION
Closes #363.

## Summary

`PerformanceProfiler.Instance` is the documented hook for per-kernel timing rollups (consumed by AiDotNet's `TensorsOperationProfile.Capture`). Setting `PerformanceProfiler.Instance.Enabled = true` and running CPU-side inference produced **zero** recorded operations because `CpuEngine`'s hot path emits ops through `Profiler.OpScope`'s ambient `ProfilerSession` — not the legacy singleton. The only call site of `PerformanceProfiler.Instance.Profile()` was `CudaDispatchPolicy.Scope` on the CUDA dispatch path.

## Fix

`Profiler.OpScope` / `Range` / `FusedOpScope` / `CompilePassScope` now also record op timings into `PerformanceProfiler.Instance` on dispose when its `Enabled` flag is on. The internal `RangeScope`'s session reference became nullable to handle the user-flipped-`Enabled`-without-starting-a-session case (the documented usage pattern from the issue's repro).

Zero-overhead contract preserved: when neither a session is active nor the legacy flag is on, `OpScope` still short-circuits to the singleton `NoOpScope`. The hot-path cost adds one extra static-field read per `OpScope` call — negligible vs the existing volatile read of `Profiler.Current`.

## Test plan

- [x] `CpuMatMul_RecordsStats_WhenLegacyProfilerEnabled` — flips `Enabled`, runs 5 `CpuEngine.TensorMatMul` calls, asserts `GetStats(\"TensorMatMul\")` returns `CallCount=5` with positive `TotalTicks`
- [x] `CpuMatMul_StaysEmpty_WhenLegacyProfilerDisabled` — counterpart with `Enabled=false`; stats stay null (bridge is gated, not unconditional)
- [x] xunit collection `PerformanceProfilerInstance` with `DisableParallelization=true` serialises tests that mutate the global singleton
- [x] Existing 2 `PerformanceProfilerTests` + 33 modern `Profiling` tests still pass

## Downstream

AiDotNet's `TensorsOperationProfile.Capture()` (in `src/Diagnostics/ProfilingReport.cs`) reads from `PerformanceProfiler.Instance.GetAllStats()` — now returns per-op CPU breakdowns automatically once the user flips the documented knob, matching the PyTorch-parity claim on the API docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)