### PR TITLE
fix(gpu): honor AIDOTNET_DISABLE_GPU in AutoDetectAndConfigureGpu

### DIFF
--- a/src/AiDotNet.Tensors/Engines/AiDotNetEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/AiDotNetEngine.cs
@@ -178,6 +178,20 @@ public static class AiDotNetEngine
     /// <returns>True if GPU was successfully configured, false otherwise.</returns>
     public static bool AutoDetectAndConfigureGpu(bool verbose)
     {
+        // Honor the AIDOTNET_DISABLE_GPU opt-out HERE, not only at module-init. Callers such as the
+        // AiModelBuilder facade re-enter this method on every BuildAsync (its default, no-GPU-config
+        // path auto-detects), so a process that disabled GPU must stay on CPU instead of repeatedly
+        // re-adopting the GPU engine (the "GPU acceleration enabled" churn seen in CPU-only runs).
+        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AIDOTNET_DISABLE_GPU")))
+        {
+            if (Current is DirectGpuTensorEngine)
+            {
+                Current = new CpuEngine();
+            }
+
+            return false;
+        }
+
         try
         {
             var gpuEngine = new DirectGpuTensorEngine();


### PR DESCRIPTION
The AIDOTNET_DISABLE_GPU opt-out was only honored in GpuAutoDetectModuleInit (assembly-load module init). AutoDetectAndConfigureGpu — which the AiModelBuilder facade re-enters on every BuildAsync via its default no-GPU-config auto-detect path — ignored it. So a CPU-only process that set AIDOTNET_DISABLE_GPU still re-adopted the GPU engine on every model build (observed as repeated "GPU acceleration enabled" log churn and an OpenCL backend spin-up in a cpu-precision run). Honor the env var in AutoDetectAndConfigureGpu too, switching back to CPU and returning false.