### PR TITLE
GPU conv/pool kernels: new→override + GPU-vs-CPU coverage (surfaces+contains 6 buggy kernels)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -2235,6 +2235,23 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         bool preferGenericForGpu = engine.SupportsGpu
             && Environment.GetEnvironmentVariable("AIDOTNET_GPU_PREFER_GENERIC") != "0";
 
+        // Diagnostic companion to GRAPHSTEP-DIAG (gated on AIDOTNET_CUDA_GRAPH_STEP=1): record the engine
+        // type + SupportsGpu + the resulting preferGenericForGpu at compile time. When a GPU plan is
+        // unexpectedly graph-ineligible this immediately distinguishes "engine isn't GPU / SupportsGpu
+        // false" from "ops aren't GPU-pure", which is otherwise invisible.
+        if (s_graphStepEnabled && typeof(T) == typeof(float))
+        {
+            try
+            {
+                System.IO.File.AppendAllText(
+                    System.IO.Path.Combine(System.IO.Path.GetTempPath(), "aidotnet_graphstep_diag.txt"),
+                    $"[GRAPHSTEP-ENGINE] type={engine.GetType().Name} SupportsGpu={engine.SupportsGpu} "
+                    + $"DirectGpu?={(engine.DirectGpu != null)} preferGenericForGpu={preferGenericForGpu}"
+                    + System.Environment.NewLine);
+            }
+            catch { /* diagnostic must never break the build */ }
+        }
+
         if (typeof(T) == typeof(float) && Optimization.TensorCodecOptions.Current.EnableDataflowFusion
             && !preferGenericForGpu)
         {

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -50,10 +50,10 @@ public partial class CpuEngine : ITensorLevelEngine
     private const int TensorMatMulGemvParallelThreshold = 128 * 1024;
 
     /// <inheritdoc/>
-    public string Name => "CPU Engine";
+    public virtual string Name => "CPU Engine";
 
     /// <inheritdoc/>
-    public bool SupportsGpu => false;
+    public virtual bool SupportsGpu => false;
 
     /// <inheritdoc/>
     public DirectGpu.DirectGpuEngine? DirectGpu => null;

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -15008,7 +15008,7 @@ public partial class CpuEngine : ITensorLevelEngine
     }
 
     /// <inheritdoc/>
-    public Tensor<T> MaxPool2DWithIndices<T>(Tensor<T> input, int[] poolSize, int[] stride, out int[,,,,] maxIndices)
+    public virtual Tensor<T> MaxPool2DWithIndices<T>(Tensor<T> input, int[] poolSize, int[] stride, out int[,,,,] maxIndices)
     {
         if (input == null) throw new ArgumentNullException(nameof(input));
 
@@ -15137,7 +15137,7 @@ public partial class CpuEngine : ITensorLevelEngine
     }
 
     /// <inheritdoc/>
-    public Tensor<T> MaxPool2DBackward<T>(Tensor<T> gradOutput, int[,,,,] maxIndices, int[] inputShape, int[] poolSize, int[] stride)
+    public virtual Tensor<T> MaxPool2DBackward<T>(Tensor<T> gradOutput, int[,,,,] maxIndices, int[] inputShape, int[] poolSize, int[] stride)
     {
         if (gradOutput == null) throw new ArgumentNullException(nameof(gradOutput));
 
@@ -15466,7 +15466,7 @@ public partial class CpuEngine : ITensorLevelEngine
     }
 
     /// <inheritdoc/>
-    public Tensor<T> DepthwiseConv2D<T>(Tensor<T> input, Tensor<T> kernel, int[] stride, int[] padding)
+    public virtual Tensor<T> DepthwiseConv2D<T>(Tensor<T> input, Tensor<T> kernel, int[] stride, int[] padding)
     {
         if (input == null) throw new ArgumentNullException(nameof(input));
         if (kernel == null) throw new ArgumentNullException(nameof(kernel));
@@ -16175,7 +16175,7 @@ public partial class CpuEngine : ITensorLevelEngine
     #region Deformable Convolution Operations
 
     /// <inheritdoc/>
-    public Tensor<T> DeformableConv2D<T>(
+    public virtual Tensor<T> DeformableConv2D<T>(
         Tensor<T> input,
         Tensor<T> kernel,
         Tensor<T> offset,
@@ -16444,7 +16444,7 @@ public partial class CpuEngine : ITensorLevelEngine
     }
 
     /// <inheritdoc/>
-    public Tensor<T> DeformableConv2DBackwardInput<T>(
+    public virtual Tensor<T> DeformableConv2DBackwardInput<T>(
         Tensor<T> gradOutput,
         Tensor<T> input,
         Tensor<T> kernel,
@@ -16614,7 +16614,7 @@ public partial class CpuEngine : ITensorLevelEngine
     }
 
     /// <inheritdoc/>
-    public Tensor<T> DeformableConv2DBackwardKernel<T>(
+    public virtual Tensor<T> DeformableConv2DBackwardKernel<T>(
         Tensor<T> gradOutput,
         Tensor<T> input,
         Tensor<T> offset,
@@ -16718,7 +16718,7 @@ public partial class CpuEngine : ITensorLevelEngine
     }
 
     /// <inheritdoc/>
-    public Tensor<T> DeformableConv2DBackwardOffset<T>(
+    public virtual Tensor<T> DeformableConv2DBackwardOffset<T>(
         Tensor<T> gradOutput,
         Tensor<T> input,
         Tensor<T> kernel,
@@ -17031,7 +17031,7 @@ public partial class CpuEngine : ITensorLevelEngine
     }
 
     /// <inheritdoc/>
-    public Tensor<T> DeformableConv2DBackwardMask<T>(
+    public virtual Tensor<T> DeformableConv2DBackwardMask<T>(
         Tensor<T> gradOutput,
         Tensor<T> input,
         Tensor<T> kernel,
@@ -18743,7 +18743,7 @@ public partial class CpuEngine : ITensorLevelEngine
     #endregion
 
     /// <inheritdoc/>
-    public Tensor<T> LocallyConnectedConv2D<T>(Tensor<T> input, Tensor<T> weights, Tensor<T>? bias, int[] stride)
+    public virtual Tensor<T> LocallyConnectedConv2D<T>(Tensor<T> input, Tensor<T> weights, Tensor<T>? bias, int[] stride)
     {
         if (input == null) throw new ArgumentNullException(nameof(input));
         if (weights == null) throw new ArgumentNullException(nameof(weights));
@@ -18855,7 +18855,7 @@ public partial class CpuEngine : ITensorLevelEngine
     }
 
     /// <inheritdoc/>
-    public Tensor<T> LocallyConnectedConv2DBackwardInput<T>(Tensor<T> gradOutput, Tensor<T> weights, int[] inputShape, int[] stride)
+    public virtual Tensor<T> LocallyConnectedConv2DBackwardInput<T>(Tensor<T> gradOutput, Tensor<T> weights, int[] inputShape, int[] stride)
     {
         if (gradOutput == null) throw new ArgumentNullException(nameof(gradOutput));
         if (weights == null) throw new ArgumentNullException(nameof(weights));
@@ -18920,7 +18920,7 @@ public partial class CpuEngine : ITensorLevelEngine
     }
 
     /// <inheritdoc/>
-    public Tensor<T> LocallyConnectedConv2DBackwardWeights<T>(Tensor<T> gradOutput, Tensor<T> input, int[] weightsShape, int[] stride)
+    public virtual Tensor<T> LocallyConnectedConv2DBackwardWeights<T>(Tensor<T> gradOutput, Tensor<T> input, int[] weightsShape, int[] stride)
     {
         if (gradOutput == null) throw new ArgumentNullException(nameof(gradOutput));
         if (input == null) throw new ArgumentNullException(nameof(input));
@@ -18992,7 +18992,7 @@ public partial class CpuEngine : ITensorLevelEngine
     }
 
     /// <inheritdoc/>
-    public Tensor<T> LocallyConnectedConv2DBackwardBias<T>(Tensor<T> gradOutput)
+    public virtual Tensor<T> LocallyConnectedConv2DBackwardBias<T>(Tensor<T> gradOutput)
     {
         if (gradOutput == null) throw new ArgumentNullException(nameof(gradOutput));
         if (gradOutput.Rank != 4) throw new ArgumentException($"LocallyConnectedConv2DBackwardBias gradOutput requires 4D tensor. Got rank {gradOutput.Rank}.");
@@ -25774,7 +25774,7 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <summary>
     /// Computes the backward pass for FlashAttention.
     /// </summary>
-    public Tensor<T> FlashAttentionBackward<T>(
+    public virtual Tensor<T> FlashAttentionBackward<T>(
         Tensor<T> gradOutput,
         Tensor<T> query,
         Tensor<T> key,
@@ -26355,7 +26355,7 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <summary>
     /// Computes the backward pass for Grouped Query Attention.
     /// </summary>
-    public Tensor<T> GroupedQueryAttentionBackward<T>(
+    public virtual Tensor<T> GroupedQueryAttentionBackward<T>(
         Tensor<T> gradOutput,
         Tensor<T> query,
         Tensor<T> key,
@@ -27709,7 +27709,7 @@ public partial class CpuEngine : ITensorLevelEngine
     }
 
     /// <inheritdoc/>
-    public Tensor<T> ReduceMax<T>(Tensor<T> input, int[] axes, bool keepDims, out int[] maxIndices)
+    public virtual Tensor<T> ReduceMax<T>(Tensor<T> input, int[] axes, bool keepDims, out int[] maxIndices)
     {
         // GraphMode: record lazy node for compiled plan
         if (GraphMode.IsActive)
@@ -35660,7 +35660,7 @@ public partial class CpuEngine : ITensorLevelEngine
     }
 
     /// <inheritdoc/>
-    public Tensor<T> FusedConv3D<T>(
+    public virtual Tensor<T> FusedConv3D<T>(
         Tensor<T> input,
         Tensor<T> kernel,
         Tensor<T>? bias,
@@ -35695,7 +35695,7 @@ public partial class CpuEngine : ITensorLevelEngine
     }
 
     /// <inheritdoc/>
-    public Tensor<T> FusedConvTranspose2D<T>(
+    public virtual Tensor<T> FusedConvTranspose2D<T>(
         Tensor<T> input,
         Tensor<T> kernel,
         Tensor<T>? bias,
@@ -35728,7 +35728,7 @@ public partial class CpuEngine : ITensorLevelEngine
     }
 
     /// <inheritdoc/>
-    public Tensor<T> FusedBatchNorm<T>(
+    public virtual Tensor<T> FusedBatchNorm<T>(
         Tensor<T> input,
         Tensor<T> gamma,
         Tensor<T> beta,
@@ -35886,7 +35886,7 @@ public partial class CpuEngine : ITensorLevelEngine
     /// On CPU, this is a no-op. Persistent tensor management only provides benefits
     /// on GPU where data transfer between host and device is expensive.
     /// </remarks>
-    public void RegisterPersistentTensor<T>(Tensor<T> tensor, PersistentTensorRole role)
+    public virtual void RegisterPersistentTensor<T>(Tensor<T> tensor, PersistentTensorRole role)
     {
         // No-op on CPU: persistence only benefits GPU by avoiding repeated transfers
         // The tensor is already in CPU memory, so there's nothing to cache
@@ -35896,7 +35896,7 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <remarks>
     /// On CPU, this is a no-op. See <see cref="RegisterPersistentTensor{T}"/>.
     /// </remarks>
-    public void UnregisterPersistentTensor<T>(Tensor<T> tensor)
+    public virtual void UnregisterPersistentTensor<T>(Tensor<T> tensor)
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
         // No-op on CPU
@@ -35906,7 +35906,7 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <remarks>
     /// On CPU, this is a no-op. See <see cref="RegisterPersistentTensor{T}"/>.
     /// </remarks>
-    public void InvalidatePersistentTensor<T>(Tensor<T> tensor)
+    public virtual void InvalidatePersistentTensor<T>(Tensor<T> tensor)
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
         // No-op on CPU

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -6480,7 +6480,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     public override Tensor<T> LocallyConnectedConv2DBackwardWeights<T>(Tensor<T> gradOutput, Tensor<T> input, int[] weightsShape, int[] stride)
     {
         // The GPU LocallyConnectedConv2DBackwardWeights kernel disagreed with the CPU reference (GpuConvKernelCoverageTests);
-        // route to the correct CPU implementation until the GPU kernel is fixed. The `override`
+        // route to the correct CPU implementation until the GPU kernel is fixed (tracked in #622). The `override`
         // (vs the prior `new` hide) keeps virtual dispatch correct.
         return base.LocallyConnectedConv2DBackwardWeights(gradOutput, input, weightsShape, stride);
     }
@@ -6610,7 +6610,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int[] dilation)
     {
         // The GPU DeformableConv2D kernel disagreed with the CPU reference (GpuConvKernelCoverageTests);
-        // route to the correct CPU implementation until the GPU kernel is fixed. The `override`
+        // route to the correct CPU implementation until the GPU kernel is fixed (tracked in #622). The `override`
         // (vs the prior `new` hide) keeps virtual dispatch correct.
         return base.DeformableConv2D(input, kernel, offsets, mask, stride, padding, dilation);
     }
@@ -6631,7 +6631,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int[] dilation)
     {
         // The GPU DeformableConv2DBackwardInput kernel disagreed with the CPU reference (GpuConvKernelCoverageTests);
-        // route to the correct CPU implementation until the GPU kernel is fixed. The `override`
+        // route to the correct CPU implementation until the GPU kernel is fixed (tracked in #622). The `override`
         // (vs the prior `new` hide) keeps virtual dispatch correct.
         return base.DeformableConv2DBackwardInput(gradOutput, input, kernel, offsets, mask, inputShape, stride, padding, dilation);
     }
@@ -6651,7 +6651,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int[] dilation)
     {
         // The GPU DeformableConv2DBackwardKernel kernel disagreed with the CPU reference (GpuConvKernelCoverageTests);
-        // route to the correct CPU implementation until the GPU kernel is fixed. The `override`
+        // route to the correct CPU implementation until the GPU kernel is fixed (tracked in #622). The `override`
         // (vs the prior `new` hide) keeps virtual dispatch correct.
         return base.DeformableConv2DBackwardKernel(gradOutput, input, offsets, mask, kernelShape, stride, padding, dilation);
     }
@@ -6671,7 +6671,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int[] dilation)
     {
         // The GPU DeformableConv2DBackwardOffset kernel disagreed with the CPU reference (GpuConvKernelCoverageTests);
-        // route to the correct CPU implementation until the GPU kernel is fixed. The `override`
+        // route to the correct CPU implementation until the GPU kernel is fixed (tracked in #622). The `override`
         // (vs the prior `new` hide) keeps virtual dispatch correct.
         return base.DeformableConv2DBackwardOffset(gradOutput, input, kernel, offsets, mask, stride, padding, dilation);
     }
@@ -6691,7 +6691,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int[] dilation)
     {
         // The GPU DeformableConv2DBackwardMask kernel disagreed with the CPU reference (GpuConvKernelCoverageTests);
-        // route to the correct CPU implementation until the GPU kernel is fixed. The `override`
+        // route to the correct CPU implementation until the GPU kernel is fixed (tracked in #622). The `override`
         // (vs the prior `new` hide) keeps virtual dispatch correct.
         return base.DeformableConv2DBackwardMask(gradOutput, input, kernel, offsets, mask, stride, padding, dilation);
     }

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -5399,7 +5399,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// Uses cached GPU buffers for registered persistent tensors (kernel/bias) to avoid
     /// redundant CPU→GPU transfers on every forward pass.
     /// </summary>
-    public new Tensor<T> FusedConv3D<T>(
+    public override Tensor<T> FusedConv3D<T>(
         Tensor<T> input,
         Tensor<T> kernel,
         Tensor<T>? bias,
@@ -5623,7 +5623,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// Uses cached GPU buffers for registered persistent tensors (kernel/bias) to avoid
     /// redundant CPU→GPU transfers on every forward pass.
     /// </summary>
-    public new Tensor<T> FusedConvTranspose2D<T>(
+    public override Tensor<T> FusedConvTranspose2D<T>(
         Tensor<T> input,
         Tensor<T> kernel,
         Tensor<T>? bias,
@@ -5889,7 +5889,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// GPU-accelerated 2D max pooling with indices for backward pass.
     /// Returns both pooled output and indices of maximum values for gradient computation.
     /// </summary>
-    public new Tensor<T> MaxPool2DWithIndices<T>(Tensor<T> input, int[] poolSize, int[] stride, out int[,,,,] maxIndices)
+    public override Tensor<T> MaxPool2DWithIndices<T>(Tensor<T> input, int[] poolSize, int[] stride, out int[,,,,] maxIndices)
     {
         if (!TryGetBackend(out var backend))
             return base.MaxPool2DWithIndices(input, poolSize, stride, out maxIndices);
@@ -5959,7 +5959,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// GPU-accelerated backward pass for 2D max pooling.
     /// Propagates gradients back through the max pooling operation using stored indices.
     /// </summary>
-    public new Tensor<T> MaxPool2DBackward<T>(Tensor<T> gradOutput, int[,,,,] maxIndices, int[] inputShape, int[] poolSize, int[] stride)
+    public override Tensor<T> MaxPool2DBackward<T>(Tensor<T> gradOutput, int[,,,,] maxIndices, int[] inputShape, int[] poolSize, int[] stride)
     {
         if (!TryGetBackend(out var backend))
             return base.MaxPool2DBackward(gradOutput, maxIndices, inputShape, poolSize, stride);
@@ -6197,7 +6197,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// GPU-accelerated depthwise 2D convolution.
     /// Each input channel is convolved with its own filter, commonly used in MobileNets.
     /// </summary>
-    public new Tensor<T> DepthwiseConv2D<T>(Tensor<T> input, Tensor<T> kernel, int[] stride, int[] padding)
+    public override Tensor<T> DepthwiseConv2D<T>(Tensor<T> input, Tensor<T> kernel, int[] stride, int[] padding)
     {
         if (!TryGetBackend(out var backend))
             return base.DepthwiseConv2D(input, kernel, stride, padding);
@@ -6343,7 +6343,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// redundant CPU→GPU transfers on every forward pass.
     /// Falls back to CPU implementation if GPU is unavailable.
     /// </summary>
-    public new Tensor<T> LocallyConnectedConv2D<T>(Tensor<T> input, Tensor<T> weights, Tensor<T>? bias, int[] stride)
+    public override Tensor<T> LocallyConnectedConv2D<T>(Tensor<T> input, Tensor<T> weights, Tensor<T>? bias, int[] stride)
     {
         if (!TryGetBackend(out var backend))
             return base.LocallyConnectedConv2D(input, weights, bias, stride);
@@ -6422,7 +6422,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// GPU-accelerated locally connected 2D backward pass for input gradients.
     /// Falls back to CPU implementation if GPU is unavailable.
     /// </summary>
-    public new Tensor<T> LocallyConnectedConv2DBackwardInput<T>(Tensor<T> gradOutput, Tensor<T> weights, int[] inputShape, int[] stride)
+    public override Tensor<T> LocallyConnectedConv2DBackwardInput<T>(Tensor<T> gradOutput, Tensor<T> weights, int[] inputShape, int[] stride)
     {
         if (!TryGetBackend(out var backend))
             return base.LocallyConnectedConv2DBackwardInput(gradOutput, weights, inputShape, stride);
@@ -6477,62 +6477,19 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// GPU-accelerated locally connected 2D backward pass for weight gradients.
     /// Falls back to CPU implementation if GPU is unavailable.
     /// </summary>
-    public new Tensor<T> LocallyConnectedConv2DBackwardWeights<T>(Tensor<T> gradOutput, Tensor<T> input, int[] weightsShape, int[] stride)
+    public override Tensor<T> LocallyConnectedConv2DBackwardWeights<T>(Tensor<T> gradOutput, Tensor<T> input, int[] weightsShape, int[] stride)
     {
-        if (!TryGetBackend(out var backend))
-            return base.LocallyConnectedConv2DBackwardWeights(gradOutput, input, weightsShape, stride);
-
-        // Validate inputs
-        if (gradOutput.Rank != 4 || input.Rank != 4)
-            return base.LocallyConnectedConv2DBackwardWeights(gradOutput, input, weightsShape, stride);
-
-        if (weightsShape == null || weightsShape.Length != 6)
-            throw new ArgumentException("Weights shape must be an array of 6 elements", nameof(weightsShape));
-        if (stride == null || stride.Length != 2)
-            throw new ArgumentException("Stride must be an array of 2 elements", nameof(stride));
-
-        int batch = input.Shape._dims[0];
-        int inChannels = input.Shape._dims[1];
-        int inHeight = input.Shape._dims[2];
-        int inWidth = input.Shape._dims[3];
-
-        int outHeight = weightsShape[0];
-        int outWidth = weightsShape[1];
-        int outChannels = weightsShape[2];
-        int kernelH = weightsShape[4];
-        int kernelW = weightsShape[5];
-
-        int weightsSize = outHeight * outWidth * outChannels * inChannels * kernelH * kernelW;
-
-        using var gradOutputBuffer = GetOrAllocateBuffer(backend, gradOutput);
-        using var inputBuffer = GetOrAllocateBuffer(backend, input);
-        using var gradWeightsBuffer = AllocateOutputBuffer(backend, weightsSize);
-
-        try
-        {
-            backend.LocallyConnectedConv2DBackwardWeights(
-                inputBuffer.Buffer, gradOutputBuffer.Buffer, gradWeightsBuffer.Buffer,
-                batch, inChannels, inHeight, inWidth,
-                outChannels, outHeight, outWidth,
-                kernelH, kernelW, stride[0], stride[1]);
-
-            float[] resultFloat = new float[weightsSize];
-            backend.DownloadBuffer(gradWeightsBuffer.Buffer, resultFloat);
-
-            T[] resultData = DirectGpuEngine.FromFloatArray<T>(resultFloat);
-            return new Tensor<T>(resultData, weightsShape);
-        }
-        catch
-        {
-            return base.LocallyConnectedConv2DBackwardWeights(gradOutput, input, weightsShape, stride);
-        }
+        // The GPU LocallyConnectedConv2DBackwardWeights kernel disagreed with the CPU reference (GpuConvKernelCoverageTests);
+        // route to the correct CPU implementation until the GPU kernel is fixed. The `override`
+        // (vs the prior `new` hide) keeps virtual dispatch correct.
+        return base.LocallyConnectedConv2DBackwardWeights(gradOutput, input, weightsShape, stride);
     }
 
     /// <summary>
     /// GPU-accelerated locally connected 2D backward pass for bias gradients.
     /// Falls back to CPU implementation if GPU is unavailable.
     /// </summary>
-    public new Tensor<T> LocallyConnectedConv2DBackwardBias<T>(Tensor<T> gradOutput)
+    public override Tensor<T> LocallyConnectedConv2DBackwardBias<T>(Tensor<T> gradOutput)
     {
         if (!TryGetBackend(out var backend))
             return base.LocallyConnectedConv2DBackwardBias<T>(gradOutput);
@@ -6643,7 +6600,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// Uses cached GPU buffers for registered persistent tensors to avoid
     /// redundant CPU→GPU transfers. Falls back to CPU if GPU unavailable.
     /// </summary>
-    public new Tensor<T> DeformableConv2D<T>(
+    public override Tensor<T> DeformableConv2D<T>(
         Tensor<T> input,
         Tensor<T> kernel,
         Tensor<T> offsets,
@@ -6652,81 +6609,17 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int[] padding,
         int[] dilation)
     {
-        if (!TryGetBackend(out var backend))
-            return base.DeformableConv2D(input, kernel, offsets, mask, stride, padding, dilation);
-
-        // Validate inputs
-        if (input.Rank != 4 || kernel.Rank != 4 || offsets.Rank != 4)
-            return base.DeformableConv2D(input, kernel, offsets, mask, stride, padding, dilation);
-
-        if (stride == null || stride.Length != 2)
-            throw new ArgumentException("Stride must be an array of 2 elements", nameof(stride));
-        if (padding == null || padding.Length != 2)
-            throw new ArgumentException("Padding must be an array of 2 elements", nameof(padding));
-        if (dilation == null || dilation.Length != 2)
-            throw new ArgumentException("Dilation must be an array of 2 elements", nameof(dilation));
-
-        int batch = input.Shape._dims[0];
-        int inChannels = input.Shape._dims[1];
-        int inHeight = input.Shape._dims[2];
-        int inWidth = input.Shape._dims[3];
-
-        int outChannels = kernel.Shape._dims[0];
-        int kernelH = kernel.Shape._dims[2];
-        int kernelW = kernel.Shape._dims[3];
-
-        int outHeight = (inHeight + 2 * padding[0] - dilation[0] * (kernelH - 1) - 1) / stride[0] + 1;
-        int outWidth = (inWidth + 2 * padding[1] - dilation[1] * (kernelW - 1) - 1) / stride[1] + 1;
-
-        if (outHeight <= 0 || outWidth <= 0)
-            return base.DeformableConv2D(input, kernel, offsets, mask, stride, padding, dilation);
-
-        // Calculate deformGroups from offsets shape: [batch, deformGroups*2*kH*kW, outH, outW]
-        int offsetChannels = offsets.Shape._dims[1];
-        int deformGroups = offsetChannels / (2 * kernelH * kernelW);
-        int groups = 1; // Standard deformable conv uses groups=1
-
-        int outputSize = batch * outChannels * outHeight * outWidth;
-
-        using var inputBuffer = GetOrAllocateBuffer(backend, input);
-        using var weightsBuffer = GetOrCacheWeightBuffer(backend, kernel.GetDataArray(), PersistentTensorRole.Weights);
-        using var offsetsBuffer = GetOrAllocateBuffer(backend, offsets);
-        using var outputBuffer = AllocateOutputBuffer(backend, outputSize);
-
-        try
-        {
-            OwnedBuffer? maskBuffer = mask != null ? GetOrAllocateBuffer(backend, mask) : null;
-            try
-            {
-                backend.DeformableConv2D(
-                    inputBuffer.Buffer, weightsBuffer.Buffer, offsetsBuffer.Buffer, maskBuffer?.Buffer, outputBuffer.Buffer,
-                    batch, inChannels, inHeight, inWidth,
-                    outChannels, outHeight, outWidth,
-                    kernelH, kernelW, stride[0], stride[1], padding[0], padding[1],
-                    dilation[0], dilation[1], groups, deformGroups);
-
-                float[] resultFloat = new float[outputSize];
-                backend.DownloadBuffer(outputBuffer.Buffer, resultFloat);
-
-                T[] resultData = DirectGpuEngine.FromFloatArray<T>(resultFloat);
-                return new Tensor<T>(resultData, new[] { batch, outChannels, outHeight, outWidth });
-            }
-            finally
-            {
-                maskBuffer?.Dispose();
-            }
-        }
-        catch
-        {
-            return base.DeformableConv2D(input, kernel, offsets, mask, stride, padding, dilation);
-        }
+        // The GPU DeformableConv2D kernel disagreed with the CPU reference (GpuConvKernelCoverageTests);
+        // route to the correct CPU implementation until the GPU kernel is fixed. The `override`
+        // (vs the prior `new` hide) keeps virtual dispatch correct.
+        return base.DeformableConv2D(input, kernel, offsets, mask, stride, padding, dilation);
     }
 
     /// <summary>
     /// GPU-accelerated deformable conv2D backward pass for input gradients.
     /// Falls back to CPU implementation if GPU is unavailable.
     /// </summary>
-    public new Tensor<T> DeformableConv2DBackwardInput<T>(
+    public override Tensor<T> DeformableConv2DBackwardInput<T>(
         Tensor<T> gradOutput,
         Tensor<T> input,
         Tensor<T> kernel,
@@ -6737,69 +6630,17 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int[] padding,
         int[] dilation)
     {
-        if (!TryGetBackend(out var backend))
-            return base.DeformableConv2DBackwardInput(gradOutput, input, kernel, offsets, mask, inputShape, stride, padding, dilation);
-
-        if (gradOutput.Rank != 4 || input.Rank != 4 || kernel.Rank != 4)
-            return base.DeformableConv2DBackwardInput(gradOutput, input, kernel, offsets, mask, inputShape, stride, padding, dilation);
-
-        int batch = inputShape[0];
-        int inChannels = inputShape[1];
-        int inHeight = inputShape[2];
-        int inWidth = inputShape[3];
-
-        int outChannels = kernel.Shape._dims[0];
-        int kernelH = kernel.Shape._dims[2];
-        int kernelW = kernel.Shape._dims[3];
-
-        int outHeight = gradOutput.Shape._dims[2];
-        int outWidth = gradOutput.Shape._dims[3];
-
-        int offsetChannels = offsets.Shape._dims[1];
-        int deformGroups = offsetChannels / (2 * kernelH * kernelW);
-        int groups = 1;
-
-        int inputSize = batch * inChannels * inHeight * inWidth;
-
-        using var gradOutputBuffer = GetOrAllocateBuffer(backend, gradOutput);
-        using var weightsBuffer = GetOrCacheWeightBuffer(backend, kernel.GetDataArray(), PersistentTensorRole.Weights);
-        using var offsetsBuffer = GetOrAllocateBuffer(backend, offsets);
-        using var gradInputBuffer = AllocateOutputBuffer(backend, inputSize);
-
-        try
-        {
-            OwnedBuffer? maskBuffer = mask != null ? GetOrAllocateBuffer(backend, mask) : null;
-            try
-            {
-                backend.DeformableConv2DBackwardInput(
-                    gradOutputBuffer.Buffer, weightsBuffer.Buffer, offsetsBuffer.Buffer, maskBuffer?.Buffer, gradInputBuffer.Buffer,
-                    batch, inChannels, inHeight, inWidth,
-                    outChannels, outHeight, outWidth,
-                    kernelH, kernelW, stride[0], stride[1], padding[0], padding[1],
-                    dilation[0], dilation[1], groups, deformGroups);
-
-                float[] resultFloat = new float[inputSize];
-                backend.DownloadBuffer(gradInputBuffer.Buffer, resultFloat);
-
-                T[] resultData = DirectGpuEngine.FromFloatArray<T>(resultFloat);
-                return new Tensor<T>(resultData, inputShape);
-            }
-            finally
-            {
-                maskBuffer?.Dispose();
-            }
-        }
-        catch
-        {
-            return base.DeformableConv2DBackwardInput(gradOutput, input, kernel, offsets, mask, inputShape, stride, padding, dilation);
-        }
+        // The GPU DeformableConv2DBackwardInput kernel disagreed with the CPU reference (GpuConvKernelCoverageTests);
+        // route to the correct CPU implementation until the GPU kernel is fixed. The `override`
+        // (vs the prior `new` hide) keeps virtual dispatch correct.
+        return base.DeformableConv2DBackwardInput(gradOutput, input, kernel, offsets, mask, inputShape, stride, padding, dilation);
     }
 
     /// <summary>
     /// GPU-accelerated deformable conv2D backward pass for kernel gradients.
     /// Falls back to CPU implementation if GPU is unavailable.
     /// </summary>
-    public new Tensor<T> DeformableConv2DBackwardKernel<T>(
+    public override Tensor<T> DeformableConv2DBackwardKernel<T>(
         Tensor<T> gradOutput,
         Tensor<T> input,
         Tensor<T> offsets,
@@ -6809,69 +6650,17 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int[] padding,
         int[] dilation)
     {
-        if (!TryGetBackend(out var backend))
-            return base.DeformableConv2DBackwardKernel(gradOutput, input, offsets, mask, kernelShape, stride, padding, dilation);
-
-        if (gradOutput.Rank != 4 || input.Rank != 4)
-            return base.DeformableConv2DBackwardKernel(gradOutput, input, offsets, mask, kernelShape, stride, padding, dilation);
-
-        int batch = input.Shape._dims[0];
-        int inChannels = input.Shape._dims[1];
-        int inHeight = input.Shape._dims[2];
-        int inWidth = input.Shape._dims[3];
-
-        int outChannels = kernelShape[0];
-        int kernelH = kernelShape[2];
-        int kernelW = kernelShape[3];
-
-        int outHeight = gradOutput.Shape._dims[2];
-        int outWidth = gradOutput.Shape._dims[3];
-
-        int offsetChannels = offsets.Shape._dims[1];
-        int deformGroups = offsetChannels / (2 * kernelH * kernelW);
-        int groups = 1;
-
-        int kernelSize = kernelShape[0] * kernelShape[1] * kernelShape[2] * kernelShape[3];
-
-        using var gradOutputBuffer = GetOrAllocateBuffer(backend, gradOutput);
-        using var inputBuffer = GetOrAllocateBuffer(backend, input);
-        using var offsetsBuffer = GetOrAllocateBuffer(backend, offsets);
-        using var gradWeightsBuffer = AllocateOutputBuffer(backend, kernelSize);
-
-        try
-        {
-            OwnedBuffer? maskBuffer = mask != null ? GetOrAllocateBuffer(backend, mask) : null;
-            try
-            {
-                backend.DeformableConv2DBackwardWeights(
-                    inputBuffer.Buffer, gradOutputBuffer.Buffer, offsetsBuffer.Buffer, maskBuffer?.Buffer, gradWeightsBuffer.Buffer,
-                    batch, inChannels, inHeight, inWidth,
-                    outChannels, outHeight, outWidth,
-                    kernelH, kernelW, stride[0], stride[1], padding[0], padding[1],
-                    dilation[0], dilation[1], groups, deformGroups);
-
-                float[] resultFloat = new float[kernelSize];
-                backend.DownloadBuffer(gradWeightsBuffer.Buffer, resultFloat);
-
-                T[] resultData = DirectGpuEngine.FromFloatArray<T>(resultFloat);
-                return new Tensor<T>(resultData, kernelShape);
-            }
-            finally
-            {
-                maskBuffer?.Dispose();
-            }
-        }
-        catch
-        {
-            return base.DeformableConv2DBackwardKernel(gradOutput, input, offsets, mask, kernelShape, stride, padding, dilation);
-        }
+        // The GPU DeformableConv2DBackwardKernel kernel disagreed with the CPU reference (GpuConvKernelCoverageTests);
+        // route to the correct CPU implementation until the GPU kernel is fixed. The `override`
+        // (vs the prior `new` hide) keeps virtual dispatch correct.
+        return base.DeformableConv2DBackwardKernel(gradOutput, input, offsets, mask, kernelShape, stride, padding, dilation);
     }
 
     /// <summary>
     /// GPU-accelerated deformable conv2D backward pass for offset gradients.
     /// Falls back to CPU implementation if GPU is unavailable.
     /// </summary>
-    public new Tensor<T> DeformableConv2DBackwardOffset<T>(
+    public override Tensor<T> DeformableConv2DBackwardOffset<T>(
         Tensor<T> gradOutput,
         Tensor<T> input,
         Tensor<T> kernel,
@@ -6881,70 +6670,17 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int[] padding,
         int[] dilation)
     {
-        if (!TryGetBackend(out var backend))
-            return base.DeformableConv2DBackwardOffset(gradOutput, input, kernel, offsets, mask, stride, padding, dilation);
-
-        if (gradOutput.Rank != 4 || input.Rank != 4 || kernel.Rank != 4)
-            return base.DeformableConv2DBackwardOffset(gradOutput, input, kernel, offsets, mask, stride, padding, dilation);
-
-        int batch = input.Shape._dims[0];
-        int inChannels = input.Shape._dims[1];
-        int inHeight = input.Shape._dims[2];
-        int inWidth = input.Shape._dims[3];
-
-        int outChannels = kernel.Shape._dims[0];
-        int kernelH = kernel.Shape._dims[2];
-        int kernelW = kernel.Shape._dims[3];
-
-        int outHeight = gradOutput.Shape._dims[2];
-        int outWidth = gradOutput.Shape._dims[3];
-
-        int offsetChannels = offsets.Shape._dims[1];
-        int deformGroups = offsetChannels / (2 * kernelH * kernelW);
-        int groups = 1;
-
-        int offsetSize = batch * offsetChannels * outHeight * outWidth;
-
-        using var gradOutputBuffer = GetOrAllocateBuffer(backend, gradOutput);
-        using var inputBuffer = GetOrAllocateBuffer(backend, input);
-        using var weightsBuffer = GetOrCacheWeightBuffer(backend, kernel.GetDataArray(), PersistentTensorRole.Weights);
-        using var offsetsBuffer = GetOrAllocateBuffer(backend, offsets);
-        using var gradOffsetBuffer = AllocateOutputBuffer(backend, offsetSize);
-
-        try
-        {
-            OwnedBuffer? maskBuffer = mask != null ? GetOrAllocateBuffer(backend, mask) : null;
-            try
-            {
-                backend.DeformableConv2DBackwardOffset(
-                    inputBuffer.Buffer, weightsBuffer.Buffer, gradOutputBuffer.Buffer, offsetsBuffer.Buffer, maskBuffer?.Buffer, gradOffsetBuffer.Buffer,
-                    batch, inChannels, inHeight, inWidth,
-                    outChannels, outHeight, outWidth,
-                    kernelH, kernelW, stride[0], stride[1], padding[0], padding[1],
-                    dilation[0], dilation[1], groups, deformGroups);
-
-                float[] resultFloat = new float[offsetSize];
-                backend.DownloadBuffer(gradOffsetBuffer.Buffer, resultFloat);
-
-                T[] resultData = DirectGpuEngine.FromFloatArray<T>(resultFloat);
-                return new Tensor<T>(resultData, offsets.Shape._dims);
-            }
-            finally
-            {
-                maskBuffer?.Dispose();
-            }
-        }
-        catch
-        {
-            return base.DeformableConv2DBackwardOffset(gradOutput, input, kernel, offsets, mask, stride, padding, dilation);
-        }
+        // The GPU DeformableConv2DBackwardOffset kernel disagreed with the CPU reference (GpuConvKernelCoverageTests);
+        // route to the correct CPU implementation until the GPU kernel is fixed. The `override`
+        // (vs the prior `new` hide) keeps virtual dispatch correct.
+        return base.DeformableConv2DBackwardOffset(gradOutput, input, kernel, offsets, mask, stride, padding, dilation);
     }
 
     /// <summary>
     /// GPU-accelerated deformable conv2D backward pass for mask gradients (DCNv2).
     /// Falls back to CPU implementation if GPU is unavailable.
     /// </summary>
-    public new Tensor<T> DeformableConv2DBackwardMask<T>(
+    public override Tensor<T> DeformableConv2DBackwardMask<T>(
         Tensor<T> gradOutput,
         Tensor<T> input,
         Tensor<T> kernel,
@@ -6954,60 +6690,10 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int[] padding,
         int[] dilation)
     {
-        // Mask gradient computation requires a valid mask
-        if (mask == null)
-            throw new ArgumentNullException(nameof(mask), "Mask cannot be null when computing mask gradients");
-
-        if (!TryGetBackend(out var backend))
-            return base.DeformableConv2DBackwardMask(gradOutput, input, kernel, offsets, mask, stride, padding, dilation);
-
-        if (gradOutput.Rank != 4 || input.Rank != 4 || kernel.Rank != 4 || mask.Rank != 4)
-            return base.DeformableConv2DBackwardMask(gradOutput, input, kernel, offsets, mask, stride, padding, dilation);
-
-        int batch = input.Shape._dims[0];
-        int inChannels = input.Shape._dims[1];
-        int inHeight = input.Shape._dims[2];
-        int inWidth = input.Shape._dims[3];
-
-        int outChannels = kernel.Shape._dims[0];
-        int kernelH = kernel.Shape._dims[2];
-        int kernelW = kernel.Shape._dims[3];
-
-        int outHeight = gradOutput.Shape._dims[2];
-        int outWidth = gradOutput.Shape._dims[3];
-
-        int offsetChannels = offsets.Shape._dims[1];
-        int deformGroups = offsetChannels / (2 * kernelH * kernelW);
-        int maskChannels = deformGroups * kernelH * kernelW;
-        int groups = 1;
-
-        int maskSize = batch * maskChannels * outHeight * outWidth;
-
-        using var gradOutputBuffer = GetOrAllocateBuffer(backend, gradOutput);
-        using var inputBuffer = GetOrAllocateBuffer(backend, input);
-        using var weightsBuffer = GetOrCacheWeightBuffer(backend, kernel.GetDataArray(), PersistentTensorRole.Weights);
-        using var offsetsBuffer = GetOrAllocateBuffer(backend, offsets);
-        using var gradMaskBuffer = AllocateOutputBuffer(backend, maskSize);
-
-        try
-        {
-            backend.DeformableConv2DBackwardMask(
-                inputBuffer.Buffer, weightsBuffer.Buffer, gradOutputBuffer.Buffer, offsetsBuffer.Buffer, gradMaskBuffer.Buffer,
-                batch, inChannels, inHeight, inWidth,
-                outChannels, outHeight, outWidth,
-                kernelH, kernelW, stride[0], stride[1], padding[0], padding[1],
-                dilation[0], dilation[1], groups, deformGroups);
-
-            float[] resultFloat = new float[maskSize];
-            backend.DownloadBuffer(gradMaskBuffer.Buffer, resultFloat);
-
-            T[] resultData = DirectGpuEngine.FromFloatArray<T>(resultFloat);
-            return new Tensor<T>(resultData, mask.Shape._dims);
-        }
-        catch
-        {
-            return base.DeformableConv2DBackwardMask(gradOutput, input, kernel, offsets, mask, stride, padding, dilation);
-        }
+        // The GPU DeformableConv2DBackwardMask kernel disagreed with the CPU reference (GpuConvKernelCoverageTests);
+        // route to the correct CPU implementation until the GPU kernel is fixed. The `override`
+        // (vs the prior `new` hide) keeps virtual dispatch correct.
+        return base.DeformableConv2DBackwardMask(gradOutput, input, kernel, offsets, mask, stride, padding, dilation);
     }
 
     /// <summary>
@@ -7112,7 +6798,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// Uses cached GPU buffers for registered persistent tensors (gamma/beta/running stats)
     /// to avoid redundant CPU→GPU transfers on every forward pass.
     /// </summary>
-    public new Tensor<T> FusedBatchNorm<T>(
+    public override Tensor<T> FusedBatchNorm<T>(
         Tensor<T> input,
         Tensor<T> gamma,
         Tensor<T> beta,
@@ -7690,7 +7376,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// GPU-accelerated backward pass for FlashAttention.
     /// Uses cached GPU buffers for registered persistent tensors to avoid redundant transfers.
     /// </summary>
-    public new Tensor<T> FlashAttentionBackward<T>(
+    public override Tensor<T> FlashAttentionBackward<T>(
         Tensor<T> gradOutput,
         Tensor<T> query,
         Tensor<T> key,
@@ -7840,7 +7526,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// GPU-accelerated backward pass for Grouped Query Attention.
     /// Uses cached GPU buffers for registered persistent tensors to avoid redundant transfers.
     /// </summary>
-    public new Tensor<T> GroupedQueryAttentionBackward<T>(
+    public override Tensor<T> GroupedQueryAttentionBackward<T>(
         Tensor<T> gradOutput,
         Tensor<T> query,
         Tensor<T> key,
@@ -8359,7 +8045,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// its data to GPU memory. This eliminates repeated CPU-GPU transfers for tensors
     /// that are reused across multiple operations (e.g., layer weights, biases).
     /// </summary>
-    public new void RegisterPersistentTensor<T>(Tensor<T> tensor, PersistentTensorRole role)
+    public override void RegisterPersistentTensor<T>(Tensor<T> tensor, PersistentTensorRole role)
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
         if (tensor.IsSparse)
@@ -8397,7 +8083,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// <summary>
     /// Unregisters a persistent tensor and releases its associated GPU memory.
     /// </summary>
-    public new void UnregisterPersistentTensor<T>(Tensor<T> tensor)
+    public override void UnregisterPersistentTensor<T>(Tensor<T> tensor)
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
         if (tensor.IsSparse)
@@ -8424,7 +8110,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// Invalidates a persistent tensor's GPU buffer, triggering re-upload of its
     /// data to GPU memory. Call this after modifying the tensor's data on CPU.
     /// </summary>
-    public new void InvalidatePersistentTensor<T>(Tensor<T> tensor)
+    public override void InvalidatePersistentTensor<T>(Tensor<T> tensor)
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
         if (tensor.IsSparse)
@@ -11780,7 +11466,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// <summary>
     /// GPU-accelerated ReduceMax operation.
     /// </summary>
-    public new Tensor<T> ReduceMax<T>(Tensor<T> input, int[] axes, bool keepDims, out int[] maxIndices)
+    public override Tensor<T> ReduceMax<T>(Tensor<T> input, int[] axes, bool keepDims, out int[] maxIndices)
     {
         var safeAxes = axes ?? Array.Empty<int>();
         if (!TryGetBackend(out var backend))

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -419,11 +419,11 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     public bool IsGpuAvailable => _directGpu?.IsAvailable == true;
 
-    public new string Name => IsGpuAvailable
-        ? $"Direct GPU Engine ({_directGpu!.BackendName} {_directGpu.DeviceName})"
+    public override string Name => IsGpuAvailable
+        ? $"Direct GPU Engine ({_directGpu?.BackendName} {_directGpu?.DeviceName})"
         : "CPU Engine (DirectGpu unavailable)";
 
-    public new bool SupportsGpu => IsGpuAvailable;
+    public override bool SupportsGpu => IsGpuAvailable;
 
     /// <summary>
     /// Gets or sets the maximum number of activation cache entries.
@@ -437,10 +437,6 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     }
 
     DirectGpuEngine? IEngine.DirectGpu => _directGpu;
-
-    string IEngine.Name => Name;
-
-    bool IEngine.SupportsGpu => SupportsGpu;
 
     /// <summary>
     /// Begins a GPU scope that enables activation caching for intermediate results.

--- a/src/AiDotNet.Tensors/LinearAlgebra/StreamingStoreCodec.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/StreamingStoreCodec.cs
@@ -42,6 +42,15 @@ internal static class StreamingStoreCodec
         return (uint)(x >> 48) & 0xFFFFu; // top 16 bits → uniform [0, 0xFFFF]
     }
 
+    /// <summary>
+    /// Pins the per-thread stochastic-rounding PRNG to a fixed seed for the CURRENT thread.
+    /// Production never calls this — the stream auto-seeds from the managed thread id and stochastic
+    /// rounding is unbiased either way. It exists so convergence tests can make the rounding sequence
+    /// reproducible instead of depending on which pool thread xUnit scheduled them on (and on RNG
+    /// state left by earlier tests on that thread) — the source of intermittent failures.
+    /// </summary>
+    internal static void SeedStochasticRng(ulong seed) => _rngState = seed | 1UL;
+
     private static unsafe uint F32Bits(float v) => *(uint*)&v;
     private static unsafe float BitsF32(uint b) => *(float*)&b;
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuConvKernelCoverageTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuConvKernelCoverageTests.cs
@@ -1,0 +1,231 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
+
+/// <summary>
+/// Dedicated GPU-vs-CPU accuracy coverage for the conv/pool/attention kernels that the generic
+/// auto-differential harness cannot drive (distinct shapes per tensor arg / interdependent geometry).
+/// These kernels were previously hidden from the EveryGpuKernel coverage gate by a `public new` hide on
+/// DirectGpuTensorEngine; once converted to `override` the gate (correctly) demands an accuracy check.
+/// Each test runs the op on a real GPU engine and the CPU reference and asserts element-wise agreement
+/// (TF32-tolerant). They no-op on CPU-only hosts. Shapes for backward ops are derived from a forward pass
+/// so the geometry is always self-consistent.
+/// </summary>
+public sealed class GpuConvKernelCoverageTests : IDisposable
+{
+    private readonly DirectGpuTensorEngine _gpu;
+    private readonly CpuEngine _cpu = new();
+    private readonly bool _ready;
+
+    public GpuConvKernelCoverageTests()
+    {
+        try { _gpu = new DirectGpuTensorEngine(); _ready = _gpu.SupportsGpu; }
+        catch { _ready = false; }
+    }
+
+    public void Dispose() => _gpu?.Dispose();
+
+    private static Tensor<float> R(int seed, params int[] shape)
+    {
+        var rng = new Random(seed);
+        int n = 1; foreach (var d in shape) n *= d;
+        var data = new float[n];
+        for (int i = 0; i < n; i++) data[i] = (float)(rng.NextDouble() - 0.5);
+        return new Tensor<float>(data, shape);
+    }
+
+    private static Tensor<float> Like(int seed, Tensor<float> t)
+    {
+        var rng = new Random(seed);
+        var data = new float[t.Length];
+        for (int i = 0; i < data.Length; i++) data[i] = (float)(rng.NextDouble() + 0.1);
+        return new Tensor<float>(data, t.Shape.ToArray());
+    }
+
+    private static void AssertClose(Tensor<float> cpu, Tensor<float> gpu, string name, float rtol = 2e-2f, float atol = 3e-3f)
+    {
+        Assert.Equal(cpu.Length, gpu.Length);
+        var c = cpu.GetDataArray();
+        var g = gpu.GetDataArray();
+        for (int i = 0; i < c.Length; i++)
+        {
+            float diff = MathF.Abs(c[i] - g[i]);
+            float tol = atol + rtol * MathF.Abs(c[i]);
+            Assert.True(diff <= tol, $"{name}[{i}]: cpu={c[i]:G6} gpu={g[i]:G6} diff={diff:G4} > tol={tol:G4}");
+        }
+    }
+
+    // ---- DepthwiseConv2D ----
+    [Fact]
+    public void DepthwiseConv2D_Gpu_MatchesCpu()
+    {
+        if (!_ready) return;
+        var input = R(1, 1, 2, 5, 5);
+        var kernel = R(2, 2, 1, 3, 3); // [inCh, mult, kH, kW]
+        int[] stride = { 1, 1 }, pad = { 1, 1 };
+        AssertClose(_cpu.DepthwiseConv2D(input, kernel, stride, pad),
+                    _gpu.DepthwiseConv2D(input, kernel, stride, pad), "DepthwiseConv2D");
+    }
+
+    // ---- DeformableConv2D (forward + all four backward) ----
+    private (Tensor<float> input, Tensor<float> kernel, Tensor<float> offset, Tensor<float> mask,
+             int[] stride, int[] pad, int[] dil, Tensor<float> fwd, Tensor<float> grad) DeformSetup()
+    {
+        var input = R(10, 1, 2, 5, 5);
+        var kernel = R(11, 3, 2, 3, 3);            // [outCh, inCh, kH, kW]
+        var offset = R(12, 1, 2 * 3 * 3, 5, 5);    // [B, 2*kH*kW, outH, outW], small deformations
+        var mask = R(13, 1, 3 * 3, 5, 5);          // [B, kH*kW, outH, outW]
+        int[] stride = { 1, 1 }, pad = { 1, 1 }, dil = { 1, 1 };
+        var fwd = _cpu.DeformableConv2D(input, kernel, offset, mask, stride, pad, dil);
+        return (input, kernel, offset, mask, stride, pad, dil, fwd, Like(14, fwd));
+    }
+
+    [Fact]
+    public void DeformableConv2D_Gpu_MatchesCpu()
+    {
+        if (!_ready) return;
+        var s = DeformSetup();
+        AssertClose(s.fwd, _gpu.DeformableConv2D(s.input, s.kernel, s.offset, s.mask, s.stride, s.pad, s.dil),
+                    "DeformableConv2D");
+    }
+
+    [Fact]
+    public void DeformableConv2DBackwardInput_Gpu_MatchesCpu()
+    {
+        if (!_ready) return;
+        var s = DeformSetup();
+        int[] inShape = s.input.Shape.ToArray();
+        AssertClose(
+            _cpu.DeformableConv2DBackwardInput(s.grad, s.input, s.kernel, s.offset, s.mask, inShape, s.stride, s.pad, s.dil),
+            _gpu.DeformableConv2DBackwardInput(s.grad, s.input, s.kernel, s.offset, s.mask, inShape, s.stride, s.pad, s.dil),
+            "DeformableConv2DBackwardInput");
+    }
+
+    [Fact]
+    public void DeformableConv2DBackwardKernel_Gpu_MatchesCpu()
+    {
+        if (!_ready) return;
+        var s = DeformSetup();
+        int[] kShape = s.kernel.Shape.ToArray();
+        AssertClose(
+            _cpu.DeformableConv2DBackwardKernel(s.grad, s.input, s.offset, s.mask, kShape, s.stride, s.pad, s.dil),
+            _gpu.DeformableConv2DBackwardKernel(s.grad, s.input, s.offset, s.mask, kShape, s.stride, s.pad, s.dil),
+            "DeformableConv2DBackwardKernel");
+    }
+
+    [Fact]
+    public void DeformableConv2DBackwardOffset_Gpu_MatchesCpu()
+    {
+        if (!_ready) return;
+        var s = DeformSetup();
+        AssertClose(
+            _cpu.DeformableConv2DBackwardOffset(s.grad, s.input, s.kernel, s.offset, s.mask, s.stride, s.pad, s.dil),
+            _gpu.DeformableConv2DBackwardOffset(s.grad, s.input, s.kernel, s.offset, s.mask, s.stride, s.pad, s.dil),
+            "DeformableConv2DBackwardOffset");
+    }
+
+    [Fact]
+    public void DeformableConv2DBackwardMask_Gpu_MatchesCpu()
+    {
+        if (!_ready) return;
+        var s = DeformSetup();
+        AssertClose(
+            _cpu.DeformableConv2DBackwardMask(s.grad, s.input, s.kernel, s.offset, s.mask, s.stride, s.pad, s.dil),
+            _gpu.DeformableConv2DBackwardMask(s.grad, s.input, s.kernel, s.offset, s.mask, s.stride, s.pad, s.dil),
+            "DeformableConv2DBackwardMask");
+    }
+
+    // ---- FusedConv3D ----
+    [Fact]
+    public void FusedConv3D_Gpu_MatchesCpu()
+    {
+        if (!_ready) return;
+        var input = R(20, 1, 1, 4, 4, 4);   // [B, Cin, D, H, W]
+        var kernel = R(21, 2, 1, 2, 2, 2);  // [Cout, Cin, kD, kH, kW]
+        AssertClose(
+            _cpu.FusedConv3D(input, kernel, null, 1, 1, 1, 0, 0, 0, 1, 1, 1, FusedActivationType.None),
+            _gpu.FusedConv3D(input, kernel, null, 1, 1, 1, 0, 0, 0, 1, 1, 1, FusedActivationType.None),
+            "FusedConv3D");
+    }
+
+    // ---- FusedConvTranspose2D ----
+    [Fact]
+    public void FusedConvTranspose2D_Gpu_MatchesCpu()
+    {
+        if (!_ready) return;
+        var input = R(30, 1, 1, 3, 3);   // [B, Cin, H, W]
+        var kernel = R(31, 1, 2, 2, 2);  // [Cin, Cout, kH, kW]
+        AssertClose(
+            _cpu.FusedConvTranspose2D(input, kernel, null, 2, 2, 0, 0, 0, 0, FusedActivationType.None),
+            _gpu.FusedConvTranspose2D(input, kernel, null, 2, 2, 0, 0, 0, 0, FusedActivationType.None),
+            "FusedConvTranspose2D");
+    }
+
+    // ---- LocallyConnectedConv2D (forward + two backward) ----
+    private (Tensor<float> input, Tensor<float> weights, int[] stride, Tensor<float> fwd, Tensor<float> grad) LocalSetup()
+    {
+        var input = R(40, 1, 1, 3, 3);
+        var weights = R(41, 2, 2, 2, 1, 2, 2); // [outH, outW, outCh, inCh, kH, kW]
+        int[] stride = { 1, 1 };
+        var fwd = _cpu.LocallyConnectedConv2D(input, weights, null, stride);
+        return (input, weights, stride, fwd, Like(42, fwd));
+    }
+
+    [Fact]
+    public void LocallyConnectedConv2D_Gpu_MatchesCpu()
+    {
+        if (!_ready) return;
+        var s = LocalSetup();
+        AssertClose(s.fwd, _gpu.LocallyConnectedConv2D(s.input, s.weights, null, s.stride), "LocallyConnectedConv2D");
+    }
+
+    [Fact]
+    public void LocallyConnectedConv2DBackwardInput_Gpu_MatchesCpu()
+    {
+        if (!_ready) return;
+        var s = LocalSetup();
+        int[] inShape = s.input.Shape.ToArray();
+        AssertClose(
+            _cpu.LocallyConnectedConv2DBackwardInput(s.grad, s.weights, inShape, s.stride),
+            _gpu.LocallyConnectedConv2DBackwardInput(s.grad, s.weights, inShape, s.stride),
+            "LocallyConnectedConv2DBackwardInput");
+    }
+
+    [Fact]
+    public void LocallyConnectedConv2DBackwardWeights_Gpu_MatchesCpu()
+    {
+        if (!_ready) return;
+        var s = LocalSetup();
+        int[] wShape = s.weights.Shape.ToArray();
+        AssertClose(
+            _cpu.LocallyConnectedConv2DBackwardWeights(s.grad, s.input, wShape, s.stride),
+            _gpu.LocallyConnectedConv2DBackwardWeights(s.grad, s.input, wShape, s.stride),
+            "LocallyConnectedConv2DBackwardWeights");
+    }
+
+    // ---- FlashAttentionBackward ----
+    [Fact]
+    public void FlashAttentionBackward_Gpu_MatchesCpu()
+    {
+        if (!_ready) return;
+        // [B, H, S, D]
+        var q = R(50, 1, 2, 4, 8);
+        var k = R(51, 1, 2, 4, 8);
+        var v = R(52, 1, 2, 4, 8);
+        double scale = 1.0 / Math.Sqrt(8);
+        var output = _cpu.FlashAttention(q, k, v, scale, false, out var stats, null);
+        var grad = Like(53, output);
+
+        var dQc = _cpu.FlashAttentionBackward(grad, q, k, v, output, stats, scale, false,
+            out var dKc, out var dVc, out var _unusedC, null);
+        var dQg = _gpu.FlashAttentionBackward(grad, q, k, v, output, stats, scale, false,
+            out var dKg, out var dVg, out var _unusedG, null);
+        // The method returns gradQuery and yields gradKey/gradValue via out params.
+        AssertClose(dQc, dQg, "FlashAttentionBackward.dQ");
+        AssertClose(dKc, dKg, "FlashAttentionBackward.dK");
+        AssertClose(dVc, dVg, "FlashAttentionBackward.dV");
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuConvKernelCoverageTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuConvKernelCoverageTests.cs
@@ -14,6 +14,7 @@ namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
 /// (TF32-tolerant). They no-op on CPU-only hosts. Shapes for backward ops are derived from a forward pass
 /// so the geometry is always self-consistent.
 /// </summary>
+[Collection("DirectGpuSerial")]
 public sealed class GpuConvKernelCoverageTests : IDisposable
 {
     private readonly DirectGpuTensorEngine _gpu;
@@ -27,6 +28,13 @@ public sealed class GpuConvKernelCoverageTests : IDisposable
     }
 
     public void Dispose() => _gpu?.Dispose();
+
+    // Skip (visibly, via Xunit.SkipException) rather than silently `return` when
+    // no GPU is present, so a failed/absent GPU setup shows as a skipped test
+    // instead of a false green. Mirrors the DirectGpu suite's SkipIfUnavailable
+    // convention (e.g. DetectionGpuParityTests).
+    private void SkipIfUnavailable()
+        => Skip.If(!_ready, "DirectGpu/GPU unavailable; skipping GPU-vs-CPU conv coverage.");
 
     private static Tensor<float> R(int seed, params int[] shape)
     {
@@ -59,10 +67,10 @@ public sealed class GpuConvKernelCoverageTests : IDisposable
     }
 
     // ---- DepthwiseConv2D ----
-    [Fact]
+    [SkippableFact]
     public void DepthwiseConv2D_Gpu_MatchesCpu()
     {
-        if (!_ready) return;
+        SkipIfUnavailable();
         var input = R(1, 1, 2, 5, 5);
         var kernel = R(2, 2, 1, 3, 3); // [inCh, mult, kH, kW]
         int[] stride = { 1, 1 }, pad = { 1, 1 };
@@ -83,19 +91,19 @@ public sealed class GpuConvKernelCoverageTests : IDisposable
         return (input, kernel, offset, mask, stride, pad, dil, fwd, Like(14, fwd));
     }
 
-    [Fact]
+    [SkippableFact]
     public void DeformableConv2D_Gpu_MatchesCpu()
     {
-        if (!_ready) return;
+        SkipIfUnavailable();
         var s = DeformSetup();
         AssertClose(s.fwd, _gpu.DeformableConv2D(s.input, s.kernel, s.offset, s.mask, s.stride, s.pad, s.dil),
                     "DeformableConv2D");
     }
 
-    [Fact]
+    [SkippableFact]
     public void DeformableConv2DBackwardInput_Gpu_MatchesCpu()
     {
-        if (!_ready) return;
+        SkipIfUnavailable();
         var s = DeformSetup();
         int[] inShape = s.input.Shape.ToArray();
         AssertClose(
@@ -104,10 +112,10 @@ public sealed class GpuConvKernelCoverageTests : IDisposable
             "DeformableConv2DBackwardInput");
     }
 
-    [Fact]
+    [SkippableFact]
     public void DeformableConv2DBackwardKernel_Gpu_MatchesCpu()
     {
-        if (!_ready) return;
+        SkipIfUnavailable();
         var s = DeformSetup();
         int[] kShape = s.kernel.Shape.ToArray();
         AssertClose(
@@ -116,10 +124,10 @@ public sealed class GpuConvKernelCoverageTests : IDisposable
             "DeformableConv2DBackwardKernel");
     }
 
-    [Fact]
+    [SkippableFact]
     public void DeformableConv2DBackwardOffset_Gpu_MatchesCpu()
     {
-        if (!_ready) return;
+        SkipIfUnavailable();
         var s = DeformSetup();
         AssertClose(
             _cpu.DeformableConv2DBackwardOffset(s.grad, s.input, s.kernel, s.offset, s.mask, s.stride, s.pad, s.dil),
@@ -127,10 +135,10 @@ public sealed class GpuConvKernelCoverageTests : IDisposable
             "DeformableConv2DBackwardOffset");
     }
 
-    [Fact]
+    [SkippableFact]
     public void DeformableConv2DBackwardMask_Gpu_MatchesCpu()
     {
-        if (!_ready) return;
+        SkipIfUnavailable();
         var s = DeformSetup();
         AssertClose(
             _cpu.DeformableConv2DBackwardMask(s.grad, s.input, s.kernel, s.offset, s.mask, s.stride, s.pad, s.dil),
@@ -139,10 +147,10 @@ public sealed class GpuConvKernelCoverageTests : IDisposable
     }
 
     // ---- FusedConv3D ----
-    [Fact]
+    [SkippableFact]
     public void FusedConv3D_Gpu_MatchesCpu()
     {
-        if (!_ready) return;
+        SkipIfUnavailable();
         var input = R(20, 1, 1, 4, 4, 4);   // [B, Cin, D, H, W]
         var kernel = R(21, 2, 1, 2, 2, 2);  // [Cout, Cin, kD, kH, kW]
         AssertClose(
@@ -152,10 +160,10 @@ public sealed class GpuConvKernelCoverageTests : IDisposable
     }
 
     // ---- FusedConvTranspose2D ----
-    [Fact]
+    [SkippableFact]
     public void FusedConvTranspose2D_Gpu_MatchesCpu()
     {
-        if (!_ready) return;
+        SkipIfUnavailable();
         var input = R(30, 1, 1, 3, 3);   // [B, Cin, H, W]
         var kernel = R(31, 1, 2, 2, 2);  // [Cin, Cout, kH, kW]
         AssertClose(
@@ -174,18 +182,18 @@ public sealed class GpuConvKernelCoverageTests : IDisposable
         return (input, weights, stride, fwd, Like(42, fwd));
     }
 
-    [Fact]
+    [SkippableFact]
     public void LocallyConnectedConv2D_Gpu_MatchesCpu()
     {
-        if (!_ready) return;
+        SkipIfUnavailable();
         var s = LocalSetup();
         AssertClose(s.fwd, _gpu.LocallyConnectedConv2D(s.input, s.weights, null, s.stride), "LocallyConnectedConv2D");
     }
 
-    [Fact]
+    [SkippableFact]
     public void LocallyConnectedConv2DBackwardInput_Gpu_MatchesCpu()
     {
-        if (!_ready) return;
+        SkipIfUnavailable();
         var s = LocalSetup();
         int[] inShape = s.input.Shape.ToArray();
         AssertClose(
@@ -194,10 +202,10 @@ public sealed class GpuConvKernelCoverageTests : IDisposable
             "LocallyConnectedConv2DBackwardInput");
     }
 
-    [Fact]
+    [SkippableFact]
     public void LocallyConnectedConv2DBackwardWeights_Gpu_MatchesCpu()
     {
-        if (!_ready) return;
+        SkipIfUnavailable();
         var s = LocalSetup();
         int[] wShape = s.weights.Shape.ToArray();
         AssertClose(
@@ -207,10 +215,10 @@ public sealed class GpuConvKernelCoverageTests : IDisposable
     }
 
     // ---- FlashAttentionBackward ----
-    [Fact]
+    [SkippableFact]
     public void FlashAttentionBackward_Gpu_MatchesCpu()
     {
-        if (!_ready) return;
+        SkipIfUnavailable();
         // [B, H, S, D]
         var q = R(50, 1, 2, 4, 8);
         var k = R(51, 1, 2, 4, 8);

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuAutoDifferentialTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuAutoDifferentialTests.cs
@@ -437,6 +437,23 @@ public sealed class GpuCpuAutoDifferentialTests : IDisposable
     // TODO(gpu-correctness): add dedicated GPU-vs-CPU tests for these and remove them from the list.
     private static readonly HashSet<string> DedicatedlyCovered = new(StringComparer.Ordinal)
     {
+        // Deformable / depthwise / locally-connected conv, 3D / transposed fused conv, FlashAttention
+        // backward — GPU-vs-CPU parity in GpuConvKernelCoverageTests (and MaxPool2DBackward in
+        // MaxPool2DBackwardGpuCorrectnessTests). These were hidden from this gate by a `public new`
+        // hide on DirectGpuTensorEngine until it was converted to `override`.
+        "DeformableConv2D(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Int32[],Int32[],Int32[])",
+        "DeformableConv2DBackwardInput(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Int32[],Int32[],Int32[],Int32[])",
+        "DeformableConv2DBackwardKernel(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Int32[],Int32[],Int32[],Int32[])",
+        "DeformableConv2DBackwardMask(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Int32[],Int32[],Int32[])",
+        "DeformableConv2DBackwardOffset(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Int32[],Int32[],Int32[])",
+        "DepthwiseConv2D(Tensor<T>,Tensor<T>,Int32[],Int32[])",
+        "FlashAttentionBackward(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Double,Boolean,out Tensor<T>,out Tensor<T>,out Tensor<T>,Tensor<T>)",
+        "FusedConv3D(Tensor<T>,Tensor<T>,Tensor<T>,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,FusedActivationType)",
+        "FusedConvTranspose2D(Tensor<T>,Tensor<T>,Tensor<T>,Int32,Int32,Int32,Int32,Int32,Int32,FusedActivationType)",
+        "LocallyConnectedConv2D(Tensor<T>,Tensor<T>,Tensor<T>,Int32[])",
+        "LocallyConnectedConv2DBackwardInput(Tensor<T>,Tensor<T>,Int32[],Int32[])",
+        "LocallyConnectedConv2DBackwardWeights(Tensor<T>,Tensor<T>,Int32[],Int32[])",
+        "MaxPool2DBackward(Tensor<T>,Int32[],Int32[],Int32[],Int32[])",
         // conv / transposed-conv / im2col — distinct input vs. kernel shapes + interdependent geometry
         "Conv3D(Tensor<T>,Tensor<T>,Int32,Int32,Int32)",
         "ConvTranspose2D(Tensor<T>,Tensor<T>,Int32[],Int32[],Int32[])",

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/Bf16MasterWeightConvergenceTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/Bf16MasterWeightConvergenceTests.cs
@@ -42,7 +42,7 @@ public class Bf16MasterWeightConvergenceTests
         StreamingStoreCodec.DecodeFloat(enc, x);
     }
 
-    private static double RunLeastSquares(Store store, int steps)
+    private static double RunLeastSquares(Store store, int steps, ulong stochSeed = 1)
     {
         const int m = 256, n = 48;
         var rng = new Rng(12345);
@@ -59,6 +59,10 @@ public class Bf16MasterWeightConvergenceTests
         double lr = 0.15;     // small enough that late-stage updates approach bf16 grid spacing
         var grad = new double[n];
         var resid = new double[m];
+        // Pin the stochastic-rounding sequence so this run is reproducible regardless of which
+        // xUnit pool thread it lands on (otherwise the thread-static RNG state leaks across tests
+        // and the final loss varies run to run — the intermittent-failure root cause).
+        if (store == Store.Bf16Stoch) StreamingStoreCodec.SeedStochasticRng(stochSeed);
         for (int step = 0; step < steps; step++)
         {
             // resid = A x - b
@@ -80,16 +84,28 @@ public class Bf16MasterWeightConvergenceTests
     public void Bf16Stochastic_TracksFp32_WhileDeterministicStalls()
     {
         const int steps = 4000;
+        const int stochTrials = 8;
         double fp32 = RunLeastSquares(Store.Fp32, steps);
         double det = RunLeastSquares(Store.Bf16Det, steps);
-        double stoch = RunLeastSquares(Store.Bf16Stoch, steps);
+
+        // Stochastic rounding is randomized by construction; assert on its EXPECTED behavior by
+        // averaging several independently-seeded runs rather than a single noisy draw. Each run is
+        // deterministic (seeded), so the mean is reproducible and the gate is stable across machines.
+        double stochSum = 0, stochWorst = 0;
+        for (ulong seed = 1; seed <= stochTrials; seed++)
+        {
+            double v = RunLeastSquares(Store.Bf16Stoch, steps, seed);
+            stochSum += v;
+            stochWorst = Math.Max(stochWorst, v);
+        }
+        double stoch = stochSum / stochTrials;
 
         var outLines = new[]
         {
             $"Final least-squares loss after {steps} steps (lower = better convergence):",
             $"  fp32 store           : {fp32:E3}",
             $"  bf16 deterministic   : {det:E3}  ({det / fp32:F1}x fp32 loss)",
-            $"  bf16 stochastic      : {stoch:E3}  ({stoch / fp32:F1}x fp32 loss)",
+            $"  bf16 stochastic mean : {stoch:E3}  ({stoch / fp32:F1}x fp32 loss; worst of {stochTrials}: {stochWorst / fp32:F1}x)",
         };
         foreach (var l in outLines) _output.WriteLine(l);
 


### PR DESCRIPTION
**Stacked on #613** (the `SupportsGpu`/`Name` fix).

## What
Converts the remaining **21 `public new`** conv/pool/attention/persistent-tensor methods on `DirectGpuTensorEngine` to proper `override` (their `CpuEngine` bases made `virtual`; compiler-verified every signature matched — pure hides). This removes the wrong-dispatch hazard **and** makes the `EveryGpuKernel_IsAutoTestedOrAllowlisted` gate see them — which it should, because they're real GPU kernels that were shipping **without GPU-vs-CPU coverage** while `new`-hidden.

New `GpuConvKernelCoverageTests`: a dedicated GPU-vs-CPU parity test for each of the 13 the generic auto-differential harness can't drive (distinct shapes per tensor arg / interdependent geometry); backward-op shapes derived from a forward pass; the 13 keys registered in `DedicatedlyCovered`.

## Bugs the coverage surfaced
6 of these GPU kernels were **silently producing wrong results** (kept out of the gate by the `new` hide):
- `DeformableConv2D` (forward sign-flip) + all four backward (`Input`/`Kernel`/`Offset`/`Mask`, ~50% off)
- `LocallyConnectedConv2DBackwardWeights` (~30% off)

Those 6 overrides now **route to the verified CPU implementation** (correctness over a wrong GPU path) with a comment flagging the GPU kernel for a future fix. The other 7 — `DepthwiseConv2D`, `FusedConv3D`, `FusedConvTranspose2D`, `LocallyConnectedConv2D`, `LocallyConnectedConv2DBackwardInput`, `FlashAttentionBackward`, `MaxPool2DBackward` — keep their GPU kernels (verified GPU==CPU).

## Verification
`EveryGpuKernel` gate + all 13 coverage tests green. Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive GPU kernel coverage tests validating convolution, attention, and pooling operations across CPU and GPU implementations.
  * Extended automated test coverage for GPU-CPU differential validation.

* **Refactor**
  * Restructured tensor engine architecture to enable custom implementation overrides for advanced tensor operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
## GPU kernel coverage follow-up
Six conv kernels (`LocallyConnectedConv2DBackwardWeights` + `DeformableConv2D` forward/4 backward) currently route to the CPU reference because their GPU kernels disagree with it (surfaced by the new `GpuConvKernelCoverageTests`). Tracked in **#622**; each fallback site carries a `(tracked in #622)` comment.
