### PR TITLE
fix(gpu): preserve NaN through CUDA ReLU + remove broken GPU TensorScatterAdd

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaActivationKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaActivationKernels.cs
@@ -9,12 +9,25 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA.Kernels
             return @"
 #include <math.h>
 
+// NaN-preserving ReLU. A plain (x > 0 ? x : 0) maps NaN to 0 because every
+// ordered comparison with NaN is false, silently swallowing NaN — the CPU
+// ReluNaNSafe* path instead keeps NaN as a numerical-blowup signal, so match
+// that contract here. NaN is detected on the raw bit pattern via
+// __float_as_uint, NOT isnan()/float comparison: the kernels compile with
+// --use_fast_math, and a bit test survives that (a float is NaN iff its
+// exponent is all-ones and mantissa non-zero, i.e. (bits & 0x7fffffff) exceeds
+// 0x7f800000, the bit pattern of +Inf).
+__device__ __forceinline__ float relu_nan_safe(float x)
+{
+    unsigned int bits = __float_as_uint(x) & 0x7fffffffu;
+    return (bits > 0x7f800000u) ? x : (x > 0.0f ? x : 0.0f);
+}
+
 extern ""C"" __global__ __launch_bounds__(256) void relu(const float* __restrict__ input, float* __restrict__ output, int size)
 {
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx >= size) return;
-    float x = input[idx];
-    output[idx] = x > 0.0f ? x : 0.0f;
+    output[idx] = relu_nan_safe(input[idx]);
 }
 
 extern ""C"" __global__ __launch_bounds__(256) void sigmoid(const float* __restrict__ input, float* __restrict__ output, int size)
@@ -1158,11 +1171,12 @@ extern ""C"" __global__ __launch_bounds__(256) void relu_vec4(const float* __res
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx >= size4) return;
     float4 v = reinterpret_cast<const float4*>(input)[idx];
+    // Use relu_nan_safe so NaN propagates here too — same contract as scalar relu.
     float4 r;
-    r.x = v.x > 0.0f ? v.x : 0.0f;
-    r.y = v.y > 0.0f ? v.y : 0.0f;
-    r.z = v.z > 0.0f ? v.z : 0.0f;
-    r.w = v.w > 0.0f ? v.w : 0.0f;
+    r.x = relu_nan_safe(v.x);
+    r.y = relu_nan_safe(v.y);
+    r.z = relu_nan_safe(v.z);
+    r.w = relu_nan_safe(v.w);
     reinterpret_cast<float4*>(output)[idx] = r;
 }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/ActivationKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/ActivationKernels.cs
@@ -70,6 +70,15 @@ inline float fast_exp1(float x) {
 // fmax(0, NaN) returns 0 in OpenCL because NaN compares as less-than,
 // silently zeroing incoming NaN values. CPU ReluNaNSafe* preserves NaN
 // as a debugging signal — match that contract here too.
+//
+// NaN is detected by reinterpreting the float bits, NOT by isnan()/float
+// comparison: the program is built with -cl-finite-math-only (see
+// OpenClBuildOptions.OptimizationFlags), which lets the compiler assume no
+// NaN/Inf exists and fold isnan(x) to constant-false — silently defeating a
+// select()/ternary that depends on it. The integer test below survives those
+// flags because it operates on the raw bit pattern: a float is NaN iff its
+// exponent is all-ones and the mantissa is non-zero, i.e. (bits & 0x7fffffff)
+// exceeds 0x7f800000 (the bit pattern of +Inf).
 __kernel void relu(
     __global const float* input,
     __global float* output,
@@ -79,17 +88,16 @@ __kernel void relu(
     const int idx4 = idx * 4;
     if (idx4 + 3 < size) {
         float4 x = vload4(idx, input);
-        // isnan returns int4 mask (all-ones per NaN lane); select() returns
-        // the NaN where the mask is set, fmax otherwise. The fmax branch is
-        // safe for non-NaN inputs.
-        float4 zero = (float4)(0.0f);
-        float4 m = fmax(zero, x);
-        int4 nanMask = isnan(x);
+        float4 m = fmax((float4)(0.0f), x);
+        // Vector relational ops return a signed int vector (-1 per true lane);
+        // select() picks x (the NaN) where the lane's MSB is set, m otherwise.
+        int4 nanMask = (as_uint4(x) & (uint4)(0x7fffffffu)) > (uint4)(0x7f800000u);
         vstore4(select(m, x, nanMask), idx, output);
     } else {
         for (int i = idx4; i < size; i++) {
             float v = input[i];
-            output[i] = isnan(v) ? v : fmax(0.0f, v);
+            uint bits = as_uint(v) & 0x7fffffffu;
+            output[i] = (bits > 0x7f800000u) ? v : fmax(0.0f, v);
         }
     }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -316,8 +316,11 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 }
                 WriteDiag($"[OpenClBackend] GEMM kernels: {string.Join(", ", GemmKernel.GetKernelNames())}");
 
-                // Compile activation kernels
-                var activationProgram = CompileOrLoadCached(ActivationKernels.GetSource(), optimizationFlags, "Activation kernels");
+                // Compile activation kernels with NaN-preserving math flags: the
+                // relu kernel propagates NaN by contract, which -cl-finite-math-only
+                // / -cl-fast-relaxed-math would optimize away (the compiler assumes
+                // no NaN exists). See OpenClBuildOptions.SafeMathFlags.
+                var activationProgram = CompileOrLoadCached(ActivationKernels.GetSource(), OpenClBuildOptions.SafeMathFlags, "Activation kernels");
                 _programs.Add(activationProgram);
                 foreach (var name in ActivationKernels.GetKernelNames())
                 {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBuildOptions.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBuildOptions.cs
@@ -7,5 +7,14 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         // Aggressive optimization flags for maximum performance.
         public const string OptimizationFlags =
             "-cl-fast-relaxed-math -cl-mad-enable -cl-unsafe-math-optimizations -cl-finite-math-only -cl-no-signed-zeros";
+
+        // NaN/Inf-preserving flags for kernels whose contract is to propagate
+        // NaN (e.g. the relu activation preserves NaN as a numerical-blowup
+        // signal — see ActivationKernels relu). Both -cl-fast-relaxed-math and
+        // -cl-finite-math-only let the compiler assume no NaN/Inf exists and
+        // fold away NaN-detection (isnan AND raw-bit tests alike), so they must
+        // be omitted here; -cl-unsafe-math-optimizations is dropped for the same
+        // safety. -cl-mad-enable and -cl-no-signed-zeros are NaN-neutral and kept.
+        public const string SafeMathFlags = "-cl-mad-enable -cl-no-signed-zeros";
     }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClKernelSources.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClKernelSources.cs
@@ -280,8 +280,15 @@ internal static class OpenClKernelSources
             // NaN-preserving: fmax(0, NaN) returns 0 in OpenCL (NaN compares
             // as "less than"), silently zeroing NaN. CPU ReluNaNSafe* preserves
             // NaN as a numerical-blowup signal — match that contract.
+            //
+            // NaN is detected on the raw bit pattern, NOT via isnan(): the program
+            // is built with -cl-finite-math-only (OpenClBuildOptions.OptimizationFlags),
+            // which lets the compiler assume no NaN exists and fold isnan(v) to
+            // constant-false. The integer test survives those flags — a float is NaN
+            // iff (bits & 0x7fffffff) > 0x7f800000 (the bit pattern of +Inf).
             float v = input[idx];
-            output[idx] = isnan(v) ? v : fmax(0.0f, v);
+            uint bits = as_uint(v) & 0x7fffffffu;
+            output[idx] = (bits > 0x7f800000u) ? v : fmax(0.0f, v);
         }
 
         __kernel void sigmoid(__global const float* input, __global float* output, const int size) {

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -13744,31 +13744,15 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
     }
 
-    public override Tensor<T> TensorScatterAdd<T>(Tensor<T> destination, Tensor<int> indices, Tensor<T> updates, int axis)
-    {
-        if (!TryGetBackend(out var backend) || axis != 0)
-            return base.TensorScatterAdd(destination, indices, updates, axis);
-
-        try
-        {
-            // Copy destination first, then scatter-add into it
-            using var bufDst = GetOrAllocateBuffer(backend, destination.GetDataArray());
-            using var bufIdx = backend.AllocateIntBuffer(indices.GetDataArray());
-            using var bufSrc = GetOrAllocateBuffer(backend, updates.GetDataArray());
-            backend.ScatterAdd(bufSrc.Buffer, bufIdx, bufDst.Buffer, updates.Length, destination.Length);
-            float[] resultFloat = backend.DownloadBuffer(bufDst.Buffer);
-            var result = DirectGpuEngine.FromFloatArray<T>(resultFloat);
-            var output = new Tensor<T>(result, destination.Shape._dims);
-            Autodiff.DifferentiableOps.RecordUnary("ScatterAdd", output, updates,
-                Autodiff.BackwardFunctions<T>.ScatterAddBackward, new object[] { indices, axis, destination.Shape._dims });
-            return output;
-        }
-        catch (Exception)
-        {
-            return base.TensorScatterAdd(destination, indices, updates, axis);
-        }
-    }
-
+    // TensorScatterAdd<T>: GPU override removed. The CUDA scatter_add kernel
+    // itself uses atomicAdd and is correct in isolation, but the engine-level
+    // 1D-into-1D wiring diverged from the CPU reference (GpuCpuAutoDifferentialTests
+    // observed max_abs_err ≈ 1.74 vs CPU on shape [257]). Falling back to the
+    // CpuEngine base implementation restores GPU/CPU parity for the autodiff
+    // harness; a properly verified GPU TensorScatterAdd path can be re-added
+    // when it can be A/B'd against CPU across the full shape grid. Inheriting
+    // from base also preserves autodiff recording (CpuEngine handles its own
+    // RecordUnary).
     public override Tensor<T> Embedding<T>(Tensor<int> indices, Tensor<T> embeddingTable)
     {
         if (!TryGetBackend(out var backend))

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/DeterministicModeTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/DeterministicModeTests.cs
@@ -9,6 +9,15 @@ using AiDotNet.Tensors.Helpers;
 
 namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
 
+// Serialized with the other BlasManaged global-state mutators (ScalarKernelTests,
+// PrePackSpeedupTest, StatsCounterTests, …). These tests toggle the process-wide
+// BlasProvider.IsDeterministicMode flag, which switches the GEMM reduction/packing
+// path. Without serialization this class runs in the parallel pool and can flip the
+// flag mid-GEMM in a concurrent pre-pack / scalar-kernel test, drifting that test's
+// packed output away from its live-pack baseline (the intermittent CI "drift"
+// failures in PrePackedB_Output_BitMatches_LivePack and the cached-packed-buffer
+// tests) — and SetDeterministicMode_Toggles can itself observe a concurrent flip.
+[Collection("BlasManaged-Stats-Serial")]
 public class DeterministicModeTests
 {
     [Fact]


### PR DESCRIPTION
## Summary

Two pre-existing GPU-backend correctness failures, only visible on GPU-equipped machines, surfaced by the #475 MLP-perf branch's full-suite run. Both root-caused, fixed, and verified on this machine's CUDA backend (NVIDIA GPU).

| Test | Symptom | Root cause | Fix |
|---|---|---|---|
| `FusedConv2D_Float_ReLU_PreservesNaNFromBias` | NaN bias-add produces NaN feature map, then ReLU returns **0** instead of NaN | CUDA `relu` kernel uses `x > 0 ? x : 0`; `NaN > 0` is false → 0. (`<double>` path takes `ShouldFallbackForPrecision` to CPU and is unaffected.) | Add `__device__ relu_nan_safe(float)` using bitwise NaN detect via `__float_as_uint` (survives `--use_fast_math`); apply in `relu` + `relu_vec4`. |
| `GpuKernel_Matches_Cpu(TensorScatterAdd)` on shape `[257]` | GPU vs CPU `max_abs_err ≈ 1.74` vs tolerance `0.01` | `DirectGpuTensorEngine.TensorScatterAdd<T>` 1D wiring diverges from CPU (kernel itself uses `atomicAdd` correctly; the engine path is wrong). | Remove the GPU override; inherit the correct `CpuEngine` impl. A verified GPU scatter_add can be re-added when A/B'd against CPU across the full shape grid. |

## Latent fix in the OpenCL backend (consistency / future-proofing)

Same NaN-zeroing bug exists in the OpenCL `relu` kernel — the global `-cl-finite-math-only` build flag lets the compiler assume no NaN exists and elide any `isnan()`-based check. Applies the same bitwise NaN detect (vector + scalar tail) and splits the activation program onto a new `OpenClBuildOptions.SafeMathFlags` (`-cl-mad-enable -cl-no-signed-zeros`); GEMM keeps the aggressive `OptimizationFlags`. OpenCL path not exercised on this machine, but the fix is the right one.

## Verification

On the live CUDA backend (NVIDIA):

- Targeted GPU/activation/scatter sweep: **412/412 pass**, 0 fail (+62 skipped pre-existing).
- `FusedConv2D_*_ReLU_PreservesNaNFromBias`: float now passes (NaN propagates through channel 5); double already passed.
- `GpuKernel_Matches_Cpu` (entire theory): all 61 sub-cases pass on `origin/main` base.

## Why this is a separate PR (not bundled with #475)

These are **pre-existing** GPU-backend correctness bugs, unrelated to the #475 MLP small-GEMM perf work. They only manifest on GPU machines (likely green in CPU-only CI), surfaced when verifying perf/475's full-suite cleanliness. Keeps the perf branch focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)