### PR TITLE
fix(compile): fix BlasBatch hoist vs MemoryPlanning aliasing in attention inference (remove #1624 gate)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledInferencePlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledInferencePlan.cs
@@ -1302,30 +1302,19 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
     {
         if (steps.Count < 4) return steps;
 
-        // CORRECTNESS GATE (#1624): the step-mutating passes (OperatorReorderingPass + MemoryPlanningPass)
-        // produce a DETERMINISTIC-but-WRONG result for the attention fan-out topology — one shared input
-        // feeding q/k/v through matmul->reshape->permute, joined at scaled-dot-product attention (which
-        // GraphMode decomposes to permute/matmul/Softmax/matmul). The compiled output silently diverges
-        // from eager (masked for years because attention compile tests check shape/finiteness/determinism,
-        // never eager parity — see MultiInputReplayAliasingTests). Bisected: each pass corrupts it
-        // independently; bypassing BOTH makes the whole compile suite pass and matches eager. The root
-        // cause is subtle (a topologically-valid reorder still corrupts, so it is not a broken dependency)
-        // and the proper fix is deeper; until then, skip these passes whenever the plan contains a Softmax
-        // (the reliable signature of an attention block) so transformer/diffusion inference is CORRECT.
-        // Non-attention plans (CNN/MLP) keep the passes unchanged. Trade-off: attention inference plans lose
-        // peak-memory reduction — acceptable vs. silently-wrong attention, and revisited when the passes are
-        // made fan-out-correct. Also gate on a FUSED ScaledDotProductAttention step: a plan that keeps SDPA
-        // as one op (rather than the GraphMode-decomposed permute/matmul/Softmax/matmul) has no Softmax step,
-        // so the Softmax check alone would let the same fan-out topology slip through and miscompile.
-        for (int s = 0; s < steps.Count; s++)
-        {
-            var op = steps[s].OpType;
-            if (op == OpType.Softmax || op == OpType.LogSoftmax || op == OpType.ScaledDotProductAttention)
-                return steps;
-        }
-
+        // OperatorReorderingPass and MemoryPlanningPass run here, pre-specialization, so the
+        // specializer pins the correct post-reorder/post-rebind tensors. These passes are now
+        // correct for the attention fan-out topology (one shared input feeding q/k/v through
+        // matmul->reshape->permute, joined at scaled-dot-product attention). The historical
+        // miscompile (#1624) was NOT in these passes: MemoryPlanningPass legally donates a
+        // buffer that dies at its original last-use, but the later BlasBatchPass HOISTS grouped
+        // matmuls to a single position and could move an aliased matmul write ahead of the
+        // donor buffer's last consumer. The fix lives in BlasBatchPass (it now refuses to batch
+        // matmuls whose output buffer was aliased by MemoryPlanning) — see BlasBatchPass.HasAliasedOutput.
+        // Verified eager-parity across the full attention/SDPA fan-out suite (MultiInputReplayAliasingTests).
         var arr = steps.ToArray();
         AiDotNet.Tensors.Engines.Optimization.ICpuOptimizationPass[] passes =
+            new AiDotNet.Tensors.Engines.Optimization.ICpuOptimizationPass[]
         {
             new AiDotNet.Tensors.Engines.Optimization.OperatorReorderingPass(),
             new AiDotNet.Tensors.Engines.Optimization.MemoryPlanningPass(),

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledInferencePlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledInferencePlan.cs
@@ -1301,6 +1301,26 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
     private static List<CompiledStep<T>> RunStepMutatingPasses(List<CompiledStep<T>> steps, IEngine engine)
     {
         if (steps.Count < 4) return steps;
+
+        // CORRECTNESS GATE (#1624): the step-mutating passes (OperatorReorderingPass + MemoryPlanningPass)
+        // produce a DETERMINISTIC-but-WRONG result for the attention fan-out topology — one shared input
+        // feeding q/k/v through matmul->reshape->permute, joined at scaled-dot-product attention (which
+        // GraphMode decomposes to permute/matmul/Softmax/matmul). The compiled output silently diverges
+        // from eager (masked for years because attention compile tests check shape/finiteness/determinism,
+        // never eager parity — see MultiInputReplayAliasingTests). Bisected: each pass corrupts it
+        // independently; bypassing BOTH makes the whole compile suite pass and matches eager. The root
+        // cause is subtle (a topologically-valid reorder still corrupts, so it is not a broken dependency)
+        // and the proper fix is deeper; until then, skip these passes whenever the plan contains a Softmax
+        // (the reliable signature of an attention block) so transformer/diffusion inference is CORRECT.
+        // Non-attention plans (CNN/MLP) keep the passes unchanged. Trade-off: attention inference plans lose
+        // peak-memory reduction — acceptable vs. silently-wrong attention, and revisited when the passes are
+        // made fan-out-correct.
+        for (int s = 0; s < steps.Count; s++)
+        {
+            if (steps[s].OpType == OpType.Softmax || steps[s].OpType == OpType.LogSoftmax)
+                return steps;
+        }
+
         var arr = steps.ToArray();
         AiDotNet.Tensors.Engines.Optimization.ICpuOptimizationPass[] passes =
         {

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledInferencePlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledInferencePlan.cs
@@ -1314,10 +1314,13 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
         // (the reliable signature of an attention block) so transformer/diffusion inference is CORRECT.
         // Non-attention plans (CNN/MLP) keep the passes unchanged. Trade-off: attention inference plans lose
         // peak-memory reduction — acceptable vs. silently-wrong attention, and revisited when the passes are
-        // made fan-out-correct.
+        // made fan-out-correct. Also gate on a FUSED ScaledDotProductAttention step: a plan that keeps SDPA
+        // as one op (rather than the GraphMode-decomposed permute/matmul/Softmax/matmul) has no Softmax step,
+        // so the Softmax check alone would let the same fan-out topology slip through and miscompile.
         for (int s = 0; s < steps.Count; s++)
         {
-            if (steps[s].OpType == OpType.Softmax || steps[s].OpType == OpType.LogSoftmax)
+            var op = steps[s].OpType;
+            if (op == OpType.Softmax || op == OpType.LogSoftmax || op == OpType.ScaledDotProductAttention)
                 return steps;
         }
 

--- a/src/AiDotNet.Tensors/Engines/Optimization/AttentionFusionPass.cs
+++ b/src/AiDotNet.Tensors/Engines/Optimization/AttentionFusionPass.cs
@@ -1,6 +1,7 @@
 using AiDotNet.Tensors.Engines.Compilation;
 using AiDotNet.Tensors.Engines.Simd;
 using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
 
 namespace AiDotNet.Tensors.Engines.Optimization;
 
@@ -100,7 +101,19 @@ internal sealed class AttentionFusionPass : ICpuOptimizationPass
         if (typeof(T) != typeof(float)) return false;
 
         var queryTensor = qk.Inputs[0];
-        var keyTensor = qk.Inputs[1]; // This is K (or K^T depending on how the graph was built)
+
+        // The matched QK op is a plain TensorMatMul/BatchMatMul (no transpose flag),
+        // so to compute scores = Q @ K^T its second operand is K^T — the output of a
+        // TensorTranspose(K) step. FlashAttention computes Q @ K^T INTERNALLY and so
+        // needs the NATURAL key K ([.., seqK, headDim]); feeding it the already-
+        // transposed K^T makes it transpose twice (→ Q @ K), which is silently wrong
+        // whenever seqK == headDim (equal shapes pass every downstream dim check) and
+        // also breaks the seqK/headDim extraction below (both were written for natural K).
+        // Recover natural K by tracing the transpose that produced the operand; if the
+        // operand is not a clean last-two-dim transpose output we cannot prove its
+        // layout, so refuse to fuse rather than risk corruption.
+        if (!TryRecoverNaturalKey(steps, index, qk.Inputs[1], out var keyTensor))
+            return false;
         var valueTensor = attnV.Inputs[1];
         var finalOutput = attnV.OutputBuffer;
 
@@ -212,5 +225,56 @@ internal sealed class AttentionFusionPass : ICpuOptimizationPass
             null);
 
         return true;
+    }
+
+    /// <summary>
+    /// Recovers the natural key tensor K from the second operand of a Q @ K^T matmul.
+    /// Because <see cref="OpType.TensorMatMul"/>/<see cref="OpType.BatchMatMul"/> carry no
+    /// transpose flag, an attention graph materialises K^T with a <see cref="OpType.TensorTranspose"/>
+    /// step and feeds its output as the matmul's second operand. The FlashAttention kernels
+    /// transpose K internally, so they require natural K — we trace that transpose to its input.
+    /// Returns false (caller must NOT fuse) when the operand has no producing transpose, was
+    /// produced by some other op, or the transpose is not a clean swap of the last two dims —
+    /// in those cases the operand's layout cannot be proven and fusing would risk silent
+    /// gradient/output corruption.
+    /// </summary>
+    private static bool TryRecoverNaturalKey<T>(
+        CompiledStep<T>[] steps, int qkIndex, Tensor<T> keyOperand, out Tensor<T> naturalKey)
+    {
+        naturalKey = keyOperand;
+        if (keyOperand is null) return false;
+
+        for (int s = qkIndex - 1; s >= 0; s--)
+        {
+            var producer = steps[s];
+            if (producer.OutputBuffer is null || !ReferenceEquals(producer.OutputBuffer, keyOperand))
+                continue;
+
+            // Found the step that writes the K operand. It must be a transpose for the
+            // operand to be K^T; anything else means we cannot reason about the layout.
+            if (producer.OpType != OpType.TensorTranspose
+                || producer.Inputs is null || producer.Inputs.Length < 1)
+                return false;
+
+            var src = producer.Inputs[0];
+            int rank = keyOperand.Rank;
+            if (src is null || src.Rank != rank || rank < 2)
+                return false;
+
+            // Require a pure last-two-dim swap: src[.., a, b] -> keyOperand[.., b, a],
+            // with all leading (batch/head) dims identical. Any other permutation is rejected.
+            if (src._shape[rank - 1] != keyOperand._shape[rank - 2]
+                || src._shape[rank - 2] != keyOperand._shape[rank - 1])
+                return false;
+            for (int d = 0; d < rank - 2; d++)
+                if (src._shape[d] != keyOperand._shape[d]) return false;
+
+            naturalKey = src;
+            return true;
+        }
+
+        // No producing step found (e.g. the operand is a plan input that is already stored
+        // transposed): the layout is unknown, so refuse to fuse.
+        return false;
     }
 }

--- a/src/AiDotNet.Tensors/Engines/Optimization/AttentionFusionPass.cs
+++ b/src/AiDotNet.Tensors/Engines/Optimization/AttentionFusionPass.cs
@@ -231,18 +231,18 @@ internal sealed class AttentionFusionPass : ICpuOptimizationPass
     /// Recovers the natural key tensor K from the second operand of a Q @ K^T matmul.
     /// Because <see cref="OpType.TensorMatMul"/>/<see cref="OpType.BatchMatMul"/> carry no
     /// transpose flag, an attention graph materialises K^T with a <see cref="OpType.TensorTranspose"/>
-    /// step and feeds its output as the matmul's second operand. The FlashAttention kernels
-    /// transpose K internally, so they require natural K — we trace that transpose to its input.
-    /// Returns false (caller must NOT fuse) when the operand has no producing transpose, was
-    /// produced by some other op, or the transpose is not a clean swap of the last two dims —
-    /// in those cases the operand's layout cannot be proven and fusing would risk silent
-    /// gradient/output corruption.
+    /// step and feeds its output as the matmul's second operand. The FlashAttention kernels transpose
+    /// K internally, so they require natural K — we trace that transpose to its input.
+    /// <see cref="CpuEngine.TensorTranspose{T}"/> is 2D-only and always swaps the two dims, so a
+    /// TensorTranspose producer's input is exactly the natural [seqK, headDim] key. Returns false
+    /// (caller must NOT fuse) when the operand has no producing transpose or was produced by some other
+    /// op — there the orientation cannot be proven and fusing would risk a silently-transposed key. The
+    /// downstream rank checks validate the recovered key's shape, so no extra shape guard is needed here.
     /// </summary>
     private static bool TryRecoverNaturalKey<T>(
         CompiledStep<T>[] steps, int qkIndex, Tensor<T> keyOperand, out Tensor<T> naturalKey)
     {
         naturalKey = keyOperand;
-        if (keyOperand is null) return false;
 
         for (int s = qkIndex - 1; s >= 0; s--)
         {
@@ -250,31 +250,17 @@ internal sealed class AttentionFusionPass : ICpuOptimizationPass
             if (producer.OutputBuffer is null || !ReferenceEquals(producer.OutputBuffer, keyOperand))
                 continue;
 
-            // Found the step that writes the K operand. It must be a transpose for the
-            // operand to be K^T; anything else means we cannot reason about the layout.
-            if (producer.OpType != OpType.TensorTranspose
-                || producer.Inputs is null || producer.Inputs.Length < 1)
-                return false;
-
-            var src = producer.Inputs[0];
-            int rank = keyOperand.Rank;
-            if (src is null || src.Rank != rank || rank < 2)
-                return false;
-
-            // Require a pure last-two-dim swap: src[.., a, b] -> keyOperand[.., b, a],
-            // with all leading (batch/head) dims identical. Any other permutation is rejected.
-            if (src._shape[rank - 1] != keyOperand._shape[rank - 2]
-                || src._shape[rank - 2] != keyOperand._shape[rank - 1])
-                return false;
-            for (int d = 0; d < rank - 2; d++)
-                if (src._shape[d] != keyOperand._shape[d]) return false;
-
-            naturalKey = src;
-            return true;
+            // The K operand is K^T only if a TensorTranspose produced it; recover that transpose's input
+            // (the natural key). Any other producer leaves the orientation unprovable -> refuse to fuse.
+            if (producer.OpType == OpType.TensorTranspose && producer.Inputs is { Length: >= 1 })
+            {
+                naturalKey = producer.Inputs[0];
+                return true;
+            }
+            return false;
         }
 
-        // No producing step found (e.g. the operand is a plan input that is already stored
-        // transposed): the layout is unknown, so refuse to fuse.
+        // No producing step found (the key is a direct plan input): orientation unknown -> refuse.
         return false;
     }
 }

--- a/src/AiDotNet.Tensors/Engines/Optimization/BlasBatchPass.cs
+++ b/src/AiDotNet.Tensors/Engines/Optimization/BlasBatchPass.cs
@@ -45,7 +45,8 @@ internal sealed class BlasBatchPass : ICpuOptimizationPass
                 continue;
 
             if (steps[i].OpType == OpType.TensorMatMul && steps[i].Inputs.Length == 2
-                && steps[i].Inputs[0].Rank == 2 && steps[i].Inputs[1].Rank == 2)
+                && steps[i].Inputs[0].Rank == 2 && steps[i].Inputs[1].Rank == 2
+                && !HasAliasedOutput(steps[i]))
             {
                 int k = steps[i].Inputs[0]._shape[1];
                 int n = steps[i].Inputs[1]._shape[1];
@@ -59,6 +60,10 @@ internal sealed class BlasBatchPass : ICpuOptimizationPass
                     if (consumed.Contains(j)) continue;
                     if (steps[j].OpType != OpType.TensorMatMul || steps[j].Inputs.Length != 2) continue;
                     if (steps[j].Inputs[0].Rank != 2 || steps[j].Inputs[1].Rank != 2) continue;
+
+                    // Skip matmuls whose output buffer was aliased to share storage with
+                    // another tensor (see HasAliasedOutput) — they cannot be hoisted.
+                    if (HasAliasedOutput(steps[j])) continue;
 
                     int jk = steps[j].Inputs[0]._shape[1];
                     int jn = steps[j].Inputs[1]._shape[1];
@@ -137,4 +142,28 @@ internal sealed class BlasBatchPass : ICpuOptimizationPass
 
         return anyBatched ? result.ToArray() : null;
     }
+
+    /// <summary>
+    /// True when this step's output buffer shares its backing storage with another
+    /// tensor (storage refcount &gt; 1) — i.e. <see cref="MemoryPlanningPass"/> rebound
+    /// it onto a donor's storage, or it is a view.
+    /// <para>
+    /// Batching <b>hoists</b> every grouped matmul to the position of the group's
+    /// first member and runs them back-to-back there (see the batched delegate
+    /// below). MemoryPlanningPass runs earlier and computes buffer lifetimes from
+    /// the <i>original</i> step order; it may legally donate a buffer D (dead at
+    /// its original last-use) to a later matmul M's output. If BlasBatch then
+    /// hoists M earlier than D's last consumer, M's write lands in D's storage
+    /// before that consumer reads it — corrupting the consumer's input. (Concrete
+    /// case: shared-input Q/K/V projection matmuls feeding reshape→permute→SDPA;
+    /// the V-projection buffer dies at its reshape, MemoryPlanning donates it to
+    /// the K-projection matmul, and batching hoists that K matmul ahead of the V
+    /// reshape — clobbering V.) An output with refcount 1 is privately owned, so
+    /// hoisting it only computes its own value earlier into its own buffer, which
+    /// is always safe. Refusing to batch aliased outputs is the necessary and
+    /// sufficient guard; the only cost is forgoing the batch for those matmuls.
+    /// </para>
+    /// </summary>
+    private static bool HasAliasedOutput<T>(CompiledStep<T> step)
+        => step.OutputBuffer._storage.RefCount > 1 || step.OutputBuffer.IsView;
 }

--- a/src/AiDotNet.Tensors/Engines/Optimization/BlasBatchPass.cs
+++ b/src/AiDotNet.Tensors/Engines/Optimization/BlasBatchPass.cs
@@ -45,8 +45,7 @@ internal sealed class BlasBatchPass : ICpuOptimizationPass
                 continue;
 
             if (steps[i].OpType == OpType.TensorMatMul && steps[i].Inputs.Length == 2
-                && steps[i].Inputs[0].Rank == 2 && steps[i].Inputs[1].Rank == 2
-                && !HasAliasedOutput(steps[i]))
+                && steps[i].Inputs[0].Rank == 2 && steps[i].Inputs[1].Rank == 2)
             {
                 int k = steps[i].Inputs[0]._shape[1];
                 int n = steps[i].Inputs[1]._shape[1];
@@ -57,21 +56,30 @@ internal sealed class BlasBatchPass : ICpuOptimizationPass
 
                 for (int j = i + 1; j < steps.Length; j++)
                 {
-                    if (consumed.Contains(j)) continue;
-                    if (steps[j].OpType != OpType.TensorMatMul || steps[j].Inputs.Length != 2) continue;
-                    if (steps[j].Inputs[0].Rank != 2 || steps[j].Inputs[1].Rank != 2) continue;
-
-                    // Skip matmuls whose output buffer was aliased to share storage with
-                    // another tensor (see HasAliasedOutput) — they cannot be hoisted.
-                    if (HasAliasedOutput(steps[j])) continue;
+                    // CONSECUTIVE-RUN ONLY: a batched group must be a CONTIGUOUS run of
+                    // matmuls. The batched step executes every member at the FIRST member's
+                    // position (and no-ops the originals). If a NON-group step sat between two
+                    // members, moving the later matmul before it would write that matmul's
+                    // output buffer early — and MemoryPlanningPass may have aliased that buffer
+                    // onto a tensor still live across the skipped region (buffers are reused by
+                    // original-order lifetime). Writing early then clobbers a live value →
+                    // silently wrong replay (the multi-input diffusion fan-out, #1620/#1624).
+                    // Stopping the run at the first step that can't join means no member is ever
+                    // hoisted across an intervening step's buffer lifetime — a structural fix
+                    // that holds regardless of how MemoryPlanning aliases buffers. (Within a
+                    // contiguous run the members are independent matmuls with no consumer
+                    // between them, so running them all at the first position reorders nothing
+                    // observable.)
+                    if (consumed.Contains(j)) break;
+                    if (steps[j].OpType != OpType.TensorMatMul || steps[j].Inputs.Length != 2) break;
+                    if (steps[j].Inputs[0].Rank != 2 || steps[j].Inputs[1].Rank != 2) break;
 
                     int jk = steps[j].Inputs[0]._shape[1];
                     int jn = steps[j].Inputs[1]._shape[1];
-                    if (jk != k || jn != n) continue;
+                    if (jk != k || jn != n) break;
 
-                    // Check independence: j's inputs must not depend on group outputs
-                    // AND must be available at position i (produced by steps before i,
-                    // or not produced by any step at all — i.e., graph-level inputs).
+                    // Independence: j's inputs must not depend on a group output, and must be
+                    // available at position i (produced before i, or a graph-level leaf).
                     bool canBatch = true;
                     foreach (var inp in steps[j].Inputs)
                     {
@@ -80,20 +88,16 @@ internal sealed class BlasBatchPass : ICpuOptimizationPass
                             canBatch = false;
                             break;
                         }
-                        // If this input is produced by a step that comes after position i,
-                        // it won't be available when the batched step executes at position i.
                         if (producedByStep.TryGetValue(inp, out int producerIdx) && producerIdx >= i)
                         {
                             canBatch = false;
                             break;
                         }
                     }
+                    if (!canBatch) break;
 
-                    if (canBatch)
-                    {
-                        group.Add(j);
-                        groupOutputs.Add(steps[j].OutputBuffer);
-                    }
+                    group.Add(j);
+                    groupOutputs.Add(steps[j].OutputBuffer);
                 }
 
                 if (group.Count >= 2)
@@ -142,28 +146,4 @@ internal sealed class BlasBatchPass : ICpuOptimizationPass
 
         return anyBatched ? result.ToArray() : null;
     }
-
-    /// <summary>
-    /// True when this step's output buffer shares its backing storage with another
-    /// tensor (storage refcount &gt; 1) — i.e. <see cref="MemoryPlanningPass"/> rebound
-    /// it onto a donor's storage, or it is a view.
-    /// <para>
-    /// Batching <b>hoists</b> every grouped matmul to the position of the group's
-    /// first member and runs them back-to-back there (see the batched delegate
-    /// below). MemoryPlanningPass runs earlier and computes buffer lifetimes from
-    /// the <i>original</i> step order; it may legally donate a buffer D (dead at
-    /// its original last-use) to a later matmul M's output. If BlasBatch then
-    /// hoists M earlier than D's last consumer, M's write lands in D's storage
-    /// before that consumer reads it — corrupting the consumer's input. (Concrete
-    /// case: shared-input Q/K/V projection matmuls feeding reshape→permute→SDPA;
-    /// the V-projection buffer dies at its reshape, MemoryPlanning donates it to
-    /// the K-projection matmul, and batching hoists that K matmul ahead of the V
-    /// reshape — clobbering V.) An output with refcount 1 is privately owned, so
-    /// hoisting it only computes its own value earlier into its own buffer, which
-    /// is always safe. Refusing to batch aliased outputs is the necessary and
-    /// sufficient guard; the only cost is forgoing the batch for those matmuls.
-    /// </para>
-    /// </summary>
-    private static bool HasAliasedOutput<T>(CompiledStep<T> step)
-        => step.OutputBuffer._storage.RefCount > 1 || step.OutputBuffer.IsView;
 }

--- a/src/AiDotNet.Tensors/Engines/Optimization/TensorCodecOptions.cs
+++ b/src/AiDotNet.Tensors/Engines/Optimization/TensorCodecOptions.cs
@@ -92,16 +92,15 @@ public sealed class TensorCodecOptions
     public bool EnableConvBnFusion { get; set; } = true;
 
     /// <summary>Phase 4.2: Fuse attention Q@K^T->Softmax->V patterns into a FlashAttention kernel.
-    /// DISABLED BY DEFAULT — the fusion is INCORRECT for this codebase's attention graphs. FlashAttention
-    /// needs K in [.., seqK, headDim] layout, but the QK step is matmul(Q, Kᵀ): a valid plain matmul's
-    /// second input is ALWAYS Kᵀ ([.., headDim, seqK]), never K. The pass takes qk.Inputs[1] as "K" and lets
-    /// FlashAttention transpose it again, computing the wrong thing. The shape sanity check only catches this
-    /// when seqK != headDim (it rejects the mismatched dims); when seqK == headDim the wrong orientation
-    /// passes the check and produces a SILENTLY WRONG result (caught by MultiInputReplayAliasingTests'
-    /// eager-parity asserts). So the fusion never fuses correctly — it either skips (seqK != headDim) or
-    /// corrupts (seqK == headDim). Keep off until rewritten to recover K structurally (trace the transpose
-    /// feeding the QK matmul) and validated against a real attention model.</summary>
-    public bool EnableAttentionFusion { get; set; } = false;
+    /// Re-enabled: the fusion now structurally recovers natural K. FlashAttention needs K in
+    /// [.., seqK, headDim] layout, but the QK step is a plain matmul(Q, Kᵀ) whose second operand is Kᵀ
+    /// ([.., headDim, seqK]) — the output of a TensorTranspose(K) step (plain matmul carries no transpose
+    /// flag). <see cref="AttentionFusionPass"/> traces that transpose back to its input to feed natural K,
+    /// and REFUSES to fuse when the operand's layout cannot be proven (no producing transpose / not a clean
+    /// last-two-dim swap), so the previous silent-corruption-at-seqK==headDim case can no longer occur.
+    /// Inference-only (CompiledInferencePlan.RunCpuOptimizationPasses), so the forward-only fused step
+    /// needs no backward kernel.</summary>
+    public bool EnableAttentionFusion { get; set; } = true;
 
     /// <summary>Phase 4.3: Merge consecutive pointwise ops into fewer dispatch steps.</summary>
     public bool EnablePointwiseFusion { get; set; } = true;

--- a/src/AiDotNet.Tensors/Engines/Optimization/TensorCodecOptions.cs
+++ b/src/AiDotNet.Tensors/Engines/Optimization/TensorCodecOptions.cs
@@ -91,8 +91,17 @@ public sealed class TensorCodecOptions
     /// <summary>Phase 4.1: Fold BatchNorm into Conv2D weights at compile time.</summary>
     public bool EnableConvBnFusion { get; set; } = true;
 
-    /// <summary>Phase 4.2: Fuse attention Q@K^T->Softmax->V patterns.</summary>
-    public bool EnableAttentionFusion { get; set; } = true;
+    /// <summary>Phase 4.2: Fuse attention Q@K^T->Softmax->V patterns into a FlashAttention kernel.
+    /// DISABLED BY DEFAULT — the fusion is INCORRECT for this codebase's attention graphs. FlashAttention
+    /// needs K in [.., seqK, headDim] layout, but the QK step is matmul(Q, Kᵀ): a valid plain matmul's
+    /// second input is ALWAYS Kᵀ ([.., headDim, seqK]), never K. The pass takes qk.Inputs[1] as "K" and lets
+    /// FlashAttention transpose it again, computing the wrong thing. The shape sanity check only catches this
+    /// when seqK != headDim (it rejects the mismatched dims); when seqK == headDim the wrong orientation
+    /// passes the check and produces a SILENTLY WRONG result (caught by MultiInputReplayAliasingTests'
+    /// eager-parity asserts). So the fusion never fuses correctly — it either skips (seqK != headDim) or
+    /// corrupts (seqK == headDim). Keep off until rewritten to recover K structurally (trace the transpose
+    /// feeding the QK matmul) and validated against a real attention model.</summary>
+    public bool EnableAttentionFusion { get; set; } = false;
 
     /// <summary>Phase 4.3: Merge consecutive pointwise ops into fewer dispatch steps.</summary>
     public bool EnablePointwiseFusion { get; set; } = true;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputReplayAliasingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputReplayAliasingTests.cs
@@ -408,13 +408,7 @@ public class MultiInputReplayAliasingTests : IDisposable
         finally { cache.Dispose(); }
     }
 
-    [Fact(Skip = "KNOWN BUG (tracked): the compiled-inference step-mutating passes (OperatorReorderingPass " +
-        "+ MemoryPlanningPass, run for plans with >=4 steps) miscompute the fan-out attention topology — " +
-        "ONE shared input feeding q/k/v via matmul->reshape->permute, joined at SDPA — producing a " +
-        "DETERMINISTIC but WRONG result vs eager. Bypassing BOTH passes makes this + the whole compile " +
-        "suite pass (541/541), but MemoryPlanningPass is the SD-UNet peak-memory reducer (2GB->300MB), so " +
-        "the real fix is to make both passes' liveness view-aliasing-aware, not to disable them. Minimal " +
-        "repro: shared-input QKV->SDPA fails; single branch and separate-input QKV->SDPA both pass.")]
+    [Fact]
     public void Parity_SharedInput_QKV_Reshape_Permute_SDPA()
     {
         // Front half of the attention chain: ONE shared input -> 3x (matmul -> reshape -> permute) -> SDPA.
@@ -584,12 +578,13 @@ public class MultiInputReplayAliasingTests : IDisposable
             Assert.Equal(inputBefore, input2D.AsSpan().ToArray());
             plan.SetInputs(new[] { input2D, t });
             var got2 = Snapshot(plan.Execute());
+            var eager = Snapshot(forward());
             for (int i = 0; i < got1.Length; i++)
                 Assert.True(Math.Abs(got1[i] - got2[i]) < 1e-5f,
                     $"selfattn replay {i}: {got1[i]} vs {got2[i]} — non-deterministic compiled replay.");
-            // NOTE: an eager-PARITY assertion here FAILS on the original compiler — the step-mutating
-            // passes miscompute this fan-out attention chain (see the skipped
-            // Parity_SharedInput_QKV_Reshape_Permute_SDPA for the minimal repro + root cause).
+            for (int i = 0; i < got1.Length; i++)
+                Assert.True(Math.Abs(got1[i] - eager[i]) < 1e-4f,
+                    $"selfattn PARITY {i}: compiled {got1[i]} vs eager {eager[i]} — wrong compiled output.");
         }
         finally { cache.Dispose(); }
     }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputReplayAliasingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputReplayAliasingTests.cs
@@ -634,4 +634,57 @@ public class MultiInputReplayAliasingTests : IDisposable
         }
         finally { cache.Dispose(); }
     }
+
+    // ---- AttentionFusion correctness (#632/#633): the fused FlashAttention path must equal eager ----
+
+    [Theory]
+    // seqK == headDim is the case that SILENTLY CORRUPTED before the K-recovery fix: with the K operand
+    // left as K^T, the fused kernel transposed it again (→ Q@K) yet the equal shapes passed every dim
+    // check. seqK != headDim previously *skipped* fusion (mismatched dims rejected). Both must now match.
+    [InlineData(5, 5)]
+    [InlineData(6, 4)]
+    [InlineData(8, 8)]
+    public void AttentionFusion_FusedForwardMatchesEager_AfterKeyRecovery(int seqK, int headDim)
+    {
+        var saved = AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.Current.EnableAttentionFusion;
+        AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.Current.EnableAttentionFusion = true;
+        try
+        {
+            var engine = new CpuEngine();
+            const int seqQ = 7;
+            float scale = 1f / MathF.Sqrt(headDim); // matches the FlashAttention kernel's internal scale
+            var q = Tensor<float>.CreateRandom(new[] { seqQ, headDim });
+            var k = Tensor<float>.CreateRandom(new[] { seqK, headDim });
+            var v = Tensor<float>.CreateRandom(new[] { seqK, headDim });
+
+            // Decomposed attention: scores = (Q @ K^T) * scale -> softmax -> @ V. The K^T comes from an
+            // explicit TensorTranspose, which AttentionFusionPass must trace back to recover natural K.
+            Func<Tensor<float>> forward = () =>
+            {
+                var scores = engine.TensorMultiplyScalar(
+                    engine.TensorMatMul(q, engine.TensorTranspose(k)), scale); // [seqQ, seqK]
+                var probs = engine.TensorSoftmax(scores, -1);
+                return engine.TensorMatMul(probs, v);                          // [seqQ, headDim]
+            };
+
+            var eager = Snapshot(forward());
+            var cache = new CompiledModelCache<float>();
+            try
+            {
+                var plan = cache.GetOrCompileInference(new[] { q, k, v }, forward);
+                plan.SetInputs(new[] { q, k, v });
+                var got = Snapshot(plan.Execute());
+                Assert.Equal(eager.Length, got.Length);
+                for (int i = 0; i < got.Length; i++)
+                    Assert.True(Math.Abs(got[i] - eager[i]) < 1e-4f,
+                        $"attention-fusion parity [seqK={seqK}, headDim={headDim}] idx {i}: " +
+                        $"fused {got[i]} vs eager {eager[i]} — K-recovery produced the wrong key orientation.");
+            }
+            finally { cache.Dispose(); }
+        }
+        finally
+        {
+            AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.Current.EnableAttentionFusion = saved;
+        }
+    }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputReplayAliasingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputReplayAliasingTests.cs
@@ -71,6 +71,7 @@ public class MultiInputReplayAliasingTests : IDisposable
             // Second replay with the SAME instances must reproduce the first (deterministic).
             plan.SetInputs(new[] { x, t });
             var got2 = Snapshot(plan.Execute());
+            Assert.Equal(got1.Length, got2.Length);        // guard against a short-output false pass
             for (int i = 0; i < got1.Length; i++)
                 Assert.True(Math.Abs(got1[i] - got2[i]) < 1e-5f,
                     $"replay {i}: {got1[i]} vs {got2[i]} — non-deterministic compiled replay.");
@@ -104,6 +105,7 @@ public class MultiInputReplayAliasingTests : IDisposable
         };
 
         var xBefore = Snapshot(x);
+        var tBefore = Snapshot(t);
         var cache = new CompiledModelCache<float>();
         try
         {
@@ -111,8 +113,10 @@ public class MultiInputReplayAliasingTests : IDisposable
             plan.SetInputs(new[] { x, t });
             var got1 = Snapshot(plan.Execute());
             Assert.Equal(xBefore, x.AsSpan().ToArray());
+            Assert.Equal(tBefore, t.AsSpan().ToArray());   // every SetInputs operand must be immutable
             plan.SetInputs(new[] { x, t });
             var got2 = Snapshot(plan.Execute());
+            Assert.Equal(got1.Length, got2.Length);        // guard against a short-output false pass
             for (int i = 0; i < got1.Length; i++)
                 Assert.True(Math.Abs(got1[i] - got2[i]) < 1e-5f,
                     $"diff-rank replay {i}: {got1[i]} vs {got2[i]} — non-deterministic.");
@@ -145,6 +149,7 @@ public class MultiInputReplayAliasingTests : IDisposable
         };
 
         var xBefore = Snapshot(x);
+        var tBefore = Snapshot(t);
         var cache = new CompiledModelCache<float>();
         try
         {
@@ -152,8 +157,10 @@ public class MultiInputReplayAliasingTests : IDisposable
             plan.SetInputs(new[] { x, t });
             var got1 = Snapshot(plan.Execute());
             Assert.Equal(xBefore, x.AsSpan().ToArray());
+            Assert.Equal(tBefore, t.AsSpan().ToArray());   // every SetInputs operand must be immutable
             plan.SetInputs(new[] { x, t });
             var got2 = Snapshot(plan.Execute());
+            Assert.Equal(got1.Length, got2.Length);        // guard against a short-output false pass
             for (int i = 0; i < got1.Length; i++)
                 Assert.True(Math.Abs(got1[i] - got2[i]) < 1e-5f,
                     $"attn replay {i}: {got1[i]} vs {got2[i]} — non-deterministic compiled replay.");
@@ -646,45 +653,40 @@ public class MultiInputReplayAliasingTests : IDisposable
     [InlineData(8, 8)]
     public void AttentionFusion_FusedForwardMatchesEager_AfterKeyRecovery(int seqK, int headDim)
     {
-        var saved = AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.Current.EnableAttentionFusion;
-        AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.Current.EnableAttentionFusion = true;
+        // AttentionFusion is on by default (TensorCodecOptions.EnableAttentionFusion = true), so this
+        // exercises the fused path WITHOUT writing the process-global TensorCodecOptions.Current — which
+        // would race other parallel tests. No test mutates that global flag (the disable-fusion tests use
+        // local TensorCodecOptions instances), so the default-on value holds for the whole run.
+        var engine = new CpuEngine();
+        const int seqQ = 7;
+        float scale = 1f / MathF.Sqrt(headDim); // matches the FlashAttention kernel's internal scale
+        var q = Tensor<float>.CreateRandom(new[] { seqQ, headDim });
+        var k = Tensor<float>.CreateRandom(new[] { seqK, headDim });
+        var v = Tensor<float>.CreateRandom(new[] { seqK, headDim });
+
+        // Decomposed attention: scores = (Q @ K^T) * scale -> softmax -> @ V. The K^T comes from an
+        // explicit TensorTranspose, which AttentionFusionPass must trace back to recover natural K.
+        Func<Tensor<float>> forward = () =>
+        {
+            var scores = engine.TensorMultiplyScalar(
+                engine.TensorMatMul(q, engine.TensorTranspose(k)), scale); // [seqQ, seqK]
+            var probs = engine.TensorSoftmax(scores, -1);
+            return engine.TensorMatMul(probs, v);                          // [seqQ, headDim]
+        };
+
+        var eager = Snapshot(forward());
+        var cache = new CompiledModelCache<float>();
         try
         {
-            var engine = new CpuEngine();
-            const int seqQ = 7;
-            float scale = 1f / MathF.Sqrt(headDim); // matches the FlashAttention kernel's internal scale
-            var q = Tensor<float>.CreateRandom(new[] { seqQ, headDim });
-            var k = Tensor<float>.CreateRandom(new[] { seqK, headDim });
-            var v = Tensor<float>.CreateRandom(new[] { seqK, headDim });
-
-            // Decomposed attention: scores = (Q @ K^T) * scale -> softmax -> @ V. The K^T comes from an
-            // explicit TensorTranspose, which AttentionFusionPass must trace back to recover natural K.
-            Func<Tensor<float>> forward = () =>
-            {
-                var scores = engine.TensorMultiplyScalar(
-                    engine.TensorMatMul(q, engine.TensorTranspose(k)), scale); // [seqQ, seqK]
-                var probs = engine.TensorSoftmax(scores, -1);
-                return engine.TensorMatMul(probs, v);                          // [seqQ, headDim]
-            };
-
-            var eager = Snapshot(forward());
-            var cache = new CompiledModelCache<float>();
-            try
-            {
-                var plan = cache.GetOrCompileInference(new[] { q, k, v }, forward);
-                plan.SetInputs(new[] { q, k, v });
-                var got = Snapshot(plan.Execute());
-                Assert.Equal(eager.Length, got.Length);
-                for (int i = 0; i < got.Length; i++)
-                    Assert.True(Math.Abs(got[i] - eager[i]) < 1e-4f,
-                        $"attention-fusion parity [seqK={seqK}, headDim={headDim}] idx {i}: " +
-                        $"fused {got[i]} vs eager {eager[i]} — K-recovery produced the wrong key orientation.");
-            }
-            finally { cache.Dispose(); }
+            var plan = cache.GetOrCompileInference(new[] { q, k, v }, forward);
+            plan.SetInputs(new[] { q, k, v });
+            var got = Snapshot(plan.Execute());
+            Assert.Equal(eager.Length, got.Length);
+            for (int i = 0; i < got.Length; i++)
+                Assert.True(Math.Abs(got[i] - eager[i]) < 1e-4f,
+                    $"attention-fusion parity [seqK={seqK}, headDim={headDim}] idx {i}: " +
+                    $"fused {got[i]} vs eager {eager[i]} — K-recovery produced the wrong key orientation.");
         }
-        finally
-        {
-            AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.Current.EnableAttentionFusion = saved;
-        }
+        finally { cache.Dispose(); }
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputReplayAliasingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputReplayAliasingTests.cs
@@ -162,6 +162,48 @@ public class MultiInputReplayAliasingTests : IDisposable
     }
 
     [Fact]
+    public void Replay_LeafThroughMatmulThenSliceAxis_Deterministic()
+    {
+        // The precise combination only the multi-input full DiT exercises: the secondary leaf (timeEmbed)
+        // goes through a matmul (AdaLNModulation) -> reshape -> TensorSliceAxis views -> AdaLN. Single-input
+        // DiT bakes this whole chain to constants (timestep is constant), so it never hits it; the prior
+        // repros tested matmul-on-leaf and slice-on-leaf SEPARATELY but not chained.
+        var engine = new CpuEngine();
+        int seq = 4, hidden = 8, k = 6;
+        var x = Tensor<float>.CreateRandom(new[] { 1, seq, hidden });
+        var te = Tensor<float>.CreateRandom(new[] { 1, k });             // timeEmbed leaf
+        var wMod = Tensor<float>.CreateRandom(new[] { k, 6 * hidden });
+
+        Func<Tensor<float>> forward = () =>
+        {
+            var mod = engine.TensorMatMul(te, wMod);                     // [1, 6*hidden]  (AdaLNModulation)
+            var modR = engine.Reshape(mod, new[] { 1, 6, 1, hidden });
+            var shift = engine.TensorSliceAxis(modR, 1, 0);
+            var scale = engine.TensorSliceAxis(modR, 1, 1);
+            var scaled = engine.TensorBroadcastMultiply(x, engine.TensorAddScalar(scale, 1f));
+            return engine.TensorBroadcastAdd(scaled, shift);
+        };
+
+        var xBefore = Snapshot(x);
+        var teBefore = Snapshot(te);
+        var cache = new CompiledModelCache<float>();
+        try
+        {
+            var plan = cache.GetOrCompileInference(new[] { x, te }, forward);
+            plan.SetInputs(new[] { x, te });
+            var got1 = Snapshot(plan.Execute());
+            Assert.Equal(xBefore, x.AsSpan().ToArray());
+            Assert.Equal(teBefore, te.AsSpan().ToArray());
+            plan.SetInputs(new[] { x, te });
+            var got2 = Snapshot(plan.Execute());
+            for (int i = 0; i < got1.Length; i++)
+                Assert.True(Math.Abs(got1[i] - got2[i]) < 1e-5f,
+                    $"matmul-then-slice replay {i}: {got1[i]} vs {got2[i]} — non-deterministic compiled replay.");
+        }
+        finally { cache.Dispose(); }
+    }
+
+    [Fact]
     public void Replay_PatchifyReshapeOfPermute_Deterministic()
     {
         // DiT.Patchify: [B,C,H,W] -> 6D reshape -> permute {0,2,4,1,3,5} -> reshape to [B,numPatches,
@@ -304,6 +346,206 @@ public class MultiInputReplayAliasingTests : IDisposable
     }
 
     [Fact]
+    public void Parity_PermuteThenReshape()
+    {
+        // The remaining piece of the failing chain: RESHAPE of a PERMUTE output. Eager permute returns a
+        // strided view; reshaping it must materialize to logical order. The compiled plan materializes the
+        // permute (TensorPermuteInto -> contiguous) then reshapes. If eager reshape reinterprets strides
+        // (physical order) instead of materializing, eager and compiled diverge here.
+        var engine = new CpuEngine();
+        int B = 1, heads = 2, seq = 4, hd = 4;
+        var x = Tensor<float>.CreateRandom(new[] { B, heads, seq, hd });
+        var t = Tensor<float>.CreateRandom(new[] { B, seq, heads * hd });
+        Func<Tensor<float>> forward = () =>
+        {
+            var p = engine.TensorPermute(x, new[] { 0, 2, 1, 3 });   // [B, seq, heads, hd] (strided in eager)
+            var flat = engine.Reshape(p, new[] { B, seq, heads * hd });
+            return engine.TensorBroadcastAdd(flat, t);                // materialize
+        };
+        var eager = Snapshot(forward());
+        var cache = new CompiledModelCache<float>();
+        try
+        {
+            var plan = cache.GetOrCompileInference(new[] { x, t }, forward);
+            plan.SetInputs(new[] { x, t });
+            var got = Snapshot(plan.Execute());
+            for (int i = 0; i < got.Length; i++)
+                Assert.True(Math.Abs(got[i] - eager[i]) < 1e-4f,
+                    $"permute-then-reshape parity {i}: compiled {got[i]} vs eager {eager[i]}.");
+        }
+        finally { cache.Dispose(); }
+    }
+
+    [Fact]
+    public void Parity_Matmul_ReshapeView_Permute_SingleBranch()
+    {
+        // Minimal: matmul -> reshape (recorded as a no-op VIEW sharing the matmul's buffer) -> permute
+        // -> materialize. If the plan reuses the matmul's buffer without seeing that the reshape-view +
+        // permute still need it, the permute reads stale data.
+        var engine = new CpuEngine();
+        int seq = 4, embed = 8, heads = 2, headDim = embed / heads;
+        var input2D = Tensor<float>.CreateRandom(new[] { seq, embed });
+        var w = Tensor<float>.CreateRandom(new[] { embed, embed });
+        var t = Tensor<float>.CreateRandom(new[] { 1, heads, seq, headDim });
+        Func<Tensor<float>> forward = () =>
+        {
+            var mm = engine.TensorMatMul(input2D, w);                                  // [seq, embed]
+            var r = engine.Reshape(mm, new[] { 1, seq, heads, headDim });              // view
+            var p = engine.TensorPermute(r, new[] { 0, 2, 1, 3 });                     // [1, heads, seq, headDim]
+            return engine.TensorBroadcastAdd(p, t);
+        };
+        var eager = Snapshot(forward());
+        var cache = new CompiledModelCache<float>();
+        try
+        {
+            var plan = cache.GetOrCompileInference(new[] { input2D, t }, forward);
+            plan.SetInputs(new[] { input2D, t });
+            var got = Snapshot(plan.Execute());
+            for (int i = 0; i < got.Length; i++)
+                Assert.True(Math.Abs(got[i] - eager[i]) < 1e-4f,
+                    $"matmul-reshape-permute parity {i}: compiled {got[i]} vs eager {eager[i]}.");
+        }
+        finally { cache.Dispose(); }
+    }
+
+    [Fact(Skip = "KNOWN BUG (tracked): the compiled-inference step-mutating passes (OperatorReorderingPass " +
+        "+ MemoryPlanningPass, run for plans with >=4 steps) miscompute the fan-out attention topology — " +
+        "ONE shared input feeding q/k/v via matmul->reshape->permute, joined at SDPA — producing a " +
+        "DETERMINISTIC but WRONG result vs eager. Bypassing BOTH passes makes this + the whole compile " +
+        "suite pass (541/541), but MemoryPlanningPass is the SD-UNet peak-memory reducer (2GB->300MB), so " +
+        "the real fix is to make both passes' liveness view-aliasing-aware, not to disable them. Minimal " +
+        "repro: shared-input QKV->SDPA fails; single branch and separate-input QKV->SDPA both pass.")]
+    public void Parity_SharedInput_QKV_Reshape_Permute_SDPA()
+    {
+        // Front half of the attention chain: ONE shared input -> 3x (matmul -> reshape -> permute) -> SDPA.
+        // The passing Parity_PermuteThenSDPA used 3 SEPARATE inputs; here q/k/v all derive from one input
+        // through matmul+reshape, which is what the real SelfAttentionLayer does.
+        var engine = new CpuEngine();
+        int seq = 4, embed = 8, heads = 2, headDim = embed / heads;
+        var input2D = Tensor<float>.CreateRandom(new[] { seq, embed });
+        var wq = Tensor<float>.CreateRandom(new[] { embed, embed });
+        var wk = Tensor<float>.CreateRandom(new[] { embed, embed });
+        var wv = Tensor<float>.CreateRandom(new[] { embed, embed });
+        Func<Tensor<float>> forward = () =>
+        {
+            var q = engine.TensorPermute(engine.Reshape(engine.TensorMatMul(input2D, wq), new[] { 1, seq, heads, headDim }), new[] { 0, 2, 1, 3 });
+            var k = engine.TensorPermute(engine.Reshape(engine.TensorMatMul(input2D, wk), new[] { 1, seq, heads, headDim }), new[] { 0, 2, 1, 3 });
+            var v = engine.TensorPermute(engine.Reshape(engine.TensorMatMul(input2D, wv), new[] { 1, seq, heads, headDim }), new[] { 0, 2, 1, 3 });
+            return engine.ScaledDotProductAttention(q, k, v, null, 1.0 / Math.Sqrt(headDim), out _);
+        };
+        var eager = Snapshot(forward());
+        var cache = new CompiledModelCache<float>();
+        try
+        {
+            var plan = cache.GetOrCompileInference(input2D, forward);
+            if (plan is ICompiledPlan<float> rb) rb.SetInputs(new[] { input2D });
+            var got = Snapshot(plan.Execute());
+            for (int i = 0; i < got.Length; i++)
+                Assert.True(Math.Abs(got[i] - eager[i]) < 1e-4f,
+                    $"shared-qkv parity {i}: compiled {got[i]} vs eager {eager[i]}.");
+        }
+        finally { cache.Dispose(); }
+    }
+
+    [Fact]
+    public void Parity_PermuteThenSDPA()
+    {
+        // The exact failing sub-chain: permute q/k/v (materialized contiguous in the plan; strided views
+        // in eager) THEN feed SDPA. SDPA-alone and permute-alone both pass parity; this composition is
+        // where the SelfAttentionLayerOps repro diverged.
+        var engine = new CpuEngine();
+        var q = Tensor<float>.CreateRandom(new[] { 1, 4, 2, 4 });   // [B, seq, heads, headDim]
+        var k = Tensor<float>.CreateRandom(new[] { 1, 4, 2, 4 });
+        var v = Tensor<float>.CreateRandom(new[] { 1, 4, 2, 4 });
+        Func<Tensor<float>> forward = () =>
+        {
+            var qh = engine.TensorPermute(q, new[] { 0, 2, 1, 3 });  // [B, heads, seq, headDim]
+            var kh = engine.TensorPermute(k, new[] { 0, 2, 1, 3 });
+            var vh = engine.TensorPermute(v, new[] { 0, 2, 1, 3 });
+            return engine.ScaledDotProductAttention(qh, kh, vh, null, 0.5, out _);
+        };
+        var eager = Snapshot(forward());
+        var cache = new CompiledModelCache<float>();
+        try
+        {
+            var plan = cache.GetOrCompileInference(new[] { q, k, v }, forward);
+            plan.SetInputs(new[] { q, k, v });
+            var got = Snapshot(plan.Execute());
+            for (int i = 0; i < got.Length; i++)
+                Assert.True(Math.Abs(got[i] - eager[i]) < 1e-4f,
+                    $"permute-then-SDPA parity {i}: compiled {got[i]} vs eager {eager[i]}.");
+        }
+        finally { cache.Dispose(); }
+    }
+
+    [Fact]
+    public void Parity_TwoPermuteOutputsLiveAtOnce()
+    {
+        // Minimal: two permute outputs that must BOTH be live for the add. If the compiled plan reuses
+        // a buffer (mis-computed liveness for materialized-permute outputs), the add reads corrupted data.
+        var engine = new CpuEngine();
+        var a = Tensor<float>.CreateRandom(new[] { 1, 4, 2, 4 });
+        var b = Tensor<float>.CreateRandom(new[] { 1, 4, 2, 4 });
+        Func<Tensor<float>> forward = () =>
+        {
+            var pa = engine.TensorPermute(a, new[] { 0, 2, 1, 3 });
+            var pb = engine.TensorPermute(b, new[] { 0, 2, 1, 3 });
+            return engine.TensorAdd(pa, pb);
+        };
+        var eager = Snapshot(forward());
+        var cache = new CompiledModelCache<float>();
+        try
+        {
+            var plan = cache.GetOrCompileInference(new[] { a, b }, forward);
+            plan.SetInputs(new[] { a, b });
+            var got = Snapshot(plan.Execute());
+            for (int i = 0; i < got.Length; i++)
+                Assert.True(Math.Abs(got[i] - eager[i]) < 1e-4f,
+                    $"two-permute parity {i}: compiled {got[i]} vs eager {eager[i]}.");
+        }
+        finally { cache.Dispose(); }
+    }
+
+    [Fact]
+    public void Parity_ScaledDotProductAttention_4D()
+    {
+        var engine = new CpuEngine();
+        var q = Tensor<float>.CreateRandom(new[] { 1, 2, 4, 4 });
+        Func<Tensor<float>> forward = () => engine.ScaledDotProductAttention(q, q, q, null, 0.5, out _);
+        var eager = Snapshot(forward());
+        var cache = new CompiledModelCache<float>();
+        try
+        {
+            var plan = cache.GetOrCompileInference(q, forward);
+            if (plan is ICompiledPlan<float> rb) rb.SetInputs(new[] { q });
+            var got = Snapshot(plan.Execute());
+            for (int i = 0; i < got.Length; i++)
+                Assert.True(Math.Abs(got[i] - eager[i]) < 1e-4f,
+                    $"SDPA parity {i}: compiled {got[i]} vs eager {eager[i]}.");
+        }
+        finally { cache.Dispose(); }
+    }
+
+    [Fact]
+    public void Parity_TensorPermuteInto_vs_TransposeContiguous_4D()
+    {
+        // Direct eager check (no compile): the compiled plan materializes permute via TensorPermuteInto;
+        // eager downstream consumes the strided Transpose view. Both must agree on the logical permuted
+        // data. Compares TensorPermuteInto's output against Transpose().Contiguous() (logical order).
+        var engine = new CpuEngine();
+        var x = Tensor<float>.CreateRandom(new[] { 1, 4, 2, 4 });
+        var axes = new[] { 0, 2, 1, 3 };
+
+        var viaInto = new Tensor<float>(new[] { 1, 2, 4, 4 });
+        engine.TensorPermuteInto(viaInto, x, axes);
+        var viaTranspose = engine.TensorPermute(x, axes).Contiguous();
+
+        for (int i = 0; i < viaInto.Length; i++)
+            Assert.True(Math.Abs(viaInto[i] - viaTranspose[i]) < 1e-5f,
+                $"PermuteInto vs Transpose.Contiguous {i}: {viaInto[i]} vs {viaTranspose[i]}.");
+    }
+
+    [Fact]
     public void Replay_SelfAttentionLayerOps_Deterministic()
     {
         // Faithful mirror of SelfAttentionLayer.Forward's op sequence: QKV matmul -> reshape to heads
@@ -345,6 +587,9 @@ public class MultiInputReplayAliasingTests : IDisposable
             for (int i = 0; i < got1.Length; i++)
                 Assert.True(Math.Abs(got1[i] - got2[i]) < 1e-5f,
                     $"selfattn replay {i}: {got1[i]} vs {got2[i]} — non-deterministic compiled replay.");
+            // NOTE: an eager-PARITY assertion here FAILS on the original compiler — the step-mutating
+            // passes miscompute this fan-out attention chain (see the skipped
+            // Parity_SharedInput_QKV_Reshape_Permute_SDPA for the minimal repro + root cause).
         }
         finally { cache.Dispose(); }
     }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputReplayAliasingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputReplayAliasingTests.cs
@@ -162,6 +162,194 @@ public class MultiInputReplayAliasingTests : IDisposable
     }
 
     [Fact]
+    public void Replay_PatchifyReshapeOfPermute_Deterministic()
+    {
+        // DiT.Patchify: [B,C,H,W] -> 6D reshape -> permute {0,2,4,1,3,5} -> reshape to [B,numPatches,
+        // patchDim]. The final reshape collapses a NON-contiguous permuted view — a pattern none of the
+        // other repros hit (they permute 4D then feed an op that handles strides; this RESHAPES the
+        // strided permute directly). Reuse the same image input across replays.
+        var engine = new CpuEngine();
+        int B = 1, C = 4, H = 8, W = 8, p = 2;
+        int nH = H / p, nW = W / p, numPatches = nH * nW, patchDim = C * p * p;
+        var x = Tensor<float>.CreateRandom(new[] { B, C, H, W });
+        var t = Tensor<float>.CreateRandom(new[] { B, numPatches, patchDim });
+
+        Func<Tensor<float>> forward = () =>
+        {
+            var split = engine.Reshape(x, new[] { B, C, nH, p, nW, p });
+            var permuted = engine.TensorPermute(split, new[] { 0, 2, 4, 1, 3, 5 });
+            var patches = engine.Reshape(permuted, new[] { B, numPatches, patchDim });
+            return engine.TensorAdd(patches, t);
+        };
+
+        var xBefore = Snapshot(x);
+        var cache = new CompiledModelCache<float>();
+        try
+        {
+            var plan = cache.GetOrCompileInference(new[] { x, t }, forward);
+            plan.SetInputs(new[] { x, t });
+            var got1 = Snapshot(plan.Execute());
+            Assert.Equal(xBefore, x.AsSpan().ToArray());
+            plan.SetInputs(new[] { x, t });
+            var got2 = Snapshot(plan.Execute());
+            for (int i = 0; i < got1.Length; i++)
+                Assert.True(Math.Abs(got1[i] - got2[i]) < 1e-5f,
+                    $"patchify replay {i}: {got1[i]} vs {got2[i]} — non-deterministic compiled replay.");
+        }
+        finally { cache.Dispose(); }
+    }
+
+    [Fact]
+    public void Replay_AdaLNSliceAxisViews_Deterministic()
+    {
+        // The exact DiT-block AdaLN pattern: a modulation tensor reshaped to [B,6,1,hidden] and split
+        // into six [B,1,hidden] VIEWS via Engine.TensorSliceAxis (shared backing buffer), then used as
+        // scale/shift in y = x*(1+scale)+shift plus a gated residual. None of the other repros use
+        // TensorSliceAxis. The second input (the modulation source) is reused across replays.
+        var engine = new CpuEngine();
+        int seq = 4, hidden = 8;
+        var x = Tensor<float>.CreateRandom(new[] { 1, seq, hidden });
+        var mod = Tensor<float>.CreateRandom(new[] { 1, 6 * hidden });    // AdaLN modulation source
+
+        Func<Tensor<float>> forward = () =>
+        {
+            var modReshaped = engine.Reshape(mod, new[] { 1, 6, 1, hidden });
+            var shift1 = engine.TensorSliceAxis(modReshaped, 1, 0);
+            var scale1 = engine.TensorSliceAxis(modReshaped, 1, 1);
+            var gate1  = engine.TensorSliceAxis(modReshaped, 1, 2);
+            // y = x*(1+scale)+shift  (ApplyAdaLN)
+            var scaled = engine.TensorBroadcastMultiply(x, engine.TensorAddScalar(scale1, 1f));
+            var normed = engine.TensorBroadcastAdd(scaled, shift1);
+            // gated residual: x + gate*normed
+            var gated = engine.TensorBroadcastMultiply(normed, gate1);
+            return engine.TensorAdd(x, gated);
+        };
+
+        var xBefore = Snapshot(x);
+        var modBefore = Snapshot(mod);
+        var cache = new CompiledModelCache<float>();
+        try
+        {
+            var plan = cache.GetOrCompileInference(new[] { x, mod }, forward);
+            plan.SetInputs(new[] { x, mod });
+            var got1 = Snapshot(plan.Execute());
+            Assert.Equal(xBefore, x.AsSpan().ToArray());
+            Assert.Equal(modBefore, mod.AsSpan().ToArray());
+            plan.SetInputs(new[] { x, mod });
+            var got2 = Snapshot(plan.Execute());
+            for (int i = 0; i < got1.Length; i++)
+                Assert.True(Math.Abs(got1[i] - got2[i]) < 1e-5f,
+                    $"adaln-slice replay {i}: {got1[i]} vs {got2[i]} — non-deterministic compiled replay.");
+        }
+        finally { cache.Dispose(); }
+    }
+
+    [Fact]
+    public void Replay_MultiBlockMiniDiT_Deterministic()
+    {
+        // A deep mini-DiT: 4 stacked blocks of (AdaLN-by-input-2 -> self-attention -> residual ->
+        // AdaLN -> GELU MLP -> residual). Stresses the compiled plan's buffer pool the way the real
+        // multi-block DiT does, which the single-block repros do not. Reuse the SAME input instance.
+        var engine = new CpuEngine();
+        int seq = 4, embed = 8, heads = 2, headDim = embed / heads;
+        const int blocks = 4;
+        var x0 = Tensor<float>.CreateRandom(new[] { seq, embed });
+        var t = Tensor<float>.CreateRandom(new[] { 1, embed });            // modulation, consumed every block
+        var g = Tensor<float>.CreateRandom(new[] { embed });
+        var b = Tensor<float>.CreateRandom(new[] { embed });
+        var wq = new Tensor<float>[blocks]; var wk = new Tensor<float>[blocks];
+        var wv = new Tensor<float>[blocks]; var wm = new Tensor<float>[blocks];
+        for (int i = 0; i < blocks; i++)
+        {
+            wq[i] = Tensor<float>.CreateRandom(new[] { embed, embed });
+            wk[i] = Tensor<float>.CreateRandom(new[] { embed, embed });
+            wv[i] = Tensor<float>.CreateRandom(new[] { embed, embed });
+            wm[i] = Tensor<float>.CreateRandom(new[] { embed, embed });
+        }
+
+        Func<Tensor<float>> forward = () =>
+        {
+            var x = (Tensor<float>)x0;
+            for (int i = 0; i < blocks; i++)
+            {
+                var n1 = engine.TensorBroadcastMultiply(engine.TensorLayerNorm(x, g, b), t);
+                var q = engine.TensorPermute(engine.Reshape(engine.TensorMatMul(n1, wq[i]), new[] { 1, seq, heads, headDim }), new[] { 0, 2, 1, 3 });
+                var k = engine.TensorPermute(engine.Reshape(engine.TensorMatMul(n1, wk[i]), new[] { 1, seq, heads, headDim }), new[] { 0, 2, 1, 3 });
+                var v = engine.TensorPermute(engine.Reshape(engine.TensorMatMul(n1, wv[i]), new[] { 1, seq, heads, headDim }), new[] { 0, 2, 1, 3 });
+                var attn = engine.ScaledDotProductAttention(q, k, v, null, 1.0 / Math.Sqrt(headDim), out _);
+                var attnFlat = engine.Reshape(engine.TensorPermute(attn, new[] { 0, 2, 1, 3 }), new[] { seq, embed });
+                x = engine.TensorAdd(x, attnFlat);
+                var n2 = engine.TensorBroadcastMultiply(engine.TensorLayerNorm(x, g, b), t);
+                var mlp = engine.GELU(engine.TensorMatMul(n2, wm[i]));
+                x = engine.TensorAdd(x, mlp);
+            }
+            return x;
+        };
+
+        var xBefore = Snapshot(x0);
+        var cache = new CompiledModelCache<float>();
+        try
+        {
+            var plan = cache.GetOrCompileInference(new[] { x0, t }, forward);
+            plan.SetInputs(new[] { x0, t });
+            var got1 = Snapshot(plan.Execute());
+            Assert.Equal(xBefore, x0.AsSpan().ToArray());
+            plan.SetInputs(new[] { x0, t });
+            var got2 = Snapshot(plan.Execute());
+            for (int i = 0; i < got1.Length; i++)
+                Assert.True(Math.Abs(got1[i] - got2[i]) < 1e-5f,
+                    $"minidit replay {i}: {got1[i]} vs {got2[i]} — non-deterministic compiled replay.");
+        }
+        finally { cache.Dispose(); }
+    }
+
+    [Fact]
+    public void Replay_SelfAttentionLayerOps_Deterministic()
+    {
+        // Faithful mirror of SelfAttentionLayer.Forward's op sequence: QKV matmul -> reshape to heads
+        // -> permute -> 4D ScaledDotProductAttention (with the secondary `out attentionWeights`) ->
+        // permute back -> reshape -> add the second input. This is the exact path a DiT block walks,
+        // and the one the simpler repros lack. Reuse the SAME input instance across replays.
+        var engine = new CpuEngine();
+        int seq = 4, embed = 8, heads = 2, headDim = embed / heads;
+        var input2D = Tensor<float>.CreateRandom(new[] { seq, embed });
+        var t = Tensor<float>.CreateRandom(new[] { 1, seq, embed });
+        var wq = Tensor<float>.CreateRandom(new[] { embed, embed });
+        var wk = Tensor<float>.CreateRandom(new[] { embed, embed });
+        var wv = Tensor<float>.CreateRandom(new[] { embed, embed });
+
+        Func<Tensor<float>> forward = () =>
+        {
+            var q = engine.Reshape(engine.TensorMatMul(input2D, wq), new[] { 1, seq, heads, headDim });
+            var k = engine.Reshape(engine.TensorMatMul(input2D, wk), new[] { 1, seq, heads, headDim });
+            var v = engine.Reshape(engine.TensorMatMul(input2D, wv), new[] { 1, seq, heads, headDim });
+            var qh = engine.TensorPermute(q, new[] { 0, 2, 1, 3 });
+            var kh = engine.TensorPermute(k, new[] { 0, 2, 1, 3 });
+            var vh = engine.TensorPermute(v, new[] { 0, 2, 1, 3 });
+            var attn = engine.ScaledDotProductAttention(qh, kh, vh, null, 1.0 / Math.Sqrt(headDim), out _);
+            var back = engine.TensorPermute(attn, new[] { 0, 2, 1, 3 });
+            var flat = engine.Reshape(back, new[] { 1, seq, embed });
+            return engine.TensorBroadcastAdd(flat, t);
+        };
+
+        var inputBefore = Snapshot(input2D);
+        var cache = new CompiledModelCache<float>();
+        try
+        {
+            var plan = cache.GetOrCompileInference(new[] { input2D, t }, forward);
+            plan.SetInputs(new[] { input2D, t });
+            var got1 = Snapshot(plan.Execute());
+            Assert.Equal(inputBefore, input2D.AsSpan().ToArray());
+            plan.SetInputs(new[] { input2D, t });
+            var got2 = Snapshot(plan.Execute());
+            for (int i = 0; i < got1.Length; i++)
+                Assert.True(Math.Abs(got1[i] - got2[i]) < 1e-5f,
+                    $"selfattn replay {i}: {got1[i]} vs {got2[i]} — non-deterministic compiled replay.");
+        }
+        finally { cache.Dispose(); }
+    }
+
+    [Fact]
     public void Replay_AdaLNBlock_Deterministic()
     {
         // Faithful mini-DiT block: LayerNorm modulated by a broadcast scale/shift derived from the

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputReplayAliasingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputReplayAliasingTests.cs
@@ -689,4 +689,76 @@ public class MultiInputReplayAliasingTests : IDisposable
         }
         finally { cache.Dispose(); }
     }
+
+    [Fact]
+    public void AttentionFusion_RefusesFusion_WhenKeyHasNoProducingTranspose_StillMatchesEager()
+    {
+        // scores = Q @ K with K supplied DIRECTLY (not produced by a TensorTranspose) -> softmax -> @ V.
+        // The pass matches the MatMul->Softmax->MatMul shape, but the key operand has no producing
+        // transpose, so TryRecoverNaturalKey can't prove its orientation and returns false -> fusion is
+        // REFUSED. The plan must fall back to the unfused steps and still equal eager. Exercises the
+        // refuse-to-fuse path (no-producer branch) that keeps a non-attention/unprovable pattern correct.
+        var engine = new CpuEngine();
+        int seqQ = 5, d = 4, seqK = 6, dV = 4;
+        var q = Tensor<float>.CreateRandom(new[] { seqQ, d });
+        var kDirect = Tensor<float>.CreateRandom(new[] { d, seqK }); // used directly as the matmul's B
+        var v = Tensor<float>.CreateRandom(new[] { seqK, dV });
+
+        Func<Tensor<float>> forward = () =>
+        {
+            var scores = engine.TensorMatMul(q, kDirect);  // [seqQ, seqK] — no transpose feeds K
+            var probs = engine.TensorSoftmax(scores, -1);
+            return engine.TensorMatMul(probs, v);          // [seqQ, dV]
+        };
+
+        var eager = Snapshot(forward());
+        var cache = new CompiledModelCache<float>();
+        try
+        {
+            var plan = cache.GetOrCompileInference(new[] { q, kDirect, v }, forward);
+            plan.SetInputs(new[] { q, kDirect, v });
+            var got = Snapshot(plan.Execute());
+            Assert.Equal(eager.Length, got.Length);
+            for (int i = 0; i < got.Length; i++)
+                Assert.True(Math.Abs(got[i] - eager[i]) < 1e-4f,
+                    $"refuse-fusion (no-transpose) parity idx {i}: compiled {got[i]} vs eager {eager[i]}.");
+        }
+        finally { cache.Dispose(); }
+    }
+
+    [Fact]
+    public void AttentionFusion_RefusesFusion_WhenKeyProducerIsNotATranspose_StillMatchesEager()
+    {
+        // K is produced by a MatMul (not a TensorTranspose), so even though the operand has a producer,
+        // TryRecoverNaturalKey returns false at the OpType check -> fusion REFUSED -> unfused == eager.
+        // Exercises the "producer is not a transpose" refuse branch.
+        var engine = new CpuEngine();
+        int seqQ = 5, d = 4, m = 3, seqK = 6, dV = 4;
+        var q = Tensor<float>.CreateRandom(new[] { seqQ, d });
+        var kx = Tensor<float>.CreateRandom(new[] { d, m });
+        var kw = Tensor<float>.CreateRandom(new[] { m, seqK });
+        var v = Tensor<float>.CreateRandom(new[] { seqK, dV });
+
+        Func<Tensor<float>> forward = () =>
+        {
+            var kProj = engine.TensorMatMul(kx, kw);       // [d, seqK] — produced by a MatMul, not a transpose
+            var scores = engine.TensorMatMul(q, kProj);    // [seqQ, seqK]
+            var probs = engine.TensorSoftmax(scores, -1);
+            return engine.TensorMatMul(probs, v);          // [seqQ, dV]
+        };
+
+        var eager = Snapshot(forward());
+        var cache = new CompiledModelCache<float>();
+        try
+        {
+            var plan = cache.GetOrCompileInference(new[] { q, kx, kw, v }, forward);
+            plan.SetInputs(new[] { q, kx, kw, v });
+            var got = Snapshot(plan.Execute());
+            Assert.Equal(eager.Length, got.Length);
+            for (int i = 0; i < got.Length; i++)
+                Assert.True(Math.Abs(got[i] - eager[i]) < 1e-4f,
+                    $"refuse-fusion (non-transpose producer) parity idx {i}: compiled {got[i]} vs eager {eager[i]}.");
+        }
+        finally { cache.Dispose(); }
+    }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputReplayAliasingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputReplayAliasingTests.cs
@@ -1,0 +1,209 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// Reproduces a multi-input compiled-inference REPLAY defect surfaced by wiring a real diffusion DiT
+/// (attention + AdaLN + residuals) through <see cref="CompiledModelCache{T}.GetOrCompileInference(Tensor{T}[], Func{Tensor{T}})"/>:
+/// the eager forward is deterministic, but the compiled plan's replay was NOT — consecutive Execute()
+/// calls with the SAME input instances produced different outputs. The smoking gun is that the plan's
+/// Execute aliases/mutates an input tensor's buffer, so a denoising loop (which reuses the same noisy
+/// sample tensor across steps) gets corrupted from the second step on.
+///
+/// The pre-existing <c>MultiInputCompiledInferenceTests</c> does not catch this because it (a) builds a
+/// fresh input each trial and (b) computes its eager oracle from the input AFTER Execute, so a mutated
+/// input is compared against an equally-mutated oracle. These tests snapshot inputs BEFORE Execute and
+/// reuse the same instances across calls.
+/// </summary>
+public class MultiInputReplayAliasingTests : IDisposable
+{
+    private readonly IEngine _priorEngine = AiDotNetEngine.Current;
+    public MultiInputReplayAliasingTests() { AiDotNetEngine.Current = new CpuEngine(); }
+    public void Dispose() { AiDotNetEngine.Current = _priorEngine; }
+
+    private static float[] Snapshot(Tensor<float> t)
+    {
+        var a = new float[t.Length];
+        t.AsSpan().CopyTo(a);
+        return a;
+    }
+
+    [Fact]
+    public void Replay_DoesNotMutateInputs_AndIsDeterministic()
+    {
+        var engine = new CpuEngine();
+        var x = Tensor<float>.CreateRandom(new[] { 4, 8 });
+        var w1 = Tensor<float>.CreateRandom(new[] { 8, 8 });
+        var w2 = Tensor<float>.CreateRandom(new[] { 8, 8 });
+        var t = Tensor<float>.CreateRandom(new[] { 4, 8 });
+
+        // A small block with a residual + second matmul — closer to a transformer block than a bare
+        // matmul+add, exercising more buffer reuse in the compiled plan.
+        Func<Tensor<float>> forward = () =>
+        {
+            var h = engine.TensorMatMul(x, w1);
+            h = engine.TensorBroadcastAdd(h, t);       // inject the per-step input
+            h = engine.ReLU(h);
+            var o = engine.TensorMatMul(h, w2);
+            return engine.TensorAdd(o, x);             // residual back to the input
+        };
+
+        var xBefore = Snapshot(x);
+        var tBefore = Snapshot(t);
+
+        var cache = new CompiledModelCache<float>();
+        try
+        {
+            var plan = cache.GetOrCompileInference(new[] { x, t }, forward);
+
+            // First replay.
+            plan.SetInputs(new[] { x, t });
+            var got1 = Snapshot(plan.Execute());
+
+            // Inputs must be untouched by Execute.
+            Assert.Equal(xBefore, x.AsSpan().ToArray());
+            Assert.Equal(tBefore, t.AsSpan().ToArray());
+
+            // Second replay with the SAME instances must reproduce the first (deterministic).
+            plan.SetInputs(new[] { x, t });
+            var got2 = Snapshot(plan.Execute());
+            for (int i = 0; i < got1.Length; i++)
+                Assert.True(Math.Abs(got1[i] - got2[i]) < 1e-5f,
+                    $"replay {i}: {got1[i]} vs {got2[i]} — non-deterministic compiled replay.");
+
+            // And the replay must match a clean eager evaluation computed from the ORIGINAL inputs.
+            var hE = engine.TensorMatMul(x, w1);
+            hE = engine.TensorBroadcastAdd(hE, t);
+            hE = engine.ReLU(hE);
+            var oE = engine.TensorMatMul(hE, w2);
+            var eager = Snapshot(engine.TensorAdd(oE, x));
+            for (int i = 0; i < eager.Length; i++)
+                Assert.True(Math.Abs(eager[i] - got1[i]) < 1e-4f,
+                    $"parity {i}: eager {eager[i]} vs compiled {got1[i]}.");
+        }
+        finally { cache.Dispose(); }
+    }
+
+    [Fact]
+    public void Replay_DifferentRankInputs_Deterministic()
+    {
+        // Mirrors DiT: a 4D primary input and a low-rank secondary (timestep-embedding-like) input
+        // broadcast in. Reuse the SAME instances across replays.
+        var engine = new CpuEngine();
+        var x = Tensor<float>.CreateRandom(new[] { 1, 4, 8, 8 });
+        var t = Tensor<float>.CreateRandom(new[] { 1, 1, 1, 8 });   // broadcast over the 4D primary
+
+        Func<Tensor<float>> forward = () =>
+        {
+            var h = engine.ReLU(x);
+            return engine.TensorBroadcastAdd(h, t);
+        };
+
+        var xBefore = Snapshot(x);
+        var cache = new CompiledModelCache<float>();
+        try
+        {
+            var plan = cache.GetOrCompileInference(new[] { x, t }, forward);
+            plan.SetInputs(new[] { x, t });
+            var got1 = Snapshot(plan.Execute());
+            Assert.Equal(xBefore, x.AsSpan().ToArray());
+            plan.SetInputs(new[] { x, t });
+            var got2 = Snapshot(plan.Execute());
+            for (int i = 0; i < got1.Length; i++)
+                Assert.True(Math.Abs(got1[i] - got2[i]) < 1e-5f,
+                    $"diff-rank replay {i}: {got1[i]} vs {got2[i]} — non-deterministic.");
+        }
+        finally { cache.Dispose(); }
+    }
+
+    [Fact]
+    public void Replay_ExplicitAttention_Deterministic()
+    {
+        // Explicit single-head attention via matmul + transpose + softmax (the path a DiT block walks
+        // when not using a fused SDPA kernel). softmax is the op the simpler graphs lack.
+        var engine = new CpuEngine();
+        int seq = 4, dim = 8;
+        var x = Tensor<float>.CreateRandom(new[] { seq, dim });
+        var t = Tensor<float>.CreateRandom(new[] { seq, dim });
+        var wq = Tensor<float>.CreateRandom(new[] { dim, dim });
+        var wk = Tensor<float>.CreateRandom(new[] { dim, dim });
+        var wv = Tensor<float>.CreateRandom(new[] { dim, dim });
+
+        Func<Tensor<float>> forward = () =>
+        {
+            var q = engine.TensorMatMul(x, wq);
+            var k = engine.TensorMatMul(x, wk);
+            var v = engine.TensorMatMul(x, wv);
+            var scores = engine.TensorMatMul(q, engine.TensorTranspose(k));   // [seq, seq]
+            var probs = engine.TensorSoftmax(scores, -1);
+            var ctx = engine.TensorMatMul(probs, v);                          // [seq, dim]
+            return engine.TensorAdd(ctx, t);
+        };
+
+        var xBefore = Snapshot(x);
+        var cache = new CompiledModelCache<float>();
+        try
+        {
+            var plan = cache.GetOrCompileInference(new[] { x, t }, forward);
+            plan.SetInputs(new[] { x, t });
+            var got1 = Snapshot(plan.Execute());
+            Assert.Equal(xBefore, x.AsSpan().ToArray());
+            plan.SetInputs(new[] { x, t });
+            var got2 = Snapshot(plan.Execute());
+            for (int i = 0; i < got1.Length; i++)
+                Assert.True(Math.Abs(got1[i] - got2[i]) < 1e-5f,
+                    $"attn replay {i}: {got1[i]} vs {got2[i]} — non-deterministic compiled replay.");
+        }
+        finally { cache.Dispose(); }
+    }
+
+    [Fact]
+    public void Replay_AdaLNBlock_Deterministic()
+    {
+        // Faithful mini-DiT block: LayerNorm modulated by a broadcast scale/shift derived from the
+        // SECOND input (the timestep-embedding analogue, consumed at MULTIPLE sites), two residuals,
+        // and a GELU MLP. Reuse the SAME input instances across replays.
+        var engine = new CpuEngine();
+        int dim = 8;
+        var x = Tensor<float>.CreateRandom(new[] { 4, dim });          // [seq, dim]
+        var t = Tensor<float>.CreateRandom(new[] { 1, dim });          // broadcast modulation (embed-like)
+        var g = Tensor<float>.CreateRandom(new[] { dim });
+        var b = Tensor<float>.CreateRandom(new[] { dim });
+        var w1 = Tensor<float>.CreateRandom(new[] { dim, dim });
+        var w2 = Tensor<float>.CreateRandom(new[] { dim, dim });
+
+        Func<Tensor<float>> forward = () =>
+        {
+            var n1 = engine.TensorLayerNorm(x, g, b);
+            var mod = engine.TensorBroadcastMultiply(n1, t);          // AdaLN scale by the 2nd input
+            var attnish = engine.TensorMatMul(mod, w1);
+            var res1 = engine.TensorAdd(x, attnish);                  // residual 1
+            var n2 = engine.TensorLayerNorm(res1, g, b);
+            var mod2 = engine.TensorBroadcastMultiply(n2, t);         // 2nd consumption of input t
+            var mlp = engine.GELU(engine.TensorMatMul(mod2, w2));
+            return engine.TensorAdd(res1, mlp);                       // residual 2
+        };
+
+        var xBefore = Snapshot(x);
+        var tBefore = Snapshot(t);
+        var cache = new CompiledModelCache<float>();
+        try
+        {
+            var plan = cache.GetOrCompileInference(new[] { x, t }, forward);
+            plan.SetInputs(new[] { x, t });
+            var got1 = Snapshot(plan.Execute());
+            Assert.Equal(xBefore, x.AsSpan().ToArray());
+            Assert.Equal(tBefore, t.AsSpan().ToArray());
+            plan.SetInputs(new[] { x, t });
+            var got2 = Snapshot(plan.Execute());
+            for (int i = 0; i < got1.Length; i++)
+                Assert.True(Math.Abs(got1[i] - got2[i]) < 1e-5f,
+                    $"adaln replay {i}: {got1[i]} vs {got2[i]} — non-deterministic compiled replay.");
+        }
+        finally { cache.Dispose(); }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputSecondaryConsumerReproTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputSecondaryConsumerReproTests.cs
@@ -1,0 +1,247 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// Repro for the DiT multi-input divergence (consumer ooples/AiDotNet#1620): the secondary
+/// input (timestep embedding) feeds a NON-trivial consumer — a matmul (adaLN modulation) —
+/// before it is combined, whereas the existing #616 coverage adds the secondary input
+/// directly. If the multi-input replay re-binds correctly the compiled output must match
+/// eager for every (x, t) pair.
+/// </summary>
+public class MultiInputSecondaryConsumerReproTests : IDisposable
+{
+    private readonly IEngine _prior = AiDotNetEngine.Current;
+    public MultiInputSecondaryConsumerReproTests() { AiDotNetEngine.Current = new CpuEngine(); }
+    public void Dispose() { AiDotNetEngine.Current = _prior; }
+
+    [Fact]
+    public void MultiInput_SecondaryInputThroughMatmul_MatchesEager()
+    {
+        var engine = new CpuEngine();
+        var x0 = Tensor<float>.CreateRandom(new[] { 2, 4 });
+        var wx = Tensor<float>.CreateRandom(new[] { 4, 5 });
+        var t0 = Tensor<float>.CreateRandom(new[] { 2, 3 });
+        var wt = Tensor<float>.CreateRandom(new[] { 3, 5 });
+
+        float[] Eager(Tensor<float> x, Tensor<float> t)
+        {
+            var a = engine.TensorMatMul(x, wx);   // primary through matmul
+            var b = engine.TensorMatMul(t, wt);   // SECONDARY through matmul (adaLN-like)
+            var o = engine.TensorAdd(a, b);
+            var arr = new float[o.Length];
+            o.AsSpan().CopyTo(arr);
+            return arr;
+        }
+
+        var cache = new CompiledModelCache<float>();
+        try
+        {
+            var plan = cache.GetOrCompileInference(new[] { x0, t0 }, () =>
+            {
+                var a = engine.TensorMatMul(x0, wx);
+                var b = engine.TensorMatMul(t0, wt);
+                return engine.TensorAdd(a, b);
+            });
+
+            AssertReplayMatches(plan, () => Tensor<float>.CreateRandom(new[] { 2, 4 }),
+                () => Tensor<float>.CreateRandom(new[] { 2, 3 }), Eager, "secondary-through-matmul");
+        }
+        finally { cache.Dispose(); }
+    }
+
+    // Secondary input read by MULTIPLE consumers (adaLN reads timeEmbed in every block).
+    [Fact]
+    public void MultiInput_SecondaryInputMultipleConsumers_MatchesEager()
+    {
+        var engine = new CpuEngine();
+        var wx = Tensor<float>.CreateRandom(new[] { 4, 5 });
+        var wt1 = Tensor<float>.CreateRandom(new[] { 3, 5 });
+        var wt2 = Tensor<float>.CreateRandom(new[] { 3, 5 });
+        var x0 = Tensor<float>.CreateRandom(new[] { 2, 4 });
+        var t0 = Tensor<float>.CreateRandom(new[] { 2, 3 });
+
+        float[] Eager(Tensor<float> x, Tensor<float> t)
+        {
+            var a = engine.TensorAdd(engine.TensorMatMul(x, wx),
+                       engine.TensorAdd(engine.TensorMatMul(t, wt1), engine.TensorMatMul(t, wt2)));
+            var arr = new float[a.Length]; a.AsSpan().CopyTo(arr); return arr;
+        }
+
+        var cache = new CompiledModelCache<float>();
+        try
+        {
+            var plan = cache.GetOrCompileInference(new[] { x0, t0 }, () =>
+                engine.TensorAdd(engine.TensorMatMul(x0, wx),
+                    engine.TensorAdd(engine.TensorMatMul(t0, wt1), engine.TensorMatMul(t0, wt2))));
+            AssertReplayMatches(plan, () => Tensor<float>.CreateRandom(new[] { 2, 4 }),
+                () => Tensor<float>.CreateRandom(new[] { 2, 3 }), Eager, "multi-consumer");
+        }
+        finally { cache.Dispose(); }
+    }
+
+    // adaLN modulation: secondary -> matmul -> broadcast-multiply with the primary branch.
+    [Fact]
+    public void MultiInput_SecondaryInputBroadcastModulation_MatchesEager()
+    {
+        var engine = new CpuEngine();
+        var wx = Tensor<float>.CreateRandom(new[] { 4, 5 });
+        var wt = Tensor<float>.CreateRandom(new[] { 3, 5 });
+        var x0 = Tensor<float>.CreateRandom(new[] { 2, 4 });
+        var t0 = Tensor<float>.CreateRandom(new[] { 1, 3 });   // broadcast over batch
+
+        float[] Eager(Tensor<float> x, Tensor<float> t)
+        {
+            var xb = engine.TensorMatMul(x, wx);                  // [2,5]
+            var scale = engine.TensorMatMul(t, wt);              // [1,5]
+            var o = engine.TensorBroadcastMultiply(xb, scale);   // adaLN scale
+            var arr = new float[o.Length]; o.AsSpan().CopyTo(arr); return arr;
+        }
+
+        var cache = new CompiledModelCache<float>();
+        try
+        {
+            var plan = cache.GetOrCompileInference(new[] { x0, t0 }, () =>
+                engine.TensorBroadcastMultiply(engine.TensorMatMul(x0, wx), engine.TensorMatMul(t0, wt)));
+            AssertReplayMatches(plan, () => Tensor<float>.CreateRandom(new[] { 2, 4 }),
+                () => Tensor<float>.CreateRandom(new[] { 1, 3 }), Eager, "broadcast-modulation");
+        }
+        finally { cache.Dispose(); }
+    }
+
+    // Deep graph (20+ steps) so the post-specialization CPU optimization passes (CSE, fusion)
+    // actually run — they are skipped below ~20 steps, which is why the shallow repros above pass
+    // but the foundation-scale DiT (many blocks, all reading timeEmbed) diverges.
+    [Fact]
+    public void MultiInput_DeepGraph_SecondaryInEveryBlock_MatchesEager()
+    {
+        var engine = new CpuEngine();
+        const int blocks = 12;
+        var wx = new Tensor<float>[blocks];
+        var wt = new Tensor<float>[blocks];
+        // Deterministic small weights keep the 12-block chain's magnitude O(1) — see Det.
+        for (int i = 0; i < blocks; i++)
+        {
+            wx[i] = Det(new[] { 5, 5 }, 100 + i);
+            wt[i] = Det(new[] { 3, 5 }, 200 + i);
+        }
+        var x0 = Det(new[] { 2, 5 }, 1);
+        var t0 = Det(new[] { 2, 3 }, 2);
+
+        Tensor<float> Build(Tensor<float> x, Tensor<float> t)
+        {
+            var h = x;
+            for (int i = 0; i < blocks; i++)
+            {
+                var hx = engine.TensorMatMul(h, wx[i]);          // block transform
+                var m = engine.TensorMatMul(t, wt[i]);           // adaLN-like, reads t every block
+                h = engine.TensorAdd(hx, m);                      // residual-ish combine
+            }
+            return h;
+        }
+        float[] Eager(Tensor<float> x, Tensor<float> t)
+        {
+            var o = Build(x, t);
+            var arr = new float[o.Length]; o.AsSpan().CopyTo(arr); return arr;
+        }
+
+        var cache = new CompiledModelCache<float>();
+        try
+        {
+            var plan = cache.GetOrCompileInference(new[] { x0, t0 }, () => Build(x0, t0));
+            int trial = 0;
+            AssertReplayMatches(plan, () => Det(new[] { 2, 5 }, 300 + trial),
+                () => Det(new[] { 2, 3 }, 400 + trial++), Eager, "deep-graph");
+        }
+        finally { cache.Dispose(); }
+    }
+
+    // Deep graph where each block has CONSECUTIVE matmuls sharing the secondary input (the
+    // attention q/k/v / adaLN pattern). These ARE batched by the consecutive-run rule, so this
+    // verifies consecutive batching itself does not corrupt multi-input replay.
+    [Fact]
+    public void MultiInput_DeepGraph_ConsecutiveSecondaryMatMuls_MatchesEager()
+    {
+        var engine = new CpuEngine();
+        const int blocks = 10;
+        var wa = new Tensor<float>[blocks];
+        var wb = new Tensor<float>[blocks];
+        var wx = new Tensor<float>[blocks];
+        // Deterministic small weights keep the 10-block chain's magnitude O(1) — see Det.
+        for (int i = 0; i < blocks; i++)
+        {
+            wa[i] = Det(new[] { 3, 5 }, 100 + i);
+            wb[i] = Det(new[] { 3, 5 }, 200 + i);
+            wx[i] = Det(new[] { 5, 5 }, 300 + i);
+        }
+        var x0 = Det(new[] { 2, 5 }, 1);
+        var t0 = Det(new[] { 2, 3 }, 2);
+
+        Tensor<float> Build(Tensor<float> x, Tensor<float> t)
+        {
+            var h = x;
+            for (int i = 0; i < blocks; i++)
+            {
+                var a = engine.TensorMatMul(t, wa[i]);   // consecutive secondary matmuls
+                var b = engine.TensorMatMul(t, wb[i]);   // (a, b adjacent -> batched together)
+                var hx = engine.TensorMatMul(h, wx[i]);
+                h = engine.TensorAdd(hx, engine.TensorAdd(a, b));
+            }
+            return h;
+        }
+        float[] Eager(Tensor<float> x, Tensor<float> t)
+        {
+            var o = Build(x, t);
+            var arr = new float[o.Length]; o.AsSpan().CopyTo(arr); return arr;
+        }
+
+        var cache = new CompiledModelCache<float>();
+        try
+        {
+            var plan = cache.GetOrCompileInference(new[] { x0, t0 }, () => Build(x0, t0));
+            int trial = 0;
+            AssertReplayMatches(plan, () => Det(new[] { 2, 5 }, 500 + trial),
+                () => Det(new[] { 2, 3 }, 600 + trial++), Eager, "consecutive-secondary");
+        }
+        finally { cache.Dispose(); }
+    }
+
+    // Deterministic, bounded-magnitude tensor for the DEEP tests. A 10–12 block
+    // unnormalized matmul chain compounds its output magnitude exponentially with
+    // random weights (|out| ~ 1e3–1e4), so the compiled path's legitimate ~1-ULP
+    // *relative* GEMM rounding (which differs from eager only on net471, where the
+    // SIMD summation order differs — net10 is bit-exact) becomes a large *absolute*
+    // diff and the absolute 1e-3 replay tolerance flakes. Small fixed weights keep
+    // |out| ~ O(1) so the same correct path stays well under 1e-3 on both TFMs —
+    // this fixes the non-determinism without touching the tolerance.
+    private static Tensor<float> Det(int[] shape, int seed)
+    {
+        int n = 1; foreach (var d in shape) n *= d;
+        var data = new float[n];
+        for (int i = 0; i < n; i++) data[i] = (float)(((i * 7 + seed * 13) % 17) - 8) * 0.1f;
+        return new Tensor<float>(data, shape);
+    }
+
+    private static void AssertReplayMatches(
+        ICompiledPlan<float> plan,
+        Func<Tensor<float>> makeX, Func<Tensor<float>> makeT,
+        Func<Tensor<float>, Tensor<float>, float[]> eager, string label)
+    {
+        for (int trial = 0; trial < 4; trial++)
+        {
+            var x = makeX();
+            var t = makeT();
+            plan.SetInputs(new[] { x, t });
+            var got = plan.Execute();
+            var exp = eager(x, t);
+            float maxDiff = 0f;
+            for (int i = 0; i < got.Length; i++)
+                maxDiff = Math.Max(maxDiff, Math.Abs(exp[i] - got[i]));
+            Assert.True(maxDiff < 1e-3f, $"[{label}] trial {trial}: compiled diverged from eager, maxDiff={maxDiff:E3}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Makes compiled attention/diffusion **inference** correct *and* fast by fixing the real root cause and removing the temporary `#1624` correctness gate.

The draft originally **gated** the step-mutating passes (OperatorReordering + MemoryPlanning) off for any plan containing `Softmax`/`LogSoftmax`/`ScaledDotProductAttention`. That masked the miscompile but cost every attention/diffusion inference plan its peak-memory reduction, and it blamed the wrong passes.

## Root cause

`MemoryPlanningPass` runs **pre-specialization** and computes buffer lifetimes from the **original** step order. It legally donates a buffer `D` (dead at its original last-use) to a later matmul `M`'s output via `RebindStorageFrom` (which AddRefs `D`'s `TensorStorage` → refcount 2).

`BlasBatchPass` runs **later** and **hoists** all same-shape independent matmuls to the group's first position, running them back-to-back there. If `M` is hoisted ahead of `D`'s last consumer, `M`'s write lands in `D`'s storage **before** that consumer reads it → silent corruption.

Concrete repro (`Parity_SharedInput_QKV_Reshape_Permute_SDPA`): one shared input → Q/K/V projection matmuls → reshape → permute → SDPA. The V-projection buffer dies at its reshape, MemoryPlanning donates it to the K-projection matmul, and BlasBatch hoists that K matmul ahead of the V reshape — clobbering V.

## Fixes

1. **`BlasBatchPass` consecutive-run guard** — a batch group must be a CONTIGUOUS run of matmuls (`continue`→`break` in the candidate scan). Since the batched step runs every member at the first member's position and nothing non-member sits between them, no matmul is ever hoisted across an intervening step's buffer lifetime — a structural fix that holds regardless of how MemoryPlanning aliases buffers. (This consolidates the approach from #637, which is cleaner than this PR's earlier refcount-based `HasAliasedOutput` guard; verified sufficient against the full replay-aliasing suite.)
2. **Remove the `#1624` Softmax/SDPA gate** in `RunStepMutatingPasses` — memplan + reorder now run for all plans, restoring peak-memory reduction for attention/diffusion inference.
3. **Fix `AttentionFusionPass` (structural K recovery) and re-enable it** — the pass fed Kᵀ to FlashAttention as "K" and produced silently wrong results whenever `seqK == headDim` (a latent bug, since it ran via `RunCpuOptimizationPasses` even under the old gate). `TryRecoverNaturalKey` now traces the `TensorTranspose` that produced the QK matmul's second operand back to its input to feed the natural key, and **refuses to fuse** when the operand's layout cannot be proven (no producing transpose / not a clean last-two-dim swap) — so the silent-corruption case can no longer occur. The pass is forward-only (inference) so it needs no backward kernel. `EnableAttentionFusion` is on.

## Validation

- `MultiInputReplayAliasingTests` **16/16**
- `Engines.Compilation` **538/538** (net10.0) + **528/528** (net471), 6 pre-existing skips
- Optimization / BlasBatch / MemoryPlan / Reorder **150/150**
- Full project net10.0: 6181 passed; the 8 failures are pre-existing/environmental (GPU-kernel tests needing a real GPU, distributed TCP, GPU-pinned, allocation-churn) and all pass in isolation — none touch the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented matmul batching from hoisting operations when outputs share backing storage, reducing the risk of incorrect results.
  * Hardened attention fusion so FlashAttention is only applied after reliably recovering the expected (non-transposed) key tensor layout; fusion is refused when the layout can’t be proven.
* **Tests**
  * Added a comprehensive replay/determinism and compiled-vs-eager parity test suite covering many graph/aliasing and attention/fusion scenarios.
* **Documentation**
  * Updated the `EnableAttentionFusion` option notes to clarify its behavior and layout constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->