### PR TITLE
fix(autodiff): detach segment inputs in checkpoint recompute (multi-segment double-count)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientCheckpointing.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientCheckpointing.cs
@@ -88,7 +88,17 @@ public static class GradientCheckpointing<T>
                     using var recomputeTape = new GradientTape<T>(
                         new GradientTapeOptions { Persistent = false });
                     var reInput = inputs[0];
-                    var reOutput = reInput;
+                    // Detach the segment input so the recompute graph is SELF-CONTAINED: its backward
+                    // stops at the segment boundary instead of following reInput's producer into an
+                    // EARLIER checkpoint segment. Without this, ComputeGradients(sources: null) below
+                    // re-enters the previous segment's recompute (nested) and scatters its gradients,
+                    // which the outer reverse walk then ALSO computes — double-counting every earlier
+                    // segment's gradients (2x with two segments; (N-i)x for segment i of N). This
+                    // mirrors torch.utils.checkpoint's detach_variable(inputs). StopGradient returns a
+                    // fresh leaf (data copy, no GradFn); the input gradient it produces is remapped
+                    // back onto the original reInput tensor when scattering below.
+                    var reInputDetached = eng.StopGradient(reInput);
+                    var reOutput = reInputDetached;
                     for (int i = capturedStart; i < capturedEnd; i++)
                         reOutput = capturedFunctions[i](reOutput);
 
@@ -130,29 +140,21 @@ public static class GradientCheckpointing<T>
                     var pseudoLoss = eng.ReduceSum(weighted);
 
                     // Differentiate the recomputed segment w.r.t. EVERY leaf it touched — the
-                    // segment input AND every weight/parameter the segment's functions read —
-                    // not just the input. PyTorch's torch.utils.checkpoint backpropagates the
+                    // (detached) segment input AND every weight/parameter the segment's functions
+                    // read — not just the input. PyTorch's torch.utils.checkpoint backpropagates the
                     // recomputed forward through all inputs that require grad, including module
-                    // parameters; an earlier version requested only `reInput`, so the WEIGHT
-                    // gradients of every checkpointed layer were silently dropped — the outer
-                    // ComputeGradients then found no gradient for those params and they never
-                    // updated (checkpointed layers did not learn; ~half of a Transformer's
-                    // parameters diverged from the eager update). `sources: null` differentiates
-                    // the whole recomputed graph.
+                    // parameters; an earlier version requested only `reInput`, so the WEIGHT gradients
+                    // of every checkpointed layer were silently dropped and checkpointed layers never
+                    // learned. `sources: null` differentiates the whole recomputed graph.
                     //
-                    // Scattering correctness: the outer forward ran this segment under NoGrad
-                    // (its ops were never recorded on the outer tape), so this recompute is the
-                    // ONLY place the segment's gradient contributions exist — there is no double
-                    // counting. Accumulating each leaf's grad into the outer `grads` accumulator
-                    // is therefore exactly right: the segment input and parameters are the same
-                    // tensor instances the caller looks up, and any captured upstream tensor gets
-                    // its segment-side contribution propagated further when the outer reverse walk
-                    // reaches that tensor's producer (the segment entry is processed before its
-                    // producers in reverse order). The recompute's throwaway intermediates are
-                    // fresh instances the caller never queries — harmless. The sole exclusion is
-                    // gradOutput: an outer-tape constant folded into the pseudo-loss only to seed
-                    // the VJP, whose inner "gradient" (== reOutput) is not a real gradient and
-                    // must not leak back onto the outer tape.
+                    // Scattering correctness: the input was detached above, so this recompute graph is
+                    // self-contained — its only leaves are the detached input and the segment's own
+                    // parameters; it does NOT reach into earlier segments, so each leaf is computed
+                    // exactly once and the outer reverse walk computes earlier segments exactly once
+                    // too (no double counting). The recompute's throwaway intermediates are fresh
+                    // instances the caller never queries — harmless. The sole exclusion is gradOutput:
+                    // an outer-tape constant folded into the pseudo-loss only to seed the VJP, whose
+                    // inner "gradient" (== reOutput) is not a real gradient and must not leak back.
                     var segGrads = recomputeTape.ComputeGradients(pseudoLoss, sources: null);
 
                     bool accumulatedAny = false;
@@ -160,7 +162,11 @@ public static class GradientCheckpointing<T>
                     {
                         if (ReferenceEquals(kvp.Key, gradOutput)) continue;
                         if (kvp.Value is null) continue;
-                        DifferentiableOps.AccumulateGrad(grads, kvp.Key, kvp.Value, eng);
+                        // The detached input's gradient belongs to the ORIGINAL segment-input tensor
+                        // the caller tracks (and that the outer walk hands to the previous segment);
+                        // remap it. Every other key is a live parameter the segment read directly.
+                        var key = ReferenceEquals(kvp.Key, reInputDetached) ? reInput : kvp.Key;
+                        DifferentiableOps.AccumulateGrad(grads, key, kvp.Value, eng);
                         accumulatedAny = true;
                     }
 
@@ -169,9 +175,11 @@ public static class GradientCheckpointing<T>
                     // equality is the only safe alias predicate — it covers the empty-segment case
                     // without false positives on shape coincidence. For a genuinely input-
                     // independent segment, leaving grads[input] untouched (zero) is the correct VJP.
-                    if (!accumulatedAny && ReferenceEquals(reOutput, reInput))
+                    if (!accumulatedAny && ReferenceEquals(reOutput, reInputDetached))
                     {
-                        DifferentiableOps.AccumulateGrad(grads, inputs[0], gradOutput, eng);
+                        // Empty / no-op segment (no functions ran): pass the upstream gradient straight
+                        // through to the original input.
+                        DifferentiableOps.AccumulateGrad(grads, reInput, gradOutput, eng);
                     }
                 });
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientCorrectnessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientCorrectnessTests.cs
@@ -480,6 +480,227 @@ public class GradientCorrectnessTests : IDisposable
             Assert.Equal(eager[x][i], ckpt[x][i], 3);
     }
 
+    /// <summary>
+    /// MULTI-SEGMENT variant: two matmul segments checkpointed with segmentSize=1 (one segment each).
+    /// Each segment's input and weight gradients must match the eager run. Guards against cross-segment
+    /// double-counting in the recompute backward (the earlier sources:null scatter could attribute a
+    /// segment input's gradient to more than one segment).
+    /// </summary>
+    [Fact]
+    public void Checkpoint_TwoSegments_ParameterGradients_MatchEager()
+    {
+        Tensor<float> MakeFilled(int[] shape, float start, float step)
+        {
+            var t = new Tensor<float>(shape);
+            for (int i = 0; i < t.Length; i++) t[i] = start + step * i;
+            return t;
+        }
+
+        var x = MakeFilled([2, 3], -0.4f, 0.05f);
+        var w0 = MakeFilled([3, 4], -0.3f, 0.03f);
+        var w1 = MakeFilled([4, 4], -0.2f, 0.02f);
+        var outW = MakeFilled([2, 4], 0.1f, 0.02f);
+
+        Func<Tensor<float>, Tensor<float>> seg0 = inp => _engine.ReLU(_engine.TensorMatMul(inp, w0));
+        Func<Tensor<float>, Tensor<float>> seg1 = inp => _engine.ReLU(_engine.TensorMatMul(inp, w1));
+
+        System.Collections.Generic.Dictionary<Tensor<float>, Tensor<float>> Run(bool checkpoint)
+        {
+            using var tape = new GradientTape<float>();
+            Tensor<float> o;
+            if (checkpoint)
+                o = GradientCheckpointing<float>.Checkpoint(new[] { seg0, seg1 }, x, segmentSize: 1);
+            else { o = seg0(x); o = seg1(o); }
+            var loss = _engine.ReduceSum(_engine.TensorMultiply(o, outW));
+            return tape.ComputeGradients(loss, sources: new[] { x, w0, w1 });
+        }
+
+        var eager = Run(checkpoint: false);
+        var ckpt = Run(checkpoint: true);
+
+        foreach (var (name, t) in new[] { ("x", x), ("w0", w0), ("w1", w1) })
+        {
+            Assert.True(ckpt.ContainsKey(t), $"checkpointed run missing {name} gradient");
+            for (int i = 0; i < eager[t].Length; i++)
+                Assert.Equal(eager[t][i], ckpt[t][i], 3);
+        }
+    }
+
+    /// <summary>
+    /// PERSISTENT-WEIGHT variant: the checkpointed segment's weight is registered as a persistent
+    /// tensor (as every real layer's weights are via RegisterPersistentTensor). Reproduces the case
+    /// where the recompute's gradient gets double-counted for registered parameters.
+    /// </summary>
+    [Fact]
+    public void Checkpoint_PersistentWeight_ParameterGradients_MatchEager()
+    {
+        Tensor<float> MakeFilled(int[] shape, float start, float step)
+        {
+            var t = new Tensor<float>(shape);
+            for (int i = 0; i < t.Length; i++) t[i] = start + step * i;
+            return t;
+        }
+
+        var x = MakeFilled([2, 3], -0.4f, 0.05f);
+        var w = MakeFilled([3, 4], -0.3f, 0.03f);
+        _engine.RegisterPersistentTensor(w, PersistentTensorRole.Weights);
+        try
+        {
+            var outW = MakeFilled([2, 4], 0.1f, 0.02f);
+            Func<Tensor<float>, Tensor<float>> seg = inp => _engine.ReLU(_engine.TensorMatMul(inp, w));
+
+            System.Collections.Generic.Dictionary<Tensor<float>, Tensor<float>> Run(bool checkpoint)
+            {
+                using var tape = new GradientTape<float>();
+                var o = checkpoint
+                    ? GradientCheckpointing<float>.Checkpoint(new[] { seg }, x, segmentSize: 1)
+                    : seg(x);
+                var loss = _engine.ReduceSum(_engine.TensorMultiply(o, outW));
+                return tape.ComputeGradients(loss, sources: new[] { x, w });
+            }
+
+            var eager = Run(checkpoint: false);
+            var ckpt = Run(checkpoint: true);
+
+            for (int i = 0; i < eager[w].Length; i++)
+                Assert.Equal(eager[w][i], ckpt[w][i], 3);
+            for (int i = 0; i < eager[x].Length; i++)
+                Assert.Equal(eager[x][i], ckpt[x][i], 3);
+        }
+        finally { _engine.UnregisterPersistentTensor(w); }
+    }
+
+    /// <summary>
+    /// sources:null variant — the mode NeuralNetworkBase tape-training uses
+    /// (ComputeGradients(loss, sources: null)). The checkpointed weight gradient (looked up by key in
+    /// the full-graph result) must equal the eager run's. Guards the recompute scatter against
+    /// double-counting when the OUTER ComputeGradients differentiates the whole graph.
+    /// </summary>
+    [Fact]
+    public void Checkpoint_NullSources_ParameterGradients_MatchEager()
+    {
+        Tensor<float> MakeFilled(int[] shape, float start, float step)
+        {
+            var t = new Tensor<float>(shape);
+            for (int i = 0; i < t.Length; i++) t[i] = start + step * i;
+            return t;
+        }
+
+        var x = MakeFilled([2, 3], -0.4f, 0.05f);
+        var w = MakeFilled([3, 4], -0.3f, 0.03f);
+        var outW = MakeFilled([2, 4], 0.1f, 0.02f);
+        Func<Tensor<float>, Tensor<float>> seg = inp => _engine.ReLU(_engine.TensorMatMul(inp, w));
+
+        System.Collections.Generic.Dictionary<Tensor<float>, Tensor<float>> Run(bool checkpoint)
+        {
+            using var tape = new GradientTape<float>();
+            var o = checkpoint
+                ? GradientCheckpointing<float>.Checkpoint(new[] { seg }, x, segmentSize: 1)
+                : seg(x);
+            var loss = _engine.ReduceSum(_engine.TensorMultiply(o, outW));
+            return tape.ComputeGradients(loss, sources: null);
+        }
+
+        var eager = Run(checkpoint: false);
+        var ckpt = Run(checkpoint: true);
+
+        Assert.True(ckpt.ContainsKey(w), "checkpointed run missing w gradient (null sources)");
+        for (int i = 0; i < eager[w].Length; i++)
+            Assert.Equal(eager[w][i], ckpt[w][i], 3);
+    }
+
+    /// <summary>
+    /// FusedLinear variant — the exact op DenseLayer.Forward uses in training (matmul+bias fused into
+    /// one tape entry). Reproduces the case where a checkpointed DenseLayer block's gradients were 2x
+    /// the eager gradients.
+    /// </summary>
+    [Fact]
+    public void Checkpoint_FusedLinear_ParameterGradients_MatchEager()
+    {
+        Tensor<float> MakeFilled(int[] shape, float start, float step)
+        {
+            var t = new Tensor<float>(shape);
+            for (int i = 0; i < t.Length; i++) t[i] = start + step * i;
+            return t;
+        }
+
+        var x = MakeFilled([2, 3], -0.4f, 0.05f);
+        var w = MakeFilled([3, 4], -0.3f, 0.03f);
+        var b = MakeFilled([4], 0.05f, 0.01f);
+        var outW = MakeFilled([2, 4], 0.1f, 0.02f);
+        Func<Tensor<float>, Tensor<float>> seg = inp =>
+            _engine.FusedLinear(inp, w, b, FusedActivationType.None);
+
+        System.Collections.Generic.Dictionary<Tensor<float>, Tensor<float>> Run(bool checkpoint)
+        {
+            using var tape = new GradientTape<float>();
+            var o = checkpoint
+                ? GradientCheckpointing<float>.Checkpoint(new[] { seg }, x, segmentSize: 1)
+                : seg(x);
+            var loss = _engine.ReduceSum(_engine.TensorMultiply(o, outW));
+            return tape.ComputeGradients(loss, sources: new[] { x, w, b });
+        }
+
+        var eager = Run(checkpoint: false);
+        var ckpt = Run(checkpoint: true);
+
+        foreach (var (name, t) in new[] { ("x", x), ("w", w), ("b", b) })
+        {
+            Assert.True(ckpt.ContainsKey(t), $"checkpointed run missing {name} gradient");
+            for (int i = 0; i < eager[t].Length; i++)
+                Assert.Equal(eager[t][i], ckpt[t][i], 3);
+        }
+    }
+
+    /// <summary>
+    /// MULTI-SEGMENT FusedLinear regression: two FusedLinear segments checkpointed with segmentSize=1
+    /// (two separate segments) — the shape of a checkpointed two-DenseLayer stack. Every parameter's
+    /// gradient (and the input's) must equal the eager run's. Guards the cross-segment defect where the
+    /// recompute of a later segment followed its (non-detached) input back into the earlier segment's
+    /// checkpoint node, re-running it and double-counting every earlier-segment gradient (2x). Detaching
+    /// each segment's input at recompute makes each segment self-contained and the gradients exact.
+    /// </summary>
+    [Fact]
+    public void Checkpoint_TwoSegment_FusedLinear_ParameterGradients_MatchEager()
+    {
+        Tensor<float> MakeFilled(int[] shape, float start, float step)
+        {
+            var t = new Tensor<float>(shape);
+            for (int i = 0; i < t.Length; i++) t[i] = start + step * i;
+            return t;
+        }
+
+        var x = MakeFilled([2, 3], -0.4f, 0.05f);
+        var w0 = MakeFilled([3, 4], -0.3f, 0.03f);
+        var b0 = MakeFilled([4], 0.05f, 0.01f);
+        var w1 = MakeFilled([4, 4], -0.2f, 0.02f);
+        var b1 = MakeFilled([4], 0.03f, 0.01f);
+        var outW = MakeFilled([2, 4], 0.1f, 0.02f);
+
+        Func<Tensor<float>, Tensor<float>> seg0 = inp => _engine.FusedLinear(inp, w0, b0, FusedActivationType.None);
+        Func<Tensor<float>, Tensor<float>> seg1 = inp => _engine.FusedLinear(inp, w1, b1, FusedActivationType.None);
+
+        System.Collections.Generic.Dictionary<Tensor<float>, Tensor<float>> Run(bool checkpoint)
+        {
+            using var tape = new GradientTape<float>();
+            Tensor<float> o;
+            if (checkpoint) o = GradientCheckpointing<float>.Checkpoint(new[] { seg0, seg1 }, x, segmentSize: 1);
+            else { o = seg0(x); o = seg1(o); }
+            var loss = _engine.ReduceSum(_engine.TensorMultiply(o, outW));
+            return tape.ComputeGradients(loss, sources: new[] { x, w0, b0, w1, b1 });
+        }
+
+        var eager = Run(checkpoint: false);
+        var ckpt = Run(checkpoint: true);
+
+        foreach (var (name, t) in new[] { ("x", x), ("w0", w0), ("b0", b0), ("w1", w1), ("b1", b1) })
+        {
+            Assert.True(ckpt.ContainsKey(t), $"checkpointed run missing {name} gradient");
+            for (int i = 0; i < eager[t].Length; i++)
+                Assert.Equal(eager[t][i], ckpt[t][i], 3);
+        }
+    }
+
     // ─── Additional arithmetic gradient checks ───────────────────
 
     [Fact]

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientCorrectnessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientCorrectnessTests.cs
@@ -653,6 +653,59 @@ public class GradientCorrectnessTests : IDisposable
     }
 
     /// <summary>
+    /// SCALING + RESIDUAL: four segments (segmentSize=1) where each segment is a residual block
+    /// inp => inp + FusedLinear(inp, w, b) — the shape of a transformer sub-layer. Verifies the
+    /// detach-per-segment fix scales beyond two segments and handles a segment whose input feeds BOTH
+    /// the residual add and the linear (the segment input appears twice in the local graph).
+    /// </summary>
+    [Fact]
+    public void Checkpoint_FourSegment_ResidualFusedLinear_MatchEager()
+    {
+        Tensor<float> MakeFilled(int[] shape, float start, float step)
+        {
+            var t = new Tensor<float>(shape);
+            for (int i = 0; i < t.Length; i++) t[i] = start + step * i;
+            return t;
+        }
+
+        var x = MakeFilled([2, 4], -0.4f, 0.05f);
+        var ws = new Tensor<float>[4];
+        var bs = new Tensor<float>[4];
+        var segs = new Func<Tensor<float>, Tensor<float>>[4];
+        for (int s = 0; s < 4; s++)
+        {
+            var w = MakeFilled([4, 4], -0.3f + 0.02f * s, 0.01f);
+            var b = MakeFilled([4], 0.05f, 0.01f);
+            ws[s] = w; bs[s] = b;
+            segs[s] = inp => _engine.TensorAdd(inp, _engine.FusedLinear(inp, w, b, FusedActivationType.None));
+        }
+        var outW = MakeFilled([2, 4], 0.1f, 0.02f);
+
+        System.Collections.Generic.Dictionary<Tensor<float>, Tensor<float>> Run(bool checkpoint)
+        {
+            using var tape = new GradientTape<float>();
+            Tensor<float> o;
+            if (checkpoint) o = GradientCheckpointing<float>.Checkpoint(segs, x, segmentSize: 1);
+            else { o = x; foreach (var s in segs) o = s(o); }
+            var loss = _engine.ReduceSum(_engine.TensorMultiply(o, outW));
+            var srcs = new System.Collections.Generic.List<Tensor<float>> { x };
+            srcs.AddRange(ws); srcs.AddRange(bs);
+            return tape.ComputeGradients(loss, sources: srcs.ToArray());
+        }
+
+        var eager = Run(checkpoint: false);
+        var ckpt = Run(checkpoint: true);
+
+        Assert.True(ckpt.ContainsKey(x), "missing input grad");
+        for (int i = 0; i < eager[x].Length; i++) Assert.Equal(eager[x][i], ckpt[x][i], 3);
+        for (int s = 0; s < 4; s++)
+        {
+            for (int i = 0; i < eager[ws[s]].Length; i++) Assert.Equal(eager[ws[s]][i], ckpt[ws[s]][i], 3);
+            for (int i = 0; i < eager[bs[s]].Length; i++) Assert.Equal(eager[bs[s]][i], ckpt[bs[s]][i], 3);
+        }
+    }
+
+    /// <summary>
     /// MULTI-SEGMENT FusedLinear regression: two FusedLinear segments checkpointed with segmentSize=1
     /// (two separate segments) — the shape of a checkpointed two-DenseLayer stack. Every parameter's
     /// gradient (and the input's) must equal the eager run's. Guards the cross-segment defect where the

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientCorrectnessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientCorrectnessTests.cs
@@ -101,6 +101,16 @@ public class GradientCorrectnessTests : IDisposable
         }
     }
 
+    /// <summary>
+    /// Helper method to create a tensor filled with sequential values.
+    /// </summary>
+    private static Tensor<float> MakeFilled(int[] shape, float start, float step)
+    {
+        var t = new Tensor<float>(shape);
+        for (int i = 0; i < t.Length; i++) t[i] = start + step * i;
+        return t;
+    }
+
     // ─── Arithmetic ─────────────────────────────────────────────
 
     [Fact]
@@ -442,13 +452,6 @@ public class GradientCorrectnessTests : IDisposable
     [Fact]
     public void Checkpoint_ProducesParameterGradients_MatchingEager()
     {
-        Tensor<float> MakeFilled(int[] shape, float start, float step)
-        {
-            var t = new Tensor<float>(shape);
-            for (int i = 0; i < t.Length; i++) t[i] = start + step * i;
-            return t;
-        }
-
         var x = MakeFilled([2, 3], -0.4f, 0.05f);
         var w = MakeFilled([3, 4], -0.3f, 0.03f);
         var outW = MakeFilled([2, 4], 0.1f, 0.02f); // non-uniform gradOutput driver
@@ -489,13 +492,6 @@ public class GradientCorrectnessTests : IDisposable
     [Fact]
     public void Checkpoint_TwoSegments_ParameterGradients_MatchEager()
     {
-        Tensor<float> MakeFilled(int[] shape, float start, float step)
-        {
-            var t = new Tensor<float>(shape);
-            for (int i = 0; i < t.Length; i++) t[i] = start + step * i;
-            return t;
-        }
-
         var x = MakeFilled([2, 3], -0.4f, 0.05f);
         var w0 = MakeFilled([3, 4], -0.3f, 0.03f);
         var w1 = MakeFilled([4, 4], -0.2f, 0.02f);
@@ -534,13 +530,6 @@ public class GradientCorrectnessTests : IDisposable
     [Fact]
     public void Checkpoint_PersistentWeight_ParameterGradients_MatchEager()
     {
-        Tensor<float> MakeFilled(int[] shape, float start, float step)
-        {
-            var t = new Tensor<float>(shape);
-            for (int i = 0; i < t.Length; i++) t[i] = start + step * i;
-            return t;
-        }
-
         var x = MakeFilled([2, 3], -0.4f, 0.05f);
         var w = MakeFilled([3, 4], -0.3f, 0.03f);
         _engine.RegisterPersistentTensor(w, PersistentTensorRole.Weights);
@@ -579,13 +568,6 @@ public class GradientCorrectnessTests : IDisposable
     [Fact]
     public void Checkpoint_NullSources_ParameterGradients_MatchEager()
     {
-        Tensor<float> MakeFilled(int[] shape, float start, float step)
-        {
-            var t = new Tensor<float>(shape);
-            for (int i = 0; i < t.Length; i++) t[i] = start + step * i;
-            return t;
-        }
-
         var x = MakeFilled([2, 3], -0.4f, 0.05f);
         var w = MakeFilled([3, 4], -0.3f, 0.03f);
         var outW = MakeFilled([2, 4], 0.1f, 0.02f);
@@ -617,13 +599,6 @@ public class GradientCorrectnessTests : IDisposable
     [Fact]
     public void Checkpoint_FusedLinear_ParameterGradients_MatchEager()
     {
-        Tensor<float> MakeFilled(int[] shape, float start, float step)
-        {
-            var t = new Tensor<float>(shape);
-            for (int i = 0; i < t.Length; i++) t[i] = start + step * i;
-            return t;
-        }
-
         var x = MakeFilled([2, 3], -0.4f, 0.05f);
         var w = MakeFilled([3, 4], -0.3f, 0.03f);
         var b = MakeFilled([4], 0.05f, 0.01f);
@@ -661,13 +636,6 @@ public class GradientCorrectnessTests : IDisposable
     [Fact]
     public void Checkpoint_FourSegment_ResidualFusedLinear_MatchEager()
     {
-        Tensor<float> MakeFilled(int[] shape, float start, float step)
-        {
-            var t = new Tensor<float>(shape);
-            for (int i = 0; i < t.Length; i++) t[i] = start + step * i;
-            return t;
-        }
-
         var x = MakeFilled([2, 4], -0.4f, 0.05f);
         var ws = new Tensor<float>[4];
         var bs = new Tensor<float>[4];
@@ -716,13 +684,6 @@ public class GradientCorrectnessTests : IDisposable
     [Fact]
     public void Checkpoint_TwoSegment_FusedLinear_ParameterGradients_MatchEager()
     {
-        Tensor<float> MakeFilled(int[] shape, float start, float step)
-        {
-            var t = new Tensor<float>(shape);
-            for (int i = 0; i < t.Length; i++) t[i] = start + step * i;
-            return t;
-        }
-
         var x = MakeFilled([2, 3], -0.4f, 0.05f);
         var w0 = MakeFilled([3, 4], -0.3f, 0.03f);
         var b0 = MakeFilled([4], 0.05f, 0.01f);


### PR DESCRIPTION
## Problem

With **more than one segment**, `GradientCheckpointing<T>.Checkpoint` double-counts every earlier segment's gradients — 2× for two segments, (N−i)× for segment *i* of *N*.

A later segment's recompute called `ComputeGradients(pseudoLoss, sources: null)` over a graph whose input (the previous segment's output) **still carried its producer link to the earlier segment's checkpoint node**. So the later segment's backward followed that link, **re-entered the earlier segment's recompute (nested)** and scattered its gradients — and then the outer reverse walk computed that earlier segment **again**.

It only surfaced with `FusedLinear` (i.e. every `DenseLayer`) blocks; plain-matmul segments happened not to expose it, and the existing test only checked single-segment + finite gradients, so it shipped silently in 0.101.4.

### Evidence (pre-fix), 2-segment FusedLinear vs eager
```
x : ratio 2.000   w0: ratio 2.000   b0: ratio 2.000     (earlier segment — doubled)
w1: ratio 1.000   b1: ratio 1.000                       (later segment — correct)
```
Instrumentation showed the earlier segment's recompute closure invoked **twice** and the later segment's recompute returning grads for the earlier segment's tensors.

## Fix

**Detach each segment's input before recomputing** (`engine.StopGradient`), so the recompute graph is self-contained and its backward stops at the segment boundary — exactly what `torch.utils.checkpoint`'s `detach_variable(inputs)` does. The detached input's gradient is remapped back onto the original input tensor when scattering, so the outer walk still gets the correct hand-off and computes each earlier segment **exactly once**. Parameters (separate leaves) are unaffected; weight-sharing across segments still accumulates correctly.

## Tests

New regression coverage in `GradientCorrectnessTests`: multi-segment matmul, single- + multi-segment FusedLinear, persistent-weight, and `sources: null` variants — each asserting the checkpointed **input and weight** gradients equal the eager run under a non-uniform output weighting. The multi-segment FusedLinear test fails 2× on the pre-fix code and is exact now.

**net10.0 + net471, 113 checkpoint/gradient-correctness tests green, no regressions.**

## Downstream
Unblocks correct multi-segment (sqrt(N)) activation checkpointing for memory-bound foundation-scale training — AiDotNet #1624 / PR #1633 (diffusion G4) and `NeuralNetworkBase` checkpointing. Builds on #643 (weights now get gradients); this fixes the remaining multi-segment defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected gradient checkpointing recomputation to avoid double-counting by isolating recompute paths via detached segment inputs.
  * Ensured gradients propagate through all recomputed leaves (including segment parameters/weights) and properly remap detached-input gradients back to the original tensors.
  * Fixed upstream gradient handling for empty/no-op segments.

* **Tests**
  * Added new deterministic gradient regression tests validating checkpointed backward gradients against eager execution across multiple scenarios, including persistent parameters and fused-linear/residual compositions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->