### PR TITLE
perf(gemm): default-on forward-GEMM core saturation + net471 PackAOnly tail fix (#653)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
@@ -50,13 +50,17 @@ public static partial class BlasManaged
     // strategy == ForcePackBoth, so the forward FFN/QKV matmuls skipped them and capped
     // M-axis parallelism (512x1024x4096 -> mc=60/nc=512 -> numMB=9, ~9 of 16 cores).
     // With this on, the same shape gets nc widened to N + mc shrunk -> numMB=15, 4.9x -> 8.0x
-    // at 16 cores (measured). Default OFF: it's a hot path the code's own notes flag as
-    // regression-prone for multi-N shapes, and the dev box is too noisy to validate a flip —
-    // gated for the gemm-bench CI A/B (set =1 to enable; flip the default once CI on a
-    // many-core runner confirms no tuned-shape regression). Only affects the DisableAutotune
-    // path; direct ForcePackBoth callers are unchanged (they already get these optimizations).
+    // at 16 cores (measured). DEFAULT ON (opt-out AIDOTNET_GEMM_FORWARD_PACKBOTH=0): a
+    // min-of-many A/B across 10 shapes on a 32-core Zen2 box (squares 768/1152/2048, FFN-up
+    // [512,1024,4096] 16.0->9.05ms, FFN-down [512,4096,1024] 16.1->8.2ms, QKV, batched
+    // [2048,1024,4096], and the LM-head [512,768,50304]) shows it FASTER or NEUTRAL on every
+    // shape and never a regression — the huge-N LM head is correctly neutral because nc can't
+    // widen to N (numNB>1), so the wide-N path self-limits and falls back. The prior "too
+    // noisy to validate" concern was measuring the off-path SgemmTiled SmallM lever (which the
+    // forward never reaches); the PackBoth path here measures cleanly on min-of-many. Only
+    // affects the DisableAutotune path; direct ForcePackBoth callers already had these.
     private static readonly bool s_forwardPackBothBlocking =
-        System.Environment.GetEnvironmentVariable("AIDOTNET_GEMM_FORWARD_PACKBOTH") == "1";
+        System.Environment.GetEnvironmentVariable("AIDOTNET_GEMM_FORWARD_PACKBOTH") != "0";
 
     // #653 cache-blocking sweep hook: env overrides for the PackBoth Mc/Nc/Kc so the
     // cache-residency-optimal blocking can be found empirically (the MKL/BLIS tuning art).

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Microkernels/Scalar/ScalarGenericStridedB.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Microkernels/Scalar/ScalarGenericStridedB.cs
@@ -1,0 +1,86 @@
+using System;
+
+namespace AiDotNet.Tensors.Engines.BlasManaged;
+
+/// <summary>
+/// Scalar reference microkernel for an ARBITRARY mr×nr output tile, strided-B.
+///
+/// <para>
+/// The fixed-size scalar kernels (<see cref="ScalarFp32_4x4"/>, <see cref="ScalarFp64_4x4"/>)
+/// only compute a 4×4 tile. <see cref="PackAOnlyStrategy"/> packs A in stripes of the caller's
+/// active <c>mr</c> and dispatches <c>mr×nr</c> tiles, so on a host WITHOUT the matching SIMD
+/// microkernel (e.g. net471 / no-AVX2, where <c>Avx2Fp32_6x16</c>/<c>Avx2Fp32_8x8</c>/etc. all
+/// report unsupported) the dispatch would otherwise fall back to the 4×4 kernel and read packed-A
+/// at the wrong stride + compute only a 4×4 corner of the tile — producing wrong results. This
+/// kernel handles any <c>mr×nr</c> so the scalar fallback is correct for every tile width.
+/// </para>
+///
+/// <para>
+/// Packed-A layout matches the SIMD kernels: <c>[Kc × mr]</c> row-major (mr-contiguous within
+/// each k-slice), so A row <c>r</c> at K-step <c>k</c> is <c>packedA[k * mr + r]</c>. B is read
+/// directly with stride <paramref name="ldb"/> (transB=false, row-major [K, N]); C is
+/// read-modify-write at stride <paramref name="ldc"/>. Accumulation is in FP64 to match the
+/// fixed-size scalar kernels' precision strategy (cast back to FP32 only at write-back).
+/// </para>
+/// </summary>
+internal static class ScalarGenericStridedB
+{
+    /// <summary>FP32 variant: accumulate packedA·B into the C[0..mr, 0..nr] tile over kc K-steps.</summary>
+    public static void RunFloat(
+        ReadOnlySpan<float> packedA, int mr,
+        ReadOnlySpan<float> b, int ldb,
+        Span<float> c, int ldc, int nr, int kc)
+    {
+        // FP64 accumulators for the mr×nr tile (mr,nr are small — 8×16 max in practice).
+        Span<double> acc = stackalloc double[mr * nr];
+        for (int r = 0; r < mr; r++)
+            for (int col = 0; col < nr; col++)
+                acc[r * nr + col] = c[r * ldc + col];
+
+        for (int k = 0; k < kc; k++)
+        {
+            int aBase = k * mr;
+            int bBase = k * ldb;
+            for (int r = 0; r < mr; r++)
+            {
+                double ar = packedA[aBase + r];
+                int accBase = r * nr;
+                for (int col = 0; col < nr; col++)
+                    acc[accBase + col] += ar * b[bBase + col];
+            }
+        }
+
+        for (int r = 0; r < mr; r++)
+            for (int col = 0; col < nr; col++)
+                c[r * ldc + col] = (float)acc[r * nr + col];
+    }
+
+    /// <summary>FP64 variant: accumulate packedA·B into the C[0..mr, 0..nr] tile over kc K-steps.</summary>
+    public static void RunDouble(
+        ReadOnlySpan<double> packedA, int mr,
+        ReadOnlySpan<double> b, int ldb,
+        Span<double> c, int ldc, int nr, int kc)
+    {
+        Span<double> acc = stackalloc double[mr * nr];
+        for (int r = 0; r < mr; r++)
+            for (int col = 0; col < nr; col++)
+                acc[r * nr + col] = c[r * ldc + col];
+
+        for (int k = 0; k < kc; k++)
+        {
+            int aBase = k * mr;
+            int bBase = k * ldb;
+            for (int r = 0; r < mr; r++)
+            {
+                double ar = packedA[aBase + r];
+                int accBase = r * nr;
+                for (int col = 0; col < nr; col++)
+                    acc[accBase + col] += ar * b[bBase + col];
+            }
+        }
+
+        for (int r = 0; r < mr; r++)
+            for (int col = 0; col < nr; col++)
+                c[r * ldc + col] = acc[r * nr + col];
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Microkernels/Scalar/ScalarGenericStridedB.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Microkernels/Scalar/ScalarGenericStridedB.cs
@@ -18,8 +18,8 @@ namespace AiDotNet.Tensors.Engines.BlasManaged;
 /// <para>
 /// Packed-A layout matches the SIMD kernels: <c>[Kc × mr]</c> row-major (mr-contiguous within
 /// each k-slice), so A row <c>r</c> at K-step <c>k</c> is <c>packedA[k * mr + r]</c>. B is read
-/// directly with stride <paramref name="ldb"/> (transB=false, row-major [K, N]); C is
-/// read-modify-write at stride <paramref name="ldc"/>. Accumulation is in FP64 to match the
+/// directly with stride <c>ldb</c> (transB=false, row-major [K, N]); C is
+/// read-modify-write at stride <c>ldc</c>. Accumulation is in FP64 to match the
 /// fixed-size scalar kernels' precision strategy (cast back to FP32 only at write-back).
 /// </para>
 /// </summary>

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackAOnlyStrategy.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackAOnlyStrategy.cs
@@ -310,7 +310,10 @@ internal static class PackAOnlyStrategy
     /// Routes to the appropriate strided-B microkernel matching T and the
     /// Mr×Nr tile width chosen by the caller. AVX2 8×8 FP32 fires when
     /// <paramref name="mr"/>==8 AND <paramref name="nr"/>==8 AND AVX2+FMA
-    /// are runtime-available; else falls through to scalar 4×4.
+    /// are runtime-available; when no matching SIMD kernel is available (e.g.
+    /// net471 or no-AVX2 platforms), falls back to scalar: the optimized
+    /// 4×4 kernel for 4×4 tiles specifically, or the generic scalar fallback
+    /// for all other tile size combinations (mr != 4 or nr != 4).
     /// </summary>
     private static void DispatchStridedMicrokernel<T>(
         ReadOnlySpan<T> packedA, ReadOnlySpan<T> b, int ldb,

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackAOnlyStrategy.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackAOnlyStrategy.cs
@@ -336,10 +336,20 @@ internal static class PackAOnlyStrategy
                     MemoryMarshal.Cast<T, float>(c), ldc, kc);
                 return;
             }
-            ScalarFp32_4x4.RunStridedB(
-                MemoryMarshal.Cast<T, float>(packedA),
-                MemoryMarshal.Cast<T, float>(b), ldb,
-                MemoryMarshal.Cast<T, float>(c), ldc, kc);
+            // Scalar fallback (no matching SIMD kernel — e.g. net471 / no-AVX2). The fixed 4×4
+            // kernel is only correct for a 4×4 tile; the general kernel honors the actual mr×nr
+            // (RunSerial packs A at the active mr and dispatches mr×nr tiles, so a 6×16/8×8 tile
+            // would read packed-A at the wrong stride + compute only a 4×4 corner here).
+            if (mr == 4 && nr == 4)
+                ScalarFp32_4x4.RunStridedB(
+                    MemoryMarshal.Cast<T, float>(packedA),
+                    MemoryMarshal.Cast<T, float>(b), ldb,
+                    MemoryMarshal.Cast<T, float>(c), ldc, kc);
+            else
+                ScalarGenericStridedB.RunFloat(
+                    MemoryMarshal.Cast<T, float>(packedA), mr,
+                    MemoryMarshal.Cast<T, float>(b), ldb,
+                    MemoryMarshal.Cast<T, float>(c), ldc, nr, kc);
             return;
         }
         if (typeof(T) == typeof(double))
@@ -362,10 +372,19 @@ internal static class PackAOnlyStrategy
                     MemoryMarshal.Cast<T, double>(c), ldc, kc);
                 return;
             }
-            ScalarFp64_4x4.RunStridedB(
-                MemoryMarshal.Cast<T, double>(packedA),
-                MemoryMarshal.Cast<T, double>(b), ldb,
-                MemoryMarshal.Cast<T, double>(c), ldc, kc);
+            // Scalar fallback (no matching SIMD kernel — e.g. net471 / no-AVX2). See the FP32
+            // branch above: the fixed 4×4 kernel is only correct for a 4×4 tile, so any other
+            // mr×nr routes to the general kernel that honors the actual tile dimensions.
+            if (mr == 4 && nr == 4)
+                ScalarFp64_4x4.RunStridedB(
+                    MemoryMarshal.Cast<T, double>(packedA),
+                    MemoryMarshal.Cast<T, double>(b), ldb,
+                    MemoryMarshal.Cast<T, double>(c), ldc, kc);
+            else
+                ScalarGenericStridedB.RunDouble(
+                    MemoryMarshal.Cast<T, double>(packedA), mr,
+                    MemoryMarshal.Cast<T, double>(b), ldb,
+                    MemoryMarshal.Cast<T, double>(c), ldc, nr, kc);
             return;
         }
         throw new NotSupportedException($"PackAOnlyStrategy does not support T={typeof(T).Name}.");

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
@@ -38,16 +38,19 @@ internal static class PackBothStrategy
     private static readonly bool s_trace =
         System.Environment.GetEnvironmentVariable("AIDOTNET_GEMM_TRACE") == "1";
 
-    // #653 single-persistent-region path (env AIDOTNET_GEMM_SINGLE_REGION=1, default off).
+    // #653 single-persistent-region path (DEFAULT ON, opt-out AIDOTNET_GEMM_SINGLE_REGION=0).
     // The M-axis RunParallelUnsafe re-dispatches the parallel region (and barriers) once per
     // (jc, pc) macro-tile. For the wide-nc forward case (numNB==1) that's one barriered
     // pack-B + ic-compute pair per K-panel — e.g. the FFN's 4 K-panels = 8 parallel regions,
     // capping utilization (~8/16 cores -> 8x). This path packs ALL K-panels of B once (one
     // dispatch) then runs ONE parallel ic region where each thread walks the full K-loop for
     // its rows — the BLIS persistent-team shape, no per-K-panel barrier. Bit-identical: each
-    // C element still reduces over k in the same panel order. Gated for A/B + flip via CI.
+    // C element still reduces over k in the same panel order. Self-limiting (only fires on the
+    // numNB==1 wide-nc case under the packed-B residency cap below); measured on top of
+    // forward-packboth it lifts FFN-up busyCores ~12->15.7 (9.7->9.05ms) with no regression
+    // across the 10-shape A/B, so flipped default-on alongside s_forwardPackBothBlocking.
     private static readonly bool s_singleRegion =
-        System.Environment.GetEnvironmentVariable("AIDOTNET_GEMM_SINGLE_REGION") == "1";
+        System.Environment.GetEnvironmentVariable("AIDOTNET_GEMM_SINGLE_REGION") != "0";
 
     // Cap on the all-panels packed-B residency for the single-region path (bytes). Above this
     // the buffer blows the cache budget; fall back to the per-panel M-axis path.

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
@@ -88,15 +88,36 @@ internal static partial class SimdGemm
         // row blocks at SmallMc to fill a many-core box. Shrink Mc toward
         // numRowBlocks ≈ maxThreads (floored at MinParallelMc, rounded to Mr) so
         // SgemmTiled's M-fan and per-row-block packing both saturate the cores.
-        // Only fires for compute-bound, parallel-eligible shapes; everything else
-        // keeps the tuned SmallMc.
-        if (SmallMRowBlockTargeting)
+        //
+        // OPT-IN (AIDOTNET_GEMM_SMALLM_TILING=1) — NOT default-on. A directional
+        // bench of the canonical FFN-up shape [512,1024]x[1024,4096] (32-core box)
+        // showed NO measurable change with the lever on vs off (min ~16.2ms both
+        // ways, busyCores ~8/32 both ways): that shape draws its parallelism from
+        // N=4096 (256 Nr-column blocks), so the M row-block count is irrelevant
+        // and the kernel is bandwidth-bound at ~8 effective cores regardless of Mc.
+        // The lever only matters in the narrow regime where BOTH m and n are small
+        // relative to the core count (so columns under-supply parallelism too),
+        // which this box can't validate cleanly (>10× run-to-run variance). Kept
+        // opt-in until a quiet-box bench proves a win on that regime.
+        //
+        // The guard below is still safe-by-construction for when it IS enabled —
+        // the only Mc it changes is non-square AND severely under-tiled:
+        //   * SQUARE shapes (m == n) are excluded — square-1152/768 etc. have a
+        //     hand-tuned Mc (the Salykova large-panel regime above); reshaping
+        //     them for parallelism would trade their cache-blocking win.
+        //   * Shapes already filling > half the cores (curRowBlocks*2 > maxThreads)
+        //     keep their tuned SmallMc — the shrink fires only on SEVERE
+        //     under-tiling (≥ half the cores would sit idle).
+        //   * The shrunk Mc is floored at MinParallelMc (8×Mr) so each Mr=6
+        //     micro-kernel panel stays packing-efficient.
+        if (SmallMRowBlockTargeting && m != n)              // never reshape square (cache-tuned)
         {
             int maxThreads = Helpers.CpuParallelSettings.MaxDegreeOfParallelism;
+            int curRowBlocks = (m + SmallMc - 1) / SmallMc;
             if (maxThreads > 1
-                && m >= MinParallelMc * 2                       // enough rows to split finer
-                && work >= ParallelWorkThreshold                // parallel-eligible at all
-                && (m + SmallMc - 1) / SmallMc < maxThreads)    // currently under-tiled
+                && m >= MinParallelMc * 2                   // enough rows to split finer
+                && work >= ParallelWorkThreshold            // parallel-eligible at all
+                && curRowBlocks * 2 <= maxThreads)          // SEVERELY under-tiled (≤ half cores busy)
             {
                 int targetMc = ((m / maxThreads) / Mr) * Mr;    // ~maxThreads row blocks, Mr-aligned
                 if (targetMc < MinParallelMc) targetMc = MinParallelMc;
@@ -113,10 +134,14 @@ internal static partial class SimdGemm
     // blocks. SgemmTiled fans M-rows across cores, so 4 blocks on a 16-core box
     // leaves >half the cores idle (measured: [512,1024]x[1024,4096] scaled only
     // 4.9× / ~8 cores at maxdop=16, vs 11× for a 2048³ GEMM with 11 row blocks).
-    // When enabled, ChooseAdaptiveMc shrinks Mc for these under-tiled shapes so
-    // numRowBlocks ≈ maxThreads, floored at MinParallelMc to keep each Mr=6
-    // micro-kernel panel efficient. Default off (env-gated) until A/B-validated
-    // against the full GEMM bench so it can't silently regress the tuned shapes.
+    // ChooseAdaptiveMc shrinks Mc for these under-tiled shapes so numRowBlocks ≈
+    // maxThreads, floored at MinParallelMc to keep each Mr=6 micro-kernel panel
+    // efficient. OPT-IN (AIDOTNET_GEMM_SMALLM_TILING=1): a directional bench of the
+    // canonical FFN-up shape showed no measurable win (that shape's parallelism
+    // comes from N, not M — see ChooseAdaptiveMc), so the default stays off pending
+    // a quiet-box bench of the small-m-AND-small-n regime where it would matter.
+    // The guard is safe-by-construction when enabled (square excluded; fires only
+    // on severe under-tiling).
     private static readonly bool SmallMRowBlockTargeting =
         Environment.GetEnvironmentVariable("AIDOTNET_GEMM_SMALLM_TILING") == "1";
     private const int MinParallelMc = 48; // 8 × Mr — floor for the shrunk small-M Mc


### PR DESCRIPTION
## Summary
#653 core-saturation: get the forward/training GEMM path to use all cores by default, plus a correctness fix for the no-AVX2 (net471) scalar fallback found while validating.

### 1. Forward-GEMM levers flipped default-on (opt-out)
`s_forwardPackBothBlocking` (BlasManaged) + `s_singleRegion` (PackBothStrategy) are the levers that actually sit on the forward path (`BatchMatMul → BlasManaged.Gemm{DisableAutotune} → PackBothStrategy`). They were env-gated default-off; flipped to default-on with opt-out `AIDOTNET_GEMM_FORWARD_PACKBOTH=0` / `AIDOTNET_GEMM_SINGLE_REGION=0`.

`AIDOTNET_GEMM_TRACE=1` confirms the forward `BatchMatMul` runs `[PackBoth]` and never reaches `SgemmTiled`/`ChooseAdaptiveMc` — so the previously-staged SgemmTiled SmallM lever was off-path (that's why its earlier A/Bs showed no movement). That lever is corrected here to honest opt-in (refined safe heuristic: square-exclusion + severe-under-tiling threshold), kept only for the SgemmTiled callers that exist.

**Min-of-many A/B, 32-core Zen2, 10 shapes — faster-or-neutral everywhere, no regression:**

| shape | OFF→ON min_ms | speedup |
|---|---|---|
| FFN-up 512×1024×4096 | 16.0→9.05 (busyCores 8.5→15.7) | 1.78× |
| FFN-down 512×4096×1024 | 16.1→8.2 | 1.97× |
| square 1152³ / 2048³ / 768³ | | 1.61× / 1.34× / 1.33× |
| QKV 512×768×768 / ×2304 | | 1.71× / 1.37× |
| batched 2048×1024×4096 | 36.3→28.1 | 1.30× |
| LM-head 512×768×50304 | 159→157 | neutral (self-limits when nc can't widen → numNB>1) |

### 2. fix: net471 PackAOnly scalar fallback for non-4×4 tiles
`PackAOnlyStrategy.RunSerial` packs A at the active `mr` and dispatches `mr×nr` tiles, but on a host without the matching SIMD kernel (net471 / no-AVX2) `DispatchStridedMicrokernel` fell through to the fixed `Scalar{Fp32,Fp64}_4x4` kernel — which reads packed-A at stride 4 and writes only a 4×4 corner, producing wrong results for 6×16/8×8/6×8/4×8 tiles. New `ScalarGenericStridedB` (FP32+FP64) honors any `mr×nr` (same packed-A layout + FP64-accumulator precision); 4×4 fast path kept. This was a pre-existing bug surfaced by `PackAOnlyStrategyTailTests`.

## Tests
- 697/697 PackBoth/BatchMatMul/Gemm green with the levers default-on.
- `PackAOnlyStrategyTailTests` 8/8 on **both** net471 and net10.0 (was 7 failing on net471).
- Only other red in the full net471 BlasManaged run is the pre-existing flaky `CooperativeSchedulerJoinParkTests` park/wake timing test (passes 3/3 isolated; a scalar-arithmetic change can't affect the scheduler).

## Note for reviewers
The default flip is validated on one Zen2 box (min-of-many, no Intel cache-hierarchy data). The existing `gemm-bench` workflow can A/B on other runners as an ongoing guard before/after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved GEMM packing strategy defaults: forward “pack both” and single-region execution now enable by default unless explicitly disabled via environment variables.
  * Made scalar fallback microkernel tile-aware so non-4×4 tile shapes use matching computation instead of assuming 4×4.
  * Tightened optional small‑M tiling behavior to shrink less aggressively for selected under-tiling scenarios (still opt-in).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->