### PR TITLE
fix(matmul): zero result before accumulating fallback paths (non-deterministic pooled-buffer reads)

### DIFF
--- a/src/AiDotNet.Tensors/LinearAlgebra/MatrixBase.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/MatrixBase.cs
@@ -923,6 +923,12 @@ public abstract class MatrixBase<T>
             return result;
         }
 
+        // The BLOCKED and RECURSIVE fallbacks accumulate into the result (C += A·B), so it must start
+        // at zero. CreateInstance returns RentUninitialized (pooled) memory whose stale contents would
+        // otherwise corrupt the accumulation — a source of non-deterministic results under buffer
+        // reuse. (The BLAS path above overwrites every element with beta = 0 and so skips this.)
+        result._memory.Span.Clear();
+
         if (MatrixMultiplyHelper.ShouldUseBlocked<T>(M, K, N))
         {
             MatrixMultiplyHelper.TraceMatmul("BLOCKED", M, N, K);


### PR DESCRIPTION
## Problem
`MatrixBase.Multiply` allocates its result via `CreateInstance` → `RentUninitialized` (pooled, possibly stale memory), on the documented assumption that callers fully overwrite every element. That holds for the **BLAS** path (GEMM `beta=0`), but **not** for the **BLOCKED** and **RECURSIVE** fallbacks, which *accumulate* (`C += A·B`). With buffer pooling enabled, those fallbacks accumulated on top of **stale data left by a previously-returned buffer**, producing **non-deterministic results** whenever BLAS was not selected.

## Symptom
Flaky net10.0 regression tests in the consuming repo (KernelRidge / GaussianProcess solve paths use the `Matrix×Matrix` fallback). The tell-tale signature: tests **passed in isolation** (empty pool → benign buffer) and **failed in the full suite** (dirty pool), with **1–9 failures varying per run**. Confirmed by toggling `AIDOTNET_DISABLE_TENSOR_POOL` (deterministic with pool off, flaky with pool on) and by NaN-poisoning `RentUninitialized` (the poison surfaced precisely at `Transpose().Multiply(matrix)`).

## Fix
Zero the result **only before the accumulating fallback paths**. The BLAS path is untouched (it overwrites with `beta=0`), so pooling/perf there is unaffected. No bandaid — pooling stays enabled.

## Verification
Full KernelRidge/GaussianProcess/Cholesky suite: **380/380 deterministic across repeated runs** (was 1–9 flaky). Broad regression model-family suite: **1276/1276**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)