### PR TITLE
fix(gpu): bind missing ConvTranspose2D output-pad kernel args + harden conv coverage gate (#622)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.ConvPool.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.ConvPool.cs
@@ -5,6 +5,25 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.Metal;
 
 public sealed partial class MetalBackend
 {
+    // Shared dispatch for the conv/pool MSL kernels (issue #646): bind the buffers (indices 0..n-1) and the int
+    // params (as setBytes at indices n..), launch a 1D grid over `threads` output elements. Returns false when the
+    // library/kernel is unavailable so the caller falls back to the CPU reference. Mirrors the Gemm dispatch shape.
+    // NOTE: validated only on a Metal runner — the dev box has no Apple GPU.
+    private bool TryDispatchConvPoolMetal(System.IntPtr library, string libName, string kernelName,
+        int threads, IGpuBuffer[] buffers, int[] intParams)
+    {
+        if (threads <= 0 || library == System.IntPtr.Zero) return false;
+        foreach (var b in buffers) if (b is not MetalGpuBuffer) return false;
+        var pipeline = GetPipeline(libName, library, kernelName);
+        var (threadgroups, threadsPerGroup) = pipeline.Calculate1DDispatch(threads);
+        using var encoder = _commandQueue.CreateScopedComputeEncoder();
+        encoder.SetPipelineState(pipeline.Handle);
+        for (int i = 0; i < buffers.Length; i++) encoder.SetBuffer((MetalGpuBuffer)buffers[i], i);
+        for (int i = 0; i < intParams.Length; i++) encoder.SetBytes((uint)intParams[i], (uint)(buffers.Length + i));
+        encoder.DispatchThreadgroups(threadgroups, threadsPerGroup);
+        return true;
+    }
+
     #region Convolution Operations
 
     /// <summary>
@@ -1002,6 +1021,15 @@ public sealed partial class MetalBackend
         int strideH, int strideW, int padH, int padW)
     {
         ThrowIfDisposed();
+        try
+        {
+            if (indices is not null && TryDispatchConvPoolMetal(_convolutionLibrary, "Convolution", "maxpool2d",
+                batch * channels * outHeight * outWidth, new[] { input, output, indices },
+                new[] { batch, channels, inHeight, inWidth, outHeight, outWidth, kernelH, kernelW, strideH, strideW, padH, padW }))
+                return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var inp = DownloadBuffer(input);
         var result = new float[batch * channels * outHeight * outWidth];
         var idxResult = indices is not null ? new float[batch * channels * outHeight * outWidth] : null;
@@ -1069,6 +1097,15 @@ public sealed partial class MetalBackend
         int strideH, int strideW, int padH, int padW)
     {
         ThrowIfDisposed();
+        try
+        {
+            if (TryDispatchConvPoolMetal(_convolutionLibrary, "Convolution", "maxpool2d_backward",
+                batch * channels * inHeight * inWidth, new[] { gradOutput, indices, gradInput },
+                new[] { batch, channels, inHeight, inWidth, outHeight, outWidth, kernelH, kernelW, strideH, strideW, padH, padW }))
+                return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var go = DownloadBuffer(gradOutput);
         var idx = DownloadBuffer(indices);
         var result = new float[batch * channels * inHeight * inWidth];
@@ -1111,6 +1148,15 @@ public sealed partial class MetalBackend
         bool countIncludePad)
     {
         ThrowIfDisposed();
+        try
+        {
+            if (TryDispatchConvPoolMetal(_convolutionLibrary, "Convolution", "avgpool2d",
+                batch * channels * outHeight * outWidth, new[] { input, output },
+                new[] { batch, channels, inHeight, inWidth, outHeight, outWidth, kernelH, kernelW, strideH, strideW, padH, padW, countIncludePad ? 1 : 0 }))
+                return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var inp = DownloadBuffer(input);
         var result = new float[batch * channels * outHeight * outWidth];
 
@@ -1167,6 +1213,15 @@ public sealed partial class MetalBackend
         bool countIncludePad)
     {
         ThrowIfDisposed();
+        try
+        {
+            if (TryDispatchConvPoolMetal(_convolutionLibrary, "Convolution", "avgpool2d_backward",
+                batch * channels * inHeight * inWidth, new[] { gradOutput, gradInput },
+                new[] { batch, channels, inHeight, inWidth, outHeight, outWidth, kernelH, kernelW, strideH, strideW, padH, padW, countIncludePad ? 1 : 0 }))
+                return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var go = DownloadBuffer(gradOutput);
         var result = new float[batch * channels * inHeight * inWidth];
 
@@ -1229,6 +1284,14 @@ public sealed partial class MetalBackend
     public void GlobalAvgPool2D(IGpuBuffer input, IGpuBuffer output, int batch, int channels, int height, int width)
     {
         ThrowIfDisposed();
+        try
+        {
+            if (TryDispatchConvPoolMetal(_convolutionLibrary, "Convolution", "global_avgpool2d",
+                batch * channels, new[] { input, output }, new[] { batch, channels, height, width }))
+                return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var inp = DownloadBuffer(input);
         var result = new float[batch * channels];
 
@@ -1258,6 +1321,14 @@ public sealed partial class MetalBackend
     public void GlobalMaxPool2D(IGpuBuffer input, IGpuBuffer output, int batch, int channels, int height, int width)
     {
         ThrowIfDisposed();
+        try
+        {
+            if (TryDispatchConvPoolMetal(_convolutionLibrary, "Convolution", "global_maxpool2d_noidx",
+                batch * channels, new[] { input, output }, new[] { batch, channels, height, width }))
+                return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var inp = DownloadBuffer(input);
         var result = new float[batch * channels];
 
@@ -1287,6 +1358,14 @@ public sealed partial class MetalBackend
     public void GlobalMaxPool2D(IGpuBuffer input, IGpuBuffer output, IGpuBuffer indices, int batch, int channels, int height, int width)
     {
         ThrowIfDisposed();
+        try
+        {
+            if (TryDispatchConvPoolMetal(_convolutionLibrary, "Convolution", "global_maxpool2d",
+                batch * channels, new[] { input, output, indices }, new[] { batch, channels, height, width }))
+                return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var inp = DownloadBuffer(input);
         var result = new float[batch * channels];
         var idxResult = new float[batch * channels];
@@ -1329,6 +1408,14 @@ public sealed partial class MetalBackend
     public void GlobalAvgPool2DBackward(IGpuBuffer gradOutput, IGpuBuffer gradInput, int batch, int channels, int height, int width)
     {
         ThrowIfDisposed();
+        try
+        {
+            if (TryDispatchConvPoolMetal(_convolutionLibrary, "Convolution", "global_avgpool2d_backward",
+                batch * channels * height * width, new[] { gradOutput, gradInput }, new[] { batch, channels, height, width }))
+                return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var go = DownloadBuffer(gradOutput);
         int spatialSize = height * width;
         var result = new float[batch * channels * spatialSize];
@@ -1357,6 +1444,14 @@ public sealed partial class MetalBackend
     public void GlobalMaxPool2DBackward(IGpuBuffer gradOutput, IGpuBuffer indices, IGpuBuffer gradInput, int batch, int channels, int height, int width)
     {
         ThrowIfDisposed();
+        try
+        {
+            if (TryDispatchConvPoolMetal(_convolutionLibrary, "Convolution", "global_maxpool2d_backward",
+                batch * channels * height * width, new[] { gradOutput, indices, gradInput }, new[] { batch, channels, height, width }))
+                return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var go = DownloadBuffer(gradOutput);
         var idx = DownloadBuffer(indices);
         int spatialSize = height * width;
@@ -1385,6 +1480,15 @@ public sealed partial class MetalBackend
     public void AdaptiveAvgPool2D(IGpuBuffer input, IGpuBuffer output, int batch, int channels, int inHeight, int inWidth, int outHeight, int outWidth)
     {
         ThrowIfDisposed();
+        try
+        {
+            if (TryDispatchConvPoolMetal(_convolutionLibrary, "Convolution", "adaptive_avgpool2d",
+                batch * channels * outHeight * outWidth, new[] { input, output },
+                new[] { batch, channels, inHeight, inWidth, outHeight, outWidth }))
+                return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var inp = DownloadBuffer(input);
         var result = new float[batch * channels * outHeight * outWidth];
 
@@ -1434,6 +1538,15 @@ public sealed partial class MetalBackend
         int strideD, int strideH, int strideW)
     {
         ThrowIfDisposed();
+        try
+        {
+            if (indices is not null && TryDispatchConvPoolMetal(_convolutionLibrary, "Convolution", "maxpool3d",
+                batch * channels * outDepth * outHeight * outWidth, new[] { input, output, indices },
+                new[] { batch, channels, inDepth, inHeight, inWidth, outDepth, outHeight, outWidth, kernelD, kernelH, kernelW, strideD, strideH, strideW }))
+                return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var inp = DownloadBuffer(input);
         var result = new float[batch * channels * outDepth * outHeight * outWidth];
         var idxResult = indices is not null ? new float[batch * channels * outDepth * outHeight * outWidth] : null;
@@ -1494,6 +1607,15 @@ public sealed partial class MetalBackend
         int outDepth, int outHeight, int outWidth)
     {
         ThrowIfDisposed();
+        try
+        {
+            if (TryDispatchConvPoolMetal(_convolutionLibrary, "Convolution", "maxpool3d_backward",
+                batch * channels * inDepth * inHeight * inWidth, new[] { gradOutput, indices, gradInput },
+                new[] { batch, channels, inDepth, inHeight, inWidth, outDepth, outHeight, outWidth }))
+                return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var go = DownloadBuffer(gradOutput);
         var idx = DownloadBuffer(indices);
         var result = new float[batch * channels * inDepth * inHeight * inWidth];

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.ConvPool.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.ConvPool.cs
@@ -627,6 +627,15 @@ public sealed partial class MetalBackend
         int strideH, int strideW)
     {
         ThrowIfDisposed();
+        try
+        {
+            if (bias is not null && TryDispatchConvPoolMetal(_convolutionLibrary, "Convolution", "locally_connected_conv2d",
+                batch * outChannels * outHeight * outWidth, new[] { input, weights, bias, output },
+                new[] { batch, inChannels, inHeight, inWidth, outChannels, outHeight, outWidth, kernelH, kernelW, strideH, strideW }))
+                return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var inp = DownloadBuffer(input);
         var w = DownloadBuffer(weights);
         float[]? b = bias is not null ? DownloadBuffer(bias) : null;
@@ -670,6 +679,15 @@ public sealed partial class MetalBackend
         int strideH, int strideW)
     {
         ThrowIfDisposed();
+        try
+        {
+            if (TryDispatchConvPoolMetal(_convolutionLibrary, "Convolution", "locally_connected_conv2d_backward_input",
+                batch * inChannels * inHeight * inWidth, new[] { gradOutput, weights, gradInput },
+                new[] { batch, inChannels, inHeight, inWidth, outChannels, outHeight, outWidth, kernelH, kernelW, strideH, strideW }))
+                return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var go = DownloadBuffer(gradOutput);
         var w = DownloadBuffer(weights);
         var result = new float[batch * inChannels * inHeight * inWidth];
@@ -709,6 +727,15 @@ public sealed partial class MetalBackend
         int strideH, int strideW)
     {
         ThrowIfDisposed();
+        try
+        {
+            if (TryDispatchConvPoolMetal(_convolutionLibrary, "Convolution", "locally_connected_conv2d_backward_weights",
+                outHeight * outWidth * outChannels * inChannels * kernelH * kernelW, new[] { gradOutput, input, gradWeights },
+                new[] { batch, inChannels, inHeight, inWidth, outChannels, outHeight, outWidth, kernelH, kernelW, strideH, strideW }))
+                return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var go = DownloadBuffer(gradOutput);
         var inp = DownloadBuffer(input);
         var result = new float[outHeight * outWidth * outChannels * inChannels * kernelH * kernelW];
@@ -746,6 +773,14 @@ public sealed partial class MetalBackend
         int batch, int outChannels, int outHeight, int outWidth)
     {
         ThrowIfDisposed();
+        try
+        {
+            if (TryDispatchConvPoolMetal(_convolutionLibrary, "Convolution", "locally_connected_conv2d_backward_bias",
+                outChannels, new[] { gradOutput, gradBias }, new[] { batch, outChannels, outHeight, outWidth }))
+                return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var go = DownloadBuffer(gradOutput);
         var result = new float[outChannels];
 
@@ -781,6 +816,17 @@ public sealed partial class MetalBackend
         int groups, int deformGroups)
     {
         ThrowIfDisposed();
+        try
+        {
+            if (mask is not null && groups > 0 && deformGroups > 0
+                && inChannels % groups == 0 && inChannels % deformGroups == 0
+                && TryDispatchConvPoolMetal(_convolutionLibrary, "Convolution", "deformable_conv2d",
+                    batch * outChannels * outHeight * outWidth, new[] { input, weights, offsets, mask, output },
+                    new[] { batch, inChannels, inHeight, inWidth, outChannels, outHeight, outWidth, kernelH, kernelW, strideH, strideW, padH, padW, dilationH, dilationW, groups, deformGroups }))
+                return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var inp = DownloadBuffer(input);
         var w = DownloadBuffer(weights);
         var off = DownloadBuffer(offsets);
@@ -839,6 +885,17 @@ public sealed partial class MetalBackend
         int groups, int deformGroups)
     {
         ThrowIfDisposed();
+        try
+        {
+            if (mask is not null && groups > 0 && deformGroups > 0
+                && inChannels % groups == 0 && inChannels % deformGroups == 0
+                && TryDispatchConvPoolMetal(_convolutionLibrary, "Convolution", "deformable_conv2d_backward_input",
+                    batch * inChannels * inHeight * inWidth, new[] { gradOutput, weights, offsets, mask, gradInput },
+                    new[] { batch, inChannels, inHeight, inWidth, outChannels, outHeight, outWidth, kernelH, kernelW, strideH, strideW, padH, padW, dilationH, dilationW, groups, deformGroups }))
+                return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var go = DownloadBuffer(gradOutput);
         var w = DownloadBuffer(weights);
         var off = DownloadBuffer(offsets);
@@ -911,6 +968,17 @@ public sealed partial class MetalBackend
         int groups, int deformGroups)
     {
         ThrowIfDisposed();
+        try
+        {
+            if (mask is not null && groups > 0 && deformGroups > 0
+                && inChannels % groups == 0 && inChannels % deformGroups == 0
+                && TryDispatchConvPoolMetal(_convolutionLibrary, "Convolution", "deformable_conv2d_backward_weights",
+                    outChannels * (inChannels / groups) * kernelH * kernelW, new[] { gradOutput, input, offsets, mask, gradWeights },
+                    new[] { batch, inChannels, inHeight, inWidth, outChannels, outHeight, outWidth, kernelH, kernelW, strideH, strideW, padH, padW, dilationH, dilationW, groups, deformGroups }))
+                return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var go = DownloadBuffer(gradOutput);
         var inp = DownloadBuffer(input);
         var off = DownloadBuffer(offsets);
@@ -970,6 +1038,18 @@ public sealed partial class MetalBackend
         int groups, int deformGroups)
     {
         ThrowIfDisposed();
+        try
+        {
+            int ksG = kernelH * kernelW;
+            if (mask is not null && groups > 0 && deformGroups > 0
+                && inChannels % groups == 0 && inChannels % deformGroups == 0
+                && TryDispatchConvPoolMetal(_convolutionLibrary, "Convolution", "deformable_conv2d_backward_offset",
+                    batch * deformGroups * 2 * ksG * outHeight * outWidth, new[] { gradOutput, input, weights, offsets, mask, gradOffsets },
+                    new[] { batch, inChannels, inHeight, inWidth, outChannels, outHeight, outWidth, kernelH, kernelW, strideH, strideW, padH, padW, dilationH, dilationW, groups, deformGroups }))
+                return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var go = DownloadBuffer(gradOutput);
         var inp = DownloadBuffer(input);
         var w = DownloadBuffer(weights);
@@ -1045,6 +1125,18 @@ public sealed partial class MetalBackend
         int groups, int deformGroups)
     {
         ThrowIfDisposed();
+        try
+        {
+            int ksG = kernelH * kernelW;
+            if (groups > 0 && deformGroups > 0
+                && inChannels % groups == 0 && inChannels % deformGroups == 0
+                && TryDispatchConvPoolMetal(_convolutionLibrary, "Convolution", "deformable_conv2d_backward_mask",
+                    batch * deformGroups * ksG * outHeight * outWidth, new[] { gradOutput, input, weights, offsets, gradMask },
+                    new[] { batch, inChannels, inHeight, inWidth, outChannels, outHeight, outWidth, kernelH, kernelW, strideH, strideW, padH, padW, dilationH, dilationW, groups, deformGroups }))
+                return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var go = DownloadBuffer(gradOutput);
         var inp = DownloadBuffer(input);
         var w = DownloadBuffer(weights);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.ConvPool.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.ConvPool.cs
@@ -44,7 +44,7 @@ public sealed partial class MetalBackend
                 new[] { batch, inChannels, inHeight, inWidth, outChannels, outHeight, outWidth, kernelH, kernelW, strideH, strideW, padH, padW, dilationH, dilationW }))
                 return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
         // CPU fallback - proper Metal implementation would use MPSNDArrayMatrixMultiplication or custom kernel
         var inp = DownloadBuffer(input);
         var kern = DownloadBuffer(kernel);
@@ -111,7 +111,7 @@ public sealed partial class MetalBackend
                 new[] { batch, inChannels, inHeight, inWidth, outChannels, outHeight, outWidth, kernelH, kernelW, strideH, strideW, padH, padW, dilationH, dilationW }))
                 return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
         // CPU fallback
         var go = DownloadBuffer(gradOutput);
         var kern = DownloadBuffer(kernel);
@@ -182,7 +182,7 @@ public sealed partial class MetalBackend
                 new[] { batch, inChannels, inHeight, inWidth, outChannels, outHeight, outWidth, kernelH, kernelW, strideH, strideW, padH, padW, dilationH, dilationW }))
                 return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var inp = DownloadBuffer(input);
         var go = DownloadBuffer(gradOutput);
@@ -266,7 +266,7 @@ public sealed partial class MetalBackend
                 new[] { batch, channels, height, width, kernelH, kernelW, strideH, strideW, padH, padW }))
                 return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var inp = DownloadBuffer(input);
         int outH = (height + 2 * padH - kernelH) / strideH + 1;
@@ -303,7 +303,7 @@ public sealed partial class MetalBackend
                 new[] { batch, channels, outputH, outputW, kernelH, kernelW, strideH, strideW, padH, padW }))
                 return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var inp = DownloadBuffer(input);
         int unfoldH = (outputH + 2 * padH - kernelH) / strideH + 1;
@@ -348,7 +348,7 @@ public sealed partial class MetalBackend
                 new[] { batch, inChannels, inDepth, inHeight, inWidth, outChannels, outDepth, outHeight, outWidth, kernelD, kernelH, kernelW, strideD, strideH, strideW, padD, padH, padW, dilationD, dilationH, dilationW }))
                 return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var inp = DownloadBuffer(input);
         var kern = DownloadBuffer(kernel);
@@ -399,7 +399,7 @@ public sealed partial class MetalBackend
                 new[] { batch, channels, inHeight, inWidth, outHeight, outWidth, kernelH, kernelW, strideH, strideW, padH, padW }))
                 return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var inp = DownloadBuffer(input);
         var kern = DownloadBuffer(kernel);
@@ -483,13 +483,16 @@ public sealed partial class MetalBackend
                 encoder.SetBytes((uint)strideW, 13);
                 encoder.SetBytes((uint)padH, 14);
                 encoder.SetBytes((uint)padW, 15);
+                encoder.SetBytes((uint)outputPadH, 16);
+                encoder.SetBytes((uint)outputPadW, 17);
                 encoder.DispatchThreadgroups(threadgroups, threadsPerGroup);
                 return;
             }
         }
         catch
         {
-            // fall through to the CPU reference
+            if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw;
+            // else fall through to the CPU reference
         }
 
         // CPU fallback (correctness safety net when the GPU kernel is unavailable / fails to launch).
@@ -539,7 +542,7 @@ public sealed partial class MetalBackend
                 new[] { batch, inChannels, inHeight, inWidth, outChannels, outHeight, outWidth, kernelH, kernelW, strideH, strideW, padH, padW }))
                 return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var go = DownloadBuffer(gradOutput);
         var kern = DownloadBuffer(kernel);
@@ -588,7 +591,7 @@ public sealed partial class MetalBackend
                 new[] { batch, inChannels, inHeight, inWidth, outChannels, outHeight, outWidth, kernelH, kernelW, strideH, strideW, padH, padW }))
                 return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var inp = DownloadBuffer(input);
         var go = DownloadBuffer(gradOutput);
@@ -634,7 +637,7 @@ public sealed partial class MetalBackend
                 new[] { batch, inChannels, inHeight, inWidth, outChannels, outHeight, outWidth, kernelH, kernelW, strideH, strideW }))
                 return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var inp = DownloadBuffer(input);
         var w = DownloadBuffer(weights);
@@ -686,7 +689,7 @@ public sealed partial class MetalBackend
                 new[] { batch, inChannels, inHeight, inWidth, outChannels, outHeight, outWidth, kernelH, kernelW, strideH, strideW }))
                 return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var go = DownloadBuffer(gradOutput);
         var w = DownloadBuffer(weights);
@@ -734,7 +737,7 @@ public sealed partial class MetalBackend
                 new[] { batch, inChannels, inHeight, inWidth, outChannels, outHeight, outWidth, kernelH, kernelW, strideH, strideW }))
                 return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var go = DownloadBuffer(gradOutput);
         var inp = DownloadBuffer(input);
@@ -779,7 +782,7 @@ public sealed partial class MetalBackend
                 outChannels, new[] { gradOutput, gradBias }, new[] { batch, outChannels, outHeight, outWidth }))
                 return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var go = DownloadBuffer(gradOutput);
         var result = new float[outChannels];
@@ -825,7 +828,7 @@ public sealed partial class MetalBackend
                     new[] { batch, inChannels, inHeight, inWidth, outChannels, outHeight, outWidth, kernelH, kernelW, strideH, strideW, padH, padW, dilationH, dilationW, groups, deformGroups }))
                 return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var inp = DownloadBuffer(input);
         var w = DownloadBuffer(weights);
@@ -894,7 +897,7 @@ public sealed partial class MetalBackend
                     new[] { batch, inChannels, inHeight, inWidth, outChannels, outHeight, outWidth, kernelH, kernelW, strideH, strideW, padH, padW, dilationH, dilationW, groups, deformGroups }))
                 return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var go = DownloadBuffer(gradOutput);
         var w = DownloadBuffer(weights);
@@ -977,7 +980,7 @@ public sealed partial class MetalBackend
                     new[] { batch, inChannels, inHeight, inWidth, outChannels, outHeight, outWidth, kernelH, kernelW, strideH, strideW, padH, padW, dilationH, dilationW, groups, deformGroups }))
                 return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var go = DownloadBuffer(gradOutput);
         var inp = DownloadBuffer(input);
@@ -1048,7 +1051,7 @@ public sealed partial class MetalBackend
                     new[] { batch, inChannels, inHeight, inWidth, outChannels, outHeight, outWidth, kernelH, kernelW, strideH, strideW, padH, padW, dilationH, dilationW, groups, deformGroups }))
                 return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var go = DownloadBuffer(gradOutput);
         var inp = DownloadBuffer(input);
@@ -1135,7 +1138,7 @@ public sealed partial class MetalBackend
                     new[] { batch, inChannels, inHeight, inWidth, outChannels, outHeight, outWidth, kernelH, kernelW, strideH, strideW, padH, padW, dilationH, dilationW, groups, deformGroups }))
                 return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var go = DownloadBuffer(gradOutput);
         var inp = DownloadBuffer(input);
@@ -1201,7 +1204,7 @@ public sealed partial class MetalBackend
                 new[] { batch, channels, inHeight, inWidth, outHeight, outWidth, kernelH, kernelW, strideH, strideW, padH, padW }))
                 return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var inp = DownloadBuffer(input);
         var result = new float[batch * channels * outHeight * outWidth];
@@ -1277,7 +1280,7 @@ public sealed partial class MetalBackend
                 new[] { batch, channels, inHeight, inWidth, outHeight, outWidth, kernelH, kernelW, strideH, strideW, padH, padW }))
                 return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var go = DownloadBuffer(gradOutput);
         var idx = DownloadBuffer(indices);
@@ -1328,7 +1331,7 @@ public sealed partial class MetalBackend
                 new[] { batch, channels, inHeight, inWidth, outHeight, outWidth, kernelH, kernelW, strideH, strideW, padH, padW, countIncludePad ? 1 : 0 }))
                 return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var inp = DownloadBuffer(input);
         var result = new float[batch * channels * outHeight * outWidth];
@@ -1393,7 +1396,7 @@ public sealed partial class MetalBackend
                 new[] { batch, channels, inHeight, inWidth, outHeight, outWidth, kernelH, kernelW, strideH, strideW, padH, padW, countIncludePad ? 1 : 0 }))
                 return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var go = DownloadBuffer(gradOutput);
         var result = new float[batch * channels * inHeight * inWidth];
@@ -1463,7 +1466,7 @@ public sealed partial class MetalBackend
                 batch * channels, new[] { input, output }, new[] { batch, channels, height, width }))
                 return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var inp = DownloadBuffer(input);
         var result = new float[batch * channels];
@@ -1500,7 +1503,7 @@ public sealed partial class MetalBackend
                 batch * channels, new[] { input, output }, new[] { batch, channels, height, width }))
                 return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var inp = DownloadBuffer(input);
         var result = new float[batch * channels];
@@ -1537,7 +1540,7 @@ public sealed partial class MetalBackend
                 batch * channels, new[] { input, output, indices }, new[] { batch, channels, height, width }))
                 return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var inp = DownloadBuffer(input);
         var result = new float[batch * channels];
@@ -1587,7 +1590,7 @@ public sealed partial class MetalBackend
                 batch * channels * height * width, new[] { gradOutput, gradInput }, new[] { batch, channels, height, width }))
                 return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var go = DownloadBuffer(gradOutput);
         int spatialSize = height * width;
@@ -1623,7 +1626,7 @@ public sealed partial class MetalBackend
                 batch * channels * height * width, new[] { gradOutput, indices, gradInput }, new[] { batch, channels, height, width }))
                 return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var go = DownloadBuffer(gradOutput);
         var idx = DownloadBuffer(indices);
@@ -1660,7 +1663,7 @@ public sealed partial class MetalBackend
                 new[] { batch, channels, inHeight, inWidth, outHeight, outWidth }))
                 return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var inp = DownloadBuffer(input);
         var result = new float[batch * channels * outHeight * outWidth];
@@ -1718,7 +1721,7 @@ public sealed partial class MetalBackend
                 new[] { batch, channels, inDepth, inHeight, inWidth, outDepth, outHeight, outWidth, kernelD, kernelH, kernelW, strideD, strideH, strideW }))
                 return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var inp = DownloadBuffer(input);
         var result = new float[batch * channels * outDepth * outHeight * outWidth];
@@ -1787,7 +1790,7 @@ public sealed partial class MetalBackend
                 new[] { batch, channels, inDepth, inHeight, inWidth, outDepth, outHeight, outWidth }))
                 return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var go = DownloadBuffer(gradOutput);
         var idx = DownloadBuffer(indices);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.ConvPool.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.ConvPool.cs
@@ -372,6 +372,45 @@ public sealed partial class MetalBackend
         int outputPadH, int outputPadW)
     {
         ThrowIfDisposed();
+
+        // GPU path: real MSL conv_transpose2d kernel (gather form, one thread per output element). Falls back to
+        // the CPU reference on any failure so results stay correct (issue #646).
+        try
+        {
+            if (input is MetalGpuBuffer inBuf && kernel is MetalGpuBuffer wBuf && output is MetalGpuBuffer outBuf
+                && _convolutionLibrary != IntPtr.Zero)
+            {
+                var pipeline = GetPipeline("Convolution", _convolutionLibrary, "conv_transpose2d");
+                int total = batch * outChannels * outHeight * outWidth;
+                var (threadgroups, threadsPerGroup) = pipeline.Calculate1DDispatch(total);
+                using var encoder = _commandQueue.CreateScopedComputeEncoder();
+                encoder.SetPipelineState(pipeline.Handle);
+                encoder.SetBuffer(inBuf, 0);
+                encoder.SetBuffer(wBuf, 1);
+                encoder.SetBuffer(outBuf, 2);
+                encoder.SetBytes((uint)batch, 3);
+                encoder.SetBytes((uint)inChannels, 4);
+                encoder.SetBytes((uint)inHeight, 5);
+                encoder.SetBytes((uint)inWidth, 6);
+                encoder.SetBytes((uint)outChannels, 7);
+                encoder.SetBytes((uint)outHeight, 8);
+                encoder.SetBytes((uint)outWidth, 9);
+                encoder.SetBytes((uint)kernelH, 10);
+                encoder.SetBytes((uint)kernelW, 11);
+                encoder.SetBytes((uint)strideH, 12);
+                encoder.SetBytes((uint)strideW, 13);
+                encoder.SetBytes((uint)padH, 14);
+                encoder.SetBytes((uint)padW, 15);
+                encoder.DispatchThreadgroups(threadgroups, threadsPerGroup);
+                return;
+            }
+        }
+        catch
+        {
+            // fall through to the CPU reference
+        }
+
+        // CPU fallback (correctness safety net when the GPU kernel is unavailable / fails to launch).
         var inp = DownloadBuffer(input);
         var kern = DownloadBuffer(kernel);
         var result = new float[batch * outChannels * outHeight * outWidth];

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.ConvPool.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.ConvPool.cs
@@ -37,6 +37,14 @@ public sealed partial class MetalBackend
         int dilationH, int dilationW)
     {
         ThrowIfDisposed();
+        try
+        {
+            if (TryDispatchConvPoolMetal(_convolutionLibrary, "Convolution", "conv2d_direct",
+                batch * outChannels * outHeight * outWidth, new[] { input, kernel, output },
+                new[] { batch, inChannels, inHeight, inWidth, outChannels, outHeight, outWidth, kernelH, kernelW, strideH, strideW, padH, padW, dilationH, dilationW }))
+                return;
+        }
+        catch { /* fall through to CPU reference */ }
         // CPU fallback - proper Metal implementation would use MPSNDArrayMatrixMultiplication or custom kernel
         var inp = DownloadBuffer(input);
         var kern = DownloadBuffer(kernel);
@@ -96,6 +104,14 @@ public sealed partial class MetalBackend
         int dilationH, int dilationW)
     {
         ThrowIfDisposed();
+        try
+        {
+            if (TryDispatchConvPoolMetal(_convolutionLibrary, "Convolution", "conv2d_backward_input",
+                batch * inChannels * inHeight * inWidth, new[] { gradOutput, kernel, gradInput },
+                new[] { batch, inChannels, inHeight, inWidth, outChannels, outHeight, outWidth, kernelH, kernelW, strideH, strideW, padH, padW, dilationH, dilationW }))
+                return;
+        }
+        catch { /* fall through to CPU reference */ }
         // CPU fallback
         var go = DownloadBuffer(gradOutput);
         var kern = DownloadBuffer(kernel);
@@ -159,6 +175,15 @@ public sealed partial class MetalBackend
         int dilationH, int dilationW)
     {
         ThrowIfDisposed();
+        try
+        {
+            if (TryDispatchConvPoolMetal(_convolutionLibrary, "Convolution", "conv2d_backward_weights",
+                outChannels * inChannels * kernelH * kernelW, new[] { input, gradOutput, gradKernel },
+                new[] { batch, inChannels, inHeight, inWidth, outChannels, outHeight, outWidth, kernelH, kernelW, strideH, strideW, padH, padW, dilationH, dilationW }))
+                return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var inp = DownloadBuffer(input);
         var go = DownloadBuffer(gradOutput);
         var result = new float[outChannels * inChannels * kernelH * kernelW];
@@ -232,6 +257,17 @@ public sealed partial class MetalBackend
     {
         ThrowIfDisposed();
         if (strideH <= 0 || strideW <= 0) throw new ArgumentException("Stride must be positive.");
+        try
+        {
+            int oH = (height + 2 * padH - kernelH) / strideH + 1;
+            int oW = (width + 2 * padW - kernelW) / strideW + 1;
+            if (TryDispatchConvPoolMetal(_convolutionLibrary, "Convolution", "unfold",
+                batch * channels * kernelH * kernelW * oH * oW, new[] { input, output },
+                new[] { batch, channels, height, width, kernelH, kernelW, strideH, strideW, padH, padW }))
+                return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var inp = DownloadBuffer(input);
         int outH = (height + 2 * padH - kernelH) / strideH + 1;
         int outW = (width + 2 * padW - kernelW) / strideW + 1;
@@ -260,6 +296,15 @@ public sealed partial class MetalBackend
     {
         ThrowIfDisposed();
         if (strideH <= 0 || strideW <= 0) throw new ArgumentException("Stride must be positive.");
+        try
+        {
+            if (TryDispatchConvPoolMetal(_convolutionLibrary, "Convolution", "fold",
+                batch * channels * outputH * outputW, new[] { input, output },
+                new[] { batch, channels, outputH, outputW, kernelH, kernelW, strideH, strideW, padH, padW }))
+                return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var inp = DownloadBuffer(input);
         int unfoldH = (outputH + 2 * padH - kernelH) / strideH + 1;
         int unfoldW = (outputW + 2 * padW - kernelW) / strideW + 1;
@@ -296,6 +341,15 @@ public sealed partial class MetalBackend
         int dilationD, int dilationH, int dilationW)
     {
         ThrowIfDisposed();
+        try
+        {
+            if (TryDispatchConvPoolMetal(_convolutionLibrary, "Convolution", "conv3d_direct",
+                batch * outChannels * outDepth * outHeight * outWidth, new[] { input, kernel, output },
+                new[] { batch, inChannels, inDepth, inHeight, inWidth, outChannels, outDepth, outHeight, outWidth, kernelD, kernelH, kernelW, strideD, strideH, strideW, padD, padH, padW, dilationD, dilationH, dilationW }))
+                return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var inp = DownloadBuffer(input);
         var kern = DownloadBuffer(kernel);
         var result = new float[batch * outChannels * outDepth * outHeight * outWidth];
@@ -338,6 +392,15 @@ public sealed partial class MetalBackend
         int strideH, int strideW, int padH, int padW)
     {
         ThrowIfDisposed();
+        try
+        {
+            if (TryDispatchConvPoolMetal(_convolutionLibrary, "Convolution", "depthwise_conv2d",
+                batch * channels * outHeight * outWidth, new[] { input, kernel, output },
+                new[] { batch, channels, inHeight, inWidth, outHeight, outWidth, kernelH, kernelW, strideH, strideW, padH, padW }))
+                return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var inp = DownloadBuffer(input);
         var kern = DownloadBuffer(kernel);
         var result = new float[batch * channels * outHeight * outWidth];
@@ -469,6 +532,15 @@ public sealed partial class MetalBackend
         int outputPadH, int outputPadW)
     {
         ThrowIfDisposed();
+        try
+        {
+            if (TryDispatchConvPoolMetal(_convolutionLibrary, "Convolution", "conv_transpose2d_backward_input",
+                batch * inChannels * inHeight * inWidth, new[] { gradOutput, kernel, gradInput },
+                new[] { batch, inChannels, inHeight, inWidth, outChannels, outHeight, outWidth, kernelH, kernelW, strideH, strideW, padH, padW }))
+                return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var go = DownloadBuffer(gradOutput);
         var kern = DownloadBuffer(kernel);
         var result = new float[batch * inChannels * inHeight * inWidth];
@@ -509,6 +581,15 @@ public sealed partial class MetalBackend
         int outputPadH, int outputPadW)
     {
         ThrowIfDisposed();
+        try
+        {
+            if (TryDispatchConvPoolMetal(_convolutionLibrary, "Convolution", "conv_transpose2d_backward_weights",
+                inChannels * outChannels * kernelH * kernelW, new[] { input, gradOutput, gradKernel },
+                new[] { batch, inChannels, inHeight, inWidth, outChannels, outHeight, outWidth, kernelH, kernelW, strideH, strideW, padH, padW }))
+                return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var inp = DownloadBuffer(input);
         var go = DownloadBuffer(gradOutput);
         var result = new float[inChannels * outChannels * kernelH * kernelW];

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalKernels.cs
@@ -2881,6 +2881,281 @@ kernel void maxpool3d_backward(
     }
     gradInput[idx] = sum;
 }
+
+// ---- Conv family (issue #646): gather-form ports of the verified OpenCL kernels. ----
+kernel void conv2d_direct(
+    device const float* inp [[buffer(0)]], device const float* wgt [[buffer(1)]], device float* outp [[buffer(2)]],
+    constant uint& batch [[buffer(3)]], constant uint& inChannels [[buffer(4)]],
+    constant uint& inHeight [[buffer(5)]], constant uint& inWidth [[buffer(6)]],
+    constant uint& outChannels [[buffer(7)]], constant uint& outHeight [[buffer(8)]], constant uint& outWidth [[buffer(9)]],
+    constant uint& kernelH [[buffer(10)]], constant uint& kernelW [[buffer(11)]],
+    constant uint& strideH [[buffer(12)]], constant uint& strideW [[buffer(13)]],
+    constant uint& padH [[buffer(14)]], constant uint& padW [[buffer(15)]],
+    constant uint& dilationH [[buffer(16)]], constant uint& dilationW [[buffer(17)]],
+    uint gid [[thread_position_in_grid]])
+{
+    uint total = batch * outChannels * outHeight * outWidth;
+    if (gid >= total) return;
+    int idx = int(gid);
+    int ow = idx % int(outWidth); int t = idx / int(outWidth);
+    int oh = t % int(outHeight); t = t / int(outHeight);
+    int oc = t % int(outChannels); int b = t / int(outChannels);
+    float sum = 0.0f;
+    for (int ic = 0; ic < int(inChannels); ic++)
+      for (int kh = 0; kh < int(kernelH); kh++)
+        for (int kw = 0; kw < int(kernelW); kw++) {
+            int ih = oh * int(strideH) - int(padH) + kh * int(dilationH);
+            int iw = ow * int(strideW) - int(padW) + kw * int(dilationW);
+            if (ih >= 0 && ih < int(inHeight) && iw >= 0 && iw < int(inWidth))
+                sum += inp[((b * int(inChannels) + ic) * int(inHeight) + ih) * int(inWidth) + iw]
+                     * wgt[((oc * int(inChannels) + ic) * int(kernelH) + kh) * int(kernelW) + kw];
+        }
+    outp[((b * int(outChannels) + oc) * int(outHeight) + oh) * int(outWidth) + ow] = sum;
+}
+
+kernel void conv2d_backward_input(
+    device const float* gradOutput [[buffer(0)]], device const float* wgt [[buffer(1)]], device float* gradInput [[buffer(2)]],
+    constant uint& batch [[buffer(3)]], constant uint& inChannels [[buffer(4)]],
+    constant uint& inHeight [[buffer(5)]], constant uint& inWidth [[buffer(6)]],
+    constant uint& outChannels [[buffer(7)]], constant uint& outHeight [[buffer(8)]], constant uint& outWidth [[buffer(9)]],
+    constant uint& kernelH [[buffer(10)]], constant uint& kernelW [[buffer(11)]],
+    constant uint& strideH [[buffer(12)]], constant uint& strideW [[buffer(13)]],
+    constant uint& padH [[buffer(14)]], constant uint& padW [[buffer(15)]],
+    constant uint& dilationH [[buffer(16)]], constant uint& dilationW [[buffer(17)]],
+    uint gid [[thread_position_in_grid]])
+{
+    uint total = batch * inChannels * inHeight * inWidth;
+    if (gid >= total) return;
+    int idx = int(gid);
+    int iw = idx % int(inWidth); int t = idx / int(inWidth);
+    int ih = t % int(inHeight); t = t / int(inHeight);
+    int ic = t % int(inChannels); int b = t / int(inChannels);
+    float sum = 0.0f;
+    for (int oc = 0; oc < int(outChannels); oc++)
+      for (int kh = 0; kh < int(kernelH); kh++)
+        for (int kw = 0; kw < int(kernelW); kw++) {
+            int ohb = ih + int(padH) - kh * int(dilationH);
+            int owb = iw + int(padW) - kw * int(dilationW);
+            if ((ohb % int(strideH)) == 0 && (owb % int(strideW)) == 0) {
+                int oh = ohb / int(strideH); int ow = owb / int(strideW);
+                if (oh >= 0 && oh < int(outHeight) && ow >= 0 && ow < int(outWidth))
+                    sum += gradOutput[((b * int(outChannels) + oc) * int(outHeight) + oh) * int(outWidth) + ow]
+                         * wgt[((oc * int(inChannels) + ic) * int(kernelH) + kh) * int(kernelW) + kw];
+            }
+        }
+    gradInput[((b * int(inChannels) + ic) * int(inHeight) + ih) * int(inWidth) + iw] = sum;
+}
+
+kernel void conv2d_backward_weights(
+    device const float* inp [[buffer(0)]], device const float* gradOutput [[buffer(1)]], device float* gradKernel [[buffer(2)]],
+    constant uint& batch [[buffer(3)]], constant uint& inChannels [[buffer(4)]],
+    constant uint& inHeight [[buffer(5)]], constant uint& inWidth [[buffer(6)]],
+    constant uint& outChannels [[buffer(7)]], constant uint& outHeight [[buffer(8)]], constant uint& outWidth [[buffer(9)]],
+    constant uint& kernelH [[buffer(10)]], constant uint& kernelW [[buffer(11)]],
+    constant uint& strideH [[buffer(12)]], constant uint& strideW [[buffer(13)]],
+    constant uint& padH [[buffer(14)]], constant uint& padW [[buffer(15)]],
+    constant uint& dilationH [[buffer(16)]], constant uint& dilationW [[buffer(17)]],
+    uint gid [[thread_position_in_grid]])
+{
+    uint total = outChannels * inChannels * kernelH * kernelW;
+    if (gid >= total) return;
+    int idx = int(gid);
+    int kw = idx % int(kernelW); int t = idx / int(kernelW);
+    int kh = t % int(kernelH); t = t / int(kernelH);
+    int ic = t % int(inChannels); int oc = t / int(inChannels);
+    float sum = 0.0f;
+    for (int b = 0; b < int(batch); b++)
+      for (int oh = 0; oh < int(outHeight); oh++)
+        for (int ow = 0; ow < int(outWidth); ow++) {
+            int ih = oh * int(strideH) - int(padH) + kh * int(dilationH);
+            int iw = ow * int(strideW) - int(padW) + kw * int(dilationW);
+            if (ih >= 0 && ih < int(inHeight) && iw >= 0 && iw < int(inWidth))
+                sum += inp[((b * int(inChannels) + ic) * int(inHeight) + ih) * int(inWidth) + iw]
+                     * gradOutput[((b * int(outChannels) + oc) * int(outHeight) + oh) * int(outWidth) + ow];
+        }
+    gradKernel[((oc * int(inChannels) + ic) * int(kernelH) + kh) * int(kernelW) + kw] = sum;
+}
+
+kernel void depthwise_conv2d(
+    device const float* inp [[buffer(0)]], device const float* wgt [[buffer(1)]], device float* outp [[buffer(2)]],
+    constant uint& batch [[buffer(3)]], constant uint& channels [[buffer(4)]],
+    constant uint& inHeight [[buffer(5)]], constant uint& inWidth [[buffer(6)]],
+    constant uint& outHeight [[buffer(7)]], constant uint& outWidth [[buffer(8)]],
+    constant uint& kernelH [[buffer(9)]], constant uint& kernelW [[buffer(10)]],
+    constant uint& strideH [[buffer(11)]], constant uint& strideW [[buffer(12)]],
+    constant uint& padH [[buffer(13)]], constant uint& padW [[buffer(14)]],
+    uint gid [[thread_position_in_grid]])
+{
+    uint total = batch * channels * outHeight * outWidth;
+    if (gid >= total) return;
+    int idx = int(gid);
+    int ow = idx % int(outWidth); int t = idx / int(outWidth);
+    int oh = t % int(outHeight); t = t / int(outHeight);
+    int c = t % int(channels); int b = t / int(channels);
+    float sum = 0.0f;
+    for (int kh = 0; kh < int(kernelH); kh++)
+      for (int kw = 0; kw < int(kernelW); kw++) {
+          int ih = oh * int(strideH) - int(padH) + kh; int iw = ow * int(strideW) - int(padW) + kw;
+          if (ih >= 0 && ih < int(inHeight) && iw >= 0 && iw < int(inWidth))
+              sum += inp[((b * int(channels) + c) * int(inHeight) + ih) * int(inWidth) + iw]
+                   * wgt[(c * int(kernelH) + kh) * int(kernelW) + kw];
+      }
+    outp[((b * int(channels) + c) * int(outHeight) + oh) * int(outWidth) + ow] = sum;
+}
+
+// Transposed conv backward input — matches the Metal CPU reference (gather per input, full out dims,
+// kernel layout [inChannels, outChannels, kH, kW]).
+kernel void conv_transpose2d_backward_input(
+    device const float* gradOutput [[buffer(0)]], device const float* wgt [[buffer(1)]], device float* gradInput [[buffer(2)]],
+    constant uint& batch [[buffer(3)]], constant uint& inChannels [[buffer(4)]],
+    constant uint& inHeight [[buffer(5)]], constant uint& inWidth [[buffer(6)]],
+    constant uint& outChannels [[buffer(7)]], constant uint& outHeight [[buffer(8)]], constant uint& outWidth [[buffer(9)]],
+    constant uint& kernelH [[buffer(10)]], constant uint& kernelW [[buffer(11)]],
+    constant uint& strideH [[buffer(12)]], constant uint& strideW [[buffer(13)]],
+    constant uint& padH [[buffer(14)]], constant uint& padW [[buffer(15)]],
+    uint gid [[thread_position_in_grid]])
+{
+    uint total = batch * inChannels * inHeight * inWidth;
+    if (gid >= total) return;
+    int idx = int(gid);
+    int iw = idx % int(inWidth); int t = idx / int(inWidth);
+    int ih = t % int(inHeight); t = t / int(inHeight);
+    int ic = t % int(inChannels); int b = t / int(inChannels);
+    float sum = 0.0f;
+    for (int oc = 0; oc < int(outChannels); oc++)
+      for (int kh = 0; kh < int(kernelH); kh++)
+        for (int kw = 0; kw < int(kernelW); kw++) {
+            int oh = ih * int(strideH) - int(padH) + kh; int ow = iw * int(strideW) - int(padW) + kw;
+            if (oh >= 0 && oh < int(outHeight) && ow >= 0 && ow < int(outWidth))
+                sum += gradOutput[((b * int(outChannels) + oc) * int(outHeight) + oh) * int(outWidth) + ow]
+                     * wgt[((ic * int(outChannels) + oc) * int(kernelH) + kh) * int(kernelW) + kw];
+        }
+    gradInput[((b * int(inChannels) + ic) * int(inHeight) + ih) * int(inWidth) + iw] = sum;
+}
+
+// Transposed conv backward weights — matches the Metal CPU reference (full out dims; layout [inC,outC,kH,kW]).
+kernel void conv_transpose2d_backward_weights(
+    device const float* inp [[buffer(0)]], device const float* gradOutput [[buffer(1)]], device float* gradWeights [[buffer(2)]],
+    constant uint& batch [[buffer(3)]], constant uint& inChannels [[buffer(4)]],
+    constant uint& inHeight [[buffer(5)]], constant uint& inWidth [[buffer(6)]],
+    constant uint& outChannels [[buffer(7)]], constant uint& outHeight [[buffer(8)]], constant uint& outWidth [[buffer(9)]],
+    constant uint& kernelH [[buffer(10)]], constant uint& kernelW [[buffer(11)]],
+    constant uint& strideH [[buffer(12)]], constant uint& strideW [[buffer(13)]],
+    constant uint& padH [[buffer(14)]], constant uint& padW [[buffer(15)]],
+    uint gid [[thread_position_in_grid]])
+{
+    uint total = inChannels * outChannels * kernelH * kernelW;
+    if (gid >= total) return;
+    int idx = int(gid);
+    int kw = idx % int(kernelW); int t = idx / int(kernelW);
+    int kh = t % int(kernelH); t = t / int(kernelH);
+    int oc = t % int(outChannels); int ic = t / int(outChannels);
+    float sum = 0.0f;
+    for (int b = 0; b < int(batch); b++)
+      for (int ih = 0; ih < int(inHeight); ih++)
+        for (int iw = 0; iw < int(inWidth); iw++) {
+            int oh = ih * int(strideH) - int(padH) + kh; int ow = iw * int(strideW) - int(padW) + kw;
+            if (oh >= 0 && oh < int(outHeight) && ow >= 0 && ow < int(outWidth))
+                sum += inp[((b * int(inChannels) + ic) * int(inHeight) + ih) * int(inWidth) + iw]
+                     * gradOutput[((b * int(outChannels) + oc) * int(outHeight) + oh) * int(outWidth) + ow];
+        }
+    gradWeights[idx] = sum;
+}
+
+kernel void conv3d_direct(
+    device const float* inp [[buffer(0)]], device const float* wgt [[buffer(1)]], device float* outp [[buffer(2)]],
+    constant uint& batch [[buffer(3)]], constant uint& inChannels [[buffer(4)]],
+    constant uint& inDepth [[buffer(5)]], constant uint& inHeight [[buffer(6)]], constant uint& inWidth [[buffer(7)]],
+    constant uint& outChannels [[buffer(8)]], constant uint& outDepth [[buffer(9)]], constant uint& outHeight [[buffer(10)]], constant uint& outWidth [[buffer(11)]],
+    constant uint& kernelD [[buffer(12)]], constant uint& kernelH [[buffer(13)]], constant uint& kernelW [[buffer(14)]],
+    constant uint& strideD [[buffer(15)]], constant uint& strideH [[buffer(16)]], constant uint& strideW [[buffer(17)]],
+    constant uint& padD [[buffer(18)]], constant uint& padH [[buffer(19)]], constant uint& padW [[buffer(20)]],
+    constant uint& dilationD [[buffer(21)]], constant uint& dilationH [[buffer(22)]], constant uint& dilationW [[buffer(23)]],
+    uint gid [[thread_position_in_grid]])
+{
+    uint total = batch * outChannels * outDepth * outHeight * outWidth;
+    if (gid >= total) return;
+    int idx = int(gid);
+    int ow = idx % int(outWidth); int t = idx / int(outWidth);
+    int oh = t % int(outHeight); t = t / int(outHeight);
+    int od = t % int(outDepth); t = t / int(outDepth);
+    int oc = t % int(outChannels); int b = t / int(outChannels);
+    float sum = 0.0f;
+    for (int ic = 0; ic < int(inChannels); ic++)
+      for (int kd = 0; kd < int(kernelD); kd++)
+        for (int kh = 0; kh < int(kernelH); kh++)
+          for (int kw = 0; kw < int(kernelW); kw++) {
+              int id = od * int(strideD) - int(padD) + kd * int(dilationD);
+              int ih = oh * int(strideH) - int(padH) + kh * int(dilationH);
+              int iw = ow * int(strideW) - int(padW) + kw * int(dilationW);
+              if (id >= 0 && id < int(inDepth) && ih >= 0 && ih < int(inHeight) && iw >= 0 && iw < int(inWidth))
+                  sum += inp[(((b * int(inChannels) + ic) * int(inDepth) + id) * int(inHeight) + ih) * int(inWidth) + iw]
+                       * wgt[(((oc * int(inChannels) + ic) * int(kernelD) + kd) * int(kernelH) + kh) * int(kernelW) + kw];
+          }
+    outp[(((b * int(outChannels) + oc) * int(outDepth) + od) * int(outHeight) + oh) * int(outWidth) + ow] = sum;
+}
+
+// Unfold (Metal column layout [b, (c*kH+ki)*kW+kj, outH*outW], no dilation) — one thread per column element.
+kernel void unfold(
+    device const float* inp [[buffer(0)]], device float* outp [[buffer(1)]],
+    constant uint& batch [[buffer(2)]], constant uint& channels [[buffer(3)]],
+    constant uint& height [[buffer(4)]], constant uint& width [[buffer(5)]],
+    constant uint& kernelH [[buffer(6)]], constant uint& kernelW [[buffer(7)]],
+    constant uint& strideH [[buffer(8)]], constant uint& strideW [[buffer(9)]],
+    constant uint& padH [[buffer(10)]], constant uint& padW [[buffer(11)]],
+    uint gid [[thread_position_in_grid]])
+{
+    int outH = (int(height) + 2 * int(padH) - int(kernelH)) / int(strideH) + 1;
+    int outW = (int(width) + 2 * int(padW) - int(kernelW)) / int(strideW) + 1;
+    int colLen = outH * outW; int colCh = int(channels) * int(kernelH) * int(kernelW);
+    uint total = batch * uint(colCh) * uint(colLen);
+    if (gid >= total) return;
+    int idx = int(gid);
+    int b = idx / (colCh * colLen); int r = idx % (colCh * colLen);
+    int colRow = r / colLen; int pos = r % colLen;
+    int oh = pos / outW; int ow = pos % outW;
+    int c = colRow / (int(kernelH) * int(kernelW)); int k = colRow % (int(kernelH) * int(kernelW));
+    int ki = k / int(kernelW); int kj = k % int(kernelW);
+    int ih = oh * int(strideH) + ki - int(padH); int iw = ow * int(strideW) + kj - int(padW);
+    float val = 0.0f;
+    if (ih >= 0 && ih < int(height) && iw >= 0 && iw < int(width))
+        val = inp[(b * int(channels) + c) * int(height) * int(width) + ih * int(width) + iw];
+    outp[idx] = val;
+}
+
+// Fold (Metal column layout, gather per output pixel — race-free inverse of unfold's scatter).
+kernel void fold(
+    device const float* inp [[buffer(0)]], device float* outp [[buffer(1)]],
+    constant uint& batch [[buffer(2)]], constant uint& channels [[buffer(3)]],
+    constant uint& outputH [[buffer(4)]], constant uint& outputW [[buffer(5)]],
+    constant uint& kernelH [[buffer(6)]], constant uint& kernelW [[buffer(7)]],
+    constant uint& strideH [[buffer(8)]], constant uint& strideW [[buffer(9)]],
+    constant uint& padH [[buffer(10)]], constant uint& padW [[buffer(11)]],
+    uint gid [[thread_position_in_grid]])
+{
+    uint total = batch * channels * outputH * outputW;
+    if (gid >= total) return;
+    int idx = int(gid);
+    int iw = idx % int(outputW); int t = idx / int(outputW);
+    int ih = t % int(outputH); t = t / int(outputH);
+    int c = t % int(channels); int b = t / int(channels);
+    int unfoldH = (int(outputH) + 2 * int(padH) - int(kernelH)) / int(strideH) + 1;
+    int unfoldW = (int(outputW) + 2 * int(padW) - int(kernelW)) / int(strideW) + 1;
+    int colLen = unfoldH * unfoldW; int colCh = int(channels) * int(kernelH) * int(kernelW);
+    float sum = 0.0f;
+    for (int ki = 0; ki < int(kernelH); ki++)
+      for (int kj = 0; kj < int(kernelW); kj++) {
+          int ohn = ih - ki + int(padH); int own = iw - kj + int(padW);
+          if ((ohn % int(strideH)) == 0 && (own % int(strideW)) == 0) {
+              int oh = ohn / int(strideH); int ow = own / int(strideW);
+              if (oh >= 0 && oh < unfoldH && ow >= 0 && ow < unfoldW) {
+                  int colRow = (c * int(kernelH) + ki) * int(kernelW) + kj;
+                  sum += inp[b * colCh * colLen + colRow * colLen + oh * unfoldW + ow];
+              }
+          }
+      }
+    outp[idx] = sum;
+}
 ";
 
     #endregion

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalKernels.cs
@@ -2628,6 +2628,259 @@ kernel void conv_transpose2d(
     }
     outp[((b * outChannels + oc) * outHeight + oh) * outWidth + ow] = sum;
 }
+
+// ---- Pooling (issue #646): all gather-form (one thread per output element; backwards scan covering outputs so
+// no atomics / zero-init are needed). Ported from the verified OpenCL pooling kernels. ----
+kernel void avgpool2d(
+    device const float* inp [[buffer(0)]], device float* outp [[buffer(1)]],
+    constant uint& batch [[buffer(2)]], constant uint& channels [[buffer(3)]],
+    constant uint& inHeight [[buffer(4)]], constant uint& inWidth [[buffer(5)]],
+    constant uint& outHeight [[buffer(6)]], constant uint& outWidth [[buffer(7)]],
+    constant uint& kernelH [[buffer(8)]], constant uint& kernelW [[buffer(9)]],
+    constant uint& strideH [[buffer(10)]], constant uint& strideW [[buffer(11)]],
+    constant uint& padH [[buffer(12)]], constant uint& padW [[buffer(13)]],
+    constant uint& countIncludePad [[buffer(14)]], uint gid [[thread_position_in_grid]])
+{
+    uint total = batch * channels * outHeight * outWidth;
+    if (gid >= total) return;
+    int idx = int(gid);
+    int ow = idx % int(outWidth); int t = idx / int(outWidth);
+    int oh = t % int(outHeight); t = t / int(outHeight);
+    int c = t % int(channels); int b = t / int(channels);
+    float sum = 0.0f; int count = 0;
+    for (int kh = 0; kh < int(kernelH); kh++) for (int kw = 0; kw < int(kernelW); kw++) {
+        int ih = oh * int(strideH) - int(padH) + kh;
+        int iw = ow * int(strideW) - int(padW) + kw;
+        if (ih >= 0 && ih < int(inHeight) && iw >= 0 && iw < int(inWidth)) {
+            sum += inp[((b * int(channels) + c) * int(inHeight) + ih) * int(inWidth) + iw]; count++;
+        } else if (countIncludePad != 0u) { count++; }
+    }
+    int divisor = (countIncludePad != 0u) ? int(kernelH * kernelW) : max(count, 1);
+    outp[((b * int(channels) + c) * int(outHeight) + oh) * int(outWidth) + ow] = sum / float(divisor);
+}
+
+kernel void avgpool2d_backward(
+    device const float* gradOutput [[buffer(0)]], device float* gradInput [[buffer(1)]],
+    constant uint& batch [[buffer(2)]], constant uint& channels [[buffer(3)]],
+    constant uint& inHeight [[buffer(4)]], constant uint& inWidth [[buffer(5)]],
+    constant uint& outHeight [[buffer(6)]], constant uint& outWidth [[buffer(7)]],
+    constant uint& kernelH [[buffer(8)]], constant uint& kernelW [[buffer(9)]],
+    constant uint& strideH [[buffer(10)]], constant uint& strideW [[buffer(11)]],
+    constant uint& padH [[buffer(12)]], constant uint& padW [[buffer(13)]],
+    constant uint& countIncludePad [[buffer(14)]], uint gid [[thread_position_in_grid]])
+{
+    uint total = batch * channels * inHeight * inWidth;
+    if (gid >= total) return;
+    int idx = int(gid);
+    int iw = idx % int(inWidth); int t = idx / int(inWidth);
+    int ih = t % int(inHeight); t = t / int(inHeight);
+    int c = t % int(channels); int b = t / int(channels);
+    float sum = 0.0f;
+    for (int oh = 0; oh < int(outHeight); oh++) for (int ow = 0; ow < int(outWidth); ow++) {
+        int hStart = oh * int(strideH) - int(padH); int wStart = ow * int(strideW) - int(padW);
+        int hEnd = hStart + int(kernelH); int wEnd = wStart + int(kernelW);
+        if (ih >= hStart && ih < hEnd && iw >= wStart && iw < wEnd) {
+            int poolSize;
+            if (countIncludePad != 0u) poolSize = int(kernelH * kernelW);
+            else { int hs = max(hStart,0); int he = min(hEnd,int(inHeight)); int ws = max(wStart,0); int we = min(wEnd,int(inWidth)); poolSize = (he-hs)*(we-ws); }
+            sum += gradOutput[((b * int(channels) + c) * int(outHeight) + oh) * int(outWidth) + ow] / float(max(poolSize,1));
+        }
+    }
+    gradInput[((b * int(channels) + c) * int(inHeight) + ih) * int(inWidth) + iw] = sum;
+}
+
+kernel void maxpool2d(
+    device const float* inp [[buffer(0)]], device float* outp [[buffer(1)]], device int* indices [[buffer(2)]],
+    constant uint& batch [[buffer(3)]], constant uint& channels [[buffer(4)]],
+    constant uint& inHeight [[buffer(5)]], constant uint& inWidth [[buffer(6)]],
+    constant uint& outHeight [[buffer(7)]], constant uint& outWidth [[buffer(8)]],
+    constant uint& kernelH [[buffer(9)]], constant uint& kernelW [[buffer(10)]],
+    constant uint& strideH [[buffer(11)]], constant uint& strideW [[buffer(12)]],
+    constant uint& padH [[buffer(13)]], constant uint& padW [[buffer(14)]],
+    uint gid [[thread_position_in_grid]])
+{
+    uint total = batch * channels * outHeight * outWidth;
+    if (gid >= total) return;
+    int idx = int(gid);
+    int ow = idx % int(outWidth); int t = idx / int(outWidth);
+    int oh = t % int(outHeight); t = t / int(outHeight);
+    int c = t % int(channels); int b = t / int(channels);
+    float maxVal = -3.402823466e+38f; int maxIdx = 0;
+    for (int kh = 0; kh < int(kernelH); kh++) for (int kw = 0; kw < int(kernelW); kw++) {
+        int ih = oh * int(strideH) - int(padH) + kh; int iw = ow * int(strideW) - int(padW) + kw;
+        if (ih >= 0 && ih < int(inHeight) && iw >= 0 && iw < int(inWidth)) {
+            float v = inp[((b * int(channels) + c) * int(inHeight) + ih) * int(inWidth) + iw];
+            if (v > maxVal) { maxVal = v; maxIdx = ih * int(inWidth) + iw; }
+        }
+    }
+    int oIdx = ((b * int(channels) + c) * int(outHeight) + oh) * int(outWidth) + ow;
+    outp[oIdx] = maxVal; indices[oIdx] = maxIdx;
+}
+
+kernel void maxpool2d_backward(
+    device const float* gradOutput [[buffer(0)]], device const int* indices [[buffer(1)]], device float* gradInput [[buffer(2)]],
+    constant uint& batch [[buffer(3)]], constant uint& channels [[buffer(4)]],
+    constant uint& inHeight [[buffer(5)]], constant uint& inWidth [[buffer(6)]],
+    constant uint& outHeight [[buffer(7)]], constant uint& outWidth [[buffer(8)]],
+    constant uint& kernelH [[buffer(9)]], constant uint& kernelW [[buffer(10)]],
+    constant uint& strideH [[buffer(11)]], constant uint& strideW [[buffer(12)]],
+    constant uint& padH [[buffer(13)]], constant uint& padW [[buffer(14)]],
+    uint gid [[thread_position_in_grid]])
+{
+    uint total = batch * channels * inHeight * inWidth;
+    if (gid >= total) return;
+    int idx = int(gid);
+    int iw = idx % int(inWidth); int t = idx / int(inWidth);
+    int ih = t % int(inHeight); t = t / int(inHeight);
+    int c = t % int(channels); int b = t / int(channels);
+    int myFlat = ih * int(inWidth) + iw;
+    float sum = 0.0f;
+    for (int oh = 0; oh < int(outHeight); oh++) for (int ow = 0; ow < int(outWidth); ow++) {
+        int hStart = oh * int(strideH) - int(padH); int wStart = ow * int(strideW) - int(padW);
+        if (ih >= hStart && ih < hStart + int(kernelH) && iw >= wStart && iw < wStart + int(kernelW)) {
+            int oIdx = ((b * int(channels) + c) * int(outHeight) + oh) * int(outWidth) + ow;
+            if (indices[oIdx] == myFlat) sum += gradOutput[oIdx];
+        }
+    }
+    gradInput[idx] = sum;
+}
+
+kernel void global_avgpool2d(
+    device const float* inp [[buffer(0)]], device float* outp [[buffer(1)]],
+    constant uint& batch [[buffer(2)]], constant uint& channels [[buffer(3)]],
+    constant uint& height [[buffer(4)]], constant uint& width [[buffer(5)]],
+    uint gid [[thread_position_in_grid]])
+{
+    uint total = batch * channels;
+    if (gid >= total) return;
+    int idx = int(gid); int c = idx % int(channels); int b = idx / int(channels);
+    float sum = 0.0f; int sp = int(height * width);
+    for (int i = 0; i < sp; i++) sum += inp[(b * int(channels) + c) * sp + i];
+    outp[b * int(channels) + c] = sum / float(sp);
+}
+
+kernel void global_avgpool2d_backward(
+    device const float* gradOutput [[buffer(0)]], device float* gradInput [[buffer(1)]],
+    constant uint& batch [[buffer(2)]], constant uint& channels [[buffer(3)]],
+    constant uint& height [[buffer(4)]], constant uint& width [[buffer(5)]],
+    uint gid [[thread_position_in_grid]])
+{
+    int sp = int(height * width); uint total = batch * channels * uint(sp);
+    if (gid >= total) return;
+    int idx = int(gid); int c = (idx / sp) % int(channels); int b = idx / (int(channels) * sp);
+    gradInput[idx] = gradOutput[b * int(channels) + c] / float(sp);
+}
+
+kernel void global_maxpool2d_noidx(
+    device const float* inp [[buffer(0)]], device float* outp [[buffer(1)]],
+    constant uint& batch [[buffer(2)]], constant uint& channels [[buffer(3)]],
+    constant uint& height [[buffer(4)]], constant uint& width [[buffer(5)]],
+    uint gid [[thread_position_in_grid]])
+{
+    uint total = batch * channels;
+    if (gid >= total) return;
+    int idx = int(gid); int c = idx % int(channels); int b = idx / int(channels);
+    float m = -3.402823466e+38f; int sp = int(height * width);
+    for (int i = 0; i < sp; i++) m = max(m, inp[(b * int(channels) + c) * sp + i]);
+    outp[b * int(channels) + c] = m;
+}
+
+kernel void global_maxpool2d(
+    device const float* inp [[buffer(0)]], device float* outp [[buffer(1)]], device int* indices [[buffer(2)]],
+    constant uint& batch [[buffer(3)]], constant uint& channels [[buffer(4)]],
+    constant uint& height [[buffer(5)]], constant uint& width [[buffer(6)]],
+    uint gid [[thread_position_in_grid]])
+{
+    uint total = batch * channels;
+    if (gid >= total) return;
+    int idx = int(gid); int c = idx % int(channels); int b = idx / int(channels);
+    float m = -3.402823466e+38f; int mi = 0; int sp = int(height * width);
+    for (int i = 0; i < sp; i++) { float v = inp[(b * int(channels) + c) * sp + i]; if (v > m) { m = v; mi = i; } }
+    outp[b * int(channels) + c] = m; indices[b * int(channels) + c] = mi;
+}
+
+kernel void global_maxpool2d_backward(
+    device const float* gradOutput [[buffer(0)]], device const int* indices [[buffer(1)]], device float* gradInput [[buffer(2)]],
+    constant uint& batch [[buffer(3)]], constant uint& channels [[buffer(4)]],
+    constant uint& height [[buffer(5)]], constant uint& width [[buffer(6)]],
+    uint gid [[thread_position_in_grid]])
+{
+    int sp = int(height * width); uint total = batch * channels * uint(sp);
+    if (gid >= total) return;
+    int idx = int(gid); int pos = idx % sp; int bc = idx / sp;
+    gradInput[idx] = (indices[bc] == pos) ? gradOutput[bc] : 0.0f;
+}
+
+kernel void adaptive_avgpool2d(
+    device const float* inp [[buffer(0)]], device float* outp [[buffer(1)]],
+    constant uint& batch [[buffer(2)]], constant uint& channels [[buffer(3)]],
+    constant uint& inHeight [[buffer(4)]], constant uint& inWidth [[buffer(5)]],
+    constant uint& outHeight [[buffer(6)]], constant uint& outWidth [[buffer(7)]],
+    uint gid [[thread_position_in_grid]])
+{
+    uint total = batch * channels * outHeight * outWidth;
+    if (gid >= total) return;
+    int idx = int(gid);
+    int ow = idx % int(outWidth); int t = idx / int(outWidth);
+    int oh = t % int(outHeight); t = t / int(outHeight);
+    int c = t % int(channels); int b = t / int(channels);
+    int hS = (oh * int(inHeight)) / int(outHeight); int hE = ((oh + 1) * int(inHeight)) / int(outHeight);
+    int wS = (ow * int(inWidth)) / int(outWidth); int wE = ((ow + 1) * int(inWidth)) / int(outWidth);
+    float sum = 0.0f; int count = 0;
+    for (int ih = hS; ih < hE; ih++) for (int iw = wS; iw < wE; iw++) { sum += inp[((b * int(channels) + c) * int(inHeight) + ih) * int(inWidth) + iw]; count++; }
+    outp[((b * int(channels) + c) * int(outHeight) + oh) * int(outWidth) + ow] = sum / float(max(count, 1));
+}
+
+kernel void maxpool3d(
+    device const float* inp [[buffer(0)]], device float* outp [[buffer(1)]], device int* indices [[buffer(2)]],
+    constant uint& batch [[buffer(3)]], constant uint& channels [[buffer(4)]],
+    constant uint& inDepth [[buffer(5)]], constant uint& inHeight [[buffer(6)]], constant uint& inWidth [[buffer(7)]],
+    constant uint& outDepth [[buffer(8)]], constant uint& outHeight [[buffer(9)]], constant uint& outWidth [[buffer(10)]],
+    constant uint& kernelD [[buffer(11)]], constant uint& kernelH [[buffer(12)]], constant uint& kernelW [[buffer(13)]],
+    constant uint& strideD [[buffer(14)]], constant uint& strideH [[buffer(15)]], constant uint& strideW [[buffer(16)]],
+    uint gid [[thread_position_in_grid]])
+{
+    uint total = batch * channels * outDepth * outHeight * outWidth;
+    if (gid >= total) return;
+    int idx = int(gid);
+    int ow = idx % int(outWidth); int t = idx / int(outWidth);
+    int oh = t % int(outHeight); t = t / int(outHeight);
+    int od = t % int(outDepth); t = t / int(outDepth);
+    int c = t % int(channels); int b = t / int(channels);
+    float m = -3.402823466e+38f; int mi = 0;
+    for (int kd = 0; kd < int(kernelD); kd++) { int id = od * int(strideD) + kd; if (id >= int(inDepth)) continue;
+      for (int kh = 0; kh < int(kernelH); kh++) { int ih = oh * int(strideH) + kh; if (ih >= int(inHeight)) continue;
+        for (int kw = 0; kw < int(kernelW); kw++) { int iw = ow * int(strideW) + kw; if (iw >= int(inWidth)) continue;
+            float v = inp[((b * int(channels) + c) * int(inDepth) + id) * int(inHeight) * int(inWidth) + ih * int(inWidth) + iw];
+            if (v > m) { m = v; mi = id * int(inHeight) * int(inWidth) + ih * int(inWidth) + iw; }
+        } } }
+    int oIdx = ((b * int(channels) + c) * int(outDepth) + od) * int(outHeight) * int(outWidth) + oh * int(outWidth) + ow;
+    outp[oIdx] = m; indices[oIdx] = mi;
+}
+
+kernel void maxpool3d_backward(
+    device const float* gradOutput [[buffer(0)]], device const int* indices [[buffer(1)]], device float* gradInput [[buffer(2)]],
+    constant uint& batch [[buffer(3)]], constant uint& channels [[buffer(4)]],
+    constant uint& inDepth [[buffer(5)]], constant uint& inHeight [[buffer(6)]], constant uint& inWidth [[buffer(7)]],
+    constant uint& outDepth [[buffer(8)]], constant uint& outHeight [[buffer(9)]], constant uint& outWidth [[buffer(10)]],
+    uint gid [[thread_position_in_grid]])
+{
+    uint total = batch * channels * inDepth * inHeight * inWidth;
+    if (gid >= total) return;
+    int idx = int(gid);
+    int iw = idx % int(inWidth); int t = idx / int(inWidth);
+    int ih = t % int(inHeight); t = t / int(inHeight);
+    int id = t % int(inDepth); t = t / int(inDepth);
+    int c = t % int(channels); int b = t / int(channels);
+    int myFlat = id * int(inHeight) * int(inWidth) + ih * int(inWidth) + iw;
+    int outSp = int(outDepth) * int(outHeight) * int(outWidth);
+    float sum = 0.0f;
+    for (int o = 0; o < outSp; o++) {
+        int oIdx = (b * int(channels) + c) * outSp + o;
+        if (indices[oIdx] == myFlat) sum += gradOutput[oIdx];
+    }
+    gradInput[idx] = sum;
+}
 ";
 
     #endregion

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalKernels.cs
@@ -2575,6 +2575,59 @@ kernel void global_avgpool(
     }
     output[b * channels + c] = sum / float(spatial_size);
 }
+
+// Transposed 2D convolution (gather form): one thread per output element, accumulating over the input
+// positions that scatter into it. Mirrors the verified OpenCL/CUDA conv_transpose2d math. Output-pad
+// rows/cols naturally compute 0 (no valid input maps to them), so outputPad needs no special handling.
+// weights layout: [inChannels, outChannels, kH, kW].
+kernel void conv_transpose2d(
+    device const float* inp [[buffer(0)]],
+    device const float* wgt [[buffer(1)]],
+    device float* outp [[buffer(2)]],
+    constant uint& batch [[buffer(3)]],
+    constant uint& inChannels [[buffer(4)]],
+    constant uint& inHeight [[buffer(5)]],
+    constant uint& inWidth [[buffer(6)]],
+    constant uint& outChannels [[buffer(7)]],
+    constant uint& outHeight [[buffer(8)]],
+    constant uint& outWidth [[buffer(9)]],
+    constant uint& kernelH [[buffer(10)]],
+    constant uint& kernelW [[buffer(11)]],
+    constant uint& strideH [[buffer(12)]],
+    constant uint& strideW [[buffer(13)]],
+    constant uint& padH [[buffer(14)]],
+    constant uint& padW [[buffer(15)]],
+    uint gid [[thread_position_in_grid]])
+{
+    uint total = batch * outChannels * outHeight * outWidth;
+    if (gid >= total) return;
+    uint idx = gid;
+    uint ow = idx % outWidth;
+    uint t = idx / outWidth;
+    uint oh = t % outHeight;
+    t = t / outHeight;
+    uint oc = t % outChannels;
+    uint b = t / outChannels;
+    float sum = 0.0f;
+    for (uint ic = 0; ic < inChannels; ic++) {
+        for (uint kh = 0; kh < kernelH; kh++) {
+            for (uint kw = 0; kw < kernelW; kw++) {
+                int ihBase = int(oh + padH) - int(kh);
+                int iwBase = int(ow + padW) - int(kw);
+                if ((ihBase % int(strideH)) == 0 && (iwBase % int(strideW)) == 0) {
+                    int ih = ihBase / int(strideH);
+                    int iw = iwBase / int(strideW);
+                    if (ih >= 0 && ih < int(inHeight) && iw >= 0 && iw < int(inWidth)) {
+                        float inVal = inp[((b * inChannels + ic) * inHeight + uint(ih)) * inWidth + uint(iw)];
+                        float wVal = wgt[((ic * outChannels + oc) * kernelH + kh) * kernelW + kw];
+                        sum += inVal * wVal;
+                    }
+                }
+            }
+        }
+    }
+    outp[((b * outChannels + oc) * outHeight + oh) * outWidth + ow] = sum;
+}
 ";
 
     #endregion

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalKernels.cs
@@ -2578,7 +2578,9 @@ kernel void global_avgpool(
 
 // Transposed 2D convolution (gather form): one thread per output element, accumulating over the input
 // positions that scatter into it. Mirrors the verified OpenCL/CUDA conv_transpose2d math. Output-pad
-// rows/cols naturally compute 0 (no valid input maps to them), so outputPad needs no special handling.
+// rows/cols naturally compute 0 (no valid input maps to them) because outHeight/outWidth already encode the
+// output padding, so outputPadH/outputPadW are accepted for cross-backend signature parity (OpenCL/CUDA/HIP
+// declare them as the final two parameters) but need no special handling in the gather body.
 // weights layout: [inChannels, outChannels, kH, kW].
 kernel void conv_transpose2d(
     device const float* inp [[buffer(0)]],
@@ -2597,8 +2599,11 @@ kernel void conv_transpose2d(
     constant uint& strideW [[buffer(13)]],
     constant uint& padH [[buffer(14)]],
     constant uint& padW [[buffer(15)]],
+    constant uint& outputPadH [[buffer(16)]],
+    constant uint& outputPadW [[buffer(17)]],
     uint gid [[thread_position_in_grid]])
 {
+    (void)outputPadH; (void)outputPadW;
     uint total = batch * outChannels * outHeight * outWidth;
     if (gid >= total) return;
     uint idx = gid;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalKernels.cs
@@ -3156,6 +3156,327 @@ kernel void fold(
       }
     outp[idx] = sum;
 }
+
+// ---- Locally connected conv2d (issue #646): gather-form, weights [outH,outW,outC,inC,kH,kW], no padding ----
+kernel void locally_connected_conv2d(
+    device const float* inp [[buffer(0)]], device const float* wgt [[buffer(1)]], device const float* bias [[buffer(2)]], device float* outp [[buffer(3)]],
+    constant uint& batch [[buffer(4)]], constant uint& inChannels [[buffer(5)]],
+    constant uint& inHeight [[buffer(6)]], constant uint& inWidth [[buffer(7)]],
+    constant uint& outChannels [[buffer(8)]], constant uint& outHeight [[buffer(9)]], constant uint& outWidth [[buffer(10)]],
+    constant uint& kernelH [[buffer(11)]], constant uint& kernelW [[buffer(12)]],
+    constant uint& strideH [[buffer(13)]], constant uint& strideW [[buffer(14)]],
+    uint gid [[thread_position_in_grid]])
+{
+    uint total = batch * outChannels * outHeight * outWidth;
+    if (gid >= total) return;
+    int idx = int(gid);
+    int ow = idx % int(outWidth); int t = idx / int(outWidth);
+    int oh = t % int(outHeight); t = t / int(outHeight);
+    int oc = t % int(outChannels); int b = t / int(outChannels);
+    int wBase = ((oh * int(outWidth) + ow) * int(outChannels) + oc) * int(inChannels) * int(kernelH) * int(kernelW);
+    float sum = bias[oc];
+    for (int ic = 0; ic < int(inChannels); ic++)
+      for (int kh = 0; kh < int(kernelH); kh++)
+        for (int kw = 0; kw < int(kernelW); kw++) {
+            int ih = oh * int(strideH) + kh; int iw = ow * int(strideW) + kw;
+            if (ih >= 0 && ih < int(inHeight) && iw >= 0 && iw < int(inWidth))
+                sum += inp[((b * int(inChannels) + ic) * int(inHeight) + ih) * int(inWidth) + iw]
+                     * wgt[wBase + (ic * int(kernelH) + kh) * int(kernelW) + kw];
+        }
+    outp[((b * int(outChannels) + oc) * int(outHeight) + oh) * int(outWidth) + ow] = sum;
+}
+
+kernel void locally_connected_conv2d_backward_input(
+    device const float* gradOutput [[buffer(0)]], device const float* wgt [[buffer(1)]], device float* gradInput [[buffer(2)]],
+    constant uint& batch [[buffer(3)]], constant uint& inChannels [[buffer(4)]],
+    constant uint& inHeight [[buffer(5)]], constant uint& inWidth [[buffer(6)]],
+    constant uint& outChannels [[buffer(7)]], constant uint& outHeight [[buffer(8)]], constant uint& outWidth [[buffer(9)]],
+    constant uint& kernelH [[buffer(10)]], constant uint& kernelW [[buffer(11)]],
+    constant uint& strideH [[buffer(12)]], constant uint& strideW [[buffer(13)]],
+    uint gid [[thread_position_in_grid]])
+{
+    uint total = batch * inChannels * inHeight * inWidth;
+    if (gid >= total) return;
+    int idx = int(gid);
+    int b = idx / (int(inChannels) * int(inHeight) * int(inWidth));
+    int r = idx % (int(inChannels) * int(inHeight) * int(inWidth));
+    int ic = r / (int(inHeight) * int(inWidth));
+    int r2 = r % (int(inHeight) * int(inWidth));
+    int ih = r2 / int(inWidth); int iw = r2 % int(inWidth);
+    float sum = 0.0f;
+    for (int oh = 0; oh < int(outHeight); oh++)
+      for (int ow = 0; ow < int(outWidth); ow++) {
+          int khr = ih - oh * int(strideH); int kwr = iw - ow * int(strideW);
+          if (khr >= 0 && khr < int(kernelH) && kwr >= 0 && kwr < int(kernelW)) {
+              for (int oc = 0; oc < int(outChannels); oc++) {
+                  float g = gradOutput[((b * int(outChannels) + oc) * int(outHeight) + oh) * int(outWidth) + ow];
+                  int wIdx = (((oh * int(outWidth) + ow) * int(outChannels) + oc) * int(inChannels) + ic) * int(kernelH) * int(kernelW) + khr * int(kernelW) + kwr;
+                  sum += g * wgt[wIdx];
+              }
+          }
+      }
+    gradInput[idx] = sum;
+}
+
+kernel void locally_connected_conv2d_backward_weights(
+    device const float* gradOutput [[buffer(0)]], device const float* inp [[buffer(1)]], device float* gradWeights [[buffer(2)]],
+    constant uint& batch [[buffer(3)]], constant uint& inChannels [[buffer(4)]],
+    constant uint& inHeight [[buffer(5)]], constant uint& inWidth [[buffer(6)]],
+    constant uint& outChannels [[buffer(7)]], constant uint& outHeight [[buffer(8)]], constant uint& outWidth [[buffer(9)]],
+    constant uint& kernelH [[buffer(10)]], constant uint& kernelW [[buffer(11)]],
+    constant uint& strideH [[buffer(12)]], constant uint& strideW [[buffer(13)]],
+    uint gid [[thread_position_in_grid]])
+{
+    uint total = outHeight * outWidth * outChannels * inChannels * kernelH * kernelW;
+    if (gid >= total) return;
+    int idx = int(gid); int tmp = idx;
+    int kw = tmp % int(kernelW); tmp /= int(kernelW);
+    int kh = tmp % int(kernelH); tmp /= int(kernelH);
+    int ic = tmp % int(inChannels); tmp /= int(inChannels);
+    int oc = tmp % int(outChannels); tmp /= int(outChannels);
+    int ow = tmp % int(outWidth); tmp /= int(outWidth);
+    int oh = tmp;
+    int ih = oh * int(strideH) + kh; int iw = ow * int(strideW) + kw;
+    float sum = 0.0f;
+    if (ih >= 0 && ih < int(inHeight) && iw >= 0 && iw < int(inWidth))
+        for (int b = 0; b < int(batch); b++)
+            sum += gradOutput[((b * int(outChannels) + oc) * int(outHeight) + oh) * int(outWidth) + ow]
+                 * inp[((b * int(inChannels) + ic) * int(inHeight) + ih) * int(inWidth) + iw];
+    gradWeights[idx] = sum;
+}
+
+kernel void locally_connected_conv2d_backward_bias(
+    device const float* gradOutput [[buffer(0)]], device float* gradBias [[buffer(1)]],
+    constant uint& batch [[buffer(2)]], constant uint& outChannels [[buffer(3)]],
+    constant uint& outHeight [[buffer(4)]], constant uint& outWidth [[buffer(5)]],
+    uint gid [[thread_position_in_grid]])
+{
+    if (gid >= outChannels) return;
+    int oc = int(gid);
+    float sum = 0.0f;
+    for (int b = 0; b < int(batch); b++)
+      for (int oh = 0; oh < int(outHeight); oh++)
+        for (int ow = 0; ow < int(outWidth); ow++)
+            sum += gradOutput[((b * int(outChannels) + oc) * int(outHeight) + oh) * int(outWidth) + ow];
+    gradBias[oc] = sum;
+}
+
+// ---- Deformable conv2d (DCNv2): gather-form, shared bilinear sampler ----
+inline float dcnBilinear(device const float* inp, int b, int c, float h, float w, int inChannels, int inHeight, int inWidth) {
+    int hl = int(floor(h)); int wl = int(floor(w)); int hh = hl + 1; int wh = wl + 1;
+    float lh = h - float(hl); float lw = w - float(wl); float hhf = 1.0f - lh; float hwf = 1.0f - lw;
+    float v1 = 0.0f, v2 = 0.0f, v3 = 0.0f, v4 = 0.0f;
+    if (hl >= 0 && hl < inHeight && wl >= 0 && wl < inWidth) v1 = inp[((b*inChannels+c)*inHeight+hl)*inWidth+wl];
+    if (hl >= 0 && hl < inHeight && wh >= 0 && wh < inWidth) v2 = inp[((b*inChannels+c)*inHeight+hl)*inWidth+wh];
+    if (hh >= 0 && hh < inHeight && wl >= 0 && wl < inWidth) v3 = inp[((b*inChannels+c)*inHeight+hh)*inWidth+wl];
+    if (hh >= 0 && hh < inHeight && wh >= 0 && wh < inWidth) v4 = inp[((b*inChannels+c)*inHeight+hh)*inWidth+wh];
+    return hhf*hwf*v1 + hhf*lw*v2 + lh*hwf*v3 + lh*lw*v4;
+}
+
+kernel void deformable_conv2d(
+    device const float* inp [[buffer(0)]], device const float* wgt [[buffer(1)]], device const float* offsets [[buffer(2)]], device const float* mask [[buffer(3)]], device float* outp [[buffer(4)]],
+    constant uint& batch [[buffer(5)]], constant uint& inChannels [[buffer(6)]], constant uint& inHeight [[buffer(7)]], constant uint& inWidth [[buffer(8)]],
+    constant uint& outChannels [[buffer(9)]], constant uint& outHeight [[buffer(10)]], constant uint& outWidth [[buffer(11)]], constant uint& kernelH [[buffer(12)]], constant uint& kernelW [[buffer(13)]],
+    constant uint& strideH [[buffer(14)]], constant uint& strideW [[buffer(15)]], constant uint& padH [[buffer(16)]], constant uint& padW [[buffer(17)]], constant uint& dilationH [[buffer(18)]], constant uint& dilationW [[buffer(19)]], constant uint& groups [[buffer(20)]], constant uint& deformGroups [[buffer(21)]],
+    uint gid [[thread_position_in_grid]])
+{
+    uint total = batch * outChannels * outHeight * outWidth;
+    if (gid >= total) return;
+    int idx = int(gid);
+    int ow = idx % int(outWidth); int t = idx / int(outWidth);
+    int oh = t % int(outHeight); t = t / int(outHeight);
+    int oc = t % int(outChannels); int b = t / int(outChannels);
+    int g = oc / (int(outChannels) / int(groups));
+    int dg = oc / (int(outChannels) / int(deformGroups));
+    int icpg = int(inChannels) / int(groups); int ks = int(kernelH) * int(kernelW);
+    int baseH = oh * int(strideH) - int(padH); int baseW = ow * int(strideW) - int(padW);
+    float sum = 0.0f;
+    for (int ic = 0; ic < icpg; ic++) {
+        int aic = g * icpg + ic;
+        for (int kh = 0; kh < int(kernelH); kh++)
+          for (int kw = 0; kw < int(kernelW); kw++) {
+              int ki = kh * int(kernelW) + kw;
+              int oIx = ((b*int(deformGroups)+dg)*2*ks + ki)*int(outHeight)*int(outWidth) + oh*int(outWidth) + ow;
+              int oIy = ((b*int(deformGroups)+dg)*2*ks + ks + ki)*int(outHeight)*int(outWidth) + oh*int(outWidth) + ow;
+              float h = float(baseH) + float(kh*int(dilationH)) + offsets[oIx];
+              float w = float(baseW) + float(kw*int(dilationW)) + offsets[oIy];
+              float val = dcnBilinear(inp, b, aic, h, w, int(inChannels), int(inHeight), int(inWidth));
+              int mIx = ((b*int(deformGroups)+dg)*ks + ki)*int(outHeight)*int(outWidth) + oh*int(outWidth) + ow;
+              val *= mask[mIx];
+              sum += val * wgt[((oc*icpg+ic)*int(kernelH)+kh)*int(kernelW)+kw];
+          }
+    }
+    outp[((b*int(outChannels)+oc)*int(outHeight)+oh)*int(outWidth)+ow] = sum;
+}
+
+kernel void deformable_conv2d_backward_input(
+    device const float* gradOutput [[buffer(0)]], device const float* wgt [[buffer(1)]], device const float* offsets [[buffer(2)]], device const float* mask [[buffer(3)]], device float* gradInput [[buffer(4)]],
+    constant uint& batch [[buffer(5)]], constant uint& inChannels [[buffer(6)]], constant uint& inHeight [[buffer(7)]], constant uint& inWidth [[buffer(8)]],
+    constant uint& outChannels [[buffer(9)]], constant uint& outHeight [[buffer(10)]], constant uint& outWidth [[buffer(11)]], constant uint& kernelH [[buffer(12)]], constant uint& kernelW [[buffer(13)]],
+    constant uint& strideH [[buffer(14)]], constant uint& strideW [[buffer(15)]], constant uint& padH [[buffer(16)]], constant uint& padW [[buffer(17)]], constant uint& dilationH [[buffer(18)]], constant uint& dilationW [[buffer(19)]], constant uint& groups [[buffer(20)]], constant uint& deformGroups [[buffer(21)]],
+    uint gid [[thread_position_in_grid]])
+{
+    uint total = batch * inChannels * inHeight * inWidth;
+    if (gid >= total) return;
+    int idx = int(gid);
+    int b = idx / (int(inChannels)*int(inHeight)*int(inWidth));
+    int r1 = idx % (int(inChannels)*int(inHeight)*int(inWidth));
+    int ic = r1 / (int(inHeight)*int(inWidth));
+    int r2 = r1 % (int(inHeight)*int(inWidth));
+    int ih = r2 / int(inWidth); int iw = r2 % int(inWidth);
+    int g = ic / (int(inChannels) / int(groups));
+    int icpg = int(inChannels)/int(groups); int ocpg = int(outChannels)/int(groups); int ks = int(kernelH)*int(kernelW);
+    float sum = 0.0f;
+    for (int oc = g*ocpg; oc < (g+1)*ocpg; oc++) {
+        int dg = oc / (int(outChannels) / int(deformGroups));
+        int icLocal = ic - g*icpg;
+        for (int oh = 0; oh < int(outHeight); oh++)
+          for (int ow = 0; ow < int(outWidth); ow++) {
+              int baseH = oh*int(strideH) - int(padH); int baseW = ow*int(strideW) - int(padW);
+              for (int kh = 0; kh < int(kernelH); kh++)
+                for (int kw = 0; kw < int(kernelW); kw++) {
+                    int ki = kh*int(kernelW) + kw;
+                    int oIx = ((b*int(deformGroups)+dg)*2*ks + ki)*int(outHeight)*int(outWidth) + oh*int(outWidth) + ow;
+                    int oIy = ((b*int(deformGroups)+dg)*2*ks + ks + ki)*int(outHeight)*int(outWidth) + oh*int(outWidth) + ow;
+                    float h = float(baseH) + float(kh*int(dilationH)) + offsets[oIx];
+                    float w = float(baseW) + float(kw*int(dilationW)) + offsets[oIy];
+                    int hl = int(floor(h)); int wl = int(floor(w)); int hh = hl+1; int wh = wl+1;
+                    float lh = h - float(hl); float lw = w - float(wl); float hhf = 1.0f-lh; float hwf = 1.0f-lw;
+                    float wc = 0.0f;
+                    if (ih == hl && iw == wl) wc = hhf*hwf;
+                    else if (ih == hl && iw == wh) wc = hhf*lw;
+                    else if (ih == hh && iw == wl) wc = lh*hwf;
+                    else if (ih == hh && iw == wh) wc = lh*lw;
+                    else continue;
+                    float go = gradOutput[((b*int(outChannels)+oc)*int(outHeight)+oh)*int(outWidth)+ow];
+                    float contrib = go * wgt[((oc*icpg+icLocal)*int(kernelH)+kh)*int(kernelW)+kw] * wc;
+                    int mIx = ((b*int(deformGroups)+dg)*ks + ki)*int(outHeight)*int(outWidth) + oh*int(outWidth) + ow;
+                    contrib *= mask[mIx];
+                    sum += contrib;
+                }
+          }
+    }
+    gradInput[idx] = sum;
+}
+
+kernel void deformable_conv2d_backward_weights(
+    device const float* gradOutput [[buffer(0)]], device const float* inp [[buffer(1)]], device const float* offsets [[buffer(2)]], device const float* mask [[buffer(3)]], device float* gradWeights [[buffer(4)]],
+    constant uint& batch [[buffer(5)]], constant uint& inChannels [[buffer(6)]], constant uint& inHeight [[buffer(7)]], constant uint& inWidth [[buffer(8)]],
+    constant uint& outChannels [[buffer(9)]], constant uint& outHeight [[buffer(10)]], constant uint& outWidth [[buffer(11)]], constant uint& kernelH [[buffer(12)]], constant uint& kernelW [[buffer(13)]],
+    constant uint& strideH [[buffer(14)]], constant uint& strideW [[buffer(15)]], constant uint& padH [[buffer(16)]], constant uint& padW [[buffer(17)]], constant uint& dilationH [[buffer(18)]], constant uint& dilationW [[buffer(19)]], constant uint& groups [[buffer(20)]], constant uint& deformGroups [[buffer(21)]],
+    uint gid [[thread_position_in_grid]])
+{
+    int icpg = int(inChannels)/int(groups);
+    uint total = outChannels * uint(icpg) * kernelH * kernelW;
+    if (gid >= total) return;
+    int idx = int(gid); int tmp = idx;
+    int kw = tmp % int(kernelW); tmp /= int(kernelW);
+    int kh = tmp % int(kernelH); tmp /= int(kernelH);
+    int icLocal = tmp % icpg; tmp /= icpg;
+    int oc = tmp;
+    int g = oc / (int(outChannels)/int(groups));
+    int dg = oc / (int(outChannels)/int(deformGroups));
+    int ic = g*icpg + icLocal; int ks = int(kernelH)*int(kernelW); int ki = kh*int(kernelW) + kw;
+    float sum = 0.0f;
+    for (int b = 0; b < int(batch); b++)
+      for (int oh = 0; oh < int(outHeight); oh++)
+        for (int ow = 0; ow < int(outWidth); ow++) {
+            int baseH = oh*int(strideH) - int(padH); int baseW = ow*int(strideW) - int(padW);
+            int oIx = ((b*int(deformGroups)+dg)*2*ks + ki)*int(outHeight)*int(outWidth) + oh*int(outWidth) + ow;
+            int oIy = ((b*int(deformGroups)+dg)*2*ks + ks + ki)*int(outHeight)*int(outWidth) + oh*int(outWidth) + ow;
+            float h = float(baseH) + float(kh*int(dilationH)) + offsets[oIx];
+            float w = float(baseW) + float(kw*int(dilationW)) + offsets[oIy];
+            float iv = dcnBilinear(inp, b, ic, h, w, int(inChannels), int(inHeight), int(inWidth));
+            int mIx = ((b*int(deformGroups)+dg)*ks + ki)*int(outHeight)*int(outWidth) + oh*int(outWidth) + ow;
+            iv *= mask[mIx];
+            sum += gradOutput[((b*int(outChannels)+oc)*int(outHeight)+oh)*int(outWidth)+ow] * iv;
+        }
+    gradWeights[idx] = sum;
+}
+
+kernel void deformable_conv2d_backward_offset(
+    device const float* gradOutput [[buffer(0)]], device const float* inp [[buffer(1)]], device const float* wgt [[buffer(2)]], device const float* offsets [[buffer(3)]], device const float* mask [[buffer(4)]], device float* gradOffsets [[buffer(5)]],
+    constant uint& batch [[buffer(6)]], constant uint& inChannels [[buffer(7)]], constant uint& inHeight [[buffer(8)]], constant uint& inWidth [[buffer(9)]],
+    constant uint& outChannels [[buffer(10)]], constant uint& outHeight [[buffer(11)]], constant uint& outWidth [[buffer(12)]], constant uint& kernelH [[buffer(13)]], constant uint& kernelW [[buffer(14)]],
+    constant uint& strideH [[buffer(15)]], constant uint& strideW [[buffer(16)]], constant uint& padH [[buffer(17)]], constant uint& padW [[buffer(18)]], constant uint& dilationH [[buffer(19)]], constant uint& dilationW [[buffer(20)]], constant uint& groups [[buffer(21)]], constant uint& deformGroups [[buffer(22)]],
+    uint gid [[thread_position_in_grid]])
+{
+    int ks = int(kernelH)*int(kernelW);
+    uint total = batch * deformGroups * 2u * uint(ks) * outHeight * outWidth;
+    if (gid >= total) return;
+    int idx = int(gid); int tmp = idx;
+    int ow = tmp % int(outWidth); tmp /= int(outWidth);
+    int oh = tmp % int(outHeight); tmp /= int(outHeight);
+    int comp = tmp % (2*ks); tmp /= (2*ks);
+    int dg = tmp % int(deformGroups); tmp /= int(deformGroups);
+    int b = tmp;
+    int isY = comp >= ks ? 1 : 0;
+    int ki = comp % ks; int kh = ki / int(kernelW); int kw = ki % int(kernelW);
+    int oIx = ((b*int(deformGroups)+dg)*2*ks + ki)*int(outHeight)*int(outWidth) + oh*int(outWidth) + ow;
+    int oIy = ((b*int(deformGroups)+dg)*2*ks + ks + ki)*int(outHeight)*int(outWidth) + oh*int(outWidth) + ow;
+    int baseH = oh*int(strideH) - int(padH); int baseW = ow*int(strideW) - int(padW);
+    float h = float(baseH) + float(kh*int(dilationH)) + offsets[oIx];
+    float w = float(baseW) + float(kw*int(dilationW)) + offsets[oIy];
+    int hl = int(floor(h)); int wl = int(floor(w)); int hh = hl+1; int wh = wl+1;
+    float lh = h - float(hl); float lw = w - float(wl);
+    float sum = 0.0f;
+    int icpg = int(inChannels)/int(groups); int ocpg = int(outChannels)/int(groups);
+    for (int oco = 0; oco < int(outChannels)/int(deformGroups); oco++) {
+        int oc = dg * (int(outChannels)/int(deformGroups)) + oco;
+        int g = oc / ocpg;
+        float go = gradOutput[((b*int(outChannels)+oc)*int(outHeight)+oh)*int(outWidth)+ow];
+        int mIx = ((b*int(deformGroups)+dg)*ks + ki)*int(outHeight)*int(outWidth) + oh*int(outWidth) + ow;
+        go *= mask[mIx];
+        for (int ic = g*icpg; ic < (g+1)*icpg; ic++) {
+            int icLocal = ic - g*icpg;
+            float wv = wgt[((oc*icpg+icLocal)*int(kernelH)+kh)*int(kernelW)+kw];
+            float v1 = 0.0f, v2 = 0.0f, v3 = 0.0f, v4 = 0.0f;
+            if (hl >= 0 && hl < int(inHeight) && wl >= 0 && wl < int(inWidth)) v1 = inp[((b*int(inChannels)+ic)*int(inHeight)+hl)*int(inWidth)+wl];
+            if (hl >= 0 && hl < int(inHeight) && wh >= 0 && wh < int(inWidth)) v2 = inp[((b*int(inChannels)+ic)*int(inHeight)+hl)*int(inWidth)+wh];
+            if (hh >= 0 && hh < int(inHeight) && wl >= 0 && wl < int(inWidth)) v3 = inp[((b*int(inChannels)+ic)*int(inHeight)+hh)*int(inWidth)+wl];
+            if (hh >= 0 && hh < int(inHeight) && wh >= 0 && wh < int(inWidth)) v4 = inp[((b*int(inChannels)+ic)*int(inHeight)+hh)*int(inWidth)+wh];
+            if (isY == 0) sum += go * wv * ((1.0f-lw)*(v3-v1) + lw*(v4-v2));
+            else sum += go * wv * ((1.0f-lh)*(v2-v1) + lh*(v4-v3));
+        }
+    }
+    gradOffsets[idx] = sum;
+}
+
+kernel void deformable_conv2d_backward_mask(
+    device const float* gradOutput [[buffer(0)]], device const float* inp [[buffer(1)]], device const float* wgt [[buffer(2)]], device const float* offsets [[buffer(3)]], device float* gradMask [[buffer(4)]],
+    constant uint& batch [[buffer(5)]], constant uint& inChannels [[buffer(6)]], constant uint& inHeight [[buffer(7)]], constant uint& inWidth [[buffer(8)]],
+    constant uint& outChannels [[buffer(9)]], constant uint& outHeight [[buffer(10)]], constant uint& outWidth [[buffer(11)]], constant uint& kernelH [[buffer(12)]], constant uint& kernelW [[buffer(13)]],
+    constant uint& strideH [[buffer(14)]], constant uint& strideW [[buffer(15)]], constant uint& padH [[buffer(16)]], constant uint& padW [[buffer(17)]], constant uint& dilationH [[buffer(18)]], constant uint& dilationW [[buffer(19)]], constant uint& groups [[buffer(20)]], constant uint& deformGroups [[buffer(21)]],
+    uint gid [[thread_position_in_grid]])
+{
+    int ks = int(kernelH)*int(kernelW);
+    uint total = batch * deformGroups * uint(ks) * outHeight * outWidth;
+    if (gid >= total) return;
+    int idx = int(gid); int tmp = idx;
+    int ow = tmp % int(outWidth); tmp /= int(outWidth);
+    int oh = tmp % int(outHeight); tmp /= int(outHeight);
+    int ki = tmp % ks; tmp /= ks;
+    int dg = tmp % int(deformGroups); tmp /= int(deformGroups);
+    int b = tmp;
+    int kh = ki / int(kernelW); int kw = ki % int(kernelW);
+    int oIx = ((b*int(deformGroups)+dg)*2*ks + ki)*int(outHeight)*int(outWidth) + oh*int(outWidth) + ow;
+    int oIy = ((b*int(deformGroups)+dg)*2*ks + ks + ki)*int(outHeight)*int(outWidth) + oh*int(outWidth) + ow;
+    float h = float(oh*int(strideH) - int(padH)) + float(kh*int(dilationH)) + offsets[oIx];
+    float w = float(ow*int(strideW) - int(padW)) + float(kw*int(dilationW)) + offsets[oIy];
+    float sum = 0.0f;
+    int icpg = int(inChannels)/int(groups); int ocpg = int(outChannels)/int(groups);
+    for (int oco = 0; oco < int(outChannels)/int(deformGroups); oco++) {
+        int oc = dg * (int(outChannels)/int(deformGroups)) + oco;
+        int g = oc / ocpg;
+        float go = gradOutput[((b*int(outChannels)+oc)*int(outHeight)+oh)*int(outWidth)+ow];
+        for (int ic = g*icpg; ic < (g+1)*icpg; ic++) {
+            int icLocal = ic - g*icpg;
+            float wv = wgt[((oc*icpg+icLocal)*int(kernelH)+kh)*int(kernelW)+kw];
+            sum += go * wv * dcnBilinear(inp, b, ic, h, w, int(inChannels), int(inHeight), int(inWidth));
+        }
+    }
+    gradMask[idx] = sum;
+}
 ";
 
     #endregion

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -6144,6 +6144,11 @@ KERNEL VARIANTS (A/B testing):
             k.SetArg(arg++, strideW);
             k.SetArg(arg++, padH);
             k.SetArg(arg++, padW);
+            // The conv_transpose2d kernel declares outputPadH/outputPadW as the last two parameters. OpenCL
+            // requires EVERY declared kernel argument to be bound before enqueue, so omitting these two raised
+            // CL_INVALID_KERNEL_ARGS (-52) at launch and the engine silently fell back to the CPU reference.
+            k.SetArg(arg++, outputPadH);
+            k.SetArg(arg++, outputPadW);
 
             int localX = 8, localY = 8, localZ = 1;
             k.Execute3D(outWidth, outHeight, batch * outChannels, localX, localY, localZ);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend2.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend2.cs
@@ -8,6 +8,26 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.Vulkan;
 
 public sealed unsafe partial class VulkanBackend
 {
+    // Shared dispatch for the conv/pool GLSL kernels (issue #646): compile-or-cache the pipeline, bind the SSBOs,
+    // push the int params, and launch a 1D grid over `threads` output elements. Returns false when the pipeline
+    // could not be built (no libshaderc at runtime) so the caller falls back to the CPU reference. Mirrors the
+    // DispatchUnary pattern. NOTE: validated only on a Vulkan runner — the dev box has no libshaderc.
+    private bool TryDispatchConvPoolGlsl(string glsl, uint[] pushInts, int threads, params IGpuBuffer[] buffers)
+    {
+        if (threads <= 0) return false;
+        var pipeline = GetOrCreateGlslPipeline(glsl, buffers.Length, (uint)(pushInts.Length * sizeof(uint)));
+        if (pipeline is null) return false;
+        var storages = new VulkanBuffer[buffers.Length];
+        for (int i = 0; i < buffers.Length; i++) storages[i] = AsVulkan(buffers[i]).Storage;
+        var threadRes = _device.AcquireThreadResources();
+        lock (_computeLock)
+        {
+            pipeline.UpdateDescriptorSet(storages);
+            RecordAndExecuteWithPushData(pipeline, threads, pushInts, (uint)(pushInts.Length * sizeof(uint)), threadRes);
+        }
+        return true;
+    }
+
     #region Convolution Operations
 
     public void Conv2D(IGpuBuffer input, IGpuBuffer kernel, IGpuBuffer output,
@@ -907,6 +927,20 @@ void main() {
         int strideH, int strideW, int padH, int padW)
     {
         EnsureInitialized();
+        try
+        {
+            // GPU path requires the indices SSBO (binding 2). When the caller wants no indices, use the CPU path.
+            if (indices is not null)
+            {
+                int total = batch * channels * outHeight * outWidth;
+                var pc = new uint[] { (uint)batch, (uint)channels, (uint)inHeight, (uint)inWidth,
+                    (uint)outHeight, (uint)outWidth, (uint)kernelH, (uint)kernelW,
+                    (uint)strideH, (uint)strideW, (uint)padH, (uint)padW };
+                if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.MaxPool2D, pc, total, input, output, indices)) return;
+            }
+        }
+        catch { /* fall through to CPU reference */ }
+
         var inp = DownloadBuffer(input);
         var outp = new float[batch * channels * outHeight * outWidth];
         float[]? idx = indices is not null ? new float[batch * channels * outHeight * outWidth] : null;
@@ -968,6 +1002,16 @@ void main() {
         int strideH, int strideW, int padH, int padW, bool countIncludePad)
     {
         EnsureInitialized();
+        try
+        {
+            int total = batch * channels * outHeight * outWidth;
+            var pc = new uint[] { (uint)batch, (uint)channels, (uint)inHeight, (uint)inWidth,
+                (uint)outHeight, (uint)outWidth, (uint)kernelH, (uint)kernelW,
+                (uint)strideH, (uint)strideW, (uint)padH, (uint)padW, (uint)(countIncludePad ? 1 : 0) };
+            if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.AvgPool2D, pc, total, input, output)) return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var inp = DownloadBuffer(input);
         var outp = new float[batch * channels * outHeight * outWidth];
         for (int b = 0; b < batch; b++)
@@ -999,6 +1043,16 @@ void main() {
         int strideH, int strideW, int padH, int padW, bool countIncludePad)
     {
         EnsureInitialized();
+        try
+        {
+            int total = batch * channels * inHeight * inWidth;
+            var pc = new uint[] { (uint)batch, (uint)channels, (uint)inHeight, (uint)inWidth,
+                (uint)outHeight, (uint)outWidth, (uint)kernelH, (uint)kernelW,
+                (uint)strideH, (uint)strideW, (uint)padH, (uint)padW, (uint)(countIncludePad ? 1 : 0) };
+            if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.AvgPool2DBackward, pc, total, gradOutput, gradInput)) return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var go = DownloadBuffer(gradOutput);
         var gi = new float[batch * channels * inHeight * inWidth];
         for (int b = 0; b < batch; b++)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend2.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend2.cs
@@ -531,6 +531,19 @@ void main() {
         int kernelH, int kernelW, int strideH, int strideW)
     {
         EnsureInitialized();
+        try
+        {
+            // GPU path needs the bias SSBO (binding 3); the no-bias case uses the CPU reference.
+            if (bias is not null)
+            {
+                int total = batch * outChannels * outHeight * outWidth;
+                var pc = new uint[] { (uint)batch, (uint)inChannels, (uint)inHeight, (uint)inWidth,
+                    (uint)outChannels, (uint)outHeight, (uint)outWidth, (uint)kernelH, (uint)kernelW, (uint)strideH, (uint)strideW };
+                if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.LocallyConnectedConv2D, pc, total, input, weights, bias, output)) return;
+            }
+        }
+        catch { /* fall through to CPU reference */ }
+
         var inp = DownloadBuffer(input);
         var w = DownloadBuffer(weights);
         float[]? bi = bias is not null ? DownloadBuffer(bias) : null;
@@ -563,6 +576,15 @@ void main() {
         int kernelH, int kernelW, int strideH, int strideW)
     {
         EnsureInitialized();
+        try
+        {
+            int total = batch * inChannels * inHeight * inWidth;
+            var pc = new uint[] { (uint)batch, (uint)inChannels, (uint)inHeight, (uint)inWidth,
+                (uint)outChannels, (uint)outHeight, (uint)outWidth, (uint)kernelH, (uint)kernelW, (uint)strideH, (uint)strideW };
+            if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.LocallyConnectedConv2DBackwardInput, pc, total, gradOutput, weights, gradInput)) return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var go = DownloadBuffer(gradOutput);
         var w = DownloadBuffer(weights);
         var gi = new float[batch * inChannels * inHeight * inWidth];
@@ -593,6 +615,15 @@ void main() {
         int kernelH, int kernelW, int strideH, int strideW)
     {
         EnsureInitialized();
+        try
+        {
+            int total = outHeight * outWidth * outChannels * inChannels * kernelH * kernelW;
+            var pc = new uint[] { (uint)batch, (uint)inChannels, (uint)inHeight, (uint)inWidth,
+                (uint)outChannels, (uint)outHeight, (uint)outWidth, (uint)kernelH, (uint)kernelW, (uint)strideH, (uint)strideW };
+            if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.LocallyConnectedConv2DBackwardWeights, pc, total, gradOutput, input, gradWeights)) return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var go = DownloadBuffer(gradOutput);
         var inp = DownloadBuffer(input);
         var gw = new float[outHeight * outWidth * outChannels * inChannels * kernelH * kernelW];
@@ -621,6 +652,13 @@ void main() {
         int batch, int outChannels, int outHeight, int outWidth)
     {
         EnsureInitialized();
+        try
+        {
+            var pc = new uint[] { (uint)batch, (uint)outChannels, (uint)outHeight, (uint)outWidth };
+            if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.LocallyConnectedConv2DBackwardBias, pc, outChannels, gradOutput, gradBias)) return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var go = DownloadBuffer(gradOutput);
         var gb = new float[outChannels];
         for (int b = 0; b < batch; b++)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend2.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend2.cs
@@ -38,6 +38,16 @@ public sealed unsafe partial class VulkanBackend
         int dilationH, int dilationW)
     {
         EnsureInitialized();
+        try
+        {
+            int total = batch * outChannels * outHeight * outWidth;
+            var pc = new uint[] { (uint)batch, (uint)inChannels, (uint)inHeight, (uint)inWidth,
+                (uint)outChannels, (uint)outHeight, (uint)outWidth, (uint)kernelH, (uint)kernelW,
+                (uint)strideH, (uint)strideW, (uint)padH, (uint)padW, (uint)dilationH, (uint)dilationW };
+            if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.Conv2D, pc, total, input, kernel, output)) return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var inp = DownloadBuffer(input);
         var ker = DownloadBuffer(kernel);
         var outp = new float[batch * outChannels * outHeight * outWidth];
@@ -70,6 +80,16 @@ public sealed unsafe partial class VulkanBackend
         int dilationH, int dilationW)
     {
         EnsureInitialized();
+        try
+        {
+            int total = batch * inChannels * inHeight * inWidth;
+            var pc = new uint[] { (uint)batch, (uint)inChannels, (uint)inHeight, (uint)inWidth,
+                (uint)outChannels, (uint)outHeight, (uint)outWidth, (uint)kernelH, (uint)kernelW,
+                (uint)strideH, (uint)strideW, (uint)padH, (uint)padW, (uint)dilationH, (uint)dilationW };
+            if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.Conv2DBackwardInput, pc, total, gradOutput, kernel, gradInput)) return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var go = DownloadBuffer(gradOutput);
         var ker = DownloadBuffer(kernel);
         var gi = new float[batch * inChannels * inHeight * inWidth];
@@ -101,6 +121,16 @@ public sealed unsafe partial class VulkanBackend
         int dilationH, int dilationW)
     {
         EnsureInitialized();
+        try
+        {
+            int total = outChannels * inChannels * kernelH * kernelW;
+            var pc = new uint[] { (uint)batch, (uint)inChannels, (uint)inHeight, (uint)inWidth,
+                (uint)outChannels, (uint)outHeight, (uint)outWidth, (uint)kernelH, (uint)kernelW,
+                (uint)strideH, (uint)strideW, (uint)padH, (uint)padW, (uint)dilationH, (uint)dilationW };
+            if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.Conv2DBackwardKernel, pc, total, input, gradOutput, gradKernel)) return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var inp = DownloadBuffer(input);
         var go = DownloadBuffer(gradOutput);
         var gk = new float[outChannels * inChannels * kernelH * kernelW];
@@ -157,6 +187,17 @@ public sealed unsafe partial class VulkanBackend
         int kernelH, int kernelW, int strideH, int strideW, int padH, int padW)
     {
         EnsureInitialized();
+        try
+        {
+            int oH = (height + 2 * padH - kernelH) / strideH + 1;
+            int oW = (width + 2 * padW - kernelW) / strideW + 1;
+            int total = batch * channels * kernelH * kernelW * oH * oW;
+            var pc = new uint[] { (uint)batch, (uint)channels, (uint)height, (uint)width,
+                (uint)kernelH, (uint)kernelW, (uint)strideH, (uint)strideW, (uint)padH, (uint)padW };
+            if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.Unfold, pc, total, input, output)) return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var inp = DownloadBuffer(input);
         int outH = (height + 2 * padH - kernelH) / strideH + 1;
         int outW = (width + 2 * padW - kernelW) / strideW + 1;
@@ -188,6 +229,15 @@ public sealed unsafe partial class VulkanBackend
         int kernelH, int kernelW, int strideH, int strideW, int padH, int padW)
     {
         EnsureInitialized();
+        try
+        {
+            int total = batch * channels * outputH * outputW;
+            var pc = new uint[] { (uint)batch, (uint)channels, (uint)outputH, (uint)outputW,
+                (uint)kernelH, (uint)kernelW, (uint)strideH, (uint)strideW, (uint)padH, (uint)padW };
+            if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.Fold, pc, total, input, output)) return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var inp = DownloadBuffer(input);
         int unfoldH = (outputH + 2 * padH - kernelH) / strideH + 1;
         int unfoldW = (outputW + 2 * padW - kernelW) / strideW + 1;
@@ -223,6 +273,17 @@ public sealed unsafe partial class VulkanBackend
         int dilationD, int dilationH, int dilationW)
     {
         EnsureInitialized();
+        try
+        {
+            int total = batch * outChannels * outDepth * outHeight * outWidth;
+            var pc = new uint[] { (uint)batch, (uint)inChannels, (uint)inDepth, (uint)inHeight, (uint)inWidth,
+                (uint)outChannels, (uint)outDepth, (uint)outHeight, (uint)outWidth,
+                (uint)kernelD, (uint)kernelH, (uint)kernelW, (uint)strideD, (uint)strideH, (uint)strideW,
+                (uint)padD, (uint)padH, (uint)padW, (uint)dilationD, (uint)dilationH, (uint)dilationW };
+            if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.Conv3D, pc, total, input, kernel, output)) return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var inp = DownloadBuffer(input);
         var ker = DownloadBuffer(kernel);
         var outp = new float[batch * outChannels * outDepth * outHeight * outWidth];
@@ -257,6 +318,16 @@ public sealed unsafe partial class VulkanBackend
         int strideH, int strideW, int padH, int padW)
     {
         EnsureInitialized();
+        try
+        {
+            int total = batch * channels * outHeight * outWidth;
+            var pc = new uint[] { (uint)batch, (uint)channels, (uint)inHeight, (uint)inWidth,
+                (uint)outHeight, (uint)outWidth, (uint)kernelH, (uint)kernelW,
+                (uint)strideH, (uint)strideW, (uint)padH, (uint)padW };
+            if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.DepthwiseConv2D, pc, total, input, kernel, output)) return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var inp = DownloadBuffer(input);
         var ker = DownloadBuffer(kernel);
         var outp = new float[batch * channels * outHeight * outWidth];
@@ -420,6 +491,16 @@ void main() {
         int outputPadH, int outputPadW)
     {
         EnsureInitialized();
+        try
+        {
+            int total = inChannels * outChannels * kernelH * kernelW;
+            var pc = new uint[] { (uint)batch, (uint)inChannels, (uint)inHeight, (uint)inWidth,
+                (uint)outChannels, (uint)outHeight, (uint)outWidth, (uint)kernelH, (uint)kernelW,
+                (uint)strideH, (uint)strideW, (uint)padH, (uint)padW, (uint)outputPadH, (uint)outputPadW };
+            if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.ConvTranspose2DBackwardWeights, pc, total, input, gradOutput, gradKernel)) return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var inp = DownloadBuffer(input);
         var go = DownloadBuffer(gradOutput);
         var gk = new float[inChannels * outChannels * kernelH * kernelW];

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend2.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend2.cs
@@ -260,6 +260,62 @@ public sealed unsafe partial class VulkanBackend
         UploadToBuffer(outp, output);
     }
 
+    // GLSL conv-transpose mirrors the verified OpenCL `conv_transpose2d` gather kernel: each thread owns one
+    // output element and accumulates over the input positions that scatter into it. Output-pad rows/cols naturally
+    // resolve to 0 (no valid input maps to them), so outputPadH/W need no special handling — matching OpenCL/CUDA.
+    private const string ConvTranspose2DGlsl = @"#version 450
+layout(local_size_x = 256) in;
+layout(set=0, binding=0) buffer B0 { float inp[]; };
+layout(set=0, binding=1) buffer B1 { float wgt[]; };
+layout(set=0, binding=2) buffer B2 { float outp[]; };
+layout(push_constant) uniform PC {
+    int batch;
+    int inChannels;
+    int inHeight;
+    int inWidth;
+    int outChannels;
+    int outHeight;
+    int outWidth;
+    int kernelH;
+    int kernelW;
+    int strideH;
+    int strideW;
+    int padH;
+    int padW;
+};
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    int total = batch * outChannels * outHeight * outWidth;
+    if (gid >= uint(total)) return;
+    int idx = int(gid);
+    int ow = idx % outWidth;
+    int t = idx / outWidth;
+    int oh = t % outHeight;
+    t = t / outHeight;
+    int oc = t % outChannels;
+    int b = t / outChannels;
+    float sum = 0.0;
+    for (int ic = 0; ic < inChannels; ic++) {
+        for (int kh = 0; kh < kernelH; kh++) {
+            for (int kw = 0; kw < kernelW; kw++) {
+                int ihBase = oh + padH - kh;
+                int iwBase = ow + padW - kw;
+                if ((ihBase % strideH) == 0 && (iwBase % strideW) == 0) {
+                    int ih = ihBase / strideH;
+                    int iw = iwBase / strideW;
+                    if (ih >= 0 && ih < inHeight && iw >= 0 && iw < inWidth) {
+                        float inVal = inp[((b * inChannels + ic) * inHeight + ih) * inWidth + iw];
+                        // weights layout [inChannels, outChannels, kH, kW]
+                        float wVal = wgt[((ic * outChannels + oc) * kernelH + kh) * kernelW + kw];
+                        sum += inVal * wVal;
+                    }
+                }
+            }
+        }
+    }
+    outp[((b * outChannels + oc) * outHeight + oh) * outWidth + ow] = sum;
+}";
+
     public void ConvTranspose2D(IGpuBuffer input, IGpuBuffer kernel, IGpuBuffer output,
         int batch, int inChannels, int inHeight, int inWidth,
         int outChannels, int outHeight, int outWidth,
@@ -268,12 +324,43 @@ public sealed unsafe partial class VulkanBackend
         int outputPadH, int outputPadW)
     {
         EnsureInitialized();
+
+        // GPU path: real GLSL compute kernel. Requires libshaderc for runtime GLSL→SPIR-V; GetOrCreateGlslPipeline
+        // returns null when it is unavailable, in which case we fall through to the CPU reference below. Any launch
+        // failure also degrades to CPU so results stay correct (issue #646).
+        try
+        {
+            var pipeline = GetOrCreateGlslPipeline(ConvTranspose2DGlsl, 3, 13u * sizeof(uint));
+            if (pipeline is not null)
+            {
+                int total = batch * outChannels * outHeight * outWidth;
+                var pc = new uint[]
+                {
+                    (uint)batch, (uint)inChannels, (uint)inHeight, (uint)inWidth,
+                    (uint)outChannels, (uint)outHeight, (uint)outWidth,
+                    (uint)kernelH, (uint)kernelW, (uint)strideH, (uint)strideW, (uint)padH, (uint)padW
+                };
+                var threadRes = _device.AcquireThreadResources();
+                lock (_computeLock)
+                {
+                    pipeline.UpdateDescriptorSet(AsVulkan(input).Storage, AsVulkan(kernel).Storage, AsVulkan(output).Storage);
+                    RecordAndExecuteWithPushData(pipeline, total, pc, 13u * sizeof(uint), threadRes);
+                }
+                return;
+            }
+        }
+        catch
+        {
+            // fall through to the CPU reference
+        }
+
+        // CPU fallback (correctness safety net when the GPU kernel is unavailable / fails to launch).
         var inp = DownloadBuffer(input);
         var ker = DownloadBuffer(kernel);
         // Output padding restricts valid output range (adds extra rows/columns to one side)
         int effectiveOutH = outHeight - outputPadH;
         int effectiveOutW = outWidth - outputPadW;
-        var outp = new float[batch * outChannels * outHeight * outWidth];
+        var outpArr = new float[batch * outChannels * outHeight * outWidth];
         for (int b = 0; b < batch; b++)
             for (int ic = 0; ic < inChannels; ic++)
                 for (int ih = 0; ih < inHeight; ih++)
@@ -287,11 +374,11 @@ public sealed unsafe partial class VulkanBackend
                                     int oh = ih * strideH - padH + kh;
                                     int ow = iw * strideW - padW + kw;
                                     if (oh >= 0 && oh < effectiveOutH && ow >= 0 && ow < effectiveOutW)
-                                        outp[((b * outChannels + oc) * outHeight + oh) * outWidth + ow]
+                                        outpArr[((b * outChannels + oc) * outHeight + oh) * outWidth + ow]
                                             += val * ker[((ic * outChannels + oc) * kernelH + kh) * kernelW + kw];
                                 }
                     }
-        UploadToBuffer(outp, output);
+        UploadToBuffer(outpArr, output);
     }
 
     public void ConvTranspose2DBackwardInput(IGpuBuffer gradOutput, IGpuBuffer kernel, IGpuBuffer gradInput,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend2.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend2.cs
@@ -46,7 +46,7 @@ public sealed unsafe partial class VulkanBackend
                 (uint)strideH, (uint)strideW, (uint)padH, (uint)padW, (uint)dilationH, (uint)dilationW };
             if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.Conv2D, pc, total, input, kernel, output)) return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var inp = DownloadBuffer(input);
         var ker = DownloadBuffer(kernel);
@@ -88,7 +88,7 @@ public sealed unsafe partial class VulkanBackend
                 (uint)strideH, (uint)strideW, (uint)padH, (uint)padW, (uint)dilationH, (uint)dilationW };
             if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.Conv2DBackwardInput, pc, total, gradOutput, kernel, gradInput)) return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var go = DownloadBuffer(gradOutput);
         var ker = DownloadBuffer(kernel);
@@ -129,7 +129,7 @@ public sealed unsafe partial class VulkanBackend
                 (uint)strideH, (uint)strideW, (uint)padH, (uint)padW, (uint)dilationH, (uint)dilationW };
             if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.Conv2DBackwardKernel, pc, total, input, gradOutput, gradKernel)) return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var inp = DownloadBuffer(input);
         var go = DownloadBuffer(gradOutput);
@@ -196,7 +196,7 @@ public sealed unsafe partial class VulkanBackend
                 (uint)kernelH, (uint)kernelW, (uint)strideH, (uint)strideW, (uint)padH, (uint)padW };
             if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.Unfold, pc, total, input, output)) return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var inp = DownloadBuffer(input);
         int outH = (height + 2 * padH - kernelH) / strideH + 1;
@@ -236,7 +236,7 @@ public sealed unsafe partial class VulkanBackend
                 (uint)kernelH, (uint)kernelW, (uint)strideH, (uint)strideW, (uint)padH, (uint)padW };
             if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.Fold, pc, total, input, output)) return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var inp = DownloadBuffer(input);
         int unfoldH = (outputH + 2 * padH - kernelH) / strideH + 1;
@@ -282,7 +282,7 @@ public sealed unsafe partial class VulkanBackend
                 (uint)padD, (uint)padH, (uint)padW, (uint)dilationD, (uint)dilationH, (uint)dilationW };
             if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.Conv3D, pc, total, input, kernel, output)) return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var inp = DownloadBuffer(input);
         var ker = DownloadBuffer(kernel);
@@ -326,7 +326,7 @@ public sealed unsafe partial class VulkanBackend
                 (uint)strideH, (uint)strideW, (uint)padH, (uint)padW };
             if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.DepthwiseConv2D, pc, total, input, kernel, output)) return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var inp = DownloadBuffer(input);
         var ker = DownloadBuffer(kernel);
@@ -442,7 +442,8 @@ void main() {
         }
         catch
         {
-            // fall through to the CPU reference
+            if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw;
+            // else fall through to the CPU reference
         }
 
         // CPU fallback (correctness safety net when the GPU kernel is unavailable / fails to launch).
@@ -499,7 +500,7 @@ void main() {
                 (uint)strideH, (uint)strideW, (uint)padH, (uint)padW, (uint)outputPadH, (uint)outputPadW };
             if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.ConvTranspose2DBackwardWeights, pc, total, input, gradOutput, gradKernel)) return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var inp = DownloadBuffer(input);
         var go = DownloadBuffer(gradOutput);
@@ -542,7 +543,7 @@ void main() {
                 if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.LocallyConnectedConv2D, pc, total, input, weights, bias, output)) return;
             }
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var inp = DownloadBuffer(input);
         var w = DownloadBuffer(weights);
@@ -583,7 +584,7 @@ void main() {
                 (uint)outChannels, (uint)outHeight, (uint)outWidth, (uint)kernelH, (uint)kernelW, (uint)strideH, (uint)strideW };
             if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.LocallyConnectedConv2DBackwardInput, pc, total, gradOutput, weights, gradInput)) return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var go = DownloadBuffer(gradOutput);
         var w = DownloadBuffer(weights);
@@ -622,7 +623,7 @@ void main() {
                 (uint)outChannels, (uint)outHeight, (uint)outWidth, (uint)kernelH, (uint)kernelW, (uint)strideH, (uint)strideW };
             if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.LocallyConnectedConv2DBackwardWeights, pc, total, gradOutput, input, gradWeights)) return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var go = DownloadBuffer(gradOutput);
         var inp = DownloadBuffer(input);
@@ -657,7 +658,7 @@ void main() {
             var pc = new uint[] { (uint)batch, (uint)outChannels, (uint)outHeight, (uint)outWidth };
             if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.LocallyConnectedConv2DBackwardBias, pc, outChannels, gradOutput, gradBias)) return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var go = DownloadBuffer(gradOutput);
         var gb = new float[outChannels];
@@ -717,7 +718,7 @@ void main() {
                 if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.DeformableConv2D, pc, total, input, weights, offsets, mask, output)) return;
             }
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var inp = DownloadBuffer(input);
         var ker = DownloadBuffer(weights);
@@ -802,7 +803,7 @@ void main() {
                 if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.DeformableConv2DBackwardInput, pc, total, gradOutput, weights, offsets, mask, gradInput)) return;
             }
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var go = DownloadBuffer(gradOutput);
         var ker = DownloadBuffer(weights);
@@ -890,7 +891,7 @@ void main() {
                 if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.DeformableConv2DBackwardWeights, pc, total, gradOutput, input, offsets, mask, gradWeights)) return;
             }
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var go = DownloadBuffer(gradOutput);
         var inp = DownloadBuffer(input);
@@ -963,7 +964,7 @@ void main() {
                 if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.DeformableConv2DBackwardOffset, pc, total, gradOutput, input, weights, offsets, mask, gradOffsets)) return;
             }
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var go = DownloadBuffer(gradOutput);
         var inp = DownloadBuffer(input);
@@ -1063,7 +1064,7 @@ void main() {
                 if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.DeformableConv2DBackwardMask, pc, total, gradOutput, input, weights, offsets, gradMask)) return;
             }
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var go = DownloadBuffer(gradOutput);
         var inp = DownloadBuffer(input);
@@ -1136,7 +1137,7 @@ void main() {
                 if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.MaxPool2D, pc, total, input, output, indices)) return;
             }
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var inp = DownloadBuffer(input);
         var outp = new float[batch * channels * outHeight * outWidth];
@@ -1182,7 +1183,7 @@ void main() {
             var pc = new uint[] { (uint)batch, (uint)channels, (uint)inHeight, (uint)inWidth, (uint)outHeight, (uint)outWidth };
             if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.MaxPool2DBackward, pc, outTotal, gradOutput, indices, gradInput)) return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var go = DownloadBuffer(gradOutput);
         var idx = DownloadBuffer(indices);
@@ -1217,7 +1218,7 @@ void main() {
                 (uint)strideH, (uint)strideW, (uint)padH, (uint)padW, (uint)(countIncludePad ? 1 : 0) };
             if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.AvgPool2D, pc, total, input, output)) return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var inp = DownloadBuffer(input);
         var outp = new float[batch * channels * outHeight * outWidth];
@@ -1258,7 +1259,7 @@ void main() {
                 (uint)strideH, (uint)strideW, (uint)padH, (uint)padW, (uint)(countIncludePad ? 1 : 0) };
             if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.AvgPool2DBackward, pc, total, gradOutput, gradInput)) return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var go = DownloadBuffer(gradOutput);
         var gi = new float[batch * channels * inHeight * inWidth];
@@ -1298,7 +1299,7 @@ void main() {
             var pc = new uint[] { (uint)batch, (uint)channels, (uint)height, (uint)width };
             if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.GlobalAvgPool2D, pc, batch * channels, input, output)) return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var inp = DownloadBuffer(input);
         var outp = new float[batch * channels];
@@ -1322,7 +1323,7 @@ void main() {
             var pc = new uint[] { (uint)batch, (uint)channels, (uint)height, (uint)width };
             if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.GlobalMaxPool2DNoIndices, pc, batch * channels, input, output)) return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var inp = DownloadBuffer(input);
         var outp = new float[batch * channels];
@@ -1346,7 +1347,7 @@ void main() {
             var pc = new uint[] { (uint)batch, (uint)channels, (uint)height, (uint)width };
             if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.GlobalMaxPool2D, pc, batch * channels, input, output, indices)) return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var inp = DownloadBuffer(input);
         var outp = new float[batch * channels];
@@ -1373,7 +1374,7 @@ void main() {
             var pc = new uint[] { (uint)batch, (uint)channels, (uint)height, (uint)width };
             if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.GlobalAvgPool2DBackward, pc, batch * channels * height * width, gradOutput, gradInput)) return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var go = DownloadBuffer(gradOutput);
         int spatial = height * width;
@@ -1397,7 +1398,7 @@ void main() {
             var pc = new uint[] { (uint)batch, (uint)channels, (uint)height, (uint)width };
             if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.GlobalMaxPool2DBackward, pc, batch * channels, gradOutput, indices, gradInput)) return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var go = DownloadBuffer(gradOutput);
         var idx = DownloadBuffer(indices);
@@ -1422,7 +1423,7 @@ void main() {
             var pc = new uint[] { (uint)batch, (uint)channels, (uint)inHeight, (uint)inWidth, (uint)outHeight, (uint)outWidth };
             if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.AdaptiveAvgPool2D, pc, batch * channels * outHeight * outWidth, input, output)) return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var inp = DownloadBuffer(input);
         var outp = new float[batch * channels * outHeight * outWidth];
@@ -1462,7 +1463,7 @@ void main() {
                 if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.MaxPool3D, pc, total, input, output, indices)) return;
             }
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var inp = DownloadBuffer(input);
         int outSize = batch * channels * outDepth * outHeight * outWidth;
@@ -1511,7 +1512,7 @@ void main() {
                 (uint)outDepth, (uint)outHeight, (uint)outWidth };
             if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.MaxPool3DBackward, pc, outTotal, gradOutput, indices, gradInput)) return;
         }
-        catch { /* fall through to CPU reference */ }
+        catch { if (AiDotNet.Tensors.Engines.DirectGpuTensorEngine.ThrowOnGpuKernelFallback) throw; /* else fall through to CPU reference */ }
 
         var go = DownloadBuffer(gradOutput);
         var idx = DownloadBuffer(indices);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend2.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend2.cs
@@ -702,6 +702,23 @@ void main() {
         int dilationH, int dilationW, int groups, int deformGroups)
     {
         EnsureInitialized();
+        try
+        {
+            // GPU (DCNv2) path requires the mask SSBO and valid grouping; otherwise the CPU reference runs (it
+            // also validates the args and handles DCNv1 / no-mask).
+            if (mask is not null && groups > 0 && deformGroups > 0
+                && inChannels % groups == 0 && inChannels % deformGroups == 0)
+            {
+                int total = batch * outChannels * outHeight * outWidth;
+                var pc = new uint[] { (uint)batch, (uint)inChannels, (uint)inHeight, (uint)inWidth,
+                    (uint)outChannels, (uint)outHeight, (uint)outWidth, (uint)kernelH, (uint)kernelW,
+                    (uint)strideH, (uint)strideW, (uint)padH, (uint)padW, (uint)dilationH, (uint)dilationW,
+                    (uint)groups, (uint)deformGroups };
+                if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.DeformableConv2D, pc, total, input, weights, offsets, mask, output)) return;
+            }
+        }
+        catch { /* fall through to CPU reference */ }
+
         var inp = DownloadBuffer(input);
         var ker = DownloadBuffer(weights);
         var off = DownloadBuffer(offsets);
@@ -772,6 +789,21 @@ void main() {
         int dilationH, int dilationW, int groups, int deformGroups)
     {
         EnsureInitialized();
+        try
+        {
+            if (mask is not null && groups > 0 && deformGroups > 0
+                && inChannels % groups == 0 && inChannels % deformGroups == 0)
+            {
+                int total = batch * inChannels * inHeight * inWidth;
+                var pc = new uint[] { (uint)batch, (uint)inChannels, (uint)inHeight, (uint)inWidth,
+                    (uint)outChannels, (uint)outHeight, (uint)outWidth, (uint)kernelH, (uint)kernelW,
+                    (uint)strideH, (uint)strideW, (uint)padH, (uint)padW, (uint)dilationH, (uint)dilationW,
+                    (uint)groups, (uint)deformGroups };
+                if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.DeformableConv2DBackwardInput, pc, total, gradOutput, weights, offsets, mask, gradInput)) return;
+            }
+        }
+        catch { /* fall through to CPU reference */ }
+
         var go = DownloadBuffer(gradOutput);
         var ker = DownloadBuffer(weights);
         var off = DownloadBuffer(offsets);
@@ -845,6 +877,21 @@ void main() {
         int dilationH, int dilationW, int groups, int deformGroups)
     {
         EnsureInitialized();
+        try
+        {
+            if (mask is not null && groups > 0 && deformGroups > 0
+                && inChannels % groups == 0 && inChannels % deformGroups == 0)
+            {
+                int total = outChannels * (inChannels / groups) * kernelH * kernelW;
+                var pc = new uint[] { (uint)batch, (uint)inChannels, (uint)inHeight, (uint)inWidth,
+                    (uint)outChannels, (uint)outHeight, (uint)outWidth, (uint)kernelH, (uint)kernelW,
+                    (uint)strideH, (uint)strideW, (uint)padH, (uint)padW, (uint)dilationH, (uint)dilationW,
+                    (uint)groups, (uint)deformGroups };
+                if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.DeformableConv2DBackwardWeights, pc, total, gradOutput, input, offsets, mask, gradWeights)) return;
+            }
+        }
+        catch { /* fall through to CPU reference */ }
+
         var go = DownloadBuffer(gradOutput);
         var inp = DownloadBuffer(input);
         var off = DownloadBuffer(offsets);
@@ -902,6 +949,22 @@ void main() {
         int dilationH, int dilationW, int groups, int deformGroups)
     {
         EnsureInitialized();
+        try
+        {
+            if (mask is not null && groups > 0 && deformGroups > 0
+                && inChannels % groups == 0 && inChannels % deformGroups == 0)
+            {
+                int ks = kernelH * kernelW;
+                int total = batch * deformGroups * 2 * ks * outHeight * outWidth;
+                var pc = new uint[] { (uint)batch, (uint)inChannels, (uint)inHeight, (uint)inWidth,
+                    (uint)outChannels, (uint)outHeight, (uint)outWidth, (uint)kernelH, (uint)kernelW,
+                    (uint)strideH, (uint)strideW, (uint)padH, (uint)padW, (uint)dilationH, (uint)dilationW,
+                    (uint)groups, (uint)deformGroups };
+                if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.DeformableConv2DBackwardOffset, pc, total, gradOutput, input, weights, offsets, mask, gradOffsets)) return;
+            }
+        }
+        catch { /* fall through to CPU reference */ }
+
         var go = DownloadBuffer(gradOutput);
         var inp = DownloadBuffer(input);
         var ker = DownloadBuffer(weights);
@@ -987,6 +1050,21 @@ void main() {
         int dilationH, int dilationW, int groups, int deformGroups)
     {
         EnsureInitialized();
+        try
+        {
+            if (groups > 0 && deformGroups > 0
+                && inChannels % groups == 0 && inChannels % deformGroups == 0)
+            {
+                int total = batch * deformGroups * kernelH * kernelW * outHeight * outWidth;
+                var pc = new uint[] { (uint)batch, (uint)inChannels, (uint)inHeight, (uint)inWidth,
+                    (uint)outChannels, (uint)outHeight, (uint)outWidth, (uint)kernelH, (uint)kernelW,
+                    (uint)strideH, (uint)strideW, (uint)padH, (uint)padW, (uint)dilationH, (uint)dilationW,
+                    (uint)groups, (uint)deformGroups };
+                if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.DeformableConv2DBackwardMask, pc, total, gradOutput, input, weights, offsets, gradMask)) return;
+            }
+        }
+        catch { /* fall through to CPU reference */ }
+
         var go = DownloadBuffer(gradOutput);
         var inp = DownloadBuffer(input);
         var ker = DownloadBuffer(weights);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend2.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend2.cs
@@ -977,6 +977,16 @@ void main() {
         int strideH, int strideW, int padH, int padW)
     {
         EnsureInitialized();
+        try
+        {
+            int inTotal = batch * channels * inHeight * inWidth;
+            int outTotal = batch * channels * outHeight * outWidth;
+            Fill(gradInput, 0f, inTotal); // scatter-add target must start at zero
+            var pc = new uint[] { (uint)batch, (uint)channels, (uint)inHeight, (uint)inWidth, (uint)outHeight, (uint)outWidth };
+            if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.MaxPool2DBackward, pc, outTotal, gradOutput, indices, gradInput)) return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var go = DownloadBuffer(gradOutput);
         var idx = DownloadBuffer(indices);
         int inSpatial = inHeight * inWidth;
@@ -1086,6 +1096,13 @@ void main() {
     public void GlobalAvgPool2D(IGpuBuffer input, IGpuBuffer output, int batch, int channels, int height, int width)
     {
         EnsureInitialized();
+        try
+        {
+            var pc = new uint[] { (uint)batch, (uint)channels, (uint)height, (uint)width };
+            if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.GlobalAvgPool2D, pc, batch * channels, input, output)) return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var inp = DownloadBuffer(input);
         var outp = new float[batch * channels];
         int spatial = height * width;
@@ -1103,6 +1120,13 @@ void main() {
     public void GlobalMaxPool2D(IGpuBuffer input, IGpuBuffer output, int batch, int channels, int height, int width)
     {
         EnsureInitialized();
+        try
+        {
+            var pc = new uint[] { (uint)batch, (uint)channels, (uint)height, (uint)width };
+            if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.GlobalMaxPool2DNoIndices, pc, batch * channels, input, output)) return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var inp = DownloadBuffer(input);
         var outp = new float[batch * channels];
         int spatial = height * width;
@@ -1120,6 +1144,13 @@ void main() {
     public void GlobalMaxPool2D(IGpuBuffer input, IGpuBuffer output, IGpuBuffer indices, int batch, int channels, int height, int width)
     {
         EnsureInitialized();
+        try
+        {
+            var pc = new uint[] { (uint)batch, (uint)channels, (uint)height, (uint)width };
+            if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.GlobalMaxPool2D, pc, batch * channels, input, output, indices)) return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var inp = DownloadBuffer(input);
         var outp = new float[batch * channels];
         var idx = new float[batch * channels];
@@ -1140,6 +1171,13 @@ void main() {
     public void GlobalAvgPool2DBackward(IGpuBuffer gradOutput, IGpuBuffer gradInput, int batch, int channels, int height, int width)
     {
         EnsureInitialized();
+        try
+        {
+            var pc = new uint[] { (uint)batch, (uint)channels, (uint)height, (uint)width };
+            if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.GlobalAvgPool2DBackward, pc, batch * channels * height * width, gradOutput, gradInput)) return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var go = DownloadBuffer(gradOutput);
         int spatial = height * width;
         var gi = new float[batch * channels * spatial];
@@ -1156,6 +1194,14 @@ void main() {
     public void GlobalMaxPool2DBackward(IGpuBuffer gradOutput, IGpuBuffer indices, IGpuBuffer gradInput, int batch, int channels, int height, int width)
     {
         EnsureInitialized();
+        try
+        {
+            Fill(gradInput, 0f, batch * channels * height * width); // only argmax positions are written
+            var pc = new uint[] { (uint)batch, (uint)channels, (uint)height, (uint)width };
+            if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.GlobalMaxPool2DBackward, pc, batch * channels, gradOutput, indices, gradInput)) return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var go = DownloadBuffer(gradOutput);
         var idx = DownloadBuffer(indices);
         int spatial = height * width;
@@ -1174,6 +1220,13 @@ void main() {
     public void AdaptiveAvgPool2D(IGpuBuffer input, IGpuBuffer output, int batch, int channels, int inHeight, int inWidth, int outHeight, int outWidth)
     {
         EnsureInitialized();
+        try
+        {
+            var pc = new uint[] { (uint)batch, (uint)channels, (uint)inHeight, (uint)inWidth, (uint)outHeight, (uint)outWidth };
+            if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.AdaptiveAvgPool2D, pc, batch * channels * outHeight * outWidth, input, output)) return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var inp = DownloadBuffer(input);
         var outp = new float[batch * channels * outHeight * outWidth];
         for (int b = 0; b < batch; b++)
@@ -1201,6 +1254,19 @@ void main() {
         int strideD, int strideH, int strideW)
     {
         EnsureInitialized();
+        try
+        {
+            if (indices is not null)
+            {
+                int total = batch * channels * outDepth * outHeight * outWidth;
+                var pc = new uint[] { (uint)batch, (uint)channels, (uint)inDepth, (uint)inHeight, (uint)inWidth,
+                    (uint)outDepth, (uint)outHeight, (uint)outWidth,
+                    (uint)kernelD, (uint)kernelH, (uint)kernelW, (uint)strideD, (uint)strideH, (uint)strideW };
+                if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.MaxPool3D, pc, total, input, output, indices)) return;
+            }
+        }
+        catch { /* fall through to CPU reference */ }
+
         var inp = DownloadBuffer(input);
         int outSize = batch * channels * outDepth * outHeight * outWidth;
         var outp = new float[outSize];
@@ -1239,6 +1305,17 @@ void main() {
         int outDepth, int outHeight, int outWidth)
     {
         EnsureInitialized();
+        try
+        {
+            int inTotal = batch * channels * inDepth * inHeight * inWidth;
+            int outTotal = batch * channels * outDepth * outHeight * outWidth;
+            Fill(gradInput, 0f, inTotal); // scatter-add target must start at zero
+            var pc = new uint[] { (uint)batch, (uint)channels, (uint)inDepth, (uint)inHeight, (uint)inWidth,
+                (uint)outDepth, (uint)outHeight, (uint)outWidth };
+            if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.MaxPool3DBackward, pc, outTotal, gradOutput, indices, gradInput)) return;
+        }
+        catch { /* fall through to CPU reference */ }
+
         var go = DownloadBuffer(gradOutput);
         var idx = DownloadBuffer(indices);
         int inSpatial = inDepth * inHeight * inWidth;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanConvPoolKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanConvPoolKernels.cs
@@ -119,10 +119,13 @@ void main() {
     indices[outIdx] = maxIdx;
 }";
 
-    // ---- Max pooling 2D (backward). Mirrors the OpenCL reference's non-atomic scatter-add: each output routes its
-    // gradient to its argmax input. Collisions (two windows sharing an argmax) race exactly as the OpenCL kernel
-    // does; parity with the validated reference is the contract. ----
-    public const string MaxPool2DBackward = Header + @"
+    // ---- Max pooling 2D (backward). One thread per OUTPUT scatters its gradient to its argmax input. Multiple
+    // windows can share an argmax, so the scatter-add uses atomicAdd (correct, unlike the OpenCL reference's racy
+    // `+=`). Requires GL_EXT_shader_atomic_float; if the device lacks it the pipeline fails to build and the caller
+    // falls back to CPU. gradInput MUST be zero-initialized by the caller (VulkanBackend.Fill) before dispatch. ----
+    public const string MaxPool2DBackward = @"#version 450
+#extension GL_EXT_shader_atomic_float : require
+layout(local_size_x = 256) in;
 layout(set=0, binding=0) buffer B0 { float gradOutput[]; };
 layout(set=0, binding=1) buffer B1 { int indices[]; };
 layout(set=0, binding=2) buffer B2 { float gradInput[]; };
@@ -141,6 +144,189 @@ void main() {
     int maxIdx = indices[outIdx];
     int ih = maxIdx / inWidth;
     int iw = maxIdx % inWidth;
-    gradInput[((b * channels + c) * inHeight + ih) * inWidth + iw] += grad;
+    atomicAdd(gradInput[((b * channels + c) * inHeight + ih) * inWidth + iw], grad);
+}";
+
+    // ---- Global average pooling 2D (forward): one thread per (b,c) ----
+    public const string GlobalAvgPool2D = Header + @"
+layout(set=0, binding=0) buffer B0 { float inp[]; };
+layout(set=0, binding=1) buffer B1 { float outp[]; };
+layout(push_constant) uniform PC { int batch; int channels; int height; int width; };
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    int total = batch * channels;
+    if (gid >= uint(total)) return;
+    int idx = int(gid);
+    int c = idx % channels; int b = idx / channels;
+    float sum = 0.0; int spatial = height * width;
+    for (int h = 0; h < height; h++)
+        for (int w = 0; w < width; w++)
+            sum += inp[((b * channels + c) * height + h) * width + w];
+    outp[b * channels + c] = sum / float(spatial);
+}";
+
+    // ---- Global average pooling 2D (backward, gather): one thread per input element ----
+    public const string GlobalAvgPool2DBackward = Header + @"
+layout(set=0, binding=0) buffer B0 { float gradOutput[]; };
+layout(set=0, binding=1) buffer B1 { float gradInput[]; };
+layout(push_constant) uniform PC { int batch; int channels; int height; int width; };
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    int spatial = height * width;
+    int total = batch * channels * spatial;
+    if (gid >= uint(total)) return;
+    int idx = int(gid);
+    int c = (idx / spatial) % channels;
+    int b = idx / (channels * spatial);
+    gradInput[idx] = gradOutput[b * channels + c] / float(spatial);
+}";
+
+    // ---- Global max pooling 2D (forward, no indices): one thread per (b,c) ----
+    public const string GlobalMaxPool2DNoIndices = Header + @"
+layout(set=0, binding=0) buffer B0 { float inp[]; };
+layout(set=0, binding=1) buffer B1 { float outp[]; };
+layout(push_constant) uniform PC { int batch; int channels; int height; int width; };
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    int total = batch * channels;
+    if (gid >= uint(total)) return;
+    int idx = int(gid);
+    int c = idx % channels; int b = idx / channels;
+    float maxVal = -3.402823466e+38;
+    for (int h = 0; h < height; h++)
+        for (int w = 0; w < width; w++)
+            maxVal = max(maxVal, inp[((b * channels + c) * height + h) * width + w]);
+    outp[b * channels + c] = maxVal;
+}";
+
+    // ---- Global max pooling 2D (forward, with argmax indices): one thread per (b,c) ----
+    public const string GlobalMaxPool2D = Header + @"
+layout(set=0, binding=0) buffer B0 { float inp[]; };
+layout(set=0, binding=1) buffer B1 { float outp[]; };
+layout(set=0, binding=2) buffer B2 { int indices[]; };
+layout(push_constant) uniform PC { int batch; int channels; int height; int width; };
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    int total = batch * channels;
+    if (gid >= uint(total)) return;
+    int idx = int(gid);
+    int c = idx % channels; int b = idx / channels;
+    float maxVal = -3.402823466e+38; int maxIdx = 0;
+    for (int h = 0; h < height; h++)
+        for (int w = 0; w < width; w++) {
+            float v = inp[((b * channels + c) * height + h) * width + w];
+            if (v > maxVal) { maxVal = v; maxIdx = h * width + w; }
+        }
+    outp[b * channels + c] = maxVal;
+    indices[b * channels + c] = maxIdx;
+}";
+
+    // ---- Global max pooling 2D (backward): one thread per (b,c) writes exactly one input position. Distinct (b,c)
+    // map to distinct offsets, so there is no collision — a plain write suffices (caller zero-inits gradInput). ----
+    public const string GlobalMaxPool2DBackward = Header + @"
+layout(set=0, binding=0) buffer B0 { float gradOutput[]; };
+layout(set=0, binding=1) buffer B1 { int indices[]; };
+layout(set=0, binding=2) buffer B2 { float gradInput[]; };
+layout(push_constant) uniform PC { int batch; int channels; int height; int width; };
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    int total = batch * channels;
+    if (gid >= uint(total)) return;
+    int idx = int(gid);
+    int c = idx % channels; int b = idx / channels;
+    int spatial = height * width;
+    gradInput[(b * channels + c) * spatial + indices[idx]] = gradOutput[idx];
+}";
+
+    // ---- Adaptive average pooling 2D (forward, gather): one thread per output element ----
+    public const string AdaptiveAvgPool2D = Header + @"
+layout(set=0, binding=0) buffer B0 { float inp[]; };
+layout(set=0, binding=1) buffer B1 { float outp[]; };
+layout(push_constant) uniform PC {
+    int batch; int channels; int inHeight; int inWidth; int outHeight; int outWidth;
+};
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    int total = batch * channels * outHeight * outWidth;
+    if (gid >= uint(total)) return;
+    int idx = int(gid);
+    int ow = idx % outWidth; int t = idx / outWidth;
+    int oh = t % outHeight; t = t / outHeight;
+    int c = t % channels; int b = t / channels;
+    int hStart = (oh * inHeight) / outHeight;
+    int hEnd = ((oh + 1) * inHeight) / outHeight;
+    int wStart = (ow * inWidth) / outWidth;
+    int wEnd = ((ow + 1) * inWidth) / outWidth;
+    float sum = 0.0; int count = 0;
+    for (int ih = hStart; ih < hEnd; ih++)
+        for (int iw = wStart; iw < wEnd; iw++) {
+            sum += inp[((b * channels + c) * inHeight + ih) * inWidth + iw]; count++;
+        }
+    outp[((b * channels + c) * outHeight + oh) * outWidth + ow] = sum / float(max(count, 1));
+}";
+
+    // ---- Max pooling 3D (forward, NCDHW, with argmax indices): one thread per output element ----
+    public const string MaxPool3D = Header + @"
+layout(set=0, binding=0) buffer B0 { float inp[]; };
+layout(set=0, binding=1) buffer B1 { float outp[]; };
+layout(set=0, binding=2) buffer B2 { int indices[]; };
+layout(push_constant) uniform PC {
+    int batch; int channels; int inDepth; int inHeight; int inWidth;
+    int outDepth; int outHeight; int outWidth;
+    int kernelD; int kernelH; int kernelW; int strideD; int strideH; int strideW;
+};
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    int total = batch * channels * outDepth * outHeight * outWidth;
+    if (gid >= uint(total)) return;
+    int idx = int(gid);
+    int ow = idx % outWidth; int t = idx / outWidth;
+    int oh = t % outHeight; t = t / outHeight;
+    int od = t % outDepth; t = t / outDepth;
+    int c = t % channels; int b = t / channels;
+    float maxVal = -3.402823466e+38; int maxIdx = 0;
+    for (int kd = 0; kd < kernelD; kd++) {
+        int id = od * strideD + kd; if (id >= inDepth) continue;
+        for (int kh = 0; kh < kernelH; kh++) {
+            int ih = oh * strideH + kh; if (ih >= inHeight) continue;
+            for (int kw = 0; kw < kernelW; kw++) {
+                int iw = ow * strideW + kw; if (iw >= inWidth) continue;
+                float v = inp[((b * channels + c) * inDepth + id) * inHeight * inWidth + ih * inWidth + iw];
+                if (v > maxVal) { maxVal = v; maxIdx = id * inHeight * inWidth + ih * inWidth + iw; }
+            }
+        }
+    }
+    int outIdx = ((b * channels + c) * outDepth + od) * outHeight * outWidth + oh * outWidth + ow;
+    outp[outIdx] = maxVal;
+    indices[outIdx] = maxIdx;
+}";
+
+    // ---- Max pooling 3D (backward): one thread per output scatter-adds to its argmax input (atomic; caller
+    // zero-inits gradInput). Requires GL_EXT_shader_atomic_float. ----
+    public const string MaxPool3DBackward = @"#version 450
+#extension GL_EXT_shader_atomic_float : require
+layout(local_size_x = 256) in;
+layout(set=0, binding=0) buffer B0 { float gradOutput[]; };
+layout(set=0, binding=1) buffer B1 { int indices[]; };
+layout(set=0, binding=2) buffer B2 { float gradInput[]; };
+layout(push_constant) uniform PC {
+    int batch; int channels; int inDepth; int inHeight; int inWidth;
+    int outDepth; int outHeight; int outWidth;
+};
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    int total = batch * channels * outDepth * outHeight * outWidth;
+    if (gid >= uint(total)) return;
+    int outIdx = int(gid);
+    int ow = outIdx % outWidth; int t = outIdx / outWidth;
+    int oh = t % outHeight; t = t / outHeight;
+    int od = t % outDepth; t = t / outDepth;
+    int c = t % channels; int b = t / channels;
+    float grad = gradOutput[outIdx];
+    int maxIdx = indices[outIdx];
+    int spatialHW = inHeight * inWidth;
+    int id = maxIdx / spatialHW; int rem = maxIdx % spatialHW;
+    int ih = rem / inWidth; int iw = rem % inWidth;
+    atomicAdd(gradInput[((b * channels + c) * inDepth + id) * inHeight * inWidth + ih * inWidth + iw], grad);
 }";
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanConvPoolKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanConvPoolKernels.cs
@@ -591,4 +591,116 @@ void main() {
         }
     outp[idx] = sum;
 }";
+
+    // ---- Locally connected Conv2D (forward, gather; weights [outH,outW,outC,inC,kH,kW]; bias [outC]; no padding) ----
+    public const string LocallyConnectedConv2D = Header + @"
+layout(set=0, binding=0) buffer B0 { float inp[]; };
+layout(set=0, binding=1) buffer B1 { float wgt[]; };
+layout(set=0, binding=2) buffer B2 { float bias[]; };
+layout(set=0, binding=3) buffer B3 { float outp[]; };
+layout(push_constant) uniform PC {
+    int batch; int inChannels; int inHeight; int inWidth;
+    int outChannels; int outHeight; int outWidth; int kernelH; int kernelW; int strideH; int strideW;
+};
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    int total = batch * outChannels * outHeight * outWidth;
+    if (gid >= uint(total)) return;
+    int idx = int(gid);
+    int ow = idx % outWidth; int t = idx / outWidth;
+    int oh = t % outHeight; t = t / outHeight;
+    int oc = t % outChannels; int b = t / outChannels;
+    int wBase = ((oh * outWidth + ow) * outChannels + oc) * inChannels * kernelH * kernelW;
+    float sum = bias[oc];
+    for (int ic = 0; ic < inChannels; ic++)
+        for (int kh = 0; kh < kernelH; kh++)
+            for (int kw = 0; kw < kernelW; kw++) {
+                int ih = oh * strideH + kh; int iw = ow * strideW + kw;
+                if (ih >= 0 && ih < inHeight && iw >= 0 && iw < inWidth)
+                    sum += inp[((b * inChannels + ic) * inHeight + ih) * inWidth + iw]
+                         * wgt[wBase + (ic * kernelH + kh) * kernelW + kw];
+            }
+    outp[((b * outChannels + oc) * outHeight + oh) * outWidth + ow] = sum;
+}";
+
+    // ---- Locally connected backward input (gather per input element) ----
+    public const string LocallyConnectedConv2DBackwardInput = Header + @"
+layout(set=0, binding=0) buffer B0 { float gradOutput[]; };
+layout(set=0, binding=1) buffer B1 { float wgt[]; };
+layout(set=0, binding=2) buffer B2 { float gradInput[]; };
+layout(push_constant) uniform PC {
+    int batch; int inChannels; int inHeight; int inWidth;
+    int outChannels; int outHeight; int outWidth; int kernelH; int kernelW; int strideH; int strideW;
+};
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    int total = batch * inChannels * inHeight * inWidth;
+    if (gid >= uint(total)) return;
+    int idx = int(gid);
+    int b = idx / (inChannels * inHeight * inWidth);
+    int r = idx % (inChannels * inHeight * inWidth);
+    int ic = r / (inHeight * inWidth);
+    int r2 = r % (inHeight * inWidth);
+    int ih = r2 / inWidth; int iw = r2 % inWidth;
+    float sum = 0.0;
+    for (int oh = 0; oh < outHeight; oh++)
+        for (int ow = 0; ow < outWidth; ow++) {
+            int khr = ih - oh * strideH; int kwr = iw - ow * strideW;
+            if (khr >= 0 && khr < kernelH && kwr >= 0 && kwr < kernelW) {
+                for (int oc = 0; oc < outChannels; oc++) {
+                    float g = gradOutput[((b * outChannels + oc) * outHeight + oh) * outWidth + ow];
+                    int wIdx = (((oh * outWidth + ow) * outChannels + oc) * inChannels + ic) * kernelH * kernelW + khr * kernelW + kwr;
+                    sum += g * wgt[wIdx];
+                }
+            }
+        }
+    gradInput[idx] = sum;
+}";
+
+    // ---- Locally connected backward weights (one thread per weight; layout [outH,outW,outC,inC,kH,kW]) ----
+    public const string LocallyConnectedConv2DBackwardWeights = Header + @"
+layout(set=0, binding=0) buffer B0 { float gradOutput[]; };
+layout(set=0, binding=1) buffer B1 { float inp[]; };
+layout(set=0, binding=2) buffer B2 { float gradWeights[]; };
+layout(push_constant) uniform PC {
+    int batch; int inChannels; int inHeight; int inWidth;
+    int outChannels; int outHeight; int outWidth; int kernelH; int kernelW; int strideH; int strideW;
+};
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    int total = outHeight * outWidth * outChannels * inChannels * kernelH * kernelW;
+    if (gid >= uint(total)) return;
+    int idx = int(gid);
+    int tmp = idx;
+    int kw = tmp % kernelW; tmp /= kernelW;
+    int kh = tmp % kernelH; tmp /= kernelH;
+    int ic = tmp % inChannels; tmp /= inChannels;
+    int oc = tmp % outChannels; tmp /= outChannels;
+    int ow = tmp % outWidth; tmp /= outWidth;
+    int oh = tmp;
+    int ih = oh * strideH + kh; int iw = ow * strideW + kw;
+    float sum = 0.0;
+    if (ih >= 0 && ih < inHeight && iw >= 0 && iw < inWidth)
+        for (int b = 0; b < batch; b++)
+            sum += gradOutput[((b * outChannels + oc) * outHeight + oh) * outWidth + ow]
+                 * inp[((b * inChannels + ic) * inHeight + ih) * inWidth + iw];
+    gradWeights[idx] = sum;
+}";
+
+    // ---- Locally connected backward bias (one thread per output channel) ----
+    public const string LocallyConnectedConv2DBackwardBias = Header + @"
+layout(set=0, binding=0) buffer B0 { float gradOutput[]; };
+layout(set=0, binding=1) buffer B1 { float gradBias[]; };
+layout(push_constant) uniform PC { int batch; int outChannels; int outHeight; int outWidth; };
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    if (gid >= uint(outChannels)) return;
+    int oc = int(gid);
+    float sum = 0.0;
+    for (int b = 0; b < batch; b++)
+        for (int oh = 0; oh < outHeight; oh++)
+            for (int ow = 0; ow < outWidth; ow++)
+                sum += gradOutput[((b * outChannels + oc) * outHeight + oh) * outWidth + ow];
+    gradBias[oc] = sum;
+}";
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanConvPoolKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanConvPoolKernels.cs
@@ -703,4 +703,282 @@ void main() {
                 sum += gradOutput[((b * outChannels + oc) * outHeight + oh) * outWidth + ow];
     gradBias[oc] = sum;
 }";
+
+    // ---- Deformable Conv2D (forward, gather; DCNv2 — mask required on the GPU path) ----
+    public const string DeformableConv2D = @"#version 450
+layout(local_size_x = 256) in;
+layout(set=0, binding=0) buffer B0 { float inp[]; };
+layout(set=0, binding=1) buffer B1 { float wgt[]; };
+layout(set=0, binding=2) buffer B2 { float offsets[]; };
+layout(set=0, binding=3) buffer B3 { float mask[]; };
+layout(set=0, binding=4) buffer B4 { float outp[]; };
+layout(push_constant) uniform PC {
+    int batch; int inChannels; int inHeight; int inWidth;
+    int outChannels; int outHeight; int outWidth; int kernelH; int kernelW;
+    int strideH; int strideW; int padH; int padW; int dilationH; int dilationW; int groups; int deformGroups;
+};
+float bilinearSample(int b, int c, float h, float w) {
+    int hl = int(floor(h)); int wl = int(floor(w)); int hh = hl + 1; int wh = wl + 1;
+    float lh = h - float(hl); float lw = w - float(wl); float hhf = 1.0 - lh; float hwf = 1.0 - lw;
+    float v1 = 0.0, v2 = 0.0, v3 = 0.0, v4 = 0.0;
+    if (hl >= 0 && hl < inHeight && wl >= 0 && wl < inWidth) v1 = inp[((b*inChannels+c)*inHeight+hl)*inWidth+wl];
+    if (hl >= 0 && hl < inHeight && wh >= 0 && wh < inWidth) v2 = inp[((b*inChannels+c)*inHeight+hl)*inWidth+wh];
+    if (hh >= 0 && hh < inHeight && wl >= 0 && wl < inWidth) v3 = inp[((b*inChannels+c)*inHeight+hh)*inWidth+wl];
+    if (hh >= 0 && hh < inHeight && wh >= 0 && wh < inWidth) v4 = inp[((b*inChannels+c)*inHeight+hh)*inWidth+wh];
+    return hhf*hwf*v1 + hhf*lw*v2 + lh*hwf*v3 + lh*lw*v4;
+}
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    int total = batch * outChannels * outHeight * outWidth;
+    if (gid >= uint(total)) return;
+    int idx = int(gid);
+    int ow = idx % outWidth; int t = idx / outWidth;
+    int oh = t % outHeight; t = t / outHeight;
+    int oc = t % outChannels; int b = t / outChannels;
+    int g = oc / (outChannels / groups);
+    int dg = oc / (outChannels / deformGroups);
+    int icpg = inChannels / groups;
+    int ks = kernelH * kernelW;
+    int baseH = oh * strideH - padH; int baseW = ow * strideW - padW;
+    float sum = 0.0;
+    for (int ic = 0; ic < icpg; ic++) {
+        int aic = g * icpg + ic;
+        for (int kh = 0; kh < kernelH; kh++)
+            for (int kw = 0; kw < kernelW; kw++) {
+                int ki = kh * kernelW + kw;
+                int oIx = ((b*deformGroups+dg)*2*ks + ki)*outHeight*outWidth + oh*outWidth + ow;
+                int oIy = ((b*deformGroups+dg)*2*ks + ks + ki)*outHeight*outWidth + oh*outWidth + ow;
+                float h = float(baseH) + float(kh*dilationH) + offsets[oIx];
+                float w = float(baseW) + float(kw*dilationW) + offsets[oIy];
+                float val = bilinearSample(b, aic, h, w);
+                int mIx = ((b*deformGroups+dg)*ks + ki)*outHeight*outWidth + oh*outWidth + ow;
+                val *= mask[mIx];
+                sum += val * wgt[((oc*icpg+ic)*kernelH+kh)*kernelW+kw];
+            }
+    }
+    outp[((b*outChannels+oc)*outHeight+oh)*outWidth+ow] = sum;
+}";
+
+    // ---- Deformable backward input (gather per input element) ----
+    public const string DeformableConv2DBackwardInput = @"#version 450
+layout(local_size_x = 256) in;
+layout(set=0, binding=0) buffer B0 { float gradOutput[]; };
+layout(set=0, binding=1) buffer B1 { float wgt[]; };
+layout(set=0, binding=2) buffer B2 { float offsets[]; };
+layout(set=0, binding=3) buffer B3 { float mask[]; };
+layout(set=0, binding=4) buffer B4 { float gradInput[]; };
+layout(push_constant) uniform PC {
+    int batch; int inChannels; int inHeight; int inWidth;
+    int outChannels; int outHeight; int outWidth; int kernelH; int kernelW;
+    int strideH; int strideW; int padH; int padW; int dilationH; int dilationW; int groups; int deformGroups;
+};
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    int total = batch * inChannels * inHeight * inWidth;
+    if (gid >= uint(total)) return;
+    int idx = int(gid);
+    int b = idx / (inChannels*inHeight*inWidth);
+    int r1 = idx % (inChannels*inHeight*inWidth);
+    int ic = r1 / (inHeight*inWidth);
+    int r2 = r1 % (inHeight*inWidth);
+    int ih = r2 / inWidth; int iw = r2 % inWidth;
+    int g = ic / (inChannels / groups);
+    int icpg = inChannels / groups; int ocpg = outChannels / groups; int ks = kernelH * kernelW;
+    float sum = 0.0;
+    for (int oc = g*ocpg; oc < (g+1)*ocpg; oc++) {
+        int dg = oc / (outChannels / deformGroups);
+        int icLocal = ic - g*icpg;
+        for (int oh = 0; oh < outHeight; oh++)
+            for (int ow = 0; ow < outWidth; ow++) {
+                int baseH = oh*strideH - padH; int baseW = ow*strideW - padW;
+                for (int kh = 0; kh < kernelH; kh++)
+                    for (int kw = 0; kw < kernelW; kw++) {
+                        int ki = kh*kernelW + kw;
+                        int oIx = ((b*deformGroups+dg)*2*ks + ki)*outHeight*outWidth + oh*outWidth + ow;
+                        int oIy = ((b*deformGroups+dg)*2*ks + ks + ki)*outHeight*outWidth + oh*outWidth + ow;
+                        float h = float(baseH) + float(kh*dilationH) + offsets[oIx];
+                        float w = float(baseW) + float(kw*dilationW) + offsets[oIy];
+                        int hl = int(floor(h)); int wl = int(floor(w)); int hh = hl+1; int wh = wl+1;
+                        float lh = h - float(hl); float lw = w - float(wl); float hhf = 1.0-lh; float hwf = 1.0-lw;
+                        float wc = 0.0;
+                        if (ih == hl && iw == wl) wc = hhf*hwf;
+                        else if (ih == hl && iw == wh) wc = hhf*lw;
+                        else if (ih == hh && iw == wl) wc = lh*hwf;
+                        else if (ih == hh && iw == wh) wc = lh*lw;
+                        else continue;
+                        float go = gradOutput[((b*outChannels+oc)*outHeight+oh)*outWidth+ow];
+                        float contrib = go * wgt[((oc*icpg+icLocal)*kernelH+kh)*kernelW+kw] * wc;
+                        int mIx = ((b*deformGroups+dg)*ks + ki)*outHeight*outWidth + oh*outWidth + ow;
+                        contrib *= mask[mIx];
+                        sum += contrib;
+                    }
+            }
+    }
+    gradInput[idx] = sum;
+}";
+
+    // ---- Deformable backward weights (one thread per weight) ----
+    public const string DeformableConv2DBackwardWeights = @"#version 450
+layout(local_size_x = 256) in;
+layout(set=0, binding=0) buffer B0 { float gradOutput[]; };
+layout(set=0, binding=1) buffer B1 { float inp[]; };
+layout(set=0, binding=2) buffer B2 { float offsets[]; };
+layout(set=0, binding=3) buffer B3 { float mask[]; };
+layout(set=0, binding=4) buffer B4 { float gradWeights[]; };
+layout(push_constant) uniform PC {
+    int batch; int inChannels; int inHeight; int inWidth;
+    int outChannels; int outHeight; int outWidth; int kernelH; int kernelW;
+    int strideH; int strideW; int padH; int padW; int dilationH; int dilationW; int groups; int deformGroups;
+};
+float bilinearSample(int b, int c, float h, float w) {
+    int hl = int(floor(h)); int wl = int(floor(w)); int hh = hl + 1; int wh = wl + 1;
+    float lh = h - float(hl); float lw = w - float(wl); float hhf = 1.0 - lh; float hwf = 1.0 - lw;
+    float v1 = 0.0, v2 = 0.0, v3 = 0.0, v4 = 0.0;
+    if (hl >= 0 && hl < inHeight && wl >= 0 && wl < inWidth) v1 = inp[((b*inChannels+c)*inHeight+hl)*inWidth+wl];
+    if (hl >= 0 && hl < inHeight && wh >= 0 && wh < inWidth) v2 = inp[((b*inChannels+c)*inHeight+hl)*inWidth+wh];
+    if (hh >= 0 && hh < inHeight && wl >= 0 && wl < inWidth) v3 = inp[((b*inChannels+c)*inHeight+hh)*inWidth+wl];
+    if (hh >= 0 && hh < inHeight && wh >= 0 && wh < inWidth) v4 = inp[((b*inChannels+c)*inHeight+hh)*inWidth+wh];
+    return hhf*hwf*v1 + hhf*lw*v2 + lh*hwf*v3 + lh*lw*v4;
+}
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    int icpg = inChannels / groups;
+    int total = outChannels * icpg * kernelH * kernelW;
+    if (gid >= uint(total)) return;
+    int idx = int(gid); int tmp = idx;
+    int kw = tmp % kernelW; tmp /= kernelW;
+    int kh = tmp % kernelH; tmp /= kernelH;
+    int icLocal = tmp % icpg; tmp /= icpg;
+    int oc = tmp;
+    int g = oc / (outChannels / groups);
+    int dg = oc / (outChannels / deformGroups);
+    int ic = g*icpg + icLocal; int ks = kernelH*kernelW; int ki = kh*kernelW + kw;
+    float sum = 0.0;
+    for (int b = 0; b < batch; b++)
+        for (int oh = 0; oh < outHeight; oh++)
+            for (int ow = 0; ow < outWidth; ow++) {
+                int baseH = oh*strideH - padH; int baseW = ow*strideW - padW;
+                int oIx = ((b*deformGroups+dg)*2*ks + ki)*outHeight*outWidth + oh*outWidth + ow;
+                int oIy = ((b*deformGroups+dg)*2*ks + ks + ki)*outHeight*outWidth + oh*outWidth + ow;
+                float h = float(baseH) + float(kh*dilationH) + offsets[oIx];
+                float w = float(baseW) + float(kw*dilationW) + offsets[oIy];
+                float iv = bilinearSample(b, ic, h, w);
+                int mIx = ((b*deformGroups+dg)*ks + ki)*outHeight*outWidth + oh*outWidth + ow;
+                iv *= mask[mIx];
+                sum += gradOutput[((b*outChannels+oc)*outHeight+oh)*outWidth+ow] * iv;
+            }
+    gradWeights[idx] = sum;
+}";
+
+    // ---- Deformable backward offset (one thread per offset element) ----
+    public const string DeformableConv2DBackwardOffset = @"#version 450
+layout(local_size_x = 256) in;
+layout(set=0, binding=0) buffer B0 { float gradOutput[]; };
+layout(set=0, binding=1) buffer B1 { float inp[]; };
+layout(set=0, binding=2) buffer B2 { float wgt[]; };
+layout(set=0, binding=3) buffer B3 { float offsets[]; };
+layout(set=0, binding=4) buffer B4 { float mask[]; };
+layout(set=0, binding=5) buffer B5 { float gradOffsets[]; };
+layout(push_constant) uniform PC {
+    int batch; int inChannels; int inHeight; int inWidth;
+    int outChannels; int outHeight; int outWidth; int kernelH; int kernelW;
+    int strideH; int strideW; int padH; int padW; int dilationH; int dilationW; int groups; int deformGroups;
+};
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    int ks = kernelH * kernelW;
+    int total = batch * deformGroups * 2 * ks * outHeight * outWidth;
+    if (gid >= uint(total)) return;
+    int idx = int(gid); int tmp = idx;
+    int ow = tmp % outWidth; tmp /= outWidth;
+    int oh = tmp % outHeight; tmp /= outHeight;
+    int comp = tmp % (2*ks); tmp /= (2*ks);
+    int dg = tmp % deformGroups; tmp /= deformGroups;
+    int b = tmp;
+    int isY = comp >= ks ? 1 : 0;
+    int ki = comp % ks; int kh = ki / kernelW; int kw = ki % kernelW;
+    int oIx = ((b*deformGroups+dg)*2*ks + ki)*outHeight*outWidth + oh*outWidth + ow;
+    int oIy = ((b*deformGroups+dg)*2*ks + ks + ki)*outHeight*outWidth + oh*outWidth + ow;
+    float oh_off = offsets[oIx]; float ow_off = offsets[oIy];
+    int baseH = oh*strideH - padH; int baseW = ow*strideW - padW;
+    float h = float(baseH) + float(kh*dilationH) + oh_off;
+    float w = float(baseW) + float(kw*dilationW) + ow_off;
+    int hl = int(floor(h)); int wl = int(floor(w)); int hh = hl+1; int wh = wl+1;
+    float lh = h - float(hl); float lw = w - float(wl);
+    float sum = 0.0;
+    int icpg = inChannels / groups; int ocpg = outChannels / groups;
+    for (int oco = 0; oco < outChannels / deformGroups; oco++) {
+        int oc = dg * (outChannels / deformGroups) + oco;
+        int g = oc / ocpg;
+        float go = gradOutput[((b*outChannels+oc)*outHeight+oh)*outWidth+ow];
+        int mIx = ((b*deformGroups+dg)*ks + ki)*outHeight*outWidth + oh*outWidth + ow;
+        go *= mask[mIx];
+        for (int ic = g*icpg; ic < (g+1)*icpg; ic++) {
+            int icLocal = ic - g*icpg;
+            float wv = wgt[((oc*icpg+icLocal)*kernelH+kh)*kernelW+kw];
+            float v1 = 0.0, v2 = 0.0, v3 = 0.0, v4 = 0.0;
+            if (hl >= 0 && hl < inHeight && wl >= 0 && wl < inWidth) v1 = inp[((b*inChannels+ic)*inHeight+hl)*inWidth+wl];
+            if (hl >= 0 && hl < inHeight && wh >= 0 && wh < inWidth) v2 = inp[((b*inChannels+ic)*inHeight+hl)*inWidth+wh];
+            if (hh >= 0 && hh < inHeight && wl >= 0 && wl < inWidth) v3 = inp[((b*inChannels+ic)*inHeight+hh)*inWidth+wl];
+            if (hh >= 0 && hh < inHeight && wh >= 0 && wh < inWidth) v4 = inp[((b*inChannels+ic)*inHeight+hh)*inWidth+wh];
+            if (isY == 0) sum += go * wv * ((1.0-lw)*(v3-v1) + lw*(v4-v2));
+            else sum += go * wv * ((1.0-lh)*(v2-v1) + lh*(v4-v3));
+        }
+    }
+    gradOffsets[idx] = sum;
+}";
+
+    // ---- Deformable backward mask (one thread per mask element) ----
+    public const string DeformableConv2DBackwardMask = @"#version 450
+layout(local_size_x = 256) in;
+layout(set=0, binding=0) buffer B0 { float gradOutput[]; };
+layout(set=0, binding=1) buffer B1 { float inp[]; };
+layout(set=0, binding=2) buffer B2 { float wgt[]; };
+layout(set=0, binding=3) buffer B3 { float offsets[]; };
+layout(set=0, binding=4) buffer B4 { float gradMask[]; };
+layout(push_constant) uniform PC {
+    int batch; int inChannels; int inHeight; int inWidth;
+    int outChannels; int outHeight; int outWidth; int kernelH; int kernelW;
+    int strideH; int strideW; int padH; int padW; int dilationH; int dilationW; int groups; int deformGroups;
+};
+float bilinearSample(int b, int c, float h, float w) {
+    int hl = int(floor(h)); int wl = int(floor(w)); int hh = hl + 1; int wh = wl + 1;
+    float lh = h - float(hl); float lw = w - float(wl); float hhf = 1.0 - lh; float hwf = 1.0 - lw;
+    float v1 = 0.0, v2 = 0.0, v3 = 0.0, v4 = 0.0;
+    if (hl >= 0 && hl < inHeight && wl >= 0 && wl < inWidth) v1 = inp[((b*inChannels+c)*inHeight+hl)*inWidth+wl];
+    if (hl >= 0 && hl < inHeight && wh >= 0 && wh < inWidth) v2 = inp[((b*inChannels+c)*inHeight+hl)*inWidth+wh];
+    if (hh >= 0 && hh < inHeight && wl >= 0 && wl < inWidth) v3 = inp[((b*inChannels+c)*inHeight+hh)*inWidth+wl];
+    if (hh >= 0 && hh < inHeight && wh >= 0 && wh < inWidth) v4 = inp[((b*inChannels+c)*inHeight+hh)*inWidth+wh];
+    return hhf*hwf*v1 + hhf*lw*v2 + lh*hwf*v3 + lh*lw*v4;
+}
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    int ks = kernelH * kernelW;
+    int total = batch * deformGroups * ks * outHeight * outWidth;
+    if (gid >= uint(total)) return;
+    int idx = int(gid); int tmp = idx;
+    int ow = tmp % outWidth; tmp /= outWidth;
+    int oh = tmp % outHeight; tmp /= outHeight;
+    int ki = tmp % ks; tmp /= ks;
+    int dg = tmp % deformGroups; tmp /= deformGroups;
+    int b = tmp;
+    int kh = ki / kernelW; int kw = ki % kernelW;
+    int oIx = ((b*deformGroups+dg)*2*ks + ki)*outHeight*outWidth + oh*outWidth + ow;
+    int oIy = ((b*deformGroups+dg)*2*ks + ks + ki)*outHeight*outWidth + oh*outWidth + ow;
+    float h = float(oh*strideH - padH) + float(kh*dilationH) + offsets[oIx];
+    float w = float(ow*strideW - padW) + float(kw*dilationW) + offsets[oIy];
+    float sum = 0.0;
+    int icpg = inChannels / groups; int ocpg = outChannels / groups;
+    for (int oco = 0; oco < outChannels / deformGroups; oco++) {
+        int oc = dg * (outChannels / deformGroups) + oco;
+        int g = oc / ocpg;
+        float go = gradOutput[((b*outChannels+oc)*outHeight+oh)*outWidth+ow];
+        for (int ic = g*icpg; ic < (g+1)*icpg; ic++) {
+            int icLocal = ic - g*icpg;
+            float wv = wgt[((oc*icpg+icLocal)*kernelH+kh)*kernelW+kw];
+            sum += go * wv * bilinearSample(b, ic, h, w);
+        }
+    }
+    gradMask[idx] = sum;
+}";
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanConvPoolKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanConvPoolKernels.cs
@@ -329,4 +329,266 @@ void main() {
     int ih = rem / inWidth; int iw = rem % inWidth;
     atomicAdd(gradInput[((b * channels + c) * inDepth + id) * inHeight * inWidth + ih * inWidth + iw], grad);
 }";
+
+    // ---- Conv2D (forward, gather): one thread per output element ----
+    public const string Conv2D = Header + @"
+layout(set=0, binding=0) buffer B0 { float inp[]; };
+layout(set=0, binding=1) buffer B1 { float wgt[]; };
+layout(set=0, binding=2) buffer B2 { float outp[]; };
+layout(push_constant) uniform PC {
+    int batch; int inChannels; int inHeight; int inWidth;
+    int outChannels; int outHeight; int outWidth; int kernelH; int kernelW;
+    int strideH; int strideW; int padH; int padW; int dilationH; int dilationW;
+};
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    int total = batch * outChannels * outHeight * outWidth;
+    if (gid >= uint(total)) return;
+    int idx = int(gid);
+    int ow = idx % outWidth; int t = idx / outWidth;
+    int oh = t % outHeight; t = t / outHeight;
+    int oc = t % outChannels; int b = t / outChannels;
+    float sum = 0.0;
+    for (int ic = 0; ic < inChannels; ic++)
+        for (int kh = 0; kh < kernelH; kh++)
+            for (int kw = 0; kw < kernelW; kw++) {
+                int ih = oh * strideH - padH + kh * dilationH;
+                int iw = ow * strideW - padW + kw * dilationW;
+                if (ih >= 0 && ih < inHeight && iw >= 0 && iw < inWidth)
+                    sum += inp[((b * inChannels + ic) * inHeight + ih) * inWidth + iw]
+                         * wgt[((oc * inChannels + ic) * kernelH + kh) * kernelW + kw];
+            }
+    outp[((b * outChannels + oc) * outHeight + oh) * outWidth + ow] = sum;
+}";
+
+    // ---- Conv2D backward input (gather per input element) ----
+    public const string Conv2DBackwardInput = Header + @"
+layout(set=0, binding=0) buffer B0 { float gradOutput[]; };
+layout(set=0, binding=1) buffer B1 { float wgt[]; };
+layout(set=0, binding=2) buffer B2 { float gradInput[]; };
+layout(push_constant) uniform PC {
+    int batch; int inChannels; int inHeight; int inWidth;
+    int outChannels; int outHeight; int outWidth; int kernelH; int kernelW;
+    int strideH; int strideW; int padH; int padW; int dilationH; int dilationW;
+};
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    int total = batch * inChannels * inHeight * inWidth;
+    if (gid >= uint(total)) return;
+    int idx = int(gid);
+    int iw = idx % inWidth; int t = idx / inWidth;
+    int ih = t % inHeight; t = t / inHeight;
+    int ic = t % inChannels; int b = t / inChannels;
+    float sum = 0.0;
+    for (int oc = 0; oc < outChannels; oc++)
+        for (int kh = 0; kh < kernelH; kh++)
+            for (int kw = 0; kw < kernelW; kw++) {
+                int ohb = ih + padH - kh * dilationH;
+                int owb = iw + padW - kw * dilationW;
+                if ((ohb % strideH) == 0 && (owb % strideW) == 0) {
+                    int oh = ohb / strideH; int ow = owb / strideW;
+                    if (oh >= 0 && oh < outHeight && ow >= 0 && ow < outWidth)
+                        sum += gradOutput[((b * outChannels + oc) * outHeight + oh) * outWidth + ow]
+                             * wgt[((oc * inChannels + ic) * kernelH + kh) * kernelW + kw];
+                }
+            }
+    gradInput[((b * inChannels + ic) * inHeight + ih) * inWidth + iw] = sum;
+}";
+
+    // ---- Conv2D backward weights (one thread per kernel weight) ----
+    public const string Conv2DBackwardKernel = Header + @"
+layout(set=0, binding=0) buffer B0 { float inp[]; };
+layout(set=0, binding=1) buffer B1 { float gradOutput[]; };
+layout(set=0, binding=2) buffer B2 { float gradKernel[]; };
+layout(push_constant) uniform PC {
+    int batch; int inChannels; int inHeight; int inWidth;
+    int outChannels; int outHeight; int outWidth; int kernelH; int kernelW;
+    int strideH; int strideW; int padH; int padW; int dilationH; int dilationW;
+};
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    int total = outChannels * inChannels * kernelH * kernelW;
+    if (gid >= uint(total)) return;
+    int idx = int(gid);
+    int kw = idx % kernelW; int t = idx / kernelW;
+    int kh = t % kernelH; t = t / kernelH;
+    int ic = t % inChannels; int oc = t / inChannels;
+    float sum = 0.0;
+    for (int b = 0; b < batch; b++)
+        for (int oh = 0; oh < outHeight; oh++)
+            for (int ow = 0; ow < outWidth; ow++) {
+                int ih = oh * strideH - padH + kh * dilationH;
+                int iw = ow * strideW - padW + kw * dilationW;
+                if (ih >= 0 && ih < inHeight && iw >= 0 && iw < inWidth)
+                    sum += inp[((b * inChannels + ic) * inHeight + ih) * inWidth + iw]
+                         * gradOutput[((b * outChannels + oc) * outHeight + oh) * outWidth + ow];
+            }
+    gradKernel[((oc * inChannels + ic) * kernelH + kh) * kernelW + kw] = sum;
+}";
+
+    // ---- Depthwise Conv2D (forward, gather; weights [channels, kH, kW]) ----
+    public const string DepthwiseConv2D = Header + @"
+layout(set=0, binding=0) buffer B0 { float inp[]; };
+layout(set=0, binding=1) buffer B1 { float wgt[]; };
+layout(set=0, binding=2) buffer B2 { float outp[]; };
+layout(push_constant) uniform PC {
+    int batch; int channels; int inHeight; int inWidth;
+    int outHeight; int outWidth; int kernelH; int kernelW;
+    int strideH; int strideW; int padH; int padW;
+};
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    int total = batch * channels * outHeight * outWidth;
+    if (gid >= uint(total)) return;
+    int idx = int(gid);
+    int ow = idx % outWidth; int t = idx / outWidth;
+    int oh = t % outHeight; t = t / outHeight;
+    int c = t % channels; int b = t / channels;
+    float sum = 0.0;
+    for (int kh = 0; kh < kernelH; kh++)
+        for (int kw = 0; kw < kernelW; kw++) {
+            int ih = oh * strideH - padH + kh;
+            int iw = ow * strideW - padW + kw;
+            if (ih >= 0 && ih < inHeight && iw >= 0 && iw < inWidth)
+                sum += inp[((b * channels + c) * inHeight + ih) * inWidth + iw]
+                     * wgt[(c * kernelH + kh) * kernelW + kw];
+        }
+    outp[((b * channels + c) * outHeight + oh) * outWidth + ow] = sum;
+}";
+
+    // ---- Transposed Conv2D backward weights (one thread per kernel weight; layout [inChannels,outChannels,kH,kW]) ----
+    public const string ConvTranspose2DBackwardWeights = Header + @"
+layout(set=0, binding=0) buffer B0 { float inp[]; };
+layout(set=0, binding=1) buffer B1 { float gradOutput[]; };
+layout(set=0, binding=2) buffer B2 { float gradWeights[]; };
+layout(push_constant) uniform PC {
+    int batch; int inChannels; int inHeight; int inWidth;
+    int outChannels; int outHeight; int outWidth; int kernelH; int kernelW;
+    int strideH; int strideW; int padH; int padW; int outputPadH; int outputPadW;
+};
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    int total = inChannels * outChannels * kernelH * kernelW;
+    if (gid >= uint(total)) return;
+    int idx = int(gid);
+    int kw = idx % kernelW; int t = idx / kernelW;
+    int kh = t % kernelH; t = t / kernelH;
+    int oc = t % outChannels; int ic = t / outChannels;
+    float sum = 0.0;
+    for (int b = 0; b < batch; b++)
+        for (int ih = 0; ih < inHeight; ih++)
+            for (int iw = 0; iw < inWidth; iw++) {
+                int oh = ih * strideH - padH + kh;
+                int ow = iw * strideW - padW + kw;
+                if (oh >= 0 && oh < outHeight && ow >= 0 && ow < outWidth)
+                    sum += inp[((b * inChannels + ic) * inHeight + ih) * inWidth + iw]
+                         * gradOutput[((b * outChannels + oc) * outHeight + oh) * outWidth + ow];
+            }
+    gradWeights[idx] = sum;
+}";
+
+    // ---- Conv3D (forward, gather; weights [outC, inC, kD, kH, kW]) ----
+    public const string Conv3D = Header + @"
+layout(set=0, binding=0) buffer B0 { float inp[]; };
+layout(set=0, binding=1) buffer B1 { float wgt[]; };
+layout(set=0, binding=2) buffer B2 { float outp[]; };
+layout(push_constant) uniform PC {
+    int batch; int inChannels; int inDepth; int inHeight; int inWidth;
+    int outChannels; int outDepth; int outHeight; int outWidth;
+    int kernelD; int kernelH; int kernelW; int strideD; int strideH; int strideW;
+    int padD; int padH; int padW; int dilationD; int dilationH; int dilationW;
+};
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    int total = batch * outChannels * outDepth * outHeight * outWidth;
+    if (gid >= uint(total)) return;
+    int idx = int(gid);
+    int ow = idx % outWidth; int t = idx / outWidth;
+    int oh = t % outHeight; t = t / outHeight;
+    int od = t % outDepth; t = t / outDepth;
+    int oc = t % outChannels; int b = t / outChannels;
+    float sum = 0.0;
+    for (int ic = 0; ic < inChannels; ic++)
+        for (int kd = 0; kd < kernelD; kd++)
+            for (int kh = 0; kh < kernelH; kh++)
+                for (int kw = 0; kw < kernelW; kw++) {
+                    int id = od * strideD - padD + kd * dilationD;
+                    int ih = oh * strideH - padH + kh * dilationH;
+                    int iw = ow * strideW - padW + kw * dilationW;
+                    if (id >= 0 && id < inDepth && ih >= 0 && ih < inHeight && iw >= 0 && iw < inWidth)
+                        sum += inp[(((b * inChannels + ic) * inDepth + id) * inHeight + ih) * inWidth + iw]
+                             * wgt[(((oc * inChannels + ic) * kernelD + kd) * kernelH + kh) * kernelW + kw];
+                }
+    outp[(((b * outChannels + oc) * outDepth + od) * outHeight + oh) * outWidth + ow] = sum;
+}";
+
+    // ---- Unfold (Vulkan column layout [b, colRow=(c*kH+ki)*kW+kj, colLen=outH*outW], no dilation): one thread
+    // per column element. Matches VulkanBackend.Unfold's CPU layout exactly (NOT the OpenCL patch-major im2col). ----
+    public const string Unfold = Header + @"
+layout(set=0, binding=0) buffer B0 { float inp[]; };
+layout(set=0, binding=1) buffer B1 { float outp[]; };
+layout(push_constant) uniform PC {
+    int batch; int channels; int height; int width;
+    int kernelH; int kernelW; int strideH; int strideW; int padH; int padW;
+};
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    int outH = (height + 2 * padH - kernelH) / strideH + 1;
+    int outW = (width + 2 * padW - kernelW) / strideW + 1;
+    int colLen = outH * outW;
+    int colCh = channels * kernelH * kernelW;
+    int total = batch * colCh * colLen;
+    if (gid >= uint(total)) return;
+    int idx = int(gid);
+    int b = idx / (colCh * colLen);
+    int r = idx % (colCh * colLen);
+    int colRow = r / colLen;
+    int pos = r % colLen;
+    int oh = pos / outW; int ow = pos % outW;
+    int c = colRow / (kernelH * kernelW);
+    int k = colRow % (kernelH * kernelW);
+    int ki = k / kernelW; int kj = k % kernelW;
+    int ih = oh * strideH + ki - padH;
+    int iw = ow * strideW + kj - padW;
+    float val = 0.0;
+    if (ih >= 0 && ih < height && iw >= 0 && iw < width)
+        val = inp[(b * channels + c) * height * width + ih * width + iw];
+    outp[idx] = val;
+}";
+
+    // ---- Fold (Vulkan layout, GATHER per output pixel — race-free inverse of Unfold's scatter) ----
+    public const string Fold = Header + @"
+layout(set=0, binding=0) buffer B0 { float inp[]; };
+layout(set=0, binding=1) buffer B1 { float outp[]; };
+layout(push_constant) uniform PC {
+    int batch; int channels; int outputH; int outputW;
+    int kernelH; int kernelW; int strideH; int strideW; int padH; int padW;
+};
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    int total = batch * channels * outputH * outputW;
+    if (gid >= uint(total)) return;
+    int idx = int(gid);
+    int iw = idx % outputW; int t = idx / outputW;
+    int ih = t % outputH; t = t / outputH;
+    int c = t % channels; int b = t / channels;
+    int unfoldH = (outputH + 2 * padH - kernelH) / strideH + 1;
+    int unfoldW = (outputW + 2 * padW - kernelW) / strideW + 1;
+    int colLen = unfoldH * unfoldW;
+    int colCh = channels * kernelH * kernelW;
+    float sum = 0.0;
+    for (int ki = 0; ki < kernelH; ki++)
+        for (int kj = 0; kj < kernelW; kj++) {
+            int ohn = ih - ki + padH;
+            int own = iw - kj + padW;
+            if ((ohn % strideH) == 0 && (own % strideW) == 0) {
+                int oh = ohn / strideH; int ow = own / strideW;
+                if (oh >= 0 && oh < unfoldH && ow >= 0 && ow < unfoldW) {
+                    int colRow = (c * kernelH + ki) * kernelW + kj;
+                    sum += inp[b * colCh * colLen + colRow * colLen + oh * unfoldW + ow];
+                }
+            }
+        }
+    outp[idx] = sum;
+}";
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanConvPoolKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanConvPoolKernels.cs
@@ -1,0 +1,146 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// GLSL compute kernels for the Vulkan conv/pool family (issue #646). Each is a 1D-flattened port of the
+// corresponding VERIFIED OpenCL kernel (one thread per output element; index decoded from gl_GlobalInvocationID.x),
+// so the math matches the OpenCL/CUDA references. Dispatched via VulkanBackend.TryDispatchConvPoolGlsl with the
+// param ints supplied as a push-constant block in declaration order. These require libshaderc at runtime and are
+// validated on a Vulkan runner (not on the dev box).
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.Vulkan;
+
+internal static class VulkanConvPoolKernels
+{
+    private const string Header = @"#version 450
+layout(local_size_x = 256) in;
+";
+
+    // ---- Average pooling 2D (forward, gather) ----
+    public const string AvgPool2D = Header + @"
+layout(set=0, binding=0) buffer B0 { float inp[]; };
+layout(set=0, binding=1) buffer B1 { float outp[]; };
+layout(push_constant) uniform PC {
+    int batch; int channels; int inHeight; int inWidth;
+    int outHeight; int outWidth; int kernelH; int kernelW;
+    int strideH; int strideW; int padH; int padW; int countIncludePad;
+};
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    int total = batch * channels * outHeight * outWidth;
+    if (gid >= uint(total)) return;
+    int idx = int(gid);
+    int ow = idx % outWidth; int t = idx / outWidth;
+    int oh = t % outHeight; t = t / outHeight;
+    int c = t % channels; int b = t / channels;
+    float sum = 0.0; int count = 0;
+    for (int kh = 0; kh < kernelH; kh++) {
+        for (int kw = 0; kw < kernelW; kw++) {
+            int ih = oh * strideH - padH + kh;
+            int iw = ow * strideW - padW + kw;
+            if (ih >= 0 && ih < inHeight && iw >= 0 && iw < inWidth) {
+                sum += inp[((b * channels + c) * inHeight + ih) * inWidth + iw]; count++;
+            } else if (countIncludePad != 0) { count++; }
+        }
+    }
+    int divisor = (countIncludePad != 0) ? (kernelH * kernelW) : max(count, 1);
+    outp[((b * channels + c) * outHeight + oh) * outWidth + ow] = sum / float(divisor);
+}";
+
+    // ---- Average pooling 2D (backward, GATHER per input element — race-free) ----
+    public const string AvgPool2DBackward = Header + @"
+layout(set=0, binding=0) buffer B0 { float gradOutput[]; };
+layout(set=0, binding=1) buffer B1 { float gradInput[]; };
+layout(push_constant) uniform PC {
+    int batch; int channels; int inHeight; int inWidth;
+    int outHeight; int outWidth; int kernelH; int kernelW;
+    int strideH; int strideW; int padH; int padW; int countIncludePad;
+};
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    int total = batch * channels * inHeight * inWidth;
+    if (gid >= uint(total)) return;
+    int idx = int(gid);
+    int iw = idx % inWidth; int t = idx / inWidth;
+    int ih = t % inHeight; t = t / inHeight;
+    int c = t % channels; int b = t / channels;
+    float sum = 0.0;
+    for (int oh = 0; oh < outHeight; oh++) {
+        for (int ow = 0; ow < outWidth; ow++) {
+            int hStart = oh * strideH - padH;
+            int wStart = ow * strideW - padW;
+            int hEnd = hStart + kernelH;
+            int wEnd = wStart + kernelW;
+            if (ih >= hStart && ih < hEnd && iw >= wStart && iw < wEnd) {
+                int poolSize;
+                if (countIncludePad != 0) {
+                    poolSize = kernelH * kernelW;
+                } else {
+                    int hs = max(hStart, 0); int he = min(hEnd, inHeight);
+                    int ws = max(wStart, 0); int we = min(wEnd, inWidth);
+                    poolSize = (he - hs) * (we - ws);
+                }
+                sum += gradOutput[((b * channels + c) * outHeight + oh) * outWidth + ow] / float(max(poolSize, 1));
+            }
+        }
+    }
+    gradInput[((b * channels + c) * inHeight + ih) * inWidth + iw] = sum;
+}";
+
+    // ---- Max pooling 2D (forward, gather; writes argmax indices as raw int bits) ----
+    public const string MaxPool2D = Header + @"
+layout(set=0, binding=0) buffer B0 { float inp[]; };
+layout(set=0, binding=1) buffer B1 { float outp[]; };
+layout(set=0, binding=2) buffer B2 { int indices[]; };
+layout(push_constant) uniform PC {
+    int batch; int channels; int inHeight; int inWidth;
+    int outHeight; int outWidth; int kernelH; int kernelW;
+    int strideH; int strideW; int padH; int padW;
+};
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    int total = batch * channels * outHeight * outWidth;
+    if (gid >= uint(total)) return;
+    int idx = int(gid);
+    int ow = idx % outWidth; int t = idx / outWidth;
+    int oh = t % outHeight; t = t / outHeight;
+    int c = t % channels; int b = t / channels;
+    float maxVal = -3.402823466e+38;
+    int maxIdx = 0;
+    for (int kh = 0; kh < kernelH; kh++) {
+        for (int kw = 0; kw < kernelW; kw++) {
+            int ih = oh * strideH - padH + kh;
+            int iw = ow * strideW - padW + kw;
+            if (ih >= 0 && ih < inHeight && iw >= 0 && iw < inWidth) {
+                float v = inp[((b * channels + c) * inHeight + ih) * inWidth + iw];
+                if (v > maxVal) { maxVal = v; maxIdx = ih * inWidth + iw; }
+            }
+        }
+    }
+    int outIdx = ((b * channels + c) * outHeight + oh) * outWidth + ow;
+    outp[outIdx] = maxVal;
+    indices[outIdx] = maxIdx;
+}";
+
+    // ---- Max pooling 2D (backward). Mirrors the OpenCL reference's non-atomic scatter-add: each output routes its
+    // gradient to its argmax input. Collisions (two windows sharing an argmax) race exactly as the OpenCL kernel
+    // does; parity with the validated reference is the contract. ----
+    public const string MaxPool2DBackward = Header + @"
+layout(set=0, binding=0) buffer B0 { float gradOutput[]; };
+layout(set=0, binding=1) buffer B1 { int indices[]; };
+layout(set=0, binding=2) buffer B2 { float gradInput[]; };
+layout(push_constant) uniform PC {
+    int batch; int channels; int inHeight; int inWidth; int outHeight; int outWidth;
+};
+void main() {
+    uint gid = gl_GlobalInvocationID.x;
+    int total = batch * channels * outHeight * outWidth;
+    if (gid >= uint(total)) return;
+    int outIdx = int(gid);
+    int ow = outIdx % outWidth; int t = outIdx / outWidth;
+    int oh = t % outHeight; t = t / outHeight;
+    int c = t % channels; int b = t / channels;
+    float grad = gradOutput[outIdx];
+    int maxIdx = indices[outIdx];
+    int ih = maxIdx / inWidth;
+    int iw = maxIdx % inWidth;
+    gradInput[((b * channels + c) * inHeight + ih) * inWidth + iw] += grad;
+}";
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -6863,16 +6863,38 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
     }
 
+    [ThreadStatic]
+    private static bool s_throwOnGpuKernelFallback;
+
     /// <summary>
-    /// Test/diagnostic hook (default <c>false</c>): when <c>true</c>, the conv / pool / attention GPU-kernel
-    /// <c>catch</c> blocks RETHROW the kernel exception instead of silently falling back to the CPU reference.
-    /// <see cref="GpuConvKernelCoverageTests"/> (in the test project) enables it so the GPU-vs-CPU accuracy gate
-    /// PROVES the GPU kernel actually ran — a kernel that threw would otherwise fall back to CPU and the
-    /// comparison would trivially pass (false green), exactly the gap that let issue #622 look "fixed" without
-    /// proof. Production leaves it <c>false</c>: the CPU fallback stays a correctness safety net for genuinely
+    /// Test/diagnostic hook (default <c>false</c>; <c>[ThreadStatic]</c> so it only affects the thread that
+    /// sets it and never leaks into other parallel test collections). When <c>true</c>, the GPU-kernel
+    /// <c>catch</c> blocks that route conv / transpose / unfold-fold / pooling / locally-connected /
+    /// deformable / attention operations to their CPU reference RETHROW the kernel exception instead of
+    /// silently falling back. Because the per-kernel fallback now lives partly inside the individual backends
+    /// (Metal / Vulkan implement the conv/pool family in their own classes), the flag is a process-wide
+    /// <c>static</c> so those backend <c>catch</c> blocks can honor it too
+    /// (<see cref="ThrowOnGpuKernelFallback"/> is read from <c>DirectGpuTensorEngine</c> by the backends).
+    /// <para>
+    /// <see cref="GpuConvKernelCoverageTests"/> (in the test project) enables it so the GPU-vs-CPU accuracy
+    /// gate PROVES the GPU kernel actually ran on-device — a kernel that threw (or a backend that silently
+    /// emulated on CPU and then threw on a real launch) would otherwise fall back to CPU and the comparison
+    /// would trivially pass (false green), exactly the gap that let issue #622 look "fixed" without proof.
+    /// </para>
+    /// <para>
+    /// Scope: this hook covers the conv/pool-family kernels exercised by the coverage suite (the methods whose
+    /// <c>catch</c> blocks contain the rethrow, both here and in the Metal/Vulkan backends). It is a coverage
+    /// aid, NOT a guarantee that every <c>catch</c> in the GPU stack rethrows; unrelated catch blocks (argument
+    /// validation, capability probing, non-kernel host paths) deliberately keep their normal behavior.
+    /// Production leaves it <c>false</c>: the CPU fallback stays a correctness safety net for genuinely
     /// unsupported shapes or transient launch failures.
+    /// </para>
     /// </summary>
-    internal bool ThrowOnGpuKernelFallback { get; set; }
+    internal static bool ThrowOnGpuKernelFallback
+    {
+        get => s_throwOnGpuKernelFallback;
+        set => s_throwOnGpuKernelFallback = value;
+    }
 
     /// <summary>
     /// GPU-accelerated locally connected 2D backward pass for weight gradients.

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -5899,6 +5899,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
         catch
         {
+            if (ThrowOnGpuKernelFallback) throw;
             return base.FusedConv3D(input, kernel, bias, strideD, strideH, strideW, padD, padH, padW, dilationD, dilationH, dilationW, activation);
         }
     }
@@ -6116,6 +6117,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
         catch
         {
+            if (ThrowOnGpuKernelFallback) throw;
             return base.FusedConvTranspose2D(input, kernel, bias, strideH, strideW, padH, padW, outputPadH, outputPadW, activation);
         }
     }
@@ -6633,6 +6635,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
         catch
         {
+            if (ThrowOnGpuKernelFallback) throw;
             return base.DepthwiseConv2D(input, kernel, stride, padding);
         }
     }
@@ -6798,6 +6801,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
         catch
         {
+            if (ThrowOnGpuKernelFallback) throw;
             // Fall back to CPU on any GPU error
             return base.LocallyConnectedConv2D(input, weights, bias, stride);
         }
@@ -6854,9 +6858,21 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
         catch
         {
+            if (ThrowOnGpuKernelFallback) throw;
             return base.LocallyConnectedConv2DBackwardInput(gradOutput, weights, inputShape, stride);
         }
     }
+
+    /// <summary>
+    /// Test/diagnostic hook (default <c>false</c>): when <c>true</c>, the conv / pool / attention GPU-kernel
+    /// <c>catch</c> blocks RETHROW the kernel exception instead of silently falling back to the CPU reference.
+    /// <see cref="GpuConvKernelCoverageTests"/> (in the test project) enables it so the GPU-vs-CPU accuracy gate
+    /// PROVES the GPU kernel actually ran — a kernel that threw would otherwise fall back to CPU and the
+    /// comparison would trivially pass (false green), exactly the gap that let issue #622 look "fixed" without
+    /// proof. Production leaves it <c>false</c>: the CPU fallback stays a correctness safety net for genuinely
+    /// unsupported shapes or transient launch failures.
+    /// </summary>
+    internal bool ThrowOnGpuKernelFallback { get; set; }
 
     /// <summary>
     /// GPU-accelerated locally connected 2D backward pass for weight gradients.
@@ -6908,6 +6924,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
         catch
         {
+            if (ThrowOnGpuKernelFallback) throw;
             return base.LocallyConnectedConv2DBackwardWeights(gradOutput, input, weightsShape, stride);
         }
     }
@@ -7103,6 +7120,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
         catch
         {
+            if (ThrowOnGpuKernelFallback) throw;
             return base.DeformableConv2D(input, kernel, offsets, mask, stride, padding, dilation);
         }
     }
@@ -7177,6 +7195,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
         catch
         {
+            if (ThrowOnGpuKernelFallback) throw;
             return base.DeformableConv2DBackwardInput(gradOutput, input, kernel, offsets, mask, inputShape, stride, padding, dilation);
         }
     }
@@ -7250,6 +7269,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
         catch
         {
+            if (ThrowOnGpuKernelFallback) throw;
             return base.DeformableConv2DBackwardKernel(gradOutput, input, offsets, mask, kernelShape, stride, padding, dilation);
         }
     }
@@ -7325,6 +7345,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
         catch
         {
+            if (ThrowOnGpuKernelFallback) throw;
             return base.DeformableConv2DBackwardOffset(gradOutput, input, kernel, offsets, mask, stride, padding, dilation);
         }
     }
@@ -7395,6 +7416,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
         catch
         {
+            if (ThrowOnGpuKernelFallback) throw;
             return base.DeformableConv2DBackwardMask(gradOutput, input, kernel, offsets, mask, stride, padding, dilation);
         }
     }
@@ -8167,6 +8189,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
         catch
         {
+            if (ThrowOnGpuKernelFallback) throw;
             return base.FlashAttentionBackward(gradOutput, query, key, value, output, softmaxStats, scale, isCausal,
                 out gradQuery, out gradKey, out gradValue, attentionBias);
         }

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuConvKernelCoverageTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuConvKernelCoverageTests.cs
@@ -23,20 +23,32 @@ public sealed class GpuConvKernelCoverageTests : IDisposable
 
     public GpuConvKernelCoverageTests()
     {
+        // Only swallow the two exceptions that mean "no native GPU runtime on this host"
+        // (PlatformNotSupportedException / DllNotFoundException). A real GPU setup or kernel/module
+        // compilation regression MUST surface as a test failure, not get converted into an "unavailable"
+        // skip that hides the regression this suite exists to catch. Mirrors DetectionGpuParityTests.
         try
         {
             _gpu = new DirectGpuTensorEngine();
             _ready = _gpu.SupportsGpu;
-            // Prove the GPU kernel ACTUALLY runs: make the conv/pool/attention catch blocks rethrow instead of
-            // silently falling back to the CPU reference. Without this, a GPU kernel that threw would fall back to
-            // CPU and every GPU-vs-CPU assertion below would compare CPU-vs-CPU and trivially pass (false green) —
-            // the exact gap that left issue #622 looking "fixed" without proof.
-            if (_gpu is not null) _gpu.ThrowOnGpuKernelFallback = true;
         }
-        catch { _ready = false; }
+        catch (PlatformNotSupportedException) { _ready = false; }
+        catch (DllNotFoundException) { _ready = false; }
+
+        // Prove the GPU kernel ACTUALLY runs: make the conv/pool/attention catch blocks (here in the engine
+        // AND inside the Metal/Vulkan backends) rethrow instead of silently falling back to the CPU reference.
+        // Without this, a GPU kernel that threw would fall back to CPU and every GPU-vs-CPU assertion below
+        // would compare CPU-vs-CPU and trivially pass (false green) — the exact gap that left issue #622
+        // looking "fixed" without proof. The flag is [ThreadStatic], so set it only when a GPU is present and
+        // always clear it in Dispose so it never leaks into other test collections on this thread.
+        if (_ready) DirectGpuTensorEngine.ThrowOnGpuKernelFallback = true;
     }
 
-    public void Dispose() => _gpu?.Dispose();
+    public void Dispose()
+    {
+        DirectGpuTensorEngine.ThrowOnGpuKernelFallback = false;
+        _gpu?.Dispose();
+    }
 
     // Skip (visibly, via Xunit.SkipException) rather than silently `return` when
     // no GPU is present, so a failed/absent GPU setup shows as a skipped test

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuConvKernelCoverageTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuConvKernelCoverageTests.cs
@@ -245,4 +245,55 @@ public sealed class GpuConvKernelCoverageTests : IDisposable
         AssertClose(dKc, dKg, "FlashAttentionBackward.dK");
         AssertClose(dVc, dVg, "FlashAttentionBackward.dV");
     }
+
+    // ---- Conv/pool family forward coverage (#646): these high-level engine ops dispatch to the backend
+    // conv/pool kernels, so on a Metal/Vulkan runner they gate the new MSL/GLSL kernels (and on OpenCL they
+    // confirm the shared math vs the CPU reference). ----
+    [SkippableFact]
+    public void Conv2D_Gpu_MatchesCpu()
+    {
+        SkipIfUnavailable();
+        var input = R(60, 1, 2, 6, 6);
+        var kernel = R(61, 3, 2, 3, 3); // [outC, inC, kH, kW]
+        int[] stride = { 1, 1 }, pad = { 1, 1 }, dil = { 1, 1 };
+        AssertClose(_cpu.Conv2D(input, kernel, stride, pad, dil),
+                    _gpu.Conv2D(input, kernel, stride, pad, dil), "Conv2D");
+    }
+
+    [SkippableFact]
+    public void Conv3D_Gpu_MatchesCpu()
+    {
+        SkipIfUnavailable();
+        var input = R(62, 1, 2, 4, 4, 4);
+        var kernel = R(63, 3, 2, 2, 2, 2); // [outC, inC, kD, kH, kW]
+        int[] stride = { 1, 1, 1 }, pad = { 0, 0, 0 }, dil = { 1, 1, 1 };
+        AssertClose(_cpu.Conv3D(input, kernel, stride, pad, dil),
+                    _gpu.Conv3D(input, kernel, stride, pad, dil), "Conv3D");
+    }
+
+    [SkippableFact]
+    public void GlobalAvgPool2D_Gpu_MatchesCpu()
+    {
+        SkipIfUnavailable();
+        var input = R(64, 2, 3, 5, 5);
+        AssertClose(_cpu.GlobalAvgPool2D(input), _gpu.GlobalAvgPool2D(input), "GlobalAvgPool2D");
+    }
+
+    [SkippableFact]
+    public void GlobalMaxPool2D_Gpu_MatchesCpu()
+    {
+        SkipIfUnavailable();
+        var input = R(65, 2, 3, 5, 5);
+        AssertClose(_cpu.GlobalMaxPool2D(input), _gpu.GlobalMaxPool2D(input), "GlobalMaxPool2D");
+    }
+
+    [SkippableFact]
+    public void MaxPool3D_Gpu_MatchesCpu()
+    {
+        SkipIfUnavailable();
+        var input = R(66, 1, 2, 4, 4, 4);
+        int[] pool = { 2, 2, 2 }, stride = { 2, 2, 2 }, pad = { 0, 0, 0 };
+        AssertClose(_cpu.MaxPool3D(input, pool, stride, pad),
+                    _gpu.MaxPool3D(input, pool, stride, pad), "MaxPool3D");
+    }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuConvKernelCoverageTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuConvKernelCoverageTests.cs
@@ -23,7 +23,16 @@ public sealed class GpuConvKernelCoverageTests : IDisposable
 
     public GpuConvKernelCoverageTests()
     {
-        try { _gpu = new DirectGpuTensorEngine(); _ready = _gpu.SupportsGpu; }
+        try
+        {
+            _gpu = new DirectGpuTensorEngine();
+            _ready = _gpu.SupportsGpu;
+            // Prove the GPU kernel ACTUALLY runs: make the conv/pool/attention catch blocks rethrow instead of
+            // silently falling back to the CPU reference. Without this, a GPU kernel that threw would fall back to
+            // CPU and every GPU-vs-CPU assertion below would compare CPU-vs-CPU and trivially pass (false green) —
+            // the exact gap that left issue #622 looking "fixed" without proof.
+            if (_gpu is not null) _gpu.ThrowOnGpuKernelFallback = true;
+        }
         catch { _ready = false; }
     }
 


### PR DESCRIPTION
Closes #622
Closes #646

## Summary
Closes the verification gap behind issue #622 and fixes a **real hidden GPU bug** the hardening surfaced.

### Context
Issue #622 tracked 6 conv kernels (DeformableConv2D fwd + 4 backward, `LocallyConnectedConv2DBackwardWeights`) that disagreed with the CPU reference and fell back to CPU. **PR #623 already fixed those kernels** — this PR confirms they genuinely run on the OpenCL GPU and match CPU, then hardens the gate so it can't silently regress.

### The hidden bug
`GpuConvKernelCoverageTests` compares `gpu.X` vs `cpu.X`, but every conv/pool/attention method falls back to the CPU reference inside a `catch`. So a GPU kernel that **threw** would fall back and the test would compare **CPU-vs-CPU** → trivially pass (false green).

`OpenClBackend.ConvTranspose2D` bound only **16 of the kernel's 18 args** (omitted `outputPadH`/`outputPadW`) → `CL_INVALID_KERNEL_ARGS` (-52) at enqueue → silent CPU fallback. `FusedConvTranspose2D_Gpu_MatchesCpu` was passing **falsely**. Fixed by binding the two missing args; the GPU kernel now runs and matches CPU.

### Changes
- **`OpenClBackend.ConvTranspose2D`**: bind the missing `outputPadH`/`outputPadW` kernel args (the real fix).
- **`DirectGpuTensorEngine.ThrowOnGpuKernelFallback`** (internal, default `false`): the 12 conv/pool/attention `catch` blocks rethrow instead of silently falling back to CPU. Production keeps the CPU safety net (flag off).
- **`GpuConvKernelCoverageTests`** enables the flag → the gate now **proves the GPU kernel actually ran** and can never false-green again.

### Validation (OpenCL, AMD RDNA1)
- All **12** `GpuConvKernelCoverageTests` pass in strict no-fallback mode (incl. all 6 from #622 + the now-fixed FusedConvTranspose2D).
- ConvTranspose suite: **25/25**.
- `net10.0` + `net471` build clean.

> Note: CUDA/HIP/Metal/Vulkan/WebGpu `ConvTranspose2D` arg-binding likely shares the same omission; the now-strict gate will surface it on those runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded GPU-first execution to transposed convolution on Metal and Vulkan.
  * Added broader convolution/pooling GPU fast paths on Vulkan (with automatic CPU fallback when GPU execution isn’t possible).

* **Bug Fixes**
  * Fixed OpenCL transposed-convolution kernel dispatch by ensuring required kernel arguments are bound, preventing invalid-argument errors and unintended CPU fallbacks.
  * Corrected Vulkan transposed-convolution CPU fallback output handling for padded bounds.

* **Improvements**
  * Added an optional diagnostic mode to throw when GPU kernel fallback would occur.

* **Tests**
  * Updated GPU convolution coverage tests to enable the diagnostic mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
