### PR TITLE
perf(gpu): GpuOptimizer GPU-resident step helpers for all 15 backend optimizer kernels

### DIFF
--- a/src/AiDotNet.Tensors/Engines/AiDotNetEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/AiDotNetEngine.cs
@@ -286,10 +286,16 @@ public static class AiDotNetEngine
             if (LinearAlgebra.WeightRegistry.OffloadAllocator is not null)
                 return;
 
-            var backendName = ((IEngine)gpuEngine).DirectGpu?.BackendName?.ToUpperInvariant();
+            var directGpu = ((IEngine)gpuEngine).DirectGpu;
+            var backendName = directGpu?.BackendName?.ToUpperInvariant();
             DirectGpu.IGpuOffloadAllocator? allocator = backendName switch
             {
-                "CUDA" or "NVIDIA" => new DirectGpu.CUDA.CudaOffloadAllocator(),
+                // Share the compute backend's CUDA context so pinned moment/weight
+                // buffers live in the SAME context as the optimizer kernels that
+                // read them — no cross-context access (which made the GPU-resident
+                // optimizer's host-readback sync flaky).
+                "CUDA" or "NVIDIA" => new DirectGpu.CUDA.CudaOffloadAllocator(
+                    directGpu?.Backend is DirectGpu.CUDA.CudaBackend cudaBackend ? cudaBackend.CudaContextHandle : IntPtr.Zero),
                 // Hip/Metal/OpenCl/Vulkan/WebGpu offload allocators exist but are
                 // not IGpuDevicePointerWrapper yet, so they cannot back a
                 // GPU-resident weight buffer. Leave the registry unconfigured for

--- a/src/AiDotNet.Tensors/Engines/AiDotNetEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/AiDotNetEngine.cs
@@ -186,6 +186,7 @@ public static class AiDotNetEngine
             if (supportsGpu && GpuPassesCorrectnessProbe(gpuEngine))
             {
                 Current = gpuEngine;
+                TryRegisterGpuOffloadAllocator(gpuEngine, verbose);
                 EmitLog($"[AiDotNet] GPU acceleration enabled: {gpuEngine.Name}", verbose);
                 return true;
             }
@@ -252,6 +253,67 @@ public static class AiDotNetEngine
             // Any failure (kernel build, allocation, readback, dispatch) means the
             // device can't be trusted for real work — reject it and fall back to CPU.
             return false;
+        }
+    }
+
+    /// <summary>
+    /// Auto-registers the GPU offload allocator that matches the adopted backend
+    /// so weights/optimizer-moments tagged <see cref="LinearAlgebra.WeightLifetime.GpuPinned"/>
+    /// (via <c>TensorAllocator.RentPinnedOnGpu</c>) actually become GPU-resident.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Without this, <see cref="LinearAlgebra.WeightRegistry.OffloadAllocator"/> stays
+    /// null after GPU adoption, <c>RentPinnedOnGpu</c> silently falls back to CPU-pinned
+    /// memory, <c>Tensor.TryGetGpuBuffer()</c> returns null for those tensors, and the
+    /// GPU-resident optimizer step (<c>GpuOptimizer.TryXStep</c> → <c>backend.XUpdate</c>)
+    /// can never fire — every optimizer silently runs the CPU weight update. This was the
+    /// missing keystone behind the GPU-resident-optimizer path never executing on GPU.
+    /// </para>
+    /// <para>
+    /// Only CUDA ships an offload allocator that is also an
+    /// <c>IGpuDevicePointerWrapper</c> (the contract <c>TryGetGpuBuffer</c> needs to wrap
+    /// an externally-owned device pointer), so GPU-resident weights are CUDA-only today;
+    /// other backends keep CPU-resident moments and the optimizer falls back to CPU there.
+    /// Best-effort: any failure leaves the registry unconfigured and GPU compute still works.
+    /// </para>
+    /// </remarks>
+    private static void TryRegisterGpuOffloadAllocator(DirectGpuTensorEngine gpuEngine, bool verbose)
+    {
+        try
+        {
+            // Respect an allocator a caller already configured — don't stomp it.
+            if (LinearAlgebra.WeightRegistry.OffloadAllocator is not null)
+                return;
+
+            var backendName = ((IEngine)gpuEngine).DirectGpu?.BackendName?.ToUpperInvariant();
+            DirectGpu.IGpuOffloadAllocator? allocator = backendName switch
+            {
+                "CUDA" or "NVIDIA" => new DirectGpu.CUDA.CudaOffloadAllocator(),
+                // Hip/Metal/OpenCl/Vulkan/WebGpu offload allocators exist but are
+                // not IGpuDevicePointerWrapper yet, so they cannot back a
+                // GPU-resident weight buffer. Leave the registry unconfigured for
+                // them (CPU-resident moments, CPU optimizer fallback).
+                _ => null,
+            };
+
+            if (allocator is null)
+                return;
+
+            if (!allocator.IsAvailable)
+            {
+                allocator.Dispose();
+                return;
+            }
+
+            LinearAlgebra.WeightRegistry.Configure(LinearAlgebra.WeightRegistry.CurrentOptions, allocator);
+            EmitLog($"[AiDotNet] GPU offload allocator registered ({backendName}) — weights/optimizer moments can be GPU-resident", verbose);
+        }
+        catch (Exception ex)
+        {
+            // Non-fatal: GPU compute works without GPU-resident weights; the
+            // optimizer simply keeps its CPU fallback.
+            EmitLog($"[AiDotNet] GPU offload allocator registration skipped: {ex.Message}", verbose);
         }
     }
 

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -47,6 +47,13 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     private IntPtr _stepGraphExec;
     private long _graphStepCalls;
     private bool _graphStepDisabled;
+    // Capture is sound only when EVERY forward+backward action enqueues its real
+    // work on the GPU stream. Host-only specialized closures (CPU-SIMD ReLU,
+    // host-.Data GEMM, fused/analytic/slice/batched-dW kernels) run once at capture
+    // time and are NOT re-executed by cuGraphLaunch, so their outputs would freeze.
+    // Set at build time = true only for all-generic (engine-dispatched) plans; any
+    // installed host-only specialization (incl. frozen-weight rebuild) clears it.
+    private bool _graphStepEligible;
     private const int GraphWarmupSteps = 3;   // eager first so cuBLAS workspace / lazy buffers stabilize
     private readonly Tensor<T>[] _parameters;
     private readonly Tensor<T>[] _gradients;
@@ -104,10 +111,12 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         int[]? compiledInputShape = null,
         Tensor<T>? compiledInputTensor = null,
         int[]? fusedStepIndices = null,
-        Action<IEngine>[]? fusedForwardActions = null)
+        Action<IEngine>[]? fusedForwardActions = null,
+        bool graphStepEligible = false)
     {
         _forwardActions = forwardActions;
         _backwardActions = backwardActions;
+        _graphStepEligible = graphStepEligible;
         _lossOutput = lossOutput;
         _engine = engine;
         _parameters = parameters;
@@ -144,13 +153,26 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         _gpuOptimizerBuffers.Clear();
 
         // Free the captured training-step graph, if any.
+        InvalidateCapturedStepGraph();
+    }
+
+    /// <summary>
+    /// Destroys the captured CUDA step graph (if any) and resets the warmup counter
+    /// so the next eligible Step() re-captures. MUST be called whenever the captured
+    /// kernel sequence's inputs change — optimizer reconfigure (new state buffers /
+    /// optimizer wiring) or a forward-action rebuild — otherwise replay would launch
+    /// kernels against freed or stale buffers.
+    /// </summary>
+    private void InvalidateCapturedStepGraph()
+    {
         if (_stepGraphExec != IntPtr.Zero
             && _engine is Engines.DirectGpuTensorEngine gte
             && gte.GetBackend() is Engines.DirectGpu.CUDA.CudaBackend cb)
         {
             cb.DestroyCapturedGraph(_stepGraphExec);
-            _stepGraphExec = IntPtr.Zero;
         }
+        _stepGraphExec = IntPtr.Zero;
+        _graphStepCalls = 0;
     }
 
     public Tensor<T>[] Gradients => _gradients;
@@ -177,6 +199,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             ? null
             : new HashSet<int>(_fusedStepIndices);
         var rebuiltForward = new List<Action<IEngine>>(_forwardSteps.Length);
+        bool installedSpecialization = false;
         int nextFusedGroupIdx = 0;
         for (int i = 0; i < _forwardSteps.Length; i++)
         {
@@ -202,6 +225,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             if (specialized != null)
             {
                 rebuiltForward.Add(specialized);
+                installedSpecialization = true;
             }
             else
             {
@@ -212,6 +236,14 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         }
         _forwardActions = rebuiltForward.ToArray();
         _isFrozenWeights = true;
+        // Installing host-only forward specializations makes the action set unsafe for
+        // CUDA-graph capture (they'd freeze under replay); the forward delegates also
+        // just changed identity, so drop eligibility and any captured graph.
+        if (installedSpecialization)
+        {
+            _graphStepEligible = false;
+            InvalidateCapturedStepGraph();
+        }
     }
 
     /// <inheritdoc/>
@@ -425,8 +457,10 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     {
         // Opt-in CUDA-graph replay of the whole compiled step. Narrowly gated:
         // float + CUDA backend + no grad-norm clip (a per-step host read) + no
-        // checkpointing. Anything else, or any capture failure, runs eager.
-        if (s_graphStepEnabled && !_graphStepDisabled && typeof(T) == typeof(float)
+        // checkpointing + an all-GPU-pure action set (_graphStepEligible — host-only
+        // specialized closures would freeze under replay). Anything else, or any
+        // capture failure, runs eager.
+        if (s_graphStepEnabled && !_graphStepDisabled && _graphStepEligible && typeof(T) == typeof(float)
             && _checkpointing is null && _maxGradNorm <= 0.0
             && _engine is Engines.DirectGpuTensorEngine gte
             && gte.GetBackend() is Engines.DirectGpu.CUDA.CudaBackend cb)
@@ -436,17 +470,24 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             {
                 if (_stepGraphExec == IntPtr.Zero)
                 {
-                    // Record the GPU forward+grad-zero+backward+optimizer sequence into a
-                    // graph, then launch once to actually execute THIS step (capture only
+                    // Record the GPU forward+grad-zero+backward sequence into a graph,
+                    // then launch once to actually execute THIS step (capture only
                     // records). The caller has already refreshed the persistent input
                     // buffer's CONTENTS, so the stable pointers stay valid across replays.
                     var exec = cb.CaptureGraph(() => RunGpuStepBodyForCapture(cb));
                     if (exec == IntPtr.Zero) { _graphStepDisabled = true; return StepEager(); }
                     _stepGraphExec = exec;
                     cb.LaunchCapturedGraph(exec);
+                    // The optimizer update is run eagerly (NOT captured): its closure
+                    // increments _optimizerStep and re-evaluates lrSchedule.GetLr +
+                    // Adam/AdamW bias-correction each step, and bakes those scalars into
+                    // the kernel args — a captured replay would freeze them at the
+                    // capture step. Its kernels enqueue (in order) after the graph launch.
+                    _optimizerUpdate?.Invoke();
                     return _lossOutput;
                 }
                 cb.LaunchCapturedGraph(_stepGraphExec);
+                _optimizerUpdate?.Invoke();
                 return _lossOutput;
             }
         }
@@ -455,9 +496,11 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
     /// <summary>
     /// The GPU-only body of a training step (forward → grad-zero → loss-grad reseed →
-    /// backward → optimizer), with grad-zero and loss-grad reseed done as GPU ops so a
+    /// backward), with grad-zero and loss-grad reseed done as GPU ops so a
     /// cuGraphLaunch replay re-does them (a host Array.Clear/Copy would run only at
-    /// capture time). Used solely under the captured graph path.
+    /// capture time). Used solely under the captured graph path. The optimizer update
+    /// is deliberately NOT captured — it runs eagerly in Step() so its per-step LR /
+    /// bias-correction scalars are recomputed each replay instead of frozen at capture.
     /// </summary>
     private void RunGpuStepBodyForCapture(Engines.DirectGpu.CUDA.CudaBackend cb)
     {
@@ -487,7 +530,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
         var bwd = _backwardActions;
         for (int i = 0; i < bwd.Length; i++) bwd[i](engine);
-        _optimizerUpdate?.Invoke();
+        // NOTE: _optimizerUpdate is intentionally NOT invoked here — it runs eagerly
+        // in Step() after LaunchCapturedGraph so the LR schedule / Adam bias-correction
+        // scalars are fresh per step rather than frozen at capture time.
     }
 
     private Tensor<T> StepEager()
@@ -869,6 +914,10 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         foreach (var buf in _gpuOptimizerBuffers)
             buf.Dispose();
         _gpuOptimizerBuffers.Clear();
+        // A captured step graph holds kernel nodes wired to the OLD optimizer state
+        // buffers + update; those are about to be freed/replaced, so drop it (replay
+        // would otherwise launch against freed device memory or stale wiring).
+        InvalidateCapturedStepGraph();
 
         // Pre-allocate optimizer state buffers for each parameter
         int paramCount = _parameters.Length;
@@ -1349,6 +1398,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         foreach (var buf in _gpuOptimizerBuffers)
             buf.Dispose();
         _gpuOptimizerBuffers.Clear();
+        // Drop any captured step graph wired to the old optimizer state (see
+        // ConfigureOptimizerFloat — replay would target freed/stale buffers).
+        InvalidateCapturedStepGraph();
 
         int paramCount = _parameters.Length;
         int groupCount = groupSchedules.Count;
@@ -2093,6 +2145,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         // constituent steps at the position of the first fused step in each group,
         // ensuring non-fused producers that appear before a fused block still run first.
         var allForwardActions = new List<Action<IEngine>>();
+        int genericForwardCount = 0; // engine-dispatched forward actions (for CUDA-graph eligibility)
         int nextFusedGroupIdx = 0; // index into fusedForwardActions
         for (int i = 0; i < forwardSteps.Count; i++)
         {
@@ -2148,9 +2201,15 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 var output = step.OutputBuffer;
                 var exec = step.Execute;
                 allForwardActions.Add(eng => exec(eng, output));
+                genericForwardCount++;  // engine-dispatched (GPU-pure on a GPU engine)
             }
         }
         var forwardActions = allForwardActions.ToArray();
+        // CUDA-graph eligibility (forward half): pure only if every forward action is
+        // the generic engine-dispatched form — any specialized/fused closure is
+        // host-only and would freeze under graph replay. (No forward pruning, so the
+        // count comparison is exact.)
+        bool graphForwardPure = genericForwardCount == allForwardActions.Count;
 
         // Build backward actions: specialized per-step + fused backward for fused groups
         var backwardActions = new List<Action<IEngine>>();
@@ -2270,6 +2329,14 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 gradients[i] = gradMap[parameters[i]];
         }
 
+        // CUDA-graph eligibility (backward half): pure only if every backward action
+        // is the generic engine-dispatched accumulator — analytic/slice/specialized/
+        // fused/batched-dW closures are host-only and would freeze under graph replay.
+        // Computed BEFORE pruning (pruning only removes actions, so an all-generic set
+        // stays all-generic, and a mixed set is already flagged impure here).
+        bool graphBackwardPure = genericBackwardCount == backwardActions.Count;
+        bool graphStepEligible = graphForwardPure && graphBackwardPure;
+
         // Phase 6.3: Backward pruning — skip gradient computation for non-trainable tensors
         var paramSet = new HashSet<Tensor<T>>(parameters);
         backwardActions = BackwardPruningPass.Prune(backwardActions, forwardSteps, parameters, gradMap);
@@ -2334,7 +2401,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             compiledInputShape,
             compiledInputTensor,
             fusedStepIndices.Count > 0 ? fusedStepIndices.ToArray() : null,
-            fusedForwardActions.Count > 0 ? fusedForwardActions.ToArray() : null);
+            fusedForwardActions.Count > 0 ? fusedForwardActions.ToArray() : null,
+            graphStepEligible);
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -34,6 +34,20 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     private readonly Action<IEngine>[] _backwardActions;
     private readonly Tensor<T> _lossOutput;
     private readonly IEngine _engine;
+
+    // ---- CUDA-graph capture of the whole compiled training step (opt-in, default OFF) ----
+    // When AIDOTNET_CUDA_GRAPH_STEP=1 on a CUDA float plan, the fixed forward+grad-zero+
+    // backward+optimizer kernel sequence (already on STABLE pre-allocated buffers) is
+    // captured once and replayed with a single cuGraphLaunch — collapsing hundreds of
+    // per-kernel launch overheads/step into 1 (the launch-bound bottleneck for small
+    // models). Default OFF => existing training is byte-identical; eligibility is
+    // narrowly gated and any capture failure falls back to eager permanently.
+    private static readonly bool s_graphStepEnabled =
+        System.Environment.GetEnvironmentVariable("AIDOTNET_CUDA_GRAPH_STEP") == "1";
+    private IntPtr _stepGraphExec;
+    private long _graphStepCalls;
+    private bool _graphStepDisabled;
+    private const int GraphWarmupSteps = 3;   // eager first so cuBLAS workspace / lazy buffers stabilize
     private readonly Tensor<T>[] _parameters;
     private readonly Tensor<T>[] _gradients;
     private readonly Tensor<T>[] _preAllocatedGrads;
@@ -128,6 +142,15 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         foreach (var buf in _gpuOptimizerBuffers)
             buf.Dispose();
         _gpuOptimizerBuffers.Clear();
+
+        // Free the captured training-step graph, if any.
+        if (_stepGraphExec != IntPtr.Zero
+            && _engine is Engines.DirectGpuTensorEngine gte
+            && gte.GetBackend() is Engines.DirectGpu.CUDA.CudaBackend cb)
+        {
+            cb.DestroyCapturedGraph(_stepGraphExec);
+            _stepGraphExec = IntPtr.Zero;
+        }
     }
 
     public Tensor<T>[] Gradients => _gradients;
@@ -399,6 +422,75 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Tensor<T> Step()
+    {
+        // Opt-in CUDA-graph replay of the whole compiled step. Narrowly gated:
+        // float + CUDA backend + no grad-norm clip (a per-step host read) + no
+        // checkpointing. Anything else, or any capture failure, runs eager.
+        if (s_graphStepEnabled && !_graphStepDisabled && typeof(T) == typeof(float)
+            && _checkpointing is null && _maxGradNorm <= 0.0
+            && _engine is Engines.DirectGpuTensorEngine gte
+            && gte.GetBackend() is Engines.DirectGpu.CUDA.CudaBackend cb)
+        {
+            _graphStepCalls++;
+            if (_graphStepCalls > GraphWarmupSteps)
+            {
+                if (_stepGraphExec == IntPtr.Zero)
+                {
+                    // Record the GPU forward+grad-zero+backward+optimizer sequence into a
+                    // graph, then launch once to actually execute THIS step (capture only
+                    // records). The caller has already refreshed the persistent input
+                    // buffer's CONTENTS, so the stable pointers stay valid across replays.
+                    var exec = cb.CaptureGraph(() => RunGpuStepBodyForCapture(cb));
+                    if (exec == IntPtr.Zero) { _graphStepDisabled = true; return StepEager(); }
+                    _stepGraphExec = exec;
+                    cb.LaunchCapturedGraph(exec);
+                    return _lossOutput;
+                }
+                cb.LaunchCapturedGraph(_stepGraphExec);
+                return _lossOutput;
+            }
+        }
+        return StepEager();
+    }
+
+    /// <summary>
+    /// The GPU-only body of a training step (forward → grad-zero → loss-grad reseed →
+    /// backward → optimizer), with grad-zero and loss-grad reseed done as GPU ops so a
+    /// cuGraphLaunch replay re-does them (a host Array.Clear/Copy would run only at
+    /// capture time). Used solely under the captured graph path.
+    /// </summary>
+    private void RunGpuStepBodyForCapture(Engines.DirectGpu.CUDA.CudaBackend cb)
+    {
+        var engine = _engine;
+        _preForwardParamTransform?.Invoke();
+        var fwd = _forwardActions;
+        for (int i = 0; i < fwd.Length; i++) fwd[i](engine);
+
+        int esz = System.Runtime.CompilerServices.Unsafe.SizeOf<T>();
+        if (_genericGradIndices != null)
+        {
+            for (int i = 0; i < _genericGradIndices.Length; i++)
+            {
+                int idx = _genericGradIndices[i];
+                if (_preAllocatedGrads[idx].TryGetGpuBuffer() is { } gb)
+                    cb.MemsetBuffer(gb, 0, (long)_preAllocatedGrads[idx].Length * esz);
+            }
+        }
+        else
+        {
+            for (int i = 0; i < _preAllocatedGrads.Length; i++)
+                if (_preAllocatedGrads[i].TryGetGpuBuffer() is { } gb)
+                    cb.MemsetBuffer(gb, 0, (long)_preAllocatedGrads[i].Length * esz);
+        }
+        if (_lossGradSeed.TryGetGpuBuffer() is { } seedBuf && _lossGradDest?.TryGetGpuBuffer() is { } destBuf)
+            cb.CopyBufferDtoD(seedBuf, destBuf, (long)_lossGradSeed.Length * esz);
+
+        var bwd = _backwardActions;
+        for (int i = 0; i < bwd.Length; i++) bwd[i](engine);
+        _optimizerUpdate?.Invoke();
+    }
+
+    private Tensor<T> StepEager()
     {
         var engine = _engine;
         // Two independent profile surfaces: PR #352's per-step

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Graph.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Graph.cs
@@ -29,6 +29,14 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA;
 public sealed partial class CudaBackend
 {
     /// <summary>
+    /// This backend's CUDA context handle. Exposed so the GPU offload allocator
+    /// can SHARE it (allocate pinned moment/weight buffers in the same context
+    /// as the compute kernels), avoiding cross-context access in the
+    /// GPU-resident optimizer step.
+    /// </summary>
+    internal IntPtr CudaContextHandle => _cudaContext;
+
+    /// <summary>
     /// Records the GPU kernel launches issued by <paramref name="launch"/> on this
     /// backend's stream into a CUDA graph and returns an instantiated, replayable
     /// graph-exec handle (or <see cref="IntPtr.Zero"/> on failure / unavailable GPU).

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Graph.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Graph.cs
@@ -87,6 +87,36 @@ public sealed partial class CudaBackend
             CudaNativeBindings.cuGraphLaunch(graphExec, _stream), "cuGraphLaunch");
     }
 
+    /// <summary>
+    /// Re-records <paramref name="relaunch"/> into a fresh graph and updates the
+    /// EXISTING <paramref name="graphExec"/> in place (cuGraphExecUpdate) instead of
+    /// re-instantiating. This extends graph replay to optimizers whose kernel SCALAR
+    /// args change every step — notably the Adam family's bias-correction <c>step</c>
+    /// (and AdaMax/Nadam/AMSGrad): topology is identical step-to-step, only the
+    /// scalar differs, so the update is cheap and the handle stays valid for
+    /// <see cref="LaunchCapturedGraph"/>. Returns true when the in-place update
+    /// succeeded; false means the topology diverged and the caller must re-capture
+    /// via <see cref="CaptureGraph"/> + <see cref="DestroyCapturedGraph"/>.
+    /// </summary>
+    public bool TryUpdateCapturedGraph(IntPtr graphExec, Action relaunch)
+    {
+        if (graphExec == IntPtr.Zero || relaunch is null || !IsAvailable) return false;
+        using var _ = PushContext();
+
+        if (CudaNativeBindings.cuStreamBeginCapture(_stream, CudaNativeBindings.CU_STREAM_CAPTURE_MODE_THREAD_LOCAL) != CudaResult.Success)
+            return false;
+        try { relaunch(); }
+        catch { CudaNativeBindings.cuStreamEndCapture(_stream, out var g); if (g != IntPtr.Zero) CudaNativeBindings.cuGraphDestroy(g); return false; }
+
+        if (CudaNativeBindings.cuStreamEndCapture(_stream, out var newGraph) != CudaResult.Success || newGraph == IntPtr.Zero)
+            return false;
+
+        var info = default(CudaNativeBindings.CUgraphExecUpdateResultInfo);
+        var rc = CudaNativeBindings.cuGraphExecUpdate(graphExec, newGraph, ref info);
+        CudaNativeBindings.cuGraphDestroy(newGraph);
+        return rc == CudaResult.Success && info.result == 0; // 0 == CU_GRAPH_EXEC_UPDATE_SUCCESS
+    }
+
     /// <summary>Frees a captured graph-exec handle. Safe to call with <see cref="IntPtr.Zero"/>.</summary>
     public void DestroyCapturedGraph(IntPtr graphExec)
     {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Graph.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Graph.cs
@@ -125,6 +125,37 @@ public sealed partial class CudaBackend
         CudaNativeBindings.cuGraphExecDestroy(graphExec);
     }
 
+    /// <summary>
+    /// Host→device copy of raw bytes into a byte/blob GPU buffer (e.g. the int8
+    /// quantized moments and double per-block scales of the 8-bit optimizer).
+    /// </summary>
+    public unsafe void UploadBytes(IGpuBuffer buffer, byte[] data)
+    {
+        if (buffer is null) throw new ArgumentNullException(nameof(buffer));
+        if (data is null) throw new ArgumentNullException(nameof(data));
+        using var _ = PushContext();
+        fixed (byte* src = data)
+        {
+            CuBlasNative.CheckCudaResult(
+                CuBlasNative.cuMemcpyHtoD(buffer.Handle, (IntPtr)src, (ulong)data.Length), "cuMemcpyHtoD(bytes)");
+        }
+    }
+
+    /// <summary>Device→host copy of raw bytes (synchronizes the compute stream first).</summary>
+    public unsafe byte[] DownloadBytes(IGpuBuffer buffer, int byteCount)
+    {
+        if (buffer is null) throw new ArgumentNullException(nameof(buffer));
+        using var _ = PushContext();
+        CuBlasNative.CheckCudaResult(CudaNativeBindings.cuStreamSynchronize(_stream), "cuStreamSynchronize(downloadBytes)");
+        var dst = new byte[byteCount];
+        fixed (byte* d = dst)
+        {
+            CuBlasNative.CheckCudaResult(
+                CuBlasNative.cuMemcpyDtoH((IntPtr)d, buffer.Handle, (ulong)byteCount), "cuMemcpyDtoH(bytes)");
+        }
+        return dst;
+    }
+
     /// <summary>True while this backend's stream is mid-capture (diagnostics).</summary>
     public bool IsStreamCapturing()
     {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Graph.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Graph.cs
@@ -156,6 +156,34 @@ public sealed partial class CudaBackend
         return dst;
     }
 
+    /// <summary>
+    /// Sets <paramref name="byteCount"/> bytes of <paramref name="buffer"/> to
+    /// <paramref name="value"/> on the compute stream (cuMemsetD8Async). Used by the
+    /// compiled-training-step graph capture to zero accumulating gradient buffers AS
+    /// A GPU OP inside the captured sequence — a host-side Array.Clear would not be
+    /// replayed by cuGraphLaunch, so the grads would accumulate across replays.
+    /// </summary>
+    public void MemsetBuffer(IGpuBuffer buffer, byte value, long byteCount)
+    {
+        if (buffer is null || byteCount <= 0) return;
+        using var _ = PushContext();
+        CuBlasNative.CheckCudaResult(
+            CudaNativeBindings.cuMemsetD8Async(buffer.Handle, value, (ulong)byteCount, _stream), "cuMemsetD8Async");
+    }
+
+    /// <summary>
+    /// Async device→device copy on the compute stream (cuMemcpyDtoDAsync). The
+    /// synchronous CopyBuffer/cuMemcpyDtoD would abort stream capture, so the
+    /// graph-captured step re-seeds the loss gradient through this instead.
+    /// </summary>
+    public void CopyBufferDtoD(IGpuBuffer source, IGpuBuffer destination, long byteCount)
+    {
+        if (source is null || destination is null || byteCount <= 0) return;
+        using var _ = PushContext();
+        CuBlasNative.CheckCudaResult(
+            CudaNativeBindings.cuMemcpyDtoDAsync(destination.Handle, source.Handle, (ulong)byteCount, _stream), "cuMemcpyDtoDAsync(graph)");
+    }
+
     /// <summary>True while this backend's stream is mid-capture (diagnostics).</summary>
     public bool IsStreamCapturing()
     {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Graph.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Graph.cs
@@ -1,0 +1,99 @@
+using System;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA;
+
+/// <summary>
+/// CUDA-graph capture/replay (training-step Phase 3). Collapses a repeated,
+/// pure-GPU kernel sequence into a single <c>cuGraphLaunch</c>, removing the
+/// per-kernel CPU launch overhead that dominates small-model GPU training
+/// (the Phase-0 probe measured ~5.5× launch-overhead removal on this stream).
+/// </summary>
+/// <remarks>
+/// Contract for a capturable region (CUDA forbids host interaction during capture):
+/// <list type="bullet">
+/// <item>PURE GPU — no host reads / <c>cuMemcpyDtoH</c> / synchronizes inside the captured action.</item>
+/// <item>STABLE device buffers — the captured kernels' pointer args are frozen at
+/// capture time; replay re-runs the same kernels on the same buffers. To feed new
+/// data each step, overwrite the SAME input buffer's CONTENTS (<c>cuMemcpyHtoD</c>
+/// into the stable pointer) before <see cref="LaunchCapturedGraph"/>; the pointer is
+/// unchanged so the graph stays valid.</item>
+/// <item>Scalar-by-value kernel args are also frozen at capture (e.g. Adam's bias-
+/// correction <c>step</c>). Sequences whose scalar args change every step
+/// (Adam/AdamW/AdaMax/Nadam/LAMB/AMSGrad) need re-capture or <c>cuGraphExecUpdate</c>;
+/// the step-free optimizers (SGD/Momentum/NAG/LARS/RMSprop/Adagrad/AdaDelta/Lion/FTRL)
+/// replay bit-exact.</item>
+/// </list>
+/// The GPU-resident optimizer (in-place weight + moment update, no gradient download)
+/// is what makes the optimizer portion of a step host-read-free and thus capturable.
+/// </remarks>
+public sealed partial class CudaBackend
+{
+    /// <summary>
+    /// Records the GPU kernel launches issued by <paramref name="launch"/> on this
+    /// backend's stream into a CUDA graph and returns an instantiated, replayable
+    /// graph-exec handle (or <see cref="IntPtr.Zero"/> on failure / unavailable GPU).
+    /// The caller owns the handle and must free it with
+    /// <see cref="DestroyCapturedGraph"/>.
+    /// </summary>
+    public IntPtr CaptureGraph(Action launch)
+    {
+        if (!IsAvailable || launch is null) return IntPtr.Zero;
+        using var _ = PushContext();
+
+        var rc = CudaNativeBindings.cuStreamBeginCapture(_stream, CudaNativeBindings.CU_STREAM_CAPTURE_MODE_THREAD_LOCAL);
+        if (rc != CudaResult.Success) return IntPtr.Zero;
+
+        // If the action throws, abort the capture so the stream is not left in
+        // capturing state (which would break every subsequent op on it).
+        try
+        {
+            launch();
+        }
+        catch
+        {
+            CudaNativeBindings.cuStreamEndCapture(_stream, out var abortedGraph);
+            if (abortedGraph != IntPtr.Zero) CudaNativeBindings.cuGraphDestroy(abortedGraph);
+            return IntPtr.Zero;
+        }
+
+        rc = CudaNativeBindings.cuStreamEndCapture(_stream, out var graph);
+        if (rc != CudaResult.Success || graph == IntPtr.Zero) return IntPtr.Zero;
+
+        rc = CudaNativeBindings.cuGraphInstantiate(out var graphExec, graph, 0UL);
+        CudaNativeBindings.cuGraphDestroy(graph); // exec holds its own copy; the template graph is no longer needed
+        if (rc != CudaResult.Success) return IntPtr.Zero;
+
+        return graphExec;
+    }
+
+    /// <summary>
+    /// Replays a previously <see cref="CaptureGraph"/>'d sequence with a single
+    /// <c>cuGraphLaunch</c> on this backend's stream. Refresh any input-buffer
+    /// CONTENTS (same pointers) before calling to feed new per-step data.
+    /// </summary>
+    public void LaunchCapturedGraph(IntPtr graphExec)
+    {
+        if (graphExec == IntPtr.Zero) return;
+        using var _ = PushContext();
+        CuBlasNative.CheckCudaResult(
+            CudaNativeBindings.cuGraphLaunch(graphExec, _stream), "cuGraphLaunch");
+    }
+
+    /// <summary>Frees a captured graph-exec handle. Safe to call with <see cref="IntPtr.Zero"/>.</summary>
+    public void DestroyCapturedGraph(IntPtr graphExec)
+    {
+        if (graphExec == IntPtr.Zero) return;
+        using var _ = PushContext();
+        CudaNativeBindings.cuGraphExecDestroy(graphExec);
+    }
+
+    /// <summary>True while this backend's stream is mid-capture (diagnostics).</summary>
+    public bool IsStreamCapturing()
+    {
+        if (!IsAvailable) return false;
+        using var _ = PushContext();
+        if (CudaNativeBindings.cuStreamIsCapturing(_stream, out int status) != CudaResult.Success)
+            return false;
+        return status != 0;
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -10113,6 +10113,41 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         LaunchKernel(kernel, grid, DefaultBlockSize, args);
     }
 
+    /// <summary>
+    /// 8-bit Adam blockwise update in place on the GPU. mQ/vQ are int8 quantized
+    /// moments (one byte per element); mScales/vScales are one double per block.
+    /// One CUDA block per quant block, 256 threads, shared-memory maxAbs reduction.
+    /// Matches the CPU Adam8BitOptimizer's CompressBothMoments / percentile>=100 /
+    /// deterministic-rounding path.
+    /// </summary>
+    public unsafe void Adam8BitUpdate(IGpuBuffer param, IGpuBuffer gradient,
+        IGpuBuffer mQuant, IGpuBuffer vQuant, IGpuBuffer mScales, IGpuBuffer vScales,
+        float learningRate, float beta1, float beta2, float epsilon,
+        float oneMinusBeta1, float oneMinusBeta2, float biasCorrection1, float biasCorrection2,
+        int blockSize, int paramLength, int numBlocks)
+    {
+        if (param is null) throw new ArgumentNullException(nameof(param));
+        if (gradient is null) throw new ArgumentNullException(nameof(gradient));
+        if (mQuant is null || vQuant is null || mScales is null || vScales is null)
+            throw new ArgumentNullException(nameof(mQuant));
+        if (paramLength <= 0 || blockSize <= 0 || numBlocks <= 0)
+            throw new ArgumentOutOfRangeException(nameof(paramLength));
+
+        if (!_kernelCache.TryGetValue("adam8bit_update", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: adam8bit_update");
+
+        using var _ = PushContext();
+        IntPtr pPtr = param.Handle, gPtr = gradient.Handle;
+        IntPtr mqPtr = mQuant.Handle, vqPtr = vQuant.Handle, msPtr = mScales.Handle, vsPtr = vScales.Handle;
+        void** args = stackalloc void*[17];
+        args[0] = &pPtr; args[1] = &gPtr; args[2] = &mqPtr; args[3] = &vqPtr; args[4] = &msPtr; args[5] = &vsPtr;
+        args[6] = &learningRate; args[7] = &beta1; args[8] = &beta2; args[9] = &epsilon;
+        args[10] = &oneMinusBeta1; args[11] = &oneMinusBeta2; args[12] = &biasCorrection1; args[13] = &biasCorrection2;
+        args[14] = &blockSize; args[15] = &paramLength; args[16] = &numBlocks;
+        // One CUDA block per quant block (256 threads); the kernel grid-strides within each.
+        LaunchKernel(kernel, (uint)numBlocks, 256u, args);
+    }
+
     /// <inheritdoc/>
     public unsafe void AdadeltaUpdate(IGpuBuffer param, IGpuBuffer gradient, IGpuBuffer accumGrad, IGpuBuffer accumUpdate,
         float rho, float epsilon, float weightDecay, int size)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -707,6 +707,15 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         // Compile SNN kernels (STDP, spike traces, RBF, PRNG, 2:4 structured sparsity)
         _snnModule = CompileKernelModule(device, CudaSnnKernels.GetSource(), "snn_kernels", CudaSnnKernels.GetKernelNames());
 
+        // Compile GPU-resident optimizer kernels (adam/adamw/sgd/momentum/nag/
+        // adagrad/rmsprop/adadelta/adamax/nadam/lamb/lars/lion/amsgrad/ftrl
+        // *_update). Without this the in-place GPU optimizer step (GpuOptimizer.
+        // TryXStep → IDirectGpuBackend.XUpdate) throws "CUDA kernel not found:
+        // <name>_update" for every kernel that is NOT also duplicated into the
+        // neuralnet module (adam/adagrad/rmsprop/lamb/adamw/sgd/... were dead),
+        // so every optimizer silently fell back to the CPU weight update.
+        CompileKernelModule(device, CudaOptimizerKernels.GetSource(), "optimizer_kernels", CudaOptimizerKernels.GetKernelNames());
+
         // Compile reduction kernels (mean, variance, std, norm, logsumexp, product, cumsum)
         CompileKernelModule(device, CudaReductionKernels.GetSource(), "reduction_kernels", CudaReductionKernels.GetKernelNames());
 
@@ -1093,6 +1102,19 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
             throw new ArgumentException("Destination array is too small.", nameof(destination));
 
         using var _ = PushContext();
+
+        // Synchronize the compute stream before the device→host copy. Kernels
+        // launch on `_stream` (a non-default stream), but cuMemcpyDtoH below
+        // issues on the null stream. With a non-blocking compute stream the
+        // null stream does NOT implicitly wait for it, so the copy can race
+        // ahead of a just-launched kernel and read stale device memory — most
+        // visibly the in-place GPU-resident optimizer update, whose write would
+        // then be silently lost on the immediately-following host read (the
+        // value oscillated run-to-run between updated and pre-step). One stream
+        // sync on the host-read path (already a synchronization point) closes
+        // the race with no effect on the GPU-resident training hot path.
+        CuBlasNative.CheckCudaResult(CudaNativeBindings.cuStreamSynchronize(_stream), "cuStreamSynchronize(download)");
+
         ulong byteSize = (ulong)(buffer.Size * sizeof(float));
 
         unsafe

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -10096,6 +10096,14 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         if (gradient is null) throw new ArgumentNullException(nameof(gradient));
         if (size <= 0)
             throw new ArgumentOutOfRangeException(nameof(size), "Size must be positive.");
+        // Validate device-buffer capacity before launch: GpuOptimizer passes p.Length
+        // for `size` without cross-checking the gradient buffer, so a shape mismatch
+        // (gradient.Size < size) would otherwise read past gradient.Handle — an illegal
+        // device access / silent corruption instead of a clear managed exception.
+        if (param.Size < size)
+            throw new ArgumentException($"param buffer too small: capacity={param.Size}, required={size}.", nameof(param));
+        if (gradient.Size < size)
+            throw new ArgumentException($"gradient buffer too small: capacity={gradient.Size}, required={size}.", nameof(gradient));
 
         if (!_kernelCache.TryGetValue("proximal_l1_update", out var kernel))
             throw new InvalidOperationException("CUDA kernel not found: proximal_l1_update");

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -10085,6 +10085,34 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         LaunchKernel(kernel, grid, DefaultBlockSize, args);
     }
 
+    /// <summary>
+    /// Proximal gradient (ISTA) step with L1 soft-threshold prox, in place on the GPU:
+    /// <c>tmp = param - lr*grad; param = sign(tmp)*max(|tmp| - l1Strength, 0)</c>.
+    /// </summary>
+    public unsafe void ProximalL1Update(IGpuBuffer param, IGpuBuffer gradient,
+        float learningRate, float l1Strength, int size)
+    {
+        if (param is null) throw new ArgumentNullException(nameof(param));
+        if (gradient is null) throw new ArgumentNullException(nameof(gradient));
+        if (size <= 0)
+            throw new ArgumentOutOfRangeException(nameof(size), "Size must be positive.");
+
+        if (!_kernelCache.TryGetValue("proximal_l1_update", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: proximal_l1_update");
+
+        using var _ = PushContext();
+        uint grid = (uint)((size + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr paramPtr = param.Handle;
+        IntPtr gradPtr = gradient.Handle;
+        void** args = stackalloc void*[5];
+        args[0] = &paramPtr;
+        args[1] = &gradPtr;
+        args[2] = &learningRate;
+        args[3] = &l1Strength;
+        args[4] = &size;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
     /// <inheritdoc/>
     public unsafe void AdadeltaUpdate(IGpuBuffer param, IGpuBuffer gradient, IGpuBuffer accumGrad, IGpuBuffer accumUpdate,
         float rho, float epsilon, float weightDecay, int size)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaNativeBindings.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaNativeBindings.cs
@@ -239,6 +239,9 @@ internal static class CudaNativeBindings
     [DllImport(CudaLibrary, EntryPoint = "cuStreamIsCapturing")]
     public static extern CudaResult cuStreamIsCapturing(IntPtr stream, out int captureStatus);
 
+    [DllImport(CudaLibrary, EntryPoint = "cuMemsetD8Async")]
+    public static extern CudaResult cuMemsetD8Async(IntPtr dstDevice, byte uc, ulong n, IntPtr stream);
+
     /// <summary>
     /// Result of cuGraphExecUpdate_v2 (CUgraphExecUpdateResultInfo). `result` 0
     /// (CU_GRAPH_EXEC_UPDATE_SUCCESS) means the existing exec was updated in place

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaNativeBindings.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaNativeBindings.cs
@@ -239,6 +239,26 @@ internal static class CudaNativeBindings
     [DllImport(CudaLibrary, EntryPoint = "cuStreamIsCapturing")]
     public static extern CudaResult cuStreamIsCapturing(IntPtr stream, out int captureStatus);
 
+    /// <summary>
+    /// Result of cuGraphExecUpdate_v2 (CUgraphExecUpdateResultInfo). `result` 0
+    /// (CU_GRAPH_EXEC_UPDATE_SUCCESS) means the existing exec was updated in place
+    /// from the new graph — far cheaper than re-instantiating — so a captured step
+    /// whose only change is a scalar kernel arg (e.g. Adam's bias-correction step)
+    /// can be replayed across steps. Non-zero means topology changed too much and
+    /// the caller must re-instantiate.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct CUgraphExecUpdateResultInfo
+    {
+        public int result;          // CUgraphExecUpdateResult enum
+        public IntPtr errorNode;    // CUgraphNode
+        public IntPtr errorFromNode;// CUgraphNode
+    }
+
+    [DllImport(CudaLibrary, EntryPoint = "cuGraphExecUpdate_v2")]
+    public static extern CudaResult cuGraphExecUpdate(
+        IntPtr hGraphExec, IntPtr hGraph, ref CUgraphExecUpdateResultInfo resultInfo);
+
     // ──────────────────────────────────────────────────────────────
     // Multi-GPU context management
     // ──────────────────────────────────────────────────────────────

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaOffloadAllocator.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaOffloadAllocator.cs
@@ -24,7 +24,31 @@ public sealed class CudaOffloadAllocator : IGpuOffloadAllocator, IGpuDevicePoint
     // create + push our own. Field stays IntPtr.Zero until first
     // Allocate; Dispose destroys it iff non-zero.
     private IntPtr _context;
+    // True when this allocator created _context itself (standalone offload path)
+    // and must destroy it on Dispose. False when _context is SHARED with an
+    // existing CudaBackend — then the offload buffers live in the SAME context
+    // as the compute kernels (no cross-context access), so the optimizer kernel
+    // reading the pinned moments and the stream sync that orders it are in one
+    // context. Sharing must NOT destroy a context the backend still owns.
+    private readonly bool _ownsContext = true;
     private bool _disposed;
+
+    /// <summary>Standalone offload allocator — lazily creates and owns its own CUDA context.</summary>
+    public CudaOffloadAllocator() { }
+
+    /// <summary>
+    /// Offload allocator that SHARES an existing CUDA context (the compute
+    /// backend's). Pinned moment/weight buffers then live in the same context as
+    /// the kernels that read them, so cross-context access and its murky
+    /// cross-context synchronization (the source of the GPU-resident-optimizer
+    /// host-readback flakiness) are eliminated. The shared context is owned by
+    /// the caller and is NOT destroyed on <see cref="Dispose"/>.
+    /// </summary>
+    public CudaOffloadAllocator(IntPtr sharedContext)
+    {
+        _context = sharedContext;
+        _ownsContext = sharedContext == IntPtr.Zero; // zero -> behave like the default ctor (create our own)
+    }
 
     public bool IsAvailable => CudaNativeBindings.IsAvailable;
 
@@ -236,7 +260,10 @@ public sealed class CudaOffloadAllocator : IGpuOffloadAllocator, IGpuDevicePoint
                 {
                     foreach (var h in snapshot) FreeNative(h);
                 }
-                CuBlasNative.cuCtxDestroy(ctxToDestroy);
+                // Only destroy the context if WE created it. A shared backend
+                // context must outlive this allocator (the backend still uses it).
+                if (_ownsContext)
+                    CuBlasNative.cuCtxDestroy(ctxToDestroy);
             }
             else
             {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaOptimizerKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaOptimizerKernels.cs
@@ -428,6 +428,81 @@ extern ""C"" __global__ __launch_bounds__(256) void proximal_l1_update(
     float sgn = (tmp > 0.0f) ? 1.0f : ((tmp < 0.0f) ? -1.0f : 0.0f);
     param[idx] = sgn * (a > 0.0f ? a : 0.0f);
 }
+
+// ---------------------------------------------------------------------------
+// 8-bit Adam (bitsandbytes-style blockwise dynamic quantization). Matches the
+// CPU Adam8BitOptimizer (CompressBothMoments, QuantizationPercentile>=100,
+// no stochastic rounding) per block: m is SIGNED int8 (scale=maxAbs/127, stored
+// as q+128), v is UNSIGNED int8 (scale=maxAbs/255). One CUDA block per quant
+// block; blockDim=256; shared-memory maxAbs reduction recomputes the per-block
+// scale before requantizing. Adam math is float (matching the CPU Tensor ops);
+// quant/dequant scaling is double (matching NumOps.ToDouble); rint() = round-
+// half-to-even = C# Math.Round. Launch with gridDim.x = numBlocks.
+// ---------------------------------------------------------------------------
+extern ""C"" __global__ __launch_bounds__(256) void adam8bit_update(
+    float* __restrict__ param, const float* __restrict__ gradient,
+    unsigned char* __restrict__ mQ, unsigned char* __restrict__ vQ,
+    double* __restrict__ mScales, double* __restrict__ vScales,
+    float learningRate, float beta1, float beta2, float epsilon,
+    float oneMinusBeta1, float oneMinusBeta2, float biasCorrection1, float biasCorrection2,
+    int blockSize, int paramLength, int numBlocks)
+{
+    int blk = blockIdx.x;
+    if (blk >= numBlocks) return;
+    int start = blk * blockSize;
+    int endIdx = start + blockSize; if (endIdx > paramLength) endIdx = paramLength;
+    double mScale = mScales[blk];
+    double vScale = vScales[blk];
+
+    __shared__ float sMaxM[256];
+    __shared__ float sMaxV[256];
+
+    // Phase 1: compute newM/newV, reduce per-block maxAbs for the new scales.
+    float locM = 0.0f, locV = 0.0f;
+    for (int i = start + threadIdx.x; i < endIdx; i += blockDim.x) {
+        float m_i = (float)((double)((int)mQ[i] - 128) * mScale);
+        float v_i = (float)((double)((int)vQ[i]) * vScale);
+        float g = gradient[i];
+        float newM = beta1 * m_i + oneMinusBeta1 * g;
+        float newV = beta2 * v_i + oneMinusBeta2 * (g * g);
+        locM = fmaxf(locM, fabsf(newM));
+        locV = fmaxf(locV, fabsf(newV));
+    }
+    sMaxM[threadIdx.x] = locM; sMaxV[threadIdx.x] = locV;
+    __syncthreads();
+    for (int s = blockDim.x >> 1; s > 0; s >>= 1) {
+        if (threadIdx.x < s) {
+            sMaxM[threadIdx.x] = fmaxf(sMaxM[threadIdx.x], sMaxM[threadIdx.x + s]);
+            sMaxV[threadIdx.x] = fmaxf(sMaxV[threadIdx.x], sMaxV[threadIdx.x + s]);
+        }
+        __syncthreads();
+    }
+    double newMScale = (double)sMaxM[0] / 127.0; if (newMScale < 1e-10) newMScale = 1e-10;
+    double newVScale = (double)sMaxV[0] / 255.0; if (newVScale < 1e-10) newVScale = 1e-10;
+    if (threadIdx.x == 0) { mScales[blk] = newMScale; vScales[blk] = newVScale; }
+    __syncthreads();
+
+    // Phase 2: recompute, apply bias-corrected param update, requantize.
+    for (int i = start + threadIdx.x; i < endIdx; i += blockDim.x) {
+        float m_i = (float)((double)((int)mQ[i] - 128) * mScale);
+        float v_i = (float)((double)((int)vQ[i]) * vScale);
+        float g = gradient[i];
+        float newM = beta1 * m_i + oneMinusBeta1 * g;
+        float newV = beta2 * v_i + oneMinusBeta2 * (g * g);
+
+        float mHat = newM / biasCorrection1;
+        float vHat = newV / biasCorrection2;
+        param[i] = param[i] - learningRate * mHat / (sqrtf(vHat) + epsilon);
+
+        int qm = (int)rint((double)newM / newMScale);
+        if (qm < -127) qm = -127; if (qm > 127) qm = 127;
+        mQ[i] = (unsigned char)(qm + 128);
+
+        int qv = (int)rint((double)newV / newVScale);
+        if (qv < 0) qv = 0; if (qv > 255) qv = 255;
+        vQ[i] = (unsigned char)qv;
+    }
+}
 ";
     }
 
@@ -453,7 +528,8 @@ extern ""C"" __global__ __launch_bounds__(256) void proximal_l1_update(
             "lion_update",
             "nadam_update",
             "ftrl_update",
-            "proximal_l1_update"
+            "proximal_l1_update",
+            "adam8bit_update"
         };
     }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaOptimizerKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaOptimizerKernels.cs
@@ -409,6 +409,25 @@ extern ""C"" __global__ __launch_bounds__(256) void ftrl_update(
         param[idx] = -zSign * (zAbs - l1Reg) / denom;
     }
 }
+
+// ---------------------------------------------------------------------------
+// Proximal gradient (ISTA) with L1 soft-threshold prox. Matches the CPU
+// ProximalGradientDescentOptimizer + L1Regularization path exactly:
+//   tmp = param - lr*grad;  param = sign(tmp) * max(|tmp| - l1Strength, 0)
+// Note the threshold is the raw L1 strength (not lr*strength), per L1Regularization.
+// ---------------------------------------------------------------------------
+extern ""C"" __global__ __launch_bounds__(256) void proximal_l1_update(
+    float* __restrict__ param, const float* __restrict__ gradient,
+    float learningRate, float l1Strength, int size)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= size) return;
+
+    float tmp = param[idx] - learningRate * gradient[idx];
+    float a = fabsf(tmp) - l1Strength;
+    float sgn = (tmp > 0.0f) ? 1.0f : ((tmp < 0.0f) ? -1.0f : 0.0f);
+    param[idx] = sgn * (a > 0.0f ? a : 0.0f);
+}
 ";
     }
 
@@ -433,7 +452,8 @@ extern ""C"" __global__ __launch_bounds__(256) void ftrl_update(
             "adamax_update",
             "lion_update",
             "nadam_update",
-            "ftrl_update"
+            "ftrl_update",
+            "proximal_l1_update"
         };
     }
 }

--- a/src/AiDotNet.Tensors/Engines/Gpu/GpuOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/GpuOptimizer.cs
@@ -148,15 +148,31 @@ public static class GpuOptimizer
         if (!(AiDotNetEngine.Current is DirectGpuTensorEngine e)) return false;
         if (!(e.GetBackend() is DirectGpu.CUDA.CudaBackend cb)) return false;
         int nb = (length + blockSize - 1) / blockSize;
-        mQ = cb.AllocateByteBuffer(length);
-        vQ = cb.AllocateByteBuffer(length);
-        mScales = cb.AllocateByteBuffer(nb * 8);
-        vScales = cb.AllocateByteBuffer(nb * 8);
-        var im = new byte[length]; for (int i = 0; i < length; i++) im[i] = 128; // signed-zero
-        var iv = new byte[length];                                              // unsigned-zero (already 0)
-        var isc = new byte[nb * 8]; for (int b = 0; b < nb; b++) BitConverter.GetBytes(1e-10).CopyTo(isc, b * 8);
-        cb.UploadBytes(mQ, im); cb.UploadBytes(vQ, iv);
-        cb.UploadBytes(mScales, isc); cb.UploadBytes(vScales, (byte[])isc.Clone());
+
+        // Allocate into locals first. If a later AllocateByteBuffer / UploadBytes
+        // throws (e.g. device OOM), free whatever was already allocated so the GPU
+        // buffers don't leak, leave the out-params null (no dangling references),
+        // and let the exception surface — masking an OOM as a `false` "fall back to
+        // CPU" would silently hide a real device failure.
+        DirectGpu.IGpuBuffer? lmQ = null, lvQ = null, lmScales = null, lvScales = null;
+        try
+        {
+            lmQ = cb.AllocateByteBuffer(length);
+            lvQ = cb.AllocateByteBuffer(length);
+            lmScales = cb.AllocateByteBuffer(nb * 8);
+            lvScales = cb.AllocateByteBuffer(nb * 8);
+            var im = new byte[length]; for (int i = 0; i < length; i++) im[i] = 128; // signed-zero
+            var iv = new byte[length];                                              // unsigned-zero (already 0)
+            var isc = new byte[nb * 8]; for (int b = 0; b < nb; b++) BitConverter.GetBytes(1e-10).CopyTo(isc, b * 8);
+            cb.UploadBytes(lmQ, im); cb.UploadBytes(lvQ, iv);
+            cb.UploadBytes(lmScales, isc); cb.UploadBytes(lvScales, (byte[])isc.Clone());
+        }
+        catch
+        {
+            FreeGpuBuffer(lmQ); FreeGpuBuffer(lvQ); FreeGpuBuffer(lmScales); FreeGpuBuffer(lvScales);
+            throw;
+        }
+        mQ = lmQ; vQ = lvQ; mScales = lmScales; vScales = lvScales;
         return true;
     }
 
@@ -175,7 +191,11 @@ public static class GpuOptimizer
         DirectGpu.IGpuBuffer? mQ, DirectGpu.IGpuBuffer? vQ, DirectGpu.IGpuBuffer? mScales, DirectGpu.IGpuBuffer? vScales,
         float lr, float beta1, float beta2, float epsilon, float biasCorrection1, float biasCorrection2, int blockSize)
     {
-        if (p is null || g is null) return false;
+        if (p is null) throw new ArgumentNullException(nameof(p));
+        if (g is null) throw new ArgumentNullException(nameof(g));
+        // The four state buffers are optional inputs: a null one means the caller
+        // hasn't allocated GPU-resident 8-bit Adam state, so signal CPU fallback
+        // (matching the documented contract) rather than throwing.
         if (mQ is null || vQ is null || mScales is null || vScales is null) return false;
         if (!(AiDotNetEngine.Current is DirectGpuTensorEngine e)) return false;
         if (!(e.GetBackend() is DirectGpu.CUDA.CudaBackend cb)) return false;

--- a/src/AiDotNet.Tensors/Engines/Gpu/GpuOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/GpuOptimizer.cs
@@ -113,4 +113,104 @@ public static class GpuOptimizer
         backend.SgdUpdate(pBuf, gBuf, learningRate, weightDecay: 0f, param.Length);
         return true;
     }
+
+    // ---- GPU-resident steps for the rest of the backend optimizer kernels (same contract as TryAdamStep:
+    //      returns false if not on a GPU engine or any tensor isn't GPU-resident, so the caller falls back to CPU).
+    //      All buffers must be GPU-resident; the kernel updates param + state IN PLACE with no host download. ----
+
+    public static bool TrySgdMomentumStep(Tensor<float> p, Tensor<float> g, Tensor<float> velocity, float lr, float momentum, float weightDecay)
+    {
+        if (!(AiDotNetEngine.Current is DirectGpuTensorEngine e)) return false; var b = e.GetBackend(); if (b is null) return false;
+        var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var vb = velocity?.TryGetGpuBuffer();
+        if (pb is null || gb is null || vb is null) return false;
+        b.SgdMomentumUpdate(pb, gb, vb, lr, momentum, weightDecay, p!.Length); return true;
+    }
+
+    public static bool TryRmspropStep(Tensor<float> p, Tensor<float> g, Tensor<float> squaredAvg, float lr, float rho, float epsilon, float weightDecay)
+    {
+        if (!(AiDotNetEngine.Current is DirectGpuTensorEngine e)) return false; var b = e.GetBackend(); if (b is null) return false;
+        var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var sb = squaredAvg?.TryGetGpuBuffer();
+        if (pb is null || gb is null || sb is null) return false;
+        b.RmspropUpdate(pb, gb, sb, lr, rho, epsilon, weightDecay, p!.Length); return true;
+    }
+
+    public static bool TryAdagradStep(Tensor<float> p, Tensor<float> g, Tensor<float> accum, float lr, float epsilon, float weightDecay)
+    {
+        if (!(AiDotNetEngine.Current is DirectGpuTensorEngine e)) return false; var b = e.GetBackend(); if (b is null) return false;
+        var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var ab = accum?.TryGetGpuBuffer();
+        if (pb is null || gb is null || ab is null) return false;
+        b.AdagradUpdate(pb, gb, ab, lr, epsilon, weightDecay, p!.Length); return true;
+    }
+
+    public static bool TryNagStep(Tensor<float> p, Tensor<float> g, Tensor<float> velocity, float lr, float momentum, float weightDecay)
+    {
+        if (!(AiDotNetEngine.Current is DirectGpuTensorEngine e)) return false; var b = e.GetBackend(); if (b is null) return false;
+        var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var vb = velocity?.TryGetGpuBuffer();
+        if (pb is null || gb is null || vb is null) return false;
+        b.NagUpdate(pb, gb, vb, lr, momentum, weightDecay, p!.Length); return true;
+    }
+
+    public static bool TryLarsStep(Tensor<float> p, Tensor<float> g, Tensor<float> velocity, float lr, float momentum, float weightDecay, float trustCoeff)
+    {
+        if (!(AiDotNetEngine.Current is DirectGpuTensorEngine e)) return false; var b = e.GetBackend(); if (b is null) return false;
+        var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var vb = velocity?.TryGetGpuBuffer();
+        if (pb is null || gb is null || vb is null) return false;
+        b.LarsUpdate(pb, gb, vb, lr, momentum, weightDecay, trustCoeff, p!.Length); return true;
+    }
+
+    public static bool TryLambStep(Tensor<float> p, Tensor<float> g, Tensor<float> m, Tensor<float> v, float lr, float beta1, float beta2, float epsilon, float weightDecay, int step)
+    {
+        if (!(AiDotNetEngine.Current is DirectGpuTensorEngine e)) return false; var b = e.GetBackend(); if (b is null) return false;
+        var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var mb = m?.TryGetGpuBuffer(); var vb = v?.TryGetGpuBuffer();
+        if (pb is null || gb is null || mb is null || vb is null) return false;
+        b.LambUpdate(pb, gb, mb, vb, lr, beta1, beta2, epsilon, weightDecay, step, p!.Length); return true;
+    }
+
+    public static bool TryAdadeltaStep(Tensor<float> p, Tensor<float> g, Tensor<float> accumGrad, Tensor<float> accumUpdate, float rho, float epsilon, float weightDecay)
+    {
+        if (!(AiDotNetEngine.Current is DirectGpuTensorEngine e)) return false; var b = e.GetBackend(); if (b is null) return false;
+        var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var ag = accumGrad?.TryGetGpuBuffer(); var au = accumUpdate?.TryGetGpuBuffer();
+        if (pb is null || gb is null || ag is null || au is null) return false;
+        b.AdadeltaUpdate(pb, gb, ag, au, rho, epsilon, weightDecay, p!.Length); return true;
+    }
+
+    public static bool TryAmsgradStep(Tensor<float> p, Tensor<float> g, Tensor<float> m, Tensor<float> v, Tensor<float> vMax, float lr, float beta1, float beta2, float epsilon, float weightDecay, int step)
+    {
+        if (!(AiDotNetEngine.Current is DirectGpuTensorEngine e)) return false; var b = e.GetBackend(); if (b is null) return false;
+        var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var mb = m?.TryGetGpuBuffer(); var vb = v?.TryGetGpuBuffer(); var xb = vMax?.TryGetGpuBuffer();
+        if (pb is null || gb is null || mb is null || vb is null || xb is null) return false;
+        b.AmsgradUpdate(pb, gb, mb, vb, xb, lr, beta1, beta2, epsilon, weightDecay, step, p!.Length); return true;
+    }
+
+    public static bool TryAdamaxStep(Tensor<float> p, Tensor<float> g, Tensor<float> m, Tensor<float> u, float lr, float beta1, float beta2, float epsilon, float weightDecay, int step)
+    {
+        if (!(AiDotNetEngine.Current is DirectGpuTensorEngine e)) return false; var b = e.GetBackend(); if (b is null) return false;
+        var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var mb = m?.TryGetGpuBuffer(); var ub = u?.TryGetGpuBuffer();
+        if (pb is null || gb is null || mb is null || ub is null) return false;
+        b.AdamaxUpdate(pb, gb, mb, ub, lr, beta1, beta2, epsilon, weightDecay, step, p!.Length); return true;
+    }
+
+    public static bool TryLionStep(Tensor<float> p, Tensor<float> g, Tensor<float> m, float lr, float beta1, float beta2, float weightDecay)
+    {
+        if (!(AiDotNetEngine.Current is DirectGpuTensorEngine e)) return false; var b = e.GetBackend(); if (b is null) return false;
+        var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var mb = m?.TryGetGpuBuffer();
+        if (pb is null || gb is null || mb is null) return false;
+        b.LionUpdate(pb, gb, mb, lr, beta1, beta2, weightDecay, p!.Length); return true;
+    }
+
+    public static bool TryNadamStep(Tensor<float> p, Tensor<float> g, Tensor<float> m, Tensor<float> v, float lr, float beta1, float beta2, float epsilon, float weightDecay, int step)
+    {
+        if (!(AiDotNetEngine.Current is DirectGpuTensorEngine e)) return false; var b = e.GetBackend(); if (b is null) return false;
+        var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var mb = m?.TryGetGpuBuffer(); var vb = v?.TryGetGpuBuffer();
+        if (pb is null || gb is null || mb is null || vb is null) return false;
+        b.NadamUpdate(pb, gb, mb, vb, lr, beta1, beta2, epsilon, weightDecay, step, p!.Length); return true;
+    }
+
+    public static bool TryFtrlStep(Tensor<float> p, Tensor<float> g, Tensor<float> z, Tensor<float> n, float lr, float l1Reg, float l2Reg, float beta)
+    {
+        if (!(AiDotNetEngine.Current is DirectGpuTensorEngine e)) return false; var b = e.GetBackend(); if (b is null) return false;
+        var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var zb = z?.TryGetGpuBuffer(); var nb = n?.TryGetGpuBuffer();
+        if (pb is null || gb is null || zb is null || nb is null) return false;
+        b.FtrlUpdate(pb, gb, zb, nb, lr, l1Reg, l2Reg, beta, p!.Length); return true;
+    }
 }

--- a/src/AiDotNet.Tensors/Engines/Gpu/GpuOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/GpuOptimizer.cs
@@ -132,6 +132,61 @@ public static class GpuOptimizer
         return true;
     }
 
+    /// <summary>
+    /// Allocates + initializes GPU-resident 8-bit Adam state (int8 m/v + per-block
+    /// double scales) for a parameter of <paramref name="length"/> elements. m starts
+    /// at the signed-zero byte (128), v at 0, scales at 1e-10 (matching the CPU
+    /// Adam8BitOptimizer's m_0=v_0=0 init). The caller keeps the four buffers
+    /// resident across steps and frees them with <see cref="FreeGpuBuffer"/>.
+    /// Returns false (buffers null) on any non-CUDA backend.
+    /// </summary>
+    public static bool TryAllocAdam8BitState(int length, int blockSize,
+        out DirectGpu.IGpuBuffer? mQ, out DirectGpu.IGpuBuffer? vQ,
+        out DirectGpu.IGpuBuffer? mScales, out DirectGpu.IGpuBuffer? vScales)
+    {
+        mQ = vQ = mScales = vScales = null;
+        if (!(AiDotNetEngine.Current is DirectGpuTensorEngine e)) return false;
+        if (!(e.GetBackend() is DirectGpu.CUDA.CudaBackend cb)) return false;
+        int nb = (length + blockSize - 1) / blockSize;
+        mQ = cb.AllocateByteBuffer(length);
+        vQ = cb.AllocateByteBuffer(length);
+        mScales = cb.AllocateByteBuffer(nb * 8);
+        vScales = cb.AllocateByteBuffer(nb * 8);
+        var im = new byte[length]; for (int i = 0; i < length; i++) im[i] = 128; // signed-zero
+        var iv = new byte[length];                                              // unsigned-zero (already 0)
+        var isc = new byte[nb * 8]; for (int b = 0; b < nb; b++) BitConverter.GetBytes(1e-10).CopyTo(isc, b * 8);
+        cb.UploadBytes(mQ, im); cb.UploadBytes(vQ, iv);
+        cb.UploadBytes(mScales, isc); cb.UploadBytes(vScales, (byte[])isc.Clone());
+        return true;
+    }
+
+    /// <summary>Frees a GPU buffer allocated by <see cref="TryAllocAdam8BitState"/> (safe on null / non-CUDA).</summary>
+    public static void FreeGpuBuffer(DirectGpu.IGpuBuffer? buffer)
+    {
+        if (buffer is IDisposable d) d.Dispose();
+    }
+
+    /// <summary>
+    /// GPU-resident 8-bit Adam step: dequantize → Adam → param update → requantize,
+    /// in place on the GPU (no host download of moments). CUDA-only; returns false
+    /// (→ CPU fallback) when param/grad aren't GPU-resident or any state buffer is null.
+    /// </summary>
+    public static bool TryAdam8BitStep(Tensor<float> p, Tensor<float> g,
+        DirectGpu.IGpuBuffer? mQ, DirectGpu.IGpuBuffer? vQ, DirectGpu.IGpuBuffer? mScales, DirectGpu.IGpuBuffer? vScales,
+        float lr, float beta1, float beta2, float epsilon, float biasCorrection1, float biasCorrection2, int blockSize)
+    {
+        if (p is null || g is null) return false;
+        if (mQ is null || vQ is null || mScales is null || vScales is null) return false;
+        if (!(AiDotNetEngine.Current is DirectGpuTensorEngine e)) return false;
+        if (!(e.GetBackend() is DirectGpu.CUDA.CudaBackend cb)) return false;
+        var pb = p.TryGetGpuBuffer(); var gb = g.TryGetGpuBuffer();
+        if (pb is null || gb is null) return false;
+        int nb = (p.Length + blockSize - 1) / blockSize;
+        cb.Adam8BitUpdate(pb, gb, mQ, vQ, mScales, vScales,
+            lr, beta1, beta2, epsilon, 1f - beta1, 1f - beta2, biasCorrection1, biasCorrection2, blockSize, p.Length, nb);
+        return true;
+    }
+
     // ---- GPU-resident steps for the rest of the backend optimizer kernels (same contract as TryAdamStep:
     //      returns false if not on a GPU engine or any tensor isn't GPU-resident, so the caller falls back to CPU).
     //      All buffers must be GPU-resident; the kernel updates param + state IN PLACE with no host download. ----

--- a/src/AiDotNet.Tensors/Engines/Gpu/GpuOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/GpuOptimizer.cs
@@ -114,6 +114,24 @@ public static class GpuOptimizer
         return true;
     }
 
+    /// <summary>
+    /// Proximal gradient (ISTA) step with L1 soft-threshold prox, in place on the GPU.
+    /// CUDA-only (proximal_l1_update lives on CudaBackend); returns false on any
+    /// other backend or when param/grad aren't GPU-resident, so the caller falls
+    /// back to the CPU path.
+    /// </summary>
+    public static bool TryProximalL1Step(Tensor<float> p, Tensor<float> g, float lr, float l1Strength)
+    {
+        if (p is null) throw new ArgumentNullException(nameof(p));
+        if (g is null) throw new ArgumentNullException(nameof(g));
+        if (!(AiDotNetEngine.Current is DirectGpuTensorEngine e)) return false;
+        if (!(e.GetBackend() is DirectGpu.CUDA.CudaBackend cb)) return false;
+        var pb = p.TryGetGpuBuffer(); var gb = g.TryGetGpuBuffer();
+        if (pb is null || gb is null) return false;
+        cb.ProximalL1Update(pb, gb, lr, l1Strength, p.Length);
+        return true;
+    }
+
     // ---- GPU-resident steps for the rest of the backend optimizer kernels (same contract as TryAdamStep:
     //      returns false if not on a GPU engine or any tensor isn't GPU-resident, so the caller falls back to CPU).
     //      All buffers must be GPU-resident; the kernel updates param + state IN PLACE with no host download. ----

--- a/src/AiDotNet.Tensors/LinearAlgebra/Tensor.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/Tensor.cs
@@ -4320,8 +4320,11 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
         if (!IsGpuResident)
             return this;
 
-        // Force materialization of deferred download if pending
-        var arr = GetDataArray();
+        // Force realization of any pending lazy upstream (side-effect only;
+        // the returned snapshot is intentionally discarded — for a GPU-resident
+        // tensor it is a copy, so the actual download below targets the backing
+        // storage directly).
+        _ = GetDataArray();
 
         // If the backing array still has a deferred download pending, force it
         var backingArray = _data.GetBackingArrayUnsafe();
@@ -4331,12 +4334,34 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
         }
 
         // If we have a GPU buffer but data was never materialized through the deferred
-        // path (e.g., tensor was created via .Gpu()), download now
+        // path (e.g., tensor was created via .Gpu()), download now.
+        //
+        // IMPORTANT: write into the BACKING storage, not the `arr` returned by
+        // GetDataArray(). For a GPU-resident tensor GetDataArray() returns a
+        // COPY (it routes through ToArray() — see GetDataArray's remarks), so
+        // Array.Copy(converted, arr, ...) lands the download in a throwaway
+        // buffer and `_data` is never updated. That silently dropped the result
+        // of any in-place GPU write — notably the GPU-resident optimizer step,
+        // which updates the weight's device buffer directly: the kernel ran and
+        // the buffer changed, but Cpu()/host reads still saw the pre-step value.
+        // AsWritableSpan() hands back the real backing span (offset/length
+        // aware), matching the engine's own DownloadIntoTensor helper.
         if (_gpuBuffer is not null && _gpuBackend is not null && _device != TensorDevice.CPU)
         {
             float[] floatData = _gpuBackend.DownloadBuffer(_gpuBuffer);
             var converted = Engines.DirectGpu.DirectGpuEngine.FromFloatArray<T>(floatData);
-            Array.Copy(converted, arr, Math.Min(converted.Length, arr.Length));
+            if (IsContiguous)
+            {
+                var dst = AsWritableSpan();
+                converted.AsSpan(0, Math.Min(converted.Length, dst.Length)).CopyTo(dst);
+            }
+            else
+            {
+                // Non-contiguous view: fall back to the element-wise setter,
+                // which routes through the storage offset/stride correctly.
+                int n = Math.Min(converted.Length, Length);
+                for (int i = 0; i < n; i++) SetFlatIndexValue(i, converted[i]);
+            }
         }
 
         _device = TensorDevice.CPU;

--- a/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
@@ -102,6 +102,15 @@ public static class WeightRegistry
         get { lock (_lock) return _offloadAllocator; }
     }
 
+    /// <summary>The currently-active offload options. Lets a caller that wants
+    /// to attach an offload allocator (e.g. GPU adoption auto-registering the
+    /// CUDA allocator) re-Configure without clobbering options another caller
+    /// already set.</summary>
+    public static GpuOffloadOptions CurrentOptions
+    {
+        get { lock (_lock) return _options; }
+    }
+
     /// <summary>Registers a weight tensor with the registry. Routes to
     /// the streaming pool / offload allocator based on the tensor's
     /// <see cref="Tensor{T}.Lifetime"/>.</summary>


### PR DESCRIPTION
## GpuOptimizer: GPU-resident step helpers for ALL 15 backend optimizer kernels

`GpuOptimizer` exposed only `TryAdamStep` / `TryAdamWStep` / `TrySgdStep`, but the backends already ship in-place GPU kernels for the **full** optimizer family. This adds the 12 missing host-free step helpers:

`TrySgdMomentumStep, TryRmspropStep, TryAdagradStep, TryNagStep, TryLarsStep, TryLambStep, TryAdadeltaStep, TryAmsgradStep, TryAdamaxStep, TryLionStep, TryNadamStep, TryFtrlStep`

Each mirrors `TryAdamStep`'s contract - returns false if not on a GPU engine or any tensor isn't GPU-resident (caller falls back to CPU); otherwise the backend kernel updates param + state **in place with no host download**. This is the enabler for GPU-resident optimizer steps across the suite; the per-optimizer wiring lands in AiDotNet (mirroring the validated `AdamOptimizer` change, ooples/AiDotNet#1501).

?? Generated with [Claude Code](https://claude.com/claude-code)