### PR TITLE
fix: record tape backward for GetSliceAlongDimension

### DIFF
--- a/src/AiDotNet.Tensors/LinearAlgebra/Tensor.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/Tensor.cs
@@ -1163,18 +1163,12 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
         ThrowIfSparse();
         if (Rank == 0)
             throw new InvalidOperationException("Cannot slice a scalar (rank-0) tensor.");
-        if (index < 0 || index >= _shape[0])
-            throw new ArgumentOutOfRangeException(nameof(index));
 
-        // O(1) view: adjust offset by index * stride[0], drop first dimension.
-        int newRank = Rank - 1;
-        var newShape = new int[newRank];
-        var newStrides = new int[newRank];
-        Array.Copy(_shape, 1, newShape, 0, newRank);
-        Array.Copy(_strides, 1, newStrides, 0, newRank);
-        int newOffset = _storageOffset + index * _strides[0];
-
-        return new Tensor<T>(_data, newShape, newStrides, newOffset, _storage);
+        // Slicing axis 0 is identical to GetSliceAlongDimension(index, 0). Delegate so
+        // both public entry points (Slice/GetSlice and GetSliceAlongDimension) share the
+        // same autodiff-aware path; otherwise Slice/GetSlice would silently drop gradients
+        // under an active GradientTape while GetSliceAlongDimension records them.
+        return GetSliceAlongDimension(index, 0);
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/LinearAlgebra/Tensor.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/Tensor.cs
@@ -3029,7 +3029,29 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
         }
 
         int newOffset = _storageOffset + index * _strides[dimension];
-        return new Tensor<T>(_data, newShape, newStrides, newOffset, _storage);
+        var result = new Tensor<T>(_data, newShape, newStrides, newOffset, _storage);
+
+        // Propagate the gradient chain: if a GradientTape is active, set GradFn on
+        // the result so gradients flow through the slice during backward. Without
+        // this, GetSliceAlongDimension was a raw storage-sharing view with no
+        // recorded backward — any layer that slices a tape tensor per-timestep
+        // (recurrent / sequence layers) leaked wrong input gradients via aliasing.
+        // The view is preserved (zero-copy) for the inference path where no tape
+        // is active; only training pays the node record. Mirrors Reshape above.
+        if (Engines.Autodiff.GradientTape<T>.Current != null)
+        {
+            var sliceNode = Engines.Autodiff.GradNodePool<T>.Rent();
+            sliceNode.OwningTape = Engines.Autodiff.GradientTape<T>.Current;
+            sliceNode.Backward = Engines.Autodiff.BackwardFunctions<T>.SliceAxisBackward;
+            sliceNode.Output = result;
+            sliceNode.Input0 = this;
+            sliceNode.InputCount = 1;
+            // SliceAxisBackward reads SavedState as { axis, index }.
+            sliceNode.SavedState = new object[] { dimension, index };
+            result.GradFn = sliceNode;
+        }
+
+        return result;
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tensors.Tests/Engines/SliceAccumulateTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/SliceAccumulateTests.cs
@@ -1,4 +1,6 @@
+using System;
 using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
 using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
 
@@ -82,5 +84,64 @@ public class SliceAccumulateTests
                 Assert.Equal(expected, result[new[] { b, d }], 1e-10);
             }
         }
+    }
+
+    [Fact]
+    public void GetSliceAlongDimension_UnderActiveTape_ScattersGradientToSlicedPositionOnly()
+    {
+        // The fix records a SliceAxisBackward node when a GradientTape is active so
+        // gradients flow back to ONLY the sliced position (zeros elsewhere) instead of
+        // leaking through storage aliasing. loss = sum(input[:, sliceIndex, :]) =>
+        // d loss / d input = 1 at seq==sliceIndex, 0 everywhere else.
+        int batch = 2, seqLen = 3, dim = 4;
+        var input = new Tensor<double>(new[] { batch, seqLen, dim });
+        var rng = new Random(7);
+        for (int i = 0; i < input.Length; i++) input[i] = rng.NextDouble() + 0.1;
+
+        const int sliceIndex = 1;
+        using var tape = new GradientTape<double>();
+        var slice = input.GetSliceAlongDimension(sliceIndex, 1); // [batch, dim] view at seq==1
+        var loss = _engine.ReduceSum(slice, null);
+        var grads = tape.ComputeGradients(loss, new[] { input });
+
+        Assert.True(grads.ContainsKey(input), "Gradient was not recorded for the sliced input (taped path missing).");
+        var g = grads[input];
+        Assert.Equal(input.Shape.ToArray(), g.Shape.ToArray());
+
+        for (int b = 0; b < batch; b++)
+            for (int t = 0; t < seqLen; t++)
+                for (int d = 0; d < dim; d++)
+                {
+                    double expected = (t == sliceIndex) ? 1.0 : 0.0;
+                    Assert.Equal(expected, g[new[] { b, t, d }], 1e-10);
+                }
+    }
+
+    [Fact]
+    public void Slice_UnderActiveTape_RecordsBackwardLikeGetSliceAlongDimension()
+    {
+        // Slice(index) (axis 0) and GetSlice(index) must follow the same taped path as
+        // GetSliceAlongDimension(index, 0); otherwise equivalent public APIs behave
+        // differently under autodiff. loss = sum(input[sliceIndex]) =>
+        // d loss / d input = 1 at row==sliceIndex, 0 elsewhere.
+        int batch = 3, dim = 4;
+        var input = new Tensor<double>(new[] { batch, dim });
+        var rng = new Random(11);
+        for (int i = 0; i < input.Length; i++) input[i] = rng.NextDouble() + 0.1;
+
+        const int sliceIndex = 2;
+        using var tape = new GradientTape<double>();
+        var slice = input.Slice(sliceIndex); // axis-0 slice must route through the taped path
+        var loss = _engine.ReduceSum(slice, null);
+        var grads = tape.ComputeGradients(loss, new[] { input });
+
+        Assert.True(grads.ContainsKey(input), "Slice(int) dropped the gradient — it is not routing through the taped path.");
+        var g = grads[input];
+        for (int b = 0; b < batch; b++)
+            for (int d = 0; d < dim; d++)
+            {
+                double expected = (b == sliceIndex) ? 1.0 : 0.0;
+                Assert.Equal(expected, g[new[] { b, d }], 1e-10);
+            }
     }
 }


### PR DESCRIPTION
## Problem

`Tensor<T>.GetSliceAlongDimension(index, dimension)` returns a raw, storage-sharing **view with no recorded autodiff backward**. Any layer that slices a tape tensor per-timestep (recurrent / sequence / attention layers) then leaks an **incorrect gradient** back to the sliced parent via storage aliasing. The most visible symptom is corrupted residual paths: the wrong input gradient flows into every upstream trainable parameter, so the analytical (tape) gradient disagrees with the finite-difference gradient.

This was root-caused while fixing `RWKV7Block`'s tape training in the downstream `AiDotNet` repo — its two-sublayer residual structure made the leak fail a numerical-gradient check on every time-mix parameter.

## Fix

Mirror the existing instance `Reshape` pattern: when a `GradientTape` is active, attach a `GradFn` (`SliceAxisBackward`) so the slice's gradient scatters back into the correct sequence position. The **zero-copy view is preserved for the inference path** where no tape is active — only training records the node.

```csharp
if (GradientTape<T>.Current != null)
{
    var sliceNode = GradNodePool<T>.Rent();
    sliceNode.OwningTape = GradientTape<T>.Current;
    sliceNode.Backward = BackwardFunctions<T>.SliceAxisBackward;
    sliceNode.Output = result;
    sliceNode.Input0 = this;
    sliceNode.InputCount = 1;
    sliceNode.SavedState = new object[] { dimension, index }; // { axis, index }
    result.GradFn = sliceNode;
}
```

## Verification

- **65 slice + 801 autodiff/gradient-tape tests pass** in this repo (no regressions).
- In the downstream `AiDotNet` consumer (built against a local pack of this branch): **520 SSM/recurrent/attention layer tape tests pass** across the 17 affected layers. `RWKV7Block`'s numerical-gradient check goes from failing to exact (all 24 parameters match finite differences).

🤖 Generated with [Claude Code](https://claude.com/claude-code)