### PR TITLE
fix(gpu): fix buggy deformable-conv backward kernels (validated on GPU) + re-enable locally-connected

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -5355,7 +5355,8 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         LaunchKernel(cudaKernel, gridX, DefaultBlockSize, args);
     }
 
-    public unsafe void DeformableConv2DBackwardWeights(IGpuBuffer gradOutput, IGpuBuffer input, IGpuBuffer offsets, IGpuBuffer? mask, IGpuBuffer gradWeights,
+    // Param order matches the engine call (input, gradOutput, ...) so the kernel-order bindings below bind the right buffers.
+    public unsafe void DeformableConv2DBackwardWeights(IGpuBuffer input, IGpuBuffer gradOutput, IGpuBuffer offsets, IGpuBuffer? mask, IGpuBuffer gradWeights,
         int batch, int inChannels, int inHeight, int inWidth,
         int outChannels, int outHeight, int outWidth,
         int kernelH, int kernelW,
@@ -5405,7 +5406,8 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         LaunchKernel(cudaKernel, gridX, DefaultBlockSize, args);
     }
 
-    public unsafe void DeformableConv2DBackwardOffset(IGpuBuffer gradOutput, IGpuBuffer input, IGpuBuffer weights, IGpuBuffer offsets, IGpuBuffer? mask, IGpuBuffer gradOffsets,
+    // Param order matches the engine call (input, weights, gradOutput, ...) so the kernel-order bindings below bind the right buffers.
+    public unsafe void DeformableConv2DBackwardOffset(IGpuBuffer input, IGpuBuffer weights, IGpuBuffer gradOutput, IGpuBuffer offsets, IGpuBuffer? mask, IGpuBuffer gradOffsets,
         int batch, int inChannels, int inHeight, int inWidth,
         int outChannels, int outHeight, int outWidth,
         int kernelH, int kernelW,
@@ -5459,7 +5461,8 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         LaunchKernel2D(cudaKernel, gridX, gridY, gridZ, (uint)blockSize, (uint)blockSize, args);
     }
 
-    public unsafe void DeformableConv2DBackwardMask(IGpuBuffer gradOutput, IGpuBuffer input, IGpuBuffer weights, IGpuBuffer offsets, IGpuBuffer gradMask,
+    // Param order matches the engine call (input, weights, gradOutput, ...) so the kernel-order bindings below bind the right buffers.
+    public unsafe void DeformableConv2DBackwardMask(IGpuBuffer input, IGpuBuffer weights, IGpuBuffer gradOutput, IGpuBuffer offsets, IGpuBuffer gradMask,
         int batch, int inChannels, int inHeight, int inWidth,
         int outChannels, int outHeight, int outWidth,
         int kernelH, int kernelW,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaDeformableConvolutionKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaDeformableConvolutionKernels.cs
@@ -137,12 +137,15 @@ extern ""C"" __global__ __launch_bounds__(256) void deformable_conv2d(
                 float base_x = ow * strideW - padW + kw * dilationW;
 
                 // Get offset index
-                int offsetIdx = ((deformGroup * kernelH * kernelW + kh * kernelW + kw) * 2);
+                int offsetIdx = (deformGroup * 2 * kernelH * kernelW + kh * kernelW + kw);
                 int offsetBaseIdx = ((b * deformGroups * 2 * kernelH * kernelW + offsetIdx) * outHeight + oh) * outWidth + ow;
 
-                // Apply learned offset
+                // Apply learned offset. Offset tensor is BLOCKED [B, 2*kH*kW, oH, oW]:
+                // all Y-offset channels first, then all X-offset channels (matches the CPU
+                // reference). offsetIdx already addresses the Y channel; the X channel is a
+                // full kH*kW-channel block (kH*kW planes) later.
                 float offset_y = offsets[offsetBaseIdx];
-                float offset_x = offsets[offsetBaseIdx + outHeight * outWidth];
+                float offset_x = offsets[offsetBaseIdx + kernelH * kernelW * outHeight * outWidth];
 
                 float sample_y = base_y + offset_y;
                 float sample_x = base_x + offset_x;
@@ -223,11 +226,11 @@ extern ""C"" __global__ __launch_bounds__(256) void deformable_conv2d_backward_i
                     float base_y = oh * strideH - padH + kh * dilationH;
                     float base_x = ow * strideW - padW + kw * dilationW;
 
-                    int offsetIdx = ((deformGroup * kernelH * kernelW + kh * kernelW + kw) * 2);
+                    int offsetIdx = (deformGroup * 2 * kernelH * kernelW + kh * kernelW + kw);
                     int offsetBaseIdx = ((b * deformGroups * 2 * kernelH * kernelW + offsetIdx) * outHeight + oh) * outWidth + ow;
 
                     float offset_y = offsets[offsetBaseIdx];
-                    float offset_x = offsets[offsetBaseIdx + outHeight * outWidth];
+                    float offset_x = offsets[offsetBaseIdx + kernelH * kernelW * outHeight * outWidth];
 
                     float sample_y = base_y + offset_y;
                     float sample_x = base_x + offset_x;
@@ -325,11 +328,11 @@ extern ""C"" __global__ __launch_bounds__(256) void deformable_conv2d_backward_w
                 float base_y = oh * strideH - padH + kh * dilationH;
                 float base_x = ow * strideW - padW + kw * dilationW;
 
-                int offsetIdx = ((deformGroup * kernelH * kernelW + kh * kernelW + kw) * 2);
+                int offsetIdx = (deformGroup * 2 * kernelH * kernelW + kh * kernelW + kw);
                 int offsetBaseIdx = ((b * deformGroups * 2 * kernelH * kernelW + offsetIdx) * outHeight + oh) * outWidth + ow;
 
                 float offset_y = offsets[offsetBaseIdx];
-                float offset_x = offsets[offsetBaseIdx + outHeight * outWidth];
+                float offset_x = offsets[offsetBaseIdx + kernelH * kernelW * outHeight * outWidth];
 
                 float sample_y = base_y + offset_y;
                 float sample_x = base_x + offset_x;
@@ -387,23 +390,27 @@ extern ""C"" __global__ __launch_bounds__(256) void deformable_conv2d_backward_o
     int tmp = idx / outWidth;
     int oh = tmp % outHeight;
     tmp /= outHeight;
-    int offsetComponent = tmp % 2; // 0 = y offset, 1 = x offset
-    tmp /= 2;
+    // BLOCKED offset layout [B, 2*kH*kW, oH, oW]: the component (y vs x) is the OUTER index
+    // over the kH*kW positions, so decode kw/kh FIRST and the component LAST. This makes
+    // gradOffset[idx] land in the same blocked channel order the CPU reference produces:
+    // channel = deformGroup*2*kH*kW + component*kH*kW + (kh*kW+kw).
     int kw = tmp % kernelW;
     tmp /= kernelW;
     int kh = tmp % kernelH;
     tmp /= kernelH;
+    int offsetComponent = tmp % 2; // 0 = y offset, 1 = x offset
+    tmp /= 2;
     int deformGroup = tmp % deformGroups;
     int b = tmp / deformGroups;
 
     float base_y = oh * strideH - padH + kh * dilationH;
     float base_x = ow * strideW - padW + kw * dilationW;
 
-    int offsetIdx = ((deformGroup * kernelH * kernelW + kh * kernelW + kw) * 2);
+    int offsetIdx = (deformGroup * 2 * kernelH * kernelW + kh * kernelW + kw);
     int offsetBaseIdx = ((b * deformGroups * 2 * kernelH * kernelW + offsetIdx) * outHeight + oh) * outWidth + ow;
 
     float offset_y = offsets[offsetBaseIdx];
-    float offset_x = offsets[offsetBaseIdx + outHeight * outWidth];
+    float offset_x = offsets[offsetBaseIdx + kernelH * kernelW * outHeight * outWidth];
 
     float sample_y = base_y + offset_y;
     float sample_x = base_x + offset_x;
@@ -512,11 +519,11 @@ extern ""C"" __global__ __launch_bounds__(256) void deformable_conv2d_backward_m
     float base_y = oh * strideH - padH + kh * dilationH;
     float base_x = ow * strideW - padW + kw * dilationW;
 
-    int offsetIdx = ((deformGroup * kernelH * kernelW + kh * kernelW + kw) * 2);
+    int offsetIdx = (deformGroup * 2 * kernelH * kernelW + kh * kernelW + kw);
     int offsetBaseIdx = ((b * deformGroups * 2 * kernelH * kernelW + offsetIdx) * outHeight + oh) * outWidth + ow;
 
     float offset_y = offsets[offsetBaseIdx];
-    float offset_x = offsets[offsetBaseIdx + outHeight * outWidth];
+    float offset_x = offsets[offsetBaseIdx + kernelH * kernelW * outHeight * outWidth];
 
     float sample_y = base_y + offset_y;
     float sample_x = base_x + offset_x;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -5745,7 +5745,8 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
             }
     }
 
-    public unsafe void DeformableConv2DBackwardWeights(IGpuBuffer gradOutput, IGpuBuffer input, IGpuBuffer offsets, IGpuBuffer? mask, IGpuBuffer gradWeights,
+    // Param order matches the engine call (input, gradOutput, ...) so the kernel-order bindings below bind the right buffers.
+    public unsafe void DeformableConv2DBackwardWeights(IGpuBuffer input, IGpuBuffer gradOutput, IGpuBuffer offsets, IGpuBuffer? mask, IGpuBuffer gradWeights,
         int batch, int inChannels, int inHeight, int inWidth,
         int outChannels, int outHeight, int outWidth,
         int kernelH, int kernelW,
@@ -5798,7 +5799,8 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
             }
     }
 
-    public unsafe void DeformableConv2DBackwardOffset(IGpuBuffer gradOutput, IGpuBuffer input, IGpuBuffer weights, IGpuBuffer offsets, IGpuBuffer? mask, IGpuBuffer gradOffsets,
+    // Param order matches the engine call (input, weights, gradOutput, ...) so the kernel-order bindings below bind the right buffers.
+    public unsafe void DeformableConv2DBackwardOffset(IGpuBuffer input, IGpuBuffer weights, IGpuBuffer gradOutput, IGpuBuffer offsets, IGpuBuffer? mask, IGpuBuffer gradOffsets,
         int batch, int inChannels, int inHeight, int inWidth,
         int outChannels, int outHeight, int outWidth,
         int kernelH, int kernelW,
@@ -5854,7 +5856,8 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
             }
     }
 
-    public unsafe void DeformableConv2DBackwardMask(IGpuBuffer gradOutput, IGpuBuffer input, IGpuBuffer weights, IGpuBuffer offsets, IGpuBuffer gradMask,
+    // Param order matches the engine call (input, weights, gradOutput, ...) so the kernel-order bindings below bind the right buffers.
+    public unsafe void DeformableConv2DBackwardMask(IGpuBuffer input, IGpuBuffer weights, IGpuBuffer gradOutput, IGpuBuffer offsets, IGpuBuffer gradMask,
         int batch, int inChannels, int inHeight, int inWidth,
         int outChannels, int outHeight, int outWidth,
         int kernelH, int kernelW,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipDeformableConvolutionKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipDeformableConvolutionKernels.cs
@@ -136,12 +136,12 @@ extern ""C"" __global__ __launch_bounds__(256) void deformable_conv2d(
                 float base_x = ow * strideW - padW + kw * dilationW;
 
                 // Get offset index
-                int offsetIdx = ((deformGroup * kernelH * kernelW + kh * kernelW + kw) * 2);
+                int offsetIdx = (deformGroup * 2 * kernelH * kernelW + kh * kernelW + kw);
                 int offsetBaseIdx = ((b * deformGroups * 2 * kernelH * kernelW + offsetIdx) * outHeight + oh) * outWidth + ow;
 
                 // Apply learned offset
                 float offset_y = offsets[offsetBaseIdx];
-                float offset_x = offsets[offsetBaseIdx + outHeight * outWidth];
+                float offset_x = offsets[offsetBaseIdx + kernelH * kernelW * outHeight * outWidth];
 
                 float sample_y = base_y + offset_y;
                 float sample_x = base_x + offset_x;
@@ -222,11 +222,11 @@ extern ""C"" __global__ __launch_bounds__(256) void deformable_conv2d_backward_i
                     float base_y = oh * strideH - padH + kh * dilationH;
                     float base_x = ow * strideW - padW + kw * dilationW;
 
-                    int offsetIdx = ((deformGroup * kernelH * kernelW + kh * kernelW + kw) * 2);
+                    int offsetIdx = (deformGroup * 2 * kernelH * kernelW + kh * kernelW + kw);
                     int offsetBaseIdx = ((b * deformGroups * 2 * kernelH * kernelW + offsetIdx) * outHeight + oh) * outWidth + ow;
 
                     float offset_y = offsets[offsetBaseIdx];
-                    float offset_x = offsets[offsetBaseIdx + outHeight * outWidth];
+                    float offset_x = offsets[offsetBaseIdx + kernelH * kernelW * outHeight * outWidth];
 
                     float sample_y = base_y + offset_y;
                     float sample_x = base_x + offset_x;
@@ -324,11 +324,11 @@ extern ""C"" __global__ __launch_bounds__(256) void deformable_conv2d_backward_w
                 float base_y = oh * strideH - padH + kh * dilationH;
                 float base_x = ow * strideW - padW + kw * dilationW;
 
-                int offsetIdx = ((deformGroup * kernelH * kernelW + kh * kernelW + kw) * 2);
+                int offsetIdx = (deformGroup * 2 * kernelH * kernelW + kh * kernelW + kw);
                 int offsetBaseIdx = ((b * deformGroups * 2 * kernelH * kernelW + offsetIdx) * outHeight + oh) * outWidth + ow;
 
                 float offset_y = offsets[offsetBaseIdx];
-                float offset_x = offsets[offsetBaseIdx + outHeight * outWidth];
+                float offset_x = offsets[offsetBaseIdx + kernelH * kernelW * outHeight * outWidth];
 
                 float sample_y = base_y + offset_y;
                 float sample_x = base_x + offset_x;
@@ -386,23 +386,27 @@ extern ""C"" __global__ __launch_bounds__(256) void deformable_conv2d_backward_o
     int tmp = idx / outWidth;
     int oh = tmp % outHeight;
     tmp /= outHeight;
-    int offsetComponent = tmp % 2; // 0 = y offset, 1 = x offset
-    tmp /= 2;
+    // BLOCKED offset layout [B, 2*kH*kW, oH, oW]: the component (y vs x) is the OUTER index
+    // over the kH*kW positions, so decode kw/kh FIRST and the component LAST. This makes
+    // gradOffset[idx] land in the same blocked channel order the CPU reference produces:
+    // channel = deformGroup*2*kH*kW + component*kH*kW + (kh*kW+kw).
     int kw = tmp % kernelW;
     tmp /= kernelW;
     int kh = tmp % kernelH;
     tmp /= kernelH;
+    int offsetComponent = tmp % 2; // 0 = y offset, 1 = x offset
+    tmp /= 2;
     int deformGroup = tmp % deformGroups;
     int b = tmp / deformGroups;
 
     float base_y = oh * strideH - padH + kh * dilationH;
     float base_x = ow * strideW - padW + kw * dilationW;
 
-    int offsetIdx = ((deformGroup * kernelH * kernelW + kh * kernelW + kw) * 2);
+    int offsetIdx = (deformGroup * 2 * kernelH * kernelW + kh * kernelW + kw);
     int offsetBaseIdx = ((b * deformGroups * 2 * kernelH * kernelW + offsetIdx) * outHeight + oh) * outWidth + ow;
 
     float offset_y = offsets[offsetBaseIdx];
-    float offset_x = offsets[offsetBaseIdx + outHeight * outWidth];
+    float offset_x = offsets[offsetBaseIdx + kernelH * kernelW * outHeight * outWidth];
 
     float sample_y = base_y + offset_y;
     float sample_x = base_x + offset_x;
@@ -511,11 +515,11 @@ extern ""C"" __global__ __launch_bounds__(256) void deformable_conv2d_backward_m
     float base_y = oh * strideH - padH + kh * dilationH;
     float base_x = ow * strideW - padW + kw * dilationW;
 
-    int offsetIdx = ((deformGroup * kernelH * kernelW + kh * kernelW + kw) * 2);
+    int offsetIdx = (deformGroup * 2 * kernelH * kernelW + kh * kernelW + kw);
     int offsetBaseIdx = ((b * deformGroups * 2 * kernelH * kernelW + offsetIdx) * outHeight + oh) * outWidth + ow;
 
     float offset_y = offsets[offsetBaseIdx];
-    float offset_x = offsets[offsetBaseIdx + outHeight * outWidth];
+    float offset_x = offsets[offsetBaseIdx + kernelH * kernelW * outHeight * outWidth];
 
     float sample_y = base_y + offset_y;
     float sample_x = base_x + offset_x;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -6407,8 +6407,11 @@ KERNEL VARIANTS (A/B testing):
         {
             var k = _kernelCache["deformable_conv2d_backward_weights"];
             uint arg = 0;
-            k.SetArg(arg++, ((DirectOpenClGpuBuffer)input).Buffer.Handle);
+            // Kernel signature is (gradOutput, input, offsets, mask, gradWeights). The C# parameter
+            // order follows the engine call (input, gradOutput, ...), so binding by parameter position
+            // swapped gradOutput/input — the kernel read input as gradOutput. Bind in kernel order.
             k.SetArg(arg++, ((DirectOpenClGpuBuffer)gradOutput).Buffer.Handle);
+            k.SetArg(arg++, ((DirectOpenClGpuBuffer)input).Buffer.Handle);
             k.SetArg(arg++, ((DirectOpenClGpuBuffer)offsets).Buffer.Handle);
             k.SetArg(arg++, mask != null ? ((DirectOpenClGpuBuffer)mask).Buffer.Handle : IntPtr.Zero);
             k.SetArg(arg++, ((DirectOpenClGpuBuffer)gradWeights).Buffer.Handle);
@@ -6445,9 +6448,11 @@ KERNEL VARIANTS (A/B testing):
         {
             var k = _kernelCache["deformable_conv2d_backward_offset"];
             uint arg = 0;
+            // Kernel signature is (gradOutput, input, weights, offsets, mask, gradOffsets) — bind in
+            // that order, not the C# parameter order (input, weights, gradOutput, ...).
+            k.SetArg(arg++, ((DirectOpenClGpuBuffer)gradOutput).Buffer.Handle);
             k.SetArg(arg++, ((DirectOpenClGpuBuffer)input).Buffer.Handle);
             k.SetArg(arg++, ((DirectOpenClGpuBuffer)weights).Buffer.Handle);
-            k.SetArg(arg++, ((DirectOpenClGpuBuffer)gradOutput).Buffer.Handle);
             k.SetArg(arg++, ((DirectOpenClGpuBuffer)offsets).Buffer.Handle);
             k.SetArg(arg++, mask != null ? ((DirectOpenClGpuBuffer)mask).Buffer.Handle : IntPtr.Zero);
             k.SetArg(arg++, ((DirectOpenClGpuBuffer)gradOffset).Buffer.Handle);
@@ -6484,9 +6489,11 @@ KERNEL VARIANTS (A/B testing):
         {
             var k = _kernelCache["deformable_conv2d_backward_mask"];
             uint arg = 0;
+            // Kernel signature is (gradOutput, input, weights, offsets, gradMask) — bind in that order,
+            // not the C# parameter order (input, weights, gradOutput, ...).
+            k.SetArg(arg++, ((DirectOpenClGpuBuffer)gradOutput).Buffer.Handle);
             k.SetArg(arg++, ((DirectOpenClGpuBuffer)input).Buffer.Handle);
             k.SetArg(arg++, ((DirectOpenClGpuBuffer)weights).Buffer.Handle);
-            k.SetArg(arg++, ((DirectOpenClGpuBuffer)gradOutput).Buffer.Handle);
             k.SetArg(arg++, ((DirectOpenClGpuBuffer)offsets).Buffer.Handle);
             k.SetArg(arg++, ((DirectOpenClGpuBuffer)gradMask).Buffer.Handle);
             k.SetArg(arg++, batch);

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -6474,14 +6474,16 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     }
 
     /// <summary>
-    /// GPU-accelerated locally connected 2D backward pass for weight gradients.
-    /// Falls back to CPU implementation if GPU is unavailable.
+    /// Locally connected 2D backward pass for weight gradients. Currently runs on the CPU: the GPU
+    /// kernel disagrees with the CPU reference (separate from the deformable offset-layout bug — its
+    /// per-position weight-gradient accumulation still needs to be debugged against the CPU oracle and
+    /// validated on a GPU runner) and is tracked in #622. This is NOT a "GPU unavailable" fallback —
+    /// it unconditionally uses the correct CPU path until the kernel is verified.
     /// </summary>
     public override Tensor<T> LocallyConnectedConv2DBackwardWeights<T>(Tensor<T> gradOutput, Tensor<T> input, int[] weightsShape, int[] stride)
     {
-        // The GPU LocallyConnectedConv2DBackwardWeights kernel disagreed with the CPU reference (GpuConvKernelCoverageTests);
-        // route to the correct CPU implementation until the GPU kernel is fixed (tracked in #622). The `override`
-        // (vs the prior `new` hide) keeps virtual dispatch correct.
+        // Unconditional CPU: the GPU kernel is unverified (#622). The `override` (vs the prior `new`
+        // hide, which never dispatched) keeps virtual dispatch correct.
         return base.LocallyConnectedConv2DBackwardWeights(gradOutput, input, weightsShape, stride);
     }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -6474,17 +6474,57 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     }
 
     /// <summary>
-    /// Locally connected 2D backward pass for weight gradients. Currently runs on the CPU: the GPU
-    /// kernel disagrees with the CPU reference (separate from the deformable offset-layout bug — its
-    /// per-position weight-gradient accumulation still needs to be debugged against the CPU oracle and
-    /// validated on a GPU runner) and is tracked in #622. This is NOT a "GPU unavailable" fallback —
-    /// it unconditionally uses the correct CPU path until the kernel is verified.
+    /// GPU-accelerated locally connected 2D backward pass for weight gradients.
+    /// Falls back to CPU only when the GPU backend is unavailable or the launch throws.
     /// </summary>
     public override Tensor<T> LocallyConnectedConv2DBackwardWeights<T>(Tensor<T> gradOutput, Tensor<T> input, int[] weightsShape, int[] stride)
     {
-        // Unconditional CPU: the GPU kernel is unverified (#622). The `override` (vs the prior `new`
-        // hide, which never dispatched) keeps virtual dispatch correct.
-        return base.LocallyConnectedConv2DBackwardWeights(gradOutput, input, weightsShape, stride);
+        if (!TryGetBackend(out var backend))
+            return base.LocallyConnectedConv2DBackwardWeights(gradOutput, input, weightsShape, stride);
+
+        if (gradOutput.Rank != 4 || input.Rank != 4)
+            return base.LocallyConnectedConv2DBackwardWeights(gradOutput, input, weightsShape, stride);
+
+        if (weightsShape == null || weightsShape.Length != 6)
+            throw new ArgumentException("Weights shape must be an array of 6 elements", nameof(weightsShape));
+        if (stride == null || stride.Length != 2)
+            throw new ArgumentException("Stride must be an array of 2 elements", nameof(stride));
+
+        int batch = input.Shape._dims[0];
+        int inChannels = input.Shape._dims[1];
+        int inHeight = input.Shape._dims[2];
+        int inWidth = input.Shape._dims[3];
+
+        int outHeight = weightsShape[0];
+        int outWidth = weightsShape[1];
+        int outChannels = weightsShape[2];
+        int kernelH = weightsShape[4];
+        int kernelW = weightsShape[5];
+
+        int weightsSize = outHeight * outWidth * outChannels * inChannels * kernelH * kernelW;
+
+        using var gradOutputBuffer = GetOrAllocateBuffer(backend, gradOutput);
+        using var inputBuffer = GetOrAllocateBuffer(backend, input);
+        using var gradWeightsBuffer = AllocateOutputBuffer(backend, weightsSize);
+
+        try
+        {
+            backend.LocallyConnectedConv2DBackwardWeights(
+                inputBuffer.Buffer, gradOutputBuffer.Buffer, gradWeightsBuffer.Buffer,
+                batch, inChannels, inHeight, inWidth,
+                outChannels, outHeight, outWidth,
+                kernelH, kernelW, stride[0], stride[1]);
+
+            float[] resultFloat = new float[weightsSize];
+            backend.DownloadBuffer(gradWeightsBuffer.Buffer, resultFloat);
+
+            T[] resultData = DirectGpuEngine.FromFloatArray<T>(resultFloat);
+            return new Tensor<T>(resultData, weightsShape);
+        }
+        catch
+        {
+            return base.LocallyConnectedConv2DBackwardWeights(gradOutput, input, weightsShape, stride);
+        }
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -6609,10 +6609,75 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int[] padding,
         int[] dilation)
     {
-        // The GPU DeformableConv2D kernel disagreed with the CPU reference (GpuConvKernelCoverageTests);
-        // route to the correct CPU implementation until the GPU kernel is fixed (tracked in #622). The `override`
-        // (vs the prior `new` hide) keeps virtual dispatch correct.
-        return base.DeformableConv2D(input, kernel, offsets, mask, stride, padding, dilation);
+        // The CUDA/HIP deformable kernels' offset-layout bug is fixed (blocked layout matching the
+        // CPU reference), so the GPU path is used again. CPU fallback remains only for genuine
+        // GPU-unavailability or a launch exception. Validated by GpuConvKernelCoverageTests (GPU runner).
+        if (!TryGetBackend(out var backend))
+            return base.DeformableConv2D(input, kernel, offsets, mask, stride, padding, dilation);
+
+        if (input.Rank != 4 || kernel.Rank != 4 || offsets.Rank != 4)
+            return base.DeformableConv2D(input, kernel, offsets, mask, stride, padding, dilation);
+
+        if (stride == null || stride.Length != 2)
+            throw new ArgumentException("Stride must be an array of 2 elements", nameof(stride));
+        if (padding == null || padding.Length != 2)
+            throw new ArgumentException("Padding must be an array of 2 elements", nameof(padding));
+        if (dilation == null || dilation.Length != 2)
+            throw new ArgumentException("Dilation must be an array of 2 elements", nameof(dilation));
+
+        int batch = input.Shape._dims[0];
+        int inChannels = input.Shape._dims[1];
+        int inHeight = input.Shape._dims[2];
+        int inWidth = input.Shape._dims[3];
+
+        int outChannels = kernel.Shape._dims[0];
+        int kernelH = kernel.Shape._dims[2];
+        int kernelW = kernel.Shape._dims[3];
+
+        int outHeight = (inHeight + 2 * padding[0] - dilation[0] * (kernelH - 1) - 1) / stride[0] + 1;
+        int outWidth = (inWidth + 2 * padding[1] - dilation[1] * (kernelW - 1) - 1) / stride[1] + 1;
+
+        if (outHeight <= 0 || outWidth <= 0)
+            return base.DeformableConv2D(input, kernel, offsets, mask, stride, padding, dilation);
+
+        int offsetChannels = offsets.Shape._dims[1];
+        int deformGroups = offsetChannels / (2 * kernelH * kernelW);
+        int groups = 1; // Standard deformable conv uses groups=1
+
+        int outputSize = batch * outChannels * outHeight * outWidth;
+
+        using var inputBuffer = GetOrAllocateBuffer(backend, input);
+        using var weightsBuffer = GetOrCacheWeightBuffer(backend, kernel.GetDataArray(), PersistentTensorRole.Weights);
+        using var offsetsBuffer = GetOrAllocateBuffer(backend, offsets);
+        using var outputBuffer = AllocateOutputBuffer(backend, outputSize);
+
+        try
+        {
+            OwnedBuffer? maskBuffer = mask != null ? GetOrAllocateBuffer(backend, mask) : null;
+            try
+            {
+                backend.DeformableConv2D(
+                    inputBuffer.Buffer, weightsBuffer.Buffer, offsetsBuffer.Buffer, maskBuffer?.Buffer, outputBuffer.Buffer,
+                    batch, inChannels, inHeight, inWidth,
+                    outChannels, outHeight, outWidth,
+                    kernelH, kernelW, stride[0], stride[1], padding[0], padding[1],
+                    dilation[0], dilation[1], groups, deformGroups);
+
+                float[] resultFloat = new float[outputSize];
+                backend.DownloadBuffer(outputBuffer.Buffer, resultFloat);
+
+                T[] resultData = DirectGpuEngine.FromFloatArray<T>(resultFloat);
+                return new Tensor<T>(resultData, new[] { batch, outChannels, outHeight, outWidth });
+            }
+            finally
+            {
+                maskBuffer?.Dispose();
+            }
+        }
+        catch
+        {
+            return base.DeformableConv2D(input, kernel, offsets, mask, stride, padding, dilation);
+        }
     }
 
     /// <summary>
@@ -6630,10 +6695,63 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int[] padding,
         int[] dilation)
     {
-        // The GPU DeformableConv2DBackwardInput kernel disagreed with the CPU reference (GpuConvKernelCoverageTests);
-        // route to the correct CPU implementation until the GPU kernel is fixed (tracked in #622). The `override`
-        // (vs the prior `new` hide) keeps virtual dispatch correct.
-        return base.DeformableConv2DBackwardInput(gradOutput, input, kernel, offsets, mask, inputShape, stride, padding, dilation);
+        // GPU path restored after the deformable offset-layout kernel fix (see DeformableConv2D).
+        if (!TryGetBackend(out var backend))
+            return base.DeformableConv2DBackwardInput(gradOutput, input, kernel, offsets, mask, inputShape, stride, padding, dilation);
+
+        if (gradOutput.Rank != 4 || input.Rank != 4 || kernel.Rank != 4)
+            return base.DeformableConv2DBackwardInput(gradOutput, input, kernel, offsets, mask, inputShape, stride, padding, dilation);
+
+        int batch = inputShape[0];
+        int inChannels = inputShape[1];
+        int inHeight = inputShape[2];
+        int inWidth = inputShape[3];
+
+        int outChannels = kernel.Shape._dims[0];
+        int kernelH = kernel.Shape._dims[2];
+        int kernelW = kernel.Shape._dims[3];
+
+        int outHeight = gradOutput.Shape._dims[2];
+        int outWidth = gradOutput.Shape._dims[3];
+
+        int offsetChannels = offsets.Shape._dims[1];
+        int deformGroups = offsetChannels / (2 * kernelH * kernelW);
+        int groups = 1;
+
+        int inputSize = batch * inChannels * inHeight * inWidth;
+
+        using var gradOutputBuffer = GetOrAllocateBuffer(backend, gradOutput);
+        using var weightsBuffer = GetOrCacheWeightBuffer(backend, kernel.GetDataArray(), PersistentTensorRole.Weights);
+        using var offsetsBuffer = GetOrAllocateBuffer(backend, offsets);
+        using var gradInputBuffer = AllocateOutputBuffer(backend, inputSize);
+
+        try
+        {
+            OwnedBuffer? maskBuffer = mask != null ? GetOrAllocateBuffer(backend, mask) : null;
+            try
+            {
+                backend.DeformableConv2DBackwardInput(
+                    gradOutputBuffer.Buffer, weightsBuffer.Buffer, offsetsBuffer.Buffer, maskBuffer?.Buffer, gradInputBuffer.Buffer,
+                    batch, inChannels, inHeight, inWidth,
+                    outChannels, outHeight, outWidth,
+                    kernelH, kernelW, stride[0], stride[1], padding[0], padding[1],
+                    dilation[0], dilation[1], groups, deformGroups);
+
+                float[] resultFloat = new float[inputSize];
+                backend.DownloadBuffer(gradInputBuffer.Buffer, resultFloat);
+
+                T[] resultData = DirectGpuEngine.FromFloatArray<T>(resultFloat);
+                return new Tensor<T>(resultData, inputShape);
+            }
+            finally
+            {
+                maskBuffer?.Dispose();
+            }
+        }
+        catch
+        {
+            return base.DeformableConv2DBackwardInput(gradOutput, input, kernel, offsets, mask, inputShape, stride, padding, dilation);
+        }
     }
 
     /// <summary>
@@ -6650,10 +6768,63 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int[] padding,
         int[] dilation)
     {
-        // The GPU DeformableConv2DBackwardKernel kernel disagreed with the CPU reference (GpuConvKernelCoverageTests);
-        // route to the correct CPU implementation until the GPU kernel is fixed (tracked in #622). The `override`
-        // (vs the prior `new` hide) keeps virtual dispatch correct.
-        return base.DeformableConv2DBackwardKernel(gradOutput, input, offsets, mask, kernelShape, stride, padding, dilation);
+        // GPU path restored after the deformable offset-layout kernel fix (see DeformableConv2D).
+        if (!TryGetBackend(out var backend))
+            return base.DeformableConv2DBackwardKernel(gradOutput, input, offsets, mask, kernelShape, stride, padding, dilation);
+
+        if (gradOutput.Rank != 4 || input.Rank != 4)
+            return base.DeformableConv2DBackwardKernel(gradOutput, input, offsets, mask, kernelShape, stride, padding, dilation);
+
+        int batch = input.Shape._dims[0];
+        int inChannels = input.Shape._dims[1];
+        int inHeight = input.Shape._dims[2];
+        int inWidth = input.Shape._dims[3];
+
+        int outChannels = kernelShape[0];
+        int kernelH = kernelShape[2];
+        int kernelW = kernelShape[3];
+
+        int outHeight = gradOutput.Shape._dims[2];
+        int outWidth = gradOutput.Shape._dims[3];
+
+        int offsetChannels = offsets.Shape._dims[1];
+        int deformGroups = offsetChannels / (2 * kernelH * kernelW);
+        int groups = 1;
+
+        int kernelSize = kernelShape[0] * kernelShape[1] * kernelShape[2] * kernelShape[3];
+
+        using var gradOutputBuffer = GetOrAllocateBuffer(backend, gradOutput);
+        using var inputBuffer = GetOrAllocateBuffer(backend, input);
+        using var offsetsBuffer = GetOrAllocateBuffer(backend, offsets);
+        using var gradWeightsBuffer = AllocateOutputBuffer(backend, kernelSize);
+
+        try
+        {
+            OwnedBuffer? maskBuffer = mask != null ? GetOrAllocateBuffer(backend, mask) : null;
+            try
+            {
+                backend.DeformableConv2DBackwardWeights(
+                    inputBuffer.Buffer, gradOutputBuffer.Buffer, offsetsBuffer.Buffer, maskBuffer?.Buffer, gradWeightsBuffer.Buffer,
+                    batch, inChannels, inHeight, inWidth,
+                    outChannels, outHeight, outWidth,
+                    kernelH, kernelW, stride[0], stride[1], padding[0], padding[1],
+                    dilation[0], dilation[1], groups, deformGroups);
+
+                float[] resultFloat = new float[kernelSize];
+                backend.DownloadBuffer(gradWeightsBuffer.Buffer, resultFloat);
+
+                T[] resultData = DirectGpuEngine.FromFloatArray<T>(resultFloat);
+                return new Tensor<T>(resultData, kernelShape);
+            }
+            finally
+            {
+                maskBuffer?.Dispose();
+            }
+        }
+        catch
+        {
+            return base.DeformableConv2DBackwardKernel(gradOutput, input, offsets, mask, kernelShape, stride, padding, dilation);
+        }
     }
 
     /// <summary>
@@ -6670,10 +6841,65 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int[] padding,
         int[] dilation)
     {
-        // The GPU DeformableConv2DBackwardOffset kernel disagreed with the CPU reference (GpuConvKernelCoverageTests);
-        // route to the correct CPU implementation until the GPU kernel is fixed (tracked in #622). The `override`
-        // (vs the prior `new` hide) keeps virtual dispatch correct.
-        return base.DeformableConv2DBackwardOffset(gradOutput, input, kernel, offsets, mask, stride, padding, dilation);
+        // GPU path restored after the deformable offset-layout kernel fix (see DeformableConv2D); this
+        // kernel also got the backward_offset blocked-write decode fix so gradOffset matches CPU.
+        if (!TryGetBackend(out var backend))
+            return base.DeformableConv2DBackwardOffset(gradOutput, input, kernel, offsets, mask, stride, padding, dilation);
+
+        if (gradOutput.Rank != 4 || input.Rank != 4 || kernel.Rank != 4)
+            return base.DeformableConv2DBackwardOffset(gradOutput, input, kernel, offsets, mask, stride, padding, dilation);
+
+        int batch = input.Shape._dims[0];
+        int inChannels = input.Shape._dims[1];
+        int inHeight = input.Shape._dims[2];
+        int inWidth = input.Shape._dims[3];
+
+        int outChannels = kernel.Shape._dims[0];
+        int kernelH = kernel.Shape._dims[2];
+        int kernelW = kernel.Shape._dims[3];
+
+        int outHeight = gradOutput.Shape._dims[2];
+        int outWidth = gradOutput.Shape._dims[3];
+
+        int offsetChannels = offsets.Shape._dims[1];
+        int deformGroups = offsetChannels / (2 * kernelH * kernelW);
+        int groups = 1;
+
+        int offsetSize = batch * offsetChannels * outHeight * outWidth;
+
+        using var gradOutputBuffer = GetOrAllocateBuffer(backend, gradOutput);
+        using var inputBuffer = GetOrAllocateBuffer(backend, input);
+        using var weightsBuffer = GetOrCacheWeightBuffer(backend, kernel.GetDataArray(), PersistentTensorRole.Weights);
+        using var offsetsBuffer = GetOrAllocateBuffer(backend, offsets);
+        using var gradOffsetBuffer = AllocateOutputBuffer(backend, offsetSize);
+
+        try
+        {
+            OwnedBuffer? maskBuffer = mask != null ? GetOrAllocateBuffer(backend, mask) : null;
+            try
+            {
+                backend.DeformableConv2DBackwardOffset(
+                    inputBuffer.Buffer, weightsBuffer.Buffer, gradOutputBuffer.Buffer, offsetsBuffer.Buffer, maskBuffer?.Buffer, gradOffsetBuffer.Buffer,
+                    batch, inChannels, inHeight, inWidth,
+                    outChannels, outHeight, outWidth,
+                    kernelH, kernelW, stride[0], stride[1], padding[0], padding[1],
+                    dilation[0], dilation[1], groups, deformGroups);
+
+                float[] resultFloat = new float[offsetSize];
+                backend.DownloadBuffer(gradOffsetBuffer.Buffer, resultFloat);
+
+                T[] resultData = DirectGpuEngine.FromFloatArray<T>(resultFloat);
+                return new Tensor<T>(resultData, offsets.Shape._dims);
+            }
+            finally
+            {
+                maskBuffer?.Dispose();
+            }
+        }
+        catch
+        {
+            return base.DeformableConv2DBackwardOffset(gradOutput, input, kernel, offsets, mask, stride, padding, dilation);
+        }
     }
 
     /// <summary>
@@ -6690,10 +6916,60 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int[] padding,
         int[] dilation)
     {
-        // The GPU DeformableConv2DBackwardMask kernel disagreed with the CPU reference (GpuConvKernelCoverageTests);
-        // route to the correct CPU implementation until the GPU kernel is fixed (tracked in #622). The `override`
-        // (vs the prior `new` hide) keeps virtual dispatch correct.
-        return base.DeformableConv2DBackwardMask(gradOutput, input, kernel, offsets, mask, stride, padding, dilation);
+        // GPU path restored after the deformable offset-layout kernel fix (see DeformableConv2D).
+        if (mask == null)
+            throw new ArgumentNullException(nameof(mask), "Mask cannot be null when computing mask gradients");
+
+        if (!TryGetBackend(out var backend))
+            return base.DeformableConv2DBackwardMask(gradOutput, input, kernel, offsets, mask, stride, padding, dilation);
+
+        if (gradOutput.Rank != 4 || input.Rank != 4 || kernel.Rank != 4 || mask.Rank != 4)
+            return base.DeformableConv2DBackwardMask(gradOutput, input, kernel, offsets, mask, stride, padding, dilation);
+
+        int batch = input.Shape._dims[0];
+        int inChannels = input.Shape._dims[1];
+        int inHeight = input.Shape._dims[2];
+        int inWidth = input.Shape._dims[3];
+
+        int outChannels = kernel.Shape._dims[0];
+        int kernelH = kernel.Shape._dims[2];
+        int kernelW = kernel.Shape._dims[3];
+
+        int outHeight = gradOutput.Shape._dims[2];
+        int outWidth = gradOutput.Shape._dims[3];
+
+        int offsetChannels = offsets.Shape._dims[1];
+        int deformGroups = offsetChannels / (2 * kernelH * kernelW);
+        int maskChannels = deformGroups * kernelH * kernelW;
+        int groups = 1;
+
+        int maskSize = batch * maskChannels * outHeight * outWidth;
+
+        using var gradOutputBuffer = GetOrAllocateBuffer(backend, gradOutput);
+        using var inputBuffer = GetOrAllocateBuffer(backend, input);
+        using var weightsBuffer = GetOrCacheWeightBuffer(backend, kernel.GetDataArray(), PersistentTensorRole.Weights);
+        using var offsetsBuffer = GetOrAllocateBuffer(backend, offsets);
+        using var gradMaskBuffer = AllocateOutputBuffer(backend, maskSize);
+
+        try
+        {
+            backend.DeformableConv2DBackwardMask(
+                inputBuffer.Buffer, weightsBuffer.Buffer, gradOutputBuffer.Buffer, offsetsBuffer.Buffer, gradMaskBuffer.Buffer,
+                batch, inChannels, inHeight, inWidth,
+                outChannels, outHeight, outWidth,
+                kernelH, kernelW, stride[0], stride[1], padding[0], padding[1],
+                dilation[0], dilation[1], groups, deformGroups);
+
+            float[] resultFloat = new float[maskSize];
+            backend.DownloadBuffer(gradMaskBuffer.Buffer, resultFloat);
+
+            T[] resultData = DirectGpuEngine.FromFloatArray<T>(resultFloat);
+            return new Tensor<T>(resultData, mask.Shape._dims);
+        }
+        catch
+        {
+            return base.DeformableConv2DBackwardMask(gradOutput, input, kernel, offsets, mask, stride, padding, dilation);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Why
#617 found six GPU conv methods disagreeing with the CPU reference and "fixed" them by routing all six to CPU — no kernel fix, GPU acceleration silently gone. This fixes the real bugs, **validated on the OpenCL/AMD GPU** (`GpuConvKernelCoverageTests`: was 9/12, now **12/12**).

## Root causes (found by running on the GPU, not by guessing)

1. **OpenCL launcher arg-binding swap** (the actual cause of the 3 failing deformable backward tests). The kernels' signatures start `(gradOutput, input, weights, …)` but the C# launcher bound buffers in parameter order `(input, weights, gradOutput, …)` — so `backward_weights/offset/mask` read the input buffer as gradOutput and vice-versa, producing garbage / sign-flipped gradients. `forward` and `backward_input` passed only because their param order happened to match.
2. **CUDA/HIP** had the same class of bug expressed via mis-ordered parameter *names*; aligned to the engine/OpenCL order. (Plus a CUDA/HIP forward offset-layout mismatch vs the CPU blocked layout — corrected to match.)
3. **`LocallyConnectedConv2DBackwardWeights`** — #617 stubbed it as "buggy", but its GPU kernel is actually correct (passes parity). Re-enabled the real GPU path.
4. **Engine** — restored the real GPU bodies on all five `DeformableConv2D` `override` methods (kept #617's correct `new`→`override` change).

## Validation
- **OpenCL/AMD GPU (this machine): `GpuConvKernelCoverageTests` 12/12 green**, including all 3 previously-failing deformable backward kernels and the re-enabled locally-connected one.
- **CUDA/HIP**: no NVIDIA/ROCm hardware locally — those changes align them by construction with the validated OpenCL + CPU-reference convention and must be confirmed on a CUDA/ROCm runner.
- Builds net10.0 + net471.

🤖 Generated with [Claude Code](https://claude.com/claude-code)