### PR TITLE
feat(vulkan): real GPU GEMM (FP32 + FP16 mixed-precision) for #560

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/ShadercNativeBindings.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/ShadercNativeBindings.cs
@@ -14,8 +14,12 @@ internal static class ShadercNativeBindings
     private const string ShadercWindows = "shaderc_shared";
     private const string ShadercLinux = "libshaderc_shared";
 
-    // Shader kind for compute shaders
-    public const int shaderc_compute_shader = 5;
+    // Shader kind for compute shaders. shaderc_shader_kind enum order is
+    // vertex=0, fragment=1, compute=2, geometry=3, tess_control=4,
+    // tess_evaluation=5 — so compute is 2 (5 was tessellation-evaluation, which
+    // made every GLSL compute dispatch fail "local_size_x: no such layout
+    // identifier for this stage" and silently fall back to the CPU path).
+    public const int shaderc_compute_shader = 2;
 
     // Compilation status
     public const int shaderc_compilation_status_success = 0;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend.cs
@@ -332,6 +332,14 @@ public sealed unsafe partial class VulkanBackend
     public void Gemm(IGpuBuffer A, IGpuBuffer B, IGpuBuffer C, int M, int N, int K, float alpha = 1.0f, float beta = 0.0f)
     {
         EnsureInitialized();
+
+        // GPU fast path: plain C = A·B (alpha=1, beta=0) runs on-device via the
+        // GLSL GEMM compute shader. This is the common case (MatMul calls Gemm
+        // with the defaults). Scaled/accumulating GEMM (alpha≠1 or beta≠0) and
+        // hosts without libshaderc fall through to the managed loop below.
+        if (alpha == 1.0f && beta == 0.0f && TryGlslGemmFp32(A, B, C, M, N, K))
+            return;
+
         var a = DownloadBuffer(A);
         var b = DownloadBuffer(B);
         // Skip downloading C when beta is 0 since existing values are not needed
@@ -347,6 +355,35 @@ public sealed unsafe partial class VulkanBackend
             }
         }
         UploadToBuffer(c, C);
+    }
+
+    /// <summary>
+    /// Runs C = A·B (row-major, M×K · K×N) on the GPU via the GLSL GEMM kernel.
+    /// Returns false (so the caller can fall back to the managed loop) when the
+    /// dimensions are non-positive or libshaderc isn't available to compile the
+    /// shader. One invocation per output element; push constants carry {M, N, K}.
+    /// </summary>
+    private bool TryGlslGemmFp32(IGpuBuffer A, IGpuBuffer B, IGpuBuffer C, int M, int N, int K)
+    {
+        if (M <= 0 || N <= 0 || K <= 0)
+            return false;
+
+        var pipeline = GetOrCreateGlslPipeline(VulkanGemmKernels.GemmFp32, 3, 3 * sizeof(uint));
+        if (pipeline is null)
+            return false;
+
+        var vbA = AsVulkan(A);
+        var vbB = AsVulkan(B);
+        var vbC = AsVulkan(C);
+        var pushConstants = new uint[] { (uint)M, (uint)N, (uint)K };
+        var threadRes = _device.AcquireThreadResources();
+        lock (_computeLock)
+        {
+            pipeline.UpdateDescriptorSet(vbA.Storage, vbB.Storage, vbC.Storage);
+            RecordAndExecuteWithPushData(pipeline, M * N, pushConstants, 3 * sizeof(uint), threadRes);
+        }
+
+        return true;
     }
 
     public IGpuBuffer MatMul(IGpuBuffer A, IGpuBuffer B, int M, int N, int K)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.HalfPrecision.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.HalfPrecision.cs
@@ -1,0 +1,99 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// IGpuHalfPrecisionBackend implementation for the Vulkan backend (issue #560):
+// FP16 GEMM on the GPU via a GLSL compute shader, built on the new real Vulkan
+// GPU GEMM (the previous Gemm was a CPU download/loop/upload fallback).
+
+using System;
+using AiDotNet.Tensors.Engines.Gpu;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.Vulkan;
+
+/// <summary>
+/// Half-precision GEMM dispatch for the <see cref="IGpuHalfPrecisionBackend"/>
+/// capability interface, so the backend-agnostic
+/// <c>DirectGpuTensorEngine.MatrixMultiply</c> FP16 path (issue #560) runs on
+/// Vulkan devices. Mirrors the CUDA backend's row-major contract.
+/// <para>
+/// FP16 operands are packed two halves per 32-bit word (the layout
+/// <c>ConvertToFp16</c> produces); the GLSL kernel reads them with the core
+/// <c>unpackHalf2x16</c> built-in and accumulates in FP32 — the AMP-standard
+/// mixed-precision matmul. Requires libshaderc for runtime GLSL→SPIR-V
+/// compilation; <see cref="SupportsHgemm"/> reflects that.
+/// </para>
+/// </summary>
+public sealed partial class VulkanBackend : IGpuHalfPrecisionBackend
+{
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Gated on libshaderc availability: the FP16 GEMM is a runtime-compiled
+    /// GLSL compute shader, so without the compiler there is no GPU FP16 path
+    /// (the engine then falls back to CPU).
+    /// </remarks>
+    public bool SupportsHgemm => IsGlslCompilerAvailable;
+
+    /// <inheritdoc/>
+    public void GemmFp16In32fOut(IGpuBuffer aFp16, IGpuBuffer bFp16, IGpuBuffer cFp32,
+        int m, int n, int k)
+    {
+        ValidateHalfGemmArgs(aFp16, bFp16, cFp32, m, n, k);
+        if (!TryGlslGemmFp16In32fOut(aFp16, bFp16, cFp32, m, n, k))
+            throw new NotSupportedException(
+                "Vulkan FP16 GEMM requires libshaderc for runtime GLSL compilation, which is unavailable.");
+    }
+
+    /// <inheritdoc/>
+    public void Hgemm(IGpuBuffer aFp16, IGpuBuffer bFp16, IGpuBuffer cFp16,
+        int m, int n, int k)
+    {
+        ValidateHalfGemmArgs(aFp16, bFp16, cFp16, m, n, k);
+        // Accumulate in FP32 into a scratch buffer, then round the result down to
+        // FP16 (matches cublasHgemm's FP16 output). Keeping the accumulation in
+        // FP32 avoids the worst half-precision drift; the output is then packed
+        // to halves by ConvertToFp16. A separate scratch avoids reading and
+        // writing the same buffer in one pass.
+        using var scratch = AllocateBuffer(m * n);
+        if (!TryGlslGemmFp16In32fOut(aFp16, bFp16, scratch, m, n, k))
+            throw new NotSupportedException(
+                "Vulkan FP16 GEMM requires libshaderc for runtime GLSL compilation, which is unavailable.");
+        ConvertToFp16(scratch, cFp16, m * n);
+    }
+
+    /// <summary>
+    /// Runs C(fp32) = A(fp16)·B(fp16) on the GPU via the GLSL FP16 GEMM kernel.
+    /// Returns false when libshaderc is unavailable so callers can surface a
+    /// clear error / fall back. One invocation per output element; push
+    /// constants carry {M, N, K}.
+    /// </summary>
+    private bool TryGlslGemmFp16In32fOut(IGpuBuffer aFp16, IGpuBuffer bFp16, IGpuBuffer cFp32,
+        int m, int n, int k)
+    {
+        var pipeline = GetOrCreateGlslPipeline(VulkanGemmKernels.GemmFp16In32fOut, 3, 3 * sizeof(uint));
+        if (pipeline is null)
+            return false;
+
+        var vbA = AsVulkan(aFp16);
+        var vbB = AsVulkan(bFp16);
+        var vbC = AsVulkan(cFp32);
+        var pushConstants = new uint[] { (uint)m, (uint)n, (uint)k };
+        var threadRes = _device.AcquireThreadResources();
+        lock (_computeLock)
+        {
+            pipeline.UpdateDescriptorSet(vbA.Storage, vbB.Storage, vbC.Storage);
+            RecordAndExecuteWithPushData(pipeline, m * n, pushConstants, 3 * sizeof(uint), threadRes);
+        }
+
+        return true;
+    }
+
+    private static void ValidateHalfGemmArgs(IGpuBuffer a, IGpuBuffer b, IGpuBuffer c,
+        int m, int n, int k)
+    {
+        if (a is null) throw new ArgumentNullException(nameof(a));
+        if (b is null) throw new ArgumentNullException(nameof(b));
+        if (c is null) throw new ArgumentNullException(nameof(c));
+        // Report the offending dimension by name (mirrors the CUDA backend).
+        if (m <= 0) throw new ArgumentOutOfRangeException(nameof(m), "Dimensions must be positive.");
+        if (n <= 0) throw new ArgumentOutOfRangeException(nameof(n), "Dimensions must be positive.");
+        if (k <= 0) throw new ArgumentOutOfRangeException(nameof(k), "Dimensions must be positive.");
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanGemmKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanGemmKernels.cs
@@ -1,0 +1,79 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Vulkan GLSL compute shaders for GEMM (C = A·B), compiled to SPIR-V at runtime
+// (libshaderc). These give the Vulkan backend a REAL on-device matmul — the
+// previous Gemm downloaded to the CPU, looped, and re-uploaded. Issue #560 (FP16)
+// builds on the FP16 variant here.
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.Vulkan;
+
+/// <summary>
+/// GEMM compute kernels. Flat 1-D dispatch: one invocation per output element
+/// (the backend dispatches <c>M*N</c> threads in <c>local_size_x = 256</c>
+/// workgroups via <c>CalculateWorkgroupCount</c>). Row-major throughout:
+/// A is M×K (<c>A[row*K + k]</c>), B is K×N (<c>B[k*N + col]</c>), C is M×N
+/// (<c>C[row*N + col]</c>). Push constants carry {M, N, K}.
+/// <para>
+/// Correctness-first (no shared-memory tiling): a simple one-thread-per-output
+/// kernel that is unambiguously correct and already replaces the CPU fallback
+/// with genuine GPU execution. A tiled / cooperative-matrix variant is a later
+/// performance pass and does not change this contract.
+/// </para>
+/// </summary>
+internal static class VulkanGemmKernels
+{
+    private const string Header = @"#version 450
+layout(local_size_x = 256) in;
+";
+
+    /// <summary>FP32 GEMM: float A, float B, float C. Replaces the CPU-fallback matmul.</summary>
+    public static string GemmFp32 => Header + @"
+layout(set=0,binding=0) readonly buffer Ab { float A[]; };
+layout(set=0,binding=1) readonly buffer Bb { float B[]; };
+layout(set=0,binding=2) writeonly buffer Cb { float C[]; };
+layout(push_constant) uniform PC { uint M; uint N; uint K; };
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    if (gid >= M * N) return;
+    uint row = gid / N;
+    uint col = gid % N;
+    uint aBase = row * K;
+    float acc = 0.0;
+    for (uint kk = 0u; kk < K; ++kk)
+        acc += A[aBase + kk] * B[kk * N + col];
+    C[gid] = acc;
+}";
+
+    /// <summary>
+    /// Mixed-precision GEMM: FP16 inputs (packed two halves per 32-bit word, the
+    /// layout VulkanBackend.ConvertToFp16 produces), FP32 accumulator + output.
+    /// Reads halves with the core <c>unpackHalf2x16</c> built-in (no extension).
+    /// The AMP standard — matches cuBLAS cublasGemmEx(CUDA_R_16F, COMPUTE_32F).
+    /// </summary>
+    public static string GemmFp16In32fOut => Header + @"
+layout(set=0,binding=0) readonly buffer Ab { uint Apacked[]; };
+layout(set=0,binding=1) readonly buffer Bb { uint Bpacked[]; };
+layout(set=0,binding=2) writeonly buffer Cb { float C[]; };
+layout(push_constant) uniform PC { uint M; uint N; uint K; };
+
+// Halves are packed two per 32-bit word (low 16 bits = even element, high 16 =
+// odd — little-endian, matching ConvertToFp16's byte layout). unpackHalf2x16 is
+// a core GLSL built-in (no extension needed).
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    if (gid >= M * N) return;
+    uint row = gid / N;
+    uint col = gid % N;
+    uint aBase = row * K;
+    float acc = 0.0;
+    for (uint kk = 0u; kk < K; ++kk) {
+        uint ae = aBase + kk;
+        uint be = kk * N + col;
+        vec2 ap = unpackHalf2x16(Apacked[ae >> 1]);
+        vec2 bp = unpackHalf2x16(Bpacked[be >> 1]);
+        float av = ((ae & 1u) == 0u) ? ap.x : ap.y;
+        float bv = ((be & 1u) == 0u) ? bp.x : bp.y;
+        acc += av * bv;
+    }
+    C[gid] = acc;
+}";
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/VulkanGemmTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/VulkanGemmTests.cs
@@ -1,0 +1,200 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Tests for the real Vulkan GPU GEMM (replacing the CPU download/loop/upload
+// fallback) and the FP16 IGpuHalfPrecisionBackend path (issue #560).
+
+// System.Half / BitConverter.Int16BitsToHalf (the FP16 oracle) are .NET 6+.
+#if NET6_0_OR_GREATER
+
+using System;
+using AiDotNet.Tensors.Engines.DirectGpu;
+using AiDotNet.Tensors.Engines.DirectGpu.Vulkan;
+using AiDotNet.Tensors.Engines.Gpu;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
+
+/// <summary>
+/// Verifies the Vulkan GPU GEMM on real hardware: the FP32 path (now a GLSL
+/// compute shader, previously a CPU fallback) and the FP16 mixed-precision path
+/// (<see cref="IGpuHalfPrecisionBackend.GemmFp16In32fOut"/> / <see cref="IGpuHalfPrecisionBackend.Hgemm"/>).
+/// <para>
+/// The FP16 oracle downloads the packed-FP16 operands and decodes each half with
+/// <see cref="BitConverter.Int16BitsToHalf"/> — the same IEEE binary16 decode the
+/// GPU's <c>unpackHalf2x16</c> performs — so the only residual error is FP32
+/// accumulation order. Honors <c>AIDOTNET_REQUIRE_GPU_TESTS=1</c> (throws instead
+/// of skipping when a GPU is required). Requires libshaderc for the FP16 path.
+/// </para>
+/// </summary>
+[Collection("VulkanGlobalState")]
+public sealed class VulkanGemmTests
+{
+    private readonly VulkanBackend _backend;
+    private readonly bool _ready;
+    private readonly bool _fp16Ready;
+
+    public VulkanGemmTests()
+    {
+        try
+        {
+            _backend = VulkanBackend.Instance;
+            // Both the FP32 and FP16 GPU GEMM paths are runtime-compiled GLSL
+            // compute shaders, so they only actually run on the GPU when
+            // libshaderc is present. Without it Gemm transparently falls back to
+            // the CPU loop — gating on IsGlslCompilerAvailable keeps these tests
+            // honest (they verify the GPU path or skip, never silently CPU-pass).
+            _ready = _backend.Initialize() && _backend.IsGlslCompilerAvailable;
+            _fp16Ready = _ready && _backend.SupportsHgemm;
+        }
+        catch
+        {
+            _ready = false;
+            _fp16Ready = false;
+        }
+    }
+
+    private bool EnsureReady(bool needFp16)
+    {
+        bool ok = needFp16 ? _fp16Ready : _ready;
+        if (ok) return true;
+        if (string.Equals(
+                Environment.GetEnvironmentVariable("AIDOTNET_REQUIRE_GPU_TESTS"),
+                "1",
+                StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "GPU tests were required (AIDOTNET_REQUIRE_GPU_TESTS=1) but the Vulkan GPU GEMM " +
+                "was unavailable (Vulkan device + libshaderc for runtime GLSL→SPIR-V are required).");
+        }
+
+        return false;
+    }
+
+    private static float[] RandomMatrix(int rows, int cols, int seed)
+    {
+        var rng = new Random(seed);
+        var data = new float[rows * cols];
+        for (int i = 0; i < data.Length; i++)
+            data[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+        return data;
+    }
+
+    private static float[] CpuReference(float[] a, float[] b, int m, int n, int k)
+    {
+        var c = new float[m * n];
+        for (int i = 0; i < m; i++)
+        {
+            for (int j = 0; j < n; j++)
+            {
+                float acc = 0f;
+                for (int l = 0; l < k; l++)
+                    acc += a[i * k + l] * b[l * n + j];
+                c[i * n + j] = acc;
+            }
+        }
+
+        return c;
+    }
+
+    private static void AssertClose(float[] expected, float[] actual, double absTol, double relTol)
+    {
+        Assert.Equal(expected.Length, actual.Length);
+        for (int i = 0; i < expected.Length; i++)
+        {
+            double diff = Math.Abs(expected[i] - actual[i]);
+            double tol = absTol + relTol * Math.Abs(expected[i]);
+            Assert.True(diff <= tol,
+                $"GEMM mismatch at [{i}]: expected {expected[i]}, got {actual[i]} (|diff|={diff}, tol={tol}).");
+        }
+    }
+
+    // Decode the exact half values held in a packed-FP16 buffer (two halves per
+    // float word, little-endian) — matches the GPU's unpackHalf2x16 exactly.
+    private float[] DecodePackedHalf(IGpuBuffer fp16Buffer, int count)
+    {
+        var packed = _backend.DownloadBuffer(fp16Buffer);
+        var bytes = new byte[packed.Length * 4];
+        Buffer.BlockCopy(packed, 0, bytes, 0, bytes.Length);
+        var values = new float[count];
+        for (int e = 0; e < count; e++)
+        {
+            ushort bits = (ushort)(bytes[e * 2] | (bytes[e * 2 + 1] << 8));
+            values[e] = (float)BitConverter.Int16BitsToHalf(unchecked((short)bits));
+        }
+
+        return values;
+    }
+
+    // ---- FP32 GPU GEMM (now a real compute shader, not a CPU fallback) ----
+
+    [SkippableTheory]
+    [InlineData(16, 16, 16)]
+    [InlineData(64, 48, 96)]
+    [InlineData(37, 53, 71)]
+    [InlineData(128, 128, 256)]
+    public void Gemm_Fp32_MatchesCpuReference(int m, int n, int k)
+    {
+        Skip.If(!EnsureReady(needFp16: false), "Vulkan not available on this system.");
+
+        var a = RandomMatrix(m, k, seed: 11 + m + k);
+        var b = RandomMatrix(k, n, seed: 22 + n + k);
+        var expected = CpuReference(a, b, m, n, k);
+
+        using var aBuf = _backend.AllocateBuffer(a);
+        using var bBuf = _backend.AllocateBuffer(b);
+        using var cBuf = _backend.AllocateBuffer(m * n);
+        _backend.Gemm(aBuf, bBuf, cBuf, m, n, k);
+        var actual = _backend.DownloadBuffer(cBuf);
+
+        AssertClose(expected, actual, absTol: 1e-3, relTol: 1e-4);
+    }
+
+    // ---- FP16 mixed-precision GEMM ----
+
+    [SkippableTheory]
+    [InlineData(16, 16, 16)]
+    [InlineData(64, 48, 96)]
+    [InlineData(37, 53, 71)]
+    [InlineData(128, 128, 256)]
+    public void GemmFp16In32fOut_MatchesCpuReference(int m, int n, int k)
+    {
+        Skip.If(!EnsureReady(needFp16: true), "Vulkan FP16 GEMM (libshaderc) not available on this system.");
+
+        var a = RandomMatrix(m, k, seed: 1234 + m + k);
+        var b = RandomMatrix(k, n, seed: 5678 + n + k);
+
+        using var aFp32 = _backend.AllocateBuffer(a);
+        using var bFp32 = _backend.AllocateBuffer(b);
+        using var aFp16 = _backend.AllocateBuffer((m * k + 1) / 2);
+        using var bFp16 = _backend.AllocateBuffer((k * n + 1) / 2);
+        _backend.ConvertToFp16(aFp32, aFp16, m * k);
+        _backend.ConvertToFp16(bFp32, bFp16, k * n);
+
+        // Exact operands the GPU will multiply (decoded from the packed buffers).
+        var aTrunc = DecodePackedHalf(aFp16, m * k);
+        var bTrunc = DecodePackedHalf(bFp16, k * n);
+        var expected = CpuReference(aTrunc, bTrunc, m, n, k);
+
+        using var cBuf = _backend.AllocateBuffer(m * n);
+        ((IGpuHalfPrecisionBackend)_backend).GemmFp16In32fOut(aFp16, bFp16, cBuf, m, n, k);
+        var actual = _backend.DownloadBuffer(cBuf);
+
+        AssertClose(expected, actual, absTol: 1e-2, relTol: 1e-2);
+    }
+
+    [SkippableFact]
+    public void GemmFp16In32fOut_RejectsNonPositiveDimensions()
+    {
+        Skip.If(!EnsureReady(needFp16: true), "Vulkan FP16 GEMM not available on this system.");
+
+        using var dummy = _backend.AllocateBuffer(4);
+        var half = (IGpuHalfPrecisionBackend)_backend;
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => half.GemmFp16In32fOut(dummy, dummy, dummy, 0, 4, 4));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => half.GemmFp16In32fOut(dummy, dummy, dummy, 4, -1, 4));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => half.GemmFp16In32fOut(dummy, dummy, dummy, 4, 4, 0));
+    }
+}
+
+#endif


### PR DESCRIPTION
## Summary

Gives the Vulkan backend a **genuine on-device GEMM** via GLSL compute shaders, plus the `IGpuHalfPrecisionBackend` FP16 mixed-precision path (issue #560) — replacing the previous CPU download/loop/upload fallback. This is part of bringing FP16 GEMM (#560) to **all** GPU backends (CUDA already had it; OpenCL #597, WebGPU #598, HIP #599 are the siblings).

**Verified on real hardware** (AMD Radeon RX 5500 XT, forced-GPU `AIDOTNET_REQUIRE_GPU_TESTS=1`): **9/9 tests pass running on the GPU**, both FP32 and FP16 matching the CPU reference.

## Root cause uncovered during verification

`shaderc_compute_shader` was bound to **5** (which is `tess_evaluation_shader` in the shaderc enum) instead of **2**. As a result, *every* Vulkan GLSL compute dispatch failed to compile with `'local_size_x': there is no such layout identifier for this stage` and **silently fell back to the CPU**. This was latent because libshaderc was never present in CI/dev to exercise the GPU path. Fixing the enum lets all Vulkan GLSL compute paths run on-device.

## Changes

- **`ShadercNativeBindings`**: `shaderc_compute_shader` `5` → `2` (correct enum value).
- **`VulkanGemmKernels`** (new): `GemmFp32` and `GemmFp16In32fOut` compute shaders. Row-major (`A[row*K+k]`, `B[k*N+col]`, `C[row*N+col]`), one invocation per output element, push constants `{M,N,K}`. The FP16 kernel reads packed halves with the core `unpackHalf2x16` built-in (no extension) and accumulates in FP32 — the AMP-standard mixed-precision matmul (matches `cublasGemmEx(CUDA_R_16F, COMPUTE_32F)`).
- **`VulkanBackend.Gemm`**: GPU fast path for plain `C = A·B` (alpha=1, beta=0, the common MatMul case); scaled/accumulating GEMM and shaderc-less hosts fall through to the existing managed loop.
- **`VulkanBackend.HalfPrecision`** (new): `IGpuHalfPrecisionBackend` — `SupportsHgemm` (gated on libshaderc), `GemmFp16In32fOut` (FP16 in / FP32 out), `Hgemm` (FP16 in / FP32 accumulate / FP16 out).
- **`VulkanGemmTests`** (new): forced-GPU correctness vs CPU reference for FP32 and FP16. Gates on `IsGlslCompilerAvailable` so it verifies the GPU path or skips — never silently CPU-passes. FP16 oracle decodes the packed-half operands exactly as `unpackHalf2x16` does, so the only residual error is FP32 accumulation order.

## Verification

```
AIDOTNET_REQUIRE_GPU_TESTS=1 dotnet test --filter VulkanGemmTests
Passed!  - Failed: 0, Passed: 9, Skipped: 0, Total: 9
```
(AMD RX 5500 XT, Vulkan proprietary driver + libshaderc 1.4.350)

Builds clean on net10.0 and net471.

> Note: running the FP16/FP32 GPU tests requires libshaderc (`shaderc_shared.dll`) on the runtime path; without it the tests skip honestly (and `Gemm` falls back to the managed loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)