### PR TITLE
AiDotNet.Native.CUDA: add nvRTC + automate staging/release

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -368,6 +368,27 @@ jobs:
             Write-Host "Skipping AiDotNet.Native.ROCm - native binaries not present"
           }
 
+          # Pack CUDA native package (NVIDIA GPU: cudart + cuBLAS + cuBLASLt + nvRTC).
+          # Binaries (~770MB) are gitignored; stage them from the official NVIDIA
+          # redistributable archives first, then pack (industry-standard, no toolkit install).
+          $cudaProj = "src/AiDotNet.Native.CUDA/AiDotNet.Native.CUDA.csproj"
+          if (Test-Path $cudaProj) {
+            Write-Host "Staging CUDA runtime from NVIDIA redist..."
+            pwsh ./tools/stage-cuda-redist.ps1
+            $cudaNative = "src/AiDotNet.Native.CUDA/runtimes/win-x64/native"
+            if ((Test-Path "$cudaNative/cudart64_12.dll") -and (Test-Path "$cudaNative/nvrtc64_120_0.dll")) {
+              Write-Host "Packing AiDotNet.Native.CUDA..."
+              dotnet restore $cudaProj
+              if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+              dotnet build $cudaProj -c Release --no-restore
+              if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+              dotnet pack $cudaProj -c Release -o out --no-build /p:PackageVersion=$VERSION
+              if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+            } else {
+              Write-Host "Skipping AiDotNet.Native.CUDA - staging did not produce the required runtime DLLs"
+            }
+          }
+
           # Pack MoltenVK native package (Vulkan on macOS via Metal translation)
           # Only pack if all required native binaries are present for both architectures
           # Note: MoltenVK is not in the solution file, so dotnet restore/build above skips it.
@@ -530,7 +551,7 @@ jobs:
             ## Packages
 
             ${{ steps.packages.outputs.list }}
-            > Note: AiDotNet.Native.CUDA must be built locally due to large binary size (770MB).
+            > Note: AiDotNet.Native.CUDA (~770MB) bundles the NVIDIA CUDA 12 runtime (cudart / cuBLAS / cuBLASLt / nvRTC). It is published by this pipeline (binaries staged from the official NVIDIA redist) and is opt-in — add it alongside AiDotNet.Tensors only on NVIDIA GPU machines.
             > Note: AiDotNet.Native.ROCm requires ROCm installed on the target machine for the kernel library (~496MB).
 
             ## Installation

--- a/src/AiDotNet.Native.CUDA/AiDotNet.Native.CUDA.csproj
+++ b/src/AiDotNet.Native.CUDA/AiDotNet.Native.CUDA.csproj
@@ -22,11 +22,13 @@
     <ContentTargetFolders>content</ContentTargetFolders>
   </PropertyGroup>
 
-  <!-- Windows x64 native libraries -->
+  <!-- Windows x64 native libraries: cudart, cuBLAS, cuBLASLt, AND nvRTC (+ builtins).
+       nvRTC is required by AiDotNet.Tensors' CUDA backend for runtime kernel JIT;
+       without it CUDA ops fail (cuMemAlloc/cuMemcpyHtoD error 700). Binaries are
+       staged by tools/stage-cuda-redist.ps1 (gitignored, ~770MB) and packed via a
+       wildcard so the full runtime is always included. -->
   <ItemGroup>
-    <None Include="runtimes\win-x64\native\cublas64_12.dll" Pack="true" PackagePath="runtimes\win-x64\native" />
-    <None Include="runtimes\win-x64\native\cublasLt64_12.dll" Pack="true" PackagePath="runtimes\win-x64\native" />
-    <None Include="runtimes\win-x64\native\cudart64_12.dll" Pack="true" PackagePath="runtimes\win-x64\native" />
+    <None Include="runtimes\win-x64\native\*.dll" Pack="true" PackagePath="runtimes\win-x64\native" />
   </ItemGroup>
 
   <!-- Future: Linux x64 native libraries -->

--- a/tools/stage-cuda-redist.ps1
+++ b/tools/stage-cuda-redist.ps1
@@ -1,0 +1,66 @@
+<#
+.SYNOPSIS
+  Stages the NVIDIA CUDA runtime DLLs that AiDotNet.Native.CUDA packs.
+
+.DESCRIPTION
+  Populates src/AiDotNet.Native.CUDA/runtimes/win-x64/native with the CUDA 12
+  runtime AiDotNet.Tensors' CUDA backend needs at run time:
+    cudart64_12, cublas64_12, cublasLt64_12, nvrtc64_120_0(+.alt), nvrtc-builtins64_*
+  These are gitignored (~770MB) and fetched on demand so the release pipeline can
+  build the package without committing the binaries (industry-standard, like the
+  other AiDotNet.Native.* packages).
+
+  Source: the official NVIDIA CUDA redistributable archives (no toolkit install
+  needed), parsed from redistrib_<version>.json. For local/offline use, pass
+  -LocalSource <dir> to copy already-downloaded DLLs instead.
+
+.EXAMPLE
+  ./tools/stage-cuda-redist.ps1                       # download CUDA 12.6.3 redist
+  ./tools/stage-cuda-redist.ps1 -LocalSource C:\cuda  # copy from a local folder
+#>
+param(
+    [string]$CudaVersion = "12.6.3",
+    [string]$OutputDir = "$PSScriptRoot/../src/AiDotNet.Native.CUDA/runtimes/win-x64/native",
+    [string]$LocalSource = ""
+)
+
+$ErrorActionPreference = "Stop"
+$wanted = @("cudart64_", "cublas64_", "cublasLt64_", "nvrtc64_", "nvrtc-builtins64_")
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+
+function Want([string]$name) { foreach ($w in $wanted) { if ($name -like "$w*") { return $true } } return $false }
+
+if ($LocalSource) {
+    Write-Host "Staging CUDA runtime from local source: $LocalSource"
+    Get-ChildItem $LocalSource -Filter *.dll | Where-Object { Want $_.Name } | ForEach-Object {
+        Copy-Item $_.FullName -Destination $OutputDir -Force
+        Write-Host "  + $($_.Name)"
+    }
+    return
+}
+
+$base = "https://developer.download.nvidia.com/compute/cuda/redist"
+$manifest = Invoke-RestMethod "$base/redistrib_$CudaVersion.json"
+$components = @("cuda_cudart", "libcublas", "cuda_nvrtc")
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) "cuda-redist-$CudaVersion"
+New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+
+foreach ($component in $components) {
+    $rel = $manifest.$component."windows-x86_64".relative_path
+    if (-not $rel) { Write-Warning "No windows-x86_64 archive for $component"; continue }
+
+    $url = "$base/$rel"
+    $zip = Join-Path $tmp (Split-Path $rel -Leaf)
+    $extract = Join-Path $tmp $component
+
+    Write-Host "Downloading $component -> $url"
+    Invoke-WebRequest $url -OutFile $zip
+    Expand-Archive $zip -DestinationPath $extract -Force
+
+    Get-ChildItem $extract -Recurse -Filter *.dll | Where-Object { Want $_.Name } | ForEach-Object {
+        Copy-Item $_.FullName -Destination $OutputDir -Force
+        Write-Host "  + $($_.Name)"
+    }
+}
+
+Write-Host "Staged CUDA runtime into $OutputDir"


### PR DESCRIPTION
Fixes the CUDA native package: adds the missing nvRTC runtime (the cause of cuMemAlloc/cuMemcpyHtoD error 700 in the CUDA backend's kernel JIT), packs the full win-x64 runtime via wildcard, adds tools/stage-cuda-redist.ps1 to fetch binaries from the official NVIDIA redist, and wires staging+pack into automated-release.yml so it's published like the other AiDotNet.Native.* packages. Verified locally: 604MB nupkg containing cudart/cuBLAS/cuBLASLt/nvRTC(+builtins).