### PR TITLE
feat(opencl): FP16 GEMM (IGpuHalfPrecisionBackend) so MatrixMultiply<Half> runs on GPU (#560)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/HalfPrecisionGemmKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/HalfPrecisionGemmKernels.cs
@@ -1,0 +1,143 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// OpenCL half-precision (FP16) GEMM kernels for the IGpuHalfPrecisionBackend
+// capability interface (issue #560: route MatrixMultiply<Half> to an FP16
+// kernel instead of the scalar CPU fallback).
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL.Kernels;
+
+/// <summary>
+/// FP16 GEMM kernels: <c>C = A · B</c> with FP16 (half) inputs.
+/// <para>
+/// Storage convention matches the rest of the OpenCL backend: FP16 values are
+/// held in <c>ushort</c>-sized buffers (2 bytes each), the same layout
+/// <c>Fp16Kernels.convert_fp32_to_fp16</c> / <see cref="MixedPrecisionKernels"/>
+/// produce. Reads use the CORE OpenCL <c>vload_half</c> built-in (NOT the
+/// optional <c>cl_khr_fp16</c> extension), so these kernels compile and run on
+/// every OpenCL 1.0+ device regardless of whether it advertises native half
+/// arithmetic — the extension is only required to declare <c>half</c> scalar
+/// variables and do half-precision math, neither of which these kernels do.
+/// </para>
+/// <para>
+/// Two variants:
+/// <list type="bullet">
+/// <item><c>gemm_fp16in_fp32out</c> — FP16 inputs, FP32 accumulator and output.
+/// The industry-standard mixed-precision matmul (matches cuBLAS
+/// <c>cublasGemmEx(CUDA_R_16F in, CUBLAS_COMPUTE_32F)</c> and the AMP forward
+/// pass): half the memory bandwidth on activations, full FP32 accumulation so
+/// long matmul chains don't lose precision.</item>
+/// <item><c>gemm_fp16in_fp16out</c> — FP16 inputs and output, still accumulated
+/// in FP32 internally then rounded to half on store (matches <c>cublasHgemm</c>
+/// behaviour closely while avoiding the worst FP16-accumulation drift). For
+/// forward-only inference where a half result is wanted.</item>
+/// </list>
+/// </para>
+/// <para>
+/// Both are tiled (16×16 work-group, FP32 local-memory staging) so the per-tile
+/// reuse keeps RDNA/GCN/Intel/NVIDIA OpenCL devices compute-bound rather than
+/// bandwidth-bound. RDNA1 and earlier lack matrix cores, so this packed-load +
+/// FP32-accumulate path is the fastest correct option there; on hardware with
+/// cooperative-matrix support a future variant can swap the inner product for a
+/// matrix-core intrinsic without changing this contract.
+/// </para>
+/// </summary>
+internal static class HalfPrecisionGemmKernels
+{
+    /// <summary>Kernel name: FP16 inputs, FP32 accumulator + output.</summary>
+    public const string Fp16In32fOutKernelName = "gemm_fp16in_fp32out";
+
+    /// <summary>Kernel name: FP16 inputs, FP32 accumulator, FP16 output.</summary>
+    public const string Fp16In16fOutKernelName = "gemm_fp16in_fp16out";
+
+    /// <summary>Work-group tile size; global sizes are rounded up to a multiple of this.</summary>
+    public const int TileSize = 16;
+
+    /// <summary>The kernel names this source compiles, for cache registration.</summary>
+    public static string[] GetKernelNames() => new[]
+    {
+        Fp16In32fOutKernelName,
+        Fp16In16fOutKernelName,
+    };
+
+    /// <summary>OpenCL C source for the FP16 GEMM kernels.</summary>
+    public static string GetSource() => @"
+// FP16 GEMM kernels — C = A * B, row-major.
+//   A: M*K half values (stored as ushort), A[row*K + col]
+//   B: K*N half values (stored as ushort), B[row*N + col]
+//   C: M*N float (fp32 variant) or M*N half/ushort (fp16 variant)
+// Uses core OpenCL vload_half / vstore_half (NO cl_khr_fp16 dependency).
+
+#define HGEMM_TS 16
+
+__kernel void gemm_fp16in_fp32out(
+    __global const ushort* A,
+    __global const ushort* B,
+    __global float* C,
+    const int M, const int N, const int K)
+{
+    const int lx = get_local_id(0);              // column within tile (N axis)
+    const int ly = get_local_id(1);              // row within tile (M axis)
+    const int col = get_group_id(0) * HGEMM_TS + lx;  // global N index
+    const int row = get_group_id(1) * HGEMM_TS + ly;  // global M index
+
+    __local float Asub[HGEMM_TS][HGEMM_TS];
+    __local float Bsub[HGEMM_TS][HGEMM_TS];
+
+    float acc = 0.0f;
+    const int numTiles = (K + HGEMM_TS - 1) / HGEMM_TS;
+    for (int t = 0; t < numTiles; ++t)
+    {
+        const int aCol = t * HGEMM_TS + lx;      // K index for A
+        const int bRow = t * HGEMM_TS + ly;      // K index for B
+        Asub[ly][lx] = (row < M && aCol < K)
+            ? vload_half(row * K + aCol, (__global const half*)A) : 0.0f;
+        Bsub[ly][lx] = (bRow < K && col < N)
+            ? vload_half(bRow * N + col, (__global const half*)B) : 0.0f;
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int kk = 0; kk < HGEMM_TS; ++kk)
+            acc += Asub[ly][kk] * Bsub[kk][lx];
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (row < M && col < N)
+        C[row * N + col] = acc;
+}
+
+__kernel void gemm_fp16in_fp16out(
+    __global const ushort* A,
+    __global const ushort* B,
+    __global ushort* C,
+    const int M, const int N, const int K)
+{
+    const int lx = get_local_id(0);
+    const int ly = get_local_id(1);
+    const int col = get_group_id(0) * HGEMM_TS + lx;
+    const int row = get_group_id(1) * HGEMM_TS + ly;
+
+    __local float Asub[HGEMM_TS][HGEMM_TS];
+    __local float Bsub[HGEMM_TS][HGEMM_TS];
+
+    float acc = 0.0f;
+    const int numTiles = (K + HGEMM_TS - 1) / HGEMM_TS;
+    for (int t = 0; t < numTiles; ++t)
+    {
+        const int aCol = t * HGEMM_TS + lx;
+        const int bRow = t * HGEMM_TS + ly;
+        Asub[ly][lx] = (row < M && aCol < K)
+            ? vload_half(row * K + aCol, (__global const half*)A) : 0.0f;
+        Bsub[ly][lx] = (bRow < K && col < N)
+            ? vload_half(bRow * N + col, (__global const half*)B) : 0.0f;
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int kk = 0; kk < HGEMM_TS; ++kk)
+            acc += Asub[ly][kk] * Bsub[kk][lx];
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (row < M && col < N)
+        vstore_half(acc, row * N + col, (__global half*)C);
+}
+";
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.HalfPrecision.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.HalfPrecision.cs
@@ -1,0 +1,127 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// IGpuHalfPrecisionBackend implementation for the OpenCL backend (issue #560):
+// FP16 GEMM so MatrixMultiply<Half> runs on the GPU instead of dropping to a
+// scalar CPU fallback.
+
+using System;
+using AiDotNet.Tensors.Engines.DirectGpu.OpenCL.Kernels;
+using AiDotNet.Tensors.Engines.Gpu;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
+{
+    /// <summary>
+    /// Half-precision GEMM dispatch for the <see cref="IGpuHalfPrecisionBackend"/>
+    /// capability interface. Mirrors the CUDA backend's contract so the
+    /// backend-agnostic <c>DirectGpuTensorEngine.MatrixMultiply</c> FP16 path
+    /// (issue #560) lights up on OpenCL devices — AMD, Intel, and NVIDIA — with
+    /// no extra dispatch logic in the engine.
+    /// </summary>
+    public sealed partial class OpenClBackend : IGpuHalfPrecisionBackend
+    {
+        private readonly object _halfGemmLock = new();
+        private bool _halfGemmKernelsTried;
+        private bool _halfGemmKernelsAvailable;
+
+        /// <inheritdoc/>
+        /// <remarks>
+        /// True once the FP16 GEMM kernels compile on this device. The kernels
+        /// use the CORE OpenCL <c>vload_half</c> built-in (not the optional
+        /// <c>cl_khr_fp16</c> extension), so they are expected to be available
+        /// on every OpenCL 1.0+ device; the flag still gates on a successful
+        /// compile so a broken driver degrades gracefully to the CPU path.
+        /// </remarks>
+        public bool SupportsHgemm => EnsureHalfGemmKernels();
+
+        /// <inheritdoc/>
+        public void Hgemm(IGpuBuffer aFp16, IGpuBuffer bFp16, IGpuBuffer cFp16,
+            int m, int n, int k)
+            => DispatchHalfGemm(HalfPrecisionGemmKernels.Fp16In16fOutKernelName,
+                aFp16, bFp16, cFp16, m, n, k);
+
+        /// <inheritdoc/>
+        public void GemmFp16In32fOut(IGpuBuffer aFp16, IGpuBuffer bFp16, IGpuBuffer cFp32,
+            int m, int n, int k)
+            => DispatchHalfGemm(HalfPrecisionGemmKernels.Fp16In32fOutKernelName,
+                aFp16, bFp16, cFp32, m, n, k);
+
+        /// <summary>
+        /// Lazily compiles and caches the FP16 GEMM kernels on first use.
+        /// Non-fatal on failure (returns false → caller falls back to CPU).
+        /// </summary>
+        private bool EnsureHalfGemmKernels()
+        {
+            if (_halfGemmKernelsTried)
+                return _halfGemmKernelsAvailable;
+
+            lock (_halfGemmLock)
+            {
+                if (_halfGemmKernelsTried)
+                    return _halfGemmKernelsAvailable;
+
+                _halfGemmKernelsTried = true;
+
+                if (_context == null)
+                {
+                    _halfGemmKernelsAvailable = false;
+                    return false;
+                }
+
+                try
+                {
+                    var program = CompileOrLoadCached(
+                        HalfPrecisionGemmKernels.GetSource(),
+                        OpenClBuildOptions.OptimizationFlags,
+                        "Half-precision GEMM kernels");
+                    _programs.Add(program);
+                    foreach (var name in HalfPrecisionGemmKernels.GetKernelNames())
+                        _kernelCache[name] = new DirectOpenClKernel(_context, program, name);
+
+                    _halfGemmKernelsAvailable = true;
+                }
+                catch (Exception ex)
+                {
+                    // Non-fatal: a driver that rejects the kernel just means
+                    // Half matmul stays on the CPU path. Don't crash init.
+                    WriteDiag($"[OpenClBackend] Half-precision GEMM kernel compilation failed (non-fatal): {ex.Message}");
+                    _halfGemmKernelsAvailable = false;
+                }
+
+                return _halfGemmKernelsAvailable;
+            }
+        }
+
+        private void DispatchHalfGemm(string kernelName, IGpuBuffer a, IGpuBuffer b, IGpuBuffer c,
+            int m, int n, int k)
+        {
+            if (a is null) throw new ArgumentNullException(nameof(a));
+            if (b is null) throw new ArgumentNullException(nameof(b));
+            if (c is null) throw new ArgumentNullException(nameof(c));
+            // Report the offending dimension by name (mirrors the CUDA backend)
+            // so a bad shape is diagnosable rather than failing opaquely in the kernel.
+            if (m <= 0) throw new ArgumentOutOfRangeException(nameof(m), "Dimensions must be positive.");
+            if (n <= 0) throw new ArgumentOutOfRangeException(nameof(n), "Dimensions must be positive.");
+            if (k <= 0) throw new ArgumentOutOfRangeException(nameof(k), "Dimensions must be positive.");
+
+            if (!EnsureHalfGemmKernels() || !_kernelCache.TryGetValue(kernelName, out var kernel))
+                throw new NotSupportedException(
+                    "Half-precision GEMM kernels are not available on this OpenCL device.");
+
+            const int ts = HalfPrecisionGemmKernels.TileSize;
+
+            uint arg = 0;
+            kernel.SetArg(arg++, ((DirectOpenClGpuBuffer)a).Buffer.Handle);
+            kernel.SetArg(arg++, ((DirectOpenClGpuBuffer)b).Buffer.Handle);
+            kernel.SetArg(arg++, ((DirectOpenClGpuBuffer)c).Buffer.Handle);
+            kernel.SetArg(arg++, m);
+            kernel.SetArg(arg++, n);
+            kernel.SetArg(arg++, k);
+
+            // Global sizes rounded up to a full tile; the kernel guards the
+            // out-of-range lanes (they still participate in the local-memory
+            // loads + barriers but skip the final store).
+            int globalX = ((n + ts - 1) / ts) * ts;   // N axis (dim 0)
+            int globalY = ((m + ts - 1) / ts) * ts;   // M axis (dim 1)
+            kernel.Execute2D(globalX, globalY, ts, ts);
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/OpenClHalfPrecisionGemmTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/OpenClHalfPrecisionGemmTests.cs
@@ -1,0 +1,214 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Correctness tests for the OpenCL IGpuHalfPrecisionBackend implementation
+// (issue #560): FP16 GEMM (C = A·B) on the GPU instead of a scalar CPU fallback.
+
+// System.Half (the FP16 oracle) only exists on .NET 5+, and the FP16 GPU path is
+// exercised only on the modern TFM anyway; net471 builds skip this file.
+#if NET6_0_OR_GREATER
+
+using System;
+using AiDotNet.Tensors.Engines.DirectGpu;
+using AiDotNet.Tensors.Engines.DirectGpu.OpenCL;
+using AiDotNet.Tensors.Engines.Gpu;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
+
+/// <summary>
+/// Exercises <see cref="IGpuHalfPrecisionBackend.GemmFp16In32fOut"/> and
+/// <see cref="IGpuHalfPrecisionBackend.Hgemm"/> on the OpenCL backend against a
+/// CPU reference computed from the SAME FP16-rounded inputs, so the only
+/// residual error is FP32 accumulation order — proving the GPU FP16 kernel is
+/// numerically correct, not just non-crashing.
+/// <para>
+/// Tests run on any OpenCL device (the kernels use the core <c>vload_half</c>
+/// built-in, not <c>cl_khr_fp16</c>). When a GPU is genuinely unavailable they
+/// skip — unless <c>AIDOTNET_REQUIRE_GPU_TESTS=1</c> is set, in which case they
+/// throw so a CI lane that is supposed to have a GPU surfaces the failure loudly
+/// rather than passing as a no-op.
+/// </para>
+/// </summary>
+public sealed class OpenClHalfPrecisionGemmTests : IDisposable
+{
+    private readonly OpenClBackend _backend;
+    private readonly bool _ready;
+    private readonly Exception _initException;
+
+    public OpenClHalfPrecisionGemmTests()
+    {
+        try
+        {
+            _backend = new OpenClBackend();
+            _ready = _backend.IsAvailable && _backend.SupportsHgemm;
+        }
+        catch (Exception ex)
+        {
+            _initException = ex;
+            _ready = false;
+        }
+    }
+
+    public void Dispose() => _backend?.Dispose();
+
+    private bool EnsureReady()
+    {
+        if (_ready) return true;
+        if (string.Equals(
+                Environment.GetEnvironmentVariable("AIDOTNET_REQUIRE_GPU_TESTS"),
+                "1",
+                StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "GPU tests were required (AIDOTNET_REQUIRE_GPU_TESTS=1) but the OpenCL " +
+                "backend or its FP16 GEMM kernels were unavailable.",
+                _initException);
+        }
+
+        return false;
+    }
+
+    // Round-trip a value through IEEE-754 binary16 exactly as the GPU does, so
+    // the CPU oracle and the GPU kernel start from identical FP16 inputs.
+    private static float ToFp16AndBack(float value) => (float)(System.Half)value;
+
+    private static float[] RandomMatrix(int rows, int cols, int seed)
+    {
+        var rng = new Random(seed);
+        var data = new float[rows * cols];
+        for (int i = 0; i < data.Length; i++)
+            data[i] = (float)(rng.NextDouble() * 2.0 - 1.0); // [-1, 1)
+        return data;
+    }
+
+    // C = A·B in FP32 from FP16-rounded inputs (row-major).
+    private static float[] CpuReferenceFromFp16(float[] a, float[] b, int m, int n, int k)
+    {
+        var c = new float[m * n];
+        for (int i = 0; i < m; i++)
+        {
+            for (int j = 0; j < n; j++)
+            {
+                float acc = 0f;
+                for (int l = 0; l < k; l++)
+                    acc += ToFp16AndBack(a[i * k + l]) * ToFp16AndBack(b[l * n + j]);
+                c[i * n + j] = acc;
+            }
+        }
+
+        return c;
+    }
+
+    private (IGpuBuffer aFp16, IGpuBuffer bFp16) UploadFp16Inputs(
+        float[] a, float[] b, int m, int n, int k)
+    {
+        // Upload FP32, then convert to FP16 on the device (cl_khr_fp16 path) —
+        // the same two ConvertToFp16 calls the engine's MatrixMultiply makes.
+        var aFp32 = _backend.AllocateBuffer(a);
+        var bFp32 = _backend.AllocateBuffer(b);
+
+        // FP16 buffers hold M*K / K*N halfs (2 bytes each). Allocating that many
+        // floats over-allocates (4 bytes each) which is harmless and mirrors the
+        // CUDA engine path's AllocateOutputBuffer(M*K) sizing.
+        var aFp16 = _backend.AllocateBuffer(m * k);
+        var bFp16 = _backend.AllocateBuffer(k * n);
+        _backend.ConvertToFp16(aFp32, aFp16, m * k);
+        _backend.ConvertToFp16(bFp32, bFp16, k * n);
+
+        aFp32.Dispose();
+        bFp32.Dispose();
+        return (aFp16, bFp16);
+    }
+
+    private static void AssertClose(float[] expected, float[] actual, double absTol, double relTol)
+    {
+        Assert.Equal(expected.Length, actual.Length);
+        double worst = 0;
+        for (int i = 0; i < expected.Length; i++)
+        {
+            double diff = Math.Abs(expected[i] - actual[i]);
+            double tol = absTol + relTol * Math.Abs(expected[i]);
+            worst = Math.Max(worst, diff - tol);
+            Assert.True(diff <= tol,
+                $"FP16 GEMM mismatch at [{i}]: expected {expected[i]}, got {actual[i]} " +
+                $"(|diff|={diff}, tol={tol}).");
+        }
+    }
+
+    [SkippableTheory]
+    [InlineData(16, 16, 16)]    // exactly one tile
+    [InlineData(64, 48, 96)]    // aligned multi-tile
+    [InlineData(37, 53, 71)]    // ragged (exercises out-of-range tile guards)
+    [InlineData(128, 128, 256)] // larger, deeper K
+    public void GemmFp16In32fOut_MatchesCpuReference(int m, int n, int k)
+    {
+        Skip.If(!EnsureReady(), "OpenCL FP16 GEMM not available on this system.");
+
+        var a = RandomMatrix(m, k, seed: 1234 + m + k);
+        var b = RandomMatrix(k, n, seed: 5678 + n + k);
+        var expected = CpuReferenceFromFp16(a, b, m, n, k);
+
+        var (aFp16, bFp16) = UploadFp16Inputs(a, b, m, n, k);
+        using var cBuf = _backend.AllocateBuffer(m * n);
+        try
+        {
+            ((IGpuHalfPrecisionBackend)_backend).GemmFp16In32fOut(aFp16, bFp16, cBuf, m, n, k);
+            var actual = _backend.DownloadBuffer(cBuf);
+            // Inputs already FP16-rounded on both sides; remaining error is just
+            // FP32 accumulation order across the tiled K loop.
+            AssertClose(expected, actual, absTol: 1e-2, relTol: 1e-2);
+        }
+        finally
+        {
+            aFp16.Dispose();
+            bFp16.Dispose();
+        }
+    }
+
+    [SkippableFact]
+    public void Hgemm_Fp16Output_MatchesCpuReferenceWithinHalfPrecision()
+    {
+        Skip.If(!EnsureReady(), "OpenCL FP16 GEMM not available on this system.");
+
+        const int m = 64, n = 64, k = 128;
+        var a = RandomMatrix(m, k, seed: 24);
+        var b = RandomMatrix(k, n, seed: 42);
+        var expected = CpuReferenceFromFp16(a, b, m, n, k);
+
+        var (aFp16, bFp16) = UploadFp16Inputs(a, b, m, n, k);
+        // FP16 output buffer (M*N halfs); over-allocate as floats.
+        using var cFp16 = _backend.AllocateBuffer(m * n);
+        // Convert the FP16 result back to FP32 for comparison.
+        using var cFp32 = _backend.AllocateBuffer(m * n);
+        try
+        {
+            ((IGpuHalfPrecisionBackend)_backend).Hgemm(aFp16, bFp16, cFp16, m, n, k);
+            _backend.ConvertToFp32(cFp16, cFp32, m * n);
+            var actual = _backend.DownloadBuffer(cFp32);
+            // The result itself is rounded to FP16, so the dominant error is the
+            // final half-rounding of the accumulated value (~1e-3 relative).
+            AssertClose(expected, actual, absTol: 5e-2, relTol: 3e-2);
+        }
+        finally
+        {
+            aFp16.Dispose();
+            bFp16.Dispose();
+        }
+    }
+
+    [SkippableFact]
+    public void GemmFp16In32fOut_RejectsNonPositiveDimensions()
+    {
+        Skip.If(!EnsureReady(), "OpenCL FP16 GEMM not available on this system.");
+
+        using var dummy = _backend.AllocateBuffer(4);
+        var half = (IGpuHalfPrecisionBackend)_backend;
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => half.GemmFp16In32fOut(dummy, dummy, dummy, 0, 4, 4));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => half.GemmFp16In32fOut(dummy, dummy, dummy, 4, -1, 4));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => half.GemmFp16In32fOut(dummy, dummy, dummy, 4, 4, 0));
+    }
+}
+
+#endif


### PR DESCRIPTION
## Problem (part of #560: full GPU FP16 support across all backends)

The FP16 mixed-precision/tensor-core capability interface `IGpuHalfPrecisionBackend` (`SupportsHgemm` / `Hgemm` / `GemmFp16In32fOut`) was implemented **only on CUDA** (PR #592). On every other GPU backend (OpenCL, HIP, Vulkan, Metal, WebGpu) a `Half` matmul never reaches an FP16 kernel — it falls through to `backend.Gemm`, which is FP32-only and reads the FP16 bytes as garbage. So Half GEMM is effectively **broken** (not just slow) off CUDA.

This PR adds the **OpenCL** implementation — covering AMD, Intel, and NVIDIA OpenCL devices.

## What's here

- **`HalfPrecisionGemmKernels.cs`** — row-major `C = A·B`, 16×16 tiled GEMM. FP16 inputs are loaded via the **core OpenCL `vload_half` built-in** (not the optional `cl_khr_fp16` extension — that's only required for half *arithmetic*, not half storage load/store), accumulated in **FP32**. Two variants:
  - `gemm_fp16in_fp32out` — FP16 in, FP32 accumulate + output. The AMP standard; matches cuBLAS `cublasGemmEx(CUDA_R_16F, COMPUTE_32F)`.
  - `gemm_fp16in_fp16out` — FP16 in/out, FP32 accumulate internally then round on store (matches `cublasHgemm` behaviour without the worst accumulation drift).
  Runs on **every OpenCL 1.0+ device**. Cooperative-matrix/tensor-core acceleration is a future perf pass for hardware that has matrix cores (RDNA3+/Turing+); RDNA1 and earlier use this packed-load + FP32-accumulate path, which is the fastest correct option there.

- **`OpenClBackend.HalfPrecision.cs`** — implements `IGpuHalfPrecisionBackend`. Lazy-compiles the kernels (non-fatal: a driver that rejects them just leaves `SupportsHgemm` false → graceful CPU fallback). Mirrors the CUDA backend's row-major contract and per-dimension validation.

- **`OpenClHalfPrecisionGemmTests.cs`** — calls `GemmFp16In32fOut`/`Hgemm` directly and compares to a CPU reference computed from the **same FP16-rounded inputs**, so the only residual error is FP32 accumulation order (proves numerical correctness, not just non-crashing). Honors `AIDOTNET_REQUIRE_GPU_TESTS=1` (throws instead of skipping when a GPU is required, per the no-silent-pass guideline). Guarded `#if NET6_0_OR_GREATER` (`System.Half`).

## Verification

Run **forced on the GPU** (`AIDOTNET_REQUIRE_GPU_TESTS=1`) on an **AMD Radeon RX 5500 XT (RDNA1)** — 0 skipped:
```
Passed!  - Failed: 0, Passed: 6, Skipped: 0
```
Covers one-tile, aligned multi-tile, ragged (out-of-range tile guards), large-K, the FP16-output variant, and dimension validation. net471 src build is green (the partial is net471-safe; the Half test is guarded out).

## Engine wiring

The engine-level Half dispatch in `DirectGpuTensorEngine.MatrixMultiply` is **backend-agnostic** (checks `backend is IGpuHalfPrecisionBackend`) and is added by #592. Once #592 lands, this OpenCL capability is used automatically by `IEngine.MatrixMultiply<Half>` — no engine change needed here. The capability is also directly callable today (e.g. AMP forward paths).

Next backends in the #560 lane: HIP, Vulkan, Metal, WebGpu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)