### PR TITLE
perf: MaxPool2DInto small-batch serial gate (skip parallel-dispatch overhead at bs1)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -7660,7 +7660,15 @@ public partial class CpuEngine : ITensorLevelEngine
             int hw = h * w;
             int ohow = oH * oW;
 
-            if (bc >= CpuParallelSettings.MaxDegreeOfParallelism)
+            // Only take the parallel (delegate + closure) path when there is enough
+            // total work to amortize its fixed dispatch cost. At small batch the pooled
+            // tensor (e.g. bs1: 16ch × 14² = 12 544 < grain) would otherwise route through
+            // ParallelForOrSerial, run *serial anyway* (work < grain), yet still pay the
+            // closure alloc + per-channel delegate dispatch — measured ~25 µs of pure
+            // overhead on top of a ~19 µs kernel. Below the grain the direct serial inline
+            // below is the fast path (no closure, fully JIT-optimized inner loop).
+            if (bc >= CpuParallelSettings.MaxDegreeOfParallelism
+                && (long)bc * hw >= PersistentParallelExecutor.DefaultSerialGrainSize)
             {
                 CpuParallelSettings.ParallelForOrSerial(0, bc, (long)bc * hw, idx =>
                 {
@@ -7731,7 +7739,15 @@ public partial class CpuEngine : ITensorLevelEngine
             int hw = h * w;
             int ohow = oH * oW;
 
-            if (bc >= CpuParallelSettings.MaxDegreeOfParallelism)
+            // Only take the parallel (delegate + closure) path when there is enough
+            // total work to amortize its fixed dispatch cost. At small batch the pooled
+            // tensor (e.g. bs1: 16ch × 14² = 12 544 < grain) would otherwise route through
+            // ParallelForOrSerial, run *serial anyway* (work < grain), yet still pay the
+            // closure alloc + per-channel delegate dispatch — measured ~25 µs of pure
+            // overhead on top of a ~19 µs kernel. Below the grain the direct serial inline
+            // below is the fast path (no closure, fully JIT-optimized inner loop).
+            if (bc >= CpuParallelSettings.MaxDegreeOfParallelism
+                && (long)bc * hw >= PersistentParallelExecutor.DefaultSerialGrainSize)
             {
                 CpuParallelSettings.ParallelForOrSerial(0, bc, (long)bc * hw, idx =>
                 {
@@ -7889,7 +7905,15 @@ public partial class CpuEngine : ITensorLevelEngine
                 }
             }
 
-            if (bc >= CpuParallelSettings.MaxDegreeOfParallelism)
+            // Only take the parallel (delegate + closure) path when there is enough
+            // total work to amortize its fixed dispatch cost. At small batch the pooled
+            // tensor (e.g. bs1: 16ch × 14² = 12 544 < grain) would otherwise route through
+            // ParallelForOrSerial, run *serial anyway* (work < grain), yet still pay the
+            // closure alloc + per-channel delegate dispatch — measured ~25 µs of pure
+            // overhead on top of a ~19 µs kernel. Below the grain the direct serial inline
+            // below is the fast path (no closure, fully JIT-optimized inner loop).
+            if (bc >= CpuParallelSettings.MaxDegreeOfParallelism
+                && (long)bc * hw >= PersistentParallelExecutor.DefaultSerialGrainSize)
             {
                 CpuParallelSettings.ParallelForOrSerial(0, bc, (long)bc * hw, idx =>
                 {

--- a/tests/AiDotNet.Tensors.Tests/Engines/MaxPool2DIntoSerialGateTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/MaxPool2DIntoSerialGateTests.cs
@@ -22,13 +22,14 @@ public class MaxPool2DIntoSerialGateTests
 
     public static TheoryData<int, int, int, int, int, int> Cases => new()
     {
-        // batch, channels, H, W, poolSize, padding  (stride = poolSize)
-        { 1,  16, 28, 28, 2, 0 },    // bs1 below-grain → must hit fast serial inline (the fix)
-        { 1,  32, 14, 14, 2, 0 },    // bs1 pool2
-        { 4,  16, 28, 28, 2, 0 },    // bc=64 ≥ MaxDOP but below grain → fast serial
-        { 128,16, 28, 28, 2, 0 },    // above grain → parallel path
-        { 1,  16, 28, 28, 3, 0 },    // 3×3 NoPad bs1
-        { 64, 16, 28, 28, 3, 0 },    // 3×3 NoPad above grain
+        // batch, channels, H, W, poolSize, padding  (stride = poolSize). Grain = 32768;
+        // "below grain" = bc*hw < grain → fast direct-serial inline (the fix's target path).
+        { 1,  16, 28, 28, 2, 0 },    // bc*hw=12544 < grain → serial inline (the fix)
+        { 1,  32, 14, 14, 2, 0 },    // bc*hw=6272 < grain, bc=32 ≥ MaxDOP → the gate-boundary case the fix re-routes to serial
+        { 4,  16, 28, 28, 2, 0 },    // bc*hw=50176 ≥ grain → parallel path
+        { 128,16, 28, 28, 2, 0 },    // bc*hw=1605632 ≥ grain → parallel path
+        { 1,  16, 28, 28, 3, 0 },    // 3×3 NoPad, bc*hw=12544 < grain → serial inline
+        { 64, 16, 28, 28, 3, 0 },    // 3×3 NoPad, bc*hw=802816 ≥ grain → parallel
         { 1,  16, 28, 28, 3, 1 },    // 3×3 padded (border path)
         { 1,  16, 28, 28, 4, 1 },    // generic (4×4, padded)
         { 128, 8, 16, 16, 2, 0 },    // parallel 2×2

--- a/tests/AiDotNet.Tensors.Tests/Engines/MaxPool2DIntoSerialGateTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/MaxPool2DIntoSerialGateTests.cs
@@ -1,0 +1,92 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Guards the small-batch serial-gate fix in the float MaxPool2DInto kernels
+/// (2×2 / 3×3 NoPad + Generic). The gate now requires <c>bc*hw ≥ grain</c> before
+/// taking the parallel (closure + delegate) path, so small-batch pools (e.g. bs1:
+/// 16ch × 14² = 12 544 &lt; grain) take the fast direct-serial inline path instead of
+/// paying ~25 µs of dispatch overhead to run serial anyway. The gate change only
+/// alters serial-vs-parallel routing, so output must stay BIT-IDENTICAL to the
+/// allocating <c>MaxPool2D</c> reference across every batch on both sides of the gate.
+/// </summary>
+public class MaxPool2DIntoSerialGateTests
+{
+    private readonly ITestOutputHelper _output;
+    public MaxPool2DIntoSerialGateTests(ITestOutputHelper output) => _output = output;
+
+    public static TheoryData<int, int, int, int, int, int> Cases => new()
+    {
+        // batch, channels, H, W, poolSize, padding  (stride = poolSize)
+        { 1,  16, 28, 28, 2, 0 },    // bs1 below-grain → must hit fast serial inline (the fix)
+        { 1,  32, 14, 14, 2, 0 },    // bs1 pool2
+        { 4,  16, 28, 28, 2, 0 },    // bc=64 ≥ MaxDOP but below grain → fast serial
+        { 128,16, 28, 28, 2, 0 },    // above grain → parallel path
+        { 1,  16, 28, 28, 3, 0 },    // 3×3 NoPad bs1
+        { 64, 16, 28, 28, 3, 0 },    // 3×3 NoPad above grain
+        { 1,  16, 28, 28, 3, 1 },    // 3×3 padded (border path)
+        { 1,  16, 28, 28, 4, 1 },    // generic (4×4, padded)
+        { 128, 8, 16, 16, 2, 0 },    // parallel 2×2
+    };
+
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public void MaxPool2DInto_MatchesAllocatingReference_AcrossGateBoundary(
+        int batch, int channels, int h, int w, int poolSize, int padding)
+    {
+        var e = new CpuEngine();
+        int stride = poolSize;
+        var input = Rand(new[] { batch, channels, h, w }, 1234);
+
+        // Reference: the allocating MaxPool2D (independent code path).
+        var reference = e.MaxPool2D(input, poolSize, stride, padding);
+        var into = new Tensor<float>(reference.Shape.ToArray());
+        e.MaxPool2DInto(into, input, poolSize, stride, padding);
+
+        var rSpan = reference.AsSpan();
+        var iSpan = into.AsSpan();
+        Assert.Equal(rSpan.Length, iSpan.Length);
+        for (int idx = 0; idx < rSpan.Length; idx++)
+            Assert.Equal(rSpan[idx], iSpan[idx]);   // bit-exact: same kernel math, only routing differs
+    }
+
+    /// <summary>Env-gated latency check: the bs1 pool should no longer pay the parallel
+    /// dispatch overhead. (AIDOTNET_RUN_JIT_PERF=1)</summary>
+    [Fact]
+    public void MaxPool2DInto_Bs1_LatencyProbe()
+    {
+        if (Environment.GetEnvironmentVariable("AIDOTNET_RUN_JIT_PERF") != "1") return;
+        var e = new CpuEngine();
+        // The two bs1 pools in the parity CNN stem (conv1→pool1, conv2→pool2).
+        Probe(e, "pool1 bs1 16ch×28²→14²", new[] { 1, 16, 28, 28 }, new[] { 1, 16, 14, 14 });
+        Probe(e, "pool2 bs1 32ch×14²→7²", new[] { 1, 32, 14, 14 }, new[] { 1, 32, 7, 7 });
+    }
+
+    private void Probe(CpuEngine e, string label, int[] inShape, int[] outShape)
+    {
+        var input = Rand(inShape, 7);
+        var into = new Tensor<float>(outShape);
+        for (int i = 0; i < 50; i++) e.MaxPool2DInto(into, input, 2, 2);
+        double best = double.MaxValue;
+        for (int r = 0; r < 400; r++)
+        {
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            e.MaxPool2DInto(into, input, 2, 2);
+            sw.Stop();
+            best = Math.Min(best, sw.Elapsed.TotalMilliseconds);
+        }
+        _output.WriteLine($"MaxPool2DInto {label}: {best*1000:F2} us (best-of-400)");
+    }
+
+    private static Tensor<float> Rand(int[] shape, int seed)
+    {
+        var rng = new Random(seed); var t = new Tensor<float>(shape); var s = t.AsWritableSpan();
+        for (int i = 0; i < s.Length; i++) s[i] = (float)(rng.NextDouble() - 0.5);
+        return t;
+    }
+}


### PR DESCRIPTION
@
## Summary

Profiling the parity CNN inference stem (the non-conv path) surfaced an anomaly: at **bs1, `pool1` MaxPool2DInto = ~44 µs — *more than* conv1 (~37 µs)** despite doing ~100× less work. The cost was **constant across machine load** — the signature of a fixed per-call dispatch overhead, not compute.

### Root cause
The three float `MaxPool2DInto` kernels (2×2 / 3×3 NoPad + Generic) gated the parallel path on **channel count alone** (`bc >= MaxDegreeOfParallelism`). At small batch the pooled tensor is below the parallel grain (bs1: 16ch × 14² = 12 544 < 32 768 `DefaultSerialGrainSize`), so it routed through `ParallelForOrSerial`, ran **serial anyway**, yet still paid the closure allocation + per-channel delegate dispatch — ~25 µs of pure overhead on top of a ~19 µs kernel.

### Fix
Require `bc*hw >= DefaultSerialGrainSize` before taking the parallel branch. Below the grain the existing **direct-serial inline** path (no closure, fully JIT-optimized inner loop) handles it. Output is **bit-identical** — only serial-vs-parallel routing changes. The above-grain (bs128, memory-bound) path is unchanged.

## Measured (bs1, best-of-400)
| pool | before | after | Δ |
|---|---|---|---|
| pool1 16ch×28²→14² | 44.1 µs | 18.6 µs | −25 µs |
| pool2 32ch×14²→7² | 18.7 µs | 11.7 µs | −7 µs |

≈ **32 µs off the parity CNN bs1 Predict** (~272 µs → ~240 µs), closing the CNN-vs-`torch.compile` gap on the non-conv path. (im2col+SimdGemm conv was already shown to be at the managed-CPU ceiling — direct conv loses 2–7×; the remaining headroom was here.)

## Tests
`MaxPool2DIntoSerialGateTests` — 9 bit-exact-vs-allocating-`MaxPool2D` cases across the gate boundary (bs1/bs4/bs128, 2×2/3×3/padded/generic) on **net10.0 + net471** (10/10 pass both), plus an env-gated latency probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@