### PR TITLE
feat(gpu): self-healing GPU fault recovery — circuit breaker + guards

### DIFF
--- a/src/AiDotNet.Tensors/Engines/AiDotNetEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/AiDotNetEngine.cs
@@ -178,6 +178,15 @@ public static class AiDotNetEngine
     /// <returns>True if GPU was successfully configured, false otherwise.</returns>
     public static bool AutoDetectAndConfigureGpu(bool verbose)
     {
+        // Once the GPU circuit breaker has tripped (a sticky CUDA fault corrupted the context),
+        // never re-adopt the GPU for the rest of the process — re-engaging would immediately fault
+        // again on the dead context. Stay on CPU.
+        if (_gpuCircuitBroken)
+        {
+            Current = new CpuEngine();
+            return false;
+        }
+
         try
         {
             var gpuEngine = new DirectGpuTensorEngine();
@@ -335,6 +344,42 @@ public static class AiDotNetEngine
     {
         Current = new CpuEngine();
         EmitLog("[AiDotNet] Reset to CPU engine", verbose: true);
+    }
+
+    private static volatile bool _gpuCircuitBroken;
+
+    /// <summary>True once a sticky CUDA fault has forced a permanent CPU fallback for this process.</summary>
+    public static bool GpuCircuitBroken => _gpuCircuitBroken;
+
+    /// <summary>
+    /// Trips the process-wide GPU circuit breaker after a sticky/context-corrupting CUDA fault
+    /// (illegal address 700, context destroyed 709, launch failed 719). Switches the engine to CPU
+    /// and blocks any further GPU adoption, so a single GPU fault degrades to CPU instead of
+    /// cascading the same failure across every subsequent op. Safe to call from inside a CUDA error
+    /// path — it never throws.
+    /// </summary>
+    public static void TripGpuCircuitBreaker(string operation, int cudaErrorCode)
+    {
+        if (_gpuCircuitBroken)
+        {
+            return;
+        }
+
+        _gpuCircuitBroken = true;
+        try
+        {
+            if (_current is DirectGpuTensorEngine)
+            {
+                _current = new CpuEngine();
+            }
+        }
+        catch
+        {
+            // The breaker must never throw — it runs from within a CUDA error handler.
+        }
+
+        EmitLog($"[AiDotNet] GPU circuit breaker tripped by '{operation}' (CUDA error {cudaErrorCode}); " +
+            "falling back to CPU for the rest of the process.", verbose: true);
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/Compilation/AutoTrainingCompiler.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/AutoTrainingCompiler.cs
@@ -244,12 +244,27 @@ internal static class AutoTrainingCompiler
     /// Minimum total forward-activation element count for a training step to be worth compiling.
     /// Below this, eager execution is used: compilation overhead exceeds any GPU benefit at this
     /// size and the GPU buffer-cache deferred-materializer path (#226) is avoided. Override with the
-    /// AIDOTNET_COMPILE_MIN_ELEMENTS environment variable.
+    /// AIDOTNET_COMPILE_MIN_ELEMENTS environment variable (read once at type load).
     /// </summary>
-    private static readonly long CompiledTrainingMinForwardElements =
+    private static readonly long CompiledTrainingMinForwardElementsDefault =
         long.TryParse(Environment.GetEnvironmentVariable("AIDOTNET_COMPILE_MIN_ELEMENTS"), out var configured) && configured > 0
             ? configured
             : 1_000_000L;
+
+    /// <summary>
+    /// Test-only override of the compile size gate. The env-backed default is a
+    /// <c>static readonly</c> read once at type load, so tests that exercise the
+    /// replay mechanism on deliberately tiny tapes cannot lower it via the env var
+    /// after the type is initialized. Set this (and reset to <c>null</c> in teardown)
+    /// to force compilation of small steps without a real million-element model.
+    /// Null = use the env-or-1M default. Mirrors the established test-hook pattern
+    /// (e.g. MixedPrecisionEmit.TestOverrideEnabled).
+    /// </summary>
+    internal static long? TestMinForwardElementsOverride { get; set; }
+
+    /// <summary>Effective size-gate threshold: the test override when set, else the env-or-1M default.</summary>
+    private static long CompiledTrainingMinForwardElements
+        => TestMinForwardElementsOverride ?? CompiledTrainingMinForwardElementsDefault;
 
     /// <summary>Sum of forward-activation element counts on the tape (early-exits once the threshold is reached).</summary>
     private static long TotalForwardElements<T>(GradientTape<T> tape)

--- a/src/AiDotNet.Tensors/Engines/Compilation/AutoTrainingCompiler.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/AutoTrainingCompiler.cs
@@ -115,6 +115,18 @@ internal static class AutoTrainingCompiler
         if (!tape.Options.Persistent) return;
         if (!State.ShouldCompile) return;
 
+        // Size gate: only compile steps whose forward activation volume is large enough to benefit
+        // from GPU-resident execution. Tiny models (small RL policies, shallow tabular nets) gain
+        // nothing from compilation — kernel-launch/transfer overhead dominates — and on the GPU
+        // buffer-cache path they can trip the deferred-materializer-vs-eviction race (#226), so we
+        // keep them on the eager path. Large models (transformer-scale training) still compile.
+        if (TotalForwardElements(tape) < CompiledTrainingMinForwardElements)
+        {
+            // Mark this pattern as not-to-compile so we don't re-evaluate every step; it runs eager.
+            State.MarkCompilationFailed();
+            return;
+        }
+
         // Clone-then-train safety: when `sources` is null the cache key
         // collapses to structure-only, which would let a cloned model with
         // identical architecture hit the original's compiled plan and replay
@@ -226,6 +238,43 @@ internal static class AutoTrainingCompiler
             }
         }
         return hash;
+    }
+
+    /// <summary>
+    /// Minimum total forward-activation element count for a training step to be worth compiling.
+    /// Below this, eager execution is used: compilation overhead exceeds any GPU benefit at this
+    /// size and the GPU buffer-cache deferred-materializer path (#226) is avoided. Override with the
+    /// AIDOTNET_COMPILE_MIN_ELEMENTS environment variable.
+    /// </summary>
+    private static readonly long CompiledTrainingMinForwardElements =
+        long.TryParse(Environment.GetEnvironmentVariable("AIDOTNET_COMPILE_MIN_ELEMENTS"), out var configured) && configured > 0
+            ? configured
+            : 1_000_000L;
+
+    /// <summary>Sum of forward-activation element counts on the tape (early-exits once the threshold is reached).</summary>
+    private static long TotalForwardElements<T>(GradientTape<T> tape)
+    {
+        long total = 0;
+        int count = tape.EntryCount;
+        for (int i = 0; i < count; i++)
+        {
+            ref var entry = ref tape.Entries[i];
+            var output = entry.Output;
+            if (output is null) continue;
+            long elements = 1;
+            foreach (int dim in output._shape)
+            {
+                elements *= dim;
+            }
+
+            total += elements;
+            if (total >= CompiledTrainingMinForwardElements)
+            {
+                return total;
+            }
+        }
+
+        return total;
     }
 }
 

--- a/src/AiDotNet.Tensors/Engines/CuBlasNative.cs
+++ b/src/AiDotNet.Tensors/Engines/CuBlasNative.cs
@@ -647,7 +647,19 @@ public static class CuBlasNative
     public static void CheckCudaResult(CudaResult result, string operation = "CUDA operation")
     {
         if (result != CudaResult.Success)
+        {
+            // Sticky/context-corrupting faults (illegal address 700, context destroyed 709, launch
+            // failed 719) leave the CUDA context unusable — every subsequent driver call returns the
+            // same error. Trip the GPU circuit breaker so the engine permanently falls back to CPU
+            // instead of cascading the fault across the rest of the process.
+            int code = (int)result;
+            if (code is 700 or 709 or 719)
+            {
+                AiDotNetEngine.TripGpuCircuitBreaker(operation, code);
+            }
+
             throw new InvalidOperationException($"{operation} failed: {GetCudaErrorString(result)}");
+        }
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -1222,6 +1222,16 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
 
     public void DownloadBuffer(IGpuBuffer buffer, float[] destination)
     {
+        // #226: never issue a device→host copy from a released buffer. After CudaGpuBuffer.Release
+        // the device pointer is zeroed; cuMemcpyDtoH from a null/freed pointer is an ILLEGAL memory
+        // access that corrupts the CUDA context — every subsequent driver call then fails with error
+        // 700, cascading across the whole process. Surface a clean managed exception BEFORE touching
+        // the driver so the deferred-materializer caller (and the fused-training fault handler) can
+        // recover on the eager path instead, leaving the context intact.
+        if (buffer.Handle == IntPtr.Zero)
+            throw new ObjectDisposedException(nameof(buffer),
+                "GPU buffer was released before its deferred download (issue #226).");
+
         if (destination.Length < buffer.Size)
             throw new ArgumentException("Destination array is too small.", nameof(destination));
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/AutoTrainingCompilerTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/AutoTrainingCompilerTests.cs
@@ -22,12 +22,19 @@ public class AutoTrainingCompilerTests : IDisposable
     {
         AutoTrainingCompiler.ResetState();
         AutoTrainingCompiler.Enabled = true;
+        // These tests exercise the compile/replay MECHANISM on deliberately tiny
+        // (2x2) tapes. The production size gate (default 1M forward elements) would
+        // otherwise route such steps to the eager path and never activate ReplayMode.
+        // Drop the gate to 1 so the smallest tape still compiles — the gate's own
+        // heuristic isn't what these tests cover.
+        AutoTrainingCompiler.TestMinForwardElementsOverride = 1;
     }
 
     public void Dispose()
     {
         AutoTrainingCompiler.ResetState();
         AutoTrainingCompiler.Enabled = true;
+        AutoTrainingCompiler.TestMinForwardElementsOverride = null;
     }
 
     // ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem
On a real GPU box, NN/RL training trips a sticky CUDA fault (illegal address **700**, also 709/719) — e.g. the activation-cache deferred-materializer race on `cuStreamSynchronize(download)`. Error 700 **corrupts the CUDA context**, so every subsequent driver call returns the same error, cascading across the whole process. Training that touches the GPU then dies wholesale instead of degrading.

## Fix — make GPU faults self-heal to CPU
- **`AiDotNetEngine.TripGpuCircuitBreaker`** — tripped from `CuBlasNative.CheckCudaResult` on a sticky code (700/709/719): switches `Current` to CPU and blocks any further GPU adoption for the process.
- **`AutoDetectAndConfigureGpu`** — respects the tripped breaker (stays on CPU; no re-adoption).
- **`CudaBackend.DownloadBuffer`** — rejects a released buffer (`Handle == IntPtr.Zero`) with a clean managed exception instead of issuing an illegal `cuMemcpyDtoH` (#226).
- **`AutoTrainingCompiler`** — size-gates the compiled-training path (`AIDOTNET_COMPILE_MIN_ELEMENTS`, default 1M forward elements) so tiny models stay eager — no GPU benefit and avoids the buffer-cache race.

Paired with the AiDotNet-side `Train`/`Predict` CPU-retry (ooples/AiDotNet#nn-gpu-fault-cpu-retry), a GPU fault now self-heals to CPU and training continues.

## Verification
Cherry-picked clean onto `main`; `AiDotNet.Tensors` builds in Release. Verified end-to-end against a consumer app whose full CPU test suite (78 tests) previously failed with cascading CUDA 700 and is now green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)