### PR TITLE
feat(compile): multi-input compiled-inference plans (re-bind every per-call input)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledInferencePlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledInferencePlan.cs
@@ -956,12 +956,26 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
         LazyTensorScope scope, IEngine engine, Tensor<T>? explicitOutput, int[] requestedInputShape)
         => Compile(scope, engine, explicitOutput, explicitInput: null, requestedInputShape);
 
+    /// <summary>
+    /// Multi-input compile: every tensor in <paramref name="explicitInputs"/> is marked as
+    /// a mutable input slot that <c>SetInputs</c> re-binds on each <c>Execute</c>; all other
+    /// traced leaves (weights, true constants) stay frozen. This is what lets a forward with
+    /// more than one per-call-varying input — e.g. a diffusion denoiser reading both the noisy
+    /// sample AND a per-step timestep embedding — replay correctly instead of baking all but the
+    /// first input as constants. Each supplied tensor must be a traced leaf the graph reads
+    /// directly (see <see cref="ValidateExplicitInputsAreLeaves"/>).
+    /// </summary>
+    internal static CompiledInferencePlan<T> Compile(
+        LazyTensorScope scope, IEngine engine, Tensor<T>? explicitOutput, Tensor<T>[] explicitInputs)
+        => Compile(scope, engine, explicitOutput, explicitInput: null, requestedInputShape: null, explicitInputs);
+
     private static CompiledInferencePlan<T> Compile(
         LazyTensorScope scope,
         IEngine engine,
         Tensor<T>? explicitOutput,
         Tensor<T>? explicitInput,
-        int[]? requestedInputShape)
+        int[]? requestedInputShape,
+        Tensor<T>[]? explicitInputs = null)
     {
         var compiler = new LazyGraphCompiler();
         var optimized = compiler.Compile(scope.Nodes);
@@ -1000,12 +1014,33 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
         // shape and treat all other leaves as frozen constants. This fixes
         // #304's weights.MatrixMultiply(query) case where the first op input
         // is a frozen weight matrix, not the variable query.
-        var inputTensor = SelectCompiledInputTensor(steps, explicitInput, requestedInputShape);
-        var inputShape = requestedInputShape is not null
-            ? (int[])requestedInputShape.Clone()
-            : inputTensor is not null
-                ? (int[])inputTensor._shape.Clone()
+        Tensor<T>? inputTensor;
+        Tensor<T>[]? compiledInputTensors;
+        int[] inputShape;
+        if (explicitInputs is not null)
+        {
+            // Multi-input plan: every supplied tensor is a mutable input slot. Validate each
+            // is a traced leaf so a caller can never pass a tensor the graph doesn't read and
+            // silently get it baked (the exact failure this path exists to prevent). The first
+            // input is the primary shape used for IsValid()/cache identity, matching the
+            // single-input contract where the noisy-sample shape keys the plan.
+            ValidateExplicitInputsAreLeaves(steps, explicitInputs);
+            inputTensor = null;
+            compiledInputTensors = explicitInputs;
+            inputShape = explicitInputs.Length > 0
+                ? (int[])explicitInputs[0]._shape.Clone()
                 : Array.Empty<int>();
+        }
+        else
+        {
+            inputTensor = SelectCompiledInputTensor(steps, explicitInput, requestedInputShape);
+            compiledInputTensors = null;
+            inputShape = requestedInputShape is not null
+                ? (int[])requestedInputShape.Clone()
+                : inputTensor is not null
+                    ? (int[])inputTensor._shape.Clone()
+                    : Array.Empty<int>();
+        }
 
         // Run step-mutating optimization passes BEFORE specialization.
         // Specialization pins raw pointers into each input/output buffer
@@ -1136,7 +1171,35 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
                 ? optimizedSteps[optimizedSteps.Length - 1].OutputBuffer
                 : new Tensor<T>(new int[] { 0 });
         }
-        return new CompiledInferencePlan<T>(optimizedSteps, finalOutput, engine, inputShape, inputTensor, pinnedHandles);
+        return new CompiledInferencePlan<T>(
+            optimizedSteps, finalOutput, engine, inputShape, inputTensor, pinnedHandles,
+            compiledInputTensors: compiledInputTensors);
+    }
+
+    /// <summary>
+    /// Verifies every tensor the caller declared as a mutable input is actually a traced leaf
+    /// (a tensor the graph consumes but no step produces). A tensor that fails this check is one
+    /// the forward never reads directly — re-binding it via <c>SetInputs</c> would have no effect
+    /// and the value the graph actually uses would stay frozen at its trace-time content. Fail
+    /// closed with a clear message so the caller falls back to eager rather than replaying stale data.
+    /// </summary>
+    private static void ValidateExplicitInputsAreLeaves(List<CompiledStep<T>> steps, Tensor<T>[] explicitInputs)
+    {
+        var leaves = new HashSet<Tensor<T>>(ReferenceEqualityComparer<Tensor<T>>.Instance);
+        foreach (var leaf in EnumerateLeafInputs(steps))
+            leaves.Add(leaf);
+
+        for (int i = 0; i < explicitInputs.Length; i++)
+        {
+            var inp = explicitInputs[i]
+                ?? throw new ArgumentException($"explicitInputs[{i}] is null.", nameof(explicitInputs));
+            if (!leaves.Contains(inp))
+                throw new InvalidOperationException(
+                    $"explicitInputs[{i}] (shape [{string.Join(",", inp._shape)}]) is not a traced leaf of " +
+                    "the captured graph — the forward never reads it directly, so it cannot be a mutable " +
+                    "input slot. Pass the exact tensor object the graph consumes, with no reshape/clone " +
+                    "between capture and first use.");
+        }
     }
 
     private static Tensor<T>? SelectCompiledInputTensor(

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledModelCache.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledModelCache.cs
@@ -110,6 +110,58 @@ public sealed class CompiledModelCache<T> : IDisposable
     }
 
     /// <summary>
+    /// Multi-input variant: traces the forward once and marks EVERY tensor in
+    /// <paramref name="inputs"/> as a mutable input slot the plan re-binds on each replay.
+    /// On cache hit, every input's data is copied into the plan's captured buffers, so a forward
+    /// whose result depends on more than one per-call-varying tensor — e.g. a diffusion denoiser
+    /// reading both the noisy sample AND a per-step timestep embedding — replays correctly instead
+    /// of baking all-but-the-first input as constants. Each input must be a traced leaf the forward
+    /// reads directly; otherwise compilation throws and the caller should fall back to eager.
+    /// </summary>
+    /// <param name="inputs">
+    /// The mutable input tensors, in a stable order. Their data is copied into the plan on cache
+    /// hit; the combined shape sequence keys the plan so distinct secondary shapes don't collide.
+    /// </param>
+    /// <param name="forward">The forward pass to trace (called once on cache miss).</param>
+    public ICompiledPlan<T> GetOrCompileInference(Tensor<T>[] inputs, Func<Tensor<T>> forward)
+    {
+        if (inputs is null) throw new ArgumentNullException(nameof(inputs));
+        if (inputs.Length == 0)
+            throw new ArgumentException("At least one input is required.", nameof(inputs));
+
+        long key = ComputeShapeKey(inputs);
+        var primaryShape = inputs[0]._shape;
+        if (_inferencePlans.TryGetValue(key, out var cached) && cached.IsValid(primaryShape))
+        {
+            cached.SetInputs(inputs);
+            return cached;
+        }
+
+        lock (_compileLock)
+        {
+            if (_inferencePlans.TryGetValue(key, out cached) && cached.IsValid(primaryShape))
+            {
+                cached.SetInputs(inputs);
+                return cached;
+            }
+
+            // The trace runs the forward against the CURRENT input data, so the freshly
+            // compiled plan already reflects this call — no SetInputs needed on the miss path
+            // (mirrors the single-input Tensor<T> overload above).
+            using var scope = GraphMode.Enable();
+            var explicitOutput = forward();
+            ThrowIfForwardRecordedNothing(scope, explicitOutput);
+            var plan = scope.CompileInference<T>(explicitOutput, inputs);
+
+            if (_inferencePlans.TryGetValue(key, out var old))
+                old.Dispose();
+
+            _inferencePlans[key] = plan;
+            return plan;
+        }
+    }
+
+    /// <summary>
     /// Gets a cached training plan for the given input shape, or compiles a new one.
     /// The forward + loss computation is traced once and compiled with backward pass.
     /// </summary>
@@ -273,6 +325,32 @@ public sealed class CompiledModelCache<T> : IDisposable
         // regardless. When a future backend reintroduces a divergent path, the
         // correct fix is per-plan instruction selection, not cache-key segregation.
 
+        return hash;
+    }
+
+    /// <summary>
+    /// Combined key over an ordered set of input shapes for multi-input plans. Folds each
+    /// input's shape into one FNV-1a hash with a per-tensor separator so that, e.g.,
+    /// ([2,3],[4]) and ([2],[3,4]) map to different keys and a plan compiled for one set of
+    /// secondary shapes is never replayed for another.
+    /// </summary>
+    private static long ComputeShapeKey(Tensor<T>[] inputs)
+    {
+        long hash = unchecked((long)0xcbf29ce484222325L);
+        hash ^= typeof(T).GetHashCode();
+        hash *= unchecked((long)0x100000001b3L);
+        for (int t = 0; t < inputs.Length; t++)
+        {
+            // Per-tensor separator so shape boundaries are significant.
+            hash ^= unchecked((long)0x9E3779B97F4A7C15L);
+            hash *= unchecked((long)0x100000001b3L);
+            var shape = inputs[t]._shape;
+            for (int i = 0; i < shape.Length; i++)
+            {
+                hash ^= shape[i];
+                hash *= unchecked((long)0x100000001b3L);
+            }
+        }
         return hash;
     }
 }

--- a/src/AiDotNet.Tensors/Engines/Compilation/LazyTensorScope.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/LazyTensorScope.cs
@@ -355,6 +355,18 @@ internal sealed class LazyTensorScope : IDisposable
     }
 
     /// <summary>
+    /// Compiles the lazy graph while binding every tensor in <paramref name="inputs"/> as a
+    /// mutable input slot the plan re-binds on each replay. Use this when more than one captured
+    /// leaf varies per call (e.g. a diffusion denoiser's noisy sample plus its per-step timestep
+    /// embedding); all other captured leaves stay frozen as constants.
+    /// </summary>
+    internal CompiledInferencePlan<T> CompileInference<T>(Tensor<T> explicitOutput, Tensor<T>[] inputs)
+    {
+        MarkCompiled();
+        return CompiledInferencePlan<T>.Compile(this, _engine, explicitOutput, inputs);
+    }
+
+    /// <summary>
     /// Compiles the lazy graph into a training plan with forward + backward steps.
     /// The plan can be replayed for zero-overhead training iterations.
     /// </summary>

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputCompiledInferenceTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputCompiledInferenceTests.cs
@@ -1,0 +1,133 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// Coverage for the multi-input compiled-inference path
+/// (<see cref="CompiledModelCache{T}.GetOrCompileInference(Tensor{T}[], Func{Tensor{T}})"/>).
+/// Before this path existed, <c>Compile</c> marked exactly ONE traced leaf as the mutable
+/// input slot and baked every other leaf as a constant. A forward with more than one
+/// per-call-varying input — the canonical case being a diffusion denoiser that reads both
+/// the noisy sample AND a per-step timestep embedding — therefore replayed the trace-time
+/// value of all-but-the-first input, silently corrupting multi-step inference. These tests
+/// assert that EVERY declared input is re-bound on replay, and that a tensor the graph never
+/// reads is rejected (fail-closed) rather than silently baked.
+/// </summary>
+public class MultiInputCompiledInferenceTests : IDisposable
+{
+    // GetOrCompileInference captures AiDotNetEngine.Current as the plan's execution engine;
+    // on GPU machines the module initializer flips Current to DirectGpu. Pin CPU so plan
+    // replay runs on the same engine that authored the recorded ops.
+    private readonly IEngine _priorEngine = AiDotNetEngine.Current;
+    public MultiInputCompiledInferenceTests() { AiDotNetEngine.Current = new CpuEngine(); }
+    public void Dispose() { AiDotNetEngine.Current = _priorEngine; }
+
+    // Eager reference: out = (x @ w) + t. `x` and `t` both vary per call; `w` is a constant.
+    private static float[] EagerForward(CpuEngine engine, Tensor<float> x, Tensor<float> w, Tensor<float> t)
+    {
+        var mm = engine.TensorMatMul(x, w);
+        var o = engine.TensorBroadcastAdd(mm, t);
+        var arr = new float[o.Length];
+        o.AsSpan().CopyTo(arr);
+        return arr;
+    }
+
+    [Fact]
+    public void MultiInput_RebindsEverySlot_SecondaryInputIsNotBaked()
+    {
+        var engine = new CpuEngine();
+        var x0 = Tensor<float>.CreateRandom(new[] { 2, 3 });
+        var w = Tensor<float>.CreateRandom(new[] { 3, 2 });
+        var t0 = Tensor<float>.CreateRandom(new[] { 2, 2 });
+
+        var cache = new CompiledModelCache<float>();
+        try
+        {
+            // Compile declaring BOTH x and t as mutable inputs.
+            var plan = cache.GetOrCompileInference(new[] { x0, t0 }, () =>
+            {
+                var mm = engine.TensorMatMul(x0, w);
+                return engine.TensorBroadcastAdd(mm, t0);
+            });
+
+            // Every (x, t) pair must reproduce the eager result — both slots re-bind.
+            for (int trial = 0; trial < 4; trial++)
+            {
+                var x = Tensor<float>.CreateRandom(new[] { 2, 3 });
+                var t = Tensor<float>.CreateRandom(new[] { 2, 2 });
+                plan.SetInputs(new[] { x, t });
+                var got = plan.Execute();
+                var expected = EagerForward(engine, x, w, t);
+
+                Assert.Equal(expected.Length, got.Length);
+                for (int i = 0; i < got.Length; i++)
+                    Assert.Equal(expected[i], got[i], 3);
+            }
+
+            // The discriminating check for the bug this path fixes: hold the PRIMARY input
+            // fixed and change ONLY the secondary input. If the secondary input were baked
+            // (the pre-fix single-input behavior), the output would be invariant to it.
+            var xFixed = Tensor<float>.CreateRandom(new[] { 2, 3 });
+            var tA = Tensor<float>.CreateRandom(new[] { 2, 2 });
+            var tB = Tensor<float>.CreateRandom(new[] { 2, 2 });
+
+            plan.SetInputs(new[] { xFixed, tA });
+            var outA = plan.Execute();
+            var a = new float[outA.Length];
+            outA.AsSpan().CopyTo(a);
+
+            plan.SetInputs(new[] { xFixed, tB });
+            var outB = plan.Execute();
+
+            bool differs = false;
+            for (int i = 0; i < outB.Length; i++)
+                if (outB[i] != a[i]) { differs = true; break; }
+            Assert.True(differs,
+                "Output did not change when only the second input varied — that input was baked " +
+                "as a constant, which is exactly the multi-step-inference corruption this path removes.");
+
+            // ...and varying the second input must still match eager (re-bind, not just "differs").
+            for (int i = 0; i < outB.Length; i++)
+                Assert.Equal(EagerForward(engine, xFixed, w, tB)[i], outB[i], 3);
+        }
+        finally { cache.Dispose(); }
+    }
+
+    [Fact]
+    public void MultiInput_NonLeafInput_FailsClosed()
+    {
+        var engine = new CpuEngine();
+        var x = Tensor<float>.CreateRandom(new[] { 2, 3 });
+        var w = Tensor<float>.CreateRandom(new[] { 3, 2 });
+        // `stray` is never read by the forward, so it is not a traced leaf. Declaring it as a
+        // mutable input must fail closed (so the caller falls back to eager) rather than
+        // silently doing nothing and replaying stale data.
+        var stray = Tensor<float>.CreateRandom(new[] { 2, 2 });
+
+        var cache = new CompiledModelCache<float>();
+        try
+        {
+            Assert.Throws<InvalidOperationException>(() =>
+                cache.GetOrCompileInference(new[] { x, stray }, () => engine.TensorMatMul(x, w)));
+        }
+        finally { cache.Dispose(); }
+    }
+
+    [Fact]
+    public void MultiInput_EmptyInputs_Throws()
+    {
+        var cache = new CompiledModelCache<float>();
+        try
+        {
+            var engine = new CpuEngine();
+            var x = Tensor<float>.CreateRandom(new[] { 2, 2 });
+            Assert.Throws<ArgumentException>(() =>
+                cache.GetOrCompileInference(Array.Empty<Tensor<float>>(), () => engine.ReLU(x)));
+        }
+        finally { cache.Dispose(); }
+    }
+}


### PR DESCRIPTION
## Problem

`CompiledInferencePlan.Compile` marked exactly **one** traced leaf as the mutable input slot (`SelectCompiledInputTensor`) and baked every other leaf — including genuinely per-call-varying inputs — as a constant. Any forward with **more than one** varying input replayed the trace-time value of all-but-the-first input.

The canonical victim is a **diffusion denoiser**: its per-step forward reads both the noisy sample **and** a per-step timestep embedding. At a constant input shape the cached plan was reused every step, so step 0's timestep embedding was baked in and reused for all steps — silently corrupting multi-step inference. `EnableCompilation` defaults to `true`, so this was live, and it hid behind tests that don't check the denoising trajectory (outputs stayed finite + deterministic, just wrong).

## Fix

The plan layer was already multi-input ready — `_compiledInputTensors` is an array and `SetInputs` re-binds N inputs in order (the ctor comment even anticipated *"when multi-input Compile lands"*). Only the **compile side** was single-input. This wires the missing path end to end:

- **`CompiledInferencePlan.Compile(scope, engine, output, Tensor<T>[] inputs)`** — marks every supplied tensor as a mutable slot. `ValidateExplicitInputsAreLeaves` **fails closed** if a declared input is not a traced leaf, so a caller can never silently get a baked input (it falls back to eager instead).
- **`LazyTensorScope.CompileInference<T>(output, Tensor<T>[] inputs)`**.
- **`CompiledModelCache.GetOrCompileInference(Tensor<T>[] inputs, Func)`** — combined shape key over all inputs; re-binds every input on cache hit.

The existing single-input `Compile` / `SelectCompiledInputTensor` path is **unchanged**.

## Tests

`MultiInputCompiledInferenceTests` (new):
- `MultiInput_RebindsEverySlot_SecondaryInputIsNotBaked` — drives `out = (x @ w) + t` with both `x` and `t` declared as inputs; asserts compiled == eager across varying pairs, and the discriminating check: **hold `x` fixed, vary only `t` → output must change** (fails if `t` was baked).
- `MultiInput_NonLeafInput_FailsClosed` — a tensor the graph never reads is rejected.
- `MultiInput_EmptyInputs_Throws`.

All 3 pass; **462** existing `Engines.Compilation` tests still green. Builds on net10.0 + net471.

## Follow-up (separate repo)

This unblocks the correct fix in **ooples/AiDotNet** diffusion: route each predictor's per-step forward through a multi-input `PredictCompiled([noisySample, timeEmbed, conditioning], …)` once this lands in a Tensors release. Until then those predictors run eagerly (correct, just not compiled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)