### PR TITLE
feat(licensing): offline RSA-signed entitlement (server-independent trust anchor) + tamper-evidence + threat model

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -403,8 +403,9 @@ jobs:
           CODE_SIGNING_CERT_BASE64: ${{ secrets.CODE_SIGNING_CERT_BASE64 }}
           CODE_SIGNING_CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CERT_PASSWORD }}
         run: |
-          if ([string]::IsNullOrWhiteSpace($env:CODE_SIGNING_CERT_BASE64)) {
-            Write-Host "No CODE_SIGNING_CERT_BASE64 secret configured - skipping signing (packages will be UNSIGNED)."
+          if ([string]::IsNullOrWhiteSpace($env:CODE_SIGNING_CERT_BASE64) -or
+              [string]::IsNullOrWhiteSpace($env:CODE_SIGNING_CERT_PASSWORD)) {
+            Write-Host "Code-signing secrets are incomplete (CERT_BASE64 and/or CERT_PASSWORD missing) - skipping signing (packages will be UNSIGNED)."
             exit 0
           }
           $certPath = Join-Path ([System.IO.Path]::GetTempPath()) "aidotnet-codesign.pfx"

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -362,6 +362,45 @@ jobs:
           Write-Host "=== Packages created ==="
           Get-ChildItem out/
 
+      # Code-signs every .nupkg with the Ooples code-signing certificate so a
+      # tampered/repacked package fails NuGet signature verification (real
+      # tamper-evidence — see docs/enterprise/licensing-security-model.md). This
+      # is a NO-OP when the cert secrets are absent (forks, PRs, or before the
+      # cert is provisioned), so it never breaks a build. To activate, set the
+      # CODE_SIGNING_CERT_BASE64 (base64 of the .pfx) and CODE_SIGNING_CERT_PASSWORD
+      # repository secrets.
+      - name: Sign NuGet packages (if cert configured)
+        shell: pwsh
+        env:
+          CODE_SIGNING_CERT_BASE64: ${{ secrets.CODE_SIGNING_CERT_BASE64 }}
+          CODE_SIGNING_CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CERT_PASSWORD }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:CODE_SIGNING_CERT_BASE64)) {
+            Write-Host "No CODE_SIGNING_CERT_BASE64 secret configured - skipping signing (packages will be UNSIGNED)."
+            exit 0
+          }
+          $certPath = Join-Path ([System.IO.Path]::GetTempPath()) "aidotnet-codesign.pfx"
+          [System.IO.File]::WriteAllBytes($certPath, [System.Convert]::FromBase64String($env:CODE_SIGNING_CERT_BASE64))
+          try {
+            $pkgs = Get-ChildItem out/*.nupkg
+            foreach ($pkg in $pkgs) {
+              Write-Host "Signing $($pkg.Name)..."
+              dotnet nuget sign "$($pkg.FullName)" `
+                --certificate-path $certPath `
+                --certificate-password $env:CODE_SIGNING_CERT_PASSWORD `
+                --timestamper "http://timestamp.digicert.com"
+              if ($LASTEXITCODE -ne 0) { Write-Error "Signing failed for $($pkg.Name)"; exit $LASTEXITCODE }
+            }
+            Write-Host "All packages signed. Verifying..."
+            foreach ($pkg in $pkgs) {
+              dotnet nuget verify "$($pkg.FullName)" --all
+              if ($LASTEXITCODE -ne 0) { Write-Error "Verification failed for $($pkg.Name)"; exit $LASTEXITCODE }
+            }
+          }
+          finally {
+            Remove-Item $certPath -Force -ErrorAction SilentlyContinue
+          }
+
       - name: Upload package artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -279,6 +279,34 @@ jobs:
           dotnet restore
           dotnet build -c Release --no-restore -p:TelemetryUrl="${{ secrets.AIDOTNET_TELEMETRY_URL }}" -p:TelemetryKey="${{ secrets.AIDOTNET_TELEMETRY_KEY }}"
 
+      # Obfuscation / anti-tamper integration point. Runs the obfuscator you
+      # provision over the freshly-built Release DLLs BEFORE they're packed, so
+      # the published assemblies are protected. This is a NO-OP until you set the
+      # OBFUSCATOR_EXE repository variable (path/command of your licensed tool,
+      # e.g. Eazfuscator/Dotfuscator CLI) and optional OBFUSCATOR_ARGS — so it
+      # never breaks a build. See docs/enterprise/licensing-security-model.md.
+      # NOTE: validate your tool against this reflection/generics-heavy library
+      # in a staging release first — aggressive obfuscation can break runtime
+      # behaviour. (No OSS default is wired in: ConfuserEx is unmaintained and
+      # risks breaking this assembly.)
+      - name: Obfuscate Release assemblies (if obfuscator configured)
+        shell: pwsh
+        env:
+          OBFUSCATOR_EXE: ${{ vars.OBFUSCATOR_EXE }}
+          OBFUSCATOR_ARGS: ${{ vars.OBFUSCATOR_ARGS }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:OBFUSCATOR_EXE)) {
+            Write-Host "No OBFUSCATOR_EXE configured - skipping obfuscation (assemblies will be UNobfuscated)."
+            exit 0
+          }
+          $targets = Get-ChildItem -Recurse -Path src -Filter AiDotNet.Tensors.dll |
+                     Where-Object { $_.FullName -match '[\\/]bin[\\/]Release[\\/]' }
+          foreach ($dll in $targets) {
+            Write-Host "Obfuscating $($dll.FullName)..."
+            & $env:OBFUSCATOR_EXE @($env:OBFUSCATOR_ARGS -split ' ' | Where-Object { $_ }) "$($dll.FullName)"
+            if ($LASTEXITCODE -ne 0) { Write-Error "Obfuscation failed for $($dll.Name)"; exit $LASTEXITCODE }
+          }
+
       - name: Pack NuGet packages
         shell: pwsh
         run: |

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -299,8 +299,19 @@ jobs:
             Write-Host "No OBFUSCATOR_EXE configured - skipping obfuscation (assemblies will be UNobfuscated)."
             exit 0
           }
-          $targets = Get-ChildItem -Recurse -Path src -Filter AiDotNet.Tensors.dll |
-                     Where-Object { $_.FullName -match '[\\/]bin[\\/]Release[\\/]' }
+          # Wrap in @() so a single-match result is still iterable as a
+          # collection (PowerShell unwraps a one-element pipeline result to
+          # the scalar otherwise, and .Count then returns the byte length).
+          $targets = @(Get-ChildItem -Recurse -Path src -Filter AiDotNet.Tensors.dll |
+                     Where-Object { $_.FullName -match '[\\/]bin[\\/]Release[\\/]' })
+          if ($targets.Count -eq 0) {
+            # Fail closed: OBFUSCATOR_EXE was explicitly configured but the
+            # Release glob found nothing to obfuscate. Shipping unobfuscated
+            # packages from a hardening-enabled job is exactly the silent
+            # weakening this guard exists to prevent.
+            Write-Error "OBFUSCATOR_EXE is configured but no src/**/bin/Release/AiDotNet.Tensors.dll were found - refusing to ship unobfuscated packages."
+            exit 1
+          }
           foreach ($dll in $targets) {
             Write-Host "Obfuscating $($dll.FullName)..."
             & $env:OBFUSCATOR_EXE @($env:OBFUSCATOR_ARGS -split ' ' | Where-Object { $_ }) "$($dll.FullName)"

--- a/build/keys/.gitignore
+++ b/build/keys/.gitignore
@@ -1,0 +1,7 @@
+# NEVER commit signing private keys. These are the trust anchors for enterprise
+# licensing — committing one compromises it permanently (git history is forever).
+*.pem
+*.key
+*.pfx
+*-PRIVATE*
+*private*

--- a/build/keys/generate-signing-keys.ps1
+++ b/build/keys/generate-signing-keys.ps1
@@ -1,0 +1,83 @@
+<#
+.SYNOPSIS
+  Generates an RSA-2048 signing keypair for AiDotNet enterprise licensing and
+  prints the PUBLIC key in the exact "{modulusBase64}:{exponentBase64}" form the
+  client embeds (RSAParameters layout — matches SignedEntitlement /
+  LicenseResponseVerifier import code byte-for-byte).
+
+.DESCRIPTION
+  RUN THIS IN A SECURE ENVIRONMENT (a clean operator workstation or, better, an
+  HSM-backed host). The PRIVATE key it writes is the entire trust anchor for that
+  signing purpose — anyone who obtains it can mint valid entitlements / sign
+  responses. Move it into your HSM or secret manager and DELETE the local copy.
+  NEVER commit it. The matching .gitignore in this folder blocks the default
+  output names, but do not rely on that alone.
+
+  Uses .NET's own RSA so the exported public key is guaranteed to import cleanly
+  via RSA.ImportParameters on both net471 and net10.0.
+
+.PARAMETER Purpose
+  'entitlement' (paste into SignedEntitlement.EntitlementPublicKey) or
+  'response'    (paste into LicenseResponseVerifier.ResponseSigningPublicKey).
+  These MUST be two DIFFERENT keypairs (compromise isolation).
+
+.PARAMETER OutDir
+  Directory to write the private key to. Defaults to the current directory.
+
+.EXAMPLE
+  pwsh ./generate-signing-keys.ps1 -Purpose entitlement -OutDir C:\secure
+  pwsh ./generate-signing-keys.ps1 -Purpose response    -OutDir C:\secure
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][ValidateSet('entitlement', 'response')]
+    [string]$Purpose,
+    [string]$OutDir = (Get-Location).Path
+)
+
+$ErrorActionPreference = 'Stop'
+
+$rsa = [System.Security.Cryptography.RSA]::Create()
+if ($rsa.KeySize -ne 2048) { $rsa.KeySize = 2048 }
+
+$pub = $rsa.ExportParameters($false)
+$embed = [Convert]::ToBase64String($pub.Modulus) + ':' + [Convert]::ToBase64String($pub.Exponent)
+
+# Export the PRIVATE key as PKCS#8 PEM for transfer into your HSM/secret store.
+$privPath = Join-Path $OutDir "aidotnet-$Purpose-signing-PRIVATE.pem"
+$pkcs8 = $rsa.ExportPkcs8PrivateKey()
+$pem = "-----BEGIN PRIVATE KEY-----`n" +
+       ([Convert]::ToBase64String($pkcs8, 'InsertLineBreaks')) +
+       "`n-----END PRIVATE KEY-----`n"
+[System.IO.File]::WriteAllText($privPath, $pem)
+
+$constName = if ($Purpose -eq 'entitlement') {
+    'SignedEntitlement.EntitlementPublicKey'
+} else {
+    'LicenseResponseVerifier.ResponseSigningPublicKey'
+}
+
+Write-Host ""
+Write-Host "=== AiDotNet $Purpose signing keypair generated ===" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "PUBLIC KEY (embed this — paste as the value of $constName):" -ForegroundColor Green
+Write-Host ""
+Write-Host "  `"$embed`""
+Write-Host ""
+Write-Host "PRIVATE KEY written to: $privPath" -ForegroundColor Yellow
+Write-Host ""
+Write-Host "  !! MOVE this into your HSM / secret manager and DELETE the local file." -ForegroundColor Red
+Write-Host "  !! NEVER commit it. Anyone with it can forge $Purpose signatures." -ForegroundColor Red
+Write-Host ""
+Write-Host "Next:" -ForegroundColor Cyan
+if ($Purpose -eq 'entitlement') {
+    Write-Host "  - Replace the placeholder in src/AiDotNet.Tensors/Licensing/SignedEntitlement.cs"
+    Write-Host "  - Sign customer entitlements with the private key (see build/LicenseValidator/README.md)."
+} else {
+    Write-Host "  - Replace the placeholder in src/AiDotNet.Tensors/Licensing/LicenseResponseVerifier.cs"
+    Write-Host "  - Load the private key into the Supabase Edge Function (see"
+    Write-Host "    docs/enterprise/license-server-response-signing.md)."
+}
+Write-Host ""
+
+$rsa.Dispose()

--- a/build/keys/generate-signing-keys.ps1
+++ b/build/keys/generate-signing-keys.ps1
@@ -22,7 +22,11 @@
   These MUST be two DIFFERENT keypairs (compromise isolation).
 
 .PARAMETER OutDir
-  Directory to write the private key to. Defaults to the current directory.
+  Directory to write the private key to. Defaults to the SCRIPT's directory
+  (build/keys/), which is covered by .gitignore — so a run with no -OutDir
+  argument cannot accidentally drop the private PEM into a parent folder that
+  the operator might subsequently `git add`. Override with an explicit path
+  outside the repo (preferably on encrypted storage) for production use.
 
 .EXAMPLE
   pwsh ./generate-signing-keys.ps1 -Purpose entitlement -OutDir C:\secure
@@ -32,10 +36,14 @@
 param(
     [Parameter(Mandatory = $true)][ValidateSet('entitlement', 'response')]
     [string]$Purpose,
-    [string]$OutDir = (Get-Location).Path
+    [string]$OutDir = $PSScriptRoot
 )
 
 $ErrorActionPreference = 'Stop'
+
+# Ensure the (possibly operator-supplied) output directory exists before we
+# try to write the private PEM into it. Idempotent when it already exists.
+New-Item -ItemType Directory -Path $OutDir -Force | Out-Null
 
 $rsa = [System.Security.Cryptography.RSA]::Create()
 if ($rsa.KeySize -ne 2048) { $rsa.KeySize = 2048 }

--- a/build/keys/generate-signing-keys.ps1
+++ b/build/keys/generate-signing-keys.ps1
@@ -53,6 +53,14 @@ $embed = [Convert]::ToBase64String($pub.Modulus) + ':' + [Convert]::ToBase64Stri
 
 # Export the PRIVATE key as PKCS#8 PEM for transfer into your HSM/secret store.
 $privPath = Join-Path $OutDir "aidotnet-$Purpose-signing-PRIVATE.pem"
+# Refuse to clobber an existing private key — a silent overwrite on an
+# accidental rerun would destroy the only local copy of the active signing key
+# (and effectively rotate it while the matching public key is still embedded
+# and in production use). The operator must move the prior PEM into their
+# HSM/secret store and delete it from disk before regenerating.
+if (Test-Path -LiteralPath $privPath) {
+    throw "Refusing to overwrite existing private key at $privPath. Move/delete it first if you intend to regenerate."
+}
 $pkcs8 = $rsa.ExportPkcs8PrivateKey()
 $pem = "-----BEGIN PRIVATE KEY-----`n" +
        ([Convert]::ToBase64String($pkcs8, 'InsertLineBreaks')) +

--- a/build/license-server/sign-validation-response.ts
+++ b/build/license-server/sign-validation-response.ts
@@ -1,0 +1,88 @@
+// Reference implementation — Supabase Edge Function (Deno) response signing.
+//
+// Drop this into your existing `validate-license` Edge Function. It signs the
+// validation response over the client's per-request nonce so the .NET client
+// (LicenseResponseVerifier) can reject spoofed/MITM'd servers when a customer
+// sets RequireSignedResponse = true. See
+// docs/enterprise/license-server-response-signing.md for the full contract.
+//
+// SECRET: store the RSA-2048 PKCS#8 PEM private key as the Edge Function secret
+// RESPONSE_SIGNING_PRIVATE_KEY_PEM (its PUBLIC half is embedded in the client as
+// LicenseResponseVerifier.ResponseSigningPublicKey). Never log or return it.
+
+const PEM_HEADER = "-----BEGIN PRIVATE KEY-----";
+const PEM_FOOTER = "-----END PRIVATE KEY-----";
+
+/** Imports the PKCS#8 PEM private key for RSASSA-PKCS1-v1_5 / SHA-256 signing. */
+async function importPrivateKey(pem: string): Promise<CryptoKey> {
+  const b64 = pem
+    .replace(PEM_HEADER, "")
+    .replace(PEM_FOOTER, "")
+    .replace(/\s+/g, "");
+  const der = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+  return await crypto.subtle.importKey(
+    "pkcs8",
+    der,
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+}
+
+/**
+ * Canonical string — MUST match LicenseResponseVerifier.BuildCanonical
+ * byte-for-byte: nonce\nstatus\ntier\nexpires\ncaps  where caps are ordinal-
+ * sorted and comma-joined, and absent fields are the empty string.
+ */
+function buildCanonical(
+  nonce: string,
+  status: string,
+  tier: string | null,
+  expiresAt: string | null,
+  capabilities: string[],
+): string {
+  const caps = [...capabilities].filter((c) => c).sort(); // JS default sort is by UTF-16 code unit (ordinal for ASCII capability names)
+  return [nonce, status, tier ?? "", expiresAt ?? "", caps.join(",")].join("\n");
+}
+
+/** Returns the base64 RSA-2048 PKCS#1 SHA-256 signature over the canonical form. */
+export async function signValidationResponse(
+  nonce: string,
+  status: string,
+  tier: string | null,
+  expiresAt: string | null,
+  capabilities: string[],
+): Promise<string> {
+  const pem = Deno.env.get("RESPONSE_SIGNING_PRIVATE_KEY_PEM");
+  if (!pem) throw new Error("RESPONSE_SIGNING_PRIVATE_KEY_PEM secret is not set.");
+  const key = await importPrivateKey(pem);
+  const canonical = new TextEncoder().encode(
+    buildCanonical(nonce, status, tier, expiresAt, capabilities),
+  );
+  const sig = await crypto.subtle.sign("RSASSA-PKCS1-v1_5", key, canonical);
+  return btoa(String.fromCharCode(...new Uint8Array(sig)));
+}
+
+// ── Integration sketch (inside your existing handler) ───────────────────────
+//
+//   const { license_key, package: pkg, nonce } = await req.json();
+//   const result = await validateLicense(license_key, pkg);  // your existing logic
+//
+//   // NEW: sign the response over the client's nonce when one was supplied.
+//   let signature: string | undefined;
+//   if (nonce) {
+//     signature = await signValidationResponse(
+//       nonce, result.status, result.tier ?? null,
+//       result.expires_at ?? null, result.capabilities ?? [],
+//     );
+//   }
+//
+//   return new Response(JSON.stringify({ ...result, signature }), {
+//     headers: { "content-type": "application/json" },
+//   });
+//
+// NOTE on capability ordering: the client sorts capabilities with .NET's
+// StringComparer.Ordinal before verifying. JS Array.sort() on ASCII capability
+// strings (e.g. "tensors:load", "tensors:save") yields the same order. If you
+// ever introduce non-ASCII capability names, switch to an explicit ordinal
+// (code-unit) comparator on BOTH sides.

--- a/docs/enterprise/license-server-response-signing.md
+++ b/docs/enterprise/license-server-response-signing.md
@@ -43,7 +43,7 @@ later request.
 
 The client reconstructs and verifies exactly this (`LicenseResponseVerifier.BuildCanonical`):
 
-```
+```text
 {nonce}\n{status}\n{tier}\n{expires_at}\n{capabilities_csv}
 ```
 

--- a/docs/enterprise/license-server-response-signing.md
+++ b/docs/enterprise/license-server-response-signing.md
@@ -1,0 +1,100 @@
+# License server: validation-response signing contract
+
+This is the **server-side** half of the anti-spoof / anti-replay hardening. The
+client (`LicenseResponseVerifier` + `LicenseValidator`) is already implemented
+and will enforce it once (a) the server signs responses per this contract and
+(b) the customer sets `AiDotNetTensorsLicenseKey.RequireSignedResponse = true`.
+Until both hold, the online path behaves exactly as before (unsigned).
+
+> **Why:** the online response is otherwise unsigned JSON, so an attacker who
+> redirects the endpoint (hosts file / proxy / DNS) can return
+> `{"status":"active"}` and bypass the online check. Signing the response over a
+> client nonce closes that.
+
+## 1. Keypair
+
+Generate an RSA-2048 keypair for response signing. This is a **separate** key
+from the entitlement-signing key (compromise isolation).
+
+```bash
+openssl genrsa -out response-signing.key 2048
+# Export the public key as modulus:exponent (matches RSAParameters import client-side):
+openssl rsa -in response-signing.key -noout -modulus            # → Modulus=HEX...
+openssl rsa -in response-signing.key -pubout                    # (for reference)
+```
+
+Convert modulus + exponent (65537 → `AQAB`) to base64 and embed in the client as
+`LicenseResponseVerifier.ResponseSigningPublicKey = "{modulusBase64}:{exponentBase64}"`.
+Keep the **private** key in the server's secret store / HSM only.
+
+## 2. Request
+
+The client sends, in the existing JSON POST body, a new field:
+
+```json
+{ "license_key": "...", "package": "AiDotNet.Tensors", "nonce": "<base64url, 256-bit, per-request>" }
+```
+
+The `nonce` is fresh per request and unpredictable. The server MUST echo it into
+the signed payload (below) so a captured response can't be replayed against a
+later request.
+
+## 3. Canonical string to sign (MUST match byte-for-byte)
+
+The client reconstructs and verifies exactly this (`LicenseResponseVerifier.BuildCanonical`):
+
+```
+{nonce}\n{status}\n{tier}\n{expires_at}\n{capabilities_csv}
+```
+
+- `\n` is U+000A (LF), single byte. Five logical fields, four separators.
+- `status`: the same string returned in the body (`active` / `expired` / `revoked` / `seat_limit_reached` / `invalid`).
+- `tier`: the tier string, or empty if none.
+- `expires_at`: the same string returned in the body's `expires_at`, or empty if none.
+- `capabilities_csv`: the capability strings **sorted with ordinal (byte) ordering** and joined by `,` (comma, no spaces). Empty string if none.
+- Absent fields are the empty string (not `null`, not the literal `"null"`).
+
+Sign `UTF-8(canonical)` with RSA-2048 **PKCS#1 v1.5**, **SHA-256**.
+
+## 4. Response
+
+Return the existing fields plus a base64 `signature`:
+
+```json
+{
+  "status": "active",
+  "tier": "enterprise",
+  "expires_at": "2027-05-22",
+  "capabilities": ["tensors:load", "tensors:save"],
+  "signature": "<base64 RSA-2048 PKCS#1 SHA-256 over the canonical string>"
+}
+```
+
+The `capabilities` array order in the JSON body does not matter (the client
+sorts before verifying), but the **signed** canonical uses the ordinal-sorted
+order — make sure the server sorts identically before signing.
+
+## 5. Client behaviour (already implemented — for reference)
+
+- `RequireSignedResponse == false` (default): signature ignored; unchanged.
+- `RequireSignedResponse == true`:
+  - missing/invalid `signature`, wrong key, or nonce/field mismatch → result
+    downgraded to `Invalid` ("failed signature verification … possible spoofed
+    server"), regardless of the body's `status`.
+  - valid signature → the body's status/tier/caps are trusted.
+
+## 6. Reference signing snippet (server pseudo-code)
+
+```python
+caps_csv = ",".join(sorted(capabilities))           # ordinal sort
+canonical = f"{nonce}\n{status}\n{tier or ''}\n{expires_at or ''}\n{caps_csv}"
+signature = rsa_pkcs1_sha256_sign(private_key, canonical.encode("utf-8"))
+response["signature"] = base64.b64encode(signature).decode()
+```
+
+## Honest scope
+
+This hardens the **online/standard** tier against server-spoof trial-bypass. It
+is bypassable by patching the client (managed code). The **high-assurance**
+trust anchor is the fully-offline `SignedEntitlement` (no server) — see
+`licensing-security-model.md`.

--- a/docs/enterprise/licensing-security-model.md
+++ b/docs/enterprise/licensing-security-model.md
@@ -97,15 +97,25 @@ infra/tooling, not code:
    `license-server-response-signing.md` and (b) the customer enables
    `RequireSignedResponse`. **Note:** the offline entitlement already covers the
    high-assurance case, so this only matters if trial-bypass is a concern.
-4. **NativeAOT the enforcement path** *(architecture initiative)*. Compiling
-   enforcement to native code turns "minutes in dnSpy" into serious reverse
-   engineering. Flipping the *whole* tensor library to AOT is infeasible
+4. **NativeAOT the enforcement path** *(architecture initiative — FULLY DESIGNED)*.
+   Compiling enforcement to native code turns "minutes in dnSpy" into serious
+   reverse engineering. Flipping the *whole* tensor library to AOT is infeasible
    (reflection/generics); the real path is extracting enforcement into a small,
-   separately-AOT-compiled component. Scoped as its own project.
-5. **Commercial obfuscation / anti-tamper** *(tooling)*. ConfuserEx (OSS) or a
-   commercial SDK (e.g. Dotfuscator) integrated into the publish step. Raises
-   reverse-engineering cost; still crackable. Requires pipeline integration; not
-   something a source edit delivers.
+   separately-AOT-compiled component. Complete architecture, P/Invoke contract,
+   the anti-no-op "binding" design, and the per-OS CI build matrix are in
+   `nativeaot-enforcement-design.md`. **Blocker:** needs the 4-runner native
+   build matrix (a single machine can't produce cross-platform native binaries,
+   and a single-RID dependency would break Linux CI / non-Windows consumers).
+   Honest ceiling: the managed call site stays patchable unless the native
+   component gates something the app genuinely needs (the "binding").
+5. **Commercial obfuscation / anti-tamper** *(tooling — INTEGRATION POINT WIRED)*.
+   The release pipeline has a guarded "Obfuscate Release assemblies" step that
+   runs your obfuscator over the built DLLs before pack — a **no-op until** you
+   set the `OBFUSCATOR_EXE` (+ optional `OBFUSCATOR_ARGS`) repository variables.
+   **Blocker:** the obfuscator itself is a licensed product (Eazfuscator /
+   Dotfuscator / PreEmptive) that must be provisioned; no OSS default is wired
+   in because ConfuserEx is unmaintained and risks breaking this
+   reflection/generics-heavy assembly. Validate against a staging release first.
 
 ## What actually protects enterprise revenue
 

--- a/docs/enterprise/licensing-security-model.md
+++ b/docs/enterprise/licensing-security-model.md
@@ -81,16 +81,21 @@ infra/tooling, not code:
    `InternalsVisibleTo` friend (incl. the test assemblies) must then also be
    strong-named / use public-key IVT, or the build breaks. Deferred because it's
    a cross-cutting change with real breakage risk and net471-only value.
-2. **Authenticode-sign the published DLLs/NuGet** *(release-eng, real)*. A
-   patched DLL fails OS signature verification; deployment policy can enforce
-   signed-only loading. This is the most practical real tamper-evidence. Belongs
-   in the release pipeline.
-3. **Sign the online validation response + client nonce** *(needs server change)*.
-   Closes the server-spoof trial-bypass. Requires the Supabase Edge Function to
-   sign `(nonce, status, tier, expiry, capabilities)` with a key whose public
-   half is embedded client-side. Client verification is straightforward to add
-   once the server signs; until then it would be inert, so it's deferred behind
-   the server work. **Note:** the offline entitlement already covers the
+2. **Sign the published NuGet packages** *(release-eng, real)* — **SCAFFOLDED.**
+   A patched/repacked `.nupkg` fails NuGet signature verification. The release
+   pipeline (`.github/workflows/automated-release.yml`) now signs every package
+   via `dotnet nuget sign` + timestamp; it's a **no-op until** the
+   `CODE_SIGNING_CERT_BASE64` / `CODE_SIGNING_CERT_PASSWORD` secrets are set, so
+   it never breaks a build. **To activate:** provision an Ooples code-signing
+   certificate and add those two secrets. (Authenticode-signing the individual
+   DLLs is a further step — `signtool`/`osslsigncode` — once a cert exists.)
+3. **Sign the online validation response + client nonce** *(client DONE, needs
+   server change to activate)*. The client (`LicenseResponseVerifier`,
+   `RequireSignedResponse`) is implemented and tested; it sends a per-request
+   nonce and verifies an RSA signature over `(nonce|status|tier|expires|caps)`.
+   It activates once (a) the Supabase Edge Function signs per
+   `license-server-response-signing.md` and (b) the customer enables
+   `RequireSignedResponse`. **Note:** the offline entitlement already covers the
    high-assurance case, so this only matters if trial-bypass is a concern.
 4. **NativeAOT the enforcement path** *(architecture initiative)*. Compiling
    enforcement to native code turns "minutes in dnSpy" into serious reverse

--- a/docs/enterprise/licensing-security-model.md
+++ b/docs/enterprise/licensing-security-model.md
@@ -1,0 +1,112 @@
+# AiDotNet.Tensors — licensing security model & threat analysis
+
+This is the honest, end-to-end picture of how enterprise/commercial licensing is
+enforced, **what it does and does not protect against**, and the remaining
+hardening work with realistic feasibility. Read the "Ceiling" section first — it
+sets the expectations everything else is measured against.
+
+## The ceiling (non-negotiable truth)
+
+Enforcement that runs **client-side**, in **managed .NET bytecode**, in a
+**source-available (BSL)** library **cannot be made un-jailbreakable.** The check
+executes on hardware the attacker controls; the IL can be decompiled and patched
+(dnSpy/ILSpy) in minutes; and with source they can simply rebuild without the
+gate. This is true of *all* client-side DRM. The realistic, achievable goal is:
+
+> **Unforgeable trust anchors + tamper-evidence + raise the cost of a bypass high
+> enough that it's cheaper to buy a license — backed by the contract/audit
+> relationship that actually protects enterprise revenue.**
+
+Shipping anything that *looks* locked-down but isn't (e.g. a runtime self-integrity
+check whose "expected" value lives in the same patchable DLL) is **worse than
+nothing** — it creates false confidence. We do not do that here.
+
+## Layers (what's implemented)
+
+| Layer | Trust anchor | Forgeable? | Bypassable? | Status |
+|---|---|---|---|---|
+| **Build-time flag gate** (`build/AiDotNet.Tensors.Enterprise.targets`) | RSA-2048 signed license file + `keyHash(key)` | No (needs private key) | Yes, with source (remove the gate) | shipped (#439) |
+| **Runtime offline entitlement** (`SignedEntitlement` → `PersistenceGuard`) | RSA-2048 signed token, embedded public key, **offline** | **No** (needs private key) | Yes, by IL-patching the check | shipped (this work) |
+| **Runtime online validation** (`LicenseValidator`) | License server response | **Yes — response is unsigned → server-spoofable** | Yes (spoof server or patch) | shipped, low-trust tier |
+| **Trial** (`TrialState`) | local JSON file | n/a | Yes (edit the file) | shipped, lowest tier |
+
+**Key design point:** high-assurance customers use the **offline signed
+entitlement**, whose trust anchor is an RSA signature an attacker cannot forge —
+*not* the online server. The online path's spoofability therefore only risks a
+**trial bypass** (low tier), not an enterprise bypass. Enterprise = offline
+entitlement, full stop.
+
+### Why the offline entitlement matters
+
+`PersistenceGuard.EnforceCore` checks a signed entitlement **first**
+(`AIDOTNET_LICENSE_TOKEN` env var, or `~/.aidotnet/tensors-entitlement.json`):
+
+- The token's RSA-2048 PKCS#1 SHA-256 signature is verified against an embedded
+  public key, **fully offline** (no server to spoof).
+- Marker/expiry/capabilities are read from the **signed** payload only.
+- A valid entitlement authorises the op with no network call and no trial tick.
+- A **present-but-invalid** token hard-fails (and is logged as a possible forged
+  token) — it does *not* silently degrade to the free trial.
+- Ships with a **placeholder** public key, so the feature is **inert** until the
+  real key is embedded (no behavior change on release).
+
+## Issuing an entitlement (operator guide)
+
+Mirror `build/LicenseValidator/README.md`. Generate the keypair once; embed the
+**public** key in `SignedEntitlement.EntitlementPublicKey` as
+`{modulusBase64}:{exponentBase64}` (RSAParameters form — cross-TFM, no
+BouncyCastle). Keep the **private** key in the HSM/secret manager.
+
+```bash
+# Sign the entitlement payload (private key never leaves the HSM):
+cat > ent.json <<'EOF'
+{ "marker":"AiDotNet-Tensors-Entitlement-v1","tenant":"ACME Corp.",
+  "expires":"2027-05-22","capabilities":["tensors:save","tensors:load"] }
+EOF
+PAYLOAD=$(openssl enc -base64 -A < ent.json)
+SIG=$(openssl dgst -sha256 -sign ent-signing.key ent.json | openssl enc -base64 -A)
+printf '{"payload":"%s","signature":"%s"}' "$PAYLOAD" "$SIG" > tensors-entitlement.json
+# Customer sets AIDOTNET_LICENSE_TOKEN to this JSON (or a path to it).
+```
+
+## Hardening roadmap (NOT yet done — honest feasibility)
+
+These raise the bypass cost; **none make it absolute**, and several are
+infra/tooling, not code:
+
+1. **Strong-name the assembly** *(release-eng, real on net471 only)*. A patched
+   strong-named assembly fails CLR signature verification on .NET Framework
+   (re-signing needs the SN private key). **Caveat:** .NET Core / net10.0 does
+   **not** verify strong names at load → no protection there. **Caveat:** every
+   `InternalsVisibleTo` friend (incl. the test assemblies) must then also be
+   strong-named / use public-key IVT, or the build breaks. Deferred because it's
+   a cross-cutting change with real breakage risk and net471-only value.
+2. **Authenticode-sign the published DLLs/NuGet** *(release-eng, real)*. A
+   patched DLL fails OS signature verification; deployment policy can enforce
+   signed-only loading. This is the most practical real tamper-evidence. Belongs
+   in the release pipeline.
+3. **Sign the online validation response + client nonce** *(needs server change)*.
+   Closes the server-spoof trial-bypass. Requires the Supabase Edge Function to
+   sign `(nonce, status, tier, expiry, capabilities)` with a key whose public
+   half is embedded client-side. Client verification is straightforward to add
+   once the server signs; until then it would be inert, so it's deferred behind
+   the server work. **Note:** the offline entitlement already covers the
+   high-assurance case, so this only matters if trial-bypass is a concern.
+4. **NativeAOT the enforcement path** *(architecture initiative)*. Compiling
+   enforcement to native code turns "minutes in dnSpy" into serious reverse
+   engineering. Flipping the *whole* tensor library to AOT is infeasible
+   (reflection/generics); the real path is extracting enforcement into a small,
+   separately-AOT-compiled component. Scoped as its own project.
+5. **Commercial obfuscation / anti-tamper** *(tooling)*. ConfuserEx (OSS) or a
+   commercial SDK (e.g. Dotfuscator) integrated into the publish step. Raises
+   reverse-engineering cost; still crackable. Requires pipeline integration; not
+   something a source edit delivers.
+
+## What actually protects enterprise revenue
+
+For enterprise/federal/air-gapped customers, the technical guard is the
+*deterrent and the audit trail*; the **contract + audit** is the enforcement.
+Those customers are the most contractually bound and the least likely to crack a
+license — which is exactly why the perpetual air-gapped build
+(`AIDOTNET_DISABLE_LICENSE_GUARD`, gated by the build-time RSA check) is the
+*least* runtime-enforced tier by design.

--- a/docs/enterprise/nativeaot-enforcement-design.md
+++ b/docs/enterprise/nativeaot-enforcement-design.md
@@ -1,0 +1,108 @@
+# NativeAOT enforcement extraction — design & execution plan
+
+Goal: move the most patch-attractive enforcement decision out of trivially
+decompilable managed IL into a **NativeAOT-compiled native component**, so
+defeating it requires native reverse-engineering instead of a 2-minute dnSpy
+edit. This is a real, multi-platform engineering initiative — it cannot be a
+single code edit, and it has an **honest benefit ceiling** (below). This doc is
+the complete plan so it can be executed when the multi-platform CI is committed.
+
+## Honest benefit & ceiling (read first)
+
+- **What it buys:** the *check itself* (signature verify / entitlement decision)
+  becomes native machine code — no symbol names, no IL, far harder to patch.
+- **What it does NOT buy:** the **managed call site** that invokes the native
+  check and decides whether to throw is *still managed IL*, so an attacker can
+  patch the caller to ignore the result, or replace the native `.dll`/`.so`
+  with a stub. To make this meaningful, the native component must gate something
+  the app **genuinely needs**, not just return a bool — see "Binding" below.
+- Net: this raises attacker cost from "minutes" to "hours/days", but does not
+  make client-side enforcement absolute. Prioritize signing + entitlement +
+  contract first; do this only if the threat model justifies the cost.
+
+## Architecture
+
+```
+AiDotNet.Tensors (managed, net471 + net10.0)
+        │  P/Invoke  [DllImport("aidotnet_license_native")]
+        ▼
+aidotnet_license_native  (NativeAOT -p:NativeLib=Shared)
+  - RSA-verify the signed entitlement (embedded public key, native)
+  - return a license-derived value (see Binding), not just a bool
+  shipped as runtimes/{rid}/native/{lib} in the NuGet package
+```
+
+### Binding (so it can't be no-op'd)
+
+Returning a bool is patch-trivial. Instead, have the native component derive a
+small value the managed persistence path actually consumes — e.g. it returns a
+verified capability set / a key the codec uses to finalize a header — so a
+stubbed native lib produces wrong output rather than "free access". Keep this
+*cheap* (verify once, cache) so legitimate users pay ~nothing. Designing this
+binding without hurting legit performance/usability is the hard part and must be
+reviewed carefully — a bad binding degrades the product for paying customers.
+
+## Project layout
+
+```
+src/AiDotNet.Native.LicenseGuard/        # NativeAOT shared lib
+  AiDotNet.Native.LicenseGuard.csproj     # <PublishAot>, <NativeLib>Shared</NativeLib>
+  Exports.cs                              # [UnmanagedCallersOnly(EntryPoint="...")]
+src/AiDotNet.Tensors/Licensing/
+  NativeLicenseGuard.cs                   # [DllImport] wrapper + managed fallback
+```
+
+The managed wrapper must degrade safely if the native lib is absent for a RID
+(fall back to the managed `SignedEntitlement` path) so unsupported platforms
+still work.
+
+## Multi-platform build (the blocker that needs your CI)
+
+NativeAOT produces a binary **per RID**, each built **on its own OS** with that
+platform's toolchain. Add a matrix job to the release pipeline:
+
+```yaml
+build-native-guard:
+  strategy:
+    matrix:
+      include:
+        - { os: windows-latest, rid: win-x64,    lib: aidotnet_license_native.dll }
+        - { os: ubuntu-latest,  rid: linux-x64,  lib: libaidotnet_license_native.so }
+        - { os: macos-latest,   rid: osx-arm64,  lib: libaidotnet_license_native.dylib }
+        - { os: macos-13,       rid: osx-x64,    lib: libaidotnet_license_native.dylib }
+  runs-on: ${{ matrix.os }}
+  steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-dotnet@v4
+      with: { dotnet-version: '10.0.x' }
+    # Linux needs clang + zlib; Windows needs the MSVC C++ build tools (preinstalled on windows-latest)
+    - run: dotnet publish src/AiDotNet.Native.LicenseGuard -c Release -r ${{ matrix.rid }} -p:PublishAot=true
+    - uses: actions/upload-artifact@v4
+      with: { name: native-${{ matrix.rid }}, path: '**/publish/${{ matrix.lib }}' }
+```
+
+The pack job then downloads all native artifacts and includes them as
+`runtimes/{rid}/native/{lib}` pack items (static `<None>` with `PackagePath`),
+exactly like the other `AiDotNet.Native.*` packages already do.
+
+## Why this isn't a single edit / can't be done from one machine
+
+- Each native binary must be compiled on its target OS (cross-compiling AOT is
+  not generally supported) → needs the 4-runner matrix above.
+- Adding the native dependency to the **shipping** build before all RIDs exist
+  would break Linux CI and non-Windows consumers — so it must land together
+  with the matrix, behind a safe managed fallback.
+- NativeAOT requires the platform C toolchain on each runner (GitHub-hosted
+  runners provide them; self-hosted must install clang/MSVC).
+
+## Execution checklist
+
+1. Create `src/AiDotNet.Native.LicenseGuard` (NativeLib=Shared, PublishAot).
+2. Implement the RSA-verify + **binding** export; design the binding so a stub
+   produces wrong output, reviewed for zero legit-user perf impact.
+3. Add `NativeLicenseGuard.cs` P/Invoke wrapper with managed fallback.
+4. Add the `build-native-guard` matrix job + wire artifacts into pack.
+5. Validate on all 4 RIDs end-to-end before enabling in `PersistenceGuard`.
+
+Until step 4 is in place, this stays **out of the shipping build** to protect CI
+and consumers.

--- a/docs/enterprise/nativeaot-enforcement-design.md
+++ b/docs/enterprise/nativeaot-enforcement-design.md
@@ -44,9 +44,9 @@ reviewed carefully — a bad binding degrades the product for paying customers.
 
 ## Project layout
 
-```
+```text
 src/AiDotNet.Native.LicenseGuard/        # NativeAOT shared lib
-  AiDotNet.Native.LicenseGuard.csproj     # <PublishAot>, <NativeLib>Shared</NativeLib>
+  AiDotNet.Native.LicenseGuard.csproj     # <PublishAot>true</PublishAot>, <NativeLib>Shared</NativeLib>
   Exports.cs                              # [UnmanagedCallersOnly(EntryPoint="...")]
 src/AiDotNet.Tensors/Licensing/
   NativeLicenseGuard.cs                   # [DllImport] wrapper + managed fallback

--- a/docs/enterprise/release-signing-runbook.md
+++ b/docs/enterprise/release-signing-runbook.md
@@ -1,0 +1,107 @@
+# Enterprise licensing — activation runbook (operator)
+
+The code is shipped and inert-by-default. This runbook is the **operator checklist**
+to turn each layer on. Everything here is done **once** by Ooples in a secure
+environment; none of it can (or should) be automated by a code change, because it
+involves secrets and CA-issued certificates.
+
+> Order doesn't matter between sections — each layer is independent.
+
+---
+
+## 1. Embed the signing keys (entitlement + response)
+
+Generate **two separate** RSA-2048 keypairs (compromise isolation) on a secure
+operator machine:
+
+```pwsh
+pwsh build/keys/generate-signing-keys.ps1 -Purpose entitlement -OutDir <secure-dir>
+pwsh build/keys/generate-signing-keys.ps1 -Purpose response    -OutDir <secure-dir>
+```
+
+Each run prints the **public** key in `{modulusBase64}:{exponentBase64}` form.
+Paste them into the two consts:
+
+| Const | File |
+|---|---|
+| `SignedEntitlement.EntitlementPublicKey` | `src/AiDotNet.Tensors/Licensing/SignedEntitlement.cs` |
+| `LicenseResponseVerifier.ResponseSigningPublicKey` | `src/AiDotNet.Tensors/Licensing/LicenseResponseVerifier.cs` |
+
+Move each **private** key into the HSM / secret manager and delete the local
+file. The `build/keys/.gitignore` blocks accidental commits — but verify with
+`git status` before committing the public-key edits.
+
+> Until you replace the placeholders, both features are **inert** (the runtime
+> falls through to the existing key/trial path) — so this is safe to defer.
+
+---
+
+## 2. NuGet package signing (release pipeline)
+
+The release pipeline already has the signing step (`automated-release.yml` →
+"Sign NuGet packages"). It's a **no-op until** these secrets exist:
+
+```bash
+# Acquire an OV (or EV) code-signing certificate from a CA (DigiCert, Sectigo, …)
+# issued to Ooples Finance LLC. Export it as a password-protected .pfx, then:
+base64 -w0 ooples-codesign.pfx > cert.b64          # macOS: base64 -i ooples-codesign.pfx | tr -d '\n'
+
+gh secret set CODE_SIGNING_CERT_BASE64    < cert.b64
+gh secret set CODE_SIGNING_CERT_PASSWORD               # paste the .pfx password
+rm cert.b64
+```
+
+Once set, every release signs + timestamps every `.nupkg`; a tampered/repacked
+package then fails `dotnet nuget verify`. (EV certs give the strongest trust /
+SmartScreen reputation but require a hardware token — see your CA's guidance.)
+
+### Optional: Authenticode-sign the DLLs too
+
+NuGet signing protects the *package*; Authenticode protects each *DLL*. Add a
+step before pack to `signtool sign /fd SHA256 /tr <timestamp-url> /td SHA256 ...`
+(Windows) or `osslsigncode` (Linux) over `src/**/bin/Release/**/AiDotNet.Tensors.dll`,
+guarded by the same secret. Deferred — wire it in if your deployment policy
+enforces signed-binary loading.
+
+---
+
+## 3. Online response signing (Supabase Edge Function)
+
+Activates the anti-spoof online path. Requires both halves:
+
+1. **Server:** add `build/license-server/sign-validation-response.ts` to your
+   `validate-license` Edge Function (integration sketch is in that file), and
+   set the private key secret:
+   ```bash
+   supabase secrets set RESPONSE_SIGNING_PRIVATE_KEY_PEM="$(cat <secure-dir>/aidotnet-response-signing-PRIVATE.pem)"
+   supabase functions deploy validate-license
+   ```
+   The server signs over the canonical form defined in
+   `license-server-response-signing.md`.
+2. **Client:** the customer (or you, for managed deployments) sets
+   `AiDotNetTensorsLicenseKey.RequireSignedResponse = true`. With the embedded
+   response public key from §1, the client now rejects any unsigned/forged
+   response.
+
+> High-assurance customers should prefer the fully-offline **entitlement**
+> (§1 + issue a token, see `licensing-security-model.md`) — it needs no server
+> at all, so it's not subject to server availability or spoofing.
+
+---
+
+## 4. Verify activation
+
+- **Entitlement:** issue a test token (private key), set `AIDOTNET_LICENSE_TOKEN`,
+  confirm a persistence op succeeds with no license key/trial; corrupt one byte
+  of the token and confirm it's rejected (and audit-logged).
+- **NuGet signing:** after a release, `dotnet nuget verify <pkg>.nupkg --all`.
+- **Response signing:** with `RequireSignedResponse=true`, point the client at a
+  server *without* signing and confirm validation returns Invalid; then at the
+  signed server and confirm Active.
+
+## What remains genuinely out of scope (not code)
+
+NativeAOT extraction of the enforcement path and commercial obfuscation /
+anti-tamper are architecture/tooling initiatives — see the roadmap in
+`licensing-security-model.md`. They raise reverse-engineering cost; none make
+client-side enforcement absolute.

--- a/src/AiDotNet.Tensors/Licensing/AiDotNetTensorsLicenseKey.cs
+++ b/src/AiDotNet.Tensors/Licensing/AiDotNetTensorsLicenseKey.cs
@@ -73,6 +73,20 @@ public sealed class AiDotNetTensorsLicenseKey
     public bool EnableTelemetry { get; set; } = true;
 
     /// <summary>
+    /// When <c>true</c>, the online validation response MUST carry a valid RSA
+    /// signature over the client's per-request nonce (see
+    /// <see cref="LicenseResponseVerifier"/>); an unsigned or bad-signature
+    /// response is treated as <see cref="LicenseKeyStatus.Invalid"/>. This
+    /// closes the server-spoof / MITM bypass of the online path. Defaults to
+    /// <c>false</c> for backward compatibility — enable it only once the
+    /// license server is deployed with response signing (see
+    /// <c>docs/enterprise/license-server-response-signing.md</c>). High-assurance
+    /// deployments should prefer the fully-offline signed entitlement
+    /// (<see cref="SignedEntitlement"/>), which needs no server at all.
+    /// </summary>
+    public bool RequireSignedResponse { get; set; }
+
+    /// <summary>
     /// Creates a new license key with the supplied string.
     /// </summary>
     /// <param name="key">The license key string. Must not be null,

--- a/src/AiDotNet.Tensors/Licensing/LicenseResponseVerifier.cs
+++ b/src/AiDotNet.Tensors/Licensing/LicenseResponseVerifier.cs
@@ -1,0 +1,129 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace AiDotNet.Tensors.Licensing;
+
+/// <summary>
+/// Verifies that an online license-server validation response is authentic and
+/// fresh, closing the server-spoof / MITM bypass of the online path. The client
+/// sends a per-request random <see cref="NewNonce"/>; the server signs a
+/// canonical string binding that nonce to the response fields; the client
+/// verifies the RSA signature against an embedded server public key and checks
+/// the nonce echoes the one it sent (which defeats replay of any previously
+/// captured response).
+///
+/// <para><b>Scope (honest):</b> this only matters when
+/// <see cref="AiDotNetTensorsLicenseKey.RequireSignedResponse"/> is enabled AND
+/// the server actually signs (see
+/// <c>docs/enterprise/license-server-response-signing.md</c>). It hardens the
+/// online/standard tier against trial-bypass-by-server-spoofing. High-assurance
+/// enterprise should use the fully-offline <see cref="SignedEntitlement"/>,
+/// whose trust anchor needs no server. Like all client-side checks, this is
+/// bypassable by patching the managed assembly — it is authenticity, not
+/// tamper-proofing.</para>
+/// </summary>
+public static class LicenseResponseVerifier
+{
+    /// <summary>Placeholder embedded server-response public key — until replaced, signed-response verification is unavailable.</summary>
+    public const string PublicKeyPlaceholderMarker = "REPLACE_WITH_REAL_OOPLES_RESPONSE_SIGNING_PUBLIC_KEY";
+
+    /// <summary>
+    /// Embedded RSA public key for the response-signing keypair, as
+    /// <c>{modulusBase64}:{exponentBase64}</c> (RSAParameters form — cross-TFM,
+    /// no BouncyCastle). This is a SEPARATE key from the entitlement key
+    /// (<see cref="SignedEntitlement"/>); compromise of one must not affect the
+    /// other. The private half lives only on the license server / HSM.
+    /// </summary>
+    public const string ResponseSigningPublicKey = PublicKeyPlaceholderMarker;
+
+    /// <summary>Test-only override of the embedded key.</summary>
+    internal static string? s_overridePublicKey;
+
+    private static string ResolvePublicKey() => s_overridePublicKey ?? ResponseSigningPublicKey;
+
+    /// <summary>True once a real (non-placeholder) response-signing key is embedded or overridden.</summary>
+    public static bool IsConfigured =>
+        !string.Equals(ResolvePublicKey(), PublicKeyPlaceholderMarker, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Generates a fresh, cryptographically-random 256-bit nonce (base64url, no
+    /// padding) for one validation request. Uses <see cref="RandomNumberGenerator"/>
+    /// — never <c>System.Random</c> — so it can't be predicted.
+    /// </summary>
+    public static string NewNonce()
+    {
+        var bytes = new byte[32];
+        using (var rng = RandomNumberGenerator.Create())
+            rng.GetBytes(bytes);
+        return Convert.ToBase64String(bytes).Replace('+', '-').Replace('/', '_').TrimEnd('=');
+    }
+
+    /// <summary>
+    /// Canonical string the server signs and the client reconstructs. MUST stay
+    /// byte-for-byte identical on both sides (see the server-signing spec).
+    /// Fields are newline-separated; capabilities are ordinal-sorted and
+    /// comma-joined; absent fields are the empty string.
+    /// </summary>
+    public static string BuildCanonical(
+        string nonce, string? status, string? tier, string? expiresAt, IEnumerable<string>? capabilities)
+    {
+        var caps = new List<string>();
+        if (capabilities is not null)
+            foreach (var c in capabilities)
+                if (!string.IsNullOrEmpty(c)) caps.Add(c);
+        caps.Sort(StringComparer.Ordinal);
+
+        var sb = new StringBuilder();
+        sb.Append(nonce ?? string.Empty).Append('\n');
+        sb.Append(status ?? string.Empty).Append('\n');
+        sb.Append(tier ?? string.Empty).Append('\n');
+        sb.Append(expiresAt ?? string.Empty).Append('\n');
+        sb.Append(string.Join(",", caps));
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Verifies <paramref name="signatureBase64"/> over the canonical form of
+    /// the response fields, using the embedded server public key. Returns false
+    /// if the key isn't configured, the signature is missing/malformed, or it
+    /// doesn't verify. The caller is responsible for having generated
+    /// <paramref name="nonce"/> and confirming the response echoed it.
+    /// </summary>
+    public static bool Verify(
+        string nonce, string? status, string? tier, string? expiresAt,
+        IEnumerable<string>? capabilities, string? signatureBase64)
+    {
+        if (!IsConfigured || string.IsNullOrWhiteSpace(signatureBase64))
+            return false;
+
+        byte[] sig;
+        try { sig = Convert.FromBase64String(signatureBase64); }
+        catch (FormatException) { return false; }
+
+        byte[] canonical = Encoding.UTF8.GetBytes(BuildCanonical(nonce, status, tier, expiresAt, capabilities));
+        try
+        {
+            using var rsa = ImportPublicKey(ResolvePublicKey());
+            return rsa.VerifyData(canonical, sig, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static RSA ImportPublicKey(string modExpBase64)
+    {
+        int sep = modExpBase64.IndexOf(':');
+        if (sep <= 0 || sep >= modExpBase64.Length - 1)
+            throw new FormatException("Embedded response-signing key must be '{modulusBase64}:{exponentBase64}'.");
+        var modulus = Convert.FromBase64String(modExpBase64.Substring(0, sep));
+        var exponent = Convert.FromBase64String(modExpBase64.Substring(sep + 1));
+        var rsa = RSA.Create();
+        rsa.ImportParameters(new RSAParameters { Modulus = modulus, Exponent = exponent });
+        return rsa;
+    }
+}

--- a/src/AiDotNet.Tensors/Licensing/LicenseValidator.cs
+++ b/src/AiDotNet.Tensors/Licensing/LicenseValidator.cs
@@ -239,10 +239,16 @@ public sealed class LicenseValidator
         // set for the calling library — `AiDotNet.Tensors` gets the
         // tensors:* capabilities, `AiDotNet` gets the model:* set, and
         // higher tiers get both.
+        // Per-request nonce: the server binds it into its signed response so a
+        // captured/spoofed response can't be replayed (the nonce won't match the
+        // next request). Always sent; only ENFORCED when RequireSignedResponse.
+        string nonce = LicenseResponseVerifier.NewNonce();
+
         var body = new Dictionary<string, string?>
         {
             ["license_key"] = _licenseKey.Key,
             ["package"] = "AiDotNet.Tensors",
+            ["nonce"] = nonce,
         };
         if (_licenseKey.Environment is not null)
             body["environment"] = _licenseKey.Environment;
@@ -255,14 +261,14 @@ public sealed class LicenseValidator
         string json = JsonSerializer.Serialize(body);
 
 #if NET471
-        return PostNet471(url, json);
+        return PostNet471(url, json, nonce, _licenseKey.RequireSignedResponse);
 #else
-        return PostModern(url, json);
+        return PostModern(url, json, nonce, _licenseKey.RequireSignedResponse);
 #endif
     }
 
 #if NET471
-    private LicenseValidationResult PostNet471(string url, string json)
+    private LicenseValidationResult PostNet471(string url, string json, string nonce, bool requireSigned)
     {
         var req = (HttpWebRequest)WebRequest.Create(url);
         req.Method = "POST";
@@ -276,15 +282,15 @@ public sealed class LicenseValidator
         using var stream = resp.GetResponseStream() ?? Stream.Null;
         using var reader = new StreamReader(stream, Encoding.UTF8);
         string responseJson = reader.ReadToEnd();
-        return ParseResponse(responseJson, (int)resp.StatusCode);
+        return ParseResponse(responseJson, (int)resp.StatusCode, nonce, requireSigned);
     }
 #else
-    private LicenseValidationResult PostModern(string url, string json)
+    private LicenseValidationResult PostModern(string url, string json, string nonce, bool requireSigned)
     {
         var content = new StringContent(json, Encoding.UTF8, "application/json");
         var response = SharedHttpClient.PostAsync(url, content).GetAwaiter().GetResult();
         string responseJson = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-        return ParseResponse(responseJson, (int)response.StatusCode);
+        return ParseResponse(responseJson, (int)response.StatusCode, nonce, requireSigned);
     }
 #endif
 
@@ -293,7 +299,8 @@ public sealed class LicenseValidator
     /// Visible to tests so the parser can be exercised without a live
     /// server.
     /// </summary>
-    internal static LicenseValidationResult ParseResponse(string responseJson, int statusCode)
+    internal static LicenseValidationResult ParseResponse(
+        string responseJson, int statusCode, string? nonce = null, bool requireSigned = false)
     {
         // Network non-2xx → invalid. The Edge Function returns 200
         // for both valid and invalid keys with status in the body, so
@@ -342,6 +349,29 @@ public sealed class LicenseValidator
                         var v = cap.GetString();
                         if (!string.IsNullOrEmpty(v)) caps.Add(v!);
                     }
+                }
+            }
+
+            // Anti-spoof: when the caller requires it, the response MUST carry a
+            // valid RSA signature over the canonical (nonce|status|tier|expires|
+            // caps) form, verified against the embedded server key. The nonce
+            // binding defeats replay of any captured response. A missing/invalid
+            // signature degrades the result to Invalid — a spoofed server can't
+            // forge "active". (Inert until RequireSignedResponse is enabled AND
+            // the embedded response-signing key is real; see the server spec.)
+            if (requireSigned)
+            {
+                string? signature = root.TryGetProperty("signature", out var sigEl) ? sigEl.GetString() : null;
+                string? expiresRaw = root.TryGetProperty("expires_at", out var expRaw) ? expRaw.GetString() : null;
+                bool ok = LicenseResponseVerifier.Verify(nonce ?? string.Empty, statusStr, tier, expiresRaw, caps, signature);
+                if (!ok)
+                {
+                    return new LicenseValidationResult(
+                        LicenseKeyStatus.Invalid,
+                        tier: null, expiresAt: null, validatedAt: DateTimeOffset.UtcNow,
+                        message: "License server response failed signature verification " +
+                                 "(RequireSignedResponse is enabled). Possible spoofed/MITM'd server.",
+                        capabilities: null);
                 }
             }
 

--- a/src/AiDotNet.Tensors/Licensing/PersistenceGuard.cs
+++ b/src/AiDotNet.Tensors/Licensing/PersistenceGuard.cs
@@ -156,6 +156,30 @@ public static class PersistenceGuard
     private static LicenseValidator GetValidator(AiDotNetTensorsLicenseKey key)
         => _validators.GetOrAdd(key.Key, _ => new LicenseValidator(key));
 
+    // ─── Signed-entitlement cache ──────────────────────────────────
+    //
+    // The offline entitlement is resolved from env/disk and RSA-verified once
+    // per process (it's effectively constant for a run, and re-verifying the
+    // signature on every persistence op would be wasteful). null sentinel ==
+    // "no entitlement configured"; a verified EntitlementResult is cached so
+    // repeated ops reuse it.
+    private static readonly object _entitlementLock = new();
+    private static bool _entitlementResolved;
+    private static EntitlementResult? _entitlement;
+
+    private static EntitlementResult? GetCachedEntitlement()
+    {
+        lock (_entitlementLock)
+        {
+            if (!_entitlementResolved)
+            {
+                _entitlement = SignedEntitlement.TryVerifyConfigured();
+                _entitlementResolved = true;
+            }
+            return _entitlement;
+        }
+    }
+
     // Per-key "pending allowance consumed" set. The first
     // ValidationPending result for a key is allowed (lets users on a
     // flaky network bootstrap into the offline-grace window), but
@@ -235,6 +259,36 @@ public static class PersistenceGuard
         // Suppressed under InternalOperation — upstream AiDotNet
         // already enforced before delegating to us.
         if (_internalDepth.Value > 0) return;
+
+        // ── Offline, RSA-signed entitlement (strongest trust anchor) ───
+        // Checked FIRST. A signed entitlement is verified with an embedded
+        // public key entirely offline, so — unlike the online key path — it
+        // can't be defeated by spoofing/MITM'ing the license server. A valid
+        // entitlement that grants the capability authorises the op with no
+        // network call and no trial tick. A present-but-INVALID token is a
+        // hard failure: we must NOT silently fall through to the trial path,
+        // or a tampered/forged token would just degrade to free trial ops.
+        // Absent (the default) → null → fall through unchanged.
+        var entitlement = GetCachedEntitlement();
+        if (entitlement is not null)
+        {
+            if (entitlement.IsValid && entitlement.HasCapability(requiredCapability))
+                return;
+            if (entitlement.IsValid)
+                throw new LicenseRequiredException(
+                    $"Signed entitlement does not grant the '{requiredCapability}' capability " +
+                    $"required for tensor {operationLabel}.",
+                    trialDaysElapsed: null, operationsPerformed: null,
+                    keyStatus: LicenseKeyStatus.CapabilityMissing,
+                    requiredCapability: requiredCapability);
+            throw new LicenseRequiredException(
+                "Signed entitlement (AIDOTNET_LICENSE_TOKEN / ~/.aidotnet/tensors-entitlement.json) " +
+                "failed verification: " + (entitlement.Message ?? "(no detail)") +
+                " Remove it to fall back to key/trial licensing, or obtain a valid entitlement from admin@aidotnet.dev.",
+                trialDaysElapsed: null, operationsPerformed: null,
+                keyStatus: LicenseKeyStatus.Invalid,
+                requiredCapability: requiredCapability);
+        }
 
         // Resolve key: AsyncLocal > env var > file. None present →
         // fall through to the trial path.
@@ -364,5 +418,10 @@ public static class PersistenceGuard
     {
         _validators.Clear();
         _pendingConsumed.Clear();
+        lock (_entitlementLock)
+        {
+            _entitlementResolved = false;
+            _entitlement = null;
+        }
     }
 }

--- a/src/AiDotNet.Tensors/Licensing/PersistenceGuard.cs
+++ b/src/AiDotNet.Tensors/Licensing/PersistenceGuard.cs
@@ -281,6 +281,15 @@ public static class PersistenceGuard
                     trialDaysElapsed: null, operationsPerformed: null,
                     keyStatus: LicenseKeyStatus.CapabilityMissing,
                     requiredCapability: requiredCapability);
+            // Tamper-EVIDENCE: a token is present but failed signature/marker/
+            // expiry verification — i.e. it was forged, corrupted, or tampered.
+            // Emit an audit trace so the attempt is recorded even if an upstream
+            // caller swallows the exception. (This is evidence, not prevention —
+            // see the SECURITY doc on why self-protection in managed code can't
+            // be absolute.)
+            System.Diagnostics.Trace.TraceWarning(
+                "AiDotNet.Tensors SECURITY: a signed entitlement was presented but FAILED verification (" +
+                (entitlement.Message ?? "no detail") + "). Possible forged/tampered license token.");
             throw new LicenseRequiredException(
                 "Signed entitlement (AIDOTNET_LICENSE_TOKEN / ~/.aidotnet/tensors-entitlement.json) " +
                 "failed verification: " + (entitlement.Message ?? "(no detail)") +

--- a/src/AiDotNet.Tensors/Licensing/SignedEntitlement.cs
+++ b/src/AiDotNet.Tensors/Licensing/SignedEntitlement.cs
@@ -1,0 +1,296 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace AiDotNet.Tensors.Licensing;
+
+/// <summary>
+/// Offline, RSA-signed entitlement verification for the runtime persistence
+/// guard. This is the cryptographic trust anchor that does NOT depend on the
+/// online license server (and therefore cannot be defeated by spoofing /
+/// MITM'ing that server — the single cheapest bypass of the online path):
+/// the entitlement is a JSON token signed by Ooples' private key, and the
+/// runtime verifies it with an embedded RSA public key, fully offline.
+///
+/// <para><b>Threat model — read this honestly.</b> RSA signature verification
+/// means an attacker cannot FORGE an entitlement without Ooples' private key.
+/// It does NOT make the guard unbreakable: this runs in managed bytecode the
+/// attacker controls, so they can still patch out the verification call or swap
+/// the embedded key (see <see cref="LicenseTamperEvidence"/>, which makes the
+/// key-swap detectable). Client-side enforcement is a high, audited speed bump,
+/// not a vault — genuine protection is this + tamper-evidence + the contractual
+/// relationship. Do not advertise it as "uncrackable".</para>
+///
+/// <para><b>Token format</b> (the outer envelope; only <c>payload</c> is
+/// signed, mirroring <c>build/LicenseValidator</c>'s signed-payload-as-source-
+/// of-truth rule):</para>
+/// <code>
+/// {
+///   "payload":   "&lt;base64 of the canonical JSON below&gt;",
+///   "signature": "&lt;base64 RSA-2048 PKCS#1 v1.5 SHA-256 signature over payload bytes&gt;"
+/// }
+/// // signed payload:
+/// {
+///   "marker":       "AiDotNet-Tensors-Entitlement-v1",
+///   "tenant":       "ACME Corp.",
+///   "expires":      "YYYY-MM-DD",
+///   "capabilities": ["tensors:save", "tensors:load"]
+/// }
+/// </code>
+/// </summary>
+public static class SignedEntitlement
+{
+    /// <summary>Marker every valid signed payload must carry.</summary>
+    public const string Marker = "AiDotNet-Tensors-Entitlement-v1";
+
+    /// <summary>
+    /// Placeholder for the embedded RSA public key. Until Ooples replaces this
+    /// with the real public key, every entitlement is rejected (safe by
+    /// default) and the runtime falls through to the existing online/trial
+    /// path — so shipping this feature with the placeholder changes nothing.
+    /// </summary>
+    public const string PublicKeyPlaceholderMarker = "REPLACE_WITH_REAL_OOPLES_ENTITLEMENT_PUBLIC_KEY";
+
+    /// <summary>
+    /// Embedded RSA public key as <c>{modulusBase64}:{exponentBase64}</c>
+    /// (RSAParameters form — chosen over PKCS#1 DER so import works on both
+    /// net471 and net10.0 with no BouncyCastle dependency in the runtime
+    /// assembly). Replace for production per build/LicenseValidator/README.md;
+    /// the PRIVATE key never ships.
+    /// </summary>
+    public const string EntitlementPublicKey = PublicKeyPlaceholderMarker;
+
+    /// <summary>Test-only override of the embedded key (see the build-time validator's identical hook).</summary>
+    internal static string? s_overridePublicKey;
+
+    private static string ResolvePublicKey() => s_overridePublicKey ?? EntitlementPublicKey;
+
+    /// <summary>
+    /// Resolves a signed entitlement from the environment / disk and verifies
+    /// it offline. Resolution order: <c>AIDOTNET_LICENSE_TOKEN</c> env var
+    /// (inline JSON or a path to a token file), then
+    /// <c>~/.aidotnet/tensors-entitlement.json</c>. Returns <c>null</c> when
+    /// no entitlement is configured (the caller then falls through to the
+    /// online/trial path) — only a present-but-INVALID entitlement is a hard
+    /// failure the caller should surface.
+    /// </summary>
+    public static EntitlementResult? TryVerifyConfigured()
+    {
+        // Feature is INERT until a real embedded key replaces the placeholder:
+        // return null (not configured) so the guard falls through to the
+        // existing key/trial path. This keeps shipping the placeholder a
+        // no-op — a stray token on a dev box can't hard-fail persistence.
+        if (string.Equals(ResolvePublicKey(), PublicKeyPlaceholderMarker, StringComparison.Ordinal))
+            return null;
+
+        string? raw = ResolveRawToken();
+        if (raw is null) return null;
+        return Verify(raw);
+    }
+
+    private static string? ResolveRawToken()
+    {
+        try
+        {
+            string? env = Environment.GetEnvironmentVariable("AIDOTNET_LICENSE_TOKEN");
+            if (!string.IsNullOrWhiteSpace(env))
+            {
+                // Inline JSON if it looks like an object, else treat as a path.
+                string t = env!.Trim();
+                if (t.StartsWith("{", StringComparison.Ordinal)) return t;
+                if (File.Exists(t)) return File.ReadAllText(t);
+            }
+        }
+        catch { /* SecurityException / IO — fall through to file probe */ }
+
+        try
+        {
+            string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            string path = Path.Combine(home, ".aidotnet", "tensors-entitlement.json");
+            if (File.Exists(path))
+            {
+                string content = File.ReadAllText(path).Trim();
+                if (!string.IsNullOrWhiteSpace(content)) return content;
+            }
+        }
+        catch { /* IO / SecurityException — no entitlement */ }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Verifies a raw entitlement-envelope JSON string. Verification order:
+    /// envelope parses → has payload+signature → embedded key is not the
+    /// placeholder → RSA signature verifies over the payload bytes → signed
+    /// payload parses → marker matches → not expired. Every privilege field
+    /// (marker, expires, capabilities, tenant) is read from the SIGNED payload
+    /// only, never the envelope.
+    /// </summary>
+    public static EntitlementResult Verify(string envelopeJson)
+    {
+        if (string.IsNullOrWhiteSpace(envelopeJson))
+            return EntitlementResult.Invalid("Entitlement token is empty.");
+
+        string pubKey = ResolvePublicKey();
+        if (string.Equals(pubKey, PublicKeyPlaceholderMarker, StringComparison.Ordinal))
+            return EntitlementResult.Invalid(
+                "Entitlement verification refused: this build ships the placeholder entitlement " +
+                "public key. Production builds must replace SignedEntitlement.EntitlementPublicKey.");
+
+        string payloadB64, signatureB64;
+        try
+        {
+            using var envelope = JsonDocument.Parse(envelopeJson);
+            var root = envelope.RootElement;
+            if (root.ValueKind != JsonValueKind.Object
+                || !TryGetString(root, "payload", out payloadB64)
+                || !TryGetString(root, "signature", out signatureB64))
+                return EntitlementResult.Invalid("Entitlement token missing 'payload' or 'signature'.");
+        }
+        catch (JsonException ex)
+        {
+            return EntitlementResult.Invalid("Entitlement token is not valid JSON: " + ex.Message);
+        }
+
+        byte[] payloadBytes, signatureBytes;
+        try
+        {
+            payloadBytes = Convert.FromBase64String(payloadB64);
+            signatureBytes = Convert.FromBase64String(signatureB64);
+        }
+        catch (FormatException ex)
+        {
+            return EntitlementResult.Invalid("Entitlement payload/signature is not valid base64: " + ex.Message);
+        }
+
+        bool signatureOk;
+        try
+        {
+            using var rsa = ImportPublicKey(pubKey);
+            signatureOk = rsa.VerifyData(payloadBytes, signatureBytes,
+                HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        }
+        catch (Exception ex)
+        {
+            return EntitlementResult.Invalid("Entitlement signature verification errored: " + ex.Message);
+        }
+
+        if (!signatureOk)
+            return EntitlementResult.Invalid("Entitlement signature is invalid (forged, corrupt, or wrong key).");
+
+        // Signature verified → the payload is authentic. Parse it as the sole
+        // source of truth for the gating fields.
+        try
+        {
+            using var payloadDoc = JsonDocument.Parse(new ReadOnlyMemory<byte>(payloadBytes));
+            var signed = payloadDoc.RootElement;
+            if (signed.ValueKind != JsonValueKind.Object)
+                return EntitlementResult.Invalid("Entitlement signed payload is not a JSON object.");
+
+            if (!TryGetString(signed, "marker", out var marker)
+                || !string.Equals(marker, Marker, StringComparison.Ordinal))
+                return EntitlementResult.Invalid("Entitlement signed payload has a missing/wrong marker.");
+
+            DateTimeOffset? expires = null;
+            if (TryGetString(signed, "expires", out var expRaw)
+                && DateTimeOffset.TryParse(expRaw, CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var parsed))
+            {
+                expires = parsed;
+                if (parsed.UtcDateTime.Date < DateTimeOffset.UtcNow.UtcDateTime.Date)
+                    return EntitlementResult.Invalid($"Entitlement expired on {parsed:yyyy-MM-dd} UTC.");
+            }
+
+            var caps = new HashSet<string>(StringComparer.Ordinal);
+            if (signed.TryGetProperty("capabilities", out var capsEl) && capsEl.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var c in capsEl.EnumerateArray())
+                {
+                    if (c.ValueKind == JsonValueKind.String)
+                    {
+                        var v = c.GetString();
+                        if (!string.IsNullOrWhiteSpace(v)) caps.Add(v!);
+                    }
+                }
+            }
+
+            string? tenant = TryGetString(signed, "tenant", out var t) && !string.IsNullOrWhiteSpace(t) ? t : null;
+            return EntitlementResult.Valid(tenant, expires, caps);
+        }
+        catch (JsonException ex)
+        {
+            return EntitlementResult.Invalid("Entitlement signed payload is not valid JSON: " + ex.Message);
+        }
+    }
+
+    private static bool TryGetString(JsonElement obj, string name, out string value)
+    {
+        if (obj.TryGetProperty(name, out var el) && el.ValueKind == JsonValueKind.String)
+        {
+            value = el.GetString() ?? string.Empty;
+            return value.Length > 0;
+        }
+        value = string.Empty;
+        return false;
+    }
+
+    /// <summary>
+    /// Imports the embedded <c>{modulusBase64}:{exponentBase64}</c> public key.
+    /// Uses <see cref="RSA.ImportParameters"/> (RSAParameters) so it works on
+    /// net471 and net10.0 alike — <see cref="RSA.ImportRSAPublicKey(System.ReadOnlySpan{byte}, out int)"/>
+    /// is netstandard2.1+ only.
+    /// </summary>
+    private static RSA ImportPublicKey(string modExpBase64)
+    {
+        int sep = modExpBase64.IndexOf(':');
+        if (sep <= 0 || sep >= modExpBase64.Length - 1)
+            throw new FormatException("Embedded entitlement key must be '{modulusBase64}:{exponentBase64}'.");
+        var modulus = Convert.FromBase64String(modExpBase64.Substring(0, sep));
+        var exponent = Convert.FromBase64String(modExpBase64.Substring(sep + 1));
+        var rsa = RSA.Create();
+        rsa.ImportParameters(new RSAParameters { Modulus = modulus, Exponent = exponent });
+        return rsa;
+    }
+}
+
+/// <summary>Outcome of verifying a signed entitlement token.</summary>
+public sealed class EntitlementResult
+{
+    /// <summary>True iff the entitlement's RSA signature, marker, and expiry all verified.</summary>
+    public bool IsValid { get; }
+
+    /// <summary>Tenant from the signed payload, or null.</summary>
+    public string? Tenant { get; }
+
+    /// <summary>Expiry from the signed payload, or null (perpetual).</summary>
+    public DateTimeOffset? ExpiresAt { get; }
+
+    /// <summary>Diagnostic message when <see cref="IsValid"/> is false.</summary>
+    public string? Message { get; }
+
+    private readonly HashSet<string> _capabilities;
+
+    /// <summary>True iff the signed entitlement grants <paramref name="capability"/>.</summary>
+    public bool HasCapability(string capability) => _capabilities.Contains(capability);
+
+    private EntitlementResult(bool valid, string? tenant, DateTimeOffset? expiresAt, string? message, HashSet<string>? caps)
+    {
+        IsValid = valid;
+        Tenant = tenant;
+        ExpiresAt = expiresAt;
+        Message = message;
+        _capabilities = caps ?? new HashSet<string>(StringComparer.Ordinal);
+    }
+
+    internal static EntitlementResult Valid(string? tenant, DateTimeOffset? expiresAt, HashSet<string> caps)
+        => new(true, tenant, expiresAt, null, caps);
+
+    internal static EntitlementResult Invalid(string message)
+        => new(false, null, null, message, null);
+}

--- a/tests/AiDotNet.Tensors.Tests/Licensing/LicenseResponseVerifierTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Licensing/LicenseResponseVerifierTests.cs
@@ -1,0 +1,172 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Tests for signed online-validation-response verification (anti-spoof / anti-replay).
+
+#nullable disable
+
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using AiDotNet.Tensors.Licensing;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Licensing;
+
+/// <summary>
+/// Verifies that, when RequireSignedResponse is on, the online validation
+/// response must carry a valid RSA signature over the canonical
+/// (nonce|status|tier|expires|caps) form — closing the server-spoof / replay
+/// bypass — while the default (unsigned) path is unchanged. Serial via the
+/// PersistenceGuard collection (mutates the embedded response-key override).
+/// </summary>
+[Collection("PersistenceGuard")]
+public class LicenseResponseVerifierTests
+{
+    private static (RSA rsa, string embeddedKey) NewKeypair()
+    {
+        var rsa = RSA.Create();
+        if (rsa.KeySize != 2048) rsa.KeySize = 2048;
+        var p = rsa.ExportParameters(false);
+        return (rsa, Convert.ToBase64String(p.Modulus) + ":" + Convert.ToBase64String(p.Exponent));
+    }
+
+    private static string Sign(RSA rsa, string canonical)
+        => Convert.ToBase64String(rsa.SignData(Encoding.UTF8.GetBytes(canonical),
+            HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1));
+
+    private static void WithEmbeddedKey(string key, Action body)
+    {
+        var saved = LicenseResponseVerifier.s_overridePublicKey;
+        try { LicenseResponseVerifier.s_overridePublicKey = key; body(); }
+        finally { LicenseResponseVerifier.s_overridePublicKey = saved; }
+    }
+
+    [Fact]
+    public void NewNonce_IsUnique_AndNonEmpty()
+    {
+        var a = LicenseResponseVerifier.NewNonce();
+        var b = LicenseResponseVerifier.NewNonce();
+        Assert.False(string.IsNullOrWhiteSpace(a));
+        Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public void Verify_ValidSignature_True()
+    {
+        var (rsa, embedded) = NewKeypair();
+        using (rsa)
+        WithEmbeddedKey(embedded, () =>
+        {
+            string nonce = LicenseResponseVerifier.NewNonce();
+            var caps = new[] { "tensors:load", "tensors:save" };
+            string canonical = LicenseResponseVerifier.BuildCanonical(nonce, "active", "enterprise", "2099-12-31", caps);
+            string sig = Sign(rsa, canonical);
+            Assert.True(LicenseResponseVerifier.Verify(nonce, "active", "enterprise", "2099-12-31", caps, sig));
+        });
+    }
+
+    [Fact]
+    public void Verify_WrongNonce_False()
+    {
+        var (rsa, embedded) = NewKeypair();
+        using (rsa)
+        WithEmbeddedKey(embedded, () =>
+        {
+            string nonce = LicenseResponseVerifier.NewNonce();
+            string canonical = LicenseResponseVerifier.BuildCanonical(nonce, "active", "enterprise", "2099-12-31", null);
+            string sig = Sign(rsa, canonical);
+            // Replay against a DIFFERENT nonce (what the next request would send).
+            Assert.False(LicenseResponseVerifier.Verify(LicenseResponseVerifier.NewNonce(), "active", "enterprise", "2099-12-31", null, sig));
+        });
+    }
+
+    [Fact]
+    public void Verify_ForgedWithOtherKey_False()
+    {
+        var (rsaReal, embedded) = NewKeypair();
+        var (rsaAttacker, _) = NewKeypair();
+        using (rsaReal)
+        using (rsaAttacker)
+        WithEmbeddedKey(embedded, () =>
+        {
+            string nonce = LicenseResponseVerifier.NewNonce();
+            string canonical = LicenseResponseVerifier.BuildCanonical(nonce, "active", null, null, null);
+            string sig = Sign(rsaAttacker, canonical);
+            Assert.False(LicenseResponseVerifier.Verify(nonce, "active", null, null, null, sig));
+        });
+    }
+
+    [Fact]
+    public void Verify_PlaceholderKey_NotConfigured_False()
+    {
+        // No override → placeholder embedded key → verification unavailable.
+        Assert.False(LicenseResponseVerifier.IsConfigured);
+        Assert.False(LicenseResponseVerifier.Verify("n", "active", null, null, null, "AAAA"));
+    }
+
+    [Fact]
+    public void ParseResponse_RequireSigned_ValidSignature_Active()
+    {
+        var (rsa, embedded) = NewKeypair();
+        using (rsa)
+        WithEmbeddedKey(embedded, () =>
+        {
+            string nonce = LicenseResponseVerifier.NewNonce();
+            var caps = new[] { "tensors:save", "tensors:load" };
+            string sig = Sign(rsa, LicenseResponseVerifier.BuildCanonical(nonce, "active", "enterprise", "2099-12-31", caps));
+            string json = JsonSerializer.Serialize(new
+            {
+                status = "active",
+                tier = "enterprise",
+                expires_at = "2099-12-31",
+                capabilities = caps,
+                signature = sig,
+            });
+            var r = LicenseValidator.ParseResponse(json, 200, nonce, requireSigned: true);
+            Assert.Equal(LicenseKeyStatus.Active, r.Status);
+            Assert.True(r.HasCapability("tensors:save"));
+        });
+    }
+
+    [Fact]
+    public void ParseResponse_RequireSigned_MissingSignature_Invalid()
+    {
+        var (rsa, embedded) = NewKeypair();
+        using (rsa)
+        WithEmbeddedKey(embedded, () =>
+        {
+            string nonce = LicenseResponseVerifier.NewNonce();
+            // A spoofed server returns "active" with NO signature.
+            string json = JsonSerializer.Serialize(new { status = "active", tier = "enterprise" });
+            var r = LicenseValidator.ParseResponse(json, 200, nonce, requireSigned: true);
+            Assert.Equal(LicenseKeyStatus.Invalid, r.Status);
+        });
+    }
+
+    [Fact]
+    public void ParseResponse_RequireSigned_TamperedStatus_Invalid()
+    {
+        var (rsa, embedded) = NewKeypair();
+        using (rsa)
+        WithEmbeddedKey(embedded, () =>
+        {
+            string nonce = LicenseResponseVerifier.NewNonce();
+            // Signature was computed over status="expired"; attacker flips the
+            // body to "active" but can't re-sign → canonical mismatch → Invalid.
+            string sig = Sign(rsa, LicenseResponseVerifier.BuildCanonical(nonce, "expired", null, null, null));
+            string json = JsonSerializer.Serialize(new { status = "active", signature = sig });
+            var r = LicenseValidator.ParseResponse(json, 200, nonce, requireSigned: true);
+            Assert.Equal(LicenseKeyStatus.Invalid, r.Status);
+        });
+    }
+
+    [Fact]
+    public void ParseResponse_NotRequiringSignature_UnsignedStillParses()
+    {
+        // Default path (requireSigned: false) is unchanged — unsigned response parses normally.
+        string json = JsonSerializer.Serialize(new { status = "active", capabilities = new[] { "tensors:save" } });
+        var r = LicenseValidator.ParseResponse(json, 200);
+        Assert.Equal(LicenseKeyStatus.Active, r.Status);
+        Assert.True(r.HasCapability("tensors:save"));
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Licensing/SignedEntitlementTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Licensing/SignedEntitlementTests.cs
@@ -1,0 +1,245 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Tests for offline RSA-signed entitlement verification + its PersistenceGuard wiring.
+
+#nullable disable
+
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using AiDotNet.Tensors.Licensing;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Licensing;
+
+/// <summary>
+/// Verifies the offline, RSA-signed entitlement path: a token signed by the
+/// (test) private key is accepted; a forged, tampered, expired, wrong-marker,
+/// or placeholder-key token is rejected; and a valid entitlement authorises a
+/// persistence op with no license key and no trial tick. Serial via the shared
+/// PersistenceGuard collection — these mutate process-wide static state
+/// (embedded-key override, the AIDOTNET_LICENSE_TOKEN env var, the guard's
+/// entitlement cache), all restored in finally.
+/// </summary>
+[Collection("PersistenceGuard")]
+public class SignedEntitlementTests
+{
+    private static (RSA rsa, string embeddedKey) NewKeypair()
+    {
+        // RSA.Create(int) is unavailable on net471 (only RSA.Create(string)),
+        // so create then set KeySize — works on net471 and net10.0 alike.
+        var rsa = RSA.Create();
+        if (rsa.KeySize != 2048) rsa.KeySize = 2048;
+        var p = rsa.ExportParameters(includePrivateParameters: false);
+        string embedded = Convert.ToBase64String(p.Modulus) + ":" + Convert.ToBase64String(p.Exponent);
+        return (rsa, embedded);
+    }
+
+    private static string SignToken(RSA rsa, string marker, string expires, string[] capabilities)
+    {
+        var payload = new { marker, tenant = "ACME Corp.", expires, capabilities };
+        var payloadBytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(payload));
+        var sig = rsa.SignData(payloadBytes, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var envelope = new
+        {
+            payload = Convert.ToBase64String(payloadBytes),
+            signature = Convert.ToBase64String(sig),
+        };
+        return JsonSerializer.Serialize(envelope);
+    }
+
+    /// <summary>Runs <paramref name="body"/> with the embedded key overridden to the test key, always restored.</summary>
+    private static void WithEmbeddedKey(string embeddedKey, Action body)
+    {
+        var saved = SignedEntitlement.s_overridePublicKey;
+        try { SignedEntitlement.s_overridePublicKey = embeddedKey; body(); }
+        finally { SignedEntitlement.s_overridePublicKey = saved; }
+    }
+
+    [Fact]
+    public void Verify_ValidToken_IsValid_WithCapabilities()
+    {
+        var (rsa, embedded) = NewKeypair();
+        using (rsa)
+        WithEmbeddedKey(embedded, () =>
+        {
+            string token = SignToken(rsa, SignedEntitlement.Marker, "2099-12-31", new[] { "tensors:save", "tensors:load" });
+            var r = SignedEntitlement.Verify(token);
+            Assert.True(r.IsValid, r.Message);
+            Assert.True(r.HasCapability("tensors:save"));
+            Assert.True(r.HasCapability("tensors:load"));
+            Assert.False(r.HasCapability("tensors:admin"));
+        });
+    }
+
+    [Fact]
+    public void Verify_ForgedWithDifferentKey_Rejected()
+    {
+        var (rsaReal, embedded) = NewKeypair();
+        var (rsaAttacker, _) = NewKeypair();
+        using (rsaReal)
+        using (rsaAttacker)
+        WithEmbeddedKey(embedded, () =>
+        {
+            // Signed by the attacker's key, verified against the embedded (real) key.
+            string forged = SignToken(rsaAttacker, SignedEntitlement.Marker, "2099-12-31", new[] { "tensors:save" });
+            var r = SignedEntitlement.Verify(forged);
+            Assert.False(r.IsValid);
+        });
+    }
+
+    [Fact]
+    public void Verify_TamperedSignature_Rejected()
+    {
+        var (rsa, embedded) = NewKeypair();
+        using (rsa)
+        WithEmbeddedKey(embedded, () =>
+        {
+            string token = SignToken(rsa, SignedEntitlement.Marker, "2099-12-31", new[] { "tensors:save" });
+            // Flip a bit in the base64 signature field.
+            using var doc = JsonDocument.Parse(token);
+            string sig = doc.RootElement.GetProperty("signature").GetString();
+            var sigBytes = Convert.FromBase64String(sig);
+            sigBytes[0] ^= 0xFF;
+            string payload = doc.RootElement.GetProperty("payload").GetString();
+            string tampered = JsonSerializer.Serialize(new { payload, signature = Convert.ToBase64String(sigBytes) });
+            var r = SignedEntitlement.Verify(tampered);
+            Assert.False(r.IsValid);
+        });
+    }
+
+    [Fact]
+    public void Verify_Expired_Rejected()
+    {
+        var (rsa, embedded) = NewKeypair();
+        using (rsa)
+        WithEmbeddedKey(embedded, () =>
+        {
+            string token = SignToken(rsa, SignedEntitlement.Marker, "2000-01-01", new[] { "tensors:save" });
+            var r = SignedEntitlement.Verify(token);
+            Assert.False(r.IsValid);
+        });
+    }
+
+    [Fact]
+    public void Verify_WrongMarker_Rejected()
+    {
+        var (rsa, embedded) = NewKeypair();
+        using (rsa)
+        WithEmbeddedKey(embedded, () =>
+        {
+            string token = SignToken(rsa, "Wrong-Marker", "2099-12-31", new[] { "tensors:save" });
+            var r = SignedEntitlement.Verify(token);
+            Assert.False(r.IsValid);
+        });
+    }
+
+    [Fact]
+    public void Verify_PlaceholderEmbeddedKey_Rejected()
+    {
+        // With the shipped placeholder key, even a structurally valid token is refused.
+        var (rsa, _) = NewKeypair();
+        using (rsa)
+        {
+            string token = SignToken(rsa, SignedEntitlement.Marker, "2099-12-31", new[] { "tensors:save" });
+            var r = SignedEntitlement.Verify(token); // no override → placeholder key in effect
+            Assert.False(r.IsValid);
+        }
+    }
+
+    [Fact]
+    public void TryVerifyConfigured_PlaceholderKey_IsInert_ReturnsNull()
+    {
+        // Even with a token present in the env, the placeholder key makes the
+        // feature inert (returns null → guard falls through to key/trial path).
+        var saved = Environment.GetEnvironmentVariable("AIDOTNET_LICENSE_TOKEN");
+        var (rsa, _) = NewKeypair();
+        using (rsa)
+        try
+        {
+            Environment.SetEnvironmentVariable("AIDOTNET_LICENSE_TOKEN",
+                SignToken(rsa, SignedEntitlement.Marker, "2099-12-31", new[] { "tensors:save" }));
+            Assert.Null(SignedEntitlement.TryVerifyConfigured()); // placeholder → inert
+        }
+        finally { Environment.SetEnvironmentVariable("AIDOTNET_LICENSE_TOKEN", saved); }
+    }
+
+    [Fact]
+    public void PersistenceGuard_ValidEntitlement_AuthorisesWithNoKeyOrTrial()
+    {
+        var savedEnv = Environment.GetEnvironmentVariable("AIDOTNET_LICENSE_TOKEN");
+        var savedKey = SignedEntitlement.s_overridePublicKey;
+        var (rsa, embedded) = NewKeypair();
+        using (rsa)
+        try
+        {
+            SignedEntitlement.s_overridePublicKey = embedded;
+            Environment.SetEnvironmentVariable("AIDOTNET_LICENSE_TOKEN",
+                SignToken(rsa, SignedEntitlement.Marker, "2099-12-31", new[] { "tensors:save", "tensors:load" }));
+            PersistenceGuard.ClearValidatorCacheForTesting(); // force re-resolve of the entitlement
+
+            // No license key, no trial override — the signed entitlement alone authorises.
+            PersistenceGuard.EnforceBeforeSave();
+            PersistenceGuard.EnforceBeforeLoad();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("AIDOTNET_LICENSE_TOKEN", savedEnv);
+            SignedEntitlement.s_overridePublicKey = savedKey;
+            PersistenceGuard.ClearValidatorCacheForTesting();
+        }
+    }
+
+    [Fact]
+    public void PersistenceGuard_EntitlementMissingCapability_Throws()
+    {
+        var savedEnv = Environment.GetEnvironmentVariable("AIDOTNET_LICENSE_TOKEN");
+        var savedKey = SignedEntitlement.s_overridePublicKey;
+        var (rsa, embedded) = NewKeypair();
+        using (rsa)
+        try
+        {
+            SignedEntitlement.s_overridePublicKey = embedded;
+            // Grants only load — save must be refused.
+            Environment.SetEnvironmentVariable("AIDOTNET_LICENSE_TOKEN",
+                SignToken(rsa, SignedEntitlement.Marker, "2099-12-31", new[] { "tensors:load" }));
+            PersistenceGuard.ClearValidatorCacheForTesting();
+
+            Assert.Throws<LicenseRequiredException>(() => PersistenceGuard.EnforceBeforeSave());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("AIDOTNET_LICENSE_TOKEN", savedEnv);
+            SignedEntitlement.s_overridePublicKey = savedKey;
+            PersistenceGuard.ClearValidatorCacheForTesting();
+        }
+    }
+
+    [Fact]
+    public void PersistenceGuard_InvalidEntitlementPresent_Throws_DoesNotFallThroughToTrial()
+    {
+        var savedEnv = Environment.GetEnvironmentVariable("AIDOTNET_LICENSE_TOKEN");
+        var savedKey = SignedEntitlement.s_overridePublicKey;
+        var (rsaReal, embedded) = NewKeypair();
+        var (rsaAttacker, _) = NewKeypair();
+        using (rsaReal)
+        using (rsaAttacker)
+        try
+        {
+            SignedEntitlement.s_overridePublicKey = embedded;
+            // Forged token (attacker key) — present but invalid. Must hard-fail,
+            // NOT silently degrade to the free trial path.
+            Environment.SetEnvironmentVariable("AIDOTNET_LICENSE_TOKEN",
+                SignToken(rsaAttacker, SignedEntitlement.Marker, "2099-12-31", new[] { "tensors:save" }));
+            PersistenceGuard.ClearValidatorCacheForTesting();
+
+            Assert.Throws<LicenseRequiredException>(() => PersistenceGuard.EnforceBeforeSave());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("AIDOTNET_LICENSE_TOKEN", savedEnv);
+            SignedEntitlement.s_overridePublicKey = savedKey;
+            PersistenceGuard.ClearValidatorCacheForTesting();
+        }
+    }
+}


### PR DESCRIPTION
Closes #459

## Enterprise licensing — cryptographic hardening (honest scope)

Hardens runtime license enforcement with **unforgeable trust anchors + tamper-evidence**, and is explicit about the ceiling and what's infra vs. code.

### ✅ Active now (real, tested, in-repo)
- **Offline RSA-signed entitlement** (`SignedEntitlement` → `PersistenceGuard`): verified with an embedded public key, **fully offline** — removes reliance on the spoofable online server. An attacker **cannot forge** authorization. Highest-value, self-contained win.
- **Tamper-evidence**: audit `Trace` when a presented entitlement fails verification (forged/tampered signal).
- **Signed online-response verifier** (`LicenseResponseVerifier`, `RequireSignedResponse`) + per-request **nonce** (anti-replay). Client side done + tested; closes the server-spoof bypass once the server signs.

### ⚙️ Scaffolded — activate via infra (no code change needed)
- **NuGet package signing** in `automated-release.yml` — no-op until `CODE_SIGNING_CERT_BASE64` / `CODE_SIGNING_CERT_PASSWORD` secrets are set.
- **Signed responses** — activate by deploying the server contract (`docs/enterprise/license-server-response-signing.md`) + embedding the real response-signing key + setting `RequireSignedResponse`.
- **Real entitlement key** — embed the production key in `SignedEntitlement.EntitlementPublicKey` (ships placeholder → feature inert until then; nothing changes on release).

### 📋 Documented, deliberately NOT auto-applied (with reasons)
- **Strong-naming**: net-core skips SN at load; would break `InternalsVisibleTo` to unsigned test assemblies. Recommended-with-caveats, not applied.
- **NativeAOT enforcement extraction**, **commercial obfuscation/anti-tamper**: architecture/tooling initiatives.

### The ceiling (please read)
Client-side enforcement in managed, source-available code **cannot be made un-jailbreakable** — RSA verification makes forgery impossible, but a determined attacker can still patch the managed IL. This PR is the strongest *unforgeable, server-independent* anchor + audit trail that code can provide; the rest of "locked down" is signing infra + the contract/audit relationship. A runtime self-integrity check is intentionally **omitted** (its expected value would live in the same patchable DLL = theater).

### Tests
37 licensing tests pass (10 entitlement + 9 response-verifier + 18 existing PersistenceGuard intact), net10.0 + net471, 0 warnings / 0 errors under `TreatWarningsAsErrors`.

Docs: `docs/enterprise/licensing-security-model.md` (threat model + roadmap), `docs/enterprise/license-server-response-signing.md` (server contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

