### PR TITLE
feat(fp16): route raw Half MatMul to FP16 Tensor-Core GEMM (stacked on #557)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpu/DirectGpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/DirectGpuEngine.cs
@@ -546,6 +546,32 @@ public sealed class DirectGpuEngine : IDisposable
         // than silently downcasting through the FP32 GPU boundary.
         if (ShouldFallbackForPrecision<T>()) return null;
 
+        // FP16 Tensor-Core fast path (composes with the #557 mixed-precision infra):
+        // a raw Half matmul routes to cublasGemmEx (FP16 multiply / FP32 accumulate)
+        // on the Tensor Cores instead of an FP32-downcast SGEMM. Half is a
+        // reduced-precision type whose whole point is speed, so — unlike double —
+        // the right behaviour is to run it on the GPU, not bail to the CPU. Falls
+        // through to the FP32 path below if the backend has no Hgemm support.
+        if (typeof(T) == typeof(Half)
+            && _backend is AiDotNet.Tensors.Engines.Gpu.IGpuHalfPrecisionBackend halfBackend
+            && halfBackend.SupportsHgemm)
+        {
+            float[] aHalfIn = ToFloatArray(A);
+            float[] bHalfIn = ToFloatArray(B);
+            using var aFp32 = _backend.AllocateBuffer(aHalfIn);
+            using var bFp32 = _backend.AllocateBuffer(bHalfIn);
+            using var aFp16 = _backend.AllocateBuffer(aHalfIn.Length);
+            using var bFp16 = _backend.AllocateBuffer(bHalfIn.Length);
+            _backend.ConvertToFp16(aFp32, aFp16, aHalfIn.Length);
+            _backend.ConvertToFp16(bFp32, bFp16, bHalfIn.Length);
+            using var cHalfOut = _backend.AllocateBuffer(M * N);
+            halfBackend.GemmFp16In32fOut(aFp16, bFp16, cHalfOut, M, N, K);
+            float[] halfResult = _backend.DownloadBuffer(cHalfOut);
+            if (GemmValidateEnabled && IsAnyNonFinite(halfResult, out _))
+                return null;
+            return FromFloatArray<T>(halfResult);
+        }
+
         // Convert to float
         float[] aFloat = ToFloatArray(A);
         float[] bFloat = ToFloatArray(B);


### PR DESCRIPTION
Completes a gap that ties into downstream GPU training work: a raw `MatrixMultiply<Half>` on the GPU took the FP32-downcast SGEMM path instead of the FP16 Tensor Cores. This routes Half through #557's `ConvertToFp16` + `GemmFp16In32fOut` (cublasGemmEx, FP16-in/FP32-accumulate) when the backend `SupportsHgemm`, falling through to FP32 otherwise.

**Stacked on #557** (feat/fp16-activation-storage) - depends on its FP16 primitives; retarget to main after #557 merges.

Verification: local full build is blocked by a pre-existing `build/LicenseValidator` netstandard/Cryptography issue in my environment (unrelated). Please let CI validate; correctness is covered by the Fp16MatMulCorrectnessTests pattern (FP16 within tolerance of FP32). Context: issue #560.