### PR TITLE
fix(blas): validate prepacked-B cache against in-place weight mutation

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
@@ -284,6 +284,52 @@ internal static partial class SimdGemm
         // WeightArrayVersionOf(b) at build time — per-array invalidation
         // (see MarkWeightDirty). Checked alongside Epoch on every hit path.
         internal long SourceVersion;
+        // Content fingerprint of the source weight (first K*N elements) at
+        // build time. Re-checked on every cache hit so an IN-PLACE mutation of
+        // the weight buffer — an optimizer step or any raw Data.Span write that
+        // does NOT call MarkWeightDirty — is detected and forces a re-pack.
+        // Without this the cache served stale packed weights after training
+        // mutated them in place (the post-train / clone inference divergence,
+        // AiDotNet #1221 / #1331). The explicit FrozenWeightRegistry path keeps
+        // its zero-overhead "caller guarantees immutability" contract instead.
+        internal ulong Fingerprint;
+    }
+
+    /// <summary>
+    /// Content fingerprint (FNV-1a over the float bit-patterns + length) used to
+    /// validate the transparent prepacked-B cache against an in-place weight
+    /// mutation that bypasses the MarkWeightDirty version path (an optimizer
+    /// step / raw Data.Span write).
+    /// </summary>
+    /// <remarks>
+    /// EXACT for small weights (full scan, cheap) and a fixed STRIDED SAMPLE for
+    /// large ones, so the per-hit cost stays O(~1K) regardless of weight size and
+    /// does not erode the prepacked-cache speedup (PrePackSpeedupTest). A training
+    /// step or a weight reload changes essentially every element, so the sample
+    /// reliably detects the "weights changed" case this guards against (AiDotNet
+    /// #1221 / #1331). Callers with genuinely immutable weights should use the
+    /// zero-overhead <see cref="FrozenWeightRegistry"/> path instead, which trades
+    /// this validation for an explicit MarkDirty contract.
+    /// </remarks>
+    internal static ulong ComputeWeightFingerprint(System.ReadOnlySpan<float> data)
+    {
+        var bits = MemoryMarshal.Cast<float, uint>(data);
+        int n = bits.Length;
+        unchecked
+        {
+            ulong h = 1469598103934665603UL ^ (ulong)(uint)n; // FNV offset basis ⊕ length
+            if (n == 0) return h;
+            const int FullScanMax = 16384;
+            const int Samples = 1024;
+            int stride = n <= FullScanMax ? 1 : n / Samples;
+            for (int i = 0; i < n; i += stride)
+                h = (h ^ bits[i]) * 1099511628211UL;
+            h = (h ^ bits[n - 1]) * 1099511628211UL; // always fold the tail element
+            h ^= h >> 33;
+            h *= 0xff51afd7ed558ccdUL;
+            h ^= h >> 29;
+            return h;
+        }
     }
 
     private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<float[], PrePackedB> _prePackedBCache = new();
@@ -362,6 +408,7 @@ internal static partial class SimdGemm
             NumPcIters = numPcIters,
             Epoch = WeightCacheEpoch,
             SourceVersion = sourceVersion,
+            Fingerprint = ComputeWeightFingerprint(new System.ReadOnlySpan<float>(b, 0, k * n)),
         };
     }
 
@@ -455,7 +502,13 @@ internal static partial class SimdGemm
 
     private static PrePackedB GetOrBuildPrePackedB(float[] b, int k, int n, int m, int expectedMc)
     {
-        if (TryGetThreadPrePackedB(b, k, n, expectedMc, out var threadCached) && threadCached is not null)
+        // Content fingerprint of the live weight — re-validated against the
+        // cached entry so an in-place mutation that bypassed MarkWeightDirty
+        // (optimizer step / raw Data.Span write) is caught and forces a re-pack
+        // instead of serving stale packed weights (AiDotNet #1221 / #1331).
+        ulong fingerprint = ComputeWeightFingerprint(new System.ReadOnlySpan<float>(b, 0, k * n));
+
+        if (TryGetThreadPrePackedB(b, k, n, expectedMc, fingerprint, out var threadCached) && threadCached is not null)
             return threadCached;
 
         long epoch = WeightCacheEpoch;
@@ -464,7 +517,8 @@ internal static partial class SimdGemm
             && existing.K == k && existing.N == n
             && existing.Mc == expectedMc
             && existing.Epoch == epoch
-            && existing.SourceVersion == sourceVersion)
+            && existing.SourceVersion == sourceVersion
+            && existing.Fingerprint == fingerprint)
         {
             RememberThreadPrePackedB(b, existing);
             return existing;
@@ -477,7 +531,8 @@ internal static partial class SimdGemm
                 if (existing.K == k && existing.N == n
                     && existing.Mc == expectedMc
                     && existing.Epoch == epoch
-                    && existing.SourceVersion == sourceVersion)
+                    && existing.SourceVersion == sourceVersion
+                    && existing.Fingerprint == fingerprint)
                 {
                     RememberThreadPrePackedB(b, existing);
                     return existing;
@@ -494,16 +549,16 @@ internal static partial class SimdGemm
     }
 
     private static bool TryGetThreadPrePackedB(
-        float[] b, int k, int n, int expectedMc, out PrePackedB? cached)
+        float[] b, int k, int n, int expectedMc, ulong fingerprint, out PrePackedB? cached)
     {
         if (TryGetThreadPrePackedBSlot(_threadPrePackedBKey0, _threadPrePackedBValue0,
-                b, k, n, expectedMc, out cached))
+                b, k, n, expectedMc, fingerprint, out cached))
         {
             return true;
         }
 
         if (TryGetThreadPrePackedBSlot(_threadPrePackedBKey1, _threadPrePackedBValue1,
-                b, k, n, expectedMc, out cached))
+                b, k, n, expectedMc, fingerprint, out cached))
         {
             return true;
         }
@@ -515,7 +570,7 @@ internal static partial class SimdGemm
     private static bool TryGetThreadPrePackedBSlot(
         WeakReference<float[]>? keyRef,
         WeakReference<PrePackedB>? valueRef,
-        float[] b, int k, int n, int expectedMc,
+        float[] b, int k, int n, int expectedMc, ulong fingerprint,
         out PrePackedB? cached)
     {
         if (valueRef is not null
@@ -527,6 +582,10 @@ internal static partial class SimdGemm
             // cannot CLEAR another thread's slot, but it CAN make the
             // recorded SourceVersion stale.
             && value.SourceVersion == WeightArrayVersionOf(b)
+            // Content fingerprint guards against an in-place weight mutation
+            // that bypassed MarkWeightDirty (so SourceVersion alone wouldn't
+            // catch it) — see ComputeWeightFingerprint / AiDotNet #1221.
+            && value.Fingerprint == fingerprint
             && keyRef is not null
             && keyRef.TryGetTarget(out var key)
             && ReferenceEquals(key, b))

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemmDouble.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemmDouble.cs
@@ -447,9 +447,42 @@ internal static partial class SimdGemm
         internal double[][] PackedPanels = System.Array.Empty<double[]>();
         internal int NumJcIters;
         internal int NumPcIters;
+        // Content fingerprint of the first K*N source elements at build time.
+        // Re-checked on every cache hit so an IN-PLACE weight mutation (an
+        // optimizer step / raw Data.Span write that doesn't notify the cache)
+        // is detected and forces a re-pack instead of serving stale packed
+        // weights — the double analogue of the float fix for AiDotNet #1221/#1331.
+        internal ulong Fingerprint;
     }
 
     private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<double[], PrePackedBDouble> _prePackedBDoubleCache = new();
+
+    /// <summary>
+    /// Content fingerprint over the double bit-patterns — the double analogue of
+    /// <see cref="SimdGemm.ComputeWeightFingerprint"/> (exact for small weights,
+    /// strided sample for large). Validates the transparent prepacked-B cache
+    /// against in-place weight mutation.
+    /// </summary>
+    internal static ulong ComputeWeightFingerprintDouble(System.ReadOnlySpan<double> data)
+    {
+        var bits = System.Runtime.InteropServices.MemoryMarshal.Cast<double, ulong>(data);
+        int n = bits.Length;
+        unchecked
+        {
+            ulong h = 1469598103934665603UL ^ (ulong)(uint)n;
+            if (n == 0) return h;
+            const int FullScanMax = 16384;
+            const int Samples = 1024;
+            int stride = n <= FullScanMax ? 1 : n / Samples;
+            for (int i = 0; i < n; i += stride)
+                h = (h ^ bits[i]) * 1099511628211UL;
+            h = (h ^ bits[n - 1]) * 1099511628211UL;
+            h ^= h >> 33;
+            h *= 0xff51afd7ed558ccdUL;
+            h ^= h >> 29;
+            return h;
+        }
+    }
     private static readonly object _prePackedBDoubleCacheLock = new();
 
     /// <summary>
@@ -483,6 +516,7 @@ internal static partial class SimdGemm
             PackedPanels = panels,
             NumJcIters = numJcIters,
             NumPcIters = numPcIters,
+            Fingerprint = ComputeWeightFingerprintDouble(new ReadOnlySpan<double>(b, 0, k * n)),
         };
     }
 
@@ -494,8 +528,16 @@ internal static partial class SimdGemm
     private static PrePackedBDouble? GetOrAddPrePackedBDouble(double[] b, int k, int n, int m)
     {
         if (b == null || b.Length == 0) return null;
+
+        // Content fingerprint of the live weight — re-validated against the
+        // cached entry so an in-place mutation that the cache wasn't notified
+        // of (optimizer step / raw Data.Span write) forces a re-pack instead of
+        // serving stale packed weights (AiDotNet #1221 / #1331).
+        ulong fingerprint = ComputeWeightFingerprintDouble(new ReadOnlySpan<double>(b, 0, k * n));
+
         if (_prePackedBDoubleCache.TryGetValue(b, out var existing)
-            && existing.K == k && existing.N == n && existing.Kc == DKc)
+            && existing.K == k && existing.N == n && existing.Kc == DKc
+            && existing.Fingerprint == fingerprint)
             return existing;
 
         // Build under lock to avoid two threads packing the same B
@@ -506,7 +548,8 @@ internal static partial class SimdGemm
             // Same-shape race: another thread added between our TryGetValue
             // and the lock — reuse theirs and skip rebuild.
             if (_prePackedBDoubleCache.TryGetValue(b, out var existing2)
-                && existing2.K == k && existing2.N == n && existing2.Kc == DKc)
+                && existing2.K == k && existing2.N == n && existing2.Kc == DKc
+                && existing2.Fingerprint == fingerprint)
                 return existing2;
 
             // Different-shape collision: the same b[] is in the cache but

--- a/tests/AiDotNet.Tensors.Tests/Engines/PrePackedWeightCacheCoherenceTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/PrePackedWeightCacheCoherenceTests.cs
@@ -1,0 +1,77 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Regression for the transparent prepacked-B GEMM cache serving STALE packed
+/// weights after the weight buffer was mutated in place (e.g. an optimizer step
+/// or any raw Data.Span write that doesn't notify the cache). This produced the
+/// post-training / clone inference divergence in AiDotNet #1221 / #1331: a model
+/// predicted with weights from before its last training update. The cache now
+/// validates a content fingerprint of the live weight on every hit.
+/// </summary>
+public class PrePackedWeightCacheCoherenceTests
+{
+    private static double MaxAbs(Tensor<float> a, Tensor<float> b)
+    { double d = 0; int n = Math.Min(a.Length, b.Length); for (int i = 0; i < n; i++) d = Math.Max(d, Math.Abs(a[i] - b[i])); return d; }
+    private static double MaxAbs(Tensor<double> a, Tensor<double> b)
+    { double d = 0; int n = Math.Min(a.Length, b.Length); for (int i = 0; i < n; i++) d = Math.Max(d, Math.Abs(a[i] - b[i])); return d; }
+
+    [Theory]
+    [InlineData(8, 32, 64)]
+    [InlineData(128, 64, 128)]
+    [InlineData(64, 256, 256)]
+    public void FusedLinear_Float_ReflectsInPlaceWeightMutation(int m, int k, int n)
+    {
+        var engine = new CpuEngine();
+        var x = new Tensor<float>(new[] { m, k });
+        var w = new Tensor<float>(new[] { k, n });
+        var b = new Tensor<float>(new[] { n });
+        var r = new Random(7);
+        for (int i = 0; i < x.Length; i++) x[i] = (float)(r.NextDouble() - 0.5);
+        for (int i = 0; i < w.Length; i++) w[i] = (float)(r.NextDouble() - 0.5);
+        for (int i = 0; i < b.Length; i++) b[i] = (float)(r.NextDouble() - 0.5);
+
+        _ = engine.FusedLinear(x, w, b, FusedActivationType.ReLU); // packs/caches w
+        var ws = w.Data.Span;
+        for (int i = 0; i < w.Length; i++) ws[i] += 3.0f;          // in-place mutation
+        var stale = engine.FusedLinear(x, w, b, FusedActivationType.ReLU);
+
+        var wFresh = new Tensor<float>(new[] { k, n });
+        w.Data.Span.CopyTo(wFresh.Data.Span);
+        var truth = engine.FusedLinear(x, wFresh, b, FusedActivationType.ReLU);
+
+        Assert.True(MaxAbs(stale, truth) < 1e-3,
+            $"Prepacked-B cache served stale weights after in-place mutation (max|delta|={MaxAbs(stale, truth):E3}).");
+    }
+
+    [Theory]
+    [InlineData(8, 32, 64)]
+    [InlineData(128, 64, 128)]
+    public void FusedLinear_Double_ReflectsInPlaceWeightMutation(int m, int k, int n)
+    {
+        var engine = new CpuEngine();
+        var x = new Tensor<double>(new[] { m, k });
+        var w = new Tensor<double>(new[] { k, n });
+        var b = new Tensor<double>(new[] { n });
+        var r = new Random(11);
+        for (int i = 0; i < x.Length; i++) x[i] = r.NextDouble() - 0.5;
+        for (int i = 0; i < w.Length; i++) w[i] = r.NextDouble() - 0.5;
+        for (int i = 0; i < b.Length; i++) b[i] = r.NextDouble() - 0.5;
+
+        _ = engine.FusedLinear(x, w, b, FusedActivationType.ReLU);
+        var ws = w.Data.Span;
+        for (int i = 0; i < w.Length; i++) ws[i] += 3.0;
+        var stale = engine.FusedLinear(x, w, b, FusedActivationType.ReLU);
+
+        var wFresh = new Tensor<double>(new[] { k, n });
+        w.Data.Span.CopyTo(wFresh.Data.Span);
+        var truth = engine.FusedLinear(x, wFresh, b, FusedActivationType.ReLU);
+
+        Assert.True(MaxAbs(stale, truth) < 1e-9,
+            $"Prepacked-B double cache served stale weights after in-place mutation (max|delta|={MaxAbs(stale, truth):E3}).");
+    }
+}


### PR DESCRIPTION
## Problem
The transparent prepacked-B GEMM cache (`SgemmWithCachedB` / `Dgemm`, keyed by the weight's backing array) only invalidated on an explicit `MarkWeightDirty` / global-epoch bump. A raw **in-place** write to the weight buffer — an optimizer step, or any `Data.Span` mutation that doesn't notify the cache — left the packed panels **stale**, so a later inference GEMM computed with the **pre-mutation** weights.

This is the root cause of AiDotNet **#1221 / #1331**: a Transformer trained then run for inference predicted with weights from *before* its last training update (cache packed on an early forward, never re-packed as training mutated weights in place). A freshly-cloned model — whose weights arrive via `SetParameters` on a new array → a fresh pack — computed the *correct* result and thus diverged from the stale original, which is how the bug surfaced.

## Reproduction (added as a test)
`FusedLinear(x, w, b, ReLU)` → mutate `w.Data.Span` in place → `FusedLinear` again returns the **stale** pre-mutation result (max|Δ| ≈ 6.7 / 15 / 39 across shapes), for both float and double.

## Fix
Stamp a **content fingerprint** of the source weight into each cached `PrePackedB` / `PrePackedBDouble` entry and re-validate it on every hit (global table, per-thread MRU, and the double path). The fingerprint is **exact for small weights** (full scan) and a fixed **strided sample for large** ones, so per-hit cost stays O(~1K) regardless of weight size and does not erode the prepacked-cache speedup. A training step / weight reload changes essentially every element, so the sample reliably detects it. Callers with genuinely immutable weights keep the zero-overhead `FrozenWeightRegistry` path (explicit `MarkDirty` contract) — untouched.

## Verification
- New `PrePackedWeightCacheCoherenceTests` (float + double): 5/5 pass.
- Broader GEMM/MatMul/FusedLinear suite: 640 pass (the one `PrePackSpeedupTest` failure is a pre-existing environmental flake — it fails *worse* on clean `main` on this box).
- Builds clean on net471 + net10.0.

Closes the engine root cause behind AiDotNet #1221 / #1331.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
