### PR TITLE
feat(webgpu): FP16 GEMM (IGpuHalfPrecisionBackend) so MatrixMultiply<Half> runs on GPU (#560)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.HalfPrecision.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.HalfPrecision.cs
@@ -1,0 +1,79 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// IGpuHalfPrecisionBackend implementation for the WebGPU backend (issue #560):
+// FP16 GEMM so MatrixMultiply<Half> runs on the GPU instead of dropping to a
+// scalar CPU fallback.
+
+
+// WebGPU is only available on .NET 7+ (Blazor WebAssembly / Dawn); the rest of
+// the backend is compiled out on net471, so this partial must be too.
+#if NET7_0_OR_GREATER
+using System;
+using AiDotNet.Tensors.Engines.Gpu;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.WebGpu;
+
+/// <summary>
+/// Half-precision GEMM dispatch for the <see cref="IGpuHalfPrecisionBackend"/>
+/// capability interface, so the backend-agnostic
+/// <c>DirectGpuTensorEngine.MatrixMultiply</c> FP16 path (issue #560) runs on
+/// WebGPU devices instead of falling back to the scalar CPU loop.
+/// <para>
+/// WebGPU has no native 16-bit storage by default — the optional
+/// <c>shader-f16</c> feature is not used here, and all WebGPU buffers are f32.
+/// This backend therefore models FP16 as f32 with a truncated 10-bit mantissa
+/// (see <see cref="ConvertToFp16"/>). Under that model an FP16 GEMM is exactly
+/// the existing real WGSL f32 GEMM run on the truncated-precision inputs: the
+/// multiply sees FP16-precision operands, the accumulation is full FP32, and the
+/// f32 output flows on to downstream ops — which is precisely the
+/// <see cref="GemmFp16In32fOut"/> (mixed-precision) contract. No separate FP16
+/// kernel is needed because the data is already f32.
+/// </para>
+/// </summary>
+public sealed partial class WebGpuBackend : IGpuHalfPrecisionBackend
+{
+    /// <inheritdoc/>
+    /// <remarks>
+    /// True whenever the backend is initialized: the real WGSL GEMM that backs
+    /// the FP16 path is always present (WebGPU has no CPU-fallback GEMM), so the
+    /// only gate is device availability.
+    /// </remarks>
+    public bool SupportsHgemm => IsAvailable;
+
+    /// <inheritdoc/>
+    public void GemmFp16In32fOut(IGpuBuffer aFp16, IGpuBuffer bFp16, IGpuBuffer cFp32,
+        int m, int n, int k)
+    {
+        ValidateHalfGemmArgs(aFp16, bFp16, cFp32, m, n, k);
+        // Inputs already carry FP16 precision (f32 storage, truncated mantissa);
+        // the WGSL GEMM accumulates in f32 and writes an f32 result.
+        Gemm(aFp16, bFp16, cFp32, m, n, k);
+    }
+
+    /// <inheritdoc/>
+    public void Hgemm(IGpuBuffer aFp16, IGpuBuffer bFp16, IGpuBuffer cFp16,
+        int m, int n, int k)
+    {
+        ValidateHalfGemmArgs(aFp16, bFp16, cFp16, m, n, k);
+        // Accumulate in f32 into a scratch buffer, then round the result down to
+        // FP16 precision so the output buffer carries half-precision values
+        // (matches cublasHgemm's FP16 output). A separate scratch avoids binding
+        // the same buffer as both GEMM output and convert input.
+        using var scratch = AllocateBuffer(m * n);
+        Gemm(aFp16, bFp16, scratch, m, n, k);
+        ConvertToFp16(scratch, cFp16, m * n);
+    }
+
+    private static void ValidateHalfGemmArgs(IGpuBuffer a, IGpuBuffer b, IGpuBuffer c,
+        int m, int n, int k)
+    {
+        if (a is null) throw new ArgumentNullException(nameof(a));
+        if (b is null) throw new ArgumentNullException(nameof(b));
+        if (c is null) throw new ArgumentNullException(nameof(c));
+        // Report the offending dimension by name (mirrors the CUDA backend).
+        if (m <= 0) throw new ArgumentOutOfRangeException(nameof(m), "Dimensions must be positive.");
+        if (n <= 0) throw new ArgumentOutOfRangeException(nameof(n), "Dimensions must be positive.");
+        if (k <= 0) throw new ArgumentOutOfRangeException(nameof(k), "Dimensions must be positive.");
+    }
+}
+
+#endif

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/WebGpuHalfPrecisionGemmTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/WebGpuHalfPrecisionGemmTests.cs
@@ -1,0 +1,196 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Correctness tests for the WebGPU IGpuHalfPrecisionBackend implementation
+// (issue #560): FP16 GEMM (C = A·B) on the GPU instead of a scalar CPU fallback.
+
+
+// WebGpuBackend only exists on .NET 7+; net471 excludes this test.
+#if NET7_0_OR_GREATER
+using System;
+using AiDotNet.Tensors.Engines.DirectGpu;
+using AiDotNet.Tensors.Engines.DirectGpu.WebGpu;
+using AiDotNet.Tensors.Engines.Gpu;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
+
+/// <summary>
+/// Exercises <see cref="IGpuHalfPrecisionBackend.GemmFp16In32fOut"/> and
+/// <see cref="IGpuHalfPrecisionBackend.Hgemm"/> on the WebGPU backend.
+/// <para>
+/// WebGPU models FP16 as f32 with a truncated mantissa, so the oracle downloads
+/// the exact truncated f32 operands the GPU multiplies and recomputes the
+/// reference from those — the only residual error is f32 accumulation order,
+/// proving the GPU FP16 GEMM is numerically correct rather than just
+/// non-crashing. Honors <c>AIDOTNET_REQUIRE_GPU_TESTS=1</c> (throws instead of
+/// skipping when a GPU is required) per the no-silent-pass guideline.
+/// </para>
+/// </summary>
+public sealed class WebGpuHalfPrecisionGemmTests : IDisposable
+{
+    private readonly WebGpuBackend _backend;
+    private readonly bool _ready;
+    private readonly Exception _initException;
+
+    public WebGpuHalfPrecisionGemmTests()
+    {
+        try
+        {
+            _backend = new WebGpuBackend();
+            _ready = _backend.IsAvailable && _backend.SupportsHgemm;
+        }
+        catch (Exception ex)
+        {
+            _initException = ex;
+            _ready = false;
+        }
+    }
+
+    public void Dispose() => _backend?.Dispose();
+
+    private bool EnsureReady()
+    {
+        if (_ready) return true;
+        if (string.Equals(
+                Environment.GetEnvironmentVariable("AIDOTNET_REQUIRE_GPU_TESTS"),
+                "1",
+                StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "GPU tests were required (AIDOTNET_REQUIRE_GPU_TESTS=1) but the WebGPU " +
+                "backend was unavailable.",
+                _initException);
+        }
+
+        return false;
+    }
+
+    private static float[] RandomMatrix(int rows, int cols, int seed)
+    {
+        var rng = new Random(seed);
+        var data = new float[rows * cols];
+        for (int i = 0; i < data.Length; i++)
+            data[i] = (float)(rng.NextDouble() * 2.0 - 1.0); // [-1, 1)
+        return data;
+    }
+
+    // C = A·B in f32 from the EXACT (FP16-truncated) operands the GPU used.
+    private static float[] CpuReference(float[] a, float[] b, int m, int n, int k)
+    {
+        var c = new float[m * n];
+        for (int i = 0; i < m; i++)
+        {
+            for (int j = 0; j < n; j++)
+            {
+                float acc = 0f;
+                for (int l = 0; l < k; l++)
+                    acc += a[i * k + l] * b[l * n + j];
+                c[i * n + j] = acc;
+            }
+        }
+
+        return c;
+    }
+
+    private static void AssertClose(float[] expected, float[] actual, double absTol, double relTol)
+    {
+        Assert.Equal(expected.Length, actual.Length);
+        for (int i = 0; i < expected.Length; i++)
+        {
+            double diff = Math.Abs(expected[i] - actual[i]);
+            double tol = absTol + relTol * Math.Abs(expected[i]);
+            Assert.True(diff <= tol,
+                $"FP16 GEMM mismatch at [{i}]: expected {expected[i]}, got {actual[i]} " +
+                $"(|diff|={diff}, tol={tol}).");
+        }
+    }
+
+    // Upload FP32, truncate to FP16 precision on the device, and return both the
+    // FP16 buffers and the EXACT truncated host values the GPU will multiply.
+    private (IGpuBuffer aFp16, IGpuBuffer bFp16, float[] aTrunc, float[] bTrunc) PrepareFp16Inputs(
+        float[] a, float[] b, int m, int n, int k)
+    {
+        using var aFp32 = _backend.AllocateBuffer(a);
+        using var bFp32 = _backend.AllocateBuffer(b);
+        var aFp16 = _backend.AllocateBuffer(m * k);
+        var bFp16 = _backend.AllocateBuffer(k * n);
+        _backend.ConvertToFp16(aFp32, aFp16, m * k);
+        _backend.ConvertToFp16(bFp32, bFp16, k * n);
+
+        var aTrunc = _backend.DownloadBuffer(aFp16);
+        var bTrunc = _backend.DownloadBuffer(bFp16);
+        return (aFp16, bFp16, aTrunc, bTrunc);
+    }
+
+    [SkippableTheory]
+    [InlineData(16, 16, 16)]
+    [InlineData(64, 48, 96)]
+    [InlineData(37, 53, 71)]
+    [InlineData(128, 128, 256)]
+    public void GemmFp16In32fOut_MatchesCpuReference(int m, int n, int k)
+    {
+        Skip.If(!EnsureReady(), "WebGPU FP16 GEMM not available on this system.");
+
+        var a = RandomMatrix(m, k, seed: 1234 + m + k);
+        var b = RandomMatrix(k, n, seed: 5678 + n + k);
+
+        var (aFp16, bFp16, aTrunc, bTrunc) = PrepareFp16Inputs(a, b, m, n, k);
+        using var cBuf = _backend.AllocateBuffer(m * n);
+        try
+        {
+            ((IGpuHalfPrecisionBackend)_backend).GemmFp16In32fOut(aFp16, bFp16, cBuf, m, n, k);
+            var actual = _backend.DownloadBuffer(cBuf);
+            var expected = CpuReference(aTrunc, bTrunc, m, n, k);
+            AssertClose(expected, actual, absTol: 1e-2, relTol: 1e-2);
+        }
+        finally
+        {
+            aFp16.Dispose();
+            bFp16.Dispose();
+        }
+    }
+
+    [SkippableFact]
+    public void Hgemm_Fp16Output_MatchesCpuReferenceWithinHalfPrecision()
+    {
+        Skip.If(!EnsureReady(), "WebGPU FP16 GEMM not available on this system.");
+
+        const int m = 64, n = 64, k = 128;
+        var a = RandomMatrix(m, k, seed: 24);
+        var b = RandomMatrix(k, n, seed: 42);
+
+        var (aFp16, bFp16, aTrunc, bTrunc) = PrepareFp16Inputs(a, b, m, n, k);
+        using var cFp16 = _backend.AllocateBuffer(m * n);
+        try
+        {
+            ((IGpuHalfPrecisionBackend)_backend).Hgemm(aFp16, bFp16, cFp16, m, n, k);
+            // WebGPU FP16 output is already f32-storage (truncated), so download directly.
+            var actual = _backend.DownloadBuffer(cFp16);
+            var expected = CpuReference(aTrunc, bTrunc, m, n, k);
+            // The result is rounded to FP16 precision, so the dominant error is the
+            // final mantissa truncation of the accumulated value.
+            AssertClose(expected, actual, absTol: 5e-2, relTol: 3e-2);
+        }
+        finally
+        {
+            aFp16.Dispose();
+            bFp16.Dispose();
+        }
+    }
+
+    [SkippableFact]
+    public void GemmFp16In32fOut_RejectsNonPositiveDimensions()
+    {
+        Skip.If(!EnsureReady(), "WebGPU FP16 GEMM not available on this system.");
+
+        using var dummy = _backend.AllocateBuffer(4);
+        var half = (IGpuHalfPrecisionBackend)_backend;
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => half.GemmFp16In32fOut(dummy, dummy, dummy, 0, 4, 4));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => half.GemmFp16In32fOut(dummy, dummy, dummy, 4, -1, 4));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => half.GemmFp16In32fOut(dummy, dummy, dummy, 4, 4, 0));
+    }
+}
+
+#endif


### PR DESCRIPTION
## Problem (part of #560: full GPU FP16 support across all backends)

The FP16 capability interface `IGpuHalfPrecisionBackend` (`SupportsHgemm` / `Hgemm` / `GemmFp16In32fOut`) was CUDA-only (PR #592). Without it, a `Half` matmul on WebGPU never reaches an FP16 path and falls through to the scalar CPU loop. This adds the **WebGPU** implementation.

## Approach

WebGPU has **no native 16-bit storage** by default — the optional `shader-f16` feature isn't used and all WebGPU buffers are f32. This backend already models FP16 as **f32 with a truncated 10-bit mantissa** (see `ConvertToFp16`). Under that model an FP16 GEMM is exactly the existing **real WGSL f32 GEMM** run on the truncated-precision inputs: FP16-precision multiply, FP32 accumulation, f32 output — precisely the `GemmFp16In32fOut` (mixed-precision) contract. No separate FP16 kernel is needed because the data is already f32.

- `GemmFp16In32fOut` delegates to the real WGSL GEMM.
- `Hgemm` accumulates in f32 into scratch, then truncates the output to FP16 via `ConvertToFp16` (matches `cublasHgemm`'s FP16 output).
- Mirrors the CUDA backend's per-dimension validation. Guarded `#if NET7_0_OR_GREATER` (the WebGPU backend is net7+ only).

## Verification

- Builds clean on **net10.0 + net471**.
- Test (`WebGpuHalfPrecisionGemmTests`) downloads the **exact FP16-truncated operands** the GPU multiplies and recomputes the reference from those, so the only residual error is f32 accumulation order (proves numerical correctness, not just non-crashing). Honors `AIDOTNET_REQUIRE_GPU_TESTS=1` — **verified the no-silent-pass gate fires** (forced run throws when WebGPU is absent).
- WebGPU/Dawn is **not set up on the dev machine** (AMD, Windows, no Dawn runtime), so the GPU tests skip here; correctness must be confirmed on WebGPU-capable hardware. The logic is a thin delegation to the already-tested WGSL GEMM + `ConvertToFp16`, both covered by the WebGPU backend's existing suite.

## Engine wiring

Backend-agnostic Half dispatch (`backend is IGpuHalfPrecisionBackend`) is provided by #592; once it lands, this capability is used automatically by `IEngine.MatrixMultiply<Half>`.

Companion to #597 (OpenCL FP16 GEMM, verified on AMD hardware). Next in the #560 lane: HIP, then real GPU GEMM pipelines for Vulkan and Metal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)