### PR TITLE
fix(gpu): bound DirectGpu activation cache - deterministic per-step release + managed-byte cap

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
@@ -61,6 +61,15 @@ public sealed class GradientTape<T> : IDisposable
     private bool _engineExplicitlyBound;
     private readonly bool _savedReplayMode; // Saved ReplayMode from outer scope for nested tapes
     private bool _disposed;
+    // Deterministic per-step activation lifetime (GPU): the DirectGpu activation
+    // cache that an outermost tape's forward populates is released wholesale on
+    // Dispose via EvictActivationsCreatedAfter(_activationSnapshot), giving ~one-step
+    // steady-state memory (PyTorch/JAX semantics) instead of leaning on the LRU byte
+    // cap to drain a backlog. Only the engine instance captured at construction is
+    // touched, and only entries newer than the snapshot — pre-existing cross-tape
+    // intermediates are preserved. Null engine / non-GPU / nested tape => no-op.
+    private readonly Engines.DirectGpuTensorEngine? _snapshotEngine;
+    private readonly long _activationSnapshot;
 
 
     /// <summary>
@@ -148,6 +157,17 @@ public sealed class GradientTape<T> : IDisposable
         _engineExplicitlyBound = false;
         _parent = _current;
         _savedReplayMode = Compilation.AutoTrainingCompiler.ReplayMode;
+
+        // Capture the activation-cache baseline for the OUTERMOST tape on a GPU engine.
+        // On Dispose, every activation cached at a higher timestamp (i.e. produced by
+        // this forward+backward) is released deterministically — see _snapshotEngine.
+        // Captured from the construction-time engine; only used at Dispose if the tape
+        // still bound to that same instance (guards the rare CPU<->GPU rebind, #350).
+        if (_parent is null && _engine is Engines.DirectGpuTensorEngine snapEngine)
+        {
+            _snapshotEngine = snapEngine;
+            _activationSnapshot = snapEngine.ActivationCacheTimestampSnapshot();
+        }
 
         if (_options.EnableHooks)
         {
@@ -1742,17 +1762,24 @@ public sealed class GradientTape<T> : IDisposable
         // Only the OUTERMOST tape invalidates — nested tapes
         // (Hvp/Hessian) must not clear their parent's pending
         // materializers mid-backward. Detect outermost via
-        // _parent == null. Engine check gates the virtual dispatch.
-        if (_parent is null && _entries.Count > 0
-            && _engine is Engines.DirectGpuTensorEngine gpuEngine)
+        // _parent == null.
+        //
+        // 2026-06-05: this used to walk _entries and invalidate only each recorded
+        // op's `entry.Output`. That was INCOMPLETE — activations cached under keys
+        // that were never a recorded tape Output (e.g. the [B,H,ctx,ctx] attention
+        // scores re-uploaded during backward) leaked: gcroot traced 36GB+ of live
+        // float[] back to DirectGpuTensorEngine._activationCache surviving across
+        // training steps. The deterministic fix releases EVERY activation this
+        // forward+backward produced (timestamp > the snapshot captured at ctor),
+        // which is a strict superset of the old per-Output walk and bounds memory
+        // to ~one step. Entries created before the tape are preserved, so the
+        // cross-tape inference-reuse scenarios the old walk protected still hold.
+        // Guard on the SAME engine instance the snapshot came from (CPU<->GPU
+        // rebind, #350); the byte/managed caps remain as a backstop either way.
+        if (_parent is null && _snapshotEngine is not null
+            && ReferenceEquals(_snapshotEngine, _engine))
         {
-            for (int i = 0; i < _entries.Count; i++)
-            {
-                ref var entry = ref _entries[i];
-                var output = entry.Output;
-                if (output is null) continue;
-                gpuEngine.InvalidateGpuCacheForTensor(output);
-            }
+            _snapshotEngine.EvictActivationsCreatedAfter(_activationSnapshot);
         }
 
         // Return arena to thread-local cache for reuse by next GradientTape

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -101,13 +101,19 @@ internal sealed class ActivationCacheEntry : IDisposable
     public int[] Shape { get; }
     public long Timestamp { get; }
     public IDirectGpuBackend Backend { get; }
+    // Approximate size of the MANAGED backing array this entry's key pins alive
+    // (product(Shape) * 4, float). Tracked separately from Buffer.SizeInBytes (GPU
+    // bytes) so the cache can bound MANAGED-heap retention independently of VRAM —
+    // see _maxActivationManagedBytes in DirectGpuTensorEngine.
+    public long ManagedBytes { get; }
 
-    public ActivationCacheEntry(IGpuBuffer buffer, int[] shape, long timestamp, IDirectGpuBackend backend)
+    public ActivationCacheEntry(IGpuBuffer buffer, int[] shape, long timestamp, IDirectGpuBackend backend, long managedBytes = 0)
     {
         Buffer = buffer;
         Shape = shape;
         Timestamp = timestamp;
         Backend = backend;
+        ManagedBytes = managedBytes;
     }
 
     public void Dispose()
@@ -249,6 +255,19 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     private long _currentActivationCacheBytes;
     private long _activationCacheTimestamp = 0;
 
+    // MANAGED-heap bound for the activation cache (independent of the VRAM byte cap).
+    // Root cause of the cortex training OOM/crash (2026-06-05, gcroot): the cache keys
+    // are the managed float[] backing arrays, but eviction was driven ONLY by GPU-buffer
+    // bytes (_currentActivationCacheBytes) and a huge 131072 entry cap. When a step's GPU
+    // buffers are freed/deferred but their managed keys linger (stale cross-step entries),
+    // nothing bounded the MANAGED heap — it grew to 36GB+ (live after GC) and crashed the
+    // process while VRAM stayed capped at ~75%. This cap evicts the OLDEST entries (exactly
+    // those stale prior-step activations) once managed retention exceeds the limit, while
+    // the current step's newest activations stay resident (no GPU<->CPU thrash for the live
+    // step). Tunable via AIDOTNET_ACT_CACHE_MANAGED_MB (default 8192 MB); 0 disables.
+    private long _maxActivationManagedBytes;
+    private long _currentActivationManagedBytes;
+
     // Deferred download tracking for GPU-resident execution
     // When GpuScope is active, intermediate results skip the blocking download.
     // The GPU buffer stays in the activation cache for direct GPU-to-GPU chaining.
@@ -261,6 +280,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         _directGpu = new DirectGpuEngine();
         _ownsDirectGpu = true;
         _maxActivationCacheBytes = _directGpu.GlobalMemoryBytes * 3 / 4; // 75% of GPU memory
+        _maxActivationManagedBytes = ResolveManagedCacheCapBytes();
     }
 
     public DirectGpuTensorEngine(DirectGpuEngine directGpu)
@@ -268,6 +288,18 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         _directGpu = directGpu;
         _ownsDirectGpu = false;
         _maxActivationCacheBytes = directGpu?.GlobalMemoryBytes * 3 / 4 ?? 0;
+        _maxActivationManagedBytes = ResolveManagedCacheCapBytes();
+    }
+
+    // Managed-heap cap for the activation cache. Default 8 GB; AIDOTNET_ACT_CACHE_MANAGED_MB
+    // overrides (set to 0 to disable the managed bound and rely on the VRAM cap alone).
+    private static long ResolveManagedCacheCapBytes()
+    {
+        const long defaultMb = 8192;
+        var env = Environment.GetEnvironmentVariable("AIDOTNET_ACT_CACHE_MANAGED_MB");
+        if (env is not null && long.TryParse(env, out var mb) && mb >= 0)
+            return mb * 1024L * 1024L;
+        return defaultMb * 1024L * 1024L;
     }
 
     public bool IsGpuAvailable => _directGpu?.IsAvailable == true;
@@ -862,6 +894,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             {
                 System.Threading.Interlocked.Add(ref _currentActivationCacheBytes,
                     -entry.Buffer.SizeInBytes);
+                System.Threading.Interlocked.Add(ref _currentActivationManagedBytes, -entry.ManagedBytes);
                 removed = entry;
             }
         }
@@ -1074,6 +1107,12 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     private void CacheActivation(object cacheKey, IGpuBuffer buffer, int[] shape, IDirectGpuBackend backend)
     {
+        // Approximate managed-heap footprint of the key array this entry pins
+        // (product(shape) * 4 bytes; activation backing arrays are float[]). Bounds
+        // managed retention independently of the VRAM byte cap — see overManaged below.
+        long managedBytes = 4L;
+        for (int d = 0; d < shape.Length; d++) managedBytes *= shape[d];
+
         List<ActivationCacheEntry> evicted = new List<ActivationCacheEntry>();
         lock (_activationCacheLock)
         {
@@ -1085,7 +1124,13 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             // for the unit-consistency contract.
             bool overMemory = _maxActivationCacheBytes > 0
                 && _currentActivationCacheBytes + buffer.SizeInBytes > _maxActivationCacheBytes;
-            if (overMemory || overCount)
+            // MANAGED-heap guard: the cache keys strong-root their float[] backing
+            // arrays, so stale cross-step entries can balloon the managed heap even
+            // while VRAM stays capped. Evicting the oldest (stale prior-step) entries
+            // here is what bounds the training-loop leak (gcroot 2026-06-05).
+            bool overManaged = _maxActivationManagedBytes > 0
+                && _currentActivationManagedBytes + managedBytes > _maxActivationManagedBytes;
+            if (overMemory || overCount || overManaged)
             {
                 // Evict the oldest activations, offloading any pending deferred downloads so a
                 // later CPU read / backward re-upload still sees correct data (#226 contract).
@@ -1103,7 +1148,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             }
 
             var timestamp = System.Threading.Interlocked.Increment(ref _activationCacheTimestamp);
-            var entry = new ActivationCacheEntry(buffer, shape, timestamp, backend);
+            var entry = new ActivationCacheEntry(buffer, shape, timestamp, backend, managedBytes);
             bool added = false;
             try
             {
@@ -1118,6 +1163,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 else
                 {
                     System.Threading.Interlocked.Add(ref _currentActivationCacheBytes, buffer.SizeInBytes);
+                    System.Threading.Interlocked.Add(ref _currentActivationManagedBytes, managedBytes);
                 }
             }
         }
@@ -1138,6 +1184,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             {
                 System.Threading.Interlocked.Add(ref _currentActivationCacheBytes,
                     -entry.Buffer.SizeInBytes);
+                System.Threading.Interlocked.Add(ref _currentActivationManagedBytes, -entry.ManagedBytes);
                 removed = entry;
             }
         }
@@ -1212,12 +1259,61 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             {
                 System.Threading.Interlocked.Add(ref _currentActivationCacheBytes,
                     -entry.Buffer.SizeInBytes);
+                System.Threading.Interlocked.Add(ref _currentActivationManagedBytes, -entry.ManagedBytes);
                 toDispose.Add(entry);
                 removed++;
             }
         }
 
         return toDispose;
+    }
+
+    /// <summary>
+    /// Monotonic snapshot of the activation-cache timestamp counter. Capture this
+    /// at the start of a forward+backward pass (the outermost GradientTape) and pass
+    /// it to <see cref="EvictActivationsCreatedAfter"/> on tape dispose to release
+    /// EXACTLY that pass's intermediate activations — the deterministic per-step
+    /// lifetime that bounds steady-state memory to ~one step (PyTorch/JAX semantics),
+    /// instead of relying on the LRU byte cap to evict a backlog. Entries created
+    /// BEFORE the snapshot (cross-tape cached intermediates an outer scope still
+    /// wants) are preserved.
+    /// </summary>
+    internal long ActivationCacheTimestampSnapshot()
+        => System.Threading.Interlocked.Read(ref _activationCacheTimestamp);
+
+    /// <summary>
+    /// Deterministically evicts every activation-cache entry created AFTER
+    /// <paramref name="snapshot"/> (i.e. during the just-finished forward+backward).
+    /// Mirrors the #226 materialize-then-free contract of
+    /// <see cref="EvictOldestActivationsUnsafe"/> so any pending deferred download is
+    /// flushed to its CPU array before the GPU buffer is freed. Safe no-op when the
+    /// engine isn't GPU-backed or nothing was cached this pass.
+    /// </summary>
+    internal void EvictActivationsCreatedAfter(long snapshot)
+    {
+        List<ActivationCacheEntry> toDispose;
+        lock (_activationCacheLock)
+        {
+            if (_activationCache.IsEmpty) return;
+            var entries = _activationCache.ToArray();
+            toDispose = new List<ActivationCacheEntry>();
+            for (int i = 0; i < entries.Length; i++)
+            {
+                if (entries[i].Value.Timestamp <= snapshot) continue;   // pre-existing — keep
+                if (Helpers.DeferredArrayMaterializer.IsPending(entries[i].Key))
+                {
+                    try { Helpers.DeferredArrayMaterializer.TryMaterialize(entries[i].Key); }
+                    catch { Helpers.DeferredArrayMaterializer.Remove(entries[i].Key); }
+                }
+                if (_activationCache.TryRemove(entries[i].Key, out var entry))
+                {
+                    System.Threading.Interlocked.Add(ref _currentActivationCacheBytes, -entry.Buffer.SizeInBytes);
+                    System.Threading.Interlocked.Add(ref _currentActivationManagedBytes, -entry.ManagedBytes);
+                    toDispose.Add(entry);
+                }
+            }
+        }
+        foreach (var entry in toDispose) entry.Dispose();
     }
 
     /// <summary>
@@ -1236,6 +1332,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             toDispose = new List<ActivationCacheEntry>(_activationCache.Values);
             _activationCache.Clear();
+            System.Threading.Interlocked.Exchange(ref _currentActivationCacheBytes, 0);
+            System.Threading.Interlocked.Exchange(ref _currentActivationManagedBytes, 0);
         }
 
         // Dispose GPU buffers outside the lock

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/ActivationCacheEvictionLifetimeTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/ActivationCacheEvictionLifetimeTests.cs
@@ -50,12 +50,17 @@ public class ActivationCacheEvictionLifetimeTests
     /// </summary>
     private static ConstructorInfo GetActivationCacheEntryCtor(Type activationCacheEntryType)
     {
+        // Matches the 5-parameter ctor introduced with the managed-byte backstop:
+        // (buffer, shape, timestamp, backend, managedBytes). managedBytes carries
+        // the approximate managed-array footprint the entry pins; eviction itself
+        // doesn't read it so the tests pass 0.
         var ctor = activationCacheEntryType.GetConstructor(new[]
         {
             typeof(IGpuBuffer),
             typeof(int[]),
             typeof(long),
-            typeof(IDirectGpuBackend)
+            typeof(IDirectGpuBackend),
+            typeof(long)
         });
         Assert.NotNull(ctor);
         return ctor!;
@@ -110,13 +115,13 @@ public class ActivationCacheEvictionLifetimeTests
         // entries; eviction itself only calls Buffer.Dispose(), so a null backend
         // is safe for this test.
         object protectedEntry = entryCtor.Invoke(
-            new object?[] { protectedBuffer, new[] { 4 }, 1L, null });
+            new object?[] { protectedBuffer, new[] { 4 }, 1L, null, 0L });
         object victimEntry1 = entryCtor.Invoke(
-            new object?[] { victimBuffer1, new[] { 4 }, 2L, null });
+            new object?[] { victimBuffer1, new[] { 4 }, 2L, null, 0L });
         object victimEntry2 = entryCtor.Invoke(
-            new object?[] { victimBuffer2, new[] { 4 }, 3L, null });
+            new object?[] { victimBuffer2, new[] { 4 }, 3L, null, 0L });
         object victimEntry3 = entryCtor.Invoke(
-            new object?[] { victimBuffer3, new[] { 4 }, 4L, null });
+            new object?[] { victimBuffer3, new[] { 4 }, 4L, null, 0L });
 
         // ConcurrentDictionary<object, ActivationCacheEntry>.TryAdd via runtime dispatch.
         var tryAdd = activationCache.GetType().GetMethod("TryAdd")!;
@@ -200,8 +205,8 @@ public class ActivationCacheEvictionLifetimeTests
         var buffer1 = new TrackingGpuBuffer(size: 4);
         var buffer2 = new TrackingGpuBuffer(size: 4);
 
-        object entry1 = entryCtor.Invoke(new object?[] { buffer1, new[] { 4 }, 1L, null });
-        object entry2 = entryCtor.Invoke(new object?[] { buffer2, new[] { 4 }, 2L, null });
+        object entry1 = entryCtor.Invoke(new object?[] { buffer1, new[] { 4 }, 1L, null, 0L });
+        object entry2 = entryCtor.Invoke(new object?[] { buffer2, new[] { 4 }, 2L, null, 0L });
 
         var tryAdd = activationCache.GetType().GetMethod("TryAdd")!;
         Assert.True((bool)tryAdd.Invoke(activationCache, new[] { key1, entry1 })!);

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/EvictActivationsCreatedAfterLifetimeTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/EvictActivationsCreatedAfterLifetimeTests.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.DirectGpu;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
+
+/// <summary>
+/// Locks the contract of the deterministic per-step activation-cache release added with
+/// the managed-byte cap (PR #552). The outermost <see cref="Autodiff.GradientTape{T}"/>
+/// snapshots <see cref="DirectGpuTensorEngine.ActivationCacheTimestampSnapshot"/> at
+/// construction and on Dispose calls <see cref="DirectGpuTensorEngine.EvictActivationsCreatedAfter"/>
+/// to release EXACTLY that forward+backward's intermediate activations (PyTorch/JAX
+/// per-step memory semantics). Without this contract, prior cross-step activations
+/// strong-rooted by the cache float[] keys grew the managed heap to 36GB+ before the OOM.
+///
+/// These tests pin three invariants on any CI host without requiring a GPU runtime:
+///   1. Pre-snapshot entries are preserved (cross-tape intermediates survive).
+///   2. Post-snapshot entries are released — buffer disposed, both byte/managed counters drop.
+///   3. The #226 materialize-then-free contract still holds — a pending deferred download
+///      is materialized BEFORE the buffer is freed, so a later CPU read never touches
+///      a freed buffer.
+/// </summary>
+public class EvictActivationsCreatedAfterLifetimeTests
+{
+    /// <summary>Fake GPU buffer — tracks Dispose so the test can assert on lifetime.</summary>
+    private sealed class TrackingGpuBuffer : IGpuBuffer
+    {
+        public int DisposeCount;
+        public int Size { get; }
+        public long SizeInBytes => Size * sizeof(float);
+        public IntPtr Handle => IntPtr.Zero;
+
+        public TrackingGpuBuffer(int size) { Size = size; }
+        public void Dispose() => DisposeCount++;
+    }
+
+    private static ConstructorInfo GetActivationCacheEntryCtor(Type activationCacheEntryType)
+    {
+        var ctor = activationCacheEntryType.GetConstructor(new[]
+        {
+            typeof(IGpuBuffer),
+            typeof(int[]),
+            typeof(long),
+            typeof(IDirectGpuBackend),
+            typeof(long)
+        });
+        Assert.NotNull(ctor);
+        return ctor!;
+    }
+
+    [Fact]
+    public void EvictActivationsCreatedAfter_KeepsPreSnapshot_ReleasesPostSnapshot()
+    {
+        using var engine = new DirectGpuTensorEngine();
+
+        var engineType = typeof(DirectGpuTensorEngine);
+        var activationCacheField = engineType.GetField(
+            "_activationCache", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var timestampField = engineType.GetField(
+            "_activationCacheTimestamp", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var snapshotMethod = engineType.GetMethod(
+            "ActivationCacheTimestampSnapshot", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var evictMethod = engineType.GetMethod(
+            "EvictActivationsCreatedAfter", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var activationCacheEntryType = engineType.Assembly.GetType(
+            "AiDotNet.Tensors.Engines.ActivationCacheEntry")!;
+        var entryCtor = GetActivationCacheEntryCtor(activationCacheEntryType);
+        object activationCache = activationCacheField.GetValue(engine)!;
+        var tryAdd = activationCache.GetType().GetMethod("TryAdd")!;
+
+        // Seed one entry at timestamp 1 (pre-snapshot survivor), snapshot, then seed two
+        // more at timestamps 2 and 3 (post-snapshot, must be released).
+        var keyPre = new float[4];
+        var keyPost1 = new float[4];
+        var keyPost2 = new float[4];
+        var bufPre = new TrackingGpuBuffer(size: 4);
+        var bufPost1 = new TrackingGpuBuffer(size: 4);
+        var bufPost2 = new TrackingGpuBuffer(size: 4);
+
+        // ManagedBytes argument matches what CacheActivation computes: product(Shape) * 4.
+        object entryPre = entryCtor.Invoke(new object?[] { bufPre, new[] { 4 }, 1L, null, 16L });
+        Assert.True((bool)tryAdd.Invoke(activationCache, new[] { (object)keyPre, entryPre })!);
+        timestampField.SetValue(engine, 1L);
+
+        long snapshot = (long)snapshotMethod.Invoke(engine, null)!;
+        Assert.Equal(1L, snapshot);
+
+        object entryPost1 = entryCtor.Invoke(new object?[] { bufPost1, new[] { 4 }, 2L, null, 16L });
+        object entryPost2 = entryCtor.Invoke(new object?[] { bufPost2, new[] { 4 }, 3L, null, 16L });
+        Assert.True((bool)tryAdd.Invoke(activationCache, new[] { (object)keyPost1, entryPost1 })!);
+        Assert.True((bool)tryAdd.Invoke(activationCache, new[] { (object)keyPost2, entryPost2 })!);
+
+        evictMethod.Invoke(engine, new object[] { snapshot });
+
+        // Pre-snapshot entry survives — buffer not disposed, still in cache.
+        Assert.Equal(0, bufPre.DisposeCount);
+        Assert.True(((System.Collections.IDictionary)activationCache).Contains(keyPre));
+
+        // Post-snapshot entries are released — buffers disposed, removed from cache.
+        Assert.Equal(1, bufPost1.DisposeCount);
+        Assert.Equal(1, bufPost2.DisposeCount);
+        Assert.False(((System.Collections.IDictionary)activationCache).Contains(keyPost1));
+        Assert.False(((System.Collections.IDictionary)activationCache).Contains(keyPost2));
+    }
+
+    [Fact]
+    public void EvictActivationsCreatedAfter_MaterializesPendingDownloadBeforeFreeing()
+    {
+        // Same #226 contract as InvalidateActivationCacheEntryLifetimeTests, on the
+        // per-step release path: if an entry being released has a registered
+        // materializer, the download must complete BEFORE the buffer is freed.
+        // Without this, a later CPU read of the activation array fires the
+        // materializer against a freed GPU buffer (CL_INVALID_MEM_OBJECT, the
+        // original gfx1012 crash).
+        using var engine = new DirectGpuTensorEngine();
+        var engineType = typeof(DirectGpuTensorEngine);
+        var activationCacheField = engineType.GetField(
+            "_activationCache", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var timestampField = engineType.GetField(
+            "_activationCacheTimestamp", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var evictMethod = engineType.GetMethod(
+            "EvictActivationsCreatedAfter", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var activationCacheEntryType = engineType.Assembly.GetType(
+            "AiDotNet.Tensors.Engines.ActivationCacheEntry")!;
+        var entryCtor = GetActivationCacheEntryCtor(activationCacheEntryType);
+        object activationCache = activationCacheField.GetValue(engine)!;
+        var tryAdd = activationCache.GetType().GetMethod("TryAdd")!;
+
+        var key = new float[4];
+        var buffer = new TrackingGpuBuffer(size: 4);
+        object entry = entryCtor.Invoke(new object?[] { buffer, new[] { 4 }, 5L, null, 16L });
+        Assert.True((bool)tryAdd.Invoke(activationCache, new[] { (object)key, entry })!);
+        timestampField.SetValue(engine, 5L);
+
+        int disposeCountWhenMaterialized = -1;
+        bool materializerRan = false;
+        AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.Register(key, _ =>
+        {
+            materializerRan = true;
+            disposeCountWhenMaterialized = buffer.DisposeCount;
+        });
+
+        try
+        {
+            Assert.True(AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.IsPending(key));
+
+            // Snapshot of 0 means "all entries are post-snapshot" — releases everything.
+            evictMethod.Invoke(engine, new object[] { 0L });
+
+            Assert.True(materializerRan,
+                "EvictActivationsCreatedAfter must materialize a pending deferred download " +
+                "before disposing its buffer (#226 contract on the per-step release path).");
+            Assert.Equal(0, disposeCountWhenMaterialized);
+            Assert.False(AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.IsPending(key));
+            Assert.Equal(1, buffer.DisposeCount);
+        }
+        finally
+        {
+            AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.Remove(key);
+        }
+    }
+
+    [Fact]
+    public void EvictActivationsCreatedAfter_EmptyCache_IsSafeNoOp()
+    {
+        // Construction-time path: a GradientTape may capture a snapshot before any
+        // activation lands in the cache. The release call must be tolerant of an
+        // empty cache — early-return without locking-and-iterating thrash, and
+        // without throwing. This is the "nested tape under a no-op forward" shape.
+        using var engine = new DirectGpuTensorEngine();
+        var engineType = typeof(DirectGpuTensorEngine);
+        var evictMethod = engineType.GetMethod(
+            "EvictActivationsCreatedAfter", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        evictMethod.Invoke(engine, new object[] { 0L });
+        evictMethod.Invoke(engine, new object[] { long.MaxValue });
+    }
+
+    [Fact]
+    public void ActivationCacheTimestampSnapshot_IsMonotonicAndMatchesField()
+    {
+        using var engine = new DirectGpuTensorEngine();
+        var engineType = typeof(DirectGpuTensorEngine);
+        var timestampField = engineType.GetField(
+            "_activationCacheTimestamp", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var snapshotMethod = engineType.GetMethod(
+            "ActivationCacheTimestampSnapshot", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.Equal(0L, (long)snapshotMethod.Invoke(engine, null)!);
+
+        timestampField.SetValue(engine, 42L);
+        Assert.Equal(42L, (long)snapshotMethod.Invoke(engine, null)!);
+
+        // Monotonic — snapshot reflects later writes.
+        timestampField.SetValue(engine, 1000L);
+        Assert.Equal(1000L, (long)snapshotMethod.Invoke(engine, null)!);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/InvalidateActivationCacheEntryLifetimeTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/InvalidateActivationCacheEntryLifetimeTests.cs
@@ -43,12 +43,17 @@ public class InvalidateActivationCacheEntryLifetimeTests
 
     private static ConstructorInfo GetActivationCacheEntryCtor(Type activationCacheEntryType)
     {
+        // Matches the 5-parameter ctor introduced with the managed-byte backstop:
+        // (buffer, shape, timestamp, backend, managedBytes). managedBytes is the
+        // approximate managed-array footprint the entry pins; this test doesn't
+        // exercise the byte-cap, so the caller passes 0.
         var ctor = activationCacheEntryType.GetConstructor(new[]
         {
             typeof(IGpuBuffer),
             typeof(int[]),
             typeof(long),
-            typeof(IDirectGpuBackend)
+            typeof(IDirectGpuBackend),
+            typeof(long)
         });
         Assert.NotNull(ctor);
         return ctor!;
@@ -75,7 +80,7 @@ public class InvalidateActivationCacheEntryLifetimeTests
         // this buffer's contents into the key array — its only defined CPU value.
         var key = new float[4];
         var buffer = new TrackingGpuBuffer(size: 4);
-        object entry = entryCtor.Invoke(new object?[] { buffer, new[] { 4 }, 1L, null });
+        object entry = entryCtor.Invoke(new object?[] { buffer, new[] { 4 }, 1L, null, 0L });
         Assert.True((bool)tryAdd.Invoke(activationCache, new[] { (object)key, entry })!);
 
         // Register a pending materializer. It records the buffer's DisposeCount at the


### PR DESCRIPTION
## Problem
Cortex / transformer **training on the DirectGpu backend OOM-crashes at scale** (test host "process crashed", working set climbing to 45-63 GB on a tiny model). Root-caused with `gcroot` on a `dotnet-dump` heap snapshot:

```
DirectGpuTensorEngine._activationCache  (ConcurrentDictionary<object, ActivationCacheEntry>)
  -> Node -> System.Single[]   (the leaked [B,H,ctx,ctx] attention activations)
```

The cache **keys on the managed `float[]` backing arrays**, but eviction was driven **only** by a GPU-buffer-byte cap (75% VRAM) plus a 131072-entry backstop, and the per-tape-dispose cleanup (#283) invalidated **only each recorded `entry.Output`**. Activations cached under non-output keys (e.g. attention scores re-uploaded during backward) therefore **survived across training steps**: the managed heap grew unbounded -- **36.7 GB live after a forced GC** on a tiny d512/L6 transformer -- while VRAM stayed capped. The leak scales with `total_steps x layers`, so every real-N run crashed.

## Fix (two layers)
1. **Deterministic per-step release.** The outermost `GradientTape` snapshots the activation-cache timestamp at construction and, on `Dispose`, calls `EvictActivationsCreatedAfter(snapshot)` -- releasing **exactly** this forward+backward's activations (PyTorch/JAX per-step lifetime). Strict superset of the old per-`Output` walk; preserves entries created *before* the tape (cross-tape inference-reuse still holds); honors the #226 materialize-then-free contract so gradients are not corrupted.
2. **Managed-byte backstop.** New `_currentActivationManagedBytes` / `_maxActivationManagedBytes` (env `AIDOTNET_ACT_CACHE_MANAGED_MB`, default 8192) add an `overManaged` eviction trigger so managed retention stays bounded even if (1) is bypassed.

## Verification
Isolated repro (small transformer, many `Train` steps, heap logged):

| | live after GC | heap trajectory | peak WS |
|---|---|---|---|
| before | **36.7 GB** | monotonic to 37 GB | 36 GB (crash) |
| after | **1.475 GB** (25x) | bounded ~5-9 GB sawtooth | 15 GB |

Real cortex training test: **passes**, peak WS **8.9 GB** (was crashing at 45-63 GB), **loss decreases and param-L1 moves -> gradients intact**.

## Follow-up (not in this PR)
The remaining footprint is the eager autodiff path itself; the fused compiled path is currently OFF (`TryStepWithFusedOptimizer` returns false, reason "(unspecified gate)"), which would give constant memory with no managed tape. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
