### PR TITLE
fix: FusedLinear must accept rank-1 input (any-rank support)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -34226,6 +34226,20 @@ public partial class CpuEngine : ITensorLevelEngine
         if (input == null) throw new ArgumentNullException(nameof(input));
         if (weights == null) throw new ArgumentNullException(nameof(weights));
 
+        // Any-rank support: a rank-1 input [K] is a single unbatched sample. The GEMM
+        // fast paths and TensorMatMul below operate on rank >= 2, so promote [K] → [1, K]
+        // (numpy/torch matmul promote a 1-D operand the same way), run the standard path,
+        // and squeeze the leading batch dim back off → [N]. This keeps the fused linear
+        // op rank-agnostic and consistent with the generic per-layer Forward path; the
+        // Reshape is tape/graph-aware, so a rank-1 input under training still records a
+        // correct backward chain.
+        if (input.Rank == 1)
+        {
+            var promotedInput = Reshape(input, new[] { 1, input._shape[0] });
+            var promotedResult = FusedLinear(promotedInput, weights, bias, activation, activationParams);
+            return Reshape(promotedResult, new[] { promotedResult._shape[promotedResult.Rank - 1] });
+        }
+
         // Lazy graph mode: record the fused operation for later compilation
         if (GraphMode.IsActive)
         {

--- a/tests/AiDotNet.Tensors.Tests/Engines/FusedLinearRank1Tests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/FusedLinearRank1Tests.cs
@@ -1,0 +1,74 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Any-rank support: a rank-1 input [K] is a single unbatched sample. FusedLinear
+/// (and MlpForward, which chains it) must accept it — promoting to [1, K], computing,
+/// and squeezing back to [N] — rather than throwing "TensorMatMul requires rank >= 2".
+/// Regression guard: this broke FeedForwardNeuralNetwork.Predict on unbatched inputs.
+/// </summary>
+public class FusedLinearRank1Tests
+{
+    private static Tensor<float> Rand(int[] shape, int seed)
+    {
+        var rng = new Random(seed);
+        var t = new Tensor<float>(shape);
+        var s = t.AsWritableSpan();
+        for (int i = 0; i < s.Length; i++) s[i] = (float)(rng.NextDouble() - 0.5);
+        return t;
+    }
+
+    [Fact]
+    public void FusedLinear_Rank1Input_MatchesRank2Squeezed()
+    {
+        var engine = new CpuEngine();
+        const int K = 12, N = 5;
+        var weights = Rand(new[] { K, N }, 1);
+        var bias = Rand(new[] { N }, 2);
+        var x1 = Rand(new[] { K }, 3);                       // rank-1 [K]
+        var x2 = engine.Reshape(x1, new[] { 1, K });          // [1, K]
+
+        var r1 = engine.FusedLinear(x1, weights, bias, FusedActivationType.ReLU);
+        var r2 = engine.FusedLinear(x2, weights, bias, FusedActivationType.ReLU);
+
+        Assert.Equal(1, r1.Rank);                             // squeezed back to [N]
+        Assert.Equal(N, r1.Shape[0]);
+        Assert.Equal(new[] { 1, N }, r2.Shape);
+
+        var a = r1.ToArray(); var b = r2.ToArray();
+        Assert.Equal(a.Length, b.Length);
+        for (int i = 0; i < a.Length; i++)
+            Assert.True(Math.Abs(a[i] - b[i]) <= 1e-6f, $"[{i}] {a[i]} vs {b[i]}");
+    }
+
+    [Fact]
+    public void MlpForward_Rank1Input_MatchesRank2Squeezed()
+    {
+        var engine = new CpuEngine();
+        int[] dims = { 12, 8, 4 };
+        var w = new System.Collections.Generic.List<Tensor<float>>
+        {
+            Rand(new[] { dims[0], dims[1] }, 10),
+            Rand(new[] { dims[1], dims[2] }, 11),
+        };
+        var biases = new System.Collections.Generic.List<Tensor<float>?>
+        {
+            Rand(new[] { dims[1] }, 12),
+            Rand(new[] { dims[2] }, 13),
+        };
+        var x1 = Rand(new[] { dims[0] }, 14);
+        var x2 = engine.Reshape(x1, new[] { 1, dims[0] });
+
+        var r1 = engine.MlpForward(x1, w, biases, FusedActivationType.ReLU, FusedActivationType.None);
+        var r2 = engine.MlpForward(x2, w, biases, FusedActivationType.ReLU, FusedActivationType.None);
+
+        Assert.Equal(dims[2], r1.ToArray().Length);
+        var a = r1.ToArray(); var b = r2.ToArray();
+        for (int i = 0; i < a.Length; i++)
+            Assert.True(Math.Abs(a[i] - b[i]) <= 1e-6f, $"[{i}] {a[i]} vs {b[i]}");
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/FusedLinearRank1Tests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/FusedLinearRank1Tests.cs
@@ -37,7 +37,10 @@ public class FusedLinearRank1Tests
 
         Assert.Equal(1, r1.Rank);                             // squeezed back to [N]
         Assert.Equal(N, r1.Shape[0]);
-        Assert.Equal(new[] { 1, N }, r2.Shape);
+        // .ToArray() so the IEnumerable<int> Assert.Equal overload resolves on
+        // net471 too (TensorShape only has an implicit ReadOnlySpan<int> operator,
+        // which xUnit's span overload picks up on net10 but not on net471).
+        Assert.Equal(new[] { 1, N }, r2.Shape.ToArray());
 
         var a = r1.ToArray(); var b = r2.ToArray();
         Assert.Equal(a.Length, b.Length);
@@ -68,6 +71,7 @@ public class FusedLinearRank1Tests
 
         Assert.Equal(dims[2], r1.ToArray().Length);
         var a = r1.ToArray(); var b = r2.ToArray();
+        Assert.Equal(a.Length, b.Length);
         for (int i = 0; i < a.Length; i++)
             Assert.True(Math.Abs(a[i] - b[i]) <= 1e-6f, $"[{i}] {a[i]} vs {b[i]}");
     }


### PR DESCRIPTION
## Problem
`FusedLinear<T>` calls `TensorMatMul(input, weights)`, which requires rank ≥ 2. A **rank-1** input `[K]` (a single unbatched sample) threw:
```
TensorMatMul requires tensors of rank >= 2. Got rank 1 for first tensor.
```
This broke `FeedForwardNeuralNetwork.Predict` on unbatched inputs via the fused `MlpForward` path (MlpForward chains FusedLinear). The generic per-layer `Forward` already handled rank-1 — the fused path must too, since the library supports any-rank tensors.

## Fix
Promote a rank-1 input `[K] → [1, K]` at the top of `FusedLinear` (numpy/torch matmul promote a 1-D operand identically), run the standard ≥2-D path, then squeeze the batch dim back off → `[N]`. The `Reshape` is tape/graph-aware so training with a rank-1 input still records a correct backward chain. `MlpForward` inherits the fix; rank ≥ 2 paths are untouched.

## Tests
`FusedLinearRank1Tests`: FusedLinear and MlpForward on a rank-1 input match the `[1,K]→[1,N]` path squeezed to `[N]`. 130 FusedLinear/MlpForward cases stay green; net10.0 + net471 build clean.

Unblocks the unbatched-`Predict` cases in the AiDotNet 0.90.x bump (FeedForwardNeuralNetwork model-family tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)