### PR TITLE
perf(gpu): CUDA-graph training-step - Phase 0 (feasibility probe + 5.53x launch-overhead removal + scope)

### DIFF
--- a/docs/cuda_graph_training_step_scope.md
+++ b/docs/cuda_graph_training_step_scope.md
@@ -1,0 +1,49 @@
+# CUDA-Graph Training-Step — PR Scope
+
+## Goal
+Eliminate **per-kernel launch overhead** — the proven dominant bottleneck for small-model GPU
+training in this engine. A small transformer fires hundreds of micro-kernels per step; each carries
+CPU-side launch cost the GPU can't hide (measured: RTX 3080 cortex training sits at ~8–30% util with
+the GPU memory-controller ~0%, and the fused fwd+bwd+update path is already engaged yet still
+launch-bound). Capturing the *repeated* per-step GPU kernel sequence into a `cudaGraph` and replaying
+it with a single `cuGraphLaunch` collapses N launches into 1.
+
+## What's already in place (de-risked)
+- **Graph bindings exist**: `cuStreamBeginCapture` / `cuStreamEndCapture` / `cuGraphInstantiateWithFlags`
+  / `cuGraphLaunch` / `cuGraphExecDestroy` / `cuGraphDestroy` / `cuStreamIsCapturing` (CudaNativeBindings).
+- **Single stream**: the backend issues every op + cuBLAS on one `_stream` → a capturable sequence.
+- **Compute ops don't sync**: `Synchronize()` was removed from compute paths; only **downloads**
+  (`cuMemcpyDtoH`) are synchronous. → Compute sequences are capturable; **host downloads are the only
+  capture-blockers.**
+- **Phase-0 probe (this PR)**: `CudaBackend.RunCudaGraphProbe()` (env `AIDOTNET_CUDA_GRAPH_PROBE=1`)
+  captures a pure-GPU op sequence and measures graph-replay vs individual-launch latency — proving
+  capture works on this stream and quantifying the launch-overhead removal that bounds the whole effort.
+
+## Hard prerequisites (CUDA graph capture forbids host interaction in the captured region)
+1. **No host reads/downloads inside the step** — the tape-walk's intermediate reads, the per-step loss
+   readback, and the CPU optimizer reading gradients all break capture. Must be removed/relocated.
+2. **Stable device buffers across steps** (same pointers) — no per-step `cuMemAlloc`/`cuMemFree`/realloc.
+   `InvalidateAllWeightCaches` (dispose+realloc every weight each step) **violates this** and must become
+   an **in-place GPU weight update**.
+3. **Re-runnable with changed data** — overwrite the *same* input buffer's contents each step
+   (`cuMemcpyHtoD` into the stable input buffer) then `cuGraphLaunch`; re-instantiate / `cuGraphExecUpdate`
+   only on shape change.
+
+## Phased plan
+- **Phase 0 — feasibility + benefit probe** *(this PR)*: bindings confirmed; probe measures replay speedup.
+  Decision gate: if replay removes a large fraction of launch cost, proceed; else stop here with evidence.
+- **Phase 1 — host-read-free step**: apply the optimizer update **on the GPU** (fused Adam kernel; no
+  gradient download); defer the loss-scalar readback to every-N-steps so the step has zero host reads.
+  Start from the already-engaged fused-compiled fwd+bwd+update path.
+- **Phase 2 — stable buffers**: replace `InvalidateAllWeightCaches` with in-place weight overwrite (no
+  realloc); pin activation/gradient buffers (stable pointers) via the buffer pool across steps.
+- **Phase 3 — capture/replay**: step 1 → `BeginCapture` → run host-read-free step → `EndCapture` →
+  `Instantiate`. Steps 2+ → upload batch into the stable input buffer → `cuGraphLaunch`. Re-capture on
+  shape change.
+- **Phase 4 — validate**: loss-parity vs eager, util/throughput, multi-config; ship behind a flag, default
+  on for CUDA once parity holds.
+
+## Risk / size
+**High risk, multi-phase (~several PRs).** Phases 1–2 (GPU-resident optimizer + stable buffers) are
+themselves substantial and are prerequisites for any capture. This PR delivers the bindings audit, the
+scope, and the **measured feasibility/benefit probe** — the evidence that justifies (or kills) phases 1–4.

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -305,6 +305,13 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
             CompileAllKernels(device);
 
             IsAvailable = true;
+
+            // CUDA-graph feasibility/benefit probe (AIDOTNET_CUDA_GRAPH_PROBE=1): capture a pure-GPU op
+            // sequence into a cudaGraph and compare graph-replay vs individual-launch latency. Quantifies
+            // whether capture works on this stream and how much per-launch overhead replay removes — the
+            // evidence basis for the CUDA-graph training-step work. Trace-only; no effect on normal runs.
+            if (Environment.GetEnvironmentVariable("AIDOTNET_CUDA_GRAPH_PROBE") == "1")
+                RunCudaGraphProbe();
         }
         catch (Exception ex)
         {
@@ -3159,6 +3166,46 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
             args[2] = &outer;
             args[3] = &reduce;
             LaunchKernel(kernel, grid, DefaultBlockSize, args);
+        }
+    }
+
+    /// <summary>Probe (AIDOTNET_CUDA_GRAPH_PROBE=1): confirms CUDA graph capture/instantiate/launch work on
+    /// this backend's stream, and measures how much per-launch overhead graph replay removes vs issuing each
+    /// op individually. Pure-GPU op sequence (DtoD copies) — the capturable subset; downloads can't be captured.</summary>
+    private void RunCudaGraphProbe()
+    {
+        void Log(string s) => System.Diagnostics.Trace.WriteLine("[CUDA-GRAPH-PROBE] " + s);
+        IntPtr src = IntPtr.Zero, dst = IntPtr.Zero, graph = IntPtr.Zero, exec = IntPtr.Zero;
+        try
+        {
+            const ulong N = 4096;
+            Log($"alloc src={CudaNativeBindings.cuMemAlloc(out src, N)} dst={CudaNativeBindings.cuMemAlloc(out dst, N)}");
+            const int OPS = 16;
+            var rb = CudaNativeBindings.cuStreamBeginCapture(_stream, CudaNativeBindings.CU_STREAM_CAPTURE_MODE_GLOBAL);
+            for (int i = 0; i < OPS; i++) CudaNativeBindings.cuMemcpyDtoDAsync(dst, src, N, _stream);
+            var re = CudaNativeBindings.cuStreamEndCapture(_stream, out graph);
+            var ri = CudaNativeBindings.cuGraphInstantiate(out exec, graph, 0);
+            Log($"beginCapture={rb} endCapture={re} instantiate={ri} graph={graph != IntPtr.Zero} exec={exec != IntPtr.Zero}");
+            if ((int)ri != 0 || exec == IntPtr.Zero) { Log("INSTANTIATE FAILED -> capture not usable as-is on this stream"); return; }
+            CudaNativeBindings.cuGraphLaunch(exec, _stream); CudaNativeBindings.cuStreamSynchronize(_stream); // warm
+            const int REP = 2000;
+            var swG = System.Diagnostics.Stopwatch.StartNew();
+            for (int i = 0; i < REP; i++) CudaNativeBindings.cuGraphLaunch(exec, _stream);
+            CudaNativeBindings.cuStreamSynchronize(_stream); swG.Stop();
+            var swD = System.Diagnostics.Stopwatch.StartNew();
+            for (int i = 0; i < REP * OPS; i++) CudaNativeBindings.cuMemcpyDtoDAsync(dst, src, N, _stream);
+            CudaNativeBindings.cuStreamSynchronize(_stream); swD.Stop();
+            double g = swG.Elapsed.TotalMilliseconds, d = swD.Elapsed.TotalMilliseconds;
+            Log($"{REP} graph-replays ({REP * OPS} ops): {g:F1}ms  |  {REP * OPS} direct launches: {d:F1}ms");
+            Log($"VERDICT: capture WORKS; replay removes per-launch overhead -> {d / System.Math.Max(0.01, g):F2}x fewer launch-cost for the same op count");
+        }
+        catch (Exception ex) { Log("EXCEPTION " + ex.GetType().Name + ": " + ex.Message); }
+        finally
+        {
+            if (exec != IntPtr.Zero) CudaNativeBindings.cuGraphExecDestroy(exec);
+            if (graph != IntPtr.Zero) CudaNativeBindings.cuGraphDestroy(graph);
+            if (src != IntPtr.Zero) CudaNativeBindings.cuMemFree(src);
+            if (dst != IntPtr.Zero) CudaNativeBindings.cuMemFree(dst);
         }
     }
 


### PR DESCRIPTION
## CUDA-graph training-step - Phase 0 (feasibility probe + scope)

Small-model GPU training here is **launch-overhead bound**: a small transformer fires hundreds of micro-kernels per step, each with CPU launch cost the GPU can't hide (RTX 3080 cortex training sits at ~8-30% util, memory-controller ~0%, and the fused fwd+bwd+update path is already engaged yet still launch-bound). **CUDA graphs** capture the repeated per-step kernel sequence once and replay it with a single `cuGraphLaunch`.

**This Phase-0 PR adds** (no behavior change to normal runs):
- `CudaBackend.RunCudaGraphProbe()` (env `AIDOTNET_CUDA_GRAPH_PROBE=1`, Trace-only) - captures a pure-GPU op sequence into a cudaGraph and times replay vs individual launches.
- `docs/cuda_graph_training_step_scope.md` - phased plan + hard prerequisites.

**Measured (RTX 3080, CUDA 12.9):** capture/instantiate/launch all succeed; **2000 graph-replays (32000 ops) = 244.8ms vs 1354.9ms for 32000 direct launches ? replay removes ~82% of per-launch overhead (5.53x).** The graph bindings + single-stream model were already present; only downloads sync, so compute sequences are capturable and host reads are the only capture-blockers.

This is the evidence basis for the follow-on phases (host-read-free GPU-resident step -> stable buffers -> capture/replay), each gated and validated for loss-parity.

?? Generated with [Claude Code](https://claude.com/claude-code)