### PR TITLE
perf(#378): FP16 + BF16 GEMM microkernels wired into the matmul dispatch

### DIFF
--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/MachineCodeBf16Kernel.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/MachineCodeBf16Kernel.cs
@@ -63,5 +63,126 @@ internal static class MachineCodeBf16Kernel
             fn(ap, bp, cp);
         return true;
     }
+
+    // ── Phase 2: full BF16 GEMM microkernel (MR=4 × NR=8, broadcast-A) ──────────
+
+    private const int MR = 4;   // rows per tile (one accumulator ymm each)
+    private const int NR = 8;   // cols per tile (one ymm of 8 FP32 lanes)
+
+    /// <summary>
+    /// Emit <c>void kernel(uint* packedA, uint* packedB, float* cTile, nuint kPairs)</c> — a
+    /// register-resident MR×NR FP32 GEMM tile driven by VDPBF16PS over a runtime K-pair loop.
+    /// <para>
+    /// Each iteration consumes one K-pair (k0=2·kp, k1=2·kp+1):
+    /// <c>packedB[kp]</c> is a 32-byte vector of NR columns × {B[k0,c], B[k1,c]} (BF16);
+    /// <c>packedA[kp]</c> is MR × {A[m,k0], A[m,k1]} packed as one uint per row. For each row the
+    /// A pair is broadcast (vbroadcastss, 32-bit) across all 8 lanes, then
+    /// <c>vdpbf16ps acc_m, aBroadcast, bVec</c> adds A[m,k0]·B[k0,c]+A[m,k1]·B[k1,c] to lane c —
+    /// i.e. the two-deep K contribution to C[m,c], accumulated in FP32.
+    /// </para>
+    /// Disjoint accumulators → bit-stable; no .NET intrinsic exists for VDPBF16PS so the body is
+    /// raw EVEX. Verify under Intel SDE on non-AVX-512-BF16 hosts.
+    /// </summary>
+    internal static byte[] EmitGemmMicrokernelWindows()
+    {
+        // Windows x64 ABI: rcx=packedA, rdx=packedB, r8=cTile, r9=kPairs.
+        const int RCX = 1, RDX = 2, R8 = 8, R9 = 9;
+        var asm = new X64Assembler();
+
+        for (int m = 0; m < MR; m++) asm.Vxorpd(m, m, m); // zero ymm0..ymm3 accumulators
+
+        int loop = asm.NewLabel();
+        asm.MarkLabel(loop);
+        asm.VmovupdLoad(4, RDX, 0);                 // ymm4 = packedB[kp]  (NR cols × 2 BF16)
+        for (int m = 0; m < MR; m++)
+        {
+            asm.VbroadcastSs(5, RCX, (sbyte)(m * 4)); // ymm5 = broadcast {A[m,k0],A[m,k1]}
+            asm.Vdpbf16ps256(m, 5, 4);                // acc_m += dpbf16(aBroadcast, bVec)
+        }
+        asm.AddRegImm8(RDX, NR * 4);                // advance B one 32-byte K-pair vector
+        asm.AddRegImm8(RCX, MR * 4);                // advance A one K-pair block (MR uints)
+        asm.DecReg(R9);
+        asm.JnzLabel(loop);
+
+        for (int m = 0; m < MR; m++) asm.VmovupdStore(R8, (sbyte)(m * NR * 4), m); // cTile rows
+        asm.Vzeroupper();
+        asm.Ret();
+        return asm.ToArray();
+    }
+
+    /// <summary>
+    /// Native AVX-512-BF16 GEMM: <c>C[m,n] = Σ_k A[m,k]·B[k,n]</c> with A/B as raw BF16 bit
+    /// patterns (row-major, A is M×K, B is K×N) and C accumulated in FP32 (row-major M×N).
+    /// Tiles M by <see cref="MR"/> and N by <see cref="NR"/>, packs each tile into the
+    /// K-pair-interleaved layout the microkernel expects (odd K and ragged M/N edges zero-padded
+    /// — BF16 0x0000 = +0.0, a no-op), and runs the emitted kernel. Returns false only if
+    /// executable memory is unavailable. MUST run under SDE on hosts lacking AVX-512-BF16.
+    /// </summary>
+    internal static unsafe bool TryGemm(
+        ReadOnlySpan<ushort> a, ReadOnlySpan<ushort> b, Span<float> c, int m, int k, int n)
+    {
+        if (m <= 0 || k <= 0 || n <= 0) return true;
+        if (a.Length < m * k || b.Length < k * n || c.Length < m * n)
+            throw new ArgumentException("BF16 GEMM: a/b/c spans smaller than M·K / K·N / M·N.");
+
+        int kPairs = (k + 1) / 2;
+        byte[] code = EmitGemmMicrokernelWindows();
+        using var mem = ExecutableMemory.TryAllocate(code);
+        if (mem is null || mem.Pointer == IntPtr.Zero) return false;
+        var fn = (delegate* unmanaged<uint*, uint*, float*, nuint, void>)mem.Pointer;
+
+        // Per-tile packed buffers (reused across tiles).
+        var packA = new uint[kPairs * MR];
+        var packB = new uint[kPairs * NR];
+        var cTile = new float[MR * NR];
+
+        fixed (uint* pA = packA)
+        fixed (uint* pB = packB)
+        fixed (float* pC = cTile)
+        {
+            for (int n0 = 0; n0 < n; n0 += NR)
+            {
+                int cols = Math.Min(NR, n - n0);
+                // Pack B[*, n0..n0+cols) → [kPairs][NR] of {B[k0,c]|B[k1,c]<<16}; pad cols/k with 0.
+                Array.Clear(packB, 0, packB.Length);
+                for (int kp = 0; kp < kPairs; kp++)
+                {
+                    int k0 = 2 * kp, k1 = k0 + 1;
+                    int baseB = kp * NR;
+                    for (int cc = 0; cc < cols; cc++)
+                    {
+                        uint lo = b[k0 * n + n0 + cc];
+                        uint hi = (k1 < k) ? b[k1 * n + n0 + cc] : 0u;
+                        packB[baseB + cc] = lo | (hi << 16);
+                    }
+                }
+
+                for (int m0 = 0; m0 < m; m0 += MR)
+                {
+                    int rows = Math.Min(MR, m - m0);
+                    // Pack A[m0..m0+rows, *) → [kPairs][MR] of {A[m,k0]|A[m,k1]<<16}; pad rows/k.
+                    Array.Clear(packA, 0, packA.Length);
+                    for (int kp = 0; kp < kPairs; kp++)
+                    {
+                        int k0 = 2 * kp, k1 = k0 + 1;
+                        int baseA = kp * MR;
+                        for (int rr = 0; rr < rows; rr++)
+                        {
+                            uint lo = a[(m0 + rr) * k + k0];
+                            uint hi = (k1 < k) ? a[(m0 + rr) * k + k1] : 0u;
+                            packA[baseA + rr] = lo | (hi << 16);
+                        }
+                    }
+
+                    fn(pA, pB, pC, (nuint)kPairs);
+
+                    for (int rr = 0; rr < rows; rr++)
+                        for (int cc = 0; cc < cols; cc++)
+                            c[(m0 + rr) * n + n0 + cc] = cTile[rr * NR + cc];
+                }
+            }
+        }
+        return true;
+    }
 }
 #endif

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/MachineCodeBf16Kernel.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/MachineCodeBf16Kernel.cs
@@ -122,10 +122,14 @@ internal static class MachineCodeBf16Kernel
         ReadOnlySpan<ushort> a, ReadOnlySpan<ushort> b, Span<float> c, int m, int k, int n)
     {
         if (m <= 0 || k <= 0 || n <= 0) return true;
-        if (a.Length < m * k || b.Length < k * n || c.Length < m * n)
+        // Size math in long so large shapes can't wrap int, bypass the guard, and then fault in
+        // packing/allocation with negative lengths (a span never exceeds int.MaxValue, so an
+        // over-large requirement throws here). kPairs likewise from long before the int narrow.
+        long aNeeded = (long)m * k, bNeeded = (long)k * n, cNeeded = (long)m * n;
+        if (aNeeded > a.Length || bNeeded > b.Length || cNeeded > c.Length)
             throw new ArgumentException("BF16 GEMM: a/b/c spans smaller than M·K / K·N / M·N.");
 
-        int kPairs = (k + 1) / 2;
+        int kPairs = (int)(((long)k + 1) / 2);
         byte[] code = EmitGemmMicrokernelWindows();
         using var mem = ExecutableMemory.TryAllocate(code);
         if (mem is null || mem.Pointer == IntPtr.Zero) return false;

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/MachineCodeBf16Kernel.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/MachineCodeBf16Kernel.cs
@@ -1,0 +1,67 @@
+#if NET5_0_OR_GREATER
+using System;
+
+namespace AiDotNet.Tensors.Engines.BlasManaged.Jit;
+
+/// <summary>
+/// #378 — AVX-512-BF16 native path, Phase 1: emit and execute a <c>VDPBF16PS</c> probe to
+/// verify the EVEX encoding (<see cref="X64Assembler.Vdpbf16ps256"/>) and the instruction's
+/// BF16-dot-product semantics.
+///
+/// <para>
+/// .NET 10 exposes no <c>Avx512Bf16</c> intrinsic, so the only way to reach VDPBF16PS from
+/// managed code is to emit the raw EVEX bytes and run them. Because this is raw machine code
+/// (not a .NET intrinsic), <b>Intel SDE emulates the instruction on any host</b> — including
+/// AVX2-only dev boxes and AMD CI runners — so the encoding is verifiable without
+/// Sapphire-Rapids / Zen-4 hardware. (On a host without AVX-512-BF16 and without SDE, the
+/// instruction faults <c>#UD</c>; the caller must only run the probe under SDE there.)
+/// </para>
+/// </summary>
+internal static class MachineCodeBf16Kernel
+{
+    // Windows x64 ABI integer arg registers: rcx, rdx, r8.
+    private const int RCX = 1, RDX = 2, R8 = 8;
+
+    /// <summary>
+    /// Emits <c>void probe(ushort* a, ushort* b, float* c)</c>:
+    /// loads 16 BF16 from <c>a</c> → ymm1 and 16 from <c>b</c> → ymm2, zeroes ymm0, then
+    /// <c>vdpbf16ps ymm0, ymm1, ymm2</c> so <c>c[i] = a[2i]·b[2i] + a[2i+1]·b[2i+1]</c>
+    /// (BF16 widened to FP32, accumulated in FP32), and stores the 8 FP32 results.
+    /// </summary>
+    internal static byte[] EmitVdpbf16ProbeWindows()
+    {
+        var asm = new X64Assembler();
+        asm.VmovupdLoad(1, RCX, 0);   // ymm1 = a[0..15]  (32 bytes = 16 BF16)
+        asm.VmovupdLoad(2, RDX, 0);   // ymm2 = b[0..15]
+        asm.Vxorpd(0, 0, 0);          // ymm0 = 0  (8 FP32 lanes)
+        asm.Vdpbf16ps256(0, 1, 2);    // ymm0[i] += a[2i]*b[2i] + a[2i+1]*b[2i+1]
+        asm.VmovupdStore(R8, 0, 0);   // c[0..7] = ymm0
+        asm.Vzeroupper();
+        asm.Ret();
+        return asm.ToArray();
+    }
+
+    /// <summary>
+    /// Emit + execute the probe. <paramref name="a"/>/<paramref name="b"/> are 16 raw BF16
+    /// bit-patterns each; <paramref name="c"/> receives 8 FP32 results. Returns false only if
+    /// executable memory could not be allocated (NativeAOT / hardened runtime). MUST be run
+    /// under Intel SDE on a host lacking AVX-512-BF16 (otherwise VDPBF16PS faults).
+    /// </summary>
+    internal static unsafe bool TryRunProbe(ushort[] a, ushort[] b, float[] c)
+    {
+        if (a.Length < 16 || b.Length < 16 || c.Length < 8)
+            throw new ArgumentException("VDPBF16PS probe needs a/b >= 16 BF16 and c >= 8 floats.");
+
+        byte[] code = EmitVdpbf16ProbeWindows();
+        using var mem = ExecutableMemory.TryAllocate(code);
+        if (mem is null || mem.Pointer == IntPtr.Zero) return false;
+
+        var fn = (delegate* unmanaged<ushort*, ushort*, float*, void>)mem.Pointer;
+        fixed (ushort* ap = a)
+        fixed (ushort* bp = b)
+        fixed (float* cp = c)
+            fn(ap, bp, cp);
+        return true;
+    }
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/X64Assembler.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/X64Assembler.cs
@@ -226,10 +226,36 @@ internal sealed class X64Assembler
     }
 
     // pp: 0=none, 1=66, 2=F3, 3=F2.  map: 1=0F, 2=0F38, 3=0F3A.  L: 0=128,1=256.
-    private const int Pp66 = 1, PpNone = 0, Map0F = 1, Map0F38 = 2;
+    private const int Pp66 = 1, PpNone = 0, PpF3 = 2, Map0F = 1, Map0F38 = 2;
 
     /// <summary>vfmadd231pd dst, s1, s2  (dst += s1*s2). VEX.DDS.256.66.0F38.W1 B8.</summary>
     internal void Vfmadd231pd(int dst, int s1, int s2) => VexRR(Map0F38, Pp66, 1, 1, 0xB8, dst, s1, s2);
+
+    // ── EVEX register-register form (#378: AVX-512-BF16) ───────────────────────
+    // 4-byte EVEX: 62 P0 P1 P2  opcode  ModRM(mod=11). Limited to ymm/zmm 0..15
+    // (no mask / broadcast / zeroing), which is all the BF16 microkernel needs —
+    // so EVEX.X=1 (no rm[4]), EVEX.R'=1 (reg<16), EVEX.V'=1 (vvvv<16) are constant.
+    //   P0 = [R X B R' 0 0 m m]   R=~reg[3], B=~rm[3], mm: 1=0F, 2=0F38, 3=0F3A
+    //   P1 = [W v v v v 1 p p]    vvvv=~vvvvReg, pp: 0=none,1=66,2=F3,3=F2
+    //   P2 = [z L'L L'L b V' a a a]  L'L: 0=128,1=256,2=512; here z=b=aaa=0, V'=1
+    private void EvexRR(int mm, int pp, int w, int ll, byte opcode, int reg, int vvvv, int rm)
+    {
+        int rBit = (reg < 8) ? 1 : 0;
+        int bBit = (rm < 8) ? 1 : 0;
+        byte p0 = (byte)((rBit << 7) | (1 << 6) | (bBit << 5) | (1 << 4) | mm);
+        int vv = (~vvvv) & 0xF;
+        byte p1 = (byte)((w << 7) | (vv << 3) | (1 << 2) | pp);
+        byte p2 = (byte)((ll << 5) | (1 << 3)); // z=0, L'L<<5, b=0, V'=1, aaa=000
+        byte modrm = (byte)(0xC0 | ((reg & 7) << 3) | (rm & 7));
+        B(0x62, p0, p1, p2, opcode, modrm);
+    }
+
+    /// <summary>vdpbf16ps ymm_dst, ymm_s1, ymm_s2  (dst[i] += s1[2i]*s2[2i] + s1[2i+1]*s2[2i+1],
+    /// BF16 inputs → FP32 accumulate). EVEX.256.F3.0F38.W0 52 /r (AVX-512-BF16, Sapphire Rapids / Zen 4+).</summary>
+    internal void Vdpbf16ps256(int dst, int s1, int s2) => EvexRR(Map0F38, PpF3, 0, 1, 0x52, dst, s1, s2);
+
+    /// <summary>512-bit vdpbf16ps zmm_dst, zmm_s1, zmm_s2. EVEX.512.F3.0F38.W0 52 /r.</summary>
+    internal void Vdpbf16ps512(int dst, int s1, int s2) => EvexRR(Map0F38, PpF3, 0, 2, 0x52, dst, s1, s2);
 
     /// <summary>vxorpd dst, s1, s2. VEX.256.66.0F.WIG 57. (zero a reg: dst=s1=s2)</summary>
     internal void Vxorpd(int dst, int s1, int s2) => VexRR(Map0F, Pp66, 0, 1, 0x57, dst, s1, s2);

--- a/src/AiDotNet.Tensors/Engines/Simd/BFloat16Kernels.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/BFloat16Kernels.cs
@@ -155,11 +155,18 @@ public static class BFloat16Kernels
             throw new ArgumentException($"bRowStride {bRowStride} must be ≥ n {n}.");
         if (cRowStride < n)
             throw new ArgumentException($"cRowStride {cRowStride} must be ≥ n {n}.");
-        if (m > 0 && a.Length < (m - 1) * aRowStride + k)
+        // Offset math in long so large m/stride can't overflow int and silently skip the guard
+        // (a span never exceeds int.MaxValue, so any required length past that correctly throws).
+        // Once these pass, every inner index below is < the validated span length, hence in-range
+        // for the int row-offset arithmetic in the loops.
+        long aRequired = m > 0 ? (long)(m - 1) * aRowStride + k : 0;
+        long bRequired = k > 0 ? (long)(k - 1) * bRowStride + n : 0;
+        long cRequired = m > 0 ? (long)(m - 1) * cRowStride + n : 0;
+        if (aRequired > a.Length)
             throw new ArgumentException($"a span ({a.Length}) too short for m={m}, k={k}, stride={aRowStride}.");
-        if (k > 0 && b.Length < (k - 1) * bRowStride + n)
+        if (bRequired > b.Length)
             throw new ArgumentException($"b span ({b.Length}) too short for k={k}, n={n}, stride={bRowStride}.");
-        if (m > 0 && c.Length < (m - 1) * cRowStride + n)
+        if (cRequired > c.Length)
             throw new ArgumentException($"c span ({c.Length}) too short for m={m}, n={n}, stride={cRowStride}.");
         Span<float> tmpB = stackalloc float[8];
         for (int i = 0; i < m; i++)

--- a/src/AiDotNet.Tensors/Engines/Simd/HalfKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/HalfKernels.cs
@@ -46,11 +46,18 @@ public static class HalfKernels
             throw new ArgumentException($"bRowStride {bRowStride} must be >= n {n}.");
         if (cRowStride < n)
             throw new ArgumentException($"cRowStride {cRowStride} must be >= n {n}.");
-        if (m > 0 && a.Length < (m - 1) * aRowStride + k)
+        // Offset math in long so large m/stride can't overflow int and silently skip the guard
+        // (a span never exceeds int.MaxValue, so any required length past that correctly throws).
+        // Once these pass, every inner index below is < the validated span length, hence in-range
+        // for the int row-offset arithmetic in the loops.
+        long aRequired = m > 0 ? (long)(m - 1) * aRowStride + k : 0;
+        long bRequired = k > 0 ? (long)(k - 1) * bRowStride + n : 0;
+        long cRequired = m > 0 ? (long)(m - 1) * cRowStride + n : 0;
+        if (aRequired > a.Length)
             throw new ArgumentException($"a span ({a.Length}) too short for m={m}, k={k}, stride={aRowStride}.");
-        if (k > 0 && b.Length < (k - 1) * bRowStride + n)
+        if (bRequired > b.Length)
             throw new ArgumentException($"b span ({b.Length}) too short for k={k}, n={n}, stride={bRowStride}.");
-        if (m > 0 && c.Length < (m - 1) * cRowStride + n)
+        if (cRequired > c.Length)
             throw new ArgumentException($"c span ({c.Length}) too short for m={m}, n={n}, stride={cRowStride}.");
 
         Span<float> tmpA = stackalloc float[8];

--- a/src/AiDotNet.Tensors/Engines/Simd/HalfKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/HalfKernels.cs
@@ -1,0 +1,94 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+#if NET5_0_OR_GREATER
+using System;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+
+namespace AiDotNet.Tensors.Engines.Simd;
+
+/// <summary>
+/// #378: SIMD-accelerated FP16 (<see cref="System.Half"/>) GEMM microkernel for the
+/// BlasManaged dispatch — the FP16 counterpart of <see cref="BFloat16Kernels"/>.Matmul.
+///
+/// <para>
+/// Like the issue's "AVX2 emulation via FP32 upcast" option, each FP16 input is widened
+/// to <see cref="float"/> and the inner product is accumulated in a <b>float</b> register
+/// (not FP16) so deep transformer K-dimensions (4096+) don't lose precision; the result is
+/// rounded back to FP16 only at the very end. The 8-lane FMA accumulation is vectorized
+/// (AVX2 + FMA); the widening is per-element because FP16→FP32 has no cheap bulk SIMD path
+/// on AVX2 (F16C aside), so the expensive part — the K-reduction FMAs — is what gets the
+/// vector treatment, matching the proven BF16 kernel's structure.
+/// </para>
+///
+/// <para>Compiles only on net5.0+ (System.Half + Intrinsics). On net471 the BlasManaged
+/// dispatch routes FP16 GEMM through the generic blocked scalar path instead.</para>
+/// </summary>
+public static class HalfKernels
+{
+    /// <summary>
+    /// FP16 matmul with float accumulation: <c>C[m,n] = A[m,k] · B[k,n]</c>. <paramref name="c"/>
+    /// is written as FP16 (round-to-nearest via the <c>(Half)float</c> cast); the inner
+    /// accumulator is float. Non-transposed, row-major; row strides are caller-supplied so an
+    /// ldc-padded / offset slice works.
+    /// </summary>
+    public static void Matmul(
+        ReadOnlySpan<Half> a, int aRowStride,
+        ReadOnlySpan<Half> b, int bRowStride,
+        Span<Half> c, int cRowStride,
+        int m, int k, int n)
+    {
+        if (m < 0 || k < 0 || n < 0)
+            throw new ArgumentException($"Matmul shapes must be non-negative; got m={m}, k={k}, n={n}.");
+        if (aRowStride < k)
+            throw new ArgumentException($"aRowStride {aRowStride} must be >= k {k}.");
+        if (bRowStride < n)
+            throw new ArgumentException($"bRowStride {bRowStride} must be >= n {n}.");
+        if (cRowStride < n)
+            throw new ArgumentException($"cRowStride {cRowStride} must be >= n {n}.");
+        if (m > 0 && a.Length < (m - 1) * aRowStride + k)
+            throw new ArgumentException($"a span ({a.Length}) too short for m={m}, k={k}, stride={aRowStride}.");
+        if (k > 0 && b.Length < (k - 1) * bRowStride + n)
+            throw new ArgumentException($"b span ({b.Length}) too short for k={k}, n={n}, stride={bRowStride}.");
+        if (m > 0 && c.Length < (m - 1) * cRowStride + n)
+            throw new ArgumentException($"c span ({c.Length}) too short for m={m}, n={n}, stride={cRowStride}.");
+
+        Span<float> tmpA = stackalloc float[8];
+        Span<float> tmpB = stackalloc float[8];
+        for (int i = 0; i < m; i++)
+        {
+            int aRow = i * aRowStride;
+            for (int j = 0; j < n; j++)
+            {
+                float acc = 0f;
+                int kk = 0;
+                if (Avx2.IsSupported && k >= 8)
+                {
+                    var vsum = Vector256<float>.Zero;
+                    for (; kk + 8 <= k; kk += 8)
+                    {
+                        for (int t = 0; t < 8; t++)
+                        {
+                            tmpA[t] = (float)a[aRow + kk + t];
+                            tmpB[t] = (float)b[(kk + t) * bRowStride + j];
+                        }
+                        var av = Vector256.Create(tmpA[0], tmpA[1], tmpA[2], tmpA[3], tmpA[4], tmpA[5], tmpA[6], tmpA[7]);
+                        var bv = Vector256.Create(tmpB[0], tmpB[1], tmpB[2], tmpB[3], tmpB[4], tmpB[5], tmpB[6], tmpB[7]);
+                        vsum = Fma.IsSupported ? Fma.MultiplyAdd(av, bv, vsum) : Avx.Add(vsum, Avx.Multiply(av, bv));
+                    }
+                    var lo = vsum.GetLower();
+                    var hi = vsum.GetUpper();
+                    var sum128 = Sse.Add(lo, hi);
+                    sum128 = Sse.Add(sum128, Sse.Shuffle(sum128, sum128, 0b01_00_11_10));
+                    sum128 = Sse.Add(sum128, Sse.Shuffle(sum128, sum128, 0b10_11_00_01));
+                    acc = sum128.ToScalar();
+                }
+                for (; kk < k; kk++)
+                    acc += (float)a[aRow + kk] * (float)b[kk * bRowStride + j];
+
+                c[i * cRowStride + j] = (Half)acc;
+            }
+        }
+    }
+}
+#endif

--- a/src/AiDotNet.Tensors/Helpers/MatrixMultiplyHelper.cs
+++ b/src/AiDotNet.Tensors/Helpers/MatrixMultiplyHelper.cs
@@ -31,9 +31,18 @@ internal static class MatrixMultiplyHelper
             Console.WriteLine($"[MATMUL-TRACE] TryGemm<{typeof(T).Name}>: m={m}, k={k}, n={n}");
         }
 
-        if (!(typeof(T) == typeof(float) || typeof(T) == typeof(double)))
+        // #378: FP16 (System.Half) and BF16 route to their SIMD GEMM microkernels
+        // (HalfKernels / BFloat16Kernels — float-accumulated upcast emulation) on net5.0+;
+        // net471 has no Vector256 intrinsics so they stay on the generic blocked path.
+        bool isSupportedType = typeof(T) == typeof(float) || typeof(T) == typeof(double);
+#if NET5_0_OR_GREATER
+        isSupportedType = isSupportedType
+            || typeof(T) == typeof(Half)
+            || typeof(T) == typeof(AiDotNet.Tensors.NumericOperations.BFloat16);
+#endif
+        if (!isSupportedType)
         {
-            if (TraceEnabled) Console.WriteLine("[MATMUL-TRACE] Type check failed - not float/double");
+            if (TraceEnabled) Console.WriteLine("[MATMUL-TRACE] Type check failed - not a SIMD-GEMM type");
             return false;
         }
 
@@ -290,6 +299,31 @@ internal static class MatrixMultiplyHelper
                 m, k, n);
             return true;
         }
+#if NET5_0_OR_GREATER
+        // #378: FP16 — SIMD upcast-emulation microkernel, float accumulator.
+        else if (typeof(T) == typeof(Half) && a is Half[] ah && b is Half[] bh && c is Half[] ch)
+        {
+            Engines.Simd.HalfKernels.Matmul(
+                ah.AsSpan(aOffset, m * k), k,
+                bh.AsSpan(bOffset, k * n), n,
+                ch.AsSpan(cOffset, m * n), n,
+                m, k, n);
+            return true;
+        }
+        // #378: BF16 — wire the (previously orphan) BF16 microkernel into the GEMM dispatch.
+        else if (typeof(T) == typeof(NumericOperations.BFloat16)
+                 && a is NumericOperations.BFloat16[] abf
+                 && b is NumericOperations.BFloat16[] bbf
+                 && c is NumericOperations.BFloat16[] cbf)
+        {
+            Engines.Simd.BFloat16Kernels.Matmul(
+                abf.AsSpan(aOffset, m * k), k,
+                bbf.AsSpan(bOffset, k * n), n,
+                cbf.AsSpan(cOffset, m * n), n,
+                m, k, n);
+            return true;
+        }
+#endif
 
         return false;
     }

--- a/tests/AiDotNet.Tensors.Benchmarks/MicrokernelGflopsBench.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/MicrokernelGflopsBench.cs
@@ -291,4 +291,54 @@ public static class MicrokernelGflopsBench
         for (int i = 0; i < n; i++) a[i] = rng.NextDouble() * 2 - 1;
         return a;
     }
+
+    // #378 AVX-512-BF16 Phase 1: verify the emitted VDPBF16PS machine code. There is no
+    // Avx512Bf16 .NET intrinsic, so the instruction is reached only via raw EVEX bytes; run
+    // this UNDER INTEL SDE on a host without AVX-512-BF16 (SDE emulates VDPBF16PS — natively
+    // it would fault #UD). Returns false on mismatch / no executable memory.
+    public static bool VerifyVdpbf16()
+    {
+        Console.WriteLine("=== VDPBF16PS machine-code probe (EVEX encoding + BF16 dot-product) ===");
+        var rng = new Random(123);
+        var a = new ushort[16];
+        var b = new ushort[16];
+        for (int i = 0; i < 16; i++)
+        {
+            a[i] = FloatToBf16((float)(rng.NextDouble() * 2 - 1));
+            b[i] = FloatToBf16((float)(rng.NextDouble() * 2 - 1));
+        }
+        var c = new float[8];
+
+        bool ran;
+        try
+        {
+            ran = AiDotNet.Tensors.Engines.BlasManaged.Jit.MachineCodeBf16Kernel.TryRunProbe(a, b, c);
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine("  probe threw (likely #UD — not under SDE, or bad encoding): " + e.Message);
+            return false;
+        }
+        if (!ran)
+        {
+            Console.WriteLine("  executable memory unavailable (NativeAOT / hardened) — cannot verify");
+            return false;
+        }
+
+        bool pass = true;
+        for (int i = 0; i < 8; i++)
+        {
+            float exp = Bf16ToFloat(a[2 * i]) * Bf16ToFloat(b[2 * i])
+                      + Bf16ToFloat(a[2 * i + 1]) * Bf16ToFloat(b[2 * i + 1]);
+            float got = c[i];
+            bool ok = Math.Abs(got - exp) <= 1e-4f * Math.Max(1f, Math.Abs(exp));
+            pass &= ok;
+            Console.WriteLine($"  lane {i}: got {got,11:G6}  exp {exp,11:G6}  {(ok ? "OK" : "FAIL")}");
+        }
+        Console.WriteLine(pass ? "VDPBF16PS VERIFIED" : "VDPBF16PS FAILED");
+        return pass;
+    }
+
+    private static ushort FloatToBf16(float f) => (ushort)(BitConverter.SingleToUInt32Bits(f) >> 16);
+    private static float Bf16ToFloat(ushort h) => BitConverter.UInt32BitsToSingle((uint)h << 16);
 }

--- a/tests/AiDotNet.Tensors.Benchmarks/MicrokernelGflopsBench.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/MicrokernelGflopsBench.cs
@@ -339,6 +339,52 @@ public static class MicrokernelGflopsBench
         return pass;
     }
 
+    // #378 AVX-512-BF16 Phase 2: verify the full BF16 GEMM machine-code microkernel end to end.
+    // Shape M=5,K=7,N=11 exercises every edge: ragged M (4+1), ragged N (8+3), odd K (pair pad).
+    // Run UNDER INTEL SDE on a non-AVX-512-BF16 host (VDPBF16PS is emulated). False on mismatch.
+    public static bool VerifyBf16Gemm()
+    {
+        Console.WriteLine("=== BF16 GEMM machine-code microkernel (MR4xNR8, VDPBF16PS K-loop) ===");
+        const int m = 5, k = 7, n = 11;
+        var rng = new Random(7);
+        var a = new ushort[m * k];
+        var b = new ushort[k * n];
+        for (int i = 0; i < a.Length; i++) a[i] = FloatToBf16((float)(rng.NextDouble() * 2 - 1));
+        for (int i = 0; i < b.Length; i++) b[i] = FloatToBf16((float)(rng.NextDouble() * 2 - 1));
+        var c = new float[m * n];
+
+        bool ran;
+        try
+        {
+            ran = AiDotNet.Tensors.Engines.BlasManaged.Jit.MachineCodeBf16Kernel.TryGemm(a, b, c, m, k, n);
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine("  GEMM threw (likely #UD — not under SDE, or bad encoding): " + e.Message);
+            return false;
+        }
+        if (!ran)
+        {
+            Console.WriteLine("  executable memory unavailable — cannot verify");
+            return false;
+        }
+
+        bool pass = true;
+        int bad = 0;
+        for (int i = 0; i < m; i++)
+            for (int j = 0; j < n; j++)
+            {
+                double truth = 0;
+                for (int kk = 0; kk < k; kk++)
+                    truth += (double)Bf16ToFloat(a[i * k + kk]) * Bf16ToFloat(b[kk * n + j]);
+                double got = c[i * n + j];
+                bool ok = Math.Abs(got - truth) <= 1e-3 * Math.Max(1.0, Math.Abs(truth));
+                if (!ok) { pass = false; if (bad++ < 6) Console.WriteLine($"  C[{i},{j}] got {got:G6} exp {truth:G6} FAIL"); }
+            }
+        Console.WriteLine(pass ? $"BF16 GEMM VERIFIED ({m}x{k}x{n}, all {m * n} elements)" : "BF16 GEMM FAILED");
+        return pass;
+    }
+
     private static ushort FloatToBf16(float f) => (ushort)(BitConverter.SingleToUInt32Bits(f) >> 16);
     private static float Bf16ToFloat(ushort h) => BitConverter.UInt32BitsToSingle((uint)h << 16);
 }

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -269,6 +269,14 @@ class Program
             return;
         }
 
+        // #378 AVX-512-BF16 Phase 1 — verify the emitted VDPBF16PS machine code. Run under
+        // Intel SDE (`sde64 -spr -- dotnet ... --verify-vdpbf16`) on a non-AVX-512-BF16 host;
+        // exits non-zero on a mismatch so a CI step can gate on it.
+        if (args[0] == "--verify-vdpbf16")
+        {
+            Environment.Exit(MicrokernelGflopsBench.VerifyVdpbf16() ? 0 : 1);
+        }
+
 #if !NET462
         // Run cuBLAS vs DirectGpu GEMM benchmark
         if (args[0] == "--cublas")

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -277,6 +277,13 @@ class Program
             Environment.Exit(MicrokernelGflopsBench.VerifyVdpbf16() ? 0 : 1);
         }
 
+        // #378 AVX-512-BF16 Phase 2 — verify the full BF16 GEMM machine-code microkernel end to
+        // end (tiling + ragged edges). Run under Intel SDE; exits non-zero on a mismatch.
+        if (args[0] == "--verify-bf16gemm")
+        {
+            Environment.Exit(MicrokernelGflopsBench.VerifyBf16Gemm() ? 0 : 1);
+        }
+
 #if !NET462
         // Run cuBLAS vs DirectGpu GEMM benchmark
         if (args[0] == "--cublas")

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -678,6 +678,8 @@ class Program
         Console.WriteLine("  --linalg   : Run linear algebra benchmarks vs MathNet.Numerics");
         Console.WriteLine("  --cpu-matmul: Run CPU matrix multiply diagnostics");
         Console.WriteLine("  --microkernel-gflops: Microkernel-only GFLOPS vs register-FMA peak (Sub-S #409)");
+        Console.WriteLine("  --verify-vdpbf16: Verify emitted VDPBF16PS (run under Intel SDE); exits non-zero on mismatch (#378)");
+        Console.WriteLine("  --verify-bf16gemm: Verify the BF16 GEMM microkernel end to end (run under Intel SDE); exits non-zero on mismatch (#378)");
 #if !NET462
         Console.WriteLine("  --cublas   : Run cuBLAS vs DirectGpu GEMM benchmark");
         Console.WriteLine("  --opencl   : Run OpenCL GEMM benchmark (AMD/Intel GPUs)");

--- a/tests/AiDotNet.Tensors.Tests/Engines/Simd/Fp16Bf16GemmTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Simd/Fp16Bf16GemmTests.cs
@@ -1,0 +1,123 @@
+#if NET5_0_OR_GREATER
+using System;
+using AiDotNet.Tensors.Engines.Simd;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.NumericOperations;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Simd;
+
+/// <summary>
+/// #378: FP16 (System.Half) and BF16 GEMM microkernels for BlasManaged, float-accumulated
+/// upcast emulation. Two layers:
+///   1. The kernels (<see cref="HalfKernels.Matmul"/>, <see cref="BFloat16Kernels.Matmul"/>)
+///      vs a double-precision reference computed from the SAME rounded inputs — so the test
+///      isolates the kernel's accumulation accuracy (float accumulator + low-precision output
+///      rounding) from the input-rounding loss.
+///   2. The dispatch wiring: <see cref="MatrixMultiplyHelper.TryGemm{T}"/> now routes Half /
+///      BFloat16 to those kernels (returns true) instead of declining to the generic scalar
+///      path.
+/// </summary>
+public class Fp16Bf16GemmTests
+{
+    [Theory]
+    [InlineData(4, 32, 8)]    // K=32: pure 8-lane SIMD path
+    [InlineData(16, 24, 20)]  // K=20: 2 SIMD blocks + 4-element scalar tail
+    [InlineData(3, 5, 7)]     // K=7 < 8: scalar-only path
+    [InlineData(1, 64, 1)]    // degenerate K=1
+    public void HalfMatmul_MatchesFloatReference(int m, int n, int k)
+    {
+        var (af, bf) = RandPair(m, k, n, seed: 1000 + m + n + k);
+        // Round inputs to FP16 and use the rounded values for BOTH kernel and reference.
+        var ah = new Half[m * k]; var afr = new float[m * k];
+        for (int i = 0; i < ah.Length; i++) { ah[i] = (Half)af[i]; afr[i] = (float)ah[i]; }
+        var bh = new Half[k * n]; var bfr = new float[k * n];
+        for (int i = 0; i < bh.Length; i++) { bh[i] = (Half)bf[i]; bfr[i] = (float)bh[i]; }
+        var ch = new Half[m * n];
+
+        HalfKernels.Matmul(ah, k, bh, n, ch, n, m, k, n);
+
+        // FP16 output rounding ~ 2^-10 relative; allow slack + magnitude floor.
+        AssertCloseRelative(ch, c => (float)c, afr, bfr, m, k, n, relTol: 6e-3, name: "FP16");
+    }
+
+    [Theory]
+    [InlineData(4, 32, 8)]
+    [InlineData(16, 24, 20)]
+    [InlineData(3, 5, 7)]
+    [InlineData(1, 64, 1)]
+    public void BFloat16Matmul_MatchesFloatReference(int m, int n, int k)
+    {
+        var (af, bf) = RandPair(m, k, n, seed: 2000 + m + n + k);
+        var ab = new BFloat16[m * k]; var afr = new float[m * k];
+        for (int i = 0; i < ab.Length; i++) { ab[i] = BFloat16.FromFloat(af[i]); afr[i] = BFloat16.ToFloat(ab[i]); }
+        var bb = new BFloat16[k * n]; var bfr = new float[k * n];
+        for (int i = 0; i < bb.Length; i++) { bb[i] = BFloat16.FromFloat(bf[i]); bfr[i] = BFloat16.ToFloat(bb[i]); }
+        var cb = new BFloat16[m * n];
+
+        BFloat16Kernels.Matmul(ab, k, bb, n, cb, n, m, k, n);
+
+        // BF16 has ~8-bit mantissa → ~2^-8 relative output rounding.
+        AssertCloseRelative(cb, BFloat16.ToFloat, afr, bfr, m, k, n, relTol: 2e-2, name: "BF16");
+    }
+
+    [Fact]
+    public void TryGemm_RoutesFp16_AndIsCorrect()
+    {
+        const int M = 96, N = 96, K = 96; // above the BLAS work threshold → SIMD route
+        var (af, bf) = RandPair(M, K, N, seed: 777);
+        var ah = new Half[M * K]; var afr = new float[M * K];
+        for (int i = 0; i < ah.Length; i++) { ah[i] = (Half)af[i]; afr[i] = (float)ah[i]; }
+        var bh = new Half[K * N]; var bfr = new float[K * N];
+        for (int i = 0; i < bh.Length; i++) { bh[i] = (Half)bf[i]; bfr[i] = (float)bh[i]; }
+        var ch = new Half[M * N];
+
+        bool routed = MatrixMultiplyHelper.TryGemm(
+            (ReadOnlyMemory<Half>)ah, 0, (ReadOnlyMemory<Half>)bh, 0, (Memory<Half>)ch, 0, M, K, N);
+        Assert.True(routed, "TryGemm must route FP16 to the SIMD microkernel (return true) above the work threshold");
+        AssertCloseRelative(ch, c => (float)c, afr, bfr, M, K, N, relTol: 6e-3, name: "FP16-routed");
+    }
+
+    [Fact]
+    public void TryGemm_RoutesBf16_AndIsCorrect()
+    {
+        const int M = 96, N = 96, K = 96;
+        var (af, bf) = RandPair(M, K, N, seed: 888);
+        var ab = new BFloat16[M * K]; var afr = new float[M * K];
+        for (int i = 0; i < ab.Length; i++) { ab[i] = BFloat16.FromFloat(af[i]); afr[i] = BFloat16.ToFloat(ab[i]); }
+        var bb = new BFloat16[K * N]; var bfr = new float[K * N];
+        for (int i = 0; i < bb.Length; i++) { bb[i] = BFloat16.FromFloat(bf[i]); bfr[i] = BFloat16.ToFloat(bb[i]); }
+        var cb = new BFloat16[M * N];
+
+        bool routed = MatrixMultiplyHelper.TryGemm(
+            (ReadOnlyMemory<BFloat16>)ab, 0, (ReadOnlyMemory<BFloat16>)bb, 0, (Memory<BFloat16>)cb, 0, M, K, N);
+        Assert.True(routed, "TryGemm must route BF16 to the SIMD microkernel (return true) above the work threshold");
+        AssertCloseRelative(cb, BFloat16.ToFloat, afr, bfr, M, K, N, relTol: 2e-2, name: "BF16-routed");
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────
+
+    private static (float[] a, float[] b) RandPair(int m, int k, int n, int seed)
+    {
+        var rng = new Random(seed);
+        var a = new float[m * k]; for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+        var b = new float[k * n]; for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+        return (a, b);
+    }
+
+    private static void AssertCloseRelative<T>(T[] c, Func<T, float> toFloat,
+        float[] aRef, float[] bRef, int m, int k, int n, double relTol, string name)
+    {
+        for (int i = 0; i < m; i++)
+            for (int j = 0; j < n; j++)
+            {
+                double truth = 0;
+                for (int kk = 0; kk < k; kk++) truth += (double)aRef[i * k + kk] * bRef[kk * n + j];
+                double got = toFloat(c[i * n + j]);
+                double bound = relTol * Math.Max(1.0, Math.Abs(truth));
+                Assert.True(Math.Abs(got - truth) <= bound,
+                    $"{name} C[{i},{j}] = {got:G6} vs truth {truth:G6} (|err| {Math.Abs(got - truth):G3} > bound {bound:G3})");
+            }
+    }
+}
+#endif


### PR DESCRIPTION
Closes #378

## Audit (what #378 needs, and the state of each)

#378 tracks **FP16 / BF16 / INT8** microkernels for BlasManaged, with higher-precision accumulation. I audited each:

| dtype | issue''s approach | state found | this PR |
|---|---|---|---|
| **INT8** | `Avx512.VnniDpbusd` (INT8→INT32) | **done** — W8A8 (#465): `SimdGemm.Int8Int8`, `Int8Int8W8A8EntryTests` (int8 GEMM is quantized → its own entry, not a `TryGemm` dtype) | — |
| **BF16** | `Avx512.Vdpbf16ps` | kernel `BFloat16Kernels.Matmul` existed but was an **orphan** — wired nowhere | **wired into the dispatch** |
| **FP16** | `Avx512.Vfmadd231Ph` **or AVX2 emulation via FP32 upcast** | **no kernel at all** | **new `HalfKernels.Matmul`** |

`MatrixMultiplyHelper.TryGemm` (the SIMD fast path CpuEngine''s matmul sites try before the scalar fallback) only admitted `float`/`double`, so Half/BFloat16 matmul fell to the generic per-element scalar path.

## Change

- **`HalfKernels.Matmul`** — the FP16 (`System.Half`) counterpart of the BF16 kernel. Each FP16 input is upcast to `float` and accumulated in a **float** register (not FP16), so deep K-dimensions keep precision; rounded back to FP16 only at the end. The 8-lane FMA accumulation is vectorized (AVX2+FMA). This is the issue''s "AVX2 emulation via FP32 upcast" option.
- **Wire Half + BFloat16 into `TryGemm`**: the type gate admits them on net5.0+ and `TryGemmFromArray` routes them to `HalfKernels` / `BFloat16Kernels`. net471 (no `Vector256`) keeps them on the generic blocked path.
- **Accumulator precision** per the issue: FP16/BF16 → `float`, INT8 → `int32` (#465).

## One platform caveat (documented, not an omission)

The AVX-512 **native** fast paths the issue names — `Vfmadd231Ph` (FP16) and `Vdpbf16ps` (BF16) — are **not implementable in managed C#**: .NET 10 does not expose `Avx512Fp16` / `Avx512Bf16` intrinsics. The FP32-upcast emulation (which the issue lists as the FP16 alternative) is the managed path for both. A native AVX-512 fast path would need the machine-code emitter (cf. #409) or new .NET intrinsics — a follow-up. So every detail that is *implementable in managed code* is covered.

## Tests

`Fp16Bf16GemmTests` — `HalfKernels`/`BFloat16Kernels` matmul vs a double reference computed from the **same rounded inputs** (FP16 relTol 6e-3, BF16 2e-2) across SIMD / tail / scalar-K regimes, plus `TryGemm` routing asserts (returns true → SIMD) for both. **10/10 pass; 487 matmul/GEMM tests pass** (float/double unaffected); both TFMs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## AVX-512-BF16 native path (emitter + Intel SDE)

.NET 10 exposes **no** `Avx512Bf16` / `Avx512Fp16` intrinsic, so the issue''s `Vdpbf16ps` option is unreachable from managed code. Implemented it via the machine-code emitter and verified under **Intel SDE** (the open SDE/CI path), so it needs no Sapphire-Rapids/Zen-4 hardware to prove:

- **`X64Assembler`** — added a 4-byte **EVEX** encoder (`EvexRR`) + `Vdpbf16ps256`/`Vdpbf16ps512`.
- **`MachineCodeBf16Kernel`** — a verified `VDPBF16PS` primitive probe **and** a full native BF16 GEMM: an emitted **MR=4 x NR=8** register-resident tile that broadcasts each A K-pair (`vbroadcastss`, 32-bit) and runs `vdpbf16ps` over a runtime K-pair loop, **accumulating in FP32**. The managed driver packs A/B into the K-pair-interleaved layout, tiles M by 4 / N by 8, and zero-pads odd K and ragged M/N edges.
- **SDE verification** (`--verify-vdpbf16`, `--verify-bf16gemm`): the primitive matches the BF16 dot-product on all 8 lanes, and the full GEMM at **M=5,K=7,N=11** (ragged M, ragged N, odd K) matches the FP32-upcast reference on all 55 outputs — both exit 0 under `sde -spr`.

Production auto-enable still needs real-hardware validation + a CPUID `AVX512_BF16` gate; until then the **FP32-upcast emulation above remains the default** and the native kernel is the SDE-verified fast path behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
