### PR TITLE
GpuMemoryTracker (built-in leak detector) + reuse resident weight buffers in fused ops (fixes a ~24 GB FusedLinear weight leak)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -1049,6 +1049,29 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
 
         // CUDA driver API calls are required for device memory operations.
         using var _ = PushContext();
+        // Stream-ordered allocation (same default mem pool as the activation buffers) when async-alloc is
+        // on. Without this, weight/persistent uploads take the legacy SYNC cuMemAlloc path below, which sees
+        // device free=0 once the async pool has reserved VRAM (release threshold maxed for caching) — the
+        // forward-only eval path then OOMs on its first weight upload while the GPU is "full" of pool-reserved
+        // (but reusable) bytes. Drawing weights from the same pool removes that sync/async split.
+        if (_asyncAlloc)
+        {
+            var pAsync = AllocDeviceMemoryAsync(byteSize);
+            try
+            {
+                unsafe
+                {
+                    fixed (float* src = data)
+                    {
+                        CuBlasNative.CheckCudaResult(
+                            CuBlasNative.cuMemcpyHtoD(pAsync, (IntPtr)src, byteSize),
+                            "cuMemcpyHtoD");
+                    }
+                }
+            }
+            catch { CuBlasNative.cuMemFreeAsync(pAsync, _stream); throw; }
+            return new CudaGpuBuffer(_cudaContext, pAsync, size, returnToPool: null, asyncFreeStream: _stream);
+        }
         if (_bufferPool.TryRent(size, out var pooled) && pooled != null)
         {
             unsafe
@@ -1246,6 +1269,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
                 ulong free = 0, total = 0;
                 try { CudaNativeBindings.cuMemGetInfo(out free, out total); }
                 catch { /* diagnostic only — never mask the real failure */ }
+                GpuMemoryTracker.Dump($"cuMemAlloc OOM requesting {byteSize} bytes (free={free})");
                 throw new InvalidOperationException(
                     $"cuMemAlloc failed: {CuBlasNative.GetCudaErrorString(result)} " +
                     $"(requested {byteSize} bytes; drained {drained} pooled buffers; " +
@@ -1256,6 +1280,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         {
             CuBlasNative.CheckCudaResult(result, "cuMemAlloc");
         }
+        GpuMemoryTracker.OnAlloc(devicePtr, (long)byteSize);
         return devicePtr;
     }
 
@@ -1320,10 +1345,18 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         var r = CuBlasNative.cuMemAllocAsync(out IntPtr p, byteSize, _stream);
         if (r != CudaResult.Success)
         {
+            // Sync so pending cuMemFreeAsync reclamations land back in the pool, then TRIM the pool's
+            // retained-but-unused reservation back to the OS. After a fused/resident training run the pool
+            // has reserved up to the training peak (release threshold maxed for caching); a later phase with
+            // a different allocation shape (e.g. forward-only eval re-uploading weights) can then OOM here
+            // while almost all of VRAM is pool-reserved-but-free. Trimming returns it so the retry succeeds.
             CuBlasNative.cuCtxSynchronize();
+            if (_asyncMemPool != IntPtr.Zero) CuBlasNative.cuMemPoolTrimTo(_asyncMemPool, 0);
             r = CuBlasNative.cuMemAllocAsync(out p, byteSize, _stream);
         }
+        if (r != CudaResult.Success) GpuMemoryTracker.Dump($"cuMemAllocAsync OOM requesting {byteSize} bytes");
         CuBlasNative.CheckCudaResult(r, "cuMemAllocAsync");
+        GpuMemoryTracker.OnAlloc(p, (long)byteSize);
         return p;
     }
 
@@ -15103,6 +15136,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
                         try
                         {
                             CuBlasNative.cuCtxPushCurrent(_context);
+                            GpuMemoryTracker.OnFree(_devicePtr);
                             // Stream-ordered free (#558 layer 6): race-safe + pool-reused in stream order.
                             if (_asyncFreeStream != IntPtr.Zero)
                                 CuBlasNative.cuMemFreeAsync(_devicePtr, _asyncFreeStream);
@@ -15198,6 +15232,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
                         try
                         {
                             CuBlasNative.cuCtxPushCurrent(_context);
+                            GpuMemoryTracker.OnFree(_devicePtr);
                             // Stream-ordered free (#558 layer 6): race-safe + pool-reused in stream order.
                             if (_asyncFreeStream != IntPtr.Zero)
                                 CuBlasNative.cuMemFreeAsync(_devicePtr, _asyncFreeStream);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/GpuMemoryTracker.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/GpuMemoryTracker.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu;
+
+/// <summary>
+/// Production GPU device-memory tracker and leak detector. A built-in, zero-dependency alternative to an
+/// external tool like <c>compute-sanitizer</c> for answering "what is holding GPU memory right now?".
+/// </summary>
+/// <remarks>
+/// <para>
+/// Records every <b>device</b> allocation (the actual <c>cuMemAlloc</c> / <c>cuMemAllocAsync</c>, not the
+/// software buffer-pool rent/return layer above it) together with its byte size and the managed call stack
+/// at the allocation site, and clears it on the matching free. <see cref="Report"/> returns the LIVE set
+/// grouped by call site and sorted by bytes — i.e. precisely the retention/leak breakdown a memcheck would
+/// surface, but in-process and on any driver (no toolkit install required).
+/// </para>
+/// <para>
+/// <b>Opt-in and zero-cost when off.</b> All hooks early-out on <see cref="Enabled"/> (env
+/// <c>AIDOTNET_GPU_MEMTRACK=1</c>) before doing any work, so a production build with tracking disabled pays
+/// only a single boolean check per allocation. When enabled, each allocation additionally captures a short
+/// managed stack trace (a few frames) — cheap relative to a device allocation but not free, hence opt-in.
+/// </para>
+/// <para>
+/// Thread-safe: the live map is a <see cref="ConcurrentDictionary{TKey,TValue}"/> and the running counters
+/// are updated with interlocked operations, so it is safe under the multi-stream / BLAS-pool concurrency the
+/// GPU backends use.
+/// </para>
+/// </remarks>
+public static class GpuMemoryTracker
+{
+    /// <summary>True when tracking is enabled (env <c>AIDOTNET_GPU_MEMTRACK=1</c>). Checked first on every hook.</summary>
+    public static readonly bool Enabled =
+        Environment.GetEnvironmentVariable("AIDOTNET_GPU_MEMTRACK") == "1";
+
+    private sealed class Rec
+    {
+        public long Bytes;
+        public string Site = "";
+        public long Seq;
+    }
+
+    private static readonly ConcurrentDictionary<long, Rec> s_live = new();
+    private static long s_seq;
+    private static long s_liveBytes;
+    private static long s_peakBytes;
+    private static long s_totalAllocs;
+    private static long s_totalFrees;
+
+    /// <summary>Bytes currently allocated on the device and not yet freed (sum over the live set).</summary>
+    public static long LiveBytes => Interlocked.Read(ref s_liveBytes);
+
+    /// <summary>The high-water mark of <see cref="LiveBytes"/> observed since process start.</summary>
+    public static long PeakBytes => Interlocked.Read(ref s_peakBytes);
+
+    /// <summary>Number of live (un-freed) device allocations.</summary>
+    public static int LiveCount => s_live.Count;
+
+    /// <summary>Records a device allocation. Call right after a successful <c>cuMemAlloc</c>/<c>cuMemAllocAsync</c>.</summary>
+    public static void OnAlloc(IntPtr ptr, long bytes)
+    {
+        if (!Enabled || ptr == IntPtr.Zero || bytes <= 0) return;
+        var rec = new Rec { Bytes = bytes, Site = CaptureSite(), Seq = Interlocked.Increment(ref s_seq) };
+        s_live[(long)ptr] = rec;
+        Interlocked.Increment(ref s_totalAllocs);
+        long lb = Interlocked.Add(ref s_liveBytes, bytes);
+        // Best-effort peak update (CAS loop; a benign miss under contention only undercounts the peak slightly).
+        long peak;
+        while (lb > (peak = Interlocked.Read(ref s_peakBytes)))
+            if (Interlocked.CompareExchange(ref s_peakBytes, lb, peak) == peak) break;
+    }
+
+    /// <summary>Clears a device allocation. Call right before the matching <c>cuMemFree</c>/<c>cuMemFreeAsync</c>.</summary>
+    public static void OnFree(IntPtr ptr)
+    {
+        if (!Enabled || ptr == IntPtr.Zero) return;
+        if (s_live.TryRemove((long)ptr, out var rec))
+        {
+            Interlocked.Add(ref s_liveBytes, -rec.Bytes);
+            Interlocked.Increment(ref s_totalFrees);
+        }
+    }
+
+    private static string CaptureSite()
+    {
+        // Skip the tracker frame + the immediate backend alloc wrapper; show the next several callers so the
+        // owning op (e.g. FusedLinear / StepEager / ConfigureOptimizer) is visible without the noise.
+        var st = new StackTrace(2, false);
+        var sb = new StringBuilder();
+        int shown = 0;
+        for (int i = 0; i < st.FrameCount && shown < 7; i++)
+        {
+            var m = st.GetFrame(i)?.GetMethod();
+            if (m is null) continue;
+            string name = (m.DeclaringType?.Name ?? "?") + "." + m.Name;
+            if (name.Contains("GpuMemoryTracker")) continue;
+            if (shown > 0) sb.Append(" < ");
+            sb.Append(name);
+            shown++;
+        }
+        return sb.Length == 0 ? "(no managed frames)" : sb.ToString();
+    }
+
+    /// <summary>
+    /// A human-readable snapshot of the LIVE device allocations, grouped by call site and sorted by bytes
+    /// (largest first). The header line carries totals (live bytes/count, peak, lifetime alloc/free counts).
+    /// Returns a short "disabled" note when <see cref="Enabled"/> is false.
+    /// </summary>
+    public static string Report(int topN = 40)
+    {
+        if (!Enabled) return "[GpuMemoryTracker] disabled (set AIDOTNET_GPU_MEMTRACK=1)";
+        var groups = new Dictionary<string, (long bytes, int count)>();
+        foreach (var kv in s_live)
+        {
+            groups.TryGetValue(kv.Value.Site, out var cur);
+            groups[kv.Value.Site] = (cur.bytes + kv.Value.Bytes, cur.count + 1);
+        }
+        var sorted = new List<KeyValuePair<string, (long bytes, int count)>>(groups);
+        sorted.Sort((a, b) => b.Value.bytes.CompareTo(a.Value.bytes));
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"[GpuMemoryTracker] live={LiveBytes / 1048576.0:F1} MB across {LiveCount} allocs " +
+                      $"(peak={PeakBytes / 1048576.0:F1} MB; lifetime allocs={Interlocked.Read(ref s_totalAllocs)}, " +
+                      $"frees={Interlocked.Read(ref s_totalFrees)}). Top {Math.Min(topN, sorted.Count)} sites by live bytes:");
+        for (int i = 0; i < sorted.Count && i < topN; i++)
+            sb.AppendLine($"  {sorted[i].Value.bytes / 1048576.0,9:F1} MB  x{sorted[i].Value.count,-5}  {sorted[i].Key}");
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Appends <see cref="Report"/> to a file (default: <c>%TEMP%/aidotnet_gpumem.txt</c>) with a label.
+    /// Called by the backends right before they surface an out-of-memory failure so the OOM is accompanied by
+    /// the live-retention breakdown. No-op when disabled. Never throws (best-effort diagnostics).
+    /// </summary>
+    public static void Dump(string label)
+    {
+        if (!Enabled) return;
+        try
+        {
+            string path = Environment.GetEnvironmentVariable("AIDOTNET_GPU_MEMTRACK_FILE")
+                          ?? System.IO.Path.Combine(System.IO.Path.GetTempPath(), "aidotnet_gpumem.txt");
+            System.IO.File.AppendAllText(path, $"==== {label} ====" + Environment.NewLine + Report() + Environment.NewLine);
+        }
+        catch { /* diagnostics must never destabilize the caller */ }
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -1675,6 +1675,49 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     }
 
     /// <summary>
+    /// Like <see cref="ClearActivationCache"/> but DROPS each cached activation WITHOUT materializing its
+    /// pending GPU→CPU download. Use ONLY when the cached activations are provably dead — e.g. a forward-only
+    /// inference/eval pass, where no backward and no host read of an intermediate activation will follow.
+    /// ClearActivationCache downloads every entry to keep a later CPU read correct; over a long eval loop
+    /// that is ~one download per cached op × thousands of positions, which dominates wall-clock. Dropping
+    /// frees the GPU buffers and removes the (now-moot) materializers directly.
+    /// </summary>
+    public void DropActivationCache()
+    {
+        List<KeyValuePair<object, ActivationCacheEntry>> toDispose;
+        lock (_activationCacheLock)
+        {
+            toDispose = new List<KeyValuePair<object, ActivationCacheEntry>>(_activationCache);
+            _activationCache.Clear();
+            System.Threading.Interlocked.Exchange(ref _currentActivationCacheBytes, 0);
+            System.Threading.Interlocked.Exchange(ref _currentActivationManagedBytes, 0);
+        }
+        foreach (var kv in toDispose)
+            Helpers.DeferredArrayMaterializer.Remove(kv.Key); // drop the pending download — the data is dead
+        foreach (var kv in toDispose)
+            kv.Value.Dispose();                               // free the GPU buffer
+    }
+
+    /// <summary>
+    /// Returns the GPU buffer for a weight/bias tensor, preferring the tensor's OWN resident GPU buffer when
+    /// it has one. Under GPU-resident parameters the weights already live on the device (and the optimizer
+    /// updates that buffer in place), so using it directly is both correct and free. The host-array fallback
+    /// (<see cref="GetOrCacheWeightBuffer"/>) is keyed by <c>GetDataArray()</c>, which for a resident tensor
+    /// returns a FRESH host array on every call → a persistent-cache MISS every forward → a re-upload AND a
+    /// brand-new cached GPU buffer each time. That leaks thousands of weight-buffer copies (GPU OOM, found
+    /// via <see cref="DirectGpu.GpuMemoryTracker"/>: ~24 GB across ~10k FusedLinear weight allocs) and wastes
+    /// the bandwidth of re-uploading the weights every step. Falls back to the persistent cache for
+    /// CPU-resident weights, where <c>GetDataArray()</c> is the stable backing array and the cache hits.
+    /// </summary>
+    private OwnedBuffer GetWeightBufferPreferResident<T>(IDirectGpuBackend backend, Tensor<T> weights, PersistentTensorRole role)
+    {
+        var resident = weights.TryGetGpuBuffer();
+        if (resident != null)
+            return new OwnedBuffer(resident, ownsBuffer: false);
+        return GetOrCacheWeightBuffer(backend, weights.GetDataArray(), role);
+    }
+
+    /// <summary>
     /// Gets a GPU buffer for weight/bias tensor, auto-caching if not already persistent.
     /// Unlike GetOrAllocateBuffer, this caches the buffer in the persistent cache
     /// so subsequent calls reuse the same GPU buffer without re-uploading.
@@ -4270,8 +4313,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // whole-step graph and pinning the cortex to the launch-bound eager path (~14% util). GetOrCacheWeightBuffer
         // adds to _persistentBufferCache — the same cache the optimizer updates in place — so the weights stay
         // resident AND fresh. Matches the sibling fused-op path below (#GPU-graph-capture).
-        using var weightsBuffer = GetOrCacheWeightBuffer(backend, weights.GetDataArray(), PersistentTensorRole.Weights);
-        using var biasBuffer = bias != null ? GetOrCacheWeightBuffer(backend, bias.GetDataArray(), PersistentTensorRole.Biases) : default;
+        using var weightsBuffer = GetWeightBufferPreferResident(backend, weights, PersistentTensorRole.Weights);
+        using var biasBuffer = bias != null ? GetWeightBufferPreferResident(backend, bias, PersistentTensorRole.Biases) : default;
 
         try
         {
@@ -4371,7 +4414,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // Upload input to GPU (activations are not cached persistently)
         using var inputBuffer = GetOrAllocateBuffer(backend, input);
         // Auto-cache weights and biases so they stay on GPU for subsequent calls
-        using var weightsBuffer = GetOrCacheWeightBuffer(backend, weights.GetDataArray(), PersistentTensorRole.Weights);
+        using var weightsBuffer = GetWeightBufferPreferResident(backend, weights, PersistentTensorRole.Weights);
         using var biasBuffer = bias != null ? GetOrCacheWeightBuffer(backend, bias.GetDataArray(), PersistentTensorRole.Biases) : default;
 
         // Execute the fused kernel and get result buffer
@@ -6322,7 +6365,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
         // Use cache-aware buffer allocation for weights/bias (persistent tensors)
         using var inputBuffer = GetOrAllocateBuffer(backend, input);
-        using var weightsBuffer = GetOrCacheWeightBuffer(backend, weights.GetDataArray(), PersistentTensorRole.Weights);
+        using var weightsBuffer = GetWeightBufferPreferResident(backend, weights, PersistentTensorRole.Weights);
         using var outputBuffer = AllocateOutputBuffer(backend, outputSize);
 
         try
@@ -6396,7 +6439,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int inputSize = batch * inChannels * inHeight * inWidth;
 
         using var gradOutputBuffer = GetOrAllocateBuffer(backend, gradOutput);
-        using var weightsBuffer = GetOrCacheWeightBuffer(backend, weights.GetDataArray(), PersistentTensorRole.Weights);
+        using var weightsBuffer = GetWeightBufferPreferResident(backend, weights, PersistentTensorRole.Weights);
         using var gradInputBuffer = AllocateOutputBuffer(backend, inputSize);
 
         try
@@ -6557,7 +6600,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
         int outputSize = batch * outChannels * outHeight * outWidth;
 
-        using var weightsBuffer = GetOrCacheWeightBuffer(backend, weights.GetDataArray(), PersistentTensorRole.Weights);
+        using var weightsBuffer = GetWeightBufferPreferResident(backend, weights, PersistentTensorRole.Weights);
         using var biasBuffer = bias != null ? GetOrCacheWeightBuffer(backend, bias.GetDataArray(), PersistentTensorRole.Biases) : default(OwnedBuffer?);
         var outputBuffer = backend.AllocateBuffer(outputSize);
 
@@ -7015,7 +7058,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
         int outputSize = batch * outChannels * outHeight * outWidth;
 
-        using var weightsBuffer = GetOrCacheWeightBuffer(backend, weights.GetDataArray(), PersistentTensorRole.Weights);
+        using var weightsBuffer = GetWeightBufferPreferResident(backend, weights, PersistentTensorRole.Weights);
         using var offsetsBuffer = GetOrAllocateBuffer(backend, offsets);
         using var maskBuffer = mask != null ? GetOrAllocateBuffer(backend, mask) : default(OwnedBuffer?);
         using var biasBuffer = bias != null ? GetOrCacheWeightBuffer(backend, bias.GetDataArray(), PersistentTensorRole.Biases) : default(OwnedBuffer?);
@@ -8086,7 +8129,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             throw new ArgumentException($"Input last dimension {lastDim} doesn't match weight input dimension {inputDim}");
 
         // Upload weights
-        using var weightsBuffer = GetOrCacheWeightBuffer(backend, weights.GetDataArray(), PersistentTensorRole.Weights);
+        using var weightsBuffer = GetWeightBufferPreferResident(backend, weights, PersistentTensorRole.Weights);
 
         // Execute MatMul
         var resultBuffer = backend.MatMul(input.Buffer, weightsBuffer.Buffer, flatBatch, outputDim, inputDim);
@@ -12939,7 +12982,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // If cached, we modify it in place.
         // We must ensure CPU side knows it's dirty if we download later.
 
-        using var weightsBuffer = GetOrCacheWeightBuffer(backend, weights.GetDataArray(), PersistentTensorRole.Weights);
+        using var weightsBuffer = GetWeightBufferPreferResident(backend, weights, PersistentTensorRole.Weights);
         backend.StdpUpdate(
             weightsBuffer.Buffer,
             preTrace.Buffer,


### PR DESCRIPTION
> Stacked on #609 (base `fix/cuda-async-alloc-default`). Rebase to `main` after #609 merges.

## GpuMemoryTracker — a built-in GPU memory leak detector

An in-process, driver-independent alternative to `compute-sanitizer` for answering *"what is holding GPU device memory right now?"*. Opt-in via `AIDOTNET_GPU_MEMTRACK=1` (a single boolean check per allocation when off — zero-cost in production). When on, it records every `cuMemAlloc`/`cuMemAllocAsync` with its byte size and the managed call stack, clears it on free, and `Report()`/`Dump()` print the **live set grouped by call site, sorted by bytes** (plus live/peak totals and lifetime alloc/free counts). The CUDA backend calls its `OnAlloc`/`OnFree` hooks and `Dump()` immediately before surfacing an OOM, so an out-of-memory failure arrives with the retention breakdown attached.

## The leak it found (and this PR fixes)

`DirectGpuTensorEngine.FusedLinear` (and sibling fused-op paths) acquired their weight buffer via `GetOrCacheWeightBuffer(weights.GetDataArray(), ...)`, which caches by the host array. For a **GPU-resident** weights tensor, `GetDataArray()` returns a **fresh host array every call**, so the persistent cache **missed on every forward** — re-uploading the weights *and* caching a brand-new GPU buffer each time. The tracker pinned it in one run:

```
24.4 GB live across 10574 allocs (258093 allocs / 247519 frees). Top sites:
  14.7 GB x4900  AllocDeviceMemoryAsync < AllocateBuffer < GetOrCacheWeightBuffer < FusedLinear < DenseLayer.Forward
   6.3 GB x286   ... < FusedLinear < ... < Predict
   2.7 GB x122   ... < FusedLinear < ... < PredictEager
```

**Fix:** new `GetWeightBufferPreferResident` uses the tensor's own resident GPU buffer when present (it already holds the optimizer-updated weights), eliminating both the leak and the per-forward `cuMemcpyHtoD`. Falls back to the host-array persistent cache for CPU-resident weights. Removing the per-forward upload also matters for CUDA-graph capture (a synchronous HtoD inside a stream capture aborts with CUDA 906).

Also bundled (allocator robustness on top of #609's stream-ordered allocator): the `float[]` weight-upload path and weight-buffer frees go through the async pool; the pool is trimmed on an async-path OOM; and a `DropActivationCache` (drop-without-download) for forward-only/inference passes.

## Verification

A d768/L6 token-LM (GPT-2-small scale) that OOM'd in the forward-only eval phase under GPU-resident params (`free=0`) now **trains fused AND completes eval** — no OOM, live GPU memory bounded, held-out metrics reported. Full Tensors suite unaffected (the same pre-existing 18 perf/OpenCL/float-tolerance failures as on the base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)