### PR TITLE
fix(gpu): softmax batchSize OOB + training-OOM root cause + CUDA finalizer safety

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/CompiledDelegateChain.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/CompiledDelegateChain.cs
@@ -202,6 +202,20 @@ internal sealed class CompiledDelegateChain<T>
         // Replay chain — straight-line delegate calls, no traversal.
         // Iterate only over the live range [0, _count).
         bool timing = BackwardTiming.Enabled;
+
+        // OOM fix: free each forward activation's GPU buffer on its LAST use — right after its step's backward; in
+        // reverse-topological order a step's output is fully consumed once its step runs (every consumer was an
+        // earlier step). Previously all forward activations stayed GPU-pinned for the whole backward, so the working
+        // set pegged at the card memory limit → OOM at scale (a tiny d256/L2 model OOM'd a 12 GB card past ~200K
+        // tokens). Skip the loss + sources (leaf params). Gated to the GPU engine; materialize-then-free is safe.
+        var gpuEngine = engine as AiDotNet.Tensors.Engines.DirectGpuTensorEngine;
+        HashSet<Tensor<T>>? freeSkip = null;
+        if (gpuEngine is not null)
+        {
+            freeSkip = new HashSet<Tensor<T>>(ReferenceEqualityComparer<Tensor<T>>.Instance) { loss };
+            if (sources is not null) foreach (var s in sources) freeSkip.Add(s);
+        }
+
         for (int i = 0; i < _count; i++)
         {
             ref var step = ref _steps[i];
@@ -216,6 +230,9 @@ internal sealed class CompiledDelegateChain<T>
                 long ticks = Stopwatch.GetTimestamp() - start;
                 BackwardTiming.Record(step.Backward.Method.Name, ticks);
             }
+
+            if (gpuEngine is not null && !freeSkip!.Contains(step.Output))
+                gpuEngine.InvalidateGpuCacheForTensor(step.Output);
         }
 
         if (sources is not null)

--- a/src/AiDotNet.Tensors/Engines/Autodiff/OptimizedBackwardPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/OptimizedBackwardPlan.cs
@@ -110,12 +110,14 @@ internal sealed class OptimizedBackwardPlan<T>
         // OOM fix: free each forward activation's GPU buffer as soon as it is DEAD — right after its entry's backward,
         // in reverse-topological order its output is fully consumed (every consumer was processed earlier). Previously
         // all forward activations stayed GPU-pinned for the whole backward, pegging the card at its memory limit →
-        // OOM at scale. Skip sources/retained tensors. (Gated to GPU engine; materialize-then-free is correctness-safe.)
+        // OOM at scale. Skip the loss + sources/retained tensors: the loss IS an entry.Output (the loss op's
+        // output), and the caller reads its value after backward, so it must never be freed mid-walk — same
+        // contract as CompiledDelegateChain.Execute. (Gated to GPU engine; materialize-then-free is correctness-safe.)
         var gpuEngine = _engine as AiDotNet.Tensors.Engines.DirectGpuTensorEngine;
         HashSet<Tensor<T>>? freeSkip = null;
-        if (gpuEngine is not null && (_sources is not null || _retainGrad is not null))
+        if (gpuEngine is not null)
         {
-            freeSkip = new HashSet<Tensor<T>>(ReferenceEqualityComparer<Tensor<T>>.Instance);
+            freeSkip = new HashSet<Tensor<T>>(ReferenceEqualityComparer<Tensor<T>>.Instance) { _loss };
             if (_sources is not null) foreach (var s in _sources) freeSkip.Add(s);
             if (_retainGrad is not null) foreach (var r in _retainGrad) freeSkip.Add(r);
         }

--- a/src/AiDotNet.Tensors/Engines/Autodiff/OptimizedBackwardPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/OptimizedBackwardPlan.cs
@@ -107,6 +107,24 @@ internal sealed class OptimizedBackwardPlan<T>
         _inputsBuf2 = BackwardInputBuffers<T>.Get2();
         _inputsBuf3 = BackwardInputBuffers<T>.Get3();
 
+        // OOM fix: free each forward activation's GPU buffer as soon as it is DEAD — right after its entry's backward,
+        // in reverse-topological order its output is fully consumed (every consumer was processed earlier). Previously
+        // all forward activations stayed GPU-pinned for the whole backward, pegging the card at its memory limit →
+        // OOM at scale. Skip sources/retained tensors. (Gated to GPU engine; materialize-then-free is correctness-safe.)
+        var gpuEngine = _engine as AiDotNet.Tensors.Engines.DirectGpuTensorEngine;
+        HashSet<Tensor<T>>? freeSkip = null;
+        if (gpuEngine is not null && (_sources is not null || _retainGrad is not null))
+        {
+            freeSkip = new HashSet<Tensor<T>>(ReferenceEqualityComparer<Tensor<T>>.Instance);
+            if (_sources is not null) foreach (var s in _sources) freeSkip.Add(s);
+            if (_retainGrad is not null) foreach (var r in _retainGrad) freeSkip.Add(r);
+        }
+        void FreeDeadActivation(Tensor<T> t)
+        {
+            if (gpuEngine is not null && (freeSkip is null || !freeSkip.Contains(t)))
+                gpuEngine.InvalidateGpuCacheForTensor(t);
+        }
+
         try
         {
             foreach (int i in _reachableIndices)
@@ -120,7 +138,10 @@ internal sealed class OptimizedBackwardPlan<T>
 
                 // Try optimized path for MatMul operations
                 if (TryOptimizedMatMulBackward(ref entry, gradOutput, cse, grads))
+                {
+                    FreeDeadActivation(entry.Output);
                     continue;
+                }
 
                 // Default path: use the original backward function.
                 // Phase A (#338) timing wrapper records per-op ticks when
@@ -137,6 +158,8 @@ internal sealed class OptimizedBackwardPlan<T>
                     entry.SavedState ?? Array.Empty<object>(), _engine, grads);
                 if (BackwardTiming.Enabled)
                     BackwardTiming.Record(entry.Backward.Method.Name, System.Diagnostics.Stopwatch.GetTimestamp() - _bwdStart);
+
+                FreeDeadActivation(entry.Output);
             }
         }
         finally

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -969,7 +969,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
             return pooled;
         }
 
-        CuBlasNative.CheckCudaResult(CuBlasNative.cuMemAlloc(out IntPtr devicePtr, byteSize), "cuMemAlloc");
+        IntPtr devicePtr = AllocDeviceMemoryWithRetry(byteSize);
 
         try
         {
@@ -990,6 +990,44 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         }
 
         return new CudaGpuBuffer(_cudaContext, devicePtr, size, _bufferPool.Return);
+    }
+
+    /// <summary>
+    /// Allocates device memory with an OOM-recovery retry. If the driver reports
+    /// out-of-memory, drain the buffer pool — a real <c>cuMemFree</c> of every
+    /// retained-for-reuse buffer — and retry the allocation once. The pool holds
+    /// bounded-but-real device memory (up to <c>_maxPerSize</c> buffers per
+    /// power-of-two bucket); under genuine pressure reclaiming it lets the
+    /// allocation through. This is the fix for the cross-step working-set growth
+    /// that OOM'd a 12 GB card on a tiny d256/L2 cortex past ~200K tokens
+    /// (200K trained, 250K OOM'd at the same per-step cost → accumulation, not a
+    /// single-step peak). If it still OOMs after draining, report the actual
+    /// free/total device memory (cuMemGetInfo) in the exception so the residual
+    /// consumer is visible rather than a bare "Out of memory".
+    /// </summary>
+    private IntPtr AllocDeviceMemoryWithRetry(ulong byteSize)
+    {
+        var result = CuBlasNative.cuMemAlloc(out IntPtr devicePtr, byteSize);
+        if (result == CudaResult.OutOfMemory)
+        {
+            int drained = _bufferPool.DrainAll();
+            result = CuBlasNative.cuMemAlloc(out devicePtr, byteSize);
+            if (result != CudaResult.Success)
+            {
+                ulong free = 0, total = 0;
+                try { CudaNativeBindings.cuMemGetInfo(out free, out total); }
+                catch { /* diagnostic only — never mask the real failure */ }
+                throw new InvalidOperationException(
+                    $"cuMemAlloc failed: {CuBlasNative.GetCudaErrorString(result)} " +
+                    $"(requested {byteSize} bytes; drained {drained} pooled buffers; " +
+                    $"device free={free} total={total} bytes)");
+            }
+        }
+        else
+        {
+            CuBlasNative.CheckCudaResult(result, "cuMemAlloc");
+        }
+        return devicePtr;
     }
 
     public IGpuBuffer AllocateBuffer(int size)
@@ -1013,7 +1051,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         }
 
         ulong byteSize = (ulong)size * sizeof(float);
-        CuBlasNative.CheckCudaResult(CuBlasNative.cuMemAlloc(out IntPtr devicePtr, byteSize), "cuMemAlloc");
+        IntPtr devicePtr = AllocDeviceMemoryWithRetry(byteSize);
         CuBlasNative.CheckCudaResult(CuBlasNative.cuMemsetD32(devicePtr, 0, (ulong)size), "cuMemsetD32");
         return new CudaGpuBuffer(_cudaContext, devicePtr, size, _bufferPool.Return);
     }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -76,6 +76,21 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
     private IntPtr _audioModule;
     private IntPtr _linalgModule;
     private bool _disposed;
+
+    // Process-exit guard: at process/AppDomain teardown the CUDA driver may already be unloaded, so calling ANY
+    // native CUDA API from a finalizer (CudaGpuBuffer.Release, CudaBackend.Dispose) FATAL-crashes the process — it
+    // is NOT a catchable .NET exception. Skip native cleanup when exiting; the OS reclaims GPU memory on process death.
+    internal static volatile bool ProcessExiting;
+    static CudaBackend()
+    {
+        try
+        {
+            AppDomain.CurrentDomain.ProcessExit += (_, __) => ProcessExiting = true;
+            AppDomain.CurrentDomain.DomainUnload += (_, __) => ProcessExiting = true;
+        }
+        catch { }
+    }
+
     private const int MaxPooledBufferElements = 16_777_216;
     private const int MaxPooledBuffersPerSize = 4;
     private readonly GpuBufferPool<CudaGpuBuffer> _bufferPool =
@@ -11366,8 +11381,13 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         IntPtr pI = input.Handle, pO = output.Handle;
         void** args = stackalloc void*[4];
         args[0] = &pI; args[1] = &pO; args[2] = &rows; args[3] = &cols;
-        CudaNativeBindings.cuLaunchKernel(kernel, grid, 1, 1, (uint)blockSize, 1, 1,
-            (uint)sharedMem, IntPtr.Zero, (IntPtr)args, IntPtr.Zero);
+        // Was an UNCHECKED launch on the DEFAULT stream (IntPtr.Zero) while every other op uses _stream — a fault
+        // here went unsurfaced and could read buffers out of order vs the rest of the pipeline. Check the result and
+        // use _stream for ordering.
+        CuBlasNative.CheckCudaResult(
+            CudaNativeBindings.cuLaunchKernel(kernel, grid, 1, 1, (uint)blockSize, 1, 1,
+                (uint)sharedMem, _stream, (IntPtr)args, IntPtr.Zero),
+            "cuLaunchKernel(softmax_rows)");
     }
 
     // ─── HRR binding primitives (issue #248) ────────────────────────
@@ -12485,6 +12505,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
             return;
 
         _disposed = true;
+        if (ProcessExiting) return;   // driver torn down at process exit — skip native+pool cleanup (OS reclaims)
         _pinnedPool.Dispose();
         _bufferPool.Dispose();
 
@@ -13443,7 +13464,10 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
 
     ~CudaBackend()
     {
-        Dispose();
+        // A finalizer must NEVER throw — Dispose() touches managed pools that may already be finalized during GC
+        // (ObjectDisposedException). Swallow so an undisposed backend (e.g. one created during backend auto-detection)
+        // tears down cleanly.
+        try { Dispose(); } catch { }
     }
 
     internal sealed class CudaGpuBuffer : IGpuBuffer, IPoolableGpuBuffer
@@ -13481,8 +13505,8 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
 
             try
             {
-                if (_context != IntPtr.Zero)
-                {
+                if (_context != IntPtr.Zero && !ProcessExiting)   // at process exit the CUDA driver is gone — any
+                {                                                 // native CUDA call FATAL-crashes (uncatchable); skip it
                     CuBlasNative.cuCtxPushCurrent(_context);
                     CuBlasNative.cuMemFree(_devicePtr);
                     CuBlasNative.cuCtxPopCurrent(out _);
@@ -13550,8 +13574,8 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
 
             try
             {
-                if (_context != IntPtr.Zero)
-                {
+                if (_context != IntPtr.Zero && !ProcessExiting)   // at process exit the CUDA driver is gone — any
+                {                                                 // native CUDA call FATAL-crashes (uncatchable); skip it
                     CuBlasNative.cuCtxPushCurrent(_context);
                     CuBlasNative.cuMemFree(_devicePtr);
                     CuBlasNative.cuCtxPopCurrent(out _);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaNativeBindings.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaNativeBindings.cs
@@ -306,6 +306,10 @@ internal static class CudaNativeBindings
     [DllImport(CudaLibrary, EntryPoint = "cuMemAlloc_v2")]
     public static extern CudaResult cuMemAlloc(out IntPtr dptr, ulong bytesize);
 
+    /// <summary>Returns free and total device memory in bytes (diagnostic).</summary>
+    [DllImport(CudaLibrary, EntryPoint = "cuMemGetInfo_v2")]
+    public static extern CudaResult cuMemGetInfo(out ulong free, out ulong total);
+
     /// <summary>Frees a device buffer allocated via <see cref="cuMemAlloc"/>.</summary>
     [DllImport(CudaLibrary, EntryPoint = "cuMemFree_v2")]
     public static extern CudaResult cuMemFree(IntPtr dptr);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/GpuBufferPool.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/GpuBufferPool.cs
@@ -105,6 +105,34 @@ internal sealed class GpuBufferPool<TBuffer> : IDisposable where TBuffer : class
         bucket.Buffers.Add(buffer);
     }
 
+    /// <summary>
+    /// Releases every pooled buffer back to the driver (a real free via
+    /// <see cref="IPoolableGpuBuffer.Release"/>, NOT a retain) while leaving the
+    /// pool usable for subsequent rents. Called under device-memory pressure —
+    /// when an allocation OOMs — to reclaim the bounded-but-real device memory
+    /// the pool holds for reuse before the caller gives up. Returns the number
+    /// of buffers released.
+    /// </summary>
+    public int DrainAll()
+    {
+        if (Volatile.Read(ref _disposed) != 0)
+        {
+            return 0;
+        }
+
+        int released = 0;
+        foreach (var bucket in _buckets.Values)
+        {
+            while (bucket.Buffers.TryTake(out var buffer))
+            {
+                Interlocked.Decrement(ref bucket.Count);
+                buffer.Release();
+                released++;
+            }
+        }
+        return released;
+    }
+
     public void Dispose()
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0)

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -1179,8 +1179,22 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             if (entries[i].Value.Timestamp <= threshold)
             {
+                // #226: an entry whose key still has a pending deferred download cannot
+                // simply have its buffer dropped — a later CPU read of that array would see
+                // garbage / hit a freed buffer. The original code SKIPPED such entries, but
+                // during pure-GPU training essentially every activation is registered as
+                // pending-deferred and never read on the CPU, so skipping made the cache
+                // un-evictable: it blew past both the count cap AND the 75%-VRAM byte cap and
+                // OOM'd the card (a tiny d256/L2 cortex pegged 12 GB past ~200K tokens — the
+                // long-hunted training OOM). Fix: MATERIALIZE the pending download now (copies
+                // the buffer into its CPU array while the buffer is still alive — the exact
+                // contract InvalidateActivationCacheEntry already relies on), THEN free the
+                // buffer. Correctness preserved; memory actually reclaimed so the cap holds.
                 if (Helpers.DeferredArrayMaterializer.IsPending(entries[i].Key))
-                    continue;
+                {
+                    try { Helpers.DeferredArrayMaterializer.TryMaterialize(entries[i].Key); }
+                    catch { Helpers.DeferredArrayMaterializer.Remove(entries[i].Key); }
+                }
 
                 if (_activationCache.TryRemove(entries[i].Key, out var entry))
                 {

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -8729,7 +8729,18 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             using var inputBuffer = GetOrAllocateBuffer(backend, input.GetDataArray());
             using var gammaBuffer = GetOrCacheWeightBuffer(backend, gamma.GetDataArray(), PersistentTensorRole.Weights);
             using var saveMeanBuffer = GetOrAllocateBuffer(backend, mean.GetDataArray());
-            using var saveVarBuffer = GetOrAllocateBuffer(backend, variance.GetDataArray());
+            // The layernorm_backward + layernorm_grad_params kernels use their "saveInvVar" input DIRECTLY as
+            // inverse-std 1/sqrt(var+eps). But during training the FORWARD runs the managed base path
+            // (IEngine.LayerNorm bails to base while a tape is active), and base's `variance` out-param is TRUE
+            // variance — so passing it raw made the kernels read variance AS invVar, yielding ~zero/garbage
+            // gradInput AND gradGamma. LayerNorm is in every transformer layer, so that zeroed the backward
+            // signal at every layer → GPU cortex training never learned (flat at ln(V), both CUDA and OpenCL),
+            // while the forward + matmul/softmax/embedding backward were all correct (see Phase_GPU_Grad_Check).
+            // Convert variance → invVar here so the kernels get the inverse-std they actually consume.
+            var varF = DirectGpuEngine.ToFloatArray(variance.GetDataArray());
+            var invVarF = new float[varF.Length];
+            for (int i = 0; i < varF.Length; i++) invVarF[i] = 1f / MathF.Sqrt(varF[i] + (float)epsilon);
+            using var saveVarBuffer = GetOrAllocateBuffer(backend, DirectGpuEngine.FromFloatArray<T>(invVarF));
             using var gradInputBuffer = AllocateOutputBuffer(backend, input.Length);
             using var gradGammaBuffer = AllocateOutputBuffer(backend, normalizedSize);
             using var gradBetaBuffer = AllocateOutputBuffer(backend, normalizedSize);

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -2779,9 +2779,14 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 var gpuOut = gpuBackend.AllocateBuffer(input.Length);
                 try
                 {
-                    // GPU softmax kernel
+                    // GPU softmax kernel. batchSize = number of softmax ROWS = total / axisSize (NOT input.Length).
+                    // Passing input.Length made the kernel index input[row*axisSize + f] for row up to input.Length →
+                    // up to input.Length*axisSize accesses on an input.Length buffer = OOB illegal address
+                    // (CUDA 700 / OpenCL -5). This was THE bug blocking all GPU training.
                     int axisSize = input.Shape._dims[axis < 0 ? input.Rank + axis : axis];
-                    gpuBackend.Softmax(gpuIn, gpuOut, input.Length, axisSize);
+                    if (axisSize <= 0 || input.Length % axisSize != 0)
+                        throw new InvalidOperationException($"softmax axisSize={axisSize} does not divide length={input.Length}");
+                    gpuBackend.Softmax(gpuIn, gpuOut, input.Length / axisSize, axisSize);
                     DownloadIntoTensor(gpuBackend, gpuOut, floatDest);
                 }
                 finally

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/ActivationCacheEvictionLifetimeTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/ActivationCacheEvictionLifetimeTests.cs
@@ -18,12 +18,16 @@ namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
 /// freed OpenCL buffer, producing <c>CL_INVALID_MEM_OBJECT</c> (OpenCL error -38)
 /// one epoch into Transformer training on AMD <c>gfx1012</c>.
 ///
-/// The fix replaces the old containsKey eviction guard with the unified
-/// <see cref="Helpers.DeferredArrayMaterializer.IsPending(object)"/> check and
-/// makes the materializer registry the single source of truth for pending
-/// downloads. These tests reach through reflection into the engine's private
-/// eviction method to assert the new invariant on any CI host — without
-/// requiring a real OpenCL runtime.
+/// The eviction guard is the unified
+/// <see cref="Helpers.DeferredArrayMaterializer.IsPending(object)"/> check, with the
+/// materializer registry as the single source of truth for pending downloads. A pending
+/// entry in the eviction window is NOT skipped — during pure-GPU training essentially every
+/// activation is pending-deferred and never read on the CPU, so skipping made the cache
+/// un-evictable and OOM'd the card (the long-hunted training OOM). Instead its deferred
+/// download is MATERIALIZED (the buffer is copied into its CPU array while still alive) and
+/// only THEN is the buffer freed — correctness preserved, memory actually reclaimed. These
+/// tests reach through reflection into the engine's private eviction method to assert the
+/// invariant on any CI host — without requiring a real OpenCL runtime.
 /// </summary>
 public class ActivationCacheEvictionLifetimeTests
 {
@@ -58,12 +62,12 @@ public class ActivationCacheEvictionLifetimeTests
     }
 
     [Fact]
-    public void EvictOldest_SkipsEntriesWithPendingMaterializer()
+    public void EvictOldest_MaterializesPendingEntryBeforeFreeing()
     {
         // The fix: EvictOldestActivationsUnsafe must consult the global
         // DeferredArrayMaterializer registry. This test reaches past CacheActivation
         // and directly populates _activationCache so the assertion focuses purely
-        // on the eviction predicate's skip behaviour.
+        // on the eviction predicate's pending-entry handling.
         using var engine = new DirectGpuTensorEngine();
 
         var engineType = typeof(DirectGpuTensorEngine);
@@ -83,11 +87,15 @@ public class ActivationCacheEvictionLifetimeTests
         object activationCache = activationCacheField.GetValue(engine)!;
         object cacheLock = activationCacheLockField.GetValue(engine)!;
 
-        // Four cache entries: the oldest is protected by a pending materializer;
-        // the other three are unprotected and eligible for eviction. EvictOldest
-        // removes entries.Length / 2 = 2 entries, scanning by timestamp from
-        // oldest up to the median. Without the skip-check, the protected entry
-        // would be disposed — that is the #226 regression this test pins.
+        // Four cache entries: the oldest carries a pending materializer; the other
+        // three are unprotected. EvictOldest removes entries.Length / 2 = 2 entries,
+        // scanning by timestamp from oldest up to the median — so the oldest (pending)
+        // entry is in the eviction window. The contract this pins: a pending entry is
+        // NOT skipped (skipping made the cache un-evictable in pure-GPU training and
+        // OOM'd the card, the bug this PR fixes); instead its deferred download is
+        // MATERIALIZED — copied into its CPU array while the buffer is still alive —
+        // and only THEN is the buffer freed. Correctness preserved (a later CPU read
+        // sees the materialized array, never a freed buffer); memory reclaimed.
         var protectedKey = new object();
         var victimKey1 = new object();
         var victimKey2 = new object();
@@ -118,11 +126,12 @@ public class ActivationCacheEvictionLifetimeTests
         Assert.True((bool)tryAdd.Invoke(activationCache, new[] { victimKey3, victimEntry3 })!);
         timestampField.SetValue(engine, 4L);
 
-        // Register a materializer for the protected key. IsPending(protectedKey) now true.
-        // DeferredArrayMaterializer is process-global state, so any test body that
-        // registers into it must guarantee cleanup even on assertion failure —
-        // hence the try/finally.
-        AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.Register(protectedKey, _ => { });
+        // Register a materializer for the protected key that records whether it ran.
+        // IsPending(protectedKey) is now true. DeferredArrayMaterializer is process-global
+        // state, so any test body that registers into it must guarantee cleanup even on
+        // assertion failure — hence the try/finally.
+        bool materializerInvoked = false;
+        AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.Register(protectedKey, _ => materializerInvoked = true);
         try
         {
             Assert.True(AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.IsPending(protectedKey));
@@ -134,13 +143,23 @@ public class ActivationCacheEvictionLifetimeTests
                     .Cast<object>().ToArray();
             }
 
+            // The pending download must have been MATERIALIZED during eviction (copied out
+            // while the buffer was still alive), and consumed from the registry — so the
+            // later buffer free is safe and the entry no longer reads as pending.
+            Assert.True(materializerInvoked,
+                "A pending entry in the eviction window must have its deferred download materialized " +
+                "(buffer copied to its CPU array) before the buffer is freed — not skipped.");
+            Assert.False(AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.IsPending(protectedKey),
+                "TryMaterialize must consume the pending registration so the entry isn't materialized twice.");
+
             // Dispose like the real code does (outside the cache lock).
             var disposeMethod = activationCacheEntryType.GetMethod("Dispose")!;
             foreach (var e in evictedList) disposeMethod.Invoke(e, null);
 
-            // The protected entry's buffer MUST NOT have been disposed; at least one of the
-            // unprotected victims should have been swept (eviction removes entries.Length/2).
-            Assert.Equal(0, protectedBuffer.DisposeCount);
+            // Memory is actually reclaimed: the (materialized) pending entry's buffer IS freed
+            // now — that's the OOM fix vs the old skip-forever behaviour — and so is at least
+            // one of the unprotected victims (eviction removes entries.Length/2 = 2).
+            Assert.Equal(1, protectedBuffer.DisposeCount);
             int totalVictimDisposes =
                 victimBuffer1.DisposeCount + victimBuffer2.DisposeCount + victimBuffer3.DisposeCount;
             Assert.True(totalVictimDisposes >= 1,


### PR DESCRIPTION
Three GPU correctness/stability fixes verified end-to-end training a small Transformer on WikiText-103 tokens (RTX 3080, 12 GB).

**1. Softmax batchSize OOB (GPU training crash).** `SoftmaxInto` passed `batchSize=input.Length` instead of `input.Length/axisSize`, so the kernel indexed off the end -> CUDA 700 / OpenCL -5. Fixed + divisibility guard. Cortex now trains on CUDA & OpenCL.

**2. Training-OOM root cause.** `EvictOldestActivationsUnsafe` SKIPPED any cache entry with a pending `DeferredArrayMaterializer` download (#226 guard). In pure-GPU training every activation is pending-but-never-read-on-CPU, so eviction skipped ~everything -> the cache blew past both its count cap AND its 75%-VRAM byte cap -> OOM (a tiny d256/L2 cortex pegged 12 GB past ~200K tokens). Fix: on eviction, MATERIALIZE the pending download first (copies the buffer to its CPU array while alive -- the InvalidateActivationCacheEntry contract), THEN free the buffer. Caps now enforceable. Verified: the 250K/3ep config that OOM'd in seconds now trains to completion at ~2.7-4.7 GB bounded. Supporting: `GpuBufferPool.DrainAll()`, `CudaBackend.AllocDeviceMemoryWithRetry()` (OOM-drain-retry + `cuMemGetInfo` diagnostic that surfaced the real cause), `CompiledDelegateChain` free-on-last-use of forward activations.

**3. CUDA finalizer safety.** Process-exit finalizers could fatally crash against a torn-down context; added a `ProcessExiting` guard + try/catch, and routed `SoftmaxRows` launch through `CheckCudaResult` on the backend stream.

?? Generated with [Claude Code](https://claude.com/claude-code)