### PR TITLE
perf(blas): close managed GEMM gap — routing + parallelism + deterministic 6×16 microkernel (audit-driven)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,10 +55,25 @@ jobs:
       run: |
         dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --configuration Release --no-build --verbosity normal --framework net10.0 \
           --filter "Category!=Benchmark&Category!=Performance" \
+          --blame-hang --blame-hang-timeout 300s --blame-crash \
           --collect:"XPlat Code Coverage" \
           --results-directory ./coverage \
           -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura \
           DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude="[*]AiDotNet.Tensors.Engines.DirectGpu.*,[*]AiDotNet.Tensors.Engines.Cu*,[*]AiDotNet.Tensors.Engines.ClBlast*,[*]AiDotNet.Tensors.Engines.OpenCl*"
+
+    # If --blame-hang-timeout (a test made no progress for 300s) or --blame-crash (test host
+    # native-crashed, e.g. a CUDA-finalizer 0xC0000005) fired, the hang/crash dump + the
+    # Sequence_*.xml naming the culprit test land under ./coverage. Upload them so the
+    # intermittent deadlock can be diagnosed instead of the run silently stalling for hours.
+    - name: Upload hang/crash dumps
+      uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: blame-dumps
+        path: |
+          ./coverage/**/*.dmp
+          ./coverage/**/Sequence_*.xml
+        if-no-files-found: ignore
 
     - name: Test enterprise license validator
       run: dotnet test build/LicenseValidator.Tests/AiDotNet.Tensors.LicenseValidator.Tests.csproj --configuration Release --verbosity normal

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
       run: |
         dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --configuration Release --no-build --verbosity normal --framework net10.0 \
           --filter "Category!=Benchmark&Category!=Performance" \
-          --blame-hang --blame-hang-timeout 300s --blame-crash \
+          --blame-hang --blame-hang-timeout 600s --blame-crash \
           --collect:"XPlat Code Coverage" \
           --results-directory ./coverage \
           -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,13 +53,20 @@ jobs:
 
     - name: Test with Coverage
       run: |
+        # Coverage Exclude: GPU backends (can't run in CI) PLUS the hand-vectorized numerical
+        # kernels (Engines.Simd.* / Engines.BlasManaged.*). Coverlet line-instruments every
+        # iteration of those tight AVX/GEMM inner loops, which made GEMM-heavy training/leak tests
+        # 40x+ slower under coverage (a single 4-layer-transformer leak test: ~6s -> ~4m26s, tipping
+        # past the hang timeout under CI CPU contention). Excluding them drops that test to ~28s and
+        # the whole suite by most of an hour. Line coverage of hand-emitted SIMD intrinsics is not
+        # meaningful anyway, and those kernels are exercised by every numerical test regardless.
         dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --configuration Release --no-build --verbosity normal --framework net10.0 \
           --filter "Category!=Benchmark&Category!=Performance" \
           --blame-hang --blame-hang-timeout 600s --blame-crash \
           --collect:"XPlat Code Coverage" \
           --results-directory ./coverage \
           -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura \
-          DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude="[*]AiDotNet.Tensors.Engines.DirectGpu.*,[*]AiDotNet.Tensors.Engines.Cu*,[*]AiDotNet.Tensors.Engines.ClBlast*,[*]AiDotNet.Tensors.Engines.OpenCl*"
+          DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude="[*]AiDotNet.Tensors.Engines.DirectGpu.*,[*]AiDotNet.Tensors.Engines.Cu*,[*]AiDotNet.Tensors.Engines.ClBlast*,[*]AiDotNet.Tensors.Engines.OpenCl*,[*]AiDotNet.Tensors.Engines.Simd.*,[*]AiDotNet.Tensors.Engines.BlasManaged.*"
 
     # If --blame-hang-timeout (a test made no progress for 300s) or --blame-crash (test host
     # native-crashed, e.g. a CUDA-finalizer 0xC0000005) fired, the hang/crash dump + the

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
@@ -218,6 +218,32 @@ public static partial class BlasManaged
     /// Defaults when omitted: no epilogue, single-threaded, no autotune key.
     /// </para>
     /// </summary>
+    // Shapes where the cache-blocking packed strategy (Dispatcher → PackBoth) beats the
+    // #409 machine-code microkernel in PRODUCTION (deterministic) mode, so the Sub-S
+    // interception below should DEFER to the strategy path instead. Measured by
+    // ManagedVsNativeGemmAudit (perf/managed-blas-vs-native-audit) on a 32-core Ryzen:
+    //   • thin-N (n < 128, k ≥ 128): the 6×Nr microkernel can't fill its Nr-wide tile when
+    //     n is tiny → idle SIMD lanes. Packed wins ~3.6× for BOTH dtypes (4096×512×16:
+    //     float 22→80, double 14→50 GF/s).
+    //   • very large work (≥ 4e9): aggressive cache blocking pays for both dtypes
+    //     (2048³: float 290→462, double 285→319). 1024³ (1.07e9) stays on the microkernel
+    //     (153>81), so the cutoff is above it.
+    //   • FP32-only wide-N / wide-K skew (FFN): packed wins big (512×512×2048 106→174;
+    //     512×2048×512 101→177). FP64 is EXCLUDED — its microkernel BEATS packed on FFN
+    //     (512×512×2048 double: 187 microkernel vs 80 packed), so FP64 falls through to the
+    //     microkernel for these shapes.
+    // The microkernel still wins (and is kept) for small/medium near-square shapes
+    // (512³, 256×784×128, 128×64×256), where its low per-call overhead dominates.
+    private static bool PrefersStrategyOverMachineKernel(int m, int n, int k, bool isFloat)
+    {
+        if (n < 128 && k >= 128) return true;                 // thin-N (both dtypes)
+        if ((long)m * n * k >= 4_000_000_000L) return true;   // very large (both dtypes)
+        if (!isFloat) return false;                            // FP64 microkernel is competitive on the rest
+        if (n >= 1024 && n > 2L * m) return true;              // FP32 wide-N skew (FFN-up)
+        if (k >= 1024 && k > 2L * m) return true;              // FP32 wide-K skew (FFN-down)
+        return false;
+    }
+
     public static void Gemm<T>(
         ReadOnlySpan<T> a, int lda, bool transA,
         ReadOnlySpan<T> b, int ldb, bool transB,
@@ -316,6 +342,7 @@ public static partial class BlasManaged
             var epi409 = options.Epilogue;
             if (mkAvail && m >= mkMr && n >= mkNr
                 && (long)m * n * k >= MachineKernelMinWork
+                && !PrefersStrategyOverMachineKernel(m, n, k, typeof(T) == typeof(float))
                 && EpilogueFlagsCompute.Compute(in epi409) == EpilogueFlags.None)
             {
                 int mAl = m - (m % mkMr); // interior rows (× Mr)

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
@@ -436,6 +436,18 @@ public static partial class BlasManaged
             ? PickMicrokernelTile<T>()
             : PickMicrokernelTilePrePack<T>();
 
+        // The FP32 6×16 kernel is PackBoth-ONLY: PackAOnly's strided-B path uses an 8×8
+        // (Avx2Fp32_8x8) tile, so the tail-split alignment and packing layout must stay on 8×8
+        // when the dispatcher picked PackAOnly. Without this, the interior is aligned to mr=6 and
+        // then handed to PackAOnly, which needs a multiple of 8 and slices out of range
+        // (ArgumentOutOfRangeException). PackBoth keeps the faster 6×16 tile.
+        if (strategy == PackingMode.ForcePackAOnly && typeof(T) == typeof(float)
+            && mr == 6 && Avx2Fp32_8x8.IsSupported)
+        {
+            mr = 8;
+            nr = 8;
+        }
+
         // Sub-D4 (#372 follow-up): partial-M/N tail splitting. When the shape is
         // big enough for the SIMD tile (m >= mr AND n >= nr) but not aligned
         // (m % mr != 0 OR n % nr != 0), split the work into:
@@ -462,18 +474,37 @@ public static partial class BlasManaged
         // get an inner options with Epilogue stripped to avoid double-application.
         int splitMAligned = m - (m % mr);
         int splitNAligned = n - (n % nr);
-        // Honor NumThreads = -1 as explicit single-thread (deterministic mode).
-        // Pre-fix: -1 fell into the "> 0 is false" branch and used all processors,
-        // breaking determinism/perf expectations. PR #402 CodeRabbit fix.
-        int splitProcs = options.NumThreads switch
+        // CORRECTNESS (reproducibility): the tail-split decomposition — aligned interior via the
+        // SIMD microkernel + Streaming for the M/N tails — picks which kernel computes each output
+        // element. It MUST be a function of the shape and the MACHINE only, never the per-call
+        // thread count, or the same shape takes a different path (and a different microkernel) at
+        // different thread counts and the output stops being bit-identical across them, violating
+        // the deterministic-mode contract. The old gate used options.NumThreads, so a tailed shape
+        // tail-split at NumThreads=1 (interior on the fast kernel) but fell through to all-Streaming
+        // at NumThreads=N — different bits. This was a LATENT reproducibility bug that the FP32 6×16
+        // tile (Mr=6 leaves an M-tail on most shapes) exposes; 8×8 only escaped because the test
+        // shapes are 8-aligned. Gate on the fixed machine core count instead — a thread-count-
+        // INVARIANT measure of "is the aligned interior big enough for its fast kernel to beat
+        // all-Streaming?" The actual parallel degree still honours options.NumThreads downstream.
+        int gateProcs = System.Environment.ProcessorCount;
+        if (m >= mr && n >= nr && (m % mr != 0 || n % nr != 0))
         {
-            -1 => 1,
-            > 0 => options.NumThreads,
-            _ => System.Environment.ProcessorCount,
-        };
-        if (m >= mr && n >= nr && (m % mr != 0 || n % nr != 0)
-            && splitMAligned >= splitProcs * mr)
-        {
+            if (splitMAligned < gateProcs * mr && options.PackingMode == PackingMode.Auto)
+            {
+                // Auto + too few aligned mr-blocks for the packed kernel to beat all-Streaming,
+                // and a tail IS present — route the WHOLE shape to Streaming, which handles the
+                // m%mr / n%nr tails internally and parallelizes the N axis. Decided by the fixed
+                // machine core count (NOT options.NumThreads), so the same shape takes this path
+                // at every thread count → bit-identical across thread counts. Force* pack modes
+                // skip this and tail-split below (the caller explicitly asked for that strategy);
+                // the tail-split keeps PackBoth's "caller guarantees m%mr==0" contract intact (it
+                // never receives an unaligned m, which it would silently skip).
+                StreamingStrategy.Run<T>(a, lda, transA, b, ldb, transB, c, ldc, m, n, k, in options);
+                var streamWholeEpi = options.Epilogue;
+                EpilogueChain.Apply<T>(c, ldc, m, n, in streamWholeEpi);
+                return;
+            }
+
             int m_aligned = splitMAligned;
             int n_aligned = splitNAligned;
             int m_tail = m - m_aligned;
@@ -1054,7 +1085,7 @@ public static partial class BlasManaged
             // boundary, a row flips between 6×16 and Streaming and the output stops being
             // bit-identical across thread counts (verified: 6×16 fails 4 bit-exact tests, incl.
             // DeterministicParallelGemmContractTests at m=16). Acceptable only in Fast mode.
-            if (!Helpers.BlasProvider.IsDeterministicMode && Avx2Fp32_6x16.IsSupported) return (6, 16);
+            if (Avx2Fp32_6x16.IsSupported) return (6, 16);   // now deterministic too — see gate fix in Gemm
             if (Avx2Fp32_8x8.IsSupported) return (8, 8);
             if (NeonFp32_8x4.IsSupported) return (8, 4);
             return (4, 4);

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
@@ -605,6 +605,31 @@ public static partial class BlasManaged
             kcFromAutotune = options.PackedB.TileKc;
         }
 
+        // Parallelism floor (PackBoth, no pre-pack): the autotuner sizes mc/nc for cache, but
+        // on high core counts a shape can yield fewer (m/mc)×(n/nc) blocks than cores, leaving
+        // cores idle. When N fits a single nc-block the 2D MN-grid can't add N-parallelism
+        // (PackBothStrategy handles the multi-N-block case), so the only lever is mc. Shrink it
+        // toward ~procs M-blocks — bounded to a multiple of mr (panels stay tile-aligned) and
+        // never below 2·mr — so e.g. FFN-down 512×2048×512 (mc=64 → 8 M-blocks on 32 cores)
+        // parallelizes across all cores via the shared-B M-axis path (no redundant B-pack).
+        //
+        // Gated to LARGE K (≥1024): a smaller mc means more A-panels and thus more pack passes,
+        // which only pays off when K is large enough to amortize the pack over the FMA work.
+        // On small-K shapes (e.g. 640³, K=640) the extra pack overhead dominates and the shrink
+        // REGRESSES — so leave those on the autotuner's larger mc.
+        if (strategy == PackingMode.ForcePackBoth && k >= 1024
+            && options.PackedA is null && options.PackedB is null && procs > 1)
+        {
+            int numNB = (n + ncFromAutotune - 1) / ncFromAutotune;
+            int numMB = (m + mcFromAutotune - 1) / mcFromAutotune;
+            if (numNB == 1 && numMB < procs && mcFromAutotune > 2 * mr)
+            {
+                int targetMc = Math.Max(2 * mr, (m + procs - 1) / procs);
+                targetMc = ((targetMc + mr - 1) / mr) * mr; // round up to a whole mr tile
+                if (targetMc < mcFromAutotune) mcFromAutotune = targetMc;
+            }
+        }
+
         switch (strategy)
         {
             case PackingMode.ForcePackBoth:

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
@@ -648,6 +648,11 @@ public static partial class BlasManaged
         // which only pays off when K is large enough to amortize the pack over the FMA work.
         // On small-K shapes (e.g. 640³, K=640) the extra pack overhead dominates and the shrink
         // REGRESSES — so leave those on the autotuner's larger mc.
+        //
+        // NOTE: this is deliberately limited to numNB==1 (genuinely under-parallelized, ≤8 blocks).
+        // Extending it to multi-N-block shapes (e.g. 1024³, mc=64 → 16 M-blocks) REGRESSED them:
+        // the box is 16 PHYSICAL cores (32 SMT threads) and compute-bound GEMM gets nothing from
+        // SMT, so 16 M-blocks already saturates the cores — shrinking mc only shrinks the panels.
         if (strategy == PackingMode.ForcePackBoth && k >= 1024
             && options.PackedA is null && options.PackedB is null && procs > 1)
         {

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
@@ -236,11 +236,23 @@ public static partial class BlasManaged
     // (512³, 256×784×128, 128×64×256), where its low per-call overhead dominates.
     private static bool PrefersStrategyOverMachineKernel(int m, int n, int k, bool isFloat)
     {
+        long work = (long)m * n * k;
         if (n < 128 && k >= 128) return true;                 // thin-N (both dtypes)
-        if ((long)m * n * k >= 4_000_000_000L) return true;   // very large (both dtypes)
-        if (!isFloat) return false;                            // FP64 microkernel is competitive on the rest
-        if (n >= 1024 && n > 2L * m) return true;              // FP32 wide-N skew (FFN-up)
-        if (k >= 1024 && k > 2L * m) return true;              // FP32 wide-K skew (FFN-down)
+        if (!isFloat)
+            // FP64 microkernel is competitive on FFN and mid squares (1024³ double 211 > packed
+            // 172); packed only pays at very large work (2048³: 316 -> 323). So FP64 defers only
+            // for thin-N (above) and the very-large tail.
+            return work >= 4_000_000_000L;
+        // FP32: the cache-blocking packed strategy wins on all mid-large work — squares from
+        // ~640³ (microkernel 110 -> packed ~192 GF/s; 1024³ 178 -> 315; stable across runs) and
+        // FFN (106 -> 174) — and on wide-N/wide-K skew. The microkernel only leads on SMALL
+        // near-square shapes (512³ 552, 256×784×128 674), where packing overhead would crater
+        // the packed path (512³ packed is only 45 GF/s). The cutoff sits just below 640³
+        // (2.6e8) and safely above 512³ (1.3e8) — conservative because mis-routing a small shape
+        // to the packed path is a ~12× loss, while mis-keeping a mid shape on the microkernel is mild.
+        if (work >= 250_000_000L) return true;                // FP32 mid-large (squares ≥ ~640³, FFN)
+        if (n >= 1024 && n > 2L * m) return true;             // FP32 wide-N skew below the cutoff
+        if (k >= 1024 && k > 2L * m) return true;             // FP32 wide-K skew below the cutoff
         return false;
     }
 

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
@@ -1048,9 +1048,12 @@ public static partial class BlasManaged
             if (Avx512Fp32_16x16.IsSupported) return (16, 16);
             // #409 S.3: the higher-arithmetic-intensity 6×16 kernel (1.5 FMA/load, ~66% of
             // peak vs the load-bound 8×8's ~0.89 / ~49-59%) is used in FAST (non-deterministic)
-            // mode only. Deterministic mode keeps 8×8 because 6×16's different float reduction
-            // order would break the bit-exact invariant the Streaming bypass / serial-vs-parallel
-            // paths assert — acceptable only where bit-reproducibility isn't promised (Fast mode).
+            // mode only. Deterministic mode keeps 8×8 because 6×16's Mr=6 leaves an M-tail on
+            // most shapes that gets computed by Streaming, and 6×16's interior bits do NOT match
+            // Streaming's (8×8's DO) — so when the parallel M-split shifts the interior/tail
+            // boundary, a row flips between 6×16 and Streaming and the output stops being
+            // bit-identical across thread counts (verified: 6×16 fails 4 bit-exact tests, incl.
+            // DeterministicParallelGemmContractTests at m=16). Acceptable only in Fast mode.
             if (!Helpers.BlasProvider.IsDeterministicMode && Avx2Fp32_6x16.IsSupported) return (6, 16);
             if (Avx2Fp32_8x8.IsSupported) return (8, 8);
             if (NeonFp32_8x4.IsSupported) return (8, 4);

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
@@ -666,6 +666,29 @@ public static partial class BlasManaged
             }
         }
 
+        // A-repack reduction (run AFTER the floor so it doesn't perturb the floor's numNB check):
+        // the M-axis path re-packs A[ic,pc] once per nc-panel because the jc loop is outermost, so
+        // numNB nc-blocks means A is packed numNB times. The autotuner sizes nc for L2 B-residency
+        // (~512), but the kernel only ever reads a Kc×Nr B micro-panel (L1-sized) at a time — the
+        // full Kc×Nc B-panel merely has to fit L3. So widen nc to span all of N when the Kc×N panel
+        // fits an L3 budget: numNB collapses to 1 and A is packed ONCE (this is why OpenBLAS uses a
+        // large Nc). Pure win — fewer pack passes, identical reduction order (bit-exact).
+        if (strategy == PackingMode.ForcePackBoth
+            && options.PackedA is null && options.PackedB is null)
+        {
+            int elemSz = System.Runtime.CompilerServices.Unsafe.SizeOf<T>();
+            const long L3PanelBudgetBytes = 8L * 1024 * 1024;
+            long fullPanelBytes = (long)kcFromAutotune * n * elemSz;
+            int numMBnow = (m + mcFromAutotune - 1) / mcFromAutotune;
+            // Skip 2D-eligible shapes (few M-blocks, numMB*4 ≤ procs): they rely on the 2D MN-grid's
+            // N-parallelism, and collapsing numNB to 1 here would disable 2D and strand them on a
+            // thin M-axis split (e.g. FFN-up 512×512×2048 → numMB=8 wants 2D's 32-way, not M-axis 8).
+            if (numMBnow * 4 > procs && n > ncFromAutotune && fullPanelBytes <= L3PanelBudgetBytes)
+            {
+                ncFromAutotune = ((n + nr - 1) / nr) * nr; // span all of N → numNB == 1, A packed once
+            }
+        }
+
         switch (strategy)
         {
             case PackingMode.ForcePackBoth:

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
@@ -674,18 +674,28 @@ public static partial class BlasManaged
         // fits an L3 budget: numNB collapses to 1 and A is packed ONCE (this is why OpenBLAS uses a
         // large Nc). Pure win — fewer pack passes, identical reduction order (bit-exact).
         if (strategy == PackingMode.ForcePackBoth
-            && options.PackedA is null && options.PackedB is null)
+            && options.PackedA is null && options.PackedB is null && m >= 256)
         {
             int elemSz = System.Runtime.CompilerServices.Unsafe.SizeOf<T>();
             const long L3PanelBudgetBytes = 8L * 1024 * 1024;
             long fullPanelBytes = (long)kcFromAutotune * n * elemSz;
-            int numMBnow = (m + mcFromAutotune - 1) / mcFromAutotune;
-            // Skip 2D-eligible shapes (few M-blocks, numMB*4 ≤ procs): they rely on the 2D MN-grid's
-            // N-parallelism, and collapsing numNB to 1 here would disable 2D and strand them on a
-            // thin M-axis split (e.g. FFN-up 512×512×2048 → numMB=8 wants 2D's 32-way, not M-axis 8).
-            if (numMBnow * 4 > procs && n > ncFromAutotune && fullPanelBytes <= L3PanelBudgetBytes)
+            if (n > ncFromAutotune && fullPanelBytes <= L3PanelBudgetBytes)
             {
                 ncFromAutotune = ((n + nr - 1) / nr) * nr; // span all of N → numNB == 1, A packed once
+
+                // With numNB now == 1, A is packed ONCE regardless of mc (total A-pack = M×K either
+                // way), so the small-mc A-repack penalty that the floor avoids no longer applies.
+                // That lets a wide-N moderate-M shape (e.g. FFN-up 512×512×2048, numMB=8) fill the
+                // cores via the shared-B M-axis with NO redundant B-pack — strictly better than the
+                // 2D grid, which re-packs B per ic-block. Shrink mc to ~physical M-blocks when under.
+                int physicalCores = Math.Max(1, procs / 2); // 2-way SMT assumption
+                int numMBwide = (m + mcFromAutotune - 1) / mcFromAutotune;
+                if (numMBwide < physicalCores && mcFromAutotune > 2 * mr)
+                {
+                    int targetMc = Math.Max(2 * mr, (m + physicalCores - 1) / physicalCores);
+                    targetMc = ((targetMc + mr - 1) / mr) * mr; // round up to a whole mr tile
+                    if (targetMc < mcFromAutotune) mcFromAutotune = targetMc;
+                }
             }
         }
 

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
@@ -937,6 +937,10 @@ internal static class PackBothStrategy
                 return;
             }
             // #409 S.3: higher-intensity 6×16 FP32 tile (Fast-mode default via SelectMrNr).
+            // NOTE: tried driving the AVX2 6×16 MACHINE-CODE kernel here — it REGRESSED (per-
+            // micro-tile fixed + indirect-call overhead; 1024³ 393→369, FFN-up 266→210). The
+            // C# kernel already saturates the harness, so the kernel is NOT the bottleneck in
+            // PackBoth — the gap to native is the macro-harness (packing / blocking / bandwidth).
             if (mr == 6 && nr == 16 && Avx2Fp32_6x16.IsSupported)
             {
                 Avx2Fp32_6x16.Run(

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
@@ -116,8 +116,14 @@ internal static class PackBothStrategy
             // Threshold 256 = empirical from baseline-after-B5 sweep on
             // x64-amd-avx2-cpu16. Future autotune (#374 F.3 deferred) should
             // measure both paths per-shape and cache the winner.
+            // The m < 256 guard kept moderate-M shapes on the M-axis path (where its shared
+            // packed-B avoids 2D's redundant per-thread B-pack). But on high core counts a
+            // wide-N shape with moderate M (e.g. FFN 512×512×2048: numMBlocks≈2-4 vs 32 cores)
+            // leaves ≥75% of cores idle on the M-axis path — there the extra MN parallelism of
+            // the 2D grid wins despite the redundant B-pack. So ALSO take 2D when the M-axis
+            // would use ≤ a quarter of the cores (numMBlocks*4 < procs), regardless of absolute M.
             bool use2D = MN2DDriver.ShouldUse2DGrid(numMBlocks, numNBlocks, procs)
-                         && m < 256;
+                         && (m < 256 || numMBlocks * 4 <= procs);
 
             // Pin a, b, c for the duration of the parallel region. Both paths use
             // unsafe pointer access from worker threads.

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -24,6 +24,16 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
     // the whole process. The OS reclaims device memory + the context at exit anyway.
     private static bool IsRuntimeTearingDown => RuntimeShutdown.IsTearingDown;
 
+    // Live CUDA contexts. A device-buffer finalizer must NOT free against a context that has already
+    // been destroyed — under per-test engine teardown (each test builds its own CudaBackend/context),
+    // a buffer that escapes explicit Dispose is GC-finalized LATER and would call cuCtxPushCurrent /
+    // cuMemFree on a dead context, raising an uncatchable, finalizer-fatal 0xC0000005 that kills the
+    // whole process (the documented "no suite crash" hazard — IsRuntimeTearingDown only covers PROCESS
+    // exit, not per-test context destruction). cuCtxDestroy already reclaimed that buffer's memory, so
+    // the finalizer skips the native free when its context is no longer registered here. Added at
+    // cuCtxCreate, removed immediately before cuCtxDestroy.
+    internal static readonly ConcurrentDictionary<IntPtr, byte> LiveContexts = new();
+
     private const int DefaultBlockSize = 256;
     private const int MaxRnnBlockSize = 1024;
     private readonly ConcurrentDictionary<string, IntPtr> _kernelCache;
@@ -271,6 +281,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
             MaxBufferAllocBytes = (long)totalMem;
 
             CuBlasNative.CheckCudaResult(CuBlasNative.cuCtxCreate(out _cudaContext, 0, device), "cuCtxCreate");
+            LiveContexts[_cudaContext] = 0; // register: a buffer finalizer may only free against a live context
             CuBlasNative.CheckCudaResult(CudaNativeBindings.cuStreamCreate(out _stream, 0), "cuStreamCreate");
             _defaultStream = new CudaStream(this, _stream, GpuStreamType.Default, ownsHandle: false);
 
@@ -13660,6 +13671,9 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
 
         if (_cudaContext != IntPtr.Zero)
         {
+            // Unregister BEFORE destroy so any buffer finalized after this point skips its native
+            // free (its memory is reclaimed by cuCtxDestroy below) instead of faulting on a dead context.
+            LiveContexts.TryRemove(_cudaContext, out _);
             CuBlasNative.cuCtxDestroy(_cudaContext);
             _cudaContext = IntPtr.Zero;
         }
@@ -14433,7 +14447,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
                 // Skip the native free at process exit (the driver is gone — any native CUDA
                 // call FATAL-crashes, uncatchable); otherwise free, suppressing any disposal
                 // error so a finalizer can't crash.
-                if (_context != IntPtr.Zero && !ProcessExiting)
+                if (_context != IntPtr.Zero && !ProcessExiting && LiveContexts.ContainsKey(_context))
                 {
                     try
                     {
@@ -14517,7 +14531,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
                 // Skip the native free at process exit (the driver is gone — any native CUDA
                 // call FATAL-crashes, uncatchable); otherwise free, suppressing any disposal
                 // error so a finalizer can't crash.
-                if (_context != IntPtr.Zero && !ProcessExiting)
+                if (_context != IntPtr.Zero && !ProcessExiting && LiveContexts.ContainsKey(_context))
                 {
                     try
                     {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -34,6 +34,14 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
     // cuCtxCreate, removed immediately before cuCtxDestroy.
     internal static readonly ConcurrentDictionary<IntPtr, byte> LiveContexts = new();
 
+    // Serializes a buffer's native free against its context's destruction. The LiveContexts check
+    // alone is a TOCTOU race: a GC-thread buffer finalizer can observe its context as live, then a
+    // concurrent engine Dispose removes + cuCtxDestroys it, and the finalizer's cuCtxPushCurrent /
+    // cuMemFree then hit the just-freed context → uncatchable 0xC0000005. Holding this lock across
+    // {check-live + free} on the finalizer side and {remove + cuCtxDestroy} on the dispose side makes
+    // the two mutually exclusive: a buffer either frees before the destroy or is skipped after it.
+    internal static readonly object ContextLifecycleLock = new();
+
     private const int DefaultBlockSize = 256;
     private const int MaxRnnBlockSize = 1024;
     private readonly ConcurrentDictionary<string, IntPtr> _kernelCache;
@@ -3939,6 +3947,52 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         args[2] = &r;
         args[3] = &c;
         LaunchKernel2D(kernel, gridX, gridY, DefaultBlockSize, 1, args);
+    }
+
+    // CUDA's "current context" is PER-THREAD: cuCtxCreate makes the context current only on the
+    // CREATING thread. This backend otherwise never re-establishes it, so every native call assumes
+    // it runs on that thread. Under xUnit's parallel / thread-pooled test execution (and any caller
+    // that drives a GPU op from a different thread than the one that built the engine), the executing
+    // thread may have NO context — or a DIFFERENT engine's context — current, so cuLaunchKernel /
+    // cuMemcpy / cuMemAlloc operate on the wrong context and fault with an uncatchable 0xC0000005.
+    // Re-assert this engine's context on the calling thread before native work. cuCtxSetCurrent is a
+    // cheap per-thread driver call (no cross-thread effect); skipped once the context is torn down.
+    internal void EnsureContextCurrent()
+    {
+        IntPtr ctx = _cudaContext;
+        if (ctx != IntPtr.Zero && !IsRuntimeTearingDown && LiveContexts.ContainsKey(ctx))
+            CudaNativeBindings.cuCtxSetCurrent(ctx);
+        DrainPendingFinalizerFrees();
+    }
+
+    // Device frees DEFERRED from buffer FINALIZERS. Calling the CUDA driver (cuCtxPushCurrent /
+    // cuMemFree) from the GC finalizer thread races with op threads' driver entry and faults with an
+    // uncatchable 0xC0000005 under the heavy GC the full test suite produces (DirectGpu-only, with low
+    // GC, never crashes). Instead the finalizer just enqueues the pointer, and the free runs here on a
+    // real op thread (with this engine's context current) at the next GPU op. A pending entry whose
+    // context was meanwhile destroyed is dropped — cuCtxDestroy already reclaimed that memory.
+    internal static readonly ConcurrentQueue<(IntPtr Ptr, IntPtr Ctx, IntPtr Stream)> PendingFinalizerFrees = new();
+
+    internal static void DrainPendingFinalizerFrees()
+    {
+        while (PendingFinalizerFrees.TryDequeue(out var f))
+        {
+            if (f.Ptr == IntPtr.Zero) continue;
+            lock (ContextLifecycleLock)
+            {
+                if (f.Ctx == IntPtr.Zero || IsRuntimeTearingDown || ProcessExiting
+                    || !LiveContexts.ContainsKey(f.Ctx))
+                    continue; // context gone — its device memory was reclaimed by cuCtxDestroy
+                try
+                {
+                    CuBlasNative.cuCtxPushCurrent(f.Ctx);
+                    if (f.Stream != IntPtr.Zero) CuBlasNative.cuMemFreeAsync(f.Ptr, f.Stream);
+                    else CuBlasNative.cuMemFree(f.Ptr);
+                    CuBlasNative.cuCtxPopCurrent(out _);
+                }
+                catch { }
+            }
+        }
     }
 
     private unsafe void LaunchKernel(IntPtr kernel, uint gridX, uint blockX, void** args)
@@ -13671,11 +13725,16 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
 
         if (_cudaContext != IntPtr.Zero)
         {
-            // Unregister BEFORE destroy so any buffer finalized after this point skips its native
-            // free (its memory is reclaimed by cuCtxDestroy below) instead of faulting on a dead context.
-            LiveContexts.TryRemove(_cudaContext, out _);
-            CuBlasNative.cuCtxDestroy(_cudaContext);
-            _cudaContext = IntPtr.Zero;
+            // Unregister + destroy under the lifecycle lock so a concurrent buffer finalizer can't
+            // observe the context as live and then fault on it after we destroy it (TOCTOU). A buffer
+            // finalized after this point sees it gone and skips its native free (cuCtxDestroy reclaims
+            // that memory anyway).
+            lock (ContextLifecycleLock)
+            {
+                LiveContexts.TryRemove(_cudaContext, out _);
+                CuBlasNative.cuCtxDestroy(_cudaContext);
+                _cudaContext = IntPtr.Zero;
+            }
         }
 
         GC.SuppressFinalize(this);
@@ -14447,21 +14506,26 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
                 // Skip the native free at process exit (the driver is gone — any native CUDA
                 // call FATAL-crashes, uncatchable); otherwise free, suppressing any disposal
                 // error so a finalizer can't crash.
-                if (_context != IntPtr.Zero && !ProcessExiting && LiveContexts.ContainsKey(_context))
+                // Hold the lifecycle lock across the live-check + free so a concurrent engine Dispose
+                // can't cuCtxDestroy this context between the check and the cuCtxPushCurrent/free.
+                lock (ContextLifecycleLock)
                 {
-                    try
+                    if (_context != IntPtr.Zero && !ProcessExiting && LiveContexts.ContainsKey(_context))
                     {
-                        CuBlasNative.cuCtxPushCurrent(_context);
-                        // Stream-ordered free (#558 layer 6): race-safe + pool-reused in stream order.
-                        if (_asyncFreeStream != IntPtr.Zero)
-                            CuBlasNative.cuMemFreeAsync(_devicePtr, _asyncFreeStream);
-                        else
-                            CuBlasNative.cuMemFree(_devicePtr);
-                        CuBlasNative.cuCtxPopCurrent(out _);
-                    }
-                    catch
-                    {
-                        // Suppress disposal errors to avoid crashing finalizers.
+                        try
+                        {
+                            CuBlasNative.cuCtxPushCurrent(_context);
+                            // Stream-ordered free (#558 layer 6): race-safe + pool-reused in stream order.
+                            if (_asyncFreeStream != IntPtr.Zero)
+                                CuBlasNative.cuMemFreeAsync(_devicePtr, _asyncFreeStream);
+                            else
+                                CuBlasNative.cuMemFree(_devicePtr);
+                            CuBlasNative.cuCtxPopCurrent(out _);
+                        }
+                        catch
+                        {
+                            // Suppress disposal errors to avoid crashing finalizers.
+                        }
                     }
                 }
             }
@@ -14495,7 +14559,13 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
 
         ~CudaGpuBuffer()
         {
-            Release();
+            // NEVER call the CUDA driver on the GC finalizer thread (races with op threads →
+            // 0xC0000005). Defer the device free to a real op thread via the pending-free queue.
+            var ptr = _devicePtr;
+            if (ptr != IntPtr.Zero && !IsRuntimeTearingDown && !ProcessExiting)
+                PendingFinalizerFrees.Enqueue((ptr, _context, _asyncFreeStream));
+            _devicePtr = IntPtr.Zero;
+            _context = IntPtr.Zero;
         }
     }
 
@@ -14531,21 +14601,26 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
                 // Skip the native free at process exit (the driver is gone — any native CUDA
                 // call FATAL-crashes, uncatchable); otherwise free, suppressing any disposal
                 // error so a finalizer can't crash.
-                if (_context != IntPtr.Zero && !ProcessExiting && LiveContexts.ContainsKey(_context))
+                // Hold the lifecycle lock across the live-check + free so a concurrent engine Dispose
+                // can't cuCtxDestroy this context between the check and the cuCtxPushCurrent/free.
+                lock (ContextLifecycleLock)
                 {
-                    try
+                    if (_context != IntPtr.Zero && !ProcessExiting && LiveContexts.ContainsKey(_context))
                     {
-                        CuBlasNative.cuCtxPushCurrent(_context);
-                        // Stream-ordered free (#558 layer 6): race-safe + pool-reused in stream order.
-                        if (_asyncFreeStream != IntPtr.Zero)
-                            CuBlasNative.cuMemFreeAsync(_devicePtr, _asyncFreeStream);
-                        else
-                            CuBlasNative.cuMemFree(_devicePtr);
-                        CuBlasNative.cuCtxPopCurrent(out _);
-                    }
-                    catch
-                    {
-                        // Suppress disposal errors to avoid crashing finalizers.
+                        try
+                        {
+                            CuBlasNative.cuCtxPushCurrent(_context);
+                            // Stream-ordered free (#558 layer 6): race-safe + pool-reused in stream order.
+                            if (_asyncFreeStream != IntPtr.Zero)
+                                CuBlasNative.cuMemFreeAsync(_devicePtr, _asyncFreeStream);
+                            else
+                                CuBlasNative.cuMemFree(_devicePtr);
+                            CuBlasNative.cuCtxPopCurrent(out _);
+                        }
+                        catch
+                        {
+                            // Suppress disposal errors to avoid crashing finalizers.
+                        }
                     }
                 }
             }
@@ -14557,7 +14632,13 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
 
         ~CudaGpuByteBuffer()
         {
-            Dispose();
+            // NEVER call the CUDA driver on the GC finalizer thread — defer the device free to a real
+            // op thread via the pending-free queue (see CudaBackend.PendingFinalizerFrees).
+            var ptr = _devicePtr;
+            if (ptr != IntPtr.Zero && !IsRuntimeTearingDown && !ProcessExiting)
+                PendingFinalizerFrees.Enqueue((ptr, _context, _asyncFreeStream));
+            _devicePtr = IntPtr.Zero;
+            _context = IntPtr.Zero;
         }
     }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -5369,6 +5369,15 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         if (!_kernelCache.TryGetValue("maxpool2d_backward", out var kernel))
             throw new InvalidOperationException("CUDA kernel not found: maxpool2d_backward");
 
+        // The non-deterministic kernel SCATTERS via atomicAdd to max cells only — non-max cells get no
+        // write, so gradInput must read as zero. AllocateBuffer zeroes it via a null-stream cuMemsetD32,
+        // which is NOT ordered against this kernel's non-blocking compute stream and can lag under load
+        // (the deterministic kernel sidesteps this by assigning every cell; this scatter cannot). Zero
+        // it again STREAM-ORDERED on _stream so the memset strictly precedes the kernel, no host sync.
+        CuBlasNative.CheckCudaResult(
+            CudaNativeBindings.cuMemsetD8Async(gradInPtr, 0, (ulong)((long)gradInput.Size * sizeof(float)), _stream),
+            "cuMemsetD8Async(maxpool2d_backward gradInput)");
+
         uint gridX = (uint)((outWidth + blockSize - 1) / blockSize);
         uint gridY = (uint)((outHeight + blockSize - 1) / blockSize);
         uint gridZ = (uint)(batch * channels);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaPoolingKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaPoolingKernels.cs
@@ -106,7 +106,13 @@ extern ""C"" __global__ __launch_bounds__(256) void maxpool2d_backward_determini
             }
         }
     }
-    gradInput[((b * channels + c) * inHeight + ih) * inWidth + iw] += sum;
+    // WRITE (not +=): each thread owns exactly one (b,c,ih,iw) input cell and computes its COMPLETE
+    // gradient in `sum`, so assignment is correct and — unlike +=, which leaves non-max cells holding
+    // whatever stale value the freshly-cuMemAlloc'd buffer carried — it does not depend on gradInput
+    // having been zeroed first. The zeroing (cuMemsetD32 on the null stream) is NOT ordered against
+    // this kernel's non-blocking compute stream, so under load it could lag and += would preserve
+    // garbage (observed: a non-max cell read -1.045 instead of 0). Assignment removes that race.
+    gradInput[((b * channels + c) * inHeight + ih) * inWidth + iw] = sum;
 }
 
 // Average Pooling 2D

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -424,7 +424,17 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
         // No deferred scope - use regular backend
         backend = _directGpu?.Backend!;
-        return IsGpuAvailable && backend != null;
+        bool available = IsGpuAvailable && backend != null;
+        if (available)
+        {
+            // CUDA's current context is PER-THREAD and set only on the engine's creating thread.
+            // This is the common entry point for ~every GPU op, so re-assert the context here so an
+            // op driven from a different thread (parallel test execution, thread-pool continuation)
+            // doesn't launch kernels / copy memory against the wrong (or no) context — the cause of
+            // the intermittent concurrent-GPU 0xC0000005. No-op when already current.
+            (backend as DirectGpu.CUDA.CudaBackend)?.EnsureContextCurrent();
+        }
+        return available;
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Helpers/OneDnnProvider.cs
+++ b/src/AiDotNet.Tensors/Helpers/OneDnnProvider.cs
@@ -62,6 +62,29 @@ internal static class OneDnnProvider
     // run truly in parallel on managed code, and concurrent oneDNN execution never happens.
     private static readonly object _executeLock = new object();
 
+    // Acquire the oneDNN execute lock with mode-aware contention behavior. Returns true if the
+    // caller should run the oneDNN primitive (and must Monitor.Exit(_executeLock) when done).
+    //
+    // In FAST mode: opportunistic (TryEnter). Contended -> false -> caller uses the parallel managed
+    // kernel. Maximizes parallelism; the managed result differing in the last ULP doesn't matter.
+    //
+    // In DETERMINISTIC mode: BLOCK (Enter). The opportunistic managed fallback is NOT bit-identical
+    // to oneDNN, so under contention a deterministic op's output would depend on whether the lock
+    // happened to be free — i.e. it would vary run-to-run / call-to-call (this is the root cause of
+    // the Conv2D_IsDeterministic flake: in a parallel suite some calls hit oneDNN and some fell back
+    // to managed). Blocking forces the SAME path (oneDNN) every time, which is what bit-exact
+    // reproducibility requires. It still serializes oneDNN execute (only one thread inside at a
+    // time), so the concurrent-execute crash guard that motivated this lock is fully preserved.
+    private static bool TryEnterExecute()
+    {
+        if (BlasProvider.IsDeterministicMode)
+        {
+            System.Threading.Monitor.Enter(_executeLock);
+            return true;
+        }
+        return System.Threading.Monitor.TryEnter(_executeLock);
+    }
+
     // Per-thread oneDNN stream. A dnnl_stream is NOT safe to use from multiple threads
     // concurrently, but the engine IS thread-safe to share and primitives are stateless.
     // So each thread gets its own stream (lazily created from the shared engine) and the
@@ -848,7 +871,7 @@ internal static class OneDnnProvider
             // Conv uses shared cached memory objects + a shared scratchpad + the WeightsReordered
             // flag, so only one oneDNN op may run at a time. Opportunistic (non-blocking): if
             // another oneDNN op is running, bail so the caller uses the managed conv. See _executeLock.
-            if (!System.Threading.Monitor.TryEnter(_executeLock)) return false;
+            if (!TryEnterExecute()) return false;
             try
             {
             // Step 1: Set user memory data handles to point to user data
@@ -961,7 +984,7 @@ internal static class OneDnnProvider
         if (!EnsureInitialized())
             return false;
         // Opportunistic (non-blocking): one oneDNN op at a time; contended -> managed fallback.
-        if (!System.Threading.Monitor.TryEnter(_executeLock)) return false;
+        if (!TryEnterExecute()) return false;
         try
         {
             const byte N = (byte)'N';
@@ -1059,7 +1082,7 @@ internal static class OneDnnProvider
     {
         // True-parallel: per-thread stream + a per-call memory object bound to this call's
         // data (shared primitive/descriptor are stateless/immutable). See ExecuteBinaryOperation.
-        if (!System.Threading.Monitor.TryEnter(_executeLock)) return false;   // opportunistic — see _executeLock
+        if (!TryEnterExecute()) return false;   // opportunistic — see _executeLock
         IntPtr mem = IntPtr.Zero, msp = IntPtr.Zero;
         try
         {
@@ -1240,7 +1263,7 @@ internal static class OneDnnProvider
     private static unsafe bool ExecuteSoftmaxOperation(CachedSoftmax cached, float* src, float* dst)
     {
         // True-parallel: per-thread stream + per-call memory objects (see ExecuteBinaryOperation).
-        if (!System.Threading.Monitor.TryEnter(_executeLock)) return false;   // opportunistic — see _executeLock
+        if (!TryEnterExecute()) return false;   // opportunistic — see _executeLock
         IntPtr ms = IntPtr.Zero, md = IntPtr.Zero, msp = IntPtr.Zero;
         try
         {
@@ -1416,7 +1439,7 @@ internal static class OneDnnProvider
         // source of the dnnl.dll access violations.)
         // Opportunistic: if another thread is already in oneDNN, bail (caller uses the managed
         // kernel) — never block, never run two oneDNN executes at once. See _executeLock.
-        if (!System.Threading.Monitor.TryEnter(_executeLock)) return false;
+        if (!TryEnterExecute()) return false;
         IntPtr m0 = IntPtr.Zero, m1 = IntPtr.Zero, md = IntPtr.Zero, msp = IntPtr.Zero;
         try
         {
@@ -2001,7 +2024,7 @@ internal static class OneDnnProvider
             args[1] = new DnnlExecArg { Arg = DnnlArgDst, Memory = dstMem };
             // This per-call path uses oneDNN's library scratchpad, so only one oneDNN op may run
             // at a time. Opportunistic (non-blocking): bail to the managed path if contended.
-            if (!System.Threading.Monitor.TryEnter(_executeLock))
+            if (!TryEnterExecute())
             {
                 dnnl_primitive_destroy(prim); dnnl_memory_destroy(srcMem); dnnl_memory_destroy(dstMem);
                 return false;
@@ -2116,7 +2139,7 @@ internal static class OneDnnProvider
             args[4] = new DnnlExecArg { Arg = DnnlArgWeights, Memory = scaleMem };
             args[5] = new DnnlExecArg { Arg = DnnlArgBias, Memory = shiftMem };
             // Library-scratchpad path -> only one oneDNN op at a time. Opportunistic (non-blocking).
-            if (!System.Threading.Monitor.TryEnter(_executeLock))
+            if (!TryEnterExecute())
             {
                 dnnl_primitive_destroy(prim);
                 dnnl_memory_destroy(srcMem); dnnl_memory_destroy(dstMem);

--- a/src/AiDotNet.Tensors/Helpers/OneDnnProvider.cs
+++ b/src/AiDotNet.Tensors/Helpers/OneDnnProvider.cs
@@ -813,6 +813,12 @@ internal static class OneDnnProvider
         float* output, int outHeight, int outWidth,
         int strideH, int strideW, int padH, int padW, int dilationH, int dilationW)
     {
+        // In deterministic mode, skip oneDNN entirely BEFORE any native setup (primitive
+        // creation, cache population, descriptor/memory-object building). TryEnterExecute()
+        // only gates the final execute step, so the deterministic "skip oneDNN" contract has
+        // to be enforced here at the entry point to avoid wasted native work.
+        if (BlasProvider.IsDeterministicMode) return false;
+
         // Gate all chatter behind the trace flag so production output stays clean.
         bool logThis = TraceEnabled;
 
@@ -1008,6 +1014,9 @@ internal static class OneDnnProvider
     /// </summary>
     private static unsafe bool TryEltwiseInPlace(float* data, int length, int algorithm)
     {
+        // Deterministic mode: skip oneDNN before any cache lookup or primitive creation.
+        if (BlasProvider.IsDeterministicMode) return false;
+
         if (!EnsureInitialized())
             return false;
 
@@ -1204,6 +1213,9 @@ internal static class OneDnnProvider
     /// <param name="axisSize">Size of the softmax axis (number of classes).</param>
     internal static unsafe bool TrySoftmax(float* input, float* output, int outerSize, int axisSize)
     {
+        // Deterministic mode: skip oneDNN before any cache lookup or primitive creation.
+        if (BlasProvider.IsDeterministicMode) return false;
+
         if (!EnsureInitialized())
             return false;
 
@@ -1356,6 +1368,9 @@ internal static class OneDnnProvider
     /// </summary>
     private static unsafe bool TryBinary(float* src0, float* src1, float* dst, int length, int algorithm)
     {
+        // Deterministic mode: skip oneDNN before any cache lookup or primitive creation.
+        if (BlasProvider.IsDeterministicMode) return false;
+
         if (!EnsureInitialized())
             return false;
 
@@ -1958,6 +1973,9 @@ internal static class OneDnnProvider
         int poolH, int poolW, int strideH, int strideW, int padH, int padW,
         int outH, int outW)
     {
+        // Deterministic mode: skip oneDNN before building any descriptors or memory objects.
+        if (BlasProvider.IsDeterministicMode) return false;
+
         if (!EnsureInitialized()) return false;
 
         try
@@ -2056,6 +2074,9 @@ internal static class OneDnnProvider
         int batch, int channels, int height, int width,
         float epsilon)
     {
+        // Deterministic mode: skip oneDNN before building any descriptors or memory objects.
+        if (BlasProvider.IsDeterministicMode) return false;
+
         if (!EnsureInitialized()) return false;
 
         try

--- a/src/AiDotNet.Tensors/Helpers/OneDnnProvider.cs
+++ b/src/AiDotNet.Tensors/Helpers/OneDnnProvider.cs
@@ -67,21 +67,18 @@ internal static class OneDnnProvider
     //
     // In FAST mode: opportunistic (TryEnter). Contended -> false -> caller uses the parallel managed
     // kernel. Maximizes parallelism; the managed result differing in the last ULP doesn't matter.
+    // TryEnter keeps oneDNN strictly one-at-a-time (the concurrent-execute crash guard).
     //
-    // In DETERMINISTIC mode: BLOCK (Enter). The opportunistic managed fallback is NOT bit-identical
-    // to oneDNN, so under contention a deterministic op's output would depend on whether the lock
-    // happened to be free — i.e. it would vary run-to-run / call-to-call (this is the root cause of
-    // the Conv2D_IsDeterministic flake: in a parallel suite some calls hit oneDNN and some fell back
-    // to managed). Blocking forces the SAME path (oneDNN) every time, which is what bit-exact
-    // reproducibility requires. It still serializes oneDNN execute (only one thread inside at a
-    // time), so the concurrent-execute crash guard that motivated this lock is fully preserved.
+    // In DETERMINISTIC mode: SKIP oneDNN entirely (return false -> caller uses the managed kernel).
+    // The managed deterministic kernels are bit-exact by contract, so taking the SAME (managed) path
+    // every time is what reproducibility requires — and it sidesteps oneDNN completely. (An earlier
+    // attempt BLOCKED here to force the oneDNN path instead; that fixed the Conv2D_IsDeterministic
+    // flake but drove far more traffic through oneDNN and surfaced a fatal concurrent-oneDNN fault
+    // under full-suite load. Skipping is both correct for determinism and strictly less oneDNN.)
     private static bool TryEnterExecute()
     {
         if (BlasProvider.IsDeterministicMode)
-        {
-            System.Threading.Monitor.Enter(_executeLock);
-            return true;
-        }
+            return false;
         return System.Threading.Monitor.TryEnter(_executeLock);
     }
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/ManagedVsNativeGemmAudit.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/ManagedVsNativeGemmAudit.cs
@@ -5,6 +5,10 @@ using System.Text;
 using AiDotNet.Tensors.Helpers;
 using Xunit;
 using ManagedBlas = AiDotNet.Tensors.Engines.BlasManaged.BlasManaged;
+using BMode = AiDotNet.Tensors.Engines.BlasManaged.BlasMode;
+using PMode = AiDotNet.Tensors.Engines.BlasManaged.PackingMode;
+using BOptF = AiDotNet.Tensors.Engines.BlasManaged.BlasOptions<float>;
+using BOptD = AiDotNet.Tensors.Engines.BlasManaged.BlasOptions<double>;
 
 namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
 
@@ -45,7 +49,7 @@ public class ManagedVsNativeGemmAudit
         // Give native all cores for a fair comparison (det mode pins it to 1).
         BlasProvider.TrySetOpenBlasThreads(Environment.ProcessorCount);
 
-        sb.AppendLine($"{"shape",-22} {"dtype",-6} {"managed GF",12} {"native GF",12} {"ratio",8}  winner");
+        sb.AppendLine($"{"shape",-18} {"dt",-6} {"det GF",9} {"detPB GF",10} {"fast GF",9} {"fastPB GF",10} {"native GF",10} {"best/nat",9}  winner");
         foreach (var (m, k, n, note) in Shapes)
         {
             RunFloat(sb, m, k, n, note);
@@ -68,21 +72,36 @@ public class ManagedVsNativeGemmAudit
         for (int i = 0; i < a.Length; i++) a[i] = (float)(rnd.NextDouble() - 0.5);
         for (int i = 0; i < b.Length; i++) b[i] = (float)(rnd.NextDouble() - 0.5);
         long flops = 2L * m * n * k;
+        int iters = IterFor(flops);
 
-        double mManaged = BestMs(() =>
-            ManagedBlas.Gemm<float>(a, k, false, b, n, false, cM, n, m, n, k), warm: 3, iters: IterFor(flops));
-
-        double mNative = double.PositiveInfinity;
-        if (BlasProvider.HasRawSgemm)
+        double det = BestMs(() =>
+            ManagedBlas.Gemm<float>(a, k, false, b, n, false, cM, n, m, n, k), 3, iters);
+        double detPB = BestMs(() =>
         {
-            mNative = BestMs(() =>
+            var o = new BOptF { PackingMode = PMode.ForcePackBoth };
+            ManagedBlas.Gemm<float>(a, k, false, b, n, false, cM, n, m, n, k, in o);
+        }, 3, iters);
+        double fast = BestMs(() =>
+        {
+            var o = new BOptF { Mode = BMode.Fast };
+            ManagedBlas.Gemm<float>(a, k, false, b, n, false, cM, n, m, n, k, in o);
+        }, 3, iters);
+        double fastPB = BestMs(() =>
+        {
+            var o = new BOptF { Mode = BMode.Fast, PackingMode = PMode.ForcePackBoth };
+            ManagedBlas.Gemm<float>(a, k, false, b, n, false, cM, n, m, n, k, in o);
+        }, 3, iters);
+
+        double nat = double.PositiveInfinity;
+        if (BlasProvider.HasRawSgemm)
+            nat = BestMs(() =>
             {
                 fixed (float* pa = a) fixed (float* pb = b) fixed (float* pc = cN)
                     BlasProvider.SgemmRaw(m, n, k, pa, k, pb, n, pc, n);
-            }, warm: 3, iters: IterFor(flops));
-        }
+            }, 3, iters);
 
-        Emit(sb, m, k, n, "float", note, GflopsOf(flops, mManaged), GflopsOf(flops, mNative));
+        Emit(sb, m, k, n, "float", note,
+            GflopsOf(flops, det), GflopsOf(flops, detPB), GflopsOf(flops, fast), GflopsOf(flops, fastPB), GflopsOf(flops, nat));
     }
 
     private static unsafe void RunDouble(StringBuilder sb, int m, int k, int n, string note)
@@ -93,21 +112,36 @@ public class ManagedVsNativeGemmAudit
         for (int i = 0; i < a.Length; i++) a[i] = rnd.NextDouble() - 0.5;
         for (int i = 0; i < b.Length; i++) b[i] = rnd.NextDouble() - 0.5;
         long flops = 2L * m * n * k;
+        int iters = IterFor(flops);
 
-        double mManaged = BestMs(() =>
-            ManagedBlas.Gemm<double>(a, k, false, b, n, false, cM, n, m, n, k), warm: 3, iters: IterFor(flops));
-
-        double mNative = double.PositiveInfinity;
-        if (BlasProvider.HasRawSgemm)
+        double det = BestMs(() =>
+            ManagedBlas.Gemm<double>(a, k, false, b, n, false, cM, n, m, n, k), 3, iters);
+        double detPB = BestMs(() =>
         {
-            mNative = BestMs(() =>
+            var o = new BOptD { PackingMode = PMode.ForcePackBoth };
+            ManagedBlas.Gemm<double>(a, k, false, b, n, false, cM, n, m, n, k, in o);
+        }, 3, iters);
+        double fast = BestMs(() =>
+        {
+            var o = new BOptD { Mode = BMode.Fast };
+            ManagedBlas.Gemm<double>(a, k, false, b, n, false, cM, n, m, n, k, in o);
+        }, 3, iters);
+        double fastPB = BestMs(() =>
+        {
+            var o = new BOptD { Mode = BMode.Fast, PackingMode = PMode.ForcePackBoth };
+            ManagedBlas.Gemm<double>(a, k, false, b, n, false, cM, n, m, n, k, in o);
+        }, 3, iters);
+
+        double nat = double.PositiveInfinity;
+        if (BlasProvider.HasRawSgemm)
+            nat = BestMs(() =>
             {
                 fixed (double* pa = a) fixed (double* pb = b) fixed (double* pc = cN)
                     BlasProvider.DgemmRaw(m, n, k, pa, k, pb, n, pc, n);
-            }, warm: 3, iters: IterFor(flops));
-        }
+            }, 3, iters);
 
-        Emit(sb, m, k, n, "double", note, GflopsOf(flops, mManaged), GflopsOf(flops, mNative));
+        Emit(sb, m, k, n, "double", note,
+            GflopsOf(flops, det), GflopsOf(flops, detPB), GflopsOf(flops, fast), GflopsOf(flops, fastPB), GflopsOf(flops, nat));
     }
 
     private static int IterFor(long flops) => flops > 500_000_000L ? 8 : flops > 50_000_000L ? 30 : 200;
@@ -128,11 +162,13 @@ public class ManagedVsNativeGemmAudit
         return best;
     }
 
-    private static void Emit(StringBuilder sb, int m, int k, int n, string dtype, string note, double managedGf, double nativeGf)
+    private static void Emit(StringBuilder sb, int m, int k, int n, string dtype, string note,
+        double detGf, double detPbGf, double fastGf, double fastPbGf, double nativeGf)
     {
-        double ratio = nativeGf > 0 ? managedGf / nativeGf : 0;
+        double bestManaged = Math.Max(Math.Max(detGf, detPbGf), Math.Max(fastGf, fastPbGf));
+        double ratio = nativeGf > 0 ? bestManaged / nativeGf : 0;
         string winner = double.IsInfinity(nativeGf) || nativeGf == 0 ? "(no native)"
             : ratio >= 1.0 ? "MANAGED" : $"native (+{(1 / ratio - 1) * 100:F0}%)";
-        sb.AppendLine($"{$"{m}x{k}x{n}",-22} {dtype,-6} {managedGf,12:F1} {nativeGf,12:F1} {ratio,8:F2}  {winner}  [{note}]");
+        sb.AppendLine($"{$"{m}x{k}x{n}",-18} {dtype,-6} {detGf,9:F1} {detPbGf,10:F1} {fastGf,9:F1} {fastPbGf,10:F1} {nativeGf,10:F1} {ratio,9:F2}  {winner}  [{note}]");
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/ManagedVsNativeGemmAudit.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/ManagedVsNativeGemmAudit.cs
@@ -133,7 +133,7 @@ public class ManagedVsNativeGemmAudit
         }, 3, iters);
 
         double nat = double.PositiveInfinity;
-        if (BlasProvider.HasRawSgemm)
+        if (BlasProvider.HasRawDgemm)
             nat = BestMs(() =>
             {
                 fixed (double* pa = a) fixed (double* pb = b) fixed (double* pc = cN)

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/ManagedVsNativeGemmAudit.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/ManagedVsNativeGemmAudit.cs
@@ -22,6 +22,7 @@ public class ManagedVsNativeGemmAudit
     private static readonly (int M, int K, int N, string Note)[] Shapes =
     {
         (512, 512, 512,   "square-med / attn-proj"),
+        (640, 640, 640,   "square-mid (microkernel→packed crossover)"),
         (1024, 1024, 1024,"square-large"),
         (2048, 2048, 2048,"square-xl"),
         (512, 512, 2048,  "ffn-up (d->4d)"),
@@ -144,7 +145,9 @@ public class ManagedVsNativeGemmAudit
             GflopsOf(flops, det), GflopsOf(flops, detPB), GflopsOf(flops, fast), GflopsOf(flops, fastPB), GflopsOf(flops, nat));
     }
 
-    private static int IterFor(long flops) => flops > 500_000_000L ? 8 : flops > 50_000_000L ? 30 : 200;
+    // More iters → better chance of catching an uncontended sample (min-of-N is the robust
+    // "peak achievable" estimator on a loaded box). Large shapes were too noisy at 8 iters.
+    private static int IterFor(long flops) => flops > 4_000_000_000L ? 40 : flops > 200_000_000L ? 60 : flops > 20_000_000L ? 120 : 300;
 
     private static double BestMs(Action op, int warm, int iters)
     {

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/ManagedVsNativeGemmAudit.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/ManagedVsNativeGemmAudit.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using AiDotNet.Tensors.Helpers;
+using Xunit;
+using ManagedBlas = AiDotNet.Tensors.Engines.BlasManaged.BlasManaged;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+// Drop-native audit (perf/managed-blas-vs-native-audit): quantify the managed-vs-native GEMM
+// gap on the real hot shapes so we can decide whether the managed kernel can fully replace
+// native OpenBLAS. Writes results to a FILE (xUnit ITestOutputHelper isn't captured for
+// passing tests). Native gets ALL cores (deterministic mode otherwise pins OpenBLAS to 1).
+// Category=Performance so CI (Category!=Performance) skips it.
+public class ManagedVsNativeGemmAudit
+{
+    private static readonly (int M, int K, int N, string Note)[] Shapes =
+    {
+        (512, 512, 512,   "square-med / attn-proj"),
+        (1024, 1024, 1024,"square-large"),
+        (2048, 2048, 2048,"square-xl"),
+        (512, 512, 2048,  "ffn-up (d->4d)"),
+        (512, 2048, 512,  "ffn-down (4d->d)"),
+        (256, 784, 128,   "mlp hidden"),
+        (128, 64, 256,    "lstm-small"),
+        (4096, 512, 16,   "thin-N (dcgan-ish)"),
+        (64, 4096, 64,    "thin-M wide-K"),
+        (4096, 64, 64,    "tall-M thin-K"),
+    };
+
+    private static readonly string ResultFile =
+        Path.Combine(Path.GetTempPath(), "blas-managed-vs-native-audit.txt");
+
+    [Trait("Category", "Performance")]
+    [Fact]
+    public unsafe void Audit_ManagedVsNative_AcrossHotShapes()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"# Managed (BlasManaged.Gemm) vs native (OpenBLAS cblas) — cores={Environment.ProcessorCount}");
+        sb.AppendLine($"# native available (HasRawSgemm)={BlasProvider.HasRawSgemm}");
+        sb.AppendLine($"# GFLOP/s = 2*M*N*K / time; higher is better. ratio = managed/native (>1 = managed wins)");
+        sb.AppendLine();
+
+        // Give native all cores for a fair comparison (det mode pins it to 1).
+        BlasProvider.TrySetOpenBlasThreads(Environment.ProcessorCount);
+
+        sb.AppendLine($"{"shape",-22} {"dtype",-6} {"managed GF",12} {"native GF",12} {"ratio",8}  winner");
+        foreach (var (m, k, n, note) in Shapes)
+        {
+            RunFloat(sb, m, k, n, note);
+            RunDouble(sb, m, k, n, note);
+        }
+
+        Directory.CreateDirectory(Path.GetDirectoryName(ResultFile)!);
+        File.WriteAllText(ResultFile, sb.ToString());
+        // Always passes — this is a measurement, not a gate.
+        Assert.True(true);
+    }
+
+    private static double GflopsOf(long mnk2, double ms) => ms <= 0 ? 0 : mnk2 / (ms * 1e6);
+
+    private static unsafe void RunFloat(StringBuilder sb, int m, int k, int n, string note)
+    {
+        var rnd = new Random(12345);
+        var a = new float[m * k]; var b = new float[k * n];
+        var cM = new float[m * n]; var cN = new float[m * n];
+        for (int i = 0; i < a.Length; i++) a[i] = (float)(rnd.NextDouble() - 0.5);
+        for (int i = 0; i < b.Length; i++) b[i] = (float)(rnd.NextDouble() - 0.5);
+        long flops = 2L * m * n * k;
+
+        double mManaged = BestMs(() =>
+            ManagedBlas.Gemm<float>(a, k, false, b, n, false, cM, n, m, n, k), warm: 3, iters: IterFor(flops));
+
+        double mNative = double.PositiveInfinity;
+        if (BlasProvider.HasRawSgemm)
+        {
+            mNative = BestMs(() =>
+            {
+                fixed (float* pa = a) fixed (float* pb = b) fixed (float* pc = cN)
+                    BlasProvider.SgemmRaw(m, n, k, pa, k, pb, n, pc, n);
+            }, warm: 3, iters: IterFor(flops));
+        }
+
+        Emit(sb, m, k, n, "float", note, GflopsOf(flops, mManaged), GflopsOf(flops, mNative));
+    }
+
+    private static unsafe void RunDouble(StringBuilder sb, int m, int k, int n, string note)
+    {
+        var rnd = new Random(54321);
+        var a = new double[m * k]; var b = new double[k * n];
+        var cM = new double[m * n]; var cN = new double[m * n];
+        for (int i = 0; i < a.Length; i++) a[i] = rnd.NextDouble() - 0.5;
+        for (int i = 0; i < b.Length; i++) b[i] = rnd.NextDouble() - 0.5;
+        long flops = 2L * m * n * k;
+
+        double mManaged = BestMs(() =>
+            ManagedBlas.Gemm<double>(a, k, false, b, n, false, cM, n, m, n, k), warm: 3, iters: IterFor(flops));
+
+        double mNative = double.PositiveInfinity;
+        if (BlasProvider.HasRawSgemm)
+        {
+            mNative = BestMs(() =>
+            {
+                fixed (double* pa = a) fixed (double* pb = b) fixed (double* pc = cN)
+                    BlasProvider.DgemmRaw(m, n, k, pa, k, pb, n, pc, n);
+            }, warm: 3, iters: IterFor(flops));
+        }
+
+        Emit(sb, m, k, n, "double", note, GflopsOf(flops, mManaged), GflopsOf(flops, mNative));
+    }
+
+    private static int IterFor(long flops) => flops > 500_000_000L ? 8 : flops > 50_000_000L ? 30 : 200;
+
+    private static double BestMs(Action op, int warm, int iters)
+    {
+        for (int i = 0; i < warm; i++) op();
+        double best = double.PositiveInfinity;
+        var sw = new Stopwatch();
+        for (int i = 0; i < iters; i++)
+        {
+            sw.Restart();
+            op();
+            sw.Stop();
+            double ms = sw.Elapsed.TotalMilliseconds;
+            if (ms < best) best = ms;
+        }
+        return best;
+    }
+
+    private static void Emit(StringBuilder sb, int m, int k, int n, string dtype, string note, double managedGf, double nativeGf)
+    {
+        double ratio = nativeGf > 0 ? managedGf / nativeGf : 0;
+        string winner = double.IsInfinity(nativeGf) || nativeGf == 0 ? "(no native)"
+            : ratio >= 1.0 ? "MANAGED" : $"native (+{(1 / ratio - 1) * 100:F0}%)";
+        sb.AppendLine($"{$"{m}x{k}x{n}",-22} {dtype,-6} {managedGf,12:F1} {nativeGf,12:F1} {ratio,8:F2}  {winner}  [{note}]");
+    }
+}


### PR DESCRIPTION
## Summary

Managed-vs-native GEMM **audit tool** plus the cache-blocking, microkernel, and parallelization fixes it surfaced — taking managed float GEMM from 2–22× losses on key shapes to competitive-or-winning, with the deterministic default both faster and bit-reproducible.

## Validated fixes (all bit-exact; full BlasManaged + determinism suite green)

1. **Routing** — defer FFN / large-square / thin-N shapes from the #409 machine-code microkernel to the cache-blocking `PackBoth` strategy where it's 1.7–3.8× better.
2. **Deterministic 6×16 microkernel** — root-caused a *latent* cross-thread-count reproducibility bug (tail-split gate keyed on `NumThreads`) and fixed it, enabling the faster 6×16 kernel in the default path. 1024³ +22%; 64×4096×64 now beats native.
3. **Parallelism floor** — fill the cores on under-parallelized single-N-block shapes (FFN-down +62%).
4. **Nc-widening** — the M-axis re-packs A once per nc-block; widen nc to span all of N (B-panel fits L3) so A is packed **once**. 640³ +27%, 2048³ +19%.
5. **Wide-N → M-axis** — with numNB==1, mc-shrink is free, so wide-N moderate-M shapes fill the cores via shared-B M-axis (no redundant B-pack) instead of the 2D grid. FFN-up +24%.

## Net (deterministic default, 32-core Ryzen)

Managed **beats** native on 512³, 2048³-double, FFN-down-double, MLP (2.9–3.8×), LSTM (2.9–3.8×), 64×4096×64; and closed most of the gap elsewhere (1024³ 0.54→0.60×, 2048³ 0.54→0.58×, FFN-up 0.39→0.47×). The residual large-square gap is OpenBLAS's per-µarch hand-tuned-assembly prefetch scheduling (managed's kernel is already ~95% of OpenBLAS single-core; the gap is multi-core memory feeding) — characterized in-code, a dedicated assembly-tuning effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
