### PR TITLE
perf(gpu): reuse adopted GPU engine instead of rebuilding CUDA context per BuildAsync

### DIFF
--- a/src/AiDotNet.Tensors/Engines/AiDotNetEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/AiDotNetEngine.cs
@@ -201,6 +201,18 @@ public static class AiDotNetEngine
             return false;
         }
 
+        // Reuse the already-adopted, working GPU engine instead of reconstructing the CUDA context,
+        // cuBLAS handle, and ~47 kernel modules on every call. The AiModelBuilder facade re-enters this
+        // method on every BuildAsync (its default, no-GPU-config path auto-detects), so without this
+        // guard each model build paid a full GPU re-init — and leaked the previous engine, since the
+        // success path below overwrites Current without disposing it. A whole tournament of small models
+        // therefore spent most of its time rebuilding (and leaking) GPU contexts. The circuit-breaker and
+        // disable checks above already cover the cases where the current engine must NOT be reused.
+        if (Current is DirectGpuTensorEngine adopted && adopted.SupportsGpu)
+        {
+            return true;
+        }
+
         try
         {
             var gpuEngine = new DirectGpuTensorEngine();


### PR DESCRIPTION
AutoDetectAndConfigureGpu had no already-adopted guard, so the AiModelBuilder facade (re-enters it on every BuildAsync) rebuilt a full CudaBackend — CUDA context + cuBLAS + ~47 kernel modules — on every model build AND leaked the previous engine. A tournament of ~8 models x 4 intervals x 4 horizons did 100+ CUDA rebuilds. Fix: short-circuit and reuse Current when it is already a working DirectGpuTensorEngine. Validated: GPU banner went 64+ -> 0 and a previously-stuck deep-model tournament now progresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)