### PR TITLE
fix(compile): three compiled-inference defects — CNN plans returned garbage, replay re-packed B every call, training-trace gate

### DIFF
--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
@@ -642,6 +642,10 @@ public static partial class BlasManaged
         handle.NumIcBlocks = numIcBlocks;
         handle.NumPcBlocks = numPcBlocks;
         handle.MultiPanelStride = tileBytes;
+        // Record the microkernel row tile the panel stripes are interleaved with —
+        // consumers must run the SAME mr or fall back to live packing (see
+        // WeightPackHandle.PackMr).
+        handle.PackMr = mr;
         BlasManagedStatsTracker.AddPackCacheBytes(packedBytes);
 
         // Snapshot Version BEFORE packing so a concurrent MarkDirty doesn't
@@ -761,6 +765,10 @@ public static partial class BlasManaged
         handle.NumIcBlocks = numJcBlocks;  // B-side: jc-blocks live in NumIcBlocks slot
         handle.NumPcBlocks = numPcBlocks;
         handle.MultiPanelStride = tileBytes;
+        // Record the microkernel column tile the panel stripes are interleaved
+        // with — consumers must run the SAME nr or fall back to live packing (see
+        // WeightPackHandle.PackNr).
+        handle.PackNr = nr;
         BlasManagedStatsTracker.AddPackCacheBytes(packedBytes);
 
         long packedVersion = Interlocked.Read(ref handle.Version);

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackAOnlyStrategy.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackAOnlyStrategy.cs
@@ -261,9 +261,12 @@ internal static class PackAOnlyStrategy
                     }
                 }
                 else if (options.PackedA != null && WeightPackCache.IsCacheCurrent(options.PackedA)
+                    && options.PackedA.PackMr == mr
                     && options.PackedA.PackedBuffer.Length >= effectivePackABytes)
                 {
                     // Legacy single-panel pre-pack: only valid when the entire weight fits one tile.
+                    // PackMr gate as above — the buffer is striped at the PACK-time mr;
+                    // consuming with a different active mr reads the wrong stride.
                     activePackA = MemoryMarshal.Cast<byte, T>(options.PackedA.PackedBuffer.AsSpan(0, effectivePackABytes));
                     packAFromPrePack = true;
                 }

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackAOnlyStrategy.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackAOnlyStrategy.cs
@@ -227,8 +227,12 @@ internal static class PackAOnlyStrategy
 
         // Sub-E (#373): detect multi-panel PackedA layout so the (ic, pc) loop
         // below picks the right tile slice rather than always reading offset 0.
+        // PackMr gate: the panel stripes are mr-interleaved at pack time; a
+        // consumer running a different active mr would read them at the wrong
+        // stride (see WeightPackHandle.PackMr). Mismatch -> live pack below.
         bool multiPanelA = options.PackedA != null
             && WeightPackCache.IsCacheCurrent(options.PackedA)
+            && options.PackedA.PackMr == mr
             && options.PackedA.TilingMatches(mc, kc)
             && options.PackedA.FullM >= m
             && options.PackedA.FullK >= k;

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
@@ -576,7 +576,11 @@ internal static class PackBothStrategy
                     Span<T> activePackA;
                     bool prePackHitParallel = false;
                     Span<byte> packAByteSlice = default;
-                    if (packedA != null && WeightPackCache.IsCacheCurrent(packedA))
+                    // PackMr gate (see WeightPackHandle.PackMr): the panel stripes
+                    // are mr-interleaved at PACK time; consuming with a different
+                    // active mr reads the wrong stride and yields garbage. Both
+                    // branches below require the recorded tile to match.
+                    if (packedA != null && WeightPackCache.IsCacheCurrent(packedA) && packedA.PackMr == mr)
                     {
                         if (packedA.MultiPanelStride > 0)
                         {

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
@@ -213,7 +213,13 @@ internal static class PackBothStrategy
                 if (options.PackedB != null && WeightPackCache.IsCacheCurrent(options.PackedB))
                 {
                     var pkdB = options.PackedB;
-                    if (pkdB.MultiPanelStride > 0)
+                    // PackNr gate: the packed panel is interleaved in nr-column
+                    // stripes; consuming with a different active nr (e.g. the
+                    // dispatcher's scalar (4,4) too-small-shape fallback on a
+                    // machine whose prepack tile is 8/16-wide) reads the stripes
+                    // at the wrong stride and yields garbage. Mismatch -> live
+                    // pack below (correct, just unaccelerated).
+                    if (pkdB.PackNr == nr && pkdB.MultiPanelStride > 0)
                     {
                         // Multi-panel: jc-blocks live in NumIcBlocks slot for PackedB.
                         if (pkdB.TileMc == nc && pkdB.TileKc == kc)
@@ -228,7 +234,7 @@ internal static class PackBothStrategy
                             }
                         }
                     }
-                    else if (pkdB.PackedBuffer.Length >= packedBByteCount)
+                    else if (pkdB.PackNr == nr && pkdB.PackedBuffer.Length >= packedBByteCount)
                     {
                         // Legacy single-panel.
                         activePackB = MemoryMarshal.Cast<byte, T>(pkdB.PackedBuffer.AsSpan(0, packedBByteCount));
@@ -263,7 +269,14 @@ internal static class PackBothStrategy
                     if (options.PackedA != null && WeightPackCache.IsCacheCurrent(options.PackedA))
                     {
                         var pkdA = options.PackedA;
-                        if (pkdA.MultiPanelStride > 0)
+                        // PackMr gate: the packed panel is interleaved in mr-row
+                        // stripes; a consumer running a different active mr (the
+                        // dispatcher's scalar (4,4) too-small-shape fallback on a
+                        // machine whose prepack tile is 8 rows wide) reads the
+                        // stripes at the wrong stride and yields garbage —
+                        // exactly the CI-only ScalarKernelTests failures on
+                        // AVX-512 runners. Mismatch -> live pack (correct).
+                        if (pkdA.PackMr == mr && pkdA.MultiPanelStride > 0)
                         {
                             if (pkdA.TileMc == mc && pkdA.TileKc == kc)
                             {
@@ -277,7 +290,7 @@ internal static class PackBothStrategy
                                 }
                             }
                         }
-                        else if (pkdA.PackedBuffer.Length >= effectivePackABytes)
+                        else if (pkdA.PackMr == mr && pkdA.PackedBuffer.Length >= effectivePackABytes)
                         {
                             activePackA = MemoryMarshal.Cast<byte, T>(pkdA.PackedBuffer.AsSpan(0, effectivePackABytes));
                             packAFromPrePack = true;
@@ -432,7 +445,10 @@ internal static class PackBothStrategy
                 // multi-panel and (TileMc, TileKc) match (nc, kc), copy from
                 // the specific (jcIdx, pcIdx) tile rather than offset 0. The
                 // pre-Sub-E single-panel path stays as the fallback else-branch.
-                if (packedB != null && WeightPackCache.IsCacheCurrent(packedB))
+                // PackNr gate (see WeightPackHandle.PackNr): the panel stripes are
+                // nr-interleaved; an active-nr mismatch (scalar fallback on small
+                // shapes vs a wide prepack tile) reads garbage. Mismatch -> live pack.
+                if (packedB != null && WeightPackCache.IsCacheCurrent(packedB) && packedB.PackNr == nr)
                 {
                     if (packedB.MultiPanelStride > 0
                         && packedB.TileMc == nc && packedB.TileKc == kc)
@@ -735,6 +751,7 @@ internal static class PackBothStrategy
                 Span<T> activePackA;
                 bool packAFromPrePack = false;
                 if (packedA != null && WeightPackCache.IsCacheCurrent(packedA)
+                    && packedA.PackMr == mr // stripe-interleave gate (WeightPackHandle.PackMr)
                     && packedA.MultiPanelStride > 0
                     && packedA.TileMc == mc && packedA.TileKc == kc)
                 {
@@ -777,6 +794,7 @@ internal static class PackBothStrategy
                 Span<T> activePackB;
                 bool packBFromPrePack = false;
                 if (packedB != null && WeightPackCache.IsCacheCurrent(packedB)
+                    && packedB.PackNr == nr // stripe-interleave gate (WeightPackHandle.PackNr)
                     && packedB.MultiPanelStride > 0
                     && packedB.TileMc == nc && packedB.TileKc == kc)
                 {

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/WeightPackHandle.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/WeightPackHandle.cs
@@ -62,6 +62,23 @@ public sealed class WeightPackHandle : IDisposable
     internal int NumPcBlocks;
     internal int MultiPanelStride;  // bytes per tile in PackedBuffer
 
+    /// <summary>
+    /// The microkernel row tile (Mr, for A-handles) / column tile (Nr, for
+    /// B-handles) the buffer was PACKED with. Avx2Pack interleaves the panel in
+    /// mr-row (nr-column) stripes, so a consumer running a DIFFERENT microkernel
+    /// tile would read the stripes at the wrong stride and produce garbage.
+    /// Consume sites must verify this matches their active tile and fall back to
+    /// live packing otherwise. The mismatch is real, not theoretical: the Gemm
+    /// dispatcher's too-small-shape fallback drops (mr, nr) to the scalar (4, 4)
+    /// tile whenever m &lt; mr or n &lt; nr — so on an AVX-512 machine (prepack
+    /// tile 8x16/16x16) an 8x8 GEMM consumed a 8/16-stride pack with a 4-stride
+    /// reader (CI: ScalarKernelTests + PrePackedB_Output_BitMatches_LivePack
+    /// failing with deterministic wrong values on AVX-512 runners only).
+    /// 0 = unset (legacy/unknown) — consumers must treat as a mismatch.
+    /// </summary>
+    internal int PackMr;
+    internal int PackNr;
+
     internal WeightPackHandle(
         byte[] packedBuffer,
         (int Mc, int Kc, bool TransA, PackingMode Mode, Type ElemType) key,

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -170,7 +170,12 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             }
 
             var step = _forwardSteps[i];
-            var specialized = TryBuildSpecializedForward(step, _pinnedHandles, allowCachedB: true);
+            // Training plans mutate parameters in-place between Step() calls, so the
+            // identity-keyed pre-pack cache would serve stale weights — same policy as
+            // the initial build below. (This site used to pass true, which was
+            // harmlessly ignored while the FusedLinear branch hardcoded false; now that
+            // the branch respects the caller's policy, training must say false here.)
+            var specialized = TryBuildSpecializedForward(step, _pinnedHandles, allowCachedB: false);
             if (specialized != null)
             {
                 rebuiltForward.Add(specialized);
@@ -2909,17 +2914,24 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             var bArr = (float[])(object)bias.GetDataArray();
             var oArr = (float[])(object)o.GetDataArray();
 
+            var fusedAllowCachedB = allowCachedB;
             return eng =>
             {
                 // Shapes were validated when the graph was compiled; replay skips
                 // public API argument checks and goes straight to the hot kernel.
                 //
-                // allowCachedB: false because optimizer.Step() mutates wArr in
-                // place between forward calls. The pre-packed B cache keys on
-                // the array's identity, so the cached panels would be stale on
-                // every step after the first.
+                // allowCachedB is the CALLER's policy, threaded through: training
+                // plans pass false because optimizer.Step() mutates wArr in place
+                // between forward calls (the pre-packed B cache keys on array
+                // identity, so cached panels would go stale), while INFERENCE
+                // plans pass true for frozen weights. This branch used to
+                // hardcode false, which forced a full PackB on EVERY replay —
+                // the compiled MLP [128,784] replayed 10-19x SLOWER than the
+                // eager forward it traced (AIsEval compiled-mode finding; pinned
+                // by CompiledInferenceParityTests.Mlp_CompiledReplay_
+                // NotDrasticallySlowerThanEager_AtBs128).
                 CpuFusedOperations.FusedGemmBiasActivationUnchecked(
-                    inArr, wArr, bArr, oArr, M, N, K, activation, allowCachedB: false);
+                    inArr, wArr, bArr, oArr, M, N, K, activation, allowCachedB: fusedAllowCachedB);
             };
         }
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -14761,6 +14761,47 @@ public partial class CpuEngine : ITensorLevelEngine
         if (outputHeight <= 0 || outputWidth <= 0)
             throw new ArgumentException($"Invalid output dimensions ({outputHeight}x{outputWidth}). Check pool size and stride.");
 
+        // Lazy graph mode (compiled-inference trace): record the pool as a graph node
+        // so the captured plan stays CONNECTED end-to-end. This entry is what
+        // MaxPoolingLayer.Forward calls, and it previously had NO GraphMode recording —
+        // tracing a conv net captured a graph with both pools missing, which fell apart
+        // into disconnected segments bridged by stale trace-time buffers and a scrambled
+        // topological order (the dense head executed BEFORE the convs). Replay returned
+        // relErr=1.0 garbage (CompiledInferenceParityTests.Cnn_CompiledReplay_MatchesEager).
+        //
+        // The indices side-output cannot be computed here: under an active trace the
+        // input buffer is a graph placeholder (values do not flow at trace time), so it
+        // is returned zero-filled. That is sound for the compiled-INFERENCE path —
+        // indices feed only the training backward, and the traced Predict runs under
+        // NoGradScope — while the recorded node's replay closure recomputes the pooled
+        // VALUES, which is all the inference plan needs.
+        if (GraphMode.IsActive)
+        {
+            var scope = GraphMode.Current;
+            if (scope != null)
+            {
+                maxIndices = new int[batch, channels, outputHeight, outputWidth, 2];
+                var captured = input;
+                int ph = poolH, pw = poolW, sh = strideH, sw = strideW;
+                return scope.RecordUnary(LazyNodeType.MaxPool2D, "MaxPool2DWithIndices", input,
+                    new[] { batch, channels, outputHeight, outputWidth },
+                    (eng, output) =>
+                    {
+                        if (eng is CpuEngine cpuEng && ph == pw && sh == sw)
+                        {
+                            cpuEng.MaxPool2DInto(output, captured, ph, sh, 0);
+                        }
+                        else
+                        {
+                            var eager = eng.MaxPool2DWithIndices(captured, new[] { ph, pw }, new[] { sh, sw }, out _);
+                            eager.AsSpan().CopyTo(output.AsWritableSpan());
+                        }
+                    },
+                    BackwardFunctions<T>.MaxPool2DWithIndicesBackward,
+                    new object[] { maxIndices, poolSize, stride });
+            }
+        }
+
         var result = TensorAllocator.Rent<T>([batch, channels, outputHeight, outputWidth]);
         // Use local variable to avoid capturing out parameter in lambda
         var indices = new int[batch, channels, outputHeight, outputWidth, 2];

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -14813,6 +14813,14 @@ public partial class CpuEngine : ITensorLevelEngine
                 maxIndices = new int[batch, channels, outputHeight, outputWidth, 2];
                 var captured = input;
                 int ph = poolH, pw = poolW, sh = strideH, sw = strideW;
+                // No backwardFn / savedState: this branch is gated to
+                // GradientTape<T>.Current is null (inference-only trace), so
+                // replay never runs a backward. Recording
+                // MaxPool2DWithIndicesBackward + the zero-filled maxIndices
+                // here would (a) pin a potentially large
+                // int[batch, channels, outH, outW, 2] for the lifetime of
+                // the lazy graph / compiled plan, and (b) hand any future
+                // backward consumer corrupt all-zero routing indices.
                 return scope.RecordUnary(LazyNodeType.MaxPool2D, "MaxPool2DWithIndices", input,
                     new[] { batch, channels, outputHeight, outputWidth },
                     (eng, output) =>
@@ -14826,9 +14834,7 @@ public partial class CpuEngine : ITensorLevelEngine
                             var eager = eng.MaxPool2DWithIndices(captured, new[] { ph, pw }, new[] { sh, sw }, out _);
                             eager.AsSpan().CopyTo(output.AsWritableSpan());
                         }
-                    },
-                    BackwardFunctions<T>.MaxPool2DWithIndicesBackward,
-                    new object[] { maxIndices, poolSize, stride });
+                    });
             }
         }
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -12629,7 +12629,22 @@ public partial class CpuEngine : ITensorLevelEngine
     // populates the cache and every subsequent call reuses the transposed
     // buffer for ~0 µs. Multi-threaded callers are handled inside
     // ConditionalWeakTable.GetValue which is documented thread-safe.
-    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<float[], float[]>
+    //
+    // Entries carry the SimdGemm.WeightCacheEpoch at build time: the cache
+    // keys on ARRAY IDENTITY and never re-reads contents, so an in-place
+    // kernel mutation (optimizer step, SetParameters bulk load) would
+    // otherwise leave a stale transpose serving old weights — the same
+    // stale-weight class of bug as SimdGemm's pre-packed-B caches. A hit is
+    // only valid while the entry's epoch matches the current global epoch
+    // (bumped via Engines.InferenceWeightCache.InvalidateAll()).
+    private sealed class KernelTransposeEntry
+    {
+        internal KernelTransposeEntry(float[] data, long epoch) { Data = data; Epoch = epoch; }
+        internal readonly float[] Data;
+        internal readonly long Epoch;
+    }
+
+    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<float[], KernelTransposeEntry>
         _kernelTransposeCache = new();
 
     /// <summary>
@@ -12839,12 +12854,22 @@ public partial class CpuEngine : ITensorLevelEngine
         // kernel array is GC'd.
         static float[] GetOrBuildTransposedKernel(float[] kernel, int rows, int cols)
         {
+            long epoch = AiDotNet.Tensors.Engines.Simd.SimdGemm.WeightCacheEpoch;
+            if (_kernelTransposeCache.TryGetValue(kernel, out var entry) && entry.Epoch == epoch)
+                return entry.Data;
+
+            // Stale (weights mutated in place since the transpose was built)
+            // or missing — rebuild from the live kernel contents. Remove+
+            // GetValue rather than AddOrUpdate: net471's ConditionalWeakTable
+            // has no AddOrUpdate, and a concurrent racer at worst redoes the
+            // transpose once.
+            _kernelTransposeCache.Remove(kernel);
             return _kernelTransposeCache.GetValue(kernel, k =>
             {
                 var kernelT = new float[cols * rows];
                 TransposeFloatParallel(k, 0, kernelT, 0, rows, cols);
-                return kernelT;
-            });
+                return new KernelTransposeEntry(kernelT, epoch);
+            }).Data;
         }
 
         /// <summary>

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -14771,11 +14771,16 @@ public partial class CpuEngine : ITensorLevelEngine
         //
         // The indices side-output cannot be computed here: under an active trace the
         // input buffer is a graph placeholder (values do not flow at trace time), so it
-        // is returned zero-filled. That is sound for the compiled-INFERENCE path —
-        // indices feed only the training backward, and the traced Predict runs under
+        // is returned zero-filled. That is sound ONLY for the compiled-INFERENCE path —
+        // indices feed the training backward, and the traced Predict runs under
         // NoGradScope — while the recorded node's replay closure recomputes the pooled
-        // VALUES, which is all the inference plan needs.
-        if (GraphMode.IsActive)
+        // VALUES, which is all the inference plan needs. TRAINING traces (an active
+        // GradientTape) must NOT take this branch: the recorded node's saved zero-filled
+        // indices would corrupt MaxPool2DWithIndicesBackward's gradient routing
+        // (surfaced as Issue1296 gradient-accumulation mismatches). They keep the
+        // eager path below, exactly as before this recording existed.
+        if (GraphMode.IsActive
+            && Autodiff.GradientTape<T>.Current is null)
         {
             var scope = GraphMode.Current;
             if (scope != null)

--- a/src/AiDotNet.Tensors/Engines/InferenceWeightCache.cs
+++ b/src/AiDotNet.Tensors/Engines/InferenceWeightCache.cs
@@ -1,0 +1,45 @@
+namespace AiDotNet.Tensors.Engines;
+
+/// <summary>
+/// Invalidation surface for the engine's identity-keyed inference weight
+/// caches. Several CPU fast paths cache a derived form of a weight array
+/// keyed by the array's OBJECT IDENTITY and never re-read its contents:
+/// <list type="bullet">
+///   <item><c>SimdGemm.SgemmWithCachedB</c> — persistent pre-packed B panels
+///   (the FusedLinear / MLP / transformer-FFN inference GEMM path).</item>
+///   <item><c>SimdGemm.SgemmWithInt8CachedB</c> — weight-only int8 packed B.</item>
+///   <item><c>CpuEngine</c>'s Conv2D small-N fast path — pre-transposed
+///   kernel arrays.</item>
+/// </list>
+/// Mutating a weight array IN PLACE (an optimizer step, a
+/// <c>SetParameters</c>/<c>WithParameters</c>-style bulk load, manual tensor
+/// writes) therefore leaves those caches stale: subsequent inference would
+/// silently compute with the OLD weights. Callers that mutate weights in
+/// place must call <see cref="InvalidateAll"/> afterwards; the next use of
+/// each weight re-derives its cached form from the live contents.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Invalidation is a single global epoch bump rather than per-array removal:
+/// the GEMM caches keep per-thread MRU slots that other threads cannot reach,
+/// and an epoch comparison on every hit path covers them all. The cost of a
+/// hit-path check is one interlocked read; the cost of an invalidation is a
+/// re-pack of every live weight on its next use — inherent, since the weights
+/// changed.
+/// </para>
+/// <para>
+/// This mirrors the GPU-side contract (<c>DirectGpuTensorEngine.
+/// InvalidateAllWeightCaches</c>): both engines key weight-derived caches by
+/// reference identity, so both need an explicit flush after in-place updates.
+/// </para>
+/// </remarks>
+public static class InferenceWeightCache
+{
+    /// <summary>
+    /// Invalidate every cached derived weight form (packed GEMM panels,
+    /// int8 packs, transposed conv kernels). Call after any in-place weight
+    /// mutation so the next inference re-derives from live weight contents.
+    /// Thread-safe; O(1).
+    /// </summary>
+    public static void InvalidateAll() => Simd.SimdGemm.InvalidateCachedWeights();
+}

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
@@ -184,6 +184,37 @@ internal static partial class SimdGemm
         int.TryParse(System.Environment.GetEnvironmentVariable("AIDOTNET_JIT_SMALLK_MAXM"), out var jmm) && jmm > 0
             ? jmm : 2048;
 
+    // ─── Stale-weight invalidation epoch ────────────────────────────────────
+    // The identity-keyed weight caches (pre-packed B below on net5+, the
+    // Conv2D kernel-transpose cache in CpuEngine) never re-read the weight
+    // array's contents. In-place weight mutation (optimizer steps,
+    // SetParameters/WithParameters-style bulk loads) therefore left the
+    // derived copy STALE: inference after a weight update silently used the
+    // old weights (caught by AiDotNet's Issue1296 grad-accum equivalence
+    // probe — two models with bit-identical parameters produced different
+    // forwards because one had a pack from its pre-load random init).
+    //
+    // Invalidation is a single global epoch counter rather than per-array
+    // removal because the thread-static MRU slots (_threadPrePackedBKey0/1)
+    // live on OTHER threads and cannot be cleared from the invalidating
+    // thread — an epoch comparison on every hit path covers them all. Cost
+    // per lookup is one Interlocked read; cost per invalidation is a full
+    // repack of every live weight on next use, which is inherent (the
+    // weights changed). Exposed publicly via Engines.InferenceWeightCache.
+    // Lives OUTSIDE the NET5_0_OR_GREATER region: the kernel-transpose cache
+    // consumes the epoch on every target framework.
+    private static long _weightCacheEpoch;
+
+    internal static long WeightCacheEpoch => System.Threading.Interlocked.Read(ref _weightCacheEpoch);
+
+    /// <summary>
+    /// Invalidate every cached derived weight (pre-packed float/int8 B,
+    /// transposed conv kernels). Must be called after mutating a weight
+    /// array in place that may have been consumed by a weight-cached fast
+    /// path; the next call re-derives from the live array contents.
+    /// </summary>
+    internal static void InvalidateCachedWeights() => System.Threading.Interlocked.Increment(ref _weightCacheEpoch);
+
 #if NET5_0_OR_GREATER
     // ─── Path A: pre-packed B cache ────────────────────────────────────────
     //
@@ -210,6 +241,9 @@ internal static partial class SimdGemm
         // Flat index: pcIter * NumColSubBlocks + csIdx.
         internal float[][] PackedSubs = System.Array.Empty<float[]>();
         internal int NumPcIters;
+        // WeightCacheEpoch value at build time. A hit is only valid while
+        // this matches the current global epoch — see _weightCacheEpoch.
+        internal long Epoch;
     }
 
     private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<float[], PrePackedB> _prePackedBCache = new();
@@ -278,6 +312,7 @@ internal static partial class SimdGemm
             ColSubSize = colSubSize,
             PackedSubs = packedSubs,
             NumPcIters = numPcIters,
+            Epoch = WeightCacheEpoch,
         };
     }
 
@@ -374,9 +409,11 @@ internal static partial class SimdGemm
         if (TryGetThreadPrePackedB(b, k, n, expectedMc, out var threadCached) && threadCached is not null)
             return threadCached;
 
+        long epoch = WeightCacheEpoch;
         if (_prePackedBCache.TryGetValue(b, out var existing)
             && existing.K == k && existing.N == n
-            && existing.Mc == expectedMc)
+            && existing.Mc == expectedMc
+            && existing.Epoch == epoch)
         {
             RememberThreadPrePackedB(b, existing);
             return existing;
@@ -387,7 +424,8 @@ internal static partial class SimdGemm
             if (_prePackedBCache.TryGetValue(b, out existing))
             {
                 if (existing.K == k && existing.N == n
-                    && existing.Mc == expectedMc)
+                    && existing.Mc == expectedMc
+                    && existing.Epoch == epoch)
                 {
                     RememberThreadPrePackedB(b, existing);
                     return existing;
@@ -431,6 +469,7 @@ internal static partial class SimdGemm
         if (valueRef is not null
             && valueRef.TryGetTarget(out var value)
             && value.K == k && value.N == n && value.Mc == expectedMc
+            && value.Epoch == WeightCacheEpoch
             && keyRef is not null
             && keyRef.TryGetTarget(out var key)
             && ReferenceEquals(key, b))
@@ -498,6 +537,8 @@ internal static partial class SimdGemm
         internal sbyte[][] PackedSubs = System.Array.Empty<sbyte[]>();
         internal int NumPcIters;
         internal float Scale;
+        // WeightCacheEpoch value at build time — see _weightCacheEpoch.
+        internal long Epoch;
     }
 
     private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<float[], Int8PrePackedB> _int8PrePackedBCache = new();
@@ -564,6 +605,7 @@ internal static partial class SimdGemm
             PackedSubs = packedSubs,
             NumPcIters = numPcIters,
             Scale = scale,
+            Epoch = WeightCacheEpoch,
         };
     }
 
@@ -601,9 +643,11 @@ internal static partial class SimdGemm
 
     private static Int8PrePackedB GetOrBuildInt8PrePackedB(float[] b, int k, int n, int m, int expectedMc)
     {
+        long epoch = WeightCacheEpoch;
         if (_int8PrePackedBCache.TryGetValue(b, out var existing)
             && existing.K == k && existing.N == n
-            && existing.Mc == expectedMc)
+            && existing.Mc == expectedMc
+            && existing.Epoch == epoch)
         {
             return existing;
         }
@@ -613,7 +657,8 @@ internal static partial class SimdGemm
             if (_int8PrePackedBCache.TryGetValue(b, out existing))
             {
                 if (existing.K == k && existing.N == n
-                    && existing.Mc == expectedMc)
+                    && existing.Mc == expectedMc
+                    && existing.Epoch == epoch)
                 {
                     return existing;
                 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/PackTileMismatchTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/PackTileMismatchTests.cs
@@ -36,7 +36,13 @@ public class PackTileMismatchTests
         {
             // Simulate the dispatcher consuming with a different microkernel tile
             // than the buffer was packed with (the AVX-512-runner scenario).
-            handle.PackMr = handle.PackMr == 4 ? 8 : 4;
+            // Use an impossible tile value: flipping 4<->8 can ACCIDENTALLY
+            // MATCH the consumer's active tile on machines whose real pack
+            // tile differs from this box's (e.g. AVX-512: pack mr=8, consume
+            // falls back to scalar mr=4 — flipping 8->4 then EQUALS the
+            // active tile and the mispacked buffer is consumed). -1 never
+            // matches any kernel tile, so the gate must always reject.
+            handle.PackMr = -1;
 
             var options = new BlasOptions<double> { PackedA = handle, PackingMode = PackingMode.ForcePackBoth };
             var result = new double[m * n];
@@ -58,7 +64,9 @@ public class PackTileMismatchTests
         var handle = BlasManagedLib.PrePackB<double>(b, ldb: n, transB: false, k, n);
         try
         {
-            handle.PackNr = handle.PackNr == 8 ? 16 : 8;
+            // Impossible tile value — see the PackMr test for why a 8<->16
+            // flip could accidentally match the consumer's active tile.
+            handle.PackNr = -1;
 
             var options = new BlasOptions<double> { PackedB = handle, PackingMode = PackingMode.ForcePackBoth };
             var result = new double[m * n];

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/PackTileMismatchTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/PackTileMismatchTests.cs
@@ -1,0 +1,119 @@
+using System;
+using AiDotNet.Tensors.Engines.BlasManaged;
+using Xunit;
+using BlasManagedLib = AiDotNet.Tensors.Engines.BlasManaged.BlasManaged;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+/// <summary>
+/// Pack-time vs consume-time microkernel-tile agreement (the root cause of the
+/// CI-only ScalarKernelTests / PrePackedB_Output_BitMatches_LivePack failures):
+/// Avx2Pack interleaves panels in mr-row / nr-column stripes, and the Gemm
+/// dispatcher's too-small-shape fallback can select a DIFFERENT (mr, nr) at
+/// consume time than the prepack tile (e.g. scalar (4,4) for an 8x8 GEMM on an
+/// AVX-512 machine whose prepack tile is 8/16 wide). Consuming the buffer with
+/// the wrong stripe stride produced deterministic garbage — but only on runners
+/// whose CPU picked mismatched tiles, which is why CI failed while dev boxes
+/// passed.
+///
+/// The fix records the pack-time tile on the handle (PackMr/PackNr) and the
+/// strategies reject the prepack on mismatch, falling back to live packing.
+/// These tests pin the gate DETERMINISTICALLY on any CPU by corrupting the
+/// recorded tile and asserting the Gemm result is still correct (live-pack
+/// fallback), instead of relying on a particular machine's tile selection.
+/// </summary>
+[Collection("BlasManaged-Stats-Serial")]
+public class PackTileMismatchTests
+{
+    [Fact]
+    public void Gemm_PackedA_WithMismatchedPackMr_FallsBackToLivePack_AndStaysCorrect()
+    {
+        int m = 8, n = 8, k = 8;
+        var (a, b) = GenerateMatrices(m, n, k, seed: 42);
+
+        var handle = BlasManagedLib.PrePackA<double>(a, lda: k, transA: false, m, k);
+        try
+        {
+            // Simulate the dispatcher consuming with a different microkernel tile
+            // than the buffer was packed with (the AVX-512-runner scenario).
+            handle.PackMr = handle.PackMr == 4 ? 8 : 4;
+
+            var options = new BlasOptions<double> { PackedA = handle, PackingMode = PackingMode.ForcePackBoth };
+            var result = new double[m * n];
+            BlasManagedLib.Gemm<double>(a, k, false, b, n, false, result, n, m, n, k, options);
+
+            var expected = Naive(a, b, m, n, k);
+            for (int i = 0; i < expected.Length; i++)
+                Assert.Equal(expected[i], result[i], precision: 10);
+        }
+        finally { handle.Dispose(); }
+    }
+
+    [Fact]
+    public void Gemm_PackedB_WithMismatchedPackNr_FallsBackToLivePack_AndStaysCorrect()
+    {
+        int m = 8, n = 16, k = 8;
+        var (a, b) = GenerateMatrices(m, n, k, seed: 7);
+
+        var handle = BlasManagedLib.PrePackB<double>(b, ldb: n, transB: false, k, n);
+        try
+        {
+            handle.PackNr = handle.PackNr == 8 ? 16 : 8;
+
+            var options = new BlasOptions<double> { PackedB = handle, PackingMode = PackingMode.ForcePackBoth };
+            var result = new double[m * n];
+            BlasManagedLib.Gemm<double>(a, k, false, b, n, false, result, n, m, n, k, options);
+
+            var expected = Naive(a, b, m, n, k);
+            for (int i = 0; i < expected.Length; i++)
+                Assert.Equal(expected[i], result[i], precision: 10);
+        }
+        finally { handle.Dispose(); }
+    }
+
+    [Fact]
+    public void Gemm_PackedA_WithMatchingPackMr_StillConsumesPrePack()
+    {
+        // Companion guard: the gate must not be over-broad — an UNTOUCHED handle
+        // (pack tile == consume tile on this machine, the normal case) must still
+        // produce correct results, whether the prepack was consumed or live-packed.
+        int m = 16, n = 16, k = 16;
+        var (a, b) = GenerateMatrices(m, n, k, seed: 11);
+
+        var handle = BlasManagedLib.PrePackA<double>(a, lda: k, transA: false, m, k);
+        try
+        {
+            var options = new BlasOptions<double> { PackedA = handle, PackingMode = PackingMode.ForcePackBoth };
+            var result = new double[m * n];
+            BlasManagedLib.Gemm<double>(a, k, false, b, n, false, result, n, m, n, k, options);
+
+            var expected = Naive(a, b, m, n, k);
+            for (int i = 0; i < expected.Length; i++)
+                Assert.Equal(expected[i], result[i], precision: 10);
+        }
+        finally { handle.Dispose(); }
+    }
+
+    private static (double[] a, double[] b) GenerateMatrices(int m, int n, int k, int seed)
+    {
+        var rng = new Random(seed);
+        var a = new double[m * k];
+        var b = new double[k * n];
+        for (int i = 0; i < a.Length; i++) a[i] = rng.NextDouble() * 2 - 1;
+        for (int i = 0; i < b.Length; i++) b[i] = rng.NextDouble() * 2 - 1;
+        return (a, b);
+    }
+
+    private static double[] Naive(double[] a, double[] b, int m, int n, int k)
+    {
+        var c = new double[m * n];
+        for (int i = 0; i < m; i++)
+            for (int j = 0; j < n; j++)
+            {
+                double acc = 0;
+                for (int p = 0; p < k; p++) acc += a[i * k + p] * b[p * n + j];
+                c[i * n + j] = acc;
+            }
+        return c;
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/ScalarKernelTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/ScalarKernelTests.cs
@@ -2404,7 +2404,17 @@ public class ScalarKernelTests
         // cache. We verify this by mutating `a` WITHOUT calling MarkDirty: the
         // Gemm result must match the ORIGINAL weight (the one captured in PrePackA),
         // not the mutated one.
-        int m = 8, n = 8, k = 8;
+        //
+        // Shape note: m and n must be >= the WIDEST microkernel tile any CPU
+        // selects (AVX-512 fp64 prepack tile is 8x16), or the dispatcher's
+        // too-small-shape fallback drops to the scalar (4,4) tile, the
+        // PackMr stripe-interleave gate correctly REJECTS the 8-striped
+        // prepack, and the live-pack fallback reads the CURRENT (mutated)
+        // source — flipping this test's expected value on AVX-512 runners
+        // only (the original 8x8x8 shape did exactly that on CI). 16x16
+        // guarantees the prepack is consumable on every tile config, which
+        // is the precondition for the stale-cache semantics asserted here.
+        int m = 16, n = 16, k = 8;
         var (a, b) = GenerateRandomMatrices(m, n, k, transA: false, transB: false, seed: 42);
         double[] aOriginal = (double[])a.Clone();
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/Simd/InferenceWeightCacheInvalidationTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Simd/InferenceWeightCacheInvalidationTests.cs
@@ -70,6 +70,58 @@ public class InferenceWeightCacheInvalidationTests
         }
     }
 
+    [Fact]
+    public void SgemmWithInt8CachedB_AfterInPlaceWeightMutation_InvalidateAll_UsesFreshWeights()
+    {
+        // Same contract as the float path, on the weight-only int8 cache.
+        // Tolerance is the int8 quantization error (per-tensor symmetric,
+        // 35-40 dB SNR), not float rounding.
+        const int m = 8, k = 512, n = 64;
+        var rng = new Random(540);
+        var a = new float[m * k];
+        var b = new float[k * n];
+        for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+        for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+
+        var c1 = new float[m * n];
+        SimdGemm.SgemmWithInt8CachedB(a, b, c1, m, k, n);
+        AssertMatchesNaiveQuantized(a, b, c1, m, k, n, "initial int8 call");
+
+        for (int i = 0; i < b.Length; i++) b[i] = -b[i] * 0.5f + 0.25f;
+        InferenceWeightCache.InvalidateAll();
+
+        var c2 = new float[m * n];
+        SimdGemm.SgemmWithInt8CachedB(a, b, c2, m, k, n);
+        AssertMatchesNaiveQuantized(a, b, c2, m, k, n, "post-mutation int8 call");
+    }
+
+    private static void AssertMatchesNaiveQuantized(
+        float[] a, float[] b, float[] c, int m, int k, int n, string label)
+    {
+        // Per-element bound: int8 symmetric quantization of B contributes
+        // |err| <= scale/2 per product term; accumulate over K with the A
+        // magnitudes. A loose absolute bound of 2% of the accumulated
+        // |a|·|b| magnitude comfortably covers it while still failing hard
+        // on stale weights (B's mutation flips sign and shifts by 0.25 —
+        // stale results differ by O(1), not O(0.02)).
+        for (int i = 0; i < m; i++)
+        {
+            for (int j = 0; j < n; j++)
+            {
+                double acc = 0, mag = 0;
+                for (int p = 0; p < k; p++)
+                {
+                    acc += (double)a[i * k + p] * b[p * n + j];
+                    mag += Math.Abs((double)a[i * k + p] * b[p * n + j]);
+                }
+                double got = c[i * n + j];
+                double tol = 0.02 * Math.Max(1.0, mag);
+                Assert.True(Math.Abs(got - acc) <= tol,
+                    $"{label}: C[{i},{j}] = {got}, expected {acc} ± {tol} (stale packed int8 weights?)");
+            }
+        }
+    }
+
     private static void AssertMatchesNaive(
         float[] a, float[] b, float[] c, int m, int k, int n, string label)
     {

--- a/tests/AiDotNet.Tensors.Tests/Engines/Simd/InferenceWeightCacheInvalidationTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Simd/InferenceWeightCacheInvalidationTests.cs
@@ -70,6 +70,9 @@ public class InferenceWeightCacheInvalidationTests
         }
     }
 
+#if NET5_0_OR_GREATER
+    // SgemmWithInt8CachedB (and the int8 pre-packed cache) only exist on
+    // net5+ — the whole Path-D region in SimdGemm is NET5_0_OR_GREATER.
     [Fact]
     public void SgemmWithInt8CachedB_AfterInPlaceWeightMutation_InvalidateAll_UsesFreshWeights()
     {
@@ -121,6 +124,7 @@ public class InferenceWeightCacheInvalidationTests
             }
         }
     }
+#endif
 
     private static void AssertMatchesNaive(
         float[] a, float[] b, float[] c, int m, int k, int n, string label)

--- a/tests/AiDotNet.Tensors.Tests/Engines/Simd/InferenceWeightCacheInvalidationTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Simd/InferenceWeightCacheInvalidationTests.cs
@@ -1,0 +1,89 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Simd;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Simd;
+
+/// <summary>
+/// Stale-weight invalidation for the identity-keyed inference caches
+/// (AiDotNet#1296 grad-accum probe root cause): SgemmWithCachedB keys its
+/// persistent pre-packed B on the weight ARRAY's object identity and never
+/// re-reads contents, so an in-place weight mutation (optimizer step,
+/// SetParameters/WithParameters bulk load) silently served the OLD weights
+/// on every subsequent inference GEMM. <see cref="InferenceWeightCache.InvalidateAll"/>
+/// bumps a global epoch that every hit path (ConditionalWeakTable AND the
+/// per-thread MRU slots) checks, forcing a re-pack from live contents.
+/// </summary>
+public class InferenceWeightCacheInvalidationTests
+{
+    [Fact]
+    public void SgemmWithCachedB_AfterInPlaceWeightMutation_InvalidateAll_UsesFreshWeights()
+    {
+        // Shape chosen to take the cached-B packed path (not the JIT/small-K
+        // or direct fast paths): large K so directWork exceeds the direct
+        // thresholds, n modest so the single-jc cache assumption holds.
+        const int m = 8, k = 512, n = 64;
+        var rng = new Random(1296);
+        var a = new float[m * k];
+        var b = new float[k * n];
+        for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+        for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+
+        // First call populates the identity-keyed pre-packed cache (or takes
+        // a non-cached path on AVX-512 machines — invalidation must be
+        // correct either way).
+        var c1 = new float[m * n];
+        SimdGemm.SgemmWithCachedB(a, b, c1, m, k, n);
+        AssertMatchesNaive(a, b, c1, m, k, n, "initial call");
+
+        // Mutate B IN PLACE — same array identity, new contents. This is
+        // exactly what an optimizer step or a bulk parameter load does.
+        for (int i = 0; i < b.Length; i++) b[i] = -b[i] * 0.5f + 0.25f;
+
+        // The documented contract: in-place mutators must invalidate.
+        InferenceWeightCache.InvalidateAll();
+
+        var c2 = new float[m * n];
+        SimdGemm.SgemmWithCachedB(a, b, c2, m, k, n);
+        AssertMatchesNaive(a, b, c2, m, k, n, "post-mutation call");
+    }
+
+    [Fact]
+    public void SgemmWithCachedB_RepeatedCallsSameWeights_StayCorrect()
+    {
+        // Companion guard: the epoch gate must not break the steady-state
+        // cache-hit path — repeated calls with UNCHANGED weights must keep
+        // producing correct results (and may consume the cached pack).
+        const int m = 8, k = 512, n = 64;
+        var rng = new Random(7);
+        var a = new float[m * k];
+        var b = new float[k * n];
+        for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+        for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+
+        for (int call = 0; call < 3; call++)
+        {
+            var c = new float[m * n];
+            SimdGemm.SgemmWithCachedB(a, b, c, m, k, n);
+            AssertMatchesNaive(a, b, c, m, k, n, $"call {call}");
+        }
+    }
+
+    private static void AssertMatchesNaive(
+        float[] a, float[] b, float[] c, int m, int k, int n, string label)
+    {
+        for (int i = 0; i < m; i++)
+        {
+            for (int j = 0; j < n; j++)
+            {
+                double acc = 0;
+                for (int p = 0; p < k; p++) acc += (double)a[i * k + p] * b[p * n + j];
+                double got = c[i * n + j];
+                double tol = 1e-3 * Math.Max(1.0, Math.Abs(acc));
+                Assert.True(Math.Abs(got - acc) <= tol,
+                    $"{label}: C[{i},{j}] = {got}, expected {acc} (stale packed weights?)");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #538. The AIsEval compiled-mode benchmark (with an eager-vs-compiled output guard) surfaced three defects in the compiled-inference path; each is root-caused, fixed, and pinned by regression tests in the AiDotNet repo (`CompiledInferenceParityTests`, `CompiledPlanMemoryTests` — red→green with these commits).

## 1. CNN compiled plans computed garbage (relErr = 1.0)
`MaxPoolingLayer.Forward` calls `MaxPool2DWithIndices`, which had **no GraphMode recording** (only the plain `MaxPool2D` overload recorded). Tracing a conv net captured a graph with every pool missing: disconnected segments bridged by stale trace-time buffers and a scrambled topological order (the dense head executed *before* the convs). Fixed by recording the pool as a graph node; the indices side-output is zero-filled under a trace (values don't flow at trace time) which is sound for inference (indices feed only the training backward; traced `Predict` runs under `NoGradScope`).

## 2. Compiled replay 10–19× slower than the eager forward it traced
`TryBuildSpecializedForward`'s FusedLinear branch hardcoded `allowCachedB:false` (a training-plan staleness precaution), ignoring the parameter the **inference** compiler computes precisely so frozen weights can use the identity-keyed pre-pack cache. Every replay re-ran a full `PackB` per linear layer — AIsEval MLP [128,784]: 6.5–12 ms replay vs 0.65 ms eager. The parameter is now threaded through; the training rebuild site that passed `true` (harmlessly ignored until now) is corrected to `false`, so training behavior is unchanged.

## 3. Training-trace safety gate
The new pool recording is gated to tape-free traces: a training trace would persist zero-filled indices into `MaxPool2DWithIndicesBackward`'s saved state and route every gradient to (0,0). Training traces keep the eager path with real indices, exactly as before.

## Verification
- AiDotNet-side: 8 parity/perf tests (CNN parity same-shape + cross-batch for plans traced at bs=1, MLP parity at bs 1/8/32/128, replay ≤3× eager guard) + plan-memory release test — all green against these fixes.
- Compiled-area regression sweep (45 tests): 42 pass; the 3 `Issue1296LargeXTrainBatching` failures reproduce **identically at the pre-change baseline commit** (verified in a clean worktree) — pre-existing, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)