### PR TITLE
ci(release): don't let the oversized CUDA package block the managed NuGet publish

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -498,7 +498,27 @@ jobs:
             exit 1
           fi
 
+          # NuGet.org rejects packages larger than 250 MB with HTTP 413. The native
+          # CUDA package (cudart + cuBLAS + nvRTC redist, ~hundreds of MB) exceeds
+          # that and CANNOT be pushed to nuget.org — it ships as a GitHub Release
+          # asset instead (the github-release job attaches out/*.nupkg). Previously
+          # its 413 aborted the whole step (GitHub Actions runs bash with `set -e`,
+          # so the failing `dotnet nuget push` killed the loop before the status
+          # check), which blocked the managed AiDotNet.Tensors package — the one
+          # downstream consumers actually pin — from ever publishing. Skip
+          # over-limit packages with a warning and make per-package pushes
+          # genuinely non-fatal so one bad package can't strand the rest.
+          NUGET_MAX_BYTES=$((250 * 1000 * 1000))
+
+          set +e
+          failed=()
           for pkg in "${pkgs[@]}"; do
+            size=$(stat -c%s "$pkg")
+            if [ "$size" -gt "$NUGET_MAX_BYTES" ]; then
+              echo "::warning::Skipping $(basename "$pkg") ($((size / 1000 / 1000)) MB) — exceeds NuGet's 250 MB limit; distributed via the GitHub Release instead."
+              continue
+            fi
+
             echo "Publishing $pkg to NuGet..."
             dotnet nuget push "$pkg" \
               --api-key ${{ secrets.NUGET_API_KEY }} \
@@ -508,9 +528,17 @@ jobs:
             if [ $? -eq 0 ]; then
               echo "Successfully published $pkg"
             else
-              echo "Warning: Failed to publish $pkg (may already exist)"
+              echo "::error::Failed to publish $pkg"
+              failed+=("$pkg")
             fi
           done
+          set -e
+
+          if [ ${#failed[@]} -gt 0 ]; then
+            echo "The following under-limit packages failed to publish:"
+            printf '  %s\n' "${failed[@]}"
+            exit 1
+          fi
 
   github-release:
     name: Create GitHub Release


### PR DESCRIPTION
## Summary

Fixes the **release blocker** that has left every post-FP16 Tensors version unpublished — which in turn blocks AiDotNet PRs (e.g. #1513) that consume the new mixed-precision API.

## Root cause

The `Automated Release Pipeline` → `Push to NuGet` step loops over `out/*.nupkg` calling `dotnet nuget push`. NuGet.org rejects packages over **250 MB** with **HTTP 413**, and the native `AiDotNet.Native.CUDA` package (cudart + cuBLAS + the nvRTC redist added in #559) now exceeds that limit.

GitHub Actions runs `bash` with `set -e`, so the failing `dotnet nuget push` on the oversized CUDA package **aborted the entire step** before the existing `if [ $? -eq 0 ]` warning could run. Result: the managed **`AiDotNet.Tensors`** package — the one downstream consumers actually pin — never got pushed.

Concretely, the release for `821316e7` ("FP16 path … [#558]") failed exactly this way:
```
Pushing AiDotNet.Native.CUDA.0.92.0.nupkg ...
error: Response status code does not indicate success: 413 (The package file exceeds the size limit...).
##[error]Process completed with exit code 1.
```
So `AiDotNet.Tensors 0.92.0` (which exports `MixedPrecisionCompiledPlan`) is **absent from NuGet** despite building and testing green — and AiDotNet #1513 fails to compile with `CS0246: MixedPrecisionCompiledPlan could not be found` against the latest published 0.91.12 (verified: the type is not in 0.91.12's DLL).

## Fix

In the push loop:
- **Skip packages over 250 MB** with a `::warning::` — they can't go to nuget.org and already ship as GitHub Release assets (the `github-release` job attaches `out/*.nupkg`).
- **Make per-package pushes non-fatal** (`set +e` around the loop, aggregate failures), so one bad package can't strand the rest. The job still fails if an *under-limit* package fails to push.

The oversized native CUDA package can no longer block the managed package.

## After merge

This push to `main` triggers the release pipeline, which will publish the managed `AiDotNet.Tensors` package (skipping the oversized CUDA package). Once that version is on NuGet, AiDotNet #1513's pin can be bumped to it and it will compile.

## Verification

- `bash -n` clean on the rewritten step; workflow YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
