### PR TITLE
Make LayerNorm graph-capturable + GpuMemoryTracker capture-trace (stacked on #610)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -552,7 +552,11 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                         RefreshGraphInputInPlace(cb);
                         RunGpuStepBodyForCapture(cb);
                         if (_graphHasEmbedding) gte.EmbeddingIndexExternallyManaged = true;
-                        exec = cb.CaptureGraph(() => RunGpuStepBodyForCapture(cb));
+                        // Trace every device allocation that fires INSIDE the capture (AIDOTNET_GPU_CAPTURE_TRACE=1):
+                        // those are the graph-purity violations that abort/spoil whole-step capture and keep the
+                        // cortex on the launch-bound eager path. The scope dumps the offending call sites on exit.
+                        using (AiDotNet.Tensors.Engines.DirectGpu.GpuMemoryTracker.BeginCapture("StepGraphCapture"))
+                            exec = cb.CaptureGraph(() => RunGpuStepBodyForCapture(cb));
                     }
                     catch
                     {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/GpuMemoryTracker.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/GpuMemoryTracker.cs
@@ -51,6 +51,18 @@ public static class GpuMemoryTracker
     private static long s_totalAllocs;
     private static long s_totalFrees;
 
+    // Capture-trace: log every device allocation that fires INSIDE a CUDA-graph capture window. Such an
+    // allocation is a graph-purity violation — it either aborts capture (CUDA 906 STREAM_CAPTURE_UNSUPPORTED)
+    // or pins device pointers the replay can't honour — so listing the offending ops (by call site) is exactly
+    // what's needed to make a training step graph-capturable. Opt-in via AIDOTNET_GPU_CAPTURE_TRACE=1 and
+    // independent of the full tracker (Enabled): the capture window is one step, so the per-alloc stack capture
+    // here is bounded even with the heavyweight tracker off.
+    public static readonly bool CaptureTrace =
+        Environment.GetEnvironmentVariable("AIDOTNET_GPU_CAPTURE_TRACE") == "1";
+    private static int s_capturing;
+    private static readonly System.Collections.Generic.List<string> s_captureAllocs = new();
+    private static readonly object s_captureLock = new();
+
     /// <summary>Bytes currently allocated on the device and not yet freed (sum over the live set).</summary>
     public static long LiveBytes => Interlocked.Read(ref s_liveBytes);
 
@@ -60,10 +72,52 @@ public static class GpuMemoryTracker
     /// <summary>Number of live (un-freed) device allocations.</summary>
     public static int LiveCount => s_live.Count;
 
+    /// <summary>
+    /// Begins a CUDA-graph capture window: every <see cref="OnAlloc"/> until the returned scope is disposed is
+    /// recorded as a capture-time allocation (a graph-purity violation). On dispose the collected list is
+    /// appended to the capture-trace file. No-op unless <see cref="CaptureTrace"/>. Re-entrant-safe.
+    /// </summary>
+    public static IDisposable BeginCapture(string label)
+    {
+        if (!CaptureTrace) return NoopScope.Instance;
+        Interlocked.Increment(ref s_capturing);
+        return new CaptureScope(label);
+    }
+
+    private sealed class NoopScope : IDisposable { public static readonly NoopScope Instance = new(); public void Dispose() { } }
+
+    private sealed class CaptureScope : IDisposable
+    {
+        private readonly string _label;
+        public CaptureScope(string label) => _label = label;
+        public void Dispose()
+        {
+            Interlocked.Decrement(ref s_capturing);
+            string[] snapshot;
+            lock (s_captureLock) { snapshot = s_captureAllocs.ToArray(); s_captureAllocs.Clear(); }
+            try
+            {
+                string path = Environment.GetEnvironmentVariable("AIDOTNET_GPU_MEMTRACK_FILE")
+                              ?? System.IO.Path.Combine(System.IO.Path.GetTempPath(), "aidotnet_capture_allocs.txt");
+                var sb = new StringBuilder();
+                sb.AppendLine($"==== capture window [{_label}] — {snapshot.Length} device alloc(s) DURING capture (graph-purity violations) ====");
+                foreach (var s in snapshot) sb.AppendLine("  " + s);
+                System.IO.File.AppendAllText(path, sb.ToString());
+            }
+            catch { /* diagnostics must never destabilize the caller */ }
+        }
+    }
+
     /// <summary>Records a device allocation. Call right after a successful <c>cuMemAlloc</c>/<c>cuMemAllocAsync</c>.</summary>
     public static void OnAlloc(IntPtr ptr, long bytes)
     {
-        if (!Enabled || ptr == IntPtr.Zero || bytes <= 0) return;
+        if (ptr == IntPtr.Zero || bytes <= 0) return;
+        if (CaptureTrace && Volatile.Read(ref s_capturing) > 0)
+        {
+            string site = CaptureSite();
+            lock (s_captureLock) s_captureAllocs.Add($"{bytes / 1024.0,10:F1} KB  {site}");
+        }
+        if (!Enabled) return;
         var rec = new Rec { Bytes = bytes, Site = CaptureSite(), Seq = Interlocked.Increment(ref s_seq) };
         s_live[(long)ptr] = rec;
         Interlocked.Increment(ref s_totalAllocs);

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -2863,8 +2863,13 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             int normSize = gamma.Length > 0 ? gamma.Length : input.Shape._dims[input.Rank - 1];
             int outerSize = input.Length / normSize;
             using var bufIn = GetOrAllocateContiguousInputBuffer(backend, input);
-            using var bufGamma = GetOrCacheWeightBuffer(backend, gamma.GetDataArray(), PersistentTensorRole.Weights);
-            using var bufBeta = GetOrCacheWeightBuffer(backend, beta.GetDataArray(), PersistentTensorRole.Biases);
+            // Prefer the resident GPU buffer for gamma/beta. GetOrCacheWeightBuffer keys its cache on the host
+            // array identity, but a resident weight's GetDataArray() returns a FRESH host copy each forward → a
+            // guaranteed cache miss → a device alloc on every call. Inside CUDA-graph capture that alloc is a
+            // graph-purity violation (the GpuMemoryTracker capture-trace pinpointed this exact site), and outside
+            // capture it's a per-step leak. GetWeightBufferPreferResident reuses the already-resident buffer.
+            using var bufGamma = GetWeightBufferPreferResident(backend, gamma, PersistentTensorRole.Weights);
+            using var bufBeta = GetWeightBufferPreferResident(backend, beta, PersistentTensorRole.Biases);
             var outBuf = GetOrCreateResidentBuffer(backend, output, input.Length);
             if (!_lnStatsScratch.TryGetValue(arr, out var stats))
             {


### PR DESCRIPTION
**Draft — validation in progress** (big-cortex d768/L6 GRAPH_STEP=1 run confirming zero capture-time allocs is running locally; will mark ready once green).

Stacked on #610 (`feat/gpu-mem-tracker-and-resident-weights`).

## Problem
The fused/compiled CUDA-graph step (`AIDOTNET_CUDA_GRAPH_STEP=1`) silently falls back to eager on the big transformer (~7–10% GPU util). A device allocation fires **during graph capture** → graph-purity violation (CUDA 906 `STREAM_CAPTURE_UNSUPPORTED`, surfaces as sticky 700) → capture abandoned.

## What this does
1. **Capture-trace diagnostic** (extends the #610 `GpuMemoryTracker`). `AIDOTNET_GPU_CAPTURE_TRACE=1` + `GpuMemoryTracker.BeginCapture(label)` records every device alloc inside a capture window and dumps the offending call sites; `CompiledTrainingPlan` wraps `cb.CaptureGraph` in that scope. Independent of the heavyweight tracker (the window is one step). It pinpointed the violator in a single run:
   ```
   3.0 KB  AllocDeviceMemoryAsync < AllocateBuffer < GetOrCacheWeightBuffer
           < TryLayerNormResidentInto < LayerNorm < RunGpuStepBodyForCapture
   ```
2. **The fix it found.** `TryLayerNormResidentInto` fetched gamma/beta via `GetOrCacheWeightBuffer(weight.GetDataArray(), …)`. For a GPU-resident weight, `GetDataArray()` returns a *fresh host copy* each forward, so the host-array-keyed cache always misses and allocates a new device buffer every call. Routing gamma/beta through `GetWeightBufferPreferResident` (the same helper #610 introduced for FusedLinear weights) reuses the resident buffer → no alloc during capture (graph-pure) and no per-step weight-buffer leak outside capture.

## Validation
- [ ] Big cortex d768/L6 `GRAPH_STEP=1` → capture-trace reports **0** capture-time allocs (was exactly 1: the LayerNorm gamma).
- [ ] `[FUSED-DIAG] eagerFallback=False`, no CUDA-700, run completes.
- [ ] Full Tensors test suite green.
- [ ] Cortex held-out top-1 unchanged (correctness gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)