### PR TITLE
fix(autodiff): gradient checkpointing must backprop to weights, not only the input

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientCheckpointing.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientCheckpointing.cs
@@ -129,41 +129,49 @@ public static class GradientCheckpointing<T>
                     var weighted = eng.TensorMultiply(reOutput, gradOutput);
                     var pseudoLoss = eng.ReduceSum(weighted);
 
-                    var segGrads = recomputeTape.ComputeGradients(pseudoLoss, sources: new[] { reInput });
+                    // Differentiate the recomputed segment w.r.t. EVERY leaf it touched — the
+                    // segment input AND every weight/parameter the segment's functions read —
+                    // not just the input. PyTorch's torch.utils.checkpoint backpropagates the
+                    // recomputed forward through all inputs that require grad, including module
+                    // parameters; an earlier version requested only `reInput`, so the WEIGHT
+                    // gradients of every checkpointed layer were silently dropped — the outer
+                    // ComputeGradients then found no gradient for those params and they never
+                    // updated (checkpointed layers did not learn; ~half of a Transformer's
+                    // parameters diverged from the eager update). `sources: null` differentiates
+                    // the whole recomputed graph.
+                    //
+                    // Scattering correctness: the outer forward ran this segment under NoGrad
+                    // (its ops were never recorded on the outer tape), so this recompute is the
+                    // ONLY place the segment's gradient contributions exist — there is no double
+                    // counting. Accumulating each leaf's grad into the outer `grads` accumulator
+                    // is therefore exactly right: the segment input and parameters are the same
+                    // tensor instances the caller looks up, and any captured upstream tensor gets
+                    // its segment-side contribution propagated further when the outer reverse walk
+                    // reaches that tensor's producer (the segment entry is processed before its
+                    // producers in reverse order). The recompute's throwaway intermediates are
+                    // fresh instances the caller never queries — harmless. The sole exclusion is
+                    // gradOutput: an outer-tape constant folded into the pseudo-loss only to seed
+                    // the VJP, whose inner "gradient" (== reOutput) is not a real gradient and
+                    // must not leak back onto the outer tape.
+                    var segGrads = recomputeTape.ComputeGradients(pseudoLoss, sources: null);
 
-                    if (segGrads.TryGetValue(reInput, out var inputGrad))
+                    bool accumulatedAny = false;
+                    foreach (var kvp in segGrads)
                     {
-                        DifferentiableOps.AccumulateGrad(grads, inputs[0], inputGrad, eng);
+                        if (ReferenceEquals(kvp.Key, gradOutput)) continue;
+                        if (kvp.Value is null) continue;
+                        DifferentiableOps.AccumulateGrad(grads, kvp.Key, kvp.Value, eng);
+                        accumulatedAny = true;
                     }
-                    else
+
+                    // Identity / no-op segment (output IS input by reference, nothing recorded on
+                    // the recompute tape): pass the upstream gradient straight through. Reference-
+                    // equality is the only safe alias predicate — it covers the empty-segment case
+                    // without false positives on shape coincidence. For a genuinely input-
+                    // independent segment, leaving grads[input] untouched (zero) is the correct VJP.
+                    if (!accumulatedAny && ReferenceEquals(reOutput, reInput))
                     {
-                        // The segment was disconnected from its input — the
-                        // recomputed forward never touched reInput, so the
-                        // mathematical VJP is ZERO regardless of whether the
-                        // output happens to share a shape with the input.
-                        //
-                        // The earlier shape-equality fallback (CodeRabbit
-                        // feedback on PR #361) incorrectly turned input-
-                        // independent same-shape segments into an identity
-                        // backward by passing gradOutput through whenever the
-                        // shapes lined up. That's only correct when the
-                        // segment is literally a no-op (reOutput IS reInput
-                        // by reference), which is the only case where the
-                        // segment trivially passes gradients through. For
-                        // every other shape-equal but input-independent
-                        // segment, the correct gradient is zero, and we
-                        // achieve that by simply NOT calling
-                        // DifferentiableOps.AccumulateGrad — grads already
-                        // contains zero for inputs[0] by initialization.
-                        //
-                        // Reference-equality is the only safe alias predicate:
-                        // it covers the identity case (reInput == reOutput,
-                        // such as when the segment was empty / no-op) without
-                        // false positives on shape-coincidence.
-                        if (ReferenceEquals(reOutput, reInput))
-                        {
-                            DifferentiableOps.AccumulateGrad(grads, inputs[0], gradOutput, eng);
-                        }
+                        DifferentiableOps.AccumulateGrad(grads, inputs[0], gradOutput, eng);
                     }
                 });
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientCorrectnessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientCorrectnessTests.cs
@@ -430,6 +430,56 @@ public class GradientCorrectnessTests : IDisposable
         }
     }
 
+    /// <summary>
+    /// A checkpointed segment that uses a WEIGHT (matmul) must produce a weight gradient identical to
+    /// the eager (non-checkpointed) run — not just the input gradient. Activation checkpointing is a
+    /// memory optimization; it must be exactly gradient-equivalent for BOTH the segment input and every
+    /// parameter the segment reads. Regression guard: the recompute backward previously differentiated
+    /// only w.r.t. the segment input (sources: [reInput]), so checkpointed-layer weight gradients were
+    /// silently dropped and checkpointed layers never learned. A non-uniform output weighting makes the
+    /// upstream gradient non-constant so a wrong (e.g. ones-seed) VJP would not coincidentally match.
+    /// </summary>
+    [Fact]
+    public void Checkpoint_ProducesParameterGradients_MatchingEager()
+    {
+        Tensor<float> MakeFilled(int[] shape, float start, float step)
+        {
+            var t = new Tensor<float>(shape);
+            for (int i = 0; i < t.Length; i++) t[i] = start + step * i;
+            return t;
+        }
+
+        var x = MakeFilled([2, 3], -0.4f, 0.05f);
+        var w = MakeFilled([3, 4], -0.3f, 0.03f);
+        var outW = MakeFilled([2, 4], 0.1f, 0.02f); // non-uniform gradOutput driver
+
+        // Segment reads the weight w: inp => relu(inp @ w). w is a closure-captured parameter.
+        Func<Tensor<float>, Tensor<float>> seg = inp => _engine.ReLU(_engine.TensorMatMul(inp, w));
+
+        System.Collections.Generic.Dictionary<Tensor<float>, Tensor<float>> Run(bool checkpoint)
+        {
+            using var tape = new GradientTape<float>();
+            var o = checkpoint
+                ? GradientCheckpointing<float>.Checkpoint(new[] { seg }, x, segmentSize: 1)
+                : seg(x);
+            var loss = _engine.ReduceSum(_engine.TensorMultiply(o, outW));
+            return tape.ComputeGradients(loss, sources: new[] { x, w });
+        }
+
+        var eager = Run(checkpoint: false);
+        var ckpt = Run(checkpoint: true);
+
+        Assert.True(eager.ContainsKey(w) && eager.ContainsKey(x), "eager run must produce x and w grads");
+        Assert.True(ckpt.ContainsKey(w),
+            "checkpointed run must produce a WEIGHT gradient (regression: recompute differentiated only w.r.t. input)");
+        Assert.True(ckpt.ContainsKey(x), "checkpointed run must produce an input gradient");
+
+        for (int i = 0; i < eager[w].Length; i++)
+            Assert.Equal(eager[w][i], ckpt[w][i], 3);
+        for (int i = 0; i < eager[x].Length; i++)
+            Assert.Equal(eager[x][i], ckpt[x][i], 3);
+    }
+
     // ─── Additional arithmetic gradient checks ───────────────────
 
     [Fact]


### PR DESCRIPTION
## Problem

`GradientCheckpointing<T>.Checkpoint`'s recompute backward differentiated the recomputed segment **only with respect to the segment input**:

```csharp
var segGrads = recomputeTape.ComputeGradients(pseudoLoss, sources: new[] { reInput });
```

Every weight / parameter the checkpointed segment's functions read was left out of the backward. The outer `ComputeGradients` then found **no gradient for those tensors**, so they never updated — **checkpointed layers silently did not learn.**

PR #361 fixed the input-gradient *shape* crash (#1341) by re-seeding the inner tape with the scalar pseudo-loss `sum(reOutput * gradOutput)`, but kept the input-only source list, so the weight-gradient gap remained — masked because the surrounding model's *non-checkpointed* params (embeddings, output projection) still trained.

### Evidence (before this fix)
- Isolated single `DenseLayer` checkpoint → weight grad absent from the tape dict and the layer buffer.
- Unconfounded Transformer test (dropout = 0, identical init, one step **with vs without** checkpointing) → **2560 / 5408 params (47%) diverge**, maxDiff 1.34. Only the non-checkpointed half learned.

## Fix

Differentiate the recomputed segment over its **whole graph** (`sources: null`) and scatter every resulting leaf gradient into the outer accumulator — the segment input **and** every parameter it touched — matching `torch.utils.checkpoint`, which backpropagates the recomputed forward through all inputs that require grad including module parameters.

Correct and non-double-counting: the outer forward ran the segment under `NoGrad`, so its ops were never recorded on the outer tape and the recompute is the sole source of those gradients; the outer reverse walk propagates any captured upstream tensor's contribution further when it reaches that tensor's producer. The only exclusion is `gradOutput` (an outer-tape constant folded into the pseudo-loss to seed the VJP). The identity/no-op passthrough (`reOutput` IS `reInput` by reference) is preserved.

## Test

`Checkpoint_ProducesParameterGradients_MatchingEager`: a checkpointed matmul segment's **weight** gradient (and input gradient) must equal the eager run's under a non-uniform output weighting. Fails on the old input-only recompute; passes now.

Verified on **net10.0 + net471**, no regressions across the autodiff / checkpointing suites (113 tests).

## Downstream
Unblocks activation checkpointing (G4) for tape-based training in the main AiDotNet repo (issue #1624 foundation-scale diffusion training). After this is published to nuget.org, AiDotNet bumps `Directory.Packages.props` and enables G4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed gradient checkpointing to correctly compute parameter gradients within checkpointed segments, preventing gradient loss during backpropagation.

* **Tests**
  * Added test verifying gradient checkpointing produces accurate parameter gradients matching eager evaluation mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->