### PR TITLE
fix(blas): park cooperative-GEMM join instead of busy-spinning (#589)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Pool/CooperativeGemmScheduler.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Pool/CooperativeGemmScheduler.cs
@@ -65,6 +65,17 @@ internal static class CooperativeGemmScheduler
         public readonly Action<int> Action;
         public int Remaining;            // Interlocked-decremented as chunks finish.
         public Exception? FirstException; // First chunk exception (CompareExchange).
+
+        // Spin-then-park join (issue #589). Once the participating caller exhausts its
+        // spin budget waiting for the LAST chunks (held by other threads), it parks on
+        // Done instead of busy-spinning a core — that spin otherwise stole ~47% of a
+        // core from a conv kernel running on the parallel path, halving conv throughput.
+        // Single waiter (the dispatch caller), so Done is created only by the caller and
+        // only when it actually needs to park (the common case completes while draining).
+        // ParkPending=1 tells the thread that decrements Remaining to 0 to wake the caller.
+        public int ParkPending;
+        public ManualResetEventSlim? Done;
+
         public Job(Action<int> action, int remaining) { Action = action; Remaining = remaining; }
     }
 
@@ -155,7 +166,8 @@ internal static class CooperativeGemmScheduler
         finally
         {
             _inScheduler = prev;
-            Interlocked.Decrement(ref item.Job.Remaining);
+            if (Interlocked.Decrement(ref item.Job.Remaining) == 0)
+                SignalIfParked(item.Job);
         }
     }
 
@@ -222,9 +234,30 @@ internal static class CooperativeGemmScheduler
                 else
                 {
                     // Queue empty but our job isn't done → other threads hold our
-                    // remaining chunks. Spin briefly, then yield.
-                    if (spin++ < 1000) Thread.SpinWait(8);
-                    else { Thread.Yield(); spin = 0; }
+                    // remaining chunks; we cannot help. Spin briefly to cover the
+                    // sub-microsecond completion gap, then PARK on the job's done
+                    // event instead of an unbounded SpinWait/Yield loop. The old loop
+                    // burned a whole core busy-waiting — under conv-dominated workloads
+                    // that core contends with the FusedConvHelper conv running on the
+                    // parallel path, roughly halving conv throughput (issue #589).
+                    if (spin++ < CoopJoinSpinBeforePark)
+                    {
+                        Thread.SpinWait(8);
+                    }
+                    else
+                    {
+                        var done = job.Done ?? EnsureDoneEvent(job);
+                        Volatile.Write(ref job.ParkPending, 1);
+                        // Publish ParkPending=1 before re-reading Remaining. Without this
+                        // fence the thread completing the last chunk could read
+                        // ParkPending==0 and skip the wake while we then read a stale
+                        // Remaining>0 and park forever (lost wakeup).
+                        Interlocked.MemoryBarrier();
+                        if (Volatile.Read(ref job.Remaining) > 0)
+                            done.Wait();
+                        Volatile.Write(ref job.ParkPending, 0);
+                        spin = 0;
+                    }
                 }
             }
         }
@@ -252,8 +285,43 @@ internal static class CooperativeGemmScheduler
         }
         finally
         {
-            Interlocked.Decrement(ref item.Job.Remaining);
+            if (Interlocked.Decrement(ref item.Job.Remaining) == 0)
+                SignalIfParked(item.Job);
         }
+    }
+
+    /// <summary>
+    /// SpinWait(8) iterations the participating caller burns waiting for the last
+    /// in-flight chunks before it parks on the job's done event (issue #589). 1000
+    /// preserves the original sub-microsecond busy-wait latency for fast completions;
+    /// only the previously-unbounded yield tail is replaced by a park.
+    /// </summary>
+    private const int CoopJoinSpinBeforePark = 1000;
+
+    /// <summary>
+    /// Lazily creates the dispatch caller's park event. Only the caller creates it
+    /// (single creator), and it is published before any <c>ParkPending = 1</c> store,
+    /// so a thread that observes <c>ParkPending == 1</c> always sees a non-null Done.
+    /// </summary>
+    private static ManualResetEventSlim EnsureDoneEvent(Job job)
+    {
+        var ev = new ManualResetEventSlim(false);
+        Volatile.Write(ref job.Done, ev);
+        return ev;
+    }
+
+    /// <summary>
+    /// Wakes the participating caller if it has parked on this job. Called by the thread
+    /// that decrements <see cref="Job.Remaining"/> to 0 — that Interlocked decrement is a
+    /// full fence, so this read of ParkPending sees the caller's store; if the caller has
+    /// committed to parking we set its event, otherwise its post-store re-read of
+    /// Remaining (now 0) makes it skip the park.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void SignalIfParked(Job job)
+    {
+        if (Volatile.Read(ref job.ParkPending) == 1)
+            job.Done?.Set();
     }
 
     private static void RunSerial(int numChunks, Action<int> action)

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/AbsSoftplusGradientRepro.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/AbsSoftplusGradientRepro.cs
@@ -1,0 +1,164 @@
+using System;
+using AiDotNet.Tensors;
+using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+/// <summary>
+/// Gradient-correctness guards for the abs/softplus op chain and for the
+/// AutoTrainingCompiler REPLAY path on realistic (parameter → matmul → unary →
+/// loss) computations.
+///
+/// Origin: AiDotNet's BCE-with-logits loss (the numerically-stable softplus
+/// max(x,0)+log(1+exp(-|x|))) was suspected of producing a wrong-direction tape
+/// gradient. Direct testing here showed that suspicion was WRONG — both the
+/// interpreted autodiff (every op) and the compiled-replay autodiff (for any
+/// computation where the parameter reaches the loss through a binary op, i.e.
+/// all real training) compute the correct gradient. These tests pin that down so
+/// the conclusion is durable and the replay path's gradient correctness — which
+/// was previously untested — is now guarded.
+/// </summary>
+public class AbsSoftplusGradientRepro
+{
+    private readonly ITestOutputHelper _out;
+    private readonly IEngine _engine = AiDotNetEngine.Current;
+
+    public AbsSoftplusGradientRepro(ITestOutputHelper output) => _out = output;
+
+    private static double Sigmoid(double x) => 1.0 / (1.0 + Math.Exp(-x));
+
+    // ── Interpreted-path correctness (the path small models use) ──────────────
+
+    [Fact]
+    public void AbsForm_Softplus_Gradient_MatchesSigmoid()
+    {
+        var data = new double[] { -2.0, -0.5, 0.5, 2.0 };
+        var x = new Tensor<double>(data, new[] { 4 });
+
+        using var tape = new GradientTape<double>();
+        // softplus(x) = max(x,0) + log(1 + exp(-|x|))  →  d/dx = sigmoid(x)
+        var logT = _engine.TensorLog(_engine.TensorAddScalar(
+            _engine.TensorExp(_engine.TensorNegate(_engine.TensorAbs(x))), 1.0));
+        var sp = _engine.TensorAdd(_engine.ReLU(x), logT);
+        var loss = _engine.ReduceSum(sp, null);
+        var gx = tape.ComputeGradients(loss, new[] { x })[x];
+
+        for (int i = 0; i < data.Length; i++)
+            Assert.True(Math.Abs(gx[i] - Sigmoid(data[i])) < 1e-6,
+                $"abs-form softplus grad at x={data[i]}: got {gx[i]}, expected {Sigmoid(data[i])}");
+    }
+
+    [Fact]
+    public void AbsFreeForm_Softplus_Gradient_MatchesSigmoid()
+    {
+        var data = new double[] { -2.0, -0.5, 0.5, 2.0 };
+        var x = new Tensor<double>(data, new[] { 4 });
+
+        using var tape = new GradientTape<double>();
+        var logT = _engine.TensorLog(_engine.TensorAddScalar(_engine.TensorExp(x), 1.0));
+        var loss = _engine.ReduceSum(logT, null);
+        var gx = tape.ComputeGradients(loss, new[] { x })[x];
+
+        for (int i = 0; i < data.Length; i++)
+            Assert.True(Math.Abs(gx[i] - Sigmoid(data[i])) < 1e-6,
+                $"abs-free softplus grad at x={data[i]}: got {gx[i]}, expected {Sigmoid(data[i])}");
+    }
+
+    [Fact]
+    public void Abs_Gradient_IsSign()
+    {
+        var data = new double[] { -2.0, -0.5, 0.5, 2.0 };
+        var x = new Tensor<double>(data, new[] { 4 });
+
+        using var tape = new GradientTape<double>();
+        var loss = _engine.ReduceSum(_engine.TensorAbs(x), null);
+        var gx = tape.ComputeGradients(loss, new[] { x })[x];
+
+        for (int i = 0; i < data.Length; i++)
+            Assert.True(Math.Abs(gx[i] - Math.Sign(data[i])) < 1e-6,
+                $"|x| grad at x={data[i]}: got {gx[i]}, expected {Math.Sign(data[i])}");
+    }
+
+    // ── Compiled-replay correctness on realistic patterns (was untested) ──────
+
+    [Fact]
+    public void CompiledReplay_MatMulChain_WeightGradientPresent()
+    {
+        var input = new Tensor<double>(new double[] { 1, 2, 3, 4 }, new[] { 2, 2 });
+        var wData = new double[] { 0.5, -0.5, 0.25, 0.75 };
+
+        bool prev = AutoTrainingCompiler.Enabled;
+        AutoTrainingCompiler.Enabled = true;
+        AutoTrainingCompiler.TestMinForwardElementsOverride = 1;
+        try
+        {
+            var weight = new Tensor<double>((double[])wData.Clone(), new[] { 2, 2 });
+            using var tape = new GradientTape<double>(new GradientTapeOptions { Persistent = true });
+            bool present = false;
+            for (int step = 0; step < 5; step++)
+            {
+                tape.Reset();
+                var h = _engine.TensorMatMul(input, weight);
+                var loss = _engine.ReduceMean(h, new[] { 0, 1 }, keepDims: false);
+                present = tape.ComputeGradients(loss, new[] { weight }).ContainsKey(weight);
+            }
+            Assert.True(present, "compiled replay dropped the matmul weight gradient");
+        }
+        finally
+        {
+            AutoTrainingCompiler.TestMinForwardElementsOverride = null;
+            AutoTrainingCompiler.Enabled = prev;
+        }
+    }
+
+    [Fact]
+    public void CompiledReplay_MatMulThenUnary_GradientMatchesReference()
+    {
+        // BCE-with-logits-shaped pattern: weight → matmul → unary(exp) → loss.
+        var input = new Tensor<double>(new double[] { 1, 2, 3, 4 }, new[] { 2, 2 });
+        var wData = new double[] { 0.1, -0.2, 0.3, 0.4 };
+
+        double[] refGrad;
+        {
+            var weight = new Tensor<double>((double[])wData.Clone(), new[] { 2, 2 });
+            using var tape = new GradientTape<double>();
+            var loss = _engine.ReduceMean(
+                _engine.TensorExp(_engine.TensorMatMul(input, weight)), new[] { 0, 1 }, keepDims: false);
+            var g = tape.ComputeGradients(loss, new[] { weight })[weight];
+            refGrad = new double[4];
+            for (int i = 0; i < 4; i++) refGrad[i] = g[i];
+        }
+
+        bool prev = AutoTrainingCompiler.Enabled;
+        AutoTrainingCompiler.Enabled = true;
+        AutoTrainingCompiler.TestMinForwardElementsOverride = 1;
+        try
+        {
+            var weight = new Tensor<double>((double[])wData.Clone(), new[] { 2, 2 });
+            using var tape = new GradientTape<double>(new GradientTapeOptions { Persistent = true });
+            double[]? cg = null;
+            for (int step = 0; step < 5; step++)
+            {
+                tape.Reset();
+                var loss = _engine.ReduceMean(
+                    _engine.TensorExp(_engine.TensorMatMul(input, weight)), new[] { 0, 1 }, keepDims: false);
+                var grads = tape.ComputeGradients(loss, new[] { weight });
+                cg = grads.TryGetValue(weight, out var g) ? new[] { g[0], g[1], g[2], g[3] } : null;
+            }
+            Assert.True(cg is not null, "compiled replay dropped the weight gradient through a unary intermediate");
+            for (int i = 0; i < 4; i++)
+                Assert.True(Math.Abs(cg![i] - refGrad[i]) < 1e-9,
+                    $"compiled replay grad[{i}]={cg[i]} != interpreted reference {refGrad[i]}");
+        }
+        finally
+        {
+            AutoTrainingCompiler.TestMinForwardElementsOverride = null;
+            AutoTrainingCompiler.Enabled = prev;
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/CooperativeSchedulerJoinParkTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/CooperativeSchedulerJoinParkTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using AiDotNet.Tensors.Engines.BlasManaged.Pool;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+/// <summary>
+/// Guards the spin-then-park join in <see cref="CooperativeGemmScheduler"/> (issue
+/// #589). When the participating caller drains the queue but its job's last chunks
+/// are still running on other threads, it now PARKS on the job's done event after a
+/// bounded spin instead of busy-spinning a core (which stole ~47% of a core from a
+/// conv kernel on the parallel path). These tests force that park path — chunks that
+/// out-live the caller's spin budget — and verify correctness with no lost wakeup or
+/// hang.
+/// </summary>
+public class CooperativeSchedulerJoinParkTests
+{
+    [Fact]
+    public void Dispatch_LongChunks_ForceCallerPark_CompleteExactlyOnce()
+    {
+        // Each chunk sleeps well past the caller's spin budget, so after the caller
+        // has drained what it can it must park and be woken by the thread that
+        // finishes the last chunk. A lost wakeup would hang here (caught by Timeout).
+        const int chunks = 16;
+        var counts = new int[chunks];
+
+        var done = Task.Run(() =>
+            CooperativeGemmScheduler.Dispatch(chunks, c =>
+            {
+                Thread.Sleep(15); // >> CoopJoinSpinBeforePark (~µs) → caller parks
+                Interlocked.Increment(ref counts[c]);
+            }));
+
+        Assert.True(done.Wait(TimeSeconds(30)), "Dispatch hung — likely a lost wakeup in the join-park path");
+        for (int c = 0; c < chunks; c++)
+            Assert.Equal(1, counts[c]);
+    }
+
+    [Fact]
+    public void Dispatch_RepeatedParkWake_NoHang_NoDoubleRun()
+    {
+        // Hammer the park/wake transition across many dispatches to surface any
+        // lost-wakeup or double-execution race in the ParkPending handshake.
+        var sw = Stopwatch.StartNew();
+        for (int iter = 0; iter < 200 && sw.Elapsed < TimeSeconds(60); iter++)
+        {
+            const int chunks = 8;
+            var counts = new int[chunks];
+            var done = Task.Run(() =>
+                CooperativeGemmScheduler.Dispatch(chunks, c =>
+                {
+                    // Mix: some chunks fast, some slow, so the caller sometimes drains
+                    // them all (no park) and sometimes must park for the slow tail.
+                    if ((c & 1) == 0) Thread.SpinWait(50);
+                    else Thread.Sleep(3);
+                    Interlocked.Increment(ref counts[c]);
+                }));
+            Assert.True(done.Wait(TimeSeconds(20)), $"Dispatch hung at iteration {iter}");
+            for (int c = 0; c < chunks; c++)
+                Assert.Equal(1, counts[c]);
+        }
+    }
+
+    private static TimeSpan TimeSeconds(int s) => TimeSpan.FromSeconds(s);
+}


### PR DESCRIPTION
## Summary

Two Tensors fixes from a debugging session on AiDotNet's conv-heavy model shards.

### 1. fix(blas): park the cooperative-GEMM join instead of busy-spinning (#589)

`CooperativeGemmScheduler.Dispatch` makes the calling thread participate by draining the shared chunk queue until its job completes. Once the queue is empty but the job isn't done (other threads hold the last chunks), the caller had **no bound** on its wait — it span `SpinWait(8)×1000` then `Thread.Yield()` and reset, forever. Under conv-dominated workloads that busy-spin burns a whole core that contends with the `FusedConvHelper` conv kernel on the parallel path, roughly **halving conv throughput** (the ResNet/diffusion timeout symptom in #589).

Fix: **spin-then-park**, mirroring the existing `StreamingWorkerPool` #589 fix. The caller spins a bounded budget (preserving sub-µs latency for fast completions) then parks on a lazy per-job `ManualResetEventSlim`; the thread that decrements `Job.Remaining` to 0 wakes it. The handshake is **lost-wakeup-safe** (`ParkPending` + `MemoryBarrier` + `Remaining` re-read; the completer's `Interlocked` decrement is a full fence).

### 2. test(autodiff): guard abs/softplus + compiled-replay gradient correctness

Adds regression guards prompted by a (disproven) suspicion that the stable BCE-with-logits softplus produced a wrong-direction gradient. Both the interpreted autodiff and the `AutoTrainingCompiler` **replay** path are confirmed correct for all realistic patterns (param → matmul → unary → loss). Notably this closes a real gap: the replay path's gradient *correctness* (vs. its `ReplayMode` bookkeeping) was previously unverified.

## Testing

- All 21 existing cooperative-scheduler concurrency/deadlock-stress/integration tests pass.
- New `CooperativeSchedulerJoinParkTests` (forced-park + repeated park/wake hammer) + `AbsSoftplusGradientRepro` (interpreted + compiled-replay parity) — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
