### PR TITLE
feat(autodiff): memory-bounded streaming backward (optimizer-in-backward)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
@@ -407,6 +407,27 @@ public sealed class GradientTape<T> : IDisposable
                 ref var step = ref steps[i];
                 if (grads.TryGetValue(step.Output, out var gradOutput))
                 {
+                    // Weight-streaming integration: rehydrate any paged-out input
+                    // weights before the backward reads them. The forward path does
+                    // this through StreamingAutogradHook.OnInputAccessed; the plain
+                    // streaming-backward walk bypasses that hook, so materialize
+                    // explicitly here. Materialize is a no-op for tensors that are
+                    // resident or not registered with the streaming pool, so this is
+                    // free when weight streaming is off. The pool evicts other LRU
+                    // weights to stay under its resident cap, keeping peak bounded —
+                    // and the just-materialized weight is resident when its gradient
+                    // completes (its last use), so the optimizer epilogue can update
+                    // it in place; eviction later writes the update back to disk.
+                    var stepInputs = step.Inputs;
+                    if (stepInputs is not null)
+                    {
+                        for (int j = 0; j < stepInputs.Length; j++)
+                        {
+                            var inp = stepInputs[j];
+                            if (inp is not null) WeightRegistry.Materialize(inp);
+                        }
+                    }
+
                     step.Backward(gradOutput, step.Inputs, step.Output,
                         step.SavedState ?? Array.Empty<object>(), engine, grads);
                 }

--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
@@ -277,6 +277,173 @@ public sealed class GradientTape<T> : IDisposable
         return new GradientsScope<T>(grads);
     }
 
+    /// <summary>
+    /// Memory-bounded streaming backward. Computes the gradient of
+    /// <paramref name="loss"/> w.r.t. each tensor in <paramref name="sources"/>
+    /// (the model parameters) and hands each one to
+    /// <paramref name="onSourceGradient"/> at the exact backward step where its
+    /// last contribution lands — its provably-earliest safe release point — then
+    /// drops the reference so the gradient set is reclaimed incrementally. The
+    /// full parameter-gradient set is therefore NEVER resident at once, which is
+    /// what lets a model whose gradients exceed RAM still take a training step
+    /// (the per-parameter optimizer update happens inside the callback).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the single-process, deterministic analogue of PyTorch's
+    /// optimizer-in-backward (<c>_apply_optimizer_in_backward</c>) / FSDP
+    /// CPU-offload, but it frees each gradient at its topological last-use rather
+    /// than at parameter-registration granularity, minimizing the peak resident
+    /// gradient set. Gradients are accumulated in the same reverse-topological
+    /// order the standard <see cref="ComputeGradients"/> path uses, so the values
+    /// handed to the callback are bit-identical to the non-streaming result.
+    /// </para>
+    /// <para>
+    /// The callback MUST consume its gradient synchronously (apply the optimizer
+    /// step) and must NOT retain the reference — the gradient buffer is released
+    /// for collection as soon as the callback returns. A source that receives no
+    /// gradient contribution gets no callback (mirrors <see cref="ComputeGradients"/>
+    /// omitting it from the returned dictionary).
+    /// </para>
+    /// </remarks>
+    /// <param name="loss">The scalar loss tensor to differentiate. Must be
+    /// tape-connected (non-null <c>GradFn</c>).</param>
+    /// <param name="sources">Parameter tensors whose gradients to stream. Each is
+    /// emitted exactly once, when complete.</param>
+    /// <param name="onSourceGradient">Invoked as <c>(source, gradient)</c> the
+    /// moment <paramref name="loss"/>'s gradient w.r.t. that source is final.</param>
+    public void ComputeGradientsStreaming(
+        Tensor<T> loss,
+        IReadOnlyList<Tensor<T>> sources,
+        Action<Tensor<T>, Tensor<T>> onSourceGradient)
+    {
+        if (_disposed) throw new ObjectDisposedException(nameof(GradientTape<T>));
+        if (sources is null) throw new ArgumentNullException(nameof(sources));
+        if (onSourceGradient is null) throw new ArgumentNullException(nameof(onSourceGradient));
+        if (_entries.Count == 0)
+            throw new InvalidOperationException("Cannot compute gradients: the tape has no recorded operations.");
+        if (loss.GradFn is null)
+            throw new InvalidOperationException(
+                "Streaming backward requires a tape-connected loss (loss.GradFn is null).");
+
+        var engine = _engine;
+        var numOps = Helpers.MathHelper.GetNumericOperations<T>();
+
+        // Suspend recording so the backward ops invoked below don't append fresh
+        // tape entries (parity with the non-streaming graph path, which also
+        // suspends — see ComputeGradients line ~306).
+        var savedCurrent = _current;
+        SetCurrentTape(null);
+        try
+        {
+            // Forward topological order; reverse is the backward execution order.
+            var visited = new HashSet<GradNode<T>>();
+            var topoOrder = new List<GradNode<T>>();
+            TopologicalSort(loss.GradFn!, visited, topoOrder);
+            int stepCount = topoOrder.Count;
+
+            var steps = new BackwardStep<T>[stepCount];
+            for (int i = 0; i < stepCount; i++)
+            {
+                var node = topoOrder[stepCount - 1 - i]; // reverse for backward
+                steps[i] = new BackwardStep<T>
+                {
+                    Output = node.Output,
+                    Inputs = node.GetInputsArray(),
+                    Backward = node.Backward,
+                    SavedState = node.SavedState,
+                };
+            }
+
+            // Last backward step that contributes to each source's gradient.
+            // A source is a leaf parameter: it only ever appears as an op INPUT,
+            // so its gradient is only written (accumulated), never read as a
+            // step output — making the last write its safe release point.
+            var lastUse = new Dictionary<Tensor<T>, int>(
+                ReferenceEqualityComparer<Tensor<T>>.Instance);
+            foreach (var s in sources)
+                if (s is not null && !lastUse.ContainsKey(s)) lastUse[s] = -1;
+            for (int i = 0; i < stepCount; i++)
+            {
+                var inputs = steps[i].Inputs;
+                if (inputs is null) continue;
+                for (int j = 0; j < inputs.Length; j++)
+                {
+                    var inp = inputs[j];
+                    if (inp is not null && lastUse.ContainsKey(inp))
+                        lastUse[inp] = i; // later step overwrites → keeps the last
+                }
+            }
+            // stepIndex -> sources to emit+release right after that step runs.
+            var emitAt = new Dictionary<int, List<Tensor<T>>>();
+            foreach (var kv in lastUse)
+            {
+                if (kv.Value < 0) continue; // source never used → no gradient
+                if (!emitAt.TryGetValue(kv.Value, out var list))
+                    emitAt[kv.Value] = list = new List<Tensor<T>>();
+                list.Add(kv.Key);
+            }
+
+            var grads = new Dictionary<Tensor<T>, Tensor<T>>(
+                stepCount + 1, ReferenceEqualityComparer<Tensor<T>>.Instance);
+
+            // Seed gradient (dL/dL = 1), same construction as the chain executor.
+            Tensor<T> seedGrad;
+            if (loss.Length == 1)
+            {
+                seedGrad = new Tensor<T>(new[] { numOps.One }, new[] { 1 });
+            }
+            else
+            {
+                var onesData = new T[loss.Length];
+                var one = numOps.One;
+                for (int j = 0; j < onesData.Length; j++) onesData[j] = one;
+                seedGrad = new Tensor<T>(onesData, loss._shape);
+            }
+            grads[loss] = seedGrad;
+
+            for (int i = 0; i < stepCount; i++)
+            {
+                ref var step = ref steps[i];
+                if (grads.TryGetValue(step.Output, out var gradOutput))
+                {
+                    step.Backward(gradOutput, step.Inputs, step.Output,
+                        step.SavedState ?? Array.Empty<object>(), engine, grads);
+                }
+
+                // Emit + release every source whose gradient just completed.
+                if (emitAt.TryGetValue(i, out var ready))
+                {
+                    for (int k = 0; k < ready.Count; k++)
+                    {
+                        var src = ready[k];
+                        if (grads.TryGetValue(src, out var g))
+                        {
+                            onSourceGradient(src, g);
+                            grads.Remove(src);   // drop the dict reference …
+                            src.Grad = null;     // … and the per-tensor mirror → reclaimable
+                        }
+                    }
+                }
+            }
+
+            // Clear .Grad on forward intermediates (parity with the non-persistent
+            // cleanup in ComputeGradientsViaGraphCore) so they don't pin a full
+            // backward's worth of gradient tensors after we return.
+            foreach (var node in topoOrder)
+            {
+                var outp = node.Output;
+                if (outp is not null && !lastUse.ContainsKey(outp))
+                    outp.Grad = null;
+            }
+        }
+        finally
+        {
+            SetCurrentTape(savedCurrent);
+            if (!_options.Persistent) _entries.Reset();
+        }
+    }
+
     public Dictionary<Tensor<T>, Tensor<T>> ComputeGradients(
         Tensor<T> loss,
         IReadOnlyList<Tensor<T>>? sources = null,

--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
@@ -387,11 +387,14 @@ public sealed class GradientTape<T> : IDisposable
             var grads = new Dictionary<Tensor<T>, Tensor<T>>(
                 stepCount + 1, ReferenceEqualityComparer<Tensor<T>>.Instance);
 
-            // Seed gradient (dL/dL = 1), same construction as the chain executor.
+            // Seed gradient (dL/dL = 1), same construction as ComputeGradients:
+            // use the loss's ACTUAL shape (which may be [] for a 0-dim scalar or
+            // [1]), not a hardcoded [1] — a hardcoded rank-1 seed mismatches a
+            // 0-dim scalar loss and can break shape-checked backward ops.
             Tensor<T> seedGrad;
             if (loss.Length == 1)
             {
-                seedGrad = new Tensor<T>(new[] { numOps.One }, new[] { 1 });
+                seedGrad = new Tensor<T>(new[] { numOps.One }, (int[])loss._shape.Clone());
             }
             else
             {

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeStreamingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeStreamingTests.cs
@@ -1,0 +1,164 @@
+using System.Collections.Generic;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+/// <summary>
+/// Tests for <see cref="GradientTape{T}.ComputeGradientsStreaming"/> — the
+/// memory-bounded streaming backward that emits + releases each parameter
+/// gradient at its topological last-use. The headline contract is that the
+/// streamed gradients are bit-identical to the non-streaming
+/// <see cref="GradientTape{T}.ComputeGradients"/> path, that each source is
+/// emitted exactly once, and that a source used in multiple ops is only emitted
+/// after its FINAL contribution (so partial gradients are never handed out).
+/// </summary>
+public class GradientTapeStreamingTests
+{
+    private readonly CpuEngine _engine = new();
+
+    /// <summary>
+    /// Builds a small graph where `a` feeds TWO ops (multiply + add) so its
+    /// gradient accumulates across two backward steps — the case the last-use
+    /// release point must get right. loss = sum(a*b + (a+b)); da = b + 1, db = a + 1.
+    /// </summary>
+    [Fact]
+    public void Streaming_MatchesComputeGradients_BitIdentical()
+    {
+        var aData = new double[] { 2, 3, 4 };
+        var bData = new double[] { 5, 6, 7 };
+
+        // Reference: standard ComputeGradients.
+        Tensor<double> refGradA, refGradB;
+        {
+            var a = new Tensor<double>(new[] { 3 }, new Vector<double>((double[])aData.Clone()));
+            var b = new Tensor<double>(new[] { 3 }, new Vector<double>((double[])bData.Clone()));
+            using var tape = new GradientTape<double>();
+            var c = _engine.TensorMultiply(a, b);
+            var d = _engine.TensorAdd(a, b);
+            var e = _engine.TensorAdd(c, d);
+            var loss = _engine.ReduceSum(e, null);
+            var grads = tape.ComputeGradients(loss, new[] { a, b });
+            refGradA = grads[a];
+            refGradB = grads[b];
+        }
+
+        // Streaming: same graph, gradients collected via the callback.
+        var streamed = new Dictionary<Tensor<double>, Tensor<double>>(
+            ReferenceEqualityComparer<Tensor<double>>.Instance);
+        var callbackCount = new Dictionary<Tensor<double>, int>(
+            ReferenceEqualityComparer<Tensor<double>>.Instance);
+        Tensor<double> sa, sb;
+        {
+            sa = new Tensor<double>(new[] { 3 }, new Vector<double>((double[])aData.Clone()));
+            sb = new Tensor<double>(new[] { 3 }, new Vector<double>((double[])bData.Clone()));
+            using var tape = new GradientTape<double>();
+            var c = _engine.TensorMultiply(sa, sb);
+            var d = _engine.TensorAdd(sa, sb);
+            var e = _engine.TensorAdd(c, d);
+            var loss = _engine.ReduceSum(e, null);
+            tape.ComputeGradientsStreaming(loss, new[] { sa, sb }, (src, grad) =>
+            {
+                // Copy out of the grad before it is released after the callback.
+                var copy = new Tensor<double>(grad._shape, new Vector<double>(grad.ToArray()));
+                streamed[src] = copy;
+                callbackCount[src] = callbackCount.TryGetValue(src, out var n) ? n + 1 : 1;
+            });
+        }
+
+        // Each source emitted exactly once (even though `a` feeds two ops).
+        Assert.Equal(1, callbackCount[sa]);
+        Assert.Equal(1, callbackCount[sb]);
+
+        // PRIMARY CONTRACT: streamed gradients are bit-identical to the
+        // non-streaming ComputeGradients result, element for element.
+        for (int i = 0; i < 3; i++)
+        {
+            Assert.Equal(refGradA[i], streamed[sa][i]);
+            Assert.Equal(refGradB[i], streamed[sb][i]);
+        }
+    }
+
+    /// <summary>
+    /// Sanity-checks the streaming gradient against the textbook value on a
+    /// clean graph where each source is used exactly once:
+    /// loss = sum(a*b) → da = b, db = a.
+    /// </summary>
+    [Fact]
+    public void Streaming_SingleUseSources_MatchesTextbook()
+    {
+        var aData = new double[] { 2, 3, 4 };
+        var bData = new double[] { 5, 6, 7 };
+        var a = new Tensor<double>(new[] { 3 }, new Vector<double>((double[])aData.Clone()));
+        var b = new Tensor<double>(new[] { 3 }, new Vector<double>((double[])bData.Clone()));
+
+        using var tape = new GradientTape<double>();
+        var c = _engine.TensorMultiply(a, b);
+        var loss = _engine.ReduceSum(c, null);
+
+        var streamed = new Dictionary<Tensor<double>, double[]>(
+            ReferenceEqualityComparer<Tensor<double>>.Instance);
+        tape.ComputeGradientsStreaming(loss, new[] { a, b }, (src, grad) => streamed[src] = grad.ToArray());
+
+        for (int i = 0; i < 3; i++)
+        {
+            Assert.Equal(bData[i], streamed[a][i], 10); // da = b
+            Assert.Equal(aData[i], streamed[b][i], 10); // db = a
+        }
+    }
+
+    /// <summary>
+    /// A source that contributes no gradient (not on the loss path) must get no
+    /// callback — matching ComputeGradients omitting it from the returned dict.
+    /// </summary>
+    [Fact]
+    public void Streaming_UnusedSource_GetsNoCallback()
+    {
+        var a = new Tensor<double>(new[] { 2 }, new Vector<double>(new double[] { 1, 2 }));
+        var b = new Tensor<double>(new[] { 2 }, new Vector<double>(new double[] { 3, 4 }));
+        var unused = new Tensor<double>(new[] { 2 }, new Vector<double>(new double[] { 9, 9 }));
+
+        using var tape = new GradientTape<double>();
+        var z = _engine.TensorAdd(a, b);
+        var loss = _engine.ReduceSum(z, null);
+
+        var emitted = new HashSet<Tensor<double>>(ReferenceEqualityComparer<Tensor<double>>.Instance);
+        tape.ComputeGradientsStreaming(loss, new[] { a, b, unused }, (src, _) => emitted.Add(src));
+
+        Assert.Contains(a, emitted);
+        Assert.Contains(b, emitted);
+        Assert.DoesNotContain(unused, emitted);
+    }
+
+    /// <summary>
+    /// Determinism: streaming twice over the same graph yields identical
+    /// gradients (the accumulation order is the fixed reverse-topological order).
+    /// </summary>
+    [Fact]
+    public void Streaming_IsDeterministic_AcrossRuns()
+    {
+        double[] Run()
+        {
+            var a = new Tensor<double>(new[] { 4 }, new Vector<double>(new double[] { 1.5, -2.0, 3.25, 0.5 }));
+            var b = new Tensor<double>(new[] { 4 }, new Vector<double>(new double[] { 2.0, 4.0, -1.0, 6.0 }));
+            using var tape = new GradientTape<double>();
+            var c = _engine.TensorMultiply(a, b);
+            var d = _engine.TensorMultiply(c, a); // a used twice
+            var loss = _engine.ReduceSum(d, null);
+            double[]? ga = null;
+            tape.ComputeGradientsStreaming(loss, new[] { a }, (src, grad) =>
+            {
+                if (ReferenceEquals(src, a)) ga = grad.ToArray();
+            });
+            return ga!;
+        }
+
+        var r1 = Run();
+        var r2 = Run();
+        Assert.Equal(r1.Length, r2.Length);
+        for (int i = 0; i < r1.Length; i++)
+            Assert.Equal(r1[i], r2[i]);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a memory-bounded **streaming backward** to `GradientTape<T>` — the autodiff
primitive that lets a model whose gradients exceed RAM still take a training
step. It is the single-process, deterministic analogue of PyTorch's
`_apply_optimizer_in_backward` / FSDP CPU-offload, but frees each gradient at its
**topological last-use** (provably-earliest release point) rather than at
parameter-registration granularity, so the peak resident gradient set is
minimal.

### What's added (additive — existing paths untouched)
- **`GradientTape.ComputeGradientsStreaming(loss, sources, onSourceGradient)`** —
  computes each parameter's gradient and hands it to the callback at the exact
  backward step where its last contribution lands, then releases it. The full
  parameter-gradient set is never resident at once (the per-parameter optimizer
  update happens inside the callback). Forces the plain reverse-topo walk so the
  per-step emit hook runs; gradients accumulate in the same order as
  `ComputeGradients`, so the streamed values are **bit-identical** to the
  non-streaming result.
- **Weight-streaming integration** — the streaming backward rehydrates each
  step's paged-out input weights via `WeightRegistry.Materialize` before reading
  them (the forward path already does this through `StreamingAutogradHook`; the
  plain-walk backward bypassed it). No-op when weight streaming is off. Combined
  with the streaming pool's write-back-on-evict, this enables gradient-streaming
  × weight-streaming together: bounded peak weights **and** bounded peak
  gradients.

The existing `ComputeGradients` / compiled-chain / rebindable-plan-cache fast
paths are completely untouched.

## Tests
`GradientTapeStreamingTests` (4/4): streamed gradients bit-identical to
`ComputeGradients` on an `a`-used-twice graph; textbook `da=b`/`db=a` on a clean
graph; one callback per source; unused source gets none; deterministic across
runs.

## Why
Consumed by AiDotNet's memory-bounded streaming training subsystem (8-bit Adam
optimizer-in-backward) to train large models that would otherwise OOM. This is
the Tensors half of that cross-repo feature; the AiDotNet PR pins to the release
cut from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)