### PR TITLE
feat(#499): fuse every activation + the remaining optimizers (Maxout op, global-reduction optimizers)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
@@ -330,6 +330,12 @@ internal static class OpRegistry
         // normally — same precedent as BatchNormInference above.
         "LstmSequenceForward", "MultiHeadAttentionForward", "MlpForward",
 
+        // Shape-changing fused output primitives (#499): forward/inference-only.
+        // Under a tape the caller decomposes into per-layer ops (linear +
+        // grouped-max / per-level sigmoids) which record normally — same
+        // precedent as the fused sequence/MLP primitives above.
+        "FusedLinearMaxout", "FusedHierarchicalSoftmax",
+
         // Vision Detection — Issue #217. The four IoU variants (BoxIou,
         // GeneralizedBoxIou, DistanceBoxIou, CompleteBoxIou) ARE
         // differentiable and have explicit backward functions registered

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Epilogue/ActivationEpilogue.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Epilogue/ActivationEpilogue.cs
@@ -199,6 +199,45 @@ internal static class ActivationEpilogue
                         c[i * ldc + j] = x / (1.0 + Math.Abs(x));
                     }
                 break;
+            case FusedActivationType.RReLU:
+            {
+                double a = p?.Alpha ?? 0.22916667; // deterministic eval slope
+                for (int i = 0; i < m; i++)
+                    for (int j = 0; j < n; j++)
+                    {
+                        double x = c[i * ldc + j];
+                        c[i * ldc + j] = x > 0 ? x : a * x;
+                    }
+                break;
+            }
+            case FusedActivationType.PReLU:
+            {
+                var slope = p?.PReluSlope;
+                for (int i = 0; i < m; i++)
+                    for (int j = 0; j < n; j++)
+                    {
+                        double s = slope == null ? 0.25 : (slope.Length == 1 ? slope[0] : slope[j]);
+                        double x = c[i * ldc + j];
+                        c[i * ldc + j] = x > 0 ? x : s * x;
+                    }
+                break;
+            }
+            case FusedActivationType.Softmax:
+            case FusedActivationType.Softmin:
+            {
+                bool min = activation == FusedActivationType.Softmin;
+                for (int i = 0; i < m; i++)
+                {
+                    int row = i * ldc;
+                    double mx = double.NegativeInfinity;
+                    for (int j = 0; j < n; j++) { double v = min ? -c[row + j] : c[row + j]; if (v > mx) mx = v; }
+                    double sum = 0.0;
+                    for (int j = 0; j < n; j++) { double v = min ? -c[row + j] : c[row + j]; double e = Math.Exp(v - mx); c[row + j] = e; sum += e; }
+                    double inv = 1.0 / sum;
+                    for (int j = 0; j < n; j++) c[row + j] *= inv;
+                }
+                break;
+            }
             case FusedActivationType.None:
                 break;
             default:
@@ -369,6 +408,45 @@ internal static class ActivationEpilogue
                         c[i * ldc + j] = x / (1f + Math.Abs(x));
                     }
                 break;
+            case FusedActivationType.RReLU:
+            {
+                float a = p?.Alpha ?? 0.22916667f;
+                for (int i = 0; i < m; i++)
+                    for (int j = 0; j < n; j++)
+                    {
+                        float x = c[i * ldc + j];
+                        c[i * ldc + j] = x > 0 ? x : a * x;
+                    }
+                break;
+            }
+            case FusedActivationType.PReLU:
+            {
+                var slope = p?.PReluSlope;
+                for (int i = 0; i < m; i++)
+                    for (int j = 0; j < n; j++)
+                    {
+                        float s = slope == null ? 0.25f : (slope.Length == 1 ? slope[0] : slope[j]);
+                        float x = c[i * ldc + j];
+                        c[i * ldc + j] = x > 0 ? x : s * x;
+                    }
+                break;
+            }
+            case FusedActivationType.Softmax:
+            case FusedActivationType.Softmin:
+            {
+                bool min = activation == FusedActivationType.Softmin;
+                for (int i = 0; i < m; i++)
+                {
+                    int row = i * ldc;
+                    float mx = float.NegativeInfinity;
+                    for (int j = 0; j < n; j++) { float v = min ? -c[row + j] : c[row + j]; if (v > mx) mx = v; }
+                    float sum = 0f;
+                    for (int j = 0; j < n; j++) { float v = min ? -c[row + j] : c[row + j]; float e = (float)Math.Exp(v - mx); c[row + j] = e; sum += e; }
+                    float inv = 1f / sum;
+                    for (int j = 0; j < n; j++) c[row + j] *= inv;
+                }
+                break;
+            }
             case FusedActivationType.None:
                 break;
             default:

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Epilogue/ActivationEpilogue.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Epilogue/ActivationEpilogue.cs
@@ -9,7 +9,7 @@ namespace AiDotNet.Tensors.Engines.BlasManaged;
 /// </summary>
 internal static class ActivationEpilogue
 {
-    public static void Apply<T>(Span<T> c, int ldc, int m, int n, FusedActivationType activation)
+    public static void Apply<T>(Span<T> c, int ldc, int m, int n, FusedActivationType activation, FusedActivationParams? p = null)
         where T : unmanaged
     {
         if (activation == FusedActivationType.None) return;
@@ -17,19 +17,19 @@ internal static class ActivationEpilogue
         if (typeof(T) == typeof(double))
         {
             var cd = MemoryMarshal.Cast<T, double>(c);
-            ApplyFp64(cd, ldc, m, n, activation);
+            ApplyFp64(cd, ldc, m, n, activation, p);
             return;
         }
         if (typeof(T) == typeof(float))
         {
             var cf = MemoryMarshal.Cast<T, float>(c);
-            ApplyFp32(cf, ldc, m, n, activation);
+            ApplyFp32(cf, ldc, m, n, activation, p);
             return;
         }
         throw new NotSupportedException($"ActivationEpilogue does not support T={typeof(T).Name}.");
     }
 
-    private static void ApplyFp64(Span<double> c, int ldc, int m, int n, FusedActivationType activation)
+    private static void ApplyFp64(Span<double> c, int ldc, int m, int n, FusedActivationType activation, FusedActivationParams? p = null)
     {
         switch (activation)
         {
@@ -42,14 +42,16 @@ internal static class ActivationEpilogue
                     }
                 break;
             case FusedActivationType.LeakyReLU:
-                // Default leaky slope = 0.01.
+            {
+                double slope = p?.Alpha ?? 0.01; // default leaky slope 0.01
                 for (int i = 0; i < m; i++)
                     for (int j = 0; j < n; j++)
                     {
                         double v = c[i * ldc + j];
-                        c[i * ldc + j] = v >= 0 ? v : 0.01 * v;
+                        c[i * ldc + j] = v >= 0 ? v : slope * v;
                     }
                 break;
+            }
             case FusedActivationType.Sigmoid:
                 for (int i = 0; i < m; i++)
                     for (int j = 0; j < n; j++)
@@ -94,14 +96,48 @@ internal static class ActivationEpilogue
                     }
                 break;
             case FusedActivationType.ELU:
-                // f(x) = x if x > 0 else alpha * (exp(x) - 1); alpha = 1.
+            {
+                // f(x) = x if x > 0 else alpha * (exp(x) - 1); alpha default 1.
+                double a = p?.Alpha ?? 1.0;
                 for (int i = 0; i < m; i++)
                     for (int j = 0; j < n; j++)
                     {
                         double x = c[i * ldc + j];
-                        c[i * ldc + j] = x > 0 ? x : (Math.Exp(x) - 1.0);
+                        c[i * ldc + j] = x > 0 ? x : a * (Math.Exp(x) - 1.0);
                     }
                 break;
+            }
+            case FusedActivationType.CELU:
+            {
+                // max(0,x)+min(0,a*(exp(x/a)-1)) → piecewise: x>=0 ? x : a*(exp(x/a)-1).
+                double a = p?.Alpha ?? 1.0;
+                for (int i = 0; i < m; i++)
+                    for (int j = 0; j < n; j++)
+                    {
+                        double x = c[i * ldc + j];
+                        c[i * ldc + j] = x >= 0 ? x : a * (Math.Exp(x / a) - 1.0);
+                    }
+                break;
+            }
+            case FusedActivationType.ThresholdedReLU:
+            {
+                double t = p?.Theta ?? 1.0;
+                for (int i = 0; i < m; i++)
+                    for (int j = 0; j < n; j++)
+                    {
+                        double x = c[i * ldc + j];
+                        c[i * ldc + j] = x > t ? x : 0.0;
+                    }
+                break;
+            }
+            case FusedActivationType.ScaledTanh:
+            {
+                double a = p?.Alpha ?? 1.0, b = p?.Beta ?? 1.0;
+                for (int i = 0; i < m; i++)
+                    for (int j = 0; j < n; j++)
+                        c[i * ldc + j] = a * Math.Tanh(b * c[i * ldc + j]);
+                break;
+            }
             case FusedActivationType.SELU:
                 // scale * (x>0 ? x : alpha*(exp(x)-1)); Klambauer et al. 2017 constants.
                 const double seluAlpha = 1.6732632423543772, seluScale = 1.0507009873554805;
@@ -170,7 +206,7 @@ internal static class ActivationEpilogue
         }
     }
 
-    private static void ApplyFp32(Span<float> c, int ldc, int m, int n, FusedActivationType activation)
+    private static void ApplyFp32(Span<float> c, int ldc, int m, int n, FusedActivationType activation, FusedActivationParams? p = null)
     {
         switch (activation)
         {
@@ -183,13 +219,16 @@ internal static class ActivationEpilogue
                     }
                 break;
             case FusedActivationType.LeakyReLU:
+            {
+                float slope = p?.Alpha ?? 0.01f;
                 for (int i = 0; i < m; i++)
                     for (int j = 0; j < n; j++)
                     {
                         float v = c[i * ldc + j];
-                        c[i * ldc + j] = v >= 0 ? v : 0.01f * v;
+                        c[i * ldc + j] = v >= 0 ? v : slope * v;
                     }
                 break;
+            }
             case FusedActivationType.Sigmoid:
                 for (int i = 0; i < m; i++)
                     for (int j = 0; j < n; j++)
@@ -231,13 +270,46 @@ internal static class ActivationEpilogue
                     }
                 break;
             case FusedActivationType.ELU:
+            {
+                float a = p?.Alpha ?? 1f;
                 for (int i = 0; i < m; i++)
                     for (int j = 0; j < n; j++)
                     {
                         float x = c[i * ldc + j];
-                        c[i * ldc + j] = x > 0 ? x : (float)(Math.Exp(x) - 1.0);
+                        c[i * ldc + j] = x > 0 ? x : a * (float)(Math.Exp(x) - 1.0);
                     }
                 break;
+            }
+            case FusedActivationType.CELU:
+            {
+                float a = p?.Alpha ?? 1f;
+                for (int i = 0; i < m; i++)
+                    for (int j = 0; j < n; j++)
+                    {
+                        float x = c[i * ldc + j];
+                        c[i * ldc + j] = x >= 0 ? x : a * (float)(Math.Exp(x / a) - 1.0);
+                    }
+                break;
+            }
+            case FusedActivationType.ThresholdedReLU:
+            {
+                float t = p?.Theta ?? 1f;
+                for (int i = 0; i < m; i++)
+                    for (int j = 0; j < n; j++)
+                    {
+                        float x = c[i * ldc + j];
+                        c[i * ldc + j] = x > t ? x : 0f;
+                    }
+                break;
+            }
+            case FusedActivationType.ScaledTanh:
+            {
+                float a = p?.Alpha ?? 1f, b = p?.Beta ?? 1f;
+                for (int i = 0; i < m; i++)
+                    for (int j = 0; j < n; j++)
+                        c[i * ldc + j] = a * (float)Math.Tanh(b * c[i * ldc + j]);
+                break;
+            }
             case FusedActivationType.SELU:
                 const float seluAlphaF = 1.6732632f, seluScaleF = 1.0507010f;
                 for (int i = 0; i < m; i++)

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Epilogue/ActivationEpilogue.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Epilogue/ActivationEpilogue.cs
@@ -102,6 +102,67 @@ internal static class ActivationEpilogue
                         c[i * ldc + j] = x > 0 ? x : (Math.Exp(x) - 1.0);
                     }
                 break;
+            case FusedActivationType.SELU:
+                // scale * (x>0 ? x : alpha*(exp(x)-1)); Klambauer et al. 2017 constants.
+                const double seluAlpha = 1.6732632423543772, seluScale = 1.0507009873554805;
+                for (int i = 0; i < m; i++)
+                    for (int j = 0; j < n; j++)
+                    {
+                        double x = c[i * ldc + j];
+                        c[i * ldc + j] = seluScale * (x > 0 ? x : seluAlpha * (Math.Exp(x) - 1.0));
+                    }
+                break;
+            case FusedActivationType.Softplus:
+                // log(1+exp(x)); x>20 linear cutoff avoids exp overflow (PyTorch threshold).
+                for (int i = 0; i < m; i++)
+                    for (int j = 0; j < n; j++)
+                    {
+                        double x = c[i * ldc + j];
+                        c[i * ldc + j] = x > 20.0 ? x : Math.Log(1.0 + Math.Exp(x));
+                    }
+                break;
+            case FusedActivationType.HardSwish:
+                for (int i = 0; i < m; i++)
+                    for (int j = 0; j < n; j++)
+                    {
+                        double x = c[i * ldc + j];
+                        double t = (x + 3.0) / 6.0;
+                        t = t < 0.0 ? 0.0 : (t > 1.0 ? 1.0 : t);
+                        c[i * ldc + j] = x * t;
+                    }
+                break;
+            case FusedActivationType.HardSigmoid:
+                for (int i = 0; i < m; i++)
+                    for (int j = 0; j < n; j++)
+                    {
+                        double t = (c[i * ldc + j] + 3.0) / 6.0;
+                        c[i * ldc + j] = t < 0.0 ? 0.0 : (t > 1.0 ? 1.0 : t);
+                    }
+                break;
+            case FusedActivationType.HardTanh:
+                for (int i = 0; i < m; i++)
+                    for (int j = 0; j < n; j++)
+                    {
+                        double x = c[i * ldc + j];
+                        c[i * ldc + j] = x < -1.0 ? -1.0 : (x > 1.0 ? 1.0 : x);
+                    }
+                break;
+            case FusedActivationType.ReLU6:
+                for (int i = 0; i < m; i++)
+                    for (int j = 0; j < n; j++)
+                    {
+                        double x = c[i * ldc + j];
+                        c[i * ldc + j] = x < 0.0 ? 0.0 : (x > 6.0 ? 6.0 : x);
+                    }
+                break;
+            case FusedActivationType.SoftSign:
+                for (int i = 0; i < m; i++)
+                    for (int j = 0; j < n; j++)
+                    {
+                        double x = c[i * ldc + j];
+                        c[i * ldc + j] = x / (1.0 + Math.Abs(x));
+                    }
+                break;
             case FusedActivationType.None:
                 break;
             default:
@@ -175,6 +236,65 @@ internal static class ActivationEpilogue
                     {
                         float x = c[i * ldc + j];
                         c[i * ldc + j] = x > 0 ? x : (float)(Math.Exp(x) - 1.0);
+                    }
+                break;
+            case FusedActivationType.SELU:
+                const float seluAlphaF = 1.6732632f, seluScaleF = 1.0507010f;
+                for (int i = 0; i < m; i++)
+                    for (int j = 0; j < n; j++)
+                    {
+                        float x = c[i * ldc + j];
+                        c[i * ldc + j] = seluScaleF * (x > 0 ? x : seluAlphaF * (float)(Math.Exp(x) - 1.0));
+                    }
+                break;
+            case FusedActivationType.Softplus:
+                for (int i = 0; i < m; i++)
+                    for (int j = 0; j < n; j++)
+                    {
+                        float x = c[i * ldc + j];
+                        c[i * ldc + j] = x > 20f ? x : (float)Math.Log(1.0 + Math.Exp(x));
+                    }
+                break;
+            case FusedActivationType.HardSwish:
+                for (int i = 0; i < m; i++)
+                    for (int j = 0; j < n; j++)
+                    {
+                        float x = c[i * ldc + j];
+                        float t = (x + 3f) / 6f;
+                        t = t < 0f ? 0f : (t > 1f ? 1f : t);
+                        c[i * ldc + j] = x * t;
+                    }
+                break;
+            case FusedActivationType.HardSigmoid:
+                for (int i = 0; i < m; i++)
+                    for (int j = 0; j < n; j++)
+                    {
+                        float t = (c[i * ldc + j] + 3f) / 6f;
+                        c[i * ldc + j] = t < 0f ? 0f : (t > 1f ? 1f : t);
+                    }
+                break;
+            case FusedActivationType.HardTanh:
+                for (int i = 0; i < m; i++)
+                    for (int j = 0; j < n; j++)
+                    {
+                        float x = c[i * ldc + j];
+                        c[i * ldc + j] = x < -1f ? -1f : (x > 1f ? 1f : x);
+                    }
+                break;
+            case FusedActivationType.ReLU6:
+                for (int i = 0; i < m; i++)
+                    for (int j = 0; j < n; j++)
+                    {
+                        float x = c[i * ldc + j];
+                        c[i * ldc + j] = x < 0f ? 0f : (x > 6f ? 6f : x);
+                    }
+                break;
+            case FusedActivationType.SoftSign:
+                for (int i = 0; i < m; i++)
+                    for (int j = 0; j < n; j++)
+                    {
+                        float x = c[i * ldc + j];
+                        c[i * ldc + j] = x / (1f + Math.Abs(x));
                     }
                 break;
             case FusedActivationType.None:

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Epilogue/ActivationEpilogue.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Epilogue/ActivationEpilogue.cs
@@ -17,13 +17,21 @@ internal static class ActivationEpilogue
         if (typeof(T) == typeof(double))
         {
             var cd = MemoryMarshal.Cast<T, double>(c);
-            ApplyFp64(cd, ldc, m, n, activation, p);
+            // Channel/row-wise (PReLU, softmax family, Sparsemax, Squash, …) via the
+            // shared helper so this path matches CpuFusedOperations exactly.
+            if (AiDotNet.Tensors.Helpers.RowwiseFusedActivations.Handles(activation))
+                AiDotNet.Tensors.Helpers.RowwiseFusedActivations.ApplyDouble(cd, ldc, m, n, activation, p);
+            else
+                ApplyFp64(cd, ldc, m, n, activation, p);
             return;
         }
         if (typeof(T) == typeof(float))
         {
             var cf = MemoryMarshal.Cast<T, float>(c);
-            ApplyFp32(cf, ldc, m, n, activation, p);
+            if (AiDotNet.Tensors.Helpers.RowwiseFusedActivations.Handles(activation))
+                AiDotNet.Tensors.Helpers.RowwiseFusedActivations.ApplyFloat(cf, ldc, m, n, activation, p);
+            else
+                ApplyFp32(cf, ldc, m, n, activation, p);
             return;
         }
         throw new NotSupportedException($"ActivationEpilogue does not support T={typeof(T).Name}.");
@@ -199,49 +207,20 @@ internal static class ActivationEpilogue
                         c[i * ldc + j] = x / (1.0 + Math.Abs(x));
                     }
                 break;
-            case FusedActivationType.RReLU:
-            {
-                double a = p?.Alpha ?? 0.22916667; // deterministic eval slope
-                for (int i = 0; i < m; i++)
-                    for (int j = 0; j < n; j++)
-                    {
-                        double x = c[i * ldc + j];
-                        c[i * ldc + j] = x > 0 ? x : a * x;
-                    }
-                break;
-            }
-            case FusedActivationType.PReLU:
-            {
-                var slope = p?.PReluSlope;
-                for (int i = 0; i < m; i++)
-                    for (int j = 0; j < n; j++)
-                    {
-                        double s = slope == null ? 0.25 : (slope.Length == 1 ? slope[0] : slope[j]);
-                        double x = c[i * ldc + j];
-                        c[i * ldc + j] = x > 0 ? x : s * x;
-                    }
-                break;
-            }
-            case FusedActivationType.Softmax:
-            case FusedActivationType.Softmin:
-            {
-                bool min = activation == FusedActivationType.Softmin;
-                for (int i = 0; i < m; i++)
-                {
-                    int row = i * ldc;
-                    double mx = double.NegativeInfinity;
-                    for (int j = 0; j < n; j++) { double v = min ? -c[row + j] : c[row + j]; if (v > mx) mx = v; }
-                    double sum = 0.0;
-                    for (int j = 0; j < n; j++) { double v = min ? -c[row + j] : c[row + j]; double e = Math.Exp(v - mx); c[row + j] = e; sum += e; }
-                    double inv = 1.0 / sum;
-                    for (int j = 0; j < n; j++) c[row + j] *= inv;
-                }
-                break;
-            }
             case FusedActivationType.None:
                 break;
             default:
-                throw new NotSupportedException($"ActivationEpilogue: {activation} not yet implemented.");
+            {
+                // Any other pointwise activation (RReLU, Sign, BentIdentity, Gaussian,
+                // LiSHT, ISRU, SQRBF, BinarySpiking, …) — resolve the scalar map once
+                // from the shared registry. Row/channel-wise types never reach here
+                // (intercepted in Apply<T> via RowwiseFusedActivations).
+                var fn = Helpers.CpuFusedOperations.GetDoubleActivation(activation, p);
+                for (int i = 0; i < m; i++)
+                    for (int j = 0; j < n; j++)
+                        c[i * ldc + j] = fn(c[i * ldc + j]);
+                break;
+            }
         }
     }
 
@@ -408,49 +387,18 @@ internal static class ActivationEpilogue
                         c[i * ldc + j] = x / (1f + Math.Abs(x));
                     }
                 break;
-            case FusedActivationType.RReLU:
-            {
-                float a = p?.Alpha ?? 0.22916667f;
-                for (int i = 0; i < m; i++)
-                    for (int j = 0; j < n; j++)
-                    {
-                        float x = c[i * ldc + j];
-                        c[i * ldc + j] = x > 0 ? x : a * x;
-                    }
-                break;
-            }
-            case FusedActivationType.PReLU:
-            {
-                var slope = p?.PReluSlope;
-                for (int i = 0; i < m; i++)
-                    for (int j = 0; j < n; j++)
-                    {
-                        float s = slope == null ? 0.25f : (slope.Length == 1 ? slope[0] : slope[j]);
-                        float x = c[i * ldc + j];
-                        c[i * ldc + j] = x > 0 ? x : s * x;
-                    }
-                break;
-            }
-            case FusedActivationType.Softmax:
-            case FusedActivationType.Softmin:
-            {
-                bool min = activation == FusedActivationType.Softmin;
-                for (int i = 0; i < m; i++)
-                {
-                    int row = i * ldc;
-                    float mx = float.NegativeInfinity;
-                    for (int j = 0; j < n; j++) { float v = min ? -c[row + j] : c[row + j]; if (v > mx) mx = v; }
-                    float sum = 0f;
-                    for (int j = 0; j < n; j++) { float v = min ? -c[row + j] : c[row + j]; float e = (float)Math.Exp(v - mx); c[row + j] = e; sum += e; }
-                    float inv = 1f / sum;
-                    for (int j = 0; j < n; j++) c[row + j] *= inv;
-                }
-                break;
-            }
             case FusedActivationType.None:
                 break;
             default:
-                throw new NotSupportedException($"ActivationEpilogue: {activation} not yet implemented.");
+            {
+                // Other pointwise activations resolved from the shared registry
+                // (row/channel-wise types are intercepted in Apply<T>).
+                var fn = Helpers.CpuFusedOperations.GetFloatActivation(activation, p);
+                for (int i = 0; i < m; i++)
+                    for (int j = 0; j < n; j++)
+                        c[i * ldc + j] = fn(c[i * ldc + j]);
+                break;
+            }
         }
     }
 }

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Epilogue/ActivationEpilogue.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Epilogue/ActivationEpilogue.cs
@@ -119,6 +119,8 @@ internal static class ActivationEpilogue
             {
                 // max(0,x)+min(0,a*(exp(x/a)-1)) → piecewise: x>=0 ? x : a*(exp(x/a)-1).
                 double a = p?.Alpha ?? 1.0;
+                if (!(a > 0.0))
+                    throw new ArgumentOutOfRangeException(nameof(p), "CELU alpha must be > 0 (the activation divides by it).");
                 for (int i = 0; i < m; i++)
                     for (int j = 0; j < n; j++)
                     {
@@ -301,6 +303,8 @@ internal static class ActivationEpilogue
             case FusedActivationType.CELU:
             {
                 float a = p?.Alpha ?? 1f;
+                if (!(a > 0f))
+                    throw new ArgumentOutOfRangeException(nameof(p), "CELU alpha must be > 0 (the activation divides by it).");
                 for (int i = 0; i < m; i++)
                     for (int j = 0; j < n; j++)
                     {

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -600,6 +600,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             && System.Array.Exists(_parameters, p => p.TryGetGpuBuffer() is not null);
         ValidatePlanOptimizerSupport(optimizerType, typeof(T) == typeof(float), hasGpuParams);
         var ex = extras ?? new FusedOptimizerExtras();
+        ex.Validate();
         if (typeof(T) == typeof(float))
         {
             ConfigureOptimizerFloat(optimizerType, schedule, beta1, beta2, eps, weightDecay, ex);
@@ -658,6 +659,11 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         bool hasGpuParams = typeof(T) == typeof(float)
             && System.Array.Exists(_parameters, p => p.TryGetGpuBuffer() is not null);
         ValidatePlanOptimizerSupport(optimizerType, typeof(T) == typeof(float), hasGpuParams);
+        // Drop any Schedule-Free pre-forward hook left over from a prior ungrouped
+        // ConfigureOptimizer(ScheduleFreeSGD); a grouped optimizer never sets one,
+        // and Step() unconditionally invokes it — leaving it active would rewrite
+        // the live weights with stale y=(1-β)z+βx before each forward.
+        _preForwardParamTransform = null;
         // Global-state optimizers adapt ONE learning-rate/distance scalar across all
         // parameters — a per-group schedule is meaningless for them, so they are only
         // supported through the ungrouped ConfigureOptimizer.
@@ -668,6 +674,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 "(or a per-step parameter transform) and is not supported with per-group schedules; " +
                 "use the ungrouped ConfigureOptimizer.");
         var ex = extras ?? new FusedOptimizerExtras();
+        ex.Validate();
         if (typeof(T) == typeof(float))
         {
             ConfigureOptimizerFloatGrouped(optimizerType, groupSchedules, paramToGroup, beta1, beta2, eps, weightDecay, ex);
@@ -919,7 +926,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         // via these captured locals. CPU-only (the device gate rejects them for
         // GPU plans) and ungrouped (a per-group LR is meaningless for a globally
         // adapted step).
-        float hgLr = (float)schedule.GetLr(1);   // Hypergradient: adaptive learning rate
+        float hgAdj = 0f;                         // Hypergradient: accumulated lr adjustment (added to the per-step schedule base)
         float dEst = extras.D0;                   // D-Adaptation: distance estimate
         float dRAccum = 0f;                       // D-Adaptation: r accumulator
         float exHyperLr = extras.HyperLr;
@@ -964,8 +971,13 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
             if (optType == OptimizerType.HypergradientSGD)
             {
-                // lr_t = lr_{t-1} + β·⟨g_t, g_{t-1}⟩ (global inner product across all params),
-                // then p -= lr_t·g. prevGrad is stored in m[p].
+                // Hypergradient descent (Baydin et al. 2018): the effective lr is the
+                // per-step schedule base PLUS an adjustment accumulated from successive
+                // gradient inner products: adj_t = adj_{t-1} + β·⟨g_t, g_{t-1}⟩, then
+                // lr_eff = schedule.GetLr(t) + adj_t, and p -= lr_eff·g. prevGrad is in
+                // m[p]. Threading the per-step `lr` in means a non-constant LrSchedule is
+                // honored (was previously frozen at GetLr(1)); a constant schedule
+                // reduces to plain hypergradient from that base.
                 double inner = 0;
                 for (int p = 0; p < paramCount; p++)
                 {
@@ -974,7 +986,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     fixed (float* pGrad = gradArrays[p], pPrev = m[p])
                         for (int i = 0; i < len2; i++) inner += (double)pGrad[i] * pPrev[i];
                 }
-                float newLr = hgLr + exHyperLr * (float)inner;
+                hgAdj += exHyperLr * (float)inner;
+                float newLr = lr + hgAdj;
                 for (int p = 0; p < paramCount; p++)
                 {
                     if (gradArrays[p].Length == 0) continue;
@@ -982,7 +995,6 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     fixed (float* pParam = paramArrays[p], pGrad = gradArrays[p], pPrev = m[p])
                         for (int i = 0; i < len2; i++) { pParam[i] -= newLr * pGrad[i]; pPrev[i] = pGrad[i]; }
                 }
-                hgLr = newLr;
                 return;
             }
             if (optType == OptimizerType.DAdaptationSGD)

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -264,6 +264,13 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
     // Fused optimizer state
     private Action? _optimizerUpdate;
+    // Schedule-Free SGD (#499): a transform applied to the live parameter
+    // backing BEFORE each forward pass. Schedule-Free evaluates gradients at
+    // the interpolated point y = (1-β)z + βx (not at the stored eval weights),
+    // so this hook writes y into the parameter backing every step; the
+    // optimizer update then restores the eval copy x afterwards. Null for
+    // every other optimizer (they evaluate at the live weights directly).
+    private Action? _preForwardParamTransform;
     private int _optimizerStep;
 
     /// <summary>
@@ -389,6 +396,12 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         // capture timestamps so kept on the hot path.
         long t0 = _profileStepEnabled ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
         bool stepTiming = StepTiming.Enabled;
+
+        // Schedule-Free SGD: write y = (1-β)z + βx into the live parameter
+        // backing so the forward/backward evaluate gradients at the
+        // interpolation point (no-op for every other optimizer — the field
+        // is null unless ConfigureOptimizer set ScheduleFreeSGD).
+        _preForwardParamTransform?.Invoke();
 
         // Forward: use checkpointing if enabled, otherwise straight-line delegates
         long fwdStart = stepTiming ? Stopwatch.GetTimestamp() : 0;
@@ -648,10 +661,12 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         // Global-state optimizers adapt ONE learning-rate/distance scalar across all
         // parameters — a per-group schedule is meaningless for them, so they are only
         // supported through the ungrouped ConfigureOptimizer.
-        if (optimizerType is OptimizerType.HypergradientSGD or OptimizerType.DAdaptationSGD)
+        if (optimizerType is OptimizerType.HypergradientSGD or OptimizerType.DAdaptationSGD
+            or OptimizerType.ScheduleFreeSGD)
             throw new NotSupportedException(
-                $"{optimizerType} maintains a single global learning-rate/distance scalar and is not " +
-                "supported with per-group schedules; use the ungrouped ConfigureOptimizer.");
+                $"{optimizerType} maintains a single global learning-rate/distance/weight-sum scalar " +
+                "(or a per-step parameter transform) and is not supported with per-group schedules; " +
+                "use the ungrouped ConfigureOptimizer.");
         var ex = extras ?? new FusedOptimizerExtras();
         if (typeof(T) == typeof(float))
         {
@@ -716,7 +731,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             or OptimizerType.ASGD
             or OptimizerType.Rprop
             or OptimizerType.HypergradientSGD
-            or OptimizerType.DAdaptationSGD;
+            or OptimizerType.DAdaptationSGD
+            or OptimizerType.ScheduleFreeSGD;
 
         bool supported = supportedAnyDtype || (isFloat && supportedFloatOnly);
         if (!supported)
@@ -789,12 +805,14 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 or OptimizerType.AdaMax or OptimizerType.AMSGrad
                 or OptimizerType.RAdam or OptimizerType.LAMB
                 or OptimizerType.LARS or OptimizerType.ASGD or OptimizerType.Rprop
-                or OptimizerType.HypergradientSGD or OptimizerType.DAdaptationSGD;
+                or OptimizerType.HypergradientSGD or OptimizerType.DAdaptationSGD
+                or OptimizerType.ScheduleFreeSGD;   // m[p] = z (SGD trajectory)
             bool needsSecondMoment = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
                 or OptimizerType.RMSprop or OptimizerType.Nadam or OptimizerType.AMSGrad
                 or OptimizerType.Adagrad
                 or OptimizerType.RAdam or OptimizerType.LAMB or OptimizerType.AdaMax
-                or OptimizerType.AdaDelta or OptimizerType.FTRL or OptimizerType.Rprop;
+                or OptimizerType.AdaDelta or OptimizerType.FTRL or OptimizerType.Rprop
+                or OptimizerType.ScheduleFreeSGD;   // v[p] = x (eval/average copy)
 
             // GPU fast path: param is GPU-resident → allocate matching GPU
             // state buffers and dispatch to backend kernels. Backends ship
@@ -907,6 +925,35 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         float exHyperLr = extras.HyperLr;
         float exGrowth = extras.DGrowthRate;
 
+        // Schedule-Free SGD (#499): z (SGD trajectory) and x (eval/average)
+        // both start at the initial parameter values. They live in m[p] / v[p]
+        // (allocated zero-filled above), so seed them from the current weights.
+        // weightSum accumulates Σ lr² across steps (Defazio p=2,q=0). The
+        // pre-forward hook writes y into the live backing each step; reset any
+        // stale hook from a prior ConfigureOptimizer for every other optimizer.
+        _preForwardParamTransform = null;
+        if (optimizerType == OptimizerType.ScheduleFreeSGD)
+        {
+            for (int p = 0; p < paramCount; p++)
+            {
+                if (paramArrays[p].Length == 0) continue; // GPU-resident: gate rejects this combo
+                Array.Copy(paramArrays[p], m[p], lengths[p]); // z ← param₀
+                Array.Copy(paramArrays[p], v[p], lengths[p]); // x ← param₀
+            }
+            float sfBeta = extras.SfBeta;
+            _preForwardParamTransform = () =>
+            {
+                for (int p = 0; p < paramCount; p++)
+                {
+                    int lenY = lengths[p];
+                    if (paramArrays[p].Length == 0) continue;
+                    fixed (float* pY = paramArrays[p], pZ = m[p], pX = v[p])
+                        FusedOptimizer.ScheduleFreeYUpdateSimd(pY, pZ, pX, lenY, sfBeta);
+                }
+            };
+        }
+        float sfWeightSum = 0f;
+
         _optimizerUpdate = () =>
         {
             _optimizerStep++;
@@ -968,6 +1015,28 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                         for (int i = 0; i < len2; i++) pParam[i] -= gammaNew * pGrad[i];
                 }
                 dEst = dNew;
+                return;
+            }
+            if (optType == OptimizerType.ScheduleFreeSGD)
+            {
+                // The pre-forward hook already wrote y into the live backing and
+                // the backward computed grad at y. Update z (SGD step) and x
+                // (running weighted average) per parameter, then restore x into
+                // the live backing so the user/eval sees the average weights.
+                // weightSum is global (lr is shared across params each step), so
+                // every per-param call consumes the SAME weightSum and returns
+                // the SAME new value — capture it once.
+                float wsNext = sfWeightSum;
+                for (int p = 0; p < paramCount; p++)
+                {
+                    if (gradArrays[p].Length == 0) continue;
+                    int len2 = lengths[p];
+                    fixed (float* pZ = m[p], pX = v[p], pGrad = gradArrays[p])
+                        wsNext = FusedOptimizer.ScheduleFreeSgdUpdateSimd(
+                            pZ, pX, pGrad, len2, lr, sfWeightSum);
+                    Array.Copy(v[p], paramArrays[p], len2); // live backing ← x (eval copy)
+                }
+                sfWeightSum = wsNext;
                 return;
             }
 

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -645,6 +645,13 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         bool hasGpuParams = typeof(T) == typeof(float)
             && System.Array.Exists(_parameters, p => p.TryGetGpuBuffer() is not null);
         ValidatePlanOptimizerSupport(optimizerType, typeof(T) == typeof(float), hasGpuParams);
+        // Global-state optimizers adapt ONE learning-rate/distance scalar across all
+        // parameters — a per-group schedule is meaningless for them, so they are only
+        // supported through the ungrouped ConfigureOptimizer.
+        if (optimizerType is OptimizerType.HypergradientSGD or OptimizerType.DAdaptationSGD)
+            throw new NotSupportedException(
+                $"{optimizerType} maintains a single global learning-rate/distance scalar and is not " +
+                "supported with per-group schedules; use the ungrouped ConfigureOptimizer.");
         var ex = extras ?? new FusedOptimizerExtras();
         if (typeof(T) == typeof(float))
         {
@@ -707,7 +714,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             or OptimizerType.LARS
             or OptimizerType.FTRL
             or OptimizerType.ASGD
-            or OptimizerType.Rprop;
+            or OptimizerType.Rprop
+            or OptimizerType.HypergradientSGD
+            or OptimizerType.DAdaptationSGD;
 
         bool supported = supportedAnyDtype || (isFloat && supportedFloatOnly);
         if (!supported)
@@ -779,7 +788,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 or OptimizerType.SGDMomentum or OptimizerType.Lion or OptimizerType.Nadam
                 or OptimizerType.AdaMax or OptimizerType.AMSGrad
                 or OptimizerType.RAdam or OptimizerType.LAMB
-                or OptimizerType.LARS or OptimizerType.ASGD or OptimizerType.Rprop;
+                or OptimizerType.LARS or OptimizerType.ASGD or OptimizerType.Rprop
+                or OptimizerType.HypergradientSGD or OptimizerType.DAdaptationSGD;
             bool needsSecondMoment = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
                 or OptimizerType.RMSprop or OptimizerType.Nadam or OptimizerType.AMSGrad
                 or OptimizerType.Adagrad
@@ -885,6 +895,17 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         var wd = weightDecay;
         var optType = optimizerType;
         var lrSchedule = schedule;
+        // Global-state optimizers (#500): these maintain a single scalar shared
+        // across ALL parameters, so they run a two-phase (global reduce → apply)
+        // pass rather than the per-parameter switch. State persists across steps
+        // via these captured locals. CPU-only (the device gate rejects them for
+        // GPU plans) and ungrouped (a per-group LR is meaningless for a globally
+        // adapted step).
+        float hgLr = (float)schedule.GetLr(1);   // Hypergradient: adaptive learning rate
+        float dEst = extras.D0;                   // D-Adaptation: distance estimate
+        float dRAccum = 0f;                       // D-Adaptation: r accumulator
+        float exHyperLr = extras.HyperLr;
+        float exGrowth = extras.DGrowthRate;
 
         _optimizerUpdate = () =>
         {
@@ -893,6 +914,63 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             // LRScheduler.step() pays managed-code dispatch overhead per
             // step; here it's an inlined Math.Cos / Math.Pow.
             float lr = (float)lrSchedule.GetLr(_optimizerStep);
+
+            if (optType == OptimizerType.HypergradientSGD)
+            {
+                // lr_t = lr_{t-1} + β·⟨g_t, g_{t-1}⟩ (global inner product across all params),
+                // then p -= lr_t·g. prevGrad is stored in m[p].
+                double inner = 0;
+                for (int p = 0; p < paramCount; p++)
+                {
+                    if (gradArrays[p].Length == 0) continue;
+                    int len2 = lengths[p];
+                    fixed (float* pGrad = gradArrays[p], pPrev = m[p])
+                        for (int i = 0; i < len2; i++) inner += (double)pGrad[i] * pPrev[i];
+                }
+                float newLr = hgLr + exHyperLr * (float)inner;
+                for (int p = 0; p < paramCount; p++)
+                {
+                    if (gradArrays[p].Length == 0) continue;
+                    int len2 = lengths[p];
+                    fixed (float* pParam = paramArrays[p], pGrad = gradArrays[p], pPrev = m[p])
+                        for (int i = 0; i < len2; i++) { pParam[i] -= newLr * pGrad[i]; pPrev[i] = pGrad[i]; }
+                }
+                hgLr = newLr;
+                return;
+            }
+            if (optType == OptimizerType.DAdaptationSGD)
+            {
+                // Defazio & Mishchenko 2023 (growth-bounded, Prodigy). s, ‖s‖², r are GLOBAL.
+                float gamma = dEst * lr;
+                double gNorm2 = 0, sNorm2 = 0;
+                for (int p = 0; p < paramCount; p++)
+                {
+                    if (gradArrays[p].Length == 0) continue;
+                    int len2 = lengths[p];
+                    fixed (float* pGrad = gradArrays[p], pS = m[p])
+                        for (int i = 0; i < len2; i++)
+                        {
+                            pS[i] += gamma * pGrad[i];
+                            gNorm2 += (double)pGrad[i] * pGrad[i];
+                            sNorm2 += (double)pS[i] * pS[i];
+                        }
+                }
+                dRAccum += gamma * gamma * (float)gNorm2;
+                float dHat = (float)(sNorm2 / (Math.Sqrt(dRAccum) + 1e-30));
+                float dCapped = float.IsPositiveInfinity(exGrowth) ? dHat : Math.Min(dHat, dEst * exGrowth);
+                float dNew = Math.Max(dEst, dCapped);
+                float gammaNew = dNew * lr;
+                for (int p = 0; p < paramCount; p++)
+                {
+                    if (gradArrays[p].Length == 0) continue;
+                    int len2 = lengths[p];
+                    fixed (float* pParam = paramArrays[p], pGrad = gradArrays[p])
+                        for (int i = 0; i < len2; i++) pParam[i] -= gammaNew * pGrad[i];
+                }
+                dEst = dNew;
+                return;
+            }
+
             for (int p = 0; p < paramCount; p++)
             {
                 int len = lengths[p];
@@ -1121,7 +1199,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 or OptimizerType.SGDMomentum or OptimizerType.Lion or OptimizerType.Nadam
                 or OptimizerType.AdaMax or OptimizerType.AMSGrad
                 or OptimizerType.RAdam or OptimizerType.LAMB
-                or OptimizerType.LARS or OptimizerType.ASGD or OptimizerType.Rprop;
+                or OptimizerType.LARS or OptimizerType.ASGD or OptimizerType.Rprop
+                or OptimizerType.HypergradientSGD or OptimizerType.DAdaptationSGD;
             bool needsSecondMoment = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
                 or OptimizerType.RMSprop or OptimizerType.Nadam or OptimizerType.AMSGrad
                 or OptimizerType.Adagrad
@@ -1430,7 +1509,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 or OptimizerType.SGDMomentum or OptimizerType.Lion or OptimizerType.Nadam
                 or OptimizerType.AdaMax or OptimizerType.AMSGrad
                 or OptimizerType.RAdam or OptimizerType.LAMB
-                or OptimizerType.LARS or OptimizerType.ASGD or OptimizerType.Rprop;
+                or OptimizerType.LARS or OptimizerType.ASGD or OptimizerType.Rprop
+                or OptimizerType.HypergradientSGD or OptimizerType.DAdaptationSGD;
             bool needsSecondMoment = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
                 or OptimizerType.RMSprop or OptimizerType.Nadam or OptimizerType.AMSGrad
                 or OptimizerType.Adagrad
@@ -1548,7 +1628,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 or OptimizerType.SGDMomentum or OptimizerType.Lion or OptimizerType.Nadam
                 or OptimizerType.AdaMax or OptimizerType.AMSGrad
                 or OptimizerType.RAdam or OptimizerType.LAMB
-                or OptimizerType.LARS or OptimizerType.ASGD or OptimizerType.Rprop;
+                or OptimizerType.LARS or OptimizerType.ASGD or OptimizerType.Rprop
+                or OptimizerType.HypergradientSGD or OptimizerType.DAdaptationSGD;
             bool needsSecondMoment = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
                 or OptimizerType.RMSprop or OptimizerType.Nadam or OptimizerType.AMSGrad
                 or OptimizerType.Adagrad

--- a/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
@@ -1329,6 +1329,29 @@ public sealed class FusedOptimizerExtras
     /// <c>y = (1-β)z + βx</c> (Defazio et al., 2024). Default 0.9 — the
     /// paper's momentum-equivalent default.</summary>
     public float SfBeta { get; init; } = 0.9f;
+
+    /// <summary>
+    /// Validates the hyperparameters that would otherwise produce undefined or
+    /// divergent fused-optimizer math, throwing <see cref="ArgumentOutOfRangeException"/>
+    /// at configuration time rather than silently corrupting a training run.
+    /// Called by <c>CompiledTrainingPlan.ConfigureOptimizer*</c> before the
+    /// per-step closures capture these values.
+    /// </summary>
+    public void Validate()
+    {
+        if (!(HyperLr >= 0f) || float.IsNaN(HyperLr))
+            throw new ArgumentOutOfRangeException(nameof(HyperLr), HyperLr,
+                "Hypergradient-SGD HyperLr (β) must be >= 0.");
+        if (!(D0 > 0f) || float.IsNaN(D0))
+            throw new ArgumentOutOfRangeException(nameof(D0), D0,
+                "D-Adaptation initial distance estimate D0 must be > 0.");
+        if (!(DGrowthRate >= 1f))   // +inf is allowed (uncapped); only < 1 (incl. NaN) is rejected
+            throw new ArgumentOutOfRangeException(nameof(DGrowthRate), DGrowthRate,
+                "D-Adaptation DGrowthRate must be >= 1 (per-step growth cap; +inf = uncapped).");
+        if (!(SfBeta >= 0f && SfBeta <= 1f))
+            throw new ArgumentOutOfRangeException(nameof(SfBeta), SfBeta,
+                "Schedule-Free SfBeta must be in [0, 1].");
+    }
 }
 
 /// <summary>Optimizer type for fused parameter updates.</summary>

--- a/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
@@ -1319,6 +1319,12 @@ public sealed class FusedOptimizerExtras
     public float RpropStepMax { get; init; } = 50f;
     /// <summary>Rprop initial per-element step size. Default 0.01.</summary>
     public float RpropInitialStep { get; init; } = 0.01f;
+    /// <summary>Hypergradient-SGD learning rate of the learning rate (β). Default 1e-7.</summary>
+    public float HyperLr { get; init; } = 1e-7f;
+    /// <summary>D-Adaptation initial distance estimate d0. Default 1e-6.</summary>
+    public float D0 { get; init; } = 1e-6f;
+    /// <summary>D-Adaptation per-step growth cap (Prodigy growth_rate). Default +inf (uncapped).</summary>
+    public float DGrowthRate { get; init; } = float.PositiveInfinity;
 }
 
 /// <summary>Optimizer type for fused parameter updates.</summary>

--- a/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
@@ -1325,6 +1325,10 @@ public sealed class FusedOptimizerExtras
     public float D0 { get; init; } = 1e-6f;
     /// <summary>D-Adaptation per-step growth cap (Prodigy growth_rate). Default +inf (uncapped).</summary>
     public float DGrowthRate { get; init; } = float.PositiveInfinity;
+    /// <summary>Schedule-Free SGD interpolation factor β for the y-update
+    /// <c>y = (1-β)z + βx</c> (Defazio et al., 2024). Default 0.9 — the
+    /// paper's momentum-equivalent default.</summary>
+    public float SfBeta { get; init; } = 0.9f;
 }
 
 /// <summary>Optimizer type for fused parameter updates.</summary>

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.Mlp.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.Mlp.cs
@@ -66,7 +66,9 @@ public partial class CpuEngine
         IReadOnlyList<Tensor<T>> weights,
         IReadOnlyList<Tensor<T>?> biases,
         FusedActivationType hiddenActivation,
-        FusedActivationType outputActivation = FusedActivationType.None)
+        FusedActivationType outputActivation = FusedActivationType.None,
+        FusedActivationParams? hiddenActivationParams = null,
+        FusedActivationParams? outputActivationParams = null)
     {
         if (input is null) throw new ArgumentNullException(nameof(input));
         if (weights is null) throw new ArgumentNullException(nameof(weights));
@@ -115,7 +117,8 @@ public partial class CpuEngine
         for (int i = 0; i < weights.Count; i++)
         {
             var activation = i == last ? outputActivation : hiddenActivation;
-            x = FusedLinear(x, weights[i], biases[i], activation);
+            var actParams = i == last ? outputActivationParams : hiddenActivationParams;
+            x = FusedLinear(x, weights[i], biases[i], activation, actParams);
         }
 
         return x;

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -34247,6 +34247,85 @@ public partial class CpuEngine : ITensorLevelEngine
         return result;
     }
 
+    /// <summary>
+    /// Fused hierarchical softmax: class probabilities over a balanced binary
+    /// tree whose per-LEVEL routing gate is <c>sigmoid(input·nodeWeights[level])</c>.
+    /// <paramref name="input"/> is [.., D]; <paramref name="nodeWeights"/> is
+    /// [treeDepth, D] (one weight vector per tree level); the result is
+    /// [.., numClasses], where each leaf's probability is the product of the
+    /// gate decisions along its root-to-leaf path (left = 1−gate, right = gate).
+    /// The fusion computes the <c>treeDepth</c> shared gate sigmoids ONCE per row
+    /// and reuses them across every class, instead of the eager layer's
+    /// per-class gate recomputation (Morin &amp; Bengio 2005). Inference/forward-only.
+    /// </summary>
+    public virtual Tensor<T> FusedHierarchicalSoftmax<T>(Tensor<T> input, Tensor<T> nodeWeights, int numClasses)
+    {
+        if (input == null) throw new ArgumentNullException(nameof(input));
+        if (nodeWeights == null) throw new ArgumentNullException(nameof(nodeWeights));
+        if (numClasses < 2) throw new ArgumentException("numClasses must be >= 2.", nameof(numClasses));
+        if (nodeWeights._shape.Length != 2)
+            throw new ArgumentException("nodeWeights must be rank-2 [treeDepth, D].", nameof(nodeWeights));
+
+        int d = input._shape[input._shape.Length - 1];
+        int treeDepth = nodeWeights._shape[0];
+        if (nodeWeights._shape[1] != d)
+            throw new ArgumentException(
+                $"nodeWeights feature dim ({nodeWeights._shape[1]}) must match input feature dim ({d}).",
+                nameof(nodeWeights));
+        // A balanced tree of depth t can address up to 2^t leaves; require
+        // enough levels to reach every class (ceil(log2(numClasses))).
+        int minDepth = 0;
+        while ((1 << minDepth) < numClasses) minDepth++;
+        if (treeDepth < minDepth)
+            throw new ArgumentException(
+                $"treeDepth ({treeDepth}) is too small for {numClasses} classes; need >= {minDepth}.",
+                nameof(nodeWeights));
+
+        int rows = input.Length / d;
+        var outShape = (int[])input._shape.Clone();
+        outShape[outShape.Length - 1] = numClasses;
+        var result = new Tensor<T>(outShape);
+
+        var numOps = MathHelper.GetNumericOperations<T>();
+        var xa = input.GetDataArray();
+        var wa = nodeWeights.GetDataArray();
+        var oa = result.GetDataArray();
+        var one = numOps.One;
+        var gates = new T[treeDepth];
+
+        for (int r = 0; r < rows; r++)
+        {
+            int xBase = r * d;
+            // Shared per-level gates: sigmoid(input·nodeWeights[level]).
+            for (int level = 0; level < treeDepth; level++)
+            {
+                int wBase = level * d;
+                T dot = numOps.Zero;
+                for (int k = 0; k < d; k++)
+                    dot = numOps.Add(dot, numOps.Multiply(xa[xBase + k], wa[wBase + k]));
+                // sigmoid(z) = 1 / (1 + exp(-z))
+                T denom = numOps.Add(one, numOps.Exp(numOps.Negate(dot)));
+                gates[level] = numOps.Divide(one, denom);
+            }
+
+            int outBase = r * numClasses;
+            for (int c = 0; c < numClasses; c++)
+            {
+                T prob = one;
+                int node = 1;
+                for (int level = 0; level < treeDepth; level++)
+                {
+                    bool goRight = (c & (1 << (treeDepth - level - 1))) != 0;
+                    prob = numOps.Multiply(prob, goRight ? gates[level] : numOps.Subtract(one, gates[level]));
+                    node = node * 2 + (goRight ? 1 : 0);
+                    if (node >= numClasses) break;
+                }
+                oa[outBase + c] = prob;
+            }
+        }
+        return result;
+    }
+
     /// <inheritdoc/>
     public Tensor<T> FusedLinearBackward<T>(
         Tensor<T> gradOutput,

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -34198,6 +34198,55 @@ public partial class CpuEngine : ITensorLevelEngine
         return fallbackResult;
     }
 
+    /// <summary>
+    /// Fused linear + Maxout: computes the linear pre-activation (x·W + bias) of
+    /// shape [.., M, N] and reduces it by taking the max over consecutive groups of
+    /// <paramref name="numPieces"/> along the feature dimension, producing
+    /// [.., M, N/numPieces]. This is the shape-changing Maxout operation (Goodfellow
+    /// et al. 2013) — not an activation epilogue, since it shrinks the feature
+    /// dimension. Inference/forward-only (mirrors MlpForward); under a gradient tape
+    /// the caller should use the per-layer decomposition.
+    /// </summary>
+    public virtual Tensor<T> FusedLinearMaxout<T>(Tensor<T> input, Tensor<T> weights, Tensor<T>? bias, int numPieces)
+    {
+        if (input == null) throw new ArgumentNullException(nameof(input));
+        if (weights == null) throw new ArgumentNullException(nameof(weights));
+        if (numPieces < 2) throw new ArgumentException("numPieces must be >= 2.", nameof(numPieces));
+
+        // GEMM + bias (no activation) — reuse the fused linear fast path.
+        var pre = FusedLinear(input, weights, bias, FusedActivationType.None);
+        int n = pre._shape[pre._shape.Length - 1];
+        if (n % numPieces != 0)
+            throw new ArgumentException(
+                $"Maxout feature dimension ({n}) must be divisible by numPieces ({numPieces}).", nameof(numPieces));
+        int units = n / numPieces;
+        int rows = pre.Length / n;
+
+        var outShape = (int[])pre._shape.Clone();
+        outShape[outShape.Length - 1] = units;
+        var result = new Tensor<T>(outShape);
+
+        var pa = pre.GetDataArray();
+        var oa = result.GetDataArray();
+        var cmp = System.Collections.Generic.Comparer<T>.Default;
+        for (int r = 0; r < rows; r++)
+        {
+            int inRow = r * n, outRow = r * units;
+            for (int u = 0; u < units; u++)
+            {
+                int g = inRow + u * numPieces;
+                T mx = pa[g];
+                for (int j = 1; j < numPieces; j++)
+                {
+                    T v = pa[g + j];
+                    if (cmp.Compare(v, mx) > 0) mx = v;
+                }
+                oa[outRow + u] = mx;
+            }
+        }
+        return result;
+    }
+
     /// <inheritdoc/>
     public Tensor<T> FusedLinearBackward<T>(
         Tensor<T> gradOutput,

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -33942,7 +33942,7 @@ public partial class CpuEngine : ITensorLevelEngine
     #if !NETFRAMEWORK
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
 #endif
-    public virtual Tensor<T> FusedLinear<T>(Tensor<T> input, Tensor<T> weights, Tensor<T>? bias, FusedActivationType activation)
+    public virtual Tensor<T> FusedLinear<T>(Tensor<T> input, Tensor<T> weights, Tensor<T>? bias, FusedActivationType activation, FusedActivationParams? activationParams = null)
     {
         if (input == null) throw new ArgumentNullException(nameof(input));
         if (weights == null) throw new ArgumentNullException(nameof(weights));
@@ -34102,7 +34102,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 if (bias != null || activation != FusedActivationType.None)
                 {
                     var bArr = bias != null ? (float[])(object)bias.GetDataArray() : null;
-                    CpuFusedOperations.ApplyBiasActivationInPlace(outArr, bArr, M, N, activation);
+                    CpuFusedOperations.ApplyBiasActivationInPlace(outArr, bArr, M, N, activation, activationParams);
                 }
 
                 return result;
@@ -34153,7 +34153,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 if (bias != null || activation != FusedActivationType.None)
                 {
                     var bArr = bias != null ? (double[])(object)bias.GetDataArray() : null;
-                    CpuFusedOperations.ApplyBiasActivationInPlaceDouble(outArr, bArr, M, N, activation);
+                    CpuFusedOperations.ApplyBiasActivationInPlaceDouble(outArr, bArr, M, N, activation, activationParams);
                 }
 
                 return result;

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -3211,8 +3211,16 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// Uses cached GPU buffers for registered persistent tensors (weights/bias) to avoid
     /// redundant CPU→GPU transfers on every forward pass.
     /// </summary>
-    public override Tensor<T> FusedLinear<T>(Tensor<T> input, Tensor<T> weights, Tensor<T>? bias, FusedActivationType activation)
+    public override Tensor<T> FusedLinear<T>(Tensor<T> input, Tensor<T> weights, Tensor<T>? bias, FusedActivationType activation, FusedActivationParams? activationParams = null)
     {
+        // Parametric activation parameters (LeakyReLU slope, ELU/CELU alpha,
+        // ThresholdedReLU theta, ScaledTanh alpha/beta) are not yet plumbed into
+        // the GPU fused kernels — defer to the base CPU params-aware path so a
+        // custom parameter produces a correct result rather than the kernel's
+        // hardcoded default.
+        if (activationParams is not null)
+            return base.FusedLinear(input, weights, bias, activation, activationParams);
+
         // When a tape is active, defer to the base (CpuEngine) tape-aware
         // path which decomposes into TensorMatMul + TensorBroadcastAdd and
         // collapses them into a single recorded "FusedLinear" entry. The

--- a/src/AiDotNet.Tensors/Engines/FusedActivationType.cs
+++ b/src/AiDotNet.Tensors/Engines/FusedActivationType.cs
@@ -142,7 +142,31 @@ public enum FusedActivationType
     /// Parametric (alpha/beta, defaults 1/1) — supply via
     /// <see cref="FusedActivationParams.Alpha"/> / <see cref="FusedActivationParams.Beta"/>.
     /// </summary>
-    ScaledTanh = 19
+    ScaledTanh = 19,
+
+    /// <summary>
+    /// PReLU: f(x) = x if x &gt; 0, else slope_c * x — a per-channel learned slope.
+    /// Supply the slopes via <see cref="FusedActivationParams.PReluSlope"/> (length =
+    /// output features, or 1 for a shared slope; default 0.25). Applied per output
+    /// column of the [batch, features] result, so it needs channel context (not a
+    /// pointwise scalar kernel).
+    /// </summary>
+    PReLU = 20,
+
+    /// <summary>
+    /// RReLU (randomized leaky ReLU): in inference/eval it is deterministic —
+    /// f(x) = x if x &gt; 0, else alpha * x with alpha = (lower+upper)/2 (PyTorch
+    /// default (1/8+1/3)/2 ≈ 0.2292). Supply the eval slope via
+    /// <see cref="FusedActivationParams.Alpha"/>. (Fused paths are inference-only;
+    /// the training-time random slope is not fused.)
+    /// </summary>
+    RReLU = 21,
+
+    /// <summary>
+    /// Softmin: softmax(-x) over each row — f(x)_i = exp(-x_i) / Σ_j exp(-x_j).
+    /// Row-wise (not pointwise); applied across the feature dimension after the GEMM.
+    /// </summary>
+    Softmin = 22
 }
 
 /// <summary>
@@ -165,4 +189,10 @@ public sealed class FusedActivationParams
     public float? Beta { get; init; }
     /// <summary>ThresholdedReLU threshold. Default 1.</summary>
     public float? Theta { get; init; }
+    /// <summary>
+    /// PReLU per-channel negative slopes — length = output features (one per column
+    /// of the [batch, features] result), or length 1 for a single shared slope.
+    /// Null ⇒ 0.25 shared (PyTorch PReLU default init).
+    /// </summary>
+    public float[]? PReluSlope { get; init; }
 }

--- a/src/AiDotNet.Tensors/Engines/FusedActivationType.cs
+++ b/src/AiDotNet.Tensors/Engines/FusedActivationType.cs
@@ -122,5 +122,47 @@ public enum FusedActivationType
     /// SoftSign: f(x) = x / (1 + |x|)
     /// Smooth, bounded (-1, 1) alternative to Tanh with polynomial tails.
     /// </summary>
-    SoftSign = 16
+    SoftSign = 16,
+
+    /// <summary>
+    /// CELU: f(x) = max(0, x) + min(0, alpha * (exp(x / alpha) - 1))
+    /// Continuously-differentiable ELU variant (Barron, 2017). Parametric (alpha,
+    /// default 1) — supply via <see cref="FusedActivationParams.Alpha"/>.
+    /// </summary>
+    CELU = 17,
+
+    /// <summary>
+    /// ThresholdedReLU: f(x) = x if x &gt; theta, else 0
+    /// Parametric (theta, default 1) — supply via <see cref="FusedActivationParams.Theta"/>.
+    /// </summary>
+    ThresholdedReLU = 18,
+
+    /// <summary>
+    /// ScaledTanh: f(x) = alpha * tanh(beta * x)
+    /// Parametric (alpha/beta, defaults 1/1) — supply via
+    /// <see cref="FusedActivationParams.Alpha"/> / <see cref="FusedActivationParams.Beta"/>.
+    /// </summary>
+    ScaledTanh = 19
+}
+
+/// <summary>
+/// Optional scalar parameters for parametric fused activations. Omit (null) to use
+/// each activation's canonical default. Only the field(s) relevant to the chosen
+/// <see cref="FusedActivationType"/> are read.
+/// </summary>
+/// <remarks>
+/// A class with nullable init properties (not a record struct) so a missing field
+/// can be distinguished from an explicit value and resolved to the per-activation
+/// default. Lets <c>FusedLinear</c> / <c>MlpForward</c> / the activation epilogue
+/// fuse LeakyReLU (any slope), ELU / CELU (any alpha), ThresholdedReLU (theta),
+/// and ScaledTanh (alpha, beta) — not only the hardcoded default value.
+/// </remarks>
+public sealed class FusedActivationParams
+{
+    /// <summary>LeakyReLU slope, ELU/CELU/ScaledTanh alpha. Default: LeakyReLU 0.01, others 1.</summary>
+    public float? Alpha { get; init; }
+    /// <summary>ScaledTanh inner scale beta. Default 1.</summary>
+    public float? Beta { get; init; }
+    /// <summary>ThresholdedReLU threshold. Default 1.</summary>
+    public float? Theta { get; init; }
 }

--- a/src/AiDotNet.Tensors/Engines/FusedActivationType.cs
+++ b/src/AiDotNet.Tensors/Engines/FusedActivationType.cs
@@ -166,7 +166,41 @@ public enum FusedActivationType
     /// Softmin: softmax(-x) over each row — f(x)_i = exp(-x_i) / Σ_j exp(-x_j).
     /// Row-wise (not pointwise); applied across the feature dimension after the GEMM.
     /// </summary>
-    Softmin = 22
+    Softmin = 22,
+
+    /// <summary>Sign: -1 if x&lt;0, 0 if x==0, +1 if x&gt;0.</summary>
+    Sign = 23,
+    /// <summary>BentIdentity: f(x) = (sqrt(x²+1) - 1)/2 + x.</summary>
+    BentIdentity = 24,
+    /// <summary>Gaussian: f(x) = exp(-x²).</summary>
+    Gaussian = 25,
+    /// <summary>LiSHT: f(x) = x · tanh(x).</summary>
+    LiSHT = 26,
+    /// <summary>ISRU: f(x) = x / sqrt(1 + alpha·x²). Parametric (alpha, default 1) via <see cref="FusedActivationParams.Alpha"/>.</summary>
+    ISRU = 27,
+    /// <summary>SQRBF (square-RBF / Gaussian RBF): f(x) = exp(-beta·x²). Parametric (beta, default 1) via <see cref="FusedActivationParams.Beta"/>.</summary>
+    SQRBF = 28,
+    /// <summary>BinarySpiking: f(x) = x &gt;= threshold ? 1 : 0. Parametric (threshold, default 1) via <see cref="FusedActivationParams.Theta"/>.</summary>
+    BinarySpiking = 29,
+    /// <summary>LogSoftmax: x_i - (max + log Σ_j exp(x_j - max)). Row-wise.</summary>
+    LogSoftmax = 30,
+    /// <summary>LogSoftmin: log(softmax(-x)) = -x_i - log Σ_j exp(-x_j). Row-wise.</summary>
+    LogSoftmin = 31,
+    /// <summary>SphericalSoftmax: softmax(x / ||x||₂) over each row. Row-wise.</summary>
+    SphericalSoftmax = 32,
+    /// <summary>TaylorSoftmax: T(x_i)/Σ_j T(x_j) with T(x)=1+x+x²/2 (2nd-order). Row-wise.</summary>
+    TaylorSoftmax = 33,
+    /// <summary>GumbelSoftmax (deterministic eval): softmax(x / temperature). Parametric (temperature via
+    /// <see cref="FusedActivationParams.Alpha"/>, default 1). The training-time Gumbel noise is not fused.</summary>
+    GumbelSoftmax = 34,
+    /// <summary>Sparsemax: Euclidean projection of each row onto the probability simplex (Martins &amp; Astudillo 2016). Row-wise.</summary>
+    Sparsemax = 35,
+    /// <summary>Squash (capsule): y = (||x||²/(1+||x||²)) · x/||x||, over each row as a vector. Row-wise.</summary>
+    Squash = 36
+
+    // NOT fusible as an in-place [M,N]→[M,N] epilogue activation (structural, not a gap):
+    //  • Maxout — reduces k channels to 1 (changes output dimensionality; it's a pooling op, not elementwise).
+    //  • HierarchicalSoftmax — needs a class tree + the target label (a loss-coupled structure, not a plain activation).
 }
 
 /// <summary>

--- a/src/AiDotNet.Tensors/Engines/FusedActivationType.cs
+++ b/src/AiDotNet.Tensors/Engines/FusedActivationType.cs
@@ -110,5 +110,17 @@ public enum FusedActivationType
     /// HardTanh: f(x) = clip(x, -1, 1)
     /// Efficient approximation of Tanh with bounded outputs.
     /// </summary>
-    HardTanh = 14
+    HardTanh = 14,
+
+    /// <summary>
+    /// ReLU6: f(x) = min(max(0, x), 6)
+    /// ReLU clamped at 6; common in mobile/quantized networks (MobileNet).
+    /// </summary>
+    ReLU6 = 15,
+
+    /// <summary>
+    /// SoftSign: f(x) = x / (1 + |x|)
+    /// Smooth, bounded (-1, 1) alternative to Tanh with polynomial tails.
+    /// </summary>
+    SoftSign = 16
 }

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -4685,6 +4685,14 @@ public interface IEngine
         FusedActivationParams? activationParams = null);
 
     /// <summary>
+    /// Fused linear + Maxout (Goodfellow et al. 2013): computes x·W + bias of shape
+    /// [.., M, N] then reduces along the feature dim by max over consecutive groups
+    /// of <paramref name="numPieces"/>, producing [.., M, N/numPieces]. A
+    /// shape-changing reduction (not an activation epilogue). Forward/inference-only.
+    /// </summary>
+    Tensor<T> FusedLinearMaxout<T>(Tensor<T> input, Tensor<T> weights, Tensor<T>? bias, int numPieces);
+
+    /// <summary>
     /// Computes the backward pass for fused linear transformation.
     /// </summary>
     Tensor<T> FusedLinearBackward<T>(

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -4693,6 +4693,16 @@ public interface IEngine
     Tensor<T> FusedLinearMaxout<T>(Tensor<T> input, Tensor<T> weights, Tensor<T>? bias, int numPieces);
 
     /// <summary>
+    /// Fused hierarchical softmax (Morin &amp; Bengio 2005): class probabilities
+    /// over a balanced binary tree whose per-level routing gate is
+    /// <c>sigmoid(input·nodeWeights[level])</c>. <paramref name="input"/> is
+    /// [.., D], <paramref name="nodeWeights"/> is [treeDepth, D]; the result is
+    /// [.., numClasses]. The <c>treeDepth</c> shared gate sigmoids are computed
+    /// once per row and reused across all classes. Forward/inference-only.
+    /// </summary>
+    Tensor<T> FusedHierarchicalSoftmax<T>(Tensor<T> input, Tensor<T> nodeWeights, int numClasses);
+
+    /// <summary>
     /// Computes the backward pass for fused linear transformation.
     /// </summary>
     Tensor<T> FusedLinearBackward<T>(

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -4681,7 +4681,8 @@ public interface IEngine
         Tensor<T> input,
         Tensor<T> weights,
         Tensor<T>? bias,
-        FusedActivationType activation);
+        FusedActivationType activation,
+        FusedActivationParams? activationParams = null);
 
     /// <summary>
     /// Computes the backward pass for fused linear transformation.
@@ -4790,7 +4791,9 @@ public interface IEngine
         IReadOnlyList<Tensor<T>> weights,
         IReadOnlyList<Tensor<T>?> biases,
         FusedActivationType hiddenActivation,
-        FusedActivationType outputActivation);
+        FusedActivationType outputActivation = FusedActivationType.None,
+        FusedActivationParams? hiddenActivationParams = null,
+        FusedActivationParams? outputActivationParams = null);
 
     #endregion
 

--- a/src/AiDotNet.Tensors/Helpers/CpuFusedOperations.cs
+++ b/src/AiDotNet.Tensors/Helpers/CpuFusedOperations.cs
@@ -562,6 +562,46 @@ public static class CpuFusedOperations
         bool hasActivation = activation != FusedActivationType.None;
         if (!hasBias && !hasActivation) return;
 
+        // PReLU / Softmax / Softmin need per-column or per-row context (not a
+        // pointwise scalar), so they get a dedicated bias-then-activation pass.
+        if (activation is FusedActivationType.PReLU or FusedActivationType.Softmax or FusedActivationType.Softmin)
+        {
+            if (hasBias)
+                for (int i = 0; i < M; i++)
+                    for (int j = 0; j < N; j++)
+                        output[i * N + j] += bias![j];
+
+            if (activation == FusedActivationType.PReLU)
+            {
+                var slope = activationParams?.PReluSlope;
+                for (int i = 0; i < M; i++)
+                {
+                    int row = i * N;
+                    for (int j = 0; j < N; j++)
+                    {
+                        float s = slope == null ? 0.25f : (slope.Length == 1 ? slope[0] : slope[j]);
+                        float v = output[row + j];
+                        output[row + j] = v > 0f ? v : s * v;
+                    }
+                }
+            }
+            else
+            {
+                bool min = activation == FusedActivationType.Softmin; // softmax over -x
+                for (int i = 0; i < M; i++)
+                {
+                    int row = i * N;
+                    float mx = float.NegativeInfinity;
+                    for (int j = 0; j < N; j++) { float v = min ? -output[row + j] : output[row + j]; if (v > mx) mx = v; }
+                    float sum = 0f;
+                    for (int j = 0; j < N; j++) { float v = min ? -output[row + j] : output[row + j]; float e = MathF.Exp(v - mx); output[row + j] = e; sum += e; }
+                    float inv = 1f / sum;
+                    for (int j = 0; j < N; j++) output[row + j] *= inv;
+                }
+            }
+            return;
+        }
+
 #if NET5_0_OR_GREATER
         // Path B: SIMD-vectorised bias + activation epilogue. The prior scalar
         // loop with per-element delegate dispatch took ~8 ms on BERT FFN
@@ -1259,6 +1299,12 @@ public static class CpuFusedOperations
         {
             case FusedActivationType.LeakyReLU when p?.Alpha is float la:
                 return x => x > 0f ? x : la * x;
+            case FusedActivationType.RReLU:
+            {
+                // Inference/eval: deterministic slope (lower+upper)/2. PyTorch default ≈ 0.2292.
+                float a = p?.Alpha ?? 0.22916667f;
+                return x => x > 0f ? x : a * x;
+            }
             case FusedActivationType.ELU when p?.Alpha is float ea:
                 return x => x > 0f ? x : ea * (MathF.Exp(x) - 1f);
             case FusedActivationType.CELU:
@@ -1385,6 +1431,45 @@ public static class CpuFusedOperations
         bool hasActivation = activation != FusedActivationType.None;
         if (!hasBias && !hasActivation) return;
 
+        // PReLU / Softmax / Softmin: per-column / per-row, not pointwise.
+        if (activation is FusedActivationType.PReLU or FusedActivationType.Softmax or FusedActivationType.Softmin)
+        {
+            if (hasBias)
+                for (int i = 0; i < M; i++)
+                    for (int j = 0; j < N; j++)
+                        output[i * N + j] += bias![j];
+
+            if (activation == FusedActivationType.PReLU)
+            {
+                var slope = activationParams?.PReluSlope;
+                for (int i = 0; i < M; i++)
+                {
+                    int row = i * N;
+                    for (int j = 0; j < N; j++)
+                    {
+                        double s = slope == null ? 0.25 : (slope.Length == 1 ? slope[0] : slope[j]);
+                        double v = output[row + j];
+                        output[row + j] = v > 0.0 ? v : s * v;
+                    }
+                }
+            }
+            else
+            {
+                bool min = activation == FusedActivationType.Softmin;
+                for (int i = 0; i < M; i++)
+                {
+                    int row = i * N;
+                    double mx = double.NegativeInfinity;
+                    for (int j = 0; j < N; j++) { double v = min ? -output[row + j] : output[row + j]; if (v > mx) mx = v; }
+                    double sum = 0.0;
+                    for (int j = 0; j < N; j++) { double v = min ? -output[row + j] : output[row + j]; double e = Math.Exp(v - mx); output[row + j] = e; sum += e; }
+                    double inv = 1.0 / sum;
+                    for (int j = 0; j < N; j++) output[row + j] *= inv;
+                }
+            }
+            return;
+        }
+
         // Hoist the delegate lookup outside the hot loop
         Func<double, double>? activationFn = hasActivation ? GetDoubleActivation(activation, activationParams) : null;
 
@@ -1432,6 +1517,11 @@ public static class CpuFusedOperations
         {
             case FusedActivationType.LeakyReLU when p?.Alpha is float la:
                 return x => x > 0.0 ? x : la * x;
+            case FusedActivationType.RReLU:
+            {
+                double a = p?.Alpha ?? 0.22916667f;
+                return x => x > 0.0 ? x : a * x;
+            }
             case FusedActivationType.ELU when p?.Alpha is float ea:
                 return x => x > 0.0 ? x : ea * (Math.Exp(x) - 1.0);
             case FusedActivationType.CELU:

--- a/src/AiDotNet.Tensors/Helpers/CpuFusedOperations.cs
+++ b/src/AiDotNet.Tensors/Helpers/CpuFusedOperations.cs
@@ -556,7 +556,7 @@ public static class CpuFusedOperations
 #endif
 
     [MethodImpl(Hot)]
-    internal static void ApplyBiasActivationInPlace(float[] output, float[]? bias, int M, int N, FusedActivationType activation)
+    internal static void ApplyBiasActivationInPlace(float[] output, float[]? bias, int M, int N, FusedActivationType activation, FusedActivationParams? activationParams = null)
     {
         bool hasBias = bias != null;
         bool hasActivation = activation != FusedActivationType.None;
@@ -644,7 +644,7 @@ public static class CpuFusedOperations
 #endif
 
         // Hoist the delegate lookup outside the hot loop to avoid per-element dictionary access
-        Func<float, float>? activationFn = hasActivation ? GetFloatActivation(activation) : null;
+        Func<float, float>? activationFn = hasActivation ? GetFloatActivation(activation, activationParams) : null;
 
         for (int i = 0; i < M; i++)
         {
@@ -1249,8 +1249,35 @@ public static class CpuFusedOperations
 
     /// <summary>Gets the float activation function delegate for use in tight loops.
     /// Resolve once outside the loop, then call the returned delegate per element.</summary>
-    internal static Func<float, float> GetFloatActivation(FusedActivationType activation)
+    internal static Func<float, float> GetFloatActivation(FusedActivationType activation, FusedActivationParams? p = null)
     {
+        // Parametric activations: build a closure from p, falling back to each
+        // activation's canonical default. LeakyReLU/ELU only intercept here when an
+        // explicit alpha is supplied; otherwise they use the hardcoded-default dict
+        // entry below. CELU/ThresholdedReLU/ScaledTanh are parametric-only.
+        switch (activation)
+        {
+            case FusedActivationType.LeakyReLU when p?.Alpha is float la:
+                return x => x > 0f ? x : la * x;
+            case FusedActivationType.ELU when p?.Alpha is float ea:
+                return x => x > 0f ? x : ea * (MathF.Exp(x) - 1f);
+            case FusedActivationType.CELU:
+            {
+                // max(0,x)+min(0,a*(exp(x/a)-1)) reduces to this piecewise form.
+                float a = p?.Alpha ?? 1f;
+                return x => x >= 0f ? x : a * (MathF.Exp(x / a) - 1f);
+            }
+            case FusedActivationType.ThresholdedReLU:
+            {
+                float t = p?.Theta ?? 1f;
+                return x => x > t ? x : 0f;
+            }
+            case FusedActivationType.ScaledTanh:
+            {
+                float a = p?.Alpha ?? 1f, b = p?.Beta ?? 1f;
+                return x => a * MathF.Tanh(b * x);
+            }
+        }
         if (_floatActivations.TryGetValue(activation, out var fn))
             return fn;
         throw new ArgumentException($"No float activation registered for type: {activation}");
@@ -1352,14 +1379,14 @@ public static class CpuFusedOperations
     /// Applies bias addition and activation function in-place over the double GEMM output.
     /// </summary>
     [MethodImpl(Hot)]
-    internal static void ApplyBiasActivationInPlaceDouble(double[] output, double[]? bias, int M, int N, FusedActivationType activation)
+    internal static void ApplyBiasActivationInPlaceDouble(double[] output, double[]? bias, int M, int N, FusedActivationType activation, FusedActivationParams? activationParams = null)
     {
         bool hasBias = bias != null;
         bool hasActivation = activation != FusedActivationType.None;
         if (!hasBias && !hasActivation) return;
 
         // Hoist the delegate lookup outside the hot loop
-        Func<double, double>? activationFn = hasActivation ? GetDoubleActivation(activation) : null;
+        Func<double, double>? activationFn = hasActivation ? GetDoubleActivation(activation, activationParams) : null;
 
         for (int i = 0; i < M; i++)
         {
@@ -1399,8 +1426,30 @@ public static class CpuFusedOperations
 
     /// <summary>Gets the double activation function delegate for use in tight loops.
     /// Resolve once outside the loop, then call the returned delegate per element.</summary>
-    internal static Func<double, double> GetDoubleActivation(FusedActivationType activation)
+    internal static Func<double, double> GetDoubleActivation(FusedActivationType activation, FusedActivationParams? p = null)
     {
+        switch (activation)
+        {
+            case FusedActivationType.LeakyReLU when p?.Alpha is float la:
+                return x => x > 0.0 ? x : la * x;
+            case FusedActivationType.ELU when p?.Alpha is float ea:
+                return x => x > 0.0 ? x : ea * (Math.Exp(x) - 1.0);
+            case FusedActivationType.CELU:
+            {
+                double a = p?.Alpha ?? 1f;
+                return x => x >= 0.0 ? x : a * (Math.Exp(x / a) - 1.0);
+            }
+            case FusedActivationType.ThresholdedReLU:
+            {
+                double t = p?.Theta ?? 1f;
+                return x => x > t ? x : 0.0;
+            }
+            case FusedActivationType.ScaledTanh:
+            {
+                double a = p?.Alpha ?? 1f, b = p?.Beta ?? 1f;
+                return x => a * Math.Tanh(b * x);
+            }
+        }
         if (_doubleActivations.TryGetValue(activation, out var fn))
             return fn;
         throw new ArgumentException($"No double activation registered for type: {activation}");

--- a/src/AiDotNet.Tensors/Helpers/CpuFusedOperations.cs
+++ b/src/AiDotNet.Tensors/Helpers/CpuFusedOperations.cs
@@ -563,42 +563,15 @@ public static class CpuFusedOperations
         if (!hasBias && !hasActivation) return;
 
         // PReLU / Softmax / Softmin need per-column or per-row context (not a
-        // pointwise scalar), so they get a dedicated bias-then-activation pass.
-        if (activation is FusedActivationType.PReLU or FusedActivationType.Softmax or FusedActivationType.Softmin)
+        // pointwise scalar), so they get a dedicated bias-then-activation pass
+        // via the shared RowwiseFusedActivations (also used by the BlasManaged epilogue).
+        if (RowwiseFusedActivations.Handles(activation))
         {
             if (hasBias)
                 for (int i = 0; i < M; i++)
                     for (int j = 0; j < N; j++)
                         output[i * N + j] += bias![j];
-
-            if (activation == FusedActivationType.PReLU)
-            {
-                var slope = activationParams?.PReluSlope;
-                for (int i = 0; i < M; i++)
-                {
-                    int row = i * N;
-                    for (int j = 0; j < N; j++)
-                    {
-                        float s = slope == null ? 0.25f : (slope.Length == 1 ? slope[0] : slope[j]);
-                        float v = output[row + j];
-                        output[row + j] = v > 0f ? v : s * v;
-                    }
-                }
-            }
-            else
-            {
-                bool min = activation == FusedActivationType.Softmin; // softmax over -x
-                for (int i = 0; i < M; i++)
-                {
-                    int row = i * N;
-                    float mx = float.NegativeInfinity;
-                    for (int j = 0; j < N; j++) { float v = min ? -output[row + j] : output[row + j]; if (v > mx) mx = v; }
-                    float sum = 0f;
-                    for (int j = 0; j < N; j++) { float v = min ? -output[row + j] : output[row + j]; float e = MathF.Exp(v - mx); output[row + j] = e; sum += e; }
-                    float inv = 1f / sum;
-                    for (int j = 0; j < N; j++) output[row + j] *= inv;
-                }
-            }
+            RowwiseFusedActivations.ApplyFloat(output, N, M, N, activation, activationParams);
             return;
         }
 
@@ -1323,6 +1296,29 @@ public static class CpuFusedOperations
                 float a = p?.Alpha ?? 1f, b = p?.Beta ?? 1f;
                 return x => a * MathF.Tanh(b * x);
             }
+            case FusedActivationType.Sign:
+                return x => x < 0f ? -1f : (x > 0f ? 1f : 0f);
+            case FusedActivationType.BentIdentity:
+                return x => 0.5f * (MathF.Sqrt(x * x + 1f) - 1f) + x;
+            case FusedActivationType.Gaussian:
+                return x => MathF.Exp(-x * x);
+            case FusedActivationType.LiSHT:
+                return x => x * MathF.Tanh(x); // tanh is bounded ⇒ no overflow; → |x| for large |x|
+            case FusedActivationType.ISRU:
+            {
+                float a = p?.Alpha ?? 1f;
+                return x => x / MathF.Sqrt(1f + a * x * x);
+            }
+            case FusedActivationType.SQRBF:
+            {
+                float b = p?.Beta ?? 1f;
+                return x => MathF.Exp(-b * x * x);
+            }
+            case FusedActivationType.BinarySpiking:
+            {
+                float t = p?.Theta ?? 1f;
+                return x => x >= t ? 1f : 0f;
+            }
         }
         if (_floatActivations.TryGetValue(activation, out var fn))
             return fn;
@@ -1431,42 +1427,15 @@ public static class CpuFusedOperations
         bool hasActivation = activation != FusedActivationType.None;
         if (!hasBias && !hasActivation) return;
 
-        // PReLU / Softmax / Softmin: per-column / per-row, not pointwise.
-        if (activation is FusedActivationType.PReLU or FusedActivationType.Softmax or FusedActivationType.Softmin)
+        // Channel/row-wise activations (PReLU, the softmax family, Sparsemax,
+        // Squash, …) via the shared RowwiseFusedActivations.
+        if (RowwiseFusedActivations.Handles(activation))
         {
             if (hasBias)
                 for (int i = 0; i < M; i++)
                     for (int j = 0; j < N; j++)
                         output[i * N + j] += bias![j];
-
-            if (activation == FusedActivationType.PReLU)
-            {
-                var slope = activationParams?.PReluSlope;
-                for (int i = 0; i < M; i++)
-                {
-                    int row = i * N;
-                    for (int j = 0; j < N; j++)
-                    {
-                        double s = slope == null ? 0.25 : (slope.Length == 1 ? slope[0] : slope[j]);
-                        double v = output[row + j];
-                        output[row + j] = v > 0.0 ? v : s * v;
-                    }
-                }
-            }
-            else
-            {
-                bool min = activation == FusedActivationType.Softmin;
-                for (int i = 0; i < M; i++)
-                {
-                    int row = i * N;
-                    double mx = double.NegativeInfinity;
-                    for (int j = 0; j < N; j++) { double v = min ? -output[row + j] : output[row + j]; if (v > mx) mx = v; }
-                    double sum = 0.0;
-                    for (int j = 0; j < N; j++) { double v = min ? -output[row + j] : output[row + j]; double e = Math.Exp(v - mx); output[row + j] = e; sum += e; }
-                    double inv = 1.0 / sum;
-                    for (int j = 0; j < N; j++) output[row + j] *= inv;
-                }
-            }
+            RowwiseFusedActivations.ApplyDouble(output, N, M, N, activation, activationParams);
             return;
         }
 
@@ -1538,6 +1507,29 @@ public static class CpuFusedOperations
             {
                 double a = p?.Alpha ?? 1f, b = p?.Beta ?? 1f;
                 return x => a * Math.Tanh(b * x);
+            }
+            case FusedActivationType.Sign:
+                return x => x < 0.0 ? -1.0 : (x > 0.0 ? 1.0 : 0.0);
+            case FusedActivationType.BentIdentity:
+                return x => 0.5 * (Math.Sqrt(x * x + 1.0) - 1.0) + x;
+            case FusedActivationType.Gaussian:
+                return x => Math.Exp(-x * x);
+            case FusedActivationType.LiSHT:
+                return x => x * Math.Tanh(x);
+            case FusedActivationType.ISRU:
+            {
+                double a = p?.Alpha ?? 1f;
+                return x => x / Math.Sqrt(1.0 + a * x * x);
+            }
+            case FusedActivationType.SQRBF:
+            {
+                double b = p?.Beta ?? 1f;
+                return x => Math.Exp(-b * x * x);
+            }
+            case FusedActivationType.BinarySpiking:
+            {
+                double t = p?.Theta ?? 1f;
+                return x => x >= t ? 1.0 : 0.0;
             }
         }
         if (_doubleActivations.TryGetValue(activation, out var fn))

--- a/src/AiDotNet.Tensors/Helpers/CpuFusedOperations.cs
+++ b/src/AiDotNet.Tensors/Helpers/CpuFusedOperations.cs
@@ -117,13 +117,17 @@ public static class CpuFusedOperations
     /// <param name="N">Number of columns in B (output features).</param>
     /// <param name="K">Shared dimension (input features).</param>
     /// <param name="activation">Activation function to apply.</param>
+    /// <param name="activationParams">Optional parametric-activation settings
+    /// (LeakyReLU/RReLU slope, ELU/CELU/ThresholdedReLU/ScaledTanh params). Null
+    /// uses each activation's default.</param>
     public static void FusedGemmBiasActivation(
         float[] A,
         float[] B,
         float[]? bias,
         float[] output,
         int M, int N, int K,
-        FusedActivationType activation)
+        FusedActivationType activation,
+        FusedActivationParams? activationParams = null)
     {
         if (A.Length < M * K)
             throw new ArgumentException($"A must have at least {M * K} elements", nameof(A));
@@ -134,7 +138,7 @@ public static class CpuFusedOperations
         if (bias != null && bias.Length < N)
             throw new ArgumentException($"bias must have at least {N} elements", nameof(bias));
 
-        FusedGemmBiasActivationUnchecked(A, B, bias, output, M, N, K, activation);
+        FusedGemmBiasActivationUnchecked(A, B, bias, output, M, N, K, activation, activationParams: activationParams);
     }
 
     internal static void FusedGemmBiasActivationUnchecked(
@@ -144,12 +148,13 @@ public static class CpuFusedOperations
         float[] output,
         int M, int N, int K,
         FusedActivationType activation,
-        bool allowCachedB = true)
+        bool allowCachedB = true,
+        FusedActivationParams? activationParams = null)
     {
         // Use BLAS for the O(MNK) GEMM, then fuse bias+activation in a cheap O(MN) second pass.
         if (BlasProvider.TryGemm(M, N, K, A, 0, K, B, 0, N, output, 0, N))
         {
-            ApplyBiasActivationInPlace(output, bias, M, N, activation);
+            ApplyBiasActivationInPlace(output, bias, M, N, activation, activationParams);
             return;
         }
 
@@ -172,7 +177,7 @@ public static class CpuFusedOperations
             SimdGemm.Sgemm(
                 A.AsSpan(0, M * K), B.AsSpan(0, K * N), output.AsSpan(0, M * N), M, K, N);
         }
-        ApplyBiasActivationInPlace(output, bias, M, N, activation);
+        ApplyBiasActivationInPlace(output, bias, M, N, activation, activationParams);
     }
 
     /// <summary>
@@ -1284,6 +1289,8 @@ public static class CpuFusedOperations
             {
                 // max(0,x)+min(0,a*(exp(x/a)-1)) reduces to this piecewise form.
                 float a = p?.Alpha ?? 1f;
+                if (!(a > 0f))
+                    throw new ArgumentOutOfRangeException(nameof(p), "CELU alpha must be > 0 (the activation divides by it).");
                 return x => x >= 0f ? x : a * (MathF.Exp(x / a) - 1f);
             }
             case FusedActivationType.ThresholdedReLU:
@@ -1383,7 +1390,8 @@ public static class CpuFusedOperations
         double[]? bias,
         double[] output,
         int M, int N, int K,
-        FusedActivationType activation)
+        FusedActivationType activation,
+        FusedActivationParams? activationParams = null)
     {
         if (A.Length < M * K)
             throw new ArgumentException($"A must have at least {M * K} elements", nameof(A));
@@ -1397,7 +1405,7 @@ public static class CpuFusedOperations
         // Use BLAS for the O(MNK) GEMM, then fuse bias+activation in a cheap O(MN) second pass.
         if (BlasProvider.TryGemm(M, N, K, A, 0, K, B, 0, N, output, 0, N))
         {
-            ApplyBiasActivationInPlaceDouble(output, bias, M, N, activation);
+            ApplyBiasActivationInPlaceDouble(output, bias, M, N, activation, activationParams);
             return;
         }
 
@@ -1414,7 +1422,7 @@ public static class CpuFusedOperations
             MathHelper.GetNumericOperations<double>(),
             A.AsMemory(0, M * K), B.AsMemory(0, K * N), output.AsMemory(0, M * N),
             M, K, N, K, N, N);
-        ApplyBiasActivationInPlaceDouble(output, bias, M, N, activation);
+        ApplyBiasActivationInPlaceDouble(output, bias, M, N, activation, activationParams);
     }
 
     /// <summary>
@@ -1496,6 +1504,8 @@ public static class CpuFusedOperations
             case FusedActivationType.CELU:
             {
                 double a = p?.Alpha ?? 1f;
+                if (!(a > 0.0))
+                    throw new ArgumentOutOfRangeException(nameof(p), "CELU alpha must be > 0 (the activation divides by it).");
                 return x => x >= 0.0 ? x : a * (Math.Exp(x / a) - 1.0);
             }
             case FusedActivationType.ThresholdedReLU:

--- a/src/AiDotNet.Tensors/Helpers/CpuFusedOperations.cs
+++ b/src/AiDotNet.Tensors/Helpers/CpuFusedOperations.cs
@@ -1240,6 +1240,9 @@ public static class CpuFusedOperations
         { FusedActivationType.HardSwish, ApplyHardSwish },
         { FusedActivationType.HardSigmoid, ApplyHardSigmoid },
         { FusedActivationType.HardTanh, ApplyHardTanh },
+        // NaN-preserving clamp (see ReLU note above): x<0 false / x>6 false on NaN ⇒ NaN survives.
+        { FusedActivationType.ReLU6, x => x < 0f ? 0f : (x > 6f ? 6f : x) },
+        { FusedActivationType.SoftSign, x => x / (1f + MathF.Abs(x)) },
         // Softmax is NOT pointwise (depends on entire row) — must not appear here.
         // Fused paths that include Softmax should apply it separately after the GEMM loop.
     };
@@ -1389,6 +1392,8 @@ public static class CpuFusedOperations
         { FusedActivationType.HardSwish, ApplyHardSwishDouble },
         { FusedActivationType.HardSigmoid, ApplyHardSigmoidDouble },
         { FusedActivationType.HardTanh, ApplyHardTanhDouble },
+        { FusedActivationType.ReLU6, x => x < 0.0 ? 0.0 : (x > 6.0 ? 6.0 : x) },
+        { FusedActivationType.SoftSign, x => x / (1.0 + Math.Abs(x)) },
         // Softmax is NOT pointwise — must not appear here.
     };
 

--- a/src/AiDotNet.Tensors/Helpers/RowwiseFusedActivations.cs
+++ b/src/AiDotNet.Tensors/Helpers/RowwiseFusedActivations.cs
@@ -35,7 +35,12 @@ internal static class RowwiseFusedActivations
                     var slope = p?.PReluSlope;
                     for (int j = 0; j < n; j++)
                     {
-                        float s = slope == null ? 0.25f : (slope.Length == 1 ? slope[0] : slope[j]);
+                        // Per-channel slope; broadcast a length-1 array, and defensively
+                        // clamp to the last element if a misconfigured slope is shorter
+                        // than the feature dim (rather than throwing IndexOutOfRange).
+                        float s = slope == null ? 0.25f
+                                : slope.Length == 1 ? slope[0]
+                                : j < slope.Length ? slope[j] : slope[slope.Length - 1];
                         float v = c[row + j];
                         c[row + j] = v > 0f ? v : s * v;
                     }
@@ -133,7 +138,12 @@ internal static class RowwiseFusedActivations
                     var slope = p?.PReluSlope;
                     for (int j = 0; j < n; j++)
                     {
-                        double s = slope == null ? 0.25 : (slope.Length == 1 ? slope[0] : slope[j]);
+                        // Per-channel slope; broadcast a length-1 array, and defensively
+                        // clamp to the last element if a misconfigured slope is shorter
+                        // than the feature dim (rather than throwing IndexOutOfRange).
+                        double s = slope == null ? 0.25
+                                 : slope.Length == 1 ? slope[0]
+                                 : j < slope.Length ? slope[j] : slope[slope.Length - 1];
                         double v = c[row + j];
                         c[row + j] = v > 0.0 ? v : s * v;
                     }

--- a/src/AiDotNet.Tensors/Helpers/RowwiseFusedActivations.cs
+++ b/src/AiDotNet.Tensors/Helpers/RowwiseFusedActivations.cs
@@ -1,0 +1,213 @@
+using System;
+using AiDotNet.Tensors.Engines;
+
+namespace AiDotNet.Tensors.Helpers;
+
+/// <summary>
+/// Activations that need per-row (across the feature dimension) or per-column
+/// (channel) context rather than a pointwise scalar map. Shared by the
+/// MlpForward/FusedLinear bias-activation epilogue (CpuFusedOperations) and the
+/// BlasManaged GEMM <c>ActivationEpilogue</c> so both fused paths apply identical
+/// math. Operates in place on a row-major matrix view: element (i,j) at
+/// <c>buffer[i*ldc + j]</c>, i in [0,m), j in [0,n).
+/// </summary>
+internal static class RowwiseFusedActivations
+{
+    /// <summary>True for activations this helper owns (channel/row-wise).</summary>
+    internal static bool Handles(FusedActivationType a) => a is
+        FusedActivationType.PReLU
+        or FusedActivationType.Softmax or FusedActivationType.Softmin
+        or FusedActivationType.LogSoftmax or FusedActivationType.LogSoftmin
+        or FusedActivationType.SphericalSoftmax or FusedActivationType.TaylorSoftmax
+        or FusedActivationType.GumbelSoftmax or FusedActivationType.Sparsemax
+        or FusedActivationType.Squash;
+
+    internal static void ApplyFloat(Span<float> c, int ldc, int m, int n, FusedActivationType act, FusedActivationParams? p)
+    {
+        float[]? scratch = act == FusedActivationType.Sparsemax ? new float[n] : null;
+        for (int i = 0; i < m; i++)
+        {
+            int row = i * ldc;
+            switch (act)
+            {
+                case FusedActivationType.PReLU:
+                {
+                    var slope = p?.PReluSlope;
+                    for (int j = 0; j < n; j++)
+                    {
+                        float s = slope == null ? 0.25f : (slope.Length == 1 ? slope[0] : slope[j]);
+                        float v = c[row + j];
+                        c[row + j] = v > 0f ? v : s * v;
+                    }
+                    break;
+                }
+                case FusedActivationType.Softmax: SoftmaxF(c, row, n, negate: false); break;
+                case FusedActivationType.Softmin: SoftmaxF(c, row, n, negate: true); break;
+                case FusedActivationType.GumbelSoftmax:
+                {
+                    float tau = p?.Alpha ?? 1f;
+                    if (tau != 1f) for (int j = 0; j < n; j++) c[row + j] /= tau;
+                    SoftmaxF(c, row, n, negate: false);
+                    break;
+                }
+                case FusedActivationType.SphericalSoftmax:
+                {
+                    // softmax(x / ||x||2); values bounded to [-1,1] so the softmax is stable.
+                    double ss = 0; for (int j = 0; j < n; j++) ss += (double)c[row + j] * c[row + j];
+                    float norm = (float)Math.Sqrt(ss);
+                    if (norm > 0f) for (int j = 0; j < n; j++) c[row + j] /= norm;
+                    SoftmaxF(c, row, n, negate: false);
+                    break;
+                }
+                case FusedActivationType.LogSoftmax: LogSoftmaxF(c, row, n, negate: false); break;
+                case FusedActivationType.LogSoftmin: LogSoftmaxF(c, row, n, negate: true); break;
+                case FusedActivationType.TaylorSoftmax:
+                {
+                    // T(x)=1+x+x²/2 (2nd-order Taylor of exp); strictly positive (=0.5(x+1)²+0.5).
+                    float sum = 0f;
+                    for (int j = 0; j < n; j++) { float x = c[row + j]; float t = 1f + x + 0.5f * x * x; c[row + j] = t; sum += t; }
+                    float inv = 1f / sum;
+                    for (int j = 0; j < n; j++) c[row + j] *= inv;
+                    break;
+                }
+                case FusedActivationType.Squash:
+                {
+                    double ss = 0; for (int j = 0; j < n; j++) ss += (double)c[row + j] * c[row + j];
+                    float normSq = (float)ss; float norm = (float)Math.Sqrt(ss);
+                    float k = norm > 0f ? (normSq / (1f + normSq)) / norm : 0f;
+                    for (int j = 0; j < n; j++) c[row + j] *= k;
+                    break;
+                }
+                case FusedActivationType.Sparsemax: SparsemaxF(c, row, n, scratch!); break;
+                default: throw new NotSupportedException($"RowwiseFusedActivations: {act} not handled.");
+            }
+        }
+    }
+
+    private static void SoftmaxF(Span<float> c, int row, int n, bool negate)
+    {
+        float mx = float.NegativeInfinity;
+        for (int j = 0; j < n; j++) { float v = negate ? -c[row + j] : c[row + j]; if (v > mx) mx = v; }
+        float sum = 0f;
+        for (int j = 0; j < n; j++) { float v = negate ? -c[row + j] : c[row + j]; float e = MathF.Exp(v - mx); c[row + j] = e; sum += e; }
+        float inv = 1f / sum;
+        for (int j = 0; j < n; j++) c[row + j] *= inv;
+    }
+
+    private static void LogSoftmaxF(Span<float> c, int row, int n, bool negate)
+    {
+        float mx = float.NegativeInfinity;
+        for (int j = 0; j < n; j++) { float v = negate ? -c[row + j] : c[row + j]; if (v > mx) mx = v; }
+        float sum = 0f;
+        for (int j = 0; j < n; j++) { float v = negate ? -c[row + j] : c[row + j]; sum += MathF.Exp(v - mx); }
+        float lse = mx + MathF.Log(sum); // log Σ exp(v)
+        for (int j = 0; j < n; j++) { float v = negate ? -c[row + j] : c[row + j]; c[row + j] = v - lse; }
+    }
+
+    private static void SparsemaxF(Span<float> c, int row, int n, float[] sorted)
+    {
+        for (int j = 0; j < n; j++) sorted[j] = c[row + j];
+        Array.Sort(sorted, 0, n);                 // ascending
+        // walk descending to find support size k and cumulative sum
+        float cum = 0f; int k = 1; float cumK = 0f;
+        for (int i = 0; i < n; i++)
+        {
+            float z = sorted[n - 1 - i];          // i-th largest
+            cum += z;
+            if (1f + (i + 1) * z > cum) { k = i + 1; cumK = cum; }
+        }
+        float tau = (cumK - 1f) / k;
+        for (int j = 0; j < n; j++) { float v = c[row + j] - tau; c[row + j] = v > 0f ? v : 0f; }
+    }
+
+    internal static void ApplyDouble(Span<double> c, int ldc, int m, int n, FusedActivationType act, FusedActivationParams? p)
+    {
+        double[]? scratch = act == FusedActivationType.Sparsemax ? new double[n] : null;
+        for (int i = 0; i < m; i++)
+        {
+            int row = i * ldc;
+            switch (act)
+            {
+                case FusedActivationType.PReLU:
+                {
+                    var slope = p?.PReluSlope;
+                    for (int j = 0; j < n; j++)
+                    {
+                        double s = slope == null ? 0.25 : (slope.Length == 1 ? slope[0] : slope[j]);
+                        double v = c[row + j];
+                        c[row + j] = v > 0.0 ? v : s * v;
+                    }
+                    break;
+                }
+                case FusedActivationType.Softmax: SoftmaxD(c, row, n, negate: false); break;
+                case FusedActivationType.Softmin: SoftmaxD(c, row, n, negate: true); break;
+                case FusedActivationType.GumbelSoftmax:
+                {
+                    double tau = p?.Alpha ?? 1.0;
+                    if (tau != 1.0) for (int j = 0; j < n; j++) c[row + j] /= tau;
+                    SoftmaxD(c, row, n, negate: false);
+                    break;
+                }
+                case FusedActivationType.SphericalSoftmax:
+                {
+                    double ss = 0; for (int j = 0; j < n; j++) ss += c[row + j] * c[row + j];
+                    double norm = Math.Sqrt(ss);
+                    if (norm > 0.0) for (int j = 0; j < n; j++) c[row + j] /= norm;
+                    SoftmaxD(c, row, n, negate: false);
+                    break;
+                }
+                case FusedActivationType.LogSoftmax: LogSoftmaxD(c, row, n, negate: false); break;
+                case FusedActivationType.LogSoftmin: LogSoftmaxD(c, row, n, negate: true); break;
+                case FusedActivationType.TaylorSoftmax:
+                {
+                    double sum = 0; for (int j = 0; j < n; j++) { double x = c[row + j]; double t = 1.0 + x + 0.5 * x * x; c[row + j] = t; sum += t; }
+                    double inv = 1.0 / sum;
+                    for (int j = 0; j < n; j++) c[row + j] *= inv;
+                    break;
+                }
+                case FusedActivationType.Squash:
+                {
+                    double normSq = 0; for (int j = 0; j < n; j++) normSq += c[row + j] * c[row + j];
+                    double norm = Math.Sqrt(normSq);
+                    double k = norm > 0.0 ? (normSq / (1.0 + normSq)) / norm : 0.0;
+                    for (int j = 0; j < n; j++) c[row + j] *= k;
+                    break;
+                }
+                case FusedActivationType.Sparsemax: SparsemaxD(c, row, n, scratch!); break;
+                default: throw new NotSupportedException($"RowwiseFusedActivations: {act} not handled.");
+            }
+        }
+    }
+
+    private static void SoftmaxD(Span<double> c, int row, int n, bool negate)
+    {
+        double mx = double.NegativeInfinity;
+        for (int j = 0; j < n; j++) { double v = negate ? -c[row + j] : c[row + j]; if (v > mx) mx = v; }
+        double sum = 0; for (int j = 0; j < n; j++) { double v = negate ? -c[row + j] : c[row + j]; double e = Math.Exp(v - mx); c[row + j] = e; sum += e; }
+        double inv = 1.0 / sum; for (int j = 0; j < n; j++) c[row + j] *= inv;
+    }
+
+    private static void LogSoftmaxD(Span<double> c, int row, int n, bool negate)
+    {
+        double mx = double.NegativeInfinity;
+        for (int j = 0; j < n; j++) { double v = negate ? -c[row + j] : c[row + j]; if (v > mx) mx = v; }
+        double sum = 0; for (int j = 0; j < n; j++) { double v = negate ? -c[row + j] : c[row + j]; sum += Math.Exp(v - mx); }
+        double lse = mx + Math.Log(sum);
+        for (int j = 0; j < n; j++) { double v = negate ? -c[row + j] : c[row + j]; c[row + j] = v - lse; }
+    }
+
+    private static void SparsemaxD(Span<double> c, int row, int n, double[] sorted)
+    {
+        for (int j = 0; j < n; j++) sorted[j] = c[row + j];
+        Array.Sort(sorted, 0, n);
+        double cum = 0; int k = 1; double cumK = 0;
+        for (int i = 0; i < n; i++)
+        {
+            double z = sorted[n - 1 - i];
+            cum += z;
+            if (1.0 + (i + 1) * z > cum) { k = i + 1; cumK = cum; }
+        }
+        double tau = (cumK - 1.0) / k;
+        for (int j = 0; j < n; j++) { double v = c[row + j] - tau; c[row + j] = v > 0.0 ? v : 0.0; }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/EpilogueActivationParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/EpilogueActivationParityTests.cs
@@ -1,0 +1,82 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.BlasManaged;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+/// <summary>
+/// Tensors #499: ActivationEpilogue (the BlasManaged GEMM-epilogue activation
+/// path) was brought to parity with the MlpForward/FusedLinear dispatch tables —
+/// it gained SELU, Softplus, HardSwish, HardSigmoid, HardTanh and the new ReLU6 /
+/// SoftSign kernels (it previously stopped at ELU). These tests check the fp32 and
+/// fp64 epilogue against an independent canonical formula so the two fused
+/// activation paths stay numerically consistent.
+/// </summary>
+public class EpilogueActivationParityTests
+{
+    private const double SeluAlpha = 1.6732632423543772, SeluScale = 1.0507009873554805;
+
+    private static double Reference(FusedActivationType act, double x) => act switch
+    {
+        FusedActivationType.ELU => x > 0 ? x : Math.Exp(x) - 1.0,
+        FusedActivationType.SELU => SeluScale * (x > 0 ? x : SeluAlpha * (Math.Exp(x) - 1.0)),
+        FusedActivationType.Softplus => x > 20 ? x : Math.Log(1.0 + Math.Exp(x)),
+        FusedActivationType.Mish => x * Math.Tanh(x > 20 ? x : Math.Log(1.0 + Math.Exp(x))),
+        FusedActivationType.HardSwish => x * Math.Max(0.0, Math.Min(1.0, (x + 3.0) / 6.0)),
+        FusedActivationType.HardSigmoid => Math.Max(0.0, Math.Min(1.0, (x + 3.0) / 6.0)),
+        FusedActivationType.HardTanh => Math.Max(-1.0, Math.Min(1.0, x)),
+        FusedActivationType.ReLU6 => Math.Max(0.0, Math.Min(6.0, x)),
+        FusedActivationType.SoftSign => x / (1.0 + Math.Abs(x)),
+        _ => throw new ArgumentOutOfRangeException(nameof(act)),
+    };
+
+    public static TheoryData<FusedActivationType> NewActivations => new()
+    {
+        FusedActivationType.ELU,
+        FusedActivationType.SELU,
+        FusedActivationType.Softplus,
+        FusedActivationType.Mish,
+        FusedActivationType.HardSwish,
+        FusedActivationType.HardSigmoid,
+        FusedActivationType.HardTanh,
+        FusedActivationType.ReLU6,
+        FusedActivationType.SoftSign,
+    };
+
+    [Theory]
+    [MemberData(nameof(NewActivations))]
+    public void ApplyFp32_MatchesCanonicalFormula(FusedActivationType act)
+    {
+        var rng = new Random(20260530);
+        const int n = 17; // odd length exercises the scalar tail past any SIMD block
+        var data = new float[n];
+        for (int i = 0; i < n; i++) data[i] = (float)(rng.NextDouble() * 8.0 - 4.0);
+        var expected = new double[n];
+        for (int i = 0; i < n; i++) expected[i] = Reference(act, data[i]);
+
+        ActivationEpilogue.Apply<float>(data, ldc: n, m: 1, n: n, act);
+
+        for (int i = 0; i < n; i++)
+            Assert.True(Math.Abs(expected[i] - data[i]) < 1e-4,
+                $"{act} fp32: epilogue {data[i]} != canonical {expected[i]} at {i}.");
+    }
+
+    [Theory]
+    [MemberData(nameof(NewActivations))]
+    public void ApplyFp64_MatchesCanonicalFormula(FusedActivationType act)
+    {
+        var rng = new Random(20260530);
+        const int n = 17;
+        var data = new double[n];
+        for (int i = 0; i < n; i++) data[i] = rng.NextDouble() * 8.0 - 4.0;
+        var expected = new double[n];
+        for (int i = 0; i < n; i++) expected[i] = Reference(act, data[i]);
+
+        ActivationEpilogue.Apply<double>(data, ldc: n, m: 1, n: n, act);
+
+        for (int i = 0; i < n; i++)
+            Assert.True(Math.Abs(expected[i] - data[i]) < 1e-12,
+                $"{act} fp64: epilogue {data[i]} != canonical {expected[i]} at {i}.");
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/EpilogueActivationParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/EpilogueActivationParityTests.cs
@@ -79,4 +79,61 @@ public class EpilogueActivationParityTests
             Assert.True(Math.Abs(expected[i] - data[i]) < 1e-12,
                 $"{act} fp64: epilogue {data[i]} != canonical {expected[i]} at {i}.");
     }
+
+    // ---- parametric (FusedActivationParams) -------------------------------
+
+    private static double ParamRef(FusedActivationType act, double x, FusedActivationParams p) => act switch
+    {
+        FusedActivationType.LeakyReLU => x >= 0 ? x : p.Alpha!.Value * x,
+        FusedActivationType.ELU => x > 0 ? x : p.Alpha!.Value * (Math.Exp(x) - 1.0),
+        FusedActivationType.CELU => x >= 0 ? x : p.Alpha!.Value * (Math.Exp(x / p.Alpha!.Value) - 1.0),
+        FusedActivationType.ThresholdedReLU => x > p.Theta!.Value ? x : 0.0,
+        FusedActivationType.ScaledTanh => p.Alpha!.Value * Math.Tanh(p.Beta!.Value * x),
+        _ => throw new ArgumentOutOfRangeException(nameof(act)),
+    };
+
+    public static TheoryData<FusedActivationType, FusedActivationParams> ParametricCases => new()
+    {
+        { FusedActivationType.LeakyReLU, new FusedActivationParams { Alpha = 0.2f } },
+        { FusedActivationType.ELU, new FusedActivationParams { Alpha = 2.0f } },
+        { FusedActivationType.CELU, new FusedActivationParams { Alpha = 1.5f } },
+        { FusedActivationType.ThresholdedReLU, new FusedActivationParams { Theta = 0.5f } },
+        { FusedActivationType.ScaledTanh, new FusedActivationParams { Alpha = 1.7f, Beta = 0.66f } },
+    };
+
+    [Theory]
+    [MemberData(nameof(ParametricCases))]
+    public void ApplyFp32_ParametricHonorsParams(FusedActivationType act, FusedActivationParams p)
+    {
+        var rng = new Random(20260601);
+        const int n = 17;
+        var data = new float[n];
+        for (int i = 0; i < n; i++) data[i] = (float)(rng.NextDouble() * 8.0 - 4.0);
+        var expected = new double[n];
+        for (int i = 0; i < n; i++) expected[i] = ParamRef(act, data[i], p);
+
+        ActivationEpilogue.Apply<float>(data, ldc: n, m: 1, n: n, act, p);
+
+        for (int i = 0; i < n; i++)
+            Assert.True(Math.Abs(expected[i] - data[i]) < 1e-4,
+                $"{act} fp32 params: epilogue {data[i]} != {expected[i]} at {i}.");
+    }
+
+    [Theory]
+    [MemberData(nameof(ParametricCases))]
+    public void ApplyFp64_ParametricHonorsParams(FusedActivationType act, FusedActivationParams p)
+    {
+        var rng = new Random(20260601);
+        const int n = 17;
+        var data = new double[n];
+        for (int i = 0; i < n; i++) data[i] = rng.NextDouble() * 8.0 - 4.0;
+        var expected = new double[n];
+        for (int i = 0; i < n; i++) expected[i] = ParamRef(act, data[i], p);
+
+        ActivationEpilogue.Apply<double>(data, ldc: n, m: 1, n: n, act, p);
+
+        for (int i = 0; i < n; i++)
+            Assert.True(Math.Abs(expected[i] - data[i]) < 1e-12,
+                $"{act} fp64 params: epilogue {data[i]} != {expected[i]} at {i}.");
+    }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/EpilogueActivationParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/EpilogueActivationParityTests.cs
@@ -85,6 +85,7 @@ public class EpilogueActivationParityTests
     private static double ParamRef(FusedActivationType act, double x, FusedActivationParams p) => act switch
     {
         FusedActivationType.LeakyReLU => x >= 0 ? x : p.Alpha!.Value * x,
+        FusedActivationType.RReLU => x > 0 ? x : p.Alpha!.Value * x,
         FusedActivationType.ELU => x > 0 ? x : p.Alpha!.Value * (Math.Exp(x) - 1.0),
         FusedActivationType.CELU => x >= 0 ? x : p.Alpha!.Value * (Math.Exp(x / p.Alpha!.Value) - 1.0),
         FusedActivationType.ThresholdedReLU => x > p.Theta!.Value ? x : 0.0,
@@ -95,11 +96,46 @@ public class EpilogueActivationParityTests
     public static TheoryData<FusedActivationType, FusedActivationParams> ParametricCases => new()
     {
         { FusedActivationType.LeakyReLU, new FusedActivationParams { Alpha = 0.2f } },
+        { FusedActivationType.RReLU, new FusedActivationParams { Alpha = 0.15f } },
         { FusedActivationType.ELU, new FusedActivationParams { Alpha = 2.0f } },
         { FusedActivationType.CELU, new FusedActivationParams { Alpha = 1.5f } },
         { FusedActivationType.ThresholdedReLU, new FusedActivationParams { Theta = 0.5f } },
         { FusedActivationType.ScaledTanh, new FusedActivationParams { Alpha = 1.7f, Beta = 0.66f } },
     };
+
+    /// <summary>Epilogue PReLU (per-channel slope) + Softmax/Softmin (row-wise).</summary>
+    [Fact]
+    public void ApplyFp32_PReLU_PerChannel_And_Softmax_Softmin()
+    {
+        // PReLU: 2 rows × 4 cols, distinct per-column slope.
+        var slope = new float[] { 0.1f, 0.2f, 0.3f, 0.4f };
+        var data = new float[] { -1f, 2f, -3f, 4f, 5f, -6f, 7f, -8f };
+        var expected = new float[8];
+        for (int i = 0; i < 2; i++)
+            for (int j = 0; j < 4; j++)
+            {
+                float v = data[i * 4 + j];
+                expected[i * 4 + j] = v > 0 ? v : slope[j] * v;
+            }
+        ActivationEpilogue.Apply<float>(data, ldc: 4, m: 2, n: 4, FusedActivationType.PReLU,
+            new FusedActivationParams { PReluSlope = slope });
+        for (int k = 0; k < 8; k++)
+            Assert.True(Math.Abs(expected[k] - data[k]) < 1e-5, $"PReLU mismatch at {k}: {data[k]} != {expected[k]}");
+
+        // Softmax over a single row of 4.
+        var sm = new float[] { 1f, 2f, 3f, 4f };
+        ActivationEpilogue.Apply<float>(sm, ldc: 4, m: 1, n: 4, FusedActivationType.Softmax);
+        float smSum = 0; foreach (var v in sm) smSum += v;
+        Assert.True(Math.Abs(smSum - 1f) < 1e-5, $"Softmax row sum {smSum} != 1");
+        Assert.True(sm[3] > sm[2] && sm[2] > sm[1] && sm[1] > sm[0], "Softmax should be monotonic in input");
+
+        // Softmin = softmax(-x): smallest input gets the largest weight.
+        var smin = new float[] { 1f, 2f, 3f, 4f };
+        ActivationEpilogue.Apply<float>(smin, ldc: 4, m: 1, n: 4, FusedActivationType.Softmin);
+        float sminSum = 0; foreach (var v in smin) sminSum += v;
+        Assert.True(Math.Abs(sminSum - 1f) < 1e-5, $"Softmin row sum {sminSum} != 1");
+        Assert.True(smin[0] > smin[1] && smin[1] > smin[2] && smin[2] > smin[3], "Softmin should be anti-monotonic in input");
+    }
 
     [Theory]
     [MemberData(nameof(ParametricCases))]

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/ConfigureOptimizerFusedDispatchTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/ConfigureOptimizerFusedDispatchTests.cs
@@ -127,16 +127,14 @@ public class ConfigureOptimizerFusedDispatchTests
     /// intentionally NOT wired and must be rejected at configure time, so models
     /// using them fall back to the eager tape cleanly:
     ///  • SparseAdam — sparse-gradient index lists (the plan operates on dense grads),
-    ///  • LBFGS — closure line-search (multiple loss evaluations per step),
-    ///  • ScheduleFreeSGD — needs the y = (1-β)z+βx buffer written BEFORE the forward
-    ///    pass (a pre-forward parameter transform the plan has no hook for).
-    /// (HypergradientSGD and DAdaptationSGD ARE now wired via the two-phase
-    /// global-reduction path — see the dedicated tests above.)
+    ///  • LBFGS — closure line-search (multiple loss evaluations per step).
+    /// (HypergradientSGD and DAdaptationSGD are wired via the two-phase
+    /// global-reduction path; ScheduleFreeSGD is wired via the pre-forward
+    /// parameter-transform hook — see the dedicated tests below.)
     /// </summary>
     [Theory]
     [InlineData(OptimizerType.SparseAdam)]
     [InlineData(OptimizerType.LBFGS)]
-    [InlineData(OptimizerType.ScheduleFreeSGD)]
     public void ConfigureOptimizer_UnwiredOptimizer_Throws(OptimizerType opt)
     {
         var engine = new CpuEngine();
@@ -285,10 +283,39 @@ public class ConfigureOptimizerFusedDispatchTests
         Assert.True(maxMove > 1e-3, $"D-Adaptation distance estimate did not grow (max move = {maxMove}).");
     }
 
+    /// <summary>
+    /// Schedule-Free SGD (Defazio et al. 2024) evaluates gradients at the
+    /// interpolation y = (1-β)z + βx (written into the live backing by the
+    /// plan's pre-forward hook) and returns the running-average eval copy x as
+    /// the parameter. On the convex loss Σ wᵢ² the eval weights must shrink
+    /// toward 0 (training works) AND differ from plain SGD's trajectory (the
+    /// averaging is active, not a silent SGD passthrough) while staying finite.
+    /// </summary>
+    [Fact]
+    public void ConfigureOptimizer_ScheduleFreeSGD_AveragesAndDivergesFromSGD()
+    {
+        var init = SeedFloat(16, seed: 79);
+        const int steps = 30;
+        var sf = RunGlobal(init, OptimizerType.ScheduleFreeSGD, steps, new FusedOptimizerExtras { SfBeta = 0.9f });
+        var sgd = RunGlobal(init, OptimizerType.SGD, steps, null);
+
+        double initNorm = L1Norm(init), sfNorm = L1Norm(sf), maxAbs = 0;
+        for (int i = 0; i < init.Length; i++)
+        {
+            Assert.True(!float.IsNaN(sf[i]) && !float.IsInfinity(sf[i]), "Schedule-Free produced a non-finite parameter");
+            maxAbs = Math.Max(maxAbs, Math.Abs(sf[i] - sgd[i]));
+        }
+        Assert.True(sfNorm < initNorm,
+            $"Schedule-Free eval weights did not shrink on Σwᵢ²: ‖w‖₁ {sfNorm} should be < initial {initNorm}.");
+        Assert.True(maxAbs > 1e-5,
+            $"Schedule-Free never diverged from plain SGD — the averaging/pre-forward hook appears unwired (max |Δ| = {maxAbs}).");
+    }
+
     /// <summary>Global-state optimizers are rejected with per-group schedules (configure-time).</summary>
     [Theory]
     [InlineData(OptimizerType.HypergradientSGD)]
     [InlineData(OptimizerType.DAdaptationSGD)]
+    [InlineData(OptimizerType.ScheduleFreeSGD)]
     public void ConfigureOptimizerGrouped_GlobalStateOptimizer_Throws(OptimizerType opt)
     {
         var engine = new CpuEngine();

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/ConfigureOptimizerFusedDispatchTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/ConfigureOptimizerFusedDispatchTests.cs
@@ -123,20 +123,20 @@ public class ConfigureOptimizerFusedDispatchTests
     }
 
     /// <summary>
-    /// Optimizers that need an execution model the per-parameter fused
-    /// optimizer-step loop can't provide are intentionally NOT wired and must be
-    /// rejected at configure time, so models using them fall back to the eager
-    /// tape cleanly: SparseAdam (sparse-gradient index lists), LBFGS (closure
-    /// line-search over the whole loss), HypergradientSGD / DAdaptationSGD (need
-    /// a GLOBAL cross-parameter reduction, not per-tensor), ScheduleFreeSGD
-    /// (needs a y-buffer written before the forward pass).
+    /// Optimizers that need an execution model the fused plan can't provide are
+    /// intentionally NOT wired and must be rejected at configure time, so models
+    /// using them fall back to the eager tape cleanly:
+    ///  • SparseAdam — sparse-gradient index lists (the plan operates on dense grads),
+    ///  • LBFGS — closure line-search (multiple loss evaluations per step),
+    ///  • ScheduleFreeSGD — needs the y = (1-β)z+βx buffer written BEFORE the forward
+    ///    pass (a pre-forward parameter transform the plan has no hook for).
+    /// (HypergradientSGD and DAdaptationSGD ARE now wired via the two-phase
+    /// global-reduction path — see the dedicated tests above.)
     /// </summary>
     [Theory]
     [InlineData(OptimizerType.SparseAdam)]
     [InlineData(OptimizerType.LBFGS)]
-    [InlineData(OptimizerType.HypergradientSGD)]
     [InlineData(OptimizerType.ScheduleFreeSGD)]
-    [InlineData(OptimizerType.DAdaptationSGD)]
     public void ConfigureOptimizer_UnwiredOptimizer_Throws(OptimizerType opt)
     {
         var engine = new CpuEngine();
@@ -213,5 +213,100 @@ public class ConfigureOptimizerFusedDispatchTests
         Assert.True(L1Norm(strongL1) < L1Norm(noL1),
             $"FTRL L1 extras did not increase sparsity: ||w||₁(L1=5)={L1Norm(strongL1)} should be < " +
             $"||w||₁(L1=0)={L1Norm(noL1)} — extras may not be flowing into the kernel.");
+    }
+
+    // ---- global-state optimizers (Hypergradient / D-Adaptation) -----------
+
+    private static float[] RunGlobal(float[] init, OptimizerType opt, int steps, FusedOptimizerExtras? extras)
+    {
+        var engine = new CpuEngine();
+        var weight = new Tensor<float>(new[] { init.Length });
+        for (int i = 0; i < init.Length; i++) weight[i] = init[i];
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var sq = engine.TensorMultiply(weight, weight);
+            engine.ReduceSum(sq, null);
+            plan = scope.CompileTraining(new[] { weight });
+        }
+        using (plan)
+        {
+            plan.ConfigureOptimizer(opt, Lr, B1, B2, Eps, 0f, extras);
+            for (int s = 0; s < steps; s++) plan.Step();
+        }
+        return weight.GetDataArray().AsSpan(0, init.Length).ToArray();
+    }
+
+    /// <summary>
+    /// Hypergradient SGD adapts ONE global learning rate from the inner product of
+    /// successive gradients. Step 1 (no prior gradient) equals plain SGD; over a
+    /// consistent-direction trajectory the adapted LR grows, so it must diverge from
+    /// plain SGD — proving the global reduction is wired (not per-tensor / a no-op).
+    /// </summary>
+    [Fact]
+    public void ConfigureOptimizer_HypergradientSGD_AdaptsGlobalLrAndDivergesFromSGD()
+    {
+        var init = SeedFloat(16, seed: 71);
+        const int steps = 12;
+        var hg = RunGlobal(init, OptimizerType.HypergradientSGD, steps, new FusedOptimizerExtras { HyperLr = 1e-3f });
+        var sgd = RunGlobal(init, OptimizerType.SGD, steps, null);
+
+        double maxAbs = 0;
+        for (int i = 0; i < init.Length; i++)
+        {
+            Assert.True(!float.IsNaN(hg[i]) && !float.IsInfinity(hg[i]), "Hypergradient produced a non-finite parameter");
+            maxAbs = Math.Max(maxAbs, Math.Abs(hg[i] - sgd[i]));
+        }
+        Assert.True(maxAbs > 1e-5, $"Hypergradient never diverged from SGD — global LR adaptation appears unwired (max |Δ| = {maxAbs}).");
+    }
+
+    /// <summary>
+    /// D-Adaptation maintains a single global distance estimate d that should GROW
+    /// from a small d0, so the parameters move substantially more than d0·lr·g would
+    /// in one step. Asserts finite, moves meaningfully, and (vs a tiny fixed d0 SGD-like
+    /// step) that the global d estimate has taken effect.
+    /// </summary>
+    [Fact]
+    public void ConfigureOptimizer_DAdaptationSGD_GrowsGlobalDistanceEstimate()
+    {
+        var init = SeedFloat(16, seed: 73);
+        const int steps = 20;
+        var d = RunGlobal(init, OptimizerType.DAdaptationSGD, steps, new FusedOptimizerExtras { D0 = 1e-6f });
+
+        double maxMove = 0;
+        for (int i = 0; i < init.Length; i++)
+        {
+            Assert.True(!float.IsNaN(d[i]) && !float.IsInfinity(d[i]), "D-Adaptation produced a non-finite parameter");
+            maxMove = Math.Max(maxMove, Math.Abs(d[i] - init[i]));
+        }
+        // With d frozen at d0=1e-6 the total move over 20 steps would be ~O(1e-6·lr·20·|g|) ≈ 1e-6.
+        // A meaningfully larger move proves d grew well above d0 (the adaptation is active).
+        Assert.True(maxMove > 1e-3, $"D-Adaptation distance estimate did not grow (max move = {maxMove}).");
+    }
+
+    /// <summary>Global-state optimizers are rejected with per-group schedules (configure-time).</summary>
+    [Theory]
+    [InlineData(OptimizerType.HypergradientSGD)]
+    [InlineData(OptimizerType.DAdaptationSGD)]
+    public void ConfigureOptimizerGrouped_GlobalStateOptimizer_Throws(OptimizerType opt)
+    {
+        var engine = new CpuEngine();
+        var weight = new Tensor<float>(new[] { 8 });
+        for (int i = 0; i < 8; i++) weight[i] = 0.1f * (i + 1);
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var sq = engine.TensorMultiply(weight, weight);
+            engine.ReduceSum(sq, null);
+            plan = scope.CompileTraining(new[] { weight });
+        }
+        using (plan)
+        {
+            var schedules = new System.Collections.Generic.List<LrSchedule> { LrSchedule.Constant(0.01) };
+            var map = new System.Collections.Generic.List<int> { 0 };
+            Assert.Throws<NotSupportedException>(() => plan.ConfigureOptimizerGrouped(opt, schedules, map, B1, B2, Eps));
+        }
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/FusedAdaptiveLrPlanTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/FusedAdaptiveLrPlanTests.cs
@@ -185,19 +185,16 @@ public class FusedAdaptiveLrPlanTests
 
     [Theory]
     [InlineData(OptimizerType.SparseAdam)]
-    [InlineData(OptimizerType.HypergradientSGD)]
     [InlineData(OptimizerType.ScheduleFreeSGD)]
-    [InlineData(OptimizerType.DAdaptationSGD)]
     public void ConfigureOptimizer_RejectsOptimizersPlanCantDispatch(OptimizerType opt)
     {
-        // Tensors #500: the per-parameter fused dispatch now covers the full
-        // elementwise kernel-backed set (SGD/Adam/AdamW/AMSGrad + SGDMomentum/
-        // Adagrad/RMSprop/Lion/AdaMax/Nadam/RAdam/LAMB/AdaDelta/LARS/FTRL/ASGD/
-        // Rprop). What remains rejected needs an execution model the per-param
-        // loop can't provide: SparseAdam (sparse-gradient indices),
-        // HypergradientSGD / DAdaptationSGD (GLOBAL cross-parameter reductions),
-        // ScheduleFreeSGD (y-buffer written before the forward). These must fail
-        // FAST at configure time, not surprise the caller on the first Step().
+        // Tensors #500/#499: the fused dispatch now covers the full elementwise
+        // kernel-backed set PLUS the global-state optimizers HypergradientSGD and
+        // DAdaptationSGD (via a two-phase global-reduction pass). What remains
+        // rejected needs an execution model the plan can't provide: SparseAdam
+        // (sparse-gradient indices) and ScheduleFreeSGD (a y-buffer written before
+        // the forward pass). These must fail FAST at configure time, not surprise
+        // the caller on the first Step().
         var engine = new CpuEngine();
         var w = new Tensor<float>(new float[] { 1.0f }, new[] { 1 });
         using var plan = CompileReduceSumPlan(engine, w);

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/FusedAdaptiveLrPlanTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/FusedAdaptiveLrPlanTests.cs
@@ -185,16 +185,15 @@ public class FusedAdaptiveLrPlanTests
 
     [Theory]
     [InlineData(OptimizerType.SparseAdam)]
-    [InlineData(OptimizerType.ScheduleFreeSGD)]
     public void ConfigureOptimizer_RejectsOptimizersPlanCantDispatch(OptimizerType opt)
     {
         // Tensors #500/#499: the fused dispatch now covers the full elementwise
-        // kernel-backed set PLUS the global-state optimizers HypergradientSGD and
-        // DAdaptationSGD (via a two-phase global-reduction pass). What remains
-        // rejected needs an execution model the plan can't provide: SparseAdam
-        // (sparse-gradient indices) and ScheduleFreeSGD (a y-buffer written before
-        // the forward pass). These must fail FAST at configure time, not surprise
-        // the caller on the first Step().
+        // kernel-backed set, the global-state optimizers HypergradientSGD and
+        // DAdaptationSGD (two-phase global-reduction pass), and ScheduleFreeSGD
+        // (the y-buffer is written by the plan's pre-forward parameter-transform
+        // hook). What remains rejected needs an execution model the plan still
+        // can't provide: SparseAdam (sparse-gradient indices). It must fail FAST
+        // at configure time, not surprise the caller on the first Step().
         var engine = new CpuEngine();
         var w = new Tensor<float>(new float[] { 1.0f }, new[] { 1 });
         using var plan = CompileReduceSumPlan(engine, w);

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/FusedAdaptiveLrPlanTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/FusedAdaptiveLrPlanTests.cs
@@ -192,8 +192,10 @@ public class FusedAdaptiveLrPlanTests
         // DAdaptationSGD (two-phase global-reduction pass), and ScheduleFreeSGD
         // (the y-buffer is written by the plan's pre-forward parameter-transform
         // hook). What remains rejected needs an execution model the plan still
-        // can't provide: SparseAdam (sparse-gradient indices). It must fail FAST
-        // at configure time, not surprise the caller on the first Step().
+        // can't provide: SparseAdam (sparse-gradient indices) and LBFGS (closure
+        // line-search — see ConfigureOptimizer_RejectsIneligibleOptimizer above).
+        // These must fail FAST at configure time, not surprise the caller on the
+        // first Step().
         var engine = new CpuEngine();
         var w = new Tensor<float>(new float[] { 1.0f }, new[] { 1 });
         using var plan = CompileReduceSumPlan(engine, w);

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuAutoDifferentialTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuAutoDifferentialTests.cs
@@ -208,6 +208,13 @@ public sealed class GpuCpuAutoDifferentialTests : IDisposable
             for (int i = 0; i < n; i++) data[i] = new Complex<float>((float)(rng.NextDouble() - 0.5), (float)(rng.NextDouble() - 0.5));
             return new List<object> { new Tensor<Complex<float>>(data, (int[])shape.Clone()) };
         }
+        // FusedActivationParams is the optional parametric-activation config on the
+        // FusedLinear(...,FusedActivationType,FusedActivationParams) overload. null is a
+        // valid value meaning "no extra params / use defaults", so the overload reduces
+        // to the base FusedLinear(...,FusedActivationType) kernel that is already
+        // auto-tested — driving it with null gives the params overload real GPU-vs-CPU
+        // coverage (CPU and GPU both apply the same default, so they match).
+        if (pt == typeof(FusedActivationParams)) return new List<object> { null };
         return null; // ValueTuple[], unknown ref types, etc. -> dedicated test / allowlist
     }
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/FusedHierarchicalSoftmaxTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/FusedHierarchicalSoftmaxTests.cs
@@ -1,0 +1,78 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// #499: FusedHierarchicalSoftmax — class probabilities over a balanced binary tree
+/// whose per-level gate is sigmoid(input·nodeWeights[level]). The fused op computes
+/// the treeDepth shared gate sigmoids ONCE per row then forms each class's path
+/// product; this verifies it matches the naive per-class path-probability reference
+/// (which recomputes the gate for every class, as the eager layer does).
+/// </summary>
+public class FusedHierarchicalSoftmaxTests
+{
+    private static double NaivePathProb(double[] input, double[][] nodeW, int treeDepth, int numClasses, int cls)
+    {
+        double prob = 1.0; int node = 1;
+        for (int depth = 0; depth < treeDepth; depth++)
+        {
+            double dot = 0; for (int k = 0; k < input.Length; k++) dot += input[k] * nodeW[depth][k];
+            double gate = 1.0 / (1.0 + Math.Exp(-dot));
+            bool goRight = (cls & (1 << (treeDepth - depth - 1))) != 0;
+            prob *= goRight ? gate : (1.0 - gate);
+            node = node * 2 + (goRight ? 1 : 0);
+            if (node >= numClasses) break;
+        }
+        return prob;
+    }
+
+    [Theory]
+    [InlineData(8)]   // power of two — complete tree, probabilities sum to 1
+    [InlineData(5)]   // non-power-of-two — incomplete tree (early break path)
+    [InlineData(16)]
+    public void FusedHierarchicalSoftmax_MatchesNaivePathProbability(int numClasses)
+    {
+        var engine = new CpuEngine();
+        const int rows = 4, d = 9;
+        int treeDepth = (int)Math.Ceiling(Math.Log(numClasses, 2)); // net471 has no Math.Log2
+        var rng = new Random(20260620);
+
+        var xData = new float[rows * d];
+        for (int i = 0; i < xData.Length; i++) xData[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+        var x = new Tensor<float>(xData, new[] { rows, d });
+        var wData = new float[treeDepth * d];
+        for (int i = 0; i < wData.Length; i++) wData[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+        var nodeW = new Tensor<float>(wData, new[] { treeDepth, d });
+
+        var outT = engine.FusedHierarchicalSoftmax(x, nodeW, numClasses);
+        Assert.Equal(numClasses, outT._shape[outT._shape.Length - 1]);
+        Assert.Equal(rows * numClasses, outT.Length);
+
+        var wRows = new double[treeDepth][];
+        for (int t = 0; t < treeDepth; t++)
+        {
+            wRows[t] = new double[d];
+            for (int k = 0; k < d; k++) wRows[t][k] = wData[t * d + k];
+        }
+
+        for (int r = 0; r < rows; r++)
+        {
+            var inRow = new double[d];
+            for (int k = 0; k < d; k++) inRow[k] = xData[r * d + k];
+            double rowSum = 0;
+            for (int c = 0; c < numClasses; c++)
+            {
+                double expected = NaivePathProb(inRow, wRows, treeDepth, numClasses, c);
+                double actual = Convert.ToDouble(outT[r * numClasses + c]);
+                Assert.True(Math.Abs(expected - actual) < 1e-5, $"HSoftmax[{r},{c}] {actual} != {expected}");
+                rowSum += actual;
+            }
+            // A complete (power-of-two) tree's leaf probabilities form a distribution.
+            if ((numClasses & (numClasses - 1)) == 0)
+                Assert.True(Math.Abs(rowSum - 1.0) < 1e-4, $"complete-tree row {r} should sum to 1 ({rowSum})");
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/FusedLinearMaxoutTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/FusedLinearMaxoutTests.cs
@@ -1,0 +1,60 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// #499: FusedLinearMaxout — GEMM + bias + grouped-max. Maxout (Goodfellow et al.
+/// 2013) reduces the feature dimension N to N/numPieces by taking the max over
+/// consecutive groups, so it's a shape-changing op, not an activation epilogue.
+/// </summary>
+public class FusedLinearMaxoutTests
+{
+    [Theory]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    public void FusedLinearMaxout_MatchesLinearThenGroupedMax(int numPieces)
+    {
+        var engine = new CpuEngine();
+        const int batch = 5, inF = 7;
+        int units = 6, n = units * numPieces;
+        var rng = new Random(20260610);
+
+        var wData = new float[inF * n];
+        for (int i = 0; i < wData.Length; i++) wData[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+        var w = new Tensor<float>(wData, new[] { inF, n });
+        var bData = new float[n];
+        for (int i = 0; i < n; i++) bData[i] = (float)(rng.NextDouble() - 0.5);
+        var bias = new Tensor<float>(bData, new[] { n });
+        var xData = new float[batch * inF];
+        for (int i = 0; i < xData.Length; i++) xData[i] = (float)(rng.NextDouble() * 4.0 - 2.0);
+        var x = new Tensor<float>(xData, new[] { batch, inF });
+
+        // Reference: linear (no activation) then grouped max.
+        var pre = engine.FusedLinear(x, w, bias, FusedActivationType.None); // [batch, n]
+        var actual = engine.FusedLinearMaxout(x, w, bias, numPieces);        // [batch, units]
+
+        Assert.Equal(units, actual._shape[actual._shape.Length - 1]);
+        Assert.Equal(batch * units, actual.Length);
+        for (int r = 0; r < batch; r++)
+            for (int u = 0; u < units; u++)
+            {
+                float mx = float.NegativeInfinity;
+                for (int j = 0; j < numPieces; j++) mx = Math.Max(mx, pre[r * n + u * numPieces + j]);
+                float got = actual[r * units + u];
+                Assert.True(Math.Abs(mx - got) < 1e-5, $"maxout[{r},{u}] {got} != {mx}");
+            }
+    }
+
+    [Fact]
+    public void FusedLinearMaxout_RejectsIndivisibleFeatureDim()
+    {
+        var engine = new CpuEngine();
+        var x = new Tensor<float>(new float[] { 1, 2, 3, 4 }, new[] { 1, 4 });
+        var w = new Tensor<float>(new float[12], new[] { 4, 3 }); // N=3, not divisible by 2
+        Assert.Throws<ArgumentException>(() => engine.FusedLinearMaxout(x, w, null, 2));
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/MlpForwardActivationParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/MlpForwardActivationParityTests.cs
@@ -117,6 +117,7 @@ public class MlpForwardActivationParityTests
     private static double ParamRef(FusedActivationType act, double x, FusedActivationParams p) => act switch
     {
         FusedActivationType.LeakyReLU => x > 0 ? x : p.Alpha!.Value * x,
+        FusedActivationType.RReLU => x > 0 ? x : p.Alpha!.Value * x,
         FusedActivationType.ELU => x > 0 ? x : p.Alpha!.Value * (Math.Exp(x) - 1.0),
         FusedActivationType.CELU => x >= 0 ? x : p.Alpha!.Value * (Math.Exp(x / p.Alpha!.Value) - 1.0),
         FusedActivationType.ThresholdedReLU => x > p.Theta!.Value ? x : 0.0,
@@ -127,6 +128,7 @@ public class MlpForwardActivationParityTests
     public static TheoryData<FusedActivationType, FusedActivationParams> ParametricCases => new()
     {
         { FusedActivationType.LeakyReLU, new FusedActivationParams { Alpha = 0.2f } },   // non-default slope
+        { FusedActivationType.RReLU, new FusedActivationParams { Alpha = 0.15f } },       // eval slope
         { FusedActivationType.ELU, new FusedActivationParams { Alpha = 2.0f } },          // non-default alpha
         { FusedActivationType.CELU, new FusedActivationParams { Alpha = 1.5f } },
         { FusedActivationType.ThresholdedReLU, new FusedActivationParams { Theta = 0.5f } },
@@ -165,6 +167,83 @@ public class MlpForwardActivationParityTests
             double actual = Convert.ToDouble(fused[i]);
             Assert.True(Math.Abs(expected - actual) < 1e-4,
                 $"{act} params: MlpForward {actual} != {expected} at {i} (raw={raw[i]}).");
+        }
+    }
+
+    /// <summary>PReLU applies a per-output-channel (per-column) learned slope.</summary>
+    [Fact]
+    public void MlpForward_PReLU_AppliesPerChannelSlope()
+    {
+        var engine = new CpuEngine();
+        const int batch = 4, inF = 16, outF = 8;
+        var rng = new Random(20260602);
+        var wData = new float[inF * outF];
+        for (int i = 0; i < wData.Length; i++) wData[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+        var w = new Tensor<float>(wData, new[] { inF, outF });
+        var xData = new float[batch * inF];
+        for (int i = 0; i < xData.Length; i++) xData[i] = (float)(rng.NextDouble() * 4.0 - 2.0);
+        var x = new Tensor<float>(xData, new[] { batch, inF });
+        var slope = new float[outF];
+        for (int j = 0; j < outF; j++) slope[j] = 0.05f + 0.1f * j; // distinct per channel
+
+        var weights = new System.Collections.Generic.List<Tensor<float>> { w };
+        var noBias = new System.Collections.Generic.List<Tensor<float>?> { null };
+
+        var raw = engine.MlpForward(x, weights, noBias, FusedActivationType.None, FusedActivationType.None);
+        var fused = engine.MlpForward(x, weights, noBias, FusedActivationType.None, FusedActivationType.PReLU,
+            outputActivationParams: new FusedActivationParams { PReluSlope = slope });
+
+        for (int i = 0; i < batch; i++)
+            for (int j = 0; j < outF; j++)
+            {
+                double v = Convert.ToDouble(raw[i * outF + j]);
+                double expected = v > 0 ? v : slope[j] * v;
+                double actual = Convert.ToDouble(fused[i * outF + j]);
+                Assert.True(Math.Abs(expected - actual) < 1e-4,
+                    $"PReLU col {j}: {actual} != {expected} (raw={v}).");
+            }
+    }
+
+    /// <summary>Softmax / Softmin normalize across each row (feature dim).</summary>
+    [Theory]
+    [InlineData(FusedActivationType.Softmax)]
+    [InlineData(FusedActivationType.Softmin)]
+    public void MlpForward_SoftmaxSoftmin_NormalizesEachRow(FusedActivationType act)
+    {
+        var engine = new CpuEngine();
+        const int batch = 4, inF = 16, outF = 8;
+        var rng = new Random(20260603);
+        var wData = new float[inF * outF];
+        for (int i = 0; i < wData.Length; i++) wData[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+        var w = new Tensor<float>(wData, new[] { inF, outF });
+        var xData = new float[batch * inF];
+        for (int i = 0; i < xData.Length; i++) xData[i] = (float)(rng.NextDouble() * 4.0 - 2.0);
+        var x = new Tensor<float>(xData, new[] { batch, inF });
+
+        var weights = new System.Collections.Generic.List<Tensor<float>> { w };
+        var noBias = new System.Collections.Generic.List<Tensor<float>?> { null };
+
+        var raw = engine.MlpForward(x, weights, noBias, FusedActivationType.None, FusedActivationType.None);
+        var fused = engine.MlpForward(x, weights, noBias, FusedActivationType.None, act);
+
+        bool min = act == FusedActivationType.Softmin;
+        for (int i = 0; i < batch; i++)
+        {
+            // independent reference softmax over the row
+            double mx = double.NegativeInfinity;
+            for (int j = 0; j < outF; j++) { double v = min ? -raw[i * outF + j] : raw[i * outF + j]; if (v > mx) mx = v; }
+            double sum = 0; var exp = new double[outF];
+            for (int j = 0; j < outF; j++) { double v = min ? -raw[i * outF + j] : raw[i * outF + j]; exp[j] = Math.Exp(v - mx); sum += exp[j]; }
+            double rowSum = 0;
+            for (int j = 0; j < outF; j++)
+            {
+                double expected = exp[j] / sum;
+                double actual = Convert.ToDouble(fused[i * outF + j]);
+                Assert.True(Math.Abs(expected - actual) < 1e-5,
+                    $"{act} row {i} col {j}: {actual} != {expected}.");
+                rowSum += actual;
+            }
+            Assert.True(Math.Abs(rowSum - 1.0) < 1e-4, $"{act} row {i} does not sum to 1 ({rowSum}).");
         }
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/MlpForwardActivationParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/MlpForwardActivationParityTests.cs
@@ -33,6 +33,13 @@ public class MlpForwardActivationParityTests
         FusedActivationType.HardTanh => Math.Max(-1.0, Math.Min(1.0, x)),
         FusedActivationType.ReLU6 => Math.Max(0.0, Math.Min(6.0, x)),
         FusedActivationType.SoftSign => x / (1.0 + Math.Abs(x)),
+        FusedActivationType.Sign => x < 0 ? -1.0 : (x > 0 ? 1.0 : 0.0),
+        FusedActivationType.BentIdentity => 0.5 * (Math.Sqrt(x * x + 1.0) - 1.0) + x,
+        FusedActivationType.Gaussian => Math.Exp(-x * x),
+        FusedActivationType.LiSHT => x * Math.Tanh(x),
+        FusedActivationType.ISRU => x / Math.Sqrt(1.0 + x * x),        // alpha=1 default
+        FusedActivationType.SQRBF => Math.Exp(-x * x),                  // beta=1 default
+        FusedActivationType.BinarySpiking => x >= 1.0 ? 1.0 : 0.0,      // threshold=1 default
         _ => throw new ArgumentOutOfRangeException(nameof(act)),
     };
 
@@ -46,6 +53,13 @@ public class MlpForwardActivationParityTests
     [InlineData(FusedActivationType.HardTanh)]
     [InlineData(FusedActivationType.ReLU6)]
     [InlineData(FusedActivationType.SoftSign)]
+    [InlineData(FusedActivationType.Sign)]
+    [InlineData(FusedActivationType.BentIdentity)]
+    [InlineData(FusedActivationType.Gaussian)]
+    [InlineData(FusedActivationType.LiSHT)]
+    [InlineData(FusedActivationType.ISRU)]
+    [InlineData(FusedActivationType.SQRBF)]
+    [InlineData(FusedActivationType.BinarySpiking)]
     public void MlpForward_NewActivationFloat_MatchesCanonicalFormula(FusedActivationType act)
     {
         var engine = new CpuEngine();
@@ -84,6 +98,13 @@ public class MlpForwardActivationParityTests
     [InlineData(FusedActivationType.HardTanh)]
     [InlineData(FusedActivationType.ReLU6)]
     [InlineData(FusedActivationType.SoftSign)]
+    [InlineData(FusedActivationType.Sign)]
+    [InlineData(FusedActivationType.BentIdentity)]
+    [InlineData(FusedActivationType.Gaussian)]
+    [InlineData(FusedActivationType.LiSHT)]
+    [InlineData(FusedActivationType.ISRU)]
+    [InlineData(FusedActivationType.SQRBF)]
+    [InlineData(FusedActivationType.BinarySpiking)]
     public void MlpForward_NewActivationDouble_MatchesCanonicalFormula(FusedActivationType act)
     {
         var engine = new CpuEngine();
@@ -244,6 +265,112 @@ public class MlpForwardActivationParityTests
                 rowSum += actual;
             }
             Assert.True(Math.Abs(rowSum - 1.0) < 1e-4, $"{act} row {i} does not sum to 1 ({rowSum}).");
+        }
+    }
+
+    /// <summary>Independent reference for the remaining row-wise activations.</summary>
+    private static double[] RowwiseRef(FusedActivationType act, double[] r)
+    {
+        int n = r.Length; var y = new double[n];
+        switch (act)
+        {
+            case FusedActivationType.LogSoftmax:
+            {
+                double mx = double.NegativeInfinity; foreach (var v in r) if (v > mx) mx = v;
+                double s = 0; foreach (var v in r) s += Math.Exp(v - mx);
+                double lse = mx + Math.Log(s);
+                for (int j = 0; j < n; j++) y[j] = r[j] - lse;
+                break;
+            }
+            case FusedActivationType.LogSoftmin:
+            {
+                double mx = double.NegativeInfinity; foreach (var v in r) if (-v > mx) mx = -v;
+                double s = 0; foreach (var v in r) s += Math.Exp(-v - mx);
+                double lse = mx + Math.Log(s);
+                for (int j = 0; j < n; j++) y[j] = -r[j] - lse;
+                break;
+            }
+            case FusedActivationType.SphericalSoftmax:
+            {
+                double ss = 0; foreach (var v in r) ss += v * v; double norm = Math.Sqrt(ss);
+                double s = 0; var e = new double[n];
+                for (int j = 0; j < n; j++) { e[j] = Math.Exp(r[j] / norm); s += e[j]; }
+                for (int j = 0; j < n; j++) y[j] = e[j] / s;
+                break;
+            }
+            case FusedActivationType.TaylorSoftmax:
+            {
+                double s = 0; var t = new double[n];
+                for (int j = 0; j < n; j++) { t[j] = 1 + r[j] + 0.5 * r[j] * r[j]; s += t[j]; }
+                for (int j = 0; j < n; j++) y[j] = t[j] / s;
+                break;
+            }
+            case FusedActivationType.GumbelSoftmax: // tau=1 ⇒ softmax(x)
+            {
+                double mx = double.NegativeInfinity; foreach (var v in r) if (v > mx) mx = v;
+                double s = 0; var e = new double[n];
+                for (int j = 0; j < n; j++) { e[j] = Math.Exp(r[j] - mx); s += e[j]; }
+                for (int j = 0; j < n; j++) y[j] = e[j] / s;
+                break;
+            }
+            case FusedActivationType.Squash:
+            {
+                double ss = 0; foreach (var v in r) ss += v * v; double norm = Math.Sqrt(ss);
+                double k = norm > 0 ? (ss / (1 + ss)) / norm : 0;
+                for (int j = 0; j < n; j++) y[j] = r[j] * k;
+                break;
+            }
+            case FusedActivationType.Sparsemax:
+            {
+                var z = (double[])r.Clone(); Array.Sort(z); Array.Reverse(z); // descending
+                double cum = 0; int k = 1; double cumK = 0;
+                for (int i = 0; i < n; i++) { cum += z[i]; if (1 + (i + 1) * z[i] > cum) { k = i + 1; cumK = cum; } }
+                double tau = (cumK - 1) / k;
+                for (int j = 0; j < n; j++) y[j] = Math.Max(0, r[j] - tau);
+                break;
+            }
+            default: throw new ArgumentOutOfRangeException(nameof(act));
+        }
+        return y;
+    }
+
+    [Theory]
+    [InlineData(FusedActivationType.LogSoftmax)]
+    [InlineData(FusedActivationType.LogSoftmin)]
+    [InlineData(FusedActivationType.SphericalSoftmax)]
+    [InlineData(FusedActivationType.TaylorSoftmax)]
+    [InlineData(FusedActivationType.GumbelSoftmax)]
+    [InlineData(FusedActivationType.Sparsemax)]
+    [InlineData(FusedActivationType.Squash)]
+    public void MlpForward_RowwiseActivation_MatchesReference(FusedActivationType act)
+    {
+        var engine = new CpuEngine();
+        const int batch = 4, inF = 16, outF = 8;
+        var rng = new Random(20260604);
+        var wData = new float[inF * outF];
+        for (int i = 0; i < wData.Length; i++) wData[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+        var w = new Tensor<float>(wData, new[] { inF, outF });
+        var xData = new float[batch * inF];
+        for (int i = 0; i < xData.Length; i++) xData[i] = (float)(rng.NextDouble() * 4.0 - 2.0);
+        var x = new Tensor<float>(xData, new[] { batch, inF });
+
+        var weights = new System.Collections.Generic.List<Tensor<float>> { w };
+        var noBias = new System.Collections.Generic.List<Tensor<float>?> { null };
+
+        var raw = engine.MlpForward(x, weights, noBias, FusedActivationType.None, FusedActivationType.None);
+        var fused = engine.MlpForward(x, weights, noBias, FusedActivationType.None, act);
+
+        for (int i = 0; i < batch; i++)
+        {
+            var rowRaw = new double[outF];
+            for (int j = 0; j < outF; j++) rowRaw[j] = Convert.ToDouble(raw[i * outF + j]);
+            var expected = RowwiseRef(act, rowRaw);
+            for (int j = 0; j < outF; j++)
+            {
+                double actual = Convert.ToDouble(fused[i * outF + j]);
+                Assert.True(Math.Abs(expected[j] - actual) < 1e-4,
+                    $"{act} row {i} col {j}: {actual} != {expected[j]}.");
+            }
         }
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/MlpForwardActivationParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/MlpForwardActivationParityTests.cs
@@ -31,6 +31,8 @@ public class MlpForwardActivationParityTests
         FusedActivationType.HardSwish => x * Math.Max(0.0, Math.Min(1.0, (x + 3.0) / 6.0)),
         FusedActivationType.HardSigmoid => Math.Max(0.0, Math.Min(1.0, (x + 3.0) / 6.0)),
         FusedActivationType.HardTanh => Math.Max(-1.0, Math.Min(1.0, x)),
+        FusedActivationType.ReLU6 => Math.Max(0.0, Math.Min(6.0, x)),
+        FusedActivationType.SoftSign => x / (1.0 + Math.Abs(x)),
         _ => throw new ArgumentOutOfRangeException(nameof(act)),
     };
 
@@ -42,6 +44,8 @@ public class MlpForwardActivationParityTests
     [InlineData(FusedActivationType.HardSwish)]
     [InlineData(FusedActivationType.HardSigmoid)]
     [InlineData(FusedActivationType.HardTanh)]
+    [InlineData(FusedActivationType.ReLU6)]
+    [InlineData(FusedActivationType.SoftSign)]
     public void MlpForward_NewActivationFloat_MatchesCanonicalFormula(FusedActivationType act)
     {
         var engine = new CpuEngine();
@@ -78,6 +82,8 @@ public class MlpForwardActivationParityTests
     [InlineData(FusedActivationType.HardSwish)]
     [InlineData(FusedActivationType.HardSigmoid)]
     [InlineData(FusedActivationType.HardTanh)]
+    [InlineData(FusedActivationType.ReLU6)]
+    [InlineData(FusedActivationType.SoftSign)]
     public void MlpForward_NewActivationDouble_MatchesCanonicalFormula(FusedActivationType act)
     {
         var engine = new CpuEngine();

--- a/tests/AiDotNet.Tensors.Tests/Engines/MlpForwardActivationParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/MlpForwardActivationParityTests.cs
@@ -111,4 +111,60 @@ public class MlpForwardActivationParityTests
                 $"{act}: MlpForward(double) {actual} != canonical {expected} at index {i} (raw={raw[i]}).");
         }
     }
+
+    // ---- parametric activations (FusedActivationParams) -------------------
+
+    private static double ParamRef(FusedActivationType act, double x, FusedActivationParams p) => act switch
+    {
+        FusedActivationType.LeakyReLU => x > 0 ? x : p.Alpha!.Value * x,
+        FusedActivationType.ELU => x > 0 ? x : p.Alpha!.Value * (Math.Exp(x) - 1.0),
+        FusedActivationType.CELU => x >= 0 ? x : p.Alpha!.Value * (Math.Exp(x / p.Alpha!.Value) - 1.0),
+        FusedActivationType.ThresholdedReLU => x > p.Theta!.Value ? x : 0.0,
+        FusedActivationType.ScaledTanh => p.Alpha!.Value * Math.Tanh(p.Beta!.Value * x),
+        _ => throw new ArgumentOutOfRangeException(nameof(act)),
+    };
+
+    public static TheoryData<FusedActivationType, FusedActivationParams> ParametricCases => new()
+    {
+        { FusedActivationType.LeakyReLU, new FusedActivationParams { Alpha = 0.2f } },   // non-default slope
+        { FusedActivationType.ELU, new FusedActivationParams { Alpha = 2.0f } },          // non-default alpha
+        { FusedActivationType.CELU, new FusedActivationParams { Alpha = 1.5f } },
+        { FusedActivationType.ThresholdedReLU, new FusedActivationParams { Theta = 0.5f } },
+        { FusedActivationType.ScaledTanh, new FusedActivationParams { Alpha = 1.7f, Beta = 0.66f } },
+    };
+
+    /// <summary>
+    /// Parametric activations must honor the supplied FusedActivationParams through
+    /// MlpForward — LeakyReLU(0.2)/ELU(2) use the given (non-default) parameter, and
+    /// CELU/ThresholdedReLU/ScaledTanh fuse at all (they have no hardcoded entry).
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ParametricCases))]
+    public void MlpForward_ParametricActivationFloat_HonorsParams(FusedActivationType act, FusedActivationParams p)
+    {
+        var engine = new CpuEngine();
+        const int batch = 4, inF = 16, outF = 8;
+        var rng = new Random(20260601);
+        var wData = new float[inF * outF];
+        for (int i = 0; i < wData.Length; i++) wData[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+        var w = new Tensor<float>(wData, new[] { inF, outF });
+        var xData = new float[batch * inF];
+        for (int i = 0; i < xData.Length; i++) xData[i] = (float)(rng.NextDouble() * 4.0 - 2.0);
+        var x = new Tensor<float>(xData, new[] { batch, inF });
+
+        var weights = new System.Collections.Generic.List<Tensor<float>> { w };
+        var noBias = new System.Collections.Generic.List<Tensor<float>?> { null };
+
+        var raw = engine.MlpForward(x, weights, noBias, FusedActivationType.None, FusedActivationType.None);
+        var fused = engine.MlpForward(x, weights, noBias, FusedActivationType.None, act,
+            hiddenActivationParams: null, outputActivationParams: p);
+
+        for (int i = 0; i < raw.Length; i++)
+        {
+            double expected = ParamRef(act, Convert.ToDouble(raw[i]), p);
+            double actual = Convert.ToDouble(fused[i]);
+            Assert.True(Math.Abs(expected - actual) < 1e-4,
+                $"{act} params: MlpForward {actual} != {expected} at {i} (raw={raw[i]}).");
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Closes the activation half of #499 and extends optimizer coverage beyond #501. Every `FusedActivationType` now fuses, and **every kernel-backed optimizer is wired into `CompiledTrainingPlan`** — including the three that needed more than an elementwise kernel (global-reduction + pre-forward transform).

### Activations — every `FusedActivationType` fuses (both paths, float+double)
Pointwise (ReLU…HardTanh, ReLU6, SoftSign, **Sign, BentIdentity, Gaussian, LiSHT**), parametric via `FusedActivationParams` (LeakyReLU/ELU/CELU/ThresholdedReLU/ScaledTanh/RReLU/**ISRU/SQRBF/BinarySpiking**), per-channel **PReLU**, and row-wise via the shared `RowwiseFusedActivations` (Softmax/Softmin/**LogSoftmax/LogSoftmin/SphericalSoftmax/TaylorSoftmax/GumbelSoftmax/Sparsemax/Squash**).

### Shape-changing fused ops (their own ops, not epilogues)
- **`FusedLinearMaxout`** (Goodfellow et al. 2013) — GEMM + bias + grouped-max, `[.., M, N] → [.., M, N/numPieces]`. CpuEngine + IEngine, forward/inference-only.
- **`FusedHierarchicalSoftmax`** (Morin & Bengio 2005) — class probabilities over a balanced binary tree; computes the `treeDepth` shared per-level gate sigmoids once per row then forms each leaf's root-to-leaf path product (vs the eager layer's per-class gate recomputation). Generic over `T`; virtual on CpuEngine (inherited by DirectGpuTensorEngine).

### Optimizers — all kernel-backed types wired into `CompiledTrainingPlan`
- Elementwise set (SGD/Adam/AdamW/AMSGrad/Nadam/RAdam/LAMB/RMSprop/Adagrad/Lion/SGDMomentum/AdaMax/AdaDelta/LARS/FTRL/ASGD/Rprop).
- **HypergradientSGD + DAdaptationSGD** — two-phase (global-reduce → apply) path in the float update closure (one scalar across all params). CPU-only, ungrouped.
- **ScheduleFreeSGD** (Defazio et al. 2024) — wired via a new **`_preForwardParamTransform`** hook in `Step()`: it writes `y=(1-β)z+βx` into the live parameter backing *before* the forward so gradients are evaluated at the interpolation point; the update advances z (SGD) and x (running average, `weightSum += lr²`) then restores x as the eval copy. z/x live in `m[p]`/`v[p]`, seeded from the initial weights. `SfBeta` added to `FusedOptimizerExtras`.

### Still rejected at configure time (need an execution model the plan can't provide)
- **SparseAdam** — sparse-gradient index lists (the plan operates on dense grads).
- **LBFGS** — closure line-search (multiple loss evaluations per step).

### Tests
`MlpForwardActivationParityTests`, `EpilogueActivationParityTests`, `FusedLinearMaxoutTests`, `FusedHierarchicalSoftmaxTests`, `ConfigureOptimizerFusedDispatchTests` (incl. Hypergradient/DAdaptation/**ScheduleFree**), `ConfigureOptimizerAMSGradTests`, `FusedAdaptiveLrPlanTests` — all green; FusedLinear/MlpForward regression green.

Companion to ooples/AiDotNet#1469.

🤖 Generated with [Claude Code](https://claude.com/claude-code)