### PR TITLE
fix(gpu): packages built on one OS silently lose CUDA/HIP on the other — resolve GPU library names at runtime

### DIFF
--- a/src/AiDotNet.Tensors/AiDotNet.Tensors.csproj
+++ b/src/AiDotNet.Tensors/AiDotNet.Tensors.csproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
 
   <!-- Define WINDOWS for correct DLL names on Windows -->
-  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows')) or '$(TargetFramework)' == 'net471'">
     <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
   </PropertyGroup>
 

--- a/src/AiDotNet.Tensors/Engines/CuBlasNative.cs
+++ b/src/AiDotNet.Tensors/Engines/CuBlasNative.cs
@@ -98,16 +98,21 @@ public static class CuBlasNative
 #if WINDOWS
     private const string CublasLibrary = "cublas64_12";
     private const string CudaLibrary = "nvcuda";
+#else
+    private const string CublasLibrary = "libcublas.so.12";
+    private const string CudaLibrary = "libcuda.so.1";
+#endif
 
+    // BOTH candidate sets are always compiled and selected at RUNTIME: the package ships ONE
+    // assembly for every platform, so the consts above reflect the BUILD machine's OS, not the
+    // user's. A package built on a Linux CI runner bakes in libcublas/libcuda — without runtime
+    // mapping, CUDA silently dies on every Windows machine (and vice versa).
     private static readonly string[] CublasWindowsCandidates =
     [
         "cublas64_13",
         "cublas64_12",
         "cublas64_11"
     ];
-#else
-    private const string CublasLibrary = "libcublas.so.12";
-    private const string CudaLibrary = "libcuda.so.1";
 
     private static readonly string[] CublasLinuxCandidates =
     [
@@ -116,7 +121,6 @@ public static class CuBlasNative
         "libcublas.so.11",
         "libcublas.so"
     ];
-#endif
 
 #if !NET471
     static CuBlasNative()
@@ -125,19 +129,22 @@ public static class CuBlasNative
         // OpenCL, Vulkan, etc. all chain through one assembly-level
         // resolver. Direct SetDllImportResolver throws on second call.
         NativeLibraryResolverRegistry.Register(ResolveCuBlasLibrary);
+        // Cross-OS mapping for the driver/nvrtc/cudart names this class P/Invokes
+        // (nvcuda vs libcuda etc.) — see GpuDriverCrossPlatformResolver.
+        GpuDriverCrossPlatformResolver.EnsureRegistered();
     }
 
     private static IntPtr ResolveCuBlasLibrary(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
     {
-        // Only intercept cuBLAS resolution — let nvcuda/libcuda resolve normally
-        if (libraryName != CublasLibrary)
+        // Intercept ANY cuBLAS alias (whichever OS's name was baked in at build time);
+        // let nvcuda/libcuda resolve via the cross-platform driver resolver.
+        if (!libraryName.StartsWith("cublas64_", StringComparison.Ordinal) &&
+            !libraryName.StartsWith("libcublas", StringComparison.Ordinal))
             return IntPtr.Zero;
 
-#if WINDOWS
-        var candidates = CublasWindowsCandidates;
-#else
-        var candidates = CublasLinuxCandidates;
-#endif
+        var candidates = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? CublasWindowsCandidates
+            : CublasLinuxCandidates;
         // First try standard DLL search (PATH, system dirs, etc.)
         foreach (var candidate in candidates)
         {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaNativeBindings.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaNativeBindings.cs
@@ -29,6 +29,17 @@ internal static class CudaNativeBindings
     private const string CudaLibrary = "libcuda";
 #endif
 
+#if NET5_0_OR_GREATER
+    // The const above is baked at BUILD time, but the package ships one assembly for all
+    // platforms — the cross-platform resolver maps whichever name was baked to the current
+    // OS's real driver library at runtime (a Linux-built package must still find nvcuda.dll
+    // on Windows, and vice versa).
+    static CudaNativeBindings()
+    {
+        GpuDriverCrossPlatformResolver.EnsureRegistered();
+    }
+#endif
+
     private static bool _isAvailable;
     private static bool _availabilityChecked;
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/NvrtcNativeBindings.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/NvrtcNativeBindings.cs
@@ -210,25 +210,28 @@ internal static class NvrtcNativeBindings
 
     private static INvrtcApi? ResolveApi()
     {
-#if WINDOWS
-        INvrtcApi[] candidates =
-        {
-            new NvrtcApi130(),
-            new NvrtcApi120(),
-            new NvrtcApi12(),
-            new NvrtcApi118(),
-            new NvrtcApi112()
-        };
-#else
-        INvrtcApi[] candidates =
-        {
-            new NvrtcApi130Linux(),
-            new NvrtcApi12(),
-            new NvrtcApi118(),
-            new NvrtcApi11(),
-            new NvrtcApiDefault()
-        };
-#endif
+        // Runtime OS selection (NOT #if): the package ships one assembly for all platforms,
+        // so a compile-time switch bakes in the build machine's OS — a Linux-built package
+        // probed only libnvrtc.so.* on Windows, nvrtc never resolved, and the CUDA backend
+        // silently fell back to OpenCL. Both candidate sets are always compiled; the right
+        // one is chosen on the machine that's actually running.
+        INvrtcApi[] candidates = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? new INvrtcApi[]
+            {
+                new NvrtcApi130(),
+                new NvrtcApi120(),
+                new NvrtcApi12(),
+                new NvrtcApi118(),
+                new NvrtcApi112()
+            }
+            : new INvrtcApi[]
+            {
+                new NvrtcApi130Linux(),
+                new NvrtcApi12Linux(),
+                new NvrtcApi118Linux(),
+                new NvrtcApi11(),
+                new NvrtcApiDefault()
+            };
 
         foreach (var candidate in candidates)
         {
@@ -353,7 +356,7 @@ internal interface INvrtcApi
     IntPtr GetErrorString(NvrtcResult result);
 }
 
-#if WINDOWS
+// Both OS class sets are ALWAYS compiled; ResolveApi selects at runtime (see above).
 internal sealed class NvrtcApi130 : INvrtcApi
 {
     private const string Library = "nvrtc64_130_0";
@@ -653,7 +656,7 @@ internal sealed class NvrtcApi112 : INvrtcApi
     public NvrtcResult DestroyProgram(ref IntPtr prog) => nvrtcDestroyProgram(ref prog);
     public IntPtr GetErrorString(NvrtcResult result) => nvrtcGetErrorString(result);
 }
-#else
+
 internal sealed class NvrtcApi130Linux : INvrtcApi
 {
     private const string Library = "libnvrtc.so.13";
@@ -714,7 +717,7 @@ internal sealed class NvrtcApi130Linux : INvrtcApi
     public IntPtr GetErrorString(NvrtcResult result) => nvrtcGetErrorString(result);
 }
 
-internal sealed class NvrtcApi12 : INvrtcApi
+internal sealed class NvrtcApi12Linux : INvrtcApi
 {
     private const string Library = "libnvrtc.so.12";
 
@@ -774,7 +777,7 @@ internal sealed class NvrtcApi12 : INvrtcApi
     public IntPtr GetErrorString(NvrtcResult result) => nvrtcGetErrorString(result);
 }
 
-internal sealed class NvrtcApi118 : INvrtcApi
+internal sealed class NvrtcApi118Linux : INvrtcApi
 {
     private const string Library = "libnvrtc.so.11.8";
 
@@ -953,4 +956,4 @@ internal sealed class NvrtcApiDefault : INvrtcApi
     public NvrtcResult DestroyProgram(ref IntPtr prog) => nvrtcDestroyProgram(ref prog);
     public IntPtr GetErrorString(NvrtcResult result) => nvrtcGetErrorString(result);
 }
-#endif
+

--- a/src/AiDotNet.Tensors/Engines/GpuDriverCrossPlatformResolver.cs
+++ b/src/AiDotNet.Tensors/Engines/GpuDriverCrossPlatformResolver.cs
@@ -1,0 +1,109 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+#if NET5_0_OR_GREATER
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace AiDotNet.Tensors.Engines;
+
+/// <summary>
+/// Maps GPU driver/runtime library names across operating systems at RUNTIME.
+///
+/// <para>WHY: several native bindings historically baked the library name in with
+/// <c>#if WINDOWS</c> compile-time switches (e.g. <c>"nvcuda"</c> vs <c>"libcuda"</c>).
+/// The NuGet package ships ONE <c>lib/netX/AiDotNet.Tensors.dll</c> for all platforms,
+/// so whichever OS the package was BUILT on became the only OS whose GPU libraries
+/// could load — a package built on a Linux CI runner silently lost CUDA/HIP on every
+/// Windows machine (DllImport("libcuda") can never resolve there; the engine fell back
+/// to OpenCL with no visible error). This resolver makes the baked-in name irrelevant:
+/// any known alias of a GPU driver/runtime library resolves to the current platform's
+/// real library.</para>
+/// </summary>
+internal static class GpuDriverCrossPlatformResolver
+{
+    private static bool _registered;
+    private static readonly object _lock = new();
+
+    /// <summary>Idempotent registration into the shared assembly-level resolver chain.</summary>
+    public static void EnsureRegistered()
+    {
+        lock (_lock)
+        {
+            if (_registered) return;
+            _registered = true;
+            NativeLibraryResolverRegistry.Register(Resolve);
+        }
+    }
+
+    private static IntPtr Resolve(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
+    {
+        string[]? candidates = MapToPlatformCandidates(libraryName);
+        if (candidates is null)
+            return IntPtr.Zero;
+
+        foreach (var candidate in candidates)
+        {
+            // Skip the name the loader is already trying — returning Zero lets the
+            // default search handle it; we only add the cross-OS aliases.
+            if (string.Equals(candidate, libraryName, StringComparison.Ordinal))
+                continue;
+            if (NativeLibrary.TryLoad(candidate, assembly, searchPath, out var handle))
+                return handle;
+        }
+        return IntPtr.Zero;
+    }
+
+    /// <summary>
+    /// Returns the current platform's candidate names for a known GPU library alias,
+    /// or null when the name is not one of ours (lets the chain continue).
+    /// </summary>
+    private static string[]? MapToPlatformCandidates(string libraryName)
+    {
+        bool windows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        // NVIDIA driver (CUDA driver API)
+        if (libraryName is "nvcuda" or "libcuda" or "libcuda.so.1" or "libcuda.so")
+            return windows ? ["nvcuda"] : ["libcuda.so.1", "libcuda.so"];
+
+        // NVRTC (runtime compiler) — newest first; exact-version probing still happens
+        // upstream in NvrtcNativeBindings.ResolveApi, this is the cross-OS fallback.
+        if (libraryName.StartsWith("nvrtc64_", StringComparison.Ordinal) ||
+            libraryName.StartsWith("libnvrtc", StringComparison.Ordinal))
+        {
+            return windows
+                ? ["nvrtc64_130_0", "nvrtc64_120_0", "nvrtc64_12", "nvrtc64_118_0", "nvrtc64_112_0"]
+                : ["libnvrtc.so.13", "libnvrtc.so.12", "libnvrtc.so.11.8", "libnvrtc.so.11", "libnvrtc.so"];
+        }
+
+        // CUDA runtime
+        if (libraryName.StartsWith("cudart64_", StringComparison.Ordinal) ||
+            libraryName.StartsWith("libcudart", StringComparison.Ordinal))
+        {
+            return windows
+                ? ["cudart64_13", "cudart64_12", "cudart64_110"]
+                : ["libcudart.so.13", "libcudart.so.12", "libcudart.so"];
+        }
+
+        // cuBLAS (CuBlasNative has its own version-fallback resolver; this covers the
+        // cross-OS direction it cannot: a Linux-built assembly asking for libcublas on Windows)
+        if (libraryName.StartsWith("cublas64_", StringComparison.Ordinal) ||
+            libraryName.StartsWith("libcublas", StringComparison.Ordinal))
+        {
+            return windows
+                ? ["cublas64_13", "cublas64_12", "cublas64_11"]
+                : ["libcublas.so.13", "libcublas.so.12", "libcublas.so.11", "libcublas.so"];
+        }
+
+        // AMD HIP driver/runtime + hiprtc
+        if (libraryName.StartsWith("amdhip64", StringComparison.Ordinal) ||
+            libraryName.StartsWith("libamdhip64", StringComparison.Ordinal))
+            return windows ? ["amdhip64_6", "amdhip64"] : ["libamdhip64.so.6", "libamdhip64.so", "libamdhip64"];
+        if (libraryName.StartsWith("hiprtc", StringComparison.Ordinal) ||
+            libraryName.StartsWith("libhiprtc", StringComparison.Ordinal))
+            return windows ? ["hiprtc0604", "hiprtc"] : ["libhiprtc.so.6", "libhiprtc.so", "libhiprtc"];
+
+        return null;
+    }
+}
+#endif


### PR DESCRIPTION
## The bug (root cause of the Windows OpenCL fallback in all official packages ≥0.93.0)

The package ships **one** `lib/netX/AiDotNet.Tensors.dll` for every platform, but the GPU native library names are baked in with `#if WINDOWS` compile-time switches. Whichever OS the **publish CI runner** uses becomes the only OS whose GPU stack can load:

```csharp
#if WINDOWS
    private const string CudaLibrary = "nvcuda";
#else
    private const string CudaLibrary = "libcuda";   // ← what 0.93.0+ packages shipped
#endif
```

Decompiling the published binaries confirms it: **0.92.1 shipped `nvcuda` (Windows build), 0.93.0/0.94.0/0.94.1 ship `libcuda` (Linux build)** — the pipeline moved to a Linux runner at 0.93.0. On Windows, `DllImport("libcuda")` can never resolve → `CudaBackend.IsAvailable=false` → **silent OpenCL fallback** (no error anywhere). Downstream we measured a 3-epoch training smoke going from ~10 min (CUDA) to 2h18m (OpenCL + CUDA-graph-step env) before tracing it back here. nvrtc has the same issue (Linux-only `NvrtcApi*` probe chain shipped), as do cuBLAS and HIP names.

## The fix — make the baked-in name irrelevant

1. **`GpuDriverCrossPlatformResolver`** (new): runtime cross-OS mapping for driver / nvrtc / cudart / cuBLAS / HIP library names, registered into the existing `NativeLibraryResolverRegistry` chain from the bindings cctors (idempotent). A Linux-built assembly asking for `libcuda` on Windows gets `nvcuda.dll`; the reverse direction works too.
2. **`NvrtcNativeBindings.ResolveApi`**: candidate API list selected by `RuntimeInformation` at **runtime**; both OS class sets are always compiled (Linux duplicates renamed `NvrtcApi12Linux`/`NvrtcApi118Linux`).
3. **`CuBlasNative`**: both version-candidate arrays always compiled and runtime-selected; the resolver now intercepts any cuBLAS alias rather than only the compile-time name.
4. **csproj**: `net471` (a Windows-only runtime) always defines `WINDOWS` regardless of build OS — the resolver API doesn't exist there, so the constant must be right.

## Verification (Windows 11, RTX 3080, driver-only box)

- Built the assembly **without** the WINDOWS define (`-p:DefineConstants=""`), simulating the Linux-published package — decompile confirms `libcuda` baked in.
- Before fix: `CudaNativeBindings.IsAvailable=False`, `NvrtcNativeBindings.IsAvailable=False` (matches the shipped 0.94.1 package exactly, reproduced side-by-side).
- After fix, same Linux-simulated assembly: **both True**; full `CudaBackend` init succeeds (device adopted, kernels compile).
- Release build clean on net10.0 + net471.

Note for the release pipeline: no CI change is required for correctness after this PR, but republishing current packages with it restores CUDA for all Windows consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)