### PR TITLE
perf(#379): typed float/double fast paths for TRSM, SYRK, SYMM & GBMV

### DIFF
--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Gbmv.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Gbmv.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.InteropServices;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.Interfaces;
 
@@ -41,6 +42,21 @@ public static partial class BlasManaged
 
         var ops = MathHelper.GetNumericOperations<T>();
 
+        // float/double take a typed band matvec (typed AXPY accumulation over the band +
+        // typed β-scale); the generic INumericOperations path is kept for other types.
+        if (typeof(T) == typeof(float))
+        {
+            GbmvFloat(transA, m, n, kl, ku, (float)(object)alpha, MemoryMarshal.Cast<T, float>(a), lda,
+                MemoryMarshal.Cast<T, float>(x), incx, (float)(object)beta, MemoryMarshal.Cast<T, float>(y), incy, lenY);
+            return;
+        }
+        if (typeof(T) == typeof(double))
+        {
+            GbmvDouble(transA, m, n, kl, ku, (double)(object)alpha, MemoryMarshal.Cast<T, double>(a), lda,
+                MemoryMarshal.Cast<T, double>(x), incx, (double)(object)beta, MemoryMarshal.Cast<T, double>(y), incy, lenY);
+            return;
+        }
+
         // Scale y by beta.
         for (int o = 0; o < lenY; o++)
         {
@@ -82,5 +98,59 @@ public static partial class BlasManaged
                 y[yj] = ops.Add(y[yj], ops.Multiply(alpha, acc));
             }
         }
+    }
+
+    private static void GbmvFloat(
+        bool transA, int m, int n, int kl, int ku, float alpha,
+        ReadOnlySpan<float> a, int lda, ReadOnlySpan<float> x, int incx, float beta,
+        Span<float> y, int incy, int lenY)
+    {
+        if (beta != 1f)
+            for (int o = 0; o < lenY; o++) y[o * incy] *= beta;
+        if (!transA)
+            for (int i = 0; i < m; i++)
+            {
+                int jlo = Math.Max(0, i - kl), jhi = Math.Min(n - 1, i + ku);
+                float acc = 0f;
+                for (int j = jlo; j <= jhi; j++)
+                    acc += a[j * lda + (ku - j + i)] * x[j * incx];
+                y[i * incy] += alpha * acc;
+            }
+        else
+            for (int j = 0; j < n; j++)
+            {
+                int ilo = Math.Max(0, j - ku), ihi = Math.Min(m - 1, j + kl);
+                float acc = 0f;
+                for (int i = ilo; i <= ihi; i++)
+                    acc += a[j * lda + (ku - j + i)] * x[i * incx];
+                y[j * incy] += alpha * acc;
+            }
+    }
+
+    private static void GbmvDouble(
+        bool transA, int m, int n, int kl, int ku, double alpha,
+        ReadOnlySpan<double> a, int lda, ReadOnlySpan<double> x, int incx, double beta,
+        Span<double> y, int incy, int lenY)
+    {
+        if (beta != 1.0)
+            for (int o = 0; o < lenY; o++) y[o * incy] *= beta;
+        if (!transA)
+            for (int i = 0; i < m; i++)
+            {
+                int jlo = Math.Max(0, i - kl), jhi = Math.Min(n - 1, i + ku);
+                double acc = 0.0;
+                for (int j = jlo; j <= jhi; j++)
+                    acc += a[j * lda + (ku - j + i)] * x[j * incx];
+                y[i * incy] += alpha * acc;
+            }
+        else
+            for (int j = 0; j < n; j++)
+            {
+                int ilo = Math.Max(0, j - ku), ihi = Math.Min(m - 1, j + kl);
+                double acc = 0.0;
+                for (int i = ilo; i <= ihi; i++)
+                    acc += a[j * lda + (ku - j + i)] * x[i * incx];
+                y[j * incy] += alpha * acc;
+            }
     }
 }

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Symm.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Symm.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.InteropServices;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.Interfaces;
 
@@ -56,12 +57,44 @@ public static partial class BlasManaged
         else
             Gemm<T>(b, ldb, false, full, s, false, result, n, m, n, s, gemmOpts); // (m×n)(n×n)
 
-        // C = α·result + β·C
+        // C = α·result + β·C. float/double take a typed, JIT-vectorizable per-row AXPBY;
+        // the generic INumericOperations path is per-element interface-dispatched + boxed.
+        if (typeof(T) == typeof(float))
+            SymmEpilogueFloat(m, n, (float)(object)alpha, MemoryMarshal.Cast<T, float>(result),
+                (float)(object)beta, MemoryMarshal.Cast<T, float>(c), ldc);
+        else if (typeof(T) == typeof(double))
+            SymmEpilogueDouble(m, n, (double)(object)alpha, MemoryMarshal.Cast<T, double>(result),
+                (double)(object)beta, MemoryMarshal.Cast<T, double>(c), ldc);
+        else
+            for (int i = 0; i < m; i++)
+                for (int j = 0; j < n; j++)
+                {
+                    int ci = i * ldc + j;
+                    c[ci] = ops.Add(ops.Multiply(alpha, result[i * n + j]), ops.Multiply(beta, c[ci]));
+                }
+    }
+
+    private static void SymmEpilogueFloat(
+        int m, int n, float alpha, ReadOnlySpan<float> result, float beta, Span<float> c, int ldc)
+    {
         for (int i = 0; i < m; i++)
+        {
+            var r = result.Slice(i * n, n);
+            var cc = c.Slice(i * ldc, n);
             for (int j = 0; j < n; j++)
-            {
-                int ci = i * ldc + j;
-                c[ci] = ops.Add(ops.Multiply(alpha, result[i * n + j]), ops.Multiply(beta, c[ci]));
-            }
+                cc[j] = alpha * r[j] + beta * cc[j];
+        }
+    }
+
+    private static void SymmEpilogueDouble(
+        int m, int n, double alpha, ReadOnlySpan<double> result, double beta, Span<double> c, int ldc)
+    {
+        for (int i = 0; i < m; i++)
+        {
+            var r = result.Slice(i * n, n);
+            var cc = c.Slice(i * ldc, n);
+            for (int j = 0; j < n; j++)
+                cc[j] = alpha * r[j] + beta * cc[j];
+        }
     }
 }

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Syrk.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Syrk.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.InteropServices;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.Interfaces;
 
@@ -40,16 +41,71 @@ public static partial class BlasManaged
         }
 
         // Write C[uplo] = α·full + β·C[uplo]; leave the other triangle untouched.
-        for (int i = 0; i < n; i++)
-        {
-            int lo = uplo == Uplo.Lower ? 0 : i;
-            int hi = uplo == Uplo.Lower ? i : n - 1;
-            for (int j = lo; j <= hi; j++)
+        // The whole n×n product is one [0,0] block of stride n.
+        SyrkWriteTriangle(uplo, 0, 0, n, n, alpha, full, n, beta, c, ldc, ops);
+    }
+
+    /// <summary>
+    /// C[uplo] tile += α·src + β·C over the (i0,j0)-offset bm×bn block, masked to the
+    /// requested triangle. float/double take a typed, JIT-vectorizable AXPBY (the generic
+    /// <see cref="INumericOperations{T}"/> path is per-element interface-dispatched + boxed);
+    /// the per-row triangle bounds replace the old inner "if (inTri) continue" branch.
+    /// </summary>
+    private static void SyrkWriteTriangle<T>(
+        Uplo uplo, int i0, int j0, int bm, int bn, T alpha,
+        ReadOnlySpan<T> src, int srcStride, T beta, Span<T> c, int ldc,
+        INumericOperations<T> ops) where T : unmanaged
+    {
+        if (typeof(T) == typeof(float))
+            SyrkWriteTriangleFloat(uplo, i0, j0, bm, bn, (float)(object)alpha,
+                MemoryMarshal.Cast<T, float>(src), srcStride, (float)(object)beta,
+                MemoryMarshal.Cast<T, float>(c), ldc);
+        else if (typeof(T) == typeof(double))
+            SyrkWriteTriangleDouble(uplo, i0, j0, bm, bn, (double)(object)alpha,
+                MemoryMarshal.Cast<T, double>(src), srcStride, (double)(object)beta,
+                MemoryMarshal.Cast<T, double>(c), ldc);
+        else
+            for (int ii = 0; ii < bm; ii++)
             {
-                int ci = i * ldc + j;
-                T scaled = ops.Multiply(alpha, full[i * n + j]);
-                c[ci] = ops.Add(scaled, ops.Multiply(beta, c[ci]));
+                int gi = i0 + ii;
+                int lo = uplo == Uplo.Lower ? 0 : Math.Max(gi - j0, 0);
+                int hi = uplo == Uplo.Lower ? Math.Min(gi - j0, bn - 1) : bn - 1;
+                int sr = ii * srcStride, cr = gi * ldc;
+                for (int jj = lo; jj <= hi; jj++)
+                {
+                    int ci = cr + j0 + jj;
+                    c[ci] = ops.Add(ops.Multiply(alpha, src[sr + jj]), ops.Multiply(beta, c[ci]));
+                }
             }
+    }
+
+    private static void SyrkWriteTriangleFloat(
+        Uplo uplo, int i0, int j0, int bm, int bn, float alpha,
+        ReadOnlySpan<float> src, int srcStride, float beta, Span<float> c, int ldc)
+    {
+        for (int ii = 0; ii < bm; ii++)
+        {
+            int gi = i0 + ii;
+            int lo = uplo == Uplo.Lower ? 0 : Math.Max(gi - j0, 0);
+            int hi = uplo == Uplo.Lower ? Math.Min(gi - j0, bn - 1) : bn - 1;
+            int sr = ii * srcStride, cr = gi * ldc + j0;
+            for (int jj = lo; jj <= hi; jj++)
+                c[cr + jj] = alpha * src[sr + jj] + beta * c[cr + jj];
+        }
+    }
+
+    private static void SyrkWriteTriangleDouble(
+        Uplo uplo, int i0, int j0, int bm, int bn, double alpha,
+        ReadOnlySpan<double> src, int srcStride, double beta, Span<double> c, int ldc)
+    {
+        for (int ii = 0; ii < bm; ii++)
+        {
+            int gi = i0 + ii;
+            int lo = uplo == Uplo.Lower ? 0 : Math.Max(gi - j0, 0);
+            int hi = uplo == Uplo.Lower ? Math.Min(gi - j0, bn - 1) : bn - 1;
+            int sr = ii * srcStride, cr = gi * ldc + j0;
+            for (int jj = lo; jj <= hi; jj++)
+                c[cr + jj] = alpha * src[sr + jj] + beta * c[cr + jj];
         }
     }
 
@@ -91,18 +147,7 @@ public static partial class BlasManaged
                 }
 
                 // Write tile into C[uplo] with alpha/beta, masking the diagonal tile.
-                for (int ii = 0; ii < bm; ii++)
-                {
-                    int gi = i0 + ii;
-                    for (int jj = 0; jj < bn; jj++)
-                    {
-                        int gj = j0 + jj;
-                        bool inTri = uplo == Uplo.Lower ? gj <= gi : gj >= gi;
-                        if (!inTri) continue;
-                        int ci = gi * ldc + gj;
-                        c[ci] = ops.Add(ops.Multiply(alpha, tile[ii * bn + jj]), ops.Multiply(beta, c[ci]));
-                    }
-                }
+                SyrkWriteTriangle(uplo, i0, j0, bm, bn, alpha, tile, bn, beta, c, ldc, ops);
             }
         }
     }

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Trsm.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.Trsm.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.InteropServices;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.Interfaces;
 
@@ -22,13 +23,19 @@ public static partial class BlasManaged
         if (m <= 0 || n <= 0) return;
         var ops = MathHelper.GetNumericOperations<T>();
 
-        // Scale B by alpha (BLAS semantics: solve against alpha·B).
-        for (int i = 0; i < m; i++)
-            for (int j = 0; j < n; j++)
-            {
-                int idx = i * ldb + j;
-                b[idx] = ops.Multiply(b[idx], alpha);
-            }
+        // Scale B by alpha (BLAS semantics: solve against alpha·B). float/double take a
+        // typed, JIT-vectorizable per-row scale; the generic path is per-element boxed.
+        if (typeof(T) == typeof(float))
+            TrsmScaleFloat(m, n, ldb, (float)(object)alpha, MemoryMarshal.Cast<T, float>(b));
+        else if (typeof(T) == typeof(double))
+            TrsmScaleDouble(m, n, ldb, (double)(object)alpha, MemoryMarshal.Cast<T, double>(b));
+        else
+            for (int i = 0; i < m; i++)
+                for (int j = 0; j < n; j++)
+                {
+                    int idx = i * ldb + j;
+                    b[idx] = ops.Multiply(b[idx], alpha);
+                }
 
         if (side == Side.Left)
         {
@@ -39,6 +46,26 @@ public static partial class BlasManaged
         }
         else
             TrsmRightScalar(uplo, transA, diag, m, n, a, lda, b, ldb, ops);
+    }
+
+    private static void TrsmScaleFloat(int m, int n, int ldb, float alpha, Span<float> b)
+    {
+        if (alpha == 1f) return;
+        for (int i = 0; i < m; i++)
+        {
+            var row = b.Slice(i * ldb, n);
+            for (int j = 0; j < n; j++) row[j] *= alpha;
+        }
+    }
+
+    private static void TrsmScaleDouble(int m, int n, int ldb, double alpha, Span<double> b)
+    {
+        if (alpha == 1.0) return;
+        for (int i = 0; i < m; i++)
+        {
+            var row = b.Slice(i * ldb, n);
+            for (int j = 0; j < n; j++) row[j] *= alpha;
+        }
     }
 
     // Block size for the diagonal-solve / trailing-update split. 64 keeps the
@@ -120,12 +147,35 @@ public static partial class BlasManaged
                 Gemm<T>(a.Slice(i0 * lda + rlo), lda, true, xBlk, ldb, false, scratchView, n, rRows, n, bm, gemmOpts);
 
             var bRem = b.Slice(rlo * ldb);
-            for (int r = 0; r < rRows; r++)
-                for (int c = 0; c < n; c++)
+            // B[rlo:rhi, :] -= scratch. float/double take a typed, JIT-vectorizable per-row
+            // subtract; generic path stays per-element boxed.
+            if (typeof(T) == typeof(float))
+            {
+                var bf = MemoryMarshal.Cast<T, float>(bRem);
+                var sf = MemoryMarshal.Cast<T, float>(scratchView);
+                for (int r = 0; r < rRows; r++)
                 {
-                    int bi = r * ldb + c;
-                    bRem[bi] = ops.Subtract(bRem[bi], scratchView[r * n + c]);
+                    int br = r * ldb, sr = r * n;
+                    for (int c = 0; c < n; c++) bf[br + c] -= sf[sr + c];
                 }
+            }
+            else if (typeof(T) == typeof(double))
+            {
+                var bd = MemoryMarshal.Cast<T, double>(bRem);
+                var sd = MemoryMarshal.Cast<T, double>(scratchView);
+                for (int r = 0; r < rRows; r++)
+                {
+                    int br = r * ldb, sr = r * n;
+                    for (int c = 0; c < n; c++) bd[br + c] -= sd[sr + c];
+                }
+            }
+            else
+                for (int r = 0; r < rRows; r++)
+                    for (int c = 0; c < n; c++)
+                    {
+                        int bi = r * ldb + c;
+                        bRem[bi] = ops.Subtract(bRem[bi], scratchView[r * n + c]);
+                    }
         }
         finally
         {
@@ -143,6 +193,22 @@ public static partial class BlasManaged
         ReadOnlySpan<T> a, int lda, Span<T> b, int ldb,
         INumericOperations<T> ops) where T : unmanaged
     {
+        // float/double: a row-AXPY reorganization (b[i,:] -= A(i,kk)·b[kk,:] over the n
+        // RHS columns, then divide the row by the diagonal) that the JIT vectorizes over
+        // the contiguous RHS row — bit-identical to the generic per-(i,j) accumulation
+        // (same operands, same kk order) but without the per-element INumericOperations
+        // dispatch + box. The generic path is kept for other element types.
+        if (typeof(T) == typeof(float))
+        {
+            TrsmLeftScalarFloat(uplo, transA, diag, m, n, MemoryMarshal.Cast<T, float>(a), lda, MemoryMarshal.Cast<T, float>(b), ldb);
+            return;
+        }
+        if (typeof(T) == typeof(double))
+        {
+            TrsmLeftScalarDouble(uplo, transA, diag, m, n, MemoryMarshal.Cast<T, double>(a), lda, MemoryMarshal.Cast<T, double>(b), ldb);
+            return;
+        }
+
         // Effective triangle after optional transpose.
         bool lower = (uplo == Uplo.Lower) ^ transA;
 
@@ -170,11 +236,112 @@ public static partial class BlasManaged
         }
     }
 
+    private static void TrsmLeftScalarFloat(
+        Uplo uplo, bool transA, Diag diag, int m, int n,
+        ReadOnlySpan<float> a, int lda, Span<float> b, int ldb)
+    {
+        bool lower = (uplo == Uplo.Lower) ^ transA;
+        if (lower)
+        {
+            for (int i = 0; i < m; i++)
+            {
+                var bi = b.Slice(i * ldb, n);
+                for (int kk = 0; kk < i; kk++)
+                {
+                    float coef = transA ? a[kk * lda + i] : a[i * lda + kk];
+                    var bk = b.Slice(kk * ldb, n);
+                    for (int j = 0; j < n; j++) bi[j] -= coef * bk[j];
+                }
+                if (diag != Diag.Unit)
+                {
+                    float d = a[i * lda + i];
+                    for (int j = 0; j < n; j++) bi[j] /= d;
+                }
+            }
+        }
+        else
+        {
+            for (int i = m - 1; i >= 0; i--)
+            {
+                var bi = b.Slice(i * ldb, n);
+                for (int kk = i + 1; kk < m; kk++)
+                {
+                    float coef = transA ? a[kk * lda + i] : a[i * lda + kk];
+                    var bk = b.Slice(kk * ldb, n);
+                    for (int j = 0; j < n; j++) bi[j] -= coef * bk[j];
+                }
+                if (diag != Diag.Unit)
+                {
+                    float d = a[i * lda + i];
+                    for (int j = 0; j < n; j++) bi[j] /= d;
+                }
+            }
+        }
+    }
+
+    private static void TrsmLeftScalarDouble(
+        Uplo uplo, bool transA, Diag diag, int m, int n,
+        ReadOnlySpan<double> a, int lda, Span<double> b, int ldb)
+    {
+        bool lower = (uplo == Uplo.Lower) ^ transA;
+        if (lower)
+        {
+            for (int i = 0; i < m; i++)
+            {
+                var bi = b.Slice(i * ldb, n);
+                for (int kk = 0; kk < i; kk++)
+                {
+                    double coef = transA ? a[kk * lda + i] : a[i * lda + kk];
+                    var bk = b.Slice(kk * ldb, n);
+                    for (int j = 0; j < n; j++) bi[j] -= coef * bk[j];
+                }
+                if (diag != Diag.Unit)
+                {
+                    double d = a[i * lda + i];
+                    for (int j = 0; j < n; j++) bi[j] /= d;
+                }
+            }
+        }
+        else
+        {
+            for (int i = m - 1; i >= 0; i--)
+            {
+                var bi = b.Slice(i * ldb, n);
+                for (int kk = i + 1; kk < m; kk++)
+                {
+                    double coef = transA ? a[kk * lda + i] : a[i * lda + kk];
+                    var bk = b.Slice(kk * ldb, n);
+                    for (int j = 0; j < n; j++) bi[j] -= coef * bk[j];
+                }
+                if (diag != Diag.Unit)
+                {
+                    double d = a[i * lda + i];
+                    for (int j = 0; j < n; j++) bi[j] /= d;
+                }
+            }
+        }
+    }
+
     private static void TrsmRightScalar<T>(
         Uplo uplo, bool transA, Diag diag, int m, int n,
         ReadOnlySpan<T> a, int lda, Span<T> b, int ldb,
         INumericOperations<T> ops) where T : unmanaged
     {
+        // float/double: same column-wise substitution but with direct typed arithmetic
+        // (no per-element INumericOperations dispatch/box). Columns are ldb-strided so
+        // there's no contiguous-row AXPY to vectorize like the Left kernel; the win is the
+        // removed boxing. Bit-identical (same operands and kk order); generic path kept.
+        if (typeof(T) == typeof(float))
+        {
+            TrsmRightScalarFloat(uplo, transA, diag, m, n, MemoryMarshal.Cast<T, float>(a), lda, MemoryMarshal.Cast<T, float>(b), ldb);
+            return;
+        }
+        if (typeof(T) == typeof(double))
+        {
+            TrsmRightScalarDouble(uplo, transA, diag, m, n, MemoryMarshal.Cast<T, double>(a), lda, MemoryMarshal.Cast<T, double>(b), ldb);
+            return;
+        }
+
         // Right solve X·op(A) = B with A n×n. Effective triangle after transpose.
         bool lower = (uplo == Uplo.Lower) ^ transA;
 
@@ -202,5 +369,55 @@ public static partial class BlasManaged
                     b[i * ldb + j] = diag == Diag.Unit ? sum : ops.Divide(sum, At(a, lda, transA, j, j));
                 }
         }
+    }
+
+    private static void TrsmRightScalarFloat(
+        Uplo uplo, bool transA, Diag diag, int m, int n,
+        ReadOnlySpan<float> a, int lda, Span<float> b, int ldb)
+    {
+        bool lower = (uplo == Uplo.Lower) ^ transA;
+        if (!lower)
+            for (int j = 0; j < n; j++)
+                for (int i = 0; i < m; i++)
+                {
+                    float sum = b[i * ldb + j];
+                    for (int kk = 0; kk < j; kk++)
+                        sum -= b[i * ldb + kk] * (transA ? a[j * lda + kk] : a[kk * lda + j]);
+                    b[i * ldb + j] = diag == Diag.Unit ? sum : sum / a[j * lda + j];
+                }
+        else
+            for (int j = n - 1; j >= 0; j--)
+                for (int i = 0; i < m; i++)
+                {
+                    float sum = b[i * ldb + j];
+                    for (int kk = j + 1; kk < n; kk++)
+                        sum -= b[i * ldb + kk] * (transA ? a[j * lda + kk] : a[kk * lda + j]);
+                    b[i * ldb + j] = diag == Diag.Unit ? sum : sum / a[j * lda + j];
+                }
+    }
+
+    private static void TrsmRightScalarDouble(
+        Uplo uplo, bool transA, Diag diag, int m, int n,
+        ReadOnlySpan<double> a, int lda, Span<double> b, int ldb)
+    {
+        bool lower = (uplo == Uplo.Lower) ^ transA;
+        if (!lower)
+            for (int j = 0; j < n; j++)
+                for (int i = 0; i < m; i++)
+                {
+                    double sum = b[i * ldb + j];
+                    for (int kk = 0; kk < j; kk++)
+                        sum -= b[i * ldb + kk] * (transA ? a[j * lda + kk] : a[kk * lda + j]);
+                    b[i * ldb + j] = diag == Diag.Unit ? sum : sum / a[j * lda + j];
+                }
+        else
+            for (int j = n - 1; j >= 0; j--)
+                for (int i = 0; i < m; i++)
+                {
+                    double sum = b[i * ldb + j];
+                    for (int kk = j + 1; kk < n; kk++)
+                        sum -= b[i * ldb + kk] * (transA ? a[j * lda + kk] : a[kk * lda + j]);
+                    b[i * ldb + j] = diag == Diag.Unit ? sum : sum / a[j * lda + j];
+                }
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SyrkTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SyrkTests.cs
@@ -128,4 +128,39 @@ public class SyrkTests
             for (int j = 0; j <= i; j++)
                 Assert.Equal(expectedFull[i * n + j], actual[i * n + j], 8);
     }
+
+    // #379: the typed-fast-path rework recomputed the blocked tile-write's triangle
+    // bounds per row; this pins the UPPER blocked path (n>64) for both trans and both
+    // element types — the combination the existing blocked test (Lower only) didn't cover.
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Syrk_LargeN_BlockedPath_Upper_MatchesReference(bool trans)
+    {
+        const int n = 150, k = 40; // n > SyrkBlock(64)
+        var rng = new Random(7777);
+        int aRows = trans ? k : n, aCols = trans ? n : k, lda = aCols;
+        double[] a = new double[aRows * aCols];
+        for (int i = 0; i < a.Length; i++) a[i] = rng.NextDouble() * 2 - 1;
+        double[] c = new double[n * n];
+        for (int i = 0; i < c.Length; i++) c[i] = rng.NextDouble() * 2 - 1;
+
+        double alpha = -1.3, beta = 0.7;
+        double[] expectedFull = ReferenceSyrk(trans, n, k, alpha, a, lda, beta, c, n);
+
+        // FP64 typed path.
+        double[] actualD = (double[])c.Clone();
+        BlasManagedLib.Syrk<double>(Uplo.Upper, trans, n, k, alpha, a, lda, beta, actualD, n);
+        // FP32 typed path (same inputs, looser tolerance).
+        float[] aF = Array.ConvertAll(a, x => (float)x);
+        float[] cF = Array.ConvertAll(c, x => (float)x);
+        BlasManagedLib.Syrk<float>(Uplo.Upper, trans, n, k, (float)alpha, aF, lda, (float)beta, cF, n);
+
+        for (int i = 0; i < n; i++)
+            for (int j = i; j < n; j++) // upper triangle
+            {
+                Assert.Equal(expectedFull[i * n + j], actualD[i * n + j], 8);
+                Assert.Equal((float)expectedFull[i * n + j], cF[i * n + j], 2);
+            }
+    }
 }


### PR DESCRIPTION
Closes #379.

## What & why

#379 tracks managed replacements for the specialized BLAS variants (triangular solve, symmetric rank-k, symmetric multiply, banded matvec, sparse GEMM) so they no longer route to native BLAS. The managed implementations already existed and are wired into the call-sites that use them (`LinearSolvers → Trsm`, `SimplicialComplex → Syrk`, `CpuSparseEngine → SpMM`); there are **no remaining `cblas_*` calls** for these. What was left was the perf gap: every variant except SpMM applied its scalar/epilogue work through the generic `INumericOperations<T>` path — a per-element interface dispatch + box/unbox (`ToDouble`/`FromDouble`) the JIT can't vectorize. This PR closes that for all of them.

## Change (all keep the generic-T path as fallback; numerics unchanged)

- **SYRK** — unify the non-blocked write and the blocked tile-write into one `SyrkWriteTriangle` with float/double typed AXBPY; per-row triangle bounds replace the old inner `if (inTri) continue`, letting the typed loop vectorize the contiguous triangle segment.
- **SYMM** — typed per-row AXPBY for the full `m×n` epilogue.
- **TRSM** — typed α pre-scale and blocked trailing-subtract; the **Left** substitution becomes a row-AXPY reorganization (`b[i,:] -= A(i,kk)·b[kk,:]` over the RHS columns, then divide the row) that vectorizes over the contiguous RHS row (bit-identical to the generic per-(i,j) accumulation — same operands, same kk order); the **Right** substitution uses typed arithmetic (columns are `ldb`-strided, so the win there is the removed boxing).
- **GBMV** — typed band matvec (typed band-dot accumulation + typed β-scale).
- **SpMM** — already typed (unchanged).

## Correctness

- **103/103** TRSM/SYRK/SYMM/GBMV tests pass (FP32/FP64, both `uplo`/`trans`/`side`/`diag`, α/β, the blocked SYRK path, and the determinism suites).
- Adds a **new blocked-path UPPER** SYRK test (n=150, both `trans`, FP32+FP64) — the tile-bounds combination the prior blocked test (Lower-only) didn't cover.
- Both TFMs (net10.0 + net471) build.

## Scope

This completes the managed + typed-fastpath coverage for the five #379 variants. The win is largest where the scalar/epilogue work is a meaningful fraction of the op (TRSM substitution, low-rank SYRK, banded matvec) and is uniform removal of per-element boxing everywhere. Related follow-ups are tracked separately: #517 (SYMM mirror-on-pack micro-opt) and #515 (GPU SpMM custom kernels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
