### PR TITLE
feat(cpu): opt-in DeterministicReductions for bit-reproducible training

### DIFF
--- a/src/AiDotNet.Tensors/Helpers/CpuParallelSettings.cs
+++ b/src/AiDotNet.Tensors/Helpers/CpuParallelSettings.cs
@@ -182,10 +182,11 @@ public static class CpuParallelSettings
         // Honor the class-level MaxDegreeOfParallelism contract: if the user has
         // pinned to 1 thread, run serial regardless of work size. Same
         // pattern as ParallelForChunks (line 84) and the legacy LightweightParallel
-        // code path. Snapshot the value once so a concurrent setter mid-call
-        // can't toggle us between paths.
+        // code path. Snapshot BOTH gating values once so a concurrent setter
+        // mid-call can't toggle us between the serial and parallel paths.
         int maxDegree = MaxDegreeOfParallelism;
-        if (maxDegree <= 1 || DeterministicReductions || totalWork < PersistentParallelExecutor.DefaultSerialGrainSize)
+        bool deterministic = DeterministicReductions;
+        if (maxDegree <= 1 || deterministic || totalWork < PersistentParallelExecutor.DefaultSerialGrainSize)
         {
             // Match Parallel.For's exception semantics: capture
             // first thrown exception, finish remaining iterations,
@@ -249,9 +250,10 @@ public static class CpuParallelSettings
         if (toExclusive <= fromInclusive) return;
         // Honor the class-level MaxDegreeOfParallelism contract: pinning to 1
         // forces serial regardless of work size (same as the Action<int>
-        // overload above). Snapshot once for consistency.
+        // overload above). Snapshot both gating values once for consistency.
         int maxDegree = MaxDegreeOfParallelism;
-        if (maxDegree <= 1 || DeterministicReductions || totalWork < PersistentParallelExecutor.DefaultSerialGrainSize)
+        bool deterministic = DeterministicReductions;
+        if (maxDegree <= 1 || deterministic || totalWork < PersistentParallelExecutor.DefaultSerialGrainSize)
         {
             // Serial fast path: one local accumulator, no
             // ParallelLoopState (Stop/Break never fire serial-side).

--- a/src/AiDotNet.Tensors/Helpers/CpuParallelSettings.cs
+++ b/src/AiDotNet.Tensors/Helpers/CpuParallelSettings.cs
@@ -24,6 +24,17 @@ public static class CpuParallelSettings
     public static int MaxDegreeOfParallelism { get; set; } = Environment.ProcessorCount;
 
     /// <summary>
+    /// When true, the grain-size-gated <see cref="ParallelForOrSerial(int,int,long,System.Action{int})"/>
+    /// helpers run serially regardless of work size. This is for the order-dependent reduction/
+    /// accumulation kernels routed through these helpers, whose multi-threaded partial-sum
+    /// combination is non-deterministic in floating point (thread-completion order). GEMM/conv use
+    /// their own parallel paths and are unaffected, so enabling this keeps those fast while making
+    /// reductions bit-reproducible. Default false (full speed); test harnesses that assert on exact
+    /// training trajectories set it true alongside <see cref="BlasProvider.SetDeterministicMode"/>.
+    /// </summary>
+    public static bool DeterministicReductions { get; set; }
+
+    /// <summary>
     /// Gets or sets whether SIMD (Single Instruction, Multiple Data) operations are enabled.
     /// </summary>
     /// <remarks>
@@ -174,7 +185,7 @@ public static class CpuParallelSettings
         // code path. Snapshot the value once so a concurrent setter mid-call
         // can't toggle us between paths.
         int maxDegree = MaxDegreeOfParallelism;
-        if (maxDegree <= 1 || totalWork < PersistentParallelExecutor.DefaultSerialGrainSize)
+        if (maxDegree <= 1 || DeterministicReductions || totalWork < PersistentParallelExecutor.DefaultSerialGrainSize)
         {
             // Match Parallel.For's exception semantics: capture
             // first thrown exception, finish remaining iterations,
@@ -240,7 +251,7 @@ public static class CpuParallelSettings
         // forces serial regardless of work size (same as the Action<int>
         // overload above). Snapshot once for consistency.
         int maxDegree = MaxDegreeOfParallelism;
-        if (maxDegree <= 1 || totalWork < PersistentParallelExecutor.DefaultSerialGrainSize)
+        if (maxDegree <= 1 || DeterministicReductions || totalWork < PersistentParallelExecutor.DefaultSerialGrainSize)
         {
             // Serial fast path: one local accumulator, no
             // ParallelLoopState (Stop/Break never fire serial-side).

--- a/tests/AiDotNet.Tensors.Tests/Helpers/ParallelForOrSerialDispatchTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/ParallelForOrSerialDispatchTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Threading;
+using AiDotNet.Tensors.Helpers;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Helpers;
+
+/// <summary>
+/// Coverage for <see cref="CpuParallelSettings.ParallelForOrSerial(int,int,long,System.Action{int})"/>
+/// and its localInit/localFinally overload, focused on the
+/// <see cref="CpuParallelSettings.DeterministicReductions"/> dispatch gate added
+/// for bit-reproducible training (PR #443). Verifies that (1) large total-work
+/// fans out to worker threads when the flag is false, and (2) the same large
+/// work runs entirely on the calling thread when the flag is true. Every test
+/// saves and restores the global flag so it can't leak into other tests.
+/// </summary>
+public class ParallelForOrSerialDispatchTests
+{
+    [Fact]
+    public void ParallelForOrSerial_LargeWork_DeterministicFalse_FansOutToWorkers()
+    {
+        // No worker pool to fan out to on a single-core host.
+        if (Environment.ProcessorCount <= 1)
+            return;
+
+        bool savedDeterministic = CpuParallelSettings.DeterministicReductions;
+        int savedMaxDegree = CpuParallelSettings.MaxDegreeOfParallelism;
+        try
+        {
+            CpuParallelSettings.DeterministicReductions = false;
+            CpuParallelSettings.MaxDegreeOfParallelism = Environment.ProcessorCount;
+
+            int callerThread = Thread.CurrentThread.ManagedThreadId;
+            int numChunks = Math.Max(2, Environment.ProcessorCount);
+            long totalWork = (long)PersistentParallelExecutor.DefaultSerialGrainSize * 4;
+            var observed = new int[numChunks];
+
+            // Same deterministic worker-probe as GrainSizeDispatchTests: a worker
+            // iteration Sets the event, caller-thread iterations Wait briefly for
+            // it. If nothing ever dispatched off-thread the Wait times out.
+            using var workerSeen = new ManualResetEventSlim(false);
+            CpuParallelSettings.ParallelForOrSerial(0, numChunks, totalWork, c =>
+            {
+                int tid = Thread.CurrentThread.ManagedThreadId;
+                observed[c] = tid;
+                if (tid != callerThread) workerSeen.Set();
+                else workerSeen.Wait(TimeSpan.FromMilliseconds(200));
+            });
+
+            bool sawWorker = false;
+            for (int c = 0; c < numChunks; c++)
+                if (observed[c] != callerThread) { sawWorker = true; break; }
+
+            Assert.True(sawWorker && workerSeen.IsSet,
+                $"totalWork ({totalWork}) >> grain size "
+                + $"({PersistentParallelExecutor.DefaultSerialGrainSize}) with DeterministicReductions=false "
+                + $"should have dispatched to the worker pool, but all {numChunks} chunks ran on caller "
+                + $"thread {callerThread}.");
+        }
+        finally
+        {
+            CpuParallelSettings.DeterministicReductions = savedDeterministic;
+            CpuParallelSettings.MaxDegreeOfParallelism = savedMaxDegree;
+        }
+    }
+
+    [Fact]
+    public void ParallelForOrSerial_DeterministicReductions_RunsOnCallerThread()
+    {
+        bool savedDeterministic = CpuParallelSettings.DeterministicReductions;
+        try
+        {
+            CpuParallelSettings.DeterministicReductions = true;
+
+            int callerThread = Thread.CurrentThread.ManagedThreadId;
+            int numChunks = Math.Max(4, Environment.ProcessorCount * 2);
+            // Well above the grain size — so serial dispatch can ONLY be due to
+            // the DeterministicReductions flag, not the work-size threshold.
+            long totalWork = (long)PersistentParallelExecutor.DefaultSerialGrainSize * 8;
+            var observed = new int[numChunks];
+
+            CpuParallelSettings.ParallelForOrSerial(0, numChunks, totalWork, c =>
+            {
+                observed[c] = Thread.CurrentThread.ManagedThreadId;
+            });
+
+            for (int c = 0; c < numChunks; c++)
+                Assert.Equal(callerThread, observed[c]);
+        }
+        finally
+        {
+            CpuParallelSettings.DeterministicReductions = savedDeterministic;
+        }
+    }
+
+    [Fact]
+    public void ParallelForOrSerial_Generic_DeterministicReductions_RunsOnCallerThread()
+    {
+        bool savedDeterministic = CpuParallelSettings.DeterministicReductions;
+        try
+        {
+            CpuParallelSettings.DeterministicReductions = true;
+
+            int callerThread = Thread.CurrentThread.ManagedThreadId;
+            int numChunks = Math.Max(4, Environment.ProcessorCount * 2);
+            long totalWork = (long)PersistentParallelExecutor.DefaultSerialGrainSize * 8;
+            var observed = new int[numChunks];
+            long sum = 0;
+
+            CpuParallelSettings.ParallelForOrSerial(
+                0, numChunks, totalWork,
+                localInit: () => 0L,
+                body: (i, _, local) =>
+                {
+                    observed[i] = Thread.CurrentThread.ManagedThreadId;
+                    return local + i;
+                },
+                localFinally: local => Interlocked.Add(ref sum, local));
+
+            for (int c = 0; c < numChunks; c++)
+                Assert.Equal(callerThread, observed[c]);
+            // localFinally must still run once and aggregate every iteration.
+            Assert.Equal((long)numChunks * (numChunks - 1) / 2, sum);
+        }
+        finally
+        {
+            CpuParallelSettings.DeterministicReductions = savedDeterministic;
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds `CpuParallelSettings.DeterministicReductions` (default `false`). When set, the two grain-size-gated `ParallelForOrSerial` helpers run serially regardless of work size, so the order-dependent reduction/accumulation kernels routed through them combine partial sums in a **fixed order** — removing the floating-point thread-completion-order non-determinism that tips near-converged loss comparisons.

GEMM/conv use `ParallelForChunks` (left untouched), so they stay fully parallel.

## Why

Downstream (AiDotNet PR #1423) has a tabular model invariant test — `TabDPTNetworkTests.MoreData_ShouldNotDegrade` — that flakes ~8% of runs because the multi-threaded backward reductions sum in a non-deterministic order, nudging a near-converged loss either side of the comparison. Seeding dropout fixed most of it; this flag closes the residual engine-side float noise without sacrificing CNN throughput.

## Verification (local, `0.81.99-detreduce2` nupkg wired into AiDotNet)

- `TabDPTNetworkTests.MoreData_ShouldNotDegrade`: **12/12** with the flag on (was ~8% flaky).
- `ResNetNetworkTests.Training_ShouldReduceLoss` (conv-heavy): **89s flag-on vs 97s flag-off** — within noise, *not degraded*. Confirms GEMM/conv `ParallelForChunks` is untouched and stays parallel.

## Notes

- Production default is `false` (full speed). Only test harnesses that assert on exact training trajectories enable it, alongside `BlasProvider.SetDeterministicMode`.
- **Not published** — opening this PR for review; AiDotNet PR #1423 will bump to the published version + flip the flag in its test base once this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)