### PR TITLE
fix: ISparseEngine.SpMM<T> must be unconstrained (public API carries no struct/unmanaged constraint)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuSparseEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuSparseEngine.cs
@@ -123,7 +123,7 @@ public sealed class CpuSparseEngine : ISparseEngine
     #region Sparse Matrix-Matrix Operations
 
     /// <inheritdoc/>
-    public Matrix<T> SpMM<T>(SparseTensor<T> sparse, Matrix<T> dense) where T : unmanaged
+    public Matrix<T> SpMM<T>(SparseTensor<T> sparse, Matrix<T> dense)
     {
         if (sparse is null) throw new ArgumentNullException(nameof(sparse));
         if (dense is null) throw new ArgumentNullException(nameof(dense));
@@ -133,14 +133,29 @@ public sealed class CpuSparseEngine : ISparseEngine
                 $"Sparse matrix columns ({sparse.Columns}) must match dense matrix rows ({dense.Rows}).");
         }
 
-        var ops = MathHelper.GetNumericOperations<T>();
-        var result = new Matrix<T>(sparse.Rows, dense.Columns);
+        // The public API is unconstrained over T (no struct/unmanaged constraint) so
+        // unconstrained-T consumers — e.g. the neural-network layers, generic over an
+        // open T backed by INumericOperations<T> — can call it. Route the blittable
+        // element types through the SIMD/parallel BLAS SpMM kernel (#379); fall back to
+        // a generic CSR scalar path for any other T. float/double satisfy `unmanaged`,
+        // so the (object) cast to the concrete type is sound at runtime.
+        if (typeof(T) == typeof(float))
+            return (Matrix<T>)(object)SpMMBlas((SparseTensor<float>)(object)sparse, (Matrix<float>)(object)dense);
+        if (typeof(T) == typeof(double))
+            return (Matrix<T>)(object)SpMMBlas((SparseTensor<double>)(object)sparse, (Matrix<double>)(object)dense);
+        return SpMMGenericScalar(sparse, dense);
+    }
 
-        // #379: route through the SIMD/parallel managed BLAS SpMM kernel (C = 1·A·B + 0·C).
-        // CSR row-parallel, cache-friendly (B rows read contiguously), bit-deterministic —
-        // replaces the prior column-strided naive triple loop.
+    // #379 SIMD/parallel managed BLAS SpMM kernel (C = 1·A·B + 0·C): CSR row-parallel,
+    // cache-friendly (B rows read contiguously), bit-deterministic. Constrained to
+    // unmanaged because the kernel reinterprets element spans (MemoryMarshal.Cast).
+    private static Matrix<TU> SpMMBlas<TU>(SparseTensor<TU> sparse, Matrix<TU> dense) where TU : unmanaged
+    {
+        var ops = MathHelper.GetNumericOperations<TU>();
+        var result = new Matrix<TU>(sparse.Rows, dense.Columns);
+
         var csr = sparse.ToCsr();
-        var layout = new BlasManaged.SparseLayout<T>
+        var layout = new BlasManaged.SparseLayout<TU>
         {
             Rows = sparse.Rows,
             Cols = sparse.Columns,
@@ -150,10 +165,44 @@ public sealed class CpuSparseEngine : ISparseEngine
             Format = BlasManaged.SparseLayoutFormat.Csr,
         };
         int n = dense.Columns;
-        BlasManaged.BlasManaged.SpMM<T>(
+        BlasManaged.BlasManaged.SpMM<TU>(
             ops.One, layout,
             dense.AsSpan(), n, n,
             ops.Zero, result.AsWritableSpan(), n);
+
+        return result;
+    }
+
+    // Generic CSR scalar SpMM for arbitrary T (mirrors SpMV's fully generic
+    // INumericOperations<T> path): C[i, :] += A[i, j] · B[j, :] over the non-zeros of
+    // each sparse row, in the same row-major-over-CSR order the BLAS kernel uses, so
+    // results agree to floating-point rounding.
+    private static Matrix<T> SpMMGenericScalar<T>(SparseTensor<T> sparse, Matrix<T> dense)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        int rows = sparse.Rows;
+        int n = dense.Columns;
+        var result = new Matrix<T>(rows, n);   // T[] backing is zero-initialized
+
+        var csr = sparse.ToCsr();
+        var rowPtrs = csr.RowPointers;
+        var colIndices = csr.ColumnIndices;
+        var values = csr.Values;
+
+        for (int row = 0; row < rows; row++)
+        {
+            int start = rowPtrs[row];
+            int end = rowPtrs[row + 1];
+            for (int idx = start; idx < end; idx++)
+            {
+                int col = colIndices[idx];
+                T val = values[idx];
+                for (int k = 0; k < n; k++)
+                {
+                    result[row, k] = ops.Add(result[row, k], ops.Multiply(val, dense[col, k]));
+                }
+            }
+        }
 
         return result;
     }

--- a/src/AiDotNet.Tensors/Engines/ISparseEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/ISparseEngine.cs
@@ -75,11 +75,17 @@ public interface ISparseEngine
     /// </para>
     /// </remarks>
     /// <remarks>
-    /// <para><b>#379:</b> <c>T : unmanaged</c> is required so SpMM can route through
-    /// the SIMD/parallel <see cref="BlasManaged.BlasManaged.SpMM{T}"/> kernel. All
-    /// numeric element types used in this library satisfy it.</para>
+    /// <para><b>Unconstrained <c>T</c>:</b> like every other public engine method
+    /// (and <see cref="SpMV{T}"/> above), this is generic over an unconstrained
+    /// <c>T</c> — the library's public API deliberately carries no <c>struct</c> /
+    /// <c>unmanaged</c> constraint so unconstrained-<c>T</c> consumers (e.g. the
+    /// neural-network layers, which are generic over an open <c>T</c> backed by
+    /// <c>INumericOperations&lt;T&gt;</c>) can call it. The implementation routes
+    /// blittable element types (float/double) through the SIMD/parallel
+    /// <see cref="BlasManaged.BlasManaged.SpMM{T}"/> kernel (#379) and falls back to
+    /// a generic CSR scalar path for any other <c>T</c>.</para>
     /// </remarks>
-    Matrix<T> SpMM<T>(SparseTensor<T> sparse, Matrix<T> dense) where T : unmanaged;
+    Matrix<T> SpMM<T>(SparseTensor<T> sparse, Matrix<T> dense);
 
     /// <summary>
     /// Sparse matrix-sparse matrix multiplication: C = A * B (both sparse)

--- a/tests/AiDotNet.Tensors.Tests/Engines/CpuSparseEngineSpMMTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/CpuSparseEngineSpMMTests.cs
@@ -1,0 +1,59 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Verifies <see cref="CpuSparseEngine.SpMM{T}"/> over an <b>unconstrained</b> T —
+/// the public API carries no struct/unmanaged constraint (so unconstrained-T
+/// consumers such as the neural-network layers can call it). float/double take the
+/// SIMD/parallel BLAS fast path; any other numeric T (here decimal) takes the
+/// generic CSR scalar fallback. All must agree with a hand-computed reference.
+///
+/// Regression guard for the #379 constraint leak: SpMM had `where T : unmanaged`,
+/// which broke SparseLinearLayer&lt;T&gt; (generic over an open T).
+/// </summary>
+public class CpuSparseEngineSpMMTests
+{
+    // A (2×3) with non-zeros (0,0)=2, (0,2)=3, (1,1)=4;  B (3×2) = [[1,2],[3,4],[5,6]].
+    //   C = A·B = [[2·1+3·5, 2·2+3·6], [4·3, 4·4]] = [[17,22],[12,16]]
+    private static readonly double[,] ExpectedC = { { 17, 22 }, { 12, 16 } };
+
+    private static void CheckSpMM<T>(double tol)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        var sparse = new SparseTensor<T>(
+            2, 3,
+            new[] { 0, 0, 1 },                                  // row indices
+            new[] { 0, 2, 1 },                                  // col indices
+            new[] { ops.FromDouble(2), ops.FromDouble(3), ops.FromDouble(4) });
+
+        var dense = new Matrix<T>(3, 2);
+        double[,] bv = { { 1, 2 }, { 3, 4 }, { 5, 6 } };
+        for (int r = 0; r < 3; r++)
+            for (int c = 0; c < 2; c++)
+                dense[r, c] = ops.FromDouble(bv[r, c]);
+
+        var engine = new CpuSparseEngine();
+        Matrix<T> result = engine.SpMM(sparse, dense);
+
+        Assert.Equal(2, result.Rows);
+        Assert.Equal(2, result.Columns);
+        for (int r = 0; r < 2; r++)
+            for (int c = 0; c < 2; c++)
+                Assert.True(Math.Abs(ops.ToDouble(result[r, c]) - ExpectedC[r, c]) <= tol,
+                    $"[{r},{c}] expected {ExpectedC[r, c]}, got {ops.ToDouble(result[r, c])}");
+    }
+
+    [Fact]
+    public void SpMM_Float_SimdFastPath_MatchesReference() => CheckSpMM<float>(1e-4);
+
+    [Fact]
+    public void SpMM_Double_SimdFastPath_MatchesReference() => CheckSpMM<double>(1e-9);
+
+    [Fact]
+    public void SpMM_Decimal_GenericFallback_MatchesReference() => CheckSpMM<decimal>(1e-9);
+}


### PR DESCRIPTION
## Problem
#379 added `where T : unmanaged` to **public** `ISparseEngine.SpMM<T>` (to route through the SIMD `BlasManaged.SpMM<T>` kernel). That constraint leaked into the public API and broke unconstrained-`T` consumers: AiDotNet's neural-network layers are generic over an open `T` backed by `INumericOperations<T>` **by design** (no `struct`/`unmanaged` constraint anywhere on the public surface). Against 0.90.x, `SparseLinearLayer<T>` fails to compile:

```
CS8377: The type 'T' must be a non-nullable value type ... to use it as parameter 'T' in ISparseEngine.SpMM<T>
```

`SpMV` / `SpMVTranspose` / `SpSpMM` are all unconstrained — `SpMM` was the lone outlier.

## Fix
Drop the constraint from the interface and `CpuSparseEngine`, and dispatch at runtime:
- **float / double** → the #379 SIMD/parallel BLAS fast path, via an internal `SpMMBlas<TU> where TU : unmanaged` reached through an `(object)` cast (sound — float/double satisfy `unmanaged`). No behavior change.
- **any other T** → a generic CSR scalar fallback mirroring `SpMV`'s `INumericOperations<T>` path, with the same row-major-over-CSR accumulation order so results agree to FP rounding.

The public surface is now constraint-free like every other engine op.

## Tests
`CpuSparseEngineSpMMTests`: float + double (fast path) and **decimal** (generic fallback — proves the unconstrained signature works beyond float/double) vs a hand-computed reference. Existing SpMM kernel/determinism tests stay green (11/11). net10.0 + net471 build clean.

Unblocks the AiDotNet 0.90.x bump (e.g. #1469 inference-compiled-plan benchmark) — `SparseLinearLayer<T>` compiles again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)