### PR TITLE
perf(autodiff): streaming backward releases intermediate gradients after use (was rooting the whole backward)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
@@ -447,6 +447,23 @@ public sealed class GradientTape<T> : IDisposable
 
                     step.Backward(gradOutput, step.Inputs, step.Output,
                         step.SavedState ?? Array.Empty<object>(), engine, grads);
+
+                    // Release this node-output's gradient now that its backward has
+                    // consumed it. In the reverse topo walk every consumer of this
+                    // output ran earlier, so its gradient is fully accumulated and is
+                    // never read again. Leaving it in `grads` ROOTS it for the rest of
+                    // the walk — and with every intermediate kept, the dict pins the
+                    // FULL backward's worth of gradient tensors at once, so GC can't
+                    // reclaim any of them and a deep net (ResNet50) OOMs. Dropping the
+                    // reference here unroots it so GC bounds the streaming peak to the
+                    // live frontier. Sources are leaves (never a step Output) and are
+                    // emitted + released separately below; the lastUse guard keeps this
+                    // from touching them.
+                    if (step.Output is not null && !lastUse.ContainsKey(step.Output))
+                    {
+                        grads.Remove(step.Output);
+                        step.Output.Grad = null;
+                    }
                 }
 
                 // Emit + release every source whose gradient just completed.


### PR DESCRIPTION
## Summary

`GradientTape.ComputeGradientsStreaming` is the memory-bounded backward used for large models. It released **source** (leaf parameter) gradients at their last use, but **never removed intermediate node-output gradients** from the `grads` dictionary during the reverse walk.

Because the dict holds a live reference, every intermediate gradient stayed **rooted for the entire backward**. So the dictionary pinned the *full backward's worth* of gradient tensors at once, GC couldn't reclaim any of them mid-walk, and the "streaming" peak was actually unbounded (proportional to graph depth). Deep nets (e.g. ResNet50) OOM.

## Fix

Each node-output gradient is consumed exactly once — by that node's own backward — and is never read again (in reverse-topo order all of its consumers ran earlier, so its gradient is fully accumulated by the time its own step runs). So right after the step's backward executes, drop the entry from `grads` and clear the per-tensor `.Grad` mirror, unrooting it so GC can bound the live set to the active frontier.

- Sources are leaves (never a step `Output`) and keep their existing emit+release path; a `lastUse` guard prevents this from touching them.
- No change to which gradients are produced or their values — only *when the intermediate references are dropped*.

## Tests

`GradientTapeStreamingTests` (gradient-correctness vs the non-streaming path) stays green — 4/4 on net10.0 and net471.

## Note

This is a correctness/footprint fix for the streaming path in general (it benefits any model trained through the memory-bounded path). It is **not** by itself a complete fix for ResNet50's training OOM — that model also has a large forward-activation footprint and high per-iteration transient-allocation/GC pressure; this PR removes the streaming backward's depth-proportional rooting, one contributor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)