### PR TITLE
perf(lstm): parallelize GEMMs + vectorize exact activations + pool backward scratch (1.60x at hidden=256)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.LstmSequenceBackward.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.LstmSequenceBackward.cs
@@ -64,6 +64,39 @@ public partial class CpuEngine
     }
 
     /// <summary>
+    /// In-place exact sigmoid over <c>buf[off..off+len)</c>: 1/(1+exp(-x)). Uses
+    /// <see cref="SimdKernels.ExpUnsafe"/> (near-exact VML/Herumi vectorized exp on AVX, scalar
+    /// elsewhere) for the expensive transcendental; the cheap negate/reciprocal stay scalar. The
+    /// exp(-x) form is overflow-safe (large |x| → 0 or 1, never NaN). Result matches the scalar
+    /// Math.Exp sigmoid to ~1e-6, so the saved gate values — and the σ(1-σ) gradients computed
+    /// from them — are unchanged within the finite-difference tolerance.
+    /// </summary>
+    private static unsafe void SigmoidExactInPlace(float[] buf, int off, int len)
+    {
+        fixed (float* p = &buf[off])
+        {
+            for (int i = 0; i < len; i++) p[i] = -p[i];
+            SimdKernels.ExpUnsafe(p, p, len);
+            for (int i = 0; i < len; i++) p[i] = 1f / (1f + p[i]);
+        }
+    }
+
+    /// <summary>
+    /// In-place exact tanh over <c>buf[off..off+len)</c> via the overflow-safe identity
+    /// tanh(x) = 2/(1+exp(-2x)) - 1 (no e^{2x}, so large x → ±1, never NaN). Same exp seam and
+    /// ~1e-6 accuracy as <see cref="SigmoidExactInPlace"/>.
+    /// </summary>
+    private static unsafe void TanhExactInPlace(float[] buf, int off, int len)
+    {
+        fixed (float* p = &buf[off])
+        {
+            for (int i = 0; i < len; i++) p[i] = -2f * p[i];
+            SimdKernels.ExpUnsafe(p, p, len);
+            for (int i = 0; i < len; i++) p[i] = 2f / (1f + p[i]) - 1f;
+        }
+    }
+
+    /// <summary>
     /// Float training forward: exact activations, saves per-timestep state, and records
     /// a single fused BPTT node on the active tape. Called from LstmSequenceForward when
     /// a gradient tape is active and T == float.
@@ -193,51 +226,77 @@ public partial class CpuEngine
         for (int b = 0; b < batch; b++)
             Array.Copy(hiddens, b * (seqLen + 1) * hidden, hPrev, b * hidden, hidden);
 
+        // Gate-major activation scratch so each gate's batch*hidden pre-activations are
+        // contiguous for ONE vectorized exact activation call (vs scalar Math.Exp/Tanh per
+        // element, which dominated the cell). act[g*bh + b*hidden + h]; cbuf holds c for tanh(c).
+        int bh = batch * hidden;
+        var act = new float[4 * bh];
+        var cbuf = new float[bh];
+
         for (int t = 0; t < seqLen; t++)
         {
             // hh = h_prev @ wHhT  → [batch, G]
             SimdGemm.SgemmSequential(hPrev.AsSpan(0, batch * hidden), wHhT.AsSpan(0, hidden * G),
                                      hh.AsSpan(0, batch * G), batch, hidden, G);
 
+            // Gather: act[g] = wx + hh (+ bHh), gate-major. Gate order i,f,g(=cell candidate),o.
             for (int b = 0; b < batch; b++)
             {
-                int wxRow = (b * seqLen + t) * G;
-                int hhRow = b * G;
-                int gateRow = (b * seqLen + t) * G;
-                int cPrevRow = (b * (seqLen + 1) + t) * hidden;
-                int cCurRow = (b * (seqLen + 1) + t + 1) * hidden;
-                int outRow = returnSequences ? (b * seqLen + t) * hidden : b * hidden;
-
-                for (int h = 0; h < hidden; h++)
+                int wxBase = (b * seqLen + t) * G;
+                int hhBase = b * G;
+                for (int g = 0; g < 4; g++)
                 {
-                    float iIn = wx[wxRow + 0 * hidden + h] + hh[hhRow + 0 * hidden + h];
-                    float fIn = wx[wxRow + 1 * hidden + h] + hh[hhRow + 1 * hidden + h];
-                    float gIn = wx[wxRow + 2 * hidden + h] + hh[hhRow + 2 * hidden + h];
-                    float oIn = wx[wxRow + 3 * hidden + h] + hh[hhRow + 3 * hidden + h];
+                    int wxg = wxBase + g * hidden, hhg = hhBase + g * hidden, dst = g * bh + b * hidden;
                     if (bHhArr is not null)
                     {
-                        iIn += bHhArr[0 * hidden + h]; fIn += bHhArr[1 * hidden + h];
-                        gIn += bHhArr[2 * hidden + h]; oIn += bHhArr[3 * hidden + h];
+                        int bOff = g * hidden;
+                        for (int h = 0; h < hidden; h++) act[dst + h] = wx[wxg + h] + hh[hhg + h] + bHhArr[bOff + h];
                     }
+                    else
+                    {
+                        for (int h = 0; h < hidden; h++) act[dst + h] = wx[wxg + h] + hh[hhg + h];
+                    }
+                }
+            }
 
-                    float ig = 1f / (1f + (float)Math.Exp(-iIn));
-                    float fg = 1f / (1f + (float)Math.Exp(-fIn));
-                    float gg = (float)Math.Tanh(gIn);
-                    float og = 1f / (1f + (float)Math.Exp(-oIn));
+            // Exact vectorized activations: i,f,o → sigmoid; g → tanh.
+            SigmoidExactInPlace(act, 0 * bh, bh);
+            SigmoidExactInPlace(act, 1 * bh, bh);
+            TanhExactInPlace(act, 2 * bh, bh);
+            SigmoidExactInPlace(act, 3 * bh, bh);
 
-                    float cPrev = cells[cPrevRow + h];
-                    float c = fg * cPrev + ig * gg;
-                    float hOut = og * (float)Math.Tanh(c);
-
-                    gates[gateRow + 0 * hidden + h] = ig;
-                    gates[gateRow + 1 * hidden + h] = fg;
-                    gates[gateRow + 2 * hidden + h] = gg;
-                    gates[gateRow + 3 * hidden + h] = og;
+            // Cell: c = f·c_prev + i·g (write raw c to cells; copy to cbuf for tanh(c)).
+            for (int b = 0; b < batch; b++)
+            {
+                int cPrevRow = (b * (seqLen + 1) + t) * hidden;
+                int cCurRow = (b * (seqLen + 1) + t + 1) * hidden;
+                int gb = b * hidden;
+                for (int h = 0; h < hidden; h++)
+                {
+                    float c = act[1 * bh + gb + h] * cells[cPrevRow + h] + act[0 * bh + gb + h] * act[2 * bh + gb + h];
                     cells[cCurRow + h] = c;
-                    hiddens[cCurRow + h] = hOut;
+                    cbuf[gb + h] = c;
+                }
+            }
+            TanhExactInPlace(cbuf, 0, bh); // cbuf = tanh(c)
 
-                    if (returnSequences) outSpan[outRow + h] = hOut;
-                    else if (t == seqLen - 1) outSpan[outRow + h] = hOut;
+            // h = o·tanh(c); scatter saved gates + hiddens + output.
+            for (int b = 0; b < batch; b++)
+            {
+                int gateRow = (b * seqLen + t) * G;
+                int cCurRow = (b * (seqLen + 1) + t + 1) * hidden;
+                int outRow = returnSequences ? (b * seqLen + t) * hidden : b * hidden;
+                int gb = b * hidden;
+                bool writeOut = returnSequences || t == seqLen - 1;
+                for (int h = 0; h < hidden; h++)
+                {
+                    float hOut = act[3 * bh + gb + h] * cbuf[gb + h];
+                    gates[gateRow + 0 * hidden + h] = act[0 * bh + gb + h];
+                    gates[gateRow + 1 * hidden + h] = act[1 * bh + gb + h];
+                    gates[gateRow + 2 * hidden + h] = act[2 * bh + gb + h];
+                    gates[gateRow + 3 * hidden + h] = act[3 * bh + gb + h];
+                    hiddens[cCurRow + h] = hOut;
+                    if (writeOut) outSpan[outRow + h] = hOut;
                 }
             }
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.LstmSequenceBackward.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.LstmSequenceBackward.cs
@@ -45,6 +45,25 @@ public partial class CpuEngine
     // ──────────────────────────────────────────────────────────────────────────
 
     /// <summary>
+    /// Routes a LARGE float GEMM to the parallel BlasManaged dispatcher. Same argument
+    /// order as <see cref="SimdGemm.Sgemm"/> (result is [m, n], k is the contraction).
+    /// The fused LSTM kernel originally ran every GEMM single-threaded (Sgemm /
+    /// SgemmSequential), which left the big forward Wx and backward dInput/dWih/dWhh GEMMs
+    /// serial and capped the fused-training speedup. These have large m (totalRows or 4·H),
+    /// so the M-axis-parallel dispatcher wins; the per-timestep recurrent GEMMs stay on
+    /// SgemmSequential (tiny m, and inherently serial across the BPTT recurrence — parallel
+    /// dispatch overhead per step would not pay off). DisableAutotune = the static-heuristic
+    /// kernel (same determinism contract as the eager-matmul fast path).
+    /// </summary>
+    private static void GemmBig(System.ReadOnlySpan<float> a, int lda, bool transA,
+                                System.ReadOnlySpan<float> b, int ldb, bool transB,
+                                System.Span<float> c, int m, int k, int n)
+    {
+        BlasManaged.BlasManaged.Gemm<float>(a, lda, transA, b, ldb, transB, c, n, m, n, k,
+            new BlasManaged.BlasOptions<float> { PackingMode = BlasManaged.PackingMode.DisableAutotune });
+    }
+
+    /// <summary>
     /// Float training forward: exact activations, saves per-timestep state, and records
     /// a single fused BPTT node on the active tape. Called from LstmSequenceForward when
     /// a gradient tape is active and T == float.
@@ -104,8 +123,8 @@ public partial class CpuEngine
 
         // Wx[b,t,:] = wIh @ x[b,t] (+ bIh), one big GEMM into [totalRows, G].
         var wx = new float[totalRows * G];
-        SimdGemm.Sgemm(inSpan, inFeatures, false, wIhSpan, inFeatures, true,
-                       wx.AsSpan(0, totalRows * G), totalRows, inFeatures, G);
+        GemmBig(inSpan, inFeatures, false, wIhSpan, inFeatures, true,
+                wx.AsSpan(0, totalRows * G), totalRows, inFeatures, G);
         if (bIhArr is not null)
         {
             for (int r = 0; r < totalRows; r++)
@@ -365,15 +384,16 @@ public partial class CpuEngine
 
         // gradInput = dgatesAll @ wIh  → [totalRows, inFeatures]
         var gradInput = new Tensor<float>(new[] { batch, seqLen, inFeatures });
-        SimdGemm.SgemmSequential(dgatesAll.AsSpan(0, totalRows * G), wIh.AsSpan().Slice(0, G * inFeatures),
-                                 gradInput.AsWritableSpan(), totalRows, G, inFeatures);
+        GemmBig(dgatesAll.AsSpan(0, totalRows * G), G, false,
+                wIh.AsSpan().Slice(0, G * inFeatures), inFeatures, false,
+                gradInput.AsWritableSpan(), totalRows, G, inFeatures);
         DifferentiableOps.AccumulateGrad(grads, input, gradInput, engine);
 
         // gradWIh = dgatesAll^T @ input2d  → [G, inFeatures]
         var gradWIh = new Tensor<float>(new[] { G, inFeatures });
-        SimdGemm.Sgemm(dgatesAll.AsSpan(0, totalRows * G), G, true,
-                       input.AsSpan(), inFeatures, false,
-                       gradWIh.AsWritableSpan(), G, totalRows, inFeatures);
+        GemmBig(dgatesAll.AsSpan(0, totalRows * G), G, true,
+                input.AsSpan(), inFeatures, false,
+                gradWIh.AsWritableSpan(), G, totalRows, inFeatures);
         DifferentiableOps.AccumulateGrad(grads, wIh, gradWIh, engine);
 
         // gradWHh = dgatesAll^T @ hPrevAll  → [G, hidden]; hPrevAll[b,t] = h_{t-1}.
@@ -383,9 +403,9 @@ public partial class CpuEngine
                 Array.Copy(hiddens, (b * (seqLen + 1) + t) * hidden,
                            hPrevAll, (b * seqLen + t) * hidden, hidden);
         var gradWHh = new Tensor<float>(new[] { G, hidden });
-        SimdGemm.Sgemm(dgatesAll.AsSpan(0, totalRows * G), G, true,
-                       hPrevAll.AsSpan(0, totalRows * hidden), hidden, false,
-                       gradWHh.AsWritableSpan(), G, totalRows, hidden);
+        GemmBig(dgatesAll.AsSpan(0, totalRows * G), G, true,
+                hPrevAll.AsSpan(0, totalRows * hidden), hidden, false,
+                gradWHh.AsWritableSpan(), G, totalRows, hidden);
         DifferentiableOps.AccumulateGrad(grads, wHh, gradWHh, engine);
 
         // gradBIh = gradBHh = column-sum of dgatesAll over (b,t) → [G].

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.LstmSequenceBackward.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.LstmSequenceBackward.cs
@@ -318,14 +318,22 @@ public partial class CpuEngine
         var wHhSpan = wHh.AsSpan();          // [G, hidden]
         var gradOutSpan = gradOutput.AsSpan();
 
+        // Pool the backward scratch (it otherwise allocates several MB/step — dgatesAll and
+        // hPrevAll dominate — churning Gen0 GC during training). Returned at method end.
+        // ArrayPool.Rent does NOT zero, so the read-accumulate carries (dhNext/dcNext, which
+        // the t=seqLen-1 iteration reads before writing) must be cleared; dgatesAll/dgatesT/
+        // dhPrev are fully written before any read, so they need no clear.
+        var pool = System.Buffers.ArrayPool<float>.Shared;
         // dgatesAll [b,t] pre-activation gate grads, row (b*seqLen+t)*G.
-        var dgatesAll = new float[totalRows * G];
+        var dgatesAll = pool.Rent(totalRows * G);
         // Recurrent carries, indexed [b, hidden].
-        var dhNext = new float[batch * hidden];
-        var dcNext = new float[batch * hidden];
+        var dhNext = pool.Rent(batch * hidden);
+        var dcNext = pool.Rent(batch * hidden);
+        System.Array.Clear(dhNext, 0, batch * hidden);
+        System.Array.Clear(dcNext, 0, batch * hidden);
         // Per-timestep scratch for the recurrent dh_prev = dgates_t @ wHh GEMM.
-        var dgatesT = new float[batch * G];
-        var dhPrev = new float[batch * hidden];
+        var dgatesT = pool.Rent(batch * G);
+        var dhPrev = pool.Rent(batch * hidden);
 
         for (int t = seqLen - 1; t >= 0; t--)
         {
@@ -397,7 +405,7 @@ public partial class CpuEngine
         DifferentiableOps.AccumulateGrad(grads, wIh, gradWIh, engine);
 
         // gradWHh = dgatesAll^T @ hPrevAll  → [G, hidden]; hPrevAll[b,t] = h_{t-1}.
-        var hPrevAll = new float[totalRows * hidden];
+        var hPrevAll = pool.Rent(totalRows * hidden);
         for (int b = 0; b < batch; b++)
             for (int t = 0; t < seqLen; t++)
                 Array.Copy(hiddens, (b * (seqLen + 1) + t) * hidden,
@@ -444,5 +452,14 @@ public partial class CpuEngine
             dcNext.AsSpan(0, batch * hidden).CopyTo(gc0.AsWritableSpan());
             DifferentiableOps.AccumulateGrad(grads, inp[idxC0], gc0, engine);
         }
+
+        // Return the pooled backward scratch (all consumers above are done). On an exception
+        // mid-backward these leak, which is benign for ArrayPool (the pool just allocates anew).
+        pool.Return(dgatesAll);
+        pool.Return(dhNext);
+        pool.Return(dcNext);
+        pool.Return(dgatesT);
+        pool.Return(dhPrev);
+        pool.Return(hPrevAll);
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/LstmFusedBackwardPerfBench.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/LstmFusedBackwardPerfBench.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Diagnostics;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Times the fused LSTM forward+backward (#587 kernel) at the AiDotNet benchmark's LSTM
+/// shape (batch 64, in 32, hidden 64, seq 32) to track the effect of routing the big
+/// forward/backward GEMMs to the parallel BlasManaged.Gemm.
+/// </summary>
+public class LstmFusedBackwardPerfBench
+{
+    private readonly ITestOutputHelper _o;
+    public LstmFusedBackwardPerfBench(ITestOutputHelper o) => _o = o;
+
+    private static Tensor<float> Rand(int[] shape, int seed)
+    {
+        var rng = new Random(seed);
+        var t = new Tensor<float>(shape);
+        var s = t.AsWritableSpan();
+        for (int i = 0; i < s.Length; i++) s[i] = (float)(rng.NextDouble() * 2 - 1) * 0.1f;
+        return t;
+    }
+
+    [Fact(Skip = "Benchmark — run manually")]
+    public void Bench_FusedLstmForwardBackward()
+    {
+        var eng = new CpuEngine();
+        int batch = 64, seq = 32, inF = 32, hidden = 64, G = 4 * hidden;
+        var input = Rand(new[] { batch, seq, inF }, 1);
+        var wIh = Rand(new[] { G, inF }, 2);
+        var wHh = Rand(new[] { G, hidden }, 3);
+        var bIh = Rand(new[] { G }, 4);
+        var bHh = Rand(new[] { G }, 5);
+
+        void Step()
+        {
+            using var tape = new GradientTape<float>();
+            var outp = eng.LstmSequenceForward(input, null, null, wIh, wHh, bIh, bHh, returnSequences: true);
+            var loss = eng.ReduceSum(eng.TensorMultiply(outp, outp), null);
+            var grads = tape.ComputeGradients(loss, new[] { input, wIh, wHh, bIh, bHh });
+            if (grads.Count == 0) throw new Exception("no grads");
+        }
+
+        for (int i = 0; i < 50; i++) Step(); // warm
+        const int iters = 500;
+        double best = double.MaxValue, sum = 0;
+        var sw = new Stopwatch();
+        for (int i = 0; i < iters; i++)
+        {
+            sw.Restart();
+            Step();
+            sw.Stop();
+            double ms = sw.Elapsed.TotalMilliseconds;
+            best = Math.Min(best, ms);
+            sum += ms;
+        }
+        _o.WriteLine($"ENGINE={eng.GetType().Name} fused LSTM fwd+bwd [b{batch},s{seq},in{inF},h{hidden}]: min {best:F4} ms | avg {sum / iters:F4} ms");
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/LstmFusedBackwardPerfBench.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/LstmFusedBackwardPerfBench.cs
@@ -48,6 +48,13 @@ public class LstmFusedBackwardPerfBench
         }
 
         for (int i = 0; i < 50; i++) Step(); // warm
+
+        long a0 = GC.GetAllocatedBytesForCurrentThread();
+        const int allocIters = 100;
+        for (int i = 0; i < allocIters; i++) Step();
+        double kbPerStep = (GC.GetAllocatedBytesForCurrentThread() - a0) / 1024.0 / allocIters;
+        _o.WriteLine($"alloc/step = {kbPerStep:F1} KB");
+
         const int iters = 500;
         double best = double.MaxValue, sum = 0;
         var sw = new Stopwatch();

--- a/tests/AiDotNet.Tensors.Tests/Engines/LstmFusedBackwardPerfBench.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/LstmFusedBackwardPerfBench.cs
@@ -49,10 +49,20 @@ public class LstmFusedBackwardPerfBench
 
         for (int i = 0; i < 50; i++) Step(); // warm
 
-        long a0 = GC.GetAllocatedBytesForCurrentThread();
+        // GC.GetAllocatedBytesForCurrentThread is netcoreapp3.0+, not on net471.
+        // Fall back to GC.GetTotalMemory on net471 — same shape (relative delta
+        // around the timed loop), coarser absolute number, but the perf-bench
+        // readout is only a diagnostic for the dev box anyway.
         const int allocIters = 100;
+#if NET6_0_OR_GREATER
+        long a0 = GC.GetAllocatedBytesForCurrentThread();
         for (int i = 0; i < allocIters; i++) Step();
         double kbPerStep = (GC.GetAllocatedBytesForCurrentThread() - a0) / 1024.0 / allocIters;
+#else
+        long a0 = GC.GetTotalMemory(forceFullCollection: false);
+        for (int i = 0; i < allocIters; i++) Step();
+        double kbPerStep = (GC.GetTotalMemory(forceFullCollection: false) - a0) / 1024.0 / allocIters;
+#endif
         _o.WriteLine($"alloc/step = {kbPerStep:F1} KB");
 
         const int iters = 500;


### PR DESCRIPTION
## Summary

Three optimizations to the #587 fused LSTM training kernel (CpuEngine.LstmSequenceBackward.cs), which originally ran every GEMM single-threaded and every activation as a scalar transcendental. Net **1.60× at a realistic `hidden=256`**, with gradients unchanged (exact).

### 1. Parallelize the big GEMMs
The four large forward/backward GEMMs (Wx, dInput, dWih, dWhh — all large-m) now route to the M-axis-parallel `BlasManaged.Gemm` via a `GemmBig` helper. The two per-timestep recurrent GEMMs (`hh`, `dh_prev`) stay on `SgemmSequential` — tiny m, inherently serial across the BPTT recurrence.

### 2. Vectorize the forward-cell activations (exact)
The cell ran 3 scalar `Math.Exp` + 2 scalar `Math.Tanh` per element (~28% of the kernel by profiling). Restructured into a gate-major **gather → one vectorized exact activation per gate → cell math → scatter**, so the transcendental runs over `batch*hidden` contiguous values at once. Built from `SimdKernels.ExpUnsafe` (near-exact VML/Herumi vectorized exp, scalar fallback on net471) via overflow-safe forms — `sigmoid = 1/(1+exp(-x))`, `tanh = 2/(1+exp(-2x))-1` — matching scalar `Math.Exp`/`Math.Tanh` to ~1e-6. **Kept EXACT** (not the Padé `FastSigmoid` the inference path uses) so the `σ(1-σ)` gradients stay correct.

### 3. Pool the backward scratch
`dgatesAll`/`hPrevAll`/carries rented from `ArrayPool` (clearing the read-accumulate carries) — ~2.6 MB/step less Gen0 GC churn. Saved state (gates/cells/hiddens) deliberately not pooled (must survive a 2nd `ComputeGradients` on a persistent tape).

## Measured (fused fwd+bwd, batch 64, seq 32, min-of-500)

| hidden | all-scalar baseline | + GEMM parallel | + vectorized activations |
|---:|---:|---:|---:|
| 64 (AIsEval toy) | 14.6 ms | 14.1 ms | **10.65 ms** (1.37×) |
| **256 (realistic)** | 118.8 ms | 90.4 ms | **74.2 ms** (1.60×) |

## Correctness
- `LstmFusedBackwardGradientTests`: **3/3** finite-difference gradient tests green (activations exact to ~1e-6, so gradients unchanged within tolerance).
- 24 LSTM tests green; both net10.0 and net471 build.

## Remaining levers (not in this PR)
- Forward-scratch + saved-state pooling (corner cases / persistent-tape lifetime).
- The LSTM kernel is only ~1/3 of the end-to-end AiDotNet training step — the dominant remainder is framework/optimizer overhead (ooples/AiDotNet#1566).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
