### PR TITLE
perf(#405): software prefetch in the AVX-512 microkernels (Sub-O)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Microkernels/Avx512/Avx512Fp32_16x16.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Microkernels/Avx512/Avx512Fp32_16x16.cs
@@ -37,6 +37,15 @@ internal static class Avx512Fp32_16x16
     public static bool IsSupported => Avx512F.IsSupported;
 
     /// <summary>
+    /// Sub-O (#405): software-prefetch lookahead, in K-steps. Each K-step touches
+    /// one Mr-wide packed-A vpanel slice and one Nr-wide packed-B stripe; issuing a
+    /// <see cref="Sse.Prefetch0"/> this many iterations ahead hides the L2→L1 fetch
+    /// latency behind the current step's FMAs (matches the AVX2 kernels). The guard
+    /// <c>k + PrefetchDistance &lt; kc</c> avoids prefetching past the packed buffers.
+    /// </summary>
+    private const int PrefetchDistance = 8;
+
+    /// <summary>
     /// Accumulate packedA · packedB into C[0..Mr, 0..Nr]. C is read-modify-write.
     /// </summary>
     public static unsafe void Run(
@@ -74,6 +83,14 @@ internal static class Avx512Fp32_16x16
             {
                 for (int k = 0; k < kc; k++)
                 {
+                    // Sub-O (#405): prefetch the packed-A vpanel + packed-B stripe
+                    // PrefetchDistance K-steps ahead so the next loads land in L1.
+                    if (k + PrefetchDistance < kc)
+                    {
+                        Sse.Prefetch0(aPtr + (k + PrefetchDistance) * Mr);
+                        Sse.Prefetch0(bPtr + (k + PrefetchDistance) * Nr);
+                    }
+
                     Vector512<float> bRow = Avx512F.LoadVector512(bPtr + k * Nr);
 
                     Vector512<float> a0  = Vector512.Create(aPtr[k * Mr + 0]);

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Microkernels/Avx512/Avx512Fp64_8x16.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Microkernels/Avx512/Avx512Fp64_8x16.cs
@@ -48,6 +48,15 @@ internal static class Avx512Fp64_8x16
     public static bool IsSupported => Avx512F.IsSupported;
 
     /// <summary>
+    /// Sub-O (#405): software-prefetch lookahead, in K-steps. Each K-step reads one
+    /// Mr-wide packed-A slice (one cache line) and one Nr-wide packed-B stripe (two
+    /// 512-bit loads ⇒ two cache lines), so we prefetch A plus both B lines this many
+    /// iterations ahead to hide L2→L1 latency behind the current step's FMAs (matches
+    /// the AVX2 kernels). Guarded by <c>k + PrefetchDistance &lt; kc</c>.
+    /// </summary>
+    private const int PrefetchDistance = 8;
+
+    /// <summary>
     /// Accumulate packedA · packedB into the C[0..Mr, 0..Nr] tile, summing over
     /// kc K-steps. C is read-modify-write; caller is responsible for zero-init
     /// if a fresh result is desired. When kc is 0 the kernel reads + writes C
@@ -93,6 +102,15 @@ internal static class Avx512Fp64_8x16
             {
                 for (int k = 0; k < kc; k++)
                 {
+                    // Sub-O (#405): prefetch packed-A slice + both packed-B cache lines
+                    // PrefetchDistance K-steps ahead so the next loads land in L1.
+                    if (k + PrefetchDistance < kc)
+                    {
+                        Sse.Prefetch0(aPtr + (k + PrefetchDistance) * Mr);
+                        Sse.Prefetch0(bPtr + (k + PrefetchDistance) * Nr + 0);
+                        Sse.Prefetch0(bPtr + (k + PrefetchDistance) * Nr + 8);
+                    }
+
                     // Two vector loads per K-step from packed-B.
                     Vector512<double> bRow_lo = Avx512F.LoadVector512(bPtr + k * Nr + 0);
                     Vector512<double> bRow_hi = Avx512F.LoadVector512(bPtr + k * Nr + 8);

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/MicrokernelCorrectnessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/MicrokernelCorrectnessTests.cs
@@ -1,0 +1,111 @@
+#if NET8_0_OR_GREATER
+using System;
+using AiDotNet.Tensors.Engines.BlasManaged;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+/// <summary>
+/// #405 (Sub-O): direct correctness tests for the BlasManaged register microkernels.
+/// Each kernel accumulates <c>C[i,j] += Σₖ packedA[k·Mr+i]·packedB[k·Nr+j]</c> into a
+/// row-major C tile (ldc = Nr, read-modify-write). These lock the numerics against a
+/// naive double-precision reference so the software-prefetch additions (which are
+/// pure cache hints and must NOT change results) are verified — the AVX2 kernels run
+/// everywhere; the AVX-512 kernels run on AVX-512 hardware (the CI avx512-verify job).
+/// Kernels not supported on the current CPU are skipped (the assert can't run there).
+/// </summary>
+public class MicrokernelCorrectnessTests
+{
+    private const int Kc = 64;
+
+    private static float[] RandomF(int n, int seed)
+    {
+        var rng = new Random(seed);
+        var a = new float[n];
+        for (int i = 0; i < n; i++) a[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+        return a;
+    }
+
+    private static double[] RandomD(int n, int seed)
+    {
+        var rng = new Random(seed);
+        var a = new double[n];
+        for (int i = 0; i < n; i++) a[i] = rng.NextDouble() * 2.0 - 1.0;
+        return a;
+    }
+
+    private static void AssertMatchesReferenceF(float[] a, float[] b, float[] c, int mr, int nr, int kc, double tol)
+    {
+        for (int i = 0; i < mr; i++)
+            for (int j = 0; j < nr; j++)
+            {
+                double expected = 0.0;
+                for (int k = 0; k < kc; k++) expected += (double)a[k * mr + i] * b[k * nr + j];
+                double actual = c[i * nr + j];
+                Assert.True(Math.Abs(actual - expected) < tol,
+                    $"C[{i},{j}] = {actual} != reference {expected} (tol {tol})");
+            }
+    }
+
+    private static void AssertMatchesReferenceD(double[] a, double[] b, double[] c, int mr, int nr, int kc, double tol)
+    {
+        for (int i = 0; i < mr; i++)
+            for (int j = 0; j < nr; j++)
+            {
+                double expected = 0.0;
+                for (int k = 0; k < kc; k++) expected += a[k * mr + i] * b[k * nr + j];
+                double actual = c[i * nr + j];
+                Assert.True(Math.Abs(actual - expected) < tol,
+                    $"C[{i},{j}] = {actual} != reference {expected} (tol {tol})");
+            }
+    }
+
+    [Fact]
+    public void Avx2Fp32_8x8_MatchesReference()
+    {
+        if (!Avx2Fp32_8x8.IsSupported) return;
+        int mr = Avx2Fp32_8x8.Mr, nr = Avx2Fp32_8x8.Nr;
+        var a = RandomF(Kc * mr, 11);
+        var b = RandomF(Kc * nr, 22);
+        var c = new float[mr * nr];
+        Avx2Fp32_8x8.Run(a, b, c, nr, Kc);
+        AssertMatchesReferenceF(a, b, c, mr, nr, Kc, 1e-3);
+    }
+
+    [Fact]
+    public void Avx2Fp64_4x8_MatchesReference()
+    {
+        if (!Avx2Fp64_4x8.IsSupported) return;
+        int mr = Avx2Fp64_4x8.Mr, nr = Avx2Fp64_4x8.Nr;
+        var a = RandomD(Kc * mr, 33);
+        var b = RandomD(Kc * nr, 44);
+        var c = new double[mr * nr];
+        Avx2Fp64_4x8.Run(a, b, c, nr, Kc);
+        AssertMatchesReferenceD(a, b, c, mr, nr, Kc, 1e-10);
+    }
+
+    [Fact]
+    public void Avx512Fp32_16x16_MatchesReference()
+    {
+        if (!Avx512Fp32_16x16.IsSupported) return;
+        int mr = Avx512Fp32_16x16.Mr, nr = Avx512Fp32_16x16.Nr;
+        var a = RandomF(Kc * mr, 55);
+        var b = RandomF(Kc * nr, 66);
+        var c = new float[mr * nr];
+        Avx512Fp32_16x16.Run(a, b, c, nr, Kc);
+        AssertMatchesReferenceF(a, b, c, mr, nr, Kc, 1e-3);
+    }
+
+    [Fact]
+    public void Avx512Fp64_8x16_MatchesReference()
+    {
+        if (!Avx512Fp64_8x16.IsSupported) return;
+        int mr = Avx512Fp64_8x16.Mr, nr = Avx512Fp64_8x16.Nr;
+        var a = RandomD(Kc * mr, 77);
+        var b = RandomD(Kc * nr, 88);
+        var c = new double[mr * nr];
+        Avx512Fp64_8x16.Run(a, b, c, nr, Kc);
+        AssertMatchesReferenceD(a, b, c, mr, nr, Kc, 1e-10);
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

Completes #405 (Sub-O — software prefetch in the register microkernels). The **AVX2** kernels (`Avx2Fp32_8x8`, `Avx2Fp64_4x8`) already issued `Sse.Prefetch0` one stripe ahead; the **AVX-512** kernels had none. This adds the same lookahead to both:

- `Avx512Fp32_16x16` — prefetch the `Mr`-wide packed-A slice + `Nr`-wide packed-B stripe, `PrefetchDistance = 8` K-steps ahead.
- `Avx512Fp64_8x16` — prefetch the A slice + **both** packed-B cache lines (`Nr = 16` doubles spans two lines).

Both guarded by `k + PrefetchDistance < kc` so they never read past the packed buffers. All four register microkernels now prefetch.

## Correctness

Software prefetch is a pure cache hint — it **cannot change computed values** — so this is correctness-neutral by construction. New **`MicrokernelCorrectnessTests`** drive each kernel's `Run()` directly and assert `C[i,j] = Σₖ A[k·Mr+i]·B[k·Nr+j]` against a double-precision reference:
- AVX2 cases run everywhere — **verified locally (4/4 pass)**.
- AVX-512 cases run on AVX-512 hardware — the **`avx512-verify` CI job** executes them (this PR's box is Zen2/AVX2-only, so they no-op locally).

## Benchmark

The existing `--microkernel-gflops` harness (`MicrokernelGflopsBench`) already drives all four kernels in isolation and reports GFLOPS vs the register FMA ceiling — so the prefetch impact is **measurable on AVX-512 hardware** with no new harness needed. Local AVX2 baseline from that bench: **54.8 GFLOPS fp32 (59% of peak) / 33.2 GFLOPS fp64 (66%)**; the AVX-512 kernels report "not supported" on this CPU (hence CI-side verification + on-target benchmarking).

Note: a full-suite run flagged 3 pre-existing perf-**threshold** tests (`BreaksRyuJitCeiling`, `BeatsOpenBlasBudget`, `Delivers_Speedup`) as failing under load; they **pass in isolation on both `main` and this branch** and exercise AVX2/timing paths my AVX-512-only change can't touch.

Closes #405.

🤖 Generated with [Claude Code](https://claude.com/claude-code)