### PR TITLE
perf(autodiff): skip dense embedding-grad seeding when sparse-grad array is wired (768 MB/backward on LayoutXLM)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -1208,22 +1208,30 @@ internal static class BackwardFunctions<T>
 
         var indices = new Tensor<long>(indicesData, indicesShape);
 
-        // Parallel sparse-grad recording: (gradOutput, indices) is everything a
+        // Sparse-grad recording: (gradOutput, indices) is everything a
         // sparse-aware optimizer needs to scatter-update only the accessed rows of the
         // embedding table. No allocation here — the Build factory just wraps the existing
         // tensor references. Sparse-aware Adam/AdamW pick this up via
-        // DifferentiableOps.GetSparseEmbeddingGradsFor.
+        // DifferentiableOps.GetSparseEmbeddingGradsFor; dense-path optimizers consume the
+        // same sparse contribution via SparseEmbeddingGradient.ToDense(engine).
         var sparseGrad = SparseEmbeddingGradient<T>.Build(gradOutput, indices, vocabSize, embeddingDim);
         DifferentiableOps.AccumulateSparseEmbeddingGrad(inputs[0], sparseGrad);
 
-        // Dense seeding for backward-compat with the 15 in-tree optimizers that don't yet
-        // consume sparse contributions directly. This is the existing [vocabSize, embeddingDim]
-        // allocation path; once an optimizer is updated to read GetSparseEmbeddingGradsFor
-        // first and skip dense for sparse-only params, the allocation can be skipped for
-        // that optimizer (the planned follow-up). Until then, both forms coexist so no
-        // existing optimizer breaks on the upgrade.
-        var dense = engine.TensorEmbeddingLookupBackward<T, long>(gradOutput, indices, vocabSize, embeddingDim);
-        DifferentiableOps.AccumulateGrad(grads, inputs[0], dense, engine);
+        // Dense fallback ONLY when the tape isn't wired with the sparse-grad array
+        // (compiled-plan paths and other non-GradientTape backward drivers that
+        // never call SetIndexedSparseGrads). In every other case the sparse-grad
+        // array is the single source of truth — the consumer optimizers
+        // (sparse-aware Adam/AdamW scatter direct; the 17 dense-path optimizers
+        // ToDense internally) cover both representations. Skipping the dense
+        // alloc here is the actual perf win — for paper-default LayoutXLM the
+        // saved [vocabSize=250002, embeddingDim=768] tensor is 768 MB per
+        // backward, against ~16 rows of real signal. Mirrors the
+        // TensorEmbeddingLookupFromFloatIndicesBackward sister path.
+        if (DifferentiableOps.GetSparseEmbeddingGradsFor(inputs[0]) is null)
+        {
+            var dense = engine.TensorEmbeddingLookupBackward<T, long>(gradOutput, indices, vocabSize, embeddingDim);
+            DifferentiableOps.AccumulateGrad(grads, inputs[0], dense, engine);
+        }
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -1550,7 +1550,37 @@ internal static class BackwardFunctions<T>
         var indices = (Tensor<int>)savedState[0];
         var axis = (int)savedState[1];
 
-        var grad = engine.ScatterAddBackward(gradOutput, indices, inputs[0]._shape, axis);
+        // Sparse-grad fast path mirroring TensorEmbeddingLookupBackward: when the input
+        // is a 2-D table (rank-2 axis-0 gather is structurally identical to an embedding
+        // lookup over [vocab, dim]), record the gradient as a SparseEmbeddingGradient
+        // wrapper instead of scattering into the full [vocab, dim] dense buffer. This
+        // covers every Gather-as-embedding pattern (token embeddings, type embeddings,
+        // segment embeddings, codebook gathers, MoE routing tables) without the
+        // forward op needing to opt-in.
+        var inputShape = inputs[0]._shape;
+        bool sparseEligible = axis == 0 && inputShape.Length == 2;
+        if (sparseEligible)
+        {
+            int vocabSize = inputShape[0];
+            int embeddingDim = inputShape[1];
+            // gradOutput shape = indices.shape ⨯ [embeddingDim], same contract as
+            // SparseEmbeddingGradient.Build expects.
+            var sparseGrad = SparseEmbeddingGradient<T>.Build(gradOutput, indices, vocabSize, embeddingDim);
+            DifferentiableOps.AccumulateSparseEmbeddingGrad(inputs[0], sparseGrad);
+
+            if (DifferentiableOps.GetSparseEmbeddingGradsFor(inputs[0]) is null)
+            {
+                var dense = engine.ScatterAddBackward(gradOutput, indices, inputShape, axis);
+                DifferentiableOps.AccumulateGrad(grads, inputs[0], dense, engine);
+            }
+            return;
+        }
+
+        // Non-embedding-shaped Gather (rank > 2 or axis != 0): keep the dense path.
+        // Generalizing SparseEmbeddingGradient to N-D / arbitrary-axis gathers is a
+        // forward-ledger surface change for a future PR. For now, the perf win we
+        // care about (embedding-table lookups) is covered.
+        var grad = engine.ScatterAddBackward(gradOutput, indices, inputShape, axis);
         DifferentiableOps.AccumulateGrad(grads, inputs[0], grad, engine);
     }
 

--- a/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
@@ -863,6 +863,263 @@ internal static class FusedOptimizer
         }
     }
 
+    // ----------------------------------------------------------------------
+    // SPARSE SCATTER-UPDATE KERNELS  (paired with OptimizerBase.SetSparseGradient)
+    //
+    // Each kernel below is the sparse counterpart of an existing dense optimizer
+    // kernel: instead of iterating over the full parameter buffer, only the
+    // (index, value) pairs supplied by the autodiff side are visited. The dense
+    // state buffers (m, v, accum, ...) keep their full size — only the touched
+    // positions are read & written, so the rest of the buffers remain valid
+    // across the call. Math matches the corresponding dense fused kernel
+    // verbatim (no SIMD — the workload is small by construction, so the
+    // managed scalar loop is faster than packing-then-AVX dance).
+    // ----------------------------------------------------------------------
+
+    /// <summary>SparseAdamW: AdamW restricted to non-zero indices.
+    /// Decoupled weight decay (PyTorch parity) applies at touched positions only.</summary>
+    internal static unsafe void SparseAdamWUpdate(
+        float* param, int* indices, float* values, float* m, float* v, int nnz,
+        float lr, float beta1, float beta2, float eps, float wd, int step)
+    {
+        float bc1 = 1f - MathF.Pow(beta1, step);
+        float bc2 = 1f - MathF.Pow(beta2, step);
+        float lrAdj = lr / bc1;
+        float bc2Inv = 1f / bc2;
+        for (int k = 0; k < nnz; k++)
+        {
+            int idx = indices[k];
+            float g = values[k];
+            float p = param[idx];
+            if (wd != 0f) p -= lr * wd * p;                       // decoupled weight decay
+            float mNew = beta1 * m[idx] + (1f - beta1) * g;
+            float vNew = beta2 * v[idx] + (1f - beta2) * g * g;
+            m[idx] = mNew;
+            v[idx] = vNew;
+            float vHat = vNew * bc2Inv;
+            param[idx] = p - lrAdj * mNew / (MathF.Sqrt(vHat) + eps);
+        }
+    }
+
+    /// <summary>SparseSGD: SGD + optional momentum + Nesterov + weight decay, restricted to non-zero indices.</summary>
+    internal static unsafe void SparseSgdUpdate(
+        float* param, int* indices, float* values, float* momentum, int nnz,
+        float lr, float mom, float dampening, float wd, bool nesterov, bool hasMomentum)
+    {
+        for (int k = 0; k < nnz; k++)
+        {
+            int idx = indices[k];
+            float g = values[k];
+            if (wd != 0f) g += wd * param[idx];
+            if (hasMomentum && mom != 0f)
+            {
+                float buf = momentum[idx] * mom + g * (1f - dampening);
+                momentum[idx] = buf;
+                g = nesterov ? g + mom * buf : buf;
+            }
+            param[idx] -= lr * g;
+        }
+    }
+
+    /// <summary>SparseNadam: Nesterov-momentum Adam, restricted to non-zero indices.</summary>
+    internal static unsafe void SparseNadamUpdate(
+        float* param, int* indices, float* values, float* m, float* v, int nnz,
+        float lr, float beta1, float beta2, float eps, float wd, int step)
+    {
+        float bc1 = 1f - MathF.Pow(beta1, step);
+        float bc2 = 1f - MathF.Pow(beta2, step);
+        float bc2Inv = 1f / bc2;
+        for (int k = 0; k < nnz; k++)
+        {
+            int idx = indices[k];
+            float g = values[k];
+            if (wd != 0f) g += wd * param[idx];
+            float mNew = beta1 * m[idx] + (1f - beta1) * g;
+            float vNew = beta2 * v[idx] + (1f - beta2) * g * g;
+            m[idx] = mNew;
+            v[idx] = vNew;
+            float mHat = (beta1 * mNew + (1f - beta1) * g) / bc1;  // Nesterov-corrected
+            float vHat = vNew * bc2Inv;
+            param[idx] -= lr * mHat / (MathF.Sqrt(vHat) + eps);
+        }
+    }
+
+    /// <summary>SparseAdamax: Adam with L∞ norm (u-state), restricted to non-zero indices.</summary>
+    internal static unsafe void SparseAdamaxUpdate(
+        float* param, int* indices, float* values, float* m, float* u, int nnz,
+        float lr, float beta1, float beta2, float eps, float wd, int step)
+    {
+        float bc1 = 1f - MathF.Pow(beta1, step);
+        float lrAdj = lr / bc1;
+        for (int k = 0; k < nnz; k++)
+        {
+            int idx = indices[k];
+            float g = values[k];
+            if (wd != 0f) g += wd * param[idx];
+            float mNew = beta1 * m[idx] + (1f - beta1) * g;
+            float uOld = u[idx];
+            float uNew = MathF.Max(beta2 * uOld, MathF.Abs(g));
+            m[idx] = mNew;
+            u[idx] = uNew;
+            param[idx] -= lrAdj * mNew / (uNew + eps);
+        }
+    }
+
+    /// <summary>SparseAdagrad: per-parameter accumulator update, restricted to non-zero indices.</summary>
+    internal static unsafe void SparseAdagradUpdate(
+        float* param, int* indices, float* values, float* accum, int nnz,
+        float lr, float eps, float wd, float lrDecay, int step)
+    {
+        float effLr = lr / (1f + step * lrDecay);
+        for (int k = 0; k < nnz; k++)
+        {
+            int idx = indices[k];
+            float g = values[k];
+            if (wd != 0f) g += wd * param[idx];
+            float a = accum[idx] + g * g;
+            accum[idx] = a;
+            param[idx] -= effLr * g / (MathF.Sqrt(a) + eps);
+        }
+    }
+
+    /// <summary>SparseRmsProp: RMSProp restricted to non-zero indices.</summary>
+    internal static unsafe void SparseRmsPropUpdate(
+        float* param, int* indices, float* values, float* sqAvg, float* momentumBuf, int nnz,
+        float lr, float alpha, float eps, float wd, float momentum, bool centered, float* gradAvg,
+        bool hasMomentum)
+    {
+        for (int k = 0; k < nnz; k++)
+        {
+            int idx = indices[k];
+            float g = values[k];
+            if (wd != 0f) g += wd * param[idx];
+            float sq = alpha * sqAvg[idx] + (1f - alpha) * g * g;
+            sqAvg[idx] = sq;
+            float denom;
+            if (centered)
+            {
+                float ga = alpha * gradAvg[idx] + (1f - alpha) * g;
+                gradAvg[idx] = ga;
+                denom = MathF.Sqrt(sq - ga * ga) + eps;
+            }
+            else
+            {
+                denom = MathF.Sqrt(sq) + eps;
+            }
+            if (hasMomentum && momentum != 0f)
+            {
+                float buf = momentumBuf[idx] * momentum + g / denom;
+                momentumBuf[idx] = buf;
+                param[idx] -= lr * buf;
+            }
+            else
+            {
+                param[idx] -= lr * g / denom;
+            }
+        }
+    }
+
+    /// <summary>SparseAdaDelta: AdaDelta restricted to non-zero indices. Maintains EMA of
+    /// squared grad and squared update.</summary>
+    internal static unsafe void SparseAdaDeltaUpdate(
+        float* param, int* indices, float* values, float* sqAvg, float* accDelta, int nnz,
+        float lr, float rho, float eps, float wd)
+    {
+        float oneMinusRho = 1f - rho;
+        for (int k = 0; k < nnz; k++)
+        {
+            int idx = indices[k];
+            float g = values[k];
+            if (wd != 0f) g += wd * param[idx];
+            float sq = rho * sqAvg[idx] + oneMinusRho * g * g;
+            sqAvg[idx] = sq;
+            float dx = MathF.Sqrt(accDelta[idx] + eps) / MathF.Sqrt(sq + eps) * g;
+            accDelta[idx] = rho * accDelta[idx] + oneMinusRho * dx * dx;
+            param[idx] -= lr * dx;
+        }
+    }
+
+    /// <summary>SparseLion: sign-of-EMA update restricted to non-zero indices.</summary>
+    internal static unsafe void SparseLionUpdate(
+        float* param, int* indices, float* values, float* m, int nnz,
+        float lr, float beta1, float beta2, float wd)
+    {
+        for (int k = 0; k < nnz; k++)
+        {
+            int idx = indices[k];
+            float g = values[k];
+            float c = beta1 * m[idx] + (1f - beta1) * g;
+            float update = MathF.Sign(c);
+            if (wd != 0f)
+                param[idx] -= lr * (update + wd * param[idx]);
+            else
+                param[idx] -= lr * update;
+            m[idx] = beta2 * m[idx] + (1f - beta2) * g;
+        }
+    }
+
+    /// <summary>SparseFtrl: FTRL-proximal restricted to non-zero indices.</summary>
+    internal static unsafe void SparseFtrlUpdate(
+        float* param, int* indices, float* values, float* accumulator, float* linear, int nnz,
+        float lr, float lrPower, float lambda1, float lambda2)
+    {
+        for (int k = 0; k < nnz; k++)
+        {
+            int idx = indices[k];
+            float g = values[k];
+            float prevAccum = accumulator[idx];
+            float newAccum = prevAccum + g * g;
+            float sigma = (MathF.Pow(newAccum, -lrPower) - MathF.Pow(prevAccum, -lrPower)) / lr;
+            if (float.IsNaN(sigma) || float.IsInfinity(sigma)) sigma = 0f;
+            linear[idx] += g - sigma * param[idx];
+            accumulator[idx] = newAccum;
+            float z = linear[idx];
+            if (MathF.Abs(z) <= lambda1) { param[idx] = 0f; continue; }
+            float pre = MathF.Pow(newAccum, -lrPower) / lr + lambda2;
+            param[idx] = (MathF.Sign(z) * lambda1 - z) / pre;
+        }
+    }
+
+    /// <summary>SparseRAdam: Rectified Adam restricted to non-zero indices.
+    /// When variance rectification is inactive (early-step), falls back to plain momentum.</summary>
+    internal static unsafe void SparseRAdamUpdate(
+        float* param, int* indices, float* values, float* m, float* v, int nnz,
+        float lr, float beta1, float beta2, float eps, float wd, int step)
+    {
+        float bc1 = 1f - MathF.Pow(beta1, step);
+        float bc2 = 1f - MathF.Pow(beta2, step);
+        float rhoInf = 2f / (1f - beta2) - 1f;
+        float rhoT = rhoInf - 2f * step * MathF.Pow(beta2, step) / bc2;
+        bool rect = rhoT > 4f;
+        float r = 0f;
+        if (rect)
+        {
+            float num = (rhoT - 4f) * (rhoT - 2f) * rhoInf;
+            float den = (rhoInf - 4f) * (rhoInf - 2f) * rhoT;
+            r = MathF.Sqrt(num / den);
+        }
+        for (int k = 0; k < nnz; k++)
+        {
+            int idx = indices[k];
+            float g = values[k];
+            if (wd != 0f) g += wd * param[idx];
+            float mNew = beta1 * m[idx] + (1f - beta1) * g;
+            float vNew = beta2 * v[idx] + (1f - beta2) * g * g;
+            m[idx] = mNew;
+            v[idx] = vNew;
+            float mHat = mNew / bc1;
+            if (rect)
+            {
+                float vHat = MathF.Sqrt(vNew / bc2);
+                param[idx] -= lr * r * mHat / (vHat + eps);
+            }
+            else
+            {
+                param[idx] -= lr * mHat;
+            }
+        }
+    }
+
     /// <summary>AVX2 ASGD: Averaged SGD (Polyak/Ruppert).
     /// Step decay <c>η_t = lr / (1 + λ·lr·t)^α</c>, weight decay applied to gradient,
     /// and exponential moving average of params written to <paramref name="ax"/>.</summary>

--- a/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
@@ -1120,6 +1120,169 @@ internal static class FusedOptimizer
         }
     }
 
+    // ==========================================================================
+    // Sparse trust-ratio & exotic-state kernels (LAMB / LARS / BF16Adam / Rprop /
+    // FP8Lion / ASGD-lazy / D-Adapt / Prodigy / Shampoo). The trust-ratio family
+    // needs a full-param ‖p‖ reduction once per step but does only sparse
+    // scatter-updates on (m, v, velocity) and the param at touched indices.
+    // Sparse-history semantics on Rprop preserve per-index step-size adaptation
+    // across the gaps when an index is rarely updated.
+    // ==========================================================================
+
+    /// <summary>SparseLAMB: trust-ratio scaled Adam restricted to non-zero indices.
+    /// ‖p‖₂ is computed over the FULL param vector (single O(N) reduction); the
+    /// Adam moments and parameter step are scatter-updated at touched indices only.
+    /// Since untouched indices have zero update, ‖update‖₂ across all i equals
+    /// ‖update_sparse‖₂ across touched i — both yield the same trust ratio.</summary>
+    internal static unsafe void SparseLAMBUpdate(
+        float* param, int* indices, float* values, float* m, float* v, int paramLen, int nnz,
+        float lr, float beta1, float beta2, float eps, float wd, int step)
+    {
+        float bc1 = 1f - MathF.Pow(beta1, step);
+        float bc2 = 1f - MathF.Pow(beta2, step);
+
+        // Full ‖p‖₂ reduction — one O(paramLen) read.
+        float pNormSq = 0f;
+        for (int i = 0; i < paramLen; i++) pNormSq += param[i] * param[i];
+        float pNorm = MathF.Sqrt(pNormSq);
+
+        // Sparse Adam-like update + collect ‖update‖₂² over touched i.
+        // Stage updates in a temp buffer so we can apply the trust-ratio scale uniformly.
+        var updates = new float[nnz];
+        float uNormSq = 0f;
+        for (int k = 0; k < nnz; k++)
+        {
+            int idx = indices[k];
+            float g = values[k];
+            float mNew = beta1 * m[idx] + (1f - beta1) * g;
+            float vNew = beta2 * v[idx] + (1f - beta2) * g * g;
+            m[idx] = mNew;
+            v[idx] = vNew;
+            float mHat = mNew / bc1;
+            float vHat = vNew / bc2;
+            float u = mHat / (MathF.Sqrt(vHat) + eps);
+            if (wd != 0f) u += wd * param[idx];
+            updates[k] = u;
+            uNormSq += u * u;
+        }
+        float uNorm = MathF.Sqrt(uNormSq);
+
+        // LAMB trust ratio: 1.0 if either norm is zero (no scaling), else ‖p‖ / ‖u‖.
+        float trustRatio = (pNorm > 0f && uNorm > 0f) ? (pNorm / uNorm) : 1f;
+        float effLr = lr * trustRatio;
+        for (int k = 0; k < nnz; k++)
+        {
+            param[indices[k]] -= effLr * updates[k];
+        }
+    }
+
+    /// <summary>SparseLARS: trust-ratio scaled SGD-momentum restricted to non-zero
+    /// indices. ‖p‖₂ via full reduction; ‖g_sparse‖₂² = sum over touched values²
+    /// (equals dense ‖g‖₂² since untouched indices have zero gradient).</summary>
+    internal static unsafe void SparseLARSUpdate(
+        float* param, int* indices, float* values, float* velocity, int paramLen, int nnz,
+        float lr, float momentum, float wd, float trustCoeff)
+    {
+        // Full ‖p‖₂ reduction.
+        float pNormSq = 0f;
+        for (int i = 0; i < paramLen; i++) pNormSq += param[i] * param[i];
+        float pNorm = MathF.Sqrt(pNormSq);
+
+        // ‖g‖₂² over touched (= dense, since untouched g = 0).
+        float gNormSq = 0f;
+        for (int k = 0; k < nnz; k++) gNormSq += values[k] * values[k];
+        float gNorm = MathF.Sqrt(gNormSq);
+
+        float denom = gNorm + wd * pNorm;
+        float localLr = (pNorm > 0f && denom > 0f) ? (lr * trustCoeff * pNorm / denom) : lr;
+
+        for (int k = 0; k < nnz; k++)
+        {
+            int idx = indices[k];
+            float g = values[k];
+            if (wd != 0f) g += wd * param[idx];
+            float v = momentum * velocity[idx] + localLr * g;
+            velocity[idx] = v;
+            param[idx] -= v;
+        }
+    }
+
+    /// <summary>SparseRprop: per-element step-size adaptation at touched indices
+    /// only. Untouched indices keep their (prev_grad, step_size) state — this is
+    /// "sparse-history" semantics, preserving the per-index adaptation across
+    /// gaps when an embedding row is rarely touched. Differs from dense Rprop
+    /// (which writes prev_grad[i] = grad[i] = 0 at every untouched i), but is
+    /// the right behavior for sparse use cases.</summary>
+    internal static unsafe void SparseRpropUpdate(
+        float* param, int* indices, float* values, float* prevGrad, float* stepSize, int nnz,
+        float etaPlus, float etaMinus, float stepMin, float stepMax)
+    {
+        for (int k = 0; k < nnz; k++)
+        {
+            int idx = indices[k];
+            float g = values[k];
+            float prev = prevGrad[idx];
+            float ss = stepSize[idx];
+            float signProduct = prev * g;
+            if (signProduct > 0f)
+            {
+                ss = MathF.Min(ss * etaPlus, stepMax);
+            }
+            else if (signProduct < 0f)
+            {
+                ss = MathF.Max(ss * etaMinus, stepMin);
+                g = 0f;  // reset gradient memory on sign change (paper convention)
+            }
+            stepSize[idx] = ss;
+            prevGrad[idx] = g;
+            if (g > 0f)        param[idx] -= ss;
+            else if (g < 0f)   param[idx] += ss;
+        }
+    }
+
+    /// <summary>SparseASGD: lazy averaging — only touched indices update both p and ax.
+    /// Untouched ax[i] drift via lazy catch-up: caller maintains last-touch step per
+    /// index and applies missed (1 - mu) decays when next touched. This kernel does
+    /// the per-touched-index update assuming caller has already applied lazy catch-up
+    /// to ax[idx] for the missed steps.</summary>
+    internal static unsafe void SparseASGDUpdate(
+        float* param, int* indices, float* values, float* ax, int nnz,
+        float eta, float lambd, float wd, float mu)
+    {
+        for (int k = 0; k < nnz; k++)
+        {
+            int idx = indices[k];
+            float g = values[k];
+            if (wd != 0f) g += wd * param[idx];
+            float pNew = param[idx] * (1f - eta * lambd) - eta * g;
+            param[idx] = pNew;
+            ax[idx] += mu * (pNew - ax[idx]);
+        }
+    }
+
+    /// <summary>SparseBF16Adam helper: dequantize one BF16-packed slot.</summary>
+    internal static float SparseBF16Unpack(float[] packed, int i)
+    {
+        int cell = i >> 1;
+        uint cellBits = (uint)BitConverter.ToInt32(BitConverter.GetBytes(packed[cell]), 0);
+        ushort bf = (i & 1) == 0 ? (ushort)(cellBits & 0xFFFFu) : (ushort)(cellBits >> 16);
+        var bytes = BitConverter.GetBytes((uint)bf << 16);
+        return BitConverter.ToSingle(bytes, 0);
+    }
+
+    /// <summary>SparseBF16Adam helper: quantize one FP32 value back to BF16-packed slot.</summary>
+    internal static void SparseBF16Pack(float[] packed, int i, float v)
+    {
+        uint bits = (uint)BitConverter.ToInt32(BitConverter.GetBytes(v), 0);
+        uint rounding = ((bits >> 16) & 1u) + 0x7FFFu;
+        ushort bf = (ushort)((bits + rounding) >> 16);
+        int cell = i >> 1;
+        uint cellBits = (uint)BitConverter.ToInt32(BitConverter.GetBytes(packed[cell]), 0);
+        if ((i & 1) == 0) cellBits = (cellBits & 0xFFFF0000u) | bf;
+        else              cellBits = (cellBits & 0x0000FFFFu) | ((uint)bf << 16);
+        packed[cell] = BitConverter.ToSingle(BitConverter.GetBytes(cellBits), 0);
+    }
+
     /// <summary>AVX2 ASGD: Averaged SGD (Polyak/Ruppert).
     /// Step decay <c>η_t = lr / (1 + λ·lr·t)^α</c>, weight decay applied to gradient,
     /// and exponential moving average of params written to <paramref name="ax"/>.</summary>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -10562,6 +10562,321 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         LaunchKernel(kernel, grid, DefaultBlockSize, args);
     }
 
+    // ==================================================================
+    // PR #567 — Native sparse scatter-update kernels
+    // ==================================================================
+    // Each method below launches the matching sparse_*_update CUDA kernel
+    // (defined in CudaOptimizerKernels.cs) with one thread per non-zero
+    // gradient entry. Reads / writes only (param[idx], state[idx]) for the
+    // nnz indices the autodiff producer published; the other (size - nnz)
+    // entries are never touched. Memory traffic is O(nnz) vs. the dense
+    // path's O(size).
+    // ==================================================================
+
+    private static void EnsureSparseArgs(IGpuBuffer? param, IGpuBuffer? sparseIndices, IGpuBuffer? sparseValues, int nnz)
+    {
+        if (param is null) throw new ArgumentNullException(nameof(param));
+        if (sparseIndices is null) throw new ArgumentNullException(nameof(sparseIndices));
+        if (sparseValues is null) throw new ArgumentNullException(nameof(sparseValues));
+        if (nnz < 0) throw new ArgumentOutOfRangeException(nameof(nnz));
+    }
+
+    /// <inheritdoc/>
+    public unsafe void SparseSgdUpdate(IGpuBuffer param,
+        IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz,
+        float learningRate, float weightDecay)
+    {
+        EnsureSparseArgs(param, sparseIndices, sparseValues, nnz);
+        if (nnz == 0) return;
+        if (!_kernelCache.TryGetValue("sparse_sgd_update", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: sparse_sgd_update");
+        using var _ = PushContext();
+        uint grid = (uint)((nnz + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr pP = param.Handle, pI = sparseIndices.Handle, pV = sparseValues.Handle;
+        void** args = stackalloc void*[6];
+        args[0] = &pP; args[1] = &pI; args[2] = &pV;
+        args[3] = &learningRate; args[4] = &weightDecay; args[5] = &nnz;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    /// <inheritdoc/>
+    public unsafe void SparseSgdMomentumUpdate(IGpuBuffer param, IGpuBuffer velocity,
+        IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz,
+        float learningRate, float momentum, float weightDecay)
+    {
+        EnsureSparseArgs(param, sparseIndices, sparseValues, nnz);
+        if (velocity is null) throw new ArgumentNullException(nameof(velocity));
+        if (nnz == 0) return;
+        if (!_kernelCache.TryGetValue("sparse_sgd_momentum_update", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: sparse_sgd_momentum_update");
+        using var _ = PushContext();
+        uint grid = (uint)((nnz + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr pP = param.Handle, pI = sparseIndices.Handle, pV = sparseValues.Handle, pVel = velocity.Handle;
+        void** args = stackalloc void*[8];
+        args[0] = &pP; args[1] = &pI; args[2] = &pV; args[3] = &pVel;
+        args[4] = &learningRate; args[5] = &momentum; args[6] = &weightDecay; args[7] = &nnz;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    /// <inheritdoc/>
+    public unsafe void SparseAdamUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer v,
+        IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz,
+        float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+    {
+        EnsureSparseArgs(param, sparseIndices, sparseValues, nnz);
+        if (m is null) throw new ArgumentNullException(nameof(m));
+        if (v is null) throw new ArgumentNullException(nameof(v));
+        if (step < 1) throw new ArgumentOutOfRangeException(nameof(step));
+        if (epsilon <= 0) throw new ArgumentOutOfRangeException(nameof(epsilon));
+        if (nnz == 0) return;
+        if (!_kernelCache.TryGetValue("sparse_adam_update", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: sparse_adam_update");
+        using var _ = PushContext();
+        uint grid = (uint)((nnz + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr pP = param.Handle, pI = sparseIndices.Handle, pV = sparseValues.Handle;
+        IntPtr pM = m.Handle, pVv = v.Handle;
+        void** args = stackalloc void*[12];
+        args[0] = &pP; args[1] = &pI; args[2] = &pV;
+        args[3] = &pM; args[4] = &pVv;
+        args[5] = &learningRate; args[6] = &beta1; args[7] = &beta2;
+        args[8] = &epsilon; args[9] = &weightDecay; args[10] = &step; args[11] = &nnz;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    /// <inheritdoc/>
+    public unsafe void SparseAdamWUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer v,
+        IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz,
+        float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+    {
+        EnsureSparseArgs(param, sparseIndices, sparseValues, nnz);
+        if (m is null) throw new ArgumentNullException(nameof(m));
+        if (v is null) throw new ArgumentNullException(nameof(v));
+        if (step < 1) throw new ArgumentOutOfRangeException(nameof(step));
+        if (nnz == 0) return;
+        if (!_kernelCache.TryGetValue("sparse_adamw_update", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: sparse_adamw_update");
+        using var _ = PushContext();
+        uint grid = (uint)((nnz + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr pP = param.Handle, pI = sparseIndices.Handle, pV = sparseValues.Handle;
+        IntPtr pM = m.Handle, pVv = v.Handle;
+        void** args = stackalloc void*[12];
+        args[0] = &pP; args[1] = &pI; args[2] = &pV;
+        args[3] = &pM; args[4] = &pVv;
+        args[5] = &learningRate; args[6] = &beta1; args[7] = &beta2;
+        args[8] = &epsilon; args[9] = &weightDecay; args[10] = &step; args[11] = &nnz;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    /// <inheritdoc/>
+    public unsafe void SparseRmspropUpdate(IGpuBuffer param, IGpuBuffer squaredAvg,
+        IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz,
+        float learningRate, float rho, float epsilon, float weightDecay)
+    {
+        EnsureSparseArgs(param, sparseIndices, sparseValues, nnz);
+        if (squaredAvg is null) throw new ArgumentNullException(nameof(squaredAvg));
+        if (nnz == 0) return;
+        if (!_kernelCache.TryGetValue("sparse_rmsprop_update", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: sparse_rmsprop_update");
+        using var _ = PushContext();
+        uint grid = (uint)((nnz + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr pP = param.Handle, pI = sparseIndices.Handle, pV = sparseValues.Handle, pSq = squaredAvg.Handle;
+        void** args = stackalloc void*[9];
+        args[0] = &pP; args[1] = &pI; args[2] = &pV; args[3] = &pSq;
+        args[4] = &learningRate; args[5] = &rho; args[6] = &epsilon; args[7] = &weightDecay; args[8] = &nnz;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    /// <inheritdoc/>
+    public unsafe void SparseAdagradUpdate(IGpuBuffer param, IGpuBuffer accumulatedGrad,
+        IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz,
+        float learningRate, float epsilon, float weightDecay)
+    {
+        EnsureSparseArgs(param, sparseIndices, sparseValues, nnz);
+        if (accumulatedGrad is null) throw new ArgumentNullException(nameof(accumulatedGrad));
+        if (nnz == 0) return;
+        if (!_kernelCache.TryGetValue("sparse_adagrad_update", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: sparse_adagrad_update");
+        using var _ = PushContext();
+        uint grid = (uint)((nnz + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr pP = param.Handle, pI = sparseIndices.Handle, pV = sparseValues.Handle, pA = accumulatedGrad.Handle;
+        void** args = stackalloc void*[8];
+        args[0] = &pP; args[1] = &pI; args[2] = &pV; args[3] = &pA;
+        args[4] = &learningRate; args[5] = &epsilon; args[6] = &weightDecay; args[7] = &nnz;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    /// <inheritdoc/>
+    public unsafe void SparseNagUpdate(IGpuBuffer param, IGpuBuffer velocity,
+        IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz,
+        float learningRate, float momentum, float weightDecay)
+    {
+        EnsureSparseArgs(param, sparseIndices, sparseValues, nnz);
+        if (velocity is null) throw new ArgumentNullException(nameof(velocity));
+        if (nnz == 0) return;
+        if (!_kernelCache.TryGetValue("sparse_nag_update", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: sparse_nag_update");
+        using var _ = PushContext();
+        uint grid = (uint)((nnz + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr pP = param.Handle, pI = sparseIndices.Handle, pV = sparseValues.Handle, pVel = velocity.Handle;
+        void** args = stackalloc void*[8];
+        args[0] = &pP; args[1] = &pI; args[2] = &pV; args[3] = &pVel;
+        args[4] = &learningRate; args[5] = &momentum; args[6] = &weightDecay; args[7] = &nnz;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    /// <inheritdoc/>
+    public unsafe void SparseAdadeltaUpdate(IGpuBuffer param, IGpuBuffer accumGrad, IGpuBuffer accumUpdate,
+        IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz,
+        float rho, float epsilon, float weightDecay)
+    {
+        EnsureSparseArgs(param, sparseIndices, sparseValues, nnz);
+        if (accumGrad is null) throw new ArgumentNullException(nameof(accumGrad));
+        if (accumUpdate is null) throw new ArgumentNullException(nameof(accumUpdate));
+        if (nnz == 0) return;
+        if (!_kernelCache.TryGetValue("sparse_adadelta_update", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: sparse_adadelta_update");
+        using var _ = PushContext();
+        uint grid = (uint)((nnz + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr pP = param.Handle, pI = sparseIndices.Handle, pV = sparseValues.Handle;
+        IntPtr pAg = accumGrad.Handle, pAu = accumUpdate.Handle;
+        void** args = stackalloc void*[9];
+        args[0] = &pP; args[1] = &pI; args[2] = &pV; args[3] = &pAg; args[4] = &pAu;
+        args[5] = &rho; args[6] = &epsilon; args[7] = &weightDecay; args[8] = &nnz;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    /// <inheritdoc/>
+    public unsafe void SparseAmsgradUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer v, IGpuBuffer vMax,
+        IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz,
+        float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+    {
+        EnsureSparseArgs(param, sparseIndices, sparseValues, nnz);
+        if (m is null) throw new ArgumentNullException(nameof(m));
+        if (v is null) throw new ArgumentNullException(nameof(v));
+        if (vMax is null) throw new ArgumentNullException(nameof(vMax));
+        if (step < 1) throw new ArgumentOutOfRangeException(nameof(step));
+        if (nnz == 0) return;
+        if (!_kernelCache.TryGetValue("sparse_amsgrad_update", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: sparse_amsgrad_update");
+        using var _ = PushContext();
+        uint grid = (uint)((nnz + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr pP = param.Handle, pI = sparseIndices.Handle, pV = sparseValues.Handle;
+        IntPtr pM = m.Handle, pVv = v.Handle, pVm = vMax.Handle;
+        void** args = stackalloc void*[13];
+        args[0] = &pP; args[1] = &pI; args[2] = &pV;
+        args[3] = &pM; args[4] = &pVv; args[5] = &pVm;
+        args[6] = &learningRate; args[7] = &beta1; args[8] = &beta2;
+        args[9] = &epsilon; args[10] = &weightDecay; args[11] = &step; args[12] = &nnz;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    /// <inheritdoc/>
+    public unsafe void SparseAdamaxUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer u,
+        IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz,
+        float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+    {
+        EnsureSparseArgs(param, sparseIndices, sparseValues, nnz);
+        if (m is null) throw new ArgumentNullException(nameof(m));
+        if (u is null) throw new ArgumentNullException(nameof(u));
+        if (step < 1) throw new ArgumentOutOfRangeException(nameof(step));
+        if (nnz == 0) return;
+        if (!_kernelCache.TryGetValue("sparse_adamax_update", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: sparse_adamax_update");
+        using var _ = PushContext();
+        uint grid = (uint)((nnz + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr pP = param.Handle, pI = sparseIndices.Handle, pV = sparseValues.Handle;
+        IntPtr pM = m.Handle, pU = u.Handle;
+        void** args = stackalloc void*[12];
+        args[0] = &pP; args[1] = &pI; args[2] = &pV;
+        args[3] = &pM; args[4] = &pU;
+        args[5] = &learningRate; args[6] = &beta1; args[7] = &beta2;
+        args[8] = &epsilon; args[9] = &weightDecay; args[10] = &step; args[11] = &nnz;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    /// <inheritdoc/>
+    public unsafe void SparseLionUpdate(IGpuBuffer param, IGpuBuffer m,
+        IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz,
+        float learningRate, float beta1, float beta2, float weightDecay)
+    {
+        EnsureSparseArgs(param, sparseIndices, sparseValues, nnz);
+        if (m is null) throw new ArgumentNullException(nameof(m));
+        if (nnz == 0) return;
+        if (!_kernelCache.TryGetValue("sparse_lion_update", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: sparse_lion_update");
+        using var _ = PushContext();
+        uint grid = (uint)((nnz + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr pP = param.Handle, pI = sparseIndices.Handle, pV = sparseValues.Handle, pM = m.Handle;
+        void** args = stackalloc void*[9];
+        args[0] = &pP; args[1] = &pI; args[2] = &pV; args[3] = &pM;
+        args[4] = &learningRate; args[5] = &beta1; args[6] = &beta2; args[7] = &weightDecay; args[8] = &nnz;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    /// <inheritdoc/>
+    public unsafe void SparseNadamUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer v,
+        IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz,
+        float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+    {
+        EnsureSparseArgs(param, sparseIndices, sparseValues, nnz);
+        if (m is null) throw new ArgumentNullException(nameof(m));
+        if (v is null) throw new ArgumentNullException(nameof(v));
+        if (step < 1) throw new ArgumentOutOfRangeException(nameof(step));
+        if (nnz == 0) return;
+        if (!_kernelCache.TryGetValue("sparse_nadam_update", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: sparse_nadam_update");
+        using var _ = PushContext();
+        uint grid = (uint)((nnz + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr pP = param.Handle, pI = sparseIndices.Handle, pV = sparseValues.Handle;
+        IntPtr pM = m.Handle, pVv = v.Handle;
+        void** args = stackalloc void*[12];
+        args[0] = &pP; args[1] = &pI; args[2] = &pV;
+        args[3] = &pM; args[4] = &pVv;
+        args[5] = &learningRate; args[6] = &beta1; args[7] = &beta2;
+        args[8] = &epsilon; args[9] = &weightDecay; args[10] = &step; args[11] = &nnz;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    /// <inheritdoc/>
+    public unsafe void SparseFtrlUpdate(IGpuBuffer param, IGpuBuffer z, IGpuBuffer n,
+        IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz,
+        float learningRate, float l1Reg, float l2Reg, float beta)
+    {
+        EnsureSparseArgs(param, sparseIndices, sparseValues, nnz);
+        if (z is null) throw new ArgumentNullException(nameof(z));
+        if (n is null) throw new ArgumentNullException(nameof(n));
+        if (nnz == 0) return;
+        if (!_kernelCache.TryGetValue("sparse_ftrl_update", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: sparse_ftrl_update");
+        using var _ = PushContext();
+        uint grid = (uint)((nnz + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr pP = param.Handle, pI = sparseIndices.Handle, pV = sparseValues.Handle;
+        IntPtr pZ = z.Handle, pN = n.Handle;
+        void** args = stackalloc void*[10];
+        args[0] = &pP; args[1] = &pI; args[2] = &pV;
+        args[3] = &pZ; args[4] = &pN;
+        args[5] = &learningRate; args[6] = &l1Reg; args[7] = &l2Reg; args[8] = &beta; args[9] = &nnz;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
+    /// <inheritdoc/>
+    public unsafe void SparseProximalL1Update(IGpuBuffer param,
+        IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz,
+        float learningRate, float l1Strength)
+    {
+        EnsureSparseArgs(param, sparseIndices, sparseValues, nnz);
+        if (nnz == 0) return;
+        if (!_kernelCache.TryGetValue("sparse_proximal_l1_update", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: sparse_proximal_l1_update");
+        using var _ = PushContext();
+        uint grid = (uint)((nnz + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr pP = param.Handle, pI = sparseIndices.Handle, pV = sparseValues.Handle;
+        void** args = stackalloc void*[6];
+        args[0] = &pP; args[1] = &pI; args[2] = &pV;
+        args[3] = &learningRate; args[4] = &l1Strength; args[5] = &nnz;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+    }
+
     /// <inheritdoc/>
     public unsafe void ConvertToFp16(IGpuBuffer input, IGpuBuffer output, int size)
     {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaOptimizerKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaOptimizerKernels.cs
@@ -503,6 +503,342 @@ extern ""C"" __global__ __launch_bounds__(256) void adam8bit_update(
         vQ[i] = (unsigned char)qv;
     }
 }
+
+// ===========================================================================
+// SPARSE OPTIMIZER KERNELS (PR #567)
+// ===========================================================================
+// Each kernel below is the sparse counterpart of the dense optimizer kernel
+// above. Instead of one thread per parameter element, we launch one thread
+// per non-zero gradient (nnz). Each thread reads (idx[k], val[k]), scatter-
+// updates ONLY (param[idx], state[idx]); the other (N - nnz) entries are
+// never touched — neither read nor written. This is the actual GPU sparse
+// fast path: O(nnz) memory traffic instead of O(N).
+//
+// Grid dim = ceil(nnz / 256); the consumer launches with this dimension and
+// passes nnz as the size argument.
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// Sparse SGD (no momentum)
+// ---------------------------------------------------------------------------
+extern ""C"" __global__ __launch_bounds__(256) void sparse_sgd_update(
+    float* __restrict__ param,
+    const int* __restrict__ indices,
+    const float* __restrict__ values,
+    float learningRate, float weightDecay, int nnz)
+{
+    int k = blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= nnz) return;
+    int i = indices[k];
+    float grad = values[k];
+    if (weightDecay > 0.0f) grad += weightDecay * param[i];
+    param[i] -= learningRate * grad;
+}
+
+// ---------------------------------------------------------------------------
+// Sparse SGD with momentum
+// ---------------------------------------------------------------------------
+extern ""C"" __global__ __launch_bounds__(256) void sparse_sgd_momentum_update(
+    float* __restrict__ param,
+    const int* __restrict__ indices,
+    const float* __restrict__ values,
+    float* __restrict__ velocity,
+    float learningRate, float momentum, float weightDecay, int nnz)
+{
+    int k = blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= nnz) return;
+    int i = indices[k];
+    float grad = values[k];
+    if (weightDecay > 0.0f) grad += weightDecay * param[i];
+    float v = momentum * velocity[i] + grad;
+    velocity[i] = v;
+    param[i] -= learningRate * v;
+}
+
+// ---------------------------------------------------------------------------
+// Sparse Adam
+// ---------------------------------------------------------------------------
+extern ""C"" __global__ __launch_bounds__(256) void sparse_adam_update(
+    float* __restrict__ param,
+    const int* __restrict__ indices,
+    const float* __restrict__ values,
+    float* __restrict__ m, float* __restrict__ v,
+    float learningRate, float beta1, float beta2, float epsilon,
+    float weightDecay, int step, int nnz)
+{
+    int k = blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= nnz) return;
+    int i = indices[k];
+    float grad = values[k];
+    float mVal = beta1 * m[i] + (1.0f - beta1) * grad;
+    float vVal = beta2 * v[i] + (1.0f - beta2) * grad * grad;
+    m[i] = mVal;
+    v[i] = vVal;
+    float mHat = mVal / (1.0f - powf(beta1, (float)step));
+    float vHat = vVal / (1.0f - powf(beta2, (float)step));
+    float update = learningRate * mHat / (sqrtf(vHat) + epsilon);
+    if (weightDecay > 0.0f) update += learningRate * weightDecay * param[i];
+    param[i] -= update;
+}
+
+// ---------------------------------------------------------------------------
+// Sparse AdamW (decoupled weight decay)
+// ---------------------------------------------------------------------------
+extern ""C"" __global__ __launch_bounds__(256) void sparse_adamw_update(
+    float* __restrict__ param,
+    const int* __restrict__ indices,
+    const float* __restrict__ values,
+    float* __restrict__ m, float* __restrict__ v,
+    float learningRate, float beta1, float beta2, float epsilon,
+    float weightDecay, int step, int nnz)
+{
+    int k = blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= nnz) return;
+    int i = indices[k];
+    float grad = values[k];
+    float p = param[i];
+    if (weightDecay > 0.0f) p -= learningRate * weightDecay * p;
+    float mVal = beta1 * m[i] + (1.0f - beta1) * grad;
+    float vVal = beta2 * v[i] + (1.0f - beta2) * grad * grad;
+    m[i] = mVal;
+    v[i] = vVal;
+    float mHat = mVal / (1.0f - powf(beta1, (float)step));
+    float vHat = vVal / (1.0f - powf(beta2, (float)step));
+    param[i] = p - learningRate * mHat / (sqrtf(vHat) + epsilon);
+}
+
+// ---------------------------------------------------------------------------
+// Sparse RMSProp
+// ---------------------------------------------------------------------------
+extern ""C"" __global__ __launch_bounds__(256) void sparse_rmsprop_update(
+    float* __restrict__ param,
+    const int* __restrict__ indices,
+    const float* __restrict__ values,
+    float* __restrict__ squaredAvg,
+    float learningRate, float rho, float epsilon, float weightDecay, int nnz)
+{
+    int k = blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= nnz) return;
+    int i = indices[k];
+    float grad = values[k];
+    if (weightDecay > 0.0f) grad += weightDecay * param[i];
+    float sq = rho * squaredAvg[i] + (1.0f - rho) * grad * grad;
+    squaredAvg[i] = sq;
+    param[i] -= learningRate * grad / (sqrtf(sq) + epsilon);
+}
+
+// ---------------------------------------------------------------------------
+// Sparse Adagrad
+// ---------------------------------------------------------------------------
+extern ""C"" __global__ __launch_bounds__(256) void sparse_adagrad_update(
+    float* __restrict__ param,
+    const int* __restrict__ indices,
+    const float* __restrict__ values,
+    float* __restrict__ accum,
+    float learningRate, float epsilon, float weightDecay, int nnz)
+{
+    int k = blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= nnz) return;
+    int i = indices[k];
+    float grad = values[k];
+    if (weightDecay > 0.0f) grad += weightDecay * param[i];
+    float a = accum[i] + grad * grad;
+    accum[i] = a;
+    param[i] -= learningRate * grad / (sqrtf(a) + epsilon);
+}
+
+// ---------------------------------------------------------------------------
+// Sparse NAG (Nesterov-accelerated SGD with momentum)
+// ---------------------------------------------------------------------------
+extern ""C"" __global__ __launch_bounds__(256) void sparse_nag_update(
+    float* __restrict__ param,
+    const int* __restrict__ indices,
+    const float* __restrict__ values,
+    float* __restrict__ velocity,
+    float learningRate, float momentum, float weightDecay, int nnz)
+{
+    int k = blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= nnz) return;
+    int i = indices[k];
+    float grad = values[k];
+    if (weightDecay > 0.0f) grad += weightDecay * param[i];
+    float vOld = velocity[i];
+    float vNew = momentum * vOld + grad;
+    velocity[i] = vNew;
+    // Nesterov look-ahead: use (1 + momentum) * vNew - momentum * vOld
+    param[i] -= learningRate * ((1.0f + momentum) * vNew - momentum * vOld);
+}
+
+// ---------------------------------------------------------------------------
+// Sparse AdaDelta
+// ---------------------------------------------------------------------------
+extern ""C"" __global__ __launch_bounds__(256) void sparse_adadelta_update(
+    float* __restrict__ param,
+    const int* __restrict__ indices,
+    const float* __restrict__ values,
+    float* __restrict__ accumGrad, float* __restrict__ accumUpdate,
+    float rho, float epsilon, float weightDecay, int nnz)
+{
+    int k = blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= nnz) return;
+    int i = indices[k];
+    float grad = values[k];
+    if (weightDecay > 0.0f) grad += weightDecay * param[i];
+    float oneMinusRho = 1.0f - rho;
+    float ag = rho * accumGrad[i] + oneMinusRho * grad * grad;
+    accumGrad[i] = ag;
+    float dx = sqrtf(accumUpdate[i] + epsilon) / sqrtf(ag + epsilon) * grad;
+    accumUpdate[i] = rho * accumUpdate[i] + oneMinusRho * dx * dx;
+    param[i] -= dx;
+}
+
+// ---------------------------------------------------------------------------
+// Sparse AMSGrad
+// ---------------------------------------------------------------------------
+extern ""C"" __global__ __launch_bounds__(256) void sparse_amsgrad_update(
+    float* __restrict__ param,
+    const int* __restrict__ indices,
+    const float* __restrict__ values,
+    float* __restrict__ m, float* __restrict__ v, float* __restrict__ vMax,
+    float learningRate, float beta1, float beta2, float epsilon,
+    float weightDecay, int step, int nnz)
+{
+    int k = blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= nnz) return;
+    int i = indices[k];
+    float grad = values[k];
+    if (weightDecay > 0.0f) grad += weightDecay * param[i];
+    float mVal = beta1 * m[i] + (1.0f - beta1) * grad;
+    float vVal = beta2 * v[i] + (1.0f - beta2) * grad * grad;
+    m[i] = mVal;
+    v[i] = vVal;
+    float vMaxNew = fmaxf(vMax[i], vVal);
+    vMax[i] = vMaxNew;
+    float mHat = mVal / (1.0f - powf(beta1, (float)step));
+    float vHat = vMaxNew / (1.0f - powf(beta2, (float)step));
+    param[i] -= learningRate * mHat / (sqrtf(vHat) + epsilon);
+}
+
+// ---------------------------------------------------------------------------
+// Sparse Adamax (Adam with L-infinity norm)
+// ---------------------------------------------------------------------------
+extern ""C"" __global__ __launch_bounds__(256) void sparse_adamax_update(
+    float* __restrict__ param,
+    const int* __restrict__ indices,
+    const float* __restrict__ values,
+    float* __restrict__ m, float* __restrict__ u,
+    float learningRate, float beta1, float beta2, float epsilon,
+    float weightDecay, int step, int nnz)
+{
+    int k = blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= nnz) return;
+    int i = indices[k];
+    float grad = values[k];
+    if (weightDecay > 0.0f) grad += weightDecay * param[i];
+    float mVal = beta1 * m[i] + (1.0f - beta1) * grad;
+    float uVal = fmaxf(beta2 * u[i], fabsf(grad));
+    m[i] = mVal;
+    u[i] = uVal;
+    float lrAdj = learningRate / (1.0f - powf(beta1, (float)step));
+    param[i] -= lrAdj * mVal / (uVal + epsilon);
+}
+
+// ---------------------------------------------------------------------------
+// Sparse Lion
+// ---------------------------------------------------------------------------
+extern ""C"" __global__ __launch_bounds__(256) void sparse_lion_update(
+    float* __restrict__ param,
+    const int* __restrict__ indices,
+    const float* __restrict__ values,
+    float* __restrict__ m,
+    float learningRate, float beta1, float beta2, float weightDecay, int nnz)
+{
+    int k = blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= nnz) return;
+    int i = indices[k];
+    float grad = values[k];
+    float c = beta1 * m[i] + (1.0f - beta1) * grad;
+    float sign = (c > 0.0f) ? 1.0f : ((c < 0.0f) ? -1.0f : 0.0f);
+    float update = sign;
+    if (weightDecay > 0.0f) update += weightDecay * param[i];
+    param[i] -= learningRate * update;
+    m[i] = beta2 * m[i] + (1.0f - beta2) * grad;
+}
+
+// ---------------------------------------------------------------------------
+// Sparse Nadam
+// ---------------------------------------------------------------------------
+extern ""C"" __global__ __launch_bounds__(256) void sparse_nadam_update(
+    float* __restrict__ param,
+    const int* __restrict__ indices,
+    const float* __restrict__ values,
+    float* __restrict__ m, float* __restrict__ v,
+    float learningRate, float beta1, float beta2, float epsilon,
+    float weightDecay, int step, int nnz)
+{
+    int k = blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= nnz) return;
+    int i = indices[k];
+    float grad = values[k];
+    if (weightDecay > 0.0f) grad += weightDecay * param[i];
+    float mVal = beta1 * m[i] + (1.0f - beta1) * grad;
+    float vVal = beta2 * v[i] + (1.0f - beta2) * grad * grad;
+    m[i] = mVal;
+    v[i] = vVal;
+    float bc1 = 1.0f - powf(beta1, (float)step);
+    float bc2 = 1.0f - powf(beta2, (float)step);
+    float mHat = (beta1 * mVal + (1.0f - beta1) * grad) / bc1;
+    float vHat = vVal / bc2;
+    param[i] -= learningRate * mHat / (sqrtf(vHat) + epsilon);
+}
+
+// ---------------------------------------------------------------------------
+// Sparse FTRL (Follow-The-Regularized-Leader)
+// ---------------------------------------------------------------------------
+extern ""C"" __global__ __launch_bounds__(256) void sparse_ftrl_update(
+    float* __restrict__ param,
+    const int* __restrict__ indices,
+    const float* __restrict__ values,
+    float* __restrict__ z, float* __restrict__ n,
+    float learningRate, float l1Reg, float l2Reg, float beta, int nnz)
+{
+    int k = blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= nnz) return;
+    int i = indices[k];
+    float grad = values[k];
+    float nOld = n[i];
+    float nNew = nOld + grad * grad;
+    n[i] = nNew;
+    float sigma = (sqrtf(nNew) - sqrtf(nOld)) / learningRate;
+    z[i] += grad - sigma * param[i];
+    float zVal = z[i];
+    if (fabsf(zVal) <= l1Reg) {
+        param[i] = 0.0f;
+    } else {
+        float sign = (zVal > 0.0f) ? 1.0f : -1.0f;
+        param[i] = (sign * l1Reg - zVal) / ((beta + sqrtf(nNew)) / learningRate + l2Reg);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sparse Proximal-L1
+// ---------------------------------------------------------------------------
+extern ""C"" __global__ __launch_bounds__(256) void sparse_proximal_l1_update(
+    float* __restrict__ param,
+    const int* __restrict__ indices,
+    const float* __restrict__ values,
+    float learningRate, float l1Strength, int nnz)
+{
+    int k = blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= nnz) return;
+    int i = indices[k];
+    float grad = values[k];
+    float p = param[i] - learningRate * grad;
+    float threshold = learningRate * l1Strength;
+    if (p > threshold)      param[i] = p - threshold;
+    else if (p < -threshold) param[i] = p + threshold;
+    else                     param[i] = 0.0f;
+}
 ";
     }
 
@@ -529,7 +865,22 @@ extern ""C"" __global__ __launch_bounds__(256) void adam8bit_update(
             "nadam_update",
             "ftrl_update",
             "proximal_l1_update",
-            "adam8bit_update"
+            "adam8bit_update",
+            // PR #567 — sparse counterparts (one thread per nnz, scatter-update).
+            "sparse_sgd_update",
+            "sparse_sgd_momentum_update",
+            "sparse_adam_update",
+            "sparse_adamw_update",
+            "sparse_rmsprop_update",
+            "sparse_adagrad_update",
+            "sparse_nag_update",
+            "sparse_adadelta_update",
+            "sparse_amsgrad_update",
+            "sparse_adamax_update",
+            "sparse_lion_update",
+            "sparse_nadam_update",
+            "sparse_ftrl_update",
+            "sparse_proximal_l1_update",
         };
     }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.SparseOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.SparseOptimizer.cs
@@ -1,0 +1,49 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// HIP backend - sparse optimizer scatter-update stubs (PR #567).
+//
+// Sparse optimizer kernels are CUDA-only in this PR — once equivalent HIP
+// rocBLAS / Composable Kernels are wired (mirroring the existing dense
+// AdamUpdate etc.), each method below should dispatch the matching HIP
+// kernel. Until then, callers (GpuOptimizer.TryXStepSparse) catch
+// NotSupportedException and fall back to the CPU sparse path.
+
+using System;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.HIP;
+
+public sealed partial class HipBackend
+{
+    private static NotSupportedException SparseNotImpl(string op) =>
+        new NotSupportedException(
+            $"HIP backend does not yet ship a native sparse '{op}' kernel; " +
+            "caller should fall back to the CPU sparse optimizer path.");
+
+    public void SparseSgdUpdate(IGpuBuffer param, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float weightDecay)
+        => throw SparseNotImpl("sgd_update");
+    public void SparseSgdMomentumUpdate(IGpuBuffer param, IGpuBuffer velocity, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float momentum, float weightDecay)
+        => throw SparseNotImpl("sgd_momentum_update");
+    public void SparseAdamUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer v, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+        => throw SparseNotImpl("adam_update");
+    public void SparseAdamWUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer v, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+        => throw SparseNotImpl("adamw_update");
+    public void SparseRmspropUpdate(IGpuBuffer param, IGpuBuffer squaredAvg, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float rho, float epsilon, float weightDecay)
+        => throw SparseNotImpl("rmsprop_update");
+    public void SparseAdagradUpdate(IGpuBuffer param, IGpuBuffer accumulatedGrad, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float epsilon, float weightDecay)
+        => throw SparseNotImpl("adagrad_update");
+    public void SparseNagUpdate(IGpuBuffer param, IGpuBuffer velocity, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float momentum, float weightDecay)
+        => throw SparseNotImpl("nag_update");
+    public void SparseAdadeltaUpdate(IGpuBuffer param, IGpuBuffer accumGrad, IGpuBuffer accumUpdate, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float rho, float epsilon, float weightDecay)
+        => throw SparseNotImpl("adadelta_update");
+    public void SparseAmsgradUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer v, IGpuBuffer vMax, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+        => throw SparseNotImpl("amsgrad_update");
+    public void SparseAdamaxUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer u, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+        => throw SparseNotImpl("adamax_update");
+    public void SparseLionUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float weightDecay)
+        => throw SparseNotImpl("lion_update");
+    public void SparseNadamUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer v, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+        => throw SparseNotImpl("nadam_update");
+    public void SparseFtrlUpdate(IGpuBuffer param, IGpuBuffer z, IGpuBuffer n, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float l1Reg, float l2Reg, float beta)
+        => throw SparseNotImpl("ftrl_update");
+    public void SparseProximalL1Update(IGpuBuffer param, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float l1Strength)
+        => throw SparseNotImpl("proximal_l1_update");
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
@@ -2139,6 +2139,97 @@ public interface IDirectGpuBackend : IDisposable
     void FtrlUpdate(IGpuBuffer param, IGpuBuffer gradient, IGpuBuffer z, IGpuBuffer n,
         float learningRate, float l1Reg, float l2Reg, float beta, int size);
 
+    // --------------------------------------------------------------
+    // PR #567 — Sparse counterparts of the dense optimizer steps above.
+    // Each method launches a native CUDA scatter-update kernel with one
+    // thread per non-zero gradient (nnz). Only (param[idx], state[idx])
+    // entries are read/written; the other (N − nnz) entries are never
+    // touched. Memory traffic is O(nnz) vs. the dense path's O(N).
+    //
+    // sparseIndices and sparseValues are GPU-resident buffers of length
+    // >= nnz; the dense state buffers (m, v, accum, ...) keep their full
+    // shape and are mutated in place at the touched indices only.
+    //
+    // Backends that don't ship the sparse_* kernel should throw
+    // NotSupportedException; the GpuOptimizer wrapper will then return
+    // false so the caller falls back to the CPU sparse path.
+    // --------------------------------------------------------------
+
+    /// <summary>Sparse SGD scatter-update on GPU. See SgdUpdate for the dense counterpart.</summary>
+    void SparseSgdUpdate(IGpuBuffer param,
+        IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz,
+        float learningRate, float weightDecay);
+
+    /// <summary>Sparse SGD-with-momentum scatter-update on GPU.</summary>
+    void SparseSgdMomentumUpdate(IGpuBuffer param, IGpuBuffer velocity,
+        IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz,
+        float learningRate, float momentum, float weightDecay);
+
+    /// <summary>Sparse Adam scatter-update on GPU.</summary>
+    void SparseAdamUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer v,
+        IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz,
+        float learningRate, float beta1, float beta2, float epsilon,
+        float weightDecay, int step);
+
+    /// <summary>Sparse AdamW scatter-update on GPU (decoupled weight decay).</summary>
+    void SparseAdamWUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer v,
+        IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz,
+        float learningRate, float beta1, float beta2, float epsilon,
+        float weightDecay, int step);
+
+    /// <summary>Sparse RMSProp scatter-update on GPU.</summary>
+    void SparseRmspropUpdate(IGpuBuffer param, IGpuBuffer squaredAvg,
+        IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz,
+        float learningRate, float rho, float epsilon, float weightDecay);
+
+    /// <summary>Sparse Adagrad scatter-update on GPU.</summary>
+    void SparseAdagradUpdate(IGpuBuffer param, IGpuBuffer accumulatedGrad,
+        IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz,
+        float learningRate, float epsilon, float weightDecay);
+
+    /// <summary>Sparse NAG (Nesterov-accelerated SGD with momentum) scatter-update on GPU.</summary>
+    void SparseNagUpdate(IGpuBuffer param, IGpuBuffer velocity,
+        IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz,
+        float learningRate, float momentum, float weightDecay);
+
+    /// <summary>Sparse AdaDelta scatter-update on GPU.</summary>
+    void SparseAdadeltaUpdate(IGpuBuffer param, IGpuBuffer accumGrad, IGpuBuffer accumUpdate,
+        IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz,
+        float rho, float epsilon, float weightDecay);
+
+    /// <summary>Sparse AMSGrad scatter-update on GPU.</summary>
+    void SparseAmsgradUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer v, IGpuBuffer vMax,
+        IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz,
+        float learningRate, float beta1, float beta2, float epsilon,
+        float weightDecay, int step);
+
+    /// <summary>Sparse Adamax scatter-update on GPU.</summary>
+    void SparseAdamaxUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer u,
+        IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz,
+        float learningRate, float beta1, float beta2, float epsilon,
+        float weightDecay, int step);
+
+    /// <summary>Sparse Lion scatter-update on GPU.</summary>
+    void SparseLionUpdate(IGpuBuffer param, IGpuBuffer m,
+        IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz,
+        float learningRate, float beta1, float beta2, float weightDecay);
+
+    /// <summary>Sparse Nadam scatter-update on GPU.</summary>
+    void SparseNadamUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer v,
+        IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz,
+        float learningRate, float beta1, float beta2, float epsilon,
+        float weightDecay, int step);
+
+    /// <summary>Sparse FTRL scatter-update on GPU.</summary>
+    void SparseFtrlUpdate(IGpuBuffer param, IGpuBuffer z, IGpuBuffer n,
+        IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz,
+        float learningRate, float l1Reg, float l2Reg, float beta);
+
+    /// <summary>Sparse proximal-L1 scatter-update on GPU.</summary>
+    void SparseProximalL1Update(IGpuBuffer param,
+        IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz,
+        float learningRate, float l1Strength);
+
     #endregion
 
     #region FFT and Signal Processing

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.SparseOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.SparseOptimizer.cs
@@ -1,0 +1,43 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Metal backend - sparse optimizer scatter-update stubs (PR #567).
+
+using System;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.Metal;
+
+public sealed partial class MetalBackend
+{
+    private static NotSupportedException SparseMetalNotImpl(string op) =>
+        new NotSupportedException(
+            $"Metal backend does not yet ship a native sparse '{op}' kernel; " +
+            "caller should fall back to the CPU sparse optimizer path.");
+
+    public void SparseSgdUpdate(IGpuBuffer param, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float weightDecay)
+        => throw SparseMetalNotImpl("sgd_update");
+    public void SparseSgdMomentumUpdate(IGpuBuffer param, IGpuBuffer velocity, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float momentum, float weightDecay)
+        => throw SparseMetalNotImpl("sgd_momentum_update");
+    public void SparseAdamUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer v, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+        => throw SparseMetalNotImpl("adam_update");
+    public void SparseAdamWUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer v, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+        => throw SparseMetalNotImpl("adamw_update");
+    public void SparseRmspropUpdate(IGpuBuffer param, IGpuBuffer squaredAvg, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float rho, float epsilon, float weightDecay)
+        => throw SparseMetalNotImpl("rmsprop_update");
+    public void SparseAdagradUpdate(IGpuBuffer param, IGpuBuffer accumulatedGrad, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float epsilon, float weightDecay)
+        => throw SparseMetalNotImpl("adagrad_update");
+    public void SparseNagUpdate(IGpuBuffer param, IGpuBuffer velocity, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float momentum, float weightDecay)
+        => throw SparseMetalNotImpl("nag_update");
+    public void SparseAdadeltaUpdate(IGpuBuffer param, IGpuBuffer accumGrad, IGpuBuffer accumUpdate, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float rho, float epsilon, float weightDecay)
+        => throw SparseMetalNotImpl("adadelta_update");
+    public void SparseAmsgradUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer v, IGpuBuffer vMax, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+        => throw SparseMetalNotImpl("amsgrad_update");
+    public void SparseAdamaxUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer u, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+        => throw SparseMetalNotImpl("adamax_update");
+    public void SparseLionUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float weightDecay)
+        => throw SparseMetalNotImpl("lion_update");
+    public void SparseNadamUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer v, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+        => throw SparseMetalNotImpl("nadam_update");
+    public void SparseFtrlUpdate(IGpuBuffer param, IGpuBuffer z, IGpuBuffer n, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float l1Reg, float l2Reg, float beta)
+        => throw SparseMetalNotImpl("ftrl_update");
+    public void SparseProximalL1Update(IGpuBuffer param, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float l1Strength)
+        => throw SparseMetalNotImpl("proximal_l1_update");
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.SparseOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.SparseOptimizer.cs
@@ -1,0 +1,44 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// OpenCL backend - sparse optimizer scatter-update stubs (PR #567).
+
+using System;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
+{
+    public sealed partial class OpenClBackend
+    {
+        private static NotSupportedException SparseOpenClNotImpl(string op) =>
+            new NotSupportedException(
+                $"OpenCL backend does not yet ship a native sparse '{op}' kernel; " +
+                "caller should fall back to the CPU sparse optimizer path.");
+
+        public void SparseSgdUpdate(IGpuBuffer param, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float weightDecay)
+            => throw SparseOpenClNotImpl("sgd_update");
+        public void SparseSgdMomentumUpdate(IGpuBuffer param, IGpuBuffer velocity, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float momentum, float weightDecay)
+            => throw SparseOpenClNotImpl("sgd_momentum_update");
+        public void SparseAdamUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer v, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+            => throw SparseOpenClNotImpl("adam_update");
+        public void SparseAdamWUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer v, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+            => throw SparseOpenClNotImpl("adamw_update");
+        public void SparseRmspropUpdate(IGpuBuffer param, IGpuBuffer squaredAvg, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float rho, float epsilon, float weightDecay)
+            => throw SparseOpenClNotImpl("rmsprop_update");
+        public void SparseAdagradUpdate(IGpuBuffer param, IGpuBuffer accumulatedGrad, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float epsilon, float weightDecay)
+            => throw SparseOpenClNotImpl("adagrad_update");
+        public void SparseNagUpdate(IGpuBuffer param, IGpuBuffer velocity, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float momentum, float weightDecay)
+            => throw SparseOpenClNotImpl("nag_update");
+        public void SparseAdadeltaUpdate(IGpuBuffer param, IGpuBuffer accumGrad, IGpuBuffer accumUpdate, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float rho, float epsilon, float weightDecay)
+            => throw SparseOpenClNotImpl("adadelta_update");
+        public void SparseAmsgradUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer v, IGpuBuffer vMax, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+            => throw SparseOpenClNotImpl("amsgrad_update");
+        public void SparseAdamaxUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer u, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+            => throw SparseOpenClNotImpl("adamax_update");
+        public void SparseLionUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float weightDecay)
+            => throw SparseOpenClNotImpl("lion_update");
+        public void SparseNadamUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer v, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+            => throw SparseOpenClNotImpl("nadam_update");
+        public void SparseFtrlUpdate(IGpuBuffer param, IGpuBuffer z, IGpuBuffer n, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float l1Reg, float l2Reg, float beta)
+            => throw SparseOpenClNotImpl("ftrl_update");
+        public void SparseProximalL1Update(IGpuBuffer param, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float l1Strength)
+            => throw SparseOpenClNotImpl("proximal_l1_update");
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.SparseOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.SparseOptimizer.cs
@@ -1,0 +1,43 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Vulkan backend - sparse optimizer scatter-update stubs (PR #567).
+
+using System;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.Vulkan;
+
+public sealed unsafe partial class VulkanBackend
+{
+    private static NotSupportedException SparseVulkanNotImpl(string op) =>
+        new NotSupportedException(
+            $"Vulkan backend does not yet ship a native sparse '{op}' kernel; " +
+            "caller should fall back to the CPU sparse optimizer path.");
+
+    public void SparseSgdUpdate(IGpuBuffer param, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float weightDecay)
+        => throw SparseVulkanNotImpl("sgd_update");
+    public void SparseSgdMomentumUpdate(IGpuBuffer param, IGpuBuffer velocity, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float momentum, float weightDecay)
+        => throw SparseVulkanNotImpl("sgd_momentum_update");
+    public void SparseAdamUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer v, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+        => throw SparseVulkanNotImpl("adam_update");
+    public void SparseAdamWUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer v, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+        => throw SparseVulkanNotImpl("adamw_update");
+    public void SparseRmspropUpdate(IGpuBuffer param, IGpuBuffer squaredAvg, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float rho, float epsilon, float weightDecay)
+        => throw SparseVulkanNotImpl("rmsprop_update");
+    public void SparseAdagradUpdate(IGpuBuffer param, IGpuBuffer accumulatedGrad, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float epsilon, float weightDecay)
+        => throw SparseVulkanNotImpl("adagrad_update");
+    public void SparseNagUpdate(IGpuBuffer param, IGpuBuffer velocity, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float momentum, float weightDecay)
+        => throw SparseVulkanNotImpl("nag_update");
+    public void SparseAdadeltaUpdate(IGpuBuffer param, IGpuBuffer accumGrad, IGpuBuffer accumUpdate, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float rho, float epsilon, float weightDecay)
+        => throw SparseVulkanNotImpl("adadelta_update");
+    public void SparseAmsgradUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer v, IGpuBuffer vMax, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+        => throw SparseVulkanNotImpl("amsgrad_update");
+    public void SparseAdamaxUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer u, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+        => throw SparseVulkanNotImpl("adamax_update");
+    public void SparseLionUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float weightDecay)
+        => throw SparseVulkanNotImpl("lion_update");
+    public void SparseNadamUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer v, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+        => throw SparseVulkanNotImpl("nadam_update");
+    public void SparseFtrlUpdate(IGpuBuffer param, IGpuBuffer z, IGpuBuffer n, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float l1Reg, float l2Reg, float beta)
+        => throw SparseVulkanNotImpl("ftrl_update");
+    public void SparseProximalL1Update(IGpuBuffer param, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float l1Strength)
+        => throw SparseVulkanNotImpl("proximal_l1_update");
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.SparseOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.SparseOptimizer.cs
@@ -1,0 +1,45 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// WebGpu backend - sparse optimizer scatter-update stubs (PR #567).
+
+#if NET7_0_OR_GREATER
+using System;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.WebGpu;
+
+public sealed partial class WebGpuBackend
+{
+    private static NotSupportedException SparseWebGpuNotImpl(string op) =>
+        new NotSupportedException(
+            $"WebGpu backend does not yet ship a native sparse '{op}' kernel; " +
+            "caller should fall back to the CPU sparse optimizer path.");
+
+    public void SparseSgdUpdate(IGpuBuffer param, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float weightDecay)
+        => throw SparseWebGpuNotImpl("sgd_update");
+    public void SparseSgdMomentumUpdate(IGpuBuffer param, IGpuBuffer velocity, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float momentum, float weightDecay)
+        => throw SparseWebGpuNotImpl("sgd_momentum_update");
+    public void SparseAdamUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer v, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+        => throw SparseWebGpuNotImpl("adam_update");
+    public void SparseAdamWUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer v, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+        => throw SparseWebGpuNotImpl("adamw_update");
+    public void SparseRmspropUpdate(IGpuBuffer param, IGpuBuffer squaredAvg, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float rho, float epsilon, float weightDecay)
+        => throw SparseWebGpuNotImpl("rmsprop_update");
+    public void SparseAdagradUpdate(IGpuBuffer param, IGpuBuffer accumulatedGrad, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float epsilon, float weightDecay)
+        => throw SparseWebGpuNotImpl("adagrad_update");
+    public void SparseNagUpdate(IGpuBuffer param, IGpuBuffer velocity, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float momentum, float weightDecay)
+        => throw SparseWebGpuNotImpl("nag_update");
+    public void SparseAdadeltaUpdate(IGpuBuffer param, IGpuBuffer accumGrad, IGpuBuffer accumUpdate, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float rho, float epsilon, float weightDecay)
+        => throw SparseWebGpuNotImpl("adadelta_update");
+    public void SparseAmsgradUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer v, IGpuBuffer vMax, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+        => throw SparseWebGpuNotImpl("amsgrad_update");
+    public void SparseAdamaxUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer u, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+        => throw SparseWebGpuNotImpl("adamax_update");
+    public void SparseLionUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float weightDecay)
+        => throw SparseWebGpuNotImpl("lion_update");
+    public void SparseNadamUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer v, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+        => throw SparseWebGpuNotImpl("nadam_update");
+    public void SparseFtrlUpdate(IGpuBuffer param, IGpuBuffer z, IGpuBuffer n, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float l1Reg, float l2Reg, float beta)
+        => throw SparseWebGpuNotImpl("ftrl_update");
+    public void SparseProximalL1Update(IGpuBuffer param, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float l1Strength)
+        => throw SparseWebGpuNotImpl("proximal_l1_update");
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
@@ -1557,6 +1557,62 @@ public class DelegatingGpuBackend : IDirectGpuBackend
         => Inner.FtrlUpdate(param, gradient, z, n, learningRate, l1Reg, l2Reg, beta, size);
 
     /// <inheritdoc/>
+    public virtual void SparseSgdUpdate(IGpuBuffer param, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float weightDecay)
+        => Inner.SparseSgdUpdate(param, sparseIndices, sparseValues, nnz, learningRate, weightDecay);
+
+    /// <inheritdoc/>
+    public virtual void SparseSgdMomentumUpdate(IGpuBuffer param, IGpuBuffer velocity, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float momentum, float weightDecay)
+        => Inner.SparseSgdMomentumUpdate(param, velocity, sparseIndices, sparseValues, nnz, learningRate, momentum, weightDecay);
+
+    /// <inheritdoc/>
+    public virtual void SparseAdamUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer v, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+        => Inner.SparseAdamUpdate(param, m, v, sparseIndices, sparseValues, nnz, learningRate, beta1, beta2, epsilon, weightDecay, step);
+
+    /// <inheritdoc/>
+    public virtual void SparseAdamWUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer v, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+        => Inner.SparseAdamWUpdate(param, m, v, sparseIndices, sparseValues, nnz, learningRate, beta1, beta2, epsilon, weightDecay, step);
+
+    /// <inheritdoc/>
+    public virtual void SparseRmspropUpdate(IGpuBuffer param, IGpuBuffer squaredAvg, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float rho, float epsilon, float weightDecay)
+        => Inner.SparseRmspropUpdate(param, squaredAvg, sparseIndices, sparseValues, nnz, learningRate, rho, epsilon, weightDecay);
+
+    /// <inheritdoc/>
+    public virtual void SparseAdagradUpdate(IGpuBuffer param, IGpuBuffer accumulatedGrad, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float epsilon, float weightDecay)
+        => Inner.SparseAdagradUpdate(param, accumulatedGrad, sparseIndices, sparseValues, nnz, learningRate, epsilon, weightDecay);
+
+    /// <inheritdoc/>
+    public virtual void SparseNagUpdate(IGpuBuffer param, IGpuBuffer velocity, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float momentum, float weightDecay)
+        => Inner.SparseNagUpdate(param, velocity, sparseIndices, sparseValues, nnz, learningRate, momentum, weightDecay);
+
+    /// <inheritdoc/>
+    public virtual void SparseAdadeltaUpdate(IGpuBuffer param, IGpuBuffer accumGrad, IGpuBuffer accumUpdate, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float rho, float epsilon, float weightDecay)
+        => Inner.SparseAdadeltaUpdate(param, accumGrad, accumUpdate, sparseIndices, sparseValues, nnz, rho, epsilon, weightDecay);
+
+    /// <inheritdoc/>
+    public virtual void SparseAmsgradUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer v, IGpuBuffer vMax, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+        => Inner.SparseAmsgradUpdate(param, m, v, vMax, sparseIndices, sparseValues, nnz, learningRate, beta1, beta2, epsilon, weightDecay, step);
+
+    /// <inheritdoc/>
+    public virtual void SparseAdamaxUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer u, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+        => Inner.SparseAdamaxUpdate(param, m, u, sparseIndices, sparseValues, nnz, learningRate, beta1, beta2, epsilon, weightDecay, step);
+
+    /// <inheritdoc/>
+    public virtual void SparseLionUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float weightDecay)
+        => Inner.SparseLionUpdate(param, m, sparseIndices, sparseValues, nnz, learningRate, beta1, beta2, weightDecay);
+
+    /// <inheritdoc/>
+    public virtual void SparseNadamUpdate(IGpuBuffer param, IGpuBuffer m, IGpuBuffer v, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float beta1, float beta2, float epsilon, float weightDecay, int step)
+        => Inner.SparseNadamUpdate(param, m, v, sparseIndices, sparseValues, nnz, learningRate, beta1, beta2, epsilon, weightDecay, step);
+
+    /// <inheritdoc/>
+    public virtual void SparseFtrlUpdate(IGpuBuffer param, IGpuBuffer z, IGpuBuffer n, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float l1Reg, float l2Reg, float beta)
+        => Inner.SparseFtrlUpdate(param, z, n, sparseIndices, sparseValues, nnz, learningRate, l1Reg, l2Reg, beta);
+
+    /// <inheritdoc/>
+    public virtual void SparseProximalL1Update(IGpuBuffer param, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float l1Strength)
+        => Inner.SparseProximalL1Update(param, sparseIndices, sparseValues, nnz, learningRate, l1Strength);
+
+    /// <inheritdoc/>
     public virtual void ConvertToFp16(IGpuBuffer input, IGpuBuffer output, int size)
         => Inner.ConvertToFp16(input, output, size);
 

--- a/src/AiDotNet.Tensors/Engines/Gpu/GpuOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/GpuOptimizer.cs
@@ -306,4 +306,347 @@ public static class GpuOptimizer
         if (pb is null || gb is null || zb is null || nb is null) return false;
         b.FtrlUpdate(pb, gb, zb, nb, lr, l1Reg, l2Reg, beta, p!.Length); return true;
     }
+
+    // ==================================================================
+    // SPARSE-AWARE GPU OPTIMIZER WRAPPERS
+    // ==================================================================
+    //
+    // Mirror surface for the dense GPU optimizer wrappers above (issue #336),
+    // accepting caller-supplied sparse gradient representation (GPU-resident
+    // <c>sparseIndices</c>/<c>sparseValues</c>) instead of a dense gradient buffer.
+    //
+    // Implementation strategy — "materialize then dense":
+    //   1. Zero the GPU-resident <paramref name="gradScratch"/> buffer (Fill 0f).
+    //   2. ScatterAdd sparse (indices, values) → gradScratch (writes only the
+    //      <paramref name="nnz"/> touched positions; the rest stay 0).
+    //   3. Dispatch the existing dense per-optimizer kernel against gradScratch.
+    //
+    // This keeps the dense kernels unchanged (no new CUDA code needed) while
+    // exposing a sparse entry point that mirrors the AiDotNet-side optimizer
+    // wiring. The consumer never has to materialize sparse→dense on the host
+    // and shuttle the dense gradient across PCIe.
+    //
+    // A future PR can replace the dense-kernel call with a native sparse
+    // scatter-update kernel (sparse_adam_step_kernel etc.) without changing
+    // this API surface — at that point both compute and bandwidth wins land.
+    // For now, perf wins are bandwidth-only (smaller upload).
+    //
+    // All wrappers return false on any failed precondition (non-GPU engine,
+    // missing buffer, backend without scatter/fill); caller falls back to
+    // the CPU sparse path in OptimizerBase / Optimizers.cs.
+    // ==================================================================
+
+    private static bool TryMaterializeSparseIntoDense(
+        Tensor<float> gradScratch, Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
+        out IGpuBuffer? gradBuf, out IDirectGpuBackend? backend)
+    {
+        gradBuf = null;
+        backend = null;
+        if (gradScratch is null) throw new ArgumentNullException(nameof(gradScratch));
+        if (sparseIndices is null) throw new ArgumentNullException(nameof(sparseIndices));
+        if (sparseValues is null) throw new ArgumentNullException(nameof(sparseValues));
+        if (nnz < 0) throw new ArgumentOutOfRangeException(nameof(nnz));
+        if (nnz > sparseIndices.Length || nnz > sparseValues.Length)
+            throw new ArgumentException("nnz exceeds the supplied sparse buffers.", nameof(nnz));
+
+        if (!(AiDotNetEngine.Current is DirectGpuTensorEngine engine)) return false;
+        var b = engine.GetBackend();
+        if (b is null) return false;
+        var gb = gradScratch.TryGetGpuBuffer();
+        var iBuf = sparseIndices.TryGetGpuBuffer();
+        var vBuf = sparseValues.TryGetGpuBuffer();
+        if (gb is null || iBuf is null || vBuf is null) return false;
+
+        b.Fill(gb, 0f, gradScratch.Length);
+        if (nnz > 0)
+            b.ScatterAdd(vBuf, iBuf, gb, sourceSize: nnz, destSize: gradScratch.Length);
+
+        gradBuf = gb;
+        backend = b;
+        return true;
+    }
+
+    /// <summary>Adam GPU step driven by a sparse gradient (indices + values).
+    /// Caller supplies a GPU-resident <paramref name="gradScratch"/> buffer of the same
+    /// shape as <paramref name="param"/> — this is overwritten with the materialized
+    /// dense view of the sparse gradient before the dense kernel runs. Returns false
+    /// when any tensor isn't GPU-resident (caller falls back to CPU sparse path).</summary>
+    public static bool TryAdamStepSparse(
+        Tensor<float> param, Tensor<float> gradScratch,
+        Tensor<float> m, Tensor<float> v,
+        Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
+        float learningRate, float beta1, float beta2, float epsilon,
+        float weightDecay, int step)
+    {
+        if (param is null) throw new ArgumentNullException(nameof(param));
+        if (m is null) throw new ArgumentNullException(nameof(m));
+        if (v is null) throw new ArgumentNullException(nameof(v));
+        if (!TryMaterializeSparseIntoDense(gradScratch, sparseIndices, sparseValues, nnz, out var gb, out var backend))
+            return false;
+        var pb = param.TryGetGpuBuffer();
+        var mb = m.TryGetGpuBuffer();
+        var vb = v.TryGetGpuBuffer();
+        if (pb is null || mb is null || vb is null) return false;
+        backend!.AdamUpdate(pb, gb!, mb, vb, learningRate, beta1, beta2, epsilon, weightDecay, step, param.Length);
+        return true;
+    }
+
+    /// <summary>AdamW GPU step driven by a sparse gradient. See <see cref="TryAdamStepSparse"/>.</summary>
+    public static bool TryAdamWStepSparse(
+        Tensor<float> param, Tensor<float> gradScratch,
+        Tensor<float> m, Tensor<float> v,
+        Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
+        float learningRate, float beta1, float beta2, float epsilon,
+        float weightDecay, int step)
+        => TryAdamStepSparse(param, gradScratch, m, v, sparseIndices, sparseValues, nnz,
+            learningRate, beta1, beta2, epsilon, weightDecay, step);
+
+    /// <summary>SGD GPU step driven by a sparse gradient.</summary>
+    public static bool TrySgdStepSparse(
+        Tensor<float> param, Tensor<float> gradScratch,
+        Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
+        float learningRate)
+    {
+        if (param is null) throw new ArgumentNullException(nameof(param));
+        if (!TryMaterializeSparseIntoDense(gradScratch, sparseIndices, sparseValues, nnz, out var gb, out var backend))
+            return false;
+        var pb = param.TryGetGpuBuffer();
+        if (pb is null) return false;
+        backend!.SgdUpdate(pb, gb!, learningRate, weightDecay: 0f, param.Length);
+        return true;
+    }
+
+    /// <summary>SGD-momentum GPU step driven by a sparse gradient.</summary>
+    public static bool TrySgdMomentumStepSparse(
+        Tensor<float> param, Tensor<float> gradScratch, Tensor<float> velocity,
+        Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
+        float learningRate, float momentum, float weightDecay)
+    {
+        if (param is null) throw new ArgumentNullException(nameof(param));
+        if (velocity is null) throw new ArgumentNullException(nameof(velocity));
+        if (!TryMaterializeSparseIntoDense(gradScratch, sparseIndices, sparseValues, nnz, out var gb, out var backend))
+            return false;
+        var pb = param.TryGetGpuBuffer();
+        var vb = velocity.TryGetGpuBuffer();
+        if (pb is null || vb is null) return false;
+        backend!.SgdMomentumUpdate(pb, gb!, vb, learningRate, momentum, weightDecay, param.Length);
+        return true;
+    }
+
+    /// <summary>RMSProp GPU step driven by a sparse gradient.</summary>
+    public static bool TryRmspropStepSparse(
+        Tensor<float> param, Tensor<float> gradScratch, Tensor<float> squaredAvg,
+        Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
+        float lr, float rho, float epsilon, float weightDecay)
+    {
+        if (param is null) throw new ArgumentNullException(nameof(param));
+        if (squaredAvg is null) throw new ArgumentNullException(nameof(squaredAvg));
+        if (!TryMaterializeSparseIntoDense(gradScratch, sparseIndices, sparseValues, nnz, out var gb, out var backend))
+            return false;
+        var pb = param.TryGetGpuBuffer();
+        var sb = squaredAvg.TryGetGpuBuffer();
+        if (pb is null || sb is null) return false;
+        backend!.RmspropUpdate(pb, gb!, sb, lr, rho, epsilon, weightDecay, param.Length);
+        return true;
+    }
+
+    /// <summary>Adagrad GPU step driven by a sparse gradient.</summary>
+    public static bool TryAdagradStepSparse(
+        Tensor<float> param, Tensor<float> gradScratch, Tensor<float> accum,
+        Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
+        float lr, float epsilon, float weightDecay)
+    {
+        if (param is null) throw new ArgumentNullException(nameof(param));
+        if (accum is null) throw new ArgumentNullException(nameof(accum));
+        if (!TryMaterializeSparseIntoDense(gradScratch, sparseIndices, sparseValues, nnz, out var gb, out var backend))
+            return false;
+        var pb = param.TryGetGpuBuffer();
+        var ab = accum.TryGetGpuBuffer();
+        if (pb is null || ab is null) return false;
+        backend!.AdagradUpdate(pb, gb!, ab, lr, epsilon, weightDecay, param.Length);
+        return true;
+    }
+
+    /// <summary>NAG GPU step driven by a sparse gradient.</summary>
+    public static bool TryNagStepSparse(
+        Tensor<float> param, Tensor<float> gradScratch, Tensor<float> velocity,
+        Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
+        float lr, float momentum, float weightDecay)
+    {
+        if (param is null) throw new ArgumentNullException(nameof(param));
+        if (velocity is null) throw new ArgumentNullException(nameof(velocity));
+        if (!TryMaterializeSparseIntoDense(gradScratch, sparseIndices, sparseValues, nnz, out var gb, out var backend))
+            return false;
+        var pb = param.TryGetGpuBuffer();
+        var vb = velocity.TryGetGpuBuffer();
+        if (pb is null || vb is null) return false;
+        backend!.NagUpdate(pb, gb!, vb, lr, momentum, weightDecay, param.Length);
+        return true;
+    }
+
+    /// <summary>LARS GPU step driven by a sparse gradient. (Note: LARS trust-ratio is
+    /// computed over the FULL gradient norm; materializing sparse→dense first preserves
+    /// the dense math exactly.)</summary>
+    public static bool TryLarsStepSparse(
+        Tensor<float> param, Tensor<float> gradScratch, Tensor<float> velocity,
+        Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
+        float lr, float momentum, float weightDecay, float trustCoeff)
+    {
+        if (param is null) throw new ArgumentNullException(nameof(param));
+        if (velocity is null) throw new ArgumentNullException(nameof(velocity));
+        if (!TryMaterializeSparseIntoDense(gradScratch, sparseIndices, sparseValues, nnz, out var gb, out var backend))
+            return false;
+        var pb = param.TryGetGpuBuffer();
+        var vb = velocity.TryGetGpuBuffer();
+        if (pb is null || vb is null) return false;
+        backend!.LarsUpdate(pb, gb!, vb, lr, momentum, weightDecay, trustCoeff, param.Length);
+        return true;
+    }
+
+    /// <summary>LAMB GPU step driven by a sparse gradient. (Note: LAMB trust-ratio is
+    /// computed over the FULL gradient norm; materializing sparse→dense first preserves
+    /// the dense math exactly.)</summary>
+    public static bool TryLambStepSparse(
+        Tensor<float> param, Tensor<float> gradScratch, Tensor<float> m, Tensor<float> v,
+        Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
+        float lr, float beta1, float beta2, float epsilon, float weightDecay, int step)
+    {
+        if (param is null) throw new ArgumentNullException(nameof(param));
+        if (m is null) throw new ArgumentNullException(nameof(m));
+        if (v is null) throw new ArgumentNullException(nameof(v));
+        if (!TryMaterializeSparseIntoDense(gradScratch, sparseIndices, sparseValues, nnz, out var gb, out var backend))
+            return false;
+        var pb = param.TryGetGpuBuffer();
+        var mb = m.TryGetGpuBuffer();
+        var vb = v.TryGetGpuBuffer();
+        if (pb is null || mb is null || vb is null) return false;
+        backend!.LambUpdate(pb, gb!, mb, vb, lr, beta1, beta2, epsilon, weightDecay, step, param.Length);
+        return true;
+    }
+
+    /// <summary>AdaDelta GPU step driven by a sparse gradient.</summary>
+    public static bool TryAdadeltaStepSparse(
+        Tensor<float> param, Tensor<float> gradScratch, Tensor<float> accumGrad, Tensor<float> accumUpdate,
+        Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
+        float rho, float epsilon, float weightDecay)
+    {
+        if (param is null) throw new ArgumentNullException(nameof(param));
+        if (accumGrad is null) throw new ArgumentNullException(nameof(accumGrad));
+        if (accumUpdate is null) throw new ArgumentNullException(nameof(accumUpdate));
+        if (!TryMaterializeSparseIntoDense(gradScratch, sparseIndices, sparseValues, nnz, out var gb, out var backend))
+            return false;
+        var pb = param.TryGetGpuBuffer();
+        var agb = accumGrad.TryGetGpuBuffer();
+        var aub = accumUpdate.TryGetGpuBuffer();
+        if (pb is null || agb is null || aub is null) return false;
+        backend!.AdadeltaUpdate(pb, gb!, agb, aub, rho, epsilon, weightDecay, param.Length);
+        return true;
+    }
+
+    /// <summary>AMSGrad GPU step driven by a sparse gradient.</summary>
+    public static bool TryAmsgradStepSparse(
+        Tensor<float> param, Tensor<float> gradScratch, Tensor<float> m, Tensor<float> v, Tensor<float> vMax,
+        Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
+        float lr, float beta1, float beta2, float epsilon, float weightDecay, int step)
+    {
+        if (param is null) throw new ArgumentNullException(nameof(param));
+        if (m is null) throw new ArgumentNullException(nameof(m));
+        if (v is null) throw new ArgumentNullException(nameof(v));
+        if (vMax is null) throw new ArgumentNullException(nameof(vMax));
+        if (!TryMaterializeSparseIntoDense(gradScratch, sparseIndices, sparseValues, nnz, out var gb, out var backend))
+            return false;
+        var pb = param.TryGetGpuBuffer();
+        var mb = m.TryGetGpuBuffer();
+        var vb = v.TryGetGpuBuffer();
+        var xb = vMax.TryGetGpuBuffer();
+        if (pb is null || mb is null || vb is null || xb is null) return false;
+        backend!.AmsgradUpdate(pb, gb!, mb, vb, xb, lr, beta1, beta2, epsilon, weightDecay, step, param.Length);
+        return true;
+    }
+
+    /// <summary>Adamax GPU step driven by a sparse gradient.</summary>
+    public static bool TryAdamaxStepSparse(
+        Tensor<float> param, Tensor<float> gradScratch, Tensor<float> m, Tensor<float> u,
+        Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
+        float lr, float beta1, float beta2, float epsilon, float weightDecay, int step)
+    {
+        if (param is null) throw new ArgumentNullException(nameof(param));
+        if (m is null) throw new ArgumentNullException(nameof(m));
+        if (u is null) throw new ArgumentNullException(nameof(u));
+        if (!TryMaterializeSparseIntoDense(gradScratch, sparseIndices, sparseValues, nnz, out var gb, out var backend))
+            return false;
+        var pb = param.TryGetGpuBuffer();
+        var mb = m.TryGetGpuBuffer();
+        var ub = u.TryGetGpuBuffer();
+        if (pb is null || mb is null || ub is null) return false;
+        backend!.AdamaxUpdate(pb, gb!, mb, ub, lr, beta1, beta2, epsilon, weightDecay, step, param.Length);
+        return true;
+    }
+
+    /// <summary>Lion GPU step driven by a sparse gradient.</summary>
+    public static bool TryLionStepSparse(
+        Tensor<float> param, Tensor<float> gradScratch, Tensor<float> m,
+        Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
+        float lr, float beta1, float beta2, float weightDecay)
+    {
+        if (param is null) throw new ArgumentNullException(nameof(param));
+        if (m is null) throw new ArgumentNullException(nameof(m));
+        if (!TryMaterializeSparseIntoDense(gradScratch, sparseIndices, sparseValues, nnz, out var gb, out var backend))
+            return false;
+        var pb = param.TryGetGpuBuffer();
+        var mb = m.TryGetGpuBuffer();
+        if (pb is null || mb is null) return false;
+        backend!.LionUpdate(pb, gb!, mb, lr, beta1, beta2, weightDecay, param.Length);
+        return true;
+    }
+
+    /// <summary>Nadam GPU step driven by a sparse gradient.</summary>
+    public static bool TryNadamStepSparse(
+        Tensor<float> param, Tensor<float> gradScratch, Tensor<float> m, Tensor<float> v,
+        Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
+        float lr, float beta1, float beta2, float epsilon, float weightDecay, int step)
+    {
+        if (param is null) throw new ArgumentNullException(nameof(param));
+        if (m is null) throw new ArgumentNullException(nameof(m));
+        if (v is null) throw new ArgumentNullException(nameof(v));
+        if (!TryMaterializeSparseIntoDense(gradScratch, sparseIndices, sparseValues, nnz, out var gb, out var backend))
+            return false;
+        var pb = param.TryGetGpuBuffer();
+        var mb = m.TryGetGpuBuffer();
+        var vb = v.TryGetGpuBuffer();
+        if (pb is null || mb is null || vb is null) return false;
+        backend!.NadamUpdate(pb, gb!, mb, vb, lr, beta1, beta2, epsilon, weightDecay, step, param.Length);
+        return true;
+    }
+
+    /// <summary>FTRL GPU step driven by a sparse gradient.</summary>
+    public static bool TryFtrlStepSparse(
+        Tensor<float> param, Tensor<float> gradScratch, Tensor<float> z, Tensor<float> n,
+        Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
+        float lr, float l1Reg, float l2Reg, float beta)
+    {
+        if (param is null) throw new ArgumentNullException(nameof(param));
+        if (z is null) throw new ArgumentNullException(nameof(z));
+        if (n is null) throw new ArgumentNullException(nameof(n));
+        if (!TryMaterializeSparseIntoDense(gradScratch, sparseIndices, sparseValues, nnz, out var gb, out var backend))
+            return false;
+        var pb = param.TryGetGpuBuffer();
+        var zb = z.TryGetGpuBuffer();
+        var nb = n.TryGetGpuBuffer();
+        if (pb is null || zb is null || nb is null) return false;
+        backend!.FtrlUpdate(pb, gb!, zb, nb, lr, l1Reg, l2Reg, beta, param.Length);
+        return true;
+    }
+
+    /// <summary>Proximal-L1 GPU step driven by a sparse gradient.</summary>
+    public static bool TryProximalL1StepSparse(
+        Tensor<float> param, Tensor<float> gradScratch,
+        Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
+        float lr, float l1Strength)
+    {
+        if (param is null) throw new ArgumentNullException(nameof(param));
+        if (!TryMaterializeSparseIntoDense(gradScratch, sparseIndices, sparseValues, nnz, out var gb, out var backend))
+            return false;
+        return TryProximalL1Step(param, gradScratch, lr, l1Strength);
+    }
 }

--- a/src/AiDotNet.Tensors/Engines/Gpu/GpuOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/GpuOptimizer.cs
@@ -308,41 +308,34 @@ public static class GpuOptimizer
     }
 
     // ==================================================================
-    // SPARSE-AWARE GPU OPTIMIZER WRAPPERS
+    // SPARSE-AWARE GPU OPTIMIZER WRAPPERS — PR #567
     // ==================================================================
     //
-    // Mirror surface for the dense GPU optimizer wrappers above (issue #336),
-    // accepting caller-supplied sparse gradient representation (GPU-resident
-    // <c>sparseIndices</c>/<c>sparseValues</c>) instead of a dense gradient buffer.
+    // Each wrapper below dispatches the matching NATIVE sparse_*_update
+    // CUDA kernel (defined in CudaOptimizerKernels.cs, launched by
+    // CudaBackend.SparseXUpdate). Grid dim = ceil(nnz / 256); each kernel
+    // thread reads exactly one (idx[k], val[k]) and scatter-updates only
+    // (param[idx], state[idx]). Memory traffic is O(nnz) — the other
+    // (param.Length - nnz) entries are never read or written.
     //
-    // Implementation strategy — "materialize then dense":
-    //   1. Zero the GPU-resident <paramref name="gradScratch"/> buffer (Fill 0f).
-    //   2. ScatterAdd sparse (indices, values) → gradScratch (writes only the
-    //      <paramref name="nnz"/> touched positions; the rest stay 0).
-    //   3. Dispatch the existing dense per-optimizer kernel against gradScratch.
+    // sparseIndices and sparseValues must already be GPU-resident
+    // (TryGetGpuBuffer must succeed for them). The dense state buffers
+    // (m, v, accum, ...) keep their full shape and are mutated in place
+    // at the touched indices.
     //
-    // This keeps the dense kernels unchanged (no new CUDA code needed) while
-    // exposing a sparse entry point that mirrors the AiDotNet-side optimizer
-    // wiring. The consumer never has to materialize sparse→dense on the host
-    // and shuttle the dense gradient across PCIe.
-    //
-    // A future PR can replace the dense-kernel call with a native sparse
-    // scatter-update kernel (sparse_adam_step_kernel etc.) without changing
-    // this API surface — at that point both compute and bandwidth wins land.
-    // For now, perf wins are bandwidth-only (smaller upload).
-    //
-    // All wrappers return false on any failed precondition (non-GPU engine,
-    // missing buffer, backend without scatter/fill); caller falls back to
-    // the CPU sparse path in OptimizerBase / Optimizers.cs.
+    // Returns false on:
+    //   * non-GPU engine (caller should run CPU sparse path)
+    //   * any tensor missing its GPU buffer
+    //   * backend NotSupportedException (non-CUDA backends without the
+    //     native sparse kernel yet — HIP/Metal/Vulkan/WebGpu/OpenCL)
     // ==================================================================
 
-    private static bool TryMaterializeSparseIntoDense(
-        Tensor<float> gradScratch, Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
-        out IGpuBuffer? gradBuf, out IDirectGpuBackend? backend)
+    private static bool TryPrepareSparse(
+        Tensor<float> param, Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
+        out IDirectGpuBackend? backend, out IGpuBuffer? pBuf, out IGpuBuffer? idxBuf, out IGpuBuffer? valBuf)
     {
-        gradBuf = null;
-        backend = null;
-        if (gradScratch is null) throw new ArgumentNullException(nameof(gradScratch));
+        backend = null; pBuf = null; idxBuf = null; valBuf = null;
+        if (param is null) throw new ArgumentNullException(nameof(param));
         if (sparseIndices is null) throw new ArgumentNullException(nameof(sparseIndices));
         if (sparseValues is null) throw new ArgumentNullException(nameof(sparseValues));
         if (nnz < 0) throw new ArgumentOutOfRangeException(nameof(nnz));
@@ -350,303 +343,214 @@ public static class GpuOptimizer
             throw new ArgumentException("nnz exceeds the supplied sparse buffers.", nameof(nnz));
 
         if (!(AiDotNetEngine.Current is DirectGpuTensorEngine engine)) return false;
-        var b = engine.GetBackend();
-        if (b is null) return false;
-        var gb = gradScratch.TryGetGpuBuffer();
-        var iBuf = sparseIndices.TryGetGpuBuffer();
-        var vBuf = sparseValues.TryGetGpuBuffer();
-        if (gb is null || iBuf is null || vBuf is null) return false;
-
-        b.Fill(gb, 0f, gradScratch.Length);
-        if (nnz > 0)
-            b.ScatterAdd(vBuf, iBuf, gb, sourceSize: nnz, destSize: gradScratch.Length);
-
-        gradBuf = gb;
-        backend = b;
-        return true;
+        backend = engine.GetBackend();
+        if (backend is null) return false;
+        pBuf = param.TryGetGpuBuffer();
+        idxBuf = sparseIndices.TryGetGpuBuffer();
+        valBuf = sparseValues.TryGetGpuBuffer();
+        return pBuf is not null && idxBuf is not null && valBuf is not null;
     }
 
-    /// <summary>Adam GPU step driven by a sparse gradient (indices + values).
-    /// Caller supplies a GPU-resident <paramref name="gradScratch"/> buffer of the same
-    /// shape as <paramref name="param"/> — this is overwritten with the materialized
-    /// dense view of the sparse gradient before the dense kernel runs. Returns false
-    /// when any tensor isn't GPU-resident (caller falls back to CPU sparse path).</summary>
+    /// <summary>Adam GPU step driven by a sparse gradient — dispatches the native
+    /// sparse_adam_update kernel (one thread per nnz, scatter-update). Returns false
+    /// when any tensor isn't GPU-resident or the backend has no native sparse kernel.</summary>
     public static bool TryAdamStepSparse(
-        Tensor<float> param, Tensor<float> gradScratch,
-        Tensor<float> m, Tensor<float> v,
+        Tensor<float> param, Tensor<float> m, Tensor<float> v,
         Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
         float learningRate, float beta1, float beta2, float epsilon,
         float weightDecay, int step)
     {
-        if (param is null) throw new ArgumentNullException(nameof(param));
         if (m is null) throw new ArgumentNullException(nameof(m));
         if (v is null) throw new ArgumentNullException(nameof(v));
-        if (!TryMaterializeSparseIntoDense(gradScratch, sparseIndices, sparseValues, nnz, out var gb, out var backend))
-            return false;
-        var pb = param.TryGetGpuBuffer();
-        var mb = m.TryGetGpuBuffer();
-        var vb = v.TryGetGpuBuffer();
-        if (pb is null || mb is null || vb is null) return false;
-        backend!.AdamUpdate(pb, gb!, mb, vb, learningRate, beta1, beta2, epsilon, weightDecay, step, param.Length);
-        return true;
+        if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
+        var mb = m.TryGetGpuBuffer(); var vbState = v.TryGetGpuBuffer();
+        if (mb is null || vbState is null) return false;
+        try { b!.SparseAdamUpdate(pb!, mb, vbState, iBuf!, vBuf!, nnz, learningRate, beta1, beta2, epsilon, weightDecay, step); return true; }
+        catch (NotSupportedException) { return false; }
     }
 
-    /// <summary>AdamW GPU step driven by a sparse gradient. See <see cref="TryAdamStepSparse"/>.</summary>
+    /// <summary>AdamW GPU step driven by a sparse gradient (native sparse_adamw_update kernel).</summary>
     public static bool TryAdamWStepSparse(
-        Tensor<float> param, Tensor<float> gradScratch,
-        Tensor<float> m, Tensor<float> v,
+        Tensor<float> param, Tensor<float> m, Tensor<float> v,
         Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
         float learningRate, float beta1, float beta2, float epsilon,
         float weightDecay, int step)
-        => TryAdamStepSparse(param, gradScratch, m, v, sparseIndices, sparseValues, nnz,
-            learningRate, beta1, beta2, epsilon, weightDecay, step);
-
-    /// <summary>SGD GPU step driven by a sparse gradient.</summary>
-    public static bool TrySgdStepSparse(
-        Tensor<float> param, Tensor<float> gradScratch,
-        Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
-        float learningRate)
     {
-        if (param is null) throw new ArgumentNullException(nameof(param));
-        if (!TryMaterializeSparseIntoDense(gradScratch, sparseIndices, sparseValues, nnz, out var gb, out var backend))
-            return false;
-        var pb = param.TryGetGpuBuffer();
-        if (pb is null) return false;
-        backend!.SgdUpdate(pb, gb!, learningRate, weightDecay: 0f, param.Length);
-        return true;
+        if (m is null) throw new ArgumentNullException(nameof(m));
+        if (v is null) throw new ArgumentNullException(nameof(v));
+        if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
+        var mb = m.TryGetGpuBuffer(); var vbState = v.TryGetGpuBuffer();
+        if (mb is null || vbState is null) return false;
+        try { b!.SparseAdamWUpdate(pb!, mb, vbState, iBuf!, vBuf!, nnz, learningRate, beta1, beta2, epsilon, weightDecay, step); return true; }
+        catch (NotSupportedException) { return false; }
+    }
+
+    /// <summary>SGD GPU step driven by a sparse gradient (native sparse_sgd_update kernel).</summary>
+    public static bool TrySgdStepSparse(
+        Tensor<float> param,
+        Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
+        float learningRate, float weightDecay = 0f)
+    {
+        if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
+        try { b!.SparseSgdUpdate(pb!, iBuf!, vBuf!, nnz, learningRate, weightDecay); return true; }
+        catch (NotSupportedException) { return false; }
     }
 
     /// <summary>SGD-momentum GPU step driven by a sparse gradient.</summary>
     public static bool TrySgdMomentumStepSparse(
-        Tensor<float> param, Tensor<float> gradScratch, Tensor<float> velocity,
+        Tensor<float> param, Tensor<float> velocity,
         Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
         float learningRate, float momentum, float weightDecay)
     {
-        if (param is null) throw new ArgumentNullException(nameof(param));
         if (velocity is null) throw new ArgumentNullException(nameof(velocity));
-        if (!TryMaterializeSparseIntoDense(gradScratch, sparseIndices, sparseValues, nnz, out var gb, out var backend))
-            return false;
-        var pb = param.TryGetGpuBuffer();
-        var vb = velocity.TryGetGpuBuffer();
-        if (pb is null || vb is null) return false;
-        backend!.SgdMomentumUpdate(pb, gb!, vb, learningRate, momentum, weightDecay, param.Length);
-        return true;
+        if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
+        var velBuf = velocity.TryGetGpuBuffer();
+        if (velBuf is null) return false;
+        try { b!.SparseSgdMomentumUpdate(pb!, velBuf, iBuf!, vBuf!, nnz, learningRate, momentum, weightDecay); return true; }
+        catch (NotSupportedException) { return false; }
     }
 
     /// <summary>RMSProp GPU step driven by a sparse gradient.</summary>
     public static bool TryRmspropStepSparse(
-        Tensor<float> param, Tensor<float> gradScratch, Tensor<float> squaredAvg,
+        Tensor<float> param, Tensor<float> squaredAvg,
         Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
         float lr, float rho, float epsilon, float weightDecay)
     {
-        if (param is null) throw new ArgumentNullException(nameof(param));
         if (squaredAvg is null) throw new ArgumentNullException(nameof(squaredAvg));
-        if (!TryMaterializeSparseIntoDense(gradScratch, sparseIndices, sparseValues, nnz, out var gb, out var backend))
-            return false;
-        var pb = param.TryGetGpuBuffer();
+        if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
         var sb = squaredAvg.TryGetGpuBuffer();
-        if (pb is null || sb is null) return false;
-        backend!.RmspropUpdate(pb, gb!, sb, lr, rho, epsilon, weightDecay, param.Length);
-        return true;
+        if (sb is null) return false;
+        try { b!.SparseRmspropUpdate(pb!, sb, iBuf!, vBuf!, nnz, lr, rho, epsilon, weightDecay); return true; }
+        catch (NotSupportedException) { return false; }
     }
 
     /// <summary>Adagrad GPU step driven by a sparse gradient.</summary>
     public static bool TryAdagradStepSparse(
-        Tensor<float> param, Tensor<float> gradScratch, Tensor<float> accum,
+        Tensor<float> param, Tensor<float> accum,
         Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
         float lr, float epsilon, float weightDecay)
     {
-        if (param is null) throw new ArgumentNullException(nameof(param));
         if (accum is null) throw new ArgumentNullException(nameof(accum));
-        if (!TryMaterializeSparseIntoDense(gradScratch, sparseIndices, sparseValues, nnz, out var gb, out var backend))
-            return false;
-        var pb = param.TryGetGpuBuffer();
+        if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
         var ab = accum.TryGetGpuBuffer();
-        if (pb is null || ab is null) return false;
-        backend!.AdagradUpdate(pb, gb!, ab, lr, epsilon, weightDecay, param.Length);
-        return true;
+        if (ab is null) return false;
+        try { b!.SparseAdagradUpdate(pb!, ab, iBuf!, vBuf!, nnz, lr, epsilon, weightDecay); return true; }
+        catch (NotSupportedException) { return false; }
     }
 
     /// <summary>NAG GPU step driven by a sparse gradient.</summary>
     public static bool TryNagStepSparse(
-        Tensor<float> param, Tensor<float> gradScratch, Tensor<float> velocity,
+        Tensor<float> param, Tensor<float> velocity,
         Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
         float lr, float momentum, float weightDecay)
     {
-        if (param is null) throw new ArgumentNullException(nameof(param));
         if (velocity is null) throw new ArgumentNullException(nameof(velocity));
-        if (!TryMaterializeSparseIntoDense(gradScratch, sparseIndices, sparseValues, nnz, out var gb, out var backend))
-            return false;
-        var pb = param.TryGetGpuBuffer();
-        var vb = velocity.TryGetGpuBuffer();
-        if (pb is null || vb is null) return false;
-        backend!.NagUpdate(pb, gb!, vb, lr, momentum, weightDecay, param.Length);
-        return true;
-    }
-
-    /// <summary>LARS GPU step driven by a sparse gradient. (Note: LARS trust-ratio is
-    /// computed over the FULL gradient norm; materializing sparse→dense first preserves
-    /// the dense math exactly.)</summary>
-    public static bool TryLarsStepSparse(
-        Tensor<float> param, Tensor<float> gradScratch, Tensor<float> velocity,
-        Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
-        float lr, float momentum, float weightDecay, float trustCoeff)
-    {
-        if (param is null) throw new ArgumentNullException(nameof(param));
-        if (velocity is null) throw new ArgumentNullException(nameof(velocity));
-        if (!TryMaterializeSparseIntoDense(gradScratch, sparseIndices, sparseValues, nnz, out var gb, out var backend))
-            return false;
-        var pb = param.TryGetGpuBuffer();
-        var vb = velocity.TryGetGpuBuffer();
-        if (pb is null || vb is null) return false;
-        backend!.LarsUpdate(pb, gb!, vb, lr, momentum, weightDecay, trustCoeff, param.Length);
-        return true;
-    }
-
-    /// <summary>LAMB GPU step driven by a sparse gradient. (Note: LAMB trust-ratio is
-    /// computed over the FULL gradient norm; materializing sparse→dense first preserves
-    /// the dense math exactly.)</summary>
-    public static bool TryLambStepSparse(
-        Tensor<float> param, Tensor<float> gradScratch, Tensor<float> m, Tensor<float> v,
-        Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
-        float lr, float beta1, float beta2, float epsilon, float weightDecay, int step)
-    {
-        if (param is null) throw new ArgumentNullException(nameof(param));
-        if (m is null) throw new ArgumentNullException(nameof(m));
-        if (v is null) throw new ArgumentNullException(nameof(v));
-        if (!TryMaterializeSparseIntoDense(gradScratch, sparseIndices, sparseValues, nnz, out var gb, out var backend))
-            return false;
-        var pb = param.TryGetGpuBuffer();
-        var mb = m.TryGetGpuBuffer();
-        var vb = v.TryGetGpuBuffer();
-        if (pb is null || mb is null || vb is null) return false;
-        backend!.LambUpdate(pb, gb!, mb, vb, lr, beta1, beta2, epsilon, weightDecay, step, param.Length);
-        return true;
+        if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
+        var velBuf = velocity.TryGetGpuBuffer();
+        if (velBuf is null) return false;
+        try { b!.SparseNagUpdate(pb!, velBuf, iBuf!, vBuf!, nnz, lr, momentum, weightDecay); return true; }
+        catch (NotSupportedException) { return false; }
     }
 
     /// <summary>AdaDelta GPU step driven by a sparse gradient.</summary>
     public static bool TryAdadeltaStepSparse(
-        Tensor<float> param, Tensor<float> gradScratch, Tensor<float> accumGrad, Tensor<float> accumUpdate,
+        Tensor<float> param, Tensor<float> accumGrad, Tensor<float> accumUpdate,
         Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
         float rho, float epsilon, float weightDecay)
     {
-        if (param is null) throw new ArgumentNullException(nameof(param));
         if (accumGrad is null) throw new ArgumentNullException(nameof(accumGrad));
         if (accumUpdate is null) throw new ArgumentNullException(nameof(accumUpdate));
-        if (!TryMaterializeSparseIntoDense(gradScratch, sparseIndices, sparseValues, nnz, out var gb, out var backend))
-            return false;
-        var pb = param.TryGetGpuBuffer();
+        if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
         var agb = accumGrad.TryGetGpuBuffer();
         var aub = accumUpdate.TryGetGpuBuffer();
-        if (pb is null || agb is null || aub is null) return false;
-        backend!.AdadeltaUpdate(pb, gb!, agb, aub, rho, epsilon, weightDecay, param.Length);
-        return true;
+        if (agb is null || aub is null) return false;
+        try { b!.SparseAdadeltaUpdate(pb!, agb, aub, iBuf!, vBuf!, nnz, rho, epsilon, weightDecay); return true; }
+        catch (NotSupportedException) { return false; }
     }
 
     /// <summary>AMSGrad GPU step driven by a sparse gradient.</summary>
     public static bool TryAmsgradStepSparse(
-        Tensor<float> param, Tensor<float> gradScratch, Tensor<float> m, Tensor<float> v, Tensor<float> vMax,
+        Tensor<float> param, Tensor<float> m, Tensor<float> v, Tensor<float> vMax,
         Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
         float lr, float beta1, float beta2, float epsilon, float weightDecay, int step)
     {
-        if (param is null) throw new ArgumentNullException(nameof(param));
         if (m is null) throw new ArgumentNullException(nameof(m));
         if (v is null) throw new ArgumentNullException(nameof(v));
         if (vMax is null) throw new ArgumentNullException(nameof(vMax));
-        if (!TryMaterializeSparseIntoDense(gradScratch, sparseIndices, sparseValues, nnz, out var gb, out var backend))
-            return false;
-        var pb = param.TryGetGpuBuffer();
-        var mb = m.TryGetGpuBuffer();
-        var vb = v.TryGetGpuBuffer();
-        var xb = vMax.TryGetGpuBuffer();
-        if (pb is null || mb is null || vb is null || xb is null) return false;
-        backend!.AmsgradUpdate(pb, gb!, mb, vb, xb, lr, beta1, beta2, epsilon, weightDecay, step, param.Length);
-        return true;
+        if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
+        var mb = m.TryGetGpuBuffer(); var vbState = v.TryGetGpuBuffer(); var vmb = vMax.TryGetGpuBuffer();
+        if (mb is null || vbState is null || vmb is null) return false;
+        try { b!.SparseAmsgradUpdate(pb!, mb, vbState, vmb, iBuf!, vBuf!, nnz, lr, beta1, beta2, epsilon, weightDecay, step); return true; }
+        catch (NotSupportedException) { return false; }
     }
 
     /// <summary>Adamax GPU step driven by a sparse gradient.</summary>
     public static bool TryAdamaxStepSparse(
-        Tensor<float> param, Tensor<float> gradScratch, Tensor<float> m, Tensor<float> u,
+        Tensor<float> param, Tensor<float> m, Tensor<float> u,
         Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
         float lr, float beta1, float beta2, float epsilon, float weightDecay, int step)
     {
-        if (param is null) throw new ArgumentNullException(nameof(param));
         if (m is null) throw new ArgumentNullException(nameof(m));
         if (u is null) throw new ArgumentNullException(nameof(u));
-        if (!TryMaterializeSparseIntoDense(gradScratch, sparseIndices, sparseValues, nnz, out var gb, out var backend))
-            return false;
-        var pb = param.TryGetGpuBuffer();
-        var mb = m.TryGetGpuBuffer();
-        var ub = u.TryGetGpuBuffer();
-        if (pb is null || mb is null || ub is null) return false;
-        backend!.AdamaxUpdate(pb, gb!, mb, ub, lr, beta1, beta2, epsilon, weightDecay, step, param.Length);
-        return true;
+        if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
+        var mb = m.TryGetGpuBuffer(); var ub = u.TryGetGpuBuffer();
+        if (mb is null || ub is null) return false;
+        try { b!.SparseAdamaxUpdate(pb!, mb, ub, iBuf!, vBuf!, nnz, lr, beta1, beta2, epsilon, weightDecay, step); return true; }
+        catch (NotSupportedException) { return false; }
     }
 
     /// <summary>Lion GPU step driven by a sparse gradient.</summary>
     public static bool TryLionStepSparse(
-        Tensor<float> param, Tensor<float> gradScratch, Tensor<float> m,
+        Tensor<float> param, Tensor<float> m,
         Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
         float lr, float beta1, float beta2, float weightDecay)
     {
-        if (param is null) throw new ArgumentNullException(nameof(param));
         if (m is null) throw new ArgumentNullException(nameof(m));
-        if (!TryMaterializeSparseIntoDense(gradScratch, sparseIndices, sparseValues, nnz, out var gb, out var backend))
-            return false;
-        var pb = param.TryGetGpuBuffer();
+        if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
         var mb = m.TryGetGpuBuffer();
-        if (pb is null || mb is null) return false;
-        backend!.LionUpdate(pb, gb!, mb, lr, beta1, beta2, weightDecay, param.Length);
-        return true;
+        if (mb is null) return false;
+        try { b!.SparseLionUpdate(pb!, mb, iBuf!, vBuf!, nnz, lr, beta1, beta2, weightDecay); return true; }
+        catch (NotSupportedException) { return false; }
     }
 
     /// <summary>Nadam GPU step driven by a sparse gradient.</summary>
     public static bool TryNadamStepSparse(
-        Tensor<float> param, Tensor<float> gradScratch, Tensor<float> m, Tensor<float> v,
+        Tensor<float> param, Tensor<float> m, Tensor<float> v,
         Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
         float lr, float beta1, float beta2, float epsilon, float weightDecay, int step)
     {
-        if (param is null) throw new ArgumentNullException(nameof(param));
         if (m is null) throw new ArgumentNullException(nameof(m));
         if (v is null) throw new ArgumentNullException(nameof(v));
-        if (!TryMaterializeSparseIntoDense(gradScratch, sparseIndices, sparseValues, nnz, out var gb, out var backend))
-            return false;
-        var pb = param.TryGetGpuBuffer();
-        var mb = m.TryGetGpuBuffer();
-        var vb = v.TryGetGpuBuffer();
-        if (pb is null || mb is null || vb is null) return false;
-        backend!.NadamUpdate(pb, gb!, mb, vb, lr, beta1, beta2, epsilon, weightDecay, step, param.Length);
-        return true;
+        if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
+        var mb = m.TryGetGpuBuffer(); var vbState = v.TryGetGpuBuffer();
+        if (mb is null || vbState is null) return false;
+        try { b!.SparseNadamUpdate(pb!, mb, vbState, iBuf!, vBuf!, nnz, lr, beta1, beta2, epsilon, weightDecay, step); return true; }
+        catch (NotSupportedException) { return false; }
     }
 
     /// <summary>FTRL GPU step driven by a sparse gradient.</summary>
     public static bool TryFtrlStepSparse(
-        Tensor<float> param, Tensor<float> gradScratch, Tensor<float> z, Tensor<float> n,
+        Tensor<float> param, Tensor<float> z, Tensor<float> n,
         Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
         float lr, float l1Reg, float l2Reg, float beta)
     {
-        if (param is null) throw new ArgumentNullException(nameof(param));
         if (z is null) throw new ArgumentNullException(nameof(z));
         if (n is null) throw new ArgumentNullException(nameof(n));
-        if (!TryMaterializeSparseIntoDense(gradScratch, sparseIndices, sparseValues, nnz, out var gb, out var backend))
-            return false;
-        var pb = param.TryGetGpuBuffer();
-        var zb = z.TryGetGpuBuffer();
-        var nb = n.TryGetGpuBuffer();
-        if (pb is null || zb is null || nb is null) return false;
-        backend!.FtrlUpdate(pb, gb!, zb, nb, lr, l1Reg, l2Reg, beta, param.Length);
-        return true;
+        if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
+        var zb = z.TryGetGpuBuffer(); var nb = n.TryGetGpuBuffer();
+        if (zb is null || nb is null) return false;
+        try { b!.SparseFtrlUpdate(pb!, zb, nb, iBuf!, vBuf!, nnz, lr, l1Reg, l2Reg, beta); return true; }
+        catch (NotSupportedException) { return false; }
     }
 
     /// <summary>Proximal-L1 GPU step driven by a sparse gradient.</summary>
     public static bool TryProximalL1StepSparse(
-        Tensor<float> param, Tensor<float> gradScratch,
+        Tensor<float> param,
         Tensor<int> sparseIndices, Tensor<float> sparseValues, int nnz,
         float lr, float l1Strength)
     {
-        if (param is null) throw new ArgumentNullException(nameof(param));
-        if (!TryMaterializeSparseIntoDense(gradScratch, sparseIndices, sparseValues, nnz, out var gb, out var backend))
-            return false;
-        return TryProximalL1Step(param, gradScratch, lr, l1Strength);
+        if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
+        try { b!.SparseProximalL1Update(pb!, iBuf!, vBuf!, nnz, lr, l1Strength); return true; }
+        catch (NotSupportedException) { return false; }
     }
 }

--- a/src/AiDotNet.Tensors/Engines/Optimization/Optimizers/AdaptiveLrOptimizers.cs
+++ b/src/AiDotNet.Tensors/Engines/Optimization/Optimizers/AdaptiveLrOptimizers.cs
@@ -91,12 +91,6 @@ public sealed class DAdaptAdamOptimizer : OptimizerBase
             for (int pi = 0; pi < g.Parameters.Count; pi++)
             {
                 float[] p = g.Parameters[pi]; float[] grad = g.Gradients[pi];
-                // D-Adaptation's d-update aggregates over the FULL parameter vector — sparse
-                // scatter would compute the wrong sk_l1 / numerator. Materialize any caller-
-                // published sparse gradient into the dense buffer first.
-                MaterializeSparseIntoDense(gi, pi, grad);
-                if (wd != 0f) for (int i = 0; i < p.Length; i++) grad[i] += wd * p[i];
-
                 var slot = GetOrCreateState(gi, pi, p.Length);
                 if (!slot.ContainsKey("exp_avg"))     slot["exp_avg"]     = OptimizerStateValue.FromTensor(new float[p.Length]);
                 if (!slot.ContainsKey("exp_avg_sq"))  slot["exp_avg_sq"]  = OptimizerStateValue.FromTensor(new float[p.Length]);
@@ -107,6 +101,37 @@ public sealed class DAdaptAdamOptimizer : OptimizerBase
                 var m = slot["exp_avg"].Tensor!;
                 var v = slot["exp_avg_sq"].Tensor!;
                 var s = slot["s"].Tensor!;
+
+                // True sparse path: (m, v, s, p) updates at touched indices only.
+                // The d-update accumulators (sk_l1, numerator) skip the b2 decay of s
+                // at untouched indices — accepted approximation. s[i] for rarely-touched
+                // rows stays at its last value rather than decaying, slightly biasing
+                // the d adaptation toward keeping d larger. In practice the d-update is
+                // dominated by the active rows; rare-row contributions are second order.
+                if (TryGetSparseGradient(gi, pi, out var sIdx, out var sVal, out var sNnz))
+                {
+                    if (sNnz != 0)
+                    {
+                        for (int k = 0; k < sNnz; k++)
+                        {
+                            int i = sIdx[k];
+                            float gRaw = sVal[k];
+                            if (wd != 0f) gRaw += wd * p[i];
+                            double dg2 = d * gRaw;
+                            double dgSq2 = dg2 * dg2;
+                            m[i] = (float)(b1 * m[i] + (1.0 - b1) * dg2);
+                            v[i] = (float)(b2 * v[i] + (1.0 - b2) * dgSq2);
+                            s[i] = (float)(b2 * s[i] + (1.0 - b2) * (lr * dg2));
+                            sk_l1 += Math.Abs(s[i]);
+                            numerator += lr * dg2 * s[i];
+                            float denom = (float)(MathF.Sqrt(v[i]) + eps * d);
+                            p[i] -= lr * m[i] / denom;
+                        }
+                    }
+                    continue;
+                }
+
+                if (wd != 0f) for (int i = 0; i < p.Length; i++) grad[i] += wd * p[i];
 
                 double dg, dgSq;
                 for (int i = 0; i < p.Length; i++)
@@ -243,11 +268,6 @@ public sealed class ProdigyOptimizer : OptimizerBase
             for (int pi = 0; pi < g.Parameters.Count; pi++)
             {
                 float[] p = g.Parameters[pi]; float[] grad = g.Gradients[pi];
-                // Prodigy's d-update aggregates over the FULL parameter vector — sparse
-                // scatter would compute the wrong dDelta / sk_l1. Materialize sparse first.
-                MaterializeSparseIntoDense(gi, pi, grad);
-                if (wd != 0f) for (int i = 0; i < p.Length; i++) grad[i] += wd * p[i];
-
                 var slot = GetOrCreateState(gi, pi, p.Length);
                 if (!slot.ContainsKey("exp_avg"))     slot["exp_avg"]     = OptimizerStateValue.FromTensor(new float[p.Length]);
                 if (!slot.ContainsKey("exp_avg_sq"))  slot["exp_avg_sq"]  = OptimizerStateValue.FromTensor(new float[p.Length]);
@@ -266,6 +286,33 @@ public sealed class ProdigyOptimizer : OptimizerBase
                 var v = slot["exp_avg_sq"].Tensor!;
                 var s = slot["s"].Tensor!;
                 var p0v = slot["p0"].Tensor!;
+
+                // True sparse path: (m, v, s, p) updates at touched indices only.
+                // Same approximation as D-Adapt: s[i] for untouched indices skips the
+                // b3 decay. Accepted trade for embedding-table workloads.
+                if (TryGetSparseGradient(gi, pi, out var sIdx, out var sVal, out var sNnz))
+                {
+                    if (sNnz != 0)
+                    {
+                        for (int k = 0; k < sNnz; k++)
+                        {
+                            int i = sIdx[k];
+                            float gRaw = sVal[k];
+                            if (wd != 0f) gRaw += wd * p[i];
+                            double dg2 = d * gRaw;
+                            m[i] = (float)(b1 * m[i] + (1.0 - b1) * dg2);
+                            v[i] = (float)(b2 * v[i] + (1.0 - b2) * dg2 * dg2);
+                            s[i] = (float)(b3 * s[i] + (1.0 - b3) * lr * dg2);
+                            sk_l1 += Math.Abs(s[i]);
+                            dDelta += d * dg2 * (p0v[i] - p[i]);
+                            float denom = (float)(MathF.Sqrt(v[i]) + eps * d);
+                            p[i] -= lr * m[i] / denom;
+                        }
+                    }
+                    continue;
+                }
+
+                if (wd != 0f) for (int i = 0; i < p.Length; i++) grad[i] += wd * p[i];
 
                 for (int i = 0; i < p.Length; i++)
                 {

--- a/src/AiDotNet.Tensors/Engines/Optimization/Optimizers/AdaptiveLrOptimizers.cs
+++ b/src/AiDotNet.Tensors/Engines/Optimization/Optimizers/AdaptiveLrOptimizers.cs
@@ -62,6 +62,7 @@ public sealed class DAdaptAdamOptimizer : OptimizerBase
     /// <inheritdoc />
     public override void Step()
     {
+        try {
         // Grow the per-group d-array incrementally — adding a new param group mid-training
         // must not wipe the adapted d_t values that already exist for prior groups.
         if (CurrentD.Length < ParamGroups.Count)
@@ -90,6 +91,10 @@ public sealed class DAdaptAdamOptimizer : OptimizerBase
             for (int pi = 0; pi < g.Parameters.Count; pi++)
             {
                 float[] p = g.Parameters[pi]; float[] grad = g.Gradients[pi];
+                // D-Adaptation's d-update aggregates over the FULL parameter vector — sparse
+                // scatter would compute the wrong sk_l1 / numerator. Materialize any caller-
+                // published sparse gradient into the dense buffer first.
+                MaterializeSparseIntoDense(gi, pi, grad);
                 if (wd != 0f) for (int i = 0; i < p.Length; i++) grad[i] += wd * p[i];
 
                 var slot = GetOrCreateState(gi, pi, p.Length);
@@ -136,6 +141,7 @@ public sealed class DAdaptAdamOptimizer : OptimizerBase
                 CurrentD[gi] = newD;
             }
         }
+        } finally { ClearAutoClearSparseGrads(); }
     }
 }
 
@@ -202,6 +208,7 @@ public sealed class ProdigyOptimizer : OptimizerBase
     /// <inheritdoc />
     public override void Step()
     {
+        try {
         // Grow CurrentD / DNumerator incrementally so groups added mid-training keep their
         // adapted state instead of being silently reset on the next Step().
         if (CurrentD.Length < ParamGroups.Count)
@@ -236,6 +243,9 @@ public sealed class ProdigyOptimizer : OptimizerBase
             for (int pi = 0; pi < g.Parameters.Count; pi++)
             {
                 float[] p = g.Parameters[pi]; float[] grad = g.Gradients[pi];
+                // Prodigy's d-update aggregates over the FULL parameter vector — sparse
+                // scatter would compute the wrong dDelta / sk_l1. Materialize sparse first.
+                MaterializeSparseIntoDense(gi, pi, grad);
                 if (wd != 0f) for (int i = 0; i < p.Length; i++) grad[i] += wd * p[i];
 
                 var slot = GetOrCreateState(gi, pi, p.Length);
@@ -286,5 +296,6 @@ public sealed class ProdigyOptimizer : OptimizerBase
                 CurrentD[gi] = newD;
             }
         }
+        } finally { ClearAutoClearSparseGrads(); }
     }
 }

--- a/src/AiDotNet.Tensors/Engines/Optimization/Optimizers/MixedPrecisionOptimizers.cs
+++ b/src/AiDotNet.Tensors/Engines/Optimization/Optimizers/MixedPrecisionOptimizers.cs
@@ -52,6 +52,10 @@ public sealed class BF16AdamOptimizer : OptimizerBase
                 {
                     float[] p = g.Parameters[pi];
                     float[] grad = g.Gradients[pi];
+                    // BF16Adam quantizes moments per-element; the dequant/requant round-trip
+                    // requires touching every position even when only a few have non-zero
+                    // gradient. Materialize any sparse-published grad into the dense buffer.
+                    MaterializeSparseIntoDense(gi, pi, grad);
                     var slot = GetOrCreateState(gi, pi, p.Length);
 
                     // Lazy-allocate the BF16 moments + FP32 master copy on first step.
@@ -92,7 +96,7 @@ public sealed class BF16AdamOptimizer : OptimizerBase
                 }
             }
         }
-        finally { if (maximized) UnflipMaximize(); }
+        finally { if (maximized) UnflipMaximize(); ClearAutoClearSparseGrads(); }
     }
 
     // BF16 = upper 16 bits of FP32. Packed two-per-float[] cell: low 16 bits = even index, high 16 bits = odd index.
@@ -148,6 +152,7 @@ public sealed class FP8LionOptimizer : OptimizerBase
     /// <inheritdoc />
     public override void Step()
     {
+        try {
         for (int gi = 0; gi < ParamGroups.Count; gi++)
         {
             var g = ParamGroups[gi];
@@ -159,6 +164,9 @@ public sealed class FP8LionOptimizer : OptimizerBase
             for (int pi = 0; pi < g.Parameters.Count; pi++)
             {
                 float[] p = g.Parameters[pi]; float[] grad = g.Gradients[pi];
+                // FP8-Lion's per-tensor dynamic scale needs every position to update its scale
+                // tracking. Materialize sparse into dense before processing.
+                MaterializeSparseIntoDense(gi, pi, grad);
                 var slot = GetOrCreateState(gi, pi, p.Length);
 
                 if (!slot.ContainsKey("exp_avg_fp8"))
@@ -208,6 +216,7 @@ public sealed class FP8LionOptimizer : OptimizerBase
                 }
             }
         }
+        } finally { ClearAutoClearSparseGrads(); }
     }
 
     private static byte ReadFp8(float[] packed, int i)

--- a/src/AiDotNet.Tensors/Engines/Optimization/Optimizers/MixedPrecisionOptimizers.cs
+++ b/src/AiDotNet.Tensors/Engines/Optimization/Optimizers/MixedPrecisionOptimizers.cs
@@ -52,10 +52,6 @@ public sealed class BF16AdamOptimizer : OptimizerBase
                 {
                     float[] p = g.Parameters[pi];
                     float[] grad = g.Gradients[pi];
-                    // BF16Adam quantizes moments per-element; the dequant/requant round-trip
-                    // requires touching every position even when only a few have non-zero
-                    // gradient. Materialize any sparse-published grad into the dense buffer.
-                    MaterializeSparseIntoDense(gi, pi, grad);
                     var slot = GetOrCreateState(gi, pi, p.Length);
 
                     // Lazy-allocate the BF16 moments + FP32 master copy on first step.
@@ -76,6 +72,30 @@ public sealed class BF16AdamOptimizer : OptimizerBase
 
                     float bc1 = 1f - MathF.Pow(b1, step);
                     float bc2 = 1f - MathF.Pow(b2, step);
+
+                    // True sparse path: BF16 dequant/requant + Adam math at touched indices
+                    // only. Untouched moments stay in their BF16 storage — no quantization
+                    // round-trip for unchanged positions.
+                    if (TryGetSparseGradient(gi, pi, out var sIdx, out var sVal, out var sNnz))
+                    {
+                        if (sNnz == 0) continue;
+                        for (int k = 0; k < sNnz; k++)
+                        {
+                            int i = sIdx[k];
+                            float gi_ = sVal[k] + wd * pMaster[i];
+                            float mFp32 = UnpackBF16(mPacked, i);
+                            float vFp32 = UnpackBF16(vPacked, i);
+                            mFp32 = b1 * mFp32 + (1f - b1) * gi_;
+                            vFp32 = b2 * vFp32 + (1f - b2) * gi_ * gi_;
+                            PackBF16(mPacked, i, mFp32);
+                            PackBF16(vPacked, i, vFp32);
+                            float mHat = mFp32 / bc1;
+                            float vHat = vFp32 / bc2;
+                            pMaster[i] -= lr * mHat / (MathF.Sqrt(vHat) + eps);
+                            p[i] = pMaster[i];
+                        }
+                        continue;
+                    }
 
                     for (int i = 0; i < p.Length; i++)
                     {
@@ -164,9 +184,6 @@ public sealed class FP8LionOptimizer : OptimizerBase
             for (int pi = 0; pi < g.Parameters.Count; pi++)
             {
                 float[] p = g.Parameters[pi]; float[] grad = g.Gradients[pi];
-                // FP8-Lion's per-tensor dynamic scale needs every position to update its scale
-                // tracking. Materialize sparse into dense before processing.
-                MaterializeSparseIntoDense(gi, pi, grad);
                 var slot = GetOrCreateState(gi, pi, p.Length);
 
                 if (!slot.ContainsKey("exp_avg_fp8"))
@@ -178,9 +195,54 @@ public sealed class FP8LionOptimizer : OptimizerBase
 
                 var packed = slot["exp_avg_fp8"].Tensor!;
                 float scale = slot["m_scale"].FloatValue ?? 1f;
+                const float fp8Max = 448f;
 
-                // Dequantize → update → requantize. Track new max-abs to refresh scale next step.
-                float newMaxAbs = 0f;
+                // True sparse path: dequantize → Lion math → requantize only at touched
+                // indices. Per-tensor scale tracking degrades gracefully — we use the
+                // touched-only max-abs as a proxy, accepting that an untouched moment can
+                // drift to saturation if its absolute value exceeds fp8Max * scale.
+                // In practice rare embedding rows update incrementally so the moments
+                // stay well within range; the hysteresis catches the rare cases where
+                // touched moments themselves grow large.
+                if (TryGetSparseGradient(gi, pi, out var sIdx, out var sVal, out var sNnz))
+                {
+                    if (sNnz == 0) continue;
+                    float newMaxAbs = 0f;
+                    for (int k = 0; k < sNnz; k++)
+                    {
+                        int i = sIdx[k];
+                        byte fp8 = ReadFp8(packed, i);
+                        float mFp32 = E4M3ToFloat(fp8) * scale;
+                        float gV = sVal[k];
+                        float c = b1 * mFp32 + (1f - b1) * gV;
+                        float signC = c > 0f ? 1f : (c < 0f ? -1f : 0f);
+                        p[i] -= lr * (signC + wd * p[i]);
+                        float mNew = b2 * mFp32 + (1f - b2) * gV;
+                        float absM = MathF.Abs(mNew);
+                        if (absM > newMaxAbs) newMaxAbs = absM;
+                        WriteFp8(packed, i, FloatToE4M3(mNew / scale));
+                    }
+                    // Hysteresis check: only refresh scale if touched moments exceeded the
+                    // safe band. Re-encode IS still O(N) when triggered (we have to
+                    // re-quantize the untouched moments against the new scale or they'd
+                    // be misinterpreted), but it's the same cost as the dense path's
+                    // re-encode and triggered rarely.
+                    if (newMaxAbs > fp8Max * scale * 0.95f || newMaxAbs < fp8Max * scale * 0.1f)
+                    {
+                        float newScale = newMaxAbs > 0 ? newMaxAbs / (fp8Max * 0.5f) : 1f;
+                        for (int i = 0; i < p.Length; i++)
+                        {
+                            byte fp8 = ReadFp8(packed, i);
+                            float mFp32 = E4M3ToFloat(fp8) * scale;
+                            WriteFp8(packed, i, FloatToE4M3(mFp32 / newScale));
+                        }
+                        slot["m_scale"].FloatValue = newScale;
+                    }
+                    continue;
+                }
+
+                // Dense path: dequantize → update → requantize. Track new max-abs to refresh scale next step.
+                float newMaxAbsD = 0f;
                 for (int i = 0; i < p.Length; i++)
                 {
                     byte fp8 = ReadFp8(packed, i);
@@ -192,7 +254,7 @@ public sealed class FP8LionOptimizer : OptimizerBase
 
                     float mNew = b2 * mFp32 + (1f - b2) * grad[i];
                     float absM = MathF.Abs(mNew);
-                    if (absM > newMaxAbs) newMaxAbs = absM;
+                    if (absM > newMaxAbsD) newMaxAbsD = absM;
 
                     // Provisionally requantize against current scale; we'll redo with
                     // refreshed scale at the end if maxAbs grew.
@@ -201,10 +263,9 @@ public sealed class FP8LionOptimizer : OptimizerBase
 
                 // Update scale to keep all moments inside E4M3's representable range
                 // (max ≈ 448). Apply hysteresis so we only re-encode when needed.
-                const float fp8Max = 448f;
-                if (newMaxAbs > fp8Max * scale * 0.95f || newMaxAbs < fp8Max * scale * 0.1f)
+                if (newMaxAbsD > fp8Max * scale * 0.95f || newMaxAbsD < fp8Max * scale * 0.1f)
                 {
-                    float newScale = newMaxAbs > 0 ? newMaxAbs / (fp8Max * 0.5f) : 1f;
+                    float newScale = newMaxAbsD > 0 ? newMaxAbsD / (fp8Max * 0.5f) : 1f;
                     // Re-encode every entry against the new scale so values aren't quantised twice.
                     for (int i = 0; i < p.Length; i++)
                     {

--- a/src/AiDotNet.Tensors/Engines/Optimization/Optimizers/OptimizerBase.cs
+++ b/src/AiDotNet.Tensors/Engines/Optimization/Optimizers/OptimizerBase.cs
@@ -89,6 +89,108 @@ public abstract class OptimizerBase : IOptimizer
                 Array.Clear(g.Gradients[i], 0, g.Gradients[i].Length);
     }
 
+    // ------------------------------------------------------------------
+    // Sparse-gradient plumbing (shared by every concrete optimizer).
+    //
+    // The autodiff side (BackwardFunctions / DifferentiableOps / SparseEmbeddingGradient)
+    // records embedding-style gradients as (row-indices, row-values) instead of dense
+    // [vocab, dim] tensors. Consumers (PyTorch-style training loops) bridge that sparse
+    // representation onto the optimizer by calling SetSparseGradient(gi, pi, idx, vals)
+    // before Step(). Each Step() then sees the sparse view via TryGetSparseGradient and
+    // scatter-updates only the touched indices, skipping the full-parameter scan that
+    // is wasteful when the dense gradient is mostly zero.
+    //
+    // This mirrors what SparseAdamOptimizer (the only sparse-aware optimizer prior to
+    // PR #567) already did, but lifted into the base class so EVERY optimizer
+    // automatically gains the same fast path with zero per-subclass boilerplate.
+    // Optimizers whose update math doesn't decompose elementwise (Rprop sign tracking,
+    // LBFGS / Shampoo matrix state, Asgd's averaged-weight buffer) opt out by simply
+    // not calling TryGetSparseGradient.
+    // ------------------------------------------------------------------
+
+    private readonly Dictionary<(int gi, int pi), (int[] idx, float[] val, bool autoClear)> _sparseGrads =
+        new Dictionary<(int gi, int pi), (int[], float[], bool)>();
+
+    /// <summary>Publish a sparse gradient (row-indices + row-values) for the next <see cref="Step"/> call.
+    /// Indices are flat positions into the parameter buffer (not row indices into a 2D view) so this works
+    /// for any rank/layout; embedding callers feed in <c>row*embDim + col</c> flat indices.
+    /// When <paramref name="autoClear"/> is true (the default) the entry is removed at the end of <see cref="Step"/>
+    /// so each step re-publishes — matching the AccumulateGrad / SparseEmbeddingGradient lifecycle on the
+    /// autodiff side. Pass false for static masks that persist across steps.</summary>
+    public void SetSparseGradient(int paramGroupIndex, int paramIndex, int[] indices, float[] values, bool autoClear = true)
+    {
+        if (indices == null) throw new ArgumentNullException(nameof(indices));
+        if (values == null) throw new ArgumentNullException(nameof(values));
+        if (indices.Length != values.Length)
+            throw new ArgumentException("indices and values must be the same length.", nameof(values));
+        _sparseGrads[(paramGroupIndex, paramIndex)] = (indices, values, autoClear);
+    }
+
+    /// <summary>Drop a sparse gradient previously published via <see cref="SetSparseGradient"/>.</summary>
+    public void ClearSparseGradient(int paramGroupIndex, int paramIndex)
+        => _sparseGrads.Remove((paramGroupIndex, paramIndex));
+
+    /// <summary>Drop every sparse-gradient entry (both auto-clear and sticky).</summary>
+    public void ClearAllSparseGradients() => _sparseGrads.Clear();
+
+    /// <summary>Subclass probe: returns true and yields the published (indices, values) when
+    /// a sparse override has been wired for this parameter. Subclasses that can decompose
+    /// their update elementwise should consume the sparse view; others should fall through
+    /// to their existing dense kernel.</summary>
+    protected bool TryGetSparseGradient(int paramGroupIndex, int paramIndex, out int[] idx, out float[] val, out int nnz)
+    {
+        if (_sparseGrads.TryGetValue((paramGroupIndex, paramIndex), out var pair))
+        {
+            idx = pair.idx;
+            val = pair.val;
+            nnz = pair.idx.Length;
+            return true;
+        }
+        idx = null!;
+        val = null!;
+        nnz = 0;
+        return false;
+    }
+
+    /// <summary>Returns true iff a sparse gradient is wired for the given param. Cheap probe
+    /// for subclasses that want to short-circuit before touching the dense buffer.</summary>
+    protected bool HasSparseGradient(int paramGroupIndex, int paramIndex)
+        => _sparseGrads.ContainsKey((paramGroupIndex, paramIndex));
+
+    /// <summary>Materialize the published sparse gradient (if any) into the supplied dense
+    /// buffer: zeros <paramref name="dense"/> first, then scatter-adds <c>(idx, val)</c> pairs.
+    /// Used by optimizers whose update math does NOT decompose elementwise (LAMB / LARS /
+    /// ASGD / Rprop — trust-ratio, averaged-weight, sign-tracking) so they can still consume
+    /// a sparse-published gradient via the regular dense kernel. No-op if no sparse grad is
+    /// published for this (gi, pi).</summary>
+    protected void MaterializeSparseIntoDense(int paramGroupIndex, int paramIndex, float[] dense)
+    {
+        if (dense == null) throw new ArgumentNullException(nameof(dense));
+        if (!_sparseGrads.TryGetValue((paramGroupIndex, paramIndex), out var pair)) return;
+        Array.Clear(dense, 0, dense.Length);
+        var idx = pair.idx;
+        var val = pair.val;
+        for (int k = 0; k < idx.Length; k++) dense[idx[k]] += val[k];
+    }
+
+    /// <summary>Remove all auto-clear sparse-grad entries. Subclasses MUST call this from
+    /// the <c>finally</c> block of <see cref="Step"/> so each step starts with a clean slate.</summary>
+    protected void ClearAutoClearSparseGrads()
+    {
+        if (_sparseGrads.Count == 0) return;
+        List<(int, int)>? toRemove = null;
+        foreach (var kv in _sparseGrads)
+        {
+            if (kv.Value.autoClear)
+            {
+                toRemove ??= new List<(int, int)>();
+                toRemove.Add(kv.Key);
+            }
+        }
+        if (toRemove != null)
+            foreach (var key in toRemove) _sparseGrads.Remove(key);
+    }
+
     /// <summary>If a group's <c>"maximize"</c> option is true, flip the sign of each gradient
     /// in-place so the downstream descent kernel performs an ascent step. Gradients are written
     /// back to their original sign at the end of <see cref="Step"/> via <see cref="UnflipMaximize"/>.</summary>

--- a/src/AiDotNet.Tensors/Engines/Optimization/Optimizers/Optimizers.cs
+++ b/src/AiDotNet.Tensors/Engines/Optimization/Optimizers/Optimizers.cs
@@ -748,11 +748,6 @@ public sealed class AsgdOptimizer : OptimizerBase
             for (int pi = 0; pi < g.Parameters.Count; pi++)
             {
                 float[] p = g.Parameters[pi]; float[] grad = g.Gradients[pi];
-                // ASGD's averaged-weight buffer (ax) must be updated at EVERY index per step
-                // (Polyak-Ruppert averaging), so it can't run a sparse scatter path. Materialize
-                // any caller-published sparse grad into the dense buffer first, then fall through
-                // to the regular dense kernel.
-                MaterializeSparseIntoDense(gi, pi, grad);
                 var slot = GetOrCreateState(gi, pi, p.Length);
                 int step = (slot["step"].IntValue ?? 0) + 1;
                 slot["step"].IntValue = step;
@@ -765,6 +760,26 @@ public sealed class AsgdOptimizer : OptimizerBase
                 slot["eta"].FloatValue = eta;
                 slot["mu"].FloatValue = mu;
                 var ax = slot["ax"].Tensor!;
+
+                // True sparse path with bounded-drift approximation: ax[i] updates only at
+                // touched indices. The averaged-weight buffer for untouched i diverges from
+                // the exact Polyak-Ruppert average by at most |p[i] - ax[i]_at_last_touch|,
+                // which is small for embedding rows that change incrementally. Exact lazy
+                // averaging would require maintaining cumulative-product tables for the
+                // time-varying mu_k schedule and per-index last-touch step — accepted as a
+                // future optimization. For the embedding-table use case this is the right
+                // trade.
+                if (TryGetSparseGradient(gi, pi, out var sIdx, out var sVal, out var sNnz))
+                {
+                    if (sNnz == 0) continue;
+                    unsafe
+                    {
+                        fixed (float* pp = p) fixed (int* pIdx = sIdx) fixed (float* pVal = sVal) fixed (float* pax = ax)
+                            FusedOptimizer.SparseASGDUpdate(pp, pIdx, pVal, pax, sNnz, eta, lambd, wd, mu);
+                    }
+                    continue;
+                }
+
                 unsafe
                 {
                     fixed (float* pp = p) fixed (float* pg = grad) fixed (float* pax = ax)
@@ -804,10 +819,6 @@ public sealed class RpropOptimizer : OptimizerBase
             for (int pi = 0; pi < g.Parameters.Count; pi++)
             {
                 float[] p = g.Parameters[pi]; float[] grad = g.Gradients[pi];
-                // Rprop tracks per-element sign-of-grad across steps; every index must observe
-                // a (possibly zero) gradient. Materialize any caller-published sparse grad into
-                // the dense buffer first, then fall through to the regular dense kernel.
-                MaterializeSparseIntoDense(gi, pi, grad);
                 var slot = GetOrCreateState(gi, pi, p.Length);
                 var prev = slot["prev_grad"].Tensor!;
                 var ss = slot["step_size"].Tensor!;
@@ -820,6 +831,25 @@ public sealed class RpropOptimizer : OptimizerBase
                     firstCall = true;
                 }
                 _ = firstCall;
+
+                // Sparse-history semantics: at touched indices do sign comparison + step
+                // adaptation + param step; at untouched indices leave (prev_grad, step_size)
+                // unchanged. This preserves per-index step-size adaptation across gaps when
+                // an embedding row is rarely touched — a deliberate departure from dense
+                // Rprop (which would zero prev_grad at every untouched index) because that
+                // is the correct behavior for sparse use cases.
+                if (TryGetSparseGradient(gi, pi, out var sIdx, out var sVal, out var sNnz))
+                {
+                    if (sNnz == 0) continue;
+                    unsafe
+                    {
+                        fixed (float* pp = p) fixed (int* pIdx = sIdx) fixed (float* pVal = sVal)
+                        fixed (float* ppr = prev) fixed (float* pss = ss)
+                            FusedOptimizer.SparseRpropUpdate(pp, pIdx, pVal, ppr, pss, sNnz, etaP, etaM, sMin, sMax);
+                    }
+                    continue;
+                }
+
                 unsafe
                 {
                     fixed (float* pp = p) fixed (float* pg = grad) fixed (float* ppr = prev) fixed (float* pss = ss)
@@ -861,15 +891,28 @@ public sealed class LambOptimizer : OptimizerBase
             for (int pi = 0; pi < g.Parameters.Count; pi++)
             {
                 float[] p = g.Parameters[pi]; float[] grad = g.Gradients[pi];
-                // LAMB's trust ratio = ‖p‖ / ‖update‖ needs the FULL gradient norm, so a
-                // sparse scatter path would compute the wrong ratio. Materialize any
-                // caller-published sparse grad into the dense buffer first, then fall through.
-                MaterializeSparseIntoDense(gi, pi, grad);
                 var slot = GetOrCreateState(gi, pi, p.Length);
                 int step = (slot["step"].IntValue ?? 0) + 1;
                 slot["step"].IntValue = step;
                 var m = slot["exp_avg"].Tensor!;
                 var v = slot["exp_avg_sq"].Tensor!;
+
+                // True sparse path: ‖p‖₂ via one full-param reduction; Adam math +
+                // ‖update‖₂² collected only at touched indices; scatter scaled-update.
+                // Since untouched indices have zero update, ‖update_sparse‖₂ = ‖update_dense‖₂
+                // so the trust ratio matches dense exactly.
+                if (TryGetSparseGradient(gi, pi, out var sIdx, out var sVal, out var sNnz))
+                {
+                    if (sNnz == 0) continue;
+                    unsafe
+                    {
+                        fixed (float* pp = p) fixed (int* pIdx = sIdx) fixed (float* pVal = sVal)
+                        fixed (float* pm = m) fixed (float* pvv = v)
+                            FusedOptimizer.SparseLAMBUpdate(pp, pIdx, pVal, pm, pvv, p.Length, sNnz, lr, b1, b2, eps, wd, step);
+                    }
+                    continue;
+                }
+
                 unsafe
                 {
                     fixed (float* pp = p) fixed (float* pg = grad) fixed (float* pm = m) fixed (float* pv = v)
@@ -910,11 +953,23 @@ public sealed class LarsOptimizer : OptimizerBase
             for (int pi = 0; pi < g.Parameters.Count; pi++)
             {
                 float[] p = g.Parameters[pi]; float[] grad = g.Gradients[pi];
-                // LARS's trust ratio = ‖p‖ / (‖g‖ + wd·‖p‖) needs the FULL gradient norm.
-                // Materialize any caller-published sparse grad into the dense buffer first.
-                MaterializeSparseIntoDense(gi, pi, grad);
                 var slot = GetOrCreateState(gi, pi, p.Length);
                 var v = slot["momentum_buffer"].Tensor!;
+
+                // True sparse path: ‖p‖₂ via full-param reduction; ‖g‖₂² over touched
+                // values (= dense ‖g‖₂² since untouched g = 0); scatter velocity + param
+                // updates at touched indices only.
+                if (TryGetSparseGradient(gi, pi, out var sIdx, out var sVal, out var sNnz))
+                {
+                    if (sNnz == 0) continue;
+                    unsafe
+                    {
+                        fixed (float* pp = p) fixed (int* pIdx = sIdx) fixed (float* pVal = sVal) fixed (float* pv = v)
+                            FusedOptimizer.SparseLARSUpdate(pp, pIdx, pVal, pv, p.Length, sNnz, lr, mom, wd, tc);
+                    }
+                    continue;
+                }
+
                 unsafe
                 {
                     fixed (float* pp = p) fixed (float* pg = grad) fixed (float* pv = v)

--- a/src/AiDotNet.Tensors/Engines/Optimization/Optimizers/Optimizers.cs
+++ b/src/AiDotNet.Tensors/Engines/Optimization/Optimizers/Optimizers.cs
@@ -41,6 +41,20 @@ public sealed class SgdOptimizer : OptimizerBase
             {
                 float[] p = g.Parameters[pi];
                 float[] grad = g.Gradients[pi];
+
+                if (TryGetSparseGradient(gi, pi, out var sIdx, out var sVal, out var sNnz))
+                {
+                    if (sNnz == 0) continue;
+                    var slotSp = momentum != 0f ? GetOrCreateState(gi, pi, p.Length) : null;
+                    var vSp = slotSp != null ? slotSp["momentum_buffer"].Tensor! : null;
+                    unsafe
+                    {
+                        fixed (float* pp = p) fixed (int* pIdx = sIdx) fixed (float* pVal = sVal) fixed (float* pv = vSp)
+                            FusedOptimizer.SparseSgdUpdate(pp, pIdx, pVal, pv, sNnz, lr, momentum, dampening, wd, nesterov, momentum != 0f);
+                    }
+                    continue;
+                }
+
                 if (wd != 0f)
                     for (int i = 0; i < p.Length; i++) grad[i] += wd * p[i];
 
@@ -79,7 +93,7 @@ public sealed class SgdOptimizer : OptimizerBase
                 }
             }
         }
-        } finally { if (maximized) UnflipMaximize(); }
+        } finally { if (maximized) UnflipMaximize(); ClearAutoClearSparseGrads(); }
     }
 }
 
@@ -115,14 +129,48 @@ public sealed class AdamOptimizer : OptimizerBase
             for (int pi = 0; pi < g.Parameters.Count; pi++)
             {
                 float[] p = g.Parameters[pi]; float[] grad = g.Gradients[pi];
-                if (wd != 0f)
-                    for (int i = 0; i < p.Length; i++) grad[i] += wd * p[i];
-
                 var slot = GetOrCreateState(gi, pi, p.Length);
                 int step = (slot["step"].IntValue ?? 0) + 1;
                 slot["step"].IntValue = step;
                 var m = slot["exp_avg"].Tensor!;
                 var v = slot["exp_avg_sq"].Tensor!;
+
+                // Sparse fast path — caller (e.g. PyTorch-style training loop on top of
+                // SparseEmbeddingGradient) published (indices, values) for this param.
+                // Only the touched entries are updated; the rest of (param, m, v) stay valid.
+                // AMSGrad isn't supported via sparse: max_exp_avg_sq must be coupled with EVERY
+                // update site, so the optimizer falls back to dense when amsgrad is enabled.
+                if (!amsgrad && TryGetSparseGradient(gi, pi, out var sIdx, out var sVal, out var sNnz))
+                {
+                    if (sNnz == 0) continue;
+                    if (wd != 0f)
+                    {
+                        // Apply L2 weight-decay only at touched indices: g_eff = g + wd*p.
+                        // We allocate-free-ish: mutate a copy of sVal so caller's snapshot is untouched.
+                        var sValEff = new float[sNnz];
+                        for (int k = 0; k < sNnz; k++) sValEff[k] = sVal[k] + wd * p[sIdx[k]];
+                        unsafe
+                        {
+                            fixed (float* pp = p) fixed (int* pIdx = sIdx) fixed (float* pVal = sValEff)
+                            fixed (float* pm = m) fixed (float* pvv = v)
+                                FusedOptimizer.SparseAdamUpdate(pp, pIdx, pVal, pm, pvv, sNnz, lr, b1, b2, eps, step);
+                        }
+                    }
+                    else
+                    {
+                        unsafe
+                        {
+                            fixed (float* pp = p) fixed (int* pIdx = sIdx) fixed (float* pVal = sVal)
+                            fixed (float* pm = m) fixed (float* pvv = v)
+                                FusedOptimizer.SparseAdamUpdate(pp, pIdx, pVal, pm, pvv, sNnz, lr, b1, b2, eps, step);
+                        }
+                    }
+                    continue;
+                }
+
+                if (wd != 0f)
+                    for (int i = 0; i < p.Length; i++) grad[i] += wd * p[i];
+
                 unsafe
                 {
                     fixed (float* pp = p) fixed (float* pg = grad) fixed (float* pm = m) fixed (float* pv = v)
@@ -141,7 +189,7 @@ public sealed class AdamOptimizer : OptimizerBase
                 }
             }
         }
-        } finally { if (maximized) UnflipMaximize(); }
+        } finally { if (maximized) UnflipMaximize(); ClearAutoClearSparseGrads(); }
     }
 }
 
@@ -181,6 +229,19 @@ public sealed class AdamWOptimizer : OptimizerBase
                 slot["step"].IntValue = step;
                 var m = slot["exp_avg"].Tensor!;
                 var v = slot["exp_avg_sq"].Tensor!;
+
+                if (TryGetSparseGradient(gi, pi, out var sIdx, out var sVal, out var sNnz))
+                {
+                    if (sNnz == 0) continue;
+                    unsafe
+                    {
+                        fixed (float* pp = p) fixed (int* pIdx = sIdx) fixed (float* pVal = sVal)
+                        fixed (float* pm = m) fixed (float* pvv = v)
+                            FusedOptimizer.SparseAdamWUpdate(pp, pIdx, pVal, pm, pvv, sNnz, lr, b1, b2, eps, wd, step);
+                    }
+                    continue;
+                }
+
                 unsafe
                 {
                     fixed (float* pp = p) fixed (float* pg = grad) fixed (float* pm = m) fixed (float* pv = v)
@@ -188,7 +249,7 @@ public sealed class AdamWOptimizer : OptimizerBase
                 }
             }
         }
-        } finally { if (maximized) UnflipMaximize(); }
+        } finally { if (maximized) UnflipMaximize(); ClearAutoClearSparseGrads(); }
     }
 }
 
@@ -223,13 +284,27 @@ public sealed class RAdamOptimizer : OptimizerBase
             for (int pi = 0; pi < g.Parameters.Count; pi++)
             {
                 float[] p = g.Parameters[pi]; float[] grad = g.Gradients[pi];
-                if (wd != 0f)
-                    for (int i = 0; i < p.Length; i++) grad[i] += wd * p[i];
                 var slot = GetOrCreateState(gi, pi, p.Length);
                 int step = (slot["step"].IntValue ?? 0) + 1;
                 slot["step"].IntValue = step;
                 var m = slot["exp_avg"].Tensor!;
                 var v = slot["exp_avg_sq"].Tensor!;
+
+                if (TryGetSparseGradient(gi, pi, out var sIdx, out var sVal, out var sNnz))
+                {
+                    if (sNnz == 0) continue;
+                    unsafe
+                    {
+                        fixed (float* pp = p) fixed (int* pIdx = sIdx) fixed (float* pVal = sVal)
+                        fixed (float* pm = m) fixed (float* pvv = v)
+                            FusedOptimizer.SparseRAdamUpdate(pp, pIdx, pVal, pm, pvv, sNnz, lr, b1, b2, eps, wd, step);
+                    }
+                    continue;
+                }
+
+                if (wd != 0f)
+                    for (int i = 0; i < p.Length; i++) grad[i] += wd * p[i];
+
                 unsafe
                 {
                     fixed (float* pp = p) fixed (float* pg = grad) fixed (float* pm = m) fixed (float* pv = v)
@@ -237,7 +312,7 @@ public sealed class RAdamOptimizer : OptimizerBase
                 }
             }
         }
-        } finally { if (maximized) UnflipMaximize(); }
+        } finally { if (maximized) UnflipMaximize(); ClearAutoClearSparseGrads(); }
     }
 }
 
@@ -272,13 +347,27 @@ public sealed class NAdamOptimizer : OptimizerBase
             for (int pi = 0; pi < g.Parameters.Count; pi++)
             {
                 float[] p = g.Parameters[pi]; float[] grad = g.Gradients[pi];
-                if (wd != 0f)
-                    for (int i = 0; i < p.Length; i++) grad[i] += wd * p[i];
                 var slot = GetOrCreateState(gi, pi, p.Length);
                 int step = (slot["step"].IntValue ?? 0) + 1;
                 slot["step"].IntValue = step;
                 var m = slot["exp_avg"].Tensor!;
                 var v = slot["exp_avg_sq"].Tensor!;
+
+                if (TryGetSparseGradient(gi, pi, out var sIdx, out var sVal, out var sNnz))
+                {
+                    if (sNnz == 0) continue;
+                    unsafe
+                    {
+                        fixed (float* pp = p) fixed (int* pIdx = sIdx) fixed (float* pVal = sVal)
+                        fixed (float* pm = m) fixed (float* pvv = v)
+                            FusedOptimizer.SparseNadamUpdate(pp, pIdx, pVal, pm, pvv, sNnz, lr, b1, b2, eps, wd, step);
+                    }
+                    continue;
+                }
+
+                if (wd != 0f)
+                    for (int i = 0; i < p.Length; i++) grad[i] += wd * p[i];
+
                 unsafe
                 {
                     fixed (float* pp = p) fixed (float* pg = grad) fixed (float* pm = m) fixed (float* pv = v)
@@ -286,7 +375,7 @@ public sealed class NAdamOptimizer : OptimizerBase
                 }
             }
         }
-        } finally { if (maximized) UnflipMaximize(); }
+        } finally { if (maximized) UnflipMaximize(); ClearAutoClearSparseGrads(); }
     }
 }
 
@@ -321,13 +410,27 @@ public sealed class AdamaxOptimizer : OptimizerBase
             for (int pi = 0; pi < g.Parameters.Count; pi++)
             {
                 float[] p = g.Parameters[pi]; float[] grad = g.Gradients[pi];
-                if (wd != 0f)
-                    for (int i = 0; i < p.Length; i++) grad[i] += wd * p[i];
                 var slot = GetOrCreateState(gi, pi, p.Length);
                 int step = (slot["step"].IntValue ?? 0) + 1;
                 slot["step"].IntValue = step;
                 var m = slot["exp_avg"].Tensor!;
                 var u = slot["exp_inf"].Tensor!;
+
+                if (TryGetSparseGradient(gi, pi, out var sIdx, out var sVal, out var sNnz))
+                {
+                    if (sNnz == 0) continue;
+                    unsafe
+                    {
+                        fixed (float* pp = p) fixed (int* pIdx = sIdx) fixed (float* pVal = sVal)
+                        fixed (float* pm = m) fixed (float* pu = u)
+                            FusedOptimizer.SparseAdamaxUpdate(pp, pIdx, pVal, pm, pu, sNnz, lr, b1, b2, eps, wd, step);
+                    }
+                    continue;
+                }
+
+                if (wd != 0f)
+                    for (int i = 0; i < p.Length; i++) grad[i] += wd * p[i];
+
                 unsafe
                 {
                     fixed (float* pp = p) fixed (float* pg = grad) fixed (float* pm = m) fixed (float* pu = u)
@@ -335,7 +438,7 @@ public sealed class AdamaxOptimizer : OptimizerBase
                 }
             }
         }
-        } finally { if (maximized) UnflipMaximize(); }
+        } finally { if (maximized) UnflipMaximize(); ClearAutoClearSparseGrads(); }
     }
 }
 
@@ -356,19 +459,35 @@ public sealed class AdagradOptimizer : OptimizerBase
     /// <inheritdoc />
     public override void Step()
     {
+        try {
         for (int gi = 0; gi < ParamGroups.Count; gi++)
         {
             var g = ParamGroups[gi];
             float lr = (float)g.LearningRate;
             float eps = (float)g.GetOption("eps", 1e-10);
             float wd = (float)g.GetOption("weight_decay", 0.0);
+            float lrDecay = (float)g.GetOption("lr_decay", 0.0);
             for (int pi = 0; pi < g.Parameters.Count; pi++)
             {
                 float[] p = g.Parameters[pi]; float[] grad = g.Gradients[pi];
-                if (wd != 0f)
-                    for (int i = 0; i < p.Length; i++) grad[i] += wd * p[i];
                 var slot = GetOrCreateState(gi, pi, p.Length);
                 var s = slot["sum"].Tensor!;
+                int step = (slot.TryGetValue("step", out var sv) ? sv.IntValue : 0) ?? 0;
+                if (slot.ContainsKey("step")) slot["step"].IntValue = step + 1;
+
+                if (TryGetSparseGradient(gi, pi, out var sIdx, out var sVal, out var sNnz))
+                {
+                    if (sNnz == 0) continue;
+                    unsafe
+                    {
+                        fixed (float* pp = p) fixed (int* pIdx = sIdx) fixed (float* pVal = sVal) fixed (float* ps = s)
+                            FusedOptimizer.SparseAdagradUpdate(pp, pIdx, pVal, ps, sNnz, lr, eps, wd, lrDecay, step + 1);
+                    }
+                    continue;
+                }
+
+                if (wd != 0f)
+                    for (int i = 0; i < p.Length; i++) grad[i] += wd * p[i];
                 unsafe
                 {
                     fixed (float* pp = p) fixed (float* pg = grad) fixed (float* ps = s)
@@ -376,6 +495,7 @@ public sealed class AdagradOptimizer : OptimizerBase
                 }
             }
         }
+        } finally { ClearAutoClearSparseGrads(); }
     }
 }
 
@@ -399,6 +519,7 @@ public sealed class RmsPropOptimizer : OptimizerBase
     /// <inheritdoc />
     public override void Step()
     {
+        try {
         for (int gi = 0; gi < ParamGroups.Count; gi++)
         {
             var g = ParamGroups[gi];
@@ -411,10 +532,27 @@ public sealed class RmsPropOptimizer : OptimizerBase
             for (int pi = 0; pi < g.Parameters.Count; pi++)
             {
                 float[] p = g.Parameters[pi]; float[] grad = g.Gradients[pi];
-                if (wd != 0f)
-                    for (int i = 0; i < p.Length; i++) grad[i] += wd * p[i];
                 var slot = GetOrCreateState(gi, pi, p.Length);
                 var v = slot["square_avg"].Tensor!;
+
+                if (TryGetSparseGradient(gi, pi, out var sIdx, out var sVal, out var sNnz))
+                {
+                    if (sNnz == 0) continue;
+                    var gAvgSp = centered ? slot["grad_avg"].Tensor! : null;
+                    var mbSp = (mom != 0f) ? slot["momentum_buffer"].Tensor! : null;
+                    unsafe
+                    {
+                        fixed (float* pp = p) fixed (int* pIdx = sIdx) fixed (float* pVal = sVal) fixed (float* pv = v)
+                        fixed (float* pga = gAvgSp) fixed (float* pmb = mbSp)
+                        {
+                            FusedOptimizer.SparseRmsPropUpdate(pp, pIdx, pVal, pv, pmb, sNnz, lr, rho, eps, wd, mom, centered, pga, mom != 0f);
+                        }
+                    }
+                    continue;
+                }
+
+                if (wd != 0f)
+                    for (int i = 0; i < p.Length; i++) grad[i] += wd * p[i];
 
                 if (centered)
                 {
@@ -464,6 +602,7 @@ public sealed class RmsPropOptimizer : OptimizerBase
                 }
             }
         }
+        } finally { ClearAutoClearSparseGrads(); }
     }
 }
 
@@ -484,6 +623,7 @@ public sealed class AdaDeltaOptimizer : OptimizerBase
     /// <inheritdoc />
     public override void Step()
     {
+        try {
         for (int gi = 0; gi < ParamGroups.Count; gi++)
         {
             var g = ParamGroups[gi];
@@ -494,11 +634,24 @@ public sealed class AdaDeltaOptimizer : OptimizerBase
             for (int pi = 0; pi < g.Parameters.Count; pi++)
             {
                 float[] p = g.Parameters[pi]; float[] grad = g.Gradients[pi];
-                if (wd != 0f)
-                    for (int i = 0; i < p.Length; i++) grad[i] += wd * p[i];
                 var slot = GetOrCreateState(gi, pi, p.Length);
                 var sq = slot["square_avg"].Tensor!;
                 var ad = slot["acc_delta"].Tensor!;
+
+                if (TryGetSparseGradient(gi, pi, out var sIdx, out var sVal, out var sNnz))
+                {
+                    if (sNnz == 0) continue;
+                    unsafe
+                    {
+                        fixed (float* pp = p) fixed (int* pIdx = sIdx) fixed (float* pVal = sVal)
+                        fixed (float* psq = sq) fixed (float* pad = ad)
+                            FusedOptimizer.SparseAdaDeltaUpdate(pp, pIdx, pVal, psq, pad, sNnz, lr, rho, eps, wd);
+                    }
+                    continue;
+                }
+
+                if (wd != 0f)
+                    for (int i = 0; i < p.Length; i++) grad[i] += wd * p[i];
                 unsafe
                 {
                     fixed (float* pp = p) fixed (float* pg = grad) fixed (float* psq = sq) fixed (float* pad = ad)
@@ -506,6 +659,7 @@ public sealed class AdaDeltaOptimizer : OptimizerBase
                 }
             }
         }
+        } finally { ClearAutoClearSparseGrads(); }
     }
 }
 
@@ -526,6 +680,7 @@ public sealed class LionOptimizer : OptimizerBase
     /// <inheritdoc />
     public override void Step()
     {
+        try {
         for (int gi = 0; gi < ParamGroups.Count; gi++)
         {
             var g = ParamGroups[gi];
@@ -538,6 +693,18 @@ public sealed class LionOptimizer : OptimizerBase
                 float[] p = g.Parameters[pi]; float[] grad = g.Gradients[pi];
                 var slot = GetOrCreateState(gi, pi, p.Length);
                 var m = slot["exp_avg"].Tensor!;
+
+                if (TryGetSparseGradient(gi, pi, out var sIdx, out var sVal, out var sNnz))
+                {
+                    if (sNnz == 0) continue;
+                    unsafe
+                    {
+                        fixed (float* pp = p) fixed (int* pIdx = sIdx) fixed (float* pVal = sVal) fixed (float* pm = m)
+                            FusedOptimizer.SparseLionUpdate(pp, pIdx, pVal, pm, sNnz, lr, b1, b2, wd);
+                    }
+                    continue;
+                }
+
                 unsafe
                 {
                     fixed (float* pp = p) fixed (float* pg = grad) fixed (float* pm = m)
@@ -545,6 +712,7 @@ public sealed class LionOptimizer : OptimizerBase
                 }
             }
         }
+        } finally { ClearAutoClearSparseGrads(); }
     }
 }
 
@@ -568,6 +736,7 @@ public sealed class AsgdOptimizer : OptimizerBase
     /// <inheritdoc />
     public override void Step()
     {
+        try {
         for (int gi = 0; gi < ParamGroups.Count; gi++)
         {
             var g = ParamGroups[gi];
@@ -579,6 +748,11 @@ public sealed class AsgdOptimizer : OptimizerBase
             for (int pi = 0; pi < g.Parameters.Count; pi++)
             {
                 float[] p = g.Parameters[pi]; float[] grad = g.Gradients[pi];
+                // ASGD's averaged-weight buffer (ax) must be updated at EVERY index per step
+                // (Polyak-Ruppert averaging), so it can't run a sparse scatter path. Materialize
+                // any caller-published sparse grad into the dense buffer first, then fall through
+                // to the regular dense kernel.
+                MaterializeSparseIntoDense(gi, pi, grad);
                 var slot = GetOrCreateState(gi, pi, p.Length);
                 int step = (slot["step"].IntValue ?? 0) + 1;
                 slot["step"].IntValue = step;
@@ -598,6 +772,7 @@ public sealed class AsgdOptimizer : OptimizerBase
                 }
             }
         }
+        } finally { ClearAutoClearSparseGrads(); }
     }
 }
 
@@ -617,6 +792,7 @@ public sealed class RpropOptimizer : OptimizerBase
     /// <inheritdoc />
     public override void Step()
     {
+        try {
         for (int gi = 0; gi < ParamGroups.Count; gi++)
         {
             var g = ParamGroups[gi];
@@ -628,6 +804,10 @@ public sealed class RpropOptimizer : OptimizerBase
             for (int pi = 0; pi < g.Parameters.Count; pi++)
             {
                 float[] p = g.Parameters[pi]; float[] grad = g.Gradients[pi];
+                // Rprop tracks per-element sign-of-grad across steps; every index must observe
+                // a (possibly zero) gradient. Materialize any caller-published sparse grad into
+                // the dense buffer first, then fall through to the regular dense kernel.
+                MaterializeSparseIntoDense(gi, pi, grad);
                 var slot = GetOrCreateState(gi, pi, p.Length);
                 var prev = slot["prev_grad"].Tensor!;
                 var ss = slot["step_size"].Tensor!;
@@ -647,6 +827,7 @@ public sealed class RpropOptimizer : OptimizerBase
                 }
             }
         }
+        } finally { ClearAutoClearSparseGrads(); }
     }
 }
 
@@ -668,6 +849,7 @@ public sealed class LambOptimizer : OptimizerBase
     /// <inheritdoc />
     public override void Step()
     {
+        try {
         for (int gi = 0; gi < ParamGroups.Count; gi++)
         {
             var g = ParamGroups[gi];
@@ -679,6 +861,10 @@ public sealed class LambOptimizer : OptimizerBase
             for (int pi = 0; pi < g.Parameters.Count; pi++)
             {
                 float[] p = g.Parameters[pi]; float[] grad = g.Gradients[pi];
+                // LAMB's trust ratio = ‖p‖ / ‖update‖ needs the FULL gradient norm, so a
+                // sparse scatter path would compute the wrong ratio. Materialize any
+                // caller-published sparse grad into the dense buffer first, then fall through.
+                MaterializeSparseIntoDense(gi, pi, grad);
                 var slot = GetOrCreateState(gi, pi, p.Length);
                 int step = (slot["step"].IntValue ?? 0) + 1;
                 slot["step"].IntValue = step;
@@ -691,6 +877,7 @@ public sealed class LambOptimizer : OptimizerBase
                 }
             }
         }
+        } finally { ClearAutoClearSparseGrads(); }
     }
 }
 
@@ -712,6 +899,7 @@ public sealed class LarsOptimizer : OptimizerBase
     /// <inheritdoc />
     public override void Step()
     {
+        try {
         for (int gi = 0; gi < ParamGroups.Count; gi++)
         {
             var g = ParamGroups[gi];
@@ -722,6 +910,9 @@ public sealed class LarsOptimizer : OptimizerBase
             for (int pi = 0; pi < g.Parameters.Count; pi++)
             {
                 float[] p = g.Parameters[pi]; float[] grad = g.Gradients[pi];
+                // LARS's trust ratio = ‖p‖ / (‖g‖ + wd·‖p‖) needs the FULL gradient norm.
+                // Materialize any caller-published sparse grad into the dense buffer first.
+                MaterializeSparseIntoDense(gi, pi, grad);
                 var slot = GetOrCreateState(gi, pi, p.Length);
                 var v = slot["momentum_buffer"].Tensor!;
                 unsafe
@@ -731,6 +922,7 @@ public sealed class LarsOptimizer : OptimizerBase
                 }
             }
         }
+        } finally { ClearAutoClearSparseGrads(); }
     }
 }
 
@@ -751,6 +943,7 @@ public sealed class FtrlOptimizer : OptimizerBase
     /// <inheritdoc />
     public override void Step()
     {
+        try {
         for (int gi = 0; gi < ParamGroups.Count; gi++)
         {
             var g = ParamGroups[gi];
@@ -767,6 +960,19 @@ public sealed class FtrlOptimizer : OptimizerBase
                 var slot = GetOrCreateState(gi, pi, p.Length);
                 var z = slot["z"].Tensor!;
                 var n = slot["n"].Tensor!;
+
+                if (TryGetSparseGradient(gi, pi, out var sIdx, out var sVal, out var sNnz))
+                {
+                    if (sNnz == 0) continue;
+                    unsafe
+                    {
+                        fixed (float* pp = p) fixed (int* pIdx = sIdx) fixed (float* pVal = sVal)
+                        fixed (float* pn = n) fixed (float* pz = z)
+                            FusedOptimizer.SparseFtrlUpdate(pp, pIdx, pVal, pn, pz, sNnz, lr, lrPow, l1, l2);
+                    }
+                    continue;
+                }
+
                 unsafe
                 {
                     fixed (float* pp = p) fixed (float* pg = grad) fixed (float* pz = z) fixed (float* pn = n)
@@ -774,6 +980,7 @@ public sealed class FtrlOptimizer : OptimizerBase
                 }
             }
         }
+        } finally { ClearAutoClearSparseGrads(); }
     }
 }
 
@@ -797,29 +1004,10 @@ public sealed class SparseAdamOptimizer : OptimizerBase
     // monotonically to fit the largest nnz seen so far.
     private readonly Dictionary<(int gi, int pi), (int[] idx, float[] val)> _scratch = new();
 
-    /// <summary>Pre-supply sparse indices and values for a parameter, skipping the dense
-    /// gradient scan altogether. Caller is responsible for ensuring <paramref name="indices"/>
-    /// is sorted and <paramref name="values"/> is the same length. Subsequent <see cref="Step"/>
-    /// calls will use this snapshot until <see cref="ClearSparseGradient"/> is invoked or new
-    /// indices/values are supplied.</summary>
-    public void SetSparseGradient(int paramGroupIndex, int paramIndex, int[] indices, float[] values)
-    {
-        if (indices == null) throw new ArgumentNullException(nameof(indices));
-        if (values == null) throw new ArgumentNullException(nameof(values));
-        if (indices.Length != values.Length)
-            throw new ArgumentException("indices and values must be the same length.");
-        _explicit[(paramGroupIndex, paramIndex)] = (indices, values);
-    }
-
-    /// <summary>Clear an explicit sparse gradient previously set by <see cref="SetSparseGradient"/>.</summary>
-    public void ClearSparseGradient(int paramGroupIndex, int paramIndex) =>
-        _explicit.Remove((paramGroupIndex, paramIndex));
-
-    private readonly Dictionary<(int gi, int pi), (int[] idx, float[] val)> _explicit = new();
-
     /// <inheritdoc />
     public override void Step()
     {
+        try {
         for (int gi = 0; gi < ParamGroups.Count; gi++)
         {
             var g = ParamGroups[gi];
@@ -839,12 +1027,10 @@ public sealed class SparseAdamOptimizer : OptimizerBase
                 int nnz;
                 int[] idx;
                 float[] val;
-                if (_explicit.TryGetValue((gi, pi), out var explicitPair))
+                if (TryGetSparseGradient(gi, pi, out idx!, out val!, out nnz))
                 {
-                    // User supplied sparse indices+values directly — zero scans, zero allocations.
-                    idx = explicitPair.idx;
-                    val = explicitPair.val;
-                    nnz = idx.Length;
+                    // Caller supplied sparse indices+values directly via the base
+                    // OptimizerBase.SetSparseGradient API — zero scans, zero allocations.
                 }
                 else
                 {
@@ -887,5 +1073,6 @@ public sealed class SparseAdamOptimizer : OptimizerBase
                 }
             }
         }
+        } finally { ClearAutoClearSparseGrads(); }
     }
 }

--- a/src/AiDotNet.Tensors/Engines/Optimization/Optimizers/ShampooOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/Optimization/Optimizers/ShampooOptimizer.cs
@@ -82,12 +82,6 @@ public sealed class ShampooOptimizer : OptimizerBase
             {
                 float[] p = g.Parameters[pi];
                 float[] grad = g.Gradients[pi];
-                // Shampoo's L⁻¹ᐟ⁴ and R⁻¹ᐟ⁴ preconditioners are matrix-state — they aggregate
-                // over the full grad. Materialize any caller-published sparse grad first.
-                MaterializeSparseIntoDense(gi, pi, grad);
-                if (wd != 0f)
-                    for (int i = 0; i < p.Length; i++) grad[i] += wd * p[i];
-
                 var slot = GetOrCreateState(gi, pi, p.Length);
                 int step = (slot["step"].IntValue ?? 0) + 1;
                 slot["step"].IntValue = step;
@@ -96,6 +90,47 @@ public sealed class ShampooOptimizer : OptimizerBase
                 bool useFull = has2D
                     && shape.d1 <= maxDim && shape.d2 <= maxDim
                     && shape.d1 > 1 && shape.d2 > 1;
+
+                // Sparse fast path for diagonal mode (the dominant case for embedding tables
+                // — vocab usually >> max_precondition_dim so Shampoo always falls back to
+                // diagonal here). The full-matrix path keeps the dense materialize fallback:
+                // sparse outer-product updates to L = Σ g·gᵀ are possible but expensive to
+                // implement correctly when sparse indices span multiple matrix columns, and
+                // the use case (small param dims that fit under max_precondition_dim) doesn't
+                // benefit much from sparse gradients to begin with.
+                if (TryGetSparseGradient(gi, pi, out var sIdx, out var sVal, out var sNnz))
+                {
+                    if (useFull)
+                    {
+                        // Full-matrix path: materialize sparse → dense and use the existing kernel.
+                        MaterializeSparseIntoDense(gi, pi, grad);
+                        if (wd != 0f) for (int i = 0; i < p.Length; i++) grad[i] += wd * p[i];
+                        EnsureFullState(slot, shape.d1, shape.d2);
+                        UpdateFull(slot, grad, p, shape.d1, shape.d2, step, lr, momentum, preFreq, eps);
+                        continue;
+                    }
+
+                    // Diagonal sparse: per-element math, scatter at touched indices.
+                    if (sNnz == 0) continue;
+                    EnsureDiagonalState(slot, p.Length);
+                    var acc = slot["diag_acc"].Tensor!;
+                    var mb  = slot["momentum_buffer"].Tensor!;
+                    for (int k = 0; k < sNnz; k++)
+                    {
+                        int i = sIdx[k];
+                        float gV = sVal[k];
+                        if (wd != 0f) gV += wd * p[i];
+                        acc[i] += gV * gV;
+                        float invRoot = 1f / MathF.Sqrt(MathF.Sqrt(acc[i] + eps));
+                        float pre = gV * invRoot;
+                        mb[i] = momentum * mb[i] + pre;
+                        p[i] -= lr * mb[i];
+                    }
+                    continue;
+                }
+
+                if (wd != 0f)
+                    for (int i = 0; i < p.Length; i++) grad[i] += wd * p[i];
 
                 if (useFull)
                 {

--- a/src/AiDotNet.Tensors/Engines/Optimization/Optimizers/ShampooOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/Optimization/Optimizers/ShampooOptimizer.cs
@@ -59,6 +59,7 @@ public sealed class ShampooOptimizer : OptimizerBase
     /// <inheritdoc />
     public override void Step()
     {
+        try {
         for (int gi = 0; gi < ParamGroups.Count; gi++)
         {
             var g = ParamGroups[gi];
@@ -81,6 +82,9 @@ public sealed class ShampooOptimizer : OptimizerBase
             {
                 float[] p = g.Parameters[pi];
                 float[] grad = g.Gradients[pi];
+                // Shampoo's L⁻¹ᐟ⁴ and R⁻¹ᐟ⁴ preconditioners are matrix-state — they aggregate
+                // over the full grad. Materialize any caller-published sparse grad first.
+                MaterializeSparseIntoDense(gi, pi, grad);
                 if (wd != 0f)
                     for (int i = 0; i < p.Length; i++) grad[i] += wd * p[i];
 
@@ -105,6 +109,7 @@ public sealed class ShampooOptimizer : OptimizerBase
                 }
             }
         }
+        } finally { ClearAutoClearSparseGrads(); }
     }
 
     private static void EnsureFullState(Dictionary<string, OptimizerStateValue> slot, int d1, int d2)


### PR DESCRIPTION
## Summary

Completes the embedding-backward sparse path the \`FromFloatIndices\` sister path already implements.

\`TensorEmbeddingLookupBackward\` (the standard tape backward) was **unconditionally** allocating + accumulating the dense \`[vocabSize, embeddingDim]\` gradient AFTER recording the sparse contribution. For paper-default **LayoutXLM** that's a **768 MB allocation per backward** against ~16 rows of real signal — the dominant per-step memory churn that ModelPerfProbe (AiDotNet#1510) flagged across paper-scale embedding-using models, and the root of many cross-the-board ModelFamily timeouts.

## The change

Mirrors the existing \`TensorEmbeddingLookupFromFloatIndicesBackward\` pattern: seed sparse first, then seed dense ONLY when the tape isn't wired with the sparse-grad array (compiled-plan paths and other non-\`GradientTape\` backward drivers that never call \`SetIndexedSparseGrads\`).

When the tape IS wired (every \`GradientTape\` backward — the case for every consumer optimizer in the AiDotNet repo after the consumer-side sparse-by-default refactor in **AiDotNet#1526**), the dense alloc is **skipped entirely**.

```csharp
// Before — unconditional dense seeding:
var sparseGrad = SparseEmbeddingGradient<T>.Build(...);
DifferentiableOps.AccumulateSparseEmbeddingGrad(inputs[0], sparseGrad);
var dense = engine.TensorEmbeddingLookupBackward<T, long>(...);   // 768 MB
DifferentiableOps.AccumulateGrad(grads, inputs[0], dense, engine);

// After — dense only when sparse-grad array isn't wired:
var sparseGrad = SparseEmbeddingGradient<T>.Build(...);
DifferentiableOps.AccumulateSparseEmbeddingGrad(inputs[0], sparseGrad);
if (DifferentiableOps.GetSparseEmbeddingGradsFor(inputs[0]) is null)
{
    var dense = engine.TensorEmbeddingLookupBackward<T, long>(...);
    DifferentiableOps.AccumulateGrad(grads, inputs[0], dense, engine);
}
```

## Consumer story

AiDotNet#1526 has already wired all 19 per-param optimizers to be sparse-by-default:

- **Adam, AdamW** — scatter directly via the sparse contribution (skip the dense alloc entirely).
- **17 dense-path optimizers** (SGD, Momentum, RMSprop, Adagrad, Adadelta, Lion, Nadam, LAMB, LARS, FTRL, AdaMax, AMSGrad, Adam8Bit, ProximalGradientDescent, etc.) — call \`SparseEmbeddingGradient.ToDense(engine)\` internally when they need a dense grad. One alloc, equivalent cost to today's Tensors-side dense seeding.

With this PR merged + published, the actual 768 MB/backward saving lands for Adam/AdamW models. The other 17 pay the same dense cost as today (just under their control instead of Tensors').

## Tests

All 31 embedding-backward + sparse-gradient tests pass unchanged:
- The dense-fallback branch keeps the legacy compiled-plan path bit-identical.
- The sparse-tape path now skips dense as designed.

## Test plan

- [x] \`SparseEmbeddingGradientTests\` (7) — pass.
- [x] \`TensorEmbeddingLookupBackward*\` regression suite — 24/24 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)