### PR TITLE
fix(gpu): version-gate resident weight buffer to avoid serving stale device data

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -1819,7 +1819,21 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     {
         var resident = weights.TryGetGpuBuffer();
         if (resident != null)
-            return new OwnedBuffer(resident, ownsBuffer: false);
+        {
+            // Only trust the resident device buffer when it is CURRENT with the host tensor. A weight's
+            // resident _gpuBuffer is tagged with the tensor Version at upload (UploadTensorRaw /
+            // BindResidentBuffer). A later CPU-side write — the optimizer's CPU update path, deserialize,
+            // or SetParameters — bumps Version but does NOT refresh the device buffer, leaving it stale.
+            // Serving a stale buffer makes inference run on pre-update (or uninitialized → NaN) weights:
+            // MobileNetV3 trained on GPU then read its classifier from a never-refreshed resident buffer,
+            // producing garbage/NaN. Falling through to the host-array persistent cache re-uploads the
+            // current weights and caches them. The offload-pointer path (GpuPinned / GpuOffload) has
+            // _gpuBuffer == null and owns its own device-pointer lifetime, so it is NOT version-tracked —
+            // keep trusting it unconditionally.
+            bool versionTracked = weights._gpuBuffer != null;
+            if (!versionTracked || weights._gpuBufferVersion == weights.Version)
+                return new OwnedBuffer(resident, ownsBuffer: false);
+        }
         return GetOrCacheWeightBuffer(backend, weights.GetDataArray(), role);
     }
 


### PR DESCRIPTION
## Problem

`GetWeightBufferPreferResident` trusted a weight tensor's resident `_gpuBuffer` unconditionally. That buffer is tagged with the tensor `Version` at upload (`UploadTensorRaw` / `BindResidentBuffer`), but a later CPU-side write — the optimizer's CPU update path, deserialize, or `SetParameters` — bumps `Version` **without** refreshing the device buffer. The forward then ran on stale (or, for a never-initialized clone, uninitialized → **NaN**) weights: MobileNetV3 trained on GPU read its classifier from a never-refreshed resident buffer and produced NaN/garbage.

## Fix

Only trust the resident buffer when `_gpuBufferVersion == Version`; otherwise fall through to the host-array persistent cache, which re-uploads the current weights. The offload-pointer path (`GpuPinned` / `GpuOffload`, `_gpuBuffer == null`) owns its own device-pointer lifetime and is not version-tracked, so it stays trusted unconditionally.

## Validation

On AMD RX 5500 XT (OpenCL): MobileNetV3 GPU inference after training went from **NaN output → a stable, idempotent result**.

> Note: a separate, deeper GPU correctness issue remains (the GPU forward under inference mode / `NoGradScope` diverges from CPU in the late `[1,160,2,2]` residual blocks — a GPU activation-buffer-reuse corruption analogous to the arena escaped-buffer bug). That is tracked separately and is NOT addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU tensor operations by adding version-tracking validation. The system now correctly validates that GPU memory buffers are synchronized with host data before reuse, preventing potential issues from stale buffers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->