### PR TITLE
fix(streaming): deterministic bf16 stochastic-rounding convergence test (unblocks flaky CI)

### DIFF
--- a/src/AiDotNet.Tensors/LinearAlgebra/StreamingStoreCodec.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/StreamingStoreCodec.cs
@@ -42,6 +42,15 @@ internal static class StreamingStoreCodec
         return (uint)(x >> 48) & 0xFFFFu; // top 16 bits → uniform [0, 0xFFFF]
     }
 
+    /// <summary>
+    /// Pins the per-thread stochastic-rounding PRNG to a fixed seed for the CURRENT thread.
+    /// Production never calls this — the stream auto-seeds from the managed thread id and stochastic
+    /// rounding is unbiased either way. It exists so convergence tests can make the rounding sequence
+    /// reproducible instead of depending on which pool thread xUnit scheduled them on (and on RNG
+    /// state left by earlier tests on that thread) — the source of intermittent failures.
+    /// </summary>
+    internal static void SeedStochasticRng(ulong seed) => _rngState = seed | 1UL;
+
     private static unsafe uint F32Bits(float v) => *(uint*)&v;
     private static unsafe float BitsF32(uint b) => *(float*)&b;
 

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/Bf16MasterWeightConvergenceTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/Bf16MasterWeightConvergenceTests.cs
@@ -42,7 +42,7 @@ public class Bf16MasterWeightConvergenceTests
         StreamingStoreCodec.DecodeFloat(enc, x);
     }
 
-    private static double RunLeastSquares(Store store, int steps)
+    private static double RunLeastSquares(Store store, int steps, ulong stochSeed = 1)
     {
         const int m = 256, n = 48;
         var rng = new Rng(12345);
@@ -59,6 +59,10 @@ public class Bf16MasterWeightConvergenceTests
         double lr = 0.15;     // small enough that late-stage updates approach bf16 grid spacing
         var grad = new double[n];
         var resid = new double[m];
+        // Pin the stochastic-rounding sequence so this run is reproducible regardless of which
+        // xUnit pool thread it lands on (otherwise the thread-static RNG state leaks across tests
+        // and the final loss varies run to run — the intermittent-failure root cause).
+        if (store == Store.Bf16Stoch) StreamingStoreCodec.SeedStochasticRng(stochSeed);
         for (int step = 0; step < steps; step++)
         {
             // resid = A x - b
@@ -80,16 +84,28 @@ public class Bf16MasterWeightConvergenceTests
     public void Bf16Stochastic_TracksFp32_WhileDeterministicStalls()
     {
         const int steps = 4000;
+        const int stochTrials = 8;
         double fp32 = RunLeastSquares(Store.Fp32, steps);
         double det = RunLeastSquares(Store.Bf16Det, steps);
-        double stoch = RunLeastSquares(Store.Bf16Stoch, steps);
+
+        // Stochastic rounding is randomized by construction; assert on its EXPECTED behavior by
+        // averaging several independently-seeded runs rather than a single noisy draw. Each run is
+        // deterministic (seeded), so the mean is reproducible and the gate is stable across machines.
+        double stochSum = 0, stochWorst = 0;
+        for (ulong seed = 1; seed <= stochTrials; seed++)
+        {
+            double v = RunLeastSquares(Store.Bf16Stoch, steps, seed);
+            stochSum += v;
+            stochWorst = Math.Max(stochWorst, v);
+        }
+        double stoch = stochSum / stochTrials;
 
         var outLines = new[]
         {
             $"Final least-squares loss after {steps} steps (lower = better convergence):",
             $"  fp32 store           : {fp32:E3}",
             $"  bf16 deterministic   : {det:E3}  ({det / fp32:F1}x fp32 loss)",
-            $"  bf16 stochastic      : {stoch:E3}  ({stoch / fp32:F1}x fp32 loss)",
+            $"  bf16 stochastic mean : {stoch:E3}  ({stoch / fp32:F1}x fp32 loss; worst of {stochTrials}: {stochWorst / fp32:F1}x)",
         };
         foreach (var l in outLines) _output.WriteLine(l);
 


### PR DESCRIPTION
## Problem

`Bf16MasterWeightConvergenceTests.Bf16Stochastic_TracksFp32_WhileDeterministicStalls` fails intermittently in CI, reddening **unrelated** PRs (observed on #614, which only touches OpenCL FP16). It is the one failing test in those PRs' `build` job — compilation is clean.

## Root cause

Stochastic rounding draws from a `[ThreadStatic]` xorshift PRNG (`StreamingStoreCodec`) that auto-seeds off `Thread.CurrentThread.ManagedThreadId` on first use. Under xUnit parallel execution, *which* pool thread runs the test — and what RNG state earlier tests left on that thread — is nondeterministic. The test made a **single** unseeded stochastic run, so its final least-squares loss varied run to run and occasionally crossed the `5× fp32` gate. Pure flakiness, not a real convergence regression.

## Fix (no assertion weakened)

- `StreamingStoreCodec.SeedStochasticRng(seed)` — `internal` hook to pin the per-thread rounding PRNG. **Production is unchanged**: it still auto-seeds from the thread id, and stochastic rounding is unbiased either way.
- The test now seeds each stochastic run and **averages 8 independently-seeded runs**, asserting on the expected (mean) behavior rather than one noisy draw. The `5×` threshold is untouched.

Fully reproducible now (identical across repeated local runs):

```
fp32 store           : 3.420E-009
bf16 deterministic   : 2.832E-004  (82820.6x fp32 loss)   <- stalls, as the thesis predicts
bf16 stochastic mean : 9.253E-009  (2.7x fp32 loss; worst of 8: 3.4x)  <- well under 5x
```

3/3 local runs pass with byte-identical numbers. Builds net10.0 + net471.

Once merged, the open PRs (#614 etc.) go green on re-run without any change to their own diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)