### PR TITLE
test: exclude two zero-assert pure benchmarks from gating CI (~11 min faster)

### DIFF
--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/ComparativeBenchmark.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/ComparativeBenchmark.cs
@@ -26,6 +26,10 @@ namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
 ///   dotnet test --filter "Compare_BlasManaged_vs_NativeBLAS_FP64" --logger "console;verbosity=normal"
 /// </para>
 /// </summary>
+// Pure reporting benchmark (see summary above — "no assertions other than
+// doesn't crash"). Ran ~3 min under CI coverage despite gating nothing; tag it
+// so the CI filter (Category!=Benchmark&Category!=Performance) excludes it.
+[Trait("Category", "Benchmark")]
 [Collection("BlasManaged-Stats-Serial")]
 public class ComparativeBenchmark
 {

--- a/tests/AiDotNet.Tensors.Tests/Engines/Simd/TensorCodecMultiSizeBenchmark.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Simd/TensorCodecMultiSizeBenchmark.cs
@@ -10,6 +10,13 @@ using Xunit.Abstractions;
 
 namespace AiDotNet.Tensors.Tests.Engines.Simd
 {
+    // Pure diagnostic benchmark — every method only measures eager-vs-compiled
+    // timing and _output.WriteLine()s the numbers; there are NO Assert calls, so
+    // it gates nothing. It was running ~8+ minutes under CI coverage (the single
+    // longest test in the suite) because it lacked the category trait the CI
+    // filter (Category!=Benchmark&Category!=Performance) keys on. Tagged so it
+    // is excluded from the gating run; invoke it explicitly when profiling.
+    [Trait("Category", "Benchmark")]
     public class TensorCodecMultiSizeBenchmark
     {
         private readonly ITestOutputHelper _output;


### PR DESCRIPTION
## What

Tags `TensorCodecMultiSizeBenchmark` and `ComparativeBenchmark` with `[Trait("Category", "Benchmark")]` so the **existing** CI filter (`--filter "Category!=Benchmark&Category!=Performance"`) excludes them from the gating test run.

## Why

While investigating a reported test-suite slowdown, I found the gating CI build spends a large chunk of its ~30 min test phase on two tests that **gate nothing**:

| Test | Duration (CI, under coverage) |
|---|---|
| `TensorCodecMultiSizeBenchmark.MatMul_VaryingSizes_CompiledVsEager` | **8 m 19 s** (longest test in the suite) |
| `ComparativeBenchmark.Compare_BlasManaged_vs_NativeBLAS_FP64` | **3 m 3 s** |

Both classes are **pure reporting benchmarks** — every method only measures eager-vs-compiled / vs-native timing and `_output.WriteLine`s the numbers. Neither contains a single `Assert` (ComparativeBenchmark's own summary says *"no assertions other than doesn't crash"*). They carried no category trait, so they slipped past the CI filter and ran in every build.

## Safety

- **Zero coverage lost** — there are no assertions to lose.
- Verified with `dotnet test --list-tests`: with the CI filter the two classes are now excluded (0 matches); unfiltered they still resolve (20 entries) so they remain runnable for explicit profiling.
- This is **not** the `#441` changes — CI builds were already ~33 min at #432/#438 before #441 merged. This is the pre-existing cause.

## Impact

Trims ~11 min of serial work (and the single 8-min long-pole test) off the gating CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)