### PR TITLE
fix(gpu): materialize element-wise vector/matrix output (real fix for #496 zeros)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -1281,27 +1281,35 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         return new OwnedBuffer(backend.AllocateBuffer(size), ownsBuffer: true);
     }
 
-    // An element-wise kernel launch is asynchronous, but FinishGpuOp only defers the *download* of
-    // the output — any freshly-uploaded input buffer (OwnsBuffer == true) is released by the
-    // caller's `using` block the moment the dispatch method returns. Because the command queue is
-    // not flushed until the deferred download (or a later op) forces it, the queued kernel can run
-    // *after* that buffer has been freed and its pooled GPU memory handed to another allocation —
-    // so the kernel reads stale/zeroed memory and writes an all-zero result (the GAMLSS-through-
-    // AiModelBuilder corruption: every Engine.Subtract/Add/Multiply/Divide on a fresh Vector came
-    // back as zeros). Cached inputs (OwnsBuffer == false — the neural-network hot path where
-    // weights/activations persist in the activation cache) are never disposed here, so they carry
-    // no such hazard and we skip the otherwise pipeline-stalling sync. Only force completion when a
-    // transient input is in play, keeping its memory valid until the kernel has consumed it.
-    private static void SyncIfInputsTransient(IDirectGpuBackend backend, OwnedBuffer a, OwnedBuffer b)
+    // Synchronously download a GPU op's output and free its buffer. Used by the array/span-based
+    // element-wise helpers — the ones whose result is wrapped in a Vector<T> or Matrix<T>. Those
+    // containers' constructors COPY the supplied array (VectorBase(IEnumerable) does values.ToArray()),
+    // which makes the deferred-download path (FinishGpuOp) unusable for them: FinishGpuOp returns an
+    // *uninitialized* array and registers a materializer keyed on that array, but the Vector/Matrix
+    // ctor copies the still-zero contents into its own buffer and the later materialization updates
+    // the orphaned original — leaving the caller holding all-zeros. That was the
+    // Engine.Subtract/Add/Multiply/Divide-on-a-fresh-Vector-returns-zeros bug that silently
+    // corrupted GAMLSS (and any model) trained through AiModelBuilder's auto-detected GPU path.
+    // Materializing here costs nothing extra for these ops: the result goes straight to a CPU-side
+    // Vector/Matrix, so there is no GPU-resident reuse to preserve (unlike the Tensor<T> path, which
+    // keeps the deferred FinishGpuOp — Tensor<T> is deferred-materialization-aware and wraps by ref).
+    private static T[] FinishGpuOpImmediate<T>(IDirectGpuBackend backend, OwnedBuffer outputBuffer, int elementCount)
     {
-        if (a.OwnsBuffer || b.OwnsBuffer)
+        try
+        {
             backend.Synchronize();
-    }
-
-    private static void SyncIfInputsTransient(IDirectGpuBackend backend, OwnedBuffer a)
-    {
-        if (a.OwnsBuffer)
-            backend.Synchronize();
+            float[] floatData = backend.DownloadBuffer(outputBuffer.Buffer);
+            var converted = DirectGpuEngine.FromFloatArray<T>(floatData);
+            if (converted.Length == elementCount)
+                return converted;
+            var result = new T[elementCount];
+            Array.Copy(converted, result, Math.Min(converted.Length, elementCount));
+            return result;
+        }
+        finally
+        {
+            outputBuffer.Dispose();
+        }
     }
 
     /// <summary>
@@ -1664,7 +1672,6 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             {
                 fp16Input?.Dispose();
             }
-            SyncIfInputsTransient(backend, bufferA);
             return FinishGpuOp<T>(backend, bufferB, input.Length);
         }
         catch
@@ -1851,10 +1858,6 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 fp16A?.Dispose();
                 fp16B?.Dispose();
             }
-            // Keep transient inputs valid until the async kernel consumes them — see
-            // SyncIfInputsTransient. (The fp16 scratch buffers are already disposed above; the
-            // hazard is the fp32 bufferA/bufferB that the `using` releases when this returns.)
-            SyncIfInputsTransient(backend, bufferA, bufferB);
             return FinishGpuOp<T>(backend, bufferC, left.Length);
         }
         catch
@@ -1977,8 +1980,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             try
             {
                 op(backend, bufferA.Buffer, bufferB.Buffer, input.Length);
-                SyncIfInputsTransient(backend, bufferA);
-                return FinishGpuOp<T>(backend, bufferB, input.Length);
+                return FinishGpuOpImmediate<T>(backend, bufferB, input.Length);
             }
             catch
             {
@@ -2008,8 +2010,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             try
             {
                 op(backend, bufferA.Buffer, bufferB.Buffer, bufferC.Buffer, left.Length);
-                SyncIfInputsTransient(backend, bufferA, bufferB);
-                return FinishGpuOp<T>(backend, bufferC, left.Length);
+                return FinishGpuOpImmediate<T>(backend, bufferC, left.Length);
             }
             catch
             {
@@ -2040,8 +2041,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             try
             {
                 op(backend, bufferA.Buffer, bufferB.Buffer, ToFloatScalar(scalar), input.Length);
-                SyncIfInputsTransient(backend, bufferA);
-                return FinishGpuOp<T>(backend, bufferB, input.Length);
+                return FinishGpuOpImmediate<T>(backend, bufferB, input.Length);
             }
             catch
             {
@@ -2074,8 +2074,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             try
             {
                 op(backend, bufferA.Buffer, bufferB.Buffer, bufferC.Buffer, left.Length);
-                SyncIfInputsTransient(backend, bufferA, bufferB);
-                return FinishGpuOp<T>(backend, bufferC, left.Length);
+                return FinishGpuOpImmediate<T>(backend, bufferC, left.Length);
             }
             catch
             {
@@ -2105,8 +2104,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             try
             {
                 op(backend, bufferA.Buffer, bufferB.Buffer, ToFloatScalar(scalar), input.Length);
-                SyncIfInputsTransient(backend, bufferA);
-                return FinishGpuOp<T>(backend, bufferB, input.Length);
+                return FinishGpuOpImmediate<T>(backend, bufferB, input.Length);
             }
             catch
             {

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuCorrectnessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuCorrectnessTests.cs
@@ -392,10 +392,26 @@ public sealed class GpuCpuCorrectnessTests : IDisposable
         var a = RandVec(101, n);
         var b = RandVec(202, n);
 
-        AssertVecGpuMatchesCpu((Vector<float>)_gpu.Add(a, b), (Vector<float>)_cpu.Add(a, b), $"Add[{n}]");
-        AssertVecGpuMatchesCpu((Vector<float>)_gpu.Subtract(a, b), (Vector<float>)_cpu.Subtract(a, b), $"Subtract[{n}]");
-        AssertVecGpuMatchesCpu((Vector<float>)_gpu.Multiply(a, b), (Vector<float>)_cpu.Multiply(a, b), $"Multiply[{n}]");
-        AssertVecGpuMatchesCpu((Vector<float>)_gpu.Divide(a, b), (Vector<float>)_cpu.Divide(a, b), $"Divide[{n}]");
+        // CRITICAL: dispatch through the IEngine interface. Add/Subtract/Multiply/Divide are
+        // EXPLICIT interface implementations on DirectGpuTensorEngine — calling them on the
+        // concrete type resolves to the inherited CpuEngine method and silently bypasses the GPU
+        // path entirely. The original element-wise-returns-zeros bug only manifests via IEngine.
+        IEngine g = _gpu;
+        IEngine c = _cpu;
+
+        AssertVecGpuMatchesCpu((Vector<float>)g.Add(a, b), (Vector<float>)c.Add(a, b), $"Add[{n}]");
+        AssertVecGpuMatchesCpu((Vector<float>)g.Subtract(a, b), (Vector<float>)c.Subtract(a, b), $"Subtract[{n}]");
+        AssertVecGpuMatchesCpu((Vector<float>)g.Multiply(a, b), (Vector<float>)c.Multiply(a, b), $"Multiply[{n}]");
+        AssertVecGpuMatchesCpu((Vector<float>)g.Divide(a, b), (Vector<float>)c.Divide(a, b), $"Divide[{n}]");
+
+        // double path too (the GAMLSS/AiModelBuilder case is double): the GPU converts
+        // double->float->double, and the result is wrapped in a Vector<double> that copies.
+        var ad = new Vector<double>(System.Linq.Enumerable.Range(0, n).Select(i => (double)a[i]).ToArray());
+        var bd = new Vector<double>(System.Linq.Enumerable.Range(0, n).Select(i => (double)b[i]).ToArray());
+        var subD = (Vector<double>)g.Subtract(ad, bd);
+        var subDc = (Vector<double>)c.Subtract(ad, bd);
+        for (int i = 0; i < n; i++)
+            Assert.True(System.Math.Abs(subD[i] - subDc[i]) < Tol, $"Subtract<double>[{n}] idx {i}: gpu {subD[i]} vs cpu {subDc[i]}");
     }
 }
 #endif


### PR DESCRIPTION
## Why this is needed

PR #496 (shipped in **0.86.5**) did **not** fix the GPU element-wise zeros bug. Verified end-to-end: AiDotNet on 0.86.5 still has `Engine.Subtract`/`Add`/`Multiply`/`Divide` on a fresh `Vector` returning all-zeros on the GPU backend (GAMLSS through `AiModelBuilder` still produces constant predictions).

Two compounding mistakes in #496:

1. **The regression test never exercised the GPU path.** `Add`/`Subtract`/etc. are *explicit* `IEngine` implementations on `DirectGpuTensorEngine`; calling them on the concrete `_gpu` resolves to the inherited `CpuEngine` method. The #496 test called them on the concrete type, so it tested CPU and passed with **or without** the fix.
2. **The root cause was misdiagnosed** as input-buffer lifetime (`SyncIfInputsTransient`). The real cause: the array/span element-wise helpers return a **deferred** array from `FinishGpuOp`, then the `IEngine` vector/matrix ops wrap it with `new Vector<T>(arr)` / `new Matrix<T>(arr)` — and those constructors **copy** (`VectorBase(IEnumerable)` does `values.ToArray()`). The copy captures the still-uninitialized (zero) contents; the deferred materializer later updates the orphaned original. The caller is left with zeros. (An immediate read of the GPU output buffer is correct — only the deferred hand-off into a copying container is broken.)

## Fix

`FinishGpuOpImmediate` — synchronously download + free the output buffer for the array/span helpers (`TryRunBinary`/`TryRunUnary`/`TryRunScalar(T[])` + span variants). Their results always go to a CPU-side `Vector`/`Matrix`, so there's no GPU-resident reuse to preserve. The `Tensor<T>` helpers keep the deferred `FinishGpuOp` (`Tensor<T>` is deferred-materialization-aware and wraps by reference, so the hot NN path is unchanged). Removes the ineffective `SyncIfInputsTransient`.

## Test

`ElementwiseVectorOps_Gpu_Matches_Cpu` now dispatches through `IEngine` (float **and** double) so it actually exercises the GPU path. Verified it **fails** (`max_abs_err ~3.7`) on the deferred path and **passes** with the fix. Full `Engines.DirectGpu` suite (**656 tests**) green on a real OpenCL GPU (AMD gfx1012).

Supersedes the ineffective part of #496.

🤖 Generated with [Claude Code](https://claude.com/claude-code)