### PR TITLE
DIAGNOSTIC (do not merge): capture #486 pre-pack drift contamination

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,25 @@ jobs:
         dotnet build src/AiDotNet.Tensors/AiDotNet.Tensors.csproj --configuration Release --no-restore --framework net471 -p:TelemetryUrl="${{ secrets.AIDOTNET_TELEMETRY_URL }}" -p:TelemetryKey="${{ secrets.AIDOTNET_TELEMETRY_KEY }}"
         dotnet build tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --configuration Release --no-restore --framework net471
 
+    - name: No-coverage drift probe (DIAGNOSTIC — is coverlet the trigger?)
+      continue-on-error: true
+      run: |
+        # Run the SAME full concurrent suite WITHOUT coverage instrumentation, 5x.
+        # If the pre-pack bit-match / scalar-kernel tests stay green here while the
+        # covered run below drifts (~50%), coverlet is the confirmed trigger.
+        drift=0
+        for i in 1 2 3 4 5; do
+          echo "===== no-coverage run $i ====="
+          if dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --configuration Release --no-build --framework net10.0 \
+               --filter "Category!=Benchmark&Category!=Performance" 2>&1 \
+             | grep -iE "pre-pack output drift|PrePackedB_Output.*FAIL|Gemm_WithoutMarkDirty.*FAIL|Gemm_WithPackedAHandle.*FAIL|Failed:[[:space:]]*[1-9]"; then
+            echo "RUN $i: DRIFT/FAILURE detected (no coverage)"; drift=$((drift+1))
+          else
+            echo "RUN $i: clean"
+          fi
+        done
+        echo "===== NO-COVERAGE DRIFT COUNT: $drift / 5 ====="
+
     - name: Test with Coverage
       run: |
         dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --configuration Release --no-build --verbosity normal --framework net10.0 \

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/PrePackSpeedupTest.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/PrePackSpeedupTest.cs
@@ -162,9 +162,9 @@ public class PrePackSpeedupTest
                    $"arenaActive={ArenaIntegration.IsArenaActive} blasDeterministic={BlasProvider.IsDeterministicMode} " +
                    $"mklVerified={BlasProvider.IsMklVerified} jitKernels={JittedKernelCache.Count} thread={Environment.CurrentManagedThreadId} " +
                    // CI-bisect: which shared global toggle is poisoned by a concurrent test?
-                   $"| EnableSimd={Helpers.CpuParallelSettings.EnableSimd} MaxDOP={Helpers.CpuParallelSettings.MaxDegreeOfParallelism} " +
-                   $"DetReductions={Helpers.CpuParallelSettings.DeterministicReductions} Avx2Gather={Helpers.CpuParallelSettings.EnableAvx2Gather} " +
-                   $"ParThreshold={Helpers.CpuParallelSettings.ParallelThreshold} inParRegion={Helpers.CpuParallelSettings.IsInParallelRegion}";
+                   $"| EnableSimd={AiDotNet.Tensors.Helpers.CpuParallelSettings.EnableSimd} MaxDOP={AiDotNet.Tensors.Helpers.CpuParallelSettings.MaxDegreeOfParallelism} " +
+                   $"DetReductions={AiDotNet.Tensors.Helpers.CpuParallelSettings.DeterministicReductions} Avx2Gather={AiDotNet.Tensors.Helpers.CpuParallelSettings.EnableAvx2Gather} " +
+                   $"ParThreshold={AiDotNet.Tensors.Helpers.CpuParallelSettings.ParallelThreshold} inParRegion={AiDotNet.Tensors.Helpers.CpuParallelSettings.IsInParallelRegion}";
             _output.WriteLine($"[DRIFT DIAG] M={M} N={N} K={K} maxDelta={maxDelta:G6} {diag}");
         }
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/PrePackSpeedupTest.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/PrePackSpeedupTest.cs
@@ -159,8 +159,12 @@ public class PrePackSpeedupTest
 
             diag = $"baseVsNaive={baseVsNaive:G6} prepackVsNaive={prepackVsNaive:G6} base2VsNaive={base2VsNaive:G6} " +
                    $"(idx {maxIdx} r{maxIdx / N} c{maxIdx % N}: base={cBaseline[maxIdx]:G6} prepack={cPrePack[maxIdx]:G6} naive={cNaive[maxIdx]:G6}) " +
-                   $"arenaActive={ArenaIntegration.IsArenaActive} deterministic={BlasProvider.IsDeterministicMode} " +
-                   $"mklVerified={BlasProvider.IsMklVerified} jitKernels={JittedKernelCache.Count} thread={Environment.CurrentManagedThreadId}";
+                   $"arenaActive={ArenaIntegration.IsArenaActive} blasDeterministic={BlasProvider.IsDeterministicMode} " +
+                   $"mklVerified={BlasProvider.IsMklVerified} jitKernels={JittedKernelCache.Count} thread={Environment.CurrentManagedThreadId} " +
+                   // CI-bisect: which shared global toggle is poisoned by a concurrent test?
+                   $"| EnableSimd={Helpers.CpuParallelSettings.EnableSimd} MaxDOP={Helpers.CpuParallelSettings.MaxDegreeOfParallelism} " +
+                   $"DetReductions={Helpers.CpuParallelSettings.DeterministicReductions} Avx2Gather={Helpers.CpuParallelSettings.EnableAvx2Gather} " +
+                   $"ParThreshold={Helpers.CpuParallelSettings.ParallelThreshold} inParRegion={Helpers.CpuParallelSettings.IsInParallelRegion}";
             _output.WriteLine($"[DRIFT DIAG] M={M} N={N} K={K} maxDelta={maxDelta:G6} {diag}");
         }
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/PrePackSpeedupTest.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/PrePackSpeedupTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using AiDotNet.Tensors.Engines.BlasManaged;
+using AiDotNet.Tensors.Helpers;
 using Xunit;
 using Xunit.Abstractions;
 using BlasManagedLib = AiDotNet.Tensors.Engines.BlasManaged.BlasManaged;
@@ -121,10 +122,50 @@ public class PrePackSpeedupTest
         finally { handle.Dispose(); }
 
         double maxDelta = 0;
+        int maxIdx = 0;
         for (int i = 0; i < cBaseline.Length; i++)
-            maxDelta = Math.Max(maxDelta, Math.Abs((double)cBaseline[i] - cPrePack[i]));
+        {
+            double d = Math.Abs((double)cBaseline[i] - cPrePack[i]);
+            if (d > maxDelta) { maxDelta = d; maxIdx = i; }
+        }
+
+        // #486 flaky-drift hunt: on drift, capture WHICH path is wrong (vs a naive
+        // reference — M is small so this is cheap) and whether a re-run of the
+        // live-pack baseline is now correct (transient cross-test/-thread
+        // contamination vs a deterministic consume-path bug), plus the suspect
+        // process/thread-global state. This message is surfaced in the CI failure log.
+        string diag = "consume path is incorrect";
+        if (maxDelta >= 1e-3)
+        {
+            var cNaive = new float[M * N];
+            for (int mi = 0; mi < M; mi++)
+                for (int ni = 0; ni < N; ni++)
+                {
+                    double acc = 0;
+                    for (int kk = 0; kk < K; kk++) acc += (double)a[mi * K + kk] * b[kk * N + ni];
+                    cNaive[mi * N + ni] = (float)acc;
+                }
+            double baseVsNaive = 0, prepackVsNaive = 0;
+            for (int i = 0; i < cNaive.Length; i++)
+            {
+                baseVsNaive = Math.Max(baseVsNaive, Math.Abs((double)cBaseline[i] - cNaive[i]));
+                prepackVsNaive = Math.Max(prepackVsNaive, Math.Abs((double)cPrePack[i] - cNaive[i]));
+            }
+            var cBaseline2 = new float[M * N];
+            BlasManagedLib.Gemm<float>(a, K, false, b, N, false, cBaseline2, N, M, N, K);
+            double base2VsNaive = 0;
+            for (int i = 0; i < cNaive.Length; i++)
+                base2VsNaive = Math.Max(base2VsNaive, Math.Abs((double)cBaseline2[i] - cNaive[i]));
+
+            diag = $"baseVsNaive={baseVsNaive:G6} prepackVsNaive={prepackVsNaive:G6} base2VsNaive={base2VsNaive:G6} " +
+                   $"(idx {maxIdx} r{maxIdx / N} c{maxIdx % N}: base={cBaseline[maxIdx]:G6} prepack={cPrePack[maxIdx]:G6} naive={cNaive[maxIdx]:G6}) " +
+                   $"arenaActive={ArenaIntegration.IsArenaActive} deterministic={BlasProvider.IsDeterministicMode} " +
+                   $"mklVerified={BlasProvider.IsMklVerified} jitKernels={JittedKernelCache.Count} thread={Environment.CurrentManagedThreadId}";
+            _output.WriteLine($"[DRIFT DIAG] M={M} N={N} K={K} maxDelta={maxDelta:G6} {diag}");
+        }
+
         Assert.True(maxDelta < 1e-3,
-            $"M={M} N={N} K={K}: pre-pack output drift {maxDelta:G6} exceeds 1e-3 — consume path is incorrect");
+            $"M={M} N={N} K={K}: pre-pack output drift {maxDelta:G6} exceeds 1e-3 — {diag}");
     }
 
     private void RunSpeedupGate(int M, int N, int K, int iterations, int warmup, double gateMin, bool enforcePerfGate = true)


### PR DESCRIPTION
**Temporary diagnostic PR — do NOT merge. Safe to close once we capture a drift.**

The build workflow only runs on PRs to main, so this draft PR exists solely to run CI and capture the intermittent `PrePackedB_Output_BitMatches_LivePack` drift with the new failure instrumentation.

On drift, the failure message now reports:
- `baseVsNaive` / `prepackVsNaive` — which GEMM path diverges from a naive ground-truth reference
- `base2VsNaive` — whether a re-run of the live-pack baseline is clean (transient cross-test contamination vs a deterministic consume-path bug)
- suspect global state at the failure instant: arena active, determinism flag, MKL-verified, JIT kernel count, thread id

Assertion threshold is unchanged (1e-3). Once the smoking gun is captured, this branch's instrumentation (or the resulting fix) lands properly and this draft is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)