### PR TITLE
test(gpu): serialize MhaLeanSdpaAllocTests to stop process-wide alloc-counter flake

### DIFF
--- a/tests/AiDotNet.Tensors.Tests/Engines/MhaLeanSdpaAllocTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/MhaLeanSdpaAllocTests.cs
@@ -14,6 +14,18 @@ namespace AiDotNet.Tensors.Tests.Engines;
 /// allocation from ~7.2 MB to ~1.0 MB (~6.9×) and sustained mean latency ~2.7×. This test
 /// fails if the forward regresses back to the weight-materializing path.
 /// </summary>
+// Disable xUnit parallel execution for this class — the gate samples
+// GC.GetTotalAllocatedBytes, a PROCESS-WIDE counter (deliberately, so it also
+// catches the SDPA path's parallel per-head worker-thread allocations that a
+// thread-local counter would miss). If any other test class allocates
+// concurrently during the measured window, those bytes are attributed to our
+// per-call figure and the threshold trips on the noise — observed as 37986 KB/call
+// under a full parallel suite run while the real path is ~1024 KB (passes in
+// isolation). Same rationale and pattern as OptimizerKernelsAllocSerial.
+[CollectionDefinition("MhaLeanSdpaAllocSerial", DisableParallelization = true)]
+public class MhaLeanSdpaAllocSerialCollection { }
+
+[Collection("MhaLeanSdpaAllocSerial")]
 public class MhaLeanSdpaAllocTests
 {
     private static Tensor<float> Rand(Random r, params int[] s)


### PR DESCRIPTION
## Summary

Fixes a pre-existing flake on `main`: `MhaLeanSdpaAllocTests.MhaForward_AllocatesFarLessThanWeightMaterializingPath` fails under a full parallel suite run (`MHA forward allocated 37986 KB/call; expected < 3072 KB`) while passing in isolation. Surfaced during a full non-GPU sweep (1 failure / 2310 tests).

## Root cause

The gate samples `GC.GetTotalAllocatedBytes` — a **process-wide** counter, chosen deliberately (per the in-code comment) so it also captures the SDPA path's parallel per-head worker-thread allocations that `GC.GetAllocatedBytesForCurrentThread` would silently miss (a false-negative regression guard). The trade-off: any *other* test class allocating concurrently during the measured 20-call window is attributed to the per-call figure. Under the full parallel suite, ~2300 other tests inflate it ~37×.

`Category=Performance` already excludes it from the coverage-instrumented CI lane (where Coverlet's per-line counters made the measurement meaningless), but the normal parallel lane still flakes — and the same contention can hit a CI shard.

## Fix

Put the test in a `DisableParallelization = true` collection so no other class allocates during its measurement window — keeping the process-wide counter intact (it still catches the SDPA worker-thread allocations the test is designed to guard). This is the identical rationale and pattern to the existing `OptimizerKernelsAllocSerial` collection in this same test project.

## Verification

- Both TFMs (net10.0 + net471) build.
- Test passes; no behavior or threshold change — only execution isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
