### PR TITLE
perf(#639): batch=1 per-op overhead — depthwise typed backward + differentiable BatchNormAffine fusion (753->339 ops)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -1067,6 +1067,48 @@ internal static class BackwardFunctions<T>
         DifferentiableOps.AccumulateGrad(grads, inputs[2], gradBeta, engine);
     }
 
+    /// <summary>
+    /// #639: backward for the AFFINE batch-norm (running-stats inference form), the single
+    /// differentiable op that replaces the ~6-primitive batch=1 BN fallback. mean/variance are
+    /// CONSTANTS (running stats), so only inputs[0]=x, inputs[1]=gamma, inputs[2]=beta get
+    /// gradients. CpuEngine uses a fused typed kernel; other engines use a primitive fallback.
+    /// </summary>
+    internal static void BatchNormAffineBackward(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
+        object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        var mean = (Tensor<T>)savedState[0];
+        var variance = (Tensor<T>)savedState[1];
+        var epsilon = (double)savedState[2];
+
+        Tensor<T> gradInput, gradGamma, gradBeta;
+        if (engine is CpuEngine cpu)
+        {
+            gradInput = cpu.BatchNormAffineBackward(
+                gradOutput, inputs[0], inputs[1], mean, variance, epsilon, out gradGamma, out gradBeta);
+        }
+        else
+        {
+            // Engine-generic primitive fallback (NCHW; gamma/mean/var are [C]).
+            int C = inputs[1].Length;
+            var bshape = new[] { 1, C, 1, 1 };
+            var eps = MathHelper.GetNumericOperations<T>().FromDouble(epsilon);
+            var std = engine.TensorSqrt(engine.TensorAddScalar(variance, eps)); // [C]
+            var inv = engine.TensorReciprocal(std);                             // 1/std [C]
+            var scale = engine.TensorMultiply(inputs[1], inv);                  // gamma/std [C]
+            gradInput = engine.TensorBroadcastMultiply(gradOutput, engine.Reshape(scale, bshape));
+            var xhat = engine.TensorBroadcastMultiply(
+                engine.TensorBroadcastSubtract(inputs[0], engine.Reshape(mean, bshape)),
+                engine.Reshape(inv, bshape));
+            gradGamma = engine.ReduceSum(engine.TensorMultiply(gradOutput, xhat), new[] { 0, 2, 3 }, false);
+            gradBeta = engine.ReduceSum(gradOutput, new[] { 0, 2, 3 }, false);
+        }
+
+        DifferentiableOps.AccumulateGrad(grads, inputs[0], gradInput, engine);
+        DifferentiableOps.AccumulateGrad(grads, inputs[1], gradGamma, engine);
+        DifferentiableOps.AccumulateGrad(grads, inputs[2], gradBeta, engine);
+    }
+
     /// <summary>LayerNorm backward: uses engine.LayerNormBackward</summary>
     internal static void LayerNormBackward(
         Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,

--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -1082,7 +1082,11 @@ internal static class BackwardFunctions<T>
         var epsilon = (double)savedState[2];
 
         Tensor<T> gradInput, gradGamma, gradBeta;
-        if (engine is CpuEngine cpu)
+        // DirectGpuTensorEngine inherits CpuEngine, so a bare `is CpuEngine` would silently route
+        // a GPU engine into the CPU fused backward (host<->device ping-pong, the worst outcome).
+        // Only take the CPU fused kernel for a genuine CPU engine; GPU engines use the
+        // engine-generic primitive fallback below, which dispatches each op to the GPU backend.
+        if (engine is CpuEngine cpu && !engine.SupportsGpu)
         {
             gradInput = cpu.BatchNormAffineBackward(
                 gradOutput, inputs[0], inputs[1], mean, variance, epsilon, out gradGamma, out gradBeta);

--- a/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
@@ -63,7 +63,7 @@ internal static class OpRegistry
         "DepthwiseConv2D", "ConvTranspose2D", "ConvTranspose3D", "LocallyConnectedConv2D",
 
         // Normalization
-        "BatchNorm", "LayerNorm", "GroupNorm", "RMSNorm", "InstanceNorm",
+        "BatchNorm", "BatchNormAffine", "LayerNorm", "GroupNorm", "RMSNorm", "InstanceNorm",
 
         // Attention/Embedding
         "Embedding", "Dropout",

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Microkernels/Avx2/Avx2Streaming.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Microkernels/Avx2/Avx2Streaming.cs
@@ -35,11 +35,16 @@ internal static class Avx2Streaming
         if (!IsSupported)
             throw new PlatformNotSupportedException("Avx2Streaming requires Avx2 + Fma.");
 
-        // transB=true: B is strided across N rows. Fall back to scalar — gather
-        // would require vgatherqpd which is slow on most µarchs.
         if (transB)
         {
-            ScalarStreaming.RunFp64(a, lda, transA, b, ldb, transB, c, ldc, m, n, k);
+            // TT: A strided along K — keep scalar (rare).
+            if (transA)
+            {
+                ScalarStreaming.RunFp64(a, lda, transA, b, ldb, transB, c, ldc, m, n, k);
+                return;
+            }
+            // NT (#639): contiguous-K dot product, vectorized. See the FP32 path.
+            RunFp64Nt(a, lda, b, ldb, c, ldc, m, n, k);
             return;
         }
 
@@ -132,7 +137,20 @@ internal static class Avx2Streaming
 
         if (transB)
         {
-            ScalarStreaming.RunFp32(a, lda, transA, b, ldb, transB, c, ldc, m, n, k);
+            // TT (A also transposed): A is strided along K, so the contiguous-K
+            // dot product below doesn't apply — keep the scalar reference (rare).
+            if (transA)
+            {
+                ScalarStreaming.RunFp32(a, lda, transA, b, ldb, transB, c, ldc, m, n, k);
+                return;
+            }
+            // NT (#639): C[i,j] += dot(A[i,:K], B[j,:K]). With transB=true, B is [N,K]
+            // row-major so B's row j is contiguous along K — same as A's row i. This is
+            // the conv-backward dX = dY·Wᵀ shape, which previously fell to the SCALAR
+            // kernel for the WHOLE GEMM (no SIMD at all — the top compiled-plan compute
+            // frame on an AVX2 box). Vectorize it as an 8-wide FMA dot product, 4 output
+            // columns per inner pass so one A-row load feeds four B-row FMAs.
+            RunFp32Nt(a, lda, b, ldb, c, ldc, m, n, k);
             return;
         }
 
@@ -237,6 +255,143 @@ internal static class Avx2Streaming
             }
         }
     }
+    /// <summary>
+    /// #639 NT microkernel (transB=true, transA=false): C[i,j] += Σ_k A[i,k]·B[j,k].
+    /// Both A row i and B row j are contiguous along K, so each output is a vectorized
+    /// 8-wide FMA dot product. Processes 4 output columns per pass so a single A-row
+    /// load feeds four independent accumulators (hides FMA latency, amortizes the load).
+    /// C is read-modify-write (caller zeroed it on the first streaming call).
+    /// </summary>
+    private static unsafe void RunFp32Nt(
+        ReadOnlySpan<float> a, int lda,
+        ReadOnlySpan<float> b, int ldb,
+        Span<float> c, int ldc,
+        int m, int n, int k)
+    {
+        int kVec = (k / 8) * 8;
+        fixed (float* aPtr = a)
+        fixed (float* bPtr = b)
+        fixed (float* cPtr = c)
+        {
+            for (int i = 0; i < m; i++)
+            {
+                float* aRow = aPtr + i * lda;
+                float* cRow = cPtr + i * ldc;
+                int j = 0;
+                for (; j + 4 <= n; j += 4)
+                {
+                    float* b0 = bPtr + (j + 0) * ldb;
+                    float* b1 = bPtr + (j + 1) * ldb;
+                    float* b2 = bPtr + (j + 2) * ldb;
+                    float* b3 = bPtr + (j + 3) * ldb;
+                    Vector256<float> acc0 = Vector256<float>.Zero;
+                    Vector256<float> acc1 = Vector256<float>.Zero;
+                    Vector256<float> acc2 = Vector256<float>.Zero;
+                    Vector256<float> acc3 = Vector256<float>.Zero;
+                    for (int kk = 0; kk < kVec; kk += 8)
+                    {
+                        Vector256<float> av = Avx.LoadVector256(aRow + kk);
+                        acc0 = Fma.MultiplyAdd(av, Avx.LoadVector256(b0 + kk), acc0);
+                        acc1 = Fma.MultiplyAdd(av, Avx.LoadVector256(b1 + kk), acc1);
+                        acc2 = Fma.MultiplyAdd(av, Avx.LoadVector256(b2 + kk), acc2);
+                        acc3 = Fma.MultiplyAdd(av, Avx.LoadVector256(b3 + kk), acc3);
+                    }
+                    float s0 = HSum256(acc0), s1 = HSum256(acc1), s2 = HSum256(acc2), s3 = HSum256(acc3);
+                    for (int kk = kVec; kk < k; kk++)
+                    {
+                        float av = aRow[kk];
+                        s0 += av * b0[kk]; s1 += av * b1[kk]; s2 += av * b2[kk]; s3 += av * b3[kk];
+                    }
+                    cRow[j + 0] += s0; cRow[j + 1] += s1; cRow[j + 2] += s2; cRow[j + 3] += s3;
+                }
+                for (; j < n; j++)
+                {
+                    float* bj = bPtr + j * ldb;
+                    Vector256<float> acc = Vector256<float>.Zero;
+                    for (int kk = 0; kk < kVec; kk += 8)
+                        acc = Fma.MultiplyAdd(Avx.LoadVector256(aRow + kk), Avx.LoadVector256(bj + kk), acc);
+                    float s = HSum256(acc);
+                    for (int kk = kVec; kk < k; kk++) s += aRow[kk] * bj[kk];
+                    cRow[j] += s;
+                }
+            }
+        }
+    }
+
+    /// <summary>FP64 mirror of <see cref="RunFp32Nt"/> (Vector256&lt;double&gt;, 4 lanes).</summary>
+    private static unsafe void RunFp64Nt(
+        ReadOnlySpan<double> a, int lda,
+        ReadOnlySpan<double> b, int ldb,
+        Span<double> c, int ldc,
+        int m, int n, int k)
+    {
+        int kVec = (k / 4) * 4;
+        fixed (double* aPtr = a)
+        fixed (double* bPtr = b)
+        fixed (double* cPtr = c)
+        {
+            for (int i = 0; i < m; i++)
+            {
+                double* aRow = aPtr + i * lda;
+                double* cRow = cPtr + i * ldc;
+                int j = 0;
+                for (; j + 4 <= n; j += 4)
+                {
+                    double* b0 = bPtr + (j + 0) * ldb;
+                    double* b1 = bPtr + (j + 1) * ldb;
+                    double* b2 = bPtr + (j + 2) * ldb;
+                    double* b3 = bPtr + (j + 3) * ldb;
+                    Vector256<double> acc0 = Vector256<double>.Zero;
+                    Vector256<double> acc1 = Vector256<double>.Zero;
+                    Vector256<double> acc2 = Vector256<double>.Zero;
+                    Vector256<double> acc3 = Vector256<double>.Zero;
+                    for (int kk = 0; kk < kVec; kk += 4)
+                    {
+                        Vector256<double> av = Avx.LoadVector256(aRow + kk);
+                        acc0 = Fma.MultiplyAdd(av, Avx.LoadVector256(b0 + kk), acc0);
+                        acc1 = Fma.MultiplyAdd(av, Avx.LoadVector256(b1 + kk), acc1);
+                        acc2 = Fma.MultiplyAdd(av, Avx.LoadVector256(b2 + kk), acc2);
+                        acc3 = Fma.MultiplyAdd(av, Avx.LoadVector256(b3 + kk), acc3);
+                    }
+                    double s0 = HSum256(acc0), s1 = HSum256(acc1), s2 = HSum256(acc2), s3 = HSum256(acc3);
+                    for (int kk = kVec; kk < k; kk++)
+                    {
+                        double av = aRow[kk];
+                        s0 += av * b0[kk]; s1 += av * b1[kk]; s2 += av * b2[kk]; s3 += av * b3[kk];
+                    }
+                    cRow[j + 0] += s0; cRow[j + 1] += s1; cRow[j + 2] += s2; cRow[j + 3] += s3;
+                }
+                for (; j < n; j++)
+                {
+                    double* bj = bPtr + j * ldb;
+                    Vector256<double> acc = Vector256<double>.Zero;
+                    for (int kk = 0; kk < kVec; kk += 4)
+                        acc = Fma.MultiplyAdd(Avx.LoadVector256(aRow + kk), Avx.LoadVector256(bj + kk), acc);
+                    double s = HSum256(acc);
+                    for (int kk = kVec; kk < k; kk++) s += aRow[kk] * bj[kk];
+                    cRow[j] += s;
+                }
+            }
+        }
+    }
+
+    /// <summary>Horizontal sum of an 8-lane FP32 vector.</summary>
+    private static float HSum256(Vector256<float> v)
+    {
+        Vector128<float> s = Sse.Add(v.GetLower(), v.GetUpper());   // 4 partials
+        s = Sse.Add(s, Sse.MoveHighToLow(s, s));                    // 2 partials
+        s = Sse.AddScalar(s, Sse.Shuffle(s, s, 0x55));              // + lane 1
+        return s.ToScalar();
+    }
+
+    /// <summary>Horizontal sum of a 4-lane FP64 vector.</summary>
+    private static double HSum256(Vector256<double> v)
+    {
+        Vector128<double> s = Sse2.Add(v.GetLower(), v.GetUpper());  // 2 partials
+        s = Sse2.AddScalar(s, Sse2.UnpackHigh(s, s));               // + lane 1
+        return s.ToScalar();
+    }
+
 #else
     /// <summary>Runtime support gate (always false on net471 — no Vector256&lt;T&gt; intrinsics).</summary>
     public static bool IsSupported => false;

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -814,7 +814,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     // #639: one-time op-type histogram of the compiled forward graph. Sizes the
     // operator-fusion prize (how many ops the plan replays per step, and which
     // adjacencies — conv→bias→activation, residual-add, BN — are worth fusing).
-    // Gated on AIDOTNET_PLAN_HISTOGRAM=1; writes to stderr once per process.
+    // Gated on AIDOTNET_PLAN_HISTOGRAM=1; writes once per process. Output goes to stderr AND
+    // (so it survives xUnit/dotnet-test console capture) to the path in AIDOTNET_PLAN_HISTOGRAM_FILE,
+    // defaulting to %TEMP%/aidotnet_plan_histogram.txt.
     private void MaybeDumpOpHistogram()
     {
         if (s_histogramDumped || _forwardSteps is null) return;
@@ -828,9 +830,22 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         }
         var ordered = new System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<string, int>>(hist);
         ordered.Sort((a, b) => b.Value.CompareTo(a.Value));
-        System.Console.Error.WriteLine($"[#639] compiled-plan forward op histogram — {_forwardSteps.Length} ops:");
+
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine($"[#639] compiled-plan forward op histogram — {_forwardSteps.Length} ops:");
         foreach (var kv in ordered)
-            System.Console.Error.WriteLine($"  {kv.Value,4}  {kv.Key}");
+            sb.AppendLine($"  {kv.Value,4}  {kv.Key}");
+        var text = sb.ToString();
+
+        System.Console.Error.Write(text);
+        try
+        {
+            var path = System.Environment.GetEnvironmentVariable("AIDOTNET_PLAN_HISTOGRAM_FILE");
+            if (string.IsNullOrEmpty(path))
+                path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "aidotnet_plan_histogram.txt");
+            System.IO.File.WriteAllText(path, text);
+        }
+        catch { /* diagnostic only — never let a histogram dump break a training run */ }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -153,6 +153,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         _lossGradSeed = lossGradSeed;
         _genericGradIndices = genericGradIndices;
         _forwardSteps = forwardSteps;
+        MaybeDumpOpHistogram(); // #639 diagnostic: AIDOTNET_PLAN_HISTOGRAM=1 dumps the replayed op profile
         // A leading "Embedding" step is an int→float gather. Capture it INSIDE the graph as a pure on-device gather
         // over a STABLE index buffer, and refresh just the small index vector before each launch (via the engine's
         // registered action, which knows the live indices tensor's TIndex) — so the whole step is one cuGraphLaunch
@@ -807,6 +808,30 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     /// here when AIDOTNET_DEBUG_SUB=1. Used by Pinpoint tests to inspect
     /// what the kernel sees vs writes.</summary>
     public static string SubFwdDiag = "";
+
+    private static bool s_histogramDumped;
+
+    // #639: one-time op-type histogram of the compiled forward graph. Sizes the
+    // operator-fusion prize (how many ops the plan replays per step, and which
+    // adjacencies — conv→bias→activation, residual-add, BN — are worth fusing).
+    // Gated on AIDOTNET_PLAN_HISTOGRAM=1; writes to stderr once per process.
+    private void MaybeDumpOpHistogram()
+    {
+        if (s_histogramDumped || _forwardSteps is null) return;
+        if (System.Environment.GetEnvironmentVariable("AIDOTNET_PLAN_HISTOGRAM") != "1") return;
+        s_histogramDumped = true;
+        var hist = new System.Collections.Generic.Dictionary<string, int>();
+        foreach (var s in _forwardSteps)
+        {
+            var key = s.OpName ?? s.OpType.ToString();
+            hist[key] = hist.TryGetValue(key, out var c) ? c + 1 : 1;
+        }
+        var ordered = new System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<string, int>>(hist);
+        ordered.Sort((a, b) => b.Value.CompareTo(a.Value));
+        System.Console.Error.WriteLine($"[#639] compiled-plan forward op histogram — {_forwardSteps.Length} ops:");
+        foreach (var kv in ordered)
+            System.Console.Error.WriteLine($"  {kv.Value,4}  {kv.Key}");
+    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Tensor<T> Step()

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -809,19 +809,21 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     /// what the kernel sees vs writes.</summary>
     public static string SubFwdDiag = "";
 
-    private static bool s_histogramDumped;
-
     // #639: one-time op-type histogram of the compiled forward graph. Sizes the
     // operator-fusion prize (how many ops the plan replays per step, and which
     // adjacencies — conv→bias→activation, residual-add, BN — are worth fusing).
     // Gated on AIDOTNET_PLAN_HISTOGRAM=1; writes once per process. Output goes to stderr AND
     // (so it survives xUnit/dotnet-test console capture) to the path in AIDOTNET_PLAN_HISTOGRAM_FILE,
     // defaulting to %TEMP%/aidotnet_plan_histogram.txt.
+    //
+    // The once-flag lives in the NON-generic CompiledPlanDiagnostics so it is genuinely process-wide
+    // (a static in CompiledTrainingPlan<T> would be per-closed-T: float, double, … each dump once) and
+    // the Interlocked latch makes the first-writer-wins check thread-safe under concurrent plan builds.
     private void MaybeDumpOpHistogram()
     {
-        if (s_histogramDumped || _forwardSteps is null) return;
+        if (_forwardSteps is null) return;
         if (System.Environment.GetEnvironmentVariable("AIDOTNET_PLAN_HISTOGRAM") != "1") return;
-        s_histogramDumped = true;
+        if (System.Threading.Interlocked.Exchange(ref CompiledPlanDiagnostics.HistogramDumped, 1) != 0) return;
         var hist = new System.Collections.Generic.Dictionary<string, int>();
         foreach (var s in _forwardSteps)
         {
@@ -7163,6 +7165,17 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             i++; // Skip past i+1 — already consumed
         }
     }
+}
+
+/// <summary>
+/// Process-wide (NON-generic) diagnostics latch for <see cref="CompiledTrainingPlan{T}"/>. A static
+/// in the generic class would be per-closed-T, so the #639 op histogram would dump once per element
+/// type instead of once per process; this non-generic holder guarantees a single dump.
+/// </summary>
+internal static class CompiledPlanDiagnostics
+{
+    /// <summary>0 until the op histogram has been dumped; latched to 1 via Interlocked (first wins).</summary>
+    internal static int HistogramDumped;
 }
 
 /// <summary>

--- a/src/AiDotNet.Tensors/Engines/Compilation/OpType.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/OpType.cs
@@ -146,7 +146,7 @@ internal static class OpTypeParser
         "Conv2D" => OpType.Conv2D,
         "DepthwiseConv2D" => OpType.DepthwiseConv2D,
         "ConvTranspose2D" => OpType.ConvTranspose2D,
-        "BatchNorm" or "BatchNormInference" => OpType.BatchNorm,
+        "BatchNorm" or "BatchNormInference" or "BatchNormAffine" => OpType.BatchNorm,
         "LayerNorm" => OpType.LayerNorm,
         "GroupNorm" => OpType.GroupNorm,
         "InstanceNorm" => OpType.InstanceNorm,

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -13148,18 +13148,30 @@ public partial class CpuEngine : ITensorLevelEngine
                 return entry.Data;
             }
 
-            // Stale (weights mutated in place since the transpose was built)
-            // or missing — rebuild from the live kernel contents. Remove+
-            // GetValue rather than AddOrUpdate: net471's ConditionalWeakTable
-            // has no AddOrUpdate, and a concurrent racer at worst redoes the
-            // transpose once.
+            // Stale (weights mutated in place since the transpose was built) or
+            // missing. #639: in TRAINING the weights change every optimizer step, so
+            // this rebuilds every step. REUSE the stale entry's buffer (same size)
+            // instead of allocating a fresh float[] each rebuild — that was ~116 MB/step
+            // of pure GC churn on MobileNetV3 batch=1. Conv ops in the compiled-plan
+            // replay run sequentially, so no other thread is mid-read of this kernel's
+            // transpose while we overwrite it.
+            int needed = cols * rows;
+            float[] kernelT = (entry != null && entry.Data.Length == needed)
+                ? entry.Data
+                : new float[needed];
+            TransposeFloatParallel(kernel, 0, kernelT, 0, rows, cols);
             _kernelTransposeCache.Remove(kernel);
-            return _kernelTransposeCache.GetValue(kernel, k =>
+            try
             {
-                var kernelT = new float[cols * rows];
-                TransposeFloatParallel(k, 0, kernelT, 0, rows, cols);
-                return new KernelTransposeEntry(kernelT, epoch, sourceVersion);
-            }).Data;
+                _kernelTransposeCache.Add(kernel, new KernelTransposeEntry(kernelT, epoch, sourceVersion));
+            }
+            catch (ArgumentException)
+            {
+                // A concurrent caller re-added an entry between Remove and Add. Our
+                // kernelT is a correct transpose of the CURRENT kernel, so return it;
+                // the cache holding the racer's (equally-correct) buffer is fine.
+            }
+            return kernelT;
         }
 
         /// <summary>
@@ -13939,11 +13951,15 @@ public partial class CpuEngine : ITensorLevelEngine
                 Array.Clear(destF, destOff, batch * inChannels * height * width);
             var gradOutputF = (float[])(object)gradOutput.GetFlattenedData();
             var kernelF = (float[])(object)kernel.GetFlattenedData();
-            var kernelT = new float[colH * outChannels];
+            var pool = System.Buffers.ArrayPool<float>.Shared;
+            // #639: rent the transposed-kernel scratch instead of `new float[]` per call.
+            // Its size is fixed per layer (only the contents change each step), and the
+            // weights change every step so this can't be content-cached — it was ~130 MB/step
+            // of pure GC churn on MobileNetV3 batch=1 (a gen2 collection every ~2 steps).
+            var kernelT = pool.Rent(colH * outChannels);
             for (int r = 0; r < outChannels; r++)
                 for (int c = 0; c < colH; c++)
                     kernelT[c * outChannels + r] = kernelF[r * colH + c];
-            var pool = System.Buffers.ArrayPool<float>.Shared;
             long col2imWorkF = (long)inChannels * kernelHeight * kernelWidth * colW;
             void ProcessImageInputF(int b, bool channelParallel)
             {
@@ -13996,6 +14012,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     b => ProcessImageInputF(b, channelParallel: false));
             else
                 for (int b = 0; b < batch; b++) ProcessImageInputF(b, channelParallel: true);
+            pool.Return(kernelT);
             return;
         }
 
@@ -14892,12 +14909,15 @@ public partial class CpuEngine : ITensorLevelEngine
             int totalLen = outChannels * colH;
             var destF = (float[])(object)dest._storage.GetDataArray();
             int destOff = dest._storageOffset;
-            // Local accumulator: per-batch BLAS writes into localGrad; merge into dest at end.
-            var gradKernelF = new float[totalLen];
+            var kPool = System.Buffers.ArrayPool<float>.Shared;
+            // #639: rent the kernel-gradient accumulator instead of `new float[]` per call.
+            // Weights change every step so it can't be content-cached — it was per-step GC
+            // churn. Rented buffers aren't zeroed and this is a += accumulator, so clear it.
+            var gradKernelF = kPool.Rent(totalLen);
+            Array.Clear(gradKernelF, 0, totalLen);
             var gradOutputF = (float[])(object)gradOutput.GetFlattenedData();
             var inputF = (float[])(object)input.GetFlattenedData();
             int inputSliceSize = inChannels * height * width;
-            var kPool = System.Buffers.ArrayPool<float>.Shared;
             long im2colWorkKF = (long)inChannels * kernelHeight * kernelWidth * colW;
 
             // Per-image: build im2col(input_b) then GEMM gradOut_b @ im2col^T into
@@ -14999,6 +15019,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 for (int i = 0; i < totalLen; i++) destF[destOff + i] += gradKernelF[i];
             else
                 Array.Copy(gradKernelF, 0, destF, destOff, totalLen);
+            kPool.Return(gradKernelF);
             return;
         }
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -2295,6 +2295,179 @@ public partial class CpuEngine : ITensorLevelEngine
     }
 
 
+    /// <summary>
+    /// #639: backward for the AFFINE batch-norm (running-stats inference form used as the
+    /// differentiable batch=1 training fallback). mean/variance are CONSTANTS (running stats),
+    /// so only x, gamma, beta receive gradients. Rank-4 NCHW.
+    ///   y = gamma·(x-mean)·inv + beta,  inv = 1/sqrt(var+eps)
+    ///   dx      = gradY · gamma · inv                         (per-channel broadcast)
+    ///   dgamma  = Σ_{n,h,w} gradY · (x-mean)·inv
+    ///   dbeta   = Σ_{n,h,w} gradY
+    /// </summary>
+    internal Tensor<T> BatchNormAffineBackward<T>(
+        Tensor<T> gradOutput, Tensor<T> input, Tensor<T> gamma, Tensor<T> mean, Tensor<T> variance,
+        double epsilon, out Tensor<T> gradGamma, out Tensor<T> gradBeta)
+    {
+        if (gradOutput.Rank != 4 || input.Rank != 4)
+            throw new ArgumentException("BatchNormAffineBackward requires rank-4 NCHW tensors.");
+        int N = input._shape[0], C = input._shape[1], H = input._shape[2], W = input._shape[3];
+        int hw = H * W, chw = C * hw;
+
+        if (typeof(T) == typeof(float))
+        {
+            var go = (float[])(object)gradOutput.Contiguous().GetFlattenedData();
+            var xf = (float[])(object)input.Contiguous().GetFlattenedData();
+            var gf = (float[])(object)gamma.GetFlattenedData();
+            var mf = (float[])(object)mean.GetFlattenedData();
+            var vf = (float[])(object)variance.GetFlattenedData();
+            var dx = new float[N * chw];
+            var dg = new float[C];
+            var db = new float[C];
+            for (int c = 0; c < C; c++)
+            {
+                float inv = 1f / MathF.Sqrt(vf[c] + (float)epsilon);
+                float gc = gf[c], mc = mf[c];
+                float sg = 0f, sb = 0f;
+                float scale = gc * inv;
+                for (int n = 0; n < N; n++)
+                {
+                    int baseIdx = n * chw + c * hw;
+                    for (int i = 0; i < hw; i++)
+                    {
+                        float gy = go[baseIdx + i];
+                        sb += gy;
+                        sg += gy * (xf[baseIdx + i] - mc) * inv;
+                        dx[baseIdx + i] = gy * scale;
+                    }
+                }
+                dg[c] = sg; db[c] = sb;
+            }
+            gradGamma = TensorAllocator.Rent<T>(gamma._shape, (T[])(object)dg);
+            gradBeta = TensorAllocator.Rent<T>(gamma._shape, (T[])(object)db);
+            return TensorAllocator.Rent<T>(input._shape, (T[])(object)dx);
+        }
+        if (typeof(T) == typeof(double))
+        {
+            var go = (double[])(object)gradOutput.Contiguous().GetFlattenedData();
+            var xf = (double[])(object)input.Contiguous().GetFlattenedData();
+            var gf = (double[])(object)gamma.GetFlattenedData();
+            var mf = (double[])(object)mean.GetFlattenedData();
+            var vf = (double[])(object)variance.GetFlattenedData();
+            var dx = new double[N * chw];
+            var dg = new double[C];
+            var db = new double[C];
+            for (int c = 0; c < C; c++)
+            {
+                double inv = 1d / Math.Sqrt(vf[c] + epsilon);
+                double gc = gf[c], mc = mf[c];
+                double sg = 0d, sb = 0d;
+                double scale = gc * inv;
+                for (int n = 0; n < N; n++)
+                {
+                    int baseIdx = n * chw + c * hw;
+                    for (int i = 0; i < hw; i++)
+                    {
+                        double gy = go[baseIdx + i];
+                        sb += gy;
+                        sg += gy * (xf[baseIdx + i] - mc) * inv;
+                        dx[baseIdx + i] = gy * scale;
+                    }
+                }
+                dg[c] = sg; db[c] = sb;
+            }
+            gradGamma = TensorAllocator.Rent<T>(gamma._shape, (T[])(object)dg);
+            gradBeta = TensorAllocator.Rent<T>(gamma._shape, (T[])(object)db);
+            return TensorAllocator.Rent<T>(input._shape, (T[])(object)dx);
+        }
+
+        // Generic fallback
+        var numOps = MathHelper.GetNumericOperations<T>();
+        var goG = gradOutput.Contiguous().GetFlattenedData();
+        var xG = input.Contiguous().GetFlattenedData();
+        var gG = gamma.GetFlattenedData();
+        var mG = mean.GetFlattenedData();
+        var vG = variance.GetFlattenedData();
+        var dxG = new T[N * chw];
+        var dgG = new T[C];
+        var dbG = new T[C];
+        T epsT = numOps.FromDouble(epsilon);
+        for (int c = 0; c < C; c++)
+        {
+            T inv = numOps.Divide(numOps.One, numOps.Sqrt(numOps.Add(vG[c], epsT)));
+            T scale = numOps.Multiply(gG[c], inv);
+            T sg = numOps.Zero, sb = numOps.Zero;
+            for (int n = 0; n < N; n++)
+            {
+                int baseIdx = n * chw + c * hw;
+                for (int i = 0; i < hw; i++)
+                {
+                    T gy = goG[baseIdx + i];
+                    sb = numOps.Add(sb, gy);
+                    sg = numOps.Add(sg, numOps.Multiply(numOps.Multiply(gy, numOps.Subtract(xG[baseIdx + i], mG[c])), inv));
+                    dxG[baseIdx + i] = numOps.Multiply(gy, scale);
+                }
+            }
+            dgG[c] = sg; dbG[c] = sb;
+        }
+        gradGamma = TensorAllocator.Rent<T>(gamma._shape, dgG);
+        gradBeta = TensorAllocator.Rent<T>(gamma._shape, dbG);
+        return TensorAllocator.Rent<T>(input._shape, dxG);
+    }
+
+    /// <summary>
+    /// #639: DIFFERENTIABLE affine batch-norm (running-stats form): y = gamma·(x-mean)·inv + beta,
+    /// inv = 1/sqrt(var+eps). Records ONE tape/graph node (vs the ~6 primitive ops the consumer's
+    /// batch=1 BN fallback decomposes into), with gradients to x, gamma, beta (mean/variance are
+    /// constant running stats). Forward math is identical to <see cref="BatchNormInference{T}"/>;
+    /// the difference is it carries a backward so it can be used in TRAINING at batch=1 (where the
+    /// batch-stats BatchNorm collapses). Rank-4 NCHW.
+    /// </summary>
+    public virtual Tensor<T> BatchNormAffine<T>(Tensor<T> x, Tensor<T> gamma, Tensor<T> beta, Tensor<T> mean, Tensor<T> variance, double epsilon)
+    {
+        if (x == null) throw new ArgumentNullException(nameof(x));
+        if (gamma == null) throw new ArgumentNullException(nameof(gamma));
+        if (beta == null) throw new ArgumentNullException(nameof(beta));
+        if (mean == null) throw new ArgumentNullException(nameof(mean));
+        if (variance == null) throw new ArgumentNullException(nameof(variance));
+        if (x.Rank != 4) throw new ArgumentException($"BatchNormAffine requires rank-4 NCHW input, got rank {x.Rank}.");
+
+        var xOrig = x;
+        if (!x.IsContiguous) x = x.Contiguous();
+
+        // GraphMode: record a single lazy node; the realize closure recomputes the affine
+        // result so the compiled plan reads the CURRENT running mean/variance each step.
+        if (GraphMode.IsActive)
+        {
+            var scope = GraphMode.Current;
+            if (scope != null)
+            {
+                var capX = x; var capG = gamma; var capB = beta; var capM = mean; var capV = variance; double capE = epsilon;
+                var lazy = scope.RecordVariadic(LazyNodeType.Custom, "BatchNormAffine",
+                    new[] { xOrig, gamma, beta }, x._shape,
+                    (eng, output) =>
+                    {
+                        if (eng is CpuEngine cpuEng)
+                            cpuEng.BatchNormInferenceInto(output, capX, capG, capB, capM, capV, capE);
+                        else
+                        {
+                            var r = eng.BatchNormInference(capX, capG, capB, capM, capV, capE);
+                            DirectGpuTensorEngine.CopyResultInto(eng, r, output);
+                        }
+                    },
+                    BackwardFunctions<T>.BatchNormAffineBackward,
+                    new object[] { mean, variance, epsilon });
+                return lazy;
+            }
+        }
+
+        // Eager path: compute the affine result, then record one differentiable node.
+        var result = new Tensor<T>(x._shape);
+        BatchNormInferenceInto(result, x, gamma, beta, mean, variance, epsilon);
+        DifferentiableOps.RecordIfActive("BatchNormAffine", result, new[] { xOrig, gamma, beta },
+            BackwardFunctions<T>.BatchNormAffineBackward, new object[] { mean, variance, epsilon });
+        return result;
+    }
+
     /// <inheritdoc/>
     public virtual Tensor<T> BatchNormInference<T>(Tensor<T> x, Tensor<T> gamma, Tensor<T> beta, Tensor<T> mean, Tensor<T> variance, double epsilon)
     {

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -2420,7 +2420,18 @@ public partial class CpuEngine : ITensorLevelEngine
     /// batch=1 BN fallback decomposes into), with gradients to x, gamma, beta (mean/variance are
     /// constant running stats). Forward math is identical to <see cref="BatchNormInference{T}"/>;
     /// the difference is it carries a backward so it can be used in TRAINING at batch=1 (where the
-    /// batch-stats BatchNorm collapses). Rank-4 NCHW.
+    /// batch-stats BatchNorm collapses). Rank-4 NCHW; gamma/beta/mean/variance are <c>[C]</c>.
+    /// <para>
+    /// <b>GPU coverage (intentional CPU forward).</b> There is no native GPU override of this
+    /// FORWARD: on a <see cref="DirectGpuTensorEngine"/> it runs the CPU in-place
+    /// <see cref="BatchNormInferenceInto{T}"/> (downloading/uploading the rank-4 operand). This is
+    /// deliberate — #639 targets the per-step OP-COUNT explosion in batch=1 training (one fused node
+    /// instead of ~6 broadcast ops), a win on either device, and batch=1 is a rare/small op where a
+    /// dedicated GPU kernel + dispatch would not pay for itself. The differentiable BACKWARD
+    /// (<see cref="BackwardFunctions{T}.BatchNormAffineBackward"/>) DOES route GPU engines through
+    /// device-resident primitives (it only takes the CPU fused kernel when <c>!SupportsGpu</c>). A
+    /// native GPU forward kernel is a follow-up under #639.
+    /// </para>
     /// </summary>
     public virtual Tensor<T> BatchNormAffine<T>(Tensor<T> x, Tensor<T> gamma, Tensor<T> beta, Tensor<T> mean, Tensor<T> variance, double epsilon)
     {
@@ -13957,6 +13968,8 @@ public partial class CpuEngine : ITensorLevelEngine
             // weights change every step so this can't be content-cached — it was ~130 MB/step
             // of pure GC churn on MobileNetV3 batch=1 (a gen2 collection every ~2 steps).
             var kernelT = pool.Rent(colH * outChannels);
+            try
+            {
             for (int r = 0; r < outChannels; r++)
                 for (int c = 0; c < colH; c++)
                     kernelT[c * outChannels + r] = kernelF[r * colH + c];
@@ -14012,7 +14025,8 @@ public partial class CpuEngine : ITensorLevelEngine
                     b => ProcessImageInputF(b, channelParallel: false));
             else
                 for (int b = 0; b < batch; b++) ProcessImageInputF(b, channelParallel: true);
-            pool.Return(kernelT);
+            }
+            finally { pool.Return(kernelT); }
             return;
         }
 
@@ -14914,6 +14928,8 @@ public partial class CpuEngine : ITensorLevelEngine
             // Weights change every step so it can't be content-cached — it was per-step GC
             // churn. Rented buffers aren't zeroed and this is a += accumulator, so clear it.
             var gradKernelF = kPool.Rent(totalLen);
+            try
+            {
             Array.Clear(gradKernelF, 0, totalLen);
             var gradOutputF = (float[])(object)gradOutput.GetFlattenedData();
             var inputF = (float[])(object)input.GetFlattenedData();
@@ -15019,7 +15035,8 @@ public partial class CpuEngine : ITensorLevelEngine
                 for (int i = 0; i < totalLen; i++) destF[destOff + i] += gradKernelF[i];
             else
                 Array.Copy(gradKernelF, 0, destF, destOff, totalLen);
-            kPool.Return(gradKernelF);
+            }
+            finally { kPool.Return(gradKernelF); }
             return;
         }
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -15610,6 +15610,102 @@ public partial class CpuEngine : ITensorLevelEngine
         int outputWidth = gradOutput._shape[3];
         int outChannels = inChannels * multiplier;
 
+        // #639: typed float/double fast paths. The generic loop below runs every
+        // multiply-add through INumericOperations<T> virtual dispatch — pathological
+        // for depthwise-heavy nets (MobileNet, EfficientNet). These typed paths use
+        // raw arrays in a plain inline loop. NOTE: deliberately NOT wrapped in
+        // ParallelForOrSerial — depthwise backward at batch-1/inference shapes is a
+        // few hundred microseconds, where the per-call delegate + closure + pool
+        // dispatch overhead measurably EXCEEDS the work (it regressed this path 3.9 ->
+        // 7.0 ms before being removed). The per-element accumulation order matches the
+        // generic path, so the result is bit-for-bit identical.
+        if (typeof(T) == typeof(float))
+        {
+            var goF = (float[])(object)gradOutput.GetFlattenedData();
+            var kF = (float[])(object)kernel.GetFlattenedData();
+            var giF = new float[batch * inChannels * height * width];
+            for (int ic = 0; ic < inChannels; ic++)
+            {
+                for (int b = 0; b < batch; b++)
+                {
+                    int giChan = (b * inChannels + ic) * height * width;
+                    for (int m = 0; m < multiplier; m++)
+                    {
+                        int oc = ic * multiplier + m;
+                        int goChan = (b * outChannels + oc) * outputHeight * outputWidth;
+                        int kBase = oc * kernelHeight * kernelWidth;
+                        for (int oh = 0; oh < outputHeight; oh++)
+                        {
+                            for (int ow = 0; ow < outputWidth; ow++)
+                            {
+                                float g = goF[goChan + oh * outputWidth + ow];
+                                if (g == 0f) continue;
+                                int ihB = oh * strideH - padH;
+                                int iwB = ow * strideW - padW;
+                                for (int kh = 0; kh < kernelHeight; kh++)
+                                {
+                                    int ih = ihB + kh;
+                                    if (ih < 0 || ih >= height) continue;
+                                    int giRow = giChan + ih * width;
+                                    int kRow = kBase + kh * kernelWidth;
+                                    for (int kw = 0; kw < kernelWidth; kw++)
+                                    {
+                                        int iw = iwB + kw;
+                                        if (iw < 0 || iw >= width) continue;
+                                        giF[giRow + iw] += g * kF[kRow + kw];
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            return TensorAllocator.Rent<T>(inputShape, (T[])(object)giF);
+        }
+        if (typeof(T) == typeof(double))
+        {
+            var goD = (double[])(object)gradOutput.GetFlattenedData();
+            var kD = (double[])(object)kernel.GetFlattenedData();
+            var giD = new double[batch * inChannels * height * width];
+            for (int ic = 0; ic < inChannels; ic++)
+            {
+                for (int b = 0; b < batch; b++)
+                {
+                    int giChan = (b * inChannels + ic) * height * width;
+                    for (int m = 0; m < multiplier; m++)
+                    {
+                        int oc = ic * multiplier + m;
+                        int goChan = (b * outChannels + oc) * outputHeight * outputWidth;
+                        int kBase = oc * kernelHeight * kernelWidth;
+                        for (int oh = 0; oh < outputHeight; oh++)
+                        {
+                            for (int ow = 0; ow < outputWidth; ow++)
+                            {
+                                double g = goD[goChan + oh * outputWidth + ow];
+                                if (g == 0d) continue;
+                                int ihB = oh * strideH - padH;
+                                int iwB = ow * strideW - padW;
+                                for (int kh = 0; kh < kernelHeight; kh++)
+                                {
+                                    int ih = ihB + kh;
+                                    if (ih < 0 || ih >= height) continue;
+                                    int giRow = giChan + ih * width;
+                                    int kRow = kBase + kh * kernelWidth;
+                                    for (int kw = 0; kw < kernelWidth; kw++)
+                                    {
+                                        int iw = iwB + kw;
+                                        if (iw < 0 || iw >= width) continue;
+                                        giD[giRow + iw] += g * kD[kRow + kw];
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            return TensorAllocator.Rent<T>(inputShape, (T[])(object)giD);
+        }
+
         var gradInput = new T[batch * inChannels * height * width];
         var gradOutputData = gradOutput.GetFlattenedData();
         var kernelData = kernel.GetFlattenedData();
@@ -15678,6 +15774,94 @@ public partial class CpuEngine : ITensorLevelEngine
 
         int outputHeight = gradOutput._shape[2];
         int outputWidth = gradOutput._shape[3];
+        int outChannels = inChannels * multiplier;
+
+        // #639: typed float/double fast paths (see DepthwiseConv2DBackwardInput). Each
+        // output channel's gradient slab is independent, so we parallelize over input
+        // channels and accumulate each kernel element with the SAME b,oh,ow order as the
+        // generic loop — bit-for-bit identical and deterministic-safe.
+        if (typeof(T) == typeof(float))
+        {
+            var goF = (float[])(object)gradOutput.GetFlattenedData();
+            var inF = (float[])(object)input.GetFlattenedData();
+            var gkF = new float[inChannels * multiplier * kernelHeight * kernelWidth];
+            for (int ic = 0; ic < inChannels; ic++)
+            {
+                for (int m = 0; m < multiplier; m++)
+                {
+                    int oc = ic * multiplier + m;
+                    int kBase = oc * kernelHeight * kernelWidth;
+                    for (int kh = 0; kh < kernelHeight; kh++)
+                    {
+                        for (int kw = 0; kw < kernelWidth; kw++)
+                        {
+                            float sum = 0f;
+                            for (int b = 0; b < batch; b++)
+                            {
+                                int goChan = (b * outChannels + oc) * outputHeight * outputWidth;
+                                int inChan = (b * inChannels + ic) * height * width;
+                                for (int oh = 0; oh < outputHeight; oh++)
+                                {
+                                    int ih = oh * strideH + kh - padH;
+                                    if (ih < 0 || ih >= height) continue;
+                                    int inRow = inChan + ih * width;
+                                    int goRow = goChan + oh * outputWidth;
+                                    for (int ow = 0; ow < outputWidth; ow++)
+                                    {
+                                        int iw = ow * strideW + kw - padW;
+                                        if (iw < 0 || iw >= width) continue;
+                                        sum += goF[goRow + ow] * inF[inRow + iw];
+                                    }
+                                }
+                            }
+                            gkF[kBase + kh * kernelWidth + kw] = sum;
+                        }
+                    }
+                }
+            }
+            return TensorAllocator.Rent<T>(kernelShape, (T[])(object)gkF);
+        }
+        if (typeof(T) == typeof(double))
+        {
+            var goD = (double[])(object)gradOutput.GetFlattenedData();
+            var inD = (double[])(object)input.GetFlattenedData();
+            var gkD = new double[inChannels * multiplier * kernelHeight * kernelWidth];
+            for (int ic = 0; ic < inChannels; ic++)
+            {
+                for (int m = 0; m < multiplier; m++)
+                {
+                    int oc = ic * multiplier + m;
+                    int kBase = oc * kernelHeight * kernelWidth;
+                    for (int kh = 0; kh < kernelHeight; kh++)
+                    {
+                        for (int kw = 0; kw < kernelWidth; kw++)
+                        {
+                            double sum = 0d;
+                            for (int b = 0; b < batch; b++)
+                            {
+                                int goChan = (b * outChannels + oc) * outputHeight * outputWidth;
+                                int inChan = (b * inChannels + ic) * height * width;
+                                for (int oh = 0; oh < outputHeight; oh++)
+                                {
+                                    int ih = oh * strideH + kh - padH;
+                                    if (ih < 0 || ih >= height) continue;
+                                    int inRow = inChan + ih * width;
+                                    int goRow = goChan + oh * outputWidth;
+                                    for (int ow = 0; ow < outputWidth; ow++)
+                                    {
+                                        int iw = ow * strideW + kw - padW;
+                                        if (iw < 0 || iw >= width) continue;
+                                        sum += goD[goRow + ow] * inD[inRow + iw];
+                                    }
+                                }
+                            }
+                            gkD[kBase + kh * kernelWidth + kw] = sum;
+                        }
+                    }
+                }
+            }
+            return TensorAllocator.Rent<T>(kernelShape, (T[])(object)gkD);
+        }
 
         var gradKernel = new T[inChannels * multiplier * kernelHeight * kernelWidth];
         var gradOutputData = gradOutput.GetFlattenedData();

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -5020,8 +5020,18 @@ public interface IEngine
     /// to x, gamma, beta (mean/variance are constants). This is the differentiable single-op form of
     /// <see cref="BatchNormInference{T}"/>, intended as the batch=1 training BN fallback (where the
     /// batch-statistics <see cref="BatchNorm{T}"/> collapses) so it stays one op instead of
-    /// decomposing into ~6 primitives. Rank-4 NCHW.
+    /// decomposing into ~6 primitives.
     /// </summary>
+    /// <param name="x">Rank-4 NCHW input <c>[N, C, H, W]</c> (the only supported rank).</param>
+    /// <param name="gamma">Per-channel scale, shape <c>[C]</c>.</param>
+    /// <param name="beta">Per-channel shift, shape <c>[C]</c>.</param>
+    /// <param name="mean">Per-channel running mean, shape <c>[C]</c> (constant w.r.t. autodiff).</param>
+    /// <param name="variance">Per-channel running variance, shape <c>[C]</c> (constant w.r.t. autodiff).</param>
+    /// <param name="epsilon">Numerical-stability term added to variance before the square root.</param>
+    /// <returns>Normalized output with the same shape as <paramref name="x"/> (<c>[N, C, H, W]</c>).</returns>
+    /// <exception cref="System.ArgumentException">Thrown when <paramref name="x"/> is not rank-4.</exception>
+    /// <remarks>GPU engines run the CPU forward (batch=1 is rare; see the CpuEngine implementation
+    /// note); the backward routes device-resident primitives on GPU engines.</remarks>
     Tensor<T> BatchNormAffine<T>(Tensor<T> x, Tensor<T> gamma, Tensor<T> beta, Tensor<T> mean, Tensor<T> variance, double epsilon);
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -5015,6 +5015,16 @@ public interface IEngine
     Tensor<T> BatchNorm<T>(Tensor<T> input, Tensor<T> gamma, Tensor<T> beta, double epsilon, out Tensor<T> mean, out Tensor<T> variance);
 
     /// <summary>
+    /// #639: DIFFERENTIABLE affine batch-norm using fixed (running) statistics —
+    /// <c>y = gamma·(x-mean)/sqrt(var+eps) + beta</c>. Records a single fused node with gradients
+    /// to x, gamma, beta (mean/variance are constants). This is the differentiable single-op form of
+    /// <see cref="BatchNormInference{T}"/>, intended as the batch=1 training BN fallback (where the
+    /// batch-statistics <see cref="BatchNorm{T}"/> collapses) so it stays one op instead of
+    /// decomposing into ~6 primitives. Rank-4 NCHW.
+    /// </summary>
+    Tensor<T> BatchNormAffine<T>(Tensor<T> x, Tensor<T> gamma, Tensor<T> beta, Tensor<T> mean, Tensor<T> variance, double epsilon);
+
+    /// <summary>
     /// Computes the backward pass for batch normalization.
     /// </summary>
     /// <typeparam name="T">The numeric type of tensor elements.</typeparam>

--- a/tests/AiDotNet.Tensors.Tests/Engines/BatchNormAffineGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BatchNormAffineGradientTests.cs
@@ -1,6 +1,7 @@
 using System;
 using AiDotNet.Tensors.Engines;
 using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
 using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
 
@@ -97,5 +98,70 @@ public class BatchNormAffineGradientTests
         for (int i = 0; i < refDx.Length; i++) Assert.Equal(refDx[i], gx[i], 4);
         for (int c = 0; c < C; c++) Assert.Equal(refDg[c], gg[c], 3);
         for (int c = 0; c < C; c++) Assert.Equal(refDb[c], gb[c], 3);
+    }
+
+    // #639: the WHOLE point of the affine-BN op is to survive the compiled-plan replay as a
+    // single node. This validates that GraphMode capture → CompiledTrainingPlan.Step() produces
+    // the SAME forward loss and the SAME gamma/beta gradients as the eager tape — i.e. the
+    // realize closure (running-stats reread) and the recorded BatchNormAffineBackward replay
+    // identically under compilation. mean/variance are constant running stats (batch=1 never
+    // refreshes them), so a single Step() is the representative replay.
+    [Fact]
+    public void BatchNormAffine_CompiledPlanReplay_MatchesEager()
+    {
+        // LazyTensorScope drives the forward closures with AiDotNetEngine.Current. On a GPU box
+        // that captured engine is DirectGpuTensorEngine; pin to CPU so the replay exercises the
+        // known-correct CpuEngine path this op was validated against (mirrors GroupNormOpTests).
+        var priorEngine = AiDotNetEngine.Current;
+        AiDotNetEngine.Current = new CpuEngine();
+        try
+        {
+            var engine = new CpuEngine();
+            int N = 2, C = 3, H = 2, W = 2;
+            var x = Rnd(new[] { N, C, H, W }, 1);
+            var gamma = Rnd(new[] { C }, 2);
+            var beta = Rnd(new[] { C }, 3);
+            var mean = Rnd(new[] { C }, 4);
+            var variance = PosRnd(new[] { C }, 5);
+            double eps = 1e-3;
+
+            // Eager reference for loss = Σ y.
+            float eagerLoss;
+            float[] eagerDg, eagerDb;
+            using (var tape = new GradientTape<float>())
+            {
+                var y = engine.BatchNormAffine(x, gamma, beta, mean, variance, eps);
+                var loss = engine.ReduceSum(y, null);
+                eagerLoss = loss.GetFlattenedData()[0];
+                var grads = tape.ComputeGradients(loss, new[] { gamma, beta });
+                eagerDg = (float[])grads[gamma].GetFlattenedData().Clone();
+                eagerDb = (float[])grads[beta].GetFlattenedData().Clone();
+            }
+
+            // Compiled-plan replay of the same graph.
+            ICompiledTrainingPlan<float> plan;
+            using (var scope = GraphMode.Enable())
+            {
+                var y = engine.BatchNormAffine(x, gamma, beta, mean, variance, eps);
+                engine.ReduceSum(y, null);
+                plan = scope.CompileTraining(new[] { gamma, beta });
+            }
+
+            var loss2 = plan.Step();
+            Assert.False(float.IsNaN(loss2[0]), "Compiled BatchNormAffine loss is NaN");
+            Assert.Equal(eagerLoss, loss2[0], 3);
+
+            Assert.Equal(2, plan.Gradients.Length);
+            var planDg = plan.Gradients[0].AsSpan();
+            var planDb = plan.Gradients[1].AsSpan();
+            for (int c = 0; c < C; c++) Assert.Equal(eagerDg[c], planDg[c], 3);
+            for (int c = 0; c < C; c++) Assert.Equal(eagerDb[c], planDb[c], 3);
+
+            plan.Dispose();
+        }
+        finally
+        {
+            AiDotNetEngine.Current = priorEngine;
+        }
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/BatchNormAffineGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BatchNormAffineGradientTests.cs
@@ -1,0 +1,101 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+// #639: validates the differentiable affine batch-norm op (BatchNormAffine) — the single fused
+// op that replaces the ~6-primitive batch=1 BN training fallback. Forward must equal
+// BatchNormInference; backward must equal the exact closed-form gradient of a linear loss
+// L = Σ(y ⊙ w), since y = gamma·(x-mean)·inv + beta is affine in x/gamma/beta.
+public class BatchNormAffineGradientTests
+{
+    private readonly CpuEngine _engine = new CpuEngine();
+
+    private static Tensor<float> Rnd(int[] shape, int seed)
+    {
+        int n = 1; foreach (var d in shape) n *= d;
+        var a = new float[n];
+        for (int i = 0; i < n; i++) a[i] = (float)Math.Sin(i * 0.7 + seed) * 0.5f;
+        return new Tensor<float>(a, shape);
+    }
+
+    private static Tensor<float> PosRnd(int[] shape, int seed)
+    {
+        int n = 1; foreach (var d in shape) n *= d;
+        var a = new float[n];
+        for (int i = 0; i < n; i++) a[i] = 0.5f + 0.4f * (float)Math.Abs(Math.Sin(i * 1.3 + seed)); // in [0.5, 0.9]
+        return new Tensor<float>(a, shape);
+    }
+
+    [Fact]
+    public void BatchNormAffine_ForwardMatchesBatchNormInference()
+    {
+        int N = 2, C = 3, H = 4, W = 5;
+        var x = Rnd(new[] { N, C, H, W }, 1);
+        var gamma = Rnd(new[] { C }, 2);
+        var beta = Rnd(new[] { C }, 3);
+        var mean = Rnd(new[] { C }, 4);
+        var variance = PosRnd(new[] { C }, 5);
+        double eps = 1e-3;
+
+        var a = _engine.BatchNormAffine(x, gamma, beta, mean, variance, eps).GetFlattenedData();
+        var b = _engine.BatchNormInference(x, gamma, beta, mean, variance, eps).GetFlattenedData();
+        Assert.Equal(b.Length, a.Length);
+        for (int i = 0; i < a.Length; i++) Assert.Equal(b[i], a[i], 5);
+    }
+
+    [Fact]
+    public void BatchNormAffine_Backward_MatchesClosedForm()
+    {
+        int N = 2, C = 3, H = 2, W = 2;
+        var x = Rnd(new[] { N, C, H, W }, 1);
+        var gamma = Rnd(new[] { C }, 2);
+        var beta = Rnd(new[] { C }, 3);
+        var mean = Rnd(new[] { C }, 4);
+        var variance = PosRnd(new[] { C }, 5);
+        var w = Rnd(new[] { N, C, H, W }, 6); // loss weights → dL/dy = w
+        double eps = 1e-3;
+
+        float[] gx, gg, gb;
+        using (var tape = new GradientTape<float>())
+        {
+            var y = _engine.BatchNormAffine(x, gamma, beta, mean, variance, eps);
+            var loss = _engine.ReduceSum(_engine.TensorMultiply(y, w), null);
+            var grads = tape.ComputeGradients(loss, new[] { x, gamma, beta });
+            gx = (float[])grads[x].GetFlattenedData().Clone();
+            gg = (float[])grads[gamma].GetFlattenedData().Clone();
+            gb = (float[])grads[beta].GetFlattenedData().Clone();
+        }
+
+        // Closed-form reference for L = Σ_{n,c,i} w·y, y = gamma·(x-mean)·inv + beta:
+        //   dL/dx[n,c,i] = w · gamma[c]·inv[c]
+        //   dL/dgamma[c] = Σ_{n,i} w · (x-mean[c])·inv[c]
+        //   dL/dbeta[c]  = Σ_{n,i} w
+        var xs = x.GetFlattenedData(); var ws = w.GetFlattenedData();
+        var gm = gamma.GetFlattenedData(); var mn = mean.GetFlattenedData(); var vr = variance.GetFlattenedData();
+        int hw = H * W, chw = C * hw;
+        var refDx = new float[N * chw]; var refDg = new float[C]; var refDb = new float[C];
+        for (int c = 0; c < C; c++)
+        {
+            float inv = 1f / MathF.Sqrt(vr[c] + (float)eps);
+            float scale = gm[c] * inv;
+            float sg = 0f, sb = 0f;
+            for (int n = 0; n < N; n++)
+                for (int i = 0; i < hw; i++)
+                {
+                    int idx = n * chw + c * hw + i;
+                    refDx[idx] = ws[idx] * scale;
+                    sg += ws[idx] * (xs[idx] - mn[c]) * inv;
+                    sb += ws[idx];
+                }
+            refDg[c] = sg; refDb[c] = sb;
+        }
+
+        for (int i = 0; i < refDx.Length; i++) Assert.Equal(refDx[i], gx[i], 4);
+        for (int c = 0; c < C; c++) Assert.Equal(refDg[c], gg[c], 3);
+        for (int c = 0; c < C; c++) Assert.Equal(refDb[c], gb[c], 3);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/DepthwiseConv2DBackwardTypedParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DepthwiseConv2DBackwardTypedParityTests.cs
@@ -1,0 +1,118 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+// #639: the typed float/double fast paths added to DepthwiseConv2DBackwardInput/Kernel
+// must produce exactly what the depthwise-conv backward math defines. We validate the
+// engine output against an independent naive reference (same formula, scalar) across a
+// spread of shapes incl. multiplier>1, 5x5, strided, and asymmetric H!=W.
+public class DepthwiseConv2DBackwardTypedParityTests
+{
+    private readonly CpuEngine _engine = new CpuEngine();
+
+    private static Tensor<float> Rnd(int[] shape, int seed)
+    {
+        int n = 1; foreach (var d in shape) n *= d;
+        var a = new float[n];
+        for (int i = 0; i < n; i++) a[i] = (float)System.Math.Sin(i * 0.7 + seed) * 0.5f;
+        return new Tensor<float>(a, shape);
+    }
+
+    // Naive reference: dInput[b,ic,ih,iw] += gradOut[b,oc,oh,ow] * kernel[oc,kh,kw]
+    private static float[] RefInput(float[] go, float[] k, int batch, int inC, int mult,
+        int H, int W, int kH, int kW, int sH, int sW, int pH, int pW, int oH, int oW)
+    {
+        int outC = inC * mult;
+        var gi = new float[batch * inC * H * W];
+        for (int b = 0; b < batch; b++)
+            for (int oc = 0; oc < outC; oc++)
+            {
+                int ic = oc / mult, m = oc % mult;
+                for (int oh = 0; oh < oH; oh++)
+                    for (int ow = 0; ow < oW; ow++)
+                    {
+                        float g = go[((b * outC + oc) * oH + oh) * oW + ow];
+                        for (int kh = 0; kh < kH; kh++)
+                            for (int kw = 0; kw < kW; kw++)
+                            {
+                                int ih = oh * sH + kh - pH, iw = ow * sW + kw - pW;
+                                if (ih < 0 || ih >= H || iw < 0 || iw >= W) continue;
+                                gi[((b * inC + ic) * H + ih) * W + iw] +=
+                                    g * k[((ic * mult + m) * kH + kh) * kW + kw];
+                            }
+                    }
+            }
+        return gi;
+    }
+
+    // Naive reference: dKernel[oc,kh,kw] = sum_b,oh,ow gradOut[b,oc,oh,ow]*input[b,ic,ih,iw]
+    private static float[] RefKernel(float[] go, float[] inp, int batch, int inC, int mult,
+        int H, int W, int kH, int kW, int sH, int sW, int pH, int pW, int oH, int oW)
+    {
+        int outC = inC * mult;
+        var gk = new float[inC * mult * kH * kW];
+        for (int ic = 0; ic < inC; ic++)
+            for (int m = 0; m < mult; m++)
+            {
+                int oc = ic * mult + m;
+                for (int kh = 0; kh < kH; kh++)
+                    for (int kw = 0; kw < kW; kw++)
+                    {
+                        float sum = 0f;
+                        for (int b = 0; b < batch; b++)
+                            for (int oh = 0; oh < oH; oh++)
+                                for (int ow = 0; ow < oW; ow++)
+                                {
+                                    int ih = oh * sH + kh - pH, iw = ow * sW + kw - pW;
+                                    if (ih < 0 || ih >= H || iw < 0 || iw >= W) continue;
+                                    sum += go[((b * outC + oc) * oH + oh) * oW + ow]
+                                         * inp[((b * inC + ic) * H + ih) * W + iw];
+                                }
+                        gk[((ic * mult + m) * kH + kh) * kW + kw] = sum;
+                    }
+            }
+        return gk;
+    }
+
+    [Theory]
+    // batch, inC, mult, H, W, kH, kW, sH, sW, pH, pW
+    [InlineData(1, 8, 1, 8, 8, 3, 3, 1, 1, 1, 1)]
+    [InlineData(1, 16, 1, 8, 8, 5, 5, 1, 1, 2, 2)]
+    [InlineData(2, 6, 2, 7, 9, 3, 3, 1, 1, 1, 1)]   // multiplier>1, H!=W, batch>1
+    [InlineData(1, 12, 1, 8, 8, 3, 3, 2, 2, 1, 1)]  // stride 2
+    [InlineData(1, 4, 3, 6, 6, 3, 3, 1, 1, 0, 0)]   // multiplier 3, valid pad
+    public void TypedDepthwiseBackward_MatchesReference(
+        int batch, int inC, int mult, int H, int W, int kH, int kW, int sH, int sW, int pH, int pW)
+    {
+        int oH = (H + 2 * pH - kH) / sH + 1;
+        int oW = (W + 2 * pW - kW) / sW + 1;
+        int outC = inC * mult;
+
+        var gradOut = Rnd(new[] { batch, outC, oH, oW }, 1);
+        var kernel = Rnd(new[] { inC, mult, kH, kW }, 2);
+        var input = Rnd(new[] { batch, inC, H, W }, 3);
+        var stride = new[] { sH, sW };
+        var padding = new[] { pH, pW };
+
+        var go = gradOut.GetFlattenedData();
+        var k = kernel.GetFlattenedData();
+        var inp = input.GetFlattenedData();
+
+        var gi = _engine.DepthwiseConv2DBackwardInput(gradOut, kernel, new[] { batch, inC, H, W }, stride, padding);
+        var gk = _engine.DepthwiseConv2DBackwardKernel(gradOut, input, new[] { inC, mult, kH, kW }, stride, padding);
+
+        var refGi = RefInput(go, k, batch, inC, mult, H, W, kH, kW, sH, sW, pH, pW, oH, oW);
+        var refGk = RefKernel(go, inp, batch, inC, mult, H, W, kH, kW, sH, sW, pH, pW, oH, oW);
+
+        var giData = gi.GetFlattenedData();
+        var gkData = gk.GetFlattenedData();
+        Assert.Equal(refGi.Length, giData.Length);
+        Assert.Equal(refGk.Length, gkData.Length);
+        for (int i = 0; i < refGi.Length; i++)
+            Assert.Equal(refGi[i], giData[i], 4);
+        for (int i = 0; i < refGk.Length; i++)
+            Assert.Equal(refGk[i], gkData[i], 4);
+    }
+}


### PR DESCRIPTION
Closes the first phase of #639.

## The problem
MobileNetV3-Large at batch=1 trains at **590.9 ms/step vs PyTorch 37.8 ms (15.6x)**. Profiling showed the gap is **per-op framework overhead x hundreds of tiny ops** in the compiled-plan replay — **753 forward ops/step** — NOT conv math (conv2d-backward kernels are <1% of the step; the original "conv backward is 15x slower" framing was wrong). PyTorch refuses batch=1 BN training entirely, so this is a case where we can be strictly better than torch, not just match it.

## What this PR ships
1. **Differentiable affine BatchNorm op — `Engine.BatchNormAffine`** (the headline). `y = gamma*(x-mean)*inv + beta`, recorded as ONE tape/graph node instead of the ~6-9 primitive decomposition the batch=1 BN fallback expands into. mean/variance are constant running stats, so gradients flow to x/gamma/beta only.
   - CpuEngine typed float/double fused backward (`BatchNormAffineBackward`, rank-4 NCHW) + engine-generic primitive fallback (GPU inherits via `DirectGpuTensorEngine : CpuEngine`).
   - Records on **both** the eager tape and the GraphMode/compiled-plan path (realize closure rereads running stats each replay).
2. **Typed float/double fast path for depthwise conv2d backward** — 3.9 -> 2.0 ms (1.9x). Lesson baked into a comment: wrapping it in `ParallelForOrSerial` REGRESSED it to 7.0 ms (delegate+closure+pool-dispatch overhead exceeds the work on sub-ms ops) — an inline typed loop wins. This is the per-op-overhead thesis in miniature.
3. **Compiled-plan op-histogram diagnostic** (`AIDOTNET_PLAN_HISTOGRAM=1`) — dumps the replayed op profile so fusion prizes are sized from data, not guesses. Writes to stderr AND a file (`AIDOTNET_PLAN_HISTOGRAM_FILE`, default `%TEMP%/aidotnet_plan_histogram.txt`) since dotnet test swallows console output.

## Measured result (apples-to-apples, same test)
MobileNetV3-Large `[1,3,32,32]`, batch=1 training step:

**753 -> 339 forward ops/step (-414, -55%).** The 46 BN layers each collapsed from ~9 primitives to 1 op:

| op | before | after |
|---|---|---|
| TensorSqrt | 46 | 0 |
| TensorDivide | 92 | 0 |
| TensorSubtract | 47 | 1 |
| TensorMultiply | 47 | 1 |
| Reshape | 164 | 72 |
| BatchNormAffine | 0 | 46 |

Op count is the direct driver of per-op overhead at batch=1; wall-clock re-measure is the immediate follow-up.

## Correctness
Three tests, green on net10.0 + net471:
- `BatchNormAffine_ForwardMatchesBatchNormInference` — forward parity with the existing single-op affine BN.
- `BatchNormAffine_Backward_MatchesClosedForm` — dx/dgamma/dbeta vs the exact analytic gradient of a linear loss.
- `BatchNormAffine_CompiledPlanReplay_MatchesEager` — GraphMode capture -> `CompiledTrainingPlan.Step()` reproduces the eager forward loss AND gamma/beta gradients (the risky replay path).
- Plus `DepthwiseConv2DBackwardTypedParityTests` (5 cases) for the typed depthwise backward vs naive reference.

## Consumer
The AiDotNet consumer adopts this in `BatchNormalizationLayer`'s batch=1 fallback (ooples/AiDotNet#1633, kept in **draft** until this releases). That edit also fixes a latent gradient detach in the old cached scale/shift path (gamma/beta grads could be dropped when the cache was reused across steps).

## Follow-ups (rest of #639)
Wall-clock re-measure; conv->bias->activation epilogue fusion; reshape elimination; systemic inline-tiny-op vs pool-dispatch; per-op allocation; cheaper generic->typed dispatch.

Goal is to **exceed** PyTorch on this path, not just match it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added differentiable affine batch normalization (forward + gradients for input, gamma, beta) using fixed running statistics.
* **Performance**
  * Improved typed CPU depthwise convolution backprop with faster float/double paths and reduced allocation churn.
  * Enhanced AVX2 matrix multiply streaming to vectorize the `transB=true` case.
* **Compatibility**
  * Extended operation-name parsing so `BatchNormInference` and `BatchNormAffine` are handled as `BatchNorm`.
* **Diagnostics**
  * Optional one-time compiled-graph operator histogram logging to console/file via environment variables.
* **Tests**
  * Added affine batch-norm gradient validation, including compiled-plan replay parity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->