### PR TITLE
feat(streaming): transparent weight streaming — auto-rehydrate on access + bounded resident set (#430)

### DIFF
--- a/src/AiDotNet.Tensors/LinearAlgebra/StreamingTensorPool.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/StreamingTensorPool.cs
@@ -46,6 +46,7 @@ public sealed class StreamingTensorPool : IDisposable
     private readonly long _maxResidentBytes;
     private readonly string _backingDir;
     private readonly bool _enableCompression;
+    private readonly bool _transparentAutoEviction;
     private bool _disposed;
 
     // Telemetry counters (#1222 PR-A task #181). All written under _lock.
@@ -73,11 +74,38 @@ public sealed class StreamingTensorPool : IDisposable
     private long _prefetchIssueCount;   // Total Rehydrate calls flagged as isPrefetch=true
     private readonly HashSet<long> _prefetchPending = new();
 
+    // Transparent-streaming owner-drop notification (issue #430 follow-up).
+    // When the pool pages an entry out to disk under budget pressure it frees
+    // its OWN byte[] snapshot — but the owning Tensor's GC-heap `_data` (if it
+    // was made resident by a prior Materialize) is invisible to the pool: this
+    // class is type-erased (handles + byte[], no Tensor<T>). Transparent
+    // auto-rehydrate (TensorBase.EnsureMaterialized) re-materialises a weight's
+    // `_data` on access; without dropping that copy when the pool evicts the
+    // entry, every accessed weight would stay GC-resident and the resident set
+    // would grow unbounded — defeating the bound the pool enforces on its own
+    // snapshots. So each paged-out handle is recorded here and WeightRegistry
+    // drains it (dropping the owning tensor via a weak back-reference). A queue
+    // rather than an immediate callback keeps the pool free of registry
+    // knowledge AND avoids running arbitrary drop logic under _lock: the
+    // registry drains lazily on its next Materialize, so evictions from any
+    // source (Register, prefetch, Materialize) are reconciled there. Written
+    // under _lock.
+    //
+    // A SET, not a queue: a handle is "pending owner-drop" while its bytes are
+    // paged out and not yet reconciled. If the same handle is re-paged-in
+    // (transparent auto-rehydrate on access) BEFORE the registry drains, its
+    // resident _data is valid again and MUST NOT be dropped — Rehydrate removes
+    // it from this set on page-in. Without that cancellation, a stale
+    // register-time eviction would make the very next drain drop the weight the
+    // caller just materialized, emptying its storage mid-read.
+    private readonly HashSet<long> _pendingOwnerDrops = new();
+
     public StreamingTensorPool(GpuOffloadOptions? options = null)
     {
         var opts = options ?? new GpuOffloadOptions();
         _maxResidentBytes = opts.StreamingPoolMaxResidentBytes;
         _enableCompression = opts.EnableCompression;
+        _transparentAutoEviction = opts.TransparentAutoEviction;
         // Always append a Guid sub-directory — even when the caller
         // supplies StreamingBackingStorePath. Two pools sharing the same
         // base path would otherwise collide on streaming-{id}.bin
@@ -293,6 +321,12 @@ public sealed class StreamingTensorPool : IDisposable
                     var freshNode = _lruOrder.AddFirst(handleId);
                     _lruIndex[handleId] = freshNode;
                 }
+                // This entry is resident again — cancel any pending owner-drop
+                // queued when it was previously evicted. Otherwise the next
+                // registry drain would drop the owning tensor's _data right
+                // after the caller materialised it (e.g. a register-time
+                // eviction that was never reconciled), emptying storage mid-read.
+                _pendingOwnerDrops.Remove(handleId);
                 // Skip the just-rehydrated entry during eviction. If this
                 // tensor alone exceeds the budget, evicting it here would
                 // page it back out before Rehydrate returns and the caller
@@ -521,6 +555,30 @@ public sealed class StreamingTensorPool : IDisposable
     }
 
     /// <summary>
+    /// Returns and clears the handles the pool has paged out to disk since the
+    /// last drain, so <see cref="WeightRegistry"/> can drop the owning tensors'
+    /// resident <c>_data</c> (see <c>_pendingOwnerDrops</c>). The pool frees
+    /// only its own byte[] snapshot on eviction; the tensor's GC-heap copy —
+    /// re-materialised by transparent auto-rehydrate — is freed by the registry
+    /// after this drain, keeping the resident set bounded. Returns
+    /// <see cref="Array.Empty{T}"/> when nothing was evicted. Snapshot is taken
+    /// under <see cref="_lock"/> so it's internally consistent; the registry
+    /// performs the actual drops (tensor-storage CAS only, no pool/registry
+    /// lock) after this returns.
+    /// </summary>
+    internal long[] DrainEvictedHandles()
+    {
+        lock (_lock)
+        {
+            if (_pendingOwnerDrops.Count == 0) return Array.Empty<long>();
+            long[] result = new long[_pendingOwnerDrops.Count];
+            _pendingOwnerDrops.CopyTo(result);
+            _pendingOwnerDrops.Clear();
+            return result;
+        }
+    }
+
+    /// <summary>
     /// Pages a single LRU entry to disk. Extracted from
     /// <see cref="EvictIfOverBudget"/> so
     /// <see cref="EvictUntilFreeBytes"/> can drive the same eviction
@@ -633,6 +691,15 @@ public sealed class StreamingTensorPool : IDisposable
         entry.ResidentBytes = 0;
         _lruOrder.Remove(oldest);
         _lruIndex.Remove(id);
+        // Record the page-out so WeightRegistry can drop the owning tensor's
+        // resident _data on its next drain — but ONLY in transparent mode.
+        // With explicit orchestration the model owns residency (and a
+        // concurrent reader could be mid-read on the very weight we'd drop),
+        // so leave the owner copy alone and keep DrainEvictedHandles empty.
+        // Only the real page-out path records — the stale-node branch above
+        // (entry.Data already null) was paged out earlier and recorded then.
+        if (_transparentAutoEviction)
+            _pendingOwnerDrops.Add(id);
         return true;
     }
 
@@ -658,6 +725,7 @@ public sealed class StreamingTensorPool : IDisposable
             _entries.Clear();
             _lruOrder.Clear();
             _lruIndex.Clear();
+            _pendingOwnerDrops.Clear();
             // Atomic write so the lock-free ResidentBytes property doesn't
             // see torn values on 32-bit hosts (net471 x86 still ships).
             Interlocked.Exchange(ref _residentBytes, 0);

--- a/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
@@ -8,10 +8,33 @@ using AiDotNet.Tensors.Interfaces;
 namespace AiDotNet.Tensors.LinearAlgebra;
 
 /// <summary>
+/// Non-generic view of a streaming-registered weight tensor that lets
+/// <see cref="WeightRegistry"/> drop a tensor's resident in-memory data
+/// without knowing its element type <c>T</c>. The registry tracks the owning
+/// tensor by streaming-pool handle (a weak reference to this interface) so it
+/// can drop the GC-heap copy when the pool pages the handle's bytes out —
+/// the symmetric half of transparent auto-rehydrate (see
+/// <see cref="TensorBase{T}"/>'s EnsureMaterialized). Implemented by
+/// <see cref="TensorBase{T}"/>.
+/// </summary>
+internal interface IStreamingDroppable
+{
+    /// <summary>The streaming-pool handle this tensor's bytes live under, or
+    /// -1 when not registered.</summary>
+    long StreamingPoolHandle { get; }
+
+    /// <summary>Drops this tensor's resident in-memory data (the streaming
+    /// pool keeps the canonical copy). Returns <c>false</c> without dropping
+    /// when the storage is still shared (refcount &gt; 1) — e.g. an autodiff
+    /// tape capture during training — leaving the data resident for the peer.</summary>
+    bool TryDropStorageForStreaming(bool throwOnSharedRefcount);
+}
+
+/// <summary>
 /// Represents a base class for multi-dimensional arrays of numeric values used in machine learning and AI computations.
 /// </summary>
 /// <typeparam name="T">The numeric type of the tensor elements (e.g., float, double, int).</typeparam>
-public abstract class TensorBase<T> : IDisposable
+public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
 {
     private bool _disposed;
     // ================================================================
@@ -247,6 +270,16 @@ public abstract class TensorBase<T> : IDisposable
         _storage = new TensorStorage<T>(_data);
         return true;
     }
+
+    // Explicit IStreamingDroppable implementation — the underlying members are
+    // internal (not public), so they can't implicitly satisfy the interface.
+    // These forward to the internal members, letting WeightRegistry drop a
+    // streaming tensor's resident data without a reference to the closed
+    // generic Tensor<T>.
+    bool IStreamingDroppable.TryDropStorageForStreaming(bool throwOnSharedRefcount)
+        => TryDropStorageForStreaming(throwOnSharedRefcount);
+
+    long IStreamingDroppable.StreamingPoolHandle => StreamingPoolHandle;
 
     /// <summary>
     /// Restores this tensor's data from a serialized byte buffer (produced
@@ -1248,11 +1281,72 @@ public abstract class TensorBase<T> : IDisposable
     /// Ensures lazy tensor data has been materialized before access.
     /// Centralizes the auto-materialization guard so all data access paths use it.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Two independent deferral mechanisms converge here so that every data-access
+    /// path (<see cref="AsSpan"/>, <see cref="AsWritableSpan"/>, the indexers,
+    /// <see cref="ToArray"/>, and — via the <see cref="GetLiveBackingArrayOrNull"/>
+    /// miss → <see cref="ToArray"/> fallback — <see cref="GetDataArray"/>) observes
+    /// live data without the caller knowing which mechanism, if any, is in play:
+    /// </para>
+    /// <list type="number">
+    ///   <item><b>Lazy graph realization</b> — a deferred (<see cref="LazySource"/>)
+    ///     node whose op hasn't run yet is realized on first touch.</item>
+    ///   <item><b>Weight streaming (issue #430, transparent path).</b> A weight tagged
+    ///     <see cref="WeightLifetime.Streaming"/> and registered with the
+    ///     <see cref="WeightRegistry"/> has its in-memory bytes paged out to the
+    ///     streaming pool's backing store under memory pressure (its backing
+    ///     <c>_data</c> dropped to <see cref="Vector{T}.Empty"/>). Auto-rehydrating
+    ///     here — rather than requiring every model to call
+    ///     <c>WeightRegistry.Materialize</c> before each Forward — is what makes
+    ///     streaming <i>transparent</i>: any model whose weights are tagged Streaming
+    ///     fits a bounded resident set without per-layer orchestration code, because
+    ///     the read path itself pages the bytes back in on demand.</item>
+    /// </list>
+    /// <para>
+    /// <b>Cost.</b> The streaming check is a single field compare
+    /// (<c>Lifetime == Streaming</c>) that short-circuits for every
+    /// <see cref="WeightLifetime.Default"/> tensor — i.e. all activations and all
+    /// non-streamed models — so the common path pays one predictable branch.
+    /// <c>Materialize</c> is only invoked when the weight is actually dropped
+    /// (<c>_data.Length != Length</c>); a resident streaming weight skips it
+    /// entirely. In a single-pass forward each weight is touched once, so the
+    /// pool's LRU (which evicts the least-recently paged-in weight) naturally
+    /// keeps the just-materialized weight — the most-recently-used — resident.
+    /// </para>
+    /// <para>
+    /// <b>Recursion safety.</b> <c>Materialize</c> → <c>RehydrateInto</c> →
+    /// <see cref="RestoreStorageFromBytes"/> swaps <c>_data</c>/<c>_storage</c>
+    /// directly; it never re-enters <see cref="AsSpan"/>/<c>EnsureMaterialized</c>,
+    /// and after it runs <c>_data.Length == Length</c> so a re-entrant call would
+    /// short-circuit regardless.
+    /// </para>
+    /// <para>
+    /// <b>Scope.</b> This is the read/inference page-in. Training write-back —
+    /// where <see cref="AsWritableSpan"/> mutates the resident copy and the pool's
+    /// snapshot goes stale — stays on the explicit <c>ReleaseToPool</c> /
+    /// dirty-tracking flow; streaming is engaged for foundation-scale <i>inference</i>,
+    /// which is read-only over weights.
+    /// </para>
+    /// </remarks>
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
     private void EnsureMaterialized()
     {
         if (LazySource is ILazyNode node && !node.IsRealized)
             node.Realize(node.RecordingEngine);
+
+        // Transparent weight-streaming page-in. Gated on the cheap Lifetime
+        // field so non-streamed tensors (the overwhelming majority) pay only
+        // one branch. Only a dropped weight (_data emptied by the pool) needs
+        // the rehydrate; a resident one is left untouched to avoid the pool
+        // lock on the hot path.
+        if (Lifetime == WeightLifetime.Streaming
+            && StreamingPoolHandle >= 0
+            && _data.Length != Length
+            && this is Tensor<T> streamedWeight)
+        {
+            WeightRegistry.Materialize(streamedWeight);
+        }
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/LinearAlgebra/WeightLifetime.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/WeightLifetime.cs
@@ -87,6 +87,28 @@ public sealed class GpuOffloadOptions
     /// pay full disk-read latency on each layer's hot path. Default 2.
     /// </summary>
     public int PrefetchWindow { get; set; } = 2;
+
+    /// <summary>
+    /// Transparent auto-eviction (issue #430 follow-up). When <c>true</c>, the
+    /// streaming pool records every weight it pages out so the
+    /// <c>WeightRegistry</c> can also drop the owning tensor's resident
+    /// in-memory copy after transparent auto-rehydrate (see
+    /// <c>TensorBase&lt;T&gt;.EnsureMaterialized</c>). This is what lets a model
+    /// fit a bounded resident set with NO per-layer orchestration code — a
+    /// forward pass that reads weight after weight keeps only ~budget worth of
+    /// weights live instead of accumulating every weight it touched.
+    /// <para>
+    /// Default <c>false</c>: with explicit orchestration
+    /// (<c>MaterializeMany</c> / <c>ReleaseToPool</c>, as in
+    /// <c>NeuralNetworkBase</c>) the MODEL owns weight residency, and making
+    /// <c>Materialize</c> drop other weights as a side effect would both change
+    /// that contract and race a concurrent reader (one thread's materialize
+    /// could drop a weight another thread just materialized and is reading).
+    /// Enable this ONLY for single-threaded foundation-scale inference, where
+    /// the cold weight being dropped is by definition not the one in use.
+    /// </para>
+    /// </summary>
+    public bool TransparentAutoEviction { get; set; } = false;
 }
 
 /// <summary>Memory-placement scheme for <see cref="WeightLifetime.GpuOffload"/> weights.</summary>

--- a/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
@@ -25,6 +25,17 @@ public static class WeightRegistry
     private static IGpuOffloadAllocator? _offloadAllocator;
     private static GpuOffloadOptions _options = new();
 
+    // Transparent-streaming owner map: streaming-pool handle → weak reference
+    // to the owning tensor (typed as the non-generic IStreamingDroppable so
+    // the registry stays element-type-agnostic, mirroring the pool). When the
+    // pool pages a handle's bytes out, DrainOwnerDropsAfterEviction looks the
+    // owner up here and drops its resident GC-heap _data — the symmetric half
+    // of transparent auto-rehydrate (TensorBase.EnsureMaterialized) that keeps
+    // the resident set bounded. WeakReference so a tensor GC'd without
+    // UnregisterWeight doesn't leak the entry; dead targets are pruned on
+    // drain. Written/read under _lock.
+    private static readonly Dictionary<long, WeakReference<IStreamingDroppable>> _ownerByHandle = new();
+
     /// <summary>Replaces the active options; must be called before any
     /// <see cref="WeightLifetime.Streaming"/> / GpuOffload registration.
     /// Throws <see cref="InvalidOperationException"/> when the existing pool
@@ -191,6 +202,11 @@ public static class WeightRegistry
                             bool dropped = weight.TryDropStorageForStreaming(throwOnSharedRefcount: false);
                             weight.StreamingPoolHandle = handle;
                             weight.StreamingDropDeferred = !dropped;
+                            // Record the owner so a later pool eviction can drop
+                            // this tensor's resident _data once transparent
+                            // auto-rehydrate has paged it back in. Weak ref: a
+                            // tensor GC'd without UnregisterWeight won't leak.
+                            _ownerByHandle[handle] = new WeakReference<IStreamingDroppable>(weight);
                         }
                         catch
                         {
@@ -492,6 +508,7 @@ public static class WeightRegistry
             if (weight.StreamingPoolHandle >= 0)
             {
                 _streamingPool?.Unregister(weight.StreamingPoolHandle);
+                _ownerByHandle.Remove(weight.StreamingPoolHandle);
                 weight.StreamingPoolHandle = -1;
             }
             if (weight.OffloadDevicePointer != IntPtr.Zero || weight.OffloadHostPointer != IntPtr.Zero)
@@ -707,6 +724,10 @@ public static class WeightRegistry
             StreamingTensorPool? poolRef;
             lock (_lock) { poolRef = _streamingPool; }
             poolRef?.MarkAccessed(weight.StreamingPoolHandle);
+            // Reconcile any evictions that happened on a non-Materialize path
+            // (a late RegisterWeight, or a background prefetch) since the last
+            // drain, so their owners' resident _data doesn't linger.
+            DrainOwnerDropsAfterEviction();
             return;
         }
 
@@ -737,6 +758,12 @@ public static class WeightRegistry
         }
         byte[] snapshot = pool.RehydrateInto(weight.StreamingPoolHandle);
         weight.RestoreStorageFromBytes(snapshot);
+
+        // RehydrateInto may have paged other weights out to stay under budget.
+        // Drop those owners' resident _data now so the transparent-streaming
+        // resident set stays bounded (the just-materialized weight is protected
+        // from eviction by RehydrateInto, so it's never in the drained set).
+        DrainOwnerDropsAfterEviction();
     }
 
     /// <summary>
@@ -1293,7 +1320,64 @@ public static class WeightRegistry
             _streamingPool = null;
             _offloadAllocator?.Dispose();
             _offloadAllocator = null;
+            _ownerByHandle.Clear();
             _options = new GpuOffloadOptions();
+        }
+    }
+
+    /// <summary>
+    /// Drops the resident in-memory <c>_data</c> of every tensor the streaming
+    /// pool has paged out since the last drain (see
+    /// <see cref="StreamingTensorPool.DrainEvictedHandles"/>). This is the
+    /// symmetric half of transparent auto-rehydrate
+    /// (<c>TensorBase&lt;T&gt;.EnsureMaterialized</c>): the pool frees its own
+    /// byte[] snapshot on eviction, and this frees the owning tensor's GC-heap
+    /// copy, so a forward pass that touches weight after weight keeps only a
+    /// bounded resident set (≈ budget) instead of accumulating every weight it
+    /// has read. Called at the end of each <see cref="Materialize{T}"/> page-in;
+    /// evictions from any source (Register, prefetch) are reconciled at the next
+    /// Materialize.
+    /// <para>
+    /// The drops run OUTSIDE <see cref="_lock"/> — <c>TryDropStorageForStreaming</c>
+    /// only touches the tensor's own storage refcount (a CAS), acquiring neither
+    /// the registry nor the pool lock, so there's no lock-order hazard. A soft
+    /// drop (<c>throwOnSharedRefcount: false</c>) leaves a weight resident when
+    /// its storage is still shared — the training-tape case — which is correct:
+    /// transparent streaming targets inference, where a paged-out weight's
+    /// refcount is 1 and the drop succeeds.
+    /// </para>
+    /// </summary>
+    private static void DrainOwnerDropsAfterEviction()
+    {
+        StreamingTensorPool? pool;
+        lock (_lock) { pool = _streamingPool; }
+        if (pool is null) return;
+
+        long[] evicted = pool.DrainEvictedHandles();
+        if (evicted.Length == 0) return;
+
+        foreach (long handle in evicted)
+        {
+            IStreamingDroppable? owner = null;
+            lock (_lock)
+            {
+                if (_ownerByHandle.TryGetValue(handle, out var weak) && !weak.TryGetTarget(out owner))
+                {
+                    // Tensor was GC'd without UnregisterWeight — prune the dead
+                    // entry; there's no resident copy left to drop.
+                    _ownerByHandle.Remove(handle);
+                }
+            }
+
+            // Only drop if the owner still maps to THIS handle (a re-registered
+            // tensor could have a new handle). Soft drop tolerates shared
+            // refcount (returns false) and only throws on view/non-contiguous
+            // storage, which a registered weight never is — guarded anyway.
+            if (owner is not null && owner.StreamingPoolHandle == handle)
+            {
+                try { owner.TryDropStorageForStreaming(throwOnSharedRefcount: false); }
+                catch (InvalidOperationException) { /* not droppable (view/non-contiguous) — leave resident */ }
+            }
         }
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightStreamingTransparentAccessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightStreamingTransparentAccessTests.cs
@@ -1,0 +1,255 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using System.IO;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.LinearAlgebra;
+
+/// <summary>
+/// Transparent weight-streaming tests (issue #430 follow-up): a streaming
+/// weight whose bytes have been paged out auto-rehydrates the moment its data
+/// is read through ANY public accessor — <see cref="Tensor{T}.AsSpan"/>, the
+/// indexer, <see cref="TensorBase{T}.ToArray"/> — with no explicit
+/// <c>WeightRegistry.Materialize</c> call. This is what makes streaming
+/// "transparent": a model fits a bounded resident set without per-layer
+/// orchestration code, because the read path itself pages weights in on demand
+/// AND the pool's symmetric owner-drop frees cold weights' GC-heap copies so
+/// the resident set stays bounded.
+///
+/// <para><c>[Collection("WeightRegistry")]</c> serializes against the other
+/// streaming suites — all mutate the process-wide <see cref="WeightRegistry"/>
+/// singleton.</para>
+/// </summary>
+[Collection("WeightRegistry")]
+public class WeightStreamingTransparentAccessTests : IDisposable
+{
+    private readonly string _backingDir;
+
+    public WeightStreamingTransparentAccessTests()
+    {
+        _backingDir = Path.Combine(Path.GetTempPath(), "aidotnet-wr-transparent-test-" + Guid.NewGuid().ToString("N"));
+        WeightRegistry.Configure(new GpuOffloadOptions
+        {
+            StreamingPoolMaxResidentBytes = 1024L * 1024 * 1024, // 1 GiB — generous headroom
+            StreamingBackingStorePath = _backingDir,
+            TransparentAutoEviction = true,
+        });
+    }
+
+    public void Dispose()
+    {
+        WeightRegistry.Reset();
+        if (Directory.Exists(_backingDir))
+        {
+            try { Directory.Delete(_backingDir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    [Fact]
+    public void AsSpan_OnDroppedStreamingWeight_AutoRehydrates()
+    {
+        float[] expected = { 1.5f, -2.25f, 3.125f, 4.0f };
+        var t = new Tensor<float>(expected, new[] { expected.Length });
+        t.Lifetime = WeightLifetime.Streaming;
+
+        // RegisterWeight drops the resident data after copying to the pool.
+        WeightRegistry.RegisterWeight(t);
+        Assert.Equal(0, t.DataVector.Length);
+
+        // Reading via AsSpan must transparently page the bytes back in — no
+        // explicit Materialize call.
+        var span = t.AsSpan();
+        Assert.Equal(expected.Length, span.Length);
+        for (int i = 0; i < expected.Length; i++)
+            Assert.Equal(expected[i], span[i]);
+
+        // Side effect: the tensor is now resident again.
+        Assert.Equal(expected.Length, t.DataVector.Length);
+    }
+
+    [Fact]
+    public void Indexer_OnDroppedStreamingWeight_AutoRehydrates()
+    {
+        float[] expected = { 10f, 20f, 30f, 40f, 50f };
+        var t = new Tensor<float>(expected, new[] { expected.Length });
+        t.Lifetime = WeightLifetime.Streaming;
+        WeightRegistry.RegisterWeight(t);
+        Assert.Equal(0, t.DataVector.Length);
+
+        // A single-element read through the flat indexer must auto-rehydrate.
+        Assert.Equal(30f, t[2]);
+        Assert.Equal(50f, t[4]);
+    }
+
+    [Fact]
+    public void ToArray_OnDroppedStreamingWeight_AutoRehydrates()
+    {
+        // ToArray() routes through EnsureMaterialized too, and GetDataArray's
+        // live-backing fast path falls back to ToArray when storage is dropped
+        // (storage.Length 0 != logical Length) — so this also covers the
+        // GetDataArray engine-consumption path.
+        double[] expected = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
+        var t = new Tensor<double>(expected, new[] { expected.Length });
+        t.Lifetime = WeightLifetime.Streaming;
+        WeightRegistry.RegisterWeight(t);
+        Assert.Equal(0, t.DataVector.Length);
+
+        double[] got = t.ToArray();
+        Assert.Equal(expected, got);
+    }
+
+    [Fact]
+    public void AsSpan_AfterDiskEviction_AutoRehydratesFromBackingStore()
+    {
+        // Tight budget so the first weight is paged out to DISK by the second
+        // weight's registration; transparent read must page it back from disk.
+        WeightRegistry.Reset();
+        WeightRegistry.Configure(new GpuOffloadOptions
+        {
+            StreamingPoolMaxResidentBytes = 16, // one 4-float tensor
+            StreamingBackingStorePath = _backingDir,
+            TransparentAutoEviction = true,
+        });
+
+        float[] first = { 7f, 8f, 9f, 10f };
+        var a = new Tensor<float>(first, new[] { 4 });
+        a.Lifetime = WeightLifetime.Streaming;
+        WeightRegistry.RegisterWeight(a);
+
+        var b = new Tensor<float>(new float[] { 1f, 2f, 3f, 4f }, new[] { 4 });
+        b.Lifetime = WeightLifetime.Streaming;
+        WeightRegistry.RegisterWeight(b);
+
+        // 'a' was evicted to backing store when 'b' registered.
+        Assert.False(WeightRegistry.IsResidentInPool(a));
+
+        // Transparent read pages it back from disk with exact bytes.
+        var span = a.AsSpan();
+        for (int i = 0; i < first.Length; i++)
+            Assert.Equal(first[i], span[i]);
+
+        var report = WeightRegistry.GetStreamingReport();
+        Assert.True(report.DiskReadCount >= 1, "Rehydrate should have read from the backing store.");
+    }
+
+    [Fact]
+    public void TransparentForward_BoundsResidentSet_ByDroppingColdOwners()
+    {
+        // The core option-(b) guarantee. Simulate a forward pass that reads
+        // weight after weight (a block loop) under a budget that fits only a
+        // couple of weights. Every read auto-rehydrates; every rehydrate pages
+        // the coldest weight out AND drops that weight's owning tensor's
+        // resident _data. So after touching all N weights, only a bounded
+        // handful are resident — NOT all N. Without the symmetric owner-drop,
+        // every materialised weight would stay GC-resident and the resident
+        // set would grow to all N (the OOM the feature exists to prevent).
+        WeightRegistry.Reset();
+        WeightRegistry.Configure(new GpuOffloadOptions
+        {
+            StreamingPoolMaxResidentBytes = 32, // two 4-float (16-byte) tensors
+            StreamingBackingStorePath = _backingDir,
+            TransparentAutoEviction = true,
+        });
+
+        const int n = 8;
+        const int elems = 4;
+        var weights = new Tensor<float>[n];
+        var expected = new float[n][];
+        for (int k = 0; k < n; k++)
+        {
+            expected[k] = new float[elems];
+            for (int i = 0; i < elems; i++) expected[k][i] = k * 100 + i;
+            weights[k] = new Tensor<float>(expected[k], new[] { elems });
+            weights[k].Lifetime = WeightLifetime.Streaming;
+            WeightRegistry.RegisterWeight(weights[k]);
+            // Registration drops resident data immediately.
+            Assert.Equal(0, weights[k].DataVector.Length);
+        }
+
+        // "Forward pass": read each weight in order via the transparent path.
+        for (int k = 0; k < n; k++)
+        {
+            var span = weights[k].AsSpan(); // auto-rehydrate
+            for (int i = 0; i < elems; i++)
+                Assert.Equal(expected[k][i], span[i]);
+        }
+
+        // After the full sweep, count how many tensors still hold resident
+        // _data. The bound: roughly the budget's worth of weights plus the
+        // last-touched one — emphatically NOT all n. We assert a generous
+        // upper bound (<= 4) that still proves cold owners were dropped: a
+        // regression that leaves every materialised weight resident would
+        // show all 8 resident here.
+        int residentTensors = 0;
+        for (int k = 0; k < n; k++)
+            if (weights[k].DataVector.Length > 0) residentTensors++;
+
+        Assert.True(residentTensors <= 4,
+            $"Transparent streaming must bound the resident set by dropping cold owners; " +
+            $"{residentTensors} of {n} tensors are still resident (expected a small handful).");
+        Assert.True(residentTensors < n,
+            "At least some cold weights must have been dropped — none were, so the owner-drop is not firing.");
+
+        // The earliest-touched weights must have been dropped outright.
+        Assert.Equal(0, weights[0].DataVector.Length);
+    }
+
+    [Fact]
+    public void DroppedColdWeight_RemainsReadable_OnNextAccess()
+    {
+        // A weight dropped by the owner-drop sweep must still read correctly
+        // when the "forward" touches it again — it simply re-pages from the
+        // pool/disk. Proves the bound doesn't corrupt data.
+        WeightRegistry.Reset();
+        WeightRegistry.Configure(new GpuOffloadOptions
+        {
+            StreamingPoolMaxResidentBytes = 32,
+            StreamingBackingStorePath = _backingDir,
+            TransparentAutoEviction = true,
+        });
+
+        float[] aData = { 1f, 2f, 3f, 4f };
+        var a = new Tensor<float>(aData, new[] { 4 });
+        a.Lifetime = WeightLifetime.Streaming;
+        WeightRegistry.RegisterWeight(a);
+
+        var fillers = new Tensor<float>[4];
+        for (int k = 0; k < fillers.Length; k++)
+        {
+            fillers[k] = new Tensor<float>(new float[] { k, k, k, k }, new[] { 4 });
+            fillers[k].Lifetime = WeightLifetime.Streaming;
+            WeightRegistry.RegisterWeight(fillers[k]);
+        }
+
+        // Touch 'a' (rehydrate), then touch all fillers so 'a' goes cold and
+        // its owner gets dropped.
+        _ = a.AsSpan();
+        for (int k = 0; k < fillers.Length; k++) _ = fillers[k].AsSpan();
+
+        // 'a' should have been dropped by now.
+        Assert.Equal(0, a.DataVector.Length);
+
+        // Re-access 'a' — must transparently re-page with exact bytes.
+        var span = a.AsSpan();
+        for (int i = 0; i < aData.Length; i++)
+            Assert.Equal(aData[i], span[i]);
+    }
+
+    [Fact]
+    public void NonStreamingWeight_ReadPath_Unaffected()
+    {
+        // A Default-lifetime tensor (every activation, every non-streamed
+        // model) must read exactly as before — the gate short-circuits on the
+        // Lifetime field with no pool interaction.
+        float[] data = { 11f, 22f, 33f };
+        var t = new Tensor<float>(data, new[] { 3 });
+        // Lifetime stays Default.
+
+        var span = t.AsSpan();
+        Assert.Equal(3, span.Length);
+        Assert.Equal(22f, span[1]);
+        Assert.Equal(3, t.DataVector.Length); // never dropped
+    }
+}


### PR DESCRIPTION
## What & why

Makes weight streaming **transparent** — fit foundation-scale models (Sora / Flux2 / WanVideo and other DiT inference) into a bounded resident set with **no per-model orchestration code**. This is the Tensors half of the option-(b) fix for the Unit-03 Diffusion/Encoding OOM shard, where single-model peak footprint (18–34 GB) exceeds the 16 GB runner.

The disk-backed pool, LRU eviction, reservation budget, drop/restore primitives, and compression already exist (#430). This PR wires the transparent read path on top of them.

## Two halves

**1. Auto-rehydrate on access — always on, pure correctness.**
`TensorBase<T>.EnsureMaterialized()` (the chokepoint `AsSpan` / `AsWritableSpan` / the indexers / `ToArray` / `GetDataArray` already funnel through) now pages a dropped `WeightLifetime.Streaming` weight back in on first touch. Previously, reading a paged-out streaming weight via `AsSpan` threw `ArgumentOutOfRange` (Slice past empty storage). Gated on the cheap `Lifetime` field, so every `Default` tensor pays a single branch.

**2. Symmetric owner-drop — opt-in, the actual memory bound.**
The pool frees only its own `byte[]` snapshot on eviction; the owning tensor's GC-heap `_data` — re-materialised by (1) — would otherwise accumulate, so a forward pass reading weight after weight would resident every weight it touched. Now `StreamingTensorPool` records each paged-out handle and `WeightRegistry` drops the owning tensor's `_data` via a weak `handle → tensor` map and a new non-generic `IStreamingDroppable`. A re-paged-in handle is removed from the pending set so a stale eviction can't drop a weight the caller just materialised.

Gated behind **`GpuOffloadOptions.TransparentAutoEviction` (default `false`)**: the explicit `MaterializeMany` / `ReleaseToPool` path (`NeuralNetworkBase`) owns residency, and making `Materialize` drop other weights as a side effect would change that contract *and* race a concurrent reader. Enable only for single-threaded foundation inference, where the evicted cold weight is by definition not in use.

## Tests

New `WeightStreamingTransparentAccessTests` (7):
- auto-rehydrate via `AsSpan` / indexer / `ToArray`
- rehydrate-from-disk after eviction
- **the core guarantee**: a sequential weight-by-weight "forward" under a tight budget bounds the resident-tensor count (cold owners dropped) while every read returns exact bytes
- re-read-after-drop stays correct; non-streaming tensors unaffected

All existing streaming suites unchanged and green (`WeightRegistryStreaming` 54 / `WeightLifetimeIntegration` 3 / `StreamingTensorPool` 4). The previously-flaky-under-this-change `StressTest_ConcurrentMaterialize` is deterministic again with owner-drop default-off.

## Follow-up (AiDotNet side, separate PR)
Bump to the published version; add an engagement scope that sets `TransparentAutoEviction = true`, a RAM-fraction resident cap, and tags foundation-model weights `Streaming` via the shared lazy-weight resolution path; wire into the Unit-03 foundation-model tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
