### PR TITLE
fix(#430): defer streaming drop when refcount > 1 instead of throwing

### DIFF
--- a/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
@@ -177,6 +177,41 @@ public abstract class TensorBase<T> : IDisposable
     /// </remarks>
     internal void DropStorageForStreaming()
     {
+        if (!TryDropStorageForStreaming(throwOnSharedRefcount: true))
+        {
+            // TryDropStorageForStreaming throws inside when refcount > 1
+            // and throwOnSharedRefcount is true; this branch is unreachable
+            // in the strict path. Kept as a defensive guard.
+            throw new InvalidOperationException(
+                $"Streaming drop requires sole storage ownership; storage refcount is {_storage.RefCount}. " +
+                "Register the weight via WeightRegistry before any RebindStorageFrom / view operation that " +
+                "shares its storage.");
+        }
+    }
+
+    /// <summary>
+    /// Tries to drop this tensor's in-memory data per <see cref="DropStorageForStreaming"/>
+    /// semantics, but returns <c>false</c> instead of throwing when the storage
+    /// refcount is &gt; 1 (a peer view — typically the autodiff tape — holds the
+    /// other reference).
+    /// <para>
+    /// Issue #430: lazy weights allocated via <c>WeightRegistry.AllocateStreaming</c>
+    /// in <c>OnFirstForward</c> have their storage referenced by the very next
+    /// op's view (autodiff tape input capture), making the refcount 2 at the
+    /// moment <c>RegisterWeight</c> is called. <c>RegisterWeight</c> uses this
+    /// non-throwing variant to detect that case and defer the drop until the
+    /// peer ref releases (typically end of training step).
+    /// </para>
+    /// </summary>
+    /// <param name="throwOnSharedRefcount">When true, throws the same
+    /// <see cref="InvalidOperationException"/> the strict
+    /// <see cref="DropStorageForStreaming"/> raises. When false, returns
+    /// <c>false</c> on shared refcount.</param>
+    /// <returns><c>true</c> when the drop succeeded (refcount 1 → 0, storage
+    /// replaced with empty); <c>false</c> when refcount &gt; 1 and the caller
+    /// opted for the soft path.</returns>
+    internal bool TryDropStorageForStreaming(bool throwOnSharedRefcount = false)
+    {
         if (!IsContiguous || _storageOffset != 0 || IsView)
             throw new InvalidOperationException(
                 "Streaming drop requires contiguous, non-view, zero-offset tensors. " +
@@ -193,10 +228,14 @@ public abstract class TensorBase<T> : IDisposable
         // refcount was exactly 1 at the moment of the claim, and after
         // success any concurrent AddRef throws ObjectDisposedException.
         if (!_storage.TryClaimExclusive())
-            throw new InvalidOperationException(
-                $"Streaming drop requires sole storage ownership; storage refcount is {_storage.RefCount}. " +
-                "Register the weight via WeightRegistry before any RebindStorageFrom / view operation that " +
-                "shares its storage.");
+        {
+            if (throwOnSharedRefcount)
+                throw new InvalidOperationException(
+                    $"Streaming drop requires sole storage ownership; storage refcount is {_storage.RefCount}. " +
+                    "Register the weight via WeightRegistry before any RebindStorageFrom / view operation that " +
+                    "shares its storage.");
+            return false;
+        }
 
         // Successful claim drove refcount 1 → 0. The old storage is now
         // owned exclusively by this method and no other thread can take
@@ -206,6 +245,7 @@ public abstract class TensorBase<T> : IDisposable
         // is already 0, Release would underflow.
         _data = Vector<T>.Empty();
         _storage = new TensorStorage<T>(_data);
+        return true;
     }
 
     /// <summary>
@@ -699,6 +739,30 @@ public abstract class TensorBase<T> : IDisposable
     /// can't desync the pool's <c>_reservedBytes</c> bookkeeping.
     /// </summary>
     internal long StreamingReservedBytes { get; set; }
+
+    /// <summary>
+    /// Issue #430: indicates that <see cref="WeightRegistry.RegisterWeight{T}"/>
+    /// registered this tensor with the streaming pool but the in-memory storage
+    /// drop was deferred because the storage refcount was &gt; 1 at register
+    /// time (a peer view, typically the autodiff tape's input capture, held
+    /// the second reference). The GC-heap storage stays live so the peer's
+    /// reads continue to see valid data; the pool also holds the serialized
+    /// snapshot under <see cref="StreamingPoolHandle"/>. On the next call to
+    /// <see cref="WeightRegistry.TryFinalizeDeferredDrop{T}"/> (typically at
+    /// the end of the training step, after backward releases tape captures)
+    /// the drop is retried and this flag clears on success.
+    /// <para>
+    /// Lifecycle:
+    /// <list type="bullet">
+    ///   <item><c>false</c> by default; remains <c>false</c> on normal
+    ///     RegisterWeight (refcount == 1, drop succeeds inline).</item>
+    ///   <item>set to <c>true</c> by <c>RegisterWeight</c> when refcount &gt; 1.</item>
+    ///   <item>cleared by <c>TryFinalizeDeferredDrop</c> when the drop
+    ///     finally succeeds.</item>
+    /// </list>
+    /// </para>
+    /// </summary>
+    internal bool StreamingDropDeferred { get; set; }
 
     /// <summary>
     /// GPU offload allocation handle when <see cref="Lifetime"/> is

--- a/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
@@ -155,7 +155,7 @@ public static class WeightRegistry
                         // Two-phase commit: drop storage FIRST (the operation
                         // that can throw — non-contiguous, view, shared
                         // refcount), then commit the handle on the tensor.
-                        // If DropStorageForStreaming throws after the pool
+                        // If TryDropStorageForStreaming throws after the pool
                         // already accepted the bytes, roll the pool entry
                         // back so we don't leak both a registered pool
                         // entry and a tensor still in its pre-stream state
@@ -163,10 +163,25 @@ public static class WeightRegistry
                         // never released" + a pool entry no caller can
                         // ever reach because StreamingPoolHandle was never
                         // set on the tensor).
+                        //
+                        // Issue #430: lazy weights allocated via
+                        // AllocateStreaming inside OnFirstForward have their
+                        // storage captured by the very next op's autodiff
+                        // tape input list — refcount becomes 2 by the time
+                        // RegisterWeight runs. Pre-fix the strict drop threw
+                        // and broke any forward path that lazy-allocated
+                        // weights mid-Forward (PatchEmbeddingLayer in
+                        // Gemma3, DeepSeekVL, etc.). Use the non-throwing
+                        // TryDropStorageForStreaming and DEFER the drop when
+                        // refcount > 1: bind the handle anyway, mark the
+                        // tensor with StreamingDropDeferred, and let
+                        // TryFinalizeDeferredDrop retry once peer refs
+                        // release (typically end of training step).
                         try
                         {
-                            weight.DropStorageForStreaming();
+                            bool dropped = weight.TryDropStorageForStreaming(throwOnSharedRefcount: false);
                             weight.StreamingPoolHandle = handle;
+                            weight.StreamingDropDeferred = !dropped;
                         }
                         catch
                         {
@@ -235,6 +250,42 @@ public static class WeightRegistry
                     throw new ArgumentOutOfRangeException(nameof(weight.Lifetime));
             }
         }
+    }
+
+    /// <summary>
+    /// Issue #430: retries the storage drop for a streaming weight whose
+    /// registration was deferred because the storage refcount was &gt; 1 at
+    /// <see cref="RegisterWeight{T}"/> time (typically the autodiff tape's
+    /// input capture holding the second ref). Call this after the peer
+    /// reference has released — for training loops, the natural call site
+    /// is the end of each step's backward pass when the tape disposes its
+    /// captures.
+    /// <para>
+    /// Idempotent and concurrent-safe: if <see cref="Tensor{T}.StreamingDropDeferred"/>
+    /// is already <c>false</c> (already dropped, or never deferred) this
+    /// returns <c>true</c> without touching the storage. When the refcount
+    /// is still &gt; 1 it returns <c>false</c> and leaves the deferred flag
+    /// set so callers can retry on the next opportunity.
+    /// </para>
+    /// </summary>
+    /// <returns><c>true</c> if the drop succeeded (or was already done);
+    /// <c>false</c> if peer refs still hold the storage.</returns>
+    public static bool TryFinalizeDeferredDrop<T>(Tensor<T> weight)
+    {
+        if (weight is null) throw new ArgumentNullException(nameof(weight));
+        // Already finalised — either the original RegisterWeight succeeded
+        // inline or a prior TryFinalizeDeferredDrop call cleared the flag.
+        if (!weight.StreamingDropDeferred) return true;
+        // No registry lock held: TryDropStorageForStreaming is internally
+        // atomic via TryClaimExclusive's CAS. Pool bookkeeping was already
+        // recorded by the deferring RegisterWeight call; the only state
+        // mutated here is on the tensor itself.
+        bool dropped = weight.TryDropStorageForStreaming(throwOnSharedRefcount: false);
+        if (dropped)
+        {
+            weight.StreamingDropDeferred = false;
+        }
+        return dropped;
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightRegistryStreamingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightRegistryStreamingTests.cs
@@ -45,6 +45,74 @@ public class WeightRegistryStreamingTests : IDisposable
     }
 
     [Fact]
+    public void RegisterStreaming_RefcountTwo_DefersDrop_KeepsPeerReadValid()
+    {
+        // Issue #430 regression: RegisterWeight on a streaming weight with
+        // refcount > 1 (autodiff tape holds the peer ref to the weight's
+        // storage, captured by the first forward op) used to throw
+        // "Streaming drop requires sole storage ownership". Lazy weights in
+        // PatchEmbeddingLayer + family hit this exact pattern — the
+        // OnFirstForward → AllocateLazyWeight → Engine.TensorMatMul sequence
+        // makes the storage refcount 2 by the time RegisterWeight runs.
+        // Post-fix: register succeeds, drop is deferred, peer continues to
+        // read valid data.
+        var w = new Tensor<float>(new float[] { 1.5f, 2.5f, 3.5f, 4.5f }, new[] { 4 });
+        w.Lifetime = WeightLifetime.Streaming;
+
+        // Simulate the autodiff tape's peer capture: a sibling tensor that
+        // shares the same storage. RebindStorageFrom is the same primitive
+        // CompiledInferencePlan / MemoryPlanningPass use; the autodiff
+        // tape's input-capture path bumps the storage refcount the same way.
+        var peer = new Tensor<float>(new[] { 4 });
+        peer.RebindStorageFrom(w);
+        Assert.Equal(2, w._storage.RefCount);
+
+        // Pre-fix this would throw InvalidOperationException. Post-fix it
+        // succeeds with the drop deferred.
+        WeightRegistry.RegisterWeight(w);
+
+        Assert.True(w.StreamingPoolHandle >= 0, "Handle must be bound even when drop is deferred.");
+        Assert.True(w.StreamingDropDeferred, "Drop should be deferred when refcount > 1.");
+        // GC heap storage is still live so the peer can read its data.
+        Assert.Equal(4, w.DataVector.Length);
+        Assert.Equal(1.5f, peer[0]);
+        Assert.Equal(4.5f, peer[3]);
+
+        // Retry while peer still holds the ref — should still return false.
+        Assert.False(WeightRegistry.TryFinalizeDeferredDrop(w),
+            "Drop must stay deferred while peer ref is still alive.");
+        Assert.True(w.StreamingDropDeferred, "Flag remains set on failed retry.");
+
+        // Release the peer ref by rebinding it to a fresh storage. Now the
+        // weight's storage refcount drops back to 1 and the deferred drop
+        // can finalize.
+        var fresh = new Tensor<float>(new[] { 4 });
+        peer.RebindStorageFrom(fresh);
+        Assert.Equal(1, w._storage.RefCount);
+
+        Assert.True(WeightRegistry.TryFinalizeDeferredDrop(w),
+            "Drop should now succeed with refcount == 1.");
+        Assert.False(w.StreamingDropDeferred, "Flag clears on successful finalize.");
+        Assert.Equal(0, w.DataVector.Length);
+    }
+
+    [Fact]
+    public void TryFinalizeDeferredDrop_NoOpOnNonDeferredTensor()
+    {
+        // Idempotency / no-op guarantee: calling TryFinalizeDeferredDrop on a
+        // tensor that never had a deferred drop (or already finalized) must
+        // return true without touching storage. AiDotNet's step-boundary
+        // loop wants to call this on every trainable parameter without
+        // tracking which ones are deferred.
+        var t = new Tensor<float>(new float[] { 1.5f, 2.5f }, new[] { 2 });
+        t.Lifetime = WeightLifetime.Streaming;
+        WeightRegistry.RegisterWeight(t);
+        Assert.False(t.StreamingDropDeferred);
+        Assert.True(WeightRegistry.TryFinalizeDeferredDrop(t));
+        Assert.False(t.StreamingDropDeferred);
+    }
+
+    [Fact]
     public void RegisterStreaming_DropsTensorData_PoolKeepsCanonicalCopy()
     {
         var t = new Tensor<float>(new float[] { 1.5f, 2.5f, 3.5f, 4.5f }, new[] { 4 });
@@ -348,14 +416,19 @@ public class WeightRegistryStreamingTests : IDisposable
     }
 
     [Fact]
-    public void DropStorage_OnSharedRefcount_Throws()
+    public void DropStorage_OnSharedRefcount_DefersDropWithoutThrowing()
     {
-        // Audit P1 #5: DropStorageForStreaming must reject tensors whose
-        // storage refcount > 1 (rebound peers exist). Construct that
-        // scenario directly via RebindStorageFrom — the test assembly
-        // has internals access. Without this guard, registering a
-        // tensor whose storage is shared with a peer would silently
-        // drop bytes the peer is still reading.
+        // Audit P1 #5 + Issue #430 update: pre-#430 this test asserted that
+        // RegisterWeight THROWS on shared refcount. That was the right strict
+        // semantics for the original streaming workflow (RegisterWeight before
+        // any view op), but it blocked the lazy-weight pattern in
+        // PatchEmbeddingLayer + family where the very next op's autodiff tape
+        // capture bumps refcount to 2 BEFORE RegisterWeight runs. The #430 fix
+        // changes the contract: RegisterWeight on a shared-refcount tensor now
+        // SUCCEEDS with the drop deferred. The pool gets the bytes-snapshot,
+        // the handle is bound, the GC-heap storage stays live so peers can
+        // continue to read it, and StreamingDropDeferred = true signals that
+        // TryFinalizeDeferredDrop must be called once peer refs release.
         var t1 = new Tensor<float>(new float[] { 1f, 2f, 3f }, new[] { 3 });
         var t2 = new Tensor<float>(new float[] { 9f, 9f, 9f }, new[] { 3 });
         // Rebind t2's storage to point at t1's — both now share storage,
@@ -364,23 +437,25 @@ public class WeightRegistryStreamingTests : IDisposable
 
         t1.Lifetime = WeightLifetime.Streaming;
 
-        // RegisterWeight implicitly calls DropStorageForStreaming; with
-        // refcount > 1 the atomic claim must fail and the call must
-        // throw. The pool-entry rollback (separate audit fix) means
-        // there's no leaked pool entry on this throw path.
-        var ex = Assert.Throws<InvalidOperationException>(() => WeightRegistry.RegisterWeight(t1));
-        Assert.Contains("sole storage ownership", ex.Message);
+        // RegisterWeight succeeds (no throw) and defers the drop.
+        WeightRegistry.RegisterWeight(t1);
 
-        // Both tensors must still be intact: the failed register must
-        // not have stripped t1's bytes (and therefore t2's).
+        Assert.True(t1.StreamingPoolHandle >= 0, "Handle must be bound on deferred-drop path.");
+        Assert.True(t1.StreamingDropDeferred, "DropDeferred flag must be set when refcount > 1.");
+
+        // Both tensors' bytes are still GC-resident so the peer can keep
+        // reading via the shared storage.
         Assert.Equal(3, t1.DataVector.Length);
         Assert.Equal(3, t2.DataVector.Length);
         Assert.Equal(1f, t1.DataVector.AsSpan()[0]);
         Assert.Equal(1f, t2.DataVector.AsSpan()[0]); // shared with t1
 
-        // No pool handle should have been assigned because the rollback
-        // must restore the tensor to its pre-register state.
-        Assert.True(t1.StreamingPoolHandle < 0);
+        // Cleanup: rebind peer to fresh storage so the deferred drop can
+        // finalize before the fixture's Dispose tears down the pool.
+        var fresh = new Tensor<float>(new[] { 3 });
+        t2.RebindStorageFrom(fresh);
+        Assert.True(WeightRegistry.TryFinalizeDeferredDrop(t1));
+        Assert.False(t1.StreamingDropDeferred);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #430.

## Summary

`PatchEmbeddingLayer` (and the Gemma3 / DeepSeekVL / InternVL / Llama32Vision / Phi3Vision / Phi4Multimodal family that share its lazy-init pattern) calls `WeightRegistry.AllocateStreaming` inside `OnFirstForward`, then immediately runs `Engine.TensorMatMul` whose autodiff tape captures the weight tensor's storage as a peer view. By the time `NeuralNetworkBase.PredictEagerStreaming` calls `RegisterWeight` on that weight, the storage refcount is **2** — the strict drop's `TryClaimExclusive` fails and the call throws, blocking the streaming-pool path for every paper-scale vision-LM in the scaffold list.

## Fix shape (issue's Option 2, as a deferred-drop state)

- **`TensorBase.TryDropStorageForStreaming(throwOnSharedRefcount: bool)`**: non-throwing variant returning `false` instead of throwing when `TryClaimExclusive` can't acquire. The strict path (`DropStorageForStreaming` → `TryDropStorageForStreaming(true)`) is preserved for callers that still want the original contract.
- **`TensorBase.StreamingDropDeferred`** (internal `bool`): set by `RegisterWeight` when the drop deferred; cleared on successful `TryFinalizeDeferredDrop`.
- **`WeightRegistry.RegisterWeight`** streaming branch: replace strict drop with `TryDropStorageForStreaming(false)`. On refcount > 1 the pool gets the bytes snapshot + handle is bound + `StreamingDropDeferred = true`, but the GC-heap storage stays live so peer views (autodiff tape's captured inputs) continue to read valid data. On refcount == 1 the inline path is unchanged.
- **`WeightRegistry.TryFinalizeDeferredDrop<T>(weight)`**: public retry API. Idempotent — returns `true` if not deferred (or if drop now succeeds); `false` if peer refs still hold the storage. Natural call site is the end of each training step's backward pass when the tape disposes its captures (AiDotNet step-boundary loop integration is a separate PR).

## Tradeoff (issue's note)

Pool budget honesty during the deferred window: the pool's `_residentBytes` still counts the snapshot bytes; the GC-heap copy stays alive too, so during this window the same logical tensor is double-counted across the two surfaces. This is the issue's "residency budget violation potential" — accepted because the window is bounded (one training step on typical workloads) and the alternative (throw) blocks the entire scaffold family from streaming.

## Test plan

- [x] `RegisterStreaming_RefcountTwo_DefersDrop_KeepsPeerReadValid` — mirrors the PatchEmbedding sequence via `RebindStorageFrom` (the same primitive CompiledInferencePlan / MemoryPlanningPass use; semantically identical to the autodiff tape's input capture). Asserts no throw, handle bound, deferred flag set, peer reads still valid, retry succeeds after peer rebinds.
- [x] `TryFinalizeDeferredDrop_NoOpOnNonDeferredTensor` — idempotency contract.
- [x] Updated `DropStorage_OnSharedRefcount_DefersDropWithoutThrowing` — the prior strict-throw test (Audit P1 #5) is now obsolete; the new contract is verified by the same shape it used to guard against.
- [x] 54 `WeightRegistry` tests pass; 423 broader `LinearAlgebra` / `TensorBase` / `Streaming` tests pass on net10.0.

## Downstream

AiDotNet#1420 (Gemma3 + family scaffold): the patch-divisibility portion ships independently; the streaming engagement is unblocked once this lands and the Tensors NuGet bumps. AiDotNet's step-boundary loop should call `WeightRegistry.TryFinalizeDeferredDrop` on each trainable parameter after backward to release the deferred-drop window (separate PR; idempotent so it's safe even on never-deferred tensors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)