### PR TITLE
fix(streaming): auto-rehydrate on .Memory/.Data access (transparent-streaming gap from #602)

### DIFF
--- a/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
@@ -905,6 +905,14 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
     {
         get
         {
+            // Same auto-materialization guard as AsSpan / AsWritableSpan: a lazy
+            // node is realized and a paged-out streaming weight is rehydrated
+            // before its backing storage is handed out. .Memory / .Data are the
+            // accessors engine + layer code (e.g. SelfAttentionLayer.Forward) use
+            // to reach the buffer, so without this gate a dropped streaming weight
+            // would Slice empty storage and throw. See EnsureMaterialized.
+            EnsureMaterialized();
+
             if (!IsContiguous)
                 throw new InvalidOperationException(
                     "Cannot get contiguous Memory from a non-contiguous tensor view. Call Contiguous() first.");

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightStreamingTransparentAccessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightStreamingTransparentAccessTests.cs
@@ -70,6 +70,26 @@ public class WeightStreamingTransparentAccessTests : IDisposable
     }
 
     [Fact]
+    public void Memory_OnDroppedStreamingWeight_AutoRehydrates()
+    {
+        // .Memory / .Data are the buffer accessors engine + layer code use (e.g.
+        // SelfAttentionLayer.Forward reaches the weight via .Memory). They must
+        // auto-rehydrate a dropped streaming weight exactly like AsSpan — without
+        // the gate, .Memory Slices empty storage and throws ArgumentOutOfRange.
+        float[] expected = { 2.5f, 4.5f, 6.5f, 8.5f };
+        var t = new Tensor<float>(expected, new[] { expected.Length });
+        t.Lifetime = WeightLifetime.Streaming;
+        WeightRegistry.RegisterWeight(t);
+        Assert.Equal(0, t.DataVector.Length);
+
+        var span = t.Memory.Span; // must page the bytes back in transparently
+        Assert.Equal(expected.Length, span.Length);
+        for (int i = 0; i < expected.Length; i++)
+            Assert.Equal(expected[i], span[i]);
+        Assert.Equal(expected.Length, t.DataVector.Length);
+    }
+
+    [Fact]
     public void Indexer_OnDroppedStreamingWeight_AutoRehydrates()
     {
         float[] expected = { 10f, 20f, 30f, 40f, 50f };


### PR DESCRIPTION
Follow-up to #602. The transparent auto-rehydrate gate covered `AsSpan`/`AsWritableSpan`/indexers/`ToArray`/`GetDataArray` but missed the internal `Memory` getter (+ `Data` alias) — the buffer accessor a lot of engine + layer code uses (e.g. `SelfAttentionLayer.Forward`). A paged-out streaming weight read via `.Memory` skipped `EnsureMaterialized`, Sliced empty dropped storage, and threw `ArgumentOutOfRangeException`. Found by end-to-end DiT weight-streaming validation in AiDotNet.

`Memory` now calls `EnsureMaterialized()` first, like the other accessors. `Raw*` spans and `DataVector` stay non-materializing (streaming-internal probe/serialization paths). New test `Memory_OnDroppedStreamingWeight_AutoRehydrates`; all 8 transparent-access tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tensor memory access to transparently rehydrate dropped streaming weights. Tensors with streamed or lazy-loaded data now automatically reload their data when accessed via memory accessors, preventing operations from encountering empty or placeholder data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->