### PR TITLE
perf(#657): forward caching allocator — prove + lock in TensorArena for inference

### DIFF
--- a/tests/AiDotNet.Tensors.Tests/Helpers/InferenceArenaForwardTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/InferenceArenaForwardTests.cs
@@ -1,0 +1,119 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// #653/#657 follow-up — forward caching allocator. A repeated inference forward run inside a
+// TensorArena (Reset() between forwards) must (a) produce BIT-IDENTICAL results to the
+// non-arena path on every iteration — the arena hands back RentUninitialized buffers holding
+// the PRIOR forward's data, so this catches any op that relies on zero-initialised scratch —
+// and (b) collapse per-forward GC allocation toward zero once the arena is warm (the
+// PyTorch-caching-allocator behaviour: the eager forward's intermediates are recycled instead
+// of re-allocated). Measured on the attnblock probe: 13.57 MB/fwd (no arena) -> ~0.26 MB/fwd
+// (arena, steady state) — a ~98% reduction.
+
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Helpers;
+
+// Serialize with the other arena tests — TensorArena.Current is [ThreadStatic] and xUnit
+// reuses worker threads across collections.
+[Collection(nameof(TensorArenaPinnedTests))]
+public class InferenceArenaForwardTests
+{
+    private static readonly CpuEngine Eng = new CpuEngine();
+
+    // A small transformer-ish forward op chain (the attnblock op mix): the same ops whose
+    // per-op TensorAllocator.Rent calls route through TensorArena.Current when one is active.
+    private static Tensor<float> Forward(Tensor<float> x, Tensor<float> w, Tensor<float> gamma, Tensor<float> beta)
+    {
+        var h = Eng.BatchMatMul(x, w);                                   // [S,D] x [D,D] -> [S,D]
+        var s = Eng.Softmax(h, -1);
+        var ln = Eng.LayerNorm(s, gamma, beta, 1e-5, out _, out _);
+        return Eng.TensorAdd(ln, h);                                     // residual
+    }
+
+    private static Tensor<float> Rand(int[] shape, int seed)
+    {
+        var rng = new Random(seed);
+        var t = new Tensor<float>(shape);
+        for (int i = 0; i < t.Length; i++) t[i] = (float)(rng.NextDouble() * 2 - 1);
+        return t;
+    }
+
+    private static float[] Snapshot(Tensor<float> t)
+    {
+        var a = new float[t.Length];
+        for (int i = 0; i < t.Length; i++) a[i] = t[i];
+        return a;
+    }
+
+    [Fact]
+    public void RepeatedForward_InArena_BitIdenticalToNonArena_AcrossResets()
+    {
+        const int S = 64, D = 128;
+        // Inputs (and weights) allocated OUTSIDE the arena, so they survive Reset() and are a
+        // safe re-entry point each forward — the consumer pattern (weights/inputs are persistent;
+        // only transient intermediates live in the arena).
+        var x = Rand(new[] { S, D }, 1);
+        var w = Rand(new[] { D, D }, 2);
+        var gamma = Rand(new[] { D }, 3);
+        var beta = Rand(new[] { D }, 4);
+
+        var reference = Snapshot(Forward(x, w, gamma, beta)); // no arena active
+
+        using var arena = TensorArena.Create();
+        for (int iter = 0; iter < 8; iter++)
+        {
+            arena.Reset(); // recycle the prior forward's intermediates (the buffers now hold stale data)
+            var y = Forward(x, w, gamma, beta);
+            // Copy the result out BEFORE the next Reset recycles it (the "detach output" pattern
+            // a consumer uses to return a prediction from an arena-scoped forward).
+            var got = Snapshot(y);
+            Assert.Equal(reference.Length, got.Length);
+            for (int i = 0; i < reference.Length; i++)
+                Assert.Equal(reference[i], got[i]); // bit-exact: reuse must not perturb the result
+        }
+    }
+
+#if NET5_0_OR_GREATER
+    [Fact]
+    public void RepeatedForward_InArena_AllocatesFarLessThanNonArena()
+    {
+        const int S = 128, D = 256, N = 40;
+        var x = Rand(new[] { S, D }, 11);
+        var w = Rand(new[] { D, D }, 12);
+        var gamma = Rand(new[] { D }, 13);
+        var beta = Rand(new[] { D }, 14);
+
+        // Warm both paths once (JIT, first-touch pools) so the measurement is steady-state.
+        float sink = 0;
+        sink += Forward(x, w, gamma, beta)[0];
+
+        long a0 = GC.GetTotalAllocatedBytes(precise: true);
+        for (int i = 0; i < N; i++) sink += Forward(x, w, gamma, beta)[0];
+        long noArenaBytes = GC.GetTotalAllocatedBytes(precise: true) - a0;
+
+        using (var arena = TensorArena.Create())
+        {
+            sink += Forward(x, w, gamma, beta)[0]; // warm the arena (first forward fills it)
+            long a1 = GC.GetTotalAllocatedBytes(precise: true);
+            for (int i = 0; i < N; i++)
+            {
+                arena.Reset();
+                sink += Forward(x, w, gamma, beta)[0];
+            }
+            long arenaBytes = GC.GetTotalAllocatedBytes(precise: true) - a1;
+
+            // Conservative gate (real ratio is ~0.05): the arena must cut forward allocation by
+            // at least half. This guards the Rent->TensorArena.Current routing for the forward
+            // ops — if a hot op regresses to a non-arena allocation path, this trips.
+            Assert.True(arenaBytes * 2 < noArenaBytes,
+                $"arena forward allocated {arenaBytes} B over {N} forwards; non-arena {noArenaBytes} B — " +
+                $"expected arena < half. The per-op TensorAllocator.Rent path is not hitting the arena.");
+        }
+
+        if (sink == float.PositiveInfinity) Console.Write(""); // keep sink live
+    }
+#endif
+}

--- a/tools/ConvParallelProbe/Program.cs
+++ b/tools/ConvParallelProbe/Program.cs
@@ -149,21 +149,35 @@ internal static class Program
         sw.Stop();
         double warm = sw.Elapsed.TotalMilliseconds;
 
+        // #653/#657 follow-up: forward caching-allocator. With --arena, ONE TensorArena lives
+        // across the whole rep loop and Reset()s before each full forward — so every per-op
+        // TensorAllocator.Rent inside blk() hits the arena (Tier 0) instead of allocating a
+        // fresh GC array, and the prior forward's intermediates are recycled. Reset is PER
+        // FORWARD (not per block): a block's output is the next block's input, so resetting
+        // mid-forward would recycle a live tensor. x0 is allocated before the arena, so it
+        // survives Reset and is a safe re-entry point each iteration.
+        bool useArena = HasFlag(a, "--arena");
+        TensorArena? arena = useArena ? TensorArena.Create() : null;
         var times = new double[reps];
         using var meter = util ? ParallelUtilizationMeter.Start() : null;   // `using` disposes on exception paths too (#654 review)
+        long allocBefore = GC.GetTotalAllocatedBytes(precise: true);
         for (int i = 0; i < reps; i++)
         {
+            arena?.Reset();
             var s = Stopwatch.StartNew();
             yy = x0;
             for (int b = 0; b < blocks; b++) yy = blk(yy);
             s.Stop();
             times[i] = s.Elapsed.TotalMilliseconds;
         }
+        long allocAfter = GC.GetTotalAllocatedBytes(precise: true);
+        arena?.Dispose();
+        double mbPerFwd = (allocAfter - allocBefore) / (1024.0 * 1024.0) / reps;
         string u = StopMeter(meter, maxdop);
         Array.Sort(times);
         Console.WriteLine(
             $"ATTNBLOCK S={S} D={D} H={H} Dh={Dh} blocks={blocks} maxdop={maxdop} procs={Environment.ProcessorCount} " +
-            $"warmup_ms={warm:F1} median_ms={times[reps / 2]:F2} min_ms={times[0]:F2} max_ms={times[times.Length - 1]:F2}{u}");
+            $"arena={useArena} alloc_MB/fwd={mbPerFwd:F2} warmup_ms={warm:F1} median_ms={times[reps / 2]:F2} min_ms={times[0]:F2} max_ms={times[times.Length - 1]:F2}{u}");
         return 0;
     }
 


### PR DESCRIPTION
## Summary
Implements & guards the lever #657 deferred: cutting the **~117 MB/forward of intermediate-tensor allocation** in the eager forward toward zero, the PyTorch-caching-allocator behavior.

**Key finding:** the machinery already exists — `CpuEngine` op outputs allocate via `TensorAllocator.Rent`, whose **Tier-0 path routes to `TensorArena.Current`**. The gap was simply that *no arena is active during an inference forward* (only training wired one, AiDotNet #1651). So the fix is to run the forward inside a `TensorArena` with `Reset()` per forward — and that's now proven and regression-guarded here.

## Measured (ConvParallelProbe `--attnblock --arena`, single-thread)
One arena across the rep loop, `Reset()` per **full** forward (not per block — a block's output feeds the next). New `alloc_MB/fwd` via `GC.GetTotalAllocatedBytes`:

| reps | no-arena | arena |
|---|---|---|
| 5  | 13.57 | 2.75 |
| 20 | 13.57 | 0.71 |
| 60 | 13.57 | **0.26** |

no-arena is flat (fresh alloc every forward); the arena trends to ~0 as the cold first forward amortizes — **~98% allocation elimination at steady state.**

## Tests (`InferenceArenaForwardTests`)
- **Bit-identity across resets:** a `BatchMatMul → Softmax → LayerNorm → residual` chain run 8× in an arena (`Reset` between) is **bit-exact** to the non-arena path every iteration. The arena returns `RentUninitialized` buffers holding the *prior* forward's data, so this catches any op that relies on zero-initialised scratch.
- **Alloc collapse:** asserts arena forward allocation is `< half` the non-arena path (real ratio ~0.05); guards the `Rent → arena` routing so a hot op regressing to a non-arena alloc path trips the test. (net5.0+; the GC API is absent on net471.)

Both green on net10.0; the bit-identity test also green on net471.

## Scope / what's next
The output must be copied out before the next `Reset` (the "detach output" pattern the test demonstrates). This PR proves + locks in the **Tensors-side mechanism**. The remaining delivery is **consumer-side forward-boundary wiring** — `NeuralNetworkBase.Predict` / the diffusion denoise loop opening an arena and `Reset`-ing per call — which is a separate AiDotNet change because only the consumer knows where one forward ends (it can't be automatic at the Tensors layer). Stateful/persistent state (KV-cache, BatchNorm running stats) and the escaping output must stay outside the recycled scope there, exactly as AiDotNet #1651 handled for training grad-accum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive validation tests for tensor arena-based forward execution, verifying output consistency across repeated reset cycles and measuring substantial memory allocation efficiency improvements in steady-state scenarios compared to conventional approaches.

* **Chores**
  * Enhanced performance analysis tool with optional arena-based memory allocation tracking, enabling detailed per-forward memory usage measurements and reporting alongside existing timing and utilization statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->