### PR TITLE
fix(mixed-precision): FP16 hetero backward weight-grad on driver-only GPU

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/MixedPrecisionCompiledPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/MixedPrecisionCompiledPlan.cs
@@ -96,11 +96,16 @@ public sealed class MixedPrecisionCompiledPlan
             // (AIDOTNET_FP16_NO_SCRATCH_FREE) so it can be disabled without losing the activation free schedule.
             _scratchFree = Environment.GetEnvironmentVariable("AIDOTNET_FP16_NO_SCRATCH_FREE") != "1";
         }
-        // Forward Half-resident store: default-on ONLY for the FP16 hetero TRAINING forward (FromCapturedOrder,
-        // fwdStoreEligible=true), where the VRAM win matters and the training parity tolerance already covers the
-        // Half-storage rounding. NOT for the standalone Compile()/Trace() inference path, whose contract is to
-        // replay a fresh trace bit-for-bit (the Half storage would perturb the matmul-intermediate values vs the
-        // eager FP32-stored trace). Opt-out AIDOTNET_FP16_NO_FWD_STORE; an explicit Fp16FwdStoreOverride wins.
+        // Forward Half-resident store: keeps each Half matmul output a HALF GPU buffer (half the VRAM)
+        // instead of up-casting to FP32. Engaged by default for the FP16 hetero TRAINING forward
+        // (FromCapturedOrder, fwdStoreEligible=true). The training backward reads these Half activations as
+        // weight-gradient operands (h in dW = hᵀ·dY); that read is correct end-to-end now that
+        // DirectGpuTensorEngine.TensorTranspose routes non-float (Half) through the element-size-correct
+        // path instead of the float-typed transpose_2d kernel, and CudaBackend.ConvertToFp32 falls back to
+        // the self-contained native kernel on driver-only GPUs (the two #1624 fixes — previously the Half
+        // weight-gradient transpose read Half-as-float and zeroed dW). NOT for the standalone
+        // Compile()/Trace() inference path (its contract is bit-for-bit eager replay). Opt-out
+        // AIDOTNET_FP16_NO_FWD_STORE; an explicit Fp16FwdStoreOverride wins.
         _fwdStoreDefault = fwdStoreEligible
             && engine is DirectGpuTensorEngine
             && Environment.GetEnvironmentVariable("AIDOTNET_FP16_NO_FWD_STORE") != "1";
@@ -208,7 +213,9 @@ public sealed class MixedPrecisionCompiledPlan
         // Engage the Half-resident forward store for the GPU hetero forward so each Half matmul output stays a
         // HALF GPU buffer (half the VRAM) instead of being up-cast to FP32 — but ONLY when the caller hasn't set
         // an explicit override (the A/B peak tests do), so their measurement intent is preserved.
-        bool setStore = _fwdStoreDefault && DirectGpuTensorEngine.Fp16FwdStoreOverride is null;
+        // AIDOTNET_FP16_NO_FWD_STORE is a hard opt-out that takes precedence over all other enable mechanisms.
+        bool hardOptOut = Environment.GetEnvironmentVariable("AIDOTNET_FP16_NO_FWD_STORE") == "1";
+        bool setStore = !hardOptOut && _fwdStoreDefault && DirectGpuTensorEngine.Fp16FwdStoreOverride is null;
         var prevStore = DirectGpuTensorEngine.Fp16FwdStoreOverride;
         if (setStore) DirectGpuTensorEngine.Fp16FwdStoreOverride = true;
         try

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -12066,18 +12066,28 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
     /// <inheritdoc/>
     public unsafe void ConvertToFp32(IGpuBuffer input, IGpuBuffer output, int size)
     {
-        if (!_kernelCache.TryGetValue("convert_fp16_to_fp32", out var kernel))
-            throw new InvalidOperationException("CUDA kernel not found: convert_fp16_to_fp32");
+        // Mirror ConvertToFp16: the toolkit (cuda_fp16.h) "convert_fp16_to_fp32" kernel only registers on
+        // CUDA-Toolkit hosts; on driver-only hosts (e.g. GTX 1660 Ti, no toolkit) it never compiles, so a
+        // hard throw here broke every FP16→FP32 up-cast on those machines — including the FP16 resident
+        // training optimizer's master-weight up-cast (#1624: surfaced once the transpose fix let the
+        // gradients reach the optimizer). Fall through to the self-contained native kernel, which is
+        // compiled in the ctor (fp16_native_kernels) and exists by construction on every CUDA system.
+        if (_kernelCache.TryGetValue("convert_fp16_to_fp32", out var kernel))
+        {
+            using var _ = PushContext();
+            uint grid = (uint)((size + DefaultBlockSize - 1) / DefaultBlockSize);
+            IntPtr inPtr = input.Handle;
+            IntPtr outPtr = output.Handle;
+            void** args = stackalloc void*[3];
+            args[0] = &inPtr;
+            args[1] = &outPtr;
+            args[2] = &size;
+            LaunchKernel(kernel, grid, DefaultBlockSize, args);
+            return;
+        }
 
-        using var _ = PushContext();
-        uint grid = (uint)((size + DefaultBlockSize - 1) / DefaultBlockSize);
-        IntPtr inPtr = input.Handle;
-        IntPtr outPtr = output.Handle;
-        void** args = stackalloc void*[3];
-        args[0] = &inPtr;
-        args[1] = &outPtr;
-        args[2] = &size;
-        LaunchKernel(kernel, grid, DefaultBlockSize, args);
+        // Driver-only fallback — same FP16→FP32 semantics, registered by construction.
+        ConvertToFp32Native(input, output, size);
     }
 
     #endregion

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -16644,6 +16644,13 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             return base.TensorTranspose(tensor);
         if (tensor.Rank != 2)
             return base.TensorTranspose(tensor);
+        // The GPU transpose_2d kernel is FLOAT-typed (4-byte elements, no element-size parameter). For a
+        // non-float tensor — notably a Half-resident activation (2-byte elements), which is exactly the
+        // weight-gradient transpose operand h in the FP16 hetero backward (dW = (transpose h)·dY) — it would
+        // read Half-as-float and return garbage (sum 12.69 → 0.306), silently zeroing the FP16 weight
+        // gradient (#1624). Route non-float transposes through the element-size-correct CPU reference.
+        if (typeof(T) != typeof(float))
+            return base.TensorTranspose(tensor);
         try
         {
             int rows = tensor.Shape._dims[0];


### PR DESCRIPTION
## Problem

FP16-resident hetero training produced a **zeroed second-matmul weight gradient** (`dW = (transpose h)·dY`) on a CUDA host, diverging FP16 training from FP32 (loss not decreasing; `gpu-w2` grad `maxDiff 3.06 ≈ maxAbs 3.07`). GPU-instrumented to two distinct bugs — both fixed with the Half-resident forward store kept **ON** (VRAM win preserved):

1. **`TensorTranspose` used a float-typed kernel for Half.** The `transpose_2d` CUDA kernel is 4-byte/float (no element-size parameter). For a Half-resident activation (2-byte) — exactly the weight-grad transpose operand `h` — it read Half-as-float and returned garbage (instrumented: `sum 12.69 → 0.306`), zeroing the gradient. Fix: route non-float transposes through the element-size-correct CPU reference.

2. **`ConvertToFp32` lacked the driver-only fallback `ConvertToFp16` has.** It hard-threw `CUDA kernel not found: convert_fp16_to_fp32` on driver-only hosts (no CUDA Toolkit, e.g. GTX 1660 Ti) where the toolkit kernel never compiles. Once fix (1) let gradients reach the resident optimizer's FP16→FP32 master up-cast, this surfaced. Fix: fall back to the self-contained `ConvertToFp32Native` (compiled by construction), mirroring `ConvertToFp16`.

This **reverts the prior store-off mitigation** — the store stays on and is now correct.

## Verification (on a CUDA host, GTX 1660 Ti)

- `Fp16InCaptureForwardParityTests.Fp16HeteroForwardBackward_OnGpu_MatchesFp32` — passes (gradients match FP32).
- `Fp16FullyResidentTrainingTests` — passes (loss decreases).
- Full mixed-precision suite: **106 pass / 0 fail / 40 GPU-skip**.

Part of AiDotNet #1624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed correctness failures in GPU FP16 mixed precision training that could produce incorrect weight gradients
  * Added graceful fallback for missing GPU kernels on driver-only systems instead of crashing
  * Corrected GPU transpose operation for non-float data types to prevent silent computation errors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->