### PR TITLE
fix(autodiff): fp64 FusedLinear backward OOM — use transpose-free GEMM (no materialized transpose)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -4382,6 +4382,61 @@ internal static class BackwardFunctions<T>
             return;
         }
 
+        // Double 2D fast path: transposed GEMMs via BlasProvider (transA/transB
+        // handled by the strided kernels — no transpose buffer is materialised),
+        // mirroring the float path above. Without this, fp64 linear layers fall to
+        // the engine fallback below, which builds FULL weight/input transposes via
+        // TensorTranspose → Contiguous(); for a large in-features dim (e.g. a CNN
+        // classifier over un-pooled features) the K×N transpose copy alone is
+        // hundreds of MB and OOMs (ResNet50/fp64 LossStrictlyDecreases crashed here
+        // in ComputeGradientsStreaming, not on convergence).
+        if (typeof(T) == typeof(double) && inputs[0].Rank == 2 && inputs[1].Rank == 2
+            && gradOutput.IsContiguous && GradientTape<T>.Current is null)
+        {
+            int M = inputs[0]._shape[0]; // batch
+            int K = inputs[0]._shape[1]; // in_features
+            int N = inputs[1]._shape[1]; // out_features
+
+            var gArr = (double[])(object)gradOutput.GetDataArray();
+            var inArr = (double[])(object)inputs[0].GetDataArray();
+            var wArr = (double[])(object)inputs[1].GetDataArray();
+
+            var inputGrad = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[0]._shape);
+            var weightGrad = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[1]._shape);
+            var gradInputArr = (double[])(object)inputGrad.GetDataArray();
+            var gradWeightArr = (double[])(object)weightGrad.GetDataArray();
+
+            // dInput[M,K] = dY[M,N] · Wᵀ[N,K]; W stored [K,N] (ldb=N), transB=true.
+            bool okInput = BlasProvider.TryGemmEx(M, K, N, gArr, 0, N, false, wArr, 0, N, true, gradInputArr, 0, K);
+            // dWeight[K,N] = inputᵀ[K,M] · dY[M,N]; input stored [M,K] (lda=K), transA=true.
+            bool okWeight = BlasProvider.TryGemmEx(K, N, M, inArr, 0, K, true, gArr, 0, N, false, gradWeightArr, 0, N);
+
+            if (!(okInput && okWeight))
+            {
+                AutoTensorCache.Return(inputGrad);
+                AutoTensorCache.Return(weightGrad);
+                goto fusedFallback;
+            }
+
+            DifferentiableOps.AccumulateGrad(grads, inputs[0], inputGrad, engine);
+            DifferentiableOps.AccumulateGrad(grads, inputs[1], weightGrad, engine);
+
+            // dL/dbias = sum(gradOutput, axis=0).
+            if (inputs.Length > 2)
+            {
+                var biasGrad = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[2]._shape);
+                var biasArr = (double[])(object)biasGrad.GetDataArray();
+                Array.Clear(biasArr, 0, N);
+                for (int row = 0; row < M; row++)
+                {
+                    int baseIdx = row * N;
+                    for (int j = 0; j < N; j++) biasArr[j] += gArr[baseIdx + j];
+                }
+                DifferentiableOps.AccumulateGrad(grads, inputs[2], biasGrad, engine);
+            }
+            return;
+        }
+
         // Fallback: engine calls (non-float or non-2D, or BLAS refused).
         //
         // Fallback: engine calls (non-float or non-2D, or BLAS refused).

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/FusedLinearGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/FusedLinearGradientTests.cs
@@ -36,6 +36,58 @@ public class FusedLinearGradientTests : IDisposable
         return tensor;
     }
 
+    private static Tensor<double> CreateRandomD(int[] shape, int seed)
+    {
+        var rng = new Random(seed);
+        var tensor = new Tensor<double>(shape);
+        var span = tensor.AsWritableSpan();
+        for (int i = 0; i < span.Length; i++)
+            span[i] = rng.NextDouble() * 2.0 - 1.0;
+        return tensor;
+    }
+
+    // fp64 FusedLinear (no activation) backward must take the transposed-GEMM fast
+    // path (BlasProvider transA/transB), NOT the engine fallback that materialises
+    // full weight/input transposes via TensorTranspose → Contiguous() — the latter
+    // OOMs on large in-features (ResNet50/fp64 crashed in ComputeGradientsStreaming
+    // there). This verifies the double path produces the SAME gradients as the
+    // unfused (MatMul + BroadcastAdd) reference. A wide in-features dim exercises the
+    // dimension whose transpose copy is the OOM risk.
+    [Fact]
+    public void FusedLinear_Double_MatchesUnfusedGradients()
+    {
+        const int M = 4, K = 512, N = 64;
+        var input = CreateRandomD([M, K], 42);
+        var weight = CreateRandomD([K, N], 43);
+        var bias = CreateRandomD([N], 44);
+
+        System.Collections.Generic.Dictionary<Tensor<double>, Tensor<double>> unfusedGrads, fusedGrads;
+        using (var tape = new GradientTape<double>())
+        {
+            var linear = _engine.TensorMatMul(input, weight);
+            var biased = _engine.TensorBroadcastAdd(linear, bias);
+            var loss = _engine.ReduceSum(biased, new[] { 0, 1 }, keepDims: false);
+            unfusedGrads = tape.ComputeGradients(loss, new[] { input, weight, bias });
+        }
+        using (var tape = new GradientTape<double>())
+        {
+            var fused = _engine.FusedLinear(input, weight, bias, FusedActivationType.None);
+            var loss = _engine.ReduceSum(fused, new[] { 0, 1 }, keepDims: false);
+            fusedGrads = tape.ComputeGradients(loss, new[] { input, weight, bias });
+        }
+
+        foreach (var param in new[] { input, weight, bias })
+        {
+            Assert.True(fusedGrads.ContainsKey(param), "Fused gradient missing for parameter");
+            var u = unfusedGrads[param];
+            var f = fusedGrads[param];
+            Assert.Equal(u.Length, f.Length);
+            for (int i = 0; i < u.Length; i++)
+                Assert.True(Math.Abs(u[i] - f[i]) < 1e-9,
+                    $"double FusedLinear grad mismatch at [{i}]: unfused={u[i]:R} fused={f[i]:R}");
+        }
+    }
+
     private void VerifyFusedMatchesUnfused(
         Func<IEngine, Tensor<float>, Tensor<float>, Tensor<float>, Tensor<float>> fusedOp,
         Func<IEngine, Tensor<float>, Tensor<float>> activationOp,


### PR DESCRIPTION
## Summary

`FusedLinearBackwardCore` had a **float-only** 2D fast path that computes the input/weight gradients with transposed GEMMs (`transA`/`transB` flags) and **never materializes a transpose buffer**. For `double`, there was no such path, so fp64 linear backward fell through to the engine fallback — which builds **full weight and input transposes** via `engine.TensorTranspose(...)` → `Tensor.Contiguous()`.

On a large in-features dimension (e.g. a CNN classifier over un-pooled feature maps), that `K × N` transpose copy alone is hundreds of MB. **ResNet50 under fp64 training crashed with `OutOfMemoryException` inside `GradientTape.ComputeGradientsStreaming` → `FusedLinearBackwardCore` → `TensorTranspose` → `Contiguous()`** — i.e. it was a memory bug in the backward, not a convergence failure.

## Fix

Add a `double` rank-2 fast path mirroring the float one:
- `dInput = dY · Wᵀ` via `BlasProvider.TryGemmEx(..., transB: true)`
- `dWeight = inputᵀ · dY` via `BlasProvider.TryGemmEx(..., transA: true)`
- inline bias reduction

`TryGemmEx` routes the transposed operands to `BlasManaged`'s `DgemmDirectParallelMIntoTransA/TransB` strided kernels (or native BLAS), which **handle the transpose without materializing it**. If BLAS refuses, it falls through to the existing fallback unchanged. No behavior change for float or for the non-fast-path shapes.

## Tests

New `FusedLinear_Double_MatchesUnfusedGradients` (in `FusedLinearGradientTests`, CPU-pinned): a wide-in-features fp64 FusedLinear backward must produce the **same** input/weight/bias gradients as the unfused `MatMul + BroadcastAdd` reference — verified to 1e-9 on net10.0 and net471. Full FusedLinear suite stays green (85 passed / 9 pre-existing skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)