### PR TITLE
perf(#368): strided transposed thin-M GEMM kernels (recovers post-merge work, transB up to 10×)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
@@ -59,6 +59,11 @@ public static partial class BlasManaged
     private const int ThinMDirectMaxM = 1024;   // above this the packed path wins
     private const int ThinMDirectMaxN = 512;    // above this B re-stream dominates
     private const int ThinMDirectMaxK = 1024;   // tested winning range
+    // Tiny GEMMs (e.g. 72×72×48 ≈ 0.25M) gain nothing from the parallel direct kernel
+    // and should stay on the strategy/autotune path (which learns + caches a winner for
+    // repeated small shapes). The validated wins are at the MLP-layer scale (L1 ≈ 8.4M,
+    // L0 ≈ 51M), so a 1M floor excludes only negligible shapes.
+    private const long ThinMDirectMinWork = 1L << 20; // 1,048,576
 
 #if NET5_0_OR_GREATER
     /// <summary>
@@ -88,6 +93,7 @@ public static partial class BlasManaged
         if (transA && transB) return false;
         if (ldc != n || (n & 7) != 0) return false;
         if (m < ThinMDirectMinM || m > ThinMDirectMaxM || n > ThinMDirectMaxN || k > ThinMDirectMaxK) return false;
+        if ((long)m * n * k < ThinMDirectMinWork) return false; // tiny GEMMs stay on the strategy/autotune path
         // Each operand must be contiguous in its stored (possibly transposed) layout:
         // !transA → A is [m,k] (lda=k); transA → Aᵀ is [k,m] (lda=m). Likewise B.
         if (lda != (transA ? m : k)) return false;

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
@@ -83,18 +83,42 @@ public static partial class BlasManaged
         if (!System.Runtime.Intrinsics.X86.Fma.IsSupported) return false;
         if (options.PackingMode != PackingMode.Auto && options.PackingMode != PackingMode.DisableAutotune) return false;
         if (options.PackedA is not null || options.PackedB is not null) return false;
-        // Transposed is intentionally NOT routed here: materializing op(A)/op(B) into
-        // contiguous scratch costs a serial transpose that dominates the (parallel)
-        // GEMM at thin-M — measured transB 27 / transA 53 GF/s, both at or below the
-        // ~57 the packed strategy already gives, i.e. a regression. Transposed thin-M
-        // wants a dedicated strided/transpose-aware kernel (separate work); for now it
-        // stays on the tuned strategy path.
-        if (transA || transB) return false;
-        if (lda != k || ldb != n || ldc != n) return false;
-        if ((n & 7) != 0) return false;
+        // both-transposed is rare and would need strided A *and* strided B (no
+        // contiguous vector dimension) — left on the strategy.
+        if (transA && transB) return false;
+        if (ldc != n || (n & 7) != 0) return false;
         if (m < ThinMDirectMinM || m > ThinMDirectMaxM || n > ThinMDirectMaxN || k > ThinMDirectMaxK) return false;
+        // Each operand must be contiguous in its stored (possibly transposed) layout:
+        // !transA → A is [m,k] (lda=k); transA → Aᵀ is [k,m] (lda=m). Likewise B.
+        if (lda != (transA ? m : k)) return false;
+        if (ldb != (transB ? k : n)) return false;
 
-        if (typeof(T) == typeof(float))
+        bool isFloat = typeof(T) == typeof(float);
+        if (transA)
+        {
+            // Aᵀ·B via the strided-A kernel (no transpose materialised).
+            if (isFloat)
+                Simd.SimdGemm.SgemmDirectParallelMIntoTransA(
+                    MemoryMarshal.Cast<T, float>(a), MemoryMarshal.Cast<T, float>(b),
+                    MemoryMarshal.Cast<T, float>(c), m, k, n);
+            else
+                Simd.SimdGemm.DgemmDirectParallelMIntoTransA(
+                    MemoryMarshal.Cast<T, double>(a), MemoryMarshal.Cast<T, double>(b),
+                    MemoryMarshal.Cast<T, double>(c), m, k, n);
+        }
+        else if (transB)
+        {
+            // A·Bᵀ via the NT dot-product kernel (Bstored rows are contiguous).
+            if (isFloat)
+                Simd.SimdGemm.SgemmDirectParallelMIntoTransB(
+                    MemoryMarshal.Cast<T, float>(a), MemoryMarshal.Cast<T, float>(b),
+                    MemoryMarshal.Cast<T, float>(c), m, k, n);
+            else
+                Simd.SimdGemm.DgemmDirectParallelMIntoTransB(
+                    MemoryMarshal.Cast<T, double>(a), MemoryMarshal.Cast<T, double>(b),
+                    MemoryMarshal.Cast<T, double>(c), m, k, n);
+        }
+        else if (isFloat)
             Simd.SimdGemm.SgemmDirectParallelMInto(
                 MemoryMarshal.Cast<T, float>(a), MemoryMarshal.Cast<T, float>(b),
                 MemoryMarshal.Cast<T, float>(c), m, k, n);

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
@@ -2005,6 +2005,330 @@ internal static partial class SimdGemm
     }
 
     /// <summary>
+    /// FP64 thin-M GEMM with A transposed (#368): C = Aᵀ·B where A is stored [k,m]
+    /// (lda=m) and B is [k,n]. Same broadcast-A 4×8 kernel as
+    /// <see cref="DgemmDirectParallelMInto"/> but A is read strided (a[i,p] = A[p·m+i],
+    /// the 4 row values at a depth are contiguous), so NO transpose is materialised —
+    /// the transpose-into-scratch alternative regresses at thin-M. n % 8 == 0; n-major
+    /// contiguous B and C; parallel over disjoint M-row-blocks (deterministic).
+    /// </summary>
+    [MethodImpl(Hot)]
+    public static unsafe void DgemmDirectParallelMIntoTransA(
+        ReadOnlySpan<double> a, ReadOnlySpan<double> b, Span<double> c, int m, int k, int n)
+    {
+        const int MRd = 4;
+        int mFull = (m / MRd) * MRd;
+        int numFullBlocks = mFull / MRd;
+        int cores = Math.Max(1, Helpers.CpuParallelSettings.MaxDegreeOfParallelism);
+        int numChunks = Math.Min(cores, Math.Max(1, (numFullBlocks + 1) / 2));
+        fixed (double* pA = a, pB = b, pC = c)
+        {
+            IntPtr ipA = (IntPtr)pA, ipB = (IntPtr)pB, ipC = (IntPtr)pC;
+            int kCap = k, nCap = n, mCap = m;
+            if (numChunks <= 1 || numFullBlocks == 0)
+                DgemmTransABlock(pA, pB, pC, 0, numFullBlocks, kCap, nCap, mCap);
+            else
+            {
+                int blocksPerChunk = (numFullBlocks + numChunks - 1) / numChunks;
+                Helpers.PersistentParallelExecutor.Instance.Execute(numChunks, chunk =>
+                {
+                    int bs = chunk * blocksPerChunk, be = Math.Min(bs + blocksPerChunk, numFullBlocks);
+                    if (bs < be) DgemmTransABlock((double*)ipA, (double*)ipB, (double*)ipC, bs, be, kCap, nCap, mCap);
+                });
+            }
+            for (int i = mFull; i < m; i++)
+            {
+                double* ci = pC + (long)i * n;
+                for (int j = 0; j < n; j++)
+                {
+                    double acc = 0.0;
+                    for (int p = 0; p < k; p++) acc += pA[(long)p * m + i] * pB[(long)p * n + j];
+                    ci[j] = acc;
+                }
+            }
+        }
+    }
+
+    private static unsafe void DgemmTransABlock(double* A, double* B, double* C, int blockStart, int blockEnd, int k, int n, int m)
+    {
+        const int MRd = 4;
+        for (int blk = blockStart; blk < blockEnd; blk++)
+        {
+            int i0 = blk * MRd;
+            for (int j = 0; j < n; j += 8)
+            {
+                var c00 = Vector256<double>.Zero; var c01 = Vector256<double>.Zero;
+                var c10 = Vector256<double>.Zero; var c11 = Vector256<double>.Zero;
+                var c20 = Vector256<double>.Zero; var c21 = Vector256<double>.Zero;
+                var c30 = Vector256<double>.Zero; var c31 = Vector256<double>.Zero;
+                double* bj = B + j;
+                for (int p = 0; p < k; p++)
+                {
+                    double* bp = bj + (long)p * n;
+                    var b0 = Avx.LoadVector256(bp);
+                    var b1 = Avx.LoadVector256(bp + 4);
+                    double* ap = A + (long)p * m + i0; // 4 row values, contiguous
+                    var av = Vector256.Create(ap[0]); c00 = Fma.MultiplyAdd(av, b0, c00); c01 = Fma.MultiplyAdd(av, b1, c01);
+                    av = Vector256.Create(ap[1]); c10 = Fma.MultiplyAdd(av, b0, c10); c11 = Fma.MultiplyAdd(av, b1, c11);
+                    av = Vector256.Create(ap[2]); c20 = Fma.MultiplyAdd(av, b0, c20); c21 = Fma.MultiplyAdd(av, b1, c21);
+                    av = Vector256.Create(ap[3]); c30 = Fma.MultiplyAdd(av, b0, c30); c31 = Fma.MultiplyAdd(av, b1, c31);
+                }
+                double* o0 = C + (long)(i0 + 0) * n + j; Avx.Store(o0, c00); Avx.Store(o0 + 4, c01);
+                double* o1 = C + (long)(i0 + 1) * n + j; Avx.Store(o1, c10); Avx.Store(o1 + 4, c11);
+                double* o2 = C + (long)(i0 + 2) * n + j; Avx.Store(o2, c20); Avx.Store(o2 + 4, c21);
+                double* o3 = C + (long)(i0 + 3) * n + j; Avx.Store(o3, c30); Avx.Store(o3 + 4, c31);
+            }
+        }
+    }
+
+    /// <summary>
+    /// FP64 thin-M GEMM with B transposed (#368): C = A·Bᵀ where B is stored [n,k]
+    /// (ldb=k). Both A[i,:] and Bstored[j,:] are contiguous rows of length k, so this
+    /// is the NT (dot-product) microkernel — 4 A-rows × 2 Bstored-rows, vector-FMA over
+    /// k with a horizontal reduce, no transpose materialised. n % 2 == 0; parallel over
+    /// disjoint M-row-blocks (deterministic). Slightly lower peak than the no-trans
+    /// kernel (the horizontal reductions) but far above the ~57 GF/s the packed path
+    /// gives transposed thin-M.
+    /// </summary>
+    [MethodImpl(Hot)]
+    public static unsafe void DgemmDirectParallelMIntoTransB(
+        ReadOnlySpan<double> a, ReadOnlySpan<double> b, Span<double> c, int m, int k, int n)
+    {
+        const int MRd = 4;
+        int mFull = (m / MRd) * MRd;
+        int numFullBlocks = mFull / MRd;
+        int cores = Math.Max(1, Helpers.CpuParallelSettings.MaxDegreeOfParallelism);
+        int numChunks = Math.Min(cores, Math.Max(1, (numFullBlocks + 1) / 2));
+        fixed (double* pA = a, pB = b, pC = c)
+        {
+            IntPtr ipA = (IntPtr)pA, ipB = (IntPtr)pB, ipC = (IntPtr)pC;
+            int kCap = k, nCap = n;
+            if (numChunks <= 1 || numFullBlocks == 0)
+                DgemmTransBBlock(pA, pB, pC, 0, numFullBlocks, kCap, nCap);
+            else
+            {
+                int blocksPerChunk = (numFullBlocks + numChunks - 1) / numChunks;
+                Helpers.PersistentParallelExecutor.Instance.Execute(numChunks, chunk =>
+                {
+                    int bs = chunk * blocksPerChunk, be = Math.Min(bs + blocksPerChunk, numFullBlocks);
+                    if (bs < be) DgemmTransBBlock((double*)ipA, (double*)ipB, (double*)ipC, bs, be, kCap, nCap);
+                });
+            }
+            for (int i = mFull; i < m; i++)
+            {
+                double* ai = pA + (long)i * k;
+                double* ci = pC + (long)i * n;
+                for (int j = 0; j < n; j++)
+                {
+                    double* bj = pB + (long)j * k;
+                    double acc = 0.0;
+                    for (int p = 0; p < k; p++) acc += ai[p] * bj[p];
+                    ci[j] = acc;
+                }
+            }
+        }
+    }
+
+    private static unsafe void DgemmTransBBlock(double* A, double* B, double* C, int blockStart, int blockEnd, int k, int n)
+    {
+        const int MRd = 4, NRd = 2;
+        int kVec = (k / 4) * 4;
+        for (int blk = blockStart; blk < blockEnd; blk++)
+        {
+            int i0 = blk * MRd;
+            double* a0 = A + (long)(i0 + 0) * k; double* a1 = A + (long)(i0 + 1) * k;
+            double* a2 = A + (long)(i0 + 2) * k; double* a3 = A + (long)(i0 + 3) * k;
+            for (int j = 0; j + NRd <= n; j += NRd)
+            {
+                double* bj0 = B + (long)(j + 0) * k; double* bj1 = B + (long)(j + 1) * k;
+                var acc00 = Vector256<double>.Zero; var acc01 = Vector256<double>.Zero;
+                var acc10 = Vector256<double>.Zero; var acc11 = Vector256<double>.Zero;
+                var acc20 = Vector256<double>.Zero; var acc21 = Vector256<double>.Zero;
+                var acc30 = Vector256<double>.Zero; var acc31 = Vector256<double>.Zero;
+                for (int p = 0; p < kVec; p += 4)
+                {
+                    var av0 = Avx.LoadVector256(a0 + p); var av1 = Avx.LoadVector256(a1 + p);
+                    var av2 = Avx.LoadVector256(a2 + p); var av3 = Avx.LoadVector256(a3 + p);
+                    var bv0 = Avx.LoadVector256(bj0 + p); var bv1 = Avx.LoadVector256(bj1 + p);
+                    acc00 = Fma.MultiplyAdd(av0, bv0, acc00); acc01 = Fma.MultiplyAdd(av0, bv1, acc01);
+                    acc10 = Fma.MultiplyAdd(av1, bv0, acc10); acc11 = Fma.MultiplyAdd(av1, bv1, acc11);
+                    acc20 = Fma.MultiplyAdd(av2, bv0, acc20); acc21 = Fma.MultiplyAdd(av2, bv1, acc21);
+                    acc30 = Fma.MultiplyAdd(av3, bv0, acc30); acc31 = Fma.MultiplyAdd(av3, bv1, acc31);
+                }
+                double s00 = Vector256.Sum(acc00), s01 = Vector256.Sum(acc01);
+                double s10 = Vector256.Sum(acc10), s11 = Vector256.Sum(acc11);
+                double s20 = Vector256.Sum(acc20), s21 = Vector256.Sum(acc21);
+                double s30 = Vector256.Sum(acc30), s31 = Vector256.Sum(acc31);
+                for (int p = kVec; p < k; p++)
+                {
+                    double a0p = a0[p], a1p = a1[p], a2p = a2[p], a3p = a3[p], b0p = bj0[p], b1p = bj1[p];
+                    s00 += a0p * b0p; s01 += a0p * b1p; s10 += a1p * b0p; s11 += a1p * b1p;
+                    s20 += a2p * b0p; s21 += a2p * b1p; s30 += a3p * b0p; s31 += a3p * b1p;
+                }
+                double* r0 = C + (long)(i0 + 0) * n + j; r0[0] = s00; r0[1] = s01;
+                double* r1 = C + (long)(i0 + 1) * n + j; r1[0] = s10; r1[1] = s11;
+                double* r2 = C + (long)(i0 + 2) * n + j; r2[0] = s20; r2[1] = s21;
+                double* r3 = C + (long)(i0 + 3) * n + j; r3[0] = s30; r3[1] = s31;
+            }
+        }
+    }
+
+    /// <summary>FP32 thin-M GEMM with A transposed (#368): C = Aᵀ·B, A stored [k,m]
+    /// (lda=m), strided-A 4×8 broadcast kernel (no transpose). n % 8 == 0; parallel-M
+    /// (deterministic). Float analog of <see cref="DgemmDirectParallelMIntoTransA"/>.</summary>
+    [MethodImpl(Hot)]
+    public static unsafe void SgemmDirectParallelMIntoTransA(
+        ReadOnlySpan<float> a, ReadOnlySpan<float> b, Span<float> c, int m, int k, int n)
+    {
+        const int MRf = 4;
+        int mFull = (m / MRf) * MRf;
+        int numFullBlocks = mFull / MRf;
+        int cores = Math.Max(1, Helpers.CpuParallelSettings.MaxDegreeOfParallelism);
+        int numChunks = Math.Min(cores, Math.Max(1, (numFullBlocks + 1) / 2));
+        fixed (float* pA = a, pB = b, pC = c)
+        {
+            IntPtr ipA = (IntPtr)pA, ipB = (IntPtr)pB, ipC = (IntPtr)pC;
+            int kCap = k, nCap = n, mCap = m;
+            if (numChunks <= 1 || numFullBlocks == 0)
+                SgemmTransABlock(pA, pB, pC, 0, numFullBlocks, kCap, nCap, mCap);
+            else
+            {
+                int blocksPerChunk = (numFullBlocks + numChunks - 1) / numChunks;
+                Helpers.PersistentParallelExecutor.Instance.Execute(numChunks, chunk =>
+                {
+                    int bs = chunk * blocksPerChunk, be = Math.Min(bs + blocksPerChunk, numFullBlocks);
+                    if (bs < be) SgemmTransABlock((float*)ipA, (float*)ipB, (float*)ipC, bs, be, kCap, nCap, mCap);
+                });
+            }
+            for (int i = mFull; i < m; i++)
+            {
+                float* ci = pC + (long)i * n;
+                for (int j = 0; j < n; j++)
+                {
+                    float acc = 0f;
+                    for (int p = 0; p < k; p++) acc += pA[(long)p * m + i] * pB[(long)p * n + j];
+                    ci[j] = acc;
+                }
+            }
+        }
+    }
+
+    private static unsafe void SgemmTransABlock(float* A, float* B, float* C, int blockStart, int blockEnd, int k, int n, int m)
+    {
+        const int MRf = 4;
+        for (int blk = blockStart; blk < blockEnd; blk++)
+        {
+            int i0 = blk * MRf;
+            for (int j = 0; j < n; j += 8)
+            {
+                var c0 = Vector256<float>.Zero; var c1 = Vector256<float>.Zero;
+                var c2 = Vector256<float>.Zero; var c3 = Vector256<float>.Zero;
+                float* bj = B + j;
+                for (int p = 0; p < k; p++)
+                {
+                    var b0 = Avx.LoadVector256(bj + (long)p * n);
+                    float* ap = A + (long)p * m + i0;
+                    c0 = Fma.MultiplyAdd(Vector256.Create(ap[0]), b0, c0);
+                    c1 = Fma.MultiplyAdd(Vector256.Create(ap[1]), b0, c1);
+                    c2 = Fma.MultiplyAdd(Vector256.Create(ap[2]), b0, c2);
+                    c3 = Fma.MultiplyAdd(Vector256.Create(ap[3]), b0, c3);
+                }
+                Avx.Store(C + (long)(i0 + 0) * n + j, c0);
+                Avx.Store(C + (long)(i0 + 1) * n + j, c1);
+                Avx.Store(C + (long)(i0 + 2) * n + j, c2);
+                Avx.Store(C + (long)(i0 + 3) * n + j, c3);
+            }
+        }
+    }
+
+    /// <summary>FP32 thin-M GEMM with B transposed (#368): C = A·Bᵀ, B stored [n,k]
+    /// (ldb=k), NT 4×2 dot-product kernel (Bstored rows contiguous; no transpose).
+    /// parallel-M (deterministic). Float analog of
+    /// <see cref="DgemmDirectParallelMIntoTransB"/>.</summary>
+    [MethodImpl(Hot)]
+    public static unsafe void SgemmDirectParallelMIntoTransB(
+        ReadOnlySpan<float> a, ReadOnlySpan<float> b, Span<float> c, int m, int k, int n)
+    {
+        const int MRf = 4;
+        int mFull = (m / MRf) * MRf;
+        int numFullBlocks = mFull / MRf;
+        int cores = Math.Max(1, Helpers.CpuParallelSettings.MaxDegreeOfParallelism);
+        int numChunks = Math.Min(cores, Math.Max(1, (numFullBlocks + 1) / 2));
+        fixed (float* pA = a, pB = b, pC = c)
+        {
+            IntPtr ipA = (IntPtr)pA, ipB = (IntPtr)pB, ipC = (IntPtr)pC;
+            int kCap = k, nCap = n;
+            if (numChunks <= 1 || numFullBlocks == 0)
+                SgemmTransBBlock(pA, pB, pC, 0, numFullBlocks, kCap, nCap);
+            else
+            {
+                int blocksPerChunk = (numFullBlocks + numChunks - 1) / numChunks;
+                Helpers.PersistentParallelExecutor.Instance.Execute(numChunks, chunk =>
+                {
+                    int bs = chunk * blocksPerChunk, be = Math.Min(bs + blocksPerChunk, numFullBlocks);
+                    if (bs < be) SgemmTransBBlock((float*)ipA, (float*)ipB, (float*)ipC, bs, be, kCap, nCap);
+                });
+            }
+            for (int i = mFull; i < m; i++)
+            {
+                float* ai = pA + (long)i * k;
+                float* ci = pC + (long)i * n;
+                for (int j = 0; j < n; j++)
+                {
+                    float* bj = pB + (long)j * k;
+                    float acc = 0f;
+                    for (int p = 0; p < k; p++) acc += ai[p] * bj[p];
+                    ci[j] = acc;
+                }
+            }
+        }
+    }
+
+    private static unsafe void SgemmTransBBlock(float* A, float* B, float* C, int blockStart, int blockEnd, int k, int n)
+    {
+        const int MRf = 4, NRf = 2;
+        int kVec = (k / 8) * 8;
+        for (int blk = blockStart; blk < blockEnd; blk++)
+        {
+            int i0 = blk * MRf;
+            float* a0 = A + (long)(i0 + 0) * k; float* a1 = A + (long)(i0 + 1) * k;
+            float* a2 = A + (long)(i0 + 2) * k; float* a3 = A + (long)(i0 + 3) * k;
+            for (int j = 0; j + NRf <= n; j += NRf)
+            {
+                float* bj0 = B + (long)(j + 0) * k; float* bj1 = B + (long)(j + 1) * k;
+                var acc00 = Vector256<float>.Zero; var acc01 = Vector256<float>.Zero;
+                var acc10 = Vector256<float>.Zero; var acc11 = Vector256<float>.Zero;
+                var acc20 = Vector256<float>.Zero; var acc21 = Vector256<float>.Zero;
+                var acc30 = Vector256<float>.Zero; var acc31 = Vector256<float>.Zero;
+                for (int p = 0; p < kVec; p += 8)
+                {
+                    var av0 = Avx.LoadVector256(a0 + p); var av1 = Avx.LoadVector256(a1 + p);
+                    var av2 = Avx.LoadVector256(a2 + p); var av3 = Avx.LoadVector256(a3 + p);
+                    var bv0 = Avx.LoadVector256(bj0 + p); var bv1 = Avx.LoadVector256(bj1 + p);
+                    acc00 = Fma.MultiplyAdd(av0, bv0, acc00); acc01 = Fma.MultiplyAdd(av0, bv1, acc01);
+                    acc10 = Fma.MultiplyAdd(av1, bv0, acc10); acc11 = Fma.MultiplyAdd(av1, bv1, acc11);
+                    acc20 = Fma.MultiplyAdd(av2, bv0, acc20); acc21 = Fma.MultiplyAdd(av2, bv1, acc21);
+                    acc30 = Fma.MultiplyAdd(av3, bv0, acc30); acc31 = Fma.MultiplyAdd(av3, bv1, acc31);
+                }
+                float s00 = Vector256.Sum(acc00), s01 = Vector256.Sum(acc01);
+                float s10 = Vector256.Sum(acc10), s11 = Vector256.Sum(acc11);
+                float s20 = Vector256.Sum(acc20), s21 = Vector256.Sum(acc21);
+                float s30 = Vector256.Sum(acc30), s31 = Vector256.Sum(acc31);
+                for (int p = kVec; p < k; p++)
+                {
+                    float a0p = a0[p], a1p = a1[p], a2p = a2[p], a3p = a3[p], b0p = bj0[p], b1p = bj1[p];
+                    s00 += a0p * b0p; s01 += a0p * b1p; s10 += a1p * b0p; s11 += a1p * b1p;
+                    s20 += a2p * b0p; s21 += a2p * b1p; s30 += a3p * b0p; s31 += a3p * b1p;
+                }
+                float* r0 = C + (long)(i0 + 0) * n + j; r0[0] = s00; r0[1] = s01;
+                float* r1 = C + (long)(i0 + 1) * n + j; r1[0] = s10; r1[1] = s11;
+                float* r2 = C + (long)(i0 + 2) * n + j; r2[0] = s20; r2[1] = s21;
+                float* r3 = C + (long)(i0 + 3) * n + j; r3[0] = s30; r3[1] = s31;
+            }
+        }
+    }
+
+    /// <summary>
     /// #209 close-parity: parallel-M wrapper around SgemmDirect's tile loop.
     /// Distributes the outer-M loop's Mr=6 blocks across cores via the
     /// persistent thread pool. Each chunk handles a contiguous range of

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManagedThinMDirectTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManagedThinMDirectTests.cs
@@ -108,6 +108,78 @@ public class BlasManagedThinMDirectTests
             $"BlasManaged.Gemm<double> thin-M carve-out rel error at {m}x{k}x{n}.");
     }
 
+    // Transposed thin-M (#368 strided kernels — no transpose materialised).
+    // transA: C = Aᵀ·B, A stored [k,m]. transB: C = A·Bᵀ, B stored [n,k].
+    [Theory]
+    [MemberData(nameof(Shapes))]
+    public void GemmDouble_ThinM_TransA_MatchesReference(int m, int k, int n)
+    {
+        var rng = RandomHelper.CreateSeededRandom(820);
+        var A = RandD(m * k, rng); var B = RandD(k * n, rng); // logical A[m,k], B[k,n]
+        var aStored = TransposeD(A, m, k);                    // [k,m] = Aᵀ (lda=m)
+        var got = new double[m * n]; var want = new double[m * n];
+        ReferenceD(A, B, want, m, k, n);
+        AiDotNet.Tensors.Engines.BlasManaged.BlasManaged.Gemm<double>(
+            aStored, m, true, B, n, false, got, n, m, n, k, default);
+        Assert.True(RelErrD(got, want) < 1e-10, $"double transA at {m}x{k}x{n}.");
+    }
+
+    [Theory]
+    [MemberData(nameof(Shapes))]
+    public void GemmDouble_ThinM_TransB_MatchesReference(int m, int k, int n)
+    {
+        var rng = RandomHelper.CreateSeededRandom(821);
+        var A = RandD(m * k, rng); var B = RandD(k * n, rng); // logical A[m,k], B[k,n]
+        var bStored = TransposeD(B, k, n);                    // [n,k] = Bᵀ (ldb=k)
+        var got = new double[m * n]; var want = new double[m * n];
+        ReferenceD(A, B, want, m, k, n);
+        AiDotNet.Tensors.Engines.BlasManaged.BlasManaged.Gemm<double>(
+            A, k, false, bStored, k, true, got, n, m, n, k, default);
+        Assert.True(RelErrD(got, want) < 1e-10, $"double transB at {m}x{k}x{n}.");
+    }
+
+    private static double[] TransposeD(double[] src, int rows, int cols)
+    {
+        var d = new double[rows * cols];
+        for (int i = 0; i < rows; i++) for (int j = 0; j < cols; j++) d[j * rows + i] = src[i * cols + j];
+        return d;
+    }
+
+    [Theory]
+    [MemberData(nameof(Shapes))]
+    public void GemmFloat_ThinM_TransA_MatchesReference(int m, int k, int n)
+    {
+        var rng = RandomHelper.CreateSeededRandom(822);
+        var A = RandF(m * k, rng); var B = RandF(k * n, rng);
+        var aStored = TransposeF(A, m, k);
+        var got = new float[m * n]; var want = new float[m * n];
+        Reference(A, B, want, m, k, n);
+        AiDotNet.Tensors.Engines.BlasManaged.BlasManaged.Gemm<float>(
+            aStored, m, true, B, n, false, got, n, m, n, k, default);
+        Assert.True(RelErr(got, want) < 1e-3, $"float transA at {m}x{k}x{n}.");
+    }
+
+    [Theory]
+    [MemberData(nameof(Shapes))]
+    public void GemmFloat_ThinM_TransB_MatchesReference(int m, int k, int n)
+    {
+        var rng = RandomHelper.CreateSeededRandom(823);
+        var A = RandF(m * k, rng); var B = RandF(k * n, rng);
+        var bStored = TransposeF(B, k, n);
+        var got = new float[m * n]; var want = new float[m * n];
+        Reference(A, B, want, m, k, n);
+        AiDotNet.Tensors.Engines.BlasManaged.BlasManaged.Gemm<float>(
+            A, k, false, bStored, k, true, got, n, m, n, k, default);
+        Assert.True(RelErr(got, want) < 1e-3, $"float transB at {m}x{k}x{n}.");
+    }
+
+    private static float[] TransposeF(float[] src, int rows, int cols)
+    {
+        var d = new float[rows * cols];
+        for (int i = 0; i < rows; i++) for (int j = 0; j < cols; j++) d[j * rows + i] = src[i * cols + j];
+        return d;
+    }
+
     // Fused bias+activation epilogue at thin-M: #368 applies it after the direct
     // kernel so FusedLinear hits the fast path. Verify out = ReLU(A·B + bias).
     [Theory]
@@ -172,6 +244,27 @@ public class BlasManagedThinMDirectTests
             ad, K, false, bd, N, false, cd, N, M, N, K, default));
         double dGf = flop / (dMs * 1e6);
         _out.WriteLine($"BlasManaged.Gemm<double> thin-M L0 [128x784x512]: {dGf:F0} GF/s (pre-#368 ~60).");
+
+        // transposed (strided kernels — pre-#368 the strategy gave ~57).
+        var bT = new double[N * K]; for (int i = 0; i < bT.Length; i++) bT[i] = rng.NextDouble() * 2 - 1;
+        var cTb = new double[M * N];
+        double tbMs = Min(() => AiDotNet.Tensors.Engines.BlasManaged.BlasManaged.Gemm<double>(
+            ad, K, false, bT, K, true, cTb, N, M, N, K, default));
+        _out.WriteLine($"BlasManaged.Gemm<double> thin-M L0 transB: {flop / (tbMs * 1e6):F0} GF/s (pre-#368 ~57).");
+        var aT = new double[K * M]; for (int i = 0; i < aT.Length; i++) aT[i] = rng.NextDouble() * 2 - 1;
+        var cTa = new double[M * N];
+        double taMs = Min(() => AiDotNet.Tensors.Engines.BlasManaged.BlasManaged.Gemm<double>(
+            aT, M, true, bd, N, false, cTa, N, M, N, K, default));
+        _out.WriteLine($"BlasManaged.Gemm<double> thin-M L0 transA: {flop / (taMs * 1e6):F0} GF/s (pre-#368 ~53).");
+
+        var bTf = RandF(N * K, rng); var cTbf = new float[M * N];
+        double tbfMs = Min(() => AiDotNet.Tensors.Engines.BlasManaged.BlasManaged.Gemm<float>(
+            a, K, false, bTf, K, true, cTbf, N, M, N, K, default));
+        _out.WriteLine($"BlasManaged.Gemm<float>  thin-M L0 transB: {flop / (tbfMs * 1e6):F0} GF/s");
+        var aTf = RandF(K * M, rng); var cTaf = new float[M * N];
+        double tafMs = Min(() => AiDotNet.Tensors.Engines.BlasManaged.BlasManaged.Gemm<float>(
+            aTf, M, true, b, N, false, cTaf, N, M, N, K, default));
+        _out.WriteLine($"BlasManaged.Gemm<float>  thin-M L0 transA: {flop / (tafMs * 1e6):F0} GF/s");
         // Pre-#368 double routed to the ~60 GF/s machine-code/strategy path; the new
         // 4x8 direct kernel clears it comfortably. 100 GF/s floor catches a regression.
         Assert.True(dGf > 100, $"BlasManaged.Gemm<double> thin-M L0 = {dGf:F0} GF/s — below the 100 GF/s floor (regressed off the #368 FP64 direct path?).");


### PR DESCRIPTION
## Why this PR exists

The strided transposed thin-M kernels were written + reviewed in #547's branch but pushed **after #547 squash-merged**, so they never reached `main` (the squash captured up to the epilogue commit only). This PR re-lands that orphaned, fully-tested commit cleanly on top of current `main`.

## What

Transposed thin-M GEMM was the one gap left by #547. The transpose-into-scratch shortcut **regressed** (serial transpose dominates the parallel GEMM). This replaces it with **dedicated strided kernels** that read the transposed operand in place — no materialized transpose:

- **transA** (`C = Aᵀ·B`, A stored `[k,m]`): strided-A broadcast kernel (`a[i,p]=A[p·m+i]`; the 4 row-values at a depth are contiguous). float + double.
- **transB** (`C = A·Bᵀ`, B stored `[n,k]`): NT dot-product kernel — `A[i,:]` and `Bstored[j,:]` are both contiguous rows, so 4×2 vector-FMA over k + horizontal reduce. float + double.
- both-transposed stays on the strategy (rare; no contiguous vector dim).

All parallel over disjoint M-row-blocks → **bit-deterministic** across thread counts.

## Measured (32-thread AVX2, L0 128×784×512; pre-#368 ~53–57 GF/s on the strategy)

| | float | double |
|---|---|---|
| transA | **189** | **136** |
| transB | **570** | **264** |

`transB` even beats the no-trans kernel (contiguous `Bstored` rows + better FMA/load).

## Verification

- 28 transposed correctness tests (float/double × transA/transB × 7 shapes incl. **M%4/M%6 tails** + large K) vs a naive reference — **all pass** (58 in the thin-M suite total).
- Builds net10.0 + net471. Broad GEMM/determinism suites pass (only pre-existing load-flaky perf-margin tests, which pass in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)