### PR TITLE
perf(#380): AMX (Sapphire Rapids) tile GEMM — BF16 + INT8 + CPUID detection, SDE-verified

### DIFF
--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/MachineCodeAmxKernel.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/MachineCodeAmxKernel.cs
@@ -133,5 +133,100 @@ internal static class MachineCodeAmxKernel
             fn(ap, bp, cp, cfgp);
         return true;
     }
+
+    // ── Phase 2: full tiled AMX BF16 GEMM ──────────────────────────────────────
+
+    /// <summary>
+    /// Emit <c>void tileMac(ushort* aTile, ushort* bTile, float* cTile, byte* cfg)</c>: a single
+    /// accumulating tile op — load the current C tile (tmm2), the A tile (tmm0) and the VNNI B
+    /// tile (tmm1), run <c>C += A·B</c>, and store C back. The driver clears <c>cTile</c> before a
+    /// K-tile sweep and calls this once per K-tile, so accumulation happens in the C buffer via
+    /// the load-accumulate-store roundtrip (HW FP32 accumulate inside the tile).
+    /// </summary>
+    internal static byte[] EmitTileMacWindows()
+    {
+        var asm = new X64Assembler();
+        asm.Ldtilecfg(R9);              // cfg → r9 (4th arg)
+        asm.MovRegImm32(RAX, RowBytes); // rax = 64
+        asm.TileloadD(2, R8, RAX);      // tmm2 = current C partial   (r8 = cTile)
+        asm.TileloadD(0, RCX, RAX);     // tmm0 = A
+        asm.TileloadD(1, RDX, RAX);     // tmm1 = B (VNNI)
+        asm.Tdpbf16ps(2, /*vvvv=B*/1, /*rm=A*/0); // tmm2 += A · B
+        asm.Tilestored(R8, RAX, 2);     // cTile = tmm2
+        asm.Tilerelease();
+        asm.Ret();
+        return asm.ToArray();
+    }
+
+    /// <summary>
+    /// Tiled AMX BF16 GEMM: <c>C[m,n] = Σ_k A[m,k]·B[k,n]</c> with A (M×K) and B (K×N) as raw BF16
+    /// bit patterns, row-major, and C (M×N) accumulated in FP32. Tiles M by 16, N by 16, K by 32;
+    /// packs each A sub-tile row-major and each B sub-tile into the AMX row-pair VNNI layout,
+    /// zero-padding ragged M/K/N edges (BF16 0x0000 = +0.0). Returns false only if executable
+    /// memory is unavailable. MUST run under Intel SDE on hosts lacking AMX.
+    /// </summary>
+    internal static unsafe bool TryGemm(
+        ReadOnlySpan<ushort> a, ReadOnlySpan<ushort> b, Span<float> c, int m, int k, int n)
+    {
+        if (m <= 0 || k <= 0 || n <= 0) return true;
+        if (a.Length < (long)m * k || b.Length < (long)k * n || c.Length < (long)m * n)
+            throw new ArgumentException("AMX GEMM: a/b/c spans smaller than M·K / K·N / M·N.");
+
+        byte[] code = EmitTileMacWindows();
+        byte[] cfg = BuildTileConfig((TileM, TileK * 2), (TileM, TileN * 4), (TileM, TileN * 4));
+        using var mem = ExecutableMemory.TryAllocate(code);
+        if (mem is null || mem.Pointer == IntPtr.Zero) return false;
+        var fn = (delegate* unmanaged<ushort*, ushort*, float*, byte*, void>)mem.Pointer;
+
+        var aTile = new ushort[TileM * TileK];        // 16×32 BF16
+        var bTile = new ushort[(TileK / 2) * (TileN * 2)]; // 16×32 BF16 (VNNI)
+        var cTile = new float[TileM * TileN];         // 16×16 FP32
+
+        fixed (ushort* atp = aTile)
+        fixed (ushort* btp = bTile)
+        fixed (float* ctp = cTile)
+        fixed (byte* cfgp = cfg)
+        {
+            for (int m0 = 0; m0 < m; m0 += TileM)
+            {
+                int mRows = Math.Min(TileM, m - m0);
+                for (int n0 = 0; n0 < n; n0 += TileN)
+                {
+                    int nCols = Math.Min(TileN, n - n0);
+                    Array.Clear(cTile, 0, cTile.Length);
+
+                    for (int k0 = 0; k0 < k; k0 += TileK)
+                    {
+                        int kCols = Math.Min(TileK, k - k0);
+
+                        // Pack A sub-tile: [mRows][kCols] row-major, zero-padded to 16×32.
+                        Array.Clear(aTile, 0, aTile.Length);
+                        for (int mr = 0; mr < mRows; mr++)
+                            for (int kr = 0; kr < kCols; kr++)
+                                aTile[mr * TileK + kr] = a[(m0 + mr) * k + k0 + kr];
+
+                        // Pack B sub-tile (VNNI): row r holds {B[k0+2r,n], B[k0+2r+1,n]} over n.
+                        Array.Clear(bTile, 0, bTile.Length);
+                        for (int r = 0; r < TileK / 2; r++)
+                        {
+                            int kk0 = 2 * r, kk1 = kk0 + 1;
+                            for (int nc = 0; nc < nCols; nc++)
+                            {
+                                if (kk0 < kCols) bTile[r * (TileN * 2) + 2 * nc] = b[(k0 + kk0) * n + n0 + nc];
+                                if (kk1 < kCols) bTile[r * (TileN * 2) + 2 * nc + 1] = b[(k0 + kk1) * n + n0 + nc];
+                            }
+                        }
+
+                        fn(atp, btp, ctp, cfgp); // cTile += aTile · bTile
+                    }
+
+                    for (int mr = 0; mr < mRows; mr++)
+                        for (int nc = 0; nc < nCols; nc++)
+                            c[(m0 + mr) * n + n0 + nc] = cTile[mr * TileN + nc];
+                }
+            }
+        }
+        return true;
+    }
 }
 #endif

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/MachineCodeAmxKernel.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/MachineCodeAmxKernel.cs
@@ -134,6 +134,91 @@ internal static class MachineCodeAmxKernel
         return true;
     }
 
+    // ── INT8 tile path (tdpbssd) + AMX CPUID detection ─────────────────────────
+
+    internal const int TileK8 = 64; // INT8 K-depth per tile (4-deep VNNI: 4 int8 per group)
+
+    // CPUID.(EAX=7,ECX=0):EDX feature bits for AMX.
+    internal const uint AmxBf16Bit = 1u << 22, AmxTileBit = 1u << 24, AmxInt8Bit = 1u << 25;
+
+    /// <summary>
+    /// Emit <c>void int8Tile(sbyte* aPacked, sbyte* bVnni4, int* c, byte* cfg)</c>: a single
+    /// <c>tdpbssd</c> (signed·signed int8 → int32) tile op. C[16,16] += A[16,64]·B[16,64], B in
+    /// the AMX 4-deep VNNI layout (row g holds {B[4g+0,n]..B[4g+3,n]} for each column n).
+    /// </summary>
+    internal static byte[] EmitTileGemmProbeInt8Windows()
+    {
+        var asm = new X64Assembler();
+        asm.Ldtilecfg(R9);
+        asm.MovRegImm32(RAX, RowBytes); // 64-byte rows for all three tiles
+        asm.TileloadD(0, RCX, RAX);     // tmm0 = A (int8)
+        asm.TileloadD(1, RDX, RAX);     // tmm1 = B (VNNI-4 int8)
+        asm.Tilezero(2);                // tmm2 = 0 (int32 accumulator)
+        asm.Tdpbssd(2, /*vvvv=B*/1, /*rm=A*/0); // tmm2 += A · B
+        asm.Tilestored(R8, RAX, 2);
+        asm.Tilerelease();
+        asm.Ret();
+        return asm.ToArray();
+    }
+
+    /// <summary>Run the INT8 tile probe. A is 16×64 int8, bVnni4 is 16×64 int8 (VNNI-4), c is 16×16 int32.</summary>
+    internal static unsafe bool TryRunTileProbeInt8(sbyte[] aPacked, sbyte[] bVnni4, int[] c)
+    {
+        if (aPacked.Length < TileM * TileK8 || bVnni4.Length < TileM * (TileN * 4) || c.Length < TileM * TileN)
+            throw new ArgumentException("AMX INT8 tile probe needs A 16×64, B(VNNI4) 16×64 int8, C 16×16 int32.");
+
+        byte[] code = EmitTileGemmProbeInt8Windows();
+        byte[] cfg = BuildTileConfig((TileM, TileK8), (TileM, TileN * 4), (TileM, TileN * 4));
+        using var mem = ExecutableMemory.TryAllocate(code);
+        if (mem is null || mem.Pointer == IntPtr.Zero) return false;
+        var fn = (delegate* unmanaged<sbyte*, sbyte*, int*, byte*, void>)mem.Pointer;
+        fixed (sbyte* ap = aPacked)
+        fixed (sbyte* bp = bVnni4)
+        fixed (int* cp = c)
+        fixed (byte* cfgp = cfg)
+            fn(ap, bp, cp, cfgp);
+        return true;
+    }
+
+    /// <summary>
+    /// Emit <c>void cpuid7Edx(uint* outEdx)</c>: query CPUID leaf 7, sub-leaf 0 and write EDX to
+    /// <paramref name="outEdx"/> — the AMX-TILE/AMX-BF16/AMX-INT8 feature bits. rbx is preserved
+    /// (non-volatile on Win x64); the out pointer is stashed in r9 before <c>cpuid</c> clobbers rcx.
+    /// </summary>
+    internal static byte[] EmitCpuidLeaf7EdxWindows()
+    {
+        var asm = new X64Assembler();
+        asm.PushReg(3);              // push rbx
+        asm.MovRegReg(R9, RCX);      // r9 = outEdx (saved before cpuid clobbers rcx)
+        asm.MovRegImm32(0, 7);       // eax = 7  (leaf)
+        asm.MovRegImm32(1, 0);       // ecx = 0  (sub-leaf)
+        asm.Cpuid();
+        asm.MovMemFromReg32(R9, 0, 2); // [r9] = edx
+        asm.PopReg(3);               // pop rbx
+        asm.Ret();
+        return asm.ToArray();
+    }
+
+    /// <summary>
+    /// Read CPUID.(7,0):EDX via emitted machine code (no .NET intrinsic exposes these bits). Returns
+    /// false only if executable memory is unavailable; otherwise <paramref name="edx"/> holds the
+    /// raw feature dword — test against <see cref="AmxTileBit"/>/<see cref="AmxBf16Bit"/>/
+    /// <see cref="AmxInt8Bit"/>. NOTE: a true result here means the CPU advertises AMX, but real
+    /// use also needs OS XSAVE state enablement (Linux 5.16+ XFD); gate production on both.
+    /// </summary>
+    internal static unsafe bool TryGetAmxCpuidEdx(out uint edx)
+    {
+        edx = 0;
+        byte[] code = EmitCpuidLeaf7EdxWindows();
+        using var mem = ExecutableMemory.TryAllocate(code);
+        if (mem is null || mem.Pointer == IntPtr.Zero) return false;
+        var fn = (delegate* unmanaged<uint*, void>)mem.Pointer;
+        uint local;
+        fn(&local);
+        edx = local;
+        return true;
+    }
+
     // ── Phase 2: full tiled AMX BF16 GEMM ──────────────────────────────────────
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/MachineCodeAmxKernel.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/MachineCodeAmxKernel.cs
@@ -76,38 +76,6 @@ internal static class MachineCodeAmxKernel
     }
 
     /// <summary>
-    /// Diagnostic: emit <c>void ldst(ushort* src, ushort* dst, byte* cfg)</c> that configures one
-    /// 16×32-BF16 tile, loads it from <c>src</c> (tmm0), and stores it straight back to <c>dst</c>
-    /// — isolating tile config + load/store from the dot-product.
-    /// </summary>
-    internal static byte[] EmitTileLoadStoreProbeWindows()
-    {
-        var asm = new X64Assembler();
-        asm.Ldtilecfg(R8);              // cfg ptr is 3rd arg → r8
-        asm.MovRegImm32(RAX, RowBytes); // rax = 64
-        asm.TileloadD(0, RCX, RAX);     // tmm0 = src
-        asm.Tilestored(RDX, RAX, 0);    // dst = tmm0
-        asm.Tilerelease();
-        asm.Ret();
-        return asm.ToArray();
-    }
-
-    /// <summary>Run the load/store roundtrip; <paramref name="src"/>/<paramref name="dst"/> are 16×32 BF16 (512 each).</summary>
-    internal static unsafe bool TryRunLoadStore(ushort[] src, ushort[] dst)
-    {
-        byte[] code = EmitTileLoadStoreProbeWindows();
-        byte[] cfg = BuildTileConfig((TileM, TileK * 2));
-        using var mem = ExecutableMemory.TryAllocate(code);
-        if (mem is null || mem.Pointer == IntPtr.Zero) return false;
-        var fn = (delegate* unmanaged<ushort*, ushort*, byte*, void>)mem.Pointer;
-        fixed (ushort* sp = src)
-        fixed (ushort* dp = dst)
-        fixed (byte* cfgp = cfg)
-            fn(sp, dp, cfgp);
-        return true;
-    }
-
-    /// <summary>
     /// Emit + execute the one-tile probe. <paramref name="aPacked"/> is 16×32 BF16 (row-major, 64
     /// bytes/row); <paramref name="bVnni"/> is the VNNI-packed B, 16×32 BF16 (row r = {B[2r,n],
     /// B[2r+1,n]} over n=0..15); <paramref name="c"/> receives 16×16 FP32. Returns false only if

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/MachineCodeAmxKernel.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/MachineCodeAmxKernel.cs
@@ -1,0 +1,137 @@
+#if NET5_0_OR_GREATER
+using System;
+
+namespace AiDotNet.Tensors.Engines.BlasManaged.Jit;
+
+/// <summary>
+/// #380 — AMX (Advanced Matrix Extensions) tile GEMM, Phase 1: emit and execute a single
+/// <c>tdpbf16ps</c> tile contraction to verify the AMX instruction encodings
+/// (<see cref="X64Assembler.Tdpbf16ps"/>, tile load/store/config) and the tensor-core dot-product
+/// semantics.
+///
+/// <para>
+/// .NET exposes no AMX intrinsics, and AMX additionally needs OS XSAVE state enablement on real
+/// hardware. Because the body is raw machine code, <b>Intel SDE emulates the AMX tiles on any
+/// host</b> (run under <c>sde -spr</c>) — including AVX2-only dev boxes — so the encodings and the
+/// BF16 tile math are verifiable without Sapphire-Rapids hardware. On a host without AMX and
+/// without SDE the instructions fault <c>#UD</c>; callers must only run these under SDE there.
+/// </para>
+///
+/// <para>
+/// A single AMX BF16 tile op computes <c>C[16,16] += A[16,32] · B[16,16]</c> in FP32, where B is
+/// in the AMX row-pair "VNNI" layout: tile row r (r=0..15) holds, for each output column n,
+/// the pair {B[2r,n], B[2r+1,n]} as two BF16 — so a B-tile row is N=16 columns × 2 BF16 = 64
+/// bytes, encoding K=32 contraction depth across its 16 rows.
+/// </para>
+/// </summary>
+internal static class MachineCodeAmxKernel
+{
+    // Windows x64 ABI integer arg registers used by the emitted kernels.
+    private const int RAX = 0, RCX = 1, RDX = 2, R8 = 8, R9 = 9;
+
+    // The one-tile shape (AMX maxima for BF16): M rows × K depth → N cols.
+    internal const int TileM = 16, TileK = 32, TileN = 16;
+    private const int RowBytes = 64; // A: K*2 ; B(VNNI): N*2*2=... N*4? see note — all three are 64 here.
+
+    /// <summary>
+    /// Build the 64-byte AMX tile-configuration block consumed by <c>ldtilecfg</c>:
+    /// byte 0 = palette (1), byte 1 = start_row (0), bytes 16+2·t = colsb (bytes per row) for
+    /// tile t, bytes 48+t = rows for tile t. <paramref name="tiles"/> is (rows, colsb) per tile,
+    /// in tmm index order.
+    /// </summary>
+    internal static byte[] BuildTileConfig(params (int rows, int colsb)[] tiles)
+    {
+        var cfg = new byte[64];
+        cfg[0] = 1; // palette_id = 1 (the only non-init palette)
+        for (int t = 0; t < tiles.Length; t++)
+        {
+            cfg[16 + t * 2] = (byte)(tiles[t].colsb & 0xFF);
+            cfg[16 + t * 2 + 1] = (byte)((tiles[t].colsb >> 8) & 0xFF);
+            cfg[48 + t] = (byte)tiles[t].rows;
+        }
+        return cfg;
+    }
+
+    /// <summary>
+    /// Emit <c>void tileGemm(ushort* aPacked, ushort* bVnni, float* c, byte* cfg)</c>:
+    /// configure tiles, load A (tmm0) and the VNNI-packed B (tmm1), zero the C accumulator
+    /// (tmm2), run <c>tdpbf16ps tmm2, tmm0, tmm1</c>, store C, and release the tiles. All three
+    /// operands use a 64-byte row stride (passed in rax).
+    /// </summary>
+    internal static byte[] EmitTileGemmProbeWindows()
+    {
+        var asm = new X64Assembler();
+        asm.Ldtilecfg(R9);                  // ldtilecfg [r9]
+        asm.MovRegImm32(RAX, RowBytes);     // rax = 64 (row stride bytes)
+        asm.TileloadD(0, RCX, RAX);         // tmm0 = A      [rcx + rax]
+        asm.TileloadD(1, RDX, RAX);         // tmm1 = B(VNNI)[rdx + rax]
+        asm.Tilezero(2);                    // tmm2 = 0      (C accumulator)
+        // tdpbf16ps: the M-row operand (A) is ModRM.rm and the K-row operand (B) is VEX.vvvv —
+        // so to compute C(tmm2) = A(tmm0)·B(tmm1), A goes in rm and B in vvvv.
+        asm.Tdpbf16ps(2, /*vvvv=B*/1, /*rm=A*/0); // tmm2 += A · B (FP32 accumulate)
+        asm.Tilestored(R8, RAX, 2);         // [r8 + rax] = tmm2
+        asm.Tilerelease();
+        asm.Ret();
+        return asm.ToArray();
+    }
+
+    /// <summary>
+    /// Diagnostic: emit <c>void ldst(ushort* src, ushort* dst, byte* cfg)</c> that configures one
+    /// 16×32-BF16 tile, loads it from <c>src</c> (tmm0), and stores it straight back to <c>dst</c>
+    /// — isolating tile config + load/store from the dot-product.
+    /// </summary>
+    internal static byte[] EmitTileLoadStoreProbeWindows()
+    {
+        var asm = new X64Assembler();
+        asm.Ldtilecfg(R8);              // cfg ptr is 3rd arg → r8
+        asm.MovRegImm32(RAX, RowBytes); // rax = 64
+        asm.TileloadD(0, RCX, RAX);     // tmm0 = src
+        asm.Tilestored(RDX, RAX, 0);    // dst = tmm0
+        asm.Tilerelease();
+        asm.Ret();
+        return asm.ToArray();
+    }
+
+    /// <summary>Run the load/store roundtrip; <paramref name="src"/>/<paramref name="dst"/> are 16×32 BF16 (512 each).</summary>
+    internal static unsafe bool TryRunLoadStore(ushort[] src, ushort[] dst)
+    {
+        byte[] code = EmitTileLoadStoreProbeWindows();
+        byte[] cfg = BuildTileConfig((TileM, TileK * 2));
+        using var mem = ExecutableMemory.TryAllocate(code);
+        if (mem is null || mem.Pointer == IntPtr.Zero) return false;
+        var fn = (delegate* unmanaged<ushort*, ushort*, byte*, void>)mem.Pointer;
+        fixed (ushort* sp = src)
+        fixed (ushort* dp = dst)
+        fixed (byte* cfgp = cfg)
+            fn(sp, dp, cfgp);
+        return true;
+    }
+
+    /// <summary>
+    /// Emit + execute the one-tile probe. <paramref name="aPacked"/> is 16×32 BF16 (row-major, 64
+    /// bytes/row); <paramref name="bVnni"/> is the VNNI-packed B, 16×32 BF16 (row r = {B[2r,n],
+    /// B[2r+1,n]} over n=0..15); <paramref name="c"/> receives 16×16 FP32. Returns false only if
+    /// executable memory is unavailable. MUST run under Intel SDE on hosts lacking AMX.
+    /// </summary>
+    internal static unsafe bool TryRunTileProbe(ushort[] aPacked, ushort[] bVnni, float[] c)
+    {
+        if (aPacked.Length < TileM * TileK || bVnni.Length < TileM * (TileN * 2) || c.Length < TileM * TileN)
+            throw new ArgumentException("AMX tile probe needs A 16×32, B(VNNI) 16×32 BF16, C 16×16 floats.");
+
+        byte[] code = EmitTileGemmProbeWindows();
+        byte[] cfg = BuildTileConfig((TileM, TileK * 2), (TileM, TileN * 2 * 2), (TileM, TileN * 4));
+        // colsb: A=K*2=64 ; B(VNNI)=N*2 BF16 per row=64 ; C=N*4=64. (TileN*2*2 == TileN*4 == 64.)
+
+        using var mem = ExecutableMemory.TryAllocate(code);
+        if (mem is null || mem.Pointer == IntPtr.Zero) return false;
+        var fn = (delegate* unmanaged<ushort*, ushort*, float*, byte*, void>)mem.Pointer;
+
+        fixed (ushort* ap = aPacked)
+        fixed (ushort* bp = bVnni)
+        fixed (float* cp = c)
+        fixed (byte* cfgp = cfg)
+            fn(ap, bp, cp, cfgp);
+        return true;
+    }
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/X64Assembler.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/X64Assembler.cs
@@ -288,6 +288,9 @@ internal sealed class X64Assembler
     /// <summary>ldtilecfg [base] — load the 64-byte tile configuration. VEX.128.NP.0F38.W0 49 /0.</summary>
     internal void Ldtilecfg(int baseReg) => VexMemDisp8(Map0F38, PpNone, 0, 0, 0x49, 0, baseReg, 0);
 
+    /// <summary>sttilecfg [base] — store the current tile configuration. VEX.128.66.0F38.W0 49 /0.</summary>
+    internal void Sttilecfg(int baseReg) => VexMemDisp8(Map0F38, Pp66, 0, 0, 0x49, 0, baseReg, 0);
+
     /// <summary>tilerelease — reset all tiles to the init state. VEX.128.NP.0F38.W0 49 C0.</summary>
     internal void Tilerelease() => VexRR(Map0F38, PpNone, 0, 0, 0x49, 0, 0, 0);
 
@@ -304,6 +307,41 @@ internal sealed class X64Assembler
     /// reg = tdst (C). NOTE the K-row source (B/VNNI) is VEX.vvvv and the M-row source (A) is ModRM.rm —
     /// i.e. for C = A·B, pass tvvvv = B and trm = A. (Verified against Intel SDE.)</summary>
     internal void Tdpbf16ps(int tdst, int tvvvv, int trm) => VexRR(Map0F38, PpF3, 0, 0, 0x5C, tdst, tvvvv, trm);
+
+    // INT8 tile dot-products → INT32 accumulate (opcode 5E; prefix selects the sign combo).
+    // Same operand convention as tdpbf16ps: the K-row source (B/VNNI-4) is VEX.vvvv (tvvvv),
+    // the M-row source (A) is ModRM.rm (trm). VNNI depth is 4 int8 per group (vs 2 BF16).
+
+    /// <summary>tdpbssd — signed·signed int8 → int32. VEX.128.F2.0F38.W0 5E /r.</summary>
+    internal void Tdpbssd(int tdst, int tvvvv, int trm) => VexRR(Map0F38, PpF2, 0, 0, 0x5E, tdst, tvvvv, trm);
+
+    /// <summary>tdpbsud — signed·unsigned int8 → int32. VEX.128.F3.0F38.W0 5E /r.</summary>
+    internal void Tdpbsud(int tdst, int tvvvv, int trm) => VexRR(Map0F38, PpF3, 0, 0, 0x5E, tdst, tvvvv, trm);
+
+    /// <summary>tdpbusd — unsigned·signed int8 → int32. VEX.128.66.0F38.W0 5E /r.</summary>
+    internal void Tdpbusd(int tdst, int tvvvv, int trm) => VexRR(Map0F38, Pp66, 0, 0, 0x5E, tdst, tvvvv, trm);
+
+    /// <summary>tdpbuud — unsigned·unsigned int8 → int32. VEX.128.NP.0F38.W0 5E /r.</summary>
+    internal void Tdpbuud(int tdst, int tvvvv, int trm) => VexRR(Map0F38, PpNone, 0, 0, 0x5E, tdst, tvvvv, trm);
+
+    /// <summary>cpuid — leaf in eax, sub-leaf in ecx; clobbers eax/ebx/ecx/edx. 0F A2.</summary>
+    internal void Cpuid() => B(0x0F, 0xA2);
+
+    /// <summary>push reg64 (50+rd, REX.B for r8–r15).</summary>
+    internal void PushReg(int reg) { if (reg >= 8) B(0x41); B((byte)(0x50 + (reg & 7))); }
+
+    /// <summary>pop reg64 (58+rd, REX.B for r8–r15).</summary>
+    internal void PopReg(int reg) { if (reg >= 8) B(0x41); B((byte)(0x58 + (reg & 7))); }
+
+    /// <summary>mov [base + disp8], reg32 — store a 32-bit register. 89 /r.</summary>
+    internal void MovMemFromReg32(int baseReg, sbyte disp8, int reg)
+    {
+        byte rex = (byte)((reg >= 8 ? 4 : 0) | (baseReg >= 8 ? 1 : 0));
+        if (rex != 0) B((byte)(0x40 | rex));
+        B(0x89, (byte)(0x40 | ((reg & 7) << 3) | (baseReg & 7)));
+        if ((baseReg & 7) == 4) B(0x24); // SIB for rsp/r12 base
+        B((byte)disp8);
+    }
 
     /// <summary>vxorpd dst, s1, s2. VEX.256.66.0F.WIG 57. (zero a reg: dst=s1=s2)</summary>
     internal void Vxorpd(int dst, int s1, int s2) => VexRR(Map0F, Pp66, 0, 1, 0x57, dst, s1, s2);

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/X64Assembler.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/X64Assembler.cs
@@ -257,6 +257,54 @@ internal sealed class X64Assembler
     /// <summary>512-bit vdpbf16ps zmm_dst, zmm_s1, zmm_s2. EVEX.512.F3.0F38.W0 52 /r.</summary>
     internal void Vdpbf16ps512(int dst, int s1, int s2) => EvexRR(Map0F38, PpF3, 0, 2, 0x52, dst, s1, s2);
 
+    // ── AMX tile instructions (#380: Sapphire Rapids tensor cores) ─────────────
+    // All VEX.128.*.0F38.W0; tile regs tmm0..7 encode in ModRM.reg/.rm and VEX.vvvv
+    // (3 bits, no extension). TILELOADD/TILESTORED take a sibmem operand (base+index,
+    // index = row-stride in bytes, scale 1) — hence the dedicated SIB emitter below.
+    private const int PpF2 = 3; // F2 prefix (pp=11); complements PpNone/Pp66/PpF3 above.
+
+    // VEX memory form with an explicit SIB (mod=00, rm=100): [base + index*1]. Requires
+    // base ∉ {rbp,r13} (those select disp32 at mod=00); callers pick base accordingly.
+    private void VexSib(int map, int pp, int w, int L, byte opcode, int reg, int baseReg, int indexReg, int scale)
+    {
+        int rBit = (reg < 8) ? 1 : 0;
+        int xBit = (indexReg < 8) ? 1 : 0;
+        int bBit = (baseReg < 8) ? 1 : 0;
+        byte b1 = (byte)((rBit << 7) | (xBit << 6) | (bBit << 5) | map);
+        byte b2 = (byte)((w << 7) | (0xF << 3) | (L << 2) | pp);
+        byte modrm = (byte)(((reg & 7) << 3) | 0x4); // mod=00, rm=100 → SIB follows
+        byte sib = (byte)((scale << 6) | ((indexReg & 7) << 3) | (baseReg & 7));
+        B(0xC4, b1, b2, opcode, modrm, sib);
+    }
+
+    /// <summary>mov reg32, imm32 (zero-extends to 64-bit). B8+rd id. For tile row strides.</summary>
+    internal void MovRegImm32(int reg, int imm)
+    {
+        if (reg >= 8) B(0x41); // REX.B
+        B((byte)(0xB8 + (reg & 7)));
+        Imm32(imm);
+    }
+
+    /// <summary>ldtilecfg [base] — load the 64-byte tile configuration. VEX.128.NP.0F38.W0 49 /0.</summary>
+    internal void Ldtilecfg(int baseReg) => VexMemDisp8(Map0F38, PpNone, 0, 0, 0x49, 0, baseReg, 0);
+
+    /// <summary>tilerelease — reset all tiles to the init state. VEX.128.NP.0F38.W0 49 C0.</summary>
+    internal void Tilerelease() => VexRR(Map0F38, PpNone, 0, 0, 0x49, 0, 0, 0);
+
+    /// <summary>tilezero tmm — zero a tile (the C accumulator). VEX.128.F2.0F38.W0 49 /r (mod=11).</summary>
+    internal void Tilezero(int tmm) => VexRR(Map0F38, PpF2, 0, 0, 0x49, tmm, 0, 0);
+
+    /// <summary>tileloadd tmm, [base + index*1] — load a tile, index = row stride bytes. VEX.128.F2.0F38.W0 4B /r.</summary>
+    internal void TileloadD(int tmm, int baseReg, int indexReg) => VexSib(Map0F38, PpF2, 0, 0, 0x4B, tmm, baseReg, indexReg, 0);
+
+    /// <summary>tilestored [base + index*1], tmm — store a tile. VEX.128.F3.0F38.W0 4B /r.</summary>
+    internal void Tilestored(int baseReg, int indexReg, int tmm) => VexSib(Map0F38, PpF3, 0, 0, 0x4B, tmm, baseReg, indexReg, 0);
+
+    /// <summary>tdpbf16ps tdst, tvvvv, trm — tile BF16 dot-product accumulate (FP32). VEX.128.F3.0F38.W0 5C /r;
+    /// reg = tdst (C). NOTE the K-row source (B/VNNI) is VEX.vvvv and the M-row source (A) is ModRM.rm —
+    /// i.e. for C = A·B, pass tvvvv = B and trm = A. (Verified against Intel SDE.)</summary>
+    internal void Tdpbf16ps(int tdst, int tvvvv, int trm) => VexRR(Map0F38, PpF3, 0, 0, 0x5C, tdst, tvvvv, trm);
+
     /// <summary>vxorpd dst, s1, s2. VEX.256.66.0F.WIG 57. (zero a reg: dst=s1=s2)</summary>
     internal void Vxorpd(int dst, int s1, int s2) => VexRR(Map0F, Pp66, 0, 1, 0x57, dst, s1, s2);
 

--- a/tests/AiDotNet.Tensors.Benchmarks/MicrokernelGflopsBench.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/MicrokernelGflopsBench.cs
@@ -385,6 +385,63 @@ public static class MicrokernelGflopsBench
         return pass;
     }
 
+    // #380 AMX Phase 1: verify a single tdpbf16ps tile op — C[16,16] += A[16,32]·B[16,16] in FP32,
+    // B in the AMX row-pair VNNI layout. Run UNDER INTEL SDE (-spr) on a non-AMX host (the tile
+    // instructions are emulated). Returns false on mismatch / no executable memory.
+    public static bool VerifyAmxTile()
+    {
+        Console.WriteLine("=== AMX tdpbf16ps tile op (C16x16 += A16x32 . B16x16, VNNI) ===");
+        const int M = 16, K = 32, N = 16;
+
+        var rng = new Random(31);
+        // Logical A[M,K] and B[K,N] as BF16.
+        var a = new ushort[M * K];
+        var bLogical = new ushort[K * N];
+        for (int i = 0; i < a.Length; i++) a[i] = FloatToBf16((float)(rng.NextDouble() * 2 - 1));
+        for (int i = 0; i < bLogical.Length; i++) bLogical[i] = FloatToBf16((float)(rng.NextDouble() * 2 - 1));
+
+        // Pack B into the AMX VNNI layout: row r (0..K/2-1) = {B[2r,n], B[2r+1,n]} over n.
+        var bVnni = new ushort[(K / 2) * (N * 2)];
+        for (int r = 0; r < K / 2; r++)
+            for (int n = 0; n < N; n++)
+            {
+                bVnni[r * (N * 2) + 2 * n] = bLogical[(2 * r) * N + n];
+                bVnni[r * (N * 2) + 2 * n + 1] = bLogical[(2 * r + 1) * N + n];
+            }
+
+        var c = new float[M * N];
+        bool ran;
+        try
+        {
+            ran = AiDotNet.Tensors.Engines.BlasManaged.Jit.MachineCodeAmxKernel.TryRunTileProbe(a, bVnni, c);
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine("  tile op threw (likely #UD — not under SDE, or bad encoding): " + e.Message);
+            return false;
+        }
+        if (!ran)
+        {
+            Console.WriteLine("  executable memory unavailable — cannot verify");
+            return false;
+        }
+
+        bool pass = true;
+        int bad = 0;
+        for (int i = 0; i < M; i++)
+            for (int j = 0; j < N; j++)
+            {
+                double truth = 0;
+                for (int kk = 0; kk < K; kk++)
+                    truth += (double)Bf16ToFloat(a[i * K + kk]) * Bf16ToFloat(bLogical[kk * N + j]);
+                double got = c[i * N + j];
+                bool ok = Math.Abs(got - truth) <= 1e-3 * Math.Max(1.0, Math.Abs(truth));
+                if (!ok) { pass = false; if (bad++ < 6) Console.WriteLine($"  C[{i},{j}] got {got:G6} exp {truth:G6} FAIL"); }
+            }
+        Console.WriteLine(pass ? $"AMX TILE VERIFIED ({M}x{K}x{N}, all {M * N} elements)" : "AMX TILE FAILED");
+        return pass;
+    }
+
     private static ushort FloatToBf16(float f) => (ushort)(BitConverter.SingleToUInt32Bits(f) >> 16);
     private static float Bf16ToFloat(ushort h) => BitConverter.UInt32BitsToSingle((uint)h << 16);
 }

--- a/tests/AiDotNet.Tensors.Benchmarks/MicrokernelGflopsBench.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/MicrokernelGflopsBench.cs
@@ -488,6 +488,63 @@ public static class MicrokernelGflopsBench
         return pass;
     }
 
+    // #380 AMX INT8: verify a single tdpbssd tile op — C[16,16] int32 += A[16,64]·B[16,64] int8,
+    // B in the AMX 4-deep VNNI layout. Exact integer compare. Run UNDER INTEL SDE (-spr).
+    public static bool VerifyAmxInt8Tile()
+    {
+        Console.WriteLine("=== AMX tdpbssd tile op (C16x16 int32 += A16x64 . B16x64 int8, VNNI-4) ===");
+        const int M = 16, K = 64, N = 16;
+        var rng = new Random(53);
+        var a = new sbyte[M * K];
+        var bLogical = new sbyte[K * N];
+        for (int i = 0; i < a.Length; i++) a[i] = (sbyte)rng.Next(-100, 101);
+        for (int i = 0; i < bLogical.Length; i++) bLogical[i] = (sbyte)rng.Next(-100, 101);
+
+        // VNNI-4: row g (0..K/4-1) holds {B[4g+0,n]..B[4g+3,n]} for each n.
+        var bVnni4 = new sbyte[(K / 4) * (N * 4)];
+        for (int g = 0; g < K / 4; g++)
+            for (int n = 0; n < N; n++)
+                for (int t = 0; t < 4; t++)
+                    bVnni4[g * (N * 4) + 4 * n + t] = bLogical[(4 * g + t) * N + n];
+
+        var c = new int[M * N];
+        bool ran;
+        try { ran = AiDotNet.Tensors.Engines.BlasManaged.Jit.MachineCodeAmxKernel.TryRunTileProbeInt8(a, bVnni4, c); }
+        catch (Exception e) { Console.WriteLine("  int8 tile threw (likely #UD — not under SDE): " + e.Message); return false; }
+        if (!ran) { Console.WriteLine("  executable memory unavailable — cannot verify"); return false; }
+
+        bool pass = true;
+        int bad = 0;
+        for (int i = 0; i < M; i++)
+            for (int j = 0; j < N; j++)
+            {
+                long truth = 0;
+                for (int kk = 0; kk < K; kk++) truth += a[i * K + kk] * bLogical[kk * N + j];
+                if (c[i * N + j] != truth) { pass = false; if (bad++ < 6) Console.WriteLine($"  C[{i},{j}] got {c[i * N + j]} exp {truth} FAIL"); }
+            }
+        Console.WriteLine(pass ? $"AMX INT8 TILE VERIFIED ({M}x{K}x{N}, all {M * N} elements, exact)" : "AMX INT8 TILE FAILED");
+        return pass;
+    }
+
+    // #380 AMX detection: read CPUID.(7,0):EDX via emitted machine code and report the AMX bits.
+    // Under `sde -spr` the AMX-TILE/BF16/INT8 bits must all be set. Returns true iff AMX-TILE present.
+    public static bool VerifyAmxCpuid()
+    {
+        Console.WriteLine("=== AMX CPUID detection (CPUID.7.0:EDX bits 24/22/25) ===");
+        if (!AiDotNet.Tensors.Engines.BlasManaged.Jit.MachineCodeAmxKernel.TryGetAmxCpuidEdx(out uint edx))
+        {
+            Console.WriteLine("  executable memory unavailable — cannot probe CPUID");
+            return false;
+        }
+        bool tile = (edx & AiDotNet.Tensors.Engines.BlasManaged.Jit.MachineCodeAmxKernel.AmxTileBit) != 0;
+        bool bf16 = (edx & AiDotNet.Tensors.Engines.BlasManaged.Jit.MachineCodeAmxKernel.AmxBf16Bit) != 0;
+        bool int8 = (edx & AiDotNet.Tensors.Engines.BlasManaged.Jit.MachineCodeAmxKernel.AmxInt8Bit) != 0;
+        Console.WriteLine($"  EDX=0x{edx:X8}  AMX-TILE={tile}  AMX-BF16={bf16}  AMX-INT8={int8}");
+        bool pass = tile && bf16 && int8; // under sde -spr all three are advertised
+        Console.WriteLine(pass ? "AMX CPUID VERIFIED (all AMX bits set)" : "AMX CPUID: not all AMX bits set (expected on a non-AMX host without SDE)");
+        return pass;
+    }
+
     private static ushort FloatToBf16(float f) => (ushort)(BitConverter.SingleToUInt32Bits(f) >> 16);
     private static float Bf16ToFloat(ushort h) => BitConverter.UInt32BitsToSingle((uint)h << 16);
 }

--- a/tests/AiDotNet.Tensors.Benchmarks/MicrokernelGflopsBench.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/MicrokernelGflopsBench.cs
@@ -442,6 +442,52 @@ public static class MicrokernelGflopsBench
         return pass;
     }
 
+    // #380 AMX Phase 2: verify the full tiled AMX GEMM. Shape M=20,K=40,N=24 is ragged in all
+    // three dims (16+4 / 32+8 / 16+8) so it exercises M/K/N tiling + zero-padded edges and K
+    // accumulation across tiles. Run UNDER INTEL SDE (-spr). Returns false on mismatch.
+    public static bool VerifyAmxGemm()
+    {
+        Console.WriteLine("=== AMX tiled BF16 GEMM (ragged tiling + K accumulation) ===");
+        const int M = 20, K = 40, N = 24;
+        var rng = new Random(41);
+        var a = new ushort[M * K];
+        var b = new ushort[K * N];
+        for (int i = 0; i < a.Length; i++) a[i] = FloatToBf16((float)(rng.NextDouble() * 2 - 1));
+        for (int i = 0; i < b.Length; i++) b[i] = FloatToBf16((float)(rng.NextDouble() * 2 - 1));
+        var c = new float[M * N];
+
+        bool ran;
+        try
+        {
+            ran = AiDotNet.Tensors.Engines.BlasManaged.Jit.MachineCodeAmxKernel.TryGemm(a, b, c, M, K, N);
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine("  GEMM threw (likely #UD — not under SDE, or bad encoding): " + e.Message);
+            return false;
+        }
+        if (!ran)
+        {
+            Console.WriteLine("  executable memory unavailable — cannot verify");
+            return false;
+        }
+
+        bool pass = true;
+        int bad = 0;
+        for (int i = 0; i < M; i++)
+            for (int j = 0; j < N; j++)
+            {
+                double truth = 0;
+                for (int kk = 0; kk < K; kk++)
+                    truth += (double)Bf16ToFloat(a[i * K + kk]) * Bf16ToFloat(b[kk * N + j]);
+                double got = c[i * N + j];
+                bool ok = Math.Abs(got - truth) <= 2e-3 * Math.Max(1.0, Math.Abs(truth));
+                if (!ok) { pass = false; if (bad++ < 6) Console.WriteLine($"  C[{i},{j}] got {got:G6} exp {truth:G6} FAIL"); }
+            }
+        Console.WriteLine(pass ? $"AMX GEMM VERIFIED ({M}x{K}x{N}, all {M * N} elements)" : "AMX GEMM FAILED");
+        return pass;
+    }
+
     private static ushort FloatToBf16(float f) => (ushort)(BitConverter.SingleToUInt32Bits(f) >> 16);
     private static float Bf16ToFloat(ushort h) => BitConverter.UInt32BitsToSingle((uint)h << 16);
 }

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -298,6 +298,19 @@ class Program
             Environment.Exit(MicrokernelGflopsBench.VerifyAmxGemm() ? 0 : 1);
         }
 
+        // #380 AMX INT8 — verify a single tdpbssd (int8→int32) tile op. Run under Intel SDE.
+        if (args[0] == "--verify-amx-int8")
+        {
+            Environment.Exit(MicrokernelGflopsBench.VerifyAmxInt8Tile() ? 0 : 1);
+        }
+
+        // #380 AMX detection — read CPUID.(7,0):EDX AMX bits via emitted machine code. Under
+        // `sde -spr` all AMX bits are set (exit 0); on a bare non-AMX host they aren't (exit 1).
+        if (args[0] == "--verify-amx-cpuid")
+        {
+            Environment.Exit(MicrokernelGflopsBench.VerifyAmxCpuid() ? 0 : 1);
+        }
+
 #if !NET462
         // Run cuBLAS vs DirectGpu GEMM benchmark
         if (args[0] == "--cublas")

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -291,6 +291,13 @@ class Program
             Environment.Exit(MicrokernelGflopsBench.VerifyAmxTile() ? 0 : 1);
         }
 
+        // #380 AMX Phase 2 — verify the full tiled AMX GEMM (ragged tiling + K accumulation).
+        // Run under Intel SDE; exits non-zero on a mismatch.
+        if (args[0] == "--verify-amx-gemm")
+        {
+            Environment.Exit(MicrokernelGflopsBench.VerifyAmxGemm() ? 0 : 1);
+        }
+
 #if !NET462
         // Run cuBLAS vs DirectGpu GEMM benchmark
         if (args[0] == "--cublas")

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -284,6 +284,13 @@ class Program
             Environment.Exit(MicrokernelGflopsBench.VerifyBf16Gemm() ? 0 : 1);
         }
 
+        // #380 AMX Phase 1 — verify a single tdpbf16ps tile op. Run under Intel SDE
+        // (`sde -spr -- dotnet ... --verify-amx-tile`); exits non-zero on a mismatch.
+        if (args[0] == "--verify-amx-tile")
+        {
+            Environment.Exit(MicrokernelGflopsBench.VerifyAmxTile() ? 0 : 1);
+        }
+
 #if !NET462
         // Run cuBLAS vs DirectGpu GEMM benchmark
         if (args[0] == "--cublas")


### PR DESCRIPTION
Closes #380

## What this is

The AMX (Advanced Matrix Extensions / Sapphire-Rapids tensor-core) GEMM path for BlasManaged. .NET exposes **no** AMX intrinsics, so — exactly as the issue anticipated ("inline assembly via DynamicMethod IL emission") — AMX is reached by emitting the raw machine code through the existing `X64Assembler`, keeping it supply-chain clean (no P/Invoke into external libraries). Everything is verified under **Intel SDE** (`sde -spr`) on an AVX2-only dev box, so the encodings and tile math are proven without Sapphire-Rapids hardware.

## Issue-coverage audit

| #380 requirement | This PR |
|---|---|
| Tile config `ldtilecfg` / `sttilecfg` | both encoders; `ldtilecfg` used + verified |
| `tdpbf16ps` (BF16) | verified — single tile **and** full tiled GEMM |
| `tdpbssd`/`tdpbsud`/`tdpbusd`/`tdpbuud` (INT8) | all 4 encoders; `tdpbssd` verified (exact int32) |
| `tileloadd` / `tilestored` | new SIB (base+index stride) emitter; verified |
| Detection `CPUID.7.0:EDX[22/24/25]` | emitted CPUID reader; `EDX=0xFFDC4432`, all AMX bits set |
| Approach: IL/machine-code emission | via `X64Assembler` — no external native dep |

## Changes

- **`X64Assembler`** — AMX VEX encodings: `ldtilecfg`/`sttilecfg`, `tilezero`, `tileloadd`/`tilestored` (new SIB base+index emitter for the row-stride operand), `tdpbf16ps`, the four INT8 `tdpb*d`, `tilerelease`; plus `cpuid`, `push`/`pop reg`, `mov [mem],reg32`, `mov reg32,imm32`.
- **`MachineCodeAmxKernel`** — the 64-byte tile config builder; a BF16 single-tile op (`C[16,16] += A[16,32]·B[16,32]`, B in 2-deep VNNI); a full tiled BF16 GEMM (M/16, N/16, K/32 tiling, VNNI packing, zero-padded ragged edges, K-accumulation through the C buffer); an INT8 `tdpbssd` tile op (4-deep VNNI, int32 accumulate); and an emitted `CPUID.(7,0):EDX` AMX-feature reader.

## Encoding gotcha pinned via SDE

For `tdpbf16ps`/`tdpb*d` the **M-row source (A) is `ModRM.rm` and the K-row source (B/VNNI) is `VEX.vvvv`** — i.e. for `C = A·B`, A goes in `rm` and B in `vvvv`. A load/store roundtrip diagnostic isolated this (config + load/store were correct; the dot-product operands were swapped).

## Verification (all under `sde -spr`, exit 0)

- `--verify-amx-tile` — BF16 16×32×16, all 256 elements match FP32 reference
- `--verify-amx-gemm` — BF16 20×40×24 (ragged in all three dims), all 480 elements
- `--verify-amx-int8` — INT8 16×64×16, all 256 elements match int32 reference **exactly**
- `--verify-amx-cpuid` — `EDX=0xFFDC4432`, AMX-TILE/BF16/INT8 all set

Both TFMs (net10.0 + net471) build clean.

## Deliberately scoped as follow-ups (blocked on real hardware)

- **Production dispatch auto-enable** — needs the CPUID gate **plus OS XSAVE/XFD enablement** and real Sapphire-Rapids/Zen-5 validation. Emulation / AVX-512-BF16 stays the default until then (same boundary as the #378 native path).
- **Perf tuning** — keep the C tile resident across K, a JIT K-loop, and hoist `ldtilecfg`; needs real AMX hardware to benchmark meaningfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
