### PR TITLE
feat(#1464): fused forward+backward recurrence kernels for the LM family (+ fused LM-head cross-entropy)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
@@ -165,6 +165,20 @@ internal static class OpRegistry
         // LstmSequenceForward / MultiHeadAttentionForward primitives).
         "Rwkv7SequenceForward",
 
+        // Fused forward+backward recurrence kernels for the LM family (#1464). Each records ONE tape
+        // node for the whole recurrence via DifferentiableOps.RecordIfActive with a custom BPTT
+        // backward, replacing the per-timestep tape micro-ops. All differentiable.
+        "Rwkv4Wkv",
+        "MambaSelectiveScan",
+        "RgLruScan",
+        "GlaScan",
+        "GatedDeltaNetScan",
+        "XLstmScan",
+        "Mamba2SsdScan",
+        // Fused linear (LM head) + cross-entropy-with-logits — avoids materializing the [N, vocab]
+        // logits on the tape for huge-vocab heads.
+        "FusedLinearCrossEntropy",
+
         // Signal
         "RFFT", "IRFFT",
 

--- a/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
@@ -168,16 +168,16 @@ internal static class OpRegistry
         // Fused forward+backward recurrence kernels for the LM family (#1464). Each records ONE tape
         // node for the whole recurrence via DifferentiableOps.RecordIfActive with a custom BPTT
         // backward, replacing the per-timestep tape micro-ops. All differentiable.
-        "Rwkv4Wkv",
-        "MambaSelectiveScan",
-        "RgLruScan",
-        "GlaScan",
-        "GatedDeltaNetScan",
-        "XLstmScan",
-        "Mamba2SsdScan",
+        "Rwkv4WkvForward",
+        "MambaSelectiveScanForward",
+        "RgLruScanForward",
+        "GlaScanForward",
+        "GatedDeltaNetScanForward",
+        "XLstmScanForward",
+        "Mamba2SsdScanForward",
         // Fused linear (LM head) + cross-entropy-with-logits — avoids materializing the [N, vocab]
         // logits on the tape for huge-vocab heads.
-        "FusedLinearCrossEntropy",
+        "FusedLinearCrossEntropyWithLogits",
 
         // Signal
         "RFFT", "IRFFT",

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.FusedLinearCrossEntropy.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.FusedLinearCrossEntropy.cs
@@ -1,0 +1,264 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.Interfaces;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines;
+
+public partial class CpuEngine
+{
+    /// <summary>
+    /// Fused linear (LM head) + cross-entropy-with-logits loss in a SINGLE op
+    /// (forward scalar loss + custom autodiff backward), for the paper-scale LM head where the
+    /// vocabulary is huge (issue ooples/AiDotNet#1464). Computes
+    /// <c>logits = hidden·weight + bias</c> (<c>weight</c> is [d, vocab], matching DenseLayer's
+    /// [inputSize, outputSize] layout), then the mean cross-entropy
+    /// <c>L = -mean_r sum_v target[r,v]·log_softmax(logits_r)[v]</c>, and returns the scalar loss.
+    ///
+    /// <para>The win vs. the decomposed path (DenseLayer producing a [N, vocab] tape tensor, then the
+    /// loss running log-softmax + multiply + reduce as separate tape ops): the full [N, vocab] logits
+    /// are NEVER materialized on the autodiff tape, and the multiple full-vocab loss passes collapse
+    /// into the single fused op. The (inherent) head GEMMs are still run on the fast parallel managed
+    /// kernel — here via TensorMatMul inside a no-grad scope, so they execute without recording. The
+    /// backward computes <c>dlogits = (softmax(logits) - target)/N</c> and then
+    /// <c>dHidden = dlogits·weightᵀ</c>, <c>dWeight = hiddenᵀ·dlogits</c>, <c>dBias = sum_r dlogits</c>.</para>
+    /// </summary>
+    /// <param name="hidden">Pre-head hidden states [N, d] (N = batch·seq).</param>
+    /// <param name="weight">LM head weight [d, vocab] (DenseLayer [inputSize, outputSize]).</param>
+    /// <param name="bias">LM head bias [vocab].</param>
+    /// <param name="target">Per-row categorical target distribution / one-hot [N, vocab].</param>
+    /// <returns>Scalar (rank-0) mean cross-entropy loss.</returns>
+    public virtual Tensor<T> FusedLinearCrossEntropyWithLogits<T>(
+        Tensor<T> hidden, Tensor<T> weight, Tensor<T> bias, Tensor<T> target)
+    {
+        if (hidden is null) throw new ArgumentNullException(nameof(hidden));
+        if (weight is null) throw new ArgumentNullException(nameof(weight));
+        if (bias is null) throw new ArgumentNullException(nameof(bias));
+        if (target is null) throw new ArgumentNullException(nameof(target));
+        if (hidden.Rank != 2)
+            throw new ArgumentException($"hidden must be rank-2 [N, d]; got rank {hidden.Rank}.", nameof(hidden));
+        if (weight.Rank != 2)
+            throw new ArgumentException($"weight must be rank-2 [d, vocab]; got rank {weight.Rank}.", nameof(weight));
+
+        int n = hidden.Shape[0];
+        int d = hidden.Shape[1];
+        int vocab = weight.Shape[1];
+        if (weight.Shape[0] != d)
+            throw new ArgumentException($"weight dim0 ({weight.Shape[0]}) must equal hidden dim1 ({d}).", nameof(weight));
+        if (bias.Length != vocab)
+            throw new ArgumentException($"bias length ({bias.Length}) must equal vocab ({vocab}).", nameof(bias));
+        if (target.Shape[target.Rank - 1] != vocab || target.Length != (long)n * vocab)
+            throw new ArgumentException($"target must be [N={n}, vocab={vocab}].", nameof(target));
+
+        // logits = hidden·weight + bias, computed via the fast parallel GEMM but NOT recorded
+        // (this op records its own single tape node). The logits tensor is transient — it never
+        // enters the tape, so the big [N, vocab] allocation is freed after the forward.
+        Tensor<T> logits;
+        using (new NoGradScope<T>())
+        {
+            logits = TensorMatMul(hidden, weight);              // [N, vocab]
+            AddBiasRows(logits, bias, n, vocab);
+        }
+
+        double lossValue;
+        if (typeof(T) == typeof(double))
+        {
+            lossValue = FusedCeLossDouble(
+                (double[])(object)logits.GetDataArray()!, (double[])(object)target.GetDataArray()!, n, vocab);
+        }
+        else
+        {
+            lossValue = FusedCeLossGeneric<T>(logits.GetDataArray()!, target.GetDataArray()!, n, vocab);
+        }
+
+        var output = new Tensor<T>(new[] { 1 }); // scalar loss (length-1)
+        output.GetDataArray()![0] = MathHelper.GetNumericOperations<T>().FromDouble(lossValue);
+
+        DifferentiableOps.RecordIfActive<T>(
+            "FusedLinearCrossEntropy", output,
+            new[] { hidden, weight, bias, target },
+            FusedLinearCrossEntropyBackward<T>,
+            savedState: null);
+
+        return output;
+    }
+
+    private static void AddBiasRows<T>(Tensor<T> logits, Tensor<T> bias, int n, int vocab)
+    {
+        var lo = logits.GetDataArray()!;
+        var bi = bias.GetDataArray()!;
+        if (typeof(T) == typeof(double))
+        {
+            var l = (double[])(object)lo; var b = (double[])(object)bi;
+            for (int r = 0; r < n; r++)
+            {
+                int off = r * vocab;
+                for (int v = 0; v < vocab; v++) l[off + v] += b[v];
+            }
+        }
+        else
+        {
+            var ops = MathHelper.GetNumericOperations<T>();
+            for (int r = 0; r < n; r++)
+            {
+                int off = r * vocab;
+                for (int v = 0; v < vocab; v++) lo[off + v] = ops.Add(lo[off + v], bi[v]);
+            }
+        }
+    }
+
+    // Mean CE = -(1/N) Σ_r Σ_v target[r,v]·(logit[r,v] - logSumExp_r). Numerically stable.
+    private static double FusedCeLossDouble(double[] logits, double[] target, int n, int vocab)
+    {
+        double total = 0.0;
+        for (int r = 0; r < n; r++)
+        {
+            int off = r * vocab;
+            double max = logits[off];
+            for (int v = 1; v < vocab; v++) if (logits[off + v] > max) max = logits[off + v];
+            double sumExp = 0.0;
+            for (int v = 0; v < vocab; v++) sumExp += Math.Exp(logits[off + v] - max);
+            double lse = max + Math.Log(sumExp);
+            double rowLoss = 0.0;
+            for (int v = 0; v < vocab; v++) rowLoss += target[off + v] * (logits[off + v] - lse);
+            total += rowLoss;
+        }
+        return -total / n;
+    }
+
+    private static double FusedCeLossGeneric<T>(T[] logits, T[] target, int n, int vocab)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        double total = 0.0;
+        for (int r = 0; r < n; r++)
+        {
+            int off = r * vocab;
+            double max = ops.ToDouble(logits[off]);
+            for (int v = 1; v < vocab; v++) { double lv = ops.ToDouble(logits[off + v]); if (lv > max) max = lv; }
+            double sumExp = 0.0;
+            for (int v = 0; v < vocab; v++) sumExp += Math.Exp(ops.ToDouble(logits[off + v]) - max);
+            double lse = max + Math.Log(sumExp);
+            double rowLoss = 0.0;
+            for (int v = 0; v < vocab; v++) rowLoss += ops.ToDouble(target[off + v]) * (ops.ToDouble(logits[off + v]) - lse);
+            total += rowLoss;
+        }
+        return -total / n;
+    }
+
+    private static void FusedLinearCrossEntropyBackward<T>(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output, object[] savedState,
+        IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        var hidden = inputs[0];
+        var weight = inputs[1];
+        var bias = inputs[2];
+        var target = inputs[3];
+
+        int n = hidden.Shape[0];
+        int d = hidden.Shape[1];
+        int vocab = weight.Shape[1];
+
+        // Upstream scalar grad (∂L_outer/∂loss). dlogits = g·(softmax(logits) - target)/N.
+        var ops = MathHelper.GetNumericOperations<T>();
+        double g = ops.ToDouble(gradOutput.GetDataArray()![0]);
+
+        // Recompute logits → softmax → dlogits, all off-tape.
+        var dLogits = new Tensor<T>(new[] { n, vocab });
+        using (new NoGradScope<T>())
+        {
+            var logits = engine.TensorMatMul(hidden, weight);
+            AddBiasRows(logits, bias, n, vocab);
+            if (typeof(T) == typeof(double))
+            {
+                SoftmaxMinusTargetDouble(
+                    (double[])(object)logits.GetDataArray()!, (double[])(object)target.GetDataArray()!,
+                    (double[])(object)dLogits.GetDataArray()!, n, vocab, g);
+            }
+            else
+            {
+                SoftmaxMinusTargetGeneric<T>(
+                    logits.GetDataArray()!, target.GetDataArray()!, dLogits.GetDataArray()!, n, vocab, g);
+            }
+
+            // dHidden = dLogits·weightᵀ  [N,d]  (weight is [d,vocab] → weightᵀ [vocab,d]).
+            var dHidden = engine.TensorMatMulTransposed(dLogits, weight);
+            // dWeight = hiddenᵀ·dLogits  [d,vocab]  (hiddenᵀ is [d,N], tiny — d,N small).
+            var dWeight = engine.TensorMatMul(engine.TensorTranspose(hidden), dLogits);
+            var dBias = ColumnSums(dLogits, n, vocab);
+
+            DifferentiableOps.AccumulateGrad(grads, hidden, dHidden, engine);
+            DifferentiableOps.AccumulateGrad(grads, weight, dWeight, engine);
+            DifferentiableOps.AccumulateGrad(grads, bias, dBias, engine);
+            // target is supervision — no gradient flows to it.
+        }
+    }
+
+    private static void SoftmaxMinusTargetDouble(
+        double[] logits, double[] target, double[] dLogits, int n, int vocab, double g)
+    {
+        double scale = g / n;
+        for (int r = 0; r < n; r++)
+        {
+            int off = r * vocab;
+            double max = logits[off];
+            for (int v = 1; v < vocab; v++) if (logits[off + v] > max) max = logits[off + v];
+            double sumExp = 0.0;
+            for (int v = 0; v < vocab; v++) sumExp += Math.Exp(logits[off + v] - max);
+            double inv = 1.0 / sumExp;
+            for (int v = 0; v < vocab; v++)
+            {
+                double sm = Math.Exp(logits[off + v] - max) * inv;
+                dLogits[off + v] = (sm - target[off + v]) * scale;
+            }
+        }
+    }
+
+    private static void SoftmaxMinusTargetGeneric<T>(
+        T[] logits, T[] target, T[] dLogits, int n, int vocab, double g)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        double scale = g / n;
+        for (int r = 0; r < n; r++)
+        {
+            int off = r * vocab;
+            double max = ops.ToDouble(logits[off]);
+            for (int v = 1; v < vocab; v++) { double lv = ops.ToDouble(logits[off + v]); if (lv > max) max = lv; }
+            double sumExp = 0.0;
+            for (int v = 0; v < vocab; v++) sumExp += Math.Exp(ops.ToDouble(logits[off + v]) - max);
+            double inv = 1.0 / sumExp;
+            for (int v = 0; v < vocab; v++)
+            {
+                double sm = Math.Exp(ops.ToDouble(logits[off + v]) - max) * inv;
+                dLogits[off + v] = ops.FromDouble((sm - ops.ToDouble(target[off + v])) * scale);
+            }
+        }
+    }
+
+    private static Tensor<T> ColumnSums<T>(Tensor<T> dLogits, int n, int vocab)
+    {
+        var result = new Tensor<T>(new[] { vocab });
+        var dl = dLogits.GetDataArray()!;
+        var res = result.GetDataArray()!;
+        if (typeof(T) == typeof(double))
+        {
+            var d = (double[])(object)dl; var rr = (double[])(object)res;
+            for (int r = 0; r < n; r++)
+            {
+                int off = r * vocab;
+                for (int v = 0; v < vocab; v++) rr[v] += d[off + v];
+            }
+        }
+        else
+        {
+            var ops = MathHelper.GetNumericOperations<T>();
+            for (int r = 0; r < n; r++)
+            {
+                int off = r * vocab;
+                for (int v = 0; v < vocab; v++) res[v] = ops.Add(res[v], dl[off + v]);
+            }
+        }
+        return result;
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.FusedLinearCrossEntropy.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.FusedLinearCrossEntropy.cs
@@ -51,8 +51,11 @@ public partial class CpuEngine
             throw new ArgumentException($"weight must have a non-empty vocab (dim1 > 0); got vocab={vocab}.", nameof(weight));
         if (weight.Shape[0] != d)
             throw new ArgumentException($"weight dim0 ({weight.Shape[0]}) must equal hidden dim1 ({d}).", nameof(weight));
-        if (bias.Length != vocab)
-            throw new ArgumentException($"bias length ({bias.Length}) must equal vocab ({vocab}).", nameof(bias));
+        // Require rank-1 [vocab]: the backward returns a rank-1 [vocab] bias gradient, so a
+        // higher-rank bias with the same flat length (e.g. [1, vocab]) would record a tape entry
+        // whose gradient shape does not match the input.
+        if (bias.Rank != 1 || bias.Length != vocab)
+            throw new ArgumentException($"bias must be rank-1 [vocab={vocab}].", nameof(bias));
         if (targetIds.Rank != 1 || targetIds.Length != n)
             throw new ArgumentException($"targetIds must be rank-1 [N={n}].", nameof(targetIds));
 
@@ -78,12 +81,14 @@ public partial class CpuEngine
         output.GetDataArray()![0] = MathHelper.GetNumericOperations<T>().FromDouble(lossValue);
 
         // target ids are supervision (no gradient): carry them in savedState rather than as a
-        // differentiable tape input. Backward reconstructs dlogits = softmax - onehot(id).
+        // differentiable tape input. Save a COPY so the backward is tied to the forward's labels —
+        // targetIds is not a tape input, so mutating/recycling it after forward must not change the
+        // gradient. Backward reconstructs dlogits = softmax - onehot(id).
         DifferentiableOps.RecordIfActive<T>(
             "FusedLinearCrossEntropy", output,
             new[] { hidden, weight, bias },
             FusedLinearCrossEntropyIndexBackward<T>,
-            savedState: new object[] { ids, vocab });
+            savedState: new object[] { (int[])ids.Clone(), vocab });
 
         return output;
     }
@@ -119,8 +124,11 @@ public partial class CpuEngine
             throw new ArgumentException($"weight must have a non-empty vocab (dim1 > 0); got vocab={vocab}.", nameof(weight));
         if (weight.Shape[0] != d)
             throw new ArgumentException($"weight dim0 ({weight.Shape[0]}) must equal hidden dim1 ({d}).", nameof(weight));
-        if (bias.Length != vocab)
-            throw new ArgumentException($"bias length ({bias.Length}) must equal vocab ({vocab}).", nameof(bias));
+        // Require rank-1 [vocab]: the backward returns a rank-1 [vocab] bias gradient, so a
+        // higher-rank bias with the same flat length (e.g. [1, vocab]) would record a tape entry
+        // whose gradient shape does not match the input.
+        if (bias.Rank != 1 || bias.Length != vocab)
+            throw new ArgumentException($"bias must be rank-1 [vocab={vocab}].", nameof(bias));
         // Check rank before indexing Shape[Rank-1] (a rank-0 target would otherwise throw
         // IndexOutOfRangeException instead of this clear argument error).
         if (target.Rank != 2 || target.Shape[0] != n || target.Shape[1] != vocab)

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.FusedLinearCrossEntropy.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.FusedLinearCrossEntropy.cs
@@ -28,6 +28,70 @@ public partial class CpuEngine
     /// <param name="hidden">Pre-head hidden states [N, d] (N = batch·seq).</param>
     /// <param name="weight">LM head weight [d, vocab] (DenseLayer [inputSize, outputSize]).</param>
     /// <param name="bias">LM head bias [vocab].</param>
+    /// <param name="targetIds">Per-row class id [N], each in [0, vocab).</param>
+    /// <returns>Scalar (length-1) mean cross-entropy loss.</returns>
+    public virtual Tensor<T> FusedLinearCrossEntropyWithLogits<T>(
+        Tensor<T> hidden, Tensor<T> weight, Tensor<T> bias, Tensor<int> targetIds)
+    {
+        if (hidden is null) throw new ArgumentNullException(nameof(hidden));
+        if (weight is null) throw new ArgumentNullException(nameof(weight));
+        if (bias is null) throw new ArgumentNullException(nameof(bias));
+        if (targetIds is null) throw new ArgumentNullException(nameof(targetIds));
+        if (hidden.Rank != 2)
+            throw new ArgumentException($"hidden must be rank-2 [N, d]; got rank {hidden.Rank}.", nameof(hidden));
+        if (weight.Rank != 2)
+            throw new ArgumentException($"weight must be rank-2 [d, vocab]; got rank {weight.Rank}.", nameof(weight));
+
+        int n = hidden.Shape[0];
+        int d = hidden.Shape[1];
+        int vocab = weight.Shape[1];
+        if (weight.Shape[0] != d)
+            throw new ArgumentException($"weight dim0 ({weight.Shape[0]}) must equal hidden dim1 ({d}).", nameof(weight));
+        if (bias.Length != vocab)
+            throw new ArgumentException($"bias length ({bias.Length}) must equal vocab ({vocab}).", nameof(bias));
+        if (targetIds.Rank != 1 || targetIds.Length != n)
+            throw new ArgumentException($"targetIds must be [N={n}].", nameof(targetIds));
+
+        var ids = (int[])(object)targetIds.GetDataArray()!;
+        for (int r = 0; r < n; r++)
+            if (ids[r] < 0 || ids[r] >= vocab)
+                throw new ArgumentOutOfRangeException(nameof(targetIds),
+                    $"targetIds[{r}] ({ids[r]}) must be in [0, vocab={vocab}).");
+
+        // logits = hidden·weight + bias, computed off-tape (this op records its own node).
+        Tensor<T> logits;
+        using (new NoGradScope<T>())
+        {
+            logits = TensorMatMul(hidden, weight);
+            AddBiasRows(logits, bias, n, vocab);
+        }
+
+        double lossValue = typeof(T) == typeof(double)
+            ? FusedCeLossIndexDouble((double[])(object)logits.GetDataArray()!, ids, n, vocab)
+            : FusedCeLossIndexGeneric<T>(logits.GetDataArray()!, ids, n, vocab);
+
+        var output = new Tensor<T>(new[] { 1 }); // scalar loss (length-1)
+        output.GetDataArray()![0] = MathHelper.GetNumericOperations<T>().FromDouble(lossValue);
+
+        // target ids are supervision (no gradient): carry them in savedState rather than as a
+        // differentiable tape input. Backward reconstructs dlogits = softmax - onehot(id).
+        DifferentiableOps.RecordIfActive<T>(
+            "FusedLinearCrossEntropy", output,
+            new[] { hidden, weight, bias },
+            FusedLinearCrossEntropyIndexBackward<T>,
+            savedState: new object[] { ids, vocab });
+
+        return output;
+    }
+
+    /// <summary>
+    /// Dense-target overload: <paramref name="target"/> is a full per-row distribution / one-hot
+    /// [N, vocab] for soft / distillation supervision. Prefer the int-id overload for standard LM
+    /// training to avoid the O(N·vocab) dense label storage/bandwidth.
+    /// </summary>
+    /// <param name="hidden">Pre-head hidden states [N, d] (N = batch·seq).</param>
+    /// <param name="weight">LM head weight [d, vocab] (DenseLayer [inputSize, outputSize]).</param>
+    /// <param name="bias">LM head bias [vocab].</param>
     /// <param name="target">Per-row categorical target distribution / one-hot [N, vocab].</param>
     /// <returns>Scalar (rank-0) mean cross-entropy loss.</returns>
     public virtual Tensor<T> FusedLinearCrossEntropyWithLogits<T>(
@@ -145,6 +209,125 @@ public partial class CpuEngine
             total += rowLoss;
         }
         return -total / n;
+    }
+
+    // Index-target mean CE = -(1/N) Σ_r (logit[r, id_r] - logSumExp_r). Numerically stable.
+    private static double FusedCeLossIndexDouble(double[] logits, int[] ids, int n, int vocab)
+    {
+        double total = 0.0;
+        for (int r = 0; r < n; r++)
+        {
+            int off = r * vocab;
+            double max = logits[off];
+            for (int v = 1; v < vocab; v++) if (logits[off + v] > max) max = logits[off + v];
+            double sumExp = 0.0;
+            for (int v = 0; v < vocab; v++) sumExp += Math.Exp(logits[off + v] - max);
+            double lse = max + Math.Log(sumExp);
+            total += logits[off + ids[r]] - lse;
+        }
+        return -total / n;
+    }
+
+    private static double FusedCeLossIndexGeneric<T>(T[] logits, int[] ids, int n, int vocab)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        double total = 0.0;
+        for (int r = 0; r < n; r++)
+        {
+            int off = r * vocab;
+            double max = ops.ToDouble(logits[off]);
+            for (int v = 1; v < vocab; v++) { double lv = ops.ToDouble(logits[off + v]); if (lv > max) max = lv; }
+            double sumExp = 0.0;
+            for (int v = 0; v < vocab; v++) sumExp += Math.Exp(ops.ToDouble(logits[off + v]) - max);
+            double lse = max + Math.Log(sumExp);
+            total += ops.ToDouble(logits[off + ids[r]]) - lse;
+        }
+        return -total / n;
+    }
+
+    // Index-target backward. dlogits[r,v] = (softmax(logits)[r,v] - [v == id_r]) · g/N.
+    private static void FusedLinearCrossEntropyIndexBackward<T>(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output, object[] savedState,
+        IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        var hidden = inputs[0];
+        var weight = inputs[1];
+        var bias = inputs[2];
+        var ids = (int[])savedState[0];
+        int vocab = (int)savedState[1];
+
+        int n = hidden.Shape[0];
+        var ops = MathHelper.GetNumericOperations<T>();
+        double g = ops.ToDouble(gradOutput.GetDataArray()![0]);
+
+        var dLogits = new Tensor<T>(new[] { n, vocab });
+        using (new NoGradScope<T>())
+        {
+            var logits = engine.TensorMatMul(hidden, weight);
+            AddBiasRows(logits, bias, n, vocab);
+            if (typeof(T) == typeof(double))
+            {
+                SoftmaxMinusIndexDouble(
+                    (double[])(object)logits.GetDataArray()!, ids,
+                    (double[])(object)dLogits.GetDataArray()!, n, vocab, g);
+            }
+            else
+            {
+                SoftmaxMinusIndexGeneric<T>(logits.GetDataArray()!, ids, dLogits.GetDataArray()!, n, vocab, g);
+            }
+
+            var dHidden = engine.TensorMatMulTransposed(dLogits, weight);
+            var dWeight = engine.TensorMatMul(engine.TensorTranspose(hidden), dLogits);
+            var dBias = ColumnSums(dLogits, n, vocab);
+
+            DifferentiableOps.AccumulateGrad(grads, hidden, dHidden, engine);
+            DifferentiableOps.AccumulateGrad(grads, weight, dWeight, engine);
+            DifferentiableOps.AccumulateGrad(grads, bias, dBias, engine);
+            // target ids are supervision — no gradient flows to them.
+        }
+    }
+
+    private static void SoftmaxMinusIndexDouble(
+        double[] logits, int[] ids, double[] dLogits, int n, int vocab, double g)
+    {
+        double scale = g / n;
+        for (int r = 0; r < n; r++)
+        {
+            int off = r * vocab;
+            double max = logits[off];
+            for (int v = 1; v < vocab; v++) if (logits[off + v] > max) max = logits[off + v];
+            double sumExp = 0.0;
+            for (int v = 0; v < vocab; v++) sumExp += Math.Exp(logits[off + v] - max);
+            double inv = 1.0 / sumExp;
+            int id = ids[r];
+            for (int v = 0; v < vocab; v++)
+            {
+                double sm = Math.Exp(logits[off + v] - max) * inv;
+                dLogits[off + v] = (sm - (v == id ? 1.0 : 0.0)) * scale;
+            }
+        }
+    }
+
+    private static void SoftmaxMinusIndexGeneric<T>(
+        T[] logits, int[] ids, T[] dLogits, int n, int vocab, double g)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        double scale = g / n;
+        for (int r = 0; r < n; r++)
+        {
+            int off = r * vocab;
+            double max = ops.ToDouble(logits[off]);
+            for (int v = 1; v < vocab; v++) { double lv = ops.ToDouble(logits[off + v]); if (lv > max) max = lv; }
+            double sumExp = 0.0;
+            for (int v = 0; v < vocab; v++) sumExp += Math.Exp(ops.ToDouble(logits[off + v]) - max);
+            double inv = 1.0 / sumExp;
+            int id = ids[r];
+            for (int v = 0; v < vocab; v++)
+            {
+                double sm = Math.Exp(ops.ToDouble(logits[off + v]) - max) * inv;
+                dLogits[off + v] = ops.FromDouble((sm - (v == id ? 1.0 : 0.0)) * scale);
+            }
+        }
     }
 
     private static void FusedLinearCrossEntropyBackward<T>(

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.FusedLinearCrossEntropy.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.FusedLinearCrossEntropy.cs
@@ -29,7 +29,7 @@ public partial class CpuEngine
     /// <param name="weight">LM head weight [d, vocab] (DenseLayer [inputSize, outputSize]).</param>
     /// <param name="bias">LM head bias [vocab].</param>
     /// <param name="targetIds">Per-row class id [N], each in [0, vocab).</param>
-    /// <returns>Scalar (length-1) mean cross-entropy loss.</returns>
+    /// <returns>Scalar (length-1, shape [1]) mean cross-entropy loss.</returns>
     public virtual Tensor<T> FusedLinearCrossEntropyWithLogits<T>(
         Tensor<T> hidden, Tensor<T> weight, Tensor<T> bias, Tensor<int> targetIds)
     {
@@ -45,12 +45,16 @@ public partial class CpuEngine
         int n = hidden.Shape[0];
         int d = hidden.Shape[1];
         int vocab = weight.Shape[1];
+        if (n <= 0)
+            throw new ArgumentException($"hidden must have a non-empty batch (N > 0); got N={n}.", nameof(hidden));
+        if (vocab <= 0)
+            throw new ArgumentException($"weight must have a non-empty vocab (dim1 > 0); got vocab={vocab}.", nameof(weight));
         if (weight.Shape[0] != d)
             throw new ArgumentException($"weight dim0 ({weight.Shape[0]}) must equal hidden dim1 ({d}).", nameof(weight));
         if (bias.Length != vocab)
             throw new ArgumentException($"bias length ({bias.Length}) must equal vocab ({vocab}).", nameof(bias));
         if (targetIds.Rank != 1 || targetIds.Length != n)
-            throw new ArgumentException($"targetIds must be [N={n}].", nameof(targetIds));
+            throw new ArgumentException($"targetIds must be rank-1 [N={n}].", nameof(targetIds));
 
         var ids = (int[])(object)targetIds.GetDataArray()!;
         for (int r = 0; r < n; r++)
@@ -93,7 +97,7 @@ public partial class CpuEngine
     /// <param name="weight">LM head weight [d, vocab] (DenseLayer [inputSize, outputSize]).</param>
     /// <param name="bias">LM head bias [vocab].</param>
     /// <param name="target">Per-row categorical target distribution / one-hot [N, vocab].</param>
-    /// <returns>Scalar (rank-0) mean cross-entropy loss.</returns>
+    /// <returns>Scalar (length-1, shape [1]) mean cross-entropy loss.</returns>
     public virtual Tensor<T> FusedLinearCrossEntropyWithLogits<T>(
         Tensor<T> hidden, Tensor<T> weight, Tensor<T> bias, Tensor<T> target)
     {
@@ -109,12 +113,18 @@ public partial class CpuEngine
         int n = hidden.Shape[0];
         int d = hidden.Shape[1];
         int vocab = weight.Shape[1];
+        if (n <= 0)
+            throw new ArgumentException($"hidden must have a non-empty batch (N > 0); got N={n}.", nameof(hidden));
+        if (vocab <= 0)
+            throw new ArgumentException($"weight must have a non-empty vocab (dim1 > 0); got vocab={vocab}.", nameof(weight));
         if (weight.Shape[0] != d)
             throw new ArgumentException($"weight dim0 ({weight.Shape[0]}) must equal hidden dim1 ({d}).", nameof(weight));
         if (bias.Length != vocab)
             throw new ArgumentException($"bias length ({bias.Length}) must equal vocab ({vocab}).", nameof(bias));
-        if (target.Shape[target.Rank - 1] != vocab || target.Length != (long)n * vocab)
-            throw new ArgumentException($"target must be [N={n}, vocab={vocab}].", nameof(target));
+        // Check rank before indexing Shape[Rank-1] (a rank-0 target would otherwise throw
+        // IndexOutOfRangeException instead of this clear argument error).
+        if (target.Rank != 2 || target.Shape[0] != n || target.Shape[1] != vocab)
+            throw new ArgumentException($"target must be rank-2 [N={n}, vocab={vocab}].", nameof(target));
 
         // logits = hidden·weight + bias, computed via the fast parallel GEMM but NOT recorded
         // (this op records its own single tape node). The logits tensor is transient — it never

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.GatedDeltaNetScan.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.GatedDeltaNetScan.cs
@@ -1,0 +1,472 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.Interfaces;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines;
+
+public partial class CpuEngine
+{
+    /// <summary>
+    /// Fused Gated DeltaNet (delta-rule) recurrence over a whole sequence in a SINGLE op
+    /// (forward + custom autodiff backward), replacing the per-element detached scalar loop the
+    /// decomposed <c>GatedDeltaNetLayer</c> ran — both slow AND detached from the autodiff tape
+    /// (issue ooples/AiDotNet#1464). Per head, with key scaling κ = 1/sqrt(headDim), scalar-per-head
+    /// gates α_t (forget) and β_t (write), matrix state S[di,ki] = 0:
+    /// <code>
+    ///   kS[ki] = κ * K_t[ki]
+    ///   sK[di] = sum_ki S_{t-1}[di,ki] * kS[ki]          (current readout for the key)
+    ///   delta[di] = V_t[di] - sK[di]                      (delta-rule correction)
+    ///   S_t[di,ki] = α_t * S_{t-1}[di,ki] + β_t * delta[di] * kS[ki]
+    ///   O_t[di] = sum_ki S_t[di,ki] * Q_t[ki]
+    /// </code>
+    /// Records one tape node whose backward is the exact BPTT adjoint, so it is differentiable under an
+    /// active <c>GradientTape</c>.
+    /// </summary>
+    /// <param name="qProj">Query projection [batch, seqLen, modelDim].</param>
+    /// <param name="kProj">Key projection [batch, seqLen, modelDim] (scaled by 1/sqrt(headDim) internally).</param>
+    /// <param name="vProj">Value projection [batch, seqLen, modelDim].</param>
+    /// <param name="alpha">Forget gate [batch, seqLen, numHeads] (scalar per head).</param>
+    /// <param name="beta">Write gate [batch, seqLen, numHeads] (scalar per head).</param>
+    /// <param name="numHeads">Number of heads; modelDim must be divisible by it.</param>
+    /// <returns>The delta-rule output [batch, seqLen, modelDim].</returns>
+    public virtual Tensor<T> GatedDeltaNetScanForward<T>(
+        Tensor<T> qProj, Tensor<T> kProj, Tensor<T> vProj, Tensor<T> alpha, Tensor<T> beta, int numHeads)
+    {
+        if (qProj is null) throw new ArgumentNullException(nameof(qProj));
+        if (kProj is null) throw new ArgumentNullException(nameof(kProj));
+        if (vProj is null) throw new ArgumentNullException(nameof(vProj));
+        if (alpha is null) throw new ArgumentNullException(nameof(alpha));
+        if (beta is null) throw new ArgumentNullException(nameof(beta));
+        if (numHeads < 1) throw new ArgumentOutOfRangeException(nameof(numHeads));
+        if (qProj.Rank != 3)
+            throw new ArgumentException($"GatedDeltaNetScanForward expects rank-3 q/k/v [batch, seqLen, modelDim]; got rank {qProj.Rank}.", nameof(qProj));
+
+        int batch = qProj.Shape[0];
+        int seqLen = qProj.Shape[1];
+        int modelDim = qProj.Shape[2];
+        if (modelDim % numHeads != 0)
+            throw new ArgumentException($"modelDim ({modelDim}) must be divisible by numHeads ({numHeads}).", nameof(numHeads));
+        int headDim = modelDim / numHeads;
+        EnsureSameShape(qProj, kProj, nameof(kProj));
+        EnsureSameShape(qProj, vProj, nameof(vProj));
+        if (alpha.Rank != 3 || alpha.Shape[0] != batch || alpha.Shape[1] != seqLen || alpha.Shape[2] != numHeads)
+            throw new ArgumentException($"alpha must be [batch={batch}, seqLen={seqLen}, numHeads={numHeads}].", nameof(alpha));
+        if (beta.Rank != 3 || beta.Shape[0] != batch || beta.Shape[1] != seqLen || beta.Shape[2] != numHeads)
+            throw new ArgumentException($"beta must be [batch={batch}, seqLen={seqLen}, numHeads={numHeads}].", nameof(beta));
+
+        var output = new Tensor<T>(new[] { batch, seqLen, modelDim });
+
+        if (typeof(T) == typeof(double))
+        {
+            GatedDeltaForwardDouble(
+                (double[])(object)qProj.GetDataArray()!, (double[])(object)kProj.GetDataArray()!,
+                (double[])(object)vProj.GetDataArray()!, (double[])(object)alpha.GetDataArray()!,
+                (double[])(object)beta.GetDataArray()!, (double[])(object)output.GetDataArray()!,
+                batch, seqLen, modelDim, numHeads, headDim);
+        }
+        else
+        {
+            GatedDeltaForwardGeneric<T>(
+                qProj.GetDataArray()!, kProj.GetDataArray()!, vProj.GetDataArray()!,
+                alpha.GetDataArray()!, beta.GetDataArray()!, output.GetDataArray()!,
+                batch, seqLen, modelDim, numHeads, headDim);
+        }
+
+        DifferentiableOps.RecordIfActive<T>(
+            "GatedDeltaNetScan", output,
+            new[] { qProj, kProj, vProj, alpha, beta },
+            GatedDeltaNetScanBackward<T>,
+            savedState: new object[] { numHeads });
+
+        return output;
+    }
+
+    // ── Double fast path ─────────────────────────────────────────────────────────────────
+    private static void GatedDeltaForwardDouble(
+        double[] Q, double[] K, double[] V, double[] A, double[] B, double[] outp,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        int hh = headDim * headDim;
+        double kappa = 1.0 / Math.Sqrt(headDim);
+        var S = new double[hh];
+        var kS = new double[headDim];
+        var sK = new double[headDim];
+        for (int b = 0; b < batch; b++)
+        {
+            for (int h = 0; h < numHeads; h++)
+            {
+                Array.Clear(S, 0, hh);
+                int hOff = h * headDim;
+                for (int t = 0; t < seqLen; t++)
+                {
+                    int baseOff = (b * seqLen + t) * modelDim + hOff;
+                    int gIdx = (b * seqLen + t) * numHeads + h;
+                    double a = A[gIdx], bet = B[gIdx];
+                    for (int ki = 0; ki < headDim; ki++) kS[ki] = K[baseOff + ki] * kappa;
+
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int srow = di * headDim;
+                        double s = 0.0;
+                        for (int ki = 0; ki < headDim; ki++) s += S[srow + ki] * kS[ki];
+                        sK[di] = s;
+                    }
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int srow = di * headDim;
+                        double delta = V[baseOff + di] - sK[di];
+                        double bd = bet * delta;
+                        for (int ki = 0; ki < headDim; ki++)
+                            S[srow + ki] = a * S[srow + ki] + bd * kS[ki];
+                    }
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int srow = di * headDim;
+                        double o = 0.0;
+                        for (int ki = 0; ki < headDim; ki++) o += S[srow + ki] * Q[baseOff + ki];
+                        outp[baseOff + di] = o;
+                    }
+                }
+            }
+        }
+    }
+
+    private static void GatedDeltaBackwardDouble(
+        double[] dOut, double[] Q, double[] K, double[] V, double[] A, double[] B,
+        double[] dQ, double[] dK, double[] dV, double[] dA, double[] dB,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        int hh = headDim * headDim;
+        double kappa = 1.0 / Math.Sqrt(headDim);
+        var Straj = new double[(seqLen + 1) * hh]; // pre-update state at index t = state entering step t
+        var S = new double[hh];
+        var dS = new double[hh];
+        var dSp = new double[hh];
+        var kS = new double[headDim];
+        var sK = new double[headDim];
+        var dKS = new double[headDim];
+        var dDelta = new double[headDim];
+
+        for (int b = 0; b < batch; b++)
+        {
+            for (int h = 0; h < numHeads; h++)
+            {
+                int hOff = h * headDim;
+
+                // Forward recompute, saving the PRE-update state entering each step (index t).
+                Array.Clear(S, 0, hh);
+                for (int t = 0; t < seqLen; t++)
+                {
+                    Array.Copy(S, 0, Straj, t * hh, hh);
+                    int baseOff = (b * seqLen + t) * modelDim + hOff;
+                    int gIdx = (b * seqLen + t) * numHeads + h;
+                    double a = A[gIdx], bet = B[gIdx];
+                    for (int ki = 0; ki < headDim; ki++) kS[ki] = K[baseOff + ki] * kappa;
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int srow = di * headDim;
+                        double s = 0.0;
+                        for (int ki = 0; ki < headDim; ki++) s += S[srow + ki] * kS[ki];
+                        double delta = V[baseOff + di] - s;
+                        double bd = bet * delta;
+                        for (int ki = 0; ki < headDim; ki++)
+                            S[srow + ki] = a * S[srow + ki] + bd * kS[ki];
+                    }
+                }
+
+                // Reverse sweep. dS = adjoint of the POST-update state S_t.
+                Array.Clear(dS, 0, hh);
+                for (int t = seqLen - 1; t >= 0; t--)
+                {
+                    int baseOff = (b * seqLen + t) * modelDim + hOff;
+                    int gIdx = (b * seqLen + t) * numHeads + h;
+                    double a = A[gIdx], bet = B[gIdx];
+                    var Sp = Straj; int spOff = t * hh; // pre-update state S_{t-1}
+
+                    for (int ki = 0; ki < headDim; ki++) kS[ki] = K[baseOff + ki] * kappa;
+                    // Recompute sK and S_t (post-update) for this step.
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int srow = di * headDim;
+                        double s = 0.0;
+                        for (int ki = 0; ki < headDim; ki++) s += Sp[spOff + srow + ki] * kS[ki];
+                        sK[di] = s;
+                    }
+
+                    // Output backward: O[di] = sum_ki S_t[di,ki]*Q[ki]; S_t[di,ki] = a*Sp + bet*delta[di]*kS[ki].
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int srow = di * headDim;
+                        double dOutVal = dOut[baseOff + di];
+                        double delta = V[baseOff + di] - sK[di];
+                        double bd = bet * delta;
+                        for (int ki = 0; ki < headDim; ki++)
+                        {
+                            double sT = a * Sp[spOff + srow + ki] + bd * kS[ki];
+                            dQ[baseOff + ki] += dOutVal * sT;
+                            dS[srow + ki] += dOutVal * Q[baseOff + ki];
+                        }
+                    }
+
+                    // State-update backward.
+                    Array.Clear(dSp, 0, hh);
+                    Array.Clear(dKS, 0, headDim);
+                    Array.Clear(dDelta, 0, headDim);
+                    double dA_acc = 0.0, dB_acc = 0.0;
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int srow = di * headDim;
+                        double delta = V[baseOff + di] - sK[di];
+                        for (int ki = 0; ki < headDim; ki++)
+                        {
+                            double dSt = dS[srow + ki];
+                            dA_acc += dSt * Sp[spOff + srow + ki];
+                            dSp[srow + ki] += dSt * a;
+                            dB_acc += dSt * delta * kS[ki];
+                            dDelta[di] += dSt * bet * kS[ki];
+                            dKS[ki] += dSt * bet * delta;
+                        }
+                    }
+                    // delta[di] = V[di] - sK[di]; sK[di] = sum_kj Sp[di,kj]*kS[kj].
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int srow = di * headDim;
+                        dV[baseOff + di] += dDelta[di];
+                        double dSk = -dDelta[di];
+                        for (int kj = 0; kj < headDim; kj++)
+                        {
+                            dSp[srow + kj] += dSk * kS[kj];
+                            dKS[kj] += dSk * Sp[spOff + srow + kj];
+                        }
+                    }
+                    // kS[ki] = kappa * K[ki].
+                    for (int ki = 0; ki < headDim; ki++) dK[baseOff + ki] += dKS[ki] * kappa;
+
+                    dA[gIdx] += dA_acc;
+                    dB[gIdx] += dB_acc;
+
+                    // dSp is the adjoint of S_{t-1}; it becomes dS for step t-1.
+                    Array.Copy(dSp, 0, dS, 0, hh);
+                }
+            }
+        }
+    }
+
+    // ── Generic-T path ───────────────────────────────────────────────────────────────────
+    private static void GatedDeltaForwardGeneric<T>(
+        T[] Q, T[] K, T[] V, T[] A, T[] B, T[] outp,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        int hh = headDim * headDim;
+        T kappa = ops.FromDouble(1.0 / Math.Sqrt(headDim));
+        var S = new T[hh];
+        var kS = new T[headDim];
+        var sK = new T[headDim];
+        for (int b = 0; b < batch; b++)
+        {
+            for (int h = 0; h < numHeads; h++)
+            {
+                for (int i = 0; i < hh; i++) S[i] = ops.Zero;
+                int hOff = h * headDim;
+                for (int t = 0; t < seqLen; t++)
+                {
+                    int baseOff = (b * seqLen + t) * modelDim + hOff;
+                    int gIdx = (b * seqLen + t) * numHeads + h;
+                    T a = A[gIdx], bet = B[gIdx];
+                    for (int ki = 0; ki < headDim; ki++) kS[ki] = ops.Multiply(K[baseOff + ki], kappa);
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int srow = di * headDim;
+                        T s = ops.Zero;
+                        for (int ki = 0; ki < headDim; ki++) s = ops.Add(s, ops.Multiply(S[srow + ki], kS[ki]));
+                        sK[di] = s;
+                    }
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int srow = di * headDim;
+                        T delta = ops.Subtract(V[baseOff + di], sK[di]);
+                        T bd = ops.Multiply(bet, delta);
+                        for (int ki = 0; ki < headDim; ki++)
+                            S[srow + ki] = ops.Add(ops.Multiply(a, S[srow + ki]), ops.Multiply(bd, kS[ki]));
+                    }
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int srow = di * headDim;
+                        T o = ops.Zero;
+                        for (int ki = 0; ki < headDim; ki++) o = ops.Add(o, ops.Multiply(S[srow + ki], Q[baseOff + ki]));
+                        outp[baseOff + di] = o;
+                    }
+                }
+            }
+        }
+    }
+
+    private static void GatedDeltaBackwardGeneric<T>(
+        T[] dOut, T[] Q, T[] K, T[] V, T[] A, T[] B,
+        T[] dQ, T[] dK, T[] dV, T[] dA, T[] dB,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        int hh = headDim * headDim;
+        T kappa = ops.FromDouble(1.0 / Math.Sqrt(headDim));
+        var Straj = new T[(seqLen + 1) * hh];
+        var S = new T[hh];
+        var dS = new T[hh];
+        var dSp = new T[hh];
+        var kS = new T[headDim];
+        var sK = new T[headDim];
+        var dKS = new T[headDim];
+        var dDelta = new T[headDim];
+
+        for (int b = 0; b < batch; b++)
+        {
+            for (int h = 0; h < numHeads; h++)
+            {
+                int hOff = h * headDim;
+                for (int i = 0; i < hh; i++) S[i] = ops.Zero;
+                for (int t = 0; t < seqLen; t++)
+                {
+                    Array.Copy(S, 0, Straj, t * hh, hh);
+                    int baseOff = (b * seqLen + t) * modelDim + hOff;
+                    int gIdx = (b * seqLen + t) * numHeads + h;
+                    T a = A[gIdx], bet = B[gIdx];
+                    for (int ki = 0; ki < headDim; ki++) kS[ki] = ops.Multiply(K[baseOff + ki], kappa);
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int srow = di * headDim;
+                        T s = ops.Zero;
+                        for (int ki = 0; ki < headDim; ki++) s = ops.Add(s, ops.Multiply(S[srow + ki], kS[ki]));
+                        T delta = ops.Subtract(V[baseOff + di], s);
+                        T bd = ops.Multiply(bet, delta);
+                        for (int ki = 0; ki < headDim; ki++)
+                            S[srow + ki] = ops.Add(ops.Multiply(a, S[srow + ki]), ops.Multiply(bd, kS[ki]));
+                    }
+                }
+
+                for (int i = 0; i < hh; i++) dS[i] = ops.Zero;
+                for (int t = seqLen - 1; t >= 0; t--)
+                {
+                    int baseOff = (b * seqLen + t) * modelDim + hOff;
+                    int gIdx = (b * seqLen + t) * numHeads + h;
+                    T a = A[gIdx], bet = B[gIdx];
+                    int spOff = t * hh;
+
+                    for (int ki = 0; ki < headDim; ki++) kS[ki] = ops.Multiply(K[baseOff + ki], kappa);
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int srow = di * headDim;
+                        T s = ops.Zero;
+                        for (int ki = 0; ki < headDim; ki++) s = ops.Add(s, ops.Multiply(Straj[spOff + srow + ki], kS[ki]));
+                        sK[di] = s;
+                    }
+
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int srow = di * headDim;
+                        T dOutVal = dOut[baseOff + di];
+                        T delta = ops.Subtract(V[baseOff + di], sK[di]);
+                        T bd = ops.Multiply(bet, delta);
+                        for (int ki = 0; ki < headDim; ki++)
+                        {
+                            T sT = ops.Add(ops.Multiply(a, Straj[spOff + srow + ki]), ops.Multiply(bd, kS[ki]));
+                            dQ[baseOff + ki] = ops.Add(dQ[baseOff + ki], ops.Multiply(dOutVal, sT));
+                            dS[srow + ki] = ops.Add(dS[srow + ki], ops.Multiply(dOutVal, Q[baseOff + ki]));
+                        }
+                    }
+
+                    for (int i = 0; i < hh; i++) dSp[i] = ops.Zero;
+                    for (int ki = 0; ki < headDim; ki++) dKS[ki] = ops.Zero;
+                    for (int di = 0; di < headDim; di++) dDelta[di] = ops.Zero;
+                    T dA_acc = ops.Zero, dB_acc = ops.Zero;
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int srow = di * headDim;
+                        T delta = ops.Subtract(V[baseOff + di], sK[di]);
+                        for (int ki = 0; ki < headDim; ki++)
+                        {
+                            T dSt = dS[srow + ki];
+                            dA_acc = ops.Add(dA_acc, ops.Multiply(dSt, Straj[spOff + srow + ki]));
+                            dSp[srow + ki] = ops.Add(dSp[srow + ki], ops.Multiply(dSt, a));
+                            dB_acc = ops.Add(dB_acc, ops.Multiply(dSt, ops.Multiply(delta, kS[ki])));
+                            dDelta[di] = ops.Add(dDelta[di], ops.Multiply(dSt, ops.Multiply(bet, kS[ki])));
+                            dKS[ki] = ops.Add(dKS[ki], ops.Multiply(dSt, ops.Multiply(bet, delta)));
+                        }
+                    }
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int srow = di * headDim;
+                        dV[baseOff + di] = ops.Add(dV[baseOff + di], dDelta[di]);
+                        T dSk = ops.Negate(dDelta[di]);
+                        for (int kj = 0; kj < headDim; kj++)
+                        {
+                            dSp[srow + kj] = ops.Add(dSp[srow + kj], ops.Multiply(dSk, kS[kj]));
+                            dKS[kj] = ops.Add(dKS[kj], ops.Multiply(dSk, Straj[spOff + srow + kj]));
+                        }
+                    }
+                    for (int ki = 0; ki < headDim; ki++) dK[baseOff + ki] = ops.Add(dK[baseOff + ki], ops.Multiply(dKS[ki], kappa));
+
+                    dA[gIdx] = ops.Add(dA[gIdx], dA_acc);
+                    dB[gIdx] = ops.Add(dB[gIdx], dB_acc);
+
+                    Array.Copy(dSp, 0, dS, 0, hh);
+                }
+            }
+        }
+    }
+
+    private static void GatedDeltaNetScanBackward<T>(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output, object[] savedState,
+        IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        int numHeads = (int)savedState[0];
+        var qProj = inputs[0];
+        var kProj = inputs[1];
+        var vProj = inputs[2];
+        var alpha = inputs[3];
+        var beta = inputs[4];
+
+        int batch = qProj.Shape[0];
+        int seqLen = qProj.Shape[1];
+        int modelDim = qProj.Shape[2];
+        int headDim = modelDim / numHeads;
+
+        var dQ = new Tensor<T>(new[] { batch, seqLen, modelDim });
+        var dK = new Tensor<T>(new[] { batch, seqLen, modelDim });
+        var dV = new Tensor<T>(new[] { batch, seqLen, modelDim });
+        var dA = new Tensor<T>(new[] { batch, seqLen, numHeads });
+        var dB = new Tensor<T>(new[] { batch, seqLen, numHeads });
+
+        if (typeof(T) == typeof(double))
+        {
+            GatedDeltaBackwardDouble(
+                (double[])(object)gradOutput.GetDataArray()!,
+                (double[])(object)qProj.GetDataArray()!, (double[])(object)kProj.GetDataArray()!,
+                (double[])(object)vProj.GetDataArray()!, (double[])(object)alpha.GetDataArray()!,
+                (double[])(object)beta.GetDataArray()!,
+                (double[])(object)dQ.GetDataArray()!, (double[])(object)dK.GetDataArray()!,
+                (double[])(object)dV.GetDataArray()!, (double[])(object)dA.GetDataArray()!,
+                (double[])(object)dB.GetDataArray()!,
+                batch, seqLen, modelDim, numHeads, headDim);
+        }
+        else
+        {
+            GatedDeltaBackwardGeneric<T>(
+                gradOutput.GetDataArray()!,
+                qProj.GetDataArray()!, kProj.GetDataArray()!, vProj.GetDataArray()!,
+                alpha.GetDataArray()!, beta.GetDataArray()!,
+                dQ.GetDataArray()!, dK.GetDataArray()!, dV.GetDataArray()!,
+                dA.GetDataArray()!, dB.GetDataArray()!,
+                batch, seqLen, modelDim, numHeads, headDim);
+        }
+
+        DifferentiableOps.AccumulateGrad(grads, qProj, dQ, engine);
+        DifferentiableOps.AccumulateGrad(grads, kProj, dK, engine);
+        DifferentiableOps.AccumulateGrad(grads, vProj, dV, engine);
+        DifferentiableOps.AccumulateGrad(grads, alpha, dA, engine);
+        DifferentiableOps.AccumulateGrad(grads, beta, dB, engine);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.GlaScan.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.GlaScan.cs
@@ -22,13 +22,14 @@ public partial class CpuEngine
     ///   O_t[ki]    = sum_di Q_t[di] * S_t[di,ki]
     /// </code>
     /// Records one tape node whose backward is the exact BPTT adjoint, so it is differentiable under an
-    /// active <c>GradientTape</c>. Inputs are the already-projected q/k/v/gate streams; the gate is the
-    /// post-sigmoid value (the layer's sigmoid records its own tape node).
+    /// active <c>GradientTape</c>. Inputs are the already-projected q/k/v streams plus a
+    /// scalar-per-head gate; the gate is the post-sigmoid value (the layer's sigmoid records
+    /// its own tape node).
     /// </summary>
     /// <param name="qProj">Query projection [batch, seqLen, modelDim].</param>
     /// <param name="kProj">Key projection [batch, seqLen, modelDim].</param>
     /// <param name="vProj">Value projection [batch, seqLen, modelDim].</param>
-    /// <param name="gate">Post-sigmoid gate [batch, seqLen, modelDim]; only the per-head first element is used.</param>
+    /// <param name="gate">Post-sigmoid scalar-per-head gate [batch, seqLen, numHeads].</param>
     /// <param name="numHeads">Number of heads; modelDim must be divisible by it.</param>
     /// <returns>The attention output [batch, seqLen, modelDim].</returns>
     public virtual Tensor<T> GlaScanForward<T>(
@@ -50,7 +51,9 @@ public partial class CpuEngine
         int headDim = modelDim / numHeads;
         EnsureSameShape(qProj, kProj, nameof(kProj));
         EnsureSameShape(qProj, vProj, nameof(vProj));
-        EnsureSameShape(qProj, gate, nameof(gate));
+        // Gate is scalar-per-head: [batch, seqLen, numHeads], not the full modelDim.
+        if (gate.Rank != 3 || gate.Shape[0] != batch || gate.Shape[1] != seqLen || gate.Shape[2] != numHeads)
+            throw new ArgumentException($"gate must be [batch={batch}, seqLen={seqLen}, numHeads={numHeads}].", nameof(gate));
 
         var output = new Tensor<T>(new[] { batch, seqLen, modelDim });
 
@@ -93,7 +96,7 @@ public partial class CpuEngine
                 for (int t = 0; t < seqLen; t++)
                 {
                     int baseOff = (b * seqLen + t) * modelDim + hOff;
-                    double g = G[baseOff];
+                    double g = G[(b * seqLen + t) * numHeads + h];
                     for (int di = 0; di < headDim; di++)
                     {
                         double vv = V[baseOff + di];
@@ -134,7 +137,7 @@ public partial class CpuEngine
                 for (int t = 0; t < seqLen; t++)
                 {
                     int baseOff = (b * seqLen + t) * modelDim + hOff;
-                    double g = G[baseOff];
+                    double g = G[(b * seqLen + t) * numHeads + h];
                     for (int di = 0; di < headDim; di++)
                     {
                         double vv = V[baseOff + di];
@@ -150,9 +153,10 @@ public partial class CpuEngine
                 for (int t = seqLen - 1; t >= 0; t--)
                 {
                     int baseOff = (b * seqLen + t) * modelDim + hOff;
+                    int gOff = (b * seqLen + t) * numHeads + h;
                     int stOff = t * hh;
                     int sprevOff = (t - 1) * hh;
-                    double g = G[baseOff];
+                    double g = G[gOff];
 
                     // Output backward: O[ki] = sum_di Q[di]*S_t[di,ki].
                     for (int ki = 0; ki < headDim; ki++)
@@ -181,7 +185,7 @@ public partial class CpuEngine
                             dV[baseOff + di] += dStv * K[baseOff + ki];
                         }
                     }
-                    dG[baseOff] += dg; // scalar-per-head gate: only the head-start position
+                    dG[gOff] += dg; // scalar-per-head gate [batch, seqLen, numHeads]
 
                     // Propagate adjoint to the previous step: dS_{t-1} = g * dS_t.
                     for (int i = 0; i < hh; i++) dS[i] *= g;
@@ -207,7 +211,7 @@ public partial class CpuEngine
                 for (int t = 0; t < seqLen; t++)
                 {
                     int baseOff = (b * seqLen + t) * modelDim + hOff;
-                    T g = G[baseOff];
+                    T g = G[(b * seqLen + t) * numHeads + h];
                     for (int di = 0; di < headDim; di++)
                     {
                         T vv = V[baseOff + di];
@@ -247,7 +251,7 @@ public partial class CpuEngine
                 for (int t = 0; t < seqLen; t++)
                 {
                     int baseOff = (b * seqLen + t) * modelDim + hOff;
-                    T g = G[baseOff];
+                    T g = G[(b * seqLen + t) * numHeads + h];
                     for (int di = 0; di < headDim; di++)
                     {
                         T vv = V[baseOff + di];
@@ -262,9 +266,10 @@ public partial class CpuEngine
                 for (int t = seqLen - 1; t >= 0; t--)
                 {
                     int baseOff = (b * seqLen + t) * modelDim + hOff;
+                    int gOff = (b * seqLen + t) * numHeads + h;
                     int stOff = t * hh;
                     int sprevOff = (t - 1) * hh;
-                    T g = G[baseOff];
+                    T g = G[gOff];
 
                     for (int ki = 0; ki < headDim; ki++)
                     {
@@ -291,7 +296,7 @@ public partial class CpuEngine
                             dV[baseOff + di] = ops.Add(dV[baseOff + di], ops.Multiply(dStv, K[baseOff + ki]));
                         }
                     }
-                    dG[baseOff] = ops.Add(dG[baseOff], dg);
+                    dG[gOff] = ops.Add(dG[gOff], dg);
 
                     for (int i = 0; i < hh; i++) dS[i] = ops.Multiply(dS[i], g);
                 }
@@ -317,7 +322,7 @@ public partial class CpuEngine
         var dQ = new Tensor<T>(new[] { batch, seqLen, modelDim });
         var dK = new Tensor<T>(new[] { batch, seqLen, modelDim });
         var dV = new Tensor<T>(new[] { batch, seqLen, modelDim });
-        var dG = new Tensor<T>(new[] { batch, seqLen, modelDim });
+        var dG = new Tensor<T>(new[] { batch, seqLen, numHeads }); // scalar-per-head gate
 
         if (typeof(T) == typeof(double))
         {

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.GlaScan.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.GlaScan.cs
@@ -1,0 +1,346 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.Interfaces;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines;
+
+public partial class CpuEngine
+{
+    /// <summary>
+    /// Fused Gated Linear Attention (GLA) recurrence over a whole sequence in a SINGLE op
+    /// (forward + custom autodiff backward), replacing the per-element detached scalar loop the
+    /// decomposed <c>GatedLinearAttentionLayer</c> ran — which was both slow (per-element index-array
+    /// allocations) and DETACHED from the autodiff tape (so the q/k/v/gate weights received no gradient
+    /// through the recurrence; issue ooples/AiDotNet#1464). Per head (modelDim split into
+    /// <paramref name="numHeads"/> blocks of headDim, keyDim = headDim), with matrix state S[di,ki] = 0
+    /// and a scalar-per-head gate g_t = gate[..., headStart]:
+    /// <code>
+    ///   S_t[di,ki] = g_t * S_{t-1}[di,ki] + K_t[ki] * V_t[di]
+    ///   O_t[ki]    = sum_di Q_t[di] * S_t[di,ki]
+    /// </code>
+    /// Records one tape node whose backward is the exact BPTT adjoint, so it is differentiable under an
+    /// active <c>GradientTape</c>. Inputs are the already-projected q/k/v/gate streams; the gate is the
+    /// post-sigmoid value (the layer's sigmoid records its own tape node).
+    /// </summary>
+    /// <param name="qProj">Query projection [batch, seqLen, modelDim].</param>
+    /// <param name="kProj">Key projection [batch, seqLen, modelDim].</param>
+    /// <param name="vProj">Value projection [batch, seqLen, modelDim].</param>
+    /// <param name="gate">Post-sigmoid gate [batch, seqLen, modelDim]; only the per-head first element is used.</param>
+    /// <param name="numHeads">Number of heads; modelDim must be divisible by it.</param>
+    /// <returns>The attention output [batch, seqLen, modelDim].</returns>
+    public virtual Tensor<T> GlaScanForward<T>(
+        Tensor<T> qProj, Tensor<T> kProj, Tensor<T> vProj, Tensor<T> gate, int numHeads)
+    {
+        if (qProj is null) throw new ArgumentNullException(nameof(qProj));
+        if (kProj is null) throw new ArgumentNullException(nameof(kProj));
+        if (vProj is null) throw new ArgumentNullException(nameof(vProj));
+        if (gate is null) throw new ArgumentNullException(nameof(gate));
+        if (numHeads < 1) throw new ArgumentOutOfRangeException(nameof(numHeads));
+        if (qProj.Rank != 3)
+            throw new ArgumentException($"GlaScanForward expects rank-3 inputs [batch, seqLen, modelDim]; got rank {qProj.Rank}.", nameof(qProj));
+
+        int batch = qProj.Shape[0];
+        int seqLen = qProj.Shape[1];
+        int modelDim = qProj.Shape[2];
+        if (modelDim % numHeads != 0)
+            throw new ArgumentException($"modelDim ({modelDim}) must be divisible by numHeads ({numHeads}).", nameof(numHeads));
+        int headDim = modelDim / numHeads;
+        EnsureSameShape(qProj, kProj, nameof(kProj));
+        EnsureSameShape(qProj, vProj, nameof(vProj));
+        EnsureSameShape(qProj, gate, nameof(gate));
+
+        var output = new Tensor<T>(new[] { batch, seqLen, modelDim });
+
+        if (typeof(T) == typeof(double))
+        {
+            GlaForwardDouble(
+                (double[])(object)qProj.GetDataArray()!, (double[])(object)kProj.GetDataArray()!,
+                (double[])(object)vProj.GetDataArray()!, (double[])(object)gate.GetDataArray()!,
+                (double[])(object)output.GetDataArray()!, batch, seqLen, modelDim, numHeads, headDim);
+        }
+        else
+        {
+            GlaForwardGeneric<T>(
+                qProj.GetDataArray()!, kProj.GetDataArray()!, vProj.GetDataArray()!, gate.GetDataArray()!,
+                output.GetDataArray()!, batch, seqLen, modelDim, numHeads, headDim);
+        }
+
+        DifferentiableOps.RecordIfActive<T>(
+            "GlaScan", output,
+            new[] { qProj, kProj, vProj, gate },
+            GlaScanBackward<T>,
+            savedState: new object[] { numHeads });
+
+        return output;
+    }
+
+    // ── Double fast path ─────────────────────────────────────────────────────────────────
+    private static void GlaForwardDouble(
+        double[] Q, double[] K, double[] V, double[] G, double[] outp,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        int hh = headDim * headDim;
+        var S = new double[hh];
+        for (int b = 0; b < batch; b++)
+        {
+            for (int h = 0; h < numHeads; h++)
+            {
+                Array.Clear(S, 0, hh);
+                int hOff = h * headDim;
+                for (int t = 0; t < seqLen; t++)
+                {
+                    int baseOff = (b * seqLen + t) * modelDim + hOff;
+                    double g = G[baseOff];
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        double vv = V[baseOff + di];
+                        int srow = di * headDim;
+                        for (int ki = 0; ki < headDim; ki++)
+                            S[srow + ki] = g * S[srow + ki] + K[baseOff + ki] * vv;
+                    }
+                    for (int ki = 0; ki < headDim; ki++)
+                    {
+                        double o = 0.0;
+                        for (int di = 0; di < headDim; di++)
+                            o += Q[baseOff + di] * S[di * headDim + ki];
+                        outp[baseOff + ki] = o;
+                    }
+                }
+            }
+        }
+    }
+
+    private static void GlaBackwardDouble(
+        double[] dOut, double[] Q, double[] K, double[] V, double[] G,
+        double[] dQ, double[] dK, double[] dV, double[] dG,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        int hh = headDim * headDim;
+        var Straj = new double[seqLen * hh];
+        var S = new double[hh];
+        var dS = new double[hh];
+
+        for (int b = 0; b < batch; b++)
+        {
+            for (int h = 0; h < numHeads; h++)
+            {
+                int hOff = h * headDim;
+
+                // Forward recompute, saving the post-update state trajectory.
+                Array.Clear(S, 0, hh);
+                for (int t = 0; t < seqLen; t++)
+                {
+                    int baseOff = (b * seqLen + t) * modelDim + hOff;
+                    double g = G[baseOff];
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        double vv = V[baseOff + di];
+                        int srow = di * headDim;
+                        for (int ki = 0; ki < headDim; ki++)
+                            S[srow + ki] = g * S[srow + ki] + K[baseOff + ki] * vv;
+                    }
+                    Array.Copy(S, 0, Straj, t * hh, hh);
+                }
+
+                // Reverse sweep.
+                Array.Clear(dS, 0, hh);
+                for (int t = seqLen - 1; t >= 0; t--)
+                {
+                    int baseOff = (b * seqLen + t) * modelDim + hOff;
+                    int stOff = t * hh;
+                    int sprevOff = (t - 1) * hh;
+                    double g = G[baseOff];
+
+                    // Output backward: O[ki] = sum_di Q[di]*S_t[di,ki].
+                    for (int ki = 0; ki < headDim; ki++)
+                    {
+                        double dOutVal = dOut[baseOff + ki];
+                        for (int di = 0; di < headDim; di++)
+                        {
+                            double sval = Straj[stOff + di * headDim + ki];
+                            dQ[baseOff + di] += dOutVal * sval;
+                            dS[di * headDim + ki] += dOutVal * Q[baseOff + di];
+                        }
+                    }
+
+                    // State-update backward: S_t[di,ki] = g*S_{t-1}[di,ki] + K[ki]*V[di].
+                    double dg = 0.0;
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        double vv = V[baseOff + di];
+                        int srow = di * headDim;
+                        for (int ki = 0; ki < headDim; ki++)
+                        {
+                            double dStv = dS[srow + ki];
+                            double sprev = t > 0 ? Straj[sprevOff + srow + ki] : 0.0;
+                            dg += dStv * sprev;
+                            dK[baseOff + ki] += dStv * vv;
+                            dV[baseOff + di] += dStv * K[baseOff + ki];
+                        }
+                    }
+                    dG[baseOff] += dg; // scalar-per-head gate: only the head-start position
+
+                    // Propagate adjoint to the previous step: dS_{t-1} = g * dS_t.
+                    for (int i = 0; i < hh; i++) dS[i] *= g;
+                }
+            }
+        }
+    }
+
+    // ── Generic-T path ───────────────────────────────────────────────────────────────────
+    private static void GlaForwardGeneric<T>(
+        T[] Q, T[] K, T[] V, T[] G, T[] outp,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        int hh = headDim * headDim;
+        var S = new T[hh];
+        for (int b = 0; b < batch; b++)
+        {
+            for (int h = 0; h < numHeads; h++)
+            {
+                for (int i = 0; i < hh; i++) S[i] = ops.Zero;
+                int hOff = h * headDim;
+                for (int t = 0; t < seqLen; t++)
+                {
+                    int baseOff = (b * seqLen + t) * modelDim + hOff;
+                    T g = G[baseOff];
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        T vv = V[baseOff + di];
+                        int srow = di * headDim;
+                        for (int ki = 0; ki < headDim; ki++)
+                            S[srow + ki] = ops.Add(ops.Multiply(g, S[srow + ki]), ops.Multiply(K[baseOff + ki], vv));
+                    }
+                    for (int ki = 0; ki < headDim; ki++)
+                    {
+                        T o = ops.Zero;
+                        for (int di = 0; di < headDim; di++)
+                            o = ops.Add(o, ops.Multiply(Q[baseOff + di], S[di * headDim + ki]));
+                        outp[baseOff + ki] = o;
+                    }
+                }
+            }
+        }
+    }
+
+    private static void GlaBackwardGeneric<T>(
+        T[] dOut, T[] Q, T[] K, T[] V, T[] G,
+        T[] dQ, T[] dK, T[] dV, T[] dG,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        int hh = headDim * headDim;
+        var Straj = new T[seqLen * hh];
+        var S = new T[hh];
+        var dS = new T[hh];
+
+        for (int b = 0; b < batch; b++)
+        {
+            for (int h = 0; h < numHeads; h++)
+            {
+                int hOff = h * headDim;
+                for (int i = 0; i < hh; i++) S[i] = ops.Zero;
+                for (int t = 0; t < seqLen; t++)
+                {
+                    int baseOff = (b * seqLen + t) * modelDim + hOff;
+                    T g = G[baseOff];
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        T vv = V[baseOff + di];
+                        int srow = di * headDim;
+                        for (int ki = 0; ki < headDim; ki++)
+                            S[srow + ki] = ops.Add(ops.Multiply(g, S[srow + ki]), ops.Multiply(K[baseOff + ki], vv));
+                    }
+                    Array.Copy(S, 0, Straj, t * hh, hh);
+                }
+
+                for (int i = 0; i < hh; i++) dS[i] = ops.Zero;
+                for (int t = seqLen - 1; t >= 0; t--)
+                {
+                    int baseOff = (b * seqLen + t) * modelDim + hOff;
+                    int stOff = t * hh;
+                    int sprevOff = (t - 1) * hh;
+                    T g = G[baseOff];
+
+                    for (int ki = 0; ki < headDim; ki++)
+                    {
+                        T dOutVal = dOut[baseOff + ki];
+                        for (int di = 0; di < headDim; di++)
+                        {
+                            T sval = Straj[stOff + di * headDim + ki];
+                            dQ[baseOff + di] = ops.Add(dQ[baseOff + di], ops.Multiply(dOutVal, sval));
+                            dS[di * headDim + ki] = ops.Add(dS[di * headDim + ki], ops.Multiply(dOutVal, Q[baseOff + di]));
+                        }
+                    }
+
+                    T dg = ops.Zero;
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        T vv = V[baseOff + di];
+                        int srow = di * headDim;
+                        for (int ki = 0; ki < headDim; ki++)
+                        {
+                            T dStv = dS[srow + ki];
+                            T sprev = t > 0 ? Straj[sprevOff + srow + ki] : ops.Zero;
+                            dg = ops.Add(dg, ops.Multiply(dStv, sprev));
+                            dK[baseOff + ki] = ops.Add(dK[baseOff + ki], ops.Multiply(dStv, vv));
+                            dV[baseOff + di] = ops.Add(dV[baseOff + di], ops.Multiply(dStv, K[baseOff + ki]));
+                        }
+                    }
+                    dG[baseOff] = ops.Add(dG[baseOff], dg);
+
+                    for (int i = 0; i < hh; i++) dS[i] = ops.Multiply(dS[i], g);
+                }
+            }
+        }
+    }
+
+    private static void GlaScanBackward<T>(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output, object[] savedState,
+        IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        int numHeads = (int)savedState[0];
+        var qProj = inputs[0];
+        var kProj = inputs[1];
+        var vProj = inputs[2];
+        var gate = inputs[3];
+
+        int batch = qProj.Shape[0];
+        int seqLen = qProj.Shape[1];
+        int modelDim = qProj.Shape[2];
+        int headDim = modelDim / numHeads;
+
+        var dQ = new Tensor<T>(new[] { batch, seqLen, modelDim });
+        var dK = new Tensor<T>(new[] { batch, seqLen, modelDim });
+        var dV = new Tensor<T>(new[] { batch, seqLen, modelDim });
+        var dG = new Tensor<T>(new[] { batch, seqLen, modelDim });
+
+        if (typeof(T) == typeof(double))
+        {
+            GlaBackwardDouble(
+                (double[])(object)gradOutput.GetDataArray()!,
+                (double[])(object)qProj.GetDataArray()!, (double[])(object)kProj.GetDataArray()!,
+                (double[])(object)vProj.GetDataArray()!, (double[])(object)gate.GetDataArray()!,
+                (double[])(object)dQ.GetDataArray()!, (double[])(object)dK.GetDataArray()!,
+                (double[])(object)dV.GetDataArray()!, (double[])(object)dG.GetDataArray()!,
+                batch, seqLen, modelDim, numHeads, headDim);
+        }
+        else
+        {
+            GlaBackwardGeneric<T>(
+                gradOutput.GetDataArray()!,
+                qProj.GetDataArray()!, kProj.GetDataArray()!, vProj.GetDataArray()!, gate.GetDataArray()!,
+                dQ.GetDataArray()!, dK.GetDataArray()!, dV.GetDataArray()!, dG.GetDataArray()!,
+                batch, seqLen, modelDim, numHeads, headDim);
+        }
+
+        DifferentiableOps.AccumulateGrad(grads, qProj, dQ, engine);
+        DifferentiableOps.AccumulateGrad(grads, kProj, dK, engine);
+        DifferentiableOps.AccumulateGrad(grads, vProj, dV, engine);
+        DifferentiableOps.AccumulateGrad(grads, gate, dG, engine);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.GlaScan.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.GlaScan.cs
@@ -18,8 +18,8 @@ public partial class CpuEngine
     /// <paramref name="numHeads"/> blocks of headDim, keyDim = headDim), with matrix state S[di,ki] = 0
     /// and a scalar-per-head gate g_t = gate[..., headStart]:
     /// <code>
-    ///   S_t[di,ki] = g_t * S_{t-1}[di,ki] + K_t[ki] * V_t[di]
-    ///   O_t[ki]    = sum_di Q_t[di] * S_t[di,ki]
+    ///   S_t[di,ki] = g_t * S_{t-1}[di,ki] + V_t[di] * K_t[ki]
+    ///   O_t[di]    = sum_ki S_t[di,ki] * Q_t[ki]   (query contracts the key dim, output is the value dim)
     /// </code>
     /// Records one tape node whose backward is the exact BPTT adjoint, so it is differentiable under an
     /// active <c>GradientTape</c>. Inputs are the already-projected q/k/v streams plus a
@@ -104,12 +104,13 @@ public partial class CpuEngine
                         for (int ki = 0; ki < headDim; ki++)
                             S[srow + ki] = g * S[srow + ki] + K[baseOff + ki] * vv;
                     }
-                    for (int ki = 0; ki < headDim; ki++)
+                    for (int di = 0; di < headDim; di++)
                     {
+                        int srow = di * headDim;
                         double o = 0.0;
-                        for (int di = 0; di < headDim; di++)
-                            o += Q[baseOff + di] * S[di * headDim + ki];
-                        outp[baseOff + ki] = o;
+                        for (int ki = 0; ki < headDim; ki++)
+                            o += S[srow + ki] * Q[baseOff + ki];
+                        outp[baseOff + di] = o;
                     }
                 }
             }
@@ -158,15 +159,16 @@ public partial class CpuEngine
                     int sprevOff = (t - 1) * hh;
                     double g = G[gOff];
 
-                    // Output backward: O[ki] = sum_di Q[di]*S_t[di,ki].
-                    for (int ki = 0; ki < headDim; ki++)
+                    // Output backward: O[di] = sum_ki S_t[di,ki]*Q[ki].
+                    for (int di = 0; di < headDim; di++)
                     {
-                        double dOutVal = dOut[baseOff + ki];
-                        for (int di = 0; di < headDim; di++)
+                        double dOutVal = dOut[baseOff + di];
+                        int srow = di * headDim;
+                        for (int ki = 0; ki < headDim; ki++)
                         {
-                            double sval = Straj[stOff + di * headDim + ki];
-                            dQ[baseOff + di] += dOutVal * sval;
-                            dS[di * headDim + ki] += dOutVal * Q[baseOff + di];
+                            double sval = Straj[stOff + srow + ki];
+                            dQ[baseOff + ki] += dOutVal * sval;
+                            dS[srow + ki] += dOutVal * Q[baseOff + ki];
                         }
                     }
 
@@ -219,12 +221,13 @@ public partial class CpuEngine
                         for (int ki = 0; ki < headDim; ki++)
                             S[srow + ki] = ops.Add(ops.Multiply(g, S[srow + ki]), ops.Multiply(K[baseOff + ki], vv));
                     }
-                    for (int ki = 0; ki < headDim; ki++)
+                    for (int di = 0; di < headDim; di++)
                     {
+                        int srow = di * headDim;
                         T o = ops.Zero;
-                        for (int di = 0; di < headDim; di++)
-                            o = ops.Add(o, ops.Multiply(Q[baseOff + di], S[di * headDim + ki]));
-                        outp[baseOff + ki] = o;
+                        for (int ki = 0; ki < headDim; ki++)
+                            o = ops.Add(o, ops.Multiply(S[srow + ki], Q[baseOff + ki]));
+                        outp[baseOff + di] = o;
                     }
                 }
             }
@@ -271,14 +274,15 @@ public partial class CpuEngine
                     int sprevOff = (t - 1) * hh;
                     T g = G[gOff];
 
-                    for (int ki = 0; ki < headDim; ki++)
+                    for (int di = 0; di < headDim; di++)
                     {
-                        T dOutVal = dOut[baseOff + ki];
-                        for (int di = 0; di < headDim; di++)
+                        T dOutVal = dOut[baseOff + di];
+                        int srow = di * headDim;
+                        for (int ki = 0; ki < headDim; ki++)
                         {
-                            T sval = Straj[stOff + di * headDim + ki];
-                            dQ[baseOff + di] = ops.Add(dQ[baseOff + di], ops.Multiply(dOutVal, sval));
-                            dS[di * headDim + ki] = ops.Add(dS[di * headDim + ki], ops.Multiply(dOutVal, Q[baseOff + di]));
+                            T sval = Straj[stOff + srow + ki];
+                            dQ[baseOff + ki] = ops.Add(dQ[baseOff + ki], ops.Multiply(dOutVal, sval));
+                            dS[srow + ki] = ops.Add(dS[srow + ki], ops.Multiply(dOutVal, Q[baseOff + ki]));
                         }
                     }
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.Mamba2SsdScan.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.Mamba2SsdScan.cs
@@ -1,0 +1,408 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.Interfaces;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines;
+
+public partial class CpuEngine
+{
+    /// <summary>
+    /// Fused Mamba-2 SSD (State Space Duality) scan over a whole sequence in a SINGLE op
+    /// (forward + custom autodiff backward), replacing the per-element detached scalar loop the
+    /// decomposed <c>Mamba2Block.SSDForward</c> ran — both slow AND detached from the autodiff tape
+    /// (issue ooples/AiDotNet#1464). Per head (innerDim split into numHeads blocks of headDim) with
+    /// PER-HEAD scalar A = -exp(aLog[h]) and per-head scalar delta, shared B/C across heads, and state
+    /// h[di,n] = 0:
+    /// <code>
+    ///   Abar = exp(delta[h] * A[h])
+    ///   h_t[di,n] = Abar * h_{t-1}[di,n] + delta[h] * B_t[n] * x_t[di]
+    ///   y_t[di]   = sum_n C_t[n] * h_t[di,n] + D[h] * x_t[di]
+    /// </code>
+    /// The chunked SSD algorithm in the paper is mathematically this recurrence; the fused op computes
+    /// it sequentially with one differentiable tape node (BPTT adjoint), safe under a GradientTape.
+    /// </summary>
+    /// <param name="x">Post-conv/SiLU input [batch, seqLen, innerDim].</param>
+    /// <param name="delta">Per-head timestep [batch, seqLen, numHeads] (post-softplus).</param>
+    /// <param name="aLog">Per-head log decay [numHeads]; A = -exp(aLog).</param>
+    /// <param name="bParam">Shared B [batch, seqLen, stateDim].</param>
+    /// <param name="cParam">Shared C [batch, seqLen, stateDim].</param>
+    /// <param name="dParam">Per-head skip D [numHeads].</param>
+    /// <param name="numHeads">Number of heads; innerDim must be divisible by it.</param>
+    /// <returns>The SSD output [batch, seqLen, innerDim].</returns>
+    public virtual Tensor<T> Mamba2SsdScanForward<T>(
+        Tensor<T> x, Tensor<T> delta, Tensor<T> aLog, Tensor<T> bParam, Tensor<T> cParam, Tensor<T> dParam, int numHeads)
+    {
+        if (x is null) throw new ArgumentNullException(nameof(x));
+        if (delta is null) throw new ArgumentNullException(nameof(delta));
+        if (aLog is null) throw new ArgumentNullException(nameof(aLog));
+        if (bParam is null) throw new ArgumentNullException(nameof(bParam));
+        if (cParam is null) throw new ArgumentNullException(nameof(cParam));
+        if (dParam is null) throw new ArgumentNullException(nameof(dParam));
+        if (numHeads < 1) throw new ArgumentOutOfRangeException(nameof(numHeads));
+        if (x.Rank != 3)
+            throw new ArgumentException($"Mamba2SsdScanForward expects rank-3 x [batch, seqLen, innerDim]; got rank {x.Rank}.", nameof(x));
+
+        int batch = x.Shape[0];
+        int seqLen = x.Shape[1];
+        int innerDim = x.Shape[2];
+        if (innerDim % numHeads != 0)
+            throw new ArgumentException($"innerDim ({innerDim}) must be divisible by numHeads ({numHeads}).", nameof(numHeads));
+        int headDim = innerDim / numHeads;
+        int stateDim = bParam.Shape[2];
+        if (delta.Rank != 3 || delta.Shape[0] != batch || delta.Shape[1] != seqLen || delta.Shape[2] != numHeads)
+            throw new ArgumentException($"delta must be [batch={batch}, seqLen={seqLen}, numHeads={numHeads}].", nameof(delta));
+        if (aLog.Length != numHeads)
+            throw new ArgumentException($"aLog length ({aLog.Length}) must equal numHeads ({numHeads}).", nameof(aLog));
+        if (cParam.Rank != 3 || cParam.Shape[2] != stateDim)
+            throw new ArgumentException($"cParam must be [batch, seqLen, stateDim={stateDim}].", nameof(cParam));
+        if (dParam.Length != numHeads)
+            throw new ArgumentException($"dParam length ({dParam.Length}) must equal numHeads ({numHeads}).", nameof(dParam));
+
+        var output = new Tensor<T>(new[] { batch, seqLen, innerDim });
+
+        if (typeof(T) == typeof(double))
+        {
+            Mamba2ForwardDouble(
+                (double[])(object)x.GetDataArray()!, (double[])(object)delta.GetDataArray()!,
+                (double[])(object)aLog.GetDataArray()!, (double[])(object)bParam.GetDataArray()!,
+                (double[])(object)cParam.GetDataArray()!, (double[])(object)dParam.GetDataArray()!,
+                (double[])(object)output.GetDataArray()!, batch, seqLen, innerDim, numHeads, headDim, stateDim);
+        }
+        else
+        {
+            Mamba2ForwardGeneric<T>(
+                x.GetDataArray()!, delta.GetDataArray()!, aLog.GetDataArray()!, bParam.GetDataArray()!,
+                cParam.GetDataArray()!, dParam.GetDataArray()!, output.GetDataArray()!,
+                batch, seqLen, innerDim, numHeads, headDim, stateDim);
+        }
+
+        DifferentiableOps.RecordIfActive<T>(
+            "Mamba2SsdScan", output,
+            new[] { x, delta, aLog, bParam, cParam, dParam },
+            Mamba2SsdScanBackward<T>,
+            savedState: new object[] { numHeads });
+
+        return output;
+    }
+
+    // ── Double fast path ─────────────────────────────────────────────────────────────────
+    private static void Mamba2ForwardDouble(
+        double[] X, double[] delta, double[] aLog, double[] B, double[] C, double[] D, double[] outp,
+        int batch, int seqLen, int innerDim, int numHeads, int headDim, int sd)
+    {
+        var negA = new double[numHeads];
+        for (int hi = 0; hi < numHeads; hi++) negA[hi] = -Math.Exp(aLog[hi]);
+        var h = new double[innerDim * sd];
+        for (int b = 0; b < batch; b++)
+        {
+            Array.Clear(h, 0, h.Length);
+            for (int t = 0; t < seqLen; t++)
+            {
+                int btInner = (b * seqLen + t) * innerDim;
+                int btState = (b * seqLen + t) * sd;
+                int btHead = (b * seqLen + t) * numHeads;
+                for (int hi = 0; hi < numHeads; hi++)
+                {
+                    double dt = delta[btHead + hi];
+                    double aBar = Math.Exp(dt * negA[hi]);
+                    double dv = D[hi];
+                    int dimStart = hi * headDim;
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int flatD = dimStart + di;
+                        double xv = X[btInner + flatD];
+                        int hsBase = flatD * sd;
+                        double y = 0.0;
+                        for (int n = 0; n < sd; n++)
+                        {
+                            double hNew = aBar * h[hsBase + n] + dt * B[btState + n] * xv;
+                            h[hsBase + n] = hNew;
+                            y += C[btState + n] * hNew;
+                        }
+                        outp[btInner + flatD] = y + dv * xv;
+                    }
+                }
+            }
+        }
+    }
+
+    private static void Mamba2BackwardDouble(
+        double[] dOut, double[] X, double[] delta, double[] aLog, double[] B, double[] C, double[] D,
+        double[] dX, double[] dDelta, double[] dALog, double[] dB, double[] dC, double[] dD,
+        int batch, int seqLen, int innerDim, int numHeads, int headDim, int sd)
+    {
+        int isd = innerDim * sd;
+        var negA = new double[numHeads];
+        for (int hi = 0; hi < numHeads; hi++) negA[hi] = -Math.Exp(aLog[hi]);
+        var hTraj = new double[seqLen * isd];
+        var h = new double[isd];
+        var dh = new double[isd];
+
+        for (int b = 0; b < batch; b++)
+        {
+            // Forward recompute, saving the post-update state trajectory.
+            Array.Clear(h, 0, isd);
+            for (int t = 0; t < seqLen; t++)
+            {
+                int btInner = (b * seqLen + t) * innerDim;
+                int btState = (b * seqLen + t) * sd;
+                int btHead = (b * seqLen + t) * numHeads;
+                for (int hi = 0; hi < numHeads; hi++)
+                {
+                    double dt = delta[btHead + hi];
+                    double aBar = Math.Exp(dt * negA[hi]);
+                    int dimStart = hi * headDim;
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int flatD = dimStart + di;
+                        double xv = X[btInner + flatD];
+                        int hsBase = flatD * sd;
+                        for (int n = 0; n < sd; n++)
+                            h[hsBase + n] = aBar * h[hsBase + n] + dt * B[btState + n] * xv;
+                    }
+                }
+                Array.Copy(h, 0, hTraj, t * isd, isd);
+            }
+
+            // Reverse sweep.
+            Array.Clear(dh, 0, isd);
+            for (int t = seqLen - 1; t >= 0; t--)
+            {
+                int btInner = (b * seqLen + t) * innerDim;
+                int btState = (b * seqLen + t) * sd;
+                int btHead = (b * seqLen + t) * numHeads;
+                int stOff = t * isd, spOff = (t - 1) * isd;
+                for (int hi = 0; hi < numHeads; hi++)
+                {
+                    double dt = delta[btHead + hi];
+                    double a = negA[hi];
+                    double aBar = Math.Exp(dt * a);
+                    int dimStart = hi * headDim;
+                    double dDeltaAcc = 0.0, dALogAcc = 0.0, dDAcc = 0.0;
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int flatD = dimStart + di;
+                        double xv = X[btInner + flatD];
+                        int hsBase = flatD * sd;
+                        double dOutVal = dOut[btInner + flatD];
+
+                        // D skip: y += D[h]*x.
+                        dX[btInner + flatD] += D[hi] * dOutVal;
+                        dDAcc += xv * dOutVal;
+
+                        for (int n = 0; n < sd; n++)
+                        {
+                            double hCur = hTraj[stOff + hsBase + n];
+                            double hPrev = t > 0 ? hTraj[spOff + hsBase + n] : 0.0;
+                            // Output: dh += C*dOut ; dC += h_t*dOut.
+                            dh[hsBase + n] += C[btState + n] * dOutVal;
+                            dC[btState + n] += hCur * dOutVal;
+                            double dhVal = dh[hsBase + n];
+
+                            // h_t = aBar*hPrev + dt*B*x.
+                            double dAbar = dhVal * hPrev;
+                            dDeltaAcc += dAbar * aBar * a;            // A-path: dAbar*Abar*A
+                            dALogAcc += dAbar * aBar * (dt * a);      // aLog: dAbar*Abar*(dt*A)
+                            dDeltaAcc += dhVal * B[btState + n] * xv; // B*x path
+                            dB[btState + n] += dhVal * dt * xv;
+                            dX[btInner + flatD] += dhVal * dt * B[btState + n];
+
+                            // Propagate to previous step.
+                            dh[hsBase + n] = dhVal * aBar;
+                        }
+                    }
+                    dDelta[btHead + hi] += dDeltaAcc;
+                    dALog[hi] += dALogAcc;
+                    dD[hi] += dDAcc;
+                }
+            }
+        }
+    }
+
+    // ── Generic-T path ───────────────────────────────────────────────────────────────────
+    private static void Mamba2ForwardGeneric<T>(
+        T[] X, T[] delta, T[] aLog, T[] B, T[] C, T[] D, T[] outp,
+        int batch, int seqLen, int innerDim, int numHeads, int headDim, int sd)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        var negA = new T[numHeads];
+        for (int hi = 0; hi < numHeads; hi++) negA[hi] = ops.Negate(ops.Exp(aLog[hi]));
+        var h = new T[innerDim * sd];
+        for (int b = 0; b < batch; b++)
+        {
+            for (int i = 0; i < h.Length; i++) h[i] = ops.Zero;
+            for (int t = 0; t < seqLen; t++)
+            {
+                int btInner = (b * seqLen + t) * innerDim;
+                int btState = (b * seqLen + t) * sd;
+                int btHead = (b * seqLen + t) * numHeads;
+                for (int hi = 0; hi < numHeads; hi++)
+                {
+                    T dt = delta[btHead + hi];
+                    T aBar = ops.Exp(ops.Multiply(dt, negA[hi]));
+                    T dv = D[hi];
+                    int dimStart = hi * headDim;
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int flatD = dimStart + di;
+                        T xv = X[btInner + flatD];
+                        int hsBase = flatD * sd;
+                        T y = ops.Zero;
+                        for (int n = 0; n < sd; n++)
+                        {
+                            T hNew = ops.Add(ops.Multiply(aBar, h[hsBase + n]),
+                                ops.Multiply(dt, ops.Multiply(B[btState + n], xv)));
+                            h[hsBase + n] = hNew;
+                            y = ops.Add(y, ops.Multiply(C[btState + n], hNew));
+                        }
+                        outp[btInner + flatD] = ops.Add(y, ops.Multiply(dv, xv));
+                    }
+                }
+            }
+        }
+    }
+
+    private static void Mamba2BackwardGeneric<T>(
+        T[] dOut, T[] X, T[] delta, T[] aLog, T[] B, T[] C, T[] D,
+        T[] dX, T[] dDelta, T[] dALog, T[] dB, T[] dC, T[] dD,
+        int batch, int seqLen, int innerDim, int numHeads, int headDim, int sd)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        int isd = innerDim * sd;
+        var negA = new T[numHeads];
+        for (int hi = 0; hi < numHeads; hi++) negA[hi] = ops.Negate(ops.Exp(aLog[hi]));
+        var hTraj = new T[seqLen * isd];
+        var h = new T[isd];
+        var dh = new T[isd];
+
+        for (int b = 0; b < batch; b++)
+        {
+            for (int i = 0; i < isd; i++) h[i] = ops.Zero;
+            for (int t = 0; t < seqLen; t++)
+            {
+                int btInner = (b * seqLen + t) * innerDim;
+                int btState = (b * seqLen + t) * sd;
+                int btHead = (b * seqLen + t) * numHeads;
+                for (int hi = 0; hi < numHeads; hi++)
+                {
+                    T dt = delta[btHead + hi];
+                    T aBar = ops.Exp(ops.Multiply(dt, negA[hi]));
+                    int dimStart = hi * headDim;
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int flatD = dimStart + di;
+                        T xv = X[btInner + flatD];
+                        int hsBase = flatD * sd;
+                        for (int n = 0; n < sd; n++)
+                            h[hsBase + n] = ops.Add(ops.Multiply(aBar, h[hsBase + n]),
+                                ops.Multiply(dt, ops.Multiply(B[btState + n], xv)));
+                    }
+                }
+                Array.Copy(h, 0, hTraj, t * isd, isd);
+            }
+
+            for (int i = 0; i < isd; i++) dh[i] = ops.Zero;
+            for (int t = seqLen - 1; t >= 0; t--)
+            {
+                int btInner = (b * seqLen + t) * innerDim;
+                int btState = (b * seqLen + t) * sd;
+                int btHead = (b * seqLen + t) * numHeads;
+                int stOff = t * isd, spOff = (t - 1) * isd;
+                for (int hi = 0; hi < numHeads; hi++)
+                {
+                    T dt = delta[btHead + hi];
+                    T a = negA[hi];
+                    T aBar = ops.Exp(ops.Multiply(dt, a));
+                    int dimStart = hi * headDim;
+                    T dDeltaAcc = ops.Zero, dALogAcc = ops.Zero, dDAcc = ops.Zero;
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int flatD = dimStart + di;
+                        T xv = X[btInner + flatD];
+                        int hsBase = flatD * sd;
+                        T dOutVal = dOut[btInner + flatD];
+                        dX[btInner + flatD] = ops.Add(dX[btInner + flatD], ops.Multiply(D[hi], dOutVal));
+                        dDAcc = ops.Add(dDAcc, ops.Multiply(xv, dOutVal));
+                        for (int n = 0; n < sd; n++)
+                        {
+                            T hCur = hTraj[stOff + hsBase + n];
+                            T hPrev = t > 0 ? hTraj[spOff + hsBase + n] : ops.Zero;
+                            dh[hsBase + n] = ops.Add(dh[hsBase + n], ops.Multiply(C[btState + n], dOutVal));
+                            dC[btState + n] = ops.Add(dC[btState + n], ops.Multiply(hCur, dOutVal));
+                            T dhVal = dh[hsBase + n];
+                            T dAbar = ops.Multiply(dhVal, hPrev);
+                            dDeltaAcc = ops.Add(dDeltaAcc, ops.Multiply(ops.Multiply(dAbar, aBar), a));
+                            dALogAcc = ops.Add(dALogAcc, ops.Multiply(ops.Multiply(dAbar, aBar), ops.Multiply(dt, a)));
+                            dDeltaAcc = ops.Add(dDeltaAcc, ops.Multiply(dhVal, ops.Multiply(B[btState + n], xv)));
+                            dB[btState + n] = ops.Add(dB[btState + n], ops.Multiply(dhVal, ops.Multiply(dt, xv)));
+                            dX[btInner + flatD] = ops.Add(dX[btInner + flatD], ops.Multiply(dhVal, ops.Multiply(dt, B[btState + n])));
+                            dh[hsBase + n] = ops.Multiply(dhVal, aBar);
+                        }
+                    }
+                    dDelta[btHead + hi] = ops.Add(dDelta[btHead + hi], dDeltaAcc);
+                    dALog[hi] = ops.Add(dALog[hi], dALogAcc);
+                    dD[hi] = ops.Add(dD[hi], dDAcc);
+                }
+            }
+        }
+    }
+
+    private static void Mamba2SsdScanBackward<T>(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output, object[] savedState,
+        IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        int numHeads = (int)savedState[0];
+        var x = inputs[0];
+        var delta = inputs[1];
+        var aLog = inputs[2];
+        var bParam = inputs[3];
+        var cParam = inputs[4];
+        var dParam = inputs[5];
+
+        int batch = x.Shape[0];
+        int seqLen = x.Shape[1];
+        int innerDim = x.Shape[2];
+        int headDim = innerDim / numHeads;
+        int stateDim = bParam.Shape[2];
+
+        var dX = new Tensor<T>(new[] { batch, seqLen, innerDim });
+        var dDelta = new Tensor<T>(new[] { batch, seqLen, numHeads });
+        var dALog = new Tensor<T>(ShapeOf(aLog));
+        var dB = new Tensor<T>(new[] { batch, seqLen, stateDim });
+        var dC = new Tensor<T>(new[] { batch, seqLen, stateDim });
+        var dD = new Tensor<T>(ShapeOf(dParam));
+
+        if (typeof(T) == typeof(double))
+        {
+            Mamba2BackwardDouble(
+                (double[])(object)gradOutput.GetDataArray()!,
+                (double[])(object)x.GetDataArray()!, (double[])(object)delta.GetDataArray()!,
+                (double[])(object)aLog.GetDataArray()!, (double[])(object)bParam.GetDataArray()!,
+                (double[])(object)cParam.GetDataArray()!, (double[])(object)dParam.GetDataArray()!,
+                (double[])(object)dX.GetDataArray()!, (double[])(object)dDelta.GetDataArray()!,
+                (double[])(object)dALog.GetDataArray()!, (double[])(object)dB.GetDataArray()!,
+                (double[])(object)dC.GetDataArray()!, (double[])(object)dD.GetDataArray()!,
+                batch, seqLen, innerDim, numHeads, headDim, stateDim);
+        }
+        else
+        {
+            Mamba2BackwardGeneric<T>(
+                gradOutput.GetDataArray()!,
+                x.GetDataArray()!, delta.GetDataArray()!, aLog.GetDataArray()!,
+                bParam.GetDataArray()!, cParam.GetDataArray()!, dParam.GetDataArray()!,
+                dX.GetDataArray()!, dDelta.GetDataArray()!, dALog.GetDataArray()!,
+                dB.GetDataArray()!, dC.GetDataArray()!, dD.GetDataArray()!,
+                batch, seqLen, innerDim, numHeads, headDim, stateDim);
+        }
+
+        DifferentiableOps.AccumulateGrad(grads, x, dX, engine);
+        DifferentiableOps.AccumulateGrad(grads, delta, dDelta, engine);
+        DifferentiableOps.AccumulateGrad(grads, aLog, dALog, engine);
+        DifferentiableOps.AccumulateGrad(grads, bParam, dB, engine);
+        DifferentiableOps.AccumulateGrad(grads, cParam, dC, engine);
+        DifferentiableOps.AccumulateGrad(grads, dParam, dD, engine);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.Mamba2SsdScan.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.Mamba2SsdScan.cs
@@ -51,13 +51,18 @@ public partial class CpuEngine
         if (innerDim % numHeads != 0)
             throw new ArgumentException($"innerDim ({innerDim}) must be divisible by numHeads ({numHeads}).", nameof(numHeads));
         int headDim = innerDim / numHeads;
+        // Validate bParam is fully rank-3 [batch, seqLen, stateDim] BEFORE reading
+        // Shape[2] — otherwise a rank/batch/seq mismatch would misindex or throw a
+        // late IndexOutOfRangeException instead of a clear argument error.
+        if (bParam.Rank != 3 || bParam.Shape[0] != batch || bParam.Shape[1] != seqLen)
+            throw new ArgumentException($"bParam must be [batch={batch}, seqLen={seqLen}, stateDim].", nameof(bParam));
         int stateDim = bParam.Shape[2];
         if (delta.Rank != 3 || delta.Shape[0] != batch || delta.Shape[1] != seqLen || delta.Shape[2] != numHeads)
             throw new ArgumentException($"delta must be [batch={batch}, seqLen={seqLen}, numHeads={numHeads}].", nameof(delta));
         if (aLog.Length != numHeads)
             throw new ArgumentException($"aLog length ({aLog.Length}) must equal numHeads ({numHeads}).", nameof(aLog));
-        if (cParam.Rank != 3 || cParam.Shape[2] != stateDim)
-            throw new ArgumentException($"cParam must be [batch, seqLen, stateDim={stateDim}].", nameof(cParam));
+        if (cParam.Rank != 3 || cParam.Shape[0] != batch || cParam.Shape[1] != seqLen || cParam.Shape[2] != stateDim)
+            throw new ArgumentException($"cParam must be [batch={batch}, seqLen={seqLen}, stateDim={stateDim}].", nameof(cParam));
         if (dParam.Length != numHeads)
             throw new ArgumentException($"dParam length ({dParam.Length}) must equal numHeads ({numHeads}).", nameof(dParam));
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.MambaScan.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.MambaScan.cs
@@ -1,0 +1,387 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.Interfaces;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines;
+
+public partial class CpuEngine
+{
+    /// <summary>
+    /// Fused Mamba S6 selective-scan over a whole sequence in a SINGLE op (forward + custom autodiff
+    /// backward), replacing the per-timestep tape micro-ops the decomposed
+    /// <c>S6Scan.SequentialScanForward</c> loop records — the dominant training cost on Mamba-family
+    /// models (issue ooples/AiDotNet#1464). Per the Gu &amp; Dao (2023) selective SSM, for each batch b,
+    /// inner channel i, state n, with hidden state h[i,n] = 0:
+    /// <code>
+    ///   A = -exp(aLog[i,n])
+    ///   Abar = exp(delta[b,t,i] * A)                 (ZOH discretization of A)
+    ///   Bbar*x = delta[b,t,i] * B[b,t,n] * x[b,t,i]  (Euler discretization of B)
+    ///   h[i,n] = Abar * h[i,n] + Bbar*x
+    ///   y[b,t,i] = sum_n C[b,t,n] * h[i,n] + D[i] * x[b,t,i]
+    /// </code>
+    /// The "selective" delta/B/C are input-dependent; A (via aLog) and D are static per-channel. Records
+    /// one tape node whose backward is the exact BPTT adjoint (matches the per-timestep result), so it is
+    /// differentiable under an active <c>GradientTape</c>.
+    /// </summary>
+    /// <param name="x">Post-conv/SiLU input [batch, seqLen, innerDim].</param>
+    /// <param name="delta">Timestep parameter (post-softplus) [batch, seqLen, innerDim].</param>
+    /// <param name="aLog">Log of the (negated) A parameter [innerDim, stateDim]; A = -exp(aLog).</param>
+    /// <param name="bParam">Input-dependent B [batch, seqLen, stateDim].</param>
+    /// <param name="cParam">Input-dependent C [batch, seqLen, stateDim].</param>
+    /// <param name="dParam">Static skip-connection D [innerDim].</param>
+    /// <returns>The scan output [batch, seqLen, innerDim].</returns>
+    public virtual Tensor<T> MambaSelectiveScanForward<T>(
+        Tensor<T> x, Tensor<T> delta, Tensor<T> aLog, Tensor<T> bParam, Tensor<T> cParam, Tensor<T> dParam)
+    {
+        if (x is null) throw new ArgumentNullException(nameof(x));
+        if (delta is null) throw new ArgumentNullException(nameof(delta));
+        if (aLog is null) throw new ArgumentNullException(nameof(aLog));
+        if (bParam is null) throw new ArgumentNullException(nameof(bParam));
+        if (cParam is null) throw new ArgumentNullException(nameof(cParam));
+        if (dParam is null) throw new ArgumentNullException(nameof(dParam));
+        if (x.Rank != 3)
+            throw new ArgumentException($"MambaSelectiveScanForward expects rank-3 x [batch, seqLen, innerDim]; got rank {x.Rank}.", nameof(x));
+        if (aLog.Rank != 2)
+            throw new ArgumentException($"aLog must be rank-2 [innerDim, stateDim]; got rank {aLog.Rank}.", nameof(aLog));
+
+        int batch = x.Shape[0];
+        int seqLen = x.Shape[1];
+        int innerDim = x.Shape[2];
+        int stateDim = aLog.Shape[1];
+        if (aLog.Shape[0] != innerDim)
+            throw new ArgumentException($"aLog dim0 ({aLog.Shape[0]}) must equal innerDim ({innerDim}).", nameof(aLog));
+        EnsureSameShape(x, delta, nameof(delta));
+        if (bParam.Rank != 3 || bParam.Shape[0] != batch || bParam.Shape[1] != seqLen || bParam.Shape[2] != stateDim)
+            throw new ArgumentException($"bParam must be [batch={batch}, seqLen={seqLen}, stateDim={stateDim}].", nameof(bParam));
+        if (cParam.Rank != 3 || cParam.Shape[0] != batch || cParam.Shape[1] != seqLen || cParam.Shape[2] != stateDim)
+            throw new ArgumentException($"cParam must be [batch={batch}, seqLen={seqLen}, stateDim={stateDim}].", nameof(cParam));
+        if (dParam.Length != innerDim)
+            throw new ArgumentException($"dParam length ({dParam.Length}) must equal innerDim ({innerDim}).", nameof(dParam));
+
+        var output = new Tensor<T>(new[] { batch, seqLen, innerDim });
+
+        if (typeof(T) == typeof(double))
+        {
+            MambaScanForwardDouble(
+                (double[])(object)x.GetDataArray()!, (double[])(object)delta.GetDataArray()!,
+                (double[])(object)aLog.GetDataArray()!, (double[])(object)bParam.GetDataArray()!,
+                (double[])(object)cParam.GetDataArray()!, (double[])(object)dParam.GetDataArray()!,
+                (double[])(object)output.GetDataArray()!, batch, seqLen, innerDim, stateDim);
+        }
+        else
+        {
+            MambaScanForwardGeneric<T>(
+                x.GetDataArray()!, delta.GetDataArray()!, aLog.GetDataArray()!, bParam.GetDataArray()!,
+                cParam.GetDataArray()!, dParam.GetDataArray()!, output.GetDataArray()!,
+                batch, seqLen, innerDim, stateDim);
+        }
+
+        DifferentiableOps.RecordIfActive<T>(
+            "MambaSelectiveScan", output,
+            new[] { x, delta, aLog, bParam, cParam, dParam },
+            MambaSelectiveScanBackward<T>,
+            savedState: null);
+
+        return output;
+    }
+
+    // ── Double fast path ─────────────────────────────────────────────────────────────────
+    private static void MambaScanForwardDouble(
+        double[] X, double[] delta, double[] aLog, double[] B, double[] C, double[] D, double[] outp,
+        int batch, int seqLen, int innerDim, int stateDim)
+    {
+        var negA = new double[innerDim * stateDim];
+        for (int i = 0; i < negA.Length; i++) negA[i] = -Math.Exp(aLog[i]);
+
+        var h = new double[innerDim * stateDim];
+        for (int b = 0; b < batch; b++)
+        {
+            Array.Clear(h, 0, h.Length);
+            for (int t = 0; t < seqLen; t++)
+            {
+                int baseID = (b * seqLen + t) * innerDim;
+                int baseSD = (b * seqLen + t) * stateDim;
+                for (int di = 0; di < innerDim; di++)
+                {
+                    double dt = delta[baseID + di];
+                    double xv = X[baseID + di];
+                    int hrow = di * stateDim;
+                    double y = 0.0;
+                    for (int ni = 0; ni < stateDim; ni++)
+                    {
+                        double aBar = Math.Exp(dt * negA[hrow + ni]);
+                        double hv = aBar * h[hrow + ni] + dt * B[baseSD + ni] * xv;
+                        h[hrow + ni] = hv;
+                        y += C[baseSD + ni] * hv;
+                    }
+                    outp[baseID + di] = y + D[di] * xv;
+                }
+            }
+        }
+    }
+
+    private static void MambaScanBackwardDouble(
+        double[] dOut, double[] X, double[] delta, double[] aLog, double[] B, double[] C, double[] D,
+        double[] dX, double[] dDelta, double[] dALog, double[] dB, double[] dC, double[] dD,
+        int batch, int seqLen, int innerDim, int stateDim)
+    {
+        int isd = innerDim * stateDim;
+        var negA = new double[isd];
+        for (int i = 0; i < isd; i++) negA[i] = -Math.Exp(aLog[i]);
+
+        var hTraj = new double[seqLen * isd];
+        var h = new double[isd];
+        var dh = new double[isd];
+
+        for (int b = 0; b < batch; b++)
+        {
+            // Forward recompute, saving the post-update state trajectory.
+            Array.Clear(h, 0, isd);
+            for (int t = 0; t < seqLen; t++)
+            {
+                int baseID = (b * seqLen + t) * innerDim;
+                int baseSD = (b * seqLen + t) * stateDim;
+                for (int di = 0; di < innerDim; di++)
+                {
+                    double dt = delta[baseID + di];
+                    double xv = X[baseID + di];
+                    int hrow = di * stateDim;
+                    for (int ni = 0; ni < stateDim; ni++)
+                    {
+                        double aBar = Math.Exp(dt * negA[hrow + ni]);
+                        h[hrow + ni] = aBar * h[hrow + ni] + dt * B[baseSD + ni] * xv;
+                    }
+                }
+                Array.Copy(h, 0, hTraj, t * isd, isd);
+            }
+
+            // Reverse sweep (dh carries the adjoint state from t+1).
+            Array.Clear(dh, 0, isd);
+            for (int t = seqLen - 1; t >= 0; t--)
+            {
+                int baseID = (b * seqLen + t) * innerDim;
+                int baseSD = (b * seqLen + t) * stateDim;
+                int stOff = t * isd;
+                int sprevOff = (t - 1) * isd;
+                for (int di = 0; di < innerDim; di++)
+                {
+                    double dt = delta[baseID + di];
+                    double xv = X[baseID + di];
+                    double dOutVal = dOut[baseID + di];
+                    int hrow = di * stateDim;
+
+                    // D skip connection.
+                    dX[baseID + di] += D[di] * dOutVal;
+                    dD[di] += xv * dOutVal;
+
+                    double dDeltaAcc = 0.0;
+                    for (int ni = 0; ni < stateDim; ni++)
+                    {
+                        double a = negA[hrow + ni];
+                        double dtA = dt * a;
+                        double aBar = Math.Exp(dtA);
+                        double hCur = hTraj[stOff + hrow + ni];
+                        double hPrev = t > 0 ? hTraj[sprevOff + hrow + ni] : 0.0;
+                        double cVal = C[baseSD + ni];
+                        double bVal = B[baseSD + ni];
+
+                        // Output gradient into the state adjoint; dC from readout.
+                        dh[hrow + ni] += cVal * dOutVal;
+                        double dhVal = dh[hrow + ni];
+                        dC[baseSD + ni] += hCur * dOutVal;
+
+                        // d(Abar) = dh * h_prev  ; chain to delta (via Abar*A) and aLog (via Abar*dt*A).
+                        double dAbar = dhVal * hPrev;
+                        dDeltaAcc += dAbar * aBar * a;          // A_bar path: dAbar*Abar*A
+                        dDeltaAcc += dhVal * bVal * xv;         // B*x path: dh*B*x
+                        dB[baseSD + ni] += dhVal * dt * xv;     // dB = dh*delta*x
+                        dX[baseID + di] += dhVal * dt * bVal;   // dx (state path) = dh*delta*B
+                        dALog[hrow + ni] += dAbar * aBar * dtA; // aLog: dAbar*Abar*(delta*A)
+
+                        // Propagate adjoint to previous step: dh_{t-1} = Abar * dh_t.
+                        dh[hrow + ni] = aBar * dhVal;
+                    }
+                    dDelta[baseID + di] = dDeltaAcc;
+                }
+            }
+        }
+    }
+
+    // ── Generic-T path ───────────────────────────────────────────────────────────────────
+    private static void MambaScanForwardGeneric<T>(
+        T[] X, T[] delta, T[] aLog, T[] B, T[] C, T[] D, T[] outp,
+        int batch, int seqLen, int innerDim, int stateDim)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        int isd = innerDim * stateDim;
+        var negA = new T[isd];
+        for (int i = 0; i < isd; i++) negA[i] = ops.Negate(ops.Exp(aLog[i]));
+
+        var h = new T[isd];
+        for (int b = 0; b < batch; b++)
+        {
+            for (int i = 0; i < isd; i++) h[i] = ops.Zero;
+            for (int t = 0; t < seqLen; t++)
+            {
+                int baseID = (b * seqLen + t) * innerDim;
+                int baseSD = (b * seqLen + t) * stateDim;
+                for (int di = 0; di < innerDim; di++)
+                {
+                    T dt = delta[baseID + di];
+                    T xv = X[baseID + di];
+                    int hrow = di * stateDim;
+                    T y = ops.Zero;
+                    for (int ni = 0; ni < stateDim; ni++)
+                    {
+                        T aBar = ops.Exp(ops.Multiply(dt, negA[hrow + ni]));
+                        T hv = ops.Add(ops.Multiply(aBar, h[hrow + ni]),
+                            ops.Multiply(ops.Multiply(dt, B[baseSD + ni]), xv));
+                        h[hrow + ni] = hv;
+                        y = ops.Add(y, ops.Multiply(C[baseSD + ni], hv));
+                    }
+                    outp[baseID + di] = ops.Add(y, ops.Multiply(D[di], xv));
+                }
+            }
+        }
+    }
+
+    private static void MambaScanBackwardGeneric<T>(
+        T[] dOut, T[] X, T[] delta, T[] aLog, T[] B, T[] C, T[] D,
+        T[] dX, T[] dDelta, T[] dALog, T[] dB, T[] dC, T[] dD,
+        int batch, int seqLen, int innerDim, int stateDim)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        int isd = innerDim * stateDim;
+        var negA = new T[isd];
+        for (int i = 0; i < isd; i++) negA[i] = ops.Negate(ops.Exp(aLog[i]));
+
+        var hTraj = new T[seqLen * isd];
+        var h = new T[isd];
+        var dh = new T[isd];
+
+        for (int b = 0; b < batch; b++)
+        {
+            for (int i = 0; i < isd; i++) h[i] = ops.Zero;
+            for (int t = 0; t < seqLen; t++)
+            {
+                int baseID = (b * seqLen + t) * innerDim;
+                int baseSD = (b * seqLen + t) * stateDim;
+                for (int di = 0; di < innerDim; di++)
+                {
+                    T dt = delta[baseID + di];
+                    T xv = X[baseID + di];
+                    int hrow = di * stateDim;
+                    for (int ni = 0; ni < stateDim; ni++)
+                    {
+                        T aBar = ops.Exp(ops.Multiply(dt, negA[hrow + ni]));
+                        h[hrow + ni] = ops.Add(ops.Multiply(aBar, h[hrow + ni]),
+                            ops.Multiply(ops.Multiply(dt, B[baseSD + ni]), xv));
+                    }
+                }
+                Array.Copy(h, 0, hTraj, t * isd, isd);
+            }
+
+            for (int i = 0; i < isd; i++) dh[i] = ops.Zero;
+            for (int t = seqLen - 1; t >= 0; t--)
+            {
+                int baseID = (b * seqLen + t) * innerDim;
+                int baseSD = (b * seqLen + t) * stateDim;
+                int stOff = t * isd;
+                int sprevOff = (t - 1) * isd;
+                for (int di = 0; di < innerDim; di++)
+                {
+                    T dt = delta[baseID + di];
+                    T xv = X[baseID + di];
+                    T dOutVal = dOut[baseID + di];
+                    int hrow = di * stateDim;
+
+                    dX[baseID + di] = ops.Add(dX[baseID + di], ops.Multiply(D[di], dOutVal));
+                    dD[di] = ops.Add(dD[di], ops.Multiply(xv, dOutVal));
+
+                    T dDeltaAcc = ops.Zero;
+                    for (int ni = 0; ni < stateDim; ni++)
+                    {
+                        T a = negA[hrow + ni];
+                        T dtA = ops.Multiply(dt, a);
+                        T aBar = ops.Exp(dtA);
+                        T hCur = hTraj[stOff + hrow + ni];
+                        T hPrev = t > 0 ? hTraj[sprevOff + hrow + ni] : ops.Zero;
+                        T cVal = C[baseSD + ni];
+                        T bVal = B[baseSD + ni];
+
+                        dh[hrow + ni] = ops.Add(dh[hrow + ni], ops.Multiply(cVal, dOutVal));
+                        T dhVal = dh[hrow + ni];
+                        dC[baseSD + ni] = ops.Add(dC[baseSD + ni], ops.Multiply(hCur, dOutVal));
+
+                        T dAbar = ops.Multiply(dhVal, hPrev);
+                        dDeltaAcc = ops.Add(dDeltaAcc, ops.Multiply(ops.Multiply(dAbar, aBar), a));
+                        dDeltaAcc = ops.Add(dDeltaAcc, ops.Multiply(dhVal, ops.Multiply(bVal, xv)));
+                        dB[baseSD + ni] = ops.Add(dB[baseSD + ni], ops.Multiply(dhVal, ops.Multiply(dt, xv)));
+                        dX[baseID + di] = ops.Add(dX[baseID + di], ops.Multiply(dhVal, ops.Multiply(dt, bVal)));
+                        dALog[hrow + ni] = ops.Add(dALog[hrow + ni], ops.Multiply(ops.Multiply(dAbar, aBar), dtA));
+
+                        dh[hrow + ni] = ops.Multiply(aBar, dhVal);
+                    }
+                    dDelta[baseID + di] = dDeltaAcc;
+                }
+            }
+        }
+    }
+
+    private static void MambaSelectiveScanBackward<T>(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output, object[] savedState,
+        IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        var x = inputs[0];
+        var delta = inputs[1];
+        var aLog = inputs[2];
+        var bParam = inputs[3];
+        var cParam = inputs[4];
+        var dParam = inputs[5];
+
+        int batch = x.Shape[0];
+        int seqLen = x.Shape[1];
+        int innerDim = x.Shape[2];
+        int stateDim = aLog.Shape[1];
+
+        var dX = new Tensor<T>(new[] { batch, seqLen, innerDim });
+        var dDelta = new Tensor<T>(new[] { batch, seqLen, innerDim });
+        var dALog = new Tensor<T>(new[] { innerDim, stateDim });
+        var dB = new Tensor<T>(new[] { batch, seqLen, stateDim });
+        var dC = new Tensor<T>(new[] { batch, seqLen, stateDim });
+        var dD = new Tensor<T>(ShapeOf(dParam));
+
+        if (typeof(T) == typeof(double))
+        {
+            MambaScanBackwardDouble(
+                (double[])(object)gradOutput.GetDataArray()!,
+                (double[])(object)x.GetDataArray()!, (double[])(object)delta.GetDataArray()!,
+                (double[])(object)aLog.GetDataArray()!, (double[])(object)bParam.GetDataArray()!,
+                (double[])(object)cParam.GetDataArray()!, (double[])(object)dParam.GetDataArray()!,
+                (double[])(object)dX.GetDataArray()!, (double[])(object)dDelta.GetDataArray()!,
+                (double[])(object)dALog.GetDataArray()!, (double[])(object)dB.GetDataArray()!,
+                (double[])(object)dC.GetDataArray()!, (double[])(object)dD.GetDataArray()!,
+                batch, seqLen, innerDim, stateDim);
+        }
+        else
+        {
+            MambaScanBackwardGeneric<T>(
+                gradOutput.GetDataArray()!,
+                x.GetDataArray()!, delta.GetDataArray()!, aLog.GetDataArray()!,
+                bParam.GetDataArray()!, cParam.GetDataArray()!, dParam.GetDataArray()!,
+                dX.GetDataArray()!, dDelta.GetDataArray()!, dALog.GetDataArray()!,
+                dB.GetDataArray()!, dC.GetDataArray()!, dD.GetDataArray()!,
+                batch, seqLen, innerDim, stateDim);
+        }
+
+        DifferentiableOps.AccumulateGrad(grads, x, dX, engine);
+        DifferentiableOps.AccumulateGrad(grads, delta, dDelta, engine);
+        DifferentiableOps.AccumulateGrad(grads, aLog, dALog, engine);
+        DifferentiableOps.AccumulateGrad(grads, bParam, dB, engine);
+        DifferentiableOps.AccumulateGrad(grads, cParam, dC, engine);
+        DifferentiableOps.AccumulateGrad(grads, dParam, dD, engine);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.RgLruScan.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.RgLruScan.cs
@@ -1,0 +1,320 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.Interfaces;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines;
+
+public partial class CpuEngine
+{
+    /// <summary>
+    /// Fused Real-Gated Linear Recurrent Unit (RG-LRU) scan over a whole sequence in a SINGLE op
+    /// (forward + custom autodiff backward), replacing the per-timestep tape micro-ops the decomposed
+    /// <c>RealGatedLinearRecurrenceLayer.GatedRecurrenceForward</c> loop records — the core sequence
+    /// mixer of Griffin / Hawk / RecurrentGemma (De et al. 2024; issue ooples/AiDotNet#1464). Inputs are
+    /// the per-position value/gate streams (the value and gates are projected by the caller); the
+    /// per-channel recurrence is, with base = sigmoid(-decay) = exp(-softplus(decay)) and h[ch] = 0:
+    /// <code>
+    ///   a_t   = recGate_t * base                       (input-modulated decay, in (0,1))
+    ///   s_t   = sqrt(max(0, 1 - a_t^2))                (magnitude-preserving input scale)
+    ///   h_t   = a_t * h_{t-1} + s_t * (inpGate_t * v_t)
+    ///   y_t   = h_t
+    /// </code>
+    /// Records one tape node whose backward is the exact BPTT adjoint, so it is differentiable under an
+    /// active <c>GradientTape</c>.
+    /// </summary>
+    /// <param name="value">Value stream v [batch, seqLen, recDim] (already x·W_v).</param>
+    /// <param name="recGate">Recurrence gate r [batch, seqLen, recDim] (post-sigmoid, in (0,1)).</param>
+    /// <param name="inpGate">Input gate i [batch, seqLen, recDim] (post-sigmoid, in (0,1)).</param>
+    /// <param name="decay">Per-channel learned decay [recDim] (raw; base = sigmoid(-decay)).</param>
+    /// <returns>The recurrence output h [batch, seqLen, recDim].</returns>
+    public virtual Tensor<T> RgLruScanForward<T>(
+        Tensor<T> value, Tensor<T> recGate, Tensor<T> inpGate, Tensor<T> decay)
+    {
+        if (value is null) throw new ArgumentNullException(nameof(value));
+        if (recGate is null) throw new ArgumentNullException(nameof(recGate));
+        if (inpGate is null) throw new ArgumentNullException(nameof(inpGate));
+        if (decay is null) throw new ArgumentNullException(nameof(decay));
+        if (value.Rank != 3)
+            throw new ArgumentException($"RgLruScanForward expects rank-3 inputs [batch, seqLen, recDim]; got rank {value.Rank}.", nameof(value));
+
+        int batch = value.Shape[0];
+        int seqLen = value.Shape[1];
+        int recDim = value.Shape[2];
+        EnsureSameShape(value, recGate, nameof(recGate));
+        EnsureSameShape(value, inpGate, nameof(inpGate));
+        if (decay.Length != recDim)
+            throw new ArgumentException($"decay length ({decay.Length}) must equal recDim ({recDim}).", nameof(decay));
+
+        var output = new Tensor<T>(new[] { batch, seqLen, recDim });
+
+        if (typeof(T) == typeof(double))
+        {
+            RgLruForwardDouble(
+                (double[])(object)value.GetDataArray()!, (double[])(object)recGate.GetDataArray()!,
+                (double[])(object)inpGate.GetDataArray()!, (double[])(object)decay.GetDataArray()!,
+                (double[])(object)output.GetDataArray()!, batch, seqLen, recDim);
+        }
+        else
+        {
+            RgLruForwardGeneric<T>(
+                value.GetDataArray()!, recGate.GetDataArray()!, inpGate.GetDataArray()!,
+                decay.GetDataArray()!, output.GetDataArray()!, batch, seqLen, recDim);
+        }
+
+        DifferentiableOps.RecordIfActive<T>(
+            "RgLruScan", output,
+            new[] { value, recGate, inpGate, decay },
+            RgLruScanBackward<T>,
+            savedState: null);
+
+        return output;
+    }
+
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+    private static double SigD(double x) => 1.0 / (1.0 + Math.Exp(-x));
+
+    // ── Double fast path ─────────────────────────────────────────────────────────────────
+    private static void RgLruForwardDouble(
+        double[] V, double[] R, double[] I, double[] decay, double[] outp,
+        int batch, int seqLen, int recDim)
+    {
+        var baseDecay = new double[recDim];
+        for (int c = 0; c < recDim; c++) baseDecay[c] = SigD(-decay[c]);
+
+        var h = new double[recDim];
+        for (int b = 0; b < batch; b++)
+        {
+            Array.Clear(h, 0, recDim);
+            for (int t = 0; t < seqLen; t++)
+            {
+                int off = (b * seqLen + t) * recDim;
+                for (int c = 0; c < recDim; c++)
+                {
+                    double a = R[off + c] * baseDecay[c];
+                    double oneMinus = 1.0 - a * a;
+                    double s = oneMinus > 0.0 ? Math.Sqrt(oneMinus) : 0.0;
+                    double hv = a * h[c] + s * (I[off + c] * V[off + c]);
+                    h[c] = hv;
+                    outp[off + c] = hv;
+                }
+            }
+        }
+    }
+
+    private static void RgLruBackwardDouble(
+        double[] dOut, double[] V, double[] R, double[] I, double[] decay,
+        double[] dV, double[] dR, double[] dI, double[] dDecay,
+        int batch, int seqLen, int recDim)
+    {
+        var baseDecay = new double[recDim];
+        for (int c = 0; c < recDim; c++) baseDecay[c] = SigD(-decay[c]);
+
+        var hTraj = new double[seqLen * recDim];
+        var h = new double[recDim];
+        var dH = new double[recDim];
+        var dBase = new double[recDim];
+
+        for (int b = 0; b < batch; b++)
+        {
+            // Forward recompute, saving the post-update state trajectory.
+            Array.Clear(h, 0, recDim);
+            for (int t = 0; t < seqLen; t++)
+            {
+                int off = (b * seqLen + t) * recDim;
+                for (int c = 0; c < recDim; c++)
+                {
+                    double a = R[off + c] * baseDecay[c];
+                    double oneMinus = 1.0 - a * a;
+                    double s = oneMinus > 0.0 ? Math.Sqrt(oneMinus) : 0.0;
+                    h[c] = a * h[c] + s * (I[off + c] * V[off + c]);
+                    hTraj[t * recDim + c] = h[c];
+                }
+            }
+
+            // Reverse sweep. dH carries the adjoint of h_t from t+1 (and y_t = h_t).
+            Array.Clear(dH, 0, recDim);
+            for (int t = seqLen - 1; t >= 0; t--)
+            {
+                int off = (b * seqLen + t) * recDim;
+                for (int c = 0; c < recDim; c++)
+                {
+                    double bd = baseDecay[c];
+                    double a = R[off + c] * bd;
+                    double oneMinus = 1.0 - a * a;
+                    double s = oneMinus > 0.0 ? Math.Sqrt(oneMinus) : 0.0;
+                    double iv = I[off + c] * V[off + c];
+                    double hPrev = t > 0 ? hTraj[(t - 1) * recDim + c] : 0.0;
+
+                    // y_t = h_t.
+                    double dh = dH[c] + dOut[off + c];
+
+                    // h_t = a*hPrev + s*(i*v).
+                    // d(g=i*v) = dh*s ; d(s) = dh*iv ; d(a) = dh*hPrev + ds/da contribution.
+                    double dG = dh * s;
+                    dI[off + c] += dG * V[off + c];
+                    dV[off + c] += dG * I[off + c];
+
+                    double dS = dh * iv;
+                    // s = sqrt(1-a^2) (when positive): ds/da = -a/s.
+                    double dA = dh * hPrev;
+                    if (s > 1e-12) dA += dS * (-a / s);
+
+                    // a = r * base.
+                    dR[off + c] += dA * bd;
+                    dBase[c] += dA * R[off + c];
+
+                    // Adjoint to previous step: d(h_{t-1}) = dh * a.
+                    dH[c] = dh * a;
+                }
+            }
+        }
+
+        // base = sigmoid(-decay): d(base)/d(decay) = -base*(1-base).
+        for (int c = 0; c < recDim; c++)
+            dDecay[c] += dBase[c] * (-baseDecay[c] * (1.0 - baseDecay[c]));
+    }
+
+    // ── Generic-T path ───────────────────────────────────────────────────────────────────
+    private static void RgLruForwardGeneric<T>(
+        T[] V, T[] R, T[] I, T[] decay, T[] outp, int batch, int seqLen, int recDim)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        T one = ops.One, zero = ops.Zero;
+        var baseDecay = new T[recDim];
+        for (int c = 0; c < recDim; c++) baseDecay[c] = SigGeneric(ops, ops.Negate(decay[c]));
+
+        var h = new T[recDim];
+        for (int b = 0; b < batch; b++)
+        {
+            for (int c = 0; c < recDim; c++) h[c] = zero;
+            for (int t = 0; t < seqLen; t++)
+            {
+                int off = (b * seqLen + t) * recDim;
+                for (int c = 0; c < recDim; c++)
+                {
+                    T a = ops.Multiply(R[off + c], baseDecay[c]);
+                    T oneMinus = ops.Subtract(one, ops.Multiply(a, a));
+                    T s = ops.GreaterThan(oneMinus, zero) ? ops.Sqrt(oneMinus) : zero;
+                    T hv = ops.Add(ops.Multiply(a, h[c]), ops.Multiply(s, ops.Multiply(I[off + c], V[off + c])));
+                    h[c] = hv;
+                    outp[off + c] = hv;
+                }
+            }
+        }
+    }
+
+    private static void RgLruBackwardGeneric<T>(
+        T[] dOut, T[] V, T[] R, T[] I, T[] decay,
+        T[] dV, T[] dR, T[] dI, T[] dDecay, int batch, int seqLen, int recDim)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        T one = ops.One, zero = ops.Zero;
+        T tiny = ops.FromDouble(1e-12);
+        var baseDecay = new T[recDim];
+        for (int c = 0; c < recDim; c++) baseDecay[c] = SigGeneric(ops, ops.Negate(decay[c]));
+
+        var hTraj = new T[seqLen * recDim];
+        var h = new T[recDim];
+        var dH = new T[recDim];
+        var dBase = new T[recDim];
+        for (int c = 0; c < recDim; c++) dBase[c] = zero;
+
+        for (int b = 0; b < batch; b++)
+        {
+            for (int c = 0; c < recDim; c++) h[c] = zero;
+            for (int t = 0; t < seqLen; t++)
+            {
+                int off = (b * seqLen + t) * recDim;
+                for (int c = 0; c < recDim; c++)
+                {
+                    T a = ops.Multiply(R[off + c], baseDecay[c]);
+                    T oneMinus = ops.Subtract(one, ops.Multiply(a, a));
+                    T s = ops.GreaterThan(oneMinus, zero) ? ops.Sqrt(oneMinus) : zero;
+                    h[c] = ops.Add(ops.Multiply(a, h[c]), ops.Multiply(s, ops.Multiply(I[off + c], V[off + c])));
+                    hTraj[t * recDim + c] = h[c];
+                }
+            }
+
+            for (int c = 0; c < recDim; c++) dH[c] = zero;
+            for (int t = seqLen - 1; t >= 0; t--)
+            {
+                int off = (b * seqLen + t) * recDim;
+                for (int c = 0; c < recDim; c++)
+                {
+                    T bd = baseDecay[c];
+                    T a = ops.Multiply(R[off + c], bd);
+                    T oneMinus = ops.Subtract(one, ops.Multiply(a, a));
+                    T s = ops.GreaterThan(oneMinus, zero) ? ops.Sqrt(oneMinus) : zero;
+                    T iv = ops.Multiply(I[off + c], V[off + c]);
+                    T hPrev = t > 0 ? hTraj[(t - 1) * recDim + c] : zero;
+
+                    T dh = ops.Add(dH[c], dOut[off + c]);
+                    T dG = ops.Multiply(dh, s);
+                    dI[off + c] = ops.Add(dI[off + c], ops.Multiply(dG, V[off + c]));
+                    dV[off + c] = ops.Add(dV[off + c], ops.Multiply(dG, I[off + c]));
+
+                    T dS = ops.Multiply(dh, iv);
+                    T dA = ops.Multiply(dh, hPrev);
+                    if (ops.GreaterThan(s, tiny))
+                        dA = ops.Add(dA, ops.Multiply(dS, ops.Divide(ops.Negate(a), s)));
+
+                    dR[off + c] = ops.Add(dR[off + c], ops.Multiply(dA, bd));
+                    dBase[c] = ops.Add(dBase[c], ops.Multiply(dA, R[off + c]));
+
+                    dH[c] = ops.Multiply(dh, a);
+                }
+            }
+        }
+
+        for (int c = 0; c < recDim; c++)
+            dDecay[c] = ops.Add(dDecay[c],
+                ops.Multiply(dBase[c], ops.Negate(ops.Multiply(baseDecay[c], ops.Subtract(one, baseDecay[c])))));
+    }
+
+    private static void RgLruScanBackward<T>(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output, object[] savedState,
+        IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        var value = inputs[0];
+        var recGate = inputs[1];
+        var inpGate = inputs[2];
+        var decay = inputs[3];
+
+        int batch = value.Shape[0];
+        int seqLen = value.Shape[1];
+        int recDim = value.Shape[2];
+
+        var dV = new Tensor<T>(new[] { batch, seqLen, recDim });
+        var dR = new Tensor<T>(new[] { batch, seqLen, recDim });
+        var dI = new Tensor<T>(new[] { batch, seqLen, recDim });
+        var dDecay = new Tensor<T>(ShapeOf(decay));
+
+        if (typeof(T) == typeof(double))
+        {
+            RgLruBackwardDouble(
+                (double[])(object)gradOutput.GetDataArray()!,
+                (double[])(object)value.GetDataArray()!, (double[])(object)recGate.GetDataArray()!,
+                (double[])(object)inpGate.GetDataArray()!, (double[])(object)decay.GetDataArray()!,
+                (double[])(object)dV.GetDataArray()!, (double[])(object)dR.GetDataArray()!,
+                (double[])(object)dI.GetDataArray()!, (double[])(object)dDecay.GetDataArray()!,
+                batch, seqLen, recDim);
+        }
+        else
+        {
+            RgLruBackwardGeneric<T>(
+                gradOutput.GetDataArray()!,
+                value.GetDataArray()!, recGate.GetDataArray()!, inpGate.GetDataArray()!,
+                decay.GetDataArray()!,
+                dV.GetDataArray()!, dR.GetDataArray()!, dI.GetDataArray()!, dDecay.GetDataArray()!,
+                batch, seqLen, recDim);
+        }
+
+        DifferentiableOps.AccumulateGrad(grads, value, dV, engine);
+        DifferentiableOps.AccumulateGrad(grads, recGate, dR, engine);
+        DifferentiableOps.AccumulateGrad(grads, inpGate, dI, engine);
+        DifferentiableOps.AccumulateGrad(grads, decay, dDecay, engine);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.Rwkv4Wkv.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.Rwkv4Wkv.cs
@@ -1,0 +1,469 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.Interfaces;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines;
+
+public partial class CpuEngine
+{
+    /// <summary>
+    /// Fused RWKV-4 time-mixing WKV recurrence over a whole sequence in a SINGLE op
+    /// (forward + custom autodiff backward), replacing the ~12 per-timestep tape micro-ops the
+    /// decomposed <c>RWKVLayer.TimeMixingForward</c> loop records — the dominant training cost on
+    /// long sequences (issue ooples/AiDotNet#1464). The projected receptance/key/value streams
+    /// <c>[batch, seqLen, modelDim]</c> are produced by the caller (tape-connected GEMMs); this op
+    /// applies the per-position receptance sigmoid internally so the recurrence and its adjoint
+    /// never touch the tape per step.
+    ///
+    /// <para>Paper-faithful RWKV-4 WKV (Peng et al. 2023), the official numerically-stable kernel:
+    /// per-CHANNEL scalar state (<c>aa</c> = weighted value sum, <c>bb</c> = weight sum) with a
+    /// running max <c>pp</c> so the exponentials never overflow. <c>w[c] = -exp(timeDecay[c])</c>
+    /// (the learned static per-channel decay, &lt; 0) and <c>u[c] = timeFirst[c]</c> (the learned
+    /// per-channel bonus) are input-independent. For each channel c, with aa=bb=0, pp=-inf:</para>
+    /// <code>
+    ///   ww = u + k_t;  q = max(pp, ww);  e1 = e^{pp-q};  e2 = e^{ww-q}
+    ///   wkv_t = (e1*aa + e2*v_t) / (e1*bb + e2)
+    ///   out_t = sigmoid(r_t) * wkv_t
+    ///   ww2 = pp + w;  q2 = max(ww2, k_t);  e1b = e^{ww2-q2};  e2b = e^{k_t-q2}
+    ///   aa <- e1b*aa + e2b*v_t;  bb <- e1b*bb + e2b;  pp <- q2
+    /// </code>
+    /// <para>Backward: the running max (<c>q</c>, <c>q2</c>/<c>pp</c>) is a pure stabilizer — it
+    /// multiplies numerator and denominator identically and cancels in every ratio, so its gradient
+    /// contribution is exactly zero. We therefore treat the max outputs as constants (stop-gradient)
+    /// and run clean BPTT through the <c>aa</c>/<c>bb</c> recurrence. This yields the exact gradient
+    /// of the (mathematically max-invariant) WKV function, matching the per-timestep tape result.</para>
+    /// </summary>
+    /// <param name="rProj">Receptance projection [batch, seqLen, modelDim] (pre-sigmoid).</param>
+    /// <param name="kProj">Key projection [batch, seqLen, modelDim].</param>
+    /// <param name="vProj">Value projection [batch, seqLen, modelDim].</param>
+    /// <param name="timeDecay">Per-channel decay parameter [modelDim] (raw; the kernel applies w = -exp(timeDecay)).</param>
+    /// <param name="timeFirst">Per-channel bonus parameter [modelDim] (u, applied directly).</param>
+    /// <returns>The gated WKV output [batch, seqLen, modelDim] (before the output projection).</returns>
+    public virtual Tensor<T> Rwkv4WkvForward<T>(
+        Tensor<T> rProj, Tensor<T> kProj, Tensor<T> vProj, Tensor<T> timeDecay, Tensor<T> timeFirst)
+    {
+        if (rProj is null) throw new ArgumentNullException(nameof(rProj));
+        if (kProj is null) throw new ArgumentNullException(nameof(kProj));
+        if (vProj is null) throw new ArgumentNullException(nameof(vProj));
+        if (timeDecay is null) throw new ArgumentNullException(nameof(timeDecay));
+        if (timeFirst is null) throw new ArgumentNullException(nameof(timeFirst));
+        if (rProj.Rank != 3)
+            throw new ArgumentException($"Rwkv4WkvForward expects rank-3 inputs [batch, seqLen, modelDim]; got rank {rProj.Rank}.", nameof(rProj));
+
+        int batch = rProj.Shape[0];
+        int seqLen = rProj.Shape[1];
+        int modelDim = rProj.Shape[2];
+
+        EnsureSameShape(rProj, kProj, nameof(kProj));
+        EnsureSameShape(rProj, vProj, nameof(vProj));
+        if (timeDecay.Length != modelDim)
+            throw new ArgumentException($"timeDecay length ({timeDecay.Length}) must equal modelDim ({modelDim}).", nameof(timeDecay));
+        if (timeFirst.Length != modelDim)
+            throw new ArgumentException($"timeFirst length ({timeFirst.Length}) must equal modelDim ({modelDim}).", nameof(timeFirst));
+
+        var output = new Tensor<T>(new[] { batch, seqLen, modelDim });
+
+        if (typeof(T) == typeof(double))
+        {
+            Rwkv4ForwardDouble(
+                (double[])(object)rProj.GetDataArray()!, (double[])(object)kProj.GetDataArray()!,
+                (double[])(object)vProj.GetDataArray()!, (double[])(object)timeDecay.GetDataArray()!,
+                (double[])(object)timeFirst.GetDataArray()!, (double[])(object)output.GetDataArray()!,
+                batch, seqLen, modelDim);
+        }
+        else
+        {
+            Rwkv4ForwardGeneric<T>(
+                rProj.GetDataArray()!, kProj.GetDataArray()!, vProj.GetDataArray()!,
+                timeDecay.GetDataArray()!, timeFirst.GetDataArray()!, output.GetDataArray()!,
+                batch, seqLen, modelDim);
+        }
+
+        // Record ONE tape node for the whole recurrence with a custom BPTT backward.
+        DifferentiableOps.RecordIfActive<T>(
+            "Rwkv4Wkv", output,
+            new[] { rProj, kProj, vProj, timeDecay, timeFirst },
+            Rwkv4WkvBackward<T>,
+            savedState: null);
+
+        return output;
+    }
+
+    // ── Double fast path ─────────────────────────────────────────────────────────────────
+    private static void Rwkv4ForwardDouble(
+        double[] R, double[] K, double[] V, double[] timeDecay, double[] timeFirst, double[] outp,
+        int batch, int seqLen, int modelDim)
+    {
+        var w = new double[modelDim];
+        for (int c = 0; c < modelDim; c++) w[c] = -Math.Exp(timeDecay[c]);
+        // u = timeFirst (used directly).
+
+        var aa = new double[modelDim];
+        var bb = new double[modelDim];
+        var pp = new double[modelDim];
+        for (int b = 0; b < batch; b++)
+        {
+            Array.Clear(aa, 0, modelDim);
+            Array.Clear(bb, 0, modelDim);
+            for (int c = 0; c < modelDim; c++) pp[c] = double.NegativeInfinity;
+            for (int t = 0; t < seqLen; t++)
+            {
+                int baseOff = (b * seqLen + t) * modelDim;
+                for (int c = 0; c < modelDim; c++)
+                {
+                    double k = K[baseOff + c];
+                    double v = V[baseOff + c];
+                    double u = timeFirst[c];
+
+                    // Output for token t (current key boosted by the time-first bonus u).
+                    double ww = u + k;
+                    double q = Math.Max(pp[c], ww);
+                    double e1 = Math.Exp(pp[c] - q);
+                    double e2 = Math.Exp(ww - q);
+                    double wkv = (e1 * aa[c] + e2 * v) / (e1 * bb[c] + e2);
+                    outp[baseOff + c] = Sig(R[baseOff + c]) * wkv;
+
+                    // State update with the static decay w (no bonus on the carried state).
+                    double ww2 = pp[c] + w[c];
+                    double q2 = Math.Max(ww2, k);
+                    double e1b = Math.Exp(ww2 - q2);
+                    double e2b = Math.Exp(k - q2);
+                    aa[c] = e1b * aa[c] + e2b * v;
+                    bb[c] = e1b * bb[c] + e2b;
+                    pp[c] = q2;
+                }
+            }
+        }
+    }
+
+    private static void Rwkv4BackwardDouble(
+        double[] dOut, double[] R, double[] K, double[] V, double[] timeDecay, double[] timeFirst,
+        double[] dR, double[] dK, double[] dV, double[] dTimeDecay, double[] dTimeFirst,
+        int batch, int seqLen, int modelDim)
+    {
+        var w = new double[modelDim];
+        for (int c = 0; c < modelDim; c++) w[c] = -Math.Exp(timeDecay[c]);
+
+        // Post-update state trajectories for every t (reused per batch).
+        var aaTraj = new double[seqLen * modelDim];
+        var bbTraj = new double[seqLen * modelDim];
+        var ppTraj = new double[seqLen * modelDim];
+        var aa = new double[modelDim];
+        var bb = new double[modelDim];
+        var pp = new double[modelDim];
+        var dAa = new double[modelDim];
+        var dBb = new double[modelDim];
+        // dw accumulates the grad of w[c] = -exp(timeDecay[c]); converted to dTimeDecay at the end.
+        var dw = new double[modelDim];
+
+        for (int b = 0; b < batch; b++)
+        {
+            // Forward recompute, saving the post-update state trajectory.
+            Array.Clear(aa, 0, modelDim);
+            Array.Clear(bb, 0, modelDim);
+            for (int c = 0; c < modelDim; c++) pp[c] = double.NegativeInfinity;
+            for (int t = 0; t < seqLen; t++)
+            {
+                int baseOff = (b * seqLen + t) * modelDim;
+                int tOff = t * modelDim;
+                for (int c = 0; c < modelDim; c++)
+                {
+                    double k = K[baseOff + c];
+                    double v = V[baseOff + c];
+                    double ww2 = pp[c] + w[c];
+                    double q2 = Math.Max(ww2, k);
+                    double e1b = Math.Exp(ww2 - q2);
+                    double e2b = Math.Exp(k - q2);
+                    aa[c] = e1b * aa[c] + e2b * v;
+                    bb[c] = e1b * bb[c] + e2b;
+                    pp[c] = q2;
+                    aaTraj[tOff + c] = aa[c];
+                    bbTraj[tOff + c] = bb[c];
+                    ppTraj[tOff + c] = pp[c];
+                }
+            }
+
+            // Reverse sweep. dAa/dBb carry the adjoint of the post-update state from t+1.
+            Array.Clear(dAa, 0, modelDim);
+            Array.Clear(dBb, 0, modelDim);
+            for (int t = seqLen - 1; t >= 0; t--)
+            {
+                int baseOff = (b * seqLen + t) * modelDim;
+                for (int c = 0; c < modelDim; c++)
+                {
+                    double k = K[baseOff + c];
+                    double v = V[baseOff + c];
+                    double u = timeFirst[c];
+
+                    // Pre-update state entering step t (post-update state of t-1).
+                    double aaPrev = t > 0 ? aaTraj[(t - 1) * modelDim + c] : 0.0;
+                    double bbPrev = t > 0 ? bbTraj[(t - 1) * modelDim + c] : 0.0;
+                    double ppPrev = t > 0 ? ppTraj[(t - 1) * modelDim + c] : double.NegativeInfinity;
+                    double ppCur = ppTraj[t * modelDim + c];
+
+                    // Output recompute (q, pp treated as constants).
+                    double ww = u + k;
+                    double q = Math.Max(ppPrev, ww);
+                    double e1 = Math.Exp(ppPrev - q);
+                    double e2 = Math.Exp(ww - q);
+                    double den = e1 * bbPrev + e2;
+                    double num = e1 * aaPrev + e2 * v;
+                    double wkv = num / den;
+                    double sr = Sig(R[baseOff + c]);
+
+                    // Output backward: out = sr * wkv.
+                    double dO = dOut[baseOff + c];
+                    dR[baseOff + c] += dO * wkv * sr * (1.0 - sr);
+                    double gWkv = dO * sr;
+                    double dNum = gWkv / den;
+                    double dDen = -gWkv * wkv / den;
+                    // num = e1*aaPrev + e2*v ; den = e1*bbPrev + e2 (e1 constant in pp).
+                    double dAaFromOut = dNum * e1;
+                    double dBbFromOut = dDen * e1;
+                    dV[baseOff + c] += dNum * e2;
+                    double dE2 = dNum * v + dDen;          // e2 = exp(u + k - q)
+                    dK[baseOff + c] += dE2 * e2;            // de2/dk = e2
+                    dTimeFirst[c] += dE2 * e2;              // de2/du = e2
+
+                    // State-update recompute (ww2, q2=ppCur constants).
+                    double ww2 = ppPrev + w[c];
+                    double e1b = Math.Exp(ww2 - ppCur);
+                    double e2b = Math.Exp(k - ppCur);
+
+                    // State-update backward: aa_t = e1b*aaPrev + e2b*v ; bb_t = e1b*bbPrev + e2b.
+                    double dAt = dAa[c];
+                    double dBt = dBb[c];
+                    double dE1b = dAt * aaPrev + dBt * bbPrev;   // e1b = exp(ppPrev + w - ppCur)
+                    dw[c] += dE1b * e1b;                          // de1b/dw = e1b
+                    dV[baseOff + c] += dAt * e2b;
+                    double dE2b = dAt * v + dBt;                 // e2b = exp(k - ppCur)
+                    dK[baseOff + c] += dE2b * e2b;                // de2b/dk = e2b
+
+                    // Adjoint flowing to the pre-update state (for step t-1): from the update
+                    // (e1b factor) and from this step's output (e1 factor).
+                    dAa[c] = dAt * e1b + dAaFromOut;
+                    dBb[c] = dBt * e1b + dBbFromOut;
+                }
+            }
+        }
+
+        // Chain w = -exp(timeDecay) -> dTimeDecay = dw * dw/dTimeDecay = dw * (-exp(timeDecay)) = dw * w.
+        for (int c = 0; c < modelDim; c++)
+            dTimeDecay[c] += dw[c] * w[c];
+    }
+
+    // ── Generic-T path (correct for any numeric T; used for non-double) ──────────────────
+    private static void Rwkv4ForwardGeneric<T>(
+        T[] R, T[] K, T[] V, T[] timeDecay, T[] timeFirst, T[] outp,
+        int batch, int seqLen, int modelDim)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        var w = new T[modelDim];
+        for (int c = 0; c < modelDim; c++) w[c] = ops.Negate(ops.Exp(timeDecay[c]));
+        T negInf = ops.FromDouble(-1e38);
+
+        var aa = new T[modelDim];
+        var bb = new T[modelDim];
+        var pp = new T[modelDim];
+        for (int b = 0; b < batch; b++)
+        {
+            for (int c = 0; c < modelDim; c++) { aa[c] = ops.Zero; bb[c] = ops.Zero; pp[c] = negInf; }
+            for (int t = 0; t < seqLen; t++)
+            {
+                int baseOff = (b * seqLen + t) * modelDim;
+                for (int c = 0; c < modelDim; c++)
+                {
+                    T k = K[baseOff + c];
+                    T v = V[baseOff + c];
+                    T ww = ops.Add(timeFirst[c], k);
+                    T q = MaxT(ops, pp[c], ww);
+                    T e1 = ops.Exp(ops.Subtract(pp[c], q));
+                    T e2 = ops.Exp(ops.Subtract(ww, q));
+                    T wkv = ops.Divide(
+                        ops.Add(ops.Multiply(e1, aa[c]), ops.Multiply(e2, v)),
+                        ops.Add(ops.Multiply(e1, bb[c]), e2));
+                    outp[baseOff + c] = ops.Multiply(SigGeneric(ops, R[baseOff + c]), wkv);
+
+                    T ww2 = ops.Add(pp[c], w[c]);
+                    T q2 = MaxT(ops, ww2, k);
+                    T e1b = ops.Exp(ops.Subtract(ww2, q2));
+                    T e2b = ops.Exp(ops.Subtract(k, q2));
+                    aa[c] = ops.Add(ops.Multiply(e1b, aa[c]), ops.Multiply(e2b, v));
+                    bb[c] = ops.Add(ops.Multiply(e1b, bb[c]), e2b);
+                    pp[c] = q2;
+                }
+            }
+        }
+    }
+
+    private static void Rwkv4BackwardGeneric<T>(
+        T[] dOut, T[] R, T[] K, T[] V, T[] timeDecay, T[] timeFirst,
+        T[] dR, T[] dK, T[] dV, T[] dTimeDecay, T[] dTimeFirst,
+        int batch, int seqLen, int modelDim)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        T one = ops.One;
+        var w = new T[modelDim];
+        for (int c = 0; c < modelDim; c++) w[c] = ops.Negate(ops.Exp(timeDecay[c]));
+        T negInf = ops.FromDouble(-1e38);
+
+        var aaTraj = new T[seqLen * modelDim];
+        var bbTraj = new T[seqLen * modelDim];
+        var ppTraj = new T[seqLen * modelDim];
+        var aa = new T[modelDim];
+        var bb = new T[modelDim];
+        var pp = new T[modelDim];
+        var dAa = new T[modelDim];
+        var dBb = new T[modelDim];
+        var dw = new T[modelDim];
+        for (int c = 0; c < modelDim; c++) dw[c] = ops.Zero;
+
+        for (int b = 0; b < batch; b++)
+        {
+            for (int c = 0; c < modelDim; c++) { aa[c] = ops.Zero; bb[c] = ops.Zero; pp[c] = negInf; }
+            for (int t = 0; t < seqLen; t++)
+            {
+                int baseOff = (b * seqLen + t) * modelDim;
+                int tOff = t * modelDim;
+                for (int c = 0; c < modelDim; c++)
+                {
+                    T k = K[baseOff + c];
+                    T v = V[baseOff + c];
+                    T ww2 = ops.Add(pp[c], w[c]);
+                    T q2 = MaxT(ops, ww2, k);
+                    T e1b = ops.Exp(ops.Subtract(ww2, q2));
+                    T e2b = ops.Exp(ops.Subtract(k, q2));
+                    aa[c] = ops.Add(ops.Multiply(e1b, aa[c]), ops.Multiply(e2b, v));
+                    bb[c] = ops.Add(ops.Multiply(e1b, bb[c]), e2b);
+                    pp[c] = q2;
+                    aaTraj[tOff + c] = aa[c];
+                    bbTraj[tOff + c] = bb[c];
+                    ppTraj[tOff + c] = pp[c];
+                }
+            }
+
+            for (int c = 0; c < modelDim; c++) { dAa[c] = ops.Zero; dBb[c] = ops.Zero; }
+            for (int t = seqLen - 1; t >= 0; t--)
+            {
+                int baseOff = (b * seqLen + t) * modelDim;
+                for (int c = 0; c < modelDim; c++)
+                {
+                    T k = K[baseOff + c];
+                    T v = V[baseOff + c];
+                    T aaPrev = t > 0 ? aaTraj[(t - 1) * modelDim + c] : ops.Zero;
+                    T bbPrev = t > 0 ? bbTraj[(t - 1) * modelDim + c] : ops.Zero;
+                    T ppPrev = t > 0 ? ppTraj[(t - 1) * modelDim + c] : negInf;
+                    T ppCur = ppTraj[t * modelDim + c];
+
+                    T ww = ops.Add(timeFirst[c], k);
+                    T q = MaxT(ops, ppPrev, ww);
+                    T e1 = ops.Exp(ops.Subtract(ppPrev, q));
+                    T e2 = ops.Exp(ops.Subtract(ww, q));
+                    T den = ops.Add(ops.Multiply(e1, bbPrev), e2);
+                    T num = ops.Add(ops.Multiply(e1, aaPrev), ops.Multiply(e2, v));
+                    T wkv = ops.Divide(num, den);
+                    T sr = SigGeneric(ops, R[baseOff + c]);
+
+                    T dO = dOut[baseOff + c];
+                    dR[baseOff + c] = ops.Add(dR[baseOff + c],
+                        ops.Multiply(ops.Multiply(dO, wkv), ops.Multiply(sr, ops.Subtract(one, sr))));
+                    T gWkv = ops.Multiply(dO, sr);
+                    T dNum = ops.Divide(gWkv, den);
+                    T dDen = ops.Divide(ops.Negate(ops.Multiply(gWkv, wkv)), den);
+                    T dAaFromOut = ops.Multiply(dNum, e1);
+                    T dBbFromOut = ops.Multiply(dDen, e1);
+                    dV[baseOff + c] = ops.Add(dV[baseOff + c], ops.Multiply(dNum, e2));
+                    T dE2 = ops.Add(ops.Multiply(dNum, v), dDen);
+                    dK[baseOff + c] = ops.Add(dK[baseOff + c], ops.Multiply(dE2, e2));
+                    dTimeFirst[c] = ops.Add(dTimeFirst[c], ops.Multiply(dE2, e2));
+
+                    T ww2 = ops.Add(ppPrev, w[c]);
+                    T e1b = ops.Exp(ops.Subtract(ww2, ppCur));
+                    T e2b = ops.Exp(ops.Subtract(k, ppCur));
+                    T dAt = dAa[c];
+                    T dBt = dBb[c];
+                    T dE1b = ops.Add(ops.Multiply(dAt, aaPrev), ops.Multiply(dBt, bbPrev));
+                    dw[c] = ops.Add(dw[c], ops.Multiply(dE1b, e1b));
+                    dV[baseOff + c] = ops.Add(dV[baseOff + c], ops.Multiply(dAt, e2b));
+                    T dE2b = ops.Add(ops.Multiply(dAt, v), dBt);
+                    dK[baseOff + c] = ops.Add(dK[baseOff + c], ops.Multiply(dE2b, e2b));
+
+                    dAa[c] = ops.Add(ops.Multiply(dAt, e1b), dAaFromOut);
+                    dBb[c] = ops.Add(ops.Multiply(dBt, e1b), dBbFromOut);
+                }
+            }
+        }
+
+        for (int c = 0; c < modelDim; c++)
+            dTimeDecay[c] = ops.Add(dTimeDecay[c], ops.Multiply(dw[c], w[c]));
+    }
+
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+    private static T MaxT<T>(INumericOperations<T> ops, T a, T b)
+        => ops.GreaterThan(a, b) ? a : b;
+
+    private static int[] ShapeOf<T>(Tensor<T> t)
+    {
+        var s = new int[t.Rank];
+        for (int i = 0; i < t.Rank; i++) s[i] = t.Shape[i];
+        return s;
+    }
+
+    private static void Rwkv4WkvBackward<T>(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output, object[] savedState,
+        IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        var rProj = inputs[0];
+        var kProj = inputs[1];
+        var vProj = inputs[2];
+        var timeDecay = inputs[3];
+        var timeFirst = inputs[4];
+
+        int batch = rProj.Shape[0];
+        int seqLen = rProj.Shape[1];
+        int modelDim = rProj.Shape[2];
+
+        var dR = new Tensor<T>(new[] { batch, seqLen, modelDim });
+        var dK = new Tensor<T>(new[] { batch, seqLen, modelDim });
+        var dV = new Tensor<T>(new[] { batch, seqLen, modelDim });
+        // Allocate the per-channel param grads with the SAME shape as the inputs
+        // (timeDecay is [modelDim]; timeFirst may be [numHeads, headDim] — same
+        // flat length, different rank) so AccumulateGrad shape-matches. The
+        // kernels index purely by flat channel c, so the backing array layout
+        // is identical regardless of rank.
+        var dTimeDecay = new Tensor<T>(ShapeOf(timeDecay));
+        var dTimeFirst = new Tensor<T>(ShapeOf(timeFirst));
+
+        if (typeof(T) == typeof(double))
+        {
+            Rwkv4BackwardDouble(
+                (double[])(object)gradOutput.GetDataArray()!,
+                (double[])(object)rProj.GetDataArray()!, (double[])(object)kProj.GetDataArray()!,
+                (double[])(object)vProj.GetDataArray()!, (double[])(object)timeDecay.GetDataArray()!,
+                (double[])(object)timeFirst.GetDataArray()!,
+                (double[])(object)dR.GetDataArray()!, (double[])(object)dK.GetDataArray()!,
+                (double[])(object)dV.GetDataArray()!, (double[])(object)dTimeDecay.GetDataArray()!,
+                (double[])(object)dTimeFirst.GetDataArray()!,
+                batch, seqLen, modelDim);
+        }
+        else
+        {
+            Rwkv4BackwardGeneric<T>(
+                gradOutput.GetDataArray()!,
+                rProj.GetDataArray()!, kProj.GetDataArray()!, vProj.GetDataArray()!,
+                timeDecay.GetDataArray()!, timeFirst.GetDataArray()!,
+                dR.GetDataArray()!, dK.GetDataArray()!, dV.GetDataArray()!,
+                dTimeDecay.GetDataArray()!, dTimeFirst.GetDataArray()!,
+                batch, seqLen, modelDim);
+        }
+
+        DifferentiableOps.AccumulateGrad(grads, rProj, dR, engine);
+        DifferentiableOps.AccumulateGrad(grads, kProj, dK, engine);
+        DifferentiableOps.AccumulateGrad(grads, vProj, dV, engine);
+        DifferentiableOps.AccumulateGrad(grads, timeDecay, dTimeDecay, engine);
+        DifferentiableOps.AccumulateGrad(grads, timeFirst, dTimeFirst, engine);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.Rwkv7Sequence.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.Rwkv7Sequence.cs
@@ -97,6 +97,13 @@ public partial class CpuEngine
                 throw new ArgumentException($"{paramName} dim {i} ({other.Shape[i]}) must match ({reference.Shape[i]}).", paramName);
     }
 
+    // Validates a scalar-per-head gate tensor shaped [batch, seqLen, numHeads].
+    private static void EnsureGateShape<T>(Tensor<T> gate, int batch, int seqLen, int numHeads, string paramName)
+    {
+        if (gate.Rank != 3 || gate.Shape[0] != batch || gate.Shape[1] != seqLen || gate.Shape[2] != numHeads)
+            throw new ArgumentException($"{paramName} must be [batch={batch}, seqLen={seqLen}, numHeads={numHeads}].", paramName);
+    }
+
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
     private static double Sig(double x) => 1.0 / (1.0 + Math.Exp(-x));
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.XLstmScan.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.XLstmScan.cs
@@ -1,0 +1,527 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.Interfaces;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines;
+
+public partial class CpuEngine
+{
+    private const double XLstmIGateClamp = 4.85e8; // exp(20) overflow guard on the exponential input gate.
+
+    /// <summary>
+    /// Fused xLSTM (mLSTM) matrix-memory recurrence over a whole sequence in a SINGLE op
+    /// (forward + custom autodiff backward), replacing the per-element detached scalar loop the
+    /// decomposed <c>ExtendedLSTMLayer</c> ran — both slow AND detached from the autodiff tape
+    /// (issue ooples/AiDotNet#1464). Per head, key scale κ = 1/sqrt(headDim), scalar-per-head gates
+    /// i (exp input), f (sigmoid forget), o (sigmoid output), matrix cell C and normalizer n at 0:
+    /// <code>
+    ///   kS[j] = κ * K_t[j]
+    ///   n_t[di]    = f_t * n_{t-1}[di] + i_t * kS[di]
+    ///   C_t[di,ki] = f_t * C_{t-1}[di,ki] + i_t * V_t[di] * kS[ki]
+    ///   num[di]    = sum_ki C_t[di,ki] * Q_t[ki]
+    ///   nf         = max(|sum_j n_t[j] * Q_t[j]|, 1)
+    ///   h_t[di]    = o_t * num[di] / nf
+    /// </code>
+    /// The gates are passed post-activation (i = exp(...), f/o = sigmoid(...)); the op uses the per-head
+    /// first element as the scalar gate (and clamps i to <see cref="XLstmIGateClamp"/>). Records one
+    /// differentiable tape node (the BPTT adjoint), so it is safe under an active <c>GradientTape</c>.
+    /// </summary>
+    /// <param name="qProj">Query projection [batch, seqLen, modelDim].</param>
+    /// <param name="kProj">Key projection [batch, seqLen, modelDim] (scaled by 1/sqrt(headDim) internally).</param>
+    /// <param name="vProj">Value projection [batch, seqLen, modelDim].</param>
+    /// <param name="iGate">Post-exp input gate [batch, seqLen, modelDim] (per-head first element used).</param>
+    /// <param name="fGate">Post-sigmoid forget gate [batch, seqLen, modelDim] (per-head first element used).</param>
+    /// <param name="oGate">Post-sigmoid output gate [batch, seqLen, modelDim] (per-head first element used).</param>
+    /// <param name="numHeads">Number of heads; modelDim must be divisible by it.</param>
+    /// <returns>The pre-output-projection hidden state [batch, seqLen, modelDim].</returns>
+    public virtual Tensor<T> XLstmScanForward<T>(
+        Tensor<T> qProj, Tensor<T> kProj, Tensor<T> vProj,
+        Tensor<T> iGate, Tensor<T> fGate, Tensor<T> oGate, int numHeads)
+    {
+        if (qProj is null) throw new ArgumentNullException(nameof(qProj));
+        if (kProj is null) throw new ArgumentNullException(nameof(kProj));
+        if (vProj is null) throw new ArgumentNullException(nameof(vProj));
+        if (iGate is null) throw new ArgumentNullException(nameof(iGate));
+        if (fGate is null) throw new ArgumentNullException(nameof(fGate));
+        if (oGate is null) throw new ArgumentNullException(nameof(oGate));
+        if (numHeads < 1) throw new ArgumentOutOfRangeException(nameof(numHeads));
+        if (qProj.Rank != 3)
+            throw new ArgumentException($"XLstmScanForward expects rank-3 inputs [batch, seqLen, modelDim]; got rank {qProj.Rank}.", nameof(qProj));
+
+        int batch = qProj.Shape[0];
+        int seqLen = qProj.Shape[1];
+        int modelDim = qProj.Shape[2];
+        if (modelDim % numHeads != 0)
+            throw new ArgumentException($"modelDim ({modelDim}) must be divisible by numHeads ({numHeads}).", nameof(numHeads));
+        int headDim = modelDim / numHeads;
+        EnsureSameShape(qProj, kProj, nameof(kProj));
+        EnsureSameShape(qProj, vProj, nameof(vProj));
+        EnsureSameShape(qProj, iGate, nameof(iGate));
+        EnsureSameShape(qProj, fGate, nameof(fGate));
+        EnsureSameShape(qProj, oGate, nameof(oGate));
+
+        var output = new Tensor<T>(new[] { batch, seqLen, modelDim });
+
+        if (typeof(T) == typeof(double))
+        {
+            XLstmForwardDouble(
+                (double[])(object)qProj.GetDataArray()!, (double[])(object)kProj.GetDataArray()!,
+                (double[])(object)vProj.GetDataArray()!, (double[])(object)iGate.GetDataArray()!,
+                (double[])(object)fGate.GetDataArray()!, (double[])(object)oGate.GetDataArray()!,
+                (double[])(object)output.GetDataArray()!, batch, seqLen, modelDim, numHeads, headDim);
+        }
+        else
+        {
+            XLstmForwardGeneric<T>(
+                qProj.GetDataArray()!, kProj.GetDataArray()!, vProj.GetDataArray()!,
+                iGate.GetDataArray()!, fGate.GetDataArray()!, oGate.GetDataArray()!,
+                output.GetDataArray()!, batch, seqLen, modelDim, numHeads, headDim);
+        }
+
+        DifferentiableOps.RecordIfActive<T>(
+            "XLstmScan", output,
+            new[] { qProj, kProj, vProj, iGate, fGate, oGate },
+            XLstmScanBackward<T>,
+            savedState: new object[] { numHeads });
+
+        return output;
+    }
+
+    // ── Double fast path ─────────────────────────────────────────────────────────────────
+    private static void XLstmForwardDouble(
+        double[] Q, double[] K, double[] V, double[] I, double[] F, double[] O, double[] outp,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        int hh = headDim * headDim;
+        double kappa = 1.0 / Math.Sqrt(headDim);
+        var C = new double[hh];
+        var n = new double[headDim];
+        for (int b = 0; b < batch; b++)
+        {
+            for (int h = 0; h < numHeads; h++)
+            {
+                Array.Clear(C, 0, hh);
+                Array.Clear(n, 0, headDim);
+                int hOff = h * headDim;
+                for (int t = 0; t < seqLen; t++)
+                {
+                    int baseOff = (b * seqLen + t) * modelDim + hOff;
+                    double iv = I[baseOff]; if (iv > XLstmIGateClamp) iv = XLstmIGateClamp;
+                    double f = F[baseOff], o = O[baseOff];
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        double kSdi = K[baseOff + di] * kappa;
+                        n[di] = f * n[di] + iv * kSdi;
+                        double vv = V[baseOff + di];
+                        int srow = di * headDim;
+                        for (int ki = 0; ki < headDim; ki++)
+                            C[srow + ki] = f * C[srow + ki] + iv * vv * (K[baseOff + ki] * kappa);
+                    }
+                    double nq = 0.0;
+                    for (int j = 0; j < headDim; j++) nq += n[j] * Q[baseOff + j];
+                    double nf = Math.Abs(nq); if (nf < 1.0) nf = 1.0;
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int srow = di * headDim;
+                        double num = 0.0;
+                        for (int ki = 0; ki < headDim; ki++) num += C[srow + ki] * Q[baseOff + ki];
+                        outp[baseOff + di] = o * num / nf;
+                    }
+                }
+            }
+        }
+    }
+
+    private static void XLstmBackwardDouble(
+        double[] dOut, double[] Q, double[] K, double[] V, double[] I, double[] F, double[] O,
+        double[] dQ, double[] dK, double[] dV, double[] dI, double[] dF, double[] dO,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        int hh = headDim * headDim;
+        double kappa = 1.0 / Math.Sqrt(headDim);
+        var Ctraj = new double[seqLen * hh];        // pre-update C entering step t
+        var ntraj = new double[seqLen * headDim];   // pre-update n entering step t
+        var C = new double[hh];
+        var n = new double[headDim];
+        var dC = new double[hh];
+        var dN = new double[headDim];
+        var dKS = new double[headDim];
+
+        for (int b = 0; b < batch; b++)
+        {
+            for (int h = 0; h < numHeads; h++)
+            {
+                int hOff = h * headDim;
+
+                // Forward recompute, saving the pre-update C/n entering each step.
+                Array.Clear(C, 0, hh); Array.Clear(n, 0, headDim);
+                for (int t = 0; t < seqLen; t++)
+                {
+                    Array.Copy(C, 0, Ctraj, t * hh, hh);
+                    Array.Copy(n, 0, ntraj, t * headDim, headDim);
+                    int baseOff = (b * seqLen + t) * modelDim + hOff;
+                    double iv = I[baseOff]; if (iv > XLstmIGateClamp) iv = XLstmIGateClamp;
+                    double f = F[baseOff];
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        n[di] = f * n[di] + iv * (K[baseOff + di] * kappa);
+                        double vv = V[baseOff + di];
+                        int srow = di * headDim;
+                        for (int ki = 0; ki < headDim; ki++)
+                            C[srow + ki] = f * C[srow + ki] + iv * vv * (K[baseOff + ki] * kappa);
+                    }
+                }
+
+                // Reverse sweep. dC/dN carry the adjoint of the POST-update state from t+1.
+                Array.Clear(dC, 0, hh); Array.Clear(dN, 0, headDim);
+                for (int t = seqLen - 1; t >= 0; t--)
+                {
+                    int baseOff = (b * seqLen + t) * modelDim + hOff;
+                    double iv = I[baseOff]; bool iClamped = iv > XLstmIGateClamp; if (iClamped) iv = XLstmIGateClamp;
+                    double f = F[baseOff], o = O[baseOff];
+                    int cpOff = t * hh, npOff = t * headDim;
+
+                    // Recompute post-update C_t, n_t, nq, nf for this step.
+                    // (Reuse C/n buffers as scratch for the post-update state.)
+                    double nq = 0.0;
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        double nCur = f * ntraj[npOff + di] + iv * (K[baseOff + di] * kappa);
+                        n[di] = nCur;
+                        nq += nCur * Q[baseOff + di];
+                    }
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        double vv = V[baseOff + di];
+                        int srow = di * headDim;
+                        for (int ki = 0; ki < headDim; ki++)
+                            C[srow + ki] = f * Ctraj[cpOff + srow + ki] + iv * vv * (K[baseOff + ki] * kappa);
+                    }
+                    double absnq = Math.Abs(nq);
+                    double nf = absnq < 1.0 ? 1.0 : absnq;
+                    double dNfSign = absnq > 1.0 ? (nq > 0 ? 1.0 : -1.0) : 0.0; // d(nf)/d(nq)
+
+                    // Output backward: h[di] = o*num[di]/nf, num[di] = sum_ki C_t[di,ki]*Q[ki].
+                    double dO_acc = 0.0, dnf = 0.0;
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int srow = di * headDim;
+                        double dh = dOut[baseOff + di];
+                        double num = 0.0;
+                        for (int ki = 0; ki < headDim; ki++) num += C[srow + ki] * Q[baseOff + ki];
+                        dO_acc += dh * num / nf;
+                        double dNum = dh * o / nf;
+                        dnf += dh * o * num * (-1.0 / (nf * nf));
+                        for (int ki = 0; ki < headDim; ki++)
+                        {
+                            dC[srow + ki] += dNum * Q[baseOff + ki];
+                            dQ[baseOff + ki] += dNum * C[srow + ki];
+                        }
+                    }
+                    dO[baseOff] += dO_acc;
+
+                    // nf = max(|nq|,1); nq = sum_j n_t[j]*Q[j].
+                    double dnq = dnf * dNfSign;
+                    for (int j = 0; j < headDim; j++)
+                    {
+                        dN[j] += dnq * Q[baseOff + j];
+                        dQ[baseOff + j] += dnq * n[j];
+                    }
+
+                    // State-update backward. dC/dN now hold the full adjoint of C_t/n_t.
+                    Array.Clear(dKS, 0, headDim);
+                    double dF_acc = 0.0, dI_acc = 0.0;
+                    // C_t[di,ki] = f*Cp[di,ki] + iv*V[di]*kS[ki].
+                    var dCp = new double[hh];
+                    var dNp = new double[headDim];
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int srow = di * headDim;
+                        double vv = V[baseOff + di];
+                        double dVacc = 0.0;
+                        for (int ki = 0; ki < headDim; ki++)
+                        {
+                            double dCt = dC[srow + ki];
+                            double kSki = K[baseOff + ki] * kappa;
+                            dF_acc += dCt * Ctraj[cpOff + srow + ki];
+                            dCp[srow + ki] = dCt * f;
+                            dI_acc += dCt * vv * kSki;
+                            dVacc += dCt * iv * kSki;
+                            dKS[ki] += dCt * iv * vv;
+                        }
+                        dV[baseOff + di] += dVacc;
+                    }
+                    // n_t[di] = f*np[di] + iv*kS[di].
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        double dNt = dN[di];
+                        dF_acc += dNt * ntraj[npOff + di];
+                        dNp[di] = dNt * f;
+                        dI_acc += dNt * (K[baseOff + di] * kappa);
+                        dKS[di] += dNt * iv;
+                    }
+                    // kS[j] = kappa*K[j].
+                    for (int j = 0; j < headDim; j++) dK[baseOff + j] += dKS[j] * kappa;
+
+                    // i gate clamp: gradient passes through only when not clamped.
+                    dI[baseOff] += iClamped ? 0.0 : dI_acc;
+                    dF[baseOff] += dF_acc;
+
+                    // Carry adjoints to the previous step.
+                    Array.Copy(dCp, 0, dC, 0, hh);
+                    Array.Copy(dNp, 0, dN, 0, headDim);
+                }
+            }
+        }
+    }
+
+    // ── Generic-T path ───────────────────────────────────────────────────────────────────
+    private static void XLstmForwardGeneric<T>(
+        T[] Q, T[] K, T[] V, T[] I, T[] F, T[] O, T[] outp,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        int hh = headDim * headDim;
+        T kappa = ops.FromDouble(1.0 / Math.Sqrt(headDim));
+        T clamp = ops.FromDouble(XLstmIGateClamp);
+        T one = ops.One;
+        var C = new T[hh];
+        var n = new T[headDim];
+        for (int b = 0; b < batch; b++)
+        {
+            for (int h = 0; h < numHeads; h++)
+            {
+                for (int i = 0; i < hh; i++) C[i] = ops.Zero;
+                for (int di = 0; di < headDim; di++) n[di] = ops.Zero;
+                int hOff = h * headDim;
+                for (int t = 0; t < seqLen; t++)
+                {
+                    int baseOff = (b * seqLen + t) * modelDim + hOff;
+                    T iv = I[baseOff]; if (ops.GreaterThan(iv, clamp)) iv = clamp;
+                    T f = F[baseOff], o = O[baseOff];
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        T kSdi = ops.Multiply(K[baseOff + di], kappa);
+                        n[di] = ops.Add(ops.Multiply(f, n[di]), ops.Multiply(iv, kSdi));
+                        T vv = V[baseOff + di];
+                        int srow = di * headDim;
+                        for (int ki = 0; ki < headDim; ki++)
+                            C[srow + ki] = ops.Add(ops.Multiply(f, C[srow + ki]),
+                                ops.Multiply(iv, ops.Multiply(vv, ops.Multiply(K[baseOff + ki], kappa))));
+                    }
+                    T nq = ops.Zero;
+                    for (int j = 0; j < headDim; j++) nq = ops.Add(nq, ops.Multiply(n[j], Q[baseOff + j]));
+                    T absnq = ops.Abs(nq);
+                    T nf = ops.GreaterThan(absnq, one) ? absnq : one;
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int srow = di * headDim;
+                        T num = ops.Zero;
+                        for (int ki = 0; ki < headDim; ki++) num = ops.Add(num, ops.Multiply(C[srow + ki], Q[baseOff + ki]));
+                        outp[baseOff + di] = ops.Divide(ops.Multiply(o, num), nf);
+                    }
+                }
+            }
+        }
+    }
+
+    private static void XLstmBackwardGeneric<T>(
+        T[] dOut, T[] Q, T[] K, T[] V, T[] I, T[] F, T[] O,
+        T[] dQ, T[] dK, T[] dV, T[] dI, T[] dF, T[] dO,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        int hh = headDim * headDim;
+        T kappa = ops.FromDouble(1.0 / Math.Sqrt(headDim));
+        T clamp = ops.FromDouble(XLstmIGateClamp);
+        T one = ops.One, zero = ops.Zero;
+        var Ctraj = new T[seqLen * hh];
+        var ntraj = new T[seqLen * headDim];
+        var C = new T[hh];
+        var n = new T[headDim];
+        var dC = new T[hh];
+        var dN = new T[headDim];
+        var dKS = new T[headDim];
+        var dCp = new T[hh];
+        var dNp = new T[headDim];
+
+        for (int b = 0; b < batch; b++)
+        {
+            for (int h = 0; h < numHeads; h++)
+            {
+                int hOff = h * headDim;
+                for (int i = 0; i < hh; i++) C[i] = zero;
+                for (int di = 0; di < headDim; di++) n[di] = zero;
+                for (int t = 0; t < seqLen; t++)
+                {
+                    Array.Copy(C, 0, Ctraj, t * hh, hh);
+                    Array.Copy(n, 0, ntraj, t * headDim, headDim);
+                    int baseOff = (b * seqLen + t) * modelDim + hOff;
+                    T iv = I[baseOff]; if (ops.GreaterThan(iv, clamp)) iv = clamp;
+                    T f = F[baseOff];
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        n[di] = ops.Add(ops.Multiply(f, n[di]), ops.Multiply(iv, ops.Multiply(K[baseOff + di], kappa)));
+                        T vv = V[baseOff + di];
+                        int srow = di * headDim;
+                        for (int ki = 0; ki < headDim; ki++)
+                            C[srow + ki] = ops.Add(ops.Multiply(f, C[srow + ki]),
+                                ops.Multiply(iv, ops.Multiply(vv, ops.Multiply(K[baseOff + ki], kappa))));
+                    }
+                }
+
+                for (int i = 0; i < hh; i++) dC[i] = zero;
+                for (int di = 0; di < headDim; di++) dN[di] = zero;
+                for (int t = seqLen - 1; t >= 0; t--)
+                {
+                    int baseOff = (b * seqLen + t) * modelDim + hOff;
+                    T iv = I[baseOff]; bool iClamped = ops.GreaterThan(iv, clamp); if (iClamped) iv = clamp;
+                    T f = F[baseOff], o = O[baseOff];
+                    int cpOff = t * hh, npOff = t * headDim;
+
+                    T nq = zero;
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        T nCur = ops.Add(ops.Multiply(f, ntraj[npOff + di]), ops.Multiply(iv, ops.Multiply(K[baseOff + di], kappa)));
+                        n[di] = nCur;
+                        nq = ops.Add(nq, ops.Multiply(nCur, Q[baseOff + di]));
+                    }
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        T vv = V[baseOff + di];
+                        int srow = di * headDim;
+                        for (int ki = 0; ki < headDim; ki++)
+                            C[srow + ki] = ops.Add(ops.Multiply(f, Ctraj[cpOff + srow + ki]),
+                                ops.Multiply(iv, ops.Multiply(vv, ops.Multiply(K[baseOff + ki], kappa))));
+                    }
+                    T absnq = ops.Abs(nq);
+                    bool over = ops.GreaterThan(absnq, one);
+                    T nf = over ? absnq : one;
+                    T dNfSign = over ? (ops.GreaterThan(nq, zero) ? one : ops.FromDouble(-1.0)) : zero;
+                    T invNf = ops.Divide(one, nf);
+                    T negInvNf2 = ops.Negate(ops.Divide(one, ops.Multiply(nf, nf)));
+
+                    T dO_acc = zero, dnf = zero;
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int srow = di * headDim;
+                        T dh = dOut[baseOff + di];
+                        T num = zero;
+                        for (int ki = 0; ki < headDim; ki++) num = ops.Add(num, ops.Multiply(C[srow + ki], Q[baseOff + ki]));
+                        dO_acc = ops.Add(dO_acc, ops.Multiply(dh, ops.Multiply(num, invNf)));
+                        T dNum = ops.Multiply(dh, ops.Multiply(o, invNf));
+                        dnf = ops.Add(dnf, ops.Multiply(ops.Multiply(dh, ops.Multiply(o, num)), negInvNf2));
+                        for (int ki = 0; ki < headDim; ki++)
+                        {
+                            dC[srow + ki] = ops.Add(dC[srow + ki], ops.Multiply(dNum, Q[baseOff + ki]));
+                            dQ[baseOff + ki] = ops.Add(dQ[baseOff + ki], ops.Multiply(dNum, C[srow + ki]));
+                        }
+                    }
+                    dO[baseOff] = ops.Add(dO[baseOff], dO_acc);
+
+                    T dnq = ops.Multiply(dnf, dNfSign);
+                    for (int j = 0; j < headDim; j++)
+                    {
+                        dN[j] = ops.Add(dN[j], ops.Multiply(dnq, Q[baseOff + j]));
+                        dQ[baseOff + j] = ops.Add(dQ[baseOff + j], ops.Multiply(dnq, n[j]));
+                    }
+
+                    for (int j = 0; j < headDim; j++) dKS[j] = zero;
+                    for (int i = 0; i < hh; i++) dCp[i] = zero;
+                    for (int di = 0; di < headDim; di++) dNp[di] = zero;
+                    T dF_acc = zero, dI_acc = zero;
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int srow = di * headDim;
+                        T vv = V[baseOff + di];
+                        T dVacc = zero;
+                        for (int ki = 0; ki < headDim; ki++)
+                        {
+                            T dCt = dC[srow + ki];
+                            T kSki = ops.Multiply(K[baseOff + ki], kappa);
+                            dF_acc = ops.Add(dF_acc, ops.Multiply(dCt, Ctraj[cpOff + srow + ki]));
+                            dCp[srow + ki] = ops.Multiply(dCt, f);
+                            dI_acc = ops.Add(dI_acc, ops.Multiply(dCt, ops.Multiply(vv, kSki)));
+                            dVacc = ops.Add(dVacc, ops.Multiply(dCt, ops.Multiply(iv, kSki)));
+                            dKS[ki] = ops.Add(dKS[ki], ops.Multiply(dCt, ops.Multiply(iv, vv)));
+                        }
+                        dV[baseOff + di] = ops.Add(dV[baseOff + di], dVacc);
+                    }
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        T dNt = dN[di];
+                        dF_acc = ops.Add(dF_acc, ops.Multiply(dNt, ntraj[npOff + di]));
+                        dNp[di] = ops.Multiply(dNt, f);
+                        dI_acc = ops.Add(dI_acc, ops.Multiply(dNt, ops.Multiply(K[baseOff + di], kappa)));
+                        dKS[di] = ops.Add(dKS[di], ops.Multiply(dNt, iv));
+                    }
+                    for (int j = 0; j < headDim; j++) dK[baseOff + j] = ops.Add(dK[baseOff + j], ops.Multiply(dKS[j], kappa));
+
+                    if (!iClamped) dI[baseOff] = ops.Add(dI[baseOff], dI_acc);
+                    dF[baseOff] = ops.Add(dF[baseOff], dF_acc);
+
+                    Array.Copy(dCp, 0, dC, 0, hh);
+                    Array.Copy(dNp, 0, dN, 0, headDim);
+                }
+            }
+        }
+    }
+
+    private static void XLstmScanBackward<T>(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output, object[] savedState,
+        IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        int numHeads = (int)savedState[0];
+        var qProj = inputs[0];
+        var kProj = inputs[1];
+        var vProj = inputs[2];
+        var iGate = inputs[3];
+        var fGate = inputs[4];
+        var oGate = inputs[5];
+
+        int batch = qProj.Shape[0];
+        int seqLen = qProj.Shape[1];
+        int modelDim = qProj.Shape[2];
+        int headDim = modelDim / numHeads;
+
+        var dQ = new Tensor<T>(new[] { batch, seqLen, modelDim });
+        var dK = new Tensor<T>(new[] { batch, seqLen, modelDim });
+        var dV = new Tensor<T>(new[] { batch, seqLen, modelDim });
+        var dI = new Tensor<T>(new[] { batch, seqLen, modelDim });
+        var dF = new Tensor<T>(new[] { batch, seqLen, modelDim });
+        var dO = new Tensor<T>(new[] { batch, seqLen, modelDim });
+
+        if (typeof(T) == typeof(double))
+        {
+            XLstmBackwardDouble(
+                (double[])(object)gradOutput.GetDataArray()!,
+                (double[])(object)qProj.GetDataArray()!, (double[])(object)kProj.GetDataArray()!,
+                (double[])(object)vProj.GetDataArray()!, (double[])(object)iGate.GetDataArray()!,
+                (double[])(object)fGate.GetDataArray()!, (double[])(object)oGate.GetDataArray()!,
+                (double[])(object)dQ.GetDataArray()!, (double[])(object)dK.GetDataArray()!,
+                (double[])(object)dV.GetDataArray()!, (double[])(object)dI.GetDataArray()!,
+                (double[])(object)dF.GetDataArray()!, (double[])(object)dO.GetDataArray()!,
+                batch, seqLen, modelDim, numHeads, headDim);
+        }
+        else
+        {
+            XLstmBackwardGeneric<T>(
+                gradOutput.GetDataArray()!,
+                qProj.GetDataArray()!, kProj.GetDataArray()!, vProj.GetDataArray()!,
+                iGate.GetDataArray()!, fGate.GetDataArray()!, oGate.GetDataArray()!,
+                dQ.GetDataArray()!, dK.GetDataArray()!, dV.GetDataArray()!,
+                dI.GetDataArray()!, dF.GetDataArray()!, dO.GetDataArray()!,
+                batch, seqLen, modelDim, numHeads, headDim);
+        }
+
+        DifferentiableOps.AccumulateGrad(grads, qProj, dQ, engine);
+        DifferentiableOps.AccumulateGrad(grads, kProj, dK, engine);
+        DifferentiableOps.AccumulateGrad(grads, vProj, dV, engine);
+        DifferentiableOps.AccumulateGrad(grads, iGate, dI, engine);
+        DifferentiableOps.AccumulateGrad(grads, fGate, dF, engine);
+        DifferentiableOps.AccumulateGrad(grads, oGate, dO, engine);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.XLstmScan.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.XLstmScan.cs
@@ -25,16 +25,16 @@ public partial class CpuEngine
     ///   nf         = max(|sum_j n_t[j] * Q_t[j]|, 1)
     ///   h_t[di]    = o_t * num[di] / nf
     /// </code>
-    /// The gates are passed post-activation (i = exp(...), f/o = sigmoid(...)); the op uses the per-head
-    /// first element as the scalar gate (and clamps i to <see cref="XLstmIGateClamp"/>). Records one
-    /// differentiable tape node (the BPTT adjoint), so it is safe under an active <c>GradientTape</c>.
+    /// The gates are passed post-activation (i = exp(...), f/o = sigmoid(...)) as scalar-per-head
+    /// values (and i is clamped to <see cref="XLstmIGateClamp"/>). Records one differentiable tape
+    /// node (the BPTT adjoint), so it is safe under an active <c>GradientTape</c>.
     /// </summary>
     /// <param name="qProj">Query projection [batch, seqLen, modelDim].</param>
     /// <param name="kProj">Key projection [batch, seqLen, modelDim] (scaled by 1/sqrt(headDim) internally).</param>
     /// <param name="vProj">Value projection [batch, seqLen, modelDim].</param>
-    /// <param name="iGate">Post-exp input gate [batch, seqLen, modelDim] (per-head first element used).</param>
-    /// <param name="fGate">Post-sigmoid forget gate [batch, seqLen, modelDim] (per-head first element used).</param>
-    /// <param name="oGate">Post-sigmoid output gate [batch, seqLen, modelDim] (per-head first element used).</param>
+    /// <param name="iGate">Post-exp scalar-per-head input gate [batch, seqLen, numHeads].</param>
+    /// <param name="fGate">Post-sigmoid scalar-per-head forget gate [batch, seqLen, numHeads].</param>
+    /// <param name="oGate">Post-sigmoid scalar-per-head output gate [batch, seqLen, numHeads].</param>
     /// <param name="numHeads">Number of heads; modelDim must be divisible by it.</param>
     /// <returns>The pre-output-projection hidden state [batch, seqLen, modelDim].</returns>
     public virtual Tensor<T> XLstmScanForward<T>(
@@ -59,9 +59,10 @@ public partial class CpuEngine
         int headDim = modelDim / numHeads;
         EnsureSameShape(qProj, kProj, nameof(kProj));
         EnsureSameShape(qProj, vProj, nameof(vProj));
-        EnsureSameShape(qProj, iGate, nameof(iGate));
-        EnsureSameShape(qProj, fGate, nameof(fGate));
-        EnsureSameShape(qProj, oGate, nameof(oGate));
+        // Gates are scalar-per-head: [batch, seqLen, numHeads], not the full modelDim.
+        EnsureGateShape(iGate, batch, seqLen, numHeads, nameof(iGate));
+        EnsureGateShape(fGate, batch, seqLen, numHeads, nameof(fGate));
+        EnsureGateShape(oGate, batch, seqLen, numHeads, nameof(oGate));
 
         var output = new Tensor<T>(new[] { batch, seqLen, modelDim });
 
@@ -109,8 +110,9 @@ public partial class CpuEngine
                 for (int t = 0; t < seqLen; t++)
                 {
                     int baseOff = (b * seqLen + t) * modelDim + hOff;
-                    double iv = I[baseOff]; if (iv > XLstmIGateClamp) iv = XLstmIGateClamp;
-                    double f = F[baseOff], o = O[baseOff];
+                    int gOff = (b * seqLen + t) * numHeads + h; // scalar-per-head gate offset
+                    double iv = I[gOff]; if (iv > XLstmIGateClamp) iv = XLstmIGateClamp;
+                    double f = F[gOff], o = O[gOff];
                     for (int di = 0; di < headDim; di++)
                     {
                         double kSdi = K[baseOff + di] * kappa;
@@ -168,8 +170,9 @@ public partial class CpuEngine
                     Array.Copy(C, 0, Ctraj, t * hh, hh);
                     Array.Copy(n, 0, ntraj, t * headDim, headDim);
                     int baseOff = (b * seqLen + t) * modelDim + hOff;
-                    double iv = I[baseOff]; if (iv > XLstmIGateClamp) iv = XLstmIGateClamp;
-                    double f = F[baseOff];
+                    int gOff = (b * seqLen + t) * numHeads + h;
+                    double iv = I[gOff]; if (iv > XLstmIGateClamp) iv = XLstmIGateClamp;
+                    double f = F[gOff];
                     for (int di = 0; di < headDim; di++)
                     {
                         n[di] = f * n[di] + iv * (K[baseOff + di] * kappa);
@@ -185,8 +188,9 @@ public partial class CpuEngine
                 for (int t = seqLen - 1; t >= 0; t--)
                 {
                     int baseOff = (b * seqLen + t) * modelDim + hOff;
-                    double iv = I[baseOff]; bool iClamped = iv > XLstmIGateClamp; if (iClamped) iv = XLstmIGateClamp;
-                    double f = F[baseOff], o = O[baseOff];
+                    int gOff = (b * seqLen + t) * numHeads + h;
+                    double iv = I[gOff]; bool iClamped = iv > XLstmIGateClamp; if (iClamped) iv = XLstmIGateClamp;
+                    double f = F[gOff], o = O[gOff];
                     int cpOff = t * hh, npOff = t * headDim;
 
                     // Recompute post-update C_t, n_t, nq, nf for this step.
@@ -226,7 +230,7 @@ public partial class CpuEngine
                             dQ[baseOff + ki] += dNum * C[srow + ki];
                         }
                     }
-                    dO[baseOff] += dO_acc;
+                    dO[gOff] += dO_acc;
 
                     // nf = max(|nq|,1); nq = sum_j n_t[j]*Q[j].
                     double dnq = dnf * dNfSign;
@@ -272,8 +276,8 @@ public partial class CpuEngine
                     for (int j = 0; j < headDim; j++) dK[baseOff + j] += dKS[j] * kappa;
 
                     // i gate clamp: gradient passes through only when not clamped.
-                    dI[baseOff] += iClamped ? 0.0 : dI_acc;
-                    dF[baseOff] += dF_acc;
+                    dI[gOff] += iClamped ? 0.0 : dI_acc;
+                    dF[gOff] += dF_acc;
 
                     // Carry adjoints to the previous step.
                     Array.Copy(dCp, 0, dC, 0, hh);
@@ -305,8 +309,9 @@ public partial class CpuEngine
                 for (int t = 0; t < seqLen; t++)
                 {
                     int baseOff = (b * seqLen + t) * modelDim + hOff;
-                    T iv = I[baseOff]; if (ops.GreaterThan(iv, clamp)) iv = clamp;
-                    T f = F[baseOff], o = O[baseOff];
+                    int gOff = (b * seqLen + t) * numHeads + h; // scalar-per-head gate offset
+                    T iv = I[gOff]; if (ops.GreaterThan(iv, clamp)) iv = clamp;
+                    T f = F[gOff], o = O[gOff];
                     for (int di = 0; di < headDim; di++)
                     {
                         T kSdi = ops.Multiply(K[baseOff + di], kappa);
@@ -365,8 +370,9 @@ public partial class CpuEngine
                     Array.Copy(C, 0, Ctraj, t * hh, hh);
                     Array.Copy(n, 0, ntraj, t * headDim, headDim);
                     int baseOff = (b * seqLen + t) * modelDim + hOff;
-                    T iv = I[baseOff]; if (ops.GreaterThan(iv, clamp)) iv = clamp;
-                    T f = F[baseOff];
+                    int gOff = (b * seqLen + t) * numHeads + h;
+                    T iv = I[gOff]; if (ops.GreaterThan(iv, clamp)) iv = clamp;
+                    T f = F[gOff];
                     for (int di = 0; di < headDim; di++)
                     {
                         n[di] = ops.Add(ops.Multiply(f, n[di]), ops.Multiply(iv, ops.Multiply(K[baseOff + di], kappa)));
@@ -383,8 +389,9 @@ public partial class CpuEngine
                 for (int t = seqLen - 1; t >= 0; t--)
                 {
                     int baseOff = (b * seqLen + t) * modelDim + hOff;
-                    T iv = I[baseOff]; bool iClamped = ops.GreaterThan(iv, clamp); if (iClamped) iv = clamp;
-                    T f = F[baseOff], o = O[baseOff];
+                    int gOff = (b * seqLen + t) * numHeads + h;
+                    T iv = I[gOff]; bool iClamped = ops.GreaterThan(iv, clamp); if (iClamped) iv = clamp;
+                    T f = F[gOff], o = O[gOff];
                     int cpOff = t * hh, npOff = t * headDim;
 
                     T nq = zero;
@@ -425,7 +432,7 @@ public partial class CpuEngine
                             dQ[baseOff + ki] = ops.Add(dQ[baseOff + ki], ops.Multiply(dNum, C[srow + ki]));
                         }
                     }
-                    dO[baseOff] = ops.Add(dO[baseOff], dO_acc);
+                    dO[gOff] = ops.Add(dO[gOff], dO_acc);
 
                     T dnq = ops.Multiply(dnf, dNfSign);
                     for (int j = 0; j < headDim; j++)
@@ -465,8 +472,8 @@ public partial class CpuEngine
                     }
                     for (int j = 0; j < headDim; j++) dK[baseOff + j] = ops.Add(dK[baseOff + j], ops.Multiply(dKS[j], kappa));
 
-                    if (!iClamped) dI[baseOff] = ops.Add(dI[baseOff], dI_acc);
-                    dF[baseOff] = ops.Add(dF[baseOff], dF_acc);
+                    if (!iClamped) dI[gOff] = ops.Add(dI[gOff], dI_acc);
+                    dF[gOff] = ops.Add(dF[gOff], dF_acc);
 
                     Array.Copy(dCp, 0, dC, 0, hh);
                     Array.Copy(dNp, 0, dN, 0, headDim);
@@ -495,9 +502,9 @@ public partial class CpuEngine
         var dQ = new Tensor<T>(new[] { batch, seqLen, modelDim });
         var dK = new Tensor<T>(new[] { batch, seqLen, modelDim });
         var dV = new Tensor<T>(new[] { batch, seqLen, modelDim });
-        var dI = new Tensor<T>(new[] { batch, seqLen, modelDim });
-        var dF = new Tensor<T>(new[] { batch, seqLen, modelDim });
-        var dO = new Tensor<T>(new[] { batch, seqLen, modelDim });
+        var dI = new Tensor<T>(new[] { batch, seqLen, numHeads }); // scalar-per-head gates
+        var dF = new Tensor<T>(new[] { batch, seqLen, numHeads });
+        var dO = new Tensor<T>(new[] { batch, seqLen, numHeads });
 
         if (typeof(T) == typeof(double))
         {

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.XLstmScan.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.XLstmScan.cs
@@ -149,6 +149,11 @@ public partial class CpuEngine
         var dC = new double[hh];
         var dN = new double[headDim];
         var dKS = new double[headDim];
+        // Hoisted out of the reverse-time loop below: a fresh new[] per timestep
+        // would create O(batch·heads·seqLen) allocations in this hot backward
+        // kernel. Both are fully overwritten each step before being read.
+        var dCp = new double[hh];
+        var dNp = new double[headDim];
 
         for (int b = 0; b < batch; b++)
         {
@@ -235,8 +240,8 @@ public partial class CpuEngine
                     Array.Clear(dKS, 0, headDim);
                     double dF_acc = 0.0, dI_acc = 0.0;
                     // C_t[di,ki] = f*Cp[di,ki] + iv*V[di]*kS[ki].
-                    var dCp = new double[hh];
-                    var dNp = new double[headDim];
+                    // dCp/dNp hoisted above; every element is written below before
+                    // the Array.Copy carry, so no per-step clear is needed.
                     for (int di = 0; di < headDim; di++)
                     {
                         int srow = di * headDim;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -65,6 +65,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
     private IntPtr _rwkv4Module; // fused RWKV-4 WKV scan kernels (#1464)
     private IntPtr _mambaModule; // fused Mamba selective scan kernels (#1464)
     private IntPtr _mamba2Module; // fused Mamba-2 SSD scan kernels (#1464)
+    private IntPtr _fusedCeModule; // fused linear + cross-entropy kernels (#1464)
     private IntPtr _gruModule;
     private IntPtr _snnModule;
     private IntPtr _fp16Module;
@@ -771,6 +772,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         _rwkv4Module = CompileKernelModule(device, Kernels.CudaRwkv4Kernels.GetSource(), "rwkv4_kernels", Kernels.CudaRwkv4Kernels.GetKernelNames());
         _mambaModule = CompileKernelModule(device, Kernels.CudaMambaKernels.GetSource(), "mamba_kernels", Kernels.CudaMambaKernels.GetKernelNames());
         _mamba2Module = CompileKernelModule(device, Kernels.CudaMamba2Kernels.GetSource(), "mamba2_kernels", Kernels.CudaMamba2Kernels.GetKernelNames());
+        _fusedCeModule = CompileKernelModule(device, Kernels.CudaFusedLinearCeKernels.GetSource(), "fused_ce_kernels", Kernels.CudaFusedLinearCeKernels.GetKernelNames());
         }
         catch
         {
@@ -12045,6 +12047,32 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         args[7] = &batch; args[8] = &seqLen; args[9] = &innerDim; args[10] = &numHeads; args[11] = &headDim; args[12] = &stateDim;
         uint total = (uint)(batch * innerDim);
         LaunchKernel(kernel, (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize, (uint)DefaultBlockSize, args);
+    }
+
+    // ── Fused linear (LM head) + cross-entropy (#1464) ─────────────────────────────────────
+    public unsafe float FusedLinearCrossEntropyIndex(
+        IGpuBuffer hidden, IGpuBuffer weight, IGpuBuffer bias, IGpuBuffer targetIds, int n, int d, int vocab)
+        => FusedCeLaunch("fused_linear_ce_index", hidden, weight, bias, targetIds, n, d, vocab);
+
+    public unsafe float FusedLinearCrossEntropyDense(
+        IGpuBuffer hidden, IGpuBuffer weight, IGpuBuffer bias, IGpuBuffer target, int n, int d, int vocab)
+        => FusedCeLaunch("fused_linear_ce_dense", hidden, weight, bias, target, n, d, vocab);
+
+    private unsafe float FusedCeLaunch(
+        string kernelName, IGpuBuffer hidden, IGpuBuffer weight, IGpuBuffer bias, IGpuBuffer tgt, int n, int d, int vocab)
+    {
+        if (!_kernelCache.TryGetValue(kernelName, out var kernel))
+            throw new InvalidOperationException($"CUDA kernel not found: {kernelName}");
+        using var _ = PushContext();
+        using var lossBuf = AllocateBuffer(1); // zeroed
+        IntPtr ph = hidden.Handle, pw = weight.Handle, pb = bias.Handle, pt = tgt.Handle, pl = lossBuf.Handle;
+        void** args = stackalloc void*[8];
+        args[0] = &ph; args[1] = &pw; args[2] = &pb; args[3] = &pt; args[4] = &pl;
+        args[5] = &n; args[6] = &d; args[7] = &vocab;
+        uint total = (uint)n;
+        LaunchKernel(kernel, (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize, (uint)DefaultBlockSize, args);
+        var loss = DownloadBuffer(lossBuf);
+        return loss[0] / n;
     }
 
     public unsafe void LstmForwardSequence(

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -62,6 +62,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
     private IntPtr _xlstmModule; // fused xLSTM scan kernels (#1464)
     private IntPtr _gatedDeltaNetModule; // fused Gated DeltaNet scan kernels (#1464)
     private IntPtr _rgLruModule; // fused RG-LRU scan kernels (#1464)
+    private IntPtr _rwkv4Module; // fused RWKV-4 WKV scan kernels (#1464)
     private IntPtr _gruModule;
     private IntPtr _snnModule;
     private IntPtr _fp16Module;
@@ -765,6 +766,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         _xlstmModule = CompileKernelModule(device, Kernels.CudaXLstmKernels.GetSource(), "xlstm_kernels", Kernels.CudaXLstmKernels.GetKernelNames());
         _gatedDeltaNetModule = CompileKernelModule(device, Kernels.CudaGatedDeltaNetKernels.GetSource(), "gated_delta_net_kernels", Kernels.CudaGatedDeltaNetKernels.GetKernelNames());
         _rgLruModule = CompileKernelModule(device, Kernels.CudaRgLruKernels.GetSource(), "rglru_kernels", Kernels.CudaRgLruKernels.GetKernelNames());
+        _rwkv4Module = CompileKernelModule(device, Kernels.CudaRwkv4Kernels.GetSource(), "rwkv4_kernels", Kernels.CudaRwkv4Kernels.GetKernelNames());
         }
         catch
         {
@@ -11981,6 +11983,23 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         args[0] = &pv; args[1] = &pr; args[2] = &pi; args[3] = &pd; args[4] = &pout;
         args[5] = &batch; args[6] = &seqLen; args[7] = &recDim;
         uint total = (uint)(batch * recDim);
+        LaunchKernel(kernel, (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize, (uint)DefaultBlockSize, args);
+    }
+
+    // ── Fused RWKV-4 WKV scan forward (#1464) ──────────────────────────────────────────────
+    public unsafe void Rwkv4WkvForward(
+        IGpuBuffer r, IGpuBuffer k, IGpuBuffer v, IGpuBuffer timeDecay, IGpuBuffer timeFirst, IGpuBuffer output,
+        int batch, int seqLen, int modelDim)
+    {
+        if (!_kernelCache.TryGetValue("rwkv4_wkv_forward", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: rwkv4_wkv_forward");
+
+        using var _ = PushContext();
+        IntPtr pr = r.Handle, pk = k.Handle, pv = v.Handle, pd = timeDecay.Handle, pf = timeFirst.Handle, pout = output.Handle;
+        void** args = stackalloc void*[9];
+        args[0] = &pr; args[1] = &pk; args[2] = &pv; args[3] = &pd; args[4] = &pf; args[5] = &pout;
+        args[6] = &batch; args[7] = &seqLen; args[8] = &modelDim;
+        uint total = (uint)(batch * modelDim);
         LaunchKernel(kernel, (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize, (uint)DefaultBlockSize, args);
     }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -64,6 +64,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
     private IntPtr _rgLruModule; // fused RG-LRU scan kernels (#1464)
     private IntPtr _rwkv4Module; // fused RWKV-4 WKV scan kernels (#1464)
     private IntPtr _mambaModule; // fused Mamba selective scan kernels (#1464)
+    private IntPtr _mamba2Module; // fused Mamba-2 SSD scan kernels (#1464)
     private IntPtr _gruModule;
     private IntPtr _snnModule;
     private IntPtr _fp16Module;
@@ -769,6 +770,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         _rgLruModule = CompileKernelModule(device, Kernels.CudaRgLruKernels.GetSource(), "rglru_kernels", Kernels.CudaRgLruKernels.GetKernelNames());
         _rwkv4Module = CompileKernelModule(device, Kernels.CudaRwkv4Kernels.GetSource(), "rwkv4_kernels", Kernels.CudaRwkv4Kernels.GetKernelNames());
         _mambaModule = CompileKernelModule(device, Kernels.CudaMambaKernels.GetSource(), "mamba_kernels", Kernels.CudaMambaKernels.GetKernelNames());
+        _mamba2Module = CompileKernelModule(device, Kernels.CudaMamba2Kernels.GetSource(), "mamba2_kernels", Kernels.CudaMamba2Kernels.GetKernelNames());
         }
         catch
         {
@@ -12021,6 +12023,26 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         void** args = stackalloc void*[11];
         args[0] = &px; args[1] = &pdt; args[2] = &pa; args[3] = &pb; args[4] = &pc; args[5] = &pd; args[6] = &pout;
         args[7] = &batch; args[8] = &seqLen; args[9] = &innerDim; args[10] = &stateDim;
+        uint total = (uint)(batch * innerDim);
+        LaunchKernel(kernel, (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize, (uint)DefaultBlockSize, args);
+    }
+
+    // ── Fused Mamba-2 SSD scan forward (#1464) ─────────────────────────────────────────────
+    public unsafe void Mamba2SsdScanForward(
+        IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,
+        IGpuBuffer output, int batch, int seqLen, int innerDim, int numHeads, int headDim, int stateDim)
+    {
+        if (stateDim > Kernels.CudaMamba2Kernels.MaxStateDim)
+            throw new InvalidOperationException(
+                $"Mamba-2 stateDim ({stateDim}) exceeds max ({Kernels.CudaMamba2Kernels.MaxStateDim}).");
+        if (!_kernelCache.TryGetValue("mamba2_ssd_scan_forward", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: mamba2_ssd_scan_forward");
+
+        using var _ = PushContext();
+        IntPtr px = x.Handle, pdt = delta.Handle, pa = aLog.Handle, pb = bParam.Handle, pc = cParam.Handle, pd = dParam.Handle, pout = output.Handle;
+        void** args = stackalloc void*[13];
+        args[0] = &px; args[1] = &pdt; args[2] = &pa; args[3] = &pb; args[4] = &pc; args[5] = &pd; args[6] = &pout;
+        args[7] = &batch; args[8] = &seqLen; args[9] = &innerDim; args[10] = &numHeads; args[11] = &headDim; args[12] = &stateDim;
         uint total = (uint)(batch * innerDim);
         LaunchKernel(kernel, (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize, (uint)DefaultBlockSize, args);
     }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -63,6 +63,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
     private IntPtr _gatedDeltaNetModule; // fused Gated DeltaNet scan kernels (#1464)
     private IntPtr _rgLruModule; // fused RG-LRU scan kernels (#1464)
     private IntPtr _rwkv4Module; // fused RWKV-4 WKV scan kernels (#1464)
+    private IntPtr _mambaModule; // fused Mamba selective scan kernels (#1464)
     private IntPtr _gruModule;
     private IntPtr _snnModule;
     private IntPtr _fp16Module;
@@ -767,6 +768,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         _gatedDeltaNetModule = CompileKernelModule(device, Kernels.CudaGatedDeltaNetKernels.GetSource(), "gated_delta_net_kernels", Kernels.CudaGatedDeltaNetKernels.GetKernelNames());
         _rgLruModule = CompileKernelModule(device, Kernels.CudaRgLruKernels.GetSource(), "rglru_kernels", Kernels.CudaRgLruKernels.GetKernelNames());
         _rwkv4Module = CompileKernelModule(device, Kernels.CudaRwkv4Kernels.GetSource(), "rwkv4_kernels", Kernels.CudaRwkv4Kernels.GetKernelNames());
+        _mambaModule = CompileKernelModule(device, Kernels.CudaMambaKernels.GetSource(), "mamba_kernels", Kernels.CudaMambaKernels.GetKernelNames());
         }
         catch
         {
@@ -12000,6 +12002,26 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         args[0] = &pr; args[1] = &pk; args[2] = &pv; args[3] = &pd; args[4] = &pf; args[5] = &pout;
         args[6] = &batch; args[7] = &seqLen; args[8] = &modelDim;
         uint total = (uint)(batch * modelDim);
+        LaunchKernel(kernel, (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize, (uint)DefaultBlockSize, args);
+    }
+
+    // ── Fused Mamba selective scan forward (#1464) ─────────────────────────────────────────
+    public unsafe void MambaSelectiveScanForward(
+        IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,
+        IGpuBuffer output, int batch, int seqLen, int innerDim, int stateDim)
+    {
+        if (stateDim > Kernels.CudaMambaKernels.MaxStateDim)
+            throw new InvalidOperationException(
+                $"Mamba stateDim ({stateDim}) exceeds max ({Kernels.CudaMambaKernels.MaxStateDim}).");
+        if (!_kernelCache.TryGetValue("mamba_selective_scan_forward", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: mamba_selective_scan_forward");
+
+        using var _ = PushContext();
+        IntPtr px = x.Handle, pdt = delta.Handle, pa = aLog.Handle, pb = bParam.Handle, pc = cParam.Handle, pd = dParam.Handle, pout = output.Handle;
+        void** args = stackalloc void*[11];
+        args[0] = &px; args[1] = &pdt; args[2] = &pa; args[3] = &pb; args[4] = &pc; args[5] = &pd; args[6] = &pout;
+        args[7] = &batch; args[8] = &seqLen; args[9] = &innerDim; args[10] = &stateDim;
+        uint total = (uint)(batch * innerDim);
         LaunchKernel(kernel, (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize, (uint)DefaultBlockSize, args);
     }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -11922,7 +11922,8 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         LaunchKernel(kernel, (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize, (uint)DefaultBlockSize, args);
     }
 
-    // dQ/dK/dV ([batch,seqLen,modelDim]) and dG ([batch,seqLen,numHeads]) MUST be pre-zeroed.
+    // dQ/dK/dV ([batch,seqLen,modelDim]) and dG ([batch,seqLen,numHeads]); dQ/dK/dG are the
+    // atomic accumulators and are zeroed internally below (no caller pre-zeroing required).
     public unsafe void GlaScanBackward(
         IGpuBuffer dOut, IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer gate,
         IGpuBuffer dQ, IGpuBuffer dK, IGpuBuffer dV, IGpuBuffer dG,
@@ -11940,6 +11941,11 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
             throw new InvalidOperationException("CUDA kernel not found: gla_scan_recompute / gla_scan_backward");
 
         using var _ = PushContext();
+        // dQ/dK/dG are atomic accumulators in the backward kernel — zero them here so the
+        // method is self-contained and correct even if the caller reuses dirty buffers.
+        Fill(dQ, 0f, batch * seqLen * modelDim);
+        Fill(dK, 0f, batch * seqLen * modelDim);
+        Fill(dG, 0f, batch * seqLen * numHeads);
         long trajLenL = checked((long)batch * numHeads * seqLen * headDim * headDim);
         if (trajLenL > int.MaxValue)
             throw new ArgumentException("GLA trajectory buffer is too large for a single allocation.");

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -60,6 +60,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
     private IntPtr _lstmModule;
     private IntPtr _glaModule; // fused GLA scan kernels (#1464)
     private IntPtr _xlstmModule; // fused xLSTM scan kernels (#1464)
+    private IntPtr _gatedDeltaNetModule; // fused Gated DeltaNet scan kernels (#1464)
     private IntPtr _gruModule;
     private IntPtr _snnModule;
     private IntPtr _fp16Module;
@@ -761,6 +762,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
             _lstmModule = CompileKernelModule(device, CudaLstmKernels.GetSource(), "lstm_kernels", CudaLstmKernels.GetKernelNames());
         _glaModule = CompileKernelModule(device, Kernels.CudaGlaKernels.GetSource(), "gla_kernels", Kernels.CudaGlaKernels.GetKernelNames());
         _xlstmModule = CompileKernelModule(device, Kernels.CudaXLstmKernels.GetSource(), "xlstm_kernels", Kernels.CudaXLstmKernels.GetKernelNames());
+        _gatedDeltaNetModule = CompileKernelModule(device, Kernels.CudaGatedDeltaNetKernels.GetSource(), "gated_delta_net_kernels", Kernels.CudaGatedDeltaNetKernels.GetKernelNames());
         }
         catch
         {
@@ -11940,6 +11942,26 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         args[0] = &pq; args[1] = &pk; args[2] = &pv; args[3] = &pi; args[4] = &pf; args[5] = &po; args[6] = &pout;
         args[7] = &batch; args[8] = &seqLen; args[9] = &modelDim; args[10] = &numHeads; args[11] = &headDim;
         uint total = (uint)(batch * numHeads);
+        LaunchKernel(kernel, (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize, (uint)DefaultBlockSize, args);
+    }
+
+    // ── Fused Gated DeltaNet scan forward (#1464) ──────────────────────────────────────────
+    public unsafe void GatedDeltaNetScanForward(
+        IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer alpha, IGpuBuffer beta, IGpuBuffer output,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        if (headDim > Kernels.CudaGatedDeltaNetKernels.MaxHeadDim)
+            throw new InvalidOperationException(
+                $"GatedDeltaNet headDim ({headDim}) exceeds max ({Kernels.CudaGatedDeltaNetKernels.MaxHeadDim}).");
+        if (!_kernelCache.TryGetValue("gated_delta_scan_forward", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: gated_delta_scan_forward");
+
+        using var _ = PushContext();
+        IntPtr pq = q.Handle, pk = k.Handle, pv = v.Handle, pa = alpha.Handle, pb = beta.Handle, pout = output.Handle;
+        void** args = stackalloc void*[11];
+        args[0] = &pq; args[1] = &pk; args[2] = &pv; args[3] = &pa; args[4] = &pb; args[5] = &pout;
+        args[6] = &batch; args[7] = &seqLen; args[8] = &modelDim; args[9] = &numHeads; args[10] = &headDim;
+        uint total = (uint)(batch * numHeads * headDim);
         LaunchKernel(kernel, (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize, (uint)DefaultBlockSize, args);
     }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -59,6 +59,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
     private IntPtr _specializedModule;
     private IntPtr _lstmModule;
     private IntPtr _glaModule; // fused GLA scan kernels (#1464)
+    private IntPtr _xlstmModule; // fused xLSTM scan kernels (#1464)
     private IntPtr _gruModule;
     private IntPtr _snnModule;
     private IntPtr _fp16Module;
@@ -759,6 +760,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         {
             _lstmModule = CompileKernelModule(device, CudaLstmKernels.GetSource(), "lstm_kernels", CudaLstmKernels.GetKernelNames());
         _glaModule = CompileKernelModule(device, Kernels.CudaGlaKernels.GetSource(), "gla_kernels", Kernels.CudaGlaKernels.GetKernelNames());
+        _xlstmModule = CompileKernelModule(device, Kernels.CudaXLstmKernels.GetSource(), "xlstm_kernels", Kernels.CudaXLstmKernels.GetKernelNames());
         }
         catch
         {
@@ -11917,6 +11919,28 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         ba[6] = &pdq; ba[7] = &pdk; ba[8] = &pdv; ba[9] = &pdg;
         ba[10] = &batch; ba[11] = &seqLen; ba[12] = &modelDim; ba[13] = &numHeads; ba[14] = &headDim;
         LaunchKernel(backward, grid, (uint)DefaultBlockSize, ba);
+    }
+
+    // ── Fused xLSTM (mLSTM) scan forward (#1464) ───────────────────────────────────────────
+    public unsafe void XLstmScanForward(
+        IGpuBuffer q, IGpuBuffer k, IGpuBuffer v,
+        IGpuBuffer iGate, IGpuBuffer fGate, IGpuBuffer oGate, IGpuBuffer output,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        if (headDim > Kernels.CudaXLstmKernels.MaxHeadDim)
+            throw new InvalidOperationException(
+                $"xLSTM headDim ({headDim}) exceeds max ({Kernels.CudaXLstmKernels.MaxHeadDim}).");
+        if (!_kernelCache.TryGetValue("xlstm_scan_forward", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: xlstm_scan_forward");
+
+        using var _ = PushContext();
+        IntPtr pq = q.Handle, pk = k.Handle, pv = v.Handle;
+        IntPtr pi = iGate.Handle, pf = fGate.Handle, po = oGate.Handle, pout = output.Handle;
+        void** args = stackalloc void*[12];
+        args[0] = &pq; args[1] = &pk; args[2] = &pv; args[3] = &pi; args[4] = &pf; args[5] = &po; args[6] = &pout;
+        args[7] = &batch; args[8] = &seqLen; args[9] = &modelDim; args[10] = &numHeads; args[11] = &headDim;
+        uint total = (uint)(batch * numHeads);
+        LaunchKernel(kernel, (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize, (uint)DefaultBlockSize, args);
     }
 
     public unsafe void LstmForwardSequence(

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -11884,9 +11884,22 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer gate, IGpuBuffer output,
         int batch, int seqLen, int modelDim, int numHeads, int headDim)
     {
+        if (batch <= 0 || seqLen <= 0 || modelDim <= 0 || numHeads <= 0 || headDim <= 0)
+            throw new ArgumentOutOfRangeException(nameof(batch), "GLA dimensions must be positive.");
+        if (modelDim != numHeads * headDim)
+            throw new ArgumentException($"modelDim ({modelDim}) must equal numHeads * headDim ({numHeads * headDim}).");
         if (headDim > Kernels.CudaGlaKernels.MaxHeadDim)
             throw new InvalidOperationException(
                 $"GLA headDim ({headDim}) exceeds max ({Kernels.CudaGlaKernels.MaxHeadDim}).");
+
+        long tokenCount = checked((long)batch * seqLen);
+        long qkvElems = checked(tokenCount * modelDim);
+        long gateElems = checked(tokenCount * numHeads);
+        if (q.Size < qkvElems || k.Size < qkvElems || v.Size < qkvElems || output.Size < qkvElems)
+            throw new ArgumentException("Q/K/V/output buffer is too small for the requested GLA shape.");
+        if (gate.Size < gateElems)
+            throw new ArgumentException("gate buffer is too small for the requested GLA shape.");
+
         if (!_kernelCache.TryGetValue("gla_scan_forward", out var kernel))
             throw new InvalidOperationException("CUDA kernel not found: gla_scan_forward");
 
@@ -11905,6 +11918,10 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         IGpuBuffer dQ, IGpuBuffer dK, IGpuBuffer dV, IGpuBuffer dG,
         int batch, int seqLen, int modelDim, int numHeads, int headDim)
     {
+        if (batch <= 0 || seqLen <= 0 || modelDim <= 0 || numHeads <= 0 || headDim <= 0)
+            throw new ArgumentOutOfRangeException(nameof(batch), "GLA dimensions must be positive.");
+        if (modelDim != numHeads * headDim)
+            throw new ArgumentException($"modelDim ({modelDim}) must equal numHeads * headDim ({numHeads * headDim}).");
         if (headDim > Kernels.CudaGlaKernels.MaxHeadDim)
             throw new InvalidOperationException(
                 $"GLA headDim ({headDim}) exceeds max ({Kernels.CudaGlaKernels.MaxHeadDim}).");
@@ -11913,7 +11930,10 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
             throw new InvalidOperationException("CUDA kernel not found: gla_scan_recompute / gla_scan_backward");
 
         using var _ = PushContext();
-        int trajLen = batch * numHeads * seqLen * headDim * headDim;
+        long trajLenL = checked((long)batch * numHeads * seqLen * headDim * headDim);
+        if (trajLenL > int.MaxValue)
+            throw new ArgumentException("GLA trajectory buffer is too large for a single allocation.");
+        int trajLen = (int)trajLenL;
         using var trajBuf = AllocateBuffer(trajLen);
         uint total = (uint)(batch * numHeads * headDim);
         uint grid = (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize;
@@ -12537,6 +12557,12 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         {
             CudaNativeBindings.cuModuleUnload(_lstmModule);
             _lstmModule = IntPtr.Zero;
+        }
+
+        if (_glaModule != IntPtr.Zero)
+        {
+            CudaNativeBindings.cuModuleUnload(_glaModule);
+            _glaModule = IntPtr.Zero;
         }
 
         if (_gruModule != IntPtr.Zero)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -61,6 +61,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
     private IntPtr _glaModule; // fused GLA scan kernels (#1464)
     private IntPtr _xlstmModule; // fused xLSTM scan kernels (#1464)
     private IntPtr _gatedDeltaNetModule; // fused Gated DeltaNet scan kernels (#1464)
+    private IntPtr _rgLruModule; // fused RG-LRU scan kernels (#1464)
     private IntPtr _gruModule;
     private IntPtr _snnModule;
     private IntPtr _fp16Module;
@@ -763,6 +764,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         _glaModule = CompileKernelModule(device, Kernels.CudaGlaKernels.GetSource(), "gla_kernels", Kernels.CudaGlaKernels.GetKernelNames());
         _xlstmModule = CompileKernelModule(device, Kernels.CudaXLstmKernels.GetSource(), "xlstm_kernels", Kernels.CudaXLstmKernels.GetKernelNames());
         _gatedDeltaNetModule = CompileKernelModule(device, Kernels.CudaGatedDeltaNetKernels.GetSource(), "gated_delta_net_kernels", Kernels.CudaGatedDeltaNetKernels.GetKernelNames());
+        _rgLruModule = CompileKernelModule(device, Kernels.CudaRgLruKernels.GetSource(), "rglru_kernels", Kernels.CudaRgLruKernels.GetKernelNames());
         }
         catch
         {
@@ -11962,6 +11964,23 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         args[0] = &pq; args[1] = &pk; args[2] = &pv; args[3] = &pa; args[4] = &pb; args[5] = &pout;
         args[6] = &batch; args[7] = &seqLen; args[8] = &modelDim; args[9] = &numHeads; args[10] = &headDim;
         uint total = (uint)(batch * numHeads * headDim);
+        LaunchKernel(kernel, (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize, (uint)DefaultBlockSize, args);
+    }
+
+    // ── Fused RG-LRU scan forward (#1464) ──────────────────────────────────────────────────
+    public unsafe void RgLruScanForward(
+        IGpuBuffer value, IGpuBuffer recGate, IGpuBuffer inpGate, IGpuBuffer decay, IGpuBuffer output,
+        int batch, int seqLen, int recDim)
+    {
+        if (!_kernelCache.TryGetValue("rglru_scan_forward", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: rglru_scan_forward");
+
+        using var _ = PushContext();
+        IntPtr pv = value.Handle, pr = recGate.Handle, pi = inpGate.Handle, pd = decay.Handle, pout = output.Handle;
+        void** args = stackalloc void*[8];
+        args[0] = &pv; args[1] = &pr; args[2] = &pi; args[3] = &pd; args[4] = &pout;
+        args[5] = &batch; args[6] = &seqLen; args[7] = &recDim;
+        uint total = (uint)(batch * recDim);
         LaunchKernel(kernel, (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize, (uint)DefaultBlockSize, args);
     }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -58,6 +58,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
     private IntPtr _capsuleModule;
     private IntPtr _specializedModule;
     private IntPtr _lstmModule;
+    private IntPtr _glaModule; // fused GLA scan kernels (#1464)
     private IntPtr _gruModule;
     private IntPtr _snnModule;
     private IntPtr _fp16Module;
@@ -757,6 +758,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         try
         {
             _lstmModule = CompileKernelModule(device, CudaLstmKernels.GetSource(), "lstm_kernels", CudaLstmKernels.GetKernelNames());
+        _glaModule = CompileKernelModule(device, Kernels.CudaGlaKernels.GetSource(), "gla_kernels", Kernels.CudaGlaKernels.GetKernelNames());
         }
         catch
         {
@@ -11862,6 +11864,60 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
     #endregion
 
     #region RNN (LSTM/GRU) Sequence Operations
+
+    // ── Fused GLA (Gated Linear Attention) scan (#1464) ────────────────────────────────────
+    public unsafe void GlaScanForward(
+        IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer gate, IGpuBuffer output,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        if (headDim > Kernels.CudaGlaKernels.MaxHeadDim)
+            throw new InvalidOperationException(
+                $"GLA headDim ({headDim}) exceeds max ({Kernels.CudaGlaKernels.MaxHeadDim}).");
+        if (!_kernelCache.TryGetValue("gla_scan_forward", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: gla_scan_forward");
+
+        using var _ = PushContext();
+        IntPtr pq = q.Handle, pk = k.Handle, pv = v.Handle, pg = gate.Handle, po = output.Handle;
+        void** args = stackalloc void*[10];
+        args[0] = &pq; args[1] = &pk; args[2] = &pv; args[3] = &pg; args[4] = &po;
+        args[5] = &batch; args[6] = &seqLen; args[7] = &modelDim; args[8] = &numHeads; args[9] = &headDim;
+        uint total = (uint)(batch * numHeads * headDim);
+        LaunchKernel(kernel, (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize, (uint)DefaultBlockSize, args);
+    }
+
+    // dQ/dK/dV ([batch,seqLen,modelDim]) and dG ([batch,seqLen,numHeads]) MUST be pre-zeroed.
+    public unsafe void GlaScanBackward(
+        IGpuBuffer dOut, IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer gate,
+        IGpuBuffer dQ, IGpuBuffer dK, IGpuBuffer dV, IGpuBuffer dG,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        if (headDim > Kernels.CudaGlaKernels.MaxHeadDim)
+            throw new InvalidOperationException(
+                $"GLA headDim ({headDim}) exceeds max ({Kernels.CudaGlaKernels.MaxHeadDim}).");
+        if (!_kernelCache.TryGetValue("gla_scan_recompute", out var recompute) ||
+            !_kernelCache.TryGetValue("gla_scan_backward", out var backward))
+            throw new InvalidOperationException("CUDA kernel not found: gla_scan_recompute / gla_scan_backward");
+
+        using var _ = PushContext();
+        int trajLen = batch * numHeads * seqLen * headDim * headDim;
+        using var trajBuf = AllocateBuffer(trajLen);
+        uint total = (uint)(batch * numHeads * headDim);
+        uint grid = (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize;
+
+        IntPtr pk = k.Handle, pv = v.Handle, pg = gate.Handle, ptr = trajBuf.Handle;
+        void** ra = stackalloc void*[9];
+        ra[0] = &pk; ra[1] = &pv; ra[2] = &pg; ra[3] = &ptr;
+        ra[4] = &batch; ra[5] = &seqLen; ra[6] = &modelDim; ra[7] = &numHeads; ra[8] = &headDim;
+        LaunchKernel(recompute, grid, (uint)DefaultBlockSize, ra);
+
+        IntPtr pdo = dOut.Handle, pq = q.Handle;
+        IntPtr pdq = dQ.Handle, pdk = dK.Handle, pdv = dV.Handle, pdg = dG.Handle;
+        void** ba = stackalloc void*[15];
+        ba[0] = &pdo; ba[1] = &pq; ba[2] = &pk; ba[3] = &pv; ba[4] = &pg; ba[5] = &ptr;
+        ba[6] = &pdq; ba[7] = &pdk; ba[8] = &pdv; ba[9] = &pdg;
+        ba[10] = &batch; ba[11] = &seqLen; ba[12] = &modelDim; ba[13] = &numHeads; ba[14] = &headDim;
+        LaunchKernel(backward, grid, (uint)DefaultBlockSize, ba);
+    }
 
     public unsafe void LstmForwardSequence(
         IGpuBuffer input, IGpuBuffer hInit, IGpuBuffer cInit,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -11969,6 +11969,10 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         IGpuBuffer iGate, IGpuBuffer fGate, IGpuBuffer oGate, IGpuBuffer output,
         int batch, int seqLen, int modelDim, int numHeads, int headDim)
     {
+        if (batch <= 0 || seqLen <= 0 || modelDim <= 0 || numHeads <= 0 || headDim <= 0)
+            throw new ArgumentOutOfRangeException(nameof(batch), "xLSTM dimensions must be positive.");
+        if (modelDim != numHeads * headDim)
+            throw new ArgumentException($"modelDim ({modelDim}) must equal numHeads * headDim ({numHeads * headDim}).");
         if (headDim > Kernels.CudaXLstmKernels.MaxHeadDim)
             throw new InvalidOperationException(
                 $"xLSTM headDim ({headDim}) exceeds max ({Kernels.CudaXLstmKernels.MaxHeadDim}).");
@@ -11990,6 +11994,10 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer alpha, IGpuBuffer beta, IGpuBuffer output,
         int batch, int seqLen, int modelDim, int numHeads, int headDim)
     {
+        if (batch <= 0 || seqLen <= 0 || modelDim <= 0 || numHeads <= 0 || headDim <= 0)
+            throw new ArgumentOutOfRangeException(nameof(batch), "GatedDeltaNet dimensions must be positive.");
+        if (modelDim != numHeads * headDim)
+            throw new ArgumentException($"modelDim ({modelDim}) must equal numHeads * headDim ({numHeads * headDim}).");
         if (headDim > Kernels.CudaGatedDeltaNetKernels.MaxHeadDim)
             throw new InvalidOperationException(
                 $"GatedDeltaNet headDim ({headDim}) exceeds max ({Kernels.CudaGatedDeltaNetKernels.MaxHeadDim}).");
@@ -12010,6 +12018,8 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         IGpuBuffer value, IGpuBuffer recGate, IGpuBuffer inpGate, IGpuBuffer decay, IGpuBuffer output,
         int batch, int seqLen, int recDim)
     {
+        if (batch <= 0 || seqLen <= 0 || recDim <= 0)
+            throw new ArgumentOutOfRangeException(nameof(batch), "RG-LRU dimensions must be positive.");
         if (!_kernelCache.TryGetValue("rglru_scan_forward", out var kernel))
             throw new InvalidOperationException("CUDA kernel not found: rglru_scan_forward");
 
@@ -12027,6 +12037,8 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         IGpuBuffer r, IGpuBuffer k, IGpuBuffer v, IGpuBuffer timeDecay, IGpuBuffer timeFirst, IGpuBuffer output,
         int batch, int seqLen, int modelDim)
     {
+        if (batch <= 0 || seqLen <= 0 || modelDim <= 0)
+            throw new ArgumentOutOfRangeException(nameof(batch), "RWKV-4 dimensions must be positive.");
         if (!_kernelCache.TryGetValue("rwkv4_wkv_forward", out var kernel))
             throw new InvalidOperationException("CUDA kernel not found: rwkv4_wkv_forward");
 
@@ -12044,6 +12056,8 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,
         IGpuBuffer output, int batch, int seqLen, int innerDim, int stateDim)
     {
+        if (batch <= 0 || seqLen <= 0 || innerDim <= 0 || stateDim <= 0)
+            throw new ArgumentOutOfRangeException(nameof(batch), "Mamba dimensions must be positive.");
         if (stateDim > Kernels.CudaMambaKernels.MaxStateDim)
             throw new InvalidOperationException(
                 $"Mamba stateDim ({stateDim}) exceeds max ({Kernels.CudaMambaKernels.MaxStateDim}).");
@@ -12064,6 +12078,10 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,
         IGpuBuffer output, int batch, int seqLen, int innerDim, int numHeads, int headDim, int stateDim)
     {
+        if (batch <= 0 || seqLen <= 0 || innerDim <= 0 || numHeads <= 0 || headDim <= 0 || stateDim <= 0)
+            throw new ArgumentOutOfRangeException(nameof(batch), "Mamba-2 dimensions must be positive.");
+        if (innerDim != numHeads * headDim)
+            throw new ArgumentException($"innerDim ({innerDim}) must equal numHeads * headDim ({numHeads * headDim}).");
         if (stateDim > Kernels.CudaMamba2Kernels.MaxStateDim)
             throw new InvalidOperationException(
                 $"Mamba-2 stateDim ({stateDim}) exceeds max ({Kernels.CudaMamba2Kernels.MaxStateDim}).");
@@ -12091,6 +12109,8 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
     private unsafe float FusedCeLaunch(
         string kernelName, IGpuBuffer hidden, IGpuBuffer weight, IGpuBuffer bias, IGpuBuffer tgt, int n, int d, int vocab)
     {
+        if (n <= 0 || d <= 0 || vocab <= 0)
+            throw new ArgumentOutOfRangeException(nameof(n), "Fused CE dimensions (n, d, vocab) must be positive.");
         if (!_kernelCache.TryGetValue(kernelName, out var kernel))
             throw new InvalidOperationException($"CUDA kernel not found: {kernelName}");
         using var _ = PushContext();
@@ -12573,6 +12593,48 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         {
             CudaNativeBindings.cuModuleUnload(_glaModule);
             _glaModule = IntPtr.Zero;
+        }
+
+        if (_xlstmModule != IntPtr.Zero)
+        {
+            CudaNativeBindings.cuModuleUnload(_xlstmModule);
+            _xlstmModule = IntPtr.Zero;
+        }
+
+        if (_gatedDeltaNetModule != IntPtr.Zero)
+        {
+            CudaNativeBindings.cuModuleUnload(_gatedDeltaNetModule);
+            _gatedDeltaNetModule = IntPtr.Zero;
+        }
+
+        if (_rgLruModule != IntPtr.Zero)
+        {
+            CudaNativeBindings.cuModuleUnload(_rgLruModule);
+            _rgLruModule = IntPtr.Zero;
+        }
+
+        if (_rwkv4Module != IntPtr.Zero)
+        {
+            CudaNativeBindings.cuModuleUnload(_rwkv4Module);
+            _rwkv4Module = IntPtr.Zero;
+        }
+
+        if (_mambaModule != IntPtr.Zero)
+        {
+            CudaNativeBindings.cuModuleUnload(_mambaModule);
+            _mambaModule = IntPtr.Zero;
+        }
+
+        if (_mamba2Module != IntPtr.Zero)
+        {
+            CudaNativeBindings.cuModuleUnload(_mamba2Module);
+            _mamba2Module = IntPtr.Zero;
+        }
+
+        if (_fusedCeModule != IntPtr.Zero)
+        {
+            CudaNativeBindings.cuModuleUnload(_fusedCeModule);
+            _fusedCeModule = IntPtr.Zero;
         }
 
         if (_gruModule != IntPtr.Zero)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -765,18 +765,28 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         try
         {
             _lstmModule = CompileKernelModule(device, CudaLstmKernels.GetSource(), "lstm_kernels", CudaLstmKernels.GetKernelNames());
-        _glaModule = CompileKernelModule(device, Kernels.CudaGlaKernels.GetSource(), "gla_kernels", Kernels.CudaGlaKernels.GetKernelNames());
-        _xlstmModule = CompileKernelModule(device, Kernels.CudaXLstmKernels.GetSource(), "xlstm_kernels", Kernels.CudaXLstmKernels.GetKernelNames());
-        _gatedDeltaNetModule = CompileKernelModule(device, Kernels.CudaGatedDeltaNetKernels.GetSource(), "gated_delta_net_kernels", Kernels.CudaGatedDeltaNetKernels.GetKernelNames());
-        _rgLruModule = CompileKernelModule(device, Kernels.CudaRgLruKernels.GetSource(), "rglru_kernels", Kernels.CudaRgLruKernels.GetKernelNames());
-        _rwkv4Module = CompileKernelModule(device, Kernels.CudaRwkv4Kernels.GetSource(), "rwkv4_kernels", Kernels.CudaRwkv4Kernels.GetKernelNames());
-        _mambaModule = CompileKernelModule(device, Kernels.CudaMambaKernels.GetSource(), "mamba_kernels", Kernels.CudaMambaKernels.GetKernelNames());
-        _mamba2Module = CompileKernelModule(device, Kernels.CudaMamba2Kernels.GetSource(), "mamba2_kernels", Kernels.CudaMamba2Kernels.GetKernelNames());
-        _fusedCeModule = CompileKernelModule(device, Kernels.CudaFusedLinearCeKernels.GetSource(), "fused_ce_kernels", Kernels.CudaFusedLinearCeKernels.GetKernelNames());
         }
         catch
         {
             // LSTM kernels may need special headers — optional.
+        }
+
+        // Compile fused recurrence / LM-head kernels (#1464) in their OWN try/catch so an
+        // optional-LSTM compile failure above doesn't also disable the recurrence family.
+        try
+        {
+            _glaModule = CompileKernelModule(device, Kernels.CudaGlaKernels.GetSource(), "gla_kernels", Kernels.CudaGlaKernels.GetKernelNames());
+            _xlstmModule = CompileKernelModule(device, Kernels.CudaXLstmKernels.GetSource(), "xlstm_kernels", Kernels.CudaXLstmKernels.GetKernelNames());
+            _gatedDeltaNetModule = CompileKernelModule(device, Kernels.CudaGatedDeltaNetKernels.GetSource(), "gated_delta_net_kernels", Kernels.CudaGatedDeltaNetKernels.GetKernelNames());
+            _rgLruModule = CompileKernelModule(device, Kernels.CudaRgLruKernels.GetSource(), "rglru_kernels", Kernels.CudaRgLruKernels.GetKernelNames());
+            _rwkv4Module = CompileKernelModule(device, Kernels.CudaRwkv4Kernels.GetSource(), "rwkv4_kernels", Kernels.CudaRwkv4Kernels.GetKernelNames());
+            _mambaModule = CompileKernelModule(device, Kernels.CudaMambaKernels.GetSource(), "mamba_kernels", Kernels.CudaMambaKernels.GetKernelNames());
+            _mamba2Module = CompileKernelModule(device, Kernels.CudaMamba2Kernels.GetSource(), "mamba2_kernels", Kernels.CudaMamba2Kernels.GetKernelNames());
+            _fusedCeModule = CompileKernelModule(device, Kernels.CudaFusedLinearCeKernels.GetSource(), "fused_ce_kernels", Kernels.CudaFusedLinearCeKernels.GetKernelNames());
+        }
+        catch
+        {
+            // Fused recurrence / LM-head kernels are optional.
         }
 
         // Compile GRU sequence kernels (forward/backward for BPTT training)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaFusedLinearCeKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaFusedLinearCeKernels.cs
@@ -19,6 +19,11 @@ extern ""C"" __global__ void fused_linear_ce_index(
     if (r >= N) return;
     int hRow = r * d;
     int id = (int)(targetIds[r] + 0.5f);
+    if (id < 0 || id >= vocab) {
+        // Invalid label: surface loudly via the mean rather than a silently-wrong loss.
+        atomicAdd(totalLoss, INFINITY);
+        return;
+    }
 
     float mx = -1.0e38f, logitTarget = 0.0f;
     for (int vv = 0; vv < vocab; vv++) {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaFusedLinearCeKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaFusedLinearCeKernels.cs
@@ -1,0 +1,74 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// CUDA kernels for the fused linear + cross-entropy loss (#1464). One thread per row; loss
+// atomic-added to a scalar accumulator (caller divides by N). Logits are never materialized.
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA.Kernels;
+
+internal static class CudaFusedLinearCeKernels
+{
+    public static string GetSource()
+    {
+        return @"
+#include <math.h>
+
+extern ""C"" __global__ void fused_linear_ce_index(
+    const float* hidden, const float* weight, const float* bias, const float* targetIds,
+    float* totalLoss, int N, int d, int vocab)
+{
+    int r = blockIdx.x * blockDim.x + threadIdx.x;
+    if (r >= N) return;
+    int hRow = r * d;
+    int id = (int)(targetIds[r] + 0.5f);
+
+    float mx = -1.0e38f, logitTarget = 0.0f;
+    for (int vv = 0; vv < vocab; vv++) {
+        float s = bias[vv];
+        for (int j = 0; j < d; j++) s += hidden[hRow + j] * weight[j * vocab + vv];
+        if (s > mx) mx = s;
+        if (vv == id) logitTarget = s;
+    }
+    float sumExp = 0.0f;
+    for (int vv = 0; vv < vocab; vv++) {
+        float s = bias[vv];
+        for (int j = 0; j < d; j++) s += hidden[hRow + j] * weight[j * vocab + vv];
+        sumExp += expf(s - mx);
+    }
+    float loss = (mx + logf(sumExp)) - logitTarget;
+    atomicAdd(totalLoss, loss);
+}
+
+extern ""C"" __global__ void fused_linear_ce_dense(
+    const float* hidden, const float* weight, const float* bias, const float* target,
+    float* totalLoss, int N, int d, int vocab)
+{
+    int r = blockIdx.x * blockDim.x + threadIdx.x;
+    if (r >= N) return;
+    int hRow = r * d;
+    int tRow = r * vocab;
+
+    float mx = -1.0e38f;
+    for (int vv = 0; vv < vocab; vv++) {
+        float s = bias[vv];
+        for (int j = 0; j < d; j++) s += hidden[hRow + j] * weight[j * vocab + vv];
+        if (s > mx) mx = s;
+    }
+    float sumExp = 0.0f;
+    for (int vv = 0; vv < vocab; vv++) {
+        float s = bias[vv];
+        for (int j = 0; j < d; j++) s += hidden[hRow + j] * weight[j * vocab + vv];
+        sumExp += expf(s - mx);
+    }
+    float lse = mx + logf(sumExp);
+    float rowLoss = 0.0f;
+    for (int vv = 0; vv < vocab; vv++) {
+        float s = bias[vv];
+        for (int j = 0; j < d; j++) s += hidden[hRow + j] * weight[j * vocab + vv];
+        rowLoss += target[tRow + vv] * (s - lse);
+    }
+    atomicAdd(totalLoss, -rowLoss);
+}
+";
+    }
+
+    public static string[] GetKernelNames() => new[] { "fused_linear_ce_index", "fused_linear_ce_dense" };
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaGatedDeltaNetKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaGatedDeltaNetKernels.cs
@@ -1,0 +1,54 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// CUDA kernel for the fused Gated DeltaNet scan forward (issue ooples/AiDotNet#1464).
+// Same design as HipGatedDeltaNetKernels: one thread per (batch, head, value-row).
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA.Kernels;
+
+internal static class CudaGatedDeltaNetKernels
+{
+    public const int MaxHeadDim = 256;
+
+    public static string GetSource()
+    {
+        return @"
+#include <math.h>
+
+#define GDN_MAX_HEADDIM 256
+
+extern ""C"" __global__ void gated_delta_scan_forward(
+    const float* Q, const float* K, const float* V, const float* A, const float* B,
+    float* output,
+    int batch, int seqLen, int modelDim, int numHeads, int headDim)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = batch * numHeads * headDim;
+    if (gid >= total) return;
+
+    int di = gid % headDim;
+    int h  = (gid / headDim) % numHeads;
+    int b  = gid / (headDim * numHeads);
+    int hOff = h * headDim;
+    float kappa = 1.0f / sqrtf((float)headDim);
+
+    float Srow[GDN_MAX_HEADDIM];
+    for (int ki = 0; ki < headDim; ki++) Srow[ki] = 0.0f;
+
+    for (int t = 0; t < seqLen; t++) {
+        int baseOff = (b * seqLen + t) * modelDim + hOff;
+        int gIdx = (b * seqLen + t) * numHeads + h;
+        float a = A[gIdx], bet = B[gIdx];
+        float sK = 0.0f;
+        for (int ki = 0; ki < headDim; ki++) sK += Srow[ki] * (K[baseOff + ki] * kappa);
+        float bd = bet * (V[baseOff + di] - sK);
+        for (int ki = 0; ki < headDim; ki++)
+            Srow[ki] = a * Srow[ki] + bd * (K[baseOff + ki] * kappa);
+        float o = 0.0f;
+        for (int ki = 0; ki < headDim; ki++) o += Srow[ki] * Q[baseOff + ki];
+        output[baseOff + di] = o;
+    }
+}
+";
+    }
+
+    public static string[] GetKernelNames() => new[] { "gated_delta_scan_forward" };
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaGlaKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaGlaKernels.cs
@@ -1,0 +1,147 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// CUDA kernels for the fused Gated Linear Attention (GLA) sequence scan (issue ooples/AiDotNet#1464).
+// Mirrors CpuEngine.GlaScan.cs exactly (see HipGlaKernels for the shared design notes):
+//   S_t[di,ki] = g_t * S_{t-1}[di,ki] + V_t[di] * K_t[ki]
+//   O_t[di]    = sum_ki S_t[di,ki] * Q_t[ki]
+// One thread owns (batch b, head h, value-row di) and carries that state row across time.
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA.Kernels;
+
+/// <summary>
+/// CUDA kernels for the fused GLA scan (forward + BPTT backward) on NVIDIA GPUs.
+/// </summary>
+internal static class CudaGlaKernels
+{
+    public const int MaxHeadDim = 256;
+
+    public static string GetSource()
+    {
+        return @"
+#include <math.h>
+
+#define GLA_MAX_HEADDIM 256
+
+extern ""C"" __global__ void gla_scan_forward(
+    const float* Q, const float* K, const float* V, const float* G,
+    float* output,
+    int batch, int seqLen, int modelDim, int numHeads, int headDim)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = batch * numHeads * headDim;
+    if (gid >= total) return;
+
+    int di = gid % headDim;
+    int h  = (gid / headDim) % numHeads;
+    int b  = gid / (headDim * numHeads);
+    int hOff = h * headDim;
+
+    float Srow[GLA_MAX_HEADDIM];
+    for (int ki = 0; ki < headDim; ki++) Srow[ki] = 0.0f;
+
+    for (int t = 0; t < seqLen; t++) {
+        int baseOff = (b * seqLen + t) * modelDim + hOff;
+        float g  = G[(b * seqLen + t) * numHeads + h];
+        float vd = V[baseOff + di];
+        float o  = 0.0f;
+        for (int ki = 0; ki < headDim; ki++) {
+            float s = g * Srow[ki] + vd * K[baseOff + ki];
+            Srow[ki] = s;
+            o += s * Q[baseOff + ki];
+        }
+        output[baseOff + di] = o;
+    }
+}
+
+extern ""C"" __global__ void gla_scan_recompute(
+    const float* K, const float* V, const float* G,
+    float* Straj,
+    int batch, int seqLen, int modelDim, int numHeads, int headDim)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = batch * numHeads * headDim;
+    if (gid >= total) return;
+
+    int di = gid % headDim;
+    int h  = (gid / headDim) % numHeads;
+    int b  = gid / (headDim * numHeads);
+    int hOff = h * headDim;
+    int hh = headDim * headDim;
+
+    float Srow[GLA_MAX_HEADDIM];
+    for (int ki = 0; ki < headDim; ki++) Srow[ki] = 0.0f;
+
+    for (int t = 0; t < seqLen; t++) {
+        int baseOff = (b * seqLen + t) * modelDim + hOff;
+        float g  = G[(b * seqLen + t) * numHeads + h];
+        float vd = V[baseOff + di];
+        long trajBase = ((long)(b * numHeads + h) * seqLen + t) * hh + (long)di * headDim;
+        for (int ki = 0; ki < headDim; ki++) {
+            float s = g * Srow[ki] + vd * K[baseOff + ki];
+            Srow[ki] = s;
+            Straj[trajBase + ki] = s;
+        }
+    }
+}
+
+extern ""C"" __global__ void gla_scan_backward(
+    const float* dOut, const float* Q, const float* K, const float* V, const float* G,
+    const float* Straj,
+    float* dQ, float* dK, float* dV, float* dG,
+    int batch, int seqLen, int modelDim, int numHeads, int headDim)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = batch * numHeads * headDim;
+    if (gid >= total) return;
+
+    int di = gid % headDim;
+    int h  = (gid / headDim) % numHeads;
+    int b  = gid / (headDim * numHeads);
+    int hOff = h * headDim;
+    int hh = headDim * headDim;
+
+    float dSrow[GLA_MAX_HEADDIM];
+    for (int ki = 0; ki < headDim; ki++) dSrow[ki] = 0.0f;
+
+    for (int t = seqLen - 1; t >= 0; t--) {
+        int baseOff = (b * seqLen + t) * modelDim + hOff;
+        int gOff = (b * seqLen + t) * numHeads + h;
+        float g = G[gOff];
+        long trajBase = ((long)(b * numHeads + h) * seqLen + t) * hh + (long)di * headDim;
+        long sprevBase = ((long)(b * numHeads + h) * seqLen + (t - 1)) * hh + (long)di * headDim;
+
+        float dOutVal = dOut[baseOff + di];
+        for (int ki = 0; ki < headDim; ki++) {
+            float sval = Straj[trajBase + ki];
+            atomicAdd(&dQ[baseOff + ki], dOutVal * sval);
+            dSrow[ki] += dOutVal * Q[baseOff + ki];
+        }
+
+        float vd = V[baseOff + di];
+        float dg = 0.0f;
+        float dVacc = 0.0f;
+        for (int ki = 0; ki < headDim; ki++) {
+            float dStv = dSrow[ki];
+            float sprev = (t > 0) ? Straj[sprevBase + ki] : 0.0f;
+            dg += dStv * sprev;
+            atomicAdd(&dK[baseOff + ki], dStv * vd);
+            dVacc += dStv * K[baseOff + ki];
+        }
+        atomicAdd(&dV[baseOff + di], dVacc);
+        atomicAdd(&dG[gOff], dg);
+
+        for (int ki = 0; ki < headDim; ki++) dSrow[ki] *= g;
+    }
+}
+";
+    }
+
+    public static string[] GetKernelNames()
+    {
+        return new[]
+        {
+            "gla_scan_forward",
+            "gla_scan_recompute",
+            "gla_scan_backward"
+        };
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaMamba2Kernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaMamba2Kernels.cs
@@ -1,0 +1,56 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// CUDA kernel for the fused Mamba-2 SSD scan forward (#1464). One thread per (batch, channel flatD).
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA.Kernels;
+
+internal static class CudaMamba2Kernels
+{
+    public const int MaxStateDim = 256;
+
+    public static string GetSource()
+    {
+        return @"
+#include <math.h>
+
+#define MAMBA2_MAX_STATEDIM 256
+
+extern ""C"" __global__ void mamba2_ssd_scan_forward(
+    const float* X, const float* delta, const float* aLog,
+    const float* B, const float* C, const float* D,
+    float* output,
+    int batch, int seqLen, int innerDim, int numHeads, int headDim, int sd)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = batch * innerDim;
+    if (gid >= total) return;
+
+    int flatD = gid % innerDim;
+    int b = gid / innerDim;
+    int hi = flatD / headDim;
+    float negA = -expf(aLog[hi]);
+    float dv = D[hi];
+
+    float h[MAMBA2_MAX_STATEDIM];
+    for (int n = 0; n < sd; n++) h[n] = 0.0f;
+
+    for (int t = 0; t < seqLen; t++) {
+        int btInner = (b * seqLen + t) * innerDim;
+        int btState = (b * seqLen + t) * sd;
+        int btHead = (b * seqLen + t) * numHeads;
+        float dt = delta[btHead + hi];
+        float aBar = expf(dt * negA);
+        float xv = X[btInner + flatD];
+        float y = 0.0f;
+        for (int n = 0; n < sd; n++) {
+            float hNew = aBar * h[n] + dt * B[btState + n] * xv;
+            h[n] = hNew;
+            y += C[btState + n] * hNew;
+        }
+        output[btInner + flatD] = y + dv * xv;
+    }
+}
+";
+    }
+
+    public static string[] GetKernelNames() => new[] { "mamba2_ssd_scan_forward" };
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaMambaKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaMambaKernels.cs
@@ -1,0 +1,54 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// CUDA kernel for the fused Mamba selective scan forward (#1464). One thread per (batch, channel).
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA.Kernels;
+
+internal static class CudaMambaKernels
+{
+    public const int MaxStateDim = 256;
+
+    public static string GetSource()
+    {
+        return @"
+#include <math.h>
+
+#define MAMBA_MAX_STATEDIM 256
+
+extern ""C"" __global__ void mamba_selective_scan_forward(
+    const float* X, const float* delta, const float* aLog,
+    const float* B, const float* C, const float* D,
+    float* output,
+    int batch, int seqLen, int innerDim, int stateDim)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = batch * innerDim;
+    if (gid >= total) return;
+
+    int di = gid % innerDim;
+    int b = gid / innerDim;
+    int hrow = di * stateDim;
+
+    float negA[MAMBA_MAX_STATEDIM];
+    float h[MAMBA_MAX_STATEDIM];
+    for (int ni = 0; ni < stateDim; ni++) { negA[ni] = -expf(aLog[hrow + ni]); h[ni] = 0.0f; }
+
+    for (int t = 0; t < seqLen; t++) {
+        int baseID = (b * seqLen + t) * innerDim;
+        int baseSD = (b * seqLen + t) * stateDim;
+        float dt = delta[baseID + di];
+        float xv = X[baseID + di];
+        float y = 0.0f;
+        for (int ni = 0; ni < stateDim; ni++) {
+            float aBar = expf(dt * negA[ni]);
+            float hv = aBar * h[ni] + dt * B[baseSD + ni] * xv;
+            h[ni] = hv;
+            y += C[baseSD + ni] * hv;
+        }
+        output[baseID + di] = y + D[di] * xv;
+    }
+}
+";
+    }
+
+    public static string[] GetKernelNames() => new[] { "mamba_selective_scan_forward" };
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaRgLruKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaRgLruKernels.cs
@@ -1,0 +1,40 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// CUDA kernel for the fused RG-LRU scan forward (#1464). One thread per (batch, channel).
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA.Kernels;
+
+internal static class CudaRgLruKernels
+{
+    public static string GetSource()
+    {
+        return @"
+#include <math.h>
+
+extern ""C"" __global__ void rglru_scan_forward(
+    const float* V, const float* R, const float* I, const float* decay,
+    float* output,
+    int batch, int seqLen, int recDim)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = batch * recDim;
+    if (gid >= total) return;
+
+    int c = gid % recDim;
+    int b = gid / recDim;
+    float base = 1.0f / (1.0f + expf(decay[c])); // sigmoid(-decay)
+    float h = 0.0f;
+
+    for (int t = 0; t < seqLen; t++) {
+        int off = (b * seqLen + t) * recDim + c;
+        float a = R[off] * base;
+        float om = 1.0f - a * a;
+        float s = om > 0.0f ? sqrtf(om) : 0.0f;
+        h = a * h + s * (I[off] * V[off]);
+        output[off] = h;
+    }
+}
+";
+    }
+
+    public static string[] GetKernelNames() => new[] { "rglru_scan_forward" };
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaRwkv4Kernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaRwkv4Kernels.cs
@@ -1,0 +1,56 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// CUDA kernel for the fused RWKV-4 time-mixing WKV scan forward (#1464). One thread per (batch, channel).
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA.Kernels;
+
+internal static class CudaRwkv4Kernels
+{
+    public static string GetSource()
+    {
+        return @"
+#include <math.h>
+
+#define RWKV4_NEG_INF (-1.0e38f)
+
+extern ""C"" __global__ void rwkv4_wkv_forward(
+    const float* R, const float* K, const float* V,
+    const float* timeDecay, const float* timeFirst,
+    float* output,
+    int batch, int seqLen, int modelDim)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = batch * modelDim;
+    if (gid >= total) return;
+
+    int c = gid % modelDim;
+    int b = gid / modelDim;
+    float w = -expf(timeDecay[c]);
+    float u = timeFirst[c];
+
+    float aa = 0.0f, bb = 0.0f, pp = RWKV4_NEG_INF;
+    for (int t = 0; t < seqLen; t++) {
+        int off = (b * seqLen + t) * modelDim + c;
+        float k = K[off];
+        float v = V[off];
+
+        float ww = u + k;
+        float q = fmaxf(pp, ww);
+        float e1 = expf(pp - q);
+        float e2 = expf(ww - q);
+        float wkv = (e1 * aa + e2 * v) / (e1 * bb + e2);
+        output[off] = (1.0f / (1.0f + expf(-R[off]))) * wkv;
+
+        float ww2 = pp + w;
+        float q2 = fmaxf(ww2, k);
+        float e1b = expf(ww2 - q2);
+        float e2b = expf(k - q2);
+        aa = e1b * aa + e2b * v;
+        bb = e1b * bb + e2b;
+        pp = q2;
+    }
+}
+";
+    }
+
+    public static string[] GetKernelNames() => new[] { "rwkv4_wkv_forward" };
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaXLstmKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaXLstmKernels.cs
@@ -1,0 +1,67 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// CUDA kernel for the fused xLSTM (mLSTM) matrix-memory scan forward (issue ooples/AiDotNet#1464).
+// Same design as HipXLstmKernels: one thread per (batch, head) carries the full C + n state.
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA.Kernels;
+
+internal static class CudaXLstmKernels
+{
+    public const int MaxHeadDim = 64;
+
+    public static string GetSource()
+    {
+        return @"
+#include <math.h>
+
+#define XLSTM_MAX_HEADDIM 64
+#define XLSTM_MAX_HH 4096
+#define XLSTM_IGATE_CLAMP 4.85e8f
+
+extern ""C"" __global__ void xlstm_scan_forward(
+    const float* Q, const float* K, const float* V,
+    const float* I, const float* F, const float* O,
+    float* output,
+    int batch, int seqLen, int modelDim, int numHeads, int headDim)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (gid >= batch * numHeads) return;
+
+    int h = gid % numHeads;
+    int b = gid / numHeads;
+    int hOff = h * headDim;
+    int hh = headDim * headDim;
+    float kappa = 1.0f / sqrtf((float)headDim);
+
+    float C[XLSTM_MAX_HH];
+    float n[XLSTM_MAX_HEADDIM];
+    for (int i = 0; i < hh; i++) C[i] = 0.0f;
+    for (int i = 0; i < headDim; i++) n[i] = 0.0f;
+
+    for (int t = 0; t < seqLen; t++) {
+        int baseOff = (b * seqLen + t) * modelDim + hOff;
+        int gOff = (b * seqLen + t) * numHeads + h;
+        float iv = I[gOff]; if (iv > XLSTM_IGATE_CLAMP) iv = XLSTM_IGATE_CLAMP;
+        float f = F[gOff], o = O[gOff];
+        for (int di = 0; di < headDim; di++) {
+            n[di] = f * n[di] + iv * (K[baseOff + di] * kappa);
+            float vv = V[baseOff + di];
+            int srow = di * headDim;
+            for (int ki = 0; ki < headDim; ki++)
+                C[srow + ki] = f * C[srow + ki] + iv * vv * (K[baseOff + ki] * kappa);
+        }
+        float nq = 0.0f;
+        for (int j = 0; j < headDim; j++) nq += n[j] * Q[baseOff + j];
+        float nf = fabsf(nq); if (nf < 1.0f) nf = 1.0f;
+        for (int di = 0; di < headDim; di++) {
+            int srow = di * headDim;
+            float num = 0.0f;
+            for (int ki = 0; ki < headDim; ki++) num += C[srow + ki] * Q[baseOff + ki];
+            output[baseOff + di] = o * num / nf;
+        }
+    }
+}
+";
+    }
+
+    public static string[] GetKernelNames() => new[] { "xlstm_scan_forward" };
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Cpu/RecurrenceCpuKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Cpu/RecurrenceCpuKernels.cs
@@ -131,4 +131,190 @@ internal static class RecurrenceCpuKernels
                 }
             }
     }
+
+    private const float XLstmIGateClamp = 4.85e8f;
+
+    /// <summary>
+    /// xLSTM (mLSTM) matrix-memory forward. q/k/v: [batch, seqLen, modelDim];
+    /// i/f/o gates: [batch, seqLen, numHeads]; output: [batch, seqLen, modelDim].
+    /// </summary>
+    public static void XLstmForward(
+        float[] q, float[] k, float[] v, float[] iGate, float[] fGate, float[] oGate, float[] output,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        int hh = headDim * headDim;
+        float kappa = 1.0f / MathF.Sqrt(headDim);
+        var c = new float[hh];
+        var n = new float[headDim];
+        for (int b = 0; b < batch; b++)
+            for (int h = 0; h < numHeads; h++)
+            {
+                Array.Clear(c, 0, hh);
+                Array.Clear(n, 0, headDim);
+                int hOff = h * headDim;
+                for (int t = 0; t < seqLen; t++)
+                {
+                    int baseOff = (b * seqLen + t) * modelDim + hOff;
+                    int gOff = (b * seqLen + t) * numHeads + h;
+                    float iv = iGate[gOff]; if (iv > XLstmIGateClamp) iv = XLstmIGateClamp;
+                    float f = fGate[gOff], o = oGate[gOff];
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        n[di] = f * n[di] + iv * (k[baseOff + di] * kappa);
+                        float vv = v[baseOff + di];
+                        int srow = di * headDim;
+                        for (int ki = 0; ki < headDim; ki++)
+                            c[srow + ki] = f * c[srow + ki] + iv * vv * (k[baseOff + ki] * kappa);
+                    }
+                    float nq = 0.0f;
+                    for (int j = 0; j < headDim; j++) nq += n[j] * q[baseOff + j];
+                    float nf = MathF.Abs(nq); if (nf < 1.0f) nf = 1.0f;
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int srow = di * headDim;
+                        float num = 0.0f;
+                        for (int ki = 0; ki < headDim; ki++) num += c[srow + ki] * q[baseOff + ki];
+                        output[baseOff + di] = o * num / nf;
+                    }
+                }
+            }
+    }
+
+    /// <summary>
+    /// xLSTM BPTT backward. dQ/dK/dV: [batch, seqLen, modelDim];
+    /// dI/dF/dO: [batch, seqLen, numHeads]. All grad outputs are overwritten.
+    /// </summary>
+    public static void XLstmBackward(
+        float[] dOut, float[] q, float[] k, float[] v, float[] iGate, float[] fGate, float[] oGate,
+        float[] dQ, float[] dK, float[] dV, float[] dI, float[] dF, float[] dO,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        Array.Clear(dQ, 0, dQ.Length); Array.Clear(dK, 0, dK.Length); Array.Clear(dV, 0, dV.Length);
+        Array.Clear(dI, 0, dI.Length); Array.Clear(dF, 0, dF.Length); Array.Clear(dO, 0, dO.Length);
+
+        int hh = headDim * headDim;
+        float kappa = 1.0f / MathF.Sqrt(headDim);
+        var ctraj = new float[seqLen * hh];
+        var ntraj = new float[seqLen * headDim];
+        var c = new float[hh];
+        var n = new float[headDim];
+        var dC = new float[hh];
+        var dN = new float[headDim];
+        var dKS = new float[headDim];
+        var dCp = new float[hh];
+        var dNp = new float[headDim];
+
+        for (int b = 0; b < batch; b++)
+            for (int h = 0; h < numHeads; h++)
+            {
+                int hOff = h * headDim;
+
+                Array.Clear(c, 0, hh); Array.Clear(n, 0, headDim);
+                for (int t = 0; t < seqLen; t++)
+                {
+                    Array.Copy(c, 0, ctraj, t * hh, hh);
+                    Array.Copy(n, 0, ntraj, t * headDim, headDim);
+                    int baseOff = (b * seqLen + t) * modelDim + hOff;
+                    int gOff = (b * seqLen + t) * numHeads + h;
+                    float iv = iGate[gOff]; if (iv > XLstmIGateClamp) iv = XLstmIGateClamp;
+                    float f = fGate[gOff];
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        n[di] = f * n[di] + iv * (k[baseOff + di] * kappa);
+                        float vv = v[baseOff + di];
+                        int srow = di * headDim;
+                        for (int ki = 0; ki < headDim; ki++)
+                            c[srow + ki] = f * c[srow + ki] + iv * vv * (k[baseOff + ki] * kappa);
+                    }
+                }
+
+                Array.Clear(dC, 0, hh); Array.Clear(dN, 0, headDim);
+                for (int t = seqLen - 1; t >= 0; t--)
+                {
+                    int baseOff = (b * seqLen + t) * modelDim + hOff;
+                    int gOff = (b * seqLen + t) * numHeads + h;
+                    float iv = iGate[gOff]; bool iClamped = iv > XLstmIGateClamp; if (iClamped) iv = XLstmIGateClamp;
+                    float f = fGate[gOff], o = oGate[gOff];
+                    int cpOff = t * hh, npOff = t * headDim;
+
+                    float nq = 0.0f;
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        float nCur = f * ntraj[npOff + di] + iv * (k[baseOff + di] * kappa);
+                        n[di] = nCur;
+                        nq += nCur * q[baseOff + di];
+                    }
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        float vv = v[baseOff + di];
+                        int srow = di * headDim;
+                        for (int ki = 0; ki < headDim; ki++)
+                            c[srow + ki] = f * ctraj[cpOff + srow + ki] + iv * vv * (k[baseOff + ki] * kappa);
+                    }
+                    float absnq = MathF.Abs(nq);
+                    float nf = absnq < 1.0f ? 1.0f : absnq;
+                    float dNfSign = absnq > 1.0f ? (nq > 0 ? 1.0f : -1.0f) : 0.0f;
+
+                    float dO_acc = 0.0f, dnf = 0.0f;
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int srow = di * headDim;
+                        float dh = dOut[baseOff + di];
+                        float num = 0.0f;
+                        for (int ki = 0; ki < headDim; ki++) num += c[srow + ki] * q[baseOff + ki];
+                        dO_acc += dh * num / nf;
+                        float dNum = dh * o / nf;
+                        dnf += dh * o * num * (-1.0f / (nf * nf));
+                        for (int ki = 0; ki < headDim; ki++)
+                        {
+                            dC[srow + ki] += dNum * q[baseOff + ki];
+                            dQ[baseOff + ki] += dNum * c[srow + ki];
+                        }
+                    }
+                    dO[gOff] += dO_acc;
+
+                    float dnq = dnf * dNfSign;
+                    for (int j = 0; j < headDim; j++)
+                    {
+                        dN[j] += dnq * q[baseOff + j];
+                        dQ[baseOff + j] += dnq * n[j];
+                    }
+
+                    Array.Clear(dKS, 0, headDim);
+                    float dF_acc = 0.0f, dI_acc = 0.0f;
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int srow = di * headDim;
+                        float vv = v[baseOff + di];
+                        float dVacc = 0.0f;
+                        for (int ki = 0; ki < headDim; ki++)
+                        {
+                            float dCt = dC[srow + ki];
+                            float kSki = k[baseOff + ki] * kappa;
+                            dF_acc += dCt * ctraj[cpOff + srow + ki];
+                            dCp[srow + ki] = dCt * f;
+                            dI_acc += dCt * vv * kSki;
+                            dVacc += dCt * iv * kSki;
+                            dKS[ki] += dCt * iv * vv;
+                        }
+                        dV[baseOff + di] += dVacc;
+                    }
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        float dNt = dN[di];
+                        dF_acc += dNt * ntraj[npOff + di];
+                        dNp[di] = dNt * f;
+                        dI_acc += dNt * (k[baseOff + di] * kappa);
+                        dKS[di] += dNt * iv;
+                    }
+                    for (int j = 0; j < headDim; j++) dK[baseOff + j] += dKS[j] * kappa;
+
+                    dI[gOff] += iClamped ? 0.0f : dI_acc;
+                    dF[gOff] += dF_acc;
+
+                    Array.Copy(dCp, 0, dC, 0, hh);
+                    Array.Copy(dNp, 0, dN, 0, headDim);
+                }
+            }
+    }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Cpu/RecurrenceCpuKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Cpu/RecurrenceCpuKernels.cs
@@ -212,6 +212,52 @@ internal static class RecurrenceCpuKernels
         }
     }
 
+    /// <summary>
+    /// RWKV-4 time-mixing WKV forward. r/k/v: [batch, seqLen, modelDim]; timeDecay/timeFirst: [modelDim].
+    /// Per-channel numerically-stable WKV recurrence (running max pp). out = sigmoid(r) * wkv.
+    /// </summary>
+    public static void Rwkv4WkvForward(
+        float[] r, float[] k, float[] v, float[] timeDecay, float[] timeFirst, float[] output,
+        int batch, int seqLen, int modelDim)
+    {
+        var w = new float[modelDim];
+        for (int c = 0; c < modelDim; c++) w[c] = -MathF.Exp(timeDecay[c]);
+        var aa = new float[modelDim];
+        var bb = new float[modelDim];
+        var pp = new float[modelDim];
+        for (int b = 0; b < batch; b++)
+        {
+            Array.Clear(aa, 0, modelDim);
+            Array.Clear(bb, 0, modelDim);
+            for (int c = 0; c < modelDim; c++) pp[c] = float.NegativeInfinity;
+            for (int t = 0; t < seqLen; t++)
+            {
+                int baseOff = (b * seqLen + t) * modelDim;
+                for (int c = 0; c < modelDim; c++)
+                {
+                    float kk = k[baseOff + c];
+                    float vv = v[baseOff + c];
+                    float u = timeFirst[c];
+
+                    float ww = u + kk;
+                    float q = MathF.Max(pp[c], ww);
+                    float e1 = MathF.Exp(pp[c] - q);
+                    float e2 = MathF.Exp(ww - q);
+                    float wkv = (e1 * aa[c] + e2 * vv) / (e1 * bb[c] + e2);
+                    output[baseOff + c] = (1.0f / (1.0f + MathF.Exp(-r[baseOff + c]))) * wkv;
+
+                    float ww2 = pp[c] + w[c];
+                    float q2 = MathF.Max(ww2, kk);
+                    float e1b = MathF.Exp(ww2 - q2);
+                    float e2b = MathF.Exp(kk - q2);
+                    aa[c] = e1b * aa[c] + e2b * vv;
+                    bb[c] = e1b * bb[c] + e2b;
+                    pp[c] = q2;
+                }
+            }
+        }
+    }
+
     private const float XLstmIGateClamp = 4.85e8f;
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Cpu/RecurrenceCpuKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Cpu/RecurrenceCpuKernels.cs
@@ -182,6 +182,36 @@ internal static class RecurrenceCpuKernels
             }
     }
 
+    /// <summary>
+    /// RG-LRU (real-gated linear recurrent unit) forward. value/recGate/inpGate: [batch, seqLen, recDim];
+    /// decay: [recDim]. base = sigmoid(-decay); a = recGate*base; h = a*h + sqrt(max(0,1-a^2))*(inpGate*value).
+    /// </summary>
+    public static void RgLruForward(
+        float[] value, float[] recGate, float[] inpGate, float[] decay, float[] output,
+        int batch, int seqLen, int recDim)
+    {
+        var baseDecay = new float[recDim];
+        for (int c = 0; c < recDim; c++) baseDecay[c] = 1.0f / (1.0f + MathF.Exp(decay[c])); // sigmoid(-decay)
+        var h = new float[recDim];
+        for (int b = 0; b < batch; b++)
+        {
+            Array.Clear(h, 0, recDim);
+            for (int t = 0; t < seqLen; t++)
+            {
+                int off = (b * seqLen + t) * recDim;
+                for (int c = 0; c < recDim; c++)
+                {
+                    float a = recGate[off + c] * baseDecay[c];
+                    float om = 1.0f - a * a;
+                    float s = om > 0.0f ? MathF.Sqrt(om) : 0.0f;
+                    float hv = a * h[c] + s * (inpGate[off + c] * value[off + c]);
+                    h[c] = hv;
+                    output[off + c] = hv;
+                }
+            }
+        }
+    }
+
     private const float XLstmIGateClamp = 4.85e8f;
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Cpu/RecurrenceCpuKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Cpu/RecurrenceCpuKernels.cs
@@ -342,6 +342,77 @@ internal static class RecurrenceCpuKernels
         }
     }
 
+    /// <summary>
+    /// Fused linear (LM head) + cross-entropy with int targets, WITHOUT materializing the [N, vocab]
+    /// logits. hidden: [N, d]; weight: [d, vocab]; bias: [vocab]; targetIds: [N]. Returns mean CE.
+    /// </summary>
+    public static float FusedLinearCeIndex(
+        float[] hidden, float[] weight, float[] bias, int[] targetIds, int n, int d, int vocab)
+    {
+        double total = 0.0;
+        for (int r = 0; r < n; r++)
+        {
+            int hRow = r * d;
+            float max = float.NegativeInfinity;
+            float logitTarget = 0.0f;
+            int id = targetIds[r];
+            for (int vv = 0; vv < vocab; vv++)
+            {
+                float s = bias[vv];
+                for (int j = 0; j < d; j++) s += hidden[hRow + j] * weight[j * vocab + vv];
+                if (s > max) max = s;
+                if (vv == id) logitTarget = s;
+            }
+            float sumExp = 0.0f;
+            for (int vv = 0; vv < vocab; vv++)
+            {
+                float s = bias[vv];
+                for (int j = 0; j < d; j++) s += hidden[hRow + j] * weight[j * vocab + vv];
+                sumExp += MathF.Exp(s - max);
+            }
+            total += (max + MathF.Log(sumExp)) - logitTarget;
+        }
+        return (float)(total / n);
+    }
+
+    /// <summary>
+    /// Fused linear (LM head) + cross-entropy with dense [N, vocab] soft targets.
+    /// </summary>
+    public static float FusedLinearCeDense(
+        float[] hidden, float[] weight, float[] bias, float[] target, int n, int d, int vocab)
+    {
+        double total = 0.0;
+        for (int r = 0; r < n; r++)
+        {
+            int hRow = r * d;
+            int tRow = r * vocab;
+            float max = float.NegativeInfinity;
+            for (int vv = 0; vv < vocab; vv++)
+            {
+                float s = bias[vv];
+                for (int j = 0; j < d; j++) s += hidden[hRow + j] * weight[j * vocab + vv];
+                if (s > max) max = s;
+            }
+            float sumExp = 0.0f;
+            for (int vv = 0; vv < vocab; vv++)
+            {
+                float s = bias[vv];
+                for (int j = 0; j < d; j++) s += hidden[hRow + j] * weight[j * vocab + vv];
+                sumExp += MathF.Exp(s - max);
+            }
+            float lse = max + MathF.Log(sumExp);
+            float rowLoss = 0.0f;
+            for (int vv = 0; vv < vocab; vv++)
+            {
+                float s = bias[vv];
+                for (int j = 0; j < d; j++) s += hidden[hRow + j] * weight[j * vocab + vv];
+                rowLoss += target[tRow + vv] * (s - lse);
+            }
+            total += -rowLoss;
+        }
+        return (float)(total / n);
+    }
+
     private const float XLstmIGateClamp = 4.85e8f;
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Cpu/RecurrenceCpuKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Cpu/RecurrenceCpuKernels.cs
@@ -1,0 +1,134 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Shared host (CPU) reference implementations of the fused recurrence scans (#1464),
+// used as the correct fallback by GPU backends that do not yet ship a native compute
+// shader for these ops (Metal / Vulkan / WebGPU follow the same CPU-fallback precedent
+// their LstmForwardSequence already uses). The math mirrors the CpuEngine.*Scan kernels
+// exactly so GPU-vs-CPU parity holds bit-for-bit on these backends.
+
+using System;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.Cpu;
+
+internal static class RecurrenceCpuKernels
+{
+    /// <summary>
+    /// Gated Linear Attention forward. q/k/v: [batch, seqLen, modelDim];
+    /// gate: [batch, seqLen, numHeads]; output: [batch, seqLen, modelDim].
+    ///   S_t[di,ki] = g_t * S_{t-1}[di,ki] + V_t[di] * K_t[ki]
+    ///   O_t[di]    = sum_ki S_t[di,ki] * Q_t[ki]
+    /// </summary>
+    public static void GlaForward(
+        float[] q, float[] k, float[] v, float[] gate, float[] output,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        int hh = headDim * headDim;
+        var s = new float[hh];
+        for (int b = 0; b < batch; b++)
+            for (int h = 0; h < numHeads; h++)
+            {
+                Array.Clear(s, 0, hh);
+                int hOff = h * headDim;
+                for (int t = 0; t < seqLen; t++)
+                {
+                    int baseOff = (b * seqLen + t) * modelDim + hOff;
+                    float g = gate[(b * seqLen + t) * numHeads + h];
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        float vd = v[baseOff + di];
+                        int srow = di * headDim;
+                        for (int ki = 0; ki < headDim; ki++)
+                            s[srow + ki] = g * s[srow + ki] + vd * k[baseOff + ki];
+                    }
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int srow = di * headDim;
+                        float o = 0.0f;
+                        for (int ki = 0; ki < headDim; ki++)
+                            o += s[srow + ki] * q[baseOff + ki];
+                        output[baseOff + di] = o;
+                    }
+                }
+            }
+    }
+
+    /// <summary>
+    /// Gated Linear Attention BPTT backward. dQ/dK/dV: [batch, seqLen, modelDim];
+    /// dG: [batch, seqLen, numHeads]. All grad outputs are overwritten (not accumulated).
+    /// </summary>
+    public static void GlaBackward(
+        float[] dOut, float[] q, float[] k, float[] v, float[] gate,
+        float[] dQ, float[] dK, float[] dV, float[] dG,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        Array.Clear(dQ, 0, dQ.Length);
+        Array.Clear(dK, 0, dK.Length);
+        Array.Clear(dV, 0, dV.Length);
+        Array.Clear(dG, 0, dG.Length);
+
+        int hh = headDim * headDim;
+        var straj = new float[seqLen * hh];
+        var s = new float[hh];
+        var dS = new float[hh];
+
+        for (int b = 0; b < batch; b++)
+            for (int h = 0; h < numHeads; h++)
+            {
+                int hOff = h * headDim;
+
+                Array.Clear(s, 0, hh);
+                for (int t = 0; t < seqLen; t++)
+                {
+                    int baseOff = (b * seqLen + t) * modelDim + hOff;
+                    float g = gate[(b * seqLen + t) * numHeads + h];
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        float vd = v[baseOff + di];
+                        int srow = di * headDim;
+                        for (int ki = 0; ki < headDim; ki++)
+                            s[srow + ki] = g * s[srow + ki] + vd * k[baseOff + ki];
+                    }
+                    Array.Copy(s, 0, straj, t * hh, hh);
+                }
+
+                Array.Clear(dS, 0, hh);
+                for (int t = seqLen - 1; t >= 0; t--)
+                {
+                    int baseOff = (b * seqLen + t) * modelDim + hOff;
+                    int gOff = (b * seqLen + t) * numHeads + h;
+                    int stOff = t * hh;
+                    int sprevOff = (t - 1) * hh;
+                    float g = gate[gOff];
+
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        float dOutVal = dOut[baseOff + di];
+                        int srow = di * headDim;
+                        for (int ki = 0; ki < headDim; ki++)
+                        {
+                            float sval = straj[stOff + srow + ki];
+                            dQ[baseOff + ki] += dOutVal * sval;
+                            dS[srow + ki] += dOutVal * q[baseOff + ki];
+                        }
+                    }
+
+                    float dg = 0.0f;
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        float vd = v[baseOff + di];
+                        int srow = di * headDim;
+                        for (int ki = 0; ki < headDim; ki++)
+                        {
+                            float dStv = dS[srow + ki];
+                            float sprev = t > 0 ? straj[sprevOff + srow + ki] : 0.0f;
+                            dg += dStv * sprev;
+                            dK[baseOff + ki] += dStv * vd;
+                            dV[baseOff + di] += dStv * k[baseOff + ki];
+                        }
+                    }
+                    dG[gOff] += dg;
+
+                    for (int i = 0; i < hh; i++) dS[i] *= g;
+                }
+            }
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Cpu/RecurrenceCpuKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Cpu/RecurrenceCpuKernels.cs
@@ -297,6 +297,51 @@ internal static class RecurrenceCpuKernels
         }
     }
 
+    /// <summary>
+    /// Mamba-2 SSD scan forward. x: [batch, seqLen, innerDim]; delta: [batch, seqLen, numHeads];
+    /// aLog/dParam: [numHeads] (per head); bParam/cParam: [batch, seqLen, stateDim]. Per channel
+    /// flatD = hi*headDim+di carries an independent state h[flatD, 0..stateDim).
+    /// </summary>
+    public static void Mamba2SsdScanForward(
+        float[] x, float[] delta, float[] aLog, float[] bParam, float[] cParam, float[] dParam, float[] output,
+        int batch, int seqLen, int innerDim, int numHeads, int headDim, int sd)
+    {
+        var negA = new float[numHeads];
+        for (int hi = 0; hi < numHeads; hi++) negA[hi] = -MathF.Exp(aLog[hi]);
+        var h = new float[innerDim * sd];
+        for (int b = 0; b < batch; b++)
+        {
+            Array.Clear(h, 0, h.Length);
+            for (int t = 0; t < seqLen; t++)
+            {
+                int btInner = (b * seqLen + t) * innerDim;
+                int btState = (b * seqLen + t) * sd;
+                int btHead = (b * seqLen + t) * numHeads;
+                for (int hi = 0; hi < numHeads; hi++)
+                {
+                    float dt = delta[btHead + hi];
+                    float aBar = MathF.Exp(dt * negA[hi]);
+                    float dv = dParam[hi];
+                    int dimStart = hi * headDim;
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int flatD = dimStart + di;
+                        float xv = x[btInner + flatD];
+                        int hsBase = flatD * sd;
+                        float y = 0.0f;
+                        for (int n = 0; n < sd; n++)
+                        {
+                            float hNew = aBar * h[hsBase + n] + dt * bParam[btState + n] * xv;
+                            h[hsBase + n] = hNew;
+                            y += cParam[btState + n] * hNew;
+                        }
+                        output[btInner + flatD] = y + dv * xv;
+                    }
+                }
+            }
+        }
+    }
+
     private const float XLstmIGateClamp = 4.85e8f;
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Cpu/RecurrenceCpuKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Cpu/RecurrenceCpuKernels.cs
@@ -132,6 +132,56 @@ internal static class RecurrenceCpuKernels
             }
     }
 
+    /// <summary>
+    /// Gated DeltaNet (delta-rule) forward. q/k/v: [batch, seqLen, modelDim];
+    /// alpha (forget) / beta (write): [batch, seqLen, numHeads]; output: [batch, seqLen, modelDim].
+    ///   sK[di]     = sum_ki S[di,ki] * (kappa*K[ki])
+    ///   S[di,ki]  := alpha * S[di,ki] + beta*(V[di]-sK[di]) * (kappa*K[ki])
+    ///   O[di]      = sum_ki S[di,ki] * Q[ki]
+    /// </summary>
+    public static void GatedDeltaNetForward(
+        float[] q, float[] k, float[] v, float[] alpha, float[] beta, float[] output,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        int hh = headDim * headDim;
+        float kappa = 1.0f / MathF.Sqrt(headDim);
+        var s = new float[hh];
+        var sK = new float[headDim];
+        for (int b = 0; b < batch; b++)
+            for (int h = 0; h < numHeads; h++)
+            {
+                Array.Clear(s, 0, hh);
+                int hOff = h * headDim;
+                for (int t = 0; t < seqLen; t++)
+                {
+                    int baseOff = (b * seqLen + t) * modelDim + hOff;
+                    int gIdx = (b * seqLen + t) * numHeads + h;
+                    float a = alpha[gIdx], bet = beta[gIdx];
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int srow = di * headDim;
+                        float acc = 0.0f;
+                        for (int ki = 0; ki < headDim; ki++) acc += s[srow + ki] * (k[baseOff + ki] * kappa);
+                        sK[di] = acc;
+                    }
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int srow = di * headDim;
+                        float bd = bet * (v[baseOff + di] - sK[di]);
+                        for (int ki = 0; ki < headDim; ki++)
+                            s[srow + ki] = a * s[srow + ki] + bd * (k[baseOff + ki] * kappa);
+                    }
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int srow = di * headDim;
+                        float o = 0.0f;
+                        for (int ki = 0; ki < headDim; ki++) o += s[srow + ki] * q[baseOff + ki];
+                        output[baseOff + di] = o;
+                    }
+                }
+            }
+    }
+
     private const float XLstmIGateClamp = 4.85e8f;
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Cpu/RecurrenceCpuKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Cpu/RecurrenceCpuKernels.cs
@@ -258,6 +258,45 @@ internal static class RecurrenceCpuKernels
         }
     }
 
+    /// <summary>
+    /// Mamba selective scan forward. x/delta: [batch, seqLen, innerDim]; aLog: [innerDim, stateDim]
+    /// (A = -exp(aLog)); bParam/cParam: [batch, seqLen, stateDim]; dParam: [innerDim].
+    ///   aBar = exp(delta * A[di,ni]);  h[di,ni] := aBar*h[di,ni] + delta*B[ni]*x[di]
+    ///   y[di] = sum_ni C[ni]*h[di,ni] + D[di]*x[di]
+    /// </summary>
+    public static void MambaSelectiveScanForward(
+        float[] x, float[] delta, float[] aLog, float[] bParam, float[] cParam, float[] dParam, float[] output,
+        int batch, int seqLen, int innerDim, int stateDim)
+    {
+        var negA = new float[innerDim * stateDim];
+        for (int i = 0; i < negA.Length; i++) negA[i] = -MathF.Exp(aLog[i]);
+        var h = new float[innerDim * stateDim];
+        for (int b = 0; b < batch; b++)
+        {
+            Array.Clear(h, 0, h.Length);
+            for (int t = 0; t < seqLen; t++)
+            {
+                int baseID = (b * seqLen + t) * innerDim;
+                int baseSD = (b * seqLen + t) * stateDim;
+                for (int di = 0; di < innerDim; di++)
+                {
+                    float dt = delta[baseID + di];
+                    float xv = x[baseID + di];
+                    int hrow = di * stateDim;
+                    float y = 0.0f;
+                    for (int ni = 0; ni < stateDim; ni++)
+                    {
+                        float aBar = MathF.Exp(dt * negA[hrow + ni]);
+                        float hv = aBar * h[hrow + ni] + dt * bParam[baseSD + ni] * xv;
+                        h[hrow + ni] = hv;
+                        y += cParam[baseSD + ni] * hv;
+                    }
+                    output[baseID + di] = y + dParam[di] * xv;
+                }
+            }
+        }
+    }
+
     private const float XLstmIGateClamp = 4.85e8f;
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Cpu/RecurrenceCpuKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Cpu/RecurrenceCpuKernels.cs
@@ -349,6 +349,8 @@ internal static class RecurrenceCpuKernels
     public static float FusedLinearCeIndex(
         float[] hidden, float[] weight, float[] bias, int[] targetIds, int n, int d, int vocab)
     {
+        if (n <= 0 || d <= 0 || vocab <= 0)
+            throw new ArgumentOutOfRangeException(nameof(n), "Fused CE dimensions (n, d, vocab) must be positive.");
         double total = 0.0;
         for (int r = 0; r < n; r++)
         {
@@ -356,6 +358,8 @@ internal static class RecurrenceCpuKernels
             float max = float.NegativeInfinity;
             float logitTarget = 0.0f;
             int id = targetIds[r];
+            if (id < 0 || id >= vocab)
+                throw new ArgumentOutOfRangeException(nameof(targetIds), $"targetIds[{r}]={id} is out of range [0, {vocab}).");
             for (int vv = 0; vv < vocab; vv++)
             {
                 float s = bias[vv];

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.FusedKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.FusedKernels.cs
@@ -432,4 +432,23 @@ public sealed partial class HipBackend
         uint total = (uint)(batch * numHeads);
         LaunchKernel(kernel, (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize, (uint)DefaultBlockSize, args);
     }
+
+    // ── Fused Gated DeltaNet scan forward (#1464) ──────────────────────────────────────────
+    public unsafe void GatedDeltaNetScanForward(
+        IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer alpha, IGpuBuffer beta, IGpuBuffer output,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        if (headDim > Kernels.HipGatedDeltaNetKernels.MaxHeadDim)
+            throw new InvalidOperationException(
+                $"GatedDeltaNet headDim ({headDim}) exceeds max ({Kernels.HipGatedDeltaNetKernels.MaxHeadDim}).");
+        if (!_kernelCache.TryGetValue("gated_delta_scan_forward", out var kernel))
+            throw new InvalidOperationException("HIP kernel not found: gated_delta_scan_forward");
+
+        IntPtr pq = q.Handle, pk = k.Handle, pv = v.Handle, pa = alpha.Handle, pb = beta.Handle, pout = output.Handle;
+        void** args = stackalloc void*[11];
+        args[0] = &pq; args[1] = &pk; args[2] = &pv; args[3] = &pa; args[4] = &pb; args[5] = &pout;
+        args[6] = &batch; args[7] = &seqLen; args[8] = &modelDim; args[9] = &numHeads; args[10] = &headDim;
+        uint total = (uint)(batch * numHeads * headDim);
+        LaunchKernel(kernel, (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize, (uint)DefaultBlockSize, args);
+    }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.FusedKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.FusedKernels.cs
@@ -502,4 +502,23 @@ public sealed partial class HipBackend
         uint total = (uint)(batch * innerDim);
         LaunchKernel(kernel, (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize, (uint)DefaultBlockSize, args);
     }
+
+    // ── Fused Mamba-2 SSD scan forward (#1464) ─────────────────────────────────────────────
+    public unsafe void Mamba2SsdScanForward(
+        IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,
+        IGpuBuffer output, int batch, int seqLen, int innerDim, int numHeads, int headDim, int stateDim)
+    {
+        if (stateDim > Kernels.HipMamba2Kernels.MaxStateDim)
+            throw new InvalidOperationException(
+                $"Mamba-2 stateDim ({stateDim}) exceeds max ({Kernels.HipMamba2Kernels.MaxStateDim}).");
+        if (!_kernelCache.TryGetValue("mamba2_ssd_scan_forward", out var kernel))
+            throw new InvalidOperationException("HIP kernel not found: mamba2_ssd_scan_forward");
+
+        IntPtr px = x.Handle, pdt = delta.Handle, pa = aLog.Handle, pb = bParam.Handle, pc = cParam.Handle, pd = dParam.Handle, pout = output.Handle;
+        void** args = stackalloc void*[13];
+        args[0] = &px; args[1] = &pdt; args[2] = &pa; args[3] = &pb; args[4] = &pc; args[5] = &pd; args[6] = &pout;
+        args[7] = &batch; args[8] = &seqLen; args[9] = &innerDim; args[10] = &numHeads; args[11] = &headDim; args[12] = &stateDim;
+        uint total = (uint)(batch * innerDim);
+        LaunchKernel(kernel, (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize, (uint)DefaultBlockSize, args);
+    }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.FusedKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.FusedKernels.cs
@@ -392,7 +392,11 @@ public sealed partial class HipBackend
             throw new InvalidOperationException("HIP kernel not found: gla_scan_recompute / gla_scan_backward");
 
         // State trajectory scratch: [batch * numHeads * seqLen * headDim * headDim].
-        int trajLen = batch * numHeads * seqLen * headDim * headDim;
+        long trajLenLong = (long)batch * numHeads * seqLen * headDim * headDim;
+        if (trajLenLong > int.MaxValue)
+            throw new InvalidOperationException(
+                $"GLA trajectory buffer size ({trajLenLong}) exceeds int.MaxValue.");
+        int trajLen = (int)trajLenLong;
         using var trajBuf = AllocateBuffer(trajLen);
         uint total = (uint)(batch * numHeads * headDim);
         uint grid = (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.FusedKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.FusedKernels.cs
@@ -521,4 +521,30 @@ public sealed partial class HipBackend
         uint total = (uint)(batch * innerDim);
         LaunchKernel(kernel, (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize, (uint)DefaultBlockSize, args);
     }
+
+    // ── Fused linear (LM head) + cross-entropy (#1464) ─────────────────────────────────────
+    // Returns the mean cross-entropy over the N rows. targetIds holds the class ids as floats.
+    public unsafe float FusedLinearCrossEntropyIndex(
+        IGpuBuffer hidden, IGpuBuffer weight, IGpuBuffer bias, IGpuBuffer targetIds, int n, int d, int vocab)
+        => FusedCeLaunch("fused_linear_ce_index", hidden, weight, bias, targetIds, n, d, vocab);
+
+    public unsafe float FusedLinearCrossEntropyDense(
+        IGpuBuffer hidden, IGpuBuffer weight, IGpuBuffer bias, IGpuBuffer target, int n, int d, int vocab)
+        => FusedCeLaunch("fused_linear_ce_dense", hidden, weight, bias, target, n, d, vocab);
+
+    private unsafe float FusedCeLaunch(
+        string kernelName, IGpuBuffer hidden, IGpuBuffer weight, IGpuBuffer bias, IGpuBuffer tgt, int n, int d, int vocab)
+    {
+        if (!_kernelCache.TryGetValue(kernelName, out var kernel))
+            throw new InvalidOperationException($"HIP kernel not found: {kernelName}");
+        using var lossBuf = AllocateBuffer(1); // zeroed
+        IntPtr ph = hidden.Handle, pw = weight.Handle, pb = bias.Handle, pt = tgt.Handle, pl = lossBuf.Handle;
+        void** args = stackalloc void*[8];
+        args[0] = &ph; args[1] = &pw; args[2] = &pb; args[3] = &pt; args[4] = &pl;
+        args[5] = &n; args[6] = &d; args[7] = &vocab;
+        uint total = (uint)n;
+        LaunchKernel(kernel, (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize, (uint)DefaultBlockSize, args);
+        var loss = DownloadBuffer(lossBuf);
+        return loss[0] / n;
+    }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.FusedKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.FusedKernels.cs
@@ -483,4 +483,23 @@ public sealed partial class HipBackend
         uint total = (uint)(batch * modelDim);
         LaunchKernel(kernel, (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize, (uint)DefaultBlockSize, args);
     }
+
+    // ── Fused Mamba selective scan forward (#1464) ─────────────────────────────────────────
+    public unsafe void MambaSelectiveScanForward(
+        IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,
+        IGpuBuffer output, int batch, int seqLen, int innerDim, int stateDim)
+    {
+        if (stateDim > Kernels.HipMambaKernels.MaxStateDim)
+            throw new InvalidOperationException(
+                $"Mamba stateDim ({stateDim}) exceeds max ({Kernels.HipMambaKernels.MaxStateDim}).");
+        if (!_kernelCache.TryGetValue("mamba_selective_scan_forward", out var kernel))
+            throw new InvalidOperationException("HIP kernel not found: mamba_selective_scan_forward");
+
+        IntPtr px = x.Handle, pdt = delta.Handle, pa = aLog.Handle, pb = bParam.Handle, pc = cParam.Handle, pd = dParam.Handle, pout = output.Handle;
+        void** args = stackalloc void*[11];
+        args[0] = &px; args[1] = &pdt; args[2] = &pa; args[3] = &pb; args[4] = &pc; args[5] = &pd; args[6] = &pout;
+        args[7] = &batch; args[8] = &seqLen; args[9] = &innerDim; args[10] = &stateDim;
+        uint total = (uint)(batch * innerDim);
+        LaunchKernel(kernel, (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize, (uint)DefaultBlockSize, args);
+    }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.FusedKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.FusedKernels.cs
@@ -411,4 +411,25 @@ public sealed partial class HipBackend
         ba[10] = &batch; ba[11] = &seqLen; ba[12] = &modelDim; ba[13] = &numHeads; ba[14] = &headDim;
         LaunchKernel(backward, grid, (uint)DefaultBlockSize, ba);
     }
+
+    // ── Fused xLSTM (mLSTM) scan forward (#1464) ───────────────────────────────────────────
+    public unsafe void XLstmScanForward(
+        IGpuBuffer q, IGpuBuffer k, IGpuBuffer v,
+        IGpuBuffer iGate, IGpuBuffer fGate, IGpuBuffer oGate, IGpuBuffer output,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        if (headDim > Kernels.HipXLstmKernels.MaxHeadDim)
+            throw new InvalidOperationException(
+                $"xLSTM headDim ({headDim}) exceeds max ({Kernels.HipXLstmKernels.MaxHeadDim}).");
+        if (!_kernelCache.TryGetValue("xlstm_scan_forward", out var kernel))
+            throw new InvalidOperationException("HIP kernel not found: xlstm_scan_forward");
+
+        IntPtr pq = q.Handle, pk = k.Handle, pv = v.Handle;
+        IntPtr pi = iGate.Handle, pf = fGate.Handle, po = oGate.Handle, pout = output.Handle;
+        void** args = stackalloc void*[12];
+        args[0] = &pq; args[1] = &pk; args[2] = &pv; args[3] = &pi; args[4] = &pf; args[5] = &po; args[6] = &pout;
+        args[7] = &batch; args[8] = &seqLen; args[9] = &modelDim; args[10] = &numHeads; args[11] = &headDim;
+        uint total = (uint)(batch * numHeads);
+        LaunchKernel(kernel, (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize, (uint)DefaultBlockSize, args);
+    }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.FusedKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.FusedKernels.cs
@@ -363,6 +363,10 @@ public sealed partial class HipBackend
         IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer gate, IGpuBuffer output,
         int batch, int seqLen, int modelDim, int numHeads, int headDim)
     {
+        if (batch <= 0 || seqLen <= 0 || modelDim <= 0 || numHeads <= 0 || headDim <= 0)
+            throw new ArgumentOutOfRangeException(nameof(batch), "GLA dimensions must be positive.");
+        if (modelDim != numHeads * headDim)
+            throw new ArgumentException($"modelDim ({modelDim}) must equal numHeads * headDim ({numHeads * headDim}).");
         if (headDim > Kernels.HipGlaKernels.MaxHeadDim)
             throw new InvalidOperationException(
                 $"GLA headDim ({headDim}) exceeds max ({Kernels.HipGlaKernels.MaxHeadDim}).");
@@ -384,6 +388,10 @@ public sealed partial class HipBackend
         IGpuBuffer dQ, IGpuBuffer dK, IGpuBuffer dV, IGpuBuffer dG,
         int batch, int seqLen, int modelDim, int numHeads, int headDim)
     {
+        if (batch <= 0 || seqLen <= 0 || modelDim <= 0 || numHeads <= 0 || headDim <= 0)
+            throw new ArgumentOutOfRangeException(nameof(batch), "GLA dimensions must be positive.");
+        if (modelDim != numHeads * headDim)
+            throw new ArgumentException($"modelDim ({modelDim}) must equal numHeads * headDim ({numHeads * headDim}).");
         if (headDim > Kernels.HipGlaKernels.MaxHeadDim)
             throw new InvalidOperationException(
                 $"GLA headDim ({headDim}) exceeds max ({Kernels.HipGlaKernels.MaxHeadDim}).");
@@ -422,6 +430,10 @@ public sealed partial class HipBackend
         IGpuBuffer iGate, IGpuBuffer fGate, IGpuBuffer oGate, IGpuBuffer output,
         int batch, int seqLen, int modelDim, int numHeads, int headDim)
     {
+        if (batch <= 0 || seqLen <= 0 || modelDim <= 0 || numHeads <= 0 || headDim <= 0)
+            throw new ArgumentOutOfRangeException(nameof(batch), "xLSTM dimensions must be positive.");
+        if (modelDim != numHeads * headDim)
+            throw new ArgumentException($"modelDim ({modelDim}) must equal numHeads * headDim ({numHeads * headDim}).");
         if (headDim > Kernels.HipXLstmKernels.MaxHeadDim)
             throw new InvalidOperationException(
                 $"xLSTM headDim ({headDim}) exceeds max ({Kernels.HipXLstmKernels.MaxHeadDim}).");
@@ -442,6 +454,10 @@ public sealed partial class HipBackend
         IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer alpha, IGpuBuffer beta, IGpuBuffer output,
         int batch, int seqLen, int modelDim, int numHeads, int headDim)
     {
+        if (batch <= 0 || seqLen <= 0 || modelDim <= 0 || numHeads <= 0 || headDim <= 0)
+            throw new ArgumentOutOfRangeException(nameof(batch), "GatedDeltaNet dimensions must be positive.");
+        if (modelDim != numHeads * headDim)
+            throw new ArgumentException($"modelDim ({modelDim}) must equal numHeads * headDim ({numHeads * headDim}).");
         if (headDim > Kernels.HipGatedDeltaNetKernels.MaxHeadDim)
             throw new InvalidOperationException(
                 $"GatedDeltaNet headDim ({headDim}) exceeds max ({Kernels.HipGatedDeltaNetKernels.MaxHeadDim}).");
@@ -461,6 +477,8 @@ public sealed partial class HipBackend
         IGpuBuffer value, IGpuBuffer recGate, IGpuBuffer inpGate, IGpuBuffer decay, IGpuBuffer output,
         int batch, int seqLen, int recDim)
     {
+        if (batch <= 0 || seqLen <= 0 || recDim <= 0)
+            throw new ArgumentOutOfRangeException(nameof(batch), "RG-LRU dimensions must be positive.");
         if (!_kernelCache.TryGetValue("rglru_scan_forward", out var kernel))
             throw new InvalidOperationException("HIP kernel not found: rglru_scan_forward");
 
@@ -477,6 +495,8 @@ public sealed partial class HipBackend
         IGpuBuffer r, IGpuBuffer k, IGpuBuffer v, IGpuBuffer timeDecay, IGpuBuffer timeFirst, IGpuBuffer output,
         int batch, int seqLen, int modelDim)
     {
+        if (batch <= 0 || seqLen <= 0 || modelDim <= 0)
+            throw new ArgumentOutOfRangeException(nameof(batch), "RWKV-4 dimensions must be positive.");
         if (!_kernelCache.TryGetValue("rwkv4_wkv_forward", out var kernel))
             throw new InvalidOperationException("HIP kernel not found: rwkv4_wkv_forward");
 
@@ -493,6 +513,8 @@ public sealed partial class HipBackend
         IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,
         IGpuBuffer output, int batch, int seqLen, int innerDim, int stateDim)
     {
+        if (batch <= 0 || seqLen <= 0 || innerDim <= 0 || stateDim <= 0)
+            throw new ArgumentOutOfRangeException(nameof(batch), "Mamba dimensions must be positive.");
         if (stateDim > Kernels.HipMambaKernels.MaxStateDim)
             throw new InvalidOperationException(
                 $"Mamba stateDim ({stateDim}) exceeds max ({Kernels.HipMambaKernels.MaxStateDim}).");
@@ -512,6 +534,10 @@ public sealed partial class HipBackend
         IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,
         IGpuBuffer output, int batch, int seqLen, int innerDim, int numHeads, int headDim, int stateDim)
     {
+        if (batch <= 0 || seqLen <= 0 || innerDim <= 0 || numHeads <= 0 || headDim <= 0 || stateDim <= 0)
+            throw new ArgumentOutOfRangeException(nameof(batch), "Mamba-2 dimensions must be positive.");
+        if (innerDim != numHeads * headDim)
+            throw new ArgumentException($"innerDim ({innerDim}) must equal numHeads * headDim ({numHeads * headDim}).");
         if (stateDim > Kernels.HipMamba2Kernels.MaxStateDim)
             throw new InvalidOperationException(
                 $"Mamba-2 stateDim ({stateDim}) exceeds max ({Kernels.HipMamba2Kernels.MaxStateDim}).");
@@ -539,6 +565,8 @@ public sealed partial class HipBackend
     private unsafe float FusedCeLaunch(
         string kernelName, IGpuBuffer hidden, IGpuBuffer weight, IGpuBuffer bias, IGpuBuffer tgt, int n, int d, int vocab)
     {
+        if (n <= 0 || d <= 0 || vocab <= 0)
+            throw new ArgumentOutOfRangeException(nameof(n), "Fused CE dimensions (n, d, vocab) must be positive.");
         if (!_kernelCache.TryGetValue(kernelName, out var kernel))
             throw new InvalidOperationException($"HIP kernel not found: {kernelName}");
         using var lossBuf = AllocateBuffer(1); // zeroed

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.FusedKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.FusedKernels.cs
@@ -467,4 +467,20 @@ public sealed partial class HipBackend
         uint total = (uint)(batch * recDim);
         LaunchKernel(kernel, (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize, (uint)DefaultBlockSize, args);
     }
+
+    // ── Fused RWKV-4 WKV scan forward (#1464) ──────────────────────────────────────────────
+    public unsafe void Rwkv4WkvForward(
+        IGpuBuffer r, IGpuBuffer k, IGpuBuffer v, IGpuBuffer timeDecay, IGpuBuffer timeFirst, IGpuBuffer output,
+        int batch, int seqLen, int modelDim)
+    {
+        if (!_kernelCache.TryGetValue("rwkv4_wkv_forward", out var kernel))
+            throw new InvalidOperationException("HIP kernel not found: rwkv4_wkv_forward");
+
+        IntPtr pr = r.Handle, pk = k.Handle, pv = v.Handle, pd = timeDecay.Handle, pf = timeFirst.Handle, pout = output.Handle;
+        void** args = stackalloc void*[9];
+        args[0] = &pr; args[1] = &pk; args[2] = &pv; args[3] = &pd; args[4] = &pf; args[5] = &pout;
+        args[6] = &batch; args[7] = &seqLen; args[8] = &modelDim;
+        uint total = (uint)(batch * modelDim);
+        LaunchKernel(kernel, (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize, (uint)DefaultBlockSize, args);
+    }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.FusedKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.FusedKernels.cs
@@ -381,8 +381,8 @@ public sealed partial class HipBackend
         LaunchKernel(kernel, (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize, (uint)DefaultBlockSize, args);
     }
 
-    // dQ/dK/dV (each [batch, seqLen, modelDim]) and dG ([batch, seqLen, numHeads]) MUST be
-    // pre-zeroed — the backward kernel accumulates into them via atomicAdd.
+    // dQ/dK/dV (each [batch, seqLen, modelDim]) and dG ([batch, seqLen, numHeads]); dQ/dK/dG are
+    // the atomicAdd accumulators and are zeroed internally below (no caller pre-zeroing required).
     public unsafe void GlaScanBackward(
         IGpuBuffer dOut, IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer gate,
         IGpuBuffer dQ, IGpuBuffer dK, IGpuBuffer dV, IGpuBuffer dG,
@@ -406,6 +406,11 @@ public sealed partial class HipBackend
                 $"GLA trajectory buffer size ({trajLenLong}) exceeds int.MaxValue.");
         int trajLen = (int)trajLenLong;
         using var trajBuf = AllocateBuffer(trajLen);
+        // dQ/dK/dG are the atomicAdd accumulators — zero them here so the method is
+        // self-contained and correct even if the caller reuses dirty buffers.
+        Fill(dQ, 0f, batch * seqLen * modelDim);
+        Fill(dK, 0f, batch * seqLen * modelDim);
+        Fill(dG, 0f, batch * seqLen * numHeads);
         uint total = (uint)(batch * numHeads * headDim);
         uint grid = (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize;
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.FusedKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.FusedKernels.cs
@@ -451,4 +451,20 @@ public sealed partial class HipBackend
         uint total = (uint)(batch * numHeads * headDim);
         LaunchKernel(kernel, (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize, (uint)DefaultBlockSize, args);
     }
+
+    // ── Fused RG-LRU scan forward (#1464) ──────────────────────────────────────────────────
+    public unsafe void RgLruScanForward(
+        IGpuBuffer value, IGpuBuffer recGate, IGpuBuffer inpGate, IGpuBuffer decay, IGpuBuffer output,
+        int batch, int seqLen, int recDim)
+    {
+        if (!_kernelCache.TryGetValue("rglru_scan_forward", out var kernel))
+            throw new InvalidOperationException("HIP kernel not found: rglru_scan_forward");
+
+        IntPtr pv = value.Handle, pr = recGate.Handle, pi = inpGate.Handle, pd = decay.Handle, pout = output.Handle;
+        void** args = stackalloc void*[8];
+        args[0] = &pv; args[1] = &pr; args[2] = &pi; args[3] = &pd; args[4] = &pout;
+        args[5] = &batch; args[6] = &seqLen; args[7] = &recDim;
+        uint total = (uint)(batch * recDim);
+        LaunchKernel(kernel, (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize, (uint)DefaultBlockSize, args);
+    }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.FusedKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.FusedKernels.cs
@@ -356,4 +356,59 @@ public sealed partial class HipBackend
         args[10] = &nKeys; args[11] = &nVals;
         LaunchKernel(kernel, grid, (uint)DefaultBlockSize, args);
     }
+
+    // ── Fused GLA (Gated Linear Attention) scan (#1464) ────────────────────────────────────
+    // q/k/v: [batch, seqLen, modelDim]; gate: [batch, seqLen, numHeads]; output: [batch, seqLen, modelDim].
+    public unsafe void GlaScanForward(
+        IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer gate, IGpuBuffer output,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        if (headDim > Kernels.HipGlaKernels.MaxHeadDim)
+            throw new InvalidOperationException(
+                $"GLA headDim ({headDim}) exceeds max ({Kernels.HipGlaKernels.MaxHeadDim}).");
+        if (!_kernelCache.TryGetValue("gla_scan_forward", out var kernel))
+            throw new InvalidOperationException("HIP kernel not found: gla_scan_forward");
+
+        IntPtr pq = q.Handle, pk = k.Handle, pv = v.Handle, pg = gate.Handle, po = output.Handle;
+        void** args = stackalloc void*[10];
+        args[0] = &pq; args[1] = &pk; args[2] = &pv; args[3] = &pg; args[4] = &po;
+        args[5] = &batch; args[6] = &seqLen; args[7] = &modelDim; args[8] = &numHeads; args[9] = &headDim;
+        uint total = (uint)(batch * numHeads * headDim);
+        LaunchKernel(kernel, (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize, (uint)DefaultBlockSize, args);
+    }
+
+    // dQ/dK/dV (each [batch, seqLen, modelDim]) and dG ([batch, seqLen, numHeads]) MUST be
+    // pre-zeroed — the backward kernel accumulates into them via atomicAdd.
+    public unsafe void GlaScanBackward(
+        IGpuBuffer dOut, IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer gate,
+        IGpuBuffer dQ, IGpuBuffer dK, IGpuBuffer dV, IGpuBuffer dG,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        if (headDim > Kernels.HipGlaKernels.MaxHeadDim)
+            throw new InvalidOperationException(
+                $"GLA headDim ({headDim}) exceeds max ({Kernels.HipGlaKernels.MaxHeadDim}).");
+        if (!_kernelCache.TryGetValue("gla_scan_recompute", out var recompute) ||
+            !_kernelCache.TryGetValue("gla_scan_backward", out var backward))
+            throw new InvalidOperationException("HIP kernel not found: gla_scan_recompute / gla_scan_backward");
+
+        // State trajectory scratch: [batch * numHeads * seqLen * headDim * headDim].
+        int trajLen = batch * numHeads * seqLen * headDim * headDim;
+        using var trajBuf = AllocateBuffer(trajLen);
+        uint total = (uint)(batch * numHeads * headDim);
+        uint grid = (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize;
+
+        IntPtr pk = k.Handle, pv = v.Handle, pg = gate.Handle, ptr = trajBuf.Handle;
+        void** ra = stackalloc void*[9];
+        ra[0] = &pk; ra[1] = &pv; ra[2] = &pg; ra[3] = &ptr;
+        ra[4] = &batch; ra[5] = &seqLen; ra[6] = &modelDim; ra[7] = &numHeads; ra[8] = &headDim;
+        LaunchKernel(recompute, grid, (uint)DefaultBlockSize, ra);
+
+        IntPtr pdo = dOut.Handle, pq = q.Handle;
+        IntPtr pdq = dQ.Handle, pdk = dK.Handle, pdv = dV.Handle, pdg = dG.Handle;
+        void** ba = stackalloc void*[15];
+        ba[0] = &pdo; ba[1] = &pq; ba[2] = &pk; ba[3] = &pv; ba[4] = &pg; ba[5] = &ptr;
+        ba[6] = &pdq; ba[7] = &pdk; ba[8] = &pdv; ba[9] = &pdg;
+        ba[10] = &batch; ba[11] = &seqLen; ba[12] = &modelDim; ba[13] = &numHeads; ba[14] = &headDim;
+        LaunchKernel(backward, grid, (uint)DefaultBlockSize, ba);
+    }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -91,6 +91,7 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
     // Fused recurrence kernels (#1464): GLA / xLSTM / GatedDeltaNet / RgLRU /
     // RWKV-4 WKV / Mamba / Mamba-2 SSD / fused-linear-cross-entropy scans.
     private IntPtr _glaModule;
+    private IntPtr _xlstmModule;
     // True iff the fused-advanced kernel module compiled and registered
     // successfully on this device. Public surface methods gate on this so a
     // partial / failed compile surfaces a clear NotSupportedException at the
@@ -533,6 +534,10 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
             // Compile fused GLA (Gated Linear Attention) scan kernels (#1464)
             CompileKernelModule(Kernels.HipGlaKernels.GetSource(), "gla", ref _glaModule,
                 Kernels.HipGlaKernels.GetKernelNames());
+
+            // Compile fused xLSTM (mLSTM) scan kernels (#1464)
+            CompileKernelModule(Kernels.HipXLstmKernels.GetSource(), "xlstm", ref _xlstmModule,
+                Kernels.HipXLstmKernels.GetKernelNames());
 
             // Compile Fused Linear + Activation kernels
             CompileKernelModule(Kernels.HipFusedLinearKernels.GetSource(), "fused_linear", ref _fusedLinearModule,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -10611,6 +10611,49 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
             _gruModule = IntPtr.Zero;
         }
 
+        // Fused recurrence kernels (#1464): unload each loaded module so repeated
+        // backend create/dispose cycles don't leak HIP module handles.
+        if (_glaModule != IntPtr.Zero)
+        {
+            HipNativeBindings.hipModuleUnload(_glaModule);
+            _glaModule = IntPtr.Zero;
+        }
+        if (_xlstmModule != IntPtr.Zero)
+        {
+            HipNativeBindings.hipModuleUnload(_xlstmModule);
+            _xlstmModule = IntPtr.Zero;
+        }
+        if (_gatedDeltaNetModule != IntPtr.Zero)
+        {
+            HipNativeBindings.hipModuleUnload(_gatedDeltaNetModule);
+            _gatedDeltaNetModule = IntPtr.Zero;
+        }
+        if (_rgLruModule != IntPtr.Zero)
+        {
+            HipNativeBindings.hipModuleUnload(_rgLruModule);
+            _rgLruModule = IntPtr.Zero;
+        }
+        if (_rwkv4Module != IntPtr.Zero)
+        {
+            HipNativeBindings.hipModuleUnload(_rwkv4Module);
+            _rwkv4Module = IntPtr.Zero;
+        }
+        if (_mambaModule != IntPtr.Zero)
+        {
+            HipNativeBindings.hipModuleUnload(_mambaModule);
+            _mambaModule = IntPtr.Zero;
+        }
+        if (_mamba2Module != IntPtr.Zero)
+        {
+            HipNativeBindings.hipModuleUnload(_mamba2Module);
+            _mamba2Module = IntPtr.Zero;
+        }
+        if (_fusedCeModule != IntPtr.Zero)
+        {
+            HipNativeBindings.hipModuleUnload(_fusedCeModule);
+            _fusedCeModule = IntPtr.Zero;
+        }
+
         if (_capsuleModule != IntPtr.Zero)
         {
             HipNativeBindings.hipModuleUnload(_capsuleModule);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -92,6 +92,7 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
     // RWKV-4 WKV / Mamba / Mamba-2 SSD / fused-linear-cross-entropy scans.
     private IntPtr _glaModule;
     private IntPtr _xlstmModule;
+    private IntPtr _gatedDeltaNetModule;
     // True iff the fused-advanced kernel module compiled and registered
     // successfully on this device. Public surface methods gate on this so a
     // partial / failed compile surfaces a clear NotSupportedException at the
@@ -538,6 +539,10 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
             // Compile fused xLSTM (mLSTM) scan kernels (#1464)
             CompileKernelModule(Kernels.HipXLstmKernels.GetSource(), "xlstm", ref _xlstmModule,
                 Kernels.HipXLstmKernels.GetKernelNames());
+
+            // Compile fused Gated DeltaNet scan kernels (#1464)
+            CompileKernelModule(Kernels.HipGatedDeltaNetKernels.GetSource(), "gated_delta_net", ref _gatedDeltaNetModule,
+                Kernels.HipGatedDeltaNetKernels.GetKernelNames());
 
             // Compile Fused Linear + Activation kernels
             CompileKernelModule(Kernels.HipFusedLinearKernels.GetSource(), "fused_linear", ref _fusedLinearModule,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -88,6 +88,9 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
     private IntPtr _softmaxVarModule;
     private IntPtr _fusedLinearModule;
     private IntPtr _fusedAdvancedModule;
+    // Fused recurrence kernels (#1464): GLA / xLSTM / GatedDeltaNet / RgLRU /
+    // RWKV-4 WKV / Mamba / Mamba-2 SSD / fused-linear-cross-entropy scans.
+    private IntPtr _glaModule;
     // True iff the fused-advanced kernel module compiled and registered
     // successfully on this device. Public surface methods gate on this so a
     // partial / failed compile surfaces a clear NotSupportedException at the
@@ -526,6 +529,10 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
             // Compile LSTM sequence kernels (forward/backward for BPTT training)
             CompileKernelModule(HipLstmKernels.GetSource(), "lstm", ref _lstmModule,
                 HipLstmKernels.GetKernelNames());
+
+            // Compile fused GLA (Gated Linear Attention) scan kernels (#1464)
+            CompileKernelModule(Kernels.HipGlaKernels.GetSource(), "gla", ref _glaModule,
+                Kernels.HipGlaKernels.GetKernelNames());
 
             // Compile Fused Linear + Activation kernels
             CompileKernelModule(Kernels.HipFusedLinearKernels.GetSource(), "fused_linear", ref _fusedLinearModule,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -97,6 +97,7 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
     private IntPtr _rwkv4Module;
     private IntPtr _mambaModule;
     private IntPtr _mamba2Module;
+    private IntPtr _fusedCeModule;
     // True iff the fused-advanced kernel module compiled and registered
     // successfully on this device. Public surface methods gate on this so a
     // partial / failed compile surfaces a clear NotSupportedException at the
@@ -563,6 +564,10 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
             // Compile fused Mamba-2 SSD scan kernels (#1464)
             CompileKernelModule(Kernels.HipMamba2Kernels.GetSource(), "mamba2", ref _mamba2Module,
                 Kernels.HipMamba2Kernels.GetKernelNames());
+
+            // Compile fused linear + cross-entropy kernels (#1464)
+            CompileKernelModule(Kernels.HipFusedLinearCeKernels.GetSource(), "fused_ce", ref _fusedCeModule,
+                Kernels.HipFusedLinearCeKernels.GetKernelNames());
 
             // Compile Fused Linear + Activation kernels
             CompileKernelModule(Kernels.HipFusedLinearKernels.GetSource(), "fused_linear", ref _fusedLinearModule,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -95,6 +95,7 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
     private IntPtr _gatedDeltaNetModule;
     private IntPtr _rgLruModule;
     private IntPtr _rwkv4Module;
+    private IntPtr _mambaModule;
     // True iff the fused-advanced kernel module compiled and registered
     // successfully on this device. Public surface methods gate on this so a
     // partial / failed compile surfaces a clear NotSupportedException at the
@@ -553,6 +554,10 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
             // Compile fused RWKV-4 WKV scan kernels (#1464)
             CompileKernelModule(Kernels.HipRwkv4Kernels.GetSource(), "rwkv4", ref _rwkv4Module,
                 Kernels.HipRwkv4Kernels.GetKernelNames());
+
+            // Compile fused Mamba selective scan kernels (#1464)
+            CompileKernelModule(Kernels.HipMambaKernels.GetSource(), "mamba", ref _mambaModule,
+                Kernels.HipMambaKernels.GetKernelNames());
 
             // Compile Fused Linear + Activation kernels
             CompileKernelModule(Kernels.HipFusedLinearKernels.GetSource(), "fused_linear", ref _fusedLinearModule,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -93,6 +93,7 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
     private IntPtr _glaModule;
     private IntPtr _xlstmModule;
     private IntPtr _gatedDeltaNetModule;
+    private IntPtr _rgLruModule;
     // True iff the fused-advanced kernel module compiled and registered
     // successfully on this device. Public surface methods gate on this so a
     // partial / failed compile surfaces a clear NotSupportedException at the
@@ -543,6 +544,10 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
             // Compile fused Gated DeltaNet scan kernels (#1464)
             CompileKernelModule(Kernels.HipGatedDeltaNetKernels.GetSource(), "gated_delta_net", ref _gatedDeltaNetModule,
                 Kernels.HipGatedDeltaNetKernels.GetKernelNames());
+
+            // Compile fused RG-LRU scan kernels (#1464)
+            CompileKernelModule(Kernels.HipRgLruKernels.GetSource(), "rglru", ref _rgLruModule,
+                Kernels.HipRgLruKernels.GetKernelNames());
 
             // Compile Fused Linear + Activation kernels
             CompileKernelModule(Kernels.HipFusedLinearKernels.GetSource(), "fused_linear", ref _fusedLinearModule,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -96,6 +96,7 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
     private IntPtr _rgLruModule;
     private IntPtr _rwkv4Module;
     private IntPtr _mambaModule;
+    private IntPtr _mamba2Module;
     // True iff the fused-advanced kernel module compiled and registered
     // successfully on this device. Public surface methods gate on this so a
     // partial / failed compile surfaces a clear NotSupportedException at the
@@ -558,6 +559,10 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
             // Compile fused Mamba selective scan kernels (#1464)
             CompileKernelModule(Kernels.HipMambaKernels.GetSource(), "mamba", ref _mambaModule,
                 Kernels.HipMambaKernels.GetKernelNames());
+
+            // Compile fused Mamba-2 SSD scan kernels (#1464)
+            CompileKernelModule(Kernels.HipMamba2Kernels.GetSource(), "mamba2", ref _mamba2Module,
+                Kernels.HipMamba2Kernels.GetKernelNames());
 
             // Compile Fused Linear + Activation kernels
             CompileKernelModule(Kernels.HipFusedLinearKernels.GetSource(), "fused_linear", ref _fusedLinearModule,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -94,6 +94,7 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
     private IntPtr _xlstmModule;
     private IntPtr _gatedDeltaNetModule;
     private IntPtr _rgLruModule;
+    private IntPtr _rwkv4Module;
     // True iff the fused-advanced kernel module compiled and registered
     // successfully on this device. Public surface methods gate on this so a
     // partial / failed compile surfaces a clear NotSupportedException at the
@@ -548,6 +549,10 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
             // Compile fused RG-LRU scan kernels (#1464)
             CompileKernelModule(Kernels.HipRgLruKernels.GetSource(), "rglru", ref _rgLruModule,
                 Kernels.HipRgLruKernels.GetKernelNames());
+
+            // Compile fused RWKV-4 WKV scan kernels (#1464)
+            CompileKernelModule(Kernels.HipRwkv4Kernels.GetSource(), "rwkv4", ref _rwkv4Module,
+                Kernels.HipRwkv4Kernels.GetKernelNames());
 
             // Compile Fused Linear + Activation kernels
             CompileKernelModule(Kernels.HipFusedLinearKernels.GetSource(), "fused_linear", ref _fusedLinearModule,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipFusedLinearCeKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipFusedLinearCeKernels.cs
@@ -1,0 +1,78 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// HIP kernels for the fused linear (LM head) + cross-entropy loss (#1464), WITHOUT materializing
+// the [N, vocab] logits. One thread per row recomputes its logits on the fly (the whole point of
+// the fused op) and atomic-adds its loss to a scalar accumulator; the caller divides by N.
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.HIP.Kernels;
+
+internal static class HipFusedLinearCeKernels
+{
+    public static string GetSource()
+    {
+        return @"
+#include <hip/hip_runtime.h>
+#include <math.h>
+
+// Index targets: loss_r = logsumexp(logits_r) - logits_r[target_r].
+extern ""C"" __global__ __launch_bounds__(256) void fused_linear_ce_index(
+    const float* hidden, const float* weight, const float* bias, const float* targetIds,
+    float* totalLoss, int N, int d, int vocab)
+{
+    int r = blockIdx.x * blockDim.x + threadIdx.x;
+    if (r >= N) return;
+    int hRow = r * d;
+    int id = (int)(targetIds[r] + 0.5f);
+
+    float mx = -1.0e38f, logitTarget = 0.0f;
+    for (int vv = 0; vv < vocab; vv++) {
+        float s = bias[vv];
+        for (int j = 0; j < d; j++) s += hidden[hRow + j] * weight[j * vocab + vv];
+        if (s > mx) mx = s;
+        if (vv == id) logitTarget = s;
+    }
+    float sumExp = 0.0f;
+    for (int vv = 0; vv < vocab; vv++) {
+        float s = bias[vv];
+        for (int j = 0; j < d; j++) s += hidden[hRow + j] * weight[j * vocab + vv];
+        sumExp += expf(s - mx);
+    }
+    float loss = (mx + logf(sumExp)) - logitTarget;
+    atomicAdd(totalLoss, loss);
+}
+
+// Dense soft targets: loss_r = -sum_v target[r,v]*(logits_r[v] - logsumexp).
+extern ""C"" __global__ __launch_bounds__(256) void fused_linear_ce_dense(
+    const float* hidden, const float* weight, const float* bias, const float* target,
+    float* totalLoss, int N, int d, int vocab)
+{
+    int r = blockIdx.x * blockDim.x + threadIdx.x;
+    if (r >= N) return;
+    int hRow = r * d;
+    int tRow = r * vocab;
+
+    float mx = -1.0e38f;
+    for (int vv = 0; vv < vocab; vv++) {
+        float s = bias[vv];
+        for (int j = 0; j < d; j++) s += hidden[hRow + j] * weight[j * vocab + vv];
+        if (s > mx) mx = s;
+    }
+    float sumExp = 0.0f;
+    for (int vv = 0; vv < vocab; vv++) {
+        float s = bias[vv];
+        for (int j = 0; j < d; j++) s += hidden[hRow + j] * weight[j * vocab + vv];
+        sumExp += expf(s - mx);
+    }
+    float lse = mx + logf(sumExp);
+    float rowLoss = 0.0f;
+    for (int vv = 0; vv < vocab; vv++) {
+        float s = bias[vv];
+        for (int j = 0; j < d; j++) s += hidden[hRow + j] * weight[j * vocab + vv];
+        rowLoss += target[tRow + vv] * (s - lse);
+    }
+    atomicAdd(totalLoss, -rowLoss);
+}
+";
+    }
+
+    public static string[] GetKernelNames() => new[] { "fused_linear_ce_index", "fused_linear_ce_dense" };
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipFusedLinearCeKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipFusedLinearCeKernels.cs
@@ -22,6 +22,11 @@ extern ""C"" __global__ __launch_bounds__(256) void fused_linear_ce_index(
     if (r >= N) return;
     int hRow = r * d;
     int id = (int)(targetIds[r] + 0.5f);
+    if (id < 0 || id >= vocab) {
+        // Invalid label: surface loudly via the mean rather than a silently-wrong loss.
+        atomicAdd(totalLoss, INFINITY);
+        return;
+    }
 
     float mx = -1.0e38f, logitTarget = 0.0f;
     for (int vv = 0; vv < vocab; vv++) {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipGatedDeltaNetKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipGatedDeltaNetKernels.cs
@@ -1,0 +1,57 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// HIP kernel for the fused Gated DeltaNet (delta-rule) scan forward (issue ooples/AiDotNet#1464).
+// Mirrors CpuEngine.GatedDeltaNetScan / RecurrenceCpuKernels.GatedDeltaNetForward. Each value row
+// is independent, so one thread owns (batch b, head h, value-row di) and carries that row of the
+// state across time. The differentiable backward runs through the CpuEngine tape path.
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.HIP.Kernels;
+
+internal static class HipGatedDeltaNetKernels
+{
+    public const int MaxHeadDim = 256;
+
+    public static string GetSource()
+    {
+        return @"
+#include <hip/hip_runtime.h>
+#include <math.h>
+
+#define GDN_MAX_HEADDIM 256
+
+extern ""C"" __global__ __launch_bounds__(1024) void gated_delta_scan_forward(
+    const float* Q, const float* K, const float* V, const float* A, const float* B,
+    float* output,
+    int batch, int seqLen, int modelDim, int numHeads, int headDim)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = batch * numHeads * headDim;
+    if (gid >= total) return;
+
+    int di = gid % headDim;
+    int h  = (gid / headDim) % numHeads;
+    int b  = gid / (headDim * numHeads);
+    int hOff = h * headDim;
+    float kappa = 1.0f / sqrtf((float)headDim);
+
+    float Srow[GDN_MAX_HEADDIM];
+    for (int ki = 0; ki < headDim; ki++) Srow[ki] = 0.0f;
+
+    for (int t = 0; t < seqLen; t++) {
+        int baseOff = (b * seqLen + t) * modelDim + hOff;
+        int gIdx = (b * seqLen + t) * numHeads + h;
+        float a = A[gIdx], bet = B[gIdx];
+        float sK = 0.0f;
+        for (int ki = 0; ki < headDim; ki++) sK += Srow[ki] * (K[baseOff + ki] * kappa);
+        float bd = bet * (V[baseOff + di] - sK);
+        for (int ki = 0; ki < headDim; ki++)
+            Srow[ki] = a * Srow[ki] + bd * (K[baseOff + ki] * kappa);
+        float o = 0.0f;
+        for (int ki = 0; ki < headDim; ki++) o += Srow[ki] * Q[baseOff + ki];
+        output[baseOff + di] = o;
+    }
+}
+";
+    }
+
+    public static string[] GetKernelNames() => new[] { "gated_delta_scan_forward" };
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipGatedDeltaNetKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipGatedDeltaNetKernels.cs
@@ -33,6 +33,7 @@ extern ""C"" __global__ __launch_bounds__(1024) void gated_delta_scan_forward(
     int hOff = h * headDim;
     float kappa = 1.0f / sqrtf((float)headDim);
 
+    if (headDim < 0 || headDim > GDN_MAX_HEADDIM) return;
     float Srow[GDN_MAX_HEADDIM];
     for (int ki = 0; ki < headDim; ki++) Srow[ki] = 0.0f;
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipGlaKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipGlaKernels.cs
@@ -1,0 +1,162 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// HIP kernels for the fused Gated Linear Attention (GLA) sequence scan (issue ooples/AiDotNet#1464).
+// Mirrors the CPU reference in CpuEngine.GlaScan.cs exactly:
+//   per head, scalar-per-head gate g_t, matrix state S[di,ki]:
+//     S_t[di,ki] = g_t * S_{t-1}[di,ki] + V_t[di] * K_t[ki]
+//     O_t[di]    = sum_ki S_t[di,ki] * Q_t[ki]   (query contracts the key dim)
+// One thread owns (batch b, head h, value-row di) and carries that row of the state
+// (headDim floats) through the sequential time loop.
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.HIP.Kernels;
+
+/// <summary>
+/// HIP kernels for the fused GLA scan (forward + BPTT backward) on AMD GPUs.
+/// </summary>
+internal static class HipGlaKernels
+{
+    // Max headDim supported by the register-resident state row. Matches the CPU
+    // path's expectation that headDim = modelDim / numHeads is modest.
+    public const int MaxHeadDim = 256;
+
+    public static string GetSource()
+    {
+        return @"
+#include <hip/hip_runtime.h>
+#include <math.h>
+
+#define GLA_MAX_HEADDIM 256
+
+// Forward: output[b,t,h,di] = sum_ki S_t[di,ki] * Q[b,t,h,ki].
+// Thread = (b, h, di). Carries state row S[di,ki] (ki in [0,headDim)) across time.
+extern ""C"" __global__ __launch_bounds__(1024) void gla_scan_forward(
+    const float* Q, const float* K, const float* V, const float* G,
+    float* output,
+    int batch, int seqLen, int modelDim, int numHeads, int headDim)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = batch * numHeads * headDim;
+    if (gid >= total) return;
+
+    int di = gid % headDim;
+    int h  = (gid / headDim) % numHeads;
+    int b  = gid / (headDim * numHeads);
+    int hOff = h * headDim;
+
+    float Srow[GLA_MAX_HEADDIM];
+    for (int ki = 0; ki < headDim; ki++) Srow[ki] = 0.0f;
+
+    for (int t = 0; t < seqLen; t++) {
+        int baseOff = (b * seqLen + t) * modelDim + hOff;
+        float g  = G[(b * seqLen + t) * numHeads + h];
+        float vd = V[baseOff + di];
+        float o  = 0.0f;
+        for (int ki = 0; ki < headDim; ki++) {
+            float s = g * Srow[ki] + vd * K[baseOff + ki];
+            Srow[ki] = s;
+            o += s * Q[baseOff + ki];
+        }
+        output[baseOff + di] = o;
+    }
+}
+
+// Backward step 1: recompute the post-update state trajectory.
+// Straj layout: [((b*numHeads + h) * seqLen + t) * headDim*headDim + di*headDim + ki].
+// Thread = (b, h, di): recomputes its own row across time into the trajectory.
+extern ""C"" __global__ __launch_bounds__(1024) void gla_scan_recompute(
+    const float* K, const float* V, const float* G,
+    float* Straj,
+    int batch, int seqLen, int modelDim, int numHeads, int headDim)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = batch * numHeads * headDim;
+    if (gid >= total) return;
+
+    int di = gid % headDim;
+    int h  = (gid / headDim) % numHeads;
+    int b  = gid / (headDim * numHeads);
+    int hOff = h * headDim;
+    int hh = headDim * headDim;
+
+    float Srow[GLA_MAX_HEADDIM];
+    for (int ki = 0; ki < headDim; ki++) Srow[ki] = 0.0f;
+
+    for (int t = 0; t < seqLen; t++) {
+        int baseOff = (b * seqLen + t) * modelDim + hOff;
+        float g  = G[(b * seqLen + t) * numHeads + h];
+        float vd = V[baseOff + di];
+        long trajBase = ((long)(b * numHeads + h) * seqLen + t) * hh + (long)di * headDim;
+        for (int ki = 0; ki < headDim; ki++) {
+            float s = g * Srow[ki] + vd * K[baseOff + ki];
+            Srow[ki] = s;
+            Straj[trajBase + ki] = s;
+        }
+    }
+}
+
+// Backward step 2: reverse sweep. Thread = (b, h, di) owns adjoint row dS[di,ki].
+// dQ, dK, dG are accumulated across di via atomicAdd; dV[di] is row-private.
+extern ""C"" __global__ __launch_bounds__(1024) void gla_scan_backward(
+    const float* dOut, const float* Q, const float* K, const float* V, const float* G,
+    const float* Straj,
+    float* dQ, float* dK, float* dV, float* dG,
+    int batch, int seqLen, int modelDim, int numHeads, int headDim)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = batch * numHeads * headDim;
+    if (gid >= total) return;
+
+    int di = gid % headDim;
+    int h  = (gid / headDim) % numHeads;
+    int b  = gid / (headDim * numHeads);
+    int hOff = h * headDim;
+    int hh = headDim * headDim;
+
+    float dSrow[GLA_MAX_HEADDIM];
+    for (int ki = 0; ki < headDim; ki++) dSrow[ki] = 0.0f;
+
+    for (int t = seqLen - 1; t >= 0; t--) {
+        int baseOff = (b * seqLen + t) * modelDim + hOff;
+        int gOff = (b * seqLen + t) * numHeads + h;
+        float g = G[gOff];
+        long trajBase = ((long)(b * numHeads + h) * seqLen + t) * hh + (long)di * headDim;
+        long sprevBase = ((long)(b * numHeads + h) * seqLen + (t - 1)) * hh + (long)di * headDim;
+
+        // Output backward: O[di] = sum_ki S_t[di,ki]*Q[ki].
+        float dOutVal = dOut[baseOff + di];
+        for (int ki = 0; ki < headDim; ki++) {
+            float sval = Straj[trajBase + ki];
+            atomicAdd(&dQ[baseOff + ki], dOutVal * sval);
+            dSrow[ki] += dOutVal * Q[baseOff + ki];
+        }
+
+        // State-update backward: S_t[di,ki] = g*S_{t-1}[di,ki] + V[di]*K[ki].
+        float vd = V[baseOff + di];
+        float dg = 0.0f;
+        float dVacc = 0.0f;
+        for (int ki = 0; ki < headDim; ki++) {
+            float dStv = dSrow[ki];
+            float sprev = (t > 0) ? Straj[sprevBase + ki] : 0.0f;
+            dg += dStv * sprev;
+            atomicAdd(&dK[baseOff + ki], dStv * vd);
+            dVacc += dStv * K[baseOff + ki];
+        }
+        atomicAdd(&dV[baseOff + di], dVacc);
+        atomicAdd(&dG[gOff], dg);
+
+        // Propagate adjoint to previous step: dS_{t-1} = g * dS_t.
+        for (int ki = 0; ki < headDim; ki++) dSrow[ki] *= g;
+    }
+}
+";
+    }
+
+    public static string[] GetKernelNames()
+    {
+        return new[]
+        {
+            "gla_scan_forward",
+            "gla_scan_recompute",
+            "gla_scan_backward"
+        };
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipMamba2Kernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipMamba2Kernels.cs
@@ -1,0 +1,60 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// HIP kernel for the fused Mamba-2 SSD scan forward (#1464).
+// Mirrors CpuEngine.Mamba2SsdScan / RecurrenceCpuKernels.Mamba2SsdScanForward. Per channel
+// flatD = head*headDim + di carries an independent state h[flatD, 0..stateDim), so one thread owns
+// (batch b, channel flatD). delta/aLog/D are per-head. Backward via tape.
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.HIP.Kernels;
+
+internal static class HipMamba2Kernels
+{
+    public const int MaxStateDim = 256;
+
+    public static string GetSource()
+    {
+        return @"
+#include <hip/hip_runtime.h>
+#include <math.h>
+
+#define MAMBA2_MAX_STATEDIM 256
+
+extern ""C"" __global__ __launch_bounds__(1024) void mamba2_ssd_scan_forward(
+    const float* X, const float* delta, const float* aLog,
+    const float* B, const float* C, const float* D,
+    float* output,
+    int batch, int seqLen, int innerDim, int numHeads, int headDim, int sd)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = batch * innerDim;
+    if (gid >= total) return;
+
+    int flatD = gid % innerDim;
+    int b = gid / innerDim;
+    int hi = flatD / headDim;
+    float negA = -expf(aLog[hi]);
+    float dv = D[hi];
+
+    float h[MAMBA2_MAX_STATEDIM];
+    for (int n = 0; n < sd; n++) h[n] = 0.0f;
+
+    for (int t = 0; t < seqLen; t++) {
+        int btInner = (b * seqLen + t) * innerDim;
+        int btState = (b * seqLen + t) * sd;
+        int btHead = (b * seqLen + t) * numHeads;
+        float dt = delta[btHead + hi];
+        float aBar = expf(dt * negA);
+        float xv = X[btInner + flatD];
+        float y = 0.0f;
+        for (int n = 0; n < sd; n++) {
+            float hNew = aBar * h[n] + dt * B[btState + n] * xv;
+            h[n] = hNew;
+            y += C[btState + n] * hNew;
+        }
+        output[btInner + flatD] = y + dv * xv;
+    }
+}
+";
+    }
+
+    public static string[] GetKernelNames() => new[] { "mamba2_ssd_scan_forward" };
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipMamba2Kernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipMamba2Kernels.cs
@@ -34,6 +34,7 @@ extern ""C"" __global__ __launch_bounds__(1024) void mamba2_ssd_scan_forward(
     float negA = -expf(aLog[hi]);
     float dv = D[hi];
 
+    if (sd < 0 || sd > MAMBA2_MAX_STATEDIM) return;
     float h[MAMBA2_MAX_STATEDIM];
     for (int n = 0; n < sd; n++) h[n] = 0.0f;
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipMambaKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipMambaKernels.cs
@@ -26,6 +26,7 @@ extern ""C"" __global__ __launch_bounds__(1024) void mamba_selective_scan_forwar
     int gid = blockIdx.x * blockDim.x + threadIdx.x;
     int total = batch * innerDim;
     if (gid >= total) return;
+    if (stateDim < 0 || stateDim > MAMBA_MAX_STATEDIM) return;
 
     int di = gid % innerDim;
     int b = gid / innerDim;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipMambaKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipMambaKernels.cs
@@ -1,0 +1,57 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// HIP kernel for the fused Mamba selective scan forward (#1464).
+// Mirrors CpuEngine.MambaScan / RecurrenceCpuKernels.MambaSelectiveScanForward. Per (channel di)
+// state h[di, 0..stateDim) is independent, so one thread owns (batch b, channel di). Backward via tape.
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.HIP.Kernels;
+
+internal static class HipMambaKernels
+{
+    public const int MaxStateDim = 256;
+
+    public static string GetSource()
+    {
+        return @"
+#include <hip/hip_runtime.h>
+#include <math.h>
+
+#define MAMBA_MAX_STATEDIM 256
+
+extern ""C"" __global__ __launch_bounds__(1024) void mamba_selective_scan_forward(
+    const float* X, const float* delta, const float* aLog,
+    const float* B, const float* C, const float* D,
+    float* output,
+    int batch, int seqLen, int innerDim, int stateDim)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = batch * innerDim;
+    if (gid >= total) return;
+
+    int di = gid % innerDim;
+    int b = gid / innerDim;
+    int hrow = di * stateDim;
+
+    float negA[MAMBA_MAX_STATEDIM];
+    float h[MAMBA_MAX_STATEDIM];
+    for (int ni = 0; ni < stateDim; ni++) { negA[ni] = -expf(aLog[hrow + ni]); h[ni] = 0.0f; }
+
+    for (int t = 0; t < seqLen; t++) {
+        int baseID = (b * seqLen + t) * innerDim;
+        int baseSD = (b * seqLen + t) * stateDim;
+        float dt = delta[baseID + di];
+        float xv = X[baseID + di];
+        float y = 0.0f;
+        for (int ni = 0; ni < stateDim; ni++) {
+            float aBar = expf(dt * negA[ni]);
+            float hv = aBar * h[ni] + dt * B[baseSD + ni] * xv;
+            h[ni] = hv;
+            y += C[baseSD + ni] * hv;
+        }
+        output[baseID + di] = y + D[di] * xv;
+    }
+}
+";
+    }
+
+    public static string[] GetKernelNames() => new[] { "mamba_selective_scan_forward" };
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipRgLruKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipRgLruKernels.cs
@@ -1,0 +1,43 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// HIP kernel for the fused RG-LRU (real-gated linear recurrent unit) scan forward (#1464).
+// Mirrors CpuEngine.RgLruScan / RecurrenceCpuKernels.RgLruForward. Per-channel recurrence, so
+// one thread owns (batch b, channel c) and carries h[c] across time. Backward via CpuEngine tape.
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.HIP.Kernels;
+
+internal static class HipRgLruKernels
+{
+    public static string GetSource()
+    {
+        return @"
+#include <hip/hip_runtime.h>
+#include <math.h>
+
+extern ""C"" __global__ __launch_bounds__(1024) void rglru_scan_forward(
+    const float* V, const float* R, const float* I, const float* decay,
+    float* output,
+    int batch, int seqLen, int recDim)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = batch * recDim;
+    if (gid >= total) return;
+
+    int c = gid % recDim;
+    int b = gid / recDim;
+    float base = 1.0f / (1.0f + expf(decay[c])); // sigmoid(-decay)
+    float h = 0.0f;
+
+    for (int t = 0; t < seqLen; t++) {
+        int off = (b * seqLen + t) * recDim + c;
+        float a = R[off] * base;
+        float om = 1.0f - a * a;
+        float s = om > 0.0f ? sqrtf(om) : 0.0f;
+        h = a * h + s * (I[off] * V[off]);
+        output[off] = h;
+    }
+}
+";
+    }
+
+    public static string[] GetKernelNames() => new[] { "rglru_scan_forward" };
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipRwkv4Kernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipRwkv4Kernels.cs
@@ -1,0 +1,59 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// HIP kernel for the fused RWKV-4 time-mixing WKV scan forward (#1464).
+// Mirrors CpuEngine.Rwkv4Wkv / RecurrenceCpuKernels.Rwkv4WkvForward. Per-channel scalar state
+// (aa, bb) with a running max pp, so one thread owns (batch b, channel c). Backward via tape.
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.HIP.Kernels;
+
+internal static class HipRwkv4Kernels
+{
+    public static string GetSource()
+    {
+        return @"
+#include <hip/hip_runtime.h>
+#include <math.h>
+
+#define RWKV4_NEG_INF (-1.0e38f)
+
+extern ""C"" __global__ __launch_bounds__(1024) void rwkv4_wkv_forward(
+    const float* R, const float* K, const float* V,
+    const float* timeDecay, const float* timeFirst,
+    float* output,
+    int batch, int seqLen, int modelDim)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = batch * modelDim;
+    if (gid >= total) return;
+
+    int c = gid % modelDim;
+    int b = gid / modelDim;
+    float w = -expf(timeDecay[c]);
+    float u = timeFirst[c];
+
+    float aa = 0.0f, bb = 0.0f, pp = RWKV4_NEG_INF;
+    for (int t = 0; t < seqLen; t++) {
+        int off = (b * seqLen + t) * modelDim + c;
+        float k = K[off];
+        float v = V[off];
+
+        float ww = u + k;
+        float q = fmaxf(pp, ww);
+        float e1 = expf(pp - q);
+        float e2 = expf(ww - q);
+        float wkv = (e1 * aa + e2 * v) / (e1 * bb + e2);
+        output[off] = (1.0f / (1.0f + expf(-R[off]))) * wkv;
+
+        float ww2 = pp + w;
+        float q2 = fmaxf(ww2, k);
+        float e1b = expf(ww2 - q2);
+        float e2b = expf(k - q2);
+        aa = e1b * aa + e2b * v;
+        bb = e1b * bb + e2b;
+        pp = q2;
+    }
+}
+";
+    }
+
+    public static string[] GetKernelNames() => new[] { "rwkv4_wkv_forward" };
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipXLstmKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipXLstmKernels.cs
@@ -1,0 +1,71 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// HIP kernel for the fused xLSTM (mLSTM) matrix-memory scan forward (issue ooples/AiDotNet#1464).
+// Mirrors CpuEngine.XLstmScan.cs / RecurrenceCpuKernels.XLstmForward. One thread owns (batch b,
+// head h) and carries the full C[headDim*headDim] cell + n[headDim] normalizer in private memory,
+// because nf = max(|sum_di n[di]*Q[di]|, 1) couples all value rows of a head. headDim is capped so
+// the private state fits. The differentiable backward runs through the CpuEngine tape path.
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.HIP.Kernels;
+
+internal static class HipXLstmKernels
+{
+    public const int MaxHeadDim = 64;
+
+    public static string GetSource()
+    {
+        return @"
+#include <hip/hip_runtime.h>
+#include <math.h>
+
+#define XLSTM_MAX_HEADDIM 64
+#define XLSTM_MAX_HH 4096
+#define XLSTM_IGATE_CLAMP 4.85e8f
+
+extern ""C"" __global__ __launch_bounds__(256) void xlstm_scan_forward(
+    const float* Q, const float* K, const float* V,
+    const float* I, const float* F, const float* O,
+    float* output,
+    int batch, int seqLen, int modelDim, int numHeads, int headDim)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (gid >= batch * numHeads) return;
+
+    int h = gid % numHeads;
+    int b = gid / numHeads;
+    int hOff = h * headDim;
+    int hh = headDim * headDim;
+    float kappa = 1.0f / sqrtf((float)headDim);
+
+    float C[XLSTM_MAX_HH];
+    float n[XLSTM_MAX_HEADDIM];
+    for (int i = 0; i < hh; i++) C[i] = 0.0f;
+    for (int i = 0; i < headDim; i++) n[i] = 0.0f;
+
+    for (int t = 0; t < seqLen; t++) {
+        int baseOff = (b * seqLen + t) * modelDim + hOff;
+        int gOff = (b * seqLen + t) * numHeads + h;
+        float iv = I[gOff]; if (iv > XLSTM_IGATE_CLAMP) iv = XLSTM_IGATE_CLAMP;
+        float f = F[gOff], o = O[gOff];
+        for (int di = 0; di < headDim; di++) {
+            n[di] = f * n[di] + iv * (K[baseOff + di] * kappa);
+            float vv = V[baseOff + di];
+            int srow = di * headDim;
+            for (int ki = 0; ki < headDim; ki++)
+                C[srow + ki] = f * C[srow + ki] + iv * vv * (K[baseOff + ki] * kappa);
+        }
+        float nq = 0.0f;
+        for (int j = 0; j < headDim; j++) nq += n[j] * Q[baseOff + j];
+        float nf = fabsf(nq); if (nf < 1.0f) nf = 1.0f;
+        for (int di = 0; di < headDim; di++) {
+            int srow = di * headDim;
+            float num = 0.0f;
+            for (int ki = 0; ki < headDim; ki++) num += C[srow + ki] * Q[baseOff + ki];
+            output[baseOff + di] = o * num / nf;
+        }
+    }
+}
+";
+    }
+
+    public static string[] GetKernelNames() => new[] { "xlstm_scan_forward" };
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipXLstmKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipXLstmKernels.cs
@@ -34,6 +34,7 @@ extern ""C"" __global__ __launch_bounds__(256) void xlstm_scan_forward(
     int b = gid / numHeads;
     int hOff = h * headDim;
     int hh = headDim * headDim;
+    if (headDim < 0 || headDim > XLSTM_MAX_HEADDIM || hh > XLSTM_MAX_HH) return;
     float kappa = 1.0f / sqrtf((float)headDim);
 
     float C[XLSTM_MAX_HH];

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
@@ -2728,6 +2728,19 @@ public interface IDirectGpuBackend : IDisposable
         IGpuBuffer output, int batch, int seqLen, int innerDim, int numHeads, int headDim, int stateDim);
 
     /// <summary>
+    /// Fused linear (LM head) + cross-entropy with int class-id targets (#1464). hidden: [N, d];
+    /// weight: [d, vocab]; bias: [vocab]; targetIds: [N] (ids stored as floats). Returns mean CE.
+    /// </summary>
+    float FusedLinearCrossEntropyIndex(
+        IGpuBuffer hidden, IGpuBuffer weight, IGpuBuffer bias, IGpuBuffer targetIds, int n, int d, int vocab);
+
+    /// <summary>
+    /// Fused linear (LM head) + cross-entropy with dense [N, vocab] soft targets (#1464). Returns mean CE.
+    /// </summary>
+    float FusedLinearCrossEntropyDense(
+        IGpuBuffer hidden, IGpuBuffer weight, IGpuBuffer bias, IGpuBuffer target, int n, int d, int vocab);
+
+    /// <summary>
     /// Backward pass for LSTM sequence - computes gradients via BPTT.
     /// </summary>
     /// <param name="gradOutput">Gradient from next layer [seqLen * batch * hiddenSize].</param>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
@@ -2719,6 +2719,15 @@ public interface IDirectGpuBackend : IDisposable
         IGpuBuffer output, int batch, int seqLen, int innerDim, int stateDim);
 
     /// <summary>
+    /// Fused Mamba-2 SSD scan forward (#1464). x: [batch, seqLen, innerDim];
+    /// delta: [batch, seqLen, numHeads]; aLog/dParam: [numHeads]; bParam/cParam: [batch, seqLen, stateDim];
+    /// output: [batch, seqLen, innerDim].
+    /// </summary>
+    void Mamba2SsdScanForward(
+        IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,
+        IGpuBuffer output, int batch, int seqLen, int innerDim, int numHeads, int headDim, int stateDim);
+
+    /// <summary>
     /// Backward pass for LSTM sequence - computes gradients via BPTT.
     /// </summary>
     /// <param name="gradOutput">Gradient from next layer [seqLen * batch * hiddenSize].</param>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
@@ -2694,6 +2694,14 @@ public interface IDirectGpuBackend : IDisposable
         int batch, int seqLen, int modelDim, int numHeads, int headDim);
 
     /// <summary>
+    /// Fused RG-LRU (real-gated linear recurrent unit) scan forward (#1464).
+    /// value/recGate/inpGate: [batch, seqLen, recDim]; decay: [recDim]; output: [batch, seqLen, recDim].
+    /// </summary>
+    void RgLruScanForward(
+        IGpuBuffer value, IGpuBuffer recGate, IGpuBuffer inpGate, IGpuBuffer decay, IGpuBuffer output,
+        int batch, int seqLen, int recDim);
+
+    /// <summary>
     /// Backward pass for LSTM sequence - computes gradients via BPTT.
     /// </summary>
     /// <param name="gradOutput">Gradient from next layer [seqLen * batch * hiddenSize].</param>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
@@ -2702,6 +2702,14 @@ public interface IDirectGpuBackend : IDisposable
         int batch, int seqLen, int recDim);
 
     /// <summary>
+    /// Fused RWKV-4 time-mixing WKV scan forward (#1464). r/k/v: [batch, seqLen, modelDim];
+    /// timeDecay/timeFirst: [modelDim]; output: [batch, seqLen, modelDim].
+    /// </summary>
+    void Rwkv4WkvForward(
+        IGpuBuffer r, IGpuBuffer k, IGpuBuffer v, IGpuBuffer timeDecay, IGpuBuffer timeFirst, IGpuBuffer output,
+        int batch, int seqLen, int modelDim);
+
+    /// <summary>
     /// Backward pass for LSTM sequence - computes gradients via BPTT.
     /// </summary>
     /// <param name="gradOutput">Gradient from next layer [seqLen * batch * hiddenSize].</param>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
@@ -2710,6 +2710,15 @@ public interface IDirectGpuBackend : IDisposable
         int batch, int seqLen, int modelDim);
 
     /// <summary>
+    /// Fused Mamba selective scan forward (#1464). x/delta: [batch, seqLen, innerDim];
+    /// aLog: [innerDim, stateDim]; bParam/cParam: [batch, seqLen, stateDim]; dParam: [innerDim];
+    /// output: [batch, seqLen, innerDim].
+    /// </summary>
+    void MambaSelectiveScanForward(
+        IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,
+        IGpuBuffer output, int batch, int seqLen, int innerDim, int stateDim);
+
+    /// <summary>
     /// Backward pass for LSTM sequence - computes gradients via BPTT.
     /// </summary>
     /// <param name="gradOutput">Gradient from next layer [seqLen * batch * hiddenSize].</param>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
@@ -2659,6 +2659,23 @@ public interface IDirectGpuBackend : IDisposable
         int seqLen, int batch, int inputSize, int hiddenSize);
 
     /// <summary>
+    /// Fused Gated Linear Attention scan forward (#1464). q/k/v: [batch, seqLen, modelDim];
+    /// gate: [batch, seqLen, numHeads]; output: [batch, seqLen, modelDim].
+    /// </summary>
+    void GlaScanForward(
+        IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer gate, IGpuBuffer output,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim);
+
+    /// <summary>
+    /// Fused Gated Linear Attention scan BPTT backward (#1464). dQ/dK/dV: [batch, seqLen, modelDim];
+    /// dG: [batch, seqLen, numHeads]. The gradient buffers must be pre-zeroed (atomic accumulation).
+    /// </summary>
+    void GlaScanBackward(
+        IGpuBuffer dOut, IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer gate,
+        IGpuBuffer dQ, IGpuBuffer dK, IGpuBuffer dV, IGpuBuffer dG,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim);
+
+    /// <summary>
     /// Backward pass for LSTM sequence - computes gradients via BPTT.
     /// </summary>
     /// <param name="gradOutput">Gradient from next layer [seqLen * batch * hiddenSize].</param>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
@@ -2676,6 +2676,16 @@ public interface IDirectGpuBackend : IDisposable
         int batch, int seqLen, int modelDim, int numHeads, int headDim);
 
     /// <summary>
+    /// Fused xLSTM (mLSTM) matrix-memory scan forward (#1464). q/k/v: [batch, seqLen, modelDim];
+    /// i/f/o gates: [batch, seqLen, numHeads]; output: [batch, seqLen, modelDim]. Inference fast
+    /// path; the differentiable backward runs through the CpuEngine tape.
+    /// </summary>
+    void XLstmScanForward(
+        IGpuBuffer q, IGpuBuffer k, IGpuBuffer v,
+        IGpuBuffer iGate, IGpuBuffer fGate, IGpuBuffer oGate, IGpuBuffer output,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim);
+
+    /// <summary>
     /// Backward pass for LSTM sequence - computes gradients via BPTT.
     /// </summary>
     /// <param name="gradOutput">Gradient from next layer [seqLen * batch * hiddenSize].</param>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
@@ -2686,6 +2686,14 @@ public interface IDirectGpuBackend : IDisposable
         int batch, int seqLen, int modelDim, int numHeads, int headDim);
 
     /// <summary>
+    /// Fused Gated DeltaNet (delta-rule) scan forward (#1464). q/k/v: [batch, seqLen, modelDim];
+    /// alpha/beta gates: [batch, seqLen, numHeads]; output: [batch, seqLen, modelDim].
+    /// </summary>
+    void GatedDeltaNetScanForward(
+        IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer alpha, IGpuBuffer beta, IGpuBuffer output,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim);
+
+    /// <summary>
     /// Backward pass for LSTM sequence - computes gradients via BPTT.
     /// </summary>
     /// <param name="gradOutput">Gradient from next layer [seqLen * batch * hiddenSize].</param>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Rnn.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Rnn.cs
@@ -143,6 +143,25 @@ public partial class MetalBackend
         UploadToBuffer(output, outp);
     }
 
+    // Fused linear + cross-entropy (#1464) — host fallback via the shared reference.
+    public float FusedLinearCrossEntropyIndex(
+        IGpuBuffer hidden, IGpuBuffer weight, IGpuBuffer bias, IGpuBuffer targetIds, int n, int d, int vocab)
+    {
+        var hd = DownloadBuffer(hidden); var wd = DownloadBuffer(weight); var bd = DownloadBuffer(bias);
+        var td = DownloadBuffer(targetIds);
+        var ids = new int[n];
+        for (int i = 0; i < n; i++) ids[i] = (int)(td[i] + 0.5f);
+        return Cpu.RecurrenceCpuKernels.FusedLinearCeIndex(hd, wd, bd, ids, n, d, vocab);
+    }
+
+    public float FusedLinearCrossEntropyDense(
+        IGpuBuffer hidden, IGpuBuffer weight, IGpuBuffer bias, IGpuBuffer target, int n, int d, int vocab)
+    {
+        var hd = DownloadBuffer(hidden); var wd = DownloadBuffer(weight); var bd = DownloadBuffer(bias);
+        var td = DownloadBuffer(target);
+        return Cpu.RecurrenceCpuKernels.FusedLinearCeDense(hd, wd, bd, td, n, d, vocab);
+    }
+
     public void LstmForwardSequence(
         IGpuBuffer input, IGpuBuffer hInit, IGpuBuffer cInit,
         IGpuBuffer weightsIh, IGpuBuffer weightsHh, IGpuBuffer biasIh, IGpuBuffer biasHh,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Rnn.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Rnn.cs
@@ -54,6 +54,11 @@ public partial class MetalBackend
         if (totalLong > int.MaxValue || trajLenLong > int.MaxValue)
             throw new ArgumentOutOfRangeException(nameof(batch), "GLA dimensions exceed Metal launch/buffer limits.");
         int total = (int)totalLong;
+        // dQ/dK/dG are atomic accumulators in the backward kernel — zero them here so the
+        // method is self-contained and correct even if the caller reuses dirty buffers.
+        Fill(dQ, 0f, batch * seqLen * modelDim);
+        Fill(dK, 0f, batch * seqLen * modelDim);
+        Fill(dG, 0f, batch * seqLen * numHeads);
         using var traj = AllocateBuffer((int)trajLenLong);
         DispatchRecurrence("gla_scan_recompute", total,
             new[] { M(k), M(v), M(gate), M(traj) },

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Rnn.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Rnn.cs
@@ -119,6 +119,8 @@ public partial class MetalBackend
     private float FusedCeRowLoss(
         string kernelName, IGpuBuffer hidden, IGpuBuffer weight, IGpuBuffer bias, IGpuBuffer tgt, int n, int d, int vocab)
     {
+        if (n <= 0 || d <= 0 || vocab <= 0)
+            throw new ArgumentOutOfRangeException(nameof(n), "Fused CE dimensions (n, d, vocab) must be positive.");
         using var rowLoss = AllocateBuffer(n);
         DispatchRecurrence(kernelName, n,
             new[] { M(hidden), M(weight), M(bias), M(tgt), M(rowLoss) }, new[] { n, d, vocab });

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Rnn.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Rnn.cs
@@ -119,6 +119,18 @@ public partial class MetalBackend
         UploadToBuffer(output, outp);
     }
 
+    // Fused Mamba selective scan forward (#1464) — host fallback via the shared reference.
+    public void MambaSelectiveScanForward(
+        IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,
+        IGpuBuffer output, int batch, int seqLen, int innerDim, int stateDim)
+    {
+        var xd = DownloadBuffer(x); var dl = DownloadBuffer(delta); var al = DownloadBuffer(aLog);
+        var bp = DownloadBuffer(bParam); var cp = DownloadBuffer(cParam); var dp = DownloadBuffer(dParam);
+        var outp = new float[batch * seqLen * innerDim];
+        Cpu.RecurrenceCpuKernels.MambaSelectiveScanForward(xd, dl, al, bp, cp, dp, outp, batch, seqLen, innerDim, stateDim);
+        UploadToBuffer(output, outp);
+    }
+
     public void LstmForwardSequence(
         IGpuBuffer input, IGpuBuffer hInit, IGpuBuffer cInit,
         IGpuBuffer weightsIh, IGpuBuffer weightsHh, IGpuBuffer biasIh, IGpuBuffer biasHh,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Rnn.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Rnn.cs
@@ -107,6 +107,18 @@ public partial class MetalBackend
         UploadToBuffer(output, outp);
     }
 
+    // Fused RWKV-4 WKV scan forward (#1464) — host fallback via the shared reference.
+    public void Rwkv4WkvForward(
+        IGpuBuffer r, IGpuBuffer k, IGpuBuffer v, IGpuBuffer timeDecay, IGpuBuffer timeFirst, IGpuBuffer output,
+        int batch, int seqLen, int modelDim)
+    {
+        var rd = DownloadBuffer(r); var kd = DownloadBuffer(k); var vd = DownloadBuffer(v);
+        var td = DownloadBuffer(timeDecay); var fd = DownloadBuffer(timeFirst);
+        var outp = new float[batch * seqLen * modelDim];
+        Cpu.RecurrenceCpuKernels.Rwkv4WkvForward(rd, kd, vd, td, fd, outp, batch, seqLen, modelDim);
+        UploadToBuffer(output, outp);
+    }
+
     public void LstmForwardSequence(
         IGpuBuffer input, IGpuBuffer hInit, IGpuBuffer cInit,
         IGpuBuffer weightsIh, IGpuBuffer weightsHh, IGpuBuffer biasIh, IGpuBuffer biasHh,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Rnn.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Rnn.cs
@@ -60,20 +60,22 @@ public partial class MetalBackend
             new[] { M(q), M(k), M(v), M(gate), M(output) },
             new[] { batch, seqLen, modelDim, numHeads, headDim });
 
-    // GLA BPTT backward is never invoked by the IEngine path (the engine override is forward-only;
-    // training flows through the CpuEngine tape). Kept on the host for completeness — HIP/CUDA/OpenCL
-    // carry the real backward kernels; an MSL backward (atomics + trajectory) is a follow-up.
+    // GLA BPTT backward — real MSL kernels (recompute trajectory + reverse sweep with CAS float
+    // atomics for the cross-row dQ/dK/dG). dQ/dK/dG must be pre-zeroed (the atomic accumulators).
     public void GlaScanBackward(
         IGpuBuffer dOut, IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer gate,
         IGpuBuffer dQ, IGpuBuffer dK, IGpuBuffer dV, IGpuBuffer dG,
         int batch, int seqLen, int modelDim, int numHeads, int headDim)
     {
-        var doData = DownloadBuffer(dOut); var qd = DownloadBuffer(q); var kd = DownloadBuffer(k);
-        var vd = DownloadBuffer(v); var gd = DownloadBuffer(gate);
-        var gq = new float[batch * seqLen * modelDim]; var gk = new float[batch * seqLen * modelDim];
-        var gv = new float[batch * seqLen * modelDim]; var gG = new float[batch * seqLen * numHeads];
-        Cpu.RecurrenceCpuKernels.GlaBackward(doData, qd, kd, vd, gd, gq, gk, gv, gG, batch, seqLen, modelDim, numHeads, headDim);
-        UploadToBuffer(dQ, gq); UploadToBuffer(dK, gk); UploadToBuffer(dV, gv); UploadToBuffer(dG, gG);
+        int hh = headDim * headDim;
+        int total = batch * numHeads * headDim;
+        using var traj = AllocateBuffer(batch * numHeads * seqLen * hh);
+        DispatchRecurrence("gla_scan_recompute", total,
+            new[] { M(k), M(v), M(gate), M(traj) },
+            new[] { batch, seqLen, modelDim, numHeads, headDim });
+        DispatchRecurrence("gla_scan_backward", total,
+            new[] { M(dOut), M(q), M(k), M(v), M(gate), M(traj), M(dQ), M(dK), M(dV), M(dG) },
+            new[] { batch, seqLen, modelDim, numHeads, headDim });
     }
 
     public void XLstmScanForward(

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Rnn.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Rnn.cs
@@ -95,6 +95,18 @@ public partial class MetalBackend
         UploadToBuffer(output, outp);
     }
 
+    // Fused RG-LRU scan forward (#1464) — host fallback via the shared reference.
+    public void RgLruScanForward(
+        IGpuBuffer value, IGpuBuffer recGate, IGpuBuffer inpGate, IGpuBuffer decay, IGpuBuffer output,
+        int batch, int seqLen, int recDim)
+    {
+        var vd = DownloadBuffer(value); var rd = DownloadBuffer(recGate);
+        var id = DownloadBuffer(inpGate); var dd = DownloadBuffer(decay);
+        var outp = new float[batch * seqLen * recDim];
+        Cpu.RecurrenceCpuKernels.RgLruForward(vd, rd, id, dd, outp, batch, seqLen, recDim);
+        UploadToBuffer(output, outp);
+    }
+
     public void LstmForwardSequence(
         IGpuBuffer input, IGpuBuffer hInit, IGpuBuffer cInit,
         IGpuBuffer weightsIh, IGpuBuffer weightsHh, IGpuBuffer biasIh, IGpuBuffer biasHh,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Rnn.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Rnn.cs
@@ -83,6 +83,18 @@ public partial class MetalBackend
         UploadToBuffer(output, outp);
     }
 
+    // Fused Gated DeltaNet scan forward (#1464) — host fallback via the shared reference.
+    public void GatedDeltaNetScanForward(
+        IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer alpha, IGpuBuffer beta, IGpuBuffer output,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        var qd = DownloadBuffer(q); var kd = DownloadBuffer(k); var vd = DownloadBuffer(v);
+        var ad = DownloadBuffer(alpha); var bd = DownloadBuffer(beta);
+        var outp = new float[batch * seqLen * modelDim];
+        Cpu.RecurrenceCpuKernels.GatedDeltaNetForward(qd, kd, vd, ad, bd, outp, batch, seqLen, modelDim, numHeads, headDim);
+        UploadToBuffer(output, outp);
+    }
+
     public void LstmForwardSequence(
         IGpuBuffer input, IGpuBuffer hInit, IGpuBuffer cInit,
         IGpuBuffer weightsIh, IGpuBuffer weightsHh, IGpuBuffer biasIh, IGpuBuffer biasHh,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Rnn.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Rnn.cs
@@ -11,27 +11,6 @@ public partial class MetalBackend
 {
     #region RNN (LSTM/GRU) Sequence Operations
 
-    /// <summary>
-    /// Forward pass for LSTM sequence - processes all timesteps in a single kernel launch.
-    /// Efficient for BPTT training with minimal kernel launch overhead.
-    /// </summary>
-    /// <param name="input">Input sequence [seqLen * batch * inputSize].</param>
-    /// <param name="hInit">Initial hidden state [batch * hiddenSize].</param>
-    /// <param name="cInit">Initial cell state [batch * hiddenSize].</param>
-    /// <param name="weightsIh">Input-to-hidden weights [4 * hiddenSize * inputSize] (gates: i, f, g, o).</param>
-    /// <param name="weightsHh">Hidden-to-hidden weights [4 * hiddenSize * hiddenSize].</param>
-    /// <param name="biasIh">Input-to-hidden bias [4 * hiddenSize].</param>
-    /// <param name="biasHh">Hidden-to-hidden bias [4 * hiddenSize].</param>
-    /// <param name="output">Output sequence [seqLen * batch * hiddenSize].</param>
-    /// <param name="hFinal">Final hidden state [batch * hiddenSize].</param>
-    /// <param name="cFinal">Final cell state [batch * hiddenSize].</param>
-    /// <param name="allH">All hidden states cache [(seqLen + 1) * batch * hiddenSize] for backward.</param>
-    /// <param name="allC">All cell states cache [(seqLen + 1) * batch * hiddenSize] for backward.</param>
-    /// <param name="cacheGates">Gate cache [seqLen * batch * hiddenSize * 4] for backward.</param>
-    /// <param name="seqLen">Sequence length.</param>
-    /// <param name="batch">Batch size.</param>
-    /// <param name="inputSize">Input feature size.</param>
-    /// <param name="hiddenSize">Hidden state size.</param>
     // ── Fused recurrence / LM-head GPU kernels (#1464) ─────────────────────────────────────
     // Real MSL compute shaders (MetalRecurrenceKernels). One thread per the same work-item the
     // other backends use. Forward only — the differentiable backward runs through the CpuEngine
@@ -67,9 +46,15 @@ public partial class MetalBackend
         IGpuBuffer dQ, IGpuBuffer dK, IGpuBuffer dV, IGpuBuffer dG,
         int batch, int seqLen, int modelDim, int numHeads, int headDim)
     {
+        if (batch <= 0 || seqLen <= 0 || modelDim <= 0 || numHeads <= 0 || headDim <= 0)
+            throw new ArgumentOutOfRangeException(nameof(batch), "GLA dimensions must be positive.");
         int hh = headDim * headDim;
-        int total = batch * numHeads * headDim;
-        using var traj = AllocateBuffer(batch * numHeads * seqLen * hh);
+        long totalLong = checked((long)batch * numHeads * headDim);
+        long trajLenLong = checked((long)batch * numHeads * seqLen * hh);
+        if (totalLong > int.MaxValue || trajLenLong > int.MaxValue)
+            throw new ArgumentOutOfRangeException(nameof(batch), "GLA dimensions exceed Metal launch/buffer limits.");
+        int total = (int)totalLong;
+        using var traj = AllocateBuffer((int)trajLenLong);
         DispatchRecurrence("gla_scan_recompute", total,
             new[] { M(k), M(v), M(gate), M(traj) },
             new[] { batch, seqLen, modelDim, numHeads, headDim });
@@ -143,6 +128,27 @@ public partial class MetalBackend
         return (float)(sum / n);
     }
 
+    /// <summary>
+    /// Forward pass for LSTM sequence - processes all timesteps in a single kernel launch.
+    /// Efficient for BPTT training with minimal kernel launch overhead.
+    /// </summary>
+    /// <param name="input">Input sequence [seqLen * batch * inputSize].</param>
+    /// <param name="hInit">Initial hidden state [batch * hiddenSize].</param>
+    /// <param name="cInit">Initial cell state [batch * hiddenSize].</param>
+    /// <param name="weightsIh">Input-to-hidden weights [4 * hiddenSize * inputSize] (gates: i, f, g, o).</param>
+    /// <param name="weightsHh">Hidden-to-hidden weights [4 * hiddenSize * hiddenSize].</param>
+    /// <param name="biasIh">Input-to-hidden bias [4 * hiddenSize].</param>
+    /// <param name="biasHh">Hidden-to-hidden bias [4 * hiddenSize].</param>
+    /// <param name="output">Output sequence [seqLen * batch * hiddenSize].</param>
+    /// <param name="hFinal">Final hidden state [batch * hiddenSize].</param>
+    /// <param name="cFinal">Final cell state [batch * hiddenSize].</param>
+    /// <param name="allH">All hidden states cache [(seqLen + 1) * batch * hiddenSize] for backward.</param>
+    /// <param name="allC">All cell states cache [(seqLen + 1) * batch * hiddenSize] for backward.</param>
+    /// <param name="cacheGates">Gate cache [seqLen * batch * hiddenSize * 4] for backward.</param>
+    /// <param name="seqLen">Sequence length.</param>
+    /// <param name="batch">Batch size.</param>
+    /// <param name="inputSize">Input feature size.</param>
+    /// <param name="hiddenSize">Hidden state size.</param>
     public void LstmForwardSequence(
         IGpuBuffer input, IGpuBuffer hInit, IGpuBuffer cInit,
         IGpuBuffer weightsIh, IGpuBuffer weightsHh, IGpuBuffer biasIh, IGpuBuffer biasHh,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Rnn.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Rnn.cs
@@ -32,6 +32,44 @@ public partial class MetalBackend
     /// <param name="batch">Batch size.</param>
     /// <param name="inputSize">Input feature size.</param>
     /// <param name="hiddenSize">Hidden state size.</param>
+    // ── Fused GLA (Gated Linear Attention) scan (#1464) ────────────────────────────────────
+    // Host fallback (mirrors this backend's LstmForwardSequence precedent); a native Metal
+    // compute shader is a follow-up. Correct + GPU-CPU bit-parity via the shared reference.
+    public void GlaScanForward(
+        IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer gate, IGpuBuffer output,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        var qd = DownloadBuffer(q);
+        var kd = DownloadBuffer(k);
+        var vd = DownloadBuffer(v);
+        var gd = DownloadBuffer(gate);
+        var outp = new float[batch * seqLen * modelDim];
+        Cpu.RecurrenceCpuKernels.GlaForward(qd, kd, vd, gd, outp, batch, seqLen, modelDim, numHeads, headDim);
+        UploadToBuffer(output, outp);
+    }
+
+    public void GlaScanBackward(
+        IGpuBuffer dOut, IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer gate,
+        IGpuBuffer dQ, IGpuBuffer dK, IGpuBuffer dV, IGpuBuffer dG,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        var doData = DownloadBuffer(dOut);
+        var qd = DownloadBuffer(q);
+        var kd = DownloadBuffer(k);
+        var vd = DownloadBuffer(v);
+        var gd = DownloadBuffer(gate);
+        var gq = new float[batch * seqLen * modelDim];
+        var gk = new float[batch * seqLen * modelDim];
+        var gv = new float[batch * seqLen * modelDim];
+        var gG = new float[batch * seqLen * numHeads];
+        Cpu.RecurrenceCpuKernels.GlaBackward(doData, qd, kd, vd, gd, gq, gk, gv, gG,
+            batch, seqLen, modelDim, numHeads, headDim);
+        UploadToBuffer(dQ, gq);
+        UploadToBuffer(dK, gk);
+        UploadToBuffer(dV, gv);
+        UploadToBuffer(dG, gG);
+    }
+
     public void LstmForwardSequence(
         IGpuBuffer input, IGpuBuffer hInit, IGpuBuffer cInit,
         IGpuBuffer weightsIh, IGpuBuffer weightsHh, IGpuBuffer biasIh, IGpuBuffer biasHh,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Rnn.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Rnn.cs
@@ -32,134 +32,113 @@ public partial class MetalBackend
     /// <param name="batch">Batch size.</param>
     /// <param name="inputSize">Input feature size.</param>
     /// <param name="hiddenSize">Hidden state size.</param>
-    // ── Fused GLA (Gated Linear Attention) scan (#1464) ────────────────────────────────────
-    // Host fallback (mirrors this backend's LstmForwardSequence precedent); a native Metal
-    // compute shader is a follow-up. Correct + GPU-CPU bit-parity via the shared reference.
+    // ── Fused recurrence / LM-head GPU kernels (#1464) ─────────────────────────────────────
+    // Real MSL compute shaders (MetalRecurrenceKernels). One thread per the same work-item the
+    // other backends use. Forward only — the differentiable backward runs through the CpuEngine
+    // tape (the engine override is forward-only and defers to base when a tape is active).
+
+    // Dispatch a recurrence kernel: bind buffers 0..b-1, then int scalars b..b+s-1, over `total` threads.
+    private void DispatchRecurrence(string kernelName, int total, MetalGpuBuffer[] buffers, int[] scalars)
+    {
+        ThrowIfDisposed();
+        var pipeline = GetPipeline("Recurrence", _recurrenceLibrary, kernelName);
+        var (threadgroups, threadsPerGroup) = pipeline.Calculate1DDispatch(total);
+        using var encoder = _commandQueue.CreateScopedComputeEncoder();
+        encoder.SetPipelineState(pipeline.Handle);
+        int idx = 0;
+        foreach (var buf in buffers) encoder.SetBuffer(buf, idx++);
+        foreach (var sc in scalars) encoder.SetBytes(sc, (ulong)idx++);
+        encoder.DispatchThreadgroups(threadgroups, threadsPerGroup);
+    }
+
+    private static MetalGpuBuffer M(IGpuBuffer b) => (MetalGpuBuffer)b;
+
     public void GlaScanForward(
         IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer gate, IGpuBuffer output,
         int batch, int seqLen, int modelDim, int numHeads, int headDim)
-    {
-        var qd = DownloadBuffer(q);
-        var kd = DownloadBuffer(k);
-        var vd = DownloadBuffer(v);
-        var gd = DownloadBuffer(gate);
-        var outp = new float[batch * seqLen * modelDim];
-        Cpu.RecurrenceCpuKernels.GlaForward(qd, kd, vd, gd, outp, batch, seqLen, modelDim, numHeads, headDim);
-        UploadToBuffer(output, outp);
-    }
+        => DispatchRecurrence("gla_scan_forward", batch * numHeads * headDim,
+            new[] { M(q), M(k), M(v), M(gate), M(output) },
+            new[] { batch, seqLen, modelDim, numHeads, headDim });
 
+    // GLA BPTT backward is never invoked by the IEngine path (the engine override is forward-only;
+    // training flows through the CpuEngine tape). Kept on the host for completeness — HIP/CUDA/OpenCL
+    // carry the real backward kernels; an MSL backward (atomics + trajectory) is a follow-up.
     public void GlaScanBackward(
         IGpuBuffer dOut, IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer gate,
         IGpuBuffer dQ, IGpuBuffer dK, IGpuBuffer dV, IGpuBuffer dG,
         int batch, int seqLen, int modelDim, int numHeads, int headDim)
     {
-        var doData = DownloadBuffer(dOut);
-        var qd = DownloadBuffer(q);
-        var kd = DownloadBuffer(k);
-        var vd = DownloadBuffer(v);
-        var gd = DownloadBuffer(gate);
-        var gq = new float[batch * seqLen * modelDim];
-        var gk = new float[batch * seqLen * modelDim];
-        var gv = new float[batch * seqLen * modelDim];
-        var gG = new float[batch * seqLen * numHeads];
-        Cpu.RecurrenceCpuKernels.GlaBackward(doData, qd, kd, vd, gd, gq, gk, gv, gG,
-            batch, seqLen, modelDim, numHeads, headDim);
-        UploadToBuffer(dQ, gq);
-        UploadToBuffer(dK, gk);
-        UploadToBuffer(dV, gv);
-        UploadToBuffer(dG, gG);
+        var doData = DownloadBuffer(dOut); var qd = DownloadBuffer(q); var kd = DownloadBuffer(k);
+        var vd = DownloadBuffer(v); var gd = DownloadBuffer(gate);
+        var gq = new float[batch * seqLen * modelDim]; var gk = new float[batch * seqLen * modelDim];
+        var gv = new float[batch * seqLen * modelDim]; var gG = new float[batch * seqLen * numHeads];
+        Cpu.RecurrenceCpuKernels.GlaBackward(doData, qd, kd, vd, gd, gq, gk, gv, gG, batch, seqLen, modelDim, numHeads, headDim);
+        UploadToBuffer(dQ, gq); UploadToBuffer(dK, gk); UploadToBuffer(dV, gv); UploadToBuffer(dG, gG);
     }
 
-    // Fused xLSTM (mLSTM) scan forward (#1464) — host fallback via the shared reference.
     public void XLstmScanForward(
         IGpuBuffer q, IGpuBuffer k, IGpuBuffer v,
         IGpuBuffer iGate, IGpuBuffer fGate, IGpuBuffer oGate, IGpuBuffer output,
         int batch, int seqLen, int modelDim, int numHeads, int headDim)
-    {
-        var qd = DownloadBuffer(q); var kd = DownloadBuffer(k); var vd = DownloadBuffer(v);
-        var id = DownloadBuffer(iGate); var fd = DownloadBuffer(fGate); var od = DownloadBuffer(oGate);
-        var outp = new float[batch * seqLen * modelDim];
-        Cpu.RecurrenceCpuKernels.XLstmForward(qd, kd, vd, id, fd, od, outp, batch, seqLen, modelDim, numHeads, headDim);
-        UploadToBuffer(output, outp);
-    }
+        => DispatchRecurrence("xlstm_scan_forward", batch * numHeads,
+            new[] { M(q), M(k), M(v), M(iGate), M(fGate), M(oGate), M(output) },
+            new[] { batch, seqLen, modelDim, numHeads, headDim });
 
-    // Fused Gated DeltaNet scan forward (#1464) — host fallback via the shared reference.
     public void GatedDeltaNetScanForward(
         IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer alpha, IGpuBuffer beta, IGpuBuffer output,
         int batch, int seqLen, int modelDim, int numHeads, int headDim)
-    {
-        var qd = DownloadBuffer(q); var kd = DownloadBuffer(k); var vd = DownloadBuffer(v);
-        var ad = DownloadBuffer(alpha); var bd = DownloadBuffer(beta);
-        var outp = new float[batch * seqLen * modelDim];
-        Cpu.RecurrenceCpuKernels.GatedDeltaNetForward(qd, kd, vd, ad, bd, outp, batch, seqLen, modelDim, numHeads, headDim);
-        UploadToBuffer(output, outp);
-    }
+        => DispatchRecurrence("gated_delta_scan_forward", batch * numHeads * headDim,
+            new[] { M(q), M(k), M(v), M(alpha), M(beta), M(output) },
+            new[] { batch, seqLen, modelDim, numHeads, headDim });
 
-    // Fused RG-LRU scan forward (#1464) — host fallback via the shared reference.
     public void RgLruScanForward(
         IGpuBuffer value, IGpuBuffer recGate, IGpuBuffer inpGate, IGpuBuffer decay, IGpuBuffer output,
         int batch, int seqLen, int recDim)
-    {
-        var vd = DownloadBuffer(value); var rd = DownloadBuffer(recGate);
-        var id = DownloadBuffer(inpGate); var dd = DownloadBuffer(decay);
-        var outp = new float[batch * seqLen * recDim];
-        Cpu.RecurrenceCpuKernels.RgLruForward(vd, rd, id, dd, outp, batch, seqLen, recDim);
-        UploadToBuffer(output, outp);
-    }
+        => DispatchRecurrence("rglru_scan_forward", batch * recDim,
+            new[] { M(value), M(recGate), M(inpGate), M(decay), M(output) },
+            new[] { batch, seqLen, recDim });
 
-    // Fused RWKV-4 WKV scan forward (#1464) — host fallback via the shared reference.
     public void Rwkv4WkvForward(
         IGpuBuffer r, IGpuBuffer k, IGpuBuffer v, IGpuBuffer timeDecay, IGpuBuffer timeFirst, IGpuBuffer output,
         int batch, int seqLen, int modelDim)
-    {
-        var rd = DownloadBuffer(r); var kd = DownloadBuffer(k); var vd = DownloadBuffer(v);
-        var td = DownloadBuffer(timeDecay); var fd = DownloadBuffer(timeFirst);
-        var outp = new float[batch * seqLen * modelDim];
-        Cpu.RecurrenceCpuKernels.Rwkv4WkvForward(rd, kd, vd, td, fd, outp, batch, seqLen, modelDim);
-        UploadToBuffer(output, outp);
-    }
+        => DispatchRecurrence("rwkv4_wkv_forward", batch * modelDim,
+            new[] { M(r), M(k), M(v), M(timeDecay), M(timeFirst), M(output) },
+            new[] { batch, seqLen, modelDim });
 
-    // Fused Mamba selective scan forward (#1464) — host fallback via the shared reference.
     public void MambaSelectiveScanForward(
         IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,
         IGpuBuffer output, int batch, int seqLen, int innerDim, int stateDim)
-    {
-        var xd = DownloadBuffer(x); var dl = DownloadBuffer(delta); var al = DownloadBuffer(aLog);
-        var bp = DownloadBuffer(bParam); var cp = DownloadBuffer(cParam); var dp = DownloadBuffer(dParam);
-        var outp = new float[batch * seqLen * innerDim];
-        Cpu.RecurrenceCpuKernels.MambaSelectiveScanForward(xd, dl, al, bp, cp, dp, outp, batch, seqLen, innerDim, stateDim);
-        UploadToBuffer(output, outp);
-    }
+        => DispatchRecurrence("mamba_selective_scan_forward", batch * innerDim,
+            new[] { M(x), M(delta), M(aLog), M(bParam), M(cParam), M(dParam), M(output) },
+            new[] { batch, seqLen, innerDim, stateDim });
 
-    // Fused Mamba-2 SSD scan forward (#1464) — host fallback via the shared reference.
     public void Mamba2SsdScanForward(
         IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,
         IGpuBuffer output, int batch, int seqLen, int innerDim, int numHeads, int headDim, int stateDim)
-    {
-        var xd = DownloadBuffer(x); var dl = DownloadBuffer(delta); var al = DownloadBuffer(aLog);
-        var bp = DownloadBuffer(bParam); var cp = DownloadBuffer(cParam); var dp = DownloadBuffer(dParam);
-        var outp = new float[batch * seqLen * innerDim];
-        Cpu.RecurrenceCpuKernels.Mamba2SsdScanForward(xd, dl, al, bp, cp, dp, outp, batch, seqLen, innerDim, numHeads, headDim, stateDim);
-        UploadToBuffer(output, outp);
-    }
+        => DispatchRecurrence("mamba2_ssd_scan_forward", batch * innerDim,
+            new[] { M(x), M(delta), M(aLog), M(bParam), M(cParam), M(dParam), M(output) },
+            new[] { batch, seqLen, innerDim, numHeads, headDim, stateDim });
 
-    // Fused linear + cross-entropy (#1464) — host fallback via the shared reference.
+    // CE kernels write a per-row loss vector; the host sums the N-element vector (the expensive
+    // logit work stays on the GPU). Returns the mean cross-entropy.
     public float FusedLinearCrossEntropyIndex(
         IGpuBuffer hidden, IGpuBuffer weight, IGpuBuffer bias, IGpuBuffer targetIds, int n, int d, int vocab)
-    {
-        var hd = DownloadBuffer(hidden); var wd = DownloadBuffer(weight); var bd = DownloadBuffer(bias);
-        var td = DownloadBuffer(targetIds);
-        var ids = new int[n];
-        for (int i = 0; i < n; i++) ids[i] = (int)(td[i] + 0.5f);
-        return Cpu.RecurrenceCpuKernels.FusedLinearCeIndex(hd, wd, bd, ids, n, d, vocab);
-    }
+        => FusedCeRowLoss("fused_linear_ce_index", hidden, weight, bias, targetIds, n, d, vocab);
 
     public float FusedLinearCrossEntropyDense(
         IGpuBuffer hidden, IGpuBuffer weight, IGpuBuffer bias, IGpuBuffer target, int n, int d, int vocab)
+        => FusedCeRowLoss("fused_linear_ce_dense", hidden, weight, bias, target, n, d, vocab);
+
+    private float FusedCeRowLoss(
+        string kernelName, IGpuBuffer hidden, IGpuBuffer weight, IGpuBuffer bias, IGpuBuffer tgt, int n, int d, int vocab)
     {
-        var hd = DownloadBuffer(hidden); var wd = DownloadBuffer(weight); var bd = DownloadBuffer(bias);
-        var td = DownloadBuffer(target);
-        return Cpu.RecurrenceCpuKernels.FusedLinearCeDense(hd, wd, bd, td, n, d, vocab);
+        using var rowLoss = AllocateBuffer(n);
+        DispatchRecurrence(kernelName, n,
+            new[] { M(hidden), M(weight), M(bias), M(tgt), M(rowLoss) }, new[] { n, d, vocab });
+        var rl = DownloadBuffer(rowLoss);
+        double sum = 0.0;
+        for (int i = 0; i < n; i++) sum += rl[i];
+        return (float)(sum / n);
     }
 
     public void LstmForwardSequence(

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Rnn.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Rnn.cs
@@ -70,6 +70,19 @@ public partial class MetalBackend
         UploadToBuffer(dG, gG);
     }
 
+    // Fused xLSTM (mLSTM) scan forward (#1464) — host fallback via the shared reference.
+    public void XLstmScanForward(
+        IGpuBuffer q, IGpuBuffer k, IGpuBuffer v,
+        IGpuBuffer iGate, IGpuBuffer fGate, IGpuBuffer oGate, IGpuBuffer output,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        var qd = DownloadBuffer(q); var kd = DownloadBuffer(k); var vd = DownloadBuffer(v);
+        var id = DownloadBuffer(iGate); var fd = DownloadBuffer(fGate); var od = DownloadBuffer(oGate);
+        var outp = new float[batch * seqLen * modelDim];
+        Cpu.RecurrenceCpuKernels.XLstmForward(qd, kd, vd, id, fd, od, outp, batch, seqLen, modelDim, numHeads, headDim);
+        UploadToBuffer(output, outp);
+    }
+
     public void LstmForwardSequence(
         IGpuBuffer input, IGpuBuffer hInit, IGpuBuffer cInit,
         IGpuBuffer weightsIh, IGpuBuffer weightsHh, IGpuBuffer biasIh, IGpuBuffer biasHh,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Rnn.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Rnn.cs
@@ -131,6 +131,18 @@ public partial class MetalBackend
         UploadToBuffer(output, outp);
     }
 
+    // Fused Mamba-2 SSD scan forward (#1464) — host fallback via the shared reference.
+    public void Mamba2SsdScanForward(
+        IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,
+        IGpuBuffer output, int batch, int seqLen, int innerDim, int numHeads, int headDim, int stateDim)
+    {
+        var xd = DownloadBuffer(x); var dl = DownloadBuffer(delta); var al = DownloadBuffer(aLog);
+        var bp = DownloadBuffer(bParam); var cp = DownloadBuffer(cParam); var dp = DownloadBuffer(dParam);
+        var outp = new float[batch * seqLen * innerDim];
+        Cpu.RecurrenceCpuKernels.Mamba2SsdScanForward(xd, dl, al, bp, cp, dp, outp, batch, seqLen, innerDim, numHeads, headDim, stateDim);
+        UploadToBuffer(output, outp);
+    }
+
     public void LstmForwardSequence(
         IGpuBuffer input, IGpuBuffer hInit, IGpuBuffer cInit,
         IGpuBuffer weightsIh, IGpuBuffer weightsHh, IGpuBuffer biasIh, IGpuBuffer biasHh,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
@@ -47,6 +47,7 @@ public sealed partial class MetalBackend : IDirectGpuBackend, IFusedAdvancedKern
     // Pre-compiled kernel libraries
     private IntPtr _elementWiseLibrary;
     private IntPtr _activationLibrary;
+    private IntPtr _recurrenceLibrary; // fused recurrence / LM-head kernels (#1464)
     private IntPtr _trigLibrary;
     private IntPtr _reductionLibrary;
     private IntPtr _matrixLibrary;
@@ -211,6 +212,9 @@ public sealed partial class MetalBackend : IDirectGpuBackend, IFusedAdvancedKern
 
             // Compile octonion algebra operations
             _octonionLibrary = _shaderLibrary.CompileLibrary("Octonion", MetalKernels.OctonionKernels);
+
+            // Compile fused recurrence / LM-head kernels (#1464)
+            _recurrenceLibrary = _shaderLibrary.CompileLibrary("Recurrence", MetalRecurrenceKernels.Source);
         }
         catch (Exception ex)
         {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalRecurrenceKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalRecurrenceKernels.cs
@@ -316,5 +316,77 @@ kernel void fused_linear_ce_dense(
     }
     rowLoss[r] = -rl;
 }
+
+// ── GLA BPTT backward (recompute trajectory + reverse sweep) ─────────────────────────────────
+// Cross-row dQ/dK/dG accumulation uses a CAS-on-uint float atomic add (portable across GPUs that
+// lack native float atomics). dV[baseOff+di] is written by a single (b,h,di) thread → plain store.
+inline void gla_atomic_add_f(device atomic_uint* buf, int idx, float val) {
+    uint oldv = atomic_load_explicit(&buf[idx], memory_order_relaxed);
+    while (true) {
+        uint newv = as_type<uint>(as_type<float>(oldv) + val);
+        if (atomic_compare_exchange_weak_explicit(&buf[idx], &oldv, newv,
+                memory_order_relaxed, memory_order_relaxed)) break;
+    }
+}
+
+kernel void gla_scan_recompute(
+    device const float* K [[buffer(0)]], device const float* V [[buffer(1)]], device const float* G [[buffer(2)]],
+    device float* Straj [[buffer(3)]],
+    constant int& batch [[buffer(4)]], constant int& seqLen [[buffer(5)]], constant int& modelDim [[buffer(6)]],
+    constant int& numHeads [[buffer(7)]], constant int& headDim [[buffer(8)]], uint gid [[thread_position_in_grid]])
+{
+    int total = batch * numHeads * headDim;
+    if ((int)gid >= total) return;
+    int di = (int)gid % headDim; int h = ((int)gid / headDim) % numHeads; int b = (int)gid / (headDim * numHeads);
+    int hOff = h * headDim; int hh = headDim * headDim;
+    float Srow[REC_MAX_HEADDIM];
+    for (int ki = 0; ki < headDim; ki++) Srow[ki] = 0.0f;
+    for (int t = 0; t < seqLen; t++) {
+        int baseOff = (b * seqLen + t) * modelDim + hOff;
+        float g = G[(b * seqLen + t) * numHeads + h];
+        float vd = V[baseOff + di];
+        int trajBase = ((b * numHeads + h) * seqLen + t) * hh + di * headDim;
+        for (int ki = 0; ki < headDim; ki++) { float s = g * Srow[ki] + vd * K[baseOff + ki]; Srow[ki] = s; Straj[trajBase + ki] = s; }
+    }
+}
+
+kernel void gla_scan_backward(
+    device const float* dOut [[buffer(0)]], device const float* Q [[buffer(1)]], device const float* K [[buffer(2)]],
+    device const float* V [[buffer(3)]], device const float* G [[buffer(4)]], device const float* Straj [[buffer(5)]],
+    device atomic_uint* dQ [[buffer(6)]], device atomic_uint* dK [[buffer(7)]], device float* dV [[buffer(8)]], device atomic_uint* dG [[buffer(9)]],
+    constant int& batch [[buffer(10)]], constant int& seqLen [[buffer(11)]], constant int& modelDim [[buffer(12)]],
+    constant int& numHeads [[buffer(13)]], constant int& headDim [[buffer(14)]], uint gid [[thread_position_in_grid]])
+{
+    int total = batch * numHeads * headDim;
+    if ((int)gid >= total) return;
+    int di = (int)gid % headDim; int h = ((int)gid / headDim) % numHeads; int b = (int)gid / (headDim * numHeads);
+    int hOff = h * headDim; int hh = headDim * headDim;
+    float dSrow[REC_MAX_HEADDIM];
+    for (int ki = 0; ki < headDim; ki++) dSrow[ki] = 0.0f;
+    for (int t = seqLen - 1; t >= 0; t--) {
+        int baseOff = (b * seqLen + t) * modelDim + hOff;
+        int gOff = (b * seqLen + t) * numHeads + h;
+        float g = G[gOff];
+        int trajBase = ((b * numHeads + h) * seqLen + t) * hh + di * headDim;
+        int sprevBase = ((b * numHeads + h) * seqLen + (t - 1)) * hh + di * headDim;
+        float dOutVal = dOut[baseOff + di];
+        for (int ki = 0; ki < headDim; ki++) {
+            float sval = Straj[trajBase + ki];
+            gla_atomic_add_f(dQ, baseOff + ki, dOutVal * sval);
+            dSrow[ki] += dOutVal * Q[baseOff + ki];
+        }
+        float vd = V[baseOff + di]; float dg = 0.0f; float dVacc = 0.0f;
+        for (int ki = 0; ki < headDim; ki++) {
+            float dStv = dSrow[ki];
+            float sprev = (t > 0) ? Straj[sprevBase + ki] : 0.0f;
+            dg += dStv * sprev;
+            gla_atomic_add_f(dK, baseOff + ki, dStv * vd);
+            dVacc += dStv * K[baseOff + ki];
+        }
+        dV[baseOff + di] = dVacc;
+        gla_atomic_add_f(dG, gOff, dg);
+        for (int ki = 0; ki < headDim; ki++) dSrow[ki] *= g;
+    }
+}
 ";
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalRecurrenceKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalRecurrenceKernels.cs
@@ -1,0 +1,320 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Metal (MSL) compute shaders for the fused recurrence / LM-head ops (#1464). Real GPU kernels —
+// they mirror the HIP/CUDA/OpenCL kernels and the CpuEngine math exactly. One thread per the same
+// work-item as the other backends. The cross-entropy kernels write a per-row loss vector (the host
+// sums the N-element vector); everything else writes the full output. Forward only — the
+// differentiable backward runs through the CpuEngine tape (same as every backend).
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.Metal;
+
+internal static class MetalRecurrenceKernels
+{
+    public const string Source = @"
+#include <metal_stdlib>
+#include <metal_math>
+using namespace metal;
+
+#define REC_MAX_HEADDIM 256
+#define XLSTM_MAX_HH 4096
+#define XLSTM_IGATE_CLAMP 4.85e8f
+
+// ── GLA scan forward ───────────────────────────────────────────────────────────────────────
+kernel void gla_scan_forward(
+    device const float* Q [[buffer(0)]], device const float* K [[buffer(1)]],
+    device const float* V [[buffer(2)]], device const float* G [[buffer(3)]],
+    device float* output [[buffer(4)]],
+    constant int& batch [[buffer(5)]], constant int& seqLen [[buffer(6)]],
+    constant int& modelDim [[buffer(7)]], constant int& numHeads [[buffer(8)]],
+    constant int& headDim [[buffer(9)]], uint gid [[thread_position_in_grid]])
+{
+    int total = batch * numHeads * headDim;
+    if ((int)gid >= total) return;
+    int di = (int)gid % headDim;
+    int h = ((int)gid / headDim) % numHeads;
+    int b = (int)gid / (headDim * numHeads);
+    int hOff = h * headDim;
+    thread float Srow[REC_MAX_HEADDIM];
+    for (int ki = 0; ki < headDim; ki++) Srow[ki] = 0.0f;
+    for (int t = 0; t < seqLen; t++) {
+        int baseOff = (b * seqLen + t) * modelDim + hOff;
+        float g = G[(b * seqLen + t) * numHeads + h];
+        float vd = V[baseOff + di];
+        float o = 0.0f;
+        for (int ki = 0; ki < headDim; ki++) {
+            float s = g * Srow[ki] + vd * K[baseOff + ki];
+            Srow[ki] = s;
+            o += s * Q[baseOff + ki];
+        }
+        output[baseOff + di] = o;
+    }
+}
+
+// ── xLSTM scan forward ─────────────────────────────────────────────────────────────────────
+kernel void xlstm_scan_forward(
+    device const float* Q [[buffer(0)]], device const float* K [[buffer(1)]],
+    device const float* V [[buffer(2)]], device const float* I [[buffer(3)]],
+    device const float* F [[buffer(4)]], device const float* O [[buffer(5)]],
+    device float* output [[buffer(6)]],
+    constant int& batch [[buffer(7)]], constant int& seqLen [[buffer(8)]],
+    constant int& modelDim [[buffer(9)]], constant int& numHeads [[buffer(10)]],
+    constant int& headDim [[buffer(11)]], uint gid [[thread_position_in_grid]])
+{
+    if ((int)gid >= batch * numHeads) return;
+    int h = (int)gid % numHeads;
+    int b = (int)gid / numHeads;
+    int hOff = h * headDim;
+    int hh = headDim * headDim;
+    float kappa = 1.0f / sqrt((float)headDim);
+    thread float C[XLSTM_MAX_HH];
+    thread float n[REC_MAX_HEADDIM];
+    for (int i = 0; i < hh; i++) C[i] = 0.0f;
+    for (int i = 0; i < headDim; i++) n[i] = 0.0f;
+    for (int t = 0; t < seqLen; t++) {
+        int baseOff = (b * seqLen + t) * modelDim + hOff;
+        int gOff = (b * seqLen + t) * numHeads + h;
+        float iv = I[gOff]; if (iv > XLSTM_IGATE_CLAMP) iv = XLSTM_IGATE_CLAMP;
+        float f = F[gOff], o = O[gOff];
+        for (int di = 0; di < headDim; di++) {
+            n[di] = f * n[di] + iv * (K[baseOff + di] * kappa);
+            float vv = V[baseOff + di];
+            int srow = di * headDim;
+            for (int ki = 0; ki < headDim; ki++)
+                C[srow + ki] = f * C[srow + ki] + iv * vv * (K[baseOff + ki] * kappa);
+        }
+        float nq = 0.0f;
+        for (int j = 0; j < headDim; j++) nq += n[j] * Q[baseOff + j];
+        float nf = fabs(nq); if (nf < 1.0f) nf = 1.0f;
+        for (int di = 0; di < headDim; di++) {
+            int srow = di * headDim;
+            float num = 0.0f;
+            for (int ki = 0; ki < headDim; ki++) num += C[srow + ki] * Q[baseOff + ki];
+            output[baseOff + di] = o * num / nf;
+        }
+    }
+}
+
+// ── Gated DeltaNet scan forward ────────────────────────────────────────────────────────────
+kernel void gated_delta_scan_forward(
+    device const float* Q [[buffer(0)]], device const float* K [[buffer(1)]],
+    device const float* V [[buffer(2)]], device const float* A [[buffer(3)]],
+    device const float* B [[buffer(4)]], device float* output [[buffer(5)]],
+    constant int& batch [[buffer(6)]], constant int& seqLen [[buffer(7)]],
+    constant int& modelDim [[buffer(8)]], constant int& numHeads [[buffer(9)]],
+    constant int& headDim [[buffer(10)]], uint gid [[thread_position_in_grid]])
+{
+    int total = batch * numHeads * headDim;
+    if ((int)gid >= total) return;
+    int di = (int)gid % headDim;
+    int h = ((int)gid / headDim) % numHeads;
+    int b = (int)gid / (headDim * numHeads);
+    int hOff = h * headDim;
+    float kappa = 1.0f / sqrt((float)headDim);
+    thread float Srow[REC_MAX_HEADDIM];
+    for (int ki = 0; ki < headDim; ki++) Srow[ki] = 0.0f;
+    for (int t = 0; t < seqLen; t++) {
+        int baseOff = (b * seqLen + t) * modelDim + hOff;
+        int gIdx = (b * seqLen + t) * numHeads + h;
+        float a = A[gIdx], bet = B[gIdx];
+        float sK = 0.0f;
+        for (int ki = 0; ki < headDim; ki++) sK += Srow[ki] * (K[baseOff + ki] * kappa);
+        float bd = bet * (V[baseOff + di] - sK);
+        for (int ki = 0; ki < headDim; ki++)
+            Srow[ki] = a * Srow[ki] + bd * (K[baseOff + ki] * kappa);
+        float o = 0.0f;
+        for (int ki = 0; ki < headDim; ki++) o += Srow[ki] * Q[baseOff + ki];
+        output[baseOff + di] = o;
+    }
+}
+
+// ── RG-LRU scan forward ────────────────────────────────────────────────────────────────────
+kernel void rglru_scan_forward(
+    device const float* V [[buffer(0)]], device const float* R [[buffer(1)]],
+    device const float* I [[buffer(2)]], device const float* decay [[buffer(3)]],
+    device float* output [[buffer(4)]],
+    constant int& batch [[buffer(5)]], constant int& seqLen [[buffer(6)]],
+    constant int& recDim [[buffer(7)]], uint gid [[thread_position_in_grid]])
+{
+    int total = batch * recDim;
+    if ((int)gid >= total) return;
+    int c = (int)gid % recDim;
+    int b = (int)gid / recDim;
+    float base = 1.0f / (1.0f + exp(decay[c]));
+    float h = 0.0f;
+    for (int t = 0; t < seqLen; t++) {
+        int off = (b * seqLen + t) * recDim + c;
+        float a = R[off] * base;
+        float om = 1.0f - a * a;
+        float s = om > 0.0f ? sqrt(om) : 0.0f;
+        h = a * h + s * (I[off] * V[off]);
+        output[off] = h;
+    }
+}
+
+// ── RWKV-4 WKV scan forward ────────────────────────────────────────────────────────────────
+kernel void rwkv4_wkv_forward(
+    device const float* R [[buffer(0)]], device const float* K [[buffer(1)]],
+    device const float* V [[buffer(2)]], device const float* timeDecay [[buffer(3)]],
+    device const float* timeFirst [[buffer(4)]], device float* output [[buffer(5)]],
+    constant int& batch [[buffer(6)]], constant int& seqLen [[buffer(7)]],
+    constant int& modelDim [[buffer(8)]], uint gid [[thread_position_in_grid]])
+{
+    int total = batch * modelDim;
+    if ((int)gid >= total) return;
+    int c = (int)gid % modelDim;
+    int b = (int)gid / modelDim;
+    float w = -exp(timeDecay[c]);
+    float u = timeFirst[c];
+    float aa = 0.0f, bb = 0.0f, pp = -1.0e38f;
+    for (int t = 0; t < seqLen; t++) {
+        int off = (b * seqLen + t) * modelDim + c;
+        float k = K[off];
+        float v = V[off];
+        float ww = u + k;
+        float q = fmax(pp, ww);
+        float e1 = exp(pp - q);
+        float e2 = exp(ww - q);
+        float wkv = (e1 * aa + e2 * v) / (e1 * bb + e2);
+        output[off] = (1.0f / (1.0f + exp(-R[off]))) * wkv;
+        float ww2 = pp + w;
+        float q2 = fmax(ww2, k);
+        float e1b = exp(ww2 - q2);
+        float e2b = exp(k - q2);
+        aa = e1b * aa + e2b * v;
+        bb = e1b * bb + e2b;
+        pp = q2;
+    }
+}
+
+// ── Mamba selective scan forward ───────────────────────────────────────────────────────────
+kernel void mamba_selective_scan_forward(
+    device const float* X [[buffer(0)]], device const float* delta [[buffer(1)]],
+    device const float* aLog [[buffer(2)]], device const float* B [[buffer(3)]],
+    device const float* C [[buffer(4)]], device const float* D [[buffer(5)]],
+    device float* output [[buffer(6)]],
+    constant int& batch [[buffer(7)]], constant int& seqLen [[buffer(8)]],
+    constant int& innerDim [[buffer(9)]], constant int& stateDim [[buffer(10)]],
+    uint gid [[thread_position_in_grid]])
+{
+    int total = batch * innerDim;
+    if ((int)gid >= total) return;
+    int di = (int)gid % innerDim;
+    int b = (int)gid / innerDim;
+    int hrow = di * stateDim;
+    thread float negA[REC_MAX_HEADDIM];
+    thread float h[REC_MAX_HEADDIM];
+    for (int n = 0; n < stateDim; n++) { negA[n] = -exp(aLog[hrow + n]); h[n] = 0.0f; }
+    for (int t = 0; t < seqLen; t++) {
+        int baseID = (b * seqLen + t) * innerDim;
+        int baseSD = (b * seqLen + t) * stateDim;
+        float dt = delta[baseID + di];
+        float xv = X[baseID + di];
+        float y = 0.0f;
+        for (int n = 0; n < stateDim; n++) {
+            float aBar = exp(dt * negA[n]);
+            float hv = aBar * h[n] + dt * B[baseSD + n] * xv;
+            h[n] = hv;
+            y += C[baseSD + n] * hv;
+        }
+        output[baseID + di] = y + D[di] * xv;
+    }
+}
+
+// ── Mamba-2 SSD scan forward ───────────────────────────────────────────────────────────────
+kernel void mamba2_ssd_scan_forward(
+    device const float* X [[buffer(0)]], device const float* delta [[buffer(1)]],
+    device const float* aLog [[buffer(2)]], device const float* B [[buffer(3)]],
+    device const float* C [[buffer(4)]], device const float* D [[buffer(5)]],
+    device float* output [[buffer(6)]],
+    constant int& batch [[buffer(7)]], constant int& seqLen [[buffer(8)]],
+    constant int& innerDim [[buffer(9)]], constant int& numHeads [[buffer(10)]],
+    constant int& headDim [[buffer(11)]], constant int& sd [[buffer(12)]],
+    uint gid [[thread_position_in_grid]])
+{
+    int total = batch * innerDim;
+    if ((int)gid >= total) return;
+    int flatD = (int)gid % innerDim;
+    int b = (int)gid / innerDim;
+    int hi = flatD / headDim;
+    float negA = -exp(aLog[hi]);
+    float dv = D[hi];
+    thread float h[REC_MAX_HEADDIM];
+    for (int n = 0; n < sd; n++) h[n] = 0.0f;
+    for (int t = 0; t < seqLen; t++) {
+        int btInner = (b * seqLen + t) * innerDim;
+        int btState = (b * seqLen + t) * sd;
+        int btHead = (b * seqLen + t) * numHeads;
+        float dt = delta[btHead + hi];
+        float aBar = exp(dt * negA);
+        float xv = X[btInner + flatD];
+        float y = 0.0f;
+        for (int n = 0; n < sd; n++) {
+            float hNew = aBar * h[n] + dt * B[btState + n] * xv;
+            h[n] = hNew;
+            y += C[btState + n] * hNew;
+        }
+        output[btInner + flatD] = y + dv * xv;
+    }
+}
+
+// ── Fused linear + cross-entropy (per-row loss; host sums) ──────────────────────────────────
+kernel void fused_linear_ce_index(
+    device const float* hidden [[buffer(0)]], device const float* weight [[buffer(1)]],
+    device const float* bias [[buffer(2)]], device const float* targetIds [[buffer(3)]],
+    device float* rowLoss [[buffer(4)]],
+    constant int& N [[buffer(5)]], constant int& d [[buffer(6)]], constant int& vocab [[buffer(7)]],
+    uint gid [[thread_position_in_grid]])
+{
+    int r = (int)gid;
+    if (r >= N) return;
+    int hRow = r * d;
+    int id = (int)(targetIds[r] + 0.5f);
+    float mx = -1.0e38f, logitTarget = 0.0f;
+    for (int vv = 0; vv < vocab; vv++) {
+        float s = bias[vv];
+        for (int j = 0; j < d; j++) s += hidden[hRow + j] * weight[j * vocab + vv];
+        if (s > mx) mx = s;
+        if (vv == id) logitTarget = s;
+    }
+    float sumExp = 0.0f;
+    for (int vv = 0; vv < vocab; vv++) {
+        float s = bias[vv];
+        for (int j = 0; j < d; j++) s += hidden[hRow + j] * weight[j * vocab + vv];
+        sumExp += exp(s - mx);
+    }
+    rowLoss[r] = (mx + log(sumExp)) - logitTarget;
+}
+
+kernel void fused_linear_ce_dense(
+    device const float* hidden [[buffer(0)]], device const float* weight [[buffer(1)]],
+    device const float* bias [[buffer(2)]], device const float* target [[buffer(3)]],
+    device float* rowLoss [[buffer(4)]],
+    constant int& N [[buffer(5)]], constant int& d [[buffer(6)]], constant int& vocab [[buffer(7)]],
+    uint gid [[thread_position_in_grid]])
+{
+    int r = (int)gid;
+    if (r >= N) return;
+    int hRow = r * d;
+    int tRow = r * vocab;
+    float mx = -1.0e38f;
+    for (int vv = 0; vv < vocab; vv++) {
+        float s = bias[vv];
+        for (int j = 0; j < d; j++) s += hidden[hRow + j] * weight[j * vocab + vv];
+        if (s > mx) mx = s;
+    }
+    float sumExp = 0.0f;
+    for (int vv = 0; vv < vocab; vv++) {
+        float s = bias[vv];
+        for (int j = 0; j < d; j++) s += hidden[hRow + j] * weight[j * vocab + vv];
+        sumExp += exp(s - mx);
+    }
+    float lse = mx + log(sumExp);
+    float rl = 0.0f;
+    for (int vv = 0; vv < vocab; vv++) {
+        float s = bias[vv];
+        for (int j = 0; j < d; j++) s += hidden[hRow + j] * weight[j * vocab + vv];
+        rl += target[tRow + vv] * (s - lse);
+    }
+    rowLoss[r] = -rl;
+}
+";
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/FusedLinearCeKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/FusedLinearCeKernels.cs
@@ -1,0 +1,80 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// OpenCL kernels for the fused linear + cross-entropy loss (#1464). One work-item per row; loss
+// atomic-added to a scalar accumulator via a CAS float-add (OpenCL 1.2 has no native float atomics).
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL.Kernels;
+
+internal static class FusedLinearCeKernels
+{
+    public static string GetSource()
+    {
+        return @"
+inline void atomic_add_float(__global volatile float* addr, float val) {
+    union { unsigned int u; float f; } oldval, newval;
+    do {
+        oldval.f = *addr;
+        newval.f = oldval.f + val;
+    } while (atomic_cmpxchg((__global volatile unsigned int*)addr, oldval.u, newval.u) != oldval.u);
+}
+
+__kernel void fused_linear_ce_index(
+    __global const float* hidden, __global const float* weight, __global const float* bias,
+    __global const float* targetIds, __global volatile float* totalLoss, int N, int d, int vocab)
+{
+    int r = get_global_id(0);
+    if (r >= N) return;
+    int hRow = r * d;
+    int id = (int)(targetIds[r] + 0.5f);
+
+    float mx = -1.0e38f, logitTarget = 0.0f;
+    for (int vv = 0; vv < vocab; vv++) {
+        float s = bias[vv];
+        for (int j = 0; j < d; j++) s += hidden[hRow + j] * weight[j * vocab + vv];
+        if (s > mx) mx = s;
+        if (vv == id) logitTarget = s;
+    }
+    float sumExp = 0.0f;
+    for (int vv = 0; vv < vocab; vv++) {
+        float s = bias[vv];
+        for (int j = 0; j < d; j++) s += hidden[hRow + j] * weight[j * vocab + vv];
+        sumExp += exp(s - mx);
+    }
+    float loss = (mx + log(sumExp)) - logitTarget;
+    atomic_add_float(totalLoss, loss);
+}
+
+__kernel void fused_linear_ce_dense(
+    __global const float* hidden, __global const float* weight, __global const float* bias,
+    __global const float* target, __global volatile float* totalLoss, int N, int d, int vocab)
+{
+    int r = get_global_id(0);
+    if (r >= N) return;
+    int hRow = r * d;
+    int tRow = r * vocab;
+
+    float mx = -1.0e38f;
+    for (int vv = 0; vv < vocab; vv++) {
+        float s = bias[vv];
+        for (int j = 0; j < d; j++) s += hidden[hRow + j] * weight[j * vocab + vv];
+        if (s > mx) mx = s;
+    }
+    float sumExp = 0.0f;
+    for (int vv = 0; vv < vocab; vv++) {
+        float s = bias[vv];
+        for (int j = 0; j < d; j++) s += hidden[hRow + j] * weight[j * vocab + vv];
+        sumExp += exp(s - mx);
+    }
+    float lse = mx + log(sumExp);
+    float rowLoss = 0.0f;
+    for (int vv = 0; vv < vocab; vv++) {
+        float s = bias[vv];
+        for (int j = 0; j < d; j++) s += hidden[hRow + j] * weight[j * vocab + vv];
+        rowLoss += target[tRow + vv] * (s - lse);
+    }
+    atomic_add_float(totalLoss, -rowLoss);
+}
+";
+    }
+
+    public static string[] GetKernelNames() => new[] { "fused_linear_ce_index", "fused_linear_ce_dense" };
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/FusedLinearCeKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/FusedLinearCeKernels.cs
@@ -25,6 +25,11 @@ __kernel void fused_linear_ce_index(
     if (r >= N) return;
     int hRow = r * d;
     int id = (int)(targetIds[r] + 0.5f);
+    if (id < 0 || id >= vocab) {
+        // Invalid label: surface loudly via the mean rather than a silently-wrong loss.
+        atomic_add_float(totalLoss, NAN);
+        return;
+    }
 
     float mx = -1.0e38f, logitTarget = 0.0f;
     for (int vv = 0; vv < vocab; vv++) {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/GatedDeltaNetKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/GatedDeltaNetKernels.cs
@@ -1,0 +1,53 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// OpenCL kernel for the fused Gated DeltaNet scan forward (issue ooples/AiDotNet#1464).
+// Same design as HipGatedDeltaNetKernels: one work-item per (batch, head, value-row).
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL.Kernels;
+
+internal static class GatedDeltaNetKernels
+{
+    public const int MaxHeadDim = 256;
+
+    public static string GetSource()
+    {
+        return @"
+#define GDN_MAX_HEADDIM 256
+
+__kernel void gated_delta_scan_forward(
+    __global const float* Q, __global const float* K, __global const float* V,
+    __global const float* A, __global const float* B,
+    __global float* output,
+    int batch, int seqLen, int modelDim, int numHeads, int headDim)
+{
+    int gid = get_global_id(0);
+    int total = batch * numHeads * headDim;
+    if (gid >= total) return;
+
+    int di = gid % headDim;
+    int h  = (gid / headDim) % numHeads;
+    int b  = gid / (headDim * numHeads);
+    int hOff = h * headDim;
+    float kappa = 1.0f / sqrt((float)headDim);
+
+    float Srow[GDN_MAX_HEADDIM];
+    for (int ki = 0; ki < headDim; ki++) Srow[ki] = 0.0f;
+
+    for (int t = 0; t < seqLen; t++) {
+        int baseOff = (b * seqLen + t) * modelDim + hOff;
+        int gIdx = (b * seqLen + t) * numHeads + h;
+        float a = A[gIdx], bet = B[gIdx];
+        float sK = 0.0f;
+        for (int ki = 0; ki < headDim; ki++) sK += Srow[ki] * (K[baseOff + ki] * kappa);
+        float bd = bet * (V[baseOff + di] - sK);
+        for (int ki = 0; ki < headDim; ki++)
+            Srow[ki] = a * Srow[ki] + bd * (K[baseOff + ki] * kappa);
+        float o = 0.0f;
+        for (int ki = 0; ki < headDim; ki++) o += Srow[ki] * Q[baseOff + ki];
+        output[baseOff + di] = o;
+    }
+}
+";
+    }
+
+    public static string[] GetKernelNames() => new[] { "gated_delta_scan_forward" };
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/GlaKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/GlaKernels.cs
@@ -1,0 +1,155 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// OpenCL kernels for the fused Gated Linear Attention (GLA) sequence scan (issue ooples/AiDotNet#1464).
+// Mirrors CpuEngine.GlaScan.cs / HipGlaKernels exactly:
+//   S_t[di,ki] = g_t * S_{t-1}[di,ki] + V_t[di] * K_t[ki]
+//   O_t[di]    = sum_ki S_t[di,ki] * Q_t[ki]
+// One work-item owns (batch b, head h, value-row di), carrying that state row across time.
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL.Kernels;
+
+/// <summary>
+/// OpenCL kernels for the fused GLA scan (forward + BPTT backward).
+/// </summary>
+internal static class GlaKernels
+{
+    public const int MaxHeadDim = 256;
+
+    public static string GetSource()
+    {
+        return @"
+#define GLA_MAX_HEADDIM 256
+
+// CAS-based float atomic add (OpenCL 1.2 has no native float atomics).
+inline void atomic_add_float(__global volatile float* addr, float val) {
+    union { unsigned int u; float f; } oldval, newval;
+    do {
+        oldval.f = *addr;
+        newval.f = oldval.f + val;
+    } while (atomic_cmpxchg((__global volatile unsigned int*)addr, oldval.u, newval.u) != oldval.u);
+}
+
+__kernel void gla_scan_forward(
+    __global const float* Q, __global const float* K, __global const float* V, __global const float* G,
+    __global float* output,
+    int batch, int seqLen, int modelDim, int numHeads, int headDim)
+{
+    int gid = get_global_id(0);
+    int total = batch * numHeads * headDim;
+    if (gid >= total) return;
+
+    int di = gid % headDim;
+    int h  = (gid / headDim) % numHeads;
+    int b  = gid / (headDim * numHeads);
+    int hOff = h * headDim;
+
+    float Srow[GLA_MAX_HEADDIM];
+    for (int ki = 0; ki < headDim; ki++) Srow[ki] = 0.0f;
+
+    for (int t = 0; t < seqLen; t++) {
+        int baseOff = (b * seqLen + t) * modelDim + hOff;
+        float g  = G[(b * seqLen + t) * numHeads + h];
+        float vd = V[baseOff + di];
+        float o  = 0.0f;
+        for (int ki = 0; ki < headDim; ki++) {
+            float s = g * Srow[ki] + vd * K[baseOff + ki];
+            Srow[ki] = s;
+            o += s * Q[baseOff + ki];
+        }
+        output[baseOff + di] = o;
+    }
+}
+
+__kernel void gla_scan_recompute(
+    __global const float* K, __global const float* V, __global const float* G,
+    __global float* Straj,
+    int batch, int seqLen, int modelDim, int numHeads, int headDim)
+{
+    int gid = get_global_id(0);
+    int total = batch * numHeads * headDim;
+    if (gid >= total) return;
+
+    int di = gid % headDim;
+    int h  = (gid / headDim) % numHeads;
+    int b  = gid / (headDim * numHeads);
+    int hOff = h * headDim;
+    int hh = headDim * headDim;
+
+    float Srow[GLA_MAX_HEADDIM];
+    for (int ki = 0; ki < headDim; ki++) Srow[ki] = 0.0f;
+
+    for (int t = 0; t < seqLen; t++) {
+        int baseOff = (b * seqLen + t) * modelDim + hOff;
+        float g  = G[(b * seqLen + t) * numHeads + h];
+        float vd = V[baseOff + di];
+        long trajBase = ((long)(b * numHeads + h) * seqLen + t) * hh + (long)di * headDim;
+        for (int ki = 0; ki < headDim; ki++) {
+            float s = g * Srow[ki] + vd * K[baseOff + ki];
+            Srow[ki] = s;
+            Straj[trajBase + ki] = s;
+        }
+    }
+}
+
+__kernel void gla_scan_backward(
+    __global const float* dOut, __global const float* Q, __global const float* K,
+    __global const float* V, __global const float* G, __global const float* Straj,
+    __global volatile float* dQ, __global volatile float* dK,
+    __global volatile float* dV, __global volatile float* dG,
+    int batch, int seqLen, int modelDim, int numHeads, int headDim)
+{
+    int gid = get_global_id(0);
+    int total = batch * numHeads * headDim;
+    if (gid >= total) return;
+
+    int di = gid % headDim;
+    int h  = (gid / headDim) % numHeads;
+    int b  = gid / (headDim * numHeads);
+    int hOff = h * headDim;
+    int hh = headDim * headDim;
+
+    float dSrow[GLA_MAX_HEADDIM];
+    for (int ki = 0; ki < headDim; ki++) dSrow[ki] = 0.0f;
+
+    for (int t = seqLen - 1; t >= 0; t--) {
+        int baseOff = (b * seqLen + t) * modelDim + hOff;
+        int gOff = (b * seqLen + t) * numHeads + h;
+        float g = G[gOff];
+        long trajBase = ((long)(b * numHeads + h) * seqLen + t) * hh + (long)di * headDim;
+        long sprevBase = ((long)(b * numHeads + h) * seqLen + (t - 1)) * hh + (long)di * headDim;
+
+        float dOutVal = dOut[baseOff + di];
+        for (int ki = 0; ki < headDim; ki++) {
+            float sval = Straj[trajBase + ki];
+            atomic_add_float(&dQ[baseOff + ki], dOutVal * sval);
+            dSrow[ki] += dOutVal * Q[baseOff + ki];
+        }
+
+        float vd = V[baseOff + di];
+        float dg = 0.0f;
+        float dVacc = 0.0f;
+        for (int ki = 0; ki < headDim; ki++) {
+            float dStv = dSrow[ki];
+            float sprev = (t > 0) ? Straj[sprevBase + ki] : 0.0f;
+            dg += dStv * sprev;
+            atomic_add_float(&dK[baseOff + ki], dStv * vd);
+            dVacc += dStv * K[baseOff + ki];
+        }
+        atomic_add_float(&dV[baseOff + di], dVacc);
+        atomic_add_float(&dG[gOff], dg);
+
+        for (int ki = 0; ki < headDim; ki++) dSrow[ki] *= g;
+    }
+}
+";
+    }
+
+    public static string[] GetKernelNames()
+    {
+        return new[]
+        {
+            "gla_scan_forward",
+            "gla_scan_recompute",
+            "gla_scan_backward"
+        };
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/Mamba2Kernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/Mamba2Kernels.cs
@@ -1,0 +1,54 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// OpenCL kernel for the fused Mamba-2 SSD scan forward (#1464). One work-item per (batch, channel flatD).
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL.Kernels;
+
+internal static class Mamba2Kernels
+{
+    public const int MaxStateDim = 256;
+
+    public static string GetSource()
+    {
+        return @"
+#define MAMBA2_MAX_STATEDIM 256
+
+__kernel void mamba2_ssd_scan_forward(
+    __global const float* X, __global const float* delta, __global const float* aLog,
+    __global const float* B, __global const float* C, __global const float* D,
+    __global float* output,
+    int batch, int seqLen, int innerDim, int numHeads, int headDim, int sd)
+{
+    int gid = get_global_id(0);
+    int total = batch * innerDim;
+    if (gid >= total) return;
+
+    int flatD = gid % innerDim;
+    int b = gid / innerDim;
+    int hi = flatD / headDim;
+    float negA = -exp(aLog[hi]);
+    float dv = D[hi];
+
+    float h[MAMBA2_MAX_STATEDIM];
+    for (int n = 0; n < sd; n++) h[n] = 0.0f;
+
+    for (int t = 0; t < seqLen; t++) {
+        int btInner = (b * seqLen + t) * innerDim;
+        int btState = (b * seqLen + t) * sd;
+        int btHead = (b * seqLen + t) * numHeads;
+        float dt = delta[btHead + hi];
+        float aBar = exp(dt * negA);
+        float xv = X[btInner + flatD];
+        float y = 0.0f;
+        for (int n = 0; n < sd; n++) {
+            float hNew = aBar * h[n] + dt * B[btState + n] * xv;
+            h[n] = hNew;
+            y += C[btState + n] * hNew;
+        }
+        output[btInner + flatD] = y + dv * xv;
+    }
+}
+";
+    }
+
+    public static string[] GetKernelNames() => new[] { "mamba2_ssd_scan_forward" };
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/MambaKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/MambaKernels.cs
@@ -1,0 +1,52 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// OpenCL kernel for the fused Mamba selective scan forward (#1464). One work-item per (batch, channel).
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL.Kernels;
+
+internal static class MambaKernels
+{
+    public const int MaxStateDim = 256;
+
+    public static string GetSource()
+    {
+        return @"
+#define MAMBA_MAX_STATEDIM 256
+
+__kernel void mamba_selective_scan_forward(
+    __global const float* X, __global const float* delta, __global const float* aLog,
+    __global const float* B, __global const float* C, __global const float* D,
+    __global float* output,
+    int batch, int seqLen, int innerDim, int stateDim)
+{
+    int gid = get_global_id(0);
+    int total = batch * innerDim;
+    if (gid >= total) return;
+
+    int di = gid % innerDim;
+    int b = gid / innerDim;
+    int hrow = di * stateDim;
+
+    float negA[MAMBA_MAX_STATEDIM];
+    float h[MAMBA_MAX_STATEDIM];
+    for (int ni = 0; ni < stateDim; ni++) { negA[ni] = -exp(aLog[hrow + ni]); h[ni] = 0.0f; }
+
+    for (int t = 0; t < seqLen; t++) {
+        int baseID = (b * seqLen + t) * innerDim;
+        int baseSD = (b * seqLen + t) * stateDim;
+        float dt = delta[baseID + di];
+        float xv = X[baseID + di];
+        float y = 0.0f;
+        for (int ni = 0; ni < stateDim; ni++) {
+            float aBar = exp(dt * negA[ni]);
+            float hv = aBar * h[ni] + dt * B[baseSD + ni] * xv;
+            h[ni] = hv;
+            y += C[baseSD + ni] * hv;
+        }
+        output[baseID + di] = y + D[di] * xv;
+    }
+}
+";
+    }
+
+    public static string[] GetKernelNames() => new[] { "mamba_selective_scan_forward" };
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/RgLruKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/RgLruKernels.cs
@@ -1,0 +1,38 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// OpenCL kernel for the fused RG-LRU scan forward (#1464). One work-item per (batch, channel).
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL.Kernels;
+
+internal static class RgLruKernels
+{
+    public static string GetSource()
+    {
+        return @"
+__kernel void rglru_scan_forward(
+    __global const float* V, __global const float* R, __global const float* I, __global const float* decay,
+    __global float* output,
+    int batch, int seqLen, int recDim)
+{
+    int gid = get_global_id(0);
+    int total = batch * recDim;
+    if (gid >= total) return;
+
+    int c = gid % recDim;
+    int b = gid / recDim;
+    float base = 1.0f / (1.0f + exp(decay[c])); // sigmoid(-decay)
+    float h = 0.0f;
+
+    for (int t = 0; t < seqLen; t++) {
+        int off = (b * seqLen + t) * recDim + c;
+        float a = R[off] * base;
+        float om = 1.0f - a * a;
+        float s = om > 0.0f ? sqrt(om) : 0.0f;
+        h = a * h + s * (I[off] * V[off]);
+        output[off] = h;
+    }
+}
+";
+    }
+
+    public static string[] GetKernelNames() => new[] { "rglru_scan_forward" };
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/Rwkv4Kernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/Rwkv4Kernels.cs
@@ -8,7 +8,7 @@ internal static class Rwkv4Kernels
     public static string GetSource()
     {
         return @"
-#define RWKV4_NEG_INF (-1.0e38f)
+#define RWKV4_NEG_INF (-INFINITY)
 
 __kernel void rwkv4_wkv_forward(
     __global const float* R, __global const float* K, __global const float* V,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/Rwkv4Kernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/Rwkv4Kernels.cs
@@ -1,0 +1,54 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// OpenCL kernel for the fused RWKV-4 time-mixing WKV scan forward (#1464). One work-item per (batch, channel).
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL.Kernels;
+
+internal static class Rwkv4Kernels
+{
+    public static string GetSource()
+    {
+        return @"
+#define RWKV4_NEG_INF (-1.0e38f)
+
+__kernel void rwkv4_wkv_forward(
+    __global const float* R, __global const float* K, __global const float* V,
+    __global const float* timeDecay, __global const float* timeFirst,
+    __global float* output,
+    int batch, int seqLen, int modelDim)
+{
+    int gid = get_global_id(0);
+    int total = batch * modelDim;
+    if (gid >= total) return;
+
+    int c = gid % modelDim;
+    int b = gid / modelDim;
+    float w = -exp(timeDecay[c]);
+    float u = timeFirst[c];
+
+    float aa = 0.0f, bb = 0.0f, pp = RWKV4_NEG_INF;
+    for (int t = 0; t < seqLen; t++) {
+        int off = (b * seqLen + t) * modelDim + c;
+        float k = K[off];
+        float v = V[off];
+
+        float ww = u + k;
+        float q = fmax(pp, ww);
+        float e1 = exp(pp - q);
+        float e2 = exp(ww - q);
+        float wkv = (e1 * aa + e2 * v) / (e1 * bb + e2);
+        output[off] = (1.0f / (1.0f + exp(-R[off]))) * wkv;
+
+        float ww2 = pp + w;
+        float q2 = fmax(ww2, k);
+        float e1b = exp(ww2 - q2);
+        float e2b = exp(k - q2);
+        aa = e1b * aa + e2b * v;
+        bb = e1b * bb + e2b;
+        pp = q2;
+    }
+}
+";
+    }
+
+    public static string[] GetKernelNames() => new[] { "rwkv4_wkv_forward" };
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/XLstmKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/XLstmKernels.cs
@@ -28,6 +28,7 @@ __kernel void xlstm_scan_forward(
     int b = gid / numHeads;
     int hOff = h * headDim;
     int hh = headDim * headDim;
+    if (headDim < 0 || headDim > XLSTM_MAX_HEADDIM || hh > XLSTM_MAX_HH) return;
     float kappa = 1.0f / sqrt((float)headDim);
 
     float C[XLSTM_MAX_HH];

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/XLstmKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/XLstmKernels.cs
@@ -1,0 +1,65 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// OpenCL kernel for the fused xLSTM (mLSTM) matrix-memory scan forward (issue ooples/AiDotNet#1464).
+// Same design as HipXLstmKernels: one work-item per (batch, head) carries the full C + n state.
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL.Kernels;
+
+internal static class XLstmKernels
+{
+    public const int MaxHeadDim = 64;
+
+    public static string GetSource()
+    {
+        return @"
+#define XLSTM_MAX_HEADDIM 64
+#define XLSTM_MAX_HH 4096
+#define XLSTM_IGATE_CLAMP 4.85e8f
+
+__kernel void xlstm_scan_forward(
+    __global const float* Q, __global const float* K, __global const float* V,
+    __global const float* I, __global const float* F, __global const float* O,
+    __global float* output,
+    int batch, int seqLen, int modelDim, int numHeads, int headDim)
+{
+    int gid = get_global_id(0);
+    if (gid >= batch * numHeads) return;
+
+    int h = gid % numHeads;
+    int b = gid / numHeads;
+    int hOff = h * headDim;
+    int hh = headDim * headDim;
+    float kappa = 1.0f / sqrt((float)headDim);
+
+    float C[XLSTM_MAX_HH];
+    float n[XLSTM_MAX_HEADDIM];
+    for (int i = 0; i < hh; i++) C[i] = 0.0f;
+    for (int i = 0; i < headDim; i++) n[i] = 0.0f;
+
+    for (int t = 0; t < seqLen; t++) {
+        int baseOff = (b * seqLen + t) * modelDim + hOff;
+        int gOff = (b * seqLen + t) * numHeads + h;
+        float iv = I[gOff]; if (iv > XLSTM_IGATE_CLAMP) iv = XLSTM_IGATE_CLAMP;
+        float f = F[gOff], o = O[gOff];
+        for (int di = 0; di < headDim; di++) {
+            n[di] = f * n[di] + iv * (K[baseOff + di] * kappa);
+            float vv = V[baseOff + di];
+            int srow = di * headDim;
+            for (int ki = 0; ki < headDim; ki++)
+                C[srow + ki] = f * C[srow + ki] + iv * vv * (K[baseOff + ki] * kappa);
+        }
+        float nq = 0.0f;
+        for (int j = 0; j < headDim; j++) nq += n[j] * Q[baseOff + j];
+        float nf = fabs(nq); if (nf < 1.0f) nf = 1.0f;
+        for (int di = 0; di < headDim; di++) {
+            int srow = di * headDim;
+            float num = 0.0f;
+            for (int ki = 0; ki < headDim; ki++) num += C[srow + ki] * Q[baseOff + ki];
+            output[baseOff + di] = o * num / nf;
+        }
+    }
+}
+";
+    }
+
+    public static string[] GetKernelNames() => new[] { "xlstm_scan_forward" };
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -11649,6 +11649,10 @@ KERNEL VARIANTS (A/B testing):
         {
             if (_context == null)
                 throw new InvalidOperationException("OpenCL context is not initialized. Cannot execute GlaScanForward.");
+            if (batch <= 0 || seqLen <= 0 || modelDim <= 0 || numHeads <= 0 || headDim <= 0)
+                throw new ArgumentOutOfRangeException(nameof(batch), "GLA dimensions must be positive.");
+            if (modelDim != numHeads * headDim)
+                throw new ArgumentException($"modelDim ({modelDim}) must equal numHeads * headDim ({numHeads * headDim}).");
             if (headDim > Kernels.GlaKernels.MaxHeadDim)
                 throw new InvalidOperationException($"GLA headDim ({headDim}) exceeds max ({Kernels.GlaKernels.MaxHeadDim}).");
             if (!_kernelCache.TryGetValue("gla_scan_forward", out var kernel))
@@ -11679,15 +11683,23 @@ KERNEL VARIANTS (A/B testing):
         {
             if (_context == null)
                 throw new InvalidOperationException("OpenCL context is not initialized. Cannot execute GlaScanBackward.");
+            if (batch <= 0 || seqLen <= 0 || modelDim <= 0 || numHeads <= 0 || headDim <= 0)
+                throw new ArgumentOutOfRangeException(nameof(batch), "GLA dimensions must be positive.");
+            if (modelDim != numHeads * headDim)
+                throw new ArgumentException($"modelDim ({modelDim}) must equal numHeads * headDim ({numHeads * headDim}).");
             if (headDim > Kernels.GlaKernels.MaxHeadDim)
                 throw new InvalidOperationException($"GLA headDim ({headDim}) exceeds max ({Kernels.GlaKernels.MaxHeadDim}).");
             if (!_kernelCache.TryGetValue("gla_scan_recompute", out var recompute) ||
                 !_kernelCache.TryGetValue("gla_scan_backward", out var backward))
                 throw new InvalidOperationException("OpenCL kernel not found: gla_scan_recompute / gla_scan_backward");
 
-            int trajLen = batch * numHeads * seqLen * headDim * headDim;
+            long totalLong = checked((long)batch * numHeads * headDim);
+            long trajLenLong = checked(totalLong * seqLen * headDim);
+            if (totalLong > int.MaxValue || trajLenLong > int.MaxValue)
+                throw new ArgumentOutOfRangeException(nameof(batch), "GLA dimensions exceed OpenCL launch/buffer limits.");
+            int trajLen = (int)trajLenLong;
             using var trajBuf = AllocateBuffer(trajLen);
-            int total = batch * numHeads * headDim;
+            int total = (int)totalLong;
             int localSize = CalculateOptimalWorkGroupSize1D(total);
             int globalSize = ((total + localSize - 1) / localSize) * localSize;
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -572,6 +572,14 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                     _kernelCache[name] = new DirectOpenClKernel(_context, rglruProgram, name);
                 }
 
+                // Compile fused RWKV-4 WKV scan kernels (#1464)
+                var rwkv4Program = CompileOrLoadCached(Rwkv4Kernels.GetSource(), optimizationFlags, "RWKV-4 WKV scan kernels");
+                _programs.Add(rwkv4Program);
+                foreach (var name in Rwkv4Kernels.GetKernelNames())
+                {
+                    _kernelCache[name] = new DirectOpenClKernel(_context, rwkv4Program, name);
+                }
+
                 // Compile GRU sequence kernels (forward/backward for BPTT training)
                 var gruProgram = CompileOrLoadCached(GruKernels.GetSource(), optimizationFlags, "GRU sequence kernels");
                 _programs.Add(gruProgram);
@@ -11770,6 +11778,32 @@ KERNEL VARIANTS (A/B testing):
             kernel.SetArg(7u, recDim);
 
             int total = batch * recDim;
+            int localSize = CalculateOptimalWorkGroupSize1D(total);
+            int globalSize = ((total + localSize - 1) / localSize) * localSize;
+            kernel.Execute1D(globalSize, localSize);
+        }
+
+        // ── Fused RWKV-4 WKV scan forward (#1464) ───────────────────────────────────────────
+        public void Rwkv4WkvForward(
+            IGpuBuffer r, IGpuBuffer k, IGpuBuffer v, IGpuBuffer timeDecay, IGpuBuffer timeFirst, IGpuBuffer output,
+            int batch, int seqLen, int modelDim)
+        {
+            if (_context == null)
+                throw new InvalidOperationException("OpenCL context is not initialized. Cannot execute Rwkv4WkvForward.");
+            if (!_kernelCache.TryGetValue("rwkv4_wkv_forward", out var kernel))
+                throw new InvalidOperationException("OpenCL kernel not found: rwkv4_wkv_forward");
+
+            kernel.SetArg(0u, ((DirectOpenClGpuBuffer)r).Buffer.Handle);
+            kernel.SetArg(1u, ((DirectOpenClGpuBuffer)k).Buffer.Handle);
+            kernel.SetArg(2u, ((DirectOpenClGpuBuffer)v).Buffer.Handle);
+            kernel.SetArg(3u, ((DirectOpenClGpuBuffer)timeDecay).Buffer.Handle);
+            kernel.SetArg(4u, ((DirectOpenClGpuBuffer)timeFirst).Buffer.Handle);
+            kernel.SetArg(5u, ((DirectOpenClGpuBuffer)output).Buffer.Handle);
+            kernel.SetArg(6u, batch);
+            kernel.SetArg(7u, seqLen);
+            kernel.SetArg(8u, modelDim);
+
+            int total = batch * modelDim;
             int localSize = CalculateOptimalWorkGroupSize1D(total);
             int globalSize = ((total + localSize - 1) / localSize) * localSize;
             kernel.Execute1D(globalSize, localSize);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -588,6 +588,14 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                     _kernelCache[name] = new DirectOpenClKernel(_context, mambaProgram, name);
                 }
 
+                // Compile fused Mamba-2 SSD scan kernels (#1464)
+                var mamba2Program = CompileOrLoadCached(Mamba2Kernels.GetSource(), optimizationFlags, "Mamba-2 SSD scan kernels");
+                _programs.Add(mamba2Program);
+                foreach (var name in Mamba2Kernels.GetKernelNames())
+                {
+                    _kernelCache[name] = new DirectOpenClKernel(_context, mamba2Program, name);
+                }
+
                 // Compile GRU sequence kernels (forward/backward for BPTT training)
                 var gruProgram = CompileOrLoadCached(GruKernels.GetSource(), optimizationFlags, "GRU sequence kernels");
                 _programs.Add(gruProgram);
@@ -11840,6 +11848,38 @@ KERNEL VARIANTS (A/B testing):
             kernel.SetArg(8u, seqLen);
             kernel.SetArg(9u, innerDim);
             kernel.SetArg(10u, stateDim);
+
+            int total = batch * innerDim;
+            int localSize = CalculateOptimalWorkGroupSize1D(total);
+            int globalSize = ((total + localSize - 1) / localSize) * localSize;
+            kernel.Execute1D(globalSize, localSize);
+        }
+
+        // ── Fused Mamba-2 SSD scan forward (#1464) ──────────────────────────────────────────
+        public void Mamba2SsdScanForward(
+            IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,
+            IGpuBuffer output, int batch, int seqLen, int innerDim, int numHeads, int headDim, int stateDim)
+        {
+            if (_context == null)
+                throw new InvalidOperationException("OpenCL context is not initialized. Cannot execute Mamba2SsdScanForward.");
+            if (stateDim > Kernels.Mamba2Kernels.MaxStateDim)
+                throw new InvalidOperationException($"Mamba-2 stateDim ({stateDim}) exceeds max ({Kernels.Mamba2Kernels.MaxStateDim}).");
+            if (!_kernelCache.TryGetValue("mamba2_ssd_scan_forward", out var kernel))
+                throw new InvalidOperationException("OpenCL kernel not found: mamba2_ssd_scan_forward");
+
+            kernel.SetArg(0u, ((DirectOpenClGpuBuffer)x).Buffer.Handle);
+            kernel.SetArg(1u, ((DirectOpenClGpuBuffer)delta).Buffer.Handle);
+            kernel.SetArg(2u, ((DirectOpenClGpuBuffer)aLog).Buffer.Handle);
+            kernel.SetArg(3u, ((DirectOpenClGpuBuffer)bParam).Buffer.Handle);
+            kernel.SetArg(4u, ((DirectOpenClGpuBuffer)cParam).Buffer.Handle);
+            kernel.SetArg(5u, ((DirectOpenClGpuBuffer)dParam).Buffer.Handle);
+            kernel.SetArg(6u, ((DirectOpenClGpuBuffer)output).Buffer.Handle);
+            kernel.SetArg(7u, batch);
+            kernel.SetArg(8u, seqLen);
+            kernel.SetArg(9u, innerDim);
+            kernel.SetArg(10u, numHeads);
+            kernel.SetArg(11u, headDim);
+            kernel.SetArg(12u, stateDim);
 
             int total = batch * innerDim;
             int localSize = CalculateOptimalWorkGroupSize1D(total);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -556,6 +556,14 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                     _kernelCache[name] = new DirectOpenClKernel(_context, xlstmProgram, name);
                 }
 
+                // Compile fused Gated DeltaNet scan kernels (#1464)
+                var gdnProgram = CompileOrLoadCached(GatedDeltaNetKernels.GetSource(), optimizationFlags, "Gated DeltaNet scan kernels");
+                _programs.Add(gdnProgram);
+                foreach (var name in GatedDeltaNetKernels.GetKernelNames())
+                {
+                    _kernelCache[name] = new DirectOpenClKernel(_context, gdnProgram, name);
+                }
+
                 // Compile GRU sequence kernels (forward/backward for BPTT training)
                 var gruProgram = CompileOrLoadCached(GruKernels.GetSource(), optimizationFlags, "GRU sequence kernels");
                 _programs.Add(gruProgram);
@@ -11699,6 +11707,36 @@ KERNEL VARIANTS (A/B testing):
             kernel.SetArg(11u, headDim);
 
             int total = batch * numHeads;
+            int localSize = CalculateOptimalWorkGroupSize1D(total);
+            int globalSize = ((total + localSize - 1) / localSize) * localSize;
+            kernel.Execute1D(globalSize, localSize);
+        }
+
+        // ── Fused Gated DeltaNet scan forward (#1464) ───────────────────────────────────────
+        public void GatedDeltaNetScanForward(
+            IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer alpha, IGpuBuffer beta, IGpuBuffer output,
+            int batch, int seqLen, int modelDim, int numHeads, int headDim)
+        {
+            if (_context == null)
+                throw new InvalidOperationException("OpenCL context is not initialized. Cannot execute GatedDeltaNetScanForward.");
+            if (headDim > Kernels.GatedDeltaNetKernels.MaxHeadDim)
+                throw new InvalidOperationException($"GatedDeltaNet headDim ({headDim}) exceeds max ({Kernels.GatedDeltaNetKernels.MaxHeadDim}).");
+            if (!_kernelCache.TryGetValue("gated_delta_scan_forward", out var kernel))
+                throw new InvalidOperationException("OpenCL kernel not found: gated_delta_scan_forward");
+
+            kernel.SetArg(0u, ((DirectOpenClGpuBuffer)q).Buffer.Handle);
+            kernel.SetArg(1u, ((DirectOpenClGpuBuffer)k).Buffer.Handle);
+            kernel.SetArg(2u, ((DirectOpenClGpuBuffer)v).Buffer.Handle);
+            kernel.SetArg(3u, ((DirectOpenClGpuBuffer)alpha).Buffer.Handle);
+            kernel.SetArg(4u, ((DirectOpenClGpuBuffer)beta).Buffer.Handle);
+            kernel.SetArg(5u, ((DirectOpenClGpuBuffer)output).Buffer.Handle);
+            kernel.SetArg(6u, batch);
+            kernel.SetArg(7u, seqLen);
+            kernel.SetArg(8u, modelDim);
+            kernel.SetArg(9u, numHeads);
+            kernel.SetArg(10u, headDim);
+
+            int total = batch * numHeads * headDim;
             int localSize = CalculateOptimalWorkGroupSize1D(total);
             int globalSize = ((total + localSize - 1) / localSize) * localSize;
             kernel.Execute1D(globalSize, localSize);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -564,6 +564,14 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                     _kernelCache[name] = new DirectOpenClKernel(_context, gdnProgram, name);
                 }
 
+                // Compile fused RG-LRU scan kernels (#1464)
+                var rglruProgram = CompileOrLoadCached(RgLruKernels.GetSource(), optimizationFlags, "RG-LRU scan kernels");
+                _programs.Add(rglruProgram);
+                foreach (var name in RgLruKernels.GetKernelNames())
+                {
+                    _kernelCache[name] = new DirectOpenClKernel(_context, rglruProgram, name);
+                }
+
                 // Compile GRU sequence kernels (forward/backward for BPTT training)
                 var gruProgram = CompileOrLoadCached(GruKernels.GetSource(), optimizationFlags, "GRU sequence kernels");
                 _programs.Add(gruProgram);
@@ -11737,6 +11745,31 @@ KERNEL VARIANTS (A/B testing):
             kernel.SetArg(10u, headDim);
 
             int total = batch * numHeads * headDim;
+            int localSize = CalculateOptimalWorkGroupSize1D(total);
+            int globalSize = ((total + localSize - 1) / localSize) * localSize;
+            kernel.Execute1D(globalSize, localSize);
+        }
+
+        // ── Fused RG-LRU scan forward (#1464) ───────────────────────────────────────────────
+        public void RgLruScanForward(
+            IGpuBuffer value, IGpuBuffer recGate, IGpuBuffer inpGate, IGpuBuffer decay, IGpuBuffer output,
+            int batch, int seqLen, int recDim)
+        {
+            if (_context == null)
+                throw new InvalidOperationException("OpenCL context is not initialized. Cannot execute RgLruScanForward.");
+            if (!_kernelCache.TryGetValue("rglru_scan_forward", out var kernel))
+                throw new InvalidOperationException("OpenCL kernel not found: rglru_scan_forward");
+
+            kernel.SetArg(0u, ((DirectOpenClGpuBuffer)value).Buffer.Handle);
+            kernel.SetArg(1u, ((DirectOpenClGpuBuffer)recGate).Buffer.Handle);
+            kernel.SetArg(2u, ((DirectOpenClGpuBuffer)inpGate).Buffer.Handle);
+            kernel.SetArg(3u, ((DirectOpenClGpuBuffer)decay).Buffer.Handle);
+            kernel.SetArg(4u, ((DirectOpenClGpuBuffer)output).Buffer.Handle);
+            kernel.SetArg(5u, batch);
+            kernel.SetArg(6u, seqLen);
+            kernel.SetArg(7u, recDim);
+
+            int total = batch * recDim;
             int localSize = CalculateOptimalWorkGroupSize1D(total);
             int globalSize = ((total + localSize - 1) / localSize) * localSize;
             kernel.Execute1D(globalSize, localSize);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -540,6 +540,13 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                     _kernelCache[name] = new DirectOpenClKernel(_context, lstmProgram, name);
                 }
 
+                // Fused recurrence / LM-head kernels (#1464) are an OPTIONAL capability: a
+                // driver that rejects one of these sources must not abort the whole backend
+                // init (which would lose every core kernel). Compile them in their own
+                // try/catch — methods that need a missing kernel already throw "kernel not
+                // found" at call time, so a partial compile degrades gracefully.
+                try
+                {
                 // Compile fused GLA (Gated Linear Attention) scan kernels (#1464)
                 var glaProgram = CompileOrLoadCached(GlaKernels.GetSource(), optimizationFlags, "GLA scan kernels");
                 _programs.Add(glaProgram);
@@ -602,6 +609,15 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 foreach (var name in FusedLinearCeKernels.GetKernelNames())
                 {
                     _kernelCache[name] = new DirectOpenClKernel(_context, fusedCeProgram, name);
+                }
+                }
+                catch (OutOfMemoryException)
+                {
+                    throw; // Fatal — never silently downgrade.
+                }
+                catch (Exception fex)
+                {
+                    WriteDiag($"[OpenClBackend] fused recurrence/LM-head kernels (#1464) unavailable: {fex.Message}");
                 }
 
                 // Compile GRU sequence kernels (forward/backward for BPTT training)
@@ -11740,6 +11756,10 @@ KERNEL VARIANTS (A/B testing):
         {
             if (_context == null)
                 throw new InvalidOperationException("OpenCL context is not initialized. Cannot execute XLstmScanForward.");
+            if (batch <= 0 || seqLen <= 0 || modelDim <= 0 || numHeads <= 0 || headDim <= 0)
+                throw new ArgumentOutOfRangeException(nameof(batch), "xLSTM dimensions must be positive.");
+            if (modelDim != numHeads * headDim)
+                throw new ArgumentException($"modelDim ({modelDim}) must equal numHeads * headDim ({numHeads * headDim}).");
             if (headDim > Kernels.XLstmKernels.MaxHeadDim)
                 throw new InvalidOperationException($"xLSTM headDim ({headDim}) exceeds max ({Kernels.XLstmKernels.MaxHeadDim}).");
             if (!_kernelCache.TryGetValue("xlstm_scan_forward", out var kernel))
@@ -11771,6 +11791,10 @@ KERNEL VARIANTS (A/B testing):
         {
             if (_context == null)
                 throw new InvalidOperationException("OpenCL context is not initialized. Cannot execute GatedDeltaNetScanForward.");
+            if (batch <= 0 || seqLen <= 0 || modelDim <= 0 || numHeads <= 0 || headDim <= 0)
+                throw new ArgumentOutOfRangeException(nameof(batch), "GatedDeltaNet dimensions must be positive.");
+            if (modelDim != numHeads * headDim)
+                throw new ArgumentException($"modelDim ({modelDim}) must equal numHeads * headDim ({numHeads * headDim}).");
             if (headDim > Kernels.GatedDeltaNetKernels.MaxHeadDim)
                 throw new InvalidOperationException($"GatedDeltaNet headDim ({headDim}) exceeds max ({Kernels.GatedDeltaNetKernels.MaxHeadDim}).");
             if (!_kernelCache.TryGetValue("gated_delta_scan_forward", out var kernel))
@@ -11801,6 +11825,8 @@ KERNEL VARIANTS (A/B testing):
         {
             if (_context == null)
                 throw new InvalidOperationException("OpenCL context is not initialized. Cannot execute RgLruScanForward.");
+            if (batch <= 0 || seqLen <= 0 || recDim <= 0)
+                throw new ArgumentOutOfRangeException(nameof(batch), "RG-LRU dimensions must be positive.");
             if (!_kernelCache.TryGetValue("rglru_scan_forward", out var kernel))
                 throw new InvalidOperationException("OpenCL kernel not found: rglru_scan_forward");
 
@@ -11826,6 +11852,8 @@ KERNEL VARIANTS (A/B testing):
         {
             if (_context == null)
                 throw new InvalidOperationException("OpenCL context is not initialized. Cannot execute Rwkv4WkvForward.");
+            if (batch <= 0 || seqLen <= 0 || modelDim <= 0)
+                throw new ArgumentOutOfRangeException(nameof(batch), "RWKV-4 dimensions must be positive.");
             if (!_kernelCache.TryGetValue("rwkv4_wkv_forward", out var kernel))
                 throw new InvalidOperationException("OpenCL kernel not found: rwkv4_wkv_forward");
 
@@ -11852,6 +11880,8 @@ KERNEL VARIANTS (A/B testing):
         {
             if (_context == null)
                 throw new InvalidOperationException("OpenCL context is not initialized. Cannot execute MambaSelectiveScanForward.");
+            if (batch <= 0 || seqLen <= 0 || innerDim <= 0 || stateDim <= 0)
+                throw new ArgumentOutOfRangeException(nameof(batch), "Mamba dimensions must be positive.");
             if (stateDim > Kernels.MambaKernels.MaxStateDim)
                 throw new InvalidOperationException($"Mamba stateDim ({stateDim}) exceeds max ({Kernels.MambaKernels.MaxStateDim}).");
             if (!_kernelCache.TryGetValue("mamba_selective_scan_forward", out var kernel))
@@ -11882,6 +11912,10 @@ KERNEL VARIANTS (A/B testing):
         {
             if (_context == null)
                 throw new InvalidOperationException("OpenCL context is not initialized. Cannot execute Mamba2SsdScanForward.");
+            if (batch <= 0 || seqLen <= 0 || innerDim <= 0 || numHeads <= 0 || headDim <= 0 || stateDim <= 0)
+                throw new ArgumentOutOfRangeException(nameof(batch), "Mamba-2 dimensions must be positive.");
+            if (innerDim != numHeads * headDim)
+                throw new ArgumentException($"innerDim ({innerDim}) must equal numHeads * headDim ({numHeads * headDim}).");
             if (stateDim > Kernels.Mamba2Kernels.MaxStateDim)
                 throw new InvalidOperationException($"Mamba-2 stateDim ({stateDim}) exceeds max ({Kernels.Mamba2Kernels.MaxStateDim}).");
             if (!_kernelCache.TryGetValue("mamba2_ssd_scan_forward", out var kernel))
@@ -11921,6 +11955,8 @@ KERNEL VARIANTS (A/B testing):
         {
             if (_context == null)
                 throw new InvalidOperationException("OpenCL context is not initialized. Cannot execute FusedLinearCrossEntropy.");
+            if (n <= 0 || d <= 0 || vocab <= 0)
+                throw new ArgumentOutOfRangeException(nameof(n), "Fused CE dimensions (n, d, vocab) must be positive.");
             if (!_kernelCache.TryGetValue(kernelName, out var kernel))
                 throw new InvalidOperationException($"OpenCL kernel not found: {kernelName}");
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -596,6 +596,14 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                     _kernelCache[name] = new DirectOpenClKernel(_context, mamba2Program, name);
                 }
 
+                // Compile fused linear + cross-entropy kernels (#1464)
+                var fusedCeProgram = CompileOrLoadCached(FusedLinearCeKernels.GetSource(), optimizationFlags, "Fused linear cross-entropy kernels");
+                _programs.Add(fusedCeProgram);
+                foreach (var name in FusedLinearCeKernels.GetKernelNames())
+                {
+                    _kernelCache[name] = new DirectOpenClKernel(_context, fusedCeProgram, name);
+                }
+
                 // Compile GRU sequence kernels (forward/backward for BPTT training)
                 var gruProgram = CompileOrLoadCached(GruKernels.GetSource(), optimizationFlags, "GRU sequence kernels");
                 _programs.Add(gruProgram);
@@ -11885,6 +11893,40 @@ KERNEL VARIANTS (A/B testing):
             int localSize = CalculateOptimalWorkGroupSize1D(total);
             int globalSize = ((total + localSize - 1) / localSize) * localSize;
             kernel.Execute1D(globalSize, localSize);
+        }
+
+        // ── Fused linear (LM head) + cross-entropy (#1464) ──────────────────────────────────
+        public float FusedLinearCrossEntropyIndex(
+            IGpuBuffer hidden, IGpuBuffer weight, IGpuBuffer bias, IGpuBuffer targetIds, int n, int d, int vocab)
+            => FusedCeLaunch("fused_linear_ce_index", hidden, weight, bias, targetIds, n, d, vocab);
+
+        public float FusedLinearCrossEntropyDense(
+            IGpuBuffer hidden, IGpuBuffer weight, IGpuBuffer bias, IGpuBuffer target, int n, int d, int vocab)
+            => FusedCeLaunch("fused_linear_ce_dense", hidden, weight, bias, target, n, d, vocab);
+
+        private float FusedCeLaunch(
+            string kernelName, IGpuBuffer hidden, IGpuBuffer weight, IGpuBuffer bias, IGpuBuffer tgt, int n, int d, int vocab)
+        {
+            if (_context == null)
+                throw new InvalidOperationException("OpenCL context is not initialized. Cannot execute FusedLinearCrossEntropy.");
+            if (!_kernelCache.TryGetValue(kernelName, out var kernel))
+                throw new InvalidOperationException($"OpenCL kernel not found: {kernelName}");
+
+            using var lossBuf = AllocateBuffer(new float[] { 0.0f }); // zeroed accumulator
+            kernel.SetArg(0u, ((DirectOpenClGpuBuffer)hidden).Buffer.Handle);
+            kernel.SetArg(1u, ((DirectOpenClGpuBuffer)weight).Buffer.Handle);
+            kernel.SetArg(2u, ((DirectOpenClGpuBuffer)bias).Buffer.Handle);
+            kernel.SetArg(3u, ((DirectOpenClGpuBuffer)tgt).Buffer.Handle);
+            kernel.SetArg(4u, ((DirectOpenClGpuBuffer)lossBuf).Buffer.Handle);
+            kernel.SetArg(5u, n);
+            kernel.SetArg(6u, d);
+            kernel.SetArg(7u, vocab);
+
+            int localSize = CalculateOptimalWorkGroupSize1D(n);
+            int globalSize = ((n + localSize - 1) / localSize) * localSize;
+            kernel.Execute1D(globalSize, localSize);
+            var loss = DownloadBuffer(lossBuf);
+            return loss[0] / n;
         }
 
         public void LstmForwardSequence(

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -580,6 +580,14 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                     _kernelCache[name] = new DirectOpenClKernel(_context, rwkv4Program, name);
                 }
 
+                // Compile fused Mamba selective scan kernels (#1464)
+                var mambaProgram = CompileOrLoadCached(MambaKernels.GetSource(), optimizationFlags, "Mamba selective scan kernels");
+                _programs.Add(mambaProgram);
+                foreach (var name in MambaKernels.GetKernelNames())
+                {
+                    _kernelCache[name] = new DirectOpenClKernel(_context, mambaProgram, name);
+                }
+
                 // Compile GRU sequence kernels (forward/backward for BPTT training)
                 var gruProgram = CompileOrLoadCached(GruKernels.GetSource(), optimizationFlags, "GRU sequence kernels");
                 _programs.Add(gruProgram);
@@ -11804,6 +11812,36 @@ KERNEL VARIANTS (A/B testing):
             kernel.SetArg(8u, modelDim);
 
             int total = batch * modelDim;
+            int localSize = CalculateOptimalWorkGroupSize1D(total);
+            int globalSize = ((total + localSize - 1) / localSize) * localSize;
+            kernel.Execute1D(globalSize, localSize);
+        }
+
+        // ── Fused Mamba selective scan forward (#1464) ──────────────────────────────────────
+        public void MambaSelectiveScanForward(
+            IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,
+            IGpuBuffer output, int batch, int seqLen, int innerDim, int stateDim)
+        {
+            if (_context == null)
+                throw new InvalidOperationException("OpenCL context is not initialized. Cannot execute MambaSelectiveScanForward.");
+            if (stateDim > Kernels.MambaKernels.MaxStateDim)
+                throw new InvalidOperationException($"Mamba stateDim ({stateDim}) exceeds max ({Kernels.MambaKernels.MaxStateDim}).");
+            if (!_kernelCache.TryGetValue("mamba_selective_scan_forward", out var kernel))
+                throw new InvalidOperationException("OpenCL kernel not found: mamba_selective_scan_forward");
+
+            kernel.SetArg(0u, ((DirectOpenClGpuBuffer)x).Buffer.Handle);
+            kernel.SetArg(1u, ((DirectOpenClGpuBuffer)delta).Buffer.Handle);
+            kernel.SetArg(2u, ((DirectOpenClGpuBuffer)aLog).Buffer.Handle);
+            kernel.SetArg(3u, ((DirectOpenClGpuBuffer)bParam).Buffer.Handle);
+            kernel.SetArg(4u, ((DirectOpenClGpuBuffer)cParam).Buffer.Handle);
+            kernel.SetArg(5u, ((DirectOpenClGpuBuffer)dParam).Buffer.Handle);
+            kernel.SetArg(6u, ((DirectOpenClGpuBuffer)output).Buffer.Handle);
+            kernel.SetArg(7u, batch);
+            kernel.SetArg(8u, seqLen);
+            kernel.SetArg(9u, innerDim);
+            kernel.SetArg(10u, stateDim);
+
+            int total = batch * innerDim;
             int localSize = CalculateOptimalWorkGroupSize1D(total);
             int globalSize = ((total + localSize - 1) / localSize) * localSize;
             kernel.Execute1D(globalSize, localSize);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -540,6 +540,14 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                     _kernelCache[name] = new DirectOpenClKernel(_context, lstmProgram, name);
                 }
 
+                // Compile fused GLA (Gated Linear Attention) scan kernels (#1464)
+                var glaProgram = CompileOrLoadCached(GlaKernels.GetSource(), optimizationFlags, "GLA scan kernels");
+                _programs.Add(glaProgram);
+                foreach (var name in GlaKernels.GetKernelNames())
+                {
+                    _kernelCache[name] = new DirectOpenClKernel(_context, glaProgram, name);
+                }
+
                 // Compile GRU sequence kernels (forward/backward for BPTT training)
                 var gruProgram = CompileOrLoadCached(GruKernels.GetSource(), optimizationFlags, "GRU sequence kernels");
                 _programs.Add(gruProgram);
@@ -11577,6 +11585,84 @@ KERNEL VARIANTS (A/B testing):
         #endregion
 
         #region RNN (LSTM/GRU) Sequence Operations
+
+        // ── Fused GLA (Gated Linear Attention) scan (#1464) ────────────────────────────────
+        public void GlaScanForward(
+            IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer gate, IGpuBuffer output,
+            int batch, int seqLen, int modelDim, int numHeads, int headDim)
+        {
+            if (_context == null)
+                throw new InvalidOperationException("OpenCL context is not initialized. Cannot execute GlaScanForward.");
+            if (headDim > Kernels.GlaKernels.MaxHeadDim)
+                throw new InvalidOperationException($"GLA headDim ({headDim}) exceeds max ({Kernels.GlaKernels.MaxHeadDim}).");
+            if (!_kernelCache.TryGetValue("gla_scan_forward", out var kernel))
+                throw new InvalidOperationException("OpenCL kernel not found: gla_scan_forward");
+
+            kernel.SetArg(0u, ((DirectOpenClGpuBuffer)q).Buffer.Handle);
+            kernel.SetArg(1u, ((DirectOpenClGpuBuffer)k).Buffer.Handle);
+            kernel.SetArg(2u, ((DirectOpenClGpuBuffer)v).Buffer.Handle);
+            kernel.SetArg(3u, ((DirectOpenClGpuBuffer)gate).Buffer.Handle);
+            kernel.SetArg(4u, ((DirectOpenClGpuBuffer)output).Buffer.Handle);
+            kernel.SetArg(5u, batch);
+            kernel.SetArg(6u, seqLen);
+            kernel.SetArg(7u, modelDim);
+            kernel.SetArg(8u, numHeads);
+            kernel.SetArg(9u, headDim);
+
+            int total = batch * numHeads * headDim;
+            int localSize = CalculateOptimalWorkGroupSize1D(total);
+            int globalSize = ((total + localSize - 1) / localSize) * localSize;
+            kernel.Execute1D(globalSize, localSize);
+        }
+
+        // dQ/dK/dV ([batch,seqLen,modelDim]) and dG ([batch,seqLen,numHeads]) MUST be pre-zeroed.
+        public void GlaScanBackward(
+            IGpuBuffer dOut, IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer gate,
+            IGpuBuffer dQ, IGpuBuffer dK, IGpuBuffer dV, IGpuBuffer dG,
+            int batch, int seqLen, int modelDim, int numHeads, int headDim)
+        {
+            if (_context == null)
+                throw new InvalidOperationException("OpenCL context is not initialized. Cannot execute GlaScanBackward.");
+            if (headDim > Kernels.GlaKernels.MaxHeadDim)
+                throw new InvalidOperationException($"GLA headDim ({headDim}) exceeds max ({Kernels.GlaKernels.MaxHeadDim}).");
+            if (!_kernelCache.TryGetValue("gla_scan_recompute", out var recompute) ||
+                !_kernelCache.TryGetValue("gla_scan_backward", out var backward))
+                throw new InvalidOperationException("OpenCL kernel not found: gla_scan_recompute / gla_scan_backward");
+
+            int trajLen = batch * numHeads * seqLen * headDim * headDim;
+            using var trajBuf = AllocateBuffer(trajLen);
+            int total = batch * numHeads * headDim;
+            int localSize = CalculateOptimalWorkGroupSize1D(total);
+            int globalSize = ((total + localSize - 1) / localSize) * localSize;
+
+            recompute.SetArg(0u, ((DirectOpenClGpuBuffer)k).Buffer.Handle);
+            recompute.SetArg(1u, ((DirectOpenClGpuBuffer)v).Buffer.Handle);
+            recompute.SetArg(2u, ((DirectOpenClGpuBuffer)gate).Buffer.Handle);
+            recompute.SetArg(3u, ((DirectOpenClGpuBuffer)trajBuf).Buffer.Handle);
+            recompute.SetArg(4u, batch);
+            recompute.SetArg(5u, seqLen);
+            recompute.SetArg(6u, modelDim);
+            recompute.SetArg(7u, numHeads);
+            recompute.SetArg(8u, headDim);
+            recompute.Execute1D(globalSize, localSize);
+
+            backward.SetArg(0u, ((DirectOpenClGpuBuffer)dOut).Buffer.Handle);
+            backward.SetArg(1u, ((DirectOpenClGpuBuffer)q).Buffer.Handle);
+            backward.SetArg(2u, ((DirectOpenClGpuBuffer)k).Buffer.Handle);
+            backward.SetArg(3u, ((DirectOpenClGpuBuffer)v).Buffer.Handle);
+            backward.SetArg(4u, ((DirectOpenClGpuBuffer)gate).Buffer.Handle);
+            backward.SetArg(5u, ((DirectOpenClGpuBuffer)trajBuf).Buffer.Handle);
+            backward.SetArg(6u, ((DirectOpenClGpuBuffer)dQ).Buffer.Handle);
+            backward.SetArg(7u, ((DirectOpenClGpuBuffer)dK).Buffer.Handle);
+            backward.SetArg(8u, ((DirectOpenClGpuBuffer)dV).Buffer.Handle);
+            backward.SetArg(9u, ((DirectOpenClGpuBuffer)dG).Buffer.Handle);
+            backward.SetArg(10u, batch);
+            backward.SetArg(11u, seqLen);
+            backward.SetArg(12u, modelDim);
+            backward.SetArg(13u, numHeads);
+            backward.SetArg(14u, headDim);
+            backward.Execute1D(globalSize, localSize);
+        }
 
         public void LstmForwardSequence(
             IGpuBuffer input, IGpuBuffer hInit, IGpuBuffer cInit,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -548,6 +548,14 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                     _kernelCache[name] = new DirectOpenClKernel(_context, glaProgram, name);
                 }
 
+                // Compile fused xLSTM (mLSTM) scan kernels (#1464)
+                var xlstmProgram = CompileOrLoadCached(XLstmKernels.GetSource(), optimizationFlags, "xLSTM scan kernels");
+                _programs.Add(xlstmProgram);
+                foreach (var name in XLstmKernels.GetKernelNames())
+                {
+                    _kernelCache[name] = new DirectOpenClKernel(_context, xlstmProgram, name);
+                }
+
                 // Compile GRU sequence kernels (forward/backward for BPTT training)
                 var gruProgram = CompileOrLoadCached(GruKernels.GetSource(), optimizationFlags, "GRU sequence kernels");
                 _programs.Add(gruProgram);
@@ -11662,6 +11670,38 @@ KERNEL VARIANTS (A/B testing):
             backward.SetArg(13u, numHeads);
             backward.SetArg(14u, headDim);
             backward.Execute1D(globalSize, localSize);
+        }
+
+        // ── Fused xLSTM (mLSTM) scan forward (#1464) ────────────────────────────────────────
+        public void XLstmScanForward(
+            IGpuBuffer q, IGpuBuffer k, IGpuBuffer v,
+            IGpuBuffer iGate, IGpuBuffer fGate, IGpuBuffer oGate, IGpuBuffer output,
+            int batch, int seqLen, int modelDim, int numHeads, int headDim)
+        {
+            if (_context == null)
+                throw new InvalidOperationException("OpenCL context is not initialized. Cannot execute XLstmScanForward.");
+            if (headDim > Kernels.XLstmKernels.MaxHeadDim)
+                throw new InvalidOperationException($"xLSTM headDim ({headDim}) exceeds max ({Kernels.XLstmKernels.MaxHeadDim}).");
+            if (!_kernelCache.TryGetValue("xlstm_scan_forward", out var kernel))
+                throw new InvalidOperationException("OpenCL kernel not found: xlstm_scan_forward");
+
+            kernel.SetArg(0u, ((DirectOpenClGpuBuffer)q).Buffer.Handle);
+            kernel.SetArg(1u, ((DirectOpenClGpuBuffer)k).Buffer.Handle);
+            kernel.SetArg(2u, ((DirectOpenClGpuBuffer)v).Buffer.Handle);
+            kernel.SetArg(3u, ((DirectOpenClGpuBuffer)iGate).Buffer.Handle);
+            kernel.SetArg(4u, ((DirectOpenClGpuBuffer)fGate).Buffer.Handle);
+            kernel.SetArg(5u, ((DirectOpenClGpuBuffer)oGate).Buffer.Handle);
+            kernel.SetArg(6u, ((DirectOpenClGpuBuffer)output).Buffer.Handle);
+            kernel.SetArg(7u, batch);
+            kernel.SetArg(8u, seqLen);
+            kernel.SetArg(9u, modelDim);
+            kernel.SetArg(10u, numHeads);
+            kernel.SetArg(11u, headDim);
+
+            int total = batch * numHeads;
+            int localSize = CalculateOptimalWorkGroupSize1D(total);
+            int globalSize = ((total + localSize - 1) / localSize) * localSize;
+            kernel.Execute1D(globalSize, localSize);
         }
 
         public void LstmForwardSequence(

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
@@ -1249,6 +1249,20 @@ public sealed unsafe partial class VulkanBackend
         UploadToBuffer(gG, dG);
     }
 
+    // Fused xLSTM (mLSTM) scan forward (#1464) — host fallback via the shared reference.
+    public void XLstmScanForward(
+        IGpuBuffer q, IGpuBuffer k, IGpuBuffer v,
+        IGpuBuffer iGate, IGpuBuffer fGate, IGpuBuffer oGate, IGpuBuffer output,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        EnsureInitialized();
+        var qd = DownloadBuffer(q); var kd = DownloadBuffer(k); var vd = DownloadBuffer(v);
+        var id = DownloadBuffer(iGate); var fd = DownloadBuffer(fGate); var od = DownloadBuffer(oGate);
+        var outp = new float[batch * seqLen * modelDim];
+        Cpu.RecurrenceCpuKernels.XLstmForward(qd, kd, vd, id, fd, od, outp, batch, seqLen, modelDim, numHeads, headDim);
+        UploadToBuffer(outp, output);
+    }
+
     public void LstmForwardSequence(
         IGpuBuffer input, IGpuBuffer hInit, IGpuBuffer cInit,
         IGpuBuffer weightsIh, IGpuBuffer weightsHh, IGpuBuffer biasIh, IGpuBuffer biasHh,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
@@ -1302,6 +1302,19 @@ public sealed unsafe partial class VulkanBackend
         UploadToBuffer(outp, output);
     }
 
+    // Fused Mamba selective scan forward (#1464) — host fallback via the shared reference.
+    public void MambaSelectiveScanForward(
+        IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,
+        IGpuBuffer output, int batch, int seqLen, int innerDim, int stateDim)
+    {
+        EnsureInitialized();
+        var xd = DownloadBuffer(x); var dl = DownloadBuffer(delta); var al = DownloadBuffer(aLog);
+        var bp = DownloadBuffer(bParam); var cp = DownloadBuffer(cParam); var dp = DownloadBuffer(dParam);
+        var outp = new float[batch * seqLen * innerDim];
+        Cpu.RecurrenceCpuKernels.MambaSelectiveScanForward(xd, dl, al, bp, cp, dp, outp, batch, seqLen, innerDim, stateDim);
+        UploadToBuffer(outp, output);
+    }
+
     public void LstmForwardSequence(
         IGpuBuffer input, IGpuBuffer hInit, IGpuBuffer cInit,
         IGpuBuffer weightsIh, IGpuBuffer weightsHh, IGpuBuffer biasIh, IGpuBuffer biasHh,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
@@ -1221,20 +1221,20 @@ public sealed unsafe partial class VulkanBackend
             batch * numHeads * headDim,
             new[] { (uint)batch, (uint)seqLen, (uint)modelDim, (uint)numHeads, (uint)headDim });
 
-    // GLA BPTT backward is never invoked by the IEngine forward-only path; HIP/CUDA/OpenCL carry
-    // the real backward kernel. Kept on host (an atomics-based GLSL backward is a follow-up).
+    // GLA BPTT backward — real GLSL kernels (recompute trajectory + reverse sweep with CAS float
+    // atomics for the cross-row dQ/dK/dG). dQ/dK/dG must be pre-zeroed (the atomic accumulators).
     public void GlaScanBackward(
         IGpuBuffer dOut, IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer gate,
         IGpuBuffer dQ, IGpuBuffer dK, IGpuBuffer dV, IGpuBuffer dG,
         int batch, int seqLen, int modelDim, int numHeads, int headDim)
     {
-        EnsureInitialized();
-        var doData = DownloadBuffer(dOut); var qd = DownloadBuffer(q); var kd = DownloadBuffer(k);
-        var vd = DownloadBuffer(v); var gd = DownloadBuffer(gate);
-        var gq = new float[batch * seqLen * modelDim]; var gk = new float[batch * seqLen * modelDim];
-        var gv = new float[batch * seqLen * modelDim]; var gG = new float[batch * seqLen * numHeads];
-        Cpu.RecurrenceCpuKernels.GlaBackward(doData, qd, kd, vd, gd, gq, gk, gv, gG, batch, seqLen, modelDim, numHeads, headDim);
-        UploadToBuffer(gq, dQ); UploadToBuffer(gk, dK); UploadToBuffer(gv, dV); UploadToBuffer(gG, dG);
+        int hh = headDim * headDim;
+        int total = batch * numHeads * headDim;
+        using var traj = AllocateBuffer(batch * numHeads * seqLen * hh);
+        var pc = new[] { (uint)batch, (uint)seqLen, (uint)modelDim, (uint)numHeads, (uint)headDim };
+        GlslNaryOp(VulkanRecurrenceKernels.GlaRecompute, new[] { k, v, gate, traj }, total, pc);
+        GlslNaryOp(VulkanRecurrenceKernels.GlaBackward,
+            new[] { dOut, q, k, v, gate, traj, dQ, dK, dV, dG }, total, pc);
     }
 
     public void XLstmScanForward(

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
@@ -1228,9 +1228,15 @@ public sealed unsafe partial class VulkanBackend
         IGpuBuffer dQ, IGpuBuffer dK, IGpuBuffer dV, IGpuBuffer dG,
         int batch, int seqLen, int modelDim, int numHeads, int headDim)
     {
+        if (batch <= 0 || seqLen <= 0 || modelDim <= 0 || numHeads <= 0 || headDim <= 0)
+            throw new ArgumentOutOfRangeException(nameof(batch), "GLA dimensions must be positive.");
         int hh = headDim * headDim;
-        int total = batch * numHeads * headDim;
-        using var traj = AllocateBuffer(batch * numHeads * seqLen * hh);
+        long totalLong = checked((long)batch * numHeads * headDim);
+        long trajLenLong = checked((long)batch * numHeads * seqLen * hh);
+        if (totalLong > int.MaxValue || trajLenLong > int.MaxValue)
+            throw new ArgumentOutOfRangeException(nameof(batch), "GLA dimensions exceed Vulkan launch/buffer limits.");
+        int total = (int)totalLong;
+        using var traj = AllocateBuffer((int)trajLenLong);
         var pc = new[] { (uint)batch, (uint)seqLen, (uint)modelDim, (uint)numHeads, (uint)headDim };
         GlslNaryOp(VulkanRecurrenceKernels.GlaRecompute, new[] { k, v, gate, traj }, total, pc);
         GlslNaryOp(VulkanRecurrenceKernels.GlaBackward,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
@@ -1209,6 +1209,46 @@ public sealed unsafe partial class VulkanBackend
 
     #region RNN (LSTM/GRU) Operations
 
+    // ── Fused GLA (Gated Linear Attention) scan (#1464) ────────────────────────────────────
+    // Host fallback (mirrors this backend's LstmForwardSequence precedent); a native Vulkan
+    // GLSL compute shader is a follow-up. Correct + GPU-CPU bit-parity via the shared reference.
+    public void GlaScanForward(
+        IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer gate, IGpuBuffer output,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        EnsureInitialized();
+        var qd = DownloadBuffer(q);
+        var kd = DownloadBuffer(k);
+        var vd = DownloadBuffer(v);
+        var gd = DownloadBuffer(gate);
+        var outp = new float[batch * seqLen * modelDim];
+        Cpu.RecurrenceCpuKernels.GlaForward(qd, kd, vd, gd, outp, batch, seqLen, modelDim, numHeads, headDim);
+        UploadToBuffer(outp, output);
+    }
+
+    public void GlaScanBackward(
+        IGpuBuffer dOut, IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer gate,
+        IGpuBuffer dQ, IGpuBuffer dK, IGpuBuffer dV, IGpuBuffer dG,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        EnsureInitialized();
+        var doData = DownloadBuffer(dOut);
+        var qd = DownloadBuffer(q);
+        var kd = DownloadBuffer(k);
+        var vd = DownloadBuffer(v);
+        var gd = DownloadBuffer(gate);
+        var gq = new float[batch * seqLen * modelDim];
+        var gk = new float[batch * seqLen * modelDim];
+        var gv = new float[batch * seqLen * modelDim];
+        var gG = new float[batch * seqLen * numHeads];
+        Cpu.RecurrenceCpuKernels.GlaBackward(doData, qd, kd, vd, gd, gq, gk, gv, gG,
+            batch, seqLen, modelDim, numHeads, headDim);
+        UploadToBuffer(gq, dQ);
+        UploadToBuffer(gk, dK);
+        UploadToBuffer(gv, dV);
+        UploadToBuffer(gG, dG);
+    }
+
     public void LstmForwardSequence(
         IGpuBuffer input, IGpuBuffer hInit, IGpuBuffer cInit,
         IGpuBuffer weightsIh, IGpuBuffer weightsHh, IGpuBuffer biasIh, IGpuBuffer biasHh,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
@@ -1236,6 +1236,11 @@ public sealed unsafe partial class VulkanBackend
         if (totalLong > int.MaxValue || trajLenLong > int.MaxValue)
             throw new ArgumentOutOfRangeException(nameof(batch), "GLA dimensions exceed Vulkan launch/buffer limits.");
         int total = (int)totalLong;
+        // dQ/dK/dG are atomic accumulators in the backward kernel — zero them here so the
+        // method is self-contained and correct even if the caller reuses dirty buffers.
+        Fill(dQ, 0f, batch * seqLen * modelDim);
+        Fill(dK, 0f, batch * seqLen * modelDim);
+        Fill(dG, 0f, batch * seqLen * numHeads);
         using var traj = AllocateBuffer((int)trajLenLong);
         var pc = new[] { (uint)batch, (uint)seqLen, (uint)modelDim, (uint)numHeads, (uint)headDim };
         GlslNaryOp(VulkanRecurrenceKernels.GlaRecompute, new[] { k, v, gate, traj }, total, pc);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
@@ -1315,6 +1315,19 @@ public sealed unsafe partial class VulkanBackend
         UploadToBuffer(outp, output);
     }
 
+    // Fused Mamba-2 SSD scan forward (#1464) — host fallback via the shared reference.
+    public void Mamba2SsdScanForward(
+        IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,
+        IGpuBuffer output, int batch, int seqLen, int innerDim, int numHeads, int headDim, int stateDim)
+    {
+        EnsureInitialized();
+        var xd = DownloadBuffer(x); var dl = DownloadBuffer(delta); var al = DownloadBuffer(aLog);
+        var bp = DownloadBuffer(bParam); var cp = DownloadBuffer(cParam); var dp = DownloadBuffer(dParam);
+        var outp = new float[batch * seqLen * innerDim];
+        Cpu.RecurrenceCpuKernels.Mamba2SsdScanForward(xd, dl, al, bp, cp, dp, outp, batch, seqLen, innerDim, numHeads, headDim, stateDim);
+        UploadToBuffer(outp, output);
+    }
+
     public void LstmForwardSequence(
         IGpuBuffer input, IGpuBuffer hInit, IGpuBuffer cInit,
         IGpuBuffer weightsIh, IGpuBuffer weightsHh, IGpuBuffer biasIh, IGpuBuffer biasHh,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
@@ -1263,6 +1263,19 @@ public sealed unsafe partial class VulkanBackend
         UploadToBuffer(outp, output);
     }
 
+    // Fused Gated DeltaNet scan forward (#1464) — host fallback via the shared reference.
+    public void GatedDeltaNetScanForward(
+        IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer alpha, IGpuBuffer beta, IGpuBuffer output,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        EnsureInitialized();
+        var qd = DownloadBuffer(q); var kd = DownloadBuffer(k); var vd = DownloadBuffer(v);
+        var ad = DownloadBuffer(alpha); var bd = DownloadBuffer(beta);
+        var outp = new float[batch * seqLen * modelDim];
+        Cpu.RecurrenceCpuKernels.GatedDeltaNetForward(qd, kd, vd, ad, bd, outp, batch, seqLen, modelDim, numHeads, headDim);
+        UploadToBuffer(outp, output);
+    }
+
     public void LstmForwardSequence(
         IGpuBuffer input, IGpuBuffer hInit, IGpuBuffer cInit,
         IGpuBuffer weightsIh, IGpuBuffer weightsHh, IGpuBuffer biasIh, IGpuBuffer biasHh,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
@@ -1328,6 +1328,27 @@ public sealed unsafe partial class VulkanBackend
         UploadToBuffer(outp, output);
     }
 
+    // Fused linear + cross-entropy (#1464) — host fallback via the shared reference.
+    public float FusedLinearCrossEntropyIndex(
+        IGpuBuffer hidden, IGpuBuffer weight, IGpuBuffer bias, IGpuBuffer targetIds, int n, int d, int vocab)
+    {
+        EnsureInitialized();
+        var hd = DownloadBuffer(hidden); var wd = DownloadBuffer(weight); var bd = DownloadBuffer(bias);
+        var td = DownloadBuffer(targetIds);
+        var ids = new int[n];
+        for (int i = 0; i < n; i++) ids[i] = (int)(td[i] + 0.5f);
+        return Cpu.RecurrenceCpuKernels.FusedLinearCeIndex(hd, wd, bd, ids, n, d, vocab);
+    }
+
+    public float FusedLinearCrossEntropyDense(
+        IGpuBuffer hidden, IGpuBuffer weight, IGpuBuffer bias, IGpuBuffer target, int n, int d, int vocab)
+    {
+        EnsureInitialized();
+        var hd = DownloadBuffer(hidden); var wd = DownloadBuffer(weight); var bd = DownloadBuffer(bias);
+        var td = DownloadBuffer(target);
+        return Cpu.RecurrenceCpuKernels.FusedLinearCeDense(hd, wd, bd, td, n, d, vocab);
+    }
+
     public void LstmForwardSequence(
         IGpuBuffer input, IGpuBuffer hInit, IGpuBuffer cInit,
         IGpuBuffer weightsIh, IGpuBuffer weightsHh, IGpuBuffer biasIh, IGpuBuffer biasHh,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
@@ -1295,6 +1295,8 @@ public sealed unsafe partial class VulkanBackend
     private float FusedCeRowLoss(
         string glsl, IGpuBuffer hidden, IGpuBuffer weight, IGpuBuffer bias, IGpuBuffer tgt, int n, int d, int vocab)
     {
+        if (n <= 0 || d <= 0 || vocab <= 0)
+            throw new ArgumentOutOfRangeException(nameof(n), "Fused CE dimensions (n, d, vocab) must be positive.");
         using var rowLoss = AllocateBuffer(n);
         GlslNaryOp(glsl, new[] { hidden, weight, bias, tgt, rowLoss }, n,
             new[] { (uint)n, (uint)d, (uint)vocab });

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
@@ -1289,6 +1289,19 @@ public sealed unsafe partial class VulkanBackend
         UploadToBuffer(outp, output);
     }
 
+    // Fused RWKV-4 WKV scan forward (#1464) — host fallback via the shared reference.
+    public void Rwkv4WkvForward(
+        IGpuBuffer r, IGpuBuffer k, IGpuBuffer v, IGpuBuffer timeDecay, IGpuBuffer timeFirst, IGpuBuffer output,
+        int batch, int seqLen, int modelDim)
+    {
+        EnsureInitialized();
+        var rd = DownloadBuffer(r); var kd = DownloadBuffer(k); var vd = DownloadBuffer(v);
+        var td = DownloadBuffer(timeDecay); var fd = DownloadBuffer(timeFirst);
+        var outp = new float[batch * seqLen * modelDim];
+        Cpu.RecurrenceCpuKernels.Rwkv4WkvForward(rd, kd, vd, td, fd, outp, batch, seqLen, modelDim);
+        UploadToBuffer(outp, output);
+    }
+
     public void LstmForwardSequence(
         IGpuBuffer input, IGpuBuffer hInit, IGpuBuffer cInit,
         IGpuBuffer weightsIh, IGpuBuffer weightsHh, IGpuBuffer biasIh, IGpuBuffer biasHh,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
@@ -1276,6 +1276,19 @@ public sealed unsafe partial class VulkanBackend
         UploadToBuffer(outp, output);
     }
 
+    // Fused RG-LRU scan forward (#1464) — host fallback via the shared reference.
+    public void RgLruScanForward(
+        IGpuBuffer value, IGpuBuffer recGate, IGpuBuffer inpGate, IGpuBuffer decay, IGpuBuffer output,
+        int batch, int seqLen, int recDim)
+    {
+        EnsureInitialized();
+        var vd = DownloadBuffer(value); var rd = DownloadBuffer(recGate);
+        var id = DownloadBuffer(inpGate); var dd = DownloadBuffer(decay);
+        var outp = new float[batch * seqLen * recDim];
+        Cpu.RecurrenceCpuKernels.RgLruForward(vd, rd, id, dd, outp, batch, seqLen, recDim);
+        UploadToBuffer(outp, output);
+    }
+
     public void LstmForwardSequence(
         IGpuBuffer input, IGpuBuffer hInit, IGpuBuffer cInit,
         IGpuBuffer weightsIh, IGpuBuffer weightsHh, IGpuBuffer biasIh, IGpuBuffer biasHh,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
@@ -1209,144 +1209,93 @@ public sealed unsafe partial class VulkanBackend
 
     #region RNN (LSTM/GRU) Operations
 
-    // ── Fused GLA (Gated Linear Attention) scan (#1464) ────────────────────────────────────
-    // Host fallback (mirrors this backend's LstmForwardSequence precedent); a native Vulkan
-    // GLSL compute shader is a follow-up. Correct + GPU-CPU bit-parity via the shared reference.
+    // ── Fused recurrence / LM-head GPU kernels (#1464) ─────────────────────────────────────
+    // Real GLSL compute shaders (VulkanRecurrenceKernels), compiled to SPIR-V at runtime. Int
+    // params go through push constants. Forward only — the differentiable backward runs through
+    // the CpuEngine tape (the engine override is forward-only and defers to base under a tape).
+
     public void GlaScanForward(
         IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer gate, IGpuBuffer output,
         int batch, int seqLen, int modelDim, int numHeads, int headDim)
-    {
-        EnsureInitialized();
-        var qd = DownloadBuffer(q);
-        var kd = DownloadBuffer(k);
-        var vd = DownloadBuffer(v);
-        var gd = DownloadBuffer(gate);
-        var outp = new float[batch * seqLen * modelDim];
-        Cpu.RecurrenceCpuKernels.GlaForward(qd, kd, vd, gd, outp, batch, seqLen, modelDim, numHeads, headDim);
-        UploadToBuffer(outp, output);
-    }
+        => GlslNaryOp(VulkanRecurrenceKernels.GlaScan, new[] { q, k, v, gate, output },
+            batch * numHeads * headDim,
+            new[] { (uint)batch, (uint)seqLen, (uint)modelDim, (uint)numHeads, (uint)headDim });
 
+    // GLA BPTT backward is never invoked by the IEngine forward-only path; HIP/CUDA/OpenCL carry
+    // the real backward kernel. Kept on host (an atomics-based GLSL backward is a follow-up).
     public void GlaScanBackward(
         IGpuBuffer dOut, IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer gate,
         IGpuBuffer dQ, IGpuBuffer dK, IGpuBuffer dV, IGpuBuffer dG,
         int batch, int seqLen, int modelDim, int numHeads, int headDim)
     {
         EnsureInitialized();
-        var doData = DownloadBuffer(dOut);
-        var qd = DownloadBuffer(q);
-        var kd = DownloadBuffer(k);
-        var vd = DownloadBuffer(v);
-        var gd = DownloadBuffer(gate);
-        var gq = new float[batch * seqLen * modelDim];
-        var gk = new float[batch * seqLen * modelDim];
-        var gv = new float[batch * seqLen * modelDim];
-        var gG = new float[batch * seqLen * numHeads];
-        Cpu.RecurrenceCpuKernels.GlaBackward(doData, qd, kd, vd, gd, gq, gk, gv, gG,
-            batch, seqLen, modelDim, numHeads, headDim);
-        UploadToBuffer(gq, dQ);
-        UploadToBuffer(gk, dK);
-        UploadToBuffer(gv, dV);
-        UploadToBuffer(gG, dG);
+        var doData = DownloadBuffer(dOut); var qd = DownloadBuffer(q); var kd = DownloadBuffer(k);
+        var vd = DownloadBuffer(v); var gd = DownloadBuffer(gate);
+        var gq = new float[batch * seqLen * modelDim]; var gk = new float[batch * seqLen * modelDim];
+        var gv = new float[batch * seqLen * modelDim]; var gG = new float[batch * seqLen * numHeads];
+        Cpu.RecurrenceCpuKernels.GlaBackward(doData, qd, kd, vd, gd, gq, gk, gv, gG, batch, seqLen, modelDim, numHeads, headDim);
+        UploadToBuffer(gq, dQ); UploadToBuffer(gk, dK); UploadToBuffer(gv, dV); UploadToBuffer(gG, dG);
     }
 
-    // Fused xLSTM (mLSTM) scan forward (#1464) — host fallback via the shared reference.
     public void XLstmScanForward(
         IGpuBuffer q, IGpuBuffer k, IGpuBuffer v,
         IGpuBuffer iGate, IGpuBuffer fGate, IGpuBuffer oGate, IGpuBuffer output,
         int batch, int seqLen, int modelDim, int numHeads, int headDim)
-    {
-        EnsureInitialized();
-        var qd = DownloadBuffer(q); var kd = DownloadBuffer(k); var vd = DownloadBuffer(v);
-        var id = DownloadBuffer(iGate); var fd = DownloadBuffer(fGate); var od = DownloadBuffer(oGate);
-        var outp = new float[batch * seqLen * modelDim];
-        Cpu.RecurrenceCpuKernels.XLstmForward(qd, kd, vd, id, fd, od, outp, batch, seqLen, modelDim, numHeads, headDim);
-        UploadToBuffer(outp, output);
-    }
+        => GlslNaryOp(VulkanRecurrenceKernels.XLstmScan, new[] { q, k, v, iGate, fGate, oGate, output },
+            batch * numHeads,
+            new[] { (uint)batch, (uint)seqLen, (uint)modelDim, (uint)numHeads, (uint)headDim });
 
-    // Fused Gated DeltaNet scan forward (#1464) — host fallback via the shared reference.
     public void GatedDeltaNetScanForward(
         IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer alpha, IGpuBuffer beta, IGpuBuffer output,
         int batch, int seqLen, int modelDim, int numHeads, int headDim)
-    {
-        EnsureInitialized();
-        var qd = DownloadBuffer(q); var kd = DownloadBuffer(k); var vd = DownloadBuffer(v);
-        var ad = DownloadBuffer(alpha); var bd = DownloadBuffer(beta);
-        var outp = new float[batch * seqLen * modelDim];
-        Cpu.RecurrenceCpuKernels.GatedDeltaNetForward(qd, kd, vd, ad, bd, outp, batch, seqLen, modelDim, numHeads, headDim);
-        UploadToBuffer(outp, output);
-    }
+        => GlslNaryOp(VulkanRecurrenceKernels.GatedDeltaScan, new[] { q, k, v, alpha, beta, output },
+            batch * numHeads * headDim,
+            new[] { (uint)batch, (uint)seqLen, (uint)modelDim, (uint)numHeads, (uint)headDim });
 
-    // Fused RG-LRU scan forward (#1464) — host fallback via the shared reference.
     public void RgLruScanForward(
         IGpuBuffer value, IGpuBuffer recGate, IGpuBuffer inpGate, IGpuBuffer decay, IGpuBuffer output,
         int batch, int seqLen, int recDim)
-    {
-        EnsureInitialized();
-        var vd = DownloadBuffer(value); var rd = DownloadBuffer(recGate);
-        var id = DownloadBuffer(inpGate); var dd = DownloadBuffer(decay);
-        var outp = new float[batch * seqLen * recDim];
-        Cpu.RecurrenceCpuKernels.RgLruForward(vd, rd, id, dd, outp, batch, seqLen, recDim);
-        UploadToBuffer(outp, output);
-    }
+        => GlslNaryOp(VulkanRecurrenceKernels.RgLruScan, new[] { value, recGate, inpGate, decay, output },
+            batch * recDim, new[] { (uint)batch, (uint)seqLen, (uint)recDim });
 
-    // Fused RWKV-4 WKV scan forward (#1464) — host fallback via the shared reference.
     public void Rwkv4WkvForward(
         IGpuBuffer r, IGpuBuffer k, IGpuBuffer v, IGpuBuffer timeDecay, IGpuBuffer timeFirst, IGpuBuffer output,
         int batch, int seqLen, int modelDim)
-    {
-        EnsureInitialized();
-        var rd = DownloadBuffer(r); var kd = DownloadBuffer(k); var vd = DownloadBuffer(v);
-        var td = DownloadBuffer(timeDecay); var fd = DownloadBuffer(timeFirst);
-        var outp = new float[batch * seqLen * modelDim];
-        Cpu.RecurrenceCpuKernels.Rwkv4WkvForward(rd, kd, vd, td, fd, outp, batch, seqLen, modelDim);
-        UploadToBuffer(outp, output);
-    }
+        => GlslNaryOp(VulkanRecurrenceKernels.Rwkv4Wkv, new[] { r, k, v, timeDecay, timeFirst, output },
+            batch * modelDim, new[] { (uint)batch, (uint)seqLen, (uint)modelDim });
 
-    // Fused Mamba selective scan forward (#1464) — host fallback via the shared reference.
     public void MambaSelectiveScanForward(
         IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,
         IGpuBuffer output, int batch, int seqLen, int innerDim, int stateDim)
-    {
-        EnsureInitialized();
-        var xd = DownloadBuffer(x); var dl = DownloadBuffer(delta); var al = DownloadBuffer(aLog);
-        var bp = DownloadBuffer(bParam); var cp = DownloadBuffer(cParam); var dp = DownloadBuffer(dParam);
-        var outp = new float[batch * seqLen * innerDim];
-        Cpu.RecurrenceCpuKernels.MambaSelectiveScanForward(xd, dl, al, bp, cp, dp, outp, batch, seqLen, innerDim, stateDim);
-        UploadToBuffer(outp, output);
-    }
+        => GlslNaryOp(VulkanRecurrenceKernels.MambaScan, new[] { x, delta, aLog, bParam, cParam, dParam, output },
+            batch * innerDim, new[] { (uint)batch, (uint)seqLen, (uint)innerDim, (uint)stateDim });
 
-    // Fused Mamba-2 SSD scan forward (#1464) — host fallback via the shared reference.
     public void Mamba2SsdScanForward(
         IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,
         IGpuBuffer output, int batch, int seqLen, int innerDim, int numHeads, int headDim, int stateDim)
-    {
-        EnsureInitialized();
-        var xd = DownloadBuffer(x); var dl = DownloadBuffer(delta); var al = DownloadBuffer(aLog);
-        var bp = DownloadBuffer(bParam); var cp = DownloadBuffer(cParam); var dp = DownloadBuffer(dParam);
-        var outp = new float[batch * seqLen * innerDim];
-        Cpu.RecurrenceCpuKernels.Mamba2SsdScanForward(xd, dl, al, bp, cp, dp, outp, batch, seqLen, innerDim, numHeads, headDim, stateDim);
-        UploadToBuffer(outp, output);
-    }
+        => GlslNaryOp(VulkanRecurrenceKernels.Mamba2Ssd, new[] { x, delta, aLog, bParam, cParam, dParam, output },
+            batch * innerDim,
+            new[] { (uint)batch, (uint)seqLen, (uint)innerDim, (uint)numHeads, (uint)headDim, (uint)stateDim });
 
-    // Fused linear + cross-entropy (#1464) — host fallback via the shared reference.
     public float FusedLinearCrossEntropyIndex(
         IGpuBuffer hidden, IGpuBuffer weight, IGpuBuffer bias, IGpuBuffer targetIds, int n, int d, int vocab)
-    {
-        EnsureInitialized();
-        var hd = DownloadBuffer(hidden); var wd = DownloadBuffer(weight); var bd = DownloadBuffer(bias);
-        var td = DownloadBuffer(targetIds);
-        var ids = new int[n];
-        for (int i = 0; i < n; i++) ids[i] = (int)(td[i] + 0.5f);
-        return Cpu.RecurrenceCpuKernels.FusedLinearCeIndex(hd, wd, bd, ids, n, d, vocab);
-    }
+        => FusedCeRowLoss(VulkanRecurrenceKernels.FusedCeIndex, hidden, weight, bias, targetIds, n, d, vocab);
 
     public float FusedLinearCrossEntropyDense(
         IGpuBuffer hidden, IGpuBuffer weight, IGpuBuffer bias, IGpuBuffer target, int n, int d, int vocab)
+        => FusedCeRowLoss(VulkanRecurrenceKernels.FusedCeDense, hidden, weight, bias, target, n, d, vocab);
+
+    // CE kernels write a per-row loss vector; the host sums the N-element vector. Returns mean CE.
+    private float FusedCeRowLoss(
+        string glsl, IGpuBuffer hidden, IGpuBuffer weight, IGpuBuffer bias, IGpuBuffer tgt, int n, int d, int vocab)
     {
-        EnsureInitialized();
-        var hd = DownloadBuffer(hidden); var wd = DownloadBuffer(weight); var bd = DownloadBuffer(bias);
-        var td = DownloadBuffer(target);
-        return Cpu.RecurrenceCpuKernels.FusedLinearCeDense(hd, wd, bd, td, n, d, vocab);
+        using var rowLoss = AllocateBuffer(n);
+        GlslNaryOp(glsl, new[] { hidden, weight, bias, tgt, rowLoss }, n,
+            new[] { (uint)n, (uint)d, (uint)vocab });
+        var rl = DownloadBuffer(rowLoss);
+        double sum = 0.0;
+        for (int i = 0; i < n; i++) sum += rl[i];
+        return (float)(sum / n);
     }
 
     public void LstmForwardSequence(

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.cs
@@ -339,6 +339,28 @@ public sealed unsafe partial class VulkanBackend : IDirectGpuBackend, IGpuBatchE
     }
 
     /// <summary>
+    /// Executes a GLSL-compiled compute pipeline with N buffers + push constants (#1464 recurrence ops).
+    /// Buffers bind to set=0, binding=0..N-1 in order; pushConstants are the kernel's int params as uints.
+    /// </summary>
+    private void GlslNaryOp(string glslSource, IGpuBuffer[] buffers, int dispatchSize, uint[] pushConstants)
+    {
+        EnsureInitialized();
+        if (dispatchSize <= 0) return;
+        uint pushConstantSize = (uint)(pushConstants.Length * sizeof(uint));
+        var pipeline = GetOrCreateGlslPipeline(glslSource, buffers.Length, pushConstantSize);
+        if (pipeline is null)
+            throw new InvalidOperationException("Failed to create GLSL recurrence pipeline.");
+        var storages = new VulkanBuffer[buffers.Length];
+        for (int i = 0; i < buffers.Length; i++) storages[i] = AsVulkan(buffers[i]).Storage;
+        var threadRes = _device.AcquireThreadResources();
+        lock (_computeLock)
+        {
+            pipeline.UpdateDescriptorSet(storages);
+            RecordAndExecuteWithPushData(pipeline, dispatchSize, pushConstants, pushConstantSize, threadRes);
+        }
+    }
+
+    /// <summary>
     /// Executes a GLSL-compiled compute pipeline with 1 buffer (output only) + push constants.
     /// Used for generate ops like Eye, Linspace, TriangularMask.
     /// </summary>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanRecurrenceKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanRecurrenceKernels.cs
@@ -1,0 +1,237 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Vulkan GLSL compute shaders for the fused recurrence / LM-head ops (#1464), compiled to SPIR-V
+// at runtime (libshaderc). Real GPU kernels — mirror the HIP/CUDA/OpenCL/MSL kernels and the
+// CpuEngine math exactly. Int params are passed as push constants. Forward only — the
+// differentiable backward runs through the CpuEngine tape (engine override is forward-only).
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.Vulkan;
+
+internal static class VulkanRecurrenceKernels
+{
+    private const string Header = @"#version 450
+layout(local_size_x = 256) in;
+";
+
+    public static string GlaScan => Header + @"
+layout(set=0,binding=0) readonly buffer Qb { float Q[]; };
+layout(set=0,binding=1) readonly buffer Kb { float K[]; };
+layout(set=0,binding=2) readonly buffer Vb { float Vd[]; };
+layout(set=0,binding=3) readonly buffer Gb { float G[]; };
+layout(set=0,binding=4) writeonly buffer Ob { float outp[]; };
+layout(push_constant) uniform PC { uint batch; uint seqLen; uint modelDim; uint numHeads; uint headDim; };
+void main() {
+    int gid = int(gl_GlobalInvocationID.x);
+    int B=int(batch), SL=int(seqLen), MD=int(modelDim), NH=int(numHeads), HD=int(headDim);
+    if (gid >= B*NH*HD) return;
+    int di = gid % HD; int h = (gid / HD) % NH; int b = gid / (HD*NH); int hOff = h*HD;
+    float Srow[256];
+    for (int ki=0; ki<HD; ki++) Srow[ki]=0.0;
+    for (int t=0; t<SL; t++) {
+        int baseOff = (b*SL+t)*MD + hOff;
+        float g = G[(b*SL+t)*NH + h];
+        float vd = Vd[baseOff+di];
+        float o = 0.0;
+        for (int ki=0; ki<HD; ki++) { float s=g*Srow[ki]+vd*K[baseOff+ki]; Srow[ki]=s; o+=s*Q[baseOff+ki]; }
+        outp[baseOff+di] = o;
+    }
+}";
+
+    public static string XLstmScan => Header + @"
+layout(set=0,binding=0) readonly buffer Qb { float Q[]; };
+layout(set=0,binding=1) readonly buffer Kb { float K[]; };
+layout(set=0,binding=2) readonly buffer Vb { float Vd[]; };
+layout(set=0,binding=3) readonly buffer Ib { float Ig[]; };
+layout(set=0,binding=4) readonly buffer Fb { float Fg[]; };
+layout(set=0,binding=5) readonly buffer Ob2 { float Og[]; };
+layout(set=0,binding=6) writeonly buffer Ob { float outp[]; };
+layout(push_constant) uniform PC { uint batch; uint seqLen; uint modelDim; uint numHeads; uint headDim; };
+void main() {
+    int gid = int(gl_GlobalInvocationID.x);
+    int B=int(batch), SL=int(seqLen), MD=int(modelDim), NH=int(numHeads), HD=int(headDim);
+    if (gid >= B*NH) return;
+    int h = gid % NH; int b = gid / NH; int hOff = h*HD; int hh = HD*HD;
+    float kappa = 1.0/sqrt(float(HD));
+    float C[4096]; float n[64];
+    for (int i=0;i<hh;i++) C[i]=0.0;
+    for (int i=0;i<HD;i++) n[i]=0.0;
+    for (int t=0;t<SL;t++) {
+        int baseOff=(b*SL+t)*MD+hOff; int gOff=(b*SL+t)*NH+h;
+        float iv=Ig[gOff]; if (iv>4.85e8) iv=4.85e8;
+        float f=Fg[gOff], o=Og[gOff];
+        for (int di=0;di<HD;di++) {
+            n[di]=f*n[di]+iv*(K[baseOff+di]*kappa);
+            float vv=Vd[baseOff+di]; int srow=di*HD;
+            for (int ki=0;ki<HD;ki++) C[srow+ki]=f*C[srow+ki]+iv*vv*(K[baseOff+ki]*kappa);
+        }
+        float nq=0.0; for (int j=0;j<HD;j++) nq+=n[j]*Q[baseOff+j];
+        float nf=abs(nq); if (nf<1.0) nf=1.0;
+        for (int di=0;di<HD;di++) {
+            int srow=di*HD; float num=0.0;
+            for (int ki=0;ki<HD;ki++) num+=C[srow+ki]*Q[baseOff+ki];
+            outp[baseOff+di]=o*num/nf;
+        }
+    }
+}";
+
+    public static string GatedDeltaScan => Header + @"
+layout(set=0,binding=0) readonly buffer Qb { float Q[]; };
+layout(set=0,binding=1) readonly buffer Kb { float K[]; };
+layout(set=0,binding=2) readonly buffer Vb { float Vd[]; };
+layout(set=0,binding=3) readonly buffer Ab { float A[]; };
+layout(set=0,binding=4) readonly buffer Bb { float Bt[]; };
+layout(set=0,binding=5) writeonly buffer Ob { float outp[]; };
+layout(push_constant) uniform PC { uint batch; uint seqLen; uint modelDim; uint numHeads; uint headDim; };
+void main() {
+    int gid = int(gl_GlobalInvocationID.x);
+    int B=int(batch), SL=int(seqLen), MD=int(modelDim), NH=int(numHeads), HD=int(headDim);
+    if (gid >= B*NH*HD) return;
+    int di = gid % HD; int h = (gid / HD) % NH; int b = gid / (HD*NH); int hOff = h*HD;
+    float kappa = 1.0/sqrt(float(HD));
+    float Srow[256];
+    for (int ki=0;ki<HD;ki++) Srow[ki]=0.0;
+    for (int t=0;t<SL;t++) {
+        int baseOff=(b*SL+t)*MD+hOff; int gIdx=(b*SL+t)*NH+h;
+        float a=A[gIdx], bet=Bt[gIdx];
+        float sK=0.0; for (int ki=0;ki<HD;ki++) sK+=Srow[ki]*(K[baseOff+ki]*kappa);
+        float bd=bet*(Vd[baseOff+di]-sK);
+        for (int ki=0;ki<HD;ki++) Srow[ki]=a*Srow[ki]+bd*(K[baseOff+ki]*kappa);
+        float o=0.0; for (int ki=0;ki<HD;ki++) o+=Srow[ki]*Q[baseOff+ki];
+        outp[baseOff+di]=o;
+    }
+}";
+
+    public static string RgLruScan => Header + @"
+layout(set=0,binding=0) readonly buffer Vb { float Vd[]; };
+layout(set=0,binding=1) readonly buffer Rb { float R[]; };
+layout(set=0,binding=2) readonly buffer Ib { float Ig[]; };
+layout(set=0,binding=3) readonly buffer Db { float decayb[]; };
+layout(set=0,binding=4) writeonly buffer Ob { float outp[]; };
+layout(push_constant) uniform PC { uint batch; uint seqLen; uint recDim; };
+void main() {
+    int gid = int(gl_GlobalInvocationID.x);
+    int B=int(batch), SL=int(seqLen), RD=int(recDim);
+    if (gid >= B*RD) return;
+    int c = gid % RD; int b = gid / RD;
+    float base = 1.0/(1.0+exp(decayb[c]));
+    float h = 0.0;
+    for (int t=0;t<SL;t++) {
+        int off=(b*SL+t)*RD+c;
+        float a=R[off]*base; float om=1.0-a*a; float s = om>0.0 ? sqrt(om) : 0.0;
+        h = a*h + s*(Ig[off]*Vd[off]); outp[off]=h;
+    }
+}";
+
+    public static string Rwkv4Wkv => Header + @"
+layout(set=0,binding=0) readonly buffer Rb { float R[]; };
+layout(set=0,binding=1) readonly buffer Kb { float K[]; };
+layout(set=0,binding=2) readonly buffer Vb { float Vd[]; };
+layout(set=0,binding=3) readonly buffer Tdb { float timeDecay[]; };
+layout(set=0,binding=4) readonly buffer Tfb { float timeFirst[]; };
+layout(set=0,binding=5) writeonly buffer Ob { float outp[]; };
+layout(push_constant) uniform PC { uint batch; uint seqLen; uint modelDim; };
+void main() {
+    int gid = int(gl_GlobalInvocationID.x);
+    int B=int(batch), SL=int(seqLen), MD=int(modelDim);
+    if (gid >= B*MD) return;
+    int c = gid % MD; int b = gid / MD;
+    float w = -exp(timeDecay[c]); float u = timeFirst[c];
+    float aa=0.0, bb=0.0, pp=-1.0e38;
+    for (int t=0;t<SL;t++) {
+        int off=(b*SL+t)*MD+c; float k=K[off]; float v=Vd[off];
+        float ww=u+k; float q=max(pp,ww); float e1=exp(pp-q); float e2=exp(ww-q);
+        float wkv=(e1*aa+e2*v)/(e1*bb+e2);
+        outp[off]=(1.0/(1.0+exp(-R[off])))*wkv;
+        float ww2=pp+w; float q2=max(ww2,k); float e1b=exp(ww2-q2); float e2b=exp(k-q2);
+        aa=e1b*aa+e2b*v; bb=e1b*bb+e2b; pp=q2;
+    }
+}";
+
+    public static string MambaScan => Header + @"
+layout(set=0,binding=0) readonly buffer Xb { float X[]; };
+layout(set=0,binding=1) readonly buffer Dtb { float delta[]; };
+layout(set=0,binding=2) readonly buffer Alb { float aLog[]; };
+layout(set=0,binding=3) readonly buffer Bb { float Bt[]; };
+layout(set=0,binding=4) readonly buffer Cb { float Ct[]; };
+layout(set=0,binding=5) readonly buffer Db { float Dt[]; };
+layout(set=0,binding=6) writeonly buffer Ob { float outp[]; };
+layout(push_constant) uniform PC { uint batch; uint seqLen; uint innerDim; uint stateDim; };
+void main() {
+    int gid = int(gl_GlobalInvocationID.x);
+    int B=int(batch), SL=int(seqLen), ID=int(innerDim), SD=int(stateDim);
+    if (gid >= B*ID) return;
+    int di = gid % ID; int b = gid / ID; int hrow = di*SD;
+    float negA[256]; float h[256];
+    for (int n=0;n<SD;n++) { negA[n]=-exp(aLog[hrow+n]); h[n]=0.0; }
+    for (int t=0;t<SL;t++) {
+        int baseID=(b*SL+t)*ID; int baseSD=(b*SL+t)*SD;
+        float dt=delta[baseID+di]; float xv=X[baseID+di]; float y=0.0;
+        for (int n=0;n<SD;n++) { float aBar=exp(dt*negA[n]); float hv=aBar*h[n]+dt*Bt[baseSD+n]*xv; h[n]=hv; y+=Ct[baseSD+n]*hv; }
+        outp[baseID+di]=y+Dt[di]*xv;
+    }
+}";
+
+    public static string Mamba2Ssd => Header + @"
+layout(set=0,binding=0) readonly buffer Xb { float X[]; };
+layout(set=0,binding=1) readonly buffer Dtb { float delta[]; };
+layout(set=0,binding=2) readonly buffer Alb { float aLog[]; };
+layout(set=0,binding=3) readonly buffer Bb { float Bt[]; };
+layout(set=0,binding=4) readonly buffer Cb { float Ct[]; };
+layout(set=0,binding=5) readonly buffer Db { float Dt[]; };
+layout(set=0,binding=6) writeonly buffer Ob { float outp[]; };
+layout(push_constant) uniform PC { uint batch; uint seqLen; uint innerDim; uint numHeads; uint headDim; uint sd; };
+void main() {
+    int gid = int(gl_GlobalInvocationID.x);
+    int B=int(batch), SL=int(seqLen), ID=int(innerDim), NH=int(numHeads), HD=int(headDim), SD=int(sd);
+    if (gid >= B*ID) return;
+    int flatD = gid % ID; int b = gid / ID; int hi = flatD / HD;
+    float negA=-exp(aLog[hi]); float dv=Dt[hi];
+    float h[256];
+    for (int n=0;n<SD;n++) h[n]=0.0;
+    for (int t=0;t<SL;t++) {
+        int btInner=(b*SL+t)*ID; int btState=(b*SL+t)*SD; int btHead=(b*SL+t)*NH;
+        float dt=delta[btHead+hi]; float aBar=exp(dt*negA); float xv=X[btInner+flatD]; float y=0.0;
+        for (int n=0;n<SD;n++) { float hNew=aBar*h[n]+dt*Bt[btState+n]*xv; h[n]=hNew; y+=Ct[btState+n]*hNew; }
+        outp[btInner+flatD]=y+dv*xv;
+    }
+}";
+
+    public static string FusedCeIndex => Header + @"
+layout(set=0,binding=0) readonly buffer Hb { float hidden[]; };
+layout(set=0,binding=1) readonly buffer Wb { float weight[]; };
+layout(set=0,binding=2) readonly buffer Bb { float bias[]; };
+layout(set=0,binding=3) readonly buffer Tb { float targetIds[]; };
+layout(set=0,binding=4) writeonly buffer Lb { float rowLoss[]; };
+layout(push_constant) uniform PC { uint N; uint d; uint vocab; };
+void main() {
+    int r = int(gl_GlobalInvocationID.x);
+    int NN=int(N), D=int(d), VC=int(vocab);
+    if (r >= NN) return;
+    int hRow=r*D; int id=int(targetIds[r]+0.5);
+    float mx=-1.0e38, logitTarget=0.0;
+    for (int vv=0;vv<VC;vv++) { float s=bias[vv]; for (int j=0;j<D;j++) s+=hidden[hRow+j]*weight[j*VC+vv]; if (s>mx) mx=s; if (vv==id) logitTarget=s; }
+    float sumExp=0.0;
+    for (int vv=0;vv<VC;vv++) { float s=bias[vv]; for (int j=0;j<D;j++) s+=hidden[hRow+j]*weight[j*VC+vv]; sumExp+=exp(s-mx); }
+    rowLoss[r]=(mx+log(sumExp))-logitTarget;
+}";
+
+    public static string FusedCeDense => Header + @"
+layout(set=0,binding=0) readonly buffer Hb { float hidden[]; };
+layout(set=0,binding=1) readonly buffer Wb { float weight[]; };
+layout(set=0,binding=2) readonly buffer Bb { float bias[]; };
+layout(set=0,binding=3) readonly buffer Tb { float target[]; };
+layout(set=0,binding=4) writeonly buffer Lb { float rowLoss[]; };
+layout(push_constant) uniform PC { uint N; uint d; uint vocab; };
+void main() {
+    int r = int(gl_GlobalInvocationID.x);
+    int NN=int(N), D=int(d), VC=int(vocab);
+    if (r >= NN) return;
+    int hRow=r*D; int tRow=r*VC;
+    float mx=-1.0e38;
+    for (int vv=0;vv<VC;vv++) { float s=bias[vv]; for (int j=0;j<D;j++) s+=hidden[hRow+j]*weight[j*VC+vv]; if (s>mx) mx=s; }
+    float sumExp=0.0;
+    for (int vv=0;vv<VC;vv++) { float s=bias[vv]; for (int j=0;j<D;j++) s+=hidden[hRow+j]*weight[j*VC+vv]; sumExp+=exp(s-mx); }
+    float lse=mx+log(sumExp); float rl=0.0;
+    for (int vv=0;vv<VC;vv++) { float s=bias[vv]; for (int j=0;j<D;j++) s+=hidden[hRow+j]*weight[j*VC+vv]; rl+=target[tRow+vv]*(s-lse); }
+    rowLoss[r]=-rl;
+}";
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanRecurrenceKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanRecurrenceKernels.cs
@@ -234,4 +234,64 @@ void main() {
     for (int vv=0;vv<VC;vv++) { float s=bias[vv]; for (int j=0;j<D;j++) s+=hidden[hRow+j]*weight[j*VC+vv]; rl+=target[tRow+vv]*(s-lse); }
     rowLoss[r]=-rl;
 }";
+
+    // GLA BPTT backward: recompute the state trajectory, then reverse-sweep. dQ/dK/dG are bound as
+    // uint SSBOs and accumulated via a CAS float-atomic add (GLSL has no portable float atomicAdd);
+    // dV is a plain per-thread store. dQ/dK/dG must be pre-zeroed.
+    public static string GlaRecompute => Header + @"
+layout(set=0,binding=0) readonly buffer Kb { float K[]; };
+layout(set=0,binding=1) readonly buffer Vb { float Vd[]; };
+layout(set=0,binding=2) readonly buffer Gb { float G[]; };
+layout(set=0,binding=3) buffer Sb { float Straj[]; };
+layout(push_constant) uniform PC { uint batch; uint seqLen; uint modelDim; uint numHeads; uint headDim; };
+void main() {
+    int gid = int(gl_GlobalInvocationID.x);
+    int B=int(batch), SL=int(seqLen), MD=int(modelDim), NH=int(numHeads), HD=int(headDim);
+    if (gid >= B*NH*HD) return;
+    int di = gid % HD; int h = (gid/HD) % NH; int b = gid/(HD*NH); int hOff = h*HD; int hh = HD*HD;
+    float Srow[256];
+    for (int ki=0; ki<HD; ki++) Srow[ki]=0.0;
+    for (int t=0; t<SL; t++) {
+        int baseOff = (b*SL+t)*MD + hOff;
+        float g = G[(b*SL+t)*NH + h]; float vd = Vd[baseOff+di];
+        int trajBase = ((b*NH+h)*SL+t)*hh + di*HD;
+        for (int ki=0; ki<HD; ki++) { float s=g*Srow[ki]+vd*K[baseOff+ki]; Srow[ki]=s; Straj[trajBase+ki]=s; }
+    }
+}";
+
+    public static string GlaBackward => Header + @"
+layout(set=0,binding=0) readonly buffer DOb { float dOut[]; };
+layout(set=0,binding=1) readonly buffer Qb { float Q[]; };
+layout(set=0,binding=2) readonly buffer Kb { float K[]; };
+layout(set=0,binding=3) readonly buffer Vb { float Vd[]; };
+layout(set=0,binding=4) readonly buffer Gb { float G[]; };
+layout(set=0,binding=5) readonly buffer Sb { float Straj[]; };
+layout(set=0,binding=6) buffer DQb { uint dQ[]; };
+layout(set=0,binding=7) buffer DKb { uint dK[]; };
+layout(set=0,binding=8) buffer DVb { float dV[]; };
+layout(set=0,binding=9) buffer DGb { uint dG[]; };
+layout(push_constant) uniform PC { uint batch; uint seqLen; uint modelDim; uint numHeads; uint headDim; };
+void addDQ(int idx, float val){ uint old=dQ[idx]; uint assumed; do { assumed=old; old=atomicCompSwap(dQ[idx], assumed, floatBitsToUint(uintBitsToFloat(assumed)+val)); } while(old!=assumed); }
+void addDK(int idx, float val){ uint old=dK[idx]; uint assumed; do { assumed=old; old=atomicCompSwap(dK[idx], assumed, floatBitsToUint(uintBitsToFloat(assumed)+val)); } while(old!=assumed); }
+void addDG(int idx, float val){ uint old=dG[idx]; uint assumed; do { assumed=old; old=atomicCompSwap(dG[idx], assumed, floatBitsToUint(uintBitsToFloat(assumed)+val)); } while(old!=assumed); }
+void main() {
+    int gid = int(gl_GlobalInvocationID.x);
+    int B=int(batch), SL=int(seqLen), MD=int(modelDim), NH=int(numHeads), HD=int(headDim);
+    if (gid >= B*NH*HD) return;
+    int di = gid % HD; int h = (gid/HD) % NH; int b = gid/(HD*NH); int hOff = h*HD; int hh = HD*HD;
+    float dSrow[256];
+    for (int ki=0; ki<HD; ki++) dSrow[ki]=0.0;
+    for (int t=SL-1; t>=0; t--) {
+        int baseOff = (b*SL+t)*MD + hOff; int gOff = (b*SL+t)*NH + h; float g = G[gOff];
+        int trajBase = ((b*NH+h)*SL+t)*hh + di*HD;
+        int sprevBase = ((b*NH+h)*SL+(t-1))*hh + di*HD;
+        float dOutVal = dOut[baseOff+di];
+        for (int ki=0; ki<HD; ki++) { float sval=Straj[trajBase+ki]; addDQ(baseOff+ki, dOutVal*sval); dSrow[ki]+=dOutVal*Q[baseOff+ki]; }
+        float vd = Vd[baseOff+di]; float dg=0.0; float dVacc=0.0;
+        for (int ki=0; ki<HD; ki++) { float dStv=dSrow[ki]; float sprev = (t>0) ? Straj[sprevBase+ki] : 0.0; dg+=dStv*sprev; addDK(baseOff+ki, dStv*vd); dVacc+=dStv*K[baseOff+ki]; }
+        dV[baseOff+di] = dVacc;
+        addDG(gOff, dg);
+        for (int ki=0; ki<HD; ki++) dSrow[ki]*=g;
+    }
+}";
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
@@ -864,6 +864,18 @@ public sealed partial class WebGpuBackend
         UploadToBuffer(outp, output);
     }
 
+    // Fused RWKV-4 WKV scan forward (#1464) — host fallback via the shared reference.
+    public void Rwkv4WkvForward(
+        IGpuBuffer r, IGpuBuffer k, IGpuBuffer v, IGpuBuffer timeDecay, IGpuBuffer timeFirst, IGpuBuffer output,
+        int batch, int seqLen, int modelDim)
+    {
+        var rd = DownloadBuffer(r); var kd = DownloadBuffer(k); var vd = DownloadBuffer(v);
+        var td = DownloadBuffer(timeDecay); var fd = DownloadBuffer(timeFirst);
+        var outp = new float[batch * seqLen * modelDim];
+        Cpu.RecurrenceCpuKernels.Rwkv4WkvForward(rd, kd, vd, td, fd, outp, batch, seqLen, modelDim);
+        UploadToBuffer(outp, output);
+    }
+
     public void LstmForwardSequence(
         IGpuBuffer input, IGpuBuffer hInit, IGpuBuffer cInit,
         IGpuBuffer weightsIh, IGpuBuffer weightsHh, IGpuBuffer biasIh, IGpuBuffer biasHh,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
@@ -822,9 +822,15 @@ public sealed partial class WebGpuBackend
         IGpuBuffer dQ, IGpuBuffer dK, IGpuBuffer dV, IGpuBuffer dG,
         int batch, int seqLen, int modelDim, int numHeads, int headDim)
     {
+        if (batch <= 0 || seqLen <= 0 || modelDim <= 0 || numHeads <= 0 || headDim <= 0)
+            throw new ArgumentOutOfRangeException(nameof(batch), "GLA dimensions must be positive.");
         int hh = headDim * headDim;
-        int total = batch * numHeads * headDim;
-        using var traj = AllocateBuffer(batch * numHeads * seqLen * hh);
+        long totalLong = checked((long)batch * numHeads * headDim);
+        long trajLenLong = checked((long)batch * numHeads * seqLen * hh);
+        if (totalLong > int.MaxValue || trajLenLong > int.MaxValue)
+            throw new ArgumentOutOfRangeException(nameof(batch), "GLA dimensions exceed WebGPU launch/buffer limits.");
+        int total = (int)totalLong;
+        using var traj = AllocateBuffer((int)trajLenLong);
         var pc = new[] { batch, seqLen, modelDim, numHeads, headDim };
         DispatchRecurrence("gla_recompute", WebGpuRecurrenceKernels.GlaRecompute, total,
             new[] { k, v, gate, traj }, pc);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
@@ -827,6 +827,19 @@ public sealed partial class WebGpuBackend
         UploadToBuffer(gG, dG);
     }
 
+    // Fused xLSTM (mLSTM) scan forward (#1464) — host fallback via the shared reference.
+    public void XLstmScanForward(
+        IGpuBuffer q, IGpuBuffer k, IGpuBuffer v,
+        IGpuBuffer iGate, IGpuBuffer fGate, IGpuBuffer oGate, IGpuBuffer output,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        var qd = DownloadBuffer(q); var kd = DownloadBuffer(k); var vd = DownloadBuffer(v);
+        var id = DownloadBuffer(iGate); var fd = DownloadBuffer(fGate); var od = DownloadBuffer(oGate);
+        var outp = new float[batch * seqLen * modelDim];
+        Cpu.RecurrenceCpuKernels.XLstmForward(qd, kd, vd, id, fd, od, outp, batch, seqLen, modelDim, numHeads, headDim);
+        UploadToBuffer(outp, output);
+    }
+
     public void LstmForwardSequence(
         IGpuBuffer input, IGpuBuffer hInit, IGpuBuffer cInit,
         IGpuBuffer weightsIh, IGpuBuffer weightsHh, IGpuBuffer biasIh, IGpuBuffer biasHh,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
@@ -852,6 +852,18 @@ public sealed partial class WebGpuBackend
         UploadToBuffer(outp, output);
     }
 
+    // Fused RG-LRU scan forward (#1464) — host fallback via the shared reference.
+    public void RgLruScanForward(
+        IGpuBuffer value, IGpuBuffer recGate, IGpuBuffer inpGate, IGpuBuffer decay, IGpuBuffer output,
+        int batch, int seqLen, int recDim)
+    {
+        var vd = DownloadBuffer(value); var rd = DownloadBuffer(recGate);
+        var id = DownloadBuffer(inpGate); var dd = DownloadBuffer(decay);
+        var outp = new float[batch * seqLen * recDim];
+        Cpu.RecurrenceCpuKernels.RgLruForward(vd, rd, id, dd, outp, batch, seqLen, recDim);
+        UploadToBuffer(outp, output);
+    }
+
     public void LstmForwardSequence(
         IGpuBuffer input, IGpuBuffer hInit, IGpuBuffer cInit,
         IGpuBuffer weightsIh, IGpuBuffer weightsHh, IGpuBuffer biasIh, IGpuBuffer biasHh,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
@@ -789,6 +789,44 @@ public sealed partial class WebGpuBackend
 
     #region RNN Operations
 
+    // ── Fused GLA (Gated Linear Attention) scan (#1464) ────────────────────────────────────
+    // Host fallback (mirrors this backend's sequence-op precedent); a native WGSL compute
+    // shader is a follow-up. Correct + GPU-CPU bit-parity via the shared reference.
+    public void GlaScanForward(
+        IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer gate, IGpuBuffer output,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        var qd = DownloadBuffer(q);
+        var kd = DownloadBuffer(k);
+        var vd = DownloadBuffer(v);
+        var gd = DownloadBuffer(gate);
+        var outp = new float[batch * seqLen * modelDim];
+        Cpu.RecurrenceCpuKernels.GlaForward(qd, kd, vd, gd, outp, batch, seqLen, modelDim, numHeads, headDim);
+        UploadToBuffer(outp, output);
+    }
+
+    public void GlaScanBackward(
+        IGpuBuffer dOut, IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer gate,
+        IGpuBuffer dQ, IGpuBuffer dK, IGpuBuffer dV, IGpuBuffer dG,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        var doData = DownloadBuffer(dOut);
+        var qd = DownloadBuffer(q);
+        var kd = DownloadBuffer(k);
+        var vd = DownloadBuffer(v);
+        var gd = DownloadBuffer(gate);
+        var gq = new float[batch * seqLen * modelDim];
+        var gk = new float[batch * seqLen * modelDim];
+        var gv = new float[batch * seqLen * modelDim];
+        var gG = new float[batch * seqLen * numHeads];
+        Cpu.RecurrenceCpuKernels.GlaBackward(doData, qd, kd, vd, gd, gq, gk, gv, gG,
+            batch, seqLen, modelDim, numHeads, headDim);
+        UploadToBuffer(gq, dQ);
+        UploadToBuffer(gk, dK);
+        UploadToBuffer(gv, dV);
+        UploadToBuffer(gG, dG);
+    }
+
     public void LstmForwardSequence(
         IGpuBuffer input, IGpuBuffer hInit, IGpuBuffer cInit,
         IGpuBuffer weightsIh, IGpuBuffer weightsHh, IGpuBuffer biasIh, IGpuBuffer biasHh,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
@@ -840,6 +840,18 @@ public sealed partial class WebGpuBackend
         UploadToBuffer(outp, output);
     }
 
+    // Fused Gated DeltaNet scan forward (#1464) — host fallback via the shared reference.
+    public void GatedDeltaNetScanForward(
+        IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer alpha, IGpuBuffer beta, IGpuBuffer output,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+    {
+        var qd = DownloadBuffer(q); var kd = DownloadBuffer(k); var vd = DownloadBuffer(v);
+        var ad = DownloadBuffer(alpha); var bd = DownloadBuffer(beta);
+        var outp = new float[batch * seqLen * modelDim];
+        Cpu.RecurrenceCpuKernels.GatedDeltaNetForward(qd, kd, vd, ad, bd, outp, batch, seqLen, modelDim, numHeads, headDim);
+        UploadToBuffer(outp, output);
+    }
+
     public void LstmForwardSequence(
         IGpuBuffer input, IGpuBuffer hInit, IGpuBuffer cInit,
         IGpuBuffer weightsIh, IGpuBuffer weightsHh, IGpuBuffer biasIh, IGpuBuffer biasHh,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
@@ -815,19 +815,21 @@ public sealed partial class WebGpuBackend
         => DispatchRecurrence("gla", WebGpuRecurrenceKernels.GlaScan, batch * numHeads * headDim,
             new[] { q, k, v, gate, output }, new[] { batch, seqLen, modelDim, numHeads, headDim });
 
-    // GLA BPTT backward is never invoked by the IEngine forward-only path; HIP/CUDA/OpenCL carry the
-    // real backward kernel. Kept on host (an atomics-based WGSL backward is a follow-up).
+    // GLA BPTT backward — real WGSL kernels (recompute trajectory + reverse sweep with bitcast-CAS
+    // u32 float atomics for the cross-row dQ/dK/dG). dQ/dK/dG must be pre-zeroed (the accumulators).
     public void GlaScanBackward(
         IGpuBuffer dOut, IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer gate,
         IGpuBuffer dQ, IGpuBuffer dK, IGpuBuffer dV, IGpuBuffer dG,
         int batch, int seqLen, int modelDim, int numHeads, int headDim)
     {
-        var doData = DownloadBuffer(dOut); var qd = DownloadBuffer(q); var kd = DownloadBuffer(k);
-        var vd = DownloadBuffer(v); var gd = DownloadBuffer(gate);
-        var gq = new float[batch * seqLen * modelDim]; var gk = new float[batch * seqLen * modelDim];
-        var gv = new float[batch * seqLen * modelDim]; var gG = new float[batch * seqLen * numHeads];
-        Cpu.RecurrenceCpuKernels.GlaBackward(doData, qd, kd, vd, gd, gq, gk, gv, gG, batch, seqLen, modelDim, numHeads, headDim);
-        UploadToBuffer(gq, dQ); UploadToBuffer(gk, dK); UploadToBuffer(gv, dV); UploadToBuffer(gG, dG);
+        int hh = headDim * headDim;
+        int total = batch * numHeads * headDim;
+        using var traj = AllocateBuffer(batch * numHeads * seqLen * hh);
+        var pc = new[] { batch, seqLen, modelDim, numHeads, headDim };
+        DispatchRecurrence("gla_recompute", WebGpuRecurrenceKernels.GlaRecompute, total,
+            new[] { k, v, gate, traj }, pc);
+        DispatchRecurrence("gla_backward", WebGpuRecurrenceKernels.GlaBackward, total,
+            new[] { dOut, q, k, v, gate, traj, dQ, dK, dV, dG }, pc);
     }
 
     public void XLstmScanForward(

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
@@ -789,134 +789,103 @@ public sealed partial class WebGpuBackend
 
     #region RNN Operations
 
-    // ── Fused GLA (Gated Linear Attention) scan (#1464) ────────────────────────────────────
-    // Host fallback (mirrors this backend's sequence-op precedent); a native WGSL compute
-    // shader is a follow-up. Correct + GPU-CPU bit-parity via the shared reference.
+    // ── Fused recurrence / LM-head GPU kernels (#1464) ─────────────────────────────────────
+    // Real WGSL compute shaders (WebGpuRecurrenceKernels). Int params come in via a uniform struct
+    // bound after the storage buffers. Forward only — the differentiable backward runs through the
+    // CpuEngine tape (the engine override is forward-only and defers to base under a tape).
+
+    private async Task DispatchRecurrenceAsync(string key, string wgsl, int total, IGpuBuffer[] buffers, int[] scalars)
+    {
+        var pipe = await GetOrCreatePipelineAsync("Recurrence:" + key, wgsl, "main");
+        using var uniforms = new WebGpuBuffer(UniformInts(scalars), WebGpuBufferUsage.Uniform | WebGpuBufferUsage.CopyDst);
+        var wb = new WebGpuBuffer[buffers.Length];
+        for (int i = 0; i < buffers.Length; i++) wb[i] = AsWgpu(buffers[i]);
+        using var bind = new WebGpuBindGroup(pipe, wb);
+        var (wg, _) = _device.CalculateWorkgroups1D(total);
+        await WebGpuNativeBindings.DispatchComputeWithUniformsAsync(pipe, bind.BindGroupId, uniforms.BufferId, wg, 1, 1);
+        await WebGpuNativeBindings.SubmitAndWaitAsync();
+    }
+
+    private void DispatchRecurrence(string key, string wgsl, int total, IGpuBuffer[] buffers, int[] scalars)
+        => DispatchRecurrenceAsync(key, wgsl, total, buffers, scalars).GetAwaiter().GetResult();
+
     public void GlaScanForward(
         IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer gate, IGpuBuffer output,
         int batch, int seqLen, int modelDim, int numHeads, int headDim)
-    {
-        var qd = DownloadBuffer(q);
-        var kd = DownloadBuffer(k);
-        var vd = DownloadBuffer(v);
-        var gd = DownloadBuffer(gate);
-        var outp = new float[batch * seqLen * modelDim];
-        Cpu.RecurrenceCpuKernels.GlaForward(qd, kd, vd, gd, outp, batch, seqLen, modelDim, numHeads, headDim);
-        UploadToBuffer(outp, output);
-    }
+        => DispatchRecurrence("gla", WebGpuRecurrenceKernels.GlaScan, batch * numHeads * headDim,
+            new[] { q, k, v, gate, output }, new[] { batch, seqLen, modelDim, numHeads, headDim });
 
+    // GLA BPTT backward is never invoked by the IEngine forward-only path; HIP/CUDA/OpenCL carry the
+    // real backward kernel. Kept on host (an atomics-based WGSL backward is a follow-up).
     public void GlaScanBackward(
         IGpuBuffer dOut, IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer gate,
         IGpuBuffer dQ, IGpuBuffer dK, IGpuBuffer dV, IGpuBuffer dG,
         int batch, int seqLen, int modelDim, int numHeads, int headDim)
     {
-        var doData = DownloadBuffer(dOut);
-        var qd = DownloadBuffer(q);
-        var kd = DownloadBuffer(k);
-        var vd = DownloadBuffer(v);
-        var gd = DownloadBuffer(gate);
-        var gq = new float[batch * seqLen * modelDim];
-        var gk = new float[batch * seqLen * modelDim];
-        var gv = new float[batch * seqLen * modelDim];
-        var gG = new float[batch * seqLen * numHeads];
-        Cpu.RecurrenceCpuKernels.GlaBackward(doData, qd, kd, vd, gd, gq, gk, gv, gG,
-            batch, seqLen, modelDim, numHeads, headDim);
-        UploadToBuffer(gq, dQ);
-        UploadToBuffer(gk, dK);
-        UploadToBuffer(gv, dV);
-        UploadToBuffer(gG, dG);
+        var doData = DownloadBuffer(dOut); var qd = DownloadBuffer(q); var kd = DownloadBuffer(k);
+        var vd = DownloadBuffer(v); var gd = DownloadBuffer(gate);
+        var gq = new float[batch * seqLen * modelDim]; var gk = new float[batch * seqLen * modelDim];
+        var gv = new float[batch * seqLen * modelDim]; var gG = new float[batch * seqLen * numHeads];
+        Cpu.RecurrenceCpuKernels.GlaBackward(doData, qd, kd, vd, gd, gq, gk, gv, gG, batch, seqLen, modelDim, numHeads, headDim);
+        UploadToBuffer(gq, dQ); UploadToBuffer(gk, dK); UploadToBuffer(gv, dV); UploadToBuffer(gG, dG);
     }
 
-    // Fused xLSTM (mLSTM) scan forward (#1464) — host fallback via the shared reference.
     public void XLstmScanForward(
         IGpuBuffer q, IGpuBuffer k, IGpuBuffer v,
         IGpuBuffer iGate, IGpuBuffer fGate, IGpuBuffer oGate, IGpuBuffer output,
         int batch, int seqLen, int modelDim, int numHeads, int headDim)
-    {
-        var qd = DownloadBuffer(q); var kd = DownloadBuffer(k); var vd = DownloadBuffer(v);
-        var id = DownloadBuffer(iGate); var fd = DownloadBuffer(fGate); var od = DownloadBuffer(oGate);
-        var outp = new float[batch * seqLen * modelDim];
-        Cpu.RecurrenceCpuKernels.XLstmForward(qd, kd, vd, id, fd, od, outp, batch, seqLen, modelDim, numHeads, headDim);
-        UploadToBuffer(outp, output);
-    }
+        => DispatchRecurrence("xlstm", WebGpuRecurrenceKernels.XLstmScan, batch * numHeads,
+            new[] { q, k, v, iGate, fGate, oGate, output }, new[] { batch, seqLen, modelDim, numHeads, headDim });
 
-    // Fused Gated DeltaNet scan forward (#1464) — host fallback via the shared reference.
     public void GatedDeltaNetScanForward(
         IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer alpha, IGpuBuffer beta, IGpuBuffer output,
         int batch, int seqLen, int modelDim, int numHeads, int headDim)
-    {
-        var qd = DownloadBuffer(q); var kd = DownloadBuffer(k); var vd = DownloadBuffer(v);
-        var ad = DownloadBuffer(alpha); var bd = DownloadBuffer(beta);
-        var outp = new float[batch * seqLen * modelDim];
-        Cpu.RecurrenceCpuKernels.GatedDeltaNetForward(qd, kd, vd, ad, bd, outp, batch, seqLen, modelDim, numHeads, headDim);
-        UploadToBuffer(outp, output);
-    }
+        => DispatchRecurrence("gdn", WebGpuRecurrenceKernels.GatedDeltaScan, batch * numHeads * headDim,
+            new[] { q, k, v, alpha, beta, output }, new[] { batch, seqLen, modelDim, numHeads, headDim });
 
-    // Fused RG-LRU scan forward (#1464) — host fallback via the shared reference.
     public void RgLruScanForward(
         IGpuBuffer value, IGpuBuffer recGate, IGpuBuffer inpGate, IGpuBuffer decay, IGpuBuffer output,
         int batch, int seqLen, int recDim)
-    {
-        var vd = DownloadBuffer(value); var rd = DownloadBuffer(recGate);
-        var id = DownloadBuffer(inpGate); var dd = DownloadBuffer(decay);
-        var outp = new float[batch * seqLen * recDim];
-        Cpu.RecurrenceCpuKernels.RgLruForward(vd, rd, id, dd, outp, batch, seqLen, recDim);
-        UploadToBuffer(outp, output);
-    }
+        => DispatchRecurrence("rglru", WebGpuRecurrenceKernels.RgLruScan, batch * recDim,
+            new[] { value, recGate, inpGate, decay, output }, new[] { batch, seqLen, recDim });
 
-    // Fused RWKV-4 WKV scan forward (#1464) — host fallback via the shared reference.
     public void Rwkv4WkvForward(
         IGpuBuffer r, IGpuBuffer k, IGpuBuffer v, IGpuBuffer timeDecay, IGpuBuffer timeFirst, IGpuBuffer output,
         int batch, int seqLen, int modelDim)
-    {
-        var rd = DownloadBuffer(r); var kd = DownloadBuffer(k); var vd = DownloadBuffer(v);
-        var td = DownloadBuffer(timeDecay); var fd = DownloadBuffer(timeFirst);
-        var outp = new float[batch * seqLen * modelDim];
-        Cpu.RecurrenceCpuKernels.Rwkv4WkvForward(rd, kd, vd, td, fd, outp, batch, seqLen, modelDim);
-        UploadToBuffer(outp, output);
-    }
+        => DispatchRecurrence("rwkv4", WebGpuRecurrenceKernels.Rwkv4Wkv, batch * modelDim,
+            new[] { r, k, v, timeDecay, timeFirst, output }, new[] { batch, seqLen, modelDim });
 
-    // Fused Mamba selective scan forward (#1464) — host fallback via the shared reference.
     public void MambaSelectiveScanForward(
         IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,
         IGpuBuffer output, int batch, int seqLen, int innerDim, int stateDim)
-    {
-        var xd = DownloadBuffer(x); var dl = DownloadBuffer(delta); var al = DownloadBuffer(aLog);
-        var bp = DownloadBuffer(bParam); var cp = DownloadBuffer(cParam); var dp = DownloadBuffer(dParam);
-        var outp = new float[batch * seqLen * innerDim];
-        Cpu.RecurrenceCpuKernels.MambaSelectiveScanForward(xd, dl, al, bp, cp, dp, outp, batch, seqLen, innerDim, stateDim);
-        UploadToBuffer(outp, output);
-    }
+        => DispatchRecurrence("mamba", WebGpuRecurrenceKernels.MambaScan, batch * innerDim,
+            new[] { x, delta, aLog, bParam, cParam, dParam, output }, new[] { batch, seqLen, innerDim, stateDim });
 
-    // Fused Mamba-2 SSD scan forward (#1464) — host fallback via the shared reference.
     public void Mamba2SsdScanForward(
         IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,
         IGpuBuffer output, int batch, int seqLen, int innerDim, int numHeads, int headDim, int stateDim)
-    {
-        var xd = DownloadBuffer(x); var dl = DownloadBuffer(delta); var al = DownloadBuffer(aLog);
-        var bp = DownloadBuffer(bParam); var cp = DownloadBuffer(cParam); var dp = DownloadBuffer(dParam);
-        var outp = new float[batch * seqLen * innerDim];
-        Cpu.RecurrenceCpuKernels.Mamba2SsdScanForward(xd, dl, al, bp, cp, dp, outp, batch, seqLen, innerDim, numHeads, headDim, stateDim);
-        UploadToBuffer(outp, output);
-    }
+        => DispatchRecurrence("mamba2", WebGpuRecurrenceKernels.Mamba2Ssd, batch * innerDim,
+            new[] { x, delta, aLog, bParam, cParam, dParam, output },
+            new[] { batch, seqLen, innerDim, numHeads, headDim, stateDim });
 
-    // Fused linear + cross-entropy (#1464) — host fallback via the shared reference.
     public float FusedLinearCrossEntropyIndex(
         IGpuBuffer hidden, IGpuBuffer weight, IGpuBuffer bias, IGpuBuffer targetIds, int n, int d, int vocab)
-    {
-        var hd = DownloadBuffer(hidden); var wd = DownloadBuffer(weight); var bd = DownloadBuffer(bias);
-        var td = DownloadBuffer(targetIds);
-        var ids = new int[n];
-        for (int i = 0; i < n; i++) ids[i] = (int)(td[i] + 0.5f);
-        return Cpu.RecurrenceCpuKernels.FusedLinearCeIndex(hd, wd, bd, ids, n, d, vocab);
-    }
+        => FusedCeRowLoss("ce_index", WebGpuRecurrenceKernels.FusedCeIndex, hidden, weight, bias, targetIds, n, d, vocab);
 
     public float FusedLinearCrossEntropyDense(
         IGpuBuffer hidden, IGpuBuffer weight, IGpuBuffer bias, IGpuBuffer target, int n, int d, int vocab)
+        => FusedCeRowLoss("ce_dense", WebGpuRecurrenceKernels.FusedCeDense, hidden, weight, bias, target, n, d, vocab);
+
+    // CE kernels write a per-row loss vector; the host sums the N-element vector. Returns mean CE.
+    private float FusedCeRowLoss(
+        string key, string wgsl, IGpuBuffer hidden, IGpuBuffer weight, IGpuBuffer bias, IGpuBuffer tgt, int n, int d, int vocab)
     {
-        var hd = DownloadBuffer(hidden); var wd = DownloadBuffer(weight); var bd = DownloadBuffer(bias);
-        var td = DownloadBuffer(target);
-        return Cpu.RecurrenceCpuKernels.FusedLinearCeDense(hd, wd, bd, td, n, d, vocab);
+        using var rowLoss = AllocateBuffer(n);
+        DispatchRecurrence(key, wgsl, n, new[] { hidden, weight, bias, tgt, rowLoss }, new[] { n, d, vocab });
+        var rl = DownloadBuffer(rowLoss);
+        double sum = 0.0;
+        for (int i = 0; i < n; i++) sum += rl[i];
+        return (float)(sum / n);
     }
 
     public void LstmForwardSequence(

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
@@ -888,6 +888,18 @@ public sealed partial class WebGpuBackend
         UploadToBuffer(outp, output);
     }
 
+    // Fused Mamba-2 SSD scan forward (#1464) — host fallback via the shared reference.
+    public void Mamba2SsdScanForward(
+        IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,
+        IGpuBuffer output, int batch, int seqLen, int innerDim, int numHeads, int headDim, int stateDim)
+    {
+        var xd = DownloadBuffer(x); var dl = DownloadBuffer(delta); var al = DownloadBuffer(aLog);
+        var bp = DownloadBuffer(bParam); var cp = DownloadBuffer(cParam); var dp = DownloadBuffer(dParam);
+        var outp = new float[batch * seqLen * innerDim];
+        Cpu.RecurrenceCpuKernels.Mamba2SsdScanForward(xd, dl, al, bp, cp, dp, outp, batch, seqLen, innerDim, numHeads, headDim, stateDim);
+        UploadToBuffer(outp, output);
+    }
+
     public void LstmForwardSequence(
         IGpuBuffer input, IGpuBuffer hInit, IGpuBuffer cInit,
         IGpuBuffer weightsIh, IGpuBuffer weightsHh, IGpuBuffer biasIh, IGpuBuffer biasHh,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
@@ -876,6 +876,18 @@ public sealed partial class WebGpuBackend
         UploadToBuffer(outp, output);
     }
 
+    // Fused Mamba selective scan forward (#1464) — host fallback via the shared reference.
+    public void MambaSelectiveScanForward(
+        IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,
+        IGpuBuffer output, int batch, int seqLen, int innerDim, int stateDim)
+    {
+        var xd = DownloadBuffer(x); var dl = DownloadBuffer(delta); var al = DownloadBuffer(aLog);
+        var bp = DownloadBuffer(bParam); var cp = DownloadBuffer(cParam); var dp = DownloadBuffer(dParam);
+        var outp = new float[batch * seqLen * innerDim];
+        Cpu.RecurrenceCpuKernels.MambaSelectiveScanForward(xd, dl, al, bp, cp, dp, outp, batch, seqLen, innerDim, stateDim);
+        UploadToBuffer(outp, output);
+    }
+
     public void LstmForwardSequence(
         IGpuBuffer input, IGpuBuffer hInit, IGpuBuffer cInit,
         IGpuBuffer weightsIh, IGpuBuffer weightsHh, IGpuBuffer biasIh, IGpuBuffer biasHh,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
@@ -830,6 +830,11 @@ public sealed partial class WebGpuBackend
         if (totalLong > int.MaxValue || trajLenLong > int.MaxValue)
             throw new ArgumentOutOfRangeException(nameof(batch), "GLA dimensions exceed WebGPU launch/buffer limits.");
         int total = (int)totalLong;
+        // dQ/dK/dG are atomic accumulators in the backward kernel — zero them here so the
+        // method is self-contained and correct even if the caller reuses dirty buffers.
+        Fill(dQ, 0f, batch * seqLen * modelDim);
+        Fill(dK, 0f, batch * seqLen * modelDim);
+        Fill(dG, 0f, batch * seqLen * numHeads);
         using var traj = AllocateBuffer((int)trajLenLong);
         var pc = new[] { batch, seqLen, modelDim, numHeads, headDim };
         DispatchRecurrence("gla_recompute", WebGpuRecurrenceKernels.GlaRecompute, total,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
@@ -888,6 +888,8 @@ public sealed partial class WebGpuBackend
     private float FusedCeRowLoss(
         string key, string wgsl, IGpuBuffer hidden, IGpuBuffer weight, IGpuBuffer bias, IGpuBuffer tgt, int n, int d, int vocab)
     {
+        if (n <= 0 || d <= 0 || vocab <= 0)
+            throw new ArgumentOutOfRangeException(nameof(n), "Fused CE dimensions (n, d, vocab) must be positive.");
         using var rowLoss = AllocateBuffer(n);
         DispatchRecurrence(key, wgsl, n, new[] { hidden, weight, bias, tgt, rowLoss }, new[] { n, d, vocab });
         var rl = DownloadBuffer(rowLoss);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
@@ -900,6 +900,25 @@ public sealed partial class WebGpuBackend
         UploadToBuffer(outp, output);
     }
 
+    // Fused linear + cross-entropy (#1464) — host fallback via the shared reference.
+    public float FusedLinearCrossEntropyIndex(
+        IGpuBuffer hidden, IGpuBuffer weight, IGpuBuffer bias, IGpuBuffer targetIds, int n, int d, int vocab)
+    {
+        var hd = DownloadBuffer(hidden); var wd = DownloadBuffer(weight); var bd = DownloadBuffer(bias);
+        var td = DownloadBuffer(targetIds);
+        var ids = new int[n];
+        for (int i = 0; i < n; i++) ids[i] = (int)(td[i] + 0.5f);
+        return Cpu.RecurrenceCpuKernels.FusedLinearCeIndex(hd, wd, bd, ids, n, d, vocab);
+    }
+
+    public float FusedLinearCrossEntropyDense(
+        IGpuBuffer hidden, IGpuBuffer weight, IGpuBuffer bias, IGpuBuffer target, int n, int d, int vocab)
+    {
+        var hd = DownloadBuffer(hidden); var wd = DownloadBuffer(weight); var bd = DownloadBuffer(bias);
+        var td = DownloadBuffer(target);
+        return Cpu.RecurrenceCpuKernels.FusedLinearCeDense(hd, wd, bd, td, n, d, vocab);
+    }
+
     public void LstmForwardSequence(
         IGpuBuffer input, IGpuBuffer hInit, IGpuBuffer cInit,
         IGpuBuffer weightsIh, IGpuBuffer weightsHh, IGpuBuffer biasIh, IGpuBuffer biasHh,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuRecurrenceKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuRecurrenceKernels.cs
@@ -1,0 +1,244 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// WebGPU (WGSL) compute shaders for the fused recurrence / LM-head ops (#1464). Real GPU kernels —
+// mirror the HIP/CUDA/OpenCL/MSL/GLSL kernels and the CpuEngine math exactly. Int params come in
+// via a uniform struct bound after the storage buffers. Forward only — the differentiable backward
+// runs through the CpuEngine tape (the engine override is forward-only).
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.WebGpu;
+
+internal static class WebGpuRecurrenceKernels
+{
+    public const string GlaScan = @"
+@group(0) @binding(0) var<storage, read> Q: array<f32>;
+@group(0) @binding(1) var<storage, read> K: array<f32>;
+@group(0) @binding(2) var<storage, read> Vd: array<f32>;
+@group(0) @binding(3) var<storage, read> G: array<f32>;
+@group(0) @binding(4) var<storage, read_write> outp: array<f32>;
+struct P { batch: i32, seqLen: i32, modelDim: i32, numHeads: i32, headDim: i32 };
+@group(0) @binding(5) var<uniform> p: P;
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) gid3: vec3<u32>) {
+    let gid = i32(gid3.x);
+    let B = p.batch; let SL = p.seqLen; let MD = p.modelDim; let NH = p.numHeads; let HD = p.headDim;
+    if (gid >= B*NH*HD) { return; }
+    let di = gid % HD; let h = (gid/HD) % NH; let b = gid/(HD*NH); let hOff = h*HD;
+    var Srow: array<f32, 256>;
+    for (var ki: i32 = 0; ki < HD; ki = ki+1) { Srow[ki] = 0.0; }
+    for (var t: i32 = 0; t < SL; t = t+1) {
+        let baseOff = (b*SL+t)*MD + hOff;
+        let g = G[(b*SL+t)*NH + h];
+        let vd = Vd[baseOff+di];
+        var o: f32 = 0.0;
+        for (var ki: i32 = 0; ki < HD; ki = ki+1) { let s = g*Srow[ki] + vd*K[baseOff+ki]; Srow[ki] = s; o = o + s*Q[baseOff+ki]; }
+        outp[baseOff+di] = o;
+    }
+}";
+
+    public const string XLstmScan = @"
+@group(0) @binding(0) var<storage, read> Q: array<f32>;
+@group(0) @binding(1) var<storage, read> K: array<f32>;
+@group(0) @binding(2) var<storage, read> Vd: array<f32>;
+@group(0) @binding(3) var<storage, read> Ig: array<f32>;
+@group(0) @binding(4) var<storage, read> Fg: array<f32>;
+@group(0) @binding(5) var<storage, read> Og: array<f32>;
+@group(0) @binding(6) var<storage, read_write> outp: array<f32>;
+struct P { batch: i32, seqLen: i32, modelDim: i32, numHeads: i32, headDim: i32 };
+@group(0) @binding(7) var<uniform> p: P;
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) gid3: vec3<u32>) {
+    let gid = i32(gid3.x);
+    let B = p.batch; let SL = p.seqLen; let MD = p.modelDim; let NH = p.numHeads; let HD = p.headDim;
+    if (gid >= B*NH) { return; }
+    let h = gid % NH; let b = gid / NH; let hOff = h*HD; let hh = HD*HD;
+    let kappa = 1.0/sqrt(f32(HD));
+    var C: array<f32, 4096>;
+    var n: array<f32, 64>;
+    for (var i: i32 = 0; i < hh; i = i+1) { C[i] = 0.0; }
+    for (var i: i32 = 0; i < HD; i = i+1) { n[i] = 0.0; }
+    for (var t: i32 = 0; t < SL; t = t+1) {
+        let baseOff = (b*SL+t)*MD + hOff; let gOff = (b*SL+t)*NH + h;
+        var iv = Ig[gOff]; if (iv > 4.85e8) { iv = 4.85e8; }
+        let f = Fg[gOff]; let o = Og[gOff];
+        for (var di: i32 = 0; di < HD; di = di+1) {
+            n[di] = f*n[di] + iv*(K[baseOff+di]*kappa);
+            let vv = Vd[baseOff+di]; let srow = di*HD;
+            for (var ki: i32 = 0; ki < HD; ki = ki+1) { C[srow+ki] = f*C[srow+ki] + iv*vv*(K[baseOff+ki]*kappa); }
+        }
+        var nq: f32 = 0.0; for (var j: i32 = 0; j < HD; j = j+1) { nq = nq + n[j]*Q[baseOff+j]; }
+        var nf = abs(nq); if (nf < 1.0) { nf = 1.0; }
+        for (var di: i32 = 0; di < HD; di = di+1) {
+            let srow = di*HD; var num: f32 = 0.0;
+            for (var ki: i32 = 0; ki < HD; ki = ki+1) { num = num + C[srow+ki]*Q[baseOff+ki]; }
+            outp[baseOff+di] = o*num/nf;
+        }
+    }
+}";
+
+    public const string GatedDeltaScan = @"
+@group(0) @binding(0) var<storage, read> Q: array<f32>;
+@group(0) @binding(1) var<storage, read> K: array<f32>;
+@group(0) @binding(2) var<storage, read> Vd: array<f32>;
+@group(0) @binding(3) var<storage, read> A: array<f32>;
+@group(0) @binding(4) var<storage, read> Bt: array<f32>;
+@group(0) @binding(5) var<storage, read_write> outp: array<f32>;
+struct P { batch: i32, seqLen: i32, modelDim: i32, numHeads: i32, headDim: i32 };
+@group(0) @binding(6) var<uniform> p: P;
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) gid3: vec3<u32>) {
+    let gid = i32(gid3.x);
+    let B = p.batch; let SL = p.seqLen; let MD = p.modelDim; let NH = p.numHeads; let HD = p.headDim;
+    if (gid >= B*NH*HD) { return; }
+    let di = gid % HD; let h = (gid/HD) % NH; let b = gid/(HD*NH); let hOff = h*HD;
+    let kappa = 1.0/sqrt(f32(HD));
+    var Srow: array<f32, 256>;
+    for (var ki: i32 = 0; ki < HD; ki = ki+1) { Srow[ki] = 0.0; }
+    for (var t: i32 = 0; t < SL; t = t+1) {
+        let baseOff = (b*SL+t)*MD + hOff; let gIdx = (b*SL+t)*NH + h;
+        let a = A[gIdx]; let bet = Bt[gIdx];
+        var sK: f32 = 0.0; for (var ki: i32 = 0; ki < HD; ki = ki+1) { sK = sK + Srow[ki]*(K[baseOff+ki]*kappa); }
+        let bd = bet*(Vd[baseOff+di] - sK);
+        for (var ki: i32 = 0; ki < HD; ki = ki+1) { Srow[ki] = a*Srow[ki] + bd*(K[baseOff+ki]*kappa); }
+        var o: f32 = 0.0; for (var ki: i32 = 0; ki < HD; ki = ki+1) { o = o + Srow[ki]*Q[baseOff+ki]; }
+        outp[baseOff+di] = o;
+    }
+}";
+
+    public const string RgLruScan = @"
+@group(0) @binding(0) var<storage, read> Vd: array<f32>;
+@group(0) @binding(1) var<storage, read> R: array<f32>;
+@group(0) @binding(2) var<storage, read> Ig: array<f32>;
+@group(0) @binding(3) var<storage, read> decayb: array<f32>;
+@group(0) @binding(4) var<storage, read_write> outp: array<f32>;
+struct P { batch: i32, seqLen: i32, recDim: i32 };
+@group(0) @binding(5) var<uniform> p: P;
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) gid3: vec3<u32>) {
+    let gid = i32(gid3.x);
+    let B = p.batch; let SL = p.seqLen; let RD = p.recDim;
+    if (gid >= B*RD) { return; }
+    let c = gid % RD; let b = gid / RD;
+    let base = 1.0/(1.0+exp(decayb[c]));
+    var h: f32 = 0.0;
+    for (var t: i32 = 0; t < SL; t = t+1) {
+        let off = (b*SL+t)*RD + c;
+        let a = R[off]*base; let om = 1.0 - a*a;
+        var s: f32 = 0.0; if (om > 0.0) { s = sqrt(om); }
+        h = a*h + s*(Ig[off]*Vd[off]); outp[off] = h;
+    }
+}";
+
+    public const string Rwkv4Wkv = @"
+@group(0) @binding(0) var<storage, read> R: array<f32>;
+@group(0) @binding(1) var<storage, read> K: array<f32>;
+@group(0) @binding(2) var<storage, read> Vd: array<f32>;
+@group(0) @binding(3) var<storage, read> timeDecay: array<f32>;
+@group(0) @binding(4) var<storage, read> timeFirst: array<f32>;
+@group(0) @binding(5) var<storage, read_write> outp: array<f32>;
+struct P { batch: i32, seqLen: i32, modelDim: i32 };
+@group(0) @binding(6) var<uniform> p: P;
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) gid3: vec3<u32>) {
+    let gid = i32(gid3.x);
+    let B = p.batch; let SL = p.seqLen; let MD = p.modelDim;
+    if (gid >= B*MD) { return; }
+    let c = gid % MD; let b = gid / MD;
+    let w = -exp(timeDecay[c]); let u = timeFirst[c];
+    var aa: f32 = 0.0; var bb: f32 = 0.0; var pp: f32 = -1.0e38;
+    for (var t: i32 = 0; t < SL; t = t+1) {
+        let off = (b*SL+t)*MD + c; let k = K[off]; let v = Vd[off];
+        let ww = u+k; let q = max(pp, ww); let e1 = exp(pp-q); let e2 = exp(ww-q);
+        let wkv = (e1*aa + e2*v)/(e1*bb + e2);
+        outp[off] = (1.0/(1.0+exp(-R[off])))*wkv;
+        let ww2 = pp+w; let q2 = max(ww2, k); let e1b = exp(ww2-q2); let e2b = exp(k-q2);
+        aa = e1b*aa + e2b*v; bb = e1b*bb + e2b; pp = q2;
+    }
+}";
+
+    public const string MambaScan = @"
+@group(0) @binding(0) var<storage, read> X: array<f32>;
+@group(0) @binding(1) var<storage, read> delta: array<f32>;
+@group(0) @binding(2) var<storage, read> aLog: array<f32>;
+@group(0) @binding(3) var<storage, read> Bt: array<f32>;
+@group(0) @binding(4) var<storage, read> Ct: array<f32>;
+@group(0) @binding(5) var<storage, read> Dt: array<f32>;
+@group(0) @binding(6) var<storage, read_write> outp: array<f32>;
+struct P { batch: i32, seqLen: i32, innerDim: i32, stateDim: i32 };
+@group(0) @binding(7) var<uniform> p: P;
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) gid3: vec3<u32>) {
+    let gid = i32(gid3.x);
+    let B = p.batch; let SL = p.seqLen; let ID = p.innerDim; let SD = p.stateDim;
+    if (gid >= B*ID) { return; }
+    let di = gid % ID; let b = gid / ID; let hrow = di*SD;
+    var negA: array<f32, 256>; var h: array<f32, 256>;
+    for (var n: i32 = 0; n < SD; n = n+1) { negA[n] = -exp(aLog[hrow+n]); h[n] = 0.0; }
+    for (var t: i32 = 0; t < SL; t = t+1) {
+        let baseID = (b*SL+t)*ID; let baseSD = (b*SL+t)*SD;
+        let dt = delta[baseID+di]; let xv = X[baseID+di]; var y: f32 = 0.0;
+        for (var n: i32 = 0; n < SD; n = n+1) { let aBar = exp(dt*negA[n]); let hv = aBar*h[n] + dt*Bt[baseSD+n]*xv; h[n] = hv; y = y + Ct[baseSD+n]*hv; }
+        outp[baseID+di] = y + Dt[di]*xv;
+    }
+}";
+
+    public const string Mamba2Ssd = @"
+@group(0) @binding(0) var<storage, read> X: array<f32>;
+@group(0) @binding(1) var<storage, read> delta: array<f32>;
+@group(0) @binding(2) var<storage, read> aLog: array<f32>;
+@group(0) @binding(3) var<storage, read> Bt: array<f32>;
+@group(0) @binding(4) var<storage, read> Ct: array<f32>;
+@group(0) @binding(5) var<storage, read> Dt: array<f32>;
+@group(0) @binding(6) var<storage, read_write> outp: array<f32>;
+struct P { batch: i32, seqLen: i32, innerDim: i32, numHeads: i32, headDim: i32, sd: i32 };
+@group(0) @binding(7) var<uniform> p: P;
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) gid3: vec3<u32>) {
+    let gid = i32(gid3.x);
+    let B = p.batch; let SL = p.seqLen; let ID = p.innerDim; let NH = p.numHeads; let HD = p.headDim; let SD = p.sd;
+    if (gid >= B*ID) { return; }
+    let flatD = gid % ID; let b = gid / ID; let hi = flatD / HD;
+    let negA = -exp(aLog[hi]); let dv = Dt[hi];
+    var h: array<f32, 256>;
+    for (var n: i32 = 0; n < SD; n = n+1) { h[n] = 0.0; }
+    for (var t: i32 = 0; t < SL; t = t+1) {
+        let btInner = (b*SL+t)*ID; let btState = (b*SL+t)*SD; let btHead = (b*SL+t)*NH;
+        let dt = delta[btHead+hi]; let aBar = exp(dt*negA); let xv = X[btInner+flatD]; var y: f32 = 0.0;
+        for (var n: i32 = 0; n < SD; n = n+1) { let hNew = aBar*h[n] + dt*Bt[btState+n]*xv; h[n] = hNew; y = y + Ct[btState+n]*hNew; }
+        outp[btInner+flatD] = y + dv*xv;
+    }
+}";
+
+    public const string FusedCeIndex = @"
+@group(0) @binding(0) var<storage, read> hidden: array<f32>;
+@group(0) @binding(1) var<storage, read> weight: array<f32>;
+@group(0) @binding(2) var<storage, read> bias: array<f32>;
+@group(0) @binding(3) var<storage, read> targetIds: array<f32>;
+@group(0) @binding(4) var<storage, read_write> rowLoss: array<f32>;
+struct P { N: i32, d: i32, vocab: i32 };
+@group(0) @binding(5) var<uniform> p: P;
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) gid3: vec3<u32>) {
+    let r = i32(gid3.x);
+    let NN = p.N; let D = p.d; let VC = p.vocab;
+    if (r >= NN) { return; }
+    let hRow = r*D; let id = i32(targetIds[r] + 0.5);
+    var mx: f32 = -1.0e38; var logitTarget: f32 = 0.0;
+    for (var vv: i32 = 0; vv < VC; vv = vv+1) { var s = bias[vv]; for (var j: i32 = 0; j < D; j = j+1) { s = s + hidden[hRow+j]*weight[j*VC+vv]; } if (s > mx) { mx = s; } if (vv == id) { logitTarget = s; } }
+    var sumExp: f32 = 0.0;
+    for (var vv: i32 = 0; vv < VC; vv = vv+1) { var s = bias[vv]; for (var j: i32 = 0; j < D; j = j+1) { s = s + hidden[hRow+j]*weight[j*VC+vv]; } sumExp = sumExp + exp(s - mx); }
+    rowLoss[r] = (mx + log(sumExp)) - logitTarget;
+}";
+
+    public const string FusedCeDense = @"
+@group(0) @binding(0) var<storage, read> hidden: array<f32>;
+@group(0) @binding(1) var<storage, read> weight: array<f32>;
+@group(0) @binding(2) var<storage, read> bias: array<f32>;
+@group(0) @binding(3) var<storage, read> target: array<f32>;
+@group(0) @binding(4) var<storage, read_write> rowLoss: array<f32>;
+struct P { N: i32, d: i32, vocab: i32 };
+@group(0) @binding(5) var<uniform> p: P;
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) gid3: vec3<u32>) {
+    let r = i32(gid3.x);
+    let NN = p.N; let D = p.d; let VC = p.vocab;
+    if (r >= NN) { return; }
+    let hRow = r*D; let tRow = r*VC;
+    var mx: f32 = -1.0e38;
+    for (var vv: i32 = 0; vv < VC; vv = vv+1) { var s = bias[vv]; for (var j: i32 = 0; j < D; j = j+1) { s = s + hidden[hRow+j]*weight[j*VC+vv]; } if (s > mx) { mx = s; } }
+    var sumExp: f32 = 0.0;
+    for (var vv: i32 = 0; vv < VC; vv = vv+1) { var s = bias[vv]; for (var j: i32 = 0; j < D; j = j+1) { s = s + hidden[hRow+j]*weight[j*VC+vv]; } sumExp = sumExp + exp(s - mx); }
+    let lse = mx + log(sumExp); var rl: f32 = 0.0;
+    for (var vv: i32 = 0; vv < VC; vv = vv+1) { var s = bias[vv]; for (var j: i32 = 0; j < D; j = j+1) { s = s + hidden[hRow+j]*weight[j*VC+vv]; } rl = rl + target[tRow+vv]*(s - lse); }
+    rowLoss[r] = -rl;
+}";
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuRecurrenceKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuRecurrenceKernels.cs
@@ -241,4 +241,66 @@ struct P { N: i32, d: i32, vocab: i32 };
     for (var vv: i32 = 0; vv < VC; vv = vv+1) { var s = bias[vv]; for (var j: i32 = 0; j < D; j = j+1) { s = s + hidden[hRow+j]*weight[j*VC+vv]; } rl = rl + target[tRow+vv]*(s - lse); }
     rowLoss[r] = -rl;
 }";
+
+    // GLA BPTT backward: recompute the state trajectory, then reverse-sweep. WGSL has no float
+    // atomics, so dQ/dK/dG are bound as atomic<u32> and accumulated via a bitcast CAS loop; dV is a
+    // plain per-thread store. dQ/dK/dG must be pre-zeroed.
+    public const string GlaRecompute = @"
+@group(0) @binding(0) var<storage, read> K: array<f32>;
+@group(0) @binding(1) var<storage, read> Vd: array<f32>;
+@group(0) @binding(2) var<storage, read> G: array<f32>;
+@group(0) @binding(3) var<storage, read_write> Straj: array<f32>;
+struct P { batch: i32, seqLen: i32, modelDim: i32, numHeads: i32, headDim: i32 };
+@group(0) @binding(4) var<uniform> p: P;
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) gid3: vec3<u32>) {
+    let gid = i32(gid3.x);
+    let B = p.batch; let SL = p.seqLen; let MD = p.modelDim; let NH = p.numHeads; let HD = p.headDim;
+    if (gid >= B*NH*HD) { return; }
+    let di = gid % HD; let h = (gid/HD) % NH; let b = gid/(HD*NH); let hOff = h*HD; let hh = HD*HD;
+    var Srow: array<f32, 256>;
+    for (var ki: i32 = 0; ki < HD; ki = ki+1) { Srow[ki] = 0.0; }
+    for (var t: i32 = 0; t < SL; t = t+1) {
+        let baseOff = (b*SL+t)*MD + hOff;
+        let g = G[(b*SL+t)*NH + h]; let vd = Vd[baseOff+di];
+        let trajBase = ((b*NH+h)*SL+t)*hh + di*HD;
+        for (var ki: i32 = 0; ki < HD; ki = ki+1) { let s = g*Srow[ki] + vd*K[baseOff+ki]; Srow[ki] = s; Straj[trajBase+ki] = s; }
+    }
+}";
+
+    public const string GlaBackward = @"
+@group(0) @binding(0) var<storage, read> dOut: array<f32>;
+@group(0) @binding(1) var<storage, read> Q: array<f32>;
+@group(0) @binding(2) var<storage, read> K: array<f32>;
+@group(0) @binding(3) var<storage, read> Vd: array<f32>;
+@group(0) @binding(4) var<storage, read> G: array<f32>;
+@group(0) @binding(5) var<storage, read> Straj: array<f32>;
+@group(0) @binding(6) var<storage, read_write> dQ: array<atomic<u32>>;
+@group(0) @binding(7) var<storage, read_write> dK: array<atomic<u32>>;
+@group(0) @binding(8) var<storage, read_write> dV: array<f32>;
+@group(0) @binding(9) var<storage, read_write> dG: array<atomic<u32>>;
+struct P { batch: i32, seqLen: i32, modelDim: i32, numHeads: i32, headDim: i32 };
+@group(0) @binding(10) var<uniform> p: P;
+fn addDQ(idx: i32, val: f32) { var old = atomicLoad(&dQ[idx]); loop { let nv = bitcast<u32>(bitcast<f32>(old) + val); let r = atomicCompareExchangeWeak(&dQ[idx], old, nv); if (r.exchanged) { break; } old = r.old_value; } }
+fn addDK(idx: i32, val: f32) { var old = atomicLoad(&dK[idx]); loop { let nv = bitcast<u32>(bitcast<f32>(old) + val); let r = atomicCompareExchangeWeak(&dK[idx], old, nv); if (r.exchanged) { break; } old = r.old_value; } }
+fn addDG(idx: i32, val: f32) { var old = atomicLoad(&dG[idx]); loop { let nv = bitcast<u32>(bitcast<f32>(old) + val); let r = atomicCompareExchangeWeak(&dG[idx], old, nv); if (r.exchanged) { break; } old = r.old_value; } }
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) gid3: vec3<u32>) {
+    let gid = i32(gid3.x);
+    let B = p.batch; let SL = p.seqLen; let MD = p.modelDim; let NH = p.numHeads; let HD = p.headDim;
+    if (gid >= B*NH*HD) { return; }
+    let di = gid % HD; let h = (gid/HD) % NH; let b = gid/(HD*NH); let hOff = h*HD; let hh = HD*HD;
+    var dSrow: array<f32, 256>;
+    for (var ki: i32 = 0; ki < HD; ki = ki+1) { dSrow[ki] = 0.0; }
+    for (var t: i32 = SL-1; t >= 0; t = t-1) {
+        let baseOff = (b*SL+t)*MD + hOff; let gOff = (b*SL+t)*NH + h; let g = G[gOff];
+        let trajBase = ((b*NH+h)*SL+t)*hh + di*HD;
+        let sprevBase = ((b*NH+h)*SL+(t-1))*hh + di*HD;
+        let dOutVal = dOut[baseOff+di];
+        for (var ki: i32 = 0; ki < HD; ki = ki+1) { let sval = Straj[trajBase+ki]; addDQ(baseOff+ki, dOutVal*sval); dSrow[ki] = dSrow[ki] + dOutVal*Q[baseOff+ki]; }
+        let vd = Vd[baseOff+di]; var dg: f32 = 0.0; var dVacc: f32 = 0.0;
+        for (var ki: i32 = 0; ki < HD; ki = ki+1) { let dStv = dSrow[ki]; var sprev: f32 = 0.0; if (t > 0) { sprev = Straj[sprevBase+ki]; } dg = dg + dStv*sprev; addDK(baseOff+ki, dStv*vd); dVacc = dVacc + dStv*K[baseOff+ki]; }
+        dV[baseOff+di] = dVacc;
+        addDG(gOff, dg);
+        for (var ki: i32 = 0; ki < HD; ki = ki+1) { dSrow[ki] = dSrow[ki] * g; }
+    }
+}";
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -6244,6 +6244,42 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
     }
 
+    // Fused RG-LRU scan (#1464). GPU inference fast path; defer to CpuEngine otherwise.
+    public override Tensor<T> RgLruScanForward<T>(
+        Tensor<T> value, Tensor<T> recGate, Tensor<T> inpGate, Tensor<T> decay)
+    {
+        if (IsTapeActive<T>() || typeof(T) != typeof(float) || !TryGetBackend(out var backend))
+            return base.RgLruScanForward(value, recGate, inpGate, decay);
+        if (value.Rank != 3)
+            return base.RgLruScanForward(value, recGate, inpGate, decay);
+
+        int batch = value.Shape._dims[0];
+        int seqLen = value.Shape._dims[1];
+        int recDim = value.Shape._dims[2];
+        if (decay.Rank != 1 || decay.Shape._dims[0] != recDim)
+            return base.RgLruScanForward(value, recGate, inpGate, decay);
+
+        try
+        {
+            using var vB = GetOrAllocateBuffer(backend, value);
+            using var rB = GetOrAllocateBuffer(backend, recGate);
+            using var iB = GetOrAllocateBuffer(backend, inpGate);
+            using var dB = GetOrAllocateBuffer(backend, decay);
+            using var outB = AllocateOutputBuffer(backend, batch * seqLen * recDim);
+
+            backend.RgLruScanForward(vB.Buffer, rB.Buffer, iB.Buffer, dB.Buffer, outB.Buffer, batch, seqLen, recDim);
+
+            float[] outF = new float[batch * seqLen * recDim];
+            backend.DownloadBuffer(outB.Buffer, outF);
+            T[] outData = DirectGpuEngine.FromFloatArray<T>(outF);
+            return new Tensor<T>(outData, new[] { batch, seqLen, recDim });
+        }
+        catch
+        {
+            return base.RgLruScanForward(value, recGate, inpGate, decay);
+        }
+    }
+
     public override Tensor<T> FlashAttention<T>(
         Tensor<T> query,
         Tensor<T> key,

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -6357,6 +6357,49 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
     }
 
+    // Fused Mamba-2 SSD scan (#1464). GPU inference fast path; defer to CpuEngine otherwise.
+    public override Tensor<T> Mamba2SsdScanForward<T>(
+        Tensor<T> x, Tensor<T> delta, Tensor<T> aLog, Tensor<T> bParam, Tensor<T> cParam, Tensor<T> dParam, int numHeads)
+    {
+        if (IsTapeActive<T>() || typeof(T) != typeof(float) || !TryGetBackend(out var backend))
+            return base.Mamba2SsdScanForward(x, delta, aLog, bParam, cParam, dParam, numHeads);
+        if (x.Rank != 3 || numHeads < 1)
+            return base.Mamba2SsdScanForward(x, delta, aLog, bParam, cParam, dParam, numHeads);
+
+        int batch = x.Shape._dims[0];
+        int seqLen = x.Shape._dims[1];
+        int innerDim = x.Shape._dims[2];
+        if (innerDim % numHeads != 0 || bParam.Rank != 3)
+            return base.Mamba2SsdScanForward(x, delta, aLog, bParam, cParam, dParam, numHeads);
+        int headDim = innerDim / numHeads;
+        int stateDim = bParam.Shape._dims[2];
+        if (stateDim > 256)
+            return base.Mamba2SsdScanForward(x, delta, aLog, bParam, cParam, dParam, numHeads);
+
+        try
+        {
+            using var xB = GetOrAllocateBuffer(backend, x);
+            using var dtB = GetOrAllocateBuffer(backend, delta);
+            using var aB = GetOrAllocateBuffer(backend, aLog);
+            using var bB = GetOrAllocateBuffer(backend, bParam);
+            using var cB = GetOrAllocateBuffer(backend, cParam);
+            using var dB = GetOrAllocateBuffer(backend, dParam);
+            using var outB = AllocateOutputBuffer(backend, batch * seqLen * innerDim);
+
+            backend.Mamba2SsdScanForward(xB.Buffer, dtB.Buffer, aB.Buffer, bB.Buffer, cB.Buffer, dB.Buffer, outB.Buffer,
+                batch, seqLen, innerDim, numHeads, headDim, stateDim);
+
+            float[] outF = new float[batch * seqLen * innerDim];
+            backend.DownloadBuffer(outB.Buffer, outF);
+            T[] outData = DirectGpuEngine.FromFloatArray<T>(outF);
+            return new Tensor<T>(outData, new[] { batch, seqLen, innerDim });
+        }
+        catch
+        {
+            return base.Mamba2SsdScanForward(x, delta, aLog, bParam, cParam, dParam, numHeads);
+        }
+    }
+
     public override Tensor<T> FlashAttention<T>(
         Tensor<T> query,
         Tensor<T> key,

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -6130,6 +6130,17 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int batch = qProj.Shape._dims[0];
         int seqLen = qProj.Shape._dims[1];
         int modelDim = qProj.Shape._dims[2];
+        // K/V/gate must share Q's batch/seq (and K/V its model dim); a mismatched
+        // caller would otherwise launch the kernel with Q-derived sizes and read/write
+        // out of bounds. Defer to the safe differentiable fallback instead.
+        if (kProj.Rank != 3 || vProj.Rank != 3 || gate.Rank != 3)
+            return base.GlaScanForward(qProj, kProj, vProj, gate, numHeads);
+        if (kProj.Shape._dims[0] != batch || kProj.Shape._dims[1] != seqLen || kProj.Shape._dims[2] != modelDim)
+            return base.GlaScanForward(qProj, kProj, vProj, gate, numHeads);
+        if (vProj.Shape._dims[0] != batch || vProj.Shape._dims[1] != seqLen || vProj.Shape._dims[2] != modelDim)
+            return base.GlaScanForward(qProj, kProj, vProj, gate, numHeads);
+        if (gate.Shape._dims[0] != batch || gate.Shape._dims[1] != seqLen)
+            return base.GlaScanForward(qProj, kProj, vProj, gate, numHeads);
         if (numHeads < 1 || modelDim % numHeads != 0)
             return base.GlaScanForward(qProj, kProj, vProj, gate, numHeads);
         int headDim = modelDim / numHeads;

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -6280,6 +6280,43 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
     }
 
+    // Fused RWKV-4 WKV scan (#1464). GPU inference fast path; defer to CpuEngine otherwise.
+    public override Tensor<T> Rwkv4WkvForward<T>(
+        Tensor<T> rProj, Tensor<T> kProj, Tensor<T> vProj, Tensor<T> timeDecay, Tensor<T> timeFirst)
+    {
+        if (IsTapeActive<T>() || typeof(T) != typeof(float) || !TryGetBackend(out var backend))
+            return base.Rwkv4WkvForward(rProj, kProj, vProj, timeDecay, timeFirst);
+        if (rProj.Rank != 3)
+            return base.Rwkv4WkvForward(rProj, kProj, vProj, timeDecay, timeFirst);
+
+        int batch = rProj.Shape._dims[0];
+        int seqLen = rProj.Shape._dims[1];
+        int modelDim = rProj.Shape._dims[2];
+        if (timeDecay.Rank != 1 || timeDecay.Shape._dims[0] != modelDim)
+            return base.Rwkv4WkvForward(rProj, kProj, vProj, timeDecay, timeFirst);
+
+        try
+        {
+            using var rB = GetOrAllocateBuffer(backend, rProj);
+            using var kB = GetOrAllocateBuffer(backend, kProj);
+            using var vB = GetOrAllocateBuffer(backend, vProj);
+            using var dB = GetOrAllocateBuffer(backend, timeDecay);
+            using var fB = GetOrAllocateBuffer(backend, timeFirst);
+            using var outB = AllocateOutputBuffer(backend, batch * seqLen * modelDim);
+
+            backend.Rwkv4WkvForward(rB.Buffer, kB.Buffer, vB.Buffer, dB.Buffer, fB.Buffer, outB.Buffer, batch, seqLen, modelDim);
+
+            float[] outF = new float[batch * seqLen * modelDim];
+            backend.DownloadBuffer(outB.Buffer, outF);
+            T[] outData = DirectGpuEngine.FromFloatArray<T>(outF);
+            return new Tensor<T>(outData, new[] { batch, seqLen, modelDim });
+        }
+        catch
+        {
+            return base.Rwkv4WkvForward(rProj, kProj, vProj, timeDecay, timeFirst);
+        }
+    }
+
     public override Tensor<T> FlashAttention<T>(
         Tensor<T> query,
         Tensor<T> key,

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -6317,6 +6317,46 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
     }
 
+    // Fused Mamba selective scan (#1464). GPU inference fast path; defer to CpuEngine otherwise.
+    public override Tensor<T> MambaSelectiveScanForward<T>(
+        Tensor<T> x, Tensor<T> delta, Tensor<T> aLog, Tensor<T> bParam, Tensor<T> cParam, Tensor<T> dParam)
+    {
+        if (IsTapeActive<T>() || typeof(T) != typeof(float) || !TryGetBackend(out var backend))
+            return base.MambaSelectiveScanForward(x, delta, aLog, bParam, cParam, dParam);
+        if (x.Rank != 3 || aLog.Rank != 2)
+            return base.MambaSelectiveScanForward(x, delta, aLog, bParam, cParam, dParam);
+
+        int batch = x.Shape._dims[0];
+        int seqLen = x.Shape._dims[1];
+        int innerDim = x.Shape._dims[2];
+        int stateDim = aLog.Shape._dims[1];
+        if (aLog.Shape._dims[0] != innerDim || stateDim > 256)
+            return base.MambaSelectiveScanForward(x, delta, aLog, bParam, cParam, dParam);
+
+        try
+        {
+            using var xB = GetOrAllocateBuffer(backend, x);
+            using var dtB = GetOrAllocateBuffer(backend, delta);
+            using var aB = GetOrAllocateBuffer(backend, aLog);
+            using var bB = GetOrAllocateBuffer(backend, bParam);
+            using var cB = GetOrAllocateBuffer(backend, cParam);
+            using var dB = GetOrAllocateBuffer(backend, dParam);
+            using var outB = AllocateOutputBuffer(backend, batch * seqLen * innerDim);
+
+            backend.MambaSelectiveScanForward(xB.Buffer, dtB.Buffer, aB.Buffer, bB.Buffer, cB.Buffer, dB.Buffer, outB.Buffer,
+                batch, seqLen, innerDim, stateDim);
+
+            float[] outF = new float[batch * seqLen * innerDim];
+            backend.DownloadBuffer(outB.Buffer, outF);
+            T[] outData = DirectGpuEngine.FromFloatArray<T>(outF);
+            return new Tensor<T>(outData, new[] { batch, seqLen, innerDim });
+        }
+        catch
+        {
+            return base.MambaSelectiveScanForward(x, delta, aLog, bParam, cParam, dParam);
+        }
+    }
+
     public override Tensor<T> FlashAttention<T>(
         Tensor<T> query,
         Tensor<T> key,

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -6400,6 +6400,74 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
     }
 
+    // Fused linear (LM head) + cross-entropy, int-id targets (#1464). GPU inference fast path.
+    public override Tensor<T> FusedLinearCrossEntropyWithLogits<T>(
+        Tensor<T> hidden, Tensor<T> weight, Tensor<T> bias, Tensor<int> targetIds)
+    {
+        if (IsTapeActive<T>() || typeof(T) != typeof(float) || !TryGetBackend(out var backend))
+            return base.FusedLinearCrossEntropyWithLogits(hidden, weight, bias, targetIds);
+        if (hidden.Rank != 2 || weight.Rank != 2)
+            return base.FusedLinearCrossEntropyWithLogits(hidden, weight, bias, targetIds);
+
+        int n = hidden.Shape._dims[0];
+        int d = hidden.Shape._dims[1];
+        int vocab = weight.Shape._dims[1];
+        if (n <= 0 || vocab <= 0 || weight.Shape._dims[0] != d || bias.Length != vocab || targetIds.Length != n)
+            return base.FusedLinearCrossEntropyWithLogits(hidden, weight, bias, targetIds);
+
+        try
+        {
+            var ids = (int[])(object)targetIds.GetDataArray()!;
+            var fids = new float[n];
+            for (int i = 0; i < n; i++) fids[i] = ids[i];
+            using var hB = GetOrAllocateBuffer(backend, hidden);
+            using var wB = GetOrAllocateBuffer(backend, weight);
+            using var bB = GetOrAllocateBuffer(backend, bias);
+            using var tB = GetOrAllocateBuffer(backend, fids);
+            float loss = backend.FusedLinearCrossEntropyIndex(hB.Buffer, wB.Buffer, bB.Buffer, tB.Buffer, n, d, vocab);
+            var outT = new Tensor<T>(new[] { 1 });
+            outT.GetDataArray()![0] = MathHelper.GetNumericOperations<T>().FromDouble(loss);
+            return outT;
+        }
+        catch
+        {
+            return base.FusedLinearCrossEntropyWithLogits(hidden, weight, bias, targetIds);
+        }
+    }
+
+    // Fused linear (LM head) + cross-entropy, dense soft targets (#1464). GPU inference fast path.
+    public override Tensor<T> FusedLinearCrossEntropyWithLogits<T>(
+        Tensor<T> hidden, Tensor<T> weight, Tensor<T> bias, Tensor<T> target)
+    {
+        if (IsTapeActive<T>() || typeof(T) != typeof(float) || !TryGetBackend(out var backend))
+            return base.FusedLinearCrossEntropyWithLogits(hidden, weight, bias, target);
+        if (hidden.Rank != 2 || weight.Rank != 2)
+            return base.FusedLinearCrossEntropyWithLogits(hidden, weight, bias, target);
+
+        int n = hidden.Shape._dims[0];
+        int d = hidden.Shape._dims[1];
+        int vocab = weight.Shape._dims[1];
+        if (n <= 0 || vocab <= 0 || weight.Shape._dims[0] != d || bias.Length != vocab
+            || target.Rank != 2 || target.Shape._dims[0] != n || target.Shape._dims[1] != vocab)
+            return base.FusedLinearCrossEntropyWithLogits(hidden, weight, bias, target);
+
+        try
+        {
+            using var hB = GetOrAllocateBuffer(backend, hidden);
+            using var wB = GetOrAllocateBuffer(backend, weight);
+            using var bB = GetOrAllocateBuffer(backend, bias);
+            using var tB = GetOrAllocateBuffer(backend, target);
+            float loss = backend.FusedLinearCrossEntropyDense(hB.Buffer, wB.Buffer, bB.Buffer, tB.Buffer, n, d, vocab);
+            var outT = new Tensor<T>(new[] { 1 });
+            outT.GetDataArray()![0] = MathHelper.GetNumericOperations<T>().FromDouble(loss);
+            return outT;
+        }
+        catch
+        {
+            return base.FusedLinearCrossEntropyWithLogits(hidden, weight, bias, target);
+        }
+    }
+
     public override Tensor<T> FlashAttention<T>(
         Tensor<T> query,
         Tensor<T> key,

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -6116,6 +6116,49 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// Supports optional attention bias (ALiBi) — the bias is uploaded to GPU and passed to the kernel.
     /// Falls back to CPU implementation when GPU is unavailable or on any GPU error.
     /// </summary>
+    // Fused GLA scan (#1464). The GPU kernel is the inference fast path; when a tape is
+    // active (or T is not float, or no backend), defer to the differentiable CpuEngine path
+    // which records the BPTT backward — same precedent as FlashAttention / MlpForward.
+    public override Tensor<T> GlaScanForward<T>(
+        Tensor<T> qProj, Tensor<T> kProj, Tensor<T> vProj, Tensor<T> gate, int numHeads)
+    {
+        if (IsTapeActive<T>() || typeof(T) != typeof(float) || !TryGetBackend(out var backend))
+            return base.GlaScanForward(qProj, kProj, vProj, gate, numHeads);
+        if (qProj.Rank != 3 || numHeads < 1)
+            return base.GlaScanForward(qProj, kProj, vProj, gate, numHeads);
+
+        int batch = qProj.Shape._dims[0];
+        int seqLen = qProj.Shape._dims[1];
+        int modelDim = qProj.Shape._dims[2];
+        if (numHeads < 1 || modelDim % numHeads != 0)
+            return base.GlaScanForward(qProj, kProj, vProj, gate, numHeads);
+        int headDim = modelDim / numHeads;
+        // Kernel caps the register-resident state row; gate must be scalar-per-head.
+        if (headDim > 256 || gate.Rank != 3 || gate.Shape._dims[2] != numHeads)
+            return base.GlaScanForward(qProj, kProj, vProj, gate, numHeads);
+
+        try
+        {
+            using var qB = GetOrAllocateBuffer(backend, qProj);
+            using var kB = GetOrAllocateBuffer(backend, kProj);
+            using var vB = GetOrAllocateBuffer(backend, vProj);
+            using var gB = GetOrAllocateBuffer(backend, gate);
+            using var outB = AllocateOutputBuffer(backend, batch * seqLen * modelDim);
+
+            backend.GlaScanForward(qB.Buffer, kB.Buffer, vB.Buffer, gB.Buffer, outB.Buffer,
+                batch, seqLen, modelDim, numHeads, headDim);
+
+            float[] outF = new float[batch * seqLen * modelDim];
+            backend.DownloadBuffer(outB.Buffer, outF);
+            T[] outData = DirectGpuEngine.FromFloatArray<T>(outF);
+            return new Tensor<T>(outData, new[] { batch, seqLen, modelDim });
+        }
+        catch
+        {
+            return base.GlaScanForward(qProj, kProj, vProj, gate, numHeads);
+        }
+    }
+
     public override Tensor<T> FlashAttention<T>(
         Tensor<T> query,
         Tensor<T> key,

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -6184,10 +6184,21 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int batch = qProj.Shape._dims[0];
         int seqLen = qProj.Shape._dims[1];
         int modelDim = qProj.Shape._dims[2];
+        // K/V must match Q's [batch, seqLen, modelDim]; mismatched operands would otherwise
+        // reach the kernel with Q-derived launch sizes and read/write out of bounds.
+        if (kProj.Rank != 3 || vProj.Rank != 3 ||
+            kProj.Shape._dims[0] != batch || kProj.Shape._dims[1] != seqLen || kProj.Shape._dims[2] != modelDim ||
+            vProj.Shape._dims[0] != batch || vProj.Shape._dims[1] != seqLen || vProj.Shape._dims[2] != modelDim)
+            return base.XLstmScanForward(qProj, kProj, vProj, iGate, fGate, oGate, numHeads);
         if (modelDim % numHeads != 0)
             return base.XLstmScanForward(qProj, kProj, vProj, iGate, fGate, oGate, numHeads);
         int headDim = modelDim / numHeads;
-        if (headDim > 64 || iGate.Rank != 3 || iGate.Shape._dims[2] != numHeads)
+        // Gates are per-head [batch, seqLen, numHeads].
+        if (headDim > 64 ||
+            iGate.Rank != 3 || fGate.Rank != 3 || oGate.Rank != 3 ||
+            iGate.Shape._dims[0] != batch || iGate.Shape._dims[1] != seqLen || iGate.Shape._dims[2] != numHeads ||
+            fGate.Shape._dims[0] != batch || fGate.Shape._dims[1] != seqLen || fGate.Shape._dims[2] != numHeads ||
+            oGate.Shape._dims[0] != batch || oGate.Shape._dims[1] != seqLen || oGate.Shape._dims[2] != numHeads)
             return base.XLstmScanForward(qProj, kProj, vProj, iGate, fGate, oGate, numHeads);
 
         try
@@ -6226,10 +6237,18 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int batch = qProj.Shape._dims[0];
         int seqLen = qProj.Shape._dims[1];
         int modelDim = qProj.Shape._dims[2];
+        if (kProj.Rank != 3 || vProj.Rank != 3 ||
+            kProj.Shape._dims[0] != batch || kProj.Shape._dims[1] != seqLen || kProj.Shape._dims[2] != modelDim ||
+            vProj.Shape._dims[0] != batch || vProj.Shape._dims[1] != seqLen || vProj.Shape._dims[2] != modelDim)
+            return base.GatedDeltaNetScanForward(qProj, kProj, vProj, alpha, beta, numHeads);
         if (modelDim % numHeads != 0)
             return base.GatedDeltaNetScanForward(qProj, kProj, vProj, alpha, beta, numHeads);
         int headDim = modelDim / numHeads;
-        if (headDim > 256 || alpha.Rank != 3 || alpha.Shape._dims[2] != numHeads)
+        // alpha/beta are per-head gates [batch, seqLen, numHeads].
+        if (headDim > 256 ||
+            alpha.Rank != 3 || beta.Rank != 3 ||
+            alpha.Shape._dims[0] != batch || alpha.Shape._dims[1] != seqLen || alpha.Shape._dims[2] != numHeads ||
+            beta.Shape._dims[0] != batch || beta.Shape._dims[1] != seqLen || beta.Shape._dims[2] != numHeads)
             return base.GatedDeltaNetScanForward(qProj, kProj, vProj, alpha, beta, numHeads);
 
         try
@@ -6269,6 +6288,11 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int recDim = value.Shape._dims[2];
         if (decay.Rank != 1 || decay.Shape._dims[0] != recDim)
             return base.RgLruScanForward(value, recGate, inpGate, decay);
+        // recGate / inpGate must match value's [batch, seqLen, recDim].
+        if (recGate.Rank != 3 || inpGate.Rank != 3 ||
+            recGate.Shape._dims[0] != batch || recGate.Shape._dims[1] != seqLen || recGate.Shape._dims[2] != recDim ||
+            inpGate.Shape._dims[0] != batch || inpGate.Shape._dims[1] != seqLen || inpGate.Shape._dims[2] != recDim)
+            return base.RgLruScanForward(value, recGate, inpGate, decay);
 
         try
         {
@@ -6303,7 +6327,13 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int batch = rProj.Shape._dims[0];
         int seqLen = rProj.Shape._dims[1];
         int modelDim = rProj.Shape._dims[2];
-        if (timeDecay.Rank != 1 || timeDecay.Shape._dims[0] != modelDim)
+        if (timeDecay.Rank != 1 || timeDecay.Shape._dims[0] != modelDim ||
+            timeFirst.Rank != 1 || timeFirst.Shape._dims[0] != modelDim)
+            return base.Rwkv4WkvForward(rProj, kProj, vProj, timeDecay, timeFirst);
+        // K/V must match R's [batch, seqLen, modelDim].
+        if (kProj.Rank != 3 || vProj.Rank != 3 ||
+            kProj.Shape._dims[0] != batch || kProj.Shape._dims[1] != seqLen || kProj.Shape._dims[2] != modelDim ||
+            vProj.Shape._dims[0] != batch || vProj.Shape._dims[1] != seqLen || vProj.Shape._dims[2] != modelDim)
             return base.Rwkv4WkvForward(rProj, kProj, vProj, timeDecay, timeFirst);
 
         try
@@ -6342,6 +6372,14 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int innerDim = x.Shape._dims[2];
         int stateDim = aLog.Shape._dims[1];
         if (aLog.Shape._dims[0] != innerDim || stateDim > 256)
+            return base.MambaSelectiveScanForward(x, delta, aLog, bParam, cParam, dParam);
+        // delta matches x [batch, seqLen, innerDim]; B/C are [batch, seqLen, stateDim]; D is [innerDim].
+        if (delta.Rank != 3 ||
+            delta.Shape._dims[0] != batch || delta.Shape._dims[1] != seqLen || delta.Shape._dims[2] != innerDim ||
+            bParam.Rank != 3 || cParam.Rank != 3 ||
+            bParam.Shape._dims[0] != batch || bParam.Shape._dims[1] != seqLen || bParam.Shape._dims[2] != stateDim ||
+            cParam.Shape._dims[0] != batch || cParam.Shape._dims[1] != seqLen || cParam.Shape._dims[2] != stateDim ||
+            dParam.Rank != 1 || dParam.Shape._dims[0] != innerDim)
             return base.MambaSelectiveScanForward(x, delta, aLog, bParam, cParam, dParam);
 
         try
@@ -6385,6 +6423,16 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int headDim = innerDim / numHeads;
         int stateDim = bParam.Shape._dims[2];
         if (stateDim > 256)
+            return base.Mamba2SsdScanForward(x, delta, aLog, bParam, cParam, dParam, numHeads);
+        // Per the CPU reference: delta [batch,seqLen,numHeads], aLog [numHeads], B/C
+        // [batch,seqLen,stateDim], D [numHeads]. Reject any mismatch before dispatch.
+        if (delta.Rank != 3 ||
+            delta.Shape._dims[0] != batch || delta.Shape._dims[1] != seqLen || delta.Shape._dims[2] != numHeads ||
+            bParam.Shape._dims[0] != batch || bParam.Shape._dims[1] != seqLen ||
+            cParam.Rank != 3 ||
+            cParam.Shape._dims[0] != batch || cParam.Shape._dims[1] != seqLen || cParam.Shape._dims[2] != stateDim ||
+            aLog.Rank != 1 || aLog.Shape._dims[0] != numHeads ||
+            dParam.Rank != 1 || dParam.Shape._dims[0] != numHeads)
             return base.Mamba2SsdScanForward(x, delta, aLog, bParam, cParam, dParam, numHeads);
 
         try

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -6159,6 +6159,50 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
     }
 
+    // Fused xLSTM scan (#1464). GPU inference fast path; tape-active / non-float / no-backend /
+    // headDim over the kernel cap defer to the differentiable CpuEngine path.
+    public override Tensor<T> XLstmScanForward<T>(
+        Tensor<T> qProj, Tensor<T> kProj, Tensor<T> vProj,
+        Tensor<T> iGate, Tensor<T> fGate, Tensor<T> oGate, int numHeads)
+    {
+        if (IsTapeActive<T>() || typeof(T) != typeof(float) || !TryGetBackend(out var backend))
+            return base.XLstmScanForward(qProj, kProj, vProj, iGate, fGate, oGate, numHeads);
+        if (qProj.Rank != 3 || numHeads < 1)
+            return base.XLstmScanForward(qProj, kProj, vProj, iGate, fGate, oGate, numHeads);
+
+        int batch = qProj.Shape._dims[0];
+        int seqLen = qProj.Shape._dims[1];
+        int modelDim = qProj.Shape._dims[2];
+        if (modelDim % numHeads != 0)
+            return base.XLstmScanForward(qProj, kProj, vProj, iGate, fGate, oGate, numHeads);
+        int headDim = modelDim / numHeads;
+        if (headDim > 64 || iGate.Rank != 3 || iGate.Shape._dims[2] != numHeads)
+            return base.XLstmScanForward(qProj, kProj, vProj, iGate, fGate, oGate, numHeads);
+
+        try
+        {
+            using var qB = GetOrAllocateBuffer(backend, qProj);
+            using var kB = GetOrAllocateBuffer(backend, kProj);
+            using var vB = GetOrAllocateBuffer(backend, vProj);
+            using var iB = GetOrAllocateBuffer(backend, iGate);
+            using var fB = GetOrAllocateBuffer(backend, fGate);
+            using var oB = GetOrAllocateBuffer(backend, oGate);
+            using var outB = AllocateOutputBuffer(backend, batch * seqLen * modelDim);
+
+            backend.XLstmScanForward(qB.Buffer, kB.Buffer, vB.Buffer, iB.Buffer, fB.Buffer, oB.Buffer, outB.Buffer,
+                batch, seqLen, modelDim, numHeads, headDim);
+
+            float[] outF = new float[batch * seqLen * modelDim];
+            backend.DownloadBuffer(outB.Buffer, outF);
+            T[] outData = DirectGpuEngine.FromFloatArray<T>(outF);
+            return new Tensor<T>(outData, new[] { batch, seqLen, modelDim });
+        }
+        catch
+        {
+            return base.XLstmScanForward(qProj, kProj, vProj, iGate, fGate, oGate, numHeads);
+        }
+    }
+
     public override Tensor<T> FlashAttention<T>(
         Tensor<T> query,
         Tensor<T> key,

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -6203,6 +6203,47 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
     }
 
+    // Fused Gated DeltaNet scan (#1464). GPU inference fast path; defer to CpuEngine otherwise.
+    public override Tensor<T> GatedDeltaNetScanForward<T>(
+        Tensor<T> qProj, Tensor<T> kProj, Tensor<T> vProj, Tensor<T> alpha, Tensor<T> beta, int numHeads)
+    {
+        if (IsTapeActive<T>() || typeof(T) != typeof(float) || !TryGetBackend(out var backend))
+            return base.GatedDeltaNetScanForward(qProj, kProj, vProj, alpha, beta, numHeads);
+        if (qProj.Rank != 3 || numHeads < 1)
+            return base.GatedDeltaNetScanForward(qProj, kProj, vProj, alpha, beta, numHeads);
+
+        int batch = qProj.Shape._dims[0];
+        int seqLen = qProj.Shape._dims[1];
+        int modelDim = qProj.Shape._dims[2];
+        if (modelDim % numHeads != 0)
+            return base.GatedDeltaNetScanForward(qProj, kProj, vProj, alpha, beta, numHeads);
+        int headDim = modelDim / numHeads;
+        if (headDim > 256 || alpha.Rank != 3 || alpha.Shape._dims[2] != numHeads)
+            return base.GatedDeltaNetScanForward(qProj, kProj, vProj, alpha, beta, numHeads);
+
+        try
+        {
+            using var qB = GetOrAllocateBuffer(backend, qProj);
+            using var kB = GetOrAllocateBuffer(backend, kProj);
+            using var vB = GetOrAllocateBuffer(backend, vProj);
+            using var aB = GetOrAllocateBuffer(backend, alpha);
+            using var bB = GetOrAllocateBuffer(backend, beta);
+            using var outB = AllocateOutputBuffer(backend, batch * seqLen * modelDim);
+
+            backend.GatedDeltaNetScanForward(qB.Buffer, kB.Buffer, vB.Buffer, aB.Buffer, bB.Buffer, outB.Buffer,
+                batch, seqLen, modelDim, numHeads, headDim);
+
+            float[] outF = new float[batch * seqLen * modelDim];
+            backend.DownloadBuffer(outB.Buffer, outF);
+            T[] outData = DirectGpuEngine.FromFloatArray<T>(outF);
+            return new Tensor<T>(outData, new[] { batch, seqLen, modelDim });
+        }
+        catch
+        {
+            return base.GatedDeltaNetScanForward(qProj, kProj, vProj, alpha, beta, numHeads);
+        }
+    }
+
     public override Tensor<T> FlashAttention<T>(
         Tensor<T> query,
         Tensor<T> key,

--- a/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
@@ -1653,6 +1653,13 @@ public class DelegatingGpuBackend : IDirectGpuBackend
         => Inner.GlaScanBackward(dOut, q, k, v, gate, dQ, dK, dV, dG, batch, seqLen, modelDim, numHeads, headDim);
 
     /// <inheritdoc/>
+    public virtual void XLstmScanForward(
+        IGpuBuffer q, IGpuBuffer k, IGpuBuffer v,
+        IGpuBuffer iGate, IGpuBuffer fGate, IGpuBuffer oGate, IGpuBuffer output,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+        => Inner.XLstmScanForward(q, k, v, iGate, fGate, oGate, output, batch, seqLen, modelDim, numHeads, headDim);
+
+    /// <inheritdoc/>
     public virtual void LstmBackwardSequence(
         IGpuBuffer gradOutput, IGpuBuffer allH, IGpuBuffer allC, IGpuBuffer cacheGates,
         IGpuBuffer hInit, IGpuBuffer cInit,

--- a/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
@@ -1660,6 +1660,12 @@ public class DelegatingGpuBackend : IDirectGpuBackend
         => Inner.XLstmScanForward(q, k, v, iGate, fGate, oGate, output, batch, seqLen, modelDim, numHeads, headDim);
 
     /// <inheritdoc/>
+    public virtual void GatedDeltaNetScanForward(
+        IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer alpha, IGpuBuffer beta, IGpuBuffer output,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+        => Inner.GatedDeltaNetScanForward(q, k, v, alpha, beta, output, batch, seqLen, modelDim, numHeads, headDim);
+
+    /// <inheritdoc/>
     public virtual void LstmBackwardSequence(
         IGpuBuffer gradOutput, IGpuBuffer allH, IGpuBuffer allC, IGpuBuffer cacheGates,
         IGpuBuffer hInit, IGpuBuffer cInit,

--- a/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
@@ -1678,6 +1678,12 @@ public class DelegatingGpuBackend : IDirectGpuBackend
         => Inner.Rwkv4WkvForward(r, k, v, timeDecay, timeFirst, output, batch, seqLen, modelDim);
 
     /// <inheritdoc/>
+    public virtual void MambaSelectiveScanForward(
+        IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,
+        IGpuBuffer output, int batch, int seqLen, int innerDim, int stateDim)
+        => Inner.MambaSelectiveScanForward(x, delta, aLog, bParam, cParam, dParam, output, batch, seqLen, innerDim, stateDim);
+
+    /// <inheritdoc/>
     public virtual void LstmBackwardSequence(
         IGpuBuffer gradOutput, IGpuBuffer allH, IGpuBuffer allC, IGpuBuffer cacheGates,
         IGpuBuffer hInit, IGpuBuffer cInit,

--- a/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
@@ -1672,6 +1672,12 @@ public class DelegatingGpuBackend : IDirectGpuBackend
         => Inner.RgLruScanForward(value, recGate, inpGate, decay, output, batch, seqLen, recDim);
 
     /// <inheritdoc/>
+    public virtual void Rwkv4WkvForward(
+        IGpuBuffer r, IGpuBuffer k, IGpuBuffer v, IGpuBuffer timeDecay, IGpuBuffer timeFirst, IGpuBuffer output,
+        int batch, int seqLen, int modelDim)
+        => Inner.Rwkv4WkvForward(r, k, v, timeDecay, timeFirst, output, batch, seqLen, modelDim);
+
+    /// <inheritdoc/>
     public virtual void LstmBackwardSequence(
         IGpuBuffer gradOutput, IGpuBuffer allH, IGpuBuffer allC, IGpuBuffer cacheGates,
         IGpuBuffer hInit, IGpuBuffer cInit,

--- a/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
@@ -1690,6 +1690,16 @@ public class DelegatingGpuBackend : IDirectGpuBackend
         => Inner.Mamba2SsdScanForward(x, delta, aLog, bParam, cParam, dParam, output, batch, seqLen, innerDim, numHeads, headDim, stateDim);
 
     /// <inheritdoc/>
+    public virtual float FusedLinearCrossEntropyIndex(
+        IGpuBuffer hidden, IGpuBuffer weight, IGpuBuffer bias, IGpuBuffer targetIds, int n, int d, int vocab)
+        => Inner.FusedLinearCrossEntropyIndex(hidden, weight, bias, targetIds, n, d, vocab);
+
+    /// <inheritdoc/>
+    public virtual float FusedLinearCrossEntropyDense(
+        IGpuBuffer hidden, IGpuBuffer weight, IGpuBuffer bias, IGpuBuffer target, int n, int d, int vocab)
+        => Inner.FusedLinearCrossEntropyDense(hidden, weight, bias, target, n, d, vocab);
+
+    /// <inheritdoc/>
     public virtual void LstmBackwardSequence(
         IGpuBuffer gradOutput, IGpuBuffer allH, IGpuBuffer allC, IGpuBuffer cacheGates,
         IGpuBuffer hInit, IGpuBuffer cInit,

--- a/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
@@ -1666,6 +1666,12 @@ public class DelegatingGpuBackend : IDirectGpuBackend
         => Inner.GatedDeltaNetScanForward(q, k, v, alpha, beta, output, batch, seqLen, modelDim, numHeads, headDim);
 
     /// <inheritdoc/>
+    public virtual void RgLruScanForward(
+        IGpuBuffer value, IGpuBuffer recGate, IGpuBuffer inpGate, IGpuBuffer decay, IGpuBuffer output,
+        int batch, int seqLen, int recDim)
+        => Inner.RgLruScanForward(value, recGate, inpGate, decay, output, batch, seqLen, recDim);
+
+    /// <inheritdoc/>
     public virtual void LstmBackwardSequence(
         IGpuBuffer gradOutput, IGpuBuffer allH, IGpuBuffer allC, IGpuBuffer cacheGates,
         IGpuBuffer hInit, IGpuBuffer cInit,

--- a/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
@@ -1684,6 +1684,12 @@ public class DelegatingGpuBackend : IDirectGpuBackend
         => Inner.MambaSelectiveScanForward(x, delta, aLog, bParam, cParam, dParam, output, batch, seqLen, innerDim, stateDim);
 
     /// <inheritdoc/>
+    public virtual void Mamba2SsdScanForward(
+        IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,
+        IGpuBuffer output, int batch, int seqLen, int innerDim, int numHeads, int headDim, int stateDim)
+        => Inner.Mamba2SsdScanForward(x, delta, aLog, bParam, cParam, dParam, output, batch, seqLen, innerDim, numHeads, headDim, stateDim);
+
+    /// <inheritdoc/>
     public virtual void LstmBackwardSequence(
         IGpuBuffer gradOutput, IGpuBuffer allH, IGpuBuffer allC, IGpuBuffer cacheGates,
         IGpuBuffer hInit, IGpuBuffer cInit,

--- a/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
@@ -1640,6 +1640,19 @@ public class DelegatingGpuBackend : IDirectGpuBackend
             output, hFinal, cFinal, allH, allC, cacheGates, seqLen, batch, inputSize, hiddenSize);
 
     /// <inheritdoc/>
+    public virtual void GlaScanForward(
+        IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer gate, IGpuBuffer output,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+        => Inner.GlaScanForward(q, k, v, gate, output, batch, seqLen, modelDim, numHeads, headDim);
+
+    /// <inheritdoc/>
+    public virtual void GlaScanBackward(
+        IGpuBuffer dOut, IGpuBuffer q, IGpuBuffer k, IGpuBuffer v, IGpuBuffer gate,
+        IGpuBuffer dQ, IGpuBuffer dK, IGpuBuffer dV, IGpuBuffer dG,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim)
+        => Inner.GlaScanBackward(dOut, q, k, v, gate, dQ, dK, dV, dG, batch, seqLen, modelDim, numHeads, headDim);
+
+    /// <inheritdoc/>
     public virtual void LstmBackwardSequence(
         IGpuBuffer gradOutput, IGpuBuffer allH, IGpuBuffer allC, IGpuBuffer cacheGates,
         IGpuBuffer hInit, IGpuBuffer cInit,

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -4127,6 +4127,11 @@ public interface IEngine
     /// Fused Gated Linear Attention recurrence over a whole sequence as one differentiable op
     /// (forward + analytic BPTT backward); see <c>CpuEngine.GlaScan.cs</c> (#1464).
     /// </summary>
+    /// <param name="qProj">Query projection [batch, seqLen, modelDim].</param>
+    /// <param name="kProj">Key projection [batch, seqLen, modelDim].</param>
+    /// <param name="vProj">Value projection [batch, seqLen, modelDim].</param>
+    /// <param name="gate">Post-sigmoid scalar-per-head gate [batch, seqLen, numHeads].</param>
+    /// <param name="numHeads">Number of heads; modelDim must be divisible by it.</param>
     Tensor<T> GlaScanForward<T>(
         Tensor<T> qProj,
         Tensor<T> kProj,
@@ -4150,6 +4155,13 @@ public interface IEngine
     /// Fused xLSTM (mLSTM) matrix-memory recurrence over a whole sequence as one differentiable op
     /// (forward + analytic BPTT backward); see <c>CpuEngine.XLstmScan.cs</c> (#1464).
     /// </summary>
+    /// <param name="qProj">Query projection [batch, seqLen, modelDim].</param>
+    /// <param name="kProj">Key projection [batch, seqLen, modelDim].</param>
+    /// <param name="vProj">Value projection [batch, seqLen, modelDim].</param>
+    /// <param name="iGate">Post-exp scalar-per-head input gate [batch, seqLen, numHeads].</param>
+    /// <param name="fGate">Post-sigmoid scalar-per-head forget gate [batch, seqLen, numHeads].</param>
+    /// <param name="oGate">Post-sigmoid scalar-per-head output gate [batch, seqLen, numHeads].</param>
+    /// <param name="numHeads">Number of heads; modelDim must be divisible by it.</param>
     Tensor<T> XLstmScanForward<T>(
         Tensor<T> qProj,
         Tensor<T> kProj,
@@ -4175,7 +4187,23 @@ public interface IEngine
     /// <summary>
     /// Fused linear (LM head) + cross-entropy-with-logits loss as one differentiable op, without
     /// materializing the [N, vocab] logits on the tape; see
-    /// <c>CpuEngine.FusedLinearCrossEntropy.cs</c> (#1464).
+    /// <c>CpuEngine.FusedLinearCrossEntropy.cs</c> (#1464). This is the primary LM-training contract:
+    /// targets are per-row class ids [N], so there is no O(N·vocab) dense-label storage/bandwidth.
+    /// For soft / distillation targets use the dense [N, vocab] overload below.
+    /// </summary>
+    /// <param name="hidden">Pre-head hidden states [N, d].</param>
+    /// <param name="weight">LM head weight [d, vocab].</param>
+    /// <param name="bias">LM head bias [vocab].</param>
+    /// <param name="targetIds">Per-row class ids [N], each in [0, vocab).</param>
+    Tensor<T> FusedLinearCrossEntropyWithLogits<T>(
+        Tensor<T> hidden,
+        Tensor<T> weight,
+        Tensor<T> bias,
+        Tensor<int> targetIds);
+
+    /// <summary>
+    /// Dense-target variant of <see cref="FusedLinearCrossEntropyWithLogits{T}(Tensor{T},Tensor{T},Tensor{T},Tensor{int})"/>
+    /// for soft / one-hot / distillation supervision; target is a full per-row distribution [N, vocab].
     /// </summary>
     Tensor<T> FusedLinearCrossEntropyWithLogits<T>(
         Tensor<T> hidden,

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -4195,6 +4195,11 @@ public interface IEngine
     /// <param name="weight">LM head weight [d, vocab].</param>
     /// <param name="bias">LM head bias [vocab].</param>
     /// <param name="targetIds">Per-row class ids [N], each in [0, vocab).</param>
+    /// <returns>
+    /// The mean cross-entropy over the N rows as a scalar (length-1, shape [1]) tensor —
+    /// already reduced, NOT a per-row [N] loss vector. All <see cref="IEngine{T}"/>
+    /// implementations (CPU and every GPU backend) MUST honor this reduced-scalar contract.
+    /// </returns>
     Tensor<T> FusedLinearCrossEntropyWithLogits<T>(
         Tensor<T> hidden,
         Tensor<T> weight,
@@ -4205,6 +4210,19 @@ public interface IEngine
     /// Dense-target variant of <see cref="FusedLinearCrossEntropyWithLogits{T}(Tensor{T},Tensor{T},Tensor{T},Tensor{int})"/>
     /// for soft / one-hot / distillation supervision; target is a full per-row distribution [N, vocab].
     /// </summary>
+    /// <param name="hidden">Pre-head hidden states [N, d].</param>
+    /// <param name="weight">LM head weight [d, vocab].</param>
+    /// <param name="bias">LM head bias [vocab].</param>
+    /// <param name="target">
+    /// Per-row target distribution [N, vocab]. Each row MUST be a normalized probability
+    /// distribution (non-negative and summing to 1) — e.g. a one-hot, label-smoothed, or
+    /// teacher (distillation) distribution; the op does not renormalize.
+    /// </param>
+    /// <returns>
+    /// The mean cross-entropy over the N rows as a scalar (length-1, shape [1]) tensor —
+    /// already reduced, NOT a per-row [N] loss vector. Same reduced-scalar contract as the
+    /// class-id overload, binding on all <see cref="IEngine{T}"/> implementations.
+    /// </returns>
     Tensor<T> FusedLinearCrossEntropyWithLogits<T>(
         Tensor<T> hidden,
         Tensor<T> weight,

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -4091,6 +4091,99 @@ public interface IEngine
         int numHeads);
 
     /// <summary>
+    /// Fused RWKV-4 WKV recurrence (running-max stable per-channel WKV) over a whole sequence as one
+    /// differentiable op (forward + analytic BPTT backward); see <c>CpuEngine.Rwkv4Wkv.cs</c> (#1464).
+    /// </summary>
+    Tensor<T> Rwkv4WkvForward<T>(
+        Tensor<T> rProj,
+        Tensor<T> kProj,
+        Tensor<T> vProj,
+        Tensor<T> timeDecay,
+        Tensor<T> timeFirst);
+
+    /// <summary>
+    /// Fused Mamba S6 selective-scan over a whole sequence as one differentiable op
+    /// (forward + analytic BPTT backward); see <c>CpuEngine.MambaScan.cs</c> (#1464).
+    /// </summary>
+    Tensor<T> MambaSelectiveScanForward<T>(
+        Tensor<T> x,
+        Tensor<T> delta,
+        Tensor<T> aLog,
+        Tensor<T> bParam,
+        Tensor<T> cParam,
+        Tensor<T> dParam);
+
+    /// <summary>
+    /// Fused RG-LRU (Griffin/Hawk/RecurrentGemma) gated linear recurrence over a whole sequence as one
+    /// differentiable op (forward + analytic BPTT backward); see <c>CpuEngine.RgLruScan.cs</c> (#1464).
+    /// </summary>
+    Tensor<T> RgLruScanForward<T>(
+        Tensor<T> value,
+        Tensor<T> recGate,
+        Tensor<T> inpGate,
+        Tensor<T> decay);
+
+    /// <summary>
+    /// Fused Gated Linear Attention recurrence over a whole sequence as one differentiable op
+    /// (forward + analytic BPTT backward); see <c>CpuEngine.GlaScan.cs</c> (#1464).
+    /// </summary>
+    Tensor<T> GlaScanForward<T>(
+        Tensor<T> qProj,
+        Tensor<T> kProj,
+        Tensor<T> vProj,
+        Tensor<T> gate,
+        int numHeads);
+
+    /// <summary>
+    /// Fused Gated DeltaNet (delta-rule) recurrence over a whole sequence as one differentiable op
+    /// (forward + analytic BPTT backward); see <c>CpuEngine.GatedDeltaNetScan.cs</c> (#1464).
+    /// </summary>
+    Tensor<T> GatedDeltaNetScanForward<T>(
+        Tensor<T> qProj,
+        Tensor<T> kProj,
+        Tensor<T> vProj,
+        Tensor<T> alpha,
+        Tensor<T> beta,
+        int numHeads);
+
+    /// <summary>
+    /// Fused xLSTM (mLSTM) matrix-memory recurrence over a whole sequence as one differentiable op
+    /// (forward + analytic BPTT backward); see <c>CpuEngine.XLstmScan.cs</c> (#1464).
+    /// </summary>
+    Tensor<T> XLstmScanForward<T>(
+        Tensor<T> qProj,
+        Tensor<T> kProj,
+        Tensor<T> vProj,
+        Tensor<T> iGate,
+        Tensor<T> fGate,
+        Tensor<T> oGate,
+        int numHeads);
+
+    /// <summary>
+    /// Fused Mamba-2 SSD scan over a whole sequence as one differentiable op
+    /// (forward + analytic BPTT backward); see <c>CpuEngine.Mamba2SsdScan.cs</c> (#1464).
+    /// </summary>
+    Tensor<T> Mamba2SsdScanForward<T>(
+        Tensor<T> x,
+        Tensor<T> delta,
+        Tensor<T> aLog,
+        Tensor<T> bParam,
+        Tensor<T> cParam,
+        Tensor<T> dParam,
+        int numHeads);
+
+    /// <summary>
+    /// Fused linear (LM head) + cross-entropy-with-logits loss as one differentiable op, without
+    /// materializing the [N, vocab] logits on the tape; see
+    /// <c>CpuEngine.FusedLinearCrossEntropy.cs</c> (#1464).
+    /// </summary>
+    Tensor<T> FusedLinearCrossEntropyWithLogits<T>(
+        Tensor<T> hidden,
+        Tensor<T> weight,
+        Tensor<T> bias,
+        Tensor<T> target);
+
+    /// <summary>
     /// Computes the backward pass for scaled dot-product attention.
     /// </summary>
     /// <typeparam name="T">The numeric type of tensor elements.</typeparam>

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuAutoDifferentialTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuAutoDifferentialTests.cs
@@ -445,6 +445,21 @@ public sealed class GpuCpuAutoDifferentialTests : IDisposable
         "MuLawEncoding(Tensor<T>,Int32)",
         "NativePacFeatures(Tensor<T>,Int32,Int32,Double,Double,ValueTuple<Double,Double>[])",
         "OctonionMatMulTensor(Tensor<T>,Tensor<T>)",
+        // fused recurrence / LM-head scans (#1464) — q/k/v [B,S,D] vs gate/alpha/etc. [B,S,H],
+        // or [N,d]+[d,vocab]+[N] CE shapes: distinct shapes per tensor arg the generic single-shape
+        // generator can't drive. Each has a dedicated GPU-vs-CPU parity suite:
+        //   GlaScanGpuParityTests, XLstmScanGpuParityTests, GatedDeltaNetScanGpuParityTests,
+        //   RgLruScanGpuParityTests, Rwkv4WkvGpuParityTests, MambaScanGpuParityTests,
+        //   Mamba2ScanGpuParityTests, FusedLinearCeGpuParityTests.
+        "GlaScanForward(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Int32)",
+        "XLstmScanForward(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Int32)",
+        "GatedDeltaNetScanForward(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Int32)",
+        "RgLruScanForward(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>)",
+        "Rwkv4WkvForward(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>)",
+        "MambaSelectiveScanForward(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>)",
+        "Mamba2SsdScanForward(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Int32)",
+        "FusedLinearCrossEntropyWithLogits(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<Int32>)",
+        "FusedLinearCrossEntropyWithLogits(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>)",
     };
 }
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/FusedLinearCeGpuParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/FusedLinearCeGpuParityTests.cs
@@ -1,0 +1,61 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.DirectGpu.Cpu;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Parity tests for the GPU fused linear + cross-entropy path (#1464): the shared
+/// <see cref="RecurrenceCpuKernels"/> host references (used by the Metal/Vulkan/WebGpu fallback)
+/// must match <see cref="CpuEngine.FusedLinearCrossEntropyWithLogits{T}(Tensor{T},Tensor{T},Tensor{T},Tensor{int})"/>
+/// and the dense overload.
+/// </summary>
+public class FusedLinearCeGpuParityTests
+{
+    private static float[] Gen(int n, int s, float scale = 0.5f)
+    {
+        var a = new float[n];
+        for (int i = 0; i < n; i++) a[i] = (float)(Math.Sin(0.7 * (i + 1) + 1.3 * s) * scale);
+        return a;
+    }
+
+    [Fact]
+    public void HostReferenceIndex_MatchesCpuEngine()
+    {
+        var engine = new CpuEngine();
+        int n = 4, d = 5, vocab = 6;
+        var hidden = new Tensor<float>(Gen(n * d, 1), new[] { n, d });
+        var weight = new Tensor<float>(Gen(d * vocab, 2), new[] { d, vocab });
+        var bias = new Tensor<float>(Gen(vocab, 3, 0.3f), new[] { vocab });
+        var ids = new int[n];
+        for (int r = 0; r < n; r++) ids[r] = (r * 7 + 2) % vocab;
+
+        float reference = ((float[])(object)engine.FusedLinearCrossEntropyWithLogits(
+            hidden, weight, bias, new Tensor<int>(ids, new[] { n })).GetDataArray()!)[0];
+        float host = RecurrenceCpuKernels.FusedLinearCeIndex(F(hidden), F(weight), F(bias), ids, n, d, vocab);
+
+        Assert.True(Math.Abs(reference - host) < 1e-4f, $"index loss cpu={reference} host={host}");
+    }
+
+    [Fact]
+    public void HostReferenceDense_MatchesCpuEngine()
+    {
+        var engine = new CpuEngine();
+        int n = 3, d = 4, vocab = 5;
+        var hidden = new Tensor<float>(Gen(n * d, 1), new[] { n, d });
+        var weight = new Tensor<float>(Gen(d * vocab, 2), new[] { d, vocab });
+        var bias = new Tensor<float>(Gen(vocab, 3, 0.3f), new[] { vocab });
+        var target = new float[n * vocab];
+        for (int r = 0; r < n; r++) target[r * vocab + ((r * 3 + 1) % vocab)] = 1.0f; // one-hot
+
+        float reference = ((float[])(object)engine.FusedLinearCrossEntropyWithLogits(
+            hidden, weight, bias, new Tensor<float>(target, new[] { n, vocab })).GetDataArray()!)[0];
+        float host = RecurrenceCpuKernels.FusedLinearCeDense(F(hidden), F(weight), F(bias), target, n, d, vocab);
+
+        Assert.True(Math.Abs(reference - host) < 1e-4f, $"dense loss cpu={reference} host={host}");
+    }
+
+    private static float[] F(Tensor<float> t) => (float[])(object)t.GetDataArray()!;
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/FusedLinearCrossEntropyTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/FusedLinearCrossEntropyTests.cs
@@ -1,0 +1,118 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Correctness tests for the fused linear + cross-entropy-with-logits kernel
+/// (<see cref="CpuEngine.FusedLinearCrossEntropyWithLogits{T}"/>, issue ooples/AiDotNet#1464).
+/// Forward loss is checked against an independent (logits → log-softmax → NLL) reference; the custom
+/// autodiff backward is checked against central finite differences of the loss for hidden/weight/bias.
+/// </summary>
+public class FusedLinearCrossEntropyTests
+{
+    private static double ReferenceLoss(double[] hidden, double[] weight, double[] bias, double[] target,
+        int n, int d, int vocab)
+    {
+        double total = 0.0;
+        for (int r = 0; r < n; r++)
+        {
+            var logit = new double[vocab];
+            for (int v = 0; v < vocab; v++)
+            {
+                double s = bias[v];
+                for (int j = 0; j < d; j++) s += hidden[r * d + j] * weight[j * vocab + v];
+                logit[v] = s;
+            }
+            double max = logit[0];
+            for (int v = 1; v < vocab; v++) if (logit[v] > max) max = logit[v];
+            double sum = 0.0;
+            for (int v = 0; v < vocab; v++) sum += Math.Exp(logit[v] - max);
+            double lse = max + Math.Log(sum);
+            for (int v = 0; v < vocab; v++) total += target[r * vocab + v] * (logit[v] - lse);
+        }
+        return -total / n;
+    }
+
+    private static double[] Gen(int len, int seed, double scale = 0.5)
+    {
+        var a = new double[len];
+        for (int i = 0; i < len; i++) a[i] = Math.Sin(0.7 * (i + 1) + 1.3 * seed) * scale;
+        return a;
+    }
+
+    // One-hot target per row.
+    private static double[] OneHot(int n, int vocab, int seed)
+    {
+        var a = new double[n * vocab];
+        for (int r = 0; r < n; r++) a[r * vocab + ((r * 7 + seed) % vocab)] = 1.0;
+        return a;
+    }
+
+    [Fact]
+    public void Forward_MatchesReference()
+    {
+        var engine = new CpuEngine();
+        int n = 4, d = 5, vocab = 6;
+        var hidden = new Tensor<double>(Gen(n * d, 1), new[] { n, d });
+        var weight = new Tensor<double>(Gen(d * vocab, 2), new[] { d, vocab });
+        var bias = new Tensor<double>(Gen(vocab, 3, 0.3), new[] { vocab });
+        var target = new Tensor<double>(OneHot(n, vocab, 1), new[] { n, vocab });
+
+        var loss = engine.FusedLinearCrossEntropyWithLogits(hidden, weight, bias, target);
+        double got = ((double[])(object)loss.GetDataArray()!)[0];
+        double expected = ReferenceLoss(
+            (double[])(object)hidden.GetDataArray()!, (double[])(object)weight.GetDataArray()!,
+            (double[])(object)bias.GetDataArray()!, (double[])(object)target.GetDataArray()!, n, d, vocab);
+        Assert.True(Math.Abs(got - expected) < 1e-10, $"loss {got} vs reference {expected}");
+    }
+
+    [Fact]
+    public void Backward_MatchesFiniteDifferences()
+    {
+        var engine = new CpuEngine();
+        int n = 3, d = 4, vocab = 5;
+        var hidden = new Tensor<double>(Gen(n * d, 1), new[] { n, d });
+        var weight = new Tensor<double>(Gen(d * vocab, 2), new[] { d, vocab });
+        var bias = new Tensor<double>(Gen(vocab, 3, 0.3), new[] { vocab });
+        var target = new Tensor<double>(OneHot(n, vocab, 1), new[] { n, vocab });
+
+        System.Collections.Generic.Dictionary<Tensor<double>, Tensor<double>> grads;
+        using (var tape = new GradientTape<double>())
+        {
+            var loss = engine.FusedLinearCrossEntropyWithLogits(hidden, weight, bias, target);
+            grads = tape.ComputeGradients(loss, new[] { hidden, weight, bias });
+        }
+
+        const double eps = 1e-6;
+        foreach (var input in new[] { hidden, weight, bias })
+        {
+            var data = (double[])(object)input.GetDataArray()!;
+            var grad = grads[input];
+            for (int i = 0; i < data.Length; i++)
+            {
+                double orig = data[i];
+                data[i] = orig + eps;
+                double lp = LossOf(engine, hidden, weight, bias, target);
+                data[i] = orig - eps;
+                double lm = LossOf(engine, hidden, weight, bias, target);
+                data[i] = orig;
+                double numeric = (lp - lm) / (2.0 * eps);
+                double analytic = grad.GetFlat(i);
+                double tol = 1e-5 + 1e-4 * Math.Abs(analytic);
+                Assert.True(Math.Abs(numeric - analytic) < tol,
+                    $"grad mismatch at element {i}: analytic={analytic}, finite-diff={numeric}");
+            }
+        }
+    }
+
+    private static double LossOf(CpuEngine engine, Tensor<double> hidden, Tensor<double> weight,
+        Tensor<double> bias, Tensor<double> target)
+    {
+        var loss = engine.FusedLinearCrossEntropyWithLogits(hidden, weight, bias, target);
+        return ((double[])(object)loss.GetDataArray()!)[0];
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/FusedLinearCrossEntropyTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/FusedLinearCrossEntropyTests.cs
@@ -115,4 +115,78 @@ public class FusedLinearCrossEntropyTests
         var loss = engine.FusedLinearCrossEntropyWithLogits(hidden, weight, bias, target);
         return ((double[])(object)loss.GetDataArray()!)[0];
     }
+
+    // ── Index-target (primary) overload ───────────────────────────────────────────────────
+
+    private static int[] Ids(int n, int vocab, int seed)
+    {
+        var a = new int[n];
+        for (int r = 0; r < n; r++) a[r] = (r * 7 + seed) % vocab;
+        return a;
+    }
+
+    private static double[] OneHotFromIds(int[] ids, int vocab)
+    {
+        var a = new double[ids.Length * vocab];
+        for (int r = 0; r < ids.Length; r++) a[r * vocab + ids[r]] = 1.0;
+        return a;
+    }
+
+    [Fact]
+    public void IndexForward_MatchesDenseOneHotReference()
+    {
+        var engine = new CpuEngine();
+        int n = 4, d = 5, vocab = 6;
+        var hidden = new Tensor<double>(Gen(n * d, 1), new[] { n, d });
+        var weight = new Tensor<double>(Gen(d * vocab, 2), new[] { d, vocab });
+        var bias = new Tensor<double>(Gen(vocab, 3, 0.3), new[] { vocab });
+        var ids = Ids(n, vocab, 2);
+
+        var loss = engine.FusedLinearCrossEntropyWithLogits(hidden, weight, bias, new Tensor<int>(ids, new[] { n }));
+        double got = ((double[])(object)loss.GetDataArray()!)[0];
+        // Index-target CE must equal dense CE against the equivalent one-hot distribution.
+        double expected = ReferenceLoss(
+            (double[])(object)hidden.GetDataArray()!, (double[])(object)weight.GetDataArray()!,
+            (double[])(object)bias.GetDataArray()!, OneHotFromIds(ids, vocab), n, d, vocab);
+        Assert.True(Math.Abs(got - expected) < 1e-10, $"index loss {got} vs one-hot reference {expected}");
+    }
+
+    [Fact]
+    public void IndexBackward_MatchesFiniteDifferences()
+    {
+        var engine = new CpuEngine();
+        int n = 3, d = 4, vocab = 5;
+        var hidden = new Tensor<double>(Gen(n * d, 1), new[] { n, d });
+        var weight = new Tensor<double>(Gen(d * vocab, 2), new[] { d, vocab });
+        var bias = new Tensor<double>(Gen(vocab, 3, 0.3), new[] { vocab });
+        var ids = new Tensor<int>(Ids(n, vocab, 2), new[] { n });
+
+        System.Collections.Generic.Dictionary<Tensor<double>, Tensor<double>> grads;
+        using (var tape = new GradientTape<double>())
+        {
+            var loss = engine.FusedLinearCrossEntropyWithLogits(hidden, weight, bias, ids);
+            grads = tape.ComputeGradients(loss, new[] { hidden, weight, bias });
+        }
+
+        const double eps = 1e-6;
+        foreach (var input in new[] { hidden, weight, bias })
+        {
+            var data = (double[])(object)input.GetDataArray()!;
+            var grad = grads[input];
+            for (int i = 0; i < data.Length; i++)
+            {
+                double orig = data[i];
+                data[i] = orig + eps;
+                double lp = ((double[])(object)engine.FusedLinearCrossEntropyWithLogits(hidden, weight, bias, ids).GetDataArray()!)[0];
+                data[i] = orig - eps;
+                double lm = ((double[])(object)engine.FusedLinearCrossEntropyWithLogits(hidden, weight, bias, ids).GetDataArray()!)[0];
+                data[i] = orig;
+                double numeric = (lp - lm) / (2.0 * eps);
+                double analytic = grad.GetFlat(i);
+                double tol = 1e-5 + 1e-4 * Math.Abs(analytic);
+                Assert.True(Math.Abs(numeric - analytic) < tol,
+                    $"grad mismatch at element {i}: analytic={analytic}, finite-diff={numeric}");
+            }
+        }
+    }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/GatedDeltaNetScanGpuParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/GatedDeltaNetScanGpuParityTests.cs
@@ -1,0 +1,53 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.DirectGpu.Cpu;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Parity test for the GPU Gated DeltaNet scan path (#1464): the shared
+/// <see cref="RecurrenceCpuKernels.GatedDeltaNetForward"/> host reference (used by the
+/// Metal/Vulkan/WebGpu fallback) must match <see cref="CpuEngine.GatedDeltaNetScanForward{T}"/>.
+/// </summary>
+public class GatedDeltaNetScanGpuParityTests
+{
+    private static float[] Gen(int n, int s, float scale = 0.4f)
+    {
+        var a = new float[n];
+        for (int i = 0; i < n; i++) a[i] = (float)(Math.Sin(0.5 * (i + 1) + 1.1 * s) * scale);
+        return a;
+    }
+    private static float[] GenSig(int n, int s)
+    {
+        var a = new float[n];
+        for (int i = 0; i < n; i++) a[i] = (float)(1.0 / (1.0 + Math.Exp(-Math.Sin(0.5 * (i + 1) + 1.1 * s))));
+        return a;
+    }
+
+    [Fact]
+    public void HostReferenceForward_MatchesCpuEngine()
+    {
+        var engine = new CpuEngine();
+        int batch = 2, seqLen = 5, modelDim = 6, numHeads = 2;
+        var shape = new[] { batch, seqLen, modelDim };
+        var gShape = new[] { batch, seqLen, numHeads };
+        var q = new Tensor<float>(Gen(batch * seqLen * modelDim, 1), shape);
+        var k = new Tensor<float>(Gen(batch * seqLen * modelDim, 2), shape);
+        var v = new Tensor<float>(Gen(batch * seqLen * modelDim, 3), shape);
+        var a = new Tensor<float>(GenSig(batch * seqLen * numHeads, 4), gShape);
+        var bta = new Tensor<float>(GenSig(batch * seqLen * numHeads, 5), gShape);
+
+        var reference = (float[])(object)engine.GatedDeltaNetScanForward(q, k, v, a, bta, numHeads).GetDataArray()!;
+        var hostOut = new float[batch * seqLen * modelDim];
+        RecurrenceCpuKernels.GatedDeltaNetForward(
+            F(q), F(k), F(v), F(a), F(bta), hostOut, batch, seqLen, modelDim, numHeads, modelDim / numHeads);
+
+        for (int i = 0; i < reference.Length; i++)
+            Assert.True(Math.Abs(reference[i] - hostOut[i]) < 1e-4f,
+                $"forward[{i}] cpu={reference[i]} host={hostOut[i]}");
+    }
+
+    private static float[] F(Tensor<float> t) => (float[])(object)t.GetDataArray()!;
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/GatedDeltaNetScanTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/GatedDeltaNetScanTests.cs
@@ -1,0 +1,152 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Correctness tests for the fused Gated DeltaNet scan kernel
+/// (<see cref="CpuEngine.GatedDeltaNetScanForward{T}"/>, issue ooples/AiDotNet#1464).
+/// Forward is checked against an independent reference delta-rule scan; the custom autodiff backward
+/// is checked against central finite differences of sum(output) for every input.
+/// </summary>
+public class GatedDeltaNetScanTests
+{
+    private static double[] ReferenceForward(
+        double[] Q, double[] K, double[] V, double[] A, double[] B,
+        int batch, int seqLen, int modelDim, int numHeads)
+    {
+        int headDim = modelDim / numHeads;
+        double kappa = 1.0 / Math.Sqrt(headDim);
+        var outp = new double[Q.Length];
+        var S = new double[headDim * headDim];
+        var sK = new double[headDim];
+        for (int b = 0; b < batch; b++)
+            for (int h = 0; h < numHeads; h++)
+            {
+                Array.Clear(S, 0, S.Length);
+                int hOff = h * headDim;
+                for (int t = 0; t < seqLen; t++)
+                {
+                    int off = (b * seqLen + t) * modelDim + hOff;
+                    int g = (b * seqLen + t) * numHeads + h;
+                    double a = A[g], bet = B[g];
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        double s = 0.0;
+                        for (int ki = 0; ki < headDim; ki++) s += S[di * headDim + ki] * (K[off + ki] * kappa);
+                        sK[di] = s;
+                    }
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        double delta = V[off + di] - sK[di];
+                        for (int ki = 0; ki < headDim; ki++)
+                            S[di * headDim + ki] = a * S[di * headDim + ki] + bet * delta * (K[off + ki] * kappa);
+                    }
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        double o = 0.0;
+                        for (int ki = 0; ki < headDim; ki++) o += S[di * headDim + ki] * Q[off + ki];
+                        outp[off + di] = o;
+                    }
+                }
+            }
+        return outp;
+    }
+
+    private static double[] Gen(int n, int s, double scale = 0.4)
+    {
+        var arr = new double[n];
+        for (int i = 0; i < n; i++) arr[i] = Math.Sin(0.5 * (i + 1) + 1.4 * s) * scale;
+        return arr;
+    }
+
+    // alpha (forget) in (0,1); beta (write) in (0,1).
+    private static double[] GenGate(int n, int s)
+    {
+        var arr = new double[n];
+        for (int i = 0; i < n; i++) arr[i] = 1.0 / (1.0 + Math.Exp(-Math.Sin(0.5 * (i + 1) + 1.4 * s)));
+        return arr;
+    }
+
+    private static (Tensor<double> q, Tensor<double> k, Tensor<double> v, Tensor<double> a, Tensor<double> b)
+        MakeInputs(int batch, int seqLen, int modelDim, int numHeads, int seed)
+    {
+        int n = batch * seqLen * modelDim;
+        int g = batch * seqLen * numHeads;
+        var shape = new[] { batch, seqLen, modelDim };
+        var gShape = new[] { batch, seqLen, numHeads };
+        return (new Tensor<double>(Gen(n, seed), shape), new Tensor<double>(Gen(n, seed + 1), shape),
+                new Tensor<double>(Gen(n, seed + 2), shape),
+                new Tensor<double>(GenGate(g, seed + 3), gShape), new Tensor<double>(GenGate(g, seed + 4), gShape));
+    }
+
+    [Fact]
+    public void Forward_MatchesReference()
+    {
+        var engine = new CpuEngine();
+        int batch = 2, seqLen = 5, modelDim = 6, numHeads = 2;
+        var (q, k, v, a, b) = MakeInputs(batch, seqLen, modelDim, numHeads, 13);
+
+        var outp = engine.GatedDeltaNetScanForward(q, k, v, a, b, numHeads);
+        var expected = ReferenceForward(
+            (double[])(object)q.GetDataArray()!, (double[])(object)k.GetDataArray()!,
+            (double[])(object)v.GetDataArray()!, (double[])(object)a.GetDataArray()!,
+            (double[])(object)b.GetDataArray()!, batch, seqLen, modelDim, numHeads);
+
+        var got = (double[])(object)outp.GetDataArray()!;
+        for (int i = 0; i < expected.Length; i++)
+            Assert.True(Math.Abs(got[i] - expected[i]) < 1e-10,
+                $"Forward[{i}] = {got[i]} vs reference {expected[i]}");
+    }
+
+    [Fact]
+    public void Backward_MatchesFiniteDifferences()
+    {
+        var engine = new CpuEngine();
+        int batch = 1, seqLen = 4, modelDim = 4, numHeads = 2;
+        var (q, k, v, a, b) = MakeInputs(batch, seqLen, modelDim, numHeads, 6);
+
+        Tensor<double> outp;
+        System.Collections.Generic.Dictionary<Tensor<double>, Tensor<double>> grads;
+        using (var tape = new GradientTape<double>())
+        {
+            outp = engine.GatedDeltaNetScanForward(q, k, v, a, b, numHeads);
+            grads = tape.ComputeGradients(outp, new[] { q, k, v, a, b });
+        }
+
+        const double eps = 1e-6;
+        foreach (var input in new[] { q, k, v, a, b })
+        {
+            var data = (double[])(object)input.GetDataArray()!;
+            var grad = grads[input];
+            for (int i = 0; i < data.Length; i++)
+            {
+                double orig = data[i];
+                data[i] = orig + eps;
+                double sp = SumForward(engine, q, k, v, a, b, numHeads);
+                data[i] = orig - eps;
+                double sm = SumForward(engine, q, k, v, a, b, numHeads);
+                data[i] = orig;
+                double numeric = (sp - sm) / (2.0 * eps);
+                double analytic = grad.GetFlat(i);
+                double tol = 1e-5 + 1e-4 * Math.Abs(analytic);
+                Assert.True(Math.Abs(numeric - analytic) < tol,
+                    $"grad mismatch at element {i}: analytic={analytic}, finite-diff={numeric}");
+            }
+        }
+    }
+
+    private static double SumForward(
+        CpuEngine engine, Tensor<double> q, Tensor<double> k, Tensor<double> v,
+        Tensor<double> a, Tensor<double> b, int numHeads)
+    {
+        var outp = engine.GatedDeltaNetScanForward(q, k, v, a, b, numHeads);
+        var data = (double[])(object)outp.GetDataArray()!;
+        double s = 0.0;
+        for (int i = 0; i < data.Length; i++) s += data[i];
+        return s;
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/GlaScanGpuParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/GlaScanGpuParityTests.cs
@@ -1,0 +1,105 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.DirectGpu.Cpu;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Parity tests for the GPU GLA scan path (issue ooples/AiDotNet#1464). The HIP/CUDA/OpenCL
+/// backends ship native kernels; Metal/Vulkan/WebGpu use the shared
+/// <see cref="RecurrenceCpuKernels"/> host reference. These tests verify that shared reference
+/// matches the differentiable <see cref="CpuEngine.GlaScanForward{T}"/> exactly (forward output
+/// and BPTT gradients), so GPU-vs-CPU parity holds on the fallback backends. The native kernels
+/// mirror the same math and are validated on GPU hardware separately.
+/// </summary>
+public class GlaScanGpuParityTests
+{
+    private static float[] Gen(int n, int s, float scale = 0.5f)
+    {
+        var a = new float[n];
+        for (int i = 0; i < n; i++) a[i] = (float)(Math.Sin(0.5 * (i + 1) + 1.3 * s) * scale);
+        return a;
+    }
+
+    private static float[] GenGate(int n, int s)
+    {
+        var a = new float[n];
+        for (int i = 0; i < n; i++) a[i] = (float)(1.0 / (1.0 + Math.Exp(-Math.Sin(0.5 * (i + 1) + 1.3 * s))));
+        return a;
+    }
+
+    [Fact]
+    public void HostReferenceForward_MatchesCpuEngine()
+    {
+        var engine = new CpuEngine();
+        int batch = 2, seqLen = 5, modelDim = 6, numHeads = 2;
+        var shape = new[] { batch, seqLen, modelDim };
+        var gShape = new[] { batch, seqLen, numHeads };
+        var q = new Tensor<float>(Gen(batch * seqLen * modelDim, 1), shape);
+        var k = new Tensor<float>(Gen(batch * seqLen * modelDim, 2), shape);
+        var v = new Tensor<float>(Gen(batch * seqLen * modelDim, 3), shape);
+        var g = new Tensor<float>(GenGate(batch * seqLen * numHeads, 4), gShape);
+
+        var reference = (float[])(object)engine.GlaScanForward(q, k, v, g, numHeads).GetDataArray()!;
+
+        var hostOut = new float[batch * seqLen * modelDim];
+        RecurrenceCpuKernels.GlaForward(
+            (float[])(object)q.GetDataArray()!, (float[])(object)k.GetDataArray()!,
+            (float[])(object)v.GetDataArray()!, (float[])(object)g.GetDataArray()!,
+            hostOut, batch, seqLen, modelDim, numHeads, headDim: modelDim / numHeads);
+
+        for (int i = 0; i < reference.Length; i++)
+            Assert.True(Math.Abs(reference[i] - hostOut[i]) < 1e-5f,
+                $"forward[{i}] cpu={reference[i]} host={hostOut[i]}");
+    }
+
+    [Fact]
+    public void HostReferenceBackward_MatchesCpuEngineTapeGradients()
+    {
+        var engine = new CpuEngine();
+        int batch = 1, seqLen = 4, modelDim = 4, numHeads = 2;
+        var shape = new[] { batch, seqLen, modelDim };
+        var gShape = new[] { batch, seqLen, numHeads };
+        var q = new Tensor<float>(Gen(batch * seqLen * modelDim, 5), shape);
+        var k = new Tensor<float>(Gen(batch * seqLen * modelDim, 6), shape);
+        var v = new Tensor<float>(Gen(batch * seqLen * modelDim, 7), shape);
+        var g = new Tensor<float>(GenGate(batch * seqLen * numHeads, 8), gShape);
+
+        System.Collections.Generic.Dictionary<Tensor<float>, Tensor<float>> grads;
+        using (var tape = new GradientTape<float>())
+        {
+            var outp = engine.GlaScanForward(q, k, v, g, numHeads);
+            grads = tape.ComputeGradients(outp, new[] { q, k, v, g });
+        }
+
+        // Tape seeds dOutput = ones (gradient of sum(output)).
+        var dOut = new float[batch * seqLen * modelDim];
+        for (int i = 0; i < dOut.Length; i++) dOut[i] = 1.0f;
+
+        var dq = new float[batch * seqLen * modelDim];
+        var dk = new float[batch * seqLen * modelDim];
+        var dv = new float[batch * seqLen * modelDim];
+        var dG = new float[batch * seqLen * numHeads];
+        RecurrenceCpuKernels.GlaBackward(
+            dOut, (float[])(object)q.GetDataArray()!, (float[])(object)k.GetDataArray()!,
+            (float[])(object)v.GetDataArray()!, (float[])(object)g.GetDataArray()!,
+            dq, dk, dv, dG, batch, seqLen, modelDim, numHeads, headDim: modelDim / numHeads);
+
+        AssertMatch(grads[q], dq, "dQ");
+        AssertMatch(grads[k], dk, "dK");
+        AssertMatch(grads[v], dv, "dV");
+        AssertMatch(grads[g], dG, "dG");
+    }
+
+    private static void AssertMatch(Tensor<float> expected, float[] actual, string name)
+    {
+        var e = (float[])(object)expected.GetDataArray()!;
+        Assert.Equal(e.Length, actual.Length);
+        for (int i = 0; i < e.Length; i++)
+            Assert.True(Math.Abs(e[i] - actual[i]) < 1e-4f,
+                $"{name}[{i}] tape={e[i]} host={actual[i]}");
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/GlaScanTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/GlaScanTests.cs
@@ -29,7 +29,7 @@ public class GlaScanTests
                 for (int t = 0; t < seqLen; t++)
                 {
                     int off = (b * seqLen + t) * modelDim + hOff;
-                    double g = G[off];
+                    double g = G[(b * seqLen + t) * numHeads + h]; // scalar-per-head gate
                     for (int di = 0; di < headDim; di++)
                         for (int ki = 0; ki < headDim; ki++)
                             S[di * headDim + ki] = g * S[di * headDim + ki] + K[off + ki] * V[off + di];
@@ -61,12 +61,15 @@ public class GlaScanTests
     }
 
     private static (Tensor<double> q, Tensor<double> k, Tensor<double> v, Tensor<double> g)
-        MakeInputs(int batch, int seqLen, int modelDim, int seed)
+        MakeInputs(int batch, int seqLen, int modelDim, int numHeads, int seed)
     {
         int n = batch * seqLen * modelDim;
         var shape = new[] { batch, seqLen, modelDim };
+        // Gate is scalar-per-head: [batch, seqLen, numHeads].
+        int gn = batch * seqLen * numHeads;
+        var gShape = new[] { batch, seqLen, numHeads };
         return (new Tensor<double>(Gen(n, seed), shape), new Tensor<double>(Gen(n, seed + 1), shape),
-                new Tensor<double>(Gen(n, seed + 2), shape), new Tensor<double>(GenGate(n, seed + 3), shape));
+                new Tensor<double>(Gen(n, seed + 2), shape), new Tensor<double>(GenGate(gn, seed + 3), gShape));
     }
 
     [Fact]
@@ -74,7 +77,7 @@ public class GlaScanTests
     {
         var engine = new CpuEngine();
         int batch = 2, seqLen = 5, modelDim = 6, numHeads = 2;
-        var (q, k, v, g) = MakeInputs(batch, seqLen, modelDim, 9);
+        var (q, k, v, g) = MakeInputs(batch, seqLen, modelDim, numHeads, 9);
 
         var outp = engine.GlaScanForward(q, k, v, g, numHeads);
         var expected = ReferenceForward(
@@ -93,7 +96,7 @@ public class GlaScanTests
     {
         var engine = new CpuEngine();
         int batch = 1, seqLen = 4, modelDim = 4, numHeads = 2;
-        var (q, k, v, g) = MakeInputs(batch, seqLen, modelDim, 5);
+        var (q, k, v, g) = MakeInputs(batch, seqLen, modelDim, numHeads, 5);
 
         Tensor<double> outp;
         System.Collections.Generic.Dictionary<Tensor<double>, Tensor<double>> grads;

--- a/tests/AiDotNet.Tensors.Tests/Engines/GlaScanTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/GlaScanTests.cs
@@ -33,12 +33,13 @@ public class GlaScanTests
                     for (int di = 0; di < headDim; di++)
                         for (int ki = 0; ki < headDim; ki++)
                             S[di * headDim + ki] = g * S[di * headDim + ki] + K[off + ki] * V[off + di];
-                    for (int ki = 0; ki < headDim; ki++)
+                    // Readout: O[di] = sum_ki S[di,ki]*Q[ki] (query contracts the key dim).
+                    for (int di = 0; di < headDim; di++)
                     {
                         double o = 0.0;
-                        for (int di = 0; di < headDim; di++)
-                            o += Q[off + di] * S[di * headDim + ki];
-                        outp[off + ki] = o;
+                        for (int ki = 0; ki < headDim; ki++)
+                            o += S[di * headDim + ki] * Q[off + ki];
+                        outp[off + di] = o;
                     }
                 }
             }

--- a/tests/AiDotNet.Tensors.Tests/Engines/GlaScanTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/GlaScanTests.cs
@@ -1,0 +1,137 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Correctness tests for the fused GLA scan kernel
+/// (<see cref="CpuEngine.GlaScanForward{T}"/>, issue ooples/AiDotNet#1464).
+/// Forward is checked against an independent reference; the custom autodiff backward is checked
+/// against central finite differences of sum(output) for every input.
+/// </summary>
+public class GlaScanTests
+{
+    private static double[] ReferenceForward(
+        double[] Q, double[] K, double[] V, double[] G,
+        int batch, int seqLen, int modelDim, int numHeads)
+    {
+        int headDim = modelDim / numHeads;
+        var outp = new double[Q.Length];
+        var S = new double[headDim * headDim];
+        for (int b = 0; b < batch; b++)
+            for (int h = 0; h < numHeads; h++)
+            {
+                Array.Clear(S, 0, S.Length);
+                int hOff = h * headDim;
+                for (int t = 0; t < seqLen; t++)
+                {
+                    int off = (b * seqLen + t) * modelDim + hOff;
+                    double g = G[off];
+                    for (int di = 0; di < headDim; di++)
+                        for (int ki = 0; ki < headDim; ki++)
+                            S[di * headDim + ki] = g * S[di * headDim + ki] + K[off + ki] * V[off + di];
+                    for (int ki = 0; ki < headDim; ki++)
+                    {
+                        double o = 0.0;
+                        for (int di = 0; di < headDim; di++)
+                            o += Q[off + di] * S[di * headDim + ki];
+                        outp[off + ki] = o;
+                    }
+                }
+            }
+        return outp;
+    }
+
+    private static double[] Gen(int n, int s, double scale = 0.5)
+    {
+        var arr = new double[n];
+        for (int i = 0; i < n; i++) arr[i] = Math.Sin(0.5 * (i + 1) + 1.3 * s) * scale;
+        return arr;
+    }
+
+    // gate is a sigmoid output in (0,1); keep < 1 for a stable recurrence.
+    private static double[] GenGate(int n, int s)
+    {
+        var arr = new double[n];
+        for (int i = 0; i < n; i++) arr[i] = 1.0 / (1.0 + Math.Exp(-Math.Sin(0.5 * (i + 1) + 1.3 * s)));
+        return arr;
+    }
+
+    private static (Tensor<double> q, Tensor<double> k, Tensor<double> v, Tensor<double> g)
+        MakeInputs(int batch, int seqLen, int modelDim, int seed)
+    {
+        int n = batch * seqLen * modelDim;
+        var shape = new[] { batch, seqLen, modelDim };
+        return (new Tensor<double>(Gen(n, seed), shape), new Tensor<double>(Gen(n, seed + 1), shape),
+                new Tensor<double>(Gen(n, seed + 2), shape), new Tensor<double>(GenGate(n, seed + 3), shape));
+    }
+
+    [Fact]
+    public void Forward_MatchesReference()
+    {
+        var engine = new CpuEngine();
+        int batch = 2, seqLen = 5, modelDim = 6, numHeads = 2;
+        var (q, k, v, g) = MakeInputs(batch, seqLen, modelDim, 9);
+
+        var outp = engine.GlaScanForward(q, k, v, g, numHeads);
+        var expected = ReferenceForward(
+            (double[])(object)q.GetDataArray()!, (double[])(object)k.GetDataArray()!,
+            (double[])(object)v.GetDataArray()!, (double[])(object)g.GetDataArray()!,
+            batch, seqLen, modelDim, numHeads);
+
+        var got = (double[])(object)outp.GetDataArray()!;
+        for (int i = 0; i < expected.Length; i++)
+            Assert.True(Math.Abs(got[i] - expected[i]) < 1e-10,
+                $"Forward[{i}] = {got[i]} vs reference {expected[i]}");
+    }
+
+    [Fact]
+    public void Backward_MatchesFiniteDifferences()
+    {
+        var engine = new CpuEngine();
+        int batch = 1, seqLen = 4, modelDim = 4, numHeads = 2;
+        var (q, k, v, g) = MakeInputs(batch, seqLen, modelDim, 5);
+
+        Tensor<double> outp;
+        System.Collections.Generic.Dictionary<Tensor<double>, Tensor<double>> grads;
+        using (var tape = new GradientTape<double>())
+        {
+            outp = engine.GlaScanForward(q, k, v, g, numHeads);
+            grads = tape.ComputeGradients(outp, new[] { q, k, v, g });
+        }
+
+        const double eps = 1e-6;
+        foreach (var input in new[] { q, k, v, g })
+        {
+            var data = (double[])(object)input.GetDataArray()!;
+            var grad = grads[input];
+            for (int i = 0; i < data.Length; i++)
+            {
+                double orig = data[i];
+                data[i] = orig + eps;
+                double sp = SumForward(engine, q, k, v, g, numHeads);
+                data[i] = orig - eps;
+                double sm = SumForward(engine, q, k, v, g, numHeads);
+                data[i] = orig;
+                double numeric = (sp - sm) / (2.0 * eps);
+                double analytic = grad.GetFlat(i);
+                double tol = 1e-5 + 1e-4 * Math.Abs(analytic);
+                Assert.True(Math.Abs(numeric - analytic) < tol,
+                    $"grad mismatch at element {i}: analytic={analytic}, finite-diff={numeric}");
+            }
+        }
+    }
+
+    private static double SumForward(
+        CpuEngine engine, Tensor<double> q, Tensor<double> k, Tensor<double> v, Tensor<double> g, int numHeads)
+    {
+        var outp = engine.GlaScanForward(q, k, v, g, numHeads);
+        var data = (double[])(object)outp.GetDataArray()!;
+        double s = 0.0;
+        for (int i = 0; i < data.Length; i++) s += data[i];
+        return s;
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Mamba2ScanGpuParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Mamba2ScanGpuParityTests.cs
@@ -1,0 +1,53 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.DirectGpu.Cpu;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Parity test for the GPU Mamba-2 SSD scan path (#1464): the shared
+/// <see cref="RecurrenceCpuKernels.Mamba2SsdScanForward"/> host reference must match
+/// <see cref="CpuEngine.Mamba2SsdScanForward{T}"/>.
+/// </summary>
+public class Mamba2ScanGpuParityTests
+{
+    private static float[] Gen(int n, int s, float scale = 0.4f)
+    {
+        var a = new float[n];
+        for (int i = 0; i < n; i++) a[i] = (float)(Math.Sin(0.5 * (i + 1) + 0.55 * s) * scale);
+        return a;
+    }
+    private static float[] GenPos(int n, int s)
+    {
+        var a = new float[n];
+        for (int i = 0; i < n; i++) a[i] = (float)(0.1 + 0.4 * (0.5 + 0.5 * Math.Sin(0.5 * (i + 1) + 0.55 * s)));
+        return a;
+    }
+
+    [Fact]
+    public void HostReferenceForward_MatchesCpuEngine()
+    {
+        var engine = new CpuEngine();
+        int batch = 2, seqLen = 5, numHeads = 2, headDim = 3, stateDim = 3;
+        int innerDim = numHeads * headDim;
+        var x = new Tensor<float>(Gen(batch * seqLen * innerDim, 1), new[] { batch, seqLen, innerDim });
+        var delta = new Tensor<float>(GenPos(batch * seqLen * numHeads, 2), new[] { batch, seqLen, numHeads });
+        var aLog = new Tensor<float>(Gen(numHeads, 3, 0.3f), new[] { numHeads });
+        var bP = new Tensor<float>(Gen(batch * seqLen * stateDim, 4), new[] { batch, seqLen, stateDim });
+        var cP = new Tensor<float>(Gen(batch * seqLen * stateDim, 5), new[] { batch, seqLen, stateDim });
+        var dP = new Tensor<float>(Gen(numHeads, 6, 0.3f), new[] { numHeads });
+
+        var reference = (float[])(object)engine.Mamba2SsdScanForward(x, delta, aLog, bP, cP, dP, numHeads).GetDataArray()!;
+        var hostOut = new float[batch * seqLen * innerDim];
+        RecurrenceCpuKernels.Mamba2SsdScanForward(
+            F(x), F(delta), F(aLog), F(bP), F(cP), F(dP), hostOut, batch, seqLen, innerDim, numHeads, headDim, stateDim);
+
+        for (int i = 0; i < reference.Length; i++)
+            Assert.True(Math.Abs(reference[i] - hostOut[i]) < 1e-4f,
+                $"forward[{i}] cpu={reference[i]} host={hostOut[i]}");
+    }
+
+    private static float[] F(Tensor<float> t) => (float[])(object)t.GetDataArray()!;
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Mamba2SsdScanTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Mamba2SsdScanTests.cs
@@ -1,0 +1,148 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Correctness tests for the fused Mamba-2 SSD scan kernel
+/// (<see cref="CpuEngine.Mamba2SsdScanForward{T}"/>, issue ooples/AiDotNet#1464).
+/// Forward is checked against an independent reference; the custom autodiff backward is checked
+/// against central finite differences of sum(output) for every input.
+/// </summary>
+public class Mamba2SsdScanTests
+{
+    private static double[] ReferenceForward(
+        double[] X, double[] delta, double[] aLog, double[] B, double[] C, double[] D,
+        int batch, int seqLen, int innerDim, int numHeads, int sd)
+    {
+        int headDim = innerDim / numHeads;
+        var outp = new double[X.Length];
+        var negA = new double[numHeads];
+        for (int hi = 0; hi < numHeads; hi++) negA[hi] = -Math.Exp(aLog[hi]);
+        var h = new double[innerDim * sd];
+        for (int b = 0; b < batch; b++)
+        {
+            Array.Clear(h, 0, h.Length);
+            for (int t = 0; t < seqLen; t++)
+            {
+                int btI = (b * seqLen + t) * innerDim, btS = (b * seqLen + t) * sd, btH = (b * seqLen + t) * numHeads;
+                for (int hi = 0; hi < numHeads; hi++)
+                {
+                    double dt = delta[btH + hi];
+                    double aBar = Math.Exp(dt * negA[hi]);
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        int flatD = hi * headDim + di;
+                        double xv = X[btI + flatD];
+                        int hb = flatD * sd;
+                        double y = 0.0;
+                        for (int n = 0; n < sd; n++)
+                        {
+                            h[hb + n] = aBar * h[hb + n] + dt * B[btS + n] * xv;
+                            y += C[btS + n] * h[hb + n];
+                        }
+                        outp[btI + flatD] = y + D[hi] * xv;
+                    }
+                }
+            }
+        }
+        return outp;
+    }
+
+    private static double[] Gen(int n, int s, double scale = 0.4)
+    {
+        var arr = new double[n];
+        for (int i = 0; i < n; i++) arr[i] = Math.Sin(0.5 * (i + 1) + 1.6 * s) * scale;
+        return arr;
+    }
+    private static double[] GenPos(int n, int s)
+    {
+        var arr = new double[n];
+        for (int i = 0; i < n; i++) arr[i] = 0.2 + 0.25 * (0.5 + 0.5 * Math.Sin(0.5 * (i + 1) + 1.6 * s));
+        return arr;
+    }
+
+    private static (Tensor<double> x, Tensor<double> delta, Tensor<double> aLog,
+                    Tensor<double> b, Tensor<double> c, Tensor<double> d)
+        MakeInputs(int batch, int seqLen, int innerDim, int numHeads, int sd, int seed)
+    {
+        int nI = batch * seqLen * innerDim, nS = batch * seqLen * sd, nH = batch * seqLen * numHeads;
+        return (new Tensor<double>(Gen(nI, seed), new[] { batch, seqLen, innerDim }),
+                new Tensor<double>(GenPos(nH, seed + 1), new[] { batch, seqLen, numHeads }),
+                new Tensor<double>(Gen(numHeads, seed + 2, 0.3), new[] { numHeads }),
+                new Tensor<double>(Gen(nS, seed + 3), new[] { batch, seqLen, sd }),
+                new Tensor<double>(Gen(nS, seed + 4), new[] { batch, seqLen, sd }),
+                new Tensor<double>(Gen(numHeads, seed + 5, 0.4), new[] { numHeads }));
+    }
+
+    [Fact]
+    public void Forward_MatchesReference()
+    {
+        var engine = new CpuEngine();
+        int batch = 2, seqLen = 5, innerDim = 6, numHeads = 3, sd = 4;
+        var (x, delta, aLog, b, c, d) = MakeInputs(batch, seqLen, innerDim, numHeads, sd, 21);
+
+        var outp = engine.Mamba2SsdScanForward(x, delta, aLog, b, c, d, numHeads);
+        var expected = ReferenceForward(
+            (double[])(object)x.GetDataArray()!, (double[])(object)delta.GetDataArray()!,
+            (double[])(object)aLog.GetDataArray()!, (double[])(object)b.GetDataArray()!,
+            (double[])(object)c.GetDataArray()!, (double[])(object)d.GetDataArray()!,
+            batch, seqLen, innerDim, numHeads, sd);
+
+        var got = (double[])(object)outp.GetDataArray()!;
+        for (int i = 0; i < expected.Length; i++)
+            Assert.True(Math.Abs(got[i] - expected[i]) < 1e-10,
+                $"Forward[{i}] = {got[i]} vs reference {expected[i]}");
+    }
+
+    [Fact]
+    public void Backward_MatchesFiniteDifferences()
+    {
+        var engine = new CpuEngine();
+        int batch = 1, seqLen = 4, innerDim = 4, numHeads = 2, sd = 3;
+        var (x, delta, aLog, b, c, d) = MakeInputs(batch, seqLen, innerDim, numHeads, sd, 9);
+
+        Tensor<double> outp;
+        System.Collections.Generic.Dictionary<Tensor<double>, Tensor<double>> grads;
+        using (var tape = new GradientTape<double>())
+        {
+            outp = engine.Mamba2SsdScanForward(x, delta, aLog, b, c, d, numHeads);
+            grads = tape.ComputeGradients(outp, new[] { x, delta, aLog, b, c, d });
+        }
+
+        const double eps = 1e-6;
+        foreach (var input in new[] { x, delta, aLog, b, c, d })
+        {
+            var data = (double[])(object)input.GetDataArray()!;
+            var grad = grads[input];
+            for (int i = 0; i < data.Length; i++)
+            {
+                double orig = data[i];
+                data[i] = orig + eps;
+                double sp = SumForward(engine, x, delta, aLog, b, c, d, numHeads);
+                data[i] = orig - eps;
+                double sm = SumForward(engine, x, delta, aLog, b, c, d, numHeads);
+                data[i] = orig;
+                double numeric = (sp - sm) / (2.0 * eps);
+                double analytic = grad.GetFlat(i);
+                double tol = 1e-5 + 1e-4 * Math.Abs(analytic);
+                Assert.True(Math.Abs(numeric - analytic) < tol,
+                    $"grad mismatch at element {i}: analytic={analytic}, finite-diff={numeric}");
+            }
+        }
+    }
+
+    private static double SumForward(
+        CpuEngine engine, Tensor<double> x, Tensor<double> delta, Tensor<double> aLog,
+        Tensor<double> b, Tensor<double> c, Tensor<double> d, int numHeads)
+    {
+        var outp = engine.Mamba2SsdScanForward(x, delta, aLog, b, c, d, numHeads);
+        var data = (double[])(object)outp.GetDataArray()!;
+        double s = 0.0;
+        for (int i = 0; i < data.Length; i++) s += data[i];
+        return s;
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/MambaScanGpuParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/MambaScanGpuParityTests.cs
@@ -1,0 +1,52 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.DirectGpu.Cpu;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Parity test for the GPU Mamba selective scan path (#1464): the shared
+/// <see cref="RecurrenceCpuKernels.MambaSelectiveScanForward"/> host reference must match
+/// <see cref="CpuEngine.MambaSelectiveScanForward{T}"/>.
+/// </summary>
+public class MambaScanGpuParityTests
+{
+    private static float[] Gen(int n, int s, float scale = 0.4f)
+    {
+        var a = new float[n];
+        for (int i = 0; i < n; i++) a[i] = (float)(Math.Sin(0.5 * (i + 1) + 0.6 * s) * scale);
+        return a;
+    }
+    private static float[] GenPos(int n, int s)
+    {
+        var a = new float[n];
+        for (int i = 0; i < n; i++) a[i] = (float)(0.1 + 0.4 * (0.5 + 0.5 * Math.Sin(0.5 * (i + 1) + 0.6 * s)));
+        return a;
+    }
+
+    [Fact]
+    public void HostReferenceForward_MatchesCpuEngine()
+    {
+        var engine = new CpuEngine();
+        int batch = 2, seqLen = 5, innerDim = 4, stateDim = 3;
+        var x = new Tensor<float>(Gen(batch * seqLen * innerDim, 1), new[] { batch, seqLen, innerDim });
+        var delta = new Tensor<float>(GenPos(batch * seqLen * innerDim, 2), new[] { batch, seqLen, innerDim });
+        var aLog = new Tensor<float>(Gen(innerDim * stateDim, 3, 0.3f), new[] { innerDim, stateDim });
+        var bP = new Tensor<float>(Gen(batch * seqLen * stateDim, 4), new[] { batch, seqLen, stateDim });
+        var cP = new Tensor<float>(Gen(batch * seqLen * stateDim, 5), new[] { batch, seqLen, stateDim });
+        var dP = new Tensor<float>(Gen(innerDim, 6, 0.3f), new[] { innerDim });
+
+        var reference = (float[])(object)engine.MambaSelectiveScanForward(x, delta, aLog, bP, cP, dP).GetDataArray()!;
+        var hostOut = new float[batch * seqLen * innerDim];
+        RecurrenceCpuKernels.MambaSelectiveScanForward(
+            F(x), F(delta), F(aLog), F(bP), F(cP), F(dP), hostOut, batch, seqLen, innerDim, stateDim);
+
+        for (int i = 0; i < reference.Length; i++)
+            Assert.True(Math.Abs(reference[i] - hostOut[i]) < 1e-4f,
+                $"forward[{i}] cpu={reference[i]} host={hostOut[i]}");
+    }
+
+    private static float[] F(Tensor<float> t) => (float[])(object)t.GetDataArray()!;
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/MambaScanTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/MambaScanTests.cs
@@ -1,0 +1,147 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Correctness tests for the fused Mamba S6 selective-scan kernel
+/// (<see cref="CpuEngine.MambaSelectiveScanForward{T}"/>, issue ooples/AiDotNet#1464).
+/// Forward is checked against an independent reference scan; the custom autodiff backward is
+/// checked against central finite differences of sum(output) for every input.
+/// </summary>
+public class MambaScanTests
+{
+    /// <summary>Independent reference: plain nested-loop selective SSM scan.</summary>
+    private static double[] ReferenceForward(
+        double[] X, double[] delta, double[] aLog, double[] B, double[] C, double[] D,
+        int batch, int seqLen, int innerDim, int stateDim)
+    {
+        var outp = new double[X.Length];
+        var negA = new double[innerDim * stateDim];
+        for (int i = 0; i < negA.Length; i++) negA[i] = -Math.Exp(aLog[i]);
+        var h = new double[innerDim * stateDim];
+        for (int b = 0; b < batch; b++)
+        {
+            Array.Clear(h, 0, h.Length);
+            for (int t = 0; t < seqLen; t++)
+            {
+                int baseID = (b * seqLen + t) * innerDim;
+                int baseSD = (b * seqLen + t) * stateDim;
+                for (int di = 0; di < innerDim; di++)
+                {
+                    double dt = delta[baseID + di], xv = X[baseID + di];
+                    int hrow = di * stateDim;
+                    double y = 0.0;
+                    for (int ni = 0; ni < stateDim; ni++)
+                    {
+                        double aBar = Math.Exp(dt * negA[hrow + ni]);
+                        h[hrow + ni] = aBar * h[hrow + ni] + dt * B[baseSD + ni] * xv;
+                        y += C[baseSD + ni] * h[hrow + ni];
+                    }
+                    outp[baseID + di] = y + D[di] * xv;
+                }
+            }
+        }
+        return outp;
+    }
+
+    private static double[] Gen(int n, int s, double scale = 0.5)
+    {
+        var arr = new double[n];
+        for (int i = 0; i < n; i++) arr[i] = Math.Sin(0.6 * (i + 1) + 1.1 * s) * scale;
+        return arr;
+    }
+
+    // delta must be positive (it is softplus output in Mamba); use a positive generator.
+    private static double[] GenPos(int n, int s)
+    {
+        var arr = new double[n];
+        for (int i = 0; i < n; i++) arr[i] = 0.2 + 0.3 * (0.5 + 0.5 * Math.Sin(0.6 * (i + 1) + 1.1 * s));
+        return arr;
+    }
+
+    private static (Tensor<double> x, Tensor<double> delta, Tensor<double> aLog,
+                    Tensor<double> b, Tensor<double> c, Tensor<double> d)
+        MakeInputs(int batch, int seqLen, int innerDim, int stateDim, int seed)
+    {
+        int n3 = batch * seqLen * innerDim;
+        int s3 = batch * seqLen * stateDim;
+        return (new Tensor<double>(Gen(n3, seed), new[] { batch, seqLen, innerDim }),
+                new Tensor<double>(GenPos(n3, seed + 1), new[] { batch, seqLen, innerDim }),
+                new Tensor<double>(Gen(innerDim * stateDim, seed + 2, 0.3), new[] { innerDim, stateDim }),
+                new Tensor<double>(Gen(s3, seed + 3), new[] { batch, seqLen, stateDim }),
+                new Tensor<double>(Gen(s3, seed + 4), new[] { batch, seqLen, stateDim }),
+                new Tensor<double>(Gen(innerDim, seed + 5, 0.4), new[] { innerDim }));
+    }
+
+    [Fact]
+    public void Forward_MatchesReferenceScan()
+    {
+        var engine = new CpuEngine();
+        int batch = 2, seqLen = 5, innerDim = 4, stateDim = 3;
+        var (x, delta, aLog, b, c, d) = MakeInputs(batch, seqLen, innerDim, stateDim, 7);
+
+        var outp = engine.MambaSelectiveScanForward(x, delta, aLog, b, c, d);
+        var expected = ReferenceForward(
+            (double[])(object)x.GetDataArray()!, (double[])(object)delta.GetDataArray()!,
+            (double[])(object)aLog.GetDataArray()!, (double[])(object)b.GetDataArray()!,
+            (double[])(object)c.GetDataArray()!, (double[])(object)d.GetDataArray()!,
+            batch, seqLen, innerDim, stateDim);
+
+        var got = (double[])(object)outp.GetDataArray()!;
+        for (int i = 0; i < expected.Length; i++)
+            Assert.True(Math.Abs(got[i] - expected[i]) < 1e-10,
+                $"Forward[{i}] = {got[i]} vs reference {expected[i]}");
+    }
+
+    [Fact]
+    public void Backward_MatchesFiniteDifferences()
+    {
+        var engine = new CpuEngine();
+        int batch = 1, seqLen = 4, innerDim = 3, stateDim = 2;
+        var (x, delta, aLog, b, c, d) = MakeInputs(batch, seqLen, innerDim, stateDim, 2);
+
+        Tensor<double> outp;
+        System.Collections.Generic.Dictionary<Tensor<double>, Tensor<double>> grads;
+        using (var tape = new GradientTape<double>())
+        {
+            outp = engine.MambaSelectiveScanForward(x, delta, aLog, b, c, d);
+            grads = tape.ComputeGradients(outp, new[] { x, delta, aLog, b, c, d });
+        }
+
+        const double eps = 1e-6;
+        foreach (var input in new[] { x, delta, aLog, b, c, d })
+        {
+            var data = (double[])(object)input.GetDataArray()!;
+            var grad = grads[input];
+            for (int i = 0; i < data.Length; i++)
+            {
+                double orig = data[i];
+                data[i] = orig + eps;
+                double sumPlus = SumForward(engine, x, delta, aLog, b, c, d);
+                data[i] = orig - eps;
+                double sumMinus = SumForward(engine, x, delta, aLog, b, c, d);
+                data[i] = orig;
+                double numeric = (sumPlus - sumMinus) / (2.0 * eps);
+                double analytic = grad.GetFlat(i);
+                double tol = 1e-5 + 1e-4 * Math.Abs(analytic);
+                Assert.True(Math.Abs(numeric - analytic) < tol,
+                    $"grad mismatch at element {i}: analytic={analytic}, finite-diff={numeric}");
+            }
+        }
+    }
+
+    private static double SumForward(
+        CpuEngine engine, Tensor<double> x, Tensor<double> delta, Tensor<double> aLog,
+        Tensor<double> b, Tensor<double> c, Tensor<double> d)
+    {
+        var outp = engine.MambaSelectiveScanForward(x, delta, aLog, b, c, d);
+        var data = (double[])(object)outp.GetDataArray()!;
+        double s = 0.0;
+        for (int i = 0; i < data.Length; i++) s += data[i];
+        return s;
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/RgLruScanGpuParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/RgLruScanGpuParityTests.cs
@@ -1,0 +1,50 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.DirectGpu.Cpu;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Parity test for the GPU RG-LRU scan path (#1464): the shared
+/// <see cref="RecurrenceCpuKernels.RgLruForward"/> host reference (Metal/Vulkan/WebGpu fallback)
+/// must match <see cref="CpuEngine.RgLruScanForward{T}"/>.
+/// </summary>
+public class RgLruScanGpuParityTests
+{
+    private static float[] Gen(int n, int s, float scale = 0.5f)
+    {
+        var a = new float[n];
+        for (int i = 0; i < n; i++) a[i] = (float)(Math.Sin(0.5 * (i + 1) + 0.9 * s) * scale);
+        return a;
+    }
+    private static float[] GenSig(int n, int s)
+    {
+        var a = new float[n];
+        for (int i = 0; i < n; i++) a[i] = (float)(1.0 / (1.0 + Math.Exp(-Math.Sin(0.5 * (i + 1) + 0.9 * s))));
+        return a;
+    }
+
+    [Fact]
+    public void HostReferenceForward_MatchesCpuEngine()
+    {
+        var engine = new CpuEngine();
+        int batch = 2, seqLen = 6, recDim = 5;
+        var shape = new[] { batch, seqLen, recDim };
+        var v = new Tensor<float>(Gen(batch * seqLen * recDim, 1), shape);
+        var r = new Tensor<float>(GenSig(batch * seqLen * recDim, 2), shape);
+        var ig = new Tensor<float>(GenSig(batch * seqLen * recDim, 3), shape);
+        var decay = new Tensor<float>(Gen(recDim, 4, 0.8f), new[] { recDim });
+
+        var reference = (float[])(object)engine.RgLruScanForward(v, r, ig, decay).GetDataArray()!;
+        var hostOut = new float[batch * seqLen * recDim];
+        RecurrenceCpuKernels.RgLruForward(F(v), F(r), F(ig), F(decay), hostOut, batch, seqLen, recDim);
+
+        for (int i = 0; i < reference.Length; i++)
+            Assert.True(Math.Abs(reference[i] - hostOut[i]) < 1e-5f,
+                $"forward[{i}] cpu={reference[i]} host={hostOut[i]}");
+    }
+
+    private static float[] F(Tensor<float> t) => (float[])(object)t.GetDataArray()!;
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/RgLruScanTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/RgLruScanTests.cs
@@ -1,0 +1,136 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Correctness tests for the fused RG-LRU scan kernel
+/// (<see cref="CpuEngine.RgLruScanForward{T}"/>, issue ooples/AiDotNet#1464).
+/// Forward is checked against an independent reference; the custom autodiff backward is checked
+/// against central finite differences of sum(output) for every input.
+/// </summary>
+public class RgLruScanTests
+{
+    private static double Sigmoid(double x) => 1.0 / (1.0 + Math.Exp(-x));
+
+    private static double[] ReferenceForward(
+        double[] V, double[] R, double[] I, double[] decay, int batch, int seqLen, int recDim)
+    {
+        var outp = new double[V.Length];
+        var baseD = new double[recDim];
+        for (int c = 0; c < recDim; c++) baseD[c] = Sigmoid(-decay[c]);
+        var h = new double[recDim];
+        for (int b = 0; b < batch; b++)
+        {
+            Array.Clear(h, 0, recDim);
+            for (int t = 0; t < seqLen; t++)
+            {
+                int off = (b * seqLen + t) * recDim;
+                for (int c = 0; c < recDim; c++)
+                {
+                    double a = R[off + c] * baseD[c];
+                    double om = 1.0 - a * a;
+                    double s = om > 0 ? Math.Sqrt(om) : 0.0;
+                    h[c] = a * h[c] + s * (I[off + c] * V[off + c]);
+                    outp[off + c] = h[c];
+                }
+            }
+        }
+        return outp;
+    }
+
+    private static double[] Gen(int n, int s, double scale = 0.6)
+    {
+        var arr = new double[n];
+        for (int i = 0; i < n; i++) arr[i] = Math.Sin(0.55 * (i + 1) + 1.2 * s) * scale;
+        return arr;
+    }
+
+    // Gates are sigmoid outputs in (0,1).
+    private static double[] GenGate(int n, int s)
+    {
+        var arr = new double[n];
+        for (int i = 0; i < n; i++) arr[i] = Sigmoid(Math.Sin(0.55 * (i + 1) + 1.2 * s));
+        return arr;
+    }
+
+    private static (Tensor<double> v, Tensor<double> r, Tensor<double> i, Tensor<double> d)
+        MakeInputs(int batch, int seqLen, int recDim, int seed)
+    {
+        int n = batch * seqLen * recDim;
+        var shape = new[] { batch, seqLen, recDim };
+        return (new Tensor<double>(Gen(n, seed), shape),
+                new Tensor<double>(GenGate(n, seed + 1), shape),
+                new Tensor<double>(GenGate(n, seed + 2), shape),
+                new Tensor<double>(Gen(recDim, seed + 3, 0.5), new[] { recDim }));
+    }
+
+    [Fact]
+    public void Forward_MatchesReference()
+    {
+        var engine = new CpuEngine();
+        int batch = 2, seqLen = 5, recDim = 6;
+        var (v, r, i, d) = MakeInputs(batch, seqLen, recDim, 11);
+
+        var outp = engine.RgLruScanForward(v, r, i, d);
+        var expected = ReferenceForward(
+            (double[])(object)v.GetDataArray()!, (double[])(object)r.GetDataArray()!,
+            (double[])(object)i.GetDataArray()!, (double[])(object)d.GetDataArray()!,
+            batch, seqLen, recDim);
+
+        var got = (double[])(object)outp.GetDataArray()!;
+        for (int k = 0; k < expected.Length; k++)
+            Assert.True(Math.Abs(got[k] - expected[k]) < 1e-10,
+                $"Forward[{k}] = {got[k]} vs reference {expected[k]}");
+    }
+
+    [Fact]
+    public void Backward_MatchesFiniteDifferences()
+    {
+        var engine = new CpuEngine();
+        int batch = 1, seqLen = 4, recDim = 3;
+        var (v, r, i, d) = MakeInputs(batch, seqLen, recDim, 4);
+
+        Tensor<double> outp;
+        System.Collections.Generic.Dictionary<Tensor<double>, Tensor<double>> grads;
+        using (var tape = new GradientTape<double>())
+        {
+            outp = engine.RgLruScanForward(v, r, i, d);
+            grads = tape.ComputeGradients(outp, new[] { v, r, i, d });
+        }
+
+        const double eps = 1e-6;
+        foreach (var input in new[] { v, r, i, d })
+        {
+            var data = (double[])(object)input.GetDataArray()!;
+            var grad = grads[input];
+            for (int k = 0; k < data.Length; k++)
+            {
+                double orig = data[k];
+                data[k] = orig + eps;
+                double sp = SumForward(engine, v, r, i, d);
+                data[k] = orig - eps;
+                double sm = SumForward(engine, v, r, i, d);
+                data[k] = orig;
+                double numeric = (sp - sm) / (2.0 * eps);
+                double analytic = grad.GetFlat(k);
+                double tol = 1e-5 + 1e-4 * Math.Abs(analytic);
+                Assert.True(Math.Abs(numeric - analytic) < tol,
+                    $"grad mismatch at element {k}: analytic={analytic}, finite-diff={numeric}");
+            }
+        }
+    }
+
+    private static double SumForward(
+        CpuEngine engine, Tensor<double> v, Tensor<double> r, Tensor<double> i, Tensor<double> d)
+    {
+        var outp = engine.RgLruScanForward(v, r, i, d);
+        var data = (double[])(object)outp.GetDataArray()!;
+        double s = 0.0;
+        for (int k = 0; k < data.Length; k++) s += data[k];
+        return s;
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Rwkv4WkvGpuParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Rwkv4WkvGpuParityTests.cs
@@ -1,0 +1,45 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.DirectGpu.Cpu;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Parity test for the GPU RWKV-4 WKV scan path (#1464): the shared
+/// <see cref="RecurrenceCpuKernels.Rwkv4WkvForward"/> host reference (Metal/Vulkan/WebGpu fallback)
+/// must match <see cref="CpuEngine.Rwkv4WkvForward{T}"/>.
+/// </summary>
+public class Rwkv4WkvGpuParityTests
+{
+    private static float[] Gen(int n, int s, float scale = 0.5f)
+    {
+        var a = new float[n];
+        for (int i = 0; i < n; i++) a[i] = (float)(Math.Sin(0.5 * (i + 1) + 0.7 * s) * scale);
+        return a;
+    }
+
+    [Fact]
+    public void HostReferenceForward_MatchesCpuEngine()
+    {
+        var engine = new CpuEngine();
+        int batch = 2, seqLen = 6, modelDim = 5;
+        var shape = new[] { batch, seqLen, modelDim };
+        var r = new Tensor<float>(Gen(batch * seqLen * modelDim, 1), shape);
+        var k = new Tensor<float>(Gen(batch * seqLen * modelDim, 2), shape);
+        var v = new Tensor<float>(Gen(batch * seqLen * modelDim, 3), shape);
+        var td = new Tensor<float>(Gen(modelDim, 4, 0.3f), new[] { modelDim });
+        var tf = new Tensor<float>(Gen(modelDim, 5, 0.3f), new[] { modelDim });
+
+        var reference = (float[])(object)engine.Rwkv4WkvForward(r, k, v, td, tf).GetDataArray()!;
+        var hostOut = new float[batch * seqLen * modelDim];
+        RecurrenceCpuKernels.Rwkv4WkvForward(F(r), F(k), F(v), F(td), F(tf), hostOut, batch, seqLen, modelDim);
+
+        for (int i = 0; i < reference.Length; i++)
+            Assert.True(Math.Abs(reference[i] - hostOut[i]) < 1e-4f,
+                $"forward[{i}] cpu={reference[i]} host={hostOut[i]}");
+    }
+
+    private static float[] F(Tensor<float> t) => (float[])(object)t.GetDataArray()!;
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Rwkv4WkvTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Rwkv4WkvTests.cs
@@ -1,0 +1,143 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Correctness tests for the fused RWKV-4 WKV sequence kernel
+/// (<see cref="CpuEngine.Rwkv4WkvForward{T}"/>, issue ooples/AiDotNet#1464).
+/// The forward is checked against an independent numerically-stable reference recurrence,
+/// and the custom autodiff backward is checked against central finite differences of sum(output)
+/// for every input (R, K, V, timeDecay, timeFirst).
+/// </summary>
+public class Rwkv4WkvTests
+{
+    private static double Sigmoid(double x) => 1.0 / (1.0 + Math.Exp(-x));
+
+    /// <summary>Independent reference: per-channel numerically-stable RWKV-4 WKV recurrence.</summary>
+    private static double[] ReferenceForward(
+        double[] R, double[] K, double[] V, double[] timeDecay, double[] timeFirst,
+        int batch, int seqLen, int modelDim)
+    {
+        var outp = new double[R.Length];
+        for (int b = 0; b < batch; b++)
+            for (int c = 0; c < modelDim; c++)
+            {
+                double w = -Math.Exp(timeDecay[c]);
+                double u = timeFirst[c];
+                double aa = 0.0, bb = 0.0, pp = double.NegativeInfinity;
+                for (int t = 0; t < seqLen; t++)
+                {
+                    int off = (b * seqLen + t) * modelDim + c;
+                    double k = K[off], v = V[off];
+                    double ww = u + k;
+                    double q = Math.Max(pp, ww);
+                    double e1 = Math.Exp(pp - q);
+                    double e2 = Math.Exp(ww - q);
+                    outp[off] = Sigmoid(R[off]) * (e1 * aa + e2 * v) / (e1 * bb + e2);
+
+                    double ww2 = pp + w;
+                    double q2 = Math.Max(ww2, k);
+                    double e1b = Math.Exp(ww2 - q2);
+                    double e2b = Math.Exp(k - q2);
+                    aa = e1b * aa + e2b * v;
+                    bb = e1b * bb + e2b;
+                    pp = q2;
+                }
+            }
+        return outp;
+    }
+
+    private static double[] Gen(int n, int s)
+    {
+        var arr = new double[n];
+        for (int i = 0; i < n; i++)
+            arr[i] = Math.Sin(0.7 * (i + 1) + 1.3 * s) * 0.9;
+        return arr;
+    }
+
+    private static (Tensor<double> r, Tensor<double> k, Tensor<double> v, Tensor<double> td, Tensor<double> tf)
+        MakeInputs(int batch, int seqLen, int modelDim, int seed)
+    {
+        int n = batch * seqLen * modelDim;
+        var shape = new[] { batch, seqLen, modelDim };
+        return (new Tensor<double>(Gen(n, seed), shape),
+                new Tensor<double>(Gen(n, seed + 1), shape),
+                new Tensor<double>(Gen(n, seed + 2), shape),
+                new Tensor<double>(Gen(modelDim, seed + 3), new[] { modelDim }),
+                new Tensor<double>(Gen(modelDim, seed + 4), new[] { modelDim }));
+    }
+
+    [Fact]
+    public void Forward_MatchesReferenceRecurrence()
+    {
+        var engine = new CpuEngine();
+        int batch = 2, seqLen = 5, modelDim = 6;
+        var (r, k, v, td, tf) = MakeInputs(batch, seqLen, modelDim, 10);
+
+        var outp = engine.Rwkv4WkvForward(r, k, v, td, tf);
+        var expected = ReferenceForward(
+            (double[])(object)r.GetDataArray()!, (double[])(object)k.GetDataArray()!,
+            (double[])(object)v.GetDataArray()!, (double[])(object)td.GetDataArray()!,
+            (double[])(object)tf.GetDataArray()!, batch, seqLen, modelDim);
+
+        var got = (double[])(object)outp.GetDataArray()!;
+        for (int i = 0; i < expected.Length; i++)
+            Assert.True(Math.Abs(got[i] - expected[i]) < 1e-10,
+                $"Forward[{i}] = {got[i]} vs reference {expected[i]}");
+    }
+
+    [Fact]
+    public void Backward_MatchesFiniteDifferences()
+    {
+        var engine = new CpuEngine();
+        int batch = 1, seqLen = 4, modelDim = 4;
+        var (r, k, v, td, tf) = MakeInputs(batch, seqLen, modelDim, 3);
+
+        Tensor<double> outp;
+        System.Collections.Generic.Dictionary<Tensor<double>, Tensor<double>> grads;
+        using (var tape = new GradientTape<double>())
+        {
+            outp = engine.Rwkv4WkvForward(r, k, v, td, tf);
+            grads = tape.ComputeGradients(outp, new[] { r, k, v, td, tf });
+        }
+
+        const double eps = 1e-6;
+        var inputs = new[] { r, k, v, td, tf };
+        foreach (var x in inputs)
+        {
+            var data = (double[])(object)x.GetDataArray()!;
+            var grad = grads[x];
+            for (int i = 0; i < data.Length; i++)
+            {
+                double orig = data[i];
+                data[i] = orig + eps;
+                double sumPlus = SumForward(engine, r, k, v, td, tf);
+                data[i] = orig - eps;
+                double sumMinus = SumForward(engine, r, k, v, td, tf);
+                data[i] = orig;
+                double numeric = (sumPlus - sumMinus) / (2.0 * eps);
+                double analytic = grad.GetFlat(i);
+                // Combined absolute + relative tolerance: the WKV ratio can produce
+                // larger gradients on timeDecay/timeFirst than the elementwise streams.
+                double tol = 1e-5 + 1e-4 * Math.Abs(analytic);
+                Assert.True(Math.Abs(numeric - analytic) < tol,
+                    $"grad mismatch at element {i}: analytic={analytic}, finite-diff={numeric}");
+            }
+        }
+    }
+
+    private static double SumForward(
+        CpuEngine engine, Tensor<double> r, Tensor<double> k, Tensor<double> v,
+        Tensor<double> td, Tensor<double> tf)
+    {
+        var outp = engine.Rwkv4WkvForward(r, k, v, td, tf);
+        var data = (double[])(object)outp.GetDataArray()!;
+        double s = 0.0;
+        for (int i = 0; i < data.Length; i++) s += data[i];
+        return s;
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/XLstmScanGpuParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/XLstmScanGpuParityTests.cs
@@ -1,0 +1,107 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.DirectGpu.Cpu;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Parity tests for the GPU xLSTM scan path (#1464): the shared
+/// <see cref="RecurrenceCpuKernels"/> host reference (used by the Metal/Vulkan/WebGpu fallback)
+/// must match the differentiable <see cref="CpuEngine.XLstmScanForward{T}"/> exactly.
+/// </summary>
+public class XLstmScanGpuParityTests
+{
+    private static float[] Gen(int n, int s, float scale = 0.35f)
+    {
+        var a = new float[n];
+        for (int i = 0; i < n; i++) a[i] = (float)(Math.Sin(0.5 * (i + 1) + 1.5 * s) * scale);
+        return a;
+    }
+    private static float[] GenExp(int n, int s)
+    {
+        var a = new float[n];
+        for (int i = 0; i < n; i++) a[i] = (float)Math.Exp(0.3 * Math.Sin(0.5 * (i + 1) + 1.5 * s));
+        return a;
+    }
+    private static float[] GenSig(int n, int s)
+    {
+        var a = new float[n];
+        for (int i = 0; i < n; i++) a[i] = (float)(1.0 / (1.0 + Math.Exp(-Math.Sin(0.5 * (i + 1) + 1.5 * s))));
+        return a;
+    }
+
+    [Fact]
+    public void HostReferenceForward_MatchesCpuEngine()
+    {
+        var engine = new CpuEngine();
+        int batch = 2, seqLen = 5, modelDim = 6, numHeads = 2;
+        var shape = new[] { batch, seqLen, modelDim };
+        var gShape = new[] { batch, seqLen, numHeads };
+        var q = new Tensor<float>(Gen(batch * seqLen * modelDim, 1), shape);
+        var k = new Tensor<float>(Gen(batch * seqLen * modelDim, 2), shape);
+        var v = new Tensor<float>(Gen(batch * seqLen * modelDim, 3), shape);
+        var ig = new Tensor<float>(GenExp(batch * seqLen * numHeads, 4), gShape);
+        var fg = new Tensor<float>(GenSig(batch * seqLen * numHeads, 5), gShape);
+        var og = new Tensor<float>(GenSig(batch * seqLen * numHeads, 6), gShape);
+
+        var reference = (float[])(object)engine.XLstmScanForward(q, k, v, ig, fg, og, numHeads).GetDataArray()!;
+        var hostOut = new float[batch * seqLen * modelDim];
+        RecurrenceCpuKernels.XLstmForward(
+            F(q), F(k), F(v), F(ig), F(fg), F(og), hostOut,
+            batch, seqLen, modelDim, numHeads, modelDim / numHeads);
+
+        for (int i = 0; i < reference.Length; i++)
+            Assert.True(Math.Abs(reference[i] - hostOut[i]) < 1e-4f,
+                $"forward[{i}] cpu={reference[i]} host={hostOut[i]}");
+    }
+
+    [Fact]
+    public void HostReferenceBackward_MatchesCpuEngineTapeGradients()
+    {
+        var engine = new CpuEngine();
+        int batch = 1, seqLen = 4, modelDim = 4, numHeads = 2;
+        var shape = new[] { batch, seqLen, modelDim };
+        var gShape = new[] { batch, seqLen, numHeads };
+        var q = new Tensor<float>(Gen(batch * seqLen * modelDim, 1), shape);
+        var k = new Tensor<float>(Gen(batch * seqLen * modelDim, 2), shape);
+        var v = new Tensor<float>(Gen(batch * seqLen * modelDim, 3), shape);
+        var ig = new Tensor<float>(GenExp(batch * seqLen * numHeads, 4), gShape);
+        var fg = new Tensor<float>(GenSig(batch * seqLen * numHeads, 5), gShape);
+        var og = new Tensor<float>(GenSig(batch * seqLen * numHeads, 6), gShape);
+
+        System.Collections.Generic.Dictionary<Tensor<float>, Tensor<float>> grads;
+        using (var tape = new GradientTape<float>())
+        {
+            var outp = engine.XLstmScanForward(q, k, v, ig, fg, og, numHeads);
+            grads = tape.ComputeGradients(outp, new[] { q, k, v, ig, fg, og });
+        }
+
+        var dOut = new float[batch * seqLen * modelDim];
+        for (int i = 0; i < dOut.Length; i++) dOut[i] = 1.0f;
+        var dq = new float[batch * seqLen * modelDim];
+        var dk = new float[batch * seqLen * modelDim];
+        var dv = new float[batch * seqLen * modelDim];
+        var di = new float[batch * seqLen * numHeads];
+        var df = new float[batch * seqLen * numHeads];
+        var dO = new float[batch * seqLen * numHeads];
+        RecurrenceCpuKernels.XLstmBackward(
+            dOut, F(q), F(k), F(v), F(ig), F(fg), F(og), dq, dk, dv, di, df, dO,
+            batch, seqLen, modelDim, numHeads, modelDim / numHeads);
+
+        Match(grads[q], dq, "dQ"); Match(grads[k], dk, "dK"); Match(grads[v], dv, "dV");
+        Match(grads[ig], di, "dI"); Match(grads[fg], df, "dF"); Match(grads[og], dO, "dO");
+    }
+
+    private static float[] F(Tensor<float> t) => (float[])(object)t.GetDataArray()!;
+
+    private static void Match(Tensor<float> expected, float[] actual, string name)
+    {
+        var e = (float[])(object)expected.GetDataArray()!;
+        Assert.Equal(e.Length, actual.Length);
+        for (int i = 0; i < e.Length; i++)
+            Assert.True(Math.Abs(e[i] - actual[i]) < 1e-3f, $"{name}[{i}] tape={e[i]} host={actual[i]}");
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/XLstmScanTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/XLstmScanTests.cs
@@ -1,0 +1,156 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Correctness tests for the fused xLSTM (mLSTM) scan kernel
+/// (<see cref="CpuEngine.XLstmScanForward{T}"/>, issue ooples/AiDotNet#1464).
+/// Forward is checked against an independent reference; the custom autodiff backward is checked
+/// against central finite differences of sum(output) for every input.
+/// </summary>
+public class XLstmScanTests
+{
+    private static double[] ReferenceForward(
+        double[] Q, double[] K, double[] V, double[] I, double[] F, double[] O,
+        int batch, int seqLen, int modelDim, int numHeads)
+    {
+        int headDim = modelDim / numHeads;
+        double kappa = 1.0 / Math.Sqrt(headDim);
+        var outp = new double[Q.Length];
+        var C = new double[headDim * headDim];
+        var n = new double[headDim];
+        for (int b = 0; b < batch; b++)
+            for (int h = 0; h < numHeads; h++)
+            {
+                Array.Clear(C, 0, C.Length); Array.Clear(n, 0, n.Length);
+                int hOff = h * headDim;
+                for (int t = 0; t < seqLen; t++)
+                {
+                    int off = (b * seqLen + t) * modelDim + hOff;
+                    double iv = I[off]; if (iv > 4.85e8) iv = 4.85e8;
+                    double f = F[off], o = O[off];
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        n[di] = f * n[di] + iv * (K[off + di] * kappa);
+                        double vv = V[off + di];
+                        for (int ki = 0; ki < headDim; ki++)
+                            C[di * headDim + ki] = f * C[di * headDim + ki] + iv * vv * (K[off + ki] * kappa);
+                    }
+                    double nq = 0.0;
+                    for (int j = 0; j < headDim; j++) nq += n[j] * Q[off + j];
+                    double nf = Math.Max(Math.Abs(nq), 1.0);
+                    for (int di = 0; di < headDim; di++)
+                    {
+                        double num = 0.0;
+                        for (int ki = 0; ki < headDim; ki++) num += C[di * headDim + ki] * Q[off + ki];
+                        outp[off + di] = o * num / nf;
+                    }
+                }
+            }
+        return outp;
+    }
+
+    private static double[] Gen(int n, int s, double scale = 0.35)
+    {
+        var arr = new double[n];
+        for (int i = 0; i < n; i++) arr[i] = Math.Sin(0.5 * (i + 1) + 1.5 * s) * scale;
+        return arr;
+    }
+
+    // i = exp(small), f/o = sigmoid.
+    private static double[] GenExp(int n, int s)
+    {
+        var arr = new double[n];
+        for (int i = 0; i < n; i++) arr[i] = Math.Exp(0.3 * Math.Sin(0.5 * (i + 1) + 1.5 * s));
+        return arr;
+    }
+    private static double[] GenSig(int n, int s)
+    {
+        var arr = new double[n];
+        for (int i = 0; i < n; i++) arr[i] = 1.0 / (1.0 + Math.Exp(-Math.Sin(0.5 * (i + 1) + 1.5 * s)));
+        return arr;
+    }
+
+    private static (Tensor<double> q, Tensor<double> k, Tensor<double> v,
+                    Tensor<double> i, Tensor<double> f, Tensor<double> o)
+        MakeInputs(int batch, int seqLen, int modelDim, int seed)
+    {
+        int n = batch * seqLen * modelDim;
+        var shape = new[] { batch, seqLen, modelDim };
+        return (new Tensor<double>(Gen(n, seed), shape), new Tensor<double>(Gen(n, seed + 1), shape),
+                new Tensor<double>(Gen(n, seed + 2), shape), new Tensor<double>(GenExp(n, seed + 3), shape),
+                new Tensor<double>(GenSig(n, seed + 4), shape), new Tensor<double>(GenSig(n, seed + 5), shape));
+    }
+
+    [Fact]
+    public void Forward_MatchesReference()
+    {
+        var engine = new CpuEngine();
+        int batch = 2, seqLen = 5, modelDim = 6, numHeads = 2;
+        var (q, k, v, i, f, o) = MakeInputs(batch, seqLen, modelDim, 17);
+
+        var outp = engine.XLstmScanForward(q, k, v, i, f, o, numHeads);
+        var expected = ReferenceForward(
+            (double[])(object)q.GetDataArray()!, (double[])(object)k.GetDataArray()!,
+            (double[])(object)v.GetDataArray()!, (double[])(object)i.GetDataArray()!,
+            (double[])(object)f.GetDataArray()!, (double[])(object)o.GetDataArray()!,
+            batch, seqLen, modelDim, numHeads);
+
+        var got = (double[])(object)outp.GetDataArray()!;
+        for (int idx = 0; idx < expected.Length; idx++)
+            Assert.True(Math.Abs(got[idx] - expected[idx]) < 1e-10,
+                $"Forward[{idx}] = {got[idx]} vs reference {expected[idx]}");
+    }
+
+    [Fact]
+    public void Backward_MatchesFiniteDifferences()
+    {
+        var engine = new CpuEngine();
+        int batch = 1, seqLen = 4, modelDim = 4, numHeads = 2;
+        var (q, k, v, i, f, o) = MakeInputs(batch, seqLen, modelDim, 8);
+
+        Tensor<double> outp;
+        System.Collections.Generic.Dictionary<Tensor<double>, Tensor<double>> grads;
+        using (var tape = new GradientTape<double>())
+        {
+            outp = engine.XLstmScanForward(q, k, v, i, f, o, numHeads);
+            grads = tape.ComputeGradients(outp, new[] { q, k, v, i, f, o });
+        }
+
+        const double eps = 1e-6;
+        foreach (var input in new[] { q, k, v, i, f, o })
+        {
+            var data = (double[])(object)input.GetDataArray()!;
+            var grad = grads[input];
+            for (int idx = 0; idx < data.Length; idx++)
+            {
+                double orig = data[idx];
+                data[idx] = orig + eps;
+                double sp = SumForward(engine, q, k, v, i, f, o, numHeads);
+                data[idx] = orig - eps;
+                double sm = SumForward(engine, q, k, v, i, f, o, numHeads);
+                data[idx] = orig;
+                double numeric = (sp - sm) / (2.0 * eps);
+                double analytic = grad.GetFlat(idx);
+                double tol = 1e-5 + 2e-4 * Math.Abs(analytic);
+                Assert.True(Math.Abs(numeric - analytic) < tol,
+                    $"grad mismatch at element {idx}: analytic={analytic}, finite-diff={numeric}");
+            }
+        }
+    }
+
+    private static double SumForward(
+        CpuEngine engine, Tensor<double> q, Tensor<double> k, Tensor<double> v,
+        Tensor<double> i, Tensor<double> f, Tensor<double> o, int numHeads)
+    {
+        var outp = engine.XLstmScanForward(q, k, v, i, f, o, numHeads);
+        var data = (double[])(object)outp.GetDataArray()!;
+        double s = 0.0;
+        for (int idx = 0; idx < data.Length; idx++) s += data[idx];
+        return s;
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/XLstmScanTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/XLstmScanTests.cs
@@ -31,8 +31,9 @@ public class XLstmScanTests
                 for (int t = 0; t < seqLen; t++)
                 {
                     int off = (b * seqLen + t) * modelDim + hOff;
-                    double iv = I[off]; if (iv > 4.85e8) iv = 4.85e8;
-                    double f = F[off], o = O[off];
+                    int gOff = (b * seqLen + t) * numHeads + h; // scalar-per-head gates
+                    double iv = I[gOff]; if (iv > 4.85e8) iv = 4.85e8;
+                    double f = F[gOff], o = O[gOff];
                     for (int di = 0; di < headDim; di++)
                     {
                         n[di] = f * n[di] + iv * (K[off + di] * kappa);
@@ -77,13 +78,16 @@ public class XLstmScanTests
 
     private static (Tensor<double> q, Tensor<double> k, Tensor<double> v,
                     Tensor<double> i, Tensor<double> f, Tensor<double> o)
-        MakeInputs(int batch, int seqLen, int modelDim, int seed)
+        MakeInputs(int batch, int seqLen, int modelDim, int numHeads, int seed)
     {
         int n = batch * seqLen * modelDim;
         var shape = new[] { batch, seqLen, modelDim };
+        // Gates are scalar-per-head: [batch, seqLen, numHeads].
+        int gn = batch * seqLen * numHeads;
+        var gShape = new[] { batch, seqLen, numHeads };
         return (new Tensor<double>(Gen(n, seed), shape), new Tensor<double>(Gen(n, seed + 1), shape),
-                new Tensor<double>(Gen(n, seed + 2), shape), new Tensor<double>(GenExp(n, seed + 3), shape),
-                new Tensor<double>(GenSig(n, seed + 4), shape), new Tensor<double>(GenSig(n, seed + 5), shape));
+                new Tensor<double>(Gen(n, seed + 2), shape), new Tensor<double>(GenExp(gn, seed + 3), gShape),
+                new Tensor<double>(GenSig(gn, seed + 4), gShape), new Tensor<double>(GenSig(gn, seed + 5), gShape));
     }
 
     [Fact]
@@ -91,7 +95,7 @@ public class XLstmScanTests
     {
         var engine = new CpuEngine();
         int batch = 2, seqLen = 5, modelDim = 6, numHeads = 2;
-        var (q, k, v, i, f, o) = MakeInputs(batch, seqLen, modelDim, 17);
+        var (q, k, v, i, f, o) = MakeInputs(batch, seqLen, modelDim, numHeads, 17);
 
         var outp = engine.XLstmScanForward(q, k, v, i, f, o, numHeads);
         var expected = ReferenceForward(
@@ -111,7 +115,7 @@ public class XLstmScanTests
     {
         var engine = new CpuEngine();
         int batch = 1, seqLen = 4, modelDim = 4, numHeads = 2;
-        var (q, k, v, i, f, o) = MakeInputs(batch, seqLen, modelDim, 8);
+        var (q, k, v, i, f, o) = MakeInputs(batch, seqLen, modelDim, numHeads, 8);
 
         Tensor<double> outp;
         System.Collections.Generic.Dictionary<Tensor<double>, Tensor<double>> grads;


### PR DESCRIPTION
## Summary

Eight fused CPU engine kernels (forward + custom analytic BPTT backward, each recording a single autodiff tape node) that eliminate the per-timestep tape-op overhead which dominated paper-scale recurrent LM training (ooples/AiDotNet#1464). The decomposed per-timestep recurrences recorded ~1500 tiny tape nodes/layer, with the tape-replay backward as the bottleneck (RWKV-4 ~3.5s/step; MambaBlock ~640ms/block forward). Four recurrences were also computed with detached raw `NumOps` (no tape) — a latent gradient bug these fused ops fix on top of the perf.

## Kernels

Each ships: `IEngine` declaration, `CpuEngine.<Op>.cs` (double fast-path + generic-T), `OpRegistry` differentiable-op entry, and a gradient-checked test.

| Op | Recurrence | Consumed by (AiDotNet) |
|----|-----------|------------------------|
| `Rwkv4WkvForward` | RWKV-4 running-max WKV | RWKVLayer (RWKV4/Eagle/Finch) |
| `MambaSelectiveScanForward` | selective SSM scan | S6Scan (Mamba/FalconMamba/Jamba/Samba/Zamba) |
| `RgLruScanForward` | real gated linear recurrence | RealGatedLinearRecurrenceLayer (Griffin/Hawk/RecurrentGemma) |
| `GlaScanForward` | gated linear attention (matrix state) | GatedLinearAttentionLayer |
| `GatedDeltaNetScanForward` | delta rule | GatedDeltaNetLayer |
| `XLstmScanForward` | mLSTM matrix cell + normalizer | ExtendedLSTMLayer |
| `Mamba2SsdScanForward` | Mamba-2 SSD scan | Mamba2Block (Mamba2/Zamba2) |
| `FusedLinearCrossEntropyWithLogits` | LM head GEMM + CE, no materialized [N,vocab] logits on tape | paper-scale LM-head loss path |

## Verification

Each kernel's test asserts (1) forward matches an independent reference (`< 1e-10`) and (2) the analytic backward matches central finite differences of the output sum for **every** input. 16/16 kernel tests pass on **net10.0 and net471**.

## Impact (measured in the consuming repo)

Wiring the 7 recurrence kernels into the AiDotNet layers takes the recurrent LM families from timing out to passing their training-trajectory invariants at **full paper-faithful iteration counts** (RWKV-4 ~3.5s → ~0.36s/step, ~10x). The fused LM-head+CE kernel targets the residual huge-vocab (256000) head cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
