### PR TITLE
feat: add Noam shape to fused LrSchedule (enables AiDotNet#1470 real fix)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/LrSchedule.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/LrSchedule.cs
@@ -77,6 +77,24 @@ public abstract class LrSchedule
     public static LrSchedule LinearWarmupCosine(
         double lrMax, int warmupSteps, int totalSteps, double lrMin = 0.0)
         => new LinearWarmupCosineLr(lrMax, warmupSteps, totalSteps, lrMin);
+
+    /// <summary>
+    /// Noam schedule from "Attention Is All You Need" (Vaswani et al. 2017,
+    /// §5.3): linear warmup then inverse-square-root decay —
+    /// <c>lr(t) = factor · d_model^(-0.5) · min(t^(-0.5), t · warmup^(-1.5))</c>,
+    /// peaking at <c>t = warmupSteps</c>. <c>t</c> is the 1-indexed optimizer
+    /// step (the same 1-based counter <see cref="GetLr"/> receives), so the
+    /// fused-path LR sequence is bit-identical to the eager
+    /// <c>AiDotNet.LearningRateSchedulers.NoamSchedule</c>: both yield
+    /// <c>lr(t=N)</c> on batch N. This lets the default Transformer recipe
+    /// (Adam β₂=0.98 + Noam) run on the fused-compiled training path with a
+    /// correct per-step ramp instead of falling back to the eager tape.
+    /// </summary>
+    /// <param name="modelDimension">Transformer model dimension (d_model); must be &gt; 0.</param>
+    /// <param name="warmupSteps">Linear-warmup step count; must be &gt; 0.</param>
+    /// <param name="factor">Multiplicative scale on the schedule (default 1.0, paper-faithful); must be &gt; 0.</param>
+    public static LrSchedule Noam(int modelDimension, int warmupSteps, double factor = 1.0)
+        => new NoamLr(modelDimension, warmupSteps, factor);
 }
 
 internal sealed class ConstantLr : LrSchedule
@@ -85,6 +103,44 @@ internal sealed class ConstantLr : LrSchedule
     public ConstantLr(double lr) { _lr = lr; }
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public override double GetLr(int step) => _lr;
+}
+
+internal sealed class NoamLr : LrSchedule
+{
+    // Pre-computed step-invariant coefficients so GetLr is one Math.Sqrt + a
+    // couple of multiplies per step (no Math.Pow), matching the eager
+    // NoamSchedule's hot-path optimization:
+    //   _scaledModelInvSqrt = factor · d_model^(-0.5)
+    //   _scaledWarmupTerm   = _scaledModelInvSqrt · warmup^(-1.5)   (coeff on the linear branch)
+    private readonly double _scaledModelInvSqrt;
+    private readonly double _scaledWarmupTerm;
+
+    public NoamLr(int modelDimension, int warmupSteps, double factor)
+    {
+        if (modelDimension <= 0)
+            throw new ArgumentOutOfRangeException(nameof(modelDimension), "modelDimension must be positive.");
+        if (warmupSteps <= 0)
+            throw new ArgumentOutOfRangeException(nameof(warmupSteps), "warmupSteps must be positive.");
+        if (factor <= 0)
+            throw new ArgumentOutOfRangeException(nameof(factor), "factor must be positive.");
+
+        _scaledModelInvSqrt = factor / System.Math.Sqrt(modelDimension);
+        _scaledWarmupTerm = _scaledModelInvSqrt / ((double)warmupSteps * System.Math.Sqrt(warmupSteps));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public override double GetLr(int step)
+    {
+        // step is 1-indexed (CompiledTrainingPlan increments _optimizerStep to 1
+        // before the first GetLr call), and the paper's t is also 1-based, so
+        // t = step directly — no +1 remap (unlike the eager NoamSchedule, which
+        // remaps from a 0-based framework counter). The clamp guards a non-
+        // positive t that would make t^(-0.5) blow up.
+        int t = step < 1 ? 1 : step;
+        double invSqrtBranch = _scaledModelInvSqrt / System.Math.Sqrt(t);
+        double warmupBranch = _scaledWarmupTerm * t;
+        return System.Math.Min(invSqrtBranch, warmupBranch);
+    }
 }
 
 internal sealed class CosineLr : LrSchedule

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/LrScheduleTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/LrScheduleTests.cs
@@ -160,4 +160,74 @@ public class LrScheduleTests
         Assert.Throws<System.ArgumentOutOfRangeException>(() => LrSchedule.OneCycle(1.0, 100, pctStart: 0.0));
         Assert.Throws<System.ArgumentOutOfRangeException>(() => LrSchedule.OneCycle(1.0, 100, pctStart: 1.0));
     }
+
+    // Noam schedule (Vaswani 2017 §5.3): lr(t) = factor·d^(-0.5)·min(t^(-0.5), t·warmup^(-1.5)).
+    // This is the schedule that lets the default Transformer (Adam β₂=0.98 + Noam)
+    // run on the fused-compiled training path with a correct per-step ramp
+    // instead of falling back to the eager tape (AiDotNet#1470).
+
+    private static double NoamRef(int d, int warmup, double factor, int t)
+        => factor * System.Math.Pow(d, -0.5)
+                  * System.Math.Min(System.Math.Pow(t, -0.5), t * System.Math.Pow(warmup, -1.5));
+
+    [Fact]
+    public void Noam_MatchesPaperFormula_AcrossWarmupAndDecay()
+    {
+        const int d = 512, warmup = 4000;
+        var s = LrSchedule.Noam(modelDimension: d, warmupSteps: warmup);
+        foreach (int t in new[] { 1, 100, 2000, 3999, 4000, 4001, 8000, 50000 })
+            Assert.Equal(NoamRef(d, warmup, 1.0, t), s.GetLr(t), Tol);
+    }
+
+    [Fact]
+    public void Noam_RampsUpDuringWarmup_PeaksAtWarmup_ThenDecays()
+    {
+        const int d = 256, warmup = 100;
+        var s = LrSchedule.Noam(modelDimension: d, warmupSteps: warmup);
+
+        // Strictly increasing up to the warmup peak.
+        for (int t = 1; t < warmup; t++)
+            Assert.True(s.GetLr(t) < s.GetLr(t + 1),
+                $"Noam must ramp up during warmup: GetLr({t}) < GetLr({t + 1})");
+
+        // Peak at exactly t = warmup, value = factor·d^(-0.5)·warmup^(-0.5).
+        double peak = s.GetLr(warmup);
+        Assert.Equal(System.Math.Pow(d, -0.5) * System.Math.Pow(warmup, -0.5), peak, Tol);
+
+        // Strictly decreasing after the peak.
+        Assert.True(s.GetLr(warmup + 1) < peak);
+        Assert.True(s.GetLr(2 * warmup) < s.GetLr(warmup + 1));
+
+        // The frozen-at-warmup-step-1 symptom (#1470) would make GetLr(warmup)
+        // ≈ GetLr(1); assert a real ramp of many ×.
+        Assert.True(peak > s.GetLr(1) * 10,
+            "Noam peak must be far above the warmup-step-1 value (the #1470 freeze symptom).");
+    }
+
+    [Fact]
+    public void Noam_FactorScalesLinearly()
+    {
+        const int d = 128, warmup = 50;
+        var s1 = LrSchedule.Noam(d, warmup, factor: 1.0);
+        var s3 = LrSchedule.Noam(d, warmup, factor: 3.0);
+        foreach (int t in new[] { 1, 25, 50, 200 })
+            Assert.Equal(3.0 * s1.GetLr(t), s3.GetLr(t), Tol);
+    }
+
+    [Fact]
+    public void Noam_ClampsNonPositiveStepToWarmupStart()
+    {
+        var s = LrSchedule.Noam(modelDimension: 64, warmupSteps: 10);
+        // step < 1 clamps to t = 1 (no 0^(-0.5) blowup).
+        Assert.Equal(s.GetLr(1), s.GetLr(0), Tol);
+        Assert.Equal(s.GetLr(1), s.GetLr(-5), Tol);
+    }
+
+    [Fact]
+    public void Noam_RejectsBadArgs()
+    {
+        Assert.Throws<System.ArgumentOutOfRangeException>(() => LrSchedule.Noam(modelDimension: 0, warmupSteps: 10));
+        Assert.Throws<System.ArgumentOutOfRangeException>(() => LrSchedule.Noam(modelDimension: 64, warmupSteps: 0));
+        Assert.Throws<System.ArgumentOutOfRangeException>(() => LrSchedule.Noam(modelDimension: 64, warmupSteps: 10, factor: 0.0));
+    }
 }


### PR DESCRIPTION
## Summary

Adds a **Noam** (linear-warmup + inverse-sqrt) shape to the fused-training `LrSchedule`, so the default Transformer recipe (Adam β₂=0.98 + Noam) can run on the **fused-compiled training path with a correct per-step LR ramp** — instead of being forced onto the slower eager tape.

This is the Tensors half of the real fix for **AiDotNet #1470** (a from-scratch Transformer trained via the per-call minibatch pattern stalled because the Noam LR stayed frozen at its warmup-step-1 value). The prior AiDotNet-side mitigation made Adam+Noam fall back to eager — correct but slow. The proper solution, matching PyTorch's `fused=True` optimizers (which take `lr` as a per-step scalar while the schedule runs outside the kernel), is to let the fused kernel evaluate the Noam schedule per step.

## Why this is the right layer

The fused training plan **already** evaluates `LrSchedule.GetLr(step)` every optimizer step:

```csharp
// CompiledTrainingPlan.cs
_optimizerStep++;
float lr = (float)lrSchedule.GetLr(_optimizerStep);
```

So every schedule shape gets true per-step adaptive LR on the fast path. Cosine / Exponential / OneCycle / LinearWarmupCosine were already supported — **Noam was simply the missing shape**, which is why Transformers fell back to eager. Adding it is a pure, isolated extension of the existing mechanism (no kernel/dispatch changes).

## Correctness — bit-identical to the eager schedule

`NoamLr.GetLr(step) = factor · d_model^(-0.5) · min(t^(-0.5), t · warmup^(-1.5))`, `t = step` (1-based).

The plan's `_optimizerStep` is already 1-based on the first call, and the paper's `t` is 1-based, so the fused sequence matches the eager `AiDotNet.LearningRateSchedulers.NoamSchedule` exactly — both yield `lr(t=N)` on batch N, no off-by-one between the two training paths. Coefficients are precomputed (one `Math.Sqrt` + a couple of multiplies per step, no `Math.Pow`), matching the eager schedule's hot-path shape.

## Tests (5, all passing)

`LrScheduleTests`: paper-formula match across warmup+decay; ramp-up → peak-at-warmup → decay monotonicity; linear `factor` scaling; non-positive-step clamp (no `0^(-0.5)` blow-up); argument validation.

## Follow-up (AiDotNet side)

After this releases, AiDotNet's `GradientBasedOptimizerBase.TryGetFusedLrSchedule` maps `NoamSchedule → LrSchedule.Noam(d, warmup, factor)` (replacing the eager-fallback workaround), and the #1470 regression guard flips to assert Adam+Noam now **engages** the fused path. Tracked on the AiDotNet `perf/fused-training-gate` branch / PR #1469.

🤖 Generated with [Claude Code](https://claude.com/claude-code)