### PR TITLE
fix(#376): verify managed LAPACK-replacement decompositions — fix Eig eigenvectors + LDL pivoting

### DIFF
--- a/src/AiDotNet.Tensors/LinearAlgebra/Decompositions/EigDecomposition.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/Decompositions/EigDecomposition.cs
@@ -115,34 +115,127 @@ internal static class EigDecomposition
             }
         }
 
-        // Write Q columns as real eigenvectors (imaginary part zero for real eigenvalues).
-        // For complex eigenvalue pairs, the two adjacent Q columns form the real and
-        // imaginary parts of a complex eigenvector pair.
-        idx = 0;
-        while (idx < n)
-        {
-            bool isComplex = idx < n - 1 && ToDouble(w[offW + idx * 2 + 1]) != 0.0;
-            if (isComplex)
+        // Right eigenvectors via inverse iteration on the ORIGINAL matrix A.
+        // The Schur vectors q are NOT eigenvectors for a non-symmetric matrix
+        // (only the Schur basis), so copying them was incorrect. Inverse
+        // iteration solves (A − λI)x = b for the (now accurate) eigenvalue λ;
+        // because the shift sits ε away from λ, one or two solves amplify the
+        // matching eigenvector to dominate. Complex λ is handled with the
+        // equivalent 2n×2n real system, so a single routine covers real and
+        // complex-conjugate eigenpairs.
+        var a0 = new double[n * n];
+        double scale = 0.0;
+        for (int i = 0; i < n; i++)
+            for (int j = 0; j < n; j++)
             {
-                for (int r = 0; r < n; r++)
-                {
-                    v[offV + (r * n + idx) * 2] = FromDouble<T>(q[r * n + idx]);
-                    v[offV + (r * n + idx) * 2 + 1] = FromDouble<T>(q[r * n + idx + 1]);
-                    v[offV + (r * n + idx + 1) * 2] = FromDouble<T>(q[r * n + idx]);
-                    v[offV + (r * n + idx + 1) * 2 + 1] = FromDouble<T>(-q[r * n + idx + 1]);
-                }
-                idx += 2;
+                double aij = ToDouble(src[offSrc + i * n + j]);
+                a0[i * n + j] = aij;
+                double m = Math.Abs(aij);
+                if (m > scale) scale = m;
             }
-            else
+        if (scale == 0.0) scale = 1.0;
+
+        for (int k = 0; k < n; k++)
+        {
+            double re = ToDouble(w[offW + k * 2]);
+            double im = ToDouble(w[offW + k * 2 + 1]);
+            EigenvectorByInverseIteration(a0, n, re, im, scale, out var xr, out var xi);
+            for (int r = 0; r < n; r++)
             {
-                for (int r = 0; r < n; r++)
-                {
-                    v[offV + (r * n + idx) * 2] = FromDouble<T>(q[r * n + idx]);
-                    v[offV + (r * n + idx) * 2 + 1] = FromDouble<T>(0.0);
-                }
-                idx += 1;
+                v[offV + (r * n + k) * 2] = FromDouble<T>(xr[r]);
+                v[offV + (r * n + k) * 2 + 1] = FromDouble<T>(xi[r]);
             }
         }
+    }
+
+    /// <summary>
+    /// Right eigenvector for eigenvalue (<paramref name="re"/> + i·<paramref name="im"/>)
+    /// of the real matrix <paramref name="a"/> via inverse iteration. The shift is
+    /// perturbed ε·scale off the eigenvalue to keep (A − shift·I) non-singular while
+    /// still converging to the matching eigenvector. The complex solve is cast to a
+    /// 2n×2n real system: (A−sI)xr + im·xi = br, −im·xr + (A−sI)xi = bi.
+    /// </summary>
+    private static void EigenvectorByInverseIteration(
+        double[] a, int n, double re, double im, double scale, out double[] xr, out double[] xi)
+    {
+        double shift = re + (re >= 0 ? 1.0 : -1.0) * 1e-7 * scale;
+        int m = 2 * n;
+        var mat = new double[m * m];
+        for (int i = 0; i < n; i++)
+            for (int j = 0; j < n; j++)
+            {
+                double val = a[i * n + j] - (i == j ? shift : 0.0);
+                mat[i * m + j] = val;               // top-left  (A − sI)
+                mat[(i + n) * m + (j + n)] = val;   // bottom-right (A − sI)
+            }
+        for (int i = 0; i < n; i++)
+        {
+            mat[i * m + (i + n)] = im;              // top-right  (+im·I)
+            mat[(i + n) * m + i] = -im;             // bottom-left (−im·I)
+        }
+
+        // Start vector: ones in the real block. Two inverse-iteration steps.
+        var x = new double[m];
+        for (int i = 0; i < n; i++) x[i] = 1.0;
+        for (int iter = 0; iter < 2; iter++)
+        {
+            var y = SolveDense(mat, x, m);
+            double nrm = 0.0;
+            for (int i = 0; i < m; i++) nrm += y[i] * y[i];
+            nrm = Math.Sqrt(nrm);
+            if (nrm > 0.0) for (int i = 0; i < m; i++) y[i] /= nrm;
+            x = y;
+        }
+
+        xr = new double[n];
+        xi = new double[n];
+        double cnorm = 0.0;
+        for (int i = 0; i < n; i++) { xr[i] = x[i]; xi[i] = x[i + n]; cnorm += xr[i] * xr[i] + xi[i] * xi[i]; }
+        cnorm = Math.Sqrt(cnorm);
+        if (cnorm > 0.0) for (int i = 0; i < n; i++) { xr[i] /= cnorm; xi[i] /= cnorm; }
+    }
+
+    /// <summary>Solve M·y = b (M is m×m, row-major) via Gaussian elimination with
+    /// partial pivoting. Operates on copies so the caller's matrix is preserved.</summary>
+    private static double[] SolveDense(double[] mIn, double[] b, int m)
+    {
+        var a = (double[])mIn.Clone();
+        var y = (double[])b.Clone();
+        for (int col = 0; col < m; col++)
+        {
+            // Partial pivot.
+            int piv = col;
+            double best = Math.Abs(a[col * m + col]);
+            for (int r = col + 1; r < m; r++)
+            {
+                double val = Math.Abs(a[r * m + col]);
+                if (val > best) { best = val; piv = r; }
+            }
+            if (piv != col)
+            {
+                for (int j = 0; j < m; j++) { (a[col * m + j], a[piv * m + j]) = (a[piv * m + j], a[col * m + j]); }
+                (y[col], y[piv]) = (y[piv], y[col]);
+            }
+            double diag = a[col * m + col];
+            if (diag == 0.0) diag = 1e-300; // guard; shift keeps M non-singular in practice
+            for (int r = col + 1; r < m; r++)
+            {
+                double f = a[r * m + col] / diag;
+                if (f == 0.0) continue;
+                for (int j = col; j < m; j++) a[r * m + j] -= f * a[col * m + j];
+                y[r] -= f * y[col];
+            }
+        }
+        // Back-substitution.
+        var x = new double[m];
+        for (int i = m - 1; i >= 0; i--)
+        {
+            double s = y[i];
+            for (int j = i + 1; j < m; j++) s -= a[i * m + j] * x[j];
+            double diag = a[i * m + i];
+            x[i] = diag == 0.0 ? 0.0 : s / diag;
+        }
+        return x;
     }
 
     private static void HessenbergReduce(double[] h, double[] q, int n)

--- a/src/AiDotNet.Tensors/LinearAlgebra/Decompositions/LdlDecomposition.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/Decompositions/LdlDecomposition.cs
@@ -70,16 +70,20 @@ internal static class LdlDecomposition
         var ldData = ld.GetDataArray();
         var bData = b.GetDataArray();
         var xData = result.GetDataArray();
+        var pivData = pivots.GetDataArray();
         int matStride = n * n;
         int rhsStride = b.Rank == ld.Rank ? n * nrhs : n;
+        int pivStride = n;
 
         for (int ib = 0; ib < batch; ib++)
-            SolveSingle(ldData, ib * matStride, bData, ib * rhsStride, xData, ib * rhsStride, n, nrhs, upper);
+            SolveSingle(ldData, ib * matStride, bData, ib * rhsStride, xData, ib * rhsStride,
+                pivData, ib * pivStride, n, nrhs, upper);
 
         return result;
     }
 
-    private static void SolveSingle<T>(T[] a, int offA, T[] b, int offB, T[] x, int offX, int n, int nrhs, bool upper)
+    private static void SolveSingle<T>(T[] a, int offA, T[] b, int offB, T[] x, int offX,
+        int[] piv, int offPiv, int n, int nrhs, bool upper)
         where T : unmanaged, IEquatable<T>, IComparable<T>
     {
         // Copy RHS into X; we solve in place.
@@ -87,6 +91,14 @@ internal static class LdlDecomposition
 
         for (int c = 0; c < nrhs; c++)
         {
+            // Apply the factorization's symmetric pivoting to the RHS: b' = P·b.
+            // (Forward order, matching how the swaps were applied during Factor.)
+            for (int j = 0; j < n; j++)
+            {
+                int pj = piv[offPiv + j];
+                if (pj != j) (x[offX + j * nrhs + c], x[offX + pj * nrhs + c]) = (x[offX + pj * nrhs + c], x[offX + j * nrhs + c]);
+            }
+
             // Phase 1: forward-solve L·y = b (or Uᵀ·y = b when upper).
             for (int i = 0; i < n; i++)
             {
@@ -121,65 +133,81 @@ internal static class LdlDecomposition
                 }
                 x[offX + i * nrhs + c] = FromDouble<T>(s);
             }
+
+            // Undo the pivoting: x = Pᵀ·z (reverse order of the forward swaps).
+            for (int j = n - 1; j >= 0; j--)
+            {
+                int pj = piv[offPiv + j];
+                if (pj != j) (x[offX + j * nrhs + c], x[offX + pj * nrhs + c]) = (x[offX + pj * nrhs + c], x[offX + j * nrhs + c]);
+            }
         }
     }
 
     private static void FactorSingle<T>(T[] a, int off, int[] piv, int offPiv, int n, bool upper)
         where T : unmanaged, IEquatable<T>, IComparable<T>
     {
-        // Simple Bunch–Kaufman (1×1 block pivoting only). Sufficient for
-        // strictly-diagonally-dominant or positive-definite cases; a future
-        // PR upgrades to full 2×2 block pivoting for strongly indefinite
-        // inputs. The unified lower-triangle loop writes L[i,j] for i>j and
-        // D[i,i] on the diagonal; when `upper` is true we transpose into the
-        // upper triangle afterwards so callers see U = Lᵀ.
+        // Outer-product LDLᵀ with symmetric (diagonal) partial pivoting:
+        // P·A·Pᵀ = L·D·Lᵀ. At each step the largest-magnitude remaining
+        // Schur-complement diagonal is permuted to the pivot position (rows AND
+        // columns swapped to preserve symmetry), then a rank-1 update eliminates
+        // the column. piv[j] records the row swapped with j at step j (LAPACK
+        // style); Solve replays it. This fixes the previous no-pivot path that
+        // produced NaN whenever an (intermediate) diagonal was zero — exactly the
+        // symmetric-INDEFINITE inputs this routine is meant to handle.
+        //
+        // Pivoting is 1×1 only (largest-diagonal rule), which covers the practical
+        // indefinite cases. A fully general matrix whose entire remaining diagonal
+        // is zero (e.g. [[0,1],[1,0]]) would need 2×2 block pivots; that is left as
+        // a tracked follow-up and detected below (D=0 → Solve reports it rather
+        // than silently dividing).
+        var m = new double[n * n];
+        for (int i = 0; i < n; i++)
+            for (int j = 0; j < n; j++)
+                m[i * n + j] = ToDouble(a[off + i * n + j]);
+
         for (int j = 0; j < n; j++)
         {
-            piv[offPiv + j] = j; // Trivial pivots for the simple path.
-            double d = ToDouble(a[off + j * n + j]);
-            for (int k = 0; k < j; k++)
+            // Choose pivot = largest |diagonal| among the remaining rows [j, n).
+            int p = j;
+            double best = Math.Abs(m[j * n + j]);
+            for (int i = j + 1; i < n; i++)
             {
-                double l_jk = ToDouble(a[off + j * n + k]);
-                double d_k = ToDouble(a[off + k * n + k]);
-                d -= l_jk * l_jk * d_k;
+                double val = Math.Abs(m[i * n + i]);
+                if (val > best) { best = val; p = i; }
             }
-            a[off + j * n + j] = FromDouble<T>(d);
-            if (d == 0.0) continue;
+            piv[offPiv + j] = p;
+            if (p != j)
+            {
+                for (int k = 0; k < n; k++) (m[j * n + k], m[p * n + k]) = (m[p * n + k], m[j * n + k]); // swap rows
+                for (int k = 0; k < n; k++) (m[k * n + j], m[k * n + p]) = (m[k * n + p], m[k * n + j]); // swap cols
+            }
+
+            double d = m[j * n + j];
+            if (d == 0.0) continue; // 2×2-pivot-essential block; D[j]=0 (see remark above)
 
             for (int i = j + 1; i < n; i++)
             {
-                double s = ToDouble(a[off + i * n + j]);
-                for (int k = 0; k < j; k++)
-                {
-                    double l_ik = ToDouble(a[off + i * n + k]);
-                    double l_jk = ToDouble(a[off + j * n + k]);
-                    double d_k = ToDouble(a[off + k * n + k]);
-                    s -= l_ik * l_jk * d_k;
-                }
-                a[off + i * n + j] = FromDouble<T>(s / d);
+                double lij = m[i * n + j] / d;
+                m[i * n + j] = lij;                               // store L (unit-lower)
+                for (int k = j + 1; k < n; k++)
+                    m[i * n + k] -= lij * m[j * n + k];           // symmetric rank-1 Schur update
             }
         }
 
+        // Pack: D on the diagonal, L strictly below; zero the rest.
+        for (int i = 0; i < n; i++)
+            for (int j = 0; j < n; j++)
+                a[off + i * n + j] = FromDouble<T>(j < i ? m[i * n + j] : (j == i ? m[i * n + i] : 0.0));
+
         if (upper)
         {
-            // Move lower-triangle L into upper-triangle U = Lᵀ, then clear the
-            // lower triangle so the returned factor has U in the upper and
-            // zeros below the diagonal.
+            // Mirror L into U = Lᵀ (upper), clearing the lower triangle.
             for (int i = 0; i < n; i++)
-            {
                 for (int j = 0; j < i; j++)
                 {
                     a[off + j * n + i] = a[off + i * n + j];
                     a[off + i * n + j] = default;
                 }
-            }
-        }
-        else
-        {
-            // Zero upper triangle for a clean L·D·Lᵀ factor view.
-            for (int i = 0; i < n; i++)
-                for (int j = i + 1; j < n; j++)
-                    a[off + i * n + j] = default;
         }
     }
 

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/LinalgTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/LinalgTests.cs
@@ -733,4 +733,154 @@ public class LinalgTests
                     Assert.Equal(expected, qd[b * 9 + i * 3 + j], 10);
                 }
     }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // #376 — managed LAPACK-replacement verification: the general (non-symmetric)
+    // Eig, LDL factor/solve, and rectangular SVD are managed replacements for
+    // native LAPACK (dgeev / dsytrf / dgesvd) but had no correctness coverage.
+    // These reconstruction tests prove the managed routines are correct so the
+    // native-LAPACK-free build is verifiably sound (no eager fallback exists).
+    // Eig output layout: eigenvalues [n,2] (Re,Im); eigenvectors [n,n,2] columns.
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Eig_DiagonalMatrix_ReturnsRealDiagonalEigenvalues()
+    {
+        var A = FromRows(new double[,] { { 2, 0, 0 }, { 0, -3, 0 }, { 0, 0, 5 } });
+        var (valsT, _) = Linalg.Eig(A);
+        var v = valsT.GetDataArray(); // [3,2]
+        var re = new List<double>();
+        for (int i = 0; i < 3; i++)
+        {
+            re.Add(v[i * 2]);
+            Assert.True(Math.Abs(v[i * 2 + 1]) < 1e-9, $"diagonal real matrix → real eigenvalue, got Im={v[i * 2 + 1]}");
+        }
+        re.Sort();
+        Assert.True(Math.Abs(re[0] - (-3)) < 1e-6 && Math.Abs(re[1] - 2) < 1e-6 && Math.Abs(re[2] - 5) < 1e-6,
+            $"eigenvalues should be {{-3,2,5}}, got {{{string.Join(",", re)}}}");
+    }
+
+    [Fact]
+    public void Eig_NonSymmetricMatrix_EigenpairsSatisfyAvEqualsLambdaV()
+    {
+        // Lower-triangular, distinct eigenvalues 2,3,4 → diagonalizable, real spectrum.
+        var A = FromRows(new double[,] { { 2, 0, 0 }, { 1, 3, 0 }, { 0, 1, 4 } });
+        var aD = A.GetDataArray();
+        const int n = 3;
+        var (valsT, vecsT) = Linalg.Eig(A);
+        var val = valsT.GetDataArray();   // [n,2]
+        var vec = vecsT.GetDataArray();   // [n,n,2] — eigenvector j is column j across rows
+        for (int j = 0; j < n; j++)
+        {
+            double lRe = val[j * 2], lIm = val[j * 2 + 1];
+            for (int r = 0; r < n; r++)
+            {
+                // (A·v)_re = A·vRe, (A·v)_im = A·vIm  (A is real)
+                double avRe = 0, avIm = 0;
+                for (int c = 0; c < n; c++)
+                {
+                    avRe += aD[r * n + c] * vec[(c * n + j) * 2];
+                    avIm += aD[r * n + c] * vec[(c * n + j) * 2 + 1];
+                }
+                // (λ·v)_re = λRe·vRe − λIm·vIm ; (λ·v)_im = λRe·vIm + λIm·vRe
+                double vrRe = vec[(r * n + j) * 2], vrIm = vec[(r * n + j) * 2 + 1];
+                double lvRe = lRe * vrRe - lIm * vrIm;
+                double lvIm = lRe * vrIm + lIm * vrRe;
+                Assert.True(Math.Abs(avRe - lvRe) < 1e-6, $"eig{j}: (A·v)re[{r}]={avRe} != (λ·v)re={lvRe}");
+                Assert.True(Math.Abs(avIm - lvIm) < 1e-6, $"eig{j}: (A·v)im[{r}]={avIm} != (λ·v)im={lvIm}");
+            }
+        }
+    }
+
+    [Fact]
+    public void Eig_RotationMatrix_ReturnsConjugateImaginaryPair()
+    {
+        // [[0,-1],[1,0]] → eigenvalues ±i.
+        var A = FromRows(new double[,] { { 0, -1 }, { 1, 0 } });
+        var (valsT, _) = Linalg.Eig(A);
+        var v = valsT.GetDataArray(); // [2,2]
+        for (int i = 0; i < 2; i++)
+            Assert.True(Math.Abs(v[i * 2]) < 1e-6, $"Re(λ{i})={v[i * 2]} should be ~0");
+        double im0 = v[1], im1 = v[3];
+        Assert.True(Math.Abs(Math.Abs(im0) - 1) < 1e-6 && Math.Abs(Math.Abs(im1) - 1) < 1e-6,
+            $"|Im| should be 1, got {im0}, {im1}");
+        Assert.True(Math.Abs(im0 + im1) < 1e-6, "eigenvalues should form a conjugate pair (Im parts sum to 0)");
+    }
+
+    [Fact]
+    public void LdlFactorSolve_SymmetricIndefinite_SolvesSystem()
+    {
+        // [[1,2],[2,1]] is symmetric INDEFINITE (eigenvalues 3, −1) — Cholesky would
+        // fail; LDL with pivoting is the managed dsytrf/dsytrs replacement.
+        var A = FromRows(new double[,] { { 1, 2 }, { 2, 1 } });
+        var b = new Tensor<double>(new[] { 2 });
+        b.GetDataArray()[0] = 5; b.GetDataArray()[1] = 4;
+        var (ld, piv) = Linalg.LdlFactor(A);
+        var x = Linalg.LdlSolve(ld, piv, b);
+        var aD = A.GetDataArray(); var xD = x.GetDataArray();
+        for (int i = 0; i < 2; i++)
+        {
+            double ax = aD[i * 2] * xD[0] + aD[i * 2 + 1] * xD[1];
+            Assert.True(Math.Abs(ax - b.GetDataArray()[i]) < 1e-8, $"A·x[{i}]={ax} != b[{i}]={b.GetDataArray()[i]}");
+        }
+    }
+
+    [Fact]
+    public void LdlFactorSolve_3x3SymmetricIndefinite_SolvesSystem()
+    {
+        var A = FromRows(new double[,] { { 0, 1, 2 }, { 1, 3, 1 }, { 2, 1, 0 } }); // symmetric, indefinite
+        var b = new Tensor<double>(new[] { 3 });
+        b.GetDataArray()[0] = 3; b.GetDataArray()[1] = 5; b.GetDataArray()[2] = 2;
+        var (ld, piv) = Linalg.LdlFactor(A);
+        var x = Linalg.LdlSolve(ld, piv, b);
+        var aD = A.GetDataArray(); var xD = x.GetDataArray();
+        for (int i = 0; i < 3; i++)
+        {
+            double ax = 0; for (int j = 0; j < 3; j++) ax += aD[i * 3 + j] * xD[j];
+            Assert.True(Math.Abs(ax - b.GetDataArray()[i]) < 1e-8, $"A·x[{i}]={ax} != b[{i}]={b.GetDataArray()[i]}");
+        }
+    }
+
+    [Fact]
+    public void Svd_TallMatrix_ReconstructsInputWithOrthonormalU()
+    {
+        var rows = new double[,] { { 1, 2 }, { 3, 4 }, { 5, 6 }, { 7, 8 } }; // 4×2
+        var A = FromRows(rows);
+        var (U, S, Vh) = Linalg.Svd(A, fullMatrices: false);
+        var Umat = ToArray2D(U); var VhMat = ToArray2D(Vh);
+        int k = S.Shape[0];
+        var sD = S.GetDataArray();
+        for (int i = 0; i < k; i++) Assert.True(sD[i] >= -1e-12, $"singular value S[{i}]={sD[i]} is negative");
+        for (int i = 1; i < k; i++) Assert.True(sD[i - 1] >= sD[i] - 1e-9, "singular values must be descending");
+
+        var diagS = new double[k, k];
+        for (int i = 0; i < k; i++) diagS[i, i] = sD[i];
+        var recon = MatMul(MatMul(Umat, diagS), VhMat);
+        AssertClose(FromRows(recon), rows, tol: 1e-4);
+
+        // Uᵀ·U = I_k (orthonormal columns).
+        var utu = MatMul(Transpose(Umat), Umat);
+        var ik = new double[k, k]; for (int i = 0; i < k; i++) ik[i, i] = 1;
+        AssertClose(FromRows(utu), ik, tol: 1e-4);
+    }
+
+    [Fact]
+    public void Svd_WideMatrix_ReconstructsInput()
+    {
+        var rows = new double[,] { { 1, 2, 3, 4 }, { 5, 6, 7, 8 } }; // 2×4
+        var A = FromRows(rows);
+        var (U, S, Vh) = Linalg.Svd(A, fullMatrices: false);
+        var Umat = ToArray2D(U); var VhMat = ToArray2D(Vh);
+        int k = S.Shape[0];
+        var sD = S.GetDataArray();
+        var diagS = new double[k, k];
+        for (int i = 0; i < k; i++) diagS[i, i] = sD[i];
+        var recon = MatMul(MatMul(Umat, diagS), VhMat);
+        AssertClose(FromRows(recon), rows, tol: 1e-4);
+
+        // Vh rows orthonormal: Vh·Vhᵀ = I_k.
+        var vvt = MatMul(VhMat, Transpose(VhMat));
+        var ik = new double[k, k]; for (int i = 0; i < k; i++) ik[i, i] = 1;
+        AssertClose(FromRows(vvt), ik, tol: 1e-4);
+    }
 }


### PR DESCRIPTION
## Summary

Actually completes #376 (LAPACK supply-chain removal). The CPU decompositions were already managed, but two of #376's three acceptance items were never done: the **leakage audit** and **correctness verification**. Doing the verification surfaced — and this fixes — **two real bugs** in routines that had no test coverage.

### 1. Audit (acceptance item 2): no CPU LAPACK leakage ✅
Grepped every native `DllImport` in `src/`. The only LAPACK-family natives are GPU `rocsolver_*` (HIP, GPU-optional). All CPU `libopenblas` / `MklImports` / `mkl_rt.3` imports are `cblas_*` **BLAS GEMM** only (sgemm/dgemm/batch/bf16) — **zero CPU LAPACK**. The managed `LinearAlgebra/Decompositions/` + `Solvers/` are the replacement.

### 2. Bug: `Eig` returned Schur vectors, not eigenvectors
`EigDecomposition` copied the Schur basis `Q` as "eigenvectors" — correct only for the leading/symmetric case. For non-symmetric `A`, `A·v = λ·v` failed for non-leading eigenpairs (eigenvalues were fine). Fixed via **inverse iteration** on the original `A` (shifted by the computed eigenvalue); complex λ handled with the equivalent **2n×2n real system**, so one routine covers real and complex-conjugate eigenpairs. `Linalg.Eig` documents "right eigenvectors" — now honored.

### 3. Bug: LDL did no pivoting → `NaN`
`FactorSingle` set `piv[j]=j` (no pivoting) despite the "Bunch–Kaufman" doc, so any zero/near-zero intermediate diagonal gave `D=0` → divide-by-zero `NaN` — exactly the symmetric-**indefinite** inputs it's meant to handle. Rewrote as outer-product LDLᵀ with **symmetric (diagonal) partial pivoting** (`P·A·Pᵀ = L·D·Lᵀ`), threading the permutation through `Solve`. Fixes the NaN for indefinite inputs with a usable pivot. (Full 2×2 block pivots for all-zero-diagonal cases like `[[0,1],[1,0]]` remain a documented follow-up — detected, not silently wrong.)

### Tests (verification — acceptance item 3)
`LinalgTests` gains: `Eig` (diagonal eigenvalues / non-symmetric `A·v=λ·v` / complex conjugate pair), LDL (2×2 and 3×3 symmetric-indefinite solve), rectangular SVD (tall + wide reconstruction with orthonormality). **48 LinalgTests + 475 LinearAlgebra-namespace tests pass; `net10.0` + `net471` build clean.**

Closes #376.

🤖 Generated with [Claude Code](https://claude.com/claude-code)