### PR TITLE
fix(softmax): size SoftmaxBackward result to logical shape, not padded GPU backing length

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -19145,13 +19145,24 @@ public partial class CpuEngine : ITensorLevelEngine
         for (int i = 0; i < axis; i++) outerSize *= output._shape[i];
         for (int i = axis + 1; i < rank; i++) innerSize *= output._shape[i];
 
+        // Logical element count == product(output._shape). A GPU-origin tensor can carry a backing
+        // buffer LARGER than this — capacity-padded to a power of two (e.g. B*ctx 6144 rounded to 8192),
+        // or a view into a bigger buffer — so GetFlattenedData().Length may exceed the logical count.
+        // The result gradient must have the logical shape (Rent below validates length == shape total),
+        // and the kernels index row*axisSize within [0,total), so re-materialize the logical contiguous
+        // elements whenever the raw backing is longer. ToArray() respects shape/strides/offset; this is a
+        // no-op on the hot path (lengths already match). Mirrors GumbelSoftmaxBackward's contiguity guard.
+        int total = outerSize * axisSize * innerSize;
+
 #if NET5_0_OR_GREATER
         // Float SIMD fast path for last-axis softmax backward (innerSize == 1)
         if (typeof(T) == typeof(float) && innerSize == 1
-            && gradOutput.GetFlattenedData() is float[] gOutF
-            && output.GetFlattenedData() is float[] outF)
+            && gradOutput.GetFlattenedData() is float[] gOutF0
+            && output.GetFlattenedData() is float[] outF0)
         {
-            var gInF = new float[outF.Length];
+            var gOutF = gOutF0.Length == total ? gOutF0 : (float[])(object)gradOutput.ToArray();
+            var outF = outF0.Length == total ? outF0 : (float[])(object)output.ToArray();
+            var gInF = new float[total];
             SoftmaxBackwardFloat(gOutF, outF, gInF, outerSize, axisSize);
             return (Tensor<T>)(object)TensorAllocator.Rent<T>(output._shape, (T[])(object)gInF);
         }
@@ -19163,10 +19174,12 @@ public partial class CpuEngine : ITensorLevelEngine
         // (4 doubles per Vector256, vs 8 floats). Falls through to scalar
         // when AVX/FMA aren't available (net471 / non-x86).
         if (typeof(T) == typeof(double) && innerSize == 1
-            && gradOutput.GetFlattenedData() is double[] gOutD
-            && output.GetFlattenedData() is double[] outD)
+            && gradOutput.GetFlattenedData() is double[] gOutD0
+            && output.GetFlattenedData() is double[] outD0)
         {
-            var gInD = new double[outD.Length];
+            var gOutD = gOutD0.Length == total ? gOutD0 : (double[])(object)gradOutput.ToArray();
+            var outD = outD0.Length == total ? outD0 : (double[])(object)output.ToArray();
+            var gInD = new double[total];
             bool useParallel = outerSize >= 4 && (long)outerSize * axisSize >= 32768;
             int axisSz = axisSize;
             Action<int> rowKernel = row => SoftmaxBackwardDoubleRow(gOutD, outD, gInD, row, axisSz);
@@ -19181,7 +19194,9 @@ public partial class CpuEngine : ITensorLevelEngine
         var numOps = MathHelper.GetNumericOperations<T>();
         var gradOutputData = gradOutput.GetFlattenedData();
         var outputData = output.GetFlattenedData();
-        var gradInputData = new T[outputData.Length];
+        if (gradOutputData.Length != total) gradOutputData = gradOutput.ToArray();
+        if (outputData.Length != total) outputData = output.ToArray();
+        var gradInputData = new T[total];
 
         CpuParallelSettings.ParallelForOrSerial(0, outerSize * innerSize, (long)outerSize * innerSize * axisSize, idx =>
         {


### PR DESCRIPTION
Fixes a SoftmaxBackward crash on the GPU fused training path.

A GPU-origin tensor can carry a backing buffer (and cached Length) padded to a power of two while its logical _shape stays smaller (e.g. B*ctx=6144 rows allocated as 8192), so GetFlattenedData().Length (4194304) exceeds the logical element count (3145728). All three SoftmaxBackward paths (float SIMD, double SIMD, generic) allocated the result at the padded length and then Rent it against output._shape, throwing "Data length (4194304) must match shape total (3145728)". In fused training this knocks the step off the compiled path and then aborts (plan-embedded optimizer state cannot transfer to the eager fallback). It only bites when B*ctx is not a power of two, which is why B=64/128 runs were unaffected.

Fix: compute total = product(output._shape), allocate the result at total, and re-materialize the logical contiguous elements (ToArray) when the raw backing is longer. The kernels already index row*axisSize within [0,total) (the valid prefix). No-op on the hot path where lengths match; mirrors the contiguity guard GumbelSoftmaxBackward already uses.

Verification: opt-parity LEAKPROBE on the GPU fused path at B=96 ctx=64 V=15001 d=512 L=6 ff=1024 (B*ctx=6144 padded to 8192) -- before: throws at step 0; after: 10 steps clean, exit 0. Existing softmax suite (87 tests) stays green.

Generated with Claude Code.