### PR TITLE
fix(simd): clamp tanh-via-exp arguments in double GELU/Tanh/Mish kernels (NaN at |x| >= ~20)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -10349,7 +10349,21 @@ public partial class CpuEngine : ITensorLevelEngine
                 var idxBuf = new int[tensor.Length];
                 tensor.FillStorageIndices(idxBuf);
                 for (int i = 0; i < tensor.Length; i++)
-                    { T v = srcRaw[idxBuf[i]]; T z = ops.Multiply(ops.FromDouble(0.7978845608), ops.Add(v, ops.Multiply(ops.FromDouble(0.044715), ops.Multiply(v, ops.Multiply(v, v))))); T e2z = ops.Exp(ops.Multiply(ops.FromDouble(2.0), z)); T th = ops.Divide(ops.Subtract(e2z, ops.One), ops.Add(e2z, ops.One)); T cdf = ops.Divide(ops.Add(ops.One, th), ops.FromDouble(2.0)); dstArr[i] = ops.Multiply(v, cdf); }
+                {
+                    T v = srcRaw[idxBuf[i]];
+                    T z = ops.Multiply(ops.FromDouble(0.7978845608), ops.Add(v, ops.Multiply(ops.FromDouble(0.044715), ops.Multiply(v, ops.Multiply(v, v)))));
+                    // Clamp the tanh argument to ±20 (tanh(±20) == ±1 to T's
+                    // precision) so exp(2z) can't overflow to Inf and make
+                    // (e^{2z}−1)/(e^{2z}+1) = Inf/Inf = NaN — same guard as the
+                    // SIMD GELU kernels (SimdKernels.GELUUnsafe).
+                    double zd = ops.ToDouble(z);
+                    if (zd > 20.0) z = ops.FromDouble(20.0);
+                    else if (zd < -20.0) z = ops.FromDouble(-20.0);
+                    T e2z = ops.Exp(ops.Multiply(ops.FromDouble(2.0), z));
+                    T th = ops.Divide(ops.Subtract(e2z, ops.One), ops.Add(e2z, ops.One));
+                    T cdf = ops.Divide(ops.Add(ops.One, th), ops.FromDouble(2.0));
+                    dstArr[i] = ops.Multiply(v, cdf);
+                }
                 DifferentiableOps.RecordUnary("GELU", resultS, tensor, BackwardFunctions<T>.GELUBackward);
                 { var c = tensor; AutoTracer.RecordOp("GELU", resultS, eng => eng.GELU(c)); }
                 return resultS;

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdKernels.cs
@@ -2983,17 +2983,24 @@ namespace AiDotNet.Tensors.Engines.Simd
             int i = 0;
 
 #if NET5_0_OR_GREATER
-            // tanh(x) = (exp(2x) - 1) / (exp(2x) + 1)
+            // tanh(x) = (exp(2x) - 1) / (exp(2x) + 1). Clamp x to ±20 first:
+            // tanh(±20) rounds to exactly ±1.0 in double, and an unclamped
+            // x ≥ ~355 drives FastExpDouble256's 2^n reconstruction into the
+            // biased-exponent-2047 (Inf) pattern, making the division
+            // Inf/Inf = NaN — see GELUUnsafe(double*) for the training
+            // failure this caused.
             if (Avx2.IsSupported && Fma.IsSupported && length >= 16)
             {
                 var two = Vector256.Create(2.0);
                 var one = Vector256.Create(1.0);
+                var clampHi = Vector256.Create(20.0);
+                var clampLo = Vector256.Create(-20.0);
                 int simdLength = length & ~15;
                 for (; i < simdLength; i += 16)
                 {
                     for (int k = 0; k < 16; k += 4)
                     {
-                        var x = ReadVector256Double(input, i + k);
+                        var x = Avx.Min(Avx.Max(ReadVector256Double(input, i + k), clampLo), clampHi);
                         var e2x = FastExpDouble256(Avx.Multiply(two, x));
                         WriteVector256Double(output, i + k,
                             Avx.Divide(Avx.Subtract(e2x, one), Avx.Add(e2x, one)));
@@ -3005,10 +3012,12 @@ namespace AiDotNet.Tensors.Engines.Simd
             {
                 var two = Vector256.Create(2.0);
                 var one = Vector256.Create(1.0);
+                var clampHi = Vector256.Create(20.0);
+                var clampLo = Vector256.Create(-20.0);
                 int simdLength = i + ((length - i) & ~3);
                 for (; i < simdLength; i += 4)
                 {
-                    var x = ReadVector256Double(input, i);
+                    var x = Avx.Min(Avx.Max(ReadVector256Double(input, i), clampLo), clampHi);
                     var e2x = FastExpDouble256(Avx.Multiply(two, x));
                     WriteVector256Double(output, i,
                         Avx.Divide(Avx.Subtract(e2x, one), Avx.Add(e2x, one)));
@@ -5743,19 +5752,25 @@ namespace AiDotNet.Tensors.Engines.Simd
         {
             int i = 0;
 #if NET5_0_OR_GREATER
+            // Clamp inputs to ±20 before the exp decomposition: tanh(±20)
+            // rounds to exactly ±1.0 in double, while an unclamped |x| ≥ ~355
+            // drives FastExpDouble256's 2^n reconstruction into the
+            // biased-exponent-2047 (Inf) pattern and (e−1)/(e+1) = Inf/Inf =
+            // NaN. See GELUUnsafe(double*) for the training failure this caused.
             if (Avx2.IsSupported && Fma.IsSupported && length >= 16)
             {
                 var one = Vector256.Create(1.0);
                 var two = Vector256.Create(2.0);
-                var negOne = Vector256.Create(-1.0);
+                var clampHi = Vector256.Create(20.0);
+                var clampLo = Vector256.Create(-20.0);
                 int simdLen = length & ~15;
                 for (; i < simdLen; i += 16)
                 {
-                    var x0 = Avx.LoadVector256(input + i);
-                    var x1 = Avx.LoadVector256(input + i + 4);
-                    var x2 = Avx.LoadVector256(input + i + 8);
-                    var x3 = Avx.LoadVector256(input + i + 12);
-                    // sigmoid(-2x) = 1/(1+exp(2x)), tanh = 1 - 2*sigmoid(-2x)
+                    var x0 = Avx.Min(Avx.Max(Avx.LoadVector256(input + i), clampLo), clampHi);
+                    var x1 = Avx.Min(Avx.Max(Avx.LoadVector256(input + i + 4), clampLo), clampHi);
+                    var x2 = Avx.Min(Avx.Max(Avx.LoadVector256(input + i + 8), clampLo), clampHi);
+                    var x3 = Avx.Min(Avx.Max(Avx.LoadVector256(input + i + 12), clampLo), clampHi);
+                    // tanh = (exp(2x)-1)/(exp(2x)+1)
                     var e0 = FastExpDouble256(Avx.Multiply(two, x0));
                     var e1 = FastExpDouble256(Avx.Multiply(two, x1));
                     var e2 = FastExpDouble256(Avx.Multiply(two, x2));
@@ -5770,10 +5785,12 @@ namespace AiDotNet.Tensors.Engines.Simd
             {
                 var one = Vector256.Create(1.0);
                 var two = Vector256.Create(2.0);
+                var clampHi = Vector256.Create(20.0);
+                var clampLo = Vector256.Create(-20.0);
                 int simdLen = i + ((length - i) & ~3);
                 for (; i < simdLen; i += 4)
                 {
-                    var x0 = Avx.LoadVector256(input + i);
+                    var x0 = Avx.Min(Avx.Max(Avx.LoadVector256(input + i), clampLo), clampHi);
                     var e0 = FastExpDouble256(Avx.Multiply(two, x0));
                     Avx.Store(output + i, Avx.Divide(Avx.Subtract(e0, one), Avx.Add(e0, one)));
                 }
@@ -5796,6 +5813,15 @@ namespace AiDotNet.Tensors.Engines.Simd
                 var vHalf = Vector256.Create(0.5);
                 var vOne = Vector256.Create(1.0);
                 var vTwo = Vector256.Create(2.0);
+                // tanh saturates: tanh(±20) rounds to exactly ±1.0 in double
+                // (1 − 2e^{−40} is within half an ulp of 1). Clamp BEFORE the
+                // exp so (e^{2z}−1)/(e^{2z}+1) never hits Inf/Inf = NaN — an
+                // unclamped z ≥ ~355 (GELU input x ≥ ~19.8) overflowed
+                // e^{2z} and poisoned training forwards with NaN at exactly
+                // the cells the SIMD lanes processed (scalar tail uses
+                // Math.Tanh and was safe), AiDotNet ACEStepTests class.
+                var vTanhClampHi = Vector256.Create(20.0);
+                var vTanhClampLo = Vector256.Create(-20.0);
 
                 int simdLen = length & ~3;
                 for (; i < simdLen; i += 4)
@@ -5803,7 +5829,7 @@ namespace AiDotNet.Tensors.Engines.Simd
                     var x = Avx.LoadVector256(input + i);
                     var x3 = Avx.Multiply(Avx.Multiply(x, x), x);
                     var inner = Fma.MultiplyAdd(vCoeff, x3, x);
-                    var tanhArg = Avx.Multiply(vSqrt2OverPi, inner);
+                    var tanhArg = Avx.Min(Avx.Max(Avx.Multiply(vSqrt2OverPi, inner), vTanhClampLo), vTanhClampHi);
                     // tanh(z) = (exp(2z)-1)/(exp(2z)+1)
                     var e2z = FastExpDouble256(Avx.Multiply(vTwo, tanhArg));
                     var tanhVal = Avx.Divide(Avx.Subtract(e2z, vOne), Avx.Add(e2z, vOne));
@@ -6264,6 +6290,11 @@ namespace AiDotNet.Tensors.Engines.Simd
                 var vTwo = Vector256.Create(2.0);
                 var vCoeff = Vector256.Create(0.044715);
                 var vSqrt2OverPi = Vector256.Create(0.7978845608028654);
+                // Clamp the tanh argument to ±20 (tanh(±20) == ±1.0 exactly in
+                // double) so e^{2t} can't overflow to Inf and yield Inf/Inf =
+                // NaN — see GELUUnsafe(double*) for the failure mode.
+                var vTanhClampHi = Vector256.Create(20.0);
+                var vTanhClampLo = Vector256.Create(-20.0);
 
                 int simdLength = i + ((length - i) & ~3);
                 for (; i < simdLength; i += 4)
@@ -6271,7 +6302,7 @@ namespace AiDotNet.Tensors.Engines.Simd
                     var x = ReadVector256Double(input, i);
                     var x3 = Avx.Multiply(Avx.Multiply(x, x), x);
                     var inner = Fma.MultiplyAdd(vCoeff, x3, x);
-                    var tanhArg = Avx.Multiply(vSqrt2OverPi, inner);
+                    var tanhArg = Avx.Min(Avx.Max(Avx.Multiply(vSqrt2OverPi, inner), vTanhClampLo), vTanhClampHi);
                     // tanh via (exp(2t)-1)/(exp(2t)+1)
                     var e2t = FastExpDouble256(Avx.Multiply(vTwo, tanhArg));
                     var tanhVal = Avx.Divide(Avx.Subtract(e2t, vOne), Avx.Add(e2t, vOne));
@@ -6311,14 +6342,25 @@ namespace AiDotNet.Tensors.Engines.Simd
             {
                 var vOne = Vector256.Create(1.0);
                 var vTwo = Vector256.Create(2.0);
+                // Two overflow guards (mirrors the scalar tail's `x > 20 ? x : …`):
+                // (1) softplus(x) ≈ x for x ≥ 20 and ln(1+e^x) overflows the
+                //     intermediate e^x for x ≥ ~709 — clamp the exp argument and
+                //     blend the identity for large x;
+                // (2) tanh(softplus) via (e^{2sp}−1)/(e^{2sp}+1) hits Inf/Inf =
+                //     NaN for sp ≥ ~355 — clamp sp to 20 (tanh(20) == 1.0 in
+                //     double). See GELUUnsafe(double*) for the failure mode.
+                var vSpClamp = Vector256.Create(20.0);
 
                 int simdLength = i + ((length - i) & ~3);
                 for (; i < simdLength; i += 4)
                 {
                     var x = ReadVector256Double(input, i);
-                    // softplus = ln(1 + exp(x))
-                    var expX = FastExpDouble256(x);
-                    var softplus = FastLogDouble256(Avx.Add(vOne, expX));
+                    // softplus = ln(1 + exp(min(x, 20))); for x > 20 softplus(x) == x
+                    // to double precision, and the tanh argument is clamped to 20
+                    // anyway, so feeding the clamped value through is exact.
+                    var xCapped = Avx.Min(x, vSpClamp);
+                    var expX = FastExpDouble256(xCapped);
+                    var softplus = Avx.Min(FastLogDouble256(Avx.Add(vOne, expX)), vSpClamp);
                     // tanh(softplus) via (exp(2*sp)-1)/(exp(2*sp)+1)
                     var e2sp = FastExpDouble256(Avx.Multiply(vTwo, softplus));
                     var tanhSp = Avx.Divide(Avx.Subtract(e2sp, vOne), Avx.Add(e2sp, vOne));
@@ -8235,6 +8277,11 @@ namespace AiDotNet.Tensors.Engines.Simd
                 var vOne = Vector256.Create(1.0);
                 var vTwo = Vector256.Create(2.0);
                 var vThreeCoeff = Vector256.Create(3.0 * 0.044715);
+                // Clamp the tanh argument to ±20 (tanh(±20) == ±1.0 exactly in
+                // double, sech² == 0) so e^{2z} can't overflow to Inf and yield
+                // Inf/Inf = NaN gradients — see GELUUnsafe(double*).
+                var vTanhClampHi = Vector256.Create(20.0);
+                var vTanhClampLo = Vector256.Create(-20.0);
 
                 int simdLen = length & ~3;
                 for (; i < simdLen; i += 4)
@@ -8244,7 +8291,7 @@ namespace AiDotNet.Tensors.Engines.Simd
                     var x2 = Avx.Multiply(x, x);
                     var x3 = Avx.Multiply(x2, x);
                     var inner = Fma.MultiplyAdd(vCoeff, x3, x);     // x + 0.044715·x³
-                    var tanhArg = Avx.Multiply(vSqrt2OverPi, inner);
+                    var tanhArg = Avx.Min(Avx.Max(Avx.Multiply(vSqrt2OverPi, inner), vTanhClampLo), vTanhClampHi);
                     var e2z = FastExpDouble256(Avx.Multiply(vTwo, tanhArg));
                     var tanhVal = Avx.Divide(Avx.Subtract(e2z, vOne), Avx.Add(e2z, vOne));
                     var sechSq = Fma.MultiplyAddNegated(tanhVal, tanhVal, vOne);   // 1 − t²

--- a/tests/AiDotNet.Tensors.Tests/Engines/ActivationLargeInputOverflowTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/ActivationLargeInputOverflowTests.cs
@@ -1,0 +1,125 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Regression tests for the SIMD double activation kernels overflowing to NaN
+/// on large-magnitude inputs. The tanh-via-exponential decomposition
+/// tanh(z) = (e^{2z} − 1)/(e^{2z} + 1) drove FastExpDouble256's 2^n
+/// reconstruction into the biased-exponent-2047 (Inf) pattern for z ≥ ~355,
+/// making the division Inf/Inf = NaN. For GELU's tanh argument
+/// z = √(2/π)·(x + 0.044715·x³) that threshold is reached at x ≈ 19.8 — well
+/// inside the range a single optimizer step can push transformer
+/// pre-activations (AiDotNet ACEStepTests: one AdamW step on the paper-scale
+/// stack produced pre-activations of ~21 and every tape-mode forward after it
+/// returned NaN). The scalar tails use Math.Tanh and were always safe, which
+/// is why only SIMD-lane elements were poisoned.
+///
+/// The kernels now clamp the tanh argument to ±20 (tanh(±20) rounds to
+/// exactly ±1.0 in double, so the clamp is bit-exact, not an approximation).
+/// These tests pin the contract: large inputs through the TENSOR kernels
+/// (which take the SIMD path for ≥4 elements) must stay finite and match the
+/// scalar reference.
+/// </summary>
+public class ActivationLargeInputOverflowTests
+{
+    private readonly CpuEngine _engine = new();
+
+    private static double GeluReference(double x)
+    {
+        double inner = 0.7978845608028654 * (x + 0.044715 * x * x * x);
+        return 0.5 * x * (1.0 + Math.Tanh(inner));
+    }
+
+    [Theory]
+    [InlineData(19.0)]   // just below the historical overflow threshold
+    [InlineData(21.66)]  // the exact pre-activation magnitude from the ACEStep repro
+    [InlineData(50.0)]
+    [InlineData(400.0)]
+    [InlineData(-21.66)]
+    [InlineData(-400.0)]
+    public void GELU_Double_LargeInputs_AreFiniteAndMatchScalarReference(double x)
+    {
+        // 8 identical elements: enough to force the Vector256 SIMD path
+        // (length >= 4) with no scalar-tail masking of the result.
+        var input = new Tensor<double>(new[] { 8 });
+        for (int i = 0; i < 8; i++) input[i] = x;
+
+        var result = _engine.GELU(input);
+
+        double expected = GeluReference(x);
+        for (int i = 0; i < 8; i++)
+        {
+            Assert.False(double.IsNaN(result[i]) || double.IsInfinity(result[i]),
+                $"GELU({x}) produced non-finite value {result[i]} at lane {i}.");
+            Assert.Equal(expected, result[i], 10);
+        }
+    }
+
+    [Theory]
+    [InlineData(25.0)]
+    [InlineData(400.0)]
+    [InlineData(-400.0)]
+    public void Tanh_Double_LargeInputs_AreFiniteAndSaturate(double x)
+    {
+        // 20 elements: covers both the 16-wide unrolled SIMD block and the
+        // 4-wide block of the double Tanh kernel.
+        var input = new Tensor<double>(new[] { 20 });
+        for (int i = 0; i < 20; i++) input[i] = x;
+
+        var result = _engine.Tanh(input);
+
+        double expected = Math.Tanh(x); // ±1.0 at these magnitudes
+        for (int i = 0; i < 20; i++)
+        {
+            Assert.False(double.IsNaN(result[i]) || double.IsInfinity(result[i]),
+                $"Tanh({x}) produced non-finite value {result[i]} at lane {i}.");
+            Assert.Equal(expected, result[i], 12);
+        }
+    }
+
+    [Theory]
+    [InlineData(25.0)]
+    [InlineData(400.0)]
+    [InlineData(800.0)]   // also overflows the softplus-internal exp(x) without the cap
+    [InlineData(-400.0)]
+    public void Mish_Double_LargeInputs_AreFiniteAndMatchScalarReference(double x)
+    {
+        var input = new Tensor<double>(new[] { 8 });
+        for (int i = 0; i < 8; i++) input[i] = x;
+
+        var result = _engine.Mish(input);
+
+        double softplus = x > 20.0 ? x : Math.Log(1.0 + Math.Exp(x));
+        double expected = x * Math.Tanh(softplus);
+        for (int i = 0; i < 8; i++)
+        {
+            Assert.False(double.IsNaN(result[i]) || double.IsInfinity(result[i]),
+                $"Mish({x}) produced non-finite value {result[i]} at lane {i}.");
+            Assert.Equal(expected, result[i], 8);
+        }
+    }
+
+    [Fact]
+    public void GELU_Double_MixedMagnitudes_OnlyLargeLanesWereAffected_AllNowCorrect()
+    {
+        // Mirrors the ACEStep failure shape: a vector with a mix of ordinary
+        // and large pre-activations — historically the large lanes NaN'd while
+        // their neighbors stayed correct, corrupting the whole forward.
+        double[] values = { -2.5, 0.0, 1.3, 21.66, -21.66, 3.7, 19.9, 355.0 };
+        var input = new Tensor<double>(new[] { values.Length });
+        for (int i = 0; i < values.Length; i++) input[i] = values[i];
+
+        var result = _engine.GELU(input);
+
+        for (int i = 0; i < values.Length; i++)
+        {
+            Assert.False(double.IsNaN(result[i]) || double.IsInfinity(result[i]),
+                $"GELU({values[i]}) produced non-finite value at lane {i}.");
+            Assert.Equal(GeluReference(values[i]), result[i], 10);
+        }
+    }
+}


### PR DESCRIPTION
## Root cause

The double SIMD activation kernels decompose `tanh(z) = (e^{2z} − 1)/(e^{2z} + 1)` via `FastExpDouble256`. For `z ≥ ~355` the `2^n` reconstruction lands on the biased-exponent-2047 (Inf) bit pattern and the division returns `Inf/Inf = NaN`. GELU reaches that threshold at input `x ≈ 19.8` — well inside the range a single optimizer step pushes transformer pre-activations.

## Downstream impact

Root-caused from AiDotNet's `ACEStepTests` CI failures (NN A-L shard) via dotnet-trace + per-layer tape-walk diagnostics: one AdamW step on the paper-scale MHA stack produced pre-activations of ~21.7, after which **every tape-mode forward returned NaN at exactly the SIMD-lane cells** (scalar tails use `Math.Tanh` and were safe). The NaN poisoned the global gradient-norm clip and wiped all 52M parameters on the next step. Naive recompute of the failing cell: `preAct = 21.657723`, scalar GELU = `21.657723`, kernel value = `NaN`.

## Fix

Clamp the tanh argument to ±20 before the exponential — `tanh(±20)` rounds to **exactly** `±1.0` in double (`1 − 2e^{−40}` is within half an ulp of 1), so the clamp is bit-exact:

- `GELUUnsafe(double*)` (forward) + `GeluBackwardDouble` (backward)
- span-based `GELU(double)`
- `TanhUnsafe(double*)` (both unrolled blocks)
- `Mish(double)` (also caps the softplus-internal `exp(x)`, which overflowed independently at `x ≥ ~709`)
- `CpuEngine` strided-scalar generic GELU fallback

Float kernels already route through VML erf / Padé sigmoid forms that divide **by** the large exponential and cannot produce `Inf/Inf` — audited, no change needed. Sigmoid double kernels use `1/(1+e^x)` — same safe shape.

## Tests

`ActivationLargeInputOverflowTests` (14 cases, net10.0 + net471 green): GELU/Tanh/Mish at 19, **21.66 (the ACEStep repro value)**, 25, 50, 355, 400, 800 and negatives, sized to force the SIMD paths, asserting finite output equal to the `Math.Tanh` scalar reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)