### PR TITLE
Fix SparseEmbeddingGradient.Build throwing on pooled/oversized gradient buffers (silently disables fused training for embedding models)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/SparseEmbeddingGradient.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/SparseEmbeddingGradient.cs
@@ -169,7 +169,15 @@ public readonly struct SparseEmbeddingGradient<T>
         }
         if (gradOutput.Rank != 2 || gradOutput.Shape[0] != totalIndices)
         {
-            flatValues = new Tensor<T>(gradOutput.GetDataArray(), new[] { totalIndices, embeddingDim });
+            // Reshape (not raw-ctor): gradOutput may be backed by a pooled / storage-offset
+            // buffer whose GetDataArray() length exceeds the logical element count (e.g. the
+            // compiled-plan StepEager path hands back pooled activation buffers). The raw
+            // Tensor(data, dims) ctor validates data.Length against the shape and throws
+            // "number of values does not match the specified shape" on such a buffer, which
+            // latched _fusedTrainingDisabled and forced the whole model onto the eager path.
+            // Reshape validates against logical Length and materializes via Contiguous() when
+            // needed, so it round-trips pooled/strided gradients correctly.
+            flatValues = gradOutput.Reshape(totalIndices, embeddingDim);
         }
 
         // Widen indices to long AND normalize to rank-1 [totalIndices]. Callers commonly
@@ -184,7 +192,9 @@ public readonly struct SparseEmbeddingGradient<T>
         }
         else if (typeof(TIndex) == typeof(long) && indices is Tensor<long> alreadyLongMulti)
         {
-            longIndices = new Tensor<long>(alreadyLongMulti.GetDataArray(), new[] { totalIndices });
+            // Same pooled/storage-offset concern as the values reshape above — use Reshape so
+            // a higher-rank long indices tensor backed by an oversized buffer flattens correctly.
+            longIndices = alreadyLongMulti.Reshape(totalIndices);
         }
         else
         {

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/SparseEmbeddingGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/SparseEmbeddingGradientTests.cs
@@ -182,4 +182,56 @@ public class SparseEmbeddingGradientTests
             for (int d = 0; d < embeddingDim; d++)
                 Assert.Equal(reference[i, d], fromSparse[i, d], precision: 5);
     }
+
+    /// <summary>
+    /// Locks the rank-3 <c>[batch, seq, dim]</c> leading-axis flatten path of
+    /// <see cref="SparseEmbeddingGradient{T}.Build"/> — the path the embedding backward takes for a
+    /// batched <c>[batch, seq]</c> token input. Build must flatten the leading axes to the canonical
+    /// <c>[totalIndices, dim]</c> values and produce a <c>ToDense</c> identical to the reference
+    /// dense scatter.
+    /// <para>
+    /// This guards the fix where Build reconstructed the flattened values via
+    /// <c>new Tensor(gradOutput.GetDataArray(), [totalIndices, dim])</c>. On the GPU compiled path
+    /// <c>GetDataArray()</c> returns a POOLED download buffer whose length exceeds the logical
+    /// element count, so the raw <c>Tensor(data, dims)</c> ctor threw "The number of values does not
+    /// match the specified shape" — which latched <c>_fusedTrainingDisabled</c> and silently dropped
+    /// the entire cortex onto the eager path after one step. The fix routes through the
+    /// logical-length-aware <c>Tensor.Reshape</c> (validated end-to-end by the d768/L6 cortex run:
+    /// the ArgumentException disappears and the fused/compiled path engages). The oversized-backing
+    /// condition is GPU-pool-specific and cannot be reproduced with a CPU tensor (CPU
+    /// <c>GetDataArray()</c> always materializes exactly-sized logical data), so this test asserts
+    /// the flatten CORRECTNESS that the Reshape route must preserve.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void Build_Rank3BatchedGradient_FlattensLeadingAxes_AndMatchesDenseReference()
+    {
+        const int batch = 2, seq = 3, dim = 4, vocabSize = 16;
+        int totalIndices = batch * seq; // 6
+
+        // Rank-3 [batch, seq, dim] per-position gradient (the batched embedding-lookup backward shape).
+        var gradOutput = new Tensor<float>(new[] { batch, seq, dim });
+        for (int b = 0; b < batch; b++)
+            for (int s = 0; s < seq; s++)
+                for (int d = 0; d < dim; d++)
+                    gradOutput[b, s, d] = (b * seq + s) * 0.5f + d * 0.1f;
+
+        // Float indices — the cortex path is TensorEmbeddingLookupFromFloatIndicesBackward; index 5
+        // is duplicated so the dense scatter-ADD accumulation is exercised too.
+        var indices = new Tensor<float>(new float[] { 2, 5, 0, 5, 1, 3 }, new[] { batch, seq });
+
+        var sparse = SparseEmbeddingGradient<float>.Build(gradOutput, indices, vocabSize, dim);
+        Assert.Equal(totalIndices, sparse.NumIndices);
+        Assert.Equal(new[] { totalIndices, dim }, sparse.Values.Shape.ToArray());
+
+        // ToDense must equal the reference dense backward built from the flattened gradient.
+        var refValues = gradOutput.Reshape(totalIndices, dim);
+        var refIndices = new Tensor<long>(new long[] { 2, 5, 0, 5, 1, 3 }, new[] { totalIndices });
+        var refDense = Engine.TensorEmbeddingLookupBackward<float, long>(refValues, refIndices, vocabSize, dim);
+        var got = sparse.ToDense(Engine);
+        Assert.Equal(new[] { vocabSize, dim }, got.Shape.ToArray());
+        for (int i = 0; i < vocabSize; i++)
+            for (int d = 0; d < dim; d++)
+                Assert.Equal(refDense[i, d], got[i, d], precision: 5);
+    }
 }


### PR DESCRIPTION
## Problem

`SparseEmbeddingGradient<T>.Build` reconstructs the flattened `[numIndices, embeddingDim]` gradient with:

```csharp
flatValues = new Tensor<T>(gradOutput.GetDataArray(), new[] { totalIndices, embeddingDim });
```

The `Tensor(T[] data, int[] dims)` ctor validates `data.Length == product(dims)`. On the **GPU compiled-training path** `GetDataArray()` returns a **pooled download buffer** whose length exceeds the tensor's logical element count, so the ctor throws:

```
ArgumentException: The number of values does not match the specified shape.
  at Tensor..ctor(T[] data, Int32[] dimensions)
  at SparseEmbeddingGradient.Build(...)
  at BackwardFunctions.TensorEmbeddingLookupFromFloatIndicesBackward(...)
  at CompiledTrainingPlan.StepEager()
  at CompiledTapeTrainingStep.TryStepWithFusedOptimizer(...)
```

`TryStepWithFusedOptimizer` catches it and latches `_fusedTrainingDisabled`, so **every embedding model on the compiled/fused path silently falls back to the eager allocation-churning path after a single step** — which presents as the GPU sitting at very low utilization while training a transformer/embedding model.

`gradOutput.Length` (logical) is correct here; only the **raw backing-array** length differs, so the existing `gradOutput.Length == totalIndices*embeddingDim` guard passes and the failure surfaces one line later in the raw `Tensor(data, dims)` ctor.

## Fix

Reconstruct via the logical-length-aware `Tensor.Reshape`, which validates the **logical** `Length` (not the raw backing length) and materializes through `Contiguous()` for non-contiguous inputs. Applied to both the values flatten and the multi-rank long-indices flatten.

## Verification

- New `Build_Rank3BatchedGradient_FlattensLeadingAxes_AndMatchesDenseReference` regression test; full `SparseEmbeddingGradient` suite green (8/8). (The oversized-backing condition is GPU-pool-specific — CPU `GetDataArray()` always returns exactly-sized logical data — so the unit test locks the rank-3 flatten correctness the `Reshape` route must preserve.)
- End-to-end on a d768/L6 token-LM (GPT-2-small scale) on CUDA: the `ArgumentException` disappears and the fused/compiled training path engages every step (warmup `plan.Step` calls go 1 → N instead of sticky-disabling after step 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)