### PR TITLE
perf(cpu): allocation-free axis reductions + small-batch channel-parallel conv-backward

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -12489,6 +12489,11 @@ public partial class CpuEngine : ITensorLevelEngine
             // CPU-thread time on the nested-scalar-loop fallback below;
             // dgemm via libopenblas cuts that to a tuned BLAS path that
             // hits the same FMA throughput the float SGEMM gets).
+            // NOTE: the register-resident SimdConvHelper.Conv2DDirectDouble
+            // kernel (used by the eager Conv2D path) was measured SLOWER than
+            // this im2col+managed-GEMM route for the compiled/deterministic
+            // CNN shapes (ResNet50 1.21→1.53s, VGG16 6.2→6.9s), so it is NOT
+            // wired here — the double GEMM microkernel itself is the lever.
             Conv2DIm2colGemmDouble(
                 (double[])(object)inputData,
                 (double[])(object)kernelData,
@@ -13551,7 +13556,8 @@ public partial class CpuEngine : ITensorLevelEngine
                 for (int c = 0; c < colH; c++)
                     kernelT[c * outChannels + r] = kernelF[r * colH + c];
             var pool = System.Buffers.ArrayPool<float>.Shared;
-            CpuParallelSettings.ParallelForOrSerial(0, batch, (long)batch * colH * colW, b =>
+            long col2imWorkF = (long)inChannels * kernelHeight * kernelWidth * colW;
+            void ProcessImageInputF(int b, bool channelParallel)
             {
                 var colBuf = pool.Rent(colW * colH);
                 try
@@ -13569,15 +13575,39 @@ public partial class CpuEngine : ITensorLevelEngine
                             colH, outChannels, colW);
                     }
                     int imgOff = destOff + b * inChannels * height * width;
-                    Im2ColHelper.Col2ImAccumulate(
-                        new ReadOnlySpan<float>(colBuf, 0, colW * colH),
-                        new Span<float>(destF, imgOff, inChannels * height * width),
-                        inChannels, height, width,
-                        kernelHeight, kernelWidth, strideH, strideW, padH, padW, dilationH, dilationW,
-                        outputHeight, outputWidth);
+                    if (channelParallel)
+                    {
+                        // Channel-parallel col2im scatter: channel c owns the disjoint
+                        // slab destF[imgOff + c·H·W ..]; deterministic-safe (each output
+                        // element's += reduction stays on one thread in serial order).
+                        CpuParallelSettings.ParallelForOrSerial(0, inChannels, col2imWorkF, c =>
+                        {
+                            Im2ColHelper.Col2ImAccumulateChannelRange(
+                                new ReadOnlySpan<float>(colBuf, 0, colW * colH),
+                                new Span<float>(destF, imgOff, inChannels * height * width),
+                                c, c + 1, height, width,
+                                kernelHeight, kernelWidth, strideH, strideW, padH, padW, dilationH, dilationW,
+                                outputHeight, outputWidth);
+                        }, deterministicSafe: true);
+                    }
+                    else
+                    {
+                        Im2ColHelper.Col2ImAccumulate(
+                            new ReadOnlySpan<float>(colBuf, 0, colW * colH),
+                            new Span<float>(destF, imgOff, inChannels * height * width),
+                            inChannels, height, width,
+                            kernelHeight, kernelWidth, strideH, strideW, padH, padW, dilationH, dilationW,
+                            outputHeight, outputWidth);
+                    }
                 }
                 finally { pool.Return(colBuf); }
-            });
+            }
+            long perImageGemmF = (long)outChannels * colH * colW;
+            if (batch > 1 && perImageGemmF < ConvBackwardParallelBatchMaxPerImage)
+                CpuParallelSettings.ParallelForOrSerial(0, batch, (long)batch * colH * colW,
+                    b => ProcessImageInputF(b, channelParallel: false));
+            else
+                for (int b = 0; b < batch; b++) ProcessImageInputF(b, channelParallel: true);
             return;
         }
 
@@ -13659,7 +13689,8 @@ public partial class CpuEngine : ITensorLevelEngine
                 for (int c = 0; c < colH; c++)
                     kernelTD[c * outChannels + r] = kernelD[r * colH + c];
             var poolD = System.Buffers.ArrayPool<double>.Shared;
-            CpuParallelSettings.ParallelForOrSerial(0, batch, (long)batch * colH * colW, b =>
+            long col2imWorkD = (long)inChannels * kernelHeight * kernelWidth * colW;
+            void ProcessImageInputD(int b, bool channelParallel)
             {
                 var colBuf = poolD.Rent(colW * colH);
                 try
@@ -13677,15 +13708,36 @@ public partial class CpuEngine : ITensorLevelEngine
                             colH, outChannels, colW);
                     }
                     int imgOff = destOff + b * inChannels * height * width;
-                    Helpers.Im2ColHelper.Col2ImAccumulate(
-                        new ReadOnlySpan<double>(colBuf, 0, colW * colH),
-                        new Span<double>(destD, imgOff, inChannels * height * width),
-                        inChannels, height, width,
-                        kernelHeight, kernelWidth, strideH, strideW, padH, padW, dilationH, dilationW,
-                        outputHeight, outputWidth);
+                    if (channelParallel)
+                    {
+                        CpuParallelSettings.ParallelForOrSerial(0, inChannels, col2imWorkD, c =>
+                        {
+                            Helpers.Im2ColHelper.Col2ImAccumulateChannelRange(
+                                new ReadOnlySpan<double>(colBuf, 0, colW * colH),
+                                new Span<double>(destD, imgOff, inChannels * height * width),
+                                c, c + 1, height, width,
+                                kernelHeight, kernelWidth, strideH, strideW, padH, padW, dilationH, dilationW,
+                                outputHeight, outputWidth);
+                        }, deterministicSafe: true);
+                    }
+                    else
+                    {
+                        Helpers.Im2ColHelper.Col2ImAccumulate(
+                            new ReadOnlySpan<double>(colBuf, 0, colW * colH),
+                            new Span<double>(destD, imgOff, inChannels * height * width),
+                            inChannels, height, width,
+                            kernelHeight, kernelWidth, strideH, strideW, padH, padW, dilationH, dilationW,
+                            outputHeight, outputWidth);
+                    }
                 }
                 finally { poolD.Return(colBuf); }
-            });
+            }
+            long perImageGemmD = (long)outChannels * colH * colW;
+            if (batch > 1 && perImageGemmD < ConvBackwardParallelBatchMaxPerImage)
+                CpuParallelSettings.ParallelForOrSerial(0, batch, (long)batch * colH * colW,
+                    b => ProcessImageInputD(b, channelParallel: false));
+            else
+                for (int b = 0; b < batch; b++) ProcessImageInputD(b, channelParallel: true);
             return;
         }
 
@@ -13720,6 +13772,18 @@ public partial class CpuEngine : ITensorLevelEngine
     // serially per batch (a perf-guard at colW=900 regressed under an
     // unconditional channel-parallel build).
     private const int ParallelIm2colMaxColW = 256;
+
+    // #403: per-image GEMM cost below which Conv2DBackwardInputInto /
+    // Conv2DBackwardKernelInto parallelize over the BATCH axis (inner GEMM +
+    // spatial transform serial per image). Mirrors the forward
+    // Conv2DIm2colGemm 50M threshold. Above this cost — and ALWAYS at batch=1,
+    // the CNN model-family training shape [1,3,224,224] — the batch loop runs
+    // INLINE so the per-image GEMM keeps full thread scaling (routing it through
+    // ParallelForOrSerial(0,1,…) would set _inParallelRegion and collapse the
+    // inner BlasManaged GEMM AND the spatial transform to a single thread), and
+    // the im2col/col2im transform parallelizes over input channels instead
+    // (disjoint c·H·W slabs / kH·kW row blocks → deterministic-safe).
+    private const long ConvBackwardParallelBatchMaxPerImage = 50_000_000L;
 
     // #403 Phase F: repack gradOutput + build the strided im2col for the K-concat
     // backward-kernel path (float). gradOutAll[oc, b·colW+n] = gradOutput[b,oc,n];
@@ -14315,48 +14379,102 @@ public partial class CpuEngine : ITensorLevelEngine
             var gradOutputF = (float[])(object)gradOutput.GetFlattenedData();
             var inputF = (float[])(object)input.GetFlattenedData();
             int inputSliceSize = inChannels * height * width;
-            var perBatchGrads = new float[batch][];
             var kPool = System.Buffers.ArrayPool<float>.Shared;
-            CpuParallelSettings.ParallelForOrSerial(0, batch, (long)batch * colH * colW, b =>
+            long im2colWorkKF = (long)inChannels * kernelHeight * kernelWidth * colW;
+
+            // Per-image: build im2col(input_b) then GEMM gradOut_b @ im2col^T into
+            // localGrad (overwrite). channelParallel=true builds the im2col across
+            // input channels (Im2ColStridedSingleChannelRange with rowStride=colW →
+            // the contiguous [colH,colW] layout; disjoint kH·kW row blocks) and lets
+            // the GEMM thread at the top level — this is the batch=1 path. When false
+            // (batch-parallel worker) everything inside runs serial; the batch axis
+            // supplies the threads.
+            void ComputeBatchGradF(int b, float[] im2colBuf, float[] localGrad, bool channelParallel)
             {
+                Array.Clear(localGrad, 0, totalLen);
+                if (channelParallel)
+                {
+                    CpuParallelSettings.ParallelForOrSerial(0, inChannels, im2colWorkKF, c =>
+                    {
+                        Im2ColHelper.Im2ColStridedSingleChannelRange(
+                            new ReadOnlySpan<float>(inputF, b * inputSliceSize, inputSliceSize),
+                            new Span<float>(im2colBuf, 0, colH * colW), colW, 0,
+                            c, c + 1, height, width, kernelHeight, kernelWidth,
+                            strideH, strideW, padH, padW, dilationH, dilationW, outputHeight, outputWidth);
+                    }, deterministicSafe: true);
+                }
+                else
+                {
+                    Im2ColHelper.Im2Col(
+                        new ReadOnlySpan<float>(inputF, b * inputSliceSize, inputSliceSize),
+                        new Span<float>(im2colBuf, 0, colH * colW),
+                        1, inChannels, height, width,
+                        kernelHeight, kernelWidth, strideH, strideW, padH, padW, dilationH, dilationW);
+                }
+                int gradOutOff = b * outChannels * colW;
+                if (!Helpers.BlasProvider.TryGemmEx(
+                    outChannels, colH, colW,
+                    gradOutputF, gradOutOff, colW, false,
+                    im2colBuf, 0, colW, true,
+                    localGrad, 0, colH))
+                {
+                    Simd.SimdGemm.Sgemm(
+                        new ReadOnlySpan<float>(gradOutputF, gradOutOff, outChannels * colW), colW, false,
+                        new ReadOnlySpan<float>(im2colBuf, 0, colH * colW), colW, true,
+                        new Span<float>(localGrad, 0, totalLen),
+                        outChannels, colW, colH);
+                }
+            }
+
+            long perImageGemmKF = (long)outChannels * colH * colW;
+            if (batch > 1 && perImageGemmKF < ConvBackwardParallelBatchMaxPerImage)
+            {
+                // Batch-parallel: each worker accumulates into its own buffer; the sum
+                // over batches runs single-threaded afterward (order-independent).
+                var perBatchGrads = new float[batch][];
+                CpuParallelSettings.ParallelForOrSerial(0, batch, (long)batch * colH * colW, b =>
+                {
+                    var im2colBuf = kPool.Rent(colH * colW);
+                    var localGrad = kPool.Rent(totalLen);
+                    try
+                    {
+                        ComputeBatchGradF(b, im2colBuf, localGrad, channelParallel: false);
+                        var gradCopy = new float[totalLen];
+                        Array.Copy(localGrad, gradCopy, totalLen);
+                        perBatchGrads[b] = gradCopy;
+                    }
+                    finally
+                    {
+                        kPool.Return(im2colBuf);
+                        kPool.Return(localGrad);
+                    }
+                });
+                for (int b = 0; b < batch; b++)
+                {
+                    var lg = perBatchGrads[b];
+                    for (int i = 0; i < totalLen; i++) gradKernelF[i] += lg[i];
+                }
+            }
+            else
+            {
+                // Serial batch loop; im2col + GEMM parallelize inside each image. The
+                // im2col/localGrad buffers are rented once and reused (no per-batch
+                // new float[totalLen] churn).
                 var im2colBuf = kPool.Rent(colH * colW);
                 var localGrad = kPool.Rent(totalLen);
                 try
                 {
-                    Array.Clear(localGrad, 0, totalLen);
-                    Im2ColHelper.Im2Col(
-                        new ReadOnlySpan<float>(inputF, b * inputSliceSize, inputSliceSize),
-                        new Span<float>(im2colBuf),
-                        1, inChannels, height, width,
-                        kernelHeight, kernelWidth, strideH, strideW, padH, padW, dilationH, dilationW);
-                    int gradOutOff = b * outChannels * colW;
-                    if (!Helpers.BlasProvider.TryGemmEx(
-                        outChannels, colH, colW,
-                        gradOutputF, gradOutOff, colW, false,
-                        im2colBuf, 0, colW, true,
-                        localGrad, 0, colH))
+                    for (int b = 0; b < batch; b++)
                     {
-                        Simd.SimdGemm.Sgemm(
-                            new ReadOnlySpan<float>(gradOutputF, gradOutOff, outChannels * colW), colW, false,
-                            new ReadOnlySpan<float>(im2colBuf, 0, colH * colW), colW, true,
-                            new Span<float>(localGrad, 0, totalLen),
-                            outChannels, colW, colH);
+                        ComputeBatchGradF(b, im2colBuf, localGrad, channelParallel: true);
+                        for (int i = 0; i < totalLen; i++) gradKernelF[i] += localGrad[i];
                     }
-                    var gradCopy = new float[totalLen];
-                    Array.Copy(localGrad, gradCopy, totalLen);
-                    perBatchGrads[b] = gradCopy;
                 }
                 finally
                 {
                     kPool.Return(im2colBuf);
                     kPool.Return(localGrad);
                 }
-            });
-            for (int b = 0; b < batch; b++)
-            {
-                var lg = perBatchGrads[b];
-                for (int i = 0; i < gradKernelF.Length; i++)
-                    gradKernelF[i] += lg[i];
             }
             // Merge into dest with accumulate flag honoured.
             if (accumulate)
@@ -14424,56 +14542,100 @@ public partial class CpuEngine : ITensorLevelEngine
             }
 
             var gradKernelD = new double[totalLen];
-            var perBatchGradsD = new double[batch][];
             var kPoolD = System.Buffers.ArrayPool<double>.Shared;
-            CpuParallelSettings.ParallelForOrSerial(0, batch, (long)batch * colH * colW, b =>
+            long im2colWorkKD = (long)inChannels * kernelHeight * kernelWidth * colW;
+
+            // Per-image im2col + GEMM into localGrad (overwrite). See the float
+            // counterpart ComputeBatchGradF for the channel-parallel rationale.
+            void ComputeBatchGradD(int b, double[] im2colBuf, double[] localGrad, bool channelParallel)
+            {
+                Array.Clear(localGrad, 0, totalLen);
+                if (channelParallel)
+                {
+                    CpuParallelSettings.ParallelForOrSerial(0, inChannels, im2colWorkKD, c =>
+                    {
+                        Helpers.Im2ColHelper.Im2ColStridedSingleChannelRange(
+                            new ReadOnlySpan<double>(inputD, b * inputSliceSize, inputSliceSize),
+                            new Span<double>(im2colBuf, 0, colH * colW), colW, 0,
+                            c, c + 1, height, width, kernelHeight, kernelWidth,
+                            strideH, strideW, padH, padW, dilationH, dilationW, outputHeight, outputWidth);
+                    }, deterministicSafe: true);
+                }
+                else
+                {
+                    Helpers.Im2ColHelper.Im2Col(
+                        new ReadOnlySpan<double>(inputD, b * inputSliceSize, inputSliceSize),
+                        new Span<double>(im2colBuf, 0, colH * colW),
+                        1, inChannels, height, width,
+                        kernelHeight, kernelWidth, strideH, strideW, padH, padW, dilationH, dilationW);
+                }
+                int gradOutOff = b * outChannels * colW;
+                if (!Helpers.BlasProvider.TryGemmEx(
+                    outChannels, colH, colW,
+                    gradOutputD, gradOutOff, colW, false,
+                    im2colBuf, 0, colW, true,
+                    localGrad, 0, colH))
+                {
+                    var im2colT = kPoolD.Rent(colW * colH);
+                    try
+                    {
+                        for (int r = 0; r < colH; r++)
+                            for (int c = 0; c < colW; c++)
+                                im2colT[c * colH + r] = im2colBuf[r * colW + c];
+                        Helpers.Im2ColHelper.MultiplyMatrixBlockedDouble(
+                            new ReadOnlySpan<double>(gradOutputD, gradOutOff, outChannels * colW),
+                            new ReadOnlySpan<double>(im2colT, 0, colW * colH),
+                            new Span<double>(localGrad, 0, totalLen),
+                            outChannels, colW, colH);
+                    }
+                    finally { kPoolD.Return(im2colT); }
+                }
+            }
+
+            long perImageGemmKD = (long)outChannels * colH * colW;
+            if (batch > 1 && perImageGemmKD < ConvBackwardParallelBatchMaxPerImage)
+            {
+                var perBatchGradsD = new double[batch][];
+                CpuParallelSettings.ParallelForOrSerial(0, batch, (long)batch * colH * colW, b =>
+                {
+                    var im2colBuf = kPoolD.Rent(colH * colW);
+                    var localGrad = kPoolD.Rent(totalLen);
+                    try
+                    {
+                        ComputeBatchGradD(b, im2colBuf, localGrad, channelParallel: false);
+                        var gradCopy = new double[totalLen];
+                        Array.Copy(localGrad, gradCopy, totalLen);
+                        perBatchGradsD[b] = gradCopy;
+                    }
+                    finally
+                    {
+                        kPoolD.Return(im2colBuf);
+                        kPoolD.Return(localGrad);
+                    }
+                });
+                for (int b = 0; b < batch; b++)
+                {
+                    var lg = perBatchGradsD[b];
+                    for (int i = 0; i < totalLen; i++) gradKernelD[i] += lg[i];
+                }
+            }
+            else
             {
                 var im2colBuf = kPoolD.Rent(colH * colW);
                 var localGrad = kPoolD.Rent(totalLen);
                 try
                 {
-                    Array.Clear(localGrad, 0, totalLen);
-                    Helpers.Im2ColHelper.Im2Col(
-                        new ReadOnlySpan<double>(inputD, b * inputSliceSize, inputSliceSize),
-                        new Span<double>(im2colBuf),
-                        1, inChannels, height, width,
-                        kernelHeight, kernelWidth, strideH, strideW, padH, padW, dilationH, dilationW);
-                    int gradOutOff = b * outChannels * colW;
-                    if (!Helpers.BlasProvider.TryGemmEx(
-                        outChannels, colH, colW,
-                        gradOutputD, gradOutOff, colW, false,
-                        im2colBuf, 0, colW, true,
-                        localGrad, 0, colH))
+                    for (int b = 0; b < batch; b++)
                     {
-                        var im2colT = kPoolD.Rent(colW * colH);
-                        try
-                        {
-                            for (int r = 0; r < colH; r++)
-                                for (int c = 0; c < colW; c++)
-                                    im2colT[c * colH + r] = im2colBuf[r * colW + c];
-                            Helpers.Im2ColHelper.MultiplyMatrixBlockedDouble(
-                                new ReadOnlySpan<double>(gradOutputD, gradOutOff, outChannels * colW),
-                                new ReadOnlySpan<double>(im2colT, 0, colW * colH),
-                                new Span<double>(localGrad, 0, totalLen),
-                                outChannels, colW, colH);
-                        }
-                        finally { kPoolD.Return(im2colT); }
+                        ComputeBatchGradD(b, im2colBuf, localGrad, channelParallel: true);
+                        for (int i = 0; i < totalLen; i++) gradKernelD[i] += localGrad[i];
                     }
-                    var gradCopy = new double[totalLen];
-                    Array.Copy(localGrad, gradCopy, totalLen);
-                    perBatchGradsD[b] = gradCopy;
                 }
                 finally
                 {
                     kPoolD.Return(im2colBuf);
                     kPoolD.Return(localGrad);
                 }
-            });
-            for (int b = 0; b < batch; b++)
-            {
-                var lg = perBatchGradsD[b];
-                for (int i = 0; i < gradKernelD.Length; i++)
-                    gradKernelD[i] += lg[i];
             }
             if (accumulate)
                 for (int i = 0; i < totalLen; i++) destD[destOff + i] += gradKernelD[i];
@@ -27177,33 +27339,26 @@ public partial class CpuEngine : ITensorLevelEngine
             maxIndices[i] = -1;
         }
 
-        var inputStrides = ComputeStrides(inputShape);
-        var outputStrides = ComputeStrides(outputShape);
-
-        for (int i = 0; i < input.Length; i++)
+        // Allocation-free odometer (replaces per-element FlatToMultiIndex +
+        // new List<int> + MultiToFlatIndex + Contains). inputData is logical
+        // row-major; advance the output flat index incrementally as we walk it.
+        int maxRank = inputShape.Length;
+        var maxOutStrideForDim = BuildReducedOutStrideForDim(inputShape, outputShape, normalizedAxes);
+        var maxCoord = new int[maxRank];
+        int maxOutFlat = 0;
+        int maxLen = input.Length;
+        for (int i = 0; i < maxLen; i++)
         {
-            var multiIndex = FlatToMultiIndex(i, inputShape, inputStrides);
-
-            var outputMultiIndex = new List<int>();
-            for (int d = 0; d < inputShape.Length; d++)
+            if (numOps.GreaterThan(inputData[i], outputData[maxOutFlat]))
             {
-                if (normalizedAxes.Contains(d))
-                {
-                    if (keepDims) outputMultiIndex.Add(0);
-                }
-                else
-                {
-                    outputMultiIndex.Add(multiIndex[d]);
-                }
+                outputData[maxOutFlat] = inputData[i];
+                maxIndices[maxOutFlat] = i;
             }
-            if (outputMultiIndex.Count == 0) outputMultiIndex.Add(0);
-
-            int outputIdx = MultiToFlatIndex([.. outputMultiIndex], outputShape, outputStrides);
-
-            if (numOps.GreaterThan(inputData[i], outputData[outputIdx]))
+            for (int d = maxRank - 1; d >= 0; d--)
             {
-                outputData[outputIdx] = inputData[i];
-                maxIndices[outputIdx] = i;
+                maxCoord[d]++; maxOutFlat += maxOutStrideForDim[d];
+                if (maxCoord[d] < inputShape[d]) break;
+                maxCoord[d] = 0; maxOutFlat -= maxOutStrideForDim[d] * inputShape[d];
             }
         }
 
@@ -27367,46 +27522,82 @@ public partial class CpuEngine : ITensorLevelEngine
 
         int outputSize = outputShape.Aggregate(1, (a, b) => a * b);
         var outputData = new T[outputSize];
-        var counts = new int[outputSize];
 
-        for (int i = 0; i < outputSize; i++)
+        // Allocation-free odometer reduction (mirrors the Tensor<T>.Sum fast
+        // path). The previous implementation allocated a FlatToMultiIndex int[]
+        // + a List<int> + a MultiToFlatIndex int[] PER ELEMENT plus a
+        // normalizedAxes.Contains() scan per dim — the same per-element heap-
+        // allocation catastrophe SumRecursive had, on every BatchNorm/LayerNorm
+        // mean over [B,C,H,W]. inputData is logical row-major (GetFlattenedData),
+        // so we walk it once, advancing the output flat index incrementally.
+        int meanRank = inputShape.Length;
+        var meanIsReduced = new bool[meanRank];
+        int reduceCount = 1;
+        for (int a = 0; a < normalizedAxes.Length; a++) { meanIsReduced[normalizedAxes[a]] = true; reduceCount *= inputShape[normalizedAxes[a]]; }
+        var meanOutStrides = ComputeStrides(outputShape);
+        var meanOutStrideForDim = new int[meanRank];
+        if (keepDims)
         {
-            outputData[i] = numOps.Zero;
-            counts[i] = 0;
+            // output rank == input rank; reduced dims have size 1 (coord always 0).
+            for (int d = 0; d < meanRank; d++) meanOutStrideForDim[d] = meanIsReduced[d] ? 0 : meanOutStrides[d];
         }
-
-        var inputStrides = ComputeStrides(inputShape);
-        var outputStrides = ComputeStrides(outputShape);
-
-        for (int i = 0; i < input.Length; i++)
+        else
         {
-            var multiIndex = FlatToMultiIndex(i, inputShape, inputStrides);
-
-            var outputMultiIndex = new List<int>();
-            for (int d = 0; d < inputShape.Length; d++)
+            int oi = 0;
+            for (int d = 0; d < meanRank; d++) meanOutStrideForDim[d] = meanIsReduced[d] ? 0 : meanOutStrides[oi++];
+        }
+        var meanCoord = new int[meanRank];
+        int meanOutFlat = 0;
+        int meanLen = input.Length;
+        if (typeof(T) == typeof(double))
+        {
+            var s = (double[])(object)inputData;
+            var o = (double[])(object)outputData;
+            for (int i = 0; i < meanLen; i++)
             {
-                if (normalizedAxes.Contains(d))
+                o[meanOutFlat] += s[i];
+                for (int d = meanRank - 1; d >= 0; d--)
                 {
-                    if (keepDims) outputMultiIndex.Add(0);
-                }
-                else
-                {
-                    outputMultiIndex.Add(multiIndex[d]);
+                    meanCoord[d]++; meanOutFlat += meanOutStrideForDim[d];
+                    if (meanCoord[d] < inputShape[d]) break;
+                    meanCoord[d] = 0; meanOutFlat -= meanOutStrideForDim[d] * inputShape[d];
                 }
             }
-            if (outputMultiIndex.Count == 0) outputMultiIndex.Add(0);
-
-            int outputIdx = MultiToFlatIndex([.. outputMultiIndex], outputShape, outputStrides);
-            outputData[outputIdx] = numOps.Add(outputData[outputIdx], inputData[i]);
-            counts[outputIdx]++;
+            double inv = 1.0 / reduceCount;
+            for (int i = 0; i < outputSize; i++) o[i] *= inv;
         }
-
-        for (int i = 0; i < outputSize; i++)
+        else if (typeof(T) == typeof(float))
         {
-            if (counts[i] > 0)
+            var s = (float[])(object)inputData;
+            var o = (float[])(object)outputData;
+            for (int i = 0; i < meanLen; i++)
             {
-                outputData[i] = numOps.Divide(outputData[i], numOps.FromDouble(counts[i]));
+                o[meanOutFlat] += s[i];
+                for (int d = meanRank - 1; d >= 0; d--)
+                {
+                    meanCoord[d]++; meanOutFlat += meanOutStrideForDim[d];
+                    if (meanCoord[d] < inputShape[d]) break;
+                    meanCoord[d] = 0; meanOutFlat -= meanOutStrideForDim[d] * inputShape[d];
+                }
             }
+            float inv = 1.0f / reduceCount;
+            for (int i = 0; i < outputSize; i++) o[i] *= inv;
+        }
+        else
+        {
+            for (int i = 0; i < outputSize; i++) outputData[i] = numOps.Zero;
+            for (int i = 0; i < meanLen; i++)
+            {
+                outputData[meanOutFlat] = numOps.Add(outputData[meanOutFlat], inputData[i]);
+                for (int d = meanRank - 1; d >= 0; d--)
+                {
+                    meanCoord[d]++; meanOutFlat += meanOutStrideForDim[d];
+                    if (meanCoord[d] < inputShape[d]) break;
+                    meanCoord[d] = 0; meanOutFlat -= meanOutStrideForDim[d] * inputShape[d];
+                }
+            }
+            T divisor = numOps.FromDouble(reduceCount);
+            for (int i = 0; i < outputSize; i++) outputData[i] = numOps.Divide(outputData[i], divisor);
         }
 
         var result = TensorAllocator.Rent<T>(outputShape, outputData);
@@ -27439,45 +27630,23 @@ public partial class CpuEngine : ITensorLevelEngine
 
         var gradOutputData = gradOutput.GetFlattenedData();
         var gradOutputShape = gradOutput._shape;
-        var inputStrides = ComputeStrides(inputShape);
-        var outputStrides = ComputeStrides(gradOutputShape);
 
+        // Allocation-free odometer: walk gradInput (input-shaped) in row-major
+        // order, advancing the reduced gradOutput flat index incrementally
+        // (replaces per-element FlatToMultiIndex + List + MultiToFlatIndex + Contains).
+        int rmbRank = inputShape.Length;
+        var rmbOutStrideForDim = BuildReducedOutStrideForDim(inputShape, gradOutputShape, normalizedAxes);
+        var rmbCoord = new int[rmbRank];
+        int rmbOutFlat = 0;
         for (int i = 0; i < inputSize; i++)
         {
-            var multiIndex = FlatToMultiIndex(i, inputShape, inputStrides);
-
-            var outputMultiIndex = new List<int>();
-            int d2 = 0;
-            for (int d = 0; d < inputShape.Length; d++)
+            gradInputData[i] = numOps.Multiply(gradOutputData[rmbOutFlat], scale);
+            for (int d = rmbRank - 1; d >= 0; d--)
             {
-                if (normalizedAxes.Contains(d))
-                {
-                    if (d2 < gradOutputShape.Length && gradOutputShape[d2] == 1)
-                    {
-                        outputMultiIndex.Add(0);
-                        d2++;
-                    }
-                }
-                else
-                {
-                    if (d2 < gradOutputShape.Length)
-                    {
-                        outputMultiIndex.Add(multiIndex[d]);
-                        d2++;
-                    }
-                }
+                rmbCoord[d]++; rmbOutFlat += rmbOutStrideForDim[d];
+                if (rmbCoord[d] < inputShape[d]) break;
+                rmbCoord[d] = 0; rmbOutFlat -= rmbOutStrideForDim[d] * inputShape[d];
             }
-            if (outputMultiIndex.Count == 0) outputMultiIndex.Add(0);
-
-            while (outputMultiIndex.Count < gradOutputShape.Length)
-                outputMultiIndex.Add(0);
-            while (outputMultiIndex.Count > gradOutputShape.Length)
-                outputMultiIndex.RemoveAt(outputMultiIndex.Count - 1);
-
-            int outputIdx = MultiToFlatIndex([.. outputMultiIndex], gradOutputShape, outputStrides);
-            if (outputIdx < 0 || outputIdx >= gradOutputData.Length)
-                throw new InvalidOperationException($"Output index {outputIdx} out of range [0, {gradOutputData.Length}). This indicates a shape mismatch between gradOutput and the expected shape.");
-            gradInputData[i] = numOps.Multiply(gradOutputData[outputIdx], scale);
         }
 
         return TensorAllocator.Rent<T>(inputShape, gradInputData);
@@ -27664,46 +27833,27 @@ public partial class CpuEngine : ITensorLevelEngine
         }
         T scale = numOps.Divide(numOps.One, numOps.FromDouble(reduceCount));
 
-        var inputStrides = ComputeStrides(inputShape);
-        var outputStrides = ComputeStrides(outputShape);
-        var meanStrides = ComputeStrides(meanShape);
-
-        // Accumulate squared differences from mean
+        // Accumulate squared differences from mean. Allocation-free odometer:
+        // two incremental flat indices (output + keepDims mean) advanced as we
+        // walk the row-major input once (replaces per-element FlatToMultiIndex +
+        // two List<int> + two MultiToFlatIndex + Contains).
+        int varRank = inputShape.Length;
+        var varOutStrideForDim = BuildReducedOutStrideForDim(inputShape, outputShape, normalizedAxes);
+        var varMeanStrideForDim = BuildReducedOutStrideForDim(inputShape, meanShape, normalizedAxes);
+        var varCoord = new int[varRank];
+        int varOutFlat = 0, varMeanFlat = 0;
         int inputSize = input.Length;
         for (int i = 0; i < inputSize; i++)
         {
-            var multiIndex = FlatToMultiIndex(i, inputShape, inputStrides);
-
-            var outputMultiIndex = new List<int>();
-            for (int d = 0; d < inputShape.Length; d++)
-            {
-                if (normalizedAxes.Contains(d))
-                {
-                    if (keepDims) outputMultiIndex.Add(0);
-                }
-                else
-                {
-                    outputMultiIndex.Add(multiIndex[d]);
-                }
-            }
-            if (outputMultiIndex.Count == 0) outputMultiIndex.Add(0);
-
-            int outputIdx = MultiToFlatIndex([.. outputMultiIndex], outputShape, outputStrides);
-
-            // Get mean value (mean tensor has keepDims=true shape)
-            var meanMultiIndex = new List<int>();
-            for (int d = 0; d < inputShape.Length; d++)
-            {
-                if (normalizedAxes.Contains(d))
-                    meanMultiIndex.Add(0);
-                else
-                    meanMultiIndex.Add(multiIndex[d]);
-            }
-            int meanIdx = MultiToFlatIndex([.. meanMultiIndex], meanShape, meanStrides);
-
-            T diff = numOps.Subtract(inputData[i], meanData[meanIdx]);
+            T diff = numOps.Subtract(inputData[i], meanData[varMeanFlat]);
             T squaredDiff = numOps.Multiply(diff, diff);
-            outputData[outputIdx] = numOps.Add(outputData[outputIdx], squaredDiff);
+            outputData[varOutFlat] = numOps.Add(outputData[varOutFlat], squaredDiff);
+            for (int d = varRank - 1; d >= 0; d--)
+            {
+                varCoord[d]++; varOutFlat += varOutStrideForDim[d]; varMeanFlat += varMeanStrideForDim[d];
+                if (varCoord[d] < inputShape[d]) break;
+                varCoord[d] = 0; varOutFlat -= varOutStrideForDim[d] * inputShape[d]; varMeanFlat -= varMeanStrideForDim[d] * inputShape[d];
+            }
         }
 
         // Divide by count to get variance
@@ -27803,33 +27953,23 @@ public partial class CpuEngine : ITensorLevelEngine
         foreach (var ax in normalizedAxes) reduceCount *= inputShape[ax];
         T scale = numOps.Divide(numOps.One, numOps.FromDouble(reduceCount));
 
-        var inputStrides = ComputeStrides(inputShape);
-        var outputStrides = ComputeStrides(outputShape);
-        var meanStrides = ComputeStrides(meanShape);
-
+        // Allocation-free odometer (output + keepDims mean), see ReduceVariance.
+        int rvtRank = inputShape.Length;
+        var rvtOutStrideForDim = BuildReducedOutStrideForDim(inputShape, outputShape, normalizedAxes);
+        var rvtMeanStrideForDim = BuildReducedOutStrideForDim(inputShape, meanShape, normalizedAxes);
+        var rvtCoord = new int[rvtRank];
+        int rvtOutFlat = 0, rvtMeanFlat = 0;
         int inputSize = input.Length;
         for (int i = 0; i < inputSize; i++)
         {
-            var multiIndex = FlatToMultiIndex(i, inputShape, inputStrides);
-            var outputMultiIndex = new List<int>();
-            for (int d = 0; d < inputShape.Length; d++)
+            T diff = numOps.Subtract(inputData[i], meanData[rvtMeanFlat]);
+            outputData[rvtOutFlat] = numOps.Add(outputData[rvtOutFlat], numOps.Multiply(diff, diff));
+            for (int d = rvtRank - 1; d >= 0; d--)
             {
-                if (normalizedAxes.Contains(d)) { if (keepDims) outputMultiIndex.Add(0); }
-                else outputMultiIndex.Add(multiIndex[d]);
+                rvtCoord[d]++; rvtOutFlat += rvtOutStrideForDim[d]; rvtMeanFlat += rvtMeanStrideForDim[d];
+                if (rvtCoord[d] < inputShape[d]) break;
+                rvtCoord[d] = 0; rvtOutFlat -= rvtOutStrideForDim[d] * inputShape[d]; rvtMeanFlat -= rvtMeanStrideForDim[d] * inputShape[d];
             }
-            if (outputMultiIndex.Count == 0) outputMultiIndex.Add(0);
-            int outputIdx = MultiToFlatIndex([.. outputMultiIndex], outputShape, outputStrides);
-
-            var meanMultiIndex = new List<int>();
-            for (int d = 0; d < inputShape.Length; d++)
-            {
-                if (normalizedAxes.Contains(d)) meanMultiIndex.Add(0);
-                else meanMultiIndex.Add(multiIndex[d]);
-            }
-            int meanIdx = MultiToFlatIndex([.. meanMultiIndex], meanShape, meanStrides);
-
-            T diff = numOps.Subtract(inputData[i], meanData[meanIdx]);
-            outputData[outputIdx] = numOps.Add(outputData[outputIdx], numOps.Multiply(diff, diff));
         }
         for (int i = 0; i < outputSize; i++) outputData[i] = numOps.Multiply(outputData[i], scale);
 
@@ -27872,21 +28012,25 @@ public partial class CpuEngine : ITensorLevelEngine
         }
         T scale = numOps.Divide(numOps.FromDouble(2.0), numOps.FromDouble(reduceCount));
 
-        var inputStrides = ComputeStrides(inputShape);
-        var outputStrides = ComputeStrides(gradOutputShape);
-        var meanStrides = ComputeStrides(meanShape);
-
+        // Allocation-free odometer (gradOutput + keepDims mean) over the
+        // row-major input (replaces per-element FlatToMultiIndex + MapToReducedIndex
+        // + MapToMeanIndex, each of which allocated a List<int> + int[] per call).
+        int rvbRank = inputShape.Length;
+        var rvbOutStrideForDim = BuildReducedOutStrideForDim(inputShape, gradOutputShape, normalizedAxes);
+        var rvbMeanStrideForDim = BuildReducedOutStrideForDim(inputShape, meanShape, normalizedAxes);
+        var rvbCoord = new int[rvbRank];
+        int rvbOutFlat = 0, rvbMeanFlat = 0;
         for (int i = 0; i < inputSize; i++)
         {
-            var multiIndex = FlatToMultiIndex(i, inputShape, inputStrides);
-
-            // Map to output and mean indices using helper methods
-            int outputIdx = MapToReducedIndex(multiIndex, inputShape, gradOutputShape, normalizedAxes, outputStrides);
-            int meanIdx = MapToMeanIndex(multiIndex, inputShape, meanShape, normalizedAxes, meanStrides);
-
             // gradient = 2 * (x - mean) * gradOutput / N
-            T diff = numOps.Subtract(inputData[i], meanData[meanIdx]);
-            gradInputData[i] = numOps.Multiply(numOps.Multiply(diff, scale), gradOutputData[outputIdx]);
+            T diff = numOps.Subtract(inputData[i], meanData[rvbMeanFlat]);
+            gradInputData[i] = numOps.Multiply(numOps.Multiply(diff, scale), gradOutputData[rvbOutFlat]);
+            for (int d = rvbRank - 1; d >= 0; d--)
+            {
+                rvbCoord[d]++; rvbOutFlat += rvbOutStrideForDim[d]; rvbMeanFlat += rvbMeanStrideForDim[d];
+                if (rvbCoord[d] < inputShape[d]) break;
+                rvbCoord[d] = 0; rvbOutFlat -= rvbOutStrideForDim[d] * inputShape[d]; rvbMeanFlat -= rvbMeanStrideForDim[d] * inputShape[d];
+            }
         }
 
         return TensorAllocator.Rent<T>(inputShape, gradInputData);
@@ -27966,64 +28110,35 @@ public partial class CpuEngine : ITensorLevelEngine
         }
         T scale = numOps.Divide(numOps.FromDouble(2.0), numOps.FromDouble(reduceCount));
 
-        var inputStrides = ComputeStrides(inputShape);
-        var outputStrides = ComputeStrides(gradOutputShape);
-        var meanStrides = ComputeStrides(meanShape);
-        var varianceStrides = ComputeStrides(varianceShape);
-
+        // Allocation-free odometer (gradOutput + keepDims mean + variance) over
+        // the row-major input (replaces per-element FlatToMultiIndex + three
+        // List<int> + three MultiToFlatIndex + Contains).
+        int rlvRank = inputShape.Length;
+        var rlvOutStrideForDim = BuildReducedOutStrideForDim(inputShape, gradOutputShape, normalizedAxes);
+        var rlvMeanStrideForDim = BuildReducedOutStrideForDim(inputShape, meanShape, normalizedAxes);
+        var rlvVarStrideForDim = BuildReducedOutStrideForDim(inputShape, varianceShape, normalizedAxes);
+        var rlvCoord = new int[rlvRank];
+        int rlvOutFlat = 0, rlvMeanFlat = 0, rlvVarFlat = 0;
         for (int i = 0; i < inputSize; i++)
         {
-            var multiIndex = FlatToMultiIndex(i, inputShape, inputStrides);
-
-            // Map to output/variance index
-            var outputMultiIndex = new List<int>();
-            int d2 = 0;
-            for (int d = 0; d < inputShape.Length; d++)
-            {
-                if (normalizedAxes.Contains(d))
-                {
-                    if (d2 < gradOutputShape.Length && gradOutputShape[d2] == 1)
-                    {
-                        outputMultiIndex.Add(0);
-                        d2++;
-                    }
-                }
-                else
-                {
-                    if (d2 < gradOutputShape.Length)
-                    {
-                        outputMultiIndex.Add(multiIndex[d]);
-                        d2++;
-                    }
-                }
-            }
-            if (outputMultiIndex.Count == 0) outputMultiIndex.Add(0);
-            while (outputMultiIndex.Count < gradOutputShape.Length) outputMultiIndex.Add(0);
-            while (outputMultiIndex.Count > gradOutputShape.Length) outputMultiIndex.RemoveAt(outputMultiIndex.Count - 1);
-
-            int outputIdx = MultiToFlatIndex([.. outputMultiIndex], gradOutputShape, outputStrides);
-
-            // Map to mean index
-            var meanMultiIndex = new List<int>();
-            for (int d = 0; d < inputShape.Length; d++)
-            {
-                if (normalizedAxes.Contains(d))
-                    meanMultiIndex.Add(0);
-                else
-                    meanMultiIndex.Add(multiIndex[d]);
-            }
-            int meanIdx = MultiToFlatIndex([.. meanMultiIndex], meanShape, meanStrides);
-            int varianceIdx = MultiToFlatIndex([.. outputMultiIndex], varianceShape, varianceStrides);
-
             // gradient = 2 * (x - mean) / (N * variance) * gradOutput
             // = (x - mean) * scale / variance * gradOutput
-            T diff = numOps.Subtract(inputData[i], meanData[meanIdx]);
-            T varianceVal = varianceData[varianceIdx];
+            T diff = numOps.Subtract(inputData[i], meanData[rlvMeanFlat]);
+            T varianceVal = varianceData[rlvVarFlat];
             // Avoid division by zero
             if (numOps.LessThanOrEquals(varianceVal, numOps.Zero))
                 varianceVal = numOps.FromDouble(1e-8);
             T gradScale = numOps.Divide(scale, varianceVal);
-            gradInputData[i] = numOps.Multiply(numOps.Multiply(diff, gradScale), gradOutputData[outputIdx]);
+            gradInputData[i] = numOps.Multiply(numOps.Multiply(diff, gradScale), gradOutputData[rlvOutFlat]);
+            for (int d = rlvRank - 1; d >= 0; d--)
+            {
+                rlvCoord[d]++; rlvOutFlat += rlvOutStrideForDim[d]; rlvMeanFlat += rlvMeanStrideForDim[d]; rlvVarFlat += rlvVarStrideForDim[d];
+                if (rlvCoord[d] < inputShape[d]) break;
+                rlvCoord[d] = 0;
+                rlvOutFlat -= rlvOutStrideForDim[d] * inputShape[d];
+                rlvMeanFlat -= rlvMeanStrideForDim[d] * inputShape[d];
+                rlvVarFlat -= rlvVarStrideForDim[d] * inputShape[d];
+            }
         }
 
         return TensorAllocator.Rent<T>(inputShape, gradInputData);
@@ -28042,74 +28157,43 @@ public partial class CpuEngine : ITensorLevelEngine
         return strides;
     }
 
-    private static int[] FlatToMultiIndex(int flatIndex, int[] shape, int[] strides)
-    {
-        var multiIndex = new int[shape.Length];
-        for (int i = 0; i < shape.Length; i++)
-        {
-            multiIndex[i] = flatIndex / strides[i];
-            flatIndex %= strides[i];
-        }
-        return multiIndex;
-    }
-
-    private static int MultiToFlatIndex(int[] multiIndex, int[] shape, int[] strides)
-    {
-        int flatIndex = 0;
-        for (int i = 0; i < multiIndex.Length; i++)
-        {
-            flatIndex += multiIndex[i] * strides[i];
-        }
-        return flatIndex;
-    }
+    // NOTE: the former per-element FlatToMultiIndex / MultiToFlatIndex /
+    // MapToReducedIndex / MapToMeanIndex helpers were removed — all reduction /
+    // normalization kernels now use the allocation-free odometer driven by
+    // BuildReducedOutStrideForDim below (no per-element int[]/List<int> allocs).
 
     /// <summary>
-    /// Maps a multi-index from input space to reduced output space for variance backward pass.
+    /// Precomputes, for each INPUT dimension, the amount to add to a reduced-output
+    /// flat index when that input dimension's coordinate increments by 1. Reduced
+    /// dimensions contribute 0 (they collapse: in a keepDims output they are size-1
+    /// so the coord is always 0; in a non-keepDims output they are absent). This is
+    /// the allocation-free replacement for the old per-element
+    /// flat-to-multi-index + <c>new List&lt;int&gt;</c> + multi-to-flat-index +
+    /// <c>Contains</c> pattern: callers walk the flat row-major input once and
+    /// advance the output flat index with a reused odometer (see
+    /// <see cref="ReduceMean{T}"/>). Works for both reduced OUTPUT shapes and
+    /// keepDims-style MEAN shapes.
     /// </summary>
-    private static int MapToReducedIndex(int[] multiIndex, int[] inputShape, int[] outputShape, int[] normalizedAxes, int[] outputStrides)
+    private static int[] BuildReducedOutStrideForDim(int[] inputShape, int[] outputShape, int[] normalizedAxes)
     {
-        var outputMultiIndex = new List<int>();
-        int d2 = 0;
-        for (int d = 0; d < inputShape.Length; d++)
+        int rank = inputShape.Length;
+        var isReduced = new bool[rank];
+        foreach (int a in normalizedAxes) isReduced[a] = true;
+        var outStrides = ComputeStrides(outputShape);
+        var map = new int[rank];
+        // keepDims (or same-rank mean shape): output rank == input rank, reduced
+        // dims present with size 1 → contribute 0. Otherwise reduced dims are
+        // dropped and surviving dims keep their relative order.
+        if (outputShape.Length == rank)
         {
-            if (Array.IndexOf(normalizedAxes, d) >= 0)
-            {
-                if (d2 < outputShape.Length && outputShape[d2] == 1)
-                {
-                    outputMultiIndex.Add(0);
-                    d2++;
-                }
-            }
-            else
-            {
-                if (d2 < outputShape.Length)
-                {
-                    outputMultiIndex.Add(multiIndex[d]);
-                    d2++;
-                }
-            }
+            for (int d = 0; d < rank; d++) map[d] = isReduced[d] ? 0 : outStrides[d];
         }
-        if (outputMultiIndex.Count == 0) outputMultiIndex.Add(0);
-        while (outputMultiIndex.Count < outputShape.Length) outputMultiIndex.Add(0);
-        while (outputMultiIndex.Count > outputShape.Length) outputMultiIndex.RemoveAt(outputMultiIndex.Count - 1);
-
-        return MultiToFlatIndex([.. outputMultiIndex], outputShape, outputStrides);
-    }
-
-    /// <summary>
-    /// Maps a multi-index from input space to mean tensor space for variance backward pass.
-    /// </summary>
-    private static int MapToMeanIndex(int[] multiIndex, int[] inputShape, int[] meanShape, int[] normalizedAxes, int[] meanStrides)
-    {
-        var meanMultiIndex = new List<int>();
-        for (int d = 0; d < inputShape.Length; d++)
+        else
         {
-            if (Array.IndexOf(normalizedAxes, d) >= 0)
-                meanMultiIndex.Add(0);
-            else
-                meanMultiIndex.Add(multiIndex[d]);
+            int oi = 0;
+            for (int d = 0; d < rank; d++) map[d] = isReduced[d] ? 0 : outStrides[oi++];
         }
-        return MultiToFlatIndex([.. meanMultiIndex], meanShape, meanStrides);
+        return map;
     }
 
     #endregion
@@ -29410,14 +29494,25 @@ public partial class CpuEngine : ITensorLevelEngine
         {
             var tensorData = tensor.GetDataArray();
             var tensorShape = tensor._shape;
-            var tensorStrides = ComputeStrides(tensorShape);
 
-            for (int i = 0; i < tensor.Length; i++)
+            // Allocation-free odometer: output and input share rank; only the
+            // concat axis is offset. outFlat tracks the input coord mapped onto
+            // the output strides; the constant axis offset is added once
+            // (replaces per-element FlatToMultiIndex + MultiToFlatIndex).
+            int cRank = tensorShape.Length;
+            int cBase = axisOffset * outputStrides[axis];
+            var cCoord = new int[cRank];
+            int cOutFlat = 0;
+            int cLen = tensor.Length;
+            for (int i = 0; i < cLen; i++)
             {
-                var multiIndex = FlatToMultiIndex(i, tensorShape, tensorStrides);
-                multiIndex[axis] += axisOffset;
-                int outputIdx = MultiToFlatIndex(multiIndex, outputShape, outputStrides);
-                outputData[outputIdx] = tensorData[i];
+                outputData[cBase + cOutFlat] = tensorData[i];
+                for (int d = cRank - 1; d >= 0; d--)
+                {
+                    cCoord[d]++; cOutFlat += outputStrides[d];
+                    if (cCoord[d] < tensorShape[d]) break;
+                    cCoord[d] = 0; cOutFlat -= outputStrides[d] * tensorShape[d];
+                }
             }
 
             axisOffset += tensor._shape[axis];

--- a/src/AiDotNet.Tensors/Helpers/Im2ColHelper.cs
+++ b/src/AiDotNet.Tensors/Helpers/Im2ColHelper.cs
@@ -407,6 +407,103 @@ internal static class Im2ColHelper
     }
 
     /// <summary>
+    /// col2im accumulate (float) restricted to input channels
+    /// <paramref name="channelStart"/>..<paramref name="channelEnd"/>. Each channel
+    /// <c>c</c> scatters into the disjoint image slab <c>imageData[c*H*W .. (c+1)*H*W)</c>,
+    /// reading its rows from the contiguous <c>[colH, colW]</c> source
+    /// (row = <c>(c,kh,kw)</c>, col = <c>(oh,ow)</c>). Distinct channel ranges touch
+    /// disjoint output slabs AND each output element's full <c>+=</c> reduction is
+    /// performed by the single channel-owner in the serial <c>(kh,kw,oh,ow)</c> order,
+    /// so the scatter parallelizes over channels with no synchronization and is
+    /// bit-identical across thread counts (deterministic-safe — same disjoint-write,
+    /// fixed-order-reduction contract as the GEMM M/N-tile splits). The destination
+    /// region for the covered channels must be zero-initialized before calling.
+    /// With <c>channelStart = 0, channelEnd = channels</c> this is identical to
+    /// <see cref="Col2ImAccumulate(ReadOnlySpan{float}, Span{float}, int, int, int, int, int, int, int, int, int, int, int, int)"/>.
+    /// </summary>
+    public static void Col2ImAccumulateChannelRange(
+        ReadOnlySpan<float> colData,
+        Span<float> imageData,
+        int channelStart, int channelEnd,
+        int height, int width,
+        int kernelH, int kernelW,
+        int strideH, int strideW,
+        int padH, int padW,
+        int dilationH, int dilationW,
+        int outputH, int outputW)
+    {
+        int colW = outputH * outputW;
+        int kHW = kernelH * kernelW;
+        int colIdx = channelStart * kHW * colW;
+        for (int c = channelStart; c < channelEnd; c++)
+        {
+            int channelBase = c * height * width;
+            for (int kh = 0; kh < kernelH; kh++)
+            {
+                for (int kw = 0; kw < kernelW; kw++)
+                {
+                    for (int oh = 0; oh < outputH; oh++)
+                    {
+                        int ih = oh * strideH + kh * dilationH - padH;
+                        for (int ow = 0; ow < outputW; ow++)
+                        {
+                            int iw = ow * strideW + kw * dilationW - padW;
+                            if (ih >= 0 && ih < height && iw >= 0 && iw < width)
+                            {
+                                imageData[channelBase + ih * width + iw] += colData[colIdx];
+                            }
+                            colIdx++;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Double-precision counterpart of
+    /// <see cref="Col2ImAccumulateChannelRange(ReadOnlySpan{float}, Span{float}, int, int, int, int, int, int, int, int, int, int, int, int, int, int)"/>.
+    /// </summary>
+    public static void Col2ImAccumulateChannelRange(
+        ReadOnlySpan<double> colData,
+        Span<double> imageData,
+        int channelStart, int channelEnd,
+        int height, int width,
+        int kernelH, int kernelW,
+        int strideH, int strideW,
+        int padH, int padW,
+        int dilationH, int dilationW,
+        int outputH, int outputW)
+    {
+        int colW = outputH * outputW;
+        int kHW = kernelH * kernelW;
+        int colIdx = channelStart * kHW * colW;
+        for (int c = channelStart; c < channelEnd; c++)
+        {
+            int channelBase = c * height * width;
+            for (int kh = 0; kh < kernelH; kh++)
+            {
+                for (int kw = 0; kw < kernelW; kw++)
+                {
+                    for (int oh = 0; oh < outputH; oh++)
+                    {
+                        int ih = oh * strideH + kh * dilationH - padH;
+                        for (int ow = 0; ow < outputW; ow++)
+                        {
+                            int iw = ow * strideW + kw * dilationW - padW;
+                            if (ih >= 0 && ih < height && iw >= 0 && iw < width)
+                            {
+                                imageData[channelBase + ih * width + iw] += colData[colIdx];
+                            }
+                            colIdx++;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// <summary>
     /// col2im: inverse of im2col. Accumulates column matrix values back into a spatial
     /// image buffer. Multiple column entries can map to the same spatial position (due to
     /// overlapping receptive fields), so values are ADDED (not overwritten). The output

--- a/src/AiDotNet.Tensors/LinearAlgebra/Tensor.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/Tensor.cs
@@ -164,6 +164,15 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
         ThrowIfSparse();
         if (IsContiguous && _storageOffset == 0) return this;
 
+        if (Environment.GetEnvironmentVariable("AIDOTNET_DEBUG_CONTIG") == "1" && Length >= 256)
+        {
+            try
+            {
+                Console.Error.WriteLine($"[CONTIG] off={_storageOffset} contig={IsContiguous} shape=[{string.Join(",", _shape)}] strides=[{string.Join(",", _strides)}] len={Length}\n{new System.Diagnostics.StackTrace(1, false)}");
+            }
+            catch { }
+        }
+
         var result = new Tensor<T>(_shape);
         var dstSpan = result._data.AsWritableSpan();
 
@@ -1431,6 +1440,96 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
         }
 
         var result = new Tensor<T>(newShape);
+
+        // Fast path: contiguous source with at least one surviving dim. The
+        // recursive fallback below allocates a `new int[result.Rank]` and does
+        // two multi-dim indexer round-trips PLUS an axes.Contains() scan FOR
+        // EVERY ELEMENT — for a [1,64,224,224] gradient reduced over {0,2,3}
+        // (every conv bias / BatchNorm / broadcast backward) that is 3.2M heap
+        // allocations + millions of virtual dispatches per reduction, which
+        // profiled as ~40% of a ResNet CPU train step. This path walks the flat
+        // row-major backing once with a reused odometer, advancing the output
+        // flat index incrementally (no per-element allocation, no indexer, no
+        // Contains). Accumulation order is identical to SumRecursive (source
+        // row-major, innermost dim fastest), so results are bit-identical.
+        int rank = Rank;
+        int outRank = newShape.Length;
+        if (IsContiguous && _storageOffset == 0 && outRank > 0)
+        {
+            // Row-major strides of the output shape.
+            var outStrides = new int[outRank];
+            int strideAcc = 1;
+            for (int i = outRank - 1; i >= 0; i--) { outStrides[i] = strideAcc; strideAcc *= newShape[i]; }
+
+            // Per-source-dim contribution to the output flat index: a reduced
+            // dim contributes 0 (it collapses), a surviving dim contributes its
+            // output stride. Surviving dims keep their original relative order,
+            // matching how newShape was built above.
+            var outStrideForDim = new int[rank];
+            int oi = 0;
+            for (int d = 0; d < rank; d++)
+            {
+                bool reduced = false;
+                for (int a = 0; a < axes.Length; a++) { if (axes[a] == d) { reduced = true; break; } }
+                outStrideForDim[d] = reduced ? 0 : outStrides[oi++];
+            }
+
+            var coord = new int[rank];
+            int len = Length;
+            int outFlat = 0;
+
+            // Typed fast paths: read the raw backing array (offset-adjusted) and
+            // accumulate with the native operator — no INumericOperations virtual
+            // dispatch. float/double cover the overwhelmingly common training dtypes.
+            if (typeof(T) == typeof(float))
+            {
+                var s = (float[])(object)GetDataArray();
+                var r = (float[])(object)result.GetDataArray();
+                for (int i = 0; i < len; i++)
+                {
+                    r[outFlat] += s[i];
+                    for (int d = rank - 1; d >= 0; d--)
+                    {
+                        coord[d]++; outFlat += outStrideForDim[d];
+                        if (coord[d] < _shape[d]) break;
+                        coord[d] = 0; outFlat -= outStrideForDim[d] * _shape[d];
+                    }
+                }
+                return result;
+            }
+            if (typeof(T) == typeof(double))
+            {
+                var s = (double[])(object)GetDataArray();
+                var r = (double[])(object)result.GetDataArray();
+                for (int i = 0; i < len; i++)
+                {
+                    r[outFlat] += s[i];
+                    for (int d = rank - 1; d >= 0; d--)
+                    {
+                        coord[d]++; outFlat += outStrideForDim[d];
+                        if (coord[d] < _shape[d]) break;
+                        coord[d] = 0; outFlat -= outStrideForDim[d] * _shape[d];
+                    }
+                }
+                return result;
+            }
+
+            // Generic T: still allocation-free / indexer-free; only Add is virtual.
+            var src = AsSpan();
+            var rArr = result.GetDataArray();
+            for (int i = 0; i < len; i++)
+            {
+                rArr[outFlat] = _numOps.Add(rArr[outFlat], src[i]);
+                for (int d = rank - 1; d >= 0; d--)
+                {
+                    coord[d]++; outFlat += outStrideForDim[d];
+                    if (coord[d] < _shape[d]) break;
+                    coord[d] = 0; outFlat -= outStrideForDim[d] * _shape[d];
+                }
+            }
+            return result;
+        }
+
         int[] indices = new int[Rank];
         SumRecursive(result, axes, indices, 0);
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/PrePackConcurrencyStress.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/PrePackConcurrencyStress.cs
@@ -16,7 +16,20 @@ namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
 /// do). If a production race exists in the shared allocator / packed-buffer path,
 /// this should surface it locally; if it stays bit-exact under heavy stress, the CI
 /// flake is environment-specific cross-test contamination (→ test isolation).
+///
+/// Outcome: the pack path stays bit-exact under this stress, so there is NO
+/// production race — the CI flake was cross-test contamination. This test's own
+/// background agitator (below) continuously flips the process-global
+/// <see cref="CpuParallelSettings.DeterministicReductions"/> /
+/// <see cref="CpuParallelSettings.MaxDegreeOfParallelism"/>; running un-serialized it
+/// drifted the deterministic GEMMs of CONCURRENT tests (PrePackedB_Output_BitMatches_LivePack,
+/// the ScalarKernel cached-packed-buffer tests) mid-computation. It belongs in the
+/// "every test that mutates process-wide GEMM global state" serial collection — it
+/// was simply missing the attribute. Membership serializes it against those tests so
+/// its agitation can no longer corrupt them; its OWN internal concurrency stress
+/// (8-thread Parallel.For) is unaffected.
 /// </summary>
+[Collection("BlasManaged-Stats-Serial")]
 [Trait("Category", "Performance")] // heavy (19k ops); a concurrency regression guard
 public class PrePackConcurrencyStress
 {
@@ -33,6 +46,13 @@ public class PrePackConcurrencyStress
         double worstDrift = 0;
         var sync = new object();
 
+        // Snapshot the global settings the agitator mutates so they are always
+        // restored — even if the Parallel.For below throws. Leaking a running
+        // agitator (or a flipped global) into the next test in this serial
+        // collection is exactly the contamination this collection exists to prevent.
+        bool savedDeterministic = CpuParallelSettings.DeterministicReductions;
+        int savedMaxDop = CpuParallelSettings.MaxDegreeOfParallelism;
+
         // A background agitator that flips the global parallel settings the way the
         // ParallelFor / DeterministicReductions tests do — to mimic cross-test churn.
         using var stop = new CancellationTokenSource();
@@ -47,39 +67,44 @@ public class PrePackConcurrencyStress
             }
         });
 
-        Parallel.For(0, threads, t =>
+        try
         {
-            var rng = new Random(1234 + t);
-            var a = new float[m * k];
-            var b = new float[k * n];
-            for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
-            for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
-            var cLive = new float[m * n];
-            var cPre = new float[m * n];
-
-            for (int it = 0; it < itersPerThread; it++)
+            Parallel.For(0, threads, t =>
             {
-                BlasManagedLib.Gemm<float>(a, k, false, b, n, false, cLive, n, m, n, k);
-                var handle = BlasManagedLib.PrePackB<float>(b, n, false, k, n);
-                try
+                var rng = new Random(1234 + t);
+                var a = new float[m * k];
+                var b = new float[k * n];
+                for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+                for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+                var cLive = new float[m * n];
+                var cPre = new float[m * n];
+
+                for (int it = 0; it < itersPerThread; it++)
                 {
-                    var opts = new BlasOptions<float> { PackedB = handle };
-                    BlasManagedLib.Gemm<float>(a, k, false, b, n, false, cPre, n, m, n, k, opts);
+                    BlasManagedLib.Gemm<float>(a, k, false, b, n, false, cLive, n, m, n, k);
+                    var handle = BlasManagedLib.PrePackB<float>(b, n, false, k, n);
+                    try
+                    {
+                        var opts = new BlasOptions<float> { PackedB = handle };
+                        BlasManagedLib.Gemm<float>(a, k, false, b, n, false, cPre, n, m, n, k, opts);
+                    }
+                    finally { handle.Dispose(); }
+
+                    double drift = 0;
+                    for (int i = 0; i < cLive.Length; i++)
+                        drift = Math.Max(drift, Math.Abs((double)cLive[i] - cPre[i]));
+                    if (drift > 1e-3)
+                        lock (sync) { failures++; worstDrift = Math.Max(worstDrift, drift); }
                 }
-                finally { handle.Dispose(); }
-
-                double drift = 0;
-                for (int i = 0; i < cLive.Length; i++)
-                    drift = Math.Max(drift, Math.Abs((double)cLive[i] - cPre[i]));
-                if (drift > 1e-3)
-                    lock (sync) { failures++; worstDrift = Math.Max(worstDrift, drift); }
-            }
-        });
-
-        stop.Cancel();
-        agitator.Wait();
-        CpuParallelSettings.DeterministicReductions = false;
-        CpuParallelSettings.MaxDegreeOfParallelism = Environment.ProcessorCount;
+            });
+        }
+        finally
+        {
+            stop.Cancel();
+            agitator.Wait();
+            CpuParallelSettings.DeterministicReductions = savedDeterministic;
+            CpuParallelSettings.MaxDegreeOfParallelism = savedMaxDop;
+        }
 
         _output.WriteLine($"threads={threads} iters/thread={itersPerThread} failures={failures} worstDrift={worstDrift:G6}");
         Assert.True(failures == 0,

--- a/tests/AiDotNet.Tensors.Tests/Engines/Conv2DBackwardChannelParallelTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Conv2DBackwardChannelParallelTests.cs
@@ -139,7 +139,12 @@ public class Conv2DBackwardChannelParallelTests
             {
                 Assert.True(Math.Abs(allocating[i] - dest[i]) < 1e-3f,
                     $"[{i}] alloc={allocating[i]:F6} into={dest[i]:F6}");
-                Assert.True(Math.Abs(expected[i] - dest[i]) < 1e-2f,
+                // Into vs the double-accumulated scalar reference. The Into path
+                // accumulates K=colW=1024 float terms in one GEMM, so the only gap
+                // is float-vs-double rounding — measured max ≈ 8e-6 at this shape,
+                // so 1e-4f keeps ~12× headroom while still catching real numerical
+                // regressions (was 1e-2f, ~1200× looser than the actual error).
+                Assert.True(Math.Abs(expected[i] - dest[i]) < 1e-4f,
                     $"[{i}] ref={expected[i]:F6} into={dest[i]:F6}");
             }
         }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Conv2DBackwardChannelParallelTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Conv2DBackwardChannelParallelTests.cs
@@ -1,0 +1,252 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// #403 small-batch channel-parallel conv-backward contract. At batch=1 (the CNN
+// model-family training shape [1,3,224,224]) Conv2DBackwardInputInto /
+// Conv2DBackwardKernelInto can no longer parallelize over the batch axis, so the
+// im2col build (Im2ColStridedSingleChannelRange) and the col2im scatter
+// (Col2ImAccumulateChannelRange) parallelize over INPUT CHANNELS instead — each
+// channel owns a disjoint c*H*W output slab / kH*kW im2col row block, so the
+// scatter is race-free AND each output element's += reduction stays on a single
+// thread in fixed order. This pins two properties the parallelization must keep:
+//   1. Correctness: the Into result matches the allocating reference AND a scalar
+//      reference, at a shape large enough that the channel loop actually runs
+//      multi-threaded (work above the grain gate) and receptive fields overlap
+//      (stride=1, k=3, pad=1 → every interior input pixel accumulates 9 columns).
+//   2. Determinism: under deterministic mode (the training harness setting) the
+//      same backward run at MaxDegreeOfParallelism 1 / 2 / 4 / 16 — which changes
+//      the channel-partition boundaries — is BIT-IDENTICAL. deterministicSafe=true
+//      on the channel loops keeps them parallel in deterministic mode, so this is
+//      the executable guard that the disjoint-write/fixed-order-reduction contract
+//      holds (same shape as DeterministicParallelGemmContractTests, for conv).
+
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.BlasManaged;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+// Toggles process-wide deterministic mode + MaxDegreeOfParallelism; serialize
+// against the other determinism-sensitive tests.
+[Collection("BlasManaged-Stats-Serial")]
+public class Conv2DBackwardChannelParallelTests
+{
+    // batch=1 forces the channel-parallel path. inC=16, H=W=32, k=3, p=1, s=1 →
+    // colW = 32*32 = 1024, channel work = inC*kH*kW*colW = 16*9*1024 = 147456,
+    // well above the 32K serial grain gate, so the channel loop runs in parallel.
+    private const int Batch = 1, InC = 16, H = 32, W = 32, OutC = 16, KH = 3, KW = 3;
+    private const int PadH = 1, PadW = 1;
+    private const int OH = H + 2 * PadH - KH + 1; // = H
+    private const int OW = W + 2 * PadW - KW + 1; // = W
+
+    private static readonly int[] ThreadCounts = { 1, 2, 4, 16 };
+
+    [Fact]
+    public void BackwardInput_FLOAT_ChannelParallel_MatchesAllocatingAndScalarReference()
+    {
+        var engine = new CpuEngine();
+        var rng = new Random(2024);
+        var gradOut = new Tensor<float>(new[] { Batch, OutC, OH, OW });
+        for (int i = 0; i < gradOut.Length; i++) gradOut[i] = (float)(rng.NextDouble() - 0.5);
+        var kernel = new Tensor<float>(new[] { OutC, InC, KH, KW });
+        for (int i = 0; i < kernel.Length; i++) kernel[i] = (float)(rng.NextDouble() - 0.5);
+
+        int beforeMax = CpuParallelSettings.MaxDegreeOfParallelism;
+        try
+        {
+            CpuParallelSettings.MaxDegreeOfParallelism = Math.Max(4, Environment.ProcessorCount);
+
+            var allocating = engine.Conv2DBackwardInput(gradOut, kernel,
+                new[] { Batch, InC, H, W }, new[] { 1, 1 }, new[] { PadH, PadW }, new[] { 1, 1 });
+            var dest = new Tensor<float>(new[] { Batch, InC, H, W });
+            engine.Conv2DBackwardInputInto(dest, gradOut, kernel,
+                new[] { Batch, InC, H, W }, new[] { 1, 1 }, new[] { PadH, PadW }, new[] { 1, 1 },
+                accumulate: false);
+
+            // Scalar reference straight from the backward-input definition.
+            var expected = new float[Batch * InC * H * W];
+            for (int ic = 0; ic < InC; ic++)
+                for (int ih = 0; ih < H; ih++)
+                    for (int iw = 0; iw < W; iw++)
+                    {
+                        double sum = 0.0;
+                        for (int oc = 0; oc < OutC; oc++)
+                            for (int kh = 0; kh < KH; kh++)
+                                for (int kw = 0; kw < KW; kw++)
+                                {
+                                    int oh = ih + PadH - kh;
+                                    int ow = iw + PadW - kw;
+                                    if (oh < 0 || oh >= OH || ow < 0 || ow >= OW) continue;
+                                    sum += (double)kernel[oc, ic, kh, kw] * gradOut[0, oc, oh, ow];
+                                }
+                        expected[(ic * H + ih) * W + iw] = (float)sum;
+                    }
+
+            for (int i = 0; i < dest.Length; i++)
+            {
+                Assert.True(Math.Abs(allocating[i] - dest[i]) < 1e-4f,
+                    $"[{i}] alloc={allocating[i]:F6} into={dest[i]:F6}");
+                Assert.True(Math.Abs(expected[i] - dest[i]) < 1e-3f,
+                    $"[{i}] ref={expected[i]:F6} into={dest[i]:F6}");
+            }
+        }
+        finally { CpuParallelSettings.MaxDegreeOfParallelism = beforeMax; }
+    }
+
+    [Fact]
+    public void BackwardKernel_FLOAT_ChannelParallel_MatchesAllocatingAndScalarReference()
+    {
+        var engine = new CpuEngine();
+        var rng = new Random(2025);
+        var gradOut = new Tensor<float>(new[] { Batch, OutC, OH, OW });
+        for (int i = 0; i < gradOut.Length; i++) gradOut[i] = (float)(rng.NextDouble() - 0.5);
+        var input = new Tensor<float>(new[] { Batch, InC, H, W });
+        for (int i = 0; i < input.Length; i++) input[i] = (float)(rng.NextDouble() - 0.5);
+
+        int beforeMax = CpuParallelSettings.MaxDegreeOfParallelism;
+        try
+        {
+            CpuParallelSettings.MaxDegreeOfParallelism = Math.Max(4, Environment.ProcessorCount);
+
+            var allocating = engine.Conv2DBackwardKernel(gradOut, input,
+                new[] { OutC, InC, KH, KW }, new[] { 1, 1 }, new[] { PadH, PadW }, new[] { 1, 1 });
+            var dest = new Tensor<float>(new[] { OutC, InC, KH, KW });
+            engine.Conv2DBackwardKernelInto(dest, gradOut, input,
+                new[] { OutC, InC, KH, KW }, new[] { 1, 1 }, new[] { PadH, PadW }, new[] { 1, 1 },
+                accumulate: false);
+
+            // Scalar reference straight from the backward-kernel definition.
+            var expected = new float[OutC * InC * KH * KW];
+            for (int oc = 0; oc < OutC; oc++)
+                for (int ic = 0; ic < InC; ic++)
+                    for (int kh = 0; kh < KH; kh++)
+                        for (int kw = 0; kw < KW; kw++)
+                        {
+                            double sum = 0.0;
+                            for (int oh = 0; oh < OH; oh++)
+                                for (int ow = 0; ow < OW; ow++)
+                                {
+                                    int ih = oh + kh - PadH;
+                                    int iw = ow + kw - PadW;
+                                    if (ih < 0 || ih >= H || iw < 0 || iw >= W) continue;
+                                    sum += (double)gradOut[0, oc, oh, ow] * input[0, ic, ih, iw];
+                                }
+                            expected[((oc * InC + ic) * KH + kh) * KW + kw] = (float)sum;
+                        }
+
+            for (int i = 0; i < dest.Length; i++)
+            {
+                Assert.True(Math.Abs(allocating[i] - dest[i]) < 1e-3f,
+                    $"[{i}] alloc={allocating[i]:F6} into={dest[i]:F6}");
+                Assert.True(Math.Abs(expected[i] - dest[i]) < 1e-2f,
+                    $"[{i}] ref={expected[i]:F6} into={dest[i]:F6}");
+            }
+        }
+        finally { CpuParallelSettings.MaxDegreeOfParallelism = beforeMax; }
+    }
+
+    [Fact]
+    public void BackwardInput_DOUBLE_BitIdentical_AcrossThreadCounts()
+        => AssertBackwardInputBitIdenticalAcrossThreadCounts();
+
+    [Fact]
+    public void BackwardKernel_DOUBLE_BitIdentical_AcrossThreadCounts()
+        => AssertBackwardKernelBitIdenticalAcrossThreadCounts();
+
+    private static void AssertBackwardInputBitIdenticalAcrossThreadCounts()
+    {
+        var engine = new CpuEngine();
+        var rng = new Random(31);
+        var gradOut = new Tensor<double>(new[] { Batch, OutC, OH, OW });
+        for (int i = 0; i < gradOut.Length; i++) gradOut[i] = rng.NextDouble() - 0.5;
+        var kernel = new Tensor<double>(new[] { OutC, InC, KH, KW });
+        for (int i = 0; i < kernel.Length; i++) kernel[i] = rng.NextDouble() - 0.5;
+
+        bool? beforeThreadDet = BlasProvider.GetThreadLocalDeterministicMode();
+        if (beforeThreadDet is not null) BlasProvider.SetThreadLocalDeterministicMode(null);
+        bool beforeDet = BlasProvider.IsDeterministicMode;
+        bool beforeReductions = CpuParallelSettings.DeterministicReductions;
+        int beforeMax = CpuParallelSettings.MaxDegreeOfParallelism;
+        try
+        {
+            BlasProvider.SetDeterministicMode(true);
+            CpuParallelSettings.DeterministicReductions = true;
+
+            double[]? reference = null;
+            int referenceThreads = 0;
+            foreach (int threads in ThreadCounts)
+            {
+                CpuParallelSettings.MaxDegreeOfParallelism = threads;
+                var dest = new Tensor<double>(new[] { Batch, InC, H, W });
+                engine.Conv2DBackwardInputInto(dest, gradOut, kernel,
+                    new[] { Batch, InC, H, W }, new[] { 1, 1 }, new[] { PadH, PadW }, new[] { 1, 1 },
+                    accumulate: false);
+                var result = new double[dest.Length];
+                for (int i = 0; i < dest.Length; i++) result[i] = dest[i];
+
+                if (reference is null) { reference = result; referenceThreads = threads; }
+                else
+                    for (int i = 0; i < reference.Length; i++)
+                        Assert.True(reference[i] == result[i],
+                            $"backward-input not bit-identical: threads={referenceThreads} vs {threads} at [{i}]: " +
+                            $"{reference[i]:R} vs {result[i]:R}");
+            }
+        }
+        finally
+        {
+            BlasProvider.SetDeterministicMode(beforeDet);
+            if (beforeThreadDet is not null) BlasProvider.SetThreadLocalDeterministicMode(beforeThreadDet);
+            CpuParallelSettings.DeterministicReductions = beforeReductions;
+            CpuParallelSettings.MaxDegreeOfParallelism = beforeMax;
+        }
+    }
+
+    private static void AssertBackwardKernelBitIdenticalAcrossThreadCounts()
+    {
+        var engine = new CpuEngine();
+        var rng = new Random(32);
+        var gradOut = new Tensor<double>(new[] { Batch, OutC, OH, OW });
+        for (int i = 0; i < gradOut.Length; i++) gradOut[i] = rng.NextDouble() - 0.5;
+        var input = new Tensor<double>(new[] { Batch, InC, H, W });
+        for (int i = 0; i < input.Length; i++) input[i] = rng.NextDouble() - 0.5;
+
+        bool? beforeThreadDet = BlasProvider.GetThreadLocalDeterministicMode();
+        if (beforeThreadDet is not null) BlasProvider.SetThreadLocalDeterministicMode(null);
+        bool beforeDet = BlasProvider.IsDeterministicMode;
+        bool beforeReductions = CpuParallelSettings.DeterministicReductions;
+        int beforeMax = CpuParallelSettings.MaxDegreeOfParallelism;
+        try
+        {
+            BlasProvider.SetDeterministicMode(true);
+            CpuParallelSettings.DeterministicReductions = true;
+
+            double[]? reference = null;
+            int referenceThreads = 0;
+            foreach (int threads in ThreadCounts)
+            {
+                CpuParallelSettings.MaxDegreeOfParallelism = threads;
+                var dest = new Tensor<double>(new[] { OutC, InC, KH, KW });
+                engine.Conv2DBackwardKernelInto(dest, gradOut, input,
+                    new[] { OutC, InC, KH, KW }, new[] { 1, 1 }, new[] { PadH, PadW }, new[] { 1, 1 },
+                    accumulate: false);
+                var result = new double[dest.Length];
+                for (int i = 0; i < dest.Length; i++) result[i] = dest[i];
+
+                if (reference is null) { reference = result; referenceThreads = threads; }
+                else
+                    for (int i = 0; i < reference.Length; i++)
+                        Assert.True(reference[i] == result[i],
+                            $"backward-kernel not bit-identical: threads={referenceThreads} vs {threads} at [{i}]: " +
+                            $"{reference[i]:R} vs {result[i]:R}");
+            }
+        }
+        finally
+        {
+            BlasProvider.SetDeterministicMode(beforeDet);
+            if (beforeThreadDet is not null) BlasProvider.SetThreadLocalDeterministicMode(beforeThreadDet);
+            CpuParallelSettings.DeterministicReductions = beforeReductions;
+            CpuParallelSettings.MaxDegreeOfParallelism = beforeMax;
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/TensorSumAxesFastPathTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/TensorSumAxesFastPathTests.cs
@@ -1,0 +1,107 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Pins the allocation-free contiguous fast path added to Tensor<T>.Sum(int[] axes)
+// (Tensor.cs). Profiling found the old SumRecursive — a `new int[]` heap alloc +
+// multi-dim strided indexer + axes.Contains() scan PER ELEMENT — was ~40% of a
+// ResNet CPU train step (every conv bias / BatchNorm / broadcast gradient reduces
+// [B,C,H,W] over axes). The fast path walks the flat row-major backing once with a
+// reused odometer. These tests assert it is bit-identical to an independent scalar
+// reference across shapes / axis combinations / dtypes, AND that the non-contiguous
+// fallback (SumRecursive) still agrees (transposed view).
+
+using System;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+public class TensorSumAxesFastPathTests
+{
+    public static TheoryData<int[], int[]> Cases => new()
+    {
+        { new[] { 1, 64, 16, 16 }, new[] { 0, 2, 3 } },  // conv bias-grad shape (batch+spatial)
+        { new[] { 2, 8, 5, 7 },    new[] { 0, 2, 3 } },  // batch>1 bias-grad
+        { new[] { 4, 6, 9 },       new[] { 1 } },        // single interior axis
+        { new[] { 4, 6, 9 },       new[] { 0 } },        // single leading axis
+        { new[] { 4, 6, 9 },       new[] { 2 } },        // single trailing axis
+        { new[] { 3, 5, 7, 2 },    new[] { 1, 3 } },     // non-adjacent axes
+        { new[] { 5, 4 },          new[] { 0 } },        // 2D
+        { new[] { 5, 4 },          new[] { 1 } },        // 2D other axis
+    };
+
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public void SumAxes_Double_MatchesScalarReference(int[] shape, int[] axes)
+        => AssertMatchesReference<double>(shape, axes, seed: 7,
+            gen: rng => rng.NextDouble() - 0.5, tol: 1e-12);
+
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public void SumAxes_Float_MatchesScalarReference(int[] shape, int[] axes)
+        => AssertMatchesReference<float>(shape, axes, seed: 9,
+            gen: rng => (float)(rng.NextDouble() - 0.5), tol: 1e-3);
+
+    private static void AssertMatchesReference<T>(int[] shape, int[] axes, int seed,
+        Func<Random, T> gen, double tol)
+    {
+        var rng = new Random(seed);
+        var t = new Tensor<T>(shape);
+        for (int i = 0; i < t.Length; i++) t[i] = gen(rng);
+
+        var actual = t.Sum(axes);
+
+        // Independent reference: brute-force reduce in row-major order into a
+        // dense [non-reduced dims] buffer using the public indexer + odometer.
+        int rank = shape.Length;
+        var reduce = new bool[rank];
+        foreach (int a in axes) reduce[a] = true;
+        var outShape = new System.Collections.Generic.List<int>();
+        for (int d = 0; d < rank; d++) if (!reduce[d]) outShape.Add(shape[d]);
+        int outLen = 1; foreach (int s in outShape) outLen *= s;
+        var outStrides = new int[outShape.Count];
+        int acc = 1;
+        for (int i = outShape.Count - 1; i >= 0; i--) { outStrides[i] = acc; acc *= outShape[i]; }
+
+        var expected = new double[outLen];
+        var coord = new int[rank];
+        int total = t.Length;
+        for (int flat = 0; flat < total; flat++)
+        {
+            // decode flat -> coord (row-major over shape)
+            int rem = flat;
+            for (int d = rank - 1; d >= 0; d--) { coord[d] = rem % shape[d]; rem /= shape[d]; }
+            int outFlat = 0, oi = 0;
+            for (int d = 0; d < rank; d++) if (!reduce[d]) outFlat += coord[d] * outStrides[oi++];
+            expected[outFlat] += Convert.ToDouble(t[coord]);
+        }
+
+        Assert.Equal(outLen, actual.Length);
+        for (int i = 0; i < outLen; i++)
+            Assert.True(Math.Abs(Convert.ToDouble(actual[i]) - expected[i]) <= tol,
+                $"[{i}] actual={Convert.ToDouble(actual[i])} expected={expected[i]}");
+    }
+
+    [Fact]
+    public void SumAxes_NonContiguousView_MatchesReference()
+    {
+        // Transposed view is non-contiguous → exercises the SumRecursive fallback.
+        var rng = new Random(13);
+        var t = new Tensor<double>(new[] { 3, 4, 5 });
+        for (int i = 0; i < t.Length; i++) t[i] = rng.NextDouble() - 0.5;
+
+        var view = t.Transpose(new[] { 2, 0, 1 }); // shape [5,3,4], non-contiguous
+        Assert.False(view.IsContiguous);
+
+        var actual = view.Sum(new[] { 0, 2 }); // reduce over axes 0 and 2 → [3]
+
+        var expected = new double[3];
+        for (int a = 0; a < 5; a++)
+            for (int b = 0; b < 3; b++)
+                for (int c = 0; c < 4; c++)
+                    expected[b] += view[a, b, c];
+
+        Assert.Equal(3, actual.Length);
+        for (int i = 0; i < 3; i++)
+            Assert.True(Math.Abs(actual[i] - expected[i]) <= 1e-12,
+                $"[{i}] actual={actual[i]} expected={expected[i]}");
+    }
+}


### PR DESCRIPTION
## Summary

Two CPU training hot-path fixes found by profiling the ModelFamily CNN shards (ResNet/VGG) that time out under the 120/180 s CI budget. **Both preserve exact numerics** — the ResNet50 train-step loss/L2 are bit-identical before and after.

### 1. Allocation-free axis reductions (the big win)
`Tensor<T>.Sum(int[] axes)` (via `SumRecursive`) and the `CpuEngine` reduction/normalization kernels — `ReduceMean`, `ReduceMax`, `ReduceMeanBackward`, `ReduceVariance`, `ReduceVarianceTapeAware`, `ReduceVarianceBackward`, `ReduceLogVarianceBackward`, `Concat` — allocated a `new int[]` / `List<int>` **per element**, plus an `axes.Contains()` scan and a multi-dim strided indexer. For a `[1,64,224,224]` gradient reduced over `{0,2,3}` that's **3.2M heap allocations per reduction**, on every conv-bias / BatchNorm / broadcast backward, every step — profiled at **~40% of a ResNet50 CPU train step**.

Replaced with a single allocation-free odometer over the flat row-major backing (shared `BuildReducedOutStrideForDim` helper), float/double specialized to raw arrays. The recursive / `Contains` / `MapTo*` helpers are removed. Accumulation order is unchanged, so results are bit-identical.

**Result: ResNet50 double train step 2553 ms → ~1150 ms (~2.2×).**

### 2. Small-batch channel-parallel conv-backward
`Conv2DBackwardInputInto` / `Conv2DBackwardKernelInto` parallelized only over the batch axis, so at **batch=1** (the CNN model-family training shape `[1,3,224,224]`) the whole backward ran single-threaded — and `ParallelForOrSerial(0, 1, ...)` even sets `_inParallelRegion`, collapsing the inner BLAS GEMM to serial too. Now at small batch the batch loop runs inline (GEMM auto-parallelizes) and the im2col / col2im transforms parallelize over **input channels** (disjoint `c*H*W` slabs / `kH*kW` row blocks, `deterministicSafe`). Adds `Im2ColHelper.Col2ImAccumulateChannelRange` and removes the per-batch `localGrad` allocation in the serial-batch kernel-grad path.

## Verification
- **New tests:**
  - `TensorSumAxesFastPathTests` — odometer vs an independent scalar reference across shapes / axis combinations / dtypes, including the non-contiguous fallback.
  - `Conv2DBackwardChannelParallelTests` — `Into` vs allocating + scalar reference at a parallelizing shape, and **bit-identical across `MaxDegreeOfParallelism` {1,2,4,16}** under deterministic mode (pins the disjoint-write / fixed-order-reduction contract).
- Existing `Conv2DBackwardIntoTests` and the reduction / BatchNorm / LayerNorm / Concat suites stay green.
- Measured CI-faithful (GPU disabled, deterministic mode = single-thread OpenBLAS + managed deterministic GEMM).

## Notes / out of scope
VGG16 / DenseNet at this config are bound by the **managed double GEMM microkernel** (not reductions); the reduction sweep doesn't move them and a direct-double-conv route was measured *slower*, so optimizing the double GEMM is left as separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Issue linkage:** delivers the **compute** half of ooples/AiDotNet#1463 (paper-scale CNN/diffusion CI shards are conv-GEMM compute-bound). The companion **memory/OOM** half is ooples/AiDotNet#1485. (Cross-repo references do not auto-close; AiDotNet#1463 closes when both land and AiDotNet bumps to the Tensors release containing this PR.)
