### PR TITLE
perf: route eager/backward/batched float matmul to parallel BlasManaged.Gemm + memory metric + prepack thin-M fix

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -583,14 +583,24 @@ internal static class BackwardFunctions<T>
 
                             if (backwardWork >= MatMulBackwardSimdThreshold)
                             {
-                                // gradA[Mflat,K] = dC[Mflat,N] · Bᵀ[N,K]. Contiguous
-                                // leading-dim collapse lets us treat the rank-3 input
-                                // as rank-2 [Mflat, K] (same memory layout).
-                                SimdGemm.Sgemm(dCArr, N, false, bArr, N, true,
-                                    gradAData.AsSpan(0, Mflat * K), Mflat, N, K);
+                                // #573 follow-up: parallel transposed GEMMs via BlasManaged.Gemm —
+                                // the legacy full-trans SimdGemm.Sgemm overload these replaced ran
+                                // single-threaded (~17 GF/s vs ~435 parallel). This branch is gated
+                                // on backwardWork >= 20M, so M is always large enough to amortize
+                                // parallel dispatch (no per-call floor needed). DisableAutotune keeps
+                                // the static-heuristic kernel; transposed M-axis split is bit-exact
+                                // (each C element is one thread's full-K reduction).
+                                // gradA[Mflat,K] = dC[Mflat,N] · Bᵀ[N,K]. Contiguous leading-dim
+                                // collapse lets us treat the rank-3 input as rank-2 [Mflat,K].
+                                Engines.BlasManaged.BlasManaged.Gemm<float>(
+                                    dCArr, N, false, bArr, N, true,
+                                    gradAData.AsSpan(0, Mflat * K), K, Mflat, K, N,
+                                    new Engines.BlasManaged.BlasOptions<float> { PackingMode = Engines.BlasManaged.PackingMode.DisableAutotune });
                                 // gradB[K,N] = Aᵀ[K,Mflat] · dC[Mflat,N].
-                                SimdGemm.Sgemm(aArr, K, true, dCArr, N, false,
-                                    gradBData.AsSpan(0, K * N), K, Mflat, N);
+                                Engines.BlasManaged.BlasManaged.Gemm<float>(
+                                    aArr, K, true, dCArr, N, false,
+                                    gradBData.AsSpan(0, K * N), N, K, N, Mflat,
+                                    new Engines.BlasManaged.BlasOptions<float> { PackingMode = Engines.BlasManaged.PackingMode.DisableAutotune });
 
                                 DifferentiableOps.AccumulateGrad(grads, inputs[0], gradATensor, engine);
                                 DifferentiableOps.AccumulateGrad(grads, inputs[1], gradBTensor, engine);

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
@@ -265,6 +265,36 @@ public static partial class BlasManaged
     {
         if (m <= 0 || n <= 0 || k <= 0) return;
 
+        // Thin-M pre-packed B re-dispatch: the fast thin-M / machine-code kernels below cannot
+        // consume pre-packed tiles (they're gated on PackedB == null), so a pre-packed thin-M GEMM
+        // falls to the slow tuned strategy. That strategy parallelizes over the M-axis, so with few
+        // M-rows AND heavy per-row work (large N·K) it leaves cores idle — measured ~7× slower than
+        // fresh-pack at M=8/N=1024/K=1024 (PrePackSpeedupTest). Re-dispatch without the handle so it
+        // takes the fast fresh-pack path (machine-code kernel parallelizes the N-axis); the result is
+        // bit-identical (packing is only a memory-layout optimization). The per-row-work guard keeps
+        // the handle for small-N·K thin-M GEMMs (e.g. M=32 K=128 N=64) where the tuned strategy is
+        // already fast and dropping it would skip the pre-pack consumption other callers rely on.
+        const long ThinMPrePackDropMinRowWork = 1L << 16; // 64K = N·K above which thin-M pre-pack stalls
+        if (options.PackedB is not null && options.PackedA is null && m < ThinMDirectMinM
+            && (long)n * k >= ThinMPrePackDropMinRowWork
+            && !transA && !transB && options.PackingMode == PackingMode.Auto)
+        {
+            Gemm<T>(a, lda, transA, b, ldb, transB, c, ldc, m, n, k,
+                new BlasOptions<T>
+                {
+                    PackingMode = options.PackingMode,
+                    Epilogue = options.Epilogue,
+                    Workspace = options.Workspace,
+                    PackedA = options.PackedA,
+                    PackedB = null,
+                    NumThreads = options.NumThreads,
+                    AutotuneKey = options.AutotuneKey,
+                    MaxJitCacheBytes = options.MaxJitCacheBytes,
+                    Mode = options.Mode,
+                });
+            return;
+        }
+
         // Strategies do read-modify-write on C; zero it here so the first call
         // produces C = A · B (not C += A · B). Future versions may expose a
         // beta=1 option that skips this zero, but Phase B's contract is C := A · B.

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.Mlp.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.Mlp.cs
@@ -108,7 +108,21 @@ public partial class CpuEngine
         // Math.Clamp isn't available on net471 — use Max/Min (see the same
         // pattern in CpuEngine.Geometry.cs / FusedPointwise.cs).
         int blasThreads = Math.Max(1, Math.Min((int)(rows / 16), Environment.ProcessorCount));
-        using var _blasScope = Helpers.BlasProvider.ScopeOpenBlasThreads(blasThreads);
+        // ScopeOpenBlasThreads is NOT free: it marshals an openblas_set_num_threads
+        // onto a dedicated BLAS thread (a semaphore round-trip) on BOTH entry and
+        // restore — ~0.1 ms of the measured ~0.29 ms batch-1 MlpForward (issue #475 /
+        // small-batch inference loss vs PyTorch). At small effective M the per-layer
+        // GEMMs are GEMV-tiny (e.g. 1×784×512) and OpenBLAS runs them single-threaded
+        // by its own size heuristic, so forcing the global pool to 1 thread changes
+        // nothing — the reconfiguration is pure overhead. Only enter the scope once
+        // there are enough output rows that native BLAS would actually multithread and
+        // oversubscribe (the #436 case was bs=128; blasThreads only drops below the
+        // core count from bs≈32 up). default(OpenBlasThreadScope) is an inert token
+        // whose Dispose is a no-op, so the small-batch path pays nothing.
+        const long BlasThreadScopeMinRows = 32;
+        using var _blasScope = rows >= BlasThreadScopeMinRows
+            ? Helpers.BlasProvider.ScopeOpenBlasThreads(blasThreads)
+            : default;
 
         int last = weights.Count - 1;
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -11878,8 +11878,30 @@ public partial class CpuEngine : ITensorLevelEngine
             var aArrF = (float[])(object)a.GetDataArray();
             var bArrF = (float[])(object)b.GetDataArray();
             var rArrF = (float[])(object)result.GetDataArray();
-            Simd.SimdGemm.Sgemm(aArrF.AsSpan(0, m * n), n, false, bArrF.AsSpan(0, n * p), p, false,
-                                rArrF.AsSpan(0, m * p), m, n, p);
+            // #573 follow-up: above a row-count floor, route through BlasManaged.Gemm (the same
+            // dispatcher the pre-packed path above uses) instead of the legacy full-trans
+            // SimdGemm.Sgemm overload. With NO PackedB handle it still packs B fresh every call
+            // (safe for in-place-mutated training weights), but it parallelizes the M-axis across
+            // cores — the legacy overload ran essentially single-threaded (~17 GF/s vs ~390 GF/s at
+            // [256,256]x[256,512] on a 32-core box; the MLP inference forward dropped 3.15→0.39 ms).
+            // DisableAutotune keeps the static-heuristic kernel choice (matching the
+            // Sgemm(a,b,c,m,k,n) shim's determinism contract); M-axis parallelism is bit-exact (each
+            // C element is one thread's full-K reduction, no cross-thread accumulation).
+            // Below the floor the parallel-dispatch overhead dominates the tiny per-row work, so the
+            // legacy single-pass kernel stays faster — keep it for m < BlasManagedParallelMinM.
+            const int BlasManagedParallelMinM = 64;
+            if (m >= BlasManagedParallelMinM)
+            {
+                Engines.BlasManaged.BlasManaged.Gemm<float>(
+                    aArrF.AsSpan(0, m * n), n, false, bArrF.AsSpan(0, n * p), p, false,
+                    rArrF.AsSpan(0, m * p), p, m, p, n,
+                    new Engines.BlasManaged.BlasOptions<float> { PackingMode = Engines.BlasManaged.PackingMode.DisableAutotune });
+            }
+            else
+            {
+                Simd.SimdGemm.Sgemm(aArrF.AsSpan(0, m * n), n, false, bArrF.AsSpan(0, n * p), p, false,
+                                    rArrF.AsSpan(0, m * p), m, n, p);
+            }
             return result;
         }
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -14222,7 +14222,11 @@ public partial class CpuEngine : ITensorLevelEngine
                     // im2col (channel-parallel at small colW, serial at large colW).
                     // Match the GEMM routing: small convs build serially (the im2col pool wakeup adds
                     // timing variance that makes the tiny-conv perf gate flaky under concurrent load).
-                    bool convParallel = (long)colH * outChannels > ConvSmallGemmOutputMax;
+                    // Fold batchColW into the heuristic — both BuildKConcatStackFloat and
+                    // ConvWeightGemmFloat do work proportional to colH·outChannels·batchColW, so a
+                    // thin output (small colH·outChannels) with a very large K still has enough
+                    // total work to amortize the parallel-pool wakeup.
+                    bool convParallel = (long)colH * outChannels * batchColW > ConvSmallGemmOutputMax;
                     BuildKConcatStackFloat(
                         gradOutputF, inputF, gradOutAllT, im2colAll,
                         batch, outChannels, inChannels, colW, colH, batchColW,

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -13963,19 +13963,47 @@ public partial class CpuEngine : ITensorLevelEngine
     // extra cores only add dispatch overhead). Extracted so Conv2DBackwardKernel's
     // hot GEMM path keeps its baseline codegen (the inline build bloated the method
     // and regressed a small-shape perf guard).
+    // Cache-blocked row-major transpose: src[rows, cols] -> dst[cols, rows]. Used by the
+    // K-concat conv-backward path to avoid the cache-hostile transB GEMM (#573 follow-up).
+    private static void TransposeFloatRowMajor(float[] src, float[] dst, int rows, int cols)
+    {
+        const int Blk = 32;
+        for (int r0 = 0; r0 < rows; r0 += Blk)
+        {
+            int rMax = Math.Min(r0 + Blk, rows);
+            for (int c0 = 0; c0 < cols; c0 += Blk)
+            {
+                int cMax = Math.Min(c0 + Blk, cols);
+                for (int r = r0; r < rMax; r++)
+                {
+                    int srcRow = r * cols;
+                    for (int c = c0; c < cMax; c++)
+                        dst[c * rows + r] = src[srcRow + c];
+                }
+            }
+        }
+    }
+
     private static void BuildKConcatStackFloat(
-        float[] gradOutputF, float[] inputF, float[] gradOutAll, float[] im2colAll,
+        float[] gradOutputF, float[] inputF, float[] gradOutAllT, float[] im2colAll,
         int batch, int outChannels, int inChannels, int colW, int colH, int batchColW,
         int inputSliceSize, int height, int width, int kernelHeight, int kernelWidth,
         int strideH, int strideW, int padH, int padW, int dilationH, int dilationW,
         int outputHeight, int outputWidth)
     {
+        // gradOutAllT[(b·colW+n), oc] = gradOutput[b, oc, n] — built TRANSPOSED so the K-concat
+        // backward GEMM is non-transposed (im2colAll · gradOutAllT) with M = colH, hitting the
+        // fast machine-code kernel (#573 follow-up; the transposed-B form was ~2 GF/s).
         for (int b = 0; b < batch; b++)
         {
             int gradOutOff = b * outChannels * colW;
+            int bColOff = b * colW;
             for (int oc = 0; oc < outChannels; oc++)
-                Array.Copy(gradOutputF, gradOutOff + oc * colW,
-                           gradOutAll, oc * batchColW + b * colW, colW);
+            {
+                int srcBase = gradOutOff + oc * colW;
+                for (int n = 0; n < colW; n++)
+                    gradOutAllT[(bColOff + n) * outChannels + oc] = gradOutputF[srcBase + n];
+            }
         }
         if (colW <= ParallelIm2colMaxColW)
         {
@@ -14102,33 +14130,43 @@ public partial class CpuEngine : ITensorLevelEngine
             {
                 int batchColW = batch * colW;
                 var kcPool = System.Buffers.ArrayPool<float>.Shared;
-                var gradOutAll = kcPool.Rent(outChannels * batchColW);
                 var im2colAll = kcPool.Rent(colH * batchColW);
+                var gradOutAllT = kcPool.Rent(batchColW * outChannels);
+                var gradKernelT = kcPool.Rent(colH * outChannels);
                 try
                 {
-                    // #403 Phase F: repack gradOutput + build the strided im2col
-                    // (channel-parallel at small colW, serial at large colW).
+                    // #403 Phase F: repack gradOutput (TRANSPOSED — see method) + build the strided
+                    // im2col (channel-parallel at small colW, serial at large colW).
                     BuildKConcatStackFloat(
-                        gradOutputF, inputF, gradOutAll, im2colAll,
+                        gradOutputF, inputF, gradOutAllT, im2colAll,
                         batch, outChannels, inChannels, colW, colH, batchColW,
                         inputSliceSize, height, width, kernelHeight, kernelWidth,
                         strideH, strideW, padH, padW, dilationH, dilationW, outputHeight, outputWidth);
 
-                    // gradKernel = gradOutAll @ im2colAll^T — one full-width GEMM.
+                    // #573 follow-up: the natural GEMM gradKernel = gradOut·im2colAllᵀ is transB=true with
+                    // M = outChannels (often thin, e.g. 16) — no microkernel handles that shape well
+                    // (~2 GF/s; transposed B access with K=batchColW stride is cache-hostile). gradOut is
+                    // built TRANSPOSED above so the result transpose is a NON-transposed GEMM whose M is
+                    // colH (= inC·kH·kW, ≥64 for real conv shapes) → hits the fast machine-code kernel:
+                    //   gradKernelᵀ[colH, oc] = im2colAll[colH, bcw] · gradOutAllᵀ[bcw, oc]
+                    // then transpose [colH, oc] back to gradKernelF[oc, colH]. Fixes the tiny-conv perf
+                    // gate AND removes the contention-variable transB tuned-strategy on large shapes.
                     if (!Helpers.BlasProvider.TryGemmEx(
-                        outChannels, colH, batchColW,
-                        gradOutAll, 0, batchColW, false,
-                        im2colAll, 0, batchColW, true,
-                        gradKernelF, 0, colH))
+                        colH, outChannels, batchColW,
+                        im2colAll, 0, batchColW, false,
+                        gradOutAllT, 0, outChannels, false,
+                        gradKernelT, 0, outChannels))
                     {
-                        // Top-level (not in a parallel region) so the parallel
-                        // SimdGemm.Sgemm self-parallelizes at full width.
-                        Simd.SimdGemm.Sgemm(
-                            new ReadOnlySpan<float>(gradOutAll, 0, outChannels * batchColW), batchColW, false,
-                            new ReadOnlySpan<float>(im2colAll, 0, colH * batchColW), batchColW, true,
-                            new Span<float>(gradKernelF, 0, outChannels * colH),
-                            outChannels, batchColW, colH);
+                        // PackingMode.Auto (default) so the no-trans machine-code 6×16 microkernel fires
+                        // (gated on Auto; handles any K, unlike TryThinMDirect which caps K at 1024) with
+                        // no autotune benchmark — it's deterministic (disjoint output tiles, fixed K order).
+                        Engines.BlasManaged.BlasManaged.Gemm<float>(
+                            new ReadOnlySpan<float>(im2colAll, 0, colH * batchColW), batchColW, false,
+                            new ReadOnlySpan<float>(gradOutAllT, 0, batchColW * outChannels), outChannels, false,
+                            new Span<float>(gradKernelT, 0, colH * outChannels), outChannels,
+                            colH, outChannels, batchColW);
                     }
+                    TransposeFloatRowMajor(gradKernelT, gradKernelF, colH, outChannels);
 
                     var opsKc = MathHelper.GetNumericOperations<T>();
                     var resultKc = new T[gradKernelF.Length];
@@ -14137,8 +14175,9 @@ public partial class CpuEngine : ITensorLevelEngine
                 }
                 finally
                 {
-                    kcPool.Return(gradOutAll);
                     kcPool.Return(im2colAll);
+                    kcPool.Return(gradOutAllT);
+                    kcPool.Return(gradKernelT);
                 }
             }
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -13971,51 +13971,77 @@ public partial class CpuEngine : ITensorLevelEngine
     private const int ConvSmallGemmMr = 6;
 
     /// <summary>
-    /// Single-threaded packed SGEMM for the K-concat conv weight gradient:
-    /// C[M=colH, N=oc] = A[M, K=batchColW] · B[K, N] (all row-major), accumulating fresh (C := A·B).
+    /// Packed SGEMM for the K-concat conv weight gradient:
+    /// C[M=colH, N=oc] = A[M, K=batchColW] · B[K, N] (all row-major), C := A·B.
     /// Packs each Mr-row panel of A so the inner loop reads contiguously, holds the C tile in
-    /// <see cref="Vector{T}"/> accumulators, and streams K once — ~20 GF/s/core with no worker-pool
-    /// dispatch. Bit-exact: each C element is one fixed-order K reduction. <paramref name="packBuf"/>
-    /// must be at least K·<see cref="ConvSmallGemmMr"/> long.
+    /// <see cref="Vector{T}"/> accumulators, and streams K once — ~20 GF/s/core. Each Mr-panel writes
+    /// disjoint C rows with a fixed-order K reduction, so it parallelizes over panels bit-exactly.
+    /// <paramref name="parallel"/>=false runs inline (small GEMMs: the worker-pool wakeup latency would
+    /// dwarf the compute and add timing variance); =true splits panels across the pool (large GEMMs:
+    /// the wakeup amortizes and the packed kernel scales, beating the no-pack dispatcher's strided-A
+    /// path that only reaches ~12 GF/s here).
     /// </summary>
-    private static void ConvWeightGemmSingleThreadFloat(
-        float[] a, float[] b, float[] c, int m, int n, int k, float[] packBuf)
+    private static void ConvWeightGemmFloat(float[] a, float[] b, float[] c, int m, int n, int k, bool parallel)
     {
         Array.Clear(c, 0, m * n);
-        int vw = System.Numerics.Vector<float>.Count;
         const int Mr = ConvSmallGemmMr;
-        var acc = new System.Numerics.Vector<float>[Mr];
-        for (int m0 = 0; m0 < m; m0 += Mr)
+        int numPanels = (m + Mr - 1) / Mr;
+        if (parallel)
         {
-            int mr = Math.Min(Mr, m - m0);
-            // Pack A[m0..m0+mr, :] into packBuf[k*Mr + i] (read each A row contiguously).
-            for (int i = 0; i < mr; i++)
+            CpuParallelSettings.ParallelForOrSerial(0, numPanels, (long)m * n * k, pi =>
             {
-                int aRow = (m0 + i) * k;
-                for (int kk = 0; kk < k; kk++) packBuf[kk * Mr + i] = a[aRow + kk];
+                var pool = System.Buffers.ArrayPool<float>.Shared;
+                var packBuf = pool.Rent(k * Mr);
+                try { ConvWeightGemmPanelFloat(a, b, c, pi * Mr, Math.Min(Mr, m - pi * Mr), n, k, packBuf); }
+                finally { pool.Return(packBuf); }
+            });
+        }
+        else
+        {
+            var pool = System.Buffers.ArrayPool<float>.Shared;
+            var packBuf = pool.Rent(k * Mr);
+            try
+            {
+                for (int pi = 0; pi < numPanels; pi++)
+                    ConvWeightGemmPanelFloat(a, b, c, pi * Mr, Math.Min(Mr, m - pi * Mr), n, k, packBuf);
             }
-            int n0 = 0;
-            for (; n0 + vw <= n; n0 += vw)
+            finally { pool.Return(packBuf); }
+        }
+    }
+
+    // One Mr-row panel of the packed conv weight GEMM: pack A[m0..m0+mr, :] then stream K into the
+    // C[m0..m0+mr, :n] tile (Vector<float> accumulators). packBuf must be ≥ k·ConvSmallGemmMr.
+    private static void ConvWeightGemmPanelFloat(
+        float[] a, float[] b, float[] c, int m0, int mr, int n, int k, float[] packBuf)
+    {
+        const int Mr = ConvSmallGemmMr;
+        int vw = System.Numerics.Vector<float>.Count;
+        for (int i = 0; i < mr; i++)
+        {
+            int aRow = (m0 + i) * k;
+            for (int kk = 0; kk < k; kk++) packBuf[kk * Mr + i] = a[aRow + kk];
+        }
+        var acc = new System.Numerics.Vector<float>[Mr];
+        int n0 = 0;
+        for (; n0 + vw <= n; n0 += vw)
+        {
+            for (int i = 0; i < mr; i++) acc[i] = System.Numerics.Vector<float>.Zero;
+            for (int kk = 0; kk < k; kk++)
             {
-                for (int i = 0; i < mr; i++) acc[i] = System.Numerics.Vector<float>.Zero;
-                for (int kk = 0; kk < k; kk++)
-                {
-                    var bv = new System.Numerics.Vector<float>(b, kk * n + n0);
-                    int pk = kk * Mr;
-                    for (int i = 0; i < mr; i++)
-                        acc[i] += new System.Numerics.Vector<float>(packBuf[pk + i]) * bv;
-                }
-                for (int i = 0; i < mr; i++) acc[i].CopyTo(c, (m0 + i) * n + n0);
+                var bv = new System.Numerics.Vector<float>(b, kk * n + n0);
+                int pk = kk * Mr;
+                for (int i = 0; i < mr; i++)
+                    acc[i] += new System.Numerics.Vector<float>(packBuf[pk + i]) * bv;
             }
-            // Scalar N-tail (n0 .. n).
-            for (; n0 < n; n0++)
+            for (int i = 0; i < mr; i++) acc[i].CopyTo(c, (m0 + i) * n + n0);
+        }
+        for (; n0 < n; n0++) // scalar N-tail
+        {
+            for (int kk = 0; kk < k; kk++)
             {
-                for (int kk = 0; kk < k; kk++)
-                {
-                    float bs = b[kk * n + n0];
-                    int pk = kk * Mr;
-                    for (int i = 0; i < mr; i++) c[(m0 + i) * n + n0] += packBuf[pk + i] * bs;
-                }
+                float bs = b[kk * n + n0];
+                int pk = kk * Mr;
+                for (int i = 0; i < mr; i++) c[(m0 + i) * n + n0] += packBuf[pk + i] * bs;
             }
         }
     }
@@ -14046,7 +14072,7 @@ public partial class CpuEngine : ITensorLevelEngine
         int batch, int outChannels, int inChannels, int colW, int colH, int batchColW,
         int inputSliceSize, int height, int width, int kernelHeight, int kernelWidth,
         int strideH, int strideW, int padH, int padW, int dilationH, int dilationW,
-        int outputHeight, int outputWidth)
+        int outputHeight, int outputWidth, bool parallelBuild)
     {
         // gradOutAllT[(b·colW+n), oc] = gradOutput[b, oc, n] — built TRANSPOSED so the K-concat
         // backward GEMM is non-transposed (im2colAll · gradOutAllT) with M = colH, hitting the
@@ -14062,7 +14088,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     gradOutAllT[(bColOff + n) * outChannels + oc] = gradOutputF[srcBase + n];
             }
         }
-        if (colW <= ParallelIm2colMaxColW)
+        if (parallelBuild && colW <= ParallelIm2colMaxColW)
         {
             int kHW = kernelHeight * kernelWidth;
             CpuParallelSettings.ParallelForOrSerial(
@@ -14194,11 +14220,15 @@ public partial class CpuEngine : ITensorLevelEngine
                 {
                     // #403 Phase F: repack gradOutput (TRANSPOSED — see method) + build the strided
                     // im2col (channel-parallel at small colW, serial at large colW).
+                    // Match the GEMM routing: small convs build serially (the im2col pool wakeup adds
+                    // timing variance that makes the tiny-conv perf gate flaky under concurrent load).
+                    bool convParallel = (long)colH * outChannels > ConvSmallGemmOutputMax;
                     BuildKConcatStackFloat(
                         gradOutputF, inputF, gradOutAllT, im2colAll,
                         batch, outChannels, inChannels, colW, colH, batchColW,
                         inputSliceSize, height, width, kernelHeight, kernelWidth,
-                        strideH, strideW, padH, padW, dilationH, dilationW, outputHeight, outputWidth);
+                        strideH, strideW, padH, padW, dilationH, dilationW, outputHeight, outputWidth,
+                        parallelBuild: convParallel);
 
                     // #573 follow-up: the natural GEMM gradKernel = gradOut·im2colAllᵀ is transB=true with
                     // M = outChannels (often thin, e.g. 16) — no microkernel handles that shape well
@@ -14207,35 +14237,21 @@ public partial class CpuEngine : ITensorLevelEngine
                     // (= inC·kH·kW): gradKernelᵀ[colH, oc] = im2colAll[colH, bcw] · gradOutAllᵀ[bcw, oc],
                     // then transposed back to gradKernelF[oc, colH].
                     //
-                    // Routing: for a SMALL output tile (colH·oc ≤ threshold) run a single-threaded packed
-                    // microkernel inline. The parallel BlasManaged dispatcher's per-call worker-pool wakeup
-                    // adds ~1 ms of variable latency that dwarfs the tiny GEMM's actual compute (~0.1 ms)
-                    // and makes the timing flaky under load; the inline kernel has none and is bit-exact.
-                    // Large outputs keep the parallel dispatcher (its throughput genuinely wins there).
-                    if ((long)colH * outChannels <= ConvSmallGemmOutputMax)
-                    {
-                        var pack = kcPool.Rent(batchColW * ConvSmallGemmMr);
-                        try
-                        {
-                            ConvWeightGemmSingleThreadFloat(
-                                im2colAll, gradOutAllT, gradKernelT, colH, outChannels, batchColW, pack);
-                        }
-                        finally { kcPool.Return(pack); }
-                    }
-                    else if (!Helpers.BlasProvider.TryGemmEx(
+                    // Routing: our packed kernel runs inline for SMALL output tiles (the parallel pool's
+                    // per-call wakeup latency, ~1 ms, would dwarf the tiny GEMM's ~0.1 ms compute and add
+                    // timing variance) and splits panels across the pool for LARGE outputs (wakeup
+                    // amortizes; the packed kernel scales — vs the no-pack dispatcher whose strided-A
+                    // access only reached ~12 GF/s here). Bit-exact either way (disjoint C rows, fixed
+                    // K order). Native BLAS (when present) still wins outright, so prefer it first.
+                    if (!Helpers.BlasProvider.TryGemmEx(
                         colH, outChannels, batchColW,
                         im2colAll, 0, batchColW, false,
                         gradOutAllT, 0, outChannels, false,
                         gradKernelT, 0, outChannels))
                     {
-                        // PackingMode.Auto (default) so the no-trans machine-code 6×16 microkernel fires
-                        // (gated on Auto; handles any K, unlike TryThinMDirect which caps K at 1024) with
-                        // no autotune benchmark — it's deterministic (disjoint output tiles, fixed K order).
-                        Engines.BlasManaged.BlasManaged.Gemm<float>(
-                            new ReadOnlySpan<float>(im2colAll, 0, colH * batchColW), batchColW, false,
-                            new ReadOnlySpan<float>(gradOutAllT, 0, batchColW * outChannels), outChannels, false,
-                            new Span<float>(gradKernelT, 0, colH * outChannels), outChannels,
-                            colH, outChannels, batchColW);
+                        ConvWeightGemmFloat(
+                            im2colAll, gradOutAllT, gradKernelT, colH, outChannels, batchColW,
+                            parallel: convParallel);
                     }
                     TransposeFloatRowMajor(gradKernelT, gradKernelF, colH, outChannels);
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -13963,6 +13963,63 @@ public partial class CpuEngine : ITensorLevelEngine
     // extra cores only add dispatch overhead). Extracted so Conv2DBackwardKernel's
     // hot GEMM path keeps its baseline codegen (the inline build bloated the method
     // and regressed a small-shape perf guard).
+    // Conv-backward small-GEMM routing (#573 follow-up). Below this output-tile size the K-concat
+    // weight GEMM runs inline single-threaded (no worker-pool wakeup variance); above it the parallel
+    // dispatcher wins on throughput. The tiny benchmark conv (colH·oc = 72·16 = 1152) is well under;
+    // the larger conv (576·64 = 36864) routes to the parallel path.
+    private const long ConvSmallGemmOutputMax = 8192;
+    private const int ConvSmallGemmMr = 6;
+
+    /// <summary>
+    /// Single-threaded packed SGEMM for the K-concat conv weight gradient:
+    /// C[M=colH, N=oc] = A[M, K=batchColW] · B[K, N] (all row-major), accumulating fresh (C := A·B).
+    /// Packs each Mr-row panel of A so the inner loop reads contiguously, holds the C tile in
+    /// <see cref="Vector{T}"/> accumulators, and streams K once — ~20 GF/s/core with no worker-pool
+    /// dispatch. Bit-exact: each C element is one fixed-order K reduction. <paramref name="packBuf"/>
+    /// must be at least K·<see cref="ConvSmallGemmMr"/> long.
+    /// </summary>
+    private static void ConvWeightGemmSingleThreadFloat(
+        float[] a, float[] b, float[] c, int m, int n, int k, float[] packBuf)
+    {
+        Array.Clear(c, 0, m * n);
+        int vw = System.Numerics.Vector<float>.Count;
+        const int Mr = ConvSmallGemmMr;
+        var acc = new System.Numerics.Vector<float>[Mr];
+        for (int m0 = 0; m0 < m; m0 += Mr)
+        {
+            int mr = Math.Min(Mr, m - m0);
+            // Pack A[m0..m0+mr, :] into packBuf[k*Mr + i] (read each A row contiguously).
+            for (int i = 0; i < mr; i++)
+            {
+                int aRow = (m0 + i) * k;
+                for (int kk = 0; kk < k; kk++) packBuf[kk * Mr + i] = a[aRow + kk];
+            }
+            int n0 = 0;
+            for (; n0 + vw <= n; n0 += vw)
+            {
+                for (int i = 0; i < mr; i++) acc[i] = System.Numerics.Vector<float>.Zero;
+                for (int kk = 0; kk < k; kk++)
+                {
+                    var bv = new System.Numerics.Vector<float>(b, kk * n + n0);
+                    int pk = kk * Mr;
+                    for (int i = 0; i < mr; i++)
+                        acc[i] += new System.Numerics.Vector<float>(packBuf[pk + i]) * bv;
+                }
+                for (int i = 0; i < mr; i++) acc[i].CopyTo(c, (m0 + i) * n + n0);
+            }
+            // Scalar N-tail (n0 .. n).
+            for (; n0 < n; n0++)
+            {
+                for (int kk = 0; kk < k; kk++)
+                {
+                    float bs = b[kk * n + n0];
+                    int pk = kk * Mr;
+                    for (int i = 0; i < mr; i++) c[(m0 + i) * n + n0] += packBuf[pk + i] * bs;
+                }
+            }
+        }
+    }
+
     // Cache-blocked row-major transpose: src[rows, cols] -> dst[cols, rows]. Used by the
     // K-concat conv-backward path to avoid the cache-hostile transB GEMM (#573 follow-up).
     private static void TransposeFloatRowMajor(float[] src, float[] dst, int rows, int cols)
@@ -14146,12 +14203,26 @@ public partial class CpuEngine : ITensorLevelEngine
                     // #573 follow-up: the natural GEMM gradKernel = gradOut·im2colAllᵀ is transB=true with
                     // M = outChannels (often thin, e.g. 16) — no microkernel handles that shape well
                     // (~2 GF/s; transposed B access with K=batchColW stride is cache-hostile). gradOut is
-                    // built TRANSPOSED above so the result transpose is a NON-transposed GEMM whose M is
-                    // colH (= inC·kH·kW, ≥64 for real conv shapes) → hits the fast machine-code kernel:
-                    //   gradKernelᵀ[colH, oc] = im2colAll[colH, bcw] · gradOutAllᵀ[bcw, oc]
-                    // then transpose [colH, oc] back to gradKernelF[oc, colH]. Fixes the tiny-conv perf
-                    // gate AND removes the contention-variable transB tuned-strategy on large shapes.
-                    if (!Helpers.BlasProvider.TryGemmEx(
+                    // built TRANSPOSED above so the result is a NON-transposed GEMM whose M is colH
+                    // (= inC·kH·kW): gradKernelᵀ[colH, oc] = im2colAll[colH, bcw] · gradOutAllᵀ[bcw, oc],
+                    // then transposed back to gradKernelF[oc, colH].
+                    //
+                    // Routing: for a SMALL output tile (colH·oc ≤ threshold) run a single-threaded packed
+                    // microkernel inline. The parallel BlasManaged dispatcher's per-call worker-pool wakeup
+                    // adds ~1 ms of variable latency that dwarfs the tiny GEMM's actual compute (~0.1 ms)
+                    // and makes the timing flaky under load; the inline kernel has none and is bit-exact.
+                    // Large outputs keep the parallel dispatcher (its throughput genuinely wins there).
+                    if ((long)colH * outChannels <= ConvSmallGemmOutputMax)
+                    {
+                        var pack = kcPool.Rent(batchColW * ConvSmallGemmMr);
+                        try
+                        {
+                            ConvWeightGemmSingleThreadFloat(
+                                im2colAll, gradOutAllT, gradKernelT, colH, outChannels, batchColW, pack);
+                        }
+                        finally { kcPool.Return(pack); }
+                    }
+                    else if (!Helpers.BlasProvider.TryGemmEx(
                         colH, outChannels, batchColW,
                         im2colAll, 0, batchColW, false,
                         gradOutAllT, 0, outChannels, false,

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -2585,7 +2585,22 @@ public partial class CpuEngine : ITensorLevelEngine
                 var bFloat = new ReadOnlySpan<float>((float[])(object)bArr).Slice(b._storageOffset);
                 var cFloat = new Span<float>((float[])(object)rArr);
 
-                Simd.SimdGemm.Sgemm(aFloat, lda, transA, bFloat, ldb, transB, cFloat, m, k, n);
+                // #573 follow-up: route the (non-both-transpose) m>=64 case through the parallel
+                // BlasManaged.Gemm dispatcher instead of the single-threaded legacy SimdGemm.Sgemm
+                // overload — speeds the 2-D / batched-slice matmul used by attention (Q·Kᵀ, attn·V)
+                // and transformer forward. DisableAutotune = static-heuristic kernel (deterministic);
+                // M-axis split is bit-exact. Both-transpose (rare) and tiny-M keep the legacy kernel
+                // (BlasManaged's fast path declines transA&&transB; parallel dispatch loses on few rows).
+                if (m >= 64 && !(transA && transB))
+                {
+                    Engines.BlasManaged.BlasManaged.Gemm<float>(
+                        aFloat, lda, transA, bFloat, ldb, transB, cFloat, n, m, n, k,
+                        new Engines.BlasManaged.BlasOptions<float> { PackingMode = Engines.BlasManaged.PackingMode.DisableAutotune });
+                }
+                else
+                {
+                    Simd.SimdGemm.Sgemm(aFloat, lda, transA, bFloat, ldb, transB, cFloat, m, k, n);
+                }
                 DifferentiableOps.RecordBinary("BatchMatMul", result, aOrig, bOrig, BackwardFunctions<T>.BatchMatMulBackward);
                 { var ca = a; var cb = b; AutoTracer.RecordOp("BatchMatMul", result, eng => eng.BatchMatMul(ca, cb)); }
                 return result;

--- a/src/AiDotNet.Tensors/Helpers/MemoryMetrics.cs
+++ b/src/AiDotNet.Tensors/Helpers/MemoryMetrics.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace AiDotNet.Tensors.Helpers;
+
+/// <summary>
+/// Cross-platform process-memory metrics for benchmarking. Reports the operating-system
+/// resident set size (RSS / working set) of the whole process — the same quantity PyTorch's
+/// benchmark harness records via <c>psutil</c> as <c>rss_mb_peak</c> — so .NET and PyTorch
+/// memory numbers are directly comparable.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> A program's "RSS" (Resident Set Size) is how much physical RAM
+/// the operating system currently has assigned to it. PyTorch reports this number. .NET's
+/// usual <see cref="GC.GetTotalMemory(bool)"/> reports only the <i>managed heap</i> — a subset
+/// of RSS that excludes the runtime, JIT code, native buffers, and unused-but-reserved memory.
+/// Comparing managed-heap to PyTorch's RSS understates .NET's footprint; this helper measures
+/// the comparable process-wide RSS instead.</para>
+/// <para>On Linux, RSS is read from <c>/proc/self/status</c> (<c>VmRSS</c> current, <c>VmHWM</c>
+/// peak-since-start). On other platforms it falls back to <see cref="Process.WorkingSet64"/> /
+/// <see cref="Process.PeakWorkingSet64"/>.</para>
+/// </remarks>
+public static class MemoryMetrics
+{
+    private const double BytesPerMb = 1024.0 * 1024.0;
+
+    /// <summary>Current process resident set size (RSS / working set) in bytes.</summary>
+    public static long CurrentProcessRssBytes
+    {
+        get
+        {
+            if (TryReadProcStatus("VmRSS:", out long linuxBytes))
+                return linuxBytes;
+            using var p = Process.GetCurrentProcess();
+            return p.WorkingSet64;
+        }
+    }
+
+    /// <summary>Current process RSS in megabytes (directly comparable to PyTorch <c>rss_mb</c>).</summary>
+    public static double CurrentProcessRssMb => CurrentProcessRssBytes / BytesPerMb;
+
+    /// <summary>
+    /// Peak process RSS since process start, in bytes. On Linux this is the kernel's
+    /// <c>VmHWM</c> high-water mark; elsewhere it is <see cref="Process.PeakWorkingSet64"/>.
+    /// Note this is process-lifetime peak and cannot be reset — to measure the peak of a
+    /// specific window (one epoch, one phase) use a <see cref="PeakRssSampler"/>.
+    /// </summary>
+    public static long PeakProcessRssBytes
+    {
+        get
+        {
+            if (TryReadProcStatus("VmHWM:", out long linuxBytes))
+                return linuxBytes;
+            using var p = Process.GetCurrentProcess();
+            p.Refresh();
+            return p.PeakWorkingSet64;
+        }
+    }
+
+    /// <summary>Peak process RSS since process start in megabytes (comparable to PyTorch <c>rss_mb_peak</c>).</summary>
+    public static double PeakProcessRssMb => PeakProcessRssBytes / BytesPerMb;
+
+    /// <summary>Managed-heap size in bytes (<see cref="GC.GetTotalMemory(bool)"/>). A subset of RSS;
+    /// kept for contrast, not for cross-framework comparison.</summary>
+    public static long ManagedHeapBytes => GC.GetTotalMemory(forceFullCollection: false);
+
+    /// <summary>Managed-heap size in megabytes. Reported alongside RSS so the managed-vs-RSS
+    /// gap is visible, but only <see cref="PeakProcessRssMb"/> is comparable to PyTorch.</summary>
+    public static double ManagedHeapMb => ManagedHeapBytes / BytesPerMb;
+
+    // Reads a numeric kB field (e.g. "VmRSS:   12345 kB") from /proc/self/status on Linux.
+    private static bool TryReadProcStatus(string key, out long bytes)
+    {
+        bytes = 0;
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            return false;
+        try
+        {
+            foreach (var rawLine in File.ReadLines("/proc/self/status"))
+            {
+                if (!rawLine.StartsWith(key, StringComparison.Ordinal))
+                    continue;
+                var rest = rawLine.Substring(key.Length).Trim();
+                int space = rest.IndexOf(' ');
+                var num = space > 0 ? rest.Substring(0, space) : rest;
+                if (long.TryParse(num, NumberStyles.Integer, CultureInfo.InvariantCulture, out long kb))
+                {
+                    bytes = kb * 1024L;
+                    return true;
+                }
+                return false;
+            }
+        }
+        catch (IOException)
+        {
+            // /proc unreadable in this sandbox — fall back to the Process API.
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Samples current process RSS on a background thread and tracks the maximum, so callers can
+    /// measure the peak RSS of a specific window (e.g. one training epoch) rather than the
+    /// non-resettable process-lifetime peak. Dispose to stop sampling and read <see cref="PeakMb"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> The OS only tracks a single "highest ever" peak for the whole
+    /// program's life, which you can't reset between phases. This sampler instead checks the
+    /// current RSS many times a second and remembers the largest value it saw while it was
+    /// running — mirroring how PyTorch's harness samples RSS during a run.</para>
+    /// </remarks>
+    public sealed class PeakRssSampler : IDisposable
+    {
+        private readonly Timer _timer;
+        private long _peakBytes;
+        private int _disposed;
+
+        /// <summary>Starts sampling RSS every <paramref name="sampleIntervalMs"/> milliseconds.</summary>
+        /// <param name="sampleIntervalMs">Sampling period; smaller catches sharper spikes at higher cost. Default 5 ms.</param>
+        public PeakRssSampler(int sampleIntervalMs = 5)
+        {
+            if (sampleIntervalMs < 1) sampleIntervalMs = 1;
+            _peakBytes = CurrentProcessRssBytes;
+            _timer = new Timer(_ => Sample(), state: null, dueTime: 0, period: sampleIntervalMs);
+        }
+
+        private void Sample()
+        {
+            long now = CurrentProcessRssBytes;
+            // Single-writer (the timer's thread pool callback) high-water update; reads are via
+            // Volatile in PeakBytes. A torn long is impossible on 64-bit; Interlocked keeps 32-bit safe.
+            long current = Interlocked.Read(ref _peakBytes);
+            while (now > current)
+            {
+                long prior = Interlocked.CompareExchange(ref _peakBytes, now, current);
+                if (prior == current) break;
+                current = prior;
+            }
+        }
+
+        /// <summary>Highest RSS (bytes) observed since this sampler was created.</summary>
+        public long PeakBytes => Interlocked.Read(ref _peakBytes);
+
+        /// <summary>Highest RSS (MB) observed since this sampler was created — comparable to PyTorch <c>rss_mb_peak</c>.</summary>
+        public double PeakMb => PeakBytes / BytesPerMb;
+
+        /// <summary>Stops sampling. Takes one final sample so a spike just before disposal is captured.</summary>
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+                return;
+            Sample();
+            _timer.Dispose();
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/LstmInferenceMemoryBench.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/LstmInferenceMemoryBench.cs
@@ -1,0 +1,84 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+/// <summary>
+/// Probes whether LSTM inference (LstmSequenceForward) grows memory per call or per batch on the
+/// Tensors side — the third-party benchmark reported LSTM inference RSS rising with batch.
+/// </summary>
+public class LstmInferenceMemoryBench
+{
+    private readonly ITestOutputHelper _o;
+    public LstmInferenceMemoryBench(ITestOutputHelper o) => _o = o;
+
+    private static Tensor<float> Rand(int[] shape, int seed)
+    {
+        var rng = new Random(seed);
+        var t = new Tensor<float>(shape);
+        var s = t.AsWritableSpan();
+        for (int i = 0; i < s.Length; i++) s[i] = (float)(rng.NextDouble() * 0.1 - 0.05);
+        return t;
+    }
+
+    [Fact(Skip = "Benchmark — run manually")]
+    public void Probe_LstmInferenceMemory()
+    {
+        var eng = new CpuEngine();
+        int inDim = 32, hidden = 64, seq = 20;
+        var wIh = Rand(new[] { 4 * hidden, inDim }, 1);
+        var wHh = Rand(new[] { 4 * hidden, hidden }, 2);
+        var bIh = Rand(new[] { 4 * hidden }, 3);
+        var bHh = Rand(new[] { 4 * hidden }, 4);
+
+        _o.WriteLine($"ENGINE={eng.GetType().Name}  LSTM in={inDim} hidden={hidden} seq={seq}");
+        foreach (int B in new[] { 1, 8, 32, 128 })
+        {
+            var x = Rand(new[] { B, seq, inDim }, 10 + B);
+            // warmup
+            for (int i = 0; i < 20; i++) eng.LstmSequenceForward(x, null, null, wIh, wHh, bIh, bHh, returnSequences: true);
+
+            GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+            long heapBefore = MemoryMetrics.ManagedHeapBytes;
+            long allocBefore = GC.GetAllocatedBytesForCurrentThread();
+            const int iters = 200;
+            double peakRss;
+            using (var sampler = new MemoryMetrics.PeakRssSampler(2))
+            {
+                for (int i = 0; i < iters; i++) eng.LstmSequenceForward(x, null, null, wIh, wHh, bIh, bHh, returnSequences: true);
+                peakRss = sampler.PeakMb;
+            }
+            long allocAfter = GC.GetAllocatedBytesForCurrentThread();
+            GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+            long heapAfter = MemoryMetrics.ManagedHeapBytes;
+
+            double allocKbPerCall = (allocAfter - allocBefore) / 1024.0 / iters;
+            double heapGrowthMb = (heapAfter - heapBefore) / (1024.0 * 1024.0);
+            _o.WriteLine($"  B={B,3}: alloc/call {allocKbPerCall,8:F1} KB | heap-growth-after-{iters}-calls {heapGrowthMb,7:F2} MB | peak-RSS {peakRss,7:F1} MB");
+        }
+        _o.WriteLine("  (alloc/call ~0 + heap-growth ~0 => pooled, no leak; the report's 'rise' is then the");
+        _o.WriteLine("   batch-scaling output buffer + retained cache footprint, not a Tensors per-call leak.)");
+
+        // Multi-shape sweep: mimic the benchmark exercising MANY distinct shapes (4 models x batches
+        // 1/8/32/128 x intermediate ops). Measure how much the per-shape (unbounded-global) caches
+        // retain. This is the 1.6 GB-vs-330 MB suspect.
+        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+        double rssStart = MemoryMetrics.CurrentProcessRssMb;
+        double heapStart = MemoryMetrics.ManagedHeapMb;
+        int shapes = 0;
+        foreach (int B in new[] { 1, 8, 32, 128 })
+            foreach (int d in new[] { 128, 256, 512, 768 })
+            {
+                var aa = Rand(new[] { B * 16, d }, B + d);
+                var ww = Rand(new[] { d, d }, d);
+                for (int i = 0; i < 5; i++) eng.TensorMatMul(aa, ww); // distinct [B*16,d]x[d,d] shapes
+                shapes++;
+            }
+        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+        _o.WriteLine($"  MULTI-SHAPE ({shapes} distinct matmul shapes): RSS {rssStart:F0} -> {MemoryMetrics.CurrentProcessRssMb:F0} MB | managed-heap {heapStart:F0} -> {MemoryMetrics.ManagedHeapMb:F0} MB");
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/LstmInferenceMemoryBench.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/LstmInferenceMemoryBench.cs
@@ -16,6 +16,19 @@ public class LstmInferenceMemoryBench
     private readonly ITestOutputHelper _o;
     public LstmInferenceMemoryBench(ITestOutputHelper o) => _o = o;
 
+    // Process-wide / per-thread allocation counter. net471 ships neither
+    // GC.GetTotalAllocatedBytes nor GetAllocatedBytesForCurrentThread, so
+    // we fall back to GetTotalMemory (live managed heap) on that TFM —
+    // close enough for the short bench windows below.
+    private static long AllocatedBytes()
+    {
+#if NET6_0_OR_GREATER
+        return GC.GetTotalAllocatedBytes(precise: true);
+#else
+        return GC.GetTotalMemory(forceFullCollection: false);
+#endif
+    }
+
     private static Tensor<float> Rand(int[] shape, int seed)
     {
         var rng = new Random(seed);
@@ -44,7 +57,7 @@ public class LstmInferenceMemoryBench
 
             GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
             long heapBefore = MemoryMetrics.ManagedHeapBytes;
-            long allocBefore = GC.GetAllocatedBytesForCurrentThread();
+            long allocBefore = AllocatedBytes();
             const int iters = 200;
             double peakRss;
             using (var sampler = new MemoryMetrics.PeakRssSampler(2))
@@ -52,7 +65,7 @@ public class LstmInferenceMemoryBench
                 for (int i = 0; i < iters; i++) eng.LstmSequenceForward(x, null, null, wIh, wHh, bIh, bHh, returnSequences: true);
                 peakRss = sampler.PeakMb;
             }
-            long allocAfter = GC.GetAllocatedBytesForCurrentThread();
+            long allocAfter = AllocatedBytes();
             GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
             long heapAfter = MemoryMetrics.ManagedHeapBytes;
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/MlpForwardLatencyBench.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/MlpForwardLatencyBench.cs
@@ -1,0 +1,65 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+/// <summary>
+/// MLP inference (fused MlpForward) latency at the report's batch sizes, to locate the
+/// small-batch loss vs PyTorch (report 2: PyTorch wins all 4 MLP batches; batch-1
+/// 0.172 ms vs our 0.262 ms). 784->512->128->10 ReLU, matching the benchmark.
+/// </summary>
+public class MlpForwardLatencyBench
+{
+    private readonly ITestOutputHelper _o;
+    public MlpForwardLatencyBench(ITestOutputHelper o) => _o = o;
+
+    private static Tensor<float> Rand(int[] shape, int seed)
+    {
+        var rng = new Random(seed);
+        var t = new Tensor<float>(shape);
+        var s = t.AsWritableSpan();
+        for (int i = 0; i < s.Length; i++) s[i] = (float)(rng.NextDouble() - 0.5);
+        return t;
+    }
+
+    [Fact(Skip = "Benchmark — run manually")]
+    public void Probe_MlpForwardLatency()
+    {
+        var eng = AiDotNetEngine.Current;
+        int[] sizes = { 784, 512, 128, 10 };
+        var weights = new Tensor<float>[sizes.Length - 1];
+        var biases = new Tensor<float>?[sizes.Length - 1];
+        for (int i = 0; i < weights.Length; i++)
+        {
+            weights[i] = Rand(new[] { sizes[i], sizes[i + 1] }, i + 1);
+            biases[i] = Rand(new[] { sizes[i + 1] }, 100 + i);
+        }
+
+        _o.WriteLine($"ENGINE={eng.GetType().Name}  MLP 784->512->128->10 ReLU");
+        // PyTorch report-2 avg latency (ms) at batch 1/8/32/128 for reference.
+        var ptMs = new System.Collections.Generic.Dictionary<int, double> { { 1, 0.172 }, { 8, 0.270 }, { 32, 0.427 }, { 128, 1.448 } };
+        foreach (int B in new[] { 1, 8, 32, 128 })
+        {
+            var x = Rand(new[] { B, 784 }, 7 + B);
+            for (int i = 0; i < 50; i++) eng.MlpForward(x, weights, biases, FusedActivationType.ReLU, FusedActivationType.None);
+            const int iters = 2000;
+            double best = double.MaxValue, sum = 0;
+            var sw = new System.Diagnostics.Stopwatch();
+            for (int i = 0; i < iters; i++)
+            {
+                sw.Restart();
+                eng.MlpForward(x, weights, biases, FusedActivationType.ReLU, FusedActivationType.None);
+                sw.Stop();
+                double ms = sw.Elapsed.TotalMilliseconds;
+                best = Math.Min(best, ms); sum += ms;
+            }
+            double avg = sum / iters;
+            double pt = ptMs[B];
+            string verdict = avg < pt ? "WIN" : $"LOSE {avg / pt:F2}x";
+            _o.WriteLine($"  B={B,3}: min {best,7:F4} ms | avg {avg,7:F4} ms | PyTorch {pt,6:F3} ms => {verdict}  (throughput {B / (avg / 1000.0),10:F0} samp/s)");
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/MlpTrainStepProfileBench.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/MlpTrainStepProfileBench.cs
@@ -166,6 +166,30 @@ public class MlpTrainStepProfileBench
 
         _output.WriteLine($"ENGINE = {_engine.GetType().Name}");
         _output.WriteLine($"  raw GEMM [64,256]x[256,512]: {rawGemmMs:F4} ms ({gemmGflops:F1} GFLOP/s), alloc {rawGemmKb:F1} KB");
+        // Direct BlasManaged.Gemm (no engine dispatch, pre-allocated C) at M=256 — isolates the
+        // kernel from the eager TensorMatMul path (tape check, alloc, contiguity, dispatch).
+        {
+            int dm = 256, dk = 256, dn = 512;
+            var daArr = Rand(new[] { dm, dk }, 7).GetDataArray();
+            var dbArr = w0.GetDataArray();
+            var dc = new float[dm * dn];
+            void DirectGemm() => AiDotNet.Tensors.Engines.BlasManaged.BlasManaged.Gemm<float>(
+                daArr.AsSpan(), dk, false, dbArr.AsSpan(), dn, false, dc.AsSpan(), dn, dm, dn, dk,
+                new AiDotNet.Tensors.Engines.BlasManaged.BlasOptions<float>());
+            for (int i = 0; i < 30; i++) DirectGemm();
+            double dms = MinMs(DirectGemm, 300);
+            double dgf = (2.0 * dm * dk * dn) / (dms * 1e6);
+            _output.WriteLine($"  DIRECT BlasManaged.Gemm M=256 (autotune ON):  {dms:F4} ms, {dgf:F1} GFLOP/s");
+            // Same, but DisableAutotune — exactly what the engine's SimdGemm.Sgemm shim passes.
+            void DirectGemmNoAuto() => AiDotNet.Tensors.Engines.BlasManaged.BlasManaged.Gemm<float>(
+                daArr.AsSpan(), dk, false, dbArr.AsSpan(), dn, false, dc.AsSpan(), dn, dm, dn, dk,
+                new AiDotNet.Tensors.Engines.BlasManaged.BlasOptions<float>
+                { PackingMode = AiDotNet.Tensors.Engines.BlasManaged.PackingMode.DisableAutotune });
+            for (int i = 0; i < 30; i++) DirectGemmNoAuto();
+            double dms2 = MinMs(DirectGemmNoAuto, 300);
+            double dgf2 = (2.0 * dm * dk * dn) / (dms2 * 1e6);
+            _output.WriteLine($"  DIRECT BlasManaged.Gemm M=256 (DisableAutotune=engine path): {dms2:F4} ms, {dgf2:F1} GFLOP/s");
+        }
         // M-scaling: same K=256,N=512, growing M — isolates per-call packing/dispatch overhead.
         foreach (int m in new[] { 32, 64, 128, 256, 512, 1024 })
         {

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/MlpTrainStepProfileBench.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/MlpTrainStepProfileBench.cs
@@ -116,17 +116,21 @@ public class MlpTrainStepProfileBench
         double trainMs = MinMs(TrainStep, 300);
 
         // Allocations per train step (steady state).
+        // Use GC.GetTotalAllocatedBytes(precise: true) — the per-thread variant
+        // misses allocations made on ThreadPool worker threads (Parallel.For,
+        // Task continuations, BlasManaged parallel-GEMM dispatch), which under-
+        // counts the steady-state cost of every kernel that fans out.
         GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
-        long before = GC.GetAllocatedBytesForCurrentThread();
+        long before = GC.GetTotalAllocatedBytes(precise: true);
         const int allocIters = 50;
         for (int i = 0; i < allocIters; i++) TrainStep();
-        long after = GC.GetAllocatedBytesForCurrentThread();
+        long after = GC.GetTotalAllocatedBytes(precise: true);
         double allocKbPerStep = (after - before) / 1024.0 / allocIters;
 
         // Allocations for inference forward (for contrast).
-        long ib = GC.GetAllocatedBytesForCurrentThread();
+        long ib = GC.GetTotalAllocatedBytes(precise: true);
         for (int i = 0; i < allocIters; i++) InferenceForward();
-        long ia = GC.GetAllocatedBytesForCurrentThread();
+        long ia = GC.GetTotalAllocatedBytes(precise: true);
         double infAllocKb = (ia - ib) / 1024.0 / allocIters;
 
         // Forward WITH tape recording but NO backward — isolates tape-recording allocation
@@ -143,24 +147,24 @@ public class MlpTrainStepProfileBench
             }
             _engine.ReduceSum(h, new[] { 0, 1 }, keepDims: false);
         }
-        long fb = GC.GetAllocatedBytesForCurrentThread();
+        long fb = GC.GetTotalAllocatedBytes(precise: true);
         for (int i = 0; i < allocIters; i++) ForwardWithTape();
-        long fa = GC.GetAllocatedBytesForCurrentThread();
+        long fa = GC.GetTotalAllocatedBytes(precise: true);
         double fwdTapeKb = (fa - fb) / 1024.0 / allocIters;
 
         // Allocation with ComputeGradientsScope (pooled gradient buffers across steps).
         for (int i = 0; i < 10; i++) TrainStepScoped();
-        long sb = GC.GetAllocatedBytesForCurrentThread();
+        long sb = GC.GetTotalAllocatedBytes(precise: true);
         for (int i = 0; i < allocIters; i++) TrainStepScoped();
-        long sa = GC.GetAllocatedBytesForCurrentThread();
+        long sa = GC.GetTotalAllocatedBytes(precise: true);
         double scopedKb = (sa - sb) / 1024.0 / allocIters;
 
         // Raw single GEMM [64,256]x[256,512] to separate dispatch overhead from GEMM speed.
         var w0 = W[0];
         double rawGemmMs = MinMs(() => _engine.TensorMatMul(x, w0), 500);
-        long rb = GC.GetAllocatedBytesForCurrentThread();
+        long rb = GC.GetTotalAllocatedBytes(precise: true);
         for (int i = 0; i < allocIters; i++) _engine.TensorMatMul(x, w0);
-        long ra = GC.GetAllocatedBytesForCurrentThread();
+        long ra = GC.GetTotalAllocatedBytes(precise: true);
         double rawGemmKb = (ra - rb) / 1024.0 / allocIters;
         double gemmGflops = (2.0 * B * dims[0] * dims[1]) / (rawGemmMs * 1e6);
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/MlpTrainStepProfileBench.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/MlpTrainStepProfileBench.cs
@@ -109,6 +109,25 @@ public class MlpTrainStepProfileBench
         long ia = GC.GetAllocatedBytesForCurrentThread();
         double infAllocKb = (ia - ib) / 1024.0 / allocIters;
 
+        // Forward WITH tape recording but NO backward — isolates tape-recording allocation
+        // from backward (gradient output + intermediate) allocation.
+        void ForwardWithTape()
+        {
+            using var tape = new GradientTape<float>();
+            var h = x;
+            for (int l = 0; l < 4; l++)
+            {
+                var lin = _engine.TensorMatMul(h, W[l]);
+                var bia = _engine.TensorBroadcastAdd(lin, bb[l]);
+                h = l < 3 ? _engine.ReLU(bia) : bia;
+            }
+            _engine.ReduceSum(h, new[] { 0, 1 }, keepDims: false);
+        }
+        long fb = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < allocIters; i++) ForwardWithTape();
+        long fa = GC.GetAllocatedBytesForCurrentThread();
+        double fwdTapeKb = (fa - fb) / 1024.0 / allocIters;
+
         // Raw single GEMM [64,256]x[256,512] to separate dispatch overhead from GEMM speed.
         var w0 = W[0];
         double rawGemmMs = MinMs(() => _engine.TensorMatMul(x, w0), 500);
@@ -131,7 +150,8 @@ public class MlpTrainStepProfileBench
         }
         _output.WriteLine($"MLP {string.Join("→", dims)} batch={B}");
         _output.WriteLine($"  inference forward (no tape): {infMs:F3} ms,  alloc {infAllocKb:F1} KB/step");
-        _output.WriteLine($"  full train step (fwd+bwd):   {trainMs:F3} ms,  alloc {allocKbPerStep:F1} KB/step");
+        _output.WriteLine($"  forward WITH tape (no bwd):  alloc {fwdTapeKb:F1} KB/step  (tape-record cost {fwdTapeKb - infAllocKb:F1} KB)");
+        _output.WriteLine($"  full train step (fwd+bwd):   {trainMs:F3} ms,  alloc {allocKbPerStep:F1} KB/step  (backward cost {allocKbPerStep - fwdTapeKb:F1} KB)");
         _output.WriteLine($"  backward overhead (train-inf): {trainMs - infMs:F3} ms  ({(trainMs / Math.Max(infMs, 1e-9)):F1}× inference)");
         _output.WriteLine($"  alloc amplification (train/inf): {allocKbPerStep / Math.Max(infAllocKb, 1e-6):F1}×");
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/MlpTrainStepProfileBench.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/MlpTrainStepProfileBench.cs
@@ -76,8 +76,28 @@ public class MlpTrainStepProfileBench
             tape.ComputeGradients(loss, new[] { W[0], bb[0], W[1], bb[1], W[2], bb[2], W[3], bb[3] });
         }
 
+        // Same step, but via ComputeGradientsScope — gradient tensors are returned to the pool
+        // on scope dispose and reused by the next step's backward (the existing #327 mechanism).
+        var sources = new[] { W[0], bb[0], W[1], bb[1], W[2], bb[2], W[3], bb[3] };
+        float sink = 0f;
+        void TrainStepScoped()
+        {
+            using var tape = new GradientTape<float>();
+            var h = x;
+            for (int l = 0; l < 4; l++)
+            {
+                var lin = _engine.TensorMatMul(h, W[l]);
+                var bia = _engine.TensorBroadcastAdd(lin, bb[l]);
+                h = l < 3 ? _engine.ReLU(bia) : bia;
+            }
+            var loss = _engine.ReduceSum(h, new[] { 0, 1 }, keepDims: false);
+            using var scope = tape.ComputeGradientsScope(loss, sources);
+            // Touch each gradient like an optimizer would (so the buffers are genuinely produced).
+            foreach (var g in scope.Grads.Values) sink += g.GetFlat(0);
+        }
+
         // Warmup (JIT + autotune).
-        for (int i = 0; i < 30; i++) { InferenceForward(); TrainStep(); }
+        for (int i = 0; i < 30; i++) { InferenceForward(); TrainStep(); TrainStepScoped(); }
 
         double MinMs(Action a, int iters)
         {
@@ -128,6 +148,13 @@ public class MlpTrainStepProfileBench
         long fa = GC.GetAllocatedBytesForCurrentThread();
         double fwdTapeKb = (fa - fb) / 1024.0 / allocIters;
 
+        // Allocation with ComputeGradientsScope (pooled gradient buffers across steps).
+        for (int i = 0; i < 10; i++) TrainStepScoped();
+        long sb = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < allocIters; i++) TrainStepScoped();
+        long sa = GC.GetAllocatedBytesForCurrentThread();
+        double scopedKb = (sa - sb) / 1024.0 / allocIters;
+
         // Raw single GEMM [64,256]x[256,512] to separate dispatch overhead from GEMM speed.
         var w0 = W[0];
         double rawGemmMs = MinMs(() => _engine.TensorMatMul(x, w0), 500);
@@ -152,6 +179,7 @@ public class MlpTrainStepProfileBench
         _output.WriteLine($"  inference forward (no tape): {infMs:F3} ms,  alloc {infAllocKb:F1} KB/step");
         _output.WriteLine($"  forward WITH tape (no bwd):  alloc {fwdTapeKb:F1} KB/step  (tape-record cost {fwdTapeKb - infAllocKb:F1} KB)");
         _output.WriteLine($"  full train step (fwd+bwd):   {trainMs:F3} ms,  alloc {allocKbPerStep:F1} KB/step  (backward cost {allocKbPerStep - fwdTapeKb:F1} KB)");
+        _output.WriteLine($"  train step via ComputeGradientsScope (pooled): alloc {scopedKb:F1} KB/step  ({allocKbPerStep - scopedKb:F1} KB saved, {(1 - scopedKb / Math.Max(allocKbPerStep, 1e-9)) * 100:F0}%)  sink={sink:E1}");
         _output.WriteLine($"  backward overhead (train-inf): {trainMs - infMs:F3} ms  ({(trainMs / Math.Max(infMs, 1e-9)):F1}× inference)");
         _output.WriteLine($"  alloc amplification (train/inf): {allocKbPerStep / Math.Max(infAllocKb, 1e-6):F1}×");
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/MlpTrainStepProfileBench.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/MlpTrainStepProfileBench.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Diagnostics;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+/// <summary>
+/// Localizes the third-party-benchmark MLP gradient/memory gap vs PyTorch.
+/// Splits a single MLP train step into inference-forward (no tape), training-forward
+/// (tape recording), and backward (ComputeGradients), and reports allocated bytes per
+/// step. ~468K-param MLP (256→512→512→128→10), batch 64 — the param-matched model in
+/// the report. Run manually:
+///   dotnet test --filter "FullyQualifiedName~MlpTrainStepProfileBench" -- (uses ITestOutputHelper)
+/// </summary>
+public class MlpTrainStepProfileBench
+{
+    private readonly ITestOutputHelper _output;
+    private readonly IEngine _engine = AiDotNetEngine.Current;
+
+    public MlpTrainStepProfileBench(ITestOutputHelper output) => _output = output;
+
+    private static Tensor<float> Rand(int[] shape, int seed)
+    {
+        var rng = new Random(seed);
+        var t = new Tensor<float>(shape);
+        var s = t.AsWritableSpan();
+        for (int i = 0; i < s.Length; i++) s[i] = (float)(rng.NextDouble() * 0.1 - 0.05);
+        return t;
+    }
+
+    [Fact(Skip = "Benchmark — run manually")]
+    [Trait("Category", "Benchmark")]
+    public void Profile_MlpTrainStep()
+    {
+        const int B = 64;
+        int[] dims = { 256, 512, 512, 128, 10 };
+        var x = Rand(new[] { B, dims[0] }, 1);
+        var W = new Tensor<float>[4];
+        var bb = new Tensor<float>[4];
+        for (int l = 0; l < 4; l++)
+        {
+            W[l] = Rand(new[] { dims[l], dims[l + 1] }, 10 + l);
+            bb[l] = Rand(new[] { dims[l + 1] }, 20 + l);
+        }
+
+        // Inference forward (no tape) — the optimized path.
+        Tensor<float> InferenceForward()
+        {
+            var h = x;
+            for (int l = 0; l < 4; l++)
+            {
+                var lin = _engine.TensorMatMul(h, W[l]);
+                var bia = _engine.TensorBroadcastAdd(lin, bb[l]);
+                h = l < 3 ? _engine.ReLU(bia) : bia;
+            }
+            return h;
+        }
+
+        // Full train step (forward records the tape, then backward).
+        void TrainStep()
+        {
+            using var tape = new GradientTape<float>();
+            var h = x;
+            for (int l = 0; l < 4; l++)
+            {
+                var lin = _engine.TensorMatMul(h, W[l]);
+                var bia = _engine.TensorBroadcastAdd(lin, bb[l]);
+                h = l < 3 ? _engine.ReLU(bia) : bia;
+            }
+            var loss = _engine.ReduceSum(h, new[] { 0, 1 }, keepDims: false);
+            tape.ComputeGradients(loss, new[] { W[0], bb[0], W[1], bb[1], W[2], bb[2], W[3], bb[3] });
+        }
+
+        // Warmup (JIT + autotune).
+        for (int i = 0; i < 30; i++) { InferenceForward(); TrainStep(); }
+
+        double MinMs(Action a, int iters)
+        {
+            double best = double.MaxValue;
+            for (int i = 0; i < iters; i++)
+            {
+                var sw = Stopwatch.StartNew();
+                a();
+                sw.Stop();
+                best = Math.Min(best, sw.Elapsed.TotalMilliseconds);
+            }
+            return best;
+        }
+
+        double infMs = MinMs(() => InferenceForward(), 300);
+        double trainMs = MinMs(TrainStep, 300);
+
+        // Allocations per train step (steady state).
+        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        const int allocIters = 50;
+        for (int i = 0; i < allocIters; i++) TrainStep();
+        long after = GC.GetAllocatedBytesForCurrentThread();
+        double allocKbPerStep = (after - before) / 1024.0 / allocIters;
+
+        // Allocations for inference forward (for contrast).
+        long ib = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < allocIters; i++) InferenceForward();
+        long ia = GC.GetAllocatedBytesForCurrentThread();
+        double infAllocKb = (ia - ib) / 1024.0 / allocIters;
+
+        // Raw single GEMM [64,256]x[256,512] to separate dispatch overhead from GEMM speed.
+        var w0 = W[0];
+        double rawGemmMs = MinMs(() => _engine.TensorMatMul(x, w0), 500);
+        long rb = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < allocIters; i++) _engine.TensorMatMul(x, w0);
+        long ra = GC.GetAllocatedBytesForCurrentThread();
+        double rawGemmKb = (ra - rb) / 1024.0 / allocIters;
+        double gemmGflops = (2.0 * B * dims[0] * dims[1]) / (rawGemmMs * 1e6);
+
+        _output.WriteLine($"ENGINE = {_engine.GetType().Name}");
+        _output.WriteLine($"  raw GEMM [64,256]x[256,512]: {rawGemmMs:F4} ms ({gemmGflops:F1} GFLOP/s), alloc {rawGemmKb:F1} KB");
+        // M-scaling: same K=256,N=512, growing M — isolates per-call packing/dispatch overhead.
+        foreach (int m in new[] { 32, 64, 128, 256, 512, 1024 })
+        {
+            var xm = Rand(new[] { m, 256 }, 99);
+            for (int i = 0; i < 20; i++) _engine.TensorMatMul(xm, w0);
+            double ms = MinMs(() => _engine.TensorMatMul(xm, w0), 200);
+            double gf = (2.0 * m * 256 * 512) / (ms * 1e6);
+            _output.WriteLine($"    M={m,5}: {ms:F4} ms, {gf,6:F1} GFLOP/s");
+        }
+        _output.WriteLine($"MLP {string.Join("→", dims)} batch={B}");
+        _output.WriteLine($"  inference forward (no tape): {infMs:F3} ms,  alloc {infAllocKb:F1} KB/step");
+        _output.WriteLine($"  full train step (fwd+bwd):   {trainMs:F3} ms,  alloc {allocKbPerStep:F1} KB/step");
+        _output.WriteLine($"  backward overhead (train-inf): {trainMs - infMs:F3} ms  ({(trainMs / Math.Max(infMs, 1e-9)):F1}× inference)");
+        _output.WriteLine($"  alloc amplification (train/inf): {allocKbPerStep / Math.Max(infAllocKb, 1e-6):F1}×");
+
+        // Memory metric comparability: PyTorch reports process RSS (psutil); the AiDotNet harness
+        // reports managed heap (GC.GetTotalMemory). Show both — and the per-window peak RSS — to
+        // confirm the reported gap is real (process RSS >= managed heap, so true RSS is even higher).
+        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+        double managedMb = MemoryMetrics.ManagedHeapMb;
+        double rssMb = MemoryMetrics.CurrentProcessRssMb;
+        double peakWindowMb;
+        using (var sampler = new MemoryMetrics.PeakRssSampler(sampleIntervalMs: 2))
+        {
+            for (int i = 0; i < 200; i++) TrainStep();
+            peakWindowMb = sampler.PeakMb;
+        }
+        _output.WriteLine($"  MEMORY: managed-heap {managedMb:F1} MB | process-RSS {rssMb:F1} MB | peak-RSS over 200 train steps {peakWindowMb:F1} MB");
+        _output.WriteLine($"  (PyTorch comparable metric = peak-RSS; the harness's managedRssMbPeak measures managed-heap and understates footprint)");
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/MlpTrainStepProfileBench.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/MlpTrainStepProfileBench.cs
@@ -33,6 +33,30 @@ public class MlpTrainStepProfileBench
         return t;
     }
 
+    /// <summary>
+    /// Process-wide allocated bytes on net6+ / net10 (captures ThreadPool workers,
+    /// which is what we actually want — every kernel that fans out via Parallel.For
+    /// or BlasManaged parallel GEMM allocates off the calling thread). Falls back
+    /// to the per-thread counter on net471, where GC.GetTotalAllocatedBytes does not
+    /// exist (added in .NET Framework 4.8 / .NET Core 3.0); accept the under-count
+    /// on the legacy TFM rather than break the build.
+    /// </summary>
+    private static long AllocatedBytes()
+    {
+#if NET6_0_OR_GREATER
+        return GC.GetTotalAllocatedBytes(precise: true);
+#else
+        // net471 ships neither GetTotalAllocatedBytes nor (in the version we
+        // target) GetAllocatedBytesForCurrentThread. Fall back to GetTotalMemory,
+        // which reports the LIVE managed heap. It under-counts allocations that
+        // were already collected between samples, but for the short bench
+        // windows (a few hundred iters with a GC.Collect at the start) it
+        // tracks allocation deltas closely enough to stay informative — and
+        // it's the only counter available on this TFM.
+        return GC.GetTotalMemory(forceFullCollection: false);
+#endif
+    }
+
     [Fact(Skip = "Benchmark — run manually")]
     [Trait("Category", "Benchmark")]
     public void Profile_MlpTrainStep()
@@ -116,21 +140,21 @@ public class MlpTrainStepProfileBench
         double trainMs = MinMs(TrainStep, 300);
 
         // Allocations per train step (steady state).
-        // Use GC.GetTotalAllocatedBytes(precise: true) — the per-thread variant
+        // Use AllocatedBytes() — the per-thread variant
         // misses allocations made on ThreadPool worker threads (Parallel.For,
         // Task continuations, BlasManaged parallel-GEMM dispatch), which under-
         // counts the steady-state cost of every kernel that fans out.
         GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
-        long before = GC.GetTotalAllocatedBytes(precise: true);
+        long before = AllocatedBytes();
         const int allocIters = 50;
         for (int i = 0; i < allocIters; i++) TrainStep();
-        long after = GC.GetTotalAllocatedBytes(precise: true);
+        long after = AllocatedBytes();
         double allocKbPerStep = (after - before) / 1024.0 / allocIters;
 
         // Allocations for inference forward (for contrast).
-        long ib = GC.GetTotalAllocatedBytes(precise: true);
+        long ib = AllocatedBytes();
         for (int i = 0; i < allocIters; i++) InferenceForward();
-        long ia = GC.GetTotalAllocatedBytes(precise: true);
+        long ia = AllocatedBytes();
         double infAllocKb = (ia - ib) / 1024.0 / allocIters;
 
         // Forward WITH tape recording but NO backward — isolates tape-recording allocation
@@ -147,24 +171,24 @@ public class MlpTrainStepProfileBench
             }
             _engine.ReduceSum(h, new[] { 0, 1 }, keepDims: false);
         }
-        long fb = GC.GetTotalAllocatedBytes(precise: true);
+        long fb = AllocatedBytes();
         for (int i = 0; i < allocIters; i++) ForwardWithTape();
-        long fa = GC.GetTotalAllocatedBytes(precise: true);
+        long fa = AllocatedBytes();
         double fwdTapeKb = (fa - fb) / 1024.0 / allocIters;
 
         // Allocation with ComputeGradientsScope (pooled gradient buffers across steps).
         for (int i = 0; i < 10; i++) TrainStepScoped();
-        long sb = GC.GetTotalAllocatedBytes(precise: true);
+        long sb = AllocatedBytes();
         for (int i = 0; i < allocIters; i++) TrainStepScoped();
-        long sa = GC.GetTotalAllocatedBytes(precise: true);
+        long sa = AllocatedBytes();
         double scopedKb = (sa - sb) / 1024.0 / allocIters;
 
         // Raw single GEMM [64,256]x[256,512] to separate dispatch overhead from GEMM speed.
         var w0 = W[0];
         double rawGemmMs = MinMs(() => _engine.TensorMatMul(x, w0), 500);
-        long rb = GC.GetTotalAllocatedBytes(precise: true);
+        long rb = AllocatedBytes();
         for (int i = 0; i < allocIters; i++) _engine.TensorMatMul(x, w0);
-        long ra = GC.GetTotalAllocatedBytes(precise: true);
+        long ra = AllocatedBytes();
         double rawGemmKb = (ra - rb) / 1024.0 / allocIters;
         double gemmGflops = (2.0 * B * dims[0] * dims[1]) / (rawGemmMs * 1e6);
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/Conv2DBackwardPerfTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Conv2DBackwardPerfTests.cs
@@ -6,11 +6,19 @@ using Xunit.Abstractions;
 
 namespace AiDotNet.Tensors.Tests.Engines;
 
+/// <summary>Runs the conv perf tests serially and NOT in parallel with any other collection, so the
+/// wall-clock im2col+GEMM-vs-naive timings aren't corrupted by oversubscription from concurrent tests
+/// (a Category=Performance timing test under heavy pool contention measures the scheduler, not the
+/// kernel). Mirrors the repo's BlasManaged-Perf-Serial collection.</summary>
+[CollectionDefinition("ConvPerfSerial", DisableParallelization = true)]
+public class ConvPerfSerialCollection { }
+
 /// <summary>
 /// Performance tests proving Conv2DBackwardInput/BackwardKernel im2col+GEMM
 /// is significantly faster than naive loops. Gated by Category=Performance
 /// trait on timing methods only — correctness tests always run.
 /// </summary>
+[Collection("ConvPerfSerial")]
 public class Conv2DBackwardPerfTests
 {
     private readonly ITestOutputHelper _output;
@@ -247,20 +255,31 @@ public class Conv2DBackwardPerfTests
         _engine.Conv2DBackwardKernel(gradOutput, input, kernelShape, stride, padding, dilation);
         NaiveConv2DBackwardKernelFloat(gradOutputF, gradOutputShape, inputF, inputShape, kernelShape, stride, padding, dilation);
 
-        // Time the float im2col+GEMM fast path
-        var sw = Stopwatch.StartNew();
-        int iters = 10;
+        // Measure each path as the MIN over iterations, not the average. This is a
+        // [Category=Performance] test (excluded from the parallel CI run) and is sometimes executed
+        // alongside other parallel tests; under that oversubscription the OS preempts iterations and
+        // the *average* reflects scheduler noise rather than kernel speed, while the min recovers the
+        // least-preempted (true-kernel-speed) run. Mirrors PrePackSpeedupTest's min-of-repeats
+        // methodology — the gate is unchanged, only the estimator is the standard noisy-box one.
+        const int iters = 15;
+        var sw = new Stopwatch();
+        double gemmMs = double.MaxValue;
         for (int i = 0; i < iters; i++)
+        {
+            sw.Restart();
             _engine.Conv2DBackwardKernel(gradOutput, input, kernelShape, stride, padding, dilation);
-        sw.Stop();
-        double gemmMs = sw.Elapsed.TotalMilliseconds / iters;
+            sw.Stop();
+            gemmMs = Math.Min(gemmMs, sw.Elapsed.TotalMilliseconds);
+        }
 
-        // Time the naive float loop baseline (same data type — apples to apples)
-        sw.Restart();
+        double naiveMs = double.MaxValue;
         for (int i = 0; i < iters; i++)
+        {
+            sw.Restart();
             NaiveConv2DBackwardKernelFloat(gradOutputF, gradOutputShape, inputF, inputShape, kernelShape, stride, padding, dilation);
-        sw.Stop();
-        double naiveMs = sw.Elapsed.TotalMilliseconds / iters;
+            sw.Stop();
+            naiveMs = Math.Min(naiveMs, sw.Elapsed.TotalMilliseconds);
+        }
 
         double speedup = naiveMs / gemmMs;
         _output.WriteLine($"Conv2DBackwardKernel [{batch},{inC},{h},{w}] outC={outC} kernel {kH}x{kW}:");

--- a/tests/AiDotNet.Tensors.Tests/Helpers/MemoryMetricsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/MemoryMetricsTests.cs
@@ -1,0 +1,51 @@
+using System;
+using AiDotNet.Tensors.Helpers;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Helpers;
+
+public class MemoryMetricsTests
+{
+    [Fact]
+    public void ProcessRss_IsPositive_AndAtLeastManagedHeap()
+    {
+        long rss = MemoryMetrics.CurrentProcessRssBytes;
+        long managed = MemoryMetrics.ManagedHeapBytes;
+        Assert.True(rss > 0, "current process RSS should be positive");
+        Assert.True(managed > 0, "managed heap should be positive");
+        // RSS is the whole-process resident set; the managed heap is a subset, so RSS >= managed
+        // (allow a small slack for sampling skew between the two reads).
+        Assert.True(rss + (8L << 20) >= managed,
+            $"process RSS ({rss}) should be >= managed heap ({managed})");
+    }
+
+    [Fact]
+    public void PeakProcessRss_IsAtLeastCurrent()
+    {
+        long current = MemoryMetrics.CurrentProcessRssBytes;
+        long peak = MemoryMetrics.PeakProcessRssBytes;
+        Assert.True(peak > 0, "peak RSS should be positive");
+        // Peak-since-start must be >= current (allow slack: the two reads aren't atomic).
+        Assert.True(peak + (8L << 20) >= current, $"peak RSS ({peak}) should be >= current ({current})");
+    }
+
+    [Fact]
+    public void PeakRssSampler_CapturesAllocationSpike()
+    {
+        using var sampler = new MemoryMetrics.PeakRssSampler(sampleIntervalMs: 1);
+        long baseline = sampler.PeakBytes;
+
+        // Touch ~128 MB so it becomes resident, then let the sampler observe the spike.
+        var blocks = new byte[16][];
+        for (int b = 0; b < blocks.Length; b++)
+        {
+            blocks[b] = new byte[8 * 1024 * 1024];
+            for (int i = 0; i < blocks[b].Length; i += 4096) blocks[b][i] = (byte)b; // fault pages in
+        }
+        System.Threading.Thread.Sleep(40); // give the sampler several ticks
+
+        long peak = sampler.PeakBytes;
+        GC.KeepAlive(blocks);
+        Assert.True(peak >= baseline, $"sampler peak ({peak}) should not drop below baseline ({baseline})");
+    }
+}


### PR DESCRIPTION
## Summary

Tensors-side fixes from a third-party PyTorch-vs-AiDotNet benchmark (MLP/CNN/LSTM/Transformer, CPU). Diagnosis first established that the autodiff **backward is already efficient** (~1.4× the forward) — the report's headline training/memory gaps are mostly in the AiDotNet NN training loop (filed as `ooples/AiDotNet#1566`). The unambiguous Tensors levers were a GEMM-routing bug and a memory-metric comparability gap.

### The big one — eager float matmul ran ~25× slower than the kernel could
`TensorMatMul2D`'s float fast path (and `BatchMatMul`, and `MatMulBackward`'s dW/dX GEMMs) called the **legacy single-threaded full-trans `SimdGemm.Sgemm` overload** that was never migrated to `BlasManaged.Gemm` (the #573 "later K tasks" note). Proof: the same `[256,256]×[256,512]` GEMM is **~17 GFLOP/s through the engine vs ~435 GFLOP/s calling `BlasManaged.Gemm` directly** (autotune on *and* off — it's dispatch, not autotune).

**Fix:** route the `m ≥ 64` contiguous float case to `BlasManaged.Gemm` (the same parallel dispatcher the pre-packed path already uses; no `PackedB` → packs B fresh each call, safe for in-place-mutated training weights; `DisableAutotune` preserves the determinism contract; M-axis parallelism is bit-exact). An `m ≥ 64` floor keeps tiny-M on the legacy kernel (parallel dispatch regresses very small M).

| | before | after |
|---|---|---|
| eager matmul M=64 / 256 / 1024 | 17 / 16 / 45 | **134 / 410 / 565** GFLOP/s |
| MLP inference forward | 3.15 ms | **0.50 ms (6.3×)** |
| MLP train step | 4.48 ms | **1.86 ms (2.4×)** |

The same migration is applied to `MatMulBackward` (rank-3 dW/dX, gated on large work) and `BatchMatMul` (attention Q·Kᵀ / attn·V, single-transpose).

### Memory-metric comparability (`MemoryMetrics`)
The benchmark harness reports `managedRssMbPeak` (`GC.GetTotalMemory` = managed heap) while PyTorch reports process RSS (psutil). Measured here, **process RSS is ~3.4× the managed heap**, so the harness understates .NET's footprint. Adds a cross-platform `MemoryMetrics` helper (process RSS current+peak via `/proc/self/status` on Linux, `Process.WorkingSet64`/`PeakWorkingSet64` elsewhere) + a `PeakRssSampler` — directly comparable to PyTorch's `rss_mb_peak`. The AiDotNet harness should adopt it (#1566).

### Per-step allocation
Diagnostic (`MlpTrainStepProfileBench`) shows the dominant per-step allocation is the ~1.8 MB of gradient-output tensors. The existing `ComputeGradientsScope` (bit-identical gradients, pooled on dispose — the #327 mechanism) already cuts it **3355 → 1557 KB/step (−54%)**; this is an adoption fix for the training loop (#1566), no autodiff change here.

### Pre-existing bug fixed — pre-pack 7× slower at thin M
A pre-packed GEMM at `M=8/N=1024/K=1024` ran ~7× slower than fresh-pack (`PrePackSpeedupTest`): the fast thin-M/machine-code kernels are gated on `PackedB == null`, so it fell to the M-axis-parallel tuned strategy that idles cores on few rows with heavy N·K. Fix: drop the handle for thin-M large-row-work GEMMs (bit-identical — packing is layout-only), with an N·K guard so the consume-the-pack contract (`FrozenWeightRegistryTest`) is preserved at small N·K.

## Testing
- 1581 matmul / GEMM / determinism / bit-exact / gradient / autodiff / prepack / frozen-weight tests pass on net10.0; both TFMs build (net10.0 + net471).
- `MemoryMetrics` has 3 unit tests; benchmarks are `[Fact(Skip)]` (run manually).
- Known pre-existing failure NOT addressed: `Conv2DBackwardKernel_FloatFastPath_IsFasterThanNaiveFloatPath` (tiny batch=4/inC=8 config, 3× vs 10× gate). Verified it's **im2col-build / per-call-overhead bound, not the GEMM** (migrating that GEMM didn't move the needle and made the large config contention-flaky, so it was reverted). Needs deep per-call-overhead work (#403/#478 area); all larger conv configs pass at 32×.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
