### PR TITLE
fix: serialize StreamingWorkerPool dispatch — concurrent GEMMs corrupted each other

### DIFF
--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Pool/StreamingWorkerPool.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Pool/StreamingWorkerPool.cs
@@ -34,6 +34,17 @@ internal static class StreamingWorkerPool
     private static int _initialized; // 0 = not started; 1 = workers spawned
     private static readonly object _initLock = new();
 
+    // The pool has ONE shared set of worker slots (_slots) plus _remaining /
+    // _firstException, so only a single dispatch can drive it at a time. The
+    // [ThreadStatic] _isExecuting flag only guards NESTED (same-thread) re-entry;
+    // it does NOT stop a DIFFERENT thread from calling Dispatch concurrently. Two
+    // concurrent GEMMs would otherwise both overwrite _slots and _remaining, so the
+    // workers run a mix of the two actions and write into the wrong output buffers
+    // (observed as large nondeterministic GEMM result drift under a parallel test
+    // suite). Dispatch acquires this lock; a concurrent caller that can't acquire it
+    // runs its chunks serially on itself instead of racing the shared state.
+    private static readonly object _dispatchLock = new();
+
     private static void EnsureInitialized()
     {
         if (Volatile.Read(ref _initialized) == 1) return;
@@ -151,7 +162,15 @@ internal static class StreamingWorkerPool
     public static void Dispatch(int numChunks, Action<int> action)
     {
         if (numChunks <= 0) return;
-        if (numChunks == 1 || _isExecuting)
+        // Run serially on the caller when: a single chunk; this thread is already
+        // driving a dispatch (nested — avoids ThreadPool starvation); or ANOTHER
+        // thread is currently driving the shared worker slots. The last case is the
+        // concurrency fix: the pool has one shared _slots set, so a second concurrent
+        // dispatch must fall back to serial rather than overwrite the in-flight
+        // dispatch's slots (which corrupted both callers' GEMM results).
+        // Monitor.TryEnter is non-blocking, so concurrent GEMMs never deadlock or
+        // stall — at most one runs parallel while the rest run serial.
+        if (numChunks == 1 || _isExecuting || !Monitor.TryEnter(_dispatchLock))
         {
             for (int c = 0; c < numChunks; c++) action(c);
             return;
@@ -214,6 +233,10 @@ internal static class StreamingWorkerPool
             var pooledEx = _firstException ?? callerException;
             if (pooledEx is not null) throw pooledEx;
         }
-        finally { _isExecuting = false; }
+        finally
+        {
+            _isExecuting = false;
+            Monitor.Exit(_dispatchLock);
+        }
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/ConcurrentLiveGemmReproTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/ConcurrentLiveGemmReproTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using Xunit;
+using BlasManagedLib = AiDotNet.Tensors.Engines.BlasManaged.BlasManaged;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+// TEMP: confirm whether concurrent LIVE (no-handle, parallel pack-B) GEMMs with
+// distinct data corrupt each other. The full-suite repro showed ParallelPackBTest
+// (serial-vs-parallel Gemm) drifting 27.2 under the concurrent suite, while a
+// pre-packed-B stress stayed clean — implicating the live parallel pack-B path.
+public class ConcurrentLiveGemmReproTests
+{
+    [Fact]
+    public void ConcurrentLiveGemms_DistinctData_StayCorrect()
+    {
+        int M = 512, N = 1024, K = 768;
+        int threads = Math.Max(8, Environment.ProcessorCount * 2);
+        var drifts = new ConcurrentBag<string>();
+
+        Parallel.For(0, threads, tid =>
+        {
+            var rng = new Random(100 + tid);
+            var a = new float[M * K];
+            var b = new float[K * N];
+            for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+            for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+
+            // Per-thread serial reference (NumThreads=-1 forces single-thread GEMM).
+            var cRef = new float[M * N];
+            BlasManagedLib.Gemm<float>(a, K, false, b, N, false, cRef, N, M, N, K,
+                new AiDotNet.Tensors.Engines.BlasManaged.BlasOptions<float> { NumThreads = -1 });
+
+            for (int it = 0; it < 40; it++)
+            {
+                var c = new float[M * N];
+                BlasManagedLib.Gemm<float>(a, K, false, b, N, false, c, N, M, N, K); // live, parallel
+                double maxDelta = 0;
+                for (int i = 0; i < cRef.Length; i++)
+                    maxDelta = Math.Max(maxDelta, Math.Abs(cRef[i] - c[i]));
+                if (maxDelta > 1e-2) { drifts.Add($"tid {tid} it {it}: drift {maxDelta:G6}"); break; }
+            }
+        });
+
+        Assert.True(drifts.IsEmpty,
+            $"{drifts.Count} concurrent live GEMMs drifted from their own serial reference. " +
+            $"First: {(drifts.IsEmpty ? "" : System.Linq.Enumerable.First(drifts))}");
+    }
+}


### PR DESCRIPTION
## Root cause (real production concurrency bug)

`StreamingWorkerPool` (used by the Streaming GEMM strategy) drives a **single shared static** set of worker slots (`_slots`) plus `_remaining` / `_firstException`. `Dispatch` was guarded only by a `[ThreadStatic] _isExecuting` flag — which prevents **nested** (same-thread) re-entry but does **nothing** against a *different* thread calling `Dispatch` concurrently.

Two concurrent `BlasManaged.Gemm` calls therefore both write their action + chunk ranges into the **same** `_slots` and overwrite `_remaining`, so the shared workers run a **mix of the two dispatches** and write into the wrong output buffers → large, nondeterministic GEMM result drift (~27–60 abs).

**Impact:** any concurrent GEMM usage corrupts results — parallel inference, concurrent layers, or (as observed) a parallel test suite. This was the root cause of the intermittent CI **"pre-pack output drift"** failures (`PrePackedB_Output_BitMatches_LivePack`, the `ScalarKernel` cached-buffer tests, `ParallelPackBTest`).

## How it was found

The drift wouldn't reproduce in isolation or under narrow same-data stress (those skip the live parallel pack-B path). It reproduced **deterministically** under the full concurrent suite, then via a focused repro: many threads each running a live parallel `Gemm` vs their own serial reference drifted **~60×/run**. CI-bisect ruled out a poisoned global toggle (all defaults at the drift) and coverage instrumentation (it reproduced without coverage), narrowing to the shared-slot race.

## Fix

Gate the parallel dispatch with a **non-blocking `Monitor.TryEnter`** on a process-wide lock (mirrors `PersistentParallelExecutor._executeLock`). One dispatch drives the shared pool at a time; a concurrent caller that can't acquire it runs its chunks **serially** on itself instead of racing the shared state. Non-blocking → concurrent GEMMs never deadlock or stall; at most one runs parallel while the rest run serial. The common single-GEMM-at-a-time case is unchanged (always acquires the lock).

## Verification

- `ConcurrentLiveGemmReproTests` (added): pre-fix ~60 drifts/run → **post-fix 0** across repeated runs.
- The pre-pack / `ScalarKernel` / `ParallelPackBTest` cluster no longer drifts under the full concurrent suite.

Merging this into the in-flight PRs (via `main`) should clear their intermittent pre-pack drift failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)