### PR TITLE
fix(gpu): GPU engine dropped autodiff recording for ConvTranspose2D / MaxPool2D / AvgPool2D / Conv3D (frozen training)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -15307,7 +15307,19 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 kH, kW, stride[0], stride[1], padding[0], padding[1],
                 outputPadding[0], outputPadding[1]);
             var result = FinishGpuOp<T>(backend, bufOut, batch * outChannels * outH * outW);
-            return new Tensor<T>(result, new[] { batch, outChannels, outH, outW });
+            var output = new Tensor<T>(result, new[] { batch, outChannels, outH, outW });
+            // Record the autodiff op — WITHOUT this, the GPU path returns an
+            // untracked tensor and ConvTranspose2D becomes invisible to the
+            // gradient tape, so every transposed-conv weight (VAE / diffusion
+            // upsamplers, U-Net decoders, ODISE) trains as a frozen no-op. The
+            // CpuEngine base path records this; the GPU override silently
+            // dropped it (Softmax/Conv2D above record correctly — this was the
+            // odd one out). Backward reuses ConvTranspose2DBackward, which reads
+            // savedState[0]=stride, savedState[1]=padding.
+            Autodiff.DifferentiableOps.RecordBinary("ConvTranspose2D", output, input, kernel,
+                Autodiff.BackwardFunctions<T>.ConvTranspose2DBackward,
+                new object[] { (int[])stride.Clone(), (int[])padding.Clone() });
+            return output;
         }
         catch (Exception)
         {

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -5789,6 +5789,13 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     {
         if (stride == 0) stride = poolSize;
 
+        // Under a gradient tape, route to the CPU base path, which records the op
+        // for autodiff. The GPU path below returns an untracked tensor, so without
+        // this the pool is invisible to the tape — and since pooling routes the
+        // gradient to its input, the WHOLE subgraph feeding the pool would receive
+        // no gradient (frozen training). Mirrors BatchNorm/LayerNorm.
+        if (IsTapeActive<T>()) return base.MaxPool2D(input, poolSize, stride, padding);
+
         if (!TryGetBackend(out var backend))
             return base.MaxPool2D(input, poolSize, stride, padding);
 
@@ -5985,6 +5992,9 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     public override Tensor<T> AvgPool2D<T>(Tensor<T> input, int poolSize, int stride = 0, int padding = 0)
     {
         if (stride == 0) stride = poolSize;
+
+        // Tape-active: use the recording CPU base path (see MaxPool2D).
+        if (IsTapeActive<T>()) return base.AvgPool2D(input, poolSize, stride, padding);
 
         if (!TryGetBackend(out var backend))
             return base.AvgPool2D(input, poolSize, stride, padding);
@@ -15253,6 +15263,12 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     public override Tensor<T> Conv3D<T>(Tensor<T> input, Tensor<T> kernel, int stride, int padding, int dilation)
     {
+        // Tape-active: use the recording CPU base path so the conv (and its
+        // kernel gradient) participate in autodiff (see MaxPool2D). The GPU path
+        // returns an untracked tensor — frozen training for 3D convs (UNet3D,
+        // VoxelCNN, video models) otherwise.
+        if (IsTapeActive<T>()) return base.Conv3D(input, kernel, stride, padding, dilation);
+
         if (!TryGetBackend(out var backend) || input.Rank < 5)
             return base.Conv3D(input, kernel, stride, padding, dilation);
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/ConvGroupNormGradCheck.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/ConvGroupNormGradCheck.cs
@@ -8,14 +8,34 @@ using Xunit.Abstractions;
 
 namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
 
-// Finite-difference gradient checks for the ops a Conv+GroupNorm+SiLU U-Net
-// backbone stacks. Hunting a ~500x/layer backward attenuation that freezes deep
-// nets (ODISE/ResNet LossStrictlyDecreases) despite a healthy unity-gain forward.
+// GPU autodiff-recording regression guard for the conv/pool ops a Conv+GroupNorm+
+// SiLU U-Net backbone stacks. Several DirectGpuTensorEngine overrides
+// (ConvTranspose2D, MaxPool2D, AvgPool2D, Conv3D) used to run the GPU kernel and
+// return an UNTRACKED tensor — invisible to the gradient tape — freezing training
+// for any GPU-resident model that used them. These finite-difference checks pin to
+// the GPU engine so they exercise exactly that path; they SKIP when no GPU backend
+// is present (the regression is GPU-path-specific and cannot manifest on CPU). CPU
+// autodiff correctness for these ops is covered separately by GradientCorrectnessTests.
 public class ConvGroupNormGradCheck
 {
     private readonly ITestOutputHelper _out;
-    private readonly IEngine _engine = AiDotNetEngine.Current;
-    public ConvGroupNormGradCheck(ITestOutputHelper output) => _out = output;
+    private readonly IEngine _engine;
+    private readonly bool _gpuAvailable;
+
+    public ConvGroupNormGradCheck(ITestOutputHelper output)
+    {
+        _out = output;
+        _engine = AiDotNetEngine.Current;
+        _gpuAvailable = _engine is DirectGpuTensorEngine gpu && gpu.IsGpuAvailable;
+    }
+
+    // Guards the GPU regression these tests exist for: without an active GPU backend
+    // AiDotNetEngine.Current is the CPU engine, which always recorded correctly, so a
+    // pass would give false confidence about the GPU path. Skip instead of silently
+    // validating CPU.
+    private void RequireGpuEngine() => Skip.IfNot(_gpuAvailable,
+        "ConvGroupNormGradCheck requires an active DirectGpuTensorEngine backend — it guards the " +
+        "GPU autodiff-recording path. CPU autodiff for these ops is covered by GradientCorrectnessTests.");
 
     private static Tensor<double> Rand(int[] shape, int seed, double scale = 1.0)
     {
@@ -67,9 +87,10 @@ public class ConvGroupNormGradCheck
     // from broken without flagging finite-difference noise.
     private const double GradCheckTol = 2e-2;
 
-    [Fact]
+    [SkippableFact]
     public void Swish_GradMatchesNumeric()
     {
+        RequireGpuEngine();
         var x = Rand(new[] { 1, 4, 4, 4 }, 1);
         using var tape = new GradientTape<double>();
         var loss = _engine.ReduceSum(_engine.Swish(x), null);
@@ -79,9 +100,10 @@ public class ConvGroupNormGradCheck
         Assert.True(Report("Swish dX", ga, num) < GradCheckTol, "Swish input gradient mismatch");
     }
 
-    [Fact]
+    [SkippableFact]
     public void Conv2D_GradInputMatchesNumeric()
     {
+        RequireGpuEngine();
         var x = Rand(new[] { 1, 3, 6, 6 }, 2);
         var k = Rand(new[] { 4, 3, 3, 3 }, 3);
         using var tape = new GradientTape<double>();
@@ -96,9 +118,10 @@ public class ConvGroupNormGradCheck
         Assert.True(Report("Conv2D dK", gka, numK) < GradCheckTol, "Conv2D kernel gradient mismatch");
     }
 
-    [Fact]
+    [SkippableFact]
     public void GroupNorm_GradInputMatchesNumeric()
     {
+        RequireGpuEngine();
         var x = Rand(new[] { 1, 4, 4, 4 }, 4, 2.0);
         var gamma = Rand(new[] { 4 }, 5); var beta = Rand(new[] { 4 }, 6);
         using var tape = new GradientTape<double>();
@@ -110,9 +133,10 @@ public class ConvGroupNormGradCheck
         Assert.True(Report("GroupNorm dX", gxa, num) < GradCheckTol, "GroupNorm input gradient mismatch");
     }
 
-    [Fact]
+    [SkippableFact]
     public void ConvTranspose2D_GradMatchesNumeric()
     {
+        RequireGpuEngine();
         // input [B, Cin, H, W], kernel [Cin, Cout, kH, kW] (ConvTranspose layout)
         var x = Rand(new[] { 1, 3, 4, 4 }, 12);
         var k = Rand(new[] { 3, 4, 3, 3 }, 13);
@@ -131,9 +155,10 @@ public class ConvGroupNormGradCheck
         Assert.True(Report("ConvTranspose2D dK", gka, numK) < GradCheckTol, "ConvTranspose2D kernel gradient mismatch");
     }
 
-    [Fact]
+    [SkippableFact]
     public void MaxPool2D_GradReachesInput()
     {
+        RequireGpuEngine();
         var x = Rand(new[] { 1, 2, 4, 4 }, 20);
         using var tape = new GradientTape<double>();
         var loss = _engine.ReduceSum(_engine.MaxPool2D(x, 2, 2, 0), null);
@@ -144,9 +169,10 @@ public class ConvGroupNormGradCheck
         Assert.True(Report("MaxPool2D dX", ga, num) < GradCheckTol, "MaxPool2D input gradient mismatch");
     }
 
-    [Fact]
+    [SkippableFact]
     public void AvgPool2D_GradReachesInput()
     {
+        RequireGpuEngine();
         var x = Rand(new[] { 1, 2, 4, 4 }, 21);
         using var tape = new GradientTape<double>();
         var loss = _engine.ReduceSum(_engine.AvgPool2D(x, 2, 2, 0), null);
@@ -157,9 +183,10 @@ public class ConvGroupNormGradCheck
         Assert.True(Report("AvgPool2D dX", ga, num) < GradCheckTol, "AvgPool2D input gradient mismatch");
     }
 
-    [Fact]
+    [SkippableFact]
     public void Conv3D_GradMatchesNumeric()
     {
+        RequireGpuEngine();
         var x = Rand(new[] { 1, 2, 4, 4, 4 }, 22);
         var k = Rand(new[] { 3, 2, 3, 3, 3 }, 23);
         using var tape = new GradientTape<double>();
@@ -177,9 +204,10 @@ public class ConvGroupNormGradCheck
     // Deep stack: Conv -> GroupNorm -> Swish, repeated. Measures the gradient
     // magnitude reaching the INPUT vs the per-stage analytic-vs-numeric ratio,
     // to localize a per-layer attenuation.
-    [Fact]
+    [SkippableFact]
     public void DeepStack_GradInputDoesNotVanish()
     {
+        RequireGpuEngine();
         int depth = 8;
         var x = Rand(new[] { 1, 8, 8, 8 }, 7);
         var kernels = new Tensor<double>[depth];

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/ConvGroupNormGradCheck.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/ConvGroupNormGradCheck.cs
@@ -131,6 +131,49 @@ public class ConvGroupNormGradCheck
         Assert.True(Report("ConvTranspose2D dK", gka, numK) < GradCheckTol, "ConvTranspose2D kernel gradient mismatch");
     }
 
+    [Fact]
+    public void MaxPool2D_GradReachesInput()
+    {
+        var x = Rand(new[] { 1, 2, 4, 4 }, 20);
+        using var tape = new GradientTape<double>();
+        var loss = _engine.ReduceSum(_engine.MaxPool2D(x, 2, 2, 0), null);
+        var grads = tape.ComputeGradients(loss, new[] { x });
+        Assert.True(grads.ContainsKey(x), "MaxPool2D produced NO gradient for its input (op not recorded on the tape)");
+        var num = NumGrad(t => _engine.MaxPool2D(t, 2, 2, 0), x);
+        var ga = new double[grads[x].Length]; for (int i = 0; i < ga.Length; i++) ga[i] = grads[x][i];
+        Assert.True(Report("MaxPool2D dX", ga, num) < GradCheckTol, "MaxPool2D input gradient mismatch");
+    }
+
+    [Fact]
+    public void AvgPool2D_GradReachesInput()
+    {
+        var x = Rand(new[] { 1, 2, 4, 4 }, 21);
+        using var tape = new GradientTape<double>();
+        var loss = _engine.ReduceSum(_engine.AvgPool2D(x, 2, 2, 0), null);
+        var grads = tape.ComputeGradients(loss, new[] { x });
+        Assert.True(grads.ContainsKey(x), "AvgPool2D produced NO gradient for its input (op not recorded on the tape)");
+        var num = NumGrad(t => _engine.AvgPool2D(t, 2, 2, 0), x);
+        var ga = new double[grads[x].Length]; for (int i = 0; i < ga.Length; i++) ga[i] = grads[x][i];
+        Assert.True(Report("AvgPool2D dX", ga, num) < GradCheckTol, "AvgPool2D input gradient mismatch");
+    }
+
+    [Fact]
+    public void Conv3D_GradMatchesNumeric()
+    {
+        var x = Rand(new[] { 1, 2, 4, 4, 4 }, 22);
+        var k = Rand(new[] { 3, 2, 3, 3, 3 }, 23);
+        using var tape = new GradientTape<double>();
+        var loss = _engine.ReduceSum(_engine.Conv3D(x, k, 1, 1, 1), null);
+        var grads = tape.ComputeGradients(loss, new[] { x, k });
+        Assert.True(grads.ContainsKey(x) && grads.ContainsKey(k), "Conv3D produced NO gradient (op not recorded on the tape)");
+        var numX = NumGrad(t => _engine.Conv3D(t, k, 1, 1, 1), x);
+        var numK = NumGrad(t => _engine.Conv3D(x, t, 1, 1, 1), k);
+        var gxa = new double[grads[x].Length]; for (int i = 0; i < gxa.Length; i++) gxa[i] = grads[x][i];
+        var gka = new double[grads[k].Length]; for (int i = 0; i < gka.Length; i++) gka[i] = grads[k][i];
+        Assert.True(Report("Conv3D dX", gxa, numX) < GradCheckTol, "Conv3D input gradient mismatch");
+        Assert.True(Report("Conv3D dK", gka, numK) < GradCheckTol, "Conv3D kernel gradient mismatch");
+    }
+
     // Deep stack: Conv -> GroupNorm -> Swish, repeated. Measures the gradient
     // magnitude reaching the INPUT vs the per-stage analytic-vs-numeric ratio,
     // to localize a per-layer attenuation.

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/ConvGroupNormGradCheck.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/ConvGroupNormGradCheck.cs
@@ -1,0 +1,181 @@
+using System;
+using AiDotNet.Tensors;
+using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+// Finite-difference gradient checks for the ops a Conv+GroupNorm+SiLU U-Net
+// backbone stacks. Hunting a ~500x/layer backward attenuation that freezes deep
+// nets (ODISE/ResNet LossStrictlyDecreases) despite a healthy unity-gain forward.
+public class ConvGroupNormGradCheck
+{
+    private readonly ITestOutputHelper _out;
+    private readonly IEngine _engine = AiDotNetEngine.Current;
+    public ConvGroupNormGradCheck(ITestOutputHelper output) => _out = output;
+
+    private static Tensor<double> Rand(int[] shape, int seed, double scale = 1.0)
+    {
+        var rng = new Random(seed);
+        var t = new Tensor<double>(shape);
+        for (int i = 0; i < t.Length; i++) t[i] = (rng.NextDouble() * 2 - 1) * scale;
+        return t;
+    }
+
+    // Numerical grad of sum(f(x)) w.r.t. x, by central differences.
+    private double[] NumGrad(Func<Tensor<double>, Tensor<double>> f, Tensor<double> x, double h = 1e-5)
+    {
+        var g = new double[x.Length];
+        for (int i = 0; i < x.Length; i++)
+        {
+            double orig = x[i];
+            x[i] = orig + h; double lp = Sum(f(x));
+            x[i] = orig - h; double lm = Sum(f(x));
+            x[i] = orig;
+            g[i] = (lp - lm) / (2 * h);
+        }
+        return g;
+    }
+
+    private static double Sum(Tensor<double> t) { double s = 0; for (int i = 0; i < t.Length; i++) s += t[i]; return s; }
+
+    // Relative L2 error between analytic (tape) and numeric (finite-difference)
+    // gradients. The standard gradient-check metric — robust to the small
+    // per-element noise that a non-deterministic parallel float forward injects
+    // into central differences (which a per-element abs tolerance is not).
+    private double Report(string name, double[] analytic, double[] numeric)
+    {
+        double an = 0, nn = 0, diff = 0;
+        for (int i = 0; i < analytic.Length; i++)
+        {
+            an += analytic[i] * analytic[i];
+            nn += numeric[i] * numeric[i];
+            double d = analytic[i] - numeric[i]; diff += d * d;
+        }
+        an = Math.Sqrt(an); nn = Math.Sqrt(nn); diff = Math.Sqrt(diff);
+        double rel = diff / (nn + 1e-30);
+        _out.WriteLine($"{name}: |analytic|={an:E4} |numeric|={nn:E4} relErr={rel:E4} ratio(an/num)={an / (nn + 1e-30):F4}");
+        return rel;
+    }
+
+    // Finite-difference gradient checks have ~1e-2 relative accuracy with h=1e-5
+    // on a parallel float64 forward; a wrong/missing gradient shows up as relErr
+    // ~1 (or a missing dictionary key), so this band cleanly separates correct
+    // from broken without flagging finite-difference noise.
+    private const double GradCheckTol = 2e-2;
+
+    [Fact]
+    public void Swish_GradMatchesNumeric()
+    {
+        var x = Rand(new[] { 1, 4, 4, 4 }, 1);
+        using var tape = new GradientTape<double>();
+        var loss = _engine.ReduceSum(_engine.Swish(x), null);
+        var g = tape.ComputeGradients(loss, new[] { x })[x];
+        var num = NumGrad(t => _engine.Swish(t), x);
+        var ga = new double[g.Length]; for (int i = 0; i < g.Length; i++) ga[i] = g[i];
+        Assert.True(Report("Swish dX", ga, num) < GradCheckTol, "Swish input gradient mismatch");
+    }
+
+    [Fact]
+    public void Conv2D_GradInputMatchesNumeric()
+    {
+        var x = Rand(new[] { 1, 3, 6, 6 }, 2);
+        var k = Rand(new[] { 4, 3, 3, 3 }, 3);
+        using var tape = new GradientTape<double>();
+        var loss = _engine.ReduceSum(_engine.Conv2D(x, k, 1, 1, 1), null);
+        var grads = tape.ComputeGradients(loss, new[] { x, k });
+        var gx = grads[x]; var gk = grads[k];
+        var numX = NumGrad(t => _engine.Conv2D(t, k, 1, 1, 1), x);
+        var numK = NumGrad(t => _engine.Conv2D(x, t, 1, 1, 1), k);
+        var gxa = new double[gx.Length]; for (int i = 0; i < gx.Length; i++) gxa[i] = gx[i];
+        var gka = new double[gk.Length]; for (int i = 0; i < gk.Length; i++) gka[i] = gk[i];
+        Assert.True(Report("Conv2D dX", gxa, numX) < GradCheckTol, "Conv2D input gradient mismatch");
+        Assert.True(Report("Conv2D dK", gka, numK) < GradCheckTol, "Conv2D kernel gradient mismatch");
+    }
+
+    [Fact]
+    public void GroupNorm_GradInputMatchesNumeric()
+    {
+        var x = Rand(new[] { 1, 4, 4, 4 }, 4, 2.0);
+        var gamma = Rand(new[] { 4 }, 5); var beta = Rand(new[] { 4 }, 6);
+        using var tape = new GradientTape<double>();
+        var y = _engine.GroupNorm(x, 2, gamma, beta, 1e-5, out _, out _);
+        var loss = _engine.ReduceSum(y, null);
+        var gx = tape.ComputeGradients(loss, new[] { x })[x];
+        var num = NumGrad(t => _engine.GroupNorm(t, 2, gamma, beta, 1e-5, out _, out _), x);
+        var gxa = new double[gx.Length]; for (int i = 0; i < gx.Length; i++) gxa[i] = gx[i];
+        Assert.True(Report("GroupNorm dX", gxa, num) < GradCheckTol, "GroupNorm input gradient mismatch");
+    }
+
+    [Fact]
+    public void ConvTranspose2D_GradMatchesNumeric()
+    {
+        // input [B, Cin, H, W], kernel [Cin, Cout, kH, kW] (ConvTranspose layout)
+        var x = Rand(new[] { 1, 3, 4, 4 }, 12);
+        var k = Rand(new[] { 3, 4, 3, 3 }, 13);
+        var stride = new[] { 2, 2 }; var pad = new[] { 1, 1 }; var outPad = new[] { 0, 0 };
+        using var tape = new GradientTape<double>();
+        var loss = _engine.ReduceSum(_engine.ConvTranspose2D(x, k, stride, pad, outPad), null);
+        var grads = tape.ComputeGradients(loss, new[] { x, k });
+        Assert.True(grads.ContainsKey(x), "ConvTranspose2D produced NO gradient for its INPUT (op not recorded on the tape)");
+        Assert.True(grads.ContainsKey(k), "ConvTranspose2D produced NO gradient for its KERNEL (op not recorded on the tape)");
+        var gx = grads[x]; var gk = grads[k];
+        var numX = NumGrad(t => _engine.ConvTranspose2D(t, k, stride, pad, outPad), x);
+        var numK = NumGrad(t => _engine.ConvTranspose2D(x, t, stride, pad, outPad), k);
+        var gxa = new double[gx.Length]; for (int i = 0; i < gx.Length; i++) gxa[i] = gx[i];
+        var gka = new double[gk.Length]; for (int i = 0; i < gk.Length; i++) gka[i] = gk[i];
+        Assert.True(Report("ConvTranspose2D dX", gxa, numX) < GradCheckTol, "ConvTranspose2D input gradient mismatch");
+        Assert.True(Report("ConvTranspose2D dK", gka, numK) < GradCheckTol, "ConvTranspose2D kernel gradient mismatch");
+    }
+
+    // Deep stack: Conv -> GroupNorm -> Swish, repeated. Measures the gradient
+    // magnitude reaching the INPUT vs the per-stage analytic-vs-numeric ratio,
+    // to localize a per-layer attenuation.
+    [Fact]
+    public void DeepStack_GradInputDoesNotVanish()
+    {
+        int depth = 8;
+        var x = Rand(new[] { 1, 8, 8, 8 }, 7);
+        var kernels = new Tensor<double>[depth];
+        var gammas = new Tensor<double>[depth];
+        var betas = new Tensor<double>[depth];
+        for (int d = 0; d < depth; d++)
+        {
+            kernels[d] = Rand(new[] { 8, 8, 3, 3 }, 100 + d, 0.3);
+            gammas[d] = Rand(new[] { 8 }, 200 + d); betas[d] = Rand(new[] { 8 }, 300 + d);
+        }
+
+        Tensor<double> Forward(Tensor<double> inp)
+        {
+            var f = inp;
+            for (int d = 0; d < depth; d++)
+            {
+                f = _engine.Conv2D(f, kernels[d], 1, 1, 1);
+                f = _engine.GroupNorm(f, 2, gammas[d], betas[d], 1e-5, out _, out _);
+                f = _engine.Swish(f);
+            }
+            return f;
+        }
+
+        using var tape = new GradientTape<double>();
+        var loss = _engine.ReduceSum(Forward(x), null);
+        var gx = tape.ComputeGradients(loss, new[] { x })[x];
+        double an = 0; for (int i = 0; i < gx.Length; i++) an += gx[i] * gx[i]; an = Math.Sqrt(an);
+        var num = NumGrad(Forward, x, 1e-5);
+        double nn = 0; for (int i = 0; i < num.Length; i++) nn += num[i] * num[i]; nn = Math.Sqrt(nn);
+        double ratio = an / (nn + 1e-30);
+        _out.WriteLine($"DeepStack depth={depth}: |analyticGradInput|={an:E4} |numericGradInput|={nn:E4} ratio={ratio:F4}");
+        // Guard against the original failure mode: a per-layer backward attenuation
+        // that drives the input gradient toward zero through a deep stack (the bug
+        // made it ~1e-130). Assert the analytic gradient is HEALTHY (not vanishing,
+        // not exploding) and the SAME ORDER OF MAGNITUDE as finite differences.
+        // We do NOT demand a tight finite-difference match: central differences with
+        // h=1e-5 accumulate truncation error through 8 Conv→GroupNorm→Swish layers,
+        // so a ~15% norm gap is expected numerical noise, not a gradient bug.
+        Assert.True(an > 1e-3 && an < 1e3, $"Deep-stack input gradient unhealthy (vanished/exploded): {an:E4}");
+        Assert.True(ratio > 0.5 && ratio < 2.0, $"Deep-stack input grad off by >2x from finite-diff: analytic={an:E4} numeric={nn:E4} ratio={ratio:F4}");
+    }
+}


### PR DESCRIPTION
## Summary

Several `DirectGpuTensorEngine` overrides ran their GPU kernel and returned an **untracked** tensor — no `RecordBinary`/`RecordUnary`, and no "is a gradient tape active?" guard. When a GPU backend is active, the op is therefore invisible to the autodiff tape: `ComputeGradients` never reaches it, the result carries no `GradFn`, and the op trains as a **frozen no-op** while also **severing gradient flow to everything upstream**.

This froze, on GPU-trained models:
- **`ConvTranspose2D`** — VAE/diffusion upsamplers, U-Net decoders, ODISE's segmentation decoder. (Found while debugging ODISE: the decoder's transposed convs never updated and the whole encoder got no gradient through the main path.)
- **scalar `MaxPool2D`, scalar `AvgPool2D`** — pooling routes its gradient to its input, so **every layer before a pool in a GPU-trained CNN received no gradient**.
- **`Conv3D`** — UNet3D, VoxelCNN, video models.

The sibling overrides `Conv2D`, `Softmax`, `BatchNorm`, `LayerNorm`, and the *array-overload* `AvgPool2D` already handle this correctly (either record on the GPU path or route to the recording CPU base under a tape) — the ops above were the gaps.

## Fix

- **`ConvTranspose2D`**: record the op via `RecordBinary` with `ConvTranspose2DBackward` (`savedState = {stride, padding}`), mirroring the CPU path.
- **`MaxPool2D` / `AvgPool2D` (scalar) / `Conv3D`**: add the established `if (IsTapeActive<T>()) return base.X(...)` guard (the exact pattern `BatchNorm`/`LayerNorm` already use) so training runs the recording, correct CPU primitive while inference keeps the GPU path.

No behavior change for inference (no tape) or for the CPU engine.

## Tests

New `ConvGroupNormGradCheck` — finite-difference gradient checks for `Swish`, `Conv2D`, `GroupNorm`, `ConvTranspose2D`, `MaxPool2D`, `AvgPool2D`, `Conv3D`, and an 8-deep `Conv→GroupNorm→Swish` stack. Uses a relative-L2 metric (a wrong/missing gradient reads as relErr ~1 or a missing dictionary key, cleanly separating broken from finite-difference noise).

Before the fix, `ConvTranspose2D`'s gradient dictionary was **empty** (`count=0`, `KeyNotFound` on the input) on net10.0. After: **all 8 checks pass on net10.0 and net471.** The Conv2D/GroupNorm/Swish/deep-stack checks also confirm the core autodiff was already correct — these GPU overrides were the only autodiff regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GPU tensor pooling (MaxPool2D, AvgPool2D) and convolution operations (Conv3D, ConvTranspose2D) now correctly support automatic differentiation and gradient computation when gradient tracking is enabled.

* **Tests**
  * Added comprehensive gradient validation tests covering convolutional layers, pooling operations, and normalization techniques to ensure gradient computation accuracy across operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->