### PR TITLE
test(#471): gfx1012/RDNA1 hardware regression guards for the CPU/GPU exit-255 crash

### DIFF
--- a/tests/AiDotNet.Tensors.Tests/Engines/Issue471CpuMatmulCrashRepro.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Issue471CpuMatmulCrashRepro.cs
@@ -22,33 +22,47 @@ public class Issue471CpuMatmulCrashRepro
     {
         Skip.IfNot(Environment.GetEnvironmentVariable("TENSORS_RUN_REPRO") == "1",
             "Env-gated #471 repro: set TENSORS_RUN_REPRO=1 to run.");
+
+        // ResetToCpu() mutates AiDotNetEngine.Current — a shared process-wide
+        // singleton. xUnit test order is nondeterministic, so without restoring
+        // the previous selection the GPU repros below could silently run on CPU
+        // and miss the hardware path they exist to cover. Capture-and-restore
+        // around the CPU-specific body keeps this test isolated.
+        var previousEngine = AiDotNetEngine.Current;
         AiDotNetEngine.ResetToCpu();
-        var eng = AiDotNetEngine.Current;
-        _o.WriteLine($"engine={eng.Name}");
-        const int d = 128;
-        foreach (int V in new[] { 1000, 10000, 30000, 50257 })
+        try
         {
-            var aData = new double[d * V]; for (int i = 0; i < aData.Length; i++) aData[i] = 0.01;
-            var bData = new double[V * d]; for (int i = 0; i < bData.Length; i++) bData[i] = 0.01;
-            var a = new Tensor<double>(aData, new[] { d, V });
-            var b = new Tensor<double>(bData, new[] { V, d });
-            _o.WriteLine($"matmul [d={d} x V={V}] x [V={V} x d={d}] ...");
-            var c = eng.TensorMatMul(a, b);
-            _o.WriteLine($"  OK V={V}: c[0,0]={c[0, 0]:F4} (expect {V * 0.01 * 0.01:F4})");
+            var eng = AiDotNetEngine.Current;
+            _o.WriteLine($"engine={eng.Name}");
+            const int d = 128;
+            foreach (int V in new[] { 1000, 10000, 30000, 50257 })
+            {
+                var aData = new double[d * V]; for (int i = 0; i < aData.Length; i++) aData[i] = 0.01;
+                var bData = new double[V * d]; for (int i = 0; i < bData.Length; i++) bData[i] = 0.01;
+                var a = new Tensor<double>(aData, new[] { d, V });
+                var b = new Tensor<double>(bData, new[] { V, d });
+                _o.WriteLine($"matmul [d={d} x V={V}] x [V={V} x d={d}] ...");
+                var c = eng.TensorMatMul(a, b);
+                _o.WriteLine($"  OK V={V}: c[0,0]={c[0, 0]:F4} (expect {V * 0.01 * 0.01:F4})");
+            }
+            // FLOAT path (matches HE's training-readout dtype; float is the oneDNN/SimdGemm-Sgemm dispatch)
+            foreach (int V in new[] { 10000, 50257 })
+            {
+                var aData = new float[d * V]; for (int i = 0; i < aData.Length; i++) aData[i] = 0.01f;
+                var bData = new float[V * d]; for (int i = 0; i < bData.Length; i++) bData[i] = 0.01f;
+                var a = new Tensor<float>(aData, new[] { d, V });
+                var b = new Tensor<float>(bData, new[] { V, d });
+                _o.WriteLine($"FLOAT matmul [d={d} x V={V}] x [V={V} x d={d}] ...");
+                var c = eng.TensorMatMul(a, b);
+                _o.WriteLine($"  OK float V={V}: c[0,0]={c[0, 0]:F4}");
+            }
+            _o.WriteLine("ALL OK — no crash");
+            Assert.True(true);
         }
-        // FLOAT path (matches HE's training-readout dtype; float is the oneDNN/SimdGemm-Sgemm dispatch)
-        foreach (int V in new[] { 10000, 50257 })
+        finally
         {
-            var aData = new float[d * V]; for (int i = 0; i < aData.Length; i++) aData[i] = 0.01f;
-            var bData = new float[V * d]; for (int i = 0; i < bData.Length; i++) bData[i] = 0.01f;
-            var a = new Tensor<float>(aData, new[] { d, V });
-            var b = new Tensor<float>(bData, new[] { V, d });
-            _o.WriteLine($"FLOAT matmul [d={d} x V={V}] x [V={V} x d={d}] ...");
-            var c = eng.TensorMatMul(a, b);
-            _o.WriteLine($"  OK float V={V}: c[0,0]={c[0, 0]:F4}");
+            AiDotNetEngine.Current = previousEngine;
         }
-        _o.WriteLine("ALL OK — no crash");
-        Assert.True(true);
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tensors.Tests/Engines/Issue471CpuMatmulCrashRepro.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Issue471CpuMatmulCrashRepro.cs
@@ -17,10 +17,11 @@ public class Issue471CpuMatmulCrashRepro
     private readonly ITestOutputHelper _o;
     public Issue471CpuMatmulCrashRepro(ITestOutputHelper o) { _o = o; }
 
-    [Fact]
+    [SkippableFact]
     public void Cpu_large_matmul_contracting_over_V()
     {
-        if (Environment.GetEnvironmentVariable("TENSORS_RUN_REPRO") != "1") return;
+        Skip.IfNot(Environment.GetEnvironmentVariable("TENSORS_RUN_REPRO") == "1",
+            "Env-gated #471 repro: set TENSORS_RUN_REPRO=1 to run.");
         AiDotNetEngine.ResetToCpu();
         var eng = AiDotNetEngine.Current;
         _o.WriteLine($"engine={eng.Name}");
@@ -56,10 +57,11 @@ public class Issue471CpuMatmulCrashRepro
     /// training-batch shapes + large [B,V] readout matmuls, mimicking the per-batch kernel-launch cadence.
     /// Env-gated TENSORS_RUN_REPRO=1. A clean run prints "GPU ALL OK".
     /// </summary>
-    [Fact]
+    [SkippableFact]
     public void Gpu_training_loop_stress()
     {
-        if (Environment.GetEnvironmentVariable("TENSORS_RUN_REPRO") != "1") return;
+        Skip.IfNot(Environment.GetEnvironmentVariable("TENSORS_RUN_REPRO") == "1",
+            "Env-gated #471 repro: set TENSORS_RUN_REPRO=1 to run.");
         var eng = AiDotNetEngine.Current;   // default = auto-detected GPU on this box
         _o.WriteLine($"engine={eng.Name}");
         const int B = 128, d = 128, ff = 512, V = 15001;
@@ -84,10 +86,11 @@ public class Issue471CpuMatmulCrashRepro
     /// matmul-chain + ReduceSum loss, then ComputeGradients (the BACKWARD pass = the prime crash suspect), with a
     /// CPU-side weight update to keep values bounded. Many iters on the default (GPU) engine. Env TENSORS_RUN_REPRO=1.
     /// </summary>
-    [Fact]
+    [SkippableFact]
     public void Gpu_autodiff_training_stress()
     {
-        if (Environment.GetEnvironmentVariable("TENSORS_RUN_REPRO") != "1") return;
+        Skip.IfNot(Environment.GetEnvironmentVariable("TENSORS_RUN_REPRO") == "1",
+            "Env-gated #471 repro: set TENSORS_RUN_REPRO=1 to run.");
         var eng = AiDotNetEngine.Current;
         _o.WriteLine($"engine={eng.Name}");
         const int B = 64, d = 128, ff = 512, V = 15001;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Issue471CpuMatmulCrashRepro.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Issue471CpuMatmulCrashRepro.cs
@@ -1,0 +1,115 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Issue #471 repro: CPU engine hard-crashes (exit 255, no managed exception) on a large TensorMatMul
+/// contracting over a big dimension (V≈50257), on AVX2-no-AVX512 hardware with OpenBLAS NOT loaded (managed
+/// AVX2 fallback). Env-gated TENSORS_RUN_REPRO=1. A clean run prints "ALL OK".
+/// </summary>
+public class Issue471CpuMatmulCrashRepro
+{
+    private readonly ITestOutputHelper _o;
+    public Issue471CpuMatmulCrashRepro(ITestOutputHelper o) { _o = o; }
+
+    [Fact]
+    public void Cpu_large_matmul_contracting_over_V()
+    {
+        if (Environment.GetEnvironmentVariable("TENSORS_RUN_REPRO") != "1") return;
+        AiDotNetEngine.ResetToCpu();
+        var eng = AiDotNetEngine.Current;
+        _o.WriteLine($"engine={eng.Name}");
+        const int d = 128;
+        foreach (int V in new[] { 1000, 10000, 30000, 50257 })
+        {
+            var aData = new double[d * V]; for (int i = 0; i < aData.Length; i++) aData[i] = 0.01;
+            var bData = new double[V * d]; for (int i = 0; i < bData.Length; i++) bData[i] = 0.01;
+            var a = new Tensor<double>(aData, new[] { d, V });
+            var b = new Tensor<double>(bData, new[] { V, d });
+            _o.WriteLine($"matmul [d={d} x V={V}] x [V={V} x d={d}] ...");
+            var c = eng.TensorMatMul(a, b);
+            _o.WriteLine($"  OK V={V}: c[0,0]={c[0, 0]:F4} (expect {V * 0.01 * 0.01:F4})");
+        }
+        // FLOAT path (matches HE's training-readout dtype; float is the oneDNN/SimdGemm-Sgemm dispatch)
+        foreach (int V in new[] { 10000, 50257 })
+        {
+            var aData = new float[d * V]; for (int i = 0; i < aData.Length; i++) aData[i] = 0.01f;
+            var bData = new float[V * d]; for (int i = 0; i < bData.Length; i++) bData[i] = 0.01f;
+            var a = new Tensor<float>(aData, new[] { d, V });
+            var b = new Tensor<float>(bData, new[] { V, d });
+            _o.WriteLine($"FLOAT matmul [d={d} x V={V}] x [V={V} x d={d}] ...");
+            var c = eng.TensorMatMul(a, b);
+            _o.WriteLine($"  OK float V={V}: c[0,0]={c[0, 0]:F4}");
+        }
+        _o.WriteLine("ALL OK — no crash");
+        Assert.True(true);
+    }
+
+    /// <summary>
+    /// GPU training-loop stress: the HE facade-Transformer training crashed (exit 255) on gfx1012/RDNA1 during the
+    /// high-frequency minibatch loop. Repro: default (auto-detected GPU) engine, many sequential matmuls of
+    /// training-batch shapes + large [B,V] readout matmuls, mimicking the per-batch kernel-launch cadence.
+    /// Env-gated TENSORS_RUN_REPRO=1. A clean run prints "GPU ALL OK".
+    /// </summary>
+    [Fact]
+    public void Gpu_training_loop_stress()
+    {
+        if (Environment.GetEnvironmentVariable("TENSORS_RUN_REPRO") != "1") return;
+        var eng = AiDotNetEngine.Current;   // default = auto-detected GPU on this box
+        _o.WriteLine($"engine={eng.Name}");
+        const int B = 128, d = 128, ff = 512, V = 15001;
+        // per-batch matmuls a training loop issues: x·W1 [B,d]x[d,ff], h·W2 [B,ff]x[ff,d], readout [B,d]x[d,V]
+        float Fill(int i) => 0.001f * ((i % 17) - 8);
+        Tensor<float> Mk(int r, int c) { var v = new float[r * c]; for (int i = 0; i < v.Length; i++) v[i] = Fill(i); return new Tensor<float>(v, new[] { r, c }); }
+        var x = Mk(B, d); var w1 = Mk(d, ff); var w2 = Mk(ff, d); var wOut = Mk(d, V);
+        int iters = 3000;
+        for (int it = 0; it < iters; it++)
+        {
+            var h = eng.TensorMatMul(x, w1);     // [B,ff]
+            var o = eng.TensorMatMul(h, w2);     // [B,d]
+            var logits = eng.TensorMatMul(o, wOut); // [B,V] — the big readout
+            if (it % 500 == 0) _o.WriteLine($"  iter {it}: logits[0,0]={logits[0, 0]:F4}");
+        }
+        _o.WriteLine($"GPU ALL OK — {iters} iters, no crash");
+        Assert.True(true);
+    }
+
+    /// <summary>
+    /// GPU AUTODIFF training stress — the faithful TrainWithTape workload: per-iter GradientTape, forward
+    /// matmul-chain + ReduceSum loss, then ComputeGradients (the BACKWARD pass = the prime crash suspect), with a
+    /// CPU-side weight update to keep values bounded. Many iters on the default (GPU) engine. Env TENSORS_RUN_REPRO=1.
+    /// </summary>
+    [Fact]
+    public void Gpu_autodiff_training_stress()
+    {
+        if (Environment.GetEnvironmentVariable("TENSORS_RUN_REPRO") != "1") return;
+        var eng = AiDotNetEngine.Current;
+        _o.WriteLine($"engine={eng.Name}");
+        const int B = 64, d = 128, ff = 512, V = 15001;
+        float Fill(int i) => 0.001f * ((i % 17) - 8);
+        Tensor<float> Mk(int r, int c) { var v = new float[r * c]; for (int i = 0; i < v.Length; i++) v[i] = Fill(i); return new Tensor<float>(v, new[] { r, c }); }
+        var x = Mk(B, d); var w1 = Mk(d, ff); var w2 = Mk(ff, d); var wOut = Mk(d, V);
+        const float lr = 1e-4f;
+        int iters = 1000;
+        for (int it = 0; it < iters; it++)
+        {
+            using var tape = new GradientTape<float>(new GradientTapeOptions { Persistent = true });
+            var h = eng.TensorMatMul(x, w1);
+            var o = eng.TensorMatMul(h, w2);
+            var logits = eng.TensorMatMul(o, wOut);
+            var loss = eng.ReduceSum(logits, null);
+            var grads = tape.ComputeGradients(loss, new[] { w1, w2, wOut });   // BACKWARD on GPU — suspect
+            // CPU-side SGD to keep weights bounded (update mechanics irrelevant to the crash)
+            void Upd(Tensor<float> w, Tensor<float> g) { var sw = w.AsWritableSpan(); var sg = g.AsWritableSpan(); for (int i = 0; i < sw.Length; i++) sw[i] -= lr * sg[i]; }
+            Upd(w1, grads[w1]); Upd(w2, grads[w2]); Upd(wOut, grads[wOut]);
+            if (it % 200 == 0) { try { double l = Convert.ToDouble(loss.AsWritableSpan()[0]); _o.WriteLine($"  iter {it}: loss={l:E3}"); } catch { _o.WriteLine($"  iter {it}: ok"); } }
+        }
+        _o.WriteLine($"GPU AUTODIFF ALL OK — {iters} backward iters, no crash");
+        Assert.True(true);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #471 by **verifying it is already fixed on `main`** and locking that in with hardware-specific regression guards.

I have the exact hardware that #471 reproduced on (**AMD gfx1012 / RDNA1, AVX2-without-AVX512, OpenBLAS not loaded** — the managed-AVX2 fallback condition the maintainers couldn't replicate). On current `main` I ran the three workloads that previously hard-crashed (exit 255, no managed exception) on the older Tensors (0.81.x) that downstream was pinned to:

| Workload (previously exit-255) | Result on `main` |
|---|---|
| CPU **managed AVX2** large-matmul, `[128×V]·[V×128]`, V∈{1000,10000,30000,50257}, **float + double**, `AIDOTNET_USE_BLAS=0` (forces the exact #471 managed path) | ✅ no crash |
| GPU matmul training-loop stress — 3000 iters incl. the large `[B,V]` readout | ✅ no crash |
| GPU **autodiff backward** stress — 1000 `GradientTape.ComputeGradients` iters (the `TrainWithTape` crash suspect) | ✅ no crash |

So the exit-255 crashes were resolved somewhere between 0.81.x and current `main`. This PR adds the three workloads as **env-gated regression guards** (`TENSORS_RUN_REPRO=1`) so the fix can be re-verified on this hardware class, which CI cannot exercise (no RDNA1 + the OpenBLAS-absent managed path).

## Why env-gated

The crash only manifests on the managed-AVX2 path (OpenBLAS/oneDNN absent) on this GPU/CPU class. CI machines load native BLAS and won't hit it, and the GPU tests need an OpenCL device. Gating keeps CI green while giving anyone with the hardware a one-flag repro.

## Test plan
- [x] `TENSORS_RUN_REPRO=1 dotnet test --filter Issue471CpuMatmulCrashRepro` on gfx1012/RDNA1 — all three pass (CPU 1s, GPU matmul 41s, GPU autodiff 59s)
- [ ] Maintainer sanity: tests are skipped without the env flag (CI stays green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)