### PR TITLE
perf: per-array weight-cache invalidation — InferenceWeightCache.Invalidate(array)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -12639,9 +12639,19 @@ public partial class CpuEngine : ITensorLevelEngine
     // (bumped via Engines.InferenceWeightCache.InvalidateAll()).
     private sealed class KernelTransposeEntry
     {
-        internal KernelTransposeEntry(float[] data, long epoch) { Data = data; Epoch = epoch; }
+        internal KernelTransposeEntry(float[] data, long epoch, long sourceVersion)
+        {
+            Data = data;
+            Epoch = epoch;
+            SourceVersion = sourceVersion;
+        }
+
         internal readonly float[] Data;
         internal readonly long Epoch;
+        // Per-array mutation version at build time — targeted invalidation
+        // via InferenceWeightCache.Invalidate(array) (see
+        // SimdGemm.MarkWeightDirty). Checked alongside the global epoch.
+        internal readonly long SourceVersion;
     }
 
     private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<float[], KernelTransposeEntry>
@@ -12855,8 +12865,13 @@ public partial class CpuEngine : ITensorLevelEngine
         static float[] GetOrBuildTransposedKernel(float[] kernel, int rows, int cols)
         {
             long epoch = AiDotNet.Tensors.Engines.Simd.SimdGemm.WeightCacheEpoch;
-            if (_kernelTransposeCache.TryGetValue(kernel, out var entry) && entry.Epoch == epoch)
+            long sourceVersion = AiDotNet.Tensors.Engines.Simd.SimdGemm.WeightArrayVersionOf(kernel);
+            if (_kernelTransposeCache.TryGetValue(kernel, out var entry)
+                && entry.Epoch == epoch
+                && entry.SourceVersion == sourceVersion)
+            {
                 return entry.Data;
+            }
 
             // Stale (weights mutated in place since the transpose was built)
             // or missing — rebuild from the live kernel contents. Remove+
@@ -12868,7 +12883,7 @@ public partial class CpuEngine : ITensorLevelEngine
             {
                 var kernelT = new float[cols * rows];
                 TransposeFloatParallel(k, 0, kernelT, 0, rows, cols);
-                return new KernelTransposeEntry(kernelT, epoch);
+                return new KernelTransposeEntry(kernelT, epoch, sourceVersion);
             }).Data;
         }
 

--- a/src/AiDotNet.Tensors/Engines/InferenceWeightCache.cs
+++ b/src/AiDotNet.Tensors/Engines/InferenceWeightCache.cs
@@ -37,9 +37,31 @@ public static class InferenceWeightCache
 {
     /// <summary>
     /// Invalidate every cached derived weight form (packed GEMM panels,
-    /// int8 packs, transposed conv kernels). Call after any in-place weight
-    /// mutation so the next inference re-derives from live weight contents.
-    /// Thread-safe; O(1).
+    /// int8 packs, transposed conv kernels) for EVERY weight array in the
+    /// process. Call after a bulk in-place mutation whose touched-array set
+    /// is unknown; when the mutated arrays are known, prefer the targeted
+    /// <see cref="Invalidate(System.Array)"/> so other models' hot caches
+    /// stay warm. Thread-safe; O(1).
     /// </summary>
     public static void InvalidateAll() => Simd.SimdGemm.InvalidateCachedWeights();
+
+    /// <summary>
+    /// Invalidate the cached derived forms of ONE weight array, leaving all
+    /// other arrays' caches hot. Call after mutating that array in place
+    /// (an optimizer step on its tensor, a bulk parameter load, a layer
+    /// fusion rewrite). Preferred over <see cref="InvalidateAll"/> for
+    /// per-model invalidation in multi-model processes: a training loop
+    /// flushing globally per step would keep evicting every OTHER model's
+    /// hot packs. Thread-safe; O(1) per array. No-op for nulls and for
+    /// element types the CPU caches never derive from (only
+    /// <c>float[]</c>-sourced forms are cached today, but versions are
+    /// tracked per <see cref="System.Array"/> so future caches inherit the
+    /// contract).
+    /// </summary>
+    /// <param name="weights">The weight array that was mutated in place.</param>
+    public static void Invalidate(System.Array? weights)
+    {
+        if (weights is null || weights.Length == 0) return;
+        Simd.SimdGemm.MarkWeightDirty(weights);
+    }
 }

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
@@ -215,6 +215,43 @@ internal static partial class SimdGemm
     /// </summary>
     internal static void InvalidateCachedWeights() => System.Threading.Interlocked.Increment(ref _weightCacheEpoch);
 
+    // ─── Per-array invalidation (review AiDotNet#1488) ──────────────────────
+    // The global epoch above evicts EVERY model's derived-weight caches; a
+    // training loop calling it per optimizer step keeps evicting the hot
+    // packs of every other model in the process. Per-array versions give
+    // targeted invalidation: each weight array gets a monotonically
+    // increasing version (CWT-keyed by identity, GC'd with the array), the
+    // cache entry records the version it was built from, and every hit path
+    // — including the cross-thread MRU slots, which per-array REMOVAL could
+    // never reach — requires it to match. A hit is therefore valid iff
+    //   entry.Epoch == WeightCacheEpoch            (no global flush since)
+    //   AND entry.SourceVersion == version(array)  (this array not dirtied)
+    private sealed class WeightArrayVersion
+    {
+        internal long Version;
+    }
+
+    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<System.Array, WeightArrayVersion> _weightArrayVersions = new();
+
+    /// <summary>Current mutation version of <paramref name="weights"/>;
+    /// 0 until the first <see cref="MarkWeightDirty"/>.</summary>
+    internal static long WeightArrayVersionOf(System.Array weights)
+        => _weightArrayVersions.TryGetValue(weights, out var v)
+            ? System.Threading.Interlocked.Read(ref v.Version)
+            : 0L;
+
+    /// <summary>
+    /// Invalidate the cached derived forms of ONE weight array (packed
+    /// GEMM panels, int8 packs, transposed conv kernels built from it),
+    /// leaving every other array's caches hot. Call after mutating that
+    /// array in place.
+    /// </summary>
+    internal static void MarkWeightDirty(System.Array weights)
+    {
+        var box = _weightArrayVersions.GetValue(weights, static _ => new WeightArrayVersion());
+        System.Threading.Interlocked.Increment(ref box.Version);
+    }
+
 #if NET5_0_OR_GREATER
     // ─── Path A: pre-packed B cache ────────────────────────────────────────
     //
@@ -244,6 +281,9 @@ internal static partial class SimdGemm
         // WeightCacheEpoch value at build time. A hit is only valid while
         // this matches the current global epoch — see _weightCacheEpoch.
         internal long Epoch;
+        // WeightArrayVersionOf(b) at build time — per-array invalidation
+        // (see MarkWeightDirty). Checked alongside Epoch on every hit path.
+        internal long SourceVersion;
     }
 
     private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<float[], PrePackedB> _prePackedBCache = new();
@@ -313,6 +353,7 @@ internal static partial class SimdGemm
             PackedSubs = packedSubs,
             NumPcIters = numPcIters,
             Epoch = WeightCacheEpoch,
+            SourceVersion = WeightArrayVersionOf(b),
         };
     }
 
@@ -410,10 +451,12 @@ internal static partial class SimdGemm
             return threadCached;
 
         long epoch = WeightCacheEpoch;
+        long sourceVersion = WeightArrayVersionOf(b);
         if (_prePackedBCache.TryGetValue(b, out var existing)
             && existing.K == k && existing.N == n
             && existing.Mc == expectedMc
-            && existing.Epoch == epoch)
+            && existing.Epoch == epoch
+            && existing.SourceVersion == sourceVersion)
         {
             RememberThreadPrePackedB(b, existing);
             return existing;
@@ -425,7 +468,8 @@ internal static partial class SimdGemm
             {
                 if (existing.K == k && existing.N == n
                     && existing.Mc == expectedMc
-                    && existing.Epoch == epoch)
+                    && existing.Epoch == epoch
+                    && existing.SourceVersion == sourceVersion)
                 {
                     RememberThreadPrePackedB(b, existing);
                     return existing;
@@ -470,6 +514,11 @@ internal static partial class SimdGemm
             && valueRef.TryGetTarget(out var value)
             && value.K == k && value.N == n && value.Mc == expectedMc
             && value.Epoch == WeightCacheEpoch
+            // Per-array invalidation reaches the cross-thread MRU slots
+            // through this version comparison — the invalidating thread
+            // cannot CLEAR another thread's slot, but it CAN make the
+            // recorded SourceVersion stale.
+            && value.SourceVersion == WeightArrayVersionOf(b)
             && keyRef is not null
             && keyRef.TryGetTarget(out var key)
             && ReferenceEquals(key, b))
@@ -539,6 +588,8 @@ internal static partial class SimdGemm
         internal float Scale;
         // WeightCacheEpoch value at build time — see _weightCacheEpoch.
         internal long Epoch;
+        // WeightArrayVersionOf(b) at build time — see MarkWeightDirty.
+        internal long SourceVersion;
     }
 
     private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<float[], Int8PrePackedB> _int8PrePackedBCache = new();
@@ -606,6 +657,7 @@ internal static partial class SimdGemm
             NumPcIters = numPcIters,
             Scale = scale,
             Epoch = WeightCacheEpoch,
+            SourceVersion = WeightArrayVersionOf(b),
         };
     }
 
@@ -644,10 +696,12 @@ internal static partial class SimdGemm
     private static Int8PrePackedB GetOrBuildInt8PrePackedB(float[] b, int k, int n, int m, int expectedMc)
     {
         long epoch = WeightCacheEpoch;
+        long sourceVersion = WeightArrayVersionOf(b);
         if (_int8PrePackedBCache.TryGetValue(b, out var existing)
             && existing.K == k && existing.N == n
             && existing.Mc == expectedMc
-            && existing.Epoch == epoch)
+            && existing.Epoch == epoch
+            && existing.SourceVersion == sourceVersion)
         {
             return existing;
         }
@@ -658,7 +712,8 @@ internal static partial class SimdGemm
             {
                 if (existing.K == k && existing.N == n
                     && existing.Mc == expectedMc
-                    && existing.Epoch == epoch)
+                    && existing.Epoch == epoch
+                    && existing.SourceVersion == sourceVersion)
                 {
                     return existing;
                 }

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
@@ -307,6 +307,14 @@ internal static partial class SimdGemm
     /// </summary>
     private static PrePackedB BuildPrePackedB(float[] b, int k, int n, int m)
     {
+        // Capture the mutation version BEFORE reading any of b's contents.
+        // Stamping at the end would race MarkWeightDirty: a mutation landing
+        // mid-pack could leave PRE-mutation data stamped with the POST-
+        // mutation version, and future hits would accept the stale pack as
+        // current. Capturing first is conservatively safe — the same race
+        // then leaves the entry stamped with the OLD version, the next
+        // lookup sees a mismatch, and the pack rebuilds.
+        long sourceVersion = WeightArrayVersionOf(b);
         int Mc = ChooseAdaptiveMc(m, k, n);
         int numRowBlocks = (m + Mc - 1) / Mc;
         int maxThreads = Helpers.CpuParallelSettings.MaxDegreeOfParallelism;
@@ -353,7 +361,7 @@ internal static partial class SimdGemm
             PackedSubs = packedSubs,
             NumPcIters = numPcIters,
             Epoch = WeightCacheEpoch,
-            SourceVersion = WeightArrayVersionOf(b),
+            SourceVersion = sourceVersion,
         };
     }
 
@@ -604,6 +612,8 @@ internal static partial class SimdGemm
     /// </summary>
     private static Int8PrePackedB BuildInt8PrePackedB(float[] b, int k, int n, int m)
     {
+        // Capture BEFORE reading b — see BuildPrePackedB for the race.
+        long sourceVersion = WeightArrayVersionOf(b);
         float scale = Int8Quantizer.ComputeSymmetricScale(b);
 
         int Mc = ChooseAdaptiveMc(m, k, n);
@@ -657,7 +667,7 @@ internal static partial class SimdGemm
             NumPcIters = numPcIters,
             Scale = scale,
             Epoch = WeightCacheEpoch,
-            SourceVersion = WeightArrayVersionOf(b),
+            SourceVersion = sourceVersion,
         };
     }
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/Simd/InferenceWeightCacheInvalidationTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Simd/InferenceWeightCacheInvalidationTests.cs
@@ -50,6 +50,49 @@ public class InferenceWeightCacheInvalidationTests
     }
 
     [Fact]
+    public void SgemmWithCachedB_AfterInPlaceWeightMutation_TargetedInvalidate_UsesFreshWeights()
+    {
+        // Per-array invalidation (review AiDotNet#1488): mutating ONE weight
+        // and invalidating ONLY that array must produce fresh results for it
+        // — while a second, untouched weight keeps producing correct results
+        // throughout (its cached pack stays valid; no global eviction).
+        const int m = 8, k = 512, n = 64;
+        var rng = new Random(1488);
+        var a = new float[m * k];
+        var b1 = new float[k * n];
+        var b2 = new float[k * n];
+        for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+        for (int i = 0; i < b1.Length; i++) b1[i] = (float)(rng.NextDouble() * 2 - 1);
+        for (int i = 0; i < b2.Length; i++) b2[i] = (float)(rng.NextDouble() * 2 - 1);
+
+        // Populate caches for BOTH weights.
+        var c1 = new float[m * n];
+        var c2 = new float[m * n];
+        SimdGemm.SgemmWithCachedB(a, b1, c1, m, k, n);
+        SimdGemm.SgemmWithCachedB(a, b2, c2, m, k, n);
+        AssertMatchesNaive(a, b1, c1, m, k, n, "b1 initial");
+        AssertMatchesNaive(a, b2, c2, m, k, n, "b2 initial");
+
+        // Mutate ONLY b1; invalidate ONLY b1.
+        for (int i = 0; i < b1.Length; i++) b1[i] = -b1[i] * 0.5f + 0.25f;
+        InferenceWeightCache.Invalidate(b1);
+
+        var c1b = new float[m * n];
+        var c2b = new float[m * n];
+        SimdGemm.SgemmWithCachedB(a, b1, c1b, m, k, n);
+        SimdGemm.SgemmWithCachedB(a, b2, c2b, m, k, n);
+        AssertMatchesNaive(a, b1, c1b, m, k, n, "b1 post-targeted-invalidate");
+        AssertMatchesNaive(a, b2, c2b, m, k, n, "b2 untouched");
+    }
+
+    [Fact]
+    public void Invalidate_NullOrEmpty_IsSafeNoOp()
+    {
+        InferenceWeightCache.Invalidate(null);
+        InferenceWeightCache.Invalidate(Array.Empty<float>());
+    }
+
+    [Fact]
     public void SgemmWithCachedB_RepeatedCallsSameWeights_StayCorrect()
     {
         // Companion guard: the epoch gate must not break the steady-state


### PR DESCRIPTION
## Why

`InferenceWeightCache.InvalidateAll()` (shipped in #540) is a global epoch bump. Correct — but a training loop calling it per optimizer step evicts the derived-weight packs of **every other model in the process**, so concurrent inference keeps rebuilding hot caches. Flagged by CodeRabbit on ooples/AiDotNet#1488.

## What

Per-array mutation versions for targeted invalidation:

- Each weight array gets a monotonically increasing version (`ConditionalWeakTable<System.Array, …>`-keyed by identity, collected with the array).
- Every cache entry (`PrePackedB`, `Int8PrePackedB`, `KernelTransposeEntry`) records the version it was built from; every hit path requires it to match — **including the cross-thread MRU slots**, which per-array *removal* could never reach but a version *comparison* covers.
- A hit is valid iff `entry.Epoch == WeightCacheEpoch && entry.SourceVersion == version(array)`.

Public surface: `InferenceWeightCache.Invalidate(System.Array)` — O(1), null/empty no-op. `InvalidateAll()` retained for bulk mutations whose touched-array set is unknown.

Hit-path cost: one extra CWT `TryGetValue` per pre-pack lookup (tens of ns against multi-µs GEMMs).

## Tests

`InferenceWeightCacheInvalidationTests`: targeted invalidate refreshes the mutated array while an untouched second weight stays correct across the flush; null/empty no-op guard. 133 cache/GEMM/conv tests green locally.

Consumer: ooples/AiDotNet#1488 will route its per-model weight-update flush through `Invalidate(array)` once this releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)