### PR TITLE
perf(#475): drop MlpForward per-call weight copy (AsSpan) + GEMM-floor diagnostic

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.Mlp.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.Mlp.cs
@@ -185,17 +185,28 @@ public partial class CpuEngine
                         bool preferManaged = (long)curK * n <= 200_000 || !BlasProvider.HasRawSgemm;
                         if (preferManaged)
                         {
-                            // Managed cached-B keys its pre-pack on the weight array identity,
-                            // so it needs a float[]. The narrow layers it serves are small, so
-                            // the GetDataArray snapshot (a copy only for GPU-tagged weights) is
-                            // cheap relative to the wide-head copy avoided above.
-                            var wArr = (float[])(object)w.GetDataArray();
+                            // Managed cached-B keys its pre-pack on the weight ARRAY IDENTITY,
+                            // so it must see the SAME float[] on every call. GetDataArray()
+                            // returns a fresh snapshot for GPU-tagged tensors, which both
+                            // defeated the identity-keyed pack cache (a silent re-pack every
+                            // call) and reintroduced the per-call weight copy this PR removes.
+                            // GetFlattenedData() returns the STABLE backing array for the
+                            // standard weight layout (contiguous, zero-offset, exact-fit —
+                            // the same memory AsSpan() reads), preserving identity across
+                            // calls; exotic layouts still get a correct flat copy, merely
+                            // without cross-call pack reuse. The AsSpan() touch first
+                            // materializes lazy data under the same contiguous-weight
+                            // contract the wide-layer branch below already relies on.
+                            var wT = (Tensor<float>)(object)w;
+                            _ = wT.AsSpan();
+                            float[] wArr = wT.GetFlattenedData();
                             Simd.SimdGemm.SgemmWithCachedB(
                                 srcSpan.Slice(0, M * curK), wArr, dst.AsSpan(0, M * n), M, curK, n);
                         }
                         else
                         {
-                            ReadOnlySpan<float> wSpan = ((Tensor<float>)(object)w).AsSpan();
+                            var wT = (Tensor<float>)(object)w;
+                            ReadOnlySpan<float> wSpan = wT.AsSpan();
                             unsafe
                             {
                                 fixed (float* ps = srcSpan, pw = wSpan, pd = dst)
@@ -203,8 +214,11 @@ public partial class CpuEngine
                                     if (BlasProvider.HasRawSgemm)
                                         BlasProvider.SgemmRaw(M, n, curK, ps, curK, pw, n, pd, n);
                                     else
+                                        // Unreachable in practice (preferManaged already captures
+                                        // !HasRawSgemm); kept as a defensive fallback, on the same
+                                        // stable-array contract as the preferManaged branch above.
                                         Simd.SimdGemm.SgemmWithCachedB(
-                                            srcSpan.Slice(0, M * curK), (float[])(object)w.GetDataArray(),
+                                            srcSpan.Slice(0, M * curK), wT.GetFlattenedData(),
                                             dst.AsSpan(0, M * n), M, curK, n);
                                 }
                             }

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.Mlp.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.Mlp.cs
@@ -149,14 +149,26 @@ public partial class CpuEngine
                 float[] bufB = maxIntermediate > 0 ? pool.Rent(maxIntermediate) : System.Array.Empty<float>();
                 try
                 {
-                    float[] src = (float[])(object)input.GetDataArray();
+                    // #475: read the input/weights through AsSpan (no copy) rather than
+                    // GetDataArray. GetDataArray hands back a *copy* for any tensor whose
+                    // _device != CPU — and the GPU auto-detect ModuleInitializer makes the
+                    // default engine (hence freshly-created tensors) GPU-resident on any box
+                    // with a working accelerator, even when the data lives in a CPU array.
+                    // That made this CPU primitive re-copy every weight on every call
+                    // (~1.5 MB for the 784×512 head alone), dominating per-call allocation
+                    // and feeding the GC tail. AsSpan returns the live CPU span after
+                    // EnsureMaterialized, so it's a no-op on genuinely CPU-resident tensors
+                    // and skips the per-call snapshot on CPU-resident-but-GPU-tagged ones.
+                    // (We're inside the typeof(T)==float branch, so the (object) casts are
+                    // exact reference casts, not boxing.)
+                    var inputF = (Tensor<float>)(object)input;
+                    ReadOnlySpan<float> srcSpan = inputF.AsSpan();
                     int curK = k0;
                     int pingToggle = 0;
                     for (int i = 0; i < weights.Count; i++)
                     {
                         var w = weights[i];
                         int n = w._shape[1];
-                        var wArr = (float[])(object)w.GetDataArray();
                         // Last layer writes directly into the result buffer (no copy).
                         float[] dst = i == last ? outArr : (pingToggle == 0 ? bufA : bufB);
 
@@ -173,20 +185,27 @@ public partial class CpuEngine
                         bool preferManaged = (long)curK * n <= 200_000 || !BlasProvider.HasRawSgemm;
                         if (preferManaged)
                         {
+                            // Managed cached-B keys its pre-pack on the weight array identity,
+                            // so it needs a float[]. The narrow layers it serves are small, so
+                            // the GetDataArray snapshot (a copy only for GPU-tagged weights) is
+                            // cheap relative to the wide-head copy avoided above.
+                            var wArr = (float[])(object)w.GetDataArray();
                             Simd.SimdGemm.SgemmWithCachedB(
-                                src.AsSpan(0, M * curK), wArr, dst.AsSpan(0, M * n), M, curK, n);
+                                srcSpan.Slice(0, M * curK), wArr, dst.AsSpan(0, M * n), M, curK, n);
                         }
                         else
                         {
+                            ReadOnlySpan<float> wSpan = ((Tensor<float>)(object)w).AsSpan();
                             unsafe
                             {
-                                fixed (float* ps = src, pw = wArr, pd = dst)
+                                fixed (float* ps = srcSpan, pw = wSpan, pd = dst)
                                 {
                                     if (BlasProvider.HasRawSgemm)
                                         BlasProvider.SgemmRaw(M, n, curK, ps, curK, pw, n, pd, n);
                                     else
                                         Simd.SimdGemm.SgemmWithCachedB(
-                                            src.AsSpan(0, M * curK), wArr, dst.AsSpan(0, M * n), M, curK, n);
+                                            srcSpan.Slice(0, M * curK), (float[])(object)w.GetDataArray(),
+                                            dst.AsSpan(0, M * n), M, curK, n);
                                 }
                             }
                         }
@@ -198,7 +217,7 @@ public partial class CpuEngine
                         if (bArr is not null || act != FusedActivationType.None)
                             CpuFusedOperations.ApplyBiasActivationInPlace(dst, bArr, M, n, act, ap);
 
-                        src = dst;
+                        srcSpan = dst.AsSpan(0, M * n);
                         curK = n;
                         if (i != last) pingToggle ^= 1;
                     }

--- a/tests/AiDotNet.Tensors.Benchmarks/PyTorchComparison/AisEvalHeadToHeadBench.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/PyTorchComparison/AisEvalHeadToHeadBench.cs
@@ -260,6 +260,19 @@ internal static class AisEvalHeadToHeadBench
             BlasProvider.MklSgemmZeroOffset(bs, 10, 128, h1, 128, w2, 10, y, 10);
         };
 
+        // Managed variant: all 3 layers through SgemmWithCachedB (the BlasManaged
+        // cached-B machine-code path, #409). Weights are stable arrays so the
+        // pre-pack cache hits. Tests whether the managed microkernel beats native
+        // BLAS at these small inference shapes (the #475 routing question).
+        Action gemm3Managed = () =>
+        {
+            AiDotNet.Tensors.Engines.Simd.SimdGemm.SgemmWithCachedB(x0.AsSpan(0, bs * 784), w0, h0.AsSpan(0, bs * 512), bs, 784, 512);
+            for (int i = 0; i < bs * 512; i++) if (h0[i] < 0) h0[i] = 0;
+            AiDotNet.Tensors.Engines.Simd.SimdGemm.SgemmWithCachedB(h0.AsSpan(0, bs * 512), w1, h1.AsSpan(0, bs * 128), bs, 512, 128);
+            for (int i = 0; i < bs * 128; i++) if (h1[i] < 0) h1[i] = 0;
+            AiDotNet.Tensors.Engines.Simd.SimdGemm.SgemmWithCachedB(h1.AsSpan(0, bs * 128), w2, y.AsSpan(0, bs * 10), bs, 128, 10);
+        };
+
         // OpenBLAS thread-count sweep: tiny GEMMs (esp. 128x10x128) may be hurt
         // by spinning all cores — torch's MKL uses small-GEMM thread heuristics.
         var sw = new Stopwatch();
@@ -297,6 +310,13 @@ internal static class AisEvalHeadToHeadBench
             (mklMed, mklP95) = Percentiles(mt);
         }
 
+        // Managed machine-code path timing
+        for (int i = 0; i < Warmup; i++) gemm3Managed();
+        SettleGc();
+        var gt = new double[Iters];
+        for (int i = 0; i < Iters; i++) { sw.Restart(); gemm3Managed(); sw.Stop(); gt[i] = sw.Elapsed.TotalMilliseconds; }
+        var (mgMed, mgP95) = Percentiles(gt);
+
         // torch reference at the same shapes
         var mlp = torch.nn.Sequential(
             ("fc1", torch.nn.Linear(784, 512)), ("relu1", torch.nn.ReLU()),
@@ -309,6 +329,7 @@ internal static class AisEvalHeadToHeadBench
         Console.WriteLine($"  raw 3xGEMM (OpenBLAS fptr) : med {med,7:F3}ms  p95 {p95,7:F3}ms");
         if (!double.IsNaN(mklMed))
             Console.WriteLine($"  raw 3xGEMM (MKL verified) : med {mklMed,7:F3}ms  p95 {mklP95,7:F3}ms");
+        Console.WriteLine($"  raw 3xGEMM (managed mc)   : med {mgMed,7:F3}ms  p95 {mgP95,7:F3}ms");
         Console.WriteLine($"  torch MLP                 : med {tMed,7:F3}ms  p95 {tP95,7:F3}ms");
         Console.WriteLine();
         double bestFloor = double.IsNaN(mklMed) ? med : Math.Min(med, mklMed);


### PR DESCRIPTION
Part of #475 (does **not** close it — see "What remains" below).

## TL;DR

Two things, from a deep profiling pass on the AIsEval MLP (`Dense 784→512→128→10`, bs=128) vs torch CPU:

1. **A real fix** — `MlpForward` was re-copying every weight on every call (~1.76 MB) because of a device-tagging interaction with GPU auto-detect. Reading through `AsSpan` instead removes it.
2. **A diagnostic** — a managed-machine-code variant in the GEMM floor bench that pins down *why* we trail torch (and rules out a routing fix).

## 1. The copy fix (`perf(#475)`)

`Tensor.GetDataArray()` returns a **copy** for any tensor whose `_device != CPU` (the guard that protects against stale GPU data). The `GpuAutoDetectModuleInit` `[ModuleInitializer]` auto-promotes the default engine to GPU on any box with a working accelerator, so `Tensor.CreateRandom` (which routes through `AiDotNetEngine.Current`) produces **OpenCL-device tensors even when their data lives in a CPU array**. The result: this CPU inference primitive snapshotted every weight on every call (~1.5 MB for the 784×512 head alone), dominating per-call allocation and feeding a ~6× p95/median GC tail.

Fix: read the input and the native-path (wide-layer) weights through `AsSpan()` — the live CPU span after `EnsureMaterialized` — instead of `GetDataArray()`. On genuinely CPU-resident tensors this is a no-op (both already hand back the backing); on CPU-resident-but-GPU-tagged ones it skips the snapshot. The managed cached-B narrow layers still take a `float[]` (their pre-pack keys on array identity) — a small residual relative to the wide-head copy now avoided. Inside the `typeof(T)==float` branch the `(Tensor<float>)(object)` casts are exact reference casts (no boxing, no generic-constraint issue).

**Measured (this 32-thread box):**

| | GPU-tagged tensors | CPU-only target (`AIDOTNET_DISABLE_GPU=1`) |
|---|---|---|
| alloc/call | 2.29 MB → **279 KB** (8.2×) | unchanged (~6 KB) |
| median | 1.26 ms → **0.71 ms** (1.8×) | unchanged (~0.55 ms) |
| p95/median | 6.1 → **2.6** | — |

`MlpForward` / `CompiledMlp` parity tests: **65 pass / 0 fail**. Both TFMs (net10.0 + net471) build.

## 2. The floor-bench diagnostic (`test(#475)`)

Added a managed-machine-code variant (`SgemmWithCachedB`, the #409 path) alongside the OpenBLAS-fptr and MKL-verified variants in `--ab-aiseval-floor`. At the MLP shapes:

| path | median |
|---|---|
| native OpenBLAS | 0.97 ms |
| our MKL-verified | 0.97 ms |
| managed machine-code | **1.31 ms (slower)** |
| torch MKL | **0.36 ms** |

So **routing these small inference GEMMs to the managed microkernel does not help** — native BLAS is faster, and the remaining 2.7× gap to torch is MKL packed-GEMM + tuned small-GEMM threading, not our routing choice.

## What remains (why this doesn't `Close #475`)

#475's core ask is matching torch's small-GEMM kernel quality. Profiling shows that needs **MKL packed GEMM** (`cblas_sgemm_pack`/`_compute` — torch pre-packs the frozen `nn.Linear` weight once; we don't bind these) plus MKL's tuned small-GEMM threading. That's a sizeable native-binding effort that likely only partially closes the gap (packing ≈ 1/6 of it), so it's left as a tracked follow-up and #475 stays open.

## Note on the measurements

A real **CPU-only deployment** (the #436 target) never had the 2.29 MB copy — it's a GPU-equipped-dev-box artifact. Cross-checking with `AIDOTNET_DISABLE_GPU=1` shows the true CPU-only MLP was always ~0.55 ms (2.1× torch), not the 1.05 ms first measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
