### PR TITLE
fix: serialize nested BlasManaged GEMMs to stop per-head attention oversubscription

### DIFF
--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
@@ -250,15 +250,10 @@ public static class BlasManaged
         // get an inner options with Epilogue stripped to avoid double-application.
         int splitMAligned = m - (m % mr);
         int splitNAligned = n - (n % nr);
-        // Honor NumThreads = -1 as explicit single-thread (deterministic mode).
-        // Pre-fix: -1 fell into the "> 0 is false" branch and used all processors,
-        // breaking determinism/perf expectations. PR #402 CodeRabbit fix.
-        int splitProcs = options.NumThreads switch
-        {
-            -1 => 1,
-            > 0 => options.NumThreads,
-            _ => System.Environment.ProcessorCount,
-        };
+        // Honor NumThreads = -1 as explicit single-thread (deterministic mode); PR #402.
+        // Also collapses to 1 when nested inside a parallel region so the split gate
+        // matches the strategies' single-threaded execution (no oversubscription).
+        int splitProcs = CpuParallelSettings.ResolveWorkerThreads(options.NumThreads);
         if (m >= mr && n >= nr && (m % mr != 0 || n % nr != 0)
             && splitMAligned >= splitProcs * mr)
         {
@@ -354,13 +349,9 @@ public static class BlasManaged
         bool hasEpilogue = options.Epilogue.Activation != AiDotNet.Tensors.Engines.FusedActivationType.None
             || !options.Epilogue.BiasN.IsEmpty
             || !options.Epilogue.SkipMxN.IsEmpty;
-        // Honor NumThreads = -1 as explicit single-thread (matches splitProcs above).
-        int procs = options.NumThreads switch
-        {
-            -1 => 1,
-            > 0 => options.NumThreads,
-            _ => Environment.ProcessorCount,
-        };
+        // Honor NumThreads = -1 as explicit single-thread (matches splitProcs above);
+        // region-aware so nested calls feed the autotuner a single-thread blocking choice.
+        int procs = CpuParallelSettings.ResolveWorkerThreads(options.NumThreads);
         var (_, autotuneMc, autotuneNc, autotuneKc, _) =
             AutotuneDispatcher.Decide<T>(
                 m, n, k,

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackAOnlyStrategy.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackAOnlyStrategy.cs
@@ -53,8 +53,10 @@ internal static class PackAOnlyStrategy
                 "Tail column handling is tracked as follow-up work; callers should pad n " +
                 "or route to a strategy that handles remainders.");
 
-        int procs = options.NumThreads > 0 ? options.NumThreads : Environment.ProcessorCount;
-        if (options.NumThreads < 0) procs = 1;
+        // Honors NumThreads AND the nested-parallel-region guard: from a per-head
+        // attention Parallel.For, an unset NumThreads collapses to 1 thread here so
+        // heads × ProcessorCount workers don't oversubscribe the ThreadPool.
+        int procs = CpuParallelSettings.ResolveWorkerThreads(options.NumThreads);
         bool isDeterministic = BlasProvider.IsDeterministicMode;
 
         var axis = AxisSelector.Select(m, n, k, mr, nr, procs, isDeterministic);

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
@@ -102,8 +102,10 @@ internal static class PackBothStrategy
             // to fill all cores via M-axis parallel alone. ShouldUse2DGrid returns
             // true when (numMBlocks * 2 < procs && numNBlocks > 1) — i.e., the
             // existing M-axis split would leave half or more cores idle.
-            int procs = options.NumThreads > 0 ? options.NumThreads : Environment.ProcessorCount;
-            if (options.NumThreads < 0) procs = 1;
+            // Honors NumThreads AND the nested-parallel-region guard (unset → 1 thread
+            // when nested in a per-head attention Parallel.For, avoiding heads ×
+            // ProcessorCount ThreadPool oversubscription).
+            int procs = CpuParallelSettings.ResolveWorkerThreads(options.NumThreads);
             int numMBlocks = (m + mc - 1) / mc;
             int numNBlocks = (n + nc - 1) / nc;
             // ShouldUse2DGrid fires when M-axis underutilizes. ALSO require m < 256
@@ -477,8 +479,7 @@ internal static class PackBothStrategy
                     // Threshold: ≥4 stripes AND ≥procs threads available AND
                     // ≥256 KB of pack work — below that, serial wins.
                     int packBStripeSize = effectiveKc * nr * elemSize;
-                    int procsLocal = options.NumThreads > 0 ? options.NumThreads : Environment.ProcessorCount;
-                    if (options.NumThreads < 0) procsLocal = 1;
+                    int procsLocal = CpuParallelSettings.ResolveWorkerThreads(options.NumThreads);
                     bool packBParallelWorthwhile =
                         totalNumStripes >= 4
                         && procsLocal >= 2

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/StreamingStrategy.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/StreamingStrategy.cs
@@ -46,9 +46,11 @@ internal static class StreamingStrategy
         int m, int n, int k,
         in BlasOptions<T> options = default) where T : unmanaged
     {
-        int procs = options.NumThreads > 0 ? options.NumThreads : Environment.ProcessorCount;
-        // -1 from caller = force single-thread (deterministic regression-test path).
-        if (options.NumThreads < 0) procs = 1;
+        // Honors NumThreads (>0 explicit, -1 deterministic single-thread) AND the
+        // nested-parallel-region guard: an unset NumThreads collapses to 1 thread when
+        // called from inside a per-head attention Parallel.For, avoiding ThreadPool
+        // oversubscription (heads × ProcessorCount workers).
+        int procs = CpuParallelSettings.ResolveWorkerThreads(options.NumThreads);
         // Determinism comes from either the global BlasProvider switch or the per-call
         // BlasOptions.Mode. Any source asking for Deterministic wins (OR semantics).
         bool isDeterministic = BlasProvider.IsDeterministicMode || options.Mode == BlasMode.Deterministic;

--- a/src/AiDotNet.Tensors/Helpers/CpuParallelSettings.cs
+++ b/src/AiDotNet.Tensors/Helpers/CpuParallelSettings.cs
@@ -103,6 +103,32 @@ public static class CpuParallelSettings
     public static bool IsInParallelRegion => _inParallelRegion;
 
     /// <summary>
+    /// Resolves the worker-thread count for a GEMM/pack parallel loop, honoring both the
+    /// caller's explicit <c>NumThreads</c> and the nested-parallel-region guard.
+    /// </summary>
+    /// <param name="requestedThreads">
+    /// The caller's <c>BlasOptions.NumThreads</c>: <c>&gt;0</c> = an explicit fixed count,
+    /// <c>-1</c> = explicit single-thread (deterministic mode), <c>0</c> = unset/default.
+    /// </param>
+    /// <returns>
+    /// The explicit count when one was requested; otherwise <c>1</c> when the calling
+    /// thread is already inside a parallel region (so the inner loop collapses to serial),
+    /// or <see cref="System.Environment.ProcessorCount"/> at the top level.
+    /// </returns>
+    /// <remarks>
+    /// This is the wiring the BlasManaged strategy doc on <see cref="IsInParallelRegion"/>
+    /// describes: without it, a per-head attention <c>Parallel.For</c> (one worker per
+    /// B·H head) would have each head launch a <c>ProcessorCount</c>-wide GEMM loop,
+    /// oversubscribing the ThreadPool by <c>heads × ProcessorCount</c> and thrashing.
+    /// </remarks>
+    public static int ResolveWorkerThreads(int requestedThreads)
+    {
+        if (requestedThreads > 0) return requestedThreads;
+        if (requestedThreads < 0) return 1;
+        return _inParallelRegion ? 1 : System.Environment.ProcessorCount;
+    }
+
+    /// <summary>
     /// Marks the calling thread as inside a parallel region until the returned
     /// scope is disposed, restoring the prior value on dispose. Wrap the body of
     /// any <c>Parallel.For</c> worker with this so nested parallel calls serialize.

--- a/tests/AiDotNet.Tensors.Tests/Engines/SdpaNestedParallelismTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/SdpaNestedParallelismTests.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Diagnostics;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Regression tests for the per-head attention GEMM oversubscription bug: the SDPA float
+/// path parallelizes over B·H heads with <see cref="CpuParallelSettings.ParallelForOrSerial"/>
+/// (which enters a parallel region per worker), but each head's QK^T / P·V GEMM went through
+/// the BlasManaged strategies, which resolved their worker count to <c>ProcessorCount</c>
+/// regardless of the region. For a large per-head GEMM that triggers multithreading, that is
+/// <c>heads × ProcessorCount</c> threads on <c>ProcessorCount</c> cores — catastrophic
+/// ThreadPool oversubscription that thrashes (e.g. SDPA float [1,8,1024,64] burned thousands
+/// of CPU-seconds without completing).
+///
+/// The fix routes every BlasManaged thread-count decision through
+/// <see cref="CpuParallelSettings.ResolveWorkerThreads"/>, which collapses an unset
+/// <c>NumThreads</c> to 1 when already inside a parallel region — the wiring the
+/// <see cref="CpuParallelSettings.IsInParallelRegion"/> doc always described.
+/// </summary>
+public class SdpaNestedParallelismTests
+{
+    private readonly ITestOutputHelper _output;
+    private readonly CpuEngine _engine;
+
+    public SdpaNestedParallelismTests(ITestOutputHelper output)
+    {
+        _output = output;
+        _engine = new CpuEngine();
+    }
+
+    // ---- Core fix: ResolveWorkerThreads honors explicit NumThreads AND the region ----
+
+    [Fact]
+    public void ResolveWorkerThreads_TopLevel_UnsetUsesAllProcessors()
+    {
+        Assert.False(CpuParallelSettings.IsInParallelRegion);
+        Assert.Equal(Environment.ProcessorCount, CpuParallelSettings.ResolveWorkerThreads(0));
+    }
+
+    [Fact]
+    public void ResolveWorkerThreads_ExplicitCount_AlwaysRespected()
+    {
+        Assert.Equal(4, CpuParallelSettings.ResolveWorkerThreads(4));
+        // Even inside a region an explicit positive count is honored (caller knows best).
+        using (CpuParallelSettings.EnterParallelRegion())
+            Assert.Equal(4, CpuParallelSettings.ResolveWorkerThreads(4));
+    }
+
+    [Fact]
+    public void ResolveWorkerThreads_NegativeMeansSingleThread()
+    {
+        Assert.Equal(1, CpuParallelSettings.ResolveWorkerThreads(-1));
+    }
+
+    [Fact]
+    public void ResolveWorkerThreads_NestedRegion_UnsetCollapsesToSingleThread()
+    {
+        // THE regression: an unset NumThreads inside a parallel region must resolve to 1,
+        // not ProcessorCount — otherwise nested GEMMs oversubscribe.
+        using (CpuParallelSettings.EnterParallelRegion())
+            Assert.Equal(1, CpuParallelSettings.ResolveWorkerThreads(0));
+        // Region scope restored on dispose.
+        Assert.False(CpuParallelSettings.IsInParallelRegion);
+        Assert.Equal(Environment.ProcessorCount, CpuParallelSettings.ResolveWorkerThreads(0));
+    }
+
+    // ---- SDPA path correctness (the fix must not change results) ----
+
+    [Theory]
+    [InlineData(2, 4, 48, 32)]   // multi-batch, multi-head, moderate seq
+    [InlineData(1, 8, 64, 64)]   // single batch, more heads
+    public void Sdpa_Float_MatchesNaiveReference(int b, int h, int seq, int d)
+    {
+        var rng = new Random(20260527);
+        var q = MakeRandom4D(rng, b, h, seq, d);
+        var k = MakeRandom4D(rng, b, h, seq, d);
+        var v = MakeRandom4D(rng, b, h, seq, d);
+
+        var got = _engine.ScaledDotProductAttention<float>(q, k, v, null, null, out _);
+        var expected = NaiveSdpa(q, k, v, b, h, seq, d);
+
+        var gs = got.AsSpan();
+        for (int i = 0; i < gs.Length; i++)
+            Assert.True(Math.Abs(gs[i] - expected[i]) <= 1e-3f * (1 + Math.Abs(expected[i])),
+                $"index {i}: got {gs[i]:E5} vs expected {expected[i]:E5}");
+    }
+
+    /// <summary>
+    /// The oversubscription repro: large per-head GEMM ([1024,1024,64]) across 8 heads. Gated
+    /// behind AIDOTNET_RUN_JIT_PERF because it is heavy; pre-fix it thrashed for minutes, post-fix
+    /// it completes in well under a second of compute. Reports best-of-3 wall time.
+    /// </summary>
+    [Trait("Category", "Performance")]
+    [Fact]
+    public void Sdpa_Float_LargeHeads_DoesNotOversubscribe()
+    {
+        if (Environment.GetEnvironmentVariable("AIDOTNET_RUN_JIT_PERF") != "1") return;
+        const int b = 1, h = 8, seq = 1024, d = 64;
+        var rng = new Random(7);
+        var q = MakeRandom4D(rng, b, h, seq, d);
+        var k = MakeRandom4D(rng, b, h, seq, d);
+        var v = MakeRandom4D(rng, b, h, seq, d);
+        _ = _engine.ScaledDotProductAttention<float>(q, k, v, null, null, out _); // warm
+        double best = double.MaxValue;
+        for (int r = 0; r < 3; r++)
+        {
+            var sw = Stopwatch.StartNew();
+            _ = _engine.ScaledDotProductAttention<float>(q, k, v, null, null, out _);
+            sw.Stop();
+            best = Math.Min(best, sw.Elapsed.TotalMilliseconds);
+        }
+        _output.WriteLine($"SDPA float [1,8,1024,64] best-of-3: {best:F1} ms");
+    }
+
+    // ---- helpers ----
+
+    private static Tensor<float> MakeRandom4D(Random rng, int a, int b, int c, int d)
+    {
+        var t = new Tensor<float>(new[] { a, b, c, d });
+        var sp = t.AsWritableSpan();
+        for (int i = 0; i < sp.Length; i++) sp[i] = (float)(rng.NextDouble() * 2 - 1);
+        return t;
+    }
+
+    private static float[] NaiveSdpa(Tensor<float> q, Tensor<float> k, Tensor<float> v,
+        int b, int h, int seq, int d)
+    {
+        var qs = q.AsSpan(); var ks = k.AsSpan(); var vs = v.AsSpan();
+        var outp = new float[b * h * seq * d];
+        float scale = (float)(1.0 / Math.Sqrt(d));
+        var scores = new double[seq];
+        for (int bi = 0; bi < b; bi++)
+            for (int hi = 0; hi < h; hi++)
+            {
+                int baseOff = ((bi * h) + hi) * seq * d;
+                for (int i = 0; i < seq; i++)
+                {
+                    double maxv = double.NegativeInfinity;
+                    for (int j = 0; j < seq; j++)
+                    {
+                        double s = 0;
+                        for (int e = 0; e < d; e++)
+                            s += (double)qs[baseOff + i * d + e] * ks[baseOff + j * d + e];
+                        s *= scale;
+                        scores[j] = s;
+                        if (s > maxv) maxv = s;
+                    }
+                    double sum = 0;
+                    for (int j = 0; j < seq; j++) { scores[j] = Math.Exp(scores[j] - maxv); sum += scores[j]; }
+                    double inv = sum != 0 ? 1.0 / sum : 0.0;
+                    for (int e = 0; e < d; e++)
+                    {
+                        double acc = 0;
+                        for (int j = 0; j < seq; j++) acc += scores[j] * inv * vs[baseOff + j * d + e];
+                        outp[baseOff + i * d + e] = (float)acc;
+                    }
+                }
+            }
+        return outp;
+    }
+}


### PR DESCRIPTION
## Problem

`ScaledDotProductAttention<float>` at moderate-to-large sequence lengths (e.g. `[1,8,1024,64]`) **thrashed for minutes** — thousands of CPU-seconds without completing — due to ThreadPool oversubscription.

The float SDPA path parallelizes over `B·H` heads via `CpuParallelSettings.ParallelForOrSerial`, which marks each worker thread as inside a parallel region. Inside each head it runs the QK^T and P·V GEMMs through BlasManaged. But the BlasManaged strategies resolved their worker count like this:

```csharp
int procs = options.NumThreads > 0 ? options.NumThreads : Environment.ProcessorCount;
if (options.NumThreads < 0) procs = 1;
```

With `NumThreads` unset (the default), that is `ProcessorCount` **regardless of the parallel region**. So when a per-head GEMM is large enough to multithread, you get `heads × ProcessorCount` workers fighting over `ProcessorCount` cores. The tiny inference shape `[128,4,32,16]` escaped only because its per-head GEMM was too small to trigger multithreading.

`CpuParallelSettings` already *documented* that BlasManaged's parallel sites should consult `IsInParallelRegion` and serialize when nested ("Raw Parallel.For sites (e.g. the BlasManaged GEMM strategies) consult this to fall back to a serial loop when nested, preventing ThreadPool starvation") — it was simply never wired in.

## Fix

Add `CpuParallelSettings.ResolveWorkerThreads(numThreads)`:

| `NumThreads` | resolves to |
|---|---|
| `> 0` | that explicit count |
| `-1` | `1` (deterministic single-thread) |
| `0` (unset), top level | `Environment.ProcessorCount` |
| `0` (unset), **inside a parallel region** | `1` |

Every BlasManaged thread-count decision now routes through it: `BlasManaged.Gemm` (`splitProcs`, `procs`), `PackBothStrategy` (×2), `PackAOnlyStrategy`, `StreamingStrategy`.

**Top-level GEMM behavior is unchanged** (`ProcessorCount` when not nested). Only nested per-head GEMMs collapse to single-thread — which is exactly what the SDPA fallback already did by hand-calling `SgemmSequential`. Numerics are unchanged (thread count only).

## Result

`SDPA float [1,8,1024,64]`: **non-terminating thrash → 20.7 ms** (best-of-3).

## Tests

New `SdpaNestedParallelismTests`:
- `ResolveWorkerThreads` unit cases, including the regression: unset `NumThreads` inside `EnterParallelRegion()` → `1`.
- SDPA float output matches a naive double-precision reference across `[2,4,48,32]` and `[1,8,64,64]`.
- Gated repro `Sdpa_Float_LargeHeads_DoesNotOversubscribe` (`AIDOTNET_RUN_JIT_PERF=1`).

Existing suites green on net10.0 + net471: **532** BlasManaged/strategy, **71** attention (FusedAttention/MHA/SDPA), **427** Gemm/MatMul.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
