### PR TITLE
perf: CPU inference kernel stack — 6xN asm panel kernel, OpenBLAS-on-our-pool, batch-parallel LSTM, fused LayerNorm, SDPA/softmax fixes (AiDotNet#1478)

### DIFF
--- a/docs/jit-gemm-issue-draft.md
+++ b/docs/jit-gemm-issue-draft.md
@@ -1,0 +1,115 @@
+# Custom JIT GEMM microkernel for AiDotNet.Tensors (managed Xbyak): match MKL/oneDNN GFLOP/s on our own thread pool
+
+## Summary / motivation
+
+On an AVX2-only rig (no AVX-512), PyTorch-CPU beats AiDotNet on the small-K/N
+transformer/FFN GEMM shapes. Root-caused via per-op profiling:
+
+- The managed `SimdGemm` kernel hits **70–113 GFLOP/s** on the small-K/N shapes
+  (QKV `[4096,64]×[64,192]`, FFN `[..,64]×[64,128]`, `[..,128]×[128,64]`) vs
+  **~170** on large square — RyuJIT can't schedule the 12-accumulator 6×16 tile
+  without spilling, and can't software-pipeline.
+- oneDNN's `dnnl_sgemm` (already shipped as `dnnl.dll`) hits **543 GFLOP/s** on
+  those exact shapes (JIT'd, shape-specialized brgemm) — **but regresses
+  end-to-end** (6/16 → 3/16 shapes vs PyTorch) because it brings its **own
+  OpenMP thread pool that oversubscribes** AiDotNet's `PersistentParallelExecutor`
+  (CNN bs128 +104%; confirmed: 16-thread 10.5 ms → 1-thread 5.9 ms).
+
+**Conclusion:** the GFLOPS are achievable on this rig, but a bolted-on native
+library can't deliver them end-to-end. We need **our own JIT'd GEMM microkernel**
+driven by AiDotNet's existing single thread pool.
+
+## Proof-of-concept results (validated, this rig, AVX2)
+
+| Milestone | Result |
+|---|---|
+| Emit raw AVX2 machine code in C#, run via `delegate* unmanaged`, correct | ✅ (maxErr ~1e-6) |
+| Hand-emitted 6×16 compute-bound microkernel vs RyuJIT, single-core | **114 vs 88 GFLOP/s (1.3×)** |
+| Same kernel fanned out across our own pool (1→16 threads) | **517 GFLOP/s @16t** (matches oneDNN's 543, **no oversubscription**) |
+| Naive production driver on real small-K shapes | 28–42 GFLOP/s — **pack/scatter-bound**, not kernel-bound |
+
+PoC lives at `C:\Users\yolan\asmjit` (encoder + 6×16 kernel + scaling + driver).
+
+## Mechanism (confirmed working)
+
+- `VirtualAlloc(PAGE_READWRITE)` → write code bytes → `VirtualProtect(PAGE_EXECUTE_READ)` (W^X-clean).
+- Call via `delegate* unmanaged[Cdecl]<float*,float*,float*,long,void>`.
+- Minimal AVX2 VEX encoder (2-/3-byte VEX): `vxorps`, `vmovups`, `vbroadcastss`,
+  `vfmadd231ps`, `vmovups` store, `add`/`dec`/`jnz`, `vzeroupper`, `ret`.
+- **Gotcha proven in testing:** disp8/imm8 sign-extension — any offset >127 must
+  use disp32/imm32 (a `sub rsp,160` silently became `add rsp,96` → AV). The
+  verification harness must catch this class of bug.
+
+## Work items (Phase 2 → production)
+
+### 2a. ldc-aware direct-write kernel
+Pass row-stride (`ldc`) so the kernel stores straight into `C[M,N]` — eliminate
+the scalar scatter that dominates small-K in the naive driver. (5th arg on the
+Win64 stack; variable-stride store addressing.)
+
+### 2b. Packing strategy — MEASURED: small-K needs an unpacked kernel
+Driver K-sweep on `[4092,*]×[*,192]` (16t, pack+compute): K=64 → 47, K=256 → 139,
+K=512 → 214 GFLOP/s. Even K=512 (214) trails the pre-packed scaling test (527),
+so **per-call A-packing is itself a dominant cost** at these shapes. The managed
+`DirectKernel6x16` beats the packed JIT driver on small-K (70–113 vs 47)
+*because it's unpacked*. ⇒ Phase 2 needs **two JIT kernels dispatched by K**:
+- **unpacked stride-reading** (reads A via `lda`, B via `ldb`, writes C via `ldc`;
+  no pack, no scatter) for small-K (transformer/FFN/QKV) — the hot case.
+- **packed** (current 6×16) for large-K, where packing amortizes (527 GFLOP/s).
+Unpacked kernel challenge: 6 strided A-row broadcasts/k under tight GP-register
+budget (hoist 6 row pointers or use index-register addressing).
+
+### 2b-2. Per-call prologue amortization (macro-kernel)
+The 10× XMM6–15 save/restore runs **per tile**. Emit a **macro-kernel** that
+loops all N/16 col-blocks (and ideally the M row-blocks) in one call so the
+prologue is paid once per row-panel, not once per 6×16 tile (~12× fewer
+prologues on the QKV shape). Confirmed relevant: small-K amortizes the prologue
+over only K iterations.
+
+### 2c. Masked edge kernels
+M%6 and N%16 tails — emit masked-load/store variants (`vmaskmovps`) or a
+generic M×N masked kernel. Required for arbitrary shapes (4096 not divisible by 6).
+
+### 2d. Software pipelining + prefetch
+Issue next-iteration B-loads ahead of the current FMAs; `prefetcht0` the next
+A/B panel. This is where per-core goes from 114 toward oneDNN's per-core rate.
+
+### 2e. Blocking (Mc/Nc/Kc) + driver
+Reuse the existing `SgemmTiled` blocking framework; call the JIT kernel as the
+microkernel. Keep B-panel in L1 (Kc tuned to L1d).
+
+### 2f. Thread-pool integration (THE thing that sank oneDNN)
+Drive parallel tiles via AiDotNet's `PersistentParallelExecutor` — one pool, no
+oversubscription. This is the architectural reason to own the kernel.
+
+### 2g. Shape→kernel JIT cache
+JIT once per (M-tail, N-tail, K, ISA) signature; cache the fn-ptr. Weights have
+fixed shapes, so inference JITs once and reuses forever. Bound the cache.
+
+### 3. Breadth (later)
+- **AVX-512** encoder (EVEX) — 16-wide, where present (this rig lacks it; most servers have it).
+- **ARM64 NEON/SVE** encoder — Apple/Graviton.
+- **Epilogue fusion** — bias + activation + residual folded into the store phase.
+  This is the thing `dnnl_sgemm` *can't* do (pure GEMM), attacking the GEMM AND
+  the allocation problem in one pass.
+
+## Cross-cutting requirements
+
+- **Verification harness:** disassemble emitted bytes (capstone/ref) + diff vs a
+  scalar reference for every JIT'd shape; fuzz offsets to catch disp/imm overflow.
+- **W^X / cross-platform exec memory:** Windows `VirtualAlloc`/`VirtualProtect`;
+  Linux `mmap`/`mprotect`; macOS `MAP_JIT` + `pthread_jit_write_protect_np`.
+- **Fallback:** keep the managed `SimdGemm` kernel as the portable path
+  (non-x64, or if exec-memory allocation is denied by policy).
+- **Supply-chain independence:** this removes the `dnnl.dll`/MKL dependency for
+  the hot GEMM path entirely.
+
+## Open questions (flagged: plan may not cover everything)
+
+- Is the goal to fully replace `SimdGemm`, or only intercept the small-K/N shapes
+  where it loses (keep managed for large square where it's already ~competitive)?
+- Threadpool ownership: does the JIT kernel call `PersistentParallelExecutor`, or
+  does the existing `SgemmTiled` driver call the JIT microkernel per tile?
+- AOT/trimming/`delegate* unmanaged` interplay; antivirus/EDR reaction to RWX→RX
+  pages in a managed process (real-world deployment concern).
+- Numerical reproducibility vs the managed/native paths (reduction order).

--- a/docs/jit-gemm-poc/JitGemmPoc.cs.txt
+++ b/docs/jit-gemm-poc/JitGemmPoc.cs.txt
@@ -1,0 +1,316 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+
+// Phase 1: a COMPUTE-BOUND 6×16 register-blocked AVX2 microkernel emitted as raw
+// machine code — the regime where RyuJIT spills at 12-accumulator pressure and a
+// hand-emitter with explicit register allocation wins.
+//   C[6,16] = sum_k packedA[k,0..5] · packedB[k,0..15]
+// packedA [K,6] k-major (24 B/k), packedB [K,16] k-major (64 B/k), C [6,16] row-major.
+// Registers: ymm0..11 = 12 accumulators (6 rows × 2 cols), ymm12/13 = B halves,
+// ymm14 = A broadcast. Windows x64: XMM6..15 low-128 are non-volatile → save/restore.
+// Args (Win64): RCX=packedA, RDX=packedB, R8=C, R9=K.
+
+[DllImport("kernel32.dll", SetLastError = true)]
+static extern IntPtr VirtualAlloc(IntPtr a, UIntPtr s, uint t, uint p);
+[DllImport("kernel32.dll", SetLastError = true)]
+static extern bool VirtualProtect(IntPtr a, UIntPtr s, uint np, out uint op);
+const uint MEM_COMMIT = 0x1000, MEM_RESERVE = 0x2000, PAGE_RW = 0x04, PAGE_EXEC_R = 0x20;
+
+var code = new List<byte>();
+void Bytes(params byte[] bs) => code.AddRange(bs);
+
+// ---- general AVX2 VEX encoder (registers 0..15) ----
+// 3-byte VEX reg-reg (modrm mod=11): opcode ymmReg, ymmVvvv, ymmRm  (map mm, prefix pp, W)
+void Vrr(int mm, int pp, int w, byte op, int reg, int vvvv, int rm)
+{
+    byte b2 = (byte)(((reg < 8 ? 1 : 0) << 7) | (1 << 6) | ((rm < 8 ? 1 : 0) << 5) | mm);
+    byte b3 = (byte)((w << 7) | (((~vvvv) & 0xF) << 3) | (1 << 2) | pp);
+    Bytes(0xC4, b2, b3, op, (byte)(0xC0 | ((reg & 7) << 3) | (rm & 7)));
+}
+// 3-byte VEX reg-mem: opcode ymmReg, [baseGp + disp]   (vvvv unused = 1111)
+void EmitMem(int reg, int baseGp, int disp)
+{
+    int rm = baseGp & 7;
+    bool rsp = rm == 4; // rsp/r12 need SIB
+    int mod = disp == 0 ? 0 : (disp >= -128 && disp <= 127 ? 1 : 2); // 0=none,1=disp8,2=disp32
+    Bytes((byte)((mod << 6) | ((reg & 7) << 3) | rm));
+    if (rsp) Bytes(0x24); // SIB: base=rsp, no index, scale 1
+    if (mod == 1) Bytes((byte)(sbyte)disp);
+    else if (mod == 2) Bytes((byte)disp, (byte)(disp >> 8), (byte)(disp >> 16), (byte)(disp >> 24));
+}
+void Vrm(int mm, int pp, int w, byte op, int reg, int baseGp, int disp)
+{
+    byte b2 = (byte)(((reg < 8 ? 1 : 0) << 7) | (1 << 6) | ((baseGp < 8 ? 1 : 0) << 5) | mm);
+    byte b3 = (byte)((w << 7) | (0xF << 3) | (1 << 2) | pp);
+    Bytes(0xC4, b2, b3, op);
+    EmitMem(reg, baseGp, disp);
+}
+// 128-bit vmovups variants for xmm save/restore (L=0)
+void Vrm128(byte op, int reg, int baseGp, int disp) // op 0x10=load,0x11=store
+{
+    byte b2 = (byte)(((reg < 8 ? 1 : 0) << 7) | (1 << 6) | ((baseGp < 8 ? 1 : 0) << 5) | 0x01); // map 0F
+    byte b3 = (byte)((0 << 7) | (0xF << 3) | (0 << 2) | 0); // W0,vvvv=1111,L=0,pp=00
+    Bytes(0xC4, b2, b3, op);
+    EmitMem(reg, baseGp, disp);
+}
+void VXor(int d) => Vrr(1, 0, 0, 0x57, d, d, d);                 // vxorps ymmd,ymmd,ymmd (zero)
+void VLoad(int d, int baseGp, int disp) => Vrm(1, 0, 0, 0x10, d, baseGp, disp);   // vmovups ymmd,[base+disp]
+void VStore(int s, int baseGp, int disp) => Vrm(1, 0, 0, 0x11, s, baseGp, disp);  // vmovups [base+disp],ymms
+void VBcast(int d, int baseGp, int disp) => Vrm(2, 1, 0, 0x18, d, baseGp, disp);  // vbroadcastss ymmd,[base+disp] (66.0F38.W0)
+void VFma(int acc, int s1, int s2) => Vrr(2, 1, 0, 0xB8, acc, s1, s2);            // vfmadd231ps acc += s1*s2 (66.0F38.W0)
+void AddR(int gp, byte imm) => Bytes((byte)(gp < 8 ? 0x48 : 0x49), 0x83, (byte)(0xC0 | (gp & 7)), imm); // add r64,imm8
+void SubRsp(int imm) => Bytes(0x48, 0x81, 0xEC, (byte)imm, (byte)(imm >> 8), (byte)(imm >> 16), (byte)(imm >> 24));
+void AddRsp(int imm) => Bytes(0x48, 0x81, 0xC4, (byte)imm, (byte)(imm >> 8), (byte)(imm >> 16), (byte)(imm >> 24));
+void MovR10Stack(byte disp) => Bytes(0x4C, 0x8B, 0x54, 0x24, disp); // mov r10, [rsp+disp8]
+void ShlR10(byte imm) => Bytes(0x49, 0xC1, 0xE2, imm);             // shl r10, imm8
+void AddR8R10() => Bytes(0x4D, 0x01, 0xD0);                        // add r8, r10
+const int RCX = 1, RDX = 2, RSP = 4, R8 = 8, R9 = 9;
+
+// ---- load ldc (5th arg, [rsp+0x28] at entry) into r10, ×4 for byte stride ----
+MovR10Stack(0x28);
+ShlR10(2);
+
+// ---- prologue: save xmm6..15 (non-volatile low-128) ----
+SubRsp(160);
+for (int x = 6; x <= 15; x++) Vrm128(0x11, x, RSP, (x - 6) * 16);  // movups [rsp+..], xmm_x
+
+// ---- zero 12 accumulators ----
+for (int d = 0; d < 12; d++) VXor(d);
+
+// ---- K loop ----
+int loopStart = code.Count;
+VLoad(12, RDX, 0);    // B[k,0:8]
+VLoad(13, RDX, 32);   // B[k,8:16]
+for (int r = 0; r < 6; r++)
+{
+    VBcast(14, RCX, r * 4);        // A[k,r]
+    VFma(r * 2, 14, 12);           // acc(row r, cols0-7)  += A * B0
+    VFma(r * 2 + 1, 14, 13);       // acc(row r, cols8-15) += A * B1
+}
+AddR(RDX, 64);
+AddR(RCX, 24);
+Bytes((byte)(0x49), 0xFF, 0xC9);   // dec r9
+int afterDec = code.Count;
+Bytes(0x75, (byte)(sbyte)(loopStart - (afterDec + 2)));  // jnz loopStart
+
+// ---- store C[6,16] directly with row-stride ldc (r10 = ldc*4 bytes) ----
+for (int r = 0; r < 6; r++)
+{
+    VStore(r * 2, R8, 0);          // C[row, 0:8]
+    VStore(r * 2 + 1, R8, 32);     // C[row, 8:16]
+    if (r < 5) AddR8R10();         // advance C to next row
+}
+
+// ---- epilogue: restore xmm6..15, ret ----
+for (int x = 6; x <= 15; x++) Vrm128(0x10, x, RSP, (x - 6) * 16);
+AddRsp(160);
+Bytes(0xC5, 0xF8, 0x77);  // vzeroupper
+Bytes(0xC3);              // ret
+
+byte[] mc = code.ToArray();
+Console.WriteLine($"emitted {mc.Length} bytes (6x16 microkernel)");
+
+IntPtr mem = VirtualAlloc(IntPtr.Zero, (UIntPtr)mc.Length, MEM_COMMIT | MEM_RESERVE, PAGE_RW);
+Marshal.Copy(mc, 0, mem, mc.Length);
+VirtualProtect(mem, (UIntPtr)mc.Length, PAGE_EXEC_R, out _);
+
+unsafe
+{
+    var kernel = (delegate* unmanaged[Cdecl]<float*, float*, float*, long, long, void>)mem;
+    int K = 256; // packedB [256,16]=16KB fits L1 -> compute-bound
+    var pa = new float[K * 6]; var pb = new float[K * 16]; var C = new float[6 * 16];
+    var rnd = new Random(1);
+    for (int i = 0; i < pa.Length; i++) pa[i] = (float)(rnd.NextDouble() - 0.5);
+    for (int i = 0; i < pb.Length; i++) pb[i] = (float)(rnd.NextDouble() - 0.5);
+
+    fixed (float* xa = pa, xb = pb, xc = C) kernel(xa, xb, xc, K, 16);
+    double maxErr = 0;
+    for (int r = 0; r < 6; r++) for (int c = 0; c < 16; c++)
+    {
+        double acc = 0; for (int k = 0; k < K; k++) acc += (double)pa[k * 6 + r] * pb[k * 16 + c];
+        maxErr = Math.Max(maxErr, Math.Abs(acc - C[r * 16 + c]));
+    }
+    Console.WriteLine($"[correctness] JIT 6x16 vs scalar maxErr = {maxErr:E3}  ({(maxErr < 1e-2 ? "PASS" : "FAIL")})");
+
+    double Flop = 6.0 * 16.0 * K * 2.0;
+    fixed (float* xa = pa, xb = pb, xc = C)
+    {
+        for (int i = 0; i < 20000; i++) kernel(xa, xb, xc, K, 16);
+        int reps = 1_000_000; var sw = Stopwatch.StartNew();
+        for (int i = 0; i < reps; i++) kernel(xa, xb, xc, K, 16);
+        sw.Stop();
+        Console.WriteLine($"[JIT 6x16]      {Flop * reps / sw.Elapsed.TotalSeconds / 1e9:F1} GFLOP/s single-core");
+    }
+    fixed (float* xa = pa, xb = pb, xc = C)
+    {
+        for (int i = 0; i < 20000; i++) Managed6x16(xa, xb, xc, K);
+        int reps = 1_000_000; var sw = Stopwatch.StartNew();
+        for (int i = 0; i < reps; i++) Managed6x16(xa, xb, xc, K);
+        sw.Stop();
+        Console.WriteLine($"[managed 6x16]  {Flop * reps / sw.Elapsed.TotalSeconds / 1e9:F1} GFLOP/s single-core (RyuJIT)");
+    }
+
+    // ---- multi-core scaling on a SINGLE pool (the thing oneDNN couldn't do) ----
+    // Tiled GEMM C[M,N]=A·B over numRB×numCB independent 6×16 tiles, each computed
+    // by the JIT kernel. We fan out tiles across T worker threads (one pool, no
+    // second runtime) and measure GFLOP/s vs T. Packed operands live in native
+    // memory so pointers are stable across threads.
+    int M = 1536, N = 512;                  // 256 row-blocks × 32 col-blocks = 8192 tiles
+    int numRB = M / 6, numCB = N / 16;
+    int totalTiles = numRB * numCB;
+    nuint paBytes = (nuint)((long)numRB * K * 6 * sizeof(float));
+    nuint pbBytes = (nuint)((long)numCB * K * 16 * sizeof(float));
+    float* PA = (float*)NativeMemory.AlignedAlloc(paBytes, 32);
+    float* PB = (float*)NativeMemory.AlignedAlloc(pbBytes, 32);
+    var rnd2 = new Random(7);
+    for (long i = 0; i < (long)numRB * K * 6; i++) PA[i] = (float)(rnd2.NextDouble() - 0.5);
+    for (long i = 0; i < (long)numCB * K * 16; i++) PB[i] = (float)(rnd2.NextDouble() - 0.5);
+
+    nint memN = mem, paN = (nint)PA, pbN = (nint)PB;
+    int Kc = K, numCBc = numCB, repsPass = 200;
+    double passFlop = (double)M * N * K * 2.0;
+    double single = 0;
+    Console.WriteLine("--- multi-core scaling (JIT 6x16 tiles, one thread pool) ---");
+    foreach (int T in new[] { 1, 2, 4, 8, 16 })
+    {
+        // warm
+        RunTiled(T);
+        var sw = Stopwatch.StartNew();
+        RunTiled(T);
+        sw.Stop();
+        double g = passFlop * repsPass / sw.Elapsed.TotalSeconds / 1e9;
+        if (T == 1) single = g;
+        Console.WriteLine($"  threads={T,2}  {g,7:F0} GFLOP/s   scaling={g / single:F2}x");
+
+        void RunTiled(int threads)
+        {
+            var ths = new System.Threading.Thread[threads];
+            int per = (totalTiles + threads - 1) / threads;
+            for (int t = 0; t < threads; t++)
+            {
+                int lo = t * per, hi = Math.Min(lo + per, totalTiles);
+                ths[t] = new System.Threading.Thread(() =>
+                {
+                    unsafe
+                    {
+                        var kf = (delegate* unmanaged[Cdecl]<float*, float*, float*, long, long, void>)memN;
+                        float* pa2 = (float*)paN, pb2 = (float*)pbN;
+                        float* tile = stackalloc float[96];
+                        for (int rep = 0; rep < repsPass; rep++)
+                            for (int ti = lo; ti < hi; ti++)
+                            {
+                                int rb = ti / numCBc, cb = ti % numCBc;
+                                kf(pa2 + (long)rb * Kc * 6, pb2 + (long)cb * Kc * 16, tile, Kc, 16);
+                            }
+                    }
+                });
+            }
+            foreach (var th in ths) th.Start();
+            foreach (var th in ths) th.Join();
+        }
+    }
+    NativeMemory.AlignedFree(PA); NativeMemory.AlignedFree(PB);
+
+    // ---- Phase 2: real-shape driver (pack A + pre-packed B + parallel tiles) ----
+    // Measures the JIT GEMM on the actual transformer GEMM shapes vs the managed
+    // numbers we recorded earlier (QKV 91, FFN1 113, FFN2 66 GFLOP/s) and oneDNN
+    // (543/564/541). M rounded to a multiple of 6 for the PoC (edge kernels = Phase 2b).
+    Console.WriteLine("--- Phase 2 driver: transformer GEMM shapes, JIT on our pool ---");
+    DriveShape("QKV ", 4092, 192, 64);
+    DriveShape("FFN1", 4092, 128, 64);
+    DriveShape("FFN2", 4092, 64, 128);
+    DriveShape("K256", 4092, 192, 256);   // diagnostic: same driver, larger K — isolates small-K/per-call overhead
+    DriveShape("K512", 4092, 192, 512);
+
+    void DriveShape(string name, int Mm, int Nn, int Kk)
+    {
+        int nRB = Mm / 6, nCB = Nn / 16;
+        var A = new float[(long)Mm * Kk]; var B = new float[(long)Kk * Nn]; var C = new float[(long)Mm * Nn];
+        var r3 = new Random(11);
+        for (long i = 0; i < A.LongLength; i++) A[i] = (float)(r3.NextDouble() - 0.5);
+        for (long i = 0; i < B.LongLength; i++) B[i] = (float)(r3.NextDouble() - 0.5);
+        // pre-pack B (weights: packed once for inference)
+        float* pbk = (float*)NativeMemory.AlignedAlloc((nuint)((long)nCB * Kk * 16 * sizeof(float)), 32);
+        for (int cb = 0; cb < nCB; cb++)
+            for (int k = 0; k < Kk; k++)
+                for (int c = 0; c < 16; c++) pbk[(long)cb * Kk * 16 + k * 16 + c] = B[(long)k * Nn + cb * 16 + c];
+        float* pak = (float*)NativeMemory.AlignedAlloc((nuint)((long)nRB * Kk * 6 * sizeof(float)), 32);
+        nint memX = mem, pakN = (nint)pak, pbkN = (nint)pbk;
+        int Kx = Kk, nCBx = nCB, Nx = Nn;
+        var Carr = C;
+
+        void OnePass(int threads)
+        {
+            // pack A (per call — activations change) in parallel, then compute tiles.
+            var ths = new System.Threading.Thread[threads];
+            int perR = (nRB + threads - 1) / threads;
+            for (int t = 0; t < threads; t++)
+            {
+                int lo = t * perR, hi = Math.Min(lo + perR, nRB);
+                ths[t] = new System.Threading.Thread(() =>
+                {
+                    unsafe
+                    {
+                        var kf = (delegate* unmanaged[Cdecl]<float*, float*, float*, long, long, void>)memX;
+                        float* pa2 = (float*)pakN, pb2 = (float*)pbkN;
+                        fixed (float* aP = A, cP = Carr)
+                        {
+                            for (int rb = lo; rb < hi; rb++)
+                            {
+                                float* myPa = pa2 + (long)rb * Kx * 6;
+                                for (int k = 0; k < Kx; k++)
+                                    for (int r = 0; r < 6; r++) myPa[k * 6 + r] = aP[(long)(rb * 6 + r) * Kx + k];
+                                // direct write into C[M,N] at this row/col block, ldc=N — no scatter.
+                                for (int cb = 0; cb < nCBx; cb++)
+                                    kf(myPa, pb2 + (long)cb * Kx * 16,
+                                       cP + (long)(rb * 6) * Nx + cb * 16, Kx, Nx);
+                            }
+                        }
+                    }
+                });
+            }
+            foreach (var th in ths) th.Start();
+            foreach (var th in ths) th.Join();
+        }
+        // correctness (single pass) vs scalar on a sample
+        OnePass(16);
+        double err = 0; var rr = new Random(5);
+        for (int s = 0; s < 200; s++)
+        {
+            int i = rr.Next(Mm), j = rr.Next(Nn); double acc = 0;
+            for (int k = 0; k < Kk; k++) acc += (double)A[(long)i * Kk + k] * B[(long)k * Nn + j];
+            err = Math.Max(err, Math.Abs(acc - C[(long)i * Nn + j]));
+        }
+        for (int i = 0; i < 30; i++) OnePass(16);
+        int reps = 300; var sw = Stopwatch.StartNew();
+        for (int i = 0; i < reps; i++) OnePass(16);
+        sw.Stop();
+        double g = (double)Mm * Nn * Kk * 2.0 * reps / sw.Elapsed.TotalSeconds / 1e9;
+        Console.WriteLine($"  {name} [{Mm},{Kk}]x[{Kk},{Nn}]  {g,6:F0} GFLOP/s (16t, pack+compute)  maxErr={err:E2}");
+        NativeMemory.AlignedFree(pak); NativeMemory.AlignedFree(pbk);
+    }
+}
+
+static unsafe void Managed6x16(float* pa, float* pb, float* pc, long K)
+{
+    Vector256<float> c0 = default, c1 = default, c2 = default, c3 = default, c4 = default, c5 = default,
+                     c6 = default, c7 = default, c8 = default, c9 = default, c10 = default, c11 = default;
+    for (long k = 0; k < K; k++)
+    {
+        var b0 = Avx.LoadVector256(pb + k * 16);
+        var b1 = Avx.LoadVector256(pb + k * 16 + 8);
+        var a = Vector256.Create(pa[k * 6 + 0]); c0 = Fma.MultiplyAdd(a, b0, c0); c1 = Fma.MultiplyAdd(a, b1, c1);
+        a = Vector256.Create(pa[k * 6 + 1]); c2 = Fma.MultiplyAdd(a, b0, c2); c3 = Fma.MultiplyAdd(a, b1, c3);
+        a = Vector256.Create(pa[k * 6 + 2]); c4 = Fma.MultiplyAdd(a, b0, c4); c5 = Fma.MultiplyAdd(a, b1, c5);
+        a = Vector256.Create(pa[k * 6 + 3]); c6 = Fma.MultiplyAdd(a, b0, c6); c7 = Fma.MultiplyAdd(a, b1, c7);
+        a = Vector256.Create(pa[k * 6 + 4]); c8 = Fma.MultiplyAdd(a, b0, c8); c9 = Fma.MultiplyAdd(a, b1, c9);
+        a = Vector256.Create(pa[k * 6 + 5]); c10 = Fma.MultiplyAdd(a, b0, c10); c11 = Fma.MultiplyAdd(a, b1, c11);
+    }
+    Avx.Store(pc + 0, c0); Avx.Store(pc + 8, c1); Avx.Store(pc + 16, c2); Avx.Store(pc + 24, c3);
+    Avx.Store(pc + 32, c4); Avx.Store(pc + 40, c5); Avx.Store(pc + 48, c6); Avx.Store(pc + 56, c7);
+    Avx.Store(pc + 64, c8); Avx.Store(pc + 72, c9); Avx.Store(pc + 80, c10); Avx.Store(pc + 88, c11);
+}

--- a/docs/jit-gemm-poc/JitGemmPoc.csproj.txt
+++ b/docs/jit-gemm-poc/JitGemmPoc.csproj.txt
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Nullable>disable</Nullable>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+</Project>

--- a/docs/jit-gemm-poc/README.md
+++ b/docs/jit-gemm-poc/README.md
@@ -1,0 +1,13 @@
+# JIT GEMM microkernel PoC (Phase 0/1)
+
+Archived proof-of-concept for the custom AVX2 JIT GEMM kernel (see
+`../jit-gemm-issue-draft.md`). Files are `.txt`-suffixed so they are NOT built as
+part of the Tensors solution. To run: copy `JitGemmPoc.cs.txt` → `Program.cs` and
+`JitGemmPoc.csproj.txt` → `*.csproj` into a scratch dir and `dotnet run -c Release`.
+
+Validated results on AVX2 (no AVX-512):
+- emit+run+correct AVX2 machine code via `delegate* unmanaged` (maxErr ~1e-6)
+- 6x16 microkernel: 118 GFLOP/s single-core vs RyuJIT 90 (1.3x)
+- multi-core on one pool: 527 GFLOP/s @16t (matches oneDNN's 543, no oversubscription)
+- naive packed driver on small-K transformer shapes is pack/prologue-bound (47/30/32)
+  -> Phase 2 needs an unpacked stride-reading kernel for small-K.

--- a/docs/jit-gemm-poc/README.md
+++ b/docs/jit-gemm-poc/README.md
@@ -23,3 +23,19 @@ Correct (maxErr ~1e-6). 3-base-pointer trick for the 6 strided A rows
 (rows 0/2/4 in RCX/RBX/RSI + index RAX=lda*4). This is the small-K hot path.
 Next: wire into CpuEngine via PersistentParallelExecutor + edge kernels +
 shape->kernel JIT cache, then the 16-shape end-to-end benchmark.
+
+## Phase 2 integration (JitGemmAvx2 wired into dispatch) — end-to-end result
+
+JitGemmAvx2 (emit-once unpacked kernel + PPE-parallel driver w/ serial-small
+fallback + managed M%6/N%16 edges) wired into SimdGemm.Sgemm, FusedLinear,
+TensorMatMul2D (AIDOTNET_JIT_GEMM=1, default OFF). 16-shape bench, min-of-6:
+- MLP b8 -38%, b32/b128 ~-2-3%  (clean big GEMMs -> JIT wins)
+- CNN/LSTM ~neutral
+- transformer REGRESSES (b8 +30%, b1 +24%): the per-6x16-tile prologue (10 XMM
+  save/restore) is paid per tile; the transformer's many-small-tile GEMMs (b8
+  QKV = 504 tiles) pay it 504x while the managed kernel pays 0.
+- net 5/16 (== baseline). Off-by-default, no shipped regression.
+
+NEXT (the transformer win): macro-kernel — prologue once per row-panel, loop the
+N/16 col-blocks internally (amortizes the 10-XMM save/restore ~12x). Then the
+kernel's isolated 600-700 GFLOP/s should translate to the transformer end-to-end.

--- a/docs/jit-gemm-poc/README.md
+++ b/docs/jit-gemm-poc/README.md
@@ -61,3 +61,25 @@ transformer's time is the aggregate of many ops + dispatch, not GEMM throughput.
 - Transformer is NOT -> no GEMM kernel (ours at 699 or oneDNN at 543) flips it.
 Next lever for the transformer is whole-forward-pass fusion / dispatch reduction,
 not a faster GEMM. The JIT kernel stays an off-by-default MLP/GEMM-bound win.
+
+## FINAL: the wins came from the OP fixes, not the GEMM JIT (6/16 -> 8/16)
+
+End-to-end op profiling (the decisive step) showed the transformer's pure GEMMs
+are only ~9%; the costs were SDPA (scalar softmax), LayerNorm (serial), and the
+two-thread-pool contention. Fixing those OPS — not the GEMM — delivered the wins:
+
+| fix | effect |
+|---|---|
+| SIMD softmax (Exp8) in SDPA      | SDPA 3.15 -> 1.42 ms/call |
+| LayerNorm row-count parallel gate | 0.33 -> 0.13 ms/call (2.5x) |
+| SDPA -> PersistentParallelExecutor (one pool) | SDPA 1.42 -> 0.86 ms/call |
+| net (16-shape, min-of-6)         | **6/16 -> 8/16**; transformer now wins b1+b8(+b32) |
+
+The JIT GEMM (beats oneDNN isolated at 699, 376 GFLOP/s per-call) is NET-NEGATIVE
+end-to-end (8/16 -> 6/16): it wins large-M (transformer FFN/QKV M=4096) but loses
+medium/small-M (MLP M<=128, transformer b32), and the transformer isn't GEMM-bound
+so the isolated GFLOP/s don't translate. Kept as an off-by-default, M-gated
+(AIDOTNET_JIT_MIN_M=512) opt-in for genuinely GEMM-bound large-M workloads.
+
+Remaining losses (8/16, all op/shape-specific, not GEMM-GFLOPS): MLP (small-M
+GEMM vs MKL's small-GEMM JIT), LSTM/transformer large-batch (aggregate ops).

--- a/docs/jit-gemm-poc/README.md
+++ b/docs/jit-gemm-poc/README.md
@@ -11,3 +11,15 @@ Validated results on AVX2 (no AVX-512):
 - multi-core on one pool: 527 GFLOP/s @16t (matches oneDNN's 543, no oversubscription)
 - naive packed driver on small-K transformer shapes is pack/prologue-bound (47/30/32)
   -> Phase 2 needs an unpacked stride-reading kernel for small-K.
+
+## Phase 2 update: UNPACKED kernel beats oneDNN (UnpackedKernel.cs.txt)
+
+Stride-reading 6x16 (no pack, no scatter), measured correctly (threads spawned
+once, reps internal) on the transformer shapes, 16t, on our own pool:
+- QKV  [4092,64]x[64,192]  699 GFLOP/s  (oneDNN 543, managed 91)
+- FFN1 [4092,64]x[64,128]  684 GFLOP/s  (oneDNN 564, managed 113)
+- FFN2 [4092,128]x[128,64] 604 GFLOP/s  (oneDNN 541, managed 66)
+Correct (maxErr ~1e-6). 3-base-pointer trick for the 6 strided A rows
+(rows 0/2/4 in RCX/RBX/RSI + index RAX=lda*4). This is the small-K hot path.
+Next: wire into CpuEngine via PersistentParallelExecutor + edge kernels +
+shape->kernel JIT cache, then the 16-shape end-to-end benchmark.

--- a/docs/jit-gemm-poc/README.md
+++ b/docs/jit-gemm-poc/README.md
@@ -39,3 +39,25 @@ TensorMatMul2D (AIDOTNET_JIT_GEMM=1, default OFF). 16-shape bench, min-of-6:
 NEXT (the transformer win): macro-kernel — prologue once per row-panel, loop the
 N/16 col-blocks internally (amortizes the 10-XMM save/restore ~12x). Then the
 kernel's isolated 600-700 GFLOP/s should translate to the transformer end-to-end.
+
+## Macro-kernel experiment: REJECTED (made transformer worse)
+
+Tried a macro-kernel (one row-panel × all N/16 col-blocks per call) to amortize
+the per-tile prologue. Isolated 566 GFLOP/s (below the per-tile 699 — the per-cb
+register resets + serialized col-block loop cost more than the prologue saves).
+End-to-end it REGRESSED the transformer further (+41-51% vs per-tile's +5-30%).
+Reverted to the per-tile kernel.
+
+## KEY CONCLUSION: the transformer is NOT GEMM-throughput-bound end-to-end
+
+The JIT kernel is 600-700 GFLOP/s in ISOLATION (beats oneDNN) yet does not flip
+the transformer end-to-end (per-tile: net-neutral/mild-regress; macro: worse).
+Why: isolated GFLOPS (same GEMM 600x, B hot in cache, threads spawned once) does
+NOT equal end-to-end throughput (each GEMM run once, cold-ish B, interleaved with
+SDPA/LayerNorm/softmax/residuals that evict cache, + per-GEMM dispatch). The
+transformer's time is the aggregate of many ops + dispatch, not GEMM throughput.
+- MLP (3 big GEMMs, weights reused across the batch, little interleaving) IS
+  GEMM-bound -> JIT wins (b8 -38%).
+- Transformer is NOT -> no GEMM kernel (ours at 699 or oneDNN at 543) flips it.
+Next lever for the transformer is whole-forward-pass fusion / dispatch reduction,
+not a faster GEMM. The JIT kernel stays an off-by-default MLP/GEMM-bound win.

--- a/docs/jit-gemm-poc/UnpackedKernel.cs.txt
+++ b/docs/jit-gemm-poc/UnpackedKernel.cs.txt
@@ -1,0 +1,190 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+
+// Phase 2: UNPACKED stride-reading 6×16 AVX2 microkernel — no A-pack, no scatter.
+//   C[6,16] = sum_k A[row,k]·B[k,0..15], reading A via lda, B via ldb, C via ldc.
+// This is the small-K hot path (QKV/FFN): packing overhead is what sank the
+// packed driver (47 GFLOP/s) below the unpacked managed kernel (70-113).
+// 6 strided A rows addressed with a 3-base-pointer trick (rows 0/2/4 in
+// RCX/RBX/RSI) + index RAX=lda*4, so [base] and [base+RAX] cover all 6 rows.
+// Signature void mk(float* A, float* B, float* C, long K, long lda, long ldb, long ldc)
+// Win64: RCX=A RDX=B R8=C R9=K ; lda=[rsp+0x28] ldb=[rsp+0x30] ldc=[rsp+0x38].
+
+[DllImport("kernel32.dll", SetLastError = true)]
+static extern IntPtr VirtualAlloc(IntPtr a, UIntPtr s, uint t, uint p);
+[DllImport("kernel32.dll", SetLastError = true)]
+static extern bool VirtualProtect(IntPtr a, UIntPtr s, uint np, out uint op);
+const uint MEM_COMMIT = 0x1000, MEM_RESERVE = 0x2000, PAGE_RW = 0x04, PAGE_EXEC_R = 0x20;
+
+var code = new List<byte>();
+void Bytes(params byte[] bs) => code.AddRange(bs);
+
+// VEX reg-reg (mod=11): op ymmReg, ymmVvvv, ymmRm
+void Vrr(int mm, int pp, byte op, int reg, int vvvv, int rm) =>
+    Bytes(0xC4,
+        (byte)(((reg < 8 ? 1 : 0) << 7) | (1 << 6) | ((rm < 8 ? 1 : 0) << 5) | mm),
+        (byte)((((~vvvv) & 0xF) << 3) | (1 << 2) | pp),
+        op, (byte)(0xC0 | ((reg & 7) << 3) | (rm & 7)));
+// VEX reg-[base+disp]
+void Vrm(int mm, int pp, byte op, int reg, int b, int disp)
+{
+    Bytes(0xC4, (byte)(((reg < 8 ? 1 : 0) << 7) | (1 << 6) | ((b < 8 ? 1 : 0) << 5) | mm),
+          (byte)((0xF << 3) | (1 << 2) | pp), op);
+    int rm = b & 7; bool sib = rm == 4; int mod = disp == 0 ? 0 : (disp is >= -128 and <= 127 ? 1 : 2);
+    Bytes((byte)((mod << 6) | ((reg & 7) << 3) | rm));
+    if (sib) Bytes(0x24);
+    if (mod == 1) Bytes((byte)(sbyte)disp);
+    else if (mod == 2) Bytes((byte)disp, (byte)(disp >> 8), (byte)(disp >> 16), (byte)(disp >> 24));
+}
+// VEX reg-[base] (mod=00, base not rsp/rbp)
+void VrmBase(int mm, int pp, byte op, int reg, int b) =>
+    Bytes(0xC4, (byte)(((reg < 8 ? 1 : 0) << 7) | (1 << 6) | ((b < 8 ? 1 : 0) << 5) | mm),
+          (byte)((0xF << 3) | (1 << 2) | pp), op, (byte)(((reg & 7) << 3) | (b & 7)));
+// VEX reg-[base+index*1] (SIB)
+void VrmIdx(int mm, int pp, byte op, int reg, int b, int idx) =>
+    Bytes(0xC4,
+        (byte)(((reg < 8 ? 1 : 0) << 7) | ((idx < 8 ? 1 : 0) << 6) | ((b < 8 ? 1 : 0) << 5) | mm),
+        (byte)((0xF << 3) | (1 << 2) | pp), op,
+        (byte)(((reg & 7) << 3) | 4),            // rm=100 -> SIB
+        (byte)(((idx & 7) << 3) | (b & 7)));      // scale=0
+void VXor(int d) => Vrr(1, 0, 0x57, d, d, d);
+void VLoad(int d, int b, int disp) => Vrm(1, 0, 0x10, d, b, disp);
+void VStore(int s, int b, int disp) => Vrm(1, 0, 0x11, s, b, disp);
+void VBcastB(int d, int b) => VrmBase(2, 1, 0x18, d, b);
+void VBcastI(int d, int b, int idx) => VrmIdx(2, 1, 0x18, d, b, idx);
+void VFma(int acc, int s1, int s2) => Vrr(2, 1, 0xB8, acc, s1, s2);
+void Vmovups128St(int reg, int b, int disp) // movups [b+disp], xmm  (L=0)
+{
+    Bytes(0xC4, (byte)(((reg < 8 ? 1 : 0) << 7) | (1 << 6) | ((b < 8 ? 1 : 0) << 5) | 1),
+          (byte)((0xF << 3) | (0 << 2) | 0), 0x11);
+    int rm = b & 7; bool sib = rm == 4; int mod = disp == 0 ? 0 : 1;
+    Bytes((byte)((mod << 6) | ((reg & 7) << 3) | rm)); if (sib) Bytes(0x24); if (mod == 1) Bytes((byte)disp);
+}
+void Vmovups128Ld(int reg, int b, int disp)
+{
+    Bytes(0xC4, (byte)(((reg < 8 ? 1 : 0) << 7) | (1 << 6) | ((b < 8 ? 1 : 0) << 5) | 1),
+          (byte)((0xF << 3) | (0 << 2) | 0), 0x10);
+    int rm = b & 7; bool sib = rm == 4; int mod = disp == 0 ? 0 : 1;
+    Bytes((byte)((mod << 6) | ((reg & 7) << 3) | rm)); if (sib) Bytes(0x24); if (mod == 1) Bytes((byte)disp);
+}
+// GP helpers (reg ids: rax=0 rcx=1 rdx=2 rbx=3 rsp=4 rsi=6 r8=8 r9=9 r10=10 r11=11)
+void MovFromStack(int dst, byte disp) // mov dst, [rsp+disp8]
+    => Bytes((byte)(0x48 | (dst >= 8 ? 4 : 0)), 0x8B, (byte)(0x44 | ((dst & 7) << 3)), 0x24, disp);
+void Shl4(int r) => Bytes((byte)(0x48 | (r >= 8 ? 1 : 0)), 0xC1, (byte)(0xE0 | (r & 7)), 2); // shl r, 2
+void Lea(int dst, int b, int idx, int scale) // lea dst,[b+idx*scale]
+{
+    int sc = scale == 2 ? 1 : scale == 4 ? 2 : scale == 8 ? 3 : 0;
+    Bytes((byte)(0x48 | (dst >= 8 ? 4 : 0) | (idx >= 8 ? 2 : 0) | (b >= 8 ? 1 : 0)), 0x8D,
+          (byte)(((dst & 7) << 3) | 4), (byte)((sc << 6) | ((idx & 7) << 3) | (b & 7)));
+}
+void AddImm(int r, byte imm) => Bytes((byte)(0x48 | (r >= 8 ? 1 : 0)), 0x83, (byte)(0xC0 | (r & 7)), imm);
+void AddRegReg(int dst, int src) // add dst, src  (r/m=dst, reg=src)
+    => Bytes((byte)(0x48 | (src >= 8 ? 4 : 0) | (dst >= 8 ? 1 : 0)), 0x01, (byte)(0xC0 | ((src & 7) << 3) | (dst & 7)));
+void Push(int r) { if (r >= 8) Bytes(0x41); Bytes((byte)(0x50 | (r & 7))); }
+void Pop(int r) { if (r >= 8) Bytes(0x41); Bytes((byte)(0x58 | (r & 7))); }
+const int RAX = 0, RCX = 1, RDX = 2, RBX = 3, RSP = 4, RSI = 6, R8 = 8, R9 = 9, R10 = 10, R11 = 11;
+
+// ---- prologue: load strides (relative to ENTRY rsp, before push/sub) ----
+MovFromStack(RAX, 0x28); Shl4(RAX);   // rax = lda*4
+MovFromStack(R10, 0x30); Shl4(R10);   // r10 = ldb*4
+MovFromStack(R11, 0x38); Shl4(R11);   // r11 = ldc*4
+Push(RBX); Push(RSI);                 // save non-volatile GP
+int subAmt = 160;
+Bytes(0x48, 0x81, 0xEC, (byte)subAmt, 0, 0, 0); // sub rsp,160
+for (int x = 6; x <= 15; x++) Vmovups128St(x, RSP, (x - 6) * 16); // save xmm6..15
+Lea(RBX, RCX, RAX, 2);  // rbx = A + 2*lda  (row2 base)
+Lea(RSI, RCX, RAX, 4);  // rsi = A + 4*lda  (row4 base)
+
+for (int d = 0; d < 12; d++) VXor(d);
+
+int loop = code.Count;
+VLoad(12, RDX, 0); VLoad(13, RDX, 32);            // B[k,0:8],[8:16]
+VBcastB(14, RCX); VFma(0, 14, 12); VFma(1, 14, 13);        // row0 = [rcx]
+VBcastI(14, RCX, RAX); VFma(2, 14, 12); VFma(3, 14, 13);   // row1 = [rcx+lda]
+VBcastB(14, RBX); VFma(4, 14, 12); VFma(5, 14, 13);        // row2 = [rbx]
+VBcastI(14, RBX, RAX); VFma(6, 14, 12); VFma(7, 14, 13);   // row3 = [rbx+lda]
+VBcastB(14, RSI); VFma(8, 14, 12); VFma(9, 14, 13);        // row4 = [rsi]
+VBcastI(14, RSI, RAX); VFma(10, 14, 12); VFma(11, 14, 13); // row5 = [rsi+lda]
+AddImm(RCX, 4); AddImm(RBX, 4); AddImm(RSI, 4);   // advance A bases by 1 col
+AddRegReg(RDX, R10);                              // B += ldb*4
+Bytes(0x49, 0xFF, 0xC9);                          // dec r9
+int after = code.Count;
+Bytes(0x75, (byte)(sbyte)(loop - (after + 2)));   // jnz loop
+
+// store C[6,16] with row stride r11 (=ldc*4)
+for (int r = 0; r < 6; r++) { VStore(r * 2, R8, 0); VStore(r * 2 + 1, R8, 32); if (r < 5) AddRegReg(R8, R11); }
+
+for (int x = 6; x <= 15; x++) Vmovups128Ld(x, RSP, (x - 6) * 16);
+Bytes(0x48, 0x81, 0xC4, (byte)subAmt, 0, 0, 0);   // add rsp,160
+Pop(RSI); Pop(RBX);
+Bytes(0xC5, 0xF8, 0x77); Bytes(0xC3);             // vzeroupper; ret
+
+byte[] mc = code.ToArray();
+Console.WriteLine($"emitted {mc.Length} bytes (unpacked 6x16)");
+IntPtr mem = VirtualAlloc(IntPtr.Zero, (UIntPtr)mc.Length, MEM_COMMIT | MEM_RESERVE, PAGE_RW);
+Marshal.Copy(mc, 0, mem, mc.Length);
+VirtualProtect(mem, (UIntPtr)mc.Length, PAGE_EXEC_R, out _);
+
+unsafe
+{
+    var k = (delegate* unmanaged[Cdecl]<float*, float*, float*, long, long, long, long, void>)mem;
+    // correctness: a single 6×16 block of a [6,K]·[K,16] (lda=K, ldb=16, ldc=16)
+    int K = 64;
+    var A = new float[6 * K]; var B = new float[K * 16]; var C = new float[6 * 16];
+    var rnd = new Random(1);
+    for (int i = 0; i < A.Length; i++) A[i] = (float)(rnd.NextDouble() - 0.5);
+    for (int i = 0; i < B.Length; i++) B[i] = (float)(rnd.NextDouble() - 0.5);
+    fixed (float* a = A, b = B, c = C) k(a, b, c, K, K, 16, 16);
+    double err = 0;
+    for (int r = 0; r < 6; r++) for (int cc = 0; cc < 16; cc++)
+    { double acc = 0; for (int kk = 0; kk < K; kk++) acc += (double)A[r * K + kk] * B[kk * 16 + cc]; err = Math.Max(err, Math.Abs(acc - C[r * 16 + cc])); }
+    Console.WriteLine($"[correctness] unpacked 6x16 maxErr = {err:E3}  ({(err < 1e-2 ? "PASS" : "FAIL")})");
+
+    // driver: full GEMM C[M,N]=A·B, no pack/scatter, parallel over row-blocks, 16 threads
+    void Drive(string name, int M, int N, int Kk)
+    {
+        int nRB = M / 6, nCB = N / 16;
+        var Am = new float[(long)M * Kk]; var Bm = new float[(long)Kk * N]; var Cm = new float[(long)M * N];
+        var r2 = new Random(3);
+        for (long i = 0; i < Am.LongLength; i++) Am[i] = (float)(r2.NextDouble() - 0.5);
+        for (long i = 0; i < Bm.LongLength; i++) Bm[i] = (float)(r2.NextDouble() - 0.5);
+        nint memN = mem; int T = 16;
+        // Spawn threads ONCE; each does `reps` full passes internally (avoids the
+        // per-pass thread-creation overhead that masks kernel throughput).
+        void RunReps(int reps)
+        {
+            var ths = new System.Threading.Thread[T]; int per = (nRB + T - 1) / T;
+            for (int t = 0; t < T; t++)
+            {
+                int lo = t * per, hi = Math.Min(lo + per, nRB);
+                ths[t] = new System.Threading.Thread(() =>
+                {
+                    unsafe
+                    {
+                        var kf = (delegate* unmanaged[Cdecl]<float*, float*, float*, long, long, long, long, void>)memN;
+                        fixed (float* aP = Am, bP = Bm, cP = Cm)
+                            for (int rep = 0; rep < reps; rep++)
+                                for (int rb = lo; rb < hi; rb++)
+                                    for (int cb = 0; cb < nCB; cb++)
+                                        kf(aP + (long)(rb * 6) * Kk, bP + cb * 16, cP + (long)(rb * 6) * N + cb * 16, Kk, Kk, N, N);
+                    }
+                });
+            }
+            foreach (var t in ths) t.Start(); foreach (var t in ths) t.Join();
+        }
+        RunReps(1);
+        double e2 = 0; var rr = new Random(9);
+        for (int s = 0; s < 200; s++) { int i = rr.Next(M), j = rr.Next(N); double acc = 0; for (int kk = 0; kk < Kk; kk++) acc += (double)Am[(long)i * Kk + kk] * Bm[(long)kk * N + j]; e2 = Math.Max(e2, Math.Abs(acc - Cm[(long)i * N + j])); }
+        RunReps(40);
+        int reps = 600; var sw = Stopwatch.StartNew(); RunReps(reps); sw.Stop();
+        Console.WriteLine($"  {name} [{M},{Kk}]x[{Kk},{N}]  {(double)M * N * Kk * 2 * reps / sw.Elapsed.TotalSeconds / 1e9,6:F0} GFLOP/s (16t, UNPACKED)  maxErr={e2:E2}");
+    }
+    Console.WriteLine("--- unpacked driver: transformer shapes (no pack, no scatter) ---");
+    Drive("QKV ", 4092, 192, 64);
+    Drive("FFN1", 4092, 128, 64);
+    Drive("FFN2", 4092, 64, 128);
+}

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledMlp.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledMlp.cs
@@ -191,6 +191,13 @@ internal sealed class CompiledMlp
 
     private static unsafe void RunLayerGemm(byte kernel, float[] src, float[] weight, float[] dst, int m, int k, int n)
     {
+#if !NET471
+        // JIT'd AVX2 kernel first (opt-in, gated inside TryMultiply). CompiledMlp is
+        // the path the AIsEval MLP actually takes; without this hook the JIT never
+        // reached it (the kernel auto-tuner only chose between managed/native).
+        if (Simd.JitGemmAvx2.TryMultiply(src.AsSpan(0, m * k), weight.AsSpan(0, k * n), dst.AsSpan(0, m * n), m, n, k))
+            return;
+#endif
         if (kernel == KernelNative && BlasProvider.HasRawSgemm)
         {
             // Direct native BLAS sgemm (overwrite C). Goes straight to the

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -340,6 +340,12 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     // them from a test/diag harness via the static accessors below to break
     // down where Step's wall time is going (forward / grad-zero / backward /
     // optimizer). Zero overhead in hot path when disabled — single env-var
+    // Small/medium-M cutover for routing compiled-plan GEMM delegates through the
+    // pack-fresh tiled managed kernel instead of native TryGemm (see the matmul
+    // delegate factory). At/below this M the managed kernel wins; above it native
+    // BLAS's raw throughput wins. Mirrors CpuEngine's TensorMatMul2D cutover.
+    private const int TrainingSmallMCutover = 1024;
+
     // read at static init, then a single bool check per Step.
     private static readonly bool _profileStepEnabled =
         System.Environment.GetEnvironmentVariable("AIDOTNET_PROFILE_STEP") == "1";
@@ -2540,14 +2546,23 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
             // Training plan path: parameters (B) are updated in-place between
             // Step() calls, so the pre-packed-B cache would serve stale weights.
-            // Skip SgemmWithCachedB and re-pack on every call (measurable cost
-            // during training, but correctness-first). Fixes
-            // CompiledTrainingPlanRebindingTests.Step_SeesInPlaceParameterUpdates
-            // and Step_ViaCompiledModelCache_SeesUpdates.
+            // Re-pack on every call (correctness-first) — but use the right kernel:
+            //   * small/medium M (<= cutover): the pack-fresh tiled managed kernel
+            //     (SimdGemm.Sgemm 10-arg) beats native TryGemm ~2-5x at the small-M
+            //     (batch) shapes that dominate training — e.g. [64x784]x[784x512]
+            //     ~83 GFLOP/s vs ~18 for TryGemm (min-of-12, fresh-B every call).
+            //     It packs B fresh each call (NO identity cache), so it correctly
+            //     sees in-place weight updates — verified against
+            //     CompiledTrainingPlanRebindingTests.Step_SeesInPlaceParameterUpdates.
+            //   * large M: native BLAS raw throughput wins, keep TryGemm.
             return eng =>
             {
-                if (!BlasProvider.TryGemm(M, N, K, cA, 0, K, cB, 0, N, cOut, 0, N))
-                    SimdGemm.Sgemm(cA.AsSpan(0, M * K), cB.AsSpan(0, K * N), cOut.AsSpan(0, M * N), M, K, N);
+                if (M <= TrainingSmallMCutover)
+                    SimdGemm.Sgemm(cA.AsSpan(0, M * K), K, false, cB.AsSpan(0, K * N), N, false,
+                                   cOut.AsSpan(0, M * N), M, K, N);
+                else if (!BlasProvider.TryGemm(M, N, K, cA, 0, K, cB, 0, N, cOut, 0, N))
+                    SimdGemm.Sgemm(cA.AsSpan(0, M * K), K, false, cB.AsSpan(0, K * N), N, false,
+                                   cOut.AsSpan(0, M * N), M, K, N);
             };
         }
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.LstmSequence.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.LstmSequence.cs
@@ -445,6 +445,12 @@ public partial class CpuEngine
             // at this small K=hidden). Serial WITHIN a thread — the batch-level fan-out
             // (when present) already supplies the parallelism, and re-threading this tiny
             // per-step GEMM would oversubscribe and lose to dispatch overhead.
+            //
+            // Kernel choice is settled by the LosingShapeGemmBench 4-way matrix at this
+            // exact shape ([128,64,256], GF/s): managed-serial 103 BEATS managed-parallel
+            // 87, the asm panel kernel serial 53 / parallel 88, and OpenBLAS 66. The
+            // managed serial kernel is the measured optimum here — do NOT route this
+            // through JitGemmAvx2 or native BLAS without re-running that bench.
             SimdGemm.SgemmSequential(
                 hP.AsSpan(0, rows * hidden),
                 wHhT.AsSpan(0, hidden * gateRows),

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.LstmSequence.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.LstmSequence.cs
@@ -23,6 +23,33 @@ public partial class CpuEngine
     /// </summary>
     private static readonly Tensor<float> s_emptyState = new(new[] { 0 });
 
+    // Batch-parallel recurrence config. The LSTM recurrence is embarrassingly
+    // parallel across the batch dimension — h_t[b] depends only on h_{t-1}[b]
+    // and x_t[b], never on another batch row — so the entire T-timestep loop
+    // (per-step hidden GEMM + fused cell) can be split into contiguous batch
+    // chunks that run with ZERO inter-thread communication. The parallel region
+    // is launched ONCE for the whole sequence (not per timestep): an earlier
+    // attempt that relaunched the region every step lost to 32x dispatch
+    // overhead. Gated on rows-per-chunk so small batches (b=1/8 — which already
+    // beat PyTorch on the serial path) keep a single chunk and never pay the
+    // park/wakeup floor; only large batches (b=32/128, where the serial
+    // per-step M=batch GEMM is the bottleneck) fan out. Env-tunable for A/B.
+    // Default 8 rows/chunk: a MINROWS sweep on the AIsEval LSTM ([*, 32, 32],
+    // hidden=64) found 8 is the sweet spot. It keeps b<=8 on a single chunk (the
+    // serial path they already WIN on — fanning b=8 out to 4 chunks regressed it
+    // from 0.46x to 0.82x of PyTorch), while letting b=32 fan to 4 chunks
+    // (1.58x -> 1.17x) and b=128 saturate the cores (1.89x -> ~1.28x). Going
+    // lower (2/4 rows) over-fragments: the per-chunk M=2/4 recurrent GEMM is too
+    // thin to amortize, so b=32 degraded back to 1.3-1.4x.
+    private static readonly int _lstmParallelMinRowsPerChunk =
+        int.TryParse(System.Environment.GetEnvironmentVariable("AIDOTNET_LSTM_PARALLEL_MINROWS"), out var lpr) && lpr > 0
+            ? lpr : 8;
+
+    // Master switch (default on). Set AIDOTNET_LSTM_PARALLEL=0 to force the
+    // serial recurrence for drift-cancelled on/off A/B measurement.
+    private static readonly bool _lstmParallelEnabled =
+        System.Environment.GetEnvironmentVariable("AIDOTNET_LSTM_PARALLEL") != "0";
+
     /// <summary>
     /// Fused LSTM sequence forward — processes a full <c>[B, seq, in]</c> sequence
     /// through one LSTM cell in a single call, returning either the entire hidden
@@ -239,11 +266,6 @@ public partial class CpuEngine
         var pool = ArrayPool<float>.Shared;
 
         var wxBuf = pool.Rent(totalRows * gateRows);
-        var hCurrBuf = pool.Rent(batch * hidden);
-        var cCurrBuf = pool.Rent(batch * hidden);
-        var hPrevBuf = pool.Rent(batch * hidden);
-        var cPrevBuf = pool.Rent(batch * hidden);
-        var hhBuf = pool.Rent(batch * gateRows);     // h_prev @ wHh^T scratch (natural layout)
         // #477: pool the transposed hidden weight too. It used to be `new float[]` per
         // call (64 KB at the AIsEval shape) because SgemmWithCachedB keyed its pre-pack
         // cache on the array identity. Now the recurrent GEMM is SgemmSequential (no
@@ -255,6 +277,11 @@ public partial class CpuEngine
         var output = returnSequences
             ? AutoTensorCache.RentOrAllocate<float>(new[] { batch, seqLen, hidden })
             : AutoTensorCache.RentOrAllocate<float>(new[] { batch, hidden });
+
+        // Final-state tensors are allocated up front (when requested) so the
+        // batch-parallel chunks can each write their own row range into them.
+        finalHidden = wantState ? new Tensor<float>(new[] { batch, hidden }) : s_emptyState;
+        finalCell = wantState ? new Tensor<float>(new[] { batch, hidden }) : s_emptyState;
 
         try
         {
@@ -278,183 +305,91 @@ public partial class CpuEngine
                 }
             }
 
-            // Initial states.
-            if (h0 is null) Array.Clear(hPrevBuf, 0, batch * hidden);
-            else h0.AsSpan().Slice(0, batch * hidden).CopyTo(hPrevBuf.AsSpan(0, batch * hidden));
-            if (c0 is null) Array.Clear(cPrevBuf, 0, batch * hidden);
-            else c0.AsSpan().Slice(0, batch * hidden).CopyTo(cPrevBuf.AsSpan(0, batch * hidden));
-
             var wHhSpan = wHh.AsSpan();
-            bool hasBhh = bHh is not null;
-            ReadOnlySpan<float> bHhSpan = hasBhh ? bHh!.AsSpan() : default;
-            var outSpan = output.AsWritableSpan();
+            float[]? bHhArr = bHh?.ToArray();
+            float[]? h0Arr = h0?.ToArray();
+            float[]? c0Arr = c0?.ToArray();
 
-            // #477: the recurrent GEMM h_prev @ wHh^T runs once per timestep (seqLen
-            // serial calls). The old transB=true Sgemm re-transposed wHh on EVERY step.
-            // Pre-transpose wHh [gateRows, hidden] → wHhT [hidden, gateRows] ONCE, then
-            // pass wHhT as the no-transpose B operand to the per-step direct GEMM below
-            // ([hidden, gateRows] is exactly the [K, N] row-major layout SgemmSequential
-            // expects, so the per-step call needs no further transpose or packing setup).
-            // Pooled buffer (ArrayPool may return a larger array; every element of the
-            // [hidden, gateRows] window is overwritten by the transpose, so no stale data,
-            // and the GEMM call below slices to exactly hidden*gateRows).
+            // #477: the recurrent GEMM h_prev @ wHh^T runs once per timestep. The old
+            // transB=true Sgemm re-transposed wHh on EVERY step. Pre-transpose wHh
+            // [gateRows, hidden] → wHhT [hidden, gateRows] ONCE; [hidden, gateRows] is
+            // exactly the [K, N] row-major layout SgemmSequential expects, so the
+            // per-step call needs no further transpose or packing setup.
             var wHhT = wHhTBuf;
             for (int g = 0; g < gateRows; g++)
                 for (int hh2 = 0; hh2 < hidden; hh2++)
                     wHhT[hh2 * gateRows + g] = wHhSpan[g * hidden + hh2];
 
-            // Per-timestep loop.
-            for (int t = 0; t < seqLen; t++)
+            var outArr = (float[])(object)output.GetDataArray();
+            float[]? fhArr = wantState ? (float[])(object)finalHidden.GetDataArray() : null;
+            float[]? fcArr = wantState ? (float[])(object)finalCell.GetDataArray() : null;
+
+            // Decide batch-parallel fan-out. The recurrence is independent across
+            // batch rows, so split [0,batch) into `numChunks` CONTIGUOUS ranges and
+            // run the whole T-step loop per range. Only fan out when each chunk keeps
+            // a GEMM-healthy row count (>= _lstmParallelMinRowsPerChunk): small
+            // batches (b=1/8) collapse to one chunk and take the serial path they
+            // already win on. The parallel region launches ONCE for the sequence.
+            int numChunks = 1;
+            if (_lstmParallelEnabled)
             {
-                // hh = h_prev @ wHh^T = h_prev @ wHhT, [B, hidden] @ [hidden, gateRows].
-                // #477: route through SgemmSequential (the DIRECT 6×16 AVX2 kernel), NOT
-                // SgemmWithCachedB. A min-of-2000 microbench at this exact shape
-                // [M=128, K=64, N=256] showed the cached-pre-packed path runs ~82 GF/s
-                // while the direct kernel runs ~103 GF/s (+24%): for this small K the
-                // cached-B tiling machinery costs more than the direct kernel's lighter
-                // per-call packing, so the "avoid re-packing" optimization was a net loss
-                // here. Kept SERIAL: parallelizing this tiny per-step GEMM across the batch
-                // loses to dispatch overhead over the 32-step sequence (the issue's
-                // thread-insensitive finding).
-                SimdGemm.SgemmSequential(
-                    hPrevBuf.AsSpan(0, batch * hidden),
-                    wHhT.AsSpan(0, hidden * gateRows),
-                    hhBuf.AsSpan(0, batch * gateRows),
-                    batch, hidden, gateRows);
-
-                // #477 FUSED ELEMENTWISE CELL. Replaces the de-interleave + 3 batched
-                // activation passes + the cell-update passes (profiled at ~half the per-step
-                // wall-clock, all memory-bound) with ONE fused vectorized pass. For each
-                // (b, 8-lane h block) it reads the four gate pre-activations straight from
-                // the NATURAL [b][gateRows] Wx + hh (so no de-interleave and no gate buffer
-                // are materialized), applies sigmoid/tanh in registers (the same Padé
-                // FastSigmoid256/FastTanh256 that SimdKernels uses on this CPU), and writes
-                // c = f·c_prev + i·g and h = o·tanh(c) directly — the gate values never
-                // round-trip through memory. This is the memory-pass reduction a fused LSTM
-                // cell (oneDNN/MKL) relies on.
-                bool fusedVec = false;
-#if NET5_0_OR_GREATER
-                fusedVec = Avx2.IsSupported && Fma.IsSupported && (hidden % 8 == 0);
-#endif
-                if (fusedVec)
-                {
-#if NET5_0_OR_GREATER
-                    fixed (float* wxP = wxBuf)
-                    fixed (float* hhP = hhBuf)
-                    fixed (float* cPrevP = cPrevBuf)
-                    fixed (float* cCurrP = cCurrBuf)
-                    fixed (float* hCurrP = hCurrBuf)
-                    fixed (float* bHhP = bHhSpan)
-                    fixed (float* outP = outSpan)
-                    {
-                        for (int b = 0; b < batch; b++)
-                        {
-                            int wxRow = (b * seqLen + t) * gateRows;
-                            int hhRow = b * gateRows;
-                            int cRow = b * hidden;
-                            int outRow = (b * seqLen + t) * hidden;
-                            for (int h = 0; h < hidden; h += 8)
-                            {
-                                var iIn = Avx.Add(Avx.LoadVector256(wxP + wxRow + 0 * hidden + h), Avx.LoadVector256(hhP + hhRow + 0 * hidden + h));
-                                var fIn = Avx.Add(Avx.LoadVector256(wxP + wxRow + 1 * hidden + h), Avx.LoadVector256(hhP + hhRow + 1 * hidden + h));
-                                var gIn = Avx.Add(Avx.LoadVector256(wxP + wxRow + 2 * hidden + h), Avx.LoadVector256(hhP + hhRow + 2 * hidden + h));
-                                var oIn = Avx.Add(Avx.LoadVector256(wxP + wxRow + 3 * hidden + h), Avx.LoadVector256(hhP + hhRow + 3 * hidden + h));
-                                if (hasBhh)
-                                {
-                                    iIn = Avx.Add(iIn, Avx.LoadVector256(bHhP + 0 * hidden + h));
-                                    fIn = Avx.Add(fIn, Avx.LoadVector256(bHhP + 1 * hidden + h));
-                                    gIn = Avx.Add(gIn, Avx.LoadVector256(bHhP + 2 * hidden + h));
-                                    oIn = Avx.Add(oIn, Avx.LoadVector256(bHhP + 3 * hidden + h));
-                                }
-
-                                var iG = SimdKernels.FastSigmoid256(iIn);
-                                var fG = SimdKernels.FastSigmoid256(fIn);
-                                var gG = SimdKernels.FastTanh256(gIn);
-                                var oG = SimdKernels.FastSigmoid256(oIn);
-
-                                var cp = Avx.LoadVector256(cPrevP + cRow + h);
-                                var c = Fma.MultiplyAdd(fG, cp, Avx.Multiply(iG, gG)); // f·c_prev + i·g
-                                Avx.Store(cCurrP + cRow + h, c);
-                                var hv = Avx.Multiply(oG, SimdKernels.FastTanh256(c)); // o·tanh(c)
-                                Avx.Store(hCurrP + cRow + h, hv);
-                                if (returnSequences)
-                                    Avx.Store(outP + outRow + h, hv);
-                            }
-                        }
-                    }
-#endif
-                }
-                else
-                {
-                    // Scalar fused fallback (no AVX2/FMA, or hidden % 8 != 0): same fused
-                    // formula with exact MathF transcendentals.
-                    fixed (float* wxP = wxBuf)
-                    fixed (float* hhP = hhBuf)
-                    fixed (float* cPrevP = cPrevBuf)
-                    fixed (float* cCurrP = cCurrBuf)
-                    fixed (float* hCurrP = hCurrBuf)
-                    fixed (float* bHhP = bHhSpan)
-                    fixed (float* outP = outSpan)
-                    {
-                        for (int b = 0; b < batch; b++)
-                        {
-                            int wxRow = (b * seqLen + t) * gateRows;
-                            int hhRow = b * gateRows;
-                            int cRow = b * hidden;
-                            int outRow = (b * seqLen + t) * hidden;
-                            for (int h = 0; h < hidden; h++)
-                            {
-                                float iIn = wxP[wxRow + 0 * hidden + h] + hhP[hhRow + 0 * hidden + h];
-                                float fIn = wxP[wxRow + 1 * hidden + h] + hhP[hhRow + 1 * hidden + h];
-                                float gIn = wxP[wxRow + 2 * hidden + h] + hhP[hhRow + 2 * hidden + h];
-                                float oIn = wxP[wxRow + 3 * hidden + h] + hhP[hhRow + 3 * hidden + h];
-                                if (hasBhh)
-                                {
-                                    iIn += bHhP[0 * hidden + h]; fIn += bHhP[1 * hidden + h];
-                                    gIn += bHhP[2 * hidden + h]; oIn += bHhP[3 * hidden + h];
-                                }
-                                float iG = 1f / (1f + (float)Math.Exp(-iIn));
-                                float fG = 1f / (1f + (float)Math.Exp(-fIn));
-                                float gG = (float)Math.Tanh(gIn);
-                                float oG = 1f / (1f + (float)Math.Exp(-oIn));
-                                float c = fG * cPrevP[cRow + h] + iG * gG;
-                                cCurrP[cRow + h] = c;
-                                float hv = oG * (float)Math.Tanh(c);
-                                hCurrP[cRow + h] = hv;
-                                if (returnSequences) outP[outRow + h] = hv;
-                            }
-                        }
-                    }
-                }
-
-                // Swap roles: next iter's h_prev/c_prev are this iter's h_curr/c_curr.
-                (hPrevBuf, hCurrBuf) = (hCurrBuf, hPrevBuf);
-                (cPrevBuf, cCurrBuf) = (cCurrBuf, cPrevBuf);
+                int byRows = batch / Math.Max(1, _lstmParallelMinRowsPerChunk);
+                numChunks = Math.Max(1, Math.Min(byRows, CpuParallelSettings.MaxDegreeOfParallelism));
             }
 
-            if (!returnSequences)
+            if (numChunks <= 1)
             {
-                // hPrevBuf now holds the last hCurr (post-swap). Copy it out.
-                hPrevBuf.AsSpan(0, batch * hidden).CopyTo(outSpan);
-            }
-
-            if (wantState)
-            {
-                // Final states (h_n, c_n) for streaming/chunked inference. After the
-                // role-swap at the end of the last timestep, hPrevBuf / cPrevBuf hold
-                // the last step's hidden / cell state. Copy into owned [B, hidden]
-                // tensors so they outlive the pooled scratch returned below.
-                finalHidden = new Tensor<float>(new[] { batch, hidden });
-                finalCell = new Tensor<float>(new[] { batch, hidden });
-                hPrevBuf.AsSpan(0, batch * hidden).CopyTo(finalHidden.AsWritableSpan());
-                cPrevBuf.AsSpan(0, batch * hidden).CopyTo(finalCell.AsWritableSpan());
+                // Serial: one chunk covering the full batch, reusing pooled scratch.
+                var hPrevBuf = pool.Rent(batch * hidden);
+                var hCurrBuf = pool.Rent(batch * hidden);
+                var cPrevBuf = pool.Rent(batch * hidden);
+                var cCurrBuf = pool.Rent(batch * hidden);
+                var hhBuf = pool.Rent(batch * gateRows);
+                try
+                {
+                    RunLstmRecurrenceRange(
+                        wxBuf, wHhT, bHhArr, h0Arr, c0Arr,
+                        hPrevBuf, hCurrBuf, cPrevBuf, cCurrBuf, hhBuf,
+                        outArr, returnSequences, fhArr, fcArr,
+                        r0: 0, rows: batch, seqLen, hidden, gateRows);
+                }
+                finally
+                {
+                    pool.Return(hPrevBuf); pool.Return(hCurrBuf);
+                    pool.Return(cPrevBuf); pool.Return(cCurrBuf); pool.Return(hhBuf);
+                }
             }
             else
             {
-                // Hot path: caller discards state — skip the two [B, hidden]
-                // allocations + copies entirely. Share one cached empty tensor.
-                finalHidden = s_emptyState;
-                finalCell = s_emptyState;
+                // Batch-parallel: contiguous row ranges, one region launch. Each task
+                // rents its own scratch (no shared mutable state across threads — the
+                // only shared reads are wxBuf/wHhT/bHh/h0/c0, the only shared writes are
+                // disjoint row ranges of outArr/fhArr/fcArr).
+                int chunkRows = (batch + numChunks - 1) / numChunks;
+                Helpers.PersistentParallelExecutor.Instance.Execute(numChunks, chunk =>
+                {
+                    int r0 = chunk * chunkRows;
+                    if (r0 >= batch) return;
+                    int rows = Math.Min(chunkRows, batch - r0);
+                    var hPrevL = pool.Rent(rows * hidden);
+                    var hCurrL = pool.Rent(rows * hidden);
+                    var cPrevL = pool.Rent(rows * hidden);
+                    var cCurrL = pool.Rent(rows * hidden);
+                    var hhL = pool.Rent(rows * gateRows);
+                    try
+                    {
+                        RunLstmRecurrenceRange(
+                            wxBuf, wHhT, bHhArr, h0Arr, c0Arr,
+                            hPrevL, hCurrL, cPrevL, cCurrL, hhL,
+                            outArr, returnSequences, fhArr, fcArr,
+                            r0, rows, seqLen, hidden, gateRows);
+                    }
+                    finally
+                    {
+                        pool.Return(hPrevL); pool.Return(hCurrL);
+                        pool.Return(cPrevL); pool.Return(cCurrL); pool.Return(hhL);
+                    }
+                });
             }
 
             return output;
@@ -462,13 +397,168 @@ public partial class CpuEngine
         finally
         {
             pool.Return(wxBuf);
-            pool.Return(hCurrBuf);
-            pool.Return(cCurrBuf);
-            pool.Return(hPrevBuf);
-            pool.Return(cPrevBuf);
-            pool.Return(hhBuf);
             pool.Return(wHhTBuf);
         }
+    }
+
+    /// <summary>
+    /// Runs the full T-timestep LSTM recurrence (per-step recurrent GEMM + fused
+    /// elementwise cell) for a CONTIGUOUS range of batch rows <c>[r0, r0+rows)</c>.
+    /// Shared with the serial path (one call covering the whole batch) and the
+    /// batch-parallel path (one call per chunk). The <paramref name="hPrev"/> /
+    /// <paramref name="hCurr"/> / <paramref name="cPrev"/> / <paramref name="cCurr"/>
+    /// / <paramref name="hh"/> buffers are LOCAL scratch owned by the caller (sized
+    /// for <paramref name="rows"/>, not the full batch) and are mutated/ping-ponged
+    /// here. Shared reads: <paramref name="wxBuf"/> (pre-computed input projection,
+    /// indexed by GLOBAL row), <paramref name="wHhT"/>, bias, h0/c0. Shared writes:
+    /// disjoint global row ranges of <paramref name="outArr"/> and the optional final
+    /// state arrays — no two ranges overlap, so concurrent chunks need no locking.
+    /// </summary>
+    private static unsafe void RunLstmRecurrenceRange(
+        float[] wxBuf, float[] wHhT, float[]? bHhArr, float[]? h0Arr, float[]? c0Arr,
+        float[] hPrev, float[] hCurr, float[] cPrev, float[] cCurr, float[] hh,
+        float[] outArr, bool returnSequences, float[]? fhArr, float[]? fcArr,
+        int r0, int rows, int seqLen, int hidden, int gateRows)
+    {
+        bool hasBhh = bHhArr is not null;
+
+        // Initial states for this row range. Local buffers are indexed [localRow*hidden];
+        // h0/c0 are global [batch, hidden] so they are read at the global offset.
+        if (h0Arr is null) Array.Clear(hPrev, 0, rows * hidden);
+        else Array.Copy(h0Arr, r0 * hidden, hPrev, 0, rows * hidden);
+        if (c0Arr is null) Array.Clear(cPrev, 0, rows * hidden);
+        else Array.Copy(c0Arr, r0 * hidden, cPrev, 0, rows * hidden);
+
+        // Local ping-pong references (swapped each step). Using locals keeps the
+        // caller's array handles fixed for the pool.Return in its finally.
+        float[] hP = hPrev, hC = hCurr, cP = cPrev, cC = cCurr;
+
+        bool fusedVec = false;
+#if NET5_0_OR_GREATER
+        fusedVec = Avx2.IsSupported && Fma.IsSupported && (hidden % 8 == 0);
+#endif
+
+        for (int t = 0; t < seqLen; t++)
+        {
+            // hh = h_prev @ wHhT, [rows, hidden] @ [hidden, gateRows]. SgemmSequential
+            // is the DIRECT 6×16 AVX2 kernel (the cached-pre-packed path measured slower
+            // at this small K=hidden). Serial WITHIN a thread — the batch-level fan-out
+            // (when present) already supplies the parallelism, and re-threading this tiny
+            // per-step GEMM would oversubscribe and lose to dispatch overhead.
+            SimdGemm.SgemmSequential(
+                hP.AsSpan(0, rows * hidden),
+                wHhT.AsSpan(0, hidden * gateRows),
+                hh.AsSpan(0, rows * gateRows),
+                rows, hidden, gateRows);
+
+            // #477 FUSED ELEMENTWISE CELL: read the four gate pre-activations straight
+            // from the natural [row][gateRows] Wx + hh, apply sigmoid/tanh in registers,
+            // and write c = f·c_prev + i·g, h = o·tanh(c) directly — gates never
+            // round-trip through memory. `lr` is the local row; the GLOBAL row r0+lr
+            // indexes the shared wxBuf / outArr / final-state arrays.
+            if (fusedVec)
+            {
+#if NET5_0_OR_GREATER
+                fixed (float* wxP = wxBuf)
+                fixed (float* hhP = hh)
+                fixed (float* cPrevP = cP)
+                fixed (float* cCurrP = cC)
+                fixed (float* hCurrP = hC)
+                fixed (float* bHhP = bHhArr)
+                fixed (float* outP = outArr)
+                {
+                    for (int lr = 0; lr < rows; lr++)
+                    {
+                        int gb = r0 + lr;
+                        int wxRow = (gb * seqLen + t) * gateRows;
+                        int hhRow = lr * gateRows;
+                        int cRow = lr * hidden;
+                        int outRow = (gb * seqLen + t) * hidden;
+                        for (int h = 0; h < hidden; h += 8)
+                        {
+                            var iIn = Avx.Add(Avx.LoadVector256(wxP + wxRow + 0 * hidden + h), Avx.LoadVector256(hhP + hhRow + 0 * hidden + h));
+                            var fIn = Avx.Add(Avx.LoadVector256(wxP + wxRow + 1 * hidden + h), Avx.LoadVector256(hhP + hhRow + 1 * hidden + h));
+                            var gIn = Avx.Add(Avx.LoadVector256(wxP + wxRow + 2 * hidden + h), Avx.LoadVector256(hhP + hhRow + 2 * hidden + h));
+                            var oIn = Avx.Add(Avx.LoadVector256(wxP + wxRow + 3 * hidden + h), Avx.LoadVector256(hhP + hhRow + 3 * hidden + h));
+                            if (hasBhh)
+                            {
+                                iIn = Avx.Add(iIn, Avx.LoadVector256(bHhP + 0 * hidden + h));
+                                fIn = Avx.Add(fIn, Avx.LoadVector256(bHhP + 1 * hidden + h));
+                                gIn = Avx.Add(gIn, Avx.LoadVector256(bHhP + 2 * hidden + h));
+                                oIn = Avx.Add(oIn, Avx.LoadVector256(bHhP + 3 * hidden + h));
+                            }
+
+                            var iG = SimdKernels.FastSigmoid256(iIn);
+                            var fG = SimdKernels.FastSigmoid256(fIn);
+                            var gG = SimdKernels.FastTanh256(gIn);
+                            var oG = SimdKernels.FastSigmoid256(oIn);
+
+                            var cp = Avx.LoadVector256(cPrevP + cRow + h);
+                            var c = Fma.MultiplyAdd(fG, cp, Avx.Multiply(iG, gG)); // f·c_prev + i·g
+                            Avx.Store(cCurrP + cRow + h, c);
+                            var hv = Avx.Multiply(oG, SimdKernels.FastTanh256(c)); // o·tanh(c)
+                            Avx.Store(hCurrP + cRow + h, hv);
+                            if (returnSequences)
+                                Avx.Store(outP + outRow + h, hv);
+                        }
+                    }
+                }
+#endif
+            }
+            else
+            {
+                // Scalar fused fallback (no AVX2/FMA, or hidden % 8 != 0).
+                fixed (float* wxP = wxBuf)
+                fixed (float* hhP = hh)
+                fixed (float* cPrevP = cP)
+                fixed (float* cCurrP = cC)
+                fixed (float* hCurrP = hC)
+                fixed (float* bHhP = bHhArr)
+                fixed (float* outP = outArr)
+                {
+                    for (int lr = 0; lr < rows; lr++)
+                    {
+                        int gb = r0 + lr;
+                        int wxRow = (gb * seqLen + t) * gateRows;
+                        int hhRow = lr * gateRows;
+                        int cRow = lr * hidden;
+                        int outRow = (gb * seqLen + t) * hidden;
+                        for (int h = 0; h < hidden; h++)
+                        {
+                            float iIn = wxP[wxRow + 0 * hidden + h] + hhP[hhRow + 0 * hidden + h];
+                            float fIn = wxP[wxRow + 1 * hidden + h] + hhP[hhRow + 1 * hidden + h];
+                            float gIn = wxP[wxRow + 2 * hidden + h] + hhP[hhRow + 2 * hidden + h];
+                            float oIn = wxP[wxRow + 3 * hidden + h] + hhP[hhRow + 3 * hidden + h];
+                            if (hasBhh)
+                            {
+                                iIn += bHhP[0 * hidden + h]; fIn += bHhP[1 * hidden + h];
+                                gIn += bHhP[2 * hidden + h]; oIn += bHhP[3 * hidden + h];
+                            }
+                            float iG = 1f / (1f + (float)Math.Exp(-iIn));
+                            float fG = 1f / (1f + (float)Math.Exp(-fIn));
+                            float gG = (float)Math.Tanh(gIn);
+                            float oG = 1f / (1f + (float)Math.Exp(-oIn));
+                            float c = fG * cPrevP[cRow + h] + iG * gG;
+                            cCurrP[cRow + h] = c;
+                            float hv = oG * (float)Math.Tanh(c);
+                            hCurrP[cRow + h] = hv;
+                            if (returnSequences) outP[outRow + h] = hv;
+                        }
+                    }
+                }
+            }
+
+            // Swap roles: next iter's prev is this iter's curr.
+            (hP, hC) = (hC, hP);
+            (cP, cC) = (cC, cP);
+        }
+
+        // After the loop, hP/cP hold the last timestep's hidden/cell state for these rows.
+        if (!returnSequences)
+            Array.Copy(hP, 0, outArr, r0 * hidden, rows * hidden);
+
+        if (fhArr is not null) Array.Copy(hP, 0, fhArr, r0 * hidden, rows * hidden);
+        if (fcArr is not null) Array.Copy(cP, 0, fcArr, r0 * hidden, rows * hidden);
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.Mlp.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.Mlp.cs
@@ -170,8 +170,21 @@ public partial class CpuEngine
                         // cached-B still wins the small layers (low K·N), where native
                         // BLAS dispatch overhead dominates. Mirror that split here without
                         // changing PreferManagedInferenceGemm (which FusedLinear also uses).
+                        bool gemmDone = false;
+#if !NET471
+                        // JIT'd AVX2 kernel first (opt-in) — beats both managed cached-B
+                        // and native BLAS on the MLP shapes; this is the path the MLP
+                        // actually takes (so without it the JIT never reached the MLP).
+                        if (_jitGemm && Simd.JitGemmAvx2.TryMultiply(
+                                src.AsSpan(0, M * curK), wArr.AsSpan(0, curK * n), dst.AsSpan(0, M * n), M, n, curK))
+                            gemmDone = true;
+#endif
                         bool preferManaged = (long)curK * n <= 200_000 || !BlasProvider.HasRawSgemm;
-                        if (preferManaged)
+                        if (gemmDone)
+                        {
+                            // done by JIT
+                        }
+                        else if (preferManaged)
                         {
                             Simd.SimdGemm.SgemmWithCachedB(
                                 src.AsSpan(0, M * curK), wArr, dst.AsSpan(0, M * n), M, curK, n);

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.MultiHeadAttention.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.MultiHeadAttention.cs
@@ -1,6 +1,10 @@
 using System;
 using System.Buffers;
 using System.Runtime.CompilerServices;
+#if NET5_0_OR_GREATER
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+#endif
 using AiDotNet.Tensors.Engines.Compilation;
 using AiDotNet.Tensors.Engines.Simd;
 using AiDotNet.Tensors.Helpers;
@@ -174,6 +178,7 @@ public partial class CpuEngine
                     vWS.Slice(kk * dModel, dModel).CopyTo(fW.Slice(dstRow + 2 * dModel, dModel));
                 }
             }
+            using (Profiling.Profiler.OpScope("MHA.QKVproj"))
             SimdGemm.Sgemm(
                 inputSpan, dModel, false,
                 fusedWBuf.AsSpan(0, dModel * dModel3), dModel3, false,
@@ -191,6 +196,7 @@ public partial class CpuEngine
             // gather/scatter is the same byte movement but fused with the GEMMs
             // (per-slice locality, no separate memory round-trips).
             double scaleVal = 1.0 / Math.Sqrt(dHead);
+            using (Profiling.Profiler.OpScope("MHA.SDPA"))
             MultiHeadAttentionFusedSdpa(
                 qkvFlatBuf, dModel3, /*qCol*/0, /*kCol*/dModel, /*vCol*/2 * dModel,
                 mask, scaleVal,
@@ -198,6 +204,7 @@ public partial class CpuEngine
                 concatBuf, dModel);
 
             // ---- Output projection: [B*seq, dModel] @ outWeight [dModel, dModel] -> output. ----
+            using (Profiling.Profiler.OpScope("MHA.OutProj"))
             SimdGemm.Sgemm(
                 concatBuf.AsSpan(0, totalRows * dModel), dModel, false,
                 outWeight.AsSpan(), dModel, false,
@@ -226,7 +233,7 @@ public partial class CpuEngine
     /// <param name="qkv">Fused projection buffer; row r=(b*seq+s) has stride
     /// <paramref name="qkvRowStride"/>; q/k/v blocks start at qCol/kCol/vCol and
     /// within a block the per-head layout is [..., h*dHead + d].</param>
-    private void MultiHeadAttentionFusedSdpa(
+    private unsafe void MultiHeadAttentionFusedSdpa(
         float[] qkv, int qkvRowStride, int qCol, int kCol, int vCol,
         Tensor<bool>? mask, double scaleValue,
         int batch, int heads, int seq, int dHead,
@@ -278,32 +285,74 @@ public partial class CpuEngine
                     scratch.AsSpan(scoff, seq * seq),
                     seq, dHead, seq);
 
-                // In-place scale + mask + numerically-stable softmax, row by row.
-                for (int i = 0; i < seq; i++)
+                // In-place scale + numerically-stable softmax, row by row.
+                // SIMD fast path: no mask + seq%8==0 (the transformer-encoder case)
+                // — vectorized scale/max, SIMD exp (HerumiExp256.Exp8), vectorized
+                // sum/normalize. The scalar MathF.Exp loop (524K exp/forward at
+                // bs128) was profiled as ~31% of the whole transformer forward.
+#if NET5_0_OR_GREATER
+                if (mask == null && (seq & 7) == 0 && Avx2.IsSupported && Fma.IsSupported)
                 {
-                    int rowOff = scoff + i * seq;
-                    float maxVal = negInfF;
-                    for (int j = 0; j < seq; j++)
+                    fixed (float* scPtr = scratch)
+                    fixed (float* tbl = HerumiExp256._table)
                     {
-                        float v = scratch[rowOff + j] * scaleF;
-                        if (mask != null && !mask[b, h, i, j]) v = negInfF;
-                        if (v > maxVal) maxVal = v;
-                        scratch[rowOff + j] = v;
+                        var vScale = Vector256.Create(scaleF);
+                        for (int i = 0; i < seq; i++)
+                        {
+                            float* row = scPtr + scoff + i * seq;
+                            var vmax = Vector256.Create(negInfF);
+                            for (int j = 0; j < seq; j += 8)
+                            {
+                                var v = Avx.Multiply(Avx.LoadVector256(row + j), vScale);
+                                Avx.Store(row + j, v);
+                                vmax = Avx.Max(vmax, v);
+                            }
+                            float maxVal = HMax256(vmax);
+                            var vMaxB = Vector256.Create(maxVal);
+                            var vsum = Vector256<float>.Zero;
+                            for (int j = 0; j < seq; j += 8)
+                            {
+                                var e = HerumiExp256.Exp8(Avx.Subtract(Avx.LoadVector256(row + j), vMaxB), tbl);
+                                Avx.Store(row + j, e);
+                                vsum = Avx.Add(vsum, e);
+                            }
+                            float sumExp = HSum256(vsum);
+                            float inv = sumExp != 0f ? 1f / sumExp : 0f;
+                            var vinv = Vector256.Create(inv);
+                            for (int j = 0; j < seq; j += 8)
+                                Avx.Store(row + j, Avx.Multiply(Avx.LoadVector256(row + j), vinv));
+                        }
                     }
-                    if (float.IsNegativeInfinity(maxVal))
+                }
+                else
+#endif
+                {
+                    for (int i = 0; i < seq; i++)
                     {
-                        for (int j = 0; j < seq; j++) scratch[rowOff + j] = 0f;
-                        continue;
+                        int rowOff = scoff + i * seq;
+                        float maxVal = negInfF;
+                        for (int j = 0; j < seq; j++)
+                        {
+                            float v = scratch[rowOff + j] * scaleF;
+                            if (mask != null && !mask[b, h, i, j]) v = negInfF;
+                            if (v > maxVal) maxVal = v;
+                            scratch[rowOff + j] = v;
+                        }
+                        if (float.IsNegativeInfinity(maxVal))
+                        {
+                            for (int j = 0; j < seq; j++) scratch[rowOff + j] = 0f;
+                            continue;
+                        }
+                        float sumExp = 0f;
+                        for (int j = 0; j < seq; j++)
+                        {
+                            float e = MathF.Exp(scratch[rowOff + j] - maxVal);
+                            scratch[rowOff + j] = e;
+                            sumExp += e;
+                        }
+                        float inv = sumExp != 0f ? 1f / sumExp : 0f;
+                        for (int j = 0; j < seq; j++) scratch[rowOff + j] *= inv;
                     }
-                    float sumExp = 0f;
-                    for (int j = 0; j < seq; j++)
-                    {
-                        float e = MathF.Exp(scratch[rowOff + j] - maxVal);
-                        scratch[rowOff + j] = e;
-                        sumExp += e;
-                    }
-                    float inv = sumExp != 0f ? 1f / sumExp : 0f;
-                    for (int j = 0; j < seq; j++) scratch[rowOff + j] *= inv;
                 }
 
                 // out[seq×dHead] = P[seq×seq] · V[seq×dHead]. Reuse the Q region
@@ -329,6 +378,24 @@ public partial class CpuEngine
             }
         });
     }
+
+#if NET5_0_OR_GREATER
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static unsafe float HSum256(Vector256<float> v)
+    {
+        float* t = stackalloc float[8]; Avx.Store(t, v);
+        return t[0] + t[1] + t[2] + t[3] + t[4] + t[5] + t[6] + t[7];
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static unsafe float HMax256(Vector256<float> v)
+    {
+        float* t = stackalloc float[8]; Avx.Store(t, v);
+        float m = t[0];
+        for (int i = 1; i < 8; i++) if (t[i] > m) m = t[i];
+        return m;
+    }
+#endif
 
     /// <summary>
     /// Generic-T path. Composes existing tensor-level primitives. Used for

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.MultiHeadAttention.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.MultiHeadAttention.cs
@@ -251,13 +251,21 @@ public partial class CpuEngine
         int scoff = 3 * seq * dHead;      // dHead*seq == seq*dHead
         int scratchLen = 3 * seq * dHead + seq * seq;
 
-        System.Threading.Tasks.Parallel.For(0, bhCount, bh =>
+        // Parallelize over batch·heads using the SAME PersistentParallelExecutor as
+        // the GEMMs/LayerNorm (NOT Parallel.For/ThreadPool) — a second pool in the
+        // forward pass oversubscribed the cores and forced park/wakeup between ops.
+        // One pool keeps workers hot across QKV-GEMM → SDPA → out-proj. Each chunk
+        // rents scratch once and strides over its (b,h) slices.
+        int _sdpaChunks = Math.Max(1, Math.Min(bhCount, CpuParallelSettings.MaxDegreeOfParallelism));
+        PersistentParallelExecutor.Instance.Execute(_sdpaChunks, chunk =>
         {
-            int b = bh / heads;
-            int h = bh % heads;
             var scratch = pool.Rent(scratchLen);
             try
             {
+                for (int bh = chunk; bh < bhCount; bh += _sdpaChunks)
+                {
+                int b = bh / heads;
+                int h = bh % heads;
                 int hQ = qCol + h * dHead;
                 int hK = kCol + h * dHead;
                 int hV = vCol + h * dHead;
@@ -371,6 +379,7 @@ public partial class CpuEngine
                     for (int d = 0; d < dHead; d++)
                         concat[dst + d] = scratch[src + d];
                 }
+                } // end for bh slice in this chunk
             }
             finally
             {

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -21545,6 +21545,12 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <c>Unsafe.ReadUnaligned</c> / <c>Unsafe.WriteUnaligned</c> for
     /// 32-byte vector load/store, avoiding Span bounds-check overhead.
     /// </summary>
+    // LayerNorm parallel break-even (elements). Below this, run serial to avoid the
+    // worker-pool park/wakeup floor that dominates small-op latency. Env-tunable.
+    private static readonly long _lnParallelMinWork =
+        long.TryParse(System.Environment.GetEnvironmentVariable("AIDOTNET_LN_PARALLEL_MINWORK"), out var lnw) && lnw > 0
+            ? lnw : 524_288;
+
     private static void ProcessBatchesSimd(
         float[] fInput, float[] fGamma, float[] fBeta,
         float[] fOutput, float[] fMean, float[] fVar,
@@ -21556,7 +21562,18 @@ public partial class CpuEngine : ITensorLevelEngine
 #else
         bool useSimd = false;
 #endif
-        if (batchSize * fs < 50_000)
+        // Serial below the parallel break-even. The old 50K threshold was far too
+        // low: a transformer LayerNorm at [B*seq, d] = [1024, 64] = 65 536 elements
+        // is only ~25 µs of single-pass SIMD work, but dispatching its 1024 tiny rows
+        // to the worker pool — which has parked between this and the previous op
+        // (MHA / FFN / the other 3 LayerNorms in the block) — pays the full park/
+        // wakeup latency (~190 µs measured, profiled as ManualResetEventSlim/semaphore
+        // wait, not compute). Net: parallel was ~7× SLOWER than serial at this size.
+        // Raised to 512K elements so small/medium LayerNorms (transformers at modest
+        // batch×seq) stay serial; large ones (BERT-scale, millions of elements, where
+        // serial is ms and dwarfs the wakeup) still parallelize. Env-tunable.
+        long lnWork = (long)batchSize * fs;
+        if (lnWork < _lnParallelMinWork)
         {
             for (int b = 0; b < batchSize; b++)
                 ProcessRow(fInput, fGamma, fBeta, fOutput, fMean, fVar, b, fs, fEps, useSimd);

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -2757,6 +2757,7 @@ public partial class CpuEngine : ITensorLevelEngine
 #endif
     public virtual unsafe Tensor<T> TensorAdd<T>(Tensor<T> a, Tensor<T> b)
     {
+        using var _opScope = AiDotNet.Tensors.Engines.Profiling.Profiler.OpScope("TensorAdd");
         if (a == null) throw new ArgumentNullException(nameof(a));
         if (b == null) throw new ArgumentNullException(nameof(b));
         if (!ShapesMatch(a._shape, b._shape))
@@ -34516,6 +34517,7 @@ public partial class CpuEngine : ITensorLevelEngine
 
     public virtual Tensor<T> FusedLinear<T>(Tensor<T> input, Tensor<T> weights, Tensor<T>? bias, FusedActivationType activation, FusedActivationParams? activationParams = null)
     {
+        using var _opScope = AiDotNet.Tensors.Engines.Profiling.Profiler.OpScope("FusedLinear");
         if (input == null) throw new ArgumentNullException(nameof(input));
         if (weights == null) throw new ArgumentNullException(nameof(weights));
 
@@ -34626,6 +34628,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var outArr = (float[])(object)result.GetDataArray();
 
                 bool blasDone = false;
+                var _ffnGemmScope = AiDotNet.Tensors.Engines.Profiling.Profiler.OpScope("FFN.GEMM");
 
 #if !NET471
                 // Tier -3 (opt-in, AIDOTNET_JIT_GEMM=1): our runtime-JIT'd AVX2 kernel.
@@ -34731,9 +34734,12 @@ public partial class CpuEngine : ITensorLevelEngine
                     }
                 }
 
+                _ffnGemmScope.Dispose();
+
                 // Fused bias + activation in one pass
                 if (bias != null || activation != FusedActivationType.None)
                 {
+                    using var _ffnEpi = AiDotNet.Tensors.Engines.Profiling.Profiler.OpScope("FFN.Epilogue");
                     var bArr = bias != null ? (float[])(object)bias.GetDataArray() : null;
                     CpuFusedOperations.ApplyBiasActivationInPlace(outArr, bArr, M, N, activation, activationParams);
                 }

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -21578,6 +21578,17 @@ public partial class CpuEngine : ITensorLevelEngine
     private static readonly bool _layerNormFusedFs64Enabled =
         Environment.GetEnvironmentVariable("AIDOTNET_LAYERNORM_FUSED_FS64") != "0";
 
+    // Batch-size ceiling for the register-resident single-pass fs=64 LayerNorm.
+    // A/B verdict (recorded inline at the fast path): the fused form WINS at small
+    // batch ([1024,64]: 133µs->117µs, +13%) — the transformer/LSTM inference shapes —
+    // but LOSES at BERT-scale ([32768,64]: +5% for 2-pass), because at huge batch the
+    // streaming prefetcher already hides the second read and the fused form's larger
+    // register footprint/code dominates. So the fused path is gated to batchSize at or
+    // below this ceiling; larger LayerNorms take the 4-way-unrolled 2-pass form.
+    private static readonly int _lnFusedFs64MaxBatch =
+        int.TryParse(Environment.GetEnvironmentVariable("AIDOTNET_LN_FUSED_MAXBATCH"), out var lfm) && lfm > 0
+            ? lfm : 8192;
+
     internal void LayerNormFloatInto(
         Tensor<float> input, Tensor<float> gamma, Tensor<float> beta,
         double epsilon, Tensor<float> output)
@@ -21656,11 +21667,16 @@ public partial class CpuEngine : ITensorLevelEngine
         // Raised to 512K elements so small/medium LayerNorms (transformers at modest
         // batch×seq) stay serial; large ones (BERT-scale, millions of elements, where
         // serial is ms and dwarfs the wakeup) still parallelize. Env-tunable.
+        // Enable the register-resident single-pass fs=64 fast path only for batch
+        // sizes where it is profiled to win (see _lnFusedFs64MaxBatch). fs==64 is the
+        // common transformer/LSTM hidden width; the path requires the AVX2 branch.
+        bool fusedFs64 = useSimd && _layerNormFusedFs64Enabled && fs == 64 && batchSize <= _lnFusedFs64MaxBatch;
+
         long lnWork = (long)batchSize * fs;
         if (lnWork < _lnParallelMinWork && batchSize < _lnParallelMinRows)
         {
             for (int b = 0; b < batchSize; b++)
-                ProcessRow(fInput, fGamma, fBeta, fOutput, fMean, fVar, b, fs, fEps, useSimd);
+                ProcessRow(fInput, fGamma, fBeta, fOutput, fMean, fVar, b, fs, fEps, useSimd, fusedFs64);
         }
         else
         {
@@ -21679,7 +21695,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 int start = c * chunkSize;
                 int end = Math.Min(start + chunkSize, totalBatch);
                 for (int b = start; b < end; b++)
-                    ProcessRow(fInput, fGamma, fBeta, fOutput, fMean, fVar, b, fs, fEps, useSimd);
+                    ProcessRow(fInput, fGamma, fBeta, fOutput, fMean, fVar, b, fs, fEps, useSimd, fusedFs64);
             });
         }
     }
@@ -21688,7 +21704,7 @@ public partial class CpuEngine : ITensorLevelEngine
     private static void ProcessRow(
         float[] fInput, float[] fGamma, float[] fBeta,
         float[] fOutput, float[] fMean, float[] fVar,
-        int b, int fs, float fEps, bool useSimd)
+        int b, int fs, float fEps, bool useSimd, bool fusedFs64 = false)
     {
         int off = b * fs;
         float m, v2;
@@ -21784,7 +21800,7 @@ public partial class CpuEngine : ITensorLevelEngine
             // fast path — keeping this comment so the lesson is preserved.
             // To re-attempt later, write the kernel with explicit XSAVE-aware
             // accumulator passing.
-            if (false && _layerNormFusedFs64Enabled)
+            if (fusedFs64)
             {
                 // Load all 8 input vectors once.
                 var v0 = System.Runtime.CompilerServices.Unsafe.ReadUnaligned<System.Runtime.Intrinsics.Vector256<float>>(

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -11738,6 +11738,13 @@ public partial class CpuEngine : ITensorLevelEngine
         int.TryParse(System.Environment.GetEnvironmentVariable("AIDOTNET_CACHEDB_MAXM"), out var cbm) && cbm >= 0
             ? cbm : 1024;
 
+    // Opt-in head-to-head (AIDOTNET_ONEDNN_GEMM=1): route float 2D matmul through
+    // oneDNN's JIT'd dnnl_sgemm (shape-specialized brgemm microkernel, the MKL-
+    // class reference) instead of the managed SimdGemm kernel. Lets us measure
+    // how far a JIT'd kernel closes the small-K/N GFLOP/s gap. Default OFF.
+    private static readonly bool _oneDnnGemm =
+        System.Environment.GetEnvironmentVariable("AIDOTNET_ONEDNN_GEMM") == "1";
+
     /// <summary>
     /// Standard 2D matrix multiplication: [M, N] @ [N, P] = [M, P]
     /// Uses BLAS when available for float/double, falls back to parallel loops otherwise.
@@ -11809,6 +11816,26 @@ public partial class CpuEngine : ITensorLevelEngine
         // worker-pool wakeup overhead. Above the cutover (large M) native BLAS's raw
         // throughput wins, so keep TryGemm there. Numerically equivalent to the native
         // path (float reduction-order only). M-cutover env-tunable (AIDOTNET_CACHEDB_MAXM).
+#if !NET471
+        // oneDNN JIT'd GEMM head-to-head (opt-in). C[m,p] = A[m,n]·B[n,p], row-major
+        // ⇒ TrySgemm(M=m, K=n, N=p). Falls through to the managed kernel if oneDNN
+        // is unavailable (TrySgemm returns false without mutating C).
+        if (_oneDnnGemm && typeof(T) == typeof(float) && a.IsContiguous && b.IsContiguous)
+        {
+            var aArrO = (float[])(object)a.GetDataArray();
+            var bArrO = (float[])(object)b.GetDataArray();
+            var rArrO = (float[])(object)result.GetDataArray();
+            unsafe
+            {
+                fixed (float* pA = aArrO, pB = bArrO, pC = rArrO)
+                {
+                    if (OneDnnProvider.TrySgemm(pA, pB, pC, m, n, p))
+                        return result;
+                }
+            }
+        }
+#endif
+
         if (typeof(T) == typeof(float) && a.IsContiguous && b.IsContiguous
             && m <= _cachedBMaxM)
         {
@@ -34583,6 +34610,26 @@ public partial class CpuEngine : ITensorLevelEngine
                 var outArr = (float[])(object)result.GetDataArray();
 
                 bool blasDone = false;
+
+#if !NET471
+                // Tier -2 (opt-in, AIDOTNET_ONEDNN_GEMM=1): oneDNN JIT'd dnnl_sgemm.
+                // The fused-linear (FFN) GEMM is exactly the small-K/N shape where
+                // oneDNN's shape-specialized brgemm hits 540+ GFLOP/s vs ~70-110 for
+                // the managed kernel (head-to-head measured). Bias+activation still
+                // run in the shared SIMD epilogue below. Size-gated so tiny GEMMs
+                // (where oneDNN's per-call dispatch loses) stay on the managed path.
+                if (!blasDone && _oneDnnGemm && (long)M * K * N >= 262_144)
+                {
+                    unsafe
+                    {
+                        fixed (float* pIn = inArr, pW = wArr, pOut = outArr)
+                        {
+                            if (OneDnnProvider.TrySgemm(pIn, pW, pOut, M, K, N))
+                                blasDone = true;
+                        }
+                    }
+                }
+#endif
 
                 // Phase 1 (compiled-inference): for small/medium inference GEMMs the
                 // managed cached-B path wins 1.3-2.8x over native BLAS + pinned copy —

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -11730,6 +11730,14 @@ public partial class CpuEngine : ITensorLevelEngine
         return outShape;
     }
 
+    // Small/medium-M cutover for the auto-caching managed cached-B GEMM in
+    // TensorMatMul2D (see the SgemmWithCachedB route below). At/below this M the
+    // packed managed kernel beats native BLAS; above it native's raw throughput
+    // wins. Calibrated from the GFLOP/s-vs-M crossover; env-overridable.
+    private static readonly int _cachedBMaxM =
+        int.TryParse(System.Environment.GetEnvironmentVariable("AIDOTNET_CACHEDB_MAXM"), out var cbm) && cbm >= 0
+            ? cbm : 1024;
+
     /// <summary>
     /// Standard 2D matrix multiplication: [M, N] @ [N, P] = [M, P]
     /// Uses BLAS when available for float/double, falls back to parallel loops otherwise.
@@ -11789,6 +11797,27 @@ public partial class CpuEngine : ITensorLevelEngine
                     return result;
                 }
             }
+        }
+
+        // Small/medium-M float fast path: route through the pack-fresh tiled managed
+        // kernel (SimdGemm.Sgemm → SgemmTiled). It packs B every call (NO identity
+        // cache — safe when B is mutated in place between calls, e.g. training weights
+        // updated by the optimizer; the cached-B kernel would serve a stale pack here),
+        // yet still measures ~2.2× over the default TryGemm path at small M:
+        // [64×784]×[784×512] ~40 GFLOP/s (min-of-12, fresh B every call) vs ~19 for
+        // TryGemm, whose small-M native/dispatch path leaves cores idle and pays
+        // worker-pool wakeup overhead. Above the cutover (large M) native BLAS's raw
+        // throughput wins, so keep TryGemm there. Numerically equivalent to the native
+        // path (float reduction-order only). M-cutover env-tunable (AIDOTNET_CACHEDB_MAXM).
+        if (typeof(T) == typeof(float) && a.IsContiguous && b.IsContiguous
+            && m <= _cachedBMaxM)
+        {
+            var aArrF = (float[])(object)a.GetDataArray();
+            var bArrF = (float[])(object)b.GetDataArray();
+            var rArrF = (float[])(object)result.GetDataArray();
+            Simd.SimdGemm.Sgemm(aArrF.AsSpan(0, m * n), n, false, bArrF.AsSpan(0, n * p), p, false,
+                                rArrF.AsSpan(0, m * p), m, n, p);
+            return result;
         }
 
         // Try BLAS-accelerated path for float/double tensors

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -11745,6 +11745,12 @@ public partial class CpuEngine : ITensorLevelEngine
     private static readonly bool _oneDnnGemm =
         System.Environment.GetEnvironmentVariable("AIDOTNET_ONEDNN_GEMM") == "1";
 
+    // Opt-in (AIDOTNET_JIT_GEMM=1): route float matmul through the runtime-JIT'd
+    // AVX2 kernel (Simd.JitGemmAvx2) — beats managed + oneDNN on small-K/N, on our
+    // own thread pool (no oversubscription). Default OFF.
+    private static readonly bool _jitGemm =
+        System.Environment.GetEnvironmentVariable("AIDOTNET_JIT_GEMM") == "1";
+
     /// <summary>
     /// Standard 2D matrix multiplication: [M, N] @ [N, P] = [M, P]
     /// Uses BLAS when available for float/double, falls back to parallel loops otherwise.
@@ -11817,6 +11823,16 @@ public partial class CpuEngine : ITensorLevelEngine
         // throughput wins, so keep TryGemm there. Numerically equivalent to the native
         // path (float reduction-order only). M-cutover env-tunable (AIDOTNET_CACHEDB_MAXM).
 #if !NET471
+        // Our JIT'd AVX2 GEMM (opt-in). C[m,p] = A[m,n]·B[n,p] ⇒ TryMultiply(M=m,N=p,K=n).
+        if (_jitGemm && typeof(T) == typeof(float) && a.IsContiguous && b.IsContiguous)
+        {
+            var aJ = (float[])(object)a.GetDataArray();
+            var bJ = (float[])(object)b.GetDataArray();
+            var rJ = (float[])(object)result.GetDataArray();
+            if (Simd.JitGemmAvx2.TryMultiply(aJ.AsSpan(0, m * n), bJ.AsSpan(0, n * p), rJ.AsSpan(0, m * p), m, p, n))
+                return result;
+        }
+
         // oneDNN JIT'd GEMM head-to-head (opt-in). C[m,p] = A[m,n]·B[n,p], row-major
         // ⇒ TrySgemm(M=m, K=n, N=p). Falls through to the managed kernel if oneDNN
         // is unavailable (TrySgemm returns false without mutating C).
@@ -34612,6 +34628,13 @@ public partial class CpuEngine : ITensorLevelEngine
                 bool blasDone = false;
 
 #if !NET471
+                // Tier -3 (opt-in, AIDOTNET_JIT_GEMM=1): our runtime-JIT'd AVX2 kernel.
+                // Beats managed + oneDNN on the small-K/N FFN shape, on our own pool.
+                // Bias+activation still run in the shared SIMD epilogue below.
+                if (!blasDone && _jitGemm
+                    && Simd.JitGemmAvx2.TryMultiply(inArr.AsSpan(0, M * K), wArr.AsSpan(0, K * N), outArr.AsSpan(0, M * N), M, N, K))
+                    blasDone = true;
+
                 // Tier -2 (opt-in, AIDOTNET_ONEDNN_GEMM=1): oneDNN JIT'd dnnl_sgemm.
                 // The fused-linear (FFN) GEMM is exactly the small-K/N shape where
                 // oneDNN's shape-specialized brgemm hits 540+ GFLOP/s vs ~70-110 for

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -21624,6 +21624,17 @@ public partial class CpuEngine : ITensorLevelEngine
         long.TryParse(System.Environment.GetEnvironmentVariable("AIDOTNET_LN_PARALLEL_MINWORK"), out var lnw) && lnw > 0
             ? lnw : 524_288;
 
+    // Row-count parallel gate: a LayerNorm over many independent rows parallelizes
+    // well even when total elements are below _lnParallelMinWork — the work-only
+    // threshold left the transformer's [4096,64] (262K < 524K) serial, but it has
+    // 4096 independent rows and parallel is 2.5× faster (0.33→0.13 ms/call, −17%
+    // on the bs128 forward). Gate on rows so large-row/small-feature LayerNorms
+    // parallelize while small-row ones (e.g. [1024,64], where the park/wakeup floor
+    // dominated) stay serial. Env-tunable.
+    private static readonly int _lnParallelMinRows =
+        int.TryParse(System.Environment.GetEnvironmentVariable("AIDOTNET_LN_PARALLEL_MINROWS"), out var lnr) && lnr > 0
+            ? lnr : 2048;
+
     private static void ProcessBatchesSimd(
         float[] fInput, float[] fGamma, float[] fBeta,
         float[] fOutput, float[] fMean, float[] fVar,
@@ -21646,7 +21657,7 @@ public partial class CpuEngine : ITensorLevelEngine
         // batch×seq) stay serial; large ones (BERT-scale, millions of elements, where
         // serial is ms and dwarfs the wakeup) still parallelize. Env-tunable.
         long lnWork = (long)batchSize * fs;
-        if (lnWork < _lnParallelMinWork)
+        if (lnWork < _lnParallelMinWork && batchSize < _lnParallelMinRows)
         {
             for (int b = 0; b < batchSize; b++)
                 ProcessRow(fInput, fGamma, fBeta, fOutput, fMean, fVar, b, fs, fEps, useSimd);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -17,6 +17,13 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA;
 
 public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernels, AiDotNet.Tensors.Engines.Gpu.IGpuHalfPrecisionBackend
 {
+    // During teardown the CUDA driver/context may already be destroyed, so calling driver
+    // APIs (cuCtxPushCurrent / cuMemFree / cuCtxPopCurrent / cuCtxDestroy / cuModuleUnload)
+    // from a finalizer raises an access violation (0xC0000005) — a Corrupted-State
+    // Exception that catch cannot trap and that is fatal on the finalizer thread, killing
+    // the whole process. The OS reclaims device memory + the context at exit anyway.
+    private static bool IsRuntimeTearingDown => RuntimeShutdown.IsTearingDown;
+
     private const int DefaultBlockSize = 256;
     private const int MaxRnnBlockSize = 1024;
     private readonly ConcurrentDictionary<string, IntPtr> _kernelCache;
@@ -12481,10 +12488,30 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
 
     public void Dispose()
     {
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
+    }
+
+    private void Dispose(bool disposing)
+    {
         if (_disposed)
             return;
 
         _disposed = true;
+
+        // Finalizer path (disposing == false) or any process/domain teardown:
+        //   - The managed members (GpuBufferPool's ConcurrentBag/ThreadLocal, the cuDNN
+        //     helpers) may already have been finalized by the runtime — touching them
+        //     throws ObjectDisposedException from the finalizer thread (fatal).
+        //   - The CUDA context may already be destroyed — every driver call below
+        //     (cublasDestroy / cuStreamDestroy / cuModuleUnload / cuCtxDestroy) would
+        //     raise an uncatchable access violation (0xC0000005), also finalizer-fatal.
+        // The OS reclaims the context and all device memory at process exit, so the only
+        // safe action here is to do nothing. Explicit Dispose during normal operation
+        // (disposing == true, not tearing down) still performs the full native cleanup.
+        if (!disposing || IsRuntimeTearingDown)
+            return;
+
         _pinnedPool.Dispose();
         _bufferPool.Dispose();
 
@@ -13443,7 +13470,8 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
 
     ~CudaBackend()
     {
-        Dispose();
+        // Finalizer: never touch managed members or the CUDA driver — see Dispose(bool).
+        Dispose(disposing: false);
     }
 
     internal sealed class CudaGpuBuffer : IGpuBuffer, IPoolableGpuBuffer
@@ -13479,18 +13507,25 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
             if (_devicePtr == IntPtr.Zero)
                 return;
 
-            try
+            // During CLR/AppDomain teardown the CUDA context may already be gone;
+            // calling the driver here raises an uncatchable, finalizer-fatal access
+            // violation. Skip the native free (the OS reclaims device memory at exit)
+            // and just clear the handles.
+            if (!IsRuntimeTearingDown)
             {
-                if (_context != IntPtr.Zero)
+                try
                 {
-                    CuBlasNative.cuCtxPushCurrent(_context);
-                    CuBlasNative.cuMemFree(_devicePtr);
-                    CuBlasNative.cuCtxPopCurrent(out _);
+                    if (_context != IntPtr.Zero)
+                    {
+                        CuBlasNative.cuCtxPushCurrent(_context);
+                        CuBlasNative.cuMemFree(_devicePtr);
+                        CuBlasNative.cuCtxPopCurrent(out _);
+                    }
                 }
-            }
-            catch
-            {
-                // Suppress disposal errors to avoid crashing finalizers.
+                catch
+                {
+                    // Suppress disposal errors to avoid crashing finalizers.
+                }
             }
 
             _devicePtr = IntPtr.Zero;
@@ -13548,18 +13583,23 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
             if (_devicePtr == IntPtr.Zero)
                 return;
 
-            try
+            // See CudaGpuBuffer.Release: skip native CUDA calls during teardown to
+            // avoid a finalizer-fatal access violation on an already-destroyed context.
+            if (!IsRuntimeTearingDown)
             {
-                if (_context != IntPtr.Zero)
+                try
                 {
-                    CuBlasNative.cuCtxPushCurrent(_context);
-                    CuBlasNative.cuMemFree(_devicePtr);
-                    CuBlasNative.cuCtxPopCurrent(out _);
+                    if (_context != IntPtr.Zero)
+                    {
+                        CuBlasNative.cuCtxPushCurrent(_context);
+                        CuBlasNative.cuMemFree(_devicePtr);
+                        CuBlasNative.cuCtxPopCurrent(out _);
+                    }
                 }
-            }
-            catch
-            {
-                // Suppress disposal errors to avoid crashing finalizers.
+                catch
+                {
+                    // Suppress disposal errors to avoid crashing finalizers.
+                }
             }
 
             _devicePtr = IntPtr.Zero;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/GpuBufferPool.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/GpuBufferPool.cs
@@ -112,14 +112,31 @@ internal sealed class GpuBufferPool<TBuffer> : IDisposable where TBuffer : class
             return;
         }
 
-        foreach (var bucket in _buckets.Values)
+        // At process/AppDomain teardown the ConcurrentBag's backing ThreadLocal may
+        // already be finalized (TryTake then throws ObjectDisposedException) and the GPU
+        // context may be gone (buffer.Release would fault). Either is fatal on the
+        // finalizer thread. The OS reclaims all device memory at exit, so skip the drain.
+        if (AiDotNet.Tensors.Engines.RuntimeShutdown.IsTearingDown)
         {
-            while (bucket.Buffers.TryTake(out var buffer))
-            {
-                buffer.Release();
-            }
+            return;
         }
 
-        _buckets.Clear();
+        try
+        {
+            foreach (var bucket in _buckets.Values)
+            {
+                while (bucket.Buffers.TryTake(out var buffer))
+                {
+                    buffer.Release();
+                }
+            }
+
+            _buckets.Clear();
+        }
+        catch (ObjectDisposedException)
+        {
+            // A concurrent teardown disposed the bag's ThreadLocal mid-drain. Cleanup is
+            // best-effort here (OS reclaims at exit); never let it crash the finalizer.
+        }
     }
 }

--- a/src/AiDotNet.Tensors/Engines/RuntimeShutdown.cs
+++ b/src/AiDotNet.Tensors/Engines/RuntimeShutdown.cs
@@ -1,0 +1,49 @@
+using System;
+
+namespace AiDotNet.Tensors.Engines;
+
+/// <summary>
+/// Process/AppDomain teardown detection shared by GPU backends and pools.
+/// </summary>
+/// <remarks>
+/// <para>
+/// During CLR shutdown or AppDomain unload, finalizers run after much of the
+/// runtime state has already been torn down: <see cref="System.Threading.ThreadLocal{T}"/>
+/// instances (and the <see cref="System.Collections.Concurrent.ConcurrentBag{T}"/> built
+/// on them) may already be finalized, and native GPU drivers/contexts may already be
+/// unloaded. Touching either from a finalizer then throws
+/// <see cref="ObjectDisposedException"/> or raises an access violation (0xC0000005) — both
+/// fatal on the finalizer thread, killing the whole process.
+/// </para>
+/// <para>
+/// <see cref="Environment.HasShutdownStarted"/> alone proved unreliable (some hosts — e.g.
+/// the vstest test host — run finalizers without that flag being set), so this type also
+/// latches a flag from the <see cref="AppDomain.ProcessExit"/> / <see cref="AppDomain.DomainUnload"/>
+/// events, which fire before the final finalizer sweep.
+/// </para>
+/// </remarks>
+internal static class RuntimeShutdown
+{
+    private static volatile bool _exiting;
+
+    static RuntimeShutdown()
+    {
+        try
+        {
+            AppDomain.CurrentDomain.ProcessExit += static (_, _) => _exiting = true;
+            AppDomain.CurrentDomain.DomainUnload += static (_, _) => _exiting = true;
+        }
+        catch
+        {
+            // If subscription fails in some constrained host, callers still have the
+            // finalizer-path (disposing == false) guard as the primary protection.
+        }
+    }
+
+    /// <summary>
+    /// True once the process/domain has begun tearing down. Finalizer-reachable cleanup
+    /// must skip all native driver calls and cross-object managed access when this is true.
+    /// </summary>
+    internal static bool IsTearingDown =>
+        _exiting || Environment.HasShutdownStarted || AppDomain.CurrentDomain.IsFinalizingForUnload();
+}

--- a/src/AiDotNet.Tensors/Engines/Simd/JitGemmAvx2.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/JitGemmAvx2.cs
@@ -63,6 +63,20 @@ internal static unsafe class JitGemmAvx2
 
     private const int JIT_MIN_WORK = 1 << 18; // skip tiny GEMMs (dispatch not amortized)
 
+    // Opt-in master gate (AIDOTNET_JIT_GEMM=1). Centralized here so every GEMM
+    // entry point (Sgemm, SgemmWithCachedB, TensorMatMul2D, FusedLinear, MlpForward,
+    // CompiledMlp) can route through TryMultiply without each re-reading the env.
+    private static readonly bool _enabled =
+        System.Environment.GetEnvironmentVariable("AIDOTNET_JIT_GEMM") == "1";
+
+    // Minimum M (rows) for the JIT to engage. The JIT wins at large M (many 6-row
+    // blocks to parallelize, prologue amortized — e.g. the transformer FFN/QKV at
+    // M=B*seq=4096), but LOSES at small M (e.g. MLP at M=batch≤128), where the
+    // tuned managed/native kernels (CompiledMlp) beat it and forcing JIT regressed
+    // the MLP ~2×. Below this, TryMultiply declines and the caller keeps its path.
+    private static readonly int _jitMinM =
+        int.TryParse(System.Environment.GetEnvironmentVariable("AIDOTNET_JIT_MIN_M"), out var jm) && jm > 0 ? jm : 512;
+
     /// <summary>
     /// C[M,N] = A[M,K]·B[K,N], row-major, contiguous (lda=K, ldb=N, ldc=N).
     /// Returns false (no mutation) when unavailable / too small, so the caller
@@ -70,7 +84,7 @@ internal static unsafe class JitGemmAvx2
     /// </summary>
     internal static bool TryMultiply(ReadOnlySpan<float> a, ReadOnlySpan<float> b, Span<float> c, int M, int N, int K)
     {
-        if (!Available || M < 6 || N < 16 || (long)M * N * K < JIT_MIN_WORK) return false;
+        if (!_enabled || !Available || M < _jitMinM || N < 16 || (long)M * N * K < JIT_MIN_WORK) return false;
 
         int Mfull = M - M % 6, Nfull = N - N % 16;
         int numRB = Mfull / 6, numCB = Nfull / 16;

--- a/src/AiDotNet.Tensors/Engines/Simd/JitGemmAvx2.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/JitGemmAvx2.cs
@@ -36,6 +36,14 @@ internal static unsafe class JitGemmAvx2
     // void kernel(float* A, float* B, float* C, long K, long lda, long ldb, long ldc)
     private static readonly delegate* unmanaged[Cdecl]<float*, float*, float*, long, long, long, long, void> _kernel;
 
+    // void panel(float* A, float* B, float* C, long K, long lda, long ldb, long ldc, long numCB)
+    // Does 6 rows × (numCB*16) cols in ONE call — the column-block loop lives INSIDE
+    // the asm, so for small K the per-call managed->native transition + Win64
+    // prologue (save/restore xmm6-15) is paid once per ROW-block instead of once per
+    // (row,col)-block. That overhead is what made the per-tile _kernel lose to the
+    // managed kernel on the K=64 shapes (transformer FFN/QKV, LSTM recurrence).
+    private static readonly delegate* unmanaged[Cdecl]<float*, float*, float*, long, long, long, long, long, void> _panelKernel;
+
     /// <summary>True when the JIT kernel was emitted successfully (Windows x64 + AVX2 + FMA).</summary>
     internal static readonly bool Available;
 
@@ -50,15 +58,23 @@ internal static unsafe class JitGemmAvx2
                 Available = false;
                 return;
             }
-            byte[] mc = Emit6x16Unpacked();
-            IntPtr mem = VirtualAlloc(IntPtr.Zero, (UIntPtr)mc.Length, MEM_COMMIT | MEM_RESERVE, PAGE_RW);
-            if (mem == IntPtr.Zero) { Available = false; return; }
-            Marshal.Copy(mc, 0, mem, mc.Length);
-            if (!VirtualProtect(mem, (UIntPtr)mc.Length, PAGE_EXEC_R, out _)) { Available = false; return; }
-            _kernel = (delegate* unmanaged[Cdecl]<float*, float*, float*, long, long, long, long, void>)mem;
-            Available = true;
+            _kernel = (delegate* unmanaged[Cdecl]<float*, float*, float*, long, long, long, long, void>)
+                Publish(Emit6x16Unpacked());
+            _panelKernel = (delegate* unmanaged[Cdecl]<float*, float*, float*, long, long, long, long, long, void>)
+                Publish(Emit6xNPanel());
+            Available = _kernel != null && _panelKernel != null;
         }
         catch { Available = false; }
+    }
+
+    // Copy machine code into W^X executable memory and return the entry pointer.
+    private static IntPtr Publish(byte[] mc)
+    {
+        IntPtr mem = VirtualAlloc(IntPtr.Zero, (UIntPtr)mc.Length, MEM_COMMIT | MEM_RESERVE, PAGE_RW);
+        if (mem == IntPtr.Zero) return IntPtr.Zero;
+        Marshal.Copy(mc, 0, mem, mc.Length);
+        if (!VirtualProtect(mem, (UIntPtr)mc.Length, PAGE_EXEC_R, out _)) return IntPtr.Zero;
+        return mem;
     }
 
     private const int JIT_MIN_WORK = 1 << 18; // skip tiny GEMMs (dispatch not amortized)
@@ -125,7 +141,7 @@ internal static unsafe class JitGemmAvx2
         finally { System.Buffers.ArrayPool<float>.Shared.Return(scratch); }
     }
 
-    private static void RunJit(ReadOnlySpan<float> a, ReadOnlySpan<float> b, Span<float> c, int M, int N, int K)
+    internal static void RunJit(ReadOnlySpan<float> a, ReadOnlySpan<float> b, Span<float> c, int M, int N, int K)
     {
         int Mfull = M - M % 6, Nfull = N - N % 16;
         int numRB = Mfull / 6, numCB = Nfull / 16;
@@ -153,27 +169,26 @@ internal static unsafe class JitGemmAvx2
                     Helpers.PersistentParallelExecutor.Instance.Execute(chunks, chunk =>
                     {
                         int lo = chunk * perChunk, hi = Math.Min(lo + perChunk, totalRB);
-                        var kf = _kernel;
+                        var pk = _panelKernel;
                         float* aP = (float*)A, bP = (float*)B, cP = (float*)C;
                         for (int rb = lo; rb < hi; rb++)
                         {
                             float* aRow = aP + (long)(rb * 6) * kk;
                             float* cRow = cP + (long)(rb * 6) * nn;
-                            for (int cb = 0; cb < ncb; cb++)
-                                kf(aRow, bP + cb * 16, cRow + cb * 16, kk, kk, nn, nn);
+                            // One call does all ncb column-blocks for this row-block.
+                            pk(aRow, bP, cRow, kk, kk, nn, nn, ncb);
                         }
                     });
                 }
                 else
                 {
-                    var kf = _kernel;
+                    var pk = _panelKernel;
                     float* aP = (float*)A, bP = (float*)B, cP = (float*)C;
                     for (int rb = 0; rb < numRB; rb++)
                     {
                         float* aRow = aP + (long)(rb * 6) * kk;
                         float* cRow = cP + (long)(rb * 6) * nn;
-                        for (int cb = 0; cb < ncb; cb++)
-                            kf(aRow, bP + cb * 16, cRow + cb * 16, kk, kk, nn, nn);
+                        pk(aRow, bP, cRow, kk, kk, nn, nn, ncb);
                     }
                 }
             }
@@ -281,6 +296,120 @@ internal static unsafe class JitGemmAvx2
         for (int x = 6; x <= 15; x++) Mov128(0x10, x, RSP, (x - 6) * 16); // restore xmm
         Bytes(0x48, 0x81, 0xC4, 160, 0, 0, 0);                 // add rsp,160
         Pop(RSI); Pop(RBX);
+        Bytes(0xC5, 0xF8, 0x77); Bytes(0xC3);                  // vzeroupper; ret
+        return code.ToArray();
+    }
+
+    // ===================== 6×N panel kernel =====================
+    // void panel(A, B, C, K, lda, ldb, ldc, numCB): C[6, numCB*16] = A[6,K]·B[K, numCB*16].
+    // Same 6×16 microkernel as above, but the column-block loop is emitted INSIDE so
+    // the prologue/epilogue + managed->native transition is paid once per row-block,
+    // not once per tile. Win64 args: RCX=A RDX=B R8=C R9=K ;
+    // lda=[rsp+0x28] ldb=[rsp+0x30] ldc=[rsp+0x38] numCB=[rsp+0x40].
+    // Register map inside: RAX=lda*4, R10=ldb*4, R11=ldc*4 (consts);
+    // R12=A base, R13=B column base (advances 64B/cb), R14=C column base (advances 64B/cb),
+    // R15=K, RBP=cb counter; RCX/RBX/RSI=A row bases, RDX=B, R8=C, R9=k (per-cb working).
+    private static byte[] Emit6xNPanel()
+    {
+        var code = new List<byte>(700);
+        void Bytes(params byte[] bs) => code.AddRange(bs);
+        void Vrr(int mm, int pp, byte op, int reg, int vvvv, int rm) => Bytes(0xC4,
+            (byte)(((reg < 8 ? 1 : 0) << 7) | (1 << 6) | ((rm < 8 ? 1 : 0) << 5) | mm),
+            (byte)((((~vvvv) & 0xF) << 3) | (1 << 2) | pp),
+            op, (byte)(0xC0 | ((reg & 7) << 3) | (rm & 7)));
+        void Vrm(int mm, int pp, byte op, int reg, int b, int disp)
+        {
+            Bytes(0xC4, (byte)(((reg < 8 ? 1 : 0) << 7) | (1 << 6) | ((b < 8 ? 1 : 0) << 5) | mm),
+                  (byte)((0xF << 3) | (1 << 2) | pp), op);
+            int rm = b & 7; bool sib = rm == 4; int mod = disp == 0 ? 0 : (disp is >= -128 and <= 127 ? 1 : 2);
+            Bytes((byte)((mod << 6) | ((reg & 7) << 3) | rm));
+            if (sib) Bytes(0x24);
+            if (mod == 1) Bytes((byte)(sbyte)disp);
+            else if (mod == 2) Bytes((byte)disp, (byte)(disp >> 8), (byte)(disp >> 16), (byte)(disp >> 24));
+        }
+        void VrmBase(int mm, int pp, byte op, int reg, int b) => Bytes(0xC4,
+            (byte)(((reg < 8 ? 1 : 0) << 7) | (1 << 6) | ((b < 8 ? 1 : 0) << 5) | mm),
+            (byte)((0xF << 3) | (1 << 2) | pp), op, (byte)(((reg & 7) << 3) | (b & 7)));
+        void VrmIdx(int mm, int pp, byte op, int reg, int b, int idx) => Bytes(0xC4,
+            (byte)(((reg < 8 ? 1 : 0) << 7) | ((idx < 8 ? 1 : 0) << 6) | ((b < 8 ? 1 : 0) << 5) | mm),
+            (byte)((0xF << 3) | (1 << 2) | pp), op, (byte)(((reg & 7) << 3) | 4), (byte)(((idx & 7) << 3) | (b & 7)));
+        void Mov128(byte op, int reg, int b, int disp)
+        {
+            Bytes(0xC4, (byte)(((reg < 8 ? 1 : 0) << 7) | (1 << 6) | ((b < 8 ? 1 : 0) << 5) | 1),
+                  (byte)((0xF << 3) | 0), op);
+            int rm = b & 7; bool sib = rm == 4; int mod = disp == 0 ? 0 : 1;
+            Bytes((byte)((mod << 6) | ((reg & 7) << 3) | rm)); if (sib) Bytes(0x24); if (mod == 1) Bytes((byte)disp);
+        }
+        void MovFromStack(int dst, byte disp) => Bytes((byte)(0x48 | (dst >= 8 ? 4 : 0)), 0x8B, (byte)(0x44 | ((dst & 7) << 3)), 0x24, disp);
+        void Shl4(int r) => Bytes((byte)(0x48 | (r >= 8 ? 1 : 0)), 0xC1, (byte)(0xE0 | (r & 7)), 2);
+        void Lea(int dst, int b, int idx, int scale)
+        {
+            int sc = scale == 2 ? 1 : scale == 4 ? 2 : scale == 8 ? 3 : 0;
+            Bytes((byte)(0x48 | (dst >= 8 ? 4 : 0) | (idx >= 8 ? 2 : 0) | (b >= 8 ? 1 : 0)), 0x8D,
+                  (byte)(((dst & 7) << 3) | 4), (byte)((sc << 6) | ((idx & 7) << 3) | (b & 7)));
+        }
+        void AddImm(int r, byte imm) => Bytes((byte)(0x48 | (r >= 8 ? 1 : 0)), 0x83, (byte)(0xC0 | (r & 7)), imm);
+        void AddRegReg(int dst, int src) => Bytes((byte)(0x48 | (src >= 8 ? 4 : 0) | (dst >= 8 ? 1 : 0)), 0x01, (byte)(0xC0 | ((src & 7) << 3) | (dst & 7)));
+        void MovRR(int dst, int src) => Bytes((byte)(0x48 | (src >= 8 ? 4 : 0) | (dst >= 8 ? 1 : 0)), 0x89, (byte)(0xC0 | ((src & 7) << 3) | (dst & 7)));
+        void Push(int r) { if (r >= 8) Bytes(0x41); Bytes((byte)(0x50 | (r & 7))); }
+        void Pop(int r) { if (r >= 8) Bytes(0x41); Bytes((byte)(0x58 | (r & 7))); }
+        const int RAX = 0, RCX = 1, RDX = 2, RBX = 3, RSP = 4, RBP = 5, RSI = 6, R8 = 8, R9 = 9, R10 = 10, R11 = 11, R12 = 12, R13 = 13, R14 = 14, R15 = 15;
+
+        // Prologue: save 7 callee-saved GPRs (rbx,rsi,rbp,r12-r15). After these the
+        // caller's stack args sit at +0x28+0x38 = +0x60 (lda) … +0x78 (numCB).
+        Push(RBX); Push(RSI); Push(RBP); Push(R12); Push(R13); Push(R14); Push(R15);
+        MovRR(R12, RCX);                    // r12 = A base
+        MovRR(R13, RDX);                    // r13 = B column base
+        MovRR(R14, R8);                     // r14 = C column base
+        MovRR(R15, R9);                     // r15 = K
+        MovFromStack(RAX, 0x60); Shl4(RAX); // rax = lda*4
+        MovFromStack(R10, 0x68); Shl4(R10); // r10 = ldb*4
+        MovFromStack(R11, 0x70); Shl4(R11); // r11 = ldc*4
+        MovFromStack(RBP, 0x78);            // rbp = numCB
+        Bytes(0x48, 0x81, 0xEC, 160, 0, 0, 0);                 // sub rsp,160
+        for (int x = 6; x <= 15; x++) Mov128(0x11, x, RSP, (x - 6) * 16); // save xmm6..15
+
+        int cbLoop = code.Count;
+        // Per-column-block setup: reset A row bases, B/C working pointers, K.
+        MovRR(RCX, R12);            // rcx = A row0 base
+        Lea(RBX, R12, RAX, 2);      // rbx = A + 2*lda  (row2 base)
+        Lea(RSI, R12, RAX, 4);      // rsi = A + 4*lda  (row4 base)
+        MovRR(RDX, R13);            // rdx = B (this column block)
+        MovRR(R8, R14);             // r8  = C (this column block)
+        MovRR(R9, R15);             // r9  = k counter
+        for (int d = 0; d < 12; d++) Vrr(1, 0, 0x57, d, d, d);  // zero ymm0..11
+
+        int kLoop = code.Count;
+        Vrm(1, 0, 0x10, 12, RDX, 0); Vrm(1, 0, 0x10, 13, RDX, 32);   // B halves
+        VrmBase(2, 1, 0x18, 14, RCX); Vrr(2, 1, 0xB8, 0, 14, 12); Vrr(2, 1, 0xB8, 1, 14, 13);
+        VrmIdx(2, 1, 0x18, 14, RCX, RAX); Vrr(2, 1, 0xB8, 2, 14, 12); Vrr(2, 1, 0xB8, 3, 14, 13);
+        VrmBase(2, 1, 0x18, 14, RBX); Vrr(2, 1, 0xB8, 4, 14, 12); Vrr(2, 1, 0xB8, 5, 14, 13);
+        VrmIdx(2, 1, 0x18, 14, RBX, RAX); Vrr(2, 1, 0xB8, 6, 14, 12); Vrr(2, 1, 0xB8, 7, 14, 13);
+        VrmBase(2, 1, 0x18, 14, RSI); Vrr(2, 1, 0xB8, 8, 14, 12); Vrr(2, 1, 0xB8, 9, 14, 13);
+        VrmIdx(2, 1, 0x18, 14, RSI, RAX); Vrr(2, 1, 0xB8, 10, 14, 12); Vrr(2, 1, 0xB8, 11, 14, 13);
+        AddImm(RCX, 4); AddImm(RBX, 4); AddImm(RSI, 4); AddRegReg(RDX, R10);
+        Bytes(0x49, 0xFF, 0xC9);                               // dec r9
+        int afterK = code.Count;
+        Bytes(0x75, (byte)(sbyte)(kLoop - (afterK + 2)));      // jnz kLoop
+
+        // Store the 6×16 accumulators to C (r8), advancing by ldc between rows.
+        for (int r = 0; r < 6; r++)
+        {
+            Vrm(1, 0, 0x11, r * 2, R8, 0); Vrm(1, 0, 0x11, r * 2 + 1, R8, 32);
+            if (r < 5) AddRegReg(R8, R11);
+        }
+
+        // Next column block: B and C advance by 16 floats (64 bytes); dec cb; loop.
+        AddImm(R13, 64); AddImm(R14, 64);
+        Bytes(0x48, 0xFF, 0xCD);                               // dec rbp
+        int afterCb = code.Count;
+        int rel = cbLoop - (afterCb + 2);
+        if (rel is >= -128 and <= 127) Bytes(0x75, (byte)(sbyte)rel);  // jnz cbLoop (short)
+        else { int r32 = cbLoop - (afterCb + 6); Bytes(0x0F, 0x85, (byte)r32, (byte)(r32 >> 8), (byte)(r32 >> 16), (byte)(r32 >> 24)); }
+
+        for (int x = 6; x <= 15; x++) Mov128(0x10, x, RSP, (x - 6) * 16); // restore xmm
+        Bytes(0x48, 0x81, 0xC4, 160, 0, 0, 0);                 // add rsp,160
+        Pop(R15); Pop(R14); Pop(R13); Pop(R12); Pop(RBP); Pop(RSI); Pop(RBX);
         Bytes(0xC5, 0xF8, 0x77); Bytes(0xC3);                  // vzeroupper; ret
         return code.ToArray();
     }

--- a/src/AiDotNet.Tensors/Engines/Simd/JitGemmAvx2.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/JitGemmAvx2.cs
@@ -1,0 +1,234 @@
+#if !NET471
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics.X86;
+
+namespace AiDotNet.Tensors.Engines.Simd;
+
+/// <summary>
+/// Runtime-JIT'd AVX2 SGEMM for float, row-major C[M,N] = A[M,K]·B[K,N].
+///
+/// <para>A C# "Xbyak": emits a hand-scheduled, register-blocked 6×16 AVX2/FMA
+/// microkernel as raw machine code into W^X executable memory and calls it via a
+/// <c>delegate* unmanaged</c> pointer. The microkernel is UNPACKED (reads A via
+/// <c>lda</c>, B via <c>ldb</c>, writes C via <c>ldc</c>) so it needs no per-call
+/// packing or scatter, and K + strides are runtime arguments — so a SINGLE emitted
+/// kernel serves every shape (no per-shape JIT cache needed). The aligned interior
+/// (M−M%6 rows × N−N%16 cols) runs on the JIT kernel parallelized over
+/// <see cref="Helpers.PersistentParallelExecutor"/> (one pool — no oversubscription,
+/// unlike a bolted-on native BLAS); the M/N tails run on a managed scalar edge path.</para>
+///
+/// <para>Measured (AVX2, 16 threads, our own pool): 600–700 GFLOP/s on the small-K/N
+/// transformer shapes (QKV/FFN) vs ~70–113 for the generic managed kernel and ~540
+/// for oneDNN. Windows-x64 + AVX2 + FMA only; <see cref="Available"/> is false
+/// otherwise and callers fall back to the managed kernel.</para>
+/// </summary>
+internal static unsafe class JitGemmAvx2
+{
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern IntPtr VirtualAlloc(IntPtr addr, UIntPtr size, uint type, uint protect);
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool VirtualProtect(IntPtr addr, UIntPtr size, uint newProtect, out uint old);
+    private const uint MEM_COMMIT = 0x1000, MEM_RESERVE = 0x2000, PAGE_RW = 0x04, PAGE_EXEC_R = 0x20;
+
+    // void kernel(float* A, float* B, float* C, long K, long lda, long ldb, long ldc)
+    private static readonly delegate* unmanaged[Cdecl]<float*, float*, float*, long, long, long, long, void> _kernel;
+
+    /// <summary>True when the JIT kernel was emitted successfully (Windows x64 + AVX2 + FMA).</summary>
+    internal static readonly bool Available;
+
+    static JitGemmAvx2()
+    {
+        try
+        {
+            if (!OperatingSystem.IsWindows()
+                || RuntimeInformation.ProcessArchitecture != Architecture.X64
+                || !Avx2.IsSupported || !Fma.IsSupported)
+            {
+                Available = false;
+                return;
+            }
+            byte[] mc = Emit6x16Unpacked();
+            IntPtr mem = VirtualAlloc(IntPtr.Zero, (UIntPtr)mc.Length, MEM_COMMIT | MEM_RESERVE, PAGE_RW);
+            if (mem == IntPtr.Zero) { Available = false; return; }
+            Marshal.Copy(mc, 0, mem, mc.Length);
+            if (!VirtualProtect(mem, (UIntPtr)mc.Length, PAGE_EXEC_R, out _)) { Available = false; return; }
+            _kernel = (delegate* unmanaged[Cdecl]<float*, float*, float*, long, long, long, long, void>)mem;
+            Available = true;
+        }
+        catch { Available = false; }
+    }
+
+    private const int JIT_MIN_WORK = 1 << 18; // skip tiny GEMMs (dispatch not amortized)
+
+    /// <summary>
+    /// C[M,N] = A[M,K]·B[K,N], row-major, contiguous (lda=K, ldb=N, ldc=N).
+    /// Returns false (no mutation) when unavailable / too small, so the caller
+    /// falls back to the managed kernel.
+    /// </summary>
+    internal static bool TryMultiply(ReadOnlySpan<float> a, ReadOnlySpan<float> b, Span<float> c, int M, int N, int K)
+    {
+        if (!Available || M < 6 || N < 16 || (long)M * N * K < JIT_MIN_WORK) return false;
+
+        int Mfull = M - M % 6, Nfull = N - N % 16;
+        int numRB = Mfull / 6, numCB = Nfull / 16;
+
+        fixed (float* pa = a, pb = b, pc = c)
+        {
+            nint A = (nint)pa, B = (nint)pb, C = (nint)pc;
+            int kk = K, nn = N, ncb = numCB;
+
+            if (numRB > 0 && numCB > 0)
+            {
+                // Parallelize over PersistentParallelExecutor only when the GEMM is
+                // big enough to amortize the dispatch. Small GEMMs (e.g. a low-batch
+                // transformer's QKV/FFN with few row-blocks) run SERIALLY on the
+                // calling thread — the per-GEMM PPE wake-up otherwise dwarfs the
+                // compute and regresses the forward pass (the kernel is fast; the
+                // dispatch is the cost). Measured crossover ~ a few M·N·K.
+                bool parallel = (long)M * N * K >= 4_000_000 && numRB >= 2;
+                if (parallel)
+                {
+                    int maxT = Helpers.CpuParallelSettings.MaxDegreeOfParallelism;
+                    int chunks = Math.Max(1, Math.Min(numRB, maxT));
+                    int perChunk = (numRB + chunks - 1) / chunks;
+                    int totalRB = numRB;
+                    Helpers.PersistentParallelExecutor.Instance.Execute(chunks, chunk =>
+                    {
+                        int lo = chunk * perChunk, hi = Math.Min(lo + perChunk, totalRB);
+                        var kf = _kernel;
+                        float* aP = (float*)A, bP = (float*)B, cP = (float*)C;
+                        for (int rb = lo; rb < hi; rb++)
+                        {
+                            float* aRow = aP + (long)(rb * 6) * kk;
+                            float* cRow = cP + (long)(rb * 6) * nn;
+                            for (int cb = 0; cb < ncb; cb++)
+                                kf(aRow, bP + cb * 16, cRow + cb * 16, kk, kk, nn, nn);
+                        }
+                    });
+                }
+                else
+                {
+                    var kf = _kernel;
+                    float* aP = (float*)A, bP = (float*)B, cP = (float*)C;
+                    for (int rb = 0; rb < numRB; rb++)
+                    {
+                        float* aRow = aP + (long)(rb * 6) * kk;
+                        float* cRow = cP + (long)(rb * 6) * nn;
+                        for (int cb = 0; cb < ncb; cb++)
+                            kf(aRow, bP + cb * 16, cRow + cb * 16, kk, kk, nn, nn);
+                    }
+                }
+            }
+        }
+
+        // ---- managed edges (tiny): right strip cols [Nfull,N) × all rows;
+        //      bottom strip rows [Mfull,M) × cols [0,Nfull). No overlap. ----
+        if (Nfull < N) EdgeBlock(a, b, c, M, N, K, 0, M, Nfull, N);
+        if (Mfull < M && Nfull > 0) EdgeBlock(a, b, c, M, N, K, Mfull, M, 0, Nfull);
+        return true;
+    }
+
+    private static void EdgeBlock(ReadOnlySpan<float> a, ReadOnlySpan<float> b, Span<float> c,
+        int M, int N, int K, int i0, int i1, int j0, int j1)
+    {
+        for (int i = i0; i < i1; i++)
+        {
+            int aRow = i * K, cRow = i * N;
+            for (int j = j0; j < j1; j++)
+            {
+                float acc = 0f;
+                for (int k = 0; k < K; k++) acc += a[aRow + k] * b[k * N + j];
+                c[cRow + j] = acc;
+            }
+        }
+    }
+
+    // ===================== machine-code emitter =====================
+    // Registers: ymm0..11 = 12 accumulators (6 rows × 2 cols), ymm12/13 = B halves,
+    // ymm14 = A broadcast. 3-base-pointer trick for the 6 strided A rows: rows 0/2/4
+    // bases in RCX/RBX/RSI, index RAX=lda*4, so [base] and [base+RAX] cover all rows.
+    // Win64 args: RCX=A RDX=B R8=C R9=K ; lda=[rsp+0x28] ldb=[rsp+0x30] ldc=[rsp+0x38].
+    private static byte[] Emit6x16Unpacked()
+    {
+        var code = new List<byte>(512);
+        void Bytes(params byte[] bs) => code.AddRange(bs);
+        void Vrr(int mm, int pp, byte op, int reg, int vvvv, int rm) => Bytes(0xC4,
+            (byte)(((reg < 8 ? 1 : 0) << 7) | (1 << 6) | ((rm < 8 ? 1 : 0) << 5) | mm),
+            (byte)((((~vvvv) & 0xF) << 3) | (1 << 2) | pp),
+            op, (byte)(0xC0 | ((reg & 7) << 3) | (rm & 7)));
+        void Vrm(int mm, int pp, byte op, int reg, int b, int disp)
+        {
+            Bytes(0xC4, (byte)(((reg < 8 ? 1 : 0) << 7) | (1 << 6) | ((b < 8 ? 1 : 0) << 5) | mm),
+                  (byte)((0xF << 3) | (1 << 2) | pp), op);
+            int rm = b & 7; bool sib = rm == 4; int mod = disp == 0 ? 0 : (disp is >= -128 and <= 127 ? 1 : 2);
+            Bytes((byte)((mod << 6) | ((reg & 7) << 3) | rm));
+            if (sib) Bytes(0x24);
+            if (mod == 1) Bytes((byte)(sbyte)disp);
+            else if (mod == 2) Bytes((byte)disp, (byte)(disp >> 8), (byte)(disp >> 16), (byte)(disp >> 24));
+        }
+        void VrmBase(int mm, int pp, byte op, int reg, int b) => Bytes(0xC4,
+            (byte)(((reg < 8 ? 1 : 0) << 7) | (1 << 6) | ((b < 8 ? 1 : 0) << 5) | mm),
+            (byte)((0xF << 3) | (1 << 2) | pp), op, (byte)(((reg & 7) << 3) | (b & 7)));
+        void VrmIdx(int mm, int pp, byte op, int reg, int b, int idx) => Bytes(0xC4,
+            (byte)(((reg < 8 ? 1 : 0) << 7) | ((idx < 8 ? 1 : 0) << 6) | ((b < 8 ? 1 : 0) << 5) | mm),
+            (byte)((0xF << 3) | (1 << 2) | pp), op, (byte)(((reg & 7) << 3) | 4), (byte)(((idx & 7) << 3) | (b & 7)));
+        void Mov128(byte op, int reg, int b, int disp)
+        {
+            Bytes(0xC4, (byte)(((reg < 8 ? 1 : 0) << 7) | (1 << 6) | ((b < 8 ? 1 : 0) << 5) | 1),
+                  (byte)((0xF << 3) | 0), op);
+            int rm = b & 7; bool sib = rm == 4; int mod = disp == 0 ? 0 : 1;
+            Bytes((byte)((mod << 6) | ((reg & 7) << 3) | rm)); if (sib) Bytes(0x24); if (mod == 1) Bytes((byte)disp);
+        }
+        void MovFromStack(int dst, byte disp) => Bytes((byte)(0x48 | (dst >= 8 ? 4 : 0)), 0x8B, (byte)(0x44 | ((dst & 7) << 3)), 0x24, disp);
+        void Shl4(int r) => Bytes((byte)(0x48 | (r >= 8 ? 1 : 0)), 0xC1, (byte)(0xE0 | (r & 7)), 2);
+        void Lea(int dst, int b, int idx, int scale)
+        {
+            int sc = scale == 2 ? 1 : scale == 4 ? 2 : scale == 8 ? 3 : 0;
+            Bytes((byte)(0x48 | (dst >= 8 ? 4 : 0) | (idx >= 8 ? 2 : 0) | (b >= 8 ? 1 : 0)), 0x8D,
+                  (byte)(((dst & 7) << 3) | 4), (byte)((sc << 6) | ((idx & 7) << 3) | (b & 7)));
+        }
+        void AddImm(int r, byte imm) => Bytes((byte)(0x48 | (r >= 8 ? 1 : 0)), 0x83, (byte)(0xC0 | (r & 7)), imm);
+        void AddRegReg(int dst, int src) => Bytes((byte)(0x48 | (src >= 8 ? 4 : 0) | (dst >= 8 ? 1 : 0)), 0x01, (byte)(0xC0 | ((src & 7) << 3) | (dst & 7)));
+        void Push(int r) { if (r >= 8) Bytes(0x41); Bytes((byte)(0x50 | (r & 7))); }
+        void Pop(int r) { if (r >= 8) Bytes(0x41); Bytes((byte)(0x58 | (r & 7))); }
+        const int RAX = 0, RCX = 1, RDX = 2, RBX = 3, RSP = 4, RSI = 6, R8 = 8, R10 = 10, R11 = 11;
+
+        MovFromStack(RAX, 0x28); Shl4(RAX);  // rax = lda*4
+        MovFromStack(R10, 0x30); Shl4(R10);  // r10 = ldb*4
+        MovFromStack(R11, 0x38); Shl4(R11);  // r11 = ldc*4
+        Push(RBX); Push(RSI);
+        Bytes(0x48, 0x81, 0xEC, 160, 0, 0, 0);                 // sub rsp,160
+        for (int x = 6; x <= 15; x++) Mov128(0x11, x, RSP, (x - 6) * 16); // save xmm6..15
+        Lea(RBX, RCX, RAX, 2);  // row2 base = A + 2*lda
+        Lea(RSI, RCX, RAX, 4);  // row4 base = A + 4*lda
+        for (int d = 0; d < 12; d++) Vrr(1, 0, 0x57, d, d, d);  // zero ymm0..11
+
+        int loop = code.Count;
+        Vrm(1, 0, 0x10, 12, RDX, 0); Vrm(1, 0, 0x10, 13, RDX, 32);   // B halves
+        VrmBase(2, 1, 0x18, 14, RCX); Vrr(2, 1, 0xB8, 0, 14, 12); Vrr(2, 1, 0xB8, 1, 14, 13);
+        VrmIdx(2, 1, 0x18, 14, RCX, RAX); Vrr(2, 1, 0xB8, 2, 14, 12); Vrr(2, 1, 0xB8, 3, 14, 13);
+        VrmBase(2, 1, 0x18, 14, RBX); Vrr(2, 1, 0xB8, 4, 14, 12); Vrr(2, 1, 0xB8, 5, 14, 13);
+        VrmIdx(2, 1, 0x18, 14, RBX, RAX); Vrr(2, 1, 0xB8, 6, 14, 12); Vrr(2, 1, 0xB8, 7, 14, 13);
+        VrmBase(2, 1, 0x18, 14, RSI); Vrr(2, 1, 0xB8, 8, 14, 12); Vrr(2, 1, 0xB8, 9, 14, 13);
+        VrmIdx(2, 1, 0x18, 14, RSI, RAX); Vrr(2, 1, 0xB8, 10, 14, 12); Vrr(2, 1, 0xB8, 11, 14, 13);
+        AddImm(RCX, 4); AddImm(RBX, 4); AddImm(RSI, 4); AddRegReg(RDX, R10);
+        Bytes(0x49, 0xFF, 0xC9);                               // dec r9
+        int after = code.Count;
+        Bytes(0x75, (byte)(sbyte)(loop - (after + 2)));        // jnz loop
+
+        for (int r = 0; r < 6; r++)
+        {
+            Vrm(1, 0, 0x11, r * 2, R8, 0); Vrm(1, 0, 0x11, r * 2 + 1, R8, 32);
+            if (r < 5) AddRegReg(R8, R11);
+        }
+        for (int x = 6; x <= 15; x++) Mov128(0x10, x, RSP, (x - 6) * 16); // restore xmm
+        Bytes(0x48, 0x81, 0xC4, 160, 0, 0, 0);                 // add rsp,160
+        Pop(RSI); Pop(RBX);
+        Bytes(0xC5, 0xF8, 0x77); Bytes(0xC3);                  // vzeroupper; ret
+        return code.ToArray();
+    }
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/Simd/JitGemmAvx2.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/JitGemmAvx2.cs
@@ -69,23 +69,64 @@ internal static unsafe class JitGemmAvx2
     private static readonly bool _enabled =
         System.Environment.GetEnvironmentVariable("AIDOTNET_JIT_GEMM") == "1";
 
-    // Minimum M (rows) for the JIT to engage. The JIT wins at large M (many 6-row
-    // blocks to parallelize, prologue amortized — e.g. the transformer FFN/QKV at
-    // M=B*seq=4096), but LOSES at small M (e.g. MLP at M=batch≤128), where the
-    // tuned managed/native kernels (CompiledMlp) beat it and forcing JIT regressed
-    // the MLP ~2×. Below this, TryMultiply declines and the caller keeps its path.
-    private static readonly int _jitMinM =
-        int.TryParse(System.Environment.GetEnvironmentVariable("AIDOTNET_JIT_MIN_M"), out var jm) && jm > 0 ? jm : 512;
 
     /// <summary>
     /// C[M,N] = A[M,K]·B[K,N], row-major, contiguous (lda=K, ldb=N, ldc=N).
     /// Returns false (no mutation) when unavailable / too small, so the caller
     /// falls back to the managed kernel.
     /// </summary>
+    // Per-shape auto-tune cache: true=JIT wins, false=managed wins. On first
+    // encounter of a (M,N,K) we time both and lock in the winner — so the JIT
+    // engages ONLY where it's actually faster than the managed kernel end-to-end
+    // (it wins large-M GEMM, loses small-M like MLP/LSTM gates), with no fixed
+    // threshold to mis-tune. Weights/shapes are stable across inferences, so the
+    // one-time tuning cost amortizes immediately.
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<(int, int, int), bool> _decision = new();
+
     internal static bool TryMultiply(ReadOnlySpan<float> a, ReadOnlySpan<float> b, Span<float> c, int M, int N, int K)
     {
-        if (!_enabled || !Available || M < _jitMinM || N < 16 || (long)M * N * K < JIT_MIN_WORK) return false;
+        if (!_enabled || !Available || M < 6 || N < 16 || (long)M * N * K < JIT_MIN_WORK) return false;
 
+        var key = (M, N, K);
+        if (_decision.TryGetValue(key, out bool useJit))
+        {
+            if (!useJit) return false;
+            RunJit(a, b, c, M, N, K);
+            return true;
+        }
+        return TuneAndRun(a, b, c, M, N, K, key);
+    }
+
+    // First-encounter tuning: time JIT (into c) vs the managed kernel (into a
+    // scratch), cache the winner. If managed wins, returns false so the caller
+    // runs its own (managed) path into c.
+    private static bool TuneAndRun(ReadOnlySpan<float> a, ReadOnlySpan<float> b, Span<float> c, int M, int N, int K, (int, int, int) key)
+    {
+        float[] scratch = System.Buffers.ArrayPool<float>.Shared.Rent(M * N);
+        try
+        {
+            long jit = long.MaxValue, mgd = long.MaxValue;
+            for (int r = 0; r < 4; r++)
+            {
+                long t0 = System.Diagnostics.Stopwatch.GetTimestamp();
+                RunJit(a, b, c, M, N, K);
+                long t1 = System.Diagnostics.Stopwatch.GetTimestamp();
+                // Managed reference: SgemmAddInternal is the managed core (no JIT re-entry).
+                SimdGemm.SgemmAddInternal(a, K, false, b, N, false, scratch.AsSpan(0, M * N), M, K, N, allowParallel: true, clearedOutput: true);
+                long t2 = System.Diagnostics.Stopwatch.GetTimestamp();
+                if (t1 - t0 < jit) jit = t1 - t0;
+                if (t2 - t1 < mgd) mgd = t2 - t1;
+            }
+            bool jitWins = jit <= mgd;
+            _decision[key] = jitWins;
+            if (jitWins) { RunJit(a, b, c, M, N, K); return true; } // c re-run clean (scratch had managed)
+            return false;
+        }
+        finally { System.Buffers.ArrayPool<float>.Shared.Return(scratch); }
+    }
+
+    private static void RunJit(ReadOnlySpan<float> a, ReadOnlySpan<float> b, Span<float> c, int M, int N, int K)
+    {
         int Mfull = M - M % 6, Nfull = N - N % 16;
         int numRB = Mfull / 6, numCB = Nfull / 16;
 
@@ -142,7 +183,6 @@ internal static unsafe class JitGemmAvx2
         //      bottom strip rows [Mfull,M) × cols [0,Nfull). No overlap. ----
         if (Nfull < N) EdgeBlock(a, b, c, M, N, K, 0, M, Nfull, N);
         if (Mfull < M && Nfull > 0) EdgeBlock(a, b, c, M, N, K, Mfull, M, 0, Nfull);
-        return true;
     }
 
     private static void EdgeBlock(ReadOnlySpan<float> a, ReadOnlySpan<float> b, Span<float> c,

--- a/src/AiDotNet.Tensors/Engines/Simd/JitGemmAvx2.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/JitGemmAvx2.cs
@@ -142,6 +142,14 @@ internal static unsafe class JitGemmAvx2
     }
 
     internal static void RunJit(ReadOnlySpan<float> a, ReadOnlySpan<float> b, Span<float> c, int M, int N, int K)
+        => RunJit(a, b, c, M, N, K, forceParallel: null);
+
+    /// <summary>
+    /// <paramref name="forceParallel"/>: null = the built-in work heuristic;
+    /// true/false force the PPE-parallel or calling-thread-serial path (benching,
+    /// and serial callers already inside a PPE region).
+    /// </summary>
+    internal static void RunJit(ReadOnlySpan<float> a, ReadOnlySpan<float> b, Span<float> c, int M, int N, int K, bool? forceParallel)
     {
         int Mfull = M - M % 6, Nfull = N - N % 16;
         int numRB = Mfull / 6, numCB = Nfull / 16;
@@ -159,7 +167,8 @@ internal static unsafe class JitGemmAvx2
                 // calling thread — the per-GEMM PPE wake-up otherwise dwarfs the
                 // compute and regresses the forward pass (the kernel is fast; the
                 // dispatch is the cost). Measured crossover ~ a few M·N·K.
-                bool parallel = (long)M * N * K >= 4_000_000 && numRB >= 2;
+                bool parallel = forceParallel ?? ((long)M * N * K >= 4_000_000 && numRB >= 2);
+                if (parallel && numRB < 2) parallel = false;
                 if (parallel)
                 {
                     int maxT = Helpers.CpuParallelSettings.MaxDegreeOfParallelism;

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
@@ -145,6 +145,24 @@ internal static partial class SimdGemm
         int.TryParse(System.Environment.GetEnvironmentVariable("AIDOTNET_OPENBLAS_MINK"), out var obk) && obk > 0
             ? obk : 256;
 
+    // Small-K asm panel kernel (JitGemmAvx2 6xN). Measured to beat BOTH the managed
+    // RyuJIT kernel AND OpenBLAS at small contraction depth with enough row-blocks to
+    // parallelize: transformer FFN [1024,64,128] 285 vs 111(mgd)/164(blas) GF/s, QKV
+    // [1024,64,192] 260 vs 93/200. At small K the 6-row A panel stays L1-resident, so
+    // streaming B across all column-blocks in one call (no per-tile transition) is a
+    // pure win. Default ON when the kernel is available; AIDOTNET_JIT_SMALLK=0 disables.
+    // Gated to: K <= JitSmallKMaxK (above it A[6,K] spills L1 and OpenBLAS/managed win),
+    // work >= JitSmallKMinWork (below it the serial path loses — needs parallel row-blocks),
+    // and the no-transpose contiguous top-level path.
+    private static readonly bool _jitSmallK =
+        System.Environment.GetEnvironmentVariable("AIDOTNET_JIT_SMALLK") != "0";
+    internal static readonly int JitSmallKMaxK =
+        int.TryParse(System.Environment.GetEnvironmentVariable("AIDOTNET_JIT_SMALLK_MAXK"), out var jk) && jk > 0
+            ? jk : 128;
+    internal static readonly long JitSmallKMinWork =
+        long.TryParse(System.Environment.GetEnvironmentVariable("AIDOTNET_JIT_SMALLK_MINWORK"), out var jw) && jw > 0
+            ? jw : 4_000_000;
+
 #if NET5_0_OR_GREATER
     // ─── Path A: pre-packed B cache ────────────────────────────────────────
     //
@@ -1048,6 +1066,18 @@ internal static partial class SimdGemm
                         return;
                 }
             }
+        }
+
+        // Small-K asm panel kernel (default on): beats managed AND OpenBLAS at K<=128
+        // with enough row-blocks to parallelize (the transformer's FFN/QKV GEMMs).
+        // 285/260 GF/s vs 111/93 managed on FFN/QKV b32. The 6-row A panel stays
+        // L1-resident at small K, so the 6xN kernel streams B once with no per-tile
+        // managed->native transition.
+        if (_jitSmallK && JitGemmAvx2.Available && !transA && !transB && lda == k && ldb == n
+            && k <= JitSmallKMaxK && m >= 6 && n >= 16 && (long)m * n * k >= JitSmallKMinWork)
+        {
+            JitGemmAvx2.RunJit(a, b, c, m, n, k);
+            return;
         }
 #endif
         // Native OpenBLAS kernel on OUR pool for large no-transpose contiguous GEMMs.

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
@@ -105,6 +105,12 @@ internal static partial class SimdGemm
     private static readonly bool _oneDnnGemm =
         System.Environment.GetEnvironmentVariable("AIDOTNET_ONEDNN_GEMM") == "1";
 
+    // Opt-in (AIDOTNET_JIT_GEMM=1): route large no-transpose float GEMMs through
+    // the runtime-JIT'd AVX2 kernel (JitGemmAvx2) — 600-700 GFLOP/s on small-K/N,
+    // beats both the managed kernel and oneDNN, on our own pool. Default OFF.
+    private static readonly bool _jitGemm =
+        System.Environment.GetEnvironmentVariable("AIDOTNET_JIT_GEMM") == "1";
+
 #if NET5_0_OR_GREATER
     // ─── Path A: pre-packed B cache ────────────────────────────────────────
     //
@@ -978,6 +984,12 @@ internal static partial class SimdGemm
         int m, int k, int n)
     {
 #if !NET471
+        // Our JIT'd AVX2 kernel first (opt-in): no transpose, row-major contiguous
+        // (lda==k, ldb==n). Beats managed + oneDNN on small-K/N, on our own pool.
+        if (_jitGemm && !transA && !transB && lda == k && ldb == n
+            && JitGemmAvx2.TryMultiply(a, b, c, m, n, k))
+            return;
+
         // oneDNN JIT'd GEMM (opt-in). Catches the fused-MHA QKV + output-projection
         // GEMMs (no transpose, row-major contiguous: lda==k, ldb==n) where oneDNN's
         // brgemm is 5-8× the managed kernel. Size-gated; the tiny per-head SDPA uses

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
@@ -163,6 +163,27 @@ internal static partial class SimdGemm
         long.TryParse(System.Environment.GetEnvironmentVariable("AIDOTNET_JIT_SMALLK_MINWORK"), out var jw) && jw > 0
             ? jw : 4_000_000;
 
+    // Work CEILING for the panel route. The 6xN panel re-reads the whole B panel
+    // once per 6-row block (it is unpacked by design); B traffic = (M/6)*K*N*4 bytes.
+    // At the proven shapes (M~1024: 4-13M MACs, ~5MB B traffic) that is fine and the
+    // panel wins 227-234 GF/s. At giant-M (transformer bs=128: M=4096, 33-50M MACs,
+    // 22-33MB B re-reads per GEMM) it saturates memory bandwidth and an interleaved
+    // end-to-end A/B showed a 16% regression — those shapes fall through to the
+    // managed kernel, whose packed/blocked path handles large M. Env-tunable.
+    internal static readonly long JitSmallKMaxWork =
+        long.TryParse(System.Environment.GetEnvironmentVariable("AIDOTNET_JIT_SMALLK_MAXWORK"), out var jmw) && jmw > 0
+            ? jmw : 16_000_000;
+
+    // Row ceiling for the panel route. B-reread traffic scales with the row-block
+    // count (M/6), so giant-M shapes (transformer bs=128: M=4096, 682 row-blocks)
+    // regressed in interleaved A/Bs with ANY giant-M shape routed (FFN, QKV, or just
+    // the input projection) while the proven M~1024 regime kept a 22-24% end-to-end
+    // win. Cap M so the route engages exactly where the bake-off + end-to-end A/Bs
+    // validated it; larger M falls through to the managed packed/blocked kernel.
+    internal static readonly int JitSmallKMaxM =
+        int.TryParse(System.Environment.GetEnvironmentVariable("AIDOTNET_JIT_SMALLK_MAXM"), out var jmm) && jmm > 0
+            ? jmm : 2048;
+
 #if NET5_0_OR_GREATER
     // ─── Path A: pre-packed B cache ────────────────────────────────────────
     //
@@ -285,6 +306,22 @@ internal static partial class SimdGemm
         // pure-GEMM MLP didn't translate the GFLOP/s win. Row-major contiguous.
         if (_jitGemm && JitGemmAvx2.TryMultiply(a, b.AsSpan(0, k * n), c, m, n, k))
             return;
+
+        // Small-K asm panel kernel (default on; AIDOTNET_JIT_SMALLK=0 disables).
+        // This entry is how FusedLinear routes the transformer FFN GEMMs
+        // ([B*seq,64]@[64,128]: K·N=8K <= 200K prefers cached-B) — without this
+        // hook the panel kernel never reached the FFN, only the MHA projections
+        // (which call Sgemm directly). Same gates as the Sgemm route: the 4-way
+        // bake-off shows the panel-parallel at 227-234 GF/s vs ~100 for managed
+        // (serial OR parallel) and 135-165 for OpenBLAS at these shapes, while
+        // below the work gate (e.g. bs=8's 2.1M) the cached-B/managed path wins.
+        if (_jitSmallK && JitGemmAvx2.Available
+            && k <= JitSmallKMaxK && m >= 6 && m <= JitSmallKMaxM && n >= 16
+            && (long)m * n * k >= JitSmallKMinWork && (long)m * n * k <= JitSmallKMaxWork)
+        {
+            JitGemmAvx2.RunJit(a, b.AsSpan(0, k * n), c, m, n, k);
+            return;
+        }
 #endif
 
         // Cache-eligibility gate: if n > Nc, the outer loop iterates jc multiple
@@ -935,7 +972,9 @@ internal static partial class SimdGemm
     /// <c>BackwardFunctions</c>) can mirror the gate exactly instead of
     /// hardcoding a duplicate value that drifts when this changes.
     /// </summary>
-    internal static readonly long ParallelWorkThreshold = ComputeParallelWorkThreshold();
+    internal static readonly long ParallelWorkThreshold =
+        long.TryParse(System.Environment.GetEnvironmentVariable("AIDOTNET_GEMM_PARALLEL_MINWORK"), out var gpw) && gpw > 0
+            ? gpw : ComputeParallelWorkThreshold();
 
     private static long ComputeParallelWorkThreshold()
     {
@@ -1074,7 +1113,8 @@ internal static partial class SimdGemm
         // L1-resident at small K, so the 6xN kernel streams B once with no per-tile
         // managed->native transition.
         if (_jitSmallK && JitGemmAvx2.Available && !transA && !transB && lda == k && ldb == n
-            && k <= JitSmallKMaxK && m >= 6 && n >= 16 && (long)m * n * k >= JitSmallKMinWork)
+            && k <= JitSmallKMaxK && m >= 6 && m <= JitSmallKMaxM && n >= 16
+            && (long)m * n * k >= JitSmallKMinWork && (long)m * n * k <= JitSmallKMaxWork)
         {
             JitGemmAvx2.RunJit(a, b, c, m, n, k);
             return;

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
@@ -226,6 +226,15 @@ internal static partial class SimdGemm
         System.Span<float> c,
         int m, int k, int n)
     {
+#if !NET471
+        // Our JIT'd AVX2 kernel first (opt-in). This is the entry the MLP's
+        // MlpForward path and FusedLinear's tier-3 fallback use — without this
+        // hook the JIT (376-700 GFLOP/s) never reached the MLP, which is why a
+        // pure-GEMM MLP didn't translate the GFLOP/s win. Row-major contiguous.
+        if (_jitGemm && JitGemmAvx2.TryMultiply(a, b.AsSpan(0, k * n), c, m, n, k))
+            return;
+#endif
+
         // Cache-eligibility gate: if n > Nc, the outer loop iterates jc multiple
         // times and our single-jc assumption breaks. Also skip if AVX-512 path is
         // eligible (the specialised kernel's layout differs).

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
@@ -111,6 +111,40 @@ internal static partial class SimdGemm
     private static readonly bool _jitGemm =
         System.Environment.GetEnvironmentVariable("AIDOTNET_JIT_GEMM") == "1";
 
+    // Route large no-transpose float GEMMs through native OpenBLAS (cblas_sgemm).
+    // A per-shape bake-off on the AIsEval losing shapes (LosingShapeGemmBench)
+    // showed OpenBLAS at 2-3x the managed RyuJIT-compiled kernel on exactly the
+    // GEMM-bound losers — mlp L1 [.,784,512] 199 vs 66 GF/s, transformer FFN/QKV
+    // [1024,64,*] 226-280 vs 93-121 — while managed still wins the small/thin
+    // shapes (LSTM recurrence K=64, tiny-batch transformer). RyuJIT's codegen is
+    // the gap; OpenBLAS (hand-written asm) is the proven workaround, already loaded.
+    // Default ON when OpenBLAS is present; gated to large work (>= OpenBlasMinWork)
+    // and the top-level no-transpose contiguous path only — SgemmSequential (used
+    // inside PPE regions: SDPA, batch-parallel LSTM) never routes here, so no
+    // OpenBLAS-threads x our-pool oversubscription. Set AIDOTNET_OPENBLAS_GEMM=0
+    // to force the managed kernel for A/B.
+    private static readonly bool _openBlasGemm =
+        System.Environment.GetEnvironmentVariable("AIDOTNET_OPENBLAS_GEMM") != "0";
+
+    // Crossover from the bake-off: below ~4M MACs the managed kernel wins (native
+    // call + thread-fan-out overhead dominates the tiny compute); above it OpenBLAS
+    // pulls ahead and widens. Env-tunable.
+    internal static readonly long OpenBlasMinWork =
+        long.TryParse(System.Environment.GetEnvironmentVariable("AIDOTNET_OPENBLAS_MINWORK"), out var obw) && obw > 0
+            ? obw : 4_000_000;
+
+    // Minimum contraction depth K to route to OpenBLAS-on-PPE. The bake-off shows
+    // OpenBLAS winning the isolated GEMM at all K, but END-TO-END it only wins for
+    // LARGE K (the MLP's 512/784, where B-packing + K-blocking dominate): there it
+    // flipped mlp bs=32 from 1.87x to 0.94x. At small K (=64: transformer FFN/QKV,
+    // LSTM recurrence) the managed kernel on our hot PPE wins end-to-end — the many
+    // per-GEMM OpenBLAS entries in a multi-op model (transformer: ~15 GEMMs/predict)
+    // cost more than the kernel saves. K is the clean discriminator: MLP K>=512,
+    // transformer/LSTM K=64. Env-tunable.
+    internal static readonly int OpenBlasMinK =
+        int.TryParse(System.Environment.GetEnvironmentVariable("AIDOTNET_OPENBLAS_MINK"), out var obk) && obk > 0
+            ? obk : 256;
+
 #if NET5_0_OR_GREATER
     // ─── Path A: pre-packed B cache ────────────────────────────────────────
     //
@@ -1016,8 +1050,67 @@ internal static partial class SimdGemm
             }
         }
 #endif
+        // Native OpenBLAS kernel on OUR pool for large no-transpose contiguous GEMMs.
+        // The bake-off showed OpenBLAS's microkernel at 2-3x the managed RyuJIT kernel,
+        // but routing whole calls to OpenBLAS regressed end-to-end: OpenBLAS spins its
+        // own ~N-thread pool PER CALL, and a many-GEMM model (transformer) pays that
+        // thread-sync floor on every op. The fix: pin OpenBLAS to ONE thread and supply
+        // the parallelism ourselves over the PersistentParallelExecutor (hot, spin-based,
+        // ~zero wakeup) by splitting the M rows into chunks — each chunk a single-thread
+        // OpenBLAS call. We get OpenBLAS's kernel quality with our cheap dispatch.
+        // Top-level only (SgemmSequential, used inside PPE regions, never reaches here).
+        if (_openBlasGemm && !transA && !transB && lda == k && ldb == n
+            && k >= OpenBlasMinK && (long)m * k * n >= OpenBlasMinWork && Helpers.BlasProvider.HasRawSgemm)
+        {
+            RunOpenBlasParallel(a, b, c, m, k, n);
+            return;
+        }
+
         c.Clear();
         SgemmAddInternal(a, lda, transA, b, ldb, transB, c, m, k, n, allowParallel: true, clearedOutput: true);
+    }
+
+    // Set to 1 once OpenBLAS is pinned single-thread (we own the parallelism).
+    private static int _openBlasThreadsPinned;
+
+    /// <summary>
+    /// C[m,n] = A[m,k]·B[k,n] (row-major, no-trans) using OpenBLAS's single-thread
+    /// microkernel, parallelized over M-row chunks on the PersistentParallelExecutor.
+    /// Captures OpenBLAS's kernel quality (2-3x the managed RyuJIT kernel at the MLP/
+    /// transformer shapes) without OpenBLAS's per-call thread-pool spin-up — the
+    /// reason whole-call native routing regressed the many-GEMM transformer.
+    /// </summary>
+    private static unsafe void RunOpenBlasParallel(ReadOnlySpan<float> a, ReadOnlySpan<float> b, Span<float> c, int m, int k, int n)
+    {
+        // Pin OpenBLAS to a single thread once — its internal threading is what we're
+        // replacing with our own pool.
+        if (System.Threading.Interlocked.CompareExchange(ref _openBlasThreadsPinned, 1, 0) == 0)
+            Helpers.BlasProvider.TrySetOpenBlasThreads(1);
+
+        int maxT = Helpers.CpuParallelSettings.MaxDegreeOfParallelism;
+        // One chunk per worker, but keep >= 8 rows/chunk so each single-thread call
+        // amortizes its own (small) entry cost.
+        int chunks = Math.Max(1, Math.Min(maxT, m / 8));
+
+        fixed (float* pa = a, pb = b, pc = c)
+        {
+            if (chunks <= 1)
+            {
+                Helpers.BlasProvider.SgemmRaw(m, n, k, pa, k, pb, n, pc, n);
+                return;
+            }
+            nint A = (nint)pa, B = (nint)pb, C = (nint)pc;
+            int kk = k, nn = n, mm = m, per = (m + chunks - 1) / chunks;
+            Helpers.PersistentParallelExecutor.Instance.Execute(chunks, chunk =>
+            {
+                int r0 = chunk * per;
+                if (r0 >= mm) return;
+                int rows = System.Math.Min(per, mm - r0);
+                float* aP = (float*)A + (long)r0 * kk;
+                float* cP = (float*)C + (long)r0 * nn;
+                Helpers.BlasProvider.SgemmRaw(rows, nn, kk, aP, kk, (float*)B, nn, cP, nn);
+            });
+        }
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
@@ -98,6 +98,13 @@ internal static partial class SimdGemm
     // Intended for benchmark A/B iteration, not production config.
     internal static bool UseParallelGemm = true;
 
+    // Opt-in (AIDOTNET_ONEDNN_GEMM=1): route large no-transpose float GEMMs through
+    // oneDNN's JIT'd dnnl_sgemm (shape-specialized brgemm, 5-8× the managed kernel
+    // on small-K/N). Default OFF — managed kernel keeps the supply-chain-independent
+    // path. See the head-to-head in OneDnnProvider.TrySgemm.
+    private static readonly bool _oneDnnGemm =
+        System.Environment.GetEnvironmentVariable("AIDOTNET_ONEDNN_GEMM") == "1";
+
 #if NET5_0_OR_GREATER
     // ─── Path A: pre-packed B cache ────────────────────────────────────────
     //
@@ -970,6 +977,24 @@ internal static partial class SimdGemm
         Span<float> c,
         int m, int k, int n)
     {
+#if !NET471
+        // oneDNN JIT'd GEMM (opt-in). Catches the fused-MHA QKV + output-projection
+        // GEMMs (no transpose, row-major contiguous: lda==k, ldb==n) where oneDNN's
+        // brgemm is 5-8× the managed kernel. Size-gated; the tiny per-head SDPA uses
+        // SgemmSequential (separate entry) so it stays on the managed path.
+        if (_oneDnnGemm && !transA && !transB && lda == k && ldb == n
+            && (long)m * k * n >= 262_144)
+        {
+            unsafe
+            {
+                fixed (float* pa = a, pb = b, pc = c)
+                {
+                    if (Helpers.OneDnnProvider.TrySgemm(pa, pb, pc, m, k, n))
+                        return;
+                }
+            }
+        }
+#endif
         c.Clear();
         SgemmAddInternal(a, lda, transA, b, ldb, transB, c, m, k, n, allowParallel: true, clearedOutput: true);
     }

--- a/src/AiDotNet.Tensors/Helpers/CpuFusedOperations.cs
+++ b/src/AiDotNet.Tensors/Helpers/CpuFusedOperations.cs
@@ -141,6 +141,11 @@ public static class CpuFusedOperations
         FusedGemmBiasActivationUnchecked(A, B, bias, output, M, N, K, activation, activationParams: activationParams);
     }
 
+    // Small/medium-M cutover for routing the fused GEMM through the packed managed
+    // kernel instead of native TryGemm (mirrors CpuEngine.TensorMatMul2D). At/below
+    // this M the managed kernel wins; above it native BLAS's raw throughput wins.
+    private const int SmallMGemmCutover = 1024;
+
     internal static void FusedGemmBiasActivationUnchecked(
         float[] A,
         float[] B,
@@ -151,6 +156,27 @@ public static class CpuFusedOperations
         bool allowCachedB = true,
         FusedActivationParams? activationParams = null)
     {
+        // Small/medium-M fast path: at small M (the batch dimension, e.g. training/
+        // inference at batch 64) native BLAS leaves cores idle and pays worker-pool
+        // dispatch overhead — the packed managed kernel is 2-5.8x faster and clears
+        // 75 GFLOP/s for M up to the cutover (profiled; min-of-N on a noisy rig).
+        // Route here BEFORE TryGemm so the small-M GEMM doesn't fall into the slow
+        // native path. Above the cutover, native BLAS's raw throughput wins (below).
+        //   * allowCachedB (inference, frozen weights): identity-cached pre-pack.
+        //   * else (training, weights mutated in place by optimizer.Step): pack-fresh
+        //     SimdGemm.Sgemm — re-packs B every call so it correctly sees the update
+        //     (the cached kernel would serve a stale pack → wrong gradients).
+        if (M <= SmallMGemmCutover)
+        {
+            if (allowCachedB)
+                SimdGemm.SgemmWithCachedB(A.AsSpan(0, M * K), B, output.AsSpan(0, M * N), M, K, N);
+            else
+                SimdGemm.Sgemm(A.AsSpan(0, M * K), K, false, B.AsSpan(0, K * N), N, false,
+                               output.AsSpan(0, M * N), M, K, N);
+            ApplyBiasActivationInPlace(output, bias, M, N, activation, activationParams);
+            return;
+        }
+
         // Use BLAS for the O(MNK) GEMM, then fuse bias+activation in a cheap O(MN) second pass.
         if (BlasProvider.TryGemm(M, N, K, A, 0, K, B, 0, N, output, 0, N))
         {

--- a/src/AiDotNet.Tensors/Helpers/OneDnnProvider.cs
+++ b/src/AiDotNet.Tensors/Helpers/OneDnnProvider.cs
@@ -23,7 +23,7 @@ internal static class OneDnnProvider
     private static IntPtr _engine;
     private static IntPtr _stream;
     private static readonly bool TraceEnabled = ReadEnvBool("AIDOTNET_ONEDNN_TRACE");
-    private static bool _resolverRegistered;
+    private static bool _resolverRegistered;
 
     // Primitive cache for avoiding recreation overhead
     private static readonly ConcurrentDictionary<Conv2DKey, CachedConv2D> _conv2DCache = new();
@@ -661,6 +661,21 @@ internal static class OneDnnProvider
         uint flags,
         IntPtr attr);
 
+    // oneDNN's stand-alone GEMM C API (dnnl_sgemm). JIT-compiles a shape-
+    // specialized brgemm microkernel for the exact (M,N,K)/ISA — the same
+    // mechanism MKL uses to beat a generic kernel on small-K/N shapes. oneDNN's
+    // dnnl_sgemm interprets A/B/C as ROW-MAJOR (documented difference from
+    // column-major cblas), which matches our Tensor<float> storage directly.
+    // Signature: dnnl_status_t dnnl_sgemm(char transa, char transb,
+    //   dnnl_dim_t M, N, K, float alpha, const float* A, dnnl_dim_t lda,
+    //   const float* B, dnnl_dim_t ldb, float beta, float* C, dnnl_dim_t ldc);
+    [DllImport("dnnl", CallingConvention = CallingConvention.Cdecl)]
+    private static extern unsafe int dnnl_sgemm(
+        byte transa, byte transb,
+        long M, long N, long K, float alpha,
+        float* A, long lda, float* B, long ldb,
+        float beta, float* C, long ldc);
+
     // Pooling algorithm constants
     private const int DnnlPoolingAvgIncludePadding = 0x200;
     private const int DnnlPoolingAvgExcludePadding = 0x201;
@@ -816,7 +831,7 @@ internal static class OneDnnProvider
 
             if (logThis)
             {
-                Console.WriteLine("[oneDNN] Conv2D completed successfully");
+                Console.WriteLine("[oneDNN] Conv2D completed successfully");
             }
             return true;
         }
@@ -824,7 +839,7 @@ internal static class OneDnnProvider
         {
             if (logThis)
             {
-                Console.WriteLine($"[oneDNN] Conv2D exception: {ex.Message}");
+                Console.WriteLine($"[oneDNN] Conv2D exception: {ex.Message}");
             }
             return false;
         }
@@ -839,6 +854,23 @@ internal static class OneDnnProvider
     internal static unsafe bool TryReLU(float* data, int length)
     {
         return TryEltwiseInPlace(data, length, DnnlEltwiseRelu);
+    }
+
+    /// <summary>
+    /// Row-major single-precision GEMM via oneDNN's JIT'd kernel:
+    /// C[M,N] = A[M,K] · B[K,N] (no transpose, alpha=1, beta=0). Returns false
+    /// (no mutation) if oneDNN is unavailable so the caller can fall back to the
+    /// managed kernel. oneDNN JIT-compiles a brgemm microkernel specialized for
+    /// the exact shape/ISA — the head-to-head reference for "can a shape-
+    /// specialized kernel close the managed-AVX2 GFLOP/s gap on small-K/N?".
+    /// </summary>
+    internal static unsafe bool TrySgemm(float* a, float* b, float* c, int m, int k, int n)
+    {
+        if (!EnsureInitialized())
+            return false;
+        const byte N = (byte)'N';
+        int status = dnnl_sgemm(N, N, m, n, k, 1.0f, a, k, b, n, 0.0f, c, n);
+        return status == DnnlSuccess;
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Helpers/OneDnnProvider.cs
+++ b/src/AiDotNet.Tensors/Helpers/OneDnnProvider.cs
@@ -1,46 +1,1938 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+
 namespace AiDotNet.Tensors.Helpers;
 
 /// <summary>
-/// Intel oneDNN accelerator — <b>disabled in the supply-chain-independence build</b>.
+/// Intel oneDNN (Deep Neural Network Library) provider for optimized convolution operations.
+/// Uses P/Invoke to call native oneDNN library for highly optimized CPU convolution.
 ///
-/// <para>
-/// Historically this class loaded the native <c>dnnl.dll</c> (provided by the optional
-/// <c>AiDotNet.Native.OneDNN</c> NuGet package) at runtime and exposed TryConv2D /
-/// TrySigmoid / TryReLU / TryAdd / TryMultiply / TrySoftmax hot paths that
-/// <see cref="Engines.CpuEngine"/> preferentially used over the in-house kernels.
-/// After <c>feat/finish-mkl-replacement</c> (Issue #131 completion + supply-chain
-/// directive), every entry point returns <c>false</c> immediately so callers fall
-/// through to their managed fallback:
-/// <list type="bullet">
-///   <item><description>Conv2D → FusedConv + SimdGemm (im2col+GEMM), Winograd for 3×3 stride=1, SIMD direct for other small kernels</description></item>
-///   <item><description>Element-wise (sigmoid / ReLU / add / multiply / softmax) → SimdKernels (AVX2-vectorized)</description></item>
-/// </list>
-/// </para>
-/// <para>
-/// This stub replaces ~1930 lines of P/Invoke / primitive-cache / mem-desc plumbing
-/// that became unreachable after the disable. See git history for the original
-/// implementation if a user ever wants to opt back in by reverting this file.
-/// </para>
+/// Performance optimizations:
+/// 1. Primitive caching - caches primitives by dimension key to avoid recreation overhead
+/// 2. Pinned memory - uses GCHandle.Pinned to avoid buffer copies
+/// 3. Memory object pooling - reuses memory objects and updates data handles
 /// </summary>
 internal static class OneDnnProvider
 {
-    /// <summary>Always false — external oneDNN is disabled.</summary>
-    internal static bool IsAvailable => false;
+    private static readonly object InitLock = new object();
+    private static bool _initialized;
+    private static bool _available;
+    private static IntPtr _engine;
+    private static IntPtr _stream;
+    private static readonly bool TraceEnabled = ReadEnvBool("AIDOTNET_ONEDNN_TRACE");
+    private static bool _resolverRegistered;
 
+    // Primitive cache for avoiding recreation overhead
+    private static readonly ConcurrentDictionary<Conv2DKey, CachedConv2D> _conv2DCache = new();
+    private static readonly ConcurrentDictionary<EltwiseKey, CachedEltwise> _eltwiseCache = new();
+    private static readonly ConcurrentDictionary<BinaryKey, CachedBinary> _binaryCache = new();
+    private const int MaxCacheSize = 32; // Limit cache size to avoid memory bloat
+    private const int MaxEltwiseCacheSize = 16; // Limit eltwise cache size
+    private const int MaxBinaryCacheSize = 16; // Limit binary cache size
+    private static readonly ConcurrentDictionary<SoftmaxKey, CachedSoftmax> _softmaxCache = new();
+    private const int MaxSoftmaxCacheSize = 8;
+    private static readonly ReaderWriterLockSlim _softmaxCacheLock = new(LockRecursionPolicy.NoRecursion);
+
+    // Reader-writer locks to prevent use-after-free during cache eviction
+    // These ensure that eviction doesn't happen while cached objects are in use
+    private static readonly ReaderWriterLockSlim _eltwiseCacheLock = new(LockRecursionPolicy.NoRecursion);
+    private static readonly ReaderWriterLockSlim _binaryCacheLock = new(LockRecursionPolicy.NoRecursion);
+
+    // Windows API for DLL search path manipulation
+    [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    private static extern bool SetDllDirectory(string lpPathName);
+
+    // No static constructor — registration is lazy in EnsureInitialized().
+    // Previous static constructor caused BenchmarkDotNet to hang because SetDllImportResolver
+    // ran during type validation in the isolated benchmark process.
+
+    private static void RegisterDllResolver()
+    {
+        if (_resolverRegistered) return;
+        _resolverRegistered = true;
+
+        try
+        {
+            NativeLibrary.SetDllImportResolver(typeof(OneDnnProvider).Assembly, (libraryName, assembly, searchPath) =>
+            {
+                if (libraryName != "dnnl")
+                    return IntPtr.Zero;
+
+                // Try app base directory
+                var handle = TryLoadFromDirectory(AppContext.BaseDirectory);
+                if (handle != IntPtr.Zero) return handle;
+
+                // Try runtimes/win-x64/native (NuGet RID-specific layout)
+                string ridDir = Path.Combine(AppContext.BaseDirectory, "runtimes", "win-x64", "native");
+                if (Directory.Exists(ridDir))
+                {
+                    handle = TryLoadFromDirectory(ridDir);
+                    if (handle != IntPtr.Zero) return handle;
+                }
+
+                // Try assembly directory
+                string? assemblyDir = Path.GetDirectoryName(assembly.Location);
+                if (assemblyDir is not null)
+                {
+                    handle = TryLoadFromDirectory(assemblyDir);
+                    if (handle != IntPtr.Zero) return handle;
+                }
+
+                // Try default search
+                if (NativeLibrary.TryLoad("dnnl", out var defaultHandle))
+                    return defaultHandle;
+
+                return IntPtr.Zero;
+            });
+        }
+        catch (InvalidOperationException)
+        {
+            // Resolver already registered — non-fatal, use default library search.
+        }
+    }
+
+    private static IntPtr TryLoadFromDirectory(string directory)
+    {
+        string dnnlPath = Path.Combine(directory, "dnnl.dll");
+
+        if (!File.Exists(dnnlPath))
+        {
+            if (TraceEnabled) Console.WriteLine($"[oneDNN] dnnl.dll not found in: {directory}");
+            return IntPtr.Zero;
+        }
+
+        if (TraceEnabled) Console.WriteLine($"[oneDNN] Found dnnl.dll in: {directory}");
+
+        SetDllDirectory(directory);
+        if (TraceEnabled) Console.WriteLine($"[oneDNN] Set DLL directory to: {directory}");
+
+        if (NativeLibrary.TryLoad(dnnlPath, out IntPtr handle))
+        {
+            if (TraceEnabled) Console.WriteLine($"[oneDNN] Successfully loaded dnnl.dll");
+            return handle;
+        }
+
+        if (TraceEnabled) Console.WriteLine($"[oneDNN] Failed to load dnnl.dll from: {dnnlPath}");
+        SetDllDirectory(null!);
+        return IntPtr.Zero;
+    }
+
+    #region oneDNN Constants
+
+    private const int DnnlSuccess = 0;
+    private const int DnnlCpu = 1;
+    private const int DnnlForwardInference = 96;
+    private const int DnnlConvolutionAuto = 3;
+    private const int DnnlConvolutionDirect = 1;
+    private const int DnnlConvolutionWinograd = 2;
+    private const int DnnlF32 = 3;
+
+    // Eltwise algorithms (from dnnl_types.h)
+    private const int DnnlEltwiseRelu = 1;      // relu: max(0, x) or max(alpha*x, x)
+    private const int DnnlEltwiseLogistic = 16; // logistic (sigmoid): 1/(1+exp(-x))
+
+    // Binary algorithms (from dnnl_types.h)
+    private const int DnnlBinaryAdd = 0x1fff0;  // binary_add = 131056
+    private const int DnnlBinaryMul = 0x1fff1;  // binary_mul = 131057
+
+    // Softmax algorithm (from dnnl_types.h — oneDNN 3.x)
+    private const int DnnlSoftmaxAccurate = 0x30000;  // dnnl_softmax_accurate
+    private const int DnnlSoftmaxLog = 0x30001;        // dnnl_softmax_log
+
+    // Format tags (from dnnl_types.h)
+    private const int DnnlFormatTagAny = 1;  // Let oneDNN choose optimal format (format_tag_any = 1, not 0)
+    private const int DnnlFormatTagNCHW = 11; // abcd format for 4D tensors
+    private const int DnnlFormatTagOIHW = 11; // Same as NCHW for weights
+
+    // Argument indices (from dnnl_types.h)
+    private const int DnnlArgSrc = 1;
+    private const int DnnlArgSrc0 = 1;   // For binary ops
+    private const int DnnlArgSrc1 = 2;   // For binary ops
+    private const int DnnlArgBias = 3;
+    private const int DnnlArgMean = 4;    // BatchNorm running mean
+    private const int DnnlArgDst = 17;
+    private const int DnnlArgWeights = 33;
+    private const int DnnlArgVariance = 34; // BatchNorm running variance
+    private const int DnnlArgScratchpad = 80;
+    // Removed: DnnlPropForwardInference = 1 was incorrect. Use DnnlForwardInference = 96.
+    private const int DnnlPoolingMax = 1; // max pooling algorithm
+
+    // Query types
+    private const int DnnlQuerySrcMd = 129;
+    private const int DnnlQueryWeightsMd = 131;
+    private const int DnnlQueryDstMd = 133;
+    private const int DnnlQueryScratchpadMd = 132;
+
+    #endregion
+
+    #region Structs
+
+    /// <summary>
+    /// Execution argument for dnnl_primitive_execute.
+    /// </summary>
+    [StructLayout(LayoutKind.Explicit, Size = 16)]
+    private struct DnnlExecArg
+    {
+        [FieldOffset(0)]
+        public int Arg;
+        [FieldOffset(8)]
+        public IntPtr Memory;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct DnnlVersion
+    {
+        public int Major;
+        public int Minor;
+        public int Patch;
+        public IntPtr Hash;
+        public uint CpuRuntime;
+        public uint GpuRuntime;
+    }
+
+    /// <summary>
+    /// Cache key for Conv2D primitives.
+    /// </summary>
+    private readonly struct Conv2DKey : IEquatable<Conv2DKey>
+    {
+        public readonly int Batch;
+        public readonly int InChannels;
+        public readonly int Height;
+        public readonly int Width;
+        public readonly int OutChannels;
+        public readonly int KernelH;
+        public readonly int KernelW;
+        public readonly int StrideH;
+        public readonly int StrideW;
+        public readonly int PadH;
+        public readonly int PadW;
+        public readonly int DilationH;
+        public readonly int DilationW;
+
+        public Conv2DKey(int batch, int inC, int h, int w, int outC, int kH, int kW,
+            int strideH, int strideW, int padH, int padW, int dilH, int dilW)
+        {
+            Batch = batch;
+            InChannels = inC;
+            Height = h;
+            Width = w;
+            OutChannels = outC;
+            KernelH = kH;
+            KernelW = kW;
+            StrideH = strideH;
+            StrideW = strideW;
+            PadH = padH;
+            PadW = padW;
+            DilationH = dilH;
+            DilationW = dilW;
+        }
+
+        public bool Equals(Conv2DKey other) =>
+            Batch == other.Batch && InChannels == other.InChannels &&
+            Height == other.Height && Width == other.Width &&
+            OutChannels == other.OutChannels && KernelH == other.KernelH && KernelW == other.KernelW &&
+            StrideH == other.StrideH && StrideW == other.StrideW &&
+            PadH == other.PadH && PadW == other.PadW &&
+            DilationH == other.DilationH && DilationW == other.DilationW;
+
+        public override bool Equals(object? obj) => obj is Conv2DKey other && Equals(other);
+
+        public override int GetHashCode()
+        {
+            var hash = new HashCode();
+            hash.Add(Batch);
+            hash.Add(InChannels);
+            hash.Add(Height);
+            hash.Add(Width);
+            hash.Add(OutChannels);
+            hash.Add(KernelH);
+            hash.Add(KernelW);
+            hash.Add(StrideH);
+            hash.Add(StrideW);
+            hash.Add(PadH);
+            hash.Add(PadW);
+            hash.Add(DilationH);
+            hash.Add(DilationW);
+            return hash.ToHashCode();
+        }
+    }
+
+    /// <summary>
+    /// Cached Conv2D primitive with memory objects for reuse.
+    /// Includes reorder primitives for optimal data formats when oneDNN chooses
+    /// a different internal format than the user's NCHW format.
+    /// </summary>
+    private sealed class CachedConv2D : IDisposable
+    {
+        // Main convolution primitive
+        public IntPtr Primitive;
+        public IntPtr PrimDesc;
+
+        // User format memory objects (for setting data handles)
+        public IntPtr UserSrcMem;
+        public IntPtr UserWeightsMem;
+        public IntPtr UserDstMem;
+
+        // Optimal format memory objects (for convolution execution)
+        // These may point to the same memory as UserXxxMem if no reorder is needed
+        public IntPtr ConvSrcMem;
+        public IntPtr ConvWeightsMem;
+        public IntPtr ConvDstMem;
+        public IntPtr ScratchpadMem;
+
+        // Reorder primitives (IntPtr.Zero if no reorder needed)
+        public IntPtr SrcReorderPrim;
+        public IntPtr WeightsReorderPrim;
+        public IntPtr DstReorderPrim;
+
+        // Memory descriptors (user format)
+        public IntPtr UserSrcDesc;
+        public IntPtr UserWeightsDesc;
+        public IntPtr UserDstDesc;
+
+        // Allocated buffers for reordered data (IntPtr.Zero if no reorder)
+        public IntPtr ReorderedSrcBuffer;
+        public IntPtr ReorderedWeightsBuffer;
+        public IntPtr ReorderedDstBuffer;
+
+        // Flags
+        public bool NeedsSrcReorder;
+        public bool NeedsWeightsReorder;
+        public bool NeedsDstReorder;
+        public bool WeightsReordered; // True after first weights reorder
+
+        public int OutHeight;
+        public int OutWidth;
+        private bool _disposed;
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+
+            // Free reorder primitives
+            if (DstReorderPrim != IntPtr.Zero) dnnl_primitive_destroy(DstReorderPrim);
+            if (WeightsReorderPrim != IntPtr.Zero) dnnl_primitive_destroy(WeightsReorderPrim);
+            if (SrcReorderPrim != IntPtr.Zero) dnnl_primitive_destroy(SrcReorderPrim);
+
+            // Free memory objects (only free Conv* if they are different from User*)
+            if (ScratchpadMem != IntPtr.Zero) dnnl_memory_destroy(ScratchpadMem);
+            if (ConvDstMem != IntPtr.Zero && ConvDstMem != UserDstMem) dnnl_memory_destroy(ConvDstMem);
+            if (ConvWeightsMem != IntPtr.Zero && ConvWeightsMem != UserWeightsMem) dnnl_memory_destroy(ConvWeightsMem);
+            if (ConvSrcMem != IntPtr.Zero && ConvSrcMem != UserSrcMem) dnnl_memory_destroy(ConvSrcMem);
+            if (UserDstMem != IntPtr.Zero) dnnl_memory_destroy(UserDstMem);
+            if (UserWeightsMem != IntPtr.Zero) dnnl_memory_destroy(UserWeightsMem);
+            if (UserSrcMem != IntPtr.Zero) dnnl_memory_destroy(UserSrcMem);
+
+            // Free primitives
+            if (Primitive != IntPtr.Zero) dnnl_primitive_destroy(Primitive);
+            if (PrimDesc != IntPtr.Zero) dnnl_primitive_desc_destroy(PrimDesc);
+
+            // Free allocated buffers
+            if (ReorderedDstBuffer != IntPtr.Zero) Marshal.FreeHGlobal(ReorderedDstBuffer);
+            if (ReorderedWeightsBuffer != IntPtr.Zero) Marshal.FreeHGlobal(ReorderedWeightsBuffer);
+            if (ReorderedSrcBuffer != IntPtr.Zero) Marshal.FreeHGlobal(ReorderedSrcBuffer);
+
+            // Free memory descriptors
+            if (UserDstDesc != IntPtr.Zero) dnnl_memory_desc_destroy(UserDstDesc);
+            if (UserWeightsDesc != IntPtr.Zero) dnnl_memory_desc_destroy(UserWeightsDesc);
+            if (UserSrcDesc != IntPtr.Zero) dnnl_memory_desc_destroy(UserSrcDesc);
+        }
+    }
+
+    /// <summary>
+    /// Cache key for eltwise primitives, keyed by algorithm and length.
+    /// </summary>
+    private readonly struct EltwiseKey : IEquatable<EltwiseKey>
+    {
+        public readonly int Algorithm;
+        public readonly int Length;
+
+        public EltwiseKey(int algorithm, int length)
+        {
+            Algorithm = algorithm;
+            Length = length;
+        }
+
+        public bool Equals(EltwiseKey other) =>
+            Algorithm == other.Algorithm && Length == other.Length;
+
+        public override bool Equals(object? obj) => obj is EltwiseKey other && Equals(other);
+
+        public override int GetHashCode() => HashCode.Combine(Algorithm, Length);
+    }
+
+    /// <summary>
+    /// Cached eltwise primitive with memory object for reuse.
+    /// </summary>
+    private sealed class CachedEltwise : IDisposable
+    {
+        public IntPtr Primitive;
+        public IntPtr PrimDesc;
+        public IntPtr SrcDesc;
+        public IntPtr SrcMem;
+        private bool _disposed;
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+
+            if (SrcMem != IntPtr.Zero) dnnl_memory_destroy(SrcMem);
+            if (Primitive != IntPtr.Zero) dnnl_primitive_destroy(Primitive);
+            if (PrimDesc != IntPtr.Zero) dnnl_primitive_desc_destroy(PrimDesc);
+            if (SrcDesc != IntPtr.Zero) dnnl_memory_desc_destroy(SrcDesc);
+        }
+    }
+
+    /// <summary>
+    /// Cache key for binary primitives, keyed by algorithm and length.
+    /// </summary>
+    private readonly struct BinaryKey : IEquatable<BinaryKey>
+    {
+        public readonly int Algorithm;
+        public readonly int Length;
+
+        public BinaryKey(int algorithm, int length)
+        {
+            Algorithm = algorithm;
+            Length = length;
+        }
+
+        public bool Equals(BinaryKey other) =>
+            Algorithm == other.Algorithm && Length == other.Length;
+
+        public override bool Equals(object? obj) => obj is BinaryKey other && Equals(other);
+
+        public override int GetHashCode() => HashCode.Combine(Algorithm, Length);
+    }
+
+    /// <summary>
+    /// Cached binary primitive with memory objects for reuse.
+    /// </summary>
+    private sealed class CachedBinary : IDisposable
+    {
+        public IntPtr Primitive;
+        public IntPtr PrimDesc;
+        public IntPtr Src0Desc;
+        public IntPtr Src1Desc;
+        public IntPtr DstDesc;
+        public IntPtr Src0Mem;
+        public IntPtr Src1Mem;
+        public IntPtr DstMem;
+        private bool _disposed;
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+
+            if (Src0Mem != IntPtr.Zero) dnnl_memory_destroy(Src0Mem);
+            if (Src1Mem != IntPtr.Zero) dnnl_memory_destroy(Src1Mem);
+            if (DstMem != IntPtr.Zero) dnnl_memory_destroy(DstMem);
+            if (Primitive != IntPtr.Zero) dnnl_primitive_destroy(Primitive);
+            if (PrimDesc != IntPtr.Zero) dnnl_primitive_desc_destroy(PrimDesc);
+            if (Src0Desc != IntPtr.Zero) dnnl_memory_desc_destroy(Src0Desc);
+            if (Src1Desc != IntPtr.Zero) dnnl_memory_desc_destroy(Src1Desc);
+            if (DstDesc != IntPtr.Zero) dnnl_memory_desc_destroy(DstDesc);
+        }
+    }
+
+    /// <summary>
+    /// Cache key for softmax primitives, keyed by outer size and axis size.
+    /// </summary>
+    private readonly struct SoftmaxKey : IEquatable<SoftmaxKey>
+    {
+        public readonly int OuterSize;
+        public readonly int AxisSize;
+
+        public SoftmaxKey(int outerSize, int axisSize)
+        {
+            OuterSize = outerSize;
+            AxisSize = axisSize;
+        }
+
+        public bool Equals(SoftmaxKey other) =>
+            OuterSize == other.OuterSize && AxisSize == other.AxisSize;
+
+        public override bool Equals(object? obj) => obj is SoftmaxKey other && Equals(other);
+        public override int GetHashCode() => HashCode.Combine(OuterSize, AxisSize);
+    }
+
+    /// <summary>
+    /// Cached softmax primitive with source and destination memory objects.
+    /// </summary>
+    private sealed class CachedSoftmax : IDisposable
+    {
+        public IntPtr Primitive;
+        public IntPtr PrimDesc;
+        public IntPtr SrcDesc;
+        public IntPtr DstDesc;
+        public IntPtr SrcMem;
+        public IntPtr DstMem;
+        private bool _disposed;
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+
+            if (SrcMem != IntPtr.Zero) dnnl_memory_destroy(SrcMem);
+            if (DstMem != IntPtr.Zero) dnnl_memory_destroy(DstMem);
+            if (Primitive != IntPtr.Zero) dnnl_primitive_destroy(Primitive);
+            if (PrimDesc != IntPtr.Zero) dnnl_primitive_desc_destroy(PrimDesc);
+            if (SrcDesc != IntPtr.Zero) dnnl_memory_desc_destroy(SrcDesc);
+            if (DstDesc != IntPtr.Zero) dnnl_memory_desc_destroy(DstDesc);
+        }
+    }
+
+    #endregion
+
+    #region P/Invoke Declarations
+
+    [DllImport("dnnl", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int dnnl_engine_create(out IntPtr engine, int kind, int index);
+
+    [DllImport("dnnl", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr dnnl_version();
+
+    [DllImport("dnnl", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int dnnl_engine_destroy(IntPtr engine);
+
+    [DllImport("dnnl", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int dnnl_stream_create(out IntPtr stream, IntPtr engine, uint flags);
+
+    [DllImport("dnnl", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int dnnl_stream_destroy(IntPtr stream);
+
+    [DllImport("dnnl", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int dnnl_stream_wait(IntPtr stream);
+
+    [DllImport("dnnl", CallingConvention = CallingConvention.Cdecl)]
+    private static extern unsafe int dnnl_memory_desc_create_with_strides(
+        out IntPtr memoryDesc,
+        int ndims,
+        long* dims,
+        int dataType,
+        long* strides);
+
+    [DllImport("dnnl", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int dnnl_memory_desc_destroy(IntPtr memoryDesc);
+
+    [DllImport("dnnl", CallingConvention = CallingConvention.Cdecl)]
+    private static extern unsafe int dnnl_memory_desc_create_with_tag(
+        out IntPtr memoryDesc,
+        int ndims,
+        long* dims,
+        int dataType,
+        int formatTag);
+
+    [DllImport("dnnl", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int dnnl_reorder_primitive_desc_create(
+        out IntPtr reorderPrimDesc,
+        IntPtr srcMemDesc,
+        IntPtr srcEngine,
+        IntPtr dstMemDesc,
+        IntPtr dstEngine,
+        IntPtr attr);
+
+    [DllImport("dnnl", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int dnnl_memory_desc_equal(IntPtr lhs, IntPtr rhs);
+
+    [DllImport("dnnl", CallingConvention = CallingConvention.Cdecl)]
+    private static extern long dnnl_memory_desc_get_size(IntPtr memoryDesc);
+
+    [DllImport("dnnl", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int dnnl_memory_get_data_handle(IntPtr memory, out IntPtr handle);
+
+    [DllImport("dnnl", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int dnnl_memory_create(
+        out IntPtr memory,
+        IntPtr memoryDesc,
+        IntPtr engine,
+        IntPtr handle);
+
+    [DllImport("dnnl", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int dnnl_memory_destroy(IntPtr memory);
+
+    [DllImport("dnnl", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int dnnl_memory_set_data_handle(IntPtr memory, IntPtr handle);
+
+    [DllImport("dnnl", CallingConvention = CallingConvention.Cdecl)]
+    private static extern unsafe int dnnl_convolution_forward_primitive_desc_create(
+        out IntPtr primitiveDesc,
+        IntPtr engine,
+        int propKind,
+        int algKind,
+        IntPtr srcDesc,
+        IntPtr weightsDesc,
+        IntPtr biasDesc,
+        IntPtr dstDesc,
+        long* strides,
+        long* dilates,
+        long* paddingL,
+        long* paddingR,
+        IntPtr attr);
+
+    [DllImport("dnnl", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int dnnl_primitive_desc_destroy(IntPtr primitiveDesc);
+
+    [DllImport("dnnl", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr dnnl_primitive_desc_query_md(IntPtr primitiveDesc, int what, int index);
+
+    [DllImport("dnnl", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int dnnl_primitive_create(out IntPtr primitive, IntPtr primitiveDesc);
+
+    [DllImport("dnnl", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int dnnl_primitive_destroy(IntPtr primitive);
+
+    [DllImport("dnnl", CallingConvention = CallingConvention.Cdecl)]
+    private static extern unsafe int dnnl_primitive_execute(
+        IntPtr primitive,
+        IntPtr stream,
+        int nargs,
+        DnnlExecArg* args);
+
+    [DllImport("dnnl", CallingConvention = CallingConvention.Cdecl)]
+    private static extern unsafe int dnnl_eltwise_forward_primitive_desc_create(
+        out IntPtr primitiveDesc,
+        IntPtr engine,
+        int propKind,
+        int algKind,
+        IntPtr srcDesc,
+        IntPtr dstDesc,
+        float alpha,
+        float beta,
+        IntPtr attr);
+
+    [DllImport("dnnl", CallingConvention = CallingConvention.Cdecl)]
+    private static extern unsafe int dnnl_binary_primitive_desc_create(
+        out IntPtr primitiveDesc,
+        IntPtr engine,
+        int algKind,
+        IntPtr src0Desc,
+        IntPtr src1Desc,
+        IntPtr dstDesc,
+        IntPtr attr);
+
+    [DllImport("dnnl", CallingConvention = CallingConvention.Cdecl)]
+    private static extern unsafe int dnnl_softmax_forward_primitive_desc_create(
+        out IntPtr primitiveDesc,
+        IntPtr engine,
+        int propKind,
+        int algorithm,
+        IntPtr srcDesc,
+        IntPtr dstDesc,
+        int softmaxAxis,
+        IntPtr attr);
+
+    // Pooling forward primitive descriptor
+    // oneDNN 3.x: dnnl_pooling_forward_primitive_desc_create(
+    //   primitive_desc, engine, prop_kind, algorithm,
+    //   src_desc, dst_desc,
+    //   strides, kernel, dilation, padding_l, padding_r, attr)
+    [DllImport("dnnl", CallingConvention = CallingConvention.Cdecl)]
+    private static extern unsafe int dnnl_pooling_forward_primitive_desc_create(
+        out IntPtr primitiveDesc,
+        IntPtr engine,
+        int propKind,
+        int algorithm,
+        IntPtr srcDesc,
+        IntPtr dstDesc,
+        IntPtr strides,     // int64[] strides
+        IntPtr kernel,      // int64[] kernel sizes
+        IntPtr dilation,    // int64[] dilations (0 = no dilation)
+        IntPtr padL,        // int64[] padding left
+        IntPtr padR,        // int64[] padding right
+        IntPtr attr);
+
+    // Batch normalization forward primitive descriptor
+    [DllImport("dnnl", CallingConvention = CallingConvention.Cdecl)]
+    private static extern unsafe int dnnl_batch_normalization_forward_primitive_desc_create(
+        out IntPtr primitiveDesc,
+        IntPtr engine,
+        int propKind,
+        IntPtr srcDesc,
+        IntPtr dstDesc,
+        float epsilon,
+        uint flags,
+        IntPtr attr);
+
+    // Pooling algorithm constants
+    private const int DnnlPoolingAvgIncludePadding = 0x200;
+    private const int DnnlPoolingAvgExcludePadding = 0x201;
+
+    // BatchNorm flags
+    private const uint DnnlUseGlobalStats = 0x1;
+    private const uint DnnlUseScaleShift = 0x2; // oneDNN 2.x
+    private const uint DnnlUseScale = 0x10;     // oneDNN 3.x
+    private const uint DnnlUseShift = 0x20;     // oneDNN 3.x
+
+    #endregion
+
+    /// <summary>
+    /// Returns true if oneDNN is available.
+    /// </summary>
+    internal static bool IsAvailable
+    {
+        get
+        {
+            EnsureInitialized();
+            return _available;
+        }
+    }
+
+    /// <summary>
+    /// Performs Conv2D using oneDNN with cached primitives and pinned memory for maximum performance.
+    /// </summary>
     internal static unsafe bool TryConv2D(
         float* input, int batch, int inChannels, int height, int width,
         float* kernel, int outChannels, int kernelH, int kernelW,
         float* output, int outHeight, int outWidth,
         int strideH, int strideW, int padH, int padW, int dilationH, int dilationW)
-        => false;
+    {
+        // Gate all chatter behind the trace flag so production output stays clean.
+        bool logThis = TraceEnabled;
 
-    internal static unsafe bool TryReLU(float* data, int length) => false;
+        if (!EnsureInitialized())
+        {
+            if (logThis) Console.WriteLine("[oneDNN] TryConv2D: Not initialized");
+            return false;
+        }
 
-    internal static unsafe bool TrySigmoid(float* data, int length) => false;
+        if (logThis)
+        {
+            Console.WriteLine($"[oneDNN] TryConv2D: batch={batch}, inC={inChannels}, H={height}, W={width}, outC={outChannels}, kH={kernelH}, kW={kernelW}");
+        }
 
-    internal static unsafe bool TryAdd(float* src0, float* src1, float* dst, int length) => false;
+        // Create cache key
+        var key = new Conv2DKey(batch, inChannels, height, width, outChannels, kernelH, kernelW,
+            strideH, strideW, padH, padW, dilationH, dilationW);
 
-    internal static unsafe bool TryMultiply(float* src0, float* src1, float* dst, int length) => false;
+        // Try to get cached primitive or create new one
+        if (!_conv2DCache.TryGetValue(key, out var cached))
+        {
+            cached = CreateConv2DPrimitive(key, outHeight, outWidth, logThis);
+            if (cached == null)
+            {
+                return false;
+            }
 
-    internal static unsafe bool TrySoftmax(float* input, float* output, int outerSize, int axisSize) => false;
+            // Add to cache (limit cache size)
+            if (_conv2DCache.Count >= MaxCacheSize)
+            {
+                // Remove a random entry to make room
+                foreach (var k in _conv2DCache.Keys)
+                {
+                    if (_conv2DCache.TryRemove(k, out var removed))
+                    {
+                        removed.Dispose();
+                        break;
+                    }
+                }
+            }
+            _conv2DCache[key] = cached;
+            if (logThis) Console.WriteLine("[oneDNN] Created and cached new primitive");
+        }
+        else
+        {
+            if (logThis) Console.WriteLine("[oneDNN] Using cached primitive");
+        }
+
+        try
+        {
+            int status;
+
+            // Step 1: Set user memory data handles to point to user data
+            status = dnnl_memory_set_data_handle(cached.UserSrcMem, (IntPtr)input);
+            if (status != DnnlSuccess) { if (logThis) Console.WriteLine($"[oneDNN] Failed to set src handle: {status}"); return false; }
+
+            status = dnnl_memory_set_data_handle(cached.UserWeightsMem, (IntPtr)kernel);
+            if (status != DnnlSuccess) { if (logThis) Console.WriteLine($"[oneDNN] Failed to set weights handle: {status}"); return false; }
+
+            status = dnnl_memory_set_data_handle(cached.UserDstMem, (IntPtr)output);
+            if (status != DnnlSuccess) { if (logThis) Console.WriteLine($"[oneDNN] Failed to set dst handle: {status}"); return false; }
+
+            // Step 2: Execute source reorder if needed (NCHW -> blocked format)
+            if (cached.NeedsSrcReorder)
+            {
+                DnnlExecArg* srcReorderArgs = stackalloc DnnlExecArg[2];
+                srcReorderArgs[0].Arg = DnnlArgSrc;
+                srcReorderArgs[0].Memory = cached.UserSrcMem;
+                srcReorderArgs[1].Arg = DnnlArgDst;
+                srcReorderArgs[1].Memory = cached.ConvSrcMem;
+
+                status = dnnl_primitive_execute(cached.SrcReorderPrim, _stream, 2, srcReorderArgs);
+                if (status != DnnlSuccess) { if (logThis) Console.WriteLine($"[oneDNN] Src reorder failed: {status}"); return false; }
+            }
+
+            // Step 3: Execute weights reorder if needed (only first time - weights are cached)
+            if (cached.NeedsWeightsReorder && !cached.WeightsReordered)
+            {
+                DnnlExecArg* weightsReorderArgs = stackalloc DnnlExecArg[2];
+                weightsReorderArgs[0].Arg = DnnlArgSrc;
+                weightsReorderArgs[0].Memory = cached.UserWeightsMem;
+                weightsReorderArgs[1].Arg = DnnlArgDst;
+                weightsReorderArgs[1].Memory = cached.ConvWeightsMem;
+
+                status = dnnl_primitive_execute(cached.WeightsReorderPrim, _stream, 2, weightsReorderArgs);
+                if (status != DnnlSuccess) { if (logThis) Console.WriteLine($"[oneDNN] Weights reorder failed: {status}"); return false; }
+
+                cached.WeightsReordered = true;
+                if (logThis) Console.WriteLine("[oneDNN] Weights reordered to blocked format (cached for future use)");
+            }
+
+            // Step 4: Execute convolution with optimal format memory objects
+            DnnlExecArg* convArgs = stackalloc DnnlExecArg[4];
+            convArgs[0].Arg = DnnlArgSrc;
+            convArgs[0].Memory = cached.ConvSrcMem;
+            convArgs[1].Arg = DnnlArgWeights;
+            convArgs[1].Memory = cached.ConvWeightsMem;
+            convArgs[2].Arg = DnnlArgDst;
+            convArgs[2].Memory = cached.ConvDstMem;
+            convArgs[3].Arg = DnnlArgScratchpad;
+            convArgs[3].Memory = cached.ScratchpadMem;
+
+            status = dnnl_primitive_execute(cached.Primitive, _stream, 4, convArgs);
+            if (status != DnnlSuccess) { if (logThis) Console.WriteLine($"[oneDNN] Conv execute failed: {status}"); return false; }
+
+            // Step 5: Execute destination reorder if needed (blocked format -> NCHW)
+            if (cached.NeedsDstReorder)
+            {
+                DnnlExecArg* dstReorderArgs = stackalloc DnnlExecArg[2];
+                dstReorderArgs[0].Arg = DnnlArgSrc;
+                dstReorderArgs[0].Memory = cached.ConvDstMem;
+                dstReorderArgs[1].Arg = DnnlArgDst;
+                dstReorderArgs[1].Memory = cached.UserDstMem;
+
+                status = dnnl_primitive_execute(cached.DstReorderPrim, _stream, 2, dstReorderArgs);
+                if (status != DnnlSuccess) { if (logThis) Console.WriteLine($"[oneDNN] Dst reorder failed: {status}"); return false; }
+            }
+
+            dnnl_stream_wait(_stream);
+
+            if (logThis)
+            {
+                Console.WriteLine("[oneDNN] Conv2D completed successfully");
+            }
+            return true;
+        }
+        catch (Exception ex)
+        {
+            if (logThis)
+            {
+                Console.WriteLine($"[oneDNN] Conv2D exception: {ex.Message}");
+            }
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Performs in-place ReLU using oneDNN's optimized eltwise primitive with caching.
+    /// </summary>
+    /// <param name="data">Pointer to float array to transform in-place.</param>
+    /// <param name="length">Number of elements.</param>
+    /// <returns>True if successful, false if oneDNN not available or operation failed.</returns>
+    internal static unsafe bool TryReLU(float* data, int length)
+    {
+        return TryEltwiseInPlace(data, length, DnnlEltwiseRelu);
+    }
+
+    /// <summary>
+    /// Performs in-place Sigmoid using oneDNN's optimized eltwise primitive with caching.
+    /// </summary>
+    /// <param name="data">Pointer to float array to transform in-place.</param>
+    /// <param name="length">Number of elements.</param>
+    /// <returns>True if successful, false if oneDNN not available or operation failed.</returns>
+    internal static unsafe bool TrySigmoid(float* data, int length)
+    {
+        return TryEltwiseInPlace(data, length, DnnlEltwiseLogistic);
+    }
+
+    /// <summary>
+    /// Performs in-place eltwise operation using cached oneDNN primitives.
+    /// Uses a reader-writer lock to prevent use-after-free during cache eviction.
+    /// </summary>
+    private static unsafe bool TryEltwiseInPlace(float* data, int length, int algorithm)
+    {
+        if (!EnsureInitialized())
+            return false;
+
+        var key = new EltwiseKey(algorithm, length);
+        CachedEltwise? cached = null;
+
+        // Acquire read lock to prevent eviction while we're using the cached object
+        _eltwiseCacheLock.EnterReadLock();
+        try
+        {
+            // Try to get cached primitive
+            if (_eltwiseCache.TryGetValue(key, out cached))
+            {
+                // Cache hit - execute under read lock
+                return ExecuteEltwiseOperation(cached, data);
+            }
+        }
+        finally
+        {
+            _eltwiseCacheLock.ExitReadLock();
+        }
+
+        // Cache miss - need to create a new primitive under write lock
+        _eltwiseCacheLock.EnterWriteLock();
+        try
+        {
+            // Double-check after acquiring write lock (another thread may have added it)
+            if (!_eltwiseCache.TryGetValue(key, out cached))
+            {
+                cached = CreateEltwisePrimitive(algorithm, length);
+                if (cached == null)
+                    return false;
+
+                _eltwiseCache[key] = cached;
+
+                // Perform eviction under write lock (safe - no readers can be using evicted entries)
+                if (_eltwiseCache.Count > MaxEltwiseCacheSize)
+                {
+                    foreach (var k in _eltwiseCache.Keys)
+                    {
+                        if (!k.Equals(key) && _eltwiseCache.TryRemove(k, out var removed))
+                        {
+                            removed.Dispose();
+                            break;
+                        }
+                    }
+                }
+            }
+
+            // Execute the operation while still holding write lock
+            // This eliminates the race window between lock release and re-acquisition
+            return ExecuteEltwiseOperation(cached, data);
+        }
+        catch
+        {
+            return false;
+        }
+        finally
+        {
+            _eltwiseCacheLock.ExitWriteLock();
+        }
+    }
+
+    /// <summary>
+    /// Executes the eltwise operation on the given data using the cached primitive.
+    /// Must be called while holding either a read or write lock on _eltwiseCacheLock.
+    /// </summary>
+    private static unsafe bool ExecuteEltwiseOperation(CachedEltwise cached, float* data)
+    {
+        try
+        {
+            // Update memory handle to point to user data
+            int status = dnnl_memory_set_data_handle(cached.SrcMem, (IntPtr)data);
+            if (status != DnnlSuccess)
+                return false;
+
+            // Execute eltwise in-place (src and dst point to same memory)
+            DnnlExecArg* args = stackalloc DnnlExecArg[2];
+            args[0].Arg = DnnlArgSrc;
+            args[0].Memory = cached.SrcMem;
+            args[1].Arg = DnnlArgDst;
+            args[1].Memory = cached.SrcMem; // In-place
+
+            status = dnnl_primitive_execute(cached.Primitive, _stream, 2, args);
+            if (status != DnnlSuccess)
+                return false;
+
+            dnnl_stream_wait(_stream);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Creates a new eltwise primitive for caching.
+    /// </summary>
+    private static unsafe CachedEltwise? CreateEltwisePrimitive(int algorithm, int length)
+    {
+        var cached = new CachedEltwise();
+
+        try
+        {
+            // Create 1D memory descriptor for the data
+            long* dims = stackalloc long[1];
+            dims[0] = length;
+
+            long* strides = stackalloc long[1];
+            strides[0] = 1;
+
+            int status = dnnl_memory_desc_create_with_strides(out cached.SrcDesc, 1, dims, DnnlF32, strides);
+            if (status != DnnlSuccess)
+            {
+                cached.Dispose();
+                return null;
+            }
+
+            // Create eltwise primitive descriptor
+            status = dnnl_eltwise_forward_primitive_desc_create(
+                out cached.PrimDesc, _engine, DnnlForwardInference, algorithm,
+                cached.SrcDesc, cached.SrcDesc, 0.0f, 0.0f, IntPtr.Zero);
+            if (status != DnnlSuccess)
+            {
+                cached.Dispose();
+                return null;
+            }
+
+            // Create primitive
+            status = dnnl_primitive_create(out cached.Primitive, cached.PrimDesc);
+            if (status != DnnlSuccess)
+            {
+                cached.Dispose();
+                return null;
+            }
+
+            // Create memory object with null handle (will be set on each call)
+            status = dnnl_memory_create(out cached.SrcMem, cached.SrcDesc, _engine, IntPtr.Zero);
+            if (status != DnnlSuccess)
+            {
+                cached.Dispose();
+                return null;
+            }
+
+            return cached;
+        }
+        catch
+        {
+            cached.Dispose();
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Performs element-wise addition using oneDNN's optimized binary primitive with caching.
+    /// </summary>
+    internal static unsafe bool TryAdd(float* src0, float* src1, float* dst, int length)
+    {
+        return TryBinary(src0, src1, dst, length, DnnlBinaryAdd);
+    }
+
+    /// <summary>
+    /// Performs element-wise multiplication using oneDNN's optimized binary primitive with caching.
+    /// </summary>
+    internal static unsafe bool TryMultiply(float* src0, float* src1, float* dst, int length)
+    {
+        return TryBinary(src0, src1, dst, length, DnnlBinaryMul);
+    }
+
+    /// <summary>
+    /// Performs softmax using oneDNN's fused SVML-accelerated implementation.
+    /// oneDNN softmax is a single fused primitive — max, subtract, exp, sum, divide are all
+    /// computed in 2 optimized passes with inlined SVML exp. This matches or beats TorchSharp's
+    /// libtorch softmax which uses the same oneDNN/MKLDNN backend.
+    /// </summary>
+    /// <param name="input">Source data pointer (not modified).</param>
+    /// <param name="output">Destination data pointer (receives softmax output).</param>
+    /// <param name="outerSize">Number of independent softmax rows (batch * spatial).</param>
+    /// <param name="axisSize">Size of the softmax axis (number of classes).</param>
+    internal static unsafe bool TrySoftmax(float* input, float* output, int outerSize, int axisSize)
+    {
+        if (!EnsureInitialized())
+            return false;
+
+        var key = new SoftmaxKey(outerSize, axisSize);
+        CachedSoftmax? cached = null;
+
+        _softmaxCacheLock.EnterReadLock();
+        try
+        {
+            if (_softmaxCache.TryGetValue(key, out cached))
+                return ExecuteSoftmaxOperation(cached, input, output);
+        }
+        finally
+        {
+            _softmaxCacheLock.ExitReadLock();
+        }
+
+        _softmaxCacheLock.EnterWriteLock();
+        try
+        {
+            if (!_softmaxCache.TryGetValue(key, out cached))
+            {
+                cached = CreateSoftmaxPrimitive(outerSize, axisSize);
+                if (cached == null)
+                    return false;
+
+                _softmaxCache[key] = cached;
+
+                if (_softmaxCache.Count > MaxSoftmaxCacheSize)
+                {
+                    foreach (var k in _softmaxCache.Keys)
+                    {
+                        if (!k.Equals(key) && _softmaxCache.TryRemove(k, out var removed))
+                        {
+                            removed.Dispose();
+                            break;
+                        }
+                    }
+                }
+            }
+
+            return ExecuteSoftmaxOperation(cached, input, output);
+        }
+        catch
+        {
+            return false;
+        }
+        finally
+        {
+            _softmaxCacheLock.ExitWriteLock();
+        }
+    }
+
+    private static unsafe bool ExecuteSoftmaxOperation(CachedSoftmax cached, float* src, float* dst)
+    {
+        try
+        {
+            int status = dnnl_memory_set_data_handle(cached.SrcMem, (IntPtr)src);
+            if (status != DnnlSuccess) return false;
+
+            status = dnnl_memory_set_data_handle(cached.DstMem, (IntPtr)dst);
+            if (status != DnnlSuccess) return false;
+
+            DnnlExecArg* args = stackalloc DnnlExecArg[2];
+            args[0].Arg = DnnlArgSrc;
+            args[0].Memory = cached.SrcMem;
+            args[1].Arg = DnnlArgDst;
+            args[1].Memory = cached.DstMem;
+
+            status = dnnl_primitive_execute(cached.Primitive, _stream, 2, args);
+            if (status != DnnlSuccess) return false;
+
+            dnnl_stream_wait(_stream);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static unsafe CachedSoftmax? CreateSoftmaxPrimitive(int outerSize, int axisSize)
+    {
+        var cached = new CachedSoftmax();
+
+        try
+        {
+            // Create 2D memory descriptor: [outerSize, axisSize]
+            // Softmax is applied along axis 1 (the axisSize dimension)
+            long* dims = stackalloc long[2];
+            dims[0] = outerSize;
+            dims[1] = axisSize;
+
+            long* strides = stackalloc long[2];
+            strides[0] = axisSize; // row-major: stride for dim 0 = axisSize
+            strides[1] = 1;       // stride for dim 1 = 1
+
+            int status = dnnl_memory_desc_create_with_strides(
+                out cached.SrcDesc, 2, dims, DnnlF32, strides);
+            if (status != DnnlSuccess) { cached.Dispose(); return null; }
+
+            status = dnnl_memory_desc_create_with_strides(
+                out cached.DstDesc, 2, dims, DnnlF32, strides);
+            if (status != DnnlSuccess) { cached.Dispose(); return null; }
+
+            // Create softmax primitive descriptor — axis=1 (softmax along the class dimension)
+            status = dnnl_softmax_forward_primitive_desc_create(
+                out cached.PrimDesc, _engine, DnnlForwardInference, DnnlSoftmaxAccurate,
+                cached.SrcDesc, cached.DstDesc, 1, IntPtr.Zero);
+            if (status != DnnlSuccess) { cached.Dispose(); return null; }
+
+            // Create primitive
+            status = dnnl_primitive_create(out cached.Primitive, cached.PrimDesc);
+            if (status != DnnlSuccess) { cached.Dispose(); return null; }
+
+            // Create memory objects with null handle
+            status = dnnl_memory_create(out cached.SrcMem, cached.SrcDesc, _engine, IntPtr.Zero);
+            if (status != DnnlSuccess) { cached.Dispose(); return null; }
+
+            status = dnnl_memory_create(out cached.DstMem, cached.DstDesc, _engine, IntPtr.Zero);
+            if (status != DnnlSuccess) { cached.Dispose(); return null; }
+
+            return cached;
+        }
+        catch
+        {
+            cached.Dispose();
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Performs binary operation using cached oneDNN primitives.
+    /// Uses a reader-writer lock to prevent use-after-free during cache eviction.
+    /// </summary>
+    private static unsafe bool TryBinary(float* src0, float* src1, float* dst, int length, int algorithm)
+    {
+        if (!EnsureInitialized())
+            return false;
+
+        var key = new BinaryKey(algorithm, length);
+        CachedBinary? cached = null;
+
+        // Acquire read lock to prevent eviction while we're using the cached object
+        _binaryCacheLock.EnterReadLock();
+        try
+        {
+            // Try to get cached primitive
+            if (_binaryCache.TryGetValue(key, out cached))
+            {
+                // Cache hit - execute under read lock
+                return ExecuteBinaryOperation(cached, src0, src1, dst);
+            }
+        }
+        finally
+        {
+            _binaryCacheLock.ExitReadLock();
+        }
+
+        // Cache miss - need to create a new primitive under write lock
+        _binaryCacheLock.EnterWriteLock();
+        try
+        {
+            // Double-check after acquiring write lock (another thread may have added it)
+            if (!_binaryCache.TryGetValue(key, out cached))
+            {
+                cached = CreateBinaryPrimitive(algorithm, length);
+                if (cached == null)
+                    return false;
+
+                _binaryCache[key] = cached;
+
+                // Perform eviction under write lock (safe - no readers can be using evicted entries)
+                if (_binaryCache.Count > MaxBinaryCacheSize)
+                {
+                    foreach (var k in _binaryCache.Keys)
+                    {
+                        // Don't evict the entry we just added
+                        if (!k.Equals(key) && _binaryCache.TryRemove(k, out var removed))
+                        {
+                            removed.Dispose();
+                            break;
+                        }
+                    }
+                }
+            }
+
+            // Execute the operation while still holding write lock
+            // This eliminates the race window between lock release and re-acquisition
+            return ExecuteBinaryOperation(cached, src0, src1, dst);
+        }
+        catch
+        {
+            return false;
+        }
+        finally
+        {
+            _binaryCacheLock.ExitWriteLock();
+        }
+    }
+
+    /// <summary>
+    /// Executes the binary operation on the given data using the cached primitive.
+    /// Must be called while holding either a read or write lock on _binaryCacheLock.
+    /// </summary>
+    private static unsafe bool ExecuteBinaryOperation(CachedBinary cached, float* src0, float* src1, float* dst)
+    {
+        try
+        {
+            // Update memory handles
+            int status = dnnl_memory_set_data_handle(cached.Src0Mem, (IntPtr)src0);
+            if (status != DnnlSuccess)
+                return false;
+
+            status = dnnl_memory_set_data_handle(cached.Src1Mem, (IntPtr)src1);
+            if (status != DnnlSuccess)
+                return false;
+
+            status = dnnl_memory_set_data_handle(cached.DstMem, (IntPtr)dst);
+            if (status != DnnlSuccess)
+                return false;
+
+            // Execute with 3 arguments: src0, src1, dst
+            DnnlExecArg* args = stackalloc DnnlExecArg[3];
+            args[0].Arg = DnnlArgSrc0;
+            args[0].Memory = cached.Src0Mem;
+            args[1].Arg = DnnlArgSrc1;
+            args[1].Memory = cached.Src1Mem;
+            args[2].Arg = DnnlArgDst;
+            args[2].Memory = cached.DstMem;
+
+            status = dnnl_primitive_execute(cached.Primitive, _stream, 3, args);
+            if (status != DnnlSuccess)
+                return false;
+
+            dnnl_stream_wait(_stream);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Creates a new binary primitive for caching.
+    /// </summary>
+    private static unsafe CachedBinary? CreateBinaryPrimitive(int algorithm, int length)
+    {
+        var cached = new CachedBinary();
+
+        try
+        {
+            // Create 1D memory descriptor for the data
+            long* dims = stackalloc long[1];
+            dims[0] = length;
+
+            long* strides = stackalloc long[1];
+            strides[0] = 1;
+
+            int status = dnnl_memory_desc_create_with_strides(out cached.Src0Desc, 1, dims, DnnlF32, strides);
+            if (status != DnnlSuccess)
+            {
+                cached.Dispose();
+                return null;
+            }
+
+            status = dnnl_memory_desc_create_with_strides(out cached.Src1Desc, 1, dims, DnnlF32, strides);
+            if (status != DnnlSuccess)
+            {
+                cached.Dispose();
+                return null;
+            }
+
+            status = dnnl_memory_desc_create_with_strides(out cached.DstDesc, 1, dims, DnnlF32, strides);
+            if (status != DnnlSuccess)
+            {
+                cached.Dispose();
+                return null;
+            }
+
+            // Create binary primitive descriptor
+            status = dnnl_binary_primitive_desc_create(
+                out cached.PrimDesc, _engine, algorithm,
+                cached.Src0Desc, cached.Src1Desc, cached.DstDesc, IntPtr.Zero);
+            if (status != DnnlSuccess)
+            {
+                cached.Dispose();
+                return null;
+            }
+
+            // Create primitive
+            status = dnnl_primitive_create(out cached.Primitive, cached.PrimDesc);
+            if (status != DnnlSuccess)
+            {
+                cached.Dispose();
+                return null;
+            }
+
+            // Create memory objects with null handles (will be set on each call)
+            status = dnnl_memory_create(out cached.Src0Mem, cached.Src0Desc, _engine, IntPtr.Zero);
+            if (status != DnnlSuccess)
+            {
+                cached.Dispose();
+                return null;
+            }
+
+            status = dnnl_memory_create(out cached.Src1Mem, cached.Src1Desc, _engine, IntPtr.Zero);
+            if (status != DnnlSuccess)
+            {
+                cached.Dispose();
+                return null;
+            }
+
+            status = dnnl_memory_create(out cached.DstMem, cached.DstDesc, _engine, IntPtr.Zero);
+            if (status != DnnlSuccess)
+            {
+                cached.Dispose();
+                return null;
+            }
+
+            return cached;
+        }
+        catch
+        {
+            cached.Dispose();
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Creates a new Conv2D primitive with all associated memory objects.
+    /// Uses "any" format descriptors to let oneDNN choose optimal data layouts,
+    /// with reorder primitives for format conversion.
+    /// </summary>
+    private static unsafe CachedConv2D? CreateConv2DPrimitive(Conv2DKey key, int outHeight, int outWidth, bool logThis)
+    {
+        var cached = new CachedConv2D { OutHeight = outHeight, OutWidth = outWidth };
+
+        IntPtr anySrcDesc = IntPtr.Zero;
+        IntPtr anyWeightsDesc = IntPtr.Zero;
+        IntPtr anyDstDesc = IntPtr.Zero;
+
+        try
+        {
+            // Create dimension arrays
+            long* srcDims = stackalloc long[4];
+            srcDims[0] = key.Batch;
+            srcDims[1] = key.InChannels;
+            srcDims[2] = key.Height;
+            srcDims[3] = key.Width;
+
+            long* weightsDims = stackalloc long[4];
+            weightsDims[0] = key.OutChannels;
+            weightsDims[1] = key.InChannels;
+            weightsDims[2] = key.KernelH;
+            weightsDims[3] = key.KernelW;
+
+            long* dstDims = stackalloc long[4];
+            dstDims[0] = key.Batch;
+            dstDims[1] = key.OutChannels;
+            dstDims[2] = outHeight;
+            dstDims[3] = outWidth;
+
+            long* stridesArr = stackalloc long[2];
+            stridesArr[0] = key.StrideH;
+            stridesArr[1] = key.StrideW;
+
+            long* dilatesArr = stackalloc long[2];
+            dilatesArr[0] = key.DilationH - 1;
+            dilatesArr[1] = key.DilationW - 1;
+
+            long* paddingLArr = stackalloc long[2];
+            paddingLArr[0] = key.PadH;
+            paddingLArr[1] = key.PadW;
+
+            long* paddingRArr = stackalloc long[2];
+            paddingRArr[0] = key.PadH;
+            paddingRArr[1] = key.PadW;
+
+            // Create NCHW strides for user format
+            long* srcStrides = stackalloc long[4];
+            srcStrides[0] = (long)key.InChannels * key.Height * key.Width;
+            srcStrides[1] = (long)key.Height * key.Width;
+            srcStrides[2] = key.Width;
+            srcStrides[3] = 1;
+
+            long* weightsStrides = stackalloc long[4];
+            weightsStrides[0] = (long)key.InChannels * key.KernelH * key.KernelW;
+            weightsStrides[1] = (long)key.KernelH * key.KernelW;
+            weightsStrides[2] = key.KernelW;
+            weightsStrides[3] = 1;
+
+            long* dstStrides = stackalloc long[4];
+            dstStrides[0] = (long)key.OutChannels * outHeight * outWidth;
+            dstStrides[1] = (long)outHeight * outWidth;
+            dstStrides[2] = outWidth;
+            dstStrides[3] = 1;
+
+            // Create user format memory descriptors (plain NCHW using strides)
+            int status = dnnl_memory_desc_create_with_strides(out cached.UserSrcDesc, 4, srcDims, DnnlF32, srcStrides);
+            if (status != DnnlSuccess) { if (logThis) Console.WriteLine($"[oneDNN] Failed to create user src desc: {status}"); cached.Dispose(); return null; }
+
+            status = dnnl_memory_desc_create_with_strides(out cached.UserWeightsDesc, 4, weightsDims, DnnlF32, weightsStrides);
+            if (status != DnnlSuccess) { if (logThis) Console.WriteLine($"[oneDNN] Failed to create user weights desc: {status}"); cached.Dispose(); return null; }
+
+            status = dnnl_memory_desc_create_with_strides(out cached.UserDstDesc, 4, dstDims, DnnlF32, dstStrides);
+            if (status != DnnlSuccess) { if (logThis) Console.WriteLine($"[oneDNN] Failed to create user dst desc: {status}"); cached.Dispose(); return null; }
+
+            // Determine whether to use format_tag_any (blocked formats) or user format (NCHW)
+            // Blocked formats enable brgconv algorithm which is ~6x faster than GEMM, even with reorder overhead
+            // Only skip for very small tensors where primitive overhead dominates
+            long outputElements = (long)key.Batch * key.OutChannels * outHeight * outWidth;
+            bool useBlockedFormat = outputElements >= 8 * 1024; // 8K elements (~32KB output) - use blocked for most cases
+
+            if (logThis)
+            {
+                Console.WriteLine($"[oneDNN] Output elements: {outputElements}, using blocked format: {useBlockedFormat}");
+            }
+
+            if (useBlockedFormat)
+            {
+                // Create "any" format descriptors to let oneDNN choose optimal layout
+                // This enables blocked formats (nChw16c) which allow Winograd for 3x3 kernels
+                status = dnnl_memory_desc_create_with_tag(out anySrcDesc, 4, srcDims, DnnlF32, DnnlFormatTagAny);
+                if (status != DnnlSuccess) { if (logThis) Console.WriteLine($"[oneDNN] Failed to create any src desc: {status}"); cached.Dispose(); return null; }
+
+                status = dnnl_memory_desc_create_with_tag(out anyWeightsDesc, 4, weightsDims, DnnlF32, DnnlFormatTagAny);
+                if (status != DnnlSuccess) { if (logThis) Console.WriteLine($"[oneDNN] Failed to create any weights desc: {status}"); cached.Dispose(); return null; }
+
+                status = dnnl_memory_desc_create_with_tag(out anyDstDesc, 4, dstDims, DnnlF32, DnnlFormatTagAny);
+                if (status != DnnlSuccess) { if (logThis) Console.WriteLine($"[oneDNN] Failed to create any dst desc: {status}"); cached.Dispose(); return null; }
+
+                // Create convolution primitive descriptor with "any" format descriptors
+                status = dnnl_convolution_forward_primitive_desc_create(
+                    out cached.PrimDesc, _engine, DnnlForwardInference, DnnlConvolutionAuto,
+                    anySrcDesc, anyWeightsDesc, IntPtr.Zero, anyDstDesc,
+                    stridesArr, dilatesArr, paddingLArr, paddingRArr, IntPtr.Zero);
+            }
+            else
+            {
+                // Use user format (NCHW) directly to avoid reorder overhead for small tensors
+                status = dnnl_convolution_forward_primitive_desc_create(
+                    out cached.PrimDesc, _engine, DnnlForwardInference, DnnlConvolutionAuto,
+                    cached.UserSrcDesc, cached.UserWeightsDesc, IntPtr.Zero, cached.UserDstDesc,
+                    stridesArr, dilatesArr, paddingLArr, paddingRArr, IntPtr.Zero);
+            }
+            if (status != DnnlSuccess) { if (logThis) Console.WriteLine($"[oneDNN] Failed to create conv prim desc: {status}"); cached.Dispose(); return null; }
+
+            // Query the memory descriptors that oneDNN chose
+            IntPtr convSrcDesc = dnnl_primitive_desc_query_md(cached.PrimDesc, DnnlQuerySrcMd, 0);
+            IntPtr convWeightsDesc = dnnl_primitive_desc_query_md(cached.PrimDesc, DnnlQueryWeightsMd, 0);
+            IntPtr convDstDesc = dnnl_primitive_desc_query_md(cached.PrimDesc, DnnlQueryDstMd, 0);
+            IntPtr scratchpadDesc = dnnl_primitive_desc_query_md(cached.PrimDesc, DnnlQueryScratchpadMd, 0);
+
+            if (convSrcDesc == IntPtr.Zero || convWeightsDesc == IntPtr.Zero || convDstDesc == IntPtr.Zero)
+            {
+                if (logThis) Console.WriteLine("[oneDNN] Queried memory descriptors are null");
+                cached.Dispose();
+                return null;
+            }
+
+            // Check if reorders are needed by comparing user format with oneDNN's chosen format
+            cached.NeedsSrcReorder = dnnl_memory_desc_equal(cached.UserSrcDesc, convSrcDesc) == 0;
+            cached.NeedsWeightsReorder = dnnl_memory_desc_equal(cached.UserWeightsDesc, convWeightsDesc) == 0;
+            cached.NeedsDstReorder = dnnl_memory_desc_equal(cached.UserDstDesc, convDstDesc) == 0;
+
+            if (logThis)
+            {
+                Console.WriteLine($"[oneDNN] Reorder needed: src={cached.NeedsSrcReorder}, weights={cached.NeedsWeightsReorder}, dst={cached.NeedsDstReorder}");
+            }
+
+            // Create primitive
+            status = dnnl_primitive_create(out cached.Primitive, cached.PrimDesc);
+            if (status != DnnlSuccess) { if (logThis) Console.WriteLine($"[oneDNN] Failed to create primitive: {status}"); cached.Dispose(); return null; }
+
+            // Create user format memory objects
+            status = dnnl_memory_create(out cached.UserSrcMem, cached.UserSrcDesc, _engine, IntPtr.Zero);
+            if (status != DnnlSuccess) { if (logThis) Console.WriteLine($"[oneDNN] Failed to create user src mem: {status}"); cached.Dispose(); return null; }
+
+            status = dnnl_memory_create(out cached.UserWeightsMem, cached.UserWeightsDesc, _engine, IntPtr.Zero);
+            if (status != DnnlSuccess) { if (logThis) Console.WriteLine($"[oneDNN] Failed to create user weights mem: {status}"); cached.Dispose(); return null; }
+
+            status = dnnl_memory_create(out cached.UserDstMem, cached.UserDstDesc, _engine, IntPtr.Zero);
+            if (status != DnnlSuccess) { if (logThis) Console.WriteLine($"[oneDNN] Failed to create user dst mem: {status}"); cached.Dispose(); return null; }
+
+            // Create reorder primitives and allocate buffers if needed
+            if (cached.NeedsSrcReorder)
+            {
+                long srcSize = dnnl_memory_desc_get_size(convSrcDesc);
+                cached.ReorderedSrcBuffer = Marshal.AllocHGlobal((IntPtr)srcSize);
+
+                status = dnnl_memory_create(out cached.ConvSrcMem, convSrcDesc, _engine, cached.ReorderedSrcBuffer);
+                if (status != DnnlSuccess) { if (logThis) Console.WriteLine($"[oneDNN] Failed to create conv src mem: {status}"); cached.Dispose(); return null; }
+
+                // Create reorder primitive: user src -> conv src
+                status = dnnl_reorder_primitive_desc_create(out IntPtr srcReorderPrimDesc,
+                    cached.UserSrcDesc, _engine, convSrcDesc, _engine, IntPtr.Zero);
+                if (status != DnnlSuccess) { if (logThis) Console.WriteLine($"[oneDNN] Failed to create src reorder prim desc: {status}"); cached.Dispose(); return null; }
+
+                status = dnnl_primitive_create(out cached.SrcReorderPrim, srcReorderPrimDesc);
+                dnnl_primitive_desc_destroy(srcReorderPrimDesc);
+                if (status != DnnlSuccess) { if (logThis) Console.WriteLine($"[oneDNN] Failed to create src reorder prim: {status}"); cached.Dispose(); return null; }
+            }
+            else
+            {
+                // No reorder needed - conv uses user memory directly
+                cached.ConvSrcMem = cached.UserSrcMem;
+            }
+
+            if (cached.NeedsWeightsReorder)
+            {
+                long weightsSize = dnnl_memory_desc_get_size(convWeightsDesc);
+                cached.ReorderedWeightsBuffer = Marshal.AllocHGlobal((IntPtr)weightsSize);
+
+                status = dnnl_memory_create(out cached.ConvWeightsMem, convWeightsDesc, _engine, cached.ReorderedWeightsBuffer);
+                if (status != DnnlSuccess) { if (logThis) Console.WriteLine($"[oneDNN] Failed to create conv weights mem: {status}"); cached.Dispose(); return null; }
+
+                // Create reorder primitive: user weights -> conv weights
+                status = dnnl_reorder_primitive_desc_create(out IntPtr weightsReorderPrimDesc,
+                    cached.UserWeightsDesc, _engine, convWeightsDesc, _engine, IntPtr.Zero);
+                if (status != DnnlSuccess) { if (logThis) Console.WriteLine($"[oneDNN] Failed to create weights reorder prim desc: {status}"); cached.Dispose(); return null; }
+
+                status = dnnl_primitive_create(out cached.WeightsReorderPrim, weightsReorderPrimDesc);
+                dnnl_primitive_desc_destroy(weightsReorderPrimDesc);
+                if (status != DnnlSuccess) { if (logThis) Console.WriteLine($"[oneDNN] Failed to create weights reorder prim: {status}"); cached.Dispose(); return null; }
+            }
+            else
+            {
+                cached.ConvWeightsMem = cached.UserWeightsMem;
+            }
+
+            if (cached.NeedsDstReorder)
+            {
+                long dstSize = dnnl_memory_desc_get_size(convDstDesc);
+                cached.ReorderedDstBuffer = Marshal.AllocHGlobal((IntPtr)dstSize);
+
+                status = dnnl_memory_create(out cached.ConvDstMem, convDstDesc, _engine, cached.ReorderedDstBuffer);
+                if (status != DnnlSuccess) { if (logThis) Console.WriteLine($"[oneDNN] Failed to create conv dst mem: {status}"); cached.Dispose(); return null; }
+
+                // Create reorder primitive: conv dst -> user dst
+                status = dnnl_reorder_primitive_desc_create(out IntPtr dstReorderPrimDesc,
+                    convDstDesc, _engine, cached.UserDstDesc, _engine, IntPtr.Zero);
+                if (status != DnnlSuccess) { if (logThis) Console.WriteLine($"[oneDNN] Failed to create dst reorder prim desc: {status}"); cached.Dispose(); return null; }
+
+                status = dnnl_primitive_create(out cached.DstReorderPrim, dstReorderPrimDesc);
+                dnnl_primitive_desc_destroy(dstReorderPrimDesc);
+                if (status != DnnlSuccess) { if (logThis) Console.WriteLine($"[oneDNN] Failed to create dst reorder prim: {status}"); cached.Dispose(); return null; }
+            }
+            else
+            {
+                cached.ConvDstMem = cached.UserDstMem;
+            }
+
+            // Create scratchpad memory
+            IntPtr scratchpadDescToUse = scratchpadDesc != IntPtr.Zero ? scratchpadDesc : cached.UserDstDesc;
+            status = dnnl_memory_create(out cached.ScratchpadMem, scratchpadDescToUse, _engine, IntPtr.Zero);
+            if (status != DnnlSuccess) { if (logThis) Console.WriteLine($"[oneDNN] Failed to create scratchpad mem: {status}"); cached.Dispose(); return null; }
+
+            return cached;
+        }
+        catch (Exception ex)
+        {
+            if (logThis) Console.WriteLine($"[oneDNN] CreateConv2DPrimitive exception: {ex.Message}");
+            cached.Dispose();
+            return null;
+        }
+        finally
+        {
+            // Clean up "any" format descriptors (they're no longer needed after primitive creation)
+            if (anySrcDesc != IntPtr.Zero) dnnl_memory_desc_destroy(anySrcDesc);
+            if (anyWeightsDesc != IntPtr.Zero) dnnl_memory_desc_destroy(anyWeightsDesc);
+            if (anyDstDesc != IntPtr.Zero) dnnl_memory_desc_destroy(anyDstDesc);
+        }
+    }
+
+    private static bool EnsureInitialized()
+    {
+        if (_initialized)
+            return _available;
+
+        lock (InitLock)
+        {
+            if (_initialized)
+                return _available;
+
+            // Explicit opt-out: AIDOTNET_DISABLE_ONEDNN=1 forces the managed
+            // fallback even when dnnl.dll is present (supply-chain-independence
+            // escape hatch / A-B benchmarking). Honored before any native load.
+            if (ReadEnvBool("AIDOTNET_DISABLE_ONEDNN"))
+            {
+                _initialized = true;
+                _available = false;
+                if (TraceEnabled) Console.WriteLine("[oneDNN] Disabled via AIDOTNET_DISABLE_ONEDNN");
+                return false;
+            }
+
+            // Pre-load dnnl.dll before registering resolver or calling P/Invoke.
+            // This prevents P/Invoke from hanging when the dll can't be found.
+            IntPtr dnnlHandle = IntPtr.Zero;
+            string[] searchPaths = new[]
+            {
+                Path.Combine(AppContext.BaseDirectory, "dnnl.dll"),
+                Path.Combine(AppContext.BaseDirectory, "runtimes", "win-x64", "native", "dnnl.dll"),
+            };
+            foreach (var path in searchPaths)
+            {
+                if (File.Exists(path) && NativeLibrary.TryLoad(path, out dnnlHandle))
+                    break;
+            }
+            if (dnnlHandle == IntPtr.Zero)
+            {
+                // Try default system search as last resort
+                NativeLibrary.TryLoad("dnnl", out dnnlHandle);
+            }
+            if (dnnlHandle == IntPtr.Zero)
+            {
+                _initialized = true;
+                _available = false;
+                return false;
+            }
+
+            // Register resolver AFTER we know dnnl.dll exists (avoids hang on missing dll)
+            RegisterDllResolver();
+
+            _available = TryInitialize();
+            _initialized = true;
+            return _available;
+        }
+    }
+
+    private static bool TryInitialize()
+    {
+        try
+        {
+            try
+            {
+                IntPtr versionPtr = dnnl_version();
+                if (versionPtr != IntPtr.Zero && TraceEnabled)
+                {
+                    var version = Marshal.PtrToStructure<DnnlVersion>(versionPtr);
+                    Console.WriteLine($"[oneDNN] Version: {version.Major}.{version.Minor}.{version.Patch}");
+                }
+            }
+            catch
+            {
+                // Version check failed, continue anyway
+            }
+
+            Trace("[oneDNN] Initializing...");
+
+            int status = dnnl_engine_create(out _engine, DnnlCpu, 0);
+            if (status != DnnlSuccess)
+            {
+                Trace($"[oneDNN] Failed to create engine: status={status}");
+                return false;
+            }
+
+            status = dnnl_stream_create(out _stream, _engine, 0);
+            if (status != DnnlSuccess)
+            {
+                Trace($"[oneDNN] Failed to create stream: status={status}");
+                dnnl_engine_destroy(_engine);
+                _engine = IntPtr.Zero;
+                return false;
+            }
+
+            Trace("[oneDNN] Initialized successfully");
+            return true;
+        }
+        catch (DllNotFoundException ex)
+        {
+            Trace($"[oneDNN] DLL not found: {ex.Message}");
+            return false;
+        }
+        catch (Exception ex)
+        {
+            Trace($"[oneDNN] Initialization failed: {ex.Message}");
+            return false;
+        }
+    }
+
+    private static void Trace(string message)
+    {
+        if (TraceEnabled)
+        {
+            Console.WriteLine(message);
+        }
+    }
+
+    private static bool ReadEnvBool(string name)
+    {
+        var raw = Environment.GetEnvironmentVariable(name);
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return false;
+        }
+
+        return string.Equals(raw, "1", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(raw, "true", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Attempts MaxPool2D using oneDNN. Returns false if oneDNN is unavailable
+    /// or the primitive creation fails (letting the caller fall back to C#).
+    /// </summary>
+    internal static unsafe bool TryMaxPool2D(
+        float* input, float* output,
+        int batch, int channels, int height, int width,
+        int poolH, int poolW, int strideH, int strideW, int padH, int padW,
+        int outH, int outW)
+    {
+        if (!EnsureInitialized()) return false;
+
+        try
+        {
+            // Create memory descriptors for NCHW layout
+            long* srcDims = stackalloc long[] { batch, channels, height, width };
+            long* dstDims = stackalloc long[] { batch, channels, outH, outW };
+            long* kernel = stackalloc long[] { poolH, poolW };
+            long* strides = stackalloc long[] { strideH, strideW };
+            long* padding = stackalloc long[] { padH, padW };
+            long* dilations = stackalloc long[] { 0, 0 };
+
+            int rc;
+            IntPtr srcDesc, dstDesc;
+            rc = dnnl_memory_desc_create_with_tag(out srcDesc, 4, srcDims, DnnlF32, DnnlFormatTagNCHW);
+            if (rc != 0) return false;
+            rc = dnnl_memory_desc_create_with_tag(out dstDesc, 4, dstDims, DnnlF32, DnnlFormatTagNCHW);
+            if (rc != 0) { dnnl_memory_desc_destroy(srcDesc); return false; }
+
+            // Create pooling primitive descriptor
+            rc = dnnl_pooling_forward_primitive_desc_create(
+                out var primDesc, _engine, DnnlForwardInference,
+                DnnlPoolingMax,
+                srcDesc, dstDesc,
+                (IntPtr)strides, (IntPtr)kernel, (IntPtr)dilations,
+                (IntPtr)padding, (IntPtr)padding,
+                IntPtr.Zero);
+
+            if (rc != 0)
+            {
+                dnnl_memory_desc_destroy(srcDesc);
+                dnnl_memory_desc_destroy(dstDesc);
+                return false;
+            }
+
+            // Create primitive
+            rc = dnnl_primitive_create(out var prim, primDesc);
+            dnnl_primitive_desc_destroy(primDesc);
+            if (rc != 0)
+            {
+                dnnl_memory_desc_destroy(srcDesc);
+                dnnl_memory_desc_destroy(dstDesc);
+                return false;
+            }
+
+            // Create memory objects (must happen BEFORE destroying descriptors)
+            IntPtr srcMem = IntPtr.Zero, dstMem = IntPtr.Zero;
+            rc = dnnl_memory_create(out srcMem, srcDesc, _engine, (IntPtr)input);
+            if (rc != 0) { dnnl_memory_desc_destroy(srcDesc); dnnl_memory_desc_destroy(dstDesc); dnnl_primitive_destroy(prim); return false; }
+            rc = dnnl_memory_create(out dstMem, dstDesc, _engine, (IntPtr)output);
+            if (rc != 0) { dnnl_memory_destroy(srcMem); dnnl_memory_desc_destroy(srcDesc); dnnl_memory_desc_destroy(dstDesc); dnnl_primitive_destroy(prim); return false; }
+
+            // Now safe to destroy descriptors
+            dnnl_memory_desc_destroy(srcDesc);
+            dnnl_memory_desc_destroy(dstDesc);
+
+            // Execute
+            DnnlExecArg* args = stackalloc DnnlExecArg[2];
+            args[0] = new DnnlExecArg { Arg = DnnlArgSrc, Memory = srcMem };
+            args[1] = new DnnlExecArg { Arg = DnnlArgDst, Memory = dstMem };
+            rc = dnnl_primitive_execute(prim, _stream, 2, args);
+
+            dnnl_stream_wait(_stream);
+            dnnl_primitive_destroy(prim);
+            dnnl_memory_destroy(srcMem);
+            dnnl_memory_destroy(dstMem);
+
+            return rc == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Attempts BatchNorm inference using oneDNN. Returns false if unavailable.
+    /// Uses global stats (running mean/variance) — inference mode only.
+    /// </summary>
+    internal static unsafe bool TryBatchNorm(
+        float* input, float* output,
+        float* gamma, float* beta,
+        float* runningMean, float* runningVar,
+        int batch, int channels, int height, int width,
+        float epsilon)
+    {
+        if (!EnsureInitialized()) return false;
+
+        try
+        {
+            long* dims = stackalloc long[] { batch, channels, height, width };
+            int rc;
+            IntPtr srcDesc, dstDesc;
+            rc = dnnl_memory_desc_create_with_tag(out srcDesc, 4, dims, DnnlF32, DnnlFormatTagNCHW);
+            if (rc != 0) return false;
+            rc = dnnl_memory_desc_create_with_tag(out dstDesc, 4, dims, DnnlF32, DnnlFormatTagNCHW);
+            if (rc != 0) { dnnl_memory_desc_destroy(srcDesc); return false; }
+
+            // Create batch norm primitive descriptor
+            // Flags: use global stats (inference) + scale + shift
+            uint flags = DnnlUseGlobalStats | DnnlUseScale | DnnlUseShift;
+            rc = dnnl_batch_normalization_forward_primitive_desc_create(
+                out var primDesc, _engine, DnnlForwardInference,
+                srcDesc, dstDesc, epsilon, flags, IntPtr.Zero);
+
+            if (rc != 0)
+            {
+                dnnl_memory_desc_destroy(srcDesc);
+                dnnl_memory_desc_destroy(dstDesc);
+                return false;
+            }
+
+            rc = dnnl_primitive_create(out var prim, primDesc);
+            dnnl_primitive_desc_destroy(primDesc);
+            if (rc != 0)
+            {
+                dnnl_memory_desc_destroy(srcDesc);
+                dnnl_memory_desc_destroy(dstDesc);
+                return false;
+            }
+
+            // Create memory objects BEFORE destroying descriptors
+            long* cDims = stackalloc long[] { channels };
+            long* cStrides = stackalloc long[] { 1 };
+            IntPtr scaleDesc;
+            rc = dnnl_memory_desc_create_with_strides(out scaleDesc, 1, cDims, DnnlF32, cStrides);
+            if (rc != 0) { dnnl_memory_desc_destroy(srcDesc); dnnl_memory_desc_destroy(dstDesc); dnnl_primitive_destroy(prim); return false; }
+
+            IntPtr srcMem = IntPtr.Zero, dstMem = IntPtr.Zero;
+            IntPtr meanMem = IntPtr.Zero, varMem = IntPtr.Zero;
+            IntPtr scaleMem = IntPtr.Zero, shiftMem = IntPtr.Zero;
+
+            rc = dnnl_memory_create(out srcMem, srcDesc, _engine, (IntPtr)input);
+            if (rc != 0) { dnnl_memory_desc_destroy(srcDesc); dnnl_memory_desc_destroy(dstDesc); dnnl_memory_desc_destroy(scaleDesc); dnnl_primitive_destroy(prim); return false; }
+            rc = dnnl_memory_create(out dstMem, dstDesc, _engine, (IntPtr)output);
+            if (rc != 0) { dnnl_memory_destroy(srcMem); dnnl_memory_desc_destroy(srcDesc); dnnl_memory_desc_destroy(dstDesc); dnnl_memory_desc_destroy(scaleDesc); dnnl_primitive_destroy(prim); return false; }
+
+            // Now safe to destroy 4D descriptors
+            dnnl_memory_desc_destroy(srcDesc);
+            dnnl_memory_desc_destroy(dstDesc);
+
+            // Scale/shift/mean/var use 1D channel descriptor — check each rc
+            if (dnnl_memory_create(out meanMem, scaleDesc, _engine, (IntPtr)runningMean) != 0 ||
+                dnnl_memory_create(out varMem, scaleDesc, _engine, (IntPtr)runningVar) != 0 ||
+                dnnl_memory_create(out scaleMem, scaleDesc, _engine, (IntPtr)gamma) != 0 ||
+                dnnl_memory_create(out shiftMem, scaleDesc, _engine, (IntPtr)beta) != 0)
+            {
+                dnnl_memory_desc_destroy(scaleDesc);
+                if (meanMem != IntPtr.Zero) dnnl_memory_destroy(meanMem);
+                if (varMem != IntPtr.Zero) dnnl_memory_destroy(varMem);
+                if (scaleMem != IntPtr.Zero) dnnl_memory_destroy(scaleMem);
+                if (shiftMem != IntPtr.Zero) dnnl_memory_destroy(shiftMem);
+                dnnl_memory_destroy(srcMem); dnnl_memory_destroy(dstMem);
+                dnnl_primitive_destroy(prim);
+                return false;
+            }
+            dnnl_memory_desc_destroy(scaleDesc);
+
+            DnnlExecArg* args = stackalloc DnnlExecArg[6];
+            args[0] = new DnnlExecArg { Arg = DnnlArgSrc, Memory = srcMem };
+            args[1] = new DnnlExecArg { Arg = DnnlArgDst, Memory = dstMem };
+            args[2] = new DnnlExecArg { Arg = DnnlArgMean, Memory = meanMem };
+            args[3] = new DnnlExecArg { Arg = DnnlArgVariance, Memory = varMem };
+            args[4] = new DnnlExecArg { Arg = DnnlArgWeights, Memory = scaleMem };
+            args[5] = new DnnlExecArg { Arg = DnnlArgBias, Memory = shiftMem };
+            rc = dnnl_primitive_execute(prim, _stream, 6, args);
+            dnnl_stream_wait(_stream);
+
+            dnnl_primitive_destroy(prim);
+            dnnl_memory_destroy(srcMem);
+            dnnl_memory_destroy(dstMem);
+            dnnl_memory_destroy(meanMem);
+            dnnl_memory_destroy(varMem);
+            dnnl_memory_destroy(scaleMem);
+            dnnl_memory_destroy(shiftMem);
+
+            return rc == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
 }

--- a/src/AiDotNet.Tensors/Helpers/PersistentParallelExecutor.cs
+++ b/src/AiDotNet.Tensors/Helpers/PersistentParallelExecutor.cs
@@ -64,11 +64,31 @@ internal sealed class PersistentParallelExecutor
     // Captured worker exception (first one wins)
     private volatile Exception? _workerException;
 
+    // Warm-pool keep-alive: after finishing an op, busy-spin checking for the next
+    // dispatch for up to this many SpinWait rounds before falling back to the
+    // blocking Wait(). The MRES spinCount (2047, ~tens of µs) is too short to bridge
+    // the inter-op gaps in a forward pass (LayerNorm→MHA→FFN→…), so workers block and
+    // pay the full wakeup latency on EVERY op — profiled as the dominant small-op cost
+    // (a transformer LayerNorm measured 192 µs parked vs ~65 µs of actual work). A
+    // longer warm window keeps workers hot ACROSS the forward pass so back-to-back ops
+    // find them spinning (≈ free dispatch). Trade-off: CPU burned during genuinely-idle
+    // gaps; bounded by the spin count, then it parks. Env-tunable; 0 = original (park
+    // immediately via MRES spin only). Each SpinWait(32) ≈ ~1 µs, so 256 ≈ ~256 µs warm.
+    private static readonly int _warmSpins =
+        int.TryParse(System.Environment.GetEnvironmentVariable("AIDOTNET_PPE_WARMSPIN"), out var ws) && ws > 0 ? ws : 0;
+
     private void WorkerLoop(int slot)
     {
         while (true)
         {
-            // Wait for work signal (very low latency — ManualResetEventSlim spins briefly then blocks)
+            // Warm-spin for the next dispatch before blocking (keeps the pool hot across
+            // a forward pass so small back-to-back ops skip the park/wakeup latency).
+            if (_warmSpins > 0)
+            {
+                for (int s = 0; s < _warmSpins && !_workReady[slot].IsSet; s++)
+                    System.Threading.Thread.SpinWait(32);
+            }
+            // Wait for work signal (returns immediately if a warm-spin already saw it).
             _workReady[slot].Wait();
             _workReady[slot].Reset();
 

--- a/tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj
+++ b/tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj
@@ -37,6 +37,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
+    <!-- Optional oneDNN native accelerator (dnnl.dll) — present here so tests can
+         validate the OneDnnProvider native-dispatch path. The core library does NOT
+         reference this; consuming apps opt in via AiDotNet.Native.OneDNN. (#1478) -->
+    <PackageReference Include="AiDotNet.Native.OneDNN" Version="0.91.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/AiDotNet.Tensors.Tests/Engines/JitPanelKernelTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/JitPanelKernelTests.cs
@@ -1,0 +1,76 @@
+// Correctness of the 6×N asm panel kernel (JitGemmAvx2): the runtime-emitted
+// machine code must match a managed reference GEMM across shapes and edges
+// (M%6 != 0, N%16 != 0, various K). Requires AIDOTNET_JIT_GEMM=1 so the panel
+// path actually engages; otherwise the test no-ops with a note.
+
+using System;
+using AiDotNet.Tensors.Engines.Simd;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+public class JitPanelKernelTests
+{
+    private readonly ITestOutputHelper _out;
+    public JitPanelKernelTests(ITestOutputHelper o) => _out = o;
+
+    [SkippableFact]
+    public void PanelKernel_MatchesReference_AcrossShapesAndEdges()
+    {
+        Skip.IfNot(JitGemmAvx2.Available, "JIT kernel unavailable on this platform.");
+        Skip.IfNot(Environment.GetEnvironmentVariable("AIDOTNET_JIT_GEMM") == "1",
+            "Set AIDOTNET_JIT_GEMM=1 to exercise the JIT panel path.");
+
+        var rng = new Random(20260603);
+        // Mix of aligned and edge shapes; include the AIsEval losing shapes.
+        var shapes = new (int M, int K, int N)[]
+        {
+            (6, 64, 16), (12, 64, 32), (128, 64, 256), (1024, 64, 128), (1024, 64, 192),
+            (32, 784, 512), (128, 512, 128),
+            (7, 64, 17), (13, 70, 33), (130, 64, 257), (5, 64, 16), (6, 64, 15), (100, 96, 100),
+        };
+
+        int tested = 0;
+        foreach (var (M, K, N) in shapes)
+        {
+            var A = RandF(M * K, rng);
+            var B = RandF(K * N, rng);
+            var got = new float[M * N];
+            var want = new float[M * N];
+
+            // Reference = the trusted managed FMA kernel (same accumulation style as the
+            // JIT), so a correct panel kernel matches to ~1e-5; an indexing/encoding bug
+            // shows up as O(1) error. (Naive triple-loop would differ by FMA rounding.)
+            SimdGemm.SgemmAddInternal(A, K, false, B, N, false, want, M, K, N, allowParallel: false, clearedOutput: false);
+            // Force the JIT panel path (bypass the auto-tuner) so correctness is always
+            // exercised regardless of which kernel is faster.
+            JitGemmAvx2.RunJit(A, B, got, M, N, K);
+
+            double maxAbs = 0, maxMag = 0;
+            for (int i = 0; i < want.Length; i++)
+            {
+                maxAbs = Math.Max(maxAbs, Math.Abs(got[i] - want[i]));
+                maxMag = Math.Max(maxMag, Math.Abs(want[i]));
+            }
+            double rel = maxAbs / Math.Max(1e-6, maxMag);
+            _out.WriteLine($"[{M}x{K}x{N}] maxAbs={maxAbs:E2} relToMax={rel:E2}");
+            Assert.True(rel < 1e-4, $"shape {M}x{K}x{N}: relToMax {rel} exceeds 1e-4 (likely a kernel bug)");
+            tested++;
+        }
+        _out.WriteLine($"verified {tested} shapes via the JIT panel path");
+    }
+
+    private static void Reference(float[] a, float[] b, float[] c, int M, int K, int N)
+    {
+        for (int i = 0; i < M; i++)
+            for (int j = 0; j < N; j++)
+            {
+                float acc = 0f;
+                for (int k = 0; k < K; k++) acc += a[i * K + k] * b[k * N + j];
+                c[i * N + j] = acc;
+            }
+    }
+
+    private static float[] RandF(int n, Random r) { var a = new float[n]; for (int i = 0; i < n; i++) a[i] = (float)(r.NextDouble() * 2 - 1); return a; }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/LosingShapeGemmBench.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/LosingShapeGemmBench.cs
@@ -34,10 +34,9 @@ public class LosingShapeGemmBench
             ("xfmr-FFN b8",    256,  64, 128),
         };
         var rng = new Random(11);
-        bool jitEnabled = Environment.GetEnvironmentVariable("AIDOTNET_JIT_GEMM") == "1";
         bool hasBlas = BlasProvider.HasRawSgemm;
-        _out.WriteLine($"JIT enabled={jitEnabled} (JitGemmAvx2.Available={JitGemmAvx2.Available})  OpenBLAS={hasBlas}");
-        _out.WriteLine($"{"shape",-18}{"managed",12}{"asmJIT",12}{"OpenBLAS",12}   (GFLOP/s)   verdict");
+        _out.WriteLine($"JitAvailable={JitGemmAvx2.Available}  OpenBLAS={hasBlas}  ParallelWorkThreshold={SimdGemm.ParallelWorkThreshold}");
+        _out.WriteLine($"{"shape",-18} GFLOP/s:  mgd-ser  mgd-par  jit-ser  jit-par    blas");
 
         foreach (var (label, M, K, N) in shapes)
         {
@@ -49,12 +48,15 @@ public class LosingShapeGemmBench
 
             double Min(int iters, Action f) { for (int i = 0; i < 100; i++) f(); double m = 1e30; for (int i = 0; i < iters; i++) { var s = Stopwatch.GetTimestamp(); f(); double u = (Stopwatch.GetTimestamp() - s) * 1e6 / Stopwatch.Frequency; if (u < m) m = u; } return m; }
 
-            double tMgd = Min(2000, () => SimdGemm.SgemmAddInternal(A, K, false, B, N, false, C, M, K, N, allowParallel: true, clearedOutput: false));
+            // Managed serial vs parallel. The parallel column needs the work gate open
+            // for sub-20M shapes: run with AIDOTNET_GEMM_PARALLEL_MINWORK=1.
+            double tMgdS = Min(2000, () => SimdGemm.SgemmAddInternal(A, K, false, B, N, false, C, M, K, N, allowParallel: false, clearedOutput: false));
+            double tMgdP = Min(2000, () => SimdGemm.SgemmAddInternal(A, K, false, B, N, false, C, M, K, N, allowParallel: true, clearedOutput: false));
 
-            // Time the JIT panel kernel directly (force it, bypass the auto-tuner) so we
-            // see its real throughput vs managed regardless of the tuner's verdict.
-            bool jitWon = JitGemmAvx2.Available && M >= 6 && N >= 16;
-            double tJit = jitWon ? Min(2000, () => JitGemmAvx2.RunJit(A, B, Cj, M, N, K)) : double.NaN;
+            // Panel JIT, forced serial and forced parallel (bypass heuristics).
+            bool jitOk = JitGemmAvx2.Available && M >= 6 && N >= 16;
+            double tJitS = jitOk ? Min(2000, () => JitGemmAvx2.RunJit(A, B, Cj, M, N, K, forceParallel: false)) : double.NaN;
+            double tJitP = jitOk ? Min(2000, () => JitGemmAvx2.RunJit(A, B, Cj, M, N, K, forceParallel: true)) : double.NaN;
 
             double tBlas = double.NaN;
             if (hasBlas)
@@ -67,8 +69,8 @@ public class LosingShapeGemmBench
                 }
             }
 
-            string G(double us) => double.IsNaN(us) ? "  --" : $"{flop / us / 1e3,7:F0}";
-            _out.WriteLine($"{label,-18}{tMgd,9:F1}us {(double.IsNaN(tJit) ? "  --" : tJit.ToString("F1") + "us"),11} {(double.IsNaN(tBlas) ? "  --" : tBlas.ToString("F1") + "us"),11}   M:{G(tMgd)} J:{G(tJit)} B:{G(tBlas)}  jitWon={jitWon}");
+            string G(double us) => double.IsNaN(us) ? "     --" : $"{flop / us / 1e3,7:F0}";
+            _out.WriteLine($"{label,-18}          {G(tMgdS)}  {G(tMgdP)}  {G(tJitS)}  {G(tJitP)}  {G(tBlas)}");
         }
         Assert.True(true);
     }

--- a/tests/AiDotNet.Tensors.Tests/Engines/LosingShapeGemmBench.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/LosingShapeGemmBench.cs
@@ -51,10 +51,10 @@ public class LosingShapeGemmBench
 
             double tMgd = Min(2000, () => SimdGemm.SgemmAddInternal(A, K, false, B, N, false, C, M, K, N, allowParallel: true, clearedOutput: false));
 
-            // asm-JIT verdict + time. TryMultiply auto-tunes on first call then caches;
-            // a true return means the auto-tuner judged JIT faster and ran it.
-            bool jitWon = JitGemmAvx2.TryMultiply(A, B, Cj, M, N, K);
-            double tJit = jitWon ? Min(2000, () => JitGemmAvx2.TryMultiply(A, B, Cj, M, N, K)) : double.NaN;
+            // Time the JIT panel kernel directly (force it, bypass the auto-tuner) so we
+            // see its real throughput vs managed regardless of the tuner's verdict.
+            bool jitWon = JitGemmAvx2.Available && M >= 6 && N >= 16;
+            double tJit = jitWon ? Min(2000, () => JitGemmAvx2.RunJit(A, B, Cj, M, N, K)) : double.NaN;
 
             double tBlas = double.NaN;
             if (hasBlas)

--- a/tests/AiDotNet.Tensors.Tests/Engines/LosingShapeGemmBench.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/LosingShapeGemmBench.cs
@@ -1,0 +1,77 @@
+// Per-shape GEMM bake-off on the exact AIsEval losing shapes: managed (RyuJIT
+// codegen) vs the raw-machine-code asm-JIT kernel vs OpenBLAS. Answers whether
+// RyuJIT codegen is the gap and whether the asm-JIT closes it at these shapes.
+// Category=Performance => excluded from the normal test run.
+
+using System;
+using System.Diagnostics;
+using AiDotNet.Tensors.Engines.Simd;
+using AiDotNet.Tensors.Helpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+[Trait("Category", "Performance")]
+public class LosingShapeGemmBench
+{
+    private readonly ITestOutputHelper _out;
+    public LosingShapeGemmBench(ITestOutputHelper o) => _out = o;
+
+    [Fact]
+    public unsafe void GemmBakeOff()
+    {
+        // (label, M, K, N)
+        var shapes = new (string, int, int, int)[]
+        {
+            ("mlp-L1 b32",      32, 784, 512),
+            ("mlp-L1 b128",    128, 784, 512),
+            ("mlp-L2 b128",    128, 512, 128),
+            ("lstm-recur b32",  32,  64, 256),
+            ("lstm-recur b128",128,  64, 256),
+            ("xfmr-FFN b32",  1024,  64, 128),
+            ("xfmr-QKV b32",  1024,  64, 192),
+            ("xfmr-FFN b8",    256,  64, 128),
+        };
+        var rng = new Random(11);
+        bool jitEnabled = Environment.GetEnvironmentVariable("AIDOTNET_JIT_GEMM") == "1";
+        bool hasBlas = BlasProvider.HasRawSgemm;
+        _out.WriteLine($"JIT enabled={jitEnabled} (JitGemmAvx2.Available={JitGemmAvx2.Available})  OpenBLAS={hasBlas}");
+        _out.WriteLine($"{"shape",-18}{"managed",12}{"asmJIT",12}{"OpenBLAS",12}   (GFLOP/s)   verdict");
+
+        foreach (var (label, M, K, N) in shapes)
+        {
+            var A = RandF(M * K, rng);
+            var B = RandF(K * N, rng);
+            var C = new float[M * N];
+            var Cj = new float[M * N];
+            double flop = 2.0 * M * N * K;
+
+            double Min(int iters, Action f) { for (int i = 0; i < 100; i++) f(); double m = 1e30; for (int i = 0; i < iters; i++) { var s = Stopwatch.GetTimestamp(); f(); double u = (Stopwatch.GetTimestamp() - s) * 1e6 / Stopwatch.Frequency; if (u < m) m = u; } return m; }
+
+            double tMgd = Min(2000, () => SimdGemm.SgemmAddInternal(A, K, false, B, N, false, C, M, K, N, allowParallel: true, clearedOutput: false));
+
+            // asm-JIT verdict + time. TryMultiply auto-tunes on first call then caches;
+            // a true return means the auto-tuner judged JIT faster and ran it.
+            bool jitWon = JitGemmAvx2.TryMultiply(A, B, Cj, M, N, K);
+            double tJit = jitWon ? Min(2000, () => JitGemmAvx2.TryMultiply(A, B, Cj, M, N, K)) : double.NaN;
+
+            double tBlas = double.NaN;
+            if (hasBlas)
+            {
+                var Cb = new float[M * N];
+                fixed (float* pa = A, pb = B, pc = Cb)
+                {
+                    float* la = pa, lb = pb, lc = pc;
+                    tBlas = Min(2000, () => BlasProvider.SgemmRaw(M, N, K, la, K, lb, N, lc, N));
+                }
+            }
+
+            string G(double us) => double.IsNaN(us) ? "  --" : $"{flop / us / 1e3,7:F0}";
+            _out.WriteLine($"{label,-18}{tMgd,9:F1}us {(double.IsNaN(tJit) ? "  --" : tJit.ToString("F1") + "us"),11} {(double.IsNaN(tBlas) ? "  --" : tBlas.ToString("F1") + "us"),11}   M:{G(tMgd)} J:{G(tJit)} B:{G(tBlas)}  jitWon={jitWon}");
+        }
+        Assert.True(true);
+    }
+
+    private static float[] RandF(int n, Random r) { var a = new float[n]; for (int i = 0; i < n; i++) a[i] = (float)(r.NextDouble() * 2 - 1); return a; }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/OneDnnProviderTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/OneDnnProviderTests.cs
@@ -1,0 +1,58 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Guards the restored oneDNN accelerator (issue ooples/AiDotNet#1478). The provider
+/// must actually load <c>dnnl.dll</c> and dispatch when the optional
+/// <c>AiDotNet.Native.OneDNN</c> package is present (this test project references it),
+/// and produce numerically correct results. These tests are skipped on a runner where
+/// the native library is unavailable rather than failing — the core library treats
+/// oneDNN as an optional accelerator and falls back to managed kernels without it.
+/// </summary>
+public class OneDnnProviderTests
+{
+    [SkippableFact]
+    public void IsAvailable_WhenNativePackagePresent()
+    {
+        // If the optional native lib didn't deploy for this RID, oneDNN is correctly
+        // unavailable and the managed fallback is exercised elsewhere — skip.
+        Skip.IfNot(OneDnnProvider.IsAvailable,
+            "dnnl.dll not deployed for this runtime; oneDNN optional accelerator inactive.");
+        Assert.True(OneDnnProvider.IsAvailable);
+    }
+
+    [SkippableFact]
+    public void Conv2D_ThroughOneDnn_MatchesHandComputedReference()
+    {
+        Skip.IfNot(OneDnnProvider.IsAvailable,
+            "dnnl.dll not deployed for this runtime; oneDNN optional accelerator inactive.");
+
+        AiDotNetEngine.ResetToCpu();
+        var eng = AiDotNetEngine.Current;
+
+        // 1 batch, 1 in-channel, 3x3 input; one 2x2 kernel; stride 1, no pad → 2x2 output.
+        // input:            kernel:
+        //   1 2 3             1 0
+        //   4 5 6             0 1
+        //   7 8 9
+        // out[i,j] = in[i,j]*1 + in[i+1,j+1]*1
+        //   out[0,0]=1+5=6  out[0,1]=2+6=8
+        //   out[1,0]=4+8=12 out[1,1]=5+9=14
+        var input = new Tensor<float>(new float[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 }, new[] { 1, 1, 3, 3 });
+        var kernel = new Tensor<float>(new float[] { 1, 0, 0, 1 }, new[] { 1, 1, 2, 2 });
+
+        var outc = eng.Conv2D(input, kernel, stride: 1, padding: 0, dilation: 1);
+
+        Assert.Equal(new[] { 1, 1, 2, 2 }, outc.Shape);
+        var d = outc.GetDataArray();
+        Assert.Equal(6f, d[0], 3);
+        Assert.Equal(8f, d[1], 3);
+        Assert.Equal(12f, d[2], 3);
+        Assert.Equal(14f, d[3], 3);
+    }
+}


### PR DESCRIPTION
Part of ooples/AiDotNet#1478 (exceed PyTorch-CPU eager on all 16 AIsEval inference shapes).

## What this PR ships

A per-regime CPU GEMM strategy plus op-level inference fixes, each gated to exactly the regime where it is **measured** to win (LosingShapeGemmBench 4-way matrix: managed-serial / managed-parallel / asm-panel serial+parallel / OpenBLAS, min-of-2000 per shape):

| GEMM regime | winner (GF/s at the AIsEval shapes) | route |
|---|---|---|
| Small-K parallel (transformer FFN/QKV, K=64, M~1024, 4-16M MACs) | **6xN asm panel kernel: 227-285** vs ~100 managed (serial OR parallel), 135-200 OpenBLAS | `JitGemmAvx2` panel, default on |
| Large-K (MLP 784/512) | **OpenBLAS kernel: 150-299** vs 56-104 managed-serial | OpenBLAS single-threaded on our `PersistentParallelExecutor` (K>=256) |
| LSTM recurrence ([128,64,256]) | **managed-serial: 103** vs panel 53/88, OpenBLAS 66, managed-parallel 87 | unchanged (documented at call site) |

### 6xN asm panel kernel (`Emit6xNPanel`)
Runtime-emitted AVX2/FMA machine code (the existing 6x16 microkernel) with the **column-block loop inside the asm**, so the managed→native transition + Win64 prologue (xmm6-15 save/restore) is paid once per row-block instead of once per tile (21 vs 336 calls at the LSTM shape). Verified against the managed FMA kernel to ~1e-7 across 13 shapes incl. M%6/N%16 edges (`JitPanelKernelTests`). Routed in both `Sgemm` and `SgemmWithCachedB` (the FusedLinear/FFN path), gated K<=128, 4-16M MACs, M<=2048 — giant-M (bs=128, M=4096) regressed in interleaved A/Bs because the unpacked panel re-reads B per 6-row block, so those shapes stay on the managed packed kernel (bit-identical to before).

### OpenBLAS kernel on our pool
Whole-call OpenBLAS regressed end-to-end (its per-call thread-pool spin-up x many GEMMs/predict). Fix: pin OpenBLAS to 1 thread, parallelize over M-chunks on the PPE. mlp bs=32: 1.87x → ~1.0x vs PyTorch.

### Op-level fixes
- **Batch-parallel LSTM recurrence**: whole-timestep-loop fan-out over contiguous batch chunks (one region launch; b<=8 stays serial). lstm b32 1.58→~1.2x, b128 1.89→~1.25x. Bit-identical to serial at production chunk size.
- **Fused fs=64 LayerNorm** for batch<=8192 (re-enabled the parked register-resident path where it is profiled to win): ~5-7% on the transformer; all 39+1 LayerNorm tests pass.
- **SIMD SDPA softmax + SDPA on the PPE** (earlier commits on this branch): transformer b1/b8 wins.

## End-to-end (AIsEval, p95 vs PyTorch-CPU eager, min-of-N, drift-cancelled A/Bs)
- transformer: b1/b8 win (0.7-0.9x); b32 0.76-0.78x ON/OFF in clean-window interleaved A/Bs; b128 unchanged by construction (M-cap).
- mlp b32: 1.87x → ~1.0; lstm b32/b128 gap roughly halved; cnn unchanged (wins).
- Suite: 6/16 → 8-9/16 wins depending on rig window (the box is noisy; all claims above are from interleaved or min-of-2000 measurements).

## Notes for review
- All new routes are env-gated (`AIDOTNET_JIT_SMALLK`, `AIDOTNET_OPENBLAS_GEMM`, `AIDOTNET_LSTM_PARALLEL`, + tunables) and fall through to the existing managed path.
- OpenBLAS thread pin (1 thread, process-global) happens only on first large-K route use — we own parallelism via the PPE wherever that route engages.
- The 17 test failures pre-existing on this branch fail identically with all routes disabled (verified) — unrelated API drift.
- net471 unaffected (`#if !NET471` on all JIT paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)