### PR TITLE
perf(blas): park idle StreamingWorkerPool workers instead of yield-spinning (#589)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Pool/StreamingWorkerPool.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Pool/StreamingWorkerPool.cs
@@ -74,6 +74,21 @@ internal static class StreamingWorkerPool
     internal static void ResetPoolStats()
     { s_parallelDispatches = 0; s_serialBelowGrain = 0; s_serialContended = 0; s_parkEvents = 0; }
 
+    /// <summary>
+    /// Idle SpinWait budget before an idle worker parks on its event (issue #589).
+    /// SpinWait(1) emits a HT-friendly `pause` and covers the sub-10µs gaps between
+    /// back-to-back GEMM dispatches so a burst stays hot without park/wake churn. The
+    /// old loop ALSO spent iterations 1000-5000 in Thread.Yield(), which under a busy
+    /// co-running workload (e.g. conv on the other parallel path) returns immediately —
+    /// keeping the idle worker runnable, re-checking, yielding again, and oversubscribing
+    /// the cores the real work needs (measured: ~47% of busy CPU wasted in the worker
+    /// loops during conv-dominated diffusion sampling). Parking right after the SpinWait
+    /// budget makes idle workers release the cores within ~10µs; the next dispatch wakes
+    /// them via the park event. GEMM dispatch is grain-gated, so the µs-scale wake latency
+    /// is negligible against the pooled work.
+    /// </summary>
+    private const int IdleSpinBeforePark = 1000;
+
     private static void WorkerLoop(int slot)
     {
         long lastSeq = 0;
@@ -83,14 +98,9 @@ internal static class StreamingWorkerPool
             int spinCount = 0;
             while (Volatile.Read(ref _slots[slot].Seq) == lastSeq)
             {
-                if (spinCount < 1000)
+                if (spinCount < IdleSpinBeforePark)
                 {
                     Thread.SpinWait(1);
-                    spinCount++;
-                }
-                else if (spinCount < 5000)
-                {
-                    Thread.Yield();
                     spinCount++;
                 }
                 else

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/StreamingWorkerPoolIdleSpinTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/StreamingWorkerPoolIdleSpinTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using AiDotNet.Tensors.Engines.BlasManaged.Pool;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+/// <summary>
+/// Issue #589 regression guard: idle StreamingWorkerPool workers must PARK between
+/// dispatches rather than busy-spin. The old loop spent iterations 1000-5000 in
+/// Thread.Yield(), which under a co-running workload keeps the idle worker runnable and
+/// oversubscribes the cores the real work needs (~47% of busy CPU wasted during conv-
+/// dominated diffusion sampling, a 55-minute CI shard hang).
+///
+/// The test measures the EXTRA process CPU the pool's idle workers add across a series of
+/// (dispatch → single-threaded busy gap) cycles, versus the busy gaps alone. A parking
+/// pool adds only µs-scale wake overhead; a spinning pool adds ~cores × gap time. Marked
+/// Performance (CI excludes it) because it reads wall/CPU timing; run manually to verify.
+/// </summary>
+[Collection("BlasManaged-Perf-Serial")]
+[Trait("Category", "Performance")]
+public class StreamingWorkerPoolIdleSpinTests
+{
+    private readonly ITestOutputHelper _o;
+    public StreamingWorkerPoolIdleSpinTests(ITestOutputHelper o) => _o = o;
+
+    // Deterministic single-threaded CPU work (the stand-in for the "conv on the other
+    // parallel path" that the idle GEMM-pool spinners were stealing cycles from).
+    private static long BusyWork(int iterations)
+    {
+        long s = 1;
+        for (int i = 0; i < iterations; i++)
+            s = unchecked(s * 6364136223846793005L + 1442695040888963407L) ^ (s >> 7);
+        return s;
+    }
+
+    [Fact]
+    public void IdleWorkers_ParkBetweenDispatches_DoNotOversubscribe()
+    {
+        int chunks = Math.Max(2, Environment.ProcessorCount);
+        Action<int> tiny = _ => { };
+        const int cycles = 150;
+        const int gapIters = 3_000_000;
+
+        // Warm up: initialize the pool + JIT both paths, then let workers park.
+        long sink = 0;
+        for (int i = 0; i < 30; i++) { StreamingWorkerPool.Dispatch(chunks, 1 << 20, tiny); sink += BusyWork(gapIters); }
+        Thread.Sleep(150);
+
+        var proc = Process.GetCurrentProcess();
+
+        // Baseline: busy gaps only. The pool gets no dispatches, so its workers stay parked.
+        var t0 = proc.TotalProcessorTime;
+        for (int i = 0; i < cycles; i++) sink += BusyWork(gapIters);
+        double baseline = (proc.TotalProcessorTime - t0).TotalMilliseconds;
+
+        // With pool: each gap is preceded by a dispatch that wakes the workers; they then
+        // go idle for the duration of the single-threaded gap. Parked workers add ≈0 CPU;
+        // workers spinning across all cores add roughly cores × gap time.
+        var t1 = proc.TotalProcessorTime;
+        for (int i = 0; i < cycles; i++) { StreamingWorkerPool.Dispatch(chunks, 1 << 20, tiny); sink += BusyWork(gapIters); }
+        double withPool = (proc.TotalProcessorTime - t1).TotalMilliseconds;
+
+        double excess = withPool - baseline;
+        _o.WriteLine($"cores={Environment.ProcessorCount} baseline={baseline:F0}ms withPool={withPool:F0}ms excess={excess:F0}ms sink={sink}");
+
+        // The idle pool must add LESS than the real work itself. A spinning pool adds many
+        // multiples of `baseline` (one busy core of real work vs ~cores of idle spinning).
+        Assert.True(excess < baseline,
+            $"idle StreamingWorkerPool workers oversubscribed (#589): baseline {baseline:F0}ms vs withPool {withPool:F0}ms " +
+            $"(excess {excess:F0}ms must be < {baseline:F0}ms). Workers spinning instead of parking?");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #589. Idle `StreamingWorkerPool` workers busy-spun via `Thread.Yield()` while a co-running workload ran on the other parallel path, oversubscribing the cores the real work needed (~47% of busy CPU wasted during conv-dominated diffusion sampling — compounded into a 55-minute CI shard hang on ooples/AiDotNet#1562).

## Root cause

The idle worker wait was a two-phase spin: `1000 × SpinWait(1)` then `4000 × Thread.Yield()` before parking on the slot event. `Thread.Yield()` returns immediately when other threads are runnable, so under a co-running workload the idle GEMM worker stays runnable — re-checks its sequence, yields again — competing with the real work for cores. The trace showed the pool worker loops at ~47% of busy CPU with no useful frames below them, while the actual conv path got only ~6%.

## Fix

Drop the `Yield()` phase; **park right after the `SpinWait` budget** (`IdleSpinBeforePark = 1000`). The `SpinWait` phase (HT-friendly `pause`) still covers the sub-10µs gaps between back-to-back GEMM dispatches so a burst stays hot, but idle workers now release the cores within ~10µs and wake via the park event on the next dispatch. GEMM dispatch is grain-gated, so the µs-scale wake latency is negligible against pooled work. The park protocol itself (Dekker-style fence + re-check that guards the lost-wakeup deadlock) is **unchanged**.

`CooperativeGemmScheduler` already parks idle workers on a semaphore, so no change there.

## Proof (fail-before / pass-after)

`StreamingWorkerPoolIdleSpinTests` measures the **extra process CPU** the idle pool adds across 150 `(dispatch → single-threaded busy gap)` cycles, versus the busy gaps alone (a parking pool adds only µs-scale wake overhead; a spinning pool adds ~cores × gap time):

| | baseline | withPool | excess (idle-pool CPU) | result |
|---|---:|---:|---:|---|
| old Yield phase (bug) | 938 ms | 3859 ms | **2922 ms** | ❌ FAIL |
| fix (park promptly) | 891 ms | 1047 ms | **156 ms** | ✅ PASS |

~19× less wasted CPU. Verified by toggling the Yield phase back in to confirm the test fails, then restoring the fix.

## Testing
- `StreamingWorkerPoolIdleSpinTests` (new, the regression guard above; `Category=Performance`).
- 26 pool tests green (StreamingWorkerPool + CooperativeScheduler concurrency/deadlock/integration).
- Builds on net10.0 + net471.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
