### PR TITLE
test(#443): force Parallel.For fan-out in ParallelForOrSerial dispatch test (unblock CI)

### DIFF
--- a/tests/AiDotNet.Tensors.Tests/Helpers/ParallelForOrSerialDispatchTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/ParallelForOrSerialDispatchTests.cs
@@ -31,20 +31,34 @@ public class ParallelForOrSerialDispatchTests
             CpuParallelSettings.MaxDegreeOfParallelism = Environment.ProcessorCount;
 
             int callerThread = Thread.CurrentThread.ManagedThreadId;
-            int numChunks = Math.Max(2, Environment.ProcessorCount);
+            // The production dispatch decision depends ONLY on totalWork vs
+            // grain size, MaxDegreeOfParallelism, and DeterministicReductions —
+            // numChunks is independent. But .NET's raw Parallel.For inlines
+            // very short iteration counts on the caller thread when the
+            // dispatch overhead would dwarf the per-iter cost (CI run
+            // 26429102450 hit this with 4 iters × empty-body on a 4-vCPU
+            // ubuntu-latest box: all chunks ran on the caller). Use a large
+            // enough iteration count that TPL is forced to fan out, so we're
+            // actually testing the ParallelForOrSerial dispatch decision
+            // (parallel branch taken) and not Parallel.For's small-loop
+            // inlining heuristic.
+            int numChunks = Math.Max(16, Environment.ProcessorCount * 4);
             long totalWork = (long)PersistentParallelExecutor.DefaultSerialGrainSize * 4;
             var observed = new int[numChunks];
 
             // Same deterministic worker-probe as GrainSizeDispatchTests: a worker
             // iteration Sets the event, caller-thread iterations Wait briefly for
             // it. If nothing ever dispatched off-thread the Wait times out.
+            // 1s wait tolerates a cold ThreadPool warmup on a constrained CI
+            // runner — Set() fires from the first off-thread iter so the wait
+            // is almost always instant on a warm pool.
             using var workerSeen = new ManualResetEventSlim(false);
             CpuParallelSettings.ParallelForOrSerial(0, numChunks, totalWork, c =>
             {
                 int tid = Thread.CurrentThread.ManagedThreadId;
                 observed[c] = tid;
                 if (tid != callerThread) workerSeen.Set();
-                else workerSeen.Wait(TimeSpan.FromMilliseconds(200));
+                else workerSeen.Wait(TimeSpan.FromSeconds(1));
             });
 
             bool sawWorker = false;


### PR DESCRIPTION
## Unblocks CI

`ParallelForOrSerial_LargeWork_DeterministicFalse_FansOutToWorkers` (added by #443, merged 2026-05-26) has been flaking on shared CI. PR #445's run [26429102450](https://github.com/ooples/AiDotNet.Tensors/actions/runs/26429102450) failed with:

> totalWork (131072) >> grain size (32768) with DeterministicReductions=false should have dispatched to the worker pool, but all 4 chunks ran on caller thread 16.

## Root cause

.NET's raw `System.Threading.Tasks.Parallel.For` inlines very short iteration counts on the caller thread when the dispatch overhead would dwarf the per-iteration cost. With `numChunks = Environment.ProcessorCount = 4` and an empty body (the test body just probes thread IDs), TPL legitimately decides to run all four iters inline on the caller. That's a valid Parallel.For optimisation — but the test was written to verify *ParallelForOrSerial*'s **parallel branch** was taken (the dispatch decision), and Parallel.For's small-loop inlining makes the fan-out probe an unreliable proxy for that decision.

The sibling test `LightweightParallel_AtOrAboveGrainSize_FansOutToWorkers` passes reliably because `LightweightParallel` routes through `PersistentParallelExecutor`, which always fans out — not raw `Parallel.For`.

## Fix

- `ParallelForOrSerial`'s actual dispatch decision depends ONLY on `totalWork` vs grain size, `MaxDegreeOfParallelism`, and `DeterministicReductions` — **`numChunks` is independent**. Bump `numChunks` to `max(16, ProcessorCount * 4)` so TPL is forced to spawn tasks (small-loop inlining doesn't kick in at 16+ iters). The production code under test is **unchanged**.
- Lengthen the caller-thread wait from 200 ms to 1 s. The worker `Set()`s the event from the first off-thread iter so the wait is nearly instant on a warm pool; but a cold-pool first-ever-`Parallel.For` on a constrained CI runner can take >200 ms to spawn a worker.

## Verified

- Local run on 16-logical-CPU Windows: test passes in **14 ms**.
- Build clean (0 errors).

## Why a separate PR

PR #445 (licensing) and PR #446 (release pack fix) are blocked by this test failing on the merged CI. Per the project's workflow rule, don't bundle test infrastructure fixes into unrelated feature PRs. Landing this on `main` first lets #445 / #446 / #447 rebase clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)