### PR TITLE
fix(compile): BlasBatchPass must not reorder matmuls across buffer lifetimes

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Optimization/BlasBatchPass.cs
+++ b/src/AiDotNet.Tensors/Engines/Optimization/BlasBatchPass.cs
@@ -56,17 +56,30 @@ internal sealed class BlasBatchPass : ICpuOptimizationPass
 
                 for (int j = i + 1; j < steps.Length; j++)
                 {
-                    if (consumed.Contains(j)) continue;
-                    if (steps[j].OpType != OpType.TensorMatMul || steps[j].Inputs.Length != 2) continue;
-                    if (steps[j].Inputs[0].Rank != 2 || steps[j].Inputs[1].Rank != 2) continue;
+                    // CONSECUTIVE-RUN ONLY: a batched group must be a CONTIGUOUS run of
+                    // matmuls. The batched step executes every member at the FIRST member's
+                    // position (and no-ops the originals). If a NON-group step sat between two
+                    // members, moving the later matmul before it would write that matmul's
+                    // output buffer early — and MemoryPlanningPass may have aliased that buffer
+                    // onto a tensor still live across the skipped region (buffers are reused by
+                    // original-order lifetime). Writing early then clobbers a live value →
+                    // silently wrong replay. This was latent while only single-input plans
+                    // existed: their secondary leaves are baked constants, so matmul(const,
+                    // const) is constant-folded away before this pass and never batched. A
+                    // multi-input plan (diffusion denoiser: noisy sample + per-step timestep
+                    // embedding) keeps those matmuls dynamic, so they reach this pass and get
+                    // reordered (#1620). Stop the run at the first step that can't join, so no
+                    // member is ever moved across an intervening step's buffer lifetime.
+                    if (consumed.Contains(j)) break;
+                    if (steps[j].OpType != OpType.TensorMatMul || steps[j].Inputs.Length != 2) break;
+                    if (steps[j].Inputs[0].Rank != 2 || steps[j].Inputs[1].Rank != 2) break;
 
                     int jk = steps[j].Inputs[0]._shape[1];
                     int jn = steps[j].Inputs[1]._shape[1];
-                    if (jk != k || jn != n) continue;
+                    if (jk != k || jn != n) break;
 
-                    // Check independence: j's inputs must not depend on group outputs
-                    // AND must be available at position i (produced by steps before i,
-                    // or not produced by any step at all — i.e., graph-level inputs).
+                    // Independence: j's inputs must not depend on a group output, and must be
+                    // available at position i (produced before i, or a graph-level leaf).
                     bool canBatch = true;
                     foreach (var inp in steps[j].Inputs)
                     {
@@ -75,20 +88,16 @@ internal sealed class BlasBatchPass : ICpuOptimizationPass
                             canBatch = false;
                             break;
                         }
-                        // If this input is produced by a step that comes after position i,
-                        // it won't be available when the batched step executes at position i.
                         if (producedByStep.TryGetValue(inp, out int producerIdx) && producerIdx >= i)
                         {
                             canBatch = false;
                             break;
                         }
                     }
+                    if (!canBatch) break;
 
-                    if (canBatch)
-                    {
-                        group.Add(j);
-                        groupOutputs.Add(steps[j].OutputBuffer);
-                    }
+                    group.Add(j);
+                    groupOutputs.Add(steps[j].OutputBuffer);
                 }
 
                 if (group.Count >= 2)

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputSecondaryConsumerReproTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputSecondaryConsumerReproTests.cs
@@ -1,0 +1,237 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// Repro for the DiT multi-input divergence (consumer ooples/AiDotNet#1620): the secondary
+/// input (timestep embedding) feeds a NON-trivial consumer — a matmul (adaLN modulation) —
+/// before it is combined, whereas the existing #616 coverage adds the secondary input
+/// directly. If the multi-input replay re-binds correctly the compiled output must match
+/// eager for every (x, t) pair.
+/// </summary>
+public class MultiInputSecondaryConsumerReproTests : IDisposable
+{
+    private readonly IEngine _prior = AiDotNetEngine.Current;
+    public MultiInputSecondaryConsumerReproTests() { AiDotNetEngine.Current = new CpuEngine(); }
+    public void Dispose() { AiDotNetEngine.Current = _prior; }
+
+    [Fact]
+    public void MultiInput_SecondaryInputThroughMatmul_MatchesEager()
+    {
+        var engine = new CpuEngine();
+        var x0 = Tensor<float>.CreateRandom(new[] { 2, 4 });
+        var wx = Tensor<float>.CreateRandom(new[] { 4, 5 });
+        var t0 = Tensor<float>.CreateRandom(new[] { 2, 3 });
+        var wt = Tensor<float>.CreateRandom(new[] { 3, 5 });
+
+        float[] Eager(Tensor<float> x, Tensor<float> t)
+        {
+            var a = engine.TensorMatMul(x, wx);   // primary through matmul
+            var b = engine.TensorMatMul(t, wt);   // SECONDARY through matmul (adaLN-like)
+            var o = engine.TensorAdd(a, b);
+            var arr = new float[o.Length];
+            o.AsSpan().CopyTo(arr);
+            return arr;
+        }
+
+        var cache = new CompiledModelCache<float>();
+        try
+        {
+            var plan = cache.GetOrCompileInference(new[] { x0, t0 }, () =>
+            {
+                var a = engine.TensorMatMul(x0, wx);
+                var b = engine.TensorMatMul(t0, wt);
+                return engine.TensorAdd(a, b);
+            });
+
+            for (int trial = 0; trial < 4; trial++)
+            {
+                var x = Tensor<float>.CreateRandom(new[] { 2, 4 });
+                var t = Tensor<float>.CreateRandom(new[] { 2, 3 });
+                plan.SetInputs(new[] { x, t });
+                var got = plan.Execute();
+                var exp = Eager(x, t);
+                float maxDiff = 0f;
+                for (int i = 0; i < got.Length; i++)
+                    maxDiff = Math.Max(maxDiff, Math.Abs(exp[i] - got[i]));
+                Assert.True(maxDiff < 1e-3f, $"trial {trial}: compiled diverged from eager, maxDiff={maxDiff:E3}");
+            }
+        }
+        finally { cache.Dispose(); }
+    }
+
+    // Secondary input read by MULTIPLE consumers (adaLN reads timeEmbed in every block).
+    [Fact]
+    public void MultiInput_SecondaryInputMultipleConsumers_MatchesEager()
+    {
+        var engine = new CpuEngine();
+        var wx = Tensor<float>.CreateRandom(new[] { 4, 5 });
+        var wt1 = Tensor<float>.CreateRandom(new[] { 3, 5 });
+        var wt2 = Tensor<float>.CreateRandom(new[] { 3, 5 });
+        var x0 = Tensor<float>.CreateRandom(new[] { 2, 4 });
+        var t0 = Tensor<float>.CreateRandom(new[] { 2, 3 });
+
+        float[] Eager(Tensor<float> x, Tensor<float> t)
+        {
+            var a = engine.TensorAdd(engine.TensorMatMul(x, wx),
+                       engine.TensorAdd(engine.TensorMatMul(t, wt1), engine.TensorMatMul(t, wt2)));
+            var arr = new float[a.Length]; a.AsSpan().CopyTo(arr); return arr;
+        }
+
+        var cache = new CompiledModelCache<float>();
+        try
+        {
+            var plan = cache.GetOrCompileInference(new[] { x0, t0 }, () =>
+                engine.TensorAdd(engine.TensorMatMul(x0, wx),
+                    engine.TensorAdd(engine.TensorMatMul(t0, wt1), engine.TensorMatMul(t0, wt2))));
+            AssertReplayMatches(engine, plan, () => Tensor<float>.CreateRandom(new[] { 2, 4 }),
+                () => Tensor<float>.CreateRandom(new[] { 2, 3 }), Eager, "multi-consumer");
+        }
+        finally { cache.Dispose(); }
+    }
+
+    // adaLN modulation: secondary -> matmul -> broadcast-multiply with the primary branch.
+    [Fact]
+    public void MultiInput_SecondaryInputBroadcastModulation_MatchesEager()
+    {
+        var engine = new CpuEngine();
+        var wx = Tensor<float>.CreateRandom(new[] { 4, 5 });
+        var wt = Tensor<float>.CreateRandom(new[] { 3, 5 });
+        var x0 = Tensor<float>.CreateRandom(new[] { 2, 4 });
+        var t0 = Tensor<float>.CreateRandom(new[] { 1, 3 });   // broadcast over batch
+
+        float[] Eager(Tensor<float> x, Tensor<float> t)
+        {
+            var xb = engine.TensorMatMul(x, wx);                  // [2,5]
+            var scale = engine.TensorMatMul(t, wt);              // [1,5]
+            var o = engine.TensorBroadcastMultiply(xb, scale);   // adaLN scale
+            var arr = new float[o.Length]; o.AsSpan().CopyTo(arr); return arr;
+        }
+
+        var cache = new CompiledModelCache<float>();
+        try
+        {
+            var plan = cache.GetOrCompileInference(new[] { x0, t0 }, () =>
+                engine.TensorBroadcastMultiply(engine.TensorMatMul(x0, wx), engine.TensorMatMul(t0, wt)));
+            AssertReplayMatches(engine, plan, () => Tensor<float>.CreateRandom(new[] { 2, 4 }),
+                () => Tensor<float>.CreateRandom(new[] { 1, 3 }), Eager, "broadcast-modulation");
+        }
+        finally { cache.Dispose(); }
+    }
+
+    // Deep graph (20+ steps) so the post-specialization CPU optimization passes (CSE, fusion)
+    // actually run — they are skipped below ~20 steps, which is why the shallow repros above pass
+    // but the foundation-scale DiT (many blocks, all reading timeEmbed) diverges.
+    [Fact]
+    public void MultiInput_DeepGraph_SecondaryInEveryBlock_MatchesEager()
+    {
+        var engine = new CpuEngine();
+        const int blocks = 12;
+        var wx = new Tensor<float>[blocks];
+        var wt = new Tensor<float>[blocks];
+        for (int i = 0; i < blocks; i++)
+        {
+            wx[i] = Tensor<float>.CreateRandom(new[] { 5, 5 });
+            wt[i] = Tensor<float>.CreateRandom(new[] { 3, 5 });
+        }
+        var x0 = Tensor<float>.CreateRandom(new[] { 2, 5 });
+        var t0 = Tensor<float>.CreateRandom(new[] { 2, 3 });
+
+        Tensor<float> Build(Tensor<float> x, Tensor<float> t)
+        {
+            var h = x;
+            for (int i = 0; i < blocks; i++)
+            {
+                var hx = engine.TensorMatMul(h, wx[i]);          // block transform
+                var m = engine.TensorMatMul(t, wt[i]);           // adaLN-like, reads t every block
+                h = engine.TensorAdd(hx, m);                      // residual-ish combine
+            }
+            return h;
+        }
+        float[] Eager(Tensor<float> x, Tensor<float> t)
+        {
+            var o = Build(x, t);
+            var arr = new float[o.Length]; o.AsSpan().CopyTo(arr); return arr;
+        }
+
+        var cache = new CompiledModelCache<float>();
+        try
+        {
+            var plan = cache.GetOrCompileInference(new[] { x0, t0 }, () => Build(x0, t0));
+            AssertReplayMatches(engine, plan, () => Tensor<float>.CreateRandom(new[] { 2, 5 }),
+                () => Tensor<float>.CreateRandom(new[] { 2, 3 }), Eager, "deep-graph");
+        }
+        finally { cache.Dispose(); }
+    }
+
+    // Deep graph where each block has CONSECUTIVE matmuls sharing the secondary input (the
+    // attention q/k/v / adaLN pattern). These ARE batched by the consecutive-run rule, so this
+    // verifies consecutive batching itself does not corrupt multi-input replay.
+    [Fact]
+    public void MultiInput_DeepGraph_ConsecutiveSecondaryMatMuls_MatchesEager()
+    {
+        var engine = new CpuEngine();
+        const int blocks = 10;
+        var wa = new Tensor<float>[blocks];
+        var wb = new Tensor<float>[blocks];
+        var wx = new Tensor<float>[blocks];
+        for (int i = 0; i < blocks; i++)
+        {
+            wa[i] = Tensor<float>.CreateRandom(new[] { 3, 5 });
+            wb[i] = Tensor<float>.CreateRandom(new[] { 3, 5 });
+            wx[i] = Tensor<float>.CreateRandom(new[] { 5, 5 });
+        }
+        var x0 = Tensor<float>.CreateRandom(new[] { 2, 5 });
+        var t0 = Tensor<float>.CreateRandom(new[] { 2, 3 });
+
+        Tensor<float> Build(Tensor<float> x, Tensor<float> t)
+        {
+            var h = x;
+            for (int i = 0; i < blocks; i++)
+            {
+                var a = engine.TensorMatMul(t, wa[i]);   // consecutive secondary matmuls
+                var b = engine.TensorMatMul(t, wb[i]);   // (a, b adjacent -> batched together)
+                var hx = engine.TensorMatMul(h, wx[i]);
+                h = engine.TensorAdd(hx, engine.TensorAdd(a, b));
+            }
+            return h;
+        }
+        float[] Eager(Tensor<float> x, Tensor<float> t)
+        {
+            var o = Build(x, t);
+            var arr = new float[o.Length]; o.AsSpan().CopyTo(arr); return arr;
+        }
+
+        var cache = new CompiledModelCache<float>();
+        try
+        {
+            var plan = cache.GetOrCompileInference(new[] { x0, t0 }, () => Build(x0, t0));
+            AssertReplayMatches(engine, plan, () => Tensor<float>.CreateRandom(new[] { 2, 5 }),
+                () => Tensor<float>.CreateRandom(new[] { 2, 3 }), Eager, "consecutive-secondary");
+        }
+        finally { cache.Dispose(); }
+    }
+
+    private static void AssertReplayMatches(
+        CpuEngine engine, ICompiledPlan<float> plan,
+        Func<Tensor<float>> makeX, Func<Tensor<float>> makeT,
+        Func<Tensor<float>, Tensor<float>, float[]> eager, string label)
+    {
+        for (int trial = 0; trial < 4; trial++)
+        {
+            var x = makeX();
+            var t = makeT();
+            plan.SetInputs(new[] { x, t });
+            var got = plan.Execute();
+            var exp = eager(x, t);
+            float maxDiff = 0f;
+            for (int i = 0; i < got.Length; i++)
+                maxDiff = Math.Max(maxDiff, Math.Abs(exp[i] - got[i]));
+            Assert.True(maxDiff < 1e-3f, $"[{label}] trial {trial}: compiled diverged from eager, maxDiff={maxDiff:E3}");
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputSecondaryConsumerReproTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputSecondaryConsumerReproTests.cs
@@ -48,18 +48,8 @@ public class MultiInputSecondaryConsumerReproTests : IDisposable
                 return engine.TensorAdd(a, b);
             });
 
-            for (int trial = 0; trial < 4; trial++)
-            {
-                var x = Tensor<float>.CreateRandom(new[] { 2, 4 });
-                var t = Tensor<float>.CreateRandom(new[] { 2, 3 });
-                plan.SetInputs(new[] { x, t });
-                var got = plan.Execute();
-                var exp = Eager(x, t);
-                float maxDiff = 0f;
-                for (int i = 0; i < got.Length; i++)
-                    maxDiff = Math.Max(maxDiff, Math.Abs(exp[i] - got[i]));
-                Assert.True(maxDiff < 1e-3f, $"trial {trial}: compiled diverged from eager, maxDiff={maxDiff:E3}");
-            }
+            AssertReplayMatches(plan, () => Tensor<float>.CreateRandom(new[] { 2, 4 }),
+                () => Tensor<float>.CreateRandom(new[] { 2, 3 }), Eager, "secondary-through-matmul");
         }
         finally { cache.Dispose(); }
     }
@@ -88,7 +78,7 @@ public class MultiInputSecondaryConsumerReproTests : IDisposable
             var plan = cache.GetOrCompileInference(new[] { x0, t0 }, () =>
                 engine.TensorAdd(engine.TensorMatMul(x0, wx),
                     engine.TensorAdd(engine.TensorMatMul(t0, wt1), engine.TensorMatMul(t0, wt2))));
-            AssertReplayMatches(engine, plan, () => Tensor<float>.CreateRandom(new[] { 2, 4 }),
+            AssertReplayMatches(plan, () => Tensor<float>.CreateRandom(new[] { 2, 4 }),
                 () => Tensor<float>.CreateRandom(new[] { 2, 3 }), Eager, "multi-consumer");
         }
         finally { cache.Dispose(); }
@@ -117,7 +107,7 @@ public class MultiInputSecondaryConsumerReproTests : IDisposable
         {
             var plan = cache.GetOrCompileInference(new[] { x0, t0 }, () =>
                 engine.TensorBroadcastMultiply(engine.TensorMatMul(x0, wx), engine.TensorMatMul(t0, wt)));
-            AssertReplayMatches(engine, plan, () => Tensor<float>.CreateRandom(new[] { 2, 4 }),
+            AssertReplayMatches(plan, () => Tensor<float>.CreateRandom(new[] { 2, 4 }),
                 () => Tensor<float>.CreateRandom(new[] { 1, 3 }), Eager, "broadcast-modulation");
         }
         finally { cache.Dispose(); }
@@ -162,7 +152,7 @@ public class MultiInputSecondaryConsumerReproTests : IDisposable
         try
         {
             var plan = cache.GetOrCompileInference(new[] { x0, t0 }, () => Build(x0, t0));
-            AssertReplayMatches(engine, plan, () => Tensor<float>.CreateRandom(new[] { 2, 5 }),
+            AssertReplayMatches(plan, () => Tensor<float>.CreateRandom(new[] { 2, 5 }),
                 () => Tensor<float>.CreateRandom(new[] { 2, 3 }), Eager, "deep-graph");
         }
         finally { cache.Dispose(); }
@@ -210,14 +200,14 @@ public class MultiInputSecondaryConsumerReproTests : IDisposable
         try
         {
             var plan = cache.GetOrCompileInference(new[] { x0, t0 }, () => Build(x0, t0));
-            AssertReplayMatches(engine, plan, () => Tensor<float>.CreateRandom(new[] { 2, 5 }),
+            AssertReplayMatches(plan, () => Tensor<float>.CreateRandom(new[] { 2, 5 }),
                 () => Tensor<float>.CreateRandom(new[] { 2, 3 }), Eager, "consecutive-secondary");
         }
         finally { cache.Dispose(); }
     }
 
     private static void AssertReplayMatches(
-        CpuEngine engine, ICompiledPlan<float> plan,
+        ICompiledPlan<float> plan,
         Func<Tensor<float>> makeX, Func<Tensor<float>> makeT,
         Func<Tensor<float>, Tensor<float>, float[]> eager, string label)
     {


### PR DESCRIPTION
## Problem

`BlasBatchPass` groups independent matmuls with matching K,N and executes the **whole group at the first member's position** (no-op'ing the originals). It runs **after** `MemoryPlanningPass` has aliased step buffers based on the *original* execution order, so moving a later matmul's write earlier can clobber a buffer the planner reused for a tensor still live across the skipped region — silently corrupting the result.

This was **latent while only single-input compiled plans existed**: their secondary leaves are baked constants, so `matmul(const, const)` is constant-folded away before this pass and never batched. A **multi-input** plan (the `GetOrCompileInference(Tensor<T>[] inputs, …)` path from #616 — e.g. a diffusion denoiser reading the noisy sample **and** a per-step timestep embedding, both mutable) keeps those matmuls dynamic, so they reach this pass and get reordered.

Surfaced by ooples/AiDotNet#1620: the DiT/UNet per-step denoising forward, routed through the multi-input compiled path, diverged from eager by ~2.2 (a 12-block graph reading the secondary input in every block diverged by ~6e5). The bug only triggers at 20+ steps, where the CPU optimization passes run — which is why the existing shallow #616 coverage missed it.

## Fix

Only batch a **consecutive run** of matmuls, so no member is ever moved across an intervening step's buffer lifetime. The genuine win (adjacent independent matmuls — attention q/k/v projections) is preserved; scattered matmuls stay in place.

## Tests

`MultiInputSecondaryConsumerReproTests` (new): secondary-through-matmul, multiple-consumers, broadcast-modulation, a **deep 12-block** graph (non-consecutive secondary matmuls — the failing repro), and a **consecutive-secondary** block graph (attention/adaLN pattern — proves consecutive batching itself is correct). Full `Engines.Compilation` suite: **527 passed, 0 failed, 6 skipped**.

End-to-end: with this fix the ooples/AiDotNet DiT multi-input compiled replay matches eager (verified against a local package build), so the verify-then-trust gate adopts the compiled plan instead of falling back to eager.

Pairs with the consumer wiring in ooples/AiDotNet (#1620 follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batching optimization to group only consecutive, compatible matmul steps and stop at the first non-joinable candidate, ensuring inputs are available at the batched execution point and preventing incorrect batching when dependencies would be violated.

* **Tests**
  * Added a new repro test suite covering multi-input compilation and replay across multiple scenarios (single/multiple consumers, broadcast modulation, deep graphs, and consecutive patterns), verifying results match an eager reference within `1e-3f`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->