### PR TITLE
feat(#499): fused-activation backward handlers for all remaining activations

### DIFF
--- a/src/AiDotNet.Tensors/Engines/ActivationHandler.cs
+++ b/src/AiDotNet.Tensors/Engines/ActivationHandler.cs
@@ -32,6 +32,28 @@ internal abstract class ActivationHandler
     /// from the pre-activation input, or override to accept it via other means.
     /// </summary>
     public abstract Tensor<T> ApplyBackward<T>(CpuEngine engine, Tensor<T> gradOutput, Tensor<T> input);
+
+    // #506 review: parametric-activation overloads. Most activations are
+    // non-parametric and ignore FusedActivationParams (the default bodies below
+    // forward to the no-param versions); the parametric handlers (ELU / CELU /
+    // ThresholdedReLU / ScaledTanh / RReLU / ISRU / SQRBF via PointwiseFused, and
+    // PReLU) override these so the fused forward AND backward honor a caller-supplied
+    // slope/alpha/theta instead of the canonical default.
+
+    /// <summary>Apply with explicit parametric settings. Default ignores them.</summary>
+    public virtual Tensor<T> Apply<T>(CpuEngine engine, Tensor<T> input, FusedActivationParams? activationParams)
+        => Apply(engine, input);
+
+    /// <summary>Apply in-place with explicit parametric settings. Default ignores them.</summary>
+    public virtual void ApplyInPlace<T>(CpuEngine engine, Tensor<T> input, FusedActivationParams? activationParams)
+    {
+        var result = Apply(engine, input, activationParams);
+        result.AsSpan().CopyTo(input.AsWritableSpan());
+    }
+
+    /// <summary>Backward with explicit parametric settings. Default ignores them.</summary>
+    public virtual Tensor<T> ApplyBackward<T>(CpuEngine engine, Tensor<T> gradOutput, Tensor<T> input, FusedActivationParams? activationParams)
+        => ApplyBackward(engine, gradOutput, input);
 }
 
 /// <summary>
@@ -191,10 +213,19 @@ internal sealed class TanhActivationHandler : ActivationHandler
 
 internal sealed class LeakyReLUActivationHandler : ActivationHandler
 {
-    public override Tensor<T> Apply<T>(CpuEngine engine, Tensor<T> input)
-        => engine.LeakyReLU(input, Helpers.MathHelper.GetNumericOperations<T>().FromDouble(0.01));
+    private const double DefaultSlope = 0.01;
+    // #506 review: honor a caller-supplied negative slope (FusedActivationParams.Alpha)
+    // in both forward and backward; default to the canonical 0.01.
+    private static double SlopeOf(FusedActivationParams? p) => p?.Alpha ?? DefaultSlope;
+
+    public override Tensor<T> Apply<T>(CpuEngine engine, Tensor<T> input) => Apply(engine, input, null);
+    public override Tensor<T> Apply<T>(CpuEngine engine, Tensor<T> input, FusedActivationParams? activationParams)
+        => engine.LeakyReLU(input, Helpers.MathHelper.GetNumericOperations<T>().FromDouble(SlopeOf(activationParams)));
+
     public override Tensor<T> ApplyBackward<T>(CpuEngine engine, Tensor<T> gradOutput, Tensor<T> input)
-        => engine.LeakyReluBackward(gradOutput, input, 0.01);
+        => ApplyBackward(engine, gradOutput, input, null);
+    public override Tensor<T> ApplyBackward<T>(CpuEngine engine, Tensor<T> gradOutput, Tensor<T> input, FusedActivationParams? activationParams)
+        => engine.LeakyReluBackward(gradOutput, input, SlopeOf(activationParams));
 }
 
 internal sealed class SwishActivationHandler : ActivationHandler
@@ -227,20 +258,24 @@ internal sealed class PointwiseFusedActivationHandler : ActivationHandler
     private readonly FusedActivationType _type;
     public PointwiseFusedActivationHandler(FusedActivationType type) => _type = type;
 
-    public override Tensor<T> Apply<T>(CpuEngine engine, Tensor<T> input)
+    public override Tensor<T> Apply<T>(CpuEngine engine, Tensor<T> input) => ApplyImpl<T>(input, null);
+    public override Tensor<T> Apply<T>(CpuEngine engine, Tensor<T> input, FusedActivationParams? activationParams)
+        => ApplyImpl<T>(input, activationParams);
+
+    private Tensor<T> ApplyImpl<T>(Tensor<T> input, FusedActivationParams? p)
     {
         var result = new Tensor<T>(input._shape);
         int n = input.Length;
         if (typeof(T) == typeof(float))
         {
-            var f = Helpers.CpuFusedOperations.GetFloatActivation(_type);
+            var f = Helpers.CpuFusedOperations.GetFloatActivation(_type, p);
             var xi = (float[])(object)input.GetDataArray();
             var ro = (float[])(object)result.GetDataArray();
             for (int i = 0; i < n; i++) ro[i] = f(xi[i]);
         }
         else if (typeof(T) == typeof(double))
         {
-            var f = Helpers.CpuFusedOperations.GetDoubleActivation(_type);
+            var f = Helpers.CpuFusedOperations.GetDoubleActivation(_type, p);
             var xi = (double[])(object)input.GetDataArray();
             var ro = (double[])(object)result.GetDataArray();
             for (int i = 0; i < n; i++) ro[i] = f(xi[i]);
@@ -250,12 +285,17 @@ internal sealed class PointwiseFusedActivationHandler : ActivationHandler
     }
 
     public override Tensor<T> ApplyBackward<T>(CpuEngine engine, Tensor<T> gradOutput, Tensor<T> input)
+        => BackwardImpl<T>(gradOutput, input, null);
+    public override Tensor<T> ApplyBackward<T>(CpuEngine engine, Tensor<T> gradOutput, Tensor<T> input, FusedActivationParams? activationParams)
+        => BackwardImpl<T>(gradOutput, input, activationParams);
+
+    private Tensor<T> BackwardImpl<T>(Tensor<T> gradOutput, Tensor<T> input, FusedActivationParams? p)
     {
         var result = new Tensor<T>(input._shape);
         int n = input.Length;
         if (typeof(T) == typeof(float))
         {
-            var d = Helpers.CpuFusedOperations.GetFloatActivationDerivative(_type);
+            var d = Helpers.CpuFusedOperations.GetFloatActivationDerivative(_type, p);
             var xi = (float[])(object)input.GetDataArray();
             var gi = (float[])(object)gradOutput.GetDataArray();
             var ro = (float[])(object)result.GetDataArray();
@@ -263,7 +303,7 @@ internal sealed class PointwiseFusedActivationHandler : ActivationHandler
         }
         else if (typeof(T) == typeof(double))
         {
-            var d = Helpers.CpuFusedOperations.GetDoubleActivationDerivative(_type);
+            var d = Helpers.CpuFusedOperations.GetDoubleActivationDerivative(_type, p);
             var xi = (double[])(object)input.GetDataArray();
             var gi = (double[])(object)gradOutput.GetDataArray();
             var ro = (double[])(object)result.GetDataArray();
@@ -274,24 +314,40 @@ internal sealed class PointwiseFusedActivationHandler : ActivationHandler
     }
 }
 
-/// <summary>PReLU with the canonical default slope 0.25: f = x&gt;0 ? x : 0.25·x; f' = x&gt;0 ? 1 : 0.25.</summary>
+/// <summary>PReLU: f = x&gt;0 ? x : a·x; f' = x&gt;0 ? 1 : a. The negative slope <c>a</c>
+/// comes from <see cref="FusedActivationParams.PReluSlope"/> (first element, the shared
+/// scalar slope) when supplied, else the canonical default 0.25.</summary>
 internal sealed class PReLUFusedActivationHandler : ActivationHandler
 {
     private const double DefaultSlope = 0.25;
-    public override Tensor<T> Apply<T>(CpuEngine engine, Tensor<T> input)
+
+    private static double SlopeOf(FusedActivationParams? p)
+        => p?.PReluSlope is { Length: > 0 } s ? s[0] : DefaultSlope;
+
+    public override Tensor<T> Apply<T>(CpuEngine engine, Tensor<T> input) => ApplyImpl<T>(input, null);
+    public override Tensor<T> Apply<T>(CpuEngine engine, Tensor<T> input, FusedActivationParams? activationParams)
+        => ApplyImpl<T>(input, activationParams);
+
+    private Tensor<T> ApplyImpl<T>(Tensor<T> input, FusedActivationParams? p)
     {
         var ops = Helpers.MathHelper.GetNumericOperations<T>();
-        var slope = ops.FromDouble(DefaultSlope);
+        var slope = ops.FromDouble(SlopeOf(p));
         var result = new Tensor<T>(input._shape);
         var xi = input.AsSpan(); var ro = result.AsWritableSpan();
         for (int i = 0; i < xi.Length; i++)
             ro[i] = ops.ToDouble(xi[i]) > 0.0 ? xi[i] : ops.Multiply(slope, xi[i]);
         return result;
     }
+
     public override Tensor<T> ApplyBackward<T>(CpuEngine engine, Tensor<T> gradOutput, Tensor<T> input)
+        => BackwardImpl<T>(gradOutput, input, null);
+    public override Tensor<T> ApplyBackward<T>(CpuEngine engine, Tensor<T> gradOutput, Tensor<T> input, FusedActivationParams? activationParams)
+        => BackwardImpl<T>(gradOutput, input, activationParams);
+
+    private Tensor<T> BackwardImpl<T>(Tensor<T> gradOutput, Tensor<T> input, FusedActivationParams? p)
     {
         var ops = Helpers.MathHelper.GetNumericOperations<T>();
-        var slope = ops.FromDouble(DefaultSlope);
+        var slope = ops.FromDouble(SlopeOf(p));
         var result = new Tensor<T>(input._shape);
         var xi = input.AsSpan(); var gi = gradOutput.AsSpan(); var ro = result.AsWritableSpan();
         for (int i = 0; i < xi.Length; i++)

--- a/src/AiDotNet.Tensors/Engines/ActivationHandler.cs
+++ b/src/AiDotNet.Tensors/Engines/ActivationHandler.cs
@@ -51,6 +51,41 @@ internal static class ActivationRegistry
             new KeyValuePair<FusedActivationType, ActivationHandler>(FusedActivationType.LeakyReLU, new LeakyReLUActivationHandler()),
             new KeyValuePair<FusedActivationType, ActivationHandler>(FusedActivationType.Swish, new SwishActivationHandler()),
             new KeyValuePair<FusedActivationType, ActivationHandler>(FusedActivationType.Softmax, new SoftmaxActivationHandler()),
+
+            // #499: backward handlers for every remaining FusedActivationType so the
+            // fused-linear backward pass never throws "No handler registered". Pointwise
+            // activations reuse the canonical fused forward delegate + its exact analytic
+            // derivative (CpuFusedOperations.GetXxxActivation[Derivative]); row-wise /
+            // Jacobian families reuse the engine's dedicated backward kernels.
+            new KeyValuePair<FusedActivationType, ActivationHandler>(FusedActivationType.ELU, new PointwiseFusedActivationHandler(FusedActivationType.ELU)),
+            new KeyValuePair<FusedActivationType, ActivationHandler>(FusedActivationType.SELU, new PointwiseFusedActivationHandler(FusedActivationType.SELU)),
+            new KeyValuePair<FusedActivationType, ActivationHandler>(FusedActivationType.Softplus, new PointwiseFusedActivationHandler(FusedActivationType.Softplus)),
+            new KeyValuePair<FusedActivationType, ActivationHandler>(FusedActivationType.Mish, new PointwiseFusedActivationHandler(FusedActivationType.Mish)),
+            new KeyValuePair<FusedActivationType, ActivationHandler>(FusedActivationType.HardSwish, new PointwiseFusedActivationHandler(FusedActivationType.HardSwish)),
+            new KeyValuePair<FusedActivationType, ActivationHandler>(FusedActivationType.HardSigmoid, new PointwiseFusedActivationHandler(FusedActivationType.HardSigmoid)),
+            new KeyValuePair<FusedActivationType, ActivationHandler>(FusedActivationType.HardTanh, new PointwiseFusedActivationHandler(FusedActivationType.HardTanh)),
+            new KeyValuePair<FusedActivationType, ActivationHandler>(FusedActivationType.ReLU6, new PointwiseFusedActivationHandler(FusedActivationType.ReLU6)),
+            new KeyValuePair<FusedActivationType, ActivationHandler>(FusedActivationType.SoftSign, new PointwiseFusedActivationHandler(FusedActivationType.SoftSign)),
+            new KeyValuePair<FusedActivationType, ActivationHandler>(FusedActivationType.CELU, new PointwiseFusedActivationHandler(FusedActivationType.CELU)),
+            new KeyValuePair<FusedActivationType, ActivationHandler>(FusedActivationType.ThresholdedReLU, new PointwiseFusedActivationHandler(FusedActivationType.ThresholdedReLU)),
+            new KeyValuePair<FusedActivationType, ActivationHandler>(FusedActivationType.ScaledTanh, new PointwiseFusedActivationHandler(FusedActivationType.ScaledTanh)),
+            new KeyValuePair<FusedActivationType, ActivationHandler>(FusedActivationType.RReLU, new PointwiseFusedActivationHandler(FusedActivationType.RReLU)),
+            new KeyValuePair<FusedActivationType, ActivationHandler>(FusedActivationType.Sign, new PointwiseFusedActivationHandler(FusedActivationType.Sign)),
+            new KeyValuePair<FusedActivationType, ActivationHandler>(FusedActivationType.BentIdentity, new PointwiseFusedActivationHandler(FusedActivationType.BentIdentity)),
+            new KeyValuePair<FusedActivationType, ActivationHandler>(FusedActivationType.Gaussian, new PointwiseFusedActivationHandler(FusedActivationType.Gaussian)),
+            new KeyValuePair<FusedActivationType, ActivationHandler>(FusedActivationType.LiSHT, new PointwiseFusedActivationHandler(FusedActivationType.LiSHT)),
+            new KeyValuePair<FusedActivationType, ActivationHandler>(FusedActivationType.ISRU, new PointwiseFusedActivationHandler(FusedActivationType.ISRU)),
+            new KeyValuePair<FusedActivationType, ActivationHandler>(FusedActivationType.SQRBF, new PointwiseFusedActivationHandler(FusedActivationType.SQRBF)),
+            new KeyValuePair<FusedActivationType, ActivationHandler>(FusedActivationType.BinarySpiking, new PointwiseFusedActivationHandler(FusedActivationType.BinarySpiking)),
+            new KeyValuePair<FusedActivationType, ActivationHandler>(FusedActivationType.PReLU, new PReLUFusedActivationHandler()),
+            new KeyValuePair<FusedActivationType, ActivationHandler>(FusedActivationType.Softmin, new SoftminActivationHandler()),
+            new KeyValuePair<FusedActivationType, ActivationHandler>(FusedActivationType.LogSoftmax, new LogSoftmaxActivationHandler(negate: false)),
+            new KeyValuePair<FusedActivationType, ActivationHandler>(FusedActivationType.LogSoftmin, new LogSoftmaxActivationHandler(negate: true)),
+            new KeyValuePair<FusedActivationType, ActivationHandler>(FusedActivationType.SphericalSoftmax, new SphericalSoftmaxActivationHandler()),
+            new KeyValuePair<FusedActivationType, ActivationHandler>(FusedActivationType.TaylorSoftmax, new TaylorSoftmaxActivationHandler()),
+            new KeyValuePair<FusedActivationType, ActivationHandler>(FusedActivationType.GumbelSoftmax, new GumbelSoftmaxActivationHandler()),
+            new KeyValuePair<FusedActivationType, ActivationHandler>(FusedActivationType.Sparsemax, new SparsemaxActivationHandler()),
+            new KeyValuePair<FusedActivationType, ActivationHandler>(FusedActivationType.Squash, new SquashActivationHandler()),
         });
 
     /// <summary>Gets the handler for a given activation type, or null for None.</summary>
@@ -177,5 +212,400 @@ internal sealed class SoftmaxActivationHandler : ActivationHandler
         // SoftmaxBackward expects post-activation output
         var softmaxOutput = engine.Softmax(input, -1);
         return engine.SoftmaxBackward(gradOutput, softmaxOutput, -1);
+    }
+}
+
+// ==================== #499 backward handlers for the remaining activations ====================
+
+/// <summary>
+/// Pointwise fused activation backward: forward via the canonical fused delegate
+/// (<see cref="Helpers.CpuFusedOperations.GetFloatActivation"/>) and backward =
+/// gradOutput ⊙ f'(preActivation) via its exact analytic derivative. float/double only.
+/// </summary>
+internal sealed class PointwiseFusedActivationHandler : ActivationHandler
+{
+    private readonly FusedActivationType _type;
+    public PointwiseFusedActivationHandler(FusedActivationType type) => _type = type;
+
+    public override Tensor<T> Apply<T>(CpuEngine engine, Tensor<T> input)
+    {
+        var result = new Tensor<T>(input._shape);
+        int n = input.Length;
+        if (typeof(T) == typeof(float))
+        {
+            var f = Helpers.CpuFusedOperations.GetFloatActivation(_type);
+            var xi = (float[])(object)input.GetDataArray();
+            var ro = (float[])(object)result.GetDataArray();
+            for (int i = 0; i < n; i++) ro[i] = f(xi[i]);
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            var f = Helpers.CpuFusedOperations.GetDoubleActivation(_type);
+            var xi = (double[])(object)input.GetDataArray();
+            var ro = (double[])(object)result.GetDataArray();
+            for (int i = 0; i < n; i++) ro[i] = f(xi[i]);
+        }
+        else throw new NotSupportedException($"Fused activation backward supports float/double, not {typeof(T).Name}.");
+        return result;
+    }
+
+    public override Tensor<T> ApplyBackward<T>(CpuEngine engine, Tensor<T> gradOutput, Tensor<T> input)
+    {
+        var result = new Tensor<T>(input._shape);
+        int n = input.Length;
+        if (typeof(T) == typeof(float))
+        {
+            var d = Helpers.CpuFusedOperations.GetFloatActivationDerivative(_type);
+            var xi = (float[])(object)input.GetDataArray();
+            var gi = (float[])(object)gradOutput.GetDataArray();
+            var ro = (float[])(object)result.GetDataArray();
+            for (int i = 0; i < n; i++) ro[i] = gi[i] * d(xi[i]);
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            var d = Helpers.CpuFusedOperations.GetDoubleActivationDerivative(_type);
+            var xi = (double[])(object)input.GetDataArray();
+            var gi = (double[])(object)gradOutput.GetDataArray();
+            var ro = (double[])(object)result.GetDataArray();
+            for (int i = 0; i < n; i++) ro[i] = gi[i] * d(xi[i]);
+        }
+        else throw new NotSupportedException($"Fused activation backward supports float/double, not {typeof(T).Name}.");
+        return result;
+    }
+}
+
+/// <summary>PReLU with the canonical default slope 0.25: f = x&gt;0 ? x : 0.25·x; f' = x&gt;0 ? 1 : 0.25.</summary>
+internal sealed class PReLUFusedActivationHandler : ActivationHandler
+{
+    private const double DefaultSlope = 0.25;
+    public override Tensor<T> Apply<T>(CpuEngine engine, Tensor<T> input)
+    {
+        var ops = Helpers.MathHelper.GetNumericOperations<T>();
+        var slope = ops.FromDouble(DefaultSlope);
+        var result = new Tensor<T>(input._shape);
+        var xi = input.AsSpan(); var ro = result.AsWritableSpan();
+        for (int i = 0; i < xi.Length; i++)
+            ro[i] = ops.ToDouble(xi[i]) > 0.0 ? xi[i] : ops.Multiply(slope, xi[i]);
+        return result;
+    }
+    public override Tensor<T> ApplyBackward<T>(CpuEngine engine, Tensor<T> gradOutput, Tensor<T> input)
+    {
+        var ops = Helpers.MathHelper.GetNumericOperations<T>();
+        var slope = ops.FromDouble(DefaultSlope);
+        var result = new Tensor<T>(input._shape);
+        var xi = input.AsSpan(); var gi = gradOutput.AsSpan(); var ro = result.AsWritableSpan();
+        for (int i = 0; i < xi.Length; i++)
+            ro[i] = ops.Multiply(gi[i], ops.ToDouble(xi[i]) > 0.0 ? ops.One : slope);
+        return result;
+    }
+}
+
+/// <summary>Softmin = softmax(−x). Backward chains through the negation:
+/// dx = −Jₛₒₓₜₘₐₓ(−x)ᵀ·g.</summary>
+internal sealed class SoftminActivationHandler : ActivationHandler
+{
+    public override Tensor<T> Apply<T>(CpuEngine engine, Tensor<T> input)
+        => engine.Softmax(FusedActivationBackwardMath.Negate(input), -1);
+    public override Tensor<T> ApplyBackward<T>(CpuEngine engine, Tensor<T> gradOutput, Tensor<T> input)
+    {
+        var o = engine.Softmax(FusedActivationBackwardMath.Negate(input), -1);
+        var g = engine.SoftmaxBackward(gradOutput, o, -1);
+        return FusedActivationBackwardMath.Negate(g);
+    }
+}
+
+/// <summary>LogSoftmax (and LogSoftmin when <c>negate</c>) over the last axis.
+/// o = u − logΣe^u with u = ±x; VJP dx = ±(g − softmax(u)·Σg).</summary>
+internal sealed class LogSoftmaxActivationHandler : ActivationHandler
+{
+    private readonly bool _negate;
+    public LogSoftmaxActivationHandler(bool negate) => _negate = negate;
+    public override Tensor<T> Apply<T>(CpuEngine engine, Tensor<T> input)
+        => FusedActivationBackwardMath.LogSoftmaxForward(input, _negate);
+    public override Tensor<T> ApplyBackward<T>(CpuEngine engine, Tensor<T> gradOutput, Tensor<T> input)
+        => FusedActivationBackwardMath.LogSoftmaxBackward(gradOutput, input, _negate);
+}
+
+/// <summary>Spherical softmax = softmax(x/‖x‖₂), matching the fused forward. Backward
+/// chains the softmax VJP through the L2-normalization Jacobian.</summary>
+internal sealed class SphericalSoftmaxActivationHandler : ActivationHandler
+{
+    public override Tensor<T> Apply<T>(CpuEngine engine, Tensor<T> input)
+        => FusedActivationBackwardMath.SphericalSoftmaxForward(input);
+    public override Tensor<T> ApplyBackward<T>(CpuEngine engine, Tensor<T> gradOutput, Tensor<T> input)
+        => FusedActivationBackwardMath.SphericalSoftmaxBackward(gradOutput, input);
+}
+
+/// <summary>Taylor softmax (2nd order): yᵢ = T(xᵢ)/ΣT, T(x)=1+x+x²/2, matching the fused
+/// forward. VJP: dxₖ = (T'(xₖ)/S)(gₖ − Σᵢgᵢyᵢ), T'(x)=1+x.</summary>
+internal sealed class TaylorSoftmaxActivationHandler : ActivationHandler
+{
+    public override Tensor<T> Apply<T>(CpuEngine engine, Tensor<T> input)
+        => FusedActivationBackwardMath.TaylorSoftmaxForward(input);
+    public override Tensor<T> ApplyBackward<T>(CpuEngine engine, Tensor<T> gradOutput, Tensor<T> input)
+        => FusedActivationBackwardMath.TaylorSoftmaxBackward(gradOutput, input);
+}
+
+internal sealed class SparsemaxActivationHandler : ActivationHandler
+{
+    public override Tensor<T> Apply<T>(CpuEngine engine, Tensor<T> input) => engine.Sparsemax(input, -1);
+    public override Tensor<T> ApplyBackward<T>(CpuEngine engine, Tensor<T> gradOutput, Tensor<T> input)
+    {
+        var output = engine.Sparsemax(input, -1);
+        return engine.SparsemaxBackward(gradOutput, output, -1);
+    }
+}
+
+/// <summary>Capsule squash yᵢ = xᵢ·‖x‖/(1+‖x‖²), matching the fused forward.</summary>
+internal sealed class SquashActivationHandler : ActivationHandler
+{
+    public override Tensor<T> Apply<T>(CpuEngine engine, Tensor<T> input)
+        => FusedActivationBackwardMath.SquashForward(input);
+    public override Tensor<T> ApplyBackward<T>(CpuEngine engine, Tensor<T> gradOutput, Tensor<T> input)
+        => FusedActivationBackwardMath.SquashBackward(gradOutput, input);
+}
+
+/// <summary>Gumbel-Softmax: the forward draws Gumbel noise (stochastic), so the fused
+/// backward uses the deterministic softmax-temperature relaxation (the standard
+/// reparameterization gradient at temperature 1) — gradients flow through the softmax,
+/// not the non-differentiable noise.</summary>
+internal sealed class GumbelSoftmaxActivationHandler : ActivationHandler
+{
+    public override Tensor<T> Apply<T>(CpuEngine engine, Tensor<T> input) => engine.GumbelSoftmax(input, 1.0, false, -1);
+    public override Tensor<T> ApplyBackward<T>(CpuEngine engine, Tensor<T> gradOutput, Tensor<T> input)
+    {
+        // Deterministic relaxation at temperature 1: J_softmax(x)ᵀ·g.
+        var relaxed = engine.Softmax(input, -1);
+        return engine.SoftmaxBackward(gradOutput, relaxed, -1);
+    }
+}
+
+/// <summary>Shared generic math for the row-wise (last-axis) softmax-family backward
+/// handlers. Computes in double precision internally for numerical stability.</summary>
+internal static class FusedActivationBackwardMath
+{
+    public static Tensor<T> Negate<T>(Tensor<T> t)
+    {
+        var ops = Helpers.MathHelper.GetNumericOperations<T>();
+        var r = new Tensor<T>(t._shape);
+        var s = t.AsSpan(); var d = r.AsWritableSpan();
+        for (int i = 0; i < s.Length; i++) d[i] = ops.Negate(s[i]);
+        return r;
+    }
+
+    public static Tensor<T> LogSoftmaxForward<T>(Tensor<T> input, bool negate)
+    {
+        var ops = Helpers.MathHelper.GetNumericOperations<T>();
+        int m = input._shape[input._shape.Length - 1];
+        int rows = m == 0 ? 0 : input.Length / m;
+        var r = new Tensor<T>(input._shape);
+        var xi = input.AsSpan(); var ro = r.AsWritableSpan();
+        for (int row = 0; row < rows; row++)
+        {
+            int off = row * m;
+            double max = double.NegativeInfinity;
+            for (int j = 0; j < m; j++)
+            {
+                double u = ops.ToDouble(xi[off + j]); if (negate) u = -u;
+                if (u > max) max = u;
+            }
+            double sum = 0.0;
+            for (int j = 0; j < m; j++)
+            {
+                double u = ops.ToDouble(xi[off + j]); if (negate) u = -u;
+                sum += Math.Exp(u - max);
+            }
+            double lse = max + Math.Log(sum);
+            for (int j = 0; j < m; j++)
+            {
+                double u = ops.ToDouble(xi[off + j]); if (negate) u = -u;
+                ro[off + j] = ops.FromDouble(u - lse);
+            }
+        }
+        return r;
+    }
+
+    public static Tensor<T> LogSoftmaxBackward<T>(Tensor<T> gradOutput, Tensor<T> input, bool negate)
+    {
+        var ops = Helpers.MathHelper.GetNumericOperations<T>();
+        int m = input._shape[input._shape.Length - 1];
+        int rows = m == 0 ? 0 : input.Length / m;
+        var r = new Tensor<T>(input._shape);
+        var xi = input.AsSpan(); var gi = gradOutput.AsSpan(); var ro = r.AsWritableSpan();
+        for (int row = 0; row < rows; row++)
+        {
+            int off = row * m;
+            double max = double.NegativeInfinity;
+            for (int j = 0; j < m; j++)
+            {
+                double u = ops.ToDouble(xi[off + j]); if (negate) u = -u;
+                if (u > max) max = u;
+            }
+            double z = 0.0, sg = 0.0;
+            for (int j = 0; j < m; j++)
+            {
+                double u = ops.ToDouble(xi[off + j]); if (negate) u = -u;
+                z += Math.Exp(u - max);
+                sg += ops.ToDouble(gi[off + j]);
+            }
+            for (int j = 0; j < m; j++)
+            {
+                double u = ops.ToDouble(xi[off + j]); if (negate) u = -u;
+                double p = Math.Exp(u - max) / z;                 // softmax(u)_j
+                double baseGrad = ops.ToDouble(gi[off + j]) - p * sg;
+                ro[off + j] = ops.FromDouble(negate ? -baseGrad : baseGrad);
+            }
+        }
+        return r;
+    }
+
+    // ---- Taylor softmax (2nd order): T(x)=1+x+x²/2, yᵢ=Tᵢ/ΣT ----
+    public static Tensor<T> TaylorSoftmaxForward<T>(Tensor<T> input)
+    {
+        var ops = Helpers.MathHelper.GetNumericOperations<T>();
+        int m = input._shape[input._shape.Length - 1];
+        int rows = m == 0 ? 0 : input.Length / m;
+        var r = new Tensor<T>(input._shape);
+        var xi = input.AsSpan(); var ro = r.AsWritableSpan();
+        for (int row = 0; row < rows; row++)
+        {
+            int off = row * m;
+            double s = 0.0;
+            for (int j = 0; j < m; j++) { double x = ops.ToDouble(xi[off + j]); s += 1.0 + x + 0.5 * x * x; }
+            for (int j = 0; j < m; j++) { double x = ops.ToDouble(xi[off + j]); ro[off + j] = ops.FromDouble((1.0 + x + 0.5 * x * x) / s); }
+        }
+        return r;
+    }
+
+    public static Tensor<T> TaylorSoftmaxBackward<T>(Tensor<T> gradOutput, Tensor<T> input)
+    {
+        var ops = Helpers.MathHelper.GetNumericOperations<T>();
+        int m = input._shape[input._shape.Length - 1];
+        int rows = m == 0 ? 0 : input.Length / m;
+        var r = new Tensor<T>(input._shape);
+        var xi = input.AsSpan(); var gi = gradOutput.AsSpan(); var ro = r.AsWritableSpan();
+        for (int row = 0; row < rows; row++)
+        {
+            int off = row * m;
+            double s = 0.0, gy = 0.0;
+            for (int j = 0; j < m; j++) { double x = ops.ToDouble(xi[off + j]); s += 1.0 + x + 0.5 * x * x; }
+            for (int j = 0; j < m; j++)
+            {
+                double x = ops.ToDouble(xi[off + j]);
+                double y = (1.0 + x + 0.5 * x * x) / s;
+                gy += ops.ToDouble(gi[off + j]) * y;
+            }
+            for (int j = 0; j < m; j++)
+            {
+                double x = ops.ToDouble(xi[off + j]);
+                double tPrime = 1.0 + x;                          // T'(x)
+                ro[off + j] = ops.FromDouble((tPrime / s) * (ops.ToDouble(gi[off + j]) - gy));
+            }
+        }
+        return r;
+    }
+
+    // ---- Spherical softmax: softmax(x/‖x‖₂) ----
+    public static Tensor<T> SphericalSoftmaxForward<T>(Tensor<T> input)
+    {
+        var ops = Helpers.MathHelper.GetNumericOperations<T>();
+        int m = input._shape[input._shape.Length - 1];
+        int rows = m == 0 ? 0 : input.Length / m;
+        var r = new Tensor<T>(input._shape);
+        var xi = input.AsSpan(); var ro = r.AsWritableSpan();
+        var u = new double[m];
+        for (int row = 0; row < rows; row++)
+        {
+            int off = row * m;
+            double r2 = 0.0;
+            for (int j = 0; j < m; j++) { double x = ops.ToDouble(xi[off + j]); r2 += x * x; }
+            double norm = Math.Sqrt(r2);
+            double max = double.NegativeInfinity;
+            for (int j = 0; j < m; j++) { u[j] = norm > 0.0 ? ops.ToDouble(xi[off + j]) / norm : ops.ToDouble(xi[off + j]); if (u[j] > max) max = u[j]; }
+            double z = 0.0;
+            for (int j = 0; j < m; j++) z += Math.Exp(u[j] - max);
+            for (int j = 0; j < m; j++) ro[off + j] = ops.FromDouble(Math.Exp(u[j] - max) / z);
+        }
+        return r;
+    }
+
+    public static Tensor<T> SphericalSoftmaxBackward<T>(Tensor<T> gradOutput, Tensor<T> input)
+    {
+        var ops = Helpers.MathHelper.GetNumericOperations<T>();
+        int m = input._shape[input._shape.Length - 1];
+        int rows = m == 0 ? 0 : input.Length / m;
+        var r = new Tensor<T>(input._shape);
+        var xi = input.AsSpan(); var gi = gradOutput.AsSpan(); var ro = r.AsWritableSpan();
+        var p = new double[m]; var gu = new double[m];
+        for (int row = 0; row < rows; row++)
+        {
+            int off = row * m;
+            double r2 = 0.0;
+            for (int j = 0; j < m; j++) { double x = ops.ToDouble(xi[off + j]); r2 += x * x; }
+            double norm = Math.Sqrt(r2);
+            double max = double.NegativeInfinity;
+            for (int j = 0; j < m; j++) { double uj = norm > 0.0 ? ops.ToDouble(xi[off + j]) / norm : ops.ToDouble(xi[off + j]); p[j] = uj; if (uj > max) max = uj; }
+            double z = 0.0;
+            for (int j = 0; j < m; j++) { p[j] = Math.Exp(p[j] - max); z += p[j]; }
+            double sp = 0.0;
+            for (int j = 0; j < m; j++) { p[j] /= z; sp += ops.ToDouble(gi[off + j]) * p[j]; }
+            // grad w.r.t. u = softmax argument
+            double gudotx = 0.0;
+            for (int j = 0; j < m; j++) { gu[j] = p[j] * (ops.ToDouble(gi[off + j]) - sp); gudotx += gu[j] * ops.ToDouble(xi[off + j]); }
+            // chain through u = x / ‖x‖:  dxₖ = guₖ/‖x‖ − xₖ·(Σ guᵢxᵢ)/‖x‖³
+            for (int j = 0; j < m; j++)
+            {
+                double dx = norm > 0.0
+                    ? gu[j] / norm - ops.ToDouble(xi[off + j]) * gudotx / (r2 * norm)
+                    : gu[j];
+                ro[off + j] = ops.FromDouble(dx);
+            }
+        }
+        return r;
+    }
+
+    // ---- Capsule squash: yᵢ = xᵢ·‖x‖/(1+‖x‖²) ----
+    public static Tensor<T> SquashForward<T>(Tensor<T> input)
+    {
+        var ops = Helpers.MathHelper.GetNumericOperations<T>();
+        int m = input._shape[input._shape.Length - 1];
+        int rows = m == 0 ? 0 : input.Length / m;
+        var r = new Tensor<T>(input._shape);
+        var xi = input.AsSpan(); var ro = r.AsWritableSpan();
+        for (int row = 0; row < rows; row++)
+        {
+            int off = row * m;
+            double r2 = 0.0;
+            for (int j = 0; j < m; j++) { double x = ops.ToDouble(xi[off + j]); r2 += x * x; }
+            double norm = Math.Sqrt(r2);
+            double a = norm > 0.0 ? norm / (1.0 + r2) : 0.0;
+            for (int j = 0; j < m; j++) ro[off + j] = ops.FromDouble(a * ops.ToDouble(xi[off + j]));
+        }
+        return r;
+    }
+
+    public static Tensor<T> SquashBackward<T>(Tensor<T> gradOutput, Tensor<T> input)
+    {
+        var ops = Helpers.MathHelper.GetNumericOperations<T>();
+        int m = input._shape[input._shape.Length - 1];
+        int rows = m == 0 ? 0 : input.Length / m;
+        var r = new Tensor<T>(input._shape);
+        var xi = input.AsSpan(); var gi = gradOutput.AsSpan(); var ro = r.AsWritableSpan();
+        for (int row = 0; row < rows; row++)
+        {
+            int off = row * m;
+            double r2 = 0.0, gdotx = 0.0;
+            for (int j = 0; j < m; j++) { double x = ops.ToDouble(xi[off + j]); r2 += x * x; gdotx += ops.ToDouble(gi[off + j]) * x; }
+            double norm = Math.Sqrt(r2);
+            double a = norm > 0.0 ? norm / (1.0 + r2) : 0.0;
+            // a = ‖x‖/(1+‖x‖²); ∂a/∂xₖ = (1−‖x‖²)/(1+‖x‖²)² · xₖ/‖x‖
+            double coef = norm > 0.0 ? (1.0 - r2) / ((1.0 + r2) * (1.0 + r2) * norm) : 0.0;
+            for (int j = 0; j < m; j++)
+            {
+                double dx = a * ops.ToDouble(gi[off + j]) + ops.ToDouble(xi[off + j]) * gdotx * coef;
+                ro[off + j] = ops.FromDouble(dx);
+            }
+        }
+        return r;
     }
 }

--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -4119,6 +4119,9 @@ internal static class BackwardFunctions<T>
         if (savedState is { Length: >= 1 })
         {
             var activation = (FusedActivationType)savedState[0];
+            // #506 review: parametric settings saved by the fused forward at [2] so the
+            // backward derivative honors a non-default slope/alpha/theta.
+            var activationParams = savedState.Length >= 3 ? savedState[2] as FusedActivationParams : null;
             Tensor<T> preActivation;
             if (savedState.Length >= 2 && savedState[1] is Tensor<T> cached)
             {
@@ -4134,21 +4137,22 @@ internal static class BackwardFunctions<T>
                 if (inputs.Length > 2)
                     preActivation = engine.TensorBroadcastAdd(preActivation, inputs[2]);
             }
-            gradOutput = ApplyActivationDerivative(gradOutput, preActivation, activation, engine);
+            gradOutput = ApplyActivationDerivative(gradOutput, preActivation, activation, engine, activationParams);
         }
 
         FusedLinearBackwardCore(gradOutput, inputs, output, savedState ?? Array.Empty<object>(), engine, grads);
     }
 
     private static Tensor<T> ApplyActivationDerivative(
-        Tensor<T> gradOutput, Tensor<T> preActivation, FusedActivationType activation, IEngine engine)
+        Tensor<T> gradOutput, Tensor<T> preActivation, FusedActivationType activation, IEngine engine,
+        FusedActivationParams? activationParams = null)
     {
         if (activation == FusedActivationType.None) return gradOutput;
 
         // Use CpuEngine.ApplyFusedActivationBackward which dispatches via ActivationRegistry
         // This is OCP-compliant: new activations register themselves, no switch needed here
         if (engine is CpuEngine cpuEngine)
-            return cpuEngine.ApplyFusedActivationBackward(gradOutput, preActivation, activation);
+            return cpuEngine.ApplyFusedActivationBackward(gradOutput, preActivation, activation, activationParams);
 
         // Fallback for non-CPU engines
         return gradOutput;

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -33964,15 +33964,18 @@ public partial class CpuEngine : ITensorLevelEngine
 
                 var inputs = bias != null ? new[] { input, weights, bias } : new[] { input, weights };
                 var capturedActivation = activation;
+                var capturedParams = activationParams;
                 return scope.RecordVariadic(nodeType, "FusedLinear", inputs, outShape,
                     (eng, output) =>
                     {
                         var eager = eng.FusedLinear(inputs[0], inputs[1],
-                            inputs.Length > 2 ? inputs[2] : null, capturedActivation);
+                            inputs.Length > 2 ? inputs[2] : null, capturedActivation, capturedParams);
                         eager.AsSpan().CopyTo(output.AsWritableSpan());
                     },
                     BackwardFunctions<T>.FusedLinearWithActivationBackward,
-                    activation != FusedActivationType.None ? new object[] { activation } : null);
+                    // savedState layout [0]=activation, [1]=preActivation (null here ⇒ backward
+                    // recomputes), [2]=FusedActivationParams (#506 review: parametric backward).
+                    activation != FusedActivationType.None ? new object[] { activation, null!, activationParams! } : null);
             }
         }
 
@@ -33996,15 +33999,16 @@ public partial class CpuEngine : ITensorLevelEngine
             if (activation != FusedActivationType.None)
             {
                 savedPreActivation = fusedResult.Clone();
-                ApplyFusedActivationInPlace(fusedResult, activation);
+                ApplyFusedActivationInPlace(fusedResult, activation, activationParams);
             }
             RemoveLastNTapeEntries<T>(bias != null ? 2 : 1);
 
             // Record single fused entry with activation info AND the captured
-            // pre-activation for backward.
+            // pre-activation for backward. #506 review: also carry FusedActivationParams
+            // ([2]) so parametric backward matches the parametric forward applied above.
             var fusedInputs = bias != null ? new[] { input, weights, bias } : new[] { input, weights };
             object[]? savedState = activation != FusedActivationType.None
-                ? new object[] { activation, savedPreActivation! } // [0]=activation, [1]=pre-activation
+                ? new object[] { activation, savedPreActivation!, activationParams! } // [0]=activation, [1]=pre-activation, [2]=params
                 : null;
             Autodiff.DifferentiableOps.RecordIfActive("FusedLinear", fusedResult, fusedInputs,
                 Autodiff.BackwardFunctions<T>.FusedLinearWithActivationBackward, savedState);
@@ -34598,11 +34602,11 @@ public partial class CpuEngine : ITensorLevelEngine
     /// Handlers with true in-place support (ReLU, Sigmoid) override ApplyInPlace.
     /// Others fall back to allocate + copy.
     /// </summary>
-    private void ApplyFusedActivationInPlace<T>(Tensor<T> tensor, FusedActivationType activation)
+    private void ApplyFusedActivationInPlace<T>(Tensor<T> tensor, FusedActivationType activation, FusedActivationParams? activationParams = null)
     {
         var handler = ActivationRegistry.Get(activation);
         if (handler is null) return; // None
-        handler.ApplyInPlace(this, tensor);
+        handler.ApplyInPlace(this, tensor, activationParams);
     }
 
     /// <summary>
@@ -34619,16 +34623,18 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <summary>
     /// Computes the backward pass for the specified activation function.
     /// </summary>
-    internal Tensor<T> ApplyFusedActivationBackward<T>(Tensor<T> gradOutput, Tensor<T> preActivation, FusedActivationType activation)
+    internal Tensor<T> ApplyFusedActivationBackward<T>(Tensor<T> gradOutput, Tensor<T> preActivation, FusedActivationType activation, FusedActivationParams? activationParams = null)
     {
         // None is an explicit pass-through — no derivative to apply
         if (activation == FusedActivationType.None) return gradOutput;
 
         // OCP-compliant: dispatch through ActivationRegistry, no switch statement.
         // ActivationRegistry.Get throws for unknown types, preventing silent identity pass-through.
+        // #506 review: forward parametric settings so non-default LeakyReLU/ELU/CELU/
+        // ThresholdedReLU/ScaledTanh/RReLU/PReLU gradients match the forward.
         var handler = ActivationRegistry.Get(activation);
         if (handler is null) return gradOutput;
-        return handler.ApplyBackward(this, gradOutput, preActivation);
+        return handler.ApplyBackward(this, gradOutput, preActivation, activationParams);
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Helpers/CpuFusedOperations.cs
+++ b/src/AiDotNet.Tensors/Helpers/CpuFusedOperations.cs
@@ -1332,6 +1332,92 @@ public static class CpuFusedOperations
         throw new ArgumentException($"No float activation registered for type: {activation}");
     }
 
+    /// <summary>Returns f'(x) for the pointwise fused activation — the exact analytic
+    /// derivative of the matching <see cref="GetFloatActivation"/> form, for use in the
+    /// fused-activation backward pass. Sign/BinarySpiking are hard (piecewise-constant)
+    /// nonlinearities whose derivative is 0 almost everywhere — they return 0 (use a
+    /// surrogate-gradient layer for SNN training).</summary>
+    internal static Func<float, float> GetFloatActivationDerivative(FusedActivationType activation, FusedActivationParams? p = null)
+    {
+        switch (activation)
+        {
+            case FusedActivationType.LeakyReLU:
+            {
+                float a = p?.Alpha ?? 0.01f;
+                return x => x > 0f ? 1f : a;
+            }
+            case FusedActivationType.RReLU:
+            {
+                float a = p?.Alpha ?? 0.22916667f;
+                return x => x > 0f ? 1f : a;
+            }
+            case FusedActivationType.ELU:
+            {
+                float a = p?.Alpha ?? 1f;
+                return x => x > 0f ? 1f : a * MathF.Exp(x);
+            }
+            case FusedActivationType.SELU:
+                return x => SeluScale * (x > 0f ? 1f : SeluAlpha * MathF.Exp(x));
+            case FusedActivationType.CELU:
+            {
+                float a = p?.Alpha ?? 1f;
+                if (!(a > 0f))
+                    throw new ArgumentOutOfRangeException(nameof(p), "CELU alpha must be > 0 (the activation divides by it).");
+                return x => x >= 0f ? 1f : MathF.Exp(x / a);
+            }
+            case FusedActivationType.Softplus:
+                return x => x > 20f ? 1f : 1f / (1f + MathF.Exp(-x));
+            case FusedActivationType.Mish:
+                return x =>
+                {
+                    float sp = ApplySoftplus(x);
+                    float t = MathF.Tanh(sp);
+                    float sig = x > 20f ? 1f : 1f / (1f + MathF.Exp(-x));
+                    return t + x * sig * (1f - t * t);
+                };
+            case FusedActivationType.HardSwish:
+                return x => x <= -3f ? 0f : (x >= 3f ? 1f : (2f * x + 3f) / 6f);
+            case FusedActivationType.HardSigmoid:
+                return x => (x > -3f && x < 3f) ? 1f / 6f : 0f;
+            case FusedActivationType.HardTanh:
+                return x => (x > -1f && x < 1f) ? 1f : 0f;
+            case FusedActivationType.ReLU6:
+                return x => (x > 0f && x < 6f) ? 1f : 0f;
+            case FusedActivationType.SoftSign:
+                return x => { float d = 1f + MathF.Abs(x); return 1f / (d * d); };
+            case FusedActivationType.ThresholdedReLU:
+            {
+                float t = p?.Theta ?? 1f;
+                return x => x > t ? 1f : 0f;
+            }
+            case FusedActivationType.ScaledTanh:
+            {
+                float a = p?.Alpha ?? 1f, b = p?.Beta ?? 1f;
+                return x => { float th = MathF.Tanh(b * x); return a * b * (1f - th * th); };
+            }
+            case FusedActivationType.BentIdentity:
+                return x => x / (2f * MathF.Sqrt(x * x + 1f)) + 1f;
+            case FusedActivationType.Gaussian:
+                return x => -2f * x * MathF.Exp(-x * x);
+            case FusedActivationType.LiSHT:
+                return x => { float t = MathF.Tanh(x); return t + x * (1f - t * t); };
+            case FusedActivationType.ISRU:
+            {
+                float a = p?.Alpha ?? 1f;
+                return x => { float denom = 1f + a * x * x; return 1f / (denom * MathF.Sqrt(denom)); };
+            }
+            case FusedActivationType.SQRBF:
+            {
+                float b = p?.Beta ?? 1f;
+                return x => -2f * b * x * MathF.Exp(-b * x * x);
+            }
+            case FusedActivationType.Sign:
+            case FusedActivationType.BinarySpiking:
+                return _ => 0f;  // derivative 0 a.e.; documented hard nonlinearity
+        }
+        throw new ArgumentException($"No float activation derivative registered for type: {activation}");
+    }
+
     /// <summary>
     /// GELU activation using fast tanh approximation.
     /// GELU(x) = 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
@@ -1545,6 +1631,90 @@ public static class CpuFusedOperations
         if (_doubleActivations.TryGetValue(activation, out var fn))
             return fn;
         throw new ArgumentException($"No double activation registered for type: {activation}");
+    }
+
+    /// <summary>Double-precision f'(x) for the pointwise fused activation — exact analytic
+    /// derivative of the matching <see cref="GetDoubleActivation"/> form. See the float
+    /// overload for the Sign/BinarySpiking note.</summary>
+    internal static Func<double, double> GetDoubleActivationDerivative(FusedActivationType activation, FusedActivationParams? p = null)
+    {
+        switch (activation)
+        {
+            case FusedActivationType.LeakyReLU:
+            {
+                double a = p?.Alpha ?? 0.01;
+                return x => x > 0.0 ? 1.0 : a;
+            }
+            case FusedActivationType.RReLU:
+            {
+                double a = p?.Alpha ?? 0.22916667;
+                return x => x > 0.0 ? 1.0 : a;
+            }
+            case FusedActivationType.ELU:
+            {
+                double a = p?.Alpha ?? 1.0;
+                return x => x > 0.0 ? 1.0 : a * Math.Exp(x);
+            }
+            case FusedActivationType.SELU:
+                return x => 1.0507009873554805 * (x > 0.0 ? 1.0 : 1.6732632423543772 * Math.Exp(x));
+            case FusedActivationType.CELU:
+            {
+                double a = p?.Alpha ?? 1.0;
+                if (!(a > 0.0))
+                    throw new ArgumentOutOfRangeException(nameof(p), "CELU alpha must be > 0 (the activation divides by it).");
+                return x => x >= 0.0 ? 1.0 : Math.Exp(x / a);
+            }
+            case FusedActivationType.Softplus:
+                return x => x > 20.0 ? 1.0 : 1.0 / (1.0 + Math.Exp(-x));
+            case FusedActivationType.Mish:
+                return x =>
+                {
+                    double sp = ApplySoftplusDouble(x);
+                    double t = Math.Tanh(sp);
+                    double sig = x > 20.0 ? 1.0 : 1.0 / (1.0 + Math.Exp(-x));
+                    return t + x * sig * (1.0 - t * t);
+                };
+            case FusedActivationType.HardSwish:
+                return x => x <= -3.0 ? 0.0 : (x >= 3.0 ? 1.0 : (2.0 * x + 3.0) / 6.0);
+            case FusedActivationType.HardSigmoid:
+                return x => (x > -3.0 && x < 3.0) ? 1.0 / 6.0 : 0.0;
+            case FusedActivationType.HardTanh:
+                return x => (x > -1.0 && x < 1.0) ? 1.0 : 0.0;
+            case FusedActivationType.ReLU6:
+                return x => (x > 0.0 && x < 6.0) ? 1.0 : 0.0;
+            case FusedActivationType.SoftSign:
+                return x => { double d = 1.0 + Math.Abs(x); return 1.0 / (d * d); };
+            case FusedActivationType.ThresholdedReLU:
+            {
+                double t = p?.Theta ?? 1.0;
+                return x => x > t ? 1.0 : 0.0;
+            }
+            case FusedActivationType.ScaledTanh:
+            {
+                double a = p?.Alpha ?? 1.0, b = p?.Beta ?? 1.0;
+                return x => { double th = Math.Tanh(b * x); return a * b * (1.0 - th * th); };
+            }
+            case FusedActivationType.BentIdentity:
+                return x => x / (2.0 * Math.Sqrt(x * x + 1.0)) + 1.0;
+            case FusedActivationType.Gaussian:
+                return x => -2.0 * x * Math.Exp(-x * x);
+            case FusedActivationType.LiSHT:
+                return x => { double t = Math.Tanh(x); return t + x * (1.0 - t * t); };
+            case FusedActivationType.ISRU:
+            {
+                double a = p?.Alpha ?? 1.0;
+                return x => { double denom = 1.0 + a * x * x; return 1.0 / (denom * Math.Sqrt(denom)); };
+            }
+            case FusedActivationType.SQRBF:
+            {
+                double b = p?.Beta ?? 1.0;
+                return x => -2.0 * b * x * Math.Exp(-b * x * x);
+            }
+            case FusedActivationType.Sign:
+            case FusedActivationType.BinarySpiking:
+                return _ => 0.0;  // derivative 0 a.e.; documented hard nonlinearity
+        }
+        throw new ArgumentException($"No double activation derivative registered for type: {activation}");
     }
 
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/FusedActivationBackwardParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/FusedActivationBackwardParityTests.cs
@@ -148,6 +148,56 @@ public class FusedActivationBackwardParityTests
         }
     }
 
+    /// <summary>
+    /// #506 review: the fused-activation backward must honor a caller-supplied
+    /// <see cref="FusedActivationParams"/> (slope/alpha), not silently use the default.
+    /// For each parametric activation: the params-aware backward matches a finite-difference
+    /// VJP of the params-aware forward, AND differs from the default-params backward (proving
+    /// the parameter actually flows through — the bug CodeRabbit flagged).
+    /// </summary>
+    [Theory]
+    [InlineData(FusedActivationType.PReLU)]   // PReluSlope[0]
+    [InlineData(FusedActivationType.ELU)]     // Alpha
+    [InlineData(FusedActivationType.CELU)]    // Alpha
+    [InlineData(FusedActivationType.LeakyReLU)] // Alpha
+    public void ParametricActivation_Backward_HonorsNonDefaultParams(FusedActivationType act)
+    {
+        var engine = new CpuEngine();
+        var handler = ActivationRegistry.Get(act)!;
+        int n = 12;
+        var x = MakeSafeInput(n, 4242 + (int)act);
+        var g = MakeGrad(n, 2424 + (int)act);
+        // Non-default params: slope/alpha = 0.3 (defaults are 0.25 / 1.0 / 1.0 / 0.01).
+        var p = act == FusedActivationType.PReLU
+            ? new FusedActivationParams { PReluSlope = new[] { 0.3f } }
+            : new FusedActivationParams { Alpha = 0.3f };
+
+        var xT = new Tensor<double>((double[])x.Clone(), new[] { n });
+        var gT = new Tensor<double>((double[])g.Clone(), new[] { n });
+        var analytic = handler.ApplyBackward(engine, gT, xT, p).AsSpan().ToArray();
+
+        // Finite-difference VJP of the params-aware forward (pointwise: per-element).
+        const double eps = 1e-6;
+        for (int i = 0; i < n; i++)
+        {
+            var xp = (double[])x.Clone(); xp[i] += eps;
+            var xm = (double[])x.Clone(); xm[i] -= eps;
+            var fp = handler.Apply(engine, new Tensor<double>(xp, new[] { n }), p).AsSpan();
+            var fm = handler.Apply(engine, new Tensor<double>(xm, new[] { n }), p).AsSpan();
+            double numerical = g[i] * (fp[i] - fm[i]) / (2.0 * eps);
+            Assert.True(Math.Abs(analytic[i] - numerical) < 2e-3,
+                $"{act} params-aware backward[{i}] {analytic[i]:E4} != finite-diff {numerical:E4}");
+        }
+
+        // And it must DIFFER from the default-params backward on the negative region
+        // (where the slope/alpha applies), proving the parameter took effect.
+        var defaultGrad = handler.ApplyBackward(engine, gT, xT).AsSpan().ToArray();
+        double maxDiff = 0;
+        for (int i = 0; i < n; i++) maxDiff = Math.Max(maxDiff, Math.Abs(analytic[i] - defaultGrad[i]));
+        Assert.True(maxDiff > 1e-6,
+            $"{act}: params-aware backward identical to default — FusedActivationParams not honored.");
+    }
+
     private static double[] MakeSafeInput(int n, int seed)
     {
         var rng = new Random(seed);

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/FusedActivationBackwardParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/FusedActivationBackwardParityTests.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+/// <summary>
+/// #499: every <see cref="FusedActivationType"/> must have a registered backward
+/// handler (so the fused-linear backward pass never throws "No handler registered"),
+/// and each handler's analytic VJP must match a finite-difference vector-Jacobian
+/// product of its own forward. This is the rigorous gradient check — it validates the
+/// derivative against the forward directly, for both pointwise and row-wise/Jacobian
+/// (softmax-family) activations.
+/// </summary>
+public class FusedActivationBackwardParityTests
+{
+    private const int Rows = 3, M = 5;
+
+    // Knots where a piecewise activation is non-differentiable; finite differences are
+    // invalid within ε of these, so the safe-input generator nudges away from them.
+    private static readonly double[] Knots = { 0.0, 1.0, -1.0, 3.0, -3.0, 6.0 };
+
+    public static IEnumerable<object[]> AllNonNoneActivations()
+    {
+        foreach (FusedActivationType a in Enum.GetValues(typeof(FusedActivationType)))
+            if (a != FusedActivationType.None)
+                yield return new object[] { a };
+    }
+
+    // Differentiable + deterministic: excludes the hard nonlinearities (Sign,
+    // BinarySpiking — 0 derivative a.e.) and the stochastic GumbelSoftmax.
+    public static IEnumerable<object[]> FiniteDiffActivations()
+    {
+        foreach (FusedActivationType a in Enum.GetValues(typeof(FusedActivationType)))
+        {
+            if (a == FusedActivationType.None || a == FusedActivationType.Sign
+                || a == FusedActivationType.BinarySpiking || a == FusedActivationType.GumbelSoftmax)
+                continue;
+            yield return new object[] { a };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(AllNonNoneActivations))]
+    public void EveryActivation_HasRegisteredBackwardHandler(FusedActivationType act)
+    {
+        // The core #499 guarantee: ActivationRegistry.Get no longer throws for any of them.
+        var handler = ActivationRegistry.Get(act);
+        Assert.NotNull(handler);
+    }
+
+    [Theory]
+    [MemberData(nameof(FiniteDiffActivations))]
+    public void FusedActivationBackward_MatchesFiniteDifferenceVJP(FusedActivationType act)
+    {
+        var engine = new CpuEngine();
+        var handler = ActivationRegistry.Get(act)!;
+        var shape = new[] { Rows, M };
+        int n = Rows * M;
+
+        var x = MakeSafeInput(n, seed: 1234 + (int)act);
+        var g = MakeGrad(n, seed: 5678 + (int)act);
+
+        // Analytic VJP: gradInput = Jᵀ·g.
+        var xTensor = new Tensor<double>((double[])x.Clone(), shape);
+        var gTensor = new Tensor<double>((double[])g.Clone(), shape);
+        var analytic = handler.ApplyBackward(engine, gTensor, xTensor).AsSpan().ToArray();
+
+        // Numerical VJP via central differences of the handler's own forward:
+        //   (Jᵀg)_i ≈ Σ_k g_k · (f(x+εeᵢ)_k − f(x−εeᵢ)_k) / (2ε)
+        const double eps = 1e-5;
+        for (int i = 0; i < n; i++)
+        {
+            var xp = (double[])x.Clone(); xp[i] += eps;
+            var xm = (double[])x.Clone(); xm[i] -= eps;
+            var fp = handler.Apply(engine, new Tensor<double>(xp, shape)).AsSpan();
+            var fm = handler.Apply(engine, new Tensor<double>(xm, shape)).AsSpan();
+
+            double numerical = 0.0;
+            for (int k = 0; k < n; k++)
+                numerical += g[k] * (fp[k] - fm[k]) / (2.0 * eps);
+
+            double tol = 2e-3 + 5e-3 * Math.Abs(numerical);
+            Assert.True(Math.Abs(analytic[i] - numerical) < tol,
+                $"{act}: dInput[{i}] analytic {analytic[i]:E4} vs finite-diff {numerical:E4} (tol {tol:E4}).");
+        }
+    }
+
+    [Theory]
+    [InlineData(FusedActivationType.Sign)]
+    [InlineData(FusedActivationType.BinarySpiking)]
+    public void HardNonlinearity_Backward_IsZeroAlmostEverywhere(FusedActivationType act)
+    {
+        // Sign and BinarySpiking are piecewise-constant; their derivative is 0 a.e.
+        // The handler returns exactly 0 (a surrogate-gradient layer is used for SNN training).
+        var engine = new CpuEngine();
+        var handler = ActivationRegistry.Get(act)!;
+        var shape = new[] { Rows, M };
+        int n = Rows * M;
+        var x = new Tensor<double>(MakeSafeInput(n, seed: 99 + (int)act), shape);
+        var g = new Tensor<double>(MakeGrad(n, seed: 7 + (int)act), shape);
+
+        var grad = handler.ApplyBackward(engine, g, x).AsSpan();
+        for (int i = 0; i < grad.Length; i++)
+            Assert.True(Math.Abs(grad[i]) < 1e-12, $"{act}: derivative is 0 a.e.; got {grad[i]} at {i}.");
+    }
+
+    [Fact]
+    public void GumbelSoftmax_Backward_RunsAndIsFinite()
+    {
+        // Stochastic forward → no finite-difference check; verify the deterministic
+        // relaxation backward produces a finite, correctly-shaped gradient (no throw).
+        var engine = new CpuEngine();
+        var handler = ActivationRegistry.Get(FusedActivationType.GumbelSoftmax)!;
+        var shape = new[] { Rows, M };
+        int n = Rows * M;
+        var x = new Tensor<double>(MakeSafeInput(n, seed: 321), shape);
+        var g = new Tensor<double>(MakeGrad(n, seed: 654), shape);
+
+        var grad = handler.ApplyBackward(engine, g, x).AsSpan();
+        Assert.Equal(n, grad.Length);
+        for (int i = 0; i < grad.Length; i++)
+            Assert.True(!double.IsNaN(grad[i]) && !double.IsInfinity(grad[i]), $"non-finite gradient at {i}.");
+    }
+
+    [Fact]
+    public void ApplyFusedActivationBackward_NoLongerThrows_ForNewlyWiredActivations()
+    {
+        // Regression for the original gap: these used to throw ArgumentException
+        // ("No handler registered") through the fused-linear backward entry point.
+        var engine = new CpuEngine();
+        var shape = new[] { Rows, M };
+        var preAct = new Tensor<float>(new float[Rows * M], shape);
+        var grad = new Tensor<float>(new float[Rows * M], shape);
+        for (int i = 0; i < Rows * M; i++) { preAct[i] = 0.3f * (i - 7); grad[i] = 1f; }
+
+        foreach (var act in new[]
+        {
+            FusedActivationType.Mish, FusedActivationType.CELU, FusedActivationType.SELU,
+            FusedActivationType.ISRU, FusedActivationType.Softmin, FusedActivationType.Sparsemax,
+            FusedActivationType.PReLU, FusedActivationType.LogSoftmax,
+        })
+        {
+            var ex = Record.Exception(() => engine.ApplyFusedActivationBackward(grad, preAct, act));
+            Assert.Null(ex);
+        }
+    }
+
+    private static double[] MakeSafeInput(int n, int seed)
+    {
+        var rng = new Random(seed);
+        var a = new double[n];
+        for (int i = 0; i < n; i++)
+        {
+            double v;
+            do { v = rng.NextDouble() * 3.6 - 1.8; } // (-1.8, 1.8)
+            while (TooCloseToKnot(v));
+            a[i] = v;
+        }
+        return a;
+    }
+
+    private static bool TooCloseToKnot(double v)
+    {
+        foreach (var k in Knots)
+            if (Math.Abs(v - k) < 0.05) return true;
+        return false;
+    }
+
+    private static double[] MakeGrad(int n, int seed)
+    {
+        var rng = new Random(seed);
+        var a = new double[n];
+        for (int i = 0; i < n; i++) a[i] = rng.NextDouble() * 2.0 - 1.0;
+        return a;
+    }
+}


### PR DESCRIPTION
## Summary

Completes the remaining work from #499. The fused-activation **forward** kernels (all 37 `FusedActivationType` values) and optimizer kernels landed in #502, but the fused-linear **backward** path only had handlers for 8 activations — the other 29 threw `ArgumentException("No handler registered")` through `BackwardFunctions.FusedLinearBackward` → `CpuEngine.ApplyFusedActivationBackward` → `ActivationRegistry.Get`. This wires backward handlers for every remaining activation so the fused backward never throws.

### What was added
- **Pointwise** (ELU, SELU, Softplus, Mish, HardSwish, HardSigmoid, HardTanh, ReLU6, SoftSign, CELU, ThresholdedReLU, ScaledTanh, RReLU, BentIdentity, Gaussian, LiSHT, ISRU, SQRBF): one `PointwiseFusedActivationHandler` reuses the canonical fused forward delegate + a new exact-derivative table `CpuFusedOperations.GetFloat/DoubleActivationDerivative`. Forward and backward are a matched pair by construction.
- **PReLU**: dedicated handler at the canonical default slope 0.25.
- **Sign / BinarySpiking**: hard piecewise-constant nonlinearities — derivative is 0 almost everywhere (documented; SNN training uses a surrogate-gradient layer).
- **Row-wise / Jacobian families** as self-consistent forward+backward pairs matching the fused forward (`RowwiseFusedActivations`): Softmin, LogSoftmax, LogSoftmin (softmax VJP), TaylorSoftmax (`T=1+x+x²/2`), SphericalSoftmax (`softmax∘L2-normalize`, chained), Squash (capsule). The engine's existing Taylor/Spherical/Squash backward kernels **disagreed with their own forward** under a finite-difference check, so these use verified analytic VJPs.
- **Sparsemax** reuses the engine's (self-consistent) `SparsemaxBackward`.
- **GumbelSoftmax**: deterministic softmax-temperature relaxation gradient (Gumbel noise is non-differentiable).

### Tests
`FusedActivationBackwardParityTests` (73/73):
- analytic VJP vs **finite-difference VJP** of each handler's own forward (covers pointwise + Jacobian families),
- the registry resolves **every** non-None `FusedActivationType` (no more "No handler registered"),
- `ApplyFusedActivationBackward` no longer throws for the newly-wired set,
- Sign/BinarySpiking assert 0-a.e. gradient; GumbelSoftmax smoke-checks finiteness.

Broad regression (autodiff + fused-linear + epilogue + tape-completeness): 708/0. Both `net10.0` and `net471` build clean.

Closes #499.

🤖 Generated with [Claude Code](https://claude.com/claude-code)