### PR TITLE
feat(cuda): GraphedInferenceStep — CUDA-graph capture/replay for inference (#1630)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/Codegen/CudaGraph/GraphedInferenceStep.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Codegen/CudaGraph/GraphedInferenceStep.cs
@@ -1,0 +1,197 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using AiDotNet.Tensors.Engines.DirectGpu;
+using AiDotNet.Tensors.Engines.Gpu;
+
+namespace AiDotNet.Tensors.Engines.Compilation.Codegen.CudaGraph;
+
+/// <summary>
+/// Captures a model's forward pass into a CUDA graph for zero-launch-overhead inference replay —
+/// the inference counterpart to <see cref="GraphedTrainingStep"/> (#1630 / #91). On the
+/// foundation-model decode path a single forward dispatches hundreds of small kernels; at low
+/// batch the per-launch overhead dominates, and CUDA graphs collapse the whole launch sequence
+/// into one <c>cuGraphLaunch</c>. This is the standard low-latency-serving lever (TensorRT-LLM /
+/// vLLM both capture decode graphs).
+/// <para>
+/// <b>Static-buffer contract.</b> CUDA-graph replay re-runs the recorded kernels against the
+/// EXACT device addresses captured. So the <paramref name="forward"/> closure must read its input
+/// from, and write its output to, FIXED device buffers (arena/persistent tensors whose pointers
+/// don't move between replays) — never freshly-allocated tensors. To run inference on new data,
+/// copy it INTO the captured input buffer (a memcpy on the same stream, outside the recorded
+/// graph) and then call <see cref="Replay()"/> / <see cref="Replay(Action)"/>; read the result
+/// from the captured output buffer. Shapes are fixed per capture — capture one
+/// <see cref="GraphedInferenceStep"/> per inference shape.
+/// </para>
+/// <para>
+/// <b>Determinism.</b> Unlike the training step (which offsets the RNG per replay), inference must
+/// be deterministic — the forward closure must contain no stochastic ops (Dropout/GaussianNoise
+/// are disabled in inference mode), so replay reproduces the captured computation exactly.
+/// </para>
+/// </summary>
+public sealed class GraphedInferenceStep : IDisposable
+{
+    private readonly IDirectGpuBackend _backend;
+    private readonly IntPtr _stream;
+    private readonly Action _forward;
+    private readonly GraphedInferenceStepOptions _options;
+    private CudaGraphScope? _scope;
+    private bool _warmedUp;
+    private bool _captured;
+    private int _replayCount;
+    private bool _disposed;
+
+    /// <summary>Creates a graphed inference-forward wrapper.</summary>
+    /// <param name="backend">The GPU backend that owns the captured graph's lifetime.</param>
+    /// <param name="stream">A non-default CUDA stream the forward runs on (default-stream capture
+    /// is rejected — other threads' launches would be captured too).</param>
+    /// <param name="forward">The model's forward closure. Must read from / write to FIXED device
+    /// buffers (see the static-buffer contract on the type) so replay sees stable pointers.</param>
+    /// <param name="options">Capture options; null uses defaults.</param>
+    public GraphedInferenceStep(
+        IDirectGpuBackend backend,
+        IntPtr stream,
+        Action forward,
+        GraphedInferenceStepOptions? options = null)
+    {
+        _backend = backend ?? throw new ArgumentNullException(nameof(backend));
+        if (stream == IntPtr.Zero) throw new ArgumentException(
+            "CUDA graph capture requires a non-default stream. Default-stream capture is rejected "
+          + "because other threads may enqueue work on it during capture.", nameof(stream));
+        _stream = stream;
+        _forward = forward ?? throw new ArgumentNullException(nameof(forward));
+        _options = options ?? GraphedInferenceStepOptions.Default;
+    }
+
+    /// <summary>True once <see cref="Capture"/> succeeded.</summary>
+    public bool HasGraph => _captured;
+
+    /// <summary>How many times <see cref="Replay()"/> has been called.</summary>
+    public int ReplayCount => _replayCount;
+
+    /// <summary>
+    /// Runs the forward <see cref="GraphedInferenceStepOptions.WarmupIterations"/> times before
+    /// capture, so lazy allocations + the arena pool reach the steady-state launch sequence the
+    /// graph will record. Must be called before <see cref="Capture"/>.
+    /// </summary>
+    public void Prepare()
+    {
+        ThrowIfDisposed();
+        for (int i = 0; i < _options.WarmupIterations; i++)
+            _forward();
+        _warmedUp = true;
+    }
+
+    /// <summary>
+    /// Captures the forward pass into a CUDA graph (one warm replay records every kernel launch).
+    /// After it returns successfully, <see cref="Replay()"/> can be called any number of times.
+    /// Honours <see cref="GraphedInferenceStepOptions.ThrowOnUnsupported"/>: throws on a
+    /// no-CUDA-graph backend by default, or silently no-ops (leaving <see cref="HasGraph"/> false)
+    /// so the caller can fall back to the eager forward.
+    /// </summary>
+    public void Capture()
+    {
+        ThrowIfDisposed();
+        if (!_warmedUp) throw new InvalidOperationException(
+            "GraphedInferenceStep.Prepare must be called before Capture so allocations are warm "
+          + "and the kernel-launch sequence has stabilised.");
+        if (_captured) return;
+
+        // Tear down any abandoned scope from a prior Capture that threw partway through, so the
+        // new BeginCapture runs against a clean slate (no leaked native graph).
+        if (_scope is not null)
+        {
+            _scope.Dispose();
+            _scope = null;
+        }
+
+        var scope = new CudaGraphScope(_backend, _stream);
+        if (!scope.IsSupported)
+        {
+            scope.Dispose();
+            if (_options.ThrowOnUnsupported)
+                throw new InvalidOperationException(
+                    "CUDA Graph is not supported by this backend or driver version. Catch this and "
+                  + "fall back to calling the forward directly (eager inference).");
+            return; // HasGraph stays false → Replay throws its "before Capture" contract message.
+        }
+
+        // Publish the scope only after a fully successful capture; on any throw, dispose the local
+        // and leave _scope null / _captured false so a retry sees a clean slate.
+        try
+        {
+            scope.BeginCapture();
+            try { _forward(); }
+            finally { scope.EndCapture(); }
+            _scope = scope;
+            _captured = true;
+        }
+        catch
+        {
+            scope.Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Replays the captured forward with zero per-kernel launch overhead. The caller must have
+    /// already copied the current input into the captured input buffer (see the static-buffer
+    /// contract); the result lands in the captured output buffer. Throws if
+    /// <see cref="Capture"/> hasn't succeeded — check <see cref="HasGraph"/> when CUDA graph may
+    /// be unavailable.
+    /// </summary>
+    public int Replay()
+    {
+        ThrowIfDisposed();
+        if (!_captured || _scope is null)
+            throw new InvalidOperationException(
+                "Replay called before Capture. Call Prepare + Capture first.");
+        _scope.Replay();
+        return _replayCount++;
+    }
+
+    /// <summary>
+    /// Convenience replay that runs <paramref name="rebindInputs"/> (copy fresh data into the
+    /// captured input buffer) immediately before replaying — making the "update-then-replay"
+    /// inference contract explicit and atomic at the call site.
+    /// </summary>
+    public int Replay(Action rebindInputs)
+    {
+        ThrowIfDisposed();
+        if (rebindInputs is null) throw new ArgumentNullException(nameof(rebindInputs));
+        if (!_captured || _scope is null)
+            throw new InvalidOperationException(
+                "Replay called before Capture. Call Prepare + Capture first.");
+        rebindInputs();
+        _scope.Replay();
+        return _replayCount++;
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _scope?.Dispose();
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (_disposed) throw new ObjectDisposedException(nameof(GraphedInferenceStep));
+    }
+}
+
+/// <summary>Configuration for <see cref="GraphedInferenceStep"/>.</summary>
+public sealed class GraphedInferenceStepOptions
+{
+    /// <summary>Warmup forwards run before capture so lazy allocations + the arena pool reach
+    /// steady state. Default 2 (one to fill the pool, one to observe steady-state launches).</summary>
+    public int WarmupIterations { get; init; } = 2;
+
+    /// <summary>Throw if CUDA graph is unsupported (true, default) vs. silently no-op
+    /// <see cref="GraphedInferenceStep.Capture"/> so the caller falls back to eager inference.</summary>
+    public bool ThrowOnUnsupported { get; init; } = true;
+
+    /// <summary>Default options.</summary>
+    public static GraphedInferenceStepOptions Default { get; } = new();
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/Codegen/GraphedInferenceStepTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/Codegen/GraphedInferenceStepTests.cs
@@ -1,0 +1,123 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// #1630 / #91: CUDA Graph INFERENCE capture (counterpart to GraphedTrainingStep). The argument
+// guards + state machine all fire BEFORE any GPU call, so they're host-agnostic and covered here
+// via a DispatchProxy mock backend (gated to non-Framework — DispatchProxy is .NET Core 5+, same
+// as the mock itself); the null-backend + options checks need no mock and run on every TFM. Real
+// CUDA capture/replay requires an NVIDIA GPU and lives in the integration harness.
+
+#nullable disable
+
+using System;
+using AiDotNet.Tensors.Engines.Compilation.Codegen.CudaGraph;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation.Codegen;
+
+public class GraphedInferenceStepTests
+{
+    // ─── Guards / options that need no backend — run on every TFM ──────────────────
+
+    [Fact]
+    public void Ctor_NullBackend_Throws()
+        => Assert.Throws<ArgumentNullException>(() =>
+            new GraphedInferenceStep(null, (IntPtr)0x1, () => { }));
+
+    [Fact]
+    public void Options_Default_HasReasonableValues()
+    {
+        var opts = GraphedInferenceStepOptions.Default;
+        Assert.Equal(2, opts.WarmupIterations);
+        Assert.True(opts.ThrowOnUnsupported);
+    }
+
+    [Fact]
+    public void Options_CustomValues_RoundTrip()
+    {
+        var opts = new GraphedInferenceStepOptions { WarmupIterations = 4, ThrowOnUnsupported = false };
+        Assert.Equal(4, opts.WarmupIterations);
+        Assert.False(opts.ThrowOnUnsupported);
+    }
+
+    [Fact]
+    public void Options_Default_IsSingleton()
+        => Assert.Same(GraphedInferenceStepOptions.Default, GraphedInferenceStepOptions.Default);
+
+#if !NETFRAMEWORK
+    // ─── State machine + remaining guards — via DispatchProxy mock (.NET Core 5+) ──
+    // All fire before any GPU call, so they're deterministic on a CUDA-less host.
+
+    private static readonly IntPtr NonDefaultStream = (IntPtr)0x1;
+    private static AiDotNet.Tensors.Engines.DirectGpu.IDirectGpuBackend Backend()
+        => AiDotNet.Tensors.Tests.Engines.DirectGpu.MockDirectGpuBackend.Create(
+               new AiDotNet.Tensors.Tests.Engines.DirectGpu.MockBackendState());
+
+    [Fact]
+    public void Ctor_DefaultStream_Throws()
+        => Assert.Throws<ArgumentException>(() =>
+            new GraphedInferenceStep(Backend(), IntPtr.Zero, () => { }));
+
+    [Fact]
+    public void Ctor_NullForward_Throws()
+        => Assert.Throws<ArgumentNullException>(() =>
+            new GraphedInferenceStep(Backend(), NonDefaultStream, null));
+
+    [Fact]
+    public void Capture_BeforePrepare_Throws()
+    {
+        using var step = new GraphedInferenceStep(Backend(), NonDefaultStream, () => { });
+        var ex = Assert.Throws<InvalidOperationException>(() => step.Capture());
+        Assert.Contains("Prepare", ex.Message);
+    }
+
+    [Fact]
+    public void Prepare_RunsForward_WarmupIterations_Times()
+    {
+        int calls = 0;
+        var opts = new GraphedInferenceStepOptions { WarmupIterations = 3 };
+        using var step = new GraphedInferenceStep(Backend(), NonDefaultStream, () => calls++, opts);
+        step.Prepare();
+        Assert.Equal(3, calls); // warmup ran the forward exactly WarmupIterations times (no GPU)
+    }
+
+    [Fact]
+    public void Prepare_ZeroWarmup_RunsForwardNever()
+    {
+        int calls = 0;
+        var opts = new GraphedInferenceStepOptions { WarmupIterations = 0 };
+        using var step = new GraphedInferenceStep(Backend(), NonDefaultStream, () => calls++, opts);
+        step.Prepare();
+        Assert.Equal(0, calls);
+    }
+
+    [Fact]
+    public void Replay_BeforeCapture_Throws()
+    {
+        using var step = new GraphedInferenceStep(Backend(), NonDefaultStream, () => { });
+        var ex = Assert.Throws<InvalidOperationException>(() => step.Replay());
+        Assert.Contains("Capture", ex.Message);
+    }
+
+    [Fact]
+    public void Replay_NullRebind_Throws()
+    {
+        using var step = new GraphedInferenceStep(Backend(), NonDefaultStream, () => { });
+        Assert.Throws<ArgumentNullException>(() => step.Replay(null)); // null-check before capture-state
+    }
+
+    [Fact]
+    public void HasGraph_FalseBeforeCapture_ReplayCountZero()
+    {
+        using var step = new GraphedInferenceStep(Backend(), NonDefaultStream, () => { });
+        Assert.False(step.HasGraph);
+        Assert.Equal(0, step.ReplayCount);
+    }
+
+    [Fact]
+    public void Prepare_AfterDispose_Throws()
+    {
+        var step = new GraphedInferenceStep(Backend(), NonDefaultStream, () => { });
+        step.Dispose();
+        Assert.Throws<ObjectDisposedException>(() => step.Prepare());
+    }
+#endif
+}


### PR DESCRIPTION
## Summary

CUDA-graph capture/replay for **inference** — the one genuine gap found in the #1630 inference-stack audit (`GraphedTrainingStep` existed for training; inference had no equivalent). Capturing the forward into a CUDA graph collapses its hundreds of small per-decode kernel launches into a single `cuGraphLaunch`; at low batch (the foundation-model decode path) that launch overhead dominates, so this is the standard low-latency-serving lever (TensorRT-LLM / vLLM both capture decode graphs).

## Design (mirrors `GraphedTrainingStep`)
`Prepare()` (warmup) → `Capture()` (BeginCapture / forward / EndCapture via `CudaGraphScope`) → `Replay()` / `Replay(rebindInputs)`.

Documents the inference-specific contracts:
- **Static-buffer**: replay re-runs the recorded kernels against the captured device addresses, so the forward must read/write FIXED device buffers; to infer on new data, copy it into the captured input buffer and replay (`Replay(rebindInputs)` makes update-then-replay atomic).
- **Determinism**: no stochastic ops (inference mode disables Dropout/noise), so replay reproduces the captured computation exactly — hence no per-replay RNG offset (unlike the training step).
- `ThrowOnUnsupported` → graceful eager fallback on non-CUDA hosts.

## Tests
13 on net10 / 4 on net471. All argument guards + the state machine fire **before any GPU call**, so they're host-agnostic and tested via the existing `MockDirectGpuBackend` (DispatchProxy, .NET Core 5+): default-stream rejection, null-backend, null-forward, Capture-before-Prepare, warmup-count (0 and N), Replay-before-Capture, null-rebind, HasGraph/ReplayCount, dispose. net471 (no DispatchProxy) covers null-backend + options. Real CUDA capture/replay parity is the GPU integration harness's job.

## Context
Part of the #1630 inference audit, which found the stack far more complete than assumed (paged-KV, continuous batching, speculative decoding, fused attention all already present). This fills the last structural gap. The bigger follow-up is wiring/enabling the existing inference stack by default (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
