### PR TITLE
fix(gpu): complete kernel before releasing transient element-wise inputs

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -1281,6 +1281,29 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         return new OwnedBuffer(backend.AllocateBuffer(size), ownsBuffer: true);
     }
 
+    // An element-wise kernel launch is asynchronous, but FinishGpuOp only defers the *download* of
+    // the output — any freshly-uploaded input buffer (OwnsBuffer == true) is released by the
+    // caller's `using` block the moment the dispatch method returns. Because the command queue is
+    // not flushed until the deferred download (or a later op) forces it, the queued kernel can run
+    // *after* that buffer has been freed and its pooled GPU memory handed to another allocation —
+    // so the kernel reads stale/zeroed memory and writes an all-zero result (the GAMLSS-through-
+    // AiModelBuilder corruption: every Engine.Subtract/Add/Multiply/Divide on a fresh Vector came
+    // back as zeros). Cached inputs (OwnsBuffer == false — the neural-network hot path where
+    // weights/activations persist in the activation cache) are never disposed here, so they carry
+    // no such hazard and we skip the otherwise pipeline-stalling sync. Only force completion when a
+    // transient input is in play, keeping its memory valid until the kernel has consumed it.
+    private static void SyncIfInputsTransient(IDirectGpuBackend backend, OwnedBuffer a, OwnedBuffer b)
+    {
+        if (a.OwnsBuffer || b.OwnsBuffer)
+            backend.Synchronize();
+    }
+
+    private static void SyncIfInputsTransient(IDirectGpuBackend backend, OwnedBuffer a)
+    {
+        if (a.OwnsBuffer)
+            backend.Synchronize();
+    }
+
     /// <summary>
     /// Completes a GPU operation by either deferring the download (when GpuScope is active)
     /// or downloading immediately. When deferred, the GPU buffer stays resident and the CPU
@@ -1641,6 +1664,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             {
                 fp16Input?.Dispose();
             }
+            SyncIfInputsTransient(backend, bufferA);
             return FinishGpuOp<T>(backend, bufferB, input.Length);
         }
         catch
@@ -1827,6 +1851,10 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 fp16A?.Dispose();
                 fp16B?.Dispose();
             }
+            // Keep transient inputs valid until the async kernel consumes them — see
+            // SyncIfInputsTransient. (The fp16 scratch buffers are already disposed above; the
+            // hazard is the fp32 bufferA/bufferB that the `using` releases when this returns.)
+            SyncIfInputsTransient(backend, bufferA, bufferB);
             return FinishGpuOp<T>(backend, bufferC, left.Length);
         }
         catch
@@ -1949,6 +1977,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             try
             {
                 op(backend, bufferA.Buffer, bufferB.Buffer, input.Length);
+                SyncIfInputsTransient(backend, bufferA);
                 return FinishGpuOp<T>(backend, bufferB, input.Length);
             }
             catch
@@ -1979,6 +2008,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             try
             {
                 op(backend, bufferA.Buffer, bufferB.Buffer, bufferC.Buffer, left.Length);
+                SyncIfInputsTransient(backend, bufferA, bufferB);
                 return FinishGpuOp<T>(backend, bufferC, left.Length);
             }
             catch
@@ -2010,6 +2040,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             try
             {
                 op(backend, bufferA.Buffer, bufferB.Buffer, ToFloatScalar(scalar), input.Length);
+                SyncIfInputsTransient(backend, bufferA);
                 return FinishGpuOp<T>(backend, bufferB, input.Length);
             }
             catch
@@ -2043,6 +2074,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             try
             {
                 op(backend, bufferA.Buffer, bufferB.Buffer, bufferC.Buffer, left.Length);
+                SyncIfInputsTransient(backend, bufferA, bufferB);
                 return FinishGpuOp<T>(backend, bufferC, left.Length);
             }
             catch
@@ -2073,6 +2105,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             try
             {
                 op(backend, bufferA.Buffer, bufferB.Buffer, ToFloatScalar(scalar), input.Length);
+                SyncIfInputsTransient(backend, bufferA);
                 return FinishGpuOp<T>(backend, bufferB, input.Length);
             }
             catch

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuCorrectnessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuCorrectnessTests.cs
@@ -341,5 +341,61 @@ public sealed class GpuCpuCorrectnessTests : IDisposable
         var b = Rand(26, batch, k, n);
         AssertGpuMatchesCpu(_gpu.BatchMatMul(a, b), _cpu.BatchMatMul(a, b), $"BatchMatMul[{batch}x{m}x{k}*{batch}x{k}x{n}]");
     }
+
+    // ----- Element-wise VECTOR ops (Add / Subtract / Multiply / Divide) -----
+    // Regression guard: the deferred-download path released its input buffers
+    // (the `using var bufferA/bufferB` in TryRunBinary) before the queued
+    // element-wise kernel ever ran, so the kernel read freed/recycled buffers
+    // and the result came back all-zeros. The sizes deliberately include values
+    // that are NOT multiples of 4 (the float4 kernel's scalar-tail path) and
+    // small sizes < one work-group.
+    private static Vector<float> RandVec(int seed, int n)
+    {
+        var rng = new Random(seed);
+        var data = new float[n];
+        for (int i = 0; i < n; i++) data[i] = (float)(rng.NextDouble() * 2.0 - 1.0) + 1.5f; // keep away from 0 for divide
+        return new Vector<float>(data);
+    }
+
+    private void AssertVecGpuMatchesCpu(Vector<float> gpu, Vector<float> cpu, string op)
+    {
+        Assert.Equal(cpu.Length, gpu.Length);
+        double m = 0;
+        for (int i = 0; i < cpu.Length; i++)
+        {
+            float x = gpu[i], y = cpu[i];
+            Assert.False(float.IsNaN(x) || float.IsInfinity(x), $"{op}: GPU produced non-finite value {x} at index {i}");
+            double e = Math.Abs((double)x - y);
+            if (e > m) m = e;
+        }
+        Assert.True(m < Tol, $"{op}: GPU vs CPU max_abs_err {m:E3} exceeded tolerance {Tol:E3}");
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    [InlineData(5)]
+    [InlineData(7)]
+    [InlineData(8)]
+    [InlineData(15)]
+    [InlineData(16)]
+    [InlineData(17)]
+    [InlineData(70)]
+    [InlineData(100)]
+    [InlineData(256)]
+    [InlineData(257)]
+    public void ElementwiseVectorOps_Gpu_Matches_Cpu(int n)
+    {
+        if (!EnsureGpuReady()) return;
+        var a = RandVec(101, n);
+        var b = RandVec(202, n);
+
+        AssertVecGpuMatchesCpu((Vector<float>)_gpu.Add(a, b), (Vector<float>)_cpu.Add(a, b), $"Add[{n}]");
+        AssertVecGpuMatchesCpu((Vector<float>)_gpu.Subtract(a, b), (Vector<float>)_cpu.Subtract(a, b), $"Subtract[{n}]");
+        AssertVecGpuMatchesCpu((Vector<float>)_gpu.Multiply(a, b), (Vector<float>)_cpu.Multiply(a, b), $"Multiply[{n}]");
+        AssertVecGpuMatchesCpu((Vector<float>)_gpu.Divide(a, b), (Vector<float>)_cpu.Divide(a, b), $"Divide[{n}]");
+    }
 }
 #endif


### PR DESCRIPTION
## Problem

Every `Engine.Add` / `Subtract` / `Multiply` / `Divide` on a **freshly-created `Vector<T>`** returned **all zeros** on the GPU engine, while `DotProduct` and `GEMM` worked. This silently corrupted any model trained through `AiModelBuilder`'s auto-detected GPU path (e.g. GAMLSS → constant predictions / R²≈0; direct CPU training of the same model gives R²=1.0).

## Root cause (engine-layer, all backends — not OpenCL-specific)

The element-wise dispatch helpers in `DirectGpuTensorEngine` (`TryRunBinary`, `TryRunUnary`, `TryRunScalar`, and their span/tensor variants) enqueue the kernel **asynchronously**, but `FinishGpuOp` only defers the **output download**. Any freshly-uploaded input buffer (`OwnedBuffer.OwnsBuffer == true`) is released by the caller's `using` block the instant the dispatch method returns. The command queue isn't flushed until the deferred download (or a later op) forces it, so the queued kernel could execute **after** its input buffer had been freed and the pooled GPU memory recycled — reading stale/zeroed memory.

This is in the **backend-agnostic engine dispatch layer**, so it affects every backend that defers downloads. It reproduced on OpenCL (AMD gfx1012); `DotProduct`/`GEMM` were unaffected only because they already `Synchronize()` before reading. All six backends (CUDA, HIP, Metal, OpenCL, Vulkan, WebGpu) implement `IDirectGpuBackend.Synchronize()` — WebGpu's is a no-op because it submits synchronously, so the hazard can't arise there.

## Fix

`SyncIfInputsTransient(backend, a[, b])` — after the kernel launch, force completion **only when an input was a transient upload** (`OwnsBuffer == true`). Cached inputs (`OwnsBuffer == false` — the neural-network hot path where weights/activations persist in the activation cache) are never disposed here, so they skip the sync and keep their async pipelining. The output download stays deferred so chained GPU ops still reuse the cached buffer. Applied consistently across all affected helpers (array + span + tensor; binary/unary/scalar).

## Performance (re: regression check)

The sync fires **only on the previously-broken transient-input path**, never on the NN hot path:
- **Hot path** (cached GPU-resident operands — NN training/inference): `GetOrAllocateBuffer` returns `OwnsBuffer == false`, so `SyncIfInputsTransient` is a no-op (one branch check). Measured `TensorAdd` hot-path throughput ≈ **589 µs/op**, unchanged from main.
- **Transient path** (fresh upload): ≈ 881 µs/op, dominated by the upload+download themselves; the added sync is largely redundant with the download's own blocking read.

This conditional approach is strictly more targeted than the existing **unconditional** `Synchronize()` call sites in the engine (e.g. `TensorSum`/`TensorMaxValue`/`TensorMinValue` sync after every upload).

## Tests

`ElementwiseVectorOps_Gpu_Matches_Cpu` in `GpuCpuCorrectnessTests` pins GPU `Add`/`Subtract`/`Multiply`/`Divide` to the CPU reference across 14 sizes (incl. non-multiples-of-4 and sub-workgroup sizes). Verified it fails (all-zeros) without the fix and passes with it. Full `Engines.DirectGpu` suite (**656 tests**) passes on a real OpenCL GPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)