### PR TITLE
fix(#444): report true native CPU BLAS state (OpenBLAS detection divergence)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/NativeLibraryDetector.cs
+++ b/src/AiDotNet.Tensors/Engines/NativeLibraryDetector.cs
@@ -27,6 +27,18 @@ public static class NativeLibraryDetector
     public static bool HasOpenBlas => Status.HasOpenBlas;
 
     /// <summary>
+    /// Gets a human-readable explanation of why the native CPU BLAS is unavailable,
+    /// or <c>null</c> when it loaded successfully (<see cref="HasCpuBlas"/> is <c>true</c>).
+    /// <para>
+    /// Issue #444: when <c>libopenblas</c> is deployed but still reports as not found, this
+    /// distinguishes the common causes — package not installed, a missing transitive
+    /// dependency causing the OS loader to fail (<c>ERROR_MOD_NOT_FOUND</c>), an
+    /// architecture mismatch, or an explicit <c>AIDOTNET_USE_BLAS</c> opt-out.
+    /// </para>
+    /// </summary>
+    public static string? OpenBlasLoadDiagnostic => Helpers.BlasProvider.LoadError;
+
+    /// <summary>
     /// Gets whether Intel MKL is available for CPU-accelerated BLAS operations.
     /// </summary>
     public static bool HasMkl => Status.HasMkl;
@@ -127,10 +139,16 @@ public static class NativeLibraryDetector
     public static string GetStatusSummary()
     {
         var status = Status;
+        // Issue #444: when OpenBLAS is not active, append the captured load
+        // reason so a deployed-but-not-loaded library is diagnosable in place.
+        var diagnostic = OpenBlasLoadDiagnostic;
+        string openBlasLine = status.HasOpenBlas
+            ? "Available"
+            : string.IsNullOrEmpty(diagnostic) ? "Not found" : $"Not found ({diagnostic})";
         return $"""
             Native Library Status:
               CPU BLAS:
-                OpenBLAS: {(status.HasOpenBlas ? "Available" : "Not found")}
+                OpenBLAS: {openBlasLine}
                 Intel MKL: {(status.HasMkl ? "Available" : "Not found")}
 
               GPU Acceleration:
@@ -160,22 +178,24 @@ public static class NativeLibraryDetector
 
     private static bool DetectOpenBlas()
     {
-        // External BLAS disabled in the supply-chain-independence build
-        // (feat/finish-mkl-replacement). NativeLibraryDetector still exists for
-        // diagnostic purposes (HasCuda / HasHip / HasOpenCl / HasClBlast all
-        // report GPU-side libraries that ARE still loaded when AiDotNet.Native.*
-        // packages are installed), but the two CPU BLAS detectors (OpenBlas,
-        // MKL) always report false since those paths are no longer used by
-        // the engine — matmul runs through SimdGemm.
-        return false;
+        // Issue #444: report the TRUE state of the native CPU BLAS path. These
+        // detectors previously hardcoded `false` (a stale assumption from when
+        // matmul ran exclusively through SimdGemm), but the engine's GEMM
+        // dispatch now routes through Helpers.BlasProvider, which loads
+        // libopenblas by default (industry-standard BLAS-on; opt out with
+        // AIDOTNET_USE_BLAS=0). Hardcoding `false` made AccelerationDiagnostics
+        // report "OpenBLAS: Not found" even when libopenblas was deployed,
+        // loaded, and actively servicing matmul — a diagnostic that
+        // contradicted reality. Delegating to BlasProvider keeps the diagnostic
+        // surface consistent with the path real matmul actually takes.
+        return Helpers.BlasProvider.IsOpenBlasActive;
     }
 
     private static bool DetectMkl()
     {
-        // See DetectOpenBlas: CPU BLAS detection disabled. The engine routes
-        // all matmul through SimdGemm's AVX2 blocked kernel + JIT micro-kernel
-        // regardless of whether a system MKL DLL is present.
-        return false;
+        // Issue #444: see DetectOpenBlas. True only when the consumer opted into
+        // MKL routing (AIDOTNET_BLAS_PROVIDER=mkl*) AND MklImports loaded.
+        return Helpers.BlasProvider.IsMklActive;
     }
 
     private static bool DetectClBlast()

--- a/src/AiDotNet.Tensors/Helpers/BlasProvider.cs
+++ b/src/AiDotNet.Tensors/Helpers/BlasProvider.cs
@@ -635,7 +635,11 @@ internal static class BlasProvider
 
     private static bool ProbeNativeLibrary()
     {
-        if (!_blasOptIn) return false;
+        if (!_blasOptIn)
+        {
+            _loadError = "native CPU BLAS disabled via AIDOTNET_USE_BLAS opt-out";
+            return false;
+        }
         try
         {
             // Call into native with a trivially-small 1×1 gemm to verify the
@@ -646,11 +650,31 @@ internal static class BlasProvider
             var c = new float[] { 0.0f };
             cblas_sgemm_native(CblasRowMajor, CblasNoTrans, CblasNoTrans,
                 1, 1, 1, 1.0f, a, 1, b, 1, 0.0f, c, 1);
-            return c[0] == 6.0f;
+            if (c[0] == 6.0f) return true;
+            _loadError = $"native CPU BLAS loaded but returned an incorrect result for the 1x1 probe GEMM (expected 6.0, got {c[0]}) — the library may be corrupt or ABI-incompatible";
+            return false;
         }
-        catch (DllNotFoundException) { return false; }
-        catch (EntryPointNotFoundException) { return false; }
-        catch (BadImageFormatException) { return false; }
+        // Issue #444: capture WHY the native library failed to load so the
+        // diagnostic surface (NativeLibraryDetector / PlatformDetector) can
+        // distinguish "package not installed" from a transitive-dependency
+        // load failure (e.g. a missing libgcc/libgfortran/pthread runtime that
+        // makes Win32 LoadLibrary fail with ERROR_MOD_NOT_FOUND (126) even
+        // though libopenblas.dll itself is present on disk).
+        catch (DllNotFoundException ex)
+        {
+            _loadError = $"native CPU BLAS module not found (the package may not be installed, or a dependent runtime DLL is missing): {ex.Message}";
+            return false;
+        }
+        catch (EntryPointNotFoundException ex)
+        {
+            _loadError = $"native CPU BLAS loaded but the cblas_sgemm entry point is missing (unexpected library or version): {ex.Message}";
+            return false;
+        }
+        catch (BadImageFormatException ex)
+        {
+            _loadError = $"native CPU BLAS architecture mismatch (e.g. x86 DLL in an x64 process): {ex.Message}";
+            return false;
+        }
     }
 
     /// <summary>
@@ -993,6 +1017,65 @@ internal static class BlasProvider
 
     /// <summary>True iff <c>AIDOTNET_USE_BLAS=1</c> is set AND libopenblas loaded successfully.</summary>
     internal static bool IsAvailable => _nativeAvailable.Value;
+
+    /// <summary>
+    /// Issue #444: the reason the native CPU BLAS probe failed, or <c>null</c> when it
+    /// succeeded (or has not run yet). Forcing <see cref="IsAvailable"/> first guarantees
+    /// the probe has run before this is read. Surfaced by
+    /// <see cref="Engines.NativeLibraryDetector.OpenBlasLoadDiagnostic"/> so consumers can
+    /// tell "package not installed" apart from a transitive-dependency load failure.
+    /// </summary>
+    private static volatile string? _loadError;
+
+    /// <summary>
+    /// Issue #444: human-readable reason the native CPU BLAS is unavailable, or <c>null</c>
+    /// when it loaded successfully. Reading this forces the (lazy) load probe to run.
+    /// </summary>
+    internal static string? LoadError
+    {
+        get
+        {
+            _ = _nativeAvailable.Value; // ensure the probe (which sets _loadError) has run
+            return _loadError;
+        }
+    }
+
+    /// <summary>
+    /// Issue #444: true when the active, successfully-loaded native CPU BLAS is OpenBLAS
+    /// (the default provider — i.e. <c>AIDOTNET_BLAS_PROVIDER</c> is not set to an MKL
+    /// variant). This is the signal the engine's GEMM dispatch actually gates on, so the
+    /// diagnostic surface stays consistent with the path real matmul takes.
+    /// </summary>
+    internal static bool IsOpenBlasActive
+    {
+        get
+        {
+#if NET5_0_OR_GREATER
+            return _nativeAvailable.Value && !_preferMkl;
+#else
+            // net471 has no DllImport resolver redirect, so the native library
+            // bound by the libopenblas DllImports is always OpenBLAS.
+            return _nativeAvailable.Value;
+#endif
+        }
+    }
+
+    /// <summary>
+    /// Issue #444: true when the active, successfully-loaded native CPU BLAS is Intel MKL
+    /// (<c>AIDOTNET_BLAS_PROVIDER=mkl*</c>, which redirects the libopenblas DllImports to
+    /// MklImports via a resolver — NET5+ only).
+    /// </summary>
+    internal static bool IsMklActive
+    {
+        get
+        {
+#if NET5_0_OR_GREATER
+            return _nativeAvailable.Value && _preferMkl;
+#else
+            return false;
+#endif
+        }
+    }
 
     internal static string BackendName => _nativeAvailable.Value
         ? "OpenBLAS (AIDOTNET_USE_BLAS=1)"

--- a/tests/AiDotNet.Tensors.Tests/Engines/Issue444OpenBlasDetectionTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Issue444OpenBlasDetectionTests.cs
@@ -1,0 +1,98 @@
+// Issue #444 — the native CPU BLAS diagnostic must reflect the ACTUAL load
+// state, not a hardcoded `false`.
+//
+// Background: NativeLibraryDetector.DetectOpenBlas()/DetectMkl() previously
+// returned a hardcoded `false` (a stale assumption from when matmul ran only
+// through SimdGemm). After BLAS-default-on (#319), the engine's GEMM dispatch
+// routes through Helpers.BlasProvider, which loads libopenblas by default.
+// The hardcoded false made AccelerationDiagnostics / PlatformDetector report
+// "OpenBLAS: Not found" even when libopenblas was deployed, loaded, and
+// actively servicing matmul — a diagnostic that contradicted reality.
+//
+// These tests lock the diagnostic to the real provider state so the divergence
+// cannot regress. The Tensors test project does NOT reference
+// AiDotNet.Native.OpenBLAS (the library is supply-chain-independent), so these
+// run in the "DLL absent" regime — but the asserted invariants hold in BOTH
+// regimes by construction (they tie the diagnostic to BlasProvider rather than
+// to a fixed expected value).
+
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Helpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+public class Issue444OpenBlasDetectionTests
+{
+    private readonly ITestOutputHelper _output;
+    public Issue444OpenBlasDetectionTests(ITestOutputHelper output) { _output = output; }
+
+    [Fact]
+    public void Detector_HasCpuBlas_MatchesActualProviderLoadState()
+    {
+        // Core #444 regression. BlasProvider.IsAvailable is exactly what the
+        // engine's GEMM dispatch gates on; HasCpuBlas must equal it — no false
+        // "Not found" while OpenBLAS is loaded and servicing matmul, and no
+        // false "Available" while it isn't. The pre-fix code hardcoded
+        // HasCpuBlas=false and so violated this whenever IsAvailable was true.
+        _output.WriteLine($"BlasProvider.IsAvailable = {BlasProvider.IsAvailable}");
+        _output.WriteLine($"NativeLibraryDetector.HasCpuBlas = {NativeLibraryDetector.HasCpuBlas}");
+        Assert.Equal(BlasProvider.IsAvailable, NativeLibraryDetector.HasCpuBlas);
+    }
+
+    [Fact]
+    public void Detector_HasOpenBlas_MatchesActiveOpenBlasProvider()
+    {
+        Assert.Equal(BlasProvider.IsOpenBlasActive, NativeLibraryDetector.HasOpenBlas);
+    }
+
+    [Fact]
+    public void Detector_HasMkl_MatchesActiveMklProvider()
+    {
+        Assert.Equal(BlasProvider.IsMklActive, NativeLibraryDetector.HasMkl);
+    }
+
+    [Fact]
+    public void LoadDiagnostic_PresentWhenUnavailable_AbsentWhenLoaded()
+    {
+        // When CPU BLAS is unavailable, the diagnostic must explain WHY (so a
+        // deployed-but-not-loaded libopenblas is diagnosable in place — the
+        // exact gap #444 reports). When it loaded, there is no error to report.
+        var diagnostic = NativeLibraryDetector.OpenBlasLoadDiagnostic;
+        _output.WriteLine($"HasCpuBlas={NativeLibraryDetector.HasCpuBlas}, diagnostic='{diagnostic ?? "(null)"}'");
+
+        // Available  -> diagnostic null/empty;  Unavailable -> diagnostic present.
+        Assert.Equal(NativeLibraryDetector.HasCpuBlas, string.IsNullOrEmpty(diagnostic));
+    }
+
+    [Fact]
+    public void StatusSummary_ExplainsWhy_WhenOpenBlasNotFound()
+    {
+        var summary = NativeLibraryDetector.GetStatusSummary();
+        _output.WriteLine(summary);
+        Assert.Contains("OpenBLAS:", summary);
+
+        if (!NativeLibraryDetector.HasOpenBlas)
+        {
+            var diagnostic = NativeLibraryDetector.OpenBlasLoadDiagnostic;
+            if (!string.IsNullOrEmpty(diagnostic))
+            {
+                // The summary's OpenBLAS line embeds the captured reason rather
+                // than a bare "Not found".
+                Assert.Contains(diagnostic, summary);
+            }
+        }
+    }
+
+    [Fact]
+    public void PlatformDetector_Capabilities_AgreeWithDetector()
+    {
+        // PlatformDetector copies NativeLibraryDetector.Status into its
+        // capability struct, so the two diagnostic surfaces must stay
+        // consistent — fixing the detector fixes both.
+        var caps = PlatformDetector.Capabilities;
+        Assert.Equal(NativeLibraryDetector.HasOpenBlas, caps.HasOpenBlas);
+        Assert.Equal(NativeLibraryDetector.HasMkl, caps.HasMkl);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #444 — `AccelerationDiagnostics` / `PlatformDetector` reported **`OpenBLAS=False` / `CpuBLAS=False` / "OpenBLAS: Not found"** even when a valid `libopenblas.dll` was deployed at the canonical `runtimes/win-x64/native/` probe path and the engine was actively using it.

**Root cause (issue's triage hypothesis #3 — diagnostic-probe divergence):** `NativeLibraryDetector.DetectOpenBlas()`/`DetectMkl()` returned a **hardcoded `false`**. That was a stale assumption from when matmul ran exclusively through `SimdGemm`. After BLAS-default-on (#319), the engine's GEMM dispatch routes through `Helpers.BlasProvider` (dozens of `TryGemm`/`TryGemmEx` call sites in `CpuEngine`), which loads `libopenblas` by default. So the diagnostic surface contradicted the path real matmul actually takes — the library *was* loaded and servicing GEMM, but the report said "Not found."

## Fix

- **`BlasProvider`** gains `IsOpenBlasActive` / `IsMklActive` — the same `_nativeAvailable` signal the engine's GEMM dispatch already gates on. Correct across both TFMs (net471 has no MKL `DllImport` resolver redirect, so the native lib there is always OpenBLAS).
- **`NativeLibraryDetector.DetectOpenBlas`/`DetectMkl`** delegate to those instead of returning `false`. `PlatformDetector` (which copies `NativeLibraryDetector.Status`) is fixed transitively.
- **`ProbeNativeLibrary`** now captures *why* the native load failed — module-not-found (package not installed **or** a missing transitive dependency → `ERROR_MOD_NOT_FOUND`), entry-point missing, architecture mismatch, or `AIDOTNET_USE_BLAS` opt-out — surfaced as `NativeLibraryDetector.OpenBlasLoadDiagnostic` and embedded in `GetStatusSummary()`'s `Not found (…)` line. This directly addresses the issue's request to disambiguate "not installed" from a transitive-dependency load failure **in place**, instead of a bare "Not found".

## Why this is safe

No production logic gates on `NativeLibraryDetector.HasOpenBlas`/`HasCpuBlas` — they feed only the diagnostic/capability surfaces (`PlatformDetector`, status summary). `RequireOpenBlas`/`RequireCpuBlas` are never called in `src`. Flipping the detector from "always false" to "the truth" only corrects reporting; it does not change any dispatch decision.

## Tests

`Issue444OpenBlasDetectionTests` (6 tests) lock the diagnostic to the real provider state so the divergence can't regress:
- `HasCpuBlas` == `BlasProvider.IsAvailable` (no false "Not found" while OpenBLAS is loaded; no false "Available" while it isn't) — the core #444 regression.
- `HasOpenBlas`/`HasMkl` track `IsOpenBlasActive`/`IsMklActive`.
- a load diagnostic is present iff CPU BLAS is unavailable, and embedded in the status summary.
- `PlatformDetector.Capabilities` agrees with the detector.

The Tensors test project doesn't reference `AiDotNet.Native.OpenBLAS` (the library is supply-chain-independent), so these run in the "DLL absent" regime — but the asserted invariants hold in **both** regimes by construction (they tie the diagnostic to the provider, not to a fixed value). The consumer-side "DLL present → reports Available" arm is exercised in the consuming app.

**6/6 pass on net471 + net10.0; existing BLAS/platform tests unaffected.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)