### PR TITLE
fix(gpu): resident matmul input lookup finds resident params (removes a capture-time alloc that abort-disabled CUDA-graph capture)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -3022,6 +3022,15 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     {
         if (t._gpuBuffer is not null && ReferenceEquals(t._gpuBackend, backend))
             return new OwnedBuffer(t._gpuBuffer, ownsBuffer: false);
+        // Comprehensive resident check (the _gpuBuffer field alone is NOT enough): a GPU-RESIDENT PARAMETER
+        // (GpuPinned/GpuOffload, AIDOTNET_GPU_RESIDENT_PARAMS=1) carries its residency as an OffloadDevicePointer
+        // in WeightRegistry, not the _gpuBuffer field, so TryGetGpuBuffer() finds it where the field check misses.
+        // Without this, a matmul WEIGHT operand fell through to GetOrCacheWeightBuffer below and allocated a fresh
+        // device buffer DURING CUDA-graph capture (GetDataArray() returns a new host array each call → a guaranteed
+        // cache miss) — a graph-purity violation (CUDA 906) that aborts whole-step capture and PERMANENTLY drops the
+        // cortex onto the launch-bound eager path (~60 s/step). Same root cause as the #611 LayerNorm fix.
+        var resident = t.TryGetGpuBuffer();
+        if (resident is not null) return new OwnedBuffer(resident, ownsBuffer: false);
         var arr = t.DataVector.GetBackingArrayUnsafe();
         if (arr is not null)
         {
@@ -3031,7 +3040,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 if (_activationCache.TryGetValue(arr, out var e) && ReferenceEquals(e.Backend, backend) && !e.IsFp16)
                     return new OwnedBuffer(e.Buffer, ownsBuffer: false);
             if (t.IsContiguous)
-                return GetOrCacheWeightBuffer(backend, t.GetDataArray(), PersistentTensorRole.Weights);
+                return GetWeightBufferPreferResident(backend, t, PersistentTensorRole.Weights);
         }
         return GetOrAllocateContiguousInputBuffer(backend, t);
     }


### PR DESCRIPTION
## Problem
`GetResidentOrPersistentInputBuffer` checked only the `t._gpuBuffer` field for residency. A GPU-resident **parameter** (GpuPinned/GpuOffload, `AIDOTNET_GPU_RESIDENT_PARAMS=1`) carries residency as an `OffloadDevicePointer` in WeightRegistry, not that field — so a matmul **weight** operand missed it and fell to `GetOrCacheWeightBuffer(t.GetDataArray(), …)`, which cache-misses (fresh host array each call) and **allocates a device buffer**.

Inside the compiled step's whole-step CUDA-graph capture, that alloc is a graph-purity violation (CUDA 906) → capture aborts → **permanently disabled** → cortex drops to the launch-bound eager path (~60 s/step on d768/L6).

The capture-trace (`AIDOTNET_GPU_CAPTURE_TRACE=1`) pinpointed it: a 2304 KB (768×768 weight) alloc via `TryMatMulResidentInto → GetResidentOrPersistentInputBuffer → GetOrCacheWeightBuffer`.

## Fix
Same pattern as the #611 LayerNorm fix: check `t.TryGetGpuBuffer()` (resolves the offload device pointer for resident params) before the cache fallback, and route the contiguous fallback through `GetWeightBufferPreferResident`.

## Verified
Capture-trace device-alloc count during capture: **1 → 0**.

Note: capture still doesn't fully engage on this model due to a **separate** pre-existing async cross-stream CUDA-700 race surfacing in `ConfigureOptimizer` (model-size-independent; tracked separately). This removes one of the two capture blockers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Enhanced GPU tensor operations to prioritize existing GPU-resident buffers, reducing memory allocation overhead and improving performance during tensor computations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->