### PR TITLE
Fix GPU engine new-hidden SupportsGpu/Name (graph-ineligible cortex, ~7% util) → virtual/override

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -2235,6 +2235,23 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         bool preferGenericForGpu = engine.SupportsGpu
             && Environment.GetEnvironmentVariable("AIDOTNET_GPU_PREFER_GENERIC") != "0";
 
+        // Diagnostic companion to GRAPHSTEP-DIAG (gated on AIDOTNET_CUDA_GRAPH_STEP=1): record the engine
+        // type + SupportsGpu + the resulting preferGenericForGpu at compile time. When a GPU plan is
+        // unexpectedly graph-ineligible this immediately distinguishes "engine isn't GPU / SupportsGpu
+        // false" from "ops aren't GPU-pure", which is otherwise invisible.
+        if (s_graphStepEnabled && typeof(T) == typeof(float))
+        {
+            try
+            {
+                System.IO.File.AppendAllText(
+                    System.IO.Path.Combine(System.IO.Path.GetTempPath(), "aidotnet_graphstep_diag.txt"),
+                    $"[GRAPHSTEP-ENGINE] type={engine.GetType().Name} SupportsGpu={engine.SupportsGpu} "
+                    + $"DirectGpu?={(engine.DirectGpu != null)} preferGenericForGpu={preferGenericForGpu}"
+                    + System.Environment.NewLine);
+            }
+            catch { /* diagnostic must never break the build */ }
+        }
+
         if (typeof(T) == typeof(float) && Optimization.TensorCodecOptions.Current.EnableDataflowFusion
             && !preferGenericForGpu)
         {

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -50,10 +50,10 @@ public partial class CpuEngine : ITensorLevelEngine
     private const int TensorMatMulGemvParallelThreshold = 128 * 1024;
 
     /// <inheritdoc/>
-    public string Name => "CPU Engine";
+    public virtual string Name => "CPU Engine";
 
     /// <inheritdoc/>
-    public bool SupportsGpu => false;
+    public virtual bool SupportsGpu => false;
 
     /// <inheritdoc/>
     public DirectGpu.DirectGpuEngine? DirectGpu => null;

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -419,11 +419,11 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     public bool IsGpuAvailable => _directGpu?.IsAvailable == true;
 
-    public new string Name => IsGpuAvailable
-        ? $"Direct GPU Engine ({_directGpu!.BackendName} {_directGpu.DeviceName})"
+    public override string Name => IsGpuAvailable
+        ? $"Direct GPU Engine ({_directGpu?.BackendName} {_directGpu?.DeviceName})"
         : "CPU Engine (DirectGpu unavailable)";
 
-    public new bool SupportsGpu => IsGpuAvailable;
+    public override bool SupportsGpu => IsGpuAvailable;
 
     /// <summary>
     /// Gets or sets the maximum number of activation cache entries.
@@ -437,10 +437,6 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     }
 
     DirectGpuEngine? IEngine.DirectGpu => _directGpu;
-
-    string IEngine.Name => Name;
-
-    bool IEngine.SupportsGpu => SupportsGpu;
 
     /// <summary>
     /// Begins a GPU scope that enables activation caching for intermediate results.


### PR DESCRIPTION
## Problem
`CpuEngine.SupportsGpu`/`Name` are non-virtual; `DirectGpuTensorEngine` **hid** them with `public new`. Any read through a `CpuEngine`/`IEngine`-typed reference bound to the base, so **`SupportsGpu` returned `false` even on a live GPU engine**.

`CompiledTrainingPlan.Compile` gates `preferGenericForGpu` on `engine.SupportsGpu`. Stuck-false → it installed host CPU-BLAS/SIMD specializations + dataflow fusion instead of generic GPU-stream ops and marked the step **CUDA-graph ineligible**. On the cortex: ~142 host-only ops (82 fwd + 60 bwd) ran on the CPU at ~7-15% util, no whole-step graph capture.

## Fix (minimal, util-critical)
`CpuEngine.SupportsGpu`/`Name` → `virtual`; derived → `override` (drop redundant `IEngine` forwarders; `!`→`?.`). Plus a one-line `[GRAPHSTEP-ENGINE]` compile diagnostic gated on `AIDOTNET_CUDA_GRAPH_STEP=1`.

## Result
`SupportsGpu=true` at compile, `preferGenericForGpu=true`, `GRAPHSTEP-DIAG` ineligible-op count **142 → 0**; step becomes CUDA-graph capturable, ~100% util peaks. `EveryGpuKernel_IsAutoTestedOrAllowlisted` passes.

## Scope note
The same `new`-hide exists on ~21 conv/pool/attention methods. Converting those surfaces that they are GPU kernels shipping **without** GPU-vs-CPU accuracy coverage (the kernel-coverage gate was blind to them while `new`-hidden — only `MaxPool2DBackward` has a dedicated test). Deferred to a follow-up that adds the coverage + fixes any buggy kernels, rather than allowlisting untested kernels here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)