### PR TITLE
fix(managedblas): StreamingWorkerPool lost-wakeup deadlock (+ Phase 1/2 gap fixes, native-optional decision, multi-seed bench)

### DIFF
--- a/docs/managed-blas-determinism.md
+++ b/docs/managed-blas-determinism.md
@@ -1,11 +1,11 @@
 # ManagedBlas determinism & dispatch modes
 
 AiDotNet.Tensors runs CPU matrix multiplication (GEMM) through its own managed
-kernel, **ManagedBlas** (`BlasManaged.Gemm`), with native OpenBLAS available only
-as an optional, per-shape accelerator in non-deterministic mode (and being retired
-entirely — see the managed-blas-deterministic-parallel roadmap). This document
-describes the two execution modes, the determinism guarantee, and how dispatch is
-routed.
+kernel, **ManagedBlas** (`BlasManaged.Gemm`), as the default path. Native OpenBLAS
+is kept as an **optional per-shape accelerator**: in non-deterministic mode the
+autotune router may dispatch to it for the (typically large, single-stream) shapes
+where it still edges the managed kernel. This document describes the two execution
+modes, the determinism guarantee, and how dispatch is routed.
 
 ## Two modes
 

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
@@ -53,8 +53,8 @@ public static class BlasManaged
     /// <para>
     /// Defaults to <see langword="true"/> (ManagedBlas deterministic-parallel +
     /// non-deterministic best-of is the intended CPU GEMM behavior; native OpenBLAS is
-    /// being retired — see the managed-blas-deterministic-parallel plan). Precedence is
-    /// resolved in <see cref="Helpers.BlasProvider.ShouldRouteManaged"/>:
+    /// kept as an optional per-shape accelerator the router picks where it still wins).
+    /// Precedence is resolved in <see cref="Helpers.BlasProvider.ShouldRouteManaged"/>:
     /// <see cref="PreferManaged"/> and <see cref="Helpers.BlasProvider.IsDeterministicMode"/>
     /// both force managed BEFORE this timing-based routing is consulted — deterministic
     /// mode must not pick its kernel by measurement noise (it would break

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/MachineKernelGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/MachineKernelGemm.cs
@@ -293,7 +293,7 @@ internal static class MachineKernelGemm
                                 for (int js = 0; js < njStripesL; js++)
                                     kern(aS, pb + (long)js * ekcL * NrL, cR + js * NrL, ldcL, ekcL);
                             }
-                        });
+                        }, deterministicSafe: true); // M-stripe split: each C tile reduced by one worker, fixed order
                     }
                 }
             }

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Pool/CooperativeGemmScheduler.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Pool/CooperativeGemmScheduler.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using AiDotNet.Tensors.Helpers;
 
 namespace AiDotNet.Tensors.Engines.BlasManaged.Pool;
 
@@ -81,6 +82,12 @@ internal static class CooperativeGemmScheduler
     private static int _initialized; // 0 = not started, 1 = workers spawned
     private static readonly object _initLock = new();
     private static int _numWorkers;
+
+    /// <summary>Number of persistent worker threads (0 until first dispatch). The pool
+    /// is fixed-size — callers PARTICIPATE rather than the pool spawning threads per
+    /// dispatch — so this never grows under load (the no-oversubscription guarantee).
+    /// Test/diagnostic accessor.</summary>
+    internal static int WorkerCount => Volatile.Read(ref _initialized) == 1 ? _numWorkers : 0;
 
     private static void EnsureInitialized()
     {
@@ -171,9 +178,11 @@ internal static class CooperativeGemmScheduler
     public static void Dispatch(int numChunks, Action<int> action)
     {
         if (numChunks <= 0) return;
-        // Single chunk, or nested call (this thread is already running a chunk) →
-        // serial on the caller. Nested pool re-entry would risk deadlock.
-        if (numChunks == 1 || _inScheduler)
+        // Run serial on the caller when: a single chunk; a nested call (this thread is
+        // already running a chunk — pool re-entry would risk deadlock); or parallelism
+        // is pinned off via CpuParallelSettings.MaxDegreeOfParallelism <= 1 (honor the
+        // class-level contract the legacy pools and ParallelForOrSerial also respect).
+        if (numChunks == 1 || _inScheduler || CpuParallelSettings.MaxDegreeOfParallelism <= 1)
         {
             RunSerial(numChunks, action);
             return;

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Pool/StreamingWorkerPool.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Pool/StreamingWorkerPool.cs
@@ -88,6 +88,18 @@ internal static class StreamingWorkerPool
                 else
                 {
                     Volatile.Write(ref _slots[slot].ParkPending, 1);
+                    // FULL FENCE before re-reading Seq. This is a Dekker-style mutual
+                    // signal: the worker writes ParkPending then reads Seq, while the
+                    // dispatcher writes Seq (Interlocked.Increment — a full fence) then
+                    // reads ParkPending. Volatile.Write/Read alone do NOT order a store
+                    // followed by a load (x86 TSO permits store-load reordering), so
+                    // without this barrier the worker could read a stale Seq==lastSeq and
+                    // park while the dispatcher reads a stale ParkPending==0 and skips the
+                    // wake — a lost wakeup that hangs the dispatcher's spin-wait on
+                    // _remaining forever (intermittent deadlock under concurrent dispatch).
+                    // The barrier makes ParkPending=1 globally visible before the Seq read,
+                    // pairing with the dispatcher's interlocked Seq increment.
+                    Thread.MemoryBarrier();
                     // Re-check under park to avoid lost wakeup.
                     if (Volatile.Read(ref _slots[slot].Seq) == lastSeq)
                         _slots[slot].ParkEvent!.Wait();

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
@@ -518,7 +518,7 @@ internal static class PackBothStrategy
                                     stripeStart, numStripesInChunk,
                                     effectiveNc_packB_cap, effectiveKc_packB_cap, nr);
                             }
-                        });
+                        }, deterministicSafe: true); // disjoint stripe packing — order-independent
                     }
                     else
                     {
@@ -647,7 +647,7 @@ internal static class PackBothStrategy
                         }
                     }
                     if (PackBothProfiler.Enabled) PackBothProfiler.AddKernel(Stopwatch.GetTimestamp() - _krStart);
-                });
+                }, deterministicSafe: true); // M-axis (ic) split: disjoint C rows, fixed-order K reduction per tile
             }
         }
 
@@ -833,7 +833,7 @@ internal static class PackBothStrategy
                             mr, nr, effectiveNr);
                     }
                 }
-            });
+            }, deterministicSafe: true); // 2D MN-grid split: each (ic,jc) tile disjoint, fixed-order K reduction
         }
     }
 

--- a/src/AiDotNet.Tensors/Helpers/BlasProvider.cs
+++ b/src/AiDotNet.Tensors/Helpers/BlasProvider.cs
@@ -1016,6 +1016,14 @@ internal static class BlasProvider
         // already guarantees. Restoring multi-threading on disable lets
         // perf go back up for callers that re-enter non-deterministic mode.
         TrySetOpenBlasThreads(deterministic ? 1 : 0);
+        // Unify the switch (plan item 1.4): deterministic mode must ALSO make the
+        // order-dependent reduction/accumulation kernels bit-reproducible — their
+        // multi-threaded partial-sum combine is non-associative. Previously callers
+        // had to set this separately, so "deterministic mode" left those reductions
+        // non-deterministic. GEMM stays parallel because its M/N-tile splits are
+        // marked deterministicSafe (see CpuParallelSettings.ParallelForOrSerial), so
+        // this serializes only the genuinely order-dependent reductions.
+        CpuParallelSettings.DeterministicReductions = deterministic;
     }
 
     /// <summary>True iff <c>AIDOTNET_USE_BLAS=1</c> is set AND libopenblas loaded successfully.</summary>

--- a/src/AiDotNet.Tensors/Helpers/CpuParallelSettings.cs
+++ b/src/AiDotNet.Tensors/Helpers/CpuParallelSettings.cs
@@ -265,7 +265,15 @@ public static class CpuParallelSettings
     /// perform across all iterations combined.</param>
     /// <param name="body">Iteration body — same shape as
     /// <c>Parallel.For</c>'s <c>Action&lt;int&gt;</c>.</param>
-    public static void ParallelForOrSerial(int fromInclusive, int toExclusive, long totalWork, Action<int> body)
+    /// <param name="deterministicSafe">When <see langword="true"/>, this loop is
+    /// exempt from the <see cref="DeterministicReductions"/> serial-forcing gate: the
+    /// caller guarantees its parallelism is bit-reproducible regardless of thread count
+    /// (disjoint-write output tiles where each element's reduction is done by a single
+    /// thread in fixed order — e.g. GEMM M/N-tile splits, see
+    /// <c>DeterministicParallelGemmContractTests</c>). Order-dependent reduction/
+    /// accumulation kernels leave this <see langword="false"/> so deterministic mode
+    /// serializes them for reproducibility.</param>
+    public static void ParallelForOrSerial(int fromInclusive, int toExclusive, long totalWork, Action<int> body, bool deterministicSafe = false)
     {
         if (toExclusive <= fromInclusive) return;
         // Honor the class-level MaxDegreeOfParallelism contract: if the user has
@@ -274,7 +282,11 @@ public static class CpuParallelSettings
         // code path. Snapshot BOTH gating values once so a concurrent setter
         // mid-call can't toggle us between the serial and parallel paths.
         int maxDegree = MaxDegreeOfParallelism;
-        bool deterministic = DeterministicReductions;
+        // DeterministicReductions forces order-dependent reductions serial for
+        // bit-reproducibility; deterministicSafe callers stay parallel (they're already
+        // reproducible across thread counts) so deterministic mode doesn't lose GEMM
+        // parallelism — the whole point of Lever A (deterministic AND parallel).
+        bool deterministic = DeterministicReductions && !deterministicSafe;
         // _inParallelRegion: a nested call (this thread is already a parallel
         // worker) runs serial to avoid ThreadPool starvation. See its docs.
         if (maxDegree <= 1 || deterministic || _inParallelRegion

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/CooperativeSchedulerConcurrencyTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/CooperativeSchedulerConcurrencyTests.cs
@@ -65,6 +65,26 @@ public class CooperativeSchedulerConcurrencyTests
     }
 
     [Fact]
+    public void Pool_IsFixedSize_DoesNotGrowUnderConcurrentLoad()
+    {
+        // No-oversubscription guarantee (plan 2.8): the cooperative pool is a FIXED set
+        // of workers and callers PARTICIPATE rather than the pool spawning a thread per
+        // dispatch/chunk. So heavy concurrent dispatch must NOT grow the worker count —
+        // that's what keeps active worker threads ≈ cores regardless of caller count.
+        CooperativeGemmScheduler.Dispatch(8, _ => { }); // trigger pool init
+        int initial = CooperativeGemmScheduler.WorkerCount;
+        Assert.InRange(initial, 1, Environment.ProcessorCount);
+
+        Parallel.For(0, Environment.ProcessorCount * 3, _ =>
+        {
+            for (int i = 0; i < 25; i++)
+                CooperativeGemmScheduler.Dispatch(48, c => { var _ = c * c; });
+        });
+
+        Assert.Equal(initial, CooperativeGemmScheduler.WorkerCount); // fixed — no per-dispatch threads
+    }
+
+    [Fact]
     public void ConcurrentDispatches_AllComplete_CorrectAndUncontaminated()
     {
         // The headline property: many threads each run their own dispatch

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/CooperativeSchedulerDeadlockStressTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/CooperativeSchedulerDeadlockStressTests.cs
@@ -1,0 +1,209 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Isolation harness for the intermittent hang observed when the cooperative GEMM
+// scheduler is ENABLED under concurrent dispatch. Unlike the throughput bench, this
+// does NOT toggle Enabled or keep the legacy pool's workers alive — it drives REAL
+// concurrent GEMMs purely through the cooperative scheduler, in many short batches,
+// so a single run either reproduces the hang fast (a batch exceeds its watchdog) or
+// builds confidence that it is gone. Category=Performance so it is excluded from the
+// normal/CI run (it is a deliberately heavy, timing-sensitive reproducer).
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using AiDotNet.Tensors.Engines.BlasManaged.Pool;
+using AiDotNet.Tensors.Helpers;
+using Xunit;
+using Xunit.Abstractions;
+using BlasManagedLib = AiDotNet.Tensors.Engines.BlasManaged.BlasManaged;
+using AiDotNet.Tensors.Engines.BlasManaged;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+[Collection("BlasManaged-Stats-Serial")]
+[Trait("Category", "Performance")]
+public class CooperativeSchedulerDeadlockStressTests
+{
+    private readonly ITestOutputHelper _out;
+    public CooperativeSchedulerDeadlockStressTests(ITestOutputHelper output) => _out = output;
+
+    [Theory]
+    [InlineData(2)]
+    [InlineData(4)]
+    [InlineData(8)]
+    public void ConcurrentGemm_ThroughCooperativeScheduler_NeverHangs(int threads)
+    {
+        const int batches = 60;
+        const int itersPerThreadPerBatch = 20;
+        const int m = 1024, n = 1024, k = 24;
+        var watchdog = TimeSpan.FromSeconds(20);
+
+        bool beforeDet = BlasProvider.IsDeterministicMode;
+        bool beforeCoop = CooperativeGemmScheduler.Enabled;
+        try
+        {
+            BlasProvider.SetDeterministicMode(true);
+            CooperativeGemmScheduler.Enabled = true;
+
+            var rng = new Random(20260529);
+            var a = new float[m * k];
+            var b = new float[k * n];
+            for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+            for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+
+            for (int batch = 0; batch < batches; batch++)
+            {
+                using var cts = new CancellationTokenSource();
+                using var gate = new Barrier(threads + 1);
+                var workers = new Task[threads];
+                for (int t = 0; t < threads; t++)
+                {
+                    workers[t] = Task.Factory.StartNew(() =>
+                    {
+                        var c = new float[m * n];
+                        gate.SignalAndWait();
+                        for (int it = 0; it < itersPerThreadPerBatch && !cts.IsCancellationRequested; it++)
+                            BlasManagedLib.Gemm<float>(a, k, false, b, n, false, c, n, m, n, k);
+                    }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+                }
+                gate.SignalAndWait();
+                var sw = Stopwatch.StartNew();
+                bool done = Task.WaitAll(workers, watchdog);
+                sw.Stop();
+                if (!done)
+                {
+                    cts.Cancel();
+                    Task.WaitAll(workers, TimeSpan.FromSeconds(30));
+                    throw new Xunit.Sdk.XunitException(
+                        $"HANG reproduced: batch {batch}/{batches} with {threads} concurrent GEMMs " +
+                        $"did not finish within {watchdog.TotalSeconds:F0}s through the cooperative scheduler.");
+                }
+            }
+            _out.WriteLine($"{threads} threads: {batches} batches x {itersPerThreadPerBatch} iters each completed, no hang.");
+        }
+        finally
+        {
+            CooperativeGemmScheduler.Enabled = beforeCoop;
+            BlasProvider.SetDeterministicMode(beforeDet);
+        }
+    }
+
+    // Decisive isolation of the LEGACY pool: Enabled stays false throughout, so the
+    // cooperative scheduler's worker threads are NEVER created — only the legacy
+    // StreamingWorkerPool's (cores-1) workers exist. If the legacy pool hangs HERE, it is
+    // a real production bug (legacy is the default). If it only hangs when the extra
+    // coop threads are also alive (the toggling test below), the hang is dual-pool
+    // oversubscription, not a legacy defect.
+    [Theory]
+    [InlineData(2)]
+    [InlineData(4)]
+    public void ConcurrentGemm_LegacyPoolOnly_NeverHangs(int threads)
+    {
+        const int batches = 80;
+        const int itersPerThreadPerBatch = 30;
+        const int m = 1024, n = 1024, k = 24;
+        var watchdog = TimeSpan.FromSeconds(25);
+
+        bool beforeDet = BlasProvider.IsDeterministicMode;
+        bool beforeCoop = CooperativeGemmScheduler.Enabled;
+        try
+        {
+            BlasProvider.SetDeterministicMode(true);
+            CooperativeGemmScheduler.Enabled = false; // legacy path only; coop workers never spawn
+
+            var rng = new Random(135792468);
+            var a = new float[m * k];
+            var b = new float[k * n];
+            for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+            for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+
+            for (int batch = 0; batch < batches; batch++)
+            {
+                if (!RunBatch(a, b, m, n, k, threads, itersPerThreadPerBatch, watchdog))
+                    throw new Xunit.Sdk.XunitException(
+                        $"HANG reproduced in LEGACY pool alone: batch {batch}/{batches}, threads={threads} " +
+                        $"did not finish within {watchdog.TotalSeconds:F0}s (coop scheduler never enabled).");
+            }
+            _out.WriteLine($"{threads} threads legacy-only: {batches} batches completed, no hang.");
+        }
+        finally
+        {
+            CooperativeGemmScheduler.Enabled = beforeCoop;
+            BlasProvider.SetDeterministicMode(beforeDet);
+        }
+    }
+
+    // Reproduces the BENCH condition: toggle Enabled each batch so BOTH the legacy
+    // StreamingWorkerPool AND the cooperative scheduler keep their (cores-1) worker
+    // threads alive simultaneously (~62 background threads on a 32-logical machine),
+    // both spin-waiting. If the "intermittent deadlock" is really spin-livelock from
+    // that dual-pool oversubscription (not a scheduler defect), this is where it shows.
+    [Theory]
+    [InlineData(2)]
+    [InlineData(4)]
+    public void ConcurrentGemm_TogglingBothPools_BenchConditionRepro(int threads)
+    {
+        const int batches = 80;
+        const int itersPerThreadPerBatch = 30;
+        const int m = 1024, n = 1024, k = 24;
+        var watchdog = TimeSpan.FromSeconds(25);
+
+        bool beforeDet = BlasProvider.IsDeterministicMode;
+        bool beforeCoop = CooperativeGemmScheduler.Enabled;
+        try
+        {
+            BlasProvider.SetDeterministicMode(true);
+
+            var rng = new Random(987654321);
+            var a = new float[m * k];
+            var b = new float[k * n];
+            for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+            for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+
+            // Warm both pools so both sets of worker threads are alive at once.
+            CooperativeGemmScheduler.Enabled = false; RunBatch(a, b, m, n, k, threads, 3, TimeSpan.FromSeconds(25));
+            CooperativeGemmScheduler.Enabled = true; RunBatch(a, b, m, n, k, threads, 3, TimeSpan.FromSeconds(25));
+
+            for (int batch = 0; batch < batches; batch++)
+            {
+                CooperativeGemmScheduler.Enabled = (batch & 1) == 0;
+                int b0 = batch;
+                if (!RunBatch(a, b, m, n, k, threads, itersPerThreadPerBatch, watchdog))
+                    throw new Xunit.Sdk.XunitException(
+                        $"HANG reproduced under dual-pool toggling: batch {b0}/{batches}, threads={threads}, " +
+                        $"Enabled={CooperativeGemmScheduler.Enabled} did not finish within {watchdog.TotalSeconds:F0}s.");
+            }
+            _out.WriteLine($"{threads} threads toggling: {batches} batches completed, no hang.");
+        }
+        finally
+        {
+            CooperativeGemmScheduler.Enabled = beforeCoop;
+            BlasProvider.SetDeterministicMode(beforeDet);
+        }
+    }
+
+    private static bool RunBatch(float[] a, float[] b, int m, int n, int k, int threads, int iters, TimeSpan watchdog)
+    {
+        using var cts = new CancellationTokenSource();
+        using var gate = new Barrier(threads + 1);
+        var workers = new Task[threads];
+        for (int t = 0; t < threads; t++)
+        {
+            workers[t] = Task.Factory.StartNew(() =>
+            {
+                var c = new float[m * n];
+                gate.SignalAndWait();
+                for (int it = 0; it < iters && !cts.IsCancellationRequested; it++)
+                    BlasManagedLib.Gemm<float>(a, k, false, b, n, false, c, n, m, n, k);
+            }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+        }
+        gate.SignalAndWait();
+        bool done = Task.WaitAll(workers, watchdog);
+        if (!done)
+        {
+            cts.Cancel();
+            Task.WaitAll(workers, TimeSpan.FromSeconds(30));
+        }
+        return done;
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/CooperativeSchedulerThroughputBench.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/CooperativeSchedulerThroughputBench.cs
@@ -31,6 +31,13 @@ public class CooperativeSchedulerThroughputBench
     private readonly ITestOutputHelper _out;
     public CooperativeSchedulerThroughputBench(ITestOutputHelper output) => _out = output;
 
+    // Repetitions per shape. Odd so the median is a real sample. Each rep uses a
+    // DISTINCT seed (fresh operands) so the verdict is robust to a single lucky/
+    // unlucky operand layout — not just to per-run timing jitter. A single A/B
+    // sample on this scheduler swings 0.7x↔1.3x run-to-run; the median over many
+    // seeds is what we trust to decide retirement of the legacy pool.
+    private const int Reps = 9;
+
     [Theory]
     // K<32 → StreamingStrategy → StreamingWorkerPool (the path wired to the
     // cooperative scheduler). Small vs large M·N to see where each pool wins:
@@ -50,39 +57,87 @@ public class CooperativeSchedulerThroughputBench
         {
             BlasProvider.SetDeterministicMode(true); // both paths → managed
 
-            var rng = new Random(123);
-            var a = new float[m * k];
-            var b = new float[k * n];
-            for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
-            for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+            var legacyMsAll = new double[Reps];
+            var coopMsAll = new double[Reps];
+            var ratios = new double[Reps];
 
-            // Warm up both paths (JIT, pool spin-up, autotune-free deterministic route).
-            CooperativeGemmScheduler.Enabled = false; RunConcurrent(a, b, m, n, k, threads, 5);
-            CooperativeGemmScheduler.Enabled = true; RunConcurrent(a, b, m, n, k, threads, 5);
+            for (int rep = 0; rep < Reps; rep++)
+            {
+                // Fresh operands per rep with a distinct seed.
+                var rng = new Random(1000 + rep * 7919);
+                var a = new float[m * k];
+                var b = new float[k * n];
+                for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+                for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
 
-            CooperativeGemmScheduler.Enabled = false;
-            double legacyMs = RunConcurrent(a, b, m, n, k, threads, itersPerThread);
+                // Warm both paths on THIS rep's data (JIT, pool spin-up, deterministic route).
+                CooperativeGemmScheduler.Enabled = false; RunConcurrent(a, b, m, n, k, threads, 5);
+                CooperativeGemmScheduler.Enabled = true; RunConcurrent(a, b, m, n, k, threads, 5);
 
-            CooperativeGemmScheduler.Enabled = true;
-            double coopMs = RunConcurrent(a, b, m, n, k, threads, itersPerThread);
+                double legacyMs, coopMs;
+                // Alternate measurement order per rep so neither path systematically
+                // benefits from a warmer cache / thermal ramp by always running second.
+                if ((rep & 1) == 0)
+                {
+                    CooperativeGemmScheduler.Enabled = false; legacyMs = RunConcurrent(a, b, m, n, k, threads, itersPerThread);
+                    CooperativeGemmScheduler.Enabled = true; coopMs = RunConcurrent(a, b, m, n, k, threads, itersPerThread);
+                }
+                else
+                {
+                    CooperativeGemmScheduler.Enabled = true; coopMs = RunConcurrent(a, b, m, n, k, threads, itersPerThread);
+                    CooperativeGemmScheduler.Enabled = false; legacyMs = RunConcurrent(a, b, m, n, k, threads, itersPerThread);
+                }
 
-            double speedup = legacyMs / coopMs;
-            _out.WriteLine($"Concurrent GEMM {m}x{n}x{k}, {threads} threads x {itersPerThread} iters:");
-            _out.WriteLine($"  legacy  StreamingWorkerPool : {legacyMs,8:F1} ms");
-            _out.WriteLine($"  cooperative scheduler       : {coopMs,8:F1} ms");
-            _out.WriteLine($"  speedup (legacy/coop)       : {speedup,8:F2}x");
+                legacyMsAll[rep] = legacyMs;
+                coopMsAll[rep] = coopMs;
+                ratios[rep] = legacyMs / coopMs;
+            }
 
-            // Anti-regression / anti-deadlock guard only: cooperative must not be
-            // catastrophically slower. The go/no-go on flipping Enabled is read from
-            // the numbers above, not asserted here.
-            Assert.True(coopMs < legacyMs * 5.0,
-                $"Cooperative scheduler is >5x slower than legacy ({coopMs:F1} vs {legacyMs:F1} ms) — investigate before enabling.");
+            double medLegacy = Median(legacyMsAll);
+            double medCoop = Median(coopMsAll);
+            double medRatio = Median(ratios);
+            double minRatio = Min(ratios);
+            double maxRatio = Max(ratios);
+
+            _out.WriteLine($"Concurrent GEMM {m}x{n}x{k}, {threads} threads x {itersPerThread} iters, {Reps} seeds:");
+            _out.WriteLine($"  legacy  StreamingWorkerPool (median) : {medLegacy,8:F1} ms");
+            _out.WriteLine($"  cooperative scheduler       (median) : {medCoop,8:F1} ms");
+            _out.WriteLine($"  speedup legacy/coop  median={medRatio:F2}x  min={minRatio:F2}x  max={maxRatio:F2}x");
+            _out.WriteLine($"    >1.0 = cooperative faster; per-seed ratios = [{string.Join(", ", System.Linq.Enumerable.Select(ratios, r => r.ToString("F2")))}]");
+
+            // Anti-regression / anti-deadlock guard only, on the MEDIAN so single-seed
+            // noise can't fail it: cooperative must not be catastrophically slower. The
+            // go/no-go on flipping Enabled is read from the reported medians, not asserted.
+            Assert.True(medCoop < medLegacy * 5.0,
+                $"Cooperative scheduler median is >5x slower than legacy ({medCoop:F1} vs {medLegacy:F1} ms) — investigate before enabling.");
         }
         finally
         {
             CooperativeGemmScheduler.Enabled = beforeCoop;
             BlasProvider.SetDeterministicMode(beforeDet);
         }
+    }
+
+    private static double Median(double[] xs)
+    {
+        var copy = (double[])xs.Clone();
+        Array.Sort(copy);
+        int mid = copy.Length / 2;
+        return (copy.Length & 1) == 1 ? copy[mid] : (copy[mid - 1] + copy[mid]) / 2.0;
+    }
+
+    private static double Min(double[] xs)
+    {
+        double m = xs[0];
+        for (int i = 1; i < xs.Length; i++) if (xs[i] < m) m = xs[i];
+        return m;
+    }
+
+    private static double Max(double[] xs)
+    {
+        double m = xs[0];
+        for (int i = 1; i < xs.Length; i++) if (xs[i] > m) m = xs[i];
+        return m;
     }
 
     private static double RunConcurrent(float[] a, float[] b, int m, int n, int k, int threads, int iters)

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/DeterministicParallelGemmContractTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/DeterministicParallelGemmContractTests.cs
@@ -118,6 +118,35 @@ public class DeterministicParallelGemmContractTests
         }
     }
 
+    [Fact]
+    public void SetDeterministicMode_IsTheUnifiedSwitch_DrivesDeterministicReductions()
+    {
+        // Plan item 1.4: SetDeterministicMode is the single public switch — it must
+        // also gate the order-dependent reduction kernels (DeterministicReductions),
+        // not just the GEMM route + OpenBLAS thread count. Otherwise "deterministic
+        // mode" would still run reductions (softmax/BN/sum) non-deterministically.
+        bool? beforeThreadDet = BlasProvider.GetThreadLocalDeterministicMode();
+        if (beforeThreadDet is not null) BlasProvider.SetThreadLocalDeterministicMode(null);
+        bool beforeDet = BlasProvider.IsDeterministicMode;
+        bool beforeReductions = CpuParallelSettings.DeterministicReductions;
+        try
+        {
+            BlasProvider.SetDeterministicMode(true);
+            Assert.True(CpuParallelSettings.DeterministicReductions,
+                "deterministic mode must force reduction kernels deterministic (DeterministicReductions)");
+
+            BlasProvider.SetDeterministicMode(false);
+            Assert.False(CpuParallelSettings.DeterministicReductions,
+                "non-deterministic mode must release the reduction serial-gate");
+        }
+        finally
+        {
+            BlasProvider.SetDeterministicMode(beforeDet);
+            CpuParallelSettings.DeterministicReductions = beforeReductions;
+            BlasProvider.SetThreadLocalDeterministicMode(beforeThreadDet);
+        }
+    }
+
     /// <summary>Bit-for-bit equality (reinterpreted integer bits), so +0.0/-0.0 and
     /// NaN payloads count as different — the contract is bit-identical, not value-equal.</summary>
     private static bool BitIdentical<T>(T x, T y) where T : unmanaged


### PR DESCRIPTION
## Headline: fix an intermittent production deadlock in the default CPU GEMM pool

The legacy `StreamingWorkerPool` — the **production-default** CPU GEMM pool — could intermittently **deadlock** under concurrent dispatch. Its spin-then-park is a Dekker-style mutual signal: the worker writes `ParkPending` then reads `Seq`, while the dispatcher does `Interlocked.Increment(Seq)` (full fence) then reads `ParkPending`. The worker side used only `Volatile.Write`/`Volatile.Read`, which do **not** order a store followed by a load — x86 TSO permits store-load reordering. So a worker could read a stale `Seq==lastSeq` and park while the dispatcher read a stale `ParkPending==0` and skipped the wake — a **lost wakeup** that hangs the dispatcher's (timeout-free) spin-wait on `_remaining` forever. Rare → intermittent, and almost certainly the long-standing intermittent GEMM/CI hang (distinct from #492, which fixed *correctness*, not *liveness*).

**Fix:** one `Thread.MemoryBarrier()` between the worker's `ParkPending` write and the `Seq` re-check, pairing with the dispatcher's interlocked `Seq` increment.

**Validation:** new `CooperativeSchedulerDeadlockStressTests` (Category=Performance) reproduced the hang reliably *before* the fix (legacy-only, 4 concurrent 1024×1024×24 GEMMs, hung ~batch 25/80). *After*: 3× full stress runs (legacy-only / coop-only / dual-pool toggling) = 21/21 green, plus 522 BlasManaged correctness tests pass on net10 and net471 builds clean.

## Also in this PR

- **Multi-seed cooperative-vs-legacy throughput bench.** A 9-seed, order-alternated median per regime (replacing a noisy single A/B). With a **fair** comparison (both pools at `cores-1` workers), the cooperative scheduler is at **parity** with the legacy pool — the earlier apparent "13% regression" was an artifact of a stray local hack capping the legacy pool to 4 workers. The bench is what surfaced the legacy deadlock and exonerated the cooperative scheduler (coop-only never hangs; legacy-only does). The cooperative scheduler stays **off-by-default**.
- **Audited Phase 1/2 gap fixes:** unified determinism switch (`SetDeterministicMode` drives `DeterministicReductions`, with a `deterministicSafe` opt-out so deterministic-safe parallel GEMM tiles stay parallel), cooperative scheduler honoring `MaxDegreeOfParallelism`, and a no-oversubscription `WorkerCount` guard.
- **Phase 3 decision:** keep native OpenBLAS as an **optional per-shape accelerator** the router picks where it still wins — not removed. Docs corrected accordingly.

## Notes
- The cooperative scheduler is unchanged from #495 and remains off-by-default; retiring the legacy pool toward it is not justified (parity, no win).
- `CooperativeSchedulerDeadlockStressTests` is `Category=Performance` (heavy/timing-sensitive), excluded from CI, kept as a manual reproducer / regression guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
