### PR TITLE
perf(managedblas): deterministic-parallel default + cooperative concurrency scheduler (Phases 0-2)

### DIFF
--- a/docs/managed-blas-determinism.md
+++ b/docs/managed-blas-determinism.md
@@ -78,6 +78,8 @@ AiDotNetEngine.SetDeterministicMode(false);
 // Hardened: never touch native BLAS, in any mode.
 BlasManaged.PreferManaged = true;
 
-// Disable per-shape autotune (always managed in non-deterministic mode too).
+// Disable per-shape autotune. Deterministic mode still routes managed; in
+// non-deterministic mode dispatch then falls back to native (unless PreferManaged
+// is true).
 BlasManaged.AutotuneRouting = false;
 ```

--- a/docs/managed-blas-determinism.md
+++ b/docs/managed-blas-determinism.md
@@ -1,0 +1,83 @@
+# ManagedBlas determinism & dispatch modes
+
+AiDotNet.Tensors runs CPU matrix multiplication (GEMM) through its own managed
+kernel, **ManagedBlas** (`BlasManaged.Gemm`), with native OpenBLAS available only
+as an optional, per-shape accelerator in non-deterministic mode (and being retired
+entirely — see the managed-blas-deterministic-parallel roadmap). This document
+describes the two execution modes, the determinism guarantee, and how dispatch is
+routed.
+
+## Two modes
+
+Select with a single process-wide switch:
+
+```csharp
+AiDotNetEngine.SetDeterministicMode(true);   // reproducible (default)
+AiDotNetEngine.SetDeterministicMode(false);  // maximum throughput
+```
+
+| | Deterministic (default) | Non-deterministic |
+|---|---|---|
+| GEMM kernel | ManagedBlas, always | per-shape best of ManagedBlas / native OpenBLAS (autotuned) |
+| Result reproducibility | **bit-identical** across runs and thread counts (same machine/ISA) | not guaranteed bit-identical (reduction order may vary) |
+| Parallelism | **full** (multi-threaded) | full |
+| Use when | training/inference that must reproduce exactly; debugging; regression baselines | latency/throughput is the only goal |
+
+### Why this exceeds the usual tradeoff
+
+PyTorch's deterministic mode (`torch.use_deterministic_algorithms(True)`) sacrifices
+parallelism for some ops. ManagedBlas does **not**: deterministic mode is both
+**reproducible and fully parallel**. This is possible because every parallel GEMM
+path splits work over **disjoint output tiles** (rows / columns / 2-D blocks) and
+performs each output element's full K-reduction on a single thread in a fixed order.
+The number of threads (i.e. how the tiles are partitioned) therefore never changes
+the result. The only split that *would* change the result — partitioning the
+K-reduction across threads and summing partials — is disabled in deterministic mode
+(`AxisSelector` gates it on non-deterministic mode only).
+
+This contract is pinned by `DeterministicParallelGemmContractTests`, which runs the
+same GEMM at 1/2/4/16 threads and asserts the output is bit-identical.
+
+### Scope of the determinism guarantee
+
+- **Guaranteed:** bit-identical across runs and across thread counts **on the same
+  machine / instruction set**.
+- **Not guaranteed:** bit-identical across *different* instruction sets (AVX-512 vs
+  AVX2 vs scalar vs ARM Neon), which reduce at different vector widths. No mainstream
+  framework (PyTorch included) guarantees cross-ISA bit-exactness either.
+
+## Dispatch routing
+
+All `BlasProvider.TryGemm*` entry points decide managed-vs-native via one helper,
+`BlasProvider.ShouldRouteManaged`, in this priority order:
+
+1. **`BlasManaged.PreferManaged`** (default `false`) — force managed everywhere; set
+   `true` for supply-chain-hardened deployments that want zero native attack surface.
+2. **Deterministic mode** — always managed (the reproducible-and-parallel kernel).
+   Deterministic mode never consults the timing-based autotune below, because a
+   measurement-chosen kernel would not be reproducible.
+3. **`BlasManaged.AutotuneRouting`** (default `true`) — in *non-deterministic* mode,
+   `PrefersManagedCache` measures both kernels once per `(shape, hardware)` tuple
+   (disk-persisted under `~/.aidotnet/autotune/`) and routes future calls to the
+   faster one. Managed where it wins, native where it wins — so the managed default
+   never costs throughput.
+4. Otherwise → native OpenBLAS.
+
+## Quick reference
+
+```csharp
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.BlasManaged;
+
+// Reproducible + parallel (default).
+AiDotNetEngine.SetDeterministicMode(true);
+
+// Max throughput; per-shape best-of managed/native.
+AiDotNetEngine.SetDeterministicMode(false);
+
+// Hardened: never touch native BLAS, in any mode.
+BlasManaged.PreferManaged = true;
+
+// Disable per-shape autotune (always managed in non-deterministic mode too).
+BlasManaged.AutotuneRouting = false;
+```

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
@@ -43,19 +43,25 @@ public static class BlasManaged
     public static bool PreferManaged { get; set; } = false;
 
     /// <summary>
-    /// Sub-F3 (#374 follow-up): when true, <see cref="Helpers.BlasProvider.TryGemmEx"/>
-    /// consults <see cref="PrefersManagedCache"/> on each call. The cache measures
-    /// both managed and native paths once per (shape, hardware) tuple and routes
-    /// future calls to the winner.
+    /// Sub-F3 (#374 follow-up): when true, the <see cref="Helpers.BlasProvider"/>
+    /// <c>TryGemm</c> / <c>TryGemmEx</c> entry points consult
+    /// <see cref="PrefersManagedCache"/> in NON-deterministic mode. The cache measures
+    /// both managed and native paths once per (shape, hardware) tuple (disk-persisted)
+    /// and routes future calls to the faster one — managed where it wins, native where
+    /// it wins — so flipping toward managed never costs throughput.
     ///
     /// <para>
-    /// Defaults to <see langword="false"/> (no autotune routing).
-    /// <see cref="PreferManaged"/> takes precedence — when both are true,
-    /// every call routes managed regardless of autotune. This lets supply-chain
-    /// deployments override autotune (forcing managed dispatch unconditionally).
+    /// Defaults to <see langword="true"/> (ManagedBlas deterministic-parallel +
+    /// non-deterministic best-of is the intended CPU GEMM behavior; native OpenBLAS is
+    /// being retired — see the managed-blas-deterministic-parallel plan). Precedence is
+    /// resolved in <see cref="Helpers.BlasProvider.ShouldRouteManaged"/>:
+    /// <see cref="PreferManaged"/> and <see cref="Helpers.BlasProvider.IsDeterministicMode"/>
+    /// both force managed BEFORE this timing-based routing is consulted — deterministic
+    /// mode must not pick its kernel by measurement noise (it would break
+    /// bit-reproducibility), so autotune only governs the non-deterministic path.
     /// </para>
     /// </summary>
-    public static bool AutotuneRouting { get; set; } = false;
+    public static bool AutotuneRouting { get; set; } = true;
 
     // #375: the earlier opt-in Gemm-level autotune (EnableAutotuneV2 + AutotuneCacheV2 +
     // a synchronous warmup sweep) was superseded by the hybrid hardware-aware strategy

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Pool/CooperativeGemmScheduler.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Pool/CooperativeGemmScheduler.cs
@@ -1,0 +1,253 @@
+using System;
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace AiDotNet.Tensors.Engines.BlasManaged.Pool;
+
+/// <summary>
+/// Cooperative work-sharing scheduler for concurrent GEMM dispatch — the Phase 2
+/// "exceed PyTorch on concurrent CPU" primitive.
+///
+/// <para>
+/// The existing pools treat one dispatch as exclusive: <see cref="StreamingWorkerPool"/>
+/// runs a contended second caller serially on itself (#492), and
+/// <c>PersistentParallelExecutor</c> blocks a second caller on a lock. So N GEMMs from
+/// N threads either serialize whole dispatches or oversubscribe (N caller threads PLUS
+/// the pool's workers). PyTorch's shared intra-op pool has the same oversubscription
+/// problem under concurrent inference.
+/// </para>
+///
+/// <para>
+/// This scheduler instead has ONE process-wide pool of <c>cores-1</c> parked workers
+/// draining ONE shared queue. <see cref="Dispatch(int, Action{int})"/> enqueues its
+/// chunks under a per-dispatch countdown and then the CALLING thread PARTICIPATES —
+/// it drains the shared queue (any job's chunks) until its own job's countdown hits
+/// zero, then returns. Effects:
+/// <list type="bullet">
+///   <item>Concurrent dispatches interleave their chunks on the shared workers — no
+///   whole-GEMM serialization.</item>
+///   <item>The caller does work instead of blocking idle, and workers PARK when the
+///   queue is empty — so the count of threads actively burning CPU stays ≈ cores
+///   regardless of how many callers are in flight (no oversubscription).</item>
+/// </list>
+/// </para>
+///
+/// <para>
+/// Correctness rests on the GEMM strategies' invariant (Phase 0): chunks write
+/// DISJOINT output regions, so interleaving chunks from different concurrent GEMMs is
+/// safe. A chunk that re-enters <see cref="Dispatch(int, Action{int})"/> (nested
+/// parallelism) runs serially — the <c>[ThreadStatic]</c> in-scheduler flag prevents
+/// pool re-entry deadlock, mirroring the existing pools' nested guard.
+/// </para>
+///
+/// <para>
+/// Disabled by default (<see cref="Enabled"/>) until the concurrency benchmark proves
+/// parity-or-better; the strategies keep using the existing pools until then.
+/// </para>
+/// </summary>
+internal static class CooperativeGemmScheduler
+{
+    /// <summary>Master switch. When false, callers use the legacy pools. Default off
+    /// until the Phase 2 concurrency benchmark proves this scheduler wins.</summary>
+    internal static bool Enabled { get; set; }
+
+    private readonly struct WorkItem
+    {
+        public readonly Job Job;
+        public readonly int Chunk;
+        public WorkItem(Job job, int chunk) { Job = job; Chunk = chunk; }
+    }
+
+    private sealed class Job
+    {
+        public readonly Action<int> Action;
+        public int Remaining;            // Interlocked-decremented as chunks finish.
+        public Exception? FirstException; // First chunk exception (CompareExchange).
+        public Job(Action<int> action, int remaining) { Action = action; Remaining = remaining; }
+    }
+
+    // MPMC queue of pending chunks across ALL in-flight dispatches.
+    private static readonly ConcurrentQueue<WorkItem> _queue = new();
+    // Counts pending items so parked workers can wake. Over-signaling only causes a
+    // spurious wake (worker finds the queue empty and re-waits) — never lost work,
+    // because completion is tracked by Job.Remaining, not by this semaphore.
+    private static readonly SemaphoreSlim _workAvailable = new(0);
+
+    // True while THIS thread is executing a chunk (worker or participating caller).
+    // A nested Dispatch from inside a chunk runs serially to avoid pool re-entry.
+    [ThreadStatic] private static bool _inScheduler;
+
+    private static int _initialized; // 0 = not started, 1 = workers spawned
+    private static readonly object _initLock = new();
+    private static int _numWorkers;
+
+    private static void EnsureInitialized()
+    {
+        if (Volatile.Read(ref _initialized) == 1) return;
+        lock (_initLock)
+        {
+            if (_initialized == 1) return;
+            _numWorkers = Math.Max(1, Environment.ProcessorCount - 1);
+            for (int i = 0; i < _numWorkers; i++)
+            {
+                var t = new Thread(WorkerLoop)
+                {
+                    IsBackground = true,
+                    Name = $"AiDotNet-CoopGemm-{i}",
+                };
+                t.Start();
+            }
+            Volatile.Write(ref _initialized, 1);
+        }
+    }
+
+    private static void WorkerLoop()
+    {
+        while (true)
+        {
+            _workAvailable.Wait();
+            // A permit may correspond to an item a participating caller already took;
+            // TryDequeue-empty just means re-wait. Drain greedily while items remain.
+            while (_queue.TryDequeue(out var item))
+            {
+                Execute(item);
+                // Each successfully dequeued item consumed one logical permit; keep
+                // draining without re-waiting. Remaining permits for items this loop
+                // drains are reconciled by the spurious-wake-tolerant Wait above.
+                if (!_queue.IsEmpty)
+                {
+                    // Best-effort: consume a permit for the next item we're about to
+                    // take so the semaphore count tracks the queue (bounded drift only).
+                    _workAvailable.Wait(0);
+                }
+            }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void Execute(in WorkItem item)
+    {
+        bool prev = _inScheduler;
+        _inScheduler = true;
+        try
+        {
+            item.Job.Action(item.Chunk);
+        }
+        catch (Exception ex)
+        {
+            Interlocked.CompareExchange(ref item.Job.FirstException, ex, null);
+        }
+        finally
+        {
+            _inScheduler = prev;
+            Interlocked.Decrement(ref item.Job.Remaining);
+        }
+    }
+
+    /// <summary>Default serial-fallback grain size (matches the other pools).</summary>
+    public static int DefaultSerialGrainSize { get; set; } = 32 * 1024;
+
+    /// <summary>
+    /// Grain-size-gated dispatch: below <see cref="DefaultSerialGrainSize"/> total work,
+    /// runs all chunks inline on the caller (no pool traffic).
+    /// </summary>
+    public static void Dispatch(int numChunks, long totalWork, Action<int> action)
+    {
+        if (numChunks <= 0) return;
+        if (totalWork < DefaultSerialGrainSize)
+        {
+            RunSerial(numChunks, action);
+            return;
+        }
+        Dispatch(numChunks, action);
+    }
+
+    /// <summary>
+    /// Run <paramref name="action"/> over <paramref name="numChunks"/> chunks on the
+    /// shared cooperative pool. Returns when all of THIS dispatch's chunks complete
+    /// (the caller participates meanwhile). Re-throws the first chunk exception.
+    /// </summary>
+    public static void Dispatch(int numChunks, Action<int> action)
+    {
+        if (numChunks <= 0) return;
+        // Single chunk, or nested call (this thread is already running a chunk) →
+        // serial on the caller. Nested pool re-entry would risk deadlock.
+        if (numChunks == 1 || _inScheduler)
+        {
+            RunSerial(numChunks, action);
+            return;
+        }
+
+        EnsureInitialized();
+
+        var job = new Job(action, numChunks);
+        for (int c = 0; c < numChunks; c++)
+            _queue.Enqueue(new WorkItem(job, c));
+        _workAvailable.Release(numChunks);
+
+        // Caller participates: drain the shared queue (any job's chunks) until OUR job
+        // is done. Marked in-scheduler so a nested Dispatch from a chunk runs serial.
+        bool prev = _inScheduler;
+        _inScheduler = true;
+        try
+        {
+            int spin = 0;
+            while (Volatile.Read(ref job.Remaining) > 0)
+            {
+                if (_queue.TryDequeue(out var item))
+                {
+                    // We took an item a worker permit was issued for; consume the
+                    // matching permit so a parked worker doesn't wake to an empty queue.
+                    _workAvailable.Wait(0);
+                    ExecuteAlreadyInScheduler(item);
+                    spin = 0;
+                }
+                else
+                {
+                    // Queue empty but our job isn't done → other threads hold our
+                    // remaining chunks. Spin briefly, then yield.
+                    if (spin++ < 1000) Thread.SpinWait(8);
+                    else { Thread.Yield(); spin = 0; }
+                }
+            }
+        }
+        finally
+        {
+            _inScheduler = prev;
+        }
+
+        var ex = job.FirstException;
+        if (ex is not null) throw ex;
+    }
+
+    // Execute when the caller has ALREADY set _inScheduler (avoids save/restore churn
+    // in the hot participate loop). Still counts down + captures exceptions.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void ExecuteAlreadyInScheduler(in WorkItem item)
+    {
+        try
+        {
+            item.Job.Action(item.Chunk);
+        }
+        catch (Exception ex)
+        {
+            Interlocked.CompareExchange(ref item.Job.FirstException, ex, null);
+        }
+        finally
+        {
+            Interlocked.Decrement(ref item.Job.Remaining);
+        }
+    }
+
+    private static void RunSerial(int numChunks, Action<int> action)
+    {
+        Exception? first = null;
+        for (int c = 0; c < numChunks; c++)
+        {
+            try { action(c); }
+            catch (Exception ex) { first ??= ex; }
+        }
+        if (first is not null) throw first;
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Pool/StreamingWorkerPool.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Pool/StreamingWorkerPool.cs
@@ -162,6 +162,17 @@ internal static class StreamingWorkerPool
     public static void Dispatch(int numChunks, Action<int> action)
     {
         if (numChunks <= 0) return;
+        // Phase 2 migration seam: when the cooperative scheduler is enabled, route
+        // there instead. Unlike this pool (one shared _slots set → a concurrent
+        // second caller falls back to fully-serial, #492), the cooperative scheduler
+        // lets concurrent dispatches interleave their chunks on a shared work queue —
+        // so concurrent GEMMs stay parallel. Default-off until the concurrency
+        // benchmark proves it; flip CooperativeGemmScheduler.Enabled to A/B test.
+        if (CooperativeGemmScheduler.Enabled)
+        {
+            CooperativeGemmScheduler.Dispatch(numChunks, action);
+            return;
+        }
         // Run serially on the caller when: a single chunk; this thread is already
         // driving a dispatch (nested — avoids ThreadPool starvation); or ANOTHER
         // thread is currently driving the shared worker slots. The last case is the

--- a/src/AiDotNet.Tensors/Helpers/BlasProvider.cs
+++ b/src/AiDotNet.Tensors/Helpers/BlasProvider.cs
@@ -1118,13 +1118,41 @@ internal static class BlasProvider
     // cblas_{s,d}gemm with standard row-major layout.
     // ────────────────────────────────────────────────────────────────────
 
+    /// <summary>
+    /// Single routing decision shared by every <c>TryGemm*</c> entry point:
+    /// should this GEMM dispatch to the managed kernel (<see cref="Engines.BlasManaged.BlasManaged.Gemm{T}"/>)
+    /// rather than native cblas? Three reasons, in priority order:
+    /// <list type="number">
+    ///   <item><see cref="Engines.BlasManaged.BlasManaged.PreferManaged"/> — supply-chain
+    ///   force-managed (no native attack surface).</item>
+    ///   <item><see cref="IsDeterministicMode"/> — the managed GEMM is parallel AND
+    ///   bit-reproducible across thread counts (M/N/2D disjoint-write splits; K-axis
+    ///   gated off — see <c>DeterministicParallelGemmContractTests</c>), whereas native
+    ///   multi-threaded reduction order is not reproducible and native deterministic
+    ///   mode runs single-threaded. Routing deterministic mode to managed gives
+    ///   reproducibility WITHOUT serializing — a capability PyTorch's deterministic
+    ///   mode lacks. Deterministic mode must NOT use the timing-based autotune below
+    ///   (its winner varies with measurement noise → non-reproducible kernel choice).</item>
+    ///   <item><see cref="Engines.BlasManaged.BlasManaged.AutotuneRouting"/> — in
+    ///   non-deterministic mode, per-shape best-of-managed-vs-native (results need not
+    ///   be bit-reproducible, so a measured kernel choice is fine).</item>
+    /// </list>
+    /// </summary>
+    internal static bool ShouldRouteManaged(int m, int n, int k, bool transA, bool transB, Type dtype)
+    {
+        if (Engines.BlasManaged.BlasManaged.PreferManaged) return true;
+        if (IsDeterministicMode) return true;
+        return Engines.BlasManaged.BlasManaged.AutotuneRouting
+            && !Engines.BlasManaged.PrefersManagedCache.BypassAutotune
+            && Engines.BlasManaged.PrefersManagedCache.PrefersManaged(m, n, k, transA, transB, dtype);
+    }
+
     internal static bool TryGemm(int m, int n, int k,
         float[] a, int aOffset, int lda,
         float[] b, int bOffset, int ldb,
         float[] c, int cOffset, int ldc)
     {
-        // Sub-F (#374) routing shim: caller-opt-in managed dispatch.
-        if (Engines.BlasManaged.BlasManaged.PreferManaged)
+        if (ShouldRouteManaged(m, n, k, false, false, typeof(float)))
         {
             Engines.BlasManaged.BlasManaged.Gemm<float>(
                 new ReadOnlySpan<float>(a, aOffset, a.Length - aOffset), lda, false,
@@ -1157,7 +1185,7 @@ internal static class BlasProvider
         double[] b, int bOffset, int ldb,
         double[] c, int cOffset, int ldc)
     {
-        if (Engines.BlasManaged.BlasManaged.PreferManaged)
+        if (ShouldRouteManaged(m, n, k, false, false, typeof(double)))
         {
             Engines.BlasManaged.BlasManaged.Gemm<double>(
                 new ReadOnlySpan<double>(a, aOffset, a.Length - aOffset), lda, false,
@@ -1188,7 +1216,7 @@ internal static class BlasProvider
     internal static bool TryGemm(int m, int n, int k,
         ReadOnlySpan<float> a, int lda, ReadOnlySpan<float> b, int ldb, Span<float> c, int ldc)
     {
-        if (Engines.BlasManaged.BlasManaged.PreferManaged)
+        if (ShouldRouteManaged(m, n, k, false, false, typeof(float)))
         {
             Engines.BlasManaged.BlasManaged.Gemm<float>(a, lda, false, b, ldb, false, c, ldc, m, n, k);
             return true;
@@ -1215,7 +1243,7 @@ internal static class BlasProvider
     internal static bool TryGemm(int m, int n, int k,
         ReadOnlySpan<double> a, int lda, ReadOnlySpan<double> b, int ldb, Span<double> c, int ldc)
     {
-        if (Engines.BlasManaged.BlasManaged.PreferManaged)
+        if (ShouldRouteManaged(m, n, k, false, false, typeof(double)))
         {
             Engines.BlasManaged.BlasManaged.Gemm<double>(a, lda, false, b, ldb, false, c, ldc, m, n, k);
             return true;
@@ -1292,21 +1320,10 @@ internal static class BlasProvider
         float[] b, int bOffset, int ldb, bool transB,
         float[] c, int cOffset, int ldc)
     {
-        if (Engines.BlasManaged.BlasManaged.PreferManaged)
-        {
-            Engines.BlasManaged.BlasManaged.Gemm<float>(
-                new ReadOnlySpan<float>(a, aOffset, a.Length - aOffset), lda, transA,
-                new ReadOnlySpan<float>(b, bOffset, b.Length - bOffset), ldb, transB,
-                new Span<float>(c, cOffset, c.Length - cOffset), ldc,
-                m, n, k);
-            return true;
-        }
-        // Sub-F3 (#374 follow-up): per-shape autotune routing.
-        // BypassAutotune is a ThreadStatic flag the PrefersManagedCache flips
-        // during its measurement probe so the nested call goes to native.
-        if (Engines.BlasManaged.BlasManaged.AutotuneRouting
-            && !Engines.BlasManaged.PrefersManagedCache.BypassAutotune
-            && Engines.BlasManaged.PrefersManagedCache.PrefersManaged(m, n, k, transA, transB, typeof(float)))
+        // PreferManaged / deterministic-mode / non-deterministic autotune best-of —
+        // see ShouldRouteManaged. (BypassAutotune, flipped during the autotune probe,
+        // is honored inside ShouldRouteManaged so the measurement still hits native.)
+        if (ShouldRouteManaged(m, n, k, transA, transB, typeof(float)))
         {
             Engines.BlasManaged.BlasManaged.Gemm<float>(
                 new ReadOnlySpan<float>(a, aOffset, a.Length - aOffset), lda, transA,
@@ -1350,18 +1367,7 @@ internal static class BlasProvider
         double[] b, int bOffset, int ldb, bool transB,
         double[] c, int cOffset, int ldc)
     {
-        if (Engines.BlasManaged.BlasManaged.PreferManaged)
-        {
-            Engines.BlasManaged.BlasManaged.Gemm<double>(
-                new ReadOnlySpan<double>(a, aOffset, a.Length - aOffset), lda, transA,
-                new ReadOnlySpan<double>(b, bOffset, b.Length - bOffset), ldb, transB,
-                new Span<double>(c, cOffset, c.Length - cOffset), ldc,
-                m, n, k);
-            return true;
-        }
-        if (Engines.BlasManaged.BlasManaged.AutotuneRouting
-            && !Engines.BlasManaged.PrefersManagedCache.BypassAutotune
-            && Engines.BlasManaged.PrefersManagedCache.PrefersManaged(m, n, k, transA, transB, typeof(double)))
+        if (ShouldRouteManaged(m, n, k, transA, transB, typeof(double)))
         {
             Engines.BlasManaged.BlasManaged.Gemm<double>(
                 new ReadOnlySpan<double>(a, aOffset, a.Length - aOffset), lda, transA,

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/CooperativeSchedulerConcurrencyTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/CooperativeSchedulerConcurrencyTests.cs
@@ -1,0 +1,113 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Phase 2 guard for CooperativeGemmScheduler — the shared work-sharing pool that
+// lets concurrent GEMMs interleave their chunks instead of serializing whole
+// dispatches (StreamingWorkerPool #492) or blocking (PersistentParallelExecutor).
+//
+// These pin the correctness properties the scheduler must hold before it can
+// replace the legacy pools:
+//   1. every chunk of a dispatch runs exactly once;
+//   2. a chunk exception is re-thrown to the dispatching caller;
+//   3. a nested dispatch (chunk re-enters Dispatch) runs serially — no deadlock;
+//   4. MANY concurrent dispatches from many threads all complete with correct,
+//      non-cross-contaminated results and no deadlock (the property the legacy
+//      pools can't provide in parallel).
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using AiDotNet.Tensors.Engines.BlasManaged.Pool;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+public class CooperativeSchedulerConcurrencyTests
+{
+    // Force the parallel path: DefaultSerialGrainSize gates the (chunks,totalWork)
+    // overload, but the (chunks,action) overload only runs serial for numChunks==1
+    // or nested calls — so multi-chunk dispatches here exercise the real pool.
+
+    [Fact]
+    public void Dispatch_RunsEveryChunkExactlyOnce()
+    {
+        const int chunks = 64;
+        var counts = new int[chunks];
+        CooperativeGemmScheduler.Dispatch(chunks, c => Interlocked.Increment(ref counts[c]));
+        for (int c = 0; c < chunks; c++)
+            Assert.Equal(1, counts[c]);
+    }
+
+    [Fact]
+    public void Dispatch_RethrowsChunkException()
+    {
+        var ex = Assert.ThrowsAny<Exception>(() =>
+            CooperativeGemmScheduler.Dispatch(32, c =>
+            {
+                if (c == 17) throw new InvalidOperationException("boom-17");
+            }));
+        Assert.Contains("boom-17", ex.Message);
+    }
+
+    [Fact]
+    public void NestedDispatch_RunsSerially_NoDeadlock()
+    {
+        // A chunk that itself dispatches must not deadlock on the pool: the nested
+        // dispatch runs serially on the worker thread (the _inScheduler guard).
+        const int outer = 8, inner = 8;
+        var inner_counts = new int[outer * inner];
+        CooperativeGemmScheduler.Dispatch(outer, o =>
+        {
+            CooperativeGemmScheduler.Dispatch(inner, i =>
+                Interlocked.Increment(ref inner_counts[o * inner + i]));
+        });
+        for (int i = 0; i < inner_counts.Length; i++)
+            Assert.Equal(1, inner_counts[i]);
+    }
+
+    [Fact]
+    public void ConcurrentDispatches_AllComplete_CorrectAndUncontaminated()
+    {
+        // The headline property: many threads each run their own dispatch
+        // concurrently; every dispatch must complete with its OWN chunks written
+        // (no cross-job contamination) and the whole thing must not deadlock.
+        int threads = Math.Max(8, Environment.ProcessorCount * 2);
+        const int chunksPerJob = 50;
+        const int itersPerThread = 40;
+        var failures = new ConcurrentBag<string>();
+
+        using var startGate = new Barrier(threads + 1);
+        var workers = new Task[threads];
+        for (int t = 0; t < threads; t++)
+        {
+            int tid = t;
+            workers[t] = Task.Factory.StartNew(() =>
+            {
+                startGate.SignalAndWait();
+                for (int it = 0; it < itersPerThread; it++)
+                {
+                    // Each job writes a value derived from (tid,it) into its own
+                    // buffer, one element per chunk. Cross-job contamination (a chunk
+                    // from another job writing here) or a missed chunk fails the check.
+                    var buf = new int[chunksPerJob];
+                    int stamp = unchecked(tid * 100003 + it * 31 + 1);
+                    CooperativeGemmScheduler.Dispatch(chunksPerJob, c => buf[c] = stamp + c);
+                    for (int c = 0; c < chunksPerJob; c++)
+                        if (buf[c] != stamp + c)
+                        {
+                            failures.Add($"tid {tid} it {it} chunk {c}: {buf[c]} != {stamp + c}");
+                            break;
+                        }
+                }
+            }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+        }
+
+        startGate.SignalAndWait();
+        // WaitAll with a generous timeout so a deadlock fails the test instead of
+        // hanging the run forever.
+        bool finished = Task.WaitAll(workers, TimeSpan.FromSeconds(120));
+        Assert.True(finished, "Concurrent dispatches did not complete within 120s — possible deadlock.");
+        Assert.True(failures.IsEmpty,
+            $"{failures.Count} concurrent dispatches were incorrect/contaminated. " +
+            $"First: {(failures.IsEmpty ? "" : System.Linq.Enumerable.First(failures))}");
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/CooperativeSchedulerGemmIntegrationTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/CooperativeSchedulerGemmIntegrationTests.cs
@@ -90,6 +90,7 @@ public class CooperativeSchedulerGemmIntegrationTests
             int threads = Math.Max(8, Environment.ProcessorCount * 2);
             const int iters = 30;
             var drifts = new ConcurrentBag<string>();
+            using var cts = new CancellationTokenSource();
             using var gate = new Barrier(threads + 1);
             var workers = new Task[threads];
             for (int t = 0; t < threads; t++)
@@ -97,7 +98,12 @@ public class CooperativeSchedulerGemmIntegrationTests
                 workers[t] = Task.Factory.StartNew(() =>
                 {
                     gate.SignalAndWait();
-                    for (int it = 0; it < iters; it++)
+                    // Observe cancellation between GEMMs so that, on a (deadlock) timeout
+                    // below, workers stop promptly and we can quiesce them BEFORE the
+                    // finally restores process-wide flags — otherwise a timed-out worker
+                    // could still be running with the test's globals and leak state into
+                    // later tests.
+                    for (int it = 0; it < iters && !cts.IsCancellationRequested; it++)
                     {
                         var c = new float[m * n];
                         BlasManagedLib.Gemm<float>(a, k, false, b, n, false, c, n, m, n, k);
@@ -108,6 +114,13 @@ public class CooperativeSchedulerGemmIntegrationTests
             }
             gate.SignalAndWait();
             bool done = Task.WaitAll(workers, TimeSpan.FromSeconds(120));
+            if (!done)
+            {
+                // Deadlock suspected: signal workers to stop and give them a moment to
+                // observe it before the finally resets the global flags.
+                cts.Cancel();
+                Task.WaitAll(workers, TimeSpan.FromSeconds(30));
+            }
             Assert.True(done, "Concurrent GEMMs via cooperative scheduler did not finish in 120s — possible deadlock.");
             Assert.True(drifts.IsEmpty,
                 $"{drifts.Count} concurrent GEMMs drifted from the serial reference. " +

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/CooperativeSchedulerGemmIntegrationTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/CooperativeSchedulerGemmIntegrationTests.cs
@@ -1,0 +1,122 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// End-to-end proof that routing the real GEMM dispatch through
+// CooperativeGemmScheduler (the Phase 2 migration seam in StreamingWorkerPool)
+// (a) produces correct results and (b) preserves the deterministic-parallel
+// bit-exactness contract. Toggles the process-wide CooperativeGemmScheduler.Enabled
+// flag, so it runs in the serial collection.
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using AiDotNet.Tensors.Engines.BlasManaged.Pool;
+using AiDotNet.Tensors.Helpers;
+using Xunit;
+using BlasManagedLib = AiDotNet.Tensors.Engines.BlasManaged.BlasManaged;
+using AiDotNet.Tensors.Engines.BlasManaged;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+[Collection("BlasManaged-Stats-Serial")]
+public class CooperativeSchedulerGemmIntegrationTests
+{
+    [Fact]
+    public void Gemm_ThroughCooperativeScheduler_BitIdenticalAcrossThreadCounts()
+    {
+        // Streaming-strategy shape so dispatch flows through StreamingWorkerPool →
+        // (when enabled) CooperativeGemmScheduler. Deterministic mode → managed,
+        // M/N-axis split → bit-exact regardless of how the scheduler interleaves.
+        const int m = 256, n = 256, k = 24;
+        bool beforeDet = BlasProvider.IsDeterministicMode;
+        bool beforeCoop = CooperativeGemmScheduler.Enabled;
+        try
+        {
+            BlasProvider.SetDeterministicMode(true);
+
+            var rng = new Random(7);
+            var a = new float[m * k];
+            var b = new float[k * n];
+            for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+            for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+
+            // Reference: legacy pool.
+            CooperativeGemmScheduler.Enabled = false;
+            var cRef = new float[m * n];
+            BlasManagedLib.Gemm<float>(a, k, false, b, n, false, cRef, n, m, n, k,
+                new BlasOptions<float> { NumThreads = Math.Max(4, Environment.ProcessorCount) });
+
+            // Cooperative scheduler must produce bit-identical output.
+            CooperativeGemmScheduler.Enabled = true;
+            var cCoop = new float[m * n];
+            BlasManagedLib.Gemm<float>(a, k, false, b, n, false, cCoop, n, m, n, k,
+                new BlasOptions<float> { NumThreads = Math.Max(4, Environment.ProcessorCount) });
+
+            for (int i = 0; i < cRef.Length; i++)
+                Assert.Equal(cRef[i], cCoop[i]);
+        }
+        finally
+        {
+            CooperativeGemmScheduler.Enabled = beforeCoop;
+            BlasProvider.SetDeterministicMode(beforeDet);
+        }
+    }
+
+    [Fact]
+    public void ConcurrentGemms_ThroughCooperativeScheduler_StayCorrect()
+    {
+        // Many threads run the same GEMM concurrently while the cooperative scheduler
+        // is enabled; every result must match the single-thread reference (deterministic
+        // mode → bit-exact) with no deadlock. This is the concurrent-inference scenario
+        // the scheduler exists for: the legacy pool would serialize these; here they
+        // interleave on the shared queue.
+        const int m = 128, n = 128, k = 24;
+        bool beforeDet = BlasProvider.IsDeterministicMode;
+        bool beforeCoop = CooperativeGemmScheduler.Enabled;
+        try
+        {
+            BlasProvider.SetDeterministicMode(true);
+            CooperativeGemmScheduler.Enabled = true;
+
+            var rng = new Random(9);
+            var a = new float[m * k];
+            var b = new float[k * n];
+            for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+            for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+
+            var cRef = new float[m * n];
+            BlasManagedLib.Gemm<float>(a, k, false, b, n, false, cRef, n, m, n, k,
+                new BlasOptions<float> { NumThreads = -1 }); // serial reference
+
+            int threads = Math.Max(8, Environment.ProcessorCount * 2);
+            const int iters = 30;
+            var drifts = new ConcurrentBag<string>();
+            using var gate = new Barrier(threads + 1);
+            var workers = new Task[threads];
+            for (int t = 0; t < threads; t++)
+            {
+                workers[t] = Task.Factory.StartNew(() =>
+                {
+                    gate.SignalAndWait();
+                    for (int it = 0; it < iters; it++)
+                    {
+                        var c = new float[m * n];
+                        BlasManagedLib.Gemm<float>(a, k, false, b, n, false, c, n, m, n, k);
+                        for (int i = 0; i < cRef.Length; i++)
+                            if (c[i] != cRef[i]) { drifts.Add($"idx {i}: {c[i]} vs {cRef[i]}"); break; }
+                    }
+                }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+            }
+            gate.SignalAndWait();
+            bool done = Task.WaitAll(workers, TimeSpan.FromSeconds(120));
+            Assert.True(done, "Concurrent GEMMs via cooperative scheduler did not finish in 120s — possible deadlock.");
+            Assert.True(drifts.IsEmpty,
+                $"{drifts.Count} concurrent GEMMs drifted from the serial reference. " +
+                $"First: {(drifts.IsEmpty ? "" : System.Linq.Enumerable.First(drifts))}");
+        }
+        finally
+        {
+            CooperativeGemmScheduler.Enabled = beforeCoop;
+            BlasProvider.SetDeterministicMode(beforeDet);
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/CooperativeSchedulerThroughputBench.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/CooperativeSchedulerThroughputBench.cs
@@ -87,6 +87,7 @@ public class CooperativeSchedulerThroughputBench
 
     private static double RunConcurrent(float[] a, float[] b, int m, int n, int k, int threads, int iters)
     {
+        using var cts = new CancellationTokenSource();
         using var gate = new Barrier(threads + 1);
         var workers = new Task[threads];
         for (int t = 0; t < threads; t++)
@@ -95,15 +96,24 @@ public class CooperativeSchedulerThroughputBench
             {
                 var c = new float[m * n];
                 gate.SignalAndWait();
-                for (int it = 0; it < iters; it++)
+                // Observe cancellation between GEMMs so a scheduler deadlock can't hang
+                // the benchmark indefinitely (which would skip the caller's finally).
+                for (int it = 0; it < iters && !cts.IsCancellationRequested; it++)
                     BlasManagedLib.Gemm<float>(a, k, false, b, n, false, c, n, m, n, k);
             }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
         }
         gate.SignalAndWait();
         var sw = Stopwatch.StartNew();
-        // Start gate already released; measure until all finish.
-        Task.WaitAll(workers);
+        // Bounded wait: on a deadlock, cancel + quiesce and surface it rather than hang.
+        bool done = Task.WaitAll(workers, TimeSpan.FromSeconds(120));
         sw.Stop();
+        if (!done)
+        {
+            cts.Cancel();
+            Task.WaitAll(workers, TimeSpan.FromSeconds(30));
+            throw new Xunit.Sdk.XunitException(
+                $"RunConcurrent({m}x{n}x{k}, {threads} threads) did not finish in 120s — possible scheduler deadlock.");
+        }
         return sw.Elapsed.TotalMilliseconds;
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/CooperativeSchedulerThroughputBench.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/CooperativeSchedulerThroughputBench.cs
@@ -1,0 +1,109 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Phase 2 benchmark: does the cooperative scheduler beat the legacy
+// StreamingWorkerPool under CONCURRENT GEMM dispatch? The legacy pool runs a
+// contended second caller fully serial (#492); the cooperative scheduler lets
+// concurrent dispatches interleave their chunks on a shared queue. This measures
+// wall-clock for N threads each running many small-K (StreamingStrategy) GEMMs,
+// legacy vs cooperative, and reports the ratio.
+//
+// Category=Performance so it's excluded from normal/CI runs (timing-sensitive). The
+// only hard assertion is a generous anti-regression / anti-deadlock guard; the
+// decision to flip CooperativeGemmScheduler.Enabled on is made from the reported
+// numbers, not a brittle perf threshold.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using AiDotNet.Tensors.Engines.BlasManaged.Pool;
+using AiDotNet.Tensors.Helpers;
+using Xunit;
+using Xunit.Abstractions;
+using BlasManagedLib = AiDotNet.Tensors.Engines.BlasManaged.BlasManaged;
+using AiDotNet.Tensors.Engines.BlasManaged;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+[Collection("BlasManaged-Stats-Serial")]
+[Trait("Category", "Performance")]
+public class CooperativeSchedulerThroughputBench
+{
+    private readonly ITestOutputHelper _out;
+    public CooperativeSchedulerThroughputBench(ITestOutputHelper output) => _out = output;
+
+    [Theory]
+    // K<32 → StreamingStrategy → StreamingWorkerPool (the path wired to the
+    // cooperative scheduler). Small vs large M·N to see where each pool wins:
+    // small GEMMs are dominated by per-chunk coordination overhead; large GEMMs
+    // expose the legacy serial-fallback's wasted parallelism under concurrency.
+    [InlineData(256, 256, 24, 200, 0)]    // small, many callers: ~1.5M work/GEMM
+    [InlineData(1024, 1024, 24, 40, 0)]   // large, many callers: ~25M work/GEMM
+    [InlineData(1024, 1024, 24, 60, 2)]   // large, FEW callers — legacy serializes the 2nd to 1 core
+    [InlineData(1024, 1024, 24, 50, 4)]   // large, few callers
+    public void ConcurrentGemm_Cooperative_Vs_Legacy_Throughput(int m, int n, int k, int itersPerThread, int threadsOverride)
+    {
+        int threads = threadsOverride > 0 ? threadsOverride : Math.Max(4, Environment.ProcessorCount);
+
+        bool beforeDet = BlasProvider.IsDeterministicMode;
+        bool beforeCoop = CooperativeGemmScheduler.Enabled;
+        try
+        {
+            BlasProvider.SetDeterministicMode(true); // both paths → managed
+
+            var rng = new Random(123);
+            var a = new float[m * k];
+            var b = new float[k * n];
+            for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+            for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+
+            // Warm up both paths (JIT, pool spin-up, autotune-free deterministic route).
+            CooperativeGemmScheduler.Enabled = false; RunConcurrent(a, b, m, n, k, threads, 5);
+            CooperativeGemmScheduler.Enabled = true; RunConcurrent(a, b, m, n, k, threads, 5);
+
+            CooperativeGemmScheduler.Enabled = false;
+            double legacyMs = RunConcurrent(a, b, m, n, k, threads, itersPerThread);
+
+            CooperativeGemmScheduler.Enabled = true;
+            double coopMs = RunConcurrent(a, b, m, n, k, threads, itersPerThread);
+
+            double speedup = legacyMs / coopMs;
+            _out.WriteLine($"Concurrent GEMM {m}x{n}x{k}, {threads} threads x {itersPerThread} iters:");
+            _out.WriteLine($"  legacy  StreamingWorkerPool : {legacyMs,8:F1} ms");
+            _out.WriteLine($"  cooperative scheduler       : {coopMs,8:F1} ms");
+            _out.WriteLine($"  speedup (legacy/coop)       : {speedup,8:F2}x");
+
+            // Anti-regression / anti-deadlock guard only: cooperative must not be
+            // catastrophically slower. The go/no-go on flipping Enabled is read from
+            // the numbers above, not asserted here.
+            Assert.True(coopMs < legacyMs * 5.0,
+                $"Cooperative scheduler is >5x slower than legacy ({coopMs:F1} vs {legacyMs:F1} ms) — investigate before enabling.");
+        }
+        finally
+        {
+            CooperativeGemmScheduler.Enabled = beforeCoop;
+            BlasProvider.SetDeterministicMode(beforeDet);
+        }
+    }
+
+    private static double RunConcurrent(float[] a, float[] b, int m, int n, int k, int threads, int iters)
+    {
+        using var gate = new Barrier(threads + 1);
+        var workers = new Task[threads];
+        for (int t = 0; t < threads; t++)
+        {
+            workers[t] = Task.Factory.StartNew(() =>
+            {
+                var c = new float[m * n];
+                gate.SignalAndWait();
+                for (int it = 0; it < iters; it++)
+                    BlasManagedLib.Gemm<float>(a, k, false, b, n, false, c, n, m, n, k);
+            }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+        }
+        gate.SignalAndWait();
+        var sw = Stopwatch.StartNew();
+        // Start gate already released; measure until all finish.
+        Task.WaitAll(workers);
+        sw.Stop();
+        return sw.Elapsed.TotalMilliseconds;
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/DeterministicParallelGemmContractTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/DeterministicParallelGemmContractTests.cs
@@ -57,6 +57,11 @@ public class DeterministicParallelGemmContractTests
     private static void AssertBitIdenticalAcrossThreadCounts<T>(int m, int n, int k, int seed)
         where T : unmanaged
     {
+        // Clear any thread-local determinism override first, else SetDeterministicMode
+        // (process-wide) wouldn't guarantee this thread actually runs deterministic
+        // (the override wins). Capture/restore it separately from the process-wide value.
+        bool? beforeThreadDet = BlasProvider.GetThreadLocalDeterministicMode();
+        if (beforeThreadDet is not null) BlasProvider.SetThreadLocalDeterministicMode(null);
         bool beforeDet = BlasProvider.IsDeterministicMode;
         int beforeMax = CpuParallelSettings.MaxDegreeOfParallelism;
         try
@@ -90,7 +95,10 @@ public class DeterministicParallelGemmContractTests
 
                 for (int i = 0; i < c.Length; i++)
                 {
-                    if (!reference[i].Equals(c[i]))
+                    // Bitwise comparison, not value-equality: the contract is BIT-identical.
+                    // .Equals treats +0.0 == -0.0 (and would also mishandle NaN), which could
+                    // mask a deterministic-drift regression.
+                    if (!BitIdentical(reference[i], c[i]))
                     {
                         Assert.Fail(
                             $"Deterministic GEMM drifted with thread-count change " +
@@ -105,9 +113,25 @@ public class DeterministicParallelGemmContractTests
         finally
         {
             BlasProvider.SetDeterministicMode(beforeDet);
+            BlasProvider.SetThreadLocalDeterministicMode(beforeThreadDet);
             CpuParallelSettings.MaxDegreeOfParallelism = beforeMax;
         }
     }
+
+    /// <summary>Bit-for-bit equality (reinterpreted integer bits), so +0.0/-0.0 and
+    /// NaN payloads count as different — the contract is bit-identical, not value-equal.</summary>
+    private static bool BitIdentical<T>(T x, T y) where T : unmanaged
+    {
+        if (typeof(T) == typeof(float))
+            return FloatBits((float)(object)x) == FloatBits((float)(object)y);
+        if (typeof(T) == typeof(double))
+            return BitConverter.DoubleToInt64Bits((double)(object)x) == BitConverter.DoubleToInt64Bits((double)(object)y);
+        throw new NotSupportedException($"Unsupported element type {typeof(T).Name}.");
+    }
+
+    // BitConverter.SingleToInt32Bits is net5+; GetBytes→ToInt32 is the net471-safe
+    // equivalent (allocates a 4-byte buffer, fine for a test).
+    private static int FloatBits(float f) => BitConverter.ToInt32(BitConverter.GetBytes(f), 0);
 
     private static T[] RandomArray<T>(int len, int seed) where T : unmanaged
     {

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/DeterministicParallelGemmContractTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/DeterministicParallelGemmContractTests.cs
@@ -1,0 +1,132 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Pins the deterministic-AND-parallel contract that ManagedBlas relies on to
+// exceed PyTorch (whose deterministic mode sacrifices parallelism). The audit
+// (ManagedBlas determinism plan, Phase 0) established that in deterministic mode
+// EVERY managed GEMM parallel path splits work over disjoint-write output tiles
+// (M / N / MN_2D) and performs each output element's full K-reduction on a single
+// thread in fixed order — so the result is bit-identical no matter how many
+// threads (i.e. how many partitions) run. The non-associative K-axis split is
+// gated off in deterministic mode by AxisSelector.
+//
+// This test makes that contract executable: the SAME GEMM run at NumThreads
+// 1 / 2 / 4 / 16 (which changes the M/N partition boundaries) must produce a
+// BIT-IDENTICAL result. If a future change introduces a cross-thread K-reduction
+// (or a thread-count-dependent partition of the reduction) into a
+// deterministic-mode path, the exact-equality assertion fails.
+//
+// Scope: bit-exact across THREAD COUNTS on one machine/ISA. Cross-ISA bit-exact
+// (AVX-512 vs AVX2 vs scalar vs Neon, which reduce at different vector widths) is
+// out of scope — PyTorch makes no such guarantee either.
+
+using System;
+using Xunit;
+using BlasManagedLib = AiDotNet.Tensors.Engines.BlasManaged.BlasManaged;
+using AiDotNet.Tensors.Engines.BlasManaged;
+using AiDotNet.Tensors.Helpers;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+// Toggles process-wide deterministic mode; serialize against the other
+// determinism-sensitive tests.
+[Collection("BlasManaged-Stats-Serial")]
+public class DeterministicParallelGemmContractTests
+{
+    // Partition counts to compare. 1 forces the serial path (AxisSelector → None);
+    // 2/4/16 force progressively finer M/N partitions. All must agree bit-for-bit.
+    private static readonly int[] ThreadCounts = { 1, 2, 4, 16 };
+
+    public static TheoryData<int, int, int> Shapes => new()
+    {
+        // (m, n, k) covering the strategy regimes the audit enumerated:
+        { 128, 128, 16 },   // small-K  → StreamingStrategy (no packing)
+        { 256, 256, 256 },  // square   → PackBothStrategy (M-axis / 2D)
+        { 512, 16,  512 },  // tall-skinny (N small) → M-axis
+        { 16,  512, 256 },  // M-small / N-large → N-axis
+    };
+
+    [Theory]
+    [MemberData(nameof(Shapes))]
+    public void Gemm_Float_BitIdentical_AcrossThreadCounts(int m, int n, int k)
+        => AssertBitIdenticalAcrossThreadCounts<float>(m, n, k, seed: 11);
+
+    [Theory]
+    [MemberData(nameof(Shapes))]
+    public void Gemm_Double_BitIdentical_AcrossThreadCounts(int m, int n, int k)
+        => AssertBitIdenticalAcrossThreadCounts<double>(m, n, k, seed: 22);
+
+    private static void AssertBitIdenticalAcrossThreadCounts<T>(int m, int n, int k, int seed)
+        where T : unmanaged
+    {
+        bool beforeDet = BlasProvider.IsDeterministicMode;
+        int beforeMax = CpuParallelSettings.MaxDegreeOfParallelism;
+        try
+        {
+            // Deterministic mode is the contract under test (it excludes the
+            // non-associative K-axis split). Ensure the executor is actually
+            // allowed to run multi-threaded so the parallel partitions execute
+            // in parallel (not collapsed to serial by a pinned MaxDegree).
+            BlasProvider.SetDeterministicMode(true);
+            CpuParallelSettings.MaxDegreeOfParallelism = Math.Max(4, Environment.ProcessorCount);
+
+            var a = RandomArray<T>(m * k, seed);
+            var b = RandomArray<T>(k * n, seed + 1);
+
+            T[]? reference = null;
+            int referenceThreads = 0;
+            foreach (int threads in ThreadCounts)
+            {
+                var c = new T[m * n];
+                // NumThreads drives `procs` inside the strategies → the M/N
+                // partition boundaries. 1 → serial; >1 → that many partitions.
+                var options = new BlasOptions<T> { NumThreads = threads };
+                BlasManagedLib.Gemm<T>(a, k, false, b, n, false, c, n, m, n, k, options);
+
+                if (reference is null)
+                {
+                    reference = c;
+                    referenceThreads = threads;
+                    continue;
+                }
+
+                for (int i = 0; i < c.Length; i++)
+                {
+                    if (!reference[i].Equals(c[i]))
+                    {
+                        Assert.Fail(
+                            $"Deterministic GEMM drifted with thread-count change " +
+                            $"({referenceThreads} → {threads}) for {typeof(T).Name} " +
+                            $"[{m}x{n}x{k}] at index {i}: {reference[i]} vs {c[i]}. " +
+                            "A deterministic-mode path introduced a thread-count-dependent " +
+                            "reduction (cross-thread K split?) — the disjoint-write contract broke.");
+                    }
+                }
+            }
+        }
+        finally
+        {
+            BlasProvider.SetDeterministicMode(beforeDet);
+            CpuParallelSettings.MaxDegreeOfParallelism = beforeMax;
+        }
+    }
+
+    private static T[] RandomArray<T>(int len, int seed) where T : unmanaged
+    {
+        var rng = new Random(seed);
+        var arr = new T[len];
+        if (typeof(T) == typeof(float))
+        {
+            var f = (float[])(object)arr;
+            for (int i = 0; i < len; i++) f[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            var d = (double[])(object)arr;
+            for (int i = 0; i < len; i++) d[i] = rng.NextDouble() * 2.0 - 1.0;
+        }
+        else
+        {
+            throw new NotSupportedException($"Unsupported element type {typeof(T).Name}.");
+        }
+        return arr;
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/PrefersManagedCacheTest.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/PrefersManagedCacheTest.cs
@@ -22,13 +22,20 @@ public class PrefersManagedCacheTest
             System.IO.Path.GetTempPath(),
             $"prefers-managed-cache-test-{Guid.NewGuid():N}.json");
         PrefersManagedCache.Clear();
+        // Force a clean baseline for the direct-cache tests in this class. NOTE: the
+        // PRODUCT default of AutotuneRouting is now `true` (see BlasManaged.AutotuneRouting
+        // — managed deterministic-parallel + non-deterministic best-of is the intended
+        // CPU GEMM behavior); this ctor resets it to false so per-test setup is explicit.
         BlasManagedLib.AutotuneRouting = false;
         BlasManagedLib.PreferManaged = false;
     }
 
     [Fact]
-    public void Default_AutotuneRouting_Is_False()
+    public void Ctor_ResetsAutotuneRouting_ForTestIsolation()
     {
+        // The ctor forces AutotuneRouting=false so the direct PrefersManaged tests
+        // start from a known state. (The product default is true — asserting that here
+        // is impossible because the ctor has already mutated the static.)
         Assert.False(BlasManagedLib.AutotuneRouting);
     }
 
@@ -64,6 +71,13 @@ public class PrefersManagedCacheTest
     {
         PrefersManagedCache.Clear();
         BlasManagedLib.AutotuneRouting = true;
+        // Autotune routing is a NON-deterministic-mode feature: deterministic mode
+        // (the default) forces managed dispatch BEFORE the timing-based autotune is
+        // consulted (BlasProvider.ShouldRouteManaged), because a measurement-chosen
+        // kernel would not be bit-reproducible. Drop into non-deterministic mode so
+        // the autotune cache is actually exercised.
+        bool beforeDet = BlasProvider.IsDeterministicMode;
+        BlasProvider.SetDeterministicMode(false);
         try
         {
             const int M = 64, N = 64, K = 64;
@@ -88,6 +102,7 @@ public class PrefersManagedCacheTest
         finally
         {
             BlasManagedLib.AutotuneRouting = false;
+            BlasProvider.SetDeterministicMode(beforeDet);
         }
     }
 
@@ -97,21 +112,32 @@ public class PrefersManagedCacheTest
         BlasManagedLib.AutotuneRouting = false;
         BlasManagedLib.PreferManaged = false;
         PrefersManagedCache.Clear();
+        // Must be non-deterministic: deterministic mode forces managed dispatch
+        // regardless of AutotuneRouting (ShouldRouteManaged), so "autotune off → native
+        // path" only holds when determinism isn't forcing managed.
+        bool beforeDet = BlasProvider.IsDeterministicMode;
+        BlasProvider.SetDeterministicMode(false);
+        try
+        {
+            const int M = 32, N = 32, K = 32;
+            var rng = new Random(42);
+            var a = new float[M * K];
+            var b = new float[K * N];
+            var c = new float[M * N];
+            for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+            for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
 
-        const int M = 32, N = 32, K = 32;
-        var rng = new Random(42);
-        var a = new float[M * K];
-        var b = new float[K * N];
-        var c = new float[M * N];
-        for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
-        for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+            bool ok = BlasProvider.TryGemmEx(M, N, K, a, 0, K, false, b, 0, N, false, c, 0, N);
 
-        bool ok = BlasProvider.TryGemmEx(M, N, K, a, 0, K, false, b, 0, N, false, c, 0, N);
-
-        // With autotune off, cache must NOT be touched.
-        Assert.Equal(0, PrefersManagedCache.Count);
-        // ok matches native availability (same as pre-F3 behavior).
-        Assert.Equal(BlasProvider.IsAvailable, ok);
+            // With autotune off (and non-deterministic), cache must NOT be touched.
+            Assert.Equal(0, PrefersManagedCache.Count);
+            // ok matches native availability (same as pre-F3 behavior).
+            Assert.Equal(BlasProvider.IsAvailable, ok);
+        }
+        finally
+        {
+            BlasProvider.SetDeterministicMode(beforeDet);
+        }
     }
 
     [Fact]

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/RoutingShimTest.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/RoutingShimTest.cs
@@ -149,20 +149,41 @@ public class RoutingShimTest
     [Fact]
     public void TryGemm_With_PreferManaged_False_Goes_Through_Native_Path()
     {
-        // This is the default behavior; just confirm TryGemm still works when
-        // the toggle is off (no regression to the existing native path).
-        const int M = 32, N = 32, K = 32;
-        var rng = new Random(42);
-        var a = new float[M * K];
-        var b = new float[K * N];
-        var c = new float[M * N];
-        for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
-        for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+        // "PreferManaged=false → native" only holds when nothing ELSE forces managed
+        // first. BlasProvider.ShouldRouteManaged routes managed when (a) PreferManaged,
+        // (b) deterministic mode — the parallel-and-reproducible kernel, default ON — or
+        // (c) AutotuneRouting (default ON) picks managed per-shape. To genuinely exercise
+        // the native path, pin determinism AND autotune off; then ok must reflect native
+        // availability (true with native loaded, false without). Capture/restore the
+        // thread-local determinism override separately from the process-wide value.
+        bool? beforeThreadDet = BlasProvider.GetThreadLocalDeterministicMode();
+        if (beforeThreadDet is not null) BlasProvider.SetThreadLocalDeterministicMode(null);
+        bool beforeDet = BlasProvider.IsDeterministicMode;
+        bool beforeAutotune = BlasManagedLib.AutotuneRouting;
+        try
+        {
+            BlasProvider.SetDeterministicMode(false);
+            BlasManagedLib.AutotuneRouting = false;
+            BlasManagedLib.PreferManaged = false;
 
-        BlasManagedLib.PreferManaged = false;
-        bool ok = BlasProvider.TryGemm(M, N, K, a, 0, K, b, 0, N, c, 0, N);
-        // If native is available, ok=true; if not, ok=false. Both are acceptable —
-        // we're just confirming the default path is unchanged.
-        Assert.Equal(BlasProvider.IsAvailable, ok);
+            const int M = 32, N = 32, K = 32;
+            var rng = new Random(42);
+            var a = new float[M * K];
+            var b = new float[K * N];
+            var c = new float[M * N];
+            for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+            for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+
+            bool ok = BlasProvider.TryGemm(M, N, K, a, 0, K, b, 0, N, c, 0, N);
+            // Native path: ok=true when native is loaded, false otherwise.
+            Assert.Equal(BlasProvider.IsAvailable, ok);
+        }
+        finally
+        {
+            BlasManagedLib.AutotuneRouting = beforeAutotune;
+            BlasProvider.SetDeterministicMode(beforeDet);
+            BlasProvider.SetThreadLocalDeterministicMode(beforeThreadDet);
+            BlasManagedLib.PreferManaged = false;
+        }
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/RoutingShimTest.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/RoutingShimTest.cs
@@ -147,23 +147,24 @@ public class RoutingShimTest
     }
 
     [Fact]
-    public void TryGemm_With_PreferManaged_False_Goes_Through_Native_Path()
+    public void TryGemm_DefaultDeterministicMode_RoutesToManaged_AndProducesCorrectOutput()
     {
-        // "PreferManaged=false → native" only holds when nothing ELSE forces managed
-        // first. BlasProvider.ShouldRouteManaged routes managed when (a) PreferManaged,
-        // (b) deterministic mode — the parallel-and-reproducible kernel, default ON — or
-        // (c) AutotuneRouting (default ON) picks managed per-shape. To genuinely exercise
-        // the native path, pin determinism AND autotune off; then ok must reflect native
-        // availability (true with native loaded, false without). Capture/restore the
-        // thread-local determinism override separately from the process-wide value.
+        // Best-practice default config: deterministic mode (the managed
+        // parallel-AND-reproducible kernel — what PyTorch's deterministic mode can't
+        // offer). BlasProvider.ShouldRouteManaged routes deterministic GEMM to the
+        // managed kernel regardless of native availability, so PreferManaged=false
+        // here STILL goes managed — and TryGemm returns true even on a no-native
+        // runner. This replaces an obsolete pre-Phase-1 test that asserted
+        // "PreferManaged=false → native" (no longer the contract). The native path
+        // for the NON-deterministic mode is covered by
+        // NativeBlasNonDeterministicConcurrencyTests; we do not disable best-practice
+        // modes here to chase it.
         bool? beforeThreadDet = BlasProvider.GetThreadLocalDeterministicMode();
         if (beforeThreadDet is not null) BlasProvider.SetThreadLocalDeterministicMode(null);
         bool beforeDet = BlasProvider.IsDeterministicMode;
-        bool beforeAutotune = BlasManagedLib.AutotuneRouting;
         try
         {
-            BlasProvider.SetDeterministicMode(false);
-            BlasManagedLib.AutotuneRouting = false;
+            BlasProvider.SetDeterministicMode(true); // ensure the default best-practice mode regardless of test order
             BlasManagedLib.PreferManaged = false;
 
             const int M = 32, N = 32, K = 32;
@@ -175,12 +176,24 @@ public class RoutingShimTest
             for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
 
             bool ok = BlasProvider.TryGemm(M, N, K, a, 0, K, b, 0, N, c, 0, N);
-            // Native path: ok=true when native is loaded, false otherwise.
-            Assert.Equal(BlasProvider.IsAvailable, ok);
+            // Deterministic mode routes to the managed kernel, which always succeeds —
+            // independent of whether native BLAS is loaded.
+            Assert.True(ok, "Deterministic-mode TryGemm must route to managed and return true");
+
+            // And the result is a correct GEMM (within FP32 bound of FP64 ground truth).
+            const double maxAbsErr = 1.6e-5; // 2 · K · eps_fp32
+            double maxErr = 0;
+            for (int i = 0; i < M; i++)
+                for (int j = 0; j < N; j++)
+                {
+                    double sum = 0;
+                    for (int kk = 0; kk < K; kk++) sum += (double)a[i * K + kk] * b[kk * N + j];
+                    maxErr = Math.Max(maxErr, Math.Abs(sum - c[i * N + j]));
+                }
+            Assert.True(maxErr < maxAbsErr, $"Managed deterministic GEMM error vs FP64 truth: {maxErr:G6} (bound {maxAbsErr})");
         }
         finally
         {
-            BlasManagedLib.AutotuneRouting = beforeAutotune;
             BlasProvider.SetDeterministicMode(beforeDet);
             BlasProvider.SetThreadLocalDeterministicMode(beforeThreadDet);
             BlasManagedLib.PreferManaged = false;


### PR DESCRIPTION
## What

First three phases of making **ManagedBlas** the CPU GEMM path that matches *and exceeds* PyTorch on the two axes where PyTorch is weak: **deterministic-and-parallel** execution, and **cooperative concurrent** dispatch. (Plan: `docs/managed-blas-determinism.md` + the approved roadmap.)

## Phase 0 — pin the deterministic-parallel contract
`DeterministicParallelGemmContractTests`: the same GEMM run at 1/2/4/16 threads must be **bit-identical** (float + double, four shape regimes). Audit confirmed every deterministic-mode parallel path (`StreamingStrategy` M/N, `PackBothStrategy` M/2D-grid, `PackAOnlyStrategy` N, `MachineKernelGemm` M-stripe) splits over **disjoint output tiles** with each element's full K-reduction on one thread; the non-associative K-axis is gated off in deterministic mode by `AxisSelector`. No production change — makes the contract executable.

## Phase 1 — deterministic-parallel default + non-deterministic autotune
`BlasProvider.ShouldRouteManaged` centralizes managed-vs-native routing for all 6 `TryGemm`/`TryGemmEx` overloads:
1. `PreferManaged` → managed (supply-chain).
2. **Deterministic mode → managed** — parallel **and** bit-reproducible. So the **default mode is now deterministic *and* parallel**, which PyTorch''s deterministic mode cannot do. Deterministic mode never consults the timing-based autotune (a measured choice wouldn''t be reproducible).
3. `AutotuneRouting` (now default **true**) → non-deterministic mode only: per-shape best-of managed/native via `PrefersManagedCache`.
4. else → native.

Full suite under the new default: **5926 pass, no crash, no new failures** (lone failure is a pre-existing parallel-isolation flaky that passes in isolation). Docs: `docs/managed-blas-determinism.md`.

## Phase 2 — cooperative work-sharing scheduler
`CooperativeGemmScheduler`: one process-wide pool of `cores-1` parked workers draining one shared queue; each dispatch enqueues its chunks under a countdown and the **calling thread participates** (drains the shared queue) until its own job finishes. Concurrent dispatches interleave instead of serializing (legacy `StreamingWorkerPool` #492) or oversubscribing. Wired into `StreamingWorkerPool` behind `CooperativeGemmScheduler.Enabled` (**default off**).

Benchmark (Ryzen 9 3950X, deterministic mode):

| callers x shape | legacy | cooperative |
|---|---|---|
| 2 x 1024²·K24 (large) | 238 ms | **112 ms — 2.14×** |
| 4 x 1024²·K24 | 130 ms | 126 ms |
| 32 x 256²·K24 (small) | 162 ms | 127 ms |
| 32 x 1024²·K24 | 1049 ms | 1088 ms |

→ big win for **few concurrent large GEMMs** (legacy serializes extra callers to one core each), parity elsewhere, no loss. Kept default-off pending the maintainer''s call on the default.

## Tests
All green on **net10.0 and net471**: the contract suite, the routing/determinism suites, the scheduler unit + GEMM-integration tests, and the full non-perf suite. Benchmark is `Category=Performance` (excluded from CI).

## Not in this PR (follow-ups)
- Flipping `CooperativeGemmScheduler.Enabled` default-on + retiring the legacy pools (pending the benchmark-driven decision).
- **Phase 3 (OpenBLAS removal)** — depends on PR #491 (the native-entry gate) merging first; that gate is the transitional safety net for the non-deterministic native path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)