### PR TITLE
feat(#500): wire ALL fused kernel-backed optimizers + pointwise activations into the plan/MlpForward dispatch

### DIFF
--- a/docs/research/2026-05-29-pytorch-fused-optimizer-internals.md
+++ b/docs/research/2026-05-29-pytorch-fused-optimizer-internals.md
@@ -1,0 +1,129 @@
+# PyTorch fused / compiled optimizer internals vs AiDotNet.Tensors
+
+Research for issue tracking the compiled-training perf gap (companion to the
+AMSGrad plan-dispatch work, PR #501 / #500). Goal: identify what PyTorch does in
+its fused / `torch.compile` optimizer path that we don't, and where we can
+*exceed* it. Grounded in PyTorch 2.x (`torch/optim/*`, ATen multi-tensor apply,
+TorchInductor) as of 2026-05.
+
+## 1. How PyTorch implements optimizer steps
+
+PyTorch ships **three** implementations per optimizer, in increasing speed:
+
+| Tier | Mechanism | Where |
+|------|-----------|-------|
+| `for-loop` | one Python loop iteration + one set of ATen ops **per parameter** | reference path |
+| `foreach` (multi-tensor) | parameters grouped by (device, dtype); the whole group's update runs as **one** `_foreach_*` / `multi_tensor_apply` call | default on CUDA |
+| `fused` | a single hand-written CUDA/CPU kernel does the entire update (and, with `capturable=True`, keeps step on-device) | `fused=True` |
+
+Performance ordering: **fused > foreach > for-loop**.
+
+### multi_tensor_apply (the foreach engine)
+`multi_tensor_apply` passes a `float**` (array of tensor base pointers) plus
+per-tensor sizes into ONE kernel. A device-side functor walks the tensor list,
+handles alignment/vectorization, and applies the math. The win is **horizontal
+fusion**: N parameter tensors → 1 kernel launch instead of N, amortizing launch
+and loop-setup overhead. Bias-correction scalars (`1 - β^t`) are computed **once
+per step** and broadcast, not per parameter.
+
+### torch.compile (TorchInductor) optimizer compilation (PT ≥ 2.2)
+- Inductor does **vertical fusion**: it can fuse the optimizer's elementwise ops
+  (and potentially the tail of backward) into a small number of generated
+  kernels, automating what the hand-written fused kernels do.
+- Works with all `foreach` optimizers except `LBFGS` / `SparseAdam`.
+- **Cost**: optimizers update params **in place** (non-functional). Inductor must
+  functionalize, which historically caused multi-minute compile times for
+  thousand-parameter models. `capturable=True` + CUDA-graph capture removes the
+  per-step CPU launch overhead once compiled.
+
+## 2. What AiDotNet.Tensors already does well
+
+- **Compile-once / replay-many**: `CompiledTrainingPlan` builds the optimizer
+  update closure once (`_optimizerUpdate`) and replays it; no per-step graph
+  rebuild, no functionalization tax. This is structurally *ahead* of eager
+  PyTorch and avoids Inductor's compile-time problem.
+- **Inlined LR schedule**: `lrSchedule.GetLr(step)` is an inlined `Math.Cos`/`Pow`
+  per step — no `LRScheduler.step()` Python dispatch (`CompiledTrainingPlan.cs`,
+  "Issue #348").
+- **Live-backed in-place writes**: params are pinned via
+  `GetLiveBackingArrayAllowingPaddingOrNull` and updated through `fixed` pointers
+  — true in-place, no functionalization copies (Issue #350).
+- **AVX2 fused kernels** per optimizer (`FusedOptimizer.*UpdateSimd`) with FMA.
+- **Epilogue fusion**: GEMM + bias + activation run as one pass
+  (`ActivationEpilogue` / `CpuFusedOperations`), comparable to Inductor vertical
+  fusion for the forward.
+
+## 3. What PyTorch does that we DON'T — adopt these
+
+### 3a. Horizontal (multi-tensor) fusion of the optimizer step  ★ highest value
+Our `_optimizerUpdate` closure loops **per parameter**, calling one
+`*UpdateSimd` per tensor:
+```
+for (int p = 0; p < paramCount; p++)
+    fixed (float* pParam = ..., pM = m[p], ...) AMSGradUpdateSimd(pParam, ...);
+```
+For a 53-layer net that's 100+ separate kernel calls per step. PyTorch's foreach
+collapses these into one. On **CPU** the cost isn't launch latency but per-call
+loop setup + the FMA pipeline not staying full across tiny params (biases, norm
+scales of length 64–512). A `multi_tensor`-style batched CPU kernel — one call
+over a packed list of (param, grad, state) spans — would keep the SIMD pipeline
+saturated and cut per-param overhead. **Biggest structural gap.**
+
+### 3b. Hoist step-constant scalars out of the per-param kernel  ★ quick win
+`AMSGradUpdateSimd` (and Adam/AdamW/Nadam/RAdam/…) recompute
+`bc1 = 1 - MathF.Pow(beta1, step)` and `bc2 = 1 - MathF.Pow(beta2, step)` **inside
+every per-parameter call**. Those are **step-constant** — PyTorch computes them
+once per step. With 100+ params that's 200+ redundant `Math.Pow` per step. Fix:
+compute `bc1`/`bc2` (and `lrAdj`) once in `_optimizerUpdate` and pass them into
+the kernels, or add `*UpdateSimdPrecomputed` overloads. Low-risk, measurable.
+
+### 3c. CUDA-graph capture of the whole training step (GPU)
+Our GPU path dispatches one backend kernel per parameter (`AdamUpdate`, …).
+PyTorch `capturable=True` keeps `step` on-device so the entire forward + backward
++ optimizer step is one CUDA graph replay — near-zero CPU launch overhead.
+We already replay a compiled plan; capturing it as a graph would remove the
+remaining per-param launch overhead on GPU.
+
+### 3d. Fuse the optimizer update into the backward's gradient write
+We run the optimizer as a **separate O(MN) pass** over params/grads/state after
+backward. Inductor can fuse the optimizer tail into the kernel that *produces*
+the gradient, so param/grad/state are touched while still hot in cache. For the
+fused-linear backward this would mean updating the weight as its gradient is
+computed — one fewer full pass over weights + grads + m + v(+vMax).
+
+## 4. Where we can EXCEED PyTorch
+
+- **No functionalization / no compile-time cliff.** Our plan is built once from a
+  live graph and replayed; we never pay Inductor's minutes-long functionalizing
+  compile for large param counts. For "compile then train N steps" we win on
+  total wall-clock at small/medium N.
+- **AOT shape specialization.** The plan knows every parameter length at
+  configure time. We can emit/Select kernels specialized to the exact lengths
+  (alignment, full-vector vs remainder split, unroll factor) — PyTorch's generic
+  `multi_tensor` functor handles arbitrary runtime sizes and can't specialize as
+  tightly.
+- **Single-pass CPU epilogue + optimizer.** On CPU we control the whole pipeline;
+  we can fuse bias+activation (forward) and (per 3d) the optimizer update into
+  fewer memory passes than PyTorch's separate foreach kernels, which is bandwidth
+  the CPU actually feels.
+- **Zero-GC persistent state.** `TensorArena.CreatePersistent`/`Activate` keeps
+  optimizer state + scratch across steps with no per-step allocation; PyTorch
+  allocates some per-step temporaries in eager and relies on the caching
+  allocator.
+
+## 5. Prioritized action items (for follow-up Tensors issues)
+
+1. **(3b) Hoist `bc1`/`bc2`/`lrAdj` out of the per-param kernels** — quick,
+   low-risk, measurable on many-param models. Do first.
+2. **(3a) Multi-tensor batched CPU optimizer kernel** — one call over a packed
+   span list; the big structural win for many-param nets. Largest effort.
+3. **(3d) Fuse optimizer update into fused-linear backward** — removes a full
+   memory pass; medium effort, high bandwidth payoff.
+4. **(3c) CUDA-graph capture of the compiled step** — GPU launch-overhead removal;
+   depends on capturable step state.
+
+## Sources
+- [GPU MODE Lecture 6: Optimizing Optimizers in PyTorch](https://christianjmills.com/posts/cuda-mode-notes/lecture-006/)
+- [torch.optim — PyTorch main documentation](https://docs.pytorch.org/docs/main/optim.html)
+- [Introduction to torch.compile](https://docs.pytorch.org/tutorials/intermediate/torch_compile_tutorial.html)
+- [RFC: APEX-style fused optimizers in PyTorch (#68041)](https://github.com/pytorch/pytorch/issues/68041)

--- a/docs/research/2026-05-29-pytorch-fused-optimizer-internals.md
+++ b/docs/research/2026-05-29-pytorch-fused-optimizer-internals.md
@@ -58,7 +58,7 @@ per step** and broadcast, not per parameter.
 ### 3a. Horizontal (multi-tensor) fusion of the optimizer step  ★ highest value
 Our `_optimizerUpdate` closure loops **per parameter**, calling one
 `*UpdateSimd` per tensor:
-```
+```csharp
 for (int p = 0; p < paramCount; p++)
     fixed (float* pParam = ..., pM = m[p], ...) AMSGradUpdateSimd(pParam, ...);
 ```

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -560,12 +560,13 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         float beta1 = 0.9f,
         float beta2 = 0.999f,
         float eps = 1e-8f,
-        float weightDecay = 0f)
+        float weightDecay = 0f,
+        FusedOptimizerExtras? extras = null)
     {
         ConfigureOptimizer(
             optimizerType,
             LrSchedule.Constant(learningRate),
-            beta1, beta2, eps, weightDecay);
+            beta1, beta2, eps, weightDecay, extras);
     }
 
     /// <inheritdoc/>
@@ -575,17 +576,22 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         float beta1 = 0.9f,
         float beta2 = 0.999f,
         float eps = 1e-8f,
-        float weightDecay = 0f)
+        float weightDecay = 0f,
+        FusedOptimizerExtras? extras = null)
     {
         if (schedule is null) throw new ArgumentNullException(nameof(schedule));
         ValidatePlanOptimizerSupport(optimizerType, typeof(T) == typeof(float));
+        var ex = extras ?? new FusedOptimizerExtras();
         if (typeof(T) == typeof(float))
         {
-            ConfigureOptimizerFloat(optimizerType, schedule, beta1, beta2, eps, weightDecay);
+            ConfigureOptimizerFloat(optimizerType, schedule, beta1, beta2, eps, weightDecay, ex);
             return;
         }
         if (typeof(T) == typeof(double))
         {
+            // The double closures only implement SGD/Adam/AdamW/AMSGrad; the
+            // extras-driven optimizers are float-only and were already rejected
+            // by ValidatePlanOptimizerSupport above for double.
             ConfigureOptimizerDouble(optimizerType, schedule, beta1, beta2, eps, weightDecay);
             return;
         }
@@ -600,7 +606,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         float beta1 = 0.9f,
         float beta2 = 0.999f,
         float eps = 1e-8f,
-        float weightDecay = 0f)
+        float weightDecay = 0f,
+        FusedOptimizerExtras? extras = null)
     {
         if (groupSchedules is null) throw new ArgumentNullException(nameof(groupSchedules));
         if (paramToGroup is null) throw new ArgumentNullException(nameof(paramToGroup));
@@ -628,9 +635,10 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     $"paramToGroup[{i}]={g} is out of range [0, {groupSchedules.Count}).");
         }
         ValidatePlanOptimizerSupport(optimizerType, typeof(T) == typeof(float));
+        var ex = extras ?? new FusedOptimizerExtras();
         if (typeof(T) == typeof(float))
         {
-            ConfigureOptimizerFloatGrouped(optimizerType, groupSchedules, paramToGroup, beta1, beta2, eps, weightDecay);
+            ConfigureOptimizerFloatGrouped(optimizerType, groupSchedules, paramToGroup, beta1, beta2, eps, weightDecay, ex);
             return;
         }
         if (typeof(T) == typeof(double))
@@ -668,7 +676,12 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             or OptimizerType.Adagrad
             or OptimizerType.Lion
             or OptimizerType.SGDMomentum
-            or OptimizerType.AdaMax;
+            or OptimizerType.AdaMax
+            or OptimizerType.AdaDelta
+            or OptimizerType.LARS
+            or OptimizerType.FTRL
+            or OptimizerType.ASGD
+            or OptimizerType.Rprop;
 
         bool supported = supportedAnyDtype || (isFloat && supportedFloatOnly);
         if (!supported)
@@ -685,7 +698,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     }
 
     private unsafe void ConfigureOptimizerFloat(
-        OptimizerType optimizerType, LrSchedule schedule, float beta1, float beta2, float eps, float weightDecay)
+        OptimizerType optimizerType, LrSchedule schedule, float beta1, float beta2, float eps, float weightDecay,
+        FusedOptimizerExtras extras)
     {
         // CodeRabbit #425: reconfigure releases any prior GPU optimizer-state
         // buffers. Without this the device memory grows every time the user
@@ -738,11 +752,13 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             bool needsMomentum = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
                 or OptimizerType.SGDMomentum or OptimizerType.Lion or OptimizerType.Nadam
                 or OptimizerType.AdaMax or OptimizerType.AMSGrad
-                or OptimizerType.RAdam or OptimizerType.LAMB;
+                or OptimizerType.RAdam or OptimizerType.LAMB
+                or OptimizerType.LARS or OptimizerType.ASGD or OptimizerType.Rprop;
             bool needsSecondMoment = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
                 or OptimizerType.RMSprop or OptimizerType.Nadam or OptimizerType.AMSGrad
                 or OptimizerType.Adagrad
-                or OptimizerType.RAdam or OptimizerType.LAMB or OptimizerType.AdaMax;
+                or OptimizerType.RAdam or OptimizerType.LAMB or OptimizerType.AdaMax
+                or OptimizerType.AdaDelta or OptimizerType.FTRL or OptimizerType.Rprop;
 
             // GPU fast path: param is GPU-resident → allocate matching GPU
             // state buffers and dispatch to backend kernels. Backends ship
@@ -833,7 +849,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
             m[p] = needsMomentum ? new float[lengths[p]] : Array.Empty<float>();
             v[p] = needsSecondMoment ? new float[lengths[p]] : Array.Empty<float>();
-            vMax[p] = optimizerType is OptimizerType.AMSGrad ? new float[lengths[p]] : Array.Empty<float>();
+            vMax[p] = optimizerType is OptimizerType.AMSGrad or OptimizerType.AdaDelta or OptimizerType.FTRL ? new float[lengths[p]] : Array.Empty<float>();
         }
 
         _optimizerStep = 0;
@@ -990,6 +1006,39 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                             FusedOptimizer.AdaMaxUpdateSimd(pParam, pGrad, pM, pV, len,
                                 lr, b1, b2, epsVal, _optimizerStep);
                             break;
+                        // #76: optimizers needing extra hyperparameters (FusedOptimizerExtras).
+                        case OptimizerType.AdaDelta:
+                            // accumGrad=pV, accumUpdate=pVMax; rho carried in the beta2 slot.
+                            if (wd != 0f)
+                                for (int i = 0; i < len; i++) pGrad[i] += wd * pParam[i];
+                            FusedOptimizer.AdaDeltaUpdateSimd(pParam, pGrad, pV, pVMax, len, lr, b2, epsVal);
+                            break;
+                        case OptimizerType.LARS:
+                            // velocity=pM; layer-wise trust ratio consumes wd + trust coefficient.
+                            FusedOptimizer.LARSUpdateSimd(pParam, pGrad, pM, len,
+                                lr, extras.Momentum, wd, extras.TrustCoefficient);
+                            break;
+                        case OptimizerType.FTRL:
+                            // z=pV, n=pVMax; FTRL applies its own L1/L2 regularization.
+                            FusedOptimizer.FTRLUpdateSimd(pParam, pGrad, pV, pVMax, len,
+                                lr, extras.L1, extras.L2, extras.LrPower);
+                            break;
+                        case OptimizerType.ASGD:
+                            {
+                                // η_t = lr/(1+λ·lr·t)^α ; μ_t = 1/max(1, t−t0); ax=pM.
+                                float etaT = lr / (float)Math.Pow(1.0 + extras.Lambd * lr * _optimizerStep, extras.Alpha);
+                                float muT = 1f / Math.Max(1f, _optimizerStep - extras.T0);
+                                FusedOptimizer.ASGDUpdateSimd(pParam, pGrad, pM, len,
+                                    etaT, extras.Lambd, extras.Alpha, wd, muT);
+                            }
+                            break;
+                        case OptimizerType.Rprop:
+                            // prevGrad=pM (zero-init); stepSize=pV (seed to the initial step on step 1).
+                            if (_optimizerStep == 1)
+                                for (int i = 0; i < len; i++) pV[i] = extras.RpropInitialStep;
+                            FusedOptimizer.RpropUpdate(pParam, pGrad, pM, pV, len,
+                                extras.RpropEtaPlus, extras.RpropEtaMinus, extras.RpropStepMin, extras.RpropStepMax);
+                            break;
                         default:
                             throw new NotSupportedException(
                                 $"Optimizer type {optType} is not yet supported by ConfigureOptimizer. " +
@@ -1004,7 +1053,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         OptimizerType optimizerType,
         System.Collections.Generic.IReadOnlyList<LrSchedule> groupSchedules,
         System.Collections.Generic.IReadOnlyList<int> paramToGroup,
-        float beta1, float beta2, float eps, float weightDecay)
+        float beta1, float beta2, float eps, float weightDecay,
+        FusedOptimizerExtras extras)
     {
         // CodeRabbit #425: reconfigure releases prior GPU optimizer-state.
         // See ConfigureOptimizerFloat for the rationale.
@@ -1044,11 +1094,13 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             bool needsMomentum = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
                 or OptimizerType.SGDMomentum or OptimizerType.Lion or OptimizerType.Nadam
                 or OptimizerType.AdaMax or OptimizerType.AMSGrad
-                or OptimizerType.RAdam or OptimizerType.LAMB;
+                or OptimizerType.RAdam or OptimizerType.LAMB
+                or OptimizerType.LARS or OptimizerType.ASGD or OptimizerType.Rprop;
             bool needsSecondMoment = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
                 or OptimizerType.RMSprop or OptimizerType.Nadam or OptimizerType.AMSGrad
                 or OptimizerType.Adagrad
-                or OptimizerType.RAdam or OptimizerType.LAMB or OptimizerType.AdaMax;
+                or OptimizerType.RAdam or OptimizerType.LAMB or OptimizerType.AdaMax
+                or OptimizerType.AdaDelta or OptimizerType.FTRL or OptimizerType.Rprop;
 
             // GPU fast path — same logic as ConfigureOptimizerFloat. See
             // there for the full rationale on per-param GPU/CPU dispatch.
@@ -1116,7 +1168,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
             m[p] = needsMomentum ? new float[lengths[p]] : Array.Empty<float>();
             v[p] = needsSecondMoment ? new float[lengths[p]] : Array.Empty<float>();
-            vMax[p] = optimizerType is OptimizerType.AMSGrad ? new float[lengths[p]] : Array.Empty<float>();
+            vMax[p] = optimizerType is OptimizerType.AMSGrad or OptimizerType.AdaDelta or OptimizerType.FTRL ? new float[lengths[p]] : Array.Empty<float>();
         }
 
         _optimizerStep = 0;
@@ -1260,6 +1312,34 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                             FusedOptimizer.AdaMaxUpdateSimd(pParam, pGrad, pM, pV, len,
                                 lr, b1, b2, epsVal, _optimizerStep);
                             break;
+                        // #76: optimizers needing extra hyperparameters (FusedOptimizerExtras).
+                        case OptimizerType.AdaDelta:
+                            if (wd != 0f)
+                                for (int i = 0; i < len; i++) pGrad[i] += wd * pParam[i];
+                            FusedOptimizer.AdaDeltaUpdateSimd(pParam, pGrad, pV, pVMax, len, lr, b2, epsVal);
+                            break;
+                        case OptimizerType.LARS:
+                            FusedOptimizer.LARSUpdateSimd(pParam, pGrad, pM, len,
+                                lr, extras.Momentum, wd, extras.TrustCoefficient);
+                            break;
+                        case OptimizerType.FTRL:
+                            FusedOptimizer.FTRLUpdateSimd(pParam, pGrad, pV, pVMax, len,
+                                lr, extras.L1, extras.L2, extras.LrPower);
+                            break;
+                        case OptimizerType.ASGD:
+                            {
+                                float etaT = lr / (float)Math.Pow(1.0 + extras.Lambd * lr * _optimizerStep, extras.Alpha);
+                                float muT = 1f / Math.Max(1f, _optimizerStep - extras.T0);
+                                FusedOptimizer.ASGDUpdateSimd(pParam, pGrad, pM, len,
+                                    etaT, extras.Lambd, extras.Alpha, wd, muT);
+                            }
+                            break;
+                        case OptimizerType.Rprop:
+                            if (_optimizerStep == 1)
+                                for (int i = 0; i < len; i++) pV[i] = extras.RpropInitialStep;
+                            FusedOptimizer.RpropUpdate(pParam, pGrad, pM, pV, len,
+                                extras.RpropEtaPlus, extras.RpropEtaMinus, extras.RpropStepMin, extras.RpropStepMax);
+                            break;
                         default:
                             throw new NotSupportedException(
                                 $"Optimizer type {optType} is not yet supported by ConfigureOptimizerGrouped. " +
@@ -1323,15 +1403,17 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             bool needsMomentum = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
                 or OptimizerType.SGDMomentum or OptimizerType.Lion or OptimizerType.Nadam
                 or OptimizerType.AdaMax or OptimizerType.AMSGrad
-                or OptimizerType.RAdam or OptimizerType.LAMB;
+                or OptimizerType.RAdam or OptimizerType.LAMB
+                or OptimizerType.LARS or OptimizerType.ASGD or OptimizerType.Rprop;
             bool needsSecondMoment = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
                 or OptimizerType.RMSprop or OptimizerType.Nadam or OptimizerType.AMSGrad
                 or OptimizerType.Adagrad
-                or OptimizerType.RAdam or OptimizerType.LAMB or OptimizerType.AdaMax;
+                or OptimizerType.RAdam or OptimizerType.LAMB or OptimizerType.AdaMax
+                or OptimizerType.AdaDelta or OptimizerType.FTRL or OptimizerType.Rprop;
 
             m[p] = needsMomentum ? new double[lengths[p]] : Array.Empty<double>();
             v[p] = needsSecondMoment ? new double[lengths[p]] : Array.Empty<double>();
-            vMax[p] = optimizerType is OptimizerType.AMSGrad ? new double[lengths[p]] : Array.Empty<double>();
+            vMax[p] = optimizerType is OptimizerType.AMSGrad or OptimizerType.AdaDelta or OptimizerType.FTRL ? new double[lengths[p]] : Array.Empty<double>();
         }
 
         _optimizerStep = 0;
@@ -1439,15 +1521,17 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             bool needsMomentum = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
                 or OptimizerType.SGDMomentum or OptimizerType.Lion or OptimizerType.Nadam
                 or OptimizerType.AdaMax or OptimizerType.AMSGrad
-                or OptimizerType.RAdam or OptimizerType.LAMB;
+                or OptimizerType.RAdam or OptimizerType.LAMB
+                or OptimizerType.LARS or OptimizerType.ASGD or OptimizerType.Rprop;
             bool needsSecondMoment = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
                 or OptimizerType.RMSprop or OptimizerType.Nadam or OptimizerType.AMSGrad
                 or OptimizerType.Adagrad
-                or OptimizerType.RAdam or OptimizerType.LAMB or OptimizerType.AdaMax;
+                or OptimizerType.RAdam or OptimizerType.LAMB or OptimizerType.AdaMax
+                or OptimizerType.AdaDelta or OptimizerType.FTRL or OptimizerType.Rprop;
 
             m[p] = needsMomentum ? new double[lengths[p]] : Array.Empty<double>();
             v[p] = needsSecondMoment ? new double[lengths[p]] : Array.Empty<double>();
-            vMax[p] = optimizerType is OptimizerType.AMSGrad ? new double[lengths[p]] : Array.Empty<double>();
+            vMax[p] = optimizerType is OptimizerType.AMSGrad or OptimizerType.AdaDelta or OptimizerType.FTRL ? new double[lengths[p]] : Array.Empty<double>();
         }
 
         _optimizerStep = 0;

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -650,14 +650,21 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     /// this is the narrower "what the plan can replay today" check.</summary>
     private static void ValidatePlanOptimizerSupport(OptimizerType optimizerType)
     {
+        // AMSGrad (#74): CPU float+double plan dispatch is wired (see the
+        // AMSGradUpdateSimd cases in the four Configure* closures). GPU AMSGrad
+        // is NOT implemented — a GPU-resident parameter with AMSGrad throws at
+        // step time via the GPU switch's default branch. The common path
+        // (FeedForwardNeuralNetwork's AMSGrad default on the CPU engine) is the
+        // one this unblocks.
         bool supported = optimizerType is OptimizerType.SGD
             or OptimizerType.Adam
-            or OptimizerType.AdamW;
+            or OptimizerType.AdamW
+            or OptimizerType.AMSGrad;
         if (!supported)
         {
             throw new NotSupportedException(
                 $"Optimizer type {optimizerType} is not yet supported by CompiledTrainingPlan's " +
-                "fused-update closures. Currently supported: SGD, Adam, AdamW. " +
+                "fused-update closures. Currently supported: SGD, Adam, AdamW, AMSGrad. " +
                 "The kernel for this optimizer may still exist (see OptimizerKernels.IsFusedPathEligible); " +
                 "use eager apply via OptimizerKernels directly until a plan-level dispatch branch lands.");
         }
@@ -684,6 +691,10 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         var m = new float[paramCount][];
         // Second moment buffers (Adam, RMSprop, etc.)
         var v = new float[paramCount][];
+        // AMSGrad (#74): per-parameter running max of the second moment. Pinned
+        // and used only by the AMSGrad case; allocated per-param below only when
+        // the optimizer is AMSGrad, else left as an empty array.
+        var vMax = new float[paramCount][];
 
         // GPU path state (parallel arrays to paramArrays etc.). For each
         // parameter that's GPU-resident, gpuParam[p] / gpuGrad[p] hold the
@@ -806,6 +817,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
             m[p] = needsMomentum ? new float[lengths[p]] : Array.Empty<float>();
             v[p] = needsSecondMoment ? new float[lengths[p]] : Array.Empty<float>();
+            vMax[p] = optimizerType is OptimizerType.AMSGrad ? new float[lengths[p]] : Array.Empty<float>();
         }
 
         _optimizerStep = 0;
@@ -874,7 +886,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 if (gradArrays[p].Length == 0) continue;
 
                 fixed (float* pParam = paramArrays[p], pGrad = gradArrays[p],
-                       pM = m[p], pV = v[p])
+                       pM = m[p], pV = v[p], pVMax = vMax[p])
                 {
                     switch (optType)
                     {
@@ -901,6 +913,19 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                         case OptimizerType.AdamW:
                             FusedOptimizer.AdamWUpdateSimd(pParam, pGrad, pM, pV, len,
                                 lr, b1, b2, epsVal, wd, _optimizerStep);
+                            break;
+                        case OptimizerType.AMSGrad:
+                            // AMSGrad (#74): Adam with a running max of v̂ so the
+                            // denominator can only grow — the non-increasing-step
+                            // property the FeedForwardNeuralNetwork default relies on
+                            // (drift fix, AiDotNet #1332). Uses Adam's L2 weight-decay
+                            // convention (grad += wd*param); wd is 0 for that default.
+                            // AMSGradUpdateSimd binds the float or double overload by
+                            // pointer type.
+                            if (wd != 0f)
+                                for (int i = 0; i < len; i++) pGrad[i] += wd * pParam[i];
+                            FusedOptimizer.AMSGradUpdateSimd(pParam, pGrad, pM, pV, pVMax, len,
+                                lr, b1, b2, epsVal, _optimizerStep);
                             break;
                         default:
                             throw new NotSupportedException(
@@ -931,6 +956,10 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         var lengths = new int[paramCount];
         var m = new float[paramCount][];
         var v = new float[paramCount][];
+        // AMSGrad (#74): per-parameter running max of the second moment. Pinned
+        // and used only by the AMSGrad case; allocated per-param below only when
+        // the optimizer is AMSGrad, else left as an empty array.
+        var vMax = new float[paramCount][];
         var paramGroup = new int[paramCount];
         // Snapshot schedule references — concrete types so closure can
         // see them without an extra interface dispatch per step.
@@ -1022,6 +1051,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
             m[p] = needsMomentum ? new float[lengths[p]] : Array.Empty<float>();
             v[p] = needsSecondMoment ? new float[lengths[p]] : Array.Empty<float>();
+            vMax[p] = optimizerType is OptimizerType.AMSGrad ? new float[lengths[p]] : Array.Empty<float>();
         }
 
         _optimizerStep = 0;
@@ -1088,7 +1118,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 if (gradArrays[p].Length == 0) continue;
 
                 fixed (float* pParam = paramArrays[p], pGrad = gradArrays[p],
-                       pM = m[p], pV = v[p])
+                       pM = m[p], pV = v[p], pVMax = vMax[p])
                 {
                     switch (optType)
                     {
@@ -1109,6 +1139,19 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                         case OptimizerType.AdamW:
                             FusedOptimizer.AdamWUpdateSimd(pParam, pGrad, pM, pV, len,
                                 lr, b1, b2, epsVal, wd, _optimizerStep);
+                            break;
+                        case OptimizerType.AMSGrad:
+                            // AMSGrad (#74): Adam with a running max of v̂ so the
+                            // denominator can only grow — the non-increasing-step
+                            // property the FeedForwardNeuralNetwork default relies on
+                            // (drift fix, AiDotNet #1332). Uses Adam's L2 weight-decay
+                            // convention (grad += wd*param); wd is 0 for that default.
+                            // AMSGradUpdateSimd binds the float or double overload by
+                            // pointer type.
+                            if (wd != 0f)
+                                for (int i = 0; i < len; i++) pGrad[i] += wd * pParam[i];
+                            FusedOptimizer.AMSGradUpdateSimd(pParam, pGrad, pM, pV, pVMax, len,
+                                lr, b1, b2, epsVal, _optimizerStep);
                             break;
                         default:
                             throw new NotSupportedException(
@@ -1135,6 +1178,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         var lengths = new int[paramCount];
         var m = new double[paramCount][];
         var v = new double[paramCount][];
+        // AMSGrad (#74): per-parameter running max of the second moment (see the
+        // float builder). Allocated per-param below only when AMSGrad.
+        var vMax = new double[paramCount][];
 
         // Issue #350: bind to the live backing (see ConfigureOptimizerFloat
         // for the full reasoning) — GetDataArray()'s pool-padded copy
@@ -1176,6 +1222,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
             m[p] = needsMomentum ? new double[lengths[p]] : Array.Empty<double>();
             v[p] = needsSecondMoment ? new double[lengths[p]] : Array.Empty<double>();
+            vMax[p] = optimizerType is OptimizerType.AMSGrad ? new double[lengths[p]] : Array.Empty<double>();
         }
 
         _optimizerStep = 0;
@@ -1195,7 +1242,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 if (gradArrays[p].Length == 0) continue;
                 int len = lengths[p];
                 fixed (double* pParam = paramArrays[p], pGrad = gradArrays[p],
-                       pM = m[p], pV = v[p])
+                       pM = m[p], pV = v[p], pVMax = vMax[p])
                 {
                     switch (optType)
                     {
@@ -1209,6 +1256,19 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                         case OptimizerType.AdamW:
                             FusedOptimizer.AdamWUpdateSimd(pParam, pGrad, pM, pV, len,
                                 lr, b1, b2, epsVal, wd, _optimizerStep);
+                            break;
+                        case OptimizerType.AMSGrad:
+                            // AMSGrad (#74): Adam with a running max of v̂ so the
+                            // denominator can only grow — the non-increasing-step
+                            // property the FeedForwardNeuralNetwork default relies on
+                            // (drift fix, AiDotNet #1332). Uses Adam's L2 weight-decay
+                            // convention (grad += wd*param); wd is 0 for that default.
+                            // AMSGradUpdateSimd binds the float or double overload by
+                            // pointer type.
+                            if (wd != 0f)
+                                for (int i = 0; i < len; i++) pGrad[i] += wd * pParam[i];
+                            FusedOptimizer.AMSGradUpdateSimd(pParam, pGrad, pM, pV, pVMax, len,
+                                lr, b1, b2, epsVal, _optimizerStep);
                             break;
                         default:
                             throw new NotSupportedException(
@@ -1233,6 +1293,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         var lengths = new int[paramCount];
         var m = new double[paramCount][];
         var v = new double[paramCount][];
+        // AMSGrad (#74): per-parameter running max of the second moment (see the
+        // float builder). Allocated per-param below only when AMSGrad.
+        var vMax = new double[paramCount][];
         var paramGroup = new int[paramCount];
         var schedules = new LrSchedule[groupCount];
         for (int g = 0; g < groupCount; g++) schedules[g] = groupSchedules[g];
@@ -1273,6 +1336,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
             m[p] = needsMomentum ? new double[lengths[p]] : Array.Empty<double>();
             v[p] = needsSecondMoment ? new double[lengths[p]] : Array.Empty<double>();
+            vMax[p] = optimizerType is OptimizerType.AMSGrad ? new double[lengths[p]] : Array.Empty<double>();
         }
 
         _optimizerStep = 0;
@@ -1296,7 +1360,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 double lr = groupLrs[paramGroup[p]];
 
                 fixed (double* pParam = paramArrays[p], pGrad = gradArrays[p],
-                       pM = m[p], pV = v[p])
+                       pM = m[p], pV = v[p], pVMax = vMax[p])
                 {
                     switch (optType)
                     {
@@ -1310,6 +1374,19 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                         case OptimizerType.AdamW:
                             FusedOptimizer.AdamWUpdateSimd(pParam, pGrad, pM, pV, len,
                                 lr, b1, b2, epsVal, wd, _optimizerStep);
+                            break;
+                        case OptimizerType.AMSGrad:
+                            // AMSGrad (#74): Adam with a running max of v̂ so the
+                            // denominator can only grow — the non-increasing-step
+                            // property the FeedForwardNeuralNetwork default relies on
+                            // (drift fix, AiDotNet #1332). Uses Adam's L2 weight-decay
+                            // convention (grad += wd*param); wd is 0 for that default.
+                            // AMSGradUpdateSimd binds the float or double overload by
+                            // pointer type.
+                            if (wd != 0f)
+                                for (int i = 0; i < len; i++) pGrad[i] += wd * pParam[i];
+                            FusedOptimizer.AMSGradUpdateSimd(pParam, pGrad, pM, pV, pVMax, len,
+                                lr, b1, b2, epsVal, _optimizerStep);
                             break;
                         default:
                             throw new NotSupportedException(

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -580,7 +580,12 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         FusedOptimizerExtras? extras = null)
     {
         if (schedule is null) throw new ArgumentNullException(nameof(schedule));
-        ValidatePlanOptimizerSupport(optimizerType, typeof(T) == typeof(float));
+        // GPU residency only matters for float (the GPU configure branch is
+        // float-gated); detect any GPU-backed parameter so the gate can reject
+        // optimizers without a GPU backend kernel.
+        bool hasGpuParams = typeof(T) == typeof(float)
+            && System.Array.Exists(_parameters, p => p.TryGetGpuBuffer() is not null);
+        ValidatePlanOptimizerSupport(optimizerType, typeof(T) == typeof(float), hasGpuParams);
         var ex = extras ?? new FusedOptimizerExtras();
         if (typeof(T) == typeof(float))
         {
@@ -634,7 +639,12 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     nameof(paramToGroup),
                     $"paramToGroup[{i}]={g} is out of range [0, {groupSchedules.Count}).");
         }
-        ValidatePlanOptimizerSupport(optimizerType, typeof(T) == typeof(float));
+        // GPU residency only matters for float (the GPU configure branch is
+        // float-gated); detect any GPU-backed parameter so the gate can reject
+        // optimizers without a GPU backend kernel.
+        bool hasGpuParams = typeof(T) == typeof(float)
+            && System.Array.Exists(_parameters, p => p.TryGetGpuBuffer() is not null);
+        ValidatePlanOptimizerSupport(optimizerType, typeof(T) == typeof(float), hasGpuParams);
         var ex = extras ?? new FusedOptimizerExtras();
         if (typeof(T) == typeof(float))
         {
@@ -656,11 +666,27 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     /// on the first Step(). <c>OptimizerKernels.IsFusedPathEligible</c>
     /// is the broader semantic predicate (which kernels exist at all);
     /// this is the narrower "what the plan can replay today" check.</summary>
-    private static void ValidatePlanOptimizerSupport(OptimizerType optimizerType, bool isFloat)
+    private static void ValidatePlanOptimizerSupport(OptimizerType optimizerType, bool isFloat, bool hasGpuParams)
     {
+        // Device-aware gate (CodeRabbit, PR #501): the GPU step path only ships
+        // SgdUpdate/AdamUpdate/AdamWUpdate backend kernels. AMSGrad and every
+        // float-only CPU kernel hit the GPU switch's default and throw — but on a
+        // MIXED CPU/GPU plan that throw lands AFTER earlier CPU parameters were
+        // already updated, leaving the optimizer step partially applied. Reject
+        // the unsupported-on-GPU combinations here, before _optimizerUpdate is
+        // published, so the failure is at configure time and atomic.
+        if (hasGpuParams &&
+            optimizerType is not (OptimizerType.SGD or OptimizerType.Adam or OptimizerType.AdamW))
+        {
+            throw new NotSupportedException(
+                $"Optimizer type {optimizerType} is not supported for GPU-resident parameters in " +
+                "CompiledTrainingPlan (the backend ships only SGD/Adam/AdamW GPU kernels). Use a " +
+                "CPU-resident plan for this optimizer, or SGD/Adam/AdamW on GPU.");
+        }
+
         // SGD/Adam/AdamW/AMSGrad have both float and double fused-update kernels
-        // (#74 added AMSGrad). GPU AMSGrad is NOT implemented — a GPU-resident
-        // parameter with AMSGrad throws at step time via the GPU switch default.
+        // (#74 added AMSGrad). GPU AMSGrad is NOT implemented — handled by the
+        // device-aware guard above.
         bool supportedAnyDtype = optimizerType is OptimizerType.SGD
             or OptimizerType.Adam
             or OptimizerType.AdamW

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -578,7 +578,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         float weightDecay = 0f)
     {
         if (schedule is null) throw new ArgumentNullException(nameof(schedule));
-        ValidatePlanOptimizerSupport(optimizerType);
+        ValidatePlanOptimizerSupport(optimizerType, typeof(T) == typeof(float));
         if (typeof(T) == typeof(float))
         {
             ConfigureOptimizerFloat(optimizerType, schedule, beta1, beta2, eps, weightDecay);
@@ -627,7 +627,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     nameof(paramToGroup),
                     $"paramToGroup[{i}]={g} is out of range [0, {groupSchedules.Count}).");
         }
-        ValidatePlanOptimizerSupport(optimizerType);
+        ValidatePlanOptimizerSupport(optimizerType, typeof(T) == typeof(float));
         if (typeof(T) == typeof(float))
         {
             ConfigureOptimizerFloatGrouped(optimizerType, groupSchedules, paramToGroup, beta1, beta2, eps, weightDecay);
@@ -648,25 +648,39 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     /// on the first Step(). <c>OptimizerKernels.IsFusedPathEligible</c>
     /// is the broader semantic predicate (which kernels exist at all);
     /// this is the narrower "what the plan can replay today" check.</summary>
-    private static void ValidatePlanOptimizerSupport(OptimizerType optimizerType)
+    private static void ValidatePlanOptimizerSupport(OptimizerType optimizerType, bool isFloat)
     {
-        // AMSGrad (#74): CPU float+double plan dispatch is wired (see the
-        // AMSGradUpdateSimd cases in the four Configure* closures). GPU AMSGrad
-        // is NOT implemented — a GPU-resident parameter with AMSGrad throws at
-        // step time via the GPU switch's default branch. The common path
-        // (FeedForwardNeuralNetwork's AMSGrad default on the CPU engine) is the
-        // one this unblocks.
-        bool supported = optimizerType is OptimizerType.SGD
+        // SGD/Adam/AdamW/AMSGrad have both float and double fused-update kernels
+        // (#74 added AMSGrad). GPU AMSGrad is NOT implemented — a GPU-resident
+        // parameter with AMSGrad throws at step time via the GPU switch default.
+        bool supportedAnyDtype = optimizerType is OptimizerType.SGD
             or OptimizerType.Adam
             or OptimizerType.AdamW
             or OptimizerType.AMSGrad;
+
+        // #76: these have float-only AVX2 kernels wired into the CPU float
+        // closures (FusedOptimizer.*UpdateSimd float overloads). Double plans
+        // and the GPU path fall outside the supported set (no double/GPU kernel).
+        bool supportedFloatOnly = optimizerType is OptimizerType.Nadam
+            or OptimizerType.RAdam
+            or OptimizerType.LAMB
+            or OptimizerType.RMSprop
+            or OptimizerType.Adagrad
+            or OptimizerType.Lion
+            or OptimizerType.SGDMomentum
+            or OptimizerType.AdaMax;
+
+        bool supported = supportedAnyDtype || (isFloat && supportedFloatOnly);
         if (!supported)
         {
+            string suffix = !isFloat && supportedFloatOnly
+                ? $" ({optimizerType} has a float-only fused kernel; use a float model or Adam/AdamW/AMSGrad/SGD for double.)"
+                : " The kernel for this optimizer may still exist (see OptimizerKernels.IsFusedPathEligible); " +
+                  "use eager apply via OptimizerKernels directly until a plan-level dispatch branch lands.";
             throw new NotSupportedException(
                 $"Optimizer type {optimizerType} is not yet supported by CompiledTrainingPlan's " +
-                "fused-update closures. Currently supported: SGD, Adam, AdamW, AMSGrad. " +
-                "The kernel for this optimizer may still exist (see OptimizerKernels.IsFusedPathEligible); " +
-                "use eager apply via OptimizerKernels directly until a plan-level dispatch branch lands.");
+                "fused-update closures. float: SGD/Adam/AdamW/AMSGrad/Nadam/RAdam/LAMB/RMSprop/" +
+                "Adagrad/Lion/SGDMomentum/AdaMax; double: SGD/Adam/AdamW/AMSGrad." + suffix);
         }
     }
 
@@ -723,10 +737,12 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             lengths[p] = _parameters[p].Length;
             bool needsMomentum = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
                 or OptimizerType.SGDMomentum or OptimizerType.Lion or OptimizerType.Nadam
-                or OptimizerType.AdaMax or OptimizerType.AMSGrad;
+                or OptimizerType.AdaMax or OptimizerType.AMSGrad
+                or OptimizerType.RAdam or OptimizerType.LAMB;
             bool needsSecondMoment = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
                 or OptimizerType.RMSprop or OptimizerType.Nadam or OptimizerType.AMSGrad
-                or OptimizerType.Adagrad;
+                or OptimizerType.Adagrad
+                or OptimizerType.RAdam or OptimizerType.LAMB or OptimizerType.AdaMax;
 
             // GPU fast path: param is GPU-resident → allocate matching GPU
             // state buffers and dispatch to backend kernels. Backends ship
@@ -927,6 +943,53 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                             FusedOptimizer.AMSGradUpdateSimd(pParam, pGrad, pM, pV, pVMax, len,
                                 lr, b1, b2, epsVal, _optimizerStep);
                             break;
+                        // #76: float-only kernel-backed optimizers. Buffer slots:
+                        // pM=first moment/velocity, pV=second moment/accumulator
+                        // (AdaMax reuses pV as the infinity-norm u). beta1/beta2/eps
+                        // carry each optimizer's hyperparameters (beta2 = RMSprop rho;
+                        // beta1 = SGD momentum). Optimizers without an internal
+                        // weight-decay term use Adam's L2 convention (grad += wd*param);
+                        // Lion and LAMB apply decoupled weight decay inside the kernel.
+                        case OptimizerType.Nadam:
+                            if (wd != 0f)
+                                for (int i = 0; i < len; i++) pGrad[i] += wd * pParam[i];
+                            FusedOptimizer.NadamUpdateSimd(pParam, pGrad, pM, pV, len,
+                                lr, b1, b2, epsVal, _optimizerStep);
+                            break;
+                        case OptimizerType.RAdam:
+                            if (wd != 0f)
+                                for (int i = 0; i < len; i++) pGrad[i] += wd * pParam[i];
+                            FusedOptimizer.RAdamUpdateSimd(pParam, pGrad, pM, pV, len,
+                                lr, b1, b2, epsVal, _optimizerStep);
+                            break;
+                        case OptimizerType.LAMB:
+                            FusedOptimizer.LAMBUpdateSimd(pParam, pGrad, pM, pV, len,
+                                lr, b1, b2, epsVal, wd, _optimizerStep);
+                            break;
+                        case OptimizerType.RMSprop:
+                            if (wd != 0f)
+                                for (int i = 0; i < len; i++) pGrad[i] += wd * pParam[i];
+                            FusedOptimizer.RMSpropUpdateSimd(pParam, pGrad, pV, len, lr, b2, epsVal);
+                            break;
+                        case OptimizerType.Adagrad:
+                            if (wd != 0f)
+                                for (int i = 0; i < len; i++) pGrad[i] += wd * pParam[i];
+                            FusedOptimizer.AdagradUpdateSimd(pParam, pGrad, pV, len, lr, epsVal);
+                            break;
+                        case OptimizerType.Lion:
+                            FusedOptimizer.LionUpdateSimd(pParam, pGrad, pM, len, lr, b1, b2, wd);
+                            break;
+                        case OptimizerType.SGDMomentum:
+                            if (wd != 0f)
+                                for (int i = 0; i < len; i++) pGrad[i] += wd * pParam[i];
+                            FusedOptimizer.SgdMomentumUpdateSimd(pParam, pGrad, pM, len, lr, b1, false);
+                            break;
+                        case OptimizerType.AdaMax:
+                            if (wd != 0f)
+                                for (int i = 0; i < len; i++) pGrad[i] += wd * pParam[i];
+                            FusedOptimizer.AdaMaxUpdateSimd(pParam, pGrad, pM, pV, len,
+                                lr, b1, b2, epsVal, _optimizerStep);
+                            break;
                         default:
                             throw new NotSupportedException(
                                 $"Optimizer type {optType} is not yet supported by ConfigureOptimizer. " +
@@ -980,10 +1043,12 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             lengths[p] = _parameters[p].Length;
             bool needsMomentum = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
                 or OptimizerType.SGDMomentum or OptimizerType.Lion or OptimizerType.Nadam
-                or OptimizerType.AdaMax or OptimizerType.AMSGrad;
+                or OptimizerType.AdaMax or OptimizerType.AMSGrad
+                or OptimizerType.RAdam or OptimizerType.LAMB;
             bool needsSecondMoment = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
                 or OptimizerType.RMSprop or OptimizerType.Nadam or OptimizerType.AMSGrad
-                or OptimizerType.Adagrad;
+                or OptimizerType.Adagrad
+                or OptimizerType.RAdam or OptimizerType.LAMB or OptimizerType.AdaMax;
 
             // GPU fast path — same logic as ConfigureOptimizerFloat. See
             // there for the full rationale on per-param GPU/CPU dispatch.
@@ -1153,6 +1218,48 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                             FusedOptimizer.AMSGradUpdateSimd(pParam, pGrad, pM, pV, pVMax, len,
                                 lr, b1, b2, epsVal, _optimizerStep);
                             break;
+                        // #76: float-only kernel-backed optimizers (see ConfigureOptimizerFloat
+                        // for the buffer-slot / hyperparameter-mapping rationale).
+                        case OptimizerType.Nadam:
+                            if (wd != 0f)
+                                for (int i = 0; i < len; i++) pGrad[i] += wd * pParam[i];
+                            FusedOptimizer.NadamUpdateSimd(pParam, pGrad, pM, pV, len,
+                                lr, b1, b2, epsVal, _optimizerStep);
+                            break;
+                        case OptimizerType.RAdam:
+                            if (wd != 0f)
+                                for (int i = 0; i < len; i++) pGrad[i] += wd * pParam[i];
+                            FusedOptimizer.RAdamUpdateSimd(pParam, pGrad, pM, pV, len,
+                                lr, b1, b2, epsVal, _optimizerStep);
+                            break;
+                        case OptimizerType.LAMB:
+                            FusedOptimizer.LAMBUpdateSimd(pParam, pGrad, pM, pV, len,
+                                lr, b1, b2, epsVal, wd, _optimizerStep);
+                            break;
+                        case OptimizerType.RMSprop:
+                            if (wd != 0f)
+                                for (int i = 0; i < len; i++) pGrad[i] += wd * pParam[i];
+                            FusedOptimizer.RMSpropUpdateSimd(pParam, pGrad, pV, len, lr, b2, epsVal);
+                            break;
+                        case OptimizerType.Adagrad:
+                            if (wd != 0f)
+                                for (int i = 0; i < len; i++) pGrad[i] += wd * pParam[i];
+                            FusedOptimizer.AdagradUpdateSimd(pParam, pGrad, pV, len, lr, epsVal);
+                            break;
+                        case OptimizerType.Lion:
+                            FusedOptimizer.LionUpdateSimd(pParam, pGrad, pM, len, lr, b1, b2, wd);
+                            break;
+                        case OptimizerType.SGDMomentum:
+                            if (wd != 0f)
+                                for (int i = 0; i < len; i++) pGrad[i] += wd * pParam[i];
+                            FusedOptimizer.SgdMomentumUpdateSimd(pParam, pGrad, pM, len, lr, b1, false);
+                            break;
+                        case OptimizerType.AdaMax:
+                            if (wd != 0f)
+                                for (int i = 0; i < len; i++) pGrad[i] += wd * pParam[i];
+                            FusedOptimizer.AdaMaxUpdateSimd(pParam, pGrad, pM, pV, len,
+                                lr, b1, b2, epsVal, _optimizerStep);
+                            break;
                         default:
                             throw new NotSupportedException(
                                 $"Optimizer type {optType} is not yet supported by ConfigureOptimizerGrouped. " +
@@ -1215,10 +1322,12 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
             bool needsMomentum = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
                 or OptimizerType.SGDMomentum or OptimizerType.Lion or OptimizerType.Nadam
-                or OptimizerType.AdaMax or OptimizerType.AMSGrad;
+                or OptimizerType.AdaMax or OptimizerType.AMSGrad
+                or OptimizerType.RAdam or OptimizerType.LAMB;
             bool needsSecondMoment = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
                 or OptimizerType.RMSprop or OptimizerType.Nadam or OptimizerType.AMSGrad
-                or OptimizerType.Adagrad;
+                or OptimizerType.Adagrad
+                or OptimizerType.RAdam or OptimizerType.LAMB or OptimizerType.AdaMax;
 
             m[p] = needsMomentum ? new double[lengths[p]] : Array.Empty<double>();
             v[p] = needsSecondMoment ? new double[lengths[p]] : Array.Empty<double>();
@@ -1329,10 +1438,12 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
             bool needsMomentum = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
                 or OptimizerType.SGDMomentum or OptimizerType.Lion or OptimizerType.Nadam
-                or OptimizerType.AdaMax or OptimizerType.AMSGrad;
+                or OptimizerType.AdaMax or OptimizerType.AMSGrad
+                or OptimizerType.RAdam or OptimizerType.LAMB;
             bool needsSecondMoment = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
                 or OptimizerType.RMSprop or OptimizerType.Nadam or OptimizerType.AMSGrad
-                or OptimizerType.Adagrad;
+                or OptimizerType.Adagrad
+                or OptimizerType.RAdam or OptimizerType.LAMB or OptimizerType.AdaMax;
 
             m[p] = needsMomentum ? new double[lengths[p]] : Array.Empty<double>();
             v[p] = needsSecondMoment ? new double[lengths[p]] : Array.Empty<double>();

--- a/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
@@ -482,6 +482,57 @@ internal static class FusedOptimizer
         }
     }
 
+    /// <summary>AVX2 AMSGrad (double): Adam with max of past squared gradients.
+    /// Mirrors the float <see cref="AMSGradUpdateSimd(float*,float*,float*,float*,float*,int,float,float,float,float,int)"/>
+    /// exactly so a double-precision CompiledTrainingPlan keeps the same
+    /// non-increasing-denominator guarantee (Reddi, Kale, Kumar 2018) that the
+    /// FeedForwardNeuralNetwork default relies on (drift fix, AiDotNet #1332).</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static unsafe void AMSGradUpdateSimd(
+        double* param, double* grad, double* m, double* v, double* vMax, int length,
+        double lr, double beta1, double beta2, double eps, int step)
+    {
+        double bc1 = 1.0 - System.Math.Pow(beta1, step);
+        double bc2 = 1.0 - System.Math.Pow(beta2, step);
+        double lrAdj = lr / bc1;
+        int i = 0;
+#if NET5_0_OR_GREATER
+        if (Fma.IsSupported && length >= 4)
+        {
+            var vB1 = Vector256.Create(beta1);
+            var v1mB1 = Vector256.Create(1.0 - beta1);
+            var vB2 = Vector256.Create(beta2);
+            var v1mB2 = Vector256.Create(1.0 - beta2);
+            var vLr = Vector256.Create(-lrAdj);
+            var vEps = Vector256.Create(eps);
+            var vBc2Inv = Vector256.Create(1.0 / bc2);
+            int simdLen = length & ~3;
+            for (; i < simdLen; i += 4)
+            {
+                var g = Avx.LoadVector256(grad + i);
+                var mNew = Fma.MultiplyAdd(vB1, Avx.LoadVector256(m + i), Avx.Multiply(v1mB1, g));
+                Avx.Store(m + i, mNew);
+                var vNew = Fma.MultiplyAdd(vB2, Avx.LoadVector256(v + i), Avx.Multiply(v1mB2, Avx.Multiply(g, g)));
+                Avx.Store(v + i, vNew);
+                var vmNew = Avx.Max(Avx.LoadVector256(vMax + i), vNew);
+                Avx.Store(vMax + i, vmNew);
+                var vMaxHat = Avx.Multiply(vmNew, vBc2Inv);
+                var denom = Avx.Add(Avx.Sqrt(vMaxHat), vEps);
+                Avx.Store(param + i, Fma.MultiplyAdd(vLr, Avx.Divide(mNew, denom), Avx.LoadVector256(param + i)));
+            }
+        }
+#endif
+        for (; i < length; i++)
+        {
+            m[i] = beta1 * m[i] + (1.0 - beta1) * grad[i];
+            v[i] = beta2 * v[i] + (1.0 - beta2) * grad[i] * grad[i];
+            vMax[i] = System.Math.Max(vMax[i], v[i]);
+            double mHat = m[i] / bc1;
+            double vMaxHat = vMax[i] / bc2;
+            param[i] -= lr * mHat / (System.Math.Sqrt(vMaxHat) + eps);
+        }
+    }
+
     /// <summary>AVX2 Nadam: Adam with Nesterov momentum</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static unsafe void NadamUpdateSimd(

--- a/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
@@ -1278,6 +1278,49 @@ internal static class FusedOptimizer
     }
 }
 
+/// <summary>
+/// Extra per-optimizer hyperparameters that don't fit the generic
+/// (learningRate, beta1, beta2, eps, weightDecay) slots of
+/// <c>CompiledTrainingPlan.ConfigureOptimizer</c>. Pass an instance to configure
+/// AdaDelta / LARS / FTRL / ASGD / Rprop; omit it to use the per-field defaults.
+/// All other optimizers ignore it.
+/// </summary>
+/// <remarks>
+/// A class with property initializers (not a record struct) so <c>new
+/// FusedOptimizerExtras()</c> reliably yields the documented defaults — a
+/// <c>default</c> record-struct would zero every field, which is wrong for e.g.
+/// LARS <c>TrustCoefficient</c> or Rprop step bounds.
+/// </remarks>
+public sealed class FusedOptimizerExtras
+{
+    /// <summary>LARS momentum coefficient. Default 0.9.</summary>
+    public float Momentum { get; init; } = 0.9f;
+    /// <summary>LARS trust coefficient (η in the layer-wise trust ratio). Default 0.001.</summary>
+    public float TrustCoefficient { get; init; } = 0.001f;
+    /// <summary>FTRL L1 regularization strength. Default 0.</summary>
+    public float L1 { get; init; } = 0f;
+    /// <summary>FTRL L2 regularization strength. Default 0.</summary>
+    public float L2 { get; init; } = 0f;
+    /// <summary>FTRL learning-rate power (β in n^β). Default -0.5.</summary>
+    public float LrPower { get; init; } = -0.5f;
+    /// <summary>ASGD decay term λ in η_t = lr/(1+λ·lr·t)^α. Default 1e-4.</summary>
+    public float Lambd { get; init; } = 1e-4f;
+    /// <summary>ASGD decay exponent α. Default 0.75.</summary>
+    public float Alpha { get; init; } = 0.75f;
+    /// <summary>ASGD averaging start step t0 (μ_t = 1/max(1, t−t0)). Default 1e6.</summary>
+    public float T0 { get; init; } = 1e6f;
+    /// <summary>Rprop step-increase factor η⁺. Default 1.2.</summary>
+    public float RpropEtaPlus { get; init; } = 1.2f;
+    /// <summary>Rprop step-decrease factor η⁻. Default 0.5.</summary>
+    public float RpropEtaMinus { get; init; } = 0.5f;
+    /// <summary>Rprop minimum step size. Default 1e-6.</summary>
+    public float RpropStepMin { get; init; } = 1e-6f;
+    /// <summary>Rprop maximum step size. Default 50.</summary>
+    public float RpropStepMax { get; init; } = 50f;
+    /// <summary>Rprop initial per-element step size. Default 0.01.</summary>
+    public float RpropInitialStep { get; init; } = 0.01f;
+}
+
 /// <summary>Optimizer type for fused parameter updates.</summary>
 public enum OptimizerType
 {

--- a/src/AiDotNet.Tensors/Engines/Compilation/ICompiledPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/ICompiledPlan.cs
@@ -407,7 +407,8 @@ public interface ICompiledTrainingPlan<T> : IDisposable
         float beta1 = 0.9f,
         float beta2 = 0.999f,
         float eps = 1e-8f,
-        float weightDecay = 0f);
+        float weightDecay = 0f,
+        FusedOptimizerExtras? extras = null);
 
     /// <summary>
     /// Configures global gradient L2-norm clipping for the fused training
@@ -440,7 +441,8 @@ public interface ICompiledTrainingPlan<T> : IDisposable
         float beta1 = 0.9f,
         float beta2 = 0.999f,
         float eps = 1e-8f,
-        float weightDecay = 0f);
+        float weightDecay = 0f,
+        FusedOptimizerExtras? extras = null);
 
     /// <summary>
     /// Configures fused optimizer updates with a per-parameter-group
@@ -468,7 +470,8 @@ public interface ICompiledTrainingPlan<T> : IDisposable
         float beta1 = 0.9f,
         float beta2 = 0.999f,
         float eps = 1e-8f,
-        float weightDecay = 0f);
+        float weightDecay = 0f,
+        FusedOptimizerExtras? extras = null);
 
     /// <summary>
     /// Issue #338 Phase G.4: Enables pre-packed-B caching on the forward

--- a/src/AiDotNet.Tensors/Helpers/CpuFusedOperations.cs
+++ b/src/AiDotNet.Tensors/Helpers/CpuFusedOperations.cs
@@ -1233,6 +1233,13 @@ public static class CpuFusedOperations
         { FusedActivationType.Tanh, MathF.Tanh },
         { FusedActivationType.LeakyReLU, x => x > 0f ? x : 0.01f * x },
         { FusedActivationType.Swish, x => x / (1f + MathF.Exp(-x)) },
+        { FusedActivationType.ELU, ApplyElu },
+        { FusedActivationType.SELU, ApplySelu },
+        { FusedActivationType.Softplus, ApplySoftplus },
+        { FusedActivationType.Mish, ApplyMish },
+        { FusedActivationType.HardSwish, ApplyHardSwish },
+        { FusedActivationType.HardSigmoid, ApplyHardSigmoid },
+        { FusedActivationType.HardTanh, ApplyHardTanh },
         // Softmax is NOT pointwise (depends on entire row) — must not appear here.
         // Fused paths that include Softmax should apply it separately after the GEMM loop.
     };
@@ -1260,6 +1267,36 @@ public static class CpuFusedOperations
         float inner = sqrt2OverPi * (x + coeff * xCubed);
         return 0.5f * x * (1f + MathF.Tanh(inner));
     }
+
+    // SELU constants (Klambauer et al., 2017 — self-normalizing networks).
+    private const float SeluAlpha = 1.6732632423543772f;
+    private const float SeluScale = 1.0507009873554805f;
+
+    [MethodImpl(Hot)]
+    private static float ApplyElu(float x) => x > 0f ? x : MathF.Exp(x) - 1f; // alpha = 1
+    [MethodImpl(Hot)]
+    private static float ApplySelu(float x) => SeluScale * (x > 0f ? x : SeluAlpha * (MathF.Exp(x) - 1f));
+    // Softplus with the standard large-x linear cutoff (matches PyTorch's threshold=20)
+    // so exp() can't overflow; above the threshold log(1+e^x) ≈ x to float precision.
+    [MethodImpl(Hot)]
+    private static float ApplySoftplus(float x) => x > 20f ? x : MathF.Log(1f + MathF.Exp(x));
+    [MethodImpl(Hot)]
+    private static float ApplyMish(float x) => x * MathF.Tanh(ApplySoftplus(x));
+    [MethodImpl(Hot)]
+    private static float ApplyHardSwish(float x)
+    {
+        float t = (x + 3f) / 6f;
+        t = t < 0f ? 0f : (t > 1f ? 1f : t);
+        return x * t;
+    }
+    [MethodImpl(Hot)]
+    private static float ApplyHardSigmoid(float x)
+    {
+        float t = (x + 3f) / 6f;
+        return t < 0f ? 0f : (t > 1f ? 1f : t);
+    }
+    [MethodImpl(Hot)]
+    private static float ApplyHardTanh(float x) => x < -1f ? -1f : (x > 1f ? 1f : x);
 
     #endregion
 
@@ -1345,6 +1382,13 @@ public static class CpuFusedOperations
         { FusedActivationType.Tanh, Math.Tanh },
         { FusedActivationType.LeakyReLU, x => x > 0.0 ? x : 0.01 * x },
         { FusedActivationType.Swish, x => x / (1.0 + Math.Exp(-x)) },
+        { FusedActivationType.ELU, ApplyEluDouble },
+        { FusedActivationType.SELU, ApplySeluDouble },
+        { FusedActivationType.Softplus, ApplySoftplusDouble },
+        { FusedActivationType.Mish, ApplyMishDouble },
+        { FusedActivationType.HardSwish, ApplyHardSwishDouble },
+        { FusedActivationType.HardSigmoid, ApplyHardSigmoidDouble },
+        { FusedActivationType.HardTanh, ApplyHardTanhDouble },
         // Softmax is NOT pointwise — must not appear here.
     };
 
@@ -1367,6 +1411,30 @@ public static class CpuFusedOperations
         double inner = sqrt2OverPi * (x + coeff * xCubed);
         return 0.5 * x * (1.0 + Math.Tanh(inner));
     }
+
+    [MethodImpl(Hot)]
+    private static double ApplyEluDouble(double x) => x > 0.0 ? x : Math.Exp(x) - 1.0;
+    [MethodImpl(Hot)]
+    private static double ApplySeluDouble(double x) => 1.0507009873554805 * (x > 0.0 ? x : 1.6732632423543772 * (Math.Exp(x) - 1.0));
+    [MethodImpl(Hot)]
+    private static double ApplySoftplusDouble(double x) => x > 20.0 ? x : Math.Log(1.0 + Math.Exp(x));
+    [MethodImpl(Hot)]
+    private static double ApplyMishDouble(double x) => x * Math.Tanh(ApplySoftplusDouble(x));
+    [MethodImpl(Hot)]
+    private static double ApplyHardSwishDouble(double x)
+    {
+        double t = (x + 3.0) / 6.0;
+        t = t < 0.0 ? 0.0 : (t > 1.0 ? 1.0 : t);
+        return x * t;
+    }
+    [MethodImpl(Hot)]
+    private static double ApplyHardSigmoidDouble(double x)
+    {
+        double t = (x + 3.0) / 6.0;
+        return t < 0.0 ? 0.0 : (t > 1.0 ? 1.0 : t);
+    }
+    [MethodImpl(Hot)]
+    private static double ApplyHardTanhDouble(double x) => x < -1.0 ? -1.0 : (x > 1.0 ? 1.0 : x);
 
     #endregion
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/ConfigureOptimizerAMSGradTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/ConfigureOptimizerAMSGradTests.cs
@@ -1,0 +1,270 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// #74: AMSGrad fused plan-dispatch. Before this change CompiledTrainingPlan's
+/// ConfigureOptimizer threw <c>NotSupportedException("Optimizer type AMSGrad …")</c>,
+/// so AiDotNet's FeedForwardNeuralNetwork — whose default optimizer is AMSGrad-mode
+/// Adam (chosen for the #1332 drift fix) — silently fell back to the eager tape for
+/// EVERY training run (the "compiled does nothing" symptom the AIsEval/parity harness
+/// surfaced).
+///
+/// Two layers of coverage:
+///  - Kernel-direct: drive <see cref="FusedOptimizer.AMSGradUpdateSimd(float*,float*,float*,float*,float*,int,float,float,float,float,int)"/>
+///    with a KNOWN gradient sequence (rise then fall, so vMax exceeds v and the max
+///    path actually matters) and compare against an independent textbook AMSGrad
+///    reference. This validates the AVX2 update against the canonical formula
+///    unambiguously (no graph-gradient semantics involved).
+///  - Plan-level: ConfigureOptimizer(AMSGrad) must dispatch (no NotSupportedException),
+///    update parameters in place, equal Adam on step 1 (when vMax == v), and diverge
+///    from Adam once vMax > v (proving the vMax buffer is consulted, not aliased).
+/// </summary>
+public class ConfigureOptimizerAMSGradTests
+{
+    private const float Lr = 0.05f, B1 = 0.9f, B2 = 0.999f, Eps = 1e-8f;
+
+    // ---- kernel-direct parity ------------------------------------------------
+
+    /// <summary>Independent textbook AMSGrad replay over an explicit gradient sequence.</summary>
+    private static float[] ReferenceAMSGradFloat(float[] w0, float[][] grads, float lr, float b1, float b2, float eps)
+    {
+        var w = (float[])w0.Clone();
+        var m = new float[w.Length];
+        var v = new float[w.Length];
+        var vMax = new float[w.Length];
+        for (int t = 1; t <= grads.Length; t++)
+        {
+            float bc1 = 1f - MathF.Pow(b1, t);
+            float bc2 = 1f - MathF.Pow(b2, t);
+            var g = grads[t - 1];
+            for (int i = 0; i < w.Length; i++)
+            {
+                m[i] = b1 * m[i] + (1f - b1) * g[i];
+                v[i] = b2 * v[i] + (1f - b2) * g[i] * g[i];
+                vMax[i] = MathF.Max(vMax[i], v[i]);
+                w[i] -= lr * (m[i] / bc1) / (MathF.Sqrt(vMax[i] / bc2) + eps);
+            }
+        }
+        return w;
+    }
+
+    private static double[] ReferenceAMSGradDouble(double[] w0, double[][] grads, double lr, double b1, double b2, double eps)
+    {
+        var w = (double[])w0.Clone();
+        var m = new double[w.Length];
+        var v = new double[w.Length];
+        var vMax = new double[w.Length];
+        for (int t = 1; t <= grads.Length; t++)
+        {
+            double bc1 = 1.0 - Math.Pow(b1, t);
+            double bc2 = 1.0 - Math.Pow(b2, t);
+            var g = grads[t - 1];
+            for (int i = 0; i < w.Length; i++)
+            {
+                m[i] = b1 * m[i] + (1.0 - b1) * g[i];
+                v[i] = b2 * v[i] + (1.0 - b2) * g[i] * g[i];
+                vMax[i] = Math.Max(vMax[i], v[i]);
+                w[i] -= lr * (m[i] / bc1) / (Math.Sqrt(vMax[i] / bc2) + eps);
+            }
+        }
+        return w;
+    }
+
+    /// <summary>Gradient sequence that rises (steps 1..4) then falls (steps 5..12), so
+    /// the running max vMax holds the early peak while v decays — the regime where
+    /// AMSGrad's max-denominator differs from plain Adam.</summary>
+    private static float[][] RiseThenFallGrads(int n, int seed)
+    {
+        var rng = new Random(seed);
+        var baseG = new float[n];
+        for (int i = 0; i < n; i++) baseG[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+        var grads = new float[12][];
+        for (int t = 0; t < 12; t++)
+        {
+            float scale = t < 4 ? 1.0f : 0.05f;
+            var g = new float[n];
+            for (int i = 0; i < n; i++) g[i] = baseG[i] * scale;
+            grads[t] = g;
+        }
+        return grads;
+    }
+
+    [Fact]
+    public unsafe void AMSGradUpdateSimd_Float_MatchesCanonicalFormula()
+    {
+        const int n = 16; // >= 8 so the AVX2 path runs
+        var rng = new Random(3);
+        var w = new float[n];
+        for (int i = 0; i < n; i++) w[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+        var grads = RiseThenFallGrads(n, seed: 5);
+
+        var reference = ReferenceAMSGradFloat(w, grads, Lr, B1, B2, Eps);
+
+        var m = new float[n];
+        var v = new float[n];
+        var vMax = new float[n];
+        for (int t = 1; t <= grads.Length; t++)
+        {
+            var g = (float[])grads[t - 1].Clone(); // kernel reads grad in place
+            fixed (float* pW = w, pG = g, pM = m, pV = v, pVMax = vMax)
+                FusedOptimizer.AMSGradUpdateSimd(pW, pG, pM, pV, pVMax, n, Lr, B1, B2, Eps, t);
+        }
+
+        double maxAbs = 0;
+        for (int i = 0; i < n; i++) maxAbs = Math.Max(maxAbs, Math.Abs(w[i] - reference[i]));
+        Assert.True(maxAbs < 1e-4,
+            $"AMSGradUpdateSimd(float) diverged from the canonical AMSGrad formula. max |Δ| = {maxAbs}");
+    }
+
+    [Fact]
+    public unsafe void AMSGradUpdateSimd_Double_MatchesCanonicalFormula()
+    {
+        const int n = 16;
+        var rng = new Random(3);
+        var w = new double[n];
+        for (int i = 0; i < n; i++) w[i] = rng.NextDouble() * 2.0 - 1.0;
+        var gradsF = RiseThenFallGrads(n, seed: 5);
+        var grads = new double[gradsF.Length][];
+        for (int t = 0; t < gradsF.Length; t++)
+        {
+            grads[t] = new double[n];
+            for (int i = 0; i < n; i++) grads[t][i] = gradsF[t][i];
+        }
+
+        var reference = ReferenceAMSGradDouble(w, grads, Lr, B1, B2, Eps);
+
+        var m = new double[n];
+        var v = new double[n];
+        var vMax = new double[n];
+        for (int t = 1; t <= grads.Length; t++)
+        {
+            var g = (double[])grads[t - 1].Clone();
+            fixed (double* pW = w, pG = g, pM = m, pV = v, pVMax = vMax)
+                FusedOptimizer.AMSGradUpdateSimd(pW, pG, pM, pV, pVMax, n, Lr, B1, B2, Eps, t);
+        }
+
+        double maxAbs = 0;
+        for (int i = 0; i < n; i++) maxAbs = Math.Max(maxAbs, Math.Abs(w[i] - reference[i]));
+        Assert.True(maxAbs < 1e-12,
+            $"AMSGradUpdateSimd(double) diverged from the canonical AMSGrad formula. max |Δ| = {maxAbs}");
+    }
+
+    // ---- plan-level wiring ---------------------------------------------------
+
+    private static float[] RunPlanFloat(float[] init, OptimizerType opt, int steps)
+    {
+        var engine = new CpuEngine();
+        var weight = new Tensor<float>(new[] { init.Length });
+        for (int i = 0; i < init.Length; i++) weight[i] = init[i];
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var sq = engine.TensorMultiply(weight, weight);
+            engine.ReduceSum(sq, null);
+            plan = scope.CompileTraining(new[] { weight });
+        }
+        using (plan)
+        {
+            plan.ConfigureOptimizer(opt, Lr, B1, B2, Eps);
+            for (int s = 0; s < steps; s++) plan.Step();
+        }
+        return weight.GetDataArray().AsSpan(0, init.Length).ToArray();
+    }
+
+    private static float[] SeedFloat(int n, int seed)
+    {
+        var rng = new Random(seed);
+        var w = new float[n];
+        for (int i = 0; i < n; i++) w[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+        return w;
+    }
+
+    /// <summary>
+    /// Direct regression for the NotSupportedException that demoted every
+    /// FeedForwardNeuralNetwork to the eager tape: ConfigureOptimizer(AMSGrad) must
+    /// dispatch and mutate the parameter in place.
+    /// </summary>
+    [Fact]
+    public void ConfigureOptimizer_AMSGradFloat_StepUpdatesParameterInPlace()
+    {
+        var init = SeedFloat(11, seed: 7);
+        var post = RunPlanFloat(init, OptimizerType.AMSGrad, steps: 1);
+        double maxAbs = 0;
+        for (int i = 0; i < init.Length; i++) maxAbs = Math.Max(maxAbs, Math.Abs(post[i] - init[i]));
+        Assert.True(maxAbs > 0,
+            $"AMSGrad(float) Step() did not update the parameter in place (dispatch missing?). max |Δ| = {maxAbs}");
+    }
+
+    [Fact]
+    public void ConfigureOptimizer_AMSGradDouble_StepUpdatesParameterInPlace()
+    {
+        var engine = new CpuEngine();
+        var rng = new Random(7);
+        var weight = new Tensor<double>(new[] { 11 });
+        var init = new double[11];
+        for (int i = 0; i < 11; i++) { init[i] = rng.NextDouble() * 2.0 - 1.0; weight[i] = init[i]; }
+
+        ICompiledTrainingPlan<double> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var sq = engine.TensorMultiply(weight, weight);
+            engine.ReduceSum(sq, null);
+            plan = scope.CompileTraining(new[] { weight });
+        }
+        using (plan)
+        {
+            plan.ConfigureOptimizer(OptimizerType.AMSGrad, Lr, B1, B2, Eps);
+            plan.Step();
+        }
+
+        var post = weight.GetDataArray();
+        double maxAbs = 0;
+        for (int i = 0; i < 11; i++) maxAbs = Math.Max(maxAbs, Math.Abs(post[i] - init[i]));
+        Assert.True(maxAbs > 0,
+            $"AMSGrad(double) Step() did not update the parameter in place. max |Δ| = {maxAbs}");
+    }
+
+    /// <summary>
+    /// On step 1, vMax = max(0, v) = v, so AMSGrad is identical to Adam through the
+    /// plan. Pins the step-1 update (m / v / bias-correction wiring) independently of
+    /// the vMax path.
+    /// </summary>
+    [Fact]
+    public void ConfigureOptimizer_AMSGradFloat_Step1_EqualsAdam()
+    {
+        var init = SeedFloat(11, seed: 13);
+        var ams = RunPlanFloat(init, OptimizerType.AMSGrad, steps: 1);
+        var adam = RunPlanFloat(init, OptimizerType.Adam, steps: 1);
+        double maxAbs = 0;
+        for (int i = 0; i < init.Length; i++) maxAbs = Math.Max(maxAbs, Math.Abs(ams[i] - adam[i]));
+        Assert.True(maxAbs < 1e-6,
+            $"AMSGrad and Adam must be identical on step 1 (vMax == v). max |Δ| = {maxAbs}");
+    }
+
+    /// <summary>
+    /// Proves the vMax buffer is consulted: with loss = sum(w²), w shrinks toward 0 so
+    /// the gradient and thus v decay; once vMax > v, AMSGrad's larger denominator takes
+    /// smaller steps than Adam, so the trajectories must diverge measurably. If vMax
+    /// were ignored (AMSGrad aliased to Adam), this stays ~0.
+    /// </summary>
+    [Fact]
+    public void ConfigureOptimizer_AMSGradFloat_DivergesFromAdam_OverManySteps()
+    {
+        var init = SeedFloat(11, seed: 21);
+        const int steps = 40;
+        var ams = RunPlanFloat(init, OptimizerType.AMSGrad, steps);
+        var adam = RunPlanFloat(init, OptimizerType.Adam, steps);
+        double maxAbs = 0;
+        for (int i = 0; i < init.Length; i++) maxAbs = Math.Max(maxAbs, Math.Abs(ams[i] - adam[i]));
+        Assert.True(maxAbs > 1e-5,
+            $"AMSGrad never diverged from Adam over {steps} steps — vMax appears unused. max |Δ| = {maxAbs}");
+        foreach (var x in ams)
+            Assert.True(!float.IsNaN(x) && !float.IsInfinity(x), "AMSGrad produced a non-finite parameter");
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/ConfigureOptimizerFusedDispatchTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/ConfigureOptimizerFusedDispatchTests.cs
@@ -40,6 +40,12 @@ public class ConfigureOptimizerFusedDispatchTests
         OptimizerType.Lion,
         OptimizerType.SGDMomentum,
         OptimizerType.AdaMax,
+        // #76 part 2: optimizers wired via the FusedOptimizerExtras API extension.
+        OptimizerType.AdaDelta,
+        OptimizerType.LARS,
+        OptimizerType.FTRL,
+        OptimizerType.ASGD,
+        OptimizerType.Rprop,
     };
 
     /// <summary>
@@ -117,17 +123,20 @@ public class ConfigureOptimizerFusedDispatchTests
     }
 
     /// <summary>
-    /// Optimizers whose kernels need hyperparameters the ConfigureOptimizer API
-    /// doesn't carry (AdaDelta rho+2 accumulators, FTRL l1/l2/lr_power, LARS
-    /// trust coeff, ASGD lambd/alpha/mu) are intentionally NOT wired and must
-    /// still be rejected at configure time — so models using them fall back to
-    /// the eager tape cleanly instead of configuring then throwing mid-step.
+    /// Optimizers that need an execution model the per-parameter fused
+    /// optimizer-step loop can't provide are intentionally NOT wired and must be
+    /// rejected at configure time, so models using them fall back to the eager
+    /// tape cleanly: SparseAdam (sparse-gradient index lists), LBFGS (closure
+    /// line-search over the whole loss), HypergradientSGD / DAdaptationSGD (need
+    /// a GLOBAL cross-parameter reduction, not per-tensor), ScheduleFreeSGD
+    /// (needs a y-buffer written before the forward pass).
     /// </summary>
     [Theory]
-    [InlineData(OptimizerType.AdaDelta)]
-    [InlineData(OptimizerType.FTRL)]
-    [InlineData(OptimizerType.LARS)]
-    [InlineData(OptimizerType.ASGD)]
+    [InlineData(OptimizerType.SparseAdam)]
+    [InlineData(OptimizerType.LBFGS)]
+    [InlineData(OptimizerType.HypergradientSGD)]
+    [InlineData(OptimizerType.ScheduleFreeSGD)]
+    [InlineData(OptimizerType.DAdaptationSGD)]
     public void ConfigureOptimizer_UnwiredOptimizer_Throws(OptimizerType opt)
     {
         var engine = new CpuEngine();
@@ -145,5 +154,64 @@ public class ConfigureOptimizerFusedDispatchTests
         {
             Assert.Throws<NotSupportedException>(() => plan.ConfigureOptimizer(opt, Lr, B1, B2, Eps));
         }
+    }
+
+    private static float[] SeedFloat(int n, int seed)
+    {
+        var rng = new Random(seed);
+        var w = new float[n];
+        for (int i = 0; i < n; i++) w[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+        return w;
+    }
+
+    private static float L1Norm(float[] w)
+    {
+        float s = 0;
+        foreach (var x in w) s += Math.Abs(x);
+        return s;
+    }
+
+    private static float[] RunFtrl(float[] init, float l1)
+    {
+        var engine = new CpuEngine();
+        var weight = new Tensor<float>(new[] { init.Length });
+        for (int i = 0; i < init.Length; i++) weight[i] = init[i];
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var sq = engine.TensorMultiply(weight, weight);
+            engine.ReduceSum(sq, null);
+            plan = scope.CompileTraining(new[] { weight });
+        }
+        using (plan)
+        {
+            // The 6th positional arg is weightDecay; the 7th is the extras object.
+            plan.ConfigureOptimizer(OptimizerType.FTRL, 0.1f, B1, B2, Eps, 0f,
+                new FusedOptimizerExtras { L1 = l1, L2 = 0f, LrPower = -0.5f });
+            for (int s = 0; s < 6; s++) plan.Step();
+        }
+        return weight.GetDataArray().AsSpan(0, init.Length).ToArray();
+    }
+
+    /// <summary>
+    /// Proves the FusedOptimizerExtras values actually flow into the kernel (not
+    /// ignored): FTRL with a strong L1 penalty must drive parameters closer to
+    /// zero (sparsity via the L1 proximal soft-threshold) than FTRL with L1=0 on
+    /// the same trajectory. If extras were dropped, both runs would be identical.
+    /// </summary>
+    [Fact]
+    public void ConfigureOptimizer_FtrlExtras_L1_DrivesSparsity()
+    {
+        var init = SeedFloat(16, seed: 55);
+        var noL1 = RunFtrl(init, l1: 0f);
+        var strongL1 = RunFtrl(init, l1: 5f);
+
+        foreach (var x in strongL1)
+            Assert.True(!float.IsNaN(x) && !float.IsInfinity(x), "FTRL produced a non-finite parameter");
+
+        Assert.True(L1Norm(strongL1) < L1Norm(noL1),
+            $"FTRL L1 extras did not increase sparsity: ||w||₁(L1=5)={L1Norm(strongL1)} should be < " +
+            $"||w||₁(L1=0)={L1Norm(noL1)} — extras may not be flowing into the kernel.");
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/ConfigureOptimizerFusedDispatchTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/ConfigureOptimizerFusedDispatchTests.cs
@@ -1,0 +1,149 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// #76: wire the remaining kernel-backed optimizers (Nadam, RAdam, LAMB, RMSprop,
+/// Adagrad, Lion, SGDMomentum, AdaMax) into CompiledTrainingPlan's float CPU
+/// fused-update dispatch. Each previously threw NotSupportedException at
+/// ConfigureOptimizer (kernel existed in FusedOptimizer but no plan dispatch
+/// branch), forcing the eager tape.
+///
+/// These tests exercise the new DISPATCH wiring end-to-end through the plan
+/// (buffer-slot selection + hyperparameter mapping + per-step replay): each wired
+/// optimizer must configure without throwing, update parameters in place, keep
+/// them finite, and move them meaningfully over several steps. The numerical
+/// correctness of each kernel's math is covered by the kernels' own tests; this
+/// validates that the plan routes the right buffers/params to the right kernel.
+/// (AMSGrad additionally has full kernel-direct parity in
+/// ConfigureOptimizerAMSGradTests.)
+/// </summary>
+public class ConfigureOptimizerFusedDispatchTests
+{
+    private const float Lr = 0.03f, B1 = 0.9f, B2 = 0.99f, Eps = 1e-8f;
+
+    public static TheoryData<OptimizerType> WiredFloatOptimizers => new()
+    {
+        OptimizerType.SGD,
+        OptimizerType.Adam,
+        OptimizerType.AdamW,
+        OptimizerType.AMSGrad,
+        OptimizerType.Nadam,
+        OptimizerType.RAdam,
+        OptimizerType.LAMB,
+        OptimizerType.RMSprop,
+        OptimizerType.Adagrad,
+        OptimizerType.Lion,
+        OptimizerType.SGDMomentum,
+        OptimizerType.AdaMax,
+    };
+
+    /// <summary>
+    /// Every wired float optimizer must dispatch through the fused plan (no
+    /// NotSupportedException), update the parameter in place, stay finite, and
+    /// move it meaningfully over several steps. Catches a missing buffer
+    /// (crash/NaN), a missing gate entry (throw), or a grossly wrong mapping
+    /// (no movement / blow-up).
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(WiredFloatOptimizers))]
+    public void ConfigureOptimizer_WiredFloatOptimizer_DispatchesAndUpdatesInPlace(OptimizerType opt)
+    {
+        var engine = new CpuEngine();
+        const int n = 16;
+        var rng = new Random(101);
+        var weight = new Tensor<float>(new[] { n });
+        var init = new float[n];
+        for (int i = 0; i < n; i++) { init[i] = (float)(rng.NextDouble() * 2.0 - 1.0); weight[i] = init[i]; }
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var sq = engine.TensorMultiply(weight, weight);
+            engine.ReduceSum(sq, null);
+            plan = scope.CompileTraining(new[] { weight });
+        }
+        using (plan)
+        {
+            // Must NOT throw — this is the regression for the per-optimizer
+            // NotSupportedException that forced eager fallback.
+            plan.ConfigureOptimizer(opt, Lr, B1, B2, Eps);
+            for (int s = 0; s < 5; s++) plan.Step();
+        }
+
+        var post = weight.GetDataArray();
+        double maxAbs = 0;
+        for (int i = 0; i < n; i++)
+        {
+            Assert.True(!float.IsNaN(post[i]) && !float.IsInfinity(post[i]),
+                $"{opt}: fused step produced a non-finite parameter at {i} ({post[i]}).");
+            maxAbs = Math.Max(maxAbs, Math.Abs(post[i] - init[i]));
+        }
+        Assert.True(maxAbs > 1e-6,
+            $"{opt}: fused dispatch did not move the parameter over 5 steps (max |Δ| = {maxAbs}).");
+    }
+
+    /// <summary>
+    /// The newly-wired optimizers have float-only kernels. A double plan must
+    /// reject them at ConfigureOptimizer (the dtype-aware gate) rather than
+    /// configure-then-throw at step time, so callers cleanly stay on eager.
+    /// </summary>
+    [Theory]
+    [InlineData(OptimizerType.Nadam)]
+    [InlineData(OptimizerType.RMSprop)]
+    [InlineData(OptimizerType.Lion)]
+    [InlineData(OptimizerType.AdaMax)]
+    public void ConfigureOptimizer_FloatOnlyOptimizer_OnDoublePlan_Throws(OptimizerType opt)
+    {
+        var engine = new CpuEngine();
+        var weight = new Tensor<double>(new[] { 8 });
+        for (int i = 0; i < 8; i++) weight[i] = 0.1 * (i + 1);
+
+        ICompiledTrainingPlan<double> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var sq = engine.TensorMultiply(weight, weight);
+            engine.ReduceSum(sq, null);
+            plan = scope.CompileTraining(new[] { weight });
+        }
+        using (plan)
+        {
+            Assert.Throws<NotSupportedException>(() => plan.ConfigureOptimizer(opt, Lr, B1, B2, Eps));
+        }
+    }
+
+    /// <summary>
+    /// Optimizers whose kernels need hyperparameters the ConfigureOptimizer API
+    /// doesn't carry (AdaDelta rho+2 accumulators, FTRL l1/l2/lr_power, LARS
+    /// trust coeff, ASGD lambd/alpha/mu) are intentionally NOT wired and must
+    /// still be rejected at configure time — so models using them fall back to
+    /// the eager tape cleanly instead of configuring then throwing mid-step.
+    /// </summary>
+    [Theory]
+    [InlineData(OptimizerType.AdaDelta)]
+    [InlineData(OptimizerType.FTRL)]
+    [InlineData(OptimizerType.LARS)]
+    [InlineData(OptimizerType.ASGD)]
+    public void ConfigureOptimizer_UnwiredOptimizer_Throws(OptimizerType opt)
+    {
+        var engine = new CpuEngine();
+        var weight = new Tensor<float>(new[] { 8 });
+        for (int i = 0; i < 8; i++) weight[i] = 0.1f * (i + 1);
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var sq = engine.TensorMultiply(weight, weight);
+            engine.ReduceSum(sq, null);
+            plan = scope.CompileTraining(new[] { weight });
+        }
+        using (plan)
+        {
+            Assert.Throws<NotSupportedException>(() => plan.ConfigureOptimizer(opt, Lr, B1, B2, Eps));
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/FusedAdaptiveLrPlanTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/FusedAdaptiveLrPlanTests.cs
@@ -184,18 +184,20 @@ public class FusedAdaptiveLrPlanTests
     }
 
     [Theory]
-    [InlineData(OptimizerType.Lion)]
-    [InlineData(OptimizerType.LAMB)]
+    [InlineData(OptimizerType.SparseAdam)]
     [InlineData(OptimizerType.HypergradientSGD)]
     [InlineData(OptimizerType.ScheduleFreeSGD)]
     [InlineData(OptimizerType.DAdaptationSGD)]
     public void ConfigureOptimizer_RejectsOptimizersPlanCantDispatch(OptimizerType opt)
     {
-        // PR #349 review #1: the kernels for these exist (so
-        // IsFusedPathEligible says yes) but CompiledTrainingPlan's
-        // dispatch only branches SGD/Adam/AdamW today. Configuring
-        // should fail FAST at configure time, not surprise the caller
-        // with a NotSupportedException on the first Step().
+        // Tensors #500: the per-parameter fused dispatch now covers the full
+        // elementwise kernel-backed set (SGD/Adam/AdamW/AMSGrad + SGDMomentum/
+        // Adagrad/RMSprop/Lion/AdaMax/Nadam/RAdam/LAMB/AdaDelta/LARS/FTRL/ASGD/
+        // Rprop). What remains rejected needs an execution model the per-param
+        // loop can't provide: SparseAdam (sparse-gradient indices),
+        // HypergradientSGD / DAdaptationSGD (GLOBAL cross-parameter reductions),
+        // ScheduleFreeSGD (y-buffer written before the forward). These must fail
+        // FAST at configure time, not surprise the caller on the first Step().
         var engine = new CpuEngine();
         var w = new Tensor<float>(new float[] { 1.0f }, new[] { 1 });
         using var plan = CompileReduceSumPlan(engine, w);

--- a/tests/AiDotNet.Tensors.Tests/Engines/MlpForwardActivationParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/MlpForwardActivationParityTests.cs
@@ -1,0 +1,108 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Tensors #500: the FusedLinear/MlpForward pointwise-activation dispatch tables
+/// (CpuFusedOperations._floatActivations/_doubleActivations) gained ELU, SELU,
+/// Softplus, Mish, HardSwish, HardSigmoid, HardTanh — previously only None/ReLU/
+/// GELU/Sigmoid/Tanh/LeakyReLU/Swish were supported, so MlpForward THREW for the
+/// rest (the gap that forced AiDotNet's Mish/ELU activations off the fused path).
+///
+/// Each test runs the same linear pre-activation two ways — MlpForward with
+/// activation=None (raw x·W) and MlpForward with the activation applied — and
+/// checks the activated output equals the canonical scalar formula applied to the
+/// raw output. This validates the table entry is dispatched AND numerically
+/// correct (an independent textbook reference, not the table's own lambda).
+/// </summary>
+public class MlpForwardActivationParityTests
+{
+    private const double SeluAlpha = 1.6732632423543772, SeluScale = 1.0507009873554805;
+
+    private static double Reference(FusedActivationType act, double x) => act switch
+    {
+        FusedActivationType.ELU => x > 0 ? x : Math.Exp(x) - 1.0,
+        FusedActivationType.SELU => SeluScale * (x > 0 ? x : SeluAlpha * (Math.Exp(x) - 1.0)),
+        FusedActivationType.Softplus => x > 20 ? x : Math.Log(1.0 + Math.Exp(x)),
+        FusedActivationType.Mish => x * Math.Tanh(x > 20 ? x : Math.Log(1.0 + Math.Exp(x))),
+        FusedActivationType.HardSwish => x * Math.Max(0.0, Math.Min(1.0, (x + 3.0) / 6.0)),
+        FusedActivationType.HardSigmoid => Math.Max(0.0, Math.Min(1.0, (x + 3.0) / 6.0)),
+        FusedActivationType.HardTanh => Math.Max(-1.0, Math.Min(1.0, x)),
+        _ => throw new ArgumentOutOfRangeException(nameof(act)),
+    };
+
+    [Theory]
+    [InlineData(FusedActivationType.ELU)]
+    [InlineData(FusedActivationType.SELU)]
+    [InlineData(FusedActivationType.Softplus)]
+    [InlineData(FusedActivationType.Mish)]
+    [InlineData(FusedActivationType.HardSwish)]
+    [InlineData(FusedActivationType.HardSigmoid)]
+    [InlineData(FusedActivationType.HardTanh)]
+    public void MlpForward_NewActivationFloat_MatchesCanonicalFormula(FusedActivationType act)
+    {
+        var engine = new CpuEngine();
+        const int batch = 4, inF = 16, outF = 8;
+        var rng = new Random(20260530);
+        var wData = new float[inF * outF];
+        for (int i = 0; i < wData.Length; i++) wData[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+        var w = new Tensor<float>(wData, new[] { inF, outF });
+        var xData = new float[batch * inF];
+        for (int i = 0; i < xData.Length; i++) xData[i] = (float)(rng.NextDouble() * 4.0 - 2.0);
+        var x = new Tensor<float>(xData, new[] { batch, inF });
+
+        var weights = new System.Collections.Generic.List<Tensor<float>> { w };
+        var noBias = new System.Collections.Generic.List<Tensor<float>?> { null };
+
+        var raw = engine.MlpForward(x, weights, noBias, FusedActivationType.None, FusedActivationType.None);
+        var fused = engine.MlpForward(x, weights, noBias, FusedActivationType.None, act);
+
+        Assert.Equal(raw.Length, fused.Length);
+        for (int i = 0; i < raw.Length; i++)
+        {
+            double expected = Reference(act, Convert.ToDouble(raw[i]));
+            double actual = Convert.ToDouble(fused[i]);
+            Assert.True(Math.Abs(expected - actual) < 1e-4,
+                $"{act}: MlpForward {actual} != canonical {expected} at index {i} (raw={raw[i]}).");
+        }
+    }
+
+    [Theory]
+    [InlineData(FusedActivationType.ELU)]
+    [InlineData(FusedActivationType.SELU)]
+    [InlineData(FusedActivationType.Softplus)]
+    [InlineData(FusedActivationType.Mish)]
+    [InlineData(FusedActivationType.HardSwish)]
+    [InlineData(FusedActivationType.HardSigmoid)]
+    [InlineData(FusedActivationType.HardTanh)]
+    public void MlpForward_NewActivationDouble_MatchesCanonicalFormula(FusedActivationType act)
+    {
+        var engine = new CpuEngine();
+        const int batch = 4, inF = 16, outF = 8;
+        var rng = new Random(20260530);
+        var wData = new double[inF * outF];
+        for (int i = 0; i < wData.Length; i++) wData[i] = rng.NextDouble() * 2.0 - 1.0;
+        var w = new Tensor<double>(wData, new[] { inF, outF });
+        var xData = new double[batch * inF];
+        for (int i = 0; i < xData.Length; i++) xData[i] = rng.NextDouble() * 4.0 - 2.0;
+        var x = new Tensor<double>(xData, new[] { batch, inF });
+
+        var weights = new System.Collections.Generic.List<Tensor<double>> { w };
+        var noBias = new System.Collections.Generic.List<Tensor<double>?> { null };
+
+        var raw = engine.MlpForward(x, weights, noBias, FusedActivationType.None, FusedActivationType.None);
+        var fused = engine.MlpForward(x, weights, noBias, FusedActivationType.None, act);
+
+        Assert.Equal(raw.Length, fused.Length);
+        for (int i = 0; i < raw.Length; i++)
+        {
+            double expected = Reference(act, raw[i]);
+            double actual = fused[i];
+            Assert.True(Math.Abs(expected - actual) < 1e-9,
+                $"{act}: MlpForward(double) {actual} != canonical {expected} at index {i} (raw={raw[i]}).");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`CompiledTrainingPlan.ConfigureOptimizer` and `FusedLinear`/`MlpForward` rejected most optimizer/activation types with `NotSupportedException` even though their AVX2 kernels already existed — a **dispatch gap**, not missing kernels. This wires in every kernel that fits the execution model.

### Optimizers — now dispatched (17 of 22 `OptimizerType`s)
`ConfigureTrainingPlan` float CPU closures now dispatch: **SGD, SGDMomentum, Adam, AdamW, Adagrad, RMSprop, Lion, AdaMax, AMSGrad, Nadam, AdaDelta, LARS, LAMB, FTRL, RAdam, ASGD, Rprop** (double: SGD/Adam/AdamW/AMSGrad — the rest are float-only kernels).
- AMSGrad: `vMax` buffer + new double kernel overload.
- A new optional `FusedOptimizerExtras` (added to the interface) carries the hyperparameters the generic `(lr, β1, β2, eps, wd)` slots don't: LARS momentum/trust-coeff, FTRL L1/L2/lr-power, ASGD λ/α/t0, Rprop η±/step-bounds/initial-step. Defaults documented per field.
- `ValidatePlanOptimizerSupport` is dtype-aware (float-only optimizers rejected on double plans at configure time).

**Rejected (need a different execution model, fail fast at configure):** SparseAdam (sparse indices), LBFGS (closure line-search), HypergradientSGD / DAdaptationSGD (GLOBAL cross-parameter reductions — per-tensor would be a different algorithm), ScheduleFreeSGD (y-buffer written before the forward).

### Activations — now dispatched (all 14 pointwise)
`CpuFusedOperations` float/double tables gained **ELU, SELU, Softplus, Mish, HardSwish, HardSigmoid, HardTanh** (were None/ReLU/GELU/Sigmoid/Tanh/LeakyReLU/Swish). `MlpForward`/`FusedLinear` now cover every pointwise activation; only Softmax stays out (row-wise).

### Tests
- `ConfigureOptimizerAMSGradTests` — kernel-direct float/double AMSGrad parity (rise-then-fall gradient so vMax>v); plan-level in-place, step1==Adam, diverges-over-40-steps.
- `ConfigureOptimizerFusedDispatchTests` — all 17 wired optimizers dispatch + in-place + finite + move; FTRL L1 extras drive sparsity (proves extras flow into the kernel); float-only-on-double throws; the 5 unwireable throw.
- `MlpForwardActivationParityTests` — all 7 new activations, float+double, match the canonical formula through MlpForward.
- Updated `FusedAdaptiveLrPlanTests` (Lion/LAMB are no longer rejected). Adam/SGD/double-path/adaptive-lr regression tests still green.

### Docs
`docs/research/2026-05-29-pytorch-fused-optimizer-internals.md` — PyTorch foreach/fused/`torch.compile` study + prioritized action items.

Companion to ooples/AiDotNet#1469. Closes #500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)