### PR TITLE
test: consolidate global-determinism mutators into one serial collection

### DIFF
--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/BlasManagedCollections.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/BlasManagedCollections.cs
@@ -13,9 +13,19 @@ namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
 // what their authors intended.
 
 /// <summary>
-/// Tests that mutate process-wide global state (CpuParallelSettings,
-/// BlasProvider.IsDeterministicMode, BlasManaged stats counters) must run
-/// serially to avoid cross-class state contamination.
+/// Single serial collection for every test that mutates process-wide global state
+/// affecting the GEMM path — CpuParallelSettings, the OpenBLAS thread count,
+/// BlasManaged stats/JIT caches, and especially BlasProvider.IsDeterministicMode
+/// (which AiDotNetEngine.SetDeterministicMode also flips, and which switches the GEMM
+/// reduction/packing path). These were previously split across three separate serial
+/// collections (BlasGlobalState, AiDotNetEngineGlobalState, this one); cross-collection
+/// DisableParallelization did NOT reliably isolate them on CI, so a flip of the
+/// determinism flag in one collection drifted a concurrent pre-pack/GEMM test's output
+/// away from its baseline (the intermittent "drift" failures in
+/// PrePackedB_Output_BitMatches_LivePack, the cached-packed-buffer tests, and
+/// SetDeterministicMode_Toggles). Membership in ONE collection guarantees sequential
+/// execution (xUnit's core contract, independent of DisableParallelization semantics),
+/// which is what actually fixes the flakiness.
 /// </summary>
 [CollectionDefinition("BlasManaged-Stats-Serial", DisableParallelization = true)]
 public sealed class BlasManagedStatsSerialCollection { }

--- a/tests/AiDotNet.Tensors.Tests/Engines/DeterministicByDefaultTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DeterministicByDefaultTests.cs
@@ -19,12 +19,12 @@ namespace AiDotNet.Tensors.Tests.Engines;
 ///   3. <see cref="CompiledModelCache{T}"/> invalidates plans compiled under the
 ///      opposite determinism setting.
 ///
-/// Shares xUnit collection <c>BlasGlobalState</c> with the existing
-/// <see cref="DeterministicModeTests"/> so tests do not run in parallel —
-/// they mutate a process-wide static flag that would race under xUnit
-/// parallelism.
+/// Shares xUnit collection <c>BlasManaged-Stats-Serial</c> with every other
+/// process-global-determinism / GEMM-path mutator (DeterministicModeTests,
+/// PrePackSpeedupTest, ScalarKernelTests, …) so tests do not run in parallel —
+/// they mutate a process-wide static flag that would race under xUnit parallelism.
 /// </summary>
-[Collection("BlasGlobalState")]
+[Collection("BlasManaged-Stats-Serial")]
 public class DeterministicByDefaultTests
 {
     // ── Acceptance criterion #1 ──────────────────────────────────────────────

--- a/tests/AiDotNet.Tensors.Tests/Engines/DeterministicModeTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DeterministicModeTests.cs
@@ -5,27 +5,16 @@ using Xunit;
 namespace AiDotNet.Tensors.Tests.Engines;
 
 /// <summary>
-/// Collection fixture that forces DeterministicModeTests to run sequentially and
-/// in isolation from any other test classes that share this collection. The tests
-/// mutate a process-wide static flag (AiDotNetEngine.DeterministicMode) which
-/// would otherwise race with concurrent matmul/BLAS tests under xUnit's default
-/// parallel execution. Putting all BLAS-state-mutating test classes in this
-/// collection serializes their execution with respect to each other and guarantees
-/// the flag is stable for the duration of each test method.
-/// </summary>
-[CollectionDefinition("BlasGlobalState", DisableParallelization = true)]
-public sealed class BlasGlobalStateCollection { }
-
-/// <summary>
 /// Tests for AiDotNetEngine.SetDeterministicMode — verifies the public API surface
 /// and that enabling deterministic mode produces bit-exact reproducible results for
 /// large matmuls (the hot path that uses MKL.NET in default mode).
 ///
-/// Marked with [Collection("BlasGlobalState")] so these tests run serialized —
-/// they toggle a process-wide static flag that would race with concurrent BLAS
-/// calls from other parallel test classes.
+/// Marked with [Collection("BlasManaged-Stats-Serial")] so these tests run serialized
+/// with every other process-global-determinism / GEMM-path mutator — they toggle a
+/// process-wide static flag (AiDotNetEngine.SetDeterministicMode -> BlasProvider) that
+/// would otherwise race with concurrent BLAS calls from other parallel test classes.
 /// </summary>
-[Collection("BlasGlobalState")]
+[Collection("BlasManaged-Stats-Serial")]
 public class DeterministicModeTests
 {
     [Fact]

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuDeterminismRegressionTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuDeterminismRegressionTests.cs
@@ -11,16 +11,6 @@ using Xunit;
 namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
 
 /// <summary>
-/// xUnit collection grouping all tests that mutate the process-wide
-/// <see cref="AiDotNetEngine.Current"/> and / or
-/// <see cref="AiDotNetEngine.SetDeterministicMode(bool)"/> static state. Tests
-/// in this collection are serialized, so a parallel test cannot observe a
-/// half-applied engine swap.
-/// </summary>
-[CollectionDefinition("AiDotNetEngineGlobalState")]
-public class AiDotNetEngineGlobalStateCollection { }
-
-/// <summary>
 /// Closed-loop regression test for issue #382. Verifies that when the global
 /// <see cref="AiDotNetEngine.SetDeterministicMode(bool)"/> flag is set, the GPU
 /// embedding gradient — the most directly visible site of the original bug —
@@ -35,11 +25,15 @@ public class AiDotNetEngineGlobalStateCollection { }
 /// kernel's nondeterminism is maximally exercised.
 ///
 /// Mutates the process-wide <see cref="AiDotNetEngine.Current"/> and the
-/// <see cref="AiDotNetEngine.SetDeterministicMode(bool)"/> static flag, so the
-/// test joins the dedicated <c>AiDotNetEngineGlobalState</c> collection to
-/// serialize against any other test that touches those statics.
+/// <see cref="AiDotNetEngine.SetDeterministicMode(bool)"/> static flag — which
+/// propagates to <c>BlasProvider.IsDeterministicMode</c> and switches the GEMM
+/// reduction/packing path — so the test joins the unified
+/// <c>BlasManaged-Stats-Serial</c> collection to serialize against every other test
+/// that touches those statics (the pre-pack / scalar-kernel GEMM tests, the CPU
+/// DeterministicMode tests, …). This is the fix for the cross-test "drift" flakiness
+/// those GEMM tests intermittently hit on CI.
 /// </summary>
-[Collection("AiDotNetEngineGlobalState")]
+[Collection("BlasManaged-Stats-Serial")]
 public class GpuDeterminismRegressionTests
 {
     private readonly bool _isDirectGpuAvailable;

--- a/tests/AiDotNet.Tensors.Tests/Engines/FlashAttentionDoubleHangIssue411Test.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/FlashAttentionDoubleHangIssue411Test.cs
@@ -25,16 +25,16 @@ namespace AiDotNet.Tensors.Tests.Engines;
 /// removes the OpenBLAS scope or re-introduces the oversubscription path, this test will
 /// time out cleanly instead of letting CI hang.</para>
 ///
-/// <para>CI-follow-up: marked with <c>[Collection("BlasGlobalState")]</c> so the test is
-/// serialised with other tests that mutate the global OpenBLAS thread count
-/// (DeterministicMode/DeterministicByDefault). Without this, an unrelated test running in
-/// parallel could set OpenBLAS threads to a high value between this test's
-/// <c>ScopeOpenBlasThreads(1)</c> acquisition and the parallel-for entry, defeating the
-/// scope and re-introducing the oversubscription cliff. Originally not gated — fixed after
-/// PR #426 hit the 30s timeout on Linux CI even though the production fix from #410 was
-/// merged.</para>
+/// <para>CI-follow-up: marked with <c>[Collection("BlasManaged-Stats-Serial")]</c> so the
+/// test is serialised with every other tests that mutate global BLAS state — the
+/// determinism flag and the OpenBLAS thread count (DeterministicMode/DeterministicByDefault,
+/// the pre-pack/GEMM tests, …). Without this, an unrelated test running in parallel could
+/// set OpenBLAS threads to a high value between this test's <c>ScopeOpenBlasThreads(1)</c>
+/// acquisition and the parallel-for entry, defeating the scope and re-introducing the
+/// oversubscription cliff. Originally not gated — fixed after PR #426 hit the 30s timeout on
+/// Linux CI even though the production fix from #410 was merged.</para>
 /// </summary>
-[Collection("BlasGlobalState")]
+[Collection("BlasManaged-Stats-Serial")]
 public class FlashAttentionDoubleHangIssue411Test
 {
     private readonly ITestOutputHelper _output;


### PR DESCRIPTION
## Problem

CI (and `main` itself) intermittently fails a cluster of `BlasManaged` tests together with packed-output **"drift"**:

- `PrePackSpeedupTest.PrePackedB_Output_BitMatches_LivePack`
- `ScalarKernelTests.Gemm_WithoutMarkDirty_UsesCachedPackedBuffer`
- `ScalarKernelTests.Gemm_WithPackedAHandle_MatchesUnpackedGemm`
- `DeterministicModeTests.BlasProvider_SetDeterministicMode_Toggles`

They pass locally and were already partly serialized, yet `main`'s latest run still failed (run on a commit that *already had* the per-class `[Collection]` fix from #375). So merging main does not reliably fix it.

## Root cause

Tests that flip the process-wide `BlasProvider.IsDeterministicMode` flag — which `AiDotNetEngine.SetDeterministicMode` also sets (`AiDotNetEngine.cs:335`), and which **switches the GEMM reduction/packing path** — were split across **three** serial collections: `BlasGlobalState`, `AiDotNetEngineGlobalState`, and `BlasManaged-Stats-Serial`. Cross-collection `DisableParallelization` did **not** reliably isolate them on the 4-vCPU coverage runner, so a flag flip in one collection drifted a concurrent pre-pack/GEMM test in another. `AiDotNetEngineGlobalState` also lacked `DisableParallelization` entirely.

## Fix

Fold all four determinism-mutating classes (`DeterministicModeTests`, `DeterministicByDefaultTests`, `FlashAttentionDoubleHangIssue411Test`, `GpuDeterminismRegressionTests`) into the single `BlasManaged-Stats-Serial` collection that already owns the pre-pack/GEMM tests. **Same-collection tests are always sequential** — xUnit's core contract, independent of cross-collection `DisableParallelization` semantics — which is what actually removes the contamination. Removed the now-empty `BlasGlobalState` / `AiDotNetEngineGlobalState` definitions.

No assertions or thresholds changed — pure test isolation.

## Verification

- Builds clean (net10.0).
- The 40 consolidated determinism + pre-pack + scalar-kernel tests pass when run together in the unified collection.

This is the canonical fix; it should be merged into the in-flight PRs (#473/#474/#483/#485/#486/#487/#488) by merging `main` once landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)