### PR TITLE
fix(ci): ship CUDA runtime to nuget.org as reassembled <250MB fragment packages

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -370,19 +370,19 @@ jobs:
 
           # Pack CUDA native package (NVIDIA GPU: cudart + cuBLAS + cuBLASLt + nvRTC).
           # Binaries (~770MB) are gitignored; stage them from the official NVIDIA
-          # redistributable archives first, then pack (industry-standard, no toolkit install).
-          $cudaProj = "src/AiDotNet.Native.CUDA/AiDotNet.Native.CUDA.csproj"
-          if (Test-Path $cudaProj) {
+          # redistributable archives first. The runtime is far over nuget.org's 250 MB
+          # per-package limit (cuBLAS / cuBLASLt EACH exceed it), so it is published as a
+          # meta package + a set of <250 MB byte-chunk "fragment" packages that the meta's
+          # build targets reassemble into the full DLLs at the consumer's build — the same
+          # multi-part approach TorchSharp uses for its CUDA runtime. See
+          # tools/pack-cuda-split.ps1 (round-trip validated: chunks reassemble byte-for-byte).
+          $cudaNative = "src/AiDotNet.Native.CUDA/runtimes/win-x64/native"
+          if (Test-Path "src/AiDotNet.Native.CUDA/AiDotNet.Native.CUDA.csproj") {
             Write-Host "Staging CUDA runtime from NVIDIA redist..."
             pwsh ./tools/stage-cuda-redist.ps1
-            $cudaNative = "src/AiDotNet.Native.CUDA/runtimes/win-x64/native"
             if ((Test-Path "$cudaNative/cudart64_12.dll") -and (Test-Path "$cudaNative/nvrtc64_120_0.dll")) {
-              Write-Host "Packing AiDotNet.Native.CUDA..."
-              dotnet restore $cudaProj
-              if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-              dotnet build $cudaProj -c Release --no-restore
-              if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-              dotnet pack $cudaProj -c Release -o out --no-build /p:PackageVersion=$VERSION
+              Write-Host "Packing AiDotNet.Native.CUDA (split into <250MB fragment packages)..."
+              pwsh ./tools/pack-cuda-split.ps1 -Version $VERSION -OutDir out
               if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
             } else {
               Write-Host "Skipping AiDotNet.Native.CUDA - staging did not produce the required runtime DLLs"
@@ -498,18 +498,19 @@ jobs:
             exit 1
           fi
 
+          # Every package (including the CUDA meta + its fragment packages) is now under
+          # nuget.org's 250 MB limit, so push them all. --skip-duplicate keeps a re-run of
+          # an already-published version green; a genuine push failure (bad API key,
+          # validation, an unexpectedly over-limit package) still fails the job under
+          # `bash -e`, which is what we want — a silent skip would hide a broken release.
           for pkg in "${pkgs[@]}"; do
-            echo "Publishing $pkg to NuGet..."
+            size=$(stat -c%s "$pkg")
+            echo "Publishing $pkg to NuGet ($((size / 1024 / 1024)) MB)..."
             dotnet nuget push "$pkg" \
               --api-key ${{ secrets.NUGET_API_KEY }} \
               --source https://api.nuget.org/v3/index.json \
               --skip-duplicate
-
-            if [ $? -eq 0 ]; then
-              echo "Successfully published $pkg"
-            else
-              echo "Warning: Failed to publish $pkg (may already exist)"
-            fi
+            echo "Successfully published $pkg"
           done
 
   github-release:
@@ -551,7 +552,7 @@ jobs:
             ## Packages
 
             ${{ steps.packages.outputs.list }}
-            > Note: AiDotNet.Native.CUDA (~770MB) bundles the NVIDIA CUDA 12 runtime (cudart / cuBLAS / cuBLASLt / nvRTC). It is published by this pipeline (binaries staged from the official NVIDIA redist) and is opt-in — add it alongside AiDotNet.Tensors only on NVIDIA GPU machines.
+            > Note: AiDotNet.Native.CUDA bundles the NVIDIA CUDA 12 runtime (cudart / cuBLAS / cuBLASLt / nvRTC, ~770MB). Because that exceeds nuget.org's 250 MB per-package limit, it ships as a small meta package plus a set of `AiDotNet.Native.CUDA.Fragments.*` chunk packages that are reassembled into the full DLLs at your build (win-x64) — just `dotnet add package AiDotNet.Native.CUDA` alongside AiDotNet.Tensors on NVIDIA GPU machines; the fragments restore automatically.
             > Note: AiDotNet.Native.ROCm requires ROCm installed on the target machine for the kernel library (~496MB).
 
             ## Installation

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,7 @@ src/AiDotNet.Native.CUDA/runtimes/*/native/*.dll
 .resnet50.log
 .bert100.log
 TR/
+
+# Generated at release time by tools/pack-cuda-split.ps1 (CUDA fragment manifest)
+src/AiDotNet.Native.CUDA/build/cuda-fragments.manifest
+src/AiDotNet.Native.CUDA/obj/cuda-split/

--- a/src/AiDotNet.Native.CUDA/AiDotNet.Native.CUDA.csproj
+++ b/src/AiDotNet.Native.CUDA/AiDotNet.Native.CUDA.csproj
@@ -22,21 +22,17 @@
     <ContentTargetFolders>content</ContentTargetFolders>
   </PropertyGroup>
 
-  <!-- Windows x64 native libraries: cudart, cuBLAS, cuBLASLt, AND nvRTC (+ builtins).
-       nvRTC is required by AiDotNet.Tensors' CUDA backend for runtime kernel JIT;
-       without it CUDA ops fail (cuMemAlloc/cuMemcpyHtoD error 700). Binaries are
-       staged by tools/stage-cuda-redist.ps1 (gitignored, ~770MB) and packed via a
-       wildcard so the full runtime is always included. -->
-  <ItemGroup>
-    <None Include="runtimes\win-x64\native\*.dll" Pack="true" PackagePath="runtimes\win-x64\native" />
-  </ItemGroup>
+  <!-- Windows x64 native libraries: cudart, cuBLAS, cuBLASLt, AND nvRTC (+ builtins),
+       staged by tools/stage-cuda-redist.ps1 (gitignored, ~770MB).
 
-  <!-- Future: Linux x64 native libraries -->
-  <!-- <None Include="runtimes\linux-x64\native\libcublas.so.12" Pack="true" PackagePath="runtimes\linux-x64\native" /> -->
-  <!-- <None Include="runtimes\linux-x64\native\libcublasLt.so.12" Pack="true" PackagePath="runtimes\linux-x64\native" /> -->
-  <!-- <None Include="runtimes\linux-x64\native\libcudart.so.12" Pack="true" PackagePath="runtimes\linux-x64\native" /> -->
+       IMPORTANT: this project does NOT pack the DLLs directly — the full runtime is far
+       over nuget.org's 250 MB per-package limit (cuBLAS / cuBLASLt EACH exceed it). The
+       shipped package is produced by tools/pack-cuda-split.ps1, which splits the runtime
+       into <250 MB AiDotNet.Native.CUDA.Fragments.* packages plus a meta package whose
+       build/AiDotNet.Native.CUDA.targets reassembles the DLLs at the consumer's build.
+       The items below only copy the staged DLLs to THIS project's output for local dev. -->
 
-  <!-- Ensure the native libraries are copied to output -->
+  <!-- Ensure the native libraries are copied to output for local development/debugging. -->
   <ItemGroup>
     <None Include="runtimes\**\*.dll" CopyToOutputDirectory="PreserveNewest" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>

--- a/src/AiDotNet.Native.CUDA/build/AiDotNet.Native.CUDA.targets
+++ b/src/AiDotNet.Native.CUDA/build/AiDotNet.Native.CUDA.targets
@@ -2,32 +2,125 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <!--
-    This targets file copies CUDA native libraries to the output directory
-    when a project references AiDotNet.Native.CUDA.
+    AiDotNet.Native.CUDA ships its ~770 MB CUDA 12 runtime as a set of <250 MB fragment
+    packages (AiDotNet.Native.CUDA.Fragments.N) because nuget.org rejects any single
+    package over 250 MB. This .targets reassembles each native DLL from its ordered
+    fragment chunks at the consumer's build, on win-x64, then lets the normal build/publish
+    copy place them next to the app (where the CUDA backend's DllImports resolve them).
+    See tools/pack-cuda-split.ps1 for how the fragments + manifest are produced.
   -->
 
+  <!-- Inline reassembly task: concatenates each DLL's chunks (restored from the fragment
+       packages alongside this meta package) into DestDir. Located relative to THIS file,
+       so it works regardless of the NuGet global-packages folder layout. -->
+  <UsingTask TaskName="ReassembleCudaRuntime"
+             TaskFactory="RoslynCodeTaskFactory"
+             AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <MetaDir ParameterType="System.String" Required="true" />
+      <ManifestPath ParameterType="System.String" Required="true" />
+      <DestDir ParameterType="System.String" Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System" />
+      <Using Namespace="System.IO" />
+      <Using Namespace="System.Collections.Generic" />
+      <Code Type="Fragment" Language="cs"><![CDATA[
+        // MetaDir = <packagesRoot>/aidotnet.native.cuda/<version>/build/
+        var meta = new DirectoryInfo(MetaDir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        var version = meta.Parent.Name;                       // <version>
+        var packagesRoot = meta.Parent.Parent.Parent;         // <packagesRoot>
+        Directory.CreateDirectory(DestDir);
+
+        // Index every restored fragment chunk by file name.
+        var chunks = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var frag in packagesRoot.GetDirectories("aidotnet.native.cuda.fragments.*"))
+        {
+            var cf = Path.Combine(frag.FullName, version, "cuda-fragments");
+            if (!Directory.Exists(cf)) continue;
+            foreach (var f in Directory.GetFiles(cf)) chunks[Path.GetFileName(f)] = f;
+        }
+
+        foreach (var raw in File.ReadAllLines(ManifestPath))
+        {
+            var line = raw.Trim();
+            if (line.Length == 0) continue;
+            var parts = line.Split('|');               // <dll>|<totalBytes>|<chunkCount>
+            var dll = parts[0];
+            long total = long.Parse(parts[1]);
+            int count = int.Parse(parts[2]);
+
+            var dest = Path.Combine(DestDir, dll);
+            if (File.Exists(dest) && new FileInfo(dest).Length == total)
+            {
+                Log.LogMessage(MessageImportance.Low, "AiDotNet.Native.CUDA: " + dll + " already reassembled.");
+                continue;
+            }
+
+            var tmp = dest + ".tmp";
+            using (var outFs = File.Create(tmp))
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    var name = string.Format("{0}.{1:D3}", dll, i);
+                    string src;
+                    if (!chunks.TryGetValue(name, out src))
+                        throw new FileNotFoundException("AiDotNet.Native.CUDA reassembly: missing chunk '" + name +
+                            "'. The AiDotNet.Native.CUDA.Fragments.* packages may not have been restored.");
+                    using (var inFs = File.OpenRead(src)) inFs.CopyTo(outFs);
+                }
+            }
+            long got = new FileInfo(tmp).Length;
+            if (got != total)
+            {
+                File.Delete(tmp);
+                throw new Exception("AiDotNet.Native.CUDA reassembly: " + dll + " is " + got + " bytes, expected " + total + ".");
+            }
+            if (File.Exists(dest)) File.Delete(dest);
+            File.Move(tmp, dest);
+            Log.LogMessage(MessageImportance.High, "AiDotNet.Native.CUDA: reassembled " + dll + " (" + total + " bytes) from " + count + " chunk(s).");
+        }
+      ]]></Code>
+    </Task>
+  </UsingTask>
+
+  <!-- Gate: only on win-x64 (the CUDA runtime is win-x64) and only when the manifest
+       shipped (i.e. this really is a split package). -->
   <PropertyGroup>
-    <AiDotNetNativeCudaPackagePath>$(MSBuildThisFileDirectory)..</AiDotNetNativeCudaPackagePath>
+    <_AiDotNetCudaEnabled Condition="('$(RuntimeIdentifier)' == 'win-x64' Or ('$(RuntimeIdentifier)' == '' And $([MSBuild]::IsOSPlatform('Windows')))) And Exists('$(MSBuildThisFileDirectory)cuda-fragments.manifest')">true</_AiDotNetCudaEnabled>
+    <_AiDotNetCudaReassembleDir>$(IntermediateOutputPath)cuda-native\</_AiDotNetCudaReassembleDir>
   </PropertyGroup>
 
-  <!-- Windows x64 -->
-  <ItemGroup Condition="'$(RuntimeIdentifier)' == 'win-x64' Or ('$(RuntimeIdentifier)' == '' And '$(Platform)' == 'x64' And $([MSBuild]::IsOSPlatform('Windows')))">
-    <None Include="$(AiDotNetNativeCudaPackagePath)\runtimes\win-x64\native\*.dll"
-          Condition="Exists('$(AiDotNetNativeCudaPackagePath)\runtimes\win-x64\native\')">
-      <Link>%(Filename)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>false</Visible>
-    </None>
-  </ItemGroup>
+  <!-- Reassemble the native DLLs from their fragment chunks into obj/. Idempotent. -->
+  <Target Name="_AiDotNetReassembleCuda" Condition="'$(_AiDotNetCudaEnabled)' == 'true'">
+    <ReassembleCudaRuntime MetaDir="$(MSBuildThisFileDirectory)"
+                           ManifestPath="$(MSBuildThisFileDirectory)cuda-fragments.manifest"
+                           DestDir="$(_AiDotNetCudaReassembleDir)" />
+  </Target>
 
-  <!-- Linux x64 -->
-  <ItemGroup Condition="'$(RuntimeIdentifier)' == 'linux-x64' Or ('$(RuntimeIdentifier)' == '' And $([MSBuild]::IsOSPlatform('Linux')))">
-    <None Include="$(AiDotNetNativeCudaPackagePath)\runtimes\linux-x64\native\*.so*"
-          Condition="Exists('$(AiDotNetNativeCudaPackagePath)\runtimes\linux-x64\native\')">
-      <Link>%(Filename)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>false</Visible>
-    </None>
-  </ItemGroup>
+  <!-- Copy the reassembled DLLs next to the app on build (so the CUDA backend's DllImports
+       resolve them at run time), mirroring the old directly-packed-DLL behaviour. Explicit
+       <Copy> rather than CopyToOutputDirectory items, because the DLLs are generated during
+       the build and dynamically-added None items don't flow into the copy machinery. -->
+  <Target Name="_AiDotNetCopyCudaToOutput"
+          AfterTargets="Build"
+          DependsOnTargets="_AiDotNetReassembleCuda"
+          Condition="'$(_AiDotNetCudaEnabled)' == 'true'">
+    <ItemGroup>
+      <_AiDotNetCudaDll Include="$(_AiDotNetCudaReassembleDir)*.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_AiDotNetCudaDll)" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
+  </Target>
+
+  <!-- And into the publish output. -->
+  <Target Name="_AiDotNetCopyCudaToPublish"
+          AfterTargets="Publish"
+          DependsOnTargets="_AiDotNetReassembleCuda"
+          Condition="'$(_AiDotNetCudaEnabled)' == 'true'">
+    <ItemGroup>
+      <_AiDotNetCudaDll Include="$(_AiDotNetCudaReassembleDir)*.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_AiDotNetCudaDll)" DestinationFolder="$(PublishDir)" SkipUnchangedFiles="true" />
+  </Target>
 
 </Project>

--- a/tools/pack-cuda-split.ps1
+++ b/tools/pack-cuda-split.ps1
@@ -1,0 +1,159 @@
+<#
+.SYNOPSIS
+  Packs AiDotNet.Native.CUDA as a set of <250 MB NuGet packages.
+
+.DESCRIPTION
+  nuget.org rejects any single package over 250 MB (HTTP 413). The CUDA 12 runtime
+  AiDotNet.Native.CUDA ships (cudart / cuBLAS / cuBLASLt / nvRTC, ~770 MB) is far over
+  that, and cuBLAS / cuBLASLt EACH exceed 250 MB on their own, so per-file packaging is
+  not enough — the payload must be byte-chunked. This is the same multi-part approach
+  TorchSharp uses to ship its multi-GB CUDA runtime through nuget.org.
+
+  Layout produced (all under the 250 MB limit, all pushed to nuget.org):
+    AiDotNet.Native.CUDA               - meta package: build/.targets + manifest, NO dlls,
+                                         depends on every fragment package below.
+    AiDotNet.Native.CUDA.Fragments.N   - one ~ChunkMiB byte-chunk of one native DLL each.
+
+  At the CONSUMER'S build, the .targets in the meta package reassembles each DLL from its
+  ordered chunks (restored via the fragment dependencies) into the build output, on
+  win-x64 only. See src/AiDotNet.Native.CUDA/build/AiDotNet.Native.CUDA.targets.
+
+.PARAMETER Version       Package version (e.g. 0.92.0).
+.PARAMETER NativeDir     Folder containing the staged CUDA *.dll (default: the package's runtimes dir).
+.PARAMETER OutDir        Where to drop the .nupkg files (default: out).
+.PARAMETER ChunkMiB      Max chunk size in MiB (default 200, safely under nuget.org's 250 MB).
+#>
+param(
+    [Parameter(Mandatory = $true)][string]$Version,
+    [string]$NativeDir = "$PSScriptRoot/../src/AiDotNet.Native.CUDA/runtimes/win-x64/native",
+    [string]$OutDir = "out",
+    [int]$ChunkMiB = 200
+)
+
+$ErrorActionPreference = "Stop"
+$chunkSize = $ChunkMiB * 1MB
+$pkgRoot = Join-Path $PSScriptRoot ".." | Resolve-Path
+$cudaProjDir = Join-Path $pkgRoot "src/AiDotNet.Native.CUDA"
+$buildDir = Join-Path $cudaProjDir "build"
+$work = Join-Path $cudaProjDir "obj/cuda-split"
+$fragDir = Join-Path $work "fragments"
+
+Remove-Item $work -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Force -Path $fragDir | Out-Null
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+New-Item -ItemType Directory -Force -Path $buildDir | Out-Null
+
+$dlls = Get-ChildItem $NativeDir -Filter *.dll -ErrorAction SilentlyContinue | Sort-Object Name
+if (-not $dlls -or $dlls.Count -eq 0) {
+    throw "No CUDA DLLs found in $NativeDir - run tools/stage-cuda-redist.ps1 first."
+}
+
+# ── 1. Split each DLL into <=ChunkMiB chunks (streamed, never loads a whole DLL) ──────
+$manifestLines = @()       # "<dll>|<totalBytes>|<chunkCount>"
+$chunkNames = @()          # ordered list of all chunk file names
+foreach ($dll in $dlls) {
+    $total = $dll.Length
+    $buffer = New-Object byte[] $chunkSize
+    $in = [System.IO.File]::OpenRead($dll.FullName)
+    try {
+        $i = 0
+        while (($read = $in.Read($buffer, 0, $chunkSize)) -gt 0) {
+            $chunkName = "{0}.{1:D3}" -f $dll.Name, $i
+            $out = [System.IO.File]::Create((Join-Path $fragDir $chunkName))
+            try { $out.Write($buffer, 0, $read) } finally { $out.Dispose() }
+            $chunkNames += $chunkName
+            $i++
+        }
+    }
+    finally { $in.Dispose() }
+    $manifestLines += "{0}|{1}|{2}" -f $dll.Name, $total, $i
+    Write-Host "  split $($dll.Name) ($([Math]::Round($total/1MB)) MB) -> $i chunk(s)"
+}
+
+# Manifest ships inside the meta package (next to the .targets) so the consumer's
+# reassembly target knows the chunk order + expected size of every DLL.
+$manifestPath = Join-Path $buildDir "cuda-fragments.manifest"
+Set-Content -Path $manifestPath -Value $manifestLines -Encoding ASCII
+Write-Host "Wrote manifest: $manifestPath ($($manifestLines.Count) DLLs, $($chunkNames.Count) chunks)"
+
+# ── 2. Pack one fragment package per chunk (each well under 250 MB) ───────────────────
+$outFull = (Resolve-Path $OutDir).Path
+function Invoke-DotnetPack([string]$csproj, [switch]$NeedsFragments) {
+    # The meta package depends on the freshly-packed fragment packages, which only exist
+    # in $OutDir yet. Use RestoreAdditionalProjectSources to ADD $OutDir to the machine's
+    # configured sources (it keeps nuget.org for the netstandard ref) — unlike `--source`,
+    # which REPLACES the source list and mangles the nuget.org URL into a relative path.
+    $extra = @()
+    if ($NeedsFragments) { $extra = @("/p:RestoreAdditionalProjectSources=$outFull") }
+    & dotnet pack $csproj -c Release -o $OutDir --nologo -v minimal "/p:PackageVersion=$Version" @extra
+    if ($LASTEXITCODE -ne 0) { throw "dotnet pack failed for $csproj" }
+}
+
+$fragmentIds = @()
+$idx = 0
+foreach ($chunkName in $chunkNames) {
+    $idx++
+    $fragId = "AiDotNet.Native.CUDA.Fragments.$idx"
+    $fragmentIds += $fragId
+    $fragProjDir = Join-Path $work "frag$idx"
+    New-Item -ItemType Directory -Force -Path $fragProjDir | Out-Null
+    $chunkAbs = (Join-Path $fragDir $chunkName)
+    @"
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <NoWarn>NU5128;NU5100</NoWarn>
+    <PackageId>$fragId</PackageId>
+    <Authors>AiDotNet Contributors</Authors>
+    <Description>CUDA runtime fragment $idx of $($chunkNames.Count) for AiDotNet.Native.CUDA. Internal payload chunk; reassembled into the full native DLLs by AiDotNet.Native.CUDA at build time. Do not reference directly.</Description>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/ooples/AiDotNet.Tensors</PackageProjectUrl>
+    <PackageTags>cuda;nvidia;gpu;native;fragment;internal</PackageTags>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="$chunkAbs" Pack="true" PackagePath="cuda-fragments/$chunkName" />
+  </ItemGroup>
+</Project>
+"@ | Set-Content -Path (Join-Path $fragProjDir "$fragId.csproj") -Encoding UTF8
+    Invoke-DotnetPack (Join-Path $fragProjDir "$fragId.csproj")
+}
+
+# ── 3. Pack the meta package: .targets + manifest + dependency on every fragment ──────
+$depXml = ($fragmentIds | ForEach-Object {
+    "    <PackageReference Include=`"$_`" Version=`"$Version`" />"
+}) -join "`n"
+
+$metaProjDir = Join-Path $work "meta"
+New-Item -ItemType Directory -Force -Path $metaProjDir | Out-Null
+@"
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <NoWarn>NU5128;NU5100</NoWarn>
+    <PackageId>AiDotNet.Native.CUDA</PackageId>
+    <Authors>AiDotNet Contributors</Authors>
+    <Company>AiDotNet</Company>
+    <Description>Native CUDA 12 runtime (cudart / cuBLAS / cuBLASLt / nvRTC) for NVIDIA GPU acceleration in AiDotNet.Tensors. The ~770 MB payload is delivered as &lt;250 MB fragment packages (nuget.org's per-package limit) and reassembled into the full DLLs at build time, on win-x64.</Description>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/ooples/AiDotNet.Tensors</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/ooples/AiDotNet.Tensors</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>cuda;nvidia;gpu;blas;native;cublas</PackageTags>
+    <!-- Dependencies on the fragment packages MUST be preserved so a consumer that adds
+         AiDotNet.Native.CUDA also restores every chunk. (Do NOT suppress.) -->
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="$buildDir/AiDotNet.Native.CUDA.targets" Pack="true" PackagePath="build/AiDotNet.Native.CUDA.targets" />
+    <None Include="$manifestPath" Pack="true" PackagePath="build/cuda-fragments.manifest" />
+  </ItemGroup>
+  <ItemGroup>
+$depXml
+  </ItemGroup>
+</Project>
+"@ | Set-Content -Path (Join-Path $metaProjDir "AiDotNet.Native.CUDA.csproj") -Encoding UTF8
+Invoke-DotnetPack (Join-Path $metaProjDir "AiDotNet.Native.CUDA.csproj") -NeedsFragments
+
+Write-Host "=== CUDA split packaging complete: 1 meta + $($fragmentIds.Count) fragment packages (each < $ChunkMiB MiB) ==="


### PR DESCRIPTION
## Problem

The **Automated Release Pipeline** fails on every push to `main` at **Push to NuGet**:

```
Pushing AiDotNet.Native.CUDA.0.92.0.nupkg ...
413 (The package file exceeds the size limit.)
```

`AiDotNet.Native.CUDA` (~770 MB NVIDIA CUDA 12 runtime) exceeds **nuget.org's 250 MB per-package limit**, so `dotnet nuget push` returns HTTP 413 and (under `bash -e`) aborts the whole release.

## Fix (industry-standard split-and-reassemble, like TorchSharp)

Skipping the package isn't a fix — it would never ship to nuget.org. Instead, split the runtime into <250 MB packages and reassemble at the consumer's build (the same approach TorchSharp uses for its multi-GB CUDA runtime). cuBLAS (~450 MB) and cuBLASLt (~500 MB) each individually exceed the limit, so this is **byte-level** chunking, not per-DLL.

- **`tools/pack-cuda-split.ps1`** — byte-chunks the staged runtime into `AiDotNet.Native.CUDA.Fragments.N` packages (each < 250 MB), writes a manifest, and packs a small **`AiDotNet.Native.CUDA`** meta package that depends on every fragment and carries the reassembly targets + manifest.
- **`build/AiDotNet.Native.CUDA.targets`** — an inline (RoslynCodeTaskFactory) task that reassembles each DLL from its ordered chunks at the consumer's build (win-x64) and copies them to the build/publish output, where the CUDA backend's DllImports resolve them.
- Push step pushes **all** packages strictly with `--skip-duplicate` (no size-skip needed now); static csproj no longer packs the oversized DLLs; release notes updated.

Consumers are unchanged: `dotnet add package AiDotNet.Native.CUDA` — the fragments restore and reassemble automatically.

## Validation

End-to-end round-trip validated locally (size-agnostic, with dummy DLLs + a real consumer build):
split → fragment packages + meta → `dotnet add package` restore → reassembly → **output DLLs byte-for-byte identical to the originals** (SHA-256 verified for cublas/cublasLt/cudart/nvrtc). The full 770 MB pack itself runs in the release job (needs the staged NVIDIA redist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)