### PR TITLE
perf(#515): 128-bit vectorized-load SpMM kernel + cuSPARSE bench harness

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -2706,6 +2706,52 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         LaunchKernel2D(kernel, gridX, gridY, (uint)DefaultBlockSize, 1, args);
     }
 
+    /// <summary>
+    /// 128-bit-vectorized CSR SpMM (issue #515): launches <c>csr_spmm_vec4</c>, where
+    /// each thread computes 4 adjacent output columns via aligned <c>float4</c> loads.
+    /// Requires <paramref name="N"/> % 4 == 0 (the caller's gate). Same numerics as
+    /// <see cref="CsrSpMM"/> (per-output sequential reduction → deterministic).
+    /// </summary>
+    public unsafe void CsrSpMMVec4(
+        IGpuBuffer csrValues,
+        IGpuBuffer csrColIndices,
+        IGpuBuffer csrRowPointers,
+        IGpuBuffer denseB,
+        IGpuBuffer output,
+        int M, int K, int N, int nnz)
+    {
+        if (!IsAvailable)
+            throw new InvalidOperationException("CUDA backend is not available.");
+
+        if (!_kernelCache.TryGetValue("csr_spmm_vec4", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: csr_spmm_vec4");
+
+        using var _ = PushContext();
+
+        // Each thread owns 4 columns, so the y-grid spans N/4 thread-columns.
+        uint gridX = (uint)M;
+        uint gridY = (uint)((N / 4 + DefaultBlockSize - 1) / DefaultBlockSize);
+
+        IntPtr valuesPtr = csrValues.Handle;
+        IntPtr colIndicesPtr = csrColIndices.Handle;
+        IntPtr rowPointersPtr = csrRowPointers.Handle;
+        IntPtr denseBPtr = denseB.Handle;
+        IntPtr outputPtr = output.Handle;
+
+        void** args = stackalloc void*[9];
+        args[0] = &valuesPtr;
+        args[1] = &colIndicesPtr;
+        args[2] = &rowPointersPtr;
+        args[3] = &denseBPtr;
+        args[4] = &outputPtr;
+        args[5] = &M;
+        args[6] = &K;
+        args[7] = &N;
+        args[8] = &nnz;
+
+        LaunchKernel2D(kernel, gridX, gridY, (uint)DefaultBlockSize, 1, args);
+    }
+
     /// <inheritdoc/>
     public unsafe void CsrSpMMBias(
         IGpuBuffer csrValues,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -2723,6 +2723,17 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         if (!IsAvailable)
             throw new InvalidOperationException("CUDA backend is not available.");
 
+        // Fail fast on misaligned N: each thread computes 4 adjacent output
+        // columns via float4 loads, so a non-multiple-of-4 N would silently
+        // TRUNCATE the grid to N/4 thread-columns and leave the last
+        // N % 4 output columns unwritten. Upstream routing gates on this,
+        // but a direct call must not rely on it.
+        if ((N & 3) != 0)
+            throw new ArgumentException(
+                $"CsrSpMMVec4 requires N divisible by 4 (got {N}); the float4-vectorized kernel " +
+                "would silently skip the last N % 4 output columns. Use CsrSpMM for unaligned N.",
+                nameof(N));
+
         if (!_kernelCache.TryGetValue("csr_spmm_vec4", out var kernel))
             throw new InvalidOperationException("CUDA kernel not found: csr_spmm_vec4");
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaSparseBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaSparseBackend.cs
@@ -70,10 +70,16 @@ internal static class CudaSparseBackend
             UploadInts(rowPtrBuf.Handle, rowPtr);
             UploadInts(colIdxBuf.Handle, colIdx);
 
-            // Warp-per-row for small/moderate N, 2-D scalar for wide N. Argument
-            // order matches IDirectGpuBackend.CsrSpMM:
+            // Kernel pick (first-cut; to be tuned by the #515 perf bar):
+            //   N % 4 == 0      -> vec4 (128-bit aligned float4 dense loads)
+            //   N <= 64         -> warp-per-row (coalesced lane-per-column)
+            //   otherwise       -> 2-D scalar
+            // Argument order matches IDirectGpuBackend.CsrSpMM:
             // (values, colIndices, rowPointers, denseB, output, M, K, N, nnz).
-            if (n <= WarpColumnThreshold)
+            if (n % 4 == 0)
+                backend.CsrSpMMVec4(valuesBuf, colIdxBuf, rowPtrBuf, bBuf, outBuf,
+                    rows, cols, n, values.Length);
+            else if (n <= WarpColumnThreshold)
                 backend.CsrSpMMWarp(valuesBuf, colIdxBuf, rowPtrBuf, bBuf, outBuf,
                     rows, cols, n, values.Length);
             else

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaSparseKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaSparseKernels.cs
@@ -126,6 +126,42 @@ extern ""C"" __global__ __launch_bounds__(256) void csr_spmm_double(
     output[row * N + col] = sum;
 }
 
+// CSR SpMM, 128-bit vectorized dense loads (issue #515): each thread computes 4
+// adjacent output columns, reading denseB as a 16-byte-aligned float4. Requires
+// N % 4 == 0 (the caller's gate); cudaMalloc gives 256-byte base alignment and
+// colA*N + col4 is a multiple of 4, so the float4 load/store are aligned. Same
+// per-output reduction order as csr_spmm → deterministic + parity-checkable.
+extern ""C"" __global__ __launch_bounds__(256) void csr_spmm_vec4(
+    const float* __restrict__ csrValues,
+    const int* __restrict__ csrColIndices,
+    const int* __restrict__ csrRowPointers,
+    const float* __restrict__ denseB,
+    float* __restrict__ output,
+    int M, int K, int N, int nnz)
+{
+    int row = blockIdx.x;
+    int col4 = (blockIdx.y * blockDim.x + threadIdx.x) * 4;
+
+    if (row >= M || col4 >= N) return;
+
+    int rowStart = csrRowPointers[row];
+    int rowEnd = csrRowPointers[row + 1];
+
+    float4 sum = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+    for (int i = rowStart; i < rowEnd; i++)
+    {
+        int colA = csrColIndices[i];
+        float valA = csrValues[i];
+        float4 bv = *reinterpret_cast<const float4*>(&denseB[colA * N + col4]);
+        sum.x += valA * bv.x;
+        sum.y += valA * bv.y;
+        sum.z += valA * bv.z;
+        sum.w += valA * bv.w;
+    }
+
+    *reinterpret_cast<float4*>(&output[row * N + col4]) = sum;
+}
+
 // CSR SpMM with fused bias addition: C[M,N] = A[M,K] * B[K,N] + bias[N]
 extern ""C"" __global__ __launch_bounds__(256) void csr_spmm_bias(
     const float* __restrict__ csrValues,
@@ -568,6 +604,7 @@ extern ""C"" __global__ __launch_bounds__(256) void symmetric_degree_normalize(
             "csr_spmm",
             "csr_spmm_warp",
             "csr_spmm_double",
+            "csr_spmm_vec4",
             "csr_spmm_bias",
             "csr_spmm_bias_relu",
             // GNN message passing (issue #382: deterministic variants for bit-reproducible scatter)

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SpecializedPerfBar.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/SpecializedPerfBar.cs
@@ -37,6 +37,16 @@ public static class SpecializedPerfBar
     /// <summary>True once the owner has frozen the SpMM bar (non-zero win rate).</summary>
     public static bool SpMMBarFrozen => SpMMMinWinRatePercent > 0;
 
+    // GPU SpMM (#515): AiDotNet's managed CUDA CSR kernels (csr_spmm / _warp / _vec4 /
+    // _double) vs native cuSPARSE cusparseSpMM on the authoritative NVIDIA runner.
+    // Freeze from GpuSpMMBenchHarness output (AIDOTNET_PERF_RUNNER=1) in a gating
+    // commit; P7 (cuSPARSE/rocSPARSE removal) stays blocked until this is green.
+    public const int    GpuSpMMMinWinRatePercent = 0;     // TO BE SET after first runner bench
+    public const double GpuSpMMMaxLossMultiple    = 99.0; // TO BE SET after first runner bench
+
+    /// <summary>True once the owner has frozen the GPU SpMM bar (non-zero win rate).</summary>
+    public static bool GpuSpMMBarFrozen => GpuSpMMMinWinRatePercent > 0;
+
     // GBMV vs OpenBLAS sgbmv/dgbmv on the authoritative runner.
     public const int    GbmvMinWinRatePercent = 0;     // TO BE SET after first bench
     public const double GbmvMaxLossMultiple    = 99.0; // TO BE SET after first bench

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/CudaSparseBackendSpMMTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/CudaSparseBackendSpMMTests.cs
@@ -101,14 +101,15 @@ public class CudaSparseBackendSpMMTests
         return maxAbs / Math.Max(1e-9, maxMag);
     }
 
-    // N <= 64 routes to csr_spmm_warp, N > 64 to the 2-D scalar csr_spmm, so the
-    // cases below exercise BOTH float kernels against the same CPU reference.
+    // Kernel pick: N%4==0 -> vec4, else N<=64 -> warp, else 2-D scalar. The cases
+    // below exercise ALL THREE float kernels against the same CPU reference.
     public static IEnumerable<object[]> Shapes() => new[]
     {
-        new object[] { 64, 48, 16, 0.20 },    // small N -> warp kernel
-        new object[] { 128, 96, 128, 0.10 },  // wide N  -> scalar kernel
-        new object[] { 256, 256, 64, 0.05 },  // N == threshold -> warp
-        new object[] { 100, 70, 1, 0.30 },    // N=1 (SpMV-like) edge -> warp
+        new object[] { 64, 48, 16, 0.20 },    // N%4==0 -> vec4 (128-bit loads)
+        new object[] { 128, 96, 128, 0.10 },  // N%4==0 -> vec4
+        new object[] { 256, 256, 64, 0.05 },  // N%4==0 -> vec4
+        new object[] { 100, 70, 1, 0.30 },    // N=1 (SpMV-like), N<=64 -> warp
+        new object[] { 200, 100, 130, 0.08 }, // N>64, N%4!=0 -> 2-D scalar
     };
 
     [SkippableTheory]

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuSpMMBenchHarness.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuSpMMBenchHarness.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using AiDotNet.Tensors.Engines.DirectGpu.CUDA;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.Tests.Engines.BlasManaged;
+using AiDotNet.Tensors.Tests.Engines.BlasManaged.Catalog;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
+
+/// <summary>
+/// Authoritative GPU SpMM bench (#515, P6 final step): times AiDotNet's managed CUDA
+/// CSR kernels (csr_spmm / _warp / _vec4, picked by <see cref="CudaSparseBackend"/>'s
+/// heuristic) against native cuSPARSE <c>cusparseSpMM</c> over the
+/// <see cref="SpecializedShapeCatalog.SpMM"/> workload shapes, and prints the win rate
+/// + max-loss multiple the owner freezes into <see cref="SpecializedPerfBar"/>'s
+/// <c>GpuSpMM*</c> constants. Once frozen, this also gates: custom must clear the bar.
+///
+/// <para>Runner-only: gated on <c>AIDOTNET_PERF_RUNNER=1</c> (the authoritative GPU
+/// runner) AND a usable CUDA driver — it no-ops/skips everywhere else, so it can't
+/// fabricate numbers on hardware that can't run the kernels. Shapes are benched in
+/// FP32 (the precision the cuSPARSE host wrapper compares at); the FP64 kernel's
+/// correctness is covered by the parity tests, not here.</para>
+/// </summary>
+[Trait("Category", "Perf")]
+public class GpuSpMMBenchHarness
+{
+    private readonly ITestOutputHelper _out;
+    public GpuSpMMBenchHarness(ITestOutputHelper o) => _out = o;
+
+    [SkippableFact]
+    public void Bench_CustomVsCuSparse_FreezeGpuSpMMBar()
+    {
+        Skip.IfNot(Environment.GetEnvironmentVariable("AIDOTNET_PERF_RUNNER") == "1",
+            "Set AIDOTNET_PERF_RUNNER=1 on the authoritative GPU runner to bench GPU SpMM.");
+        Skip.IfNot(CudaSparseBackend.IsAvailable, "CUDA driver/NVRTC not available on this host.");
+
+        bool haveCuSparse = CuSparseBackend.IsAvailable;
+        _out.WriteLine($"custom = managed CUDA csr_spmm/_warp/_vec4 ; cuSPARSE available = {haveCuSparse}");
+        _out.WriteLine($"{"shape",-32}{"nnz",11}{"custom GF/s",14}{"cuSPARSE GF/s",16}{"ratio",9}");
+
+        var rng = RandomHelper.CreateSeededRandom(515);
+        int wins = 0, compared = 0;
+        double maxLoss = 1.0;
+
+        foreach (var s in SpecializedShapeCatalog.SpMM)
+        {
+            double density = s.DensityPercent / 100.0;
+            var (rowPtr, colIdx) = BuildCsr(s.Rows, s.Cols, density, rng, out int nnz);
+            var vals = RandF(nnz, rng);
+            var b = RandF(s.Cols * s.N, rng);
+            double flop = 2.0 * nnz * s.N;
+
+            double customMs = MinMs(20, () => CudaSparseBackend.SpMM(rowPtr, colIdx, vals, b, s.Rows, s.Cols, s.N));
+            double customGf = flop / (customMs * 1e6);
+
+            double cuGf = double.NaN;
+            string ratio = "    --";
+            if (haveCuSparse)
+            {
+                double cuMs = MinMs(20, () => CuSparseBackend.SpMM(rowPtr, colIdx, vals, b, s.Rows, s.Cols, s.N));
+                cuGf = flop / (cuMs * 1e6);
+                double r = cuMs / customMs;   // > 1 => custom faster (a win)
+                ratio = $"{r,7:F2}x";
+                compared++;
+                if (r >= 1.0) wins++; else maxLoss = Math.Max(maxLoss, 1.0 / r);
+            }
+
+            string cuCol = double.IsNaN(cuGf) ? "--" : cuGf.ToString("F1");
+            _out.WriteLine($"{s.Name,-32}{nnz,11}{customGf,14:F1}{cuCol,16}{ratio,9}");
+        }
+
+        if (compared == 0)
+        {
+            _out.WriteLine("cuSPARSE unavailable — custom throughput reported only; the bar needs a cuSPARSE baseline to freeze.");
+            return;
+        }
+
+        int winRate = (int)Math.Round(100.0 * wins / compared);
+        _out.WriteLine("");
+        _out.WriteLine($"=> custom wins {wins}/{compared} = {winRate}% ; max loss {maxLoss:F2}x");
+        _out.WriteLine($"=> FREEZE into SpecializedPerfBar: GpuSpMMMinWinRatePercent = {winRate}; GpuSpMMMaxLossMultiple = {maxLoss:F2}");
+
+        if (SpecializedPerfBar.GpuSpMMBarFrozen)
+        {
+            Assert.True(winRate >= SpecializedPerfBar.GpuSpMMMinWinRatePercent,
+                $"GPU SpMM win rate {winRate}% < frozen bar {SpecializedPerfBar.GpuSpMMMinWinRatePercent}%.");
+            Assert.True(maxLoss <= SpecializedPerfBar.GpuSpMMMaxLossMultiple,
+                $"GPU SpMM max loss {maxLoss:F2}x > frozen bar {SpecializedPerfBar.GpuSpMMMaxLossMultiple}x.");
+        }
+        else
+        {
+            _out.WriteLine("(GpuSpMM bar not yet frozen — informational run; set the constants above to start gating.)");
+        }
+    }
+
+    private static double MinMs(int iters, Action f)
+    {
+        for (int i = 0; i < 3; i++) f();   // warmup (JIT/NVRTC + caches)
+        double m = double.MaxValue;
+        for (int i = 0; i < iters; i++)
+        {
+            var sw = Stopwatch.StartNew();
+            f();
+            sw.Stop();
+            m = Math.Min(m, sw.Elapsed.TotalMilliseconds);
+        }
+        return m;
+    }
+
+    private static (int[] rowPtr, int[] colIdx) BuildCsr(int rows, int cols, double density, Random rng, out int nnz)
+    {
+        var rowPtr = new int[rows + 1];
+        var colList = new List<int>();
+        for (int r = 0; r < rows; r++)
+        {
+            rowPtr[r] = colList.Count;
+            for (int c = 0; c < cols; c++)
+                if (rng.NextDouble() < density) colList.Add(c);
+        }
+        rowPtr[rows] = colList.Count;
+        nnz = colList.Count;
+        return (rowPtr, colList.ToArray());
+    }
+
+    private static float[] RandF(int len, Random rng)
+    {
+        var a = new float[len];
+        for (int i = 0; i < len; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+        return a;
+    }
+}


### PR DESCRIPTION
## What & why

Two remaining **#515 (P6)** pieces, both validatable on your NVIDIA runner:

### 128-bit vectorized-load kernel (wired + parity-tested)
- New **`csr_spmm_vec4`**: each thread computes 4 adjacent output columns via aligned `float4` dense loads (gated on `N % 4 == 0`, which guarantees 16-byte alignment given cudaMalloc's 256-byte base). Same per-output reduction order as `csr_spmm` → deterministic + parity-checkable. New `CsrSpMMVec4` launch.
- `CudaSparseBackend` float heuristic is now: `N%4==0 → vec4`, else `N≤64 → warp`, else `2-D scalar`. The parity tests add an `N=130` case so **vec4 / warp / scalar are all covered**.

### Bench harness — unblocks the bar + the P7 decision
- `SpecializedPerfBar` gains `GpuSpMM{MinWinRatePercent, MaxLossMultiple, BarFrozen}` placeholders (custom vs cuSPARSE).
- New **`GpuSpMMBenchHarness`** (`AIDOTNET_PERF_RUNNER=1` + CUDA gated): times the managed kernels vs `cusparseSpMM` over the `SpecializedShapeCatalog.SpMM` workload shapes (GNN/RecSys), prints per-shape **GF/s + ratio** and the exact **win-rate / max-loss numbers to paste into the bar**. Once you freeze the bar, the same harness *gates* (custom must clear it). It no-ops off the runner — it cannot fabricate numbers on hardware that can't run the kernels.

## How you'd use it on the runner

```
AIDOTNET_PERF_RUNNER=1 dotnet test --filter "FullyQualifiedName~GpuSpMMBenchHarness"
```

→ reads off `GpuSpMMMinWinRatePercent` / `GpuSpMMMaxLossMultiple`, you set them in a one-line gating commit, and P7 (cuSPARSE/rocSPARSE removal) unblocks once that's green.

## Verification

| Check | Result |
|---|---|
| Library + tests compile net10.0 + net471 | ✅ 0 errors |
| GPU parity tests + bench (this host) | ✅ skip (no NVRTC) |
| Existing sparse suite (net10.0) | ✅ pass |

Kernel correctness/perf + the actual bar numbers come from the self-hosted runner (`ns107444`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)