### PR TITLE
perf(conv): parallelize fused + SIMD-direct Conv2D to saturate cores (#642)

### DIFF
--- a/src/AiDotNet.Tensors/Helpers/FusedConvHelper.cs
+++ b/src/AiDotNet.Tensors/Helpers/FusedConvHelper.cs
@@ -101,73 +101,78 @@ internal static class FusedConvHelper
     {
         int kernelSize = kernelH * kernelW;
 
-        // Parallel over output channel tiles for large convolutions
-        bool useParallel = M >= 64 && N >= 1024 && Environment.ProcessorCount > 1;
+        // Parallelize over a 2D grid of (output-channel tile × spatial tile). #642:
+        // the old gate (M>=64 && N>=1024, N = output H*W) ran the WHOLE conv serially for
+        // every small-spatial conv — i.e. all the deep SD-UNet stages (16x16, 8x8), which
+        // carry the most channels and the most FLOPs — and even when it did parallelize it
+        // split only the channel dim, so a shallow conv (outChannels==Mc) got a single tile.
+        // Net: ~90% of the diffusion forward ran on one core (measured: maxdop 1->16 = 1.13x).
+        // Tiling BOTH dims fans every shape out: channel-heavy/small-spatial deep convs split
+        // over M-tiles, large-spatial shallow convs split over N-tiles. Each (mTile,nTile)
+        // writes a DISJOINT C[m-range, n-range] block (C is [outChannels, outputSize]), so
+        // chunks never alias — the same disjoint-output invariant the engine's other parallel
+        // kernels rely on, and bit-reproducible regardless of thread count (each output element
+        // is reduced over K by a single thread in fixed order) => deterministicSafe. The K-loop
+        // order inside each tile is identical to the old ProcessMcTile, so output is unchanged.
+        // ParallelForOrSerial self-gates: serial below the grain size, when pinned to one
+        // thread, or when already inside a parallel region (a batched/outer-parallel caller).
+        int numMTiles = (M + Mc - 1) / Mc;
+        int numNTiles = (N + Nc - 1) / Nc;
+        int totalTiles = numMTiles * numNTiles;
 
-        if (useParallel)
-        {
-            int numMTiles = (M + Mc - 1) / Mc;
-            AiDotNet.Tensors.Helpers.CpuParallelSettings.ParallelForOrSerial(0, numMTiles, (long)M * N * K, mcTile =>
+        AiDotNet.Tensors.Helpers.CpuParallelSettings.ParallelForOrSerial(
+            0, totalTiles, (long)M * N * K, tileId =>
             {
-                int mc = mcTile * Mc;
+                int mTile = tileId / numNTiles;
+                int nTile = tileId % numNTiles;
+                int mc = mTile * Mc;
                 int mcEnd = Math.Min(mc + Mc, M);
-
-                ProcessMcTile(A, input, C, mc, mcEnd, M, N, K,
+                int nc = nTile * Nc;
+                int ncEnd = Math.Min(nc + Nc, N);
+                ProcessMcNcTile(A, input, C, mc, mcEnd, nc, ncEnd, M, N, K,
                     height, width, outHeight, outWidth,
                     kernelH, kernelW, kernelSize, strideH, strideW,
                     padH, padW, dilationH, dilationW, inChannels);
-            });
-        }
-        else
-        {
-            // Sequential processing
-            for (int mc = 0; mc < M; mc += Mc)
-            {
-                int mcEnd = Math.Min(mc + Mc, M);
-                ProcessMcTile(A, input, C, mc, mcEnd, M, N, K,
-                    height, width, outHeight, outWidth,
-                    kernelH, kernelW, kernelSize, strideH, strideW,
-                    padH, padW, dilationH, dilationW, inChannels);
-            }
-        }
+            }, deterministicSafe: true);
     }
 
+    /// <summary>
+    /// Compute one output block: output-channel range [mc,mcEnd) × spatial range
+    /// [ncStart,ncEnd). Tiles over K then runs the Mr×Nr fused-im2col micro-kernel. The
+    /// (kc outer, then m, then n) order matches the previous full-N ProcessMcTile so each
+    /// output element's K-reduction is bit-identical; the block is disjoint from every
+    /// other tile, so calls are safe to run concurrently (#642 2D conv parallelism).
+    /// </summary>
     [MethodImpl(HotInline)]
-    private static unsafe void ProcessMcTile(
+    private static unsafe void ProcessMcNcTile(
         float* A, float* input, float* C,
-        int mc, int mcEnd, int M, int N, int K,
+        int mc, int mcEnd, int ncStart, int ncEnd, int M, int N, int K,
         int height, int width, int outHeight, int outWidth,
         int kernelH, int kernelW, int kernelSize,
         int strideH, int strideW, int padH, int padW,
         int dilationH, int dilationW, int inChannels)
     {
-        // Tile over spatial positions (N)
-        for (int nc = 0; nc < N; nc += Nc)
+        // Tile over K (input channels * kernel elements)
+        for (int kc = 0; kc < K; kc += Kc)
         {
-            int ncEnd = Math.Min(nc + Nc, N);
+            int kcEnd = Math.Min(kc + Kc, K);
 
-            // Tile over K (input channels * kernel elements)
-            for (int kc = 0; kc < K; kc += Kc)
+            // Micro-kernel: process Mr x Nr blocks within this (channel, spatial) tile
+            for (int m = mc; m < mcEnd; m += Mr)
             {
-                int kcEnd = Math.Min(kc + Kc, K);
+                int mEnd = Math.Min(m + Mr, mcEnd);
 
-                // Micro-kernel: process Mr x Nr blocks
-                for (int m = mc; m < mcEnd; m += Mr)
+                for (int n = ncStart; n < ncEnd; n += Nr)
                 {
-                    int mEnd = Math.Min(m + Mr, mcEnd);
+                    int nEnd = Math.Min(n + Nr, ncEnd);
 
-                    for (int n = nc; n < ncEnd; n += Nr)
-                    {
-                        int nEnd = Math.Min(n + Nr, ncEnd);
-
-                        // Compute micro-tile with fused im2col
-                        ComputeMicroTileFused(
-                            A, input, C,
-                            m, mEnd, n, nEnd, kc, kcEnd, K, N,
-                            height, width, outHeight, outWidth,
-                            kernelH, kernelW, kernelSize, strideH, strideW,
-                            padH, padW, dilationH, dilationW, inChannels);
-                    }
+                    // Compute micro-tile with fused im2col
+                    ComputeMicroTileFused(
+                        A, input, C,
+                        m, mEnd, n, nEnd, kc, kcEnd, K, N,
+                        height, width, outHeight, outWidth,
+                        kernelH, kernelW, kernelSize, strideH, strideW,
+                        padH, padW, dilationH, dilationW, inChannels);
                 }
             }
         }

--- a/src/AiDotNet.Tensors/Helpers/FusedConvHelper.cs
+++ b/src/AiDotNet.Tensors/Helpers/FusedConvHelper.cs
@@ -129,7 +129,7 @@ internal static class FusedConvHelper
                 int mcEnd = Math.Min(mc + Mc, M);
                 int nc = nTile * Nc;
                 int ncEnd = Math.Min(nc + Nc, N);
-                ProcessMcNcTile(A, input, C, mc, mcEnd, nc, ncEnd, M, N, K,
+                ProcessMcNcTile(A, input, C, mc, mcEnd, nc, ncEnd, N, K,
                     height, width, outHeight, outWidth,
                     kernelH, kernelW, kernelSize, strideH, strideW,
                     padH, padW, dilationH, dilationW, inChannels);
@@ -146,7 +146,7 @@ internal static class FusedConvHelper
     [MethodImpl(HotInline)]
     private static unsafe void ProcessMcNcTile(
         float* A, float* input, float* C,
-        int mc, int mcEnd, int ncStart, int ncEnd, int M, int N, int K,
+        int mc, int mcEnd, int ncStart, int ncEnd, int N, int K,
         int height, int width, int outHeight, int outWidth,
         int kernelH, int kernelW, int kernelSize,
         int strideH, int strideW, int padH, int padW,

--- a/src/AiDotNet.Tensors/Helpers/SimdConvHelper.cs
+++ b/src/AiDotNet.Tensors/Helpers/SimdConvHelper.cs
@@ -1122,17 +1122,6 @@ internal static class SimdConvHelper
         int outWidth = width + 2 * padW - (dilationW * 2 + 1) + 1;
         int outputSize = outHeight * outWidth;
 
-        // #415 Phase F: per-task FMA threshold — see Conv3x3Stride1Double for
-        // the rationale. FP32 lane count is 2× FP64 so the empirical
-        // crossover is lower; 500K per-task FMAs (~half the FP64 threshold)
-        // keeps small-spatial × high-channel FP32 shapes parallel while
-        // staying above ThreadPool dispatch overhead (~100K FMAs at 8 GFLOPS
-        // FP32 SIMD peak).
-        long perTaskFmas = (long)inChannels * outputSize * 9L;
-        bool useParallel = perTaskFmas >= 500_000L
-                          && outChannels >= 2
-                          && Environment.ProcessorCount > 1;
-
         // #209 close-parity A/B: select Conv3x3 variant.
         // Pad=1 dilation=1 are required by the OcBlock kernels.
         bool padOneNoDilation = padH == 1 && padW == 1 && dilationH == 1 && dilationW == 1;
@@ -1162,6 +1151,22 @@ internal static class SimdConvHelper
         // Fallback if requested variant not applicable (wrong shape).
         if (variant == Conv3x3Variant.Block4 && !canUseBlock4) variant = Conv3x3Variant.PerChannel;
         if (variant == Conv3x3Variant.Block2 && !canUseBlock2) variant = Conv3x3Variant.PerChannel;
+
+        // #642: parallelize over the variant's output-channel tasks when the work justifies
+        // it. The old gate compared PER-CHANNEL FMAs (inChannels*outputSize*9) to 500K — but a
+        // task is a BLOCK of channelsPerTask channels, and for small-spatial × high-channel
+        // convs (SD-UNet deep stages, e.g. 256ch @ 8x8) per-channel work is ~150K, so the WHOLE
+        // conv ran serial despite ~64 block4 tasks and ~38M aggregate FMAs. Gate on PER-TASK
+        // work (above dispatch overhead) and task count instead, so deep convs fan to all cores.
+        int channelsPerTask = variant == Conv3x3Variant.Block4 ? 4
+                            : variant == Conv3x3Variant.Block2 ? 2 : 1;
+        int numConvTasks = outChannels / channelsPerTask;
+        long perTaskFmas = (long)channelsPerTask * inChannels * outputSize * 9L;
+        // Honor the MaxDegreeOfParallelism contract (pin-to-1 => serial); the old gate
+        // checked Environment.ProcessorCount and so ignored it.
+        bool useParallel = numConvTasks >= 2
+                          && perTaskFmas >= 100_000L
+                          && CpuParallelSettings.MaxDegreeOfParallelism > 1;
 
         for (int b = 0; b < batch; b++)
         {

--- a/tools/ConvParallelProbe/ConvParallelProbe.csproj
+++ b/tools/ConvParallelProbe/ConvParallelProbe.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <AssemblyName>ConvParallelProbe</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\AiDotNet.Tensors\AiDotNet.Tensors.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/ConvParallelProbe/Program.cs
+++ b/tools/ConvParallelProbe/Program.cs
@@ -15,6 +15,7 @@ internal static class Program
         var eng = (CpuEngine)AiDotNetEngine.Current;
 
         if (args.Length > 0 && args[0] == "--resblock") return RunResblock(eng, args);
+        if (args.Length > 0 && args[0] == "--gpu") return RunGpu(args);
 
         int maxdop = ArgI(args, "--maxdop", Environment.ProcessorCount);
         int inC = ArgI(args, "--inc", 256);
@@ -106,6 +107,67 @@ internal static class Program
         Console.WriteLine(
             $"RESBLOCK C={C} sp={sp}x{sp} blocks={blocks} maxdop={maxdop} procs={Environment.ProcessorCount} " +
             $"warmup_ms={warm:F1} median_ms={times[reps / 2]:F2} min_ms={times[0]:F2} max_ms={times[times.Length - 1]:F2}");
+        return 0;
+    }
+
+    // P3 (#642): GPU utilization baseline. Drives the GPU engine through a sustained
+    // Conv2D loop (the diffusion-relevant op) so nvidia-smi can sample GPU util, and
+    // compares ms/op to the CPU path to detect a silent CPU fallback (DirectGpuTensorEngine
+    // does NOT override Conv2D). Reads the output each iter to force GPU->host sync so we
+    // measure real completed work, not just queued launches.
+    private static int RunGpu(string[] args)
+    {
+        int secs = ArgI(args, "--secs", 12);
+        int C = ArgI(args, "--c", 256);
+        int sp = ArgI(args, "--sp", 16);
+        bool fused = ArgI(args, "--fused", 0) != 0;
+
+        var gpu = new AiDotNet.Tensors.Engines.DirectGpuTensorEngine();
+        AiDotNetEngine.Current = gpu;
+        Console.WriteLine($"engine={gpu.GetType().Name} SupportsGpu={gpu.SupportsGpu}");
+
+        bool rb = ArgI(args, "--rb", 0) != 0;
+        var rng = new Random(0);
+        var input = Rand(new[] { 1, C, sp, sp }, rng);
+        var kernel = Rand(new[] { C, C, 3, 3 }, rng);
+        var k2 = Rand(new[] { C, C, 3, 3 }, rng);
+        var gamma = Rand(new[] { C }, rng);
+        var beta = Rand(new[] { C }, rng);
+
+        Func<Tensor<float>> oneIter = rb
+            ? () =>
+            {
+                // ResBlock: GN -> Swish -> Conv -> GN -> Swish -> Conv -> residual add
+                var h = gpu.GroupNorm(input, 32, gamma, beta, 1e-5, out _, out _);
+                gpu.SwishInPlace(h);
+                h = gpu.Conv2D(h, kernel, 1, 1, 1);
+                h = gpu.GroupNorm(h, 32, gamma, beta, 1e-5, out _, out _);
+                gpu.SwishInPlace(h);
+                h = gpu.Conv2D(h, k2, 1, 1, 1);
+                return gpu.TensorAdd(input, h);
+            }
+        : () => gpu.Conv2D(input, kernel, 1, 1, 1);
+
+        var w = Stopwatch.StartNew();
+        var o = oneIter();
+        float sink = o[0];   // force materialize / GPU->host sync (kernel compile + first run)
+        w.Stop();
+        Console.WriteLine($"warmup {(rb ? "resblock" : "conv")} {w.Elapsed.TotalMilliseconds:F0}ms (sink={sink:E2})");
+
+        int syncEvery = ArgI(args, "--syncevery", 1);
+        long n = 0;
+        var sw = Stopwatch.StartNew();
+        while (sw.Elapsed.TotalMilliseconds < secs * 1000.0)
+        {
+            o = oneIter();
+            if (n % syncEvery == 0) sink += o[0];   // host->GPU sync every N iters
+            n++;
+        }
+        sink += o[0]; // final sync
+        sw.Stop();
+        Console.WriteLine(
+            $"GPU {(rb ? "ResBlock" : "Conv2D")} [1,{C},{sp}x{sp}] {n} iters / {sw.Elapsed.TotalSeconds:F1}s = " +
+            $"{sw.Elapsed.TotalMilliseconds / n:F3} ms/iter  ({n / sw.Elapsed.TotalSeconds:F0} iters/s)  sink={sink:E2}");
         return 0;
     }
 

--- a/tools/ConvParallelProbe/Program.cs
+++ b/tools/ConvParallelProbe/Program.cs
@@ -14,6 +14,8 @@ internal static class Program
         AiDotNetEngine.Current = new CpuEngine();
         var eng = (CpuEngine)AiDotNetEngine.Current;
 
+        if (args.Length > 0 && args[0] == "--resblock") return RunResblock(eng, args);
+
         int maxdop = ArgI(args, "--maxdop", Environment.ProcessorCount);
         int inC = ArgI(args, "--inc", 256);
         int outC = ArgI(args, "--outc", 256);
@@ -43,6 +45,61 @@ internal static class Program
         Console.WriteLine(
             $"CONV inC={inC} outC={outC} sp={sp}x{sp} out.len={o.Length} maxdop={maxdop} " +
             $"procs={Environment.ProcessorCount} warmup_ms={warm:F1} median_ms={times[reps / 2]:F2} min_ms={times[0]:F2}");
+        return 0;
+    }
+
+    // P2 (#642): an SD-style ResBlock stack (GroupNorm -> Swish -> Conv -> GroupNorm ->
+    // Swish -> Conv -> residual add) — the real per-op mix of a diffusion forward. Sweep
+    // maxdop to see whether the WHOLE stack (not just conv) saturates cores after the conv
+    // fixes, and profile to find the next bottleneck (norms/activations/elementwise/barriers).
+    private static int RunResblock(CpuEngine eng, string[] a)
+    {
+        int maxdop = ArgI(a, "--maxdop", Environment.ProcessorCount);
+        int C = ArgI(a, "--c", 256);
+        int sp = ArgI(a, "--sp", 16);
+        int blocks = ArgI(a, "--blocks", 8);
+        int reps = ArgI(a, "--reps", 10);
+        const int groups = 32;
+
+        CpuParallelSettings.MaxDegreeOfParallelism = maxdop;
+
+        var rng = new Random(0);
+        var x0 = Rand(new[] { 1, C, sp, sp }, rng);
+        var gamma = Rand(new[] { C }, rng);
+        var beta = Rand(new[] { C }, rng);
+        var k1 = Rand(new[] { C, C, 3, 3 }, rng);
+        var k2 = Rand(new[] { C, C, 3, 3 }, rng);
+
+        Func<Tensor<float>, Tensor<float>> block = x =>
+        {
+            var h = eng.GroupNorm(x, groups, gamma, beta, 1e-5, out _, out _);
+            eng.SwishInPlace(h);
+            h = eng.Conv2D(h, k1, 1, 1, 1);
+            h = eng.GroupNorm(h, groups, gamma, beta, 1e-5, out _, out _);
+            eng.SwishInPlace(h);
+            h = eng.Conv2D(h, k2, 1, 1, 1);
+            return eng.TensorAdd(x, h);
+        };
+
+        var sw = Stopwatch.StartNew();
+        var y = x0;
+        for (int b = 0; b < blocks; b++) y = block(y);
+        sw.Stop();
+        double warm = sw.Elapsed.TotalMilliseconds;
+
+        var times = new double[reps];
+        for (int i = 0; i < reps; i++)
+        {
+            var s = Stopwatch.StartNew();
+            y = x0;
+            for (int b = 0; b < blocks; b++) y = block(y);
+            s.Stop();
+            times[i] = s.Elapsed.TotalMilliseconds;
+        }
+        Array.Sort(times);
+        Console.WriteLine(
+            $"RESBLOCK C={C} sp={sp}x{sp} blocks={blocks} maxdop={maxdop} procs={Environment.ProcessorCount} " +
+            $"warmup_ms={warm:F1} median_ms={times[reps / 2]:F2} min_ms={times[0]:F2}");
         return 0;
     }
 

--- a/tools/ConvParallelProbe/Program.cs
+++ b/tools/ConvParallelProbe/Program.cs
@@ -68,6 +68,17 @@ internal static class Program
         int reps = ArgI(a, "--reps", 10);
         const int groups = 32;
 
+        if (maxdop < 1 || C < 1 || sp < 1 || blocks < 1 || reps < 1)
+        {
+            Console.Error.WriteLine("resblock: --maxdop, --c, --sp, --blocks, --reps must all be >= 1.");
+            return 2;
+        }
+        if (C % groups != 0)
+        {
+            Console.Error.WriteLine($"resblock: --c ({C}) must be a multiple of groups ({groups}).");
+            return 2;
+        }
+
         CpuParallelSettings.MaxDegreeOfParallelism = maxdop;
 
         var rng = new Random(0);
@@ -121,6 +132,13 @@ internal static class Program
         int C = ArgI(args, "--c", 256);
         int sp = ArgI(args, "--sp", 16);
         bool fused = ArgI(args, "--fused", 0) != 0;
+        int syncEvery = ArgI(args, "--syncevery", 1);
+
+        if (secs < 1 || C < 1 || sp < 1 || syncEvery < 1)
+        {
+            Console.Error.WriteLine("gpu: --secs, --c, --sp, --syncevery must all be >= 1.");
+            return 2;
+        }
 
         var gpu = new AiDotNet.Tensors.Engines.DirectGpuTensorEngine();
         AiDotNetEngine.Current = gpu;
@@ -154,7 +172,6 @@ internal static class Program
         w.Stop();
         Console.WriteLine($"warmup {(rb ? "resblock" : "conv")} {w.Elapsed.TotalMilliseconds:F0}ms (sink={sink:E2})");
 
-        int syncEvery = ArgI(args, "--syncevery", 1);
         long n = 0;
         var sw = Stopwatch.StartNew();
         while (sw.Elapsed.TotalMilliseconds < secs * 1000.0)

--- a/tools/ConvParallelProbe/Program.cs
+++ b/tools/ConvParallelProbe/Program.cs
@@ -22,6 +22,12 @@ internal static class Program
         int sp = ArgI(args, "--sp", 16);
         int reps = ArgI(args, "--reps", 12);
 
+        if (maxdop < 1 || inC < 1 || outC < 1 || sp < 1 || reps < 1)
+        {
+            Console.WriteLine("Error: All numeric arguments must be at least 1");
+            return 1;
+        }
+
         CpuParallelSettings.MaxDegreeOfParallelism = maxdop;
 
         var rng = new Random(0);
@@ -44,7 +50,7 @@ internal static class Program
         Array.Sort(times);
         Console.WriteLine(
             $"CONV inC={inC} outC={outC} sp={sp}x{sp} out.len={o.Length} maxdop={maxdop} " +
-            $"procs={Environment.ProcessorCount} warmup_ms={warm:F1} median_ms={times[reps / 2]:F2} min_ms={times[0]:F2}");
+            $"procs={Environment.ProcessorCount} warmup_ms={warm:F1} median_ms={times[reps / 2]:F2} min_ms={times[0]:F2} max_ms={times[times.Length - 1]:F2}");
         return 0;
     }
 
@@ -99,7 +105,7 @@ internal static class Program
         Array.Sort(times);
         Console.WriteLine(
             $"RESBLOCK C={C} sp={sp}x{sp} blocks={blocks} maxdop={maxdop} procs={Environment.ProcessorCount} " +
-            $"warmup_ms={warm:F1} median_ms={times[reps / 2]:F2} min_ms={times[0]:F2}");
+            $"warmup_ms={warm:F1} median_ms={times[reps / 2]:F2} min_ms={times[0]:F2} max_ms={times[times.Length - 1]:F2}");
         return 0;
     }
 

--- a/tools/ConvParallelProbe/Program.cs
+++ b/tools/ConvParallelProbe/Program.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Diagnostics;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+
+// #642 P0 verification: time a single 3x3 stride-1 pad-1 Conv2D (the SD-UNet resblock
+// conv, routed through FusedConvHelper.Conv2DFused) at a chosen MaxDegreeOfParallelism.
+// Sweep maxdop=1..N: speedup/N = parallel efficiency = core utilization for that shape.
+internal static class Program
+{
+    private static int Main(string[] args)
+    {
+        AiDotNetEngine.Current = new CpuEngine();
+        var eng = (CpuEngine)AiDotNetEngine.Current;
+
+        int maxdop = ArgI(args, "--maxdop", Environment.ProcessorCount);
+        int inC = ArgI(args, "--inc", 256);
+        int outC = ArgI(args, "--outc", 256);
+        int sp = ArgI(args, "--sp", 16);
+        int reps = ArgI(args, "--reps", 12);
+
+        CpuParallelSettings.MaxDegreeOfParallelism = maxdop;
+
+        var rng = new Random(0);
+        var input = Rand(new[] { 1, inC, sp, sp }, rng);
+        var kernel = Rand(new[] { outC, inC, 3, 3 }, rng);
+
+        var sw = Stopwatch.StartNew();
+        var o = eng.Conv2D(input, kernel, 1, 1, 1);   // 3x3 stride1 pad1 -> same spatial
+        sw.Stop();
+        double warm = sw.Elapsed.TotalMilliseconds;
+
+        var times = new double[reps];
+        for (int i = 0; i < reps; i++)
+        {
+            var s = Stopwatch.StartNew();
+            o = eng.Conv2D(input, kernel, 1, 1, 1);
+            s.Stop();
+            times[i] = s.Elapsed.TotalMilliseconds;
+        }
+        Array.Sort(times);
+        Console.WriteLine(
+            $"CONV inC={inC} outC={outC} sp={sp}x{sp} out.len={o.Length} maxdop={maxdop} " +
+            $"procs={Environment.ProcessorCount} warmup_ms={warm:F1} median_ms={times[reps / 2]:F2} min_ms={times[0]:F2}");
+        return 0;
+    }
+
+    private static int ArgI(string[] a, string f, int d)
+    {
+        int i = Array.IndexOf(a, f);
+        return i >= 0 && i + 1 < a.Length && int.TryParse(a[i + 1], out var v) ? v : d;
+    }
+
+    private static Tensor<float> Rand(int[] s, Random r)
+    {
+        var t = new Tensor<float>(s);
+        for (int i = 0; i < t.Length; i++) t[i] = (float)(r.NextDouble() - 0.5);
+        return t;
+    }
+}


### PR DESCRIPTION
## What

Fixes the core-utilization gap in #642: a batch=1 SD-UNet forward parallelized **1→16 cores at only ~1.1–1.2×** (≈7.5% efficiency). Profiling (P0) attributed ~**89%** of the serial wall-clock to the Conv2D path, with the actual GEMM microkernel at only **2.75%** — i.e. the conv was overhead/serial-bound, not compute-bound.

## Root cause

`FusedConvHelper.TiledGemmFusedIm2Col`:
```csharp
bool useParallel = M >= 64 && N >= 1024 && Environment.ProcessorCount > 1;  // M=outChannels, N=output H*W
```
- The `N >= 1024` gate forced **every small-spatial conv** (SD-UNet deep stages at 16×16, 8×8) fully **serial** — and those carry the most channels = the most FLOPs.
- Even when it did parallelize, it tiled **only the output-channel dim**, so `numMTiles = outChannels/Mc` (Mc=64). A 256-channel conv → 4 tiles → caps at **4 cores** regardless of how many are available.

## Fix

Dispatch a **2D grid of (output-channel tile × spatial tile)** through the engine's grain-gated `ParallelForOrSerial`:
- channel-heavy / small-spatial **deep** convs split over channel tiles,
- large-spatial **shallow** convs split over spatial tiles,
- together they fan **every** shape out to all cores.

`ProcessMcTile → ProcessMcNcTile` takes a spatial sub-range. The `kc`-outer / `m` / `n` loop order is unchanged, so each output element's K-reduction is **bit-identical**; tiles write **disjoint** output blocks (`C[m-range, n-range]`), so concurrent execution is safe (same disjoint-output invariant the engine's other parallel kernels use) and `deterministicSafe: true`.

## Measured (conv `[1,256,64,64]` k3s1p1 — the dominant `FusedConvHelper` path)

| maxdop | before (channel-only) | after (2D) |
|---|---|---|
| 1 | 22500 ms | 22479 ms |
| 4 | 6040 ms (3.7×) | — |
| 16 | **6210 ms — 3.6×, plateau at 4 cores** | **3007 ms — 7.5×, all 16 cores** |

→ **2.06× faster at 16 cores**, parallel efficiency 22% → 47%.

## Correctness

**50/50** forward-conv tests pass (`NormConvAccuracy`, `Conv2DIntoFastPath`, `FusedConv2DResnetSpeedup`, `FusedConv2DBiasActivation`, `Conv2DBackwardChannelParallel`) — output unchanged. Adds `tools/ConvParallelProbe`, the maxdop-sweep harness used to measure this.

## Commit 2 — SIMD-direct 3×3 path (the deep small-spatial convs)

`ShouldUseFusedConv` only routes convs with **im2col > 16 MB** to `FusedConvHelper`; the SD-UNet **deep stages** (8×8, 16×16) fall below that and take `SimdConvHelper.Conv3x3Stride1` instead. That path gated parallelism on **per-channel** FMAs (`inChannels·outputSize·9`) ≥ 500K — but a task is a *block of channels*, so a 256-ch 8×8 conv (~147K per-channel) ran **fully serial** despite ~64 block-of-4 tasks and ~38M aggregate FMAs. Fixed: gate on **per-task** work (≥100K, above dispatch overhead) × `≥2 tasks`, and honor `MaxDegreeOfParallelism` (the old gate checked `Environment.ProcessorCount` and ignored pin-to-1).

**Measured (conv `[1,256,8,8]` k3s1p1):** maxdop 1→16 was **28.2 ms flat (1.0×, serial)**; now **27.7 → 3.9 ms = 7.0×**.

## Net effect

Both dominant CPU conv paths now fan out to all cores:
| conv | path | before (1→16) | after |
|---|---|---|---|
| `[1,256,64,64]` high-res | FusedConvHelper | 3.6× (plateau @ 4 cores) | **7.5×** |
| `[1,256,8,8]` deep | SIMD-direct 3×3 | 1.0× (serial) | **7.0×** |

90/90 conv-correctness tests pass across both commits (output unchanged). Efficiency is ~44–47% (further gains possible via finer load-balancing), but this takes the conv-dominated diffusion forward from ~serial to genuinely multi-core — the #642 timeout driver.

Related: AiDotNet#1622 (foundation-timeout tracker), AiDotNet#1646 (the per-forward reflection overhead, fixed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved CPU parallelization efficiency in tensor convolution operations through enhanced multi-core task distribution strategies.
  * Refined parallelization logic for standard 3×3 convolution execution to better utilize available processors.

* **New Tools**
  * Added ConvParallelProbe benchmarking utility for profiling and diagnosing convolution performance across different hardware configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->