### PR TITLE
perf(#403): channel-parallel strided im2col build in Conv2DBackwardKernel

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -13711,6 +13711,104 @@ public partial class CpuEngine : ITensorLevelEngine
         }
     }
 
+    // #403 Phase F: maximum colW (= outputH·outputW) at which the K-concat
+    // im2col build is parallelized over input channels. At small colW each
+    // im2col row is a tiny scattered strided write, so building channels in
+    // parallel hides the cache-miss latency (DCGAN colW=49 → ~74µs→35µs). At
+    // large colW each row is a big contiguous copy and the build is memory-
+    // bandwidth-bound: extra cores only add dispatch overhead, so those build
+    // serially per batch (a perf-guard at colW=900 regressed under an
+    // unconditional channel-parallel build).
+    private const int ParallelIm2colMaxColW = 256;
+
+    // #403 Phase F: repack gradOutput + build the strided im2col for the K-concat
+    // backward-kernel path (float). gradOutAll[oc, b·colW+n] = gradOutput[b,oc,n];
+    // im2colAll[ki, b·colW+n] = im2col(input[b])[ki, n]. The im2col build is
+    // parallelized over input channels at small colW (each row is a tiny scattered
+    // strided write, so parallelism hides cache-miss latency) and built serially
+    // per batch at large colW (each row is a big contiguous copy → bandwidth-bound,
+    // extra cores only add dispatch overhead). Extracted so Conv2DBackwardKernel's
+    // hot GEMM path keeps its baseline codegen (the inline build bloated the method
+    // and regressed a small-shape perf guard).
+    private static void BuildKConcatStackFloat(
+        float[] gradOutputF, float[] inputF, float[] gradOutAll, float[] im2colAll,
+        int batch, int outChannels, int inChannels, int colW, int colH, int batchColW,
+        int inputSliceSize, int height, int width, int kernelHeight, int kernelWidth,
+        int strideH, int strideW, int padH, int padW, int dilationH, int dilationW,
+        int outputHeight, int outputWidth)
+    {
+        for (int b = 0; b < batch; b++)
+        {
+            int gradOutOff = b * outChannels * colW;
+            for (int oc = 0; oc < outChannels; oc++)
+                Array.Copy(gradOutputF, gradOutOff + oc * colW,
+                           gradOutAll, oc * batchColW + b * colW, colW);
+        }
+        if (colW <= ParallelIm2colMaxColW)
+        {
+            int kHW = kernelHeight * kernelWidth;
+            CpuParallelSettings.ParallelForOrSerial(
+                0, inChannels, (long)inChannels * batch * kHW * colW, c =>
+                {
+                    for (int b = 0; b < batch; b++)
+                        Helpers.Im2ColHelper.Im2ColStridedSingleChannelRange(
+                            new ReadOnlySpan<float>(inputF, b * inputSliceSize, inputSliceSize),
+                            new Span<float>(im2colAll, 0, colH * batchColW), batchColW, b * colW,
+                            c, c + 1, height, width, kernelHeight, kernelWidth,
+                            strideH, strideW, padH, padW, dilationH, dilationW, outputHeight, outputWidth);
+                });
+        }
+        else
+        {
+            for (int b = 0; b < batch; b++)
+                Helpers.Im2ColHelper.Im2ColStridedSingle(
+                    new ReadOnlySpan<float>(inputF, b * inputSliceSize, inputSliceSize),
+                    new Span<float>(im2colAll, 0, colH * batchColW), batchColW, b * colW,
+                    inChannels, height, width, kernelHeight, kernelWidth,
+                    strideH, strideW, padH, padW, dilationH, dilationW, outputHeight, outputWidth);
+        }
+    }
+
+    // #403 Phase F: double counterpart of <see cref="BuildKConcatStackFloat"/>.
+    private static void BuildKConcatStackDouble(
+        double[] gradOutputD, double[] inputD, double[] gradOutAll, double[] im2colAll,
+        int batch, int outChannels, int inChannels, int colW, int colH, int batchColW,
+        int inputSliceSize, int height, int width, int kernelHeight, int kernelWidth,
+        int strideH, int strideW, int padH, int padW, int dilationH, int dilationW,
+        int outputHeight, int outputWidth)
+    {
+        for (int b = 0; b < batch; b++)
+        {
+            int gradOutOff = b * outChannels * colW;
+            for (int oc = 0; oc < outChannels; oc++)
+                Array.Copy(gradOutputD, gradOutOff + oc * colW,
+                           gradOutAll, oc * batchColW + b * colW, colW);
+        }
+        if (colW <= ParallelIm2colMaxColW)
+        {
+            int kHW = kernelHeight * kernelWidth;
+            CpuParallelSettings.ParallelForOrSerial(
+                0, inChannels, (long)inChannels * batch * kHW * colW, c =>
+                {
+                    for (int b = 0; b < batch; b++)
+                        Helpers.Im2ColHelper.Im2ColStridedSingleChannelRange(
+                            new ReadOnlySpan<double>(inputD, b * inputSliceSize, inputSliceSize),
+                            new Span<double>(im2colAll, 0, colH * batchColW), batchColW, b * colW,
+                            c, c + 1, height, width, kernelHeight, kernelWidth,
+                            strideH, strideW, padH, padW, dilationH, dilationW, outputHeight, outputWidth);
+                });
+        }
+        else
+        {
+            for (int b = 0; b < batch; b++)
+                Helpers.Im2ColHelper.Im2ColStridedSingle(
+                    new ReadOnlySpan<double>(inputD, b * inputSliceSize, inputSliceSize),
+                    new Span<double>(im2colAll, 0, colH * batchColW), batchColW, b * colW,
+                    inChannels, height, width, kernelHeight, kernelWidth,
+                    strideH, strideW, padH, padW, dilationH, dilationW, outputHeight, outputWidth);
+        }
+    }
+
     /// <inheritdoc/>
     public Tensor<T> Conv2DBackwardKernel<T>(Tensor<T> gradOutput, Tensor<T> input, int[] kernelShape, int[] stride, int[] padding, int[] dilation)
     {
@@ -13775,22 +13873,13 @@ public partial class CpuEngine : ITensorLevelEngine
                 var im2colAll = kcPool.Rent(colH * batchColW);
                 try
                 {
-                    for (int b = 0; b < batch; b++)
-                    {
-                        int gradOutOff = b * outChannels * colW;
-                        for (int oc = 0; oc < outChannels; oc++)
-                            Array.Copy(gradOutputF, gradOutOff + oc * colW,
-                                       gradOutAll, oc * batchColW + b * colW, colW);
-
-                        // #403 Phase E: im2col directly into batch b's column block
-                        // (no per-batch temp + strided row-copies).
-                        Im2ColHelper.Im2ColStridedSingle(
-                            new ReadOnlySpan<float>(inputF, b * inputSliceSize, inputSliceSize),
-                            new Span<float>(im2colAll, 0, colH * batchColW), batchColW, b * colW,
-                            inChannels, height, width,
-                            kernelHeight, kernelWidth, strideH, strideW, padH, padW, dilationH, dilationW,
-                            outputHeight, outputWidth);
-                    }
+                    // #403 Phase F: repack gradOutput + build the strided im2col
+                    // (channel-parallel at small colW, serial at large colW).
+                    BuildKConcatStackFloat(
+                        gradOutputF, inputF, gradOutAll, im2colAll,
+                        batch, outChannels, inChannels, colW, colH, batchColW,
+                        inputSliceSize, height, width, kernelHeight, kernelWidth,
+                        strideH, strideW, padH, padW, dilationH, dilationW, outputHeight, outputWidth);
 
                     // gradKernel = gradOutAll @ im2colAll^T — one full-width GEMM.
                     if (!Helpers.BlasProvider.TryGemmEx(
@@ -14010,25 +14099,13 @@ public partial class CpuEngine : ITensorLevelEngine
                 var im2colAll = kcPool.Rent(colH * batchColW);
                 try
                 {
-                    for (int b = 0; b < batch; b++)
-                    {
-                        // gradOutAll[oc, b·colW + n] = gradOutput[b, oc, n]
-                        int gradOutOff = b * outChannels * colW;
-                        for (int oc = 0; oc < outChannels; oc++)
-                            Array.Copy(gradOutputD, gradOutOff + oc * colW,
-                                       gradOutAll, oc * batchColW + b * colW, colW);
-
-                        // #403 Phase E: im2col(input[b]) DIRECTLY into batch b's
-                        // column block of im2colAll (row stride batchColW, col
-                        // offset b·colW) — no per-batch temp buffer + no ~colH
-                        // strided row-copies.
-                        Helpers.Im2ColHelper.Im2ColStridedSingle(
-                            new ReadOnlySpan<double>(inputD, b * inputSliceSize, inputSliceSize),
-                            new Span<double>(im2colAll, 0, colH * batchColW), batchColW, b * colW,
-                            inChannels, height, width,
-                            kernelHeight, kernelWidth, strideH, strideW, padH, padW, dilationH, dilationW,
-                            outputHeight, outputWidth);
-                    }
+                    // #403 Phase F: repack gradOutput + build the strided im2col
+                    // (channel-parallel at small colW, serial at large colW).
+                    BuildKConcatStackDouble(
+                        gradOutputD, inputD, gradOutAll, im2colAll,
+                        batch, outChannels, inChannels, colW, colH, batchColW,
+                        inputSliceSize, height, width, kernelHeight, kernelWidth,
+                        strideH, strideW, padH, padW, dilationH, dilationW, outputHeight, outputWidth);
 
                     // gradKernel = gradOutAll @ im2colAll^T — one full-width GEMM.
                     if (Helpers.BlasProvider.TryGemmEx(

--- a/src/AiDotNet.Tensors/Helpers/Im2ColHelper.cs
+++ b/src/AiDotNet.Tensors/Helpers/Im2ColHelper.cs
@@ -739,15 +739,34 @@ internal static class Im2ColHelper
         int padH, int padW,
         int dilationH, int dilationW,
         int outputH, int outputW)
+        => Im2ColStridedSingleChannelRange(input, output, colRowStride, colColOffset,
+            0, channels, height, width, kernelH, kernelW, strideH, strideW,
+            padH, padW, dilationH, dilationW, outputH, outputW);
+
+    /// <summary>Strided-destination im2col for a single image (double), restricted to
+    /// input channels <paramref name="channelStart"/>..<paramref name="channelEnd"/>.
+    /// Each channel owns a disjoint block of <c>kernelH*kernelW</c> destination rows
+    /// (row block base <c>c*kernelH*kernelW</c>), so distinct channel ranges write to
+    /// disjoint rows and the build parallelizes over channels with no synchronization.</summary>
+    public static unsafe void Im2ColStridedSingleChannelRange(
+        ReadOnlySpan<double> input,
+        Span<double> output, int colRowStride, int colColOffset,
+        int channelStart, int channelEnd, int height, int width,
+        int kernelH, int kernelW,
+        int strideH, int strideW,
+        int padH, int padW,
+        int dilationH, int dilationW,
+        int outputH, int outputW)
     {
         int colW = outputH * outputW;
+        int kHW = kernelH * kernelW;
         fixed (double* inputPtr = input)
         fixed (double* outputPtr = output)
         {
             if (strideH == 1 && strideW == 1 && dilationH == 1 && dilationW == 1)
             {
-                int rowIdx = 0;
-                for (int c = 0; c < channels; c++)
+                int rowIdx = channelStart * kHW;
+                for (int c = channelStart; c < channelEnd; c++)
                 {
                     int channelOffset = c * height * width;
                     for (int kh = 0; kh < kernelH; kh++)
@@ -783,8 +802,8 @@ internal static class Im2ColHelper
             }
             else
             {
-                int rowIdx = 0;
-                for (int c = 0; c < channels; c++)
+                int rowIdx = channelStart * kHW;
+                for (int c = channelStart; c < channelEnd; c++)
                 {
                     int channelOffset = c * height * width;
                     for (int kh = 0; kh < kernelH; kh++)
@@ -824,15 +843,34 @@ internal static class Im2ColHelper
         int padH, int padW,
         int dilationH, int dilationW,
         int outputH, int outputW)
+        => Im2ColStridedSingleChannelRange(input, output, colRowStride, colColOffset,
+            0, channels, height, width, kernelH, kernelW, strideH, strideW,
+            padH, padW, dilationH, dilationW, outputH, outputW);
+
+    /// <summary>Strided-destination im2col for a single image (float), restricted to
+    /// input channels <paramref name="channelStart"/>..<paramref name="channelEnd"/>.
+    /// Float counterpart of the <c>double</c> channel-range overload — each channel owns
+    /// a disjoint <c>kernelH*kernelW</c>-row block, so the build parallelizes over
+    /// channels with no synchronization.</summary>
+    public static unsafe void Im2ColStridedSingleChannelRange(
+        ReadOnlySpan<float> input,
+        Span<float> output, int colRowStride, int colColOffset,
+        int channelStart, int channelEnd, int height, int width,
+        int kernelH, int kernelW,
+        int strideH, int strideW,
+        int padH, int padW,
+        int dilationH, int dilationW,
+        int outputH, int outputW)
     {
         int colW = outputH * outputW;
+        int kHW = kernelH * kernelW;
         fixed (float* inputPtr = input)
         fixed (float* outputPtr = output)
         {
             if (strideH == 1 && strideW == 1 && dilationH == 1 && dilationW == 1)
             {
-                int rowIdx = 0;
-                for (int c = 0; c < channels; c++)
+                int rowIdx = channelStart * kHW;
+                for (int c = channelStart; c < channelEnd; c++)
                 {
                     int channelOffset = c * height * width;
                     for (int kh = 0; kh < kernelH; kh++)
@@ -868,8 +906,8 @@ internal static class Im2ColHelper
             }
             else
             {
-                int rowIdx = 0;
-                for (int c = 0; c < channels; c++)
+                int rowIdx = channelStart * kHW;
+                for (int c = channelStart; c < channelEnd; c++)
                 {
                     int channelOffset = c * height * width;
                     for (int kh = 0; kh < kernelH; kh++)

--- a/tests/AiDotNet.Tensors.Benchmarks/DCGANStepProbe.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/DCGANStepProbe.cs
@@ -416,6 +416,92 @@ public class DCGANStepProbe
     }
 
     /// <summary>
+    /// Issue #403 Phase F — Conv2DBackwardKernel sub-step breakdown at the full
+    /// batched DCGAN shape. The K-concat path stacks each batch's gradOutput and
+    /// im2col along the GEMM K axis (k = b·colW + n) into [outC, batchColW] /
+    /// [colH, batchColW] buffers, then issues ONE transB GEMM. Splits the wrapper
+    /// into the gradOut repack, the strided im2col build (serial Phase-E vs the
+    /// channel-parallel Phase-F build), and the full-width GEMM so we can see
+    /// where the ~860µs wrapper time actually goes and whether parallelizing the
+    /// strided build moves the needle.
+    /// </summary>
+    public static string RunBackwardKernelBreakdown(int innerReps = 50, int outerSamples = 25)
+    {
+        int colH = InChannels * KernelHW * KernelHW; // 1024
+        int colW = SpatialOut * SpatialOut;          // 49
+        int batchColW = Batch * colW;                // 98
+        int inputSliceSize = InChannels * SpatialIn * SpatialIn;
+        int kHW = KernelHW * KernelHW;
+        var rng = new Random(23);
+        double[] R(int n) { var x = new double[n]; for (int i = 0; i < n; i++) x[i] = rng.NextDouble(); return x; }
+
+        double[] input = R(Batch * inputSliceSize);
+        double[] gradOut = R(Batch * OutChannels * colW);
+        double[] gradOutAll = new double[OutChannels * batchColW];
+        double[] im2colAll = new double[colH * batchColW];
+        double[] gradKernel = new double[OutChannels * colH];
+
+        void Repack()
+        {
+            for (int b = 0; b < Batch; b++)
+            {
+                int off = b * OutChannels * colW;
+                for (int oc = 0; oc < OutChannels; oc++)
+                    Array.Copy(gradOut, off + oc * colW, gradOutAll, oc * batchColW + b * colW, colW);
+            }
+        }
+        void StackSerial()
+        {
+            for (int b = 0; b < Batch; b++)
+                Im2ColHelper.Im2ColStridedSingle(
+                    new ReadOnlySpan<double>(input, b * inputSliceSize, inputSliceSize),
+                    new Span<double>(im2colAll), batchColW, b * colW,
+                    InChannels, SpatialIn, SpatialIn, KernelHW, KernelHW,
+                    Stride, Stride, Padding, Padding, 1, 1, SpatialOut, SpatialOut);
+        }
+        void StackParallel()
+            => AiDotNet.Tensors.Helpers.CpuParallelSettings.ParallelForOrSerial(
+                0, InChannels, (long)InChannels * Batch * kHW * colW, c =>
+                {
+                    for (int b = 0; b < Batch; b++)
+                        Im2ColHelper.Im2ColStridedSingleChannelRange(
+                            new ReadOnlySpan<double>(input, b * inputSliceSize, inputSliceSize),
+                            new Span<double>(im2colAll), batchColW, b * colW,
+                            c, c + 1, SpatialIn, SpatialIn, KernelHW, KernelHW,
+                            Stride, Stride, Padding, Padding, 1, 1, SpatialOut, SpatialOut);
+                });
+        // Measure the GEMM through the SAME production chokepoint the wrapper
+        // uses (BlasProvider.TryGemmEx), not BlasManaged.Gemm directly — the
+        // routing the wrapper sees is what actually matters. NOTE: a swapped
+        // formulation (gradKernel^T = im2colAll @ gradOutAll^T, M=colH big +
+        // blocked transpose) was profiled here and is ~145µs faster in isolation,
+        // BUT regressed the end-to-end wrapper by ~200µs (the swap packs the
+        // freshly-built im2colAll as its large-M operand cold), so the direct GEMM
+        // is the one shipped. Left as the single GEMM measurement below.
+        double GemmDirect() => MinTime(() =>
+            AiDotNet.Tensors.Helpers.BlasProvider.TryGemmEx(
+                OutChannels, colH, batchColW,
+                gradOutAll, 0, batchColW, false,
+                im2colAll, 0, batchColW, true,
+                gradKernel, 0, colH),
+            innerReps, outerSamples);
+
+        Repack(); StackSerial(); StackParallel(); GemmDirect();
+        double rp = MinTime(Repack, innerReps, outerSamples);
+        double ss = MinTime(StackSerial, innerReps, outerSamples);
+        double sp = MinTime(StackParallel, innerReps, outerSamples);
+        double gDirect = GemmDirect();
+
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine("Conv2DBackwardKernel sub-step breakdown (min-of-many, µs, full batched shape):");
+        sb.AppendLine($"  {rp / 1000.0,10:N3} µs  gradOut repack (outC·colW copies × batch)");
+        sb.AppendLine($"  {ss / 1000.0,10:N3} µs  im2col stack — SERIAL per-batch (Phase E)");
+        sb.AppendLine($"  {sp / 1000.0,10:N3} µs  im2col stack — channel-PARALLEL (Phase F, shipped)");
+        sb.AppendLine($"  {gDirect / 1000.0,10:N3} µs  transB GEMM M=64 N=1024 K=98 via TryGemmEx (gradKernel = gradOut @ im2col^T)");
+        return sb.ToString();
+    }
+
+    /// <summary>
     /// Issue #403 Phase D — strategy sweep for the three conv GEMM shapes.
     /// Each shape is timed under Auto (the deterministic-mode static heuristic)
     /// vs forced Streaming / PackAOnly / PackBoth, so we can see whether the

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -195,6 +195,9 @@ class Program
             Console.WriteLine(DCGANStepProbe.RunBackwardInputBreakdown());
 
             Console.WriteLine();
+            Console.WriteLine(DCGANStepProbe.RunBackwardKernelBreakdown());
+
+            Console.WriteLine();
             Console.WriteLine(DCGANStepProbe.RunForwardBreakdown());
 
             Console.WriteLine();

--- a/tests/AiDotNet.Tensors.Tests/Engines/Conv2DBackwardPerfTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Conv2DBackwardPerfTests.cs
@@ -361,6 +361,61 @@ public class Conv2DBackwardPerfTests
         }
     }
 
+    // #403 Phase F: validate the channel-parallel K-concat im2col build at a
+    // high-channel-count shape. The default correctness shape above has inC=3
+    // (colW=36) — this one uses inC=32 (colH = 32·9 = 288, colW = 8·8 = 64 ≤ 256,
+    // batch ≥ 2 → K-concat with the channel-parallel im2col build over 32 disjoint
+    // channel tasks), so the channel-range row-offset math is exercised across many
+    // blocks. Asserted for both element types against the naive reference.
+    [Fact]
+    public void Conv2DBackwardKernel_Correctness_ChannelParallelManyChannels_MatchesNaive()
+    {
+        int batch = 2, inC = 32, outC = 8, h = 10, w = 10, kH = 3, kW = 3;
+        int outH = h - kH + 1, outW = w - kW + 1;
+        int colW = outH * outW;                   // 64 ≤ 256 → channel-parallel build
+        Assert.True(colW <= 256 && inC >= 16);    // guard the precondition
+
+        var rng = new Random(789);
+        var gradOutputF = new float[batch * outC * outH * outW];
+        var inputF = new float[batch * inC * h * w];
+        for (int i = 0; i < gradOutputF.Length; i++) gradOutputF[i] = (float)(rng.NextDouble() * 2 - 1);
+        for (int i = 0; i < inputF.Length; i++) inputF[i] = (float)(rng.NextDouble() * 2 - 1);
+
+        var kernelShape = new[] { outC, inC, kH, kW };
+        var stride = new[] { 1, 1 };
+        var padding = new[] { 0, 0 };
+        var dilation = new[] { 1, 1 };
+        var gradOutputShape = new[] { batch, outC, outH, outW };
+        var inputShape = new[] { batch, inC, h, w };
+
+        var resultNaive = NaiveConv2DBackwardKernelFloat(
+            gradOutputF, gradOutputShape, inputF, inputShape, kernelShape, stride, padding, dilation);
+
+        // FP32 swapped path
+        var gradOutF = new Tensor<float>(gradOutputShape);
+        var inF = new Tensor<float>(inputShape);
+        for (int i = 0; i < gradOutputF.Length; i++) gradOutF[i] = gradOutputF[i];
+        for (int i = 0; i < inputF.Length; i++) inF[i] = inputF[i];
+        var resultF = _engine.Conv2DBackwardKernel(gradOutF, inF, kernelShape, stride, padding, dilation);
+
+        // FP64 swapped path (same swap+transpose code, double element type)
+        var gradOutD = new Tensor<double>(gradOutputShape);
+        var inD = new Tensor<double>(inputShape);
+        for (int i = 0; i < gradOutputF.Length; i++) gradOutD[i] = gradOutputF[i];
+        for (int i = 0; i < inputF.Length; i++) inD[i] = inputF[i];
+        var resultD = _engine.Conv2DBackwardKernel(gradOutD, inD, kernelShape, stride, padding, dilation);
+
+        for (int i = 0; i < resultNaive.Length; i++)
+        {
+            double diffF = Math.Abs(resultF[i] - resultNaive[i]);
+            Assert.True(diffF < 1e-2,
+                $"FP32 swap mismatch at [{i}]: swap={resultF[i]:F6}, naive={resultNaive[i]:F6}, diff={diffF:E2}");
+            double diffD = Math.Abs(resultD[i] - resultNaive[i]);
+            Assert.True(diffD < 1e-2,
+                $"FP64 swap mismatch at [{i}]: swap={resultD[i]:F6}, naive={resultNaive[i]:F6}, diff={diffD:E2}");
+        }
+    }
+
     [Theory]
     [InlineData(2, 1, 1, 1)]  // stride=2, pad=1, dilation=1
     [InlineData(1, 1, 2, 1)]  // stride=1, pad=1, dilation=2 (dilated)


### PR DESCRIPTION
Closes #403

## Summary

Final increment of the #403 DCGAN<double> training-step perf work. The headline goal (>=3x step) was already reached cumulatively across Phases A-E (merged in #516; conv step 6.02ms -> ~1.80ms = 3.34x). This PR adds the remaining BackwardKernel im2col improvement and closes the issue.

Parallelizes the strided im2col build in `Conv2DBackwardKernel`'s K-concat path (`batch >= 2`), which previously ran **serially per batch**. Profiling the DCGAN-decoder shape (batch=2, in=out=64, 8×8, 4×4) showed each im2col row writes `colW` contiguous then jumps a full row stride — a cache-unfriendly build that was not using available cores.

## What changed

- **Parallelize the im2col build over input channels.** Each channel owns a disjoint `kH·kW`-row block across all batches, so the fan-out needs no synchronization. Parallelizing over **channels (not batch)** is deliberate: the `[colH, batchColW]` layout packs every batch's `colW` slice into the *same* row, so a per-batch split would false-share cache lines.
- **Gated on `colW`** (`ParallelIm2colMaxColW = 256`): at small `colW` (DCGAN `colW=49`) each row is a tiny scattered strided write where parallelism hides cache-miss latency; at large `colW` each row is a big contiguous copy (bandwidth-bound) where extra cores only add dispatch overhead, so those build serially.
- New `Im2ColHelper.Im2ColStridedSingleChannelRange` (double + float) — a channel-range overload of the strided im2col with row-base offset `c*kH*kW`.
- The repack + build is extracted into `BuildKConcatStack{Float,Double}` so the hot GEMM path in the (large, generic) `Conv2DBackwardKernel` keeps its baseline JIT codegen.

## Results

- DCGAN probe (min-of-many, full batched shape): **im2col stack 76->31us**; `Conv2DBackwardKernel` wrapper **~854->~796us** in a same-thermal-state A/B.
- Correctness verified for **FP32 and FP64** against the naive reference, including a new high-channel-count shape (`inC=32`) that exercises the channel-parallel build across 32 disjoint channel blocks.
- All 93 `Conv2D` tests pass on net10.0; both TFMs build clean.

## Explored and rejected

A swapped/transposed GEMM (`M=colH` instead of `M=outChannels`) + blocked transpose was **~145us faster in isolation** but regressed the **end-to-end wrapper ~200us** (it cold-packs the freshly-built im2col as its large-M operand — invisible to warm-buffer isolation benchmarks), so only the direct GEMM is shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)