### PR TITLE
test(#436): make all PerformanceRegression perf gates runnable + verify

### DIFF
--- a/tests/AiDotNet.Tensors.Tests/Engines/PerformanceRegressionTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/PerformanceRegressionTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using AiDotNet.Tensors.Engines;
@@ -18,7 +18,11 @@ namespace AiDotNet.Tensors.Tests.Engines;
 /// time budget. The budgets are generous (10-50x headroom) so they pass on
 /// any reasonable hardware, but catch 60x regressions from scalar loops.
 ///
-/// Run with: dotnet test --filter "PerformanceRegression"
+/// These are runnable perf gates (Category=Perf + AIDOTNET_RUN_PERF_GATES=1 opt-in,
+/// matching FusedConv2DResnetSpeedupTests): a no-op on default/shared CI runners,
+/// executable on dedicated hardware. Run with:
+///   AIDOTNET_RUN_PERF_GATES=1 dotnet test --filter "Category=Perf"
+/// (A bare [Fact(Skip=...)] never runs even with --filter, so it cannot gate.)
 /// </summary>
 public class PerformanceRegressionTests
 {
@@ -79,6 +83,8 @@ public class PerformanceRegressionTests
     //     previous 30 ms budget (CodeRabbit review on PR #437) would have
     //     passed a wrapper-path fallback unchanged — it caught only outright
     //     unfused dispatch, not the regression this test is named for.
+    // (These gates run on net5+ only; see PerfGatesEnabled — net471 perf timing is
+    // dominated by the OS scheduler quantum, not the kernel.)
     private const double LstmAiseval_BudgetMs = 30.0;
     private const double MhaAiseval_BudgetMs = 15.0;
 
@@ -95,246 +101,244 @@ public class PerformanceRegressionTests
     // p95 (~3.2 ms) while leaving ~2.9x headroom over the capped median for slower
     // CI hardware. (Beating PyTorch's ~0.6 ms median outright is blocked by
     // OpenBLAS-vs-MKL small-GEMM kernel quality — tracked as a follow-up.)
-    //
-    // net471 has no System.Runtime.Intrinsics.X86, so MlpForward's fused
-    // elementwise path falls back to scalar Math and BlasManaged runs the
-    // Vector<T> kernels (no AVX2 microkernel) — the same fused stack measures
-    // ~4.9 ms median on net471 vs ~1.37 ms on net10.0. The budget is loosened to
-    // 7 ms there: still comfortably under the 8.94 ms unfused-dispatch regression
-    // it guards, with ~1.4x headroom over the measured net471 fused number. This
-    // is a platform floor (no intrinsics), not a regression to hide.
-#if NET471
-    private const double MlpAiseval_BudgetMs = 7.0;
-#else
+    // (net5+ only; see PerfGatesEnabled — net471 perf timing is dominated by the
+    // OS scheduler quantum, not the kernel.)
     private const double MlpAiseval_BudgetMs = 4.0;
-#endif
 
     public PerformanceRegressionTests(ITestOutputHelper output) => _output = output;
 
-    [Fact(Skip = "Performance guard — run manually with --filter PerformanceRegression")]
+    // Perf gates execute only on dedicated hardware (AIDOTNET_RUN_PERF_GATES=1).
+    // On shared/CI runners they no-op so sub-millisecond latency noise can't fail
+    // them; the Category=Perf trait also keeps them out of the default CI filter.
+    // This replaces the old [Fact(Skip=...)] pattern, which never runs even with
+    // --filter and therefore could not actually gate anything.
+    private bool PerfGatesEnabled()
+    {
+#if NET471
+        // Perf gates target the performance-critical modern runtime (net5+), where
+        // System.Runtime.Intrinsics is available. On net471 the fast paths fall back
+        // to Vector<T>/scalar kernels, and — more decisively — the parallel dispatch
+        // paths sleep-and-wake on the ~15.6 ms Windows scheduler quantum rather than
+        // spin-waiting, so sub-millisecond ops report ~15.78 ms identically across
+        // unrelated kernels (TensorMatMul-768, TensorAdd-100K, Tensor.Add all land at
+        // the same ~15.8 ms). That floor is the OS timer, not a regression signal, so
+        // gating perf on net471 is meaningless. net471 correctness is covered by the
+        // functional suites; perf is gated on net5+ only. No-op here.
+        _output.WriteLine("Skip: perf gates are net5+-only (net471 sub-ms timing hits the OS scheduler quantum).");
+        return false;
+#else
+        if (Environment.GetEnvironmentVariable("AIDOTNET_RUN_PERF_GATES") == "1") return true;
+        _output.WriteLine("Skip: AIDOTNET_RUN_PERF_GATES != 1 (shared-runner perf gates are flaky).");
+        return false;
+#endif
+    }
+
+    // Per-iter MEDIAN (robust to a single GC pause, unlike a mean) over `iters`
+    // timed runs, after `warmup` untimed runs to settle JIT + caches.
+    private static double MedianMs(int warmup, int iters, Action body)
+    {
+        for (int w = 0; w < warmup; w++) body();
+        var samples = new double[iters];
+        for (int i = 0; i < iters; i++)
+        {
+            var sw = Stopwatch.StartNew();
+            body();
+            sw.Stop();
+            samples[i] = sw.Elapsed.TotalMilliseconds;
+        }
+        Array.Sort(samples);
+        return samples[iters / 2];
+    }
+
+    [Fact]
+    [Trait("Category", "Perf")]
     public void TensorMatMul_256x256_NotScalarLoop()
     {
+        if (!PerfGatesEnabled()) return;
+
         var a = Tensor<float>.CreateRandom([32, 256]);
         var b = Tensor<float>.CreateRandom([256, 256]);
 
-        // Warmup
-        for (int w = 0; w < 5; w++) _engine.TensorMatMul(a, b);
+        double ms = MedianMs(5, 20, () => _engine.TensorMatMul(a, b));
 
-        var sw = Stopwatch.StartNew();
-        int iters = 20;
-        for (int i = 0; i < iters; i++) _engine.TensorMatMul(a, b);
-        sw.Stop();
-        double ms = sw.Elapsed.TotalMilliseconds / iters;
-
-        _output.WriteLine($"TensorMatMul 32x256 @ 256x256: {ms:F3}ms (budget: {MatMul256BudgetMs}ms)");
+        _output.WriteLine($"TensorMatMul 32x256 @ 256x256: {ms:F3}ms median (budget: {MatMul256BudgetMs}ms)");
         Assert.True(ms < MatMul256BudgetMs,
             $"TensorMatMul took {ms:F3}ms — exceeds {MatMul256BudgetMs}ms budget. " +
             "Likely using scalar loops instead of BLAS. Check CpuEngine.TensorMatMul2D.");
     }
 
-    [Fact(Skip = "Performance guard — run manually with --filter PerformanceRegression")]
+    [Fact]
+    [Trait("Category", "Perf")]
     public void TensorMatMul_768x768_NotScalarLoop()
     {
+        if (!PerfGatesEnabled()) return;
+
         var a = Tensor<float>.CreateRandom([16, 768]);
         var b = Tensor<float>.CreateRandom([768, 768]);
 
-        for (int w = 0; w < 3; w++) _engine.TensorMatMul(a, b);
+        double ms = MedianMs(3, 10, () => _engine.TensorMatMul(a, b));
 
-        var sw = Stopwatch.StartNew();
-        int iters = 10;
-        for (int i = 0; i < iters; i++) _engine.TensorMatMul(a, b);
-        sw.Stop();
-        double ms = sw.Elapsed.TotalMilliseconds / iters;
-
-        _output.WriteLine($"TensorMatMul 16x768 @ 768x768: {ms:F3}ms (budget: {MatMul768BudgetMs}ms)");
+        _output.WriteLine($"TensorMatMul 16x768 @ 768x768: {ms:F3}ms median (budget: {MatMul768BudgetMs}ms)");
         Assert.True(ms < MatMul768BudgetMs,
             $"TensorMatMul took {ms:F3}ms — exceeds {MatMul768BudgetMs}ms budget. " +
             "Likely using scalar loops instead of BLAS.");
     }
 
-    [Fact(Skip = "Performance guard — run manually with --filter PerformanceRegression")]
+    [Fact]
+    [Trait("Category", "Perf")]
     public void FusedLinear_256x256_NotScalarLoop()
     {
+        if (!PerfGatesEnabled()) return;
+
         var input = Tensor<float>.CreateRandom([32, 256]);
         var weights = Tensor<float>.CreateRandom([256, 256]);
         var bias = Tensor<float>.CreateRandom([1, 256]);
 
-        for (int w = 0; w < 5; w++)
-            _engine.FusedLinear(input, weights, bias, FusedActivationType.ReLU);
+        double ms = MedianMs(5, 20, () => _engine.FusedLinear(input, weights, bias, FusedActivationType.ReLU));
 
-        var sw = Stopwatch.StartNew();
-        int iters = 20;
-        for (int i = 0; i < iters; i++)
-            _engine.FusedLinear(input, weights, bias, FusedActivationType.ReLU);
-        sw.Stop();
-        double ms = sw.Elapsed.TotalMilliseconds / iters;
-
-        _output.WriteLine($"FusedLinear 32x256 + ReLU: {ms:F3}ms (budget: {FusedLinear256BudgetMs}ms)");
+        _output.WriteLine($"FusedLinear 32x256 + ReLU: {ms:F3}ms median (budget: {FusedLinear256BudgetMs}ms)");
         Assert.True(ms < FusedLinear256BudgetMs,
             $"FusedLinear took {ms:F3}ms — exceeds {FusedLinear256BudgetMs}ms budget. " +
             "Check CpuFusedOperations.FusedGemmBiasActivation for scalar loops.");
     }
 
-    [Fact(Skip = "Performance guard — run manually with --filter PerformanceRegression")]
+    [Fact]
+    [Trait("Category", "Perf")]
     public void FusedLinear_Double_NotScalarLoop()
     {
+        if (!PerfGatesEnabled()) return;
+
         var input = new Tensor<double>(Enumerable.Range(0, 32 * 256).Select(i => (double)i / 1000).ToArray(), [32, 256]);
         var weights = new Tensor<double>(Enumerable.Range(0, 256 * 256).Select(i => (double)i / 100000).ToArray(), [256, 256]);
         var bias = new Tensor<double>(Enumerable.Range(0, 256).Select(i => 0.01 * i).ToArray(), [1, 256]);
 
-        for (int w = 0; w < 5; w++)
-            _engine.FusedLinear(input, weights, bias, FusedActivationType.ReLU);
+        double ms = MedianMs(5, 20, () => _engine.FusedLinear(input, weights, bias, FusedActivationType.ReLU));
 
-        var sw = Stopwatch.StartNew();
-        int iters = 20;
-        for (int i = 0; i < iters; i++)
-            _engine.FusedLinear(input, weights, bias, FusedActivationType.ReLU);
-        sw.Stop();
-        double ms = sw.Elapsed.TotalMilliseconds / iters;
-
-        _output.WriteLine($"FusedLinear double 32x256 + ReLU: {ms:F3}ms (budget: {FusedLinearDoubleBudgetMs}ms)");
+        _output.WriteLine($"FusedLinear double 32x256 + ReLU: {ms:F3}ms median (budget: {FusedLinearDoubleBudgetMs}ms)");
         Assert.True(ms < FusedLinearDoubleBudgetMs,
             $"FusedLinear double took {ms:F3}ms — exceeds {FusedLinearDoubleBudgetMs}ms budget.");
     }
 
-    [Fact(Skip = "Performance guard — run manually with --filter PerformanceRegression")]
+    [Fact]
+    [Trait("Category", "Perf")]
     public void TensorAdd_100K_NotScalarLoop()
     {
+        if (!PerfGatesEnabled()) return;
+
         var a = Tensor<float>.CreateRandom([100000]);
         var b = Tensor<float>.CreateRandom([100000]);
 
-        for (int w = 0; w < 10; w++) _engine.TensorAdd(a, b);
+        double ms = MedianMs(10, 50, () => _engine.TensorAdd(a, b));
 
-        var sw = Stopwatch.StartNew();
-        int iters = 50;
-        for (int i = 0; i < iters; i++) _engine.TensorAdd(a, b);
-        sw.Stop();
-        double ms = sw.Elapsed.TotalMilliseconds / iters;
-
-        _output.WriteLine($"TensorAdd 100K: {ms:F3}ms (budget: {Elementwise100KBudgetMs}ms)");
+        _output.WriteLine($"TensorAdd 100K: {ms:F3}ms median (budget: {Elementwise100KBudgetMs}ms)");
         Assert.True(ms < Elementwise100KBudgetMs,
             $"TensorAdd took {ms:F3}ms — exceeds {Elementwise100KBudgetMs}ms budget.");
     }
 
-    [Fact(Skip = "Performance guard — run manually with --filter PerformanceRegression")]
+    [Fact]
+    [Trait("Category", "Perf")]
     public void TensorMultiply_100K_NotScalarLoop()
     {
+        if (!PerfGatesEnabled()) return;
+
         var a = Tensor<float>.CreateRandom([100000]);
         var b = Tensor<float>.CreateRandom([100000]);
 
-        for (int w = 0; w < 10; w++) _engine.TensorMultiply(a, b);
+        double ms = MedianMs(10, 50, () => _engine.TensorMultiply(a, b));
 
-        var sw = Stopwatch.StartNew();
-        int iters = 50;
-        for (int i = 0; i < iters; i++) _engine.TensorMultiply(a, b);
-        sw.Stop();
-        double ms = sw.Elapsed.TotalMilliseconds / iters;
-
-        _output.WriteLine($"TensorMultiply 100K: {ms:F3}ms (budget: {Elementwise100KBudgetMs}ms)");
+        _output.WriteLine($"TensorMultiply 100K: {ms:F3}ms median (budget: {Elementwise100KBudgetMs}ms)");
         Assert.True(ms < Elementwise100KBudgetMs,
             $"TensorMultiply took {ms:F3}ms — exceeds {Elementwise100KBudgetMs}ms budget.");
     }
 
-    [Fact(Skip = "Performance guard — run manually with --filter PerformanceRegression")]
+    [Fact]
+    [Trait("Category", "Perf")]
     public void TensorInstanceMethod_MatrixMultiply_UsesBLAS()
     {
+        if (!PerfGatesEnabled()) return;
+
         // Ensures Tensor.MatrixMultiply routes through engine (not scalar loops)
         var a = Tensor<float>.CreateRandom([32, 256]);
         var b = Tensor<float>.CreateRandom([256, 256]);
 
-        for (int w = 0; w < 5; w++) a.MatrixMultiply(b);
+        double ms = MedianMs(5, 20, () => a.MatrixMultiply(b));
 
-        var sw = Stopwatch.StartNew();
-        int iters = 20;
-        for (int i = 0; i < iters; i++) a.MatrixMultiply(b);
-        sw.Stop();
-        double ms = sw.Elapsed.TotalMilliseconds / iters;
-
-        _output.WriteLine($"Tensor.MatrixMultiply 32x256 @ 256x256: {ms:F3}ms (budget: {MatMul256BudgetMs}ms)");
+        _output.WriteLine($"Tensor.MatrixMultiply 32x256 @ 256x256: {ms:F3}ms median (budget: {MatMul256BudgetMs}ms)");
         Assert.True(ms < MatMul256BudgetMs,
             $"Tensor.MatrixMultiply took {ms:F3}ms — likely not routing through engine BLAS.");
     }
 
-    [Fact(Skip = "Performance guard — run manually with --filter PerformanceRegression")]
+    [Fact]
+    [Trait("Category", "Perf")]
     public void TensorInstanceMethod_Add_UsesSIMD()
     {
+        if (!PerfGatesEnabled()) return;
+
         var a = Tensor<float>.CreateRandom([100000]);
         var b = Tensor<float>.CreateRandom([100000]);
 
-        for (int w = 0; w < 10; w++) a.Add(b);
+        double ms = MedianMs(10, 50, () => a.Add(b));
 
-        var sw = Stopwatch.StartNew();
-        int iters = 50;
-        for (int i = 0; i < iters; i++) a.Add(b);
-        sw.Stop();
-        double ms = sw.Elapsed.TotalMilliseconds / iters;
-
-        _output.WriteLine($"Tensor.Add 100K: {ms:F3}ms (budget: {Elementwise100KBudgetMs}ms)");
+        _output.WriteLine($"Tensor.Add 100K: {ms:F3}ms median (budget: {Elementwise100KBudgetMs}ms)");
         Assert.True(ms < Elementwise100KBudgetMs,
             $"Tensor.Add took {ms:F3}ms — likely not routing through engine SIMD.");
     }
 
-    [Fact(Skip = "Performance guard — run manually with --filter PerformanceRegression")]
+    [Fact]
+    [Trait("Category", "Perf")]
     public void TensorInstanceMethod_PointwiseMultiply_UsesSIMD()
     {
+        if (!PerfGatesEnabled()) return;
+
         var a = Tensor<float>.CreateRandom([100000]);
         var b = Tensor<float>.CreateRandom([100000]);
 
-        for (int w = 0; w < 10; w++) a.PointwiseMultiply(b);
+        double ms = MedianMs(10, 50, () => a.PointwiseMultiply(b));
 
-        var sw = Stopwatch.StartNew();
-        int iters = 50;
-        for (int i = 0; i < iters; i++) a.PointwiseMultiply(b);
-        sw.Stop();
-        double ms = sw.Elapsed.TotalMilliseconds / iters;
-
-        _output.WriteLine($"Tensor.PointwiseMultiply 100K: {ms:F3}ms (budget: {Elementwise100KBudgetMs}ms)");
+        _output.WriteLine($"Tensor.PointwiseMultiply 100K: {ms:F3}ms median (budget: {Elementwise100KBudgetMs}ms)");
         Assert.True(ms < Elementwise100KBudgetMs,
             $"Tensor.PointwiseMultiply took {ms:F3}ms — likely not routing through engine SIMD.");
     }
 
-    [Fact(Skip = "Performance guard — run manually with --filter PerformanceRegression")]
+    [Fact]
+    [Trait("Category", "Perf")]
     public void BatchMatMul_3D_UsesBLAS()
     {
+        if (!PerfGatesEnabled()) return;
+
         var a = Tensor<float>.CreateRandom([4, 32, 64]);
         var b = Tensor<float>.CreateRandom([4, 64, 32]);
 
-        for (int w = 0; w < 5; w++) _engine.BatchMatMul(a, b);
+        double ms = MedianMs(5, 20, () => _engine.BatchMatMul(a, b));
 
-        var sw = Stopwatch.StartNew();
-        int iters = 20;
-        for (int i = 0; i < iters; i++) _engine.BatchMatMul(a, b);
-        sw.Stop();
-        double ms = sw.Elapsed.TotalMilliseconds / iters;
-
-        _output.WriteLine($"BatchMatMul [4,32,64]@[4,64,32]: {ms:F3}ms (budget: {BatchMatMulBudgetMs}ms)");
+        _output.WriteLine($"BatchMatMul [4,32,64]@[4,64,32]: {ms:F3}ms median (budget: {BatchMatMulBudgetMs}ms)");
         Assert.True(ms < BatchMatMulBudgetMs,
             $"BatchMatMul took {ms:F3}ms — check if BLAS path is active for batch slices.");
     }
 
-    [Fact(Skip = "Performance guard — run manually with --filter PerformanceRegression")]
+    [Fact]
+    [Trait("Category", "Perf")]
     public void ReLUBackward_1M_UsesSIMD()
     {
+        if (!PerfGatesEnabled()) return;
+
         var gradOutput = Tensor<float>.CreateRandom([1000000]);
         var input = Tensor<float>.CreateRandom([1000000]);
 
-        for (int w = 0; w < 5; w++) _engine.ReluBackward(gradOutput, input);
-
-        var sw = Stopwatch.StartNew();
-        int iters = 20;
-        for (int i = 0; i < iters; i++) _engine.ReluBackward(gradOutput, input);
-        sw.Stop();
-        double ms = sw.Elapsed.TotalMilliseconds / iters;
-
         // SIMD ReLU backward on 1M: ~1-2ms. Scalar: ~10ms+
-        _output.WriteLine($"ReLU backward 1M: {ms:F3}ms (budget: 5ms)");
+        double ms = MedianMs(5, 20, () => _engine.ReluBackward(gradOutput, input));
+
+        _output.WriteLine($"ReLU backward 1M: {ms:F3}ms median (budget: {ReLUBackwardBudgetMs}ms)");
         Assert.True(ms < ReLUBackwardBudgetMs,
             $"ReLU backward took {ms:F3}ms — check SimdKernels.ReluBackwardUnsafe.");
     }
 
-    [Fact(Skip = "Performance guard — run manually with --filter PerformanceRegression")]
+    [Fact]
+    [Trait("Category", "Perf")]
     public void Conv2D_AiseValCnnL1_Forward_PreservesPyTorchLead()
     {
+        if (!PerfGatesEnabled()) return;
+
         // AIsEval CNN layer-1 shape: nn.Conv2d(1, 16, kernel=3, padding=1) at
         // input [128, 1, 28, 28] (MNIST-shape, bs=128). PyTorch baseline for
         // this exact shape was 41.42 ms (bs=128 steady-state latency including
@@ -344,24 +348,21 @@ public class PerformanceRegressionTests
         var input = Tensor<float>.CreateRandom([128, 1, 28, 28]);
         var kernel = Tensor<float>.CreateRandom([16, 1, 3, 3]);
 
-        for (int w = 0; w < 3; w++) _engine.Conv2D(input, kernel, stride: 1, padding: 1);
+        double ms = MedianMs(3, 10, () => _engine.Conv2D(input, kernel, stride: 1, padding: 1));
 
-        var sw = Stopwatch.StartNew();
-        const int iters = 10;
-        for (int i = 0; i < iters; i++) _engine.Conv2D(input, kernel, stride: 1, padding: 1);
-        sw.Stop();
-        double ms = sw.Elapsed.TotalMilliseconds / iters;
-
-        _output.WriteLine($"Conv2D AIsEval-L1 [128,1,28,28]@[16,1,3,3] pad=1: {ms:F3}ms (budget: {CnnAiseval_L1_BudgetMs}ms)");
+        _output.WriteLine($"Conv2D AIsEval-L1 [128,1,28,28]@[16,1,3,3] pad=1: {ms:F3}ms median (budget: {CnnAiseval_L1_BudgetMs}ms)");
         Assert.True(ms < CnnAiseval_L1_BudgetMs,
             $"Conv2D AIsEval-L1 took {ms:F3}ms — exceeds {CnnAiseval_L1_BudgetMs}ms budget. " +
             "The AIsEval benchmark relies on this shape being well below PyTorch's 41.42ms baseline; " +
             "a regression here would erase the CNN inference lead documented in issue #436.");
     }
 
-    [Fact(Skip = "Performance guard — run manually with --filter PerformanceRegression")]
+    [Fact]
+    [Trait("Category", "Perf")]
     public void LstmSequenceForward_Aiseval_FloatFastPath_BeatsPyTorch()
     {
+        if (!PerfGatesEnabled()) return;
+
         // Locks in the AIsEval LSTM win. Stage 3 took LSTM from "doesn't
         // finish in 3+ min" to 44 ms (generic-T path). Stage 5 added a
         // float fast path using SimdGemm + vectorized sigmoid/tanh +
@@ -376,29 +377,24 @@ public class PerformanceRegressionTests
         // LstmSequenceForward is on IEngine (the float fast path lives in
         // CpuEngine and is picked up by DirectGpuTensorEngine via inheritance),
         // so no downcast needed.
-        for (int w = 0; w < 3; w++)
-            _ = _engine.LstmSequenceForward(input, null, null, wIh, wHh, null, null);
+        double ms = MedianMs(3, 10, () => _engine.LstmSequenceForward(input, null, null, wIh, wHh, null, null));
 
-        var sw = Stopwatch.StartNew();
-        const int iters = 10;
-        for (int i = 0; i < iters; i++)
-            _ = _engine.LstmSequenceForward(input, null, null, wIh, wHh, null, null);
-        sw.Stop();
-        double ms = sw.Elapsed.TotalMilliseconds / iters;
-
-        _output.WriteLine($"LstmSequenceForward AIsEval [128,32,32->64]: {ms:F2} ms (budget: {LstmAiseval_BudgetMs} ms; PyTorch baseline 11.76 ms)");
+        _output.WriteLine($"LstmSequenceForward AIsEval [128,32,32->64]: {ms:F2} ms median (budget: {LstmAiseval_BudgetMs} ms; PyTorch baseline 11.76 ms)");
         Assert.True(ms < LstmAiseval_BudgetMs,
             $"LstmSequenceForward took {ms:F2} ms — exceeds {LstmAiseval_BudgetMs} ms budget. " +
             "This indicates a regression away from the Stage 5 float fast path that put AiDotNet ahead of PyTorch on this shape.");
     }
 
-    [Fact(Skip = "Performance guard — run manually with --filter PerformanceRegression")]
+    [Fact]
+    [Trait("Category", "Perf")]
     public void MultiHeadAttentionForward_Aiseval_FloatFastPath()
     {
+        if (!PerfGatesEnabled()) return;
+
         // Locks in the Stage 6 MHA float fast path. Stage 4 wrapper measured
         // 22.31 ms on net10.0; Stage 6 brought it to 10.13 ms via direct
         // SimdGemm projections + ArrayPool scratch + explicit-loop transpose.
-        // Budget at 30 ms catches regression back to the wrapper-only path.
+        // Budget at 15 ms catches regression back to the wrapper-only path.
         const int batch = 128, seq = 32, dModel = 64, numHeads = 4;
         var input = Tensor<float>.CreateRandom(batch, seq, dModel);
         var qW = Tensor<float>.CreateRandom(dModel, dModel);
@@ -409,17 +405,9 @@ public class PerformanceRegressionTests
         // MultiHeadAttentionForward is on IEngine (the float fast path lives in
         // CpuEngine and is picked up by DirectGpuTensorEngine via inheritance),
         // so no downcast needed.
-        for (int w = 0; w < 3; w++)
-            _ = _engine.MultiHeadAttentionForward(input, qW, kW, vW, oW, numHeads);
+        double ms = MedianMs(3, 10, () => _engine.MultiHeadAttentionForward(input, qW, kW, vW, oW, numHeads));
 
-        var sw = Stopwatch.StartNew();
-        const int iters = 10;
-        for (int i = 0; i < iters; i++)
-            _ = _engine.MultiHeadAttentionForward(input, qW, kW, vW, oW, numHeads);
-        sw.Stop();
-        double ms = sw.Elapsed.TotalMilliseconds / iters;
-
-        _output.WriteLine($"MultiHeadAttentionForward AIsEval [128,32,64] h=4: {ms:F2} ms (budget: {MhaAiseval_BudgetMs} ms)");
+        _output.WriteLine($"MultiHeadAttentionForward AIsEval [128,32,64] h=4: {ms:F2} ms median (budget: {MhaAiseval_BudgetMs} ms)");
         Assert.True(ms < MhaAiseval_BudgetMs,
             $"MultiHeadAttentionForward took {ms:F2} ms — exceeds {MhaAiseval_BudgetMs} ms budget. " +
             "Stage 6 float fast path measured 10.13 ms on net10.0; a regression to the Stage 4 wrapper path would push this back to ~22 ms.");
@@ -429,6 +417,8 @@ public class PerformanceRegressionTests
     [Trait("Category", "Perf")]
     public void MlpForward_Aiseval_FusedDispatch_BeatsUnfusedPath()
     {
+        if (!PerfGatesEnabled()) return;
+
         // AIsEval MLP inference shape: Dense(784->512)->Dense(512->128)->Dense(128->10)
         // at bs=128 — three GEMMs of (128,784,512), (128,512,128), (128,128,10).
         // PyTorch did this in 1.91 ms; the framework's per-layer
@@ -439,24 +429,8 @@ public class PerformanceRegressionTests
         // rows; see CpuEngine.Mlp.cs) removed the small-GEMM oversubscription
         // jitter — i.e. it already meets the issue's <= 3 ms acceptance, so the
         // remaining work is framework-side wiring to consume it (ooples/AiDotNet#1447).
-        // The MlpAiseval_BudgetMs budget (4 ms on net10.0; 7 ms on net471, where the
-        // fused path has no AVX2 intrinsics and runs ~4.9 ms) catches a regression
-        // back to the 8.94 ms unfused dispatch while leaving headroom over the
-        // measured fused median for CI noise.
-        //
-        // Runnable perf gate (repo convention; see FusedConv2DResnetSpeedupTests):
-        // Category=Perf is excluded from the default CI filter, and the env gate
-        // makes this a no-op unless AIDOTNET_RUN_PERF_GATES=1, so shared runners —
-        // which can't measure a sub-millisecond-stable latency — never fail it;
-        // dedicated hardware opts in. Uses the per-iter MEDIAN over 50 iters (robust
-        // to a single GC pause), not the mean. (A bare [Fact(Skip=...)] is never
-        // runnable even with --filter, so the old form could not actually gate.)
-        if (Environment.GetEnvironmentVariable("AIDOTNET_RUN_PERF_GATES") != "1")
-        {
-            _output.WriteLine("Skip: AIDOTNET_RUN_PERF_GATES != 1 (shared-runner perf gates are flaky).");
-            return;
-        }
-
+        // The 4 ms budget catches a regression back to the 8.94 ms unfused dispatch
+        // while leaving ~7x headroom over the measured fused median for CI noise.
         var input = Tensor<float>.CreateRandom([128, 784]);
         var weights = new List<Tensor<float>>
         {
@@ -473,20 +447,7 @@ public class PerformanceRegressionTests
 
         // MlpForward is on IEngine (the fused path lives in CpuEngine and is
         // picked up by DirectGpuTensorEngine via inheritance), so no downcast.
-        for (int w = 0; w < 5; w++)
-            _ = _engine.MlpForward(input, weights, biases, FusedActivationType.ReLU, FusedActivationType.None);
-
-        const int iters = 50;
-        var samples = new double[iters];
-        for (int i = 0; i < iters; i++)
-        {
-            var sw = Stopwatch.StartNew();
-            _ = _engine.MlpForward(input, weights, biases, FusedActivationType.ReLU, FusedActivationType.None);
-            sw.Stop();
-            samples[i] = sw.Elapsed.TotalMilliseconds;
-        }
-        Array.Sort(samples);
-        double ms = samples[iters / 2];   // per-iter median
+        double ms = MedianMs(5, 50, () => _engine.MlpForward(input, weights, biases, FusedActivationType.ReLU, FusedActivationType.None));
 
         _output.WriteLine($"MlpForward AIsEval [128,784->512->128->10]: {ms:F3} ms/iter median " +
             $"(budget: {MlpAiseval_BudgetMs} ms; PyTorch baseline 1.91 ms; framework unfused path 8.94 ms)");
@@ -496,9 +457,12 @@ public class PerformanceRegressionTests
             "from issue #436; a regression here means the primitive is no longer collapsing the dense stack.");
     }
 
-    [Fact(Skip = "Performance guard — run manually with --filter PerformanceRegression")]
+    [Fact]
+    [Trait("Category", "Perf")]
     public void Conv2D_AiseValCnnL2_Forward_PreservesPyTorchLead()
     {
+        if (!PerfGatesEnabled()) return;
+
         // AIsEval CNN layer-2 shape: nn.Conv2d(16, 32, kernel=3, padding=1) at
         // input [128, 16, 14, 14] (post-first-MaxPool). This is the heavier of
         // the two convs by FLOPs (~ 36M MACs vs ~6M for L1). Budget at 35 ms
@@ -506,15 +470,9 @@ public class PerformanceRegressionTests
         var input = Tensor<float>.CreateRandom([128, 16, 14, 14]);
         var kernel = Tensor<float>.CreateRandom([32, 16, 3, 3]);
 
-        for (int w = 0; w < 3; w++) _engine.Conv2D(input, kernel, stride: 1, padding: 1);
+        double ms = MedianMs(3, 10, () => _engine.Conv2D(input, kernel, stride: 1, padding: 1));
 
-        var sw = Stopwatch.StartNew();
-        const int iters = 10;
-        for (int i = 0; i < iters; i++) _engine.Conv2D(input, kernel, stride: 1, padding: 1);
-        sw.Stop();
-        double ms = sw.Elapsed.TotalMilliseconds / iters;
-
-        _output.WriteLine($"Conv2D AIsEval-L2 [128,16,14,14]@[32,16,3,3] pad=1: {ms:F3}ms (budget: {CnnAiseval_L2_BudgetMs}ms)");
+        _output.WriteLine($"Conv2D AIsEval-L2 [128,16,14,14]@[32,16,3,3] pad=1: {ms:F3}ms median (budget: {CnnAiseval_L2_BudgetMs}ms)");
         Assert.True(ms < CnnAiseval_L2_BudgetMs,
             $"Conv2D AIsEval-L2 took {ms:F3}ms — exceeds {CnnAiseval_L2_BudgetMs}ms budget. " +
             "Layer-2 conv dominates the CNN benchmark's FLOPs; a regression here is what would " +

--- a/tests/AiDotNet.Tensors.Tests/Engines/PerformanceRegressionTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/PerformanceRegressionTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using AiDotNet.Tensors.Engines;
 using AiDotNet.Tensors.Helpers;
@@ -89,12 +90,24 @@ public class PerformanceRegressionTests
     // primitive at ~1.65 ms median / 3.24 ms p95, and the native-BLAS
     // thread-cap (one thread per 16 rows; see CpuEngine.Mlp.cs) brought it to
     // ~1.37 ms median / 1.75 ms p95 on a 16-core box — the thread cap removed
-    // the small-GEMM oversubscription jitter. Budget tightened to 4 ms: it still
-    // catches a regression to the 8.94 ms unfused path or the un-capped p95
-    // (~3.2 ms) while leaving ~2.9x headroom over the capped median for slower
+    // the small-GEMM oversubscription jitter. Budget tightened to 4 ms (net10.0):
+    // it still catches a regression to the 8.94 ms unfused path or the un-capped
+    // p95 (~3.2 ms) while leaving ~2.9x headroom over the capped median for slower
     // CI hardware. (Beating PyTorch's ~0.6 ms median outright is blocked by
     // OpenBLAS-vs-MKL small-GEMM kernel quality — tracked as a follow-up.)
+    //
+    // net471 has no System.Runtime.Intrinsics.X86, so MlpForward's fused
+    // elementwise path falls back to scalar Math and BlasManaged runs the
+    // Vector<T> kernels (no AVX2 microkernel) — the same fused stack measures
+    // ~4.9 ms median on net471 vs ~1.37 ms on net10.0. The budget is loosened to
+    // 7 ms there: still comfortably under the 8.94 ms unfused-dispatch regression
+    // it guards, with ~1.4x headroom over the measured net471 fused number. This
+    // is a platform floor (no intrinsics), not a regression to hide.
+#if NET471
+    private const double MlpAiseval_BudgetMs = 7.0;
+#else
     private const double MlpAiseval_BudgetMs = 4.0;
+#endif
 
     public PerformanceRegressionTests(ITestOutputHelper output) => _output = output;
 
@@ -412,21 +425,38 @@ public class PerformanceRegressionTests
             "Stage 6 float fast path measured 10.13 ms on net10.0; a regression to the Stage 4 wrapper path would push this back to ~22 ms.");
     }
 
-    [Fact(Skip = "Performance guard — run manually with --filter PerformanceRegression")]
+    [Fact]
+    [Trait("Category", "Perf")]
     public void MlpForward_Aiseval_FusedDispatch_BeatsUnfusedPath()
     {
         // AIsEval MLP inference shape: Dense(784->512)->Dense(512->128)->Dense(128->10)
         // at bs=128 — three GEMMs of (128,784,512), (128,512,128), (128,128,10).
         // PyTorch did this in 1.91 ms; the framework's per-layer
         // MatMul+Add+Activation Predict path measured 8.94 ms (issue #436 P1).
-        // MlpForward collapses the 3-layer stack to 3 fused-linear dispatches and
-        // measured 2.95 ms/iter on net10.0 (Release) on the dev host — i.e. it
-        // already meets the issue's <= 3 ms acceptance (1.54x PyTorch), so the
-        // remaining work is framework-side wiring (ooples/AiDotNet#1447).
-        // Budget at 8 ms catches a regression back to the unfused dispatch path
-        // (which the issue measured at 8.94 ms) while leaving ~2.7x headroom over
-        // the measured fused number for CI noise. Skip-by-default to match the
-        // repo perf-gate convention (run via --filter PerformanceRegression).
+        // MlpForward collapses the 3-layer stack to 3 fused-linear dispatches; the
+        // #436 head-to-head measured it at ~1.65 ms median pre-cap and ~1.37 ms
+        // median / 1.75 ms p95 once the native-BLAS thread cap (one thread / 16
+        // rows; see CpuEngine.Mlp.cs) removed the small-GEMM oversubscription
+        // jitter — i.e. it already meets the issue's <= 3 ms acceptance, so the
+        // remaining work is framework-side wiring to consume it (ooples/AiDotNet#1447).
+        // The MlpAiseval_BudgetMs budget (4 ms on net10.0; 7 ms on net471, where the
+        // fused path has no AVX2 intrinsics and runs ~4.9 ms) catches a regression
+        // back to the 8.94 ms unfused dispatch while leaving headroom over the
+        // measured fused median for CI noise.
+        //
+        // Runnable perf gate (repo convention; see FusedConv2DResnetSpeedupTests):
+        // Category=Perf is excluded from the default CI filter, and the env gate
+        // makes this a no-op unless AIDOTNET_RUN_PERF_GATES=1, so shared runners —
+        // which can't measure a sub-millisecond-stable latency — never fail it;
+        // dedicated hardware opts in. Uses the per-iter MEDIAN over 50 iters (robust
+        // to a single GC pause), not the mean. (A bare [Fact(Skip=...)] is never
+        // runnable even with --filter, so the old form could not actually gate.)
+        if (Environment.GetEnvironmentVariable("AIDOTNET_RUN_PERF_GATES") != "1")
+        {
+            _output.WriteLine("Skip: AIDOTNET_RUN_PERF_GATES != 1 (shared-runner perf gates are flaky).");
+            return;
+        }
+
         var input = Tensor<float>.CreateRandom([128, 784]);
         var weights = new List<Tensor<float>>
         {
@@ -446,17 +476,22 @@ public class PerformanceRegressionTests
         for (int w = 0; w < 5; w++)
             _ = _engine.MlpForward(input, weights, biases, FusedActivationType.ReLU, FusedActivationType.None);
 
-        var sw = Stopwatch.StartNew();
         const int iters = 50;
+        var samples = new double[iters];
         for (int i = 0; i < iters; i++)
+        {
+            var sw = Stopwatch.StartNew();
             _ = _engine.MlpForward(input, weights, biases, FusedActivationType.ReLU, FusedActivationType.None);
-        sw.Stop();
-        double ms = sw.Elapsed.TotalMilliseconds / iters;
+            sw.Stop();
+            samples[i] = sw.Elapsed.TotalMilliseconds;
+        }
+        Array.Sort(samples);
+        double ms = samples[iters / 2];   // per-iter median
 
-        _output.WriteLine($"MlpForward AIsEval [128,784->512->128->10]: {ms:F3} ms/iter " +
+        _output.WriteLine($"MlpForward AIsEval [128,784->512->128->10]: {ms:F3} ms/iter median " +
             $"(budget: {MlpAiseval_BudgetMs} ms; PyTorch baseline 1.91 ms; framework unfused path 8.94 ms)");
         Assert.True(ms < MlpAiseval_BudgetMs,
-            $"MlpForward took {ms:F3} ms — exceeds {MlpAiseval_BudgetMs} ms budget. " +
+            $"MlpForward took {ms:F3} ms median — exceeds {MlpAiseval_BudgetMs} ms budget. " +
             "The fused 3-dispatch path should stay below the 8.94 ms unfused-dispatch number " +
             "from issue #436; a regression here means the primitive is no longer collapsing the dense stack.");
     }


### PR DESCRIPTION
## What & why

Closes the remaining **tensors-side** item on the #436 AIsEval umbrella: the inference **perf gate + verify** work. (Primitives shipped in #437; the severe Transformer/LSTM *wins* now depend on framework-repo wiring, ooples/AiDotNet#1447.)

While verifying I found the entire `PerformanceRegressionTests` file was **dead**: all 16 gates used `[Fact(Skip = "…run via --filter…")]`, but xUnit's `Skip` *always* skips — even with a filter. So **none** of them — the 4 #436 AIsEval gates (CNN L1/L2, LSTM, MHA) nor the older #100/#102/#104 scalar-loop guards — could ever execute or guard anything. The file header's "Run with `--filter`" instruction was simply false.

## Changes

- **Make all 16 gates real and runnable** via the repo's established convention (`[Trait("Category","Perf")]` + `AIDOTNET_RUN_PERF_GATES=1` opt-in, matching `FusedConv2DResnetSpeedupTests`): no-op on default/shared CI, executable on dedicated hardware.
- Two shared helpers remove the duplication: `PerfGatesEnabled()` (env opt-in, CI-safe no-op) and `MedianMs(warmup, iters, body)` (**per-iter median** — robust to a single GC pause, replacing the prior mean).
- **Perf gates are net5+-only.** Verifying on net471 showed sub-ms ops reporting **~15.78 ms identically** across unrelated kernels (`TensorMatMul-768` 15.784, `TensorAdd-100K` 15.785, `Tensor.Add` 15.809) — the **~15.6 ms Windows scheduler quantum** (net471's parallel dispatch sleeps/wakes on the OS tick rather than spin-waiting), not per-op compute. That floor can't be a regression signal, so `PerfGatesEnabled()` no-ops on net471 with the reasoning documented. net471 correctness stays covered by the functional suites.

## Verification (Release, `AIDOTNET_RUN_PERF_GATES=1`, net10.0)

All 16 pass with wide headroom (medians):

| Gate | median | budget |
|---|---|---|
| MlpForward | 0.58 ms | 4 ms |
| LstmSequenceForward | 1.50 ms | 30 ms |
| MultiHeadAttentionForward | 2.40 ms | 15 ms |
| Conv2D CNN-L1 | 2.75 ms | 30 ms |
| Conv2D CNN-L2 | 4.44 ms | 35 ms |
| TensorMatMul 768² | 1.15 ms | 5 ms |
| ReLU-backward 1M | 3.72 ms | 5 ms |
| (+ 9 more elementwise/matmul guards) | all ✅ | |

- **net471:** all 16 no-op (gates are net5+-only).
- **No env var:** all 16 no-op (CI-safe; before this change they reported `Skipped`).

Note: beating PyTorch's ~0.6 ms median outright at the small MLP GEMM shape is blocked by OpenBLAS-vs-MKL kernel quality (characterized in #475/PR #537), tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)