### PR TITLE
test(#374): validate routing shim across the full production shape catalog

### DIFF
--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/RoutingShimTest.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/RoutingShimTest.cs
@@ -1,6 +1,7 @@
 using System;
 using AiDotNet.Tensors.Engines.BlasManaged;
 using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.Tests.Engines.BlasManaged.Catalog;
 using Xunit;
 using BlasManagedLib = AiDotNet.Tensors.Engines.BlasManaged.BlasManaged;
 
@@ -198,5 +199,111 @@ public class RoutingShimTest
             BlasProvider.SetThreadLocalDeterministicMode(beforeThreadDet);
             BlasManagedLib.PreferManaged = false;
         }
+    }
+
+    // #374 acceptance (the managed-only routed path): the per-shape tests above cover a
+    // couple of hand-picked sizes; this sweeps the WHOLE production shape catalog (the
+    // 50-80 instrumented + workload shapes the shim must serve). With PreferManaged=true,
+    // EVERY shape must route through the managed kernel (TryGemmEx returns true) and
+    // produce a numerically correct GEMM — catching a routing/packing/transpose bug on
+    // any production shape, not just the canned ones. Correctness is checked against an
+    // FP64 ground truth for shapes below a work cap (the cap keeps the O(M·N·K) reference
+    // fast); larger shapes assert routed + non-zero only.
+    [Fact]
+    public void PreferManaged_FullCatalog_RoutesToManaged_AndIsNumericallyCorrect()
+    {
+        const long TruthCap = 4_000_000; // M·N·K above this → routed+non-zero only
+        Assert.NotEmpty(ShapeCatalog.All);
+        BlasManagedLib.PreferManaged = false;
+        try
+        {
+            BlasManagedLib.PreferManaged = true;
+            foreach (var s in ShapeCatalog.All)
+            {
+                if (s.Dtype == DType.Single) VerifyCatalogShapeF(s, TruthCap);
+                else VerifyCatalogShapeD(s, TruthCap);
+            }
+        }
+        finally { BlasManagedLib.PreferManaged = false; }
+    }
+
+    private static void VerifyCatalogShapeF(Shape s, long truthCap)
+    {
+        int m = s.M, n = s.N, k = s.K;
+        bool tA = s.TransA, tB = s.TransB;
+        int lda = tA ? m : k, ldb = tB ? k : n, ldc = n;
+        var rng = new Random(unchecked(s.Name.GetHashCode()) ^ 0x5151);
+        var a = new float[m * k]; for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+        var b = new float[k * n]; for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+        var c = new float[m * n];
+
+        bool ok = BlasProvider.TryGemmEx(m, n, k, a, 0, lda, tA, b, 0, ldb, tB, c, 0, ldc);
+        string tag = $"[{s.Name} {m}x{n}x{k} tA={tA} tB={tB} FP32]";
+        Assert.True(ok, $"{tag} PreferManaged TryGemmEx must route to managed and return true");
+        Assert.True(AnyNonZero(c), $"{tag} managed output is all-zero");
+
+        if ((long)m * n * k > truthCap) return;
+        double maxErr = 0, maxAbs = 0;
+        for (int i = 0; i < m; i++)
+            for (int j = 0; j < n; j++)
+            {
+                double sum = 0;
+                for (int kk = 0; kk < k; kk++)
+                {
+                    double av = tA ? a[kk * lda + i] : a[i * lda + kk];
+                    double bv = tB ? b[j * ldb + kk] : b[kk * ldb + j];
+                    sum += av * bv;
+                }
+                maxAbs = Math.Max(maxAbs, Math.Abs(sum));
+                maxErr = Math.Max(maxErr, Math.Abs(sum - c[i * n + j]));
+            }
+        double bound = 1e-3 * Math.Max(1.0, maxAbs);  // FP32 accumulation vs FP64 truth, magnitude-relative
+        Assert.True(maxErr <= bound, $"{tag} managed GEMM err vs FP64 truth {maxErr:G6} > bound {bound:G6}");
+    }
+
+    private static void VerifyCatalogShapeD(Shape s, long truthCap)
+    {
+        int m = s.M, n = s.N, k = s.K;
+        bool tA = s.TransA, tB = s.TransB;
+        int lda = tA ? m : k, ldb = tB ? k : n, ldc = n;
+        var rng = new Random(unchecked(s.Name.GetHashCode()) ^ 0x7373);
+        var a = new double[m * k]; for (int i = 0; i < a.Length; i++) a[i] = rng.NextDouble() * 2 - 1;
+        var b = new double[k * n]; for (int i = 0; i < b.Length; i++) b[i] = rng.NextDouble() * 2 - 1;
+        var c = new double[m * n];
+
+        bool ok = BlasProvider.TryGemmEx(m, n, k, a, 0, lda, tA, b, 0, ldb, tB, c, 0, ldc);
+        string tag = $"[{s.Name} {m}x{n}x{k} tA={tA} tB={tB} FP64]";
+        Assert.True(ok, $"{tag} PreferManaged TryGemmEx must route to managed and return true");
+        Assert.True(AnyNonZero(c), $"{tag} managed output is all-zero");
+
+        if ((long)m * n * k > truthCap) return;
+        double maxErr = 0, maxAbs = 0;
+        for (int i = 0; i < m; i++)
+            for (int j = 0; j < n; j++)
+            {
+                double sum = 0;
+                for (int kk = 0; kk < k; kk++)
+                {
+                    double av = tA ? a[kk * lda + i] : a[i * lda + kk];
+                    double bv = tB ? b[j * ldb + kk] : b[kk * ldb + j];
+                    sum += av * bv;
+                }
+                maxAbs = Math.Max(maxAbs, Math.Abs(sum));
+                maxErr = Math.Max(maxErr, Math.Abs(sum - c[i * n + j]));
+            }
+        double bound = 1e-9 * Math.Max(1.0, maxAbs);  // FP64 accumulation; reduction-order differences only
+        Assert.True(maxErr <= bound, $"{tag} managed GEMM err vs FP64 truth {maxErr:G6} > bound {bound:G6}");
+    }
+
+    private static bool AnyNonZero(float[] c)
+    {
+        for (int i = 0; i < c.Length; i++) if (c[i] != 0) return true;
+        return false;
+    }
+
+    private static bool AnyNonZero(double[] c)
+    {
+        for (int i = 0; i < c.Length; i++) if (c[i] != 0) return true;
+        return false;
     }
 }


### PR DESCRIPTION
Closes #374

## Context

Most of #374 (Sub-F: the BlasProvider routing shim + autotune dispatch) already landed via the ManagedBlas rollup (**#495**): `BlasProvider.ShouldRouteManaged` (called atop `TryGemm`/`TryGemmEx`), `PrefersManagedCache` (per-shape autotune cache with the `BypassAutotune` measurement hook), the static `BlasManaged.PreferManaged` switch, and per-shape `RoutingShimTest` / `PrefersManagedCacheTest`. Verified all 12 existing routing tests pass.

The one acceptance-criterion gap: nothing exercised the **managed-only routed path across the production shapes the shim must actually serve** — the existing tests only cover a couple of hand-picked 64×64×64 cases.

## Change

Adds `PreferManaged_FullCatalog_RoutesToManaged_AndIsNumericallyCorrect`. With `PreferManaged = true` it sweeps the **whole `ShapeCatalog`** (the 50–80 instrumented + curated workload shapes) and asserts, for **every** shape, that `BlasProvider.TryGemmEx`:
1. returns `true` — i.e. the shim routed it to the managed kernel (the mechanism that gives all 144 call sites the managed wins with zero caller edits), and
2. produces a numerically correct GEMM vs an FP64 ground truth (transpose-aware, magnitude-relative tolerance).

Shapes above a 4M-MAC work cap assert routed + non-zero only, so the O(M·N·K) reference stays fast (full run ≈ 21 s). This catches a routing / packing / transpose regression on any production shape, not just the canned ones.

## Acceptance criteria status (#374)
- [x] `TryGemm`/`TryGemmEx` query `PrefersManagedCache` before native (`ShouldRouteManaged`) — #495
- [x] First call per (shape, hardware) measures both paths and caches the winner — `PrefersManagedCache` / `PrefersManagedCacheTest`
- [x] `PreferManaged = true` forces all calls through managed regardless of autotune — `RoutingShimTest`
- [x] The managed-only routed path is correct across the production catalog — **this PR**
- [x] Existing suite unchanged-and-green (13/13 routing tests pass; both TFMs build)

## Tests
`13/13` `RoutingShimTest` + `PrefersManagedCacheTest` pass on net10.0; both TFMs build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)