### PR TITLE
fix(release): unbreak NuGet pack (don't propagate --no-build into LicenseValidator build)

### DIFF
--- a/build/AiDotNet.Tensors.Enterprise.targets
+++ b/build/AiDotNet.Tensors.Enterprise.targets
@@ -119,7 +119,7 @@
     <MSBuild Projects="$(MSBuildThisFileDirectory)LicenseValidator\AiDotNet.Tensors.LicenseValidator.csproj"
              Targets="Restore;Build"
              Properties="Configuration=Release"
-             RemoveProperties="TargetFramework" />
+             RemoveProperties="TargetFramework;NoBuild" />
   </Target>
 
   <!--
@@ -228,7 +228,7 @@
     <MSBuild Projects="$(MSBuildThisFileDirectory)LicenseValidator\AiDotNet.Tensors.LicenseValidator.csproj"
              Targets="Restore;Build"
              Properties="Configuration=Release"
-             RemoveProperties="TargetFramework" />
+             RemoveProperties="TargetFramework;NoBuild" />
     <ItemGroup>
       <!-- ONLY the validator DLL closure is added dynamically — those files
            don't exist until the validator is built above, and the


### PR DESCRIPTION
## Summary
The **Automated Release Pipeline** has been failing at the **Pack NuGet packages** step on every push to `main`:

```
NETSDK1085: The 'NoBuild' property was set to true but the 'Build' target was invoked.
  [build/LicenseValidator/AiDotNet.Tensors.LicenseValidator.csproj]
```

## Root cause
`dotnet pack … --no-build` sets `NoBuild=true` as a **global** MSBuild property. The enterprise-gate targets (`build/AiDotNet.Tensors.Enterprise.targets`) build the license-validator task assembly *during pack* via a nested `<MSBuild Targets="Restore;Build">` (`PackLicenseValidatorAssets`, `BeforeTargets=_GetPackageFiles`) so its DLL closure can be packed into the `.nupkg`. The validator project isn't in the solution, so the pipeline's solution build doesn't produce it — pack **must** build it. But the nested `<MSBuild>` only removed `TargetFramework`, so it **inherited the parent's `NoBuild=true`** and tripped NETSDK1085 (plus a downstream CS0234 from the half-built state).

## Fix
Add `NoBuild` to `RemoveProperties` on both nested validator `<MSBuild>` calls (`PackLicenseValidatorAssets` and `EnsureAiDotNetLicenseValidatorBuilt`) so the validator builds normally regardless of the outer `--no-build`. One-line change in the targets file.

## The LicenseValidator / enterprise gate is fully preserved
This does **not** skip the validator. Verified the packed `.nupkg` still contains the complete gate:
- `build/AiDotNet.Tensors.Enterprise.targets`
- `build/AiDotNet.Tensors.targets` (NuGet auto-import shim)
- all **10** `build/LicenseValidator/bin/*.dll` (the validator + BouncyCastle + the System.Text.Json netstandard2.0 closure)

## Verification (local)
Reproduced NETSDK1085 with `dotnet build` (solution) then `dotnet pack --no-build`; after the fix, pack succeeds (`Successfully created package …`) and the validator assets are present in the package.

## ⚠️ Release implication — needs explicit approval to merge
`automated-release.yml` triggers on **push to `main`**. It currently dies at pack, so no release is produced. With this fix, the next push to `main` (i.e. merging this PR) will pack successfully and then run **Publish to NuGet** + **Create GitHub Release** — a real release. Please merge only when you intend to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)