### PR TITLE
fix(autodiff): scope auto-compiled backward plan to its exact model (cross-model cache leak)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/AutoTrainingCompiler.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/AutoTrainingCompiler.cs
@@ -87,9 +87,15 @@ internal static class AutoTrainingCompiler
         // the caller actually wants gradients for.
         long currentHash = ComputeStructureHash(tape.Entries, tape.EntryCount);
         currentHash = IncludeTargetIdentity(currentHash, loss, sources);
-        if (!State.MatchesCompiledHash(currentHash))
+        // Match on BOTH the full hash AND exact source reference-equality. The
+        // hash alone is collision-prone (XOR of 32-bit GetHashCode values), and
+        // the state is thread-static — a different model on the same thread could
+        // collide and replay the wrong backward against the wrong parameters
+        // (the flaky, batch-only LossStrictly failures). The reference check makes
+        // a cross-model hit impossible.
+        if (!State.MatchesCompiledHash(currentHash) || !State.SourcesMatch(sources))
         {
-            // Pattern changed — disable replay mode so recording resumes
+            // Pattern / sources changed — disable replay mode so recording resumes
             ReplayMode = false;
             return null;
         }
@@ -145,7 +151,7 @@ internal static class AutoTrainingCompiler
             // computation in TryGetCompiledBackward — both must agree.
             long hash = ComputeStructureHash(tape.Entries, tape.EntryCount);
             hash = IncludeTargetIdentity(hash, loss, sources);
-            State.StoreCompiledBackwardWithHash(compiled, hash);
+            State.StoreCompiledBackwardWithHash(compiled, hash, sources);
             // Drop the plan's strong reference to the compilation-time loss
             // tensor. The compile cache is thread-static and persists for
             // the lifetime of the worker thread; without this release, the
@@ -303,6 +309,15 @@ internal sealed class AutoTrainingState
     private int _repeatCount;
     private object? _compiledBackward; // CompiledBackwardGraph<T> — type-erased
     private bool _compiledStored;
+    // Weak references to the EXACT source tensors the compiled plan was built
+    // against. The full hash (_compiledHash) folds in RuntimeHelpers.GetHashCode
+    // of these sources, but hash codes are 32-bit and XOR-combined, so a
+    // DIFFERENT model on the same (thread-static) state could collide and replay
+    // the wrong backward — silently producing wrong gradients (root cause of the
+    // flaky, batch-only LossStrictly failures). Verifying reference-equality of
+    // the sources on lookup makes a cross-model hit impossible. Weak so the plan
+    // never pins another model's parameter tensors alive.
+    private System.WeakReference<object>[]? _compiledSourceRefs;
 
     private const int CompileThreshold = 2;
 
@@ -321,17 +336,24 @@ internal sealed class AutoTrainingState
         {
             _repeatCount++;
         }
-        else if (!_compiledStored || hash != _lastStepHash)
+        else
         {
-            // New pattern — reset state. But don't drop compiled state if
-            // the pattern hash matches (only the full hash differs due to sources).
+            // New STRUCTURE pattern (different model / input shape). The
+            // thread-static state persists across models and tests on the same
+            // thread, so a previously-compiled plan here belongs to the OLD
+            // structure and its source tensors. Drop it completely: keeping it
+            // (the previous behaviour, which only cleared when !_compiledStored)
+            // let a structurally-different model leave a stale plan in the single
+            // slot, which then blocked its own compilation and — on a hash
+            // collision — could be replayed against the wrong parameters. A model
+            // whose structure genuinely repeats will recompile on its next steps.
             _lastStepHash = hash;
             _repeatCount = 1;
-            if (!_compiledStored)
-            {
-                _compilationFailed = false;
-                _compiledBackward = null;
-            }
+            _compilationFailed = false;
+            _compiledBackward = null;
+            _compiledStored = false;
+            _compiledHash = 0;
+            _compiledSourceRefs = null;
         }
     }
 
@@ -341,11 +363,45 @@ internal sealed class AutoTrainingState
         _compiledStored = true;
     }
 
-    internal void StoreCompiledBackwardWithHash<T>(CompiledBackwardGraph<T> compiled, long hash)
+    internal void StoreCompiledBackwardWithHash<T>(CompiledBackwardGraph<T> compiled, long hash, Tensor<T>[]? sources)
     {
         _compiledBackward = compiled;
         _compiledStored = true;
         _compiledHash = hash; // Store full hash (pattern + sources) for lookup matching
+        // Record the EXACT source tensors (weakly) so lookup can confirm the
+        // plan belongs to THIS model and not a hash-colliding different one.
+        if (sources is null || sources.Length == 0)
+        {
+            _compiledSourceRefs = null;
+        }
+        else
+        {
+            _compiledSourceRefs = new System.WeakReference<object>[sources.Length];
+            for (int i = 0; i < sources.Length; i++)
+                _compiledSourceRefs[i] = new System.WeakReference<object>(sources[i]);
+        }
+    }
+
+    /// <summary>
+    /// True only if the stored plan was compiled against EXACTLY these source
+    /// tensor instances (same count, each reference-equal). Guards against a
+    /// hash collision serving one model's plan to another. A null/empty stored
+    /// source set only matches a null/empty query (structure-only plans are
+    /// refused at compile time, so this is the defensive case).
+    /// </summary>
+    internal bool SourcesMatch<T>(Tensor<T>[]? sources)
+    {
+        var stored = _compiledSourceRefs;
+        int queryLen = sources?.Length ?? 0;
+        int storedLen = stored?.Length ?? 0;
+        if (queryLen != storedLen) return false;
+        if (storedLen == 0) return true;
+        for (int i = 0; i < storedLen; i++)
+        {
+            if (!stored![i].TryGetTarget(out var obj) || !ReferenceEquals(obj, sources![i]))
+                return false;
+        }
+        return true;
     }
 
     internal CompiledBackwardGraph<T>? TryGetCompiledBackward<T>()

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/AutoTrainingCompilerTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/AutoTrainingCompilerTests.cs
@@ -207,6 +207,58 @@ public class AutoTrainingCompilerTests : IDisposable
     }
 
     // ──────────────────────────────────────────────────────────────
+    // Cross-model isolation (thread-static state persists across models/tests)
+    // ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DifferentStructureAfterCompile_RecompilesForNewModel_NoStalePlanBlock()
+    {
+        // Two DIFFERENT models trained sequentially on the same thread WITHOUT a
+        // ResetState between them (the real batched-test / sequential-training
+        // scenario — the compiler state is [ThreadStatic] and survives across
+        // models). Model A's compiled plan must not stay stuck in the single slot
+        // and block model B (different structure) from compiling its own. Before
+        // the fix, B's ShouldCompile stayed false forever because _compiledStored
+        // (A's plan) was never cleared on a structure change — and on a hash
+        // collision B could even replay A's backward against B's parameters.
+        var inputA = new Tensor<float>(new float[] { 1f, 0f, 0f, 1f }, new[] { 2, 2 });
+        var weightA = new Tensor<float>(new float[] { 2f, 0f, 0f, 2f }, new[] { 2, 2 });
+
+        using (var tapeA = new GradientTape<float>(new GradientTapeOptions { Persistent = true }))
+        {
+            for (int s = 0; s < 3; s++)
+            {
+                tapeA.Reset();
+                var h = _engine.TensorMatMul(inputA, weightA);
+                var loss = _engine.ReduceSum(h, null);
+                tapeA.ComputeGradients(loss, new[] { weightA });
+            }
+            Assert.True(AutoTrainingCompiler.ReplayMode, "Model A should have compiled (sanity check)");
+        }
+
+        // Model B: different structure (3x3 vs 2x2) + different parameter tensor.
+        // No ResetState — A's plan is still in the thread-static slot.
+        var inputB = new Tensor<float>(new float[] { 1f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 1f }, new[] { 3, 3 });
+        var weightB = new Tensor<float>(new float[] { 2f, 0f, 0f, 0f, 2f, 0f, 0f, 0f, 2f }, new[] { 3, 3 });
+        bool bCompiled;
+        using (var tapeB = new GradientTape<float>(new GradientTapeOptions { Persistent = true }))
+        {
+            for (int s = 0; s < 3; s++)
+            {
+                tapeB.Reset();
+                var h = _engine.TensorMatMul(inputB, weightB);
+                var loss = _engine.ReduceSum(h, null);
+                tapeB.ComputeGradients(loss, new[] { weightB });
+            }
+            bCompiled = AutoTrainingCompiler.ReplayMode;
+        }
+
+        Assert.True(bCompiled,
+            "Model B (different structure) must compile its OWN plan; a stale plan from model A " +
+            "must not occupy the single thread-static slot and block B's compilation.");
+    }
+
+    // ──────────────────────────────────────────────────────────────
     // TryCompileBackward guards
     // ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem
The auto-training compiler's compiled-backward plan is stored in `[ThreadStatic]` `AutoTrainingState`, so it survives across models trained sequentially on the same thread (batched tests / sequential training). Two defects let one model's plan affect another:

1. **Collision-prone key.** The single-slot plan was keyed only by `structureHash XOR RuntimeHelpers.GetHashCode(sources)`. Hash codes are 32-bit and XOR-combined, so a structurally-similar *different* model could collide and have model A's compiled backward replayed against model B's parameters → silently wrong gradients.
2. **Stale plan not cleared on structure change.** `RecordStepHash` reset the repeat counter but kept the stored plan, so a structurally-different model found the single slot occupied and its own `ShouldCompile` stayed false forever.

## Fix
- Record **weak references to the exact source tensors** a plan was compiled against and require **reference-equality** (not just the hash) on lookup → a cross-model hit is impossible. Weak refs avoid pinning another model's parameters alive.
- **Clear** the stored plan + hash + source refs when the structure pattern changes → a new model always gets a fresh slot.

Auto-compiled inference stays enabled by default.

## Why
Suspected root cause of flaky, batch-only `LossStrictly` / training-invariant failures in AiDotNet's ModelFamily CI shards — e.g. `FastTextTests.LossStrictly` passes alone, passes in-batch with `AIDOTNET_DISABLE_AUTO_COMPILE=1`, fails in-batch with it on. Tracked as ooples/AiDotNet#1645.

## Verification
- New test `DifferentStructureAfterCompile_RecompilesForNewModel_NoStalePlanBlock` (fails pre-fix: model B blocked by A's stale plan).
- Full autodiff/compilation suite green: **1355 passed, 0 failed**; 11/11 `AutoTrainingCompiler` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a critical issue where cached computation plans from one model could be incorrectly reused when training a different model, potentially causing incorrect gradient calculations.
* Improved validation of cached plans to ensure they are only applied to the correct model parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->