### PR TITLE
perf(#477): faster LSTM recurrent step — direct-kernel routing + vectorized de-interleave (~39%)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.LstmSequence.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.LstmSequence.cs
@@ -281,14 +281,11 @@ public partial class CpuEngine
             var outSpan = output.AsWritableSpan();
 
             // #477: the recurrent GEMM h_prev @ wHh^T runs once per timestep (seqLen
-            // serial calls). The old transB=true Sgemm re-transposed + re-packed the
-            // constant wHh on EVERY step — per-GEMM dispatch over the sequence was the
-            // measured bottleneck (thread-insensitive ~5.9 ms). Pre-transpose wHh
-            // [gateRows, hidden] → wHhT [hidden, gateRows] ONCE, then drive the per-step
-            // GEMM through SgemmWithCachedB: it keys the pre-packed B on the array
-            // identity, so wHhT is packed once (step 0) and reused for every later step.
-            // A fresh array (not pooled) guarantees a unique identity per call, so the
-            // pack cache can never serve stale bytes from a recycled buffer.
+            // serial calls). The old transB=true Sgemm re-transposed wHh on EVERY step.
+            // Pre-transpose wHh [gateRows, hidden] → wHhT [hidden, gateRows] ONCE, then
+            // pass wHhT as the no-transpose B operand to the per-step direct GEMM below
+            // ([hidden, gateRows] is exactly the [K, N] row-major layout SgemmSequential
+            // expects, so the per-step call needs no further transpose or packing setup).
             var wHhT = new float[hidden * gateRows];
             for (int g = 0; g < gateRows; g++)
                 for (int hh2 = 0; hh2 < hidden; hh2++)
@@ -298,13 +295,16 @@ public partial class CpuEngine
             for (int t = 0; t < seqLen; t++)
             {
                 // hh = h_prev @ wHh^T = h_prev @ wHhT, [B, hidden] @ [hidden, gateRows].
-                // No-transpose A·B with the pre-packed (cached) wHhT — pack happens once
-                // on the first step, every later step reuses it. See the wHhT note above.
-                // Kept SERIAL on purpose: parallelizing this tiny per-step GEMM across the
-                // batch loses badly (32 parallel-for dispatches over the sequence dominate
-                // the ~2M-FMA chunks — measured 4× slower), matching the issue's
-                // thread-insensitive finding.
-                SimdGemm.SgemmWithCachedB(
+                // #477: route through SgemmSequential (the DIRECT 6×16 AVX2 kernel), NOT
+                // SgemmWithCachedB. A min-of-2000 microbench at this exact shape
+                // [M=128, K=64, N=256] showed the cached-pre-packed path runs ~82 GF/s
+                // while the direct kernel runs ~103 GF/s (+24%): for this small K the
+                // cached-B tiling machinery costs more than the direct kernel's lighter
+                // per-call packing, so the "avoid re-packing" optimization was a net loss
+                // here. Kept SERIAL: parallelizing this tiny per-step GEMM across the batch
+                // loses to dispatch overhead over the 32-step sequence (the issue's
+                // thread-insensitive finding).
+                SimdGemm.SgemmSequential(
                     hPrevBuf.AsSpan(0, batch * hidden),
                     wHhT,
                     hhBuf.AsSpan(0, batch * gateRows),

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.LstmSequence.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.LstmSequence.cs
@@ -318,19 +318,36 @@ public partial class CpuEngine
                 // cell update into a flat contiguous pass. #477: the per-call activation
                 // overhead over the 32-step sequence was ~half the kernel wall-clock.
                 int bh = batch * hidden;
-                for (int b = 0; b < batch; b++)
+                // #477: vectorize the gate combine + de-interleave. Each (b, gType) block
+                // is a CONTIGUOUS add of two [hidden]-length runs (Wx slice + hh slice,
+                // plus optional bHh) into a contiguous destination. Using raw pointers
+                // drops the per-element bounds checks and the per-element bias branch
+                // (hoisted out of the inner loop), so the inner add auto-vectorizes to
+                // SIMD — the scalar version was a measured chunk of the per-step overhead.
+                fixed (float* wxP = wxBuf)
+                fixed (float* hhP = hhBuf)
+                fixed (float* gateP = gateBuf)
+                fixed (float* bHhP = bHhSpan)
                 {
-                    int wxRowOff = (b * seqLen + t) * gateRows;
-                    int hhOff = b * gateRows;
-                    for (int gType = 0; gType < 4; gType++)
+                    for (int b = 0; b < batch; b++)
                     {
-                        int srcG = gType * hidden;
-                        int dst = gType * bh + b * hidden;
-                        for (int h = 0; h < hidden; h++)
+                        int wxRowOff = (b * seqLen + t) * gateRows;
+                        int hhOff = b * gateRows;
+                        for (int gType = 0; gType < 4; gType++)
                         {
-                            float v = wxBuf[wxRowOff + srcG + h] + hhBuf[hhOff + srcG + h];
-                            if (hasBhh) v += bHhSpan[srcG + h];
-                            gateBuf[dst + h] = v;
+                            int srcG = gType * hidden;
+                            float* wx = wxP + wxRowOff + srcG;
+                            float* hh = hhP + hhOff + srcG;
+                            float* dst = gateP + gType * bh + b * hidden;
+                            if (hasBhh)
+                            {
+                                float* bb = bHhP + srcG;
+                                for (int h = 0; h < hidden; h++) dst[h] = wx[h] + hh[h] + bb[h];
+                            }
+                            else
+                            {
+                                for (int h = 0; h < hidden; h++) dst[h] = wx[h] + hh[h];
+                            }
                         }
                     }
                 }
@@ -338,10 +355,12 @@ public partial class CpuEngine
                 // Activate each gate-type block in a single vectorized call.
                 fixed (float* gateP = gateBuf)
                 {
-                    SimdKernels.SigmoidUnsafe(gateP + 0 * bh, gateP + 0 * bh, bh);  // i
-                    SimdKernels.SigmoidUnsafe(gateP + 1 * bh, gateP + 1 * bh, bh);  // f
-                    SimdKernels.TanhUnsafe(gateP + 2 * bh, gateP + 2 * bh, bh);     // g
-                    SimdKernels.SigmoidUnsafe(gateP + 3 * bh, gateP + 3 * bh, bh);  // o
+                    // i and f are both sigmoid and ADJACENT in the de-interleaved layout
+                    // (blocks 0 and 1), so activate them in ONE call over 2*bh — one fewer
+                    // kernel dispatch per step than activating each gate block separately.
+                    SimdKernels.SigmoidUnsafe(gateP + 0 * bh, gateP + 0 * bh, 2 * bh); // i + f
+                    SimdKernels.TanhUnsafe(gateP + 2 * bh, gateP + 2 * bh, bh);        // g
+                    SimdKernels.SigmoidUnsafe(gateP + 3 * bh, gateP + 3 * bh, bh);     // o
                 }
 
                 // Cell + hidden update over the flat [batch*hidden] blocks:

--- a/tests/AiDotNet.Tensors.Tests/Engines/LstmSequencePerfBench.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/LstmSequencePerfBench.cs
@@ -1,0 +1,55 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// #477 perf measurement for LstmSequenceForward at the AIsEval workload
+// ([128,32,32]->64, last-step output). Reports median / p95 wall-clock so the
+// fused-recurrent-kernel work can be measured against the torch ~2.78ms target
+// without needing TorchSharp in the harness. Category=Performance => excluded
+// from the normal/CI run.
+
+using System;
+using System.Diagnostics;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+[Trait("Category", "Performance")]
+public class LstmSequencePerfBench
+{
+    private readonly ITestOutputHelper _out;
+    public LstmSequencePerfBench(ITestOutputHelper output) => _out = output;
+
+    [Fact]
+    public void LstmSequenceForward_AisEvalWorkload_Timing()
+    {
+        const int batch = 128, seq = 32, inF = 32, hidden = 64;
+        const int warmup = 50, measured = 200;
+
+        var engine = new CpuEngine();
+        var input = Tensor<float>.CreateRandom(batch, seq, inF);
+        var wIh = Tensor<float>.CreateRandom(4 * hidden, inF);
+        var wHh = Tensor<float>.CreateRandom(4 * hidden, hidden);
+
+        for (int i = 0; i < warmup; i++)
+            engine.LstmSequenceForward(input, null, null, wIh, wHh, null, null);
+
+        var times = new double[measured];
+        for (int i = 0; i < measured; i++)
+        {
+            var sw = Stopwatch.StartNew();
+            engine.LstmSequenceForward(input, null, null, wIh, wHh, null, null);
+            sw.Stop();
+            times[i] = sw.Elapsed.TotalMilliseconds;
+        }
+
+        Array.Sort(times);
+        double median = times[measured / 2];
+        double p95 = times[(int)(measured * 0.95)];
+        double min = times[0];
+        _out.WriteLine($"LSTM [128,32,32]->64 last-step, {measured} runs:");
+        _out.WriteLine($"  min={min:F3} ms  median={median:F3} ms  p95={p95:F3} ms   (torch target ~2.78 ms)");
+
+        Assert.True(median > 0);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Simd/LstmGemmShapeMicroBench.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Simd/LstmGemmShapeMicroBench.cs
@@ -1,0 +1,61 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// #477: isolate the LSTM recurrent GEMM shape [M=128, K=64, N=256] and compare the
+// SimdGemm dispatch paths head-to-head, reporting MIN-of-many GF/s (the noise-robust
+// best-case estimator) so a routing/kernel win is measurable on a busy machine.
+// Category=Performance => excluded from the normal/CI run.
+
+using System;
+using System.Diagnostics;
+using AiDotNet.Tensors.Engines.Simd;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNet.Tensors.Tests.Engines.Simd;
+
+[Trait("Category", "Performance")]
+public class LstmGemmShapeMicroBench
+{
+    private readonly ITestOutputHelper _out;
+    public LstmGemmShapeMicroBench(ITestOutputHelper output) => _out = output;
+
+    [Fact]
+    public void RecurrentGemmShape_PathComparison_MinGflops()
+    {
+        const int m = 128, k = 64, n = 256;
+        const int warmup = 200, measured = 2000;
+        double flops = 2.0 * m * k * n;
+
+        var rng = new Random(12345);
+        var a = new float[m * k];
+        var b = new float[k * n];
+        for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+        for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+        var c = new float[m * n];
+
+        double MinMs(Action call)
+        {
+            for (int i = 0; i < warmup; i++) call();
+            double min = double.MaxValue;
+            for (int i = 0; i < measured; i++)
+            {
+                var sw = Stopwatch.StartNew();
+                call();
+                sw.Stop();
+                double ms = sw.Elapsed.TotalMilliseconds;
+                if (ms < min) min = ms;
+            }
+            return min;
+        }
+
+        double cachedB = MinMs(() => SimdGemm.SgemmWithCachedB(a, b, c, m, k, n));
+        double seq = MinMs(() => SimdGemm.SgemmSequential(a, b, c, m, k, n));
+        double gen = MinMs(() => SimdGemm.Sgemm(a, b, c, m, k, n));
+
+        _out.WriteLine($"LSTM recurrent GEMM [M={m}, K={k}, N={n}] — min over {measured} runs:");
+        _out.WriteLine($"  SgemmWithCachedB (current) : {cachedB * 1000:F2} us   {flops / (cachedB * 1e-3) / 1e9:F1} GF/s");
+        _out.WriteLine($"  SgemmSequential  (direct)  : {seq * 1000:F2} us   {flops / (seq * 1e-3) / 1e9:F1} GF/s");
+        _out.WriteLine($"  Sgemm            (general) : {gen * 1000:F2} us   {flops / (gen * 1e-3) / 1e9:F1} GF/s");
+
+        Assert.True(cachedB > 0 && seq > 0 && gen > 0);
+    }
+}


### PR DESCRIPTION
## Summary

Speeds up the **float** `LstmSequenceForward` recurrent step (issue #477) at the AIsEval workload `[128,32,32]→64`. Two independent, measured wins — the headline one came from profiling the GEMM dispatch, not hand-writing a kernel.

### 1. Route the recurrent GEMM to the direct kernel (the big win)
A min-of-2000 microbench at the exact recurrent shape `[M=128, K=64, N=256]` (`LstmGemmShapeMicroBench`) shows the cached-pre-packed path the step had been using is **not** the fastest for this small K:

| path | min | GF/s |
|---|---|---|
| `SgemmWithCachedB` (was) | 50.7 µs | 82.7 |
| **`SgemmSequential` (now)** | **40.8 µs** | **102.8** (+24%) |
| `Sgemm` (general shim) | 407 µs | 10.3 |

For small K the cached-B tiling machinery costs more than the direct 6×16 AVX2 kernel's lighter per-call packing — so "avoid re-packing" was a net loss here. The transposed `wHhT` is already the `[K, N]` row-major B the direct kernel wants, so it's a one-line routing change.

### 2. Vectorize the gate combine + de-interleave, merge i/f activation
Raw-pointer contiguous SIMD add (bounds-check-free, bias branch hoisted) for the de-interleave, and one `SigmoidUnsafe` over `2*bh` for the adjacent `i`/`f` blocks instead of two.

### Measured (Ryzen 9 3950X, `[128,32,32]→64`, min-of-many — the noise-robust estimator)

| metric | baseline | now |
|---|---|---|
| min | 5.39 ms | **~3.3 ms (~39%)** |
| median | 7.49 ms | ~3.8 ms |

Now within ~18% of torch's ~2.78 ms (MKL fused-LSTM on AVX-512-class tuning). Correctness unchanged: `LstmSequenceForwardTests` 7/7, ONNX `RecurrentOpTests` 2/2; net10 + net471 build clean.

### What was tried and rejected (recorded so it isn't re-attempted)
A full hand-rolled **fused recurrent microkernel** (register-blocked, MR=8, packed weights for sequential B access) was implemented and benchmarked fairly (same-session min A/B): it is **~10–15% slower** than the direct kernel. Fusion interleaves the GEMM FMA stream with the Wx-load/de-interleave-store and breaks the tight FMA pipeline; two clean specialized passes (direct GEMM + vectorized de-interleave) win. The recurrent GEMM was already on a good kernel — it was just dispatched to the wrong variant for its shape. The remaining gap to torch is GEMM-kernel utilization for small K, a `SimdGemm`-level follow-up; #477 stays open for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
