### PR TITLE
fix(blas): route small/unaligned fp32 GEMM to Streaming, not the broken mr=4 PackBoth fallback

### DIFF
--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
@@ -697,16 +697,18 @@ public static partial class BlasManaged
             return;
         }
 
-        // Shapes too small for the SIMD tile entirely: fall back to scalar 4×4.
-        if (m < mr || n < nr || m % mr != 0)
-        {
-            mr = 4; nr = 4;
-        }
-
-        // If still misaligned after the scalar fallback (m < 4 or n < 4 or m%4 != 0):
-        // route to Streaming. This is the D.1 correctness fix for genuinely tiny
-        // misaligned shapes; the Sub-D4 split above handles m >= mr cases.
-        if (m % mr != 0 || n % nr != 0)
+        // Shapes too small for, or unaligned to, the CHOSEN SIMD tile (mr, nr) route to Streaming,
+        // which correctly handles arbitrary tiny / unaligned shapes. The previous "reset to mr=nr=4
+        // then run PackBoth" fallback was UNSAFE for fp32: PackBoth's fp32 pack + 6×16 microkernel
+        // assume the mr=6/nr=16 tile, so an mr=4 fallback (e.g. m=4 — the 1×1 stride-2 conv whose
+        // im2col SGEMM is m=4, k=512, n=1024, which every ResNet/diffusion CNN forward hits) packed
+        // and indexed with a mismatched tile and overran ArrayPool<float>.Shared, corrupting the pool
+        // and crashing the test host with an AccessViolation on a later Rent. The Sub-D4 tail-split
+        // above already covers m >= mr && n >= nr unaligned shapes (aligned interior recurses to
+        // PackBoth; the m/n tails use Streaming); this catches the genuinely-small (m < mr or n < nr)
+        // and any residual unaligned shape. Note: m % mr / n % nr here use the ORIGINAL chosen tile,
+        // not a reset 4×4 — the reset was exactly what let m=4 slip past into the broken PackBoth path.
+        if (m < mr || n < nr || m % mr != 0 || n % nr != 0)
         {
             StreamingStrategy.Run<T>(
                 a, lda, transA,

--- a/tests/AiDotNet.Tensors.Tests/Engines/Conv2DIm2colArrayPoolReproTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Conv2DIm2colArrayPoolReproTests.cs
@@ -32,8 +32,24 @@ public sealed class Conv2DIm2colArrayPoolReproTests
         var kernel = Rand(new[] { outC, inC, k, k }, seed + 1);
         var output = new Tensor<float>(new[] { 1, outC, oHW, oHW });
         eng.Conv2DInto(output, input, kernel, stride, 0, 1);
-        float v = output[0, 0, 0, 0];
-        Assert.False(float.IsNaN(v) || float.IsInfinity(v));
+
+        // Validate the WHOLE output buffer, not just element 0: every value must be
+        // finite (pool corruption / a mismatched-tile overrun shows up as NaN/Inf
+        // partway through the buffer), and the conv of random non-zero input*kernel
+        // must produce a non-zero result (an all-zero buffer means the GEMM was
+        // silently skipped / wrote nothing — a no-op regression the single-element
+        // check would miss).
+        var span = output.AsWritableSpan();
+        bool anyNonZero = false;
+        for (int i = 0; i < span.Length; i++)
+        {
+            float v = span[i];
+            Assert.False(float.IsNaN(v) || float.IsInfinity(v),
+                $"non-finite output at index {i} (inC={inC} hw={hw} outC={outC} k={k} s={stride})");
+            if (v != 0f) anyNonZero = true;
+        }
+        Assert.True(anyNonZero,
+            $"conv produced an all-zero output buffer (inC={inC} hw={hw} outC={outC} k={k} s={stride})");
     }
 
     [Fact]
@@ -46,11 +62,34 @@ public sealed class Conv2DIm2colArrayPoolReproTests
         var b = new float[K * N];
         for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() - 0.5);
         for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() - 0.5);
+
+        // Naive row-major reference (a,b are fixed across iterations). Asserting against
+        // this validates not just "no NaN/crash" but that the shape that used to slip into
+        // the broken mr=4 PackBoth fallback now produces the CORRECT product through the
+        // Streaming reroute — over the ENTIRE C buffer, not element 0 alone.
+        var expected = new float[M * N];
+        for (int i = 0; i < M; i++)
+            for (int j = 0; j < N; j++)
+            {
+                double acc = 0;
+                for (int p = 0; p < K; p++) acc += (double)a[i * K + p] * b[p * N + j];
+                expected[i * N + j] = (float)acc;
+            }
+
         for (int it = 0; it < 300; it++)
         {
             var c = new float[M * N];
             AiDotNet.Tensors.Engines.Simd.SimdGemm.Sgemm(a, b, c, M, K, N); // 6-arg overload (the one Conv2DIm2colGemm uses)
-            Assert.False(float.IsNaN(c[0]) || float.IsInfinity(c[0]));
+            for (int idx = 0; idx < c.Length; idx++)
+            {
+                float v = c[idx];
+                Assert.False(float.IsNaN(v) || float.IsInfinity(v), $"non-finite C[{idx}] on iteration {it}");
+                // K=512 fp32 accumulation differs from the naive order by a few ULPs scaled
+                // by the magnitude (~5-6 here); 1e-2 absolute is comfortably above that and
+                // well below any corruption-sized error.
+                Assert.True(Math.Abs(v - expected[idx]) < 1e-2f,
+                    $"C[{idx}]={v} != expected {expected[idx]} on iteration {it}");
+            }
             // Force ArrayPool traffic between GEMMs so corruption surfaces as an AV on Rent.
             var scratch = System.Buffers.ArrayPool<float>.Shared.Rent(4096);
             System.Buffers.ArrayPool<float>.Shared.Return(scratch);

--- a/tests/AiDotNet.Tensors.Tests/Engines/Conv2DIm2colArrayPoolReproTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Conv2DIm2colArrayPoolReproTests.cs
@@ -1,0 +1,79 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Repro for the native ArrayPool&lt;float&gt;.Shared corruption that crashes the test host in the
+/// float Conv2DIm2colGemm small-N transposed SGEMM path (the AccessViolation seen across every
+/// CNN/diffusion CI shard). Uses the exact small-N shapes ResNet50 (32x32) hits right before the
+/// crash: small N (=4/16 output patches), large outC, via Conv2DInto (the route ConvolutionalLayer
+/// uses). Deterministic.
+/// </summary>
+public sealed class Conv2DIm2colArrayPoolReproTests
+{
+    private static Tensor<float> Rand(int[] shape, int seed)
+    {
+        var rng = new Random(seed);
+        var t = new Tensor<float>(shape);
+        var s = t.AsWritableSpan();
+        for (int i = 0; i < s.Length; i++) s[i] = (float)(rng.NextDouble() - 0.5);
+        return t;
+    }
+
+    // input [1,inC,H,W], kernel [outC,inC,kH,kW], stride s -> output [1,outC,oHW,oHW]; runs Conv2DInto.
+    private static void Conv(CpuEngine eng, int inC, int hw, int outC, int k, int stride, int seed)
+    {
+        int oHW = (hw - k) / stride + 1;
+        var input = Rand(new[] { 1, inC, hw, hw }, seed);
+        var kernel = Rand(new[] { outC, inC, k, k }, seed + 1);
+        var output = new Tensor<float>(new[] { 1, outC, oHW, oHW });
+        eng.Conv2DInto(output, input, kernel, stride, 0, 1);
+        float v = output[0, 0, 0, 0];
+        Assert.False(float.IsNaN(v) || float.IsInfinity(v));
+    }
+
+    [Fact]
+    public void Direct_SmallM_Sgemm_DoesNotCorruptArrayPool()
+    {
+        // Isolate the small-N conv's transposed SGEMM: M=4 (<=NParallelSmallMMaxM=8), large N.
+        const int M = 4, K = 512, N = 1024;
+        var rng = new Random(7);
+        var a = new float[M * K];
+        var b = new float[K * N];
+        for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() - 0.5);
+        for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() - 0.5);
+        for (int it = 0; it < 300; it++)
+        {
+            var c = new float[M * N];
+            AiDotNet.Tensors.Engines.Simd.SimdGemm.Sgemm(a, b, c, M, K, N); // 6-arg overload (the one Conv2DIm2colGemm uses)
+            Assert.False(float.IsNaN(c[0]) || float.IsInfinity(c[0]));
+            // Force ArrayPool traffic between GEMMs so corruption surfaces as an AV on Rent.
+            var scratch = System.Buffers.ArrayPool<float>.Shared.Rent(4096);
+            System.Buffers.ArrayPool<float>.Shared.Return(scratch);
+        }
+    }
+
+    [Fact]
+    public void SmallN_ResNetShapeConvs_DoNotCorruptArrayPool()
+    {
+        var engine = new CpuEngine();
+        // The exact small-N shapes ResNet50@32x32 runs right before the host crash:
+        //   inC=512 4x4 -> outC=1024 1x1 s2  (K=512  N=4)
+        //   inC=256 2x2 -> outC=1024 1x1     (K=256  N=4)
+        //   inC=256 4x4 -> outC=256  3x3 s2  (K=2304 N=4)
+        //   inC=128 4x4 -> outC=512  1x1     (K=128  N=16)
+        //   inC=512 4x4 -> outC=128  1x1     (K=512  N=16)
+        for (int i = 0; i < 80; i++)
+        {
+            Conv(engine, 512, 4, 1024, 1, 2, i * 7 + 1);
+            Conv(engine, 256, 2, 1024, 1, 1, i * 7 + 2);
+            Conv(engine, 256, 4, 256, 3, 2, i * 7 + 3);
+            Conv(engine, 128, 4, 512, 1, 1, i * 7 + 4);
+            Conv(engine, 512, 4, 128, 1, 1, i * 7 + 5);
+        }
+    }
+}


### PR DESCRIPTION
## The bug (CI shards going *backwards*)

Over the last few Tensors bumps, AiDotNet CI went from ~17 → ~25 failing shards even as raw GEMM/conv perf improved. The increase was **chunky** (whole shards flipping red at once), not a drift of independent test regressions — the signature of a **host-process crash**, not test failures.

Root cause: a native `System.AccessViolationException` originating in `System.Buffers.SharedArrayPoolPartitions.TryPop()` (i.e. `ArrayPool<float>.Shared.Rent`). One corrupting GEMM poisons the **shared** pool free-list, so the *next* `Rent` anywhere in the process faults and takes down the **entire test host** — aborting every remaining test in the shard. That's why CNN + diffusion + integration shards all died together.

## Where it comes from

`BlasManaged.Gemm` for `fp32` shapes too small for the chosen `6×16` SIMD tile:

```csharp
// BEFORE — buggy
if (m < mr || n < nr || m % mr != 0) { mr = 4; nr = 4; }   // reset tile
if (m % mr != 0 || n % nr != 0) { /* Streaming */ return; } // re-checked vs the NEW mr=4
```

For `m = 4`: the first line resets `mr = 4`, then `4 % 4 == 0` passes the guard, so the shape slips into `PackBothStrategy` — whose fp32 pack + 6×16 machine-code/microkernel **assume `mr=6/nr=16`**. Packing/indexing a 4-row problem against the 6×16 tile overruns the pooled scratch buffer and corrupts the pool.

The real-world trigger is a **1×1 stride-2 conv** (ResNet bottleneck downsample, e.g. `inC=512 4×4 → outC=1024`): im2col produces `SGEMM m=4, k=512, n=1024`, which the 6-arg `SimdGemm.Sgemm` forwards to `BlasManaged.Gemm{DisableAutotune}` → this path. (The 7-arg `beta` overload uses the tiered managed path and was unaffected — which is why only some callers crashed.) The bug **predates** the recent machine-code GEMM work; that work only broadened its blast radius.

## The fix

Route any shape too small for, or unaligned to, the **chosen** tile to `StreamingStrategy` (which handles arbitrary tiny/unaligned shapes correctly), using the **original** `mr/nr` for the test:

```csharp
// AFTER — fixed (no mr/nr reset)
if (m < mr || n < nr || m % mr != 0 || n % nr != 0)
{
    StreamingStrategy.Run<T>(a, lda, transA, b, ldb, transB, c, ldc, m, n, k, in options);
    var streamingEpilogue = options.Epilogue;
    EpilogueChain.Apply<T>(c, ldc, m, n, in streamingEpilogue);
    return;
}
```

The Sub-D4 tail-split above still handles `m >= mr && n >= nr` unaligned shapes (aligned interior recurses to PackBoth; tails stream), so the **only** behavior change is that genuinely-small / `mr`-unaligned fp32 shapes use the safe Streaming kernel instead of the broken `mr=4` PackBoth fallback.

## Verification (AVX2 box, GTX 1660 Ti)

- **New regression test** `Conv2DIm2colArrayPoolReproTests` (direct `SGEMM m=4` + the exact ResNet small-N conv shapes, each looping with interleaved `ArrayPool` traffic so corruption surfaces as an AV) — **passes**; reproduced the crash deterministically before the fix.
- Real `ResNetNetworkTests` — **56/56** (previously a host crash at test ~8).
- Broad GEMM/BLAS/conv sweep — **923 passed, 0 real failures** (the lone perf-budget timing test is flaky under concurrent build load and passes in isolation; it exercises `Im2ColHelper`'s smallN-transA kernel, a different path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved matrix multiplication edge-case handling so small or unaligned shapes bypass the packed-tile path and use a safer streaming route, preventing incorrect numerical output.

* **Tests**
  * Added deterministic regression tests to reproduce and guard against potential `ArrayPool` corruption during small-`N` convolution/im2col GEMM scenarios, validating outputs for finiteness and expected values across targeted shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->