### PR TITLE
perf(#379): specialized BLAS variants — TRSM/SYRK/SYMM/SpMM/GBMV (CPU)

### DIFF
--- a/docs/superpowers/plans/2026-05-30-specialized-blas-variants-p0-p1-trsm.md
+++ b/docs/superpowers/plans/2026-05-30-specialized-blas-variants-p0-p1-trsm.md
@@ -1,0 +1,910 @@
+# Specialized BLAS Variants — P0 (Scaffolding) + P1 (TRSM) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the shared scaffolding (`Side`/`Uplo`/`Diag` enums, `SparseLayout<T>`, perf/determinism harness stubs) and the first variant — a bit-deterministic, drop-in `BlasManaged.Trsm<T>` triangular solve — then rewire the existing managed substitution loops in `LinearSolvers` to use it.
+
+**Architecture:** Approach A from the spec — `Trsm` is a blocked BLIS-style driver: solve each `Mr`-sized diagonal block with a new scalar triangular-solve kernel, then update the trailing right-hand-side via the existing `PackBothStrategy` GEMM macrokernel. TDD throughout: a correct scalar `Trsm` is built and verified against the existing `TriangularSolveSingle` oracle first, then the blocked/macrokernel-reuse optimization is layered in behind the same passing tests.
+
+**Tech Stack:** C# (net8.0 / net6.0 / net471 multi-target), xUnit, the existing `AiDotNet.Tensors.Engines.BlasManaged` infrastructure (microkernels, `PackBothStrategy`, `BlasOptions<T>`, `BlasMode`).
+
+**Spec:** `docs/superpowers/specs/2026-05-30-specialized-blas-variants-design.md` (§3 API, §4 TRSM, §6 phasing).
+
+**Branch:** `feature/379-specialized-blas-variants` (already created; the spec commit is already on it).
+
+---
+
+## File Structure
+
+**Created:**
+- `src/AiDotNet.Tensors/Engines/BlasManaged/SpecializedBlasEnums.cs` — `Side`, `Uplo`, `Diag` enums + `SparseLayout<T>` ref-struct view + `SparseLayoutFormat` enum.
+- `src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Trsm.cs` — `BlasManaged.Trsm<T>` partial-class file (keeps the 800-line `BlasManaged.cs` from growing further; each new variant gets its own partial file).
+- `tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/Catalog/SpecializedShapeCatalog.cs` — per-variant bench shapes (TRSM entries this phase).
+- `tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SpecializedPerfBar.cs` — frozen per-variant perf-bar constants (TRSM stub this phase).
+- `tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/TrsmTests.cs` — correctness + shape-coverage matrix.
+- `tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/TrsmDeterminismTests.cs` — bit-exact across thread counts.
+
+**Modified:**
+- `src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs` — change `public static class BlasManaged` to `public static partial class BlasManaged` so the `.Trsm.cs` partial compiles.
+- `src/AiDotNet.Tensors/LinearAlgebra/Solvers/LinearSolvers.cs:129-163` — rewire `SolveTriangularInternal` to call `BlasManaged.Trsm` for the FP32/FP64 non-batched 2D case; keep `TriangularSolveSingle` as the fallback (batched/other T) and as the test oracle.
+
+---
+
+## Task 1: Make `BlasManaged` a partial class
+
+**Files:**
+- Modify: `src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs:12`
+
+- [ ] **Step 1: Change the class declaration to partial**
+
+In `src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs`, line 12, change:
+
+```csharp
+public static class BlasManaged
+```
+
+to:
+
+```csharp
+public static partial class BlasManaged
+```
+
+- [ ] **Step 2: Build to verify nothing broke**
+
+Run: `dotnet build src/AiDotNet.Tensors/AiDotNet.Tensors.csproj --no-restore -f net8.0`
+Expected: `Build succeeded.` with 0 errors. (`partial` on a single declaration is always legal.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
+git commit -m "refactor(#379): make BlasManaged a partial class for per-variant files"
+```
+
+---
+
+## Task 2: Add the shared enums and `SparseLayout<T>`
+
+**Files:**
+- Create: `src/AiDotNet.Tensors/Engines/BlasManaged/SpecializedBlasEnums.cs`
+
+- [ ] **Step 1: Write the file**
+
+Create `src/AiDotNet.Tensors/Engines/BlasManaged/SpecializedBlasEnums.cs`:
+
+```csharp
+using System;
+
+namespace AiDotNet.Tensors.Engines.BlasManaged;
+
+/// <summary>Which side of the product the triangular/symmetric operand sits on.</summary>
+public enum Side
+{
+    /// <summary>op(A) is on the left: op(A)·X = B  (TRSM) or C = A·B (SYMM).</summary>
+    Left,
+    /// <summary>op(A) is on the right: X·op(A) = B (TRSM) or C = B·A (SYMM).</summary>
+    Right,
+}
+
+/// <summary>Which triangle of a triangular/symmetric matrix is referenced.</summary>
+public enum Uplo
+{
+    /// <summary>Upper triangle (including diagonal) holds the data.</summary>
+    Upper,
+    /// <summary>Lower triangle (including diagonal) holds the data.</summary>
+    Lower,
+}
+
+/// <summary>Whether a triangular matrix has an implicit unit diagonal.</summary>
+public enum Diag
+{
+    /// <summary>Diagonal entries are read from the matrix.</summary>
+    NonUnit,
+    /// <summary>Diagonal entries are assumed to be 1 and not read.</summary>
+    Unit,
+}
+
+/// <summary>Storage format of a <see cref="SparseLayout{T}"/> view.</summary>
+public enum SparseLayoutFormat
+{
+    /// <summary>Compressed Sparse Row: RowPtr length = Rows+1, Indices = column indices.</summary>
+    Csr,
+    /// <summary>Compressed Sparse Column: RowPtr length = Cols+1, Indices = row indices.</summary>
+    Csc,
+}
+
+/// <summary>
+/// Allocation-free readonly view over a CSR/CSC sparse matrix, decoupled from the
+/// heap <see cref="AiDotNet.Tensors.LinearAlgebra.SparseTensor{T}"/> class so
+/// <see cref="BlasManaged.SpMM{T}"/> can be called from hot paths without boxing.
+/// For CSR, <see cref="Pointers"/> is the row-pointer array (length Rows+1) and
+/// <see cref="Indices"/> holds column indices. For CSC the roles transpose.
+/// </summary>
+public readonly ref struct SparseLayout<T> where T : unmanaged
+{
+    /// <summary>Number of rows in the logical (dense-equivalent) matrix.</summary>
+    public int Rows { get; init; }
+    /// <summary>Number of columns in the logical (dense-equivalent) matrix.</summary>
+    public int Cols { get; init; }
+    /// <summary>Row pointers (CSR) or column pointers (CSC).</summary>
+    public ReadOnlySpan<int> Pointers { get; init; }
+    /// <summary>Column indices (CSR) or row indices (CSC).</summary>
+    public ReadOnlySpan<int> Indices { get; init; }
+    /// <summary>Nonzero values, parallel to <see cref="Indices"/>.</summary>
+    public ReadOnlySpan<T> Values { get; init; }
+    /// <summary>Which compressed format the spans encode.</summary>
+    public SparseLayoutFormat Format { get; init; }
+}
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `dotnet build src/AiDotNet.Tensors/AiDotNet.Tensors.csproj --no-restore -f net8.0`
+Expected: `Build succeeded.` 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/AiDotNet.Tensors/Engines/BlasManaged/SpecializedBlasEnums.cs
+git commit -m "feat(#379): add Side/Uplo/Diag enums and SparseLayout<T> view"
+```
+
+---
+
+## Task 3: Write the failing TRSM correctness test (FP64, the simplest case)
+
+**Files:**
+- Create: `tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/TrsmTests.cs`
+
+The oracle is a naive in-test reference solve (independent of the production code so the test can't be satisfied by a no-op). We start with the single simplest case: left, lower, non-transposed, non-unit, single RHS.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/TrsmTests.cs`:
+
+```csharp
+using System;
+using AiDotNet.Tensors.Engines.BlasManaged;
+using Xunit;
+using BlasManagedLib = AiDotNet.Tensors.Engines.BlasManaged.BlasManaged;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+[Collection("BlasManaged-Stats-Serial")]
+public class TrsmTests
+{
+    // Naive reference: solve op(A)·X = alpha·B in place, row-major, left side.
+    // Independent of production code so it is a genuine oracle.
+    private static void ReferenceTrsmLeft(
+        Side side, Uplo uplo, bool transA, Diag diag,
+        int m, int n, double alpha,
+        double[] a, int lda, double[] b, int ldb)
+    {
+        // Scale B by alpha first.
+        for (int i = 0; i < m; i++)
+            for (int j = 0; j < n; j++)
+                b[i * ldb + j] *= alpha;
+
+        // Effective triangular access: A(r,c) with optional transpose.
+        double A(int r, int c) => transA ? a[c * lda + r] : a[r * lda + c];
+
+        bool lower = (uplo == Uplo.Lower) ^ transA; // transpose flips triangle
+        if (side != Side.Left) throw new NotSupportedException("test covers Left only here");
+
+        if (lower)
+        {
+            // Forward substitution: row 0..m-1
+            for (int i = 0; i < m; i++)
+                for (int j = 0; j < n; j++)
+                {
+                    double sum = b[i * ldb + j];
+                    for (int kk = 0; kk < i; kk++) sum -= A(i, kk) * b[kk * ldb + j];
+                    b[i * ldb + j] = diag == Diag.Unit ? sum : sum / A(i, i);
+                }
+        }
+        else
+        {
+            // Back substitution: row m-1..0
+            for (int i = m - 1; i >= 0; i--)
+                for (int j = 0; j < n; j++)
+                {
+                    double sum = b[i * ldb + j];
+                    for (int kk = i + 1; kk < m; kk++) sum -= A(i, kk) * b[kk * ldb + j];
+                    b[i * ldb + j] = diag == Diag.Unit ? sum : sum / A(i, i);
+                }
+        }
+    }
+
+    [Fact]
+    public void Trsm_FP64_LeftLowerNoTransNonUnit_SingleRhs_MatchesReference()
+    {
+        const int m = 5, n = 1;
+        var rng = new Random(42);
+        double[] a = new double[m * m];
+        double[] b = new double[m * n];
+        // Lower-triangular A with a strong diagonal so it is well-conditioned.
+        for (int i = 0; i < m; i++)
+        {
+            for (int j = 0; j <= i; j++) a[i * m + j] = rng.NextDouble() * 2 - 1;
+            a[i * m + i] += m; // dominant diagonal
+        }
+        for (int i = 0; i < b.Length; i++) b[i] = rng.NextDouble() * 2 - 1;
+
+        double[] expected = (double[])b.Clone();
+        ReferenceTrsmLeft(Side.Left, Uplo.Lower, false, Diag.NonUnit, m, n, 1.0, a, m, expected, n);
+
+        double[] actual = (double[])b.Clone();
+        BlasManagedLib.Trsm<double>(
+            Side.Left, Uplo.Lower, transA: false, Diag.NonUnit,
+            m, n, 1.0, a, m, actual, n);
+
+        for (int i = 0; i < actual.Length; i++)
+            Assert.Equal(expected[i], actual[i], 10); // 10 decimal places
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails to compile / fail**
+
+Run: `dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --filter "FullyQualifiedName~TrsmTests" -f net8.0`
+Expected: **compile error** `'BlasManaged' does not contain a definition for 'Trsm'` (the method does not exist yet). This confirms the test exercises the new API.
+
+---
+
+## Task 4: Implement a correct scalar `Trsm<T>` (make the test pass)
+
+**Files:**
+- Create: `src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Trsm.cs`
+
+This first implementation is **scalar and correct, not yet fast** — TDD's "minimal code to pass." The blocked/macrokernel optimization is Task 7, layered in behind the same tests.
+
+- [ ] **Step 1: Write the scalar implementation**
+
+Create `src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Trsm.cs`:
+
+```csharp
+using System;
+using AiDotNet.Tensors.Helpers;
+
+namespace AiDotNet.Tensors.Engines.BlasManaged;
+
+public static partial class BlasManaged
+{
+    /// <summary>
+    /// Triangular solve. Computes op(A)·X = α·B (Left) or X·op(A) = α·B (Right),
+    /// overwriting B with X. A is the <paramref name="uplo"/> triangle of an
+    /// m×m (Left) or n×n (Right) matrix; op(A) is A or Aᵀ per <paramref name="transA"/>.
+    /// Drop-in for cblas_strsm/cblas_dtrsm (row-major; order is fixed RowMajor).
+    /// </summary>
+    public static void Trsm<T>(
+        Side side, Uplo uplo, bool transA, Diag diag,
+        int m, int n, T alpha,
+        ReadOnlySpan<T> a, int lda,
+        Span<T> b, int ldb,
+        in BlasOptions<T> options = default) where T : unmanaged
+    {
+        if (m <= 0 || n <= 0) return;
+        var ops = MathHelper.GetNumericOperations<T>();
+
+        // Scale B by alpha (BLAS semantics: solve against alpha·B).
+        for (int i = 0; i < m; i++)
+            for (int j = 0; j < n; j++)
+            {
+                int idx = i * ldb + j;
+                b[idx] = ops.Multiply(b[idx], alpha);
+            }
+
+        if (side == Side.Left)
+            TrsmLeftScalar(uplo, transA, diag, m, n, a, lda, b, ldb, ops);
+        else
+            TrsmRightScalar(uplo, transA, diag, m, n, a, lda, b, ldb, ops);
+    }
+
+    private static void TrsmLeftScalar<T>(
+        Uplo uplo, bool transA, Diag diag, int m, int n,
+        ReadOnlySpan<T> a, int lda, Span<T> b, int ldb,
+        AiDotNet.Tensors.LinearAlgebra.INumericOperations<T> ops) where T : unmanaged
+    {
+        // Effective triangle after optional transpose.
+        bool lower = (uplo == Uplo.Lower) ^ transA;
+
+        // A(r,c) honoring transpose.
+        T A(int r, int c) => transA ? a[c * lda + r] : a[r * lda + c];
+
+        if (lower)
+        {
+            for (int i = 0; i < m; i++)
+                for (int j = 0; j < n; j++)
+                {
+                    T sum = b[i * ldb + j];
+                    for (int kk = 0; kk < i; kk++)
+                        sum = ops.Subtract(sum, ops.Multiply(A(i, kk), b[kk * ldb + j]));
+                    b[i * ldb + j] = diag == Diag.Unit ? sum : ops.Divide(sum, A(i, i));
+                }
+        }
+        else
+        {
+            for (int i = m - 1; i >= 0; i--)
+                for (int j = 0; j < n; j++)
+                {
+                    T sum = b[i * ldb + j];
+                    for (int kk = i + 1; kk < m; kk++)
+                        sum = ops.Subtract(sum, ops.Multiply(A(i, kk), b[kk * ldb + j]));
+                    b[i * ldb + j] = diag == Diag.Unit ? sum : ops.Divide(sum, A(i, i));
+                }
+        }
+    }
+
+    private static void TrsmRightScalar<T>(
+        Uplo uplo, bool transA, Diag diag, int m, int n,
+        ReadOnlySpan<T> a, int lda, Span<T> b, int ldb,
+        AiDotNet.Tensors.LinearAlgebra.INumericOperations<T> ops) where T : unmanaged
+    {
+        // Right solve X·op(A) = B with A n×n. Effective triangle after transpose.
+        bool lower = (uplo == Uplo.Lower) ^ transA;
+        T A(int r, int c) => transA ? a[c * lda + r] : a[r * lda + c];
+
+        if (!lower)
+        {
+            // X·U = B : columns left-to-right.
+            for (int j = 0; j < n; j++)
+                for (int i = 0; i < m; i++)
+                {
+                    T sum = b[i * ldb + j];
+                    for (int kk = 0; kk < j; kk++)
+                        sum = ops.Subtract(sum, ops.Multiply(b[i * ldb + kk], A(kk, j)));
+                    b[i * ldb + j] = diag == Diag.Unit ? sum : ops.Divide(sum, A(j, j));
+                }
+        }
+        else
+        {
+            // X·L = B : columns right-to-left.
+            for (int j = n - 1; j >= 0; j--)
+                for (int i = 0; i < m; i++)
+                {
+                    T sum = b[i * ldb + j];
+                    for (int kk = j + 1; kk < n; kk++)
+                        sum = ops.Subtract(sum, ops.Multiply(b[i * ldb + kk], A(kk, j)));
+                    b[i * ldb + j] = diag == Diag.Unit ? sum : ops.Divide(sum, A(j, j));
+                }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Verify `INumericOperations<T>` has `Subtract`/`Multiply`/`Divide`**
+
+Run: `grep -nE "T (Subtract|Multiply|Divide)\(" src/AiDotNet.Tensors/LinearAlgebra/INumericOperations.cs`
+Expected: all three method signatures print. (They are the standard generic-math ops used throughout the codebase. If the namespace of `INumericOperations<T>` differs, fix the fully-qualified name in the file accordingly — confirm with `grep -rn "interface INumericOperations" src/`.)
+
+- [ ] **Step 3: Run the test to verify it passes**
+
+Run: `dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --filter "FullyQualifiedName~Trsm_FP64_LeftLowerNoTransNonUnit_SingleRhs_MatchesReference" -f net8.0`
+Expected: `Passed!  - Failed: 0, Passed: 1`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Trsm.cs tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/TrsmTests.cs
+git commit -m "feat(#379): scalar-correct BlasManaged.Trsm<T> + first correctness test"
+```
+
+---
+
+## Task 5: Expand the correctness matrix (all Side×Uplo×Trans×Diag, multi-RHS, FP32)
+
+**Files:**
+- Modify: `tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/TrsmTests.cs`
+
+- [ ] **Step 1: Add the parameterized full-matrix test**
+
+Append to `TrsmTests.cs` (inside the class). The reference for Right-side is added here; reuse `ReferenceTrsmLeft` for Left.
+
+```csharp
+    private static void ReferenceTrsmRight(
+        Uplo uplo, bool transA, Diag diag, int m, int n,
+        double alpha, double[] a, int lda, double[] b, int ldb)
+    {
+        for (int i = 0; i < m; i++)
+            for (int j = 0; j < n; j++) b[i * ldb + j] *= alpha;
+        double A(int r, int c) => transA ? a[c * lda + r] : a[r * lda + c];
+        bool lower = (uplo == Uplo.Lower) ^ transA;
+        if (!lower)
+            for (int j = 0; j < n; j++)
+                for (int i = 0; i < m; i++)
+                {
+                    double sum = b[i * ldb + j];
+                    for (int kk = 0; kk < j; kk++) sum -= b[i * ldb + kk] * A(kk, j);
+                    b[i * ldb + j] = diag == Diag.Unit ? sum : sum / A(j, j);
+                }
+        else
+            for (int j = n - 1; j >= 0; j--)
+                for (int i = 0; i < m; i++)
+                {
+                    double sum = b[i * ldb + j];
+                    for (int kk = j + 1; kk < n; kk++) sum -= b[i * ldb + kk] * A(kk, j);
+                    b[i * ldb + j] = diag == Diag.Unit ? sum : sum / A(j, j);
+                }
+    }
+
+    public static System.Collections.Generic.IEnumerable<object[]> FullMatrix()
+    {
+        foreach (var side in new[] { Side.Left, Side.Right })
+        foreach (var uplo in new[] { Uplo.Upper, Uplo.Lower })
+        foreach (var trans in new[] { false, true })
+        foreach (var diag in new[] { Diag.NonUnit, Diag.Unit })
+            yield return new object[] { side, uplo, trans, diag };
+    }
+
+    [Theory]
+    [MemberData(nameof(FullMatrix))]
+    public void Trsm_FP64_FullCoverage_MultiRhs_MatchesReference(
+        Side side, Uplo uplo, bool trans, Diag diag)
+    {
+        const int m = 7, n = 4;            // multi-RHS
+        int triDim = side == Side.Left ? m : n;
+        var rng = new Random(123);
+        double[] a = new double[triDim * triDim];
+        for (int i = 0; i < triDim; i++)
+        {
+            for (int j = 0; j < triDim; j++)
+                if ((uplo == Uplo.Upper && j >= i) || (uplo == Uplo.Lower && j <= i))
+                    a[i * triDim + j] = rng.NextDouble() * 2 - 1;
+            a[i * triDim + i] += triDim; // dominant diagonal
+        }
+        double[] b = new double[m * n];
+        for (int i = 0; i < b.Length; i++) b[i] = rng.NextDouble() * 2 - 1;
+
+        double[] expected = (double[])b.Clone();
+        if (side == Side.Left)
+            ReferenceTrsmLeft(side, uplo, trans, diag, m, n, 1.0, a, triDim, expected, n);
+        else
+            ReferenceTrsmRight(uplo, trans, diag, m, n, 1.0, a, triDim, expected, n);
+
+        double[] actual = (double[])b.Clone();
+        BlasManagedLib.Trsm<double>(side, uplo, trans, diag, m, n, 1.0, a, triDim, actual, n);
+
+        for (int i = 0; i < actual.Length; i++)
+            Assert.Equal(expected[i], actual[i], 9);
+    }
+
+    [Fact]
+    public void Trsm_FP32_LeftLower_MatchesReference()
+    {
+        const int m = 6, n = 3;
+        var rng = new Random(7);
+        float[] a = new float[m * m];
+        for (int i = 0; i < m; i++)
+        {
+            for (int j = 0; j <= i; j++) a[i * m + j] = (float)(rng.NextDouble() * 2 - 1);
+            a[i * m + i] += m;
+        }
+        float[] b = new float[m * n];
+        for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+
+        // FP64 reference for accuracy.
+        double[] a64 = Array.ConvertAll(a, x => (double)x);
+        double[] e64 = new double[b.Length];
+        for (int i = 0; i < b.Length; i++) e64[i] = b[i];
+        ReferenceTrsmLeft(Side.Left, Uplo.Lower, false, Diag.NonUnit, m, n, 1.0, a64, m, e64, n);
+
+        float[] actual = (float[])b.Clone();
+        BlasManagedLib.Trsm<float>(Side.Left, Uplo.Lower, false, Diag.NonUnit, m, n, 1f, a, m, actual, n);
+
+        for (int i = 0; i < actual.Length; i++)
+            Assert.Equal(e64[i], actual[i], 3); // FP32: 3 decimal places
+    }
+
+    [Fact]
+    public void Trsm_Alpha_ScalesRightHandSide()
+    {
+        const int m = 4, n = 2;
+        var rng = new Random(99);
+        double[] a = new double[m * m];
+        for (int i = 0; i < m; i++) { for (int j = 0; j <= i; j++) a[i*m+j] = rng.NextDouble(); a[i*m+i] += m; }
+        double[] b = new double[m * n];
+        for (int i = 0; i < b.Length; i++) b[i] = rng.NextDouble();
+
+        double[] expected = (double[])b.Clone();
+        ReferenceTrsmLeft(Side.Left, Uplo.Lower, false, Diag.NonUnit, m, n, 2.5, a, m, expected, n);
+        double[] actual = (double[])b.Clone();
+        BlasManagedLib.Trsm<double>(Side.Left, Uplo.Lower, false, Diag.NonUnit, m, n, 2.5, a, m, actual, n);
+        for (int i = 0; i < actual.Length; i++) Assert.Equal(expected[i], actual[i], 9);
+    }
+```
+
+- [ ] **Step 2: Run the full TRSM test class**
+
+Run: `dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --filter "FullyQualifiedName~TrsmTests" -f net8.0`
+Expected: `Passed!` — 16 (full matrix) + 1 (FP32) + 1 (alpha) + 1 (original) = 19 tests pass, 0 fail.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/TrsmTests.cs
+git commit -m "test(#379): full Side×Uplo×Trans×Diag + FP32 + alpha coverage for Trsm"
+```
+
+---
+
+## Task 6: Determinism test across thread counts
+
+**Files:**
+- Create: `tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/TrsmDeterminismTests.cs`
+
+The scalar impl ignores `NumThreads`, so this passes trivially now and acts as the **guard** that Task 7's parallel optimization must not break.
+
+- [ ] **Step 1: Write the determinism test**
+
+Create `tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/TrsmDeterminismTests.cs`:
+
+```csharp
+using System;
+using AiDotNet.Tensors.Engines.BlasManaged;
+using Xunit;
+using BlasManagedLib = AiDotNet.Tensors.Engines.BlasManaged.BlasManaged;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+[Collection("BlasManaged-Stats-Serial")]
+public class TrsmDeterminismTests
+{
+    [Theory]
+    [InlineData(64, 32)]
+    [InlineData(128, 16)]
+    [InlineData(256, 8)]
+    public void Trsm_FP64_BitExactAcrossThreadCounts(int m, int n)
+    {
+        var rng = new Random(42);
+        double[] a = new double[m * m];
+        for (int i = 0; i < m; i++)
+        {
+            for (int j = 0; j <= i; j++) a[i * m + j] = rng.NextDouble() * 2 - 1;
+            a[i * m + i] += m;
+        }
+        double[] b0 = new double[m * n];
+        for (int i = 0; i < b0.Length; i++) b0[i] = rng.NextDouble() * 2 - 1;
+
+        double[]? baseline = null;
+        foreach (int threads in new[] { 1, 2, 4, 8 })
+        {
+            double[] actual = (double[])b0.Clone();
+            var opts = new BlasOptions<double> { NumThreads = threads, Mode = BlasMode.Deterministic };
+            BlasManagedLib.Trsm<double>(Side.Left, Uplo.Lower, false, Diag.NonUnit, m, n, 1.0, a, m, actual, n, opts);
+            if (baseline is null) baseline = actual;
+            else
+                for (int i = 0; i < actual.Length; i++)
+                    Assert.Equal(baseline[i], actual[i]); // EXACT bit equality, no tolerance
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --filter "FullyQualifiedName~TrsmDeterminismTests" -f net8.0`
+Expected: `Passed!` 3 tests, 0 fail.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/TrsmDeterminismTests.cs
+git commit -m "test(#379): Trsm bit-exact determinism guard across thread counts"
+```
+
+---
+
+## Task 7: Blocked TRSM with GEMM-macrokernel trailing updates (the optimization)
+
+**Files:**
+- Modify: `src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Trsm.cs`
+
+Replace the trailing inner loops with blocked panels: solve a small diagonal block with the scalar kernel, then subtract its contribution from the remaining RHS using the existing `PackBothStrategy.Run` GEMM macrokernel. The scalar kernel from Task 4 stays as the per-block solver and the small-`m` fast path.
+
+- [ ] **Step 1: Read the macrokernel entry signature you will call**
+
+Run: `sed -n '59,73p' src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs`
+Expected: prints the `public static unsafe void Run<T>(...)` parameter list. Confirm the parameter order (a, lda, transA, b, ldb, transB, c, ldc, m, n, k, mc, nc, kc, mr, nr, …) before writing the call. If the trailing tuning params (mc/nc/kc/mr/nr) are non-trivial to supply directly, call the public `BlasManaged.Gemm<T>` dispatcher instead (it selects them) — see Step 2's note.
+
+- [ ] **Step 2: Add the blocked driver**
+
+In `BlasManaged.Trsm.cs`, add a blocked path used when `m` (Left) or `n` (Right) exceeds a block threshold, and route `Trsm` to it. Use the public `Gemm<T>` for trailing updates to avoid duplicating tile-size selection (it computes `C := A·B`; we need `B -= A·X`, so compute into a scratch tile and subtract — or pass a negative-alpha equivalent via a temporary). Concrete Left-Lower-NoTrans implementation:
+
+```csharp
+    // Block size for the diagonal-solve / trailing-update split. 64 keeps the
+    // diagonal block in L1 while giving the GEMM macrokernel a worthwhile panel.
+    private const int TrsmBlock = 64;
+
+    private static void TrsmLeftLowerNoTransBlocked<T>(
+        Diag diag, int m, int n,
+        ReadOnlySpan<T> a, int lda, Span<T> b, int ldb,
+        in BlasOptions<T> options,
+        AiDotNet.Tensors.LinearAlgebra.INumericOperations<T> ops) where T : unmanaged
+    {
+        for (int i0 = 0; i0 < m; i0 += TrsmBlock)
+        {
+            int bm = Math.Min(TrsmBlock, m - i0);
+
+            // 1) Solve the bm×n diagonal block with the scalar kernel.
+            //    The block's own triangle is A[i0:i0+bm, i0:i0+bm].
+            var aDiag = a.Slice(i0 * lda + i0);
+            var bBlock = b.Slice(i0 * ldb);
+            TrsmLeftScalar(Uplo.Lower, false, diag, bm, n, aDiag, lda, bBlock, ldb, ops);
+
+            // 2) Trailing update: for rows below this block,
+            //    B[i0+bm:, :] -= A[i0+bm:, i0:i0+bm] · X[i0:i0+bm, :]
+            int remRows = m - (i0 + bm);
+            if (remRows > 0)
+            {
+                var aSub = a.Slice((i0 + bm) * lda + i0); // remRows × bm panel (lda-strided)
+                var xBlk = b.Slice(i0 * ldb);              // bm × n (just solved), lda=ldb
+                // scratch = aSub · xBlk  (remRows × n)
+                T[] scratch = new T[remRows * n];
+                Gemm<T>(aSub, lda, false, xBlk, ldb, false, scratch, n, remRows, n, bm,
+                        new BlasOptions<T> { NumThreads = options.NumThreads, Mode = options.Mode });
+                var bRem = b.Slice((i0 + bm) * ldb);
+                for (int r = 0; r < remRows; r++)
+                    for (int c = 0; c < n; c++)
+                    {
+                        int bi = r * ldb + c;
+                        bRem[bi] = ops.Subtract(bRem[bi], scratch[r * n + c]);
+                    }
+            }
+        }
+    }
+```
+
+Then route to it from `TrsmLeftScalar`'s caller. In `Trsm<T>`, replace the `side == Side.Left` branch with:
+
+```csharp
+        if (side == Side.Left)
+        {
+            bool lower = (uplo == Uplo.Lower) ^ transA;
+            // Blocked path only for the canonical Left-Lower-NoTrans case in this
+            // phase; all other combinations use the proven scalar kernel. Later
+            // tasks extend blocking to upper/transposed cases.
+            if (m > TrsmBlock && uplo == Uplo.Lower && !transA && lower)
+                TrsmLeftLowerNoTransBlocked(diag, m, n, a, lda, b, ldb, options, ops);
+            else
+                TrsmLeftScalar(uplo, transA, diag, m, n, a, lda, b, ldb, ops);
+        }
+        else
+            TrsmRightScalar(uplo, transA, diag, m, n, a, lda, b, ldb, ops);
+```
+
+> **Note on the trailing-update direction:** the trailing GEMM operates only on rows *below* the just-solved block and on the off-diagonal sub-panel `A[i0+bm:, i0:i0+bm]`, which is fully populated (not triangular), so the dense `Gemm` is exact. Determinism is preserved because `Gemm` in `BlasMode.Deterministic` is itself bit-exact across threads (verified by the existing `DeterminismTests`), and the subtraction order is fixed.
+
+- [ ] **Step 3: Run the full correctness + determinism suite (must still pass)**
+
+Run: `dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --filter "FullyQualifiedName~Trsm" -f net8.0`
+Expected: `Passed!` — all TRSM correctness (19) + determinism (3) tests pass. The blocked path is now exercised by the `256×8` determinism case and the larger correctness cases.
+
+- [ ] **Step 4: Add a large-shape correctness case that forces the blocked path**
+
+Append to `TrsmTests.cs`:
+
+```csharp
+    [Fact]
+    public void Trsm_FP64_LargeLeftLower_BlockedPath_MatchesReference()
+    {
+        const int m = 200, n = 5; // m > TrsmBlock(64) → blocked
+        var rng = new Random(2024);
+        double[] a = new double[m * m];
+        for (int i = 0; i < m; i++)
+        {
+            for (int j = 0; j <= i; j++) a[i * m + j] = rng.NextDouble() * 2 - 1;
+            a[i * m + i] += m;
+        }
+        double[] b = new double[m * n];
+        for (int i = 0; i < b.Length; i++) b[i] = rng.NextDouble() * 2 - 1;
+
+        double[] expected = (double[])b.Clone();
+        ReferenceTrsmLeft(Side.Left, Uplo.Lower, false, Diag.NonUnit, m, n, 1.0, a, m, expected, n);
+        double[] actual = (double[])b.Clone();
+        BlasManagedLib.Trsm<double>(Side.Left, Uplo.Lower, false, Diag.NonUnit, m, n, 1.0, a, m, actual, n);
+        for (int i = 0; i < actual.Length; i++) Assert.Equal(expected[i], actual[i], 8);
+    }
+```
+
+- [ ] **Step 5: Run it**
+
+Run: `dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --filter "FullyQualifiedName~Trsm_FP64_LargeLeftLower" -f net8.0`
+Expected: `Passed!` 1 test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Trsm.cs tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/TrsmTests.cs
+git commit -m "perf(#379): blocked Trsm Left-Lower path reuses GEMM macrokernel for trailing updates"
+```
+
+---
+
+## Task 8: Bench catalog + perf-bar stub
+
+**Files:**
+- Create: `tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/Catalog/SpecializedShapeCatalog.cs`
+- Create: `tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SpecializedPerfBar.cs`
+
+- [ ] **Step 1: Confirm the existing `ShapeCatalog` record shape to mirror it**
+
+Run: `sed -n '1,40p' tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/Catalog/ShapeCatalog.cs`
+Expected: prints the `Shape` record / catalog structure. Mirror its `(Name, M, N, K, …, Frequency, Source)` convention in the new file (adapt fields to TRSM: `Side`, `Uplo`, `M`, `N` instead of `K`).
+
+- [ ] **Step 2: Write the TRSM catalog**
+
+Create `tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/Catalog/SpecializedShapeCatalog.cs`:
+
+```csharp
+using AiDotNet.Tensors.Engines.BlasManaged;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged.Catalog;
+
+/// <summary>Per-variant bench shapes for the #379 specialized BLAS variants.</summary>
+public static class SpecializedShapeCatalog
+{
+    public record TrsmShape(string Name, Side Side, Uplo Uplo, bool TransA, Diag Diag,
+        int M, int N, bool Fp64, int Frequency, string Source);
+
+    public static readonly TrsmShape[] Trsm =
+    {
+        new("Chol_Solve_64x1",   Side.Left, Uplo.Lower, false, Diag.NonUnit,  64,   1, true,  50, "workload:cholesky-solve"),
+        new("Chol_Solve_256x1",  Side.Left, Uplo.Lower, false, Diag.NonUnit, 256,   1, true,  40, "workload:cholesky-solve"),
+        new("QR_BackSub_256x64", Side.Left, Uplo.Upper, false, Diag.NonUnit, 256,  64, true,  30, "workload:qr-backsub"),
+        new("Solve_MultiRhs_512x128", Side.Left, Uplo.Lower, false, Diag.NonUnit, 512, 128, true, 20, "workload:linsolve"),
+        new("Chol_SolveT_256x1", Side.Left, Uplo.Lower, true,  Diag.NonUnit, 256,   1, true,  25, "workload:cholesky-solve-transpose"),
+        new("Solve_FP32_512x64", Side.Left, Uplo.Lower, false, Diag.NonUnit, 512,  64, false, 15, "workload:linsolve-fp32"),
+    };
+}
+```
+
+- [ ] **Step 3: Write the perf-bar stub**
+
+Create `tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SpecializedPerfBar.cs`:
+
+```csharp
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+/// <summary>
+/// Frozen per-variant perf bars for #379. Values are placeholders until the first
+/// authoritative bench run on the self-hosted runner (AIDOTNET_PERF_RUNNER=1) lands,
+/// at which point the project owner sets them in a single gating commit — same
+/// discipline as <see cref="PerfBar"/> for dense GEMM (#368).
+/// </summary>
+public static class SpecializedPerfBar
+{
+    // TRSM vs OpenBLAS strsm/dtrsm on the authoritative runner.
+    public const int    TrsmMinWinRatePercent = 0;     // TO BE SET after first bench
+    public const double TrsmMaxLossMultiple    = 99.0; // TO BE SET after first bench
+    public const string TargetHardwareFingerprint = ""; // captured from runner
+
+    /// <summary>True once the owner has frozen the TRSM bar (non-zero win rate).</summary>
+    public static bool TrsmBarFrozen => TrsmMinWinRatePercent > 0;
+}
+```
+
+> The `0` / `99.0` placeholders are **intentional and documented** (not a plan gap): the bar is set only after real measurement, exactly as `PerfBar.cs` does for dense GEMM. `TrsmBarFrozen` lets the perf-regression test skip until then.
+
+- [ ] **Step 4: Build the test project**
+
+Run: `dotnet build tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --no-restore -f net8.0`
+Expected: `Build succeeded.` 0 errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/Catalog/SpecializedShapeCatalog.cs tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SpecializedPerfBar.cs
+git commit -m "test(#379): TRSM bench catalog + frozen-after-measurement perf-bar stub"
+```
+
+---
+
+## Task 9: Rewire `LinearSolvers.SolveTriangularInternal` to use `BlasManaged.Trsm`
+
+**Files:**
+- Modify: `src/AiDotNet.Tensors/LinearAlgebra/Solvers/LinearSolvers.cs:129-163`
+
+The existing `TriangularSolveSingle` stays (batched / non-FP32-FP64 fallback + oracle). For the common non-batched FP32/FP64 2D case, delegate to `BlasManaged.Trsm`.
+
+- [ ] **Step 1: Read the current `TriangularSolveSingle` to match its triangle/transpose semantics exactly**
+
+Run: `grep -n "TriangularSolveSingle" src/AiDotNet.Tensors/LinearAlgebra/Solvers/LinearSolvers.cs`
+then `sed -n '<line>,<line+60>p'` over its body.
+Expected: confirms `upper`/`transpose`/`unitDiagonal` flag meanings map to `Uplo`/`transA`/`Diag` as: `upper → Uplo.Upper`, `transpose → transA`, `unitDiagonal → Diag.Unit`. (Triangular solve is always Left, alpha=1, here.)
+
+- [ ] **Step 2: Add the delegation in `SolveTriangularInternal`**
+
+In the per-batch loop (`LinearSolvers.cs` ~line 156-160), replace the body of the `for (int bi …)` loop with a typed delegation when `T` is `float`/`double` and the input is non-batched-friendly. Concretely, after the existing setup and before the loop, add:
+
+```csharp
+        // Fast path: route FP32/FP64 to the managed BLAS Trsm kernel (#379).
+        // Triangular solve is always Left side with alpha = 1.
+        bool useBlas = (typeof(T) == typeof(double) || typeof(T) == typeof(float));
+        if (useBlas)
+        {
+            var trsmUplo = upper ? AiDotNet.Tensors.Engines.BlasManaged.Uplo.Upper
+                                 : AiDotNet.Tensors.Engines.BlasManaged.Uplo.Lower;
+            var trsmDiag = unitDiagonal ? AiDotNet.Tensors.Engines.BlasManaged.Diag.Unit
+                                        : AiDotNet.Tensors.Engines.BlasManaged.Diag.NonUnit;
+            for (int bi = 0; bi < batch; bi++)
+            {
+                var aSlice = new ReadOnlySpan<T>(aData, bi * aStride, n * n);
+                var xSlice = new Span<T>(xData, bi * xStride, nrhs == 1 ? n : n * nrhs);
+                AiDotNet.Tensors.Engines.BlasManaged.BlasManaged.Trsm<T>(
+                    AiDotNet.Tensors.Engines.BlasManaged.Side.Left,
+                    trsmUplo, transpose, trsmDiag,
+                    n, nrhs, MathHelper.GetNumericOperations<T>().One,
+                    aSlice, n, xSlice, nrhs);
+            }
+            return x;
+        }
+
+        for (int bi = 0; bi < batch; bi++)
+        {
+            TriangularSolveSingle(
+                aData, bi * aStride,
+                xData, bi * xStride,
+                n, nrhs, upper, transpose, unitDiagonal);
+        }
+
+        return x;
+```
+
+> Confirm `MathHelper.GetNumericOperations<T>().One` exists with `grep -n "T One" src/AiDotNet.Tensors/LinearAlgebra/INumericOperations.cs`; if the property is named differently (e.g. `FromDouble(1.0)`), use that instead.
+
+- [ ] **Step 3: Run the existing linear-solver test suite (the canary)**
+
+Run: `dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --filter "FullyQualifiedName~Solve|FullyQualifiedName~Triangular|FullyQualifiedName~Cholesky|FullyQualifiedName~Lstsq" -f net8.0`
+Expected: `Passed!` — all existing solver/Cholesky/Lstsq tests still pass. Any failure here means the flag mapping in Step 1 is wrong; fix the `Uplo`/`transA`/`Diag` translation, do not weaken the test.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/AiDotNet.Tensors/LinearAlgebra/Solvers/LinearSolvers.cs
+git commit -m "perf(#379): route FP32/FP64 triangular solve through BlasManaged.Trsm"
+```
+
+---
+
+## Task 10: Multi-target build verification + full BlasManaged suite
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Build all target frameworks**
+
+Run: `dotnet build src/AiDotNet.Tensors/AiDotNet.Tensors.csproj --no-restore`
+Expected: `Build succeeded.` for net8.0, net6.0, and net471 (the multi-target set). If net471 errors on a span/`MathHelper` API, gate or adjust — net471 lacks some APIs (see CLAUDE.md note on `GC.GetAllocatedBytesForCurrentThread`).
+
+- [ ] **Step 2: Run the full BlasManaged + solver test surface**
+
+Run: `dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --filter "FullyQualifiedName~BlasManaged|FullyQualifiedName~Trsm|FullyQualifiedName~Solve|FullyQualifiedName~Cholesky" -f net8.0`
+Expected: `Passed!` 0 failures.
+
+- [ ] **Step 3: Final commit if any net471 gating was needed; otherwise nothing to commit.**
+
+```bash
+git add -A
+git commit -m "build(#379): TFM compatibility for Trsm path" || echo "nothing to commit"
+```
+
+---
+
+## Self-Review (completed by plan author)
+
+**Spec coverage (P0+P1 portion):**
+- §3 `Side`/`Uplo`/`Diag` + `SparseLayout<T>` → Task 2 ✓
+- §3 `Trsm` signature (drop-in CBLAS arg order) → Task 4 ✓
+- §4 TRSM blocked driver reusing GEMM macrokernel → Task 7 ✓
+- §4 TRSM determinism (Left independent RHS, GEMM trailing updates bit-exact) → Task 6 + Task 7 note ✓
+- §5 bench catalog + frozen perf bar → Task 8 ✓
+- §5 full Side×Uplo×Trans×Diag correctness matrix → Task 5 ✓
+- §6 P1 call-site rewiring (`LinearSolvers`) with existing tests as canary → Task 9 ✓
+- §6 partial-file-per-variant structure → Task 1 ✓
+
+**Out of this plan (subsequent phase plans):** SYRK (P2), SYMM (P3), CPU SpMM (P4), GBMV (P5), GPU SpMM (P6), vendor removal (P7), and TRSM blocking for the non-Left-Lower cases (the scalar kernel handles them correctly meanwhile). Each gets its own `docs/superpowers/plans/` document once this template lands.
+
+**Placeholder scan:** the only `0`/`99.0`/`""` placeholders are in `SpecializedPerfBar.cs`, intentional and documented (frozen-after-measurement discipline from #368). No `TODO`/`TBD`/"implement later" in code steps.
+
+**Type consistency:** `Trsm<T>` signature is identical in Task 4 (definition), Task 3/5/6 (tests), and Task 9 (call site). Enum names `Side`/`Uplo`/`Diag` consistent throughout. `TrsmBlock`, `TrsmLeftScalar`, `TrsmRightScalar`, `TrsmLeftLowerNoTransBlocked` referenced consistently between Tasks 4 and 7.
+
+**Verification-before-completion notes embedded:** every code task ends with a `dotnet test`/`dotnet build` step and an explicit expected result; `grep` confirmation steps guard the two assumptions that could be wrong (`INumericOperations<T>` method names, `PackBothStrategy.Run` signature, `TriangularSolveSingle` flag semantics).

--- a/docs/superpowers/plans/2026-05-30-specialized-blas-variants-p0-p1-trsm.md
+++ b/docs/superpowers/plans/2026-05-30-specialized-blas-variants-p0-p1-trsm.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Approach A from the spec — `Trsm` is a blocked BLIS-style driver: solve each `Mr`-sized diagonal block with a new scalar triangular-solve kernel, then update the trailing right-hand-side via the existing `PackBothStrategy` GEMM macrokernel. TDD throughout: a correct scalar `Trsm` is built and verified against the existing `TriangularSolveSingle` oracle first, then the blocked/macrokernel-reuse optimization is layered in behind the same passing tests.
 
-**Tech Stack:** C# (net8.0 / net6.0 / net471 multi-target), xUnit, the existing `AiDotNet.Tensors.Engines.BlasManaged` infrastructure (microkernels, `PackBothStrategy`, `BlasOptions<T>`, `BlasMode`).
+**Tech Stack:** C# (net10.0 / net471 multi-target), xUnit, the existing `AiDotNet.Tensors.Engines.BlasManaged` infrastructure (microkernels, `PackBothStrategy`, `BlasOptions<T>`, `BlasMode`).
 
 **Spec:** `docs/superpowers/specs/2026-05-30-specialized-blas-variants-design.md` (§3 API, §4 TRSM, §6 phasing).
 
@@ -51,7 +51,7 @@ public static partial class BlasManaged
 
 - [ ] **Step 2: Build to verify nothing broke**
 
-Run: `dotnet build src/AiDotNet.Tensors/AiDotNet.Tensors.csproj --no-restore -f net8.0`
+Run: `dotnet build src/AiDotNet.Tensors/AiDotNet.Tensors.csproj --no-restore -f net10.0`
 Expected: `Build succeeded.` with 0 errors. (`partial` on a single declaration is always legal.)
 
 - [ ] **Step 3: Commit**
@@ -139,7 +139,7 @@ public readonly ref struct SparseLayout<T> where T : unmanaged
 
 - [ ] **Step 2: Build to verify it compiles**
 
-Run: `dotnet build src/AiDotNet.Tensors/AiDotNet.Tensors.csproj --no-restore -f net8.0`
+Run: `dotnet build src/AiDotNet.Tensors/AiDotNet.Tensors.csproj --no-restore -f net10.0`
 Expected: `Build succeeded.` 0 errors.
 
 - [ ] **Step 3: Commit**
@@ -246,7 +246,7 @@ public class TrsmTests
 
 - [ ] **Step 2: Run the test to verify it fails to compile / fail**
 
-Run: `dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --filter "FullyQualifiedName~TrsmTests" -f net8.0`
+Run: `dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --filter "FullyQualifiedName~TrsmTests" -f net10.0`
 Expected: **compile error** `'BlasManaged' does not contain a definition for 'Trsm'` (the method does not exist yet). This confirms the test exercises the new API.
 
 ---
@@ -379,7 +379,7 @@ Expected: all three method signatures print. (They are the standard generic-math
 
 - [ ] **Step 3: Run the test to verify it passes**
 
-Run: `dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --filter "FullyQualifiedName~Trsm_FP64_LeftLowerNoTransNonUnit_SingleRhs_MatchesReference" -f net8.0`
+Run: `dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --filter "FullyQualifiedName~Trsm_FP64_LeftLowerNoTransNonUnit_SingleRhs_MatchesReference" -f net10.0`
 Expected: `Passed!  - Failed: 0, Passed: 1`.
 
 - [ ] **Step 4: Commit**
@@ -515,7 +515,7 @@ Append to `TrsmTests.cs` (inside the class). The reference for Right-side is add
 
 - [ ] **Step 2: Run the full TRSM test class**
 
-Run: `dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --filter "FullyQualifiedName~TrsmTests" -f net8.0`
+Run: `dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --filter "FullyQualifiedName~TrsmTests" -f net10.0`
 Expected: `Passed!` — 16 (full matrix) + 1 (FP32) + 1 (alpha) + 1 (original) = 19 tests pass, 0 fail.
 
 - [ ] **Step 3: Commit**
@@ -582,7 +582,7 @@ public class TrsmDeterminismTests
 
 - [ ] **Step 2: Run it**
 
-Run: `dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --filter "FullyQualifiedName~TrsmDeterminismTests" -f net8.0`
+Run: `dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --filter "FullyQualifiedName~TrsmDeterminismTests" -f net10.0`
 Expected: `Passed!` 3 tests, 0 fail.
 
 - [ ] **Step 3: Commit**
@@ -676,7 +676,7 @@ Then route to it from `TrsmLeftScalar`'s caller. In `Trsm<T>`, replace the `side
 
 - [ ] **Step 3: Run the full correctness + determinism suite (must still pass)**
 
-Run: `dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --filter "FullyQualifiedName~Trsm" -f net8.0`
+Run: `dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --filter "FullyQualifiedName~Trsm" -f net10.0`
 Expected: `Passed!` — all TRSM correctness (19) + determinism (3) tests pass. The blocked path is now exercised by the `256×8` determinism case and the larger correctness cases.
 
 - [ ] **Step 4: Add a large-shape correctness case that forces the blocked path**
@@ -708,7 +708,7 @@ Append to `TrsmTests.cs`:
 
 - [ ] **Step 5: Run it**
 
-Run: `dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --filter "FullyQualifiedName~Trsm_FP64_LargeLeftLower" -f net8.0`
+Run: `dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --filter "FullyQualifiedName~Trsm_FP64_LargeLeftLower" -f net10.0`
 Expected: `Passed!` 1 test.
 
 - [ ] **Step 6: Commit**
@@ -787,7 +787,7 @@ public static class SpecializedPerfBar
 
 - [ ] **Step 4: Build the test project**
 
-Run: `dotnet build tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --no-restore -f net8.0`
+Run: `dotnet build tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --no-restore -f net10.0`
 Expected: `Build succeeded.` 0 errors.
 
 - [ ] **Step 5: Commit**
@@ -854,7 +854,7 @@ In the per-batch loop (`LinearSolvers.cs` ~line 156-160), replace the body of th
 
 - [ ] **Step 3: Run the existing linear-solver test suite (the canary)**
 
-Run: `dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --filter "FullyQualifiedName~Solve|FullyQualifiedName~Triangular|FullyQualifiedName~Cholesky|FullyQualifiedName~Lstsq" -f net8.0`
+Run: `dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --filter "FullyQualifiedName~Solve|FullyQualifiedName~Triangular|FullyQualifiedName~Cholesky|FullyQualifiedName~Lstsq" -f net10.0`
 Expected: `Passed!` — all existing solver/Cholesky/Lstsq tests still pass. Any failure here means the flag mapping in Step 1 is wrong; fix the `Uplo`/`transA`/`Diag` translation, do not weaken the test.
 
 - [ ] **Step 4: Commit**
@@ -873,11 +873,11 @@ git commit -m "perf(#379): route FP32/FP64 triangular solve through BlasManaged.
 - [ ] **Step 1: Build all target frameworks**
 
 Run: `dotnet build src/AiDotNet.Tensors/AiDotNet.Tensors.csproj --no-restore`
-Expected: `Build succeeded.` for net8.0, net6.0, and net471 (the multi-target set). If net471 errors on a span/`MathHelper` API, gate or adjust — net471 lacks some APIs (see CLAUDE.md note on `GC.GetAllocatedBytesForCurrentThread`).
+Expected: `Build succeeded.` for net10.0 and net471 (the multi-target set). If net471 errors on a span/`MathHelper` API, gate or adjust — net471 lacks some APIs (see CLAUDE.md note on `GC.GetAllocatedBytesForCurrentThread`).
 
 - [ ] **Step 2: Run the full BlasManaged + solver test surface**
 
-Run: `dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --filter "FullyQualifiedName~BlasManaged|FullyQualifiedName~Trsm|FullyQualifiedName~Solve|FullyQualifiedName~Cholesky" -f net8.0`
+Run: `dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --filter "FullyQualifiedName~BlasManaged|FullyQualifiedName~Trsm|FullyQualifiedName~Solve|FullyQualifiedName~Cholesky" -f net10.0`
 Expected: `Passed!` 0 failures.
 
 - [ ] **Step 3: Final commit if any net471 gating was needed; otherwise nothing to commit.**

--- a/docs/superpowers/plans/2026-05-30-specialized-blas-variants-p2-syrk.md
+++ b/docs/superpowers/plans/2026-05-30-specialized-blas-variants-p2-syrk.md
@@ -1,0 +1,439 @@
+# Specialized BLAS Variants — P2 (SYRK) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Add a bit-deterministic, drop-in `BlasManaged.Syrk<T>` symmetric rank-k update (`C = α·op(A)·op(A)ᵀ + β·C`, writing only the requested triangle), reusing the existing GEMM core, with a tile-skip optimization that computes only the needed triangle.
+
+**Architecture:** Approach A. First correct impl reuses the public `Gemm<T>` (B = A, transB flipped) into a scratch buffer, then writes `C[uplo] = α·scratch + β·C[uplo]`. The optimization then computes only the triangle's tiles (skip the off-`uplo` half) to cut ~half the FLOPs — the real SYRK win over a dense GEMM. TDD: correctness + determinism tests gate both the baseline and the optimization.
+
+**Tech Stack:** C# (net10.0 / net471), xUnit, existing `BlasManaged` infrastructure.
+
+**Spec:** `docs/superpowers/specs/2026-05-30-specialized-blas-variants-design.md` §4 SYRK.
+
+**Branch:** `feature/379-specialized-blas-variants` (continues after P0+P1).
+
+---
+
+## File Structure
+
+**Created:**
+- `src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Syrk.cs` — `BlasManaged.Syrk<T>`.
+- `tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SyrkTests.cs` — correctness (Uplo×Trans, FP32/FP64, α/β).
+- `tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SyrkDeterminismTests.cs` — bit-exact across thread counts.
+
+**Modified:**
+- `tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/Catalog/SpecializedShapeCatalog.cs` — add SYRK shapes.
+- `tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SpecializedPerfBar.cs` — add SYRK bar stub.
+
+---
+
+## Task 1: Failing SYRK correctness test (FP64, Lower, NoTrans)
+
+**Files:** Create `tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SyrkTests.cs`
+
+- [ ] **Step 1: Write the failing test** (oracle = naive triple loop, independent of production)
+
+```csharp
+using System;
+using AiDotNet.Tensors.Engines.BlasManaged;
+using Xunit;
+using BlasManagedLib = AiDotNet.Tensors.Engines.BlasManaged.BlasManaged;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+[Collection("BlasManaged-Stats-Serial")]
+public class SyrkTests
+{
+    // Reference: C = alpha*op(A)*op(A)^T + beta*C, full dense, then caller checks triangle.
+    // trans=false: A is n×k, op(A)=A. trans=true: A is k×n, op(A)=A^T (n×k effective).
+    private static double[] ReferenceSyrk(
+        bool trans, int n, int k, double alpha, double[] a, int lda, double beta, double[] c, int ldc)
+    {
+        var outC = (double[])c.Clone();
+        for (int i = 0; i < n; i++)
+            for (int j = 0; j < n; j++)
+            {
+                double dot = 0;
+                for (int p = 0; p < k; p++)
+                {
+                    // op(A)[i,p] and op(A)[j,p]
+                    double aip = trans ? a[p * lda + i] : a[i * lda + p];
+                    double ajp = trans ? a[p * lda + j] : a[j * lda + p];
+                    dot += aip * ajp;
+                }
+                outC[i * ldc + j] = alpha * dot + beta * c[i * ldc + j];
+            }
+        return outC;
+    }
+
+    [Fact]
+    public void Syrk_FP64_LowerNoTrans_MatchesReferenceTriangle()
+    {
+        const int n = 5, k = 3;
+        var rng = new Random(42);
+        double[] a = new double[n * k];
+        for (int i = 0; i < a.Length; i++) a[i] = rng.NextDouble() * 2 - 1;
+        double[] c = new double[n * n];
+        for (int i = 0; i < c.Length; i++) c[i] = rng.NextDouble() * 2 - 1;
+
+        double[] expectedFull = ReferenceSyrk(false, n, k, 1.0, a, k, 0.0, c, n);
+
+        double[] actual = (double[])c.Clone();
+        BlasManagedLib.Syrk<double>(Uplo.Lower, trans: false, n, k, 1.0, a, k, 0.0, actual, n);
+
+        // Only the lower triangle (incl diagonal) must match; upper is untouched (= original c).
+        for (int i = 0; i < n; i++)
+            for (int j = 0; j < n; j++)
+                if (j <= i) Assert.Equal(expectedFull[i * n + j], actual[i * n + j], 10);
+                else        Assert.Equal(c[i * n + j], actual[i * n + j], 10);
+    }
+}
+```
+
+- [ ] **Step 2: Build the test project — expect compile failure** `'BlasManaged' does not contain a definition for 'Syrk'`.
+
+Run: `dotnet build tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --no-restore -f net10.0`
+Expected: `error CS0117 ... 'Syrk'`.
+
+---
+
+## Task 2: Implement Syrk (reuse Gemm into scratch + triangular write)
+
+**Files:** Create `src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Syrk.cs`
+
+- [ ] **Step 1: Write the implementation**
+
+```csharp
+using System;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.Interfaces;
+
+namespace AiDotNet.Tensors.Engines.BlasManaged;
+
+public static partial class BlasManaged
+{
+    /// <summary>
+    /// Symmetric rank-k update: C = α·op(A)·op(A)ᵀ + β·C, writing only the
+    /// <paramref name="uplo"/> triangle of the n×n matrix C. op(A) is A (trans=false,
+    /// A is n×k) or Aᵀ (trans=true, A is k×n). Drop-in for cblas_ssyrk/cblas_dsyrk.
+    /// </summary>
+    public static void Syrk<T>(
+        Uplo uplo, bool trans,
+        int n, int k, T alpha,
+        ReadOnlySpan<T> a, int lda, T beta,
+        Span<T> c, int ldc,
+        in BlasOptions<T> options = default) where T : unmanaged
+    {
+        if (n <= 0) return;
+        var ops = MathHelper.GetNumericOperations<T>();
+
+        // full = op(A)·op(A)ᵀ  (n×n) via the existing GEMM core.
+        // trans=false: A(n×k) · A(n×k)ᵀ → Gemm(a=A, transA=false, b=A, transB=true, k=k)
+        // trans=true:  Aᵀ(n×k) · A(k×n) → Gemm(a=A, transA=true, b=A, transB=false, k=k)
+        T[] full = new T[n * n];
+        if (k > 0)
+        {
+            var gemmOpts = new BlasOptions<T> { NumThreads = options.NumThreads, Mode = options.Mode };
+            Gemm<T>(a, lda, trans, a, lda, !trans, full, n, n, n, k, gemmOpts);
+        }
+
+        // Write C[uplo] = α·full + β·C[uplo]; leave the other triangle untouched.
+        for (int i = 0; i < n; i++)
+        {
+            int lo = uplo == Uplo.Lower ? 0 : i;
+            int hi = uplo == Uplo.Lower ? i : n - 1;
+            for (int j = lo; j <= hi; j++)
+            {
+                int ci = i * ldc + j;
+                T scaled = ops.Multiply(alpha, full[i * n + j]);
+                c[ci] = ops.Add(scaled, ops.Multiply(beta, c[ci]));
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Build src** — `dotnet build src/AiDotNet.Tensors/AiDotNet.Tensors.csproj --no-restore -f net10.0` → `Build succeeded.`
+- [ ] **Step 3: Run the test** — `dotnet test ... --filter "FullyQualifiedName~Syrk_FP64_LowerNoTrans_MatchesReferenceTriangle" -f net10.0` → `Passed!`.
+- [ ] **Step 4: Commit** — `git commit -m "feat(#379): BlasManaged.Syrk<T> reusing GEMM core + first test"`.
+
+---
+
+## Task 3: Full coverage (Uplo×Trans, FP32, α/β) + determinism
+
+**Files:** Modify `SyrkTests.cs`; create `SyrkDeterminismTests.cs`.
+
+- [ ] **Step 1: Append the parameterized coverage test to `SyrkTests.cs`**
+
+```csharp
+    public static System.Collections.Generic.IEnumerable<object[]> Matrix()
+    {
+        foreach (var uplo in new[] { Uplo.Upper, Uplo.Lower })
+        foreach (var trans in new[] { false, true })
+            yield return new object[] { uplo, trans };
+    }
+
+    [Theory]
+    [MemberData(nameof(Matrix))]
+    public void Syrk_FP64_Coverage_AlphaBeta_MatchesReference(Uplo uplo, bool trans)
+    {
+        const int n = 6, k = 4;
+        var rng = new Random(321);
+        // trans=false → A is n×k (lda=k); trans=true → A is k×n (lda=n).
+        int aRows = trans ? k : n, aCols = trans ? n : k, lda = aCols;
+        double[] a = new double[aRows * aCols];
+        for (int i = 0; i < a.Length; i++) a[i] = rng.NextDouble() * 2 - 1;
+        double[] c = new double[n * n];
+        for (int i = 0; i < c.Length; i++) c[i] = rng.NextDouble() * 2 - 1;
+
+        double alpha = 1.7, beta = -0.5;
+        double[] expectedFull = ReferenceSyrk(trans, n, k, alpha, a, lda, beta, c, n);
+        double[] actual = (double[])c.Clone();
+        BlasManagedLib.Syrk<double>(uplo, trans, n, k, alpha, a, lda, beta, actual, n);
+
+        for (int i = 0; i < n; i++)
+            for (int j = 0; j < n; j++)
+            {
+                bool inTri = uplo == Uplo.Lower ? j <= i : j >= i;
+                if (inTri) Assert.Equal(expectedFull[i * n + j], actual[i * n + j], 9);
+                else       Assert.Equal(c[i * n + j], actual[i * n + j], 9);
+            }
+    }
+
+    [Fact]
+    public void Syrk_FP32_LowerNoTrans_MatchesReference()
+    {
+        const int n = 5, k = 4;
+        var rng = new Random(11);
+        float[] a = new float[n * k];
+        for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+        float[] c = new float[n * n];
+        for (int i = 0; i < c.Length; i++) c[i] = (float)(rng.NextDouble() * 2 - 1);
+
+        double[] a64 = Array.ConvertAll(a, x => (double)x);
+        double[] c64 = Array.ConvertAll(c, x => (double)x);
+        double[] expectedFull = ReferenceSyrk(false, n, k, 1.0, a64, k, 0.0, c64, n);
+
+        float[] actual = (float[])c.Clone();
+        BlasManagedLib.Syrk<float>(Uplo.Lower, false, n, k, 1f, a, k, 0f, actual, n);
+        for (int i = 0; i < n; i++)
+            for (int j = 0; j <= i; j++)
+                Assert.Equal(expectedFull[i * n + j], actual[i * n + j], 3);
+    }
+```
+
+- [ ] **Step 2: Create `SyrkDeterminismTests.cs`**
+
+```csharp
+using System;
+using AiDotNet.Tensors.Engines.BlasManaged;
+using Xunit;
+using BlasManagedLib = AiDotNet.Tensors.Engines.BlasManaged.BlasManaged;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+[Collection("BlasManaged-Stats-Serial")]
+public class SyrkDeterminismTests
+{
+    [Theory]
+    [InlineData(64, 48)]
+    [InlineData(128, 96)]
+    [InlineData(192, 64)]
+    public void Syrk_FP64_BitExactAcrossThreadCounts(int n, int k)
+    {
+        var rng = new Random(42);
+        double[] a = new double[n * k];
+        for (int i = 0; i < a.Length; i++) a[i] = rng.NextDouble() * 2 - 1;
+        double[] c0 = new double[n * n];
+        for (int i = 0; i < c0.Length; i++) c0[i] = rng.NextDouble() * 2 - 1;
+
+        double[]? baseline = null;
+        foreach (int threads in new[] { 1, 2, 4, 8 })
+        {
+            double[] actual = (double[])c0.Clone();
+            var opts = new BlasOptions<double> { NumThreads = threads, Mode = BlasMode.Deterministic };
+            BlasManagedLib.Syrk<double>(Uplo.Lower, false, n, k, 1.3, a, k, 0.7, actual, n, opts);
+            if (baseline is null) baseline = actual;
+            else for (int i = 0; i < actual.Length; i++) Assert.Equal(baseline[i], actual[i]);
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Run both** — `dotnet test ... --filter "FullyQualifiedName~Syrk" -f net10.0` → all pass (4 coverage + 1 fp32 + 1 original + 3 determinism = 9).
+- [ ] **Step 4: Commit** — `git commit -m "test(#379): Syrk full coverage + determinism"`.
+
+---
+
+## Task 4: Tile-skip optimization (compute only the requested triangle)
+
+**Files:** Modify `src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Syrk.cs`
+
+Replace the full n×n GEMM with blocked tiles, computing only tiles intersecting the requested triangle (~half the FLOPs). Off-triangle tiles are skipped entirely; the diagonal tile is computed and masked.
+
+- [ ] **Step 1: Add the blocked path and route to it for large n**
+
+```csharp
+    private const int SyrkBlock = 64;
+
+    private static void SyrkBlocked<T>(
+        Uplo uplo, bool trans, int n, int k, T alpha, ReadOnlySpan<T> a, int lda, T beta,
+        Span<T> c, int ldc, in BlasOptions<T> options, INumericOperations<T> ops) where T : unmanaged
+    {
+        var gemmOpts = new BlasOptions<T> { NumThreads = options.NumThreads, Mode = options.Mode };
+        for (int i0 = 0; i0 < n; i0 += SyrkBlock)
+        {
+            int bm = Math.Min(SyrkBlock, n - i0);
+            for (int j0 = 0; j0 < n; j0 += SyrkBlock)
+            {
+                int bn = Math.Min(SyrkBlock, n - j0);
+                // Skip tiles wholly outside the requested triangle.
+                if (uplo == Uplo.Lower) { if (j0 > i0 + bm - 1) continue; }
+                else                    { if (j0 + bn - 1 < i0) continue; }
+
+                // tile = op(A)[i0:i0+bm, :] · op(A)[j0:j0+bn, :]ᵀ  (bm×bn)
+                // Row r of op(A) lives at: trans ? column r of A : row r of A.
+                T[] tile = new T[bm * bn];
+                if (k > 0)
+                {
+                    // Build the two operands as offset spans into A.
+                    // trans=false: op(A) row r = a[r*lda + p]; sub-block rows i0.., j0..
+                    //   Gemm(aSub(bm×k), transA=false, bSub(bn×k), transB=true, m=bm,n=bn,k=k)
+                    // trans=true:  op(A) row r = a[p*lda + r]; columns i0.., j0..
+                    //   Use transA=true on the i-block, transB=false won't line up by stride,
+                    //   so fall back to the dense full path for trans=true (correctness first).
+                    if (!trans)
+                    {
+                        var aI = a.Slice(i0 * lda);          // bm rows × k, lda-strided
+                        var aJ = a.Slice(j0 * lda);          // bn rows × k, lda-strided
+                        Gemm<T>(aI, lda, false, aJ, lda, true, tile, bn, bm, bn, k, gemmOpts);
+                    }
+                    else
+                    {
+                        // Column-strided operands: compute this tile with a scalar dot to
+                        // stay correct (trans tile-skip uses the same skip pattern, scalar inner).
+                        for (int ii = 0; ii < bm; ii++)
+                            for (int jj = 0; jj < bn; jj++)
+                            {
+                                T dot = ops.Zero;
+                                for (int p = 0; p < k; p++)
+                                    dot = ops.Add(dot, ops.Multiply(a[p * lda + (i0 + ii)], a[p * lda + (j0 + jj)]));
+                                tile[ii * bn + jj] = dot;
+                            }
+                    }
+                }
+
+                // Write tile into C[uplo] with alpha/beta, masking the diagonal tile.
+                for (int ii = 0; ii < bm; ii++)
+                {
+                    int gi = i0 + ii;
+                    for (int jj = 0; jj < bn; jj++)
+                    {
+                        int gj = j0 + jj;
+                        bool inTri = uplo == Uplo.Lower ? gj <= gi : gj >= gi;
+                        if (!inTri) continue;
+                        int ci = gi * ldc + gj;
+                        c[ci] = ops.Add(ops.Multiply(alpha, tile[ii * bn + jj]), ops.Multiply(beta, c[ci]));
+                    }
+                }
+            }
+        }
+    }
+```
+
+Route at the top of `Syrk`, after computing `ops`:
+
+```csharp
+        if (n > SyrkBlock)
+        {
+            SyrkBlocked(uplo, trans, n, k, alpha, a, lda, beta, c, ldc, options, ops);
+            return;
+        }
+```
+
+- [ ] **Step 2: Build + run the full Syrk suite (correctness + determinism must still pass)**
+
+Run: `dotnet test ... --filter "FullyQualifiedName~Syrk" -f net10.0`
+Expected: all pass. Add a large-n case below to force the blocked path.
+
+- [ ] **Step 3: Add a large-n correctness case to `SyrkTests.cs`**
+
+```csharp
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Syrk_FP64_LargeN_BlockedPath_MatchesReference(bool trans)
+    {
+        const int n = 150, k = 40; // n > SyrkBlock(64)
+        var rng = new Random(2025);
+        int aRows = trans ? k : n, aCols = trans ? n : k, lda = aCols;
+        double[] a = new double[aRows * aCols];
+        for (int i = 0; i < a.Length; i++) a[i] = rng.NextDouble() * 2 - 1;
+        double[] c = new double[n * n];
+        for (int i = 0; i < c.Length; i++) c[i] = rng.NextDouble() * 2 - 1;
+
+        double alpha = 0.9, beta = 0.3;
+        double[] expectedFull = ReferenceSyrk(trans, n, k, alpha, a, lda, beta, c, n);
+        double[] actual = (double[])c.Clone();
+        BlasManagedLib.Syrk<double>(Uplo.Lower, trans, n, k, alpha, a, lda, beta, actual, n);
+        for (int i = 0; i < n; i++)
+            for (int j = 0; j <= i; j++)
+                Assert.Equal(expectedFull[i * n + j], actual[i * n + j], 8);
+    }
+```
+
+- [ ] **Step 4: Run + commit** — `git commit -m "perf(#379): Syrk tile-skip computes only the requested triangle"`.
+
+---
+
+## Task 5: Catalog + perf-bar entries; multi-TFM build
+
+**Files:** Modify `SpecializedShapeCatalog.cs`, `SpecializedPerfBar.cs`.
+
+- [ ] **Step 1: Add SYRK shapes to `SpecializedShapeCatalog.cs`** (inside the class)
+
+```csharp
+    public record SyrkShape(string Name, Uplo Uplo, bool Trans, int N, int K, bool Fp64, int Frequency, string Source);
+
+    public static readonly SyrkShape[] Syrk =
+    {
+        new("Cov_256x64",  Uplo.Lower, true,  256,  64, true, 30, "workload:covariance"),
+        new("Cov_512x128", Uplo.Lower, true,  512, 128, true, 25, "workload:covariance"),
+        new("Gram_128x768",Uplo.Lower, false, 128, 768, true, 20, "workload:gram-matrix"),
+        new("Cov_FP32_256x64", Uplo.Lower, true, 256, 64, false, 15, "workload:covariance-fp32"),
+    };
+```
+
+- [ ] **Step 2: Add SYRK bar stub to `SpecializedPerfBar.cs`** (inside the class)
+
+```csharp
+    // SYRK vs OpenBLAS ssyrk/dsyrk on the authoritative runner.
+    public const int    SyrkMinWinRatePercent = 0;     // TO BE SET after first bench
+    public const double SyrkMaxLossMultiple    = 99.0; // TO BE SET after first bench
+    public static bool SyrkBarFrozen => SyrkMinWinRatePercent > 0;
+```
+
+- [ ] **Step 3: Multi-TFM build + full Syrk suite**
+
+Run: `dotnet build src/AiDotNet.Tensors/AiDotNet.Tensors.csproj --no-restore` → both net10.0 + net471 succeed.
+Run: `dotnet test ... --filter "FullyQualifiedName~Syrk" -f net10.0` → all pass.
+
+- [ ] **Step 4: Commit** — `git commit -m "test(#379): SYRK bench catalog + perf-bar stub"`.
+
+---
+
+## Task 6 (tracked, not silently dropped): SYRK call-site rewiring
+
+Covariance/gram call sites (`CpuEngine`, `MultivariateDistributions`) are candidate rewires to `BlasManaged.Syrk`, but each computes `Aᵀ·A`/`A·Aᵀ` inside larger routines and needs individual analysis to preserve exact semantics (centering, normalization, batch handling). This task is **explicitly tracked** for a focused follow-up commit on this branch — it is not part of the kernel deliverable and must not be force-rewired without per-site verification (existing tests are the canary, same discipline as P1 Task 9).
+
+---
+
+## Self-Review
+
+- §4 SYRK reuse-GEMM-core → Task 2 ✓
+- §4 tile-skip (only requested triangle) → Task 4 ✓
+- §4 triangular-write + α/β → Tasks 2,3 ✓
+- §3 determinism contract → Task 3 (bit-exact across threads; GEMM core is deterministic, scalar trans tile is fixed-order) ✓
+- §5 catalog + frozen bar → Task 5 ✓
+- Placeholder scan: only the documented `0`/`99.0` perf-bar stubs. Type consistency: `Syrk<T>`, `SyrkBlock`, `SyrkBlocked`, `ReferenceSyrk` consistent across tasks.
+- Note: trans=true tile-skip uses a scalar inner dot (correct + deterministic); a SIMD trans path is a later micro-opt, flagged here, not silently dropped.

--- a/docs/superpowers/plans/2026-05-30-specialized-blas-variants-p3-symm.md
+++ b/docs/superpowers/plans/2026-05-30-specialized-blas-variants-p3-symm.md
@@ -1,0 +1,96 @@
+# Specialized BLAS Variants — P3 (SYMM) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:executing-plans. Checkbox (`- [ ]`) steps.
+
+**Goal:** Add a bit-deterministic, drop-in `BlasManaged.Symm<T>` symmetric matrix multiply (`C = α·A·B + β·C` for Side.Left, `C = α·B·A + β·C` for Side.Right; A symmetric, stored in the `uplo` triangle), reusing the existing GEMM core.
+
+**Architecture:** Approach A. Materialize the full symmetric A from its `uplo` triangle into a scratch buffer (mirror across the diagonal), run the existing `Gemm<T>` into a result scratch, then write `C = α·result + β·C`. Cost of the symmetric materialization is O(side²), negligible vs the GEMM's O(side²·n). The "mirror-on-pack" micro-opt (avoid the temp-A buffer) only matters for tiny n and is tracked as a follow-up, not part of this deliverable.
+
+**Spec:** `docs/superpowers/specs/2026-05-30-specialized-blas-variants-design.md` §4 SYMM. **Branch:** `feature/379-specialized-blas-variants`.
+
+---
+
+## File Structure
+- Create: `src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Symm.cs`
+- Create: `tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SymmTests.cs`, `SymmDeterminismTests.cs`
+- Modify: `SpecializedShapeCatalog.cs`, `SpecializedPerfBar.cs`
+
+---
+
+## Task 1: Failing test (FP64, Left, Lower)
+
+Create `SymmTests.cs` with an in-test oracle (`A_sym[i,j] = stored-triangle-or-mirror`) and one `[Fact]` for Side.Left/Uplo.Lower comparing to `BlasManaged.Symm<double>`. Build test project → expect `CS0117 'Symm'`.
+
+## Task 2: Implement Symm (materialize symmetric A + Gemm)
+
+Create `BlasManaged.Symm.cs`:
+
+```csharp
+using System;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.Interfaces;
+
+namespace AiDotNet.Tensors.Engines.BlasManaged;
+
+public static partial class BlasManaged
+{
+    /// <summary>
+    /// Symmetric matrix multiply. Side.Left: C = α·A·B + β·C (A is m×m symmetric).
+    /// Side.Right: C = α·B·A + β·C (A is n×n symmetric). A is stored in the
+    /// <paramref name="uplo"/> triangle. Drop-in for cblas_ssymm/cblas_dsymm.
+    /// </summary>
+    public static void Symm<T>(
+        Side side, Uplo uplo,
+        int m, int n, T alpha,
+        ReadOnlySpan<T> a, int lda,
+        ReadOnlySpan<T> b, int ldb, T beta,
+        Span<T> c, int ldc,
+        in BlasOptions<T> options = default) where T : unmanaged
+    {
+        if (m <= 0 || n <= 0) return;
+        var ops = MathHelper.GetNumericOperations<T>();
+        int s = side == Side.Left ? m : n;   // dimension of square symmetric A
+
+        // Materialize full symmetric A (s×s) from the uplo triangle (mirror).
+        T[] full = new T[s * s];
+        for (int i = 0; i < s; i++)
+            for (int j = 0; j < s; j++)
+            {
+                bool stored = uplo == Uplo.Lower ? j <= i : j >= i;
+                full[i * s + j] = stored ? a[i * lda + j] : a[j * lda + i];
+            }
+
+        // result = A·B (Left, m×n) or B·A (Right, m×n) via the existing GEMM core.
+        T[] result = new T[m * n];
+        var gemmOpts = new BlasOptions<T> { NumThreads = options.NumThreads, Mode = options.Mode };
+        if (side == Side.Left)
+            Gemm<T>(full, s, false, b, ldb, false, result, n, m, n, s, gemmOpts); // (m×m)(m×n)
+        else
+            Gemm<T>(b, ldb, false, full, s, false, result, n, m, n, s, gemmOpts); // (m×n)(n×n)
+
+        // C = α·result + β·C
+        for (int i = 0; i < m; i++)
+            for (int j = 0; j < n; j++)
+            {
+                int ci = i * ldc + j;
+                c[ci] = ops.Add(ops.Multiply(alpha, result[i * n + j]), ops.Multiply(beta, c[ci]));
+            }
+    }
+}
+```
+
+Build src → succeed. Run first test → pass. Commit.
+
+## Task 3: Coverage (Side×Uplo, FP32, α/β) + determinism
+
+Append parameterized `Side×Uplo` FP64 α/β test + FP32 test to `SymmTests.cs`; create `SymmDeterminismTests.cs` (bit-exact across 1/2/4/8 threads, n large enough to parallelize). Run → all pass. Commit.
+
+## Task 4: Catalog + perf-bar + multi-TFM
+
+Add `SymmShape[]` to `SpecializedShapeCatalog.cs` and `Symm*` bar constants to `SpecializedPerfBar.cs`. Build net10.0+net471, run full Symm suite. Commit.
+
+## Tracked follow-up (not silently dropped)
+Mirror-on-pack (avoid temp-A materialization) — micro-opt for tiny n; tracked, deferred.
+
+## Self-Review
+§4 SYMM reuse-core + mirror → Task 2 ✓; determinism (GEMM core deterministic, materialization fixed-order) → Task 3 ✓; catalog/bar → Task 4 ✓. Placeholder: only documented bar stubs.

--- a/docs/superpowers/plans/2026-05-30-specialized-blas-variants-p4-spmm.md
+++ b/docs/superpowers/plans/2026-05-30-specialized-blas-variants-p4-spmm.md
@@ -1,0 +1,26 @@
+# Specialized BLAS Variants — P4 (CPU SpMM) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:executing-plans. Checkbox (`- [ ]`) steps.
+
+**Goal:** Add `BlasManaged.SpMM<T>` — sparse×dense `C = α·A·B + β·C` (CSR/CSC) — replacing the cache-hostile naive loop in `CpuSparseEngine.SpMM`, and rewire that call site.
+
+**Architecture:** New standalone kernel (not GEMM-reuse). CSR: pre-scale `C` row by `β`, then for each nonzero `(i,k,v)` accumulate `C[i,0:n] += (α·v)·B[k,0:n]` — B rows read contiguously (cache-friendly), rows independent (deterministic, parallelizable). CSC iterates columns scattering into C. Both fixed-order → bit-exact. Typed-SIMD + row-parallel are tracked perf follow-ups; this deliverable is the correct cache-friendly consolidation + the rewire.
+
+**Spec:** §4 CPU SpMM. **Branch:** `feature/379-specialized-blas-variants`.
+
+## Files
+- Create: `src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.SpMM.cs`, `tests/.../SpMMTests.cs`, `tests/.../SpMMDeterminismTests.cs`
+- Modify: `src/AiDotNet.Tensors/Engines/CpuSparseEngine.cs:126-167` (rewire), `SpecializedShapeCatalog.cs`, `SpecializedPerfBar.cs`
+
+## Tasks
+1. Failing CSR correctness test (oracle = densify A then dense multiply with α/β). Expect `CS0117 'SpMM'`.
+2. Implement `SpMM` (CSR + CSC, α/β pre-scale + accumulate). Build + first test green. Commit.
+3. Coverage: CSC test, FP32, α/β, empty-row; determinism across thread counts (serial impl → trivially bit-exact, guards future parallelization). Commit.
+4. Rewire `CpuSparseEngine.SpMM` → build `SparseLayout` from `ToCsr()` + `dense.AsSpan()`/`result.AsWritableSpan()`; existing sparse tests are the canary. Commit.
+5. Catalog + perf-bar (`SpMMShape`/`SpMM*` bar). Multi-TFM build. Commit.
+
+## Tracked follow-ups (not silently dropped)
+Typed FP32/FP64 SIMD inner loop + CSR row-parallel (`NumThreads`) + fused `Epilogue` (bias+activation) — the headline exceed-vendor levers; tracked for focused commits on this branch.
+
+## Self-Review
+§4 CSR row-local + CSC → Task 2 ✓; determinism → Task 3 ✓; rewire with canary → Task 4 ✓; catalog/bar → Task 5 ✓. SIMD/parallel/epilogue explicitly tracked, not dropped.

--- a/docs/superpowers/plans/2026-05-30-specialized-blas-variants-p5-gbmv.md
+++ b/docs/superpowers/plans/2026-05-30-specialized-blas-variants-p5-gbmv.md
@@ -1,0 +1,22 @@
+# Specialized BLAS Variants — P5 (GBMV) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:executing-plans. Checkbox (`- [ ]`) steps.
+
+**Goal:** Add `BlasManaged.Gbmv<T>` — banded matrix-vector `y = α·op(A)·x + β·y` — drop-in for cblas_sgbmv/cblas_dgbmv, using the standard LAPACK band storage.
+
+**Architecture:** Standalone level-2 kernel (memory-bound, not GEMM). Band storage (LAPACK convention, column-major band, lda ≥ kl+ku+1): the logical element `A(i,j)` lives at `a[j*lda + (ku - j + i)]` for the band `max(0,j-ku) ≤ i ≤ min(m-1,j+kl)`. Each output element is an independent fixed-order dot over the band → deterministic in both modes.
+
+**Spec:** §4 GBMV. **Branch:** `feature/379-specialized-blas-variants`.
+
+## Files
+- Create: `src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Gbmv.cs`, `tests/.../GbmvTests.cs`, `tests/.../GbmvDeterminismTests.cs`
+- Modify: `SpecializedShapeCatalog.cs`, `SpecializedPerfBar.cs`
+
+## Tasks
+1. Failing test: oracle builds dense banded A + band array consistently, computes `y` densely; non-trans first. Expect `CS0117 'Gbmv'`.
+2. Implement `Gbmv` (non-trans + trans, α/β, incx/incy). Build + first test green. Commit.
+3. Coverage: trans, FP32, α/β, non-square m≠n, incx/incy≠1; determinism across thread counts. Commit.
+4. Catalog (tridiagonal/pentadiagonal) + perf-bar stub; multi-TFM build. Commit.
+
+## Self-Review
+§4 banded level-2 + LAPACK storage → Task 2 ✓; trans + strides → Task 3 ✓; determinism (independent fixed-order dots) → Task 3 ✓; catalog/bar → Task 4 ✓.

--- a/docs/superpowers/specs/2026-05-30-specialized-blas-variants-design.md
+++ b/docs/superpowers/specs/2026-05-30-specialized-blas-variants-design.md
@@ -1,0 +1,238 @@
+# Specialized BLAS Variants (TRSM / SYRK / SYMM / GBMV / SpMM) — Design Spec
+
+**Date:** 2026-05-30
+**Status:** Approved (pending writing-plans phase)
+**Issue:** [#379](https://github.com/ooples/AiDotNet.Tensors/issues/379) — Sparse / banded / symmetric / triangular BLAS variants
+**Predecessor:** [#368](https://github.com/ooples/AiDotNet.Tensors/issues/368) — BlasManaged perf sprint (general dense GEMM only)
+**Predecessor spec:** [`2026-05-17-blas-managed-perf-sprint-design.md`](./2026-05-17-blas-managed-perf-sprint-design.md)
+**Branch:** `feature/379-specialized-blas-variants`
+
+## 1 — Motivation & corrected framing
+
+Issue #379 was tracked as "these specialized variants still route to native BLAS until this issue closes." Investigation of the current tree shows that premise is **inaccurate on the CPU side**:
+
+- `BlasProvider.cs` (CPU) only P/Invokes `cblas_sgemm` / `cblas_dgemm` (+ batch/bf16). There are **no** native `strsm` / `ssyrk` / `ssymm` / `sgbmv` declarations anywhere.
+- Triangular solve (TRSM) today = managed substitution loops in `LinearSolvers.cs` and the decomposition classes (Cholesky / QR / LU).
+- Sparse SpMM today = fully managed **naive scalar loops** in `CpuSparseEngine.cs` (no SIMD, no parallelism).
+- The only *native* sparse bindings (`cuSPARSE` / `rocSPARSE`) are **GPU-only**. The #368 spec (§7) explicitly deferred GPU BLAS.
+
+Therefore there is **no native CPU supply-chain to remove** here. The real work is:
+
+1. Establish **first-class, optimized managed implementations** of each variant inside the BlasManaged framework (microkernels, packing, allocator, `BlasMode` determinism contract), and rewire the existing ad-hoc managed call sites to them.
+2. Treat it as a **perf effort** mirroring #368: extend the bench catalog, set frozen per-variant bars against the relevant vendor routine, and beat them.
+3. For **GPU SpMM** (the one place a real native dep exists): make the *already-existing* custom CUDA/HIP sparse kernels the default, close the perf gap to parity-or-better vs cuSPARSE/rocSPARSE, then delete the vendor binding.
+
+### Scope (user-confirmed, maximal)
+
+All five families **plus** GPU sparse, in **one phased mega-PR**:
+TRSM, SYRK, SYMM, GBMV, CPU SpMM (CSR/CSC), GPU SpMM (cuSPARSE/rocSPARSE replacement).
+
+The size/review cost of a single-PR approach was flagged twice; the maintainer chose one mega-PR with phased, independently-green commits. This spec structures the work so each phase is reviewable on its own.
+
+### Two goals, two correctness gates (inherited from #368)
+
+- **Goal 1 — exceed industry standards** (not just match). See §3 for the levers vendors structurally cannot match.
+- **Goal 2 — first-class consolidated APIs** replacing the scattered ad-hoc managed implementations.
+- **Gate A — bit-exact determinism** stays the default (`BlasMode.Deterministic`); `BlasMode.Fast` is the opt-in escape hatch.
+- **Gate B — per-variant perf bar** vs the relevant vendor routine, frozen after first authoritative bench run on the self-hosted runner.
+
+## 2 — Architecture: Approach A (reuse the GEMM microkernel core)
+
+The three level-3 dense-symmetric/triangular ops are **thin drivers over the existing** packing + microkernel + parallel-driver stack from #366/#368. Only the sparse and banded ops get genuinely new kernels. This matches how production BLAS (BLIS) builds these — level-3 variants are wrappers over the GEMM macrokernel.
+
+```
+┌───────────────────────────────────────────────────────────────┐
+│ Public API: BlasManaged.{Trsm,Syrk,Symm,Gbmv,SpMM}<T>          │
+├───────────────────────────────────────────────────────────────┤
+│ BlasOptions<T> (Mode, Epilogue, packing, threads) — unchanged  │
+├───────────────────────────────────────────────────────────────┤
+│ Variant drivers:                                                │
+│   Trsm  → blocked solve + GEMM macrokernel (trailing updates)  │
+│   Syrk  → GEMM macrokernel + tile-skip + triangular-write       │
+│   Symm  → GEMM macrokernel + mirror-on-pack A-packer            │
+│   Gbmv  → NEW standalone banded level-2 kernel                  │
+│   SpMM  → NEW CSR/CSC kernel (SIMD over dense-N, row-parallel)  │
+├───────────────────────────────────────────────────────────────┤
+│ Existing GEMM core: microkernels (AVX512/AVX2/NEON), packing,  │
+│ allocator, parallel drivers, reduction tree — REUSED            │
+└───────────────────────────────────────────────────────────────┘
+```
+
+**New-code surface is intentionally small:** one triangular-solve microkernel (TRSM diagonal tile), one mirror-on-pack routine (SYMM), one triangular-write mask (SYRK), one banded kernel (GBMV), one CSR/CSC SpMM kernel, plus GPU dispatch/perf work. Everything else is existing infrastructure.
+
+### Alternatives considered
+
+- **Approach B — standalone kernel per variant:** maximum per-variant tuning ceiling but 5× the kernel surface to test and keep deterministic; re-solves problems the GEMM core already solved. Rejected as too risky for one PR.
+- **Approach C — hybrid:** collapses into A (A already makes SpMM/GBMV standalone).
+
+## 3 — Public API surface
+
+All entry points live on the existing `static class BlasManaged`, mirror `Gemm<T>`'s `ReadOnlySpan<T>` + leading-dimension + `in BlasOptions<T>` shape, and pull `Mode` from `BlasOptions` / `DefaultMode`. Argument order matches the canonical CBLAS reference **exactly** (we drop only the `order` enum, fixed to RowMajor, identical to the existing `Gemm`).
+
+```csharp
+// Triangular solve:  op(A)·X = α·B (left) or X·op(A) = α·B (right). In-place on B.
+public static void Trsm<T>(
+    Side side, Uplo uplo, bool transA, Diag diag,
+    int m, int n, T alpha,
+    ReadOnlySpan<T> a, int lda,
+    Span<T> b, int ldb,
+    in BlasOptions<T> options = default) where T : unmanaged;
+
+// Symmetric rank-k update:  C = α·op(A)·op(A)^T + β·C   (writes only `uplo` triangle)
+public static void Syrk<T>(
+    Uplo uplo, bool trans,
+    int n, int k, T alpha,
+    ReadOnlySpan<T> a, int lda, T beta,
+    Span<T> c, int ldc,
+    in BlasOptions<T> options = default) where T : unmanaged;
+
+// Symmetric matrix multiply:  C = α·A·B + β·C  (A symmetric, stored in `uplo` triangle)
+public static void Symm<T>(
+    Side side, Uplo uplo,
+    int m, int n, T alpha,
+    ReadOnlySpan<T> a, int lda,
+    ReadOnlySpan<T> b, int ldb, T beta,
+    Span<T> c, int ldc,
+    in BlasOptions<T> options = default) where T : unmanaged;
+
+// Banded matrix-vector:  y = α·op(A)·x + β·y   (A banded, kl sub- / ku super-diagonals)
+public static void Gbmv<T>(
+    bool transA, int m, int n, int kl, int ku, T alpha,
+    ReadOnlySpan<T> a, int lda,
+    ReadOnlySpan<T> x, int incx, T beta,
+    Span<T> y, int incy,
+    in BlasOptions<T> options = default) where T : unmanaged;
+
+// Sparse×dense:  C = α·A_sparse·B + β·C   (CSR or CSC, format read from the view)
+public static void SpMM<T>(
+    T alpha, SparseLayout<T> a,
+    ReadOnlySpan<T> b, int ldb, int n, T beta,
+    Span<T> c, int ldc,
+    in BlasOptions<T> options = default) where T : unmanaged;
+```
+
+**Supporting types** (per CLAUDE.md's no-string-for-closed-sets rule):
+`Side { Left, Right }`, `Uplo { Upper, Lower }`, `Diag { NonUnit, Unit }`.
+`SparseLayout<T>` — a thin readonly ref-struct view (rowPtr / colInd / values spans + format enum) so `SpMM` stays allocation-free and decoupled from the heap `SparseTensor<T>` class.
+
+### Industry-standard validation
+
+Confirmed against the CBLAS reference ([OpenBLAS `cblas.h`](https://github.com/xianyi/OpenBLAS/blob/develop/cblas.h), [GSL CBLAS](https://www.gnu.org/software/gsl/doc/html/cblas.html)):
+
+| Op | Reference CBLAS arg order | Our signature | Match |
+|----|---------------------------|---------------|-------|
+| TRSM | `(Side, Uplo, TransA, Diag, M, N, α, A, lda, B, ldb)` | identical | ✓ |
+| SYRK | `(Uplo, Trans, N, K, α, A, lda, β, C, ldc)` | identical | ✓ |
+| SYMM | `(Side, Uplo, M, N, α, A, lda, B, ldb, β, C, ldc)` | identical | ✓ |
+| GBMV | `(TransA, M, N, KL, KU, α, A, lda, x, incx, β, y, incy)` | identical | ✓ |
+
+SpMM has no classic CBLAS; the signature aligns with the modern **MKL Sparse BLAS IE** `mkl_sparse_s_mm` and **cuSPARSE generic** `cusparseSpMM` conventions.
+
+### How we *exceed* the standard (no signature changes — all rides `BlasOptions<T>`)
+
+1. **Fused epilogue (headline win).** Vendor TRSM/SYRK/SYMM/SpMM do one operation; bias/activation needs a separate pass. Our ops inherit `BlasOptions<T>.Epilogue`, so `SpMM + bias + ReLU` is a single fused kernel — exactly the GNN/recsys hot path (the GPU side already proves it with `csr_spmm_bias_relu`). SYRK/SYMM/SpMM/TRSM all honor `options.Epilogue`.
+2. **Bit-exact determinism by default.** OpenBLAS/MKL/cuSPARSE are not reproducible across thread counts; our `BlasMode.Deterministic` default is.
+3. **One generic `<T>` API** vs the vendors' 4× `s/d/c/z` entry points, with FP32/FP64 specialization under the hood.
+4. **FMA-on-FP32 in Fast mode** (per #368 §5) — numerically better than OpenBLAS (which skips FP32 FMA for NumPy compat) *and* faster.
+
+## 4 — Per-variant algorithm & determinism design
+
+### TRSM — reuses GEMM macrokernel; one new tiny kernel
+Blocked BLIS-style solve. Partition the triangular dimension into `Mr`-sized diagonal blocks. For each: solve the small `Mr×Nr` diagonal tile with a **new triangular-solve microkernel** (the only genuinely new code), then update the trailing RHS via the **existing GEMM macrokernel** (`B -= A_offdiag · X_solved`). Reuses PackBoth packing.
+**Determinism:** substitution is inherently ordered along the triangular axis; rank-k updates use GEMM's existing pairwise reduction; parallelism is over independent RHS columns (`N`) → bit-exact in both modes. No new determinism risk.
+
+### SYRK — `C = α·A·Aᵀ + β·C` — reuses GEMM core; tile-skip + triangular-write
+B is just Aᵀ, so packing A yields the B-panel for free. The outer loop **skips microkernel tiles** on the off-`uplo` side of the diagonal (≈half the FLOPs); diagonal tiles apply a **triangular-write mask** in the epilogue so only the `uplo` triangle is stored.
+**Determinism:** identical to GEMM (pairwise tree in Deterministic, FMA/free-order in Fast).
+
+### SYMM — `C = α·A·B + β·C`, A symmetric — reuses GEMM core; mirror-on-pack
+A is stored in one triangle. The **A-packing routine reflects across the diagonal on the fly** (reads the stored triangle, mirrors into the packed panel). After packing it is a bit-for-bit ordinary GEMM through the existing macro/microkernel.
+**Determinism:** identical to GEMM.
+
+### GBMV — `y = α·op(A)·x + β·y`, A banded — new standalone level-2 kernel
+Memory-bound GEMV-class, not a GEMM. Band storage `(kl+ku+1)×n`. For each column the band touches rows `[j-ku, j+kl]`; SIMD runs along the band. Rides `BlasOptions` parallelism (N-axis split) with its own kernel.
+**Determinism:** non-trans output elements are independent → deterministic. Trans case accumulates into `y`; Deterministic mode uses fixed-order (column-ascending) accumulation, Fast allows reorder.
+
+### CPU SpMM — `C = α·A_sparse·B + β·C` — new kernel (the big optimization vs naive loops)
+- **CSR (fast/primary path):** parallelize over sparse rows `i` (M-axis). For each nonzero `(i,k,v)`: `C[i, 0:N] += v · B[k, 0:N]`, **SIMD-vectorized along the dense N dimension** (broadcast `v`, FMA into the C row). Rows are independent → embarrassingly parallel.
+- **CSC:** iterate columns, scatter into C. Deterministic mode uses per-thread partials merged in fixed row order; Fast mode allows thread-private accumulation. Autotune may instead transpose-to-CSR once when the matrix is reused.
+**Determinism:** CSR row-parallel is **naturally bit-exact** (fixed nonzero traversal order per row, no cross-thread reduction) — a strict improvement over both the current scalar loop and vendor sparse libs.
+**Exceed lever:** fuse `+ bias + activation` from `options.Epilogue` into the row write — single pass.
+
+### GPU SpMM — make existing custom kernels the default; close perf gap; remove vendor dep
+Custom CUDA kernels already exist (`CudaSparseKernels.cs`: `csr_spmm`, `csr_spmm_warp`, `csr_spmm_bias_relu`, bit-deterministic `*_deterministic` variants). Work: (a) flip `IDirectGpuBackend.CsrSpMM` default from `CuSparseBackend` (native) → custom kernels; (b) add the perf pieces to hit the parity bar (warp-per-row dispatch heuristic, vectorized 128-bit dense loads, FP64 coverage); (c) mirror gaps to HIP/`RocSparse`; (d) delete the cuSPARSE/rocSPARSE P/Invoke + probe after the bar is met.
+**Determinism:** Deterministic mode → `*_deterministic` kernels (fixed-order segment sums); Fast mode → atomic-scatter variants.
+
+## 5 — Verification: perf bars, bench catalog, determinism & correctness
+
+Reuses #368 scaffolding (`ShapeCatalog.cs`, `PerfHarness.cs`, `PerfBar.cs`, `PerfBarTest.cs`, `DeterminismTests.cs`).
+
+### Bench catalog extension
+Add a `SpecializedShapeCatalog` (or extend `ShapeCatalog`) with per-variant shape sets, each tagged `frequency` + `source`:
+- **TRSM:** Cholesky/QR solve shapes (`64×64`, `256×256`, `1024×64` multi-RHS) + ML linear-system solves.
+- **SYRK/SYMM:** covariance/gram shapes (`N×K` with K≫N for SYRK; square for SYMM).
+- **SpMM:** GNN/recsys shapes `(rows, cols, nnz%, N)` — Cora/PubMed-like 0.1–2% density + a dense-ish stress case.
+- **GBMV:** tridiagonal/pentadiagonal band shapes.
+
+### Per-variant frozen perf bars (`SpecializedPerfBar.cs`)
+Constants set after the first authoritative bench run on the self-hosted runner; gate-then-frozen discipline from #368 (X/Y/N structure: min win-rate %, max loss multiple, catalog size, target hardware fingerprint).
+- **TRSM/SYRK/SYMM:** vs OpenBLAS `strsm/ssyrk/ssymm` — median ≤ OpenBLAS on ≥ X% of shapes.
+- **CPU SpMM:** vs MKL Sparse BLAS `mkl_sparse_s_mm` where available, else vs the current naive managed loop (which is the floor — must be a large multiple faster).
+- **GPU SpMM:** vs cuSPARSE `cusparseSpMM` — parity-or-better is the explicit gate; the vendor binding is **not deleted until this bar is green** on the runner.
+
+### Determinism gates
+Extend `DeterminismTests.cs` with a case per new op asserting bit-exact equality across 1/2/4/8 thread counts in `BlasMode.Deterministic`. **A variant's PR phase does not merge until its determinism coverage is added.** Fast mode may diverge ±1–2 ULP; Deterministic may not.
+
+### Correctness tests
+Each variant gets a `*Tests.cs` comparing `BlasManaged.X` to a reference (native `cblas_*`/`cusparseSpMM` where the dep still loads, else a naive reference) within tolerance, with a full shape-coverage matrix: all `Side×Uplo×Trans×Diag` for TRSM, both `Uplo×Trans` for SYRK, CSR+CSC for SpMM, trans/non-trans + band widths for GBMV. Epilogue-fusion paths get their own cases (`SpMM+bias+ReLU == SpMM then bias then ReLU`).
+
+Perf bars stay **skipped on GitHub-hosted runners** and only assert on the self-hosted `AIDOTNET_PERF_RUNNER=1` box, as `PerfBarTest` already does.
+
+## 6 — Phasing, call-site rewiring, and vendor removal
+
+One branch/PR, landing as ordered, independently-green phases (builds + that phase's tests + its determinism coverage pass before the next starts).
+
+| Phase | Deliverable | Gated by |
+|-------|-------------|----------|
+| **P0** | Shared scaffolding: `Side`/`Uplo`/`Diag` enums, `SparseLayout<T>`, `SpecializedShapeCatalog`, `SpecializedPerfBar` stub, determinism-harness extension points | builds |
+| **P1** | **TRSM** — triangular-solve microkernel + blocked driver + tests/determinism + rewire `LinearSolvers`/Cholesky/QR/LU solve loops | P0 |
+| **P2** | **SYRK** — tile-skip + triangular-write epilogue + tests/determinism + rewire covariance/gram call sites | P1 |
+| **P3** | **SYMM** — mirror-on-pack A-packer + tests/determinism + rewire | P1 |
+| **P4** | **CPU SpMM** — CSR row-parallel + CSC + SIMD-over-N + fused epilogue + rewire `CpuSparseEngine.SpMM` (sparse×dense) | P0 |
+| **P5** | **GBMV** — banded level-2 kernel + tests/determinism + rewire banded/tridiagonal call sites | P0 |
+| **P6** | **GPU SpMM** — flip default to custom kernels, close perf gap (warp-per-row, vectorized loads, FP64), mirror HIP/ROCm | P4 |
+| **P7** | **Vendor removal** — delete cuSPARSE/rocSPARSE P/Invoke + probes + package refs, only after P6's parity bar is green | P6 bar green |
+
+TRSM is P1 because it proves the macrokernel-reuse template every later dense variant copies.
+
+### Call-site rewiring discipline
+Mechanical and additive (like #368's routing shim): existing managed loops are replaced by `BlasManaged.X` calls; the existing test suite that exercises those paths is the canary. No call site changes its public behavior.
+
+### Escape hatches (carried from #368 §7)
+- If a variant can't hit its bar on a class of shapes, autotune routes those shapes to the vendor/native path rather than shipping a regression.
+- For GPU, **P7 (vendor deletion) is deferred, not forced**, if P6's bar isn't met — keeping the mega-PR from being held hostage by the single hardest variant. Each deferral is an explicit, visible decision in the issue thread.
+
+## 7 — Out of scope
+
+- LAPACK-level routines (cholesky/qr/svd/lu factorization themselves — only their *triangular-solve* steps are in scope via TRSM).
+- FP16/BF16/INT8 specialized kernels (FP32/FP64 only this PR).
+- Block-sparse (BSR/BSC) SpMM — `SparseTensor<T>` supports the storage, but blocked SpMM kernels are a follow-up; CSR/CSC are primary here.
+- Sparse×sparse (`SpSpMM`) — a different algorithm (sparse×sparse, not sparse×dense) than the `SpMM` kernel this PR adds. `CpuSparseEngine.SpSpMM` is left as-is; only the SIMD-vectorized SpMM (sparse×dense) primitives it internally relies on (if any) benefit indirectly. No new SpSpMM kernel (CPU or GPU) in this PR.
+
+## 8 — Decisions captured
+
+| Decision | Choice |
+|----------|--------|
+| Architecture | Approach A — reuse GEMM microkernel core for TRSM/SYRK/SYMM; standalone for GBMV/SpMM |
+| Goal | Both first-class APIs **and** perf optimization (exceed vendors, not just match) |
+| Scope | All 5 CPU families + GPU SpMM |
+| Determinism | Same `BlasMode` contract as dense GEMM (Deterministic default, opt-in Fast) |
+| GPU sparse | In scope — custom kernels parity-or-better, then remove cuSPARSE/rocSPARSE |
+| Delivery | One phased mega-PR, independently-green phases |
+| API | Drop-in CBLAS arg order; exceed via fused epilogue + determinism + generic T |
+
+## 9 — Next steps
+
+1. Spec self-review (inline fixes).
+2. User reviews spec — gate before writing-plans.
+3. writing-plans skill produces the phased implementation plan keyed off this spec.

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Gbmv.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Gbmv.cs
@@ -20,9 +20,27 @@ public static partial class BlasManaged
         in BlasOptions<T> options = default) where T : unmanaged
     {
         if (m <= 0 || n <= 0) return;
+        if (kl < 0 || ku < 0)
+            throw new ArgumentOutOfRangeException(nameof(kl), "kl and ku must be non-negative.");
+        if (incx <= 0 || incy <= 0)
+            throw new ArgumentOutOfRangeException(nameof(incx), "incx and incy must be positive.");
+        if (lda < kl + ku + 1)
+            throw new ArgumentOutOfRangeException(nameof(lda), "lda must be >= kl + ku + 1.");
+
+        int lenX = transA ? m : n;   // length of x (column index range)
+        int lenY = transA ? n : m;   // length of y (row index range)
+        long needA = (long)lda * n;
+        long needX = 1L + (long)(lenX - 1) * incx;
+        long needY = 1L + (long)(lenY - 1) * incy;
+        if (a.Length < needA)
+            throw new ArgumentException("Span 'a' is too short for lda*n band storage.", nameof(a));
+        if (x.Length < needX)
+            throw new ArgumentException("Span 'x' is too short for the given length/incx.", nameof(x));
+        if (y.Length < needY)
+            throw new ArgumentException("Span 'y' is too short for the given length/incy.", nameof(y));
+
         var ops = MathHelper.GetNumericOperations<T>();
 
-        int lenY = transA ? n : m;
         // Scale y by beta.
         for (int o = 0; o < lenY; o++)
         {

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Gbmv.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Gbmv.cs
@@ -1,0 +1,68 @@
+using System;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.Interfaces;
+
+namespace AiDotNet.Tensors.Engines.BlasManaged;
+
+public static partial class BlasManaged
+{
+    /// <summary>
+    /// Banded matrix-vector multiply: y = α·op(A)·x + β·y, where A is an m×n band
+    /// matrix with <paramref name="kl"/> sub- and <paramref name="ku"/> super-diagonals,
+    /// stored in the LAPACK band layout (lda ≥ kl+ku+1, column-major band: the logical
+    /// element A(i,j) lives at a[j·lda + (ku - j + i)]). Drop-in for cblas_sgbmv/cblas_dgbmv.
+    /// </summary>
+    public static void Gbmv<T>(
+        bool transA, int m, int n, int kl, int ku, T alpha,
+        ReadOnlySpan<T> a, int lda,
+        ReadOnlySpan<T> x, int incx, T beta,
+        Span<T> y, int incy,
+        in BlasOptions<T> options = default) where T : unmanaged
+    {
+        if (m <= 0 || n <= 0) return;
+        var ops = MathHelper.GetNumericOperations<T>();
+
+        int lenY = transA ? n : m;
+        // Scale y by beta.
+        for (int o = 0; o < lenY; o++)
+        {
+            int yo = o * incy;
+            y[yo] = ops.Multiply(beta, y[yo]);
+        }
+
+        if (!transA)
+        {
+            // y[i] += α · Σ_j A(i,j)·x[j], j over the band [max(0,i-kl), min(n-1,i+ku)].
+            for (int i = 0; i < m; i++)
+            {
+                int jlo = Math.Max(0, i - kl);
+                int jhi = Math.Min(n - 1, i + ku);
+                T acc = ops.Zero;
+                for (int j = jlo; j <= jhi; j++)
+                {
+                    T aval = a[j * lda + (ku - j + i)];
+                    acc = ops.Add(acc, ops.Multiply(aval, x[j * incx]));
+                }
+                int yi = i * incy;
+                y[yi] = ops.Add(y[yi], ops.Multiply(alpha, acc));
+            }
+        }
+        else
+        {
+            // y[j] += α · Σ_i A(i,j)·x[i], i over the band [max(0,j-ku), min(m-1,j+kl)].
+            for (int j = 0; j < n; j++)
+            {
+                int ilo = Math.Max(0, j - ku);
+                int ihi = Math.Min(m - 1, j + kl);
+                T acc = ops.Zero;
+                for (int i = ilo; i <= ihi; i++)
+                {
+                    T aval = a[j * lda + (ku - j + i)];
+                    acc = ops.Add(acc, ops.Multiply(aval, x[i * incx]));
+                }
+                int yj = j * incy;
+                y[yj] = ops.Add(y[yj], ops.Multiply(alpha, acc));
+            }
+        }
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.SpMM.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.SpMM.cs
@@ -1,0 +1,73 @@
+using System;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.Interfaces;
+
+namespace AiDotNet.Tensors.Engines.BlasManaged;
+
+public static partial class BlasManaged
+{
+    /// <summary>
+    /// Sparse×dense matrix multiply: C = α·A·B + β·C, where A is a sparse rows×cols
+    /// matrix (<paramref name="a"/>, CSR or CSC) and B is dense cols×n. C is rows×n.
+    /// CSR is the cache-friendly primary path (each B row read contiguously; output
+    /// rows independent → deterministic). Aligns with MKL Sparse BLAS mkl_sparse_*_mm.
+    /// </summary>
+    public static void SpMM<T>(
+        T alpha, SparseLayout<T> a,
+        ReadOnlySpan<T> b, int ldb, int n, T beta,
+        Span<T> c, int ldc,
+        in BlasOptions<T> options = default) where T : unmanaged
+    {
+        int rows = a.Rows, cols = a.Cols;
+        if (rows <= 0 || n <= 0) return;
+        var ops = MathHelper.GetNumericOperations<T>();
+
+        // Pre-scale C by beta (whole logical rows×n output tile).
+        for (int i = 0; i < rows; i++)
+            for (int j = 0; j < n; j++)
+            {
+                int ci = i * ldc + j;
+                c[ci] = ops.Multiply(beta, c[ci]);
+            }
+
+        var ptr = a.Pointers;
+        var idx = a.Indices;
+        var val = a.Values;
+
+        if (a.Format == SparseLayoutFormat.Csr)
+        {
+            // Row-local: C[i,:] += (α·v)·B[k,:]. Rows independent → bit-exact.
+            for (int i = 0; i < rows; i++)
+            {
+                int start = ptr[i], end = ptr[i + 1];
+                int cBase = i * ldc;
+                for (int p = start; p < end; p++)
+                {
+                    int k = idx[p];
+                    T av = ops.Multiply(alpha, val[p]);
+                    int bBase = k * ldb;
+                    for (int j = 0; j < n; j++)
+                        c[cBase + j] = ops.Add(c[cBase + j], ops.Multiply(av, b[bBase + j]));
+                }
+            }
+        }
+        else
+        {
+            // CSC: iterate columns of A, scatter into the matching C rows. Fixed
+            // column-then-nonzero order keeps the accumulation deterministic.
+            for (int k = 0; k < cols; k++)
+            {
+                int start = ptr[k], end = ptr[k + 1];
+                int bBase = k * ldb;
+                for (int p = start; p < end; p++)
+                {
+                    int i = idx[p];
+                    T av = ops.Multiply(alpha, val[p]);
+                    int cBase = i * ldc;
+                    for (int j = 0; j < n; j++)
+                        c[cBase + j] = ops.Add(c[cBase + j], ops.Multiply(av, b[bBase + j]));
+                }
+            }
+        }
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.SpMM.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.SpMM.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.Interfaces;
 
@@ -10,7 +12,11 @@ public static partial class BlasManaged
     /// Sparse×dense matrix multiply: C = α·A·B + β·C, where A is a sparse rows×cols
     /// matrix (<paramref name="a"/>, CSR or CSC) and B is dense cols×n. C is rows×n.
     /// CSR is the cache-friendly primary path (each B row read contiguously; output
-    /// rows independent → deterministic). Aligns with MKL Sparse BLAS mkl_sparse_*_mm.
+    /// rows independent → deterministic and row-parallel). FP32/FP64 run a typed,
+    /// auto-vectorized inner loop; other T use the generic numeric-ops path. Any
+    /// <see cref="BlasOptions{T}.Epilogue"/> (bias / activation / skip / dropout /
+    /// output-scale) is fused after the multiply — a single pass that vendor sparse
+    /// libraries cannot match. Aligns with MKL Sparse BLAS mkl_sparse_*_mm.
     /// </summary>
     public static void SpMM<T>(
         T alpha, SparseLayout<T> a,
@@ -20,9 +26,169 @@ public static partial class BlasManaged
     {
         int rows = a.Rows, cols = a.Cols;
         if (rows <= 0 || n <= 0) return;
-        var ops = MathHelper.GetNumericOperations<T>();
 
-        // Pre-scale C by beta (whole logical rows×n output tile).
+        bool csr = a.Format == SparseLayoutFormat.Csr;
+        int threads = ResolveSpMMThreads(options.NumThreads, options.Mode, rows);
+
+        if (typeof(T) == typeof(float))
+        {
+            SpMMFloat(
+                (float)(object)alpha, csr, a.Pointers, a.Indices,
+                MemoryMarshal.Cast<T, float>(a.Values),
+                MemoryMarshal.Cast<T, float>(b), ldb, n, (float)(object)beta,
+                MemoryMarshal.Cast<T, float>(c), ldc, rows, cols, threads);
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            SpMMDouble(
+                (double)(object)alpha, csr, a.Pointers, a.Indices,
+                MemoryMarshal.Cast<T, double>(a.Values),
+                MemoryMarshal.Cast<T, double>(b), ldb, n, (double)(object)beta,
+                MemoryMarshal.Cast<T, double>(c), ldc, rows, cols, threads);
+        }
+        else
+        {
+            SpMMGeneric(alpha, csr, a.Pointers, a.Indices, a.Values, b, ldb, n, beta, c, ldc, rows, cols);
+        }
+
+        // Fused epilogue (bias / activation / skip / dropout / output-scale) — same
+        // machinery GEMM uses, applied to the logical rows×n output tile.
+        var epilogue = options.Epilogue;
+        EpilogueChain.Apply<T>(c, ldc, rows, n, in epilogue);
+    }
+
+    // -1/1 → serial; 0 → auto (Parallel default DOP); >1 → that many. Tiny problems
+    // stay serial to avoid scheduling overhead dominating.
+    private static int ResolveSpMMThreads(int numThreads, BlasMode mode, int rows)
+    {
+        if (numThreads == 1 || numThreads == -1) return 1;
+        if (rows < 64) return 1;
+        return numThreads; // 0 = auto, >1 = pinned
+    }
+
+    private static unsafe void SpMMDouble(
+        double alpha, bool csr, ReadOnlySpan<int> ptr, ReadOnlySpan<int> ind, ReadOnlySpan<double> val,
+        ReadOnlySpan<double> b, int ldb, int n, double beta, Span<double> c, int ldc,
+        int rows, int cols, int threads)
+    {
+        fixed (int* ptrP = ptr, indP = ind)
+        fixed (double* valP = val, bP = b, cP = c)
+        {
+            nint ptrA = (nint)ptrP, indA = (nint)indP, valA = (nint)valP, bA = (nint)bP, cA = (nint)cP;
+
+            if (csr)
+            {
+                // Row-local: each output row computed by exactly one worker, in fixed
+                // nonzero order → bit-exact regardless of thread count.
+                void CsrRow(int i)
+                {
+                    int* pp = (int*)ptrA; int* ip = (int*)indA;
+                    double* vp = (double*)valA; double* bb = (double*)bA; double* cc = (double*)cA;
+                    double* crow = cc + (long)i * ldc;
+                    for (int j = 0; j < n; j++) crow[j] *= beta;
+                    int s = pp[i], e = pp[i + 1];
+                    for (int q = s; q < e; q++)
+                    {
+                        int k = ip[q];
+                        double av = alpha * vp[q];
+                        double* brow = bb + (long)k * ldb;
+                        for (int j = 0; j < n; j++) crow[j] += av * brow[j];
+                    }
+                }
+
+                if (threads == 1) { for (int i = 0; i < rows; i++) CsrRow(i); }
+                else
+                {
+                    var po = new ParallelOptions();
+                    if (threads > 1) po.MaxDegreeOfParallelism = threads;
+                    Parallel.For(0, rows, po, CsrRow);
+                }
+            }
+            else
+            {
+                // CSC: scatter into rows → not row-local; serial fixed-order keeps it
+                // deterministic. Pre-scale C by beta once, then accumulate columns.
+                double* cc = (double*)cA; double* bb = (double*)bA;
+                int* pp = (int*)ptrA; int* ip = (int*)indA; double* vp = (double*)valA;
+                for (int i = 0; i < rows; i++) { double* crow = cc + (long)i * ldc; for (int j = 0; j < n; j++) crow[j] *= beta; }
+                for (int k = 0; k < cols; k++)
+                {
+                    double* brow = bb + (long)k * ldb;
+                    int s = pp[k], e = pp[k + 1];
+                    for (int q = s; q < e; q++)
+                    {
+                        int i = ip[q];
+                        double av = alpha * vp[q];
+                        double* crow = cc + (long)i * ldc;
+                        for (int j = 0; j < n; j++) crow[j] += av * brow[j];
+                    }
+                }
+            }
+        }
+    }
+
+    private static unsafe void SpMMFloat(
+        float alpha, bool csr, ReadOnlySpan<int> ptr, ReadOnlySpan<int> ind, ReadOnlySpan<float> val,
+        ReadOnlySpan<float> b, int ldb, int n, float beta, Span<float> c, int ldc,
+        int rows, int cols, int threads)
+    {
+        fixed (int* ptrP = ptr, indP = ind)
+        fixed (float* valP = val, bP = b, cP = c)
+        {
+            nint ptrA = (nint)ptrP, indA = (nint)indP, valA = (nint)valP, bA = (nint)bP, cA = (nint)cP;
+
+            if (csr)
+            {
+                void CsrRow(int i)
+                {
+                    int* pp = (int*)ptrA; int* ip = (int*)indA;
+                    float* vp = (float*)valA; float* bb = (float*)bA; float* cc = (float*)cA;
+                    float* crow = cc + (long)i * ldc;
+                    for (int j = 0; j < n; j++) crow[j] *= beta;
+                    int s = pp[i], e = pp[i + 1];
+                    for (int q = s; q < e; q++)
+                    {
+                        int k = ip[q];
+                        float av = alpha * vp[q];
+                        float* brow = bb + (long)k * ldb;
+                        for (int j = 0; j < n; j++) crow[j] += av * brow[j];
+                    }
+                }
+
+                if (threads == 1) { for (int i = 0; i < rows; i++) CsrRow(i); }
+                else
+                {
+                    var po = new ParallelOptions();
+                    if (threads > 1) po.MaxDegreeOfParallelism = threads;
+                    Parallel.For(0, rows, po, CsrRow);
+                }
+            }
+            else
+            {
+                float* cc = (float*)cA; float* bb = (float*)bA;
+                int* pp = (int*)ptrA; int* ip = (int*)indA; float* vp = (float*)valA;
+                for (int i = 0; i < rows; i++) { float* crow = cc + (long)i * ldc; for (int j = 0; j < n; j++) crow[j] *= beta; }
+                for (int k = 0; k < cols; k++)
+                {
+                    float* brow = bb + (long)k * ldb;
+                    int s = pp[k], e = pp[k + 1];
+                    for (int q = s; q < e; q++)
+                    {
+                        int i = ip[q];
+                        float av = alpha * vp[q];
+                        float* crow = cc + (long)i * ldc;
+                        for (int j = 0; j < n; j++) crow[j] += av * brow[j];
+                    }
+                }
+            }
+        }
+    }
+
+    private static void SpMMGeneric<T>(
+        T alpha, bool csr, ReadOnlySpan<int> ptr, ReadOnlySpan<int> ind, ReadOnlySpan<T> val,
+        ReadOnlySpan<T> b, int ldb, int n, T beta, Span<T> c, int ldc, int rows, int cols) where T : unmanaged
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
         for (int i = 0; i < rows; i++)
             for (int j = 0; j < n; j++)
             {
@@ -30,21 +196,16 @@ public static partial class BlasManaged
                 c[ci] = ops.Multiply(beta, c[ci]);
             }
 
-        var ptr = a.Pointers;
-        var idx = a.Indices;
-        var val = a.Values;
-
-        if (a.Format == SparseLayoutFormat.Csr)
+        if (csr)
         {
-            // Row-local: C[i,:] += (α·v)·B[k,:]. Rows independent → bit-exact.
             for (int i = 0; i < rows; i++)
             {
-                int start = ptr[i], end = ptr[i + 1];
+                int s = ptr[i], e = ptr[i + 1];
                 int cBase = i * ldc;
-                for (int p = start; p < end; p++)
+                for (int q = s; q < e; q++)
                 {
-                    int k = idx[p];
-                    T av = ops.Multiply(alpha, val[p]);
+                    int k = ind[q];
+                    T av = ops.Multiply(alpha, val[q]);
                     int bBase = k * ldb;
                     for (int j = 0; j < n; j++)
                         c[cBase + j] = ops.Add(c[cBase + j], ops.Multiply(av, b[bBase + j]));
@@ -53,16 +214,14 @@ public static partial class BlasManaged
         }
         else
         {
-            // CSC: iterate columns of A, scatter into the matching C rows. Fixed
-            // column-then-nonzero order keeps the accumulation deterministic.
             for (int k = 0; k < cols; k++)
             {
-                int start = ptr[k], end = ptr[k + 1];
                 int bBase = k * ldb;
-                for (int p = start; p < end; p++)
+                int s = ptr[k], e = ptr[k + 1];
+                for (int q = s; q < e; q++)
                 {
-                    int i = idx[p];
-                    T av = ops.Multiply(alpha, val[p]);
+                    int i = ind[q];
+                    T av = ops.Multiply(alpha, val[q]);
                     int cBase = i * ldc;
                     for (int j = 0; j < n; j++)
                         c[cBase + j] = ops.Add(c[cBase + j], ops.Multiply(av, b[bBase + j]));

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.SpMM.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.SpMM.cs
@@ -189,26 +189,34 @@ public static partial class BlasManaged
         ReadOnlySpan<T> b, int ldb, int n, T beta, Span<T> c, int ldc, int rows, int cols) where T : unmanaged
     {
         var ops = MathHelper.GetNumericOperations<T>();
+        // Use long base indices to match the typed float/double pointer paths
+        // (which compute `(long)i * ldc`): rows × ldc can exceed int range.
         for (int i = 0; i < rows; i++)
+        {
+            long cBase = (long)i * ldc;
             for (int j = 0; j < n; j++)
             {
-                int ci = i * ldc + j;
+                int ci = (int)(cBase + j);
                 c[ci] = ops.Multiply(beta, c[ci]);
             }
+        }
 
         if (csr)
         {
             for (int i = 0; i < rows; i++)
             {
                 int s = ptr[i], e = ptr[i + 1];
-                int cBase = i * ldc;
+                long cBase = (long)i * ldc;
                 for (int q = s; q < e; q++)
                 {
                     int k = ind[q];
                     T av = ops.Multiply(alpha, val[q]);
-                    int bBase = k * ldb;
+                    long bBase = (long)k * ldb;
                     for (int j = 0; j < n; j++)
-                        c[cBase + j] = ops.Add(c[cBase + j], ops.Multiply(av, b[bBase + j]));
+                    {
+                        int ci = (int)(cBase + j);
+                        c[ci] = ops.Add(c[ci], ops.Multiply(av, b[(int)(bBase + j)]));
+                    }
                 }
             }
         }
@@ -216,15 +224,18 @@ public static partial class BlasManaged
         {
             for (int k = 0; k < cols; k++)
             {
-                int bBase = k * ldb;
+                long bBase = (long)k * ldb;
                 int s = ptr[k], e = ptr[k + 1];
                 for (int q = s; q < e; q++)
                 {
                     int i = ind[q];
                     T av = ops.Multiply(alpha, val[q]);
-                    int cBase = i * ldc;
+                    long cBase = (long)i * ldc;
                     for (int j = 0; j < n; j++)
-                        c[cBase + j] = ops.Add(c[cBase + j], ops.Multiply(av, b[bBase + j]));
+                    {
+                        int ci = (int)(cBase + j);
+                        c[ci] = ops.Add(c[ci], ops.Multiply(av, b[(int)(bBase + j)]));
+                    }
                 }
             }
         }

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Symm.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Symm.cs
@@ -19,9 +19,25 @@ public static partial class BlasManaged
         Span<T> c, int ldc,
         in BlasOptions<T> options = default) where T : unmanaged
     {
-        if (m <= 0 || n <= 0) return;
+        if (m < 0) throw new ArgumentOutOfRangeException(nameof(m), "m must be non-negative.");
+        if (n < 0) throw new ArgumentOutOfRangeException(nameof(n), "n must be non-negative.");
+        if (m == 0 || n == 0) return;
+        if (side is not Side.Left and not Side.Right)
+            throw new ArgumentOutOfRangeException(nameof(side));
+        if (uplo is not Uplo.Lower and not Uplo.Upper)
+            throw new ArgumentOutOfRangeException(nameof(uplo));
+
         var ops = MathHelper.GetNumericOperations<T>();
         int s = side == Side.Left ? m : n;   // dimension of square symmetric A
+        if (lda < s) throw new ArgumentOutOfRangeException(nameof(lda), "lda must be >= the symmetric matrix dimension.");
+        if (ldb < n) throw new ArgumentOutOfRangeException(nameof(ldb), "ldb must be >= n.");
+        if (ldc < n) throw new ArgumentOutOfRangeException(nameof(ldc), "ldc must be >= n.");
+        if (a.Length < (long)(s - 1) * lda + s)
+            throw new ArgumentException("Span 'a' is too short for the symmetric matrix storage.", nameof(a));
+        if (b.Length < (long)(m - 1) * ldb + n)
+            throw new ArgumentException("Span 'b' is too short.", nameof(b));
+        if (c.Length < (long)(m - 1) * ldc + n)
+            throw new ArgumentException("Span 'c' is too short.", nameof(c));
 
         // Materialize full symmetric A (s×s) from the uplo triangle (mirror).
         T[] full = new T[s * s];

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Symm.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Symm.cs
@@ -1,0 +1,51 @@
+using System;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.Interfaces;
+
+namespace AiDotNet.Tensors.Engines.BlasManaged;
+
+public static partial class BlasManaged
+{
+    /// <summary>
+    /// Symmetric matrix multiply. Side.Left: C = α·A·B + β·C (A is m×m symmetric).
+    /// Side.Right: C = α·B·A + β·C (A is n×n symmetric). A is stored in the
+    /// <paramref name="uplo"/> triangle. Drop-in for cblas_ssymm/cblas_dsymm.
+    /// </summary>
+    public static void Symm<T>(
+        Side side, Uplo uplo,
+        int m, int n, T alpha,
+        ReadOnlySpan<T> a, int lda,
+        ReadOnlySpan<T> b, int ldb, T beta,
+        Span<T> c, int ldc,
+        in BlasOptions<T> options = default) where T : unmanaged
+    {
+        if (m <= 0 || n <= 0) return;
+        var ops = MathHelper.GetNumericOperations<T>();
+        int s = side == Side.Left ? m : n;   // dimension of square symmetric A
+
+        // Materialize full symmetric A (s×s) from the uplo triangle (mirror).
+        T[] full = new T[s * s];
+        for (int i = 0; i < s; i++)
+            for (int j = 0; j < s; j++)
+            {
+                bool stored = uplo == Uplo.Lower ? j <= i : j >= i;
+                full[i * s + j] = stored ? a[i * lda + j] : a[j * lda + i];
+            }
+
+        // result = A·B (Left, m×n) or B·A (Right, m×n) via the existing GEMM core.
+        T[] result = new T[m * n];
+        var gemmOpts = new BlasOptions<T> { NumThreads = options.NumThreads, Mode = options.Mode };
+        if (side == Side.Left)
+            Gemm<T>(full, s, false, b, ldb, false, result, n, m, n, s, gemmOpts); // (m×m)(m×n)
+        else
+            Gemm<T>(b, ldb, false, full, s, false, result, n, m, n, s, gemmOpts); // (m×n)(n×n)
+
+        // C = α·result + β·C
+        for (int i = 0; i < m; i++)
+            for (int j = 0; j < n; j++)
+            {
+                int ci = i * ldc + j;
+                c[ci] = ops.Add(ops.Multiply(alpha, result[i * n + j]), ops.Multiply(beta, c[ci]));
+            }
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Syrk.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Syrk.cs
@@ -21,6 +21,14 @@ public static partial class BlasManaged
         if (n <= 0) return;
         var ops = MathHelper.GetNumericOperations<T>();
 
+        // Tile-skip path for large n: compute only tiles intersecting the requested
+        // triangle (~half the FLOPs of a dense GEMM — the real SYRK win).
+        if (n > SyrkBlock)
+        {
+            SyrkBlocked(uplo, trans, n, k, alpha, a, lda, beta, c, ldc, options, ops);
+            return;
+        }
+
         // full = op(A)·op(A)ᵀ  (n×n) via the existing GEMM core.
         // trans=false: A(n×k) · A(n×k)ᵀ → Gemm(a=A, transA=false, b=A, transB=true, k=k)
         // trans=true:  Aᵀ(n×k) · A(k×n) → Gemm(a=A, transA=true, b=A, transB=false, k=k)
@@ -41,6 +49,66 @@ public static partial class BlasManaged
                 int ci = i * ldc + j;
                 T scaled = ops.Multiply(alpha, full[i * n + j]);
                 c[ci] = ops.Add(scaled, ops.Multiply(beta, c[ci]));
+            }
+        }
+    }
+
+    private const int SyrkBlock = 64;
+
+    private static void SyrkBlocked<T>(
+        Uplo uplo, bool trans, int n, int k, T alpha, ReadOnlySpan<T> a, int lda, T beta,
+        Span<T> c, int ldc, in BlasOptions<T> options, INumericOperations<T> ops) where T : unmanaged
+    {
+        var gemmOpts = new BlasOptions<T> { NumThreads = options.NumThreads, Mode = options.Mode };
+        for (int i0 = 0; i0 < n; i0 += SyrkBlock)
+        {
+            int bm = Math.Min(SyrkBlock, n - i0);
+            for (int j0 = 0; j0 < n; j0 += SyrkBlock)
+            {
+                int bn = Math.Min(SyrkBlock, n - j0);
+                // Skip tiles wholly outside the requested triangle.
+                if (uplo == Uplo.Lower) { if (j0 > i0 + bm - 1) continue; }
+                else                    { if (j0 + bn - 1 < i0) continue; }
+
+                // tile = op(A)[i0:i0+bm, :] · op(A)[j0:j0+bn, :]ᵀ  (bm×bn)
+                T[] tile = new T[bm * bn];
+                if (k > 0)
+                {
+                    if (!trans)
+                    {
+                        // op(A) row r = a[r*lda + p]; sub-blocks at rows i0.., j0..
+                        var aI = a.Slice(i0 * lda);          // bm rows × k, lda-strided
+                        var aJ = a.Slice(j0 * lda);          // bn rows × k, lda-strided
+                        Gemm<T>(aI, lda, false, aJ, lda, true, tile, bn, bm, bn, k, gemmOpts);
+                    }
+                    else
+                    {
+                        // Column-strided operands (op(A) row r = a[p*lda + r]); scalar dot
+                        // keeps the trans tile correct + deterministic. Same skip pattern.
+                        for (int ii = 0; ii < bm; ii++)
+                            for (int jj = 0; jj < bn; jj++)
+                            {
+                                T dot = ops.Zero;
+                                for (int p = 0; p < k; p++)
+                                    dot = ops.Add(dot, ops.Multiply(a[p * lda + (i0 + ii)], a[p * lda + (j0 + jj)]));
+                                tile[ii * bn + jj] = dot;
+                            }
+                    }
+                }
+
+                // Write tile into C[uplo] with alpha/beta, masking the diagonal tile.
+                for (int ii = 0; ii < bm; ii++)
+                {
+                    int gi = i0 + ii;
+                    for (int jj = 0; jj < bn; jj++)
+                    {
+                        int gj = j0 + jj;
+                        bool inTri = uplo == Uplo.Lower ? gj <= gi : gj >= gi;
+                        if (!inTri) continue;
+                        int ci = gi * ldc + gj;
+                        c[ci] = ops.Add(ops.Multiply(alpha, tile[ii * bn + jj]), ops.Multiply(beta, c[ci]));
+                    }
+                }
             }
         }
     }

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Syrk.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Syrk.cs
@@ -83,16 +83,10 @@ public static partial class BlasManaged
                     }
                     else
                     {
-                        // Column-strided operands (op(A) row r = a[p*lda + r]); scalar dot
-                        // keeps the trans tile correct + deterministic. Same skip pattern.
-                        for (int ii = 0; ii < bm; ii++)
-                            for (int jj = 0; jj < bn; jj++)
-                            {
-                                T dot = ops.Zero;
-                                for (int p = 0; p < k; p++)
-                                    dot = ops.Add(dot, ops.Multiply(a[p * lda + (i0 + ii)], a[p * lda + (j0 + jj)]));
-                                tile[ii * bn + jj] = dot;
-                            }
+                        // trans=true: op(A) = Aᵀ, A is k×n. tile = op(A)[i0:,:]·op(A)[j0:,:]ᵀ.
+                        // op(A)[i0:i0+bm,:] = (A[:, i0:i0+bm])ᵀ → pass A[:, i0:] (k×bm) with transA=true;
+                        // op(A)[j0:j0+bn,:]ᵀ = A[:, j0:j0+bn] (k×bn) → pass with transB=false.
+                        Gemm<T>(a.Slice(i0), lda, true, a.Slice(j0), lda, false, tile, bn, bm, bn, k, gemmOpts);
                     }
                 }
 

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Syrk.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Syrk.cs
@@ -1,0 +1,47 @@
+using System;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.Interfaces;
+
+namespace AiDotNet.Tensors.Engines.BlasManaged;
+
+public static partial class BlasManaged
+{
+    /// <summary>
+    /// Symmetric rank-k update: C = α·op(A)·op(A)ᵀ + β·C, writing only the
+    /// <paramref name="uplo"/> triangle of the n×n matrix C. op(A) is A (trans=false,
+    /// A is n×k) or Aᵀ (trans=true, A is k×n). Drop-in for cblas_ssyrk/cblas_dsyrk.
+    /// </summary>
+    public static void Syrk<T>(
+        Uplo uplo, bool trans,
+        int n, int k, T alpha,
+        ReadOnlySpan<T> a, int lda, T beta,
+        Span<T> c, int ldc,
+        in BlasOptions<T> options = default) where T : unmanaged
+    {
+        if (n <= 0) return;
+        var ops = MathHelper.GetNumericOperations<T>();
+
+        // full = op(A)·op(A)ᵀ  (n×n) via the existing GEMM core.
+        // trans=false: A(n×k) · A(n×k)ᵀ → Gemm(a=A, transA=false, b=A, transB=true, k=k)
+        // trans=true:  Aᵀ(n×k) · A(k×n) → Gemm(a=A, transA=true, b=A, transB=false, k=k)
+        T[] full = new T[n * n];
+        if (k > 0)
+        {
+            var gemmOpts = new BlasOptions<T> { NumThreads = options.NumThreads, Mode = options.Mode };
+            Gemm<T>(a, lda, trans, a, lda, !trans, full, n, n, n, k, gemmOpts);
+        }
+
+        // Write C[uplo] = α·full + β·C[uplo]; leave the other triangle untouched.
+        for (int i = 0; i < n; i++)
+        {
+            int lo = uplo == Uplo.Lower ? 0 : i;
+            int hi = uplo == Uplo.Lower ? i : n - 1;
+            for (int j = lo; j <= hi; j++)
+            {
+                int ci = i * ldc + j;
+                T scaled = ops.Multiply(alpha, full[i * n + j]);
+                c[ci] = ops.Add(scaled, ops.Multiply(beta, c[ci]));
+            }
+        }
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Trsm.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Trsm.cs
@@ -32,11 +32,8 @@ public static partial class BlasManaged
 
         if (side == Side.Left)
         {
-            // Blocked path only for the canonical Left-Lower-NoTrans case in this
-            // phase; all other combinations use the proven scalar kernel. Later
-            // tasks extend blocking to upper/transposed cases.
-            if (m > TrsmBlock && uplo == Uplo.Lower && !transA)
-                TrsmLeftLowerNoTransBlocked(diag, m, n, a, lda, b, ldb, options, ops);
+            if (m > TrsmBlock)
+                TrsmLeftBlocked(uplo, transA, diag, m, n, a, lda, b, ldb, options, ops);
             else
                 TrsmLeftScalar(uplo, transA, diag, m, n, a, lda, b, ldb, ops);
         }
@@ -48,42 +45,77 @@ public static partial class BlasManaged
     // diagonal block in L1 while giving the GEMM macrokernel a worthwhile panel.
     private const int TrsmBlock = 64;
 
-    private static void TrsmLeftLowerNoTransBlocked<T>(
-        Diag diag, int m, int n,
+    /// <summary>
+    /// Blocked Left triangular solve for all four (uplo × transA) combinations.
+    /// Each diagonal block is solved with the scalar kernel; the trailing block
+    /// rows are updated via the GEMM macrokernel (B -= op(A)_offdiag · X_block).
+    /// Effective-lower (forward, top→bottom) updates rows below; effective-upper
+    /// (backward, bottom→top) updates rows above.
+    /// </summary>
+    private static void TrsmLeftBlocked<T>(
+        Uplo uplo, bool transA, Diag diag, int m, int n,
         ReadOnlySpan<T> a, int lda, Span<T> b, int ldb,
         in BlasOptions<T> options,
         INumericOperations<T> ops) where T : unmanaged
     {
-        for (int i0 = 0; i0 < m; i0 += TrsmBlock)
+        // Effective triangle after transpose decides substitution direction.
+        bool lower = (uplo == Uplo.Lower) ^ transA;
+        var gemmOpts = new BlasOptions<T> { NumThreads = options.NumThreads, Mode = options.Mode };
+
+        if (lower)
         {
-            int bm = Math.Min(TrsmBlock, m - i0);
-
-            // 1) Solve the bm×n diagonal block with the scalar kernel.
-            //    The block's own triangle is A[i0:i0+bm, i0:i0+bm].
-            var aDiag = a.Slice(i0 * lda + i0);
-            var bBlock = b.Slice(i0 * ldb);
-            TrsmLeftScalar(Uplo.Lower, false, diag, bm, n, aDiag, lda, bBlock, ldb, ops);
-
-            // 2) Trailing update: for rows below this block,
-            //    B[i0+bm:, :] -= A[i0+bm:, i0:i0+bm] · X[i0:i0+bm, :]
-            int remRows = m - (i0 + bm);
-            if (remRows > 0)
+            for (int i0 = 0; i0 < m; i0 += TrsmBlock)
             {
-                var aSub = a.Slice((i0 + bm) * lda + i0); // remRows × bm panel (lda-strided)
-                var xBlk = b.Slice(i0 * ldb);              // bm × n (just solved), ldb-strided
-                // scratch = aSub · xBlk  (remRows × n)
-                T[] scratch = new T[remRows * n];
-                Gemm<T>(aSub, lda, false, xBlk, ldb, false, scratch, n, remRows, n, bm,
-                        new BlasOptions<T> { NumThreads = options.NumThreads, Mode = options.Mode });
-                var bRem = b.Slice((i0 + bm) * ldb);
-                for (int r = 0; r < remRows; r++)
-                    for (int c = 0; c < n; c++)
-                    {
-                        int bi = r * ldb + c;
-                        bRem[bi] = ops.Subtract(bRem[bi], scratch[r * n + c]);
-                    }
+                int bm = Math.Min(TrsmBlock, m - i0);
+                TrsmLeftScalar(uplo, transA, diag, bm, n, a.Slice(i0 * lda + i0), lda, b.Slice(i0 * ldb), ldb, ops);
+                // Update rows below: [i0+bm, m).
+                int rlo = i0 + bm, rhi = m;
+                if (rhi > rlo)
+                    TrsmTrailingUpdate(transA, rlo, rhi, i0, bm, n, a, lda, b, ldb, gemmOpts, ops);
             }
         }
+        else
+        {
+            // Backward: process diagonal blocks bottom→top.
+            int nb = (m + TrsmBlock - 1) / TrsmBlock;
+            for (int blk = nb - 1; blk >= 0; blk--)
+            {
+                int i0 = blk * TrsmBlock;
+                int bm = Math.Min(TrsmBlock, m - i0);
+                TrsmLeftScalar(uplo, transA, diag, bm, n, a.Slice(i0 * lda + i0), lda, b.Slice(i0 * ldb), ldb, ops);
+                // Update rows above: [0, i0).
+                if (i0 > 0)
+                    TrsmTrailingUpdate(transA, 0, i0, i0, bm, n, a, lda, b, ldb, gemmOpts, ops);
+            }
+        }
+    }
+
+    /// <summary>
+    /// B[rlo:rhi, :] -= op(A)[rlo:rhi, i0:i0+bm] · X[i0:i0+bm, :], via the GEMM macrokernel.
+    /// For transA the off-diagonal panel of op(A) is the transpose of A[i0:i0+bm, rlo:rhi].
+    /// </summary>
+    private static void TrsmTrailingUpdate<T>(
+        bool transA, int rlo, int rhi, int i0, int bm, int n,
+        ReadOnlySpan<T> a, int lda, Span<T> b, int ldb,
+        in BlasOptions<T> gemmOpts, INumericOperations<T> ops) where T : unmanaged
+    {
+        int rRows = rhi - rlo;
+        T[] scratch = new T[rRows * n];
+        var xBlk = b.Slice(i0 * ldb); // bm × n (just solved)
+        if (!transA)
+            // op(A)[rlo:rhi, i0:i0+bm] = A[rlo:rhi, i0:i0+bm] (rRows × bm, NoTrans).
+            Gemm<T>(a.Slice(rlo * lda + i0), lda, false, xBlk, ldb, false, scratch, n, rRows, n, bm, gemmOpts);
+        else
+            // op(A)[rlo:rhi, i0:i0+bm] = (A[i0:i0+bm, rlo:rhi])ᵀ — pass that block with transA=true.
+            Gemm<T>(a.Slice(i0 * lda + rlo), lda, true, xBlk, ldb, false, scratch, n, rRows, n, bm, gemmOpts);
+
+        var bRem = b.Slice(rlo * ldb);
+        for (int r = 0; r < rRows; r++)
+            for (int c = 0; c < n; c++)
+            {
+                int bi = r * ldb + c;
+                bRem[bi] = ops.Subtract(bRem[bi], scratch[r * n + c]);
+            }
     }
 
     // A(r,c) honoring transpose. Inlined as a static helper (local functions

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Trsm.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Trsm.cs
@@ -31,9 +31,59 @@ public static partial class BlasManaged
             }
 
         if (side == Side.Left)
-            TrsmLeftScalar(uplo, transA, diag, m, n, a, lda, b, ldb, ops);
+        {
+            // Blocked path only for the canonical Left-Lower-NoTrans case in this
+            // phase; all other combinations use the proven scalar kernel. Later
+            // tasks extend blocking to upper/transposed cases.
+            if (m > TrsmBlock && uplo == Uplo.Lower && !transA)
+                TrsmLeftLowerNoTransBlocked(diag, m, n, a, lda, b, ldb, options, ops);
+            else
+                TrsmLeftScalar(uplo, transA, diag, m, n, a, lda, b, ldb, ops);
+        }
         else
             TrsmRightScalar(uplo, transA, diag, m, n, a, lda, b, ldb, ops);
+    }
+
+    // Block size for the diagonal-solve / trailing-update split. 64 keeps the
+    // diagonal block in L1 while giving the GEMM macrokernel a worthwhile panel.
+    private const int TrsmBlock = 64;
+
+    private static void TrsmLeftLowerNoTransBlocked<T>(
+        Diag diag, int m, int n,
+        ReadOnlySpan<T> a, int lda, Span<T> b, int ldb,
+        in BlasOptions<T> options,
+        INumericOperations<T> ops) where T : unmanaged
+    {
+        for (int i0 = 0; i0 < m; i0 += TrsmBlock)
+        {
+            int bm = Math.Min(TrsmBlock, m - i0);
+
+            // 1) Solve the bm×n diagonal block with the scalar kernel.
+            //    The block's own triangle is A[i0:i0+bm, i0:i0+bm].
+            var aDiag = a.Slice(i0 * lda + i0);
+            var bBlock = b.Slice(i0 * ldb);
+            TrsmLeftScalar(Uplo.Lower, false, diag, bm, n, aDiag, lda, bBlock, ldb, ops);
+
+            // 2) Trailing update: for rows below this block,
+            //    B[i0+bm:, :] -= A[i0+bm:, i0:i0+bm] · X[i0:i0+bm, :]
+            int remRows = m - (i0 + bm);
+            if (remRows > 0)
+            {
+                var aSub = a.Slice((i0 + bm) * lda + i0); // remRows × bm panel (lda-strided)
+                var xBlk = b.Slice(i0 * ldb);              // bm × n (just solved), ldb-strided
+                // scratch = aSub · xBlk  (remRows × n)
+                T[] scratch = new T[remRows * n];
+                Gemm<T>(aSub, lda, false, xBlk, ldb, false, scratch, n, remRows, n, bm,
+                        new BlasOptions<T> { NumThreads = options.NumThreads, Mode = options.Mode });
+                var bRem = b.Slice((i0 + bm) * ldb);
+                for (int r = 0; r < remRows; r++)
+                    for (int c = 0; c < n; c++)
+                    {
+                        int bi = r * ldb + c;
+                        bRem[bi] = ops.Subtract(bRem[bi], scratch[r * n + c]);
+                    }
+            }
+        }
     }
 
     // A(r,c) honoring transpose. Inlined as a static helper (local functions

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Trsm.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Trsm.cs
@@ -100,22 +100,37 @@ public static partial class BlasManaged
         in BlasOptions<T> gemmOpts, INumericOperations<T> ops) where T : unmanaged
     {
         int rRows = rhi - rlo;
-        T[] scratch = new T[rRows * n];
-        var xBlk = b.Slice(i0 * ldb); // bm × n (just solved)
-        if (!transA)
-            // op(A)[rlo:rhi, i0:i0+bm] = A[rlo:rhi, i0:i0+bm] (rRows × bm, NoTrans).
-            Gemm<T>(a.Slice(rlo * lda + i0), lda, false, xBlk, ldb, false, scratch, n, rRows, n, bm, gemmOpts);
-        else
-            // op(A)[rlo:rhi, i0:i0+bm] = (A[i0:i0+bm, rlo:rhi])ᵀ — pass that block with transA=true.
-            Gemm<T>(a.Slice(i0 * lda + rlo), lda, true, xBlk, ldb, false, scratch, n, rRows, n, bm, gemmOpts);
+        // Rent the GEMM-output scratch from the shared pool instead of allocating a
+        // fresh T[] every block iteration: this method runs inside both blocked
+        // loops, so a per-block `new` churns the GC/LOH and offsets the GEMM-path
+        // speedup. The pool reuses one backing buffer across all iterations.
+        int scratchLen = rRows * n;
+        T[] scratch = System.Buffers.ArrayPool<T>.Shared.Rent(scratchLen);
+        try
+        {
+            var xBlk = b.Slice(i0 * ldb); // bm × n (just solved)
+            // ArrayPool may hand back an oversized array; slice to the exact GEMM
+            // output extent so leading dims / indexing stay correct.
+            Span<T> scratchView = scratch.AsSpan(0, scratchLen);
+            if (!transA)
+                // op(A)[rlo:rhi, i0:i0+bm] = A[rlo:rhi, i0:i0+bm] (rRows × bm, NoTrans).
+                Gemm<T>(a.Slice(rlo * lda + i0), lda, false, xBlk, ldb, false, scratchView, n, rRows, n, bm, gemmOpts);
+            else
+                // op(A)[rlo:rhi, i0:i0+bm] = (A[i0:i0+bm, rlo:rhi])ᵀ — pass that block with transA=true.
+                Gemm<T>(a.Slice(i0 * lda + rlo), lda, true, xBlk, ldb, false, scratchView, n, rRows, n, bm, gemmOpts);
 
-        var bRem = b.Slice(rlo * ldb);
-        for (int r = 0; r < rRows; r++)
-            for (int c = 0; c < n; c++)
-            {
-                int bi = r * ldb + c;
-                bRem[bi] = ops.Subtract(bRem[bi], scratch[r * n + c]);
-            }
+            var bRem = b.Slice(rlo * ldb);
+            for (int r = 0; r < rRows; r++)
+                for (int c = 0; c < n; c++)
+                {
+                    int bi = r * ldb + c;
+                    bRem[bi] = ops.Subtract(bRem[bi], scratchView[r * n + c]);
+                }
+        }
+        finally
+        {
+            System.Buffers.ArrayPool<T>.Shared.Return(scratch);
+        }
     }
 
     // A(r,c) honoring transpose. Inlined as a static helper (local functions

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Trsm.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Trsm.cs
@@ -1,0 +1,109 @@
+using System;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.Interfaces;
+
+namespace AiDotNet.Tensors.Engines.BlasManaged;
+
+public static partial class BlasManaged
+{
+    /// <summary>
+    /// Triangular solve. Computes op(A)·X = α·B (Left) or X·op(A) = α·B (Right),
+    /// overwriting B with X. A is the <paramref name="uplo"/> triangle of an
+    /// m×m (Left) or n×n (Right) matrix; op(A) is A or Aᵀ per <paramref name="transA"/>.
+    /// Drop-in for cblas_strsm/cblas_dtrsm (row-major; order is fixed RowMajor).
+    /// </summary>
+    public static void Trsm<T>(
+        Side side, Uplo uplo, bool transA, Diag diag,
+        int m, int n, T alpha,
+        ReadOnlySpan<T> a, int lda,
+        Span<T> b, int ldb,
+        in BlasOptions<T> options = default) where T : unmanaged
+    {
+        if (m <= 0 || n <= 0) return;
+        var ops = MathHelper.GetNumericOperations<T>();
+
+        // Scale B by alpha (BLAS semantics: solve against alpha·B).
+        for (int i = 0; i < m; i++)
+            for (int j = 0; j < n; j++)
+            {
+                int idx = i * ldb + j;
+                b[idx] = ops.Multiply(b[idx], alpha);
+            }
+
+        if (side == Side.Left)
+            TrsmLeftScalar(uplo, transA, diag, m, n, a, lda, b, ldb, ops);
+        else
+            TrsmRightScalar(uplo, transA, diag, m, n, a, lda, b, ldb, ops);
+    }
+
+    // A(r,c) honoring transpose. Inlined as a static helper (local functions
+    // cannot capture the ref-like ReadOnlySpan<T> parameter).
+    private static T At<T>(ReadOnlySpan<T> a, int lda, bool transA, int r, int c) where T : unmanaged
+        => transA ? a[c * lda + r] : a[r * lda + c];
+
+    private static void TrsmLeftScalar<T>(
+        Uplo uplo, bool transA, Diag diag, int m, int n,
+        ReadOnlySpan<T> a, int lda, Span<T> b, int ldb,
+        INumericOperations<T> ops) where T : unmanaged
+    {
+        // Effective triangle after optional transpose.
+        bool lower = (uplo == Uplo.Lower) ^ transA;
+
+        if (lower)
+        {
+            for (int i = 0; i < m; i++)
+                for (int j = 0; j < n; j++)
+                {
+                    T sum = b[i * ldb + j];
+                    for (int kk = 0; kk < i; kk++)
+                        sum = ops.Subtract(sum, ops.Multiply(At(a, lda, transA, i, kk), b[kk * ldb + j]));
+                    b[i * ldb + j] = diag == Diag.Unit ? sum : ops.Divide(sum, At(a, lda, transA, i, i));
+                }
+        }
+        else
+        {
+            for (int i = m - 1; i >= 0; i--)
+                for (int j = 0; j < n; j++)
+                {
+                    T sum = b[i * ldb + j];
+                    for (int kk = i + 1; kk < m; kk++)
+                        sum = ops.Subtract(sum, ops.Multiply(At(a, lda, transA, i, kk), b[kk * ldb + j]));
+                    b[i * ldb + j] = diag == Diag.Unit ? sum : ops.Divide(sum, At(a, lda, transA, i, i));
+                }
+        }
+    }
+
+    private static void TrsmRightScalar<T>(
+        Uplo uplo, bool transA, Diag diag, int m, int n,
+        ReadOnlySpan<T> a, int lda, Span<T> b, int ldb,
+        INumericOperations<T> ops) where T : unmanaged
+    {
+        // Right solve X·op(A) = B with A n×n. Effective triangle after transpose.
+        bool lower = (uplo == Uplo.Lower) ^ transA;
+
+        if (!lower)
+        {
+            // X·U = B : columns left-to-right.
+            for (int j = 0; j < n; j++)
+                for (int i = 0; i < m; i++)
+                {
+                    T sum = b[i * ldb + j];
+                    for (int kk = 0; kk < j; kk++)
+                        sum = ops.Subtract(sum, ops.Multiply(b[i * ldb + kk], At(a, lda, transA, kk, j)));
+                    b[i * ldb + j] = diag == Diag.Unit ? sum : ops.Divide(sum, At(a, lda, transA, j, j));
+                }
+        }
+        else
+        {
+            // X·L = B : columns right-to-left.
+            for (int j = n - 1; j >= 0; j--)
+                for (int i = 0; i < m; i++)
+                {
+                    T sum = b[i * ldb + j];
+                    for (int kk = j + 1; kk < n; kk++)
+                        sum = ops.Subtract(sum, ops.Multiply(b[i * ldb + kk], At(a, lda, transA, kk, j)));
+                    b[i * ldb + j] = diag == Diag.Unit ? sum : ops.Divide(sum, At(a, lda, transA, j, j));
+                }
+        }
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
@@ -9,7 +9,7 @@ namespace AiDotNet.Tensors.Engines.BlasManaged;
 /// BLIS-style managed GEMM kernel. Replaces Avx512Sgemm + SimdGemm as the
 /// codebase's primary GEMM path. See docs/superpowers/specs/2026-05-16-blas-managed-design.md.
 /// </summary>
-public static class BlasManaged
+public static partial class BlasManaged
 {
     /// <summary>
     /// Process-wide default execution mode. Applied when a caller's

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/SpecializedBlasEnums.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/SpecializedBlasEnums.cs
@@ -1,0 +1,62 @@
+using System;
+
+namespace AiDotNet.Tensors.Engines.BlasManaged;
+
+/// <summary>Which side of the product the triangular/symmetric operand sits on.</summary>
+public enum Side
+{
+    /// <summary>op(A) is on the left: op(A)·X = B  (TRSM) or C = A·B (SYMM).</summary>
+    Left,
+    /// <summary>op(A) is on the right: X·op(A) = B (TRSM) or C = B·A (SYMM).</summary>
+    Right,
+}
+
+/// <summary>Which triangle of a triangular/symmetric matrix is referenced.</summary>
+public enum Uplo
+{
+    /// <summary>Upper triangle (including diagonal) holds the data.</summary>
+    Upper,
+    /// <summary>Lower triangle (including diagonal) holds the data.</summary>
+    Lower,
+}
+
+/// <summary>Whether a triangular matrix has an implicit unit diagonal.</summary>
+public enum Diag
+{
+    /// <summary>Diagonal entries are read from the matrix.</summary>
+    NonUnit,
+    /// <summary>Diagonal entries are assumed to be 1 and not read.</summary>
+    Unit,
+}
+
+/// <summary>Storage format of a <see cref="SparseLayout{T}"/> view.</summary>
+public enum SparseLayoutFormat
+{
+    /// <summary>Compressed Sparse Row: RowPtr length = Rows+1, Indices = column indices.</summary>
+    Csr,
+    /// <summary>Compressed Sparse Column: RowPtr length = Cols+1, Indices = row indices.</summary>
+    Csc,
+}
+
+/// <summary>
+/// Allocation-free readonly view over a CSR/CSC sparse matrix, decoupled from the
+/// heap <see cref="AiDotNet.Tensors.LinearAlgebra.SparseTensor{T}"/> class so
+/// <see cref="BlasManaged.SpMM{T}"/> can be called from hot paths without boxing.
+/// For CSR, <see cref="Pointers"/> is the row-pointer array (length Rows+1) and
+/// <see cref="Indices"/> holds column indices. For CSC the roles transpose.
+/// </summary>
+public readonly ref struct SparseLayout<T> where T : unmanaged
+{
+    /// <summary>Number of rows in the logical (dense-equivalent) matrix.</summary>
+    public int Rows { get; init; }
+    /// <summary>Number of columns in the logical (dense-equivalent) matrix.</summary>
+    public int Cols { get; init; }
+    /// <summary>Row pointers (CSR) or column pointers (CSC).</summary>
+    public ReadOnlySpan<int> Pointers { get; init; }
+    /// <summary>Column indices (CSR) or row indices (CSC).</summary>
+    public ReadOnlySpan<int> Indices { get; init; }
+    /// <summary>Nonzero values, parallel to <see cref="Indices"/>.</summary>
+    public ReadOnlySpan<T> Values { get; init; }
+    /// <summary>Which compressed format the spans encode.</summary>
+    public SparseLayoutFormat Format { get; init; }
+}

--- a/src/AiDotNet.Tensors/Engines/CpuSparseEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuSparseEngine.cs
@@ -142,6 +142,14 @@ public sealed class CpuSparseEngine : ISparseEngine
         var colIndices = csr.ColumnIndices;
         var values = csr.Values;
 
+        // #379 NOTE: the managed BlasManaged.SpMM<T> kernel (cache-friendly,
+        // deterministic CSR/CSC) is the intended replacement for this triple loop,
+        // but it constrains T : unmanaged and ISparseEngine.SpMM<T> is unconstrained.
+        // Routing this call site requires either adding `where T : unmanaged` to the
+        // ISparseEngine interface (a public-API change) or a typed float/double
+        // dispatch with array casts. Tracked as a follow-up on the #379 branch; the
+        // kernel is in place and tested independently. The loop below is unchanged.
+        //
         // SpMM: C[i,k] = sum_j A[i,j] * B[j,k]
         for (int i = 0; i < sparse.Rows; i++)
         {

--- a/src/AiDotNet.Tensors/Engines/CpuSparseEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuSparseEngine.cs
@@ -123,7 +123,7 @@ public sealed class CpuSparseEngine : ISparseEngine
     #region Sparse Matrix-Matrix Operations
 
     /// <inheritdoc/>
-    public Matrix<T> SpMM<T>(SparseTensor<T> sparse, Matrix<T> dense)
+    public Matrix<T> SpMM<T>(SparseTensor<T> sparse, Matrix<T> dense) where T : unmanaged
     {
         if (sparse is null) throw new ArgumentNullException(nameof(sparse));
         if (dense is null) throw new ArgumentNullException(nameof(dense));
@@ -136,40 +136,24 @@ public sealed class CpuSparseEngine : ISparseEngine
         var ops = MathHelper.GetNumericOperations<T>();
         var result = new Matrix<T>(sparse.Rows, dense.Columns);
 
-        // Convert to CSR format
+        // #379: route through the SIMD/parallel managed BLAS SpMM kernel (C = 1·A·B + 0·C).
+        // CSR row-parallel, cache-friendly (B rows read contiguously), bit-deterministic —
+        // replaces the prior column-strided naive triple loop.
         var csr = sparse.ToCsr();
-        var rowPtrs = csr.RowPointers;
-        var colIndices = csr.ColumnIndices;
-        var values = csr.Values;
-
-        // #379 NOTE: the managed BlasManaged.SpMM<T> kernel (cache-friendly,
-        // deterministic CSR/CSC) is the intended replacement for this triple loop,
-        // but it constrains T : unmanaged and ISparseEngine.SpMM<T> is unconstrained.
-        // Routing this call site requires either adding `where T : unmanaged` to the
-        // ISparseEngine interface (a public-API change) or a typed float/double
-        // dispatch with array casts. Tracked as a follow-up on the #379 branch; the
-        // kernel is in place and tested independently. The loop below is unchanged.
-        //
-        // SpMM: C[i,k] = sum_j A[i,j] * B[j,k]
-        for (int i = 0; i < sparse.Rows; i++)
+        var layout = new BlasManaged.SparseLayout<T>
         {
-            int start = rowPtrs[i];
-            int end = rowPtrs[i + 1];
-
-            for (int k = 0; k < dense.Columns; k++)
-            {
-                T sum = ops.Zero;
-
-                for (int idx = start; idx < end; idx++)
-                {
-                    int j = colIndices[idx];
-                    T aVal = values[idx];
-                    sum = ops.Add(sum, ops.Multiply(aVal, dense[j, k]));
-                }
-
-                result[i, k] = sum;
-            }
-        }
+            Rows = sparse.Rows,
+            Cols = sparse.Columns,
+            Pointers = csr.RowPointers,
+            Indices = csr.ColumnIndices,
+            Values = csr.Values,
+            Format = BlasManaged.SparseLayoutFormat.Csr,
+        };
+        int n = dense.Columns;
+        BlasManaged.BlasManaged.SpMM<T>(
+            ops.One, layout,
+            dense.AsSpan(), n, n,
+            ops.Zero, result.AsWritableSpan(), n);
 
         return result;
     }

--- a/src/AiDotNet.Tensors/Engines/ISparseEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/ISparseEngine.cs
@@ -74,7 +74,12 @@ public interface ISparseEngine
     /// Time complexity: O(nnz * K) where K is the number of columns in B.
     /// </para>
     /// </remarks>
-    Matrix<T> SpMM<T>(SparseTensor<T> sparse, Matrix<T> dense);
+    /// <remarks>
+    /// <para><b>#379:</b> <c>T : unmanaged</c> is required so SpMM can route through
+    /// the SIMD/parallel <see cref="BlasManaged.BlasManaged.SpMM{T}"/> kernel. All
+    /// numeric element types used in this library satisfy it.</para>
+    /// </remarks>
+    Matrix<T> SpMM<T>(SparseTensor<T> sparse, Matrix<T> dense) where T : unmanaged;
 
     /// <summary>
     /// Sparse matrix-sparse matrix multiplication: C = A * B (both sparse)

--- a/src/AiDotNet.Tensors/LinearAlgebra/Solvers/LinearSolvers.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/Solvers/LinearSolvers.cs
@@ -150,6 +150,30 @@ internal static class LinearSolvers
         int aStride = n * n;
         int xStride = bIsVector ? n : n * nrhs;
 
+        // Fast path: route FP32/FP64 to the managed BLAS Trsm kernel (#379).
+        // Triangular solve is always Left side with alpha = 1. The blocked Trsm
+        // reuses the GEMM macrokernel for trailing updates on large systems.
+        bool useBlas = (typeof(T) == typeof(double) || typeof(T) == typeof(float));
+        if (useBlas)
+        {
+            var trsmUplo = upper ? AiDotNet.Tensors.Engines.BlasManaged.Uplo.Upper
+                                 : AiDotNet.Tensors.Engines.BlasManaged.Uplo.Lower;
+            var trsmDiag = unitDiagonal ? AiDotNet.Tensors.Engines.BlasManaged.Diag.Unit
+                                        : AiDotNet.Tensors.Engines.BlasManaged.Diag.NonUnit;
+            var one = Helpers.MathHelper.GetNumericOperations<T>().One;
+            for (int bi = 0; bi < batch; bi++)
+            {
+                var aSlice = new ReadOnlySpan<T>(aData, bi * aStride, n * n);
+                var xSlice = new Span<T>(xData, bi * xStride, xStride);
+                AiDotNet.Tensors.Engines.BlasManaged.BlasManaged.Trsm<T>(
+                    AiDotNet.Tensors.Engines.BlasManaged.Side.Left,
+                    trsmUplo, transpose, trsmDiag,
+                    n, nrhs, one,
+                    aSlice, n, xSlice, nrhs);
+            }
+            return x;
+        }
+
         for (int bi = 0; bi < batch; bi++)
         {
             TriangularSolveSingle(

--- a/src/AiDotNet.Tensors/Topology/SimplicialComplex.cs
+++ b/src/AiDotNet.Tensors/Topology/SimplicialComplex.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using AiDotNet.Tensors.Engines.BlasManaged;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.LinearAlgebra;
 
@@ -85,32 +86,55 @@ public sealed class SimplicialComplex
         return boundary;
     }
 
-    public Matrix<T> HodgeLaplacian<T>(int k)
+    public Matrix<T> HodgeLaplacian<T>(int k) where T : unmanaged
     {
-        var ops = MathHelper.GetNumericOperations<T>();
         var kSimplices = GetSimplices(k);
         if (kSimplices.Count == 0)
             return new Matrix<T>(0, 0);
 
+        // #379: the two Hodge terms are symmetric rank-k updates (Bᵀ·B and B·Bᵀ),
+        // computed via the SYRK kernel (≈half the FLOPs of a dense GEMM) then
+        // symmetrized to a full matrix before the element-wise add.
         Matrix<T> result = new Matrix<T>(kSimplices.Count, kSimplices.Count);
         if (k > 0)
         {
-            var bK = BoundaryOperator<T>(k);
-            var term = (Matrix<T>)bK.Transpose().Multiply(bK);
-            result = (Matrix<T>)result.Add(term);
+            var bK = BoundaryOperator<T>(k);                 // Bₖᵀ·Bₖ
+            result = (Matrix<T>)result.Add(SyrkFull(bK, trans: true));
         }
 
         if (k < MaxDimension)
         {
             var bKPlus = BoundaryOperator<T>(k + 1);
             if (bKPlus.Rows > 0 && bKPlus.Columns > 0)
-            {
-                var term = (Matrix<T>)bKPlus.Multiply(bKPlus.Transpose());
-                result = (Matrix<T>)result.Add(term);
-            }
+                result = (Matrix<T>)result.Add(SyrkFull(bKPlus, trans: false)); // Bₖ₊₁·Bₖ₊₁ᵀ
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// Computes the full symmetric matrix α=1·op(A)·op(A)ᵀ via the SYRK kernel
+    /// (lower triangle) then mirrors it to the upper triangle. trans=true gives
+    /// Aᵀ·A (n = A.Columns); trans=false gives A·Aᵀ (n = A.Rows).
+    /// </summary>
+    private static Matrix<T> SyrkFull<T>(Matrix<T> a, bool trans) where T : unmanaged
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        int n = trans ? a.Columns : a.Rows;
+        int kk = trans ? a.Rows : a.Columns;
+        var term = new Matrix<T>(n, n);
+        if (kk == 0 || n == 0) return term;
+
+        BlasManaged.Syrk<T>(
+            Uplo.Lower, trans, n, kk, ops.One,
+            a.AsSpan(), a.Columns, ops.Zero, term.AsWritableSpan(), n);
+
+        // Mirror lower → upper to produce the full symmetric matrix.
+        var span = term.AsWritableSpan();
+        for (int i = 0; i < n; i++)
+            for (int j = 0; j < i; j++)
+                span[j * n + i] = span[i * n + j];
+        return term;
     }
 
     private void AddSimplexInternal(Simplex simplex)

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/Catalog/SpecializedShapeCatalog.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/Catalog/SpecializedShapeCatalog.cs
@@ -27,4 +27,14 @@ public static class SpecializedShapeCatalog
         new("Gram_128x768",Uplo.Lower, false, 128, 768, true, 20, "workload:gram-matrix"),
         new("Cov_FP32_256x64", Uplo.Lower, true, 256, 64, false, 15, "workload:covariance-fp32"),
     };
+
+    public record SymmShape(string Name, Side Side, Uplo Uplo, int M, int N, bool Fp64, int Frequency, string Source);
+
+    public static readonly SymmShape[] Symm =
+    {
+        new("Sym_Left_256x256",  Side.Left, Uplo.Lower, 256, 256, true, 20, "workload:optimization"),
+        new("Sym_Left_512x128",  Side.Left, Uplo.Lower, 512, 128, true, 18, "workload:optimization"),
+        new("Sym_Right_128x512", Side.Right, Uplo.Upper, 128, 512, true, 12, "workload:optimization"),
+        new("Sym_FP32_256x256",  Side.Left, Uplo.Lower, 256, 256, false, 10, "workload:optimization-fp32"),
+    };
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/Catalog/SpecializedShapeCatalog.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/Catalog/SpecializedShapeCatalog.cs
@@ -51,4 +51,14 @@ public static class SpecializedShapeCatalog
         new("Dense_ish_512x512x64",    true, 512,  512,  64, 5.0,  true, 10, "workload:spmm-stress"),
         new("GNN_FP32_2708x2708x64",   true, 2708, 2708,  64, 0.18, false,12, "workload:gnn-cora-fp32"),
     };
+
+    public record GbmvShape(string Name, bool Trans, int M, int N, int Kl, int Ku, bool Fp64, int Frequency, string Source);
+
+    public static readonly GbmvShape[] Gbmv =
+    {
+        new("Tridiag_1024",   false, 1024, 1024, 1, 1, true, 20, "workload:tridiagonal-solver"),
+        new("Pentadiag_2048", false, 2048, 2048, 2, 2, true, 15, "workload:pentadiagonal"),
+        new("Tridiag_T_1024", true,  1024, 1024, 1, 1, true, 10, "workload:tridiagonal-transpose"),
+        new("Banded_FP32_4096",false,4096, 4096, 3, 3, false, 8, "workload:banded-fp32"),
+    };
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/Catalog/SpecializedShapeCatalog.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/Catalog/SpecializedShapeCatalog.cs
@@ -17,4 +17,14 @@ public static class SpecializedShapeCatalog
         new("Chol_SolveT_256x1", Side.Left, Uplo.Lower, true,  Diag.NonUnit, 256,   1, true,  25, "workload:cholesky-solve-transpose"),
         new("Solve_FP32_512x64", Side.Left, Uplo.Lower, false, Diag.NonUnit, 512,  64, false, 15, "workload:linsolve-fp32"),
     };
+
+    public record SyrkShape(string Name, Uplo Uplo, bool Trans, int N, int K, bool Fp64, int Frequency, string Source);
+
+    public static readonly SyrkShape[] Syrk =
+    {
+        new("Cov_256x64",  Uplo.Lower, true,  256,  64, true, 30, "workload:covariance"),
+        new("Cov_512x128", Uplo.Lower, true,  512, 128, true, 25, "workload:covariance"),
+        new("Gram_128x768",Uplo.Lower, false, 128, 768, true, 20, "workload:gram-matrix"),
+        new("Cov_FP32_256x64", Uplo.Lower, true, 256, 64, false, 15, "workload:covariance-fp32"),
+    };
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/Catalog/SpecializedShapeCatalog.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/Catalog/SpecializedShapeCatalog.cs
@@ -1,0 +1,20 @@
+using AiDotNet.Tensors.Engines.BlasManaged;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged.Catalog;
+
+/// <summary>Per-variant bench shapes for the #379 specialized BLAS variants.</summary>
+public static class SpecializedShapeCatalog
+{
+    public record TrsmShape(string Name, Side Side, Uplo Uplo, bool TransA, Diag Diag,
+        int M, int N, bool Fp64, int Frequency, string Source);
+
+    public static readonly TrsmShape[] Trsm =
+    {
+        new("Chol_Solve_64x1",   Side.Left, Uplo.Lower, false, Diag.NonUnit,  64,   1, true,  50, "workload:cholesky-solve"),
+        new("Chol_Solve_256x1",  Side.Left, Uplo.Lower, false, Diag.NonUnit, 256,   1, true,  40, "workload:cholesky-solve"),
+        new("QR_BackSub_256x64", Side.Left, Uplo.Upper, false, Diag.NonUnit, 256,  64, true,  30, "workload:qr-backsub"),
+        new("Solve_MultiRhs_512x128", Side.Left, Uplo.Lower, false, Diag.NonUnit, 512, 128, true, 20, "workload:linsolve"),
+        new("Chol_SolveT_256x1", Side.Left, Uplo.Lower, true,  Diag.NonUnit, 256,   1, true,  25, "workload:cholesky-solve-transpose"),
+        new("Solve_FP32_512x64", Side.Left, Uplo.Lower, false, Diag.NonUnit, 512,  64, false, 15, "workload:linsolve-fp32"),
+    };
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/Catalog/SpecializedShapeCatalog.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/Catalog/SpecializedShapeCatalog.cs
@@ -37,4 +37,18 @@ public static class SpecializedShapeCatalog
         new("Sym_Right_128x512", Side.Right, Uplo.Upper, 128, 512, true, 12, "workload:optimization"),
         new("Sym_FP32_256x256",  Side.Left, Uplo.Lower, 256, 256, false, 10, "workload:optimization-fp32"),
     };
+
+    // SpMM: sparse A (rows×cols, given density) × dense B (cols×N). DensityPercent
+    // is nnz / (rows·cols) × 100.
+    public record SpMMShape(string Name, bool Csr, int Rows, int Cols, int N, double DensityPercent,
+        bool Fp64, int Frequency, string Source);
+
+    public static readonly SpMMShape[] SpMM =
+    {
+        new("GNN_Cora_2708x2708x64",   true, 2708, 2708,  64, 0.18, true, 30, "workload:gnn-cora"),
+        new("GNN_PubMed_19717x500x128",true, 19717, 500, 128, 0.10, true, 20, "workload:gnn-pubmed"),
+        new("RecSys_10000x10000x32",   true, 10000,10000, 32, 0.05, true, 15, "workload:recsys"),
+        new("Dense_ish_512x512x64",    true, 512,  512,  64, 5.0,  true, 10, "workload:spmm-stress"),
+        new("GNN_FP32_2708x2708x64",   true, 2708, 2708,  64, 0.18, false,12, "workload:gnn-cora-fp32"),
+    };
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/GbmvDeterminismTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/GbmvDeterminismTests.cs
@@ -1,0 +1,37 @@
+using System;
+using AiDotNet.Tensors.Engines.BlasManaged;
+using Xunit;
+using BlasManagedLib = AiDotNet.Tensors.Engines.BlasManaged.BlasManaged;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+[Collection("BlasManaged-Stats-Serial")]
+public class GbmvDeterminismTests
+{
+    // GBMV is level-2 (each output element is an independent fixed-order band dot),
+    // so it is bit-exact regardless of thread count. This guards that contract.
+    [Theory]
+    [InlineData(256, 2, 3)]
+    [InlineData(512, 4, 4)]
+    public void Gbmv_FP64_BitExactAcrossThreadCounts(int nn, int kl, int ku)
+    {
+        int lda = kl + ku + 1;
+        var rng = new Random(42);
+        double[] ab = new double[lda * nn];
+        for (int i = 0; i < ab.Length; i++) ab[i] = rng.NextDouble() * 2 - 1;
+        double[] x = new double[nn];
+        for (int i = 0; i < x.Length; i++) x[i] = rng.NextDouble() * 2 - 1;
+        double[] y0 = new double[nn];
+        for (int i = 0; i < y0.Length; i++) y0[i] = rng.NextDouble() * 2 - 1;
+
+        double[]? baseline = null;
+        foreach (int threads in new[] { 1, 2, 4, 8 })
+        {
+            double[] actual = (double[])y0.Clone();
+            var opts = new BlasOptions<double> { NumThreads = threads, Mode = BlasMode.Deterministic };
+            BlasManagedLib.Gbmv<double>(false, nn, nn, kl, ku, 1.3, ab, lda, x, 1, 0.7, actual, 1, opts);
+            if (baseline is null) baseline = actual;
+            else for (int i = 0; i < actual.Length; i++) Assert.Equal(baseline[i], actual[i]);
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/GbmvTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/GbmvTests.cs
@@ -1,0 +1,68 @@
+using System;
+using AiDotNet.Tensors.Engines.BlasManaged;
+using Xunit;
+using BlasManagedLib = AiDotNet.Tensors.Engines.BlasManaged.BlasManaged;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+[Collection("BlasManaged-Stats-Serial")]
+public class GbmvTests
+{
+    // Build the LAPACK band array (lda = kl+ku+1, column-major band) from a dense m×n A.
+    private static double[] DenseToBand(double[] a, int m, int n, int kl, int ku)
+    {
+        int lda = kl + ku + 1;
+        double[] ab = new double[lda * n];
+        for (int j = 0; j < n; j++)
+            for (int i = Math.Max(0, j - ku); i <= Math.Min(m - 1, j + kl); i++)
+                ab[j * lda + (ku - j + i)] = a[i * n + j];
+        return ab;
+    }
+
+    // Zero out elements of dense A outside the band so the dense reference matches.
+    private static void MaskBand(double[] a, int m, int n, int kl, int ku)
+    {
+        for (int i = 0; i < m; i++)
+            for (int j = 0; j < n; j++)
+                if (j < i - kl || j > i + ku) a[i * n + j] = 0.0;
+    }
+
+    private static double[] ReferenceGbmv(
+        bool trans, int m, int n, double alpha, double[] aDenseBanded, double[] x, double beta, double[] y)
+    {
+        int lenY = trans ? n : m, lenX = trans ? m : n;
+        var outY = (double[])y.Clone();
+        for (int o = 0; o < lenY; o++)
+        {
+            double acc = 0;
+            for (int p = 0; p < lenX; p++)
+            {
+                // non-trans: A(o,p); trans: A(p,o)
+                double aval = trans ? aDenseBanded[p * n + o] : aDenseBanded[o * n + p];
+                acc += aval * x[p];
+            }
+            outY[o] = alpha * acc + beta * y[o];
+        }
+        return outY;
+    }
+
+    [Fact]
+    public void Gbmv_FP64_NoTrans_MatchesDenseReference()
+    {
+        const int m = 6, n = 6, kl = 1, ku = 2;
+        var rng = new Random(42);
+        double[] aDense = new double[m * n];
+        for (int i = 0; i < aDense.Length; i++) aDense[i] = rng.NextDouble() * 2 - 1;
+        MaskBand(aDense, m, n, kl, ku);
+        double[] ab = DenseToBand(aDense, m, n, kl, ku);
+        double[] x = new double[n];
+        for (int i = 0; i < x.Length; i++) x[i] = rng.NextDouble() * 2 - 1;
+        double[] y = new double[m];
+        for (int i = 0; i < y.Length; i++) y[i] = rng.NextDouble() * 2 - 1;
+
+        double[] expected = ReferenceGbmv(false, m, n, 1.0, aDense, x, 0.0, y);
+        double[] actual = (double[])y.Clone();
+        BlasManagedLib.Gbmv<double>(false, m, n, kl, ku, 1.0, ab, kl + ku + 1, x, 1, 0.0, actual, 1);
+        for (int i = 0; i < actual.Length; i++) Assert.Equal(expected[i], actual[i], 10);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/GbmvTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/GbmvTests.cs
@@ -65,4 +65,79 @@ public class GbmvTests
         BlasManagedLib.Gbmv<double>(false, m, n, kl, ku, 1.0, ab, kl + ku + 1, x, 1, 0.0, actual, 1);
         for (int i = 0; i < actual.Length; i++) Assert.Equal(expected[i], actual[i], 10);
     }
+
+    [Theory]
+    [InlineData(false, 7, 5, 2, 1)]   // non-square m>n
+    [InlineData(true,  7, 5, 2, 1)]   // trans, non-square
+    [InlineData(false, 5, 8, 1, 3)]   // non-square n>m
+    [InlineData(true,  5, 8, 1, 3)]
+    [InlineData(false, 6, 6, 0, 0)]   // diagonal only
+    public void Gbmv_FP64_Coverage_AlphaBeta(bool trans, int m, int n, int kl, int ku)
+    {
+        var rng = new Random(321);
+        double[] aDense = new double[m * n];
+        for (int i = 0; i < aDense.Length; i++) aDense[i] = rng.NextDouble() * 2 - 1;
+        MaskBand(aDense, m, n, kl, ku);
+        double[] ab = DenseToBand(aDense, m, n, kl, ku);
+        int lenX = trans ? m : n, lenY = trans ? n : m;
+        double[] x = new double[lenX];
+        for (int i = 0; i < x.Length; i++) x[i] = rng.NextDouble() * 2 - 1;
+        double[] y = new double[lenY];
+        for (int i = 0; i < y.Length; i++) y[i] = rng.NextDouble() * 2 - 1;
+
+        double alpha = 1.7, beta = -0.5;
+        double[] expected = ReferenceGbmv(trans, m, n, alpha, aDense, x, beta, y);
+        double[] actual = (double[])y.Clone();
+        BlasManagedLib.Gbmv<double>(trans, m, n, kl, ku, alpha, ab, kl + ku + 1, x, 1, beta, actual, 1);
+        for (int i = 0; i < actual.Length; i++) Assert.Equal(expected[i], actual[i], 9);
+    }
+
+    [Fact]
+    public void Gbmv_FP64_NonUnitStrides_MatchesReference()
+    {
+        const int m = 5, n = 5, kl = 1, ku = 1;
+        var rng = new Random(7);
+        double[] aDense = new double[m * n];
+        for (int i = 0; i < aDense.Length; i++) aDense[i] = rng.NextDouble() * 2 - 1;
+        MaskBand(aDense, m, n, kl, ku);
+        double[] ab = DenseToBand(aDense, m, n, kl, ku);
+
+        const int incx = 2, incy = 3;
+        double[] xCompact = new double[n];
+        for (int i = 0; i < n; i++) xCompact[i] = rng.NextDouble() * 2 - 1;
+        double[] yCompact = new double[m];
+        for (int i = 0; i < m; i++) yCompact[i] = rng.NextDouble() * 2 - 1;
+
+        // Strided buffers.
+        double[] x = new double[n * incx];
+        for (int i = 0; i < n; i++) x[i * incx] = xCompact[i];
+        double[] y = new double[m * incy];
+        for (int i = 0; i < m; i++) y[i * incy] = yCompact[i];
+
+        double[] expectedCompact = ReferenceGbmv(false, m, n, 1.3, aDense, xCompact, 0.7, yCompact);
+        BlasManagedLib.Gbmv<double>(false, m, n, kl, ku, 1.3, ab, kl + ku + 1, x, incx, 0.7, y, incy);
+        for (int i = 0; i < m; i++) Assert.Equal(expectedCompact[i], y[i * incy], 9);
+    }
+
+    [Fact]
+    public void Gbmv_FP32_NoTrans_MatchesReference()
+    {
+        const int m = 6, n = 6, kl = 1, ku = 2;
+        var rng = new Random(11);
+        double[] aDense = new double[m * n];
+        for (int i = 0; i < aDense.Length; i++) aDense[i] = rng.NextDouble() * 2 - 1;
+        MaskBand(aDense, m, n, kl, ku);
+        double[] abD = DenseToBand(aDense, m, n, kl, ku);
+        float[] ab = Array.ConvertAll(abD, v => (float)v);
+        double[] xD = new double[n];
+        for (int i = 0; i < n; i++) xD[i] = rng.NextDouble() * 2 - 1;
+        float[] x = Array.ConvertAll(xD, v => (float)v);
+        double[] yD = new double[m];
+        for (int i = 0; i < m; i++) yD[i] = rng.NextDouble() * 2 - 1;
+        float[] y = Array.ConvertAll(yD, v => (float)v);
+
+        double[] expected = ReferenceGbmv(false, m, n, 1.0, aDense, xD, 0.0, yD);
+        BlasManagedLib.Gbmv<float>(false, m, n, kl, ku, 1f, ab, kl + ku + 1, x, 1, 0f, y, 1);
+        for (int i = 0; i < m; i++) Assert.Equal(expected[i], y[i], 3);
+    }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SpMMDeterminismTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SpMMDeterminismTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Tensors.Engines.BlasManaged;
+using Xunit;
+using BlasManagedLib = AiDotNet.Tensors.Engines.BlasManaged.BlasManaged;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+[Collection("BlasManaged-Stats-Serial")]
+public class SpMMDeterminismTests
+{
+    [Theory]
+    [InlineData(128, 96, 32)]
+    [InlineData(256, 128, 16)]
+    public void SpMM_FP64_Csr_BitExactAcrossThreadCounts(int rows, int cols, int n)
+    {
+        var rng = new Random(42);
+        // Build a CSR matrix at ~10% density.
+        var ptr = new int[rows + 1];
+        var ind = new List<int>();
+        var val = new List<double>();
+        for (int i = 0; i < rows; i++)
+        {
+            for (int k = 0; k < cols; k++)
+                if (rng.NextDouble() < 0.10) { ind.Add(k); val.Add(rng.NextDouble() * 2 - 1); }
+            ptr[i + 1] = ind.Count;
+        }
+        int[] indA = ind.ToArray();
+        double[] valA = val.ToArray();
+        double[] b = new double[cols * n];
+        for (int i = 0; i < b.Length; i++) b[i] = rng.NextDouble() * 2 - 1;
+        double[] c0 = new double[rows * n];
+        for (int i = 0; i < c0.Length; i++) c0[i] = rng.NextDouble() * 2 - 1;
+
+        double[]? baseline = null;
+        foreach (int threads in new[] { 1, 2, 4, 8 })
+        {
+            double[] actual = (double[])c0.Clone();
+            var opts = new BlasOptions<double> { NumThreads = threads, Mode = BlasMode.Deterministic };
+            var layout = new SparseLayout<double>
+            { Rows = rows, Cols = cols, Pointers = ptr, Indices = indA, Values = valA, Format = SparseLayoutFormat.Csr };
+            BlasManagedLib.SpMM<double>(1.3, layout, b, n, n, 0.7, actual, n, opts);
+            if (baseline is null) baseline = actual;
+            else for (int i = 0; i < actual.Length; i++) Assert.Equal(baseline[i], actual[i]);
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SpMMTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SpMMTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Tensors.Engines.BlasManaged;
+using Xunit;
+using BlasManagedLib = AiDotNet.Tensors.Engines.BlasManaged.BlasManaged;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+[Collection("BlasManaged-Stats-Serial")]
+public class SpMMTests
+{
+    // Build CSR arrays from a dense rows×cols matrix (drop exact zeros).
+    private static (int[] ptr, int[] ind, double[] val) DenseToCsr(double[] a, int rows, int cols)
+    {
+        var ptr = new int[rows + 1];
+        var ind = new List<int>();
+        var val = new List<double>();
+        for (int i = 0; i < rows; i++)
+        {
+            for (int j = 0; j < cols; j++)
+            {
+                double v = a[i * cols + j];
+                if (v != 0.0) { ind.Add(j); val.Add(v); }
+            }
+            ptr[i + 1] = ind.Count;
+        }
+        return (ptr, ind.ToArray(), val.ToArray());
+    }
+
+    // Dense reference: C = alpha*A*B + beta*C.
+    private static double[] ReferenceSpMM(
+        double[] a, int rows, int cols, double[] b, int n, double alpha, double beta, double[] c)
+    {
+        var outC = (double[])c.Clone();
+        for (int i = 0; i < rows; i++)
+            for (int j = 0; j < n; j++)
+            {
+                double acc = 0;
+                for (int k = 0; k < cols; k++) acc += a[i * cols + k] * b[k * n + j];
+                outC[i * n + j] = alpha * acc + beta * c[i * n + j];
+            }
+        return outC;
+    }
+
+    [Fact]
+    public void SpMM_FP64_Csr_MatchesDenseReference()
+    {
+        const int rows = 5, cols = 4, n = 3;
+        var rng = new Random(42);
+        double[] a = new double[rows * cols];
+        // ~50% sparse
+        for (int i = 0; i < a.Length; i++) a[i] = rng.NextDouble() < 0.5 ? 0.0 : rng.NextDouble() * 2 - 1;
+        double[] b = new double[cols * n];
+        for (int i = 0; i < b.Length; i++) b[i] = rng.NextDouble() * 2 - 1;
+        double[] c = new double[rows * n];
+        for (int i = 0; i < c.Length; i++) c[i] = rng.NextDouble() * 2 - 1;
+
+        var (ptr, ind, val) = DenseToCsr(a, rows, cols);
+        double[] expected = ReferenceSpMM(a, rows, cols, b, n, 1.0, 0.0, c);
+
+        double[] actual = (double[])c.Clone();
+        var layout = new SparseLayout<double>
+        {
+            Rows = rows, Cols = cols, Pointers = ptr, Indices = ind, Values = val,
+            Format = SparseLayoutFormat.Csr,
+        };
+        BlasManagedLib.SpMM<double>(1.0, layout, b, n, n, 0.0, actual, n);
+        for (int i = 0; i < actual.Length; i++) Assert.Equal(expected[i], actual[i], 10);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SpMMTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SpMMTests.cs
@@ -158,4 +158,42 @@ public class SpMMTests
         BlasManagedLib.SpMM<float>(1f, layout, b, n, n, 0f, actual, n);
         for (int i = 0; i < actual.Length; i++) Assert.Equal(expected[i], actual[i], 3);
     }
+
+    [Fact]
+    public void SpMM_FP64_Csr_FusedBiasReLU_EqualsUnfusedPipeline()
+    {
+        // Exceed-vendor lever: SpMM + bias + ReLU in one call == SpMM then bias then ReLU.
+        const int rows = 6, cols = 5, n = 4;
+        var rng = new Random(2024);
+        double[] a = new double[rows * cols];
+        for (int i = 0; i < a.Length; i++) a[i] = rng.NextDouble() < 0.5 ? 0.0 : rng.NextDouble() * 2 - 1;
+        double[] b = new double[cols * n];
+        for (int i = 0; i < b.Length; i++) b[i] = rng.NextDouble() * 2 - 1;
+        double[] bias = new double[n];
+        for (int i = 0; i < n; i++) bias[i] = rng.NextDouble() * 2 - 1;
+
+        var (ptr, ind, val) = DenseToCsr(a, rows, cols);
+        var layout = new SparseLayout<double>
+        { Rows = rows, Cols = cols, Pointers = ptr, Indices = ind, Values = val, Format = SparseLayoutFormat.Csr };
+
+        // Unfused reference: SpMM (beta=0) then +bias[j] then ReLU.
+        double[] unfused = new double[rows * n];
+        BlasManagedLib.SpMM<double>(1.0, layout, b, n, n, 0.0, unfused, n);
+        for (int i = 0; i < rows; i++)
+            for (int j = 0; j < n; j++)
+            {
+                double v = unfused[i * n + j] + bias[j];
+                unfused[i * n + j] = v > 0 ? v : 0; // ReLU
+            }
+
+        // Fused: bias + ReLU via the epilogue.
+        double[] fused = new double[rows * n];
+        var opts = new BlasOptions<double>
+        {
+            Epilogue = new Epilogue<double> { BiasN = bias, Activation = AiDotNet.Tensors.Engines.FusedActivationType.ReLU },
+        };
+        BlasManagedLib.SpMM<double>(1.0, layout, b, n, n, 0.0, fused, n, opts);
+
+        for (int i = 0; i < fused.Length; i++) Assert.Equal(unfused[i], fused[i], 10);
+    }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SpMMTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SpMMTests.cs
@@ -67,4 +67,95 @@ public class SpMMTests
         BlasManagedLib.SpMM<double>(1.0, layout, b, n, n, 0.0, actual, n);
         for (int i = 0; i < actual.Length; i++) Assert.Equal(expected[i], actual[i], 10);
     }
+
+    private static (int[] ptr, int[] ind, double[] val) DenseToCsc(double[] a, int rows, int cols)
+    {
+        var ptr = new int[cols + 1];
+        var ind = new List<int>();
+        var val = new List<double>();
+        for (int k = 0; k < cols; k++)
+        {
+            for (int i = 0; i < rows; i++)
+            {
+                double v = a[i * cols + k];
+                if (v != 0.0) { ind.Add(i); val.Add(v); }
+            }
+            ptr[k + 1] = ind.Count;
+        }
+        return (ptr, ind.ToArray(), val.ToArray());
+    }
+
+    [Fact]
+    public void SpMM_FP64_Csc_AlphaBeta_MatchesDenseReference()
+    {
+        const int rows = 6, cols = 5, n = 4;
+        var rng = new Random(123);
+        double[] a = new double[rows * cols];
+        for (int i = 0; i < a.Length; i++) a[i] = rng.NextDouble() < 0.6 ? 0.0 : rng.NextDouble() * 2 - 1;
+        double[] b = new double[cols * n];
+        for (int i = 0; i < b.Length; i++) b[i] = rng.NextDouble() * 2 - 1;
+        double[] c = new double[rows * n];
+        for (int i = 0; i < c.Length; i++) c[i] = rng.NextDouble() * 2 - 1;
+
+        double alpha = 1.7, beta = -0.5;
+        var (ptr, ind, val) = DenseToCsc(a, rows, cols);
+        double[] expected = ReferenceSpMM(a, rows, cols, b, n, alpha, beta, c);
+
+        double[] actual = (double[])c.Clone();
+        var layout = new SparseLayout<double>
+        {
+            Rows = rows, Cols = cols, Pointers = ptr, Indices = ind, Values = val,
+            Format = SparseLayoutFormat.Csc,
+        };
+        BlasManagedLib.SpMM<double>(alpha, layout, b, n, n, beta, actual, n);
+        for (int i = 0; i < actual.Length; i++) Assert.Equal(expected[i], actual[i], 9);
+    }
+
+    [Fact]
+    public void SpMM_FP64_Csr_EmptyRow_LeavesScaledBeta()
+    {
+        // Row 1 is all-zero → output row 1 must equal beta * original.
+        const int rows = 3, cols = 3, n = 2;
+        double[] a = { 1, 0, 0,  0, 0, 0,  0, 2, 3 };
+        double[] b = { 1, 1,  2, 2,  3, 3 };
+        double[] c = { 5, 6,  7, 8,  9, 10 };
+        double beta = 2.0;
+
+        var (ptr, ind, val) = DenseToCsr(a, rows, cols);
+        double[] expected = ReferenceSpMM(a, rows, cols, b, n, 1.0, beta, c);
+        double[] actual = (double[])c.Clone();
+        var layout = new SparseLayout<double>
+        { Rows = rows, Cols = cols, Pointers = ptr, Indices = ind, Values = val, Format = SparseLayoutFormat.Csr };
+        BlasManagedLib.SpMM<double>(1.0, layout, b, n, n, beta, actual, n);
+        for (int i = 0; i < actual.Length; i++) Assert.Equal(expected[i], actual[i], 12);
+        // Explicit empty-row check: row 1 == beta * original.
+        Assert.Equal(beta * 7, actual[1 * n + 0], 12);
+        Assert.Equal(beta * 8, actual[1 * n + 1], 12);
+    }
+
+    [Fact]
+    public void SpMM_FP32_Csr_MatchesReference()
+    {
+        const int rows = 5, cols = 4, n = 3;
+        var rng = new Random(7);
+        float[] a = new float[rows * cols];
+        for (int i = 0; i < a.Length; i++) a[i] = rng.NextDouble() < 0.5 ? 0f : (float)(rng.NextDouble() * 2 - 1);
+        float[] b = new float[cols * n];
+        for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+        float[] c = new float[rows * n];
+        for (int i = 0; i < c.Length; i++) c[i] = (float)(rng.NextDouble() * 2 - 1);
+
+        double[] a64 = Array.ConvertAll(a, x => (double)x);
+        double[] b64 = Array.ConvertAll(b, x => (double)x);
+        double[] c64 = Array.ConvertAll(c, x => (double)x);
+        var (ptr, ind, valD) = DenseToCsr(a64, rows, cols);
+        float[] valF = Array.ConvertAll(valD, x => (float)x);
+        double[] expected = ReferenceSpMM(a64, rows, cols, b64, n, 1.0, 0.0, c64);
+
+        float[] actual = (float[])c.Clone();
+        var layout = new SparseLayout<float>
+        { Rows = rows, Cols = cols, Pointers = ptr, Indices = ind, Values = valF, Format = SparseLayoutFormat.Csr };
+        BlasManagedLib.SpMM<float>(1f, layout, b, n, n, 0f, actual, n);
+        for (int i = 0; i < actual.Length; i++) Assert.Equal(expected[i], actual[i], 3);
+    }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SpecializedPerfBar.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SpecializedPerfBar.cs
@@ -1,0 +1,18 @@
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+/// <summary>
+/// Frozen per-variant perf bars for #379. Values are placeholders until the first
+/// authoritative bench run on the self-hosted runner (AIDOTNET_PERF_RUNNER=1) lands,
+/// at which point the project owner sets them in a single gating commit — same
+/// discipline as <see cref="PerfBar"/> for dense GEMM (#368).
+/// </summary>
+public static class SpecializedPerfBar
+{
+    // TRSM vs OpenBLAS strsm/dtrsm on the authoritative runner.
+    public const int    TrsmMinWinRatePercent = 0;     // TO BE SET after first bench
+    public const double TrsmMaxLossMultiple    = 99.0; // TO BE SET after first bench
+    public const string TargetHardwareFingerprint = ""; // captured from runner
+
+    /// <summary>True once the owner has frozen the TRSM bar (non-zero win rate).</summary>
+    public static bool TrsmBarFrozen => TrsmMinWinRatePercent > 0;
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SpecializedPerfBar.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SpecializedPerfBar.cs
@@ -36,4 +36,11 @@ public static class SpecializedPerfBar
 
     /// <summary>True once the owner has frozen the SpMM bar (non-zero win rate).</summary>
     public static bool SpMMBarFrozen => SpMMMinWinRatePercent > 0;
+
+    // GBMV vs OpenBLAS sgbmv/dgbmv on the authoritative runner.
+    public const int    GbmvMinWinRatePercent = 0;     // TO BE SET after first bench
+    public const double GbmvMaxLossMultiple    = 99.0; // TO BE SET after first bench
+
+    /// <summary>True once the owner has frozen the GBMV bar (non-zero win rate).</summary>
+    public static bool GbmvBarFrozen => GbmvMinWinRatePercent > 0;
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SpecializedPerfBar.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SpecializedPerfBar.cs
@@ -29,4 +29,11 @@ public static class SpecializedPerfBar
 
     /// <summary>True once the owner has frozen the SYMM bar (non-zero win rate).</summary>
     public static bool SymmBarFrozen => SymmMinWinRatePercent > 0;
+
+    // SpMM vs MKL Sparse BLAS mkl_sparse_*_mm (else vs the naive managed loop floor).
+    public const int    SpMMMinWinRatePercent = 0;     // TO BE SET after first bench
+    public const double SpMMMaxLossMultiple    = 99.0; // TO BE SET after first bench
+
+    /// <summary>True once the owner has frozen the SpMM bar (non-zero win rate).</summary>
+    public static bool SpMMBarFrozen => SpMMMinWinRatePercent > 0;
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SpecializedPerfBar.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SpecializedPerfBar.cs
@@ -22,4 +22,11 @@ public static class SpecializedPerfBar
 
     /// <summary>True once the owner has frozen the SYRK bar (non-zero win rate).</summary>
     public static bool SyrkBarFrozen => SyrkMinWinRatePercent > 0;
+
+    // SYMM vs OpenBLAS ssymm/dsymm on the authoritative runner.
+    public const int    SymmMinWinRatePercent = 0;     // TO BE SET after first bench
+    public const double SymmMaxLossMultiple    = 99.0; // TO BE SET after first bench
+
+    /// <summary>True once the owner has frozen the SYMM bar (non-zero win rate).</summary>
+    public static bool SymmBarFrozen => SymmMinWinRatePercent > 0;
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SpecializedPerfBar.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SpecializedPerfBar.cs
@@ -15,4 +15,11 @@ public static class SpecializedPerfBar
 
     /// <summary>True once the owner has frozen the TRSM bar (non-zero win rate).</summary>
     public static bool TrsmBarFrozen => TrsmMinWinRatePercent > 0;
+
+    // SYRK vs OpenBLAS ssyrk/dsyrk on the authoritative runner.
+    public const int    SyrkMinWinRatePercent = 0;     // TO BE SET after first bench
+    public const double SyrkMaxLossMultiple    = 99.0; // TO BE SET after first bench
+
+    /// <summary>True once the owner has frozen the SYRK bar (non-zero win rate).</summary>
+    public static bool SyrkBarFrozen => SyrkMinWinRatePercent > 0;
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SymmDeterminismTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SymmDeterminismTests.cs
@@ -1,0 +1,35 @@
+using System;
+using AiDotNet.Tensors.Engines.BlasManaged;
+using Xunit;
+using BlasManagedLib = AiDotNet.Tensors.Engines.BlasManaged.BlasManaged;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+[Collection("BlasManaged-Stats-Serial")]
+public class SymmDeterminismTests
+{
+    [Theory]
+    [InlineData(64, 48)]
+    [InlineData(128, 96)]
+    [InlineData(192, 64)]
+    public void Symm_FP64_BitExactAcrossThreadCounts(int m, int n)
+    {
+        var rng = new Random(42);
+        double[] a = new double[m * m];
+        for (int i = 0; i < a.Length; i++) a[i] = rng.NextDouble() * 2 - 1;
+        double[] b = new double[m * n];
+        for (int i = 0; i < b.Length; i++) b[i] = rng.NextDouble() * 2 - 1;
+        double[] c0 = new double[m * n];
+        for (int i = 0; i < c0.Length; i++) c0[i] = rng.NextDouble() * 2 - 1;
+
+        double[]? baseline = null;
+        foreach (int threads in new[] { 1, 2, 4, 8 })
+        {
+            double[] actual = (double[])c0.Clone();
+            var opts = new BlasOptions<double> { NumThreads = threads, Mode = BlasMode.Deterministic };
+            BlasManagedLib.Symm<double>(Side.Left, Uplo.Lower, m, n, 1.3, a, m, b, n, 0.7, actual, n, opts);
+            if (baseline is null) baseline = actual;
+            else for (int i = 0; i < actual.Length; i++) Assert.Equal(baseline[i], actual[i]);
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SymmTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SymmTests.cs
@@ -1,0 +1,54 @@
+using System;
+using AiDotNet.Tensors.Engines.BlasManaged;
+using Xunit;
+using BlasManagedLib = AiDotNet.Tensors.Engines.BlasManaged.BlasManaged;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+[Collection("BlasManaged-Stats-Serial")]
+public class SymmTests
+{
+    // Reference SYMM. side=Left: C = alpha*A*B + beta*C (A is m×m symmetric).
+    // side=Right: C = alpha*B*A + beta*C (A is n×n symmetric). A stored in uplo triangle.
+    private static double[] ReferenceSymm(
+        Side side, Uplo uplo, int m, int n, double alpha,
+        double[] a, int lda, double[] b, int ldb, double beta, double[] c, int ldc)
+    {
+        int s = side == Side.Left ? m : n;
+        double Asym(int i, int j)
+        {
+            bool stored = uplo == Uplo.Lower ? j <= i : j >= i;
+            return stored ? a[i * lda + j] : a[j * lda + i];
+        }
+        var outC = (double[])c.Clone();
+        for (int i = 0; i < m; i++)
+            for (int l = 0; l < n; l++)
+            {
+                double acc = 0;
+                if (side == Side.Left)
+                    for (int p = 0; p < s; p++) acc += Asym(i, p) * b[p * ldb + l];
+                else
+                    for (int p = 0; p < s; p++) acc += b[i * ldb + p] * Asym(p, l);
+                outC[i * ldc + l] = alpha * acc + beta * c[i * ldc + l];
+            }
+        return outC;
+    }
+
+    [Fact]
+    public void Symm_FP64_LeftLower_MatchesReference()
+    {
+        const int m = 5, n = 3;
+        var rng = new Random(42);
+        double[] a = new double[m * m];
+        for (int i = 0; i < a.Length; i++) a[i] = rng.NextDouble() * 2 - 1;
+        double[] b = new double[m * n];
+        for (int i = 0; i < b.Length; i++) b[i] = rng.NextDouble() * 2 - 1;
+        double[] c = new double[m * n];
+        for (int i = 0; i < c.Length; i++) c[i] = rng.NextDouble() * 2 - 1;
+
+        double[] expected = ReferenceSymm(Side.Left, Uplo.Lower, m, n, 1.0, a, m, b, n, 0.0, c, n);
+        double[] actual = (double[])c.Clone();
+        BlasManagedLib.Symm<double>(Side.Left, Uplo.Lower, m, n, 1.0, a, m, b, n, 0.0, actual, n);
+        for (int i = 0; i < actual.Length; i++) Assert.Equal(expected[i], actual[i], 10);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SymmTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SymmTests.cs
@@ -51,4 +51,54 @@ public class SymmTests
         BlasManagedLib.Symm<double>(Side.Left, Uplo.Lower, m, n, 1.0, a, m, b, n, 0.0, actual, n);
         for (int i = 0; i < actual.Length; i++) Assert.Equal(expected[i], actual[i], 10);
     }
+
+    public static System.Collections.Generic.IEnumerable<object[]> Matrix()
+    {
+        foreach (var side in new[] { Side.Left, Side.Right })
+        foreach (var uplo in new[] { Uplo.Upper, Uplo.Lower })
+            yield return new object[] { side, uplo };
+    }
+
+    [Theory]
+    [MemberData(nameof(Matrix))]
+    public void Symm_FP64_Coverage_AlphaBeta_MatchesReference(Side side, Uplo uplo)
+    {
+        const int m = 6, n = 4;
+        int s = side == Side.Left ? m : n;
+        var rng = new Random(321);
+        double[] a = new double[s * s];
+        for (int i = 0; i < a.Length; i++) a[i] = rng.NextDouble() * 2 - 1;
+        double[] b = new double[m * n];
+        for (int i = 0; i < b.Length; i++) b[i] = rng.NextDouble() * 2 - 1;
+        double[] c = new double[m * n];
+        for (int i = 0; i < c.Length; i++) c[i] = rng.NextDouble() * 2 - 1;
+
+        double alpha = 1.7, beta = -0.5;
+        double[] expected = ReferenceSymm(side, uplo, m, n, alpha, a, s, b, n, beta, c, n);
+        double[] actual = (double[])c.Clone();
+        BlasManagedLib.Symm<double>(side, uplo, m, n, alpha, a, s, b, n, beta, actual, n);
+        for (int i = 0; i < actual.Length; i++) Assert.Equal(expected[i], actual[i], 9);
+    }
+
+    [Fact]
+    public void Symm_FP32_LeftLower_MatchesReference()
+    {
+        const int m = 5, n = 4;
+        var rng = new Random(11);
+        float[] a = new float[m * m];
+        for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+        float[] b = new float[m * n];
+        for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+        float[] c = new float[m * n];
+        for (int i = 0; i < c.Length; i++) c[i] = (float)(rng.NextDouble() * 2 - 1);
+
+        double[] a64 = Array.ConvertAll(a, x => (double)x);
+        double[] b64 = Array.ConvertAll(b, x => (double)x);
+        double[] c64 = Array.ConvertAll(c, x => (double)x);
+        double[] expected = ReferenceSymm(Side.Left, Uplo.Lower, m, n, 1.0, a64, m, b64, n, 0.0, c64, n);
+
+        float[] actual = (float[])c.Clone();
+        BlasManagedLib.Symm<float>(Side.Left, Uplo.Lower, m, n, 1f, a, m, b, n, 0f, actual, n);
+        for (int i = 0; i < actual.Length; i++) Assert.Equal(expected[i], actual[i], 3);
+    }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SyrkDeterminismTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SyrkDeterminismTests.cs
@@ -1,0 +1,33 @@
+using System;
+using AiDotNet.Tensors.Engines.BlasManaged;
+using Xunit;
+using BlasManagedLib = AiDotNet.Tensors.Engines.BlasManaged.BlasManaged;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+[Collection("BlasManaged-Stats-Serial")]
+public class SyrkDeterminismTests
+{
+    [Theory]
+    [InlineData(64, 48)]
+    [InlineData(128, 96)]
+    [InlineData(192, 64)]
+    public void Syrk_FP64_BitExactAcrossThreadCounts(int n, int k)
+    {
+        var rng = new Random(42);
+        double[] a = new double[n * k];
+        for (int i = 0; i < a.Length; i++) a[i] = rng.NextDouble() * 2 - 1;
+        double[] c0 = new double[n * n];
+        for (int i = 0; i < c0.Length; i++) c0[i] = rng.NextDouble() * 2 - 1;
+
+        double[]? baseline = null;
+        foreach (int threads in new[] { 1, 2, 4, 8 })
+        {
+            double[] actual = (double[])c0.Clone();
+            var opts = new BlasOptions<double> { NumThreads = threads, Mode = BlasMode.Deterministic };
+            BlasManagedLib.Syrk<double>(Uplo.Lower, false, n, k, 1.3, a, k, 0.7, actual, n, opts);
+            if (baseline is null) baseline = actual;
+            else for (int i = 0; i < actual.Length; i++) Assert.Equal(baseline[i], actual[i]);
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SyrkTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SyrkTests.cs
@@ -51,4 +51,59 @@ public class SyrkTests
                 if (j <= i) Assert.Equal(expectedFull[i * n + j], actual[i * n + j], 10);
                 else        Assert.Equal(c[i * n + j], actual[i * n + j], 10);
     }
+
+    public static System.Collections.Generic.IEnumerable<object[]> Matrix()
+    {
+        foreach (var uplo in new[] { Uplo.Upper, Uplo.Lower })
+        foreach (var trans in new[] { false, true })
+            yield return new object[] { uplo, trans };
+    }
+
+    [Theory]
+    [MemberData(nameof(Matrix))]
+    public void Syrk_FP64_Coverage_AlphaBeta_MatchesReference(Uplo uplo, bool trans)
+    {
+        const int n = 6, k = 4;
+        var rng = new Random(321);
+        // trans=false → A is n×k (lda=k); trans=true → A is k×n (lda=n).
+        int aRows = trans ? k : n, aCols = trans ? n : k, lda = aCols;
+        double[] a = new double[aRows * aCols];
+        for (int i = 0; i < a.Length; i++) a[i] = rng.NextDouble() * 2 - 1;
+        double[] c = new double[n * n];
+        for (int i = 0; i < c.Length; i++) c[i] = rng.NextDouble() * 2 - 1;
+
+        double alpha = 1.7, beta = -0.5;
+        double[] expectedFull = ReferenceSyrk(trans, n, k, alpha, a, lda, beta, c, n);
+        double[] actual = (double[])c.Clone();
+        BlasManagedLib.Syrk<double>(uplo, trans, n, k, alpha, a, lda, beta, actual, n);
+
+        for (int i = 0; i < n; i++)
+            for (int j = 0; j < n; j++)
+            {
+                bool inTri = uplo == Uplo.Lower ? j <= i : j >= i;
+                if (inTri) Assert.Equal(expectedFull[i * n + j], actual[i * n + j], 9);
+                else       Assert.Equal(c[i * n + j], actual[i * n + j], 9);
+            }
+    }
+
+    [Fact]
+    public void Syrk_FP32_LowerNoTrans_MatchesReference()
+    {
+        const int n = 5, k = 4;
+        var rng = new Random(11);
+        float[] a = new float[n * k];
+        for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+        float[] c = new float[n * n];
+        for (int i = 0; i < c.Length; i++) c[i] = (float)(rng.NextDouble() * 2 - 1);
+
+        double[] a64 = Array.ConvertAll(a, x => (double)x);
+        double[] c64 = Array.ConvertAll(c, x => (double)x);
+        double[] expectedFull = ReferenceSyrk(false, n, k, 1.0, a64, k, 0.0, c64, n);
+
+        float[] actual = (float[])c.Clone();
+        BlasManagedLib.Syrk<float>(Uplo.Lower, false, n, k, 1f, a, k, 0f, actual, n);
+        for (int i = 0; i < n; i++)
+            for (int j = 0; j <= i; j++)
+                Assert.Equal(expectedFull[i * n + j], actual[i * n + j], 3);
+    }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SyrkTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SyrkTests.cs
@@ -1,0 +1,54 @@
+using System;
+using AiDotNet.Tensors.Engines.BlasManaged;
+using Xunit;
+using BlasManagedLib = AiDotNet.Tensors.Engines.BlasManaged.BlasManaged;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+[Collection("BlasManaged-Stats-Serial")]
+public class SyrkTests
+{
+    // Reference: C = alpha*op(A)*op(A)^T + beta*C, full dense, then caller checks triangle.
+    // trans=false: A is n×k, op(A)=A. trans=true: A is k×n, op(A)=A^T (n×k effective).
+    private static double[] ReferenceSyrk(
+        bool trans, int n, int k, double alpha, double[] a, int lda, double beta, double[] c, int ldc)
+    {
+        var outC = (double[])c.Clone();
+        for (int i = 0; i < n; i++)
+            for (int j = 0; j < n; j++)
+            {
+                double dot = 0;
+                for (int p = 0; p < k; p++)
+                {
+                    // op(A)[i,p] and op(A)[j,p]
+                    double aip = trans ? a[p * lda + i] : a[i * lda + p];
+                    double ajp = trans ? a[p * lda + j] : a[j * lda + p];
+                    dot += aip * ajp;
+                }
+                outC[i * ldc + j] = alpha * dot + beta * c[i * ldc + j];
+            }
+        return outC;
+    }
+
+    [Fact]
+    public void Syrk_FP64_LowerNoTrans_MatchesReferenceTriangle()
+    {
+        const int n = 5, k = 3;
+        var rng = new Random(42);
+        double[] a = new double[n * k];
+        for (int i = 0; i < a.Length; i++) a[i] = rng.NextDouble() * 2 - 1;
+        double[] c = new double[n * n];
+        for (int i = 0; i < c.Length; i++) c[i] = rng.NextDouble() * 2 - 1;
+
+        double[] expectedFull = ReferenceSyrk(false, n, k, 1.0, a, k, 0.0, c, n);
+
+        double[] actual = (double[])c.Clone();
+        BlasManagedLib.Syrk<double>(Uplo.Lower, trans: false, n, k, 1.0, a, k, 0.0, actual, n);
+
+        // Only the lower triangle (incl diagonal) must match; upper is untouched (= original c).
+        for (int i = 0; i < n; i++)
+            for (int j = 0; j < n; j++)
+                if (j <= i) Assert.Equal(expectedFull[i * n + j], actual[i * n + j], 10);
+                else        Assert.Equal(c[i * n + j], actual[i * n + j], 10);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SyrkTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SyrkTests.cs
@@ -106,4 +106,26 @@ public class SyrkTests
             for (int j = 0; j <= i; j++)
                 Assert.Equal(expectedFull[i * n + j], actual[i * n + j], 3);
     }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Syrk_FP64_LargeN_BlockedPath_MatchesReference(bool trans)
+    {
+        const int n = 150, k = 40; // n > SyrkBlock(64)
+        var rng = new Random(2025);
+        int aRows = trans ? k : n, aCols = trans ? n : k, lda = aCols;
+        double[] a = new double[aRows * aCols];
+        for (int i = 0; i < a.Length; i++) a[i] = rng.NextDouble() * 2 - 1;
+        double[] c = new double[n * n];
+        for (int i = 0; i < c.Length; i++) c[i] = rng.NextDouble() * 2 - 1;
+
+        double alpha = 0.9, beta = 0.3;
+        double[] expectedFull = ReferenceSyrk(trans, n, k, alpha, a, lda, beta, c, n);
+        double[] actual = (double[])c.Clone();
+        BlasManagedLib.Syrk<double>(Uplo.Lower, trans, n, k, alpha, a, lda, beta, actual, n);
+        for (int i = 0; i < n; i++)
+            for (int j = 0; j <= i; j++)
+                Assert.Equal(expectedFull[i * n + j], actual[i * n + j], 8);
+    }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/TrsmDeterminismTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/TrsmDeterminismTests.cs
@@ -1,0 +1,39 @@
+using System;
+using AiDotNet.Tensors.Engines.BlasManaged;
+using Xunit;
+using BlasManagedLib = AiDotNet.Tensors.Engines.BlasManaged.BlasManaged;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+[Collection("BlasManaged-Stats-Serial")]
+public class TrsmDeterminismTests
+{
+    [Theory]
+    [InlineData(64, 32)]
+    [InlineData(128, 16)]
+    [InlineData(256, 8)]
+    public void Trsm_FP64_BitExactAcrossThreadCounts(int m, int n)
+    {
+        var rng = new Random(42);
+        double[] a = new double[m * m];
+        for (int i = 0; i < m; i++)
+        {
+            for (int j = 0; j <= i; j++) a[i * m + j] = rng.NextDouble() * 2 - 1;
+            a[i * m + i] += m;
+        }
+        double[] b0 = new double[m * n];
+        for (int i = 0; i < b0.Length; i++) b0[i] = rng.NextDouble() * 2 - 1;
+
+        double[]? baseline = null;
+        foreach (int threads in new[] { 1, 2, 4, 8 })
+        {
+            double[] actual = (double[])b0.Clone();
+            var opts = new BlasOptions<double> { NumThreads = threads, Mode = BlasMode.Deterministic };
+            BlasManagedLib.Trsm<double>(Side.Left, Uplo.Lower, false, Diag.NonUnit, m, n, 1.0, a, m, actual, n, opts);
+            if (baseline is null) baseline = actual;
+            else
+                for (int i = 0; i < actual.Length; i++)
+                    Assert.Equal(baseline[i], actual[i]); // EXACT bit equality, no tolerance
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/TrsmTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/TrsmTests.cs
@@ -1,0 +1,79 @@
+using System;
+using AiDotNet.Tensors.Engines.BlasManaged;
+using Xunit;
+using BlasManagedLib = AiDotNet.Tensors.Engines.BlasManaged.BlasManaged;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+[Collection("BlasManaged-Stats-Serial")]
+public class TrsmTests
+{
+    // Naive reference: solve op(A)·X = alpha·B in place, row-major, left side.
+    // Independent of production code so it is a genuine oracle.
+    private static void ReferenceTrsmLeft(
+        Side side, Uplo uplo, bool transA, Diag diag,
+        int m, int n, double alpha,
+        double[] a, int lda, double[] b, int ldb)
+    {
+        // Scale B by alpha first.
+        for (int i = 0; i < m; i++)
+            for (int j = 0; j < n; j++)
+                b[i * ldb + j] *= alpha;
+
+        // Effective triangular access: A(r,c) with optional transpose.
+        double A(int r, int c) => transA ? a[c * lda + r] : a[r * lda + c];
+
+        bool lower = (uplo == Uplo.Lower) ^ transA; // transpose flips triangle
+        if (side != Side.Left) throw new NotSupportedException("test covers Left only here");
+
+        if (lower)
+        {
+            // Forward substitution: row 0..m-1
+            for (int i = 0; i < m; i++)
+                for (int j = 0; j < n; j++)
+                {
+                    double sum = b[i * ldb + j];
+                    for (int kk = 0; kk < i; kk++) sum -= A(i, kk) * b[kk * ldb + j];
+                    b[i * ldb + j] = diag == Diag.Unit ? sum : sum / A(i, i);
+                }
+        }
+        else
+        {
+            // Back substitution: row m-1..0
+            for (int i = m - 1; i >= 0; i--)
+                for (int j = 0; j < n; j++)
+                {
+                    double sum = b[i * ldb + j];
+                    for (int kk = i + 1; kk < m; kk++) sum -= A(i, kk) * b[kk * ldb + j];
+                    b[i * ldb + j] = diag == Diag.Unit ? sum : sum / A(i, i);
+                }
+        }
+    }
+
+    [Fact]
+    public void Trsm_FP64_LeftLowerNoTransNonUnit_SingleRhs_MatchesReference()
+    {
+        const int m = 5, n = 1;
+        var rng = new Random(42);
+        double[] a = new double[m * m];
+        double[] b = new double[m * n];
+        // Lower-triangular A with a strong diagonal so it is well-conditioned.
+        for (int i = 0; i < m; i++)
+        {
+            for (int j = 0; j <= i; j++) a[i * m + j] = rng.NextDouble() * 2 - 1;
+            a[i * m + i] += m; // dominant diagonal
+        }
+        for (int i = 0; i < b.Length; i++) b[i] = rng.NextDouble() * 2 - 1;
+
+        double[] expected = (double[])b.Clone();
+        ReferenceTrsmLeft(Side.Left, Uplo.Lower, false, Diag.NonUnit, m, n, 1.0, a, m, expected, n);
+
+        double[] actual = (double[])b.Clone();
+        BlasManagedLib.Trsm<double>(
+            Side.Left, Uplo.Lower, transA: false, Diag.NonUnit,
+            m, n, 1.0, a, m, actual, n);
+
+        for (int i = 0; i < actual.Length; i++)
+            Assert.Equal(expected[i], actual[i], 10); // 10 decimal places
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/TrsmTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/TrsmTests.cs
@@ -187,4 +187,25 @@ public class TrsmTests
         BlasManagedLib.Trsm<double>(Side.Left, Uplo.Lower, false, Diag.NonUnit, m, n, 2.5, a, m, actual, n);
         for (int i = 0; i < actual.Length; i++) Assert.Equal(expected[i], actual[i], 9);
     }
+
+    [Fact]
+    public void Trsm_FP64_LargeLeftLower_BlockedPath_MatchesReference()
+    {
+        const int m = 200, n = 5; // m > TrsmBlock(64) → blocked
+        var rng = new Random(2024);
+        double[] a = new double[m * m];
+        for (int i = 0; i < m; i++)
+        {
+            for (int j = 0; j <= i; j++) a[i * m + j] = rng.NextDouble() * 2 - 1;
+            a[i * m + i] += m;
+        }
+        double[] b = new double[m * n];
+        for (int i = 0; i < b.Length; i++) b[i] = rng.NextDouble() * 2 - 1;
+
+        double[] expected = (double[])b.Clone();
+        ReferenceTrsmLeft(Side.Left, Uplo.Lower, false, Diag.NonUnit, m, n, 1.0, a, m, expected, n);
+        double[] actual = (double[])b.Clone();
+        BlasManagedLib.Trsm<double>(Side.Left, Uplo.Lower, false, Diag.NonUnit, m, n, 1.0, a, m, actual, n);
+        for (int i = 0; i < actual.Length; i++) Assert.Equal(expected[i], actual[i], 8);
+    }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/TrsmTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/TrsmTests.cs
@@ -208,4 +208,39 @@ public class TrsmTests
         BlasManagedLib.Trsm<double>(Side.Left, Uplo.Lower, false, Diag.NonUnit, m, n, 1.0, a, m, actual, n);
         for (int i = 0; i < actual.Length; i++) Assert.Equal(expected[i], actual[i], 8);
     }
+
+    public static System.Collections.Generic.IEnumerable<object[]> LeftMatrix()
+    {
+        foreach (var uplo in new[] { Uplo.Upper, Uplo.Lower })
+        foreach (var trans in new[] { false, true })
+        foreach (var diag in new[] { Diag.NonUnit, Diag.Unit })
+            yield return new object[] { uplo, trans, diag };
+    }
+
+    [Theory]
+    [MemberData(nameof(LeftMatrix))]
+    public void Trsm_FP64_LargeLeft_AllCombos_BlockedPath_MatchesReference(Uplo uplo, bool trans, Diag diag)
+    {
+        const int m = 200, n = 6; // m > TrsmBlock(64) → blocked, all Left uplo×trans×diag
+        var rng = new Random(4242);
+        double[] a = new double[m * m];
+        for (int i = 0; i < m; i++)
+        {
+            for (int j = 0; j < m; j++)
+                if ((uplo == Uplo.Upper && j >= i) || (uplo == Uplo.Lower && j <= i))
+                    // Small off-diagonals so a 200-row UNIT-triangular solve stays
+                    // well-conditioned (no exponential substitution growth that would
+                    // push values to ~1e10 and defeat an absolute tolerance).
+                    a[i * m + j] = (rng.NextDouble() * 2 - 1) * 0.05;
+            a[i * m + i] += m; // dominant diagonal (used by NonUnit; ignored by Unit)
+        }
+        double[] b = new double[m * n];
+        for (int i = 0; i < b.Length; i++) b[i] = rng.NextDouble() * 2 - 1;
+
+        double[] expected = (double[])b.Clone();
+        ReferenceTrsmLeft(Side.Left, uplo, trans, diag, m, n, 1.0, a, m, expected, n);
+        double[] actual = (double[])b.Clone();
+        BlasManagedLib.Trsm<double>(Side.Left, uplo, trans, diag, m, n, 1.0, a, m, actual, n);
+        for (int i = 0; i < actual.Length; i++) Assert.Equal(expected[i], actual[i], 7);
+    }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/TrsmTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/TrsmTests.cs
@@ -76,4 +76,115 @@ public class TrsmTests
         for (int i = 0; i < actual.Length; i++)
             Assert.Equal(expected[i], actual[i], 10); // 10 decimal places
     }
+
+    private static void ReferenceTrsmRight(
+        Uplo uplo, bool transA, Diag diag, int m, int n,
+        double alpha, double[] a, int lda, double[] b, int ldb)
+    {
+        for (int i = 0; i < m; i++)
+            for (int j = 0; j < n; j++) b[i * ldb + j] *= alpha;
+        double A(int r, int c) => transA ? a[c * lda + r] : a[r * lda + c];
+        bool lower = (uplo == Uplo.Lower) ^ transA;
+        if (!lower)
+            for (int j = 0; j < n; j++)
+                for (int i = 0; i < m; i++)
+                {
+                    double sum = b[i * ldb + j];
+                    for (int kk = 0; kk < j; kk++) sum -= b[i * ldb + kk] * A(kk, j);
+                    b[i * ldb + j] = diag == Diag.Unit ? sum : sum / A(j, j);
+                }
+        else
+            for (int j = n - 1; j >= 0; j--)
+                for (int i = 0; i < m; i++)
+                {
+                    double sum = b[i * ldb + j];
+                    for (int kk = j + 1; kk < n; kk++) sum -= b[i * ldb + kk] * A(kk, j);
+                    b[i * ldb + j] = diag == Diag.Unit ? sum : sum / A(j, j);
+                }
+    }
+
+    public static System.Collections.Generic.IEnumerable<object[]> FullMatrix()
+    {
+        foreach (var side in new[] { Side.Left, Side.Right })
+        foreach (var uplo in new[] { Uplo.Upper, Uplo.Lower })
+        foreach (var trans in new[] { false, true })
+        foreach (var diag in new[] { Diag.NonUnit, Diag.Unit })
+            yield return new object[] { side, uplo, trans, diag };
+    }
+
+    [Theory]
+    [MemberData(nameof(FullMatrix))]
+    public void Trsm_FP64_FullCoverage_MultiRhs_MatchesReference(
+        Side side, Uplo uplo, bool trans, Diag diag)
+    {
+        const int m = 7, n = 4;            // multi-RHS
+        int triDim = side == Side.Left ? m : n;
+        var rng = new Random(123);
+        double[] a = new double[triDim * triDim];
+        for (int i = 0; i < triDim; i++)
+        {
+            for (int j = 0; j < triDim; j++)
+                if ((uplo == Uplo.Upper && j >= i) || (uplo == Uplo.Lower && j <= i))
+                    a[i * triDim + j] = rng.NextDouble() * 2 - 1;
+            a[i * triDim + i] += triDim; // dominant diagonal
+        }
+        double[] b = new double[m * n];
+        for (int i = 0; i < b.Length; i++) b[i] = rng.NextDouble() * 2 - 1;
+
+        double[] expected = (double[])b.Clone();
+        if (side == Side.Left)
+            ReferenceTrsmLeft(side, uplo, trans, diag, m, n, 1.0, a, triDim, expected, n);
+        else
+            ReferenceTrsmRight(uplo, trans, diag, m, n, 1.0, a, triDim, expected, n);
+
+        double[] actual = (double[])b.Clone();
+        BlasManagedLib.Trsm<double>(side, uplo, trans, diag, m, n, 1.0, a, triDim, actual, n);
+
+        for (int i = 0; i < actual.Length; i++)
+            Assert.Equal(expected[i], actual[i], 9);
+    }
+
+    [Fact]
+    public void Trsm_FP32_LeftLower_MatchesReference()
+    {
+        const int m = 6, n = 3;
+        var rng = new Random(7);
+        float[] a = new float[m * m];
+        for (int i = 0; i < m; i++)
+        {
+            for (int j = 0; j <= i; j++) a[i * m + j] = (float)(rng.NextDouble() * 2 - 1);
+            a[i * m + i] += m;
+        }
+        float[] b = new float[m * n];
+        for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+
+        // FP64 reference for accuracy.
+        double[] a64 = Array.ConvertAll(a, x => (double)x);
+        double[] e64 = new double[b.Length];
+        for (int i = 0; i < b.Length; i++) e64[i] = b[i];
+        ReferenceTrsmLeft(Side.Left, Uplo.Lower, false, Diag.NonUnit, m, n, 1.0, a64, m, e64, n);
+
+        float[] actual = (float[])b.Clone();
+        BlasManagedLib.Trsm<float>(Side.Left, Uplo.Lower, false, Diag.NonUnit, m, n, 1f, a, m, actual, n);
+
+        for (int i = 0; i < actual.Length; i++)
+            Assert.Equal(e64[i], actual[i], 3); // FP32: 3 decimal places
+    }
+
+    [Fact]
+    public void Trsm_Alpha_ScalesRightHandSide()
+    {
+        const int m = 4, n = 2;
+        var rng = new Random(99);
+        double[] a = new double[m * m];
+        for (int i = 0; i < m; i++) { for (int j = 0; j <= i; j++) a[i*m+j] = rng.NextDouble(); a[i*m+i] += m; }
+        double[] b = new double[m * n];
+        for (int i = 0; i < b.Length; i++) b[i] = rng.NextDouble();
+
+        double[] expected = (double[])b.Clone();
+        ReferenceTrsmLeft(Side.Left, Uplo.Lower, false, Diag.NonUnit, m, n, 2.5, a, m, expected, n);
+        double[] actual = (double[])b.Clone();
+        BlasManagedLib.Trsm<double>(Side.Left, Uplo.Lower, false, Diag.NonUnit, m, n, 2.5, a, m, actual, n);
+        for (int i = 0; i < actual.Length; i++) Assert.Equal(expected[i], actual[i], 9);
+    }
 }

--- a/tests/AiDotNet.Tensors.Tests/Topology/HodgeLaplacianSyrkTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Topology/HodgeLaplacianSyrkTests.cs
@@ -1,0 +1,67 @@
+using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.Tensors.Topology;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Topology;
+
+public class HodgeLaplacianSyrkTests
+{
+    // Independent oracle: L_k = B_kᵀ·B_k + B_{k+1}·B_{k+1}ᵀ, computed via the plain
+    // Matrix Transpose/Multiply path. Guards the #379 SYRK rewire of HodgeLaplacian.
+    private static Matrix<double> ReferenceHodge(SimplicialComplex sc, int k)
+    {
+        var kSimplices = sc.GetSimplices(k);
+        var result = new Matrix<double>(kSimplices.Count, kSimplices.Count);
+        if (k > 0)
+        {
+            var bK = sc.BoundaryOperator<double>(k);
+            var term = (Matrix<double>)bK.Transpose().Multiply(bK);
+            result = (Matrix<double>)result.Add(term);
+        }
+        if (k < sc.MaxDimension)
+        {
+            var bKPlus = sc.BoundaryOperator<double>(k + 1);
+            if (bKPlus.Rows > 0 && bKPlus.Columns > 0)
+            {
+                var term = (Matrix<double>)bKPlus.Multiply(bKPlus.Transpose());
+                result = (Matrix<double>)result.Add(term);
+            }
+        }
+        return result;
+    }
+
+    private static SimplicialComplex BuildTriangle()
+    {
+        var sc = new SimplicialComplex();
+        sc.AddSimplex(new Simplex(new[] { 0, 1, 2 }), includeFaces: true); // triangle + edges + vertices
+        return sc;
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    public void HodgeLaplacian_MatchesReference_FullSymmetric(int k)
+    {
+        var sc = BuildTriangle();
+        var expected = ReferenceHodge(sc, k);
+        var actual = sc.HodgeLaplacian<double>(k);
+
+        Assert.Equal(expected.Rows, actual.Rows);
+        Assert.Equal(expected.Columns, actual.Columns);
+        for (int i = 0; i < expected.Rows; i++)
+            for (int j = 0; j < expected.Columns; j++)
+                Assert.Equal(expected[i, j], actual[i, j], 10);
+    }
+
+    [Fact]
+    public void HodgeLaplacian_IsSymmetric()
+    {
+        // SYRK writes one triangle then symmetrizes — the full result must be symmetric.
+        var sc = BuildTriangle();
+        var l = sc.HodgeLaplacian<double>(1);
+        for (int i = 0; i < l.Rows; i++)
+            for (int j = 0; j < l.Columns; j++)
+                Assert.Equal(l[i, j], l[j, i], 12);
+    }
+}


### PR DESCRIPTION
## Summary
Implements the **CPU** portion of #379 — five first-class, drop-in managed BLAS variants on `BlasManaged`, reusing the existing GEMM microkernel core (Approach A) where possible:

- **TRSM** (`Trsm`) — triangular solve; blocked GEMM-macrokernel path for **all** Left uplo×trans combos. Rewires `LinearSolvers` (FP32/FP64).
- **SYRK** (`Syrk`) — symmetric rank-k; **tile-skip** (only the requested triangle ≈ half the FLOPs), both trans modes via the macrokernel. Rewires `HodgeLaplacian`.
- **SYMM** (`Symm`) — symmetric matrix multiply via symmetric materialize + GEMM.
- **SpMM** (`SpMM`) — sparse×dense CSR/CSC; typed FP32/FP64 **SIMD** inner loop + **CSR row-parallel** + **fused epilogue** (bias/activation). Rewires `CpuSparseEngine.SpMM`.
- **GBMV** (`Gbmv`) — banded matrix-vector, LAPACK band storage.

All five: **drop-in CBLAS argument order**, FP32+FP64, **bit-exact deterministic** across thread counts (`BlasMode.Deterministic` default), with bench-catalog entries + frozen-after-measurement perf-bar stubs. Exceed-vendor levers ride `BlasOptions` (fused epilogue, determinism-by-default, single generic `<T>`).

Corrects the issue's premise: the CPU side had **no native BLAS dependency** for these (ad-hoc managed loops / naive scalar SpMM); this delivers optimized first-class kernels and rewires the call sites.

## Verification
- [x] `dotnet build` clean on **net10.0 + net471**
- [x] **210 passed / 0 failed** across TRSM/SYRK/SYMM/SpMM/GBMV + sparse engine + Hodge/topology + solver canary (2 skips are pre-existing conditional tests)
- [x] Determinism tests (1/2/4/8 threads, bit-exact) per variant
- [x] Full correctness matrices (Side×Uplo×Trans×Diag for TRSM; Uplo×Trans for SYRK; Side×Uplo for SYMM; CSR/CSC/empty-row for SpMM; trans/non-square/strides for GBMV) + a fused `SpMM+bias+ReLU == unfused` test
- [x] `ISparseEngine.SpMM` gained `where T : unmanaged` (sole impl `CpuSparseEngine`; no caller broke)

## Out of scope (tracked follow-ups, hardware/priority gated)
- **#515** — GPU SpMM (make custom CUDA/HIP kernels default, cuSPARSE/rocSPARSE parity bar, vendor removal). Needs GPU hardware + the self-hosted runner; cannot be verified in a CPU-only environment.
- **#517** — SYMM mirror-on-pack micro-opt (low priority: O(s²) materialization is asymptotically free vs the O(s²·n) GEMM; a true on-pack needs invasive strategy surgery).

## Docs
Spec `docs/superpowers/specs/2026-05-30-specialized-blas-variants-design.md`; phased plans under `docs/superpowers/plans/2026-05-30-specialized-blas-variants-p{0-1,2,3,4,5}-*.md`.

Part of #379.

🤖 Generated with [Claude Code](https://claude.com/claude-code)