### PR TITLE
perf(#1650/#638): diffusion UNet forward CUDA-graph capture ENGAGES — whole forward resident, ~3.2x (replay bit-exact)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledInferencePlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledInferencePlan.cs
@@ -70,6 +70,11 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
     // Eviction is suspended for the captured graph's LIFETIME (resumed in Dispose): the captured kernels
     // reference resident intermediate buffers in the activation cache that must not be freed before replay.
     private bool _graphEvictionSuspended;
+    // Structural flag: this plan contains steps that run on a DIFFERENT engine than _engine (a cross-engine
+    // stitch — see ThenAsync). Capturing only _engine's backend would record the CUDA work but run the
+    // CPU/other-backend steps once at capture and skip them on replay, leaving stale downstream outputs.
+    // So graph capture is refused for such plans (TryGetGraphBackend returns false).
+    private readonly bool _containsCrossEngineSteps;
     private static readonly bool s_inferenceCudaGraph =
         System.Environment.GetEnvironmentVariable("AIDOTNET_INFERENCE_CUDA_GRAPH") == "1";
     // Eager calls before capture, so lazy uploads / kernel autotune settle into the steady-state
@@ -141,12 +146,14 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
         Tensor<T>? compiledInputTensor,
         List<GCHandle>? handles = null,
         CompiledInferencePlan<T>[]? sourcePlans = null,
-        Tensor<T>[]? compiledInputTensors = null)
+        Tensor<T>[]? compiledInputTensors = null,
+        bool containsCrossEngineSteps = false)
     {
         _steps = steps;
         _finalOutput = finalOutput;
         _engine = engine;
         _compiledInputShape = inputShape;
+        _containsCrossEngineSteps = containsCrossEngineSteps;
         // Compile() / CreateFromDeserialized currently capture one input,
         // so the array has length 0 or 1 in practice. Storing it as an array
         // lets SetInputs generalize cleanly when multi-input Compile lands.
@@ -718,7 +725,10 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
             inputShape: (int[])_compiledInputShape.Clone(),
             compiledInputTensor: _compiledInputTensors.Length > 0 ? _compiledInputTensors[0] : null,
             handles: null,
-            sourcePlans: stitchedSources);
+            sourcePlans: stitchedSources,
+            // A stitched plan contains cross-engine steps if THIS stitch crosses engines or either operand
+            // already did — so graph capture stays disabled for the whole chain, not just the first hop.
+            containsCrossEngineSteps: crossEngine || _containsCrossEngineSteps || nextPlan._containsCrossEngineSteps);
     }
 
     private static bool ShapesEqual(int[] a, int[] b)
@@ -774,8 +784,30 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
             // then run the whole forward as one cuGraphLaunch.
             if (_graphExec != IntPtr.Zero)
             {
-                RefreshInferenceInputsInPlace(cb);
-                cb.LaunchCapturedGraph(_graphExec);
+                bool replayed = false;
+                try
+                {
+                    RefreshInferenceInputsInPlace(cb);            // throws if an input can't be refreshed in place
+                    cb.LaunchCapturedGraph(_graphExec);
+                    replayed = RefreshFinalOutputFromResident(); // fresh DtoH into _finalOutput's host storage
+                }
+                catch (InvalidOperationException) { replayed = false; }
+                if (replayed) return _finalOutput;
+
+                // Fail closed: an input could not be refreshed in place, or the output could not be downloaded
+                // — discard the captured graph and run this call eagerly so we never serve a result computed
+                // from stale device inputs or read from a stale host buffer. Capture stays disabled afterward.
+                if (_graphExec != IntPtr.Zero) { try { cb.DestroyCapturedGraph(_graphExec); } catch { } _graphExec = IntPtr.Zero; }
+                _graphBackend = null;
+                _graphCaptureDisabled = true;
+                if (_graphEvictionSuspended && _graphEngine is not null)
+                {
+                    try { _graphEngine.ResumeActivationEviction(); } catch { }
+                    _graphEvictionSuspended = false;
+                }
+                _graphEngine = null;
+                for (int i = 0; i < steps.Length; i++)
+                    steps[i].Execute(engine, steps[i].OutputBuffer);
                 return _finalOutput;
             }
 
@@ -816,6 +848,12 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
                                 _graphBackend = cb;
                                 _graphEngine = gte;
                                 cb.LaunchCapturedGraph(exec);
+                                // Force a fresh DtoH into _finalOutput's host storage (else the returned tensor
+                                // exposes capture-time host data). If the output is not resident-downloadable,
+                                // treat capture as failed — the outer catch disables it and falls back to eager.
+                                if (!RefreshFinalOutputFromResident())
+                                    throw new InvalidOperationException(
+                                        "Captured-graph output is not resident-downloadable; abandoning capture.");
                                 return _finalOutput;
                             }
                         }
@@ -831,6 +869,16 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
                 catch
                 {
                     _graphCaptureDisabled = true;
+                    // A throw after _graphExec was assigned (the first LaunchCapturedGraph or the output
+                    // download above) leaves the graph executable allocated — destroy it so it isn't leaked
+                    // until Dispose, and HasGraph-style state reflects that capture was abandoned.
+                    if (_graphExec != IntPtr.Zero)
+                    {
+                        try { cb.DestroyCapturedGraph(_graphExec); } catch { }
+                        _graphExec = IntPtr.Zero;
+                        _graphBackend = null;
+                        _graphEngine = null;
+                    }
                     if (_graphEvictionSuspended) { gte.ResumeActivationEviction(); _graphEvictionSuspended = false; }
                 }
             }
@@ -852,6 +900,9 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
     private bool TryGetGraphBackend(out Engines.DirectGpu.CUDA.CudaBackend cb)
     {
         cb = null!;
+        // A cross-engine stitched plan runs some steps on a non-_engine backend; capturing only _engine's
+        // CUDA work would skip those steps on replay and serve stale downstream outputs. Refuse capture.
+        if (_containsCrossEngineSteps) return false;
         if (typeof(T) != typeof(float)) return false;
         if (_engine is not DirectGpuTensorEngine gte) return false;
         if (gte.GetBackend() is not Engines.DirectGpu.CUDA.CudaBackend backend) return false;
@@ -871,12 +922,41 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
         {
             var inT = inputs[i];
             if (inT is null) continue;
-            if (inT._gpuBuffer is not { } buf || !ReferenceEquals(inT._gpuBackend, cb)) continue;
+            // Fail closed (the captured graph reads fixed resident input addresses): if a buffer is missing,
+            // belongs to another backend, or is too small, refreshing in place is impossible, so the replay
+            // would consume this call's inputs from STALE device memory. Throw so the caller abandons the
+            // graph and falls back to eager rather than silently producing a wrong result.
+            if (inT._gpuBuffer is not { } buf || !ReferenceEquals(inT._gpuBackend, cb))
+                throw new InvalidOperationException(
+                    $"Captured-graph input {i} has no resident buffer on the capture backend; cannot refresh in place.");
             var data = inT.GetDataArray();
-            if (buf.Size < data.Length) continue;
+            if (buf.Size < data.Length)
+                throw new InvalidOperationException(
+                    $"Captured-graph input {i} resident buffer (size {buf.Size}) is smaller than its host data " +
+                    $"({data.Length}); cannot refresh in place.");
             cb.UploadBufferInPlace((float[])(object)data, buf);
             inT._gpuBufferVersion = inT.Version;
         }
+    }
+
+    /// <summary>
+    /// After a captured-graph launch the result lives in <c>_finalOutput</c>'s resident GPU buffer; force a
+    /// fresh device→host download into its host storage so a CPU read of the returned tensor observes THIS
+    /// call's output, not the capture-time host data. Mirrors <see cref="ResidentInferenceGraph"/>'s explicit
+    /// output-download contract. Returns false when no resident buffer is available to download (the caller
+    /// then fails closed and falls back to eager). float only.
+    /// </summary>
+    private bool RefreshFinalOutputFromResident()
+    {
+        var eng = _graphEngine ?? _engine as DirectGpuTensorEngine;
+        if (eng is null) return false;
+        var data = eng.DownloadResidentBuffer(_finalOutput);
+        if (data is null) return false;
+        var src = (T[])(object)data;
+        var dst = _finalOutput.AsWritableSpan();
+        if (src.Length < dst.Length) return false;
+        src.AsSpan(0, dst.Length).CopyTo(dst);
+        return true;
     }
 
     /// <inheritdoc/>

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledInferencePlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledInferencePlan.cs
@@ -64,8 +64,12 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
     // fallback) if any op issues a non-capturable sync alloc/copy during capture.
     private IntPtr _graphExec = IntPtr.Zero;
     private Engines.DirectGpu.CUDA.CudaBackend? _graphBackend;
+    private DirectGpuTensorEngine? _graphEngine;
     private int _graphWarmupCalls;
     private bool _graphCaptureDisabled;
+    // Eviction is suspended for the captured graph's LIFETIME (resumed in Dispose): the captured kernels
+    // reference resident intermediate buffers in the activation cache that must not be freed before replay.
+    private bool _graphEvictionSuspended;
     private static readonly bool s_inferenceCudaGraph =
         System.Environment.GetEnvironmentVariable("AIDOTNET_INFERENCE_CUDA_GRAPH") == "1";
     // Eager calls before capture, so lazy uploads / kernel autotune settle into the steady-state
@@ -776,32 +780,58 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
             }
 
             _graphWarmupCalls++;
-            if (_graphWarmupCalls >= InferenceGraphWarmup)
+            if (_graphWarmupCalls >= InferenceGraphWarmup && _engine is DirectGpuTensorEngine gte)
             {
-                // Refresh the input in place OUTSIDE the captured region (an HtoD upload inside
-                // capture is a non-capturable op that would abort EndCapture), then record the
-                // step launches. Capture RECORDS but does not execute, so launch once afterwards
-                // to produce this call's output.
+                // Enter the resident capture path. ResidentStepActive (capture-path depth + eviction
+                // suspended) flips the engine's GPU ops to stable resident buffers — no host round-trips —
+                // and BeginInferenceCapture lets the resident in-place ops engage for inference. Eviction
+                // stays suspended for the plan's LIFETIME (resumed in Dispose) so the resident intermediate
+                // buffers the captured graph references aren't evicted/freed before replay.
                 try
                 {
-                    RefreshInferenceInputsInPlace(cb);
-                    var exec = cb.CaptureGraph(() =>
+                    if (!_graphEvictionSuspended) { gte.SuspendActivationEviction(); _graphEvictionSuspended = true; }
+                    gte.BeginInferenceCapture();
+                    try
                     {
-                        for (int i = 0; i < steps.Length; i++)
-                            steps[i].Execute(engine, steps[i].OutputBuffer);
-                    });
-                    if (exec != IntPtr.Zero)
-                    {
-                        _graphExec = exec;
-                        _graphBackend = cb;
-                        cb.LaunchCapturedGraph(exec);
-                        return _finalOutput;
+                        using (gte.EnterCompiledCapturePath())
+                        {
+                            // Pre-residency pass: run the body once under ResidentStepActive so every op
+                            // binds its STABLE resident buffer; the capture below then records reads/writes
+                            // against those exact addresses. (Sync uploads here are fine — not capturing yet.)
+                            for (int i = 0; i < steps.Length; i++)
+                                steps[i].Execute(engine, steps[i].OutputBuffer);
+
+                            // Refresh inputs in place OUTSIDE the captured region (an HtoD upload inside
+                            // capture is non-capturable), then record the step launches. Capture RECORDS
+                            // but does not execute, so launch once afterwards to produce this call's output.
+                            RefreshInferenceInputsInPlace(cb);
+                            var exec = cb.CaptureGraph(() =>
+                            {
+                                for (int i = 0; i < steps.Length; i++)
+                                    steps[i].Execute(engine, steps[i].OutputBuffer);
+                            });
+                            if (exec != IntPtr.Zero)
+                            {
+                                _graphExec = exec;
+                                _graphBackend = cb;
+                                _graphEngine = gte;
+                                cb.LaunchCapturedGraph(exec);
+                                return _finalOutput;
+                            }
+                        }
+                        // Capture failed (a non-capturable op remains) — disable + resume eviction.
+                        _graphCaptureDisabled = true;
+                        if (_graphEvictionSuspended) { gte.ResumeActivationEviction(); _graphEvictionSuspended = false; }
                     }
-                    _graphCaptureDisabled = true; // a non-capturable op fired during launch — stay eager
+                    finally
+                    {
+                        gte.EndInferenceCapture();
+                    }
                 }
                 catch
                 {
                     _graphCaptureDisabled = true;
+                    if (_graphEvictionSuspended) { gte.ResumeActivationEviction(); _graphEvictionSuspended = false; }
                 }
             }
 
@@ -937,11 +967,17 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
         if (_disposed) return;
         _disposed = true;
 
-        // Free the captured CUDA graph (if any) before the buffers it references are torn down.
+        // Free the captured CUDA graph (if any) before the buffers it references are torn down,
+        // then resume the eviction we suspended for the graph's lifetime.
         if (_graphExec != IntPtr.Zero && _graphBackend is not null)
         {
             try { _graphBackend.DestroyCapturedGraph(_graphExec); } catch { }
             _graphExec = IntPtr.Zero;
+        }
+        if (_graphEvictionSuspended && _graphEngine is not null)
+        {
+            try { _graphEngine.ResumeActivationEviction(); } catch { }
+            _graphEvictionSuspended = false;
         }
 
         // Tear down the cached execution stream BEFORE freeing pinned

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledInferencePlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledInferencePlan.cs
@@ -53,6 +53,25 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
 
     private bool _disposed;
 
+    // #91/#1650 — inference CUDA-graph capture (the inference analog of #638's training-step capture).
+    // The plan executes into PRE-ALLOCATED, stable buffers with zero allocation during execution (see
+    // Execute), so the kernel-launch sequence AND device addresses are stable across Execute() calls —
+    // exactly the precondition cuStreamBeginCapture needs. After a short warmup we capture the whole
+    // step's launches once and replay it as a single cuGraphLaunch, refreshing the input buffer CONTENTS
+    // in place (same pointers) each call. This collapses hundreds of per-kernel launches into one — the
+    // TensorRT-LLM / vLLM decode-graph lever — which dominates latency at the low batch a diffusion
+    // denoising step runs. Opt-in via AIDOTNET_INFERENCE_CUDA_GRAPH=1; disabled automatically (eager
+    // fallback) if any op issues a non-capturable sync alloc/copy during capture.
+    private IntPtr _graphExec = IntPtr.Zero;
+    private Engines.DirectGpu.CUDA.CudaBackend? _graphBackend;
+    private int _graphWarmupCalls;
+    private bool _graphCaptureDisabled;
+    private static readonly bool s_inferenceCudaGraph =
+        System.Environment.GetEnvironmentVariable("AIDOTNET_INFERENCE_CUDA_GRAPH") == "1";
+    // Eager calls before capture, so lazy uploads / kernel autotune settle into the steady-state
+    // launch sequence the graph records.
+    private const int InferenceGraphWarmup = 2;
+
     // Lazy-initialized execution stream cached across ExecuteAsync /
     // ChainAsync calls. The first call constructs the stream (Channel +
     // long-lived worker on CPU; lightweight wrapper on GPU); every
@@ -737,11 +756,97 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
 
         var steps = _steps;
         var engine = _engine;
+
+        if (s_inferenceCudaGraph && System.Environment.GetEnvironmentVariable("AIDOTNET_INFGRAPH_DIAG") == "1")
+        {
+            try { System.IO.File.AppendAllText(System.IO.Path.Combine(System.IO.Path.GetTempPath(), "aidotnet_infgraph_diag.txt"),
+                $"Execute: enabled={s_inferenceCudaGraph} disabled={_graphCaptureDisabled} backendOk={TryGetGraphBackend(out _)} warmup={_graphWarmupCalls} hasGraph={_graphExec != IntPtr.Zero} steps={steps.Length} engine={_engine.GetType().Name}\n"); } catch { }
+        }
+
+        if (s_inferenceCudaGraph && !_graphCaptureDisabled && TryGetGraphBackend(out var cb))
+        {
+            // REPLAY: refresh the input buffer contents in place (stable pointers) — the caller's
+            // SetInputs already copied this call's data into the captured input tensor's host array —
+            // then run the whole forward as one cuGraphLaunch.
+            if (_graphExec != IntPtr.Zero)
+            {
+                RefreshInferenceInputsInPlace(cb);
+                cb.LaunchCapturedGraph(_graphExec);
+                return _finalOutput;
+            }
+
+            _graphWarmupCalls++;
+            if (_graphWarmupCalls >= InferenceGraphWarmup)
+            {
+                // Refresh the input in place OUTSIDE the captured region (an HtoD upload inside
+                // capture is a non-capturable op that would abort EndCapture), then record the
+                // step launches. Capture RECORDS but does not execute, so launch once afterwards
+                // to produce this call's output.
+                try
+                {
+                    RefreshInferenceInputsInPlace(cb);
+                    var exec = cb.CaptureGraph(() =>
+                    {
+                        for (int i = 0; i < steps.Length; i++)
+                            steps[i].Execute(engine, steps[i].OutputBuffer);
+                    });
+                    if (exec != IntPtr.Zero)
+                    {
+                        _graphExec = exec;
+                        _graphBackend = cb;
+                        cb.LaunchCapturedGraph(exec);
+                        return _finalOutput;
+                    }
+                    _graphCaptureDisabled = true; // a non-capturable op fired during launch — stay eager
+                }
+                catch
+                {
+                    _graphCaptureDisabled = true;
+                }
+            }
+
+            // Warmup call (or capture just failed): run eagerly.
+            for (int i = 0; i < steps.Length; i++)
+                steps[i].Execute(engine, steps[i].OutputBuffer);
+            return _finalOutput;
+        }
+
         for (int i = 0; i < steps.Length; i++)
         {
             steps[i].Execute(engine, steps[i].OutputBuffer);
         }
         return _finalOutput;
+    }
+
+    /// <summary>True when this plan is float + running on a CUDA backend that can capture graphs.</summary>
+    private bool TryGetGraphBackend(out Engines.DirectGpu.CUDA.CudaBackend cb)
+    {
+        cb = null!;
+        if (typeof(T) != typeof(float)) return false;
+        if (_engine is not DirectGpuTensorEngine gte) return false;
+        if (gte.GetBackend() is not Engines.DirectGpu.CUDA.CudaBackend backend) return false;
+        cb = backend;
+        return true;
+    }
+
+    /// <summary>
+    /// Uploads each captured input tensor's current host data into its EXISTING resident GPU buffer
+    /// in place (stable pointer), so a replayed graph — which reads the address captured at record
+    /// time — sees fresh per-call data. Mirrors CompiledTrainingPlan.RefreshGraphInputInPlace.
+    /// </summary>
+    private void RefreshInferenceInputsInPlace(Engines.DirectGpu.CUDA.CudaBackend cb)
+    {
+        var inputs = _compiledInputTensors;
+        for (int i = 0; i < inputs.Length; i++)
+        {
+            var inT = inputs[i];
+            if (inT is null) continue;
+            if (inT._gpuBuffer is not { } buf || !ReferenceEquals(inT._gpuBackend, cb)) continue;
+            var data = inT.GetDataArray();
+            if (buf.Size < data.Length) continue;
+            cb.UploadBufferInPlace((float[])(object)data, buf);
+            inT._gpuBufferVersion = inT.Version;
+        }
     }
 
     /// <inheritdoc/>
@@ -831,6 +936,13 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
     {
         if (_disposed) return;
         _disposed = true;
+
+        // Free the captured CUDA graph (if any) before the buffers it references are torn down.
+        if (_graphExec != IntPtr.Zero && _graphBackend is not null)
+        {
+            try { _graphBackend.DestroyCapturedGraph(_graphExec); } catch { }
+            _graphExec = IntPtr.Zero;
+        }
 
         // Tear down the cached execution stream BEFORE freeing pinned
         // handles — the stream's worker thread might still be draining

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Graph.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Graph.cs
@@ -78,7 +78,21 @@ public sealed partial class CudaBackend
         // Diagnostic: how many kernel/memory nodes did the capture actually record? A near-empty graph means
         // the forward's ops were short-circuited (e.g. served from the activation cache) during capture, so
         // replay reproduces a frozen output that ignores refreshed inputs.
-        { ulong nodeCount = 0; var gn = CudaNativeBindings.cuGraphGetNodes(graph, IntPtr.Zero, ref nodeCount); GcDiag($"captured graph node count = {nodeCount} (rc={gn})"); }
+        { ulong nodeCount = 0; var gn = CudaNativeBindings.cuGraphGetNodes(graph, IntPtr.Zero, ref nodeCount); GcDiag($"captured graph node count = {nodeCount} (rc={gn})");
+          // Node-type breakdown (KERNEL/MEMCPY/MEMSET/MEM_ALLOC/MEM_FREE/…) — tells us how much of the chain is
+          // fusable kernels vs memcpy/alloc overhead. Only when capture-debug is on.
+          if (System.Environment.GetEnvironmentVariable("AIDOTNET_GRAPH_CAPTURE_DEBUG") == "1" && nodeCount > 0 && gn == CudaResult.Success)
+          {
+              var nodes = new IntPtr[nodeCount]; ulong n2 = nodeCount;
+              if (CudaNativeBindings.cuGraphGetNodesArray(graph, nodes, ref n2) == CudaResult.Success)
+              {
+                  var counts = new int[16];
+                  for (ulong i = 0; i < nodeCount; i++)
+                      if (CudaNativeBindings.cuGraphNodeGetType(nodes[i], out int t) == CudaResult.Success && t >= 0 && t < 16) counts[t]++;
+                  GcDiag($"node types: KERNEL={counts[0]} MEMCPY={counts[1]} MEMSET={counts[2]} MEM_ALLOC={counts[10]} MEM_FREE={counts[11]} (other={nodeCount - (ulong)(counts[0] + counts[1] + counts[2] + counts[10] + counts[11])})");
+              }
+          }
+        }
 
         // PR #638 Phase B: the captured whole-step graph contains cuMemAllocAsync MEMORY NODES (the resident-into
         // backward ops allocate per-call scratch from the async pool during capture). A graph with allocation nodes

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Graph.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Graph.cs
@@ -75,6 +75,11 @@ public sealed partial class CudaBackend
         rc = CudaNativeBindings.cuStreamEndCapture(_stream, out var graph);
         if (rc != CudaResult.Success || graph == IntPtr.Zero) { GcDiag($"endCapture FAILED rc={rc} graph={(graph != IntPtr.Zero)} (a non-capturable op — sync HtoD/DtoH or cuMemAlloc — was issued during launch)"); return IntPtr.Zero; }
 
+        // Diagnostic: how many kernel/memory nodes did the capture actually record? A near-empty graph means
+        // the forward's ops were short-circuited (e.g. served from the activation cache) during capture, so
+        // replay reproduces a frozen output that ignores refreshed inputs.
+        { ulong nodeCount = 0; var gn = CudaNativeBindings.cuGraphGetNodes(graph, IntPtr.Zero, ref nodeCount); GcDiag($"captured graph node count = {nodeCount} (rc={gn})"); }
+
         // PR #638 Phase B: the captured whole-step graph contains cuMemAllocAsync MEMORY NODES (the resident-into
         // backward ops allocate per-call scratch from the async pool during capture). A graph with allocation nodes
         // can only be relaunched if its allocations are freed between launches — otherwise the SECOND cuGraphLaunch

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -1083,6 +1083,15 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
     // capture-aborting on the first. The dedup'd op frames are the residency-grind work-list.
     private static readonly bool s_residentAudit =
         System.Environment.GetEnvironmentVariable("AIDOTNET_RESIDENT_AUDIT") == "1";
+
+    // #638/#1650 capture-blocker diagnostic: when AIDOTNET_GRAPH_CAPTURE_DEBUG=1, log the call stack of the
+    // FIRST sync HtoD/DtoH that runs WHILE the stream is actually capturing (cuStreamBeginCapture active).
+    // Unlike AIDOTNET_RESIDENT_AUDIT (which also logs the eager passes that run AFTER capture is disabled,
+    // polluting the work-list), this fires ONLY inside CaptureGraph's recorded forward, so it pinpoints the
+    // exact op that aborts capture with no pollution. One-shot per process (capture is attempted once).
+    private static readonly bool s_captureDebug =
+        System.Environment.GetEnvironmentVariable("AIDOTNET_GRAPH_CAPTURE_DEBUG") == "1";
+    private static int s_captureBlockerLogged;
     internal static void AuditSyncIO(string kind, long bytes)
     {
         if (!s_residentAudit) return;
@@ -1108,11 +1117,43 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         catch { }
     }
 
+    internal void LogCaptureBlockerIfCapturing(string kind, long bytes)
+    {
+        if (!s_captureDebug) return;
+        if (System.Threading.Volatile.Read(ref s_captureBlockerLogged) != 0) return;
+        bool capturing;
+        try { capturing = IsStreamCapturing(); } catch { return; }
+        if (!capturing) return;
+        if (System.Threading.Interlocked.Exchange(ref s_captureBlockerLogged, 1) != 0) return;
+        try
+        {
+            var st = new System.Diagnostics.StackTrace(1, false);
+            var sb = new System.Text.StringBuilder();
+            sb.Append("CAPTURE BLOCKER — first sync ").Append(kind).Append(" (").Append(bytes).Append(" bytes) during capture: ");
+            for (int i = 0; i < st.FrameCount; i++)
+            {
+                var m = st.GetFrame(i)?.GetMethod();
+                var tn = m?.DeclaringType?.Name;
+                if (tn is null) continue;
+                if (tn.Contains("Layer") || tn.Contains("NoisePredictor") || tn.Contains("ResBlock")
+                    || tn.Contains("Attention") || tn.Contains("DirectGpuTensorEngine") || tn.Contains("CpuEngine")
+                    || tn.Contains("UNet") || tn.Contains("Diffusion"))
+                {
+                    sb.Append(tn).Append('.').Append(m!.Name).Append(" <- ");
+                    if (sb.Length > 600) break;
+                }
+            }
+            System.IO.File.WriteAllText(System.IO.Path.Combine(System.IO.Path.GetTempPath(), "aidotnet_capture_blocker.txt"), sb.ToString() + "\n");
+        }
+        catch { }
+    }
+
     public IGpuBuffer AllocateBuffer(float[] data)
     {
         if (!IsAvailable)
             throw new InvalidOperationException("CUDA backend is not available.");
         AuditSyncIO("HtoD-alloc", (long)data.Length * sizeof(float));
+        LogCaptureBlockerIfCapturing("HtoD-alloc", (long)data.Length * sizeof(float));
 
         int size = data.Length;
         if (size <= 0)
@@ -1519,6 +1560,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         // sync on the host-read path (already a synchronization point) closes
         // the race with no effect on the GPU-resident training hot path.
         AuditSyncIO("DtoH-download", (long)buffer.Size * sizeof(float));
+        LogCaptureBlockerIfCapturing("DtoH-download", (long)buffer.Size * sizeof(float));
         CuBlasNative.CheckCudaResult(CudaNativeBindings.cuStreamSynchronize(_stream), "cuStreamSynchronize(download)");
 
         ulong byteSize = (ulong)(buffer.Size * sizeof(float));
@@ -12616,15 +12658,13 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         IntPtr srcPtr = source.Handle + sourceOffset * sizeof(float);
         IntPtr dstPtr = destination.Handle + destinationOffset * sizeof(float);
         ulong byteSize = (ulong)length * sizeof(float);
-        // Async during capture (sync cuMemcpyDtoD aborts capture with 906); sync otherwise. See Copy(src,dst,size).
-        if (IsStreamCapturing())
-            CuBlasNative.CheckCudaResult(
-                CudaNativeBindings.cuMemcpyDtoDAsync(dstPtr, srcPtr, byteSize, _stream),
-                "cuMemcpyDtoDAsync(strided)");
-        else
-            CuBlasNative.CheckCudaResult(
-                CuBlasNative.cuMemcpyDtoD(dstPtr, srcPtr, byteSize),
-                "cuMemcpyDtoD(strided)");
+        // Stream-ordered async DtoD (same fix as the 3-arg Copy): the synchronous cuMemcpyDtoD is NOT
+        // capturable — it aborts CUDA-graph stream capture (CUDA 906). The async copy on _stream records
+        // as a graph node and stays correctly ordered with the surrounding kernels (e.g. the resident
+        // channel-concat that copies each input's slab into the pooled output).
+        CuBlasNative.CheckCudaResult(
+            CudaNativeBindings.cuMemcpyDtoDAsync(dstPtr, srcPtr, byteSize, _stream),
+            "cuMemcpyDtoDAsync(strided)");
     }
 
     /// <inheritdoc/>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -4952,6 +4952,56 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
     /// <summary>True when the fused FP16 im2col kernel compiled (needs cuda_fp16.h). #1650/#638.</summary>
     public bool Fp16HwIm2colAvailable => _kernelCache.ContainsKey("im2col_kn_fp16hw");
 
+    /// <summary>True when the direct FP16 conv kernel compiled (needs cuda_fp16.h). #1650/#638 / #671.</summary>
+    public bool Fp16DirectConvAvailable => _kernelCache.ContainsKey("conv2d_direct_fp16hw");
+
+    /// <summary>
+    /// #1650/#638 (#671): DIRECT FP16 convolution for the tiny-spatial deep convs the im2col + Tensor-Core GEMM
+    /// path skips (small N, where im2col + launch overhead exceeds the GEMM win). FP32 <paramref name="input"/>
+    /// rounded to FP16 per access, FP16 <paramref name="weightsHalf"/> (the cached half copy of the conv weights,
+    /// [outChannels, inChannels, kernelH, kernelW] layout), FP32 multiply-accumulate, FP32 <paramref name="output"/>.
+    /// Capture-safe: a single kernel launch, no device allocation. CUDA-first — parity for the other backends is a
+    /// tracked follow-up; validate end-to-end on CUDA hardware before relying on it.
+    /// </summary>
+    public unsafe void Conv2dDirectFp16Hw(IGpuBuffer input, IGpuBuffer weightsHalf, IGpuBuffer output,
+        int batch, int inChannels, int inHeight, int inWidth, int outChannels, int outHeight, int outWidth,
+        int kernelH, int kernelW, int strideH, int strideW, int padH, int padW, int dilationH, int dilationW)
+    {
+        using var _ = PushContext();
+        if (!_kernelCache.TryGetValue("conv2d_direct_fp16hw", out var k))
+            throw new InvalidOperationException("CUDA kernel not found: conv2d_direct_fp16hw");
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (weightsHalf is null) throw new ArgumentNullException(nameof(weightsHalf));
+        if (output is null) throw new ArgumentNullException(nameof(output));
+        if (batch <= 0) throw new ArgumentOutOfRangeException(nameof(batch), "Dimensions must be positive.");
+        if (inChannels <= 0) throw new ArgumentOutOfRangeException(nameof(inChannels), "Dimensions must be positive.");
+        if (inHeight <= 0) throw new ArgumentOutOfRangeException(nameof(inHeight), "Dimensions must be positive.");
+        if (inWidth <= 0) throw new ArgumentOutOfRangeException(nameof(inWidth), "Dimensions must be positive.");
+        if (outChannels <= 0) throw new ArgumentOutOfRangeException(nameof(outChannels), "Dimensions must be positive.");
+        if (outHeight <= 0) throw new ArgumentOutOfRangeException(nameof(outHeight), "Dimensions must be positive.");
+        if (outWidth <= 0) throw new ArgumentOutOfRangeException(nameof(outWidth), "Dimensions must be positive.");
+        if (kernelH <= 0) throw new ArgumentOutOfRangeException(nameof(kernelH), "Dimensions must be positive.");
+        if (kernelW <= 0) throw new ArgumentOutOfRangeException(nameof(kernelW), "Dimensions must be positive.");
+        if (strideH <= 0) throw new ArgumentOutOfRangeException(nameof(strideH), "Stride must be positive.");
+        if (strideW <= 0) throw new ArgumentOutOfRangeException(nameof(strideW), "Stride must be positive.");
+        if (dilationH <= 0) throw new ArgumentOutOfRangeException(nameof(dilationH), "Dilation must be positive.");
+        if (dilationW <= 0) throw new ArgumentOutOfRangeException(nameof(dilationW), "Dilation must be positive.");
+        if (padH < 0) throw new ArgumentOutOfRangeException(nameof(padH), "Padding must be non-negative.");
+        if (padW < 0) throw new ArgumentOutOfRangeException(nameof(padW), "Padding must be non-negative.");
+        IntPtr inputPtr = input.Handle, wPtr = weightsHalf.Handle, outputPtr = output.Handle;
+        const int BLOCK = 16;
+        uint gx = (uint)((outWidth + BLOCK - 1) / BLOCK);
+        uint gy = (uint)((outHeight + BLOCK - 1) / BLOCK);
+        uint gz = (uint)(batch * outChannels);
+        void** a = stackalloc void*[18];
+        a[0] = &inputPtr; a[1] = &wPtr; a[2] = &outputPtr;
+        a[3] = &batch; a[4] = &inChannels; a[5] = &inHeight; a[6] = &inWidth;
+        a[7] = &outChannels; a[8] = &outHeight; a[9] = &outWidth;
+        a[10] = &kernelH; a[11] = &kernelW; a[12] = &strideH; a[13] = &strideW;
+        a[14] = &padH; a[15] = &padW; a[16] = &dilationH; a[17] = &dilationW;
+        LaunchKernel3D(k, gx, gy, gz, (uint)BLOCK, (uint)BLOCK, 1, a, 0);
+    }
+
     // IGpuHalfPrecisionBackend FP16-conv im2col (backend-agnostic dispatch); delegates to the CUDA impl.
     /// <inheritdoc/>
     public bool Fp16Im2colAvailable => Fp16HwIm2colAvailable;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -1077,10 +1077,42 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         return log;
     }
 
+    // #1650 residency AUDIT: when AIDOTNET_RESIDENT_AUDIT=1, log a compact call-stack at each sync HtoD/DtoH
+    // (the exact ops that would abort CUDA-graph capture). Run the forward once under ResidentStepActive AFTER a
+    // warmup (so one-time cache-fills don't show) → the full set of NOT-YET-RESIDENT ops in ONE pass, instead of
+    // capture-aborting on the first. The dedup'd op frames are the residency-grind work-list.
+    private static readonly bool s_residentAudit =
+        System.Environment.GetEnvironmentVariable("AIDOTNET_RESIDENT_AUDIT") == "1";
+    internal static void AuditSyncIO(string kind, long bytes)
+    {
+        if (!s_residentAudit) return;
+        try
+        {
+            var st = new System.Diagnostics.StackTrace(2, false);
+            var sb = new System.Text.StringBuilder();
+            for (int i = 0; i < st.FrameCount; i++)
+            {
+                var m = st.GetFrame(i)?.GetMethod();
+                var tn = m?.DeclaringType?.Name;
+                if (tn is null) continue;
+                if (tn.Contains("Layer") || tn.Contains("NoisePredictor") || tn.Contains("ResBlock")
+                    || tn.Contains("Attention") || tn.Contains("DirectGpuTensorEngine") || tn.Contains("CpuEngine"))
+                {
+                    sb.Append(tn).Append('.').Append(m!.Name).Append(" <- ");
+                    if (sb.Length > 300) break;
+                }
+            }
+            System.IO.File.AppendAllText(System.IO.Path.Combine(System.IO.Path.GetTempPath(), "aidotnet_resident_audit.txt"),
+                $"{kind}\t{bytes}\t{sb}\n");
+        }
+        catch { }
+    }
+
     public IGpuBuffer AllocateBuffer(float[] data)
     {
         if (!IsAvailable)
             throw new InvalidOperationException("CUDA backend is not available.");
+        AuditSyncIO("HtoD-alloc", (long)data.Length * sizeof(float));
 
         int size = data.Length;
         if (size <= 0)
@@ -1472,6 +1504,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         // value oscillated run-to-run between updated and pre-step). One stream
         // sync on the host-read path (already a synchronization point) closes
         // the race with no effect on the GPU-resident training hot path.
+        AuditSyncIO("DtoH-download", (long)buffer.Size * sizeof(float));
         CuBlasNative.CheckCudaResult(CudaNativeBindings.cuStreamSynchronize(_stream), "cuStreamSynchronize(download)");
 
         ulong byteSize = (ulong)(buffer.Size * sizeof(float));

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -12616,9 +12616,15 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         IntPtr srcPtr = source.Handle + sourceOffset * sizeof(float);
         IntPtr dstPtr = destination.Handle + destinationOffset * sizeof(float);
         ulong byteSize = (ulong)length * sizeof(float);
-        CuBlasNative.CheckCudaResult(
-            CuBlasNative.cuMemcpyDtoD(dstPtr, srcPtr, byteSize),
-            "cuMemcpyDtoD(strided)");
+        // Async during capture (sync cuMemcpyDtoD aborts capture with 906); sync otherwise. See Copy(src,dst,size).
+        if (IsStreamCapturing())
+            CuBlasNative.CheckCudaResult(
+                CudaNativeBindings.cuMemcpyDtoDAsync(dstPtr, srcPtr, byteSize, _stream),
+                "cuMemcpyDtoDAsync(strided)");
+        else
+            CuBlasNative.CheckCudaResult(
+                CuBlasNative.cuMemcpyDtoD(dstPtr, srcPtr, byteSize),
+                "cuMemcpyDtoD(strided)");
     }
 
     /// <inheritdoc/>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -4972,9 +4972,29 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         using var _ = PushContext();
         if (!_kernelCache.TryGetValue("im2col_kn_fp16hw", out var k))
             throw new InvalidOperationException("CUDA kernel not found: im2col_kn_fp16hw");
+        // #671 review: validate launch dimensions before computing the grid — strideH/strideW == 0 divides by
+        // zero, a non-positive output extent makes `elems` negative, and an overflowing `elems` casts to a huge
+        // uint launch size. Guard the public backend boundary before LaunchKernel.
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (outputHalf is null) throw new ArgumentNullException(nameof(outputHalf));
+        if (batch <= 0) throw new ArgumentOutOfRangeException(nameof(batch), "Dimensions must be positive.");
+        if (channels <= 0) throw new ArgumentOutOfRangeException(nameof(channels), "Dimensions must be positive.");
+        if (height <= 0) throw new ArgumentOutOfRangeException(nameof(height), "Dimensions must be positive.");
+        if (width <= 0) throw new ArgumentOutOfRangeException(nameof(width), "Dimensions must be positive.");
+        if (kernelH <= 0) throw new ArgumentOutOfRangeException(nameof(kernelH), "Dimensions must be positive.");
+        if (kernelW <= 0) throw new ArgumentOutOfRangeException(nameof(kernelW), "Dimensions must be positive.");
+        if (strideH <= 0) throw new ArgumentOutOfRangeException(nameof(strideH), "Stride must be positive.");
+        if (strideW <= 0) throw new ArgumentOutOfRangeException(nameof(strideW), "Stride must be positive.");
+        if (dilationH <= 0) throw new ArgumentOutOfRangeException(nameof(dilationH), "Dilation must be positive.");
+        if (dilationW <= 0) throw new ArgumentOutOfRangeException(nameof(dilationW), "Dilation must be positive.");
+        if (padH < 0) throw new ArgumentOutOfRangeException(nameof(padH), "Padding must be non-negative.");
+        if (padW < 0) throw new ArgumentOutOfRangeException(nameof(padW), "Padding must be non-negative.");
         IntPtr inputPtr = input.Handle, outputPtr = outputHalf.Handle;
         int outH = (height + 2 * padH - ((kernelH - 1) * dilationH + 1)) / strideH + 1;
         int outW = (width + 2 * padW - ((kernelW - 1) * dilationW + 1)) / strideW + 1;
+        if (outH <= 0 || outW <= 0)
+            throw new ArgumentException(
+                $"Convolution output size is non-positive (outH={outH}, outW={outW}); check kernel/stride/pad/dilation vs input size.");
         int totalPatches = batch * outH * outW;
         void** a = stackalloc void*[16];
         a[0] = &inputPtr; a[1] = &outputPtr;
@@ -4982,6 +5002,8 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         a[6] = &kernelH; a[7] = &kernelW; a[8] = &strideH; a[9] = &strideW;
         a[10] = &padH; a[11] = &padW; a[12] = &dilationH; a[13] = &dilationW; a[14] = &outH; a[15] = &outW;
         long elems = (long)totalPatches * (channels * kernelH * kernelW); // N*K threads (one per col element)
+        if (elems > int.MaxValue)
+            throw new NotSupportedException($"FP16 im2col work size {elems} exceeds the launch limit.");
         uint grid = (uint)((elems + DefaultBlockSize - 1) / DefaultBlockSize);
         LaunchKernel(k, grid, DefaultBlockSize, a);
     }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -4952,6 +4952,16 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
     /// <summary>True when the fused FP16 im2col kernel compiled (needs cuda_fp16.h). #1650/#638.</summary>
     public bool Fp16HwIm2colAvailable => _kernelCache.ContainsKey("im2col_kn_fp16hw");
 
+    // IGpuHalfPrecisionBackend FP16-conv im2col (backend-agnostic dispatch); delegates to the CUDA impl.
+    /// <inheritdoc/>
+    public bool Fp16Im2colAvailable => Fp16HwIm2colAvailable;
+    /// <inheritdoc/>
+    public void Im2colKNFp16(IGpuBuffer input, IGpuBuffer outputHalf,
+        int batch, int channels, int height, int width,
+        int kernelH, int kernelW, int strideH, int strideW, int padH, int padW, int dilationH, int dilationW)
+        => UnfoldKNFp16Hw(input, outputHalf, batch, channels, height, width,
+            kernelH, kernelW, strideH, strideW, padH, padW, dilationH, dilationW);
+
     /// <summary>FUSED im2col + hw FP32→FP16, TRANSPOSED [K,N] layout (outputHalf = half/ushort buffer of K*N).
     /// Pair with GemmFp16(weightsHalf[outC,K], colHalf[K,N]) → out[outC,N] for a Tensor-Core FP16 conv.
     /// Capture-safe (one kernel on the compute stream). #1650/#638.</summary>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -4949,35 +4949,31 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         }
     }
 
-    /// <summary>True when the HARDWARE-FP16 conv kernel (conv2d_direct_fp16hw, needs cuda_fp16.h) compiled into
-    /// the cache. False on a driver-only box (no cuda_fp16.h → CudaFp16Kernels module skipped) → callers fall
-    /// back to FP32. #1650/#638 toolkit-box FP16-conv lever.</summary>
-    public bool Fp16HwConvAvailable => _kernelCache.ContainsKey("conv2d_direct_fp16hw");
+    /// <summary>True when the fused FP16 im2col kernel compiled (needs cuda_fp16.h). #1650/#638.</summary>
+    public bool Fp16HwIm2colAvailable => _kernelCache.ContainsKey("im2col_kn_fp16hw");
 
-    /// <summary>HARDWARE-FP16 direct conv2d: FP32 input/weights/output buffers (same memory as the FP32 path),
-    /// FP16 multiply-accumulate IN-KERNEL via __half2 (hardware __floats2half2_rn/__hfma2). ~2x FMA throughput
-    /// on a CUDA-toolkit GPU; absent on driver-only boxes (use <see cref="Fp16HwConvAvailable"/> to gate).
-    /// Capture-safe (one kernel on the compute stream).</summary>
-    public unsafe void Conv2DDirectFp16Hw(IGpuBuffer input, IGpuBuffer kernel, IGpuBuffer output,
-        int batch, int inChannels, int inHeight, int inWidth,
-        int outChannels, int outHeight, int outWidth,
+    /// <summary>FUSED im2col + hw FP32→FP16, TRANSPOSED [K,N] layout (outputHalf = half/ushort buffer of K*N).
+    /// Pair with GemmFp16(weightsHalf[outC,K], colHalf[K,N]) → out[outC,N] for a Tensor-Core FP16 conv.
+    /// Capture-safe (one kernel on the compute stream). #1650/#638.</summary>
+    public unsafe void UnfoldKNFp16Hw(IGpuBuffer input, IGpuBuffer outputHalf,
+        int batch, int channels, int height, int width,
         int kernelH, int kernelW, int strideH, int strideW, int padH, int padW, int dilationH, int dilationW)
     {
         using var _ = PushContext();
-        if (!_kernelCache.TryGetValue("conv2d_direct_fp16hw", out var k))
-            throw new InvalidOperationException("CUDA kernel not found: conv2d_direct_fp16hw");
-        IntPtr inputPtr = input.Handle, kernelPtr = kernel.Handle, outputPtr = output.Handle;
-        const int BLOCK = 16;
-        uint dgx = (uint)((outWidth + BLOCK - 1) / BLOCK);
-        uint dgy = (uint)((outHeight + BLOCK - 1) / BLOCK);
-        uint dgz = (uint)(batch * outChannels);
-        void** a = stackalloc void*[18];
-        a[0] = &inputPtr; a[1] = &kernelPtr; a[2] = &outputPtr;
-        a[3] = &batch; a[4] = &inChannels; a[5] = &inHeight; a[6] = &inWidth;
-        a[7] = &outChannels; a[8] = &outHeight; a[9] = &outWidth;
-        a[10] = &kernelH; a[11] = &kernelW; a[12] = &strideH; a[13] = &strideW;
-        a[14] = &padH; a[15] = &padW; a[16] = &dilationH; a[17] = &dilationW;
-        LaunchKernel3D(k, dgx, dgy, dgz, (uint)BLOCK, (uint)BLOCK, 1, a, 0);
+        if (!_kernelCache.TryGetValue("im2col_kn_fp16hw", out var k))
+            throw new InvalidOperationException("CUDA kernel not found: im2col_kn_fp16hw");
+        IntPtr inputPtr = input.Handle, outputPtr = outputHalf.Handle;
+        int outH = (height + 2 * padH - ((kernelH - 1) * dilationH + 1)) / strideH + 1;
+        int outW = (width + 2 * padW - ((kernelW - 1) * dilationW + 1)) / strideW + 1;
+        int totalPatches = batch * outH * outW;
+        void** a = stackalloc void*[16];
+        a[0] = &inputPtr; a[1] = &outputPtr;
+        a[2] = &batch; a[3] = &channels; a[4] = &height; a[5] = &width;
+        a[6] = &kernelH; a[7] = &kernelW; a[8] = &strideH; a[9] = &strideW;
+        a[10] = &padH; a[11] = &padW; a[12] = &dilationH; a[13] = &dilationW; a[14] = &outH; a[15] = &outW;
+        long elems = (long)totalPatches * (channels * kernelH * kernelW); // N*K threads (one per col element)
+        uint grid = (uint)((elems + DefaultBlockSize - 1) / DefaultBlockSize);
+        LaunchKernel(k, grid, DefaultBlockSize, a);
     }
 
     /// <summary>Lazily spin up the cuDNN context + convolution helper on

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -4931,6 +4931,37 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         }
     }
 
+    /// <summary>True when the HARDWARE-FP16 conv kernel (conv2d_direct_fp16hw, needs cuda_fp16.h) compiled into
+    /// the cache. False on a driver-only box (no cuda_fp16.h → CudaFp16Kernels module skipped) → callers fall
+    /// back to FP32. #1650/#638 toolkit-box FP16-conv lever.</summary>
+    public bool Fp16HwConvAvailable => _kernelCache.ContainsKey("conv2d_direct_fp16hw");
+
+    /// <summary>HARDWARE-FP16 direct conv2d: FP32 input/weights/output buffers (same memory as the FP32 path),
+    /// FP16 multiply-accumulate IN-KERNEL via __half2 (hardware __floats2half2_rn/__hfma2). ~2x FMA throughput
+    /// on a CUDA-toolkit GPU; absent on driver-only boxes (use <see cref="Fp16HwConvAvailable"/> to gate).
+    /// Capture-safe (one kernel on the compute stream).</summary>
+    public unsafe void Conv2DDirectFp16Hw(IGpuBuffer input, IGpuBuffer kernel, IGpuBuffer output,
+        int batch, int inChannels, int inHeight, int inWidth,
+        int outChannels, int outHeight, int outWidth,
+        int kernelH, int kernelW, int strideH, int strideW, int padH, int padW, int dilationH, int dilationW)
+    {
+        using var _ = PushContext();
+        if (!_kernelCache.TryGetValue("conv2d_direct_fp16hw", out var k))
+            throw new InvalidOperationException("CUDA kernel not found: conv2d_direct_fp16hw");
+        IntPtr inputPtr = input.Handle, kernelPtr = kernel.Handle, outputPtr = output.Handle;
+        const int BLOCK = 16;
+        uint dgx = (uint)((outWidth + BLOCK - 1) / BLOCK);
+        uint dgy = (uint)((outHeight + BLOCK - 1) / BLOCK);
+        uint dgz = (uint)(batch * outChannels);
+        void** a = stackalloc void*[18];
+        a[0] = &inputPtr; a[1] = &kernelPtr; a[2] = &outputPtr;
+        a[3] = &batch; a[4] = &inChannels; a[5] = &inHeight; a[6] = &inWidth;
+        a[7] = &outChannels; a[8] = &outHeight; a[9] = &outWidth;
+        a[10] = &kernelH; a[11] = &kernelW; a[12] = &strideH; a[13] = &strideW;
+        a[14] = &padH; a[15] = &padW; a[16] = &dilationH; a[17] = &dilationW;
+        LaunchKernel3D(k, dgx, dgy, dgz, (uint)BLOCK, (uint)BLOCK, 1, a, 0);
+    }
+
     /// <summary>Lazily spin up the cuDNN context + convolution helper on
     /// the first call that routes Conv2D through the vendor path. Both
     /// live for the lifetime of this backend and are released in

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -466,8 +466,10 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         // (nvidia-cuda-runtime-cuXX) WITHOUT a full toolkit install or hijacking the global CUDA_PATH (which
         // other tools expect to be a complete toolkit with bin/nvcc). Checked first; falls through if unset.
         var directInclude = Environment.GetEnvironmentVariable("AIDOTNET_CUDA_INCLUDE");
-        if (!string.IsNullOrEmpty(directInclude) && Directory.Exists(directInclude))
-            return directInclude;
+        if (!string.IsNullOrWhiteSpace(directInclude)
+            && Directory.Exists(directInclude)
+            && File.Exists(Path.Combine(directInclude, "cuda_fp16.h"))) // validate it actually holds the headers
+            return directInclude;                                       // before short-circuiting CUDA_PATH (#671 review)
 
         // Check CUDA_PATH environment variable first
         var cudaPath = Environment.GetEnvironmentVariable("CUDA_PATH");

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -1444,6 +1444,20 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
     private IntPtr AllocDeviceMemoryAsync(ulong byteSize)
     {
         var r = CuBlasNative.cuMemAllocAsync(out IntPtr p, byteSize, _stream);
+        if (r != CudaResult.Success && IsStreamCapturing())
+        {
+            // #1650/#638 capture: during stream capture cuCtxSynchronize / cuMemPoolTrimTo are ILLEGAL
+            // (they throw CUDA 900 and abort the capture — blocker #2 of the diffusion UNet capture, a
+            // scratch alloc inside GroupNormSwish's SwishInPlace). The pre-residency warmup pass already
+            // grew the async pool for these exact allocations, so the capture-time alloc is a pool-hit
+            // memory-node; if it still failed, the synchronizing reclamation cannot help mid-capture
+            // anyway. Surface the real alloc error (capture aborts → graceful eager fallback) instead of
+            // masking it behind an illegal-sync CUDA 900.
+            if (r != CudaResult.Success) GpuMemoryTracker.Dump($"cuMemAllocAsync OOM (capturing) requesting {byteSize} bytes");
+            CuBlasNative.CheckCudaResult(r, "cuMemAllocAsync (during capture)");
+            GpuMemoryTracker.OnAlloc(p, (long)byteSize);
+            return p;
+        }
         if (r != CudaResult.Success)
         {
             // Sync so pending cuMemFreeAsync reclamations land back in the pool, then TRIM the pool's
@@ -7514,9 +7528,15 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
 
         using var _ = PushContext();
         ulong byteSize = (ulong)size * sizeof(float);
+        // #1650/#638 capture: async device->device on the backend's own stream so this op is
+        // CAPTURABLE inside a CUDA graph. The synchronous cuMemcpyDtoD throws CUDA 906
+        // ("operation not permitted while stream is capturing") and aborts graph capture — it was
+        // the first blocker in the diffusion UNet capture (resident conv-bias add's a->out copy).
+        // Device-side ordering is preserved (later ops on the same stream serialize after it);
+        // host reads go through the download path which synchronizes the stream.
         CuBlasNative.CheckCudaResult(
-            CuBlasNative.cuMemcpyDtoD(destination.Handle, source.Handle, byteSize),
-            "cuMemcpyDtoD");
+            CudaNativeBindings.cuMemcpyDtoDAsync(destination.Handle, source.Handle, byteSize, _stream),
+            "cuMemcpyDtoDAsync (Copy)");
     }
 
     public void Fill(IGpuBuffer buffer, float value, int size)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -5058,6 +5058,34 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         LaunchKernel(k, grid, DefaultBlockSize, a);
     }
 
+    /// <summary>True when the FP16-in im2col kernel compiled (needs cuda_fp16.h). #1650/#638 #3.</summary>
+    public bool Fp16Im2colFromFp16Available => _kernelCache.ContainsKey("im2col_kn_fp16_from_fp16");
+
+    /// <summary>FUSED im2col with an FP16 input + FP16 output, TRANSPOSED [K,N] layout (outputHalf = half/ushort
+    /// buffer of K*N). Same as <see cref="UnfoldKNFp16Hw"/> but the input is already half-resident (each tap loaded
+    /// via __half2float, oob → 0) — avoids the FP32→FP16 cast pass when the activation feeding the conv is FP16.
+    /// Pair with GemmFp16(weightsHalf[outC,K], colHalf[K,N]) → out[outC,N]. Capture-safe (one kernel). #1650/#638 #3.</summary>
+    public unsafe void UnfoldKNFp16FromFp16(IGpuBuffer inputHalf, IGpuBuffer outputHalf,
+        int batch, int channels, int height, int width,
+        int kernelH, int kernelW, int strideH, int strideW, int padH, int padW, int dilationH, int dilationW)
+    {
+        using var _ = PushContext();
+        if (!_kernelCache.TryGetValue("im2col_kn_fp16_from_fp16", out var k))
+            throw new InvalidOperationException("CUDA kernel not found: im2col_kn_fp16_from_fp16");
+        IntPtr inputPtr = inputHalf.Handle, outputPtr = outputHalf.Handle;
+        int outH = (height + 2 * padH - ((kernelH - 1) * dilationH + 1)) / strideH + 1;
+        int outW = (width + 2 * padW - ((kernelW - 1) * dilationW + 1)) / strideW + 1;
+        int totalPatches = batch * outH * outW;
+        void** a = stackalloc void*[16];
+        a[0] = &inputPtr; a[1] = &outputPtr;
+        a[2] = &batch; a[3] = &channels; a[4] = &height; a[5] = &width;
+        a[6] = &kernelH; a[7] = &kernelW; a[8] = &strideH; a[9] = &strideW;
+        a[10] = &padH; a[11] = &padW; a[12] = &dilationH; a[13] = &dilationW; a[14] = &outH; a[15] = &outW;
+        long elems = (long)totalPatches * (channels * kernelH * kernelW); // N*K threads (one per col element)
+        uint grid = (uint)((elems + DefaultBlockSize - 1) / DefaultBlockSize);
+        LaunchKernel(k, grid, DefaultBlockSize, a);
+    }
+
     /// <summary>Lazily spin up the cuDNN context + convolution helper on
     /// the first call that routes Conv2D through the vendor path. Both
     /// live for the lifetime of this backend and are released in
@@ -12099,6 +12127,64 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         args[0] = &inPtr; args[1] = &gPtr; args[2] = &bPtr; args[3] = &outPtr;
         args[4] = &meanPtr; args[5] = &varPtr; args[6] = &rows; args[7] = &cols; args[8] = &eps;
         LaunchKernelWithSharedMem(kernel, (uint)rows, block, block * sizeof(float), args);
+    }
+
+    /// <summary>True when the fused FP16 GroupNorm+Swish kernel compiled (driver-only, no cuda_fp16.h). #1650/#638 #3.</summary>
+    public bool Fp16GroupNormSwishAvailable => _kernelCache.ContainsKey("fp16_groupnorm_swish");
+
+    /// <summary>FP16-native fused GroupNorm + Swish: ONE BLOCK PER (batch, group). input/output are FP16 buffers
+    /// [batch, channels, spatial]; gamma/beta are FP32 (per-channel). Population variance (÷groupSize), eps inside
+    /// the rsqrt, then affine + Swish (x/(1+exp(-x))) — matches the FP32 groupnorm_forward + Swish. #1650/#638 #3.</summary>
+    public unsafe void Fp16GroupNormSwish(IGpuBuffer inHalf, IGpuBuffer gammaFp32, IGpuBuffer betaFp32, IGpuBuffer outHalf,
+        int batch, int numGroups, int channels, int spatial, float eps)
+    {
+        if (inHalf is null) throw new ArgumentNullException(nameof(inHalf));
+        if (gammaFp32 is null) throw new ArgumentNullException(nameof(gammaFp32));
+        if (betaFp32 is null) throw new ArgumentNullException(nameof(betaFp32));
+        if (outHalf is null) throw new ArgumentNullException(nameof(outHalf));
+        if (batch <= 0 || channels <= 0 || spatial <= 0) throw new ArgumentException($"batch/channels/spatial must be positive (batch={batch}, channels={channels}, spatial={spatial}).");
+        if (numGroups <= 0 || channels % numGroups != 0) throw new ArgumentException($"numGroups must be positive and divide channels (numGroups={numGroups}, channels={channels}).");
+        long matHalfBytes = (long)batch * channels * spatial * Fp16ByteWidth;
+        long chanFp32Bytes = (long)channels * sizeof(float);
+        if (inHalf.SizeInBytes < matHalfBytes) throw new ArgumentException($"input half buffer too small: {inHalf.SizeInBytes} < {matHalfBytes}.");
+        if (outHalf.SizeInBytes < matHalfBytes) throw new ArgumentException($"output half buffer too small: {outHalf.SizeInBytes} < {matHalfBytes}.");
+        if (gammaFp32.SizeInBytes < chanFp32Bytes) throw new ArgumentException($"gamma FP32 buffer too small: {gammaFp32.SizeInBytes} < {chanFp32Bytes}.");
+        if (betaFp32.SizeInBytes < chanFp32Bytes) throw new ArgumentException($"beta FP32 buffer too small: {betaFp32.SizeInBytes} < {chanFp32Bytes}.");
+        if (eps <= 0f || float.IsNaN(eps) || float.IsInfinity(eps)) throw new ArgumentOutOfRangeException(nameof(eps), eps, "eps must be finite and positive.");
+        if (!_kernelCache.TryGetValue("fp16_groupnorm_swish", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: fp16_groupnorm_swish");
+        using var _ = PushContext();
+        const uint block = 256u;
+        IntPtr inPtr = inHalf.Handle, gPtr = gammaFp32.Handle, bPtr = betaFp32.Handle, outPtr = outHalf.Handle;
+        void** args = stackalloc void*[9];
+        args[0] = &inPtr; args[1] = &gPtr; args[2] = &bPtr; args[3] = &outPtr;
+        args[4] = &batch; args[5] = &numGroups; args[6] = &channels; args[7] = &spatial; args[8] = &eps;
+        LaunchKernelWithSharedMem(kernel, (uint)(batch * numGroups), block, block * sizeof(float), args);
+    }
+
+    /// <summary>True when the FP16 per-channel broadcast-add kernel compiled (driver-only, no cuda_fp16.h). #1650/#638 #3.</summary>
+    public bool Fp16BroadcastAddChannelAvailable => _kernelCache.ContainsKey("fp16_broadcast_add_channel");
+
+    /// <summary>FP16-native per-channel broadcast add (conv bias): ioHalf[b,c,sp] += biasHalf[b,c], in place.
+    /// Both are FP16 buffers (io = [batch, channels, spatial], bias = [batch, channels]); FP32 add. #1650/#638 #3.</summary>
+    public unsafe void Fp16BroadcastAddChannel(IGpuBuffer ioHalf, IGpuBuffer biasHalf, int batch, int channels, int spatial)
+    {
+        if (ioHalf is null) throw new ArgumentNullException(nameof(ioHalf));
+        if (biasHalf is null) throw new ArgumentNullException(nameof(biasHalf));
+        if (batch <= 0 || channels <= 0 || spatial <= 0) throw new ArgumentException($"batch/channels/spatial must be positive (batch={batch}, channels={channels}, spatial={spatial}).");
+        long ioHalfBytes = (long)batch * channels * spatial * Fp16ByteWidth;
+        long biasHalfBytes = (long)batch * channels * Fp16ByteWidth;
+        if (ioHalf.SizeInBytes < ioHalfBytes) throw new ArgumentException($"io half buffer too small: {ioHalf.SizeInBytes} < {ioHalfBytes}.");
+        if (biasHalf.SizeInBytes < biasHalfBytes) throw new ArgumentException($"bias half buffer too small: {biasHalf.SizeInBytes} < {biasHalfBytes}.");
+        if (!_kernelCache.TryGetValue("fp16_broadcast_add_channel", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: fp16_broadcast_add_channel");
+        using var _ = PushContext();
+        long elems = (long)batch * channels * spatial;
+        uint grid = (uint)((elems + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr ioPtr = ioHalf.Handle, biasPtr = biasHalf.Handle;
+        void** args = stackalloc void*[5];
+        args[0] = &ioPtr; args[1] = &biasPtr; args[2] = &batch; args[3] = &channels; args[4] = &spatial;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
     }
 
     /// <summary>FP16-native GELU backward: gradIn = gradOut * gelu'(x). All FP16 buffers; FP32 math in-register.

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -1084,6 +1084,35 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
     private static readonly bool s_residentAudit =
         System.Environment.GetEnvironmentVariable("AIDOTNET_RESIDENT_AUDIT") == "1";
 
+    // Bounded sink for the opt-in resident-audit diagnostics. The path is process-unique (no cross-process
+    // append collision) and overridable via AIDOTNET_RESIDENT_AUDIT_PATH; the cumulative size is capped so a
+    // long capture session can't grow it without bound; write/cap failures surface via Trace instead of being
+    // silently swallowed. Only ever exercised when AIDOTNET_RESIDENT_AUDIT=1 (developer diagnostics).
+    private const long ResidentAuditMaxBytes = 16L * 1024 * 1024; // 16 MB
+    private static readonly string s_residentAuditPath =
+        System.Environment.GetEnvironmentVariable("AIDOTNET_RESIDENT_AUDIT_PATH")
+        ?? System.IO.Path.Combine(System.IO.Path.GetTempPath(),
+            $"aidotnet_resident_audit_{System.Diagnostics.Process.GetCurrentProcess().Id}.txt");
+    private static long s_residentAuditBytes;
+    private static int s_residentAuditFull;
+
+    private static void AppendResidentAudit(string line)
+    {
+        if (System.Threading.Volatile.Read(ref s_residentAuditFull) != 0) return;
+        if (System.Threading.Interlocked.Add(ref s_residentAuditBytes, line.Length) > ResidentAuditMaxBytes)
+        {
+            if (System.Threading.Interlocked.Exchange(ref s_residentAuditFull, 1) == 0)
+                System.Diagnostics.Trace.WriteLine(
+                    $"[AiDotNet] resident-audit log reached {ResidentAuditMaxBytes} bytes; further entries dropped ({s_residentAuditPath}).");
+            return;
+        }
+        try { System.IO.File.AppendAllText(s_residentAuditPath, line); }
+        catch (System.Exception ex)
+        {
+            System.Diagnostics.Trace.WriteLine($"[AiDotNet] resident-audit write failed ({s_residentAuditPath}): {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
     // #638/#1650 capture-blocker diagnostic: when AIDOTNET_GRAPH_CAPTURE_DEBUG=1, log the call stack of the
     // FIRST sync HtoD/DtoH that runs WHILE the stream is actually capturing (cuStreamBeginCapture active).
     // Unlike AIDOTNET_RESIDENT_AUDIT (which also logs the eager passes that run AFTER capture is disabled,
@@ -1111,8 +1140,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
                     if (sb.Length > 300) break;
                 }
             }
-            System.IO.File.AppendAllText(System.IO.Path.Combine(System.IO.Path.GetTempPath(), "aidotnet_resident_audit.txt"),
-                $"{kind}\t{bytes}\t{sb}\n");
+            AppendResidentAudit($"{kind}\t{bytes}\t{sb}\n");
         }
         catch { }
     }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -461,6 +461,14 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
 
     private static string? GetCudaIncludePath()
     {
+        // AIDOTNET_CUDA_INCLUDE points DIRECTLY at a dir holding the CUDA headers (cuda_fp16.h etc.) for nvrtc.
+        // Lets a driver-only box enable the FP16/hardware-half kernels via just the pip CUDA-runtime headers
+        // (nvidia-cuda-runtime-cuXX) WITHOUT a full toolkit install or hijacking the global CUDA_PATH (which
+        // other tools expect to be a complete toolkit with bin/nvcc). Checked first; falls through if unset.
+        var directInclude = Environment.GetEnvironmentVariable("AIDOTNET_CUDA_INCLUDE");
+        if (!string.IsNullOrEmpty(directInclude) && Directory.Exists(directInclude))
+            return directInclude;
+
         // Check CUDA_PATH environment variable first
         var cudaPath = Environment.GetEnvironmentVariable("CUDA_PATH");
         if (string.IsNullOrEmpty(cudaPath) && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -910,6 +918,14 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
             // here disables the ENTIRE FP16 GPU path (convert + half activations + Tensor-Core throughput),
             // which is invisible otherwise (#558). Surfaced via Fp16ModuleCompileError for diagnostics.
             Fp16ModuleCompileError = fp16Ex.Message;
+        }
+        if (System.Environment.GetEnvironmentVariable("AIDOTNET_FP16_SETUP_DIAG") == "1")
+        {
+            try { System.IO.File.WriteAllText(System.IO.Path.Combine(System.IO.Path.GetTempPath(), "aidotnet_fp16_setup.txt"),
+                $"cudaInclude={GetCudaIncludePath() ?? "(null)"}\n" +
+                $"fp16ModuleCompiled={_fp16Module != IntPtr.Zero}\n" +
+                $"conv2d_direct_fp16hw in cache={_kernelCache.ContainsKey("conv2d_direct_fp16hw")}\n" +
+                $"Fp16ModuleCompileError={Fp16ModuleCompileError ?? "(none)"}\n"); } catch { }
         }
 
         // Compile LSTM sequence kernels (forward/backward for BPTT training)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaNativeBindings.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaNativeBindings.cs
@@ -245,6 +245,14 @@ internal static class CudaNativeBindings
     [DllImport(CudaLibrary, EntryPoint = "cuGraphGetNodes")]
     public static extern CudaResult cuGraphGetNodes(IntPtr graph, IntPtr nodes, ref ulong numNodes);
 
+    [DllImport(CudaLibrary, EntryPoint = "cuGraphGetNodes")]
+    public static extern CudaResult cuGraphGetNodesArray(IntPtr graph, [Out] IntPtr[] nodes, ref ulong numNodes);
+
+    // CUgraphNodeType: 0=KERNEL 1=MEMCPY 2=MEMSET 3=HOST 4=GRAPH 5=EMPTY 6=WAIT_EVENT 7=EVENT_RECORD
+    // 8=EXT_SEMAS_SIGNAL 9=EXT_SEMAS_WAIT 10=MEM_ALLOC 11=MEM_FREE 12=BATCH_MEMOP
+    [DllImport(CudaLibrary, EntryPoint = "cuGraphNodeGetType")]
+    public static extern CudaResult cuGraphNodeGetType(IntPtr node, out int type);
+
     [DllImport(CudaLibrary, EntryPoint = "cuGraphDestroy")]
     public static extern CudaResult cuGraphDestroy(IntPtr graph);
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaNativeBindings.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaNativeBindings.cs
@@ -241,6 +241,10 @@ internal static class CudaNativeBindings
     [DllImport(CudaLibrary, EntryPoint = "cuGraphLaunch")]
     public static extern CudaResult cuGraphLaunch(IntPtr graphExec, IntPtr stream);
 
+    // Pass nodes=IntPtr.Zero to query just the node count (numNodes is in/out).
+    [DllImport(CudaLibrary, EntryPoint = "cuGraphGetNodes")]
+    public static extern CudaResult cuGraphGetNodes(IntPtr graph, IntPtr nodes, ref ulong numNodes);
+
     [DllImport(CudaLibrary, EntryPoint = "cuGraphDestroy")]
     public static extern CudaResult cuGraphDestroy(IntPtr graph);
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaFp16Kernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaFp16Kernels.cs
@@ -434,52 +434,38 @@ extern ""C"" __global__ __launch_bounds__(256) void fp16_softmax(
     }
 }
 
-// HARDWARE-FP16 direct conv2d (#1650/#638 toolkit-box replay-floor lever). Reads FP32 input/weights, converts
-// to half IN-REGISTER via the HARDWARE __floats2half2_rn (a single instruction on a CUDA-toolkit GPU — ~free,
-// unlike the 10x-slower software h2f on a driver-only box), multiply-accumulates two input channels per
-// __hfma2 (packed __half2), accumulates in FP32, writes FP32. SAME memory traffic as the FP32 path (no FP16
-// buffers, no cast-in/out, no activation chain) — a pure ~2x FMA-throughput win on the FMA-bound deep convs.
-// This module #includes <cuda_fp16.h>, so on a driver-only box (no header) the WHOLE module fails to compile
-// and is skipped (try/catch in InitializeKernels) → this kernel is absent from _kernelCache → the engine's
-// Fp16HwConvAvailable is false → it falls back to the FP32 Winograd path. On a toolkit box it compiles and the
-// engine routes the resident conv here when AIDOTNET_FP16_CONV=1.
-extern ""C"" __global__ __launch_bounds__(256) void conv2d_direct_fp16hw(
-    const float* __restrict__ input, const float* __restrict__ kernel, float* __restrict__ output,
-    int batch, int inChannels, int inHeight, int inWidth,
-    int outChannels, int outHeight, int outWidth,
+// FUSED im2col + hardware FP32->FP16, TRANSPOSED [K,N] layout (K=channels*kH*kW, N=batch*outH*outW). This is
+// the industry FP16-conv path: feed col[K,N] (FP16) + weights[outC,K] (FP16) to a Tensor-Core GEMM
+// (GemmFp16: out[outC,N] = weights @ col, FP16 multiply / FP32 accumulate). Writing FP16 directly here (hw
+// __float2half) avoids a separate cast pass + halves col bandwidth. #1650/#638 replay-floor lever.
+extern ""C"" __global__ __launch_bounds__(256) void im2col_kn_fp16hw(
+    const float* __restrict__ input, unsigned short* __restrict__ output,
+    int batch, int channels, int height, int width,
     int kernelH, int kernelW, int strideH, int strideW,
-    int padH, int padW, int dilationH, int dilationW)
+    int padH, int padW, int dilationH, int dilationW, int outH, int outW)
 {
-    int ow = blockIdx.x * blockDim.x + threadIdx.x;
-    int oh = blockIdx.y * blockDim.y + threadIdx.y;
-    int oc = blockIdx.z % outChannels;
-    int b = blockIdx.z / outChannels;
-    if (ow >= outWidth || oh >= outHeight || b >= batch) return;
-
-    int inStride = inHeight * inWidth;
-    int kStride = kernelH * kernelW;
-    float sum = 0.0f;
-    for (int kh = 0; kh < kernelH; kh++) {
-        for (int kw = 0; kw < kernelW; kw++) {
-            int ih = oh * strideH - padH + kh * dilationH;
-            int iw = ow * strideW - padW + kw * dilationW;
-            if (ih < 0 || ih >= inHeight || iw < 0 || iw >= inWidth) continue;
-            const float* inP = input + ((b * inChannels) * inHeight + ih) * inWidth + iw;
-            const float* kP  = kernel + ((oc * inChannels) * kernelH + kh) * kernelW + kw;
-            int ic = 0;
-            for (; ic + 1 < inChannels; ic += 2) {
-                // HW FP16 multiply (__hmul2, packed 2-channels), FP32 ACCUMULATE (mixed precision — accumulating
-                // in __half2 over up to hundreds of channels drifts badly; the sum must stay FP32).
-                __half2 iv = __floats2half2_rn(inP[ic * inStride], inP[(ic + 1) * inStride]);
-                __half2 kv = __floats2half2_rn(kP[ic * kStride], kP[(ic + 1) * kStride]);
-                float2 p = __half22float2(__hmul2(iv, kv));
-                sum += p.x + p.y;
-            }
-            for (; ic < inChannels; ic++)   // odd-channel remainder
-                sum += __half2float(__hmul(__float2half(inP[ic * inStride]), __float2half(kP[ic * kStride])));
-        }
-    }
-    output[((b * outChannels + oc) * outHeight + oh) * outWidth + ow] = sum;
+    // ONE THREAD PER col ELEMENT (N*K threads) — fills the GPU and writes col[t]=col[k*N+n] fully coalesced
+    // (adjacent threads → adjacent n → adjacent addresses). The previous thread-per-patch version launched only
+    // N threads (~4 blocks → ~6% occupancy → ~107us for a ~6us-of-bandwidth job); this is the fix.
+    int N = batch * outH * outW;
+    int K = channels * kernelH * kernelW;
+    long t = (long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (t >= (long)N * K) return;
+    int n = (int)(t % N);     // output position (fastest — coalesced)
+    int k = (int)(t / N);     // unrolled (c,kh,kw) row
+    int b = n / (outH * outW);
+    int rem = n % (outH * outW);
+    int oh = rem / outW;
+    int ow = rem % outW;
+    int kw = k % kernelW;
+    int kh = (k / kernelW) % kernelH;
+    int c  = k / (kernelW * kernelH);
+    int ih = oh * strideH - padH + kh * dilationH;
+    int iw = ow * strideW - padW + kw * dilationW;
+    float val = (ih >= 0 && ih < height && iw >= 0 && iw < width)
+        ? input[((b * channels + c) * height + ih) * width + iw] : 0.0f;
+    __half h = __float2half(val);
+    output[t] = *reinterpret_cast<unsigned short*>(&h);
 }
 ";
     }
@@ -491,7 +477,7 @@ extern ""C"" __global__ __launch_bounds__(256) void conv2d_direct_fp16hw(
     {
         return new[]
         {
-            "conv2d_direct_fp16hw",
+            "im2col_kn_fp16hw",
             "convert_fp32_to_fp16",
             "convert_fp16_to_fp32",
             "convert_fp32_to_fp16_rounding",

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaFp16Kernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaFp16Kernels.cs
@@ -428,6 +428,53 @@ extern ""C"" __global__ __launch_bounds__(256) void fp16_softmax(
         *reinterpret_cast<__half*>(&rowOut[c]) = __float2half(result);
     }
 }
+
+// HARDWARE-FP16 direct conv2d (#1650/#638 toolkit-box replay-floor lever). Reads FP32 input/weights, converts
+// to half IN-REGISTER via the HARDWARE __floats2half2_rn (a single instruction on a CUDA-toolkit GPU — ~free,
+// unlike the 10x-slower software h2f on a driver-only box), multiply-accumulates two input channels per
+// __hfma2 (packed __half2), accumulates in FP32, writes FP32. SAME memory traffic as the FP32 path (no FP16
+// buffers, no cast-in/out, no activation chain) — a pure ~2x FMA-throughput win on the FMA-bound deep convs.
+// This module #includes <cuda_fp16.h>, so on a driver-only box (no header) the WHOLE module fails to compile
+// and is skipped (try/catch in InitializeKernels) → this kernel is absent from _kernelCache → the engine's
+// Fp16HwConvAvailable is false → it falls back to the FP32 Winograd path. On a toolkit box it compiles and the
+// engine routes the resident conv here when AIDOTNET_FP16_CONV=1.
+extern ""C"" __global__ __launch_bounds__(256) void conv2d_direct_fp16hw(
+    const float* __restrict__ input, const float* __restrict__ kernel, float* __restrict__ output,
+    int batch, int inChannels, int inHeight, int inWidth,
+    int outChannels, int outHeight, int outWidth,
+    int kernelH, int kernelW, int strideH, int strideW,
+    int padH, int padW, int dilationH, int dilationW)
+{
+    int ow = blockIdx.x * blockDim.x + threadIdx.x;
+    int oh = blockIdx.y * blockDim.y + threadIdx.y;
+    int oc = blockIdx.z % outChannels;
+    int b = blockIdx.z / outChannels;
+    if (ow >= outWidth || oh >= outHeight || b >= batch) return;
+
+    int inStride = inHeight * inWidth;
+    int kStride = kernelH * kernelW;
+    float sum = 0.0f;
+    for (int kh = 0; kh < kernelH; kh++) {
+        for (int kw = 0; kw < kernelW; kw++) {
+            int ih = oh * strideH - padH + kh * dilationH;
+            int iw = ow * strideW - padW + kw * dilationW;
+            if (ih < 0 || ih >= inHeight || iw < 0 || iw >= inWidth) continue;
+            const float* inP = input + ((b * inChannels) * inHeight + ih) * inWidth + iw;
+            const float* kP  = kernel + ((oc * inChannels) * kernelH + kh) * kernelW + kw;
+            __half2 acc = __floats2half2_rn(0.0f, 0.0f);
+            int ic = 0;
+            for (; ic + 1 < inChannels; ic += 2) {
+                __half2 iv = __floats2half2_rn(inP[ic * inStride], inP[(ic + 1) * inStride]);
+                __half2 kv = __floats2half2_rn(kP[ic * kStride], kP[(ic + 1) * kStride]);
+                acc = __hfma2(iv, kv, acc);
+            }
+            sum += __half2float(__low2half(acc)) + __half2float(__high2half(acc));
+            for (; ic < inChannels; ic++)   // odd-channel remainder
+                sum += __half2float(__hmul(__float2half(inP[ic * inStride]), __float2half(kP[ic * kStride])));
+        }
+    }
+    output[((b * outChannels + oc) * outHeight + oh) * outWidth + ow] = sum;
+}
 ";
     }
 
@@ -438,6 +485,7 @@ extern ""C"" __global__ __launch_bounds__(256) void fp16_softmax(
     {
         return new[]
         {
+            "conv2d_direct_fp16hw",
             "convert_fp32_to_fp16",
             "convert_fp16_to_fp32",
             "convert_fp32_to_fp16_rounding",

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaFp16Kernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaFp16Kernels.cs
@@ -12,6 +12,11 @@ public static class CudaFp16Kernels
         return @"
 #include <cuda_fp16.h>
 
+// nvrtc has no <sys/types.h>, so `uint` (used by the vec2 conversion kernels below) is undefined under nvrtc
+// even with the toolkit headers present — this is why the whole module historically failed to compile. Provide
+// the typedef (identical re-typedef is legal C++ if a CUDA header also defines it).
+typedef unsigned int uint;
+
 // ============================================================================
 // FP16 CONVERSION KERNELS
 // ============================================================================
@@ -461,14 +466,15 @@ extern ""C"" __global__ __launch_bounds__(256) void conv2d_direct_fp16hw(
             if (ih < 0 || ih >= inHeight || iw < 0 || iw >= inWidth) continue;
             const float* inP = input + ((b * inChannels) * inHeight + ih) * inWidth + iw;
             const float* kP  = kernel + ((oc * inChannels) * kernelH + kh) * kernelW + kw;
-            __half2 acc = __floats2half2_rn(0.0f, 0.0f);
             int ic = 0;
             for (; ic + 1 < inChannels; ic += 2) {
+                // HW FP16 multiply (__hmul2, packed 2-channels), FP32 ACCUMULATE (mixed precision — accumulating
+                // in __half2 over up to hundreds of channels drifts badly; the sum must stay FP32).
                 __half2 iv = __floats2half2_rn(inP[ic * inStride], inP[(ic + 1) * inStride]);
                 __half2 kv = __floats2half2_rn(kP[ic * kStride], kP[(ic + 1) * kStride]);
-                acc = __hfma2(iv, kv, acc);
+                float2 p = __half22float2(__hmul2(iv, kv));
+                sum += p.x + p.y;
             }
-            sum += __half2float(__low2half(acc)) + __half2float(__high2half(acc));
             for (; ic < inChannels; ic++)   // odd-channel remainder
                 sum += __half2float(__hmul(__float2half(inP[ic * inStride]), __float2half(kP[ic * kStride])));
         }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaFp16Kernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaFp16Kernels.cs
@@ -503,6 +503,42 @@ extern ""C"" __global__ void conv2d_direct_fp16hw(
     }
     output[((b * outChannels + oc) * outHeight + oh) * outWidth + ow] = acc;
 }
+
+// FP16-IN variant of im2col_kn_fp16hw: input is already FP16 (unsigned short), output FP16 col[K,N] in the SAME
+// TRANSPOSED [K,N] layout (N=batch*outH*outW, K=channels*kH*kW). Each tap is loaded via __half2float (oob → 0);
+// avoids a separate FP16→FP32 cast pass when the activation feeding the conv is already half-resident
+// (#1650/#638 #3 — FP16-activation diffusion inference). ONE THREAD PER col element (N*K threads), fully coalesced.
+extern ""C"" __global__ __launch_bounds__(256) void im2col_kn_fp16_from_fp16(
+    const unsigned short* __restrict__ input, unsigned short* __restrict__ output,
+    int batch, int channels, int height, int width,
+    int kernelH, int kernelW, int strideH, int strideW,
+    int padH, int padW, int dilationH, int dilationW, int outH, int outW)
+{
+    int N = batch * outH * outW;
+    int K = channels * kernelH * kernelW;
+    long t = (long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (t >= (long)N * K) return;
+    int n = (int)(t % N);     // output position (fastest — coalesced)
+    int k = (int)(t / N);     // unrolled (c,kh,kw) row
+    int b = n / (outH * outW);
+    int rem = n % (outH * outW);
+    int oh = rem / outW;
+    int ow = rem % outW;
+    int kw = k % kernelW;
+    int kh = (k / kernelW) % kernelH;
+    int c  = k / (kernelW * kernelH);
+    int ih = oh * strideH - padH + kh * dilationH;
+    int iw = ow * strideW - padW + kw * dilationW;
+    float val;
+    if (ih >= 0 && ih < height && iw >= 0 && iw < width) {
+        int idx = ((b * channels + c) * height + ih) * width + iw;
+        val = __half2float(*reinterpret_cast<const __half*>(&input[idx]));
+    } else {
+        val = 0.0f;
+    }
+    __half h = __float2half(val);
+    output[t] = *reinterpret_cast<unsigned short*>(&h); // store the half BITS (NOT a value-convert __half→ushort)
+}
 ";
     }
 
@@ -515,6 +551,7 @@ extern ""C"" __global__ void conv2d_direct_fp16hw(
         {
             "im2col_kn_fp16hw",
             "conv2d_direct_fp16hw",
+            "im2col_kn_fp16_from_fp16",
             "convert_fp32_to_fp16",
             "convert_fp16_to_fp32",
             "convert_fp32_to_fp16_rounding",

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaFp16Kernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaFp16Kernels.cs
@@ -467,6 +467,42 @@ extern ""C"" __global__ __launch_bounds__(256) void im2col_kn_fp16hw(
     __half h = __float2half(val);
     output[t] = *reinterpret_cast<unsigned short*>(&h);
 }
+
+// #1650/#638 (#671): DIRECT FP16 conv for the tiny-spatial deep convs the im2col+GEMM path skips (small N where
+// im2col + launch overhead exceeds the Tensor-Core GEMM win). FP32 input rounded to FP16 per access (mirrors
+// im2col_kn_fp16hw), FP16 weights, FP32 multiply-accumulate (matches GemmFp16In32fOut numerics), FP32 output.
+// One thread per output (ow, oh) with a 3D grid z = b*outChannels. Capture-safe (single kernel, no device alloc).
+extern ""C"" __global__ void conv2d_direct_fp16hw(
+    const float* __restrict__ input, const unsigned short* __restrict__ weightsHalf, float* __restrict__ output,
+    int batch, int inChannels, int inHeight, int inWidth,
+    int outChannels, int outHeight, int outWidth,
+    int kernelH, int kernelW, int strideH, int strideW,
+    int padH, int padW, int dilationH, int dilationW)
+{
+    int ow = blockIdx.x * blockDim.x + threadIdx.x;
+    int oh = blockIdx.y * blockDim.y + threadIdx.y;
+    int bz = blockIdx.z;                 // b * outChannels + oc
+    if (ow >= outWidth || oh >= outHeight) return;
+    int oc = bz % outChannels;
+    int b  = bz / outChannels;
+    float acc = 0.0f;
+    for (int ic = 0; ic < inChannels; ic++) {
+        for (int kh = 0; kh < kernelH; kh++) {
+            int ih = oh * strideH - padH + kh * dilationH;
+            if (ih < 0 || ih >= inHeight) continue;
+            for (int kw = 0; kw < kernelW; kw++) {
+                int iw = ow * strideW - padW + kw * dilationW;
+                if (iw < 0 || iw >= inWidth) continue;
+                float inV = input[((b * inChannels + ic) * inHeight + ih) * inWidth + iw];
+                int wIdx = ((oc * inChannels + ic) * kernelH + kh) * kernelW + kw;
+                __half wH = *reinterpret_cast<const __half*>(&weightsHalf[wIdx]);
+                // FP16 operands, FP32 multiply-accumulate (Tensor-Core semantics): round input to FP16, mul in FP32.
+                acc += __half2float(__float2half(inV)) * __half2float(wH);
+            }
+        }
+    }
+    output[((b * outChannels + oc) * outHeight + oh) * outWidth + ow] = acc;
+}
 ";
     }
 
@@ -478,6 +514,7 @@ extern ""C"" __global__ __launch_bounds__(256) void im2col_kn_fp16hw(
         return new[]
         {
             "im2col_kn_fp16hw",
+            "conv2d_direct_fp16hw",
             "convert_fp32_to_fp16",
             "convert_fp16_to_fp32",
             "convert_fp32_to_fp16_rounding",

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaFp16NativeKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaFp16NativeKernels.cs
@@ -172,6 +172,71 @@ extern ""C"" __global__ void fp16_layernorm_native(
     }
 }
 
+// FP16-NATIVE fused GroupNorm + Swish: ONE BLOCK PER (batch, group). Reads FP16 directly, mean/population-variance
+// reductions in FP32 (mirrors fp16_layernorm_native's full-block tree reduction — no warp-size assumption), then
+// applies affine gamma/beta (FP32) followed by Swish (x/(1+exp(-x))) in-register and writes FP16. gamma/beta are
+// FP32 (per-channel). Population variance (÷groupSize), eps inside the rsqrt — matches the FP32 groupnorm_forward
+// + swish semantics. Shared mem = blockDim.x floats. #1650/#638 #3 (FP16-activation diffusion inference).
+extern ""C"" __global__ void fp16_groupnorm_swish(
+    const unsigned short* __restrict__ input, const float* __restrict__ gamma, const float* __restrict__ beta,
+    unsigned short* __restrict__ output, int batch, int numGroups, int channels, int spatial, float eps)
+{
+    int blockId = blockIdx.x;
+    int g = blockId % numGroups;
+    int b = blockId / numGroups;
+    if (b >= batch) return;
+    extern __shared__ float sdata[];
+    int tid = threadIdx.x; int bs = blockDim.x;
+    int channelsPerGroup = channels / numGroups;
+    int groupSize = channelsPerGroup * spatial;
+    // mean (FP32)
+    float s = 0.0f;
+    for (int i = tid; i < groupSize; i += bs) {
+        int c = g * channelsPerGroup + i / spatial;
+        int sp = i % spatial;
+        s += h2f(input[(b * channels + c) * spatial + sp]);
+    }
+    sdata[tid] = s; __syncthreads();
+    for (int st = bs >> 1; st > 0; st >>= 1) { if (tid < st) sdata[tid] += sdata[tid + st]; __syncthreads(); }
+    float mean = sdata[0] / (float)groupSize; __syncthreads();
+    // population variance (FP32)
+    float v = 0.0f;
+    for (int i = tid; i < groupSize; i += bs) {
+        int c = g * channelsPerGroup + i / spatial;
+        int sp = i % spatial;
+        float d = h2f(input[(b * channels + c) * spatial + sp]) - mean;
+        v += d * d;
+    }
+    sdata[tid] = v; __syncthreads();
+    for (int st = bs >> 1; st > 0; st >>= 1) { if (tid < st) sdata[tid] += sdata[tid + st]; __syncthreads(); }
+    float var = sdata[0] / (float)groupSize; __syncthreads();
+    float invstd = rsqrtf(var + eps);
+    // normalize + affine + Swish
+    for (int i = tid; i < groupSize; i += bs) {
+        int c = g * channelsPerGroup + i / spatial;
+        int sp = i % spatial;
+        int idx = (b * channels + c) * spatial + sp;
+        float norm = (h2f(input[idx]) - mean) * invstd;
+        float aff = norm * gamma[c] + beta[c];
+        float swish = aff / (1.0f + expf(-aff));
+        output[idx] = f2h(swish);
+    }
+}
+
+// FP16-NATIVE per-channel broadcast add (conv bias): io[b,c,sp] += bias[b,c], in place. ONE THREAD PER io element.
+// bias is laid out [batch, channels]; reads FP16 directly, FP32 add, writes FP16. #1650/#638 #3.
+extern ""C"" __global__ __launch_bounds__(256) void fp16_broadcast_add_channel(
+    unsigned short* __restrict__ io, const unsigned short* __restrict__ bias,
+    int batch, int channels, int spatial)
+{
+    long i = (long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= (long)batch * channels * spatial) return;
+    int b = (int)(i / ((long)channels * spatial));
+    int rem = (int)(i % ((long)channels * spatial));
+    int c = rem / spatial;
+    io[i] = f2h(h2f(io[i]) + h2f(bias[b * channels + c]));
+}
+
 // ── FP16-NATIVE BACKWARD kernels (read FP16 grad + FP16 saved activation, FP32 math, write FP16 grad) ──
 // Each mirrors the EXACT formula of its FP32 counterpart so the Half backward is parity-equivalent to the
 // FP32 backward — only the storage dtype differs (the converts that scaled with data size are eliminated).
@@ -288,6 +353,8 @@ extern ""C"" __global__ __launch_bounds__(256) void fp16_layernorm_grad_params_n
         "fp16_add_native",
         "fp16_softmax_native",
         "fp16_layernorm_native",
+        "fp16_groupnorm_swish",
+        "fp16_broadcast_add_channel",
         "fp16_gelu_backward_native",
         "fp16_relu_backward_native",
         "fp16_softmax_backward_native",

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.HalfPrecision.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.HalfPrecision.cs
@@ -175,4 +175,14 @@ public sealed partial class HipBackend : IGpuHalfPrecisionBackend
         if (n <= 0) throw new ArgumentOutOfRangeException(nameof(n), "Dimensions must be positive.");
         if (k <= 0) throw new ArgumentOutOfRangeException(nameof(k), "Dimensions must be positive.");
     }
+    // #1650/#638 FP16 conv im2col — STUB pending the HIP kernel port (dispatch gates on Fp16Im2colAvailable
+    // so Im2colKNFp16 is never invoked while this returns false; the engine keeps the FP32 conv on HIP).
+    /// <inheritdoc/>
+    public bool Fp16Im2colAvailable => false;
+    /// <inheritdoc/>
+    public void Im2colKNFp16(IGpuBuffer input, IGpuBuffer outputHalf,
+        int batch, int channels, int height, int width,
+        int kernelH, int kernelW, int strideH, int strideW, int padH, int padW, int dilationH, int dilationW)
+        => throw new System.NotSupportedException("FP16 im2col (Im2colKNFp16) is not yet ported to the HIP backend.");
+
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.HalfPrecision.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.HalfPrecision.cs
@@ -175,14 +175,31 @@ public sealed partial class HipBackend : IGpuHalfPrecisionBackend
         if (n <= 0) throw new ArgumentOutOfRangeException(nameof(n), "Dimensions must be positive.");
         if (k <= 0) throw new ArgumentOutOfRangeException(nameof(k), "Dimensions must be positive.");
     }
-    // #1650/#638 FP16 conv im2col — STUB pending the HIP kernel port (dispatch gates on Fp16Im2colAvailable
-    // so Im2colKNFp16 is never invoked while this returns false; the engine keeps the FP32 conv on HIP).
+    // #1650/#638 FP16 conv im2col (the industry conv-as-GEMM path): fused im2col + FP32->FP16 into a [K,N] half
+    // buffer (im2col_kn_fp16hw in HipFp16Kernels), paired with GemmFp16In32fOut (hipBLAS) on the MFMA units.
+    // Available only when the FP16 kernel module compiled (hiprtc + hip_fp16.h); else the engine keeps FP32 conv.
     /// <inheritdoc/>
-    public bool Fp16Im2colAvailable => false;
+    public bool Fp16Im2colAvailable => _fp16Module != IntPtr.Zero && _kernelCache.ContainsKey("im2col_kn_fp16hw");
+
     /// <inheritdoc/>
-    public void Im2colKNFp16(IGpuBuffer input, IGpuBuffer outputHalf,
+    public unsafe void Im2colKNFp16(IGpuBuffer input, IGpuBuffer outputHalf,
         int batch, int channels, int height, int width,
         int kernelH, int kernelW, int strideH, int strideW, int padH, int padW, int dilationH, int dilationW)
-        => throw new System.NotSupportedException("FP16 im2col (Im2colKNFp16) is not yet ported to the HIP backend.");
+    {
+        if (!_kernelCache.TryGetValue("im2col_kn_fp16hw", out var k))
+            throw new System.InvalidOperationException("HIP kernel not found: im2col_kn_fp16hw");
+        IntPtr inputPtr = input.Handle, outputPtr = outputHalf.Handle;
+        int outH = (height + 2 * padH - ((kernelH - 1) * dilationH + 1)) / strideH + 1;
+        int outW = (width + 2 * padW - ((kernelW - 1) * dilationW + 1)) / strideW + 1;
+        int totalPatches = batch * outH * outW;
+        void** a = stackalloc void*[16];
+        a[0] = &inputPtr; a[1] = &outputPtr;
+        a[2] = &batch; a[3] = &channels; a[4] = &height; a[5] = &width;
+        a[6] = &kernelH; a[7] = &kernelW; a[8] = &strideH; a[9] = &strideW;
+        a[10] = &padH; a[11] = &padW; a[12] = &dilationH; a[13] = &dilationW; a[14] = &outH; a[15] = &outW;
+        long elems = (long)totalPatches * (channels * kernelH * kernelW); // N*K threads (one per col element)
+        uint grid = (uint)((elems + DefaultBlockSize - 1) / DefaultBlockSize);
+        LaunchKernel(k, grid, DefaultBlockSize, a);
+    }
 
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.HalfPrecision.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.HalfPrecision.cs
@@ -188,9 +188,29 @@ public sealed partial class HipBackend : IGpuHalfPrecisionBackend
     {
         if (!_kernelCache.TryGetValue("im2col_kn_fp16hw", out var k))
             throw new System.InvalidOperationException("HIP kernel not found: im2col_kn_fp16hw");
+        // #671 review: validate at the public entry (the rest of this backend does) — null/foreign buffers,
+        // a zero stride/dilation (divide-by-zero), and a non-positive output extent (negative elems cast to a
+        // huge uint grid) would otherwise pass invalid pointers/launch sizes into hipModuleLaunchKernel.
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (outputHalf is null) throw new ArgumentNullException(nameof(outputHalf));
+        if (batch <= 0) throw new ArgumentOutOfRangeException(nameof(batch), "Dimensions must be positive.");
+        if (channels <= 0) throw new ArgumentOutOfRangeException(nameof(channels), "Dimensions must be positive.");
+        if (height <= 0) throw new ArgumentOutOfRangeException(nameof(height), "Dimensions must be positive.");
+        if (width <= 0) throw new ArgumentOutOfRangeException(nameof(width), "Dimensions must be positive.");
+        if (kernelH <= 0) throw new ArgumentOutOfRangeException(nameof(kernelH), "Dimensions must be positive.");
+        if (kernelW <= 0) throw new ArgumentOutOfRangeException(nameof(kernelW), "Dimensions must be positive.");
+        if (strideH <= 0) throw new ArgumentOutOfRangeException(nameof(strideH), "Stride must be positive.");
+        if (strideW <= 0) throw new ArgumentOutOfRangeException(nameof(strideW), "Stride must be positive.");
+        if (dilationH <= 0) throw new ArgumentOutOfRangeException(nameof(dilationH), "Dilation must be positive.");
+        if (dilationW <= 0) throw new ArgumentOutOfRangeException(nameof(dilationW), "Dilation must be positive.");
+        if (padH < 0) throw new ArgumentOutOfRangeException(nameof(padH), "Padding must be non-negative.");
+        if (padW < 0) throw new ArgumentOutOfRangeException(nameof(padW), "Padding must be non-negative.");
         IntPtr inputPtr = input.Handle, outputPtr = outputHalf.Handle;
         int outH = (height + 2 * padH - ((kernelH - 1) * dilationH + 1)) / strideH + 1;
         int outW = (width + 2 * padW - ((kernelW - 1) * dilationW + 1)) / strideW + 1;
+        if (outH <= 0 || outW <= 0)
+            throw new ArgumentException(
+                $"Convolution output size is non-positive (outH={outH}, outW={outW}); check kernel/stride/pad/dilation vs input size.");
         int totalPatches = batch * outH * outW;
         void** a = stackalloc void*[16];
         a[0] = &inputPtr; a[1] = &outputPtr;
@@ -198,6 +218,8 @@ public sealed partial class HipBackend : IGpuHalfPrecisionBackend
         a[6] = &kernelH; a[7] = &kernelW; a[8] = &strideH; a[9] = &strideW;
         a[10] = &padH; a[11] = &padW; a[12] = &dilationH; a[13] = &dilationW; a[14] = &outH; a[15] = &outW;
         long elems = (long)totalPatches * (channels * kernelH * kernelW); // N*K threads (one per col element)
+        if (elems > int.MaxValue)
+            throw new NotSupportedException($"FP16 im2col work size {elems} exceeds the launch limit.");
         uint grid = (uint)((elems + DefaultBlockSize - 1) / DefaultBlockSize);
         LaunchKernel(k, grid, DefaultBlockSize, a);
     }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipFp16Kernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipFp16Kernels.cs
@@ -92,6 +92,40 @@ extern ""C"" __global__ __launch_bounds__(256) void convert_fp16_to_fp32_vec2(
 }
 
 // ============================================================================
+// FP16 CONV im2col (#1650/#638): fused im2col + FP32->FP16 in TRANSPOSED [K,N] layout (K=channels*kernelH*kernelW,
+// N=batch*outH*outW) so the conv becomes a plain NN GEMM out[outC,N] = weights[outC,K] . col[K,N] via
+// GemmFp16In32fOut (hipBLAS, FP16 multiply / FP32 accumulate on the MFMA matrix units) — the industry conv path.
+// ONE THREAD PER col ELEMENT (N*K threads) → coalesced col[t]=col[k*N+n] writes (adjacent threads → adjacent n →
+// adjacent addresses) + full occupancy (a thread-per-patch version launched only N threads → starved).
+// ============================================================================
+extern ""C"" __global__ __launch_bounds__(256) void im2col_kn_fp16hw(
+    const float* __restrict__ input, unsigned short* __restrict__ output,
+    int batch, int channels, int height, int width,
+    int kernelH, int kernelW, int strideH, int strideW,
+    int padH, int padW, int dilationH, int dilationW, int outH, int outW)
+{
+    int N = batch * outH * outW;
+    int K = channels * kernelH * kernelW;
+    long t = (long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (t >= (long)N * K) return;
+    int n = (int)(t % N);     // output position (fastest — coalesced)
+    int k = (int)(t / N);     // unrolled (c,kh,kw) row
+    int b = n / (outH * outW);
+    int rem = n % (outH * outW);
+    int oh = rem / outW;
+    int ow = rem % outW;
+    int kw = k % kernelW;
+    int kh = (k / kernelW) % kernelH;
+    int c  = k / (kernelW * kernelH);
+    int ih = oh * strideH - padH + kh * dilationH;
+    int iw = ow * strideW - padW + kw * dilationW;
+    float val = (ih >= 0 && ih < height && iw >= 0 && iw < width)
+        ? input[((b * channels + c) * height + ih) * width + iw] : 0.0f;
+    __half h = __float2half(val);
+    output[t] = *reinterpret_cast<unsigned short*>(&h);
+}
+
+// ============================================================================
 // FP16 ELEMENT-WISE ARITHMETIC (packed __half2 for 2x throughput)
 // ============================================================================
 
@@ -453,6 +487,7 @@ extern ""C"" __global__ void fp16_layernorm(
     {
         return new[]
         {
+            "im2col_kn_fp16hw",
             "convert_fp32_to_fp16",
             "convert_fp16_to_fp32",
             "convert_fp32_to_fp16_rounding",

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.HalfPrecision.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.HalfPrecision.cs
@@ -277,4 +277,14 @@ public sealed partial class MetalBackend : IGpuHalfPrecisionBackend
         if (n <= 0) throw new ArgumentOutOfRangeException(nameof(n), "Dimensions must be positive.");
         if (k <= 0) throw new ArgumentOutOfRangeException(nameof(k), "Dimensions must be positive.");
     }
+    // #1650/#638 FP16 conv im2col — STUB pending the Metal kernel port (dispatch gates on Fp16Im2colAvailable
+    // so Im2colKNFp16 is never invoked while this returns false; the engine keeps the FP32 conv on Metal).
+    /// <inheritdoc/>
+    public bool Fp16Im2colAvailable => false;
+    /// <inheritdoc/>
+    public void Im2colKNFp16(IGpuBuffer input, IGpuBuffer outputHalf,
+        int batch, int channels, int height, int width,
+        int kernelH, int kernelW, int strideH, int strideW, int padH, int padW, int dilationH, int dilationW)
+        => throw new System.NotSupportedException("FP16 im2col (Im2colKNFp16) is not yet ported to the Metal backend.");
+
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.HalfPrecision.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.HalfPrecision.cs
@@ -277,14 +277,75 @@ public sealed partial class MetalBackend : IGpuHalfPrecisionBackend
         if (n <= 0) throw new ArgumentOutOfRangeException(nameof(n), "Dimensions must be positive.");
         if (k <= 0) throw new ArgumentOutOfRangeException(nameof(k), "Dimensions must be positive.");
     }
-    // #1650/#638 FP16 conv im2col — STUB pending the Metal kernel port (dispatch gates on Fp16Im2colAvailable
-    // so Im2colKNFp16 is never invoked while this returns false; the engine keeps the FP32 conv on Metal).
+    // #1650/#638 FP16 conv im2col (the industry conv-as-GEMM path): fused im2col + FP32->FP16 into a [K,N] half
+    // buffer (the im2col_kn_fp16hw MSL kernel in the matrix library), paired with GemmFp16In32fOut on the GPU
+    // matrix units. The kernel lives in the same matrix MSL library as the FP16 GEMM, so it compiles whenever the
+    // backend does; the availability gate verifies its pipeline actually builds before the conv path uses it.
+    // Bit-identical index math to the CUDA/HIP im2col_kn_fp16hw kernels. NOTE: written against the Metal launch
+    // conventions but NOT validated on Apple hardware (the dev box has no Apple GPU).
     /// <inheritdoc/>
-    public bool Fp16Im2colAvailable => false;
+    public bool Fp16Im2colAvailable
+        => IsAvailable && _matrixLibrary != IntPtr.Zero
+           && TryGetPipeline("Matrix", _matrixLibrary, "im2col_kn_fp16hw") is not null;
+
     /// <inheritdoc/>
     public void Im2colKNFp16(IGpuBuffer input, IGpuBuffer outputHalf,
         int batch, int channels, int height, int width,
         int kernelH, int kernelW, int strideH, int strideW, int padH, int padW, int dilationH, int dilationW)
-        => throw new System.NotSupportedException("FP16 im2col (Im2colKNFp16) is not yet ported to the Metal backend.");
+    {
+        ThrowIfDisposed();
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (outputHalf is null) throw new ArgumentNullException(nameof(outputHalf));
+        if (batch <= 0 || channels <= 0 || height <= 0 || width <= 0)
+            throw new ArgumentOutOfRangeException(nameof(batch), "batch/channels/height/width must be positive.");
+        if (kernelH <= 0 || kernelW <= 0)
+            throw new ArgumentOutOfRangeException(nameof(kernelH), "kernel dimensions must be positive.");
+        if (strideH <= 0 || strideW <= 0)
+            throw new ArgumentOutOfRangeException(nameof(strideH), "stride must be positive.");
+        if (dilationH <= 0 || dilationW <= 0)
+            throw new ArgumentOutOfRangeException(nameof(dilationH), "dilation must be positive.");
+        if (input is not MetalGpuBuffer inBuf || outputHalf is not MetalGpuBuffer outBuf)
+            throw new ArgumentException("Buffers must be MetalGpuBuffer");
+
+        // Host computes outH/outW (mirrors the CUDA/HIP launchers) and passes them to the kernel.
+        int outH = (height + 2 * padH - ((kernelH - 1) * dilationH + 1)) / strideH + 1;
+        int outW = (width + 2 * padW - ((kernelW - 1) * dilationW + 1)) / strideW + 1;
+        if (outH <= 0 || outW <= 0)
+            throw new ArgumentOutOfRangeException(nameof(outH), "Computed output spatial size is non-positive; check kernel/stride/pad/dilation.");
+
+        // One thread per col element: total = N*K = (batch*outH*outW) * (channels*kernelH*kernelW).
+        // Calculate1DDispatch is int-bounded; guard against int overflow rather than silently truncating
+        // (a Metal limitation vs. the long grid the CUDA/HIP kernels use — see report).
+        long n = (long)batch * outH * outW;
+        long k = (long)channels * kernelH * kernelW;
+        long totalLong = n * k;
+        if (totalLong > int.MaxValue)
+            throw new NotSupportedException(
+                $"FP16 im2col col-matrix element count ({totalLong}) exceeds the Metal 1-D dispatch limit (int.MaxValue).");
+        int total = (int)totalLong;
+
+        var pipeline = GetPipeline("Matrix", _matrixLibrary, "im2col_kn_fp16hw");
+        var (threadgroups, threadsPerGroup) = pipeline.Calculate1DDispatch(total);
+
+        using var encoder = _commandQueue.CreateScopedComputeEncoder();
+        encoder.SetPipelineState(pipeline.Handle);
+        encoder.SetBuffer(inBuf, 0);
+        encoder.SetBuffer(outBuf, 1);
+        encoder.SetBytes((uint)batch, 2);
+        encoder.SetBytes((uint)channels, 3);
+        encoder.SetBytes((uint)height, 4);
+        encoder.SetBytes((uint)width, 5);
+        encoder.SetBytes((uint)kernelH, 6);
+        encoder.SetBytes((uint)kernelW, 7);
+        encoder.SetBytes((uint)strideH, 8);
+        encoder.SetBytes((uint)strideW, 9);
+        encoder.SetBytes((uint)padH, 10);
+        encoder.SetBytes((uint)padW, 11);
+        encoder.SetBytes((uint)dilationH, 12);
+        encoder.SetBytes((uint)dilationW, 13);
+        encoder.SetBytes((uint)outH, 14);
+        encoder.SetBytes((uint)outW, 15);
+        encoder.DispatchThreadgroups(threadgroups, threadsPerGroup);
+    }
 
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.HalfPrecision.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.HalfPrecision.cs
@@ -281,8 +281,10 @@ public sealed partial class MetalBackend : IGpuHalfPrecisionBackend
     // buffer (the im2col_kn_fp16hw MSL kernel in the matrix library), paired with GemmFp16In32fOut on the GPU
     // matrix units. The kernel lives in the same matrix MSL library as the FP16 GEMM, so it compiles whenever the
     // backend does; the availability gate verifies its pipeline actually builds before the conv path uses it.
-    // Bit-identical index math to the CUDA/HIP im2col_kn_fp16hw kernels. NOTE: written against the Metal launch
-    // conventions but NOT validated on Apple hardware (the dev box has no Apple GPU).
+    // Bit-identical index math to the CUDA/HIP im2col_kn_fp16hw kernels. Per the #671 policy decision the FP16 conv
+    // path is enabled by default on every backend whose pipeline compiles; end-to-end correctness is validated on
+    // CUDA (RTX 3080) and CPU-parity-tested on OpenCL/Vulkan, while Metal/WebGpu/HIP end-to-end hardware validation
+    // is a tracked follow-up (this dev box has no Apple GPU). Opt out globally with AIDOTNET_FP16_CONV=0.
     /// <inheritdoc/>
     public bool Fp16Im2colAvailable
         => IsAvailable && _matrixLibrary != IntPtr.Zero

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
@@ -368,6 +368,27 @@ public sealed partial class MetalBackend : IDirectGpuBackend, IFusedAdvancedKern
         });
     }
 
+    /// <summary>
+    /// Like <see cref="GetPipeline"/> but returns <c>null</c> instead of throwing when the kernel is missing or
+    /// fails to compile into a pipeline. Used by capability gates (e.g. <see cref="Fp16Im2colAvailable"/>) that
+    /// must report honestly whether a specific kernel is actually available before dispatching it. On success the
+    /// pipeline is cached so a following <see cref="GetPipeline"/> for the same kernel reuses it. (GetOrAdd does
+    /// not cache a throwing factory, so a failed probe leaves the cache clean for a later retry.)
+    /// </summary>
+    private MetalPipelineState? TryGetPipeline(string libraryName, IntPtr library, string kernelName)
+    {
+        if (library == IntPtr.Zero) return null;
+        try
+        {
+            return GetPipeline(libraryName, library, kernelName);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Metal pipeline '{kernelName}' unavailable: {ex.Message}");
+            return null;
+        }
+    }
+
     #endregion
 
     #region Memory Management

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalKernels.cs
@@ -1749,6 +1749,54 @@ kernel void matmul_fp16_backward(
     }
 }
 
+// FP16 CONV im2col (#1650/#638): fused im2col + FP32->FP16 in the TRANSPOSED [K,N] layout
+// (K = channels*kernelH*kernelW, N = batch*outH*outW) so the conv becomes a plain NN GEMM
+// out[outC,N] = weights[outC,K] . col[K,N] via matmul_fp16_fp32out (GemmFp16In32fOut) on the GPU
+// matrix units — the industry conv-as-GEMM path (oneDNN/cuDNN/PyTorch). ONE THREAD PER col ELEMENT
+// (N*K threads): n = t % N is the fastest-varying index so adjacent threads write adjacent col[t]
+// addresses (coalesced) and the launch is fully occupied. The half output is written directly
+// (MSL native half), matching the other FP16-native kernels. Index math is bit-identical to the
+// CUDA/HIP im2col_kn_fp16hw kernels. The grid is 1-D over N*K (the host passes outH/outW).
+kernel void im2col_kn_fp16hw(
+    device const float* input [[buffer(0)]],
+    device half* output [[buffer(1)]],
+    constant uint& batch [[buffer(2)]],
+    constant uint& channels [[buffer(3)]],
+    constant uint& height [[buffer(4)]],
+    constant uint& width [[buffer(5)]],
+    constant uint& kernelH [[buffer(6)]],
+    constant uint& kernelW [[buffer(7)]],
+    constant uint& strideH [[buffer(8)]],
+    constant uint& strideW [[buffer(9)]],
+    constant uint& padH [[buffer(10)]],
+    constant uint& padW [[buffer(11)]],
+    constant uint& dilationH [[buffer(12)]],
+    constant uint& dilationW [[buffer(13)]],
+    constant uint& outH [[buffer(14)]],
+    constant uint& outW [[buffer(15)]],
+    uint t [[thread_position_in_grid]])
+{
+    uint N = batch * outH * outW;
+    uint K = channels * kernelH * kernelW;
+    if (t >= N * K) return;
+    uint n = t % N;     // output position (fastest — coalesced)
+    uint k = t / N;     // unrolled (c,kh,kw) row
+    uint b = n / (outH * outW);
+    uint rem = n % (outH * outW);
+    uint oh = rem / outW;
+    uint ow = rem % outW;
+    uint kw = k % kernelW;
+    uint kh = (k / kernelW) % kernelH;
+    uint c  = k / (kernelW * kernelH);
+    int ih = int(oh * strideH) - int(padH) + int(kh * dilationH);
+    int iw = int(ow * strideW) - int(padW) + int(kw * dilationW);
+    float val = 0.0f;
+    if (ih >= 0 && ih < int(height) && iw >= 0 && iw < int(width)) {
+        val = input[((b * channels + c) * height + uint(ih)) * width + uint(iw)];
+    }
+    output[t] = half(val);
+}
+
 // FP16-NATIVE elementwise / activation kernels (#558): read the activation DIRECTLY from a half buffer
 // (MSL has a native half type), compute in FP32 in-register, write half — no FP32 buffer materialized,
 // no convert transient. GPU counterpart of the CPU FP16-native emit.

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/Fp16Kernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/Fp16Kernels.cs
@@ -112,6 +112,41 @@ __kernel void convert_fp16_to_fp32_vec2(
     float2 f2 = vload_half2(idx, (__global const half*)input);
     output[idx] = f2;
 }
+
+// ============================================================================
+// FP16 CONV im2col (#1650/#638): fused im2col + FP32->FP16 in TRANSPOSED [K,N] layout (K=channels*kernelH*kernelW,
+// N=batch*outH*outW) so the conv becomes a plain NN GEMM out[outC,N] = weights[outC,K] . col[K,N] via
+// GemmFp16In32fOut (the OpenCL HalfPrecisionGemmKernels, FP16 multiply / FP32 accumulate) — the industry conv path.
+// ONE WORK-ITEM PER col ELEMENT (N*K items) → coalesced col[t]=col[k*N+n] writes via the CORE vstore_half built-in
+// (round-to-nearest-even, matches convert_fp32_to_fp16 / ConvertToFp16 so the col + weights agree bit-for-bit).
+// ============================================================================
+__kernel void im2col_kn_fp16hw(
+    __global const float* input,
+    __global ushort* output,
+    const int batch, const int channels, const int height, const int width,
+    const int kernelH, const int kernelW, const int strideH, const int strideW,
+    const int padH, const int padW, const int dilationH, const int dilationW,
+    const int outH, const int outW)
+{
+    size_t t = get_global_id(0);
+    long N = (long)batch * outH * outW;
+    long K = (long)channels * kernelH * kernelW;
+    if ((long)t >= N * K) return;
+    int n = (int)((long)t % N);     // output position (fastest — coalesced)
+    int k = (int)((long)t / N);     // unrolled (c,kh,kw) row
+    int b = n / (outH * outW);
+    int rem = n % (outH * outW);
+    int oh = rem / outW;
+    int ow = rem % outW;
+    int kw = k % kernelW;
+    int kh = (k / kernelW) % kernelH;
+    int c  = k / (kernelW * kernelH);
+    int ih = oh * strideH - padH + kh * dilationH;
+    int iw = ow * strideW - padW + kw * dilationW;
+    float val = (ih >= 0 && ih < height && iw >= 0 && iw < width)
+        ? input[((b * channels + c) * height + ih) * width + iw] : 0.0f;
+    vstore_half(val, t, (__global half*)output);
+}
 ";
     }
 
@@ -122,6 +157,7 @@ __kernel void convert_fp16_to_fp32_vec2(
     {
         return new[]
         {
+            "im2col_kn_fp16hw",
             "convert_fp32_to_fp16",
             "convert_fp16_to_fp32",
             "convert_fp32_to_fp16_rounding",

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.HalfPrecision.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.HalfPrecision.cs
@@ -201,8 +201,26 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         if (!_kernelCache.TryGetValue("im2col_kn_fp16hw", out var kernel))
             throw new NotSupportedException("FP16 im2col kernel is not available on this OpenCL device.");
 
+        // #671 review: validate convolution parameters before deriving the work size — a zero stride/dilation
+        // divides by zero, and non-positive dims/output extents would flow into Execute1D as invalid global sizes.
+        if (batch <= 0) throw new ArgumentOutOfRangeException(nameof(batch), "Dimensions must be positive.");
+        if (channels <= 0) throw new ArgumentOutOfRangeException(nameof(channels), "Dimensions must be positive.");
+        if (height <= 0) throw new ArgumentOutOfRangeException(nameof(height), "Dimensions must be positive.");
+        if (width <= 0) throw new ArgumentOutOfRangeException(nameof(width), "Dimensions must be positive.");
+        if (kernelH <= 0) throw new ArgumentOutOfRangeException(nameof(kernelH), "Dimensions must be positive.");
+        if (kernelW <= 0) throw new ArgumentOutOfRangeException(nameof(kernelW), "Dimensions must be positive.");
+        if (strideH <= 0) throw new ArgumentOutOfRangeException(nameof(strideH), "Stride must be positive.");
+        if (strideW <= 0) throw new ArgumentOutOfRangeException(nameof(strideW), "Stride must be positive.");
+        if (dilationH <= 0) throw new ArgumentOutOfRangeException(nameof(dilationH), "Dilation must be positive.");
+        if (dilationW <= 0) throw new ArgumentOutOfRangeException(nameof(dilationW), "Dilation must be positive.");
+        if (padH < 0) throw new ArgumentOutOfRangeException(nameof(padH), "Padding must be non-negative.");
+        if (padW < 0) throw new ArgumentOutOfRangeException(nameof(padW), "Padding must be non-negative.");
+
         int outH = (height + 2 * padH - ((kernelH - 1) * dilationH + 1)) / strideH + 1;
         int outW = (width + 2 * padW - ((kernelW - 1) * dilationW + 1)) / strideW + 1;
+        if (outH <= 0 || outW <= 0)
+            throw new ArgumentException(
+                $"Convolution output size is non-positive (outH={outH}, outW={outW}); check kernel/stride/pad/dilation vs input size.");
         long elems = (long)batch * outH * outW * channels * kernelH * kernelW; // N*K work-items
         if (elems > int.MaxValue)
             throw new NotSupportedException($"FP16 im2col work size {elems} exceeds the 1-D dispatch limit.");

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.HalfPrecision.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.HalfPrecision.cs
@@ -185,15 +185,49 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             int globalY = ((mo + ts - 1) / ts) * ts;   // Mo axis (dim 1)
             kernel.Execute2D(globalX, globalY, ts, ts);
         }
-    // #1650/#638 FP16 conv im2col — STUB pending the OpenCL kernel port (dispatch gates on Fp16Im2colAvailable
-    // so Im2colKNFp16 is never invoked while this returns false; the engine keeps the FP32 conv on OpenCL).
+    // #1650/#638 FP16 conv im2col (the industry conv-as-GEMM path): fused im2col + FP32->FP16 into a [K,N] half
+    // buffer (im2col_kn_fp16hw in Fp16Kernels — compiled into _kernelCache at init), paired with GemmFp16In32fOut
+    // (HalfPrecisionGemmKernels). Available only when that kernel compiled on this device; else FP32 conv.
     /// <inheritdoc/>
-    public bool Fp16Im2colAvailable => false;
+    public bool Fp16Im2colAvailable => _kernelCache.ContainsKey("im2col_kn_fp16hw");
+
     /// <inheritdoc/>
     public void Im2colKNFp16(IGpuBuffer input, IGpuBuffer outputHalf,
         int batch, int channels, int height, int width,
         int kernelH, int kernelW, int strideH, int strideW, int padH, int padW, int dilationH, int dilationW)
-        => throw new System.NotSupportedException("FP16 im2col (Im2colKNFp16) is not yet ported to the OpenCL backend.");
+    {
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (outputHalf is null) throw new ArgumentNullException(nameof(outputHalf));
+        if (!_kernelCache.TryGetValue("im2col_kn_fp16hw", out var kernel))
+            throw new NotSupportedException("FP16 im2col kernel is not available on this OpenCL device.");
+
+        int outH = (height + 2 * padH - ((kernelH - 1) * dilationH + 1)) / strideH + 1;
+        int outW = (width + 2 * padW - ((kernelW - 1) * dilationW + 1)) / strideW + 1;
+        long elems = (long)batch * outH * outW * channels * kernelH * kernelW; // N*K work-items
+        if (elems > int.MaxValue)
+            throw new NotSupportedException($"FP16 im2col work size {elems} exceeds the 1-D dispatch limit.");
+
+        uint arg = 0;
+        kernel.SetArg(arg++, ((DirectOpenClGpuBuffer)input).Buffer.Handle);
+        kernel.SetArg(arg++, ((DirectOpenClGpuBuffer)outputHalf).Buffer.Handle);
+        kernel.SetArg(arg++, batch);
+        kernel.SetArg(arg++, channels);
+        kernel.SetArg(arg++, height);
+        kernel.SetArg(arg++, width);
+        kernel.SetArg(arg++, kernelH);
+        kernel.SetArg(arg++, kernelW);
+        kernel.SetArg(arg++, strideH);
+        kernel.SetArg(arg++, strideW);
+        kernel.SetArg(arg++, padH);
+        kernel.SetArg(arg++, padW);
+        kernel.SetArg(arg++, dilationH);
+        kernel.SetArg(arg++, dilationW);
+        kernel.SetArg(arg++, outH);
+        kernel.SetArg(arg++, outW);
+
+        int global = (int)elems; // Execute1D rounds up to a local multiple; the kernel guards OOB work-items
+        kernel.Execute1D(global, CalculateOptimalWorkGroupSize1D(global));
+    }
 
     }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.HalfPrecision.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.HalfPrecision.cs
@@ -185,5 +185,15 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             int globalY = ((mo + ts - 1) / ts) * ts;   // Mo axis (dim 1)
             kernel.Execute2D(globalX, globalY, ts, ts);
         }
+    // #1650/#638 FP16 conv im2col — STUB pending the OpenCL kernel port (dispatch gates on Fp16Im2colAvailable
+    // so Im2colKNFp16 is never invoked while this returns false; the engine keeps the FP32 conv on OpenCL).
+    /// <inheritdoc/>
+    public bool Fp16Im2colAvailable => false;
+    /// <inheritdoc/>
+    public void Im2colKNFp16(IGpuBuffer input, IGpuBuffer outputHalf,
+        int batch, int channels, int height, int width,
+        int kernelH, int kernelW, int strideH, int strideW, int padH, int padW, int dilationH, int dilationW)
+        => throw new System.NotSupportedException("FP16 im2col (Im2colKNFp16) is not yet ported to the OpenCL backend.");
+
     }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.HalfPrecision.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.HalfPrecision.cs
@@ -163,4 +163,14 @@ public sealed partial class VulkanBackend : IGpuHalfPrecisionBackend
         if (n <= 0) throw new ArgumentOutOfRangeException(nameof(n), "Dimensions must be positive.");
         if (k <= 0) throw new ArgumentOutOfRangeException(nameof(k), "Dimensions must be positive.");
     }
+    // #1650/#638 FP16 conv im2col — STUB pending the Vulkan kernel port (dispatch gates on Fp16Im2colAvailable
+    // so Im2colKNFp16 is never invoked while this returns false; the engine keeps the FP32 conv on Vulkan).
+    /// <inheritdoc/>
+    public bool Fp16Im2colAvailable => false;
+    /// <inheritdoc/>
+    public void Im2colKNFp16(IGpuBuffer input, IGpuBuffer outputHalf,
+        int batch, int channels, int height, int width,
+        int kernelH, int kernelW, int strideH, int strideW, int padH, int padW, int dilationH, int dilationW)
+        => throw new System.NotSupportedException("FP16 im2col (Im2colKNFp16) is not yet ported to the Vulkan backend.");
+
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.HalfPrecision.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.HalfPrecision.cs
@@ -206,6 +206,9 @@ public sealed partial class VulkanBackend : IGpuHalfPrecisionBackend
         if (strideW <= 0) throw new ArgumentOutOfRangeException(nameof(strideW), "Stride must be positive.");
         if (dilationH <= 0) throw new ArgumentOutOfRangeException(nameof(dilationH), "Dilation must be positive.");
         if (dilationW <= 0) throw new ArgumentOutOfRangeException(nameof(dilationW), "Dilation must be positive.");
+        // #671 review: reject negative padding to match the peer (WebGPU) contract and keep output geometry consistent.
+        if (padH < 0) throw new ArgumentOutOfRangeException(nameof(padH), "Padding must be non-negative.");
+        if (padW < 0) throw new ArgumentOutOfRangeException(nameof(padW), "Padding must be non-negative.");
 
         // HOST computes outH/outW (mirrors the CUDA launcher: the kernel receives them as args).
         int outH = (height + 2 * padH - ((kernelH - 1) * dilationH + 1)) / strideH + 1;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.HalfPrecision.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.HalfPrecision.cs
@@ -163,14 +163,79 @@ public sealed partial class VulkanBackend : IGpuHalfPrecisionBackend
         if (n <= 0) throw new ArgumentOutOfRangeException(nameof(n), "Dimensions must be positive.");
         if (k <= 0) throw new ArgumentOutOfRangeException(nameof(k), "Dimensions must be positive.");
     }
-    // #1650/#638 FP16 conv im2col — STUB pending the Vulkan kernel port (dispatch gates on Fp16Im2colAvailable
-    // so Im2colKNFp16 is never invoked while this returns false; the engine keeps the FP32 conv on Vulkan).
+    // #1650/#638 FP16 conv im2col — ported to Vulkan (1-D-flattened port of the VALIDATED CUDA im2col_kn_fp16hw).
+    // The col matrix is written in the packed-half layout (two halves per 32-bit word) that ConvertToFp16 produces
+    // and GemmFp16In32fOut consumes, so the conv becomes a plain NN GEMM out[outC,N] = weights[outC,K] · col[K,N].
+    // Dispatch gates on Fp16Im2colAvailable: false (no libshaderc, or the shader/pipeline failed to build) keeps
+    // the FP32 conv; Im2colKNFp16 is only invoked when this is true.
+    private const uint Im2colKnFp16PushInts = 14u * sizeof(uint);
+
     /// <inheritdoc/>
-    public bool Fp16Im2colAvailable => false;
+    /// <remarks>
+    /// True only when the <c>im2col_kn_fp16hw</c> GLSL compute shader actually compiled to SPIR-V AND its pipeline
+    /// built — <see cref="GetOrCreateGlslPipeline"/> returns non-null only in that case (and caches it, so the
+    /// pipeline is reused by the subsequent <see cref="Im2colKNFp16"/> dispatch). Stronger than the bare
+    /// libshaderc gate the GEMM uses (<see cref="SupportsHgemm"/> = <c>IsGlslCompilerAvailable</c>): it confirms
+    /// this specific shader is usable on the device. Returns false (no throw) when libshaderc is unavailable.
+    /// </remarks>
+    public bool Fp16Im2colAvailable
+    {
+        get
+        {
+            if (!IsGlslCompilerAvailable)
+                return false;
+            return GetOrCreateGlslPipeline(VulkanConvPoolKernels.Im2colKnFp16Hw, 2, Im2colKnFp16PushInts) is not null;
+        }
+    }
+
     /// <inheritdoc/>
     public void Im2colKNFp16(IGpuBuffer input, IGpuBuffer outputHalf,
         int batch, int channels, int height, int width,
         int kernelH, int kernelW, int strideH, int strideW, int padH, int padW, int dilationH, int dilationW)
-        => throw new System.NotSupportedException("FP16 im2col (Im2colKNFp16) is not yet ported to the Vulkan backend.");
+    {
+        EnsureInitialized();
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (outputHalf is null) throw new ArgumentNullException(nameof(outputHalf));
+        if (batch <= 0) throw new ArgumentOutOfRangeException(nameof(batch), "Dimensions must be positive.");
+        if (channels <= 0) throw new ArgumentOutOfRangeException(nameof(channels), "Dimensions must be positive.");
+        if (height <= 0) throw new ArgumentOutOfRangeException(nameof(height), "Dimensions must be positive.");
+        if (width <= 0) throw new ArgumentOutOfRangeException(nameof(width), "Dimensions must be positive.");
+        if (kernelH <= 0) throw new ArgumentOutOfRangeException(nameof(kernelH), "Dimensions must be positive.");
+        if (kernelW <= 0) throw new ArgumentOutOfRangeException(nameof(kernelW), "Dimensions must be positive.");
+        if (strideH <= 0) throw new ArgumentOutOfRangeException(nameof(strideH), "Stride must be positive.");
+        if (strideW <= 0) throw new ArgumentOutOfRangeException(nameof(strideW), "Stride must be positive.");
+        if (dilationH <= 0) throw new ArgumentOutOfRangeException(nameof(dilationH), "Dilation must be positive.");
+        if (dilationW <= 0) throw new ArgumentOutOfRangeException(nameof(dilationW), "Dilation must be positive.");
+
+        // HOST computes outH/outW (mirrors the CUDA launcher: the kernel receives them as args).
+        int outH = (height + 2 * padH - ((kernelH - 1) * dilationH + 1)) / strideH + 1;
+        int outW = (width + 2 * padW - ((kernelW - 1) * dilationW + 1)) / strideW + 1;
+        if (outH <= 0 || outW <= 0)
+            throw new ArgumentException(
+                $"Convolution output size is non-positive (outH={outH}, outW={outW}); check kernel/stride/pad/dilation vs input size.");
+
+        // N*K col elements packed two halves per 32-bit word ⇒ ceil(N*K/2) threads (one per word), exactly the
+        // per-word dispatch the FP16-native kernels use. Each thread writes one race-free packHalf2x16.
+        int n = batch * outH * outW;
+        int k = channels * kernelH * kernelW;
+        long total = (long)n * k;
+        int numWords = (int)((total + 1L) / 2L);
+
+        var pc = new uint[]
+        {
+            (uint)batch, (uint)channels, (uint)height, (uint)width,
+            (uint)kernelH, (uint)kernelW, (uint)strideH, (uint)strideW,
+            (uint)padH, (uint)padW, (uint)dilationH, (uint)dilationW, (uint)outH, (uint)outW,
+        };
+
+        // Reuses the validated conv-family dispatch helper (compile-or-cache the pipeline gated on libshaderc, bind
+        // the two SSBOs, push the 14 ints, launch ceil(N*K/2) threads). Capture-safe: no device alloc/free inside.
+        if (TryDispatchConvPoolGlsl(VulkanConvPoolKernels.Im2colKnFp16Hw, pc, numWords, input, outputHalf))
+            return;
+
+        // Reached only if libshaderc/pipeline became unavailable between the Fp16Im2colAvailable gate and here.
+        throw new NotSupportedException(
+            "Vulkan FP16 im2col requires libshaderc for runtime GLSL compilation, which is unavailable.");
+    }
 
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanConvPoolKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanConvPoolKernels.cs
@@ -330,6 +330,58 @@ void main() {
     atomicAdd(gradInput[((b * channels + c) * inDepth + id) * inHeight * inWidth + ih * inWidth + iw], grad);
 }";
 
+    // ---- FUSED im2col + FP32->FP16, TRANSPOSED [K,N] layout (#1650/#638). 1-D-flattened port of the VALIDATED
+    // CUDA im2col_kn_fp16hw (primitive relL2 0.028%). K = channels*kernelH*kernelW, N = batch*outH*outW; the col
+    // matrix is written so the conv becomes a plain NN GEMM out[outC,N] = weights[outC,K] · col[K,N] fed to
+    // GemmFp16In32fOut. The Vulkan backend stores FP16 packed TWO halves per 32-bit word (the layout
+    // VulkanBackend.ConvertToFp16 produces and GemmFp16In32fOut consumes via unpackHalf2x16), so — unlike the CUDA
+    // kernel which writes one ushort per thread — this kernel dispatches ONE THREAD PER OUTPUT WORD (ceil(N*K/2)
+    // threads, exactly the per-word pattern of the FP16-native kernels) and writes one packHalf2x16 per word. That
+    // makes the two-halves-share-a-word writes race-free (each word is written by exactly one thread). The two
+    // col elements a word holds are the consecutive linear indices t0=2*w (low/even half) and t1=2*w+1 (high/odd
+    // half); each is decoded + gathered with the SAME math as the CUDA reference (t = k*N + n). The high half of
+    // the final word when N*K is odd is padding (val=0) the GEMM never reads (it indexes strictly < K*N).
+    // packHalf2x16 is a core GLSL built-in (no float16/extension needed), matching GemmFp16In32fOut. outH/outW are
+    // host-computed and passed in (declaration-order push constants, as int — same convention as the conv family).
+    public const string Im2colKnFp16Hw = Header + @"
+layout(set=0, binding=0) readonly buffer B0 { float inp[]; };
+layout(set=0, binding=1) writeonly buffer B1 { uint outp[]; };
+layout(push_constant) uniform PC {
+    int batch; int channels; int height; int width;
+    int kernelH; int kernelW; int strideH; int strideW;
+    int padH; int padW; int dilationH; int dilationW; int outH; int outW;
+};
+float gather(int t, int N, int K) {
+    // EXACT math of the CUDA im2col_kn_fp16hw, per col element t in [0, N*K).
+    int n = t % N;     // output position (fastest — coalesced)
+    int k = t / N;     // unrolled (c,kh,kw) row
+    int b = n / (outH * outW);
+    int rem = n % (outH * outW);
+    int oh = rem / outW;
+    int ow = rem % outW;
+    int kw = k % kernelW;
+    int kh = (k / kernelW) % kernelH;
+    int c  = k / (kernelW * kernelH);
+    int ih = oh * strideH - padH + kh * dilationH;
+    int iw = ow * strideW - padW + kw * dilationW;
+    if (ih >= 0 && ih < height && iw >= 0 && iw < width)
+        return inp[((b * channels + c) * height + ih) * width + iw];
+    return 0.0;
+}
+void main() {
+    int N = batch * outH * outW;
+    int K = channels * kernelH * kernelW;
+    int total = N * K;
+    int w = int(gl_GlobalInvocationID.x);
+    int numWords = (total + 1) / 2;     // ceil — packed two halves per 32-bit word
+    if (w >= numWords) return;
+    int t0 = 2 * w;
+    int t1 = t0 + 1;
+    float v0 = gather(t0, N, K);
+    float v1 = (t1 < total) ? gather(t1, N, K) : 0.0;   // odd tail: high half is unread padding
+    outp[w] = packHalf2x16(vec2(v0, v1));
+}";
+
     // ---- Conv2D (forward, gather): one thread per output element ----
     public const string Conv2D = Header + @"
 layout(set=0, binding=0) buffer B0 { float inp[]; };

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.HalfPrecision.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.HalfPrecision.cs
@@ -159,13 +159,14 @@ public sealed partial class WebGpuBackend : IGpuHalfPrecisionBackend
             if (_im2colFp16Tried)
                 return _im2colFp16Available;
 
-            _im2colFp16Tried = true;
-
             if (!IsAvailable)
             {
-                _im2colFp16Available = false;
+                // #671 review: the backend isn't initialized yet — do NOT latch this miss (_im2colFp16Tried
+                // stays false) so a later query retries the pipeline build once IsAvailable becomes true.
                 return false;
             }
+
+            _im2colFp16Tried = true;
 
             try
             {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.HalfPrecision.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.HalfPrecision.cs
@@ -123,6 +123,16 @@ public sealed partial class WebGpuBackend : IGpuHalfPrecisionBackend
         if (n <= 0) throw new ArgumentOutOfRangeException(nameof(n), "Dimensions must be positive.");
         if (k <= 0) throw new ArgumentOutOfRangeException(nameof(k), "Dimensions must be positive.");
     }
+    // #1650/#638 FP16 conv im2col — STUB pending the WebGpu kernel port (dispatch gates on Fp16Im2colAvailable
+    // so Im2colKNFp16 is never invoked while this returns false; the engine keeps the FP32 conv on WebGpu).
+    /// <inheritdoc/>
+    public bool Fp16Im2colAvailable => false;
+    /// <inheritdoc/>
+    public void Im2colKNFp16(IGpuBuffer input, IGpuBuffer outputHalf,
+        int batch, int channels, int height, int width,
+        int kernelH, int kernelW, int strideH, int strideW, int padH, int padW, int dilationH, int dilationW)
+        => throw new System.NotSupportedException("FP16 im2col (Im2colKNFp16) is not yet ported to the WebGpu backend.");
+
 }
 
 #endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.HalfPrecision.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.HalfPrecision.cs
@@ -123,15 +123,130 @@ public sealed partial class WebGpuBackend : IGpuHalfPrecisionBackend
         if (n <= 0) throw new ArgumentOutOfRangeException(nameof(n), "Dimensions must be positive.");
         if (k <= 0) throw new ArgumentOutOfRangeException(nameof(k), "Dimensions must be positive.");
     }
-    // #1650/#638 FP16 conv im2col — STUB pending the WebGpu kernel port (dispatch gates on Fp16Im2colAvailable
-    // so Im2colKNFp16 is never invoked while this returns false; the engine keeps the FP32 conv on WebGpu).
+    // #1650/#638 FP16 conv im2col port (WebGpu): fused im2col + FP32→FP16 in the TRANSPOSED [K,N] layout
+    // so conv becomes out[outC,N] = weights[outC,K] · col[K,N] via GemmFp16In32fOut (the industry path).
+    // WebGPU models FP16 as f32 with a truncated 10-bit mantissa (no native 16-bit storage / shader-f16
+    // feature; see class remarks), so outputHalf is an ordinary f32 buffer of K*N elements whose values are
+    // the same truncated-f32 that ConvertToFp16 produces — exactly what GemmFp16In32fOut consumes. The WGSL
+    // kernel's fused f16_trunc helper is a byte-for-byte copy of fp16_convert's rounding, so the result is
+    // identical to a separate gather + ConvertToFp16.
+
+    private readonly object _im2colFp16Lock = new();
+    private bool _im2colFp16Tried;
+    private bool _im2colFp16Available;
+
     /// <inheritdoc/>
-    public bool Fp16Im2colAvailable => false;
+    /// <remarks>
+    /// Gated on the <c>im2col_kn_fp16hw</c> WGSL shader actually compiling and the compute pipeline being
+    /// created (lazily, on first query, cached). Unlike <see cref="SupportsHgemm"/> (which only needs device
+    /// availability because the FP16 GEMM reuses the always-present f32 GEMM), this kernel is its own shader:
+    /// gating on a successful pipeline build means a device/driver that rejects it degrades gracefully to the
+    /// FP32 conv instead of throwing. The FP16 model is truncated-f32 (no <c>shader-f16</c> feature), so this
+    /// is expected to compile on every WebGPU device.
+    /// </remarks>
+    public bool Fp16Im2colAvailable => EnsureIm2colFp16Pipeline();
+
+    /// <summary>Lazily builds and caches the <c>im2col_kn_fp16hw</c> pipeline. Non-fatal on failure
+    /// (returns false ⇒ the engine keeps the FP32 conv on WebGpu); a broken/unsupported shader never
+    /// crashes the conv path.</summary>
+    private bool EnsureIm2colFp16Pipeline()
+    {
+        if (_im2colFp16Tried)
+            return _im2colFp16Available;
+
+        lock (_im2colFp16Lock)
+        {
+            if (_im2colFp16Tried)
+                return _im2colFp16Available;
+
+            _im2colFp16Tried = true;
+
+            if (!IsAvailable)
+            {
+                _im2colFp16Available = false;
+                return false;
+            }
+
+            try
+            {
+                // Build (and cache in _pipelineCache) the compute pipeline. Throws if the WGSL shader
+                // fails to compile or the pipeline cannot be created on this device.
+                GetOrCreatePipelineAsync("Im2colKnFp16", WebGpuKernels.Im2colKnFp16Source, "im2col_kn_fp16hw")
+                    .GetAwaiter().GetResult();
+                _im2colFp16Available = true;
+            }
+            catch (Exception)
+            {
+                // Non-fatal: without the kernel the FP16 conv stays on the FP32 path.
+                _im2colFp16Available = false;
+            }
+
+            return _im2colFp16Available;
+        }
+    }
+
     /// <inheritdoc/>
     public void Im2colKNFp16(IGpuBuffer input, IGpuBuffer outputHalf,
         int batch, int channels, int height, int width,
         int kernelH, int kernelW, int strideH, int strideW, int padH, int padW, int dilationH, int dilationW)
-        => throw new System.NotSupportedException("FP16 im2col (Im2colKNFp16) is not yet ported to the WebGpu backend.");
+    {
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (outputHalf is null) throw new ArgumentNullException(nameof(outputHalf));
+        if (batch <= 0) throw new ArgumentOutOfRangeException(nameof(batch), "Dimensions must be positive.");
+        if (channels <= 0) throw new ArgumentOutOfRangeException(nameof(channels), "Dimensions must be positive.");
+        if (height <= 0) throw new ArgumentOutOfRangeException(nameof(height), "Dimensions must be positive.");
+        if (width <= 0) throw new ArgumentOutOfRangeException(nameof(width), "Dimensions must be positive.");
+        if (kernelH <= 0) throw new ArgumentOutOfRangeException(nameof(kernelH), "Kernel size must be positive.");
+        if (kernelW <= 0) throw new ArgumentOutOfRangeException(nameof(kernelW), "Kernel size must be positive.");
+        if (strideH <= 0) throw new ArgumentOutOfRangeException(nameof(strideH), "Stride must be positive.");
+        if (strideW <= 0) throw new ArgumentOutOfRangeException(nameof(strideW), "Stride must be positive.");
+        if (padH < 0) throw new ArgumentOutOfRangeException(nameof(padH), "Padding must be non-negative.");
+        if (padW < 0) throw new ArgumentOutOfRangeException(nameof(padW), "Padding must be non-negative.");
+        if (dilationH <= 0) throw new ArgumentOutOfRangeException(nameof(dilationH), "Dilation must be positive.");
+        if (dilationW <= 0) throw new ArgumentOutOfRangeException(nameof(dilationW), "Dilation must be positive.");
+
+        // HOST computes the output spatial dims (same formula on every backend) and passes them in.
+        int outH = (height + 2 * padH - ((kernelH - 1) * dilationH + 1)) / strideH + 1;
+        int outW = (width + 2 * padW - ((kernelW - 1) * dilationW + 1)) / strideW + 1;
+        if (outH <= 0 || outW <= 0)
+            throw new ArgumentException(
+                $"Computed output dims are non-positive (outH={outH}, outW={outW}); kernel/stride/pad/dilation " +
+                "exceed the input size.");
+
+        long n = (long)batch * outH * outW;      // N = batch*outH*outW
+        long k = (long)channels * kernelH * kernelW; // K = channels*kernelH*kernelW
+        long total = n * k;                       // one invocation per col element
+        if (total > int.MaxValue)
+            throw new ArgumentOutOfRangeException(nameof(batch),
+                $"im2col element count N*K = {total} exceeds Int32.MaxValue.");
+        if (total <= 0) return;
+
+        // Im2colParams uniform: 14 u32 fields packed as a flat float[] (same convention as ConvParams /
+        // MakeConvUniforms — all-scalar u32 members are tightly 4-byte packed in a WGSL uniform struct).
+        // Padded to 16 floats (64 bytes) so the allocated uniform buffer is at least the 16-byte-rounded
+        // struct size (mirrors MakeDeformConvUniforms padding).
+        var uniforms = new float[16];
+        uniforms[0] = BitConverter.Int32BitsToSingle(batch);
+        uniforms[1] = BitConverter.Int32BitsToSingle(channels);
+        uniforms[2] = BitConverter.Int32BitsToSingle(height);
+        uniforms[3] = BitConverter.Int32BitsToSingle(width);
+        uniforms[4] = BitConverter.Int32BitsToSingle(kernelH);
+        uniforms[5] = BitConverter.Int32BitsToSingle(kernelW);
+        uniforms[6] = BitConverter.Int32BitsToSingle(strideH);
+        uniforms[7] = BitConverter.Int32BitsToSingle(strideW);
+        uniforms[8] = BitConverter.Int32BitsToSingle(padH);
+        uniforms[9] = BitConverter.Int32BitsToSingle(padW);
+        uniforms[10] = BitConverter.Int32BitsToSingle(dilationH);
+        uniforms[11] = BitConverter.Int32BitsToSingle(dilationW);
+        uniforms[12] = BitConverter.Int32BitsToSingle(outH);
+        uniforms[13] = BitConverter.Int32BitsToSingle(outW);
+        // uniforms[14], [15] = 0 (padding to 16 floats / 64 bytes)
+
+        // One thread per col element (t in [0, N*K)); workgroup_size(256), dispatch = ceil(N*K/256).
+        // outputHalf is the truncated-f32 half buffer GemmFp16In32fOut consumes.
+        Dispatch2BufferAsync("Im2colKnFp16", WebGpuKernels.Im2colKnFp16Source, "im2col_kn_fp16hw",
+            input, outputHalf, uniforms, (int)total).GetAwaiter().GetResult();
+    }
 
 }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuKernels.cs
@@ -8065,6 +8065,104 @@ fn fp16_convert(@builtin(global_invocation_id) gid: vec3<u32>) {
 ";
 
     /// <summary>
+    /// FUSED im2col + FP32→FP16, writing the column matrix in the TRANSPOSED [K, N] layout
+    /// (K = channels·kernelH·kernelW, N = batch·outH·outW) so a conv becomes a plain NN GEMM
+    /// <c>out[outC, N] = weights[outC, K] · col[K, N]</c> via <see cref="GemmFp16In32fOut"/> — the
+    /// industry FP16-conv path (#1650/#638). WebGPU counterpart of the validated CUDA
+    /// <c>im2col_kn_fp16hw</c> kernel: one invocation per col element (t in [0, N·K)), identical index
+    /// math. WebGPU has no native 16-bit storage by default (the optional <c>shader-f16</c> feature is
+    /// not used here), so this backend models FP16 as f32 with a truncated 10-bit mantissa — exactly the
+    /// layout <see cref="Fp16ConvertSource"/>/<c>ConvertToFp16</c> produces and the FP16 GEMM consumes.
+    /// The fused <c>f16_trunc</c> helper below is a byte-for-byte copy of the <c>fp16_convert</c> (dir 0)
+    /// rounding so the output is identical to gather-then-ConvertToFp16. Out-of-bounds taps store +0.0.
+    /// Index math is done in u32/i32; the bounds check is in i32; the stored value is truncated f32.
+    /// </summary>
+    public const string Im2colKnFp16Source = @"
+@group(0) @binding(0) var<storage, read> input: array<f32>;
+@group(0) @binding(1) var<storage, read_write> output: array<f32>;
+
+struct Im2colParams {
+    batch: u32,
+    channels: u32,
+    height: u32,
+    width: u32,
+    kernel_h: u32,
+    kernel_w: u32,
+    stride_h: u32,
+    stride_w: u32,
+    pad_h: u32,
+    pad_w: u32,
+    dilation_h: u32,
+    dilation_w: u32,
+    out_h: u32,
+    out_w: u32,
+}
+@group(0) @binding(2) var<uniform> params: Im2colParams;
+
+// FP32 -> FP16-precision (truncated-f32) emulation: byte-identical to fp16_convert (direction 0).
+fn f16_trunc(val: f32) -> f32 {
+    let bits = bitcast<u32>(val);
+    let sign = (bits >> 31u) & 1u;
+    let exp_bits = (bits >> 23u) & 0xFFu;
+    let mantissa = bits & 0x7FFFFFu;
+    if (exp_bits == 0xFFu) {
+        // Inf/NaN: preserve
+        return val;
+    }
+    let exp_val: i32 = i32(exp_bits) - 127;
+    if (exp_val < -14) {
+        // Underflow to zero (FP16 subnormal range)
+        return select(-0.0, 0.0, sign == 0u);
+    }
+    if (exp_val > 15) {
+        // Overflow to infinity
+        let inf_bits = (sign << 31u) | 0x7F800000u;
+        return bitcast<f32>(inf_bits);
+    }
+    let truncated_mantissa = mantissa & 0x7FE000u; // mask off bottom 13 bits
+    let result_bits = (sign << 31u) | (exp_bits << 23u) | truncated_mantissa;
+    return bitcast<f32>(result_bits);
+}
+
+@compute @workgroup_size(256)
+fn im2col_kn_fp16hw(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let t = gid.x;
+    let out_h = params.out_h;
+    let out_w = params.out_w;
+    let n_total = params.batch * out_h * out_w;       // N
+    let k_total = params.channels * params.kernel_h * params.kernel_w; // K
+    if (t >= n_total * k_total) { return; }
+
+    // t = k*N + n  (TRANSPOSED [K, N] layout)
+    let n = t % n_total;
+    let k = t / n_total;
+
+    // Decode n -> (b, oh, ow)
+    let hw = out_h * out_w;
+    let b = n / hw;
+    let rem = n % hw;
+    let oh = rem / out_w;
+    let ow = rem % out_w;
+
+    // Decode k -> (c, kh, kw)
+    let kw = k % params.kernel_w;
+    let kh = (k / params.kernel_w) % params.kernel_h;
+    let c = k / (params.kernel_w * params.kernel_h);
+
+    // Source pixel (signed: padding can push it out of bounds)
+    let ih = i32(oh * params.stride_h) - i32(params.pad_h) + i32(kh * params.dilation_h);
+    let iw = i32(ow * params.stride_w) - i32(params.pad_w) + i32(kw * params.dilation_w);
+
+    var val: f32 = 0.0;
+    if (ih >= 0 && ih < i32(params.height) && iw >= 0 && iw < i32(params.width)) {
+        let in_idx = ((b * params.channels + c) * params.height + u32(ih)) * params.width + u32(iw);
+        val = input[in_idx];
+    }
+    output[t] = f16_trunc(val);
+}
+";
+
+    /// <summary>
     /// LSTM backward sequence kernel: computes gate gradients for one timestep.
     /// Buffers: gates_cache, grad_h_next, grad_c_next, grad_gates (output).
     /// </summary>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuKernels.cs
@@ -8424,7 +8424,8 @@ fn reduce_partial_sums(@builtin(local_invocation_id) lid: vec3<u32>) {
                GatedActivationSource + SoftmaxVariantsSource +
                ShapeOpsSource + ReductionExtSource +
                StridedOpsSource +
-               Pool1DSource + BilinearUpsample2DSource;
+               Pool1DSource + BilinearUpsample2DSource +
+               Im2colKnFp16Source; // #671: include the FP16 im2col shader in the combined-module pipeline source
     }
 
     // ============================================================================

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -397,6 +397,96 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             System.Threading.Interlocked.Increment(ref _evictionSuspendDepth); // clamp at 0
     }
 
+    // ───────────────────────────────────────────────────────────────────────────────────────────
+    // #1650 PUBLIC inference CUDA-graph capture API. ForwardUNet (the diffusion eager GPU forward to
+    // capture) lives in AiDotNet, a separate assembly that cannot reach the internal capture-path
+    // machinery — so expose a minimal, safe public surface. A consumer:
+    //   1. warms up its forward eagerly a few times (lazy allocs / autotune settle),
+    //   2. enters a resident capture scope (eviction suspended for the graph's lifetime, ResidentStepActive
+    //      on so GPU ops use stable resident buffers, inference-capture on so resident in-place ops engage),
+    //   3. refreshes its stable input buffers in place, captures the forward, then replays it per step,
+    //   4. disposes the scope when done (resumes eviction, frees the graph).
+    // ───────────────────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>True when this engine is backed by a CUDA backend that can capture/replay CUDA graphs.</summary>
+    public bool SupportsInferenceGraphCapture => GetBackend() is Engines.DirectGpu.CUDA.CudaBackend cb && cb.IsAvailable;
+
+    /// <summary>Records the GPU kernel launches issued by <paramref name="forward"/> into a CUDA graph and
+    /// returns a replayable handle (IntPtr.Zero on failure / a non-capturable op — caller falls back to eager).
+    /// Must be called inside a <see cref="EnterResidentCaptureScope"/> so the forward runs resident (capturable).</summary>
+    public IntPtr CaptureGpuGraph(Action forward)
+        => GetBackend() is Engines.DirectGpu.CUDA.CudaBackend cb ? cb.CaptureGraph(forward) : System.IntPtr.Zero;
+
+    /// <summary>Replays a graph captured by <see cref="CaptureGpuGraph"/> as a single cuGraphLaunch. Refresh
+    /// input-buffer CONTENTS (via <see cref="RefreshResidentInputInPlace"/>) before calling to feed new data.</summary>
+    public void LaunchGpuGraph(System.IntPtr graphExec)
+    {
+        if (graphExec != System.IntPtr.Zero && GetBackend() is Engines.DirectGpu.CUDA.CudaBackend cb)
+            cb.LaunchCapturedGraph(graphExec);
+    }
+
+    /// <summary>Frees a captured graph handle.</summary>
+    public void DestroyGpuGraph(System.IntPtr graphExec)
+    {
+        if (graphExec != System.IntPtr.Zero && GetBackend() is Engines.DirectGpu.CUDA.CudaBackend cb)
+            cb.DestroyCapturedGraph(graphExec);
+    }
+
+    /// <summary>Enters the resident capture path: suspends activation eviction (so resident intermediates a
+    /// captured graph references survive replay), marks ResidentStepActive (GPU ops bind stable resident
+    /// buffers) and inference-capture (resident in-place ops engage). The returned scope reverses all three on
+    /// Dispose — keep it alive for the captured graph's whole lifetime (dispose when the graph is no longer
+    /// replayed). Returns null on a non-CUDA engine.</summary>
+    public IDisposable? EnterResidentCaptureScope()
+    {
+        if (GetBackend() is not Engines.DirectGpu.CUDA.CudaBackend) return null;
+        SuspendActivationEviction();
+        BeginInferenceCapture();
+        System.Threading.Interlocked.Increment(ref _capturePathDepth);
+        return new ResidentCaptureScope(this);
+    }
+
+    private sealed class ResidentCaptureScope : IDisposable
+    {
+        private DirectGpuTensorEngine? _e;
+        public ResidentCaptureScope(DirectGpuTensorEngine e) => _e = e;
+        public void Dispose()
+        {
+            var e = System.Threading.Interlocked.Exchange(ref _e, null);
+            if (e is null) return;
+            System.Threading.Interlocked.Decrement(ref e._capturePathDepth);
+            e.EndInferenceCapture();
+            e.ResumeActivationEviction();
+        }
+    }
+
+    /// <summary>Uploads <paramref name="t"/>'s current host data into its EXISTING resident GPU buffer in place
+    /// (stable pointer) so a replayed graph — which reads the address captured at record time — sees fresh data.
+    /// No-op if the tensor has no resident buffer on this engine. float only.</summary>
+    public void RefreshResidentInputInPlace<T>(Tensor<T> t)
+    {
+        if (typeof(T) != typeof(float) || t is null) return;
+        if (GetBackend() is not Engines.DirectGpu.CUDA.CudaBackend cb) return;
+        if (t._gpuBuffer is not { } buf || !ReferenceEquals(t._gpuBackend, cb) || buf.Handle == System.IntPtr.Zero) return;
+        var data = t.GetDataArray();
+        if (buf.Size < data.Length) return;
+        cb.UploadBufferInPlace((float[])(object)data, buf);
+        t._gpuBufferVersion = t.Version;
+    }
+
+    /// <summary>Downloads <paramref name="t"/>'s resident GPU buffer (which a replayed graph just wrote) into a
+    /// fresh host array. Needed for a graph OUTPUT: its deferred materializer caches after the first read, so a
+    /// plain re-read returns the capture-step's stale values; this forces a fresh DtoH each replay. Returns null
+    /// if the tensor has no resident buffer on this engine. float only.</summary>
+    public float[]? DownloadResidentBuffer<T>(Tensor<T> t)
+    {
+        if (typeof(T) != typeof(float) || t is null) return null;
+        if (GetBackend() is not Engines.DirectGpu.CUDA.CudaBackend cb) return null;
+        var buf = t._gpuBuffer;
+        if (buf is null || !ReferenceEquals(t._gpuBackend, cb) || buf.Handle == System.IntPtr.Zero) return null;
+        return cb.DownloadBuffer(buf);
+    }
+
     /// <summary>
     /// Per-training-step hook: bound cross-step VRAM growth from dereferenced-but-not-yet-finalized
     /// transient activation buffers by forcing a finalizer-backed reclaim under memory pressure.
@@ -404,7 +494,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// </summary>
     internal void ReclaimGpuMemoryUnderPressure()
     {
-        if (TryGetBackend(out var backend) && backend is DirectGpu.CUDA.CudaBackend cudaBackend)
+        if (TryGetBackend(out var backend) && backend is Engines.DirectGpu.CUDA.CudaBackend cudaBackend)
             cudaBackend.ReclaimUnderPressure();
     }
 
@@ -1426,7 +1516,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // the pipeline (the earlier full-stream-sync fix was correct but impractically slow).
         if (evicted.Count > 0)
         {
-            if (backend is DirectGpu.CUDA.CudaBackend cudaBackend)
+            if (backend is Engines.DirectGpu.CUDA.CudaBackend cudaBackend)
             {
                 foreach (var entry in evicted)
                     cudaBackend.FreeBufferDeferred(entry.Buffer);
@@ -1479,7 +1569,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             if (!_activationCache.TryGetValue(key, out var e)) return false;
             if (e.IsFp16) return true;
-            if (e.Backend is not DirectGpu.CUDA.CudaBackend cuda) return false;
+            if (e.Backend is not Engines.DirectGpu.CUDA.CudaBackend cuda) return false;
             // Only compress genuine FP32 buffers (elementCount*4 bytes); skip anything unexpected.
             if (e.Buffer.SizeInBytes != (long)elementCount * sizeof(float)) return false;
             IGpuBuffer fp16;
@@ -1497,7 +1587,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             System.Threading.Interlocked.Add(ref _currentActivationCacheBytes, fp16.SizeInBytes - e.Buffer.SizeInBytes);
             old = e;
         }
-        if (old is not null && old.Backend is DirectGpu.CUDA.CudaBackend c) c.FreeBufferDeferred(old.Buffer);
+        if (old is not null && old.Backend is Engines.DirectGpu.CUDA.CudaBackend c) c.FreeBufferDeferred(old.Buffer);
         else old?.Dispose();
         return true;
     }
@@ -1513,7 +1603,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     private bool TryTransientUpcastFp16(object key, IDirectGpuBackend backend, out OwnedBuffer transient)
     {
         transient = default;
-        if (backend is not DirectGpu.CUDA.CudaBackend cuda) return false;
+        if (backend is not Engines.DirectGpu.CUDA.CudaBackend cuda) return false;
         IGpuBuffer halfBuf; int elems;
         lock (_activationCacheLock)
         {
@@ -1539,7 +1629,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             if (!_activationCache.TryGetValue(key, out var e)) return false;
             if (!e.IsFp16) return true;
-            if (e.Backend is not DirectGpu.CUDA.CudaBackend cuda) return false;
+            if (e.Backend is not Engines.DirectGpu.CUDA.CudaBackend cuda) return false;
             IGpuBuffer fp32;
             try
             {
@@ -1552,7 +1642,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             System.Threading.Interlocked.Add(ref _currentActivationCacheBytes, fp32.SizeInBytes - e.Buffer.SizeInBytes);
             old = e;
         }
-        if (old is not null && old.Backend is DirectGpu.CUDA.CudaBackend c) c.FreeBufferDeferred(old.Buffer);
+        if (old is not null && old.Backend is Engines.DirectGpu.CUDA.CudaBackend c) c.FreeBufferDeferred(old.Buffer);
         else old?.Dispose();
         return true;
     }
@@ -1602,7 +1692,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // equivalent. Every other backend takes the immediate, equally-correct e.Dispose() (no leak, no
         // cross-backend semantic difference — just a synchronous free). This asymmetry is intentional, not a
         // missing feature; a deferred-free abstraction across all backends is tracked as a follow-up.
-        if (e.Backend is DirectGpu.CUDA.CudaBackend c) c.FreeBufferDeferred(e.Buffer);
+        if (e.Backend is Engines.DirectGpu.CUDA.CudaBackend c) c.FreeBufferDeferred(e.Buffer);
         else e.Dispose();
         return true;
     }
@@ -2172,7 +2262,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     internal bool TryLandResidentHalf(Tensor<Half> r, Tensor<Half> o)
     {
         if (r is null || o is null || o.Length == 0 || r.Length != o.Length) return false;
-        if (!TryGetBackend(out var backend) || backend is not DirectGpu.CUDA.CudaBackend cb) return false;
+        if (!TryGetBackend(out var backend) || backend is not Engines.DirectGpu.CUDA.CudaBackend cb) return false;
         if (!TryGetResidentFp16Buffer(r, backend, out var rBuf) || rBuf is null) return false;
         var oKey = o.DataVector.GetBackingArrayUnsafe();
         if (oKey is null) return false;
@@ -3491,7 +3581,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     {
         if (_onesBufferCache.TryGetValue(size, out var existing) && existing.Handle != System.IntPtr.Zero) return existing;
         // Allocate+fill only when NOT capturing (cuMemsetD32 aborts capture). The pre-pass populates the cache.
-        if (backend is DirectGpu.CUDA.CudaBackend cb && cb.IsStreamCapturing()) return null;
+        if (backend is Engines.DirectGpu.CUDA.CudaBackend cb && cb.IsStreamCapturing()) return null;
         try
         {
             var buf = backend.AllocateBuffer(size);
@@ -3615,7 +3705,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     internal bool TryBatchedMatMulResidentInto<T>(Tensor<T> output, Tensor<T> a, Tensor<T> b)
     {
         if (!ResidentStepActive || Gpu.AutocastScope.IsEnabled || typeof(T) != typeof(float)) return false;
-        if (!TryGetBackend(out var backend) || backend is not DirectGpu.CUDA.CudaBackend cb) return false;
+        if (!TryGetBackend(out var backend) || backend is not Engines.DirectGpu.CUDA.CudaBackend cb) return false;
         int rank = a.Rank;
         // ND batched: equal rank ≥ 3, contiguous, matching leading (batch) dims, inner dims compatible (K).
         if (rank < 3 || b.Rank != rank || !a.IsContiguous || !b.IsContiguous) return false;
@@ -3738,7 +3828,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             var gradBuf = GetOrCreateResidentBuffer(backend, gradTable, vocabSize * embeddingDim);
             if (gradBuf.Handle == System.IntPtr.Zero || gradBuf.Size < (long)vocabSize * embeddingDim) return null;
             // Capturable zero (cuMemsetD8Async); backend.Fill (cuMemsetD32) aborts capture (906). Scatter-ADD needs 0-init.
-            if (backend is DirectGpu.CUDA.CudaBackend cudaEmbBe)
+            if (backend is Engines.DirectGpu.CUDA.CudaBackend cudaEmbBe)
                 cudaEmbBe.MemsetBuffer(gradBuf, 0, (long)vocabSize * embeddingDim * sizeof(float));
             else backend.Fill(gradBuf, 0f, vocabSize * embeddingDim);
             backend.EmbeddingBackward(gR, _cachedEmbIndexBuffer, gradBuf, numIndices, embeddingDim, vocabSize);
@@ -5311,7 +5401,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (activationParams is not null || bias is null || weights.Rank != 2 || !input.IsContiguous) return false;
         if (activation != FusedActivationType.None && activation != FusedActivationType.ReLU && activation != FusedActivationType.GELU)
             return false;
-        if (!TryGetBackend(out var backend) || backend is not DirectGpu.CUDA.CudaBackend cb) return false;
+        if (!TryGetBackend(out var backend) || backend is not Engines.DirectGpu.CUDA.CudaBackend cb) return false;
         int K = weights.Shape._dims[0];   // input features
         int N = weights.Shape._dims[1];   // output features
         if (K <= 0 || N <= 0 || input.Length % K != 0) return false;
@@ -10282,7 +10372,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 // FP16 Half-native backward: read IsFp16 grad + softmax output directly, FP16-native softmax
                 // backward (Half grad out), store Half. Parity-equivalent to softmax_backward (same math).
                 if (typeof(T) == typeof(Half) && s_fp16FwdStore
-                    && backend is DirectGpu.CUDA.CudaBackend cbS && cbS.SupportsFp16NativeOps)
+                    && backend is Engines.DirectGpu.CUDA.CudaBackend cbS && cbS.SupportsFp16NativeOps)
                 {
                     IGpuBuffer? hgOwned = null, hoOwned = null, hOut = null;
                     bool ok = false;
@@ -10990,7 +11080,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             // backward (gradInput) + grad-params (gradGamma/gradBeta), store Half. mean/invVar stay FP32 (tiny,
             // one per row) exactly like the float path. Parity-equivalent to layernorm_backward + grad_params.
             if (typeof(T) == typeof(Half) && s_fp16FwdStore
-                && backend is DirectGpu.CUDA.CudaBackend cbL && cbL.SupportsFp16NativeOps)
+                && backend is Engines.DirectGpu.CUDA.CudaBackend cbL && cbL.SupportsFp16NativeOps)
             {
                 IGpuBuffer? hgOwned = null, hiOwned = null, hgamOwned = null;
                 IGpuBuffer? meanBuf = null, invVarBuf = null, giOut = null, ggOut = null, gbOut = null;
@@ -15292,7 +15382,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // FP16 Half-resident store (keystone-enabled): the transformer residual add. Read both IsFp16 inputs
         // directly, FP16-native add (FP32 accumulate, Half out), store Half — keeps the residual stream Half.
         if (typeof(T) == typeof(Half) && s_fp16FwdStore && TryGetBackend(out var bkA)
-            && bkA is DirectGpu.CUDA.CudaBackend cbA && cbA.SupportsFp16NativeOps)
+            && bkA is Engines.DirectGpu.CUDA.CudaBackend cbA && cbA.SupportsFp16NativeOps)
         {
             IGpuBuffer? hAOwned = null, hBOwned = null, hOut = null;
             bool ok = false;
@@ -15478,7 +15568,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (typeof(T) == typeof(float))
         {
             if (System.Environment.GetEnvironmentVariable("AIDOTNET_GRAPH_CAPTURE_DEBUG") == "1"
-                && TryGetBackend(out var dbgB) && dbgB is DirectGpu.CUDA.CudaBackend dbgCb && dbgCb.IsStreamCapturing())
+                && TryGetBackend(out var dbgB) && dbgB is Engines.DirectGpu.CUDA.CudaBackend dbgCb && dbgCb.IsStreamCapturing())
                 AliasDiag($"Negate DURING-CAPTURE residentStep={ResidentStepActive} evictSusp={EvictionSuspended} capDepth>0");
             var resOut = new Tensor<T>(new T[tensor.Length], tensor.Shape._dims);
             if (TryUnaryResidentInto(resOut, tensor, static (be, i, o, n) => be.Negate(i, o, n), "Negate"))
@@ -15622,7 +15712,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 // FP16 Half-native backward: read IsFp16 grad + input directly, FP16-native ReLU backward
                 // (Half grad out), store Half. Parity-equivalent to relu_backward.
                 if (typeof(T) == typeof(Half) && s_fp16FwdStore
-                    && backend is DirectGpu.CUDA.CudaBackend cbR && cbR.SupportsFp16NativeOps)
+                    && backend is Engines.DirectGpu.CUDA.CudaBackend cbR && cbR.SupportsFp16NativeOps)
                 {
                     IGpuBuffer? hgOwned = null, hiOwned = null, hOut = null;
                     bool ok = false;
@@ -15748,7 +15838,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 // (Half grad out), store Half — keeps the backward signal Half (no up-cast). Parity-equivalent
                 // to the FP32 gelu_backward kernel (same formula).
                 if (typeof(T) == typeof(Half) && s_fp16FwdStore
-                    && backend is DirectGpu.CUDA.CudaBackend cbG && cbG.SupportsFp16NativeOps)
+                    && backend is Engines.DirectGpu.CUDA.CudaBackend cbG && cbG.SupportsFp16NativeOps)
                 {
                     IGpuBuffer? hgOwned = null, hiOwned = null, hOut = null;
                     bool ok = false;
@@ -18041,7 +18131,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // FP16 Half-resident store (keystone-enabled): read IsFp16 input directly, FP16-native ReLU (Half out),
         // store Half — keeps the activation Half end-to-end. Gated like the other forward stores.
         if (typeof(T) == typeof(Half) && s_fp16FwdStore && TryGetBackend(out var bkR)
-            && bkR is DirectGpu.CUDA.CudaBackend cbR && cbR.SupportsFp16NativeOps)
+            && bkR is Engines.DirectGpu.CUDA.CudaBackend cbR && cbR.SupportsFp16NativeOps)
         {
             IGpuBuffer? hInOwned = null, hOut = null;
             bool ok = false;
@@ -18088,7 +18178,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // (Half output, FP32-in-register math), store the Half output as an IsFp16 entry — keeps the activation
         // Half end-to-end so the next op reads Half (no up-cast/re-inflate). Gated like the other forward stores.
         if (typeof(T) == typeof(Half) && s_fp16FwdStore && TryGetBackend(out var bkG)
-            && bkG is DirectGpu.CUDA.CudaBackend cbG && cbG.SupportsFp16NativeOps)
+            && bkG is Engines.DirectGpu.CUDA.CudaBackend cbG && cbG.SupportsFp16NativeOps)
         {
             IGpuBuffer? hInOwned = null, hOut = null;
             bool ok = false;
@@ -18606,7 +18696,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                     for (int d = 0; d < axis; d++) outerCount *= destination.Shape._dims[d];
                     int axisSize = destination.Shape._dims[axis];
                     var dstBuf = GetOrCreateResidentBuffer(backend, destination, destination.Length);
-                    if (backend is DirectGpu.CUDA.CudaBackend cudaBe
+                    if (backend is Engines.DirectGpu.CUDA.CudaBackend cudaBe
                         && dstBuf.Handle != System.IntPtr.Zero && dstBuf.Size >= destination.Length)
                     {
                         // Capturable zero (cuMemsetD8Async) — backend.Fill is cuMemsetD32 which aborts capture (906).

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -609,6 +609,145 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         return scratch;
     }
 
+    // ============================================================================================================
+    // #1650/#638 #3 FP16 ACTIVATIONS END-TO-END (opt-in AIDOTNET_FP16_ACT, default OFF until validated): keep the
+    // resident UNet activations in FP16 BETWEEN ops so no FP32↔FP16 convert happens at op boundaries (the
+    // conversions are what cap the im2col path). Strictly ADDITIVE: when OFF, every path below is inert and the
+    // validated FP32 resident path is bit-identical. A resident buffer can be TAGGED as holding FP16 data (count
+    // halfs, packed in the low 2·count bytes of an over-allocated float buffer). FP16-aware ops (conv/groupnorm/
+    // add) read the raw FP16 via TryFp16ResidentInput; every OTHER op up-converts at the gap through the input-
+    // fetch helpers. Capture-safe: all FP16 / convert buffers are CACHED stable scratch (pre-allocated in the
+    // pre-residency pass, reused on replay).
+    private static readonly bool s_fp16ActEnv =
+        System.Environment.GetEnvironmentVariable("AIDOTNET_FP16_ACT") == "1";
+    /// <summary>#3: runtime override for the FP16-activations gate (used by the validation test). Null ⇒ env default.</summary>
+    internal static bool? Fp16ActOverride;
+    private static bool Fp16ActEnabled => Fp16ActOverride ?? s_fp16ActEnv;
+
+    // backing-array → element count: presence marks the tensor's resident buffer as holding FP16 (count halfs).
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<object, int> _fp16ResidentArrays = new();
+
+    /// <summary>Mark a tensor GPU-resident on an FP16 buffer (count halfs): tags the backing array FP16 and
+    /// registers a downconvert (FP16→FP32) host materializer so CPU reads stay correct.</summary>
+    internal void BindResidentBufferFp16<T>(Tensor<T> t, IGpuBuffer buf, IDirectGpuBackend backend, int elementCount)
+    {
+        t._gpuBuffer = buf; t._gpuBackend = backend; t._gpuBufferVersion = t.Version;
+        var arr = t.DataVector.GetBackingArrayUnsafe();
+        if (arr is null) return;
+        _fp16ResidentArrays[arr] = elementCount;
+        var capBuf = buf; var capBackend = backend; var capCount = elementCount;
+        Helpers.DeferredArrayMaterializer.Register(arr, a =>
+        {
+            using var f32 = AllocateOutputBuffer(capBackend, capCount); // post-capture host read: alloc is fine
+            capBackend.ConvertToFp32(capBuf, f32.Buffer, capCount);
+            float[] f = capBackend.DownloadBuffer(f32.Buffer);
+            var conv = DirectGpuEngine.FromFloatArray<T>(f);
+            System.Array.Copy(conv, (T[])a, System.Math.Min(conv.Length, ((T[])a).Length));
+        });
+    }
+
+    /// <summary>True when <paramref name="t"/>'s resident buffer currently holds FP16 data (and FP16-act is on).</summary>
+    internal bool IsFp16Resident<T>(Tensor<T> t)
+    {
+        if (!Fp16ActEnabled) return false;
+        var arr = t.DataVector.GetBackingArrayUnsafe();
+        return arr is not null && _fp16ResidentArrays.ContainsKey(arr);
+    }
+
+    /// <summary>The FP16 resident buffer (+ element count) for an FP16-tagged input, or null. Callers narrow with
+    /// <c>is not null</c>. Read directly (no re-upload from the stale host array).</summary>
+    internal IGpuBuffer? TryFp16ResidentInput<T>(Tensor<T> t, out int count)
+    {
+        count = 0;
+        if (!Fp16ActEnabled) return null;
+        var arr = t.DataVector.GetBackingArrayUnsafe();
+        if (arr is null || !_fp16ResidentArrays.TryGetValue(arr, out count)) return null;
+        if (t._gpuBuffer is null || t._gpuBuffer.Handle == System.IntPtr.Zero) return null;
+        return t._gpuBuffer;
+    }
+
+    // Stable per-consumer FP32 up-convert scratch (keyed by the consuming tensor's backing array), for convert-at-gap
+    // ops with no FP16 path. Capture-safe (allocated pre-residency, reused on replay).
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<object, IGpuBuffer> _fp16UpconvertScratch = new();
+    private IGpuBuffer Fp16InputToFp32Stable(IDirectGpuBackend backend, IGpuBuffer fp16Buf, int count, object scratchKey)
+    {
+        if (!_fp16UpconvertScratch.TryGetValue(scratchKey, out var f32)
+            || f32.Handle == System.IntPtr.Zero || f32.Size < count)
+        {
+            f32 = backend.AllocateBuffer(count);
+            _fp16UpconvertScratch[scratchKey] = f32;
+        }
+        backend.ConvertToFp32(fp16Buf, f32, count);
+        return f32;
+    }
+
+    // Stable per-consumer FP16 down-convert scratch: for an FP16-native op fed an FP32 input (convert-at-gap entry).
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<object, IGpuBuffer> _fp16DownconvertScratch = new();
+    private IGpuBuffer Fp32InputToFp16Stable(IDirectGpuBackend backend, IGpuBuffer fp32Buf, int count, object scratchKey)
+    {
+        if (!_fp16DownconvertScratch.TryGetValue(scratchKey, out var half)
+            || half.Handle == System.IntPtr.Zero || half.Size < count)
+        {
+            half = backend.AllocateBuffer(count);
+            _fp16DownconvertScratch[scratchKey] = half;
+        }
+        backend.ConvertToFp16(fp32Buf, half, count);
+        return half;
+    }
+
+    /// <summary>#3 FP16-act residual add (a += b) keeping a FP16-resident (Fp16Add). Returns false to fall back.</summary>
+    private bool TryFp16AddInPlace<T>(Tensor<T> a, Tensor<T> b)
+    {
+        if (!Fp16ActEnabled || typeof(T) != typeof(float)) return false;
+        if (!ShapesMatch(a.Shape._dims, b.Shape._dims)) return false;
+        if (!TryGetBackend(out var be) || be is not Engines.DirectGpu.CUDA.CudaBackend cb || !cb.SupportsFp16NativeOps) return false;
+        var aHalf = TryFp16ResidentInput(a, out _);
+        if (aHalf is null) return false; // only when the in-place target is FP16
+        var aArr = a.DataVector.GetBackingArrayUnsafe();
+        if (aArr is null) return false;
+        int len = a.Length;
+        try
+        {
+            IGpuBuffer bHalf;
+            var bh = TryFp16ResidentInput(b, out _);
+            if (bh is not null) bHalf = bh;
+            else { using var bbuf = GetResidentOrPersistentInputBuffer(cb, b); bHalf = Fp32InputToFp16Stable(cb, bbuf.Buffer, len, aArr); }
+            cb.Fp16Add(aHalf, bHalf, aHalf, len);
+            ResidentSyncCheck("AddInPlace");
+            a._gpuBufferVersion = a.Version; // a stays FP16-resident + tagged
+            return true;
+        }
+        catch (Exception ex) { AliasDiag($"Fp16AddInPlace FELLBACK: {ex.GetType().Name}: {ex.Message}"); return false; }
+    }
+
+    /// <summary>#3 FP16-act per-channel broadcast add (a[N,C,H,W] += b[.,C,1,1]) keeping a FP16-resident.</summary>
+    private bool TryFp16BroadcastAddInPlace<T>(Tensor<T> a, Tensor<T> b)
+    {
+        if (!Fp16ActEnabled || typeof(T) != typeof(float)) return false;
+        if (a.Rank != 4 || b.Rank != 4 || !a.IsContiguous) return false;
+        if (b.Shape._dims[2] != 1 || b.Shape._dims[3] != 1 || a.Shape._dims[1] != b.Shape._dims[1]) return false;
+        int n = a.Shape._dims[0];
+        if (!(n == 1 || b.Shape._dims[0] == n)) return false; // bias[b·C+c] addressing valid (capture is n=1)
+        if (!TryGetBackend(out var be) || be is not Engines.DirectGpu.CUDA.CudaBackend cb || !cb.Fp16BroadcastAddChannelAvailable) return false;
+        var aHalf = TryFp16ResidentInput(a, out _);
+        if (aHalf is null) return false;
+        var aArr = a.DataVector.GetBackingArrayUnsafe();
+        if (aArr is null) return false;
+        int c = a.Shape._dims[1], hw = a.Shape._dims[2] * a.Shape._dims[3];
+        try
+        {
+            IGpuBuffer biasHalf;
+            var bh = TryFp16ResidentInput(b, out _);
+            if (bh is not null) biasHalf = bh;
+            else { using var bbuf = GetResidentOrPersistentInputBuffer(cb, b); biasHalf = Fp32InputToFp16Stable(cb, bbuf.Buffer, b.Length, aArr); }
+            cb.Fp16BroadcastAddChannel(aHalf, biasHalf, n, c, hw);
+            ResidentSyncCheck("BroadcastAddInPlace");
+            a._gpuBufferVersion = a.Version;
+            return true;
+        }
+        catch (Exception ex) { AliasDiag($"Fp16BroadcastAddInPlace FELLBACK: {ex.GetType().Name}: {ex.Message}"); return false; }
+    }
+
     /// <summary>Pre-capture (sync alloc — call OUTSIDE stream capture): allocate/reuse a persistent output buffer
     /// sized to the forward's output. float only / no-op off CUDA.</summary>
     public void PrepareStableCaptureOutput<T>(Tensor<T> sampleOutput)
@@ -659,9 +798,16 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 "WriteOutputToStableCapture: the forward output is not resident; cannot record the stable-output copy node.");
             return output;
         }
-        cb.Copy(src, _stableCaptureOutput, need); // async on the compute stream — captured into the graph
+        // #3 FP16-act: if the forward's final output is an FP16 activation, DOWN-CONVERT it to FP32 into the stable
+        // (FP32-sized) output buffer — the FP16-region EXIT. A raw Copy would memcpy need*4 bytes from a need*2-byte
+        // FP16 buffer (garbage). The convert is captured into the graph, so replay re-runs it; the stable output is
+        // then plain FP32 for DownloadOutput + the host read.
+        if (IsFp16Resident(output))
+            cb.ConvertToFp32(src, _stableCaptureOutput, need); // FP16 → FP32, captured
+        else
+            cb.Copy(src, _stableCaptureOutput, need); // async on the compute stream — captured into the graph
         var stableT = new Tensor<T>(output.Shape._dims);
-        BindResidentBuffer(stableT, _stableCaptureOutput, cb);
+        BindResidentBuffer(stableT, _stableCaptureOutput, cb); // FP32 (down-converted if the output was FP16)
         return stableT;
     }
 
@@ -1177,6 +1323,15 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// </summary>
     private OwnedBuffer GetOrAllocateBuffer<T>(IDirectGpuBackend backend, Tensor<T> tensor)
     {
+        // #3 FP16-act CONVERT-AT-GAP: an FP16-tagged input → stable up-converted FP32, so EVERY non-FP16-aware op
+        // that fetches its activation through this helper (softmax, scale, in-place unary/binary, etc.) reads
+        // correct FP32. FP16-aware ops (conv/groupnorm/add) bypass via TryFp16ResidentInput. Capture-safe scratch.
+        var tHalfG = TryFp16ResidentInput(tensor, out var tCountG);
+        if (tHalfG is not null)
+        {
+            var kG = tensor.DataVector.GetBackingArrayUnsafe();
+            if (kG is not null) return new OwnedBuffer(Fp16InputToFp32Stable(backend, tHalfG, tCountG, kG), ownsBuffer: false);
+        }
         // A non-contiguous tensor (or one with a nonzero storage offset) is a STRIDED VIEW: it shares
         // its source's backing array, and any GPU buffer cached against that array holds the SOURCE's
         // contiguous layout — NOT the view's permuted/sliced layout. The fast paths below all key off
@@ -3637,6 +3792,13 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     private OwnedBuffer GetOrAllocateContiguousInputBuffer<T>(IDirectGpuBackend backend, Tensor<T> tensor)
     {
+        // #3 FP16-act CONVERT-AT-GAP: an FP16-tagged input → stable up-converted FP32 (see GetResidentOrPersistentInputBuffer).
+        var tHalfC = TryFp16ResidentInput(tensor, out var tCountC);
+        if (tHalfC is not null)
+        {
+            var kC = tensor.DataVector.GetBackingArrayUnsafe();
+            if (kC is not null) return new OwnedBuffer(Fp16InputToFp32Stable(backend, tHalfC, tCountC, kC), ownsBuffer: false);
+        }
         if (tensor._gpuBuffer is not null && ReferenceEquals(tensor._gpuBackend, backend))
             return new OwnedBuffer(tensor._gpuBuffer, ownsBuffer: false);
 
@@ -3685,6 +3847,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         t._gpuBuffer = buf; t._gpuBackend = backend; t._gpuBufferVersion = t.Version;
         var arr = t.DataVector.GetBackingArrayUnsafe();
         if (arr is null) return;
+        // #3 FP16-act: this array now holds FP32 — drop any stale FP16 tag (a pooled array reused FP16→FP32).
+        if (Fp16ActEnabled) _fp16ResidentArrays.TryRemove(arr, out _);
         if (s_currentForwardOp is not null) if (s_producerDiagEnabled && s_producerOf.Count < ProducerDiagCap) s_producerOf[arr] = s_currentForwardOp;
         var capBuf = buf; var capBackend = backend;
         Helpers.DeferredArrayMaterializer.Register(arr, a =>
@@ -3908,10 +4072,27 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             int batch = input.Shape._dims[0], channels = input.Shape._dims[1];
             int spatial = input.Length / (batch * channels);
             int statSize = batch * numGroups;
-            using var bufIn = GetOrAllocateContiguousInputBuffer(backend, input);
+            // #3 FP16-act: read an FP16-resident input RAW. Skip bufIn only when the FP16 GroupNorm+Swish path runs
+            // on a RAW FP16 input; else bufIn is needed (FP32 input down-convert, or the FP32 fallback when the
+            // kernel didn't compile — where the central guard up-converts an FP16 input).
+            var ihGn = TryFp16ResidentInput(input, out _);
+            bool gnFp16Path = ihGn is not null && backend is Engines.DirectGpu.CUDA.CudaBackend cbAvail && cbAvail.Fp16GroupNormSwishAvailable;
+            using var bufIn = gnFp16Path ? default : GetOrAllocateContiguousInputBuffer(backend, input);
             using var bufGamma = GetWeightBufferPreferResident(backend, gamma, PersistentTensorRole.Weights);
             using var bufBeta = GetWeightBufferPreferResident(backend, beta, PersistentTensorRole.Biases);
             var outBuf = GetOrCreateResidentBuffer(backend, output, input.Length);
+            // #3 FP16-ACTIVATIONS: fused FP16 GroupNorm+Swish (FP16 in/out, FP32-internal mean/var) — keeps the
+            // activation FP16 for the next conv (no convert). Input is the FP16-resident buffer, or an FP32 input
+            // down-converted once (convert-at-gap, e.g. after attention/resample). gamma/beta stay FP32.
+            if (Fp16ActEnabled && backend is Engines.DirectGpu.CUDA.CudaBackend cbGn && cbGn.Fp16GroupNormSwishAvailable)
+            {
+                var inHalfGn = ihGn is not null ? ihGn : Fp32InputToFp16Stable(backend, bufIn.Buffer, input.Length, arr);
+                cbGn.Fp16GroupNormSwish(inHalfGn, bufGamma.Buffer, bufBeta.Buffer, outBuf,
+                    batch, numGroups, channels, spatial, (float)epsilon);
+                ResidentSyncCheck("GroupNormSwish");
+                BindResidentBufferFp16(output, outBuf, backend, input.Length);
+                return true;
+            }
             // Key AND validate by required capacity: the cache is keyed on the output backing array, but the
             // same array can recur with different group metadata (batch*numGroups) or a larger input, and a
             // reused undersized norm/mean/var buffer would feed GroupNorm out-of-bounds scratch. (Re)allocate
@@ -4192,6 +4373,15 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     // whole graph). Falls back to the transient path if it has no backing array.
     private OwnedBuffer GetResidentOrPersistentInputBuffer<T>(IDirectGpuBackend backend, Tensor<T> t)
     {
+        // #3 FP16-act CONVERT-AT-GAP: if t holds FP16 activation data, transparently up-convert to a STABLE FP32
+        // buffer so any non-FP16-aware resident op (attention matmul/softmax, resample, concat) reads correct FP32.
+        // FP16-aware ops (conv/groupnorm/add) BYPASS this by reading the raw FP16 via TryFp16ResidentInput.
+        var tHalfR = TryFp16ResidentInput(t, out var tCountR);
+        if (tHalfR is not null)
+        {
+            var kR = t.DataVector.GetBackingArrayUnsafe();
+            if (kR is not null) return new OwnedBuffer(Fp16InputToFp32Stable(backend, tHalfR, tCountR, kR), ownsBuffer: false);
+        }
         // PR #638 (CUDA-700 fix): a REUSED input buffer must hold at least the tensor's logical length, else the
         // consuming kernel reads PAST the allocation (out-of-bounds → sticky CUDA-700). A pooled backing array
         // reused at a larger shape leaves an UNDERSIZED cached/resident buffer; skip it and re-resolve a correctly
@@ -4799,6 +4989,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     void IEngine.TensorAddInPlace<T>(Tensor<T> a, Tensor<T> b)
     {
+        // #3 FP16-act: FP16-native residual add when a is FP16-resident (keeps the activation FP16, no convert).
+        if (TryFp16AddInPlace(a, b)) return;
         // Version-counter contract is enforced inside TryRunBinaryInPlace
         // (and CpuEngine's base implementation on the fallback path).
         if (ShapesMatch(a.Shape._dims, b.Shape._dims) && TryRunBinaryInPlace(a, b,
@@ -4868,6 +5060,10 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     void IEngine.TensorBroadcastAddInPlace<T>(Tensor<T> a, Tensor<T> b)
     {
+        // #3 FP16-act: keep the activation FP16 across the add. Same-shape → FP16 residual add; per-channel
+        // broadcast ([N,C,H,W] += [.,C,1,1]) → FP16 broadcast-add. Both no-op back to FP32 if not tagged.
+        if (ShapesMatch(a.Shape._dims, b.Shape._dims)) { if (TryFp16AddInPlace(a, b)) return; }
+        else if (TryFp16BroadcastAddInPlace(a, b)) return;
         // If shapes match, use GPU element-wise add in-place
         if (ShapesMatch(a.Shape._dims, b.Shape._dims) && TryRunBinaryInPlace(a, b,
             static (backend, bufA, bufB, size) => backend.Add(bufA, bufB, bufA, size)))
@@ -4989,18 +5185,20 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 int ih = input.Shape._dims[2], iw = input.Shape._dims[3];
                 int oc = kernel.Shape._dims[0], kh = kernel.Shape._dims[2], kw = kernel.Shape._dims[3];
                 int oh = output.Shape._dims[2], ow = output.Shape._dims[3];
-                using var bufIn = GetOrAllocateContiguousInputBuffer(rbk, input);
+                // #3 FP16-act: detect an FP16-resident input up-front so we read it RAW. bufIn (FP32 path's input)
+                // is skipped when FP16 (else the central up-convert guard wastes a convert we don't use).
+                var inHalf = TryFp16ResidentInput(input, out _);
+                bool inFp16 = inHalf is not null;
+                using var bufIn = inFp16 ? default : GetOrAllocateContiguousInputBuffer(rbk, input);
                 using var bufK = GetWeightBufferPreferResident(rbk, kernel, PersistentTensorRole.Weights);
                 var outBuf = GetOrCreateResidentBuffer(rbk, output, output.Length);
 
                 // #1650/#638 FP16-conv replay-floor lever (AIDOTNET_FP16_CONV=1): the INDUSTRY path (oneDNN/cuDNN/
                 // PyTorch) — conv as a GEMM on the matrix units. Fused FP16 im2col → col[K,N] (FP16), cached FP16
-                // weights[outC,K], GemmFp16In32fOut (FP16 multiply / FP32 accumulate on Tensor Cores / MFMA /
-                // simdgroup / coopmat) → out[outC,N]. Measured ~11x my FP32-Winograd on a big conv; end-to-end
-                // diffusion replay 25ms→17.7ms (1.41x). BACKEND-AGNOSTIC: dispatched via IGpuHalfPrecisionBackend
-                // (CUDA/HIP/Metal/OpenCL/Vulkan/WebGpu) — any backend whose Fp16Im2colAvailable is true. Don't
-                // swallow failures (the availability flag already gates support) — let them hit the outer catch.
+                // weights[outC,K], GemmFp16In32fOut/HalfOut → out[outC,N]. #3 FP16-ACT: read FP16 input directly
+                // (UnfoldKNFp16FromFp16, no convert) + write FP16 output (GemmFp16HalfOut) so the next op stays FP16.
                 int gemmK = ic * kh * kw, gemmN = b * oh * ow, gemmM = oc;
+                var outArr = output.DataVector.GetBackingArrayUnsafe(); // stable scratch key (gate above ensured non-null)
                 // The matrix-unit GEMM only PAYS OFF on a big-enough GEMM. Deep convs at small spatial (8x8→N=64,
                 // 4x4→N=16) are tiny GEMMs where the im2col + launch overhead exceeds the win. Gate on N/K/M so
                 // only the large convs take the FP16 path; the small ones stay on the FP32 conv kernel.
@@ -5012,8 +5210,19 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                     int K = gemmK, N = gemmN, M = gemmM;
                     // STABLE cached col scratch (NOT a per-call `using` alloc) — capture-replay-safe (see method doc).
                     var colHalf = GetOrCacheFp16ColScratch(rbk, bufK.Buffer, K * N);
-                    hbConvR.Im2colKNFp16(bufIn.Buffer, colHalf, b, ic, ih, iw, kh, kw, stride, stride, padding, padding, dilation, dilation);
+                    if (inHalf is not null && rbk is Engines.DirectGpu.CUDA.CudaBackend cbIn && cbIn.Fp16Im2colFromFp16Available)
+                        cbIn.UnfoldKNFp16FromFp16(inHalf, colHalf, b, ic, ih, iw, kh, kw, stride, stride, padding, padding, dilation, dilation);
+                    else
+                        hbConvR.Im2colKNFp16(bufIn.Buffer, colHalf, b, ic, ih, iw, kh, kw, stride, stride, padding, padding, dilation, dilation);
                     var wHalf = GetOrCacheFp16Weights(rbk, bufK.Buffer, M * K); // FP16 weights, converted once + cached
+                    // FP16-act: keep the conv OUTPUT FP16 (GemmFp16HalfOut) + tag, so the next op reads FP16 (no convert).
+                    if (Fp16ActEnabled && rbk is Engines.DirectGpu.CUDA.CudaBackend cbOut)
+                    {
+                        cbOut.GemmFp16HalfOut(wHalf, colHalf, outBuf, M, N, K);
+                        ResidentSyncCheck("Conv2DInto");
+                        BindResidentBufferFp16(output, outBuf, rbk, M * N);
+                        return;
+                    }
                     hbConvR.GemmFp16In32fOut(wHalf, colHalf, outBuf, M, N, K);
                 }
                 else if (s_fp16Conv && gemmN <= Fp16ConvTinyGemmN && gemmK >= 64 && gemmM >= 16
@@ -5024,12 +5233,24 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                     // small convs. CUDA-first; parity for the other backends is a tracked follow-up. Weights reuse the
                     // same cached FP16 copy ([outC,inC,kh,kw] layout); input stays FP32 (rounded to FP16 in-kernel).
                     var wHalfDirect = GetOrCacheFp16Weights(rbk, bufK.Buffer, gemmM * gemmK);
-                    cudaDirectConv.Conv2dDirectFp16Hw(bufIn.Buffer, wHalfDirect, outBuf,
+                    // #3 FP16-act: the direct conv takes an FP32 input (rounds to FP16 in-kernel). When the activation
+                    // is FP16-resident, bufIn is null (skipped) — up-convert it to a stable FP32 scratch (convert-at-gap).
+                    var directIn = inHalf is not null && outArr is not null
+                        ? Fp16InputToFp32Stable(rbk, inHalf, input.Length, outArr)
+                        : bufIn.Buffer;
+                    cudaDirectConv.Conv2dDirectFp16Hw(directIn, wHalfDirect, outBuf,
                         b, ic, ih, iw, oc, oh, ow, kh, kw, stride, stride, padding, padding, dilation, dilation);
                 }
                 else
-                    rbk.Conv2D(bufIn.Buffer, bufK.Buffer, outBuf,
+                {
+                    // FP32 conv (small conv, or FP16-conv off). If the input is FP16-resident, up-convert it to a
+                    // stable FP32 scratch first (convert-at-gap) so this FP32 kernel reads correct data.
+                    var convIn = inHalf is not null && outArr is not null
+                        ? Fp16InputToFp32Stable(rbk, inHalf, input.Length, outArr)
+                        : bufIn.Buffer;
+                    rbk.Conv2D(convIn, bufK.Buffer, outBuf,
                         b, ic, ih, iw, oc, oh, ow, kh, kw, stride, stride, padding, padding, dilation, dilation);
+                }
                 ResidentSyncCheck("Conv2DInto");
                 BindResidentBuffer(output, outBuf, rbk);
                 return;

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -3540,6 +3540,48 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         });
     }
 
+    /// <summary>
+    /// #638/#1650 resident channel-axis concatenation: concat NCHW tensors <paramref name="a"/> ([N,cA,H,W]) and
+    /// <paramref name="b"/> ([N,cB,H,W]) into <paramref name="output"/> ([N,cA+cB,H,W]) entirely on-device, via
+    /// stream-ordered device-to-device copies of each input's per-batch channel slab into the output's resident
+    /// buffer, then binds the output resident (no host span-copy → stays GPU-resident and CUDA-graph-capturable).
+    /// Returns false (caller does its host concat) when not on the resident step, non-float, non-contiguous, or
+    /// shapes don't match the channel-concat contract. The diffusion U-Net decoder skip-concat is the caller.
+    /// </summary>
+    public bool TryConcatenateChannelsResidentInto<T>(Tensor<T> output, Tensor<T> a, Tensor<T> b)
+    {
+        if (!ResidentStepActive || Gpu.AutocastScope.IsEnabled || typeof(T) != typeof(float)) return false;
+        if (a is null || b is null || output is null) return false;
+        if (a.Rank != 4 || b.Rank != 4 || output.Rank != 4) return false;
+        if (!a.IsContiguous || !b.IsContiguous || !output.IsContiguous) return false;
+        int n = a.Shape._dims[0], cA = a.Shape._dims[1], h = a.Shape._dims[2], w = a.Shape._dims[3];
+        int cB = b.Shape._dims[1];
+        if (b.Shape._dims[0] != n || b.Shape._dims[2] != h || b.Shape._dims[3] != w) return false;
+        if (output.Shape._dims[0] != n || output.Shape._dims[1] != cA + cB
+            || output.Shape._dims[2] != h || output.Shape._dims[3] != w) return false;
+        if (!TryGetBackend(out var be) || be is not Engines.DirectGpu.CUDA.CudaBackend cb) return false;
+        try
+        {
+            int spatial = h * w;
+            int aBatch = cA * spatial, bBatch = cB * spatial, oBatch = (cA + cB) * spatial;
+            using var abuf = GetOrAllocateContiguousInputBuffer(cb, a);
+            using var bbuf = GetOrAllocateContiguousInputBuffer(cb, b);
+            var outBuf = GetOrCreateResidentBuffer(cb, output, output.Length);
+            if (abuf.Buffer.Handle == System.IntPtr.Zero || bbuf.Buffer.Handle == System.IntPtr.Zero
+                || outBuf.Handle == System.IntPtr.Zero || outBuf.Size < output.Length)
+                return false;
+            for (int bi = 0; bi < n; bi++)
+            {
+                cb.Copy(abuf.Buffer, bi * aBatch, outBuf, bi * oBatch, aBatch);
+                cb.Copy(bbuf.Buffer, bi * bBatch, outBuf, bi * oBatch + aBatch, bBatch);
+            }
+            ResidentSyncCheck("ConcatenateChannels");
+            BindResidentBuffer(output, outBuf, cb);
+            return true;
+        }
+        catch (Exception cex) { AliasDiag($"ConcatChannels-resident FELLBACK n={n} cA={cA} cB={cB}: {cex.GetType().Name}: {cex.Message}"); return false; }
+    }
+
     /// <summary>PR #638 A1: ensure tensor `t` has a STABLE resident GPU buffer (allocate + bind once if it has none),
     /// so the compiled backward's pre-allocated gradient accumulators are device-resident before capture. Idempotent:
     /// returns the existing resident buffer when already bound. MUST be called OUTSIDE stream capture (it may allocate);
@@ -4764,6 +4806,34 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     void IEngine.Conv2DInto<T>(Tensor<T> output, Tensor<T> input, Tensor<T> kernel, int stride, int padding, int dilation)
     {
+        // #1650/#638: resident path for the capture step — read resident input + prefer-resident
+        // kernel, conv into the output's STABLE resident buffer, BindResidentBuffer, NO host
+        // round-trip. The legacy GPU path below uploads input/kernel + DownloadIntoTensor (non-
+        // capturable: 901/900). This is the ResBlock's inference fast-path conv (pre-allocated
+        // output), so making it resident is what lets the residual add downstream stay on-device.
+        if (ResidentStepActive && !Gpu.AutocastScope.IsEnabled && typeof(T) == typeof(float)
+            && input.Rank == 4 && kernel.Rank == 4
+            && output.DataVector.GetBackingArrayUnsafe() is not null
+            && TryGetBackend(out var rbk) && rbk is Engines.DirectGpu.CUDA.CudaBackend)
+        {
+            try
+            {
+                int b = input.Shape._dims[0], ic = input.Shape._dims[1];
+                int ih = input.Shape._dims[2], iw = input.Shape._dims[3];
+                int oc = kernel.Shape._dims[0], kh = kernel.Shape._dims[2], kw = kernel.Shape._dims[3];
+                int oh = output.Shape._dims[2], ow = output.Shape._dims[3];
+                using var bufIn = GetOrAllocateContiguousInputBuffer(rbk, input);
+                using var bufK = GetWeightBufferPreferResident(rbk, kernel, PersistentTensorRole.Weights);
+                var outBuf = GetOrCreateResidentBuffer(rbk, output, output.Length);
+                rbk.Conv2D(bufIn.Buffer, bufK.Buffer, outBuf,
+                    b, ic, ih, iw, oc, oh, ow, kh, kw, stride, stride, padding, padding, dilation, dilation);
+                ResidentSyncCheck("Conv2DInto");
+                BindResidentBuffer(output, outBuf, rbk);
+                return;
+            }
+            catch (Exception cex) { AliasDiag($"Conv2DInto-resident FELLBACK in=[{string.Join(",", input._shape)}]: {cex.GetType().Name}: {cex.Message}"); }
+        }
+
         if (TryGetBackend(out var gpuBackend))
         {
             try
@@ -5491,9 +5561,10 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         result = null;
         if (!ResidentStepActive || Gpu.AutocastScope.IsEnabled || typeof(T) != typeof(float)) return false;
         if (activationParams is not null || bias is null || weights.Rank != 2 || !input.IsContiguous) return false;
-        if (activation != FusedActivationType.None && activation != FusedActivationType.ReLU
-            && activation != FusedActivationType.GELU && activation != FusedActivationType.Swish)
-            return false;
+        // All FusedActivationType values are applied below by ApplyGpuActivation as in-place GPU kernels
+        // (no host round-trip), so the resident path covers Swish/SiLU (the diffusion ResBlock time-MLP —
+        // the first in-capture blocker), Sigmoid, Tanh, ELU, Mish, etc. — not just ReLU/GELU. An activation
+        // ApplyGpuActivation doesn't support throws inside the try and cleanly falls back to the eager path.
         if (!TryGetBackend(out var backend) || backend is not Engines.DirectGpu.CUDA.CudaBackend cb) return false;
         int K = weights.Shape._dims[0];   // input features
         int N = weights.Shape._dims[1];   // output features
@@ -5514,9 +5585,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 return false;
             cb.Gemm(inBuf.Buffer, wBuf.Buffer, outBuf, M, N, K, 1.0f, 0.0f);   // outBuf = input @ weights
             cb.BiasAdd(outBuf, bBuf.Buffer, outBuf, M, N);                     // += bias[N] (in place)
-            if (activation == FusedActivationType.ReLU) cb.Relu(outBuf, outBuf, M * N);
-            else if (activation == FusedActivationType.GELU) cb.Gelu(outBuf, outBuf, M * N);
-            else if (activation == FusedActivationType.Swish) cb.Swish(outBuf, outBuf, M * N);
+            if (activation != FusedActivationType.None)
+                ApplyGpuActivation(backend, outBuf, M * N, activation);        // in-place GPU activation (covers Swish/SiLU, Sigmoid, Tanh, …)
             ResidentSyncCheck("FusedLinear");
             BindResidentBuffer(outTensor, outBuf, backend);
             result = outTensor;
@@ -8988,6 +9058,41 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
         // Compute scale if not provided
         float scaleFloat = (float)(scale ?? (1.0 / Math.Sqrt(headDim)));
+
+        // #638/#1650 GPU-RESIDENT capture path: run FlashAttentionV2 into resident output + softmax-stats
+        // buffers and BIND them (no DownloadBuffer), so the diffusion attention block stays fully on-device
+        // for CUDA-graph capture. Inputs Q/K/V are read through their resident buffers with no re-upload.
+        // Scope: float, no attention bias (diffusion self-attention), CUDA backend; anything else falls
+        // through to the eager download path below. Numerically identical — same FlashAttentionV2 kernel.
+        if (ResidentStepActive && !Gpu.AutocastScope.IsEnabled && typeof(T) == typeof(float)
+            && attentionBias is null && query.IsContiguous && key.IsContiguous && value.IsContiguous
+            && backend is Engines.DirectGpu.CUDA.CudaBackend)
+        {
+            try
+            {
+                using var qBufR = GetOrAllocateContiguousInputBuffer(backend, query);
+                using var kBufR = GetOrAllocateContiguousInputBuffer(backend, key);
+                using var vBufR = GetOrAllocateContiguousInputBuffer(backend, value);
+                var outT = new Tensor<T>(new T[(long)batch * heads * seqQ * headDim], new[] { batch, heads, seqQ, headDim });
+                var statsT = new Tensor<T>(new T[(long)batch * heads * seqQ], new[] { batch, heads, seqQ });
+                var outBufR = GetOrCreateResidentBuffer(backend, outT, batch * heads * seqQ * headDim);
+                var statsBufR = GetOrCreateResidentBuffer(backend, statsT, batch * heads * seqQ);
+                using var biasNoneR = default(OwnedBuffer);
+                if (qBufR.Buffer.Handle != System.IntPtr.Zero && kBufR.Buffer.Handle != System.IntPtr.Zero
+                    && vBufR.Buffer.Handle != System.IntPtr.Zero
+                    && outBufR.Handle != System.IntPtr.Zero && statsBufR.Handle != System.IntPtr.Zero)
+                {
+                    backend.FlashAttentionV2(qBufR.Buffer, kBufR.Buffer, vBufR.Buffer, outBufR, statsBufR,
+                        batch, heads, seqQ, seqK, headDim, scaleFloat, isCausal, biasNoneR.Buffer, 0);
+                    ResidentSyncCheck("FlashAttention");
+                    BindResidentBuffer(outT, outBufR, backend);
+                    BindResidentBuffer(statsT, statsBufR, backend);
+                    softmaxStats = statsT;
+                    return outT;
+                }
+            }
+            catch (Exception fex) { AliasDiag($"FlashAttention-resident FELLBACK q=[{string.Join(",", query._shape)}]: {fex.GetType().Name}: {fex.Message}"); }
+        }
 
         // Use cache-aware buffer allocation (especially important for KV cache)
         using var queryBuffer = GetOrAllocateBuffer(backend, query);
@@ -17422,6 +17527,41 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (!TryGetBackend(out var backend) || input.Rank < 4)
             return base.ConvTranspose2D(input, kernel, stride, padding, outputPadding);
 
+        // #638/#1650 GPU-RESIDENT capture path: run ConvTranspose2D into a resident output buffer and BIND it
+        // (no FinishGpuOp deferred download), so the diffusion decoder upsample stays on-device for CUDA-graph
+        // capture. The eager path below uses FinishGpuOp, whose deferred materializer races activation-cache
+        // eviction under capture (issue #226). Float, rank-4, no active tape (inference) — same kernel, so
+        // numerically identical; tape training still records via the eager path below.
+        if (ResidentStepActive && !Gpu.AutocastScope.IsEnabled && typeof(T) == typeof(float)
+            && input.Rank == 4 && kernel.Rank == 4 && !IsTapeActive<T>()
+            && input.IsContiguous && backend is Engines.DirectGpu.CUDA.CudaBackend rbkT)
+        {
+            try
+            {
+                int batchR = input.Shape._dims[0], inChR = input.Shape._dims[1];
+                int inHR = input.Shape._dims[2], inWR = input.Shape._dims[3];
+                int outChR = kernel.Shape._dims[1], kHR = kernel.Shape._dims[2], kWR = kernel.Shape._dims[3];
+                int outHR = (inHR - 1) * stride[0] - 2 * padding[0] + kHR + outputPadding[0];
+                int outWR = (inWR - 1) * stride[1] - 2 * padding[1] + kWR + outputPadding[1];
+                long outLenR = (long)batchR * outChR * outHR * outWR;
+                using var bufInR = GetOrAllocateContiguousInputBuffer(rbkT, input);
+                using var bufKR = GetWeightBufferPreferResident(rbkT, kernel, PersistentTensorRole.Weights);
+                var outTR = new Tensor<T>(new T[outLenR], new[] { batchR, outChR, outHR, outWR });
+                var outBufR = GetOrCreateResidentBuffer(rbkT, outTR, (int)outLenR);
+                if (bufInR.Buffer.Handle != System.IntPtr.Zero && bufKR.Buffer.Handle != System.IntPtr.Zero
+                    && outBufR.Handle != System.IntPtr.Zero && outBufR.Size >= outLenR)
+                {
+                    rbkT.ConvTranspose2D(bufInR.Buffer, bufKR.Buffer, outBufR,
+                        batchR, inChR, inHR, inWR, outChR, outHR, outWR,
+                        kHR, kWR, stride[0], stride[1], padding[0], padding[1], outputPadding[0], outputPadding[1]);
+                    ResidentSyncCheck("ConvTranspose2D");
+                    BindResidentBuffer(outTR, outBufR, rbkT);
+                    return outTR;
+                }
+            }
+            catch (Exception tex) { AliasDiag($"ConvTranspose2D-resident FELLBACK in=[{string.Join(",", input._shape)}]: {tex.GetType().Name}: {tex.Message}"); }
+        }
+
         try
         {
             int batch = input.Shape._dims[0];
@@ -18434,11 +18574,21 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 int n = a.Shape._dims[0], c = a.Shape._dims[1], hw = a.Shape._dims[2] * a.Shape._dims[3];
                 using var abuf = GetResidentOrPersistentInputBuffer(beCh, a);
                 using var bbuf = GetResidentOrPersistentInputBuffer(beCh, b);
-                var outBuf = AllocateOutputBuffer(beCh, a.Length);
-                cbCh.Copy(abuf.Buffer, outBuf.Buffer, a.Length);          // out = a
-                cbCh.Conv2DBiasAdd(outBuf.Buffer, bbuf.Buffer, n, c, hw); // out += bias (per channel)
-                var resData = FinishGpuOp<T>(beCh, outBuf, a.Length);
-                return new Tensor<T>(resData, a.Shape._dims);
+                // BIND the result resident (no FinishGpuOp deferred download): the diffusion decoder's Deconv
+                // bias-add runs inside the captured forward, where a deferred materializer races activation-
+                // cache eviction (issue #226) and aborts replay. Fresh output → its resident buffer becomes a
+                // graph alloc node under capture; downstream reads it on-device with no re-upload.
+                var outT = new Tensor<T>(new T[a.Length], a.Shape._dims);
+                var outBuf = GetOrCreateResidentBuffer(beCh, outT, a.Length);
+                if (abuf.Buffer.Handle != System.IntPtr.Zero && bbuf.Buffer.Handle != System.IntPtr.Zero
+                    && outBuf.Handle != System.IntPtr.Zero && outBuf.Size >= a.Length)
+                {
+                    cbCh.Copy(abuf.Buffer, outBuf, a.Length);          // out = a (DtoD async, capturable)
+                    cbCh.Conv2DBiasAdd(outBuf, bbuf.Buffer, n, c, hw); // out += bias (per channel)
+                    ResidentSyncCheck("BroadcastAddConvBias");
+                    BindResidentBuffer(outT, outBuf, beCh);
+                    return outT;
+                }
             }
             catch { /* fall through to the paths below */ }
         }

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -5271,8 +5271,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // it safe (no owned upload to async-free under the kernel, the CUDA-700 the s_residentInPlace gate guarded).
         if (((s_residentInPlace && InGradAccumulation) || InferenceCaptureActive) && ResidentStepActive && !Gpu.AutocastScope.IsEnabled && typeof(T) == typeof(float)
             && a.IsContiguous && b.IsContiguous && a.Length == b.Length
-            && a.TryGetGpuBuffer() is { } aResident
-            && b.TryGetGpuBuffer() is { } bResident
+            && ResolveResidentBufferNoUpload(backend, a, a.Length) is { } aResident
+            && ResolveResidentBufferNoUpload(backend, b, b.Length) is { } bResident
             && !ReferenceEquals(aResident, bResident)
             && aResident.Handle != System.IntPtr.Zero && bResident.Handle != System.IntPtr.Zero
             && aResident.Size >= a.Length && bResident.Size >= b.Length)

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -542,10 +542,13 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     // units), backend-agnostic via IGpuHalfPrecisionBackend. DEFAULT ON (set AIDOTNET_FP16_CONV=0 to disable),
     // VALIDATED before flipping on (PR #671 #2): primitive conv vs FP32 Conv2D relL2=0.028%; one full UNet forward
     // end-to-end relL2=0.67% — at the cuBLAS run-to-run FP32-vs-FP32 noise floor (0.666%), PSNR 60.9 dB — and
-    // 1.40x faster end-to-end. Self-gates to FP32 where it can't or shouldn't run: no toolkit (the FP16 im2col
-    // kernel isn't compiled → Fp16Im2colAvailable false), backend without the kernel (HIP/Metal/OpenCL/Vulkan/
-    // WebGpu pending → false), or a too-small GEMM (size gate below). So default-on changes behavior ONLY on the
-    // validated CUDA-with-toolkit inference path; everywhere else it is inert.
+    // 1.40x faster end-to-end. Self-gates to FP32 where it can't or shouldn't run: no FP16 im2col kernel on the
+    // device (Fp16Im2colAvailable false) or a too-small GEMM (size gate below). The FP16 im2col kernel now ships
+    // for ALL backends (CUDA/HIP/Metal/OpenCL/Vulkan/WebGpu), so default-on engages wherever it compiles — it is
+    // NOT CUDA-only anymore. Validation status differs per backend (#671 review): CUDA is validated end-to-end
+    // (RTX 3080, primitive relL2 0.028%, UNet relL2 0.67% at the cuBLAS FP32 noise floor, PSNR 60.9 dB);
+    // OpenCL/Vulkan have CPU-parity coverage; HIP/Metal/WebGpu compile-and-dispatch but are not yet hardware-
+    // validated end-to-end (tracked follow-up). Set AIDOTNET_FP16_CONV=0 to disable globally.
     private static readonly bool s_fp16ConvEnv =
         System.Environment.GetEnvironmentVariable("AIDOTNET_FP16_CONV") != "0";
 
@@ -557,6 +560,12 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     private static bool s_fp16Conv => Fp16ConvOverride ?? s_fp16ConvEnv;
 
+    // #1650/#638 (#671 review): the matrix-unit FP16 conv only pays off on a big-enough GEMM. The documented
+    // tiny boundary is 8x8 spatial -> N=64 (and 4x4 -> N=16), where im2col + launch overhead exceeds the win,
+    // so N must be STRICTLY greater than this to take the FP16 path. The next real conv spatial (16x16) gives
+    // N=256, so this excludes only the tiny convs the benchmark flagged.
+    private const int Fp16ConvTinyGemmN = 64;
+
     // Cache the FP16 copy of each conv weight (constant across denoising steps), keyed by its resident FP32
     // buffer handle. Converted ONCE (sync, on the pre-residency pass — not while stream-capturing); reused on
     // every captured replay. The Tensor-Core GemmFp16 conv path needs the weights as FP16.
@@ -566,6 +575,11 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (_fp16WeightCache.TryGetValue(wFp32.Handle, out var cached)
             && cached.Handle != System.IntPtr.Zero && cached.SizeInBytes >= (long)count * 2)
             return cached;
+        // #671 review: a miss while the stream is capturing means the pre-residency prewarm was skipped.
+        // Allocating/converting inside cuStreamBeginCapture aborts the graph (CUDA 906) — fail loudly instead.
+        if (backend is Engines.DirectGpu.CUDA.CudaBackend capCb && capCb.IsStreamCapturing())
+            throw new InvalidOperationException(
+                "FP16 conv weight cache miss during CUDA stream capture — convert the weights on the pre-residency pass before cuStreamBeginCapture.");
         var half = backend.AllocateBuffer(count); // count floats ≥ count halfs; sync alloc — only on the pre-residency miss
         backend.ConvertToFp16(wFp32, half, count);
         _fp16WeightCache[wFp32.Handle] = half;
@@ -585,6 +599,11 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (_fp16ColScratchCache.TryGetValue(wFp32Key.Handle, out var cached)
             && cached.Handle != System.IntPtr.Zero && cached.SizeInBytes >= (long)count * 2)
             return cached;
+        // #671 review: a miss while the stream is capturing means the pre-residency prewarm was skipped.
+        // Allocating inside cuStreamBeginCapture aborts the graph (CUDA 906) — fail loudly instead.
+        if (backend is Engines.DirectGpu.CUDA.CudaBackend capCb && capCb.IsStreamCapturing())
+            throw new InvalidOperationException(
+                "FP16 conv col-scratch cache miss during CUDA stream capture — allocate the scratch on the pre-residency pass before cuStreamBeginCapture.");
         var scratch = backend.AllocateBuffer(count); // count floats ≥ count halfs; sync alloc — only on the pre-residency miss
         _fp16ColScratchCache[wFp32Key.Handle] = scratch;
         return scratch;
@@ -4985,7 +5004,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 // The matrix-unit GEMM only PAYS OFF on a big-enough GEMM. Deep convs at small spatial (8x8→N=64,
                 // 4x4→N=16) are tiny GEMMs where the im2col + launch overhead exceeds the win. Gate on N/K/M so
                 // only the large convs take the FP16 path; the small ones stay on the FP32 conv kernel.
-                bool fp16ConvWorth = gemmN >= 64 && gemmK >= 64 && gemmM >= 16;
+                bool fp16ConvWorth = gemmN > Fp16ConvTinyGemmN && gemmK >= 64 && gemmM >= 16;
                 if (s_fp16Conv && fp16ConvWorth
                     && rbk is Engines.Gpu.IGpuHalfPrecisionBackend hbConvR
                     && hbConvR.SupportsHgemm && hbConvR.Fp16Im2colAvailable)

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -5016,6 +5016,17 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                     var wHalf = GetOrCacheFp16Weights(rbk, bufK.Buffer, M * K); // FP16 weights, converted once + cached
                     hbConvR.GemmFp16In32fOut(wHalf, colHalf, outBuf, M, N, K);
                 }
+                else if (s_fp16Conv && gemmN <= Fp16ConvTinyGemmN && gemmK >= 64 && gemmM >= 16
+                    && rbk is Engines.DirectGpu.CUDA.CudaBackend cudaDirectConv && cudaDirectConv.Fp16DirectConvAvailable)
+                {
+                    // #671: the tiny-spatial deep convs (N <= Fp16ConvTinyGemmN) that the im2col+GEMM path skips run
+                    // through the DIRECT FP16 conv (no im2col materialization) for FP16-consistent numerics on the
+                    // small convs. CUDA-first; parity for the other backends is a tracked follow-up. Weights reuse the
+                    // same cached FP16 copy ([outC,inC,kh,kw] layout); input stays FP32 (rounded to FP16 in-kernel).
+                    var wHalfDirect = GetOrCacheFp16Weights(rbk, bufK.Buffer, gemmM * gemmK);
+                    cudaDirectConv.Conv2dDirectFp16Hw(bufIn.Buffer, wHalfDirect, outBuf,
+                        b, ic, ih, iw, oc, oh, ow, kh, kw, stride, stride, padding, padding, dilation, dilation);
+                }
                 else
                     rbk.Conv2D(bufIn.Buffer, bufK.Buffer, outBuf,
                         b, ic, ih, iw, oc, oh, ow, kh, kw, stride, stride, padding, padding, dilation, dilation);

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -381,6 +381,15 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             if (e is not null) System.Threading.Interlocked.Decrement(ref e._gradAccumDepth);
         }
     }
+    // #1650 inference CUDA-graph capture: while set, GPU-resident in-place ops (TryRunBinaryInPlace) engage
+    // on ResidentStepActive WITHOUT the training-only InGradAccumulation gate, so the inference forward runs
+    // host-round-trip-free and is capturable. Depth counter (not bool) so it's visible on the BLAS pool
+    // threads the op execution fans out to, mirroring _capturePathDepth / _evictionSuspendDepth.
+    private int _inferenceCaptureDepth;
+    internal bool InferenceCaptureActive => System.Threading.Volatile.Read(ref _inferenceCaptureDepth) > 0;
+    internal void BeginInferenceCapture() => System.Threading.Interlocked.Increment(ref _inferenceCaptureDepth);
+    internal void EndInferenceCapture() => System.Threading.Interlocked.Decrement(ref _inferenceCaptureDepth);
+
     internal void SuspendActivationEviction() => System.Threading.Interlocked.Increment(ref _evictionSuspendDepth);
     internal void ResumeActivationEviction()
     {
@@ -5075,7 +5084,10 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             var aCached = aArr is not null ? TryGetCachedBuffer(aArr) : null;
             AliasDiag($"gradacc-inplace probe: aField={(aB is null ? "null" : "H=" + ((long)aB.Handle).ToString("X") + "/sz" + aB.Size)} aCache={(aCached is null ? "null" : "H=" + ((long)aCached.Handle).ToString("X") + "/sz" + aCached.Size)} bField={(bB2 is null ? "null" : "H=" + ((long)bB2.Handle).ToString("X") + "/sz" + bB2.Size)} need={a.Length} aContig={a.IsContiguous}");
         }
-        if (s_residentInPlace && InGradAccumulation && ResidentStepActive && !Gpu.AutocastScope.IsEnabled && typeof(T) == typeof(float)
+        // Training grad-accum (opt-in s_residentInPlace) OR inference CUDA-graph capture engage the resident
+        // in-place path. Both still require BOTH operands already resident (checked below) — that is what makes
+        // it safe (no owned upload to async-free under the kernel, the CUDA-700 the s_residentInPlace gate guarded).
+        if (((s_residentInPlace && InGradAccumulation) || InferenceCaptureActive) && ResidentStepActive && !Gpu.AutocastScope.IsEnabled && typeof(T) == typeof(float)
             && a.IsContiguous && b.IsContiguous && a.Length == b.Length
             && a.TryGetGpuBuffer() is { } aResident
             && b.TryGetGpuBuffer() is { } bResident

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -425,6 +425,13 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             cb.LaunchCapturedGraph(graphExec);
     }
 
+    /// <summary>Blocks until all work on the backend's compute stream completes. Used to separate GPU-compute
+    /// time from the DtoH copy when profiling the captured-graph replay. No-op off CUDA.</summary>
+    public void SynchronizeStream()
+    {
+        if (GetBackend() is Engines.DirectGpu.CUDA.CudaBackend cbSync) cbSync.Synchronize();
+    }
+
     /// <summary>Frees a captured graph handle.</summary>
     public void DestroyGpuGraph(System.IntPtr graphExec)
     {

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -474,6 +474,29 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         t._gpuBufferVersion = t.Version;
     }
 
+    /// <summary>Binds <paramref name="t"/> to a STABLE resident GPU buffer (uploading its current host data),
+    /// so the captured graph reads a fixed device address and GetOrAllocateBuffer finds it (no re-upload mid-
+    /// capture). Call during the non-capturing pre-residency pass for each EXTERNAL stable input (the graph's
+    /// own intermediates become resident via FinishGpuOp under ResidentStepActive). Idempotent: re-binds the
+    /// current data into the existing buffer if already bound + big enough. float only / no-op off CUDA.</summary>
+    public void EnsureResidentInput<T>(Tensor<T> t)
+    {
+        if (typeof(T) != typeof(float) || t is null) return;
+        if (GetBackend() is not Engines.DirectGpu.CUDA.CudaBackend cb) return;
+        var data = t.GetDataArray();
+        if (t._gpuBuffer is { } existing && ReferenceEquals(t._gpuBackend, cb)
+            && existing.Handle != System.IntPtr.Zero && existing.Size >= data.Length)
+        {
+            cb.UploadBufferInPlace((float[])(object)data, existing);
+            t._gpuBufferVersion = t.Version;
+            return;
+        }
+        var buf = cb.AllocateBuffer((float[])(object)data); // sync upload — OK in the non-capturing pre-pass
+        t._gpuBuffer = buf;
+        t._gpuBackend = cb;
+        t._gpuBufferVersion = t.Version;
+    }
+
     /// <summary>Downloads <paramref name="t"/>'s resident GPU buffer (which a replayed graph just wrote) into a
     /// fresh host array. Needed for a graph OUTPUT: its deferred materializer caches after the first read, so a
     /// plain re-read returns the capture-step's stale values; this forces a fresh DtoH each replay. Returns null

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -18314,6 +18314,31 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     {
         if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
             return base.TensorBroadcastAdd(a, b);
+
+        // #1650 inference capture: per-channel [N,C,H,W] + [1,C,1,1] (conv bias) is NOT a last-axis
+        // broadcast, so the path below correctly declines it and the CPU base path would download a
+        // resident operand mid-capture. On the capture path, do it resident on-device via Conv2DBiasAdd
+        // (copy a → out, then add bias per channel). Gated on ResidentStepActive so non-capture inference
+        // is unchanged.
+        if (ResidentStepActive && typeof(T) == typeof(float) && !Gpu.AutocastScope.IsEnabled
+            && a.Rank == 4 && b.Rank == 4 && a.IsContiguous && b.IsContiguous
+            && b.Shape._dims[0] == 1 && b.Shape._dims[2] == 1 && b.Shape._dims[3] == 1
+            && a.Shape._dims[1] == b.Shape._dims[1]
+            && TryGetBackend(out var beCh) && beCh is Engines.DirectGpu.CUDA.CudaBackend cbCh)
+        {
+            try
+            {
+                int n = a.Shape._dims[0], c = a.Shape._dims[1], hw = a.Shape._dims[2] * a.Shape._dims[3];
+                using var abuf = GetResidentOrPersistentInputBuffer(beCh, a);
+                using var bbuf = GetResidentOrPersistentInputBuffer(beCh, b);
+                var outBuf = AllocateOutputBuffer(beCh, a.Length);
+                cbCh.Copy(abuf.Buffer, outBuf.Buffer, a.Length);          // out = a
+                cbCh.Conv2DBiasAdd(outBuf.Buffer, bbuf.Buffer, n, c, hw); // out += bias (per channel)
+                var resData = FinishGpuOp<T>(beCh, outBuf, a.Length);
+                return new Tensor<T>(resData, a.Shape._dims);
+            }
+            catch { /* fall through to the paths below */ }
+        }
         // BroadcastAddLast(outer, inner=b.Length) computes out[o*inner+i] = a[o*inner+i] + b[i] — i.e. b
         // MUST map to a's contiguous LAST axis (or be a scalar). For a channel-broadcast like
         // [N,C,H,W] + [1,C,1,1] the b vector spans the OUTER (channel) axis with stride H*W, so

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -6518,7 +6518,15 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
                 var biasedData = FinishGpuOp<T>(backend, outputBuffer, outputSize);
                 outputHandedOff = true;
-                return new Tensor<T>(biasedData, new[] { batch, outChannels, outHeight, outWidth });
+                var biasedT = new Tensor<T>(biasedData, new[] { batch, outChannels, outHeight, outWidth });
+                // #1650/#638: during the capture step, ALSO bind the output buffer as resident so a
+                // downstream in-place/resident op (e.g. the ResBlock residual add reading this conv's
+                // output as operand b) sees TryGetGpuBuffer() != null and stays on-device instead of
+                // downloading (CUDA-900 in capture). FinishGpuOp already keeps the buffer alive; this
+                // additionally exposes it for resident reuse. Gated → non-capture inference unchanged.
+                if (ResidentStepActive && typeof(T) == typeof(float))
+                    BindResidentBuffer(biasedT, outputBuffer.Buffer, backend);
+                return biasedT;
             }
             else
             {
@@ -6539,7 +6547,12 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 // lifetime from here, so it must NOT be disposed in the finally.
                 var resultData = FinishGpuOp<T>(backend, outputBuffer, outputSize);
                 outputHandedOff = true;
-                return new Tensor<T>(resultData, new[] { batch, outChannels, outHeight, outWidth });
+                var resultT = new Tensor<T>(resultData, new[] { batch, outChannels, outHeight, outWidth });
+                // #1650/#638: bind resident during capture (see bias path above) so downstream resident
+                // ops reuse the conv output on-device. Gated on ResidentStepActive → non-capture unchanged.
+                if (ResidentStepActive && typeof(T) == typeof(float))
+                    BindResidentBuffer(resultT, outputBuffer.Buffer, backend);
+                return resultT;
             }
         }
         catch

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -8993,8 +8993,9 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         using var queryBuffer = GetOrAllocateBuffer(backend, query);
         using var keyBuffer = GetOrAllocateBuffer(backend, key);
         using var valueBuffer = GetOrAllocateBuffer(backend, value);
-        using var outputBuffer = AllocateOutputBuffer(backend, batch * heads * seqQ * headDim);
-        using var statsBuffer = AllocateOutputBuffer(backend, batch * heads * seqQ);
+        var outputBuffer = AllocateOutputBuffer(backend, batch * heads * seqQ * headDim);
+        var statsBuffer = AllocateOutputBuffer(backend, batch * heads * seqQ);
+        bool faHanded = false;
 
         // Upload attention bias to GPU if provided, with shape validation
         int biasBatchStride = 0;
@@ -9008,6 +9009,19 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             backend.FlashAttentionV2(queryBuffer.Buffer, keyBuffer.Buffer, valueBuffer.Buffer, outputBuffer.Buffer, statsBuffer.Buffer,
                 batch, heads, seqQ, seqK, headDim, scaleFloat, isCausal,
                 biasBufferHandle.Buffer, biasBatchStride);
+
+            // #1650 capture path: DEFER the output/stats downloads (a sync DtoH aborts capture with 900).
+            // FinishGpuOp keeps the buffers resident + lazily materialized; downstream resident ops read them
+            // on-device and a host read downloads after scope.Execute(). softmaxStats is backward-only (unused
+            // in the inference forward) but deferred the same way for shape/contract parity.
+            if (ResidentStepActive && typeof(T) == typeof(float))
+            {
+                T[] outResident = FinishGpuOp<T>(backend, outputBuffer, batch * heads * seqQ * headDim);
+                T[] statsResident = FinishGpuOp<T>(backend, statsBuffer, batch * heads * seqQ);
+                faHanded = true; // FinishGpuOp owns the buffers' lifetime now (activation cache)
+                softmaxStats = new Tensor<T>(statsResident, new[] { batch, heads, seqQ });
+                return new Tensor<T>(outResident, new[] { batch, heads, seqQ, headDim });
+            }
 
             // DownloadBuffer uses blocking read, Synchronize() removed for performance
             float[] outputFloat = new float[batch * heads * seqQ * headDim];
@@ -9026,6 +9040,11 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             // Fall back to CPU on any GPU error
             return base.FlashAttention(query, key, value, scale, isCausal, out softmaxStats, attentionBias);
+        }
+        finally
+        {
+            // Free the GPU buffers unless they were handed to FinishGpuOp (resident path owns them).
+            if (!faHanded) { outputBuffer.Dispose(); statsBuffer.Dispose(); }
         }
     }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -4929,20 +4929,16 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
                 // #1650/#638 hardware-FP16 conv lever: on a CUDA-TOOLKIT box (Fp16HwConvAvailable) route through
                 // the in-kernel __half2 conv — FP32 in/out (same memory, capture-safe), FP16 compute (~2x on the
-                // FMA-bound deep convs). Driver-only box: Fp16HwConvAvailable is false → skip → FP32 below. The
-                // hw kernel reads FP32 and converts in-register, so NO cast buffers / activation chain needed.
-                bool fp16Ran = false;
+                // FMA-bound deep convs). Driver-only box: Fp16HwConvAvailable is false → FP32 path. The hw kernel
+                // reads FP32 and converts in-register, so NO cast buffers / activation chain needed.
+                // Fp16HwConvAvailable already gates the kernel-unsupported case, so DON'T swallow exceptions here:
+                // a failed launch / capture-invalidating error must propagate to the outer resident catch (which
+                // abandons the resident path + re-runs eager cleanly) rather than continuing a corrupted capture
+                // by appending an FP32 conv on top of it. (#671 review)
                 if (s_fp16Conv && rbk is Engines.DirectGpu.CUDA.CudaBackend cudaRbk && cudaRbk.Fp16HwConvAvailable)
-                {
-                    try
-                    {
-                        cudaRbk.Conv2DDirectFp16Hw(bufIn.Buffer, bufK.Buffer, outBuf,
-                            b, ic, ih, iw, oc, oh, ow, kh, kw, stride, stride, padding, padding, dilation, dilation);
-                        fp16Ran = true;
-                    }
-                    catch (Exception) { fp16Ran = false; } // any issue → FP32 fallback below
-                }
-                if (!fp16Ran)
+                    cudaRbk.Conv2DDirectFp16Hw(bufIn.Buffer, bufK.Buffer, outBuf,
+                        b, ic, ih, iw, oc, oh, ow, kh, kw, stride, stride, padding, padding, dilation, dilation);
+                else
                     rbk.Conv2D(bufIn.Buffer, bufK.Buffer, outBuf,
                         b, ic, ih, iw, oc, oh, ow, kh, kw, stride, stride, padding, padding, dilation, dilation);
                 ResidentSyncCheck("Conv2DInto");

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -539,9 +539,24 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     // #1650/#638 hardware-FP16 conv lever (AIDOTNET_FP16_CONV=1): route the resident conv through the in-kernel
     // __half2 conv (conv2d_direct_fp16hw, FP32 in/out, FP16 compute) on a CUDA-TOOLKIT box. No-op on a driver-
-    // only box (the kernel isn't compiled → Fp16HwConvAvailable false → FP32 fallback). Default OFF.
+    // only box (the im2col kernel isn't compiled → Fp16HwIm2colAvailable false → FP32 fallback). Default OFF.
     private static readonly bool s_fp16Conv =
         System.Environment.GetEnvironmentVariable("AIDOTNET_FP16_CONV") == "1";
+
+    // Cache the FP16 copy of each conv weight (constant across denoising steps), keyed by its resident FP32
+    // buffer handle. Converted ONCE (sync, on the pre-residency pass — not while stream-capturing); reused on
+    // every captured replay. The Tensor-Core GemmFp16 conv path needs the weights as FP16.
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<System.IntPtr, IGpuBuffer> _fp16WeightCache = new();
+    private IGpuBuffer GetOrCacheFp16Weights(IDirectGpuBackend backend, IGpuBuffer wFp32, int count)
+    {
+        if (_fp16WeightCache.TryGetValue(wFp32.Handle, out var cached)
+            && cached.Handle != System.IntPtr.Zero && cached.SizeInBytes >= (long)count * 2)
+            return cached;
+        var half = backend.AllocateBuffer(count); // count floats ≥ count halfs; sync alloc — only on the pre-residency miss
+        backend.ConvertToFp16(wFp32, half, count);
+        _fp16WeightCache[wFp32.Handle] = half;
+        return half;
+    }
 
     /// <summary>Pre-capture (sync alloc — call OUTSIDE stream capture): allocate/reuse a persistent output buffer
     /// sized to the forward's output. float only / no-op off CUDA.</summary>
@@ -4927,17 +4942,29 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 using var bufK = GetWeightBufferPreferResident(rbk, kernel, PersistentTensorRole.Weights);
                 var outBuf = GetOrCreateResidentBuffer(rbk, output, output.Length);
 
-                // #1650/#638 hardware-FP16 conv lever: on a CUDA-TOOLKIT box (Fp16HwConvAvailable) route through
-                // the in-kernel __half2 conv — FP32 in/out (same memory, capture-safe), FP16 compute (~2x on the
-                // FMA-bound deep convs). Driver-only box: Fp16HwConvAvailable is false → FP32 path. The hw kernel
-                // reads FP32 and converts in-register, so NO cast buffers / activation chain needed.
-                // Fp16HwConvAvailable already gates the kernel-unsupported case, so DON'T swallow exceptions here:
-                // a failed launch / capture-invalidating error must propagate to the outer resident catch (which
-                // abandons the resident path + re-runs eager cleanly) rather than continuing a corrupted capture
-                // by appending an FP32 conv on top of it. (#671 review)
-                if (s_fp16Conv && rbk is Engines.DirectGpu.CUDA.CudaBackend cudaRbk && cudaRbk.Fp16HwConvAvailable)
-                    cudaRbk.Conv2DDirectFp16Hw(bufIn.Buffer, bufK.Buffer, outBuf,
-                        b, ic, ih, iw, oc, oh, ow, kh, kw, stride, stride, padding, padding, dilation, dilation);
+                // #1650/#638 FP16-conv replay-floor lever (AIDOTNET_FP16_CONV=1, CUDA-toolkit box): the INDUSTRY
+                // path (oneDNN/cuDNN/PyTorch) — conv as a Tensor-Core GEMM. Fused FP16 im2col → col[K,N] (FP16),
+                // cached FP16 weights[outC,K], GemmFp16 (cublasGemmEx: FP16 multiply / FP32 accumulate on Tensor
+                // Cores) → out[outC,N]. Measured ~11x faster than the hand-rolled FP32 Winograd at 256ch (the
+                // Winograd kernel itself is ~5.7x slower than even an FP32 cuBLAS GEMM). Driver-only box: kernel
+                // absent → FP32 path. Fp16HwIm2colAvailable gates the unsupported case, so DON'T swallow here —
+                // a launch/capture failure must propagate to the outer resident catch (clean eager fallback). (#671)
+                int gemmK = ic * kh * kw, gemmN = b * oh * ow, gemmM = oc;
+                // Tensor-Core FP16 GEMM only PAYS OFF on a big-enough GEMM. The diffusion UNet's deep convs are
+                // at small spatial (8x8→N=64, 4x4→N=16) — tiny GEMMs where the im2col + GEMM-launch overhead
+                // exceeds the FP16 win and the MMA units sit idle. Gate on N (= outH*outW) and K so only the
+                // large convs (32x32 N=1024, 16x16 N=256) take the FP16 path; the small ones stay FP32 Winograd.
+                bool fp16ConvWorth = gemmN >= 64 && gemmK >= 64 && gemmM >= 16;
+                if (s_fp16Conv && fp16ConvWorth
+                    && rbk is Engines.DirectGpu.CUDA.CudaBackend cudaRbk && cudaRbk.Fp16HwIm2colAvailable
+                    && rbk is Engines.Gpu.IGpuHalfPrecisionBackend hbConvR && hbConvR.SupportsHgemm)
+                {
+                    int K = gemmK, N = gemmN, M = gemmM;
+                    using var colHalf = AllocateOutputBuffer(rbk, K * N); // float-sized buffer holds K*N FP16 col
+                    cudaRbk.UnfoldKNFp16Hw(bufIn.Buffer, colHalf.Buffer, b, ic, ih, iw, kh, kw, stride, stride, padding, padding, dilation, dilation);
+                    var wHalf = GetOrCacheFp16Weights(rbk, bufK.Buffer, M * K); // FP16 weights, converted once + cached
+                    hbConvR.GemmFp16In32fOut(wHalf, colHalf.Buffer, outBuf, M, N, K);
+                }
                 else
                     rbk.Conv2D(bufIn.Buffer, bufK.Buffer, outBuf,
                         b, ic, ih, iw, oc, oh, ow, kh, kw, stride, stride, padding, padding, dilation, dilation);

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -4942,26 +4942,25 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 using var bufK = GetWeightBufferPreferResident(rbk, kernel, PersistentTensorRole.Weights);
                 var outBuf = GetOrCreateResidentBuffer(rbk, output, output.Length);
 
-                // #1650/#638 FP16-conv replay-floor lever (AIDOTNET_FP16_CONV=1, CUDA-toolkit box): the INDUSTRY
-                // path (oneDNN/cuDNN/PyTorch) — conv as a Tensor-Core GEMM. Fused FP16 im2col → col[K,N] (FP16),
-                // cached FP16 weights[outC,K], GemmFp16 (cublasGemmEx: FP16 multiply / FP32 accumulate on Tensor
-                // Cores) → out[outC,N]. Measured ~11x faster than the hand-rolled FP32 Winograd at 256ch (the
-                // Winograd kernel itself is ~5.7x slower than even an FP32 cuBLAS GEMM). Driver-only box: kernel
-                // absent → FP32 path. Fp16HwIm2colAvailable gates the unsupported case, so DON'T swallow here —
-                // a launch/capture failure must propagate to the outer resident catch (clean eager fallback). (#671)
+                // #1650/#638 FP16-conv replay-floor lever (AIDOTNET_FP16_CONV=1): the INDUSTRY path (oneDNN/cuDNN/
+                // PyTorch) — conv as a GEMM on the matrix units. Fused FP16 im2col → col[K,N] (FP16), cached FP16
+                // weights[outC,K], GemmFp16In32fOut (FP16 multiply / FP32 accumulate on Tensor Cores / MFMA /
+                // simdgroup / coopmat) → out[outC,N]. Measured ~11x my FP32-Winograd on a big conv; end-to-end
+                // diffusion replay 25ms→17.7ms (1.41x). BACKEND-AGNOSTIC: dispatched via IGpuHalfPrecisionBackend
+                // (CUDA/HIP/Metal/OpenCL/Vulkan/WebGpu) — any backend whose Fp16Im2colAvailable is true. Don't
+                // swallow failures (the availability flag already gates support) — let them hit the outer catch.
                 int gemmK = ic * kh * kw, gemmN = b * oh * ow, gemmM = oc;
-                // Tensor-Core FP16 GEMM only PAYS OFF on a big-enough GEMM. The diffusion UNet's deep convs are
-                // at small spatial (8x8→N=64, 4x4→N=16) — tiny GEMMs where the im2col + GEMM-launch overhead
-                // exceeds the FP16 win and the MMA units sit idle. Gate on N (= outH*outW) and K so only the
-                // large convs (32x32 N=1024, 16x16 N=256) take the FP16 path; the small ones stay FP32 Winograd.
+                // The matrix-unit GEMM only PAYS OFF on a big-enough GEMM. Deep convs at small spatial (8x8→N=64,
+                // 4x4→N=16) are tiny GEMMs where the im2col + launch overhead exceeds the win. Gate on N/K/M so
+                // only the large convs take the FP16 path; the small ones stay on the FP32 conv kernel.
                 bool fp16ConvWorth = gemmN >= 64 && gemmK >= 64 && gemmM >= 16;
                 if (s_fp16Conv && fp16ConvWorth
-                    && rbk is Engines.DirectGpu.CUDA.CudaBackend cudaRbk && cudaRbk.Fp16HwIm2colAvailable
-                    && rbk is Engines.Gpu.IGpuHalfPrecisionBackend hbConvR && hbConvR.SupportsHgemm)
+                    && rbk is Engines.Gpu.IGpuHalfPrecisionBackend hbConvR
+                    && hbConvR.SupportsHgemm && hbConvR.Fp16Im2colAvailable)
                 {
                     int K = gemmK, N = gemmN, M = gemmM;
                     using var colHalf = AllocateOutputBuffer(rbk, K * N); // float-sized buffer holds K*N FP16 col
-                    cudaRbk.UnfoldKNFp16Hw(bufIn.Buffer, colHalf.Buffer, b, ic, ih, iw, kh, kw, stride, stride, padding, padding, dilation, dilation);
+                    hbConvR.Im2colKNFp16(bufIn.Buffer, colHalf.Buffer, b, ic, ih, iw, kh, kw, stride, stride, padding, padding, dilation, dilation);
                     var wHalf = GetOrCacheFp16Weights(rbk, bufK.Buffer, M * K); // FP16 weights, converted once + cached
                     hbConvR.GemmFp16In32fOut(wHalf, colHalf.Buffer, outBuf, M, N, K);
                 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -240,7 +240,7 @@ public sealed class GpuScope : IDisposable
 /// <para>For concurrent weight updates during inference, consider using separate engine instances
 /// or implementing external synchronization around weight update + invalidation sequences.</para>
 /// </remarks>
-public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDisposable
+public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDisposable, Engines.Gpu.IInferenceGraphCaptureEngine
 {
     private readonly DirectGpuEngine? _directGpu;
     private readonly bool _ownsDirectGpu;
@@ -415,7 +415,11 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// returns a replayable handle (IntPtr.Zero on failure / a non-capturable op — caller falls back to eager).
     /// Must be called inside a <see cref="EnterResidentCaptureScope"/> so the forward runs resident (capturable).</summary>
     public IntPtr CaptureGpuGraph(Action forward)
-        => GetBackend() is Engines.DirectGpu.CUDA.CudaBackend cb ? cb.CaptureGraph(forward) : System.IntPtr.Zero;
+    {
+        // Reject API misuse here rather than letting a null delegate surface as a backend-side failure.
+        if (forward is null) throw new System.ArgumentNullException(nameof(forward));
+        return GetBackend() is Engines.DirectGpu.CUDA.CudaBackend cb ? cb.CaptureGraph(forward) : System.IntPtr.Zero;
+    }
 
     /// <summary>Replays a graph captured by <see cref="CaptureGpuGraph"/> as a single cuGraphLaunch. Refresh
     /// input-buffer CONTENTS (via <see cref="RefreshResidentInputInPlace"/>) before calling to feed new data.</summary>
@@ -499,6 +503,11 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             t._gpuBufferVersion = t.Version;
             return;
         }
+        // Release the previous allocation before overwriting it. The reuse branch above already returned for a
+        // same-backend buffer big enough; reaching here means the old buffer is too small or on another backend,
+        // so dropping the reference without freeing would leak VRAM across recaptures / shape changes.
+        if (t._gpuBuffer is { } stale && stale.Handle != System.IntPtr.Zero)
+            stale.Dispose();
         var buf = cb.AllocateBuffer((float[])(object)data); // sync upload — OK in the non-capturing pre-pass
         t._gpuBuffer = buf;
         t._gpuBackend = cb;
@@ -549,13 +558,35 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     public Tensor<T> WriteOutputToStableCapture<T>(Tensor<T> output)
     {
         if (output is null) throw new System.ArgumentNullException(nameof(output));
+        // Genuinely off the capture path (a non-float / non-CUDA forward never captures): no-op pass-through.
         if (typeof(T) != typeof(float)) return output;
         if (GetBackend() is not Engines.DirectGpu.CUDA.CudaBackend cb) return output;
-        if (_stableCaptureOutput is null || _stableCaptureOutput.Handle == System.IntPtr.Zero) return output;
+        // On the ACTIVE capture path the misses below are unrecoverable invalid-capture states, NOT benign
+        // no-ops: returning `output` records no DtoD copy node, so the graph computes into its internal pool
+        // and a later DownloadOutput reads the now-stale externally-held pointer — the exact frozen-output
+        // regression this path exists to prevent. Throw so the caller abandons capture (falls back to eager)
+        // loudly and deterministically instead of silently producing a constant-output graph.
+        bool capturing = ResidentStepActive;
         int need = output.Length;
-        if (_stableCaptureOutputSize < need) return output;
+        if (_stableCaptureOutput is null || _stableCaptureOutput.Handle == System.IntPtr.Zero)
+        {
+            if (capturing) throw new System.InvalidOperationException(
+                "WriteOutputToStableCapture: stable capture-output buffer was not prepared (call PrepareStableCaptureOutput before capture).");
+            return output;
+        }
+        if (_stableCaptureOutputSize < need)
+        {
+            if (capturing) throw new System.InvalidOperationException(
+                $"WriteOutputToStableCapture: stable capture-output buffer (size {_stableCaptureOutputSize}) is smaller than the forward output ({need}).");
+            return output;
+        }
         var src = ResolveResidentBufferNoUpload(cb, output, need);
-        if (src is null) return output;
+        if (src is null)
+        {
+            if (capturing) throw new System.InvalidOperationException(
+                "WriteOutputToStableCapture: the forward output is not resident; cannot record the stable-output copy node.");
+            return output;
+        }
         cb.Copy(src, _stableCaptureOutput, need); // async on the compute stream — captured into the graph
         var stableT = new Tensor<T>(output.Shape._dims);
         BindResidentBuffer(stableT, _stableCaptureOutput, cb);
@@ -3804,13 +3835,25 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             int batch = input.Shape._dims[0], channels = input.Shape._dims[1];
             int spatial = input.Length / (batch * channels);
+            int statSize = batch * numGroups;
             using var bufIn = GetOrAllocateContiguousInputBuffer(backend, input);
             using var bufGamma = GetWeightBufferPreferResident(backend, gamma, PersistentTensorRole.Weights);
             using var bufBeta = GetWeightBufferPreferResident(backend, beta, PersistentTensorRole.Biases);
             var outBuf = GetOrCreateResidentBuffer(backend, output, input.Length);
-            if (!_gnSwishScratch.TryGetValue(arr, out var sc))
+            // Key AND validate by required capacity: the cache is keyed on the output backing array, but the
+            // same array can recur with different group metadata (batch*numGroups) or a larger input, and a
+            // reused undersized norm/mean/var buffer would feed GroupNorm out-of-bounds scratch. (Re)allocate
+            // when the cached buffers are too small — and do it HERE, during the pre-residency warmup pass, so
+            // the capture-time pass is a pure pool-hit (a miss/realloc inside stream capture is a graph-purity
+            // violation: CUDA 901).
+            if (!_gnSwishScratch.TryGetValue(arr, out var sc)
+                || sc.norm.Size < input.Length || sc.mean.Size < statSize || sc.var.Size < statSize)
             {
-                sc = (backend.AllocateBuffer(input.Length), backend.AllocateBuffer(batch * numGroups), backend.AllocateBuffer(batch * numGroups));
+                if (_gnSwishScratch.TryRemove(arr, out var oldSc))
+                {
+                    oldSc.norm.Dispose(); oldSc.mean.Dispose(); oldSc.var.Dispose();
+                }
+                sc = (backend.AllocateBuffer(input.Length), backend.AllocateBuffer(statSize), backend.AllocateBuffer(statSize));
                 _gnSwishScratch[arr] = sc;
             }
             // GroupNorm into the norm scratch, then Swish (x*sigmoid(x)) into the resident output.
@@ -9176,8 +9219,16 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 T[] outResident = FinishGpuOp<T>(backend, outputBuffer, batch * heads * seqQ * headDim);
                 T[] statsResident = FinishGpuOp<T>(backend, statsBuffer, batch * heads * seqQ);
                 faHanded = true; // FinishGpuOp owns the buffers' lifetime now (activation cache)
-                softmaxStats = new Tensor<T>(statsResident, new[] { batch, heads, seqQ });
-                return new Tensor<T>(outResident, new[] { batch, heads, seqQ, headDim });
+                var outResT = new Tensor<T>(outResident, new[] { batch, heads, seqQ, headDim });
+                var statsResT = new Tensor<T>(statsResident, new[] { batch, heads, seqQ });
+                // Bind the resident buffers (matching the resident branch above): FinishGpuOp registers them in
+                // the activation cache keyed on the backing array, but downstream resident ops probe the
+                // tensor's _gpuBuffer — without this bind they see none and fall back to host materialization,
+                // breaking the on-device chain during capture.
+                BindResidentBuffer(outResT, outputBuffer.Buffer, backend);
+                BindResidentBuffer(statsResT, statsBuffer.Buffer, backend);
+                softmaxStats = statsResT;
+                return outResT;
             }
 
             // DownloadBuffer uses blocking read, Synchronize() removed for performance

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -537,11 +537,25 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     private IGpuBuffer? _stableCaptureOutput;
     private int _stableCaptureOutputSize;
 
-    // #1650/#638 hardware-FP16 conv lever (AIDOTNET_FP16_CONV=1): route the resident conv through the in-kernel
-    // __half2 conv (conv2d_direct_fp16hw, FP32 in/out, FP16 compute) on a CUDA-TOOLKIT box. No-op on a driver-
-    // only box (the im2col kernel isn't compiled → Fp16HwIm2colAvailable false → FP32 fallback). Default OFF.
-    private static readonly bool s_fp16Conv =
-        System.Environment.GetEnvironmentVariable("AIDOTNET_FP16_CONV") == "1";
+    // #1650/#638 hardware-FP16 conv lever: route the resident inference conv through the INDUSTRY path (oneDNN/
+    // cuDNN/PyTorch) — im2col → FP16 col[K,N] → GemmFp16In32fOut (FP16 multiply / FP32 accumulate on the matrix
+    // units), backend-agnostic via IGpuHalfPrecisionBackend. DEFAULT ON (set AIDOTNET_FP16_CONV=0 to disable),
+    // VALIDATED before flipping on (PR #671 #2): primitive conv vs FP32 Conv2D relL2=0.028%; one full UNet forward
+    // end-to-end relL2=0.67% — at the cuBLAS run-to-run FP32-vs-FP32 noise floor (0.666%), PSNR 60.9 dB — and
+    // 1.40x faster end-to-end. Self-gates to FP32 where it can't or shouldn't run: no toolkit (the FP16 im2col
+    // kernel isn't compiled → Fp16Im2colAvailable false), backend without the kernel (HIP/Metal/OpenCL/Vulkan/
+    // WebGpu pending → false), or a too-small GEMM (size gate below). So default-on changes behavior ONLY on the
+    // validated CUDA-with-toolkit inference path; everywhere else it is inert.
+    private static readonly bool s_fp16ConvEnv =
+        System.Environment.GetEnvironmentVariable("AIDOTNET_FP16_CONV") != "0";
+
+    /// <summary>#1650/#638: runtime override for the FP16-conv gate. Used by the precision-validation tests
+    /// (<c>Fp16Conv_PrimitiveMatchesFp32Conv_OnCuda</c> / <c>Fp16Conv_TrajectoryMatchesFp32_OnCuda</c>) to force
+    /// FP32 (false) or FP16 (true) within one process, and by the graph-correctness test to isolate the graph path
+    /// from FP16 precision noise. Null ⇒ use the <c>AIDOTNET_FP16_CONV</c> env default (now ON unless ="0").</summary>
+    internal static bool? Fp16ConvOverride;
+
+    private static bool s_fp16Conv => Fp16ConvOverride ?? s_fp16ConvEnv;
 
     // Cache the FP16 copy of each conv weight (constant across denoising steps), keyed by its resident FP32
     // buffer handle. Converted ONCE (sync, on the pre-residency pass — not while stream-capturing); reused on
@@ -556,6 +570,24 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         backend.ConvertToFp16(wFp32, half, count);
         _fp16WeightCache[wFp32.Handle] = half;
         return half;
+    }
+
+    // #1650/#638: the FP16 im2col col[K,N] SCRATCH must be a STABLE, REUSED device buffer — NOT a fresh
+    // AllocateOutputBuffer each call. The captured graph (CaptureGpuGraph at ResidentInferenceGraph) replays the
+    // im2col + GEMM nodes; a per-call `using` scratch is freed after the pre-residency pass, so on replay the
+    // GEMM reads a freed / pool-reused VA → garbage output (the symptom: primitive conv correct, but the
+    // captured-forward path diverges 100%). Cache it (keyed by the conv's resident FP32 weight handle — K·N is
+    // fixed per conv layer) so the pre-residency pass (sync, capture-safe) allocates it ONCE and every captured
+    // replay reuses the same address. Mirrors _fp16WeightCache + the LayerNorm stable-scratch pattern.
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<System.IntPtr, IGpuBuffer> _fp16ColScratchCache = new();
+    private IGpuBuffer GetOrCacheFp16ColScratch(IDirectGpuBackend backend, IGpuBuffer wFp32Key, int count)
+    {
+        if (_fp16ColScratchCache.TryGetValue(wFp32Key.Handle, out var cached)
+            && cached.Handle != System.IntPtr.Zero && cached.SizeInBytes >= (long)count * 2)
+            return cached;
+        var scratch = backend.AllocateBuffer(count); // count floats ≥ count halfs; sync alloc — only on the pre-residency miss
+        _fp16ColScratchCache[wFp32Key.Handle] = scratch;
+        return scratch;
     }
 
     /// <summary>Pre-capture (sync alloc — call OUTSIDE stream capture): allocate/reuse a persistent output buffer
@@ -4959,10 +4991,11 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                     && hbConvR.SupportsHgemm && hbConvR.Fp16Im2colAvailable)
                 {
                     int K = gemmK, N = gemmN, M = gemmM;
-                    using var colHalf = AllocateOutputBuffer(rbk, K * N); // float-sized buffer holds K*N FP16 col
-                    hbConvR.Im2colKNFp16(bufIn.Buffer, colHalf.Buffer, b, ic, ih, iw, kh, kw, stride, stride, padding, padding, dilation, dilation);
+                    // STABLE cached col scratch (NOT a per-call `using` alloc) — capture-replay-safe (see method doc).
+                    var colHalf = GetOrCacheFp16ColScratch(rbk, bufK.Buffer, K * N);
+                    hbConvR.Im2colKNFp16(bufIn.Buffer, colHalf, b, ic, ih, iw, kh, kw, stride, stride, padding, padding, dilation, dilation);
                     var wHalf = GetOrCacheFp16Weights(rbk, bufK.Buffer, M * K); // FP16 weights, converted once + cached
-                    hbConvR.GemmFp16In32fOut(wHalf, colHalf.Buffer, outBuf, M, N, K);
+                    hbConvR.GemmFp16In32fOut(wHalf, colHalf, outBuf, M, N, K);
                 }
                 else
                     rbk.Conv2D(bufIn.Buffer, bufK.Buffer, outBuf,

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -5491,7 +5491,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         result = null;
         if (!ResidentStepActive || Gpu.AutocastScope.IsEnabled || typeof(T) != typeof(float)) return false;
         if (activationParams is not null || bias is null || weights.Rank != 2 || !input.IsContiguous) return false;
-        if (activation != FusedActivationType.None && activation != FusedActivationType.ReLU && activation != FusedActivationType.GELU)
+        if (activation != FusedActivationType.None && activation != FusedActivationType.ReLU
+            && activation != FusedActivationType.GELU && activation != FusedActivationType.Swish)
             return false;
         if (!TryGetBackend(out var backend) || backend is not Engines.DirectGpu.CUDA.CudaBackend cb) return false;
         int K = weights.Shape._dims[0];   // input features
@@ -5515,6 +5516,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             cb.BiasAdd(outBuf, bBuf.Buffer, outBuf, M, N);                     // += bias[N] (in place)
             if (activation == FusedActivationType.ReLU) cb.Relu(outBuf, outBuf, M * N);
             else if (activation == FusedActivationType.GELU) cb.Gelu(outBuf, outBuf, M * N);
+            else if (activation == FusedActivationType.Swish) cb.Swish(outBuf, outBuf, M * N);
             ResidentSyncCheck("FusedLinear");
             BindResidentBuffer(outTensor, outBuf, backend);
             result = outTensor;

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -537,6 +537,12 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     private IGpuBuffer? _stableCaptureOutput;
     private int _stableCaptureOutputSize;
 
+    // #1650/#638 hardware-FP16 conv lever (AIDOTNET_FP16_CONV=1): route the resident conv through the in-kernel
+    // __half2 conv (conv2d_direct_fp16hw, FP32 in/out, FP16 compute) on a CUDA-TOOLKIT box. No-op on a driver-
+    // only box (the kernel isn't compiled → Fp16HwConvAvailable false → FP32 fallback). Default OFF.
+    private static readonly bool s_fp16Conv =
+        System.Environment.GetEnvironmentVariable("AIDOTNET_FP16_CONV") == "1";
+
     /// <summary>Pre-capture (sync alloc — call OUTSIDE stream capture): allocate/reuse a persistent output buffer
     /// sized to the forward's output. float only / no-op off CUDA.</summary>
     public void PrepareStableCaptureOutput<T>(Tensor<T> sampleOutput)
@@ -4920,8 +4926,25 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 using var bufIn = GetOrAllocateContiguousInputBuffer(rbk, input);
                 using var bufK = GetWeightBufferPreferResident(rbk, kernel, PersistentTensorRole.Weights);
                 var outBuf = GetOrCreateResidentBuffer(rbk, output, output.Length);
-                rbk.Conv2D(bufIn.Buffer, bufK.Buffer, outBuf,
-                    b, ic, ih, iw, oc, oh, ow, kh, kw, stride, stride, padding, padding, dilation, dilation);
+
+                // #1650/#638 hardware-FP16 conv lever: on a CUDA-TOOLKIT box (Fp16HwConvAvailable) route through
+                // the in-kernel __half2 conv — FP32 in/out (same memory, capture-safe), FP16 compute (~2x on the
+                // FMA-bound deep convs). Driver-only box: Fp16HwConvAvailable is false → skip → FP32 below. The
+                // hw kernel reads FP32 and converts in-register, so NO cast buffers / activation chain needed.
+                bool fp16Ran = false;
+                if (s_fp16Conv && rbk is Engines.DirectGpu.CUDA.CudaBackend cudaRbk && cudaRbk.Fp16HwConvAvailable)
+                {
+                    try
+                    {
+                        cudaRbk.Conv2DDirectFp16Hw(bufIn.Buffer, bufK.Buffer, outBuf,
+                            b, ic, ih, iw, oc, oh, ow, kh, kw, stride, stride, padding, padding, dilation, dilation);
+                        fp16Ran = true;
+                    }
+                    catch (Exception) { fp16Ran = false; } // any issue → FP32 fallback below
+                }
+                if (!fp16Ran)
+                    rbk.Conv2D(bufIn.Buffer, bufK.Buffer, outBuf,
+                        b, ic, ih, iw, oc, oh, ow, kh, kw, stride, stride, padding, padding, dilation, dilation);
                 ResidentSyncCheck("Conv2DInto");
                 BindResidentBuffer(output, outBuf, rbk);
                 return;

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -3689,6 +3689,48 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         catch (Exception lex) { AliasDiag($"LN-resident FELLBACK in=[{string.Join(",", input._shape)}] inContig={input.IsContiguous}: {lex.GetType().Name}: {lex.Message}"); return false; }
     }
 
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<object, (IGpuBuffer norm, IGpuBuffer mean, IGpuBuffer var)> _gnSwishScratch = new();
+
+    /// <summary>
+    /// #1650/#638 GPU-RESIDENT GroupNorm+Swish (the diffusion ResBlock's <c>GroupNormSwishInto</c>):
+    /// reads the resident input + prefer-resident gamma/beta, runs GroupNorm then Swish into the
+    /// output's STABLE resident buffer, and BindResidentBuffer's the result — NO AllocateBuffer(data)
+    /// upload and NO DownloadIntoTensor (the legacy GPU path did both, which are non-capturable inside
+    /// CUDA-graph capture: CUDA 901 on the alloc, 900 on the sync download). Stats/norm scratch are
+    /// allocated ONCE (cached) so capture-time passes are pool-hits, not pool-growth. Returns false to
+    /// fall back to the legacy GPU/CPU path (non-resident / non-float / autocast).
+    /// </summary>
+    internal bool TryGroupNormSwishResidentInto<T>(Tensor<T> output, Tensor<T> input, int numGroups, Tensor<T> gamma, Tensor<T> beta, double epsilon)
+    {
+        if (!ResidentStepActive || Gpu.AutocastScope.IsEnabled || typeof(T) != typeof(float)) return false;
+        if (!TryGetBackend(out var backend) || input.Rank < 2) return false;
+        var arr = output.DataVector.GetBackingArrayUnsafe();
+        if (arr is null) return false;
+        try
+        {
+            int batch = input.Shape._dims[0], channels = input.Shape._dims[1];
+            int spatial = input.Length / (batch * channels);
+            using var bufIn = GetOrAllocateContiguousInputBuffer(backend, input);
+            using var bufGamma = GetWeightBufferPreferResident(backend, gamma, PersistentTensorRole.Weights);
+            using var bufBeta = GetWeightBufferPreferResident(backend, beta, PersistentTensorRole.Biases);
+            var outBuf = GetOrCreateResidentBuffer(backend, output, input.Length);
+            if (!_gnSwishScratch.TryGetValue(arr, out var sc))
+            {
+                sc = (backend.AllocateBuffer(input.Length), backend.AllocateBuffer(batch * numGroups), backend.AllocateBuffer(batch * numGroups));
+                _gnSwishScratch[arr] = sc;
+            }
+            // GroupNorm into the norm scratch, then Swish (x*sigmoid(x)) into the resident output.
+            // Arg order (batch, numGroups, channels, spatial) matches the corrected GroupNorm signature.
+            backend.GroupNorm(bufIn.Buffer, sc.norm, bufGamma.Buffer, bufBeta.Buffer, sc.mean, sc.var,
+                batch, numGroups, channels, spatial, (float)epsilon);
+            backend.Swish(sc.norm, outBuf, input.Length);
+            ResidentSyncCheck("GroupNormSwish");
+            BindResidentBuffer(output, outBuf, backend);
+            return true;
+        }
+        catch (Exception gex) { AliasDiag($"GNSwish-resident FELLBACK in=[{string.Join(",", input._shape)}]: {gex.GetType().Name}: {gex.Message}"); return false; }
+    }
+
     /// <summary>GPU-RESIDENT 2-D / ND×2-D matmul for the compiled step (e.g. attention out-proj / LM-head /
     /// any TensorMatMul against a 2-D weight): collapse A's leading dims into M and run backend.Gemm (C=A@B)
     /// into the destination's stable buffer — no host TensorMatMulFloatInto (which materializes inputs → a DtoH
@@ -4621,6 +4663,30 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (ShapesMatch(a.Shape._dims, b.Shape._dims) && TryRunBinaryInPlace(a, b,
             static (backend, bufA, bufB, size) => backend.Add(bufA, bufB, bufA, size)))
             return;
+
+        // #1650/#638 resident per-channel in-place add (diffusion time-embed residual: h[N,C,H,W] += t[.,C,1,1]).
+        // The shapes-differ broadcast otherwise falls to CpuEngine, which materializes `a` (DtoH download) —
+        // non-capturable inside CUDA-graph capture. Do it on-device via Conv2DBiasAdd (per-channel a += b) on
+        // a's resident buffer (mutated in place; a stays bound). Gated on ResidentStepActive so non-capture
+        // inference is unchanged. Mirrors the resident conv-bias TensorBroadcastAdd path.
+        if (ResidentStepActive && typeof(T) == typeof(float) && !Gpu.AutocastScope.IsEnabled
+            && a.Rank == 4 && b.Rank == 4 && a.IsContiguous
+            && b.Shape._dims[2] == 1 && b.Shape._dims[3] == 1
+            && a.Shape._dims[1] == b.Shape._dims[1]
+            && (b.Shape._dims[0] == 1 || b.Shape._dims[0] == a.Shape._dims[0])
+            && TryGetBackend(out var beCh) && beCh is Engines.DirectGpu.CUDA.CudaBackend cbCh)
+        {
+            try
+            {
+                int n = a.Shape._dims[0], c = a.Shape._dims[1], hw = a.Shape._dims[2] * a.Shape._dims[3];
+                using var abuf = GetResidentOrPersistentInputBuffer(beCh, a);
+                using var bbuf = GetResidentOrPersistentInputBuffer(beCh, b);
+                cbCh.Conv2DBiasAdd(abuf.Buffer, bbuf.Buffer, n, c, hw); // a += b (per channel), in place
+                ResidentSyncCheck("BroadcastAddInPlace");
+                return;
+            }
+            catch (Exception rex) { AliasDiag($"BCastAddInPlace-resident FELLBACK: {rex.GetType().Name}: {rex.Message}"); }
+        }
         // Shapes differ — CPU handles broadcasting logic
         base.TensorBroadcastAddInPlace(a, b);
     }
@@ -5092,6 +5158,9 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     void IEngine.GroupNormSwishInto<T>(Tensor<T> output, Tensor<T> input, int numGroups, Tensor<T> gamma, Tensor<T> beta, double epsilon)
     {
+        // #1650/#638: resident GPU path for the capture step (no host round-trip). Falls through to the
+        // legacy upload/compute/download GPU path (then CPU) when not in a resident step.
+        if (TryGroupNormSwishResidentInto(output, input, numGroups, gamma, beta, epsilon)) return;
         if (TryGetBackend(out var gpuBackend))
         {
             try

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -463,6 +463,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// <summary>Uploads <paramref name="t"/>'s current host data into its EXISTING resident GPU buffer in place
     /// (stable pointer) so a replayed graph — which reads the address captured at record time — sees fresh data.
     /// No-op if the tensor has no resident buffer on this engine. float only.</summary>
+
     public void RefreshResidentInputInPlace<T>(Tensor<T> t)
     {
         if (typeof(T) != typeof(float) || t is null) return;
@@ -508,6 +509,50 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         var buf = t._gpuBuffer;
         if (buf is null || !ReferenceEquals(t._gpuBackend, cb) || buf.Handle == System.IntPtr.Zero) return null;
         return cb.DownloadBuffer(buf);
+    }
+
+    // #1650 — STABLE captured-graph output. The forward's own output buffer is a graph-internal cuMemAllocAsync
+    // node; under CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH the graph frees+reallocs its pool every launch,
+    // so reading the capture-time output pointer after a later replay returns STALE data (the captured-step
+    // output) — the graph computes fresh values into the realloc'd internal buffer but the externally-held
+    // pointer no longer aliases them. Fix (the cortex resident-into pattern): pre-allocate ONE persistent buffer
+    // OUTSIDE the graph and make the final captured op copy the forward output into it, so the externally-read
+    // address is fixed and holds fresh data every replay.
+    private IGpuBuffer? _stableCaptureOutput;
+    private int _stableCaptureOutputSize;
+
+    /// <summary>Pre-capture (sync alloc — call OUTSIDE stream capture): allocate/reuse a persistent output buffer
+    /// sized to the forward's output. float only / no-op off CUDA.</summary>
+    public void PrepareStableCaptureOutput<T>(Tensor<T> sampleOutput)
+    {
+        if (typeof(T) != typeof(float) || sampleOutput is null) return;
+        if (GetBackend() is not Engines.DirectGpu.CUDA.CudaBackend cb) return;
+        int need = sampleOutput.Length;
+        if (_stableCaptureOutput is null || _stableCaptureOutput.Handle == System.IntPtr.Zero || _stableCaptureOutput.Size < need)
+        {
+            _stableCaptureOutput?.Dispose();
+            _stableCaptureOutput = cb.AllocateBuffer(need); // sync alloc — safe pre-capture
+            _stableCaptureOutputSize = need;
+        }
+    }
+
+    /// <summary>During capture: copy <paramref name="output"/> into the persistent buffer prepared by
+    /// <see cref="PrepareStableCaptureOutput"/> (async DtoD → a captured graph node) and return a tensor bound to
+    /// that fixed address. Returns the input unchanged off the capture path / on any miss. float only.</summary>
+    public Tensor<T> WriteOutputToStableCapture<T>(Tensor<T> output)
+    {
+        if (output is null) throw new System.ArgumentNullException(nameof(output));
+        if (typeof(T) != typeof(float)) return output;
+        if (GetBackend() is not Engines.DirectGpu.CUDA.CudaBackend cb) return output;
+        if (_stableCaptureOutput is null || _stableCaptureOutput.Handle == System.IntPtr.Zero) return output;
+        int need = output.Length;
+        if (_stableCaptureOutputSize < need) return output;
+        var src = ResolveResidentBufferNoUpload(cb, output, need);
+        if (src is null) return output;
+        cb.Copy(src, _stableCaptureOutput, need); // async on the compute stream — captured into the graph
+        var stableT = new Tensor<T>(output.Shape._dims);
+        BindResidentBuffer(stableT, _stableCaptureOutput, cb);
+        return stableT;
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/Gpu/DeferredScope.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/DeferredScope.cs
@@ -74,14 +74,23 @@ public sealed class DeferredScope : IDeferredScope
         _totalTimer = Stopwatch.StartNew();
 
         // Create the recording backend wrapper and start recording
-        _recordingBackend = new RecordingGpuBackend(backend);
+        _recordingBackend = new RecordingGpuBackend(backend)
+        {
+            ExecuteWhileRecording = options.ExecuteEagerlyWhileRecording
+        };
         _recordingBackend.BeginRecording(GraphBuilder);
 
         // #642: defer buffer releases for the lifetime of this scope. Ops allocate buffers
         // eagerly during recording but their compute is replayed at Execute(); without this the
         // engine's normal tensor lifetime frees those buffers mid-record, leaving the recorded
         // graph pointing at freed device memory. Flushed in Execute()/Dispose().
-        GpuBufferReleaseDeferral.Begin();
+        // Trace-by-execution runs ops eagerly during recording, so buffers are consumed immediately
+        // and there is nothing to keep alive for a later replay — deferring releases there only
+        // perturbs the engine's buffer reuse vs. the eager path. Skip it in that mode.
+        if (!_recordingBackend.ExecuteWhileRecording)
+        {
+            GpuBufferReleaseDeferral.Begin();
+        }
 
         // Set this scope as current (save parent for restore on dispose)
         _parentScope = _current;
@@ -136,7 +145,13 @@ public sealed class DeferredScope : IDeferredScope
 
             var executionTimer = Stopwatch.StartNew();
 
-            if (_streamPool != null)
+            if (_recordingBackend.ExecuteWhileRecording)
+            {
+                // Trace-by-execution: every op already ran eagerly at record time. Replaying the graph
+                // would execute each op a second time — harmless for pure functional kernels but wrong
+                // for in-place / accumulate ops. The recorded graph remains available via Compile().
+            }
+            else if (_streamPool != null)
             {
                 graph.Execute(_backend, _streamPool);
             }
@@ -187,7 +202,11 @@ public sealed class DeferredScope : IDeferredScope
 
             var executionTimer = Stopwatch.StartNew();
 
-            if (_streamPool != null)
+            if (_recordingBackend.ExecuteWhileRecording)
+            {
+                // Trace-by-execution: ops already ran eagerly at record time (see Execute()).
+            }
+            else if (_streamPool != null)
             {
                 await graph.ExecuteAsync(_backend, _streamPool, cancellationToken);
             }
@@ -231,6 +250,7 @@ public sealed class DeferredScope : IDeferredScope
     {
         if (_deferralEnded) return;
         _deferralEnded = true;
+        if (_recordingBackend.ExecuteWhileRecording) return; // no Begin() was issued in trace-by-execution mode
         GpuBufferReleaseDeferral.EndAndRelease();
     }
 

--- a/src/AiDotNet.Tensors/Engines/Gpu/GpuExecutionOptions.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/GpuExecutionOptions.cs
@@ -115,6 +115,23 @@ public sealed class GpuExecutionOptions
     public bool CacheCompiledGraphs { get; set; } = true;
 
     /// <summary>
+    /// When true, the <see cref="RecordingGpuBackend"/> EXECUTES each operation eagerly at
+    /// record time (in addition to recording it into the graph), and <see cref="DeferredScope.Execute"/>
+    /// does NOT replay the graph (it would re-run already-executed ops, double-computing and corrupting
+    /// any in-place/accumulate op). Default: false (pure deferral — ops execute only at graph-execute time).
+    /// <para>
+    /// Pure deferral is only correct when EVERY op in the recorded region routes through a deferrable
+    /// primitive (the ~28 overridden in <see cref="RecordingGpuBackend"/>). A forward that also uses
+    /// non-overridden ops (GroupNorm, reductions, upsample, concat, …) or an already-compiled plan
+    /// (the diffusion UNet's <c>PredictCompiledForward</c>) has those ops fall through to the inner
+    /// backend and execute EAGERLY mid-record — reading buffers whose deferred producers have not run
+    /// yet (garbage). Setting this true makes recording a faithful trace-by-execution (the same contract
+    /// as CUDA-graph stream capture): the forward runs correctly on the GPU and a graph is still recorded.
+    /// </para>
+    /// </summary>
+    public bool ExecuteEagerlyWhileRecording { get; set; } = false;
+
+    /// <summary>
     /// Creates options with default values.
     /// </summary>
     public GpuExecutionOptions()
@@ -238,7 +255,8 @@ public sealed class GpuExecutionOptions
             TransferStreams = TransferStreams,
             EnableProfiling = EnableProfiling,
             GraphBatchSize = GraphBatchSize,
-            CacheCompiledGraphs = CacheCompiledGraphs
+            CacheCompiledGraphs = CacheCompiledGraphs,
+            ExecuteEagerlyWhileRecording = ExecuteEagerlyWhileRecording
         };
     }
 

--- a/src/AiDotNet.Tensors/Engines/Gpu/Graph/ExecutionGraph.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/Graph/ExecutionGraph.cs
@@ -61,7 +61,7 @@ public sealed class ExecutionGraph : IDisposable
 
         TotalEstimatedCost = _nodes.Sum(n => n.EstimatedCost);
         CriticalPathLength = _levelNodes.Count;
-        MaxParallelism = _levelNodes.Values.Max(level => level.Count);
+        MaxParallelism = _levelNodes.Count == 0 ? 0 : _levelNodes.Values.Max(level => level.Count);
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/Gpu/IGpuHalfPrecisionBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/IGpuHalfPrecisionBackend.cs
@@ -94,4 +94,21 @@ public interface IGpuHalfPrecisionBackend
     /// real buffer; backends supply a temporary internally if a backend-specific null is allowed).</summary>
     void Fp16LayerNorm(IGpuBuffer input, IGpuBuffer gamma, IGpuBuffer beta, IGpuBuffer output,
         IGpuBuffer meanFp32, IGpuBuffer varFp32, int rows, int cols, float eps);
+
+    /// <summary>True when this backend ships the fused FP16 im2col kernel (<see cref="Im2colKNFp16"/>) that the
+    /// Tensor-Core FP16 conv path needs (#1650/#638). False ⇒ the engine keeps the FP32 conv. Distinct from
+    /// <see cref="SupportsHgemm"/> because the half GEMM can exist before the conv im2col kernel is ported.</summary>
+    bool Fp16Im2colAvailable { get; }
+
+    /// <summary>
+    /// FUSED im2col + FP32→FP16, writing the col matrix in the TRANSPOSED [K, N] layout
+    /// (K = channels·kernelH·kernelW, N = batch·outH·outW) so the conv becomes a plain NN GEMM:
+    /// <c>out[outC, N] = weights[outC, K] · col[K, N]</c> via <see cref="GemmFp16In32fOut"/> (FP16 multiply /
+    /// FP32 accumulate on the Tensor-Core / matrix units) — the industry FP16-conv path (oneDNN/cuDNN/PyTorch).
+    /// <paramref name="outputHalf"/> is an FP16 (half / 16-bit) buffer of at least K·N elements. The kernel
+    /// MUST launch one thread per col element (N·K threads) for coalesced writes + full occupancy. Capture-safe.
+    /// </summary>
+    void Im2colKNFp16(IGpuBuffer input, IGpuBuffer outputHalf,
+        int batch, int channels, int height, int width,
+        int kernelH, int kernelW, int strideH, int strideW, int padH, int padW, int dilationH, int dilationW);
 }

--- a/src/AiDotNet.Tensors/Engines/Gpu/IInferenceGraphCaptureEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/IInferenceGraphCaptureEngine.cs
@@ -42,6 +42,9 @@ public interface IInferenceGraphCaptureEngine
     void RefreshResidentInputInPlace<T>(Tensor<T> t);
 
     /// <summary>Downloads <paramref name="t"/>'s resident GPU buffer (which a replayed graph just wrote) into
-    /// a fresh host array, forcing a fresh DtoH each replay. Null if the tensor has no resident buffer.</summary>
+    /// a fresh host array, forcing a fresh DtoH each replay. Returns <see langword="null"/> if the tensor has no
+    /// resident buffer. Resident inference buffers are float-only, so the result is <c>float[]</c> regardless of
+    /// <typeparamref name="T"/> (the generic parameter is for call-site convenience; a non-float
+    /// <typeparamref name="T"/> has no resident buffer and yields null).</summary>
     float[]? DownloadResidentBuffer<T>(Tensor<T> t);
 }

--- a/src/AiDotNet.Tensors/Engines/Gpu/IInferenceGraphCaptureEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/IInferenceGraphCaptureEngine.cs
@@ -1,0 +1,47 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines.Gpu;
+
+/// <summary>
+/// #1650: optional capability interface for engines that can capture a model's eager GPU forward into
+/// a replayable CUDA graph (the TensorRT-LLM / vLLM decode-graph lever). Consumers typed against the
+/// core <c>IEngine</c> downcast to this interface (<c>engine is IInferenceGraphCaptureEngine cap</c>)
+/// to reach the capture surface without a concrete-type cast.
+/// <para>
+/// Kept off the base engine interface — like <see cref="IGpuHalfPrecisionBackend"/> — because only the
+/// CUDA-backed <c>DirectGpuTensorEngine</c> ships graph capture; making it a base member would force
+/// every CPU/other-backend engine to implement no-ops or throw <c>NotSupportedException</c>.
+/// </para>
+/// </summary>
+public interface IInferenceGraphCaptureEngine
+{
+    /// <summary>True when this engine is backed by a backend that can capture/replay CUDA graphs.</summary>
+    bool SupportsInferenceGraphCapture { get; }
+
+    /// <summary>Records the GPU kernel launches issued by <paramref name="forward"/> into a CUDA graph and
+    /// returns a replayable handle (<see cref="IntPtr.Zero"/> on failure / a non-capturable op). Must be
+    /// called inside an <see cref="EnterResidentCaptureScope"/> so the forward runs resident (capturable).</summary>
+    IntPtr CaptureGpuGraph(Action forward);
+
+    /// <summary>Replays a graph captured by <see cref="CaptureGpuGraph"/> as a single cuGraphLaunch.</summary>
+    void LaunchGpuGraph(IntPtr graphExec);
+
+    /// <summary>Frees a captured graph handle.</summary>
+    void DestroyGpuGraph(IntPtr graphExec);
+
+    /// <summary>Enters the resident capture path (eviction suspended, resident in-place ops engaged). The
+    /// returned scope reverses it on Dispose — keep it alive for the captured graph's lifetime. Null on a
+    /// non-supporting backend.</summary>
+    IDisposable? EnterResidentCaptureScope();
+
+    /// <summary>Uploads <paramref name="t"/>'s current host data into its EXISTING resident GPU buffer in
+    /// place (stable pointer) so a replayed graph reads fresh per-call data. No-op without a resident buffer.</summary>
+    void RefreshResidentInputInPlace<T>(Tensor<T> t);
+
+    /// <summary>Downloads <paramref name="t"/>'s resident GPU buffer (which a replayed graph just wrote) into
+    /// a fresh host array, forcing a fresh DtoH each replay. Null if the tensor has no resident buffer.</summary>
+    float[]? DownloadResidentBuffer<T>(Tensor<T> t);
+}

--- a/src/AiDotNet.Tensors/Engines/Gpu/RecordingGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/RecordingGpuBackend.cs
@@ -44,6 +44,14 @@ public class RecordingGpuBackend : DelegatingGpuBackend
     private bool _isRecording;
 
     /// <summary>
+    /// When true, each recorded operation is ALSO executed eagerly at record time (trace-by-execution),
+    /// so intermediates are valid for any non-deferred op that reads them mid-record and the forward
+    /// produces correct output. The owning <see cref="DeferredScope"/> must then NOT replay the graph
+    /// (it would double-execute). See <see cref="GpuExecutionOptions.ExecuteEagerlyWhileRecording"/>.
+    /// </summary>
+    public bool ExecuteWhileRecording { get; set; }
+
+    /// <summary>
     /// Gets whether the backend is currently recording operations.
     /// </summary>
     public bool IsRecording => _isRecording;
@@ -114,6 +122,9 @@ public class RecordingGpuBackend : DelegatingGpuBackend
             Action<IDirectGpuBackend, IGpuStream?> deferredAction = (backend, stream) => executeAction();
 
             _graphBuilder.AddKernel(kernelType, inputTensors, outputTensors, deferredAction, parameters);
+
+            // Trace-by-execution: also run now so any non-deferred reader downstream sees real data.
+            if (ExecuteWhileRecording) executeAction();
         }
         else
         {
@@ -158,6 +169,7 @@ public class RecordingGpuBackend : DelegatingGpuBackend
                 () => Inner.Gemm(A, B, output, M, N, K, 1.0f, 0.0f),
                 new Dictionary<string, object> { ["M"] = M, ["N"] = N, ["K"] = K });
 
+            // Note: RecordOrExecute already eager-executes the Gemm-into-output when ExecuteWhileRecording.
             return output;
         }
 
@@ -209,6 +221,7 @@ public class RecordingGpuBackend : DelegatingGpuBackend
                 M, N, K, FusedActivationType.ReLU, action);
 
             _graphBuilder.AddNode(node);
+            if (ExecuteWhileRecording) action(Inner, null);
             return output;
         }
 
@@ -237,6 +250,7 @@ public class RecordingGpuBackend : DelegatingGpuBackend
                 M, N, K, FusedActivationType.GELU, action);
 
             _graphBuilder.AddNode(node);
+            if (ExecuteWhileRecording) action(Inner, null);
             return output;
         }
 
@@ -265,6 +279,7 @@ public class RecordingGpuBackend : DelegatingGpuBackend
                 M, N, K, FusedActivationType.Sigmoid, action);
 
             _graphBuilder.AddNode(node);
+            if (ExecuteWhileRecording) action(Inner, null);
             return output;
         }
 
@@ -293,6 +308,7 @@ public class RecordingGpuBackend : DelegatingGpuBackend
                 M, N, K, FusedActivationType.Tanh, action);
 
             _graphBuilder.AddNode(node);
+            if (ExecuteWhileRecording) action(Inner, null);
             return output;
         }
 
@@ -321,6 +337,7 @@ public class RecordingGpuBackend : DelegatingGpuBackend
                 M, N, K, FusedActivationType.None, action);
 
             _graphBuilder.AddNode(node);
+            if (ExecuteWhileRecording) action(Inner, null);
             return output;
         }
 
@@ -400,6 +417,7 @@ public class RecordingGpuBackend : DelegatingGpuBackend
 
             _graphBuilder.AddActivation(inputTensor, outputTensor, FusedActivationType.ReLU,
                 (backend, stream) => backend.Relu(A, B, size));
+            if (ExecuteWhileRecording) Inner.Relu(A, B, size);
         }
         else
         {
@@ -417,6 +435,7 @@ public class RecordingGpuBackend : DelegatingGpuBackend
 
             _graphBuilder.AddActivation(inputTensor, outputTensor, FusedActivationType.Sigmoid,
                 (backend, stream) => backend.Sigmoid(A, B, size));
+            if (ExecuteWhileRecording) Inner.Sigmoid(A, B, size);
         }
         else
         {
@@ -434,6 +453,7 @@ public class RecordingGpuBackend : DelegatingGpuBackend
 
             _graphBuilder.AddActivation(inputTensor, outputTensor, FusedActivationType.Tanh,
                 (backend, stream) => backend.Tanh(A, B, size));
+            if (ExecuteWhileRecording) Inner.Tanh(A, B, size);
         }
         else
         {
@@ -451,6 +471,7 @@ public class RecordingGpuBackend : DelegatingGpuBackend
 
             _graphBuilder.AddActivation(inputTensor, outputTensor, FusedActivationType.GELU,
                 (backend, stream) => backend.Gelu(A, B, size));
+            if (ExecuteWhileRecording) Inner.Gelu(A, B, size);
         }
         else
         {
@@ -468,6 +489,7 @@ public class RecordingGpuBackend : DelegatingGpuBackend
 
             _graphBuilder.AddActivation(inputTensor, outputTensor, FusedActivationType.Softmax,
                 (backend, stream) => backend.Softmax(A, B, batchSize, features));
+            if (ExecuteWhileRecording) Inner.Softmax(A, B, batchSize, features);
         }
         else
         {
@@ -485,6 +507,7 @@ public class RecordingGpuBackend : DelegatingGpuBackend
 
             _graphBuilder.AddActivation(inputTensor, outputTensor, FusedActivationType.LeakyReLU,
                 (backend, stream) => backend.LeakyRelu(A, B, alpha, size));
+            if (ExecuteWhileRecording) Inner.LeakyRelu(A, B, alpha, size);
         }
         else
         {
@@ -502,6 +525,7 @@ public class RecordingGpuBackend : DelegatingGpuBackend
 
             _graphBuilder.AddActivation(inputTensor, outputTensor, FusedActivationType.Swish,
                 (backend, stream) => backend.Swish(A, B, size));
+            if (ExecuteWhileRecording) Inner.Swish(A, B, size);
         }
         else
         {
@@ -749,6 +773,7 @@ public class RecordingGpuBackend : DelegatingGpuBackend
         if (_isRecording && _graphBuilder != null)
         {
             _graphBuilder.AddCopy(source, destination, size);
+            if (ExecuteWhileRecording) Inner.Copy(source, destination, size);
         }
         else
         {

--- a/src/AiDotNet.Tensors/Engines/Gpu/ResidentInferenceGraph.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/ResidentInferenceGraph.cs
@@ -112,6 +112,17 @@ public sealed class ResidentInferenceGraph : System.IDisposable
         // pre-residency pass so every op binds its stable resident buffer, then record the forward.
         try
         {
+            // RESIDENT-VS-CPU VERIFY (AIDOTNET_RESIDENT_VERIFY=1): run the SAME input eagerly first (outside
+            // the scope → ResidentStepActive off → CPU/host reference), then compare the resident pre-residency
+            // forward to it. Localizes a wrong resident op immediately, per build, with NO capture needed.
+            float[]? verifyRef = null;
+            bool verify = System.Environment.GetEnvironmentVariable("AIDOTNET_RESIDENT_VERIFY") == "1";
+            if (verify)
+            {
+                var refOut = forward(s);
+                verifyRef = refOut.AsSpan().ToArray() as float[];
+            }
+
             _scope = _engine.EnterResidentCaptureScope();
             if (_scope is null) { _disabled = true; return forward(s); }
 
@@ -119,7 +130,15 @@ public sealed class ResidentInferenceGraph : System.IDisposable
             // stable device address (no re-upload mid-capture). The forward's own intermediates become
             // resident under the capture path.
             for (int i = 0; i < s.Length; i++) _engine.EnsureResidentInput(s[i]);
-            _ = forward(s); // pre-residency: bind resident buffers (sync uploads here are fine — not capturing)
+            var preResOut = forward(s); // pre-residency: bind resident buffers (sync uploads here are fine — not capturing)
+            if (verify && verifyRef is not null)
+            {
+                var got = preResOut.AsSpan();
+                double maxd = 0; int n = System.Math.Min(got.Length, verifyRef.Length);
+                for (int i = 0; i < n; i++) maxd = System.Math.Max(maxd, System.Math.Abs(System.Convert.ToDouble(got[i]) - verifyRef[i]));
+                try { System.IO.File.AppendAllText(System.IO.Path.Combine(System.IO.Path.GetTempPath(), "aidotnet_resident_verify.txt"),
+                    $"resident-vs-cpu maxAbsDiff={maxd:E4} n={got.Length}\n"); } catch { }
+            }
             for (int i = 0; i < s.Length; i++) _engine.RefreshResidentInputInPlace(s[i]);
 
             // RESIDENCY AUDIT (AIDOTNET_RESIDENT_AUDIT=1): run one more resident pass with the audit log

--- a/src/AiDotNet.Tensors/Engines/Gpu/ResidentInferenceGraph.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/ResidentInferenceGraph.cs
@@ -151,6 +151,11 @@ public sealed class ResidentInferenceGraph : System.IDisposable
             // caller never receives a stale (frozen-buffer) result.
             if (_exec != System.IntPtr.Zero) { _engine.DestroyGpuGraph(_exec); _exec = System.IntPtr.Zero; }
             _output = null;
+            // Dispose the capture scope BEFORE the eager fallback: it resumes activation eviction and clears
+            // ResidentStepActive, so forward(s) runs as a normal eager pass — not under resident-capture state
+            // (which would keep binding/pinning resident buffers for a graph that no longer exists). (#671 review)
+            _scope?.Dispose();
+            _scope = null;
             _disabled = true;
             return forward(s);
           }

--- a/src/AiDotNet.Tensors/Engines/Gpu/ResidentInferenceGraph.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/ResidentInferenceGraph.cs
@@ -22,6 +22,10 @@ public sealed class ResidentInferenceGraph : System.IDisposable
 {
     private readonly DirectGpuTensorEngine _engine;
     private readonly int _warmupRuns;
+    // Serializes Forward on a single graph instance: _stableInputs/_exec/_output and the stable device
+    // buffers are shared mutable state, so two concurrent calls could interleave input copy/refresh/launch
+    // and replay one request with another's inputs.
+    private readonly object _gate = new object();
     private System.IntPtr _exec;
     private object? _stableInputs;   // Tensor<T>[]
     private object? _output;         // Tensor<T> captured output (its resident buffer is what the graph writes)
@@ -57,7 +61,14 @@ public sealed class ResidentInferenceGraph : System.IDisposable
     {
         if (inputs is null) throw new System.ArgumentNullException(nameof(inputs));
         if (forward is null) throw new System.ArgumentNullException(nameof(forward));
+        // Validate every element up front — the diagnostic loop and shape handling below dereference
+        // inputs[i], so a null slot must surface as a clear contract error, not an NRE deep inside.
+        for (int i = 0; i < inputs.Length; i++)
+            if (inputs[i] is null) throw new System.ArgumentException($"inputs[{i}] is null.", nameof(inputs));
 
+        // Serialize the whole forward/capture/replay on this instance (shared mutable graph state — see _gate).
+        lock (_gate)
+        {
         if (System.Environment.GetEnvironmentVariable("AIDOTNET_INFGRAPH_DIAG") == "1")
         {
             var sh = new System.Text.StringBuilder();
@@ -102,6 +113,8 @@ public sealed class ResidentInferenceGraph : System.IDisposable
         // REPLAY: refresh stable input buffers in place, one cuGraphLaunch, fresh download of the output.
         if (_exec != System.IntPtr.Zero)
         {
+          try
+          {
             bool timing = System.Environment.GetEnvironmentVariable("AIDOTNET_INFGRAPH_TIMING") == "1";
             bool breakdown = timing && System.Environment.GetEnvironmentVariable("AIDOTNET_INFGRAPH_TIMING_BREAKDOWN") == "1";
             double freq = System.Diagnostics.Stopwatch.Frequency / 1_000_000.0;
@@ -131,11 +144,23 @@ public sealed class ResidentInferenceGraph : System.IDisposable
                     $"REPLAY inSum(s0)={inSum:F4} timeSum(s1)={tSum:F4} -> outSum={outSum:F4}\n"); } catch { }
             }
             return outR;
+          }
+          catch (System.InvalidOperationException)
+          {
+            // Resident replay/download failed — fail closed: discard the graph and run eager so the
+            // caller never receives a stale (frozen-buffer) result.
+            if (_exec != System.IntPtr.Zero) { _engine.DestroyGpuGraph(_exec); _exec = System.IntPtr.Zero; }
+            _output = null;
+            _disabled = true;
+            return forward(s);
+          }
         }
 
         // WARMUP: a few eager forwards on the stable inputs so lazy allocs / autotune settle.
+        // <= so warmupRuns eager forwards run before capture (the count is incremented first, so a
+        // strict < would run only warmupRuns-1 — and zero at the clamped minimum of 1).
         _warmup++;
-        if (_warmup < _warmupRuns)
+        if (_warmup <= _warmupRuns)
         {
             if (System.Environment.GetEnvironmentVariable("AIDOTNET_INFGRAPH_TIMING") == "1")
             {
@@ -266,21 +291,30 @@ public sealed class ResidentInferenceGraph : System.IDisposable
                     System.IO.Path.Combine(System.IO.Path.GetTempPath(), "aidotnet_graphcapture_diag.txt"),
                     $"[RESIDENT-INF-GRAPH] capture threw: {ex.GetType().Name}: {ex.Message} | {ex.StackTrace?.Replace("\r", "").Replace("\n", " >> ")}\n"); } catch { }
             }
+            // A launch/download can throw after _exec was assigned (Lines above). Destroy the partially
+            // captured graph so HasGraph reports false and the handle is not leaked until Dispose.
+            if (_exec != System.IntPtr.Zero) { _engine.DestroyGpuGraph(_exec); _exec = System.IntPtr.Zero; }
+            _output = null;
             _scope?.Dispose();
             _scope = null;
             _disabled = true;
             return forward(inputs);
         }
+        } // lock (_gate)
     }
 
 
     private Tensor<T> DownloadOutput<T>()
     {
-        var outT = (Tensor<T>)_output!;
+        if (_output is not Tensor<T> outT)
+            throw new System.InvalidOperationException("Resident graph output is not available for download.");
         var data = _engine.DownloadResidentBuffer(outT);
-        if (data is not null && _outShape is not null)
-            return new Tensor<T>(_outShape, new Vector<T>((T[])(object)data));
-        return outT; // fallback: the tensor's own (possibly stale) data
+        if (data is null || _outShape is null)
+            // Fail closed: the graph wrote the resident buffer, not necessarily outT's host data, so
+            // returning outT would surface a stale (frozen-buffer) result. Throwing lets the caller
+            // disable capture and fall back to eager — never a stale inference result.
+            throw new System.InvalidOperationException("Resident output download failed; refusing to return stale inference result.");
+        return new Tensor<T>(_outShape, new Vector<T>((T[])(object)data));
     }
 
     private static bool ShapeMatches<T>(Tensor<T> a, Tensor<T> b)

--- a/src/AiDotNet.Tensors/Engines/Gpu/ResidentInferenceGraph.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/ResidentInferenceGraph.cs
@@ -54,32 +54,51 @@ public sealed class ResidentInferenceGraph : System.IDisposable
         if (inputs is null) throw new System.ArgumentNullException(nameof(inputs));
         if (forward is null) throw new System.ArgumentNullException(nameof(forward));
 
+        if (System.Environment.GetEnvironmentVariable("AIDOTNET_INFGRAPH_DIAG") == "1")
+        {
+            var sh = new System.Text.StringBuilder();
+            for (int i = 0; i < inputs.Length; i++) sh.Append($"[{string.Join("x", inputs[i].Shape._dims)}]");
+            var stb = _stableInputs as Tensor<T>[];
+            var ss = new System.Text.StringBuilder();
+            if (stb != null) for (int i = 0; i < stb.Length; i++) ss.Append($"[{string.Join("x", stb[i].Shape._dims)}]");
+            try { System.IO.File.AppendAllText(System.IO.Path.Combine(System.IO.Path.GetTempPath(), "aidotnet_infgraph_diag.txt"),
+                $"RIG.Forward<{typeof(T).Name}>: disabled={_disabled} warmup={_warmup} hasGraph={_exec != System.IntPtr.Zero} inShapes={sh} stableShapes={ss}\n"); } catch { }
+        }
+
         if (_disabled || typeof(T) != typeof(float) || !_engine.SupportsInferenceGraphCapture)
             return forward(inputs); // eager passthrough (no capture possible / already abandoned)
 
         // Stable input copies — fixed device addresses the captured graph reads from.
         var stable = (Tensor<T>[]?)_stableInputs;
-        if (stable is null)
+        // (Re)build the stable input copies on the first call OR when the shape changes — e.g. the first
+        // PredictNoise is an internal lazy-shape-resolution probe at a smaller size ([1,3,16,16]) before the
+        // real denoising steps ([1,3,32,32]); lock onto the steady-state shape rather than the probe. A shape
+        // change discards any graph captured for the old shape and restarts the warmup.
+        bool needRebuild = stable is null || stable.Length != inputs.Length;
+        if (!needRebuild)
         {
+            for (int i = 0; i < inputs.Length; i++)
+                if (!ShapeMatches(inputs[i], stable![i])) { needRebuild = true; break; }
+        }
+        if (needRebuild)
+        {
+            if (_exec != System.IntPtr.Zero) { _engine.DestroyGpuGraph(_exec); _exec = System.IntPtr.Zero; }
+            _scope?.Dispose();
+            _scope = null;
             stable = new Tensor<T>[inputs.Length];
             for (int i = 0; i < inputs.Length; i++)
                 stable[i] = new Tensor<T>(inputs[i].Shape._dims);
             _stableInputs = stable;
+            _warmup = 0;
         }
-        else if (stable.Length != inputs.Length)
-        {
-            return forward(inputs); // input arity changed unexpectedly — stay eager
-        }
+        var s = stable!; // non-null from here: either pre-existing or rebuilt above
         for (int i = 0; i < inputs.Length; i++)
-        {
-            if (!ShapeMatches(inputs[i], stable[i])) return forward(inputs); // shape changed — eager
-            inputs[i].AsSpan().CopyTo(stable[i].AsWritableSpan());
-        }
+            inputs[i].AsSpan().CopyTo(s[i].AsWritableSpan());
 
         // REPLAY: refresh stable input buffers in place, one cuGraphLaunch, fresh download of the output.
         if (_exec != System.IntPtr.Zero)
         {
-            for (int i = 0; i < stable.Length; i++) _engine.RefreshResidentInputInPlace(stable[i]);
+            for (int i = 0; i < s.Length; i++) _engine.RefreshResidentInputInPlace(s[i]);
             _engine.LaunchGpuGraph(_exec);
             return DownloadOutput<T>();
         }
@@ -87,20 +106,24 @@ public sealed class ResidentInferenceGraph : System.IDisposable
         // WARMUP: a few eager forwards on the stable inputs so lazy allocs / autotune settle.
         _warmup++;
         if (_warmup < _warmupRuns)
-            return forward(stable);
+            return forward(s);
 
         // CAPTURE: enter the resident capture path (kept alive for the graph's lifetime), do a
         // pre-residency pass so every op binds its stable resident buffer, then record the forward.
         try
         {
             _scope = _engine.EnterResidentCaptureScope();
-            if (_scope is null) { _disabled = true; return forward(stable); }
+            if (_scope is null) { _disabled = true; return forward(s); }
 
-            _ = forward(stable); // pre-residency: bind resident buffers (sync uploads here are fine — not capturing)
-            for (int i = 0; i < stable.Length; i++) _engine.RefreshResidentInputInPlace(stable[i]);
+            // Bind each external stable input to a fixed resident buffer so the captured forward reads a
+            // stable device address (no re-upload mid-capture). The forward's own intermediates become
+            // resident under the capture path.
+            for (int i = 0; i < s.Length; i++) _engine.EnsureResidentInput(s[i]);
+            _ = forward(s); // pre-residency: bind resident buffers (sync uploads here are fine — not capturing)
+            for (int i = 0; i < s.Length; i++) _engine.RefreshResidentInputInPlace(s[i]);
 
             Tensor<T>? captured = null;
-            var exec = _engine.CaptureGpuGraph(() => { captured = forward(stable); });
+            var exec = _engine.CaptureGpuGraph(() => { captured = forward(s); });
             if (exec != System.IntPtr.Zero && captured is not null)
             {
                 _exec = exec;
@@ -114,7 +137,7 @@ public sealed class ResidentInferenceGraph : System.IDisposable
             _scope.Dispose();
             _scope = null;
             _disabled = true;
-            return forward(stable);
+            return forward(s);
         }
         catch (System.Exception ex)
         {

--- a/src/AiDotNet.Tensors/Engines/Gpu/ResidentInferenceGraph.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/ResidentInferenceGraph.cs
@@ -103,14 +103,22 @@ public sealed class ResidentInferenceGraph : System.IDisposable
         if (_exec != System.IntPtr.Zero)
         {
             bool timing = System.Environment.GetEnvironmentVariable("AIDOTNET_INFGRAPH_TIMING") == "1";
+            bool breakdown = timing && System.Environment.GetEnvironmentVariable("AIDOTNET_INFGRAPH_TIMING_BREAKDOWN") == "1";
+            double freq = System.Diagnostics.Stopwatch.Frequency / 1_000_000.0;
             long t0 = timing ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
             for (int i = 0; i < s.Length; i++) _engine.RefreshResidentInputInPlace(s[i]);
+            long tRefresh = breakdown ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
             _engine.LaunchGpuGraph(_exec);
+            if (breakdown) _engine.SynchronizeStream(); // block so the next stamp isolates GPU-compute time
+            long tCompute = breakdown ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
             var outR = DownloadOutput<T>();
             if (timing)
             {
-                double us = (System.Diagnostics.Stopwatch.GetTimestamp() - t0) * 1_000_000.0 / System.Diagnostics.Stopwatch.Frequency;
-                try { System.IO.File.AppendAllText(System.IO.Path.Combine(System.IO.Path.GetTempPath(), "aidotnet_infgraph_timing.txt"), $"REPLAY {us:F1} us\n"); } catch { }
+                double us = (System.Diagnostics.Stopwatch.GetTimestamp() - t0) / freq;
+                string line = breakdown
+                    ? $"REPLAY {us:F1} us  [refresh(HtoD)={(tRefresh - t0) / freq:F1} compute={(tCompute - tRefresh) / freq:F1} download(DtoH)={(System.Diagnostics.Stopwatch.GetTimestamp() - tCompute) / freq:F1}]\n"
+                    : $"REPLAY {us:F1} us\n";
+                try { System.IO.File.AppendAllText(System.IO.Path.Combine(System.IO.Path.GetTempPath(), "aidotnet_infgraph_timing.txt"), line); } catch { }
             }
             if (System.Environment.GetEnvironmentVariable("AIDOTNET_REPLAY_VERIFY") == "1")
             {

--- a/src/AiDotNet.Tensors/Engines/Gpu/ResidentInferenceGraph.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/ResidentInferenceGraph.cs
@@ -122,6 +122,17 @@ public sealed class ResidentInferenceGraph : System.IDisposable
             _ = forward(s); // pre-residency: bind resident buffers (sync uploads here are fine — not capturing)
             for (int i = 0; i < s.Length; i++) _engine.RefreshResidentInputInPlace(s[i]);
 
+            // RESIDENCY AUDIT (AIDOTNET_RESIDENT_AUDIT=1): run one more resident pass with the audit log
+            // cleared first, so only GENUINELY non-resident ops (sync HtoD/DtoH every pass — not one-time
+            // cache fills) are recorded. Lists the whole residency work-list in ONE run; then bail (no capture).
+            if (System.Environment.GetEnvironmentVariable("AIDOTNET_RESIDENT_AUDIT") == "1")
+            {
+                try { System.IO.File.Delete(System.IO.Path.Combine(System.IO.Path.GetTempPath(), "aidotnet_resident_audit.txt")); } catch { }
+                var auditOut = forward(s);
+                _scope.Dispose(); _scope = null; _disabled = true;
+                return auditOut;
+            }
+
             Tensor<T>? captured = null;
             var exec = _engine.CaptureGpuGraph(() => { captured = forward(s); });
             if (exec != System.IntPtr.Zero && captured is not null)

--- a/src/AiDotNet.Tensors/Engines/Gpu/ResidentInferenceGraph.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/ResidentInferenceGraph.cs
@@ -1,0 +1,158 @@
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines.Gpu;
+
+/// <summary>
+/// #1650 — captures a model's EAGER GPU forward into a CUDA graph and replays it per call, the
+/// inference analog of the #638 training-step capture. Drives the resident capture path on
+/// <see cref="DirectGpuTensorEngine"/> so the forward runs host-round-trip-free (capturable), then
+/// collapses its hundreds of per-kernel launches into one <c>cuGraphLaunch</c> — the TensorRT-LLM /
+/// vLLM decode-graph lever, which dominates latency at the low batch a diffusion denoising step runs.
+/// <para>
+/// The caller supplies, per step, the FRESH input tensors and a forward closure. This class keeps
+/// STABLE copies of the inputs (fixed device addresses), copies the fresh data in, runs a short eager
+/// warmup, captures the forward once, and thereafter replays — refreshing the stable input buffers in
+/// place and forcing a fresh download of the (stable) output. If the forward isn't yet capture-pure
+/// (some op still does a host round-trip), capture fails and it transparently falls back to eager, so
+/// correctness is never affected. The forward MUST be run on the tensors this class passes it (the
+/// stable copies), never the originals.
+/// </para>
+/// </summary>
+public sealed class ResidentInferenceGraph : System.IDisposable
+{
+    private readonly DirectGpuTensorEngine _engine;
+    private readonly int _warmupRuns;
+    private System.IntPtr _exec;
+    private object? _stableInputs;   // Tensor<T>[]
+    private object? _output;         // Tensor<T> captured output (its resident buffer is what the graph writes)
+    private int[]? _outShape;
+    private int _warmup;
+    private bool _disabled;
+    private System.IDisposable? _scope;
+
+    /// <param name="engine">The CUDA-backed engine to capture on.</param>
+    /// <param name="warmupRuns">Eager forwards before capture (lazy allocs / autotune settle). Default 2.</param>
+    public ResidentInferenceGraph(DirectGpuTensorEngine engine, int warmupRuns = 2)
+    {
+        _engine = engine ?? throw new System.ArgumentNullException(nameof(engine));
+        _warmupRuns = warmupRuns < 1 ? 1 : warmupRuns;
+    }
+
+    /// <summary>True once the forward has been captured into a replayable graph.</summary>
+    public bool HasGraph => _exec != System.IntPtr.Zero;
+
+    /// <summary>True once capture was abandoned (a non-capturable op) — the forward runs eager from here.</summary>
+    public bool Disabled => _disabled;
+
+    /// <summary>
+    /// Runs the forward for this step. Returns the forward's output. On the capture path, <paramref name="forward"/>
+    /// is invoked with this class's STABLE input copies (run the model on those, not the originals); on a replay
+    /// it is not invoked at all (the graph runs) and the captured output is downloaded fresh.
+    /// </summary>
+    public Tensor<T> Forward<T>(Tensor<T>[] inputs, System.Func<Tensor<T>[], Tensor<T>> forward)
+    {
+        if (inputs is null) throw new System.ArgumentNullException(nameof(inputs));
+        if (forward is null) throw new System.ArgumentNullException(nameof(forward));
+
+        if (_disabled || typeof(T) != typeof(float) || !_engine.SupportsInferenceGraphCapture)
+            return forward(inputs); // eager passthrough (no capture possible / already abandoned)
+
+        // Stable input copies — fixed device addresses the captured graph reads from.
+        var stable = (Tensor<T>[]?)_stableInputs;
+        if (stable is null)
+        {
+            stable = new Tensor<T>[inputs.Length];
+            for (int i = 0; i < inputs.Length; i++)
+                stable[i] = new Tensor<T>(inputs[i].Shape._dims);
+            _stableInputs = stable;
+        }
+        else if (stable.Length != inputs.Length)
+        {
+            return forward(inputs); // input arity changed unexpectedly — stay eager
+        }
+        for (int i = 0; i < inputs.Length; i++)
+        {
+            if (!ShapeMatches(inputs[i], stable[i])) return forward(inputs); // shape changed — eager
+            inputs[i].AsSpan().CopyTo(stable[i].AsWritableSpan());
+        }
+
+        // REPLAY: refresh stable input buffers in place, one cuGraphLaunch, fresh download of the output.
+        if (_exec != System.IntPtr.Zero)
+        {
+            for (int i = 0; i < stable.Length; i++) _engine.RefreshResidentInputInPlace(stable[i]);
+            _engine.LaunchGpuGraph(_exec);
+            return DownloadOutput<T>();
+        }
+
+        // WARMUP: a few eager forwards on the stable inputs so lazy allocs / autotune settle.
+        _warmup++;
+        if (_warmup < _warmupRuns)
+            return forward(stable);
+
+        // CAPTURE: enter the resident capture path (kept alive for the graph's lifetime), do a
+        // pre-residency pass so every op binds its stable resident buffer, then record the forward.
+        try
+        {
+            _scope = _engine.EnterResidentCaptureScope();
+            if (_scope is null) { _disabled = true; return forward(stable); }
+
+            _ = forward(stable); // pre-residency: bind resident buffers (sync uploads here are fine — not capturing)
+            for (int i = 0; i < stable.Length; i++) _engine.RefreshResidentInputInPlace(stable[i]);
+
+            Tensor<T>? captured = null;
+            var exec = _engine.CaptureGpuGraph(() => { captured = forward(stable); });
+            if (exec != System.IntPtr.Zero && captured is not null)
+            {
+                _exec = exec;
+                _output = captured;
+                _outShape = captured.Shape._dims;
+                _engine.LaunchGpuGraph(exec); // capture records but does not execute — run once for this call
+                return DownloadOutput<T>();
+            }
+
+            // A non-capturable op remains → abandon capture, resume eviction, run eager from here.
+            _scope.Dispose();
+            _scope = null;
+            _disabled = true;
+            return forward(stable);
+        }
+        catch (System.Exception ex)
+        {
+            if (System.Environment.GetEnvironmentVariable("AIDOTNET_GRAPH_CAPTURE_DEBUG") == "1")
+            {
+                try { System.IO.File.AppendAllText(
+                    System.IO.Path.Combine(System.IO.Path.GetTempPath(), "aidotnet_graphcapture_diag.txt"),
+                    $"[RESIDENT-INF-GRAPH] capture threw: {ex.GetType().Name}: {ex.Message} | {ex.StackTrace?.Replace("\r", "").Replace("\n", " >> ")}\n"); } catch { }
+            }
+            _scope?.Dispose();
+            _scope = null;
+            _disabled = true;
+            return forward(inputs);
+        }
+    }
+
+    private Tensor<T> DownloadOutput<T>()
+    {
+        var outT = (Tensor<T>)_output!;
+        var data = _engine.DownloadResidentBuffer(outT);
+        if (data is not null && _outShape is not null)
+            return new Tensor<T>(_outShape, new Vector<T>((T[])(object)data));
+        return outT; // fallback: the tensor's own (possibly stale) data
+    }
+
+    private static bool ShapeMatches<T>(Tensor<T> a, Tensor<T> b)
+    {
+        var ad = a.Shape._dims; var bd = b.Shape._dims;
+        if (ad.Length != bd.Length) return false;
+        for (int i = 0; i < ad.Length; i++) if (ad[i] != bd[i]) return false;
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (_exec != System.IntPtr.Zero) { _engine.DestroyGpuGraph(_exec); _exec = System.IntPtr.Zero; }
+        _scope?.Dispose();
+        _scope = null;
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/Gpu/ResidentInferenceGraph.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/ResidentInferenceGraph.cs
@@ -35,6 +35,10 @@ public sealed class ResidentInferenceGraph : System.IDisposable
     public ResidentInferenceGraph(DirectGpuTensorEngine engine, int warmupRuns = 2)
     {
         _engine = engine ?? throw new System.ArgumentNullException(nameof(engine));
+        // Benchmarking knob: AIDOTNET_INFGRAPH_WARMUP overrides the eager-warmup count so a timing run can
+        // collect many eager-forward samples before capture (see AIDOTNET_INFGRAPH_TIMING).
+        var wenv = System.Environment.GetEnvironmentVariable("AIDOTNET_INFGRAPH_WARMUP");
+        if (wenv is not null && int.TryParse(wenv, out var w) && w >= 1) warmupRuns = w;
         _warmupRuns = warmupRuns < 1 ? 1 : warmupRuns;
     }
 
@@ -98,15 +102,44 @@ public sealed class ResidentInferenceGraph : System.IDisposable
         // REPLAY: refresh stable input buffers in place, one cuGraphLaunch, fresh download of the output.
         if (_exec != System.IntPtr.Zero)
         {
+            bool timing = System.Environment.GetEnvironmentVariable("AIDOTNET_INFGRAPH_TIMING") == "1";
+            long t0 = timing ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
             for (int i = 0; i < s.Length; i++) _engine.RefreshResidentInputInPlace(s[i]);
             _engine.LaunchGpuGraph(_exec);
-            return DownloadOutput<T>();
+            var outR = DownloadOutput<T>();
+            if (timing)
+            {
+                double us = (System.Diagnostics.Stopwatch.GetTimestamp() - t0) * 1_000_000.0 / System.Diagnostics.Stopwatch.Frequency;
+                try { System.IO.File.AppendAllText(System.IO.Path.Combine(System.IO.Path.GetTempPath(), "aidotnet_infgraph_timing.txt"), $"REPLAY {us:F1} us\n"); } catch { }
+            }
+            if (System.Environment.GetEnvironmentVariable("AIDOTNET_REPLAY_VERIFY") == "1")
+            {
+                double inSum = 0; var isp = s[0].AsSpan();
+                for (int i = 0; i < isp.Length; i++) inSum += System.Convert.ToDouble(isp[i]);
+                double tSum = 0; if (s.Length > 1) { var tsp = s[1].AsSpan(); for (int i = 0; i < tsp.Length; i++) tSum += System.Convert.ToDouble(tsp[i]); }
+                double outSum = 0; var osp = outR.AsSpan();
+                for (int i = 0; i < osp.Length; i++) outSum += System.Convert.ToDouble(osp[i]);
+                try { System.IO.File.AppendAllText(System.IO.Path.Combine(System.IO.Path.GetTempPath(), "aidotnet_replay_verify.txt"),
+                    $"REPLAY inSum(s0)={inSum:F4} timeSum(s1)={tSum:F4} -> outSum={outSum:F4}\n"); } catch { }
+            }
+            return outR;
         }
 
         // WARMUP: a few eager forwards on the stable inputs so lazy allocs / autotune settle.
         _warmup++;
         if (_warmup < _warmupRuns)
+        {
+            if (System.Environment.GetEnvironmentVariable("AIDOTNET_INFGRAPH_TIMING") == "1")
+            {
+                long t0 = System.Diagnostics.Stopwatch.GetTimestamp();
+                var w = forward(s);
+                _ = w.AsSpan(); // force materialization so timing includes the eager download
+                double us = (System.Diagnostics.Stopwatch.GetTimestamp() - t0) * 1_000_000.0 / System.Diagnostics.Stopwatch.Frequency;
+                try { System.IO.File.AppendAllText(System.IO.Path.Combine(System.IO.Path.GetTempPath(), "aidotnet_infgraph_timing.txt"), $"EAGER {us:F1} us\n"); } catch { }
+                return w;
+            }
             return forward(s);
+        }
 
         // CAPTURE: enter the resident capture path (kept alive for the graph's lifetime), do a
         // pre-residency pass so every op binds its stable resident buffer, then record the forward.
@@ -131,6 +164,9 @@ public sealed class ResidentInferenceGraph : System.IDisposable
             // resident under the capture path.
             for (int i = 0; i < s.Length; i++) _engine.EnsureResidentInput(s[i]);
             var preResOut = forward(s); // pre-residency: bind resident buffers (sync uploads here are fine — not capturing)
+            // Allocate the STABLE output buffer (sync, pre-capture) the captured graph's final op will copy into,
+            // so the externally-read output address survives AUTO_FREE relaunch (else replays read stale output).
+            _engine.PrepareStableCaptureOutput(preResOut);
             if (verify && verifyRef is not null)
             {
                 var got = preResOut.AsSpan();
@@ -153,14 +189,59 @@ public sealed class ResidentInferenceGraph : System.IDisposable
             }
 
             Tensor<T>? captured = null;
-            var exec = _engine.CaptureGpuGraph(() => { captured = forward(s); });
+            // Capture the forward AND a final copy of its output into the stable buffer — both become graph nodes,
+            // so replay recomputes into the stable address and DownloadOutput reads fresh data every launch.
+            var exec = _engine.CaptureGpuGraph(() => { var o = forward(s); captured = _engine.WriteOutputToStableCapture(o); });
             if (exec != System.IntPtr.Zero && captured is not null)
             {
                 _exec = exec;
                 _output = captured;
                 _outShape = captured.Shape._dims;
                 _engine.LaunchGpuGraph(exec); // capture records but does not execute — run once for this call
-                return DownloadOutput<T>();
+                var out1 = DownloadOutput<T>();
+
+                // REPLAY DETERMINISM (AIDOTNET_REPLAY_VERIFY=1): relaunch the SAME graph on the SAME (unrefreshed)
+                // input buffers and compare. Identical ⇒ replay is bit-stable (any later run-vs-run divergence is
+                // from input refresh, not the graph). Nonzero ⇒ the graph replay itself corrupts (AUTO_FREE
+                // realloc moving a buffer's VA, or a captured pointer into a non-graph-managed buffer).
+                if (System.Environment.GetEnvironmentVariable("AIDOTNET_REPLAY_VERIFY") == "1")
+                {
+                    _engine.LaunchGpuGraph(exec);
+                    var out2 = DownloadOutput<T>();
+                    var a = out1.AsSpan(); var b = out2.AsSpan();
+                    double maxd = 0, a0 = 0, b0 = 0; int n = System.Math.Min(a.Length, b.Length);
+                    for (int i = 0; i < n; i++)
+                    {
+                        double ai = System.Convert.ToDouble(a[i]), bi = System.Convert.ToDouble(b[i]);
+                        if (i == 0) { a0 = ai; b0 = bi; }
+                        maxd = System.Math.Max(maxd, System.Math.Abs(ai - bi));
+                    }
+                    // Does the graph actually CONSUME a refreshed input? Mutate s[0], refresh, relaunch.
+                    // If the output is unchanged, RefreshResidentInputInPlace isn't reaching the buffer the
+                    // graph's first op reads (the run-vs-run divergence then comes entirely from this).
+                    var orig = s[0].AsSpan().ToArray();
+                    var w = s[0].AsWritableSpan();
+                    var zeroT = (T)(object)0f; // typeof(T)==float guaranteed above
+                    for (int i = 0; i < w.Length; i++) w[i] = zeroT;
+                    _engine.RefreshResidentInputInPlace(s[0]);
+                    _engine.LaunchGpuGraph(exec);
+                    var out3 = DownloadOutput<T>();
+                    var c = out3.AsSpan();
+                    double mutd = 0, c0 = 0; int n3 = System.Math.Min(a.Length, c.Length);
+                    for (int i = 0; i < n3; i++)
+                    {
+                        double ci = System.Convert.ToDouble(c[i]);
+                        if (i == 0) c0 = ci;
+                        mutd = System.Math.Max(mutd, System.Math.Abs(System.Convert.ToDouble(a[i]) - ci));
+                    }
+                    orig.AsSpan().CopyTo(s[0].AsWritableSpan()); // restore
+                    _engine.RefreshResidentInputInPlace(s[0]);
+                    _engine.LaunchGpuGraph(exec);
+                    out1 = DownloadOutput<T>();
+                    try { System.IO.File.AppendAllText(System.IO.Path.Combine(System.IO.Path.GetTempPath(), "aidotnet_replay_verify.txt"),
+                        $"relaunch-same-input maxAbsDiff={maxd:E4} n={a.Length} launch1[0]={a0:F4} launch2[0]={b0:F4} | zeroed-input maxAbsDiffVsOrig={mutd:E4} zeroOut[0]={c0:F4} (≈0 ⇒ refresh INEFFECTIVE)\n"); } catch { }
+                }
+                return out1;
             }
 
             // A non-capturable op remains → abandon capture, resume eviction, run eager from here.
@@ -183,6 +264,7 @@ public sealed class ResidentInferenceGraph : System.IDisposable
             return forward(inputs);
         }
     }
+
 
     private Tensor<T> DownloadOutput<T>()
     {

--- a/tests/AiDotNet.Tensors.Tests/Engines/Gpu/Conv2dDirectFp16HwTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Gpu/Conv2dDirectFp16HwTests.cs
@@ -1,0 +1,103 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.DirectGpu.CUDA;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Gpu;
+
+/// <summary>
+/// #1650/#638 (#671) — validates the DIRECT FP16 convolution (<see cref="CudaBackend.Conv2dDirectFp16Hw"/>) on real
+/// hardware. This kernel handles the tiny-spatial deep convs the im2col + Tensor-Core GEMM path deliberately skips
+/// (small N, where im2col + launch overhead exceeds the GEMM win). It rounds the FP32 input to FP16 per access,
+/// multiplies by FP16 weights, and accumulates in FP32 — exactly the GemmFp16In32fOut numerics. This proves the
+/// result matches an FP16-rounded CPU reference within FP16 tolerance, so the path is correct (CUDA-first; parity
+/// for the other backends is a tracked follow-up). Skips on a box without a CUDA toolkit (the kernel needs
+/// cuda_fp16.h, gated by <see cref="CudaBackend.Fp16DirectConvAvailable"/>).
+/// </summary>
+public class Conv2dDirectFp16HwTests
+{
+    [SkippableFact]
+    public void Conv2dDirectFp16_matches_fp32_reference_within_fp16_tolerance()
+    {
+        Skip.IfNot(CudaNativeBindings.IsAvailable, "CUDA driver not available");
+        var eng = AiDotNetEngine.Current;
+        Skip.IfNot(eng is DirectGpuTensorEngine, "active engine is not the CUDA backend");
+        // Warm up so the engine compiles its kernel modules (incl. the FP16 module that owns conv2d_direct_fp16hw).
+        var warm = new Tensor<float>(new float[] { 1, 2, 3, 4 }, new[] { 2, 2 });
+        _ = eng.TensorMatMul(warm, warm);
+        var b = ((DirectGpuTensorEngine)eng).TestBackend as CudaBackend;
+        Skip.IfNot(b is not null && b.IsAvailable, "CudaBackend not available");
+        Skip.IfNot(b!.Fp16DirectConvAvailable, "conv2d_direct_fp16hw not compiled (needs the CUDA toolkit / cuda_fp16.h)");
+
+        // A tiny-spatial deep conv: N = b*outH*outW = 64 (the documented tiny boundary), K = inC*kh*kw = 576,
+        // M = outC = 32 — exactly the shape the im2col+GEMM path skips and the direct kernel is wired for.
+        const int batch = 1, inC = 64, H = 8, W = 8, outC = 32, kh = 3, kw = 3;
+        const int strideH = 1, strideW = 1, padH = 1, padW = 1, dilH = 1, dilW = 1;
+        int outH = (H + 2 * padH - ((kh - 1) * dilH + 1)) / strideH + 1; // 8
+        int outW = (W + 2 * padW - ((kw - 1) * dilW + 1)) / strideW + 1; // 8
+
+        var rng = new Random(1650);
+        var input = new float[batch * inC * H * W];
+        var weights = new float[outC * inC * kh * kw];
+        for (int i = 0; i < input.Length; i++) input[i] = (float)(rng.NextDouble() * 2 - 1);   // [-1,1] — safe FP16 range
+        for (int i = 0; i < weights.Length; i++) weights[i] = (float)(rng.NextDouble() * 2 - 1);
+
+        // FP16-rounded CPU reference (input + weights rounded to half, FP32 multiply-accumulate) — mirrors the
+        // kernel exactly, so the only residual difference is FP32 accumulation order.
+        static float ToHalfF(float x) => (float)(Half)x;
+        var cpu = new float[batch * outC * outH * outW];
+        for (int bb = 0; bb < batch; bb++)
+            for (int oc = 0; oc < outC; oc++)
+                for (int oh = 0; oh < outH; oh++)
+                    for (int ow = 0; ow < outW; ow++)
+                    {
+                        double acc = 0;
+                        for (int ic = 0; ic < inC; ic++)
+                            for (int r = 0; r < kh; r++)
+                            {
+                                int ih = oh * strideH - padH + r * dilH;
+                                if (ih < 0 || ih >= H) continue;
+                                for (int s = 0; s < kw; s++)
+                                {
+                                    int iw = ow * strideW - padW + s * dilW;
+                                    if (iw < 0 || iw >= W) continue;
+                                    float inV = ToHalfF(input[((bb * inC + ic) * H + ih) * W + iw]);
+                                    float wV = ToHalfF(weights[((oc * inC + ic) * kh + r) * kw + s]);
+                                    acc += (double)inV * wV;
+                                }
+                            }
+                        cpu[((bb * outC + oc) * outH + oh) * outW + ow] = (float)acc;
+                    }
+
+        using var dInput = b.AllocateBuffer(input);
+        using var dWeightsF32 = b.AllocateBuffer(weights);
+        using var hWeights = b.AllocateByteBuffer(weights.Length * 2); // FP16 weights
+        b.ConvertToFp16Native(dWeightsF32, hWeights, weights.Length);
+        Assert.Equal((long)weights.Length * 2, hWeights.SizeInBytes);  // genuinely half
+
+        using var dOut = b.AllocateBuffer(cpu.Length); // FP32 accumulate output
+        try
+        {
+            b.Conv2dDirectFp16Hw(dInput, hWeights, dOut,
+                batch, inC, H, W, outC, outH, outW, kh, kw, strideH, strideW, padH, padW, dilH, dilW);
+        }
+        catch (NotSupportedException ex)
+        {
+            Skip.If(true, $"direct FP16 conv not supported on this device: {ex.Message}");
+            return;
+        }
+        var got = b.DownloadBuffer(dOut);
+
+        double num = 0, den = 0;
+        for (int i = 0; i < cpu.Length; i++)
+        {
+            Assert.False(float.IsNaN(got[i]) || float.IsInfinity(got[i]), $"non-finite output at {i}: {got[i]}");
+            double d = got[i] - cpu[i];
+            num += d * d;
+            den += (double)cpu[i] * cpu[i];
+        }
+        double relL2 = den > 0 ? Math.Sqrt(num / den) : Math.Sqrt(num);
+        Assert.True(relL2 < 0.02, $"direct FP16 conv relL2 {relL2:F5} exceeds FP16 tolerance vs the FP16-rounded CPU reference");
+    }
+}


### PR DESCRIPTION
## #1650 / #638 — Diffusion U-Net forward as one replayable CUDA graph (the speedup)

Makes the **entire eager `ForwardUNet`** of the diffusion U-Net run fully GPU-resident (no host round-trips), so `cuStreamBeginCapture` records it as **one CUDA graph** that replays via `cuGraphLaunch`. This is the stream-capture speedup follow-up to the #642 correctness work.

### Verified on an RTX 3080 — DDPM `Generate([1,3,32,32])`
- `capture + instantiate SUCCEEDED`; **zero** sync HtoD/DtoH during capture.
- resident-vs-CPU **bit-exact** (`AIDOTNET_RESIDENT_VERIFY` → maxAbsDiff = 0).
- `cuGraphLaunch` **replay == eager, BIT-EXACT** (identical output checksum in capture vs eager mode — a stronger check than the pre-residency verify).
- **~3.2× faster** end-to-end: 32-step Generate ≈ **31 ms/step** (replay, rock-steady) vs ≈ **99 ms/step** (eager) — reconciled-stack run; an earlier run measured 27 vs 89 ms/step. Speedup is consistently ~3.2×.
- 57 / 57 diffusion tests green (no regression).

### Residency ops (all gated `ResidentStepActive`, each verified vs the CPU engine)
- `FusedLinear` resident for **all** activations incl. Swish/SiLU (the ResBlock time-MLP — first in-capture blocker).
- `FlashAttention` resident output (kernel into resident out + softmax-stats buffers, `BindResidentBuffer`, no `DownloadBuffer`).
- In-place add operands resolved via cache with no upload (`+time` / `+residual`).
- strided `Copy` `cuMemcpyDtoD` → `cuMemcpyDtoDAsync(_stream)` (was non-capturable, 906) + resident channel-concat.
- `ConvTranspose2D` resident + Deconv conv-bias `BindResidentBuffer` (decoder upsample — the final blocker; `FinishGpuOp`'s deferred materializer raced eviction under capture).
- `TryConcatenateChannelsResidentInto` — device-to-device skip-concat into the pooled buffer.

### Tooling
`AIDOTNET_GRAPH_CAPTURE_DEBUG=1` now logs the **first sync HtoD/DtoH that runs while the stream is actually capturing** (pollution-free, unlike the audit which also records the post-disable eager passes) — pinpoints the exact capture-aborting op each cycle.

### Companion / merge order
Model-side wiring is in **ooples/AiDotNet#1650** (`feature/642-diffusion-deferred-gpu`): `UNetNoisePredictor.PredictNoise` runs inference in eval mode (convs take the resident fast path) and routes `ForwardUNet` through `ResidentInferenceGraph` under `AIDOTNET_DIFFUSION_CUDA_GRAPH=1` (eager fallback otherwise). Order: **merge + publish this PR first**, then bump `Directory.Packages.props` in AiDotNet and the model PR goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CUDA-graph resident inference capture/replay for eligible float workloads (via `AIDOTNET_INFERENCE_CUDA_GRAPH=1`) with `ResidentInferenceGraph` and resident input/output handling.
  * Added `ExecuteEagerlyWhileRecording` option for trace-by-execution workflows.
  * Introduced FP16 fused im2col support (`im2col_kn_fp16hw`) across CUDA/HIP/Metal/OpenCL/Vulkan/WebGPU backends (when available).
* **Bug Fixes**
  * Prevented double-execution when recording in trace-by-execution mode.
* **Performance Improvements**
  * Improved CUDA-graph capturability for device-to-device copies and refined capture eligibility/fallbacks.
* **Documentation**
  * Updated behavior notes for recording/execution options and capture diagnostics env flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->