### PR TITLE
fix(arena): nested arena must not pool escaped buffers (#1221)

### DIFF
--- a/src/AiDotNet.Tensors/Helpers/TensorArena.cs
+++ b/src/AiDotNet.Tensors/Helpers/TensorArena.cs
@@ -413,17 +413,31 @@ public sealed class TensorArena : IDisposable
         // ReturnPersistent and simply dropped for GC. The pinned tier is NOT
         // returned — those are long-lived (weights / optimizer state) and the
         // owner still holds references to them.
-        foreach (var kvp in _pool)
+        //
+        // ONLY a TOP-LEVEL arena (no outer arena active) may pool its scratch/ring
+        // buffers. A NESTED arena (_previous != null) disposes back into a still-live
+        // outer scope, and its op-output tensors routinely ESCAPE there — a layer caches
+        // the forward activation for backward, the caller retains the model output, etc.
+        // Pooling an escaped buffer lets a later RentPersistent zero+reuse it and silently
+        // corrupt the live tensor (issue #1221: MobileNetV3 trained under an outer arena,
+        // then a per-step training arena's escaped activation buffer was recycled into the
+        // following eval forward, making Predict non-idempotent — first forward ≠ rest).
+        // Top-level per-step training arenas (the #478 pattern: TrainWithTape's own
+        // `using var arena`, no outer wrapper) keep pooling, so the GC win is preserved.
+        if (_previous is null)
         {
-            var (type, size) = kvp.Key;
-            var bucket = kvp.Value;
-            for (int i = 0; i < bucket.Count; i++)
-                ReturnPersistent(type, size, bucket[i]);
-        }
-        for (int i = 0; i < _ringBackingArrays.Count; i++)
-        {
-            var (type, size, arr) = _ringBackingArrays[i];
-            ReturnPersistent(type, size, arr);
+            foreach (var kvp in _pool)
+            {
+                var (type, size) = kvp.Key;
+                var bucket = kvp.Value;
+                for (int i = 0; i < bucket.Count; i++)
+                    ReturnPersistent(type, size, bucket[i]);
+            }
+            for (int i = 0; i < _ringBackingArrays.Count; i++)
+            {
+                var (type, size, arr) = _ringBackingArrays[i];
+                ReturnPersistent(type, size, arr);
+            }
         }
 
         _pool.Clear();


### PR DESCRIPTION
## Problem

MobileNetV3 `Clone_AfterTraining_ShouldPreserveLearnedWeights` failed on **both net10 and net471**. The failure was mislabeled as a clone bug — it's actually **`Predict` non-idempotence under an outer `TensorArena`**: `Predict`×2 on the *same* network (no clone) produced an identical ~6e-3 delta. The test captures `trainedOutputs` on the first (corrupted) forward, so the clone comparison fails.

## Root cause

Training runs per-step **nested** arenas inside the test's outer arena. On a nested arena's `Dispose`, it returned its scratch/ring backing buffers to the cross-arena persistent pool (#478 GC win). But a nested arena's op-output tensors routinely **escape** into the still-live outer scope (a layer caches the forward activation for backward, the caller retains the model output). A later `RentPersistent` then zeroed and reused an escaped buffer, silently corrupting the live tensor.

A/B proof: `AIDOTNET_ARENA_NOPOOL=1` and `ClearPersistentPool()` after training both drove ‖Δ‖ to 0.

## Fix

Only a **top-level** arena (`_previous is null`) returns buffers to the persistent pool. Nested arenas let their buffers GC — the only safe option when their tensors may have escaped. Top-level per-step training arenas (the #478 pattern, no outer wrapper) are unaffected, so the GC win is preserved.

## Validation
- `Clone_AfterTraining` now **passes on net10.0 AND net471**
- `TensorArena` test suite: 11/11
- MobileNetV3 suite: 41/42 (the 1 = a pre-existing MobileNetV2 optimizer loss-sensitivity test, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resource management for nested tensor scopes to prevent buffer reuse conflicts when tensor data escapes to outer scopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->