### PR TITLE
fix(gpu): skip FP16 Tensor-Core GEMM test on unsupported devices (cublasGemmEx NOT_SUPPORTED → NotSupportedException)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -10626,19 +10626,33 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         float aVal = alpha, bVal = beta;
         IntPtr alphaPtr = (IntPtr)(&aVal);
         IntPtr betaPtr = (IntPtr)(&bVal);
-        CuBlasNative.CheckCublasStatus(
-            CuBlasNative.cublasGemmEx(
-                _cublasHandle,
-                CublasOperation.None, CublasOperation.None,
-                N, M, K,
-                alphaPtr,
-                Bhalf.Handle, CuBlasNative.CUDA_R_16F, N,
-                Ahalf.Handle, CuBlasNative.CUDA_R_16F, K,
-                betaPtr,
-                C.Handle, CuBlasNative.CUDA_R_32F, N,
-                CuBlasNative.CUBLAS_COMPUTE_32F,
-                0 /* CUBLAS_GEMM_DEFAULT — selects Tensor Cores under the handle's math mode */),
-            "cublasGemmEx(GemmFp16)");
+        var status = CuBlasNative.cublasGemmEx(
+            _cublasHandle,
+            CublasOperation.None, CublasOperation.None,
+            N, M, K,
+            alphaPtr,
+            Bhalf.Handle, CuBlasNative.CUDA_R_16F, N,
+            Ahalf.Handle, CuBlasNative.CUDA_R_16F, K,
+            betaPtr,
+            C.Handle, CuBlasNative.CUDA_R_32F, N,
+            CuBlasNative.CUBLAS_COMPUTE_32F,
+            0 /* CUBLAS_GEMM_DEFAULT — selects Tensor Cores under the handle's math mode */);
+
+        // CUBLAS_STATUS_NOT_SUPPORTED is a CAPABILITY signal, not an operational failure:
+        // the FP16-in / FP32-compute cublasGemmEx config isn't available on this device
+        // (some GPUs/driver combos lack it even at compute capability >= 5). Surface it as
+        // NotSupportedException — the semantically correct type — so callers can cleanly
+        // fall back to the TF32 cublasSgemm path instead of treating it as a hard error.
+        // The compute-capability floor (SupportsHgemm, cc >= 5) is necessary but not
+        // sufficient, so we key off the authoritative runtime status here.
+        if (status == AiDotNet.Tensors.Engines.CublasStatus.NotSupported)
+        {
+            throw new NotSupportedException(
+                $"FP16 Tensor-Core GEMM (cublasGemmEx CUDA_R_16F in / CUBLAS_COMPUTE_32F) is not " +
+                $"supported on this device (compute capability {_ccMajor}.{_ccMinor}); " +
+                $"use the TF32 Gemm path instead.");
+        }
+        CuBlasNative.CheckCublasStatus(status, "cublasGemmEx(GemmFp16)");
     }
 
     private unsafe void LaunchUnaryFp16(string kernelName, IGpuBuffer input, IGpuBuffer output, int size)

--- a/tests/AiDotNet.Tensors.Tests/Engines/Gpu/Fp16TensorCoreGemmTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Gpu/Fp16TensorCoreGemmTests.cs
@@ -62,7 +62,20 @@ public class Fp16TensorCoreGemmTests
         Assert.Equal((long)K * N * 2, hB.SizeInBytes);
 
         using var dC16 = b.AllocateBuffer(M * N); // FP32 accumulate output
-        b.GemmFp16(hA, hB, dC16, M, N, K);
+        // Not every CUDA device/driver supports the FP16-in / FP32-compute cublasGemmEx
+        // config (it returns CUBLAS_STATUS_NOT_SUPPORTED, surfaced as NotSupportedException).
+        // The compute-capability guards above can't predict it precisely, so skip on the
+        // authoritative runtime signal — the test validates correctness only where the
+        // Tensor-Core path actually runs.
+        try
+        {
+            b.GemmFp16(hA, hB, dC16, M, N, K);
+        }
+        catch (NotSupportedException ex)
+        {
+            Skip.If(true, $"FP16 Tensor-Core GEMM not supported on this device: {ex.Message}");
+            return;
+        }
         var got16 = b.DownloadBuffer(dC16);
 
         // Relative Frobenius error ||got - ref|| / ||ref|| — the standard GEMM accuracy metric.


### PR DESCRIPTION
## Summary

Fixes a pre-existing failure on `main`: `Fp16TensorCoreGemmTests.GemmFp16_matches_fp32_reference_within_fp16_tolerance` fails (`cublasGemmEx(GemmFp16) failed: Not supported`) on any CUDA device whose driver/arch lacks the FP16-in / FP32-compute `cublasGemmEx` config — instead of skipping as a `[SkippableFact]` should. It's red on every branch that merges main and on CI runners without FP16 Tensor-Core support.

## Root cause

`CudaBackend.GemmFp16` routed the `cublasGemmEx` status through `CheckCublasStatus`, which turns **any** non-success into a generic `InvalidOperationException`. But `CUBLAS_STATUS_NOT_SUPPORTED` is a **capability** signal, not an operational error — the config simply isn't available on this GPU/driver. Two consequences:
- Production callers couldn't distinguish "this hardware can't" from a genuine fault, so they couldn't fall back to the TF32 `Gemm` path.
- The test's skip guards check CUDA *availability* (`CudaNativeBindings.IsAvailable`, `CudaBackend.IsAvailable`) but not FP16 Tensor-Core *capability*, so it ran the op and hard-failed.

Note `GemmFp16` also lacked the compute-capability guard its sibling `GemmFp16In32fOut` has (`SupportsHgemm`, cc ≥ 5) — but cc ≥ 5 is necessary, not sufficient: some such devices still return `NOT_SUPPORTED`. The authoritative signal is the runtime cublas status.

## Fix

- `GemmFp16` now translates `CublasStatus.NotSupported` into `NotSupportedException` (the semantically correct, catchable type) before delegating other statuses to `CheckCublasStatus`. Callers can catch it to fall back to TF32.
- The test catches `NotSupportedException` and skips — validating correctness only where the Tensor-Core path actually runs.

## Verification

- Both TFMs (net10.0 + net471) build.
- The test **skips** (was **fail**) on a device without FP16 Tensor-Core GEMM support; on hardware that supports it, the correctness assertions run unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
