### PR TITLE
perf(#1662): backward-pass memory — conv-arena fix (#4) + tiled FlashAttention backward (#3)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -941,10 +941,30 @@ internal static class BackwardFunctions<T>
         var padding = (int[])savedState[1];
         var dilation = (int[])savedState[2];
 
-        var gradInput = engine.Conv2DBackwardInput(
-            gradOutput, inputs[1], inputs[0]._shape, stride, padding, dilation);
-        var gradKernel = engine.Conv2DBackwardKernel(
-            gradOutput, inputs[0], inputs[1]._shape, stride, padding, dilation);
+        // #1662 lever #4: route the conv backward OUTPUT gradients through the per-step arena
+        // (AutoTensorCache -> TensorAllocator -> TensorArena) instead of the raw `new float[]`
+        // the allocating Conv2DBackwardInput/Kernel entries use, which bypassed the arena
+        // (~1 MB/step leak measured by `--trainbench --block conv`: only 76.6% recycled vs
+        // 98-99.9% for matmul/attention backward). The *Into variants fill a rented buffer and
+        // zero it first (accumulate:false -> Array.Clear), so renting uninitialized memory is
+        // safe. CPU-only; the GPU engine keeps the allocating path.
+        Tensor<T> gradInput, gradKernel;
+        if (engine is CpuEngine cpu)
+        {
+            gradInput = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[0]._shape);
+            gradKernel = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[1]._shape);
+            cpu.Conv2DBackwardInputInto(
+                gradInput, gradOutput, inputs[1], inputs[0]._shape, stride, padding, dilation, accumulate: false);
+            cpu.Conv2DBackwardKernelInto(
+                gradKernel, gradOutput, inputs[0], inputs[1]._shape, stride, padding, dilation, accumulate: false);
+        }
+        else
+        {
+            gradInput = engine.Conv2DBackwardInput(
+                gradOutput, inputs[1], inputs[0]._shape, stride, padding, dilation);
+            gradKernel = engine.Conv2DBackwardKernel(
+                gradOutput, inputs[0], inputs[1]._shape, stride, padding, dilation);
+        }
 
         DifferentiableOps.AccumulateGrad(grads, inputs[0], gradInput, engine);
         DifferentiableOps.AccumulateGrad(grads, inputs[1], gradKernel, engine);

--- a/src/AiDotNet.Tensors/Engines/Autodiff/FusedAttention.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/FusedAttention.cs
@@ -479,6 +479,13 @@ public static class FusedAttention<T>
     /// <typeparamref name="T"/> is not a floating-point type
     /// (<c>float</c>, <c>double</c>, or <c>System.Half</c>).
     /// </exception>
+    /// <summary>
+    /// #1662 bench-only switch: force the full-matrix backward even when the tiled path would
+    /// engage, so <c>ConvParallelProbe --flashbwd</c> can measure tiled-vs-full peak memory at
+    /// the same shape. Never set in production. Not thread-safe; for single-threaded benchmarking.
+    /// </summary>
+    internal static bool ForceFullBackwardForBench;
+
     public static (Tensor<T> GradQuery, Tensor<T> GradKey, Tensor<T> GradValue) Backward(
         Tensor<T> gradOutput,
         Tensor<T> query,
@@ -524,7 +531,7 @@ public static class FusedAttention<T>
         // which is faster when the S^2 matrices fit comfortably. This is a permanent size-tiered
         // fast path, mirroring the FP32/FP64 split already here.
         const int TileBk = 128;
-        if (attentionBias is null && Sk > TileBk)
+        if (attentionBias is null && Sk > TileBk && !ForceFullBackwardForBench)
         {
             (gradQ, gradK, gradV) = BackwardTiled(
                 engine, numOps, query, key, value, gradOutput,

--- a/src/AiDotNet.Tensors/Engines/Autodiff/FusedAttention.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/FusedAttention.cs
@@ -469,11 +469,11 @@ public static class FusedAttention<T>
     /// </code>
     /// </para>
     ///
-    /// <para>Memory: this reference implementation materialises the full
-    /// <c>[B, H, Sq, Sk]</c> attention-weight matrix. A tiled online-
-    /// softmax backward that matches FlashAttention-2's O(seqLen) memory
-    /// cost is future work; this version is sufficient for correctness
-    /// testing and for small/medium sequences.</para>
+    /// <para>Memory: for small/medium key lengths (<c>Sk &lt;= 128</c>) and for the bias / causal
+    /// cases, the straightforward path materialises the full <c>[B, H, Sq, Sk]</c> attention-weight
+    /// matrix. For longer unmasked sequences (<c>Sk &gt; 128</c>) the backward is tiled over key
+    /// blocks (<see cref="BackwardTiled"/>) in the FlashAttention-2 style, so the full <c>Sq×Sk</c>
+    /// matrices are never resident — peak extra memory is O(Sq·tile) instead of O(Sq·Sk).</para>
     /// </summary>
     /// <exception cref="NotSupportedException">
     /// <typeparamref name="T"/> is not a floating-point type
@@ -514,51 +514,69 @@ public static class FusedAttention<T>
         double scaleVal = config.Scale ?? 1.0 / Math.Sqrt(headDim);
         T scaleT = numOps.FromDouble(scaleVal);
 
-        var qFlat  = engine.Reshape(query, new[] { B * H, Sq, headDim });
-        var kFlat  = engine.Reshape(key,   new[] { B * H, Sk, headDim });
-        var vFlat  = engine.Reshape(value, new[] { B * H, Sk, Dv });
-        var kFlatT = kFlat.TransposeLast2D();
+        Tensor<T> gradQ, gradK, gradV;
 
-        var scoresFlat = engine.TensorBatchMatMul(qFlat, kFlatT);
-        scoresFlat = engine.TensorMultiplyScalar(scoresFlat, scaleT);
-        var scores = engine.Reshape(scoresFlat, new[] { B, H, Sq, Sk });
-        if (attentionBias is not null)
-            scores = AddBroadcastBias(engine, scores, attentionBias);
-        else if (config.IsCausal)
-            scores = ApplyCausalMask(engine, scores, numOps, config.QueryOffset);
-        else if (config.IsCausal && attentionBias is not null)
-            scores = ApplyCausalMask(engine, scores, numOps, config.QueryOffset);
-        var P = engine.TensorSoftmax(scores, axis: 3);                           // [B, H, Sq, Sk]
+        // #1662 lever #3: for long key sequences, tile the backward over key blocks so the full
+        // [Sq, Sk] score/prob matrices are NEVER materialized — peak extra memory is O(Sq*tile)
+        // instead of O(Sq*Sk). Engages only for unmasked attention; the bias/causal cases keep
+        // the full-matrix path (tiled masking is handled in the same lever, below). Small/medium
+        // Sk also keeps the full path, which is faster when the S^2 matrices fit comfortably.
+        // This is a permanent size-tiered fast path, mirroring the FP32/FP64 split already here.
+        const int TileBk = 128;
+        if (attentionBias is null && !config.IsCausal && Sk > TileBk)
+        {
+            (gradQ, gradK, gradV) = BackwardTiled(
+                engine, numOps, query, key, value, gradOutput,
+                B, H, Sq, Sk, headDim, Dv, scaleVal, TileBk);
+        }
+        else
+        {
+            // ===== Full-matrix path (small/medium Sk, or bias/causal masking) =====
+            // Recompute the forward softmax to get P — needed for every gradient below.
+            var qFlat  = engine.Reshape(query, new[] { B * H, Sq, headDim });
+            var kFlat  = engine.Reshape(key,   new[] { B * H, Sk, headDim });
+            var vFlat  = engine.Reshape(value, new[] { B * H, Sk, Dv });
+            var kFlatT = kFlat.TransposeLast2D();
 
-        var pFlat = engine.Reshape(P, new[] { B * H, Sq, Sk });
-        var pFlatT = pFlat.TransposeLast2D();                                    // [B*H, Sk, Sq]
-        var goFlat = engine.Reshape(gradOutput, new[] { B * H, Sq, Dv });
+            var scoresFlat = engine.TensorBatchMatMul(qFlat, kFlatT);
+            scoresFlat = engine.TensorMultiplyScalar(scoresFlat, scaleT);
+            var scores = engine.Reshape(scoresFlat, new[] { B, H, Sq, Sk });
+            if (attentionBias is not null)
+                scores = AddBroadcastBias(engine, scores, attentionBias);
+            else if (config.IsCausal)
+                scores = ApplyCausalMask(engine, scores, numOps, config.QueryOffset);
+            var P = engine.TensorSoftmax(scores, axis: 3);                       // [B, H, Sq, Sk]
 
-        // dV = P^T @ dO                                                        [B*H, Sk, Dv]
-        var dvFlat = engine.TensorBatchMatMul(pFlatT, goFlat);
+            var pFlat = engine.Reshape(P, new[] { B * H, Sq, Sk });
+            var pFlatT = pFlat.TransposeLast2D();                                // [B*H, Sk, Sq]
+            var goFlat = engine.Reshape(gradOutput, new[] { B * H, Sq, Dv });
 
-        // dP = dO @ V^T                                                        [B*H, Sq, Sk]
-        var vFlatT = vFlat.TransposeLast2D();
-        var dpFlat = engine.TensorBatchMatMul(goFlat, vFlatT);
+            // dV = P^T @ dO                                                    [B*H, Sk, Dv]
+            var dvFlat = engine.TensorBatchMatMul(pFlatT, goFlat);
 
-        // dS = P * (dP - rowsum(dP * P)) — softmax backward
-        var dP = engine.Reshape(dpFlat, new[] { B, H, Sq, Sk });
-        var dS = SoftmaxBackward(engine, numOps, dP, P);
+            // dP = dO @ V^T                                                    [B*H, Sq, Sk]
+            var vFlatT = vFlat.TransposeLast2D();
+            var dpFlat = engine.TensorBatchMatMul(goFlat, vFlatT);
 
-        var dsFlat = engine.Reshape(dS, new[] { B * H, Sq, Sk });
+            // dS = P * (dP - rowsum(dP * P)) — softmax backward
+            var dP = engine.Reshape(dpFlat, new[] { B, H, Sq, Sk });
+            var dS = SoftmaxBackward(engine, numOps, dP, P);
 
-        // dQ = dS @ K * scale                                                  [B*H, Sq, headDim]
-        var dqFlat = engine.TensorBatchMatMul(dsFlat, kFlat);
-        dqFlat = engine.TensorMultiplyScalar(dqFlat, scaleT);
+            var dsFlat = engine.Reshape(dS, new[] { B * H, Sq, Sk });
 
-        // dK = dS^T @ Q * scale                                                [B*H, Sk, headDim]
-        var dsFlatT = dsFlat.TransposeLast2D();
-        var dkFlat = engine.TensorBatchMatMul(dsFlatT, qFlat);
-        dkFlat = engine.TensorMultiplyScalar(dkFlat, scaleT);
+            // dQ = dS @ K * scale                                              [B*H, Sq, headDim]
+            var dqFlat = engine.TensorBatchMatMul(dsFlat, kFlat);
+            dqFlat = engine.TensorMultiplyScalar(dqFlat, scaleT);
 
-        var gradQ = engine.Reshape(dqFlat, new[] { B, H, Sq, headDim });
-        var gradK = engine.Reshape(dkFlat, new[] { B, H, Sk, headDim });
-        var gradV = engine.Reshape(dvFlat, new[] { B, H, Sk, Dv });
+            // dK = dS^T @ Q * scale                                            [B*H, Sk, headDim]
+            var dsFlatT = dsFlat.TransposeLast2D();
+            var dkFlat = engine.TensorBatchMatMul(dsFlatT, qFlat);
+            dkFlat = engine.TensorMultiplyScalar(dkFlat, scaleT);
+
+            gradQ = engine.Reshape(dqFlat, new[] { B, H, Sq, headDim });
+            gradK = engine.Reshape(dkFlat, new[] { B, H, Sk, headDim });
+            gradV = engine.Reshape(dvFlat, new[] { B, H, Sk, Dv });
+        }
 
         if (was3D)
         {
@@ -567,6 +585,152 @@ public static class FusedAttention<T>
             gradV = DemoteToThreeD(engine, gradV);
         }
         return (gradQ, gradK, gradV);
+    }
+
+    /// <summary>
+    /// #1662 lever #3 — FlashAttention-2 style tiled backward. Tiles over key blocks so the
+    /// full [Sq, Sk] score / probability matrices are never materialized; peak extra memory is
+    /// O(Sq * tile) instead of O(Sq * Sk). Three streaming passes over key tiles:
+    ///   1. online softmax normalizers m_i (row max) and l_i (row sum-exp);
+    ///   2. the softmax-backward correction D_i = Σ_j P_ij·(dO_i·v_j);
+    ///   3. dQ / dK / dV from P_ij = exp(s_ij − m_i)/l_i and dS_ij = P_ij·(dP_ij − D_i).
+    /// The heavy GEMMs (scores, dP, dQ, dK, dV) run through the engine's batched matmul; only the
+    /// O(Sq*tile) per-row softmax elementwise is done inline. Unmasked attention only (the bias /
+    /// causal cases use the full-matrix path in <see cref="Backward"/>).
+    /// </summary>
+    private static (Tensor<T> GradQuery, Tensor<T> GradKey, Tensor<T> GradValue) BackwardTiled(
+        IEngine engine, INumericOperations<T> numOps,
+        Tensor<T> query, Tensor<T> key, Tensor<T> value, Tensor<T> gradOutput,
+        int B, int H, int Sq, int Sk, int headDim, int Dv, double scaleVal, int tileBk)
+    {
+        int BH = B * H;
+        T scaleT = numOps.FromDouble(scaleVal);
+
+        var qf  = engine.Reshape(query,      new[] { BH, Sq, headDim }); // [BH, Sq, Dh]
+        var kf  = engine.Reshape(key,        new[] { BH, Sk, headDim }); // [BH, Sk, Dh]
+        var vf  = engine.Reshape(value,      new[] { BH, Sk, Dv });      // [BH, Sk, Dv]
+        var dof = engine.Reshape(gradOutput, new[] { BH, Sq, Dv });      // [BH, Sq, Dv]
+
+        var m = new T[BH * Sq];
+        var l = new T[BH * Sq];
+        for (int i = 0; i < m.Length; i++) { m[i] = numOps.MinValue; l[i] = numOps.Zero; }
+
+        // ---- Pass 1: online softmax normalizers (m, l) ----
+        for (int j0 = 0; j0 < Sk; j0 += tileBk)
+        {
+            int bk = Math.Min(tileBk, Sk - j0);
+            var kt = SliceAxis1(numOps, kf, BH, Sk, headDim, j0, bk);                       // [BH, bk, Dh]
+            var sTile = engine.TensorMultiplyScalar(
+                engine.TensorBatchMatMul(qf, kt.TransposeLast2D()), scaleT);                // [BH, Sq, bk]
+            var s = sTile.GetDataArray();
+            for (int row = 0; row < BH * Sq; row++)
+            {
+                int b0 = row * bk;
+                T tmax = numOps.MinValue;
+                for (int j = 0; j < bk; j++)
+                    if (numOps.GreaterThan(s[b0 + j], tmax)) tmax = s[b0 + j];
+                T mOld = m[row];
+                T mNew = numOps.GreaterThan(mOld, tmax) ? mOld : tmax;
+                T alpha = numOps.Exp(numOps.Subtract(mOld, mNew)); // 0 on the first (mOld = MinValue) tile
+                T sumExp = numOps.Zero;
+                for (int j = 0; j < bk; j++)
+                    sumExp = numOps.Add(sumExp, numOps.Exp(numOps.Subtract(s[b0 + j], mNew)));
+                l[row] = numOps.Add(numOps.Multiply(l[row], alpha), sumExp);
+                m[row] = mNew;
+            }
+        }
+
+        // ---- Pass 2: softmax-backward correction D_i = Σ_j P_ij · dP_ij ----
+        var D = new T[BH * Sq]; // zero-init
+        for (int j0 = 0; j0 < Sk; j0 += tileBk)
+        {
+            int bk = Math.Min(tileBk, Sk - j0);
+            var kt = SliceAxis1(numOps, kf, BH, Sk, headDim, j0, bk);                       // [BH, bk, Dh]
+            var vt = SliceAxis1(numOps, vf, BH, Sk, Dv, j0, bk);                            // [BH, bk, Dv]
+            var sTile = engine.TensorMultiplyScalar(
+                engine.TensorBatchMatMul(qf, kt.TransposeLast2D()), scaleT);                // [BH, Sq, bk]
+            var dpTile = engine.TensorBatchMatMul(dof, vt.TransposeLast2D());               // [BH, Sq, bk]
+            var s = sTile.GetDataArray();
+            var dp = dpTile.GetDataArray();
+            for (int row = 0; row < BH * Sq; row++)
+            {
+                int b0 = row * bk;
+                for (int j = 0; j < bk; j++)
+                {
+                    T p = numOps.Divide(numOps.Exp(numOps.Subtract(s[b0 + j], m[row])), l[row]);
+                    D[row] = numOps.Add(D[row], numOps.Multiply(p, dp[b0 + j]));
+                }
+            }
+        }
+
+        // ---- Pass 3: dQ (accumulated), dK / dV (per-tile, disjoint keys) ----
+        var dQacc = new T[BH * Sq * headDim]; // zero-init, accumulated across tiles
+        var dKfull = new T[BH * Sk * headDim];
+        var dVfull = new T[BH * Sk * Dv];
+        for (int j0 = 0; j0 < Sk; j0 += tileBk)
+        {
+            int bk = Math.Min(tileBk, Sk - j0);
+            var kt = SliceAxis1(numOps, kf, BH, Sk, headDim, j0, bk);                       // [BH, bk, Dh]
+            var vt = SliceAxis1(numOps, vf, BH, Sk, Dv, j0, bk);                            // [BH, bk, Dv]
+            var sTile = engine.TensorMultiplyScalar(
+                engine.TensorBatchMatMul(qf, kt.TransposeLast2D()), scaleT);                // [BH, Sq, bk]
+            var dpTile = engine.TensorBatchMatMul(dof, vt.TransposeLast2D());               // [BH, Sq, bk]
+            var s = sTile.GetDataArray();
+            var dp = dpTile.GetDataArray();
+
+            var pData = new T[BH * Sq * bk];
+            var dsData = new T[BH * Sq * bk];
+            for (int row = 0; row < BH * Sq; row++)
+            {
+                int b0 = row * bk;
+                for (int j = 0; j < bk; j++)
+                {
+                    T p = numOps.Divide(numOps.Exp(numOps.Subtract(s[b0 + j], m[row])), l[row]);
+                    pData[b0 + j] = p;
+                    dsData[b0 + j] = numOps.Multiply(p, numOps.Subtract(dp[b0 + j], D[row]));
+                }
+            }
+            var pTile = new Tensor<T>(pData, new[] { BH, Sq, bk });
+            var dsTile = new Tensor<T>(dsData, new[] { BH, Sq, bk });
+
+            // dV_j = Σ_i P_ij · dO_i  -> [BH, bk, Dv]; keys are disjoint per tile, so write.
+            var dVtile = engine.TensorBatchMatMul(pTile.TransposeLast2D(), dof);            // [BH, bk, Dv]
+            CopyTileIntoAxis1(dVfull, dVtile.GetDataArray(), BH, Sk, Dv, j0, bk);
+            // dK_j = scale · Σ_i dS_ij · q_i -> [BH, bk, Dh]
+            var dKtile = engine.TensorMultiplyScalar(
+                engine.TensorBatchMatMul(dsTile.TransposeLast2D(), qf), scaleT);            // [BH, bk, Dh]
+            CopyTileIntoAxis1(dKfull, dKtile.GetDataArray(), BH, Sk, headDim, j0, bk);
+            // dQ_i += scale · Σ_j dS_ij · k_j -> [BH, Sq, Dh] (accumulate across tiles)
+            var dQtile = engine.TensorMultiplyScalar(
+                engine.TensorBatchMatMul(dsTile, kt), scaleT);                              // [BH, Sq, Dh]
+            var dq = dQtile.GetDataArray();
+            for (int idx = 0; idx < dQacc.Length; idx++)
+                dQacc[idx] = numOps.Add(dQacc[idx], dq[idx]);
+        }
+
+        var gradQ = engine.Reshape(new Tensor<T>(dQacc, new[] { BH, Sq, headDim }), new[] { B, H, Sq, headDim });
+        var gradK = engine.Reshape(new Tensor<T>(dKfull, new[] { BH, Sk, headDim }), new[] { B, H, Sk, headDim });
+        var gradV = engine.Reshape(new Tensor<T>(dVfull, new[] { BH, Sk, Dv }), new[] { B, H, Sk, Dv });
+        return (gradQ, gradK, gradV);
+    }
+
+    /// <summary>Copies the key/value slice [:, j0:j0+bk, :] out of a contiguous [BH, S, D]
+    /// tensor into a fresh contiguous [BH, bk, D] tile.</summary>
+    private static Tensor<T> SliceAxis1(INumericOperations<T> numOps, Tensor<T> src, int BH, int S, int D, int j0, int bk)
+    {
+        var srcData = src.IsContiguous ? src.GetDataArray() : src.Contiguous().GetDataArray();
+        var dst = new T[BH * bk * D];
+        for (int b = 0; b < BH; b++)
+            Array.Copy(srcData, (b * S + j0) * D, dst, b * bk * D, bk * D);
+        return new Tensor<T>(dst, new[] { BH, bk, D });
+    }
+
+    /// <summary>Writes a [BH, bk, D] tile into the [:, j0:j0+bk, :] slice of a flat [BH, S, D]
+    /// destination buffer (keys are disjoint across tiles, so a copy is correct).</summary>
+    private static void CopyTileIntoAxis1(T[] dst, T[] tile, int BH, int S, int D, int j0, int bk)
+    {
+        for (int b = 0; b < BH; b++)
+            Array.Copy(tile, b * bk * D, dst, (b * S + j0) * D, bk * D);
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/Autodiff/FusedAttention.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/FusedAttention.cs
@@ -469,11 +469,12 @@ public static class FusedAttention<T>
     /// </code>
     /// </para>
     ///
-    /// <para>Memory: for small/medium key lengths (<c>Sk &lt;= 128</c>) and for the bias / causal
-    /// cases, the straightforward path materialises the full <c>[B, H, Sq, Sk]</c> attention-weight
-    /// matrix. For longer unmasked sequences (<c>Sk &gt; 128</c>) the backward is tiled over key
-    /// blocks (<see cref="BackwardTiled"/>) in the FlashAttention-2 style, so the full <c>Sq×Sk</c>
-    /// matrices are never resident — peak extra memory is O(Sq·tile) instead of O(Sq·Sk).</para>
+    /// <para>Memory: for small/medium key lengths (<c>Sk &lt;= 128</c>) the straightforward path
+    /// materialises the full <c>[B, H, Sq, Sk]</c> attention-weight matrix. For longer sequences
+    /// (<c>Sk &gt; 128</c>) the backward is tiled over key blocks (<see cref="BackwardTiled"/>) in
+    /// the FlashAttention-2 style — including the causal and additive-bias cases — so the full
+    /// <c>Sq×Sk</c> intermediates are never resident: peak extra memory is O(Sq·tile), not
+    /// O(Sq·Sk).</para>
     /// </summary>
     /// <exception cref="NotSupportedException">
     /// <typeparamref name="T"/> is not a floating-point type
@@ -525,22 +526,22 @@ public static class FusedAttention<T>
 
         // #1662 lever #3: for long key sequences, tile the backward over key blocks so the full
         // [Sq, Sk] score/prob matrices are NEVER materialized — peak extra memory is O(Sq*tile)
-        // instead of O(Sq*Sk). Handles both plain and CAUSAL attention (causal fully-masked key
-        // tiles are skipped, which is also where the LLM long-context memory win lands). Additive
-        // attention bias keeps the full-matrix path. Small/medium Sk also keeps the full path,
-        // which is faster when the S^2 matrices fit comfortably. This is a permanent size-tiered
-        // fast path, mirroring the FP32/FP64 split already here.
+        // instead of O(Sq*Sk). Handles plain, CAUSAL (fully-masked key tiles skipped — the LLM
+        // long-context win), AND additive-bias attention (the bias is sliced per key tile and
+        // broadcast-added to each tile's scores). Matching the full path, bias takes precedence
+        // over the causal flag. Small/medium Sk keeps the full path (faster when S^2 fits).
         const int TileBk = 128;
-        if (attentionBias is null && Sk > TileBk && !ForceFullBackwardForBench)
+        if (Sk > TileBk && !ForceFullBackwardForBench)
         {
             (gradQ, gradK, gradV) = BackwardTiled(
                 engine, numOps, query, key, value, gradOutput,
                 B, H, Sq, Sk, headDim, Dv, scaleVal, TileBk,
-                config.IsCausal, config.QueryOffset);
+                isCausal: attentionBias is null && config.IsCausal, // bias precedence: no causal mask when bias present
+                config.QueryOffset, attentionBias);
         }
         else
         {
-            // ===== Full-matrix path (small/medium Sk, or bias/causal masking) =====
+            // ===== Full-matrix path (small/medium Sk only; Sk>128 — incl. causal/bias — tiles) =====
             // Recompute the forward softmax to get P — needed for every gradient below.
             var qFlat  = engine.Reshape(query, new[] { B * H, Sq, headDim });
             var kFlat  = engine.Reshape(key,   new[] { B * H, Sk, headDim });
@@ -604,14 +605,15 @@ public static class FusedAttention<T>
     ///   2. the softmax-backward correction D_i = Σ_j P_ij·(dO_i·v_j);
     ///   3. dQ / dK / dV from P_ij = exp(s_ij − m_i)/l_i and dS_ij = P_ij·(dP_ij − D_i).
     /// The heavy GEMMs (scores, dP, dQ, dK, dV) run through the engine's batched matmul; only the
-    /// O(Sq*tile) per-row softmax elementwise is done inline. Unmasked attention only (the bias /
-    /// causal cases use the full-matrix path in <see cref="Backward"/>).
+    /// O(Sq*tile) per-row softmax elementwise is done inline. Supports plain, causal (fully-masked
+    /// key tiles skipped), and additive-bias attention (bias sliced + broadcast-added per key tile
+    /// via <see cref="ScoresTileWithBias"/>); bias takes precedence over the causal flag.
     /// </summary>
     private static (Tensor<T> GradQuery, Tensor<T> GradKey, Tensor<T> GradValue) BackwardTiled(
         IEngine engine, INumericOperations<T> numOps,
         Tensor<T> query, Tensor<T> key, Tensor<T> value, Tensor<T> gradOutput,
         int B, int H, int Sq, int Sk, int headDim, int Dv, double scaleVal, int tileBk,
-        bool isCausal, int queryOffset)
+        bool isCausal, int queryOffset, Tensor<T>? attentionBias)
     {
         int BH = B * H;
         T scaleT = numOps.FromDouble(scaleVal);
@@ -635,8 +637,7 @@ public static class FusedAttention<T>
             if (TileFullyMasked(j0)) continue;
             int bk = Math.Min(tileBk, Sk - j0);
             var kt = SliceAxis1(numOps, kf, BH, Sk, headDim, j0, bk);                       // [BH, bk, Dh]
-            var sTile = engine.TensorMultiplyScalar(
-                engine.TensorBatchMatMul(qf, kt.TransposeLast2D()), scaleT);                // [BH, Sq, bk]
+            var sTile = ScoresTileWithBias(engine, qf, kt, scaleT, attentionBias, B, H, Sq, bk, j0); // [BH, Sq, bk]
             var s = sTile.GetDataArray();
             for (int row = 0; row < BH * Sq; row++)
             {
@@ -666,8 +667,7 @@ public static class FusedAttention<T>
             int bk = Math.Min(tileBk, Sk - j0);
             var kt = SliceAxis1(numOps, kf, BH, Sk, headDim, j0, bk);                       // [BH, bk, Dh]
             var vt = SliceAxis1(numOps, vf, BH, Sk, Dv, j0, bk);                            // [BH, bk, Dv]
-            var sTile = engine.TensorMultiplyScalar(
-                engine.TensorBatchMatMul(qf, kt.TransposeLast2D()), scaleT);                // [BH, Sq, bk]
+            var sTile = ScoresTileWithBias(engine, qf, kt, scaleT, attentionBias, B, H, Sq, bk, j0); // [BH, Sq, bk]
             var dpTile = engine.TensorBatchMatMul(dof, vt.TransposeLast2D());               // [BH, Sq, bk]
             var s = sTile.GetDataArray();
             var dp = dpTile.GetDataArray();
@@ -694,8 +694,7 @@ public static class FusedAttention<T>
             int bk = Math.Min(tileBk, Sk - j0);
             var kt = SliceAxis1(numOps, kf, BH, Sk, headDim, j0, bk);                       // [BH, bk, Dh]
             var vt = SliceAxis1(numOps, vf, BH, Sk, Dv, j0, bk);                            // [BH, bk, Dv]
-            var sTile = engine.TensorMultiplyScalar(
-                engine.TensorBatchMatMul(qf, kt.TransposeLast2D()), scaleT);                // [BH, Sq, bk]
+            var sTile = ScoresTileWithBias(engine, qf, kt, scaleT, attentionBias, B, H, Sq, bk, j0); // [BH, Sq, bk]
             var dpTile = engine.TensorBatchMatMul(dof, vt.TransposeLast2D());               // [BH, Sq, bk]
             var s = sTile.GetDataArray();
             var dp = dpTile.GetDataArray();
@@ -738,6 +737,29 @@ public static class FusedAttention<T>
         var gradK = engine.Reshape(new Tensor<T>(dKfull, new[] { BH, Sk, headDim }), new[] { B, H, Sk, headDim });
         var gradV = engine.Reshape(new Tensor<T>(dVfull, new[] { BH, Sk, Dv }), new[] { B, H, Sk, Dv });
         return (gradQ, gradK, gradV);
+    }
+
+    /// <summary>Scaled scores for one key tile: <c>scale · (Q @ Kt^T)</c> as [BH, Sq, bk], plus
+    /// the additive attention bias sliced to the tile's key columns when present. The bias slice
+    /// preserves the bias's broadcast shape (last axis Sk → [j0, j0+bk)); TensorBroadcastAdd then
+    /// applies the same broadcast rules as the full-matrix path's AddBroadcastBias.</summary>
+    private static Tensor<T> ScoresTileWithBias(
+        IEngine engine, Tensor<T> qf, Tensor<T> kt, T scaleT, Tensor<T>? bias,
+        int B, int H, int Sq, int bk, int j0)
+    {
+        var s = engine.TensorMultiplyScalar(engine.TensorBatchMatMul(qf, kt.TransposeLast2D()), scaleT); // [BH, Sq, bk]
+        if (bias is null) return s;
+
+        int br = bias.Rank;
+        var start = new int[br];
+        var len = new int[br];
+        for (int d = 0; d < br; d++) { start[d] = 0; len[d] = bias._shape[d]; }
+        start[br - 1] = j0;   // slice the key axis to this tile
+        len[br - 1] = bk;
+        var biasTile = engine.TensorSlice(bias, start, len);                 // [.., Sq, bk] (broadcastable)
+        var s4 = engine.Reshape(s, new[] { B, H, Sq, bk });
+        s4 = engine.TensorBroadcastAdd(s4, biasTile);
+        return engine.Reshape(s4, new[] { B * H, Sq, bk });
     }
 
     /// <summary>Copies the key/value slice [:, j0:j0+bk, :] out of a contiguous [BH, S, D]

--- a/src/AiDotNet.Tensors/Engines/Autodiff/FusedAttention.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/FusedAttention.cs
@@ -518,16 +518,18 @@ public static class FusedAttention<T>
 
         // #1662 lever #3: for long key sequences, tile the backward over key blocks so the full
         // [Sq, Sk] score/prob matrices are NEVER materialized — peak extra memory is O(Sq*tile)
-        // instead of O(Sq*Sk). Engages only for unmasked attention; the bias/causal cases keep
-        // the full-matrix path (tiled masking is handled in the same lever, below). Small/medium
-        // Sk also keeps the full path, which is faster when the S^2 matrices fit comfortably.
-        // This is a permanent size-tiered fast path, mirroring the FP32/FP64 split already here.
+        // instead of O(Sq*Sk). Handles both plain and CAUSAL attention (causal fully-masked key
+        // tiles are skipped, which is also where the LLM long-context memory win lands). Additive
+        // attention bias keeps the full-matrix path. Small/medium Sk also keeps the full path,
+        // which is faster when the S^2 matrices fit comfortably. This is a permanent size-tiered
+        // fast path, mirroring the FP32/FP64 split already here.
         const int TileBk = 128;
-        if (attentionBias is null && !config.IsCausal && Sk > TileBk)
+        if (attentionBias is null && Sk > TileBk)
         {
             (gradQ, gradK, gradV) = BackwardTiled(
                 engine, numOps, query, key, value, gradOutput,
-                B, H, Sq, Sk, headDim, Dv, scaleVal, TileBk);
+                B, H, Sq, Sk, headDim, Dv, scaleVal, TileBk,
+                config.IsCausal, config.QueryOffset);
         }
         else
         {
@@ -601,10 +603,15 @@ public static class FusedAttention<T>
     private static (Tensor<T> GradQuery, Tensor<T> GradKey, Tensor<T> GradValue) BackwardTiled(
         IEngine engine, INumericOperations<T> numOps,
         Tensor<T> query, Tensor<T> key, Tensor<T> value, Tensor<T> gradOutput,
-        int B, int H, int Sq, int Sk, int headDim, int Dv, double scaleVal, int tileBk)
+        int B, int H, int Sq, int Sk, int headDim, int Dv, double scaleVal, int tileBk,
+        bool isCausal, int queryOffset)
     {
         int BH = B * H;
         T scaleT = numOps.FromDouble(scaleVal);
+        // Causal: key kg is visible to query i iff kg <= queryOffset + i (matches ApplyCausalMask).
+        // A whole key tile [j0, j0+bk) is fully masked for EVERY query when j0 > queryOffset+(Sq-1);
+        // such tiles are skipped (their dK/dV stay zero, dQ contribution zero).
+        bool TileFullyMasked(int j0) => isCausal && j0 > queryOffset + (Sq - 1);
 
         var qf  = engine.Reshape(query,      new[] { BH, Sq, headDim }); // [BH, Sq, Dh]
         var kf  = engine.Reshape(key,        new[] { BH, Sk, headDim }); // [BH, Sk, Dh]
@@ -618,6 +625,7 @@ public static class FusedAttention<T>
         // ---- Pass 1: online softmax normalizers (m, l) ----
         for (int j0 = 0; j0 < Sk; j0 += tileBk)
         {
+            if (TileFullyMasked(j0)) continue;
             int bk = Math.Min(tileBk, Sk - j0);
             var kt = SliceAxis1(numOps, kf, BH, Sk, headDim, j0, bk);                       // [BH, bk, Dh]
             var sTile = engine.TensorMultiplyScalar(
@@ -626,14 +634,17 @@ public static class FusedAttention<T>
             for (int row = 0; row < BH * Sq; row++)
             {
                 int b0 = row * bk;
+                int i = row % Sq;                       // query position within [0, Sq)
+                int jMax = isCausal ? Math.Min(bk, queryOffset + i - j0 + 1) : bk; // visible cols in this tile
+                if (jMax <= 0) continue;                // this row sees nothing in this tile
                 T tmax = numOps.MinValue;
-                for (int j = 0; j < bk; j++)
+                for (int j = 0; j < jMax; j++)
                     if (numOps.GreaterThan(s[b0 + j], tmax)) tmax = s[b0 + j];
                 T mOld = m[row];
                 T mNew = numOps.GreaterThan(mOld, tmax) ? mOld : tmax;
                 T alpha = numOps.Exp(numOps.Subtract(mOld, mNew)); // 0 on the first (mOld = MinValue) tile
                 T sumExp = numOps.Zero;
-                for (int j = 0; j < bk; j++)
+                for (int j = 0; j < jMax; j++)
                     sumExp = numOps.Add(sumExp, numOps.Exp(numOps.Subtract(s[b0 + j], mNew)));
                 l[row] = numOps.Add(numOps.Multiply(l[row], alpha), sumExp);
                 m[row] = mNew;
@@ -644,6 +655,7 @@ public static class FusedAttention<T>
         var D = new T[BH * Sq]; // zero-init
         for (int j0 = 0; j0 < Sk; j0 += tileBk)
         {
+            if (TileFullyMasked(j0)) continue;
             int bk = Math.Min(tileBk, Sk - j0);
             var kt = SliceAxis1(numOps, kf, BH, Sk, headDim, j0, bk);                       // [BH, bk, Dh]
             var vt = SliceAxis1(numOps, vf, BH, Sk, Dv, j0, bk);                            // [BH, bk, Dv]
@@ -655,7 +667,9 @@ public static class FusedAttention<T>
             for (int row = 0; row < BH * Sq; row++)
             {
                 int b0 = row * bk;
-                for (int j = 0; j < bk; j++)
+                int i = row % Sq;
+                int jMax = isCausal ? Math.Min(bk, queryOffset + i - j0 + 1) : bk;
+                for (int j = 0; j < jMax; j++)
                 {
                     T p = numOps.Divide(numOps.Exp(numOps.Subtract(s[b0 + j], m[row])), l[row]);
                     D[row] = numOps.Add(D[row], numOps.Multiply(p, dp[b0 + j]));
@@ -669,6 +683,7 @@ public static class FusedAttention<T>
         var dVfull = new T[BH * Sk * Dv];
         for (int j0 = 0; j0 < Sk; j0 += tileBk)
         {
+            if (TileFullyMasked(j0)) continue;
             int bk = Math.Min(tileBk, Sk - j0);
             var kt = SliceAxis1(numOps, kf, BH, Sk, headDim, j0, bk);                       // [BH, bk, Dh]
             var vt = SliceAxis1(numOps, vf, BH, Sk, Dv, j0, bk);                            // [BH, bk, Dv]
@@ -678,12 +693,16 @@ public static class FusedAttention<T>
             var s = sTile.GetDataArray();
             var dp = dpTile.GetDataArray();
 
+            // Masked (j >= jMax) entries stay zero-init, so they contribute nothing to the
+            // dV / dK / dQ GEMMs below — exactly the causal mask.
             var pData = new T[BH * Sq * bk];
             var dsData = new T[BH * Sq * bk];
             for (int row = 0; row < BH * Sq; row++)
             {
                 int b0 = row * bk;
-                for (int j = 0; j < bk; j++)
+                int i = row % Sq;
+                int jMax = isCausal ? Math.Min(bk, queryOffset + i - j0 + 1) : bk;
+                for (int j = 0; j < jMax; j++)
                 {
                     T p = numOps.Divide(numOps.Exp(numOps.Subtract(s[b0 + j], m[row])), l[row]);
                     pData[b0 + j] = p;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/BackwardArenaTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/BackwardArenaTests.cs
@@ -57,6 +57,7 @@ public class BackwardArenaTests
 
         const int warmup = 12, reps = 10;
 
+#if NET5_0_OR_GREATER
         // Measure WITHOUT an arena: conv backward output grads are fresh allocations each step.
         // (Relative on-vs-off comparison is robust to the process-global AutoTensorCache state
         // left by other tests in the suite, which an absolute byte threshold is not.)
@@ -82,6 +83,17 @@ public class BackwardArenaTests
         Assert.True(perStepOn * 3 < perStepOff,
             $"arena did not recycle conv backward allocation: on={perStepOn} B/step, off={perStepOff} B/step " +
             $"(expected on < off/3; conv backward output-grad arena routing may have regressed)");
+#else
+        // net471 (.NET Framework) has no per-thread allocation counter
+        // (GC.GetAllocatedBytesForCurrentThread is .NET Core / .NET 5+ only), so the
+        // byte-delta guard above can only run on the modern TFM (which CI uses for this
+        // assertion). Still exercise the conv-backward arena path here so net471 guards
+        // against a crash / shape regression in the *Into routing, even though it can't
+        // measure the allocation win.
+        for (int i = 0; i < warmup; i++) OneStep();
+        using (var arena = TensorArena.Create())
+            for (int i = 0; i < reps; i++) { arena.Reset(); OneStep(); }
+#endif
     }
 
     private static Tensor<float> Rand(int[] s, Random r)

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/BackwardArenaTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/BackwardArenaTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+/// <summary>
+/// #1662 lever #4 guard: per-step BACKWARD allocation must stay bounded when the per-step
+/// <see cref="TensorArena"/> is active (the way real training runs). This locks in the fix
+/// that routed Conv2D backward output gradients through the arena — before it, the conv
+/// backward leaked ~1 MB/step of `new float[]` output buffers past the arena
+/// (`--trainbench --block conv`: 1.072 MB/step, 76.6% recycled). After, ~0.1 MB/step.
+///
+/// <para>Measurement note: <see cref="GC.GetAllocatedBytesForCurrentThread"/> counts only the
+/// test thread. The streaming backward and the output-grad rent run on this thread; conv's
+/// internal im2col scratch uses ArrayPool on worker threads (not counted, and already pooled).
+/// So this faithfully guards the main-thread output-grad allocation the fix addressed.</para>
+/// </summary>
+public class BackwardArenaTests
+{
+    private readonly CpuEngine _engine = new();
+
+    [Fact]
+    public void Conv2DBackward_PerStepAllocation_StaysBounded_WithArena()
+    {
+        var rng = new Random(0);
+        // Same shape class as the trainbench conv probe that surfaced the leak.
+        const int channels = 32, sp = 32, layers = 6;
+        var x = Rand(new[] { 1, channels, sp, sp }, rng);
+        var kernels = new Tensor<float>[layers];
+        for (int l = 0; l < layers; l++)
+            kernels[l] = Scaled(Rand(new[] { channels, channels, 3, 3 }, rng), 0.02f);
+
+        void OneStep()
+        {
+            using var tape = new GradientTape<float>();
+            var h = x;
+            for (int l = 0; l < layers; l++)
+            {
+                var y = _engine.Conv2D(h, kernels[l], 1, 1, 1);
+                y = _engine.GELU(y);
+                h = _engine.TensorAdd(h, y);
+            }
+            var loss = _engine.ReduceSum(_engine.TensorMultiply(h, h));
+            var sources = new List<Tensor<float>>(layers);
+            for (int l = 0; l < layers; l++) sources.Add(kernels[l]);
+            tape.ComputeGradientsStreaming(loss, sources, (src, g) =>
+            {
+                if (g is null || g.Length == 0) return;
+                for (int i = 0; i < src.Length; i++) src[i] -= 1e-4f * g[i];
+            });
+        }
+
+        using var arena = TensorArena.Create();
+        for (int i = 0; i < 5; i++) { arena.Reset(); OneStep(); } // warmup: fill the arena
+
+        const int reps = 10;
+        long start = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < reps; i++) { arena.Reset(); OneStep(); }
+        long perStep = (GC.GetAllocatedBytesForCurrentThread() - start) / reps;
+
+        // Pre-fix this path allocated ~1.07 MB/step on the main thread; post-fix ~0.1 MB/step.
+        // 0.5 MB threshold sits firmly between the two so a regression of the conv arena
+        // routing trips it, while leaving headroom for tape bookkeeping / machine variance.
+        const long thresholdBytes = 512L * 1024;
+        Assert.True(perStep < thresholdBytes,
+            $"per-step conv backward allocation {perStep} bytes >= threshold {thresholdBytes} " +
+            $"(arena routing for Conv2D backward output grads may have regressed)");
+    }
+
+    private static Tensor<float> Rand(int[] s, Random r)
+    {
+        var t = new Tensor<float>(s);
+        for (int i = 0; i < t.Length; i++) t[i] = (float)(r.NextDouble() - 0.5);
+        return t;
+    }
+
+    private static Tensor<float> Scaled(Tensor<float> t, float s)
+    {
+        for (int i = 0; i < t.Length; i++) t[i] *= s;
+        return t;
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/BackwardArenaTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/BackwardArenaTests.cs
@@ -25,7 +25,7 @@ public class BackwardArenaTests
     private readonly CpuEngine _engine = new();
 
     [Fact]
-    public void Conv2DBackward_PerStepAllocation_StaysBounded_WithArena()
+    public void Conv2DBackward_PerStepAllocation_Recycled_ByArena()
     {
         var rng = new Random(0);
         // Same shape class as the trainbench conv probe that surfaced the leak.
@@ -55,21 +55,33 @@ public class BackwardArenaTests
             });
         }
 
-        using var arena = TensorArena.Create();
-        for (int i = 0; i < 5; i++) { arena.Reset(); OneStep(); } // warmup: fill the arena
+        const int warmup = 12, reps = 10;
 
-        const int reps = 10;
-        long start = GC.GetAllocatedBytesForCurrentThread();
-        for (int i = 0; i < reps; i++) { arena.Reset(); OneStep(); }
-        long perStep = (GC.GetAllocatedBytesForCurrentThread() - start) / reps;
+        // Measure WITHOUT an arena: conv backward output grads are fresh allocations each step.
+        // (Relative on-vs-off comparison is robust to the process-global AutoTensorCache state
+        // left by other tests in the suite, which an absolute byte threshold is not.)
+        for (int i = 0; i < warmup; i++) OneStep();
+        long offStart = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < reps; i++) OneStep();
+        long perStepOff = (GC.GetAllocatedBytesForCurrentThread() - offStart) / reps;
 
-        // Pre-fix this path allocated ~1.07 MB/step on the main thread; post-fix ~0.1 MB/step.
-        // 0.5 MB threshold sits firmly between the two so a regression of the conv arena
-        // routing trips it, while leaving headroom for tape bookkeeping / machine variance.
-        const long thresholdBytes = 512L * 1024;
-        Assert.True(perStep < thresholdBytes,
-            $"per-step conv backward allocation {perStep} bytes >= threshold {thresholdBytes} " +
-            $"(arena routing for Conv2D backward output grads may have regressed)");
+        // Measure WITH the per-step arena: the conv backward output grads (and other scratch)
+        // are recycled via Reset(), so per-step allocation drops sharply.
+        long perStepOn;
+        using (var arena = TensorArena.Create())
+        {
+            for (int i = 0; i < warmup; i++) { arena.Reset(); OneStep(); }
+            long onStart = GC.GetAllocatedBytesForCurrentThread();
+            for (int i = 0; i < reps; i++) { arena.Reset(); OneStep(); }
+            perStepOn = (GC.GetAllocatedBytesForCurrentThread() - onStart) / reps;
+        }
+
+        // The arena must recycle the bulk of the per-step allocation. Pre-fix, conv backward
+        // output grads bypassed the arena (raw new float[]) so the arena barely helped here;
+        // after routing them through the arena, on-allocation is a small fraction of off.
+        Assert.True(perStepOn * 3 < perStepOff,
+            $"arena did not recycle conv backward allocation: on={perStepOn} B/step, off={perStepOff} B/step " +
+            $"(expected on < off/3; conv backward output-grad arena routing may have regressed)");
     }
 
     private static Tensor<float> Rand(int[] s, Random r)

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/FusedAttentionTiledBackwardTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/FusedAttentionTiledBackwardTests.cs
@@ -34,7 +34,7 @@ public class FusedAttentionTiledBackwardTests
         var v  = RandomTensor(new[] { B, H, S, Dh }, 3);
         var dO = RandomTensor(new[] { B, H, S, Dh }, 4);
 
-        var (refQ, refK, refV) = ReferenceBackward(B, H, S, Dh, dO, q, k, v, causal: false, queryOffset: 0);
+        var (refQ, refK, refV) = ReferenceBackward(B, H, S, Dh, dO, q, k, v, causal: false, queryOffset: 0, bias: null);
         var (gQ, gK, gV) = FusedAttention<float>.Backward(dO, q, k, v, engine: engine);
 
         AssertClose(refQ, gQ.AsSpan().ToArray(), 1e-3f, "dQ");
@@ -54,7 +54,7 @@ public class FusedAttentionTiledBackwardTests
         var v  = RandomTensor(new[] { B, H, S, Dh }, 13);
         var dO = RandomTensor(new[] { B, H, S, Dh }, 14);
 
-        var (refQ, refK, refV) = ReferenceBackward(B, H, S, Dh, dO, q, k, v, causal: true, queryOffset: 0);
+        var (refQ, refK, refV) = ReferenceBackward(B, H, S, Dh, dO, q, k, v, causal: true, queryOffset: 0, bias: null);
         var cfg = new FlashAttentionConfig { IsCausal = true };
         var (gQ, gK, gV) = FusedAttention<float>.Backward(dO, q, k, v, config: cfg, engine: engine);
 
@@ -63,16 +63,39 @@ public class FusedAttentionTiledBackwardTests
         AssertClose(refV, gV.AsSpan().ToArray(), 1e-3f, "dV");
     }
 
+    [Theory]
+    [InlineData(1, 2, 64, 16)]   // additive bias, full-matrix path (S <= 128)
+    [InlineData(1, 4, 256, 32)]  // additive bias, tiled path (2 key tiles)
+    [InlineData(2, 4, 200, 16)]  // additive bias, tiled, uneven last tile
+    public void Backward_Bias_MatchesNaiveReference_dQdKdV(int B, int H, int S, int Dh)
+    {
+        var engine = new CpuEngine();
+        var q  = RandomTensor(new[] { B, H, S, Dh }, 21);
+        var k  = RandomTensor(new[] { B, H, S, Dh }, 22);
+        var v  = RandomTensor(new[] { B, H, S, Dh }, 23);
+        var dO = RandomTensor(new[] { B, H, S, Dh }, 24);
+        var bias = RandomTensor(new[] { B, H, S, S }, 25); // full additive [B,H,Sq,Sk] bias
+
+        var (refQ, refK, refV) = ReferenceBackward(B, H, S, Dh, dO, q, k, v, causal: false, queryOffset: 0, bias: bias);
+        var (gQ, gK, gV) = FusedAttention<float>.Backward(dO, q, k, v, attentionBias: bias, engine: engine);
+
+        AssertClose(refQ, gQ.AsSpan().ToArray(), 1e-3f, "dQ");
+        AssertClose(refK, gK.AsSpan().ToArray(), 1e-3f, "dK");
+        AssertClose(refV, gV.AsSpan().ToArray(), 1e-3f, "dV");
+    }
+
     // Naive analytic attention backward over [B,H,S,Dh] row-major tensors. No engine ops.
     // Causal: key j is visible to query i iff j <= queryOffset + i (matches ApplyCausalMask).
+    // bias (optional, full [B,H,Sq,Sk]): added to the scaled scores before softmax.
     private static (float[] dQ, float[] dK, float[] dV) ReferenceBackward(
         int B, int H, int S, int Dh, Tensor<float> dOT, Tensor<float> qT, Tensor<float> kT, Tensor<float> vT,
-        bool causal, int queryOffset)
+        bool causal, int queryOffset, Tensor<float>? bias)
     {
         float[] dO = dOT.AsSpan().ToArray();
         float[] q = qT.AsSpan().ToArray();
         float[] k = kT.AsSpan().ToArray();
         float[] v = vT.AsSpan().ToArray();
+        float[]? biasData = bias?.AsSpan().ToArray(); // full [B,H,S,S]
         float scale = (float)(1.0 / Math.Sqrt(Dh));
 
         var dQ = new float[B * H * S * Dh];
@@ -101,6 +124,7 @@ public class FusedAttentionTiledBackwardTests
                     float s = 0f;
                     for (int d = 0; d < Dh; d++) s += q[o + i * Dh + d] * k[o + j * Dh + d];
                     s *= scale;
+                    if (biasData != null) s += biasData[(((i + S * ((b * H) + h))) * S) + j]; // bias[b,h,i,j]
                     P[i * S + j] = s;
                     if (s > max) max = s;
                 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/FusedAttentionTiledBackwardTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/FusedAttentionTiledBackwardTests.cs
@@ -34,7 +34,7 @@ public class FusedAttentionTiledBackwardTests
         var v  = RandomTensor(new[] { B, H, S, Dh }, 3);
         var dO = RandomTensor(new[] { B, H, S, Dh }, 4);
 
-        var (refQ, refK, refV) = ReferenceBackward(B, H, S, Dh, dO, q, k, v);
+        var (refQ, refK, refV) = ReferenceBackward(B, H, S, Dh, dO, q, k, v, causal: false, queryOffset: 0);
         var (gQ, gK, gV) = FusedAttention<float>.Backward(dO, q, k, v, engine: engine);
 
         AssertClose(refQ, gQ.AsSpan().ToArray(), 1e-3f, "dQ");
@@ -42,9 +42,32 @@ public class FusedAttentionTiledBackwardTests
         AssertClose(refV, gV.AsSpan().ToArray(), 1e-3f, "dV");
     }
 
+    [Theory]
+    [InlineData(1, 2, 64, 16)]   // causal, full-matrix path (S <= 128)
+    [InlineData(1, 4, 256, 32)]  // causal, tiled path: above-diagonal tiles skipped
+    [InlineData(2, 4, 200, 16)]  // causal, tiled, uneven last tile
+    public void Backward_Causal_MatchesNaiveReference_dQdKdV(int B, int H, int S, int Dh)
+    {
+        var engine = new CpuEngine();
+        var q  = RandomTensor(new[] { B, H, S, Dh }, 11);
+        var k  = RandomTensor(new[] { B, H, S, Dh }, 12);
+        var v  = RandomTensor(new[] { B, H, S, Dh }, 13);
+        var dO = RandomTensor(new[] { B, H, S, Dh }, 14);
+
+        var (refQ, refK, refV) = ReferenceBackward(B, H, S, Dh, dO, q, k, v, causal: true, queryOffset: 0);
+        var cfg = new FlashAttentionConfig { IsCausal = true };
+        var (gQ, gK, gV) = FusedAttention<float>.Backward(dO, q, k, v, config: cfg, engine: engine);
+
+        AssertClose(refQ, gQ.AsSpan().ToArray(), 1e-3f, "dQ");
+        AssertClose(refK, gK.AsSpan().ToArray(), 1e-3f, "dK");
+        AssertClose(refV, gV.AsSpan().ToArray(), 1e-3f, "dV");
+    }
+
     // Naive analytic attention backward over [B,H,S,Dh] row-major tensors. No engine ops.
+    // Causal: key j is visible to query i iff j <= queryOffset + i (matches ApplyCausalMask).
     private static (float[] dQ, float[] dK, float[] dV) ReferenceBackward(
-        int B, int H, int S, int Dh, Tensor<float> dOT, Tensor<float> qT, Tensor<float> kT, Tensor<float> vT)
+        int B, int H, int S, int Dh, Tensor<float> dOT, Tensor<float> qT, Tensor<float> kT, Tensor<float> vT,
+        bool causal, int queryOffset)
     {
         float[] dO = dOT.AsSpan().ToArray();
         float[] q = qT.AsSpan().ToArray();
@@ -74,6 +97,7 @@ public class FusedAttentionTiledBackwardTests
                 float max = float.NegativeInfinity;
                 for (int j = 0; j < S; j++)
                 {
+                    if (causal && j > queryOffset + i) { P[i * S + j] = float.NegativeInfinity; continue; }
                     float s = 0f;
                     for (int d = 0; d < Dh; d++) s += q[o + i * Dh + d] * k[o + j * Dh + d];
                     s *= scale;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/FusedAttentionTiledBackwardTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/FusedAttentionTiledBackwardTests.cs
@@ -1,0 +1,158 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+/// <summary>
+/// #1662 lever #3 parity gate: <see cref="FusedAttention{T}.Backward"/> must produce
+/// dQ / dK / dV that match a straightforward, independent reference across sequence
+/// lengths and head counts.
+///
+/// <para>The reference is a NAIVE nested-loop implementation of the analytic attention
+/// backward (dV = P^T dO, dP = dO V^T, dS = P*(dP - rowsum(dP*P)), dQ = scale·dS K,
+/// dK = scale·dS^T Q) — it shares no code with the kernel under test, so it validates the
+/// kernel's tiling logic, not just self-consistency. Written test-first: it passes against
+/// the current stored-P backward (proving the reference is correct) and must keep passing
+/// after the backward is rewritten to a tiled O(S)-memory form.</para>
+/// </summary>
+public class FusedAttentionTiledBackwardTests
+{
+    [Theory]
+    [InlineData(1, 2, 16, 8)]    // tiny
+    [InlineData(2, 4, 64, 16)]   // medium, multi-batch/head
+    [InlineData(1, 8, 256, 32)]  // long-ish sequence (where O(S) memory matters)
+    public void Backward_MatchesNaiveReference_dQdKdV(int B, int H, int S, int Dh)
+    {
+        var engine = new CpuEngine();
+        var q  = RandomTensor(new[] { B, H, S, Dh }, 1);
+        var k  = RandomTensor(new[] { B, H, S, Dh }, 2);
+        var v  = RandomTensor(new[] { B, H, S, Dh }, 3);
+        var dO = RandomTensor(new[] { B, H, S, Dh }, 4);
+
+        var (refQ, refK, refV) = ReferenceBackward(B, H, S, Dh, dO, q, k, v);
+        var (gQ, gK, gV) = FusedAttention<float>.Backward(dO, q, k, v, engine: engine);
+
+        AssertClose(refQ, gQ.AsSpan().ToArray(), 1e-3f, "dQ");
+        AssertClose(refK, gK.AsSpan().ToArray(), 1e-3f, "dK");
+        AssertClose(refV, gV.AsSpan().ToArray(), 1e-3f, "dV");
+    }
+
+    // Naive analytic attention backward over [B,H,S,Dh] row-major tensors. No engine ops.
+    private static (float[] dQ, float[] dK, float[] dV) ReferenceBackward(
+        int B, int H, int S, int Dh, Tensor<float> dOT, Tensor<float> qT, Tensor<float> kT, Tensor<float> vT)
+    {
+        float[] dO = dOT.AsSpan().ToArray();
+        float[] q = qT.AsSpan().ToArray();
+        float[] k = kT.AsSpan().ToArray();
+        float[] v = vT.AsSpan().ToArray();
+        float scale = (float)(1.0 / Math.Sqrt(Dh));
+
+        var dQ = new float[B * H * S * Dh];
+        var dK = new float[B * H * S * Dh];
+        var dV = new float[B * H * S * Dh];
+
+        int Off(int b, int h) => ((b * H) + h) * S * Dh; // start of [b,h,:,:]
+
+        var P = new float[S * S];   // per-(b,h) softmax weights
+        var dP = new float[S * S];
+        var dS = new float[S * S];
+        var rowsum = new float[S];
+
+        for (int b = 0; b < B; b++)
+        for (int h = 0; h < H; h++)
+        {
+            int o = Off(b, h);
+
+            // scores[i,j] = scale * <q_i, k_j>, then softmax over j -> P[i,j]
+            for (int i = 0; i < S; i++)
+            {
+                float max = float.NegativeInfinity;
+                for (int j = 0; j < S; j++)
+                {
+                    float s = 0f;
+                    for (int d = 0; d < Dh; d++) s += q[o + i * Dh + d] * k[o + j * Dh + d];
+                    s *= scale;
+                    P[i * S + j] = s;
+                    if (s > max) max = s;
+                }
+                float sum = 0f;
+                for (int j = 0; j < S; j++) { float e = (float)Math.Exp(P[i * S + j] - max); P[i * S + j] = e; sum += e; }
+                for (int j = 0; j < S; j++) P[i * S + j] /= sum;
+            }
+
+            // dP[i,j] = <dO_i, v_j>
+            for (int i = 0; i < S; i++)
+            for (int j = 0; j < S; j++)
+            {
+                float s = 0f;
+                for (int e = 0; e < Dh; e++) s += dO[o + i * Dh + e] * v[o + j * Dh + e];
+                dP[i * S + j] = s;
+            }
+
+            // dV[j,e] = sum_i P[i,j] * dO[i,e]
+            for (int j = 0; j < S; j++)
+            for (int e = 0; e < Dh; e++)
+            {
+                float s = 0f;
+                for (int i = 0; i < S; i++) s += P[i * S + j] * dO[o + i * Dh + e];
+                dV[o + j * Dh + e] = s;
+            }
+
+            // rowsum_i = sum_j dP[i,j]*P[i,j];  dS[i,j] = P[i,j]*(dP[i,j]-rowsum_i)
+            for (int i = 0; i < S; i++)
+            {
+                float rs = 0f;
+                for (int j = 0; j < S; j++) rs += dP[i * S + j] * P[i * S + j];
+                rowsum[i] = rs;
+                for (int j = 0; j < S; j++) dS[i * S + j] = P[i * S + j] * (dP[i * S + j] - rs);
+            }
+
+            // dQ[i,d] = scale * sum_j dS[i,j]*k[j,d]
+            for (int i = 0; i < S; i++)
+            for (int d = 0; d < Dh; d++)
+            {
+                float s = 0f;
+                for (int j = 0; j < S; j++) s += dS[i * S + j] * k[o + j * Dh + d];
+                dQ[o + i * Dh + d] = scale * s;
+            }
+
+            // dK[j,d] = scale * sum_i dS[i,j]*q[i,d]
+            for (int j = 0; j < S; j++)
+            for (int d = 0; d < Dh; d++)
+            {
+                float s = 0f;
+                for (int i = 0; i < S; i++) s += dS[i * S + j] * q[o + i * Dh + d];
+                dK[o + j * Dh + d] = scale * s;
+            }
+        }
+        return (dQ, dK, dV);
+    }
+
+    private static void AssertClose(float[] expected, float[] actual, float tol, string name)
+    {
+        Assert.Equal(expected.Length, actual.Length);
+        float maxAbs = 0f;
+        int worst = -1;
+        for (int i = 0; i < expected.Length; i++)
+        {
+            float d = Math.Abs(expected[i] - actual[i]);
+            // relative tolerance for larger magnitudes
+            float bound = tol * (1f + Math.Abs(expected[i]));
+            if (d > bound && d > maxAbs) { maxAbs = d; worst = i; }
+        }
+        Assert.True(worst < 0,
+            $"{name} mismatch at index {worst}: expected {(worst >= 0 ? expected[worst] : 0)}, " +
+            $"actual {(worst >= 0 ? actual[worst] : 0)} (absdiff {maxAbs}, tol {tol})");
+    }
+
+    private static Tensor<float> RandomTensor(int[] shape, int seed)
+    {
+        var r = new Random(seed);
+        var t = new Tensor<float>(shape);
+        for (int i = 0; i < t.Length; i++) t[i] = (float)(r.NextDouble() - 0.5);
+        return t;
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/FusedAttentionTiledBackwardTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/FusedAttentionTiledBackwardTests.cs
@@ -21,9 +21,11 @@ namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
 public class FusedAttentionTiledBackwardTests
 {
     [Theory]
-    [InlineData(1, 2, 16, 8)]    // tiny
-    [InlineData(2, 4, 64, 16)]   // medium, multi-batch/head
-    [InlineData(1, 8, 256, 32)]  // long-ish sequence (where O(S) memory matters)
+    [InlineData(1, 2, 16, 8)]    // tiny (full-matrix path)
+    [InlineData(2, 4, 64, 16)]   // medium, multi-batch/head (full-matrix path)
+    [InlineData(1, 8, 256, 32)]  // long sequence -> tiled path, 2 even key tiles (128+128)
+    [InlineData(1, 4, 200, 16)]  // tiled path, UNEVEN last tile (128+72)
+    [InlineData(2, 4, 320, 16)]  // tiled path, multi-batch/head, 3 tiles (128+128+64)
     public void Backward_MatchesNaiveReference_dQdKdV(int B, int H, int S, int Dh)
     {
         var engine = new CpuEngine();

--- a/tools/ConvParallelProbe/Program.cs
+++ b/tools/ConvParallelProbe/Program.cs
@@ -33,6 +33,7 @@ internal static class Program
         if (args.Length > 0 && args[0] == "--gemmprofile") return RunGemmProfile(eng, args);
         if (args.Length > 0 && args[0] == "--gpu") return RunGpu(args);
         if (args.Length > 0 && args[0] == "--trainbench") return RunTrainbench(eng, args);
+        if (args.Length > 0 && args[0] == "--flashbwd") return RunFlashBwd(eng, args);
 
         int maxdop = ArgI(args, "--maxdop", Environment.ProcessorCount);
         int inC = ArgI(args, "--inc", 256);
@@ -239,6 +240,69 @@ internal static class Program
             $"procs={Environment.ProcessorCount} median_ms={times[reps / 2]:F3} min_ms={times[0]:F3} " +
             $"alloc_mb_per_step={perStepAllocMB:F3} peak_ws_mb={peakWs / (1024.0 * 1024.0):F1} " +
             $"last_loss={step.LastLoss:E3}");
+        return 0;
+    }
+
+    // #1662 lever #3 memory proof: peak LIVE managed set during one FusedAttention.Backward at a
+    // long sequence, tiled (default) vs --full (forces the full-matrix path at the same shape).
+    // The full path keeps the [B,H,S,S] score/prob matrices simultaneously reachable (O(S^2));
+    // the tiled path holds only one O(S*tile) tile + the outputs at a time. The sampler FORCES a
+    // collection per sample (GC.GetTotalMemory(true)) so only REACHABLE bytes count — otherwise
+    // the tiled path's transient per-tile garbage (it recomputes scores 3x) would dominate and
+    // hide the peak-live win. Timing is perturbed by the forced GCs, so this mode reports memory,
+    // not speed (use --trainbench / plain backward_ms elsewhere for timing).
+    private static int RunFlashBwd(CpuEngine eng, string[] a)
+    {
+        int B = ArgI(a, "--b", 1);
+        int H = ArgI(a, "--h", 8);
+        int S = ArgI(a, "--s", 2048);
+        int Dh = ArgI(a, "--dh", 64);
+        bool full = HasFlag(a, "--full");
+        if (B < 1 || H < 1 || S < 1 || Dh < 1) { Console.Error.WriteLine("flashbwd: --b,--h,--s,--dh must be >= 1."); return 2; }
+
+        var rng = new Random(0);
+        var q = Rand(new[] { B, H, S, Dh }, rng);
+        var k = Rand(new[] { B, H, S, Dh }, rng);
+        var v = Rand(new[] { B, H, S, Dh }, rng);
+        var dO = Rand(new[] { B, H, S, Dh }, rng);
+
+        var toggle = typeof(FusedAttention<float>).GetField(
+            "ForceFullBackwardForBench",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        toggle?.SetValue(null, full);
+
+        // Warmup (JIT + first-touch); result discarded.
+        var (wq, _, _) = FusedAttention<float>.Backward(dO, q, k, v, engine: eng);
+        if (wq[0] == float.PositiveInfinity) Console.Write("");
+
+        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+        long baseline = GC.GetTotalMemory(true);
+        long peak = baseline;
+        bool stop = false;
+        var sampler = new System.Threading.Thread(() =>
+        {
+            while (!System.Threading.Volatile.Read(ref stop))
+            {
+                long m = GC.GetTotalMemory(true); // forced collection -> reachable bytes only
+                if (m > peak) peak = m;
+                System.Threading.Thread.Sleep(10);
+            }
+        }) { IsBackground = true };
+        sampler.Start();
+
+        var sw = Stopwatch.StartNew();
+        var (gq, gk, gv) = FusedAttention<float>.Backward(dO, q, k, v, engine: eng);
+        sw.Stop();
+
+        System.Threading.Volatile.Write(ref stop, true);
+        sampler.Join();
+        toggle?.SetValue(null, false); // restore
+
+        float sink = gq[0] + gk[0] + gv[0];
+        Console.WriteLine(
+            $"FLASHBWD path={(full ? "full" : "tiled")} B={B} H={H} S={S} Dh={Dh} " +
+            $"backward_ms={sw.Elapsed.TotalMilliseconds:F1} peak_managed_mb={(peak - baseline) / (1024.0 * 1024.0):F1} " +
+            $"(sink={sink:E1})");
         return 0;
     }
 

--- a/tools/ConvParallelProbe/Program.cs
+++ b/tools/ConvParallelProbe/Program.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.LinearAlgebra;
 
@@ -30,6 +32,7 @@ internal static class Program
         if (args.Length > 0 && args[0] == "--gemm") return RunGemm(eng, args);
         if (args.Length > 0 && args[0] == "--gemmprofile") return RunGemmProfile(eng, args);
         if (args.Length > 0 && args[0] == "--gpu") return RunGpu(args);
+        if (args.Length > 0 && args[0] == "--trainbench") return RunTrainbench(eng, args);
 
         int maxdop = ArgI(args, "--maxdop", Environment.ProcessorCount);
         int inC = ArgI(args, "--inc", 256);
@@ -165,6 +168,118 @@ internal static class Program
             $"ATTNBLOCK S={S} D={D} H={H} Dh={Dh} blocks={blocks} maxdop={maxdop} procs={Environment.ProcessorCount} " +
             $"warmup_ms={warm:F1} median_ms={times[reps / 2]:F2} min_ms={times[0]:F2} max_ms={times[times.Length - 1]:F2}{u}");
         return 0;
+    }
+
+    // #1662 lever #4 / #1 proof harness: per-step TRAINING cost (fwd + bwd + optimizer step)
+    // for a residual-FFN stack on the autodiff tape. Backward runs through
+    // tape.ComputeGradientsStreaming (the optimizer-in-backward path), so this isolates the
+    // per-step backward ALLOCATION (the audit target) and per-step wall time. Emits one
+    // machine-readable line so trainbench_torch.py (same shape/optimizer) can be diffed
+    // against it to prove AiDotNet beats PyTorch CPU on time / alloc / peak-RSS.
+    //
+    // Shape mirrors the #1624 acceptance model's FFN block (SimCSE dim=384, 10 layers). A
+    // residual MLP stack (TensorMatMul + GELU) deliberately hammers matmul-backward — the
+    // hottest backward op and the primary arena-bypass suspect — and records robustly on the
+    // tape (attention's manual Backward is not a tape op, so it is exercised by the #3 parity
+    // test instead, not here).
+    private static int RunTrainbench(CpuEngine eng, string[] a)
+    {
+        int maxdop = ArgI(a, "--maxdop", Environment.ProcessorCount);
+        int S = ArgI(a, "--s", 128);        // sequence length (rows)
+        int D = ArgI(a, "--d", 384);        // model dim
+        int layers = ArgI(a, "--layers", 10);
+        int reps = ArgI(a, "--reps", 20);
+        int warmup = ArgI(a, "--warmup", 5);
+        if (maxdop < 1 || S < 1 || D < 1 || layers < 1 || reps < 1 || warmup < 0)
+        {
+            Console.Error.WriteLine("trainbench: --maxdop,--s,--d,--layers,--reps must be >= 1 (--warmup >= 0).");
+            return 2;
+        }
+        CpuParallelSettings.MaxDegreeOfParallelism = maxdop;
+
+        var rng = new Random(0);
+        var step = new TrainbenchStep(eng, S, D, layers, rng);
+
+        for (int i = 0; i < warmup; i++) step.RunStep();
+
+        var times = new double[reps];
+        long peakWs = 0;
+        long allocStart = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < reps; i++)
+        {
+            var sw = Stopwatch.StartNew();
+            step.RunStep();
+            sw.Stop();
+            times[i] = sw.Elapsed.TotalMilliseconds;
+            peakWs = Math.Max(peakWs, Process.GetCurrentProcess().WorkingSet64);
+        }
+        long allocTotal = GC.GetAllocatedBytesForCurrentThread() - allocStart;
+        Array.Sort(times);
+        double perStepAllocMB = allocTotal / (double)reps / (1024.0 * 1024.0);
+        Console.WriteLine(
+            $"TRAINBENCH engine=aidotnet S={S} D={D} layers={layers} maxdop={maxdop} " +
+            $"procs={Environment.ProcessorCount} median_ms={times[reps / 2]:F3} min_ms={times[0]:F3} " +
+            $"alloc_mb_per_step={perStepAllocMB:F3} peak_ws_mb={peakWs / (1024.0 * 1024.0):F1} " +
+            $"last_loss={step.LastLoss:E3}");
+        return 0;
+    }
+
+    // Owns the residual-FFN weights and runs one fwd+bwd+SGD step on the tape. SGD (not Adam)
+    // so the optimizer step itself contributes ~no allocation — the metric isolates fwd+bwd.
+    private sealed class TrainbenchStep
+    {
+        private readonly CpuEngine _eng;
+        private readonly int _layers;
+        private readonly Tensor<float>[] _w1; // [D, 4D]
+        private readonly Tensor<float>[] _w2; // [4D, D]
+        private readonly Tensor<float> _x;    // [S, D] fixed input
+        private const float Lr = 1e-3f;
+
+        public float LastLoss { get; private set; }
+
+        public TrainbenchStep(CpuEngine eng, int s, int d, int layers, Random rng)
+        {
+            _eng = eng; _layers = layers;
+            _x = Rand(new[] { s, d }, rng);
+            _w1 = new Tensor<float>[layers];
+            _w2 = new Tensor<float>[layers];
+            // Scale weights small so the residual stack stays numerically tame over many steps.
+            for (int l = 0; l < layers; l++)
+            {
+                _w1[l] = Scale(Rand(new[] { d, 4 * d }, rng), 0.02f);
+                _w2[l] = Scale(Rand(new[] { 4 * d, d }, rng), 0.02f);
+            }
+        }
+
+        public void RunStep()
+        {
+            using var tape = new GradientTape<float>();
+            var h = _x;
+            for (int l = 0; l < _layers; l++)
+            {
+                var f = _eng.TensorMatMul(h, _w1[l]);   // [S, 4D]
+                f = _eng.GELU(f);
+                f = _eng.TensorMatMul(f, _w2[l]);        // [S, D]
+                h = _eng.TensorAdd(h, f);                // residual
+            }
+            // Scalar MSE-to-zero loss so the whole stack is on one connected graph.
+            var loss = _eng.ReduceSum(_eng.TensorMultiply(h, h));
+            LastLoss = loss.Length > 0 ? loss[0] : 0f;
+
+            var sources = new List<Tensor<float>>(_layers * 2);
+            for (int l = 0; l < _layers; l++) { sources.Add(_w1[l]); sources.Add(_w2[l]); }
+            tape.ComputeGradientsStreaming(loss, sources, (src, g) =>
+            {
+                if (g is null || g.Length == 0) return;
+                for (int i = 0; i < src.Length; i++) src[i] -= Lr * g[i]; // SGD, in place
+            });
+        }
+
+        private static Tensor<float> Scale(Tensor<float> t, float s)
+        {
+            for (int i = 0; i < t.Length; i++) t[i] *= s;
+            return t;
+        }
     }
 
     // P4 (#653): the elementwise-activation stragglers (GELU/Swish/Tanh/Sigmoid) on a single

--- a/tools/ConvParallelProbe/Program.cs
+++ b/tools/ConvParallelProbe/Program.cs
@@ -196,17 +196,27 @@ internal static class Program
             return 2;
         }
         CpuParallelSettings.MaxDegreeOfParallelism = maxdop;
+        // Real training (NeuralNetworkBase) wraps each step in a per-step TensorArena that
+        // recycles fwd+bwd scratch. Mirror that by default so the metric reflects the REAL
+        // per-step churn (what bypasses the arena) — the lever #4 audit target. --no-arena
+        // measures the un-pooled worst case.
+        bool arenaOn = !HasFlag(a, "--no-arena");
 
         var rng = new Random(0);
         var step = new TrainbenchStep(eng, S, D, layers, rng);
 
-        for (int i = 0; i < warmup; i++) step.RunStep();
+        // Weights are constructed above (before the arena) so they stay persistent across
+        // Reset(); only per-step scratch recycles.
+        using var arena = arenaOn ? TensorArena.Create() : null;
+
+        for (int i = 0; i < warmup; i++) { arena?.Reset(); step.RunStep(); }
 
         var times = new double[reps];
         long peakWs = 0;
         long allocStart = GC.GetAllocatedBytesForCurrentThread();
         for (int i = 0; i < reps; i++)
         {
+            arena?.Reset();
             var sw = Stopwatch.StartNew();
             step.RunStep();
             sw.Stop();
@@ -217,7 +227,7 @@ internal static class Program
         Array.Sort(times);
         double perStepAllocMB = allocTotal / (double)reps / (1024.0 * 1024.0);
         Console.WriteLine(
-            $"TRAINBENCH engine=aidotnet S={S} D={D} layers={layers} maxdop={maxdop} " +
+            $"TRAINBENCH engine=aidotnet arena={(arenaOn ? "on" : "off")} S={S} D={D} layers={layers} maxdop={maxdop} " +
             $"procs={Environment.ProcessorCount} median_ms={times[reps / 2]:F3} min_ms={times[0]:F3} " +
             $"alloc_mb_per_step={perStepAllocMB:F3} peak_ws_mb={peakWs / (1024.0 * 1024.0):F1} " +
             $"last_loss={step.LastLoss:E3}");

--- a/tools/ConvParallelProbe/Program.cs
+++ b/tools/ConvParallelProbe/Program.cs
@@ -185,11 +185,12 @@ internal static class Program
     private static int RunTrainbench(CpuEngine eng, string[] a)
     {
         int maxdop = ArgI(a, "--maxdop", Environment.ProcessorCount);
-        int S = ArgI(a, "--s", 128);        // sequence length (rows)
-        int D = ArgI(a, "--d", 384);        // model dim
+        int S = ArgI(a, "--s", 128);        // sequence length (rows) / conv spatial
+        int D = ArgI(a, "--d", 384);        // model dim / conv channels
         int layers = ArgI(a, "--layers", 10);
         int reps = ArgI(a, "--reps", 20);
         int warmup = ArgI(a, "--warmup", 5);
+        string block = ArgS(a, "--block", "mlp"); // mlp | attn | conv
         if (maxdop < 1 || S < 1 || D < 1 || layers < 1 || reps < 1 || warmup < 0)
         {
             Console.Error.WriteLine("trainbench: --maxdop,--s,--d,--layers,--reps must be >= 1 (--warmup >= 0).");
@@ -203,7 +204,14 @@ internal static class Program
         bool arenaOn = !HasFlag(a, "--no-arena");
 
         var rng = new Random(0);
-        var step = new TrainbenchStep(eng, S, D, layers, rng);
+        ITrainStep step = block switch
+        {
+            "attn" => new TrainbenchAttnStep(eng, S, D, layers, rng),
+            "conv" => new TrainbenchConvStep(eng, S, D, layers, rng),
+            "mlp"  => new TrainbenchStep(eng, S, D, layers, rng),
+            _      => null!,
+        };
+        if (step is null) { Console.Error.WriteLine($"trainbench: --block must be mlp|attn|conv (got '{block}')."); return 2; }
 
         // Weights are constructed above (before the arena) so they stay persistent across
         // Reset(); only per-step scratch recycles.
@@ -227,23 +235,40 @@ internal static class Program
         Array.Sort(times);
         double perStepAllocMB = allocTotal / (double)reps / (1024.0 * 1024.0);
         Console.WriteLine(
-            $"TRAINBENCH engine=aidotnet arena={(arenaOn ? "on" : "off")} S={S} D={D} layers={layers} maxdop={maxdop} " +
+            $"TRAINBENCH engine=aidotnet block={block} arena={(arenaOn ? "on" : "off")} S={S} D={D} layers={layers} maxdop={maxdop} " +
             $"procs={Environment.ProcessorCount} median_ms={times[reps / 2]:F3} min_ms={times[0]:F3} " +
             $"alloc_mb_per_step={perStepAllocMB:F3} peak_ws_mb={peakWs / (1024.0 * 1024.0):F1} " +
             $"last_loss={step.LastLoss:E3}");
         return 0;
     }
 
+    // A single training block whose per-step fwd+bwd allocation the trainbench measures.
+    private interface ITrainStep { void RunStep(); float LastLoss { get; } }
+
+    private const float TbLr = 1e-3f;
+
+    // In-place SGD update applied inside the streaming-backward callback.
+    private static void SgdApply(Tensor<float> src, Tensor<float> g)
+    {
+        if (g is null || g.Length == 0) return;
+        for (int i = 0; i < src.Length; i++) src[i] -= TbLr * g[i];
+    }
+
+    private static Tensor<float> Scaled(Tensor<float> t, float s)
+    {
+        for (int i = 0; i < t.Length; i++) t[i] *= s;
+        return t;
+    }
+
     // Owns the residual-FFN weights and runs one fwd+bwd+SGD step on the tape. SGD (not Adam)
     // so the optimizer step itself contributes ~no allocation — the metric isolates fwd+bwd.
-    private sealed class TrainbenchStep
+    private sealed class TrainbenchStep : ITrainStep
     {
         private readonly CpuEngine _eng;
         private readonly int _layers;
         private readonly Tensor<float>[] _w1; // [D, 4D]
         private readonly Tensor<float>[] _w2; // [4D, D]
         private readonly Tensor<float> _x;    // [S, D] fixed input
-        private const float Lr = 1e-3f;
 
         public float LastLoss { get; private set; }
 
@@ -256,8 +281,8 @@ internal static class Program
             // Scale weights small so the residual stack stays numerically tame over many steps.
             for (int l = 0; l < layers; l++)
             {
-                _w1[l] = Scale(Rand(new[] { d, 4 * d }, rng), 0.02f);
-                _w2[l] = Scale(Rand(new[] { 4 * d, d }, rng), 0.02f);
+                _w1[l] = Scaled(Rand(new[] { d, 4 * d }, rng), 0.02f);
+                _w2[l] = Scaled(Rand(new[] { 4 * d, d }, rng), 0.02f);
             }
         }
 
@@ -278,17 +303,106 @@ internal static class Program
 
             var sources = new List<Tensor<float>>(_layers * 2);
             for (int l = 0; l < _layers; l++) { sources.Add(_w1[l]); sources.Add(_w2[l]); }
-            tape.ComputeGradientsStreaming(loss, sources, (src, g) =>
+            tape.ComputeGradientsStreaming(loss, sources, SgdApply);
+        }
+    }
+
+    // Single-head attention block (q@k^T -> softmax -> @v -> proj -> residual -> LayerNorm),
+    // built from tape primitives so Softmax/LayerNorm/MatMulTransposed BACKWARD are exercised
+    // — the attention backward path #1662 lever #4 names. Verifies it stays arena-bounded.
+    private sealed class TrainbenchAttnStep : ITrainStep
+    {
+        private readonly CpuEngine _eng;
+        private readonly int _layers, _d;
+        private readonly float _scale;
+        private readonly Tensor<float>[] _wq, _wk, _wv, _wo, _gamma, _beta;
+        private readonly Tensor<float> _x; // [S, D]
+
+        public float LastLoss { get; private set; }
+
+        public TrainbenchAttnStep(CpuEngine eng, int s, int d, int layers, Random rng)
+        {
+            _eng = eng; _layers = layers; _d = d;
+            _scale = (float)(1.0 / Math.Sqrt(d));
+            _x = Rand(new[] { s, d }, rng);
+            _wq = new Tensor<float>[layers]; _wk = new Tensor<float>[layers];
+            _wv = new Tensor<float>[layers]; _wo = new Tensor<float>[layers];
+            _gamma = new Tensor<float>[layers]; _beta = new Tensor<float>[layers];
+            for (int l = 0; l < layers; l++)
             {
-                if (g is null || g.Length == 0) return;
-                for (int i = 0; i < src.Length; i++) src[i] -= Lr * g[i]; // SGD, in place
-            });
+                _wq[l] = Scaled(Rand(new[] { d, d }, rng), 0.02f);
+                _wk[l] = Scaled(Rand(new[] { d, d }, rng), 0.02f);
+                _wv[l] = Scaled(Rand(new[] { d, d }, rng), 0.02f);
+                _wo[l] = Scaled(Rand(new[] { d, d }, rng), 0.02f);
+                _gamma[l] = Scaled(Rand(new[] { d }, rng), 0f); // gamma=0+1 below
+                for (int i = 0; i < d; i++) _gamma[l][i] = 1f;
+                _beta[l] = Scaled(Rand(new[] { d }, rng), 0f);
+            }
         }
 
-        private static Tensor<float> Scale(Tensor<float> t, float s)
+        public void RunStep()
         {
-            for (int i = 0; i < t.Length; i++) t[i] *= s;
-            return t;
+            using var tape = new GradientTape<float>();
+            var h = _x;
+            for (int l = 0; l < _layers; l++)
+            {
+                var q = _eng.TensorMatMul(h, _wq[l]);                 // [S, D]
+                var k = _eng.TensorMatMul(h, _wk[l]);
+                var v = _eng.TensorMatMul(h, _wv[l]);
+                var scores = _eng.TensorMatMulTransposed(q, k);       // q @ k^T -> [S, S]
+                scores = _eng.TensorMultiplyScalar(scores, _scale);
+                var p = _eng.Softmax(scores, -1);                     // [S, S]
+                var ctx = _eng.TensorMatMul(p, v);                    // [S, D]
+                var o = _eng.TensorMatMul(ctx, _wo[l]);               // [S, D]
+                var res = _eng.TensorAdd(h, o);                       // residual
+                h = _eng.TensorLayerNorm(res, _gamma[l], _beta[l]);   // LayerNorm
+            }
+            var loss = _eng.ReduceSum(_eng.TensorMultiply(h, h));
+            LastLoss = loss.Length > 0 ? loss[0] : 0f;
+
+            var sources = new List<Tensor<float>>(_layers * 6);
+            for (int l = 0; l < _layers; l++)
+            { sources.Add(_wq[l]); sources.Add(_wk[l]); sources.Add(_wv[l]); sources.Add(_wo[l]); sources.Add(_gamma[l]); sources.Add(_beta[l]); }
+            tape.ComputeGradientsStreaming(loss, sources, SgdApply);
+        }
+    }
+
+    // Residual conv stack (Conv2D 3x3 pad-1 -> GELU -> residual) so Conv2D BACKWARD (im2col /
+    // col2im scratch) is exercised — the conv backward path #1662 lever #4 names.
+    private sealed class TrainbenchConvStep : ITrainStep
+    {
+        private readonly CpuEngine _eng;
+        private readonly int _layers;
+        private readonly Tensor<float>[] _kernels; // [C, C, 3, 3]
+        private readonly Tensor<float> _x;         // [1, C, sp, sp]
+
+        public float LastLoss { get; private set; }
+
+        public TrainbenchConvStep(CpuEngine eng, int sp, int channels, int layers, Random rng)
+        {
+            _eng = eng; _layers = layers;
+            _x = Rand(new[] { 1, channels, sp, sp }, rng);
+            _kernels = new Tensor<float>[layers];
+            for (int l = 0; l < layers; l++)
+                _kernels[l] = Scaled(Rand(new[] { channels, channels, 3, 3 }, rng), 0.02f);
+        }
+
+        public void RunStep()
+        {
+            using var tape = new GradientTape<float>();
+            var h = _x;
+            for (int l = 0; l < _layers; l++)
+            {
+                var y = _eng.Conv2D(h, _kernels[l], 1, 1, 1); // 3x3 stride1 pad1 -> same spatial
+                y = _eng.GELU(y);
+                h = _eng.TensorAdd(h, y);                     // residual
+            }
+            var loss = _eng.ReduceSum(_eng.TensorMultiply(h, h));
+            LastLoss = loss.Length > 0 ? loss[0] : 0f;
+
+            var sources = new List<Tensor<float>>(_layers);
+            for (int l = 0; l < _layers; l++) sources.Add(_kernels[l]);
+            tape.ComputeGradientsStreaming(loss, sources, SgdApply);
         }
     }
 
@@ -741,6 +855,12 @@ internal static class Program
     }
 
     private static bool HasFlag(string[] a, string f) => Array.IndexOf(a, f) >= 0;
+
+    private static string ArgS(string[] a, string f, string d)
+    {
+        int i = Array.IndexOf(a, f);
+        return i >= 0 && i + 1 < a.Length ? a[i + 1] : d;
+    }
 
     // Stop a utilization meter (if any) and format its reading.
     //  busyCores = mean busy CPU cores over the window (process CPU-time / wall) — pool-agnostic.


### PR DESCRIPTION
Backward-pass memory work for ooples/AiDotNet#1662 (part of #653). Tensors-side levers #4 and #3. Lever #2 (checkpointing) is out of scope (owned by AiDotNet PR #1633).

## Lever #4 — backward buffer-reuse audit
- Added `--trainbench` to `ConvParallelProbe` (mlp/attn/conv blocks; arena on/off; per-step time/alloc/peak-RSS).
- **Finding:** the per-step `TensorArena` already recycles ~99.9% of mlp/attn backward allocation. The one real bypass was **Conv2D backward output gradients** (raw `new float[]`), now routed through `AutoTensorCache` + the existing `Conv2DBackward*Into` variants.
- **Result:** conv backward alloc **1.072 → 0.108 MB/step** (~10×); gradients unchanged (net471 conv autodiff 255/255, loss bit-identical). Guarded by `BackwardArenaTests`.

## Lever #3 — FlashAttention-2 style tiled backward
- `FusedAttention.Backward` no longer materializes the full S×S score/prob matrices. Tiled over key blocks (3 passes: online softmax m/l → D correction → dQ/dK/dV), engine batched-matmul for the GEMMs + per-row softmax inline. Engages for `Sk > 128`; small/medium Sk keeps the full path.
- **Covers every case** at `Sk>128`: **plain, causal** (above-diagonal tiles skipped), **and additive bias** (sliced per key tile + broadcast-added via `ScoresTileWithBias`; bias takes precedence over the causal flag, matching the full path).
- **Parity-gated:** dQ/dK/dV bit-close (1e-3) to an independent naive reference across even/uneven/multi-tile × {plain, causal, bias} shapes; full FusedAttention suite **42/42**.
- **Peak-memory proof** (`--flashbwd`, S=2048): **236 MB tiled vs 924 MB full (~3.9×)**.

## Verification
No regressions: every failure in the full Autodiff suite is pre-existing/GPU-env (GPU CUDA-700; order-dependent compiled-replay flakes that pass in isolation; MaxPool2D fails on base too — confirmed by reverting my files).

## Release
Should publish as **AiDotNet.Tensors 0.102.0** — the AiDotNet #1662 PR bumps to it for the #3/#4 benefits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)