### PR TITLE
perf(#515): managed custom-kernel CSR SpMM default + warp heuristic + FP64 (CUDA); HIP mirror

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -2615,6 +2615,97 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         LaunchKernel2D(kernel, gridX, gridY, (uint)DefaultBlockSize, 1, args);
     }
 
+    /// <summary>
+    /// Warp-per-row CSR SpMM (issue #515): launches <c>csr_spmm_warp</c>, where each
+    /// warp (32 lanes) owns one output row and the lanes stride over columns. Best
+    /// for small/moderate N (the lanes cover the columns with coalesced B reads);
+    /// the 2-D <see cref="CsrSpMM"/> is better for wide N. Same numerics as
+    /// <see cref="CsrSpMM"/> (per-output sequential reduction → deterministic).
+    /// </summary>
+    public unsafe void CsrSpMMWarp(
+        IGpuBuffer csrValues,
+        IGpuBuffer csrColIndices,
+        IGpuBuffer csrRowPointers,
+        IGpuBuffer denseB,
+        IGpuBuffer output,
+        int M, int K, int N, int nnz)
+    {
+        if (!IsAvailable)
+            throw new InvalidOperationException("CUDA backend is not available.");
+
+        if (!_kernelCache.TryGetValue("csr_spmm_warp", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: csr_spmm_warp");
+
+        using var _ = PushContext();
+
+        // One warp (32 lanes) per row; DefaultBlockSize threads/block => 8 warps/block.
+        uint gridX = (uint)((M + 7) / 8);
+
+        IntPtr valuesPtr = csrValues.Handle;
+        IntPtr colIndicesPtr = csrColIndices.Handle;
+        IntPtr rowPointersPtr = csrRowPointers.Handle;
+        IntPtr denseBPtr = denseB.Handle;
+        IntPtr outputPtr = output.Handle;
+
+        void** args = stackalloc void*[9];
+        args[0] = &valuesPtr;
+        args[1] = &colIndicesPtr;
+        args[2] = &rowPointersPtr;
+        args[3] = &denseBPtr;
+        args[4] = &outputPtr;
+        args[5] = &M;
+        args[6] = &K;
+        args[7] = &N;
+        args[8] = &nnz;
+
+        LaunchKernel(kernel, gridX, (uint)DefaultBlockSize, args);
+    }
+
+    /// <summary>
+    /// FP64 CSR SpMM (issue #515): launches <c>csr_spmm_double</c>. The CSR-value /
+    /// dense-B / output buffers carry <c>double</c> payloads (byte buffers); the int
+    /// CSR index buffers are unchanged. Same 2-D launch + numerics as the float
+    /// <see cref="CsrSpMM"/>.
+    /// </summary>
+    public unsafe void CsrSpMMDouble(
+        IGpuBuffer csrValues,
+        IGpuBuffer csrColIndices,
+        IGpuBuffer csrRowPointers,
+        IGpuBuffer denseB,
+        IGpuBuffer output,
+        int M, int K, int N, int nnz)
+    {
+        if (!IsAvailable)
+            throw new InvalidOperationException("CUDA backend is not available.");
+
+        if (!_kernelCache.TryGetValue("csr_spmm_double", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: csr_spmm_double");
+
+        using var _ = PushContext();
+
+        uint gridX = (uint)M;
+        uint gridY = (uint)((N + DefaultBlockSize - 1) / DefaultBlockSize);
+
+        IntPtr valuesPtr = csrValues.Handle;
+        IntPtr colIndicesPtr = csrColIndices.Handle;
+        IntPtr rowPointersPtr = csrRowPointers.Handle;
+        IntPtr denseBPtr = denseB.Handle;
+        IntPtr outputPtr = output.Handle;
+
+        void** args = stackalloc void*[9];
+        args[0] = &valuesPtr;
+        args[1] = &colIndicesPtr;
+        args[2] = &rowPointersPtr;
+        args[3] = &denseBPtr;
+        args[4] = &outputPtr;
+        args[5] = &M;
+        args[6] = &K;
+        args[7] = &N;
+        args[8] = &nnz;
+
+        LaunchKernel2D(kernel, gridX, gridY, (uint)DefaultBlockSize, 1, args);
+    }
+
     /// <inheritdoc/>
     public unsafe void CsrSpMMBias(
         IGpuBuffer csrValues,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaSparseBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaSparseBackend.cs
@@ -5,10 +5,11 @@ using System;
 namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA;
 
 /// <summary>
-/// CSR · dense → dense SpMM using AiDotNet's own managed CUDA kernel
-/// (<c>csr_spmm</c> in <see cref="Kernels.CudaSparseKernels"/>), exposed with the
-/// same host-array entry shape as <see cref="CuSparseBackend"/>: allocate device
-/// buffers, upload the CSR triple + dense B, launch, download the dense result.
+/// CSR · dense → dense SpMM using AiDotNet's own managed CUDA kernels
+/// (<c>csr_spmm</c> / <c>csr_spmm_warp</c> / <c>csr_spmm_double</c> in
+/// <see cref="Kernels.CudaSparseKernels"/>), exposed with the same host-array entry
+/// shape as <see cref="CuSparseBackend"/>: allocate device buffers, upload the CSR
+/// triple + dense B, launch, download the dense result.
 ///
 /// <para>This is the supply-chain-removal replacement for native cuSPARSE
 /// (issue #515, P6): <see cref="LinearAlgebra.Sparse.SparseOps"/> makes this the
@@ -16,23 +17,31 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA;
 /// availability fallback. Unlike cuSPARSE it needs no external library — only the
 /// CUDA driver + NVRTC the rest of <see cref="CudaBackend"/> already requires.</para>
 ///
-/// <para>The launched <c>csr_spmm</c> kernel accumulates each output element in a
-/// single thread over the row's stored order, so the result is deterministic and
-/// matches the managed CPU CSR reference to FMA tolerance. The warp-per-row kernel
-/// variant, FP64 coverage, and the HIP/ROCm mirror are tracked as #515 follow-ups.</para>
+/// <para>The launched kernels accumulate each output element in a single thread over
+/// the row's stored order, so results are deterministic and match the managed CPU
+/// CSR reference to FMA tolerance. The float path picks the warp-per-row kernel for
+/// small/moderate N (coalesced B reads) and the 2-D scalar kernel for wide N; the
+/// FP64 path uses the scalar double kernel.</para>
 /// </summary>
 internal static class CudaSparseBackend
 {
+    /// <summary>N (dense column count) at or below which the warp-per-row kernel is
+    /// preferred over the 2-D scalar kernel. First-cut threshold — to be tuned by the
+    /// #515 perf bar on real hardware (the warp kernel covers columns 32-at-a-time per
+    /// row, so it wins while N is small; wide N favours the scalar kernel's extra
+    /// block-level parallelism).</summary>
+    private const int WarpColumnThreshold = 64;
+
     /// <summary>Whether the managed custom-kernel SpMM path can run here. It needs
     /// only a constructible <see cref="CudaBackend"/> (CUDA driver + NVRTC); no
     /// cuSPARSE library, which is the whole point of the supply-chain removal.</summary>
     public static bool IsAvailable => CudaBackend.IsCudaAvailable;
 
     /// <summary>
-    /// CSR · dense → dense, where the inputs are host-side <c>float[]</c> arrays in
-    /// CSR layout. Returns the dense output flat array of length <c>rows · n</c>.
-    /// Mirrors <see cref="CuSparseBackend.SpMM"/> but dispatches the managed
-    /// <c>csr_spmm</c> kernel instead of <c>cusparseSpMM</c>.
+    /// CSR · dense → dense, host-side <c>float[]</c> CSR inputs. Returns the dense
+    /// output flat array of length <c>rows · n</c>. Mirrors
+    /// <see cref="CuSparseBackend.SpMM"/> but dispatches the managed
+    /// <c>csr_spmm</c> / <c>csr_spmm_warp</c> kernels instead of <c>cusparseSpMM</c>.
     /// </summary>
     public static float[] SpMM(
         int[] rowPtr, int[] colIdx, float[] values,
@@ -46,8 +55,7 @@ internal static class CudaSparseBackend
 
         // Every allocation sits inside the try so a throw anywhere along the
         // upload chain still hits the finally and frees the device buffers
-        // already allocated (mirrors CuSparseBackend's leak-safe cleanup). The
-        // null checks keep each cleanup branch independent on partial init.
+        // already allocated (mirrors CuSparseBackend's leak-safe cleanup).
         IGpuBuffer? valuesBuf = null, bBuf = null, outBuf = null;
         IGpuBuffer? rowPtrBuf = null, colIdxBuf = null;
         try
@@ -62,12 +70,67 @@ internal static class CudaSparseBackend
             UploadInts(rowPtrBuf.Handle, rowPtr);
             UploadInts(colIdxBuf.Handle, colIdx);
 
-            // Argument order matches IDirectGpuBackend.CsrSpMM:
+            // Warp-per-row for small/moderate N, 2-D scalar for wide N. Argument
+            // order matches IDirectGpuBackend.CsrSpMM:
             // (values, colIndices, rowPointers, denseB, output, M, K, N, nnz).
-            backend.CsrSpMM(valuesBuf, colIdxBuf, rowPtrBuf, bBuf, outBuf,
-                rows, cols, n, values.Length);
+            if (n <= WarpColumnThreshold)
+                backend.CsrSpMMWarp(valuesBuf, colIdxBuf, rowPtrBuf, bBuf, outBuf,
+                    rows, cols, n, values.Length);
+            else
+                backend.CsrSpMM(valuesBuf, colIdxBuf, rowPtrBuf, bBuf, outBuf,
+                    rows, cols, n, values.Length);
 
             backend.DownloadBuffer(outBuf, output);
+            return output;
+        }
+        finally
+        {
+            outBuf?.Dispose();
+            bBuf?.Dispose();
+            valuesBuf?.Dispose();
+            rowPtrBuf?.Dispose();
+            colIdxBuf?.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// FP64 CSR · dense → dense (issue #515). Same shape as the float
+    /// <see cref="SpMM(int[], int[], float[], float[], int, int, int)"/> but the
+    /// value / dense / output payloads are <c>double</c>, carried on byte buffers
+    /// and dispatched through <c>csr_spmm_double</c>. This fills the gap where the
+    /// double tier previously had no GPU path at all.
+    /// </summary>
+    public static double[] SpMM(
+        int[] rowPtr, int[] colIdx, double[] values,
+        double[] b, int rows, int cols, int n)
+    {
+        if (!IsAvailable)
+            throw new InvalidOperationException("CUDA custom-kernel SpMM backend is not available.");
+
+        var backend = CudaBackend.CreateOrThrow();
+        var output = new double[rows * n];
+
+        IGpuBuffer? valuesBuf = null, bBuf = null, outBuf = null;
+        IGpuBuffer? rowPtrBuf = null, colIdxBuf = null;
+        try
+        {
+            // double payloads ride byte buffers (CudaBackend's typed buffer API is
+            // float-only); raw HtoD/DtoH copies move them.
+            valuesBuf = backend.AllocateByteBuffer(values.Length * sizeof(double));
+            bBuf = backend.AllocateByteBuffer(b.Length * sizeof(double));
+            outBuf = backend.AllocateByteBuffer(output.Length * sizeof(double));
+            UploadDoubles(valuesBuf.Handle, values);
+            UploadDoubles(bBuf.Handle, b);
+
+            rowPtrBuf = backend.AllocateByteBuffer(rowPtr.Length * sizeof(int));
+            colIdxBuf = backend.AllocateByteBuffer(colIdx.Length * sizeof(int));
+            UploadInts(rowPtrBuf.Handle, rowPtr);
+            UploadInts(colIdxBuf.Handle, colIdx);
+
+            backend.CsrSpMMDouble(valuesBuf, colIdxBuf, rowPtrBuf, bBuf, outBuf,
+                rows, cols, n, values.Length);
+
+            DownloadDoubles(outBuf.Handle, output);
             return output;
         }
         finally
@@ -89,6 +152,28 @@ internal static class CudaSparseBackend
         {
             var status = CuBlasNative.cuMemcpyHtoD(device, (IntPtr)src, byteCount);
             CuBlasNative.CheckCudaResult(status, "cuMemcpyHtoD(int[])");
+        }
+    }
+
+    /// <summary>Synchronous host→device copy for a <c>double[]</c> payload.</summary>
+    private static unsafe void UploadDoubles(IntPtr device, double[] host)
+    {
+        ulong byteCount = (ulong)host.Length * sizeof(double);
+        fixed (double* src = host)
+        {
+            var status = CuBlasNative.cuMemcpyHtoD(device, (IntPtr)src, byteCount);
+            CuBlasNative.CheckCudaResult(status, "cuMemcpyHtoD(double[])");
+        }
+    }
+
+    /// <summary>Synchronous device→host copy into a <c>double[]</c> via <c>cuMemcpyDtoH</c>.</summary>
+    private static unsafe void DownloadDoubles(IntPtr device, double[] host)
+    {
+        ulong byteCount = (ulong)host.Length * sizeof(double);
+        fixed (double* dst = host)
+        {
+            var status = CuBlasNative.cuMemcpyDtoH((IntPtr)dst, device, byteCount);
+            CuBlasNative.CheckCudaResult(status, "cuMemcpyDtoH(double[])");
         }
     }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaSparseBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaSparseBackend.cs
@@ -1,0 +1,94 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA;
+
+/// <summary>
+/// CSR · dense → dense SpMM using AiDotNet's own managed CUDA kernel
+/// (<c>csr_spmm</c> in <see cref="Kernels.CudaSparseKernels"/>), exposed with the
+/// same host-array entry shape as <see cref="CuSparseBackend"/>: allocate device
+/// buffers, upload the CSR triple + dense B, launch, download the dense result.
+///
+/// <para>This is the supply-chain-removal replacement for native cuSPARSE
+/// (issue #515, P6): <see cref="LinearAlgebra.Sparse.SparseOps"/> makes this the
+/// default GPU SpMM path, keeping <see cref="CuSparseBackend"/> only as an
+/// availability fallback. Unlike cuSPARSE it needs no external library — only the
+/// CUDA driver + NVRTC the rest of <see cref="CudaBackend"/> already requires.</para>
+///
+/// <para>The launched <c>csr_spmm</c> kernel accumulates each output element in a
+/// single thread over the row's stored order, so the result is deterministic and
+/// matches the managed CPU CSR reference to FMA tolerance. The warp-per-row kernel
+/// variant, FP64 coverage, and the HIP/ROCm mirror are tracked as #515 follow-ups.</para>
+/// </summary>
+internal static class CudaSparseBackend
+{
+    /// <summary>Whether the managed custom-kernel SpMM path can run here. It needs
+    /// only a constructible <see cref="CudaBackend"/> (CUDA driver + NVRTC); no
+    /// cuSPARSE library, which is the whole point of the supply-chain removal.</summary>
+    public static bool IsAvailable => CudaBackend.IsCudaAvailable;
+
+    /// <summary>
+    /// CSR · dense → dense, where the inputs are host-side <c>float[]</c> arrays in
+    /// CSR layout. Returns the dense output flat array of length <c>rows · n</c>.
+    /// Mirrors <see cref="CuSparseBackend.SpMM"/> but dispatches the managed
+    /// <c>csr_spmm</c> kernel instead of <c>cusparseSpMM</c>.
+    /// </summary>
+    public static float[] SpMM(
+        int[] rowPtr, int[] colIdx, float[] values,
+        float[] b, int rows, int cols, int n)
+    {
+        if (!IsAvailable)
+            throw new InvalidOperationException("CUDA custom-kernel SpMM backend is not available.");
+
+        var backend = CudaBackend.CreateOrThrow();
+        var output = new float[rows * n];
+
+        // Every allocation sits inside the try so a throw anywhere along the
+        // upload chain still hits the finally and frees the device buffers
+        // already allocated (mirrors CuSparseBackend's leak-safe cleanup). The
+        // null checks keep each cleanup branch independent on partial init.
+        IGpuBuffer? valuesBuf = null, bBuf = null, outBuf = null;
+        IGpuBuffer? rowPtrBuf = null, colIdxBuf = null;
+        try
+        {
+            valuesBuf = backend.AllocateBuffer(values);
+            bBuf = backend.AllocateBuffer(b);
+            outBuf = backend.AllocateBuffer(output);
+
+            // int[] payloads ride a byte buffer (matches CuSparseBackend).
+            rowPtrBuf = backend.AllocateByteBuffer(rowPtr.Length * sizeof(int));
+            colIdxBuf = backend.AllocateByteBuffer(colIdx.Length * sizeof(int));
+            UploadInts(rowPtrBuf.Handle, rowPtr);
+            UploadInts(colIdxBuf.Handle, colIdx);
+
+            // Argument order matches IDirectGpuBackend.CsrSpMM:
+            // (values, colIndices, rowPointers, denseB, output, M, K, N, nnz).
+            backend.CsrSpMM(valuesBuf, colIdxBuf, rowPtrBuf, bBuf, outBuf,
+                rows, cols, n, values.Length);
+
+            backend.DownloadBuffer(outBuf, output);
+            return output;
+        }
+        finally
+        {
+            outBuf?.Dispose();
+            bBuf?.Dispose();
+            valuesBuf?.Dispose();
+            rowPtrBuf?.Dispose();
+            colIdxBuf?.Dispose();
+        }
+    }
+
+    /// <summary>Synchronous host→device copy for an <c>int[]</c> payload via the
+    /// driver's <c>cuMemcpyHtoD</c> (same mechanism as <see cref="CuSparseBackend"/>).</summary>
+    private static unsafe void UploadInts(IntPtr device, int[] host)
+    {
+        ulong byteCount = (ulong)host.Length * sizeof(int);
+        fixed (int* src = host)
+        {
+            var status = CuBlasNative.cuMemcpyHtoD(device, (IntPtr)src, byteCount);
+            CuBlasNative.CheckCudaResult(status, "cuMemcpyHtoD(int[])");
+        }
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaSparseKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaSparseKernels.cs
@@ -96,6 +96,36 @@ extern ""C"" __global__ __launch_bounds__(256) void csr_spmm_warp(
     }
 }
 
+// CSR SpMM, FP64 (issue #515): double-precision analog of csr_spmm. Each thread
+// computes one output element; identical reduction order to the float kernel and
+// to the managed CPU CSR reference, so it is deterministic + parity-checkable.
+extern ""C"" __global__ __launch_bounds__(256) void csr_spmm_double(
+    const double* __restrict__ csrValues,
+    const int* __restrict__ csrColIndices,
+    const int* __restrict__ csrRowPointers,
+    const double* __restrict__ denseB,
+    double* __restrict__ output,
+    int M, int K, int N, int nnz)
+{
+    int row = blockIdx.x;
+    int col = blockIdx.y * blockDim.x + threadIdx.x;
+
+    if (row >= M || col >= N) return;
+
+    int rowStart = csrRowPointers[row];
+    int rowEnd = csrRowPointers[row + 1];
+
+    double sum = 0.0;
+    for (int i = rowStart; i < rowEnd; i++)
+    {
+        int colA = csrColIndices[i];
+        double valA = csrValues[i];
+        sum += valA * denseB[colA * N + col];
+    }
+
+    output[row * N + col] = sum;
+}
+
 // CSR SpMM with fused bias addition: C[M,N] = A[M,K] * B[K,N] + bias[N]
 extern ""C"" __global__ __launch_bounds__(256) void csr_spmm_bias(
     const float* __restrict__ csrValues,
@@ -537,6 +567,7 @@ extern ""C"" __global__ __launch_bounds__(256) void symmetric_degree_normalize(
             // CSR SpMM operations
             "csr_spmm",
             "csr_spmm_warp",
+            "csr_spmm_double",
             "csr_spmm_bias",
             "csr_spmm_bias_relu",
             // GNN message passing (issue #382: deterministic variants for bit-reproducible scatter)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -3124,6 +3124,71 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
             M, K, N, nnz);
     }
 
+    /// <summary>Warp-per-row CSR SpMM (issue #515): launches <c>csr_spmm_warp</c>
+    /// (one warp per output row). The kernel uses only blockIdx.x/threadIdx.x, so it
+    /// runs on the shared 2-D launcher with gridY=1. Same numerics as
+    /// <see cref="CsrSpMM"/>. CUDA mirror: <see cref="CUDA.CudaBackend.CsrSpMMWarp"/>.</summary>
+    public void CsrSpMMWarp(
+        IGpuBuffer csrValues,
+        IGpuBuffer csrColIndices,
+        IGpuBuffer csrRowPointers,
+        IGpuBuffer denseB,
+        IGpuBuffer output,
+        int M, int K, int N, int nnz)
+    {
+        if (!IsAvailable)
+            throw new InvalidOperationException("HIP backend is not available.");
+
+        if (!_kernelCache.TryGetValue("csr_spmm_warp", out var kernel))
+            throw new InvalidOperationException("HIP kernel not found: csr_spmm_warp");
+
+        // One warp (32 lanes) per row; DefaultBlockSize threads/block => 8 warps/block.
+        int gridX = (M * 32 + DefaultBlockSize - 1) / DefaultBlockSize;
+        int gridY = 1;
+
+        var valuesHandle = ((HipGpuBuffer)csrValues).Handle;
+        var colIndicesHandle = ((HipGpuBuffer)csrColIndices).Handle;
+        var rowPointersHandle = ((HipGpuBuffer)csrRowPointers).Handle;
+        var denseBHandle = ((HipGpuBuffer)denseB).Handle;
+        var outputHandle = ((HipGpuBuffer)output).Handle;
+
+        LaunchKernel2D(kernel, gridX, gridY, DefaultBlockSize, 1,
+            valuesHandle, colIndicesHandle, rowPointersHandle, denseBHandle, outputHandle,
+            M, K, N, nnz);
+    }
+
+    /// <summary>FP64 CSR SpMM (issue #515): launches <c>csr_spmm_double</c>. The
+    /// value / dense / output buffers carry <c>double</c> payloads (byte buffers); the
+    /// int CSR index buffers are unchanged. CUDA mirror:
+    /// <see cref="CUDA.CudaBackend.CsrSpMMDouble"/>.</summary>
+    public void CsrSpMMDouble(
+        IGpuBuffer csrValues,
+        IGpuBuffer csrColIndices,
+        IGpuBuffer csrRowPointers,
+        IGpuBuffer denseB,
+        IGpuBuffer output,
+        int M, int K, int N, int nnz)
+    {
+        if (!IsAvailable)
+            throw new InvalidOperationException("HIP backend is not available.");
+
+        if (!_kernelCache.TryGetValue("csr_spmm_double", out var kernel))
+            throw new InvalidOperationException("HIP kernel not found: csr_spmm_double");
+
+        int gridX = M;
+        int gridY = (N + DefaultBlockSize - 1) / DefaultBlockSize;
+
+        var valuesHandle = ((HipGpuBuffer)csrValues).Handle;
+        var colIndicesHandle = ((HipGpuBuffer)csrColIndices).Handle;
+        var rowPointersHandle = ((HipGpuBuffer)csrRowPointers).Handle;
+        var denseBHandle = ((HipGpuBuffer)denseB).Handle;
+        var outputHandle = ((HipGpuBuffer)output).Handle;
+
+        LaunchKernel2D(kernel, gridX, gridY, DefaultBlockSize, 1,
+            valuesHandle, colIndicesHandle, rowPointersHandle, denseBHandle, outputHandle,
+            M, K, N, nnz);
+    }
+
     /// <inheritdoc/>
     public void CsrSpMMBias(
         IGpuBuffer csrValues,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipCustomSparseBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipCustomSparseBackend.cs
@@ -1,0 +1,156 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.HIP;
+
+/// <summary>
+/// HIP/ROCm equivalent of <see cref="CUDA.CudaSparseBackend"/>: CSR · dense → dense
+/// SpMM using AiDotNet's own managed HIP kernels (<c>csr_spmm</c> /
+/// <c>csr_spmm_warp</c> / <c>csr_spmm_double</c> in
+/// <see cref="Kernels.HipSparseKernels"/>), with the same host-array entry shape as
+/// <see cref="HipSparseBackend"/> but dispatching the managed kernels instead of
+/// rocSPARSE — the supply-chain-removal default for AMD GPUs (issue #515, P6).
+///
+/// <para><b>Status (#515): implemented but NOT yet wired into
+/// <see cref="LinearAlgebra.Sparse.SparseOps"/> dispatch.</b> The only cheap
+/// availability signal, <see cref="HipBackend.IsHipAvailable"/>, reports true whenever
+/// the HIP runtime sees a device (it can route over a CUDA device) even when the HIP
+/// kernel toolchain can't build a usable binary for the active arch (e.g. a
+/// gfx-mismatched / header-missing install). Routing on that signal would replace the
+/// safe CPU/vendor fallback with a failing backend. Wiring this in needs a
+/// kernel-load-strict availability gate, validated end-to-end on a healthy ROCm
+/// runner. The kernels + launches are a faithful mirror of the CUDA path so the wiring
+/// is a small follow-up once such a runner exists.</para>
+/// </summary>
+internal static class HipCustomSparseBackend
+{
+    /// <summary>N (dense column count) at or below which the warp-per-row kernel is
+    /// preferred over the 2-D scalar kernel (mirrors
+    /// <see cref="CUDA.CudaSparseBackend"/>; first-cut, to be tuned by the #515 bar).</summary>
+    private const int WarpColumnThreshold = 64;
+
+    /// <summary>Needs only a constructible HIP runtime — no rocSPARSE library, which
+    /// is the point of the supply-chain removal.</summary>
+    public static bool IsAvailable => HipBackend.IsHipAvailable;
+
+    /// <summary>CSR · dense → dense, host-side <c>float[]</c> CSR inputs. Warp-per-row
+    /// kernel for small/moderate N, 2-D scalar for wide N.</summary>
+    public static float[] SpMM(
+        int[] rowPtr, int[] colIdx, float[] values,
+        float[] b, int rows, int cols, int n)
+    {
+        if (!IsAvailable)
+            throw new InvalidOperationException("HIP custom-kernel SpMM backend is not available.");
+
+        var backend = new HipBackend();
+        if (!backend.IsAvailable)
+            throw new InvalidOperationException("HIP backend failed to initialise.");
+
+        var output = new float[rows * n];
+
+        IGpuBuffer? valuesBuf = null, bBuf = null, outBuf = null;
+        IGpuBuffer? rowPtrBuf = null, colIdxBuf = null;
+        try
+        {
+            valuesBuf = backend.AllocateBuffer(values);
+            bBuf = backend.AllocateBuffer(b);
+            outBuf = backend.AllocateBuffer(output);
+            rowPtrBuf = backend.AllocateByteBuffer(rowPtr.Length * sizeof(int));
+            colIdxBuf = backend.AllocateByteBuffer(colIdx.Length * sizeof(int));
+            UploadInts(rowPtrBuf.Handle, rowPtr);
+            UploadInts(colIdxBuf.Handle, colIdx);
+
+            if (n <= WarpColumnThreshold)
+                backend.CsrSpMMWarp(valuesBuf, colIdxBuf, rowPtrBuf, bBuf, outBuf,
+                    rows, cols, n, values.Length);
+            else
+                backend.CsrSpMM(valuesBuf, colIdxBuf, rowPtrBuf, bBuf, outBuf,
+                    rows, cols, n, values.Length);
+
+            backend.DownloadBuffer(outBuf, output);
+            return output;
+        }
+        finally
+        {
+            outBuf?.Dispose();
+            bBuf?.Dispose();
+            valuesBuf?.Dispose();
+            rowPtrBuf?.Dispose();
+            colIdxBuf?.Dispose();
+        }
+    }
+
+    /// <summary>FP64 CSR · dense → dense (issue #515). Double payloads ride byte
+    /// buffers, dispatched through <c>csr_spmm_double</c>.</summary>
+    public static double[] SpMM(
+        int[] rowPtr, int[] colIdx, double[] values,
+        double[] b, int rows, int cols, int n)
+    {
+        if (!IsAvailable)
+            throw new InvalidOperationException("HIP custom-kernel SpMM backend is not available.");
+
+        var backend = new HipBackend();
+        if (!backend.IsAvailable)
+            throw new InvalidOperationException("HIP backend failed to initialise.");
+
+        var output = new double[rows * n];
+
+        IGpuBuffer? valuesBuf = null, bBuf = null, outBuf = null;
+        IGpuBuffer? rowPtrBuf = null, colIdxBuf = null;
+        try
+        {
+            valuesBuf = backend.AllocateByteBuffer(values.Length * sizeof(double));
+            bBuf = backend.AllocateByteBuffer(b.Length * sizeof(double));
+            outBuf = backend.AllocateByteBuffer(output.Length * sizeof(double));
+            UploadDoubles(valuesBuf.Handle, values);
+            UploadDoubles(bBuf.Handle, b);
+
+            rowPtrBuf = backend.AllocateByteBuffer(rowPtr.Length * sizeof(int));
+            colIdxBuf = backend.AllocateByteBuffer(colIdx.Length * sizeof(int));
+            UploadInts(rowPtrBuf.Handle, rowPtr);
+            UploadInts(colIdxBuf.Handle, colIdx);
+
+            backend.CsrSpMMDouble(valuesBuf, colIdxBuf, rowPtrBuf, bBuf, outBuf,
+                rows, cols, n, values.Length);
+
+            DownloadDoubles(outBuf.Handle, output);
+            return output;
+        }
+        finally
+        {
+            outBuf?.Dispose();
+            bBuf?.Dispose();
+            valuesBuf?.Dispose();
+            rowPtrBuf?.Dispose();
+            colIdxBuf?.Dispose();
+        }
+    }
+
+    private static unsafe void UploadInts(IntPtr device, int[] host)
+    {
+        var bytes = (UIntPtr)((ulong)host.Length * sizeof(int));
+        fixed (int* src = host)
+            HipNativeBindings.CheckError(
+                HipNativeBindings.hipMemcpy(device, (IntPtr)src, bytes, HipMemcpyKind.HostToDevice),
+                "hipMemcpy(int[])");
+    }
+
+    private static unsafe void UploadDoubles(IntPtr device, double[] host)
+    {
+        var bytes = (UIntPtr)((ulong)host.Length * sizeof(double));
+        fixed (double* src = host)
+            HipNativeBindings.CheckError(
+                HipNativeBindings.hipMemcpy(device, (IntPtr)src, bytes, HipMemcpyKind.HostToDevice),
+                "hipMemcpy(double[])");
+    }
+
+    private static unsafe void DownloadDoubles(IntPtr device, double[] host)
+    {
+        var bytes = (UIntPtr)((ulong)host.Length * sizeof(double));
+        fixed (double* dst = host)
+            HipNativeBindings.CheckError(
+                HipNativeBindings.hipMemcpy((IntPtr)dst, device, bytes, HipMemcpyKind.DeviceToHost),
+                "hipMemcpy(double[] download)");
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipSparseKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipSparseKernels.cs
@@ -76,6 +76,35 @@ extern ""C"" __global__ __launch_bounds__(256) void csr_spmm_warp(
     }
 }
 
+// CSR SpMM, FP64 (issue #515): double-precision analog of csr_spmm. Same per-output
+// reduction order as the float kernel and the managed CPU reference → deterministic.
+extern ""C"" __global__ __launch_bounds__(256) void csr_spmm_double(
+    const double* __restrict__ csrValues,
+    const int* __restrict__ csrColIndices,
+    const int* __restrict__ csrRowPointers,
+    const double* __restrict__ denseB,
+    double* __restrict__ output,
+    int M, int K, int N, int nnz)
+{
+    int row = blockIdx.x;
+    int col = blockIdx.y * blockDim.x + threadIdx.x;
+
+    if (row >= M || col >= N) return;
+
+    int rowStart = csrRowPointers[row];
+    int rowEnd = csrRowPointers[row + 1];
+
+    double sum = 0.0;
+    for (int i = rowStart; i < rowEnd; i++)
+    {
+        int colA = csrColIndices[i];
+        double valA = csrValues[i];
+        sum += valA * denseB[colA * N + col];
+    }
+
+    output[row * N + col] = sum;
+}
+
 extern ""C"" __global__ __launch_bounds__(256) void csr_spmm_bias(
     const float* __restrict__ csrValues,
     const int* __restrict__ csrColIndices,
@@ -464,6 +493,7 @@ extern ""C"" __global__ __launch_bounds__(256) void symmetric_degree_normalize(
         [
             "csr_spmm",
             "csr_spmm_warp",
+            "csr_spmm_double",
             "csr_spmm_bias",
             "csr_spmm_bias_relu",
             "scatter_add_edges",

--- a/src/AiDotNet.Tensors/LinearAlgebra/Sparse/SparseOps.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/Sparse/SparseOps.cs
@@ -74,6 +74,14 @@ public static class SparseOps
                 // HIP/Metal mirrors + FP64 + the perf bar land (tracked in #515).
                 if (CudaSparseBackend.IsAvailable)
                     outArr = CudaSparseBackend.SpMM(rowPtr, colIdx, valsArr, bArr, rows, k, n);
+                // NOTE (#515): the managed HIP custom kernel (HipCustomSparseBackend)
+                // is implemented + compiled but intentionally NOT routed here yet. Its
+                // only cheap availability signal, HipBackend.IsHipAvailable, reports
+                // true whenever the HIP runtime sees a device even when the HIP kernel
+                // toolchain can't actually build a binary (e.g. a gfx-mismatched /
+                // header-missing install), which would regress this path to a failing
+                // backend instead of the CPU/vendor fallbacks. Wiring it needs a
+                // kernel-load-strict gate validated on a healthy ROCm runner.
                 else if (CuSparseBackend.IsAvailable)
                     outArr = CuSparseBackend.SpMM(rowPtr, colIdx, valsArr, bArr, rows, k, n);
                 else if (HipSparseBackend.IsAvailable)
@@ -98,16 +106,35 @@ public static class SparseOps
             }
             // else fall through to scalar tier below.
         }
-        if (typeof(T) == typeof(double) && System.Numerics.Vector.IsHardwareAccelerated)
+        if (typeof(T) == typeof(double))
         {
             var valsArr = (double[])(object)csr.DataVector.ToArray();
             var bArr = (double[])(object)b.ToArray();
-            var outArr = new double[rows * n];
-            CsrDenseSimd.MultiplyDouble(rowPtr, colIdx, valsArr, bArr, outArr, rows, n);
-            var outSpanDouble = output.AsWritableSpan();
-            for (int i = 0; i < outSpanDouble.Length; i++) outSpanDouble[i] = (T)(object)outArr[i];
-            _ = k;
-            return output;
+            double[]? outArr = null;
+
+            // Tier 0 — GPU dispatch via the managed FP64 CSR kernel (#515). The
+            // vendor host-array paths (cuSPARSE/rocSPARSE) aren't wired for FP64, so
+            // the managed CUDA kernel is the only GPU double path; previously double
+            // had no GPU tier at all and went straight to CPU. (The HIP FP64 mirror
+            // exists but isn't routed yet — see the float tier's note.)
+            if (rows * (long)n >= GpuDispatchThreshold && CudaSparseBackend.IsAvailable)
+                outArr = CudaSparseBackend.SpMM(rowPtr, colIdx, valsArr, bArr, rows, k, n);
+
+            // Tier 1 — CPU SIMD on hardware-accelerated Vector<T>.
+            if (outArr is null && System.Numerics.Vector.IsHardwareAccelerated)
+            {
+                outArr = new double[rows * n];
+                CsrDenseSimd.MultiplyDouble(rowPtr, colIdx, valsArr, bArr, outArr, rows, n);
+            }
+
+            if (outArr is not null)
+            {
+                var outSpanDouble = output.AsWritableSpan();
+                for (int i = 0; i < outSpanDouble.Length; i++) outSpanDouble[i] = (T)(object)outArr[i];
+                _ = k;
+                return output;
+            }
+            // else fall through to the generic scalar tier below.
         }
 
         var valsT = csr.DataVector;

--- a/src/AiDotNet.Tensors/LinearAlgebra/Sparse/SparseOps.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/Sparse/SparseOps.cs
@@ -62,12 +62,19 @@ public static class SparseOps
             var bArr = (float[])(object)b.ToArray();
             float[]? outArr = null;
 
-            // Tier 0 — GPU dispatch (cuSPARSE / rocSPARSE / MPS) gated
-            // by host availability + a size threshold; small problems
-            // pay more in upload/download than they save in compute.
+            // Tier 0 — GPU dispatch gated by host availability + a size
+            // threshold; small problems pay more in upload/download than
+            // they save in compute.
             if (rows * (long)n >= GpuDispatchThreshold)
             {
-                if (CuSparseBackend.IsAvailable)
+                // #515 (P6): AiDotNet's own managed CSR-SpMM CUDA kernel is the
+                // default GPU path — it needs only the CUDA driver, removing the
+                // native cuSPARSE dependency. The vendor backends (cuSPARSE /
+                // rocSPARSE / MPS) stay as availability fallbacks until the custom
+                // HIP/Metal mirrors + FP64 + the perf bar land (tracked in #515).
+                if (CudaSparseBackend.IsAvailable)
+                    outArr = CudaSparseBackend.SpMM(rowPtr, colIdx, valsArr, bArr, rows, k, n);
+                else if (CuSparseBackend.IsAvailable)
                     outArr = CuSparseBackend.SpMM(rowPtr, colIdx, valsArr, bArr, rows, k, n);
                 else if (HipSparseBackend.IsAvailable)
                     outArr = HipSparseBackend.SpMM(rowPtr, colIdx, valsArr, bArr, rows, k, n);

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/CudaSparseBackendSpMMTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/CudaSparseBackendSpMMTests.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Tensors.Engines.DirectGpu.CUDA;
+using AiDotNet.Tensors.Helpers;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
+
+/// <summary>
+/// Parity + determinism guard for the managed custom-kernel CSR SpMM path that
+/// #515 (P6) makes the default GPU SpMM (replacing native cuSPARSE). The
+/// <c>csr_spmm</c> CUDA kernel accumulates each output element in a single thread
+/// over the row's stored order, so it must (a) match a hand-written CPU CSR
+/// reference to FMA tolerance and (b) be bit-identical across repeated calls.
+///
+/// <para>These run only where the CUDA driver is present (the self-hosted GPU
+/// runner) — on a CPU-only host they skip. The CPU reference is the oracle; it
+/// uses the same per-output sequential reduction order as the kernel, so any
+/// indexing/launch bug shows up as O(1) error, not rounding.</para>
+/// </summary>
+public class CudaSparseBackendSpMMTests
+{
+    // CPU CSR · dense reference. Same reduction order as csr_spmm (ascending nnz
+    // per row, accumulate into one scalar), so a correct kernel matches to ~1e-3
+    // relative (the GPU may FMA-contract val*B+sum; the CPU does separate mul+add).
+    private static float[] CpuReference(
+        int[] rowPtr, int[] colIdx, float[] vals, float[] b, int rows, int n)
+    {
+        var outp = new float[rows * n];
+        for (int r = 0; r < rows; r++)
+            for (int j = 0; j < n; j++)
+            {
+                float acc = 0f;
+                for (int p = rowPtr[r]; p < rowPtr[r + 1]; p++)
+                    acc += vals[p] * b[colIdx[p] * n + j];
+                outp[r * n + j] = acc;
+            }
+        return outp;
+    }
+
+    // Random CSR with ascending column indices per row (the layout csr_spmm expects).
+    private static (int[] rowPtr, int[] colIdx, float[] vals) BuildCsr(
+        int rows, int cols, double density, Random rng)
+    {
+        var rowPtr = new int[rows + 1];
+        var colList = new List<int>();
+        var valList = new List<float>();
+        for (int r = 0; r < rows; r++)
+        {
+            rowPtr[r] = colList.Count;
+            for (int c = 0; c < cols; c++)
+                if (rng.NextDouble() < density)
+                {
+                    colList.Add(c);
+                    valList.Add((float)(rng.NextDouble() * 2 - 1));
+                }
+        }
+        rowPtr[rows] = colList.Count;
+        return (rowPtr, colList.ToArray(), valList.ToArray());
+    }
+
+    private static float[] RandDense(int len, Random rng)
+    {
+        var b = new float[len];
+        for (int i = 0; i < len; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+        return b;
+    }
+
+    [SkippableTheory]
+    [InlineData(64, 48, 16, 0.20)]    // small N — exercises the warp-relevant regime
+    [InlineData(128, 96, 128, 0.10)]  // moderate, square-ish dense
+    [InlineData(256, 256, 64, 0.05)]  // larger + sparser
+    [InlineData(100, 70, 1, 0.30)]    // N=1 (SpMV-like) edge
+    public void CustomCsrSpMM_MatchesCpuReference(int rows, int cols, int n, double density)
+    {
+        Skip.IfNot(CudaSparseBackend.IsAvailable,
+            "CUDA driver not available; managed custom-kernel SpMM path inactive on this host.");
+
+        var rng = RandomHelper.CreateSeededRandom(1234);
+        var (rowPtr, colIdx, vals) = BuildCsr(rows, cols, density, rng);
+        var b = RandDense(cols * n, rng);
+
+        var want = CpuReference(rowPtr, colIdx, vals, b, rows, n);
+        var got = CudaSparseBackend.SpMM(rowPtr, colIdx, vals, b, rows, cols, n);
+
+        Assert.Equal(want.Length, got.Length);
+        double maxAbs = 0, maxMag = 0;
+        for (int i = 0; i < want.Length; i++)
+        {
+            maxAbs = Math.Max(maxAbs, Math.Abs(got[i] - want[i]));
+            maxMag = Math.Max(maxMag, Math.Abs(want[i]));
+        }
+        double rel = maxAbs / Math.Max(1e-6, maxMag);
+        Assert.True(rel < 1e-3,
+            $"custom csr_spmm rel error {rel:E2} exceeds 1e-3 at shape {rows}x{cols}x{n} (density {density}) — likely a kernel/launch bug.");
+    }
+
+    [SkippableFact]
+    public void CustomCsrSpMM_IsDeterministic_AcrossRepeatedCalls()
+    {
+        Skip.IfNot(CudaSparseBackend.IsAvailable,
+            "CUDA driver not available; managed custom-kernel SpMM path inactive on this host.");
+
+        var rng = RandomHelper.CreateSeededRandom(99);
+        const int rows = 200, cols = 160, n = 48;
+        var (rowPtr, colIdx, vals) = BuildCsr(rows, cols, 0.1, rng);
+        var b = RandDense(cols * n, rng);
+
+        var first = CudaSparseBackend.SpMM(rowPtr, colIdx, vals, b, rows, cols, n);
+        var second = CudaSparseBackend.SpMM(rowPtr, colIdx, vals, b, rows, cols, n);
+
+        // Each output element is reduced by exactly one thread in stored order, so
+        // repeated launches must be bit-identical (no atomics, no cross-thread race).
+        Assert.Equal(first, second);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/CudaSparseBackendSpMMTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/CudaSparseBackendSpMMTests.cs
@@ -7,24 +7,21 @@ using Xunit;
 namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
 
 /// <summary>
-/// Parity + determinism guard for the managed custom-kernel CSR SpMM path that
-/// #515 (P6) makes the default GPU SpMM (replacing native cuSPARSE). The
-/// <c>csr_spmm</c> CUDA kernel accumulates each output element in a single thread
-/// over the row's stored order, so it must (a) match a hand-written CPU CSR
-/// reference to FMA tolerance and (b) be bit-identical across repeated calls.
+/// Parity + determinism guards for the managed custom-kernel CSR SpMM that #515 (P6)
+/// makes the default GPU SpMM (replacing native cuSPARSE). Covers the CUDA float warp
+/// + scalar kernels and the CUDA FP64 kernel. Every kernel accumulates each output
+/// element in one thread over the row's stored order, so each must (a) match a
+/// hand-written CPU CSR reference and (b) be bit-identical across repeated launches.
 ///
-/// <para>These run only where the CUDA driver is present (the self-hosted GPU
-/// runner) — on a CPU-only host they skip. The CPU reference is the oracle; it
-/// uses the same per-output sequential reduction order as the kernel, so any
-/// indexing/launch bug shows up as O(1) error, not rounding.</para>
+/// <para>These run only where the CUDA driver + NVRTC are present (the self-hosted
+/// runner) — on a host without them they skip. The CPU reference is the oracle and
+/// uses the same per-output reduction order as the kernels, so an indexing/launch bug
+/// shows up as O(1) error, not rounding. (The HIP mirror is implemented but not yet
+/// wired/validated — it needs a healthy ROCm runner; see HipCustomSparseBackend.)</para>
 /// </summary>
 public class CudaSparseBackendSpMMTests
 {
-    // CPU CSR · dense reference. Same reduction order as csr_spmm (ascending nnz
-    // per row, accumulate into one scalar), so a correct kernel matches to ~1e-3
-    // relative (the GPU may FMA-contract val*B+sum; the CPU does separate mul+add).
-    private static float[] CpuReference(
-        int[] rowPtr, int[] colIdx, float[] vals, float[] b, int rows, int n)
+    private static float[] CpuReference(int[] rowPtr, int[] colIdx, float[] vals, float[] b, int rows, int n)
     {
         var outp = new float[rows * n];
         for (int r = 0; r < rows; r++)
@@ -38,79 +35,133 @@ public class CudaSparseBackendSpMMTests
         return outp;
     }
 
-    // Random CSR with ascending column indices per row (the layout csr_spmm expects).
-    private static (int[] rowPtr, int[] colIdx, float[] vals) BuildCsr(
-        int rows, int cols, double density, Random rng)
+    private static double[] CpuReferenceDouble(int[] rowPtr, int[] colIdx, double[] vals, double[] b, int rows, int n)
+    {
+        var outp = new double[rows * n];
+        for (int r = 0; r < rows; r++)
+            for (int j = 0; j < n; j++)
+            {
+                double acc = 0.0;
+                for (int p = rowPtr[r]; p < rowPtr[r + 1]; p++)
+                    acc += vals[p] * b[colIdx[p] * n + j];
+                outp[r * n + j] = acc;
+            }
+        return outp;
+    }
+
+    // Random CSR with ascending column indices per row (the layout the kernels expect).
+    private static (int[] rowPtr, int[] colIdx) BuildCsrPattern(int rows, int cols, double density, Random rng, out int nnz)
     {
         var rowPtr = new int[rows + 1];
         var colList = new List<int>();
-        var valList = new List<float>();
         for (int r = 0; r < rows; r++)
         {
             rowPtr[r] = colList.Count;
             for (int c = 0; c < cols; c++)
-                if (rng.NextDouble() < density)
-                {
-                    colList.Add(c);
-                    valList.Add((float)(rng.NextDouble() * 2 - 1));
-                }
+                if (rng.NextDouble() < density) colList.Add(c);
         }
         rowPtr[rows] = colList.Count;
-        return (rowPtr, colList.ToArray(), valList.ToArray());
+        nnz = colList.Count;
+        return (rowPtr, colList.ToArray());
     }
 
-    private static float[] RandDense(int len, Random rng)
+    private static float[] RandF(int len, Random rng)
     {
-        var b = new float[len];
-        for (int i = 0; i < len; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
-        return b;
+        var a = new float[len];
+        for (int i = 0; i < len; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+        return a;
     }
 
-    [SkippableTheory]
-    [InlineData(64, 48, 16, 0.20)]    // small N — exercises the warp-relevant regime
-    [InlineData(128, 96, 128, 0.10)]  // moderate, square-ish dense
-    [InlineData(256, 256, 64, 0.05)]  // larger + sparser
-    [InlineData(100, 70, 1, 0.30)]    // N=1 (SpMV-like) edge
-    public void CustomCsrSpMM_MatchesCpuReference(int rows, int cols, int n, double density)
+    private static double[] RandD(int len, Random rng)
     {
-        Skip.IfNot(CudaSparseBackend.IsAvailable,
-            "CUDA driver not available; managed custom-kernel SpMM path inactive on this host.");
+        var a = new double[len];
+        for (int i = 0; i < len; i++) a[i] = rng.NextDouble() * 2 - 1;
+        return a;
+    }
 
-        var rng = RandomHelper.CreateSeededRandom(1234);
-        var (rowPtr, colIdx, vals) = BuildCsr(rows, cols, density, rng);
-        var b = RandDense(cols * n, rng);
-
-        var want = CpuReference(rowPtr, colIdx, vals, b, rows, n);
-        var got = CudaSparseBackend.SpMM(rowPtr, colIdx, vals, b, rows, cols, n);
-
-        Assert.Equal(want.Length, got.Length);
+    private static double RelErr(ReadOnlySpan<float> got, ReadOnlySpan<float> want)
+    {
         double maxAbs = 0, maxMag = 0;
         for (int i = 0; i < want.Length; i++)
         {
             maxAbs = Math.Max(maxAbs, Math.Abs(got[i] - want[i]));
             maxMag = Math.Max(maxMag, Math.Abs(want[i]));
         }
-        double rel = maxAbs / Math.Max(1e-6, maxMag);
-        Assert.True(rel < 1e-3,
-            $"custom csr_spmm rel error {rel:E2} exceeds 1e-3 at shape {rows}x{cols}x{n} (density {density}) — likely a kernel/launch bug.");
+        return maxAbs / Math.Max(1e-6, maxMag);
+    }
+
+    private static double RelErr(ReadOnlySpan<double> got, ReadOnlySpan<double> want)
+    {
+        double maxAbs = 0, maxMag = 0;
+        for (int i = 0; i < want.Length; i++)
+        {
+            maxAbs = Math.Max(maxAbs, Math.Abs(got[i] - want[i]));
+            maxMag = Math.Max(maxMag, Math.Abs(want[i]));
+        }
+        return maxAbs / Math.Max(1e-9, maxMag);
+    }
+
+    // N <= 64 routes to csr_spmm_warp, N > 64 to the 2-D scalar csr_spmm, so the
+    // cases below exercise BOTH float kernels against the same CPU reference.
+    public static IEnumerable<object[]> Shapes() => new[]
+    {
+        new object[] { 64, 48, 16, 0.20 },    // small N -> warp kernel
+        new object[] { 128, 96, 128, 0.10 },  // wide N  -> scalar kernel
+        new object[] { 256, 256, 64, 0.05 },  // N == threshold -> warp
+        new object[] { 100, 70, 1, 0.30 },    // N=1 (SpMV-like) edge -> warp
+    };
+
+    [SkippableTheory]
+    [MemberData(nameof(Shapes))]
+    public void CudaFloat_MatchesCpuReference(int rows, int cols, int n, double density)
+    {
+        Skip.IfNot(CudaSparseBackend.IsAvailable, "CUDA driver/NVRTC not available on this host.");
+
+        var rng = RandomHelper.CreateSeededRandom(1234);
+        var (rowPtr, colIdx) = BuildCsrPattern(rows, cols, density, rng, out int nnz);
+        var vals = RandF(nnz, rng);
+        var b = RandF(cols * n, rng);
+
+        var want = CpuReference(rowPtr, colIdx, vals, b, rows, n);
+        var got = CudaSparseBackend.SpMM(rowPtr, colIdx, vals, b, rows, cols, n);
+
+        Assert.Equal(want.Length, got.Length);
+        double rel = RelErr(got, want);
+        Assert.True(rel < 1e-3, $"CUDA float csr_spmm rel error {rel:E2} > 1e-3 at {rows}x{cols}x{n} (density {density}).");
     }
 
     [SkippableFact]
-    public void CustomCsrSpMM_IsDeterministic_AcrossRepeatedCalls()
+    public void CudaFloat_IsDeterministic_AcrossRepeatedCalls()
     {
-        Skip.IfNot(CudaSparseBackend.IsAvailable,
-            "CUDA driver not available; managed custom-kernel SpMM path inactive on this host.");
+        Skip.IfNot(CudaSparseBackend.IsAvailable, "CUDA driver/NVRTC not available on this host.");
 
         var rng = RandomHelper.CreateSeededRandom(99);
         const int rows = 200, cols = 160, n = 48;
-        var (rowPtr, colIdx, vals) = BuildCsr(rows, cols, 0.1, rng);
-        var b = RandDense(cols * n, rng);
+        var (rowPtr, colIdx) = BuildCsrPattern(rows, cols, 0.1, rng, out int nnz);
+        var vals = RandF(nnz, rng);
+        var b = RandF(cols * n, rng);
 
         var first = CudaSparseBackend.SpMM(rowPtr, colIdx, vals, b, rows, cols, n);
         var second = CudaSparseBackend.SpMM(rowPtr, colIdx, vals, b, rows, cols, n);
-
-        // Each output element is reduced by exactly one thread in stored order, so
-        // repeated launches must be bit-identical (no atomics, no cross-thread race).
         Assert.Equal(first, second);
+    }
+
+    [SkippableTheory]
+    [MemberData(nameof(Shapes))]
+    public void CudaDouble_MatchesCpuReference(int rows, int cols, int n, double density)
+    {
+        Skip.IfNot(CudaSparseBackend.IsAvailable, "CUDA driver/NVRTC not available on this host.");
+
+        var rng = RandomHelper.CreateSeededRandom(4321);
+        var (rowPtr, colIdx) = BuildCsrPattern(rows, cols, density, rng, out int nnz);
+        var vals = RandD(nnz, rng);
+        var b = RandD(cols * n, rng);
+
+        var want = CpuReferenceDouble(rowPtr, colIdx, vals, b, rows, n);
+        var got = CudaSparseBackend.SpMM(rowPtr, colIdx, vals, b, rows, cols, n);
+
+        Assert.Equal(want.Length, got.Length);
+        double rel = RelErr(got, want);
+        Assert.True(rel < 1e-9, $"CUDA double csr_spmm_double rel error {rel:E2} > 1e-9 at {rows}x{cols}x{n} (density {density}).");
     }
 }


### PR DESCRIPTION
## What & why

Advances **#515 (P6)**: replace native cuSPARSE/rocSPARSE with AiDotNet's own managed CSR-SpMM kernels (supply-chain removal).

## CUDA — wired + parity-tested (validates on the NVIDIA runner)

- **Default flip.** New `CudaSparseBackend.SpMM` host-array wrapper dispatches the managed `csr_spmm` kernel (needs only the CUDA driver, no cuSPARSE); `SparseOps` Tier 0 prefers it, cuSPARSE/rocSPARSE/MPS become fallbacks.
- **Warp-per-row heuristic.** New `CsrSpMMWarp` launch; the host wrapper picks `csr_spmm_warp` for N≤64 (coalesced lane-per-column) and the 2-D scalar `csr_spmm` for wider N. Identical numerics.
- **FP64.** New `csr_spmm_double` kernel + `CsrSpMMDouble` launch + a `double` host overload (double payloads on byte buffers). Wires the managed FP64 kernel into `SparseOps`' double tier, **which previously had no GPU path at all** (it went straight to CPU SIMD).
- **Tests.** Float (warp **and** scalar, via N≤64 / N>64 cases) + double parity vs a CPU CSR reference, plus float determinism. `SkippableFact`/`Theory` — skip without CUDA, run on the runner.

## HIP — implemented, intentionally NOT wired

Mirror kernels (`csr_spmm_double`) + launches (`CsrSpMMWarp`/`CsrSpMMDouble`) + `HipCustomSparseBackend` (float + double) — a faithful copy of the CUDA path. **Not routed in `SparseOps`**, and here's the finding that forced that call:

> `HipBackend.IsHipAvailable` reports **true** whenever the HIP runtime sees a device (it can route over a CUDA device) **even when the HIP kernel toolchain can't build a usable binary** for the active arch. On this dev box every HIP module fails to load (`gfx900` / missing `math.h`). Routing on that loose signal would **regress** sparse matmul to a failing backend instead of the CPU/vendor fallback.

So HIP needs a **kernel-load-strict availability gate validated on a healthy ROCm runner** before wiring; the mirror code is ready for that small follow-up.

## Verification

| Check | Result |
|---|---|
| Library + tests compile net10.0 + net471 | ✅ 0 errors |
| GPU parity/determinism tests (this host) | ✅ skip cleanly (no NVRTC) |
| Existing 49 sparse tests (net10.0) | ✅ pass — CPU path unchanged |

CUDA kernel **correctness + perf validate on the self-hosted runner** (`ns107444`); the cuSPARSE perf-bar bench (P6 final checkbox) is runner-only — it can't be produced without the GPU and won't be fabricated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)