### PR TITLE
WIP: GPU-resident compiled-plan execution for CUDA-graph training capture

### DIFF
--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Pool/CooperativeGemmScheduler.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Pool/CooperativeGemmScheduler.cs
@@ -100,7 +100,7 @@ internal static class CooperativeGemmScheduler
             // .NET runtime threads exceed the logical cores, so the OS preempts active
             // workers and a stolen chunk stalls the caller's join — the p95 tail. Tunable
             // to leave runtime headroom (AIDOTNET_COOP_WORKERS).
-            _numWorkers = Math.Max(1, Environment.ProcessorCount - 1);
+            _numWorkers = AiDotNet.Tensors.Helpers.CpuParallelSettings.WorkerPoolThreads;   // capped (was ProcessorCount-1)
             if (int.TryParse(Environment.GetEnvironmentVariable("AIDOTNET_COOP_WORKERS"), out var wOverride) && wOverride >= 1)
                 _numWorkers = Math.Min(wOverride, Math.Max(1, Environment.ProcessorCount - 1));
             for (int i = 0; i < _numWorkers; i++)

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Pool/StreamingWorkerPool.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Pool/StreamingWorkerPool.cs
@@ -20,7 +20,7 @@ internal static class StreamingWorkerPool
 {
     [ThreadStatic] private static bool _isExecuting;
 
-    private static readonly int _numWorkers = Math.Max(1, Environment.ProcessorCount - 1);
+    private static readonly int _numWorkers = AiDotNet.Tensors.Helpers.CpuParallelSettings.WorkerPoolThreads;   // capped (was ProcessorCount-1)
     private static readonly WorkerSlot[] _slots = new WorkerSlot[_numWorkers];
     private static readonly Thread[] _workers = new Thread[_numWorkers];
 

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -2344,7 +2344,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 var output = step.OutputBuffer;
                 var exec = step.Execute;
                 var opName = step.OpName;
-                allForwardActions.Add(eng => { Engines.DirectGpuTensorEngine.s_currentForwardOp = opName; exec(eng, output); });
+                allForwardActions.Add(eng => { Engines.DirectGpuTensorEngine.s_currentForwardOp = opName; exec(eng, output); Engines.DirectGpuTensorEngine.TagProducer(output, opName); });
                 genericForwardCount++;  // engine-dispatched (GPU-pure on a GPU engine)
             }
         }

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -56,6 +56,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     private long _graphStepCalls;
     private bool _graphStepDisabled;
     private bool _graphEvictionSuspended;   // eviction suspended for the graph lifetime (resumed on Dispose)
+    private int _graphEagerFwd;              // # leading forward steps (the embedding) run EAGERLY outside the captured graph
     // Capture is sound only when EVERY forward+backward action enqueues its real
     // work on the GPU stream. Host-only specialized closures (CPU-SIMD ReLU,
     // host-.Data GEMM, fused/analytic/slice/batched-dW kernels) run once at capture
@@ -134,6 +135,10 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         _lossGradSeed = lossGradSeed;
         _genericGradIndices = genericGradIndices;
         _forwardSteps = forwardSteps;
+        // A leading "Embedding" forward step is a host int→float gather that the captured GPU graph cannot
+        // replay (its output upload would freeze at capture). Run it EAGERLY outside the captured region and
+        // refresh its output into the graph each step (see RunEagerForwardPrefix + RefreshGraphInputInPlace).
+        _graphEagerFwd = (_forwardSteps != null && _forwardSteps.Length > 0 && _forwardSteps[0].OpType == OpType.Embedding) ? 1 : 0;
         _compiledInputShape = compiledInputShape;
         _compiledInputTensor = compiledInputTensor;
         _fusedStepIndices = fusedStepIndices;
@@ -507,6 +512,11 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 if (!_graphEvictionSuspended) { gte.SuspendActivationEviction(); _graphEvictionSuspended = true; }
                 if (_stepGraphExec == IntPtr.Zero)
                 {
+                    // Run the embedding EAGERLY (host int→float gather, re-reading LIVE token indices) and upload
+                    // its fresh output into the graph's stable input buffer, so the pre-residency body AND the
+                    // captured graph read THIS step's embeddings rather than a frozen snapshot.
+                    RunEagerForwardPrefix();
+                    RefreshGraphInputInPlace(cb);
                     // PRE-RESIDENCY PASS: run the step body once EAGERLY so every host-backed tensor the
                     // captured ops touch (weights/bias AND the input) is uploaded + cached OUTSIDE
                     // capture. Then capture finds them resident → no cuMemcpyHtoD inside capture (which
@@ -528,6 +538,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 // version. Refresh the persistent input BUFFER in place (stable pointer) OUTSIDE capture
                 // so the replayed graph reads fresh data; then replay. Without this the graph would
                 // recompute on the captured step's stale input (silently wrong training).
+                RunEagerForwardPrefix();   // re-run the embedding (host gather, live token indices) for THIS step
                 RefreshGraphInputInPlace(cb);
                 cb.LaunchCapturedGraph(_stepGraphExec);
                 _optimizerUpdate?.Invoke();
@@ -559,12 +570,26 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         inT._gpuBufferVersion = inT.Version;
     }
 
+    /// <summary>
+    /// Runs the EAGER forward prefix — the leading "Embedding" step (a host int→float gather the captured GPU
+    /// graph cannot replay). Re-reads the LIVE token indices each call (the compiled-embedding refresh), so the
+    /// embedding's output tensor holds THIS step's data; <see cref="RefreshGraphInputInPlace"/> then uploads it
+    /// into the graph's stable input buffer. No-op when there is no embedding prefix (_graphEagerFwd == 0).
+    /// </summary>
+    private void RunEagerForwardPrefix()
+    {
+        var fwd = _forwardActions;
+        for (int i = 0; i < _graphEagerFwd && i < fwd.Length; i++) fwd[i](_engine);
+    }
+
     private void RunGpuStepBodyForCapture(Engines.DirectGpu.CUDA.CudaBackend cb)
     {
         var engine = _engine;
         _preForwardParamTransform?.Invoke();
         var fwd = _forwardActions;
-        for (int i = 0; i < fwd.Length; i++) fwd[i](engine);
+        // Skip the eager prefix (the embedding) — it runs OUTSIDE the captured graph via RunEagerForwardPrefix
+        // each step, so the captured GPU sequence reads the embedding's freshly-refreshed output buffer.
+        for (int i = _graphEagerFwd; i < fwd.Length; i++) fwd[i](engine);
 
         int esz = System.Runtime.CompilerServices.Unsafe.SizeOf<T>();
         if (_genericGradIndices != null)
@@ -2512,9 +2537,17 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         //   FusedOptimizer.AppendFusedUpdates(plan.BackwardActions, params, grads, lr)
         // This avoids hard-coding the learning rate into the compiled plan.
 
-        // Determine compiled input shape/tensor from the forward steps.
-        Tensor<T>? compiledInputTensor = forwardSteps.Count > 0 && forwardSteps[0].Inputs.Length > 0
-            ? forwardSteps[0].Inputs[0] : null;
+        // Determine the per-step persistent input for CUDA-graph refresh. For a token-LM whose FIRST forward
+        // step is the EMBEDDING (a host int→float gather the captured GPU graph cannot re-run), the float
+        // graph's true per-step input is the embedding's OUTPUT (it varies every step with the token indices).
+        // forwardSteps[0].Inputs[0] is the embeddings MATRIX (a trained param) — refreshing that leaves the
+        // token indices FROZEN at the capture step → loss stuck at ln V. So point the refresh at the embedding
+        // OUTPUT, and run the embedding eagerly each step (see _graphEagerFwd / RunEagerForwardPrefix) so its
+        // output is fresh before each graph launch.
+        bool firstIsEmbedding = forwardSteps.Count > 0 && forwardSteps[0].OpType == OpType.Embedding;
+        Tensor<T>? compiledInputTensor = firstIsEmbedding
+            ? forwardSteps[0].OutputBuffer
+            : (forwardSteps.Count > 0 && forwardSteps[0].Inputs.Length > 0 ? forwardSteps[0].Inputs[0] : null);
         int[] compiledInputShape = compiledInputTensor is not null
             ? (int[])compiledInputTensor._shape.Clone() : Array.Empty<int>();
 

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -2333,7 +2333,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             {
                 var output = step.OutputBuffer;
                 var exec = step.Execute;
-                allForwardActions.Add(eng => exec(eng, output));
+                var opName = step.OpName;
+                allForwardActions.Add(eng => { Engines.DirectGpuTensorEngine.s_currentForwardOp = opName; exec(eng, output); });
                 genericForwardCount++;  // engine-dispatched (GPU-pure on a GPU engine)
             }
         }

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -588,7 +588,17 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         var fwd = _forwardActions;
         // The whole forward (INCLUDING the embedding, which gathers on-device from the externally-refreshed stable
         // index buffer) is captured. _graphEagerFwd is 0 in capture mode (no eager prefix).
-        for (int i = _graphEagerFwd; i < fwd.Length; i++) fwd[i](engine);
+        bool capDiag = System.Environment.GetEnvironmentVariable("AIDOTNET_GRAPH_CAPTURE_DEBUG") == "1" && cb.IsStreamCapturing();
+        for (int i = _graphEagerFwd; i < fwd.Length; i++)
+        {
+            fwd[i](engine);
+            if (capDiag && cb.StreamCaptureStatusRaw() == 2)
+            {
+                try { System.IO.File.AppendAllText(System.IO.Path.Combine(System.IO.Path.GetTempPath(), "aidotnet_graphcapture_diag.txt"),
+                    $"[CAPTURE-INVALIDATED-BY] forwardAction#{i} op={Engines.DirectGpuTensorEngine.s_currentForwardOp}" + System.Environment.NewLine); } catch { }
+                capDiag = false;   // log only the FIRST invalidation
+            }
+        }
 
         int esz = System.Runtime.CompilerServices.Unsafe.SizeOf<T>();
         if (_genericGradIndices != null)

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -146,9 +146,12 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         // lives in the embedding step's saved state ({ indices }); grab it to refresh the buffer each step.
         _graphEagerFwd = 0;
         if (_forwardSteps != null && _forwardSteps.Length > 0 && _forwardSteps[0].OpType == OpType.Embedding
-            && _forwardSteps[0].SavedState is { Length: > 0 } ss && ss[0] is Tensor<int> embIdx)
+            && _forwardSteps[0].SavedState is { } ss)
         {
-            _graphEmbIndices = embIdx;
+            // The live token-index tensor lives in the embedding step's saved state, but at different positions
+            // per op (Embedding<T> stores it at [0]; TensorEmbeddingLookup stores it after idxSnap/shape/vocab/dim).
+            // Scan for the first Tensor<int> so both ops compile to the in-graph capture path.
+            foreach (var o in ss) if (o is Tensor<int> ti) { _graphEmbIndices = ti; break; }
         }
         _compiledInputShape = compiledInputShape;
         _compiledInputTensor = compiledInputTensor;

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -44,12 +44,14 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     // narrowly gated and any capture failure falls back to eager permanently.
     // Default ON so users get the whole-step CUDA-graph capture (collapses per-kernel launch
     // overhead → full GPU power) automatically; opt out with AIDOTNET_CUDA_GRAPH_STEP=0. Still
-    // narrowly gated at the call site (float + CUDA + eligible + no clip/checkpoint). OPT-IN
-    // (default OFF): for an embedding-input model (token LM cortex), the captured graph still trains
-    // on the capture step's STALE token indices (loss frozen at ln V) — the embedding-boundary "forward
-    // not stream-pure" root (#558) is not fully solved, so enabling the graph by default would silently
-    // break correctness on the cortex. Opt in with AIDOTNET_CUDA_GRAPH_STEP=1 once that is fixed; the
-    // default path (generic GPU-pure ops, no graph) is correct + already moves all work onto the device.
+    // narrowly gated at the call site (float + CUDA + eligible + no clip/checkpoint). OPT-IN (default OFF).
+    // The embedding-input correctness root (#558 — captured graph trained on STALE token indices, loss frozen
+    // at ln V) is now FIXED via the prefix-eager embedding (run it outside capture + refresh its output each
+    // step; see _graphEagerFwd / RunEagerForwardPrefix) — VERIFIED: the d256/L2 cortex loss drops 9.59→7.20
+    // under the graph. Kept OPT-IN conservatively because (a) a NON-embedding leading host op would need the
+    // same eager-prefix treatment, and (b) for a token LM the eager host embedding currently caps GPU util
+    // (~15%) until the gather is GPU-ized — a perf follow-up, not a correctness gate. Enable for the GPU-op
+    // acceleration with AIDOTNET_CUDA_GRAPH_STEP=1; the default (generic GPU-pure ops, no graph) is correct.
     private static readonly bool s_graphStepEnabled =
         System.Environment.GetEnvironmentVariable("AIDOTNET_CUDA_GRAPH_STEP") == "1";
     private IntPtr _stepGraphExec;

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -2107,7 +2107,15 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         var fusedBackwardActions = new List<Action<IEngine>>();
         var fusedStepIndices = new HashSet<int>(); // indices consumed by fusion
 
-        if (typeof(T) == typeof(float) && Optimization.TensorCodecOptions.Current.EnableDataflowFusion)
+        // CUDA-graph eligibility: on a GPU engine, prefer the generic engine-dispatched (GPU-stream) path over
+        // host CPU-BLAS/SIMD specializations AND over dataflow FUSION — both build host-side closures that break
+        // graph purity and starve the device. Computed here (before fusion) so fusion can be skipped on GPU.
+        // CPU engines are unaffected (preferGenericForGpu == false → fusion + specialization unchanged).
+        bool preferGenericForGpu = engine.SupportsGpu
+            && Environment.GetEnvironmentVariable("AIDOTNET_GPU_PREFER_GENERIC") != "0";
+
+        if (typeof(T) == typeof(float) && Optimization.TensorCodecOptions.Current.EnableDataflowFusion
+            && !preferGenericForGpu)
         {
             TryFuseForwardBackward(forwardSteps, gradMap, consumerCount, engine,
                 fusedForwardActions, fusedBackwardActions, fusedStepIndices);
@@ -2148,9 +2156,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         // (1) run the heavy GEMMs + elementwise on the CPU, starving the device (cortex GPU util ~7%), and
         // (2) are host-only, so the fixed kernel sequence can't be CUDA-graph captured (AIDOTNET_CUDA_GRAPH_STEP).
         // Routing to generic moves the work onto the GPU AND makes the whole step graph-eligible. Default ON
-        // for GPU engines; opt out with AIDOTNET_GPU_PREFER_GENERIC=0 to restore the CPU-specialized path.
-        bool preferGenericForGpu = engine.SupportsGpu
-            && Environment.GetEnvironmentVariable("AIDOTNET_GPU_PREFER_GENERIC") != "0";
+        // for GPU engines; opt out with AIDOTNET_GPU_PREFER_GENERIC=0 (preferGenericForGpu computed above).
         if (typeof(T) == typeof(float) && !preferGenericForGpu)
         {
             DetectAnalyticLossMatMulBackward(forwardSteps, consumerCount, gradMap, analyticBackwardSpecs, skippableReduceSumIndices, analyticForwardSpecs, skippableReduceSumForwardIndices, sharedRowSumCache);

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -532,12 +532,31 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     // embedding gather reads the now-resident index buffer WITHOUT an inline upload (a cuMemcpyHtoD
                     // inside capture is CUDA 906 STREAM_CAPTURE_UNSUPPORTED). Flag cleared after capture so the eager
                     // fallback (and warmup steps) upload inline again.
-                    if (_graphHasEmbedding) gte.EmbeddingIndexExternallyManaged = false;
-                    RefreshGraphInputInPlace(cb);
-                    RunGpuStepBodyForCapture(cb);
-                    if (_graphHasEmbedding) gte.EmbeddingIndexExternallyManaged = true;
-                    var exec = cb.CaptureGraph(() => RunGpuStepBodyForCapture(cb));
-                    if (_graphHasEmbedding) gte.EmbeddingIndexExternallyManaged = false;
+                    IntPtr exec;
+                    try
+                    {
+                        if (_graphHasEmbedding) gte.EmbeddingIndexExternallyManaged = false;
+                        RefreshGraphInputInPlace(cb);
+                        RunGpuStepBodyForCapture(cb);
+                        if (_graphHasEmbedding) gte.EmbeddingIndexExternallyManaged = true;
+                        exec = cb.CaptureGraph(() => RunGpuStepBodyForCapture(cb));
+                    }
+                    catch
+                    {
+                        // A throw during pre-residency/capture (not just exec==Zero) must also roll back the
+                        // graph-lifetime state — otherwise eviction stays suspended (pins every offload buffer,
+                        // risking OOM) and the embedding stays in externally-managed mode (the eager fallback
+                        // would skip its inline index upload and silently train on stale indices). PR #581 review.
+                        _graphStepDisabled = true;
+                        if (_graphHasEmbedding) gte.EmbeddingIndexExternallyManaged = false;
+                        gte.ResumeActivationEviction();
+                        _graphEvictionSuspended = false;
+                        throw;
+                    }
+                    finally
+                    {
+                        if (_graphHasEmbedding) gte.EmbeddingIndexExternallyManaged = false;
+                    }
                     if (exec == IntPtr.Zero)
                     {
                         // Capture failed → the graph is permanently abandoned for this plan. Resume the
@@ -592,7 +611,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     {
         // In-graph embedding design: for an embedding-first plan there is NO float input to refresh (the gather
         // happens on-device inside the captured graph; only the small index buffer is refreshed, via
-        // RefreshGraphEmbeddingIndicesNow). _compiledInputTensor is null for those plans → no-op here.
+        // RefreshGraphEmbeddingIndicesNow). _compiledInputTensor stays set for SetInput/SetInputs API
+        // compatibility (it's the embeddings matrix there), so gate on the flag, not on null.
+        if (_graphHasEmbedding) return;
         if (_compiledInputTensor is not { } inT) return;
         if (inT._gpuBuffer is not { } buf || !ReferenceEquals(inT._gpuBackend, cb)) return;
         var data = inT.GetDataArray();                 // host backing (T==float on the graph path)
@@ -2567,15 +2588,15 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         //   FusedOptimizer.AppendFusedUpdates(plan.BackwardActions, params, grads, lr)
         // This avoids hard-coding the learning rate into the compiled plan.
 
-        // Determine the per-step persistent input for the CUDA-graph float-input refresh. When the FIRST step is
-        // the EMBEDDING, it is now CAPTURED inside the graph (a pure on-device gather over a stable index buffer
-        // refreshed via RefreshGraphEmbeddingIndices), so there is NO float input to refresh — leave it null
-        // (refreshing the embedding output would DtoH+HtoD the whole activation each step, the util killer). For a
-        // non-embedding graph plan, the persistent input is forwardSteps[0].Inputs[0] (the generic input-feed case).
+        // _compiledInputTensor stays the caller-visible captured input (forwardSteps[0].Inputs[0]) for ALL plans
+        // so SetInput/SetInputs and the serialized input-shape metadata keep working on embedding-first plans
+        // (nulling it made SetInput throw — PR #581 review). The CUDA-graph float-input refresh is instead gated
+        // by _graphHasEmbedding in RefreshGraphInputInPlace: an embedding-first plan gathers ON-DEVICE inside the
+        // captured graph (only the small index buffer is refreshed, via RefreshGraphEmbeddingIndicesNow), so it
+        // must NOT upload a float input each step (the DtoH+HtoD round-trip is the util killer).
         bool firstIsEmbedding = forwardSteps.Count > 0 && forwardSteps[0].OpType == OpType.Embedding;
-        Tensor<T>? compiledInputTensor = firstIsEmbedding
-            ? null
-            : (forwardSteps.Count > 0 && forwardSteps[0].Inputs.Length > 0 ? forwardSteps[0].Inputs[0] : null);
+        Tensor<T>? compiledInputTensor =
+            forwardSteps.Count > 0 && forwardSteps[0].Inputs.Length > 0 ? forwardSteps[0].Inputs[0] : null;
         int[] compiledInputShape = compiledInputTensor is not null
             ? (int[])compiledInputTensor._shape.Clone() : Array.Empty<int>();
         // SEPARATE tensor for CUDA-graph replay refresh: for a token-LM whose first step is the EMBEDDING

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -546,12 +546,15 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                         // A throw during pre-residency/capture (not just exec==Zero) must also roll back the
                         // graph-lifetime state — otherwise eviction stays suspended (pins every offload buffer,
                         // risking OOM) and the embedding stays in externally-managed mode (the eager fallback
-                        // would skip its inline index upload and silently train on stale indices). PR #581 review.
+                        // would skip its inline index upload and silently train on stale indices). With the state
+                        // rolled back and the graph permanently disabled, the eager path is fully valid — fall
+                        // back NOW rather than aborting this step (PR #581 review: a one-off capture hiccup
+                        // shouldn't kill a training run when every later step would succeed eagerly anyway).
                         _graphStepDisabled = true;
                         if (_graphHasEmbedding) gte.EmbeddingIndexExternallyManaged = false;
                         gte.ResumeActivationEviction();
                         _graphEvictionSuspended = false;
-                        throw;
+                        return StepEager();
                     }
                     finally
                     {

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -59,9 +59,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     private bool _graphStepDisabled;
     private bool _graphEvictionSuspended;   // eviction suspended for the graph lifetime (resumed on Dispose)
     private int _graphEagerFwd;              // # leading forward steps run EAGERLY outside the captured graph (0 in capture mode)
-    private Tensor<int>? _graphEmbIndices;   // the captured embedding's token-index tensor; refreshed (small int HtoD)
-                                             // into the engine's stable index buffer before each launch, OUTSIDE capture,
-                                             // so the embedding gather runs INSIDE the graph at full util (no eager prefix)
+    private bool _graphHasEmbedding;         // first forward step is the embedding → captured INSIDE the graph as an
+                                             // on-device gather; the engine's registered action refreshes the stable
+                                             // index buffer (any TIndex) before each launch, OUTSIDE capture
     // Capture is sound only when EVERY forward+backward action enqueues its real
     // work on the GPU stream. Host-only specialized closures (CPU-SIMD ReLU,
     // host-.Data GEMM, fused/analytic/slice/batched-dW kernels) run once at capture
@@ -140,19 +140,13 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         _lossGradSeed = lossGradSeed;
         _genericGradIndices = genericGradIndices;
         _forwardSteps = forwardSteps;
-        // A leading "Embedding" step is an int→float gather. Capture it INSIDE the graph (a pure on-device gather
-        // over a STABLE index buffer) and refresh just the small index vector before each launch — so the whole
-        // step is one cuGraphLaunch at full util, no eager prefix (_graphEagerFwd stays 0). The token-index tensor
-        // lives in the embedding step's saved state ({ indices }); grab it to refresh the buffer each step.
+        // A leading "Embedding" step is an int→float gather. Capture it INSIDE the graph as a pure on-device gather
+        // over a STABLE index buffer, and refresh just the small index vector before each launch (via the engine's
+        // registered action, which knows the live indices tensor's TIndex) — so the whole step is one cuGraphLaunch
+        // at full util, no eager prefix (_graphEagerFwd stays 0).
         _graphEagerFwd = 0;
-        if (_forwardSteps != null && _forwardSteps.Length > 0 && _forwardSteps[0].OpType == OpType.Embedding
-            && _forwardSteps[0].SavedState is { } ss)
-        {
-            // The live token-index tensor lives in the embedding step's saved state, but at different positions
-            // per op (Embedding<T> stores it at [0]; TensorEmbeddingLookup stores it after idxSnap/shape/vocab/dim).
-            // Scan for the first Tensor<int> so both ops compile to the in-graph capture path.
-            foreach (var o in ss) if (o is Tensor<int> ti) { _graphEmbIndices = ti; break; }
-        }
+        _graphHasEmbedding = _forwardSteps != null && _forwardSteps.Length > 0
+            && _forwardSteps[0].OpType == OpType.Embedding;
         _compiledInputShape = compiledInputShape;
         _compiledInputTensor = compiledInputTensor;
         _fusedStepIndices = fusedStepIndices;
@@ -526,28 +520,21 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 if (!_graphEvictionSuspended) { gte.SuspendActivationEviction(); _graphEvictionSuspended = true; }
                 if (_stepGraphExec == IntPtr.Zero)
                 {
-                    // CAPTURE (first step): refresh THIS step's small index vector into the stable buffer OUTSIDE
-                    // capture, and flag the engine so the embedding delegate (run by the pre-residency body + the
-                    // capture) gathers from that buffer WITHOUT an inline upload — a cuMemcpyHtoD inside capture is
-                    // CUDA 906. The flag is cleared right after capture so the eager fallback uploads inline again.
-                    if (_graphEmbIndices is not null)
-                    {
-                        gte.EmbeddingIndexExternallyManaged = true;
-                        gte.RefreshGraphEmbeddingIndices(_graphEmbIndices);
-                    }
+                    // PRE-RESIDENCY runs the body with the embedding index buffer EAGER (managed=false): the embedding
+                    // delegate uploads THIS step's indices inline, REGISTERS the per-step refresh action, and makes the
+                    // table/output/index buffers resident. CAPTURE then re-runs the body with managed=TRUE so the
+                    // embedding gather reads the now-resident index buffer WITHOUT an inline upload (a cuMemcpyHtoD
+                    // inside capture is CUDA 906 STREAM_CAPTURE_UNSUPPORTED). Flag cleared after capture so the eager
+                    // fallback (and warmup steps) upload inline again.
+                    if (_graphHasEmbedding) gte.EmbeddingIndexExternallyManaged = false;
                     RefreshGraphInputInPlace(cb);
-                    // PRE-RESIDENCY PASS: run the step body once EAGERLY so every host-backed tensor the
-                    // captured ops touch (weights/bias AND the input) is uploaded + cached OUTSIDE
-                    // capture. Then capture finds them resident → no cuMemcpyHtoD inside capture (which
-                    // is CUDA 906 STREAM_CAPTURE_UNSUPPORTED). First step does one extra (redundant) body.
                     RunGpuStepBodyForCapture(cb);
+                    if (_graphHasEmbedding) gte.EmbeddingIndexExternallyManaged = true;
                     var exec = cb.CaptureGraph(() => RunGpuStepBodyForCapture(cb));
-                    // The embedding delegate has now run (pre-residency + capture); clear the flag so a capture-failure
-                    // fallback to StepEager (and any later eager step) refreshes the index buffer inline again.
-                    gte.EmbeddingIndexExternallyManaged = false;
+                    if (_graphHasEmbedding) gte.EmbeddingIndexExternallyManaged = false;
                     if (exec == IntPtr.Zero) { _graphStepDisabled = true; return StepEager(); }
                     _stepGraphExec = exec;
-                    cb.LaunchCapturedGraph(exec);   // executes THIS step on the just-uploaded input
+                    cb.LaunchCapturedGraph(exec);   // executes THIS step on the just-uploaded indices
                     // The optimizer update is run eagerly (NOT captured): its closure
                     // increments _optimizerStep and re-evaluates lrSchedule.GetLr +
                     // Adam/AdamW bias-correction each step, and bakes those scalars into
@@ -562,7 +549,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 // recompute on the captured step's stale input (silently wrong training).
                 // Upload THIS step's token indices into the stable buffer (OUTSIDE capture) so the captured
                 // embedding gather replays on fresh indices; then replay the whole step as one graph launch.
-                if (_graphEmbIndices is not null) gte.RefreshGraphEmbeddingIndices(_graphEmbIndices);
+                if (_graphHasEmbedding) gte.RefreshGraphEmbeddingIndicesNow();   // upload step-N indices (registered action)
                 RefreshGraphInputInPlace(cb);
                 cb.LaunchCapturedGraph(_stepGraphExec);
                 _optimizerUpdate?.Invoke();

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -58,7 +58,10 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     private long _graphStepCalls;
     private bool _graphStepDisabled;
     private bool _graphEvictionSuspended;   // eviction suspended for the graph lifetime (resumed on Dispose)
-    private int _graphEagerFwd;              // # leading forward steps (the embedding) run EAGERLY outside the captured graph
+    private int _graphEagerFwd;              // # leading forward steps run EAGERLY outside the captured graph (0 in capture mode)
+    private Tensor<int>? _graphEmbIndices;   // the captured embedding's token-index tensor; refreshed (small int HtoD)
+                                             // into the engine's stable index buffer before each launch, OUTSIDE capture,
+                                             // so the embedding gather runs INSIDE the graph at full util (no eager prefix)
     // Capture is sound only when EVERY forward+backward action enqueues its real
     // work on the GPU stream. Host-only specialized closures (CPU-SIMD ReLU,
     // host-.Data GEMM, fused/analytic/slice/batched-dW kernels) run once at capture
@@ -137,10 +140,16 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         _lossGradSeed = lossGradSeed;
         _genericGradIndices = genericGradIndices;
         _forwardSteps = forwardSteps;
-        // A leading "Embedding" forward step is a host int→float gather that the captured GPU graph cannot
-        // replay (its output upload would freeze at capture). Run it EAGERLY outside the captured region and
-        // refresh its output into the graph each step (see RunEagerForwardPrefix + RefreshGraphInputInPlace).
-        _graphEagerFwd = (_forwardSteps != null && _forwardSteps.Length > 0 && _forwardSteps[0].OpType == OpType.Embedding) ? 1 : 0;
+        // A leading "Embedding" step is an int→float gather. Capture it INSIDE the graph (a pure on-device gather
+        // over a STABLE index buffer) and refresh just the small index vector before each launch — so the whole
+        // step is one cuGraphLaunch at full util, no eager prefix (_graphEagerFwd stays 0). The token-index tensor
+        // lives in the embedding step's saved state ({ indices }); grab it to refresh the buffer each step.
+        _graphEagerFwd = 0;
+        if (_forwardSteps != null && _forwardSteps.Length > 0 && _forwardSteps[0].OpType == OpType.Embedding
+            && _forwardSteps[0].SavedState is { Length: > 0 } ss && ss[0] is Tensor<int> embIdx)
+        {
+            _graphEmbIndices = embIdx;
+        }
         _compiledInputShape = compiledInputShape;
         _compiledInputTensor = compiledInputTensor;
         _fusedStepIndices = fusedStepIndices;
@@ -514,10 +523,15 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 if (!_graphEvictionSuspended) { gte.SuspendActivationEviction(); _graphEvictionSuspended = true; }
                 if (_stepGraphExec == IntPtr.Zero)
                 {
-                    // Run the embedding EAGERLY (host int→float gather, re-reading LIVE token indices) and upload
-                    // its fresh output into the graph's stable input buffer, so the pre-residency body AND the
-                    // captured graph read THIS step's embeddings rather than a frozen snapshot.
-                    RunEagerForwardPrefix();
+                    // CAPTURE (first step): refresh THIS step's small index vector into the stable buffer OUTSIDE
+                    // capture, and flag the engine so the embedding delegate (run by the pre-residency body + the
+                    // capture) gathers from that buffer WITHOUT an inline upload — a cuMemcpyHtoD inside capture is
+                    // CUDA 906. The flag is cleared right after capture so the eager fallback uploads inline again.
+                    if (_graphEmbIndices is not null)
+                    {
+                        gte.EmbeddingIndexExternallyManaged = true;
+                        gte.RefreshGraphEmbeddingIndices(_graphEmbIndices);
+                    }
                     RefreshGraphInputInPlace(cb);
                     // PRE-RESIDENCY PASS: run the step body once EAGERLY so every host-backed tensor the
                     // captured ops touch (weights/bias AND the input) is uploaded + cached OUTSIDE
@@ -525,6 +539,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     // is CUDA 906 STREAM_CAPTURE_UNSUPPORTED). First step does one extra (redundant) body.
                     RunGpuStepBodyForCapture(cb);
                     var exec = cb.CaptureGraph(() => RunGpuStepBodyForCapture(cb));
+                    // The embedding delegate has now run (pre-residency + capture); clear the flag so a capture-failure
+                    // fallback to StepEager (and any later eager step) refreshes the index buffer inline again.
+                    gte.EmbeddingIndexExternallyManaged = false;
                     if (exec == IntPtr.Zero) { _graphStepDisabled = true; return StepEager(); }
                     _stepGraphExec = exec;
                     cb.LaunchCapturedGraph(exec);   // executes THIS step on the just-uploaded input
@@ -540,7 +557,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 // version. Refresh the persistent input BUFFER in place (stable pointer) OUTSIDE capture
                 // so the replayed graph reads fresh data; then replay. Without this the graph would
                 // recompute on the captured step's stale input (silently wrong training).
-                RunEagerForwardPrefix();   // re-run the embedding (host gather, live token indices) for THIS step
+                // Upload THIS step's token indices into the stable buffer (OUTSIDE capture) so the captured
+                // embedding gather replays on fresh indices; then replay the whole step as one graph launch.
+                if (_graphEmbIndices is not null) gte.RefreshGraphEmbeddingIndices(_graphEmbIndices);
                 RefreshGraphInputInPlace(cb);
                 cb.LaunchCapturedGraph(_stepGraphExec);
                 _optimizerUpdate?.Invoke();
@@ -572,25 +591,13 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         inT._gpuBufferVersion = inT.Version;
     }
 
-    /// <summary>
-    /// Runs the EAGER forward prefix — the leading "Embedding" step (a host int→float gather the captured GPU
-    /// graph cannot replay). Re-reads the LIVE token indices each call (the compiled-embedding refresh), so the
-    /// embedding's output tensor holds THIS step's data; <see cref="RefreshGraphInputInPlace"/> then uploads it
-    /// into the graph's stable input buffer. No-op when there is no embedding prefix (_graphEagerFwd == 0).
-    /// </summary>
-    private void RunEagerForwardPrefix()
-    {
-        var fwd = _forwardActions;
-        for (int i = 0; i < _graphEagerFwd && i < fwd.Length; i++) fwd[i](_engine);
-    }
-
     private void RunGpuStepBodyForCapture(Engines.DirectGpu.CUDA.CudaBackend cb)
     {
         var engine = _engine;
         _preForwardParamTransform?.Invoke();
         var fwd = _forwardActions;
-        // Skip the eager prefix (the embedding) — it runs OUTSIDE the captured graph via RunEagerForwardPrefix
-        // each step, so the captured GPU sequence reads the embedding's freshly-refreshed output buffer.
+        // The whole forward (INCLUDING the embedding, which gathers on-device from the externally-refreshed stable
+        // index buffer) is captured. _graphEagerFwd is 0 in capture mode (no eager prefix).
         for (int i = _graphEagerFwd; i < fwd.Length; i++) fwd[i](engine);
 
         int esz = System.Runtime.CompilerServices.Unsafe.SizeOf<T>();
@@ -2539,16 +2546,14 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         //   FusedOptimizer.AppendFusedUpdates(plan.BackwardActions, params, grads, lr)
         // This avoids hard-coding the learning rate into the compiled plan.
 
-        // Determine the per-step persistent input for CUDA-graph refresh. For a token-LM whose FIRST forward
-        // step is the EMBEDDING (a host int→float gather the captured GPU graph cannot re-run), the float
-        // graph's true per-step input is the embedding's OUTPUT (it varies every step with the token indices).
-        // forwardSteps[0].Inputs[0] is the embeddings MATRIX (a trained param) — refreshing that leaves the
-        // token indices FROZEN at the capture step → loss stuck at ln V. So point the refresh at the embedding
-        // OUTPUT, and run the embedding eagerly each step (see _graphEagerFwd / RunEagerForwardPrefix) so its
-        // output is fresh before each graph launch.
+        // Determine the per-step persistent input for the CUDA-graph float-input refresh. When the FIRST step is
+        // the EMBEDDING, it is now CAPTURED inside the graph (a pure on-device gather over a stable index buffer
+        // refreshed via RefreshGraphEmbeddingIndices), so there is NO float input to refresh — leave it null
+        // (refreshing the embedding output would DtoH+HtoD the whole activation each step, the util killer). For a
+        // non-embedding graph plan, the persistent input is forwardSteps[0].Inputs[0] (the generic input-feed case).
         bool firstIsEmbedding = forwardSteps.Count > 0 && forwardSteps[0].OpType == OpType.Embedding;
         Tensor<T>? compiledInputTensor = firstIsEmbedding
-            ? forwardSteps[0].OutputBuffer
+            ? null
             : (forwardSteps.Count > 0 && forwardSteps[0].Inputs.Length > 0 ? forwardSteps[0].Inputs[0] : null);
         int[] compiledInputShape = compiledInputTensor is not null
             ? (int[])compiledInputTensor._shape.Clone() : Array.Empty<int>();

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -44,13 +44,18 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     // narrowly gated and any capture failure falls back to eager permanently.
     // Default ON so users get the whole-step CUDA-graph capture (collapses per-kernel launch
     // overhead → full GPU power) automatically; opt out with AIDOTNET_CUDA_GRAPH_STEP=0. Still
-    // narrowly gated at the call site (float + CUDA + eligible + no clip/checkpoint) and any
-    // capture failure falls back to eager permanently, so default-on can't change correctness.
+    // narrowly gated at the call site (float + CUDA + eligible + no clip/checkpoint). OPT-IN
+    // (default OFF): for an embedding-input model (token LM cortex), the captured graph still trains
+    // on the capture step's STALE token indices (loss frozen at ln V) — the embedding-boundary "forward
+    // not stream-pure" root (#558) is not fully solved, so enabling the graph by default would silently
+    // break correctness on the cortex. Opt in with AIDOTNET_CUDA_GRAPH_STEP=1 once that is fixed; the
+    // default path (generic GPU-pure ops, no graph) is correct + already moves all work onto the device.
     private static readonly bool s_graphStepEnabled =
-        System.Environment.GetEnvironmentVariable("AIDOTNET_CUDA_GRAPH_STEP") != "0";
+        System.Environment.GetEnvironmentVariable("AIDOTNET_CUDA_GRAPH_STEP") == "1";
     private IntPtr _stepGraphExec;
     private long _graphStepCalls;
     private bool _graphStepDisabled;
+    private bool _graphEvictionSuspended;   // eviction suspended for the graph lifetime (resumed on Dispose)
     // Capture is sound only when EVERY forward+backward action enqueues its real
     // work on the GPU stream. Host-only specialized closures (CPU-SIMD ReLU,
     // host-.Data GEMM, fused/analytic/slice/batched-dW kernels) run once at capture
@@ -177,6 +182,13 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         }
         _stepGraphExec = IntPtr.Zero;
         _graphStepCalls = 0;
+        // Balance the graph-lifetime eviction suspension (Step()): once the captured graph is gone,
+        // the buffers no longer need stable pointers, so re-enable normal activation eviction.
+        if (_graphEvictionSuspended && _engine is Engines.DirectGpuTensorEngine gEvict)
+        {
+            gEvict.ResumeActivationEviction();
+            _graphEvictionSuspended = false;
+        }
     }
 
     public Tensor<T>[] Gradients => _gradients;
@@ -487,39 +499,39 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 //    AutocastScope is a thread-static stack, so nesting with StepEager's own
                 //    scope on the capture-failure fallback is safe; eviction suspension is
                 //    refcounted for the same reason.
-                var evictGuard = System.Environment.GetEnvironmentVariable("AIDOTNET_GPU_OFFLOAD") == "1"
-                    ? null
-                    : gte;
-                evictGuard?.SuspendActivationEviction();
                 using var _graphAutocast = AiDotNet.Tensors.Engines.Gpu.AutocastScope.EnableFromEnvironment();
-                try
+                // Suspend activation eviction ONCE for the plan's entire graph lifetime (resumed on Dispose).
+                // Graph replay bakes in device POINTERS, so every buffer the captured step touches — params,
+                // activations, and the persistent input — must keep a STABLE pointer across replays; eviction
+                // would free+realloc them and invalidate the graph. (75d806b #558 model — suspend-once, not per-step.)
+                if (!_graphEvictionSuspended) { gte.SuspendActivationEviction(); _graphEvictionSuspended = true; }
+                if (_stepGraphExec == IntPtr.Zero)
                 {
-                    if (_stepGraphExec == IntPtr.Zero)
-                    {
-                        // Record the GPU forward+grad-zero+backward sequence into a graph,
-                        // then launch once to actually execute THIS step (capture only
-                        // records). The caller has already refreshed the persistent input
-                        // buffer's CONTENTS, so the stable pointers stay valid across replays.
-                        var exec = cb.CaptureGraph(() => RunGpuStepBodyForCapture(cb));
-                        if (exec == IntPtr.Zero) { _graphStepDisabled = true; return StepEager(); }
-                        _stepGraphExec = exec;
-                        cb.LaunchCapturedGraph(exec);
-                        // The optimizer update is run eagerly (NOT captured): its closure
-                        // increments _optimizerStep and re-evaluates lrSchedule.GetLr +
-                        // Adam/AdamW bias-correction each step, and bakes those scalars into
-                        // the kernel args — a captured replay would freeze them at the
-                        // capture step. Its kernels enqueue (in order) after the graph launch.
-                        _optimizerUpdate?.Invoke();
-                        return _lossOutput;
-                    }
-                    cb.LaunchCapturedGraph(_stepGraphExec);
+                    // PRE-RESIDENCY PASS: run the step body once EAGERLY so every host-backed tensor the
+                    // captured ops touch (weights/bias AND the input) is uploaded + cached OUTSIDE
+                    // capture. Then capture finds them resident → no cuMemcpyHtoD inside capture (which
+                    // is CUDA 906 STREAM_CAPTURE_UNSUPPORTED). First step does one extra (redundant) body.
+                    RunGpuStepBodyForCapture(cb);
+                    var exec = cb.CaptureGraph(() => RunGpuStepBodyForCapture(cb));
+                    if (exec == IntPtr.Zero) { _graphStepDisabled = true; return StepEager(); }
+                    _stepGraphExec = exec;
+                    cb.LaunchCapturedGraph(exec);   // executes THIS step on the just-uploaded input
+                    // The optimizer update is run eagerly (NOT captured): its closure
+                    // increments _optimizerStep and re-evaluates lrSchedule.GetLr +
+                    // Adam/AdamW bias-correction each step, and bakes those scalars into
+                    // the kernel args — a captured replay would freeze them at the
+                    // capture step. Its kernels enqueue (in order) after the graph launch.
                     _optimizerUpdate?.Invoke();
                     return _lossOutput;
                 }
-                finally
-                {
-                    evictGuard?.ResumeActivationEviction();
-                }
+                // REPLAY: SetInput copied THIS step's batch into the (host) input tensor, bumping its
+                // version. Refresh the persistent input BUFFER in place (stable pointer) OUTSIDE capture
+                // so the replayed graph reads fresh data; then replay. Without this the graph would
+                // recompute on the captured step's stale input (silently wrong training).
+                RefreshGraphInputInPlace(cb);
+                cb.LaunchCapturedGraph(_stepGraphExec);
+                _optimizerUpdate?.Invoke();
+                return _lossOutput;
             }
         }
         return StepEager();
@@ -533,6 +545,20 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     /// is deliberately NOT captured — it runs eagerly in Step() so its per-step LR /
     /// bias-correction scalars are recomputed each replay instead of frozen at capture.
     /// </summary>
+    /// <summary>Refresh the persistent graph-input tensor's GPU buffer IN PLACE (stable pointer) with
+    /// its current host contents, OUTSIDE capture, and sync its buffer-version so a captured read is a
+    /// cache hit. Called before each graph REPLAY (SetInput already wrote this step's batch into the
+    /// host tensor). No-op until the input has a resident buffer (the pre-residency pass allocates it).</summary>
+    private void RefreshGraphInputInPlace(Engines.DirectGpu.CUDA.CudaBackend cb)
+    {
+        if (_compiledInputTensor is not { } inT) return;
+        if (inT._gpuBuffer is not { } buf || !ReferenceEquals(inT._gpuBackend, cb)) return;
+        var data = inT.GetDataArray();                 // host backing (T==float on the graph path)
+        if (buf.Size < data.Length) return;
+        cb.UploadBufferInPlace((float[])(object)data, buf);
+        inT._gpuBufferVersion = inT.Version;
+    }
+
     private void RunGpuStepBodyForCapture(Engines.DirectGpu.CUDA.CudaBackend cb)
     {
         var engine = _engine;

--- a/src/AiDotNet.Tensors/Engines/Compilation/OpType.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/OpType.cs
@@ -89,6 +89,9 @@ internal enum OpType : byte
     MSELoss,
     CrossEntropyLoss,
     BinaryCrossEntropy,
+
+    // Embedding (int→float gather; a host op the captured GPU graph cannot replay — run eagerly)
+    Embedding,
 }
 
 internal static class OpTypeParser
@@ -155,6 +158,7 @@ internal static class OpTypeParser
         "MSELoss" => OpType.MSELoss,
         "TensorCrossEntropyLoss" or "CrossEntropyLoss" => OpType.CrossEntropyLoss,
         "TensorBinaryCrossEntropy" => OpType.BinaryCrossEntropy,
+        "Embedding" or "TensorEmbeddingLookup" => OpType.Embedding,
         _ => OpType.Unknown,
     };
 }

--- a/src/AiDotNet.Tensors/Engines/Compilation/OpType.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/OpType.cs
@@ -158,7 +158,7 @@ internal static class OpTypeParser
         "MSELoss" => OpType.MSELoss,
         "TensorCrossEntropyLoss" or "CrossEntropyLoss" => OpType.CrossEntropyLoss,
         "TensorBinaryCrossEntropy" => OpType.BinaryCrossEntropy,
-        "Embedding" or "TensorEmbeddingLookup" => OpType.Embedding,
+        "Embedding" or "TensorEmbeddingLookup" or "TensorEmbeddingLookupFromFloatIndices" => OpType.Embedding,
         _ => OpType.Unknown,
     };
 }

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -2023,7 +2023,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var capturedShape = newShape;
                 var origShape = tensor.Shape.ToArray();
                 return scope.RecordUnary(LazyNodeType.Reshape, "Reshape", tensor, newShape,
-                    (eng, output) => { captured.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { DirectGpuTensorEngine.CopyResultInto(eng, captured, output); },
                     BackwardFunctions<T>.ReshapeBackward, new object[] { origShape });
             }
         }
@@ -2064,7 +2064,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     (eng, output) =>
                     {
                         var eager = eng.ReorderToNchwc(captured, capturedLayout);
-                        eager.AsSpan().CopyTo(output.AsWritableSpan());
+                        DirectGpuTensorEngine.CopyResultInto(eng, eager, output);
                         output.Layout = capturedLayout;
                     });
                 // Mirror the layout on the placeholder at RECORD time. A later
@@ -2134,7 +2134,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     (eng, output) =>
                     {
                         var eager = eng.ReorderToNchw(captured);
-                        eager.AsSpan().CopyTo(output.AsWritableSpan());
+                        DirectGpuTensorEngine.CopyResultInto(eng, eager, output);
                         output.Layout = LinearAlgebra.TensorLayout.Nchw;
                     });
                 // Propagate Layout at record time (see matching comment in
@@ -2326,7 +2326,7 @@ public partial class CpuEngine : ITensorLevelEngine
                         else
                         {
                             var r = eng.BatchNormInference(capX, capG, capB, capM, capV, capE);
-                            r.AsSpan().CopyTo(output.AsWritableSpan());
+                            DirectGpuTensorEngine.CopyResultInto(eng, r, output);
                             output.Layout = r.Layout;
                         }
                     },
@@ -2483,7 +2483,7 @@ public partial class CpuEngine : ITensorLevelEngine
                         else
                         {
                             var eager = eng.BatchMatMul(capturedA, capturedB);
-                            eager.AsSpan().CopyTo(output.AsWritableSpan());
+                            DirectGpuTensorEngine.CopyResultInto(eng, eager, output);
                         }
                     },
                     BackwardFunctions<T>.BatchMatMulBackward);
@@ -3130,7 +3130,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var capturedB = b;
                 var broadcastShape = ComputeBroadcastShape(a._shape, b._shape);
                 return scope.RecordBinary(LazyNodeType.BroadcastAdd, "TensorBroadcastAdd", a, b, broadcastShape,
-                    (eng, output) => { var eager = eng.TensorBroadcastAdd(capturedA, capturedB); eager.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var eager = eng.TensorBroadcastAdd(capturedA, capturedB); DirectGpuTensorEngine.CopyResultInto(eng, eager, output); },
                     BackwardFunctions<T>.BroadcastAddBackward);
             }
         }
@@ -3229,7 +3229,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 // a._shape is not always the final broadcast shape.
                 var broadcastShape = ComputeBroadcastShape(a._shape, b._shape);
                 return scope.RecordBinary(LazyNodeType.BroadcastSubtract, "TensorBroadcastSubtract", a, b, broadcastShape,
-                    (eng, output) => { var r = eng.TensorBroadcastSubtract(capturedA, capturedB); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorBroadcastSubtract(capturedA, capturedB); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.BroadcastSubtractBackward);
             }
         }
@@ -3339,7 +3339,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 // Same broadcast-shape fix as TensorBroadcastMultiply.
                 var broadcastShape = ComputeBroadcastShape(a._shape, b._shape);
                 return scope.RecordBinary(LazyNodeType.BroadcastDivide, "TensorBroadcastDivide", a, b, broadcastShape,
-                    (eng, output) => { var r = eng.TensorBroadcastDivide(capturedA, capturedB); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorBroadcastDivide(capturedA, capturedB); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.BroadcastDivideBackward);
             }
         }
@@ -3397,7 +3397,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 // inside the closure overran it with "Destination is too short".
                 var broadcastShape = ComputeBroadcastShape(a._shape, b._shape);
                 return scope.RecordBinary(LazyNodeType.BroadcastMultiply, "TensorBroadcastMultiply", a, b, broadcastShape,
-                    (eng, output) => { var r = eng.TensorBroadcastMultiply(capturedA, capturedB); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorBroadcastMultiply(capturedA, capturedB); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.BroadcastMultiplyBackward);
             }
         }
@@ -4769,7 +4769,7 @@ public partial class CpuEngine : ITensorLevelEngine
             }
         }
 
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var captured = tensors.ToArray(); return scope.RecordVariadic(LazyNodeType.Custom, "TensorAddMany", captured, referenceShape, (eng, output) => { var r = eng.TensorAddMany(captured); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.AddManyBackward); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var captured = tensors.ToArray(); return scope.RecordVariadic(LazyNodeType.Custom, "TensorAddMany", captured, referenceShape, (eng, output) => { var r = eng.TensorAddMany(captured); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.AddManyBackward); } }
 
         var numOps = MathHelper.GetNumericOperations<T>();
         int length = tensors[0].Length;
@@ -5579,7 +5579,7 @@ public partial class CpuEngine : ITensorLevelEngine
             }
         }
 
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var captured = tensors.ToArray(); return scope.RecordVariadic(LazyNodeType.Custom, "TensorMultiplyMany", captured, referenceShape, (eng, output) => { var r = eng.TensorMultiplyMany(captured); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.MultiplyManyBackward); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var captured = tensors.ToArray(); return scope.RecordVariadic(LazyNodeType.Custom, "TensorMultiplyMany", captured, referenceShape, (eng, output) => { var r = eng.TensorMultiplyMany(captured); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.MultiplyManyBackward); } }
 
         var numOps = MathHelper.GetNumericOperations<T>();
 
@@ -5615,7 +5615,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     (eng, output) =>
                     {
                         if (eng is CpuEngine cpuEng) cpuEng.TensorMultiplyScalarInto(output, captured, capturedScalar);
-                        else { var r = eng.TensorMultiplyScalar(captured, capturedScalar); r.AsSpan().CopyTo(output.AsWritableSpan()); }
+                        else { var r = eng.TensorMultiplyScalar(captured, capturedScalar); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }
                     },
                     BackwardFunctions<T>.MultiplyScalarBackward, scalar != null ? new object[] { scalar } : Array.Empty<object>());
             }
@@ -5966,7 +5966,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     (eng, output) =>
                     {
                         if (eng is CpuEngine cpuEng) cpuEng.TensorLogInto(output, captured);
-                        else { var r = eng.TensorLog(captured); r.AsSpan().CopyTo(output.AsWritableSpan()); }
+                        else { var r = eng.TensorLog(captured); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }
                     },
                     BackwardFunctions<T>.LogBackward);
             }
@@ -6030,7 +6030,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     (eng, output) =>
                     {
                         if (eng is CpuEngine cpuEng) cpuEng.TensorExpInto(output, captured);
-                        else { var r = eng.TensorExp(captured); r.AsSpan().CopyTo(output.AsWritableSpan()); }
+                        else { var r = eng.TensorExp(captured); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }
                     },
                     BackwardFunctions<T>.ExpBackward);
             }
@@ -6099,7 +6099,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     (eng, output) =>
                     {
                         if (eng is CpuEngine cpuEng) cpuEng.TensorSqrtInto(output, captured);
-                        else { var r = eng.TensorSqrt(captured); r.AsSpan().CopyTo(output.AsWritableSpan()); }
+                        else { var r = eng.TensorSqrt(captured); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }
                     },
                     BackwardFunctions<T>.SqrtBackward);
             }
@@ -6149,7 +6149,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     (eng, output) =>
                     {
                         if (eng is CpuEngine cpuEng) cpuEng.TensorAbsInto(output, captured);
-                        else { var r = eng.TensorAbs(captured); r.AsSpan().CopyTo(output.AsWritableSpan()); }
+                        else { var r = eng.TensorAbs(captured); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }
                     },
                     BackwardFunctions<T>.AbsBackward);
             }
@@ -6262,7 +6262,7 @@ public partial class CpuEngine : ITensorLevelEngine
             {
                 var captured = tensor; var capturedExp = exponent;
                 return scope.RecordUnary(LazyNodeType.Custom, "TensorPower", tensor, tensor._shape,
-                    (eng, output) => { var r = eng.TensorPower(captured, capturedExp); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorPower(captured, capturedExp); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.PowerBackward, exponent is not null ? new object[] { exponent } : Array.Empty<object>());
             }
         }
@@ -6338,7 +6338,7 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (bases == null) throw new ArgumentNullException(nameof(bases));
         if (exponents == null) throw new ArgumentNullException(nameof(exponents));
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_bases = bases; var c_exponents = exponents; return scope.RecordBinary(LazyNodeType.Custom, "TensorPowerTensor", bases, exponents, bases._shape, (eng, output) => { var r = eng.TensorPower(c_bases, c_exponents); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.PowerTensorBackward); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_bases = bases; var c_exponents = exponents; return scope.RecordBinary(LazyNodeType.Custom, "TensorPowerTensor", bases, exponents, bases._shape, (eng, output) => { var r = eng.TensorPower(c_bases, c_exponents); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.PowerTensorBackward); } }
 
         var basesOrig = bases;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!bases.IsContiguous) bases = bases.Contiguous();
@@ -6505,7 +6505,7 @@ public partial class CpuEngine : ITensorLevelEngine
     public Tensor<T> TensorFrac<T>(Tensor<T> tensor)
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_tensor = tensor; return scope.RecordUnary(LazyNodeType.Custom, "TensorFrac", tensor, tensor._shape, (eng, output) => { var r = eng.TensorFrac(c_tensor); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.FracBackward); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_tensor = tensor; return scope.RecordUnary(LazyNodeType.Custom, "TensorFrac", tensor, tensor._shape, (eng, output) => { var r = eng.TensorFrac(c_tensor); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.FracBackward); } }
 
 
         var tensorOrig = tensor;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
@@ -6541,7 +6541,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     (eng, output) =>
                     {
                         if (eng is CpuEngine cpuEng) cpuEng.TensorSinInto(output, captured);
-                        else { var r = eng.TensorSin(captured); r.AsSpan().CopyTo(output.AsWritableSpan()); }
+                        else { var r = eng.TensorSin(captured); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }
                     },
                     BackwardFunctions<T>.SinBackward);
             }
@@ -6596,7 +6596,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     (eng, output) =>
                     {
                         if (eng is CpuEngine cpuEng) cpuEng.TensorCosInto(output, captured);
-                        else { var r = eng.TensorCos(captured); r.AsSpan().CopyTo(output.AsWritableSpan()); }
+                        else { var r = eng.TensorCos(captured); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }
                     },
                     BackwardFunctions<T>.CosBackward);
             }
@@ -6643,7 +6643,7 @@ public partial class CpuEngine : ITensorLevelEngine
             throw new ArgumentException("Grid must be 4D tensor of shape [D, H, W, C]", nameof(grid));
         if (positions._shape.Length != 2 || positions._shape[1] != 3)
             throw new ArgumentException("Positions must be 2D tensor of shape [N, 3]", nameof(positions));
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_grid = grid; var c_positions = positions; return scope.RecordBinary(LazyNodeType.Custom, "TensorTrilinearInterpolate", grid, positions, grid._shape, (eng, output) => { var r = eng.TensorTrilinearInterpolate(c_grid, c_positions); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.TrilinearInterpolateBackward); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_grid = grid; var c_positions = positions; return scope.RecordBinary(LazyNodeType.Custom, "TensorTrilinearInterpolate", grid, positions, grid._shape, (eng, output) => { var r = eng.TensorTrilinearInterpolate(c_grid, c_positions); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.TrilinearInterpolateBackward); } }
         { var ac = AutoTracer.TryGetCompiledPlan<T>("TensorTrilinearInterpolate", grid._shape); if (ac is not null) return ac.Execute(); }
 
         var numOps = MathHelper.GetNumericOperations<T>();
@@ -6840,7 +6840,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var capturedExponent = exponent;
                 object boxedExp = exponent is not null ? (object)exponent : throw new InvalidOperationException("Exponent cannot be null");
                 return scope.RecordUnary(LazyNodeType.Custom, "TensorPow", tensor, tensor._shape,
-                    (eng, output) => { var r = eng.TensorPow(captured, capturedExponent); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorPow(captured, capturedExponent); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.TensorPowBackward, new object[] { boxedExp });
             }
         }
@@ -6878,7 +6878,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var capturedA = a;
                 var capturedB = b;
                 return scope.RecordBinary(LazyNodeType.Custom, "TensorMax", a, b, a._shape,
-                    (eng, output) => { var r = eng.TensorMax(capturedA, capturedB); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorMax(capturedA, capturedB); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.MaxBackward);
             }
         }
@@ -6970,7 +6970,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var capturedA = a;
                 var capturedB = b;
                 return scope.RecordBinary(LazyNodeType.Custom, "TensorMin", a, b, a._shape,
-                    (eng, output) => { var r = eng.TensorMin(capturedA, capturedB); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorMin(capturedA, capturedB); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.MinBackward);
             }
         }
@@ -7063,7 +7063,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var capturedMax = max;
                 var numOpsLazy = MathHelper.GetNumericOperations<T>();
                 return scope.RecordUnary(LazyNodeType.Custom, "Clamp", captured, captured._shape,
-                    (eng, output) => { var r = eng.TensorClamp(captured, capturedMin, capturedMax); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorClamp(captured, capturedMin, capturedMax); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.ClampBackward, new object[] { numOpsLazy.ToDouble(min), numOpsLazy.ToDouble(max) });
             }
         }
@@ -7244,7 +7244,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     (eng, output) =>
                     {
                         var eager = eng.ReduceSum(captured, capturedAxes, capturedKeepDims);
-                        eager.AsSpan().CopyTo(output.AsWritableSpan());
+                        DirectGpuTensorEngine.CopyResultInto(eng, eager, output);
                     },
                     BackwardFunctions<T>.ReduceSumBackward,
                     new object[] { axes ?? Array.Empty<int>(), keepDims });
@@ -7973,7 +7973,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     (eng, output) =>
                     {
                         if (eng is CpuEngine cpuEng) cpuEng.MaxPool2DInto(output, captured, ps, st, pd);
-                        else { var eager = eng.MaxPool2D(captured, ps, st, pd); eager.AsSpan().CopyTo(output.AsWritableSpan()); }
+                        else { var eager = eng.MaxPool2D(captured, ps, st, pd); DirectGpuTensorEngine.CopyResultInto(eng, eager, output); }
                     },
                     BackwardFunctions<T>.MaxPool2DBackward, new object[] { new[] { poolSize, poolSize }, new[] { stride, stride } });
             }
@@ -8412,7 +8412,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     (eng, output) =>
                     {
                         if (eng is CpuEngine cpuEng) cpuEng.AvgPool2DInto(output, captured, ps, s, p);
-                        else { var r = eng.AvgPool2D(captured, ps, s, p); r.AsSpan().CopyTo(output.AsWritableSpan()); }
+                        else { var r = eng.AvgPool2D(captured, ps, s, p); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }
                     },
                     BackwardFunctions<T>.AvgPool2DBackward, new object[] { new[] { poolSize, poolSize }, new[] { st, st } });
             }
@@ -8586,7 +8586,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var capturedKernel = kernel;
                 int s = stride, p = padding, d = dilation;
                 return scope.RecordBinary(LazyNodeType.Custom, "Conv1D", input, kernel, outShape,
-                    (eng, output) => { var r = eng.Conv1D(capturedInput, capturedKernel, s, p, d); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.Conv1D(capturedInput, capturedKernel, s, p, d); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.Conv1DBackward, new object[] { stride, padding, dilation });
             }
         }
@@ -8696,7 +8696,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     (eng, output) =>
                     {
                         if (eng is CpuEngine cpuEng) cpuEng.Conv2DInto(output, capturedInput, capturedKernel, s, p, d);
-                        else { var eager = eng.Conv2D(capturedInput, capturedKernel, s, p, d); eager.AsSpan().CopyTo(output.AsWritableSpan()); }
+                        else { var eager = eng.Conv2D(capturedInput, capturedKernel, s, p, d); DirectGpuTensorEngine.CopyResultInto(eng, eager, output); }
                     },
                     BackwardFunctions<T>.Conv2DBackward, new object[] { new[] { stride, stride }, new[] { padding, padding }, new[] { dilation, dilation } });
             }
@@ -10389,7 +10389,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     (eng, output) =>
                     {
                         if (eng is CpuEngine cpuEng) cpuEng.MishInto(output, captured);
-                        else { var r = eng.Mish(captured); r.AsSpan().CopyTo(output.AsWritableSpan()); }
+                        else { var r = eng.Mish(captured); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }
                     },
                     BackwardFunctions<T>.MishBackward);
             }
@@ -10519,7 +10519,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     (eng, output) =>
                     {
                         if (eng is CpuEngine cpuEng) cpuEng.ELUInto(output, captured, capturedAlpha);
-                        else { var r = eng.ELU(captured, capturedAlpha); r.AsSpan().CopyTo(output.AsWritableSpan()); }
+                        else { var r = eng.ELU(captured, capturedAlpha); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }
                     },
                     BackwardFunctions<T>.ELUBackward, new object[] { alpha });
             }
@@ -10711,7 +10711,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var outShape = input.Shape.ToArray();
                 outShape[actualDim] = input._shape[actualDim] / 2;
                 return scope.RecordUnary(LazyNodeType.Custom, "GLU", input, outShape,
-                    (eng, output) => { var r = eng.GLU(captured, capDim); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.GLU(captured, capDim); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.GLUBackward, new object[] { actualDim });
             }
         }
@@ -11286,7 +11286,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     (eng, output) =>
                     {
                         var eager = eng.TensorMatMulTransposed(capturedA, capturedB);
-                        eager.AsSpan().CopyTo(output.AsWritableSpan());
+                        DirectGpuTensorEngine.CopyResultInto(eng, eager, output);
                     },
                     BackwardFunctions<T>.MatMulTransposedBackward);
             }
@@ -11420,7 +11420,7 @@ public partial class CpuEngine : ITensorLevelEngine
                         else
                         {
                             var eager = eng.TensorMatMul(capturedA, capturedB);
-                            eager.AsSpan().CopyTo(output.AsWritableSpan());
+                            DirectGpuTensorEngine.CopyResultInto(eng, eager, output);
                         }
                     },
                     BackwardFunctions<T>.MatMulBackward);
@@ -12451,7 +12451,7 @@ public partial class CpuEngine : ITensorLevelEngine
                         // allocating an intermediate tensor.
                         if (eng is CpuEngine cpuEng)
                             cpuEng.Conv2DInto(output, capturedInput, capturedKernel, capturedStride, capturedPad, capturedDil);
-                        else { var eager = eng.Conv2D(capturedInput, capturedKernel, capturedStride, capturedPad, capturedDil); eager.AsSpan().CopyTo(output.AsWritableSpan()); }
+                        else { var eager = eng.Conv2D(capturedInput, capturedKernel, capturedStride, capturedPad, capturedDil); DirectGpuTensorEngine.CopyResultInto(eng, eager, output); }
                     },
                     BackwardFunctions<T>.Conv2DBackward, new object[] { stride, padding, dilation });
             }
@@ -14857,7 +14857,7 @@ public partial class CpuEngine : ITensorLevelEngine
                         else
                         {
                             var eager = eng.MaxPool2DWithIndices(captured, new[] { ph, pw }, new[] { sh, sw }, out _);
-                            eager.AsSpan().CopyTo(output.AsWritableSpan());
+                            DirectGpuTensorEngine.CopyResultInto(eng, eager, output);
                         }
                     });
             }
@@ -15059,7 +15059,7 @@ public partial class CpuEngine : ITensorLevelEngine
                         // which the int-scalar AvgPool2D doesn't support. Compute
                         // via the int[] path on replay to preserve rect semantics.
                         var r = eng.AvgPool2D(capturedInput, capturedPool, capturedStride);
-                        r.AsSpan().CopyTo(output.AsWritableSpan());
+                        DirectGpuTensorEngine.CopyResultInto(eng, r, output);
                     },
                     BackwardFunctions<T>.AvgPool2DBackward, new object[] { capturedPool, capturedStride });
             }
@@ -15268,7 +15268,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     (eng, output) =>
                     {
                         if (eng is CpuEngine cpuEng) cpuEng.DepthwiseConv2DInto(output, capturedInput, capturedKernel, capturedStride, capturedPadding);
-                        else { var r = eng.DepthwiseConv2D(capturedInput, capturedKernel, capturedStride, capturedPadding); r.AsSpan().CopyTo(output.AsWritableSpan()); }
+                        else { var r = eng.DepthwiseConv2D(capturedInput, capturedKernel, capturedStride, capturedPadding); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }
                     },
                     BackwardFunctions<T>.DepthwiseConv2DBackward, new object[] { stride, padding });
             }
@@ -15538,7 +15538,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var capturedPadding = (int[])padding.Clone();
                 var capturedOutputPadding = (int[])outputPadding.Clone();
                 return scope.RecordBinary(LazyNodeType.Custom, "ConvTranspose2D", input, kernel, outShape,
-                    (eng, output) => { var r = eng.ConvTranspose2D(capturedInput, capturedKernel, capturedStride, capturedPadding, capturedOutputPadding); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.ConvTranspose2D(capturedInput, capturedKernel, capturedStride, capturedPadding, capturedOutputPadding); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.ConvTranspose2DBackward, new object[] { (int[])stride.Clone(), (int[])padding.Clone() });
             }
         }
@@ -16140,7 +16140,7 @@ public partial class CpuEngine : ITensorLevelEngine
                                 capturedInput, capturedKernel, capturedOffset,
                                 mask: null,
                                 capturedStride, capturedPadding, capturedDilation);
-                            replayed.AsSpan().CopyTo(output.AsWritableSpan());
+                            DirectGpuTensorEngine.CopyResultInto(eng, replayed, output);
                         },
                         BackwardFunctions<T>.DeformableConv2DBackward,
                         savedState);
@@ -17133,7 +17133,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var capturedPadding = padding;
                 var capturedDilation = dilation;
                 return scope.RecordBinary(LazyNodeType.Custom, "Conv3D", input, kernel, outShape,
-                    (eng, output) => { var r = eng.Conv3D(capturedInput, capturedKernel, capturedStride, capturedPadding, capturedDilation); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.Conv3D(capturedInput, capturedKernel, capturedStride, capturedPadding, capturedDilation); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.Conv3DBackward, new object[] { stride, padding, dilation });
             }
         }
@@ -17646,7 +17646,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var capturedStride = stride;
                 var capturedPadding = padding;
                 return scope.RecordUnary(LazyNodeType.Custom, "MaxPool3D", input, outShape,
-                    (eng, output) => { var r = eng.MaxPool3D(capturedInput, capturedPool, capturedStride, capturedPadding); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.MaxPool3D(capturedInput, capturedPool, capturedStride, capturedPadding); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     backwardFn: null, savedState: new object[] { capturedPool, capturedStride, capturedPadding });
             }
         }
@@ -17942,7 +17942,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var capturedStride = stride;
                 var capturedPadding = padding;
                 return scope.RecordUnary(LazyNodeType.Custom, "AvgPool3D", input, outShape,
-                    (eng, output) => { var r = eng.AvgPool3D(capturedInput, capturedPool, capturedStride, capturedPadding); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.AvgPool3D(capturedInput, capturedPool, capturedStride, capturedPadding); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     backwardFn: null, savedState: new object[] { capturedPool, capturedStride, capturedPadding });
             }
         }
@@ -17967,7 +17967,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var capturedStride = stride;
                 var capturedPadding = padding;
                 return scope.RecordUnary(LazyNodeType.Custom, "AvgPool3D", input, outShape,
-                    (eng, output) => { var r = eng.AvgPool3D(captured, capturedPool, capturedStride, capturedPadding); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.AvgPool3D(captured, capturedPool, capturedStride, capturedPadding); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.AvgPool3DBackward, new object[] { poolSize, stride, padding });
             }
         }
@@ -18167,7 +18167,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var outShape = new[] { input._shape[0], input._shape[1],
                     input._shape[2] * scaleD, input._shape[3] * scaleH, input._shape[4] * scaleW };
                 return scope.RecordUnary(LazyNodeType.Custom, "Upsample3D", input, outShape,
-                    (eng, output) => { var r = eng.Upsample3D(captured, capD, capH, capW); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.Upsample3D(captured, capD, capH, capW); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.Upsample3DBackward, new object[] { capD, capH, capW });
             }
         }
@@ -18319,7 +18319,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var ci = input; var ck = kernel;
                 var cs = (int[])stride.Clone(); var cp = (int[])padding.Clone(); var cop = (int[])outputPadding.Clone();
                 return scope.RecordBinary(LazyNodeType.Custom, "ConvTranspose3D", input, kernel, outShape,
-                    (eng, output) => { var r = eng.ConvTranspose3D(ci, ck, cs, cp, cop); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.ConvTranspose3D(ci, ck, cs, cp, cop); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.ConvTranspose3DBackward, new object[] { (int[])stride.Clone(), (int[])padding.Clone() });
             }
         }
@@ -18573,7 +18573,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var ci = input; var cw = weights; var cb = bias; var cs = (int[])stride.Clone();
                 var inputs = bias is not null ? new[] { input, weights, bias } : new[] { input, weights };
                 return scope.RecordVariadic(LazyNodeType.Custom, "LocallyConnectedConv2D", inputs, outShape,
-                    (eng, output) => { var r = eng.LocallyConnectedConv2D(ci, cw, cb, cs); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.LocallyConnectedConv2D(ci, cw, cb, cs); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.LocallyConnectedConv2DBackward, new object[] { (int[])stride.Clone() });
             }
         }
@@ -19547,7 +19547,7 @@ public partial class CpuEngine : ITensorLevelEngine
         if (input == null) throw new ArgumentNullException(nameof(input));
         if (order < 1)
             throw new ArgumentOutOfRangeException(nameof(order), order, "Order must be at least 1.");
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_input = input; var c_order = order; var c_axis = axis; return scope.RecordUnary(LazyNodeType.Custom, "TaylorSoftmax", input, input._shape, (eng, output) => { var r = eng.TaylorSoftmax(c_input, c_order, c_axis); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.SoftmaxBackward); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_input = input; var c_order = order; var c_axis = axis; return scope.RecordUnary(LazyNodeType.Custom, "TaylorSoftmax", input, input._shape, (eng, output) => { var r = eng.TaylorSoftmax(c_input, c_order, c_axis); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.SoftmaxBackward); } }
         { var ac = AutoTracer.TryGetCompiledPlan<T>("TaylorSoftmax", input._shape); if (ac is not null) return ac.Execute(); }
 
         var numOps = MathHelper.GetNumericOperations<T>();
@@ -19719,7 +19719,7 @@ public partial class CpuEngine : ITensorLevelEngine
     public Tensor<T> Sparsemax<T>(Tensor<T> input, int axis = -1)
     {
         if (input == null) throw new ArgumentNullException(nameof(input));
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_input = input; var c_axis = axis; return scope.RecordUnary(LazyNodeType.Custom, "Sparsemax", input, input._shape, (eng, output) => { var r = eng.Sparsemax(c_input, c_axis); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.SparsemaxBackward); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_input = input; var c_axis = axis; return scope.RecordUnary(LazyNodeType.Custom, "Sparsemax", input, input._shape, (eng, output) => { var r = eng.Sparsemax(c_input, c_axis); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.SparsemaxBackward); } }
         { var ac = AutoTracer.TryGetCompiledPlan<T>("Sparsemax", input._shape); if (ac is not null) return ac.Execute(); }
 
         var numOps = MathHelper.GetNumericOperations<T>();
@@ -20052,7 +20052,7 @@ public partial class CpuEngine : ITensorLevelEngine
                         var r = eng.BatchNorm(ci, cg, cb, ce, out var freshMean, out var freshVar);
                         try
                         {
-                            r.AsSpan().CopyTo(output.AsWritableSpan());
+                            DirectGpuTensorEngine.CopyResultInto(eng, r, output);
                             freshMean.AsSpan().CopyTo(capturedMean.AsWritableSpan());
                             freshVar.AsSpan().CopyTo(capturedVar.AsWritableSpan());
                         }
@@ -21497,7 +21497,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     (eng, output) =>
                     {
                         var r = eng.LayerNorm(ci, cg, cb, ce, out var freshMean, out var freshVar);
-                        r.AsSpan().CopyTo(output.AsWritableSpan());
+                        DirectGpuTensorEngine.CopyResultInto(eng, r, output);
                         // Hand the correctly-shaped realize-time stats to backward
                         // by reference — avoids the trace-vs-replay size mismatch.
                         stateRef.Mean = freshMean;
@@ -22832,7 +22832,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     (eng, output) =>
                     {
                         var r = eng.GroupNorm(ci, cn, cg, cb, ce, out var freshMean, out var freshVar);
-                        r.AsSpan().CopyTo(output.AsWritableSpan());
+                        DirectGpuTensorEngine.CopyResultInto(eng, r, output);
                         freshMean.AsSpan().CopyTo(capturedGNMean.AsWritableSpan());
                         freshVar.AsSpan().CopyTo(capturedGNVar.AsWritableSpan());
                     },
@@ -23292,7 +23292,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     (eng, output) =>
                     {
                         var r = eng.RMSNorm(ci, cg, ce, out var freshRms);
-                        r.AsSpan().CopyTo(output.AsWritableSpan());
+                        DirectGpuTensorEngine.CopyResultInto(eng, r, output);
                         freshRms.AsSpan().CopyTo(capturedRms.AsWritableSpan());
                     },
                     BackwardFunctions<T>.RMSNormBackward, new object[] { rms, epsilon });
@@ -24879,7 +24879,7 @@ public partial class CpuEngine : ITensorLevelEngine
                         var freshOut = eng.FlashAttention(
                             capturedQuery, capturedKey, capturedValue,
                             capturedScale, capturedIsCausal, out var freshStats, capturedBias);
-                        freshOut.AsSpan().CopyTo(output.AsWritableSpan());
+                        DirectGpuTensorEngine.CopyResultInto(eng, freshOut, output);
                         freshStats.AsSpan().CopyTo(capturedStats.AsWritableSpan());
                     },
                     BackwardFunctions<T>.FlashAttentionBackward,
@@ -26432,7 +26432,7 @@ public partial class CpuEngine : ITensorLevelEngine
                                 capturedNode, capturedSrcIdx, capturedTgtIdx,
                                 capturedSrc, capturedTgt, capturedAlpha,
                                 out _);
-                            replayed.AsSpan().CopyTo(output.AsWritableSpan());
+                            DirectGpuTensorEngine.CopyResultInto(eng, replayed, output);
                         },
                         BackwardFunctions<T>.GraphAttentionBackward,
                         savedState);
@@ -26757,7 +26757,7 @@ public partial class CpuEngine : ITensorLevelEngine
             throw new ArgumentNullException(nameof(source));
         if (indices == null)
             throw new ArgumentNullException(nameof(indices));
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_source = source; var c_indices = indices; var c_dim = dim; var c_outputSize = outputSize; return scope.RecordUnary(LazyNodeType.Custom, "ScatterAdd", source, source._shape, (eng, output) => { var r = eng.ScatterAdd(c_source, c_indices, c_dim, c_outputSize); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.ScatterAddBackward); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_source = source; var c_indices = indices; var c_dim = dim; var c_outputSize = outputSize; return scope.RecordUnary(LazyNodeType.Custom, "ScatterAdd", source, source._shape, (eng, output) => { var r = eng.ScatterAdd(c_source, c_indices, c_dim, c_outputSize); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.ScatterAddBackward); } }
         { var ac = AutoTracer.TryGetCompiledPlan<T>("ScatterAdd", source._shape); if (ac is not null) return ac.Execute(); }
 
         var numOps = MathHelper.GetNumericOperations<T>();
@@ -26900,7 +26900,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     (eng, output) =>
                     {
                         var r = eng.ScatterMean(cs, ci, out var freshCounts, cd, co);
-                        r.AsSpan().CopyTo(output.AsWritableSpan());
+                        DirectGpuTensorEngine.CopyResultInto(eng, r, output);
                         if (capturedCounts is not null && freshCounts is not null
                             && capturedCounts.Length == freshCounts.Length)
                             freshCounts.AsSpan().CopyTo(capturedCounts.AsWritableSpan());
@@ -27255,7 +27255,7 @@ public partial class CpuEngine : ITensorLevelEngine
         if (indices == null)
             throw new ArgumentNullException(nameof(indices));
 
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var cs = source; var ci = indices; var cd = dim; var co = outputSize; return scope.RecordUnary(LazyNodeType.Custom, "ScatterSoftmax", source, source._shape, (eng, output) => { var r = eng.ScatterSoftmax(cs, ci, cd, co); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.ScatterSoftmaxBackward); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var cs = source; var ci = indices; var cd = dim; var co = outputSize; return scope.RecordUnary(LazyNodeType.Custom, "ScatterSoftmax", source, source._shape, (eng, output) => { var r = eng.ScatterSoftmax(cs, ci, cd, co); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.ScatterSoftmaxBackward); } }
 
         { var ac = AutoTracer.TryGetCompiledPlan<T>("ScatterSoftmax", source._shape); if (ac is not null) return ac.Execute(); }
 
@@ -27659,7 +27659,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 }
                 var outShape = shapeList.Count > 0 ? shapeList.ToArray() : new[] { 1 };
                 return scope.RecordUnary(LazyNodeType.ReduceMean, "ReduceMean", input, outShape,
-                    (eng, output) => { var r = eng.ReduceMean(captured, capturedAxes, capturedKeepDims); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.ReduceMean(captured, capturedAxes, capturedKeepDims); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.ReduceMeanBackward, new object[] { axes, keepDims });
             }
         }
@@ -28161,7 +28161,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     {
                         // Replay: re-run the math into the pre-allocated output.
                         var replayed = eng.ReduceVariance(capturedInput, capturedAxes, capturedKeepDims);
-                        replayed.AsSpan().CopyTo(output.AsWritableSpan());
+                        DirectGpuTensorEngine.CopyResultInto(eng, replayed, output);
                     },
                     BackwardFunctions<T>.ReduceVarianceBackward,
                     new object[] { (int[])capturedAxes.Clone(), meanForBackward });
@@ -28287,7 +28287,7 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (input == null)
             throw new ArgumentNullException(nameof(input));
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_input = input; var c_axes = axes; var c_keepDims = keepDims; var c_epsilon = epsilon; return scope.RecordUnary(LazyNodeType.Custom, "ReduceLogVariance", input, input._shape, (eng, output) => { var r = eng.ReduceLogVariance(c_input, c_axes, c_keepDims, c_epsilon); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.ReduceLogVarianceBackward); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_input = input; var c_axes = axes; var c_keepDims = keepDims; var c_epsilon = epsilon; return scope.RecordUnary(LazyNodeType.Custom, "ReduceLogVariance", input, input._shape, (eng, output) => { var r = eng.ReduceLogVariance(c_input, c_axes, c_keepDims, c_epsilon); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.ReduceLogVarianceBackward); } }
         { var ac = AutoTracer.TryGetCompiledPlan<T>("ReduceLogVariance", input._shape); if (ac is not null) return ac.Execute(); }
 
         var inputOrig = input;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
@@ -28537,7 +28537,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     (eng, output) =>
                     {
                         if (eng is CpuEngine cpuEng) cpuEng.UpsampleInto(output, captured, capScaleH, capScaleW);
-                        else { var r = eng.Upsample(captured, capScaleH, capScaleW); r.AsSpan().CopyTo(output.AsWritableSpan()); }
+                        else { var r = eng.Upsample(captured, capScaleH, capScaleW); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }
                     },
                     BackwardFunctions<T>.UpsampleBackward, new object[] { capScaleH, capScaleW });
             }
@@ -28810,7 +28810,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     (eng, output) =>
                     {
                         if (eng is CpuEngine cpuEng) cpuEng.PixelShuffleInto(output, c_input, c_upscaleFactor);
-                        else { var r = eng.PixelShuffle(c_input, c_upscaleFactor); r.AsSpan().CopyTo(output.AsWritableSpan()); }
+                        else { var r = eng.PixelShuffle(c_input, c_upscaleFactor); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }
                     },
                     BackwardFunctions<T>.PixelShuffleBackward, new object[] { c_upscaleFactor });
             }
@@ -28936,7 +28936,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var ci = input; var cg = grid;
                 var outShape = new[] { input._shape[0], grid._shape[1], grid._shape[2], input._shape[3] };
                 return scope.RecordBinary(LazyNodeType.Custom, "GridSample", input, grid, outShape,
-                    (eng, output) => { var r = eng.GridSample(ci, cg); r.AsSpan().CopyTo(output.AsWritableSpan()); });
+                    (eng, output) => { var r = eng.GridSample(ci, cg); DirectGpuTensorEngine.CopyResultInto(eng, r, output); });
             }
         }
 
@@ -29033,7 +29033,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 int oW = (input._shape[3] + 2 * lpW - lkW) / lsW + 1;
                 var outShape = new[] { input._shape[0], input._shape[1] * lkH * lkW, oH * oW };
                 return scope.RecordUnary(LazyNodeType.Custom, "Unfold", input, outShape,
-                    (eng, output) => { var r = eng.Unfold(ci, ck, cs, cp); r.AsSpan().CopyTo(output.AsWritableSpan()); });
+                    (eng, output) => { var r = eng.Unfold(ci, ck, cs, cp); DirectGpuTensorEngine.CopyResultInto(eng, r, output); });
             }
         }
         { var ac = AutoTracer.TryGetCompiledPlan<T>("Unfold", input._shape); if (ac is not null) return ac.Execute(); }
@@ -29127,7 +29127,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 int lCh = input._shape[1] / (lkH * lkW);
                 var outShape = new[] { lBatch, lCh, outputSize[0], outputSize[1] };
                 return scope.RecordUnary(LazyNodeType.Custom, "Fold", input, outShape,
-                    (eng, output) => { var r = eng.Fold(ci, co, ck, cs, cp); r.AsSpan().CopyTo(output.AsWritableSpan()); });
+                    (eng, output) => { var r = eng.Fold(ci, co, ck, cs, cp); DirectGpuTensorEngine.CopyResultInto(eng, r, output); });
             }
         }
         { var ac = AutoTracer.TryGetCompiledPlan<T>("Fold", input._shape); if (ac is not null) return ac.Execute(); }
@@ -29255,7 +29255,7 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (real == null || imag == null)
             throw new ArgumentNullException("ComplexMagnitudeSquared inputs cannot be null");
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_real = real; var c_imag = imag; return scope.RecordBinary(LazyNodeType.Custom, "ComplexMagnitudeSquared", real, imag, real._shape, (eng, output) => { var r = eng.ComplexMagnitudeSquared(c_real, c_imag); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.ComplexMagnitudeSquaredBackward); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_real = real; var c_imag = imag; return scope.RecordBinary(LazyNodeType.Custom, "ComplexMagnitudeSquared", real, imag, real._shape, (eng, output) => { var r = eng.ComplexMagnitudeSquared(c_real, c_imag); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.ComplexMagnitudeSquaredBackward); } }
         { var ac = AutoTracer.TryGetCompiledPlan<T>("ComplexMagnitudeSquared", real._shape); if (ac is not null) return ac.Execute(); }
 
         if (!real._shape.SequenceEqual(imag._shape))
@@ -29388,7 +29388,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     (eng, output) =>
                     {
                         if (eng is CpuEngine cpuEng) cpuEng.CropInto(output, c_input, c_top, c_left, c_height, c_width);
-                        else { var r = eng.Crop(c_input, c_top, c_left, c_height, c_width); r.AsSpan().CopyTo(output.AsWritableSpan()); }
+                        else { var r = eng.Crop(c_input, c_top, c_left, c_height, c_width); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }
                     },
                     BackwardFunctions<T>.CropBackward, new object[] { c_top, c_left });
             }
@@ -29580,7 +29580,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     (eng, output) =>
                     {
                         if (eng is CpuEngine cpuEng) cpuEng.PadInto(output, captured, capTop, capBottom, capLeft, capRight, capValue);
-                        else { var r = eng.Pad(captured, capTop, capBottom, capLeft, capRight, capValue); r.AsSpan().CopyTo(output.AsWritableSpan()); }
+                        else { var r = eng.Pad(captured, capTop, capBottom, capLeft, capRight, capValue); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }
                     },
                     BackwardFunctions<T>.PadBackward, new object[] { capTop, capLeft });
             }
@@ -29661,7 +29661,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     (eng, output) =>
                     {
                         if (eng is CpuEngine cpuEng) cpuEng.ConcatInto(output, captured, capturedAxis);
-                        else { var r = eng.Concat(captured, capturedAxis); r.AsSpan().CopyTo(output.AsWritableSpan()); }
+                        else { var r = eng.Concat(captured, capturedAxis); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }
                     },
                     BackwardFunctions<T>.ConcatenateBackward, new object[] { capturedAxis });
             }
@@ -30248,7 +30248,7 @@ public partial class CpuEngine : ITensorLevelEngine
         if (input == null) throw new ArgumentNullException(nameof(input));
         if (centers == null) throw new ArgumentNullException(nameof(centers));
         if (epsilons == null) throw new ArgumentNullException(nameof(epsilons));
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_input = input; var c_centers = centers; var c_epsilons = epsilons; return scope.RecordVariadic(LazyNodeType.Custom, "RBFKernel", new[] { input, centers, epsilons }, input._shape, (eng, output) => { var r = eng.RBFKernel(c_input, c_centers, c_epsilons); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.RBFKernelBackward); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_input = input; var c_centers = centers; var c_epsilons = epsilons; return scope.RecordVariadic(LazyNodeType.Custom, "RBFKernel", new[] { input, centers, epsilons }, input._shape, (eng, output) => { var r = eng.RBFKernel(c_input, c_centers, c_epsilons); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.RBFKernelBackward); } }
         { var ac = AutoTracer.TryGetCompiledPlan<T>("RBFKernel", input._shape); if (ac is not null) return ac.Execute(); }
 
         if (input.Rank != 2)
@@ -30414,7 +30414,7 @@ public partial class CpuEngine : ITensorLevelEngine
         if (repeats < 1) throw new ArgumentOutOfRangeException(nameof(repeats), "Repeats must be at least 1");
         if (axis < 0 || axis >= tensor._shape.Length)
             throw new ArgumentOutOfRangeException(nameof(axis), $"Axis {axis} out of range for tensor with {tensor._shape.Length} dimensions");
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_tensor = tensor; var c_repeats = repeats; var c_axis = axis; return scope.RecordUnary(LazyNodeType.Custom, "TensorRepeatElements", tensor, tensor._shape, (eng, output) => { var r = eng.TensorRepeatElements(c_tensor, c_repeats, c_axis); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.RepeatElementsBackward); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_tensor = tensor; var c_repeats = repeats; var c_axis = axis; return scope.RecordUnary(LazyNodeType.Custom, "TensorRepeatElements", tensor, tensor._shape, (eng, output) => { var r = eng.TensorRepeatElements(c_tensor, c_repeats, c_axis); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.RepeatElementsBackward); } }
 
 
         // Calculate output shape
@@ -30479,7 +30479,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 for (int i = 0; i < tensor._shape.Length; i++)
                     outShape[i] = tensor._shape[i] * multiples[i];
                 return scope.RecordUnary(LazyNodeType.Custom, "Tile", tensor, outShape,
-                    (eng, output) => { var r = eng.TensorTile(captured, capMultiples); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorTile(captured, capMultiples); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.TileBackward);
             }
         }
@@ -30557,7 +30557,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var capStart = (int[])start.Clone();
                 var capLength = (int[])length.Clone();
                 return scope.RecordUnary(LazyNodeType.Custom, "TensorSlice", tensor, capLength,
-                    (eng, output) => { var r = eng.TensorSlice(captured, capStart, capLength); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorSlice(captured, capStart, capLength); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.SliceBackward, new object[] { capStart });
             }
         }
@@ -30664,7 +30664,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var cc = condition; var cx = x; var cy = y;
                 return scope.RecordVariadic(LazyNodeType.Custom, "TensorWhere",
                     new[] { condition, x, y }, x._shape,
-                    (eng, output) => { var r = eng.TensorWhere(cc, cx, cy); r.AsSpan().CopyTo(output.AsWritableSpan()); });
+                    (eng, output) => { var r = eng.TensorWhere(cc, cx, cy); DirectGpuTensorEngine.CopyResultInto(eng, r, output); });
             }
         }
         if (y == null) throw new ArgumentNullException(nameof(y));
@@ -30737,7 +30737,7 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (a == null) throw new ArgumentNullException(nameof(a));
         if (b == null) throw new ArgumentNullException(nameof(b));
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_a = a; var c_b = b; return scope.RecordBinary(LazyNodeType.Custom, "TensorOuterProduct", a, b, a._shape, (eng, output) => { var r = eng.TensorOuterProduct(c_a, c_b); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.OuterProductBackward); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_a = a; var c_b = b; return scope.RecordBinary(LazyNodeType.Custom, "TensorOuterProduct", a, b, a._shape, (eng, output) => { var r = eng.TensorOuterProduct(c_a, c_b); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.OuterProductBackward); } }
 
 
         // Flatten both tensors to 1D
@@ -30774,7 +30774,7 @@ public partial class CpuEngine : ITensorLevelEngine
             throw new ArgumentException("Both tensors must be 2D [batch, features]");
         if (a._shape[0] != b._shape[0])
             throw new ArgumentException("Batch sizes must match");
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_a = a; var c_b = b; return scope.RecordBinary(LazyNodeType.Custom, "TensorBatchOuterProduct", a, b, a._shape, (eng, output) => { var r = eng.TensorBatchOuterProduct(c_a, c_b); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.OuterProductBackward); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_a = a; var c_b = b; return scope.RecordBinary(LazyNodeType.Custom, "TensorBatchOuterProduct", a, b, a._shape, (eng, output) => { var r = eng.TensorBatchOuterProduct(c_a, c_b); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.OuterProductBackward); } }
 
 
         int batch = a._shape[0];
@@ -31026,7 +31026,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     // materializes it into row-major memory so AsSpan doesn't
                     // throw "non-contiguous" when copying into the pre-allocated
                     // output. O(n) materialization cost, paid once per Execute.
-                    (eng, output) => { var r = eng.TensorPermute(captured, capturedAxes).Contiguous(); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorPermute(captured, capturedAxes).Contiguous(); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.PermuteBackward, new object[] { capturedAxes });
             }
         }
@@ -31064,7 +31064,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 outShape[capturedAxis] = 1;
                 for (int i = capturedAxis; i < rank; i++) outShape[i + 1] = tensor._shape[i];
                 return scope.RecordUnary(LazyNodeType.Custom, "TensorExpandDims", tensor, outShape,
-                    (eng, output) => { var r = eng.TensorExpandDims(captured, capturedAxis); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorExpandDims(captured, capturedAxis); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.ExpandDimsBackward, new object[] { capturedAxis });
             }
         }
@@ -31102,7 +31102,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 if (capturedAxis == -1) { shapeList = shapeList.Where(s => s != 1).ToList(); if (shapeList.Count == 0) shapeList.Add(1); }
                 else { int normAxis = capturedAxis < 0 ? shapeList.Count + capturedAxis : capturedAxis; shapeList.RemoveAt(normAxis); if (shapeList.Count == 0) shapeList.Add(1); }
                 return scope.RecordUnary(LazyNodeType.Custom, "TensorSqueeze", tensor, shapeList.ToArray(),
-                    (eng, output) => { var r = eng.TensorSqueeze(captured, capturedAxis); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorSqueeze(captured, capturedAxis); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.SqueezeBackward, new object[] { capturedAxis });
             }
         }
@@ -31141,7 +31141,7 @@ public partial class CpuEngine : ITensorLevelEngine
         if (destination == null) throw new ArgumentNullException(nameof(destination));
         if (indices == null) throw new ArgumentNullException(nameof(indices));
         if (updates == null) throw new ArgumentNullException(nameof(updates));
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_destination = destination; var c_indices = indices; var c_updates = updates; var c_axis = axis; return scope.RecordBinary(LazyNodeType.Custom, "TensorScatterAdd", destination, updates, destination._shape, (eng, output) => { var r = eng.TensorScatterAdd(c_destination, c_indices, c_updates, c_axis); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.ScatterAddBackward); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_destination = destination; var c_indices = indices; var c_updates = updates; var c_axis = axis; return scope.RecordBinary(LazyNodeType.Custom, "TensorScatterAdd", destination, updates, destination._shape, (eng, output) => { var r = eng.TensorScatterAdd(c_destination, c_indices, c_updates, c_axis); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.ScatterAddBackward); } }
 
         if (!destination.IsContiguous) throw new InvalidOperationException("Output tensor must be contiguous.");
 
@@ -31240,7 +31240,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 // Compute output shape: replace source._shape[axis] with indices shape
                 var outShape = ComputeGatherOutputShape(source._shape, indices._shape, capAxis);
                 return scope.RecordUnary(LazyNodeType.Custom, "TensorGather", source, outShape,
-                    (eng, output) => { var r = eng.TensorGather(captured, capIndices, capAxis); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorGather(captured, capIndices, capAxis); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.GatherBackward, new object[] { capIndices, capAxis });
             }
         }
@@ -31333,7 +31333,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var captured = tensor;
                 var capturedAxis = axis;
                 return scope.RecordUnary(LazyNodeType.Custom, "TensorCumSum", tensor, tensor._shape,
-                    (eng, output) => { var r = eng.TensorCumSum(captured, capturedAxis); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorCumSum(captured, capturedAxis); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.CumSumBackward, new object[] { capturedAxis });
             }
         }
@@ -31473,7 +31473,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 }
                 if (outShape.Count == 0) outShape.Add(1);
                 return scope.RecordUnary(LazyNodeType.Custom, "LogSumExp", tensor, outShape.ToArray(),
-                    (eng, output) => { var r = eng.TensorLogSumExp(captured, capAxis, capKeepDims); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorLogSumExp(captured, capAxis, capKeepDims); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.LogSumExpBackward, new object[] { capAxis });
             }
         }
@@ -31934,7 +31934,7 @@ public partial class CpuEngine : ITensorLevelEngine
     public Tensor<T> ScalarMinusTensor<T>(T scalar, Tensor<T> tensor)
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_scalar = scalar; var c_tensor = tensor; return scope.RecordUnary(LazyNodeType.Custom, "ScalarMinusTensor", tensor, tensor._shape, (eng, output) => { var r = eng.ScalarMinusTensor(c_scalar, c_tensor); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.NegateBackward); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_scalar = scalar; var c_tensor = tensor; return scope.RecordUnary(LazyNodeType.Custom, "ScalarMinusTensor", tensor, tensor._shape, (eng, output) => { var r = eng.ScalarMinusTensor(c_scalar, c_tensor); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.NegateBackward); } }
 
         var tensorOrig = tensor;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!tensor.IsContiguous) tensor = tensor.Contiguous();
@@ -31996,7 +31996,7 @@ public partial class CpuEngine : ITensorLevelEngine
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
         if (tensor._shape.Length != 2)
             throw new ArgumentException("Tensor must be 2D");
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_tensor = tensor; return scope.RecordUnary(LazyNodeType.Custom, "TensorDiagonal", tensor, tensor._shape, (eng, output) => { var r = eng.TensorDiagonal(c_tensor); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.DiagonalBackward); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_tensor = tensor; return scope.RecordUnary(LazyNodeType.Custom, "TensorDiagonal", tensor, tensor._shape, (eng, output) => { var r = eng.TensorDiagonal(c_tensor); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.DiagonalBackward); } }
 
 
         int n = Math.Min(tensor._shape[0], tensor._shape[1]);
@@ -32121,7 +32121,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var captured = tensor;
                 var capturedScalar = scalar;
                 return scope.RecordUnary(LazyNodeType.AddScalar, "TensorAddScalar", tensor, tensor._shape,
-                    (eng, output) => { var r = eng.TensorAddScalar(captured, capturedScalar); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorAddScalar(captured, capturedScalar); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.AddScalarBackward);
             }
         }
@@ -32151,7 +32151,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var captured = tensor;
                 var capturedScalar = scalar;
                 return scope.RecordUnary(LazyNodeType.Custom, "TensorSubtractScalar", tensor, tensor._shape,
-                    (eng, output) => { var r = eng.TensorSubtractScalar(captured, capturedScalar); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorSubtractScalar(captured, capturedScalar); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.SubtractScalarBackward);
             }
         }
@@ -32181,7 +32181,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var captured = tensor;
                 var capturedScalar = scalar;
                 return scope.RecordUnary(LazyNodeType.DivideScalar, "TensorDivideScalar", tensor, tensor._shape,
-                    (eng, output) => { var r = eng.TensorDivideScalar(captured, capturedScalar); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorDivideScalar(captured, capturedScalar); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.DivideScalarBackward, scalar != null ? new object[] { scalar } : Array.Empty<object>());
             }
         }
@@ -32359,7 +32359,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 }
                 if (outShape.Count == 0) outShape.Add(1);
                 return scope.RecordUnary(LazyNodeType.Custom, "Norm", tensor, outShape.ToArray(),
-                    (eng, output) => { var r = eng.TensorNorm(captured, capAxis, capKeepDims); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorNorm(captured, capAxis, capKeepDims); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.NormBackward, new object[] { capAxis });
             }
         }
@@ -32558,7 +32558,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 }
                 outShape[normAxis] = totalAxis;
                 return scope.RecordVariadic(LazyNodeType.Custom, "Concatenate", captured, outShape,
-                    (eng, output) => { var r = eng.TensorConcatenate(captured, capturedAxis); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorConcatenate(captured, capturedAxis); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.ConcatenateBackward, new object[] { capturedAxis });
             }
         }
@@ -32634,7 +32634,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     var outShape = (int[])tensor._shape.Clone();
                     outShape[ca] = splitSizeLazy;
                     lazyResults[s] = scope.RecordUnary(LazyNodeType.Custom, "TensorSplit", tensor, outShape,
-                        (eng, output) => { var r = eng.TensorSplit(ct, cn, ca)[splitIdx]; r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                        (eng, output) => { var r = eng.TensorSplit(ct, cn, ca)[splitIdx]; DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                         BackwardFunctions<T>.SplitBackward, new object[] { numSplits, axis, s });
                 }
                 return lazyResults;
@@ -32845,7 +32845,7 @@ public partial class CpuEngine : ITensorLevelEngine
             {
                 var cp = predictions; var ct = targets; var ce = epsilon;
                 return scope.RecordBinary(LazyNodeType.Custom, "TensorBinaryCrossEntropy", predictions, targets, predictions._shape,
-                    (eng, output) => { var r = ((CpuEngine)eng).TensorBinaryCrossEntropy(cp, ct, ce); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = ((CpuEngine)eng).TensorBinaryCrossEntropy(cp, ct, ce); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.BinaryCrossEntropyBackward, new object[] { (object)epsilon! });
             }
         }
@@ -33069,7 +33069,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var captured = tensor;
                 int capAxis = axis, capIndex = index;
                 return scope.RecordUnary(LazyNodeType.Custom, "TensorSliceAxis", tensor, outShape,
-                    (eng, output) => { var r = eng.TensorSliceAxis(captured, capAxis, capIndex); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorSliceAxis(captured, capAxis, capIndex); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.SliceAxisBackward, new object[] { axis, index });
             }
         }
@@ -33175,7 +33175,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 $"TensorBatchMatMul requires a to be 3D and b to be 2D or 3D. Got ranks {a.Rank} and {b.Rank}.");
         }
 
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ca = a; var cb = b; var outShape = new[] { a._shape[0], a._shape[1], b._shape[1] }; return scope.RecordBinary(LazyNodeType.Custom, "TensorBatchMatMul", a, b, outShape, (eng, output) => { var r = eng.TensorBatchMatMul(ca, cb); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.BatchMatMulBackward); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ca = a; var cb = b; var outShape = new[] { a._shape[0], a._shape[1], b._shape[1] }; return scope.RecordBinary(LazyNodeType.Custom, "TensorBatchMatMul", a, b, outShape, (eng, output) => { var r = eng.TensorBatchMatMul(ca, cb); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.BatchMatMulBackward); } }
         { var ac = AutoTracer.TryGetCompiledPlan<T>("TensorBatchMatMul", a._shape); if (ac is not null) return ac.Execute(); }
 
         var numOps = MathHelper.GetNumericOperations<T>();
@@ -33310,7 +33310,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var captured = tensor;
                 var capturedAxis = axis;
                 return scope.RecordUnary(LazyNodeType.Custom, "LogSoftmax", tensor, tensor._shape,
-                    (eng, output) => { var r = eng.TensorLogSoftmax(captured, capturedAxis); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorLogSoftmax(captured, capturedAxis); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.LogSoftmaxBackward);
             }
         }
@@ -33555,7 +33555,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var outShape = (int[])tensor._shape.Clone();
                 outShape[axis] = indices.Length;
                 return scope.RecordUnary(LazyNodeType.Custom, "TensorIndexSelect", tensor, outShape,
-                    (eng, output) => { var r = eng.TensorIndexSelect(captured, capIndices, capAxis); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorIndexSelect(captured, capIndices, capAxis); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.IndexSelectBackward, new object[] { capIndices, capAxis });
             }
         }
@@ -33644,7 +33644,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 outShape[axis] = numTensors;
                 for (int i = axis; i < firstShape.Length; i++) outShape[i + 1] = firstShape[i];
                 return scope.RecordVariadic(LazyNodeType.Custom, "TensorStack", captured, outShape,
-                    (eng, output) => { var r = eng.TensorStack(captured, capAxis); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorStack(captured, capAxis); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.StackBackward, new object[] { capAxis });
             }
         }
@@ -33759,7 +33759,7 @@ public partial class CpuEngine : ITensorLevelEngine
             {
                 var ct = tensor; var cm = mask; var cv = value;
                 return scope.RecordUnary(LazyNodeType.Custom, "TensorMaskedFill", tensor, tensor._shape,
-                    (eng, output) => { var r = eng.TensorMaskedFill(ct, cm, cv); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorMaskedFill(ct, cm, cv); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.MaskedFillBackward, new object[] { mask });
             }
         }
@@ -33795,7 +33795,7 @@ public partial class CpuEngine : ITensorLevelEngine
         if (!tensor._shape.SequenceEqual(mask._shape))
             throw new ArgumentException($"Tensor shape [{string.Join(", ", tensor._shape)}] must match mask shape [{string.Join(", ", mask._shape)}].");
 
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ct = tensor; var cm = mask; var cv = value; return scope.RecordUnary(LazyNodeType.Custom, "MaskedFill", tensor, tensor._shape, (eng, output) => { var r = eng.TensorMaskedFill(ct, cm, cv); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.MaskedFillBackward); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ct = tensor; var cm = mask; var cv = value; return scope.RecordUnary(LazyNodeType.Custom, "MaskedFill", tensor, tensor._shape, (eng, output) => { var r = eng.TensorMaskedFill(ct, cm, cv); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.MaskedFillBackward); } }
 
         { var ac = AutoTracer.TryGetCompiledPlan<T>("MaskedFill", tensor._shape); if (ac is not null) return ac.Execute(); }
 
@@ -34448,7 +34448,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 for (int i = 0; i < input._shape.Length; i++)
                     outShape[i] = i == axis ? indices.Length : input._shape[i];
                 return scope.RecordUnary(LazyNodeType.Custom, "Gather", input, outShape,
-                    (eng, output) => { var r = eng.Gather(captured, capIndices, capAxis); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.Gather(captured, capIndices, capAxis); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.GatherBackward, new object[] { capIndices, capAxis });
             }
         }
@@ -34495,7 +34495,7 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc/>
     public Tensor<T> Scatter<T>(Tensor<T> input, Tensor<int> indices, Tensor<T> values, int axis)
     {
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ci = input; var cind = indices; var cv = values; var ca = axis; return scope.RecordBinary(LazyNodeType.Custom, "Scatter", input, values, input._shape, (eng, output) => { var r = eng.Scatter(ci, cind, cv, ca); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.ScatterBackward, new object[] { indices, axis }); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ci = input; var cind = indices; var cv = values; var ca = axis; return scope.RecordBinary(LazyNodeType.Custom, "Scatter", input, values, input._shape, (eng, output) => { var r = eng.Scatter(ci, cind, cv, ca); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.ScatterBackward, new object[] { indices, axis }); } }
 
         { var ac = AutoTracer.TryGetCompiledPlan<T>("Scatter", input._shape); if (ac is not null) return ac.Execute(); }
 
@@ -34606,7 +34606,7 @@ public partial class CpuEngine : ITensorLevelEngine
             {
                 var captured = tensor;
                 return scope.RecordUnary(LazyNodeType.Custom, "TensorCosh", tensor, tensor._shape,
-                    (eng, output) => { var r = eng.TensorCosh(captured); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorCosh(captured); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.CoshBackward);
             }
         }
@@ -34660,7 +34660,7 @@ public partial class CpuEngine : ITensorLevelEngine
             {
                 var captured = tensor;
                 return scope.RecordUnary(LazyNodeType.Custom, "TensorSinh", tensor, tensor._shape,
-                    (eng, output) => { var r = eng.TensorSinh(captured); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorSinh(captured); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.SinhBackward);
             }
         }
@@ -34707,7 +34707,7 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (a._shape.Length != 1 || b._shape.Length != 1)
             throw new ArgumentException("Both inputs must be 1D tensors");
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_a = a; var c_b = b; return scope.RecordBinary(LazyNodeType.Custom, "TensorOuter", a, b, a._shape, (eng, output) => { var r = eng.TensorOuter(c_a, c_b); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.OuterProductBackward); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_a = a; var c_b = b; return scope.RecordBinary(LazyNodeType.Custom, "TensorOuter", a, b, a._shape, (eng, output) => { var r = eng.TensorOuter(c_a, c_b); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.OuterProductBackward); } }
         { var ac = AutoTracer.TryGetCompiledPlan<T>("TensorOuter", a._shape); if (ac is not null) return ac.Execute(); }
 
         int n = a._shape[0];
@@ -34789,7 +34789,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     {
                         var eager = eng.FusedLinear(inputs[0], inputs[1],
                             inputs.Length > 2 ? inputs[2] : null, capturedActivation, capturedParams);
-                        eager.AsSpan().CopyTo(output.AsWritableSpan());
+                        DirectGpuTensorEngine.CopyResultInto(eng, eager, output);
                     },
                     BackwardFunctions<T>.FusedLinearWithActivationBackward,
                     // savedState layout [0]=activation, [1]=preActivation (null here ⇒ backward
@@ -35610,7 +35610,7 @@ public partial class CpuEngine : ITensorLevelEngine
     public Tensor<T> RFFT<T>(Tensor<T> input)
     {
         if (input == null) throw new ArgumentNullException(nameof(input));
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_input = input; return scope.RecordUnary(LazyNodeType.Custom, "RFFT", input, input._shape, (eng, output) => { var r = eng.RFFT(c_input); r.AsSpan().CopyTo(output.AsWritableSpan()); }, null); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_input = input; return scope.RecordUnary(LazyNodeType.Custom, "RFFT", input, input._shape, (eng, output) => { var r = eng.RFFT(c_input); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, null); } }
         { var ac = AutoTracer.TryGetCompiledPlan<T>("RFFT", input._shape); if (ac is not null) return ac.Execute(); }
 
         var numOps = MathHelper.GetNumericOperations<T>();
@@ -35669,7 +35669,7 @@ public partial class CpuEngine : ITensorLevelEngine
     public Tensor<T> IRFFT<T>(Tensor<T> input, int outputLength)
     {
         if (input == null) throw new ArgumentNullException(nameof(input));
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_input = input; var c_outputLength = outputLength; return scope.RecordUnary(LazyNodeType.Custom, "IRFFT", input, input._shape, (eng, output) => { var r = eng.IRFFT(c_input, c_outputLength); r.AsSpan().CopyTo(output.AsWritableSpan()); }, null); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_input = input; var c_outputLength = outputLength; return scope.RecordUnary(LazyNodeType.Custom, "IRFFT", input, input._shape, (eng, output) => { var r = eng.IRFFT(c_input, c_outputLength); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, null); } }
         { var ac = AutoTracer.TryGetCompiledPlan<T>("IRFFT", input._shape); if (ac is not null) return ac.Execute(); }
 
         var inputOrig = input;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
@@ -36612,7 +36612,7 @@ public partial class CpuEngine : ITensorLevelEngine
             {
                 var captured = input;
                 return scope.RecordUnary(LazyNodeType.Custom, "Softplus", captured, captured._shape,
-                    (eng, output) => { var r = eng.Softplus(captured); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.Softplus(captured); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.SoftplusBackward);
             }
         }
@@ -36663,7 +36663,7 @@ public partial class CpuEngine : ITensorLevelEngine
             {
                 var captured = input;
                 return scope.RecordUnary(LazyNodeType.Custom, "HardSwish", captured, captured._shape,
-                    (eng, output) => { var r = eng.HardSwish(captured); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.HardSwish(captured); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.HardSwishBackward);
             }
         }
@@ -37372,7 +37372,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     (eng, output) =>
                     {
                         var r = eng.InstanceNorm(ci, cg, cb, ce, out var freshMean, out var freshVar);
-                        r.AsSpan().CopyTo(output.AsWritableSpan());
+                        DirectGpuTensorEngine.CopyResultInto(eng, r, output);
                         freshMean.AsSpan().CopyTo(capturedINMean.AsWritableSpan());
                         freshVar.AsSpan().CopyTo(capturedINVar.AsWritableSpan());
                     },
@@ -37574,7 +37574,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     (eng, output) =>
                     {
                         var r = eng.Dropout(ci, cdr, ct, out var freshMask);
-                        r.AsSpan().CopyTo(output.AsWritableSpan());
+                        DirectGpuTensorEngine.CopyResultInto(eng, r, output);
                         freshMask.AsSpan().CopyTo(capturedMask.AsWritableSpan());
                     },
                     BackwardFunctions<T>.DropoutBackward, new object[] { mask, dropoutRate });
@@ -37707,7 +37707,7 @@ public partial class CpuEngine : ITensorLevelEngine
                             gpuEng.RegisterEmbIndexRefresh(() => gpuEng.UploadEmbeddingIndices(ci, ci.Length));
                             if (gpuEng.TryEmbeddingGatherGpu(ct, ci, ci.Length, output)) return;
                         }
-                        var r = eng.Embedding(ci, ct); r.AsSpan().CopyTo(output.AsWritableSpan());
+                        var r = eng.Embedding(ci, ct); DirectGpuTensorEngine.CopyResultInto(eng, r, output);
                     },
                     BackwardFunctions<T>.EmbeddingBackward, new object[] { indices });
             }
@@ -38286,7 +38286,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     (eng, output) =>
                     {
                         if (eng is CpuEngine cpuEng) cpuEng.AdaptiveAvgPool2DInto(output, captured, capOutH, capOutW);
-                        else { var r = eng.AdaptiveAvgPool2D(captured, capOutH, capOutW); r.AsSpan().CopyTo(output.AsWritableSpan()); }
+                        else { var r = eng.AdaptiveAvgPool2D(captured, capOutH, capOutW); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }
                     },
                     BackwardFunctions<T>.AdaptiveAvgPool2DBackward, new object[] { capOutH, capOutW });
             }
@@ -38508,7 +38508,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var ci = input; var cg = gamma; var cb = beta; double ce = epsilon;
                 return scope.RecordVariadic(LazyNodeType.Custom, "TensorLayerNorm",
                     new[] { input, gamma, beta }, input._shape,
-                    (eng, output) => { var r = eng.TensorLayerNorm(ci, cg, cb, ce); r.AsSpan().CopyTo(output.AsWritableSpan()); });
+                    (eng, output) => { var r = eng.TensorLayerNorm(ci, cg, cb, ce); DirectGpuTensorEngine.CopyResultInto(eng, r, output); });
             }
         }
         var inputOrig = input;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
@@ -38532,7 +38532,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var lazyVar = ReduceVariance(input, axes, keepDims);
                 var outShape = lazyVar._shape;
                 return scope.RecordUnary(LazyNodeType.Custom, "ReduceStd", input, outShape,
-                    (eng, output) => { var r = eng.ReduceStd(ci, ca, ck); r.AsSpan().CopyTo(output.AsWritableSpan()); });
+                    (eng, output) => { var r = eng.ReduceStd(ci, ca, ck); DirectGpuTensorEngine.CopyResultInto(eng, r, output); });
             }
         }
         // ReduceVariance is already stride-aware — no Contiguous() needed here
@@ -38592,7 +38592,7 @@ public partial class CpuEngine : ITensorLevelEngine
             {
                 var ca = a; var cb = b; var csA = scaleA; var csB = scaleB;
                 return scope.RecordBinary(LazyNodeType.Custom, "TensorAddScaled", a, b, a._shape,
-                    (eng, output) => { var r = eng.TensorAddScaled(ca, cb, csA, csB); r.AsSpan().CopyTo(output.AsWritableSpan()); });
+                    (eng, output) => { var r = eng.TensorAddScaled(ca, cb, csA, csB); DirectGpuTensorEngine.CopyResultInto(eng, r, output); });
             }
         }
 
@@ -38738,7 +38738,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var capturedPred = predictions;
                 var capturedTarget = targets;
                 return scope.RecordBinary(LazyNodeType.MSELoss, "MSELoss", predictions, targets, new[] { 1 },
-                    (eng, output) => { var r = eng.TensorMSELoss(capturedPred, capturedTarget); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorMSELoss(capturedPred, capturedTarget); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.MSELossBackward);
             }
         }
@@ -38808,7 +38808,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var capturedP = predictions;
                 var capturedT = targets;
                 return scope.RecordBinary(LazyNodeType.Custom, "L1Loss", predictions, targets, new[] { 1 },
-                    (eng, output) => { var r = eng.TensorL1Loss(capturedP, capturedT); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorL1Loss(capturedP, capturedT); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.L1LossBackward);
             }
         }
@@ -38873,7 +38873,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var capturedT = targets;
                 double capturedDelta = delta;
                 return scope.RecordBinary(LazyNodeType.Custom, "HuberLoss", predictions, targets, new[] { 1 },
-                    (eng, output) => { var r = eng.TensorHuberLoss(capturedP, capturedT, capturedDelta); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorHuberLoss(capturedP, capturedT, capturedDelta); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.HuberLossBackward, new object[] { delta });
             }
         }
@@ -38954,7 +38954,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var capturedLogits = logits;
                 var capturedTargets = targets;
                 return scope.RecordBinary(LazyNodeType.Custom, "BCEWithLogitsLoss", logits, targets, new[] { 1 },
-                    (eng, output) => { var r = eng.TensorBCEWithLogitsLoss(capturedLogits, capturedTargets); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorBCEWithLogitsLoss(capturedLogits, capturedTargets); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.BCEWithLogitsLossBackward);
             }
         }
@@ -39033,7 +39033,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var capturedLogits = logits;
                 var capturedTargets = targets;
                 return scope.RecordBinary(LazyNodeType.CrossEntropyLoss, "CrossEntropyLoss", logits, targets, new[] { 1 },
-                    (eng, output) => { var r = eng.TensorCrossEntropyLoss(capturedLogits, capturedTargets); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorCrossEntropyLoss(capturedLogits, capturedTargets); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.CrossEntropyLossBackward);
             }
         }
@@ -39078,7 +39078,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var capturedLogProbs = logProbs;
                 var capturedTargets = targets;
                 return scope.RecordBinary(LazyNodeType.Custom, "NLLLoss", logProbs, targets, new[] { 1 },
-                    (eng, output) => { var r = eng.TensorNLLLoss(capturedLogProbs, capturedTargets); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorNLLLoss(capturedLogProbs, capturedTargets); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.NLLLossBackward);
             }
         }
@@ -39117,7 +39117,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var capturedInput = input;
                 var capturedTarget = target;
                 return scope.RecordBinary(LazyNodeType.Custom, "KLDivLoss", input, target, new[] { 1 },
-                    (eng, output) => { var r = eng.TensorKLDivLoss(capturedInput, capturedTarget); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorKLDivLoss(capturedInput, capturedTarget); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.KLDivLossBackward);
             }
         }
@@ -39155,7 +39155,7 @@ public partial class CpuEngine : ITensorLevelEngine
             normB += vb * vb;
         }
         double sim = dotProd / (Math.Sqrt(normA) * Math.Sqrt(normB) + 1e-8);
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_a = a; var c_b = b; return scope.RecordBinary(LazyNodeType.Custom, "CosineSimilarity", a, b, a._shape, (eng, output) => { var r = eng.TensorCosineSimilarityLoss(c_a, c_b); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.CosineSimilarityBackward); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_a = a; var c_b = b; return scope.RecordBinary(LazyNodeType.Custom, "CosineSimilarity", a, b, a._shape, (eng, output) => { var r = eng.TensorCosineSimilarityLoss(c_a, c_b); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.CosineSimilarityBackward); } }
 
         var result = new Tensor<T>(new[] { numOps.FromDouble(sim) }, [1]);
         DifferentiableOps.RecordBinary("CosineSimilarity", result, a, b,
@@ -39179,7 +39179,7 @@ public partial class CpuEngine : ITensorLevelEngine
             {
                 var captured = tensor;
                 return scope.RecordUnary(LazyNodeType.Custom, "SELU", captured, captured._shape,
-                    (eng, output) => { var r = eng.TensorSELU(captured); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorSELU(captured); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.SELUBackward);
             }
         }
@@ -39241,7 +39241,7 @@ public partial class CpuEngine : ITensorLevelEngine
             {
                 var captured = tensor;
                 return scope.RecordUnary(LazyNodeType.Custom, "HardSigmoid", captured, captured._shape,
-                    (eng, output) => { var r = eng.TensorHardSigmoid(captured); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorHardSigmoid(captured); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.HardSigmoidBackward);
             }
         }
@@ -39297,7 +39297,7 @@ public partial class CpuEngine : ITensorLevelEngine
             {
                 var captured = tensor;
                 return scope.RecordUnary(LazyNodeType.Custom, "ReLU6", captured, captured._shape,
-                    (eng, output) => { var r = eng.TensorReLU6(captured); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorReLU6(captured); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.ReLU6Backward);
             }
         }
@@ -39351,7 +39351,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 int capChannels = alpha.Length;
                 int capSpatialSize = tensor.Rank >= 4 ? tensor._shape[^2] * tensor._shape[^1] : 1;
                 return scope.RecordBinary(LazyNodeType.Custom, "PReLU", tensor, alpha, tensor._shape,
-                    (eng, output) => { var r = eng.TensorPReLU(captured, capAlpha); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorPReLU(captured, capAlpha); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.PReLUBackward, new object[] { capChannels, capSpatialSize });
             }
         }
@@ -39438,7 +39438,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 double capLower = lower, capUpper = upper;
                 bool capTraining = training;
                 return scope.RecordUnary(LazyNodeType.Custom, "RReLU", tensor, tensor._shape,
-                    (eng, output) => { var r = eng.TensorRReLU(captured, capLower, capUpper, capTraining); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorRReLU(captured, capLower, capUpper, capTraining); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.RReLUBackward);
             }
         }
@@ -39474,7 +39474,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 T capValue = value;
                 var numOpsLazy = MathHelper.GetNumericOperations<T>();
                 return scope.RecordUnary(LazyNodeType.Custom, "Threshold", tensor, tensor._shape,
-                    (eng, output) => { var r = eng.TensorThreshold(captured, capThreshold, capValue); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorThreshold(captured, capThreshold, capValue); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.ThresholdBackward, new object[] { numOpsLazy.ToDouble(threshold) });
             }
         }
@@ -39503,7 +39503,7 @@ public partial class CpuEngine : ITensorLevelEngine
             {
                 var captured = tensor;
                 return scope.RecordUnary(LazyNodeType.Custom, "Reciprocal", captured, captured._shape,
-                    (eng, output) => { var r = eng.TensorReciprocal(captured); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorReciprocal(captured); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.ReciprocalBackward);
             }
         }
@@ -39547,7 +39547,7 @@ public partial class CpuEngine : ITensorLevelEngine
             {
                 var captured = tensor;
                 return scope.RecordUnary(LazyNodeType.Custom, "Sign", captured, captured._shape,
-                    (eng, output) => { var r = eng.TensorSign(captured); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorSign(captured); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.SignBackward);
             }
         }
@@ -39594,7 +39594,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var captured = tensor;
                 var outShape = new int[] { tensor.Length };
                 return scope.RecordUnary(LazyNodeType.Custom, "Flatten", tensor, outShape,
-                    (eng, output) => { var r = captured.Reshape(new int[] { captured.Length }); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = captured.Reshape(new int[] { captured.Length }); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.FlattenBackward);
             }
         }
@@ -39620,7 +39620,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var outShape = (int[])tensor._shape.Clone();
                 outShape[dim] = length;
                 return scope.RecordUnary(LazyNodeType.Custom, "Narrow", tensor, outShape,
-                    (eng, output) => { var r = eng.TensorNarrow(captured, capDim, capStart, capLen); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorNarrow(captured, capDim, capStart, capLen); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.NarrowBackward, new object[] { dim, start, length });
             }
         }
@@ -39660,7 +39660,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     outShape[dim] += padding[2 * i] + padding[2 * i + 1];
                 }
                 return scope.RecordUnary(LazyNodeType.Custom, "ConstantPad", tensor, outShape,
-                    (eng, output) => { var r = eng.TensorConstantPad(captured, capPadding, capValue); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorConstantPad(captured, capPadding, capValue); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.ConstantPadBackward, new object[] { capPadding });
             }
         }
@@ -39896,7 +39896,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     (eng, output) =>
                     {
                         if (eng is CpuEngine cpuEng) cpuEng.TensorUpsampleBilinearInto(output, captured, capOutputSize);
-                        else { var r = eng.TensorUpsampleBilinear(captured, capOutputSize); r.AsSpan().CopyTo(output.AsWritableSpan()); }
+                        else { var r = eng.TensorUpsampleBilinear(captured, capOutputSize); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }
                     },
                     BackwardFunctions<T>.UpsampleBilinearBackward, new object[] { new[] { capH, capW } });
             }
@@ -39931,7 +39931,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var captured = input;
                 int ks = kernelSize, st = stride;
                 return scope.RecordUnary(LazyNodeType.Custom, "AvgPool1D", input, outShape,
-                    (eng, output) => { var r = eng.TensorAvgPool1D(captured, ks, st); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorAvgPool1D(captured, ks, st); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.AvgPool1DBackward, new object[] { kernelSize, stride });
             }
         }
@@ -39974,7 +39974,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var captured = input;
                 int ks = kernelSize, st = stride;
                 return scope.RecordUnary(LazyNodeType.Custom, "MaxPool1D", input, outShape,
-                    (eng, output) => { var r = eng.TensorMaxPool1D(captured, ks, st); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorMaxPool1D(captured, ks, st); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.MaxPool1DBackward, new object[] { kernelSize, stride });
             }
         }
@@ -40026,7 +40026,7 @@ public partial class CpuEngine : ITensorLevelEngine
             {
                 var captured = tensor;
                 return scope.RecordUnary(LazyNodeType.Custom, "Mean", captured, new int[] { 1 },
-                    (eng, output) => { var r = eng.TensorMeanDiff(captured); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorMeanDiff(captured); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.MeanBackward);
             }
         }
@@ -40063,7 +40063,7 @@ public partial class CpuEngine : ITensorLevelEngine
             {
                 var captured = tensor;
                 return scope.RecordUnary(LazyNodeType.Custom, "Var", captured, new int[] { 1 },
-                    (eng, output) => { var r = eng.TensorVar(captured); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorVar(captured); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.VarBackward);
             }
         }
@@ -40097,7 +40097,7 @@ public partial class CpuEngine : ITensorLevelEngine
             {
                 var captured = tensor;
                 return scope.RecordUnary(LazyNodeType.Custom, "Std", captured, new int[] { 1 },
-                    (eng, output) => { var r = eng.TensorStd(captured); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorStd(captured); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.StdBackward);
             }
         }
@@ -40141,7 +40141,7 @@ public partial class CpuEngine : ITensorLevelEngine
             {
                 var captured = tensor;
                 return scope.RecordUnary(LazyNodeType.Custom, "LogSumExp", tensor, new int[] { 1 },
-                    (eng, output) => { var r = eng.TensorLogSumExp(captured); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorLogSumExp(captured); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.LogSumExpBackward);
             }
         }
@@ -40172,7 +40172,7 @@ public partial class CpuEngine : ITensorLevelEngine
             {
                 var captured = tensor;
                 return scope.RecordUnary(LazyNodeType.Custom, "Norm", tensor, new int[] { 1 },
-                    (eng, output) => { var r = eng.TensorNorm(captured); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorNorm(captured); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.NormBackward);
             }
         }
@@ -40204,7 +40204,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var capOutputSize = (int[])outputSize.Clone();
                 var outShape = new[] { input._shape[0], input._shape[1], outputSize[0], outputSize[1] };
                 return scope.RecordUnary(LazyNodeType.Custom, "AdaptiveMaxPool2D", input, outShape,
-                    (eng, output) => { var r = eng.TensorAdaptiveMaxPool2D(captured, capOutputSize); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorAdaptiveMaxPool2D(captured, capOutputSize); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.AdaptiveMaxPool2DBackward);
             }
         }
@@ -40256,7 +40256,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var capturedY = y;
                 var capturedCond = condition;
                 return scope.RecordBinary(LazyNodeType.Custom, "Where", x, y, x._shape,
-                    (eng, output) => { var r = eng.TensorWhere(capturedCond, capturedX, capturedY); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) => { var r = eng.TensorWhere(capturedCond, capturedX, capturedY); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.WhereBackward, new object[] { condition });
             }
         }
@@ -40349,7 +40349,7 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc/>
     public virtual Tensor<T> FusedLinearReLU<T>(Tensor<T> input, Tensor<T> weight, Tensor<T> bias)
     {
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ci = input; var cw = weight; var cb = bias; return scope.RecordVariadic(LazyNodeType.FusedLinearReLU, "FusedLinearReLU", new[] { input, weight, bias }, input._shape, (eng, output) => { var r = eng.FusedLinearReLU(ci, cw, cb); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.FusedMatMulAddReLUBackward); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ci = input; var cw = weight; var cb = bias; return scope.RecordVariadic(LazyNodeType.FusedLinearReLU, "FusedLinearReLU", new[] { input, weight, bias }, input._shape, (eng, output) => { var r = eng.FusedLinearReLU(ci, cw, cb); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.FusedMatMulAddReLUBackward); } }
 
         var linear = TensorMatMul(input, weight);
         var biased = TensorBroadcastAdd(linear, bias);
@@ -40367,7 +40367,7 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc/>
     public virtual Tensor<T> FusedLinearSigmoid<T>(Tensor<T> input, Tensor<T> weight, Tensor<T> bias)
     {
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ci = input; var cw = weight; var cb = bias; return scope.RecordVariadic(LazyNodeType.FusedLinearSigmoid, "FusedLinearSigmoid", new[] { input, weight, bias }, input._shape, (eng, output) => { var r = eng.FusedLinearSigmoid(ci, cw, cb); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.FusedMatMulAddSigmoidBackward); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ci = input; var cw = weight; var cb = bias; return scope.RecordVariadic(LazyNodeType.FusedLinearSigmoid, "FusedLinearSigmoid", new[] { input, weight, bias }, input._shape, (eng, output) => { var r = eng.FusedLinearSigmoid(ci, cw, cb); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.FusedMatMulAddSigmoidBackward); } }
 
         var linear = TensorMatMul(input, weight);
         var biased = TensorBroadcastAdd(linear, bias);
@@ -40383,7 +40383,7 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc/>
     public virtual Tensor<T> FusedLinearTanh<T>(Tensor<T> input, Tensor<T> weight, Tensor<T> bias)
     {
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ci = input; var cw = weight; var cb = bias; return scope.RecordVariadic(LazyNodeType.Custom, "FusedLinearTanh", new[] { input, weight, bias }, input._shape, (eng, output) => { var r = eng.FusedLinearTanh(ci, cw, cb); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.FusedMatMulAddTanhBackward); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ci = input; var cw = weight; var cb = bias; return scope.RecordVariadic(LazyNodeType.Custom, "FusedLinearTanh", new[] { input, weight, bias }, input._shape, (eng, output) => { var r = eng.FusedLinearTanh(ci, cw, cb); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.FusedMatMulAddTanhBackward); } }
 
         var linear = TensorMatMul(input, weight);
         var biased = TensorBroadcastAdd(linear, bias);
@@ -40399,7 +40399,7 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc/>
     public virtual Tensor<T> FusedLinearGELU<T>(Tensor<T> input, Tensor<T> weight, Tensor<T> bias)
     {
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ci = input; var cw = weight; var cb = bias; return scope.RecordVariadic(LazyNodeType.FusedLinearGELU, "FusedLinearGELU", new[] { input, weight, bias }, input._shape, (eng, output) => { var r = eng.FusedLinearGELU(ci, cw, cb); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.FusedMatMulAddGELUBackward); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ci = input; var cw = weight; var cb = bias; return scope.RecordVariadic(LazyNodeType.FusedLinearGELU, "FusedLinearGELU", new[] { input, weight, bias }, input._shape, (eng, output) => { var r = eng.FusedLinearGELU(ci, cw, cb); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.FusedMatMulAddGELUBackward); } }
 
         var linear = TensorMatMul(input, weight);
         var biased = TensorBroadcastAdd(linear, bias);
@@ -40417,7 +40417,7 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc/>
     public virtual Tensor<T> FusedLinearSwish<T>(Tensor<T> input, Tensor<T> weight, Tensor<T> bias)
     {
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ci = input; var cw = weight; var cb = bias; return scope.RecordVariadic(LazyNodeType.Custom, "FusedLinearSwish", new[] { input, weight, bias }, input._shape, (eng, output) => { var r = eng.FusedLinearSwish(ci, cw, cb); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.FusedMatMulAddSwishBackward); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ci = input; var cw = weight; var cb = bias; return scope.RecordVariadic(LazyNodeType.Custom, "FusedLinearSwish", new[] { input, weight, bias }, input._shape, (eng, output) => { var r = eng.FusedLinearSwish(ci, cw, cb); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.FusedMatMulAddSwishBackward); } }
 
         var linear = TensorMatMul(input, weight);
         var biased = TensorBroadcastAdd(linear, bias);
@@ -40463,7 +40463,7 @@ public partial class CpuEngine : ITensorLevelEngine
             {
                 var cp = predicted; var ct = target;
                 return scope.RecordBinary(LazyNodeType.Custom, "TensorIoULoss", predicted, target, new[] { predicted._shape[0] },
-                    (eng, output) => { var r = eng.TensorIoULoss(cp, ct); r.AsSpan().CopyTo(output.AsWritableSpan()); });
+                    (eng, output) => { var r = eng.TensorIoULoss(cp, ct); DirectGpuTensorEngine.CopyResultInto(eng, r, output); });
             }
         }
         if (predicted.Shape.Length != 2 || predicted.Shape[1] != 4)
@@ -40529,7 +40529,7 @@ public partial class CpuEngine : ITensorLevelEngine
             {
                 var cp = predicted; var ct = target;
                 return scope.RecordBinary(LazyNodeType.Custom, "TensorGIoULoss", predicted, target, new[] { predicted._shape[0] },
-                    (eng, output) => { var r = eng.TensorGIoULoss(cp, ct); r.AsSpan().CopyTo(output.AsWritableSpan()); });
+                    (eng, output) => { var r = eng.TensorGIoULoss(cp, ct); DirectGpuTensorEngine.CopyResultInto(eng, r, output); });
             }
         }
         if (predicted.Shape.Length != 2 || predicted.Shape[1] != 4)
@@ -40599,7 +40599,7 @@ public partial class CpuEngine : ITensorLevelEngine
             {
                 var cp = predicted; var ct = target;
                 return scope.RecordBinary(LazyNodeType.Custom, "TensorDIoULoss", predicted, target, new[] { predicted._shape[0] },
-                    (eng, output) => { var r = eng.TensorDIoULoss(cp, ct); r.AsSpan().CopyTo(output.AsWritableSpan()); });
+                    (eng, output) => { var r = eng.TensorDIoULoss(cp, ct); DirectGpuTensorEngine.CopyResultInto(eng, r, output); });
             }
         }
 
@@ -40677,7 +40677,7 @@ public partial class CpuEngine : ITensorLevelEngine
             {
                 var cp = predicted; var ct = target;
                 return scope.RecordBinary(LazyNodeType.Custom, "TensorCIoULoss", predicted, target, new[] { predicted._shape[0] },
-                    (eng, output) => { var r = eng.TensorCIoULoss(cp, ct); r.AsSpan().CopyTo(output.AsWritableSpan()); });
+                    (eng, output) => { var r = eng.TensorCIoULoss(cp, ct); DirectGpuTensorEngine.CopyResultInto(eng, r, output); });
             }
         }
 
@@ -40931,7 +40931,7 @@ public partial class CpuEngine : ITensorLevelEngine
         if (input._shape[1] != weight._shape[1])
             throw new ArgumentException($"Input features ({input._shape[1]}) must match weight input dimension ({weight._shape[1]}).");
         var outputShape = new[] { input._shape[0], weight._shape[0], 8 };
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_input = input; var c_weight = weight; return scope.RecordBinary(LazyNodeType.Custom, "OctonionMatMulTensor", input, weight, outputShape, (eng, output) => { var r = eng.OctonionMatMulTensor(c_input, c_weight); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.OctonionMatMulBackward); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_input = input; var c_weight = weight; return scope.RecordBinary(LazyNodeType.Custom, "OctonionMatMulTensor", input, weight, outputShape, (eng, output) => { var r = eng.OctonionMatMulTensor(c_input, c_weight); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.OctonionMatMulBackward); } }
         { var ac = AutoTracer.TryGetCompiledPlan<T>("OctonionMatMulTensor", outputShape); if (ac is not null) return ac.Execute(); }
 
         var numOps = MathHelper.GetNumericOperations<T>();
@@ -41103,7 +41103,7 @@ public partial class CpuEngine : ITensorLevelEngine
             throw new ArgumentException($"Tensor lengths must match: {a.Length} vs {b.Length}");
         if (a.Length % 2 != 0 || (a.Rank > 0 && a._shape[a.Rank - 1] % 2 != 0))
             throw new ArgumentException("Complex tensors must have even length with the last axis divisible by 2 (interleaved re/im).");
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_a = a; var c_b = b; return scope.RecordBinary(LazyNodeType.Custom, "ComplexMultiply", a, b, a._shape, (eng, output) => { var r = eng.TensorComplexMultiply(c_a, c_b); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.ComplexMultiplyBackward); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_a = a; var c_b = b; return scope.RecordBinary(LazyNodeType.Custom, "ComplexMultiply", a, b, a._shape, (eng, output) => { var r = eng.TensorComplexMultiply(c_a, c_b); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.ComplexMultiplyBackward); } }
 
 
         var ops = MathHelper.GetNumericOperations<T>();
@@ -41131,7 +41131,7 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (a.Length % 2 != 0)
             throw new ArgumentException("Complex tensors must have even length (interleaved re/im).");
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_a = a; return scope.RecordUnary(LazyNodeType.Custom, "ComplexConjugate", a, a._shape, (eng, output) => { var r = eng.TensorComplexConjugate(c_a); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.ComplexConjugateBackward); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_a = a; return scope.RecordUnary(LazyNodeType.Custom, "ComplexConjugate", a, a._shape, (eng, output) => { var r = eng.TensorComplexConjugate(c_a); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.ComplexConjugateBackward); } }
 
 
         var ops = MathHelper.GetNumericOperations<T>();
@@ -41153,7 +41153,7 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (a.Length % 2 != 0)
             throw new ArgumentException("Complex tensors must have even length (interleaved re/im).");
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c = a; return scope.RecordUnary(LazyNodeType.Custom, "ComplexMagnitude", a, a._shape, (eng, output) => { var r = eng.TensorComplexMagnitude(c); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.ComplexMagnitudeBackward); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c = a; return scope.RecordUnary(LazyNodeType.Custom, "ComplexMagnitude", a, a._shape, (eng, output) => { var r = eng.TensorComplexMagnitude(c); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.ComplexMagnitudeBackward); } }
 
 
         var ops = MathHelper.GetNumericOperations<T>();
@@ -41276,7 +41276,7 @@ public partial class CpuEngine : ITensorLevelEngine
         var (batchCount, fftSize) = GetBatchedFFTDims(input._shape);
         ValidatePowerOfTwo(fftSize, nameof(input));
 
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ci = input; return scope.RecordCrossType<T, Complex<T>>(LazyNodeType.Custom, "NativeComplexFFT", input, input._shape, (eng, output) => { var r = eng.NativeComplexFFT(ci); r.AsSpan().CopyTo(output.AsWritableSpan()); }); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ci = input; return scope.RecordCrossType<T, Complex<T>>(LazyNodeType.Custom, "NativeComplexFFT", input, input._shape, (eng, output) => { var r = eng.NativeComplexFFT(ci); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }); } }
         { var ac = AutoTracer.TryGetCompiledPlan<Complex<T>>("NativeComplexFFT", input._shape); if (ac is not null) return ac.Execute(); }
 
         var ops = MathHelper.GetNumericOperations<T>();
@@ -41602,7 +41602,7 @@ public partial class CpuEngine : ITensorLevelEngine
         var (batchCount, fftSize) = GetBatchedFFTDims(input._shape);
         ValidatePowerOfTwo(fftSize, nameof(input));
 
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ci = input; var fL = freqLow; var fH = freqHigh; var sr = sampleRate; return scope.RecordCrossType<T, Complex<T>>(LazyNodeType.Custom, "NativeAnalyticSignal", input, input._shape, (eng, output) => { var r = eng.NativeAnalyticSignal(ci, fL, fH, sr); r.AsSpan().CopyTo(output.AsWritableSpan()); }); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ci = input; var fL = freqLow; var fH = freqHigh; var sr = sampleRate; return scope.RecordCrossType<T, Complex<T>>(LazyNodeType.Custom, "NativeAnalyticSignal", input, input._shape, (eng, output) => { var r = eng.NativeAnalyticSignal(ci, fL, fH, sr); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }); } }
 
         var ops = MathHelper.GetNumericOperations<T>();
         var result = new Tensor<Complex<T>>(input._shape);
@@ -42546,7 +42546,7 @@ public partial class CpuEngine : ITensorLevelEngine
         var (batchCount, fftSize) = GetBatchedFFTDims(input._shape);
         ValidatePowerOfTwo(fftSize, nameof(input));
 
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ci = input; return scope.RecordCrossType<Complex<T>, T>(LazyNodeType.Custom, "NativeComplexIFFTReal", input, input._shape, (eng, output) => { var r = eng.NativeComplexIFFTReal(ci); r.AsSpan().CopyTo(output.AsWritableSpan()); }); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ci = input; return scope.RecordCrossType<Complex<T>, T>(LazyNodeType.Custom, "NativeComplexIFFTReal", input, input._shape, (eng, output) => { var r = eng.NativeComplexIFFTReal(ci); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }); } }
         { var ac = AutoTracer.TryGetCompiledPlan<T>("NativeComplexIFFTReal", input._shape); if (ac is not null) return ac.Execute(); }
 
         var ops = MathHelper.GetNumericOperations<T>();
@@ -42576,7 +42576,7 @@ public partial class CpuEngine : ITensorLevelEngine
         var (batchCount, fftSize) = GetBatchedFFTDims(input._shape);
         ValidatePowerOfTwo(fftSize, nameof(input));
 
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ci = input; return scope.RecordUnary(LazyNodeType.Custom, "NativeComplexIFFT", input, input._shape, (eng, output) => { var r = eng.NativeComplexIFFT(ci); r.AsSpan().CopyTo(output.AsWritableSpan()); }, null); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ci = input; return scope.RecordUnary(LazyNodeType.Custom, "NativeComplexIFFT", input, input._shape, (eng, output) => { var r = eng.NativeComplexIFFT(ci); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, null); } }
         { var ac = AutoTracer.TryGetCompiledPlan<Complex<T>>("NativeComplexIFFT", input._shape); if (ac is not null) return ac.Execute(); }
 
         var ops = MathHelper.GetNumericOperations<T>();
@@ -42608,7 +42608,7 @@ public partial class CpuEngine : ITensorLevelEngine
         var (batchCount, fftSize) = GetBatchedFFTDims(input._shape);
         ValidatePowerOfTwo(fftSize, nameof(input));
 
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ci = input; return scope.RecordUnary(LazyNodeType.Custom, "NativeComplexFFTComplex", input, input._shape, (eng, output) => { var r = eng.NativeComplexFFTComplex(ci); r.AsSpan().CopyTo(output.AsWritableSpan()); }, null); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ci = input; return scope.RecordUnary(LazyNodeType.Custom, "NativeComplexFFTComplex", input, input._shape, (eng, output) => { var r = eng.NativeComplexFFTComplex(ci); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, null); } }
         { var ac = AutoTracer.TryGetCompiledPlan<Complex<T>>("NativeComplexFFTComplex", input._shape); if (ac is not null) return ac.Execute(); }
 
         var ops = MathHelper.GetNumericOperations<T>();
@@ -42672,7 +42672,7 @@ public partial class CpuEngine : ITensorLevelEngine
         if (input is null) throw new ArgumentNullException(nameof(input));
         if (input.Rank != 2) throw new ArgumentException("TensorSoftmaxRows requires a 2D tensor.", nameof(input));
 
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ci = input; return scope.RecordUnary(LazyNodeType.Custom, "TensorSoftmaxRows", input, input._shape, (eng, output) => { var r = eng.TensorSoftmaxRows(ci); r.AsSpan().CopyTo(output.AsWritableSpan()); }, null); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ci = input; return scope.RecordUnary(LazyNodeType.Custom, "TensorSoftmaxRows", input, input._shape, (eng, output) => { var r = eng.TensorSoftmaxRows(ci); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, null); } }
         { var ac = AutoTracer.TryGetCompiledPlan<T>("TensorSoftmaxRows", input._shape); if (ac is not null) return ac.Execute(); }
 
         var ops = MathHelper.GetNumericOperations<T>();
@@ -42718,7 +42718,7 @@ public partial class CpuEngine : ITensorLevelEngine
         if (a.Length != b.Length)
             throw new ArgumentException($"Tensor lengths must match: {a.Length} vs {b.Length}");
 
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ca = a; var cb = b; return scope.RecordBinary(LazyNodeType.Custom, "NativeComplexMultiply", a, b, a._shape, (eng, output) => { var r = eng.NativeComplexMultiply(ca, cb); r.AsSpan().CopyTo(output.AsWritableSpan()); }, null); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ca = a; var cb = b; return scope.RecordBinary(LazyNodeType.Custom, "NativeComplexMultiply", a, b, a._shape, (eng, output) => { var r = eng.NativeComplexMultiply(ca, cb); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, null); } }
         { var ac = AutoTracer.TryGetCompiledPlan<Complex<T>>("NativeComplexMultiply", a._shape); if (ac is not null) return ac.Execute(); }
 
         var ops = MathHelper.GetNumericOperations<T>();
@@ -43136,7 +43136,7 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (a is null) throw new ArgumentNullException(nameof(a));
 
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ca = a; return scope.RecordUnary(LazyNodeType.Custom, "NativeComplexConjugate", a, a._shape, (eng, output) => { var r = eng.NativeComplexConjugate(ca); r.AsSpan().CopyTo(output.AsWritableSpan()); }, null); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ca = a; return scope.RecordUnary(LazyNodeType.Custom, "NativeComplexConjugate", a, a._shape, (eng, output) => { var r = eng.NativeComplexConjugate(ca); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, null); } }
         { var ac = AutoTracer.TryGetCompiledPlan<Complex<T>>("NativeComplexConjugate", a._shape); if (ac is not null) return ac.Execute(); }
 
         var ops = MathHelper.GetNumericOperations<T>();
@@ -43172,7 +43172,7 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (a is null) throw new ArgumentNullException(nameof(a));
 
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ca = a; return scope.RecordCrossType<Complex<T>, T>(LazyNodeType.Custom, "NativeComplexMagnitude", a, a._shape, (eng, output) => { var r = eng.NativeComplexMagnitude(ca); r.AsSpan().CopyTo(output.AsWritableSpan()); }); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ca = a; return scope.RecordCrossType<Complex<T>, T>(LazyNodeType.Custom, "NativeComplexMagnitude", a, a._shape, (eng, output) => { var r = eng.NativeComplexMagnitude(ca); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }); } }
         { var ac = AutoTracer.TryGetCompiledPlan<T>("NativeComplexMagnitude", a._shape); if (ac is not null) return ac.Execute(); }
 
         var ops = MathHelper.GetNumericOperations<T>();
@@ -43212,7 +43212,7 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (a is null) throw new ArgumentNullException(nameof(a));
 
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ca = a; return scope.RecordCrossType<Complex<T>, T>(LazyNodeType.Custom, "NativeComplexMagnitudeSquared", a, a._shape, (eng, output) => { var r = eng.NativeComplexMagnitudeSquared(ca); r.AsSpan().CopyTo(output.AsWritableSpan()); }); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ca = a; return scope.RecordCrossType<Complex<T>, T>(LazyNodeType.Custom, "NativeComplexMagnitudeSquared", a, a._shape, (eng, output) => { var r = eng.NativeComplexMagnitudeSquared(ca); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }); } }
         { var ac = AutoTracer.TryGetCompiledPlan<T>("NativeComplexMagnitudeSquared", a._shape); if (ac is not null) return ac.Execute(); }
 
         var ops = MathHelper.GetNumericOperations<T>();
@@ -43250,7 +43250,7 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (a is null) throw new ArgumentNullException(nameof(a));
 
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ca = a; return scope.RecordCrossType<Complex<T>, T>(LazyNodeType.Custom, "NativeComplexPhase", a, a._shape, (eng, output) => { var r = eng.NativeComplexPhase(ca); r.AsSpan().CopyTo(output.AsWritableSpan()); }); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ca = a; return scope.RecordCrossType<Complex<T>, T>(LazyNodeType.Custom, "NativeComplexPhase", a, a._shape, (eng, output) => { var r = eng.NativeComplexPhase(ca); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }); } }
         { var ac = AutoTracer.TryGetCompiledPlan<T>("NativeComplexPhase", a._shape); if (ac is not null) return ac.Execute(); }
 
         var ops = MathHelper.GetNumericOperations<T>();
@@ -43284,7 +43284,7 @@ public partial class CpuEngine : ITensorLevelEngine
         if (magnitudes.Length != phases.Length)
             throw new ArgumentException($"Tensor lengths must match: {magnitudes.Length} vs {phases.Length}");
 
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { _ = phases.Length; var cm = magnitudes; var cp = phases; return scope.RecordCrossType<T, Complex<T>>(LazyNodeType.Custom, "NativeComplexFromPolar", magnitudes, magnitudes._shape, (eng, output) => { var r = eng.NativeComplexFromPolar(cm, cp); r.AsSpan().CopyTo(output.AsWritableSpan()); }); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { _ = phases.Length; var cm = magnitudes; var cp = phases; return scope.RecordCrossType<T, Complex<T>>(LazyNodeType.Custom, "NativeComplexFromPolar", magnitudes, magnitudes._shape, (eng, output) => { var r = eng.NativeComplexFromPolar(cm, cp); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }); } }
         { var ac = AutoTracer.TryGetCompiledPlan<Complex<T>>("NativeComplexFromPolar", magnitudes._shape); if (ac is not null) return ac.Execute(); }
 
         var ops = MathHelper.GetNumericOperations<T>();
@@ -43325,7 +43325,7 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (a is null) throw new ArgumentNullException(nameof(a));
 
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ca = a; var cs = scalar; return scope.RecordUnary(LazyNodeType.Custom, "NativeComplexScale", a, a._shape, (eng, output) => { var r = eng.NativeComplexScale(ca, cs); r.AsSpan().CopyTo(output.AsWritableSpan()); }, null); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ca = a; var cs = scalar; return scope.RecordUnary(LazyNodeType.Custom, "NativeComplexScale", a, a._shape, (eng, output) => { var r = eng.NativeComplexScale(ca, cs); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, null); } }
         { var ac = AutoTracer.TryGetCompiledPlan<Complex<T>>("NativeComplexScale", a._shape); if (ac is not null) return ac.Execute(); }
 
         var ops = MathHelper.GetNumericOperations<T>();
@@ -43366,7 +43366,7 @@ public partial class CpuEngine : ITensorLevelEngine
         if (x.Length != y.Length)
             throw new ArgumentException($"Tensor lengths must match: {x.Length} vs {y.Length}");
 
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var cx = x; var cy = y; return scope.RecordBinary(LazyNodeType.Custom, "NativeComplexCrossSpectral", x, y, x._shape, (eng, output) => { var r = eng.NativeComplexCrossSpectral(cx, cy); r.AsSpan().CopyTo(output.AsWritableSpan()); }, null); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var cx = x; var cy = y; return scope.RecordBinary(LazyNodeType.Custom, "NativeComplexCrossSpectral", x, y, x._shape, (eng, output) => { var r = eng.NativeComplexCrossSpectral(cx, cy); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, null); } }
         { var ac = AutoTracer.TryGetCompiledPlan<Complex<T>>("NativeComplexCrossSpectral", x._shape); if (ac is not null) return ac.Execute(); }
 
         var ops = MathHelper.GetNumericOperations<T>();
@@ -43412,7 +43412,7 @@ public partial class CpuEngine : ITensorLevelEngine
         if (input.Rank < 2)
             throw new ArgumentException("NativeComplexFFT2D requires at least a 2D tensor.", nameof(input));
 
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c = input; return scope.RecordCrossType<T, Complex<T>>(LazyNodeType.Custom, "NativeComplexFFT2D", input, input._shape, (eng, output) => { var r = eng.NativeComplexFFT2D(c); r.AsSpan().CopyTo(output.AsWritableSpan()); }); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c = input; return scope.RecordCrossType<T, Complex<T>>(LazyNodeType.Custom, "NativeComplexFFT2D", input, input._shape, (eng, output) => { var r = eng.NativeComplexFFT2D(c); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }); } }
         { var ac = AutoTracer.TryGetCompiledPlan<Complex<T>>("NativeComplexFFT2D", input._shape); if (ac is not null) return ac.Execute(); }
 
         int h = input._shape[^2];
@@ -43451,7 +43451,7 @@ public partial class CpuEngine : ITensorLevelEngine
         if ((iw & (iw - 1)) != 0 || iw <= 0)
             throw new ArgumentException($"Width {iw} must be a positive power of 2.", nameof(input));
 
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c = input; return scope.RecordCrossType<Complex<T>, T>(LazyNodeType.Custom, "NativeComplexIFFT2DReal", input, input._shape, (eng, output) => { var r = eng.NativeComplexIFFT2DReal(c); r.AsSpan().CopyTo(output.AsWritableSpan()); }); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c = input; return scope.RecordCrossType<Complex<T>, T>(LazyNodeType.Custom, "NativeComplexIFFT2DReal", input, input._shape, (eng, output) => { var r = eng.NativeComplexIFFT2DReal(c); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }); } }
         { var ac = AutoTracer.TryGetCompiledPlan<T>("NativeComplexIFFT2DReal", input._shape); if (ac is not null) return ac.Execute(); }
 
         // Step 1: Transpose so columns are last axis
@@ -43481,7 +43481,7 @@ public partial class CpuEngine : ITensorLevelEngine
         for (int i = 0; i < axes.Length; i++)
             axesHash = axesHash * 31 + axes[i];
 
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c = input; var ca = axes; return scope.RecordCrossType<T, Complex<T>>(LazyNodeType.Custom, "NativeComplexFFTND", input, input._shape, (eng, output) => { var r = eng.NativeComplexFFTND(c, ca); r.AsSpan().CopyTo(output.AsWritableSpan()); }); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c = input; var ca = axes; return scope.RecordCrossType<T, Complex<T>>(LazyNodeType.Custom, "NativeComplexFFTND", input, input._shape, (eng, output) => { var r = eng.NativeComplexFFTND(c, ca); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }); } }
         { var ac = AutoTracer.TryGetCompiledPlan<Complex<T>>("NativeComplexFFTND", input._shape, paramHash: axesHash); if (ac is not null) return ac.Execute(); }
 
         // Normalize negative axes and reject duplicates (matches NumPy/PyTorch behavior)
@@ -43519,7 +43519,7 @@ public partial class CpuEngine : ITensorLevelEngine
         for (int i = 0; i < axes.Length; i++)
             axesHash = axesHash * 31 + axes[i];
 
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c = input; var ca = axes; return scope.RecordCrossType<Complex<T>, T>(LazyNodeType.Custom, "NativeComplexIFFTNDReal", input, input._shape, (eng, output) => { var r = eng.NativeComplexIFFTNDReal(c, ca); r.AsSpan().CopyTo(output.AsWritableSpan()); }); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c = input; var ca = axes; return scope.RecordCrossType<Complex<T>, T>(LazyNodeType.Custom, "NativeComplexIFFTNDReal", input, input._shape, (eng, output) => { var r = eng.NativeComplexIFFTNDReal(c, ca); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }); } }
         { var ac = AutoTracer.TryGetCompiledPlan<T>("NativeComplexIFFTNDReal", input._shape, paramHash: axesHash); if (ac is not null) return ac.Execute(); }
 
         int rank = input.Rank;
@@ -43860,7 +43860,7 @@ public partial class CpuEngine : ITensorLevelEngine
         if (a.Length != b.Length)
             throw new ArgumentException($"Tensor lengths must match: {a.Length} vs {b.Length}");
 
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ca = a; var cb = b; return scope.RecordBinary(LazyNodeType.Custom, "NativeComplexAdd", a, b, a._shape, (eng, output) => { var r = eng.NativeComplexAdd(ca, cb); r.AsSpan().CopyTo(output.AsWritableSpan()); }, null); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ca = a; var cb = b; return scope.RecordBinary(LazyNodeType.Custom, "NativeComplexAdd", a, b, a._shape, (eng, output) => { var r = eng.NativeComplexAdd(ca, cb); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, null); } }
         { var ac = AutoTracer.TryGetCompiledPlan<Complex<T>>("NativeComplexAdd", a._shape); if (ac is not null) return ac.Execute(); }
 
         var ops = MathHelper.GetNumericOperations<T>();
@@ -44098,7 +44098,7 @@ public partial class CpuEngine : ITensorLevelEngine
         if (logProbs.Rank != 3)
             throw new ArgumentException("logProbs must be 3D [T, N, C].");
 
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var clp = logProbs; var ct = targets; var cil = inputLengths; var ctl = targetLengths; var cb = blank; var outShape = new[] { logProbs._shape[1] }; return scope.RecordUnary(LazyNodeType.Custom, "CTCLoss", logProbs, outShape, (eng, output) => { var r = eng.TensorCTCLoss(clp, ct, cil, ctl, cb); r.AsSpan().CopyTo(output.AsWritableSpan()); }, BackwardFunctions<T>.CTCLossBackward); } }
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var clp = logProbs; var ct = targets; var cil = inputLengths; var ctl = targetLengths; var cb = blank; var outShape = new[] { logProbs._shape[1] }; return scope.RecordUnary(LazyNodeType.Custom, "CTCLoss", logProbs, outShape, (eng, output) => { var r = eng.TensorCTCLoss(clp, ct, cil, ctl, cb); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.CTCLossBackward); } }
 
         var ops = MathHelper.GetNumericOperations<T>();
         int maxT = logProbs._shape[0];

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -11408,6 +11408,10 @@ public partial class CpuEngine : ITensorLevelEngine
                     // 2D/ND×2D/ND×ND cases to write-through kernels.
                     (eng, output) =>
                     {
+                        // GPU-resident 2D / ND×2D matmul into output's stable buffer (no host materialize that
+                        // breaks CUDA-graph capture); else the host write-through path.
+                        if (eng is DirectGpuTensorEngine mmGpu && mmGpu.TryMatMulResidentInto(output, capturedA, capturedB))
+                            return;
                         if (typeof(T) == typeof(float) && eng is CpuEngine cpuEngF)
                         {
                             cpuEngF.TensorMatMulFloatInto(
@@ -33085,7 +33089,14 @@ public partial class CpuEngine : ITensorLevelEngine
                 var captured = tensor;
                 int capAxis = axis, capIndex = index;
                 return scope.RecordUnary(LazyNodeType.Custom, "TensorSliceAxis", tensor, outShape,
-                    (eng, output) => { var r = eng.TensorSliceAxis(captured, capAxis, capIndex); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
+                    (eng, output) =>
+                    {
+                        // GPU-resident slice into output's stable buffer (no host materialize that breaks capture).
+                        if (eng is DirectGpuTensorEngine slGpu && slGpu.TrySliceAxisResidentInto(output, captured, capAxis, capIndex))
+                            return;
+                        var r = eng.TensorSliceAxis(captured, capAxis, capIndex);
+                        DirectGpuTensorEngine.CopyResultInto(eng, r, output);
+                    },
                     BackwardFunctions<T>.SliceAxisBackward, new object[] { axis, index });
             }
         }

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -30016,6 +30016,12 @@ public partial class CpuEngine : ITensorLevelEngine
                     outputShape,
                     (eng, output) =>
                     {
+                        // On a GPU engine, gather on-device straight into the output buffer so this embedding is
+                        // CUDA-graph-CAPTURABLE (the host Array.Copy gather below can't be recorded into a graph).
+                        // Managed-index path (capture/replay) reads the externally-refreshed stable index buffer;
+                        // eager path uploads inline. Falls through to the host gather when not GPU-resident.
+                        if (eng is DirectGpuTensorEngine gpuEng && capturedIndices is Tensor<int> idxInt
+                            && gpuEng.TryEmbeddingLookupGpuInto(capturedEmb, idxInt, output)) return;
                         // #1331-for-embeddings: re-read the LIVE indices each replay. The compiled plan is
                         // traced once and replayed across steps; the higher-level Train() loop refreshes the
                         // input tensor's data IN PLACE (persistent-input fix). But the indices were captured
@@ -30044,7 +30050,7 @@ public partial class CpuEngine : ITensorLevelEngine
                         }
                     },
                     BackwardFunctions<TValue>.TensorEmbeddingLookupBackward,
-                    new object[] { idxSnap, idxShapeSnap, capturedVocab, capturedDim });
+                    new object[] { idxSnap, idxShapeSnap, capturedVocab, capturedDim, capturedIndices });
             }
         }
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -37689,7 +37689,14 @@ public partial class CpuEngine : ITensorLevelEngine
                 int embDim = embeddingTable._shape[^1];
                 var outShape = new[] { indices.Length, embDim };
                 return scope.RecordUnary(LazyNodeType.Custom, "Embedding", embeddingTable, outShape,
-                    (eng, output) => { var r = eng.Embedding(ci, ct); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                    (eng, output) =>
+                    {
+                        // On the GPU engine, gather on-device straight into the output buffer (no host round-trip)
+                        // so the eager-prefix embedding doesn't stall GPU util; fall back to the host gather + copy
+                        // when the table/output aren't GPU-resident (CPU engine, or not-yet-resident tensors).
+                        if (eng is DirectGpuTensorEngine gpuEng && gpuEng.TryEmbeddingLookupGpuInto(ct, ci, output)) return;
+                        var r = eng.Embedding(ci, ct); r.AsSpan().CopyTo(output.AsWritableSpan());
+                    },
                     BackwardFunctions<T>.EmbeddingBackward, new object[] { indices });
             }
         }

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -30020,8 +30020,11 @@ public partial class CpuEngine : ITensorLevelEngine
                         // CUDA-graph-CAPTURABLE (the host Array.Copy gather below can't be recorded into a graph).
                         // Managed-index path (capture/replay) reads the externally-refreshed stable index buffer;
                         // eager path uploads inline. Falls through to the host gather when not GPU-resident.
-                        if (eng is DirectGpuTensorEngine gpuEng && capturedIndices is Tensor<int> idxInt
-                            && gpuEng.TryEmbeddingLookupGpuInto(capturedEmb, idxInt, output)) return;
+                        if (eng is DirectGpuTensorEngine gpuEng)
+                        {
+                            gpuEng.RegisterEmbIndexRefresh(() => gpuEng.UploadEmbeddingIndices(capturedIndices, n));
+                            if (gpuEng.TryEmbeddingGatherGpu(capturedEmb, capturedIndices, n, output)) return;
+                        }
                         // #1331-for-embeddings: re-read the LIVE indices each replay. The compiled plan is
                         // traced once and replayed across steps; the higher-level Train() loop refreshes the
                         // input tensor's data IN PLACE (persistent-input fix). But the indices were captured
@@ -37697,10 +37700,13 @@ public partial class CpuEngine : ITensorLevelEngine
                 return scope.RecordUnary(LazyNodeType.Custom, "Embedding", embeddingTable, outShape,
                     (eng, output) =>
                     {
-                        // On the GPU engine, gather on-device straight into the output buffer (no host round-trip)
-                        // so the eager-prefix embedding doesn't stall GPU util; fall back to the host gather + copy
-                        // when the table/output aren't GPU-resident (CPU engine, or not-yet-resident tensors).
-                        if (eng is DirectGpuTensorEngine gpuEng && gpuEng.TryEmbeddingLookupGpuInto(ct, ci, output)) return;
+                        // On the GPU engine, gather on-device straight into the output buffer (graph-capturable);
+                        // fall back to the host gather + copy when not GPU-resident (CPU engine / not-yet-resident).
+                        if (eng is DirectGpuTensorEngine gpuEng)
+                        {
+                            gpuEng.RegisterEmbIndexRefresh(() => gpuEng.UploadEmbeddingIndices(ci, ci.Length));
+                            if (gpuEng.TryEmbeddingGatherGpu(ct, ci, ci.Length, output)) return;
+                        }
                         var r = eng.Embedding(ci, ct); r.AsSpan().CopyTo(output.AsWritableSpan());
                     },
                     BackwardFunctions<T>.EmbeddingBackward, new object[] { indices });

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -30158,6 +30158,12 @@ public partial class CpuEngine : ITensorLevelEngine
                     embeddings, floatIndices, outputShape,
                     (eng, output) =>
                     {
+                        // GPU-resident embedding gather into output's stable buffer (the embedding_forward kernel
+                        // casts float→int) — keeps the whole forward chain on-device for CUDA-graph capture. Else
+                        // the host gather below.
+                        if (eng is DirectGpuTensorEngine embGpu
+                            && embGpu.TryEmbeddingFromFloatIndicesResidentInto(output, capturedEmb, capturedFloatIdx, n, dim))
+                            return;
                         // Read fresh float indices each replay; convert to int
                         // via banker's rounding (matches Convert.ToInt32(double)
                         // semantics used by the eager path so any code that flips

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -11224,13 +11224,10 @@ public partial class CpuEngine : ITensorLevelEngine
                 int cols0 = tensor._shape[1];
                 var captured = tensor;
                 return scope.RecordUnary(LazyNodeType.Transpose, "TensorTranspose", tensor, new[] { cols0, rows0 },
-                    (eng, output) =>
-                    {
-                        // TensorTranspose returns a view — need to materialize contiguous data into the output buffer
-                        var transposed = eng.TensorTranspose(captured);
-                        var data = transposed.ToArray();
-                        data.AsSpan().CopyTo(output.AsWritableSpan());
-                    },
+                    // 2-D transpose = permute [1,0], routed through the resident TensorPermuteInto so on GPU it
+                    // writes backend.Permute into output's resident buffer (no host ToArray that breaks the
+                    // residency chain / CUDA-graph capture); CPU path is the base strided copy into output.
+                    (eng, output) => eng.TensorPermuteInto(output, captured, new[] { 1, 0 }),
                     BackwardFunctions<T>.TransposeBackward);
             }
         }
@@ -31022,11 +31019,13 @@ public partial class CpuEngine : ITensorLevelEngine
                 var outShape = new int[axes.Length];
                 for (int i = 0; i < axes.Length; i++) outShape[i] = tensor._shape[axes[i]];
                 return scope.RecordUnary(LazyNodeType.Custom, "TensorPermute", tensor, outShape,
-                    // Permute's eager path returns a strided view; .Contiguous()
-                    // materializes it into row-major memory so AsSpan doesn't
-                    // throw "non-contiguous" when copying into the pre-allocated
-                    // output. O(n) materialization cost, paid once per Execute.
-                    (eng, output) => { var r = eng.TensorPermute(captured, capturedAxes).Contiguous(); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
+                    // Permute directly INTO the pre-allocated output via TensorPermuteInto: on the GPU engine
+                    // this runs backend.Permute into output's resident buffer and leaves it GPU-resident (no
+                    // host materialize/download — which would break the residency chain + abort CUDA-graph
+                    // capture); on the CPU engine it's the base strided copy into output. Replaces the prior
+                    // eng.TensorPermute(...).Contiguous() + CopyResultInto, which host-materialized the strided
+                    // view (non-resident src → the alias couldn't fire → the next op re-uploaded = CUDA 906).
+                    (eng, output) => eng.TensorPermuteInto(output, captured, capturedAxes),
                     BackwardFunctions<T>.PermuteBackward, new object[] { capturedAxes });
             }
         }

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -3130,7 +3130,15 @@ public partial class CpuEngine : ITensorLevelEngine
                 var capturedB = b;
                 var broadcastShape = ComputeBroadcastShape(a._shape, b._shape);
                 return scope.RecordBinary(LazyNodeType.BroadcastAdd, "TensorBroadcastAdd", a, b, broadcastShape,
-                    (eng, output) => { var eager = eng.TensorBroadcastAdd(capturedA, capturedB); DirectGpuTensorEngine.CopyResultInto(eng, eager, output); },
+                    (eng, output) =>
+                    {
+                        // GPU-resident trailing-broadcast add into output's stable buffer (no host fallback that
+                        // breaks CUDA-graph capture); else the eager allocating path.
+                        if (eng is DirectGpuTensorEngine baGpu && baGpu.TryBroadcastAddResidentInto(output, capturedA, capturedB))
+                            return;
+                        var eager = eng.TensorBroadcastAdd(capturedA, capturedB);
+                        DirectGpuTensorEngine.CopyResultInto(eng, eager, output);
+                    },
                     BackwardFunctions<T>.BroadcastAddBackward);
             }
         }
@@ -21493,6 +21501,15 @@ public partial class CpuEngine : ITensorLevelEngine
                     new[] { input, gamma, beta }, eagerResult._shape,
                     (eng, output) =>
                     {
+                        // GPU-resident compiled-step path: normalize into output's stable buffer + stable mean/var
+                        // scratch (no fresh alloc that aborts CUDA-graph capture). Falls back to the eager path.
+                        if (eng is DirectGpuTensorEngine lnGpu
+                            && lnGpu.TryLayerNormResidentInto(output, ci, cg, cb, ce, out var rMean, out var rVar))
+                        {
+                            stateRef.Mean = rMean!;
+                            stateRef.Variance = rVar!;
+                            return;
+                        }
                         var r = eng.LayerNorm(ci, cg, cb, ce, out var freshMean, out var freshVar);
                         DirectGpuTensorEngine.CopyResultInto(eng, r, output);
                         // Hand the correctly-shaped realize-time stats to backward

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Graph.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Graph.cs
@@ -202,4 +202,15 @@ public sealed partial class CudaBackend
             return false;
         return status != 0;
     }
+
+    /// <summary>Raw capture status (0=NONE, 1=ACTIVE, 2=INVALIDATED, -1=unknown). Used to pinpoint the FIRST
+    /// op that issues a non-capturable operation (which silently invalidates the whole capture).</summary>
+    public int StreamCaptureStatusRaw()
+    {
+        if (!IsAvailable) return -1;
+        using var _ = PushContext();
+        if (CudaNativeBindings.cuStreamIsCapturing(_stream, out int status) != CudaResult.Success)
+            return -1;
+        return status;
+    }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Graph.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Graph.cs
@@ -43,13 +43,20 @@ public sealed partial class CudaBackend
     /// The caller owns the handle and must free it with
     /// <see cref="DestroyCapturedGraph"/>.
     /// </summary>
+    private static void GcDiag(string s)
+    {
+        if (System.Environment.GetEnvironmentVariable("AIDOTNET_GRAPH_CAPTURE_DEBUG") != "1") return;
+        try { System.IO.File.AppendAllText(System.IO.Path.Combine(System.IO.Path.GetTempPath(),
+            "aidotnet_graphcapture_diag.txt"), "[GRAPH-CAPTURE] " + s + System.Environment.NewLine); } catch { }
+    }
+
     public IntPtr CaptureGraph(Action launch)
     {
         if (!IsAvailable || launch is null) return IntPtr.Zero;
         using var _ = PushContext();
 
         var rc = CudaNativeBindings.cuStreamBeginCapture(_stream, CudaNativeBindings.CU_STREAM_CAPTURE_MODE_THREAD_LOCAL);
-        if (rc != CudaResult.Success) return IntPtr.Zero;
+        if (rc != CudaResult.Success) { GcDiag($"beginCapture FAILED rc={rc}"); return IntPtr.Zero; }
 
         // If the action throws, abort the capture so the stream is not left in
         // capturing state (which would break every subsequent op on it).
@@ -57,20 +64,22 @@ public sealed partial class CudaBackend
         {
             launch();
         }
-        catch
+        catch (Exception ex)
         {
+            { var st = ex.StackTrace?.Replace("\r", "").Replace("\n", " >> ") ?? ""; GcDiag($"launch() THREW {ex.GetType().Name}: {ex.Message} | {st.Substring(0, System.Math.Min(2500, st.Length))}"); }
             CudaNativeBindings.cuStreamEndCapture(_stream, out var abortedGraph);
             if (abortedGraph != IntPtr.Zero) CudaNativeBindings.cuGraphDestroy(abortedGraph);
             return IntPtr.Zero;
         }
 
         rc = CudaNativeBindings.cuStreamEndCapture(_stream, out var graph);
-        if (rc != CudaResult.Success || graph == IntPtr.Zero) return IntPtr.Zero;
+        if (rc != CudaResult.Success || graph == IntPtr.Zero) { GcDiag($"endCapture FAILED rc={rc} graph={(graph != IntPtr.Zero)} (a non-capturable op — sync HtoD/DtoH or cuMemAlloc — was issued during launch)"); return IntPtr.Zero; }
 
         rc = CudaNativeBindings.cuGraphInstantiate(out var graphExec, graph, 0UL);
         CudaNativeBindings.cuGraphDestroy(graph); // exec holds its own copy; the template graph is no longer needed
-        if (rc != CudaResult.Success) return IntPtr.Zero;
+        if (rc != CudaResult.Success) { GcDiag($"instantiate FAILED rc={rc}"); return IntPtr.Zero; }
 
+        GcDiag("capture+instantiate SUCCEEDED");
         return graphExec;
     }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -3521,6 +3521,22 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
                 "cuMemcpyHtoD(graph input refresh in-place)");
     }
 
+    /// <summary>In-place int upload (no allocation) — used to refresh a STABLE embedding-index buffer each
+    /// step so the per-step path has no <c>cuMemAlloc</c> (which is synchronous and serializes the step).</summary>
+    public unsafe void UploadIntBufferInPlace(int[] data, IGpuBuffer buffer)
+    {
+        if (data == null) throw new ArgumentNullException(nameof(data));
+        if (buffer == null) throw new ArgumentNullException(nameof(buffer));
+        if (data.Length > buffer.Size)
+            throw new ArgumentException($"Host data ({data.Length}) exceeds buffer ({buffer.Size}).");
+        using var _ = PushContext();
+        ulong byteSize = (ulong)data.Length * sizeof(int);
+        fixed (int* src = data)
+            CuBlasNative.CheckCudaResult(
+                CuBlasNative.cuMemcpyHtoD(buffer.Handle, (IntPtr)src, byteSize),
+                "cuMemcpyHtoD(embedding index refresh in-place)");
+    }
+
     /// <inheritdoc/>
     public unsafe void UploadBufferAsync(ReadOnlySpan<float> data, IGpuBuffer buffer, IGpuStream stream)
     {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -3503,6 +3503,24 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         }
     }
 
+    /// <summary>Synchronously overwrite an EXISTING buffer's contents in place (stable pointer, no
+    /// realloc). Used to refresh the persistent CUDA-graph input each step OUTSIDE capture so the
+    /// captured forward reads fresh data without a re-upload INSIDE capture (which is CUDA 906
+    /// STREAM_CAPTURE_UNSUPPORTED). Keeping the pointer stable preserves the captured graph's validity.</summary>
+    public unsafe void UploadBufferInPlace(float[] data, IGpuBuffer buffer)
+    {
+        if (data == null) throw new ArgumentNullException(nameof(data));
+        if (buffer == null) throw new ArgumentNullException(nameof(buffer));
+        if (data.Length > buffer.Size)
+            throw new ArgumentException($"Host data ({data.Length}) exceeds buffer ({buffer.Size}).");
+        using var _ = PushContext();
+        ulong byteSize = (ulong)data.Length * sizeof(float);
+        fixed (float* src = data)
+            CuBlasNative.CheckCudaResult(
+                CuBlasNative.cuMemcpyHtoD(buffer.Handle, (IntPtr)src, byteSize),
+                "cuMemcpyHtoD(graph input refresh in-place)");
+    }
+
     /// <inheritdoc/>
     public unsafe void UploadBufferAsync(ReadOnlySpan<float> data, IGpuBuffer buffer, IGpuStream stream)
     {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -5459,6 +5459,10 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
         return new HipGpuBuffer(devicePtr, size);
     }
 
+    /// <inheritdoc/>
+    public void UploadIntBufferInPlace(int[] data, IGpuBuffer buffer)
+        => throw new NotSupportedException("UploadIntBufferInPlace is not supported by the HIP backend.");
+
     public IGpuBuffer AllocateIntBuffer(int[] data)
     {
         IntPtr devicePtr = IntPtr.Zero;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
@@ -1367,6 +1367,10 @@ public interface IDirectGpuBackend : IDisposable
     IGpuBuffer AllocateIntBuffer(int size);
     IGpuBuffer AllocateIntBuffer(int[] data);
 
+    /// <summary>In-place int upload (no allocation) — refreshes a stable embedding-index buffer each step.
+    /// Only the CUDA graph-capture cortex path needs it; other backends may throw NotSupported.</summary>
+    void UploadIntBufferInPlace(int[] data, IGpuBuffer buffer);
+
     #endregion
 
     #region Dot Product Operations

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
@@ -522,6 +522,10 @@ public sealed partial class MetalBackend : IDirectGpuBackend, IFusedAdvancedKern
     /// <summary>
     /// Allocates an integer buffer with initial data.
     /// </summary>
+    /// <inheritdoc/>
+    public void UploadIntBufferInPlace(int[] data, IGpuBuffer buffer)
+        => throw new NotSupportedException("UploadIntBufferInPlace is not supported by the Metal backend.");
+
     public IGpuBuffer AllocateIntBuffer(int[] data)
     {
         ThrowIfDisposed();

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -7427,6 +7427,10 @@ KERNEL VARIANTS (A/B testing):
             return new DirectOpenClGpuBuffer(buffer);
         }
 
+        /// <inheritdoc/>
+        public void UploadIntBufferInPlace(int[] data, IGpuBuffer buffer)
+            => throw new NotSupportedException("UploadIntBufferInPlace is not supported by the OpenCL backend.");
+
         public IGpuBuffer AllocateIntBuffer(int[] data)
         {
             if (_context == null)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.cs
@@ -997,6 +997,10 @@ public sealed unsafe partial class VulkanBackend : IDirectGpuBackend, IGpuBatchE
     public bool SupportsBatchExecution => true;
 
     /// <inheritdoc/>
+    public void UploadIntBufferInPlace(int[] data, IGpuBuffer buffer)
+        => throw new NotSupportedException("UploadIntBufferInPlace is not supported by the Vulkan backend.");
+
+    /// <inheritdoc/>
     public IGpuBuffer AllocateWorkspaceBuffer(int totalElements)
     {
         return AllocateBuffer(totalElements);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.cs
@@ -163,6 +163,10 @@ public sealed partial class WebGpuBackend : IDirectGpuBackend, IDisposable, IFus
     /// <summary>
     /// Allocates a GPU buffer with the specified element count.
     /// </summary>
+    /// <inheritdoc/>
+    public void UploadIntBufferInPlace(int[] data, IGpuBuffer buffer)
+        => throw new NotSupportedException("UploadIntBufferInPlace is not supported by the WebGPU backend.");
+
     /// <param name="elementCount">Number of float elements.</param>
     /// <returns>A new GPU buffer.</returns>
     public IGpuBuffer AllocateBuffer(int elementCount)

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -3660,9 +3660,15 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
         // Use cache-aware buffer allocation — checks _gpuBuffer and activation cache first
         using var inputBuffer = GetOrAllocateBuffer(backend, input);
-        // Auto-cache weights and biases so they stay on GPU for subsequent calls
-        using var weightsBuffer = GetOrAllocateBuffer(backend, weights);
-        using var biasBuffer = bias != null ? GetOrAllocateBuffer(backend, bias) : default;
+        // PERSISTENTLY cache weights and biases (not the transient GetOrAllocateBuffer, which returns an
+        // ownsBuffer:true fresh allocation that the `using` disposes — re-uploading the weights on EVERY call).
+        // That per-call cuMemcpyHtoD is both a steady-state waste AND fatal under CUDA-graph capture: a
+        // synchronous HtoD inside a stream capture throws CUDA 906 (STREAM_CAPTURE_UNSUPPORTED), aborting the
+        // whole-step graph and pinning the cortex to the launch-bound eager path (~14% util). GetOrCacheWeightBuffer
+        // adds to _persistentBufferCache — the same cache the optimizer updates in place — so the weights stay
+        // resident AND fresh. Matches the sibling fused-op path below (#GPU-graph-capture).
+        using var weightsBuffer = GetOrCacheWeightBuffer(backend, weights.GetDataArray(), PersistentTensorRole.Weights);
+        using var biasBuffer = bias != null ? GetOrCacheWeightBuffer(backend, bias.GetDataArray(), PersistentTensorRole.Biases) : default;
 
         try
         {

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -1770,6 +1770,93 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     }
 
     /// <summary>
+    /// Central output-write for the compiled-plan GraphMode Execute delegates (replaces the inline
+    /// <c>src.AsSpan().CopyTo(dest.AsWritableSpan())</c> at ~183 sites). On a GPU engine DURING a compiled step
+    /// (eviction suspended → activation buffers are pinned/stable for the whole step), aliases <paramref name="dest"/>
+    /// to <paramref name="src"/>'s RESIDENT GPU buffer instead of host-copying, so the activation chain stays
+    /// GPU-resident: the next op resolves dest via the <c>_gpuBuffer</c> fast path (no host round-trip, no
+    /// <c>cuMemcpyHtoD</c> re-upload). That re-upload was BOTH the per-op GPU↔host ping-pong (the real low-util
+    /// cause) AND a hard CUDA-graph capture abort (CUDA 906 STREAM_CAPTURE_UNSUPPORTED). Falls back to the exact
+    /// prior host-copy when not on GPU / not in a suspended-eviction step / src isn't resident — so CPU + eager
+    /// behavior is byte-identical. A deferred materializer keeps host reads of dest correct.
+    /// </summary>
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, int> s_aliasDiag = new();
+    private static void AliasDiag(string reason)
+    {
+        if (System.Environment.GetEnvironmentVariable("AIDOTNET_GRAPH_CAPTURE_DEBUG") != "1") return;
+        int n = s_aliasDiag.AddOrUpdate(reason, 1, (_, c) => c + 1);
+        if (n <= 3) try { System.IO.File.AppendAllText(System.IO.Path.Combine(System.IO.Path.GetTempPath(),
+            "aidotnet_graphcapture_diag.txt"), "[ALIAS] " + reason + System.Environment.NewLine); } catch { }
+    }
+
+    internal static void CopyResultInto<T>(IEngine eng, Tensor<T> src, Tensor<T> dest)
+    {
+        if (eng is DirectGpuTensorEngine gpu && gpu.TryAliasResidentOutput(src, dest))
+        { AliasDiag("OK aliased"); return; }
+        AliasDiag(eng is DirectGpuTensorEngine ? "FELLBACK host-copy" : "not-gpu-engine");
+        src.AsSpan().CopyTo(dest.AsWritableSpan());
+    }
+
+    private bool TryAliasResidentOutput<T>(Tensor<T> src, Tensor<T> dest)
+    {
+        // Only safe while the step has eviction suspended: the source buffer is then guaranteed live for the
+        // whole step (and across the captured graph's stable-buffer replay), so dest can borrow it.
+        if (!EvictionSuspended) { AliasDiag("skip: eviction not suspended"); return false; }
+        if (ReferenceEquals(src, dest)) return true;            // in-place op already resident; nothing to copy
+        if (!TryGetBackend(out var backend)) { AliasDiag("skip: no backend"); return false; }
+
+        // Resolve src's resident GPU buffer WITHOUT triggering an upload/download.
+        IGpuBuffer? srcBuf = null;
+        if (src._gpuBuffer is not null && ReferenceEquals(src._gpuBackend, backend)
+            && src._gpuBufferVersion == src.Version && IsCachedGpuBufferLive(src, backend))
+        {
+            srcBuf = src._gpuBuffer;
+        }
+        else
+        {
+            var srcArr = src.DataVector.GetBackingArrayUnsafe();
+            lock (_activationCacheLock)
+            {
+                if (srcArr is not null && _activationCache.TryGetValue(srcArr, out var e1)
+                    && ReferenceEquals(e1.Backend, backend) && !e1.IsFp16)
+                    srcBuf = e1.Buffer;
+                else if (_activationCache.TryGetValue(src.DataVector, out var e2)
+                    && ReferenceEquals(e2.Backend, backend) && !e2.IsFp16)
+                    srcBuf = e2.Buffer;
+            }
+        }
+        if (srcBuf is null)
+        {
+            bool capturing = backend is Engines.DirectGpu.CUDA.CudaBackend cbk && cbk.IsStreamCapturing();
+            AliasDiag($"skip: src not resident shape=[{string.Join(",", src._shape)}] hasArr={src.DataVector.GetBackingArrayUnsafe() is not null} capturing={capturing}");
+            return false;
+        }
+
+        // dest needs a backing array as the deferred-materializer key (for any host read of dest).
+        var destArr = dest.DataVector.GetBackingArrayUnsafe();
+        if (destArr is null) { AliasDiag("skip: dest has no backing array"); return false; }
+
+        // Borrow src's buffer: consumers resolve dest via the _gpuBuffer fast path. We do NOT add a second
+        // activation-cache entry under destArr — aliasing one buffer under two keys would double-free on
+        // eviction. The _gpuBuffer pointer + the IsCachedGpuBufferLive liveness check is the single source of
+        // truth; if src's buffer is later evicted, the consumer cleanly falls back to a re-upload.
+        dest._gpuBuffer = srcBuf;
+        dest._gpuBackend = backend;
+        dest._gpuBufferVersion = dest.Version;
+
+        // Host reads of dest (the loss scalar, a debug checksum, a host op) download from the borrowed buffer.
+        var capturedBuf = srcBuf;
+        var capturedBackend = backend;
+        Helpers.DeferredArrayMaterializer.Register(destArr, arr =>
+        {
+            float[] floatData = capturedBackend.DownloadBuffer(capturedBuf);
+            var converted = DirectGpuEngine.FromFloatArray<T>(floatData);
+            System.Array.Copy(converted, (T[])arr, System.Math.Min(converted.Length, ((T[])arr).Length));
+        });
+        return true;
+    }
+
+    /// <summary>
     /// Variant of <see cref="FinishGpuOp{T}"/> that registers the deferred-download
     /// materializer directly against a caller-supplied destination array, so an
     /// <c>*Into</c> API doesn't need to allocate an intermediate result array and

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -14402,24 +14402,56 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
         try
         {
-            // CUDA / HIP / Metal / OpenCL / Vulkan / WebGpu all already
-            // implement Permute(input, output, shape, axes) — the GPU
-            // kernels were written around an explicit destination buffer
-            // from day one, so the Into form just plumbs the caller's
-            // output buffer's existing array through. We download the
-            // result directly into output.GetDataArray() instead of into a
-            // freshly-allocated managed array, so the per-call allocation
-            // the API docs promise to skip is actually skipped on the hot
-            // path (FinishGpuOp's default behavior allocates and copies).
-            using var bufIn = GetOrAllocateBuffer(backend, tensor.GetDataArray());
-            var bufOut = AllocateOutputBuffer(backend, tensor.Length);
-            backend.Permute(bufIn.Buffer, bufOut.Buffer, tensor.Shape._dims, axes);
-            // Download directly into the caller's existing array. This
-            // keeps output's identity stable for repeated calls AND avoids
-            // the materialize-then-copy pattern that would otherwise
-            // double the per-call CPU memory traffic.
-            var dst = output.GetDataArray();
-            DownloadGpuBufferInto(backend, bufOut, dst, output.Length);
+            // CUDA / HIP / Metal / OpenCL / Vulkan / WebGpu all already implement Permute(input, output, shape,
+            // axes) writing into an explicit destination buffer. The bug for CUDA-graph capture / GPU util was the
+            // DOWNLOAD that followed: the GPU permute ran resident but the result was then DtoH-copied to host,
+            // breaking the residency chain (the next op re-uploaded = cuMemcpyHtoD = a non-capturable 906; and the
+            // GPU↔host ping-pong every op = the low-util cause).
+            if (EvictionSuspended)
+            {
+                // COMPILED-STEP GPU-RESIDENT PATH: read the (resident) input, permute into a STABLE cached output
+                // buffer, leave output resident (no download). The output buffer is cached by output's backing
+                // array so it's allocated ONCE (in the pre-residency pass) and reused on capture/replay — no
+                // per-call cuMemAlloc (which would itself abort the capture). Host reads of output download lazily
+                // via the registered materializer.
+                using var bufIn = GetOrAllocateBuffer(backend, tensor);   // Tensor overload: resident fast-path, no forced download
+                var arr = output.DataVector.GetBackingArrayUnsafe();
+                IGpuBuffer? outBuf = null;
+                if (output._gpuBuffer is not null && ReferenceEquals(output._gpuBackend, backend) && IsCachedGpuBufferLive(output, backend))
+                    outBuf = output._gpuBuffer;
+                else if (arr is not null)
+                    lock (_activationCacheLock)
+                        if (_activationCache.TryGetValue(arr, out var e) && ReferenceEquals(e.Backend, backend) && !e.IsFp16)
+                            outBuf = e.Buffer;
+                if (outBuf is null)
+                {
+                    outBuf = backend.AllocateBuffer(output.Length);
+                    if (arr is not null) CacheActivation(arr, outBuf, output._shape, backend);
+                }
+                backend.Permute(bufIn.Buffer, outBuf, tensor.Shape._dims, axes);
+                output._gpuBuffer = outBuf;
+                output._gpuBackend = backend;
+                output._gpuBufferVersion = output.Version;
+                if (arr is not null)
+                {
+                    var capBuf = outBuf; var capBackend = backend;
+                    Helpers.DeferredArrayMaterializer.Register(arr, a =>
+                    {
+                        float[] f = capBackend.DownloadBuffer(capBuf);
+                        var conv = DirectGpuEngine.FromFloatArray<T>(f);
+                        System.Array.Copy(conv, (T[])a, System.Math.Min(conv.Length, ((T[])a).Length));
+                    });
+                }
+            }
+            else
+            {
+                // Eager/inference path (unchanged): permute on GPU, download directly into output's array.
+                using var bufIn = GetOrAllocateBuffer(backend, tensor.GetDataArray());
+                var bufOut = AllocateOutputBuffer(backend, tensor.Length);
+                backend.Permute(bufIn.Buffer, bufOut.Buffer, tensor.Shape._dims, axes);
+                var dst = output.GetDataArray();
+                DownloadGpuBufferInto(backend, bufOut, dst, output.Length);
+            }
         }
         catch (Exception)
         {

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -1206,7 +1206,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 nameof(attentionBias));
         }
 
-        return GetOrAllocateBuffer(backend, attentionBias.GetDataArray());
+        return GetOrAllocateBuffer(backend, attentionBias);
     }
 
     /// <summary>
@@ -1828,7 +1828,9 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (srcBuf is null)
         {
             bool capturing = backend is Engines.DirectGpu.CUDA.CudaBackend cbk && cbk.IsStreamCapturing();
-            AliasDiag($"skip: src not resident shape=[{string.Join(",", src._shape)}] hasArr={src.DataVector.GetBackingArrayUnsafe() is not null} capturing={capturing}");
+            bool hasBuf = src._gpuBuffer is not null;
+            bool verMatch = hasBuf && src._gpuBufferVersion == src.Version;
+            AliasDiag($"skip: src not resident shape=[{string.Join(",", src._shape)}] hasBuf={hasBuf} verMatch={verMatch} bkndMatch={hasBuf && ReferenceEquals(src._gpuBackend, backend)} capturing={capturing}");
             return false;
         }
 
@@ -2615,6 +2617,39 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         return GetOrAllocateBuffer(backend, tensor);
     }
 
+    // Stable cached GPU buffer for a compiled-plan op OUTPUT: allocated ONCE and reused across steps (the
+    // activation cache holds it alive while the step has eviction suspended), so capture/replay never cuMemAlloc
+    // — a sync alloc inside a stream capture aborts it. Keyed by the destination's backing array.
+    private IGpuBuffer GetOrCreateResidentBuffer<T>(IDirectGpuBackend backend, Tensor<T> t, int length)
+    {
+        if (t._gpuBuffer is not null && ReferenceEquals(t._gpuBackend, backend) && IsCachedGpuBufferLive(t, backend))
+            return t._gpuBuffer;
+        var arr = t.DataVector.GetBackingArrayUnsafe();
+        if (arr is not null)
+            lock (_activationCacheLock)
+                if (_activationCache.TryGetValue(arr, out var e) && ReferenceEquals(e.Backend, backend) && !e.IsFp16)
+                    return e.Buffer;
+        var buf = backend.AllocateBuffer(length);
+        if (arr is not null) CacheActivation(arr, buf, t._shape, backend);
+        return buf;
+    }
+
+    // Mark a tensor GPU-resident on `buf`: consumers resolve it via the _gpuBuffer fast path (no re-upload), and
+    // a deferred materializer keeps host reads correct. Used by the compiled-step resident op paths.
+    internal void BindResidentBuffer<T>(Tensor<T> t, IGpuBuffer buf, IDirectGpuBackend backend)
+    {
+        t._gpuBuffer = buf; t._gpuBackend = backend; t._gpuBufferVersion = t.Version;
+        var arr = t.DataVector.GetBackingArrayUnsafe();
+        if (arr is null) return;
+        var capBuf = buf; var capBackend = backend;
+        Helpers.DeferredArrayMaterializer.Register(arr, a =>
+        {
+            float[] f = capBackend.DownloadBuffer(capBuf);
+            var conv = DirectGpuEngine.FromFloatArray<T>(f);
+            System.Array.Copy(conv, (T[])a, System.Math.Min(conv.Length, ((T[])a).Length));
+        });
+    }
+
     private bool TryRunBinaryInto<T>(
         Tensor<T> destination,
         Tensor<T> left,
@@ -2624,9 +2659,27 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     {
         if (left.Length != right.Length)
             return false;
-        if (!TryGetSimpleCpuDestinationArray(destination, left.Length, out var destinationArray))
-            return false;
         if (!TryGetBackend(out var backend))
+            return false;
+
+        // GPU-RESIDENT compiled-step path: op directly into destination's stable buffer — no temp output
+        // allocation and no DtoH download (both abort CUDA-graph capture + ping-pong host every op). Gated on
+        // suspended eviction (the compiled step pins buffers) and no autocast fp16 remap.
+        if (EvictionSuspended && !Gpu.AutocastScope.IsEnabled)
+        {
+            try
+            {
+                using var bA = GetOrAllocateContiguousInputBuffer(backend, left);
+                using var bB = GetOrAllocateContiguousInputBuffer(backend, right);
+                var destBuf = GetOrCreateResidentBuffer(backend, destination, left.Length);
+                op(backend, bA.Buffer, bB.Buffer, destBuf, left.Length);
+                BindResidentBuffer(destination, destBuf, backend);
+                return true;
+            }
+            catch { /* fall through to the host-download path below */ }
+        }
+
+        if (!TryGetSimpleCpuDestinationArray(destination, left.Length, out var destinationArray))
             return false;
 
         try
@@ -2686,9 +2739,25 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, float, int> op,
         [System.Runtime.CompilerServices.CallerMemberName] string callerName = "")
     {
-        if (!TryGetSimpleCpuDestinationArray(destination, input.Length, out var destinationArray))
-            return false;
         if (!TryGetBackend(out var backend))
+            return false;
+
+        // GPU-RESIDENT compiled-step path (see TryRunBinaryInto): op into destination's stable buffer, no temp
+        // alloc / no download — keeps the activation chain on-device for CUDA-graph capture.
+        if (EvictionSuspended && !Gpu.AutocastScope.IsEnabled)
+        {
+            try
+            {
+                using var bA = GetOrAllocateContiguousInputBuffer(backend, input);
+                var destBuf = GetOrCreateResidentBuffer(backend, destination, input.Length);
+                op(backend, bA.Buffer, destBuf, ToFloatScalar(scalar), input.Length);
+                BindResidentBuffer(destination, destBuf, backend);
+                return true;
+            }
+            catch { /* fall through to the host-download path below */ }
+        }
+
+        if (!TryGetSimpleCpuDestinationArray(destination, input.Length, out var destinationArray))
             return false;
 
         try
@@ -3675,7 +3744,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (!TryGetBackend(out var backend))
             return base.TensorSum(tensor);
 
-        using var bufferA = GetOrAllocateBuffer(backend, tensor.GetDataArray());
+        using var bufferA = GetOrAllocateBuffer(backend, tensor);
         backend.Synchronize();
         float sum = backend.Sum(bufferA.Buffer, tensor.Length);
         return FromFloatScalar<T>(sum);
@@ -3686,7 +3755,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (!TryGetBackend(out var backend))
             return base.TensorMaxValue(tensor);
 
-        using var bufferA = GetOrAllocateBuffer(backend, tensor.GetDataArray());
+        using var bufferA = GetOrAllocateBuffer(backend, tensor);
         backend.Synchronize();
         float max = backend.Max(bufferA.Buffer, tensor.Length);
         return FromFloatScalar<T>(max);
@@ -3697,7 +3766,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (!TryGetBackend(out var backend))
             return base.TensorMinValue(tensor);
 
-        using var bufferA = GetOrAllocateBuffer(backend, tensor.GetDataArray());
+        using var bufferA = GetOrAllocateBuffer(backend, tensor);
         backend.Synchronize();
         float min = backend.Min(bufferA.Buffer, tensor.Length);
         return FromFloatScalar<T>(min);
@@ -3853,7 +3922,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int outputFeatures = weights.Shape._dims[1];
 
         // Upload input to GPU (activations are not cached persistently)
-        using var inputBuffer = GetOrAllocateBuffer(backend, input.GetDataArray());
+        using var inputBuffer = GetOrAllocateBuffer(backend, input);
         // Auto-cache weights and biases so they stay on GPU for subsequent calls
         using var weightsBuffer = GetOrCacheWeightBuffer(backend, weights.GetDataArray(), PersistentTensorRole.Weights);
         using var biasBuffer = bias != null ? GetOrCacheWeightBuffer(backend, bias.GetDataArray(), PersistentTensorRole.Biases) : default;
@@ -4658,7 +4727,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             return base.FusedConv2D(input, kernel, bias, strideH, strideW, padH, padW, dilationH, dilationW, activation);
 
         // Use cache-aware buffer allocation (OwnedBuffer auto-disposes only if we allocated)
-        using var inputBuffer = GetOrAllocateBuffer(backend, input.GetDataArray());
+        using var inputBuffer = GetOrAllocateBuffer(backend, input);
         using var kernelBuffer = GetOrCacheWeightBuffer(backend, kernel.GetDataArray(), PersistentTensorRole.Weights);
         using var outputBuffer = AllocateOutputBuffer(backend, batch * outChannels * outHeight * outWidth);
 
@@ -4879,7 +4948,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             return base.FusedConv3D(input, kernel, bias, strideD, strideH, strideW, padD, padH, padW, dilationD, dilationH, dilationW, activation);
 
         // Use cache-aware buffer allocation (OwnedBuffer auto-disposes only if we allocated)
-        using var inputBuffer = GetOrAllocateBuffer(backend, input.GetDataArray());
+        using var inputBuffer = GetOrAllocateBuffer(backend, input);
         using var kernelBuffer = GetOrCacheWeightBuffer(backend, kernel.GetDataArray(), PersistentTensorRole.Weights);
         using var outputBuffer = AllocateOutputBuffer(backend, batch * outChannels * outDepth * outHeight * outWidth);
 
@@ -5097,7 +5166,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             return base.FusedConvTranspose2D(input, kernel, bias, strideH, strideW, padH, padW, outputPadH, outputPadW, activation);
 
         // Use cache-aware buffer allocation (OwnedBuffer auto-disposes only if we allocated)
-        using var inputBuffer = GetOrAllocateBuffer(backend, input.GetDataArray());
+        using var inputBuffer = GetOrAllocateBuffer(backend, input);
         using var kernelBuffer = GetOrCacheWeightBuffer(backend, kernel.GetDataArray(), PersistentTensorRole.Weights);
         using var outputBuffer = AllocateOutputBuffer(backend, batch * outChannels * outHeight * outWidth);
 
@@ -5292,7 +5361,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (outHeight <= 0 || outWidth <= 0)
             return base.MaxPool2D(input, poolSize, stride, padding);
 
-        using var inputBuffer = GetOrAllocateBuffer(backend, input.GetDataArray());
+        using var inputBuffer = GetOrAllocateBuffer(backend, input);
         using var outputBuffer = AllocateOutputBuffer(backend, batch * channels * outHeight * outWidth);
 
         try
@@ -5341,7 +5410,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (outHeight <= 0 || outWidth <= 0)
             return base.MaxPool2DWithIndices(input, poolSize, stride, out maxIndices);
 
-        using var inputBuffer = GetOrAllocateBuffer(backend, input.GetDataArray());
+        using var inputBuffer = GetOrAllocateBuffer(backend, input);
         using var outputBuffer = AllocateOutputBuffer(backend, batch * channels * outHeight * outWidth);
         using var indicesBuffer = AllocateOutputBuffer(backend, batch * channels * outHeight * outWidth);
 
@@ -5436,7 +5505,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             }
         }
 
-        using var gradOutputBuffer = GetOrAllocateBuffer(backend, gradOutput.GetDataArray());
+        using var gradOutputBuffer = GetOrAllocateBuffer(backend, gradOutput);
         using var indicesBuffer = backend.AllocateIntBuffer(indicesFlat);
         using var gradInputBuffer = AllocateOutputBuffer(backend, batch * channels * inHeight * inWidth);
 
@@ -5489,7 +5558,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (outHeight <= 0 || outWidth <= 0)
             return base.AvgPool2D(input, poolSize, stride, padding);
 
-        using var inputBuffer = GetOrAllocateBuffer(backend, input.GetDataArray());
+        using var inputBuffer = GetOrAllocateBuffer(backend, input);
         using var outputBuffer = AllocateOutputBuffer(backend, batch * channels * outHeight * outWidth);
 
         try
@@ -5543,7 +5612,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (outHeight <= 0 || outWidth <= 0)
             return base.AvgPool2D(input, poolSize, stride);
 
-        using var inputBuffer = GetOrAllocateBuffer(backend, input.GetDataArray());
+        using var inputBuffer = GetOrAllocateBuffer(backend, input);
         using var outputBuffer = AllocateOutputBuffer(backend, batch * channels * outHeight * outWidth);
 
         try
@@ -5598,7 +5667,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int outHeight = gradOutput.Shape._dims[2];
         int outWidth = gradOutput.Shape._dims[3];
 
-        using var gradOutputBuffer = GetOrAllocateBuffer(backend, gradOutput.GetDataArray());
+        using var gradOutputBuffer = GetOrAllocateBuffer(backend, gradOutput);
         using var gradInputBuffer = AllocateOutputBuffer(backend, batch * channels * inHeight * inWidth);
 
         try
@@ -5656,7 +5725,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (outHeight <= 0 || outWidth <= 0)
             return base.DepthwiseConv2D(input, kernel, stride, padding);
 
-        using var inputBuffer = GetOrAllocateBuffer(backend, input.GetDataArray());
+        using var inputBuffer = GetOrAllocateBuffer(backend, input);
         using var kernelBuffer = GetOrCacheWeightBuffer(backend, kernel.GetDataArray(), PersistentTensorRole.Weights);
         using var outputBuffer = AllocateOutputBuffer(backend, batch * channels * outHeight * outWidth);
 
@@ -5805,7 +5874,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int outputSize = batch * outChannels * outHeight * outWidth;
 
         // Use cache-aware buffer allocation for weights/bias (persistent tensors)
-        using var inputBuffer = GetOrAllocateBuffer(backend, input.GetDataArray());
+        using var inputBuffer = GetOrAllocateBuffer(backend, input);
         using var weightsBuffer = GetOrCacheWeightBuffer(backend, weights.GetDataArray(), PersistentTensorRole.Weights);
         using var outputBuffer = AllocateOutputBuffer(backend, outputSize);
 
@@ -5879,7 +5948,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
         int inputSize = batch * inChannels * inHeight * inWidth;
 
-        using var gradOutputBuffer = GetOrAllocateBuffer(backend, gradOutput.GetDataArray());
+        using var gradOutputBuffer = GetOrAllocateBuffer(backend, gradOutput);
         using var weightsBuffer = GetOrCacheWeightBuffer(backend, weights.GetDataArray(), PersistentTensorRole.Weights);
         using var gradInputBuffer = AllocateOutputBuffer(backend, inputSize);
 
@@ -5934,8 +6003,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
         int weightsSize = outHeight * outWidth * outChannels * inChannels * kernelH * kernelW;
 
-        using var gradOutputBuffer = GetOrAllocateBuffer(backend, gradOutput.GetDataArray());
-        using var inputBuffer = GetOrAllocateBuffer(backend, input.GetDataArray());
+        using var gradOutputBuffer = GetOrAllocateBuffer(backend, gradOutput);
+        using var inputBuffer = GetOrAllocateBuffer(backend, input);
         using var gradWeightsBuffer = AllocateOutputBuffer(backend, weightsSize);
 
         try
@@ -5976,7 +6045,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int outHeight = gradOutput.Shape._dims[2];
         int outWidth = gradOutput.Shape._dims[3];
 
-        using var gradOutputBuffer = GetOrAllocateBuffer(backend, gradOutput.GetDataArray());
+        using var gradOutputBuffer = GetOrAllocateBuffer(backend, gradOutput);
         using var gradBiasBuffer = AllocateOutputBuffer(backend, outChannels);
 
         try
@@ -6118,14 +6187,14 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
         int outputSize = batch * outChannels * outHeight * outWidth;
 
-        using var inputBuffer = GetOrAllocateBuffer(backend, input.GetDataArray());
+        using var inputBuffer = GetOrAllocateBuffer(backend, input);
         using var weightsBuffer = GetOrCacheWeightBuffer(backend, kernel.GetDataArray(), PersistentTensorRole.Weights);
-        using var offsetsBuffer = GetOrAllocateBuffer(backend, offsets.GetDataArray());
+        using var offsetsBuffer = GetOrAllocateBuffer(backend, offsets);
         using var outputBuffer = AllocateOutputBuffer(backend, outputSize);
 
         try
         {
-            OwnedBuffer? maskBuffer = mask != null ? GetOrAllocateBuffer(backend, mask.GetDataArray()) : null;
+            OwnedBuffer? maskBuffer = mask != null ? GetOrAllocateBuffer(backend, mask) : null;
             try
             {
                 backend.DeformableConv2D(
@@ -6191,14 +6260,14 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
         int inputSize = batch * inChannels * inHeight * inWidth;
 
-        using var gradOutputBuffer = GetOrAllocateBuffer(backend, gradOutput.GetDataArray());
+        using var gradOutputBuffer = GetOrAllocateBuffer(backend, gradOutput);
         using var weightsBuffer = GetOrCacheWeightBuffer(backend, kernel.GetDataArray(), PersistentTensorRole.Weights);
-        using var offsetsBuffer = GetOrAllocateBuffer(backend, offsets.GetDataArray());
+        using var offsetsBuffer = GetOrAllocateBuffer(backend, offsets);
         using var gradInputBuffer = AllocateOutputBuffer(backend, inputSize);
 
         try
         {
-            OwnedBuffer? maskBuffer = mask != null ? GetOrAllocateBuffer(backend, mask.GetDataArray()) : null;
+            OwnedBuffer? maskBuffer = mask != null ? GetOrAllocateBuffer(backend, mask) : null;
             try
             {
                 backend.DeformableConv2DBackwardInput(
@@ -6263,14 +6332,14 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
         int kernelSize = kernelShape[0] * kernelShape[1] * kernelShape[2] * kernelShape[3];
 
-        using var gradOutputBuffer = GetOrAllocateBuffer(backend, gradOutput.GetDataArray());
-        using var inputBuffer = GetOrAllocateBuffer(backend, input.GetDataArray());
-        using var offsetsBuffer = GetOrAllocateBuffer(backend, offsets.GetDataArray());
+        using var gradOutputBuffer = GetOrAllocateBuffer(backend, gradOutput);
+        using var inputBuffer = GetOrAllocateBuffer(backend, input);
+        using var offsetsBuffer = GetOrAllocateBuffer(backend, offsets);
         using var gradWeightsBuffer = AllocateOutputBuffer(backend, kernelSize);
 
         try
         {
-            OwnedBuffer? maskBuffer = mask != null ? GetOrAllocateBuffer(backend, mask.GetDataArray()) : null;
+            OwnedBuffer? maskBuffer = mask != null ? GetOrAllocateBuffer(backend, mask) : null;
             try
             {
                 backend.DeformableConv2DBackwardWeights(
@@ -6335,15 +6404,15 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
         int offsetSize = batch * offsetChannels * outHeight * outWidth;
 
-        using var gradOutputBuffer = GetOrAllocateBuffer(backend, gradOutput.GetDataArray());
-        using var inputBuffer = GetOrAllocateBuffer(backend, input.GetDataArray());
+        using var gradOutputBuffer = GetOrAllocateBuffer(backend, gradOutput);
+        using var inputBuffer = GetOrAllocateBuffer(backend, input);
         using var weightsBuffer = GetOrCacheWeightBuffer(backend, kernel.GetDataArray(), PersistentTensorRole.Weights);
-        using var offsetsBuffer = GetOrAllocateBuffer(backend, offsets.GetDataArray());
+        using var offsetsBuffer = GetOrAllocateBuffer(backend, offsets);
         using var gradOffsetBuffer = AllocateOutputBuffer(backend, offsetSize);
 
         try
         {
-            OwnedBuffer? maskBuffer = mask != null ? GetOrAllocateBuffer(backend, mask.GetDataArray()) : null;
+            OwnedBuffer? maskBuffer = mask != null ? GetOrAllocateBuffer(backend, mask) : null;
             try
             {
                 backend.DeformableConv2DBackwardOffset(
@@ -6413,10 +6482,10 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
         int maskSize = batch * maskChannels * outHeight * outWidth;
 
-        using var gradOutputBuffer = GetOrAllocateBuffer(backend, gradOutput.GetDataArray());
-        using var inputBuffer = GetOrAllocateBuffer(backend, input.GetDataArray());
+        using var gradOutputBuffer = GetOrAllocateBuffer(backend, gradOutput);
+        using var inputBuffer = GetOrAllocateBuffer(backend, input);
         using var weightsBuffer = GetOrCacheWeightBuffer(backend, kernel.GetDataArray(), PersistentTensorRole.Weights);
-        using var offsetsBuffer = GetOrAllocateBuffer(backend, offsets.GetDataArray());
+        using var offsetsBuffer = GetOrAllocateBuffer(backend, offsets);
         using var gradMaskBuffer = AllocateOutputBuffer(backend, maskSize);
 
         try
@@ -6500,8 +6569,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int outputSize = batch * outChannels * outHeight * outWidth;
 
         using var weightsBuffer = GetOrCacheWeightBuffer(backend, weights.GetDataArray(), PersistentTensorRole.Weights);
-        using var offsetsBuffer = GetOrAllocateBuffer(backend, offsets.GetDataArray());
-        using var maskBuffer = mask != null ? GetOrAllocateBuffer(backend, mask.GetDataArray()) : default(OwnedBuffer?);
+        using var offsetsBuffer = GetOrAllocateBuffer(backend, offsets);
+        using var maskBuffer = mask != null ? GetOrAllocateBuffer(backend, mask) : default(OwnedBuffer?);
         using var biasBuffer = bias != null ? GetOrCacheWeightBuffer(backend, bias.GetDataArray(), PersistentTensorRole.Biases) : default(OwnedBuffer?);
         var outputBuffer = backend.AllocateBuffer(outputSize);
 
@@ -6565,7 +6634,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int features = input.Shape._dims[1];
 
         // Use cache-aware buffer allocation (OwnedBuffer auto-disposes only if we allocated)
-        using var inputBuffer = GetOrAllocateBuffer(backend, input.GetDataArray());
+        using var inputBuffer = GetOrAllocateBuffer(backend, input);
         using var outputBuffer = AllocateOutputBuffer(backend, batchSize * features);
         using var saveMeanBuffer = AllocateOutputBuffer(backend, features);
         using var saveVarBuffer = AllocateOutputBuffer(backend, features);
@@ -7077,9 +7146,9 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         float scaleFloat = (float)(scale ?? (1.0 / Math.Sqrt(headDim)));
 
         // Use cache-aware buffer allocation (especially important for KV cache)
-        using var queryBuffer = GetOrAllocateBuffer(backend, query.GetDataArray());
-        using var keyBuffer = GetOrAllocateBuffer(backend, key.GetDataArray());
-        using var valueBuffer = GetOrAllocateBuffer(backend, value.GetDataArray());
+        using var queryBuffer = GetOrAllocateBuffer(backend, query);
+        using var keyBuffer = GetOrAllocateBuffer(backend, key);
+        using var valueBuffer = GetOrAllocateBuffer(backend, value);
         using var outputBuffer = AllocateOutputBuffer(backend, batch * heads * seqQ * headDim);
         using var statsBuffer = AllocateOutputBuffer(backend, batch * heads * seqQ);
 
@@ -7149,12 +7218,12 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int seqK = key.Shape._dims[2];
 
         // Use cache-aware buffer allocation
-        using var gradOutBuffer = GetOrAllocateBuffer(backend, gradOutput.GetDataArray());
-        using var queryBuffer = GetOrAllocateBuffer(backend, query.GetDataArray());
-        using var keyBuffer = GetOrAllocateBuffer(backend, key.GetDataArray());
-        using var valueBuffer = GetOrAllocateBuffer(backend, value.GetDataArray());
-        using var outputBuffer = GetOrAllocateBuffer(backend, output.GetDataArray());
-        using var statsBuffer = GetOrAllocateBuffer(backend, softmaxStats.GetDataArray());
+        using var gradOutBuffer = GetOrAllocateBuffer(backend, gradOutput);
+        using var queryBuffer = GetOrAllocateBuffer(backend, query);
+        using var keyBuffer = GetOrAllocateBuffer(backend, key);
+        using var valueBuffer = GetOrAllocateBuffer(backend, value);
+        using var outputBuffer = GetOrAllocateBuffer(backend, output);
+        using var statsBuffer = GetOrAllocateBuffer(backend, softmaxStats);
         using var gradQBuffer = AllocateOutputBuffer(backend, batch * heads * seqQ * headDim);
         using var gradKBuffer = AllocateOutputBuffer(backend, batch * heads * seqK * headDim);
         using var gradVBuffer = AllocateOutputBuffer(backend, batch * heads * seqK * headDim);
@@ -7235,9 +7304,9 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         float scaleFloat = (float)(scale ?? (1.0 / Math.Sqrt(headDim)));
 
         // Use cache-aware buffer allocation (especially important for KV cache)
-        using var queryBuffer = GetOrAllocateBuffer(backend, query.GetDataArray());
-        using var keyBuffer = GetOrAllocateBuffer(backend, key.GetDataArray());
-        using var valueBuffer = GetOrAllocateBuffer(backend, value.GetDataArray());
+        using var queryBuffer = GetOrAllocateBuffer(backend, query);
+        using var keyBuffer = GetOrAllocateBuffer(backend, key);
+        using var valueBuffer = GetOrAllocateBuffer(backend, value);
         using var outputBuffer = AllocateOutputBuffer(backend, batch * numQHeads * seqQ * headDim);
         using var attnWeightsBuffer = AllocateOutputBuffer(backend, batch * numQHeads * seqQ * seqK);
 
@@ -7298,11 +7367,11 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int seqK = key.Shape._dims[2];
 
         // Use cache-aware buffer allocation
-        using var gradOutBuffer = GetOrAllocateBuffer(backend, gradOutput.GetDataArray());
-        using var queryBuffer = GetOrAllocateBuffer(backend, query.GetDataArray());
-        using var keyBuffer = GetOrAllocateBuffer(backend, key.GetDataArray());
-        using var valueBuffer = GetOrAllocateBuffer(backend, value.GetDataArray());
-        using var attnWeightsBuffer = GetOrAllocateBuffer(backend, attentionWeights.GetDataArray());
+        using var gradOutBuffer = GetOrAllocateBuffer(backend, gradOutput);
+        using var queryBuffer = GetOrAllocateBuffer(backend, query);
+        using var keyBuffer = GetOrAllocateBuffer(backend, key);
+        using var valueBuffer = GetOrAllocateBuffer(backend, value);
+        using var attnWeightsBuffer = GetOrAllocateBuffer(backend, attentionWeights);
         using var gradQBuffer = AllocateOutputBuffer(backend, batch * numQHeads * seqQ * headDim);
         using var gradKBuffer = AllocateOutputBuffer(backend, batch * numKVHeads * seqK * headDim);
         using var gradVBuffer = AllocateOutputBuffer(backend, batch * numKVHeads * seqK * headDim);
@@ -7953,8 +8022,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         try
         {
             // Use cache-aware buffer allocation for inputs
-            using var inputRealBuffer = GetOrAllocateBuffer(backend, inputReal.GetDataArray());
-            using var inputImagBuffer = GetOrAllocateBuffer(backend, inputImag.GetDataArray());
+            using var inputRealBuffer = GetOrAllocateBuffer(backend, inputReal);
+            using var inputImagBuffer = GetOrAllocateBuffer(backend, inputImag);
             using var outputRealBuffer = AllocateOutputBuffer(backend, inputReal.Length);
             using var outputImagBuffer = AllocateOutputBuffer(backend, inputImag.Length);
 
@@ -7995,8 +8064,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         try
         {
             // Use cache-aware buffer allocation for inputs
-            using var inputRealBuffer = GetOrAllocateBuffer(backend, inputReal.GetDataArray());
-            using var inputImagBuffer = GetOrAllocateBuffer(backend, inputImag.GetDataArray());
+            using var inputRealBuffer = GetOrAllocateBuffer(backend, inputReal);
+            using var inputImagBuffer = GetOrAllocateBuffer(backend, inputImag);
             using var outputRealBuffer = AllocateOutputBuffer(backend, inputReal.Length);
             using var outputImagBuffer = AllocateOutputBuffer(backend, inputImag.Length);
 
@@ -8039,8 +8108,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         try
         {
             // Use cache-aware buffer allocation for inputs
-            using var inputRealBuffer = GetOrAllocateBuffer(backend, inputReal.GetDataArray());
-            using var inputImagBuffer = GetOrAllocateBuffer(backend, inputImag.GetDataArray());
+            using var inputRealBuffer = GetOrAllocateBuffer(backend, inputReal);
+            using var inputImagBuffer = GetOrAllocateBuffer(backend, inputImag);
             using var outputRealBuffer = AllocateOutputBuffer(backend, inputReal.Length);
             using var outputImagBuffer = AllocateOutputBuffer(backend, inputImag.Length);
 
@@ -8083,8 +8152,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         try
         {
             // Use cache-aware buffer allocation for inputs
-            using var inputRealBuffer = GetOrAllocateBuffer(backend, inputReal.GetDataArray());
-            using var inputImagBuffer = GetOrAllocateBuffer(backend, inputImag.GetDataArray());
+            using var inputRealBuffer = GetOrAllocateBuffer(backend, inputReal);
+            using var inputImagBuffer = GetOrAllocateBuffer(backend, inputImag);
             using var outputRealBuffer = AllocateOutputBuffer(backend, inputReal.Length);
             using var outputImagBuffer = AllocateOutputBuffer(backend, inputImag.Length);
 
@@ -8148,7 +8217,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             float[] inputFloat = DirectGpuEngine.ToFloatArray(inputData);
 
             // Use cache-aware allocation for window (likely persistent)
-            using var windowBuffer = GetOrAllocateBuffer(backend, window.GetDataArray());
+            using var windowBuffer = GetOrAllocateBuffer(backend, window);
             // Allocate working buffers
             using var frameBuffer = AllocateOutputBuffer(backend, nFft);
             using var windowedBuffer = AllocateOutputBuffer(backend, nFft);
@@ -8238,7 +8307,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             float[] windowSum = new float[outputSamples];
 
             // Use cache-aware allocation for window (likely persistent)
-            using var windowBuffer = GetOrAllocateBuffer(backend, window.GetDataArray());
+            using var windowBuffer = GetOrAllocateBuffer(backend, window);
             // Allocate working buffers
             using var outputRealBuffer = AllocateOutputBuffer(backend, nFft);
             using var outputImagBuffer = AllocateOutputBuffer(backend, nFft);
@@ -8364,7 +8433,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             }
 
             // Use cache-aware allocation for filterbank (likely persistent)
-            using var filterbankBuffer = GetOrAllocateBuffer(backend, filterbank.GetDataArray());
+            using var filterbankBuffer = GetOrAllocateBuffer(backend, filterbank);
             // Allocate working buffers
             using var powerBuffer = backend.AllocateBuffer(powerSpec);
             using var melBuffer = AllocateOutputBuffer(backend, numFrames * nMels);
@@ -8545,8 +8614,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 int features = output.Shape._dims[rank - 1];
                 int outerSize = output.Length / features;
 
-                using var gradOutBuffer = GetOrAllocateBuffer(backend, gradOutput.GetDataArray());
-                using var outputBuffer = GetOrAllocateBuffer(backend, output.GetDataArray());
+                using var gradOutBuffer = GetOrAllocateBuffer(backend, gradOutput);
+                using var outputBuffer = GetOrAllocateBuffer(backend, output);
                 using var gradInputBuffer = AllocateOutputBuffer(backend, output.Length);
 
                 backend.SoftmaxBackward(gradOutBuffer.Buffer, outputBuffer.Buffer, gradInputBuffer.Buffer, outerSize, features);
@@ -8574,8 +8643,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 int features = permutedOutput.Shape._dims[rank - 1];
                 int outerSize = permutedOutput.Length / features;
 
-                using var gradOutBuffer = GetOrAllocateBuffer(backend, permutedGradOutput.GetDataArray());
-                using var outputBuffer = GetOrAllocateBuffer(backend, permutedOutput.GetDataArray());
+                using var gradOutBuffer = GetOrAllocateBuffer(backend, permutedGradOutput);
+                using var outputBuffer = GetOrAllocateBuffer(backend, permutedOutput);
                 using var gradInputBuffer = AllocateOutputBuffer(backend, permutedOutput.Length);
 
                 backend.SoftmaxBackward(gradOutBuffer.Buffer, outputBuffer.Buffer, gradInputBuffer.Buffer, outerSize, features);
@@ -8622,7 +8691,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 int capsuleDim = tensor.Shape._dims[rank - 1];
                 int numCapsules = tensor.Length / capsuleDim;
 
-                using var inputBuffer = GetOrAllocateBuffer(backend, tensor.GetDataArray());
+                using var inputBuffer = GetOrAllocateBuffer(backend, tensor);
                 using var outputBuffer = AllocateOutputBuffer(backend, tensor.Length);
 
                 backend.Squash(inputBuffer.Buffer, outputBuffer.Buffer, numCapsules, capsuleDim, 1e-8f);
@@ -8648,7 +8717,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 int capsuleDim = permutedInput.Shape._dims[rank - 1];
                 int numCapsules = permutedInput.Length / capsuleDim;
 
-                using var inputBuffer = GetOrAllocateBuffer(backend, permutedInput.GetDataArray());
+                using var inputBuffer = GetOrAllocateBuffer(backend, permutedInput);
                 using var outputBuffer = AllocateOutputBuffer(backend, permutedInput.Length);
 
                 backend.Squash(inputBuffer.Buffer, outputBuffer.Buffer, numCapsules, capsuleDim, 1e-8f);
@@ -8693,8 +8762,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 int capsuleDim = input.Shape._dims[rank - 1];
                 int numCapsules = input.Length / capsuleDim;
 
-                using var gradOutputBuffer = GetOrAllocateBuffer(backend, gradOutput.GetDataArray());
-                using var inputBuffer = GetOrAllocateBuffer(backend, input.GetDataArray());
+                using var gradOutputBuffer = GetOrAllocateBuffer(backend, gradOutput);
+                using var inputBuffer = GetOrAllocateBuffer(backend, input);
                 using var gradInputBuffer = AllocateOutputBuffer(backend, input.Length);
 
                 backend.SquashBackward(gradOutputBuffer.Buffer, inputBuffer.Buffer, gradInputBuffer.Buffer, numCapsules, capsuleDim, 1e-8f);
@@ -8721,8 +8790,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 int capsuleDim = permutedInput.Shape._dims[rank - 1];
                 int numCapsules = permutedInput.Length / capsuleDim;
 
-                using var gradOutputBuffer = GetOrAllocateBuffer(backend, permutedGradOutput.GetDataArray());
-                using var inputBuffer = GetOrAllocateBuffer(backend, permutedInput.GetDataArray());
+                using var gradOutputBuffer = GetOrAllocateBuffer(backend, permutedGradOutput);
+                using var inputBuffer = GetOrAllocateBuffer(backend, permutedInput);
                 using var gradInputBuffer = AllocateOutputBuffer(backend, permutedInput.Length);
 
                 backend.SquashBackward(gradOutputBuffer.Buffer, inputBuffer.Buffer, gradInputBuffer.Buffer, numCapsules, capsuleDim, 1e-8f);
@@ -9168,7 +9237,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 for (int i = 0; i < batchDims; i++) batchShape[i] = input.Shape[i];
             }
 
-            using var inputBuffer = GetOrAllocateBuffer(backend, input.GetDataArray());
+            using var inputBuffer = GetOrAllocateBuffer(backend, input);
             using var gammaBuffer = GetOrCacheWeightBuffer(backend, gamma.GetDataArray(), PersistentTensorRole.Weights);
             using var betaBuffer = GetOrCacheWeightBuffer(backend, beta.GetDataArray(), PersistentTensorRole.Biases);
             using var outputBuffer = AllocateOutputBuffer(backend, input.Length);
@@ -9208,10 +9277,10 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             if (batchSize * normalizedSize != input.Length)
                 return base.LayerNormBackward(gradOutput, input, gamma, mean, variance, epsilon, out gradGamma, out gradBeta);
 
-            using var gradOutBuffer = GetOrAllocateBuffer(backend, gradOutput.GetDataArray());
-            using var inputBuffer = GetOrAllocateBuffer(backend, input.GetDataArray());
+            using var gradOutBuffer = GetOrAllocateBuffer(backend, gradOutput);
+            using var inputBuffer = GetOrAllocateBuffer(backend, input);
             using var gammaBuffer = GetOrCacheWeightBuffer(backend, gamma.GetDataArray(), PersistentTensorRole.Weights);
-            using var saveMeanBuffer = GetOrAllocateBuffer(backend, mean.GetDataArray());
+            using var saveMeanBuffer = GetOrAllocateBuffer(backend, mean);
             // The layernorm_backward + layernorm_grad_params kernels use their "saveInvVar" input DIRECTLY as
             // inverse-std 1/sqrt(var+eps). But during training the FORWARD runs the managed base path
             // (IEngine.LayerNorm bails to base while a tape is active), and base's `variance` out-param is TRUE
@@ -9264,7 +9333,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             if (batchSize * normalizedSize != input.Length)
                 return base.RMSNorm(input, gamma, epsilon, out rms);
 
-            using var inputBuffer = GetOrAllocateBuffer(backend, input.GetDataArray());
+            using var inputBuffer = GetOrAllocateBuffer(backend, input);
             using var gammaBuffer = GetOrCacheWeightBuffer(backend, gamma.GetDataArray(), PersistentTensorRole.Weights);
             using var outputBuffer = AllocateOutputBuffer(backend, input.Length);
             using var saveRmsBuffer = AllocateOutputBuffer(backend, batchSize);
@@ -9300,10 +9369,10 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             if (batchSize * normalizedSize != input.Length)
                 return base.RMSNormBackward(gradOutput, input, gamma, rms, epsilon, out gradGamma);
 
-            using var gradOutBuffer = GetOrAllocateBuffer(backend, gradOutput.GetDataArray());
-            using var inputBuffer = GetOrAllocateBuffer(backend, input.GetDataArray());
+            using var gradOutBuffer = GetOrAllocateBuffer(backend, gradOutput);
+            using var inputBuffer = GetOrAllocateBuffer(backend, input);
             using var gammaBuffer = GetOrCacheWeightBuffer(backend, gamma.GetDataArray(), PersistentTensorRole.Weights);
-            using var saveRmsBuffer = GetOrAllocateBuffer(backend, rms.GetDataArray());
+            using var saveRmsBuffer = GetOrAllocateBuffer(backend, rms);
             using var gradInputBuffer = AllocateOutputBuffer(backend, input.Length);
             using var gradGammaBuffer = AllocateOutputBuffer(backend, normalizedSize);
 
@@ -9347,7 +9416,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             if (channels % numGroups != 0)
                 return base.GroupNorm(input, numGroups, gamma, beta, epsilon, out mean, out variance);
 
-            using var inputBuffer = GetOrAllocateBuffer(backend, input.GetDataArray());
+            using var inputBuffer = GetOrAllocateBuffer(backend, input);
             using var gammaBuffer = GetOrCacheWeightBuffer(backend, gamma.GetDataArray(), PersistentTensorRole.Weights);
             using var betaBuffer = GetOrCacheWeightBuffer(backend, beta.GetDataArray(), PersistentTensorRole.Biases);
             using var outputBuffer = AllocateOutputBuffer(backend, input.Length);
@@ -9393,7 +9462,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             for (int i = 2; i < input.Rank; i++)
                 spatialSize *= input.Shape._dims[i];
 
-            using var inputBuffer = GetOrAllocateBuffer(backend, input.GetDataArray());
+            using var inputBuffer = GetOrAllocateBuffer(backend, input);
             using var gammaBuffer = GetOrCacheWeightBuffer(backend, gamma.GetDataArray(), PersistentTensorRole.Weights);
             using var betaBuffer = GetOrCacheWeightBuffer(backend, beta.GetDataArray(), PersistentTensorRole.Biases);
             using var outputBuffer = AllocateOutputBuffer(backend, input.Length);
@@ -10340,7 +10409,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             int size = input.Length;
             ulong seed = (ulong)DateTime.UtcNow.Ticks;
 
-            using var inputBuffer = GetOrAllocateBuffer(backend, input.GetDataArray());
+            using var inputBuffer = GetOrAllocateBuffer(backend, input);
             using var outputBuffer = AllocateOutputBuffer(backend, size);
             using var maskBuffer = AllocateOutputBuffer(backend, size);
 
@@ -10370,8 +10439,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             int size = gradOutput.Length;
 
-            using var gradOutBuffer = GetOrAllocateBuffer(backend, gradOutput.GetDataArray());
-            using var maskBuffer = GetOrAllocateBuffer(backend, mask.GetDataArray());
+            using var gradOutBuffer = GetOrAllocateBuffer(backend, gradOutput);
+            using var maskBuffer = GetOrAllocateBuffer(backend, mask);
             using var gradInputBuffer = AllocateOutputBuffer(backend, size);
 
             backend.DropoutBackward(gradOutBuffer.Buffer, maskBuffer.Buffer, gradInputBuffer.Buffer, size, (float)dropoutRate);
@@ -10421,7 +10490,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             int rows = input.Length / lastDim;
             try
             {
-                using var inputBuf = GetOrAllocateBuffer(backend, input.GetDataArray());
+                using var inputBuf = GetOrAllocateBuffer(backend, input);
                 using var biasBuf = GetOrCacheWeightBuffer(backend, bias.GetDataArray(), PersistentTensorRole.Biases);
                 using var outBuf = AllocateOutputBuffer(backend, input.Length);
                 backend.BiasAdd(inputBuf.Buffer, biasBuf.Buffer, outBuf.Buffer, rows, lastDim);
@@ -10445,7 +10514,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             int cols = lastDim;
             float scale = 1.0f / (1.0f - (float)dropoutRate);
 
-            using var inputBuffer = GetOrAllocateBuffer(backend, input.GetDataArray());
+            using var inputBuffer = GetOrAllocateBuffer(backend, input);
             using var biasBuffer = GetOrCacheWeightBuffer(backend, bias.GetDataArray(), PersistentTensorRole.Biases);
             using var outputBuffer = AllocateOutputBuffer(backend, input.Length);
             using var maskBuffer = AllocateOutputBuffer(backend, input.Length);
@@ -10552,7 +10621,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             int numIndices = indices.Length;
 
-            using var gradOutBuffer = GetOrAllocateBuffer(backend, gradOutput.GetDataArray());
+            using var gradOutBuffer = GetOrAllocateBuffer(backend, gradOutput);
             using var indicesBuffer = backend.AllocateIntBuffer(indices.GetDataArray());
             using var gradEmbeddingBuffer = AllocateOutputBuffer(backend, vocabSize * embeddingDim);
 
@@ -10797,8 +10866,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             int batchSize = predictions.Shape._dims[0];
             int numClasses = predictions.Shape._dims[1];
 
-            using var predBuffer = GetOrAllocateBuffer(backend, predictions.GetDataArray());
-            using var targetBuffer = GetOrAllocateBuffer(backend, targets.GetDataArray());
+            using var predBuffer = GetOrAllocateBuffer(backend, predictions);
+            using var targetBuffer = GetOrAllocateBuffer(backend, targets);
             using var gradInputBuffer = AllocateOutputBuffer(backend, predictions.Length);
 
             backend.CrossEntropyBackward(predBuffer.Buffer, targetBuffer.Buffer, gradInputBuffer.Buffer, batchSize, numClasses);
@@ -10828,8 +10897,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             int size = predictions.Length;
 
-            using var predBuffer = GetOrAllocateBuffer(backend, predictions.GetDataArray());
-            using var targetBuffer = GetOrAllocateBuffer(backend, targets.GetDataArray());
+            using var predBuffer = GetOrAllocateBuffer(backend, predictions);
+            using var targetBuffer = GetOrAllocateBuffer(backend, targets);
             using var gradInputBuffer = AllocateOutputBuffer(backend, size);
 
             backend.MseBackward(predBuffer.Buffer, targetBuffer.Buffer, gradInputBuffer.Buffer, size);
@@ -10859,8 +10928,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             int size = gradOutput.Length;
 
-            using var gradOutBuffer = GetOrAllocateBuffer(backend, gradOutput.GetDataArray());
-            using var inputBuffer = GetOrAllocateBuffer(backend, input.GetDataArray());
+            using var gradOutBuffer = GetOrAllocateBuffer(backend, gradOutput);
+            using var inputBuffer = GetOrAllocateBuffer(backend, input);
             using var gradInputBuffer = AllocateOutputBuffer(backend, size);
 
             backend.ReluBackward(gradOutBuffer.Buffer, inputBuffer.Buffer, gradInputBuffer.Buffer, size);
@@ -10886,8 +10955,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             int size = gradOutput.Length;
 
-            using var gradOutBuffer = GetOrAllocateBuffer(backend, gradOutput.GetDataArray());
-            using var outputBuffer = GetOrAllocateBuffer(backend, output.GetDataArray());
+            using var gradOutBuffer = GetOrAllocateBuffer(backend, gradOutput);
+            using var outputBuffer = GetOrAllocateBuffer(backend, output);
             using var gradInputBuffer = AllocateOutputBuffer(backend, size);
 
             backend.SigmoidBackward(gradOutBuffer.Buffer, outputBuffer.Buffer, gradInputBuffer.Buffer, size);
@@ -10913,8 +10982,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             int size = gradOutput.Length;
 
-            using var gradOutBuffer = GetOrAllocateBuffer(backend, gradOutput.GetDataArray());
-            using var outputBuffer = GetOrAllocateBuffer(backend, output.GetDataArray());
+            using var gradOutBuffer = GetOrAllocateBuffer(backend, gradOutput);
+            using var outputBuffer = GetOrAllocateBuffer(backend, output);
             using var gradInputBuffer = AllocateOutputBuffer(backend, size);
 
             backend.TanhBackward(gradOutBuffer.Buffer, outputBuffer.Buffer, gradInputBuffer.Buffer, size);
@@ -10940,8 +11009,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             int size = gradOutput.Length;
 
-            using var gradOutBuffer = GetOrAllocateBuffer(backend, gradOutput.GetDataArray());
-            using var inputBuffer = GetOrAllocateBuffer(backend, input.GetDataArray());
+            using var gradOutBuffer = GetOrAllocateBuffer(backend, gradOutput);
+            using var inputBuffer = GetOrAllocateBuffer(backend, input);
             using var gradInputBuffer = AllocateOutputBuffer(backend, size);
 
             backend.GeluBackward(gradOutBuffer.Buffer, inputBuffer.Buffer, gradInputBuffer.Buffer, size);
@@ -11001,7 +11070,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             int kernelH = kernel.Shape._dims[2];
             int kernelW = kernel.Shape._dims[3];
 
-            using var gradOutBuffer = GetOrAllocateBuffer(backend, gradOutput.GetDataArray());
+            using var gradOutBuffer = GetOrAllocateBuffer(backend, gradOutput);
             using var kernelBuffer = GetOrCacheWeightBuffer(backend, kernel.GetDataArray(), PersistentTensorRole.Weights);
             using var gradInputBuffer = AllocateOutputBuffer(backend, batch * inChannels * inHeight * inWidth);
 
@@ -11051,8 +11120,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             int kernelH = kernelShape[2];
             int kernelW = kernelShape[3];
 
-            using var inputBuffer = GetOrAllocateBuffer(backend, input.GetDataArray());
-            using var gradOutBuffer = GetOrAllocateBuffer(backend, gradOutput.GetDataArray());
+            using var inputBuffer = GetOrAllocateBuffer(backend, input);
+            using var gradOutBuffer = GetOrAllocateBuffer(backend, gradOutput);
             using var gradKernelBuffer = AllocateOutputBuffer(backend, outChannels * inChannels * kernelH * kernelW);
 
             backend.Conv2DBackwardKernel(inputBuffer.Buffer, gradOutBuffer.Buffer, gradKernelBuffer.Buffer,
@@ -11091,7 +11160,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             int height = input.Shape._dims[2];
             int width = input.Shape._dims[3];
 
-            using var inputBuffer = GetOrAllocateBuffer(backend, input.GetDataArray());
+            using var inputBuffer = GetOrAllocateBuffer(backend, input);
             using var outputBuffer = AllocateOutputBuffer(backend, batch * channels);
 
             backend.GlobalAvgPool2D(inputBuffer.Buffer, outputBuffer.Buffer, batch, channels, height, width);
@@ -11124,7 +11193,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             int height = input.Shape._dims[2];
             int width = input.Shape._dims[3];
 
-            using var inputBuffer = GetOrAllocateBuffer(backend, input.GetDataArray());
+            using var inputBuffer = GetOrAllocateBuffer(backend, input);
             using var outputBuffer = AllocateOutputBuffer(backend, batch * channels);
 
             backend.GlobalMaxPool2D(inputBuffer.Buffer, outputBuffer.Buffer, batch, channels, height, width);
@@ -11157,7 +11226,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             int inHeight = input.Shape._dims[2];
             int inWidth = input.Shape._dims[3];
 
-            using var inputBuffer = GetOrAllocateBuffer(backend, input.GetDataArray());
+            using var inputBuffer = GetOrAllocateBuffer(backend, input);
             using var outputBuffer = AllocateOutputBuffer(backend, batch * channels * outputHeight * outputWidth);
 
             backend.AdaptiveAvgPool2D(inputBuffer.Buffer, outputBuffer.Buffer, batch, channels, inHeight, inWidth, outputHeight, outputWidth);
@@ -11591,8 +11660,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             try
             {
-                using var bufferA = GetOrAllocateBuffer(backend, a.GetDataArray());
-                using var bufferB = GetOrAllocateBuffer(backend, b.GetDataArray());
+                using var bufferA = GetOrAllocateBuffer(backend, a);
+                using var bufferB = GetOrAllocateBuffer(backend, b);
                 using var bufferC = AllocateOutputBuffer(backend, a.Length);
 
                 backend.Multiply(bufferA.Buffer, bufferB.Buffer, bufferC.Buffer, a.Length);
@@ -11616,8 +11685,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 int innerSize = b.Shape._dims[0];
                 int outerSize = a.Length / innerSize;
 
-                using var bufferA = GetOrAllocateBuffer(backend, a.GetDataArray());
-                using var bufferB = GetOrAllocateBuffer(backend, b.GetDataArray());
+                using var bufferA = GetOrAllocateBuffer(backend, a);
+                using var bufferB = GetOrAllocateBuffer(backend, b);
                 using var bufferC = AllocateOutputBuffer(backend, a.Length);
 
                 backend.BroadcastMultiplyLastAxis(bufferA.Buffer, bufferB.Buffer, bufferC.Buffer, outerSize, innerSize);
@@ -11638,7 +11707,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 for (int i = 0; i < outerSize; i++)
                     bFlatData[i] = b.GetDataArray()[i];
 
-                using var bufferA = GetOrAllocateBuffer(backend, a.GetDataArray());
+                using var bufferA = GetOrAllocateBuffer(backend, a);
                 using var bufferB = GetOrAllocateBuffer(backend, bFlatData);
                 using var bufferC = AllocateOutputBuffer(backend, a.Length);
 
@@ -11672,7 +11741,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                     for (int i = 0; i < innerSize; i++)
                         bFlatData[i] = b.GetDataArray()[i];
 
-                    using var bufferA = GetOrAllocateBuffer(backend, a.GetDataArray());
+                    using var bufferA = GetOrAllocateBuffer(backend, a);
                     using var bufferB = GetOrAllocateBuffer(backend, bFlatData);
                     using var bufferC = AllocateOutputBuffer(backend, a.Length);
 
@@ -12333,9 +12402,9 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (!TryGetBackend(out var backend))
             throw new InvalidOperationException("No GPU backend available for SgdMomentumUpdateGpu");
 
-        using var paramBuffer = GetOrAllocateBuffer(backend, param.GetDataArray());
-        using var gradBuffer = GetOrAllocateBuffer(backend, gradient.GetDataArray());
-        using var velocityBuffer = GetOrAllocateBuffer(backend, velocity.GetDataArray());
+        using var paramBuffer = GetOrAllocateBuffer(backend, param);
+        using var gradBuffer = GetOrAllocateBuffer(backend, gradient);
+        using var velocityBuffer = GetOrAllocateBuffer(backend, velocity);
 
         backend.SgdMomentumUpdate(paramBuffer.Buffer, gradBuffer.Buffer, velocityBuffer.Buffer,
             learningRate, momentum, weightDecay, param.Length);
@@ -12366,8 +12435,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
 
         // Upload persistent tensors (using cache if registered)
-        using var centersBuffer = GetOrAllocateBuffer(backend, centers.GetDataArray());
-        using var epsilonsBuffer = GetOrAllocateBuffer(backend, epsilons.GetDataArray());
+        using var centersBuffer = GetOrAllocateBuffer(backend, centers);
+        using var epsilonsBuffer = GetOrAllocateBuffer(backend, epsilons);
 
         var outputBuffer = backend.AllocateBuffer(batch * numCenters);
 
@@ -13140,7 +13209,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         try
         {
             float alphaFloat = ToFloatScalar(alpha);
-            using var bufferA = GetOrAllocateBuffer(backend, tensor.GetDataArray());
+            using var bufferA = GetOrAllocateBuffer(backend, tensor);
             using var bufferB = AllocateOutputBuffer(backend, tensor.Length);
             backend.LeakyRelu(bufferA.Buffer, bufferB.Buffer, alphaFloat, tensor.Length);
             float[] resultFloat = backend.DownloadBuffer(bufferB.Buffer);
@@ -13212,8 +13281,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             float tFloat = ToFloatScalar(t);
             int size = a.Length;
 
-            using var bufferA = GetOrAllocateBuffer(backend, a.GetDataArray());
-            using var bufferB = GetOrAllocateBuffer(backend, b.GetDataArray());
+            using var bufferA = GetOrAllocateBuffer(backend, a);
+            using var bufferB = GetOrAllocateBuffer(backend, b);
             var bufferResult = AllocateOutputBuffer(backend, size);
 
             backend.Lerp(bufferA.Buffer, bufferB.Buffer, bufferResult.Buffer, tFloat, size);
@@ -13239,8 +13308,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             float scaleBFloat = ToFloatScalar(scaleB);
             int size = a.Length;
 
-            using var bufferA = GetOrAllocateBuffer(backend, a.GetDataArray());
-            using var bufferB = GetOrAllocateBuffer(backend, b.GetDataArray());
+            using var bufferA = GetOrAllocateBuffer(backend, a);
+            using var bufferB = GetOrAllocateBuffer(backend, b);
             var bufferResult = AllocateOutputBuffer(backend, size);
 
             backend.AddScaled(bufferA.Buffer, bufferB.Buffer, bufferResult.Buffer, scaleAFloat, scaleBFloat, size);
@@ -14135,7 +14204,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             float minF = ToFloatScalar(min);
             float maxF = ToFloatScalar(max);
-            using var bufferA = GetOrAllocateBuffer(backend, tensor.GetDataArray());
+            using var bufferA = GetOrAllocateBuffer(backend, tensor);
             var bufferOut = AllocateOutputBuffer(backend, tensor.Length);
             backend.Clamp(bufferA.Buffer, bufferOut.Buffer, minF, maxF, tensor.Length);
             var result = FinishGpuOp<T>(backend, bufferOut, tensor.Length);
@@ -14154,9 +14223,9 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
         try
         {
-            using var condBuf = GetOrAllocateBuffer(backend, condition.GetDataArray());
-            using var xBuf = GetOrAllocateBuffer(backend, x.GetDataArray());
-            using var yBuf = GetOrAllocateBuffer(backend, y.GetDataArray());
+            using var condBuf = GetOrAllocateBuffer(backend, condition);
+            using var xBuf = GetOrAllocateBuffer(backend, x);
+            using var yBuf = GetOrAllocateBuffer(backend, y);
             var outBuf = AllocateOutputBuffer(backend, x.Length);
             backend.Where(condBuf.Buffer, xBuf.Buffer, yBuf.Buffer, outBuf.Buffer, x.Length);
             var result = FinishGpuOp<T>(backend, outBuf, x.Length);
@@ -14211,8 +14280,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 throw new ArgumentException(
                     $"TensorMatMul shape mismatch: a.Shape[1]={K} but b.Shape[0]={bLeadingDim}.");
 
-            using var bufA = GetOrAllocateBuffer(backend, a.GetDataArray());
-            using var bufB = GetOrAllocateBuffer(backend, b.GetDataArray());
+            using var bufA = GetOrAllocateBuffer(backend, a);
+            using var bufB = GetOrAllocateBuffer(backend, b);
             var bufOut = AllocateOutputBuffer(backend, M * N);
             backend.Gemm(bufA.Buffer, bufB.Buffer, bufOut.Buffer, M, N, K);
             var result = FinishGpuOp<T>(backend, bufOut, M * N);
@@ -14245,8 +14314,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 throw new ArgumentException(
                     $"TensorMatMulTransposed K mismatch: a's trailing dim {K} != b's trailing dim {b._shape[1]}.");
 
-            using var bufA = GetOrAllocateBuffer(backend, a.GetDataArray());
-            using var bufB = GetOrAllocateBuffer(backend, b.GetDataArray());
+            using var bufA = GetOrAllocateBuffer(backend, a);
+            using var bufB = GetOrAllocateBuffer(backend, b);
             var bufOut = AllocateOutputBuffer(backend, M * N);
             // Backend-native A·Bᵀ: cuBLAS / rocBLAS / MPS / CLBlast use
             // their transB flag; Vulkan/WebGPU dispatch a custom kernel
@@ -14278,8 +14347,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             int M = a.Shape._dims[a.Rank - 2];
             int K = a.Shape._dims[a.Rank - 1];
             int N = b.Shape._dims[b.Rank - 1];
-            using var bufA = GetOrAllocateBuffer(backend, a.GetDataArray());
-            using var bufB = GetOrAllocateBuffer(backend, b.GetDataArray());
+            using var bufA = GetOrAllocateBuffer(backend, a);
+            using var bufB = GetOrAllocateBuffer(backend, b);
             var bufOut = AllocateOutputBuffer(backend, batchSize * M * N);
             backend.BatchedGemm(bufA.Buffer, bufB.Buffer, bufOut.Buffer, M, N, K, batchSize);
             var result = FinishGpuOp<T>(backend, bufOut, batchSize * M * N);
@@ -14315,7 +14384,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             int rows = tensor.Shape._dims[0];
             int cols = tensor.Shape._dims[1];
-            using var bufIn = GetOrAllocateBuffer(backend, tensor.GetDataArray());
+            using var bufIn = GetOrAllocateBuffer(backend, tensor);
             var bufOut = AllocateOutputBuffer(backend, tensor.Length);
             backend.Transpose(bufIn.Buffer, bufOut.Buffer, rows, cols);
             var result = FinishGpuOp<T>(backend, bufOut, tensor.Length);
@@ -14446,7 +14515,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             else
             {
                 // Eager/inference path (unchanged): permute on GPU, download directly into output's array.
-                using var bufIn = GetOrAllocateBuffer(backend, tensor.GetDataArray());
+                using var bufIn = GetOrAllocateBuffer(backend, tensor);
                 var bufOut = AllocateOutputBuffer(backend, tensor.Length);
                 backend.Permute(bufIn.Buffer, bufOut.Buffer, tensor.Shape._dims, axes);
                 var dst = output.GetDataArray();
@@ -14491,9 +14560,9 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             int batch = input.Shape._dims[0];
             int channels = input.Shape._dims[1];
             int spatial = input.Length / (batch * channels);
-            using var bufIn = GetOrAllocateBuffer(backend, input.GetDataArray());
-            using var bufGamma = GetOrAllocateBuffer(backend, gamma.GetDataArray());
-            using var bufBeta = GetOrAllocateBuffer(backend, beta.GetDataArray());
+            using var bufIn = GetOrAllocateBuffer(backend, input);
+            using var bufGamma = GetOrAllocateBuffer(backend, gamma);
+            using var bufBeta = GetOrAllocateBuffer(backend, beta);
             bufOut = AllocateOutputBuffer(backend, input.Length);
             using var bufRunMean = AllocateOutputBuffer(backend, channels);
             using var bufRunVar = AllocateOutputBuffer(backend, channels);
@@ -14539,9 +14608,9 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             int outerSize = input.Shape._dims[0];
             int normSize = input.Length / outerSize;
-            using var bufIn = GetOrAllocateBuffer(backend, input.GetDataArray());
-            using var bufGamma = GetOrAllocateBuffer(backend, gamma.GetDataArray());
-            using var bufBeta = GetOrAllocateBuffer(backend, beta.GetDataArray());
+            using var bufIn = GetOrAllocateBuffer(backend, input);
+            using var bufGamma = GetOrAllocateBuffer(backend, gamma);
+            using var bufBeta = GetOrAllocateBuffer(backend, beta);
             bufOut = AllocateOutputBuffer(backend, input.Length);
             bufMean = AllocateOutputBuffer(backend, outerSize);
             bufVar = AllocateOutputBuffer(backend, outerSize);
@@ -14579,9 +14648,9 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             int batch = input.Shape._dims[0];
             int channels = input.Shape._dims[1];
             int spatial = input.Length / (batch * channels);
-            using var bufIn = GetOrAllocateBuffer(backend, input.GetDataArray());
-            using var bufGamma = GetOrAllocateBuffer(backend, gamma.GetDataArray());
-            using var bufBeta = GetOrAllocateBuffer(backend, beta.GetDataArray());
+            using var bufIn = GetOrAllocateBuffer(backend, input);
+            using var bufGamma = GetOrAllocateBuffer(backend, gamma);
+            using var bufBeta = GetOrAllocateBuffer(backend, beta);
             bufOut = AllocateOutputBuffer(backend, input.Length);
             bufMean = AllocateOutputBuffer(backend, batch * numGroups);
             bufVar = AllocateOutputBuffer(backend, batch * numGroups);
@@ -14619,9 +14688,9 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             int batch = input.Shape._dims[0];
             int channels = input.Shape._dims[1];
             int spatial = input.Length / (batch * channels);
-            using var bufIn = GetOrAllocateBuffer(backend, input.GetDataArray());
-            using var bufGamma = GetOrAllocateBuffer(backend, gamma.GetDataArray());
-            using var bufBeta = GetOrAllocateBuffer(backend, beta.GetDataArray());
+            using var bufIn = GetOrAllocateBuffer(backend, input);
+            using var bufGamma = GetOrAllocateBuffer(backend, gamma);
+            using var bufBeta = GetOrAllocateBuffer(backend, beta);
             bufOut = AllocateOutputBuffer(backend, input.Length);
             bufMean = AllocateOutputBuffer(backend, batch * channels);
             bufVar = AllocateOutputBuffer(backend, batch * channels);
@@ -14657,8 +14726,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             int outerSize = input.Shape._dims[0];
             int normSize = input.Length / outerSize;
-            using var bufIn = GetOrAllocateBuffer(backend, input.GetDataArray());
-            using var bufGamma = GetOrAllocateBuffer(backend, gamma.GetDataArray());
+            using var bufIn = GetOrAllocateBuffer(backend, input);
+            using var bufGamma = GetOrAllocateBuffer(backend, gamma);
             bufOut = AllocateOutputBuffer(backend, input.Length);
             bufRms = AllocateOutputBuffer(backend, outerSize);
             backend.RmsNorm(bufIn.Buffer, bufOut.Buffer, bufGamma.Buffer, bufRms.Buffer,
@@ -14701,8 +14770,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             int outChannels = kernel.Shape._dims[0];
             int kernelW = kernel.Shape._dims[2];
             int outWidth = (inWidth + 2 * padding - dilation * (kernelW - 1) - 1) / stride + 1;
-            using var bufIn = GetOrAllocateBuffer(backend, input.GetDataArray());
-            using var bufK = GetOrAllocateBuffer(backend, kernel.GetDataArray());
+            using var bufIn = GetOrAllocateBuffer(backend, input);
+            using var bufK = GetOrAllocateBuffer(backend, kernel);
             var bufOut = AllocateOutputBuffer(backend, batch * outChannels * outWidth);
             backend.Conv1D(bufIn.Buffer, bufK.Buffer, bufOut.Buffer,
                 batch, inChannels, inWidth, outChannels, outWidth, kernelW, stride, padding, dilation);
@@ -14730,8 +14799,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             int outD = (inD + 2 * padding - dilation * (kD - 1) - 1) / stride + 1;
             int outH = (inH + 2 * padding - dilation * (kH - 1) - 1) / stride + 1;
             int outW = (inW + 2 * padding - dilation * (kW - 1) - 1) / stride + 1;
-            using var bufIn = GetOrAllocateBuffer(backend, input.GetDataArray());
-            using var bufK = GetOrAllocateBuffer(backend, kernel.GetDataArray());
+            using var bufIn = GetOrAllocateBuffer(backend, input);
+            using var bufK = GetOrAllocateBuffer(backend, kernel);
             var bufOut = AllocateOutputBuffer(backend, batch * outChannels * outD * outH * outW);
             backend.Conv3D(bufIn.Buffer, bufK.Buffer, bufOut.Buffer,
                 batch, inChannels, inD, inH, inW,
@@ -14763,8 +14832,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             int kH = kernel.Shape._dims[2], kW = kernel.Shape._dims[3];
             int outH = (inH - 1) * stride[0] - 2 * padding[0] + kH + outputPadding[0];
             int outW = (inW - 1) * stride[1] - 2 * padding[1] + kW + outputPadding[1];
-            using var bufIn = GetOrAllocateBuffer(backend, input.GetDataArray());
-            using var bufK = GetOrAllocateBuffer(backend, kernel.GetDataArray());
+            using var bufIn = GetOrAllocateBuffer(backend, input);
+            using var bufK = GetOrAllocateBuffer(backend, kernel);
             var bufOut = AllocateOutputBuffer(backend, batch * outChannels * outH * outW);
             backend.ConvTranspose2D(bufIn.Buffer, bufK.Buffer, bufOut.Buffer,
                 batch, inChannels, inH, inW, outChannels, outH, outW,
@@ -14805,7 +14874,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             int features = input.Shape._dims[ea];
             int outerSize = input.Length / features;
-            using var bufIn = GetOrAllocateBuffer(backend, input.GetDataArray());
+            using var bufIn = GetOrAllocateBuffer(backend, input);
             var bufOut = AllocateOutputBuffer(backend, input.Length);
             backend.Softmax(bufIn.Buffer, bufOut.Buffer, outerSize, features);
             var result = FinishGpuOp<T>(backend, bufOut, input.Length);
@@ -14842,7 +14911,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             int numIndices = indices.Length;
             int featureSize = source.Rank >= 2 ? source.Length / source.Shape._dims[0] : 1;
-            using var bufSrc = GetOrAllocateBuffer(backend, source.GetDataArray());
+            using var bufSrc = GetOrAllocateBuffer(backend, source);
             using var bufIdx = backend.AllocateIntBuffer(indices.GetDataArray());
             var bufOut = AllocateOutputBuffer(backend, numIndices * featureSize);
             backend.Gather(bufSrc.Buffer, bufIdx, bufOut.Buffer, numIndices, featureSize);
@@ -14879,7 +14948,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             int numIndices = indices.Length;
             int embeddingDim = embeddingTable.Shape._dims[1];
-            using var bufTable = GetOrAllocateBuffer(backend, embeddingTable.GetDataArray());
+            using var bufTable = GetOrAllocateBuffer(backend, embeddingTable);
             using var bufIdx = backend.AllocateIntBuffer(indices.GetDataArray());
             var bufOut = AllocateOutputBuffer(backend, numIndices * embeddingDim);
             backend.Embedding(bufIdx, bufTable.Buffer, bufOut.Buffer, numIndices, embeddingDim);
@@ -14942,8 +15011,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             int batchSize = predictions.Rank >= 2 ? predictions.Shape._dims[0] : 1;
             int numFeatures = predictions.Length / batchSize;
-            using var bufP = GetOrAllocateBuffer(backend, predictions.GetDataArray());
-            using var bufT = GetOrAllocateBuffer(backend, targets.GetDataArray());
+            using var bufP = GetOrAllocateBuffer(backend, predictions);
+            using var bufT = GetOrAllocateBuffer(backend, targets);
             using var bufOut = AllocateOutputBuffer(backend, batchSize);
             backend.L1Loss(bufP.Buffer, bufT.Buffer, bufOut.Buffer, batchSize, numFeatures);
             // Kernel returns per-row means; CpuEngine contract is a single scalar = mean over ALL
@@ -14966,8 +15035,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             int batchSize = predictions.Rank >= 2 ? predictions.Shape._dims[0] : 1;
             int numFeatures = predictions.Length / batchSize;
-            using var bufP = GetOrAllocateBuffer(backend, predictions.GetDataArray());
-            using var bufT = GetOrAllocateBuffer(backend, targets.GetDataArray());
+            using var bufP = GetOrAllocateBuffer(backend, predictions);
+            using var bufT = GetOrAllocateBuffer(backend, targets);
             using var bufOut = AllocateOutputBuffer(backend, batchSize);
             backend.HuberLoss(bufP.Buffer, bufT.Buffer, bufOut.Buffer, batchSize, numFeatures, (float)delta);
             // Reduce per-row means to the single scalar mean over all elements (CpuEngine contract).
@@ -15012,8 +15081,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             int batchSize = logProbs.Shape._dims[0];
             int numClasses = logProbs.Shape._dims[1];
-            using var bufLP = GetOrAllocateBuffer(backend, logProbs.GetDataArray());
-            using var bufT = GetOrAllocateBuffer(backend, targets.GetDataArray());
+            using var bufLP = GetOrAllocateBuffer(backend, logProbs);
+            using var bufT = GetOrAllocateBuffer(backend, targets);
             var bufOut = AllocateOutputBuffer(backend, batchSize);
             backend.NllLoss(bufLP.Buffer, bufT.Buffer, bufOut.Buffer, batchSize, numClasses);
             float[] perBatch = backend.DownloadBuffer(bufOut.Buffer);
@@ -15044,8 +15113,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
         try
         {
-            using var bufI = GetOrAllocateBuffer(backend, input.GetDataArray());
-            using var bufT = GetOrAllocateBuffer(backend, target.GetDataArray());
+            using var bufI = GetOrAllocateBuffer(backend, input);
+            using var bufT = GetOrAllocateBuffer(backend, target);
             var bufOut = AllocateOutputBuffer(backend, input.Length);
             backend.KlDivLoss(bufI.Buffer, bufT.Buffer, bufOut.Buffer, input.Length);
             float[] perElem = backend.DownloadBuffer(bufOut.Buffer);
@@ -15073,7 +15142,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         try
         {
             ulong seed = (ulong)Environment.TickCount;
-            using var bufIn = GetOrAllocateBuffer(backend, input.GetDataArray());
+            using var bufIn = GetOrAllocateBuffer(backend, input);
             var bufOut = AllocateOutputBuffer(backend, input.Length);
             var bufMask = AllocateOutputBuffer(backend, input.Length);
             backend.Dropout(bufIn.Buffer, bufOut.Buffer, bufMask.Buffer, input.Length, (float)dropoutRate, seed, true);
@@ -15098,7 +15167,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             int batch = input.Shape._dims[0], channels = input.Shape._dims[1];
             int inH = input.Shape._dims[2], inW = input.Shape._dims[3];
             int outH = inH * scaleH, outW = inW * scaleW;
-            using var bufIn = GetOrAllocateBuffer(backend, input.GetDataArray());
+            using var bufIn = GetOrAllocateBuffer(backend, input);
             var bufOut = AllocateOutputBuffer(backend, batch * channels * outH * outW);
             backend.NearestNeighborUpsample(bufIn.Buffer, bufOut.Buffer, batch * channels, inH, inW, scaleH);
             var result = FinishGpuOp<T>(backend, bufOut, batch * channels * outH * outW);
@@ -15120,8 +15189,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             int batch = input.Shape._dims[0], channels = input.Shape._dims[1];
             int inH = input.Shape._dims[2], inW = input.Shape._dims[3];
             int outH = grid.Shape._dims[1], outW = grid.Shape._dims[2];
-            using var bufIn = GetOrAllocateBuffer(backend, input.GetDataArray());
-            using var bufGrid = GetOrAllocateBuffer(backend, grid.GetDataArray());
+            using var bufIn = GetOrAllocateBuffer(backend, input);
+            using var bufGrid = GetOrAllocateBuffer(backend, grid);
             var bufOut = AllocateOutputBuffer(backend, batch * channels * outH * outW);
             backend.GridSample(bufIn.Buffer, bufGrid.Buffer, bufOut.Buffer,
                 batch, channels, inH, inW, outH, outW);
@@ -15143,7 +15212,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             int batch = input.Shape._dims[0], channels = input.Shape._dims[1];
             int inH = input.Shape._dims[2], inW = input.Shape._dims[3];
-            using var bufIn = GetOrAllocateBuffer(backend, input.GetDataArray());
+            using var bufIn = GetOrAllocateBuffer(backend, input);
             var bufOut = AllocateOutputBuffer(backend, batch * channels * outputHeight * outputWidth);
             backend.AdaptiveAvgPool2D(bufIn.Buffer, bufOut.Buffer, batch, channels, inH, inW, outputHeight, outputWidth);
             var result = FinishGpuOp<T>(backend, bufOut, batch * channels * outputHeight * outputWidth);
@@ -15202,7 +15271,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         try
         {
             float alphaF = ToFloatScalar(alpha);
-            using var buf = GetOrAllocateBuffer(backend, tensor.GetDataArray());
+            using var buf = GetOrAllocateBuffer(backend, tensor);
             backend.LeakyRelu(buf.Buffer, buf.Buffer, alphaF, tensor.Length);
             float[] result = backend.DownloadBuffer(buf.Buffer);
             var ops = MathHelper.GetNumericOperations<T>();
@@ -15227,8 +15296,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
         try
         {
-            using var bufIn = GetOrAllocateBuffer(backend, tensor.GetDataArray());
-            using var bufAlpha = GetOrAllocateBuffer(backend, alpha.GetDataArray());
+            using var bufIn = GetOrAllocateBuffer(backend, tensor);
+            using var bufAlpha = GetOrAllocateBuffer(backend, alpha);
             var bufOut = AllocateOutputBuffer(backend, tensor.Length);
             backend.PRelu(bufIn.Buffer, bufAlpha.Buffer, bufOut.Buffer, tensor.Length, alpha.Length);
             var result = FinishGpuOp<T>(backend, bufOut, tensor.Length);
@@ -15252,7 +15321,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             float threshF = ToFloatScalar(threshold);
             float valueF = ToFloatScalar(value);
-            using var bufIn = GetOrAllocateBuffer(backend, tensor.GetDataArray());
+            using var bufIn = GetOrAllocateBuffer(backend, tensor);
             var bufOut = AllocateOutputBuffer(backend, tensor.Length);
             backend.Threshold(bufIn.Buffer, bufOut.Buffer, threshF, valueF, tensor.Length);
             var result = FinishGpuOp<T>(backend, bufOut, tensor.Length);
@@ -15287,7 +15356,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             int outH = (inH + 2 * pH - kH) / sH + 1;
             int outW = (inW + 2 * pW - kW) / sW + 1;
             int colSize = batch * channels * kH * kW * outH * outW;
-            using var bufIn = GetOrAllocateBuffer(backend, input.GetDataArray());
+            using var bufIn = GetOrAllocateBuffer(backend, input);
             var bufOut = AllocateOutputBuffer(backend, colSize);
             backend.Unfold(bufIn.Buffer, bufOut.Buffer, batch, channels, inH, inW, kH, kW, sH, sW, pH, pW);
             var result = FinishGpuOp<T>(backend, bufOut, colSize);
@@ -15314,7 +15383,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             int sH = stride[0], sW = stride[1];
             int pH = padding[0], pW = padding[1];
             int totalOut = batch * outC * outH * outW;
-            using var bufIn = GetOrAllocateBuffer(backend, input.GetDataArray());
+            using var bufIn = GetOrAllocateBuffer(backend, input);
             var bufOut = AllocateOutputBuffer(backend, totalOut);
             backend.Fill(bufOut.Buffer, 0f, totalOut);
             backend.Fold(bufIn.Buffer, bufOut.Buffer, batch, outC, outH, outW, kH, kW, sH, sW, pH, pW);
@@ -15577,7 +15646,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         try
         {
             float alphaFloat = ToFloatScalar(alpha);
-            using var bufferA = GetOrAllocateBuffer(backend, tensor.GetDataArray());
+            using var bufferA = GetOrAllocateBuffer(backend, tensor);
             var bufferB = AllocateOutputBuffer(backend, tensor.Length);
             backend.LeakyRelu(bufferA.Buffer, bufferB.Buffer, alphaFloat, tensor.Length);
             var result = FinishGpuOp<T>(backend, bufferB, tensor.Length);
@@ -15628,8 +15697,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             try
             {
                 int outerSize = a.Length / b.Length;
-                using var bufA = GetOrAllocateBuffer(backend, a.GetDataArray());
-                using var bufB = GetOrAllocateBuffer(backend, b.GetDataArray());
+                using var bufA = GetOrAllocateBuffer(backend, a);
+                using var bufB = GetOrAllocateBuffer(backend, b);
                 var bufOut = AllocateOutputBuffer(backend, a.Length);
                 backend.BroadcastAddLast(bufA.Buffer, bufB.Buffer, bufOut.Buffer, outerSize, b.Length);
                 var result = FinishGpuOp<T>(backend, bufOut, a.Length);
@@ -15652,8 +15721,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             try
             {
                 int outerSize = a.Length / b.Length;
-                using var bufA = GetOrAllocateBuffer(backend, a.GetDataArray());
-                using var bufB = GetOrAllocateBuffer(backend, b.GetDataArray());
+                using var bufA = GetOrAllocateBuffer(backend, a);
+                using var bufB = GetOrAllocateBuffer(backend, b);
                 var bufOut = AllocateOutputBuffer(backend, a.Length);
                 backend.BroadcastSubLast(bufA.Buffer, bufB.Buffer, bufOut.Buffer, outerSize, b.Length);
                 var result = FinishGpuOp<T>(backend, bufOut, a.Length);
@@ -15676,8 +15745,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             try
             {
                 int outerSize = a.Length / b.Length;
-                using var bufA = GetOrAllocateBuffer(backend, a.GetDataArray());
-                using var bufB = GetOrAllocateBuffer(backend, b.GetDataArray());
+                using var bufA = GetOrAllocateBuffer(backend, a);
+                using var bufB = GetOrAllocateBuffer(backend, b);
                 var bufOut = AllocateOutputBuffer(backend, a.Length);
                 backend.BroadcastDivLast(bufA.Buffer, bufB.Buffer, bufOut.Buffer, outerSize, b.Length);
                 var result = FinishGpuOp<T>(backend, bufOut, a.Length);
@@ -15757,7 +15826,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             try
             {
-                using var bufIn = GetOrAllocateBuffer(backend, tensor.GetDataArray());
+                using var bufIn = GetOrAllocateBuffer(backend, tensor);
                 var bufOut = AllocateOutputBuffer(backend, tensor.Length);
                 backend.AddScalar(bufIn.Buffer, bufOut.Buffer, Convert.ToSingle(scalar), tensor.Length);
                 var result = FinishGpuOp<T>(backend, bufOut, tensor.Length);
@@ -15775,7 +15844,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             try
             {
-                using var bufIn = GetOrAllocateBuffer(backend, tensor.GetDataArray());
+                using var bufIn = GetOrAllocateBuffer(backend, tensor);
                 var bufOut = AllocateOutputBuffer(backend, tensor.Length);
                 backend.SubScalar(bufIn.Buffer, bufOut.Buffer, Convert.ToSingle(scalar), tensor.Length);
                 var result = FinishGpuOp<T>(backend, bufOut, tensor.Length);
@@ -15864,7 +15933,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             // Generate noise buffer for RReLU
             float lowerF = (float)lower, upperF = (float)upper;
-            using var bufIn = GetOrAllocateBuffer(backend, tensor.GetDataArray());
+            using var bufIn = GetOrAllocateBuffer(backend, tensor);
             var bufNoise = AllocateOutputBuffer(backend, tensor.Length);
             var bufOut = AllocateOutputBuffer(backend, tensor.Length);
             if (training)
@@ -15932,7 +16001,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             for (int i = 0; i < mask.Length; i++)
                 maskFloat[i] = maskData[i] ? 1f : 0f;
 
-            using var bufIn = GetOrAllocateBuffer(backend, tensor.GetDataArray());
+            using var bufIn = GetOrAllocateBuffer(backend, tensor);
             using var bufMask = backend.AllocateBuffer(maskFloat);
             var bufOut = AllocateOutputBuffer(backend, tensor.Length);
             backend.MaskedFillKernel(bufIn.Buffer, bufMask, bufOut.Buffer, Convert.ToSingle(value), tensor.Length);
@@ -15997,7 +16066,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             // For 1x1 output, use GlobalMaxPool2D
             if (outH == 1 && outW == 1)
             {
-                using var bufIn = GetOrAllocateBuffer(backend, input.GetDataArray());
+                using var bufIn = GetOrAllocateBuffer(backend, input);
                 var bufOut = AllocateOutputBuffer(backend, batch * channels);
                 backend.GlobalMaxPool2D(bufIn.Buffer, bufOut.Buffer, batch, channels, inH, inW);
                 var result = FinishGpuOp<T>(backend, bufOut, batch * channels);

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -1780,6 +1780,10 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// prior host-copy when not on GPU / not in a suspended-eviction step / src isn't resident — so CPU + eager
     /// behavior is byte-identical. A deferred materializer keeps host reads of dest correct.
     /// </summary>
+    // Diagnostic: the OpName of the compiled forward action currently executing (set by the generic forward
+    // action in CompiledTrainingPlan), so a "src not resident" log names the PRODUCER op.
+    [System.ThreadStatic] internal static string? s_currentForwardOp;
+
     private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, int> s_aliasDiag = new();
     private static void AliasDiag(string reason)
     {
@@ -1830,7 +1834,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             bool capturing = backend is Engines.DirectGpu.CUDA.CudaBackend cbk && cbk.IsStreamCapturing();
             bool hasBuf = src._gpuBuffer is not null;
             bool verMatch = hasBuf && src._gpuBufferVersion == src.Version;
-            AliasDiag($"skip: src not resident shape=[{string.Join(",", src._shape)}] hasBuf={hasBuf} verMatch={verMatch} bkndMatch={hasBuf && ReferenceEquals(src._gpuBackend, backend)} capturing={capturing}");
+            AliasDiag($"skip: src not resident producerOp={s_currentForwardOp} shape=[{string.Join(",", src._shape)}] hasBuf={hasBuf} capturing={capturing}");
             return false;
         }
 
@@ -2655,6 +2659,95 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             var conv = DirectGpuEngine.FromFloatArray<T>(f);
             System.Array.Copy(conv, (T[])a, System.Math.Min(conv.Length, ((T[])a).Length));
         });
+    }
+
+    // Stable per-LayerNorm mean/variance scratch buffers (keyed by the LN output's backing array), allocated
+    // once so capture/replay don't cuMemAlloc them. The backward reads these (resident) via the state ref.
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<object, (IGpuBuffer mean, IGpuBuffer var)> _lnStatsScratch = new();
+
+    /// <summary>GPU-RESIDENT LayerNorm for the compiled step: normalize into the destination's stable buffer and
+    /// compute mean/var into stable scratch — no fresh AllocateOutputBuffer (which cuMemAllocs → aborts capture →
+    /// falls to host → breaks the residency chain). Returns false to fall back to the eager allocating path.</summary>
+    internal bool TryLayerNormResidentInto<T>(Tensor<T> output, Tensor<T> input, Tensor<T> gamma, Tensor<T> beta, double epsilon, out Tensor<T>? mean, out Tensor<T>? variance)
+    {
+        mean = null; variance = null;
+        if (!EvictionSuspended || Gpu.AutocastScope.IsEnabled || typeof(T) != typeof(float)) return false;
+        if (!TryGetBackend(out var backend) || input.Rank < 2) return false;
+        var arr = output.DataVector.GetBackingArrayUnsafe();
+        if (arr is null) return false;
+        try
+        {
+            // LayerNorm normalizes over the LAST dimension (gamma/beta length); outerSize = all the leading
+            // positions. The legacy GPU path used dims[0] which is only correct for a rank-2 [B*S, D] input —
+            // wrong for the cortex's rank-3 [B, S, D] (it would normalize over S*D and corrupt the result).
+            int normSize = gamma.Length > 0 ? gamma.Length : input.Shape._dims[input.Rank - 1];
+            int outerSize = input.Length / normSize;
+            using var bufIn = GetOrAllocateContiguousInputBuffer(backend, input);
+            using var bufGamma = GetOrCacheWeightBuffer(backend, gamma.GetDataArray(), PersistentTensorRole.Weights);
+            using var bufBeta = GetOrCacheWeightBuffer(backend, beta.GetDataArray(), PersistentTensorRole.Biases);
+            var outBuf = GetOrCreateResidentBuffer(backend, output, input.Length);
+            if (!_lnStatsScratch.TryGetValue(arr, out var stats))
+            {
+                stats = (backend.AllocateBuffer(outerSize), backend.AllocateBuffer(outerSize));
+                _lnStatsScratch[arr] = stats;
+            }
+            backend.LayerNorm(bufIn.Buffer, outBuf, bufGamma.Buffer, bufBeta.Buffer, stats.mean, stats.var, outerSize, normSize, (float)epsilon);
+            BindResidentBuffer(output, outBuf, backend);
+            var meanT = new Tensor<T>(new T[outerSize], new[] { outerSize });
+            var varT = new Tensor<T>(new T[outerSize], new[] { outerSize });
+            BindResidentBuffer(meanT, stats.mean, backend);
+            BindResidentBuffer(varT, stats.var, backend);
+            mean = meanT; variance = varT;
+            return true;
+        }
+        catch (Exception lex) { AliasDiag($"LN-resident FELLBACK in=[{string.Join(",", input._shape)}] inContig={input.IsContiguous}: {lex.GetType().Name}: {lex.Message}"); return false; }
+    }
+
+    private static bool IsTrailingBroadcast(int[] fullShape, int[] biasShape)
+    {
+        // Strip leading 1s from the bias (numpy/torch broadcast: leading singleton dims broadcast over the
+        // full tensor's leading dims, e.g. positional [1,S,D] over [B,S,D]). The remaining bias dims must match
+        // the full tensor's trailing dims exactly — then bias-flattened is the per-leading-row vector BiasAdd wants.
+        int bstart = 0;
+        while (bstart < biasShape.Length && biasShape[bstart] == 1) bstart++;
+        int effLen = biasShape.Length - bstart;
+        if (effLen > fullShape.Length) return false;
+        int off = fullShape.Length - effLen;
+        for (int i = 0; i < effLen; i++)
+            if (biasShape[bstart + i] != fullShape[off + i]) return false;
+        return true;
+    }
+
+    /// <summary>GPU-RESIDENT broadcast-add for the compiled step (the common trailing-broadcast case, e.g. the
+    /// positional-embedding add [B,S,D] + [S,D], or a bias [D]): maps to backend.BiasAdd(full[M,N] + bias[N])
+    /// into the destination's stable buffer — no fresh alloc / no host fallback that breaks CUDA-graph capture.</summary>
+    internal bool TryBroadcastAddResidentInto<T>(Tensor<T> output, Tensor<T> a, Tensor<T> b)
+    {
+        if (!EvictionSuspended || Gpu.AutocastScope.IsEnabled || typeof(T) != typeof(float)) return false;
+        if (!TryGetBackend(out var backend)) return false;
+        Tensor<T> full, bias;
+        if (a.Length == output.Length && b.Length > 0 && b.Length < a.Length) { full = a; bias = b; }
+        else if (b.Length == output.Length && a.Length > 0 && a.Length < b.Length) { full = b; bias = a; }
+        else { AliasDiag($"BA-skip operands a=[{string.Join(",", a._shape)}] b=[{string.Join(",", b._shape)}] out=[{string.Join(",", output._shape)}]"); return false; }
+        if (full.Length % bias.Length != 0 || !IsTrailingBroadcast(full._shape, bias._shape))
+        { AliasDiag($"BA-skip not-trailing full=[{string.Join(",", full._shape)}] bias=[{string.Join(",", bias._shape)}]"); return false; }
+        if (!full.IsContiguous || !bias.IsContiguous) { AliasDiag($"BA-skip noncontig full={full.IsContiguous} bias={bias.IsContiguous}"); return false; }
+        int N = bias.Length;
+        int M = full.Length / N;
+        try
+        {
+            using var bufFull = GetOrAllocateContiguousInputBuffer(backend, full);
+            // The broadcast operand (positional embedding / bias vector) is a stable PARAMETER, not an
+            // activation — resolve it through the PERSISTENT weight cache (uploaded once, kept fresh by the
+            // optimizer) so capture/replay don't re-upload it (the transient GetOrAllocateBuffer path would
+            // cuMemcpyHtoD every step → aborts the CUDA-graph capture).
+            using var bufBias = GetOrCacheWeightBuffer(backend, bias.GetDataArray(), PersistentTensorRole.Biases);
+            var outBuf = GetOrCreateResidentBuffer(backend, output, full.Length);
+            backend.BiasAdd(bufFull.Buffer, bufBias.Buffer, outBuf, M, N);
+            BindResidentBuffer(output, outBuf, backend);
+            return true;
+        }
+        catch (Exception bex) { AliasDiag($"BA-resident FELLBACK full=[{string.Join(",", full._shape)}] bias=[{string.Join(",", bias._shape)}]: {bex.GetType().Name}: {bex.Message}"); return false; }
     }
 
     private bool TryRunBinaryInto<T>(

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -2787,11 +2787,20 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if ((long)numIndices * embeddingDim != output.Length) return false;
         try
         {
-            using var idxBuf = GetOrAllocateContiguousInputBuffer(backend, floatIndices);            // resident step input
-            using var tableBuf = GetOrCacheWeightBuffer(backend, embeddings.GetDataArray(), PersistentTensorRole.Embeddings);
-            var outBuf = GetOrCreateResidentBuffer(backend, output, numIndices * embeddingDim);
-            backend.Embedding(idxBuf.Buffer, tableBuf.Buffer, outBuf, numIndices, embeddingDim);
-            BindResidentBuffer(output, outBuf, backend);
+            var tableBuf = ResolveResidentEmbeddingTable(backend, embeddings);
+            if (tableBuf is null) return false;
+            var outBuf = output.TryGetGpuBuffer() ?? GetOrCreateResidentBuffer(backend, output, numIndices * embeddingDim);
+            // Indices via the EXTERNALLY-MANAGED stable buffer (mirrors TryEmbeddingGatherGpu): register the refresh
+            // so the plan re-uploads fresh indices before each captured replay; upload inline only on the eager
+            // (non-managed) pass. The index upload (the only HtoD) thus never happens INSIDE the capture (= the 906).
+            var capIdx = floatIndices; var capN = numIndices;
+            RegisterEmbIndexRefresh(() => UploadEmbeddingIndices(capIdx, capN));
+            if (!EmbeddingIndexExternallyManaged) UploadEmbeddingIndices(floatIndices, numIndices);
+            if (_cachedEmbIndexBuffer is null) return false;
+            backend.Embedding(_cachedEmbIndexBuffer, tableBuf, outBuf, numIndices, embeddingDim);
+            output._gpuBuffer = outBuf; output._gpuBackend = backend; output._gpuBufferVersion = output.Version;
+            var oArr = output.DataVector.GetBackingArrayUnsafe();
+            if (oArr is not null && s_currentForwardOp is not null) s_producerOf[oArr] = s_currentForwardOp;
             return true;
         }
         catch (Exception eex) { AliasDiag($"EmbFloat-resident FELLBACK n={numIndices} dim={embeddingDim}: {eex.GetType().Name}: {eex.Message}"); return false; }

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -817,7 +817,11 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // the GPU pointer and force a re-upload.
         if (tensor._gpuBuffer is not null && ReferenceEquals(tensor._gpuBackend, backend))
         {
-            if (tensor._gpuBufferVersion == tensor.Version && IsCachedGpuBufferLive(tensor, backend))
+            // During a compiled step (eviction suspended) the activation buffers are pinned/stable, so _gpuBuffer
+            // is the LIVE data regardless of the host Version snapshot — accept it. Clearing it on a version
+            // mismatch (the path below) would orphan a deferred materializer registered by BindResidentBuffer →
+            // a later host read fires it on a recycled buffer = #226 "buffer released before materialization".
+            if (EvictionSuspended || (tensor._gpuBufferVersion == tensor.Version && IsCachedGpuBufferLive(tensor, backend)))
                 return new OwnedBuffer(tensor._gpuBuffer, ownsBuffer: false);
 
             // Stale snapshot — also clear any matching activation-cache entry so
@@ -2705,6 +2709,55 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             return true;
         }
         catch (Exception lex) { AliasDiag($"LN-resident FELLBACK in=[{string.Join(",", input._shape)}] inContig={input.IsContiguous}: {lex.GetType().Name}: {lex.Message}"); return false; }
+    }
+
+    /// <summary>GPU-RESIDENT 2-D / ND×2-D matmul for the compiled step (e.g. attention out-proj / LM-head /
+    /// any TensorMatMul against a 2-D weight): collapse A's leading dims into M and run backend.Gemm (C=A@B)
+    /// into the destination's stable buffer — no host TensorMatMulFloatInto (which materializes inputs → a DtoH
+    /// download that's a non-capturable CUDA-900 inside the graph capture). Returns false to fall back.</summary>
+    internal bool TryMatMulResidentInto<T>(Tensor<T> output, Tensor<T> a, Tensor<T> b)
+    {
+        if (!EvictionSuspended || Gpu.AutocastScope.IsEnabled || typeof(T) != typeof(float)) return false;
+        if (!TryGetBackend(out var backend)) return false;
+        if (a.Rank < 2 || b.Rank != 2 || !a.IsContiguous || !b.IsContiguous) return false;
+        int K = b.Shape._dims[0];
+        int N = b.Shape._dims[1];
+        if (a.Shape._dims[a.Rank - 1] != K) return false;
+        int M = a.Length / K;
+        if ((long)M * N != output.Length) return false;
+        try
+        {
+            using var bufA = GetResidentOrPersistentInputBuffer(backend, a);
+            using var bufB = GetResidentOrPersistentInputBuffer(backend, b);
+            var outBuf = GetOrCreateResidentBuffer(backend, output, M * N);
+            backend.Gemm(bufA.Buffer, bufB.Buffer, outBuf, M, N, K, 1.0f, 0.0f);
+            BindResidentBuffer(output, outBuf, backend);
+            return true;
+        }
+        catch (Exception mex) { AliasDiag($"MM-resident FELLBACK a=[{string.Join(",", a._shape)}] b=[{string.Join(",", b._shape)}]: {mex.GetType().Name}: {mex.Message}"); return false; }
+    }
+
+    /// <summary>GPU-RESIDENT slice-along-axis for the compiled step (e.g. the LM-head last-token select
+    /// [B,S,D]→[B,D]): backend.SliceAxis into the destination's stable buffer — no host TensorSliceAxis that
+    /// materializes the input (DtoH download = non-capturable CUDA-900). Returns false to fall back.</summary>
+    internal bool TrySliceAxisResidentInto<T>(Tensor<T> output, Tensor<T> input, int axis, int index)
+    {
+        if (!EvictionSuspended || Gpu.AutocastScope.IsEnabled || typeof(T) != typeof(float)) return false;
+        if (!TryGetBackend(out var backend) || !input.IsContiguous) return false;
+        if (axis < 0 || axis >= input.Rank) return false;
+        int outerSize = 1; for (int i = 0; i < axis; i++) outerSize *= input.Shape._dims[i];
+        int axisSize = input.Shape._dims[axis];
+        int stride = 1; for (int i = axis + 1; i < input.Rank; i++) stride *= input.Shape._dims[i];
+        if (index < 0 || index >= axisSize || (long)outerSize * stride != output.Length) return false;
+        try
+        {
+            using var bufIn = GetResidentOrPersistentInputBuffer(backend, input);
+            var outBuf = GetOrCreateResidentBuffer(backend, output, outerSize * stride);
+            backend.SliceAxis(bufIn.Buffer, outBuf, outerSize, axisSize, stride, index);
+            BindResidentBuffer(output, outBuf, backend);
+            return true;
+        }
+        catch (Exception sex) { AliasDiag($"Slice-resident FELLBACK in=[{string.Join(",", input._shape)}] axis={axis} idx={index}: {sex.GetType().Name}: {sex.Message}"); return false; }
     }
 
     private static bool IsTrailingBroadcast(int[] fullShape, int[] biasShape)

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -10567,8 +10567,31 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// The embedding table is read from its LIVE GPU buffer (updated in place by the GPU optimizer), so the
     /// gather sees the current trained embeddings; only the small index vector is uploaded per step.
     /// </summary>
-    private IGpuBuffer? _cachedEmbIndexBuffer;   // stable per-step embedding-index buffer (avoids per-step cuMemAlloc)
+    private IGpuBuffer? _cachedEmbIndexBuffer;   // stable embedding-index buffer (single alloc; refreshed in place)
     private int _cachedEmbIndexCapacity;
+
+    /// <summary>When true, the embedding index buffer is refreshed EXTERNALLY (by the compiled plan, OUTSIDE any
+    /// graph capture) via <see cref="RefreshGraphEmbeddingIndices"/>, so the captured gather kernel reads a stable
+    /// device buffer with NO host upload inside the capture (which would be CUDA 906). The eager/non-graph path
+    /// leaves this false and uploads inline.</summary>
+    internal bool EmbeddingIndexExternallyManaged;
+
+    /// <summary>Upload the given token indices into the stable embedding-index buffer (host→device, OUTSIDE any
+    /// capture). The compiled plan calls this before each graph launch so the captured gather reads THIS step's
+    /// indices. The buffer keeps a STABLE pointer across launches (allocated once), so the captured kernel that
+    /// baked that pointer stays valid.</summary>
+    internal void RefreshGraphEmbeddingIndices(Tensor<int> indices)
+    {
+        if (!TryGetBackend(out var backend)) return;
+        int n = indices.Length;
+        if (_cachedEmbIndexBuffer is null || _cachedEmbIndexCapacity < n)
+        {
+            _cachedEmbIndexBuffer?.Dispose();
+            _cachedEmbIndexBuffer = backend.AllocateIntBuffer(n);
+            _cachedEmbIndexCapacity = n;
+        }
+        backend.UploadIntBufferInPlace(indices.GetDataArray(), _cachedEmbIndexBuffer);
+    }
 
     internal bool TryEmbeddingLookupGpuInto<T>(Tensor<T> embeddingTable, Tensor<int> indices, Tensor<T> output)
     {
@@ -10579,16 +10602,20 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int numIndices = indices.Length;
         int embeddingDim = embeddingTable.Shape._dims[^1];
         if ((long)numIndices * embeddingDim > outBuf.Size) return false;
-        // Reuse a STABLE index buffer across steps. A per-step AllocateIntBuffer would cuMemAlloc — which is
-        // SYNCHRONOUS — between graph launches, serializing the step and collapsing GPU util. Allocate once,
-        // then only upload the (small) index vector in place each step so the eager-prefix stays async.
-        if (_cachedEmbIndexBuffer is null || _cachedEmbIndexCapacity < numIndices)
+        if (!EmbeddingIndexExternallyManaged)
         {
-            _cachedEmbIndexBuffer?.Dispose();
-            _cachedEmbIndexBuffer = backend.AllocateIntBuffer(numIndices);
-            _cachedEmbIndexCapacity = numIndices;
+            // Eager / non-graph path: refresh the stable index buffer inline (reuse it to avoid per-step cuMemAlloc).
+            if (_cachedEmbIndexBuffer is null || _cachedEmbIndexCapacity < numIndices)
+            {
+                _cachedEmbIndexBuffer?.Dispose();
+                _cachedEmbIndexBuffer = backend.AllocateIntBuffer(numIndices);
+                _cachedEmbIndexCapacity = numIndices;
+            }
+            backend.UploadIntBufferInPlace(indices.GetDataArray(), _cachedEmbIndexBuffer);
         }
-        backend.UploadIntBufferInPlace(indices.GetDataArray(), _cachedEmbIndexBuffer);
+        // Managed path: RefreshGraphEmbeddingIndices already uploaded THIS step's indices OUTSIDE capture, so this
+        // is a pure GPU gather kernel over stable device buffers — safe to RECORD into a CUDA graph and replay.
+        if (_cachedEmbIndexBuffer is null) return false;
         backend.Embedding(_cachedEmbIndexBuffer, tableBuf, outBuf, numIndices, embeddingDim);
         return true;
     }

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -1809,10 +1809,14 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (ReferenceEquals(src, dest)) return true;            // in-place op already resident; nothing to copy
         if (!TryGetBackend(out var backend)) { AliasDiag("skip: no backend"); return false; }
 
-        // Resolve src's resident GPU buffer WITHOUT triggering an upload/download.
+        // Resolve src's resident GPU buffer WITHOUT triggering an upload/download. We accept src._gpuBuffer on
+        // backend match alone (no version / IsCachedGpuBufferLive gate) — eviction is suspended for the whole
+        // compiled step so the buffer is guaranteed live, and an ALIASED buffer (a prior CopyResultInto borrow,
+        // or a reshape/permute that shares a base buffer) is NOT in the activation cache under this tensor's key,
+        // so the stricter gate would wrongly decline and force a host-copy that fires a deferred download = CUDA
+        // 900 inside the capture. This matches GetOrAllocateContiguousInputBuffer's resolution.
         IGpuBuffer? srcBuf = null;
-        if (src._gpuBuffer is not null && ReferenceEquals(src._gpuBackend, backend)
-            && src._gpuBufferVersion == src.Version && IsCachedGpuBufferLive(src, backend))
+        if (src._gpuBuffer is not null && ReferenceEquals(src._gpuBackend, backend))
         {
             srcBuf = src._gpuBuffer;
         }
@@ -2750,6 +2754,30 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         catch (Exception bex) { AliasDiag($"BA-resident FELLBACK full=[{string.Join(",", full._shape)}] bias=[{string.Join(",", bias._shape)}]: {bex.GetType().Name}: {bex.Message}"); return false; }
     }
 
+    // Resolve a compiled-step binary/scalar INPUT to a resident GPU buffer. A resident activation (produced by a
+    // prior forward op) is found via _gpuBuffer / the persistent / activation caches — no upload. A non-resident
+    // input during a compiled step is a STABLE parameter/constant (operand never on the forward chain, e.g. a
+    // learned scale or a recording-time constant); route it through the PERSISTENT weight cache so it's uploaded
+    // ONCE rather than every step (a per-step cuMemcpyHtoD inside a stream capture = CUDA 900 → invalidates the
+    // whole graph). Falls back to the transient path if it has no backing array.
+    private OwnedBuffer GetResidentOrPersistentInputBuffer<T>(IDirectGpuBackend backend, Tensor<T> t)
+    {
+        if (t._gpuBuffer is not null && ReferenceEquals(t._gpuBackend, backend))
+            return new OwnedBuffer(t._gpuBuffer, ownsBuffer: false);
+        var arr = t.DataVector.GetBackingArrayUnsafe();
+        if (arr is not null)
+        {
+            var cached = TryGetCachedBuffer(arr);
+            if (cached != null) return new OwnedBuffer(cached, ownsBuffer: false);
+            lock (_activationCacheLock)
+                if (_activationCache.TryGetValue(arr, out var e) && ReferenceEquals(e.Backend, backend) && !e.IsFp16)
+                    return new OwnedBuffer(e.Buffer, ownsBuffer: false);
+            if (t.IsContiguous)
+                return GetOrCacheWeightBuffer(backend, t.GetDataArray(), PersistentTensorRole.Weights);
+        }
+        return GetOrAllocateContiguousInputBuffer(backend, t);
+    }
+
     private bool TryRunBinaryInto<T>(
         Tensor<T> destination,
         Tensor<T> left,
@@ -2769,8 +2797,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             try
             {
-                using var bA = GetOrAllocateContiguousInputBuffer(backend, left);
-                using var bB = GetOrAllocateContiguousInputBuffer(backend, right);
+                using var bA = GetResidentOrPersistentInputBuffer(backend, left);
+                using var bB = GetResidentOrPersistentInputBuffer(backend, right);
                 var destBuf = GetOrCreateResidentBuffer(backend, destination, left.Length);
                 op(backend, bA.Buffer, bB.Buffer, destBuf, left.Length);
                 BindResidentBuffer(destination, destBuf, backend);
@@ -2852,7 +2880,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             try
             {
-                using var bA = GetOrAllocateContiguousInputBuffer(backend, input);
+                using var bA = GetResidentOrPersistentInputBuffer(backend, input);
                 var destBuf = GetOrCreateResidentBuffer(backend, destination, input.Length);
                 op(backend, bA.Buffer, destBuf, ToFloatScalar(scalar), input.Length);
                 BindResidentBuffer(destination, destBuf, backend);

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -1073,8 +1073,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // buffer to UploadTensorRaw callers.
         if (tensor._gpuBuffer is not null && ReferenceEquals(tensor._gpuBackend, backend))
         {
-            if (tensor._gpuBufferVersion == tensor.Version && IsCachedGpuBufferLive(tensor, backend))
-                return new OwnedBuffer(tensor._gpuBuffer, ownsBuffer: false);
+            if (EvictionSuspended || (tensor._gpuBufferVersion == tensor.Version && IsCachedGpuBufferLive(tensor, backend)))
+                return new OwnedBuffer(tensor._gpuBuffer, ownsBuffer: false);   // compiled step: buffers pinned, don't orphan aliases
 
             var staleArray = tensor.DataVector.GetBackingArrayUnsafe();
             if (staleArray is not null)

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -1843,14 +1843,33 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         else
         {
             var srcArr = src.DataVector.GetBackingArrayUnsafe();
-            lock (_activationCacheLock)
+            // Persistent weight cache first — a reshape/view of a PARAMETER (e.g. positional embedding) has the
+            // param resident in _persistentBufferCache (uploaded once by the optimizer / an earlier op) but NOT in
+            // the activation cache; without this the alias declines and host-copies, dropping the param's reshape
+            // off the residency chain.
+            if (srcArr is not null) { var pc = TryGetCachedBuffer(srcArr); if (pc != null) srcBuf = pc; }
+            if (srcBuf is null)
+                lock (_activationCacheLock)
+                {
+                    if (srcArr is not null && _activationCache.TryGetValue(srcArr, out var e1)
+                        && ReferenceEquals(e1.Backend, backend) && !e1.IsFp16)
+                        srcBuf = e1.Buffer;
+                    else if (_activationCache.TryGetValue(src.DataVector, out var e2)
+                        && ReferenceEquals(e2.Backend, backend) && !e2.IsFp16)
+                        srcBuf = e2.Buffer;
+                }
+        }
+        // Last resort: a non-resident CONTIGUOUS src with a real host backing array and NO pending deferred
+        // download is a stable host CONSTANT/parameter (e.g. a sinusoidal positional encoding, or a param not yet
+        // touched by a GPU op) — upload it ONCE to the persistent cache and alias to that. Guard on no-pending so we
+        // never fire a materializer (a DtoH that 900s) for a real activation that merely hasn't been bound yet.
+        if (srcBuf is null)
+        {
+            var cArr = src.DataVector.GetBackingArrayUnsafe();
+            if (cArr is not null && src.IsContiguous && !Helpers.DeferredArrayMaterializer.IsPending(cArr))
             {
-                if (srcArr is not null && _activationCache.TryGetValue(srcArr, out var e1)
-                    && ReferenceEquals(e1.Backend, backend) && !e1.IsFp16)
-                    srcBuf = e1.Buffer;
-                else if (_activationCache.TryGetValue(src.DataVector, out var e2)
-                    && ReferenceEquals(e2.Backend, backend) && !e2.IsFp16)
-                    srcBuf = e2.Buffer;
+                try { srcBuf = GetOrCacheWeightBuffer(backend, src.GetDataArray(), PersistentTensorRole.Weights).Buffer; }
+                catch { srcBuf = null; }
             }
         }
         if (srcBuf is null)

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -1789,6 +1789,17 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     [System.ThreadStatic] internal static string? s_currentForwardOp;
 
     private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, int> s_aliasDiag = new();
+    // Diagnostic: maps a (compiled-plan output) backing array → the op that produced it, so a "src not resident"
+    // log names the actual PRODUCER (not the consuming op). Tagged in CopyResultInto.
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<object, string> s_producerOf = new();
+    /// <summary>Tag a forward-action's OUTPUT with the producing op name (diagnostics), covering ops that write
+    /// output directly (no CopyResultInto/BindResidentBuffer). Called by the generic forward action after exec.</summary>
+    internal static void TagProducer<T>(Tensor<T> output, string? op)
+    {
+        if (op is null || s_currentForwardOp is null) return;
+        var arr = output.DataVector.GetBackingArrayUnsafe();
+        if (arr is not null) s_producerOf[arr] = op;
+    }
     private static void AliasDiag(string reason)
     {
         if (System.Environment.GetEnvironmentVariable("AIDOTNET_GRAPH_CAPTURE_DEBUG") != "1") return;
@@ -1799,6 +1810,11 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     internal static void CopyResultInto<T>(IEngine eng, Tensor<T> src, Tensor<T> dest)
     {
+        if (s_currentForwardOp is not null)
+        {
+            var dArr = dest.DataVector.GetBackingArrayUnsafe();
+            if (dArr is not null) s_producerOf[dArr] = s_currentForwardOp;
+        }
         if (eng is DirectGpuTensorEngine gpu && gpu.TryAliasResidentOutput(src, dest))
         { AliasDiag("OK aliased"); return; }
         AliasDiag(eng is DirectGpuTensorEngine ? "FELLBACK host-copy" : "not-gpu-engine");
@@ -1842,7 +1858,9 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             bool capturing = backend is Engines.DirectGpu.CUDA.CudaBackend cbk && cbk.IsStreamCapturing();
             bool hasBuf = src._gpuBuffer is not null;
             bool verMatch = hasBuf && src._gpuBufferVersion == src.Version;
-            AliasDiag($"skip: src not resident producerOp={s_currentForwardOp} shape=[{string.Join(",", src._shape)}] hasBuf={hasBuf} capturing={capturing}");
+            var srcArr2 = src.DataVector.GetBackingArrayUnsafe();
+            string realProducer = (srcArr2 is not null && s_producerOf.TryGetValue(srcArr2, out var rp)) ? rp : "<untagged/host>";
+            AliasDiag($"skip: src not resident PRODUCER={realProducer} consumer={s_currentForwardOp} shape=[{string.Join(",", src._shape)}] hasBuf={hasBuf} capturing={capturing}");
             return false;
         }
 
@@ -2660,6 +2678,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         t._gpuBuffer = buf; t._gpuBackend = backend; t._gpuBufferVersion = t.Version;
         var arr = t.DataVector.GetBackingArrayUnsafe();
         if (arr is null) return;
+        if (s_currentForwardOp is not null) s_producerOf[arr] = s_currentForwardOp;
         var capBuf = buf; var capBackend = backend;
         Helpers.DeferredArrayMaterializer.Register(arr, a =>
         {
@@ -2735,6 +2754,28 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             return true;
         }
         catch (Exception mex) { AliasDiag($"MM-resident FELLBACK a=[{string.Join(",", a._shape)}] b=[{string.Join(",", b._shape)}]: {mex.GetType().Name}: {mex.Message}"); return false; }
+    }
+
+    /// <summary>GPU-RESIDENT embedding lookup from FLOAT indices for the compiled step (the cortex's actual
+    /// embedding op): backend.Embedding (the kernel casts float→int) into the destination's stable buffer, with
+    /// the table from the PERSISTENT weight cache and the indices from the resident input buffer — no host gather
+    /// (3× GetDataArray = DtoH downloads = non-capturable CUDA-900 that invalidates the whole graph capture).
+    /// This is the SOURCE of the forward residency chain; without it every downstream op re-uploads.</summary>
+    internal bool TryEmbeddingFromFloatIndicesResidentInto<T>(Tensor<T> output, Tensor<T> embeddings, Tensor<T> floatIndices, int numIndices, int embeddingDim)
+    {
+        if (!EvictionSuspended || Gpu.AutocastScope.IsEnabled || typeof(T) != typeof(float)) return false;
+        if (!TryGetBackend(out var backend) || !embeddings.IsContiguous || !floatIndices.IsContiguous) return false;
+        if ((long)numIndices * embeddingDim != output.Length) return false;
+        try
+        {
+            using var idxBuf = GetOrAllocateContiguousInputBuffer(backend, floatIndices);            // resident step input
+            using var tableBuf = GetOrCacheWeightBuffer(backend, embeddings.GetDataArray(), PersistentTensorRole.Embeddings);
+            var outBuf = GetOrCreateResidentBuffer(backend, output, numIndices * embeddingDim);
+            backend.Embedding(idxBuf.Buffer, tableBuf.Buffer, outBuf, numIndices, embeddingDim);
+            BindResidentBuffer(output, outBuf, backend);
+            return true;
+        }
+        catch (Exception eex) { AliasDiag($"EmbFloat-resident FELLBACK n={numIndices} dim={embeddingDim}: {eex.GetType().Name}: {eex.Message}"); return false; }
     }
 
     /// <summary>GPU-RESIDENT slice-along-axis for the compiled step (e.g. the LM-head last-token select

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -10715,6 +10715,13 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (!EmbeddingIndexExternallyManaged) UploadEmbeddingIndices(indices, n);   // eager: refresh inline
         if (_cachedEmbIndexBuffer is null) return false;
         backend.Embedding(_cachedEmbIndexBuffer, tableBuf, outBuf, n, embeddingDim);
+        // Leave the gathered output GPU-resident + version-current so EVERY downstream op (and the
+        // CopyResultInto residency alias) resolves it via the _gpuBuffer fast path instead of re-uploading its
+        // stale host data — this is the SOURCE of the forward residency chain that keeps the whole step
+        // on-device for CUDA-graph capture. Without it, the first consumer re-uploads and the chain collapses.
+        output._gpuBuffer = outBuf;
+        output._gpuBackend = backend;
+        output._gpuBufferVersion = output.Version;
         return true;
     }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -10567,6 +10567,9 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// The embedding table is read from its LIVE GPU buffer (updated in place by the GPU optimizer), so the
     /// gather sees the current trained embeddings; only the small index vector is uploaded per step.
     /// </summary>
+    private IGpuBuffer? _cachedEmbIndexBuffer;   // stable per-step embedding-index buffer (avoids per-step cuMemAlloc)
+    private int _cachedEmbIndexCapacity;
+
     internal bool TryEmbeddingLookupGpuInto<T>(Tensor<T> embeddingTable, Tensor<int> indices, Tensor<T> output)
     {
         if (!TryGetBackend(out var backend)) return false;
@@ -10576,8 +10579,17 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int numIndices = indices.Length;
         int embeddingDim = embeddingTable.Shape._dims[^1];
         if ((long)numIndices * embeddingDim > outBuf.Size) return false;
-        using var idxBuf = backend.AllocateIntBuffer(indices.GetDataArray());
-        backend.Embedding(idxBuf, tableBuf, outBuf, numIndices, embeddingDim);
+        // Reuse a STABLE index buffer across steps. A per-step AllocateIntBuffer would cuMemAlloc — which is
+        // SYNCHRONOUS — between graph launches, serializing the step and collapsing GPU util. Allocate once,
+        // then only upload the (small) index vector in place each step so the eager-prefix stays async.
+        if (_cachedEmbIndexBuffer is null || _cachedEmbIndexCapacity < numIndices)
+        {
+            _cachedEmbIndexBuffer?.Dispose();
+            _cachedEmbIndexBuffer = backend.AllocateIntBuffer(numIndices);
+            _cachedEmbIndexCapacity = numIndices;
+        }
+        backend.UploadIntBufferInPlace(indices.GetDataArray(), _cachedEmbIndexBuffer);
+        backend.Embedding(_cachedEmbIndexBuffer, tableBuf, outBuf, numIndices, embeddingDim);
         return true;
     }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -2600,6 +2600,13 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (destination.IsSparse || !destination.IsContiguous || destination.Length < elementCount)
             return false;
 
+        // The destination is about to be OVERWRITTEN. Drop any pending deferred GPU download on its backing array
+        // FIRST: firing it here is wasteful (its bytes are about to be replaced) and crashes if the source buffer
+        // was already recycled ("buffer released before materialization"). Reading the unsafe reference does not
+        // fire the materializer; Remove clears it so a later host read can't resurrect obsolete GPU bytes either.
+        var rawArr = destination.DataVector.GetBackingArrayUnsafe();
+        if (rawArr is not null) Helpers.DeferredArrayMaterializer.Remove(rawArr);
+
         destinationArray = destination.GetLiveBackingArrayOrNull()!;
         return destinationArray is not null;
     }
@@ -2676,7 +2683,11 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 BindResidentBuffer(destination, destBuf, backend);
                 return true;
             }
-            catch { /* fall through to the host-download path below */ }
+            catch (Exception rex)
+            {
+                AliasDiag($"binary-into FELLBACK op={callerName} L=[{string.Join(",", left._shape)}]contig={left.IsContiguous} R=[{string.Join(",", right._shape)}]contig={right.IsContiguous}: {rex.GetType().Name}: {rex.Message}");
+                /* fall through to the host-download path below */
+            }
         }
 
         if (!TryGetSimpleCpuDestinationArray(destination, left.Length, out var destinationArray))

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -10570,57 +10570,54 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     private IGpuBuffer? _cachedEmbIndexBuffer;   // stable embedding-index buffer (single alloc; refreshed in place)
     private int _cachedEmbIndexCapacity;
 
+    private int[]? _embIndexScratch;             // host int[] scratch for TIndex→int conversion (long/int tokens)
+    private System.Action? _embIndexRefresh;     // refreshes the index buffer from the LIVE indices (closure knows TIndex)
+
     /// <summary>When true, the embedding index buffer is refreshed EXTERNALLY (by the compiled plan, OUTSIDE any
-    /// graph capture) via <see cref="RefreshGraphEmbeddingIndices"/>, so the captured gather kernel reads a stable
+    /// graph capture) via <see cref="RefreshGraphEmbeddingIndicesNow"/>, so the captured gather kernel reads a stable
     /// device buffer with NO host upload inside the capture (which would be CUDA 906). The eager/non-graph path
     /// leaves this false and uploads inline.</summary>
     internal bool EmbeddingIndexExternallyManaged;
 
-    /// <summary>Upload the given token indices into the stable embedding-index buffer (host→device, OUTSIDE any
-    /// capture). The compiled plan calls this before each graph launch so the captured gather reads THIS step's
-    /// indices. The buffer keeps a STABLE pointer across launches (allocated once), so the captured kernel that
-    /// baked that pointer stays valid.</summary>
-    internal void RefreshGraphEmbeddingIndices(Tensor<int> indices)
+    /// <summary>The embedding op delegate registers a closure here that uploads its LIVE (typed) token indices into
+    /// the stable buffer — so the compiled plan can refresh the buffer for ANY TIndex (int/long) without knowing
+    /// the type. Invoked by <see cref="RefreshGraphEmbeddingIndicesNow"/> before each graph launch.</summary>
+    internal void RegisterEmbIndexRefresh(System.Action refresh) => _embIndexRefresh = refresh;
+    internal void RefreshGraphEmbeddingIndicesNow() => _embIndexRefresh?.Invoke();
+
+    /// <summary>Convert any-typed token indices to int and upload them into the stable index buffer (allocated once,
+    /// refreshed in place — no per-step cuMemAlloc). Used inline on the eager path and via the registered action on
+    /// the managed (graph) path.</summary>
+    internal void UploadEmbeddingIndices<TIndex>(Tensor<TIndex> indices, int n)
     {
         if (!TryGetBackend(out var backend)) return;
-        int n = indices.Length;
         if (_cachedEmbIndexBuffer is null || _cachedEmbIndexCapacity < n)
         {
             _cachedEmbIndexBuffer?.Dispose();
             _cachedEmbIndexBuffer = backend.AllocateIntBuffer(n);
             _cachedEmbIndexCapacity = n;
         }
-        backend.UploadIntBufferInPlace(indices.GetDataArray(), _cachedEmbIndexBuffer);
+        if (_embIndexScratch is null || _embIndexScratch.Length < n) _embIndexScratch = new int[n];
+        var raw = indices.GetDataArray();
+        for (int i = 0; i < n; i++) _embIndexScratch[i] = System.Convert.ToInt32((object)raw[i]!);
+        backend.UploadIntBufferInPlace(_embIndexScratch, _cachedEmbIndexBuffer);
     }
 
-    internal bool TryEmbeddingLookupGpuInto<T>(Tensor<T> embeddingTable, Tensor<int> indices, Tensor<T> output)
+    /// <summary>On-device embedding gather straight into the output's GPU buffer — CUDA-graph-CAPTURABLE. Resolves
+    /// the resident embedding-table weight buffer (host-cached weight the optimizer updates in place). On the eager
+    /// path it uploads THIS call's indices inline; on the managed (capture/replay) path it reads the stable buffer
+    /// the plan already refreshed via the registered action, so no host upload happens inside the captured region.</summary>
+    internal bool TryEmbeddingGatherGpu<T, TIndex>(Tensor<T> embeddingTable, Tensor<TIndex> indices, int n, Tensor<T> output)
     {
         if (!TryGetBackend(out var backend)) return false;
         var outBuf = output.TryGetGpuBuffer();
-        // The embedding table is usually a HOST-cached weight (no GPU buffer on the tensor itself), which would
-        // null here and force the host fallback → breaking stream capture. Resolve its RESIDENT weight buffer —
-        // the same buffer the captured MatMul reads and the optimizer updates IN PLACE — so the gather reads the
-        // CURRENT trained embeddings and records cleanly into the graph.
         var tableBuf = embeddingTable.TryGetGpuBuffer() ?? ResolveResidentEmbeddingTable(backend, embeddingTable);
         if (outBuf is null || tableBuf is null) return false;
-        int numIndices = indices.Length;
         int embeddingDim = embeddingTable.Shape._dims[^1];
-        if ((long)numIndices * embeddingDim > outBuf.Size) return false;
-        if (!EmbeddingIndexExternallyManaged)
-        {
-            // Eager / non-graph path: refresh the stable index buffer inline (reuse it to avoid per-step cuMemAlloc).
-            if (_cachedEmbIndexBuffer is null || _cachedEmbIndexCapacity < numIndices)
-            {
-                _cachedEmbIndexBuffer?.Dispose();
-                _cachedEmbIndexBuffer = backend.AllocateIntBuffer(numIndices);
-                _cachedEmbIndexCapacity = numIndices;
-            }
-            backend.UploadIntBufferInPlace(indices.GetDataArray(), _cachedEmbIndexBuffer);
-        }
-        // Managed path: RefreshGraphEmbeddingIndices already uploaded THIS step's indices OUTSIDE capture, so this
-        // is a pure GPU gather kernel over stable device buffers — safe to RECORD into a CUDA graph and replay.
+        if ((long)n * embeddingDim > outBuf.Size) return false;
+        if (!EmbeddingIndexExternallyManaged) UploadEmbeddingIndices(indices, n);   // eager: refresh inline
         if (_cachedEmbIndexBuffer is null) return false;
-        backend.Embedding(_cachedEmbIndexBuffer, tableBuf, outBuf, numIndices, embeddingDim);
+        backend.Embedding(_cachedEmbIndexBuffer, tableBuf, outBuf, n, embeddingDim);
         return true;
     }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -2863,12 +2863,12 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int M = full.Length / N;
         try
         {
-            using var bufFull = GetOrAllocateContiguousInputBuffer(backend, full);
+            using var bufFull = GetResidentOrPersistentInputBuffer(backend, full);
             // The broadcast operand (positional embedding / bias vector) is a stable PARAMETER, not an
             // activation — resolve it through the PERSISTENT weight cache (uploaded once, kept fresh by the
             // optimizer) so capture/replay don't re-upload it (the transient GetOrAllocateBuffer path would
             // cuMemcpyHtoD every step → aborts the CUDA-graph capture).
-            using var bufBias = GetOrCacheWeightBuffer(backend, bias.GetDataArray(), PersistentTensorRole.Biases);
+            using var bufBias = GetResidentOrPersistentInputBuffer(backend, bias);
             var outBuf = GetOrCreateResidentBuffer(backend, output, full.Length);
             backend.BiasAdd(bufFull.Buffer, bufBias.Buffer, outBuf, M, N);
             BindResidentBuffer(output, outBuf, backend);

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -10560,6 +10560,28 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     }
 
     /// <summary>
+    /// GPU embedding gather that writes directly INTO an existing output tensor's GPU buffer — no allocation,
+    /// no host round-trip. Used by the compiled embedding forward action so the (prefix-eager) embedding runs
+    /// fully on-device each step and does NOT stall GPU util the way the host gather + full-output HtoD did.
+    /// Returns false (caller falls back to the host path) if the table/output are not GPU-resident.
+    /// The embedding table is read from its LIVE GPU buffer (updated in place by the GPU optimizer), so the
+    /// gather sees the current trained embeddings; only the small index vector is uploaded per step.
+    /// </summary>
+    internal bool TryEmbeddingLookupGpuInto<T>(Tensor<T> embeddingTable, Tensor<int> indices, Tensor<T> output)
+    {
+        if (!TryGetBackend(out var backend)) return false;
+        var outBuf = output.TryGetGpuBuffer();
+        var tableBuf = embeddingTable.TryGetGpuBuffer();
+        if (outBuf is null || tableBuf is null) return false;
+        int numIndices = indices.Length;
+        int embeddingDim = embeddingTable.Shape._dims[^1];
+        if ((long)numIndices * embeddingDim > outBuf.Size) return false;
+        using var idxBuf = backend.AllocateIntBuffer(indices.GetDataArray());
+        backend.Embedding(idxBuf, tableBuf, outBuf, numIndices, embeddingDim);
+        return true;
+    }
+
+    /// <summary>
     /// GPU-resident embedding backward operation.
     /// Computes gradients for the embedding table on GPU.
     /// </summary>

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -10597,7 +10597,11 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     {
         if (!TryGetBackend(out var backend)) return false;
         var outBuf = output.TryGetGpuBuffer();
-        var tableBuf = embeddingTable.TryGetGpuBuffer();
+        // The embedding table is usually a HOST-cached weight (no GPU buffer on the tensor itself), which would
+        // null here and force the host fallback → breaking stream capture. Resolve its RESIDENT weight buffer —
+        // the same buffer the captured MatMul reads and the optimizer updates IN PLACE — so the gather reads the
+        // CURRENT trained embeddings and records cleanly into the graph.
+        var tableBuf = embeddingTable.TryGetGpuBuffer() ?? ResolveResidentEmbeddingTable(backend, embeddingTable);
         if (outBuf is null || tableBuf is null) return false;
         int numIndices = indices.Length;
         int embeddingDim = embeddingTable.Shape._dims[^1];
@@ -10618,6 +10622,23 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (_cachedEmbIndexBuffer is null) return false;
         backend.Embedding(_cachedEmbIndexBuffer, tableBuf, outBuf, numIndices, embeddingDim);
         return true;
+    }
+
+    private IGpuBuffer? _cachedEmbTableBuffer;   // resolved-once resident embedding-table weight buffer
+
+    /// <summary>Resolve the embedding table's RESIDENT weight buffer (the cached weight uploaded once + updated in
+    /// place by the optimizer — exactly the buffer the captured MatMul reads). Cached after first resolution so
+    /// capture/replay never re-read host data or re-upload (no DtoH/HtoD inside the captured region).</summary>
+    private IGpuBuffer? ResolveResidentEmbeddingTable<T>(IDirectGpuBackend backend, Tensor<T> embeddingTable)
+    {
+        if (_cachedEmbTableBuffer is not null) return _cachedEmbTableBuffer;
+        try
+        {
+            var owned = GetOrCacheWeightBuffer(backend, embeddingTable.GetDataArray(), PersistentTensorRole.Embeddings);
+            _cachedEmbTableBuffer = owned.Buffer;
+        }
+        catch { return null; }
+        return _cachedEmbTableBuffer;
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -10599,7 +10599,11 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
         if (_embIndexScratch is null || _embIndexScratch.Length < n) _embIndexScratch = new int[n];
         var raw = indices.GetDataArray();
-        for (int i = 0; i < n; i++) _embIndexScratch[i] = System.Convert.ToInt32((object)raw[i]!);
+        // Typed fast paths avoid boxing every token each step (Convert.ToInt32((object)x) on ~B*ctx elements
+        // per step is heavy GC pressure). Token indices are int or long in practice.
+        if (raw is int[] ir) System.Array.Copy(ir, _embIndexScratch, n);
+        else if (raw is long[] lr) { for (int i = 0; i < n; i++) _embIndexScratch[i] = (int)lr[i]; }
+        else { for (int i = 0; i < n; i++) _embIndexScratch[i] = System.Convert.ToInt32((object)raw[i]!); }
         backend.UploadIntBufferInPlace(_embIndexScratch, _cachedEmbIndexBuffer);
     }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -2749,11 +2749,12 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int axisSize = input.Shape._dims[axis];
         int stride = 1; for (int i = axis + 1; i < input.Rank; i++) stride *= input.Shape._dims[i];
         if (index < 0 || index >= axisSize || (long)outerSize * stride != output.Length) return false;
+        if (backend is not Engines.DirectGpu.CUDA.CudaBackend cudaB) return false;   // SliceAxis is a CudaBackend op
         try
         {
             using var bufIn = GetResidentOrPersistentInputBuffer(backend, input);
             var outBuf = GetOrCreateResidentBuffer(backend, output, outerSize * stride);
-            backend.SliceAxis(bufIn.Buffer, outBuf, outerSize, axisSize, stride, index);
+            cudaB.SliceAxis(bufIn.Buffer, outBuf, outerSize, axisSize, stride, index);
             BindResidentBuffer(output, outBuf, backend);
             return true;
         }

--- a/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
@@ -837,6 +837,9 @@ public class DelegatingGpuBackend : IDirectGpuBackend
     /// <inheritdoc/>
     public virtual IGpuBuffer AllocateIntBuffer(int[] data) => Inner.AllocateIntBuffer(data);
 
+    /// <inheritdoc/>
+    public virtual void UploadIntBufferInPlace(int[] data, IGpuBuffer buffer) => Inner.UploadIntBufferInPlace(data, buffer);
+
     #endregion
 
     #region Attention Operations

--- a/src/AiDotNet.Tensors/Helpers/CpuParallelSettings.cs
+++ b/src/AiDotNet.Tensors/Helpers/CpuParallelSettings.cs
@@ -24,6 +24,23 @@ public static class CpuParallelSettings
     public static int MaxDegreeOfParallelism { get; set; } = Environment.ProcessorCount;
 
     /// <summary>
+    /// Worker-thread count for the library's persistent custom thread pools (PersistentParallelExecutor,
+    /// StreamingWorkerPool, CooperativeGemmScheduler). Honors <see cref="MaxDegreeOfParallelism"/> and clamps to
+    /// a ceiling so a high-core box (e.g. 64 logical processors) does NOT spawn ~63 threads PER pool — three such
+    /// pools at 63 each = ~189 mostly-parked threads of pure oversubscription tax. Each pool reads this once at
+    /// construction. Override the ceiling with AIDOTNET_POOL_THREADS.
+    /// </summary>
+    public static int WorkerPoolThreads
+    {
+        get
+        {
+            int ceiling = 32;
+            if (int.TryParse(Environment.GetEnvironmentVariable("AIDOTNET_POOL_THREADS"), out var c) && c > 0) ceiling = c;
+            return Math.Max(1, Math.Min(Math.Min(MaxDegreeOfParallelism, Environment.ProcessorCount) - 1, ceiling));
+        }
+    }
+
+    /// <summary>
     /// When true, the grain-size-gated <see cref="ParallelForOrSerial(int,int,long,System.Action{int})"/>
     /// helpers run serially regardless of work size. This is for the order-dependent reduction/
     /// accumulation kernels routed through these helpers, whose multi-threaded partial-sum

--- a/src/AiDotNet.Tensors/Helpers/PersistentParallelExecutor.cs
+++ b/src/AiDotNet.Tensors/Helpers/PersistentParallelExecutor.cs
@@ -37,7 +37,7 @@ internal sealed class PersistentParallelExecutor
 
     private PersistentParallelExecutor()
     {
-        _numWorkers = Math.Max(1, Environment.ProcessorCount - 1);
+        _numWorkers = CpuParallelSettings.WorkerPoolThreads;   // capped (was ProcessorCount-1 = ~63 on a 64-core box)
         _workers = new Thread[_numWorkers];
         _workReady = new ManualResetEventSlim[_numWorkers];
 


### PR DESCRIPTION
## Summary (DRAFT — work in progress)

Makes the compiled training-plan forward pass **fully GPU-resident** so the whole training step is **CUDA-graph-capturable** (one `cuGraphLaunch` per step) instead of falling back to the launch-bound eager path (~7–14% util). On the token-LM cortex this takes the capture from **aborting at the first op → running through ~95% of the forward**, with GPU util climbing **7% → 29–41% peak**. **Loss is verified correct (9.62, no drift) at every step.**

## Root cause

Every compiled-plan op did a host round-trip — **download its result**, **upload a non-resident input** (`GetDataArray` forces DtoH; an un-cached param HtoD's), or **fresh `AllocateOutputBuffer`** (`cuMemAlloc`). All three are `CUDA_ERROR_STREAM_CAPTURE_UNSUPPORTED` (900) inside a stream capture — and one 900 silently invalidates the whole graph (every op after gets a 901 "victim" error). The fix routes each op's GraphMode `Execute` through a **resident `*Into` path**: resident inputs → `backend.<op>` into a **stable cached output buffer** → mark resident (`BindResidentBuffer`), gated on the compiled step (`EvictionSuspended`).

## What's done (committed, loss-parity verified)

- Central `CopyResultInto` residency alias (183 host-copy sites) + `BindResidentBuffer` / `GetOrCreateResidentBuffer` / `GetResidentOrPersistentInputBuffer` helpers
- Resident ops: **embedding-from-float-indices** (the chain source), FusedLinear weights to persistent cache, permute/transpose, binary/scalar elementwise, **LayerNorm** (plus a real correctness fix: `normSize` must be the last dim, not `dims[0]`, for rank-3 `[B,S,D]`), BroadcastAdd (positional), TensorMatMul, SliceAxis
- 194 `GetOrAllocateBuffer(X.GetDataArray())` to `(X)` input-resolution sites (resident-first, no forced download)
- `_gpuBuffer`-clearing paths gated by `!EvictionSuspended` (don't orphan alias chains; fixes a #226 "buffer released" race)
- Permanent diagnostics: `AIDOTNET_GRAPH_CAPTURE_DEBUG=1` capture-fail reason+stack, `[CAPTURE-INVALIDATED-BY] forwardAction#N op=X`, producer-tracking

## Remaining (why this is a draft)

- One untagged/host `[B,D]` producer near the LM head still cascades a host result through a reshape
- The **backward half** (`_backwardActions`) is untouched — same treatment needed
- Graph capture stays **opt-in** (`AIDOTNET_CUDA_GRAPH_STEP=1`); default path unchanged

Repro: `d256/L2/12K` cortex with `HE_RUN_HEAVY=1 AIDOTNET_CUDA_GRAPH_STEP=1 AIDOTNET_GRAPH_CAPTURE_DEBUG=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
