### PR TITLE
perf(gpu): reuse already-adopted GPU engine in AutoDetectAndConfigureGpu

### DIFF
--- a/src/AiDotNet.Tensors/Engines/AiDotNetEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/AiDotNetEngine.cs
@@ -200,6 +200,14 @@ public static class AiDotNetEngine
             return false;
         }
 
+        // Reuse the already-adopted, working GPU engine instead of reconstructing the CUDA context,
+        // cuBLAS handle, and ~47 kernel modules on every call (the AiModelBuilder facade re-enters this
+        // on every BuildAsync). The circuit-breaker/disable checks above already cover when NOT to reuse.
+        if (Current is DirectGpuTensorEngine adopted && adopted.SupportsGpu)
+        {
+            return true;
+        }
+
         try
         {
             var gpuEngine = new DirectGpuTensorEngine();


### PR DESCRIPTION
AiModelBuilder.BuildAsync re-enters AutoDetectAndConfigureGpu on every build. Without a reuse guard this reconstructs the CUDA context, cuBLAS handle, and ~47 kernel modules each call (and leaks the prior engine), causing ~10x training slowdown and a per-build "GPU acceleration enabled" banner. Short-circuit when a working GPU engine is already adopted; the disable/circuit-breaker checks above still gate when NOT to reuse.

Port of PR #578 onto main (which carries SparseEmbeddingGradient / the 0.91.68 content). Packaged as 0.91.69.