### PR TITLE
fix(arena): byte-budget the cross-arena persistent pool to stop training-scale OOM (#1624)

### DIFF
--- a/src/AiDotNet.Tensors/Helpers/TensorArena.cs
+++ b/src/AiDotNet.Tensors/Helpers/TensorArena.cs
@@ -90,11 +90,18 @@ public sealed class TensorArena : IDisposable
     // Thread-static: each thread keeps its own pool (no locks, matches the
     // [ThreadStatic] _current contract). Bounded: only arrays at/above
     // PersistThresholdElems are retained (small buffers GC cheaply and would
-    // bloat the dictionary), and at most MaxPersistPerSize per (type,size) so
-    // a model with many distinct shapes can't grow the pool without bound.
+    // bloat the dictionary), and the TOTAL retained bytes are capped by
+    // MaxPersistTotalBytes so the pool can't grow without bound.
     // ---------------------------------------------------------------------
     [ThreadStatic]
     private static Dictionary<(Type, int), Stack<Array>>? _persistent;
+
+    // Running total of bytes currently retained in this thread's persistent
+    // pool. Kept in lock-step with _persistent (incremented on push, decremented
+    // on pop) so ReturnPersistent can enforce the byte budget in O(1) without
+    // walking the dictionary.
+    [ThreadStatic]
+    private static long _persistentBytes;
 
     // Test/diagnostic: counts how many times a large buffer was served from the
     // cross-arena persistent pool (a reuse hit) rather than freshly allocated.
@@ -112,11 +119,71 @@ public sealed class TensorArena : IDisposable
     /// allocation/GC is cheap and pooling churns the dictionary for no gain.</summary>
     private const int PersistThresholdElems = 64 * 1024;
 
-    /// <summary>Max retained buffers per (type, size). A single-threaded training
-    /// step rents each distinct size O(1) times, so a small cap fully covers
-    /// steady-state reuse while bounding worst-case retained memory to a few ×
-    /// the model's transient working set.</summary>
-    private const int MaxPersistPerSize = 4;
+    /// <summary>Soft ceiling on the TOTAL bytes retained by this thread's
+    /// cross-arena persistent pool. The pool makes the create+dispose-arena-
+    /// per-step pattern allocation-free after warmup (#478): each step reuses the
+    /// previous step's transient buffers instead of re-allocating + gen2-
+    /// collecting them. The pool is bounded by BYTES rather than by a per-(type,
+    /// size) COUNT because a single step of a deep model rents the SAME large
+    /// size MANY times — every op produces a like-shaped intermediate that a
+    /// persistent gradient tape keeps live for the whole backward pass — so a
+    /// small per-size count cap (the old value 4) recycled only a sliver and left
+    /// thousands of large buffers to be re-allocated and GC'd every step. Under a
+    /// constrained heap (DOTNET_GCHeapHardLimit) that per-step churn outpaces
+    /// gen2 collection and OOMs even though the LIVE set is flat (issue #1624).
+    /// Pooling by total bytes lets a high-fan-out size pool fully — the buffers
+    /// then just cycle between "in pool" (between steps) and "rented by the
+    /// current step", so the steady-state footprint is the single-step working
+    /// set, not working-set × churn. Override with the
+    /// AIDOTNET_ARENA_PERSIST_BYTES environment variable (a byte count; 0 = pool
+    /// disabled). Default: half of the memory the GC is allowed to use (which
+    /// reflects the heap hard limit when one is set, else physical RAM).</summary>
+    private static readonly long MaxPersistTotalBytes = ResolveMaxPersistTotalBytes();
+
+    private static long ResolveMaxPersistTotalBytes()
+    {
+        var env = Environment.GetEnvironmentVariable("AIDOTNET_ARENA_PERSIST_BYTES");
+        if (env is not null && long.TryParse(env, out var overrideBytes) && overrideBytes >= 0)
+            return overrideBytes;
+
+        long available = GetGcAvailableMemoryBytes();
+        if (available <= 0)
+            available = 8L * 1024 * 1024 * 1024; // 8 GiB fallback when unknown
+        return available / 2;
+    }
+
+    private static long GetGcAvailableMemoryBytes()
+    {
+#if NET5_0_OR_GREATER
+        try
+        {
+            long total = GC.GetGCMemoryInfo().TotalAvailableMemoryBytes;
+            if (total > 0) return total;
+        }
+        catch
+        {
+            // GetGCMemoryInfo can throw on some constrained hosts — fall through.
+        }
+#endif
+        return 0;
+    }
+
+    // Exact byte size of an array whose elements are a primitive numeric type
+    // (the only element types tensor backing arrays use). Buffer.ByteLength is an
+    // O(1) intrinsic for primitive arrays; a non-primitive element type (which
+    // tensor storage never produces) conservatively counts 8 bytes/element so the
+    // byte budget is never UNDER-counted.
+    private static long ArrayByteLength(Array arr, int elementCount)
+    {
+        try
+        {
+            return Buffer.ByteLength(arr);
+        }
+        catch (ArgumentException)
+        {
+            return (long)elementCount * 8;
+        }
+    }
 
     private static Array? RentPersistent(Type type, int elementCount)
     {
@@ -126,6 +193,8 @@ public sealed class TensorArena : IDisposable
         if (pool.TryGetValue((type, elementCount), out var stack) && stack.Count > 0)
         {
             var arr = stack.Pop();
+            _persistentBytes -= ArrayByteLength(arr, elementCount);
+            if (_persistentBytes < 0) _persistentBytes = 0; // guard against drift
             _persistentReuseHits++;
             // Zero the recycled buffer. The arena's previous behaviour allocated
             // every first-use-per-arena buffer via `new T[]`, which the CLR
@@ -146,26 +215,33 @@ public sealed class TensorArena : IDisposable
     private static void ReturnPersistent(Type type, int elementCount, Array arr)
     {
         if (elementCount < PersistThresholdElems) return; // let small buffers GC
+        long bytes = ArrayByteLength(arr, elementCount);
+        // Enforce the thread's total-byte budget: once the pool is full, drop the
+        // surplus buffer for GC instead of hoarding. This is what bounds the pool
+        // for a model with a huge or unbounded set of transient shapes, while
+        // still letting the common case (a handful of high-fan-out sizes) pool
+        // fully — see MaxPersistTotalBytes.
+        if (_persistentBytes + bytes > MaxPersistTotalBytes) return;
         var pool = _persistent ??= new Dictionary<(Type, int), Stack<Array>>();
         var key = (type, elementCount);
         if (!pool.TryGetValue(key, out var stack))
         {
-            stack = new Stack<Array>(MaxPersistPerSize);
+            stack = new Stack<Array>();
             pool[key] = stack;
         }
-        if (stack.Count < MaxPersistPerSize)
-            stack.Push(arr);
-        // else: at cap — drop the reference, let GC reclaim (don't hoard).
+        stack.Push(arr);
+        _persistentBytes += bytes;
     }
 
     /// <summary>
     /// Drops every buffer held in the calling thread's cross-arena persistent
     /// pool. For tests / explicit memory-pressure handling; production code
-    /// never needs this (the pool is bounded by <see cref="MaxPersistPerSize"/>).
+    /// never needs this (the pool is bounded by <see cref="MaxPersistTotalBytes"/>).
     /// </summary>
     public static void ClearPersistentPool()
     {
         _persistent?.Clear();
+        _persistentBytes = 0;
         _persistentReuseHits = 0;
     }
 

--- a/src/AiDotNet.Tensors/Helpers/TensorArena.cs
+++ b/src/AiDotNet.Tensors/Helpers/TensorArena.cs
@@ -137,8 +137,34 @@ public sealed class TensorArena : IDisposable
     /// set, not working-set × churn. Override with the
     /// AIDOTNET_ARENA_PERSIST_BYTES environment variable (a byte count; 0 = pool
     /// disabled). Default: half of the memory the GC is allowed to use (which
-    /// reflects the heap hard limit when one is set, else physical RAM).</summary>
+    /// reflects the heap hard limit when one is set, else physical RAM).
+    /// <para><b>Per-thread:</b> the budget bounds EACH thread's pool independently
+    /// (the pool is [ThreadStatic]). In the create+dispose-arena-per-step pattern
+    /// the pool only accrues on the thread that creates arenas — the training
+    /// thread — so a single pool exists in practice. If a host were to drive arenas
+    /// from many threads concurrently, lower this via the env var so N × budget
+    /// stays within the heap.</para></summary>
     private static readonly long MaxPersistTotalBytes = ResolveMaxPersistTotalBytes();
+
+    // Test hook (InternalsVisibleTo): a per-thread override of the byte budget so
+    // the eviction path can be exercised at a size small enough to hit in a unit
+    // test (the production MaxPersistTotalBytes is gigabytes). [ThreadStatic] so a
+    // test only affects its own worker thread and never leaks the budget to a
+    // concurrent test. 0 = unset → use MaxPersistTotalBytes. Set back to 0 in a
+    // finally to restore production behaviour.
+    [ThreadStatic]
+    private static long _maxPersistTotalBytesOverride;
+
+    internal static long MaxPersistTotalBytesOverrideForTests
+    {
+        get => _maxPersistTotalBytesOverride;
+        set => _maxPersistTotalBytesOverride = value;
+    }
+
+    /// <summary>The byte budget in force on this thread — the test override when
+    /// set (&gt; 0), else the resolved <see cref="MaxPersistTotalBytes"/>.</summary>
+    private static long EffectiveMaxPersistTotalBytes
+        => _maxPersistTotalBytesOverride > 0 ? _maxPersistTotalBytesOverride : MaxPersistTotalBytes;
 
     private static long ResolveMaxPersistTotalBytes()
     {
@@ -221,7 +247,7 @@ public sealed class TensorArena : IDisposable
         // for a model with a huge or unbounded set of transient shapes, while
         // still letting the common case (a handful of high-fan-out sizes) pool
         // fully — see MaxPersistTotalBytes.
-        if (_persistentBytes + bytes > MaxPersistTotalBytes) return;
+        if (_persistentBytes + bytes > EffectiveMaxPersistTotalBytes) return;
         var pool = _persistent ??= new Dictionary<(Type, int), Stack<Array>>();
         var key = (type, elementCount);
         if (!pool.TryGetValue(key, out var stack))

--- a/tests/AiDotNet.Tensors.Tests/Helpers/TensorArenaPersistentPoolTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/TensorArenaPersistentPoolTests.cs
@@ -166,6 +166,61 @@ public class TensorArenaPersistentPoolTests
     }
 
     /// <summary>
+    /// The byte budget MUST bound the pool: a model with an effectively unbounded
+    /// set of distinct large shapes can't grow the persistent pool past
+    /// MaxPersistTotalBytes — surplus buffers are dropped for GC on return. This
+    /// is the mechanism that prevents the fix itself from becoming an unbounded
+    /// leak. Exercised via the per-thread test override of the budget (production
+    /// budget is gigabytes); we set it to exactly <c>budgetBuffers</c> large
+    /// buffers and assert only that many are retained — the next lifetime reuses
+    /// exactly <c>budgetBuffers</c> and re-allocates the rest.
+    /// </summary>
+    [Fact]
+    public void ByteBudget_BoundsPool_DropsSurplusBuffers()
+    {
+        TensorArena.ClearPersistentPool();
+        int[] shape = { LargeElems };
+        const int budgetBuffers = 4;
+        const int fanOut = 16; // 4x the budget — the surplus 12 must be dropped
+        long bufferBytes = (long)LargeElems * sizeof(float); // 8 MB
+
+        long savedOverride = TensorArena.MaxPersistTotalBytesOverrideForTests;
+        TensorArena.MaxPersistTotalBytesOverrideForTests = budgetBuffers * bufferBytes;
+        try
+        {
+            // Lifetime 1: return fanOut buffers; only budgetBuffers fit the budget,
+            // the rest are dropped for GC (no reuse recorded yet).
+            using (var arena = TensorArena.Create())
+            {
+                for (int i = 0; i < fanOut; i++)
+                {
+                    var t = TensorAllocator.RentUninitialized<float>(shape);
+                    t.AsWritableSpan()[0] = i;
+                }
+            }
+            Assert.Equal(0, TensorArena.PersistentReuseHits);
+
+            // Lifetime 2: only the budgetBuffers that were retained can be reused;
+            // the remaining (fanOut - budgetBuffers) rents allocate fresh. So the
+            // reuse-hit count is capped at the budget, proving the pool is bounded.
+            using (var arena = TensorArena.Create())
+            {
+                for (int i = 0; i < fanOut; i++)
+                {
+                    var t = TensorAllocator.RentUninitialized<float>(shape);
+                    t.AsWritableSpan()[0] = i;
+                }
+            }
+            Assert.Equal(budgetBuffers, TensorArena.PersistentReuseHits);
+        }
+        finally
+        {
+            TensorArena.MaxPersistTotalBytesOverrideForTests = savedOverride;
+            TensorArena.ClearPersistentPool();
+        }
+    }
+
+    /// <summary>
     /// Small buffers (below the persist threshold) are intentionally NOT pooled
     /// across lifetimes — they GC cheaply and pooling them would bloat the
     /// dictionary. This guards the threshold so the pool stays focused on the

--- a/tests/AiDotNet.Tensors.Tests/Helpers/TensorArenaPersistentPoolTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/TensorArenaPersistentPoolTests.cs
@@ -123,6 +123,49 @@ public class TensorArenaPersistentPoolTests
     }
 
     /// <summary>
+    /// Regression for the #1624 training-scale OOM: a single deep-model step rents
+    /// the SAME large size MANY times (every op produces a like-shaped intermediate
+    /// that the persistent gradient tape keeps live for the whole backward pass, so
+    /// the arena cannot reuse them within the step). The cross-arena pool must
+    /// retain ALL of them so the next step reuses every buffer — the old fixed
+    /// per-(type,size) cap of 4 retained only a sliver and re-allocated the rest
+    /// each step, which under a constrained heap (DOTNET_GCHeapHardLimit) churns
+    /// faster than gen2 collects and OOMs even though the LIVE set is flat.
+    /// </summary>
+    [Fact]
+    public void HighFanOutLargeSize_PoolsEveryBufferAcrossLifetimes()
+    {
+        TensorArena.ClearPersistentPool();
+        int[] shape = { LargeElems };
+        const int fanOut = 16; // far more than the old per-size cap of 4
+
+        // Lifetime 1: rent the same large size fanOut times. No Reset between
+        // rents, so each rent allocates a distinct backing array (matching a
+        // step whose tape keeps every intermediate live). Fresh — no reuse yet.
+        using (var arena = TensorArena.Create())
+        {
+            for (int i = 0; i < fanOut; i++)
+            {
+                var t = TensorAllocator.RentUninitialized<float>(shape);
+                t.AsWritableSpan()[0] = i;
+            }
+        }
+        Assert.Equal(0, TensorArena.PersistentReuseHits);
+
+        // Lifetime 2: the same fan-out must reuse EVERY buffer from the pool, not
+        // just the first 4. One reuse hit per rent == fully allocation-free step.
+        using (var arena = TensorArena.Create())
+        {
+            for (int i = 0; i < fanOut; i++)
+            {
+                var t = TensorAllocator.RentUninitialized<float>(shape);
+                t.AsWritableSpan()[0] = i;
+            }
+        }
+        Assert.Equal(fanOut, TensorArena.PersistentReuseHits);
+    }
+
+    /// <summary>
     /// Small buffers (below the persist threshold) are intentionally NOT pooled
     /// across lifetimes — they GC cheaply and pooling them would bloat the
     /// dictionary. This guards the threshold so the pool stays focused on the


### PR DESCRIPTION
## Problem

The cross-arena persistent buffer pool (#478) retained at most **4 buffers per `(type, size)`** (`MaxPersistPerSize = 4`), on the assumption — stated in its own comment — that "a single-threaded training step rents each distinct size O(1) times."

A deep model trained with a **persistent gradient tape** (`GradientTapeOptions.Persistent = true`, the default) violates that assumption: the tape keeps **every** forward intermediate live for the whole backward pass, so the arena cannot reuse buffers *within* a step, and a single step rents the **same large size thousands of times**. With only 4 retained per size, the next step re-allocates thousands of multi-hundred-KB buffers from scratch — **every step**. Under a constrained heap (`DOTNET_GCHeapHardLimit`) that per-step churn outpaces gen2 collection and OOMs **even though the live set is flat** — the AiDotNet **#1624** training-scale failure.

### Dump evidence
A 14-layer ~110M-param model (SimCSE, tiny `[1,768]` input) grew the heap from ~1.7 GB to the 16 GB limit over a handful of steps. A captured dump showed **one live arena** holding **6,928 backing arrays (~6.46 GB) across only 8 distinct sizes** (e.g. `196608` = a `[256,768]` activation, repeated thousands of times).

## Fix

Bound the persistent pool by **total bytes** instead of a per-`(type,size)` count. A high-fan-out size now pools fully, so its buffers simply cycle between "in the pool" (between steps) and "rented by the current step" — steady-state footprint becomes the **single-step working set**, not working-set × churn.

- Byte ceiling defaults to **half of `GC.GetGCMemoryInfo().TotalAvailableMemoryBytes`** (reflects the heap hard limit when one is set, else physical RAM), overridable via `AIDOTNET_ARENA_PERSIST_BYTES` (`0` disables the pool).
- `net471` (no `GetGCMemoryInfo`) falls back to an 8 GiB default via `#if NET5_0_OR_GREATER`.
- New `_persistentBytes` thread-static counter kept in lock-step with the pool (inc on push, dec on pop).
- Recycled buffers are still zeroed — the zero-init contract is preserved.
- Budget is **per-thread** (the pool is `[ThreadStatic]`); documented on `MaxPersistTotalBytes`.

## Tests

- `HighFanOutLargeSize_PoolsEveryBufferAcrossLifetimes`: rents one large size **16 times per lifetime** and asserts all 16 are reused on the next lifetime. **Fails under the old cap-of-4, passes now.**
- `ByteBudget_BoundsPool_DropsSurplusBuffers`: sets the budget to exactly 4 large buffers, returns 16, and asserts the next lifetime reuses **exactly 4** — proving the budget actually *bounds* the pool (the surplus 12 are dropped for GC). Exercised through a `[ThreadStatic]` test seam (`MaxPersistTotalBytesOverrideForTests`) since the production budget is gigabytes.

Arena persistent-pool tests: **6/6** (net10.0), **5/5** (net471); CI green.

## Note

The end-to-end SimCSE 16 GB heap-bound repro is a consumer-side (AiDotNet) validation. The Tensors-side mechanism is now unit-proven in both directions: it pools the full high-fan-out working set **and** is bounded by the byte budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)