### PR TITLE
perf(#653): recording-off fast path (forward hot ops) + e2e overhead audit

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -2786,7 +2786,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     Simd.SimdGemm.Sgemm(aFloat, lda, transA, bFloat, ldb, transB, cFloat, m, k, n);
                 }
                 DifferentiableOps.RecordBinary("BatchMatMul", result, aOrig, bOrig, BackwardFunctions<T>.BatchMatMulBackward);
-                { var ca = a; var cb = b; AutoTracer.RecordOp("BatchMatMul", result, eng => eng.BatchMatMul(ca, cb)); }
+                if (AutoTracer.ShouldRecord) { var ca = a; var cb = b; AutoTracer.RecordOp("BatchMatMul", result, eng => eng.BatchMatMul(ca, cb)); }
                 return result;
             }
 
@@ -2796,7 +2796,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 if (MatrixMultiplyHelper.TryGemm(a.ReadOnlyData, 0, b.ReadOnlyData, 0, result.Data, 0, m, k, n))
                 {
                     DifferentiableOps.RecordBinary("BatchMatMul", result, aOrig, bOrig, BackwardFunctions<T>.BatchMatMulBackward);
-                    { var ca = a; var cb = b; AutoTracer.RecordOp("BatchMatMul", result, eng => eng.BatchMatMul(ca, cb)); }
+                    if (AutoTracer.ShouldRecord) { var ca = a; var cb = b; AutoTracer.RecordOp("BatchMatMul", result, eng => eng.BatchMatMul(ca, cb)); }
                     return result;
                 }
             }
@@ -2816,7 +2816,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 var cSpanD = new Span<double>((double[])(object)rArrD, 0, m * n);
                 SimdGemm.Dgemm(aSpanD, bSpanD, cSpanD, m, k, n);
                 DifferentiableOps.RecordBinary("BatchMatMul", result, aOrig, bOrig, BackwardFunctions<T>.BatchMatMulBackward);
-                { var ca = a; var cb = b; AutoTracer.RecordOp("BatchMatMul", result, eng => eng.BatchMatMul(ca, cb)); }
+                if (AutoTracer.ShouldRecord) { var ca = a; var cb = b; AutoTracer.RecordOp("BatchMatMul", result, eng => eng.BatchMatMul(ca, cb)); }
                 return result;
             }
 
@@ -2848,7 +2848,7 @@ public partial class CpuEngine : ITensorLevelEngine
             });
             DifferentiableOps.RecordBinary("BatchMatMul", result, aOrig, bOrig,
                 BackwardFunctions<T>.BatchMatMulBackward);
-            { var ca = a; var cb = b; AutoTracer.RecordOp("BatchMatMul", result, eng => eng.BatchMatMul(ca, cb)); }
+            if (AutoTracer.ShouldRecord) { var ca = a; var cb = b; AutoTracer.RecordOp("BatchMatMul", result, eng => eng.BatchMatMul(ca, cb)); }
             return result;
         }
 
@@ -2982,7 +2982,7 @@ public partial class CpuEngine : ITensorLevelEngine
 
         DifferentiableOps.RecordBinary("BatchMatMul", result, aOrig, bOrig,
             BackwardFunctions<T>.BatchMatMulBackward);
-        { var ca = a; var cb = b; AutoTracer.RecordOp("BatchMatMul", result, eng => eng.BatchMatMul(ca, cb)); }
+        if (AutoTracer.ShouldRecord) { var ca = a; var cb = b; AutoTracer.RecordOp("BatchMatMul", result, eng => eng.BatchMatMul(ca, cb)); }
         return result;
     }
 
@@ -3148,7 +3148,7 @@ public partial class CpuEngine : ITensorLevelEngine
         DifferentiableOps.RecordBinary("TensorAdd", result, a, b, BackwardFunctions<T>.AddBackward);
 
         // Auto-tracer: record this op for future compilation
-        { var ca = a; var cb = b; AutoTracer.RecordOp("TensorAdd", result, eng => eng.TensorAdd(ca, cb)); }
+        if (AutoTracer.ShouldRecord) { var ca = a; var cb = b; AutoTracer.RecordOp("TensorAdd", result, eng => eng.TensorAdd(ca, cb)); }
 
         return result;
     }
@@ -33956,7 +33956,7 @@ public partial class CpuEngine : ITensorLevelEngine
 
         DifferentiableOps.RecordBinary("BatchMatMul", result, aOrig, bOrig,
             BackwardFunctions<T>.BatchMatMulBackward);
-        { var ca = a; var cb = b; AutoTracer.RecordOp("BatchMatMul", result, eng => eng.BatchMatMul(ca, cb)); }
+        if (AutoTracer.ShouldRecord) { var ca = a; var cb = b; AutoTracer.RecordOp("BatchMatMul", result, eng => eng.BatchMatMul(ca, cb)); }
         return result;
     }
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -8990,7 +8990,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 outputHeight, outputWidth);
             DifferentiableOps.RecordBinary("Conv2D", result, inputOrig, kernel,
                 BackwardFunctions<T>.Conv2DBackward, new object[] { new[] { stride, stride }, new[] { padding, padding }, new[] { dilation, dilation } });
-            AutoTracer.RecordOp("Conv2D", result, eng => result);
+            if (AutoTracer.ShouldRecord) AutoTracer.RecordOp("Conv2D", result, eng => result);
             return result;
         }
 
@@ -9089,7 +9089,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 }
                 DifferentiableOps.RecordBinary("Conv2D", result, inputOrig, kernel,
                     BackwardFunctions<T>.Conv2DBackward, new object[] { new[] { stride, stride }, new[] { padding, padding }, new[] { dilation, dilation } });
-                AutoTracer.RecordOp("Conv2D", result, eng => result);
+                if (AutoTracer.ShouldRecord) AutoTracer.RecordOp("Conv2D", result, eng => result);
                 return result;
             }
 #endif
@@ -9104,7 +9104,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 outputHeight, outputWidth);
             DifferentiableOps.RecordBinary("Conv2D", result, inputOrig, kernel,
                 BackwardFunctions<T>.Conv2DBackward, new object[] { new[] { stride, stride }, new[] { padding, padding }, new[] { dilation, dilation } });
-            AutoTracer.RecordOp("Conv2D", result, eng => result);
+            if (AutoTracer.ShouldRecord) AutoTracer.RecordOp("Conv2D", result, eng => result);
             return result;
         }
 
@@ -9117,7 +9117,7 @@ public partial class CpuEngine : ITensorLevelEngine
 
         DifferentiableOps.RecordBinary("Conv2D", result, inputOrig, kernel,
             BackwardFunctions<T>.Conv2DBackward, new object[] { new[] { stride, stride }, new[] { padding, padding }, new[] { dilation, dilation } });
-        AutoTracer.RecordOp("Conv2D", result, eng => result);
+        if (AutoTracer.ShouldRecord) AutoTracer.RecordOp("Conv2D", result, eng => result);
         return result;
     }
 
@@ -12854,7 +12854,7 @@ public partial class CpuEngine : ITensorLevelEngine
             result.Layout = LinearAlgebra.TensorLayout.Nchwc16;
             DifferentiableOps.RecordBinary("Conv2D", result, inputOrig, kernel, BackwardFunctions<T>.Conv2DBackward,
                 new object[] { stride, padding, dilation });
-            AutoTracer.RecordOp("Conv2D", result, eng => result);
+            if (AutoTracer.ShouldRecord) AutoTracer.RecordOp("Conv2D", result, eng => result);
             return result;
         }
 
@@ -12885,7 +12885,7 @@ public partial class CpuEngine : ITensorLevelEngine
             result.Layout = LinearAlgebra.TensorLayout.Nchwc8;
             DifferentiableOps.RecordBinary("Conv2D", result, inputOrig, kernel, BackwardFunctions<T>.Conv2DBackward,
                 new object[] { stride, padding, dilation });
-            AutoTracer.RecordOp("Conv2D", result, eng => result);
+            if (AutoTracer.ShouldRecord) AutoTracer.RecordOp("Conv2D", result, eng => result);
             return result;
         }
 
@@ -12988,7 +12988,7 @@ public partial class CpuEngine : ITensorLevelEngine
 
         DifferentiableOps.RecordBinary("Conv2D", result, inputOrig, kernel, BackwardFunctions<T>.Conv2DBackward,
             new object[] { stride, padding, dilation });
-        AutoTracer.RecordOp("Conv2D", result, eng => result);
+        if (AutoTracer.ShouldRecord) AutoTracer.RecordOp("Conv2D", result, eng => result);
         return result;
     }
 
@@ -19609,7 +19609,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 SoftmaxFloatFastPtr((float*)pinIn.Pointer, (float*)pinOut.Pointer, outerSize, axisSize);
             }
             DifferentiableOps.RecordUnary("Softmax", result, input, BackwardFunctions<T>.SoftmaxBackward, new object[] { axis });
-            { var c = input; int ax = axis; AutoTracer.RecordOp("Softmax", result, eng => eng.Softmax(c, ax), paramHash: ax); }
+            if (AutoTracer.ShouldRecord) { var c = input; int ax = axis; AutoTracer.RecordOp("Softmax", result, eng => eng.Softmax(c, ax), paramHash: ax); }
             return result;
         }
 
@@ -19656,7 +19656,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 }
             }
             DifferentiableOps.RecordUnary("Softmax", result, input, BackwardFunctions<T>.SoftmaxBackward, new object[] { axis });
-            { var c = input; int ax = axis; AutoTracer.RecordOp("Softmax", result, eng => eng.Softmax(c, ax), paramHash: ax); }
+            if (AutoTracer.ShouldRecord) { var c = input; int ax = axis; AutoTracer.RecordOp("Softmax", result, eng => eng.Softmax(c, ax), paramHash: ax); }
             return result;
         }
 
@@ -19696,7 +19696,7 @@ public partial class CpuEngine : ITensorLevelEngine
         });
 
         DifferentiableOps.RecordUnary("Softmax", result2, input, BackwardFunctions<T>.SoftmaxBackward, new object[] { axis });
-        { var c = input; int ax = axis; AutoTracer.RecordOp("Softmax", result2, eng => eng.Softmax(c, ax), paramHash: ax); }
+        if (AutoTracer.ShouldRecord) { var c = input; int ax = axis; AutoTracer.RecordOp("Softmax", result2, eng => eng.Softmax(c, ax), paramHash: ax); }
         return result2;
     }
 
@@ -22368,7 +22368,7 @@ public partial class CpuEngine : ITensorLevelEngine
             var lnResult = (Tensor<T>)(object)lnResultF;
             DifferentiableOps.RecordIfActive("LayerNorm", lnResult, new[] { input, gamma, beta },
                 BackwardFunctions<T>.LayerNormBackward, new object[] { mean, variance, epsilon });
-            AutoTracer.RecordOp("LayerNorm", lnResult, eng => lnResult);
+            if (AutoTracer.ShouldRecord) AutoTracer.RecordOp("LayerNorm", lnResult, eng => lnResult);
             return lnResult;
         }
 
@@ -22458,7 +22458,7 @@ public partial class CpuEngine : ITensorLevelEngine
         var lnResultG = TensorAllocator.Rent<T>(input._shape, outputData);
         DifferentiableOps.RecordIfActive("LayerNorm", lnResultG, new[] { input, gamma, beta },
             BackwardFunctions<T>.LayerNormBackward, new object[] { mean, variance, epsilon });
-        AutoTracer.RecordOp("LayerNorm", lnResultG, eng => lnResultG);
+        if (AutoTracer.ShouldRecord) AutoTracer.RecordOp("LayerNorm", lnResultG, eng => lnResultG);
         return lnResultG;
     }
 
@@ -23726,7 +23726,7 @@ public partial class CpuEngine : ITensorLevelEngine
             }
             DifferentiableOps.RecordIfActive("GroupNorm", result, new[] { inputOrig, gamma, beta },
                 BackwardFunctions<T>.GroupNormBackward, new object[] { numGroups, mean, variance, epsilon });
-            AutoTracer.RecordOp("GroupNorm", result, eng => result);
+            if (AutoTracer.ShouldRecord) AutoTracer.RecordOp("GroupNorm", result, eng => result);
             return result;
         }
 

--- a/tools/ConvParallelProbe/Program.cs
+++ b/tools/ConvParallelProbe/Program.cs
@@ -29,10 +29,12 @@ internal static class Program
         if (Environment.GetEnvironmentVariable("AIDOTNET_NO_AUTOTRACE") == "1")
         {
             // AutoTracer.ShouldRecord = Enabled && !GraphMode && EnableCompilation && !ThreadTapeActive.
-            // EnableCompilation is the PUBLIC, documented disable knob (AutoTracer.cs), so flip it
-            // directly — no reflection (the property is compile-time-resolved, so it can't silently
-            // no-op the way the old reflected `?.SetValue` could).
-            AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.Current.EnableCompilation = false;
+            // EnableCompilation is the PUBLIC, documented disable knob (AutoTracer.cs). Current returns
+            // a FRESH Default copy when the thread has no installed options, so mutating it in place is
+            // lost — take the copy, disable compilation, and install it via SetCurrent so it persists.
+            var codecOpts = AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.Current;
+            codecOpts.EnableCompilation = false;
+            AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.SetCurrent(codecOpts);
             Console.Error.WriteLine("[probe] TensorCodecOptions.EnableCompilation=false (AutoTracer recording off)");
         }
 
@@ -660,10 +662,13 @@ internal static class Program
         // ShouldRecord = Enabled && !GraphMode && EnableCompilation && !ThreadTapeActive.
         // Disabling compilation via the PUBLIC, documented knob (AutoTracer.cs) forces
         // ShouldRecord=false (the training / no-compilation hot path this benchmarks) — no
-        // reflection. It's a one-time set before the timed loop, so it never touches the
-        // per-op measurement; the public property is compile-time-resolved so it can't
-        // silently no-op the way the old reflected `?.SetValue` could.
-        AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.Current.EnableCompilation = false;
+        // reflection. Current returns a FRESH Default copy when the thread has no installed
+        // options, so mutate the copy and install it via SetCurrent (a bare property set on
+        // Current would be discarded). One-time set before the timed loop, so it never touches
+        // the per-op measurement.
+        var codecOpts = AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.Current;
+        codecOpts.EnableCompilation = false;
+        AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.SetCurrent(codecOpts);
         Console.Error.WriteLine("[probe] TensorCodecOptions.EnableCompilation=false (AutoTracer.ShouldRecord=false)");
 
         var rng = new Random(0);

--- a/tools/ConvParallelProbe/Program.cs
+++ b/tools/ConvParallelProbe/Program.cs
@@ -161,17 +161,25 @@ internal static class Program
         double warm = sw.Elapsed.TotalMilliseconds;
 
         var times = new double[reps];
+        // #653: optionally run the forward inside a TensorArena scope (PyTorch-caching-allocator
+        // equivalent) — Reset() per rep recycles the prior iteration's intermediate arrays.
+        bool useArena = Environment.GetEnvironmentVariable("AIDOTNET_ARENA") == "1";
+        TensorArena arena = useArena ? TensorArena.Create() : null;
         using var meter = util ? ParallelUtilizationMeter.Start() : null;   // `using` disposes on exception paths too (#654 review)
+        // Warm the arena (first rep allocates; subsequent reps reuse) before the alloc window.
+        if (useArena) { arena.Reset(); yy = x0; for (int b = 0; b < blocks; b++) yy = blk(yy); }
         GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
         long allocStart = GC.GetAllocatedBytesForCurrentThread();
         for (int i = 0; i < reps; i++)
         {
+            if (useArena) arena.Reset();
             var s = Stopwatch.StartNew();
             yy = x0;
             for (int b = 0; b < blocks; b++) yy = blk(yy);
             s.Stop();
             times[i] = s.Elapsed.TotalMilliseconds;
         }
+        arena?.Dispose();
         long allocBytes = GC.GetAllocatedBytesForCurrentThread() - allocStart;
         string u = StopMeter(meter, maxdop);
         Array.Sort(times);

--- a/tools/ConvParallelProbe/Program.cs
+++ b/tools/ConvParallelProbe/Program.cs
@@ -24,6 +24,7 @@ internal static class Program
             Console.Error.WriteLine("[probe] MachineKernelGemm.Enabled=false");
         }
 
+        if (args.Length > 0 && args[0] == "--allocbench") return RunAllocBench(eng, args);
         if (args.Length > 0 && args[0] == "--resblock") return RunResblock(eng, args);
         if (args.Length > 0 && args[0] == "--attnblock") return RunAttnBlock(eng, args);
         if (args.Length > 0 && args[0] == "--act") return RunAct(eng, args);
@@ -606,6 +607,42 @@ internal static class Program
         }
         catch (Exception ex) { Console.WriteLine($"CAPTURE FAILED: {ex.GetType().Name}: {ex.Message}"); }
         finally { scope.Dispose(); }
+        return 0;
+    }
+
+    // #653: measure per-op allocated bytes + time when AutoTracer.ShouldRecord is FALSE (the
+    // training / no-compilation hot path) — isolates the autotrace closure allocate-then-discard
+    // overhead. ShouldRecord is forced false by disabling compilation (reflection). Tiny shapes
+    // so the per-op closure alloc is visible against the (unavoidable) result-tensor alloc.
+    private static int RunAllocBench(CpuEngine eng, string[] a)
+    {
+        int M = ArgI(a, "--m", 8), K = ArgI(a, "--k", 8), N = ArgI(a, "--n", 8);
+        int reps = ArgI(a, "--reps", 200000);
+        // ShouldRecord = Enabled && !GraphMode && EnableCompilation && !ThreadTapeActive.
+        // Force AutoTracer.Enabled=false so ShouldRecord is false (mirrors the training hot path
+        // where a live tape makes ShouldRecord false). Verify before measuring.
+        var asm = typeof(CpuEngine).Assembly;
+        const System.Reflection.BindingFlags SF = System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public;
+        var at = asm.GetType("AiDotNet.Tensors.Engines.Compilation.AutoTracer");
+        at?.GetProperty("Enabled", SF)?.SetValue(null, false);
+        var shouldRec = at?.GetProperty("ShouldRecord", SF)?.GetValue(null);
+        Console.Error.WriteLine($"[probe] AutoTracer.ShouldRecord={shouldRec}");
+
+        var rng = new Random(0);
+        var lhs = Rand(new[] { M, K }, rng);
+        var rhs = Rand(new[] { K, N }, rng);
+        var warm = eng.BatchMatMul(lhs, rhs); float sink = warm[0];
+
+        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+        long startBytes = GC.GetAllocatedBytesForCurrentThread();
+        var sw = Stopwatch.StartNew();
+        for (int i = 0; i < reps; i++) { var o = eng.BatchMatMul(lhs, rhs); sink += o[0]; }
+        sw.Stop();
+        long bytes = GC.GetAllocatedBytesForCurrentThread() - startBytes;
+        Console.WriteLine(
+            $"ALLOCBENCH op=BatchMatMul {M}x{K}x{N} reps={reps} " +
+            $"bytes_per_op={(double)bytes / reps:F1} ns_per_op={sw.Elapsed.TotalMilliseconds * 1e6 / reps:F1} " +
+            $"total_MB={bytes / 1048576.0:F1} (sink={sink:E1})");
         return 0;
     }
 

--- a/tools/ConvParallelProbe/Program.cs
+++ b/tools/ConvParallelProbe/Program.cs
@@ -28,9 +28,17 @@ internal static class Program
         // path) so the end-to-end probes measure the recording-off fast path.
         if (Environment.GetEnvironmentVariable("AIDOTNET_NO_AUTOTRACE") == "1")
         {
-            typeof(CpuEngine).Assembly.GetType("AiDotNet.Tensors.Engines.Compilation.AutoTracer")
-                ?.GetProperty("Enabled", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public)
-                ?.SetValue(null, false);
+            // FAIL FAST: a silent `?.` no-op (type/property renamed) would leave recording ON
+            // and silently invalidate every downstream probe measurement, so require the set.
+            const System.Reflection.BindingFlags SF = System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public;
+            var enabledProp = typeof(CpuEngine).Assembly
+                .GetType("AiDotNet.Tensors.Engines.Compilation.AutoTracer")?.GetProperty("Enabled", SF);
+            if (enabledProp is null)
+            {
+                Console.Error.WriteLine("[probe] ERROR: AIDOTNET_NO_AUTOTRACE=1 but AutoTracer.Enabled not found (renamed?) — refusing to run with recording silently left on.");
+                return 3;
+            }
+            enabledProp.SetValue(null, false);
             Console.Error.WriteLine("[probe] AutoTracer.Enabled=false");
         }
 
@@ -640,15 +648,32 @@ internal static class Program
     {
         int M = ArgI(a, "--m", 8), K = ArgI(a, "--k", 8), N = ArgI(a, "--n", 8);
         int reps = ArgI(a, "--reps", 200000);
+        if (M < 1 || K < 1 || N < 1 || reps < 1)
+        {
+            Console.Error.WriteLine("allocbench: --m, --k, --n, --reps must all be >= 1.");
+            return 2;
+        }
         // ShouldRecord = Enabled && !GraphMode && EnableCompilation && !ThreadTapeActive.
         // Force AutoTracer.Enabled=false so ShouldRecord is false (mirrors the training hot path
-        // where a live tape makes ShouldRecord false). Verify before measuring.
-        var asm = typeof(CpuEngine).Assembly;
+        // where a live tape makes ShouldRecord false). FAIL FAST: if the reflected type/property
+        // is missing or renamed, the silent `?.` no-op would leave recording ON and produce
+        // invalid benchmark data — so require the set to succeed AND verify ShouldRecord==false.
         const System.Reflection.BindingFlags SF = System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public;
-        var at = asm.GetType("AiDotNet.Tensors.Engines.Compilation.AutoTracer");
-        at?.GetProperty("Enabled", SF)?.SetValue(null, false);
-        var shouldRec = at?.GetProperty("ShouldRecord", SF)?.GetValue(null);
-        Console.Error.WriteLine($"[probe] AutoTracer.ShouldRecord={shouldRec}");
+        var at = typeof(CpuEngine).Assembly.GetType("AiDotNet.Tensors.Engines.Compilation.AutoTracer");
+        var enabledProp = at?.GetProperty("Enabled", SF);
+        var shouldRecProp = at?.GetProperty("ShouldRecord", SF);
+        if (at is null || enabledProp is null || shouldRecProp is null)
+        {
+            Console.Error.WriteLine("allocbench: could not reflect AutoTracer.Enabled/ShouldRecord (renamed?) — refusing to report invalid numbers.");
+            return 3;
+        }
+        enabledProp.SetValue(null, false);
+        if (shouldRecProp.GetValue(null) is not bool rec || rec)
+        {
+            Console.Error.WriteLine("allocbench: AutoTracer.ShouldRecord is still true after disabling — recording would skew the measurement.");
+            return 3;
+        }
+        Console.Error.WriteLine("[probe] AutoTracer.ShouldRecord=False");
 
         var rng = new Random(0);
         var lhs = Rand(new[] { M, K }, rng);

--- a/tools/ConvParallelProbe/Program.cs
+++ b/tools/ConvParallelProbe/Program.cs
@@ -24,6 +24,16 @@ internal static class Program
             Console.Error.WriteLine("[probe] MachineKernelGemm.Enabled=false");
         }
 
+        // #653: force AutoTracer.ShouldRecord=false (the training / inference-without-compile hot
+        // path) so the end-to-end probes measure the recording-off fast path.
+        if (Environment.GetEnvironmentVariable("AIDOTNET_NO_AUTOTRACE") == "1")
+        {
+            typeof(CpuEngine).Assembly.GetType("AiDotNet.Tensors.Engines.Compilation.AutoTracer")
+                ?.GetProperty("Enabled", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public)
+                ?.SetValue(null, false);
+            Console.Error.WriteLine("[probe] AutoTracer.Enabled=false");
+        }
+
         if (args.Length > 0 && args[0] == "--allocbench") return RunAllocBench(eng, args);
         if (args.Length > 0 && args[0] == "--resblock") return RunResblock(eng, args);
         if (args.Length > 0 && args[0] == "--attnblock") return RunAttnBlock(eng, args);
@@ -152,6 +162,8 @@ internal static class Program
 
         var times = new double[reps];
         using var meter = util ? ParallelUtilizationMeter.Start() : null;   // `using` disposes on exception paths too (#654 review)
+        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+        long allocStart = GC.GetAllocatedBytesForCurrentThread();
         for (int i = 0; i < reps; i++)
         {
             var s = Stopwatch.StartNew();
@@ -160,11 +172,13 @@ internal static class Program
             s.Stop();
             times[i] = s.Elapsed.TotalMilliseconds;
         }
+        long allocBytes = GC.GetAllocatedBytesForCurrentThread() - allocStart;
         string u = StopMeter(meter, maxdop);
         Array.Sort(times);
         Console.WriteLine(
             $"ATTNBLOCK S={S} D={D} H={H} Dh={Dh} blocks={blocks} maxdop={maxdop} procs={Environment.ProcessorCount} " +
-            $"warmup_ms={warm:F1} median_ms={times[reps / 2]:F2} min_ms={times[0]:F2} max_ms={times[times.Length - 1]:F2}{u}");
+            $"warmup_ms={warm:F1} median_ms={times[reps / 2]:F2} min_ms={times[0]:F2} max_ms={times[times.Length - 1]:F2} " +
+            $"alloc_MB_per_fwd={allocBytes / 1048576.0 / reps:F3}{u}");
         return 0;
     }
 

--- a/tools/ConvParallelProbe/Program.cs
+++ b/tools/ConvParallelProbe/Program.cs
@@ -28,18 +28,12 @@ internal static class Program
         // path) so the end-to-end probes measure the recording-off fast path.
         if (Environment.GetEnvironmentVariable("AIDOTNET_NO_AUTOTRACE") == "1")
         {
-            // FAIL FAST: a silent `?.` no-op (type/property renamed) would leave recording ON
-            // and silently invalidate every downstream probe measurement, so require the set.
-            const System.Reflection.BindingFlags SF = System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public;
-            var enabledProp = typeof(CpuEngine).Assembly
-                .GetType("AiDotNet.Tensors.Engines.Compilation.AutoTracer")?.GetProperty("Enabled", SF);
-            if (enabledProp is null)
-            {
-                Console.Error.WriteLine("[probe] ERROR: AIDOTNET_NO_AUTOTRACE=1 but AutoTracer.Enabled not found (renamed?) — refusing to run with recording silently left on.");
-                return 3;
-            }
-            enabledProp.SetValue(null, false);
-            Console.Error.WriteLine("[probe] AutoTracer.Enabled=false");
+            // AutoTracer.ShouldRecord = Enabled && !GraphMode && EnableCompilation && !ThreadTapeActive.
+            // EnableCompilation is the PUBLIC, documented disable knob (AutoTracer.cs), so flip it
+            // directly — no reflection (the property is compile-time-resolved, so it can't silently
+            // no-op the way the old reflected `?.SetValue` could).
+            AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.Current.EnableCompilation = false;
+            Console.Error.WriteLine("[probe] TensorCodecOptions.EnableCompilation=false (AutoTracer recording off)");
         }
 
         if (args.Length > 0 && args[0] == "--allocbench") return RunAllocBench(eng, args);
@@ -642,7 +636,7 @@ internal static class Program
 
     // #653: measure per-op allocated bytes + time when AutoTracer.ShouldRecord is FALSE (the
     // training / no-compilation hot path) — isolates the autotrace closure allocate-then-discard
-    // overhead. ShouldRecord is forced false by disabling compilation (reflection). Tiny shapes
+    // overhead. ShouldRecord is forced false via the public TensorCodecOptions knob. Tiny shapes
     // so the per-op closure alloc is visible against the (unavoidable) result-tensor alloc.
     private static int RunAllocBench(CpuEngine eng, string[] a)
     {
@@ -654,26 +648,13 @@ internal static class Program
             return 2;
         }
         // ShouldRecord = Enabled && !GraphMode && EnableCompilation && !ThreadTapeActive.
-        // Force AutoTracer.Enabled=false so ShouldRecord is false (mirrors the training hot path
-        // where a live tape makes ShouldRecord false). FAIL FAST: if the reflected type/property
-        // is missing or renamed, the silent `?.` no-op would leave recording ON and produce
-        // invalid benchmark data — so require the set to succeed AND verify ShouldRecord==false.
-        const System.Reflection.BindingFlags SF = System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public;
-        var at = typeof(CpuEngine).Assembly.GetType("AiDotNet.Tensors.Engines.Compilation.AutoTracer");
-        var enabledProp = at?.GetProperty("Enabled", SF);
-        var shouldRecProp = at?.GetProperty("ShouldRecord", SF);
-        if (at is null || enabledProp is null || shouldRecProp is null)
-        {
-            Console.Error.WriteLine("allocbench: could not reflect AutoTracer.Enabled/ShouldRecord (renamed?) — refusing to report invalid numbers.");
-            return 3;
-        }
-        enabledProp.SetValue(null, false);
-        if (shouldRecProp.GetValue(null) is not bool rec || rec)
-        {
-            Console.Error.WriteLine("allocbench: AutoTracer.ShouldRecord is still true after disabling — recording would skew the measurement.");
-            return 3;
-        }
-        Console.Error.WriteLine("[probe] AutoTracer.ShouldRecord=False");
+        // Disabling compilation via the PUBLIC, documented knob (AutoTracer.cs) forces
+        // ShouldRecord=false (the training / no-compilation hot path this benchmarks) — no
+        // reflection. It's a one-time set before the timed loop, so it never touches the
+        // per-op measurement; the public property is compile-time-resolved so it can't
+        // silently no-op the way the old reflected `?.SetValue` could.
+        AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.Current.EnableCompilation = false;
+        Console.Error.WriteLine("[probe] TensorCodecOptions.EnableCompilation=false (AutoTracer.ShouldRecord=false)");
 
         var rng = new Random(0);
         var lhs = Rand(new[] { M, K }, rng);


### PR DESCRIPTION
## Summary
Guards the per-op `AutoTracer.RecordOp` closure sites for the foundation-forward hot ops with `if (AutoTracer.ShouldRecord)` — a PyTorch-`inference_mode`-style recording-off fast path. The closure (`eng => eng.Op(captured)`) was allocated at the call site on **every** op even when recording is off (all training — tape active — and inference without compilation). Guards touch ONLY the closure; `DifferentiableOps.Record*` (training gradients) is untouched.

**Coverage (all 6 ops the PR claims are now actually guarded):** BatchMatMul (6 sites), TensorAdd (1), **Conv2D (7), Softmax (3), LayerNorm (2), GroupNorm (1)** — the latter four were added so the diff matches the description (they were previously still allocating unconditionally).

## Why it's safe / behavior-preserving
`AutoTracer.ShouldRecord` (`Enabled && !GraphMode.IsActive && EnableCompilation && !ThreadTapeActive()`) is **exactly the negation of `RecordOp`'s own early-return gate** (AutoTracer.cs lines 97 + 110). So `if (ShouldRecord) RecordOp(...)` is provably equivalent to the unguarded call — it only elides the closure allocation when recording is off, never changes what gets recorded.

## Metrics
**Per-op micro (BatchMatMul 8×8×8, recording off):** 1032 B/op → 936 B/op (**−9.3% alloc**) = the eliminated closure.

**Honest end-to-end finding (attnblock S=256 D=768 H=12 blocks=6, recording off):** 117.204 → 117.197 MB/forward — **essentially identical**. The closures are ~7 KB (0.006%) against ~117 MB/forward of intermediate-tensor allocation, which dominates. So this guard is a correct, low-risk GC-pressure win on small-op / training-heavy paths but is **not** the big lever.

## The real overhead vs PyTorch
The ~117 MB/forward of intermediate tensors is the actual gap (PyTorch's caching allocator reuses freed storage at ≈zero malloc/op). The consumer-side training half of this is addressed by AiDotNet #1651 (one `TensorArena` reused across grad-accum chunks, ~970× fewer allocs); the forward-inference caching-allocator wiring (`GraphExecutor`/`MemoryPlanner`/`TensorAllocator` pooling) remains the open follow-up.

## Tests
- AutoTracer / Compiled / Softmax / LayerNorm filter: **292 passed / 1 failed identically with and without these guards** — the lone red (`AbsSoftplusGradientRepro.CompiledReplay_MatMulChain_WeightGradientPresent`, passes in isolation) is a pre-existing AutoTracer ThreadStatic cross-test batch-order flake, not introduced here.
- Default path behavior unchanged (guard is a no-op when recording is on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes
* **New Features**
  * Added a new `--allocbench` CLI mode to benchmark allocation usage (bytes/op) alongside runtime.
  * Added an optional arena-based allocation measurement mode for attention block runs.
* **Performance**
  * Reduced AutoTracer overhead for several CPU tensor operations by recording only when tracing is enabled.
* **Configuration**
  * Added `AIDOTNET_NO_AUTOTRACE=1` to disable AutoTracer recording at runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->