### PR TITLE
fix(gpu): correct MaxPool2D backward index dtype + CUDA kernel arg count

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -4866,6 +4866,12 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         IntPtr gradOutPtr = gradOutput.Handle;
         IntPtr indicesPtr = indices.Handle;
         IntPtr gradInPtr = gradInput.Handle;
+        // Both maxpool2d_backward kernels take NINE parameters — the last two are
+        // (outHeight, outWidth). Passing only eight args (a single outWidth) left the
+        // kernel's outWidth reading an unfilled arg slot — garbage — which blew up
+        // outIdx into an out-of-bounds gradOutput/indices read and a hard CUDA access
+        // violation (0xC0000005) one step into CNN backprop (AiDotNet#1468). Pass both.
+        int outH = outHeight;
         int outW = outWidth;
 
         if (GpuDeterminism.IsActive)
@@ -4873,7 +4879,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
             // Issue #382: route to atomic-free variant.
             if (!_kernelCache.TryGetValue("maxpool2d_backward_deterministic", out var kernelD))
                 throw new InvalidOperationException("CUDA kernel not found: maxpool2d_backward_deterministic");
-            void** argsD = stackalloc void*[8];
+            void** argsD = stackalloc void*[9];
             argsD[0] = &gradOutPtr;
             argsD[1] = &indicesPtr;
             argsD[2] = &gradInPtr;
@@ -4881,7 +4887,8 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
             argsD[4] = &channels;
             argsD[5] = &inHeight;
             argsD[6] = &inWidth;
-            argsD[7] = &outW;
+            argsD[7] = &outH;
+            argsD[8] = &outW;
             // Deterministic variant grid: per (b, c, ih, iw) input cell.
             uint gridDX = (uint)((inWidth + blockSize - 1) / blockSize);
             uint gridDY = (uint)((inHeight + blockSize - 1) / blockSize);
@@ -4897,7 +4904,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         uint gridY = (uint)((outHeight + blockSize - 1) / blockSize);
         uint gridZ = (uint)(batch * channels);
 
-        void** args = stackalloc void*[8];
+        void** args = stackalloc void*[9];
         args[0] = &gradOutPtr;
         args[1] = &indicesPtr;
         args[2] = &gradInPtr;
@@ -4905,7 +4912,8 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         args[4] = &channels;
         args[5] = &inHeight;
         args[6] = &inWidth;
-        args[7] = &outW;
+        args[7] = &outH;
+        args[8] = &outW;
         LaunchKernel2D(kernel, gridX, gridY, gridZ, (uint)blockSize, (uint)blockSize, args);
     }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -4925,9 +4925,18 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int outHeight = gradOutput.Shape._dims[2];
         int outWidth = gradOutput.Shape._dims[3];
 
-        // Convert indices to flat GPU buffer
+        // Convert indices to a flat GPU buffer. The maxpool2d_backward kernels on
+        // every backend (CUDA/OpenCL/HIP) declare the indices parameter as
+        // `const int*` and read it as int32, so the buffer MUST hold int32 values
+        // uploaded via AllocateIntBuffer. Uploading a float[] here (the previous bug)
+        // made the kernel reinterpret float bit-patterns as ints — e.g. index 5 →
+        // 5.0f = 0x40A00000 = 1084227584 — producing a wild gradInput offset and an
+        // out-of-bounds write: a hard CUDA access violation (0xC0000005) and, on
+        // OpenCL, GPU-memory corruption that surfaced later as "Failed to read OpenCL
+        // buffer: -5". This crashed AiModelBuilder.BuildAsync for every prebuilt CNN
+        // (AiDotNet#1468).
         int indexCount = batch * channels * outHeight * outWidth;
-        float[] indicesFlat = new float[indexCount];
+        int[] indicesFlat = new int[indexCount];
         for (int b = 0; b < batch; b++)
         {
             for (int c = 0; c < channels; c++)
@@ -4946,7 +4955,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
 
         using var gradOutputBuffer = GetOrAllocateBuffer(backend, gradOutput.GetDataArray());
-        using var indicesBuffer = backend.AllocateBuffer(indicesFlat);
+        using var indicesBuffer = backend.AllocateIntBuffer(indicesFlat);
         using var gradInputBuffer = AllocateOutputBuffer(backend, batch * channels * inHeight * inWidth);
 
         try

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/MaxPool2DBackwardGpuCorrectnessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/MaxPool2DBackwardGpuCorrectnessTests.cs
@@ -1,0 +1,75 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
+
+/// <summary>
+/// Regression guard for the GPU MaxPool2D backward bugs that crashed CNN training
+/// through the AiDotNet facade (AiDotNet#1468):
+///   1. The engine uploaded pooling indices as a <c>float[]</c>, but every backend's
+///      <c>maxpool2d_backward</c> kernel reads them as <c>const int*</c>. The kernel
+///      reinterpreted float bit-patterns as ints (5 → 5.0f = 0x40A00000 ≈ 1.08e9),
+///      producing an out-of-bounds scatter into gradInput — a hard CUDA access
+///      violation (0xC0000005) and OpenCL memory corruption surfacing as
+///      "Failed to read OpenCL buffer: -5".
+///   2. The CUDA backend launched the 9-parameter kernel with only 8 arguments
+///      (omitting outHeight), so the kernel's outWidth read a garbage arg slot.
+///
+/// Both bugs corrupt or crash the backward pass, so a GPU-vs-CPU equality check on the
+/// input gradient catches them. NON-SQUARE spatial dims are used deliberately: a square
+/// output (outHeight == outWidth) coincidentally masked bug #2.
+/// </summary>
+public class MaxPool2DBackwardGpuCorrectnessTests
+{
+    [Fact]
+    public void MaxPool2DBackward_Gpu_MatchesCpu_NonSquare()
+    {
+        var prior = AiDotNetEngine.Current;
+        DirectGpuTensorEngine? gpu = null;
+        try
+        {
+            gpu = new DirectGpuTensorEngine();
+            if (!gpu.SupportsGpu) return; // CPU-only host: nothing to compare
+
+            // Non-square input [batch=2, channels=3, H=6, W=4] → pool 2x2 stride 2
+            // → output [2,3,3,2] (outHeight=3 != outWidth=2).
+            const int batch = 2, channels = 3, inH = 6, inW = 4;
+            var rng = new Random(1468);
+            var inputData = new float[batch * channels * inH * inW];
+            for (int i = 0; i < inputData.Length; i++) inputData[i] = (float)(rng.NextDouble() * 4 - 2);
+            var input = new Tensor<float>(inputData, new[] { batch, channels, inH, inW });
+
+            var poolSize = new[] { 2, 2 };
+            var stride = new[] { 2, 2 };
+
+            // Forward (with indices) on CPU to get a stable index set + output shape.
+            var cpu = new CpuEngine();
+            var pooled = ((IEngine)cpu).MaxPool2DWithIndices(input, poolSize, stride, out var indices);
+
+            // Upstream gradient shaped like the pooled output.
+            var goData = new float[pooled.Length];
+            for (int i = 0; i < goData.Length; i++) goData[i] = (float)(rng.NextDouble() + 0.1);
+            var gradOutput = new Tensor<float>(goData, pooled.Shape.ToArray());
+
+            var inputShape = new[] { batch, channels, inH, inW };
+            var cpuGrad = ((IEngine)cpu).MaxPool2DBackward(gradOutput, indices, inputShape, poolSize, stride);
+
+            AiDotNetEngine.Current = gpu;
+            var gpuGrad = ((IEngine)gpu).MaxPool2DBackward(gradOutput, indices, inputShape, poolSize, stride);
+
+            Assert.Equal(cpuGrad.Length, gpuGrad.Length);
+            for (int i = 0; i < cpuGrad.Length; i++)
+            {
+                Assert.False(float.IsNaN(gpuGrad.GetFlatIndexValue(i)), $"GPU grad[{i}] is NaN");
+                Assert.Equal(cpuGrad.GetFlatIndexValue(i), gpuGrad.GetFlatIndexValue(i), 3);
+            }
+        }
+        finally
+        {
+            AiDotNetEngine.Current = prior;
+            gpu?.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Two bugs in the GPU **MaxPool2D backward** path crashed CNN training the moment it ran through the AiDotNet facade (`AiModelBuilder.BuildAsync` on any prebuilt CNN — [AiDotNet#1468](https://github.com/ooples/AiDotNet/issues/1468)). On CUDA it was a hard access violation (`0xC0000005`); on OpenCL it surfaced as `Failed to read OpenCL buffer: -5` (out-of-bounds writes corrupting GPU memory, detected later at a buffer read).

### Bug 1 — index dtype mismatch (all backends)

`DirectGpuTensorEngine.MaxPool2DBackward<T>` uploaded the pooling indices as a **`float[]`**, but every backend's `maxpool2d_backward` kernel declares the indices parameter as **`const int*`** and reads int32. The kernel reinterpreted float bit-patterns as ints — e.g. index `5` → `5.0f` = `0x40A00000` = `1084227584` — producing a wild `gradInput` offset and an out-of-bounds scatter.

**Fix:** upload via the existing `AllocateIntBuffer(int[])` so the buffer holds the int32 values the kernel expects.

### Bug 2 — CUDA kernel arg-count mismatch

`CudaBackend.MaxPool2DBackward` launched the **9-parameter** `maxpool2d_backward` / `maxpool2d_backward_deterministic` kernels with only **8 arguments** (a single `outWidth`). The kernel's `outHeight` received `outWidth`, and its `outWidth` read an unfilled arg slot — garbage — exploding `outIdx` into an OOB read.

**Fix:** pass both `outHeight` and `outWidth` (`stackalloc void*[9]`). OpenCL and HIP already passed all nine; only CUDA was short.

## Verification (against the real crash)

- **End-to-end:** AiDotNet's `FacadeMultiDimInputBuildAsyncTests` CNN `BuildAsync` (train + predict) now **passes on a real CUDA GPU** (previously crashed with `0xC0000005`), consuming a local build of this fix. Both bugs had to be fixed for it to pass.
- **New regression test:** `MaxPool2DBackwardGpuCorrectnessTests` — GPU-vs-CPU input-gradient equality on **non-square** spatial dims (`outHeight != outWidth`), so both bugs are caught. (A square output coincidentally masked bug #2.) Skips on CPU-only hosts.
- Existing maxpool + #226/#283 activation-cache lifetime suites stay green (25/25 in the relevant slice).

## Notes

- This is the root cause of the CNN-training GPU crash. The earlier deferred-materializer fix (#526, shipped in 0.91.0) addressed a real, separate lifetime hole but was not what crashed the CNN.
- The index OOB also explains the OpenCL `-5`: corrupting GPU memory via the bad scatter, then failing at a subsequent buffer read.

## Cross-reference
- AiDotNet#1468 (the prebuilt-CNN facade crash this fixes)
- #526 (prior deferred-materializer lifetime fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)